### PR TITLE
ci: 릴리즈 워크플로 mcp_protocol pin 경로 정정

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Pin private dependencies
         run: |
           opam pin add compact-protocol https://github.com/jeong-sik/compact-protocol.git#main -n -y
-          opam pin add mcp_protocol https://github.com/jeong-sik/mcp-protocol-ocaml.git#main -n -y
+          opam pin add mcp_protocol https://github.com/jeong-sik/mcp-protocol-sdk.git#main -n -y
           opam pin add grpc-direct-core https://github.com/jeong-sik/grpc-direct.git#main -n -y
 
       - name: Install dependencies


### PR DESCRIPTION
## 변경 내용
- 릴리즈 워크플로의 mcp_protocol pin 소스를 mcp-protocol-ocaml → mcp-protocol-sdk로 정정
- CI(.github/workflows/ci.yml)와 동일한 pin 경로로 통일

## 배경
- Release 워크플로가 "Pin private dependencies" 단계에서 짧게 실패하는 이력이 있음
- CI는 mcp-protocol-sdk를 사용 중이라 경로 불일치 가능성이 높음

## 검증
- dune build --root .
- dune runtest --root .
