### PR TITLE
feat(gc): 통합 메시지 retention 정책 구현

### DIFF
--- a/test/test_backend.ml
+++ b/test/test_backend.ml
@@ -11,6 +11,7 @@ let test_config () = {
   postgres_url = None;
   node_id = "test-node-1";
   cluster_name = "test-cluster";
+  pubsub_max_messages = 1000;
 }
 
 (* Test: generate unique node IDs *)


### PR DESCRIPTION
## Summary

- PostgreSQL `masc_pubsub` 테이블 자동 정리 기능 추가
- Redis LTRIM 제한값 설정 가능 (`MASC_PUBSUB_MAX_MESSAGES` 환경변수)
- GC 함수에 backend-agnostic cleanup dispatch 추가

## Changes

### backend.ml
- `pubsub_max_messages` config 필드 추가
- PostgresNative: `cleanup_pubsub_by_age`, `cleanup_pubsub_by_limit`, `cleanup_pubsub` 함수 추가
- PostgresNative: `idx_masc_pubsub_created_at` 인덱스 추가
- RedisNative: 설정 가능한 LTRIM 제한 적용

### room_utils.ml
- `backend_cleanup_pubsub` dispatch 함수 추가

### room.ml
- GC에 4단계 backend pubsub cleanup 추가
- 상세 로깅 (`pubsub_cleaned` 카운트)

## Test plan
- [x] `dune runtest` 전체 통과
- [ ] PostgreSQL 백엔드에서 실제 cleanup 테스트
- [ ] Redis 백엔드에서 LTRIM 제한값 변경 테스트

🤖 Generated with [Claude Code](https://claude.com/claude-code)