### PR TITLE
chain timeout 및 rate_limit cleanup 보강

### DIFF
--- a/lib/mcp_server_eio.ml
+++ b/lib/mcp_server_eio.ml
@@ -1135,7 +1135,7 @@ let execute_tool_eio ~sw ~clock ?mcp_session_id state ~name ~arguments =
       let target = match get_string "target" "" with "" -> None | t -> Some t in
       (* Use Eio-native Walph for production (fiber-safe, non-blocking) *)
       let net = get_net () in
-      (true, Room_walph_eio.walph_loop config ~net ~agent_name ~preset ~max_iterations ?target ())
+      (true, Room_walph_eio.walph_loop config ~net ~clock ~agent_name ~preset ~max_iterations ?target ())
 
   | "masc_walph_control" ->
       let command = get_string "command" "STATUS" in
@@ -1187,16 +1187,16 @@ let execute_tool_eio ~sw ~clock ?mcp_session_id state ~name ~arguments =
             (true, Room_walph_eio.walph_control config ~from_agent:agent_name ~command:"STATUS" ~args:"" ())
         | `Start_coverage ->
             let net = get_net () in
-            (true, Room_walph_eio.walph_loop config ~net ~agent_name ~preset:"coverage" ~max_iterations:10 ())
+            (true, Room_walph_eio.walph_loop config ~net ~clock ~agent_name ~preset:"coverage" ~max_iterations:10 ())
         | `Start_refactor ->
             let net = get_net () in
-            (true, Room_walph_eio.walph_loop config ~net ~agent_name ~preset:"refactor" ~max_iterations:10 ())
+            (true, Room_walph_eio.walph_loop config ~net ~clock ~agent_name ~preset:"refactor" ~max_iterations:10 ())
         | `Start_docs ->
             let net = get_net () in
-            (true, Room_walph_eio.walph_loop config ~net ~agent_name ~preset:"docs" ~max_iterations:10 ())
+            (true, Room_walph_eio.walph_loop config ~net ~clock ~agent_name ~preset:"docs" ~max_iterations:10 ())
         | `Start_drain ->
             let net = get_net () in
-            (true, Room_walph_eio.walph_loop config ~net ~agent_name ~preset:"drain" ~max_iterations:10 ())
+            (true, Room_walph_eio.walph_loop config ~net ~clock ~agent_name ~preset:"drain" ~max_iterations:10 ())
       end
 
   | "masc_swarm_walph" ->

--- a/lib/rate_limit.ml
+++ b/lib/rate_limit.ml
@@ -93,7 +93,7 @@ let cleanup limiter ~older_than_seconds =
     let now = Unix.gettimeofday () in
     let threshold = now -. float_of_int older_than_seconds in
     let to_remove = Hashtbl.fold (fun key bucket acc ->
-      if bucket.last_update < threshold then key :: acc
+      if bucket.last_update <= threshold then key :: acc
       else acc
     ) limiter.buckets [] in
     List.iter (Hashtbl.remove limiter.buckets) to_remove;

--- a/lib/room_walph_eio.ml
+++ b/lib/room_walph_eio.ml
@@ -209,11 +209,12 @@ let get_chain_id_for_preset = function
     Eio-native implementation with fiber-safe concurrency.
 
     @param net Eio network capability (for llm-mcp chain calls)
+    @param clock Eio clock capability (for hard timeouts)
     @param preset Loop preset (drain, coverage, refactor, docs)
     @param max_iterations Maximum iterations before forced stop
     @param target Target file/directory for preset
     @return Status string with loop results *)
-let walph_loop config ~net ~agent_name ?(preset="drain") ?(max_iterations=10) ?target () =
+let walph_loop config ~net ~clock ~agent_name ?(preset="drain") ?(max_iterations=10) ?target () =
   Room.ensure_initialized config;
 
   (* Get Walph state for this specific agent *)
@@ -339,7 +340,7 @@ let walph_loop config ~net ~agent_name ?(preset="drain") ?(max_iterations=10) ?t
                       in
                       let _ = Room.broadcast config ~from_agent:agent_name
                         ~content:(Printf.sprintf "🔗 @walph calling chain '%s' for '%s'..." cid task_title) in
-                      Llm_client_eio.call_chain ~net ~goal ~chain_id:cid ()
+                      Llm_client_eio.call_chain ~net ~clock ~goal ~chain_id:cid ()
                   in
 
                   (match chain_result with

--- a/test/test_rate_limit_coverage.ml
+++ b/test/test_rate_limit_coverage.ml
@@ -97,10 +97,9 @@ let test_remaining_multiple () =
 let test_cleanup_removes_old () =
   let limiter = Rate_limit.create () in
   let _ = Rate_limit.check limiter ~key:"old" in
-  (* Ensure entry is older than the cleanup threshold. *)
-  Unix.sleepf 0.001;
+  (* Cleanup with 0 threshold: anything created before cleanup is considered old *)
   let removed = Rate_limit.cleanup limiter ~older_than_seconds:0 in
-  check bool "removed old entries" true (removed >= 1)
+  check int "removes immediately when threshold=0" 1 removed
 
 let test_cleanup_keeps_recent () =
   let limiter = Rate_limit.create () in


### PR DESCRIPTION
- call_chain 하드 타임아웃(clock 주입) + JSON 응답 파싱\n- walph loop clock 전달\n- rate_limit cleanup 기준/테스트 안정화