### PR TITLE
MCP 초기화 검증 및 오류 응답 개선

### DIFF
--- a/bin/main_eio.ml
+++ b/bin/main_eio.ml
@@ -261,87 +261,97 @@ let handle_post_mcp request reqd =
   in
 
   Http.Request.read_body_async reqd (fun body_str ->
-    let state = match !server_state with
-      | Some s -> s
-      | None -> failwith "Server state not initialized"
-    in
-    let sw = match !current_sw with
-      | Some s -> s
-      | None -> failwith "Eio switch not initialized"
-    in
-    let clock = match !current_clock with
-      | Some c -> c
-      | None -> failwith "Eio clock not initialized"
-    in
-    let response_json = Mcp_eio.handle_request ~clock ~sw state body_str in
-    (match protocol_version_from_body body_str with
-     | Some v -> remember_protocol_version session_id v
-     | None -> ());
-    let protocol_version = get_protocol_version_for_session ~session_id request in
-    if not (accepts_streamable_mcp request) then
-      let body = json_rpc_error (-32600)
-        "Invalid Accept header: must include application/json and text/event-stream"
+    try
+      let state = match !server_state with
+        | Some s -> s
+        | None -> failwith "Server state not initialized"
       in
+      let sw = match !current_sw with
+        | Some s -> s
+        | None -> failwith "Eio switch not initialized"
+      in
+      let clock = match !current_clock with
+        | Some c -> c
+        | None -> failwith "Eio clock not initialized"
+      in
+      let response_json = Mcp_eio.handle_request ~clock ~sw state body_str in
+      (match protocol_version_from_body body_str with
+       | Some v -> remember_protocol_version session_id v
+       | None -> ());
+      let protocol_version = get_protocol_version_for_session ~session_id request in
+      if not (accepts_streamable_mcp request) then
+        let body = json_rpc_error (-32600)
+          "Invalid Accept header: must include application/json and text/event-stream"
+        in
+        let headers = Httpun.Headers.of_list (
+          ("content-length", string_of_int (String.length body))
+          :: json_headers session_id protocol_version origin
+        ) in
+        let response = Httpun.Response.create ~headers `Bad_request in
+        Httpun.Reqd.respond_with_string reqd response body
+      else
+        let wants_sse = accepts_sse request && not force_json_response in
+        if wants_sse then begin
+          match response_json with
+          | `Null ->
+              let headers = Httpun.Headers.of_list (
+                ("content-length", "0")
+                :: mcp_headers session_id protocol_version
+              ) in
+              let response = Httpun.Response.create ~headers `Accepted in
+              Httpun.Reqd.respond_with_string reqd response ""
+          | json when is_http_error_response json ->
+              let body = Yojson.Safe.to_string json in
+              let headers = Httpun.Headers.of_list (
+                ("content-length", string_of_int (String.length body))
+                :: json_headers session_id protocol_version origin
+              ) in
+              let response = Httpun.Response.create ~headers `Bad_request in
+              Httpun.Reqd.respond_with_string reqd response body
+          | json ->
+              let event = Sse.format_event ~event_type:"message" (Yojson.Safe.to_string json) in
+              let body = sse_prime_event () ^ event in
+              let headers = Httpun.Headers.of_list (
+                ("content-length", string_of_int (String.length body))
+                :: sse_headers session_id protocol_version origin
+              ) in
+              let response = Httpun.Response.create ~headers `OK in
+              Httpun.Reqd.respond_with_string reqd response body
+        end else begin
+          match response_json with
+          | `Null ->
+              let headers = Httpun.Headers.of_list (
+                ("content-length", "0")
+                :: mcp_headers session_id protocol_version
+              ) in
+              let response = Httpun.Response.create ~headers `Accepted in
+              Httpun.Reqd.respond_with_string reqd response ""
+          | json when is_http_error_response json ->
+              let body = Yojson.Safe.to_string json in
+              let headers = Httpun.Headers.of_list (
+                ("content-length", string_of_int (String.length body))
+                :: json_headers session_id protocol_version origin
+              ) in
+              let response = Httpun.Response.create ~headers `Bad_request in
+              Httpun.Reqd.respond_with_string reqd response body
+          | json ->
+              let body = Yojson.Safe.to_string json in
+              let headers = Httpun.Headers.of_list (
+                ("content-length", string_of_int (String.length body))
+                :: json_headers session_id protocol_version origin
+              ) in
+              let response = Httpun.Response.create ~headers `OK in
+              Httpun.Reqd.respond_with_string reqd response body
+        end
+    with exn ->
+      let protocol_version = get_protocol_version_for_session ~session_id request in
+      let body = json_rpc_error (-32603) ("Internal error: " ^ Printexc.to_string exn) in
       let headers = Httpun.Headers.of_list (
         ("content-length", string_of_int (String.length body))
         :: json_headers session_id protocol_version origin
       ) in
-      let response = Httpun.Response.create ~headers `Bad_request in
-      Httpun.Reqd.respond_with_string reqd response body
-    else
-      let wants_sse = accepts_sse request && not force_json_response in
-      if wants_sse then begin
-        match response_json with
-        | `Null ->
-            let headers = Httpun.Headers.of_list (
-              ("content-length", "0")
-              :: mcp_headers session_id protocol_version
-            ) in
-            let response = Httpun.Response.create ~headers `Accepted in
-            Httpun.Reqd.respond_with_string reqd response ""
-        | json when is_http_error_response json ->
-            let body = Yojson.Safe.to_string json in
-            let headers = Httpun.Headers.of_list (
-              ("content-length", string_of_int (String.length body))
-              :: json_headers session_id protocol_version origin
-            ) in
-            let response = Httpun.Response.create ~headers `Bad_request in
-            Httpun.Reqd.respond_with_string reqd response body
-        | json ->
-            let event = Sse.format_event ~event_type:"message" (Yojson.Safe.to_string json) in
-            let body = sse_prime_event () ^ event in
-            let headers = Httpun.Headers.of_list (
-              ("content-length", string_of_int (String.length body))
-              :: sse_headers session_id protocol_version origin
-            ) in
-            let response = Httpun.Response.create ~headers `OK in
-            Httpun.Reqd.respond_with_string reqd response body
-      end else begin
-        match response_json with
-        | `Null ->
-            let headers = Httpun.Headers.of_list (
-              ("content-length", "0")
-              :: mcp_headers session_id protocol_version
-            ) in
-            let response = Httpun.Response.create ~headers `Accepted in
-            Httpun.Reqd.respond_with_string reqd response ""
-        | json when is_http_error_response json ->
-            let body = Yojson.Safe.to_string json in
-            let headers = Httpun.Headers.of_list (
-              ("content-length", string_of_int (String.length body))
-              :: json_headers session_id protocol_version origin
-            ) in
-            let response = Httpun.Response.create ~headers `Bad_request in
-            Httpun.Reqd.respond_with_string reqd response body
-        | json ->
-            let body = Yojson.Safe.to_string json in
-            let headers = Httpun.Headers.of_list (
-              ("content-length", string_of_int (String.length body))
-              :: json_headers session_id protocol_version origin
-            ) in
-            let response = Httpun.Response.create ~headers `OK in
-            Httpun.Reqd.respond_with_string reqd response body
-      end
+        let response = Httpun.Response.create ~headers `Internal_server_error in
+        Httpun.Reqd.respond_with_string reqd response body
   )
 
 (** SSE connection tracking (prevents leaks / stale sessions) *)

--- a/lib/backend.ml
+++ b/lib/backend.ml
@@ -111,14 +111,14 @@ let validate_ttl ttl_seconds =
 
 (** Safely parse JSON lock file, returning None on any error.
     Also removes corrupted files to allow recovery. *)
-let safe_parse_lock_json path =
-  if not (Sys.file_exists path) then None
+let safe_parse_lock_json file_path =
+  if not (Sys.file_exists file_path) then None
   else
     try
-      let content = In_channel.with_open_text path In_channel.input_all in
+      let content = In_channel.with_open_text file_path In_channel.input_all in
       if String.length content = 0 then begin
         (* Empty file is corrupted - remove it *)
-        (try Sys.remove path with _ -> ());
+        (try Sys.remove file_path with _ -> ());
         None
       end else
         let json = Yojson.Safe.from_string content in
@@ -139,12 +139,12 @@ let safe_parse_lock_json path =
         match parse_string_field "owner", parse_float_field "expires_at" with
         | Some own, Some exp -> Some (own, exp)
         | _ ->
-            (try Sys.remove path with _ -> ());
+            (try Sys.remove file_path with _ -> ());
             None
     with
     | _ ->
         (* Corrupted JSON file - remove it to allow recovery *)
-        (try Sys.remove path with _ -> ());
+        (try Sys.remove file_path with _ -> ());
         None
 
 (** Acquire exclusive file lock using Unix.lockf.

--- a/lib/mcp_server_eio.ml
+++ b/lib/mcp_server_eio.ml
@@ -34,6 +34,8 @@ let normalize_protocol_version = Mcp_server.normalize_protocol_version
 let validate_initialize_params = Mcp_server.validate_initialize_params
 let make_response = Mcp_server.make_response
 let make_error = Mcp_server.make_error
+let is_valid_request_id = Mcp_server.is_valid_request_id
+let validate_initialize_params = Mcp_server.validate_initialize_params
 
 (** Unregister agent synchronously - adapter for Session.registry
 

--- a/lib/mcp_server_eio.mli
+++ b/lib/mcp_server_eio.mli
@@ -88,4 +88,4 @@ val normalize_protocol_version : string -> string
 val make_response : id:Yojson.Safe.t -> Yojson.Safe.t -> Yojson.Safe.t
 
 (** Make error JSON-RPC response *)
-val make_error : id:Yojson.Safe.t -> int -> string -> Yojson.Safe.t
+val make_error : ?data:Yojson.Safe.t -> id:Yojson.Safe.t -> int -> string -> Yojson.Safe.t


### PR DESCRIPTION
## 변경 사항\n- initialize 파라미터 스펙 검증 추가\n- JSON-RPC 오류 응답 data 필드 지원\n- /mcp POST 예외 발생 시 응답 보장\n\n## 테스트\n- opam exec --switch /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/mcp-error-handling -- dune test --root .