### PR TITLE
room_enter 이동 중복 제거 및 status 보강

### DIFF
--- a/lib/tool_room.ml
+++ b/lib/tool_room.ml
@@ -70,7 +70,7 @@ let handle_room_enter ctx args =
     (false, "❌ Room ID is required")
   else
     let agent_type = get_string args "agent_type" "claude" in
-    let result = Room.room_enter ctx.config ~room_id ~agent_type in
+    let result = Room.room_enter ctx.config ~room_id ~agent_type ~agent_name:ctx.agent_name () in
     let success = match result with
       | `Assoc fields -> not (List.mem_assoc "error" fields)
       | _ -> false


### PR DESCRIPTION
## 요약\n- room_enter 시 이전 방에서 에이전트 중복 제거\n- masc_room_enter가 호출자 닉네임을 유지하도록 전달\n- masc_status에 클러스터명 표시 보강\n- 멀티룸 테스트에 에이전트 이동 케이스 추가\n\n## 테스트\n- dune exec ./test/test_multi_room.exe