### PR TITLE
docs: README에 검증 절차 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,16 @@ OCaml로 만든 개인용 MCP 서버입니다.
 curl http://127.0.0.1:8935/health
 ```
 
+## 검증
+
+```bash
+# 최소 검증
+make test
+
+# 포맷 + 테스트 (CI 동일)
+make ci
+```
+
 ## MCP 설정
 
 `~/.mcp.json` 예시:


### PR DESCRIPTION
## 요약
README에 검증(테스트/CI) 절차를 추가했습니다.

## 변경사항
- README에 `make test`, `make ci` 안내 추가

## 테스트
- `make ci` (성공)
  - `dune fmt --check`는 옵션 미지원 메시지 출력되지만 `|| true` 처리로 CI 성공
