### PR TITLE
feat: 작업 보드 기본 필터 및 락 도구

### DIFF
--- a/bin/main_eio.ml
+++ b/bin/main_eio.ml
@@ -111,6 +111,15 @@ let int_query_param request key ~default =
   | None -> default
   | Some s -> (try int_of_string s with _ -> default)
 
+let bool_query_param request key ~default =
+  match query_param request key with
+  | None -> default
+  | Some s ->
+      let v = String.lowercase_ascii (String.trim s) in
+      if v = "1" || v = "true" || v = "yes" || v = "y" then true
+      else if v = "0" || v = "false" || v = "no" || v = "n" then false
+      else default
+
 let bearer_token_from_header value =
   let prefix = "Bearer " in
   let prefix_lower = "bearer " in
@@ -1003,6 +1012,8 @@ let make_routes ~port ~host =
        with_read_auth (fun state req reqd ->
          let config = state.Mcp_server.room_config in
          let status_filter = query_param req "status" in
+         let include_done = bool_query_param req "include_done" ~default:false in
+         let include_cancelled = bool_query_param req "include_cancelled" ~default:false in
          let limit = int_query_param req "limit" ~default:50 in
          let offset = int_query_param req "offset" ~default:0 in
          let tasks = Masc_mcp.Room.get_tasks_raw config in
@@ -1013,6 +1024,23 @@ let make_routes ~port ~host =
                List.filter (fun (t : Masc_mcp.Types.task) ->
                  String.equal status (Masc_mcp.Types.string_of_task_status t.task_status)
                ) tasks
+         in
+         let filtered =
+           match status_filter with
+           | Some _ -> filtered
+           | None ->
+               List.filter (fun (t : Masc_mcp.Types.task) ->
+                 let is_done = match t.task_status with
+                   | Types.Done _ -> true
+                   | _ -> false
+                 in
+                 let is_cancelled = match t.task_status with
+                   | Types.Cancelled _ -> true
+                   | _ -> false
+                 in
+                 (include_done || not is_done) &&
+                 (include_cancelled || not is_cancelled)
+               ) filtered
          in
          let total = List.length filtered in
          let page =

--- a/lib/dashboard.ml
+++ b/lib/dashboard.ml
@@ -185,6 +185,43 @@ let worktrees_section (config : Room_utils.config) : section =
   ) worktrees in
   { title = "Worktrees"; content; empty_msg = "(no worktrees)" }
 
+(** Count lock files under the locks directory (filesystem backend).
+    Ignores ".flock" metadata files. *)
+let rec count_lock_files path =
+  try
+    if Sys.file_exists path then
+      if Sys.is_directory path then
+        let entries = Sys.readdir path |> Array.to_list in
+        List.fold_left (fun acc name ->
+          let full = Filename.concat path name in
+          if Sys.is_directory full then
+            acc + count_lock_files full
+          else if Filename.check_suffix name ".flock" then
+            acc
+          else
+            acc + 1
+        ) 0 entries
+      else
+        0
+    else
+      0
+  with _ -> 0
+
+(** Count active locks across backends *)
+let count_locks (config : Room_utils.config) : int =
+  match config.backend with
+  | Room_utils.FileSystem _ ->
+      let locks_dir = Filename.concat (Room_utils.masc_dir config) "locks" in
+      count_lock_files locks_dir
+  | Room_utils.Memory _ ->
+      (match Room_utils.backend_list_keys config ~prefix:"locks:" with
+       | Ok keys -> List.length keys
+       | Error _ -> 0)
+  | Room_utils.PostgresNative _ ->
+      (match Room_utils.backend_list_keys config ~prefix:"lock:" with
+       | Ok keys -> List.length keys
+       | Error _ -> 0)
+
 (** Generate full dashboard *)
 let generate (config : Room_utils.config) : string =
   let now = Unix.gettimeofday () in
@@ -209,6 +246,7 @@ let generate (config : Room_utils.config) : string =
 let generate_compact (config : Room_utils.config) : string =
   let agents = Room.get_agents_raw config in
   let tasks = Room.get_tasks_raw config in
+  let locks = count_locks config in
   let tempo = Tempo.get_tempo config in
   let pending = List.filter (fun t -> t.Types.task_status = Types.Todo) tasks in
   let active = List.filter (fun t ->
@@ -217,8 +255,9 @@ let generate_compact (config : Room_utils.config) : string =
     | Types.Claimed _ -> true
     | _ -> false
   ) tasks in
-  Printf.sprintf "Agents: %d | Tasks: %d active, %d pending | Tempo: %.0fs"
+  Printf.sprintf "Agents: %d | Tasks: %d active, %d pending | Locks: %d | Tempo: %.0fs"
     (List.length agents)
     (List.length active)
     (List.length pending)
+    locks
     tempo.Tempo.current_interval_s

--- a/lib/mcp_server.ml
+++ b/lib/mcp_server.ml
@@ -185,13 +185,13 @@ let resources : mcp_resource list = [
   {
     uri = "masc://tasks";
     name = "Quest Board";
-    description = "Task board snapshot (same as masc_tasks)";
+    description = "Task board snapshot (defaults to active tasks; same as masc_tasks)";
     mime_type = "text/markdown";
   };
   {
     uri = "masc://tasks.json";
     name = "Quest Board (JSON)";
-    description = "Task board snapshot as JSON (backlog.json)";
+    description = "Task board snapshot as JSON (backlog.json; all statuses)";
     mime_type = "application/json";
   };
   {

--- a/lib/mcp_server_eio.ml
+++ b/lib/mcp_server_eio.ml
@@ -745,6 +745,7 @@ let execute_tool_eio ~sw ~clock ?mcp_session_id ?auth_token state ~name ~argumen
     "masc_vote_create"; "masc_vote_cast"; "masc_interrupt"; "masc_approve"; "masc_reject";
     "masc_portal_open"; "masc_portal_send"; "masc_portal_close";
     "masc_deliver"; "masc_note_add"; "masc_error_add"; "masc_error_resolve";
+    "masc_lock"; "masc_unlock";
   ] in
 
   (* Check if agent must join first *)
@@ -909,6 +910,79 @@ let execute_tool_eio ~sw ~clock ?mcp_session_id ?auth_token state ~name ~argumen
   | None ->
 
   match name with
+  | "masc_lock" ->
+      let file = get_string "file" "" in
+      if file = "" then
+        (false, "❌ file is required")
+      else begin
+        let expanded =
+          if String.length file > 0 && file.[0] = '~' then
+            match Sys.getenv_opt "HOME" with
+            | Some home -> Filename.concat home (String.sub file 1 (String.length file - 1))
+            | None -> file
+          else if Filename.is_relative file then
+            Filename.concat config.base_path file
+          else
+            file
+        in
+        match Room_utils.key_of_path_from_root config ~root:config.base_path expanded with
+        | None ->
+            (false, Printf.sprintf "❌ file must be under base_path: %s" config.base_path)
+        | Some key ->
+            let ttl_seconds = config.lock_expiry_minutes * 60 in
+            let now = Unix.gettimeofday () in
+            let expires_at = now +. float_of_int ttl_seconds in
+            (match Room_utils.backend_acquire_lock config ~key ~ttl_seconds ~owner:agent_name with
+             | Ok true ->
+                 let payload = `Assoc [
+                   ("status", `String "acquired");
+                   ("resource", `String expanded);
+                   ("key", `String key);
+                   ("owner", `String agent_name);
+                   ("acquired_at", `Float now);
+                   ("expires_at", `Float expires_at);
+                 ] in
+                 (true, Yojson.Safe.pretty_to_string payload)
+             | Ok false ->
+                 (false, Printf.sprintf "❌ Lock busy: %s" expanded)
+             | Error e ->
+                 (false, Printf.sprintf "❌ Lock error: %s" (Backend.show_error e)))
+      end
+
+  | "masc_unlock" ->
+      let file = get_string "file" "" in
+      if file = "" then
+        (false, "❌ file is required")
+      else begin
+        let expanded =
+          if String.length file > 0 && file.[0] = '~' then
+            match Sys.getenv_opt "HOME" with
+            | Some home -> Filename.concat home (String.sub file 1 (String.length file - 1))
+            | None -> file
+          else if Filename.is_relative file then
+            Filename.concat config.base_path file
+          else
+            file
+        in
+        match Room_utils.key_of_path_from_root config ~root:config.base_path expanded with
+        | None ->
+            (false, Printf.sprintf "❌ file must be under base_path: %s" config.base_path)
+        | Some key ->
+            (match Room_utils.backend_release_lock config ~key ~owner:agent_name with
+             | Ok true ->
+                 let payload = `Assoc [
+                   ("status", `String "released");
+                   ("resource", `String expanded);
+                   ("key", `String key);
+                   ("owner", `String agent_name);
+                 ] in
+                 (true, Yojson.Safe.pretty_to_string payload)
+             | Ok false ->
+                 (false, Printf.sprintf "❌ Lock not held by %s: %s" agent_name expanded)
+             | Error e ->
+                 (false, Printf.sprintf "❌ Lock release error: %s" (Backend.show_error e)))
+      end
+
   | "masc_set_room" ->
       let path = get_string "path" "" in
       let expanded =

--- a/lib/room.ml
+++ b/lib/room.ml
@@ -1574,18 +1574,41 @@ let get_messages_raw config ~since_seq ~limit =
     |> (fun msgs -> List.filteri (fun i _ -> i < limit) msgs)
 
 (** List tasks *)
-let list_tasks config =
+let list_tasks ?(include_done = false) ?(include_cancelled = false) ?status config =
   ensure_initialized config;
 
   let backlog = read_backlog config in
-  if backlog.tasks = [] then
-    "📋 No tasks yet."
+  let tasks =
+    match status with
+    | Some status_filter ->
+        List.filter (fun (task : task) ->
+          String.equal status_filter (string_of_task_status task.task_status)
+        ) backlog.tasks
+    | None ->
+        List.filter (fun (task : task) ->
+          let is_done = match task.task_status with
+            | Done _ -> true
+            | _ -> false
+          in
+          let is_cancelled = match task.task_status with
+            | Cancelled _ -> true
+            | _ -> false
+          in
+          (include_done || not is_done) &&
+          (include_cancelled || not is_cancelled)
+        ) backlog.tasks
+  in
+  if tasks = [] then
+    if backlog.tasks = [] then
+      "📋 No tasks yet."
+    else
+      "📋 No active tasks. (use include_done=true or include_cancelled=true)"
   else begin
     let buf = Buffer.create 256 in
     Buffer.add_string buf "📋 Quest Board\n";
     Buffer.add_string buf "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n";
 
-    let sorted = List.sort (fun a b -> compare a.priority b.priority) backlog.tasks in
+    let sorted = List.sort (fun a b -> compare a.priority b.priority) tasks in
     List.iter (fun task ->
       let status_icon = match task.task_status with
         | Done _ -> "✅"

--- a/lib/tool_task.ml
+++ b/lib/tool_task.ml
@@ -24,6 +24,11 @@ let get_int args key default =
   | `Int i -> i
   | _ -> default
 
+let get_bool args key default =
+  match args |> member key with
+  | `Bool b -> b
+  | _ -> default
+
 let get_int_opt args key =
   match args |> member key with
   | `Int i -> Some i
@@ -229,8 +234,15 @@ let handle_update_priority ctx args =
   let priority = get_int args "priority" 3 in
   (true, Room.update_priority ctx.config ~task_id ~priority)
 
-let handle_tasks ctx _args =
-  (true, Room.list_tasks ctx.config)
+let handle_tasks ctx args =
+  let include_done = get_bool args "include_done" false in
+  let include_cancelled = get_bool args "include_cancelled" false in
+  let status =
+    match args |> member "status" with
+    | `String s when s <> "" -> Some s
+    | _ -> None
+  in
+  (true, Room.list_tasks ctx.config ~include_done ~include_cancelled ?status)
 
 let handle_task_history ctx args =
   let task_id = get_string args "task_id" "" in

--- a/lib/tools.ml
+++ b/lib/tools.ml
@@ -324,14 +324,65 @@ Example: masc_batch_add_tasks({tasks: [{title: 'Task A', priority: 2}, {title: '
   };
   {
     name = "masc_tasks";
-    description = "List all tasks in backlog with their status and assignee. \
-Shows: todo (available), claimed (in progress), done, cancelled. \
-Use before masc_claim to find available tasks. \
+    description = "List tasks in backlog with their status and assignee. \
+Defaults to active tasks (todo/claimed/in_progress). \
+Use include_done/include_cancelled or status to filter. \
 Output includes task ID, title, priority, assignee, timestamps. \
 Tip: Look for status='todo' tasks to claim.";
     input_schema = `Assoc [
       ("type", `String "object");
-      ("properties", `Assoc []);
+      ("properties", `Assoc [
+        ("status", `Assoc [
+          ("type", `String "string");
+          ("description", `String "Optional status filter: todo|claimed|in_progress|done|cancelled");
+        ]);
+        ("include_done", `Assoc [
+          ("type", `String "boolean");
+          ("description", `String "Include done tasks (default: false)");
+          ("default", `Bool false);
+        ]);
+        ("include_cancelled", `Assoc [
+          ("type", `String "boolean");
+          ("description", `String "Include cancelled tasks (default: false)");
+          ("default", `Bool false);
+        ]);
+      ]);
+    ];
+  };
+  {
+    name = "masc_lock";
+    description = "Acquire a lock for a file path (relative to project root). Use masc_unlock to release.";
+    input_schema = `Assoc [
+      ("type", `String "object");
+      ("properties", `Assoc [
+        ("agent_name", `Assoc [
+          ("type", `String "string");
+          ("description", `String "Your agent name");
+        ]);
+        ("file", `Assoc [
+          ("type", `String "string");
+          ("description", `String "File path to lock (relative to project root)");
+        ]);
+      ]);
+      ("required", `List [`String "agent_name"; `String "file"]);
+    ];
+  };
+  {
+    name = "masc_unlock";
+    description = "Release a lock for a file path (relative to project root).";
+    input_schema = `Assoc [
+      ("type", `String "object");
+      ("properties", `Assoc [
+        ("agent_name", `Assoc [
+          ("type", `String "string");
+          ("description", `String "Your agent name");
+        ]);
+        ("file", `Assoc [
+          ("type", `String "string");
+          ("description", `String "File path to unlock (relative to project root)");
+        ]);
+      ]);
+      ("required", `List [`String "agent_name"; `String "file"]);
     ];
   };
 


### PR DESCRIPTION
## 변경 사항
- tasks 기본 목록에서 done/cancelled 제외(옵션 include_done/include_cancelled 추가)
- /api/v1/tasks 쿼리: status/include_done/include_cancelled 지원
- MCP: masc_tasks 스키마 갱신 + masc_lock/masc_unlock 도구 추가

## 테스트
- dune runtest --root .