### PR TITLE
feat(worktree): link worktree info to task in backlog

### DIFF
--- a/lib/room.ml
+++ b/lib/room.ml
@@ -588,6 +588,7 @@ let add_task config ~title ~priority ~description =
     priority;
     files = [];
     created_at = now_iso ();
+    worktree = None;  (* Linked when worktree is created *)
   } in
 
   let new_backlog = {

--- a/lib/room_worktree.ml
+++ b/lib/room_worktree.ml
@@ -17,8 +17,37 @@ let git_root config =
 let is_git_repo config =
   Room_git.is_git_repo ~base_path:config.base_path
 
-(** Create worktree for agent - Result version *)
-let worktree_create_r config ~agent_name ~task_id ~base_branch : string masc_result =
+(** Link worktree info to a task in backlog *)
+let link_worktree_to_task config ~task_id ~worktree_info =
+  let backlog_file = Filename.concat (tasks_dir config) "backlog.json" in
+  if not (Sys.file_exists backlog_file) then
+    Error (IoError "Backlog not found")
+  else begin
+    let content = In_channel.with_open_text backlog_file In_channel.input_all in
+    match Yojson.Safe.from_string content |> backlog_of_yojson with
+    | Error e -> Error (IoError e)
+    | Ok backlog ->
+        let found = ref false in
+        let new_tasks = List.map (fun task ->
+          if task.id = task_id then begin
+            found := true;
+            { task with worktree = Some worktree_info }
+          end else task
+        ) backlog.tasks in
+        if not !found then
+          Error (TaskNotFound task_id)
+        else begin
+          let new_backlog = { backlog with tasks = new_tasks; last_updated = now_iso () } in
+          let oc = open_out backlog_file in
+          output_string oc (Yojson.Safe.pretty_to_string (backlog_to_yojson new_backlog));
+          close_out oc;
+          Ok ()
+        end
+  end
+
+(** Create worktree for agent - Result version
+    @param link_task If true, links worktree info to the task in backlog (default: true) *)
+let worktree_create_r ?(link_task=true) config ~agent_name ~task_id ~base_branch : string masc_result =
   if not (is_initialized config) then
     Error NotInitialized
   else if not (is_git_repo config) then
@@ -33,6 +62,16 @@ let worktree_create_r config ~agent_name ~task_id ~base_branch : string masc_res
         let worktree_name = Printf.sprintf "%s-%s" agent_name task_id in
         let worktree_path = Filename.concat root (Filename.concat ".worktrees" worktree_name) in
         let branch_name = Printf.sprintf "%s/%s" agent_name task_id in
+        let repo_name = Filename.basename root in
+
+        (* Build worktree_info for task linking *)
+        let wt_info : worktree_info = {
+          branch = branch_name;
+          path = Printf.sprintf ".worktrees/%s" worktree_name;
+          git_root = root;
+          repo_name = repo_name;
+        } in
+
         let update_agent_current_task () =
           let agent_file = Filename.concat (agents_dir config) (safe_filename agent_name ^ ".json") in
           if Sys.file_exists agent_file then begin
@@ -47,6 +86,16 @@ let worktree_create_r config ~agent_name ~task_id ~base_branch : string masc_res
           end
         in
 
+        (* Link worktree to task in backlog *)
+        let maybe_link_task () =
+          if link_task then begin
+            match link_worktree_to_task config ~task_id ~worktree_info:wt_info with
+            | Ok () -> ""
+            | Error (TaskNotFound _) -> "\n  Note: Task not found in backlog, worktree not linked"
+            | Error _ -> "\n  Note: Could not link worktree to task"
+          end else ""
+        in
+
         (* Create .worktrees directory if not exists *)
         let worktrees_dir = Filename.concat root ".worktrees" in
         if not (Sys.file_exists worktrees_dir) then
@@ -55,8 +104,9 @@ let worktree_create_r config ~agent_name ~task_id ~base_branch : string masc_res
         (* Check if worktree already exists *)
         if Sys.file_exists worktree_path then begin
           update_agent_current_task ();
-          Ok (Printf.sprintf "✅ Worktree already exists:\n  Path: %s\n  Branch: %s\n\nNext: cd %s"
-              worktree_path branch_name worktree_path)
+          let link_note = maybe_link_task () in
+          Ok (Printf.sprintf "✅ Worktree already exists:\n  Path: %s\n  Branch: %s\n  Repo: %s%s\n\nNext: cd %s"
+              worktree_path branch_name repo_name link_note worktree_path)
         end else begin
           (* Fetch origin first *)
           let fetch_cmd = Printf.sprintf "cd %s && git fetch origin 2>&1" root in
@@ -80,14 +130,17 @@ let worktree_create_r config ~agent_name ~task_id ~base_branch : string masc_res
                 (* Update agent's current_worktree in state *)
                 update_agent_current_task ();
 
-                (* Log event *)
+                (* Link to task *)
+                let link_note = maybe_link_task () in
+
+                (* Log event with worktree info *)
                 let event = Printf.sprintf
-                  "{\"type\":\"worktree_create\",\"agent\":\"%s\",\"branch\":\"%s\",\"path\":\"%s\",\"ts\":\"%s\"}"
-                  agent_name branch_name worktree_path (now_iso ()) in
+                  "{\"type\":\"worktree_create\",\"agent\":\"%s\",\"branch\":\"%s\",\"path\":\"%s\",\"repo\":\"%s\",\"task_id\":\"%s\",\"ts\":\"%s\"}"
+                  agent_name branch_name worktree_path repo_name task_id (now_iso ()) in
                 log_event config event;
 
-                Ok (Printf.sprintf "✅ Worktree created:\n  Path: %s\n  Branch: %s%s\n\nNext: cd %s && work && gh pr create --draft"
-                    worktree_path branch_name note worktree_path)
+                Ok (Printf.sprintf "✅ Worktree created:\n  Path: %s\n  Branch: %s\n  Repo: %s%s%s\n\nNext: cd %s && work && gh pr create --draft"
+                    worktree_path branch_name repo_name note link_note worktree_path)
               end
               else
                 Error (IoError (Printf.sprintf "Failed to create worktree from origin/%s." resolved_base))


### PR DESCRIPTION
## Summary
- When creating a worktree via `masc_worktree_create`, worktree metadata (branch, path, git_root, repo_name) is now automatically recorded in the task's backlog entry
- This enables tracking which worktree is associated with which task across multi-repo workspaces

## Changes
- Added `worktree_info` type to `types.ml` with JSON serialization
- Added optional `worktree` field to `task` type (backwards compatible with existing backlog.json)
- Added `link_worktree_to_task` function in `room_worktree.ml`
- Modified `worktree_create_r` to auto-link worktree to task (opt-out via `?link_task` parameter)

## Test plan
- [x] Build passes with `dune build`
- [ ] Manual test: Create task → Create worktree → Verify backlog.json contains worktree info

🤖 Generated with [Claude Code](https://claude.com/claude-code)