### PR TITLE
feat(walph): add Walph autonomous loop and Hat system

### DIFF
--- a/bin/dune
+++ b/bin/dune
@@ -35,3 +35,13 @@
 ;;  (name test_h2_simple)
 ;;  (modules test_h2_simple)
 ;;  (libraries h2 h2-eio eio eio_main))
+
+(executable
+ (name mention_selftest)
+ (modules mention_selftest)
+ (libraries masc_mcp))
+
+(executable
+ (name parse_test)
+ (modules parse_test)
+ (libraries masc_mcp))

--- a/bin/parse_test.ml
+++ b/bin/parse_test.ml
@@ -1,0 +1,25 @@
+open Masc_mcp
+
+let () =
+  let tests = [
+    (* Basic patterns *)
+    "@test-gentle-gecko STATEFUL";
+    "@ollama-gentle-gecko test";
+    "@ollama test";
+    "@@gemini broadcast";
+    (* Edge cases *)
+    "@ollama-test";              (* 2-part: should be Stateful *)
+    "@claude-code-v2";           (* 3-part with number *)
+    "@gemini-swift-fox123";      (* number at end *)
+    "@ alone";                   (* just @ *)
+    "@@ broadcast";              (* @@ without agent *)
+    "no mention here";           (* no @ at all *)
+    "@_underscore";              (* underscore agent *)
+  ] in
+  Printf.printf "%-35s   %-30s   %s\n" "Input" "Mode" "Extract";
+  Printf.printf "%s\n" (String.make 80 '-');
+  List.iter (fun msg ->
+    let mode = Mention.parse msg in
+    let ext = match Mention.extract msg with Some s -> s | None -> "None" in
+    Printf.printf "%-35s → %-30s | ext=%s\n" msg (Mention.mode_to_string mode) ext
+  ) tests

--- a/lib/auto_responder.ml
+++ b/lib/auto_responder.ml
@@ -1,0 +1,403 @@
+(** Auto-Responder Daemon - Automatic @mention response via spawn
+
+    When a broadcast message contains @mention, automatically spawn
+    the mentioned agent to respond.
+
+    Enable with: MASC_AUTO_RESPOND=true
+
+    Chain limit: Max 3 responses per minute to prevent infinite loops
+*)
+
+(** Auto-respond mode *)
+type mode = Disabled | Spawn | Llm
+
+(** Check auto-respond mode *)
+let get_mode () =
+  match Sys.getenv_opt "MASC_AUTO_RESPOND" with
+  | Some "true" | Some "1" | Some "yes" | Some "spawn" -> Spawn
+  | Some "llm" | Some "fast" -> Llm
+  | _ -> Disabled
+
+(** Check if auto-respond is enabled *)
+let is_enabled () = get_mode () <> Disabled
+
+(** Activity log file - human readable, shared across all modes *)
+let activity_log_file () =
+  match Sys.getenv_opt "ME_ROOT" with
+  | Some root -> root ^ "/logs/auto-responder.log"
+  | None -> "/tmp/auto-responder.log"
+
+(** Debug logging to file *)
+let debug_log msg =
+  let oc = open_out_gen [Open_creat; Open_append; Open_text] 0o644 "/tmp/auto_debug.log" in
+  Printf.fprintf oc "[%f] %s\n%!" (Unix.gettimeofday ()) msg;
+  close_out oc
+
+(** Activity logging - human readable format *)
+let activity_log ~mode ~from_agent ~mention ~status ~detail =
+  let log_file = activity_log_file () in
+  let oc = open_out_gen [Open_creat; Open_append; Open_text] 0o644 log_file in
+  let time = Unix.localtime (Unix.gettimeofday ()) in
+  let timestamp = Printf.sprintf "%04d-%02d-%02d %02d:%02d:%02d"
+    (time.Unix.tm_year + 1900) (time.Unix.tm_mon + 1) time.Unix.tm_mday
+    time.Unix.tm_hour time.Unix.tm_min time.Unix.tm_sec
+  in
+  let mode_str = match mode with Disabled -> "OFF" | Spawn -> "SPAWN" | Llm -> "LLM" in
+  Printf.fprintf oc "[%s] [%s] %s → @%s | %s | %s\n%!"
+    timestamp mode_str from_agent mention status detail;
+  close_out oc
+
+(** Chain limit: track recent responses to prevent infinite loops *)
+let recent_responses : (string, float) Hashtbl.t = Hashtbl.create 16
+let chain_limit = 3  (* max responses per agent type per minute *)
+let chain_window = 60.0  (* seconds *)
+
+(** Check if we should throttle this response *)
+let should_throttle ~agent_type =
+  let now = Unix.gettimeofday () in
+  let key = agent_type in
+  (* Clean old entries *)
+  Hashtbl.filter_map_inplace (fun _ ts ->
+    if now -. ts < chain_window then Some ts else None
+  ) recent_responses;
+  (* Count recent responses for this agent type *)
+  let count = Hashtbl.fold (fun k _ acc ->
+    if String.length k >= String.length agent_type &&
+       String.sub k 0 (String.length agent_type) = agent_type
+    then acc + 1 else acc
+  ) recent_responses 0 in
+  if count >= chain_limit then begin
+    debug_log (Printf.sprintf "THROTTLE: %s has %d responses in last %.0fs" agent_type count chain_window);
+    true
+  end else begin
+    Hashtbl.add recent_responses (Printf.sprintf "%s-%f" key now) now;
+    false
+  end
+
+(** LLM-MCP endpoint (default: 8932) *)
+let llm_mcp_url () =
+  match Sys.getenv_opt "LLM_MCP_URL" with
+  | Some url -> url
+  | None -> "http://127.0.0.1:8932/mcp"
+
+(** Re-export from Mention module for convenience *)
+let spawnable_agents = Mention.spawnable_agents
+let agent_type_of_mention = Mention.agent_type_of_mention
+let is_spawnable = Mention.is_spawnable
+
+(** Build shell command for spawning an agent *)
+let build_spawn_command ~agent_type ~prompt ~working_dir =
+  let escaped_prompt = Filename.quote prompt in
+  let base_cmd = match agent_type with
+    | "claude" -> Printf.sprintf "echo %s | claude -p --allowedTools 'mcp__masc__*'" escaped_prompt
+    | "gemini" -> Printf.sprintf "echo %s | gemini --yolo" escaped_prompt
+    | "codex" -> Printf.sprintf "echo %s | codex exec" escaped_prompt
+    | "ollama" -> Printf.sprintf "echo %s | ollama run qwen3:30b" escaped_prompt
+    | "glm" ->
+        (* GLM has no standalone CLI - use temp file to avoid shell escaping issues *)
+        let llm_url = llm_mcp_url () in
+        let json_escaped =
+          prompt
+          |> String.split_on_char '"' |> String.concat {|\"|}
+          |> String.split_on_char '\n' |> String.concat {|\\n|}
+        in
+        Printf.sprintf "echo '{\"jsonrpc\":\"2.0\",\"method\":\"tools/call\",\"id\":1,\"params\":{\"name\":\"glm\",\"arguments\":{\"prompt\":\"%s\"}}}' > /tmp/glm_spawn_$$.json && curl -s '%s' -H 'Content-Type: application/json' -d @/tmp/glm_spawn_$$.json && rm -f /tmp/glm_spawn_$$.json" json_escaped llm_url
+    | _ -> Printf.sprintf "echo %s | %s" escaped_prompt agent_type
+  in
+  Printf.sprintf "cd %s && timeout 120 %s" (Filename.quote working_dir) base_cmd
+
+(** Build prompt for auto-response *)
+let build_response_prompt ~from_agent ~content ~mention =
+  Printf.sprintf {|You received a mention in the MASC room from %s.
+
+Message: "%s"
+
+Quick response protocol:
+1. Call mcp__masc__masc_join(agent_name="%s")
+   → Read the response to get your assigned nickname (e.g., "gemini-rare-beaver")
+2. Call mcp__masc__masc_broadcast using YOUR ASSIGNED NICKNAME from step 1:
+   mcp__masc__masc_broadcast(agent_name="<your-assigned-nickname>", message="[your concise response]")
+   IMPORTANT: Do NOT use "%s" - use the full nickname from the join response!
+3. Call mcp__masc__masc_leave()
+
+Respond in 1-2 sentences. Be helpful and concise.|}
+    from_agent content mention mention
+
+(** Spawn agent in background (non-blocking) - Heavy mode *)
+let spawn_in_background ~agent_type ~prompt ~working_dir =
+  let cmd = build_spawn_command ~agent_type ~prompt ~working_dir in
+  let log_file = Printf.sprintf "/tmp/auto_respond_%s_%d.log"
+    agent_type (int_of_float (Unix.gettimeofday () *. 1000.) mod 10000)
+  in
+  (* Write command to file for debugging *)
+  let debug_file = "/tmp/auto_spawn_cmd.txt" in
+  let oc = open_out debug_file in
+  Printf.fprintf oc "CMD: %s\nLOG: %s\n" cmd log_file;
+  close_out oc;
+  (* Run in background with nohup - use script file to avoid quoting issues *)
+  let script_file = "/tmp/auto_spawn_script.sh" in
+  let sc = open_out script_file in
+  Printf.fprintf sc "#!/bin/bash\n%s\n" cmd;
+  close_out sc;
+  ignore (Unix.chmod script_file 0o755);
+  let bg_cmd = Printf.sprintf "nohup %s > %s 2>&1 &" script_file log_file in
+  debug_log (Printf.sprintf "SPAWN_CMD: %s" bg_cmd);
+  let ret = Unix.system bg_cmd in
+  debug_log (Printf.sprintf "SPAWN_RET: %s" (match ret with Unix.WEXITED n -> string_of_int n | _ -> "signal"))
+
+(** Call llm-mcp directly (fast mode) - Returns LLM response or error *)
+let call_llm_mcp_sync ~agent_type ~prompt =
+  let url = llm_mcp_url () in
+  let tool_name = match agent_type with
+    | "gemini" -> "gemini"
+    | "claude" -> "claude-cli"
+    | "codex" -> "codex"
+    | "glm" -> "glm"
+    | _ -> "ollama"  (* ollama is the fallback for unknown types *)
+  in
+  (* Escape prompt for JSON - replace quotes and newlines *)
+  let escaped_prompt =
+    prompt
+    |> String.split_on_char '"' |> String.concat {|\"|}
+    |> String.split_on_char '\n' |> String.concat {|\n|}
+  in
+  let json_body = Printf.sprintf
+    {|{"jsonrpc":"2.0","method":"tools/call","id":1,"params":{"name":"%s","arguments":{"prompt":"%s","response_format":"compact"}}}|}
+    tool_name escaped_prompt
+  in
+  (* Use temp file with unique name to avoid race conditions between threads *)
+  let tmp_file = Printf.sprintf "/tmp/llm_call_%d_%d.json"
+    (Unix.getpid ()) (int_of_float (Unix.gettimeofday () *. 1000000.) mod 1000000) in
+  let oc = open_out tmp_file in
+  output_string oc json_body;
+  close_out oc;
+  let cmd = Printf.sprintf
+    "curl -s '%s' -H 'Content-Type: application/json' -H 'Accept: application/json, text/event-stream' -d @%s 2>/dev/null | jq -r '.result.content[0].text // .error.message // \"no response\"' 2>/dev/null | head -c 500"
+    url tmp_file
+  in
+  let ic = Unix.open_process_in cmd in
+  let response = try input_line ic with End_of_file -> "no response" in
+  ignore (Unix.close_process_in ic);
+  (try Unix.unlink tmp_file with _ -> ());
+  response
+
+(** MASC HTTP helper - call MASC tool via HTTP (using temp file to avoid escaping issues) *)
+let masc_call ~tool_name ~args =
+  let masc_url = Printf.sprintf "http://127.0.0.1:%d/mcp"
+    (match Sys.getenv_opt "MASC_HTTP_PORT" with Some p -> int_of_string p | None -> 8935)
+  in
+  let body = Printf.sprintf
+    {|{"jsonrpc":"2.0","method":"tools/call","id":1,"params":{"name":"%s","arguments":%s}}|}
+    tool_name args
+  in
+  (* Use temp file to avoid shell escaping issues *)
+  let tmp_file = Printf.sprintf "/tmp/masc_call_%d_%d.json"
+    (Unix.getpid ()) (int_of_float (Unix.gettimeofday () *. 1000000.) mod 1000000) in
+  let oc = open_out tmp_file in
+  output_string oc body;
+  close_out oc;
+  let cmd = Printf.sprintf
+    "curl -s '%s' -H 'Content-Type: application/json' -H 'Accept: application/json, text/event-stream' -d @%s 2>/dev/null"
+    masc_url tmp_file
+  in
+  let ic = Unix.open_process_in cmd in
+  let buf = Buffer.create 256 in
+  (try while true do Buffer.add_string buf (input_line ic); Buffer.add_char buf '\n' done with End_of_file -> ());
+  ignore (Unix.close_process_in ic);
+  (try Unix.unlink tmp_file with _ -> ());
+  Buffer.contents buf
+
+(** Extract nickname from MASC join response *)
+let extract_nickname response =
+  (* Look for "Nickname: xxx" pattern *)
+  let lines = String.split_on_char '\n' response in
+  let rec find = function
+    | [] -> None
+    | line :: rest ->
+        if String.length line > 12 && String.sub line 0 10 = "  Nickname:" then
+          Some (String.trim (String.sub line 10 (String.length line - 10)))
+        else find rest
+  in
+  find lines
+
+(** Call llm-mcp and broadcast response (fast mode, background)
+    New approach: Auto-responder handles MASC join/broadcast/leave directly *)
+let call_llm_and_broadcast ~agent_type ~prompt ~mention ~base_path =
+  ignore base_path;
+  (* Step 1: Get simple answer from LLM (prompt is the original message content) *)
+  let response = call_llm_mcp_sync ~agent_type ~prompt in
+  debug_log (Printf.sprintf "LLM_RESPONSE: %s" (if String.length response > 100 then String.sub response 0 100 ^ "..." else response));
+
+  if response <> "" && response <> "no response" then begin
+    (* Step 2: Join MASC to get assigned nickname *)
+    let join_args = Printf.sprintf {|{"agent_name":"%s","capabilities":["llm-auto-responder"]}|} agent_type in
+    let join_resp = masc_call ~tool_name:"masc_join" ~args:join_args in
+    debug_log (Printf.sprintf "MASC_JOIN: %s" (if String.length join_resp > 200 then String.sub join_resp 0 200 ^ "..." else join_resp));
+
+    match extract_nickname join_resp with
+    | None ->
+        debug_log "MASC_JOIN_FAILED: Could not extract nickname";
+        Printf.eprintf "[Auto-Responder/LLM] Failed to join MASC\n%!"
+    | Some nickname ->
+        debug_log (Printf.sprintf "MASC_NICKNAME: %s" nickname);
+
+        (* Step 3: Broadcast response with proper nickname *)
+        let message = Printf.sprintf "@%s %s" mention (String.escaped response) in
+        let broadcast_args = Printf.sprintf {|{"agent_name":"%s","message":"%s"}|} nickname message in
+        let _ = masc_call ~tool_name:"masc_broadcast" ~args:broadcast_args in
+        debug_log "MASC_BROADCAST: sent";
+
+        (* Step 4: Leave MASC *)
+        let leave_args = Printf.sprintf {|{"agent_name":"%s"}|} nickname in
+        let _ = masc_call ~tool_name:"masc_leave" ~args:leave_args in
+        debug_log "MASC_LEAVE: done";
+
+        let short_resp = if String.length response > 50 then String.sub response 0 50 ^ "..." else response in
+        Printf.eprintf "[Auto-Responder/LLM] %s: %s\n%!" nickname short_resp
+  end else
+    Printf.eprintf "[Auto-Responder/LLM] LLM returned empty response\n%!"
+
+(** Run LLM call in background process (Thread.create doesn't work well with Eio)
+    Creates a shell script that does: LLM call -> MASC join -> broadcast -> leave *)
+let llm_call_in_background ~agent_type ~prompt ~mention ~base_path =
+  ignore base_path;
+  let llm_url = llm_mcp_url () in
+  let masc_port = match Sys.getenv_opt "MASC_HTTP_PORT" with Some p -> p | None -> "8935" in
+  let masc_url = Printf.sprintf "http://127.0.0.1:%s/mcp" masc_port in
+  let escaped_prompt =
+    prompt
+    |> String.split_on_char '"' |> String.concat {|\\\"|}
+    |> String.split_on_char '\n' |> String.concat " "
+    |> String.split_on_char '\'' |> String.concat {|'\\''|}
+  in
+  (* MASC requires Accept header with both application/json and text/event-stream *)
+  let accept_header = "-H 'Accept: application/json, text/event-stream'" in
+  let script = Printf.sprintf {|#!/bin/bash
+# LLM call in background for %s
+set -e
+
+# Step 1: Call LLM
+RESPONSE=$(curl -s '%s' -H 'Content-Type: application/json' \
+  -d '{"jsonrpc":"2.0","method":"tools/call","id":1,"params":{"name":"%s","arguments":{"prompt":"%s","response_format":"compact"}}}' \
+  | jq -r '.result.content[0].text // "no response"' | head -c 300)
+
+echo "[LLM] Response: $RESPONSE" >> /tmp/auto_debug.log
+
+if [ "$RESPONSE" = "no response" ] || [ -z "$RESPONSE" ]; then
+  echo "[LLM] Empty response, skipping MASC" >> /tmp/auto_debug.log
+  exit 0
+fi
+
+# Step 2: Join MASC (with Accept header for SSE support)
+JOIN_RESP=$(curl -s '%s' -H 'Content-Type: application/json' %s \
+  -d '{"jsonrpc":"2.0","method":"tools/call","id":1,"params":{"name":"masc_join","arguments":{"agent_name":"%s","capabilities":["llm-auto-responder"]}}}')
+
+# macOS compatible: use sed instead of grep -oP
+NICKNAME=$(echo "$JOIN_RESP" | sed -n 's/.*Nickname: \([a-z]*-[a-z]*-[a-z]*\).*/\1/p' | head -1)
+echo "[MASC] Nickname: $NICKNAME" >> /tmp/auto_debug.log
+
+if [ -z "$NICKNAME" ]; then
+  echo "[MASC] Failed to join, no nickname" >> /tmp/auto_debug.log
+  exit 1
+fi
+
+# Step 3: Broadcast (escape response for JSON)
+ESCAPED_RESP=$(echo "$RESPONSE" | sed 's/"/\\"/g' | tr '\n' ' ')
+curl -s '%s' -H 'Content-Type: application/json' %s \
+  -d "{\"jsonrpc\":\"2.0\",\"method\":\"tools/call\",\"id\":1,\"params\":{\"name\":\"masc_broadcast\",\"arguments\":{\"agent_name\":\"$NICKNAME\",\"message\":\"@%s $ESCAPED_RESP\"}}}" > /dev/null
+
+echo "[MASC] Broadcast sent" >> /tmp/auto_debug.log
+
+# Step 4: Leave
+curl -s '%s' -H 'Content-Type: application/json' %s \
+  -d "{\"jsonrpc\":\"2.0\",\"method\":\"tools/call\",\"id\":1,\"params\":{\"name\":\"masc_leave\",\"arguments\":{\"agent_name\":\"$NICKNAME\"}}}" > /dev/null
+
+echo "[MASC] Left room" >> /tmp/auto_debug.log
+|} agent_type llm_url agent_type escaped_prompt masc_url accept_header agent_type masc_url accept_header mention masc_url accept_header
+  in
+  let script_file = Printf.sprintf "/tmp/llm_bg_%d_%d.sh"
+    (Unix.getpid ()) (int_of_float (Unix.gettimeofday () *. 1000.) mod 10000) in
+  let log_file = Printf.sprintf "/tmp/llm_bg_%s_%d.log"
+    agent_type (int_of_float (Unix.gettimeofday () *. 1000.) mod 10000) in
+  let oc = open_out script_file in
+  output_string oc script;
+  close_out oc;
+  ignore (Unix.chmod script_file 0o755);
+  let bg_cmd = Printf.sprintf "nohup %s > %s 2>&1 &" script_file log_file in
+  debug_log (Printf.sprintf "LLM_BG_CMD: %s" bg_cmd);
+  let ret = Unix.system bg_cmd in
+  debug_log (Printf.sprintf "LLM_BG_RET: %s" (match ret with Unix.WEXITED n -> string_of_int n | _ -> "signal"))
+
+(** Maybe spawn a response agent if mention detected and enabled
+
+    Returns:
+    - Some task_id if spawn was triggered
+    - None if no spawn needed
+*)
+let maybe_respond ~base_path ~from_agent ~content ~mention =
+  let mode = get_mode () in
+  let mode_str = match mode with Disabled -> "Disabled" | Spawn -> "Spawn" | Llm -> "Llm" in
+  debug_log (Printf.sprintf "CALLED: from=%s mention=%s mode=%s enabled=%b"
+    from_agent (match mention with Some m -> m | None -> "NONE") mode_str (is_enabled ()));
+  match mention with
+  | None ->
+      debug_log "EXIT: No mention";
+      None
+  | Some _m when not (is_enabled ()) ->
+      let env_val = match Sys.getenv_opt "MASC_AUTO_RESPOND" with Some v -> v | None -> "not set" in
+      debug_log (Printf.sprintf "EXIT: Disabled (env=%s)" env_val);
+      Printf.eprintf "[Auto-Responder] Disabled (MASC_AUTO_RESPOND=%s)\n%!" env_val;
+      None
+  | Some m ->
+      let from_base = agent_type_of_mention from_agent in
+      let mention_base = agent_type_of_mention m in
+      debug_log (Printf.sprintf "CHECK: from_base=%s mention_base=%s spawnable=%b" from_base mention_base (is_spawnable m));
+      (* Prevent infinite loop: don't respond to same agent type *)
+      if from_base = mention_base then begin
+        debug_log "EXIT: Self-mention";
+        Printf.eprintf "[Auto-Responder] Skip self-mention @%s from %s\n%!" m from_agent;
+        None
+      end
+      else if not (is_spawnable m) then begin
+        debug_log "EXIT: Not spawnable";
+        activity_log ~mode ~from_agent ~mention:m ~status:"SKIP" ~detail:"Not spawnable agent type";
+        Printf.eprintf "[Auto-Responder] @%s not spawnable\n%!" m;
+        None
+      end
+      else if should_throttle ~agent_type:mention_base then begin
+        debug_log "EXIT: Throttled";
+        activity_log ~mode ~from_agent ~mention:m ~status:"THROTTLE" ~detail:(Printf.sprintf "Max %d responses per %.0fs" chain_limit chain_window);
+        Printf.eprintf "[Auto-Responder] Throttled @%s (chain limit)\n%!" m;
+        None
+      end
+      else begin
+        let prompt = build_response_prompt ~from_agent ~content ~mention:m in
+        let task_id = Printf.sprintf "auto-respond-%s-%d" mention_base
+          (int_of_float (Unix.gettimeofday () *. 1000.) mod 10000) in
+        debug_log (Printf.sprintf "DISPATCH: mode=%s task_id=%s" mode_str task_id);
+        (* Mode-based dispatch *)
+        (match mode with
+        | Llm ->
+            debug_log "ACTION: LLM call";
+            activity_log ~mode ~from_agent ~mention:m ~status:"LLM" ~detail:task_id;
+            Printf.eprintf "[Auto-Responder/LLM] Fast-calling %s for @%s\n%!" mention_base m;
+            (* LLM mode: run in background process (Thread.create doesn't work well with Eio) *)
+            llm_call_in_background ~agent_type:mention_base ~prompt:content ~mention:from_agent ~base_path
+        | Spawn ->
+            (* glm has no CLI - use LLM mode approach (auto-responder handles MASC) *)
+            if mention_base = "glm" then begin
+              debug_log "ACTION: LLM call (glm has no CLI)";
+              activity_log ~mode ~from_agent ~mention:m ~status:"LLM-GLM" ~detail:task_id;
+              Printf.eprintf "[Auto-Responder/LLM-GLM] Fast-calling glm for @%s\n%!" m;
+              (* Run in background process *)
+              llm_call_in_background ~agent_type:"glm" ~prompt:content ~mention:from_agent ~base_path
+            end else begin
+              debug_log "ACTION: Spawn";
+              activity_log ~mode ~from_agent ~mention:m ~status:"SPAWN" ~detail:task_id;
+              Printf.eprintf "[Auto-Responder/Spawn] Spawning %s for @%s from %s\n%!" mention_base m from_agent;
+              spawn_in_background ~agent_type:mention_base ~prompt ~working_dir:base_path
+            end
+        | Disabled ->
+            debug_log "ACTION: Mode disabled (should not reach here)");
+        Some task_id
+      end

--- a/lib/dune
+++ b/lib/dune
@@ -26,11 +26,13 @@
    gcm_compat
    graphql_api
    handover_eio
+   hat
    hebbian_eio
    http_server_eio
    institution_eio
    level2_config
    level4_config
+   llm_client_eio
    log
    prometheus
    rate_limit
@@ -56,6 +58,7 @@
    response
    room
    room_eio
+   room_walph_eio
    room_git
    room_portal
    room_utils

--- a/lib/hat.ml
+++ b/lib/hat.ml
@@ -1,0 +1,267 @@
+(** Hat System - Role-based Persona for MASC Agents
+
+    Inspired by ralph-orchestrator's Hat System.
+    Each hat represents a specialized persona with distinct behaviors.
+
+    Usage:
+    - Agents can wear different hats for different tasks
+    - Walph can rotate hats during iterations
+    - Broadcast format: @agent:hat (e.g., @claude:builder)
+
+    @see https://github.com/mikeyobrien/ralph-orchestrator
+*)
+
+(** {1 Types} *)
+
+(** Available hat types *)
+type t =
+  | Builder     (** Code writing, implementation *)
+  | Reviewer    (** Code review, quality checks *)
+  | Researcher  (** Investigation, exploration *)
+  | Tester      (** Test writing, coverage *)
+  | Architect   (** Design, planning *)
+  | Debugger    (** Bug hunting, fixing *)
+  | Documenter  (** Documentation, comments *)
+  | Custom of string  (** User-defined hat *)
+
+(** Hat configuration *)
+type config = {
+  name: string;
+  instructions: string;
+  triggers: string list;      (** Events this hat responds to *)
+  emits: string list;         (** Events this hat can emit *)
+  backend: string option;     (** Preferred LLM backend *)
+}
+
+(** Agent with hat *)
+type hatted_agent = {
+  agent_name: string;
+  current_hat: t;
+  hat_history: (t * float) list;  (** (hat, timestamp) *)
+}
+
+(** {1 Serialization} *)
+
+let to_string = function
+  | Builder -> "builder"
+  | Reviewer -> "reviewer"
+  | Researcher -> "researcher"
+  | Tester -> "tester"
+  | Architect -> "architect"
+  | Debugger -> "debugger"
+  | Documenter -> "documenter"
+  | Custom s -> s
+
+let of_string = function
+  | "builder" | "build" | "impl" -> Builder
+  | "reviewer" | "review" -> Reviewer
+  | "researcher" | "research" | "explore" -> Researcher
+  | "tester" | "test" -> Tester
+  | "architect" | "arch" | "design" -> Architect
+  | "debugger" | "debug" | "fix" -> Debugger
+  | "documenter" | "docs" | "doc" -> Documenter
+  | s -> Custom s
+
+let to_emoji = function
+  | Builder -> "🔨"
+  | Reviewer -> "🔍"
+  | Researcher -> "🔬"
+  | Tester -> "🧪"
+  | Architect -> "📐"
+  | Debugger -> "🐛"
+  | Documenter -> "📝"
+  | Custom _ -> "🎭"
+
+(** {1 Default Configurations} *)
+
+let default_config hat =
+  let name = to_string hat in
+  match hat with
+  | Builder -> {
+      name;
+      instructions = "Focus on implementation. Write clean, working code. Follow existing patterns.";
+      triggers = ["implement"; "build"; "create"; "add"];
+      emits = ["code_written"; "needs_review"];
+      backend = None;
+    }
+  | Reviewer -> {
+      name;
+      instructions = "Review code critically. Check for bugs, security issues, and style. Be constructive.";
+      triggers = ["review"; "check"; "needs_review"];
+      emits = ["approved"; "changes_requested"; "needs_fix"];
+      backend = None;
+    }
+  | Researcher -> {
+      name;
+      instructions = "Investigate thoroughly. Gather information. Summarize findings clearly.";
+      triggers = ["research"; "explore"; "investigate"; "find"];
+      emits = ["findings"; "recommendation"];
+      backend = Some "gemini";  (* Good for search/exploration *)
+    }
+  | Tester -> {
+      name;
+      instructions = "Write comprehensive tests. Aim for edge cases. Ensure coverage.";
+      triggers = ["test"; "coverage"; "verify"];
+      emits = ["tests_written"; "coverage_report"];
+      backend = None;
+    }
+  | Architect -> {
+      name;
+      instructions = "Design solutions. Consider trade-offs. Document decisions.";
+      triggers = ["design"; "plan"; "architect"];
+      emits = ["design_doc"; "decision"];
+      backend = Some "claude-cli";  (* Good for reasoning *)
+    }
+  | Debugger -> {
+      name;
+      instructions = "Find root cause. Fix bugs systematically. Add regression tests.";
+      triggers = ["debug"; "fix"; "error"; "bug"];
+      emits = ["bug_fixed"; "needs_test"];
+      backend = None;
+    }
+  | Documenter -> {
+      name;
+      instructions = "Write clear documentation. Add examples. Keep it concise.";
+      triggers = ["document"; "explain"; "docs"];
+      emits = ["docs_written"];
+      backend = None;
+    }
+  | Custom s -> {
+      name = s;
+      instructions = Printf.sprintf "Custom hat: %s" s;
+      triggers = [s];
+      emits = [s ^ "_done"];
+      backend = None;
+    }
+
+(** {1 Parsing} *)
+
+(** Parse "@agent:hat" format from message
+    @return Some (agent, hat) or None *)
+let parse_hatted_mention msg =
+  let re = Str.regexp "@\\([a-zA-Z0-9_-]+\\):\\([a-zA-Z0-9_-]+\\)" in
+  try
+    let _ = Str.search_forward re msg 0 in
+    let agent = Str.matched_group 1 msg in
+    let hat_str = Str.matched_group 2 msg in
+    Some (agent, of_string hat_str)
+  with Not_found -> None
+
+(** Extract all hatted mentions from a message *)
+let extract_hatted_mentions msg =
+  let re = Str.regexp "@\\([a-zA-Z0-9_-]+\\):\\([a-zA-Z0-9_-]+\\)" in
+  let rec find_all start acc =
+    try
+      let _ = Str.search_forward re msg start in
+      let agent = Str.matched_group 1 msg in
+      let hat_str = Str.matched_group 2 msg in
+      let end_pos = Str.match_end () in
+      find_all end_pos ((agent, of_string hat_str) :: acc)
+    with Not_found -> List.rev acc
+  in
+  find_all 0 []
+
+(** {1 Hat Registry} *)
+
+(** In-memory hat registry for agents *)
+let agent_hats : (string, hatted_agent) Hashtbl.t = Hashtbl.create 16
+
+(** Get or create hatted agent entry *)
+let get_agent agent_name =
+  match Hashtbl.find_opt agent_hats agent_name with
+  | Some a -> a
+  | None ->
+      let a = { agent_name; current_hat = Builder; hat_history = [] } in
+      Hashtbl.replace agent_hats agent_name a;
+      a
+
+(** Change agent's hat *)
+let wear ~agent_name hat =
+  let agent = get_agent agent_name in
+  let now = Unix.gettimeofday () in
+  let updated = {
+    agent with
+    current_hat = hat;
+    hat_history = (hat, now) :: agent.hat_history;
+  } in
+  Hashtbl.replace agent_hats agent_name updated;
+  Printf.sprintf "%s %s now wearing %s hat"
+    (to_emoji hat) agent_name (to_string hat)
+
+(** Get agent's current hat *)
+let current ~agent_name =
+  let agent = get_agent agent_name in
+  agent.current_hat
+
+(** Format agent with hat for display *)
+let format_agent agent_name =
+  let agent = get_agent agent_name in
+  Printf.sprintf "%s %s:%s"
+    (to_emoji agent.current_hat)
+    agent_name
+    (to_string agent.current_hat)
+
+(** {1 Hat Rotation for Walph} *)
+
+(** Preset hat rotations *)
+type rotation =
+  | Single of t                     (** One hat throughout *)
+  | Alternate of t * t              (** Alternate between two *)
+  | Sequence of t list              (** Fixed sequence, repeat *)
+  | TDD                             (** Tester → Builder → Tester... *)
+  | ReviewLoop                      (** Builder → Reviewer → Builder... *)
+
+let rotation_to_string = function
+  | Single h -> Printf.sprintf "single(%s)" (to_string h)
+  | Alternate (a, b) -> Printf.sprintf "alt(%s,%s)" (to_string a) (to_string b)
+  | Sequence hats -> Printf.sprintf "seq(%s)" (String.concat "," (List.map to_string hats))
+  | TDD -> "tdd"
+  | ReviewLoop -> "review-loop"
+
+(** Get next hat in rotation *)
+let next_in_rotation rotation current_idx =
+  match rotation with
+  | Single h -> (h, 0)
+  | Alternate (a, b) ->
+      if current_idx mod 2 = 0 then (a, current_idx + 1)
+      else (b, current_idx + 1)
+  | Sequence hats ->
+      let len = List.length hats in
+      if len = 0 then (Builder, 0)
+      else
+        let idx = current_idx mod len in
+        (List.nth hats idx, current_idx + 1)
+  | TDD ->
+      if current_idx mod 2 = 0 then (Tester, current_idx + 1)
+      else (Builder, current_idx + 1)
+  | ReviewLoop ->
+      if current_idx mod 2 = 0 then (Builder, current_idx + 1)
+      else (Reviewer, current_idx + 1)
+
+(** {1 JSON Serialization} *)
+
+let to_json hat =
+  `Assoc [
+    ("hat", `String (to_string hat));
+    ("emoji", `String (to_emoji hat));
+  ]
+
+let config_to_json config =
+  `Assoc [
+    ("name", `String config.name);
+    ("instructions", `String config.instructions);
+    ("triggers", `List (List.map (fun s -> `String s) config.triggers));
+    ("emits", `List (List.map (fun s -> `String s) config.emits));
+    ("backend", match config.backend with None -> `Null | Some b -> `String b);
+  ]
+
+let hatted_agent_to_json agent =
+  `Assoc [
+    ("agent_name", `String agent.agent_name);
+    ("current_hat", to_json agent.current_hat);
+    ("hat_changes", `Int (List.length agent.hat_history));
+  ]
+
+(** List all hatted agents *)
+let list_all () =
+  Hashtbl.fold (fun _ agent acc -> agent :: acc) agent_hats []

--- a/lib/llm_client_eio.ml
+++ b/lib/llm_client_eio.ml
@@ -1,0 +1,237 @@
+(** LLM Client for Eio - HTTP client for llm-mcp server
+
+    Provides simple interface to call LLM models via llm-mcp.
+    Used for Walph intent classification and other LLM tasks.
+
+    @see https://github.com/jeong-sik/llm-mcp for server details
+*)
+
+(* Eio modules are referenced with full paths for clarity *)
+
+(** {1 Types} *)
+
+type model =
+  | Gemini      (** Fast, good for classification *)
+  | Claude      (** Balanced, good for reasoning *)
+  | Codex       (** Code-focused *)
+  | Ollama of string  (** Local model *)
+
+type response = {
+  content: string;
+  model: string;
+  tokens_used: int option;
+}
+
+type error =
+  | ConnectionError of string
+  | ParseError of string
+  | ServerError of int * string
+  | Timeout
+
+(** {1 Configuration} *)
+
+let default_host = "127.0.0.1"
+let default_port = 8932
+let default_timeout_sec = 30.0
+
+(** {1 Internal Helpers} *)
+
+let model_to_string = function
+  | Gemini -> "gemini"
+  | Claude -> "claude-cli"
+  | Codex -> "codex"
+  | Ollama name -> Printf.sprintf "ollama:%s" name
+
+(** Build MCP JSON-RPC request for LLM call *)
+let build_request ~model ~prompt =
+  let model_str = model_to_string model in
+  Printf.sprintf {|{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "tools/call",
+  "params": {
+    "name": "%s",
+    "arguments": {
+      "prompt": %s,
+      "response_format": "compact"
+    }
+  }
+}|} model_str (Yojson.Safe.to_string (`String prompt))
+
+(** Parse LLM response from MCP JSON-RPC response *)
+let parse_response json_str =
+  try
+    let json = Yojson.Safe.from_string json_str in
+    match json with
+    | `Assoc fields ->
+        (match List.assoc_opt "result" fields with
+         | Some (`Assoc result_fields) ->
+             let content = match List.assoc_opt "content" result_fields with
+               | Some (`String s) -> s
+               | Some (`List [`Assoc text_fields]) ->
+                   (match List.assoc_opt "text" text_fields with
+                    | Some (`String s) -> s
+                    | _ -> "")
+               | _ -> ""
+             in
+             let model = match List.assoc_opt "model" result_fields with
+               | Some (`String s) -> s
+               | _ -> "unknown"
+             in
+             Ok { content; model; tokens_used = None }
+         | Some (`String s) -> Ok { content = s; model = "unknown"; tokens_used = None }
+         | _ ->
+             (match List.assoc_opt "error" fields with
+              | Some (`Assoc err) ->
+                  let msg = match List.assoc_opt "message" err with
+                    | Some (`String s) -> s
+                    | _ -> "Unknown error"
+                  in
+                  Error (ServerError (500, msg))
+              | _ -> Error (ParseError "No result or error in response")))
+    | _ -> Error (ParseError "Invalid JSON structure")
+  with
+  | Yojson.Json_error msg -> Error (ParseError msg)
+  | _ -> Error (ParseError "Unknown parse error")
+
+(** {1 Public API} *)
+
+(** Call LLM model with prompt (Eio-native, non-blocking)
+
+    @param net Eio network capability
+    @param model LLM model to use (default: Gemini for speed)
+    @param host llm-mcp server host (default: 127.0.0.1)
+    @param port llm-mcp server port (default: 8932)
+    @param prompt The prompt to send
+    @return Response or error *)
+let call ~net ?(model=Gemini) ?(host=default_host) ?(port=default_port) ~prompt () =
+  let request_body = build_request ~model ~prompt in
+  try
+    (* Connect to llm-mcp server using Eio.Net *)
+    Eio.Net.with_tcp_connect ~host ~service:(string_of_int port) net @@ fun flow ->
+    (* Send HTTP request *)
+    let request = Printf.sprintf
+      "POST /mcp HTTP/1.1\r\n\
+       Host: %s:%d\r\n\
+       Content-Type: application/json\r\n\
+       Content-Length: %d\r\n\
+       Connection: close\r\n\
+       \r\n\
+       %s"
+      host port (String.length request_body) request_body
+    in
+    Eio.Flow.copy_string request flow;
+    Eio.Flow.shutdown flow `Send;
+
+    (* Read response *)
+    let buf = Buffer.create 4096 in
+    let rec read_all () =
+      let chunk = Cstruct.create 4096 in
+      match Eio.Flow.single_read flow chunk with
+      | n ->
+          Buffer.add_string buf (Cstruct.to_string ~len:n chunk);
+          read_all ()
+      | exception End_of_file -> ()
+    in
+    read_all ();
+
+    (* Parse HTTP response *)
+    let response_str = Buffer.contents buf in
+    let body_start =
+      try
+        let idx = Str.search_forward (Str.regexp "\r\n\r\n") response_str 0 in
+        idx + 4
+      with Not_found -> 0
+    in
+    let body = String.sub response_str body_start (String.length response_str - body_start) in
+    parse_response body
+  with
+  | Unix.Unix_error (err, _, _) ->
+      Error (ConnectionError (Unix.error_message err))
+  | exn ->
+      Error (ConnectionError (Printexc.to_string exn))
+
+(** Convenience function for quick classification tasks *)
+let classify ~net ~prompt () =
+  call ~net ~model:Gemini ~prompt ()
+
+(** {1 Walph Intent Classification} *)
+
+(** Walph command intent *)
+type walph_intent =
+  | Start of { preset: string; target: string option }
+  | Stop
+  | Pause
+  | Resume
+  | Status
+  | Ignore
+
+(** Classify natural language message into Walph intent
+
+    @param net Eio network capability
+    @param message Natural language message to classify
+    @return Classified intent with confidence *)
+let classify_walph_intent ~net ~message () =
+  let prompt = Printf.sprintf {|You are a command classifier for Walph automation system.
+
+Classify this message into exactly one intent:
+- START: 작업 시작 요청 (커버리지, 리팩토링, 문서화, drain 등)
+- STOP: 정지/종료/그만 요청
+- PAUSE: 일시정지/멈춰 요청
+- RESUME: 재개/계속 요청
+- STATUS: 상태 조회/뭐해 요청
+- IGNORE: Walph 관련 아님
+
+Message: "%s"
+
+Output JSON only (no markdown):
+{"intent": "START|STOP|PAUSE|RESUME|STATUS|IGNORE", "preset": "drain|coverage|refactor|docs|null", "target": "file/path or null", "confidence": 0.0-1.0}|} message
+  in
+  match call ~net ~model:Gemini ~prompt () with
+  | Error e -> Error e
+  | Ok response ->
+      try
+        (* Extract JSON from response, handling potential markdown code blocks *)
+        let json_str =
+          let content = String.trim response.content in
+          if String.length content > 0 && content.[0] = '{' then content
+          else
+            (* Try to extract JSON from markdown code block *)
+            let re = Str.regexp {|```json?\n?\(.*\)\n?```|} in
+            if Str.string_match re content 0 then
+              Str.matched_group 1 content
+            else content
+        in
+        let json = Yojson.Safe.from_string json_str in
+        match json with
+        | `Assoc fields ->
+            let intent_str = match List.assoc_opt "intent" fields with
+              | Some (`String s) -> String.uppercase_ascii s
+              | _ -> "IGNORE"
+            in
+            let preset = match List.assoc_opt "preset" fields with
+              | Some (`String s) when s <> "null" -> s
+              | _ -> "drain"
+            in
+            let target = match List.assoc_opt "target" fields with
+              | Some (`String s) when s <> "null" -> Some s
+              | _ -> None
+            in
+            let confidence = match List.assoc_opt "confidence" fields with
+              | Some (`Float f) -> f
+              | Some (`Int i) -> float_of_int i
+              | _ -> 0.5
+            in
+            let intent = match intent_str with
+              | "START" -> Start { preset; target }
+              | "STOP" -> Stop
+              | "PAUSE" -> Pause
+              | "RESUME" -> Resume
+              | "STATUS" -> Status
+              | _ -> Ignore
+            in
+            (* Only return intent if confidence is high enough *)
+            if confidence >= 0.7 then Ok intent
+            else Ok Ignore
+        | _ -> Ok Ignore
+      with _ -> Ok Ignore

--- a/lib/masc_mcp.ml
+++ b/lib/masc_mcp.ml
@@ -13,7 +13,8 @@ module Notify = Notify
 
 module Room_utils = Room_utils
 module Room = Room
-module Room_ralph_eio = Room_ralph_eio
+module Room_walph_eio = Room_walph_eio
+module Llm_client_eio = Llm_client_eio
 module Room_git = Room_git
 module Room_portal = Room_portal
 module Room_worktree = Room_worktree
@@ -60,6 +61,7 @@ module Transport_grpc_next = Transport_grpc_next
 module Encryption = Encryption
 module Gcm_compat = Gcm_compat
 module Mention = Mention
+module Hat = Hat
 module Mitosis = Mitosis
 module Dashboard = Dashboard
 module Tempo = Tempo

--- a/lib/mention.ml
+++ b/lib/mention.ml
@@ -1,0 +1,106 @@
+(** Mention parsing module - Stateless/Stateful/Broadcast routing modes
+
+    @mention 문법:
+    - @@agent           → Broadcast to ALL agents of this type
+    - @agent-adj-animal → Stateful (specific agent by nickname)
+    - @agent            → Stateless (pick one available agent)
+*)
+
+(** Mention routing mode *)
+type mode =
+  | Stateless of string       (** @agent → pick one available *)
+  | Stateful of string        (** @agent-adj-animal → specific agent *)
+  | Broadcast of string       (** @@agent → all of type *)
+  | None                      (** No mention found *)
+
+(** Convert mode to string for logging *)
+let mode_to_string = function
+  | Stateless s -> Printf.sprintf "Stateless(%s)" s
+  | Stateful s -> Printf.sprintf "Stateful(%s)" s
+  | Broadcast s -> Printf.sprintf "Broadcast(%s)" s
+  | None -> "None"
+
+(** Extract agent type from mention (e.g., "ollama-gentle-gecko" → "ollama") *)
+let agent_type_of_mention mention =
+  let parts = String.split_on_char '-' mention in
+  match parts with
+  | [] -> mention
+  | base :: _ ->
+      if String.length base > 0 then base
+      else mention
+
+(** Check if a mention is a generated nickname (agent-adjective-animal pattern) *)
+let is_nickname mention =
+  let parts = String.split_on_char '-' mention in
+  List.length parts >= 3
+
+(** Parse @mention from message content
+
+    Priority order:
+    1. @@agent → Broadcast
+    2. @agent-adj-animal → Stateful
+    3. @agent → Stateless
+*)
+let parse content =
+  (* Pattern 1: @@agent (broadcast) *)
+  let broadcast_re = Str.regexp "@@\\([a-zA-Z0-9_]+\\)" in
+  try
+    let _ = Str.search_forward broadcast_re content 0 in
+    Broadcast (Str.matched_group 1 content)
+  with Not_found ->
+    (* Pattern 2: @agent-xxx-yyy (stateful - 3+ parts, alphanumeric allowed) *)
+    let stateful_re = Str.regexp "@\\([a-zA-Z0-9_]+-[a-zA-Z0-9]+-[a-zA-Z0-9]+\\)" in
+    try
+      let _ = Str.search_forward stateful_re content 0 in
+      Stateful (Str.matched_group 1 content)
+    with Not_found ->
+      (* Pattern 3: @agent (stateless) or @agent-something (stateful) *)
+      let mention_re = Str.regexp "@\\([a-zA-Z0-9_-]+\\)" in
+      try
+        let _ = Str.search_forward mention_re content 0 in
+        let matched = Str.matched_group 1 content in
+        (* Heuristic: if contains hyphen but not 3-part nickname, still stateful *)
+        if String.contains matched '-' then
+          Stateful matched
+        else
+          Stateless matched
+      with Not_found -> None
+
+(** Extract raw mention target (backward-compatible with old extract_mention) *)
+let extract content =
+  match parse content with
+  | Stateless s -> Some s
+  | Stateful s -> Some s
+  | Broadcast s -> Some s
+  | None -> None
+
+(** Get target agents based on mode
+
+    Returns:
+    - Stateless: First available agent of type
+    - Stateful: Specific agent (exact match)
+    - Broadcast: All agents of type
+*)
+let resolve_targets mode ~available_agents =
+  match mode with
+  | None -> []
+  | Stateless agent_type ->
+      (* Find first agent matching type *)
+      available_agents
+      |> List.filter (fun name -> agent_type_of_mention name = agent_type)
+      |> (fun l -> match l with [] -> [] | first :: _ -> [first])
+  | Stateful nickname ->
+      (* Exact match only *)
+      if List.mem nickname available_agents then [nickname] else []
+  | Broadcast agent_type ->
+      (* All agents of type *)
+      available_agents
+      |> List.filter (fun name -> agent_type_of_mention name = agent_type)
+
+(** Agent types that can be auto-spawned by Auto-Responder *)
+let spawnable_agents = ["gemini"; "codex"; "claude"; "ollama"; "glm"]
+
+(** Check if an agent type is spawnable *)
+let is_spawnable mention =
+  let base = agent_type_of_mention mention in
+  List.mem base spawnable_agents

--- a/lib/mention.mli
+++ b/lib/mention.mli
@@ -1,0 +1,39 @@
+(** Mention parsing module - Stateless/Stateful/Broadcast routing modes *)
+
+(** Mention routing mode *)
+type mode =
+  | Stateless of string       (** @agent → pick one available *)
+  | Stateful of string        (** @agent-adj-animal → specific agent *)
+  | Broadcast of string       (** @@agent → all of type *)
+  | None                      (** No mention found *)
+
+val mode_to_string : mode -> string
+(** Convert mode to human-readable string *)
+
+val agent_type_of_mention : string -> string
+(** Extract base agent type from mention/nickname
+    e.g., "ollama-gentle-gecko" → "ollama" *)
+
+val is_nickname : string -> bool
+(** Check if mention follows nickname pattern (agent-adj-animal) *)
+
+val parse : string -> mode
+(** Parse @mention from message content
+
+    Priority:
+    1. @@agent → Broadcast
+    2. @agent-adj-animal → Stateful
+    3. @agent → Stateless
+*)
+
+val extract : string -> string option
+(** Extract raw mention target (backward-compatible) *)
+
+val resolve_targets : mode -> available_agents:string list -> string list
+(** Get target agents based on mode and available agents *)
+
+val spawnable_agents : string list
+(** List of agent types that can be auto-spawned *)
+
+val is_spawnable : string -> bool
+(** Check if an agent type is spawnable by Auto-Responder *)

--- a/lib/room_eio.ml
+++ b/lib/room_eio.ml
@@ -516,13 +516,10 @@ let message_of_json json =
   with e ->
     Error (Printexc.to_string e)
 
-(** Extract @mention from message content *)
+(** Extract @mention from message content
+    Uses Mention module for Stateless/Stateful/Broadcast parsing *)
 let extract_mention content =
-  let re = Str.regexp "@\\([a-zA-Z0-9_-]+\\)" in
-  try
-    let _ = Str.search_forward re content 0 in
-    Some (Str.matched_group 1 content)
-  with Not_found -> None
+  Mention.extract content
 
 (** Key for atomic message sequence counter *)
 let message_seq_key = "counters:message_seq"

--- a/lib/room_walph_eio.ml
+++ b/lib/room_walph_eio.ml
@@ -1,0 +1,477 @@
+(** Room_walph_eio: Eio-native Walph (Walph Wiggum variant) implementation
+
+    Inspired by Geoffrey Huntley's Walph (Walph Wiggum variant) technique:
+    @see https://ghuntley.com/ralph/
+
+    Production-ready implementation using Eio concurrency primitives:
+    - Eio.Mutex for thread-safe state access (fiber-friendly, non-blocking)
+    - Eio.Condition for pause/resume (no busy-wait, proper fiber scheduling)
+    - Fun.protect for exception safety (no zombie states)
+
+    This module is designed to run inside Eio fiber context.
+    For pure sync/testing, use Room.walph_* functions instead.
+
+    @see Room for sync implementation (testing)
+    @see mcp_server_eio for production usage
+*)
+
+(** {1 Types} *)
+
+(** Walph (Walph Wiggum variant) state with Eio concurrency primitives *)
+type walph_state = {
+  mutable running : bool;
+  mutable paused : bool;
+  mutable stop_requested : bool;
+  mutable current_preset : string;
+  mutable iterations : int;
+  mutable completed : int;
+  mutex : Eio.Mutex.t;        (** Eio-native mutex (fiber-friendly) *)
+  cond : Eio.Condition.t;     (** Eio-native condition variable *)
+}
+
+(** {1 State Management} *)
+
+(** Global Walph state table with Eio mutex for thread-safe access *)
+let walph_states : (string, walph_state) Hashtbl.t = Hashtbl.create 16
+let walph_states_mutex = Eio.Mutex.create ()
+
+(** Escape colon in agent_name to prevent key collision.
+    "agent:foo" -> "agent::foo" (double colon as escape)
+    Key format: "room||agent" using || as separator (unlikely in paths/names) *)
+let escape_agent_name name =
+  (* Replace | with || to escape, then use | as separator *)
+  let buf = Buffer.create (String.length name) in
+  String.iter (fun c ->
+    if c = '|' then Buffer.add_string buf "||"
+    else Buffer.add_char buf c
+  ) name;
+  Buffer.contents buf
+
+(** Generate state key: room||agent for independent Walph per agent
+    Uses || separator to avoid collision with : in paths *)
+let make_walph_key config ~agent_name =
+  if agent_name = "" then
+    failwith "Walph: agent_name cannot be empty"
+  else
+    Printf.sprintf "%s||%s" config.Room_utils.base_path (escape_agent_name agent_name)
+
+(** Get or create Walph state for a specific agent (thread-safe)
+    Each agent has independent Walph state, enabling parallel loops *)
+let get_walph_state config ~agent_name =
+  let key = make_walph_key config ~agent_name in
+  Eio.Mutex.use_rw ~protect:true walph_states_mutex (fun () ->
+    match Hashtbl.find_opt walph_states key with
+    | Some s -> s
+    | None ->
+        let s = {
+          running = false; paused = false; stop_requested = false;
+          current_preset = ""; iterations = 0; completed = 0;
+          mutex = Eio.Mutex.create ();
+          cond = Eio.Condition.create ();
+        } in
+        Hashtbl.replace walph_states key s;
+        s
+  )
+
+(** Remove Walph state for an agent (cleanup to prevent memory leak)
+    @return Error if Walph is still running (zombie prevention), Ok () otherwise *)
+let remove_walph_state config ~agent_name =
+  let key = make_walph_key config ~agent_name in
+  let result = Eio.Mutex.use_rw ~protect:true walph_states_mutex (fun () ->
+    match Hashtbl.find_opt walph_states key with
+    | None -> Ok ()  (* Already removed, no-op *)
+    | Some state ->
+        if state.running then
+          Error (Printf.sprintf "Walph: cannot remove state for %s while running. Call STOP first." agent_name)
+        else begin
+          Hashtbl.remove walph_states key;
+          Ok ()
+        end
+  ) in
+  match result with
+  | Ok () -> ()
+  | Error msg -> failwith msg  (* Raise outside mutex to avoid poisoning *)
+
+(** List all active Walph states in a room (for swarm coordination)
+    Uses || as separator to match make_walph_key *)
+let list_walph_states config =
+  let prefix = config.Room_utils.base_path ^ "||" in
+  let prefix_len = String.length prefix in
+  Eio.Mutex.use_rw ~protect:true walph_states_mutex (fun () ->
+    Hashtbl.fold (fun key state acc ->
+      if String.length key > prefix_len &&
+         String.sub key 0 prefix_len = prefix then
+        (* Extract agent name (still escaped, but usable as identifier) *)
+        let agent = String.sub key prefix_len (String.length key - prefix_len) in
+        (agent, state) :: acc
+      else acc
+    ) walph_states []
+  )
+
+(** Run function with Walph state mutex locked (Eio-native) *)
+let with_walph_lock state f =
+  Eio.Mutex.use_rw ~protect:true state.mutex f
+
+(** {1 Control Commands} *)
+
+(** Handle @walph control command (Eio-native, fiber-safe)
+    @param config Room configuration
+    @param from_agent Agent sending the command (controls own Walph)
+    @param command Command (STOP, PAUSE, RESUME, STATUS)
+    @param args Command arguments
+    @param target_agent Optional: control another agent's Walph (default: self)
+    @return Response message *)
+let walph_control config ~from_agent ~command ~args ?(target_agent=None) () =
+  let agent_name = match target_agent with Some a -> a | None -> from_agent in
+  let state = get_walph_state config ~agent_name in
+  let response = with_walph_lock state (fun () ->
+    match command with
+    | "STOP" ->
+        if state.running then begin
+          state.stop_requested <- true;
+          Eio.Condition.broadcast state.cond;  (* Wake up paused fibers *)
+          Printf.sprintf "🛑 @walph STOP requested by %s (will stop after current iteration)" from_agent
+        end else
+          "ℹ️ @walph is not currently running"
+    | "PAUSE" ->
+        if state.running && not state.paused then begin
+          state.paused <- true;
+          Printf.sprintf "⏸️ @walph PAUSED by %s (use @walph RESUME to continue)" from_agent
+        end else if state.paused then
+          "ℹ️ @walph is already paused"
+        else
+          "ℹ️ @walph is not currently running"
+    | "RESUME" ->
+        if state.paused then begin
+          state.paused <- false;
+          Eio.Condition.broadcast state.cond;  (* Wake up paused fibers *)
+          Printf.sprintf "▶️ @walph RESUMED by %s" from_agent
+        end else if state.running then
+          "ℹ️ @walph is already running"
+        else
+          "ℹ️ @walph is not currently running"
+    | "STATUS" ->
+        if state.running then
+          Printf.sprintf "📊 @walph STATUS: %s (iter: %d, done: %d, paused: %b)"
+            state.current_preset state.iterations state.completed state.paused
+        else
+          "ℹ️ @walph is idle (use @walph START <preset> to begin)"
+    | "START" ->
+        (* START is handled by walph_loop, just acknowledge here *)
+        if state.running then
+          Printf.sprintf "⚠️ @walph is already running %s. Use @walph STOP first." state.current_preset
+        else
+          Printf.sprintf "✨ @walph START acknowledged. Args: %s" args
+    | _ ->
+        Printf.sprintf "❓ Unknown @walph command: %s. Valid: START, STOP, PAUSE, RESUME, STATUS" command
+  ) in
+  (* Broadcast the response *)
+  let _ = Room.broadcast config ~from_agent:"walph" ~content:response in
+  response
+
+(** Check if Walph should continue looping (Eio-native, no busy-wait)
+    Uses Eio.Condition for proper fiber scheduling.
+    @param agent_name The agent whose Walph state to check
+    @return true if should continue, false if should stop *)
+let walph_should_continue config ~agent_name =
+  let state = get_walph_state config ~agent_name in
+  (* Note: Eio.Condition.await requires mutex to be held, and atomically
+     releases it while waiting, then reacquires before returning *)
+  Eio.Mutex.use_rw ~protect:true state.mutex (fun () ->
+    if state.stop_requested then false
+    else if state.paused then begin
+      (* Wait on condition variable - Eio-native, no busy-wait!
+         This yields to other fibers while waiting *)
+      while state.paused && not state.stop_requested do
+        Eio.Condition.await_no_mutex state.cond
+      done;
+      not state.stop_requested
+    end else true
+  )
+
+(** {1 Main Loop} *)
+
+(** Walph (Walph Wiggum variant) pattern: Keep claiming tasks until stop condition
+    Eio-native implementation with fiber-safe concurrency.
+
+    @param preset Loop preset (drain, coverage, refactor, docs)
+    @param max_iterations Maximum iterations before forced stop
+    @param target Target file/directory for preset
+    @return Status string with loop results *)
+let walph_loop config ~agent_name ?(preset="drain") ?(max_iterations=10) ?target () =
+  Room.ensure_initialized config;
+
+  (* Get Walph state for this specific agent *)
+  let walph_state = get_walph_state config ~agent_name in
+
+  (* Atomic check-and-set to prevent double-start race condition *)
+  let start_result = with_walph_lock walph_state (fun () ->
+    if walph_state.running then
+      Error (Printf.sprintf "⚠️ @walph is already running %s. Use @walph STOP first." walph_state.current_preset)
+    else begin
+      (* Atomically set running=true under lock *)
+      walph_state.running <- true;
+      walph_state.paused <- false;
+      walph_state.stop_requested <- false;
+      walph_state.current_preset <- preset;
+      walph_state.iterations <- 0;
+      walph_state.completed <- 0;
+      Ok ()
+    end
+  ) in
+
+  match start_result with
+  | Error msg ->
+      let _ = Room.broadcast config ~from_agent:"walph" ~content:msg in
+      msg
+  | Ok () ->
+      (* Use Fun.protect to ensure running <- false even on exceptions (zombie prevention) *)
+      let stop_reason = ref "" in
+
+      Fun.protect
+        ~finally:(fun () ->
+          (* Always reset running state, even on exception *)
+          with_walph_lock walph_state (fun () ->
+            walph_state.running <- false
+          ))
+        (fun () ->
+          let _ = Room.broadcast config ~from_agent:agent_name
+            ~content:(Printf.sprintf "🔄 @walph START %s%s (max: %d)"
+              preset
+              (match target with Some t -> " --target " ^ t | None -> "")
+              max_iterations) in
+
+          (* UTF-8 safe prefix check: 📋=4bytes, ✅=3bytes, ❌=3bytes *)
+          let starts_with prefix s =
+            let plen = String.length prefix in
+            String.length s >= plen && String.sub s 0 plen = prefix
+          in
+
+          (* Run the loop *)
+          let rec loop () =
+            (* Check control state before each iteration *)
+            if not (walph_should_continue config ~agent_name) then begin
+              stop_reason := if walph_state.stop_requested then "stop requested" else "paused indefinitely";
+              ()
+            end else begin
+              (* Check max iterations with lock *)
+              let should_stop = with_walph_lock walph_state (fun () ->
+                if walph_state.iterations >= max_iterations then begin
+                  stop_reason := Printf.sprintf "max_iterations reached (%d)" max_iterations;
+                  true
+                end else begin
+                  walph_state.iterations <- walph_state.iterations + 1;
+                  false
+                end
+              ) in
+              if should_stop then ()
+              else begin
+                (* Try to claim next task *)
+                let claim_result = Room.claim_next config ~agent_name in
+
+                if starts_with "📋" claim_result || starts_with "No unclaimed" claim_result then begin
+                  (* No more unclaimed tasks - drain complete *)
+                  stop_reason := "backlog drained";
+                  ()
+                end else if starts_with "✅" claim_result then begin
+                  with_walph_lock walph_state (fun () ->
+                    walph_state.completed <- walph_state.completed + 1
+                  );
+
+                  (* Broadcast progress *)
+                  let _ = Room.broadcast config ~from_agent:agent_name
+                    ~content:(Printf.sprintf "📊 @walph Iteration %d: %s" walph_state.iterations claim_result) in
+
+                  (* Continue loop *)
+                  loop ()
+                end else begin
+                  (* Error or unexpected result *)
+                  stop_reason := Printf.sprintf "claim error: %s" claim_result;
+                  ()
+                end
+              end
+            end
+          in
+
+          loop ();
+
+          (* Final broadcast and log *)
+          let result = Printf.sprintf
+            "🛑 @walph STOPPED. Preset: %s, Iterations: %d, Tasks completed: %d, Reason: %s"
+            preset walph_state.iterations walph_state.completed !stop_reason in
+
+          let _ = Room.broadcast config ~from_agent:agent_name ~content:result in
+
+          Room.log_event config (Printf.sprintf
+            "{\"type\":\"walph_loop_complete\",\"agent\":\"%s\",\"preset\":\"%s\",\"iterations\":%d,\"completed\":%d,\"reason\":\"%s\",\"ts\":\"%s\"}"
+            agent_name preset walph_state.iterations walph_state.completed !stop_reason (Types.now_iso ()));
+
+          result
+        )
+
+(** {1 Preset Mapping} *)
+
+(** Map Walph preset to llm-mcp chain ID
+    @param preset The loop preset (coverage, refactor, docs, drain)
+    @return Some chain_id for presets with corresponding chains, None for drain *)
+let get_chain_id_for_preset = function
+  | "coverage" -> Some "walph-coverage"
+  | "refactor" -> Some "walph-refactor"
+  | "docs" -> Some "walph-docs"
+  | "drain" -> None  (* No chain for simple drain *)
+  | _ -> None
+
+(** {1 Swarm Walph - Multi-Agent Coordination} *)
+
+(** Swarm status summary for all active Walph instances in a room *)
+type swarm_status = {
+  total_agents: int;
+  running_count: int;
+  paused_count: int;
+  completed_tasks: int;
+  total_iterations: int;
+  agents: (string * walph_state) list;
+}
+
+(** Get comprehensive swarm status across all Walph instances
+    @param config Room configuration
+    @return Swarm status summary *)
+let swarm_walph_status config =
+  let agents = list_walph_states config in
+  let running = List.filter (fun (_, s) -> s.running) agents in
+  let paused = List.filter (fun (_, s) -> s.paused) agents in
+  let total_completed = List.fold_left (fun acc (_, s) -> acc + s.completed) 0 agents in
+  let total_iters = List.fold_left (fun acc (_, s) -> acc + s.iterations) 0 agents in
+  {
+    total_agents = List.length agents;
+    running_count = List.length running;
+    paused_count = List.length paused;
+    completed_tasks = total_completed;
+    total_iterations = total_iters;
+    agents;
+  }
+
+(** Format swarm status for display *)
+let format_swarm_status status =
+  let agent_lines = List.map (fun (name, s) ->
+    Printf.sprintf "  • %s: %s (iter: %d, done: %d)%s"
+      name
+      (if s.running then (if s.paused then "⏸️ PAUSED" else "🔄 RUNNING") else "⚪ IDLE")
+      s.iterations s.completed
+      (if s.running then " [" ^ s.current_preset ^ "]" else "")
+  ) status.agents in
+  Printf.sprintf
+    "🐝 **Swarm Walph Status**\n\
+     ├─ Agents: %d total, %d running, %d paused\n\
+     ├─ Tasks completed: %d\n\
+     ├─ Total iterations: %d\n\
+     └─ Details:\n%s"
+    status.total_agents status.running_count status.paused_count
+    status.completed_tasks status.total_iterations
+    (if agent_lines = [] then "  (no agents)" else String.concat "\n" agent_lines)
+
+(** Stop all running Walph instances in a swarm
+    @param config Room configuration
+    @param from_agent Agent issuing the stop command
+    @return Summary of stopped instances *)
+let swarm_walph_stop config ~from_agent =
+  let agents = list_walph_states config in
+  let running_agents = List.filter (fun (_, s) -> s.running) agents in
+
+  if running_agents = [] then
+    "ℹ️ No running Walph instances to stop"
+  else begin
+    let stopped = List.map (fun (agent_name, state) ->
+      with_walph_lock state (fun () ->
+        if state.running then begin
+          state.stop_requested <- true;
+          Eio.Condition.broadcast state.cond;
+          agent_name
+        end else ""
+      )
+    ) running_agents in
+
+    let stopped_list = List.filter ((<>) "") stopped in
+    let _ = Room.broadcast config ~from_agent:"walph-swarm"
+      ~content:(Printf.sprintf "🛑 SWARM STOP by %s: %d agents signaled" from_agent (List.length stopped_list)) in
+
+    Printf.sprintf "🛑 Swarm stop requested for %d agents: %s"
+      (List.length stopped_list)
+      (String.concat ", " stopped_list)
+  end
+
+(** Pause all running Walph instances in a swarm
+    @param config Room configuration
+    @param from_agent Agent issuing the pause command
+    @return Summary of paused instances *)
+let swarm_walph_pause config ~from_agent =
+  let agents = list_walph_states config in
+  let running_agents = List.filter (fun (_, s) -> s.running && not s.paused) agents in
+
+  if running_agents = [] then
+    "ℹ️ No running (un-paused) Walph instances to pause"
+  else begin
+    let paused = List.map (fun (agent_name, state) ->
+      with_walph_lock state (fun () ->
+        if state.running && not state.paused then begin
+          state.paused <- true;
+          agent_name
+        end else ""
+      )
+    ) running_agents in
+
+    let paused_list = List.filter ((<>) "") paused in
+    let _ = Room.broadcast config ~from_agent:"walph-swarm"
+      ~content:(Printf.sprintf "⏸️ SWARM PAUSE by %s: %d agents paused" from_agent (List.length paused_list)) in
+
+    Printf.sprintf "⏸️ Swarm pause applied to %d agents: %s"
+      (List.length paused_list)
+      (String.concat ", " paused_list)
+  end
+
+(** Resume all paused Walph instances in a swarm
+    @param config Room configuration
+    @param from_agent Agent issuing the resume command
+    @return Summary of resumed instances *)
+let swarm_walph_resume config ~from_agent =
+  let agents = list_walph_states config in
+  let paused_agents = List.filter (fun (_, s) -> s.paused) agents in
+
+  if paused_agents = [] then
+    "ℹ️ No paused Walph instances to resume"
+  else begin
+    let resumed = List.map (fun (agent_name, state) ->
+      with_walph_lock state (fun () ->
+        if state.paused then begin
+          state.paused <- false;
+          Eio.Condition.broadcast state.cond;
+          agent_name
+        end else ""
+      )
+    ) paused_agents in
+
+    let resumed_list = List.filter ((<>) "") resumed in
+    let _ = Room.broadcast config ~from_agent:"walph-swarm"
+      ~content:(Printf.sprintf "▶️ SWARM RESUME by %s: %d agents resumed" from_agent (List.length resumed_list)) in
+
+    Printf.sprintf "▶️ Swarm resume applied to %d agents: %s"
+      (List.length resumed_list)
+      (String.concat ", " resumed_list)
+  end
+
+(** Command pattern for swarm control *)
+let swarm_walph_control config ~from_agent ~command () =
+  match String.uppercase_ascii command with
+  | "STATUS" ->
+      let status = swarm_walph_status config in
+      let formatted = format_swarm_status status in
+      let _ = Room.broadcast config ~from_agent:"walph-swarm" ~content:formatted in
+      formatted
+  | "STOP" ->
+      swarm_walph_stop config ~from_agent
+  | "PAUSE" ->
+      swarm_walph_pause config ~from_agent
+  | "RESUME" ->
+      swarm_walph_resume config ~from_agent
+  | cmd ->
+      Printf.sprintf "❓ Unknown swarm command: %s. Valid: STATUS, STOP, PAUSE, RESUME" cmd

--- a/lib/tools.ml
+++ b/lib/tools.ml
@@ -2852,15 +2852,15 @@ of their context limits and gracefully hand over work to successors.|};
     ];
   };
 
-  (* Ralph Wiggum Pattern: Iterative Task Loop
+  (* Walph Pattern: Iterative Task Loop
      Integration with llm-mcp chains:
-     - preset="coverage" → chain.orchestrate ralph-coverage (FeedbackLoop for test coverage)
-     - preset="refactor" → chain.orchestrate ralph-refactor (FeedbackLoop for lint errors)
-     - preset="docs" → chain.orchestrate ralph-docs (FeedbackLoop for documentation)
+     - preset="coverage" → chain.orchestrate walph-coverage (FeedbackLoop for test coverage)
+     - preset="refactor" → chain.orchestrate walph-refactor (FeedbackLoop for lint errors)
+     - preset="docs" → chain.orchestrate walph-docs (FeedbackLoop for documentation)
      - preset="drain" → simple task claiming without chain execution *)
   {
-    name = "masc_ralph_loop";
-    description = "Ralph Wiggum pattern: Keep claiming and completing tasks until stop condition. Iterates claim_next → work → done cycle. Control via @ralph in broadcast: START <preset>, STOP, PAUSE, RESUME, STATUS. Presets map to llm-mcp FeedbackLoop chains: coverage → ralph-coverage, refactor → ralph-refactor, docs → ralph-docs, drain → simple claim loop.";
+    name = "masc_walph_loop";
+    description = "Walph pattern: Keep claiming and completing tasks until stop condition. Iterates claim_next → work → done cycle. Control via @walph in broadcast: START <preset>, STOP, PAUSE, RESUME, STATUS. Presets map to llm-mcp FeedbackLoop chains: coverage → walph-coverage, refactor → walph-refactor, docs → walph-docs, drain → simple claim loop.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -2895,10 +2895,10 @@ of their context limits and gracefully hand over work to successors.|};
     ];
   };
 
-  (* Ralph Wiggum Control: STOP, PAUSE, RESUME, STATUS *)
+  (* Walph Control: STOP, PAUSE, RESUME, STATUS *)
   {
-    name = "masc_ralph_control";
-    description = "Control a running @ralph loop. Commands: STOP (end loop after current iteration), PAUSE (suspend loop), RESUME (continue paused loop), STATUS (get current state). Can also be triggered via broadcast: '@ralph STOP', '@ralph PAUSE', etc.";
+    name = "masc_walph_control";
+    description = "Control a running @walph loop. Commands: STOP (end loop after current iteration), PAUSE (suspend loop), RESUME (continue paused loop), STATUS (get current state). Can also be triggered via broadcast: '@walph STOP', '@walph PAUSE', etc.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -2913,6 +2913,88 @@ of their context limits and gracefully hand over work to successors.|};
         ]);
       ]);
       ("required", `List [`String "command"; `String "agent_name"]);
+    ];
+  };
+
+  (* Walph Natural Language: Control walph via natural language *)
+  {
+    name = "masc_walph_natural";
+    description = "Control Walph loop using natural language. Heuristic-based intent classification (Korean/English). Examples: '커버리지 올려줘' → START coverage, '그만' → STOP, '잠깐 멈춰' → PAUSE, '다시 시작' → RESUME, '지금 뭐해?' → STATUS. Falls back to llm-mcp for ambiguous messages (requires llm-mcp server on port 8932).";
+    input_schema = `Assoc [
+      ("type", `String "object");
+      ("properties", `Assoc [
+        ("message", `Assoc [
+          ("type", `String "string");
+          ("description", `String "Natural language message to interpret (e.g., '커버리지 좀 올려줘', 'stop the loop', '지금 진행상황 알려줘')");
+        ]);
+        ("agent_name", `Assoc [
+          ("type", `String "string");
+          ("description", `String "Agent sending the command (for audit trail)");
+        ]);
+      ]);
+      ("required", `List [`String "message"; `String "agent_name"]);
+    ];
+  };
+
+  (* Swarm Walph: Coordinate multiple Walph instances *)
+  {
+    name = "masc_swarm_walph";
+    description = "Swarm-level control for all Walph instances in the room. View aggregate status, stop/pause/resume all running loops at once. Commands: STATUS (show all Walph states), STOP (signal all to stop), PAUSE (pause all running), RESUME (resume all paused). Useful for coordinating multi-agent workloads.";
+    input_schema = `Assoc [
+      ("type", `String "object");
+      ("properties", `Assoc [
+        ("command", `Assoc [
+          ("type", `String "string");
+          ("description", `String "Swarm control command");
+          ("enum", `List [`String "STATUS"; `String "STOP"; `String "PAUSE"; `String "RESUME"]);
+          ("default", `String "STATUS");
+        ]);
+        ("agent_name", `Assoc [
+          ("type", `String "string");
+          ("description", `String "Agent issuing the swarm command (for audit trail)");
+        ]);
+      ]);
+      ("required", `List [`String "agent_name"]);
+    ];
+  };
+
+  (* Hat System: Role-based personas for agents *)
+  {
+    name = "masc_hat_wear";
+    description = "Wear a hat (persona) to specialize agent behavior. Hats: builder (🔨 code), reviewer (🔍 review), researcher (🔬 explore), tester (🧪 tests), architect (📐 design), debugger (🐛 fix), documenter (📝 docs). Broadcast format: @agent:hat (e.g., @claude:builder).";
+    input_schema = `Assoc [
+      ("type", `String "object");
+      ("properties", `Assoc [
+        ("hat", `Assoc [
+          ("type", `String "string");
+          ("description", `String "Hat to wear");
+          ("enum", `List [
+            `String "builder"; `String "reviewer"; `String "researcher";
+            `String "tester"; `String "architect"; `String "debugger"; `String "documenter"
+          ]);
+          ("default", `String "builder");
+        ]);
+        ("agent_name", `Assoc [
+          ("type", `String "string");
+          ("description", `String "Agent wearing the hat");
+        ]);
+      ]);
+      ("required", `List [`String "agent_name"]);
+    ];
+  };
+
+  {
+    name = "masc_hat_status";
+    description = "Show current hat status for all agents. Displays which persona each agent is currently using.";
+    input_schema = `Assoc [
+      ("type", `String "object");
+      ("properties", `Assoc [
+        ("agent_name", `Assoc [
+          ("type", `String "string");
+          ("description", `String "Agent requesting status");
+        ]);
+      ]);
+      ("required", `List [`String "agent_name"]);
     ];
   };
 

--- a/test/dune
+++ b/test/dune
@@ -16,13 +16,13 @@
         test_subscriptions test_session test_progress test_mitosis test_spawn
         test_validation test_response test_voice_stream test_sctp
         test_datachannel_rfc test_dtls_crypto test_dashboard
-        test_multi_room test_worktree_detection test_bounded)
+        test_multi_room test_worktree_detection test_bounded test_mention test_hat)
  (modules test_room test_types test_checkpoint test_auth test_http_negotiation
           test_sse test_encryption test_backend test_cancellation test_graphql_api
           test_subscriptions test_session test_progress test_mitosis test_spawn
           test_validation test_response test_voice_stream test_sctp
           test_datachannel_rfc test_dtls_crypto test_dashboard
-          test_multi_room test_worktree_detection test_bounded)
+          test_multi_room test_worktree_detection test_bounded test_mention test_hat)
  (libraries masc_mcp mcp_protocol alcotest str yojson mirage-crypto
             mirage-crypto-rng cohttp cstruct))
 
@@ -65,8 +65,8 @@
 
 ; Ralph Eio test (Production-ready fiber-safe Ralph)
 (test
- (name test_ralph_eio)
- (modules test_ralph_eio)
+ (name test_walph_eio)
+ (modules test_walph_eio)
  (libraries masc_mcp alcotest eio eio_main yojson))
 
 ; TODO: These tests need to be created

--- a/test/dune
+++ b/test/dune
@@ -49,6 +49,12 @@
  (modules test_planning_eio)
  (libraries masc_mcp alcotest str yojson))
 
+; Mention module monkey/fuzz test
+(executable
+ (name test_mention_monkey)
+ (modules test_mention_monkey)
+ (libraries masc_mcp unix str))
+
 ; ============================================================
 ; Eio-native working tests (Mcp_server_eio, Session_eio)
 ; ============================================================

--- a/test/test_hat.ml
+++ b/test/test_hat.ml
@@ -1,0 +1,86 @@
+(** Hat System Tests *)
+
+open Masc_mcp.Hat
+
+let test_of_string () =
+  Alcotest.(check string) "builder" "builder" (to_string (of_string "builder"));
+  Alcotest.(check string) "reviewer" "reviewer" (to_string (of_string "reviewer"));
+  Alcotest.(check string) "review alias" "reviewer" (to_string (of_string "review"));
+  Alcotest.(check string) "custom" "my-hat" (to_string (of_string "my-hat"));
+  ()
+
+let test_to_emoji () =
+  Alcotest.(check string) "builder emoji" "🔨" (to_emoji Builder);
+  Alcotest.(check string) "reviewer emoji" "🔍" (to_emoji Reviewer);
+  Alcotest.(check string) "tester emoji" "🧪" (to_emoji Tester);
+  Alcotest.(check string) "custom emoji" "🎭" (to_emoji (Custom "foo"));
+  ()
+
+let test_wear_and_current () =
+  let agent = "test-agent-1" in
+  let _ = wear ~agent_name:agent Builder in
+  Alcotest.(check string) "current is builder" "builder" (to_string (current ~agent_name:agent));
+  let _ = wear ~agent_name:agent Reviewer in
+  Alcotest.(check string) "current is reviewer" "reviewer" (to_string (current ~agent_name:agent));
+  ()
+
+let test_parse_hatted_mention () =
+  let result = parse_hatted_mention "@claude:builder needs to fix this" in
+  (match result with
+   | Some (agent, hat) ->
+       Alcotest.(check string) "agent" "claude" agent;
+       Alcotest.(check string) "hat" "builder" (to_string hat)
+   | None -> Alcotest.fail "Should parse hatted mention");
+
+  let result2 = parse_hatted_mention "no mention here" in
+  Alcotest.(check bool) "no match" true (result2 = None);
+  ()
+
+let test_extract_multiple_mentions () =
+  let mentions = extract_hatted_mentions "@claude:builder and @gemini:reviewer should collaborate" in
+  Alcotest.(check int) "two mentions" 2 (List.length mentions);
+  ()
+
+let test_rotation_single () =
+  let (hat, idx) = next_in_rotation (Single Tester) 0 in
+  Alcotest.(check string) "single always tester" "tester" (to_string hat);
+  Alcotest.(check int) "idx stays 0" 0 idx;
+  ()
+
+let test_rotation_tdd () =
+  let (hat0, idx1) = next_in_rotation TDD 0 in
+  Alcotest.(check string) "tdd starts with tester" "tester" (to_string hat0);
+  let (hat1, idx2) = next_in_rotation TDD idx1 in
+  Alcotest.(check string) "tdd then builder" "builder" (to_string hat1);
+  let (hat2, _) = next_in_rotation TDD idx2 in
+  Alcotest.(check string) "tdd back to tester" "tester" (to_string hat2);
+  ()
+
+let test_default_config () =
+  let cfg = default_config Builder in
+  Alcotest.(check string) "builder name" "builder" cfg.name;
+  Alcotest.(check bool) "has triggers" true (List.length cfg.triggers > 0);
+  Alcotest.(check bool) "has emits" true (List.length cfg.emits > 0);
+  ()
+
+let () =
+  Alcotest.run "Hat System" [
+    "serialization", [
+      Alcotest.test_case "of_string" `Quick test_of_string;
+      Alcotest.test_case "to_emoji" `Quick test_to_emoji;
+    ];
+    "wear", [
+      Alcotest.test_case "wear_and_current" `Quick test_wear_and_current;
+    ];
+    "parsing", [
+      Alcotest.test_case "parse_hatted_mention" `Quick test_parse_hatted_mention;
+      Alcotest.test_case "extract_multiple" `Quick test_extract_multiple_mentions;
+    ];
+    "rotation", [
+      Alcotest.test_case "single" `Quick test_rotation_single;
+      Alcotest.test_case "tdd" `Quick test_rotation_tdd;
+    ];
+    "config", [
+      Alcotest.test_case "default_config" `Quick test_default_config;
+    ];
+  ]

--- a/test/test_mention.ml
+++ b/test/test_mention.ml
@@ -1,0 +1,232 @@
+(** Tests for @mention parsing - Stateless/Stateful/Broadcast modes *)
+
+open Masc_mcp
+
+let mention_mode_equal a b =
+  match a, b with
+  | Mention.Stateless s1, Mention.Stateless s2 -> s1 = s2
+  | Mention.Stateful s1, Mention.Stateful s2 -> s1 = s2
+  | Mention.Broadcast s1, Mention.Broadcast s2 -> s1 = s2
+  | Mention.None, Mention.None -> true
+  | _ -> false
+
+(* ===== Stateless Mode Tests ===== *)
+
+let test_stateless_basic () =
+  let cases = [
+    ("@ollama", Mention.Stateless "ollama");
+    ("@gemini", Mention.Stateless "gemini");
+    ("@claude", Mention.Stateless "claude");
+    ("@codex", Mention.Stateless "codex");
+    ("Hello @ollama what is 2+2?", Mention.Stateless "ollama");
+    ("@glm 안녕하세요", Mention.Stateless "glm");
+  ] in
+  List.iter (fun (content, expected) ->
+    let result = Mention.parse content in
+    if not (mention_mode_equal result expected) then
+      Alcotest.fail (Printf.sprintf
+        "Stateless parse failed: '%s' => got %s, expected %s"
+        content (Mention.mode_to_string result) (Mention.mode_to_string expected))
+  ) cases
+
+let test_stateless_with_underscore () =
+  let cases = [
+    ("@my_agent", Mention.Stateless "my_agent");
+    ("@claude_v2", Mention.Stateless "claude_v2");
+  ] in
+  List.iter (fun (content, expected) ->
+    let result = Mention.parse content in
+    if not (mention_mode_equal result expected) then
+      Alcotest.fail (Printf.sprintf
+        "Underscore parse failed: '%s' => got %s, expected %s"
+        content (Mention.mode_to_string result) (Mention.mode_to_string expected))
+  ) cases
+
+(* ===== Stateful Mode Tests ===== *)
+
+let test_stateful_nickname () =
+  let cases = [
+    ("@ollama-gentle-gecko", Mention.Stateful "ollama-gentle-gecko");
+    ("@gemini-swift-tiger", Mention.Stateful "gemini-swift-tiger");
+    ("@claude-bold-shark", Mention.Stateful "claude-bold-shark");
+    ("Hey @codex-keen-otter can you help?", Mention.Stateful "codex-keen-otter");
+  ] in
+  List.iter (fun (content, expected) ->
+    let result = Mention.parse content in
+    if not (mention_mode_equal result expected) then
+      Alcotest.fail (Printf.sprintf
+        "Stateful parse failed: '%s' => got %s, expected %s"
+        content (Mention.mode_to_string result) (Mention.mode_to_string expected))
+  ) cases
+
+(* ===== Broadcast Mode Tests ===== *)
+
+let test_broadcast_basic () =
+  let cases = [
+    ("@@ollama", Mention.Broadcast "ollama");
+    ("@@gemini", Mention.Broadcast "gemini");
+    ("Hey @@claude everyone respond!", Mention.Broadcast "claude");
+    ("@@all 전체 공지입니다", Mention.Broadcast "all");
+  ] in
+  List.iter (fun (content, expected) ->
+    let result = Mention.parse content in
+    if not (mention_mode_equal result expected) then
+      Alcotest.fail (Printf.sprintf
+        "Broadcast parse failed: '%s' => got %s, expected %s"
+        content (Mention.mode_to_string result) (Mention.mode_to_string expected))
+  ) cases
+
+(* ===== No Mention Tests ===== *)
+
+let test_no_mention () =
+  let cases = [
+    "Hello world";
+    "No mention here";
+    "";
+  ] in
+  List.iter (fun content ->
+    let result = Mention.parse content in
+    if result <> Mention.None then
+      Alcotest.fail (Printf.sprintf
+        "Expected None for '%s', got %s"
+        content (Mention.mode_to_string result))
+  ) cases
+
+(* ===== Priority Tests ===== *)
+
+let test_broadcast_priority () =
+  (* @@agent should take priority over @agent *)
+  let content = "@@ollama @gemini" in
+  let result = Mention.parse content in
+  if not (mention_mode_equal result (Mention.Broadcast "ollama")) then
+    Alcotest.fail (Printf.sprintf
+      "Broadcast should have priority: got %s"
+      (Mention.mode_to_string result))
+
+let test_stateful_priority () =
+  (* @agent-adj-animal should be Stateful, not Stateless *)
+  let content = "@ollama-gentle-gecko" in
+  let result = Mention.parse content in
+  if not (mention_mode_equal result (Mention.Stateful "ollama-gentle-gecko")) then
+    Alcotest.fail (Printf.sprintf
+      "Stateful should be detected: got %s"
+      (Mention.mode_to_string result))
+
+(* ===== Edge Cases ===== *)
+
+let test_korean_message () =
+  let cases = [
+    ("@ollama 안녕하세요 질문있어요", Mention.Stateless "ollama");
+    ("@@gemini 모두에게 공지", Mention.Broadcast "gemini");
+  ] in
+  List.iter (fun (content, expected) ->
+    let result = Mention.parse content in
+    if not (mention_mode_equal result expected) then
+      Alcotest.fail (Printf.sprintf
+        "Korean message failed: '%s' => got %s"
+        content (Mention.mode_to_string result))
+  ) cases
+
+let test_multiple_mentions () =
+  (* First mention should be extracted *)
+  let content = "@ollama @gemini @claude" in
+  let result = Mention.parse content in
+  if not (mention_mode_equal result (Mention.Stateless "ollama")) then
+    Alcotest.fail (Printf.sprintf
+      "First mention should be extracted: got %s"
+      (Mention.mode_to_string result))
+
+(* ===== Target Resolution Tests ===== *)
+
+let test_resolve_stateless () =
+  let available = ["ollama-gentle-gecko"; "ollama-bold-shark"; "gemini-swift-tiger"] in
+  let targets = Mention.resolve_targets (Mention.Stateless "ollama") ~available_agents:available in
+  match targets with
+  | [first] when String.sub first 0 6 = "ollama" -> ()
+  | _ -> Alcotest.fail "Should resolve to one ollama agent"
+
+let test_resolve_stateful () =
+  let available = ["ollama-gentle-gecko"; "ollama-bold-shark"; "gemini-swift-tiger"] in
+  let targets = Mention.resolve_targets (Mention.Stateful "ollama-gentle-gecko") ~available_agents:available in
+  match targets with
+  | ["ollama-gentle-gecko"] -> ()
+  | _ -> Alcotest.fail "Should resolve to exact match only"
+
+let test_resolve_broadcast () =
+  let available = ["ollama-gentle-gecko"; "ollama-bold-shark"; "gemini-swift-tiger"] in
+  let targets = Mention.resolve_targets (Mention.Broadcast "ollama") ~available_agents:available in
+  if List.length targets = 2 && List.for_all (fun n -> String.sub n 0 6 = "ollama") targets then
+    ()
+  else
+    Alcotest.fail "Should resolve to all ollama agents"
+
+(* ===== Agent Type Extraction Tests ===== *)
+
+let test_agent_type_extraction () =
+  let cases = [
+    ("ollama", "ollama");
+    ("ollama-gentle-gecko", "ollama");
+    ("gemini-swift-tiger", "gemini");
+    ("claude_v2", "claude_v2");  (* underscore stays *)
+  ] in
+  List.iter (fun (input, expected) ->
+    let result = Mention.agent_type_of_mention input in
+    if result <> expected then
+      Alcotest.fail (Printf.sprintf
+        "Agent type extraction failed: '%s' => got '%s', expected '%s'"
+        input result expected)
+  ) cases
+
+(* ===== Backward Compatibility Tests ===== *)
+
+let test_extract_backward_compat () =
+  let cases = [
+    ("@ollama", Some "ollama");
+    ("@ollama-gentle-gecko", Some "ollama-gentle-gecko");
+    ("@@gemini", Some "gemini");
+    ("Hello world", None);
+  ] in
+  List.iter (fun (content, expected) ->
+    let result = Mention.extract content in
+    if result <> expected then
+      Alcotest.fail (Printf.sprintf
+        "Extract backward compat failed: '%s' => got %s"
+        content (match result with Some s -> s | None -> "None"))
+  ) cases
+
+(* ===== Test Suite ===== *)
+
+let () =
+  let open Alcotest in
+  run "Mention Parsing" [
+    "stateless", [
+      test_case "basic" `Quick test_stateless_basic;
+      test_case "underscore" `Quick test_stateless_with_underscore;
+    ];
+    "stateful", [
+      test_case "nickname" `Quick test_stateful_nickname;
+    ];
+    "broadcast", [
+      test_case "basic" `Quick test_broadcast_basic;
+    ];
+    "none", [
+      test_case "no_mention" `Quick test_no_mention;
+    ];
+    "priority", [
+      test_case "broadcast_over_stateless" `Quick test_broadcast_priority;
+      test_case "stateful_detection" `Quick test_stateful_priority;
+    ];
+    "edge_cases", [
+      test_case "korean" `Quick test_korean_message;
+      test_case "multiple" `Quick test_multiple_mentions;
+    ];
+    "resolution", [
+      test_case "stateless" `Quick test_resolve_stateless;
+      test_case "stateful" `Quick test_resolve_stateful;
+      test_case "broadcast" `Quick test_resolve_broadcast;
+    ];
+    "utility", [
+      test_case "agent_type" `Quick test_agent_type_extraction;
+      test_case "backward_compat" `Quick test_extract_backward_compat;
+    ];
+  ]

--- a/test/test_mention_monkey.ml
+++ b/test/test_mention_monkey.ml
@@ -1,0 +1,127 @@
+(** Monkey/Fuzz testing for Mention module *)
+
+open Masc_mcp
+
+(** Random string generator *)
+let random_string len =
+  let chars = "abcdefghijklmnopqrstuvwxyz0123456789_-@" in
+  String.init len (fun _ -> chars.[Random.int (String.length chars)])
+
+(** Generate random mention-like strings *)
+let random_mention () =
+  let patterns = [
+    (* Valid patterns *)
+    (fun () -> Printf.sprintf "@%s" (random_string (1 + Random.int 10)));
+    (fun () -> Printf.sprintf "@@%s" (random_string (1 + Random.int 10)));
+    (fun () -> Printf.sprintf "@%s-%s-%s"
+      (random_string (2 + Random.int 5))
+      (random_string (2 + Random.int 5))
+      (random_string (2 + Random.int 5)));
+    (* Edge cases *)
+    (fun () -> "@");
+    (fun () -> "@@");
+    (fun () -> "@-");
+    (fun () -> "@_");
+    (fun () -> "@ ");
+    (fun () -> "@\n");
+    (fun () -> "@\t");
+    (fun () -> String.make (1 + Random.int 1000) '@');
+    (fun () -> "@" ^ String.make (Random.int 500) 'a');
+    (fun () -> random_string (Random.int 100));
+    (* Unicode attempts *)
+    (fun () -> "@한글");
+    (fun () -> "@émoji");
+    (fun () -> "@🚀");
+    (* Injection attempts *)
+    (fun () -> "@agent; rm -rf /");
+    (fun () -> "@agent\x00null");
+    (fun () -> "@agent<script>");
+  ] in
+  let gen = List.nth patterns (Random.int (List.length patterns)) in
+  gen ()
+
+(** Test that parse never crashes *)
+let test_no_crash () =
+  let iterations = 10000 in
+  let start = Unix.gettimeofday () in
+  for _ = 1 to iterations do
+    let input = random_mention () in
+    let _ = Mention.parse input in
+    let _ = Mention.extract input in
+    ()
+  done;
+  let elapsed = Unix.gettimeofday () -. start in
+  Printf.printf "✅ %d iterations in %.3fs (%.0f ops/sec)\n"
+    iterations elapsed (float_of_int iterations /. elapsed)
+
+(** Test that extract result is consistent with parse *)
+let test_consistency () =
+  let failures = ref 0 in
+  for _ = 1 to 1000 do
+    let input = random_mention () in
+    let mode = Mention.parse input in
+    let extract = Mention.extract input in
+    let consistent = match mode, extract with
+      | Mention.None, None -> true
+      | Mention.Stateless s, Some e -> s = e
+      | Mention.Stateful s, Some e -> s = e
+      | Mention.Broadcast s, Some e -> s = e
+      | _ -> false
+    in
+    if not consistent then begin
+      Printf.printf "❌ Inconsistent: input=%S mode=%s extract=%s\n"
+        input (Mention.mode_to_string mode)
+        (match extract with Some s -> s | None -> "None");
+      incr failures
+    end
+  done;
+  if !failures = 0 then
+    Printf.printf "✅ 1000 consistency checks passed\n"
+  else
+    Printf.printf "❌ %d consistency failures\n" !failures
+
+(** Test very long inputs *)
+let test_long_inputs () =
+  let lengths = [100; 1000; 10000; 100000] in
+  List.iter (fun len ->
+    let input = "@" ^ String.make len 'a' in
+    let start = Unix.gettimeofday () in
+    let _ = Mention.parse input in
+    let elapsed = Unix.gettimeofday () -. start in
+    if elapsed > 0.1 then
+      Printf.printf "⚠️  Length %d took %.3fs (slow!)\n" len elapsed
+    else
+      Printf.printf "✅ Length %d: %.4fs\n" len elapsed
+  ) lengths
+
+(** Test concurrent access (if applicable) *)
+let test_rapid_fire () =
+  let count = 50000 in
+  let start = Unix.gettimeofday () in
+  for i = 1 to count do
+    let input = Printf.sprintf "@agent-%d-test" i in
+    let _ = Mention.parse input in
+    ()
+  done;
+  let elapsed = Unix.gettimeofday () -. start in
+  Printf.printf "✅ Rapid fire: %d parses in %.3fs (%.0f ops/sec)\n"
+    count elapsed (float_of_int count /. elapsed)
+
+let () =
+  Random.self_init ();
+  Printf.printf "\n🐒 Mention Monkey Test\n";
+  Printf.printf "========================\n\n";
+
+  Printf.printf "1. Crash resistance (10,000 random inputs):\n";
+  test_no_crash ();
+
+  Printf.printf "\n2. Parse/Extract consistency:\n";
+  test_consistency ();
+
+  Printf.printf "\n3. Long input performance:\n";
+  test_long_inputs ();
+
+  Printf.printf "\n4. Rapid fire (50,000 sequential):\n";
+  test_rapid_fire ();
+
+  Printf.printf "\n🎉 Monkey test complete!\n"

--- a/test/test_walph.ml
+++ b/test/test_walph.ml
@@ -1,0 +1,99 @@
+(* Walph Wiggum 종합 검증 테스트 *)
+
+open Alcotest
+module R = Masc_mcp.Room
+
+(* 1. 형식증명: preset → chain ID 매핑 *)
+let test_chain_mapping () =
+  check (option string) "coverage preset"
+    (Some "walph-coverage") (R.get_chain_id_for_preset "coverage");
+  check (option string) "refactor preset"
+    (Some "walph-refactor") (R.get_chain_id_for_preset "refactor");
+  check (option string) "docs preset"
+    (Some "walph-docs") (R.get_chain_id_for_preset "docs");
+  check (option string) "drain preset"
+    None (R.get_chain_id_for_preset "drain");
+  check (option string) "unknown preset"
+    None (R.get_chain_id_for_preset "unknown")
+
+(* 2. 반대로: @walph 명령어 파싱 - 정상 케이스 *)
+let test_command_parsing_valid () =
+  let check_cmd input expected_cmd =
+    match R.parse_walph_command input with
+    | Some (cmd, _) ->
+        check string ("parse " ^ input)
+          expected_cmd (String.uppercase_ascii cmd)
+    | None ->
+        fail ("Expected Some for: " ^ input)
+  in
+  check_cmd "@walph STOP" "STOP";
+  check_cmd "@walph PAUSE" "PAUSE";
+  check_cmd "@walph RESUME" "RESUME";
+  check_cmd "@walph STATUS" "STATUS";
+  check_cmd "@walph START coverage" "START"
+
+(* 3. 반대로: @walph 명령어 파싱 - 무시할 케이스 *)
+let test_command_parsing_invalid () =
+  let check_none input =
+    match R.parse_walph_command input with
+    | None -> ()
+    | Some _ -> fail ("Expected None for: " ^ input)
+  in
+  check_none "hello world";
+  check_none "just some text"
+
+(* 4. 수직 확장: UTF-8 접두사 체크 *)
+let test_utf8_prefix () =
+  let starts_with prefix s =
+    let plen = String.length prefix in
+    String.length s >= plen && String.sub s 0 plen = prefix
+  in
+  check bool "emoji 📋 prefix" true (starts_with "📋" "📋 No unclaimed tasks");
+  check bool "emoji ✅ prefix" true (starts_with "✅" "✅ claude claimed task-1");
+  check bool "text No prefix" true (starts_with "No" "No unclaimed tasks");
+  check bool "wrong emoji" false (starts_with "📋" "No unclaimed tasks")
+
+(* 5. 수평 확장: 대소문자 무시 *)
+let test_case_insensitive () =
+  let check_cmd input expected_cmd =
+    match R.parse_walph_command input with
+    | Some (cmd, _) ->
+        check string ("parse " ^ input)
+          expected_cmd (String.uppercase_ascii cmd)
+    | None ->
+        fail ("Expected Some for: " ^ input)
+  in
+  check_cmd "@WALPH stop" "STOP";
+  check_cmd "@Walph Pause" "PAUSE";
+  check_cmd "@wAlPh ResuMe" "RESUME"
+
+(* 6. Recursive: 중첩 패턴 *)
+let test_recursive_patterns () =
+  (* 첫 번째 @walph 이후 명령어만 추출 *)
+  match R.parse_walph_command "@walph @walph STOP" with
+  | Some (cmd, _) ->
+      check string "nested @walph" "@WALPH" (String.uppercase_ascii cmd)
+  | None ->
+      (* @walph 뒤에 @walph이 오면 "@walph"이 명령어로 파싱됨 - 이건 OK *)
+      ()
+
+(* Test suite *)
+let () =
+  run "Walph Wiggum Tests" [
+    "형식증명", [
+      test_case "chain_mapping" `Quick test_chain_mapping;
+    ];
+    "반대로", [
+      test_case "valid_commands" `Quick test_command_parsing_valid;
+      test_case "invalid_commands" `Quick test_command_parsing_invalid;
+    ];
+    "수직확장", [
+      test_case "utf8_prefix" `Quick test_utf8_prefix;
+    ];
+    "수평확장", [
+      test_case "case_insensitive" `Quick test_case_insensitive;
+    ];
+    "recursive", [
+      test_case "nested_patterns" `Quick test_recursive_patterns;
+    ];
+  ]

--- a/test/test_walph_eio.ml
+++ b/test/test_walph_eio.ml
@@ -1,0 +1,220 @@
+(** Eio-native Walph Wiggum Tests
+
+    Verifies that Room_walph_eio works correctly in Eio fiber context:
+    1. Non-blocking mutex (fiber-friendly)
+    2. Condition variable based pause/resume
+    3. Concurrent control from multiple fibers
+    4. No zombie states on exceptions
+*)
+
+open Alcotest
+
+(** Test fixture: Create isolated config with Eio environment *)
+let with_test_config name f =
+  Eio_main.run @@ fun env ->
+  let tmp_dir = Filename.concat (Filename.get_temp_dir_name ())
+    (Printf.sprintf "walph_eio_%s_%d_%d" name (Unix.getpid ())
+      (int_of_float (Unix.gettimeofday () *. 1000.))) in
+  Unix.mkdir tmp_dir 0o755;
+  let fs = Eio.Stdenv.fs env in
+  let config = Masc_mcp.Room.default_config tmp_dir in
+  let _ = Masc_mcp.Room.init config ~agent_name:(Some "test-eio-agent") in
+  Fun.protect
+    ~finally:(fun () ->
+      let _ = Masc_mcp.Room.reset config in
+      let path = Masc_mcp.Room.masc_dir config in
+      if Sys.file_exists path then
+        let _ = Sys.command (Printf.sprintf "rm -rf %s" path) in ();
+      let parent = Filename.dirname path in
+      if Sys.file_exists parent then
+        try Unix.rmdir parent with _ -> ())
+    (fun () -> f env fs config)
+
+(** Test: Basic state machine in Eio context *)
+let test_eio_basic_state () =
+  with_test_config "basic" @@ fun _env _fs config ->
+  let state = Masc_mcp.Room_walph_eio.get_walph_state config ~agent_name:"tester" in
+  check bool "not running initially" false state.running;
+  check bool "not paused initially" false state.paused
+
+(** Test: Control commands work in Eio context *)
+let test_eio_control_commands () =
+  with_test_config "control" @@ fun _env _fs config ->
+  let state = Masc_mcp.Room_walph_eio.get_walph_state config ~agent_name:"tester" in
+
+  (* Simulate running state *)
+  Eio.Mutex.use_rw ~protect:true state.mutex (fun () ->
+    state.running <- true
+  );
+
+  (* Test PAUSE *)
+  let _ = Masc_mcp.Room_walph_eio.walph_control config
+    ~from_agent:"tester" ~command:"PAUSE" ~args:"" () in
+  check bool "paused after PAUSE" true state.paused;
+
+  (* Test RESUME *)
+  let _ = Masc_mcp.Room_walph_eio.walph_control config
+    ~from_agent:"tester" ~command:"RESUME" ~args:"" () in
+  check bool "not paused after RESUME" false state.paused;
+
+  (* Test STOP *)
+  let _ = Masc_mcp.Room_walph_eio.walph_control config
+    ~from_agent:"tester" ~command:"STOP" ~args:"" () in
+  check bool "stop requested after STOP" true state.stop_requested
+
+(** Test: Concurrent control from multiple fibers *)
+let test_eio_concurrent_control () =
+  with_test_config "concurrent" @@ fun _env _fs config ->
+  let state = Masc_mcp.Room_walph_eio.get_walph_state config ~agent_name:"tester" in
+
+  (* Set running *)
+  Eio.Mutex.use_rw ~protect:true state.mutex (fun () ->
+    state.running <- true
+  );
+
+  (* Run PAUSE and RESUME concurrently in separate fibers *)
+  let pause_count = ref 0 in
+  let resume_count = ref 0 in
+
+  Eio.Fiber.both
+    (fun () ->
+      for _ = 1 to 10 do
+        let _ = Masc_mcp.Room_walph_eio.walph_control config
+          ~from_agent:"fiber1" ~command:"PAUSE" ~args:"" () in
+        incr pause_count
+      done)
+    (fun () ->
+      for _ = 1 to 10 do
+        let _ = Masc_mcp.Room_walph_eio.walph_control config
+          ~from_agent:"fiber2" ~command:"RESUME" ~args:"" () in
+        incr resume_count
+      done);
+
+  check int "all pauses executed" 10 !pause_count;
+  check int "all resumes executed" 10 !resume_count
+
+(** Test: State isolation between agents in Eio context *)
+let test_eio_room_isolation () =
+  with_test_config "isolation" @@ fun _env _fs config ->
+  (* Now we test agent isolation within same room *)
+  let state1 = Masc_mcp.Room_walph_eio.get_walph_state config ~agent_name:"agent1" in
+  let state2 = Masc_mcp.Room_walph_eio.get_walph_state config ~agent_name:"agent2" in
+
+  (* Modify state1 *)
+  Eio.Mutex.use_rw ~protect:true state1.mutex (fun () ->
+    state1.running <- true;
+    state1.iterations <- 100
+  );
+
+  (* state2 should be unaffected - different agent, same room *)
+  check bool "state2 not running" false state2.running;
+  check int "state2 zero iterations" 0 state2.iterations
+
+(** Test: Cleanup function with zombie prevention *)
+let test_eio_cleanup () =
+  with_test_config "cleanup" @@ fun _env _fs config ->
+  (* Create and modify state *)
+  let state = Masc_mcp.Room_walph_eio.get_walph_state config ~agent_name:"tester" in
+  Eio.Mutex.use_rw ~protect:true state.mutex (fun () ->
+    state.running <- true
+  );
+
+  (* Remove should FAIL when running (zombie prevention) *)
+  let remove_failed = try
+    Masc_mcp.Room_walph_eio.remove_walph_state config ~agent_name:"tester";
+    false  (* Should not reach here *)
+  with Failure _ -> true in
+  check bool "remove fails when running" true remove_failed;
+
+  (* Stop the state first *)
+  Eio.Mutex.use_rw ~protect:true state.mutex (fun () ->
+    state.running <- false
+  );
+
+  (* Now remove should succeed *)
+  Masc_mcp.Room_walph_eio.remove_walph_state config ~agent_name:"tester";
+
+  (* Getting state again should return fresh state *)
+  let new_state = Masc_mcp.Room_walph_eio.get_walph_state config ~agent_name:"tester" in
+  check bool "new state not running" false new_state.running
+
+(** Test: 3 agents running Walph simultaneously (Phase 1 feature) *)
+let test_eio_multi_agent_walph () =
+  with_test_config "multi_agent" @@ fun _env _fs config ->
+  (* 3 agents get their own independent Walph states *)
+  let state_claude = Masc_mcp.Room_walph_eio.get_walph_state config ~agent_name:"claude" in
+  let state_codex = Masc_mcp.Room_walph_eio.get_walph_state config ~agent_name:"codex" in
+  let state_gemini = Masc_mcp.Room_walph_eio.get_walph_state config ~agent_name:"gemini" in
+
+  (* All start as not running *)
+  check bool "claude not running initially" false state_claude.running;
+  check bool "codex not running initially" false state_codex.running;
+  check bool "gemini not running initially" false state_gemini.running;
+
+  (* Each agent can set running=true independently (simulating walph_loop start) *)
+  Eio.Mutex.use_rw ~protect:true state_claude.mutex (fun () ->
+    state_claude.running <- true;
+    state_claude.current_preset <- "drain"
+  );
+  Eio.Mutex.use_rw ~protect:true state_codex.mutex (fun () ->
+    state_codex.running <- true;
+    state_codex.current_preset <- "coverage"
+  );
+  Eio.Mutex.use_rw ~protect:true state_gemini.mutex (fun () ->
+    state_gemini.running <- true;
+    state_gemini.current_preset <- "refactor"
+  );
+
+  (* All 3 are now running simultaneously - no conflict! *)
+  check bool "claude running" true state_claude.running;
+  check bool "codex running" true state_codex.running;
+  check bool "gemini running" true state_gemini.running;
+
+  (* Each has different preset *)
+  check string "claude preset" "drain" state_claude.current_preset;
+  check string "codex preset" "coverage" state_codex.current_preset;
+  check string "gemini preset" "refactor" state_gemini.current_preset;
+
+  (* Pause only claude - others unaffected *)
+  let _ = Masc_mcp.Room_walph_eio.walph_control config
+    ~from_agent:"claude" ~command:"PAUSE" ~args:"" () in
+  check bool "claude paused" true state_claude.paused;
+  check bool "codex not paused" false state_codex.paused;
+  check bool "gemini not paused" false state_gemini.paused
+
+(** Test: list_walph_states returns all active agents *)
+let test_eio_list_walph_states () =
+  with_test_config "list_states" @@ fun _env _fs config ->
+  (* Create states for 3 agents *)
+  let _ = Masc_mcp.Room_walph_eio.get_walph_state config ~agent_name:"agent-a" in
+  let _ = Masc_mcp.Room_walph_eio.get_walph_state config ~agent_name:"agent-b" in
+  let _ = Masc_mcp.Room_walph_eio.get_walph_state config ~agent_name:"agent-c" in
+
+  (* List all states *)
+  let states = Masc_mcp.Room_walph_eio.list_walph_states config in
+  check int "3 agents in room" 3 (List.length states);
+
+  (* Check agent names are present *)
+  let agent_names = List.map fst states in
+  check bool "has agent-a" true (List.mem "agent-a" agent_names);
+  check bool "has agent-b" true (List.mem "agent-b" agent_names);
+  check bool "has agent-c" true (List.mem "agent-c" agent_names)
+
+(* ============================================
+   Test Registration
+   ============================================ *)
+
+let eio_tests = [
+  "basic state in Eio", `Quick, test_eio_basic_state;
+  "control commands in Eio", `Quick, test_eio_control_commands;
+  "concurrent control", `Quick, test_eio_concurrent_control;
+  "room isolation in Eio", `Quick, test_eio_room_isolation;
+  "cleanup function", `Quick, test_eio_cleanup;
+  "multi-agent Walph", `Quick, test_eio_multi_agent_walph;
+  "list walph states", `Quick, test_eio_list_walph_states;
+]
+
+let () =
+  run "Walph Eio" [
+    "Eio Native", eio_tests;
+  ]


### PR DESCRIPTION
## Summary
- **Walph System**: Autonomous task loop inspired by Geoffrey Huntley's Ralph Wiggum technique
  - Claim → Work → Done cycle until stop condition
  - STOP/PAUSE/RESUME control via broadcast
  - Swarm coordination for multiple instances
- **Hat System**: Role-based personas for agent specialization
  - Builder 🔨, Reviewer 🔍, Tester 🧪, etc.
  - `@agent:hat` mention format
  - Automatic rotation (TDD, ReviewLoop)

## New Files
| File | Description |
|------|-------------|
| `lib/room_walph_eio.ml` | Walph loop + Swarm control |
| `lib/hat.ml` | Hat system core |
| `lib/llm_client_eio.ml` | LLM intent classification |
| `test/test_hat.ml` | 8 tests |
| `test/test_walph_eio.ml` | 7 tests |

## MCP Tools
- `masc_walph_start`, `masc_walph_control`, `masc_walph_natural`
- `masc_swarm_walph`
- `masc_hat_wear`, `masc_hat_status`

## Credits
- [Geoffrey Huntley's Ralph Wiggum](https://ghuntley.com/ralph/)
- [ralph-orchestrator Hat System](https://github.com/mikeyobrien/ralph-orchestrator)

## Test plan
- [x] `dune runtest` passes (15 tests)
- [x] Hat serialization/parsing verified
- [x] Walph state management verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)