### PR TITLE
fix: finalizer 예외 가드 추가

### DIFF
--- a/lib/a2a_tools.ml
+++ b/lib/a2a_tools.ml
@@ -118,7 +118,7 @@ let save_subscriptions () =
     let content = Yojson.Safe.pretty_to_string json in
     try
       let oc = open_out !subscriptions_file in
-      Fun.protect ~finally:(fun () -> close_out_noerr oc) (fun () ->
+      Common.protect ~module_name:"a2a_tools" ~finally_label:"finalizer" ~finally:(fun () -> close_out_noerr oc) (fun () ->
         output_string oc content)
     with e ->
       Printf.eprintf "[WARN] save_subscriptions failed: %s\n%!" (Printexc.to_string e)

--- a/lib/agent_registry_eio.ml
+++ b/lib/agent_registry_eio.ml
@@ -21,7 +21,7 @@ let initialized = ref false
 (** Initialize the global registry. Must be called within Eio context. *)
 let init () =
   Mutex.lock registry_lock;
-  Fun.protect ~finally:(fun () -> Mutex.unlock registry_lock) (fun () ->
+  Common.protect ~module_name:"agent_registry_eio" ~finally_label:"finalizer" ~finally:(fun () -> Mutex.unlock registry_lock) (fun () ->
     if not !initialized then begin
       global_registry := Some (Agent_identity.Registry.create ());
       initialized := true
@@ -42,7 +42,7 @@ let get_registry () =
 (** Reset registry for testing *)
 let reset_for_testing () =
   Mutex.lock registry_lock;
-  Fun.protect ~finally:(fun () -> Mutex.unlock registry_lock) (fun () ->
+  Common.protect ~module_name:"agent_registry_eio" ~finally_label:"finalizer" ~finally:(fun () -> Mutex.unlock registry_lock) (fun () ->
     global_registry := Some (Agent_identity.Registry.create ());
     initialized := true
   )
@@ -73,7 +73,7 @@ let get_or_create_identity ?mcp_session_id params =
     | None -> None
     | Some sid ->
         Mutex.lock session_map_lock;
-        let result = Fun.protect ~finally:(fun () -> Mutex.unlock session_map_lock) (fun () ->
+        let result = Common.protect ~module_name:"agent_registry_eio" ~finally_label:"finalizer" ~finally:(fun () -> Mutex.unlock session_map_lock) (fun () ->
           match Hashtbl.find_opt session_identity_map sid with
           | Some session_key -> Agent_identity.Registry.find_by_session reg session_key
           | None -> None
@@ -102,7 +102,7 @@ let get_or_create_identity ?mcp_session_id params =
       (match mcp_session_id with
        | Some sid ->
            Mutex.lock session_map_lock;
-           Fun.protect ~finally:(fun () -> Mutex.unlock session_map_lock) (fun () ->
+           Common.protect ~module_name:"agent_registry_eio" ~finally_label:"finalizer" ~finally:(fun () -> Mutex.unlock session_map_lock) (fun () ->
              Hashtbl.replace session_identity_map sid registered.session_key
            )
        | None -> ());
@@ -147,7 +147,7 @@ let list_active ?(within_seconds = 300.0) () =
 let cleanup_stale_sessions () =
   let reg = get_registry () in
   Mutex.lock session_map_lock;
-  Fun.protect ~finally:(fun () -> Mutex.unlock session_map_lock) (fun () ->
+  Common.protect ~module_name:"agent_registry_eio" ~finally_label:"finalizer" ~finally:(fun () -> Mutex.unlock session_map_lock) (fun () ->
     let to_remove = ref [] in
     Hashtbl.iter (fun sid session_key ->
       match Agent_identity.Registry.find_by_session reg session_key with
@@ -164,7 +164,7 @@ let unregister session_key =
   Agent_identity.Registry.unregister reg session_key;
   (* Also clean up session map *)
   Mutex.lock session_map_lock;
-  Fun.protect ~finally:(fun () -> Mutex.unlock session_map_lock) (fun () ->
+  Common.protect ~module_name:"agent_registry_eio" ~finally_label:"finalizer" ~finally:(fun () -> Mutex.unlock session_map_lock) (fun () ->
     let to_remove = ref [] in
     Hashtbl.iter (fun sid sk ->
       if sk = session_key then to_remove := sid :: !to_remove

--- a/lib/auto_responder.ml
+++ b/lib/auto_responder.ml
@@ -30,14 +30,14 @@ let activity_log_file () =
 (** Debug logging to file *)
 let debug_log msg =
   let oc = open_out_gen [Open_creat; Open_append; Open_text] 0o644 "/tmp/auto_debug.log" in
-  Fun.protect ~finally:(fun () -> close_out_noerr oc) (fun () ->
+  Common.protect ~module_name:"auto_responder" ~finally_label:"finalizer" ~finally:(fun () -> close_out_noerr oc) (fun () ->
     Printf.fprintf oc "[%f] %s\n%!" (Unix.gettimeofday ()) msg)
 
 (** Activity logging - human readable format *)
 let activity_log ~mode ~from_agent ~mention ~status ~detail =
   let log_file = activity_log_file () in
   let oc = open_out_gen [Open_creat; Open_append; Open_text] 0o644 log_file in
-  Fun.protect ~finally:(fun () -> close_out_noerr oc) (fun () ->
+  Common.protect ~module_name:"auto_responder" ~finally_label:"finalizer" ~finally:(fun () -> close_out_noerr oc) (fun () ->
     let time = Unix.localtime (Unix.gettimeofday ()) in
     let timestamp = Printf.sprintf "%04d-%02d-%02d %02d:%02d:%02d"
       (time.Unix.tm_year + 1900) (time.Unix.tm_mon + 1) time.Unix.tm_mday
@@ -132,12 +132,12 @@ let spawn_in_background ~agent_type ~prompt ~working_dir =
   (* Write command to file for debugging *)
   let debug_file = "/tmp/auto_spawn_cmd.txt" in
   (let oc = open_out debug_file in
-   Fun.protect ~finally:(fun () -> close_out_noerr oc) (fun () ->
+   Common.protect ~module_name:"auto_responder" ~finally_label:"finalizer" ~finally:(fun () -> close_out_noerr oc) (fun () ->
      Printf.fprintf oc "CMD: %s\nLOG: %s\n" cmd log_file));
   (* Run in background with nohup - use script file to avoid quoting issues *)
   let script_file = "/tmp/auto_spawn_script.sh" in
   (let sc = open_out script_file in
-   Fun.protect ~finally:(fun () -> close_out_noerr sc) (fun () ->
+   Common.protect ~module_name:"auto_responder" ~finally_label:"finalizer" ~finally:(fun () -> close_out_noerr sc) (fun () ->
      Printf.fprintf sc "#!/bin/bash\n%s\n" cmd));
   ignore (Unix.chmod script_file 0o755);
   let bg_cmd = Printf.sprintf "nohup %s > %s 2>&1 &" script_file log_file in
@@ -169,7 +169,7 @@ let call_llm_mcp_sync ~agent_type ~prompt =
   let tmp_file = Printf.sprintf "/tmp/llm_call_%d_%d.json"
     (Unix.getpid ()) (int_of_float (Unix.gettimeofday () *. 1000000.) mod 1000000) in
   (let oc = open_out tmp_file in
-   Fun.protect ~finally:(fun () -> close_out_noerr oc) (fun () ->
+   Common.protect ~module_name:"auto_responder" ~finally_label:"finalizer" ~finally:(fun () -> close_out_noerr oc) (fun () ->
      output_string oc json_body));
   let cmd = Printf.sprintf
     "curl -s '%s' -H 'Content-Type: application/json' -H 'Accept: application/json, text/event-stream' -d @%s 2>/dev/null | jq -r '.result.content[0].text // .error.message // \"no response\"' 2>/dev/null | head -c 500"
@@ -194,7 +194,7 @@ let masc_call ~tool_name ~args =
   let tmp_file = Printf.sprintf "/tmp/masc_call_%d_%d.json"
     (Unix.getpid ()) (int_of_float (Unix.gettimeofday () *. 1000000.) mod 1000000) in
   (let oc = open_out tmp_file in
-   Fun.protect ~finally:(fun () -> close_out_noerr oc) (fun () ->
+   Common.protect ~module_name:"auto_responder" ~finally_label:"finalizer" ~finally:(fun () -> close_out_noerr oc) (fun () ->
      output_string oc body));
   let cmd = Printf.sprintf
     "curl -s '%s' -H 'Content-Type: application/json' -H 'Accept: application/json, text/event-stream' -d @%s 2>/dev/null"
@@ -320,7 +320,7 @@ echo "[MASC] Left room" >> /tmp/auto_debug.log
   let log_file = Printf.sprintf "/tmp/llm_bg_%s_%d.log"
     agent_type (int_of_float (Unix.gettimeofday () *. 1000.) mod 10000) in
   (let oc = open_out script_file in
-   Fun.protect ~finally:(fun () -> close_out_noerr oc) (fun () ->
+   Common.protect ~module_name:"auto_responder" ~finally_label:"finalizer" ~finally:(fun () -> close_out_noerr oc) (fun () ->
      output_string oc script));
   ignore (Unix.chmod script_file 0o755);
   let bg_cmd = Printf.sprintf "nohup %s > %s 2>&1 &" script_file log_file in

--- a/lib/backend_eio.ml
+++ b/lib/backend_eio.ml
@@ -477,7 +477,7 @@ module FileSystem = struct
 
           (* Open file for read+write, create if needed *)
           let fd = Unix.openfile path_str [Unix.O_RDWR; Unix.O_CREAT] 0o644 in
-          Fun.protect ~finally:(fun () -> Unix.close fd) @@ fun () ->
+          Common.protect ~module_name:"backend_eio" ~finally_label:"finalizer" ~finally:(fun () -> Unix.close fd) @@ fun () ->
 
           (* Acquire exclusive lock with non-blocking retry *)
           let max_retries = 100 in
@@ -495,7 +495,7 @@ module FileSystem = struct
                 try_lock (retries - 1)
           in
           let _ = try_lock max_retries in
-          Fun.protect ~finally:(fun () -> Unix.lockf fd Unix.F_ULOCK 0) @@ fun () ->
+          Common.protect ~module_name:"backend_eio" ~finally_label:"finalizer" ~finally:(fun () -> Unix.lockf fd Unix.F_ULOCK 0) @@ fun () ->
 
           (* Read current value *)
           let _ = Unix.lseek fd 0 Unix.SEEK_SET in
@@ -528,10 +528,10 @@ module FileSystem = struct
           if not (Sys.file_exists path_str) then Ok 0
           else
             let fd = Unix.openfile path_str [Unix.O_RDONLY] 0o644 in
-            Fun.protect ~finally:(fun () -> Unix.close fd) @@ fun () ->
+            Common.protect ~module_name:"backend_eio" ~finally_label:"finalizer" ~finally:(fun () -> Unix.close fd) @@ fun () ->
             (* Shared lock for reading *)
             Unix.lockf fd Unix.F_RLOCK 0;
-            Fun.protect ~finally:(fun () -> Unix.lockf fd Unix.F_ULOCK 0) @@ fun () ->
+            Common.protect ~module_name:"backend_eio" ~finally_label:"finalizer" ~finally:(fun () -> Unix.lockf fd Unix.F_ULOCK 0) @@ fun () ->
             let buf = Bytes.create 32 in
             let n = Unix.read fd buf 0 32 in
             if n = 0 then Ok 0
@@ -562,7 +562,7 @@ module FileSystem = struct
 
           (* Open file for read+write, create if needed *)
           let fd = Unix.openfile path_str [Unix.O_RDWR; Unix.O_CREAT] 0o644 in
-          Fun.protect ~finally:(fun () -> Unix.close fd) @@ fun () ->
+          Common.protect ~module_name:"backend_eio" ~finally_label:"finalizer" ~finally:(fun () -> Unix.close fd) @@ fun () ->
 
           (* Acquire exclusive lock with non-blocking retry *)
           let max_retries = 100 in
@@ -579,7 +579,7 @@ module FileSystem = struct
                 try_lock (retries - 1)
           in
           let _ = try_lock max_retries in
-          Fun.protect ~finally:(fun () -> Unix.lockf fd Unix.F_ULOCK 0) @@ fun () ->
+          Common.protect ~module_name:"backend_eio" ~finally_label:"finalizer" ~finally:(fun () -> Unix.lockf fd Unix.F_ULOCK 0) @@ fun () ->
 
           (* Read current content *)
           let _ = Unix.lseek fd 0 Unix.SEEK_SET in

--- a/lib/cache_eio.ml
+++ b/lib/cache_eio.ml
@@ -98,7 +98,7 @@ let set config ~key ~value ?(ttl_seconds : int option) ?(tags : string list = []
   let content = Yojson.Safe.pretty_to_string json in
   try
     let oc = open_out path in
-    Fun.protect ~finally:(fun () -> close_out_noerr oc) (fun () ->
+    Common.protect ~module_name:"cache_eio" ~finally_label:"finalizer" ~finally:(fun () -> close_out_noerr oc) (fun () ->
       output_string oc content);
     Ok entry
   with e ->
@@ -112,7 +112,7 @@ let get config ~key : (cache_entry option, string) result =
   else
     try
       let ic = open_in path in
-      let content = Fun.protect ~finally:(fun () -> close_in_noerr ic) (fun () ->
+      let content = Common.protect ~module_name:"cache_eio" ~finally_label:"finalizer" ~finally:(fun () -> close_in_noerr ic) (fun () ->
         really_input_string ic (in_channel_length ic)) in
       let json = Yojson.Safe.from_string content in
       match entry_of_json json with

--- a/lib/common.ml
+++ b/lib/common.ml
@@ -1,0 +1,33 @@
+let env_true name =
+  match Sys.getenv_opt name with
+  | None -> false
+  | Some v ->
+      let v = String.trim v |> String.lowercase_ascii in
+      v = "1" || v = "true" || v = "yes" || v = "on"
+
+let strict_finalizers () = env_true "MASC_MCP_STRICT_FINALIZERS"
+
+let handle_finalizer_error ~module_name ~label ~during_exception ~backtrace ex =
+  let suffix = if during_exception then " (during exception)" else "" in
+  Printf.eprintf "[%s] %s failed in finalizer%s: %s\n%!"
+    module_name label suffix (Printexc.to_string ex);
+  if (not during_exception) && strict_finalizers () then
+    Printexc.raise_with_backtrace ex backtrace
+
+let protect ~module_name ~finally_label ~finally f =
+  match f () with
+  | v ->
+      (try finally () with
+       | ex ->
+           let bt = Printexc.get_raw_backtrace () in
+           handle_finalizer_error ~module_name ~label:finally_label
+             ~during_exception:false ~backtrace:bt ex);
+      v
+  | exception ex ->
+      let bt = Printexc.get_raw_backtrace () in
+      (try finally () with
+       | ex2 ->
+           let bt2 = Printexc.get_raw_backtrace () in
+           handle_finalizer_error ~module_name ~label:finally_label
+             ~during_exception:true ~backtrace:bt2 ex2);
+      Printexc.raise_with_backtrace ex bt

--- a/lib/debate.ml
+++ b/lib/debate.ml
@@ -144,7 +144,7 @@ let write_json path json =
   let tmp_path = Filename.concat dir (Printf.sprintf ".%s.tmp.%d" base (Unix.getpid ())) in
   let oc = open_out tmp_path in
   let closed = ref false in
-  Fun.protect ~finally:(fun () ->
+  Common.protect ~module_name:"debate" ~finally_label:"finalizer" ~finally:(fun () ->
     if not !closed then (try close_out oc with _ -> ());
     if Sys.file_exists tmp_path then
       try Sys.remove tmp_path with _ -> ()

--- a/lib/dune
+++ b/lib/dune
@@ -18,6 +18,7 @@
    env_config
    cancellation
    checkpoint_types
+   common
    compression_dict
    config
    dashboard

--- a/lib/encryption.ml
+++ b/lib/encryption.ml
@@ -68,7 +68,7 @@ let load_key config : (GCM.key, encryption_error) result =
     | `File path ->
         if Sys.file_exists path then
           let ic = open_in path in
-          let content = Fun.protect ~finally:(fun () -> close_in_noerr ic) (fun () ->
+          let content = Common.protect ~module_name:"encryption" ~finally_label:"finalizer" ~finally:(fun () -> close_in_noerr ic) (fun () ->
             really_input_string ic 64) in (* hex-encoded 32 bytes *)
           (* Decode hex to bytes *)
           let bytes = ref "" in

--- a/lib/federation.ml
+++ b/lib/federation.ml
@@ -260,7 +260,7 @@ let safe_write_file (path : string) (content : string) : (unit, string) result =
       Unix.mkdir dir 0o700;
     let tmp_path = path ^ ".tmp" in
     let oc = open_out_gen [Open_wronly; Open_creat; Open_trunc] 0o600 tmp_path in
-    Fun.protect ~finally:(fun () -> close_out_noerr oc) (fun () ->
+    Common.protect ~module_name:"federation" ~finally_label:"finalizer" ~finally:(fun () -> close_out_noerr oc) (fun () ->
       output_string oc content);
     (* Atomic rename for consistency *)
     Sys.rename tmp_path path;
@@ -276,7 +276,7 @@ let safe_read_file (path : string) : (string, string) result =
       Error (Printf.sprintf "File not found: %s" path)
     else
       let ic = open_in path in
-      let content = Fun.protect ~finally:(fun () -> close_in_noerr ic) (fun () ->
+      let content = Common.protect ~module_name:"federation" ~finally_label:"finalizer" ~finally:(fun () -> close_in_noerr ic) (fun () ->
         really_input_string ic (in_channel_length ic)) in
       Ok content
   with
@@ -289,7 +289,7 @@ let safe_append_file (path : string) (content : string) : (unit, string) result 
     if not (Sys.file_exists dir) then
       Unix.mkdir dir 0o700;
     let oc = open_out_gen [Open_append; Open_creat] 0o600 path in
-    Fun.protect ~finally:(fun () -> close_out_noerr oc) (fun () ->
+    Common.protect ~module_name:"federation" ~finally_label:"finalizer" ~finally:(fun () -> close_out_noerr oc) (fun () ->
       output_string oc content);
     Ok ()
   with

--- a/lib/hebbian_eio.ml
+++ b/lib/hebbian_eio.ml
@@ -100,7 +100,7 @@ let with_graph_lock config f =
   let warn_threshold = Level2_config.Lock.warn_threshold_ms () in
   if wait_ms > warn_threshold then
     Printf.eprintf "[hebbian_eio] WARN: Lock contention detected: %.1fms wait (threshold: %.0fms)\n" wait_ms warn_threshold;
-  Fun.protect
+  Common.protect ~module_name:"hebbian_eio" ~finally_label:"finalizer"
     ~finally:(fun () ->
       Unix.lockf fd Unix.F_ULOCK 0;
       Unix.close fd)

--- a/lib/masc_mcp.ml
+++ b/lib/masc_mcp.ml
@@ -1,6 +1,7 @@
 (** MASC MCP - Main Library Entry Point (Eio-only) *)
 
 module Version = Version
+module Common = Common
 module Log = Log
 module Types = Types
 module Nickname = Nickname

--- a/lib/mcp_server.ml
+++ b/lib/mcp_server.ml
@@ -345,7 +345,7 @@ let read_event_lines config ~limit =
     let remaining = ref limit in
     let read_lines path =
       let ic = open_in path in
-      Fun.protect ~finally:(fun () -> close_in_noerr ic) (fun () ->
+      Common.protect ~module_name:"mcp_server" ~finally_label:"finalizer" ~finally:(fun () -> close_in_noerr ic) (fun () ->
         let rec loop acc =
           match input_line ic with
           | line -> loop (line :: acc)

--- a/lib/mcp_server_eio.ml
+++ b/lib/mcp_server_eio.ml
@@ -440,7 +440,7 @@ let append_audit_event (config : Room.config) (e : audit_event) =
     let line = Yojson.Safe.to_string (audit_event_to_json e) ^ "\n" in
     Room_utils.with_file_lock config path (fun () ->
       let oc = open_out_gen [Open_creat; Open_append; Open_wronly] 0o600 path in
-      Fun.protect ~finally:(fun () -> close_out_noerr oc) (fun () ->
+      Common.protect ~module_name:"mcp_server_eio" ~finally_label:"finalizer" ~finally:(fun () -> close_out_noerr oc) (fun () ->
         output_string oc line)
     )
   end
@@ -608,8 +608,11 @@ let execute_tool_eio ~sw ~clock ?mcp_session_id ?auth_token state ~name ~argumen
         let file = Printf.sprintf "/tmp/.masc_agent_mcp_%s" sid in
         try
           let ic = open_in file in
-          let name = Fun.protect ~finally:(fun () -> close_in_noerr ic) (fun () ->
-            input_line ic) in
+          let name =
+            Common.protect ~module_name:"mcp_server_eio" ~finally_label:"finalizer"
+              ~finally:(fun () -> close_in_noerr ic)
+              (fun () -> input_line ic)
+          in
           if name = "" then None else Some name
         with Sys_error _ | End_of_file -> None
   in
@@ -622,8 +625,9 @@ let execute_tool_eio ~sw ~clock ?mcp_session_id ?auth_token state ~name ~argumen
         let file = Printf.sprintf "/tmp/.masc_agent_mcp_%s" sid in
         try
           let oc = open_out file in
-          Fun.protect ~finally:(fun () -> close_out_noerr oc) (fun () ->
-            output_string oc agent_name)
+          Common.protect ~module_name:"mcp_server_eio" ~finally_label:"finalizer"
+            ~finally:(fun () -> close_out_noerr oc)
+            (fun () -> output_string oc agent_name)
         with Sys_error msg ->
           Printf.eprintf "[WARN] write_mcp_session_agent: %s\n%!" msg
   in
@@ -672,8 +676,11 @@ let execute_tool_eio ~sw ~clock ?mcp_session_id ?auth_token state ~name ~argumen
           let term_file = Printf.sprintf "/tmp/.masc_agent_%s" term_session_id in
           (try
             let ic = open_in term_file in
-            let name = Fun.protect ~finally:(fun () -> close_in_noerr ic) (fun () ->
-              input_line ic) in
+            let name =
+              Common.protect ~module_name:"mcp_server_eio" ~finally_label:"finalizer"
+                ~finally:(fun () -> close_in_noerr ic)
+                (fun () -> input_line ic)
+            in
             if name <> "" then name else raise Not_found
           with Sys_error _ | End_of_file | Not_found ->
             Printf.sprintf "agent-%s" (String.sub identity.session_key 0 8))
@@ -949,8 +956,9 @@ let execute_tool_eio ~sw ~clock ?mcp_session_id ?auth_token state ~name ~argumen
       let agent_file = Printf.sprintf "/tmp/.masc_agent_%s" term_session_id in
       (try
         let oc = open_out agent_file in
-        Fun.protect ~finally:(fun () -> close_out_noerr oc) (fun () ->
-          output_string oc nickname)
+        Common.protect ~module_name:"mcp_server_eio" ~finally_label:"finalizer"
+          ~finally:(fun () -> close_out_noerr oc)
+          (fun () -> output_string oc nickname)
       with e ->
         Eio.traceln "[WARN] Failed to write agent file %s: %s" agent_file (Printexc.to_string e));
       (* Cultural Inheritance: append institution welcome to join response *)
@@ -1508,15 +1516,18 @@ Time: %s
           let file_path = Filename.concat pending_dir file in
           try
             let ic = open_in file_path in
-            let content = Fun.protect ~finally:(fun () -> close_in_noerr ic) (fun () ->
-              let buf = Buffer.create 4096 in
-              (try
-                while true do
-                  Buffer.add_channel buf ic 1024
-                done
-              with End_of_file -> ());
-              Buffer.contents buf
-            ) in
+            let content =
+              Common.protect ~module_name:"mcp_server_eio" ~finally_label:"finalizer"
+                ~finally:(fun () -> close_in_noerr ic)
+                (fun () ->
+                  let buf = Buffer.create 4096 in
+                  (try
+                    while true do
+                      Buffer.add_channel buf ic 1024
+                    done
+                  with End_of_file -> ());
+                  Buffer.contents buf)
+            in
             (* Parse and validate *)
             let json = Yojson.Safe.from_string content in
             let open Yojson.Safe.Util in
@@ -1599,11 +1610,14 @@ Time: %s
               try
                 let path = Filename.concat processed_dir file in
                 let ic = open_in path in
-                let content = Fun.protect ~finally:(fun () -> close_in_noerr ic) (fun () ->
-                  let buf = Buffer.create 4096 in
-                  (try while true do Buffer.add_channel buf ic 1024 done with End_of_file -> ());
-                  Buffer.contents buf
-                ) in
+                let content =
+                  Common.protect ~module_name:"mcp_server_eio" ~finally_label:"finalizer"
+                    ~finally:(fun () -> close_in_noerr ic)
+                    (fun () ->
+                      let buf = Buffer.create 4096 in
+                      (try while true do Buffer.add_channel buf ic 1024 done with End_of_file -> ());
+                      Buffer.contents buf)
+                in
                 let json = Yojson.Safe.from_string content in
                 let ep_agent = Yojson.Safe.Util.(json |> member "agent_name" |> to_string) in
                 let ep_gen = Yojson.Safe.Util.(json |> member "generation" |> to_int) in

--- a/lib/metrics_store_eio.ml
+++ b/lib/metrics_store_eio.ml
@@ -120,7 +120,7 @@ let read_metrics_file file : task_metric list =
     []
   else
     let ic = open_in file in
-    let content = Fun.protect ~finally:(fun () -> close_in_noerr ic) (fun () ->
+    let content = Common.protect ~module_name:"metrics_store_eio" ~finally_label:"finalizer" ~finally:(fun () -> close_in_noerr ic) (fun () ->
       really_input_string ic (in_channel_length ic)) in
     let lines = String.split_on_char '\n' content
       |> List.filter (fun s -> String.trim s <> "") in

--- a/lib/mitosis.ml
+++ b/lib/mitosis.ml
@@ -741,7 +741,7 @@ let write_status ~base_path ~cell ~config =
   if Sys.file_exists masc_dir && Sys.is_directory masc_dir then begin
     try
       let oc = open_out status_file in
-      Fun.protect ~finally:(fun () -> close_out_noerr oc) (fun () ->
+      Common.protect ~module_name:"mitosis" ~finally_label:"finalizer" ~finally:(fun () -> close_out_noerr oc) (fun () ->
         output_string oc (Yojson.Safe.pretty_to_string json ^ "\n"))
     with exn ->
       Printf.eprintf "[MITOSIS/ERROR] Failed to write status: %s\n%!" (Printexc.to_string exn)
@@ -787,7 +787,7 @@ let write_status_with_backend ~room_config ~cell ~config =
   if Sys.file_exists masc_dir && Sys.is_directory masc_dir then begin
     try
       let oc = open_out status_file in
-      Fun.protect ~finally:(fun () -> close_out_noerr oc) (fun () ->
+      Common.protect ~module_name:"mitosis" ~finally_label:"finalizer" ~finally:(fun () -> close_out_noerr oc) (fun () ->
         output_string oc (Yojson.Safe.pretty_to_string json ^ "\n")
       )
     with exn ->

--- a/lib/planning_eio.ml
+++ b/lib/planning_eio.ml
@@ -130,7 +130,7 @@ let ensure_dir path =
 let read_file_content path =
   if Sys.file_exists path then
     let ic = open_in path in
-    Fun.protect ~finally:(fun () -> close_in ic) (fun () ->
+    Common.protect ~module_name:"planning_eio" ~finally_label:"finalizer" ~finally:(fun () -> close_in ic) (fun () ->
       really_input_string ic (in_channel_length ic))
   else ""
 
@@ -138,11 +138,11 @@ let read_file_content path =
 let write_file_content path content =
   ensure_dir (Filename.dirname path);
   let oc = open_out path in
-  Fun.protect ~finally:(fun () -> close_out oc) (fun () ->
+  Common.protect ~module_name:"planning_eio" ~finally_label:"finalizer" ~finally:(fun () -> close_out oc) (fun () ->
     (* Use exclusive lock for concurrent writes *)
     let fd = Unix.descr_of_out_channel oc in
     Unix.lockf fd Unix.F_LOCK 0;
-    Fun.protect ~finally:(fun () -> Unix.lockf fd Unix.F_ULOCK 0) (fun () ->
+    Common.protect ~module_name:"planning_eio" ~finally_label:"finalizer" ~finally:(fun () -> Unix.lockf fd Unix.F_ULOCK 0) (fun () ->
       output_string oc content))
 
 (* ===== Core Operations (Pure Sync) ===== *)

--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -36,7 +36,7 @@ let metrics_mutex = Mutex.create ()
 
 let with_lock f =
   Mutex.lock metrics_mutex;
-  Fun.protect ~finally:(fun () -> Mutex.unlock metrics_mutex) f
+  Common.protect ~module_name:"prometheus" ~finally_label:"finalizer" ~finally:(fun () -> Mutex.unlock metrics_mutex) f
 
 (** {1 Metric Registration} *)
 

--- a/lib/rate_limit.ml
+++ b/lib/rate_limit.ml
@@ -55,7 +55,7 @@ let create_from_env () =
 
 let with_lock limiter f =
   Mutex.lock limiter.mutex;
-  Fun.protect ~finally:(fun () -> Mutex.unlock limiter.mutex) f
+  Common.protect ~module_name:"rate_limit" ~finally_label:"finalizer" ~finally:(fun () -> Mutex.unlock limiter.mutex) f
 
 let check limiter ~key =
   with_lock limiter (fun () ->

--- a/lib/room.ml
+++ b/lib/room.ml
@@ -1232,7 +1232,7 @@ let remove_walph_state config =
 (** Run with Walph state mutex locked *)
 let with_walph_lock state f =
   Mutex.lock state.mutex;
-  Fun.protect ~finally:(fun () -> Mutex.unlock state.mutex) f
+  Common.protect ~module_name:"room" ~finally_label:"finalizer" ~finally:(fun () -> Mutex.unlock state.mutex) f
 
 (** Parse @walph command from broadcast message
     Returns: (command, args) or None if not a walph command *)
@@ -1375,7 +1375,7 @@ let walph_loop config ~agent_name ?(preset="drain") ?(max_iterations=10) ?target
       (* Use Fun.protect to ensure running <- false even on exceptions (zombie prevention) *)
       let stop_reason = ref "" in
 
-      Fun.protect
+      Common.protect ~module_name:"room" ~finally_label:"finalizer"
         ~finally:(fun () ->
           (* Always reset running state, even on exception *)
           with_walph_lock walph_state (fun () ->

--- a/lib/room_utils.ml
+++ b/lib/room_utils.ml
@@ -764,7 +764,7 @@ let with_file_lock config path f =
       let lock_path = path ^ ".lock" in
       mkdir_p (Filename.dirname lock_path);
       let fd = Unix.openfile lock_path [Unix.O_CREAT; Unix.O_WRONLY] 0o644 in
-      Fun.protect
+      Common.protect ~module_name:"room_utils" ~finally_label:"finalizer"
         ~finally:(fun () ->
           (try Unix.lockf fd Unix.F_ULOCK 0
            with Unix.Unix_error (err, _, _) ->
@@ -786,7 +786,7 @@ let with_file_lock config path f =
               acquire (attempts - 1)
       in
       if acquire 20 then
-        Fun.protect
+        Common.protect ~module_name:"room_utils" ~finally_label:"finalizer"
           ~finally:(fun () -> ignore (backend_release_lock config ~key ~owner))
           f
       else
@@ -798,7 +798,7 @@ let with_file_lock_r config path f : ('a, masc_error) result =
       let lock_path = path ^ ".lock" in
       mkdir_p (Filename.dirname lock_path);
       let fd = Unix.openfile lock_path [Unix.O_CREAT; Unix.O_WRONLY] 0o644 in
-      Fun.protect
+      Common.protect ~module_name:"room_utils" ~finally_label:"finalizer"
         ~finally:(fun () ->
           (try Unix.lockf fd Unix.F_ULOCK 0
            with Unix.Unix_error (err, _, _) ->
@@ -818,7 +818,7 @@ let with_file_lock_r config path f : ('a, masc_error) result =
           | _ -> Unix.sleepf 0.05; acquire (attempts - 1)
       in
       if acquire 20 then
-        Fun.protect
+        Common.protect ~module_name:"room_utils" ~finally_label:"finalizer"
           ~finally:(fun () -> ignore (backend_release_lock config ~key ~owner))
           (fun () -> Ok (f ()))
       else

--- a/lib/room_walph_eio.ml
+++ b/lib/room_walph_eio.ml
@@ -258,7 +258,7 @@ let walph_loop config ~net ~clock ~agent_name ?(preset="drain") ?(max_iterations
       (* Use Fun.protect to ensure running <- false even on exceptions (zombie prevention) *)
       let stop_reason = ref "" in
 
-      Fun.protect
+      Common.protect ~module_name:"room_walph_eio" ~finally_label:"finalizer"
         ~finally:(fun () ->
           (* Always reset running state, even on exception *)
           with_walph_lock walph_state (fun () ->

--- a/lib/run_eio.ml
+++ b/lib/run_eio.ml
@@ -168,7 +168,7 @@ let append_log config ~task_id ~note : (log_entry, string) result =
     let line = Yojson.Safe.to_string (log_entry_to_json entry) ^ "\n" in
     with_file_lock config file (fun () ->
       let oc = open_out_gen [Open_creat; Open_append; Open_wronly] 0o600 file in
-      Fun.protect ~finally:(fun () -> close_out_noerr oc) (fun () ->
+      Common.protect ~module_name:"run_eio" ~finally_label:"finalizer" ~finally:(fun () -> close_out_noerr oc) (fun () ->
         output_string oc line)
     );
     Ok entry

--- a/lib/safe_ops.ml
+++ b/lib/safe_ops.ml
@@ -37,7 +37,7 @@ let read_file_safe path : (string, string) result =
   else
     try
       let ic = open_in path in
-      let content = Fun.protect ~finally:(fun () -> close_in_noerr ic) (fun () ->
+      let content = Common.protect ~module_name:"safe_ops" ~finally_label:"finalizer" ~finally:(fun () -> close_in_noerr ic) (fun () ->
         really_input_string ic (in_channel_length ic)) in
       Ok content
     with e ->

--- a/lib/social.ml
+++ b/lib/social.ml
@@ -185,7 +185,7 @@ let write_json path json =
   let tmp_path = Filename.concat dir (Printf.sprintf ".%s.tmp.%d" base (Unix.getpid ())) in
   let oc = open_out tmp_path in
   let closed = ref false in
-  Fun.protect ~finally:(fun () ->
+  Common.protect ~module_name:"social" ~finally_label:"finalizer" ~finally:(fun () ->
     (* Only close if not already closed in protected block *)
     if not !closed then (try close_out oc with _ -> ());
     (* Clean up temp file on error (won't exist after successful rename) *)
@@ -340,7 +340,7 @@ let get_comments_threaded config ~post_id : (comment * comment list) list =
 let with_file_lock path f =
   let lock_path = path ^ ".lock" in
   let fd = Unix.openfile lock_path [Unix.O_CREAT; Unix.O_WRONLY] 0o644 in
-  Fun.protect ~finally:(fun () ->
+  Common.protect ~module_name:"social" ~finally_label:"finalizer" ~finally:(fun () ->
     (try Unix.lockf fd Unix.F_ULOCK 0 with _ -> ());
     Unix.close fd
   ) (fun () ->

--- a/lib/spawn_eio.ml
+++ b/lib/spawn_eio.ml
@@ -273,7 +273,7 @@ let spawn ~sw ~proc_mgr ~agent_name ~prompt ?timeout_seconds ?working_dir ?room_
       if Sys.file_exists inst_file then
         try
           let ic = open_in inst_file in
-          let content = Fun.protect ~finally:(fun () -> close_in_noerr ic)
+          let content = Common.protect ~module_name:"spawn_eio" ~finally_label:"finalizer" ~finally:(fun () -> close_in_noerr ic)
             (fun () -> really_input_string ic (in_channel_length ic)) in
           let json = Yojson.Safe.from_string content in
           let inst = Institution_eio.institution_of_json json in

--- a/lib/tempo.ml
+++ b/lib/tempo.ml
@@ -79,7 +79,7 @@ let save_state (config : Room_utils.config) (state : tempo_state) : unit =
   let json = state_to_json state in
   let content = Yojson.Safe.pretty_to_string json in
   let oc = open_out path in
-  Fun.protect ~finally:(fun () -> close_out_noerr oc) (fun () ->
+  Common.protect ~module_name:"tempo" ~finally_label:"finalizer" ~finally:(fun () -> close_out_noerr oc) (fun () ->
     output_string oc content)
 
 (** Set tempo manually *)

--- a/lib/tool_mitosis.ml
+++ b/lib/tool_mitosis.ml
@@ -77,7 +77,7 @@ let queue_episode ~base_path ~session_id ~agent_name ~generation
   let file = Filename.concat dir (ep_id ^ ".json") in
   try
     let oc = open_out file in
-    Fun.protect ~finally:(fun () -> close_out_noerr oc) (fun () ->
+    Common.protect ~module_name:"tool_mitosis" ~finally_label:"finalizer" ~finally:(fun () -> close_out_noerr oc) (fun () ->
       output_string oc (Yojson.Safe.pretty_to_string json));
     Printf.printf "[EPISODE/QUEUE] Queued episode %s (gen %d) → %s\n%!" ep_id generation file;
     Some ep_id

--- a/lib/voice_session_manager.ml
+++ b/lib/voice_session_manager.ml
@@ -101,14 +101,14 @@ let save_session t session =
   let content = Yojson.Safe.pretty_to_string json in
   let filepath = session_file t session.agent_id in
   let oc = open_out filepath in
-  Fun.protect ~finally:(fun () -> close_out_noerr oc) (fun () ->
+  Common.protect ~module_name:"voice_session_manager" ~finally_label:"finalizer" ~finally:(fun () -> close_out_noerr oc) (fun () ->
     output_string oc content)
 
 let load_session t agent_id =
   let filepath = session_file t agent_id in
   if Sys.file_exists filepath then begin
     let ic = open_in filepath in
-    let content = Fun.protect ~finally:(fun () -> close_in_noerr ic) (fun () ->
+    let content = Common.protect ~module_name:"voice_session_manager" ~finally_label:"finalizer" ~finally:(fun () -> close_in_noerr ic) (fun () ->
       really_input_string ic (in_channel_length ic)) in
     try
       let json = Yojson.Safe.from_string content in

--- a/lib/void.ml
+++ b/lib/void.ml
@@ -301,7 +301,7 @@ let select_koan_safe (reader : reader_context) : (koan, void_error) result =
 
 (** Safe contemplation with resource cleanup callback *)
 let contemplate_with_cleanup ~(cleanup: unit -> unit) (x : 'a) : 'a =
-  Fun.protect ~finally:cleanup (fun () -> x)
+  Common.protect ~module_name:"void" ~finally_label:"finalizer" ~finally:cleanup (fun () -> x)
 
 (** {1 Phantom Types for Level Safety}
 

--- a/test/dune
+++ b/test/dune
@@ -61,6 +61,12 @@
  (modules test_safe_ops)
  (libraries masc_mcp alcotest str yojson))
 
+; Common module tests (finalizer guard)
+(test
+ (name test_common)
+ (modules test_common)
+ (libraries masc_mcp alcotest))
+
 ; Dispatch chain evidence test
 (test
  (name test_dispatch_chain_evidence)

--- a/test/dune
+++ b/test/dune
@@ -26,12 +26,6 @@
  (libraries masc_mcp mcp_protocol alcotest str yojson mirage-crypto
             mirage-crypto-rng cohttp cstruct))
 
-; Message Schema tests (Phase 1: structured message validation)
-(test
- (name test_message_schema)
- (modules test_message_schema)
- (libraries masc_mcp alcotest yojson))
-
 ; ============================================================
 ; Eio module tests (Pure sync - Cache_eio, Metrics_store_eio, Hebbian_eio)
 ; ============================================================

--- a/test/test_common.ml
+++ b/test/test_common.ml
@@ -1,0 +1,82 @@
+open Alcotest
+
+let set_env name value = Unix.putenv name value
+let unset_env name = Unix.putenv name ""
+
+let with_env name value f =
+  let prev = Sys.getenv_opt name in
+  (match value with
+   | Some v -> set_env name v
+   | None -> unset_env name);
+  Fun.protect
+    ~finally:(fun () ->
+      match prev with
+      | Some v -> set_env name v
+      | None -> unset_env name)
+    f
+
+let test_protect_finally_runs () =
+  let called = ref false in
+  let value =
+    Masc_mcp.Common.protect
+      ~module_name:"test_common"
+      ~finally_label:"finally"
+      ~finally:(fun () -> called := true)
+      (fun () -> 42)
+  in
+  check int "value" 42 value;
+  check bool "finally called" true !called
+
+let test_protect_finally_error_no_raise () =
+  with_env "MASC_MCP_STRICT_FINALIZERS" (Some "0") (fun () ->
+    let called = ref false in
+    let value =
+      Masc_mcp.Common.protect
+        ~module_name:"test_common"
+        ~finally_label:"finally"
+        ~finally:(fun () -> called := true; failwith "boom")
+        (fun () -> 7)
+    in
+    check int "value" 7 value;
+    check bool "finally called" true !called)
+
+let test_protect_finally_error_raise () =
+  with_env "MASC_MCP_STRICT_FINALIZERS" (Some "1") (fun () ->
+    let raised =
+      try
+        let _ =
+          Masc_mcp.Common.protect
+            ~module_name:"test_common"
+            ~finally_label:"finally"
+            ~finally:(fun () -> failwith "boom")
+            (fun () -> 1)
+        in
+        false
+      with Failure _ -> true
+    in
+    check bool "raises in strict mode" true raised)
+
+let test_protect_preserves_exception () =
+  let raised =
+    try
+      let _ =
+        Masc_mcp.Common.protect
+          ~module_name:"test_common"
+          ~finally_label:"finally"
+          ~finally:(fun () -> failwith "finalizer")
+          (fun () -> failwith "main")
+      in
+      None
+    with Failure msg -> Some msg
+  in
+  check (option string) "main exception preserved" (Some "main") raised
+
+let () =
+  run "Masc_mcp.Common" [
+    "finalizer_guard", [
+      test_case "runs finally" `Quick test_protect_finally_runs;
+      test_case "finalizer error no raise" `Quick test_protect_finally_error_no_raise;
+      test_case "finalizer error raise" `Quick test_protect_finally_error_raise;
+      test_case "preserve main exception" `Quick test_protect_preserves_exception;
+    ];
+  ]


### PR DESCRIPTION
## 변경 사항
- Common.protect 추가 (finalizer 예외는 로그만, strict 모드에서만 재전파; 메인 예외는 유지)
- Fun.protect → Common.protect 교체 (masc_mcp 라이브러리 전반)
- test_common 추가 + dune 등록
- strict 토글: MASC_MCP_STRICT_FINALIZERS

## 테스트
- dune exec --root . test/test_common.exe
