### PR TITLE
fix(lwt): improve exception handling and cleanup guarantee

### DIFF
--- a/start-masc-mcp.sh
+++ b/start-masc-mcp.sh
@@ -87,9 +87,6 @@ if [ -n "$MASC_EIO_EXE" ] && command -v dune >/dev/null 2>&1; then
     fi
 fi
 
-# Eio is now the default runtime (Lwt deprecated)
-EIO_MODE="true"
-
 # Default arguments
 PORT="${MASC_MCP_PORT:-8935}"
 HTTP_MODE="${MASC_MCP_HTTP:-true}"
@@ -113,8 +110,9 @@ while [[ $# -gt 0 ]]; do
             shift
             ;;
         --lwt)
-            EIO_MODE="false"
-            shift
+            echo "Error: Lwt runtime is deprecated since 2026-01." >&2
+            echo "Please use Eio (default). Lwt support has been removed." >&2
+            exit 1
             ;;
         --port)
             PORT="$2"


### PR DESCRIPTION
## Summary
Self-review 결과 발견된 이슈 수정

## Changes
1. **특정 예외만 catch**: `Lwt_io.Channel_closed`, `End_of_file`만 잡고 나머지는 로깅
2. **Lwt.finalize 사용**: cleanup (stop_sse_conn_by_key) 보장
3. **중복 제거**: `EIO_MODE="true"` 중복 설정 제거
4. **--lwt 플래그**: deprecation error 반환

## Before/After
```ocaml
(* Before: 모든 예외 무시 *)
(fun _exn -> Lwt.return_unit)

(* After: 특정 예외만 + 로깅 + finalize *)
(function
  | Lwt_io.Channel_closed _ | End_of_file -> Lwt.return_unit
  | exn -> Printf.eprintf "[WARN] ..."; Lwt.return_unit)
```

## Test plan
- [x] `dune build` passes
- [ ] Manual test: connect/disconnect SSE client

🤖 Generated with [Claude Code](https://claude.com/claude-code)