### PR TITLE
test(council): add Archive module tests

### DIFF
--- a/test/test_council.ml
+++ b/test/test_council.ml
@@ -343,6 +343,60 @@ let executor_tests = [
   "dry run reject", `Quick, test_executor_dry_run_reject;
 ]
 
+(* ============================================================
+   Archive Tests
+   ============================================================ *)
+
+module Archive = Council.Archive
+
+let test_archive_record_to_json () =
+  let record : Archive.record = {
+    id = "test-001";
+    type_ = Archive.Debate;
+    content = "Test content";
+    agents = ["agent1"; "agent2"];
+    timestamp = "2026-02-01T12:00:00Z";
+    metadata = [("key", "value")];
+  } in
+  let json = Archive.record_to_yojson record in
+  let id = Yojson.Safe.Util.(json |> member "id" |> to_string) in
+  check string "id matches" id "test-001"
+
+let test_archive_record_roundtrip () =
+  let record : Archive.record = {
+    id = "test-002";
+    type_ = Archive.Vote;
+    content = "Vote content";
+    agents = ["voter1"];
+    timestamp = "2026-02-01T13:00:00Z";
+    metadata = [];
+  } in
+  let json = Archive.record_to_yojson record in
+  match Archive.record_of_yojson json with
+  | Ok parsed ->
+    check string "id" parsed.id record.id;
+    check string "content" parsed.content record.content
+  | Error e -> fail e
+
+let test_archive_record_type_strings () =
+  check string "debate" (Archive.record_type_to_string Archive.Debate) "debate";
+  check string "vote" (Archive.record_type_to_string Archive.Vote) "vote";
+  check string "decision" (Archive.record_type_to_string Archive.Decision) "decision";
+  check string "post" (Archive.record_type_to_string Archive.Post) "post"
+
+let test_archive_neo4j_url_check () =
+  (* This test checks if Neo4j URL is configured, doesn't require connection *)
+  match Sys.getenv_opt "RAILWAY_NEO4J_URL" with
+  | Some url -> check bool "has url" (String.length url > 0) true
+  | None -> check bool "no url configured" true true (* Skip gracefully *)
+
+let archive_tests = [
+  "record to json", `Quick, test_archive_record_to_json;
+  "record roundtrip", `Quick, test_archive_record_roundtrip;
+  "record type strings", `Quick, test_archive_record_type_strings;
+  "neo4j url check", `Quick, test_archive_neo4j_url_check;
+]
+
 let () =
   run "Council" [
     "Debate", debate_tests;
@@ -350,4 +404,5 @@ let () =
     "Router", router_tests;
     "Balance", balance_tests;
     "Executor", executor_tests;
+    "Archive", archive_tests;
   ]


### PR DESCRIPTION
## Summary
Add unit tests for Council Archive module.

## Tests
- record_to_json: JSON serialization
- record_roundtrip: serialize + deserialize
- record_type_strings: type enum conversions  
- neo4j_url_check: env var presence (graceful skip if not set)

Note: Actual Neo4j integration tests require live connection. These tests validate the serialization layer.