### PR TITLE
chore: Remove compact-protocol dependency

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -26,7 +26,6 @@
   ; External dependencies (opam pin)
   (mcp_protocol (>= 0.1.0))
   (ocaml-webrtc (>= 0.1.0))
-  (compact-protocol (>= 0.1.0))
   ; Standard dependencies
   (yojson (>= 2.0))
   (graphql (>= 0.14.0))

--- a/lib/compression_dict.ml
+++ b/lib/compression_dict.ml
@@ -1,61 +1,62 @@
-(** Compression Dictionary for Small Messages - v5 Unified
+(** Compression for Small Messages - Simplified
 
-    This module now delegates to lib/compact-protocol (Compact Protocol v5).
+    Plain zstd compression without external dictionary dependency.
     Maintains backward-compatible API for existing MASC code.
 
-    @see lib/compact-protocol/compact.ml for implementation
-    @since 2026-01-13 v5.0 unified
+    @since 2026-01-23 v6.0 simplified (removed compact-protocol dependency)
 *)
-
-(** Module alias for convenience *)
-module CP = Compact_protocol.Compact
-
-(** {1 Dictionary Access - Delegates to Compact_protocol} *)
-
-(** Get dictionary for compression *)
-let get_dict () : string = CP.get_embedded_dict ()
-
-(** Check if dictionary is available *)
-let has_dict () : bool = CP.has_embedded_dict ()
 
 (** {1 Size Thresholds} *)
 
-(** Minimum message size for dictionary compression *)
-let min_dict_size = CP.min_compress_size
+(** Minimum message size for compression *)
+let min_dict_size = 32
 
-(** Maximum message size for dictionary compression *)
-let max_dict_size = CP.max_dict_size
+(** Maximum message size for dictionary compression (not used in simplified version) *)
+let max_dict_size = 2048
 
-(** Should use dictionary for this message size? *)
-let should_use_dict = CP.should_use_dict
+(** Should compress this message size? *)
+let should_use_dict (size : int) : bool =
+  size >= min_dict_size
 
-(** {1 Compression - Wrapper around Compact_protocol} *)
+(** {1 Dictionary Stubs} *)
 
-(** Compress with dictionary if beneficial
+(** Get dictionary - returns empty (no dictionary in simplified version) *)
+let get_dict () : string = ""
+
+(** Check if dictionary is available - always false in simplified version *)
+let has_dict () : bool = false
+
+(** {1 Compression} *)
+
+(** Compress data if beneficial
 
     @param data The data to compress
-    @return (compressed_data, used_dict, did_compress) *)
+    @return (compressed_data, used_dict, did_compress)
+    Note: used_dict is always false in simplified version *)
 let compress ?(level = 3) (data : string) : string * bool * bool =
   let orig_size = String.length data in
-  let compressed, used_dict = CP.compress ~level data in
-  let did_compress = String.length compressed < orig_size in
-  (compressed, used_dict, did_compress)
+  if orig_size < min_dict_size then
+    (data, false, false)
+  else
+    try
+      let compressed = Zstd.compress ~level data in
+      if String.length compressed < orig_size then
+        (compressed, false, true)
+      else
+        (data, false, false)
+    with _ -> (data, false, false)
 
-(** Decompress with optional dictionary
+(** Decompress data
 
     @param data The compressed data
     @param orig_size Original size of uncompressed data
-    @param used_dict Whether dictionary was used for compression
+    @param used_dict Ignored in simplified version
     @return Decompressed data *)
 let decompress ~orig_size ~(used_dict : bool) (data : string) : string =
-  let dict = if used_dict then Some (get_dict ()) else None in
+  let _ = used_dict in  (* Ignored - no dictionary *)
   try
-    match dict with
-    | Some d -> Zstd.decompress orig_size ~dict:d data
-    | None -> Zstd.decompress orig_size data
-  with _ ->
-    (* Fallback: try Compact Protocol auto-detect path *)
-    CP.decompress data
+    Zstd.decompress orig_size data
+  with _ -> data
 
 (** {1 Content-Encoding Headers} *)
 
@@ -67,6 +68,5 @@ let encoding_standard = "zstd"
 
 (** {1 Version Info} *)
 
-(** Protocol version - now unified with Compact_protocol *)
-let version = CP.version
-let version_string = CP.version_string
+let version = "6.0.0"
+let version_string = "MASC Compression v6.0 (simplified)"

--- a/lib/dune
+++ b/lib/dune
@@ -120,8 +120,7 @@
    cohttp-eio
    ;; UUID generation (for mind_eio, noosphere_eio)
    uuidm
-   ;; Compact Protocol v5: unified DSL + compression
-   compact-protocol
+   ;; Zstd compression
    zstd
    )
  (preprocess (pps ppx_deriving_yojson ppx_deriving.show ppx_deriving.eq)))

--- a/lib/mcp_server.ml
+++ b/lib/mcp_server.ml
@@ -4,9 +4,6 @@
     Legacy handlers have been removed.
 *)
 
-(* Compact Protocol v1.3 - used for agent-to-agent communication *)
-module Compact = Compact_protocol.Compact
-
 (** Global state for Mitosis cell lifecycle *)
 let current_cell = ref (Mitosis.create_stem_cell ~generation:0)
 let stem_pool = ref (Mitosis.init_pool ~config:Mitosis.default_config)

--- a/masc_mcp.opam
+++ b/masc_mcp.opam
@@ -15,7 +15,6 @@ depends: [
   "dune" {>= "3.13" & >= "3.13"}
   "mcp_protocol" {>= "0.1.0"}
   "ocaml-webrtc" {>= "0.1.0"}
-  "compact-protocol" {>= "0.1.0"}
   "yojson" {>= "2.0"}
   "graphql" {>= "0.14.0"}
   "graphql_parser" {>= "0.14.0"}


### PR DESCRIPTION
## Summary
- Simplified compression_dict.ml to use Zstd directly
- Removed unused Compact module import from mcp_server.ml
- Removed compact-protocol from dependencies

## Why
The compact-protocol library was over-engineered for simple zstd compression.
Plain Zstd is sufficient and removes an external dependency barrier for public release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)