### PR TITLE
refactor(swarm): P0 MAGI review — RNG, Normalized, Result types

### DIFF
--- a/lib/level4_config.ml
+++ b/lib/level4_config.ml
@@ -208,18 +208,3 @@ module Strength = Normalized
 (** Threshold: Normalized alias for quorum thresholds *)
 module Threshold = Normalized
 
-(** Clamp float to valid range *)
-let clamp_float ~min ~max f =
-  if f < min then min
-  else if f > max then max
-  else f
-
-(** Validate fitness value (0.0-1.0) *)
-let validate_fitness f =
-  if not (is_finite f) then None
-  else Some (clamp_float ~min:0.0 ~max:1.0 f)
-
-(** Validate non-negative float *)
-let validate_positive f =
-  if not (is_finite f) || f < 0.0 then None
-  else Some f

--- a/lib/level4_config.ml
+++ b/lib/level4_config.ml
@@ -45,6 +45,19 @@ let random_int max =
   ensure_rng_init ();
   Random.int max
 
+(** {2 Parameterized RNG}
+
+    Pure functions accept [~rng:Random.State.t] for deterministic testing.
+    Use [make_rng ~seed:42 ()] in tests, [make_rng ()] in production.
+*)
+
+let make_rng ?seed () =
+  let s = match seed with
+    | Some s -> s
+    | None -> get_env_int "MASC_SWARM_SEED" (int_of_float (Unix.gettimeofday () *. 1000.0))
+  in
+  Random.State.make [|s|]
+
 (** {1 Swarm Configuration} *)
 
 module Swarm = struct
@@ -117,39 +130,22 @@ let is_finite f =
   | FP_normal | FP_subnormal | FP_zero -> true
   | FP_infinite | FP_nan -> false
 
-(** {1 Abstract Fitness Type}
+(** {1 Normalized Type — Parse Don't Validate}
 
-    Parse Don't Validate: Invalid fitness values cannot exist.
+    Abstract type guaranteed to be in [0.0, 1.0].
+    Used for fitness, strength, threshold, selection_pressure, mutation_rate, etc.
+
     - Bartosz Milewski: "Make invalid states unrepresentable"
     - Alexis King: "Parse don't validate"
 *)
 
-module Fitness : sig
-  (** Abstract type - guaranteed to be in [0.0, 1.0] *)
+module Normalized : sig
   type t
 
-  (** Create fitness from float. Returns None if invalid. *)
   val of_float : float -> t option
-
-  (** Create fitness from float, clamping to valid range. *)
   val of_float_clamped : float -> t
-
-  (** Extract the underlying float value. *)
   val to_float : t -> float
-
-  (** Initial fitness for new agents *)
-  val initial : unit -> t
-
-  (** Combine two fitness values (average) *)
-  val combine : t -> t -> t
-
-  (** Adjust fitness by delta, clamping result *)
-  val adjust : t -> delta:float -> t
-
-  (** Compare fitness values *)
   val compare : t -> t -> int
-
-  (** JSON serialization *)
   val to_json : t -> Yojson.Safe.t
   val of_json : Yojson.Safe.t -> t option
 end = struct
@@ -160,21 +156,11 @@ end = struct
     else Some f
 
   let of_float_clamped f =
-    if not (is_finite f) then 0.5  (* Default on invalid *)
+    if not (is_finite f) then 0.5
     else max 0.0 (min 1.0 f)
 
   let to_float t = t
-
-  let initial () =
-    Swarm.initial_fitness ()
-
-  let combine a b = (a +. b) /. 2.0
-
-  let adjust t ~delta =
-    of_float_clamped (t +. delta)
-
   let compare = Float.compare
-
   let to_json t = `Float t
 
   let of_json = function
@@ -182,6 +168,45 @@ end = struct
     | `Int i -> of_float (float_of_int i)
     | _ -> None
 end
+
+(** Fitness: Normalized + domain-specific helpers for agent fitness *)
+module Fitness : sig
+  type t = Normalized.t
+
+  val of_float : float -> t option
+  val of_float_clamped : float -> t
+  val to_float : t -> float
+  val initial : unit -> t
+  val combine : t -> t -> t
+  val adjust : t -> delta:float -> t
+  val compare : t -> t -> int
+  val to_json : t -> Yojson.Safe.t
+  val of_json : Yojson.Safe.t -> t option
+end = struct
+  type t = Normalized.t
+
+  let of_float = Normalized.of_float
+  let of_float_clamped = Normalized.of_float_clamped
+  let to_float = Normalized.to_float
+  let compare = Normalized.compare
+  let to_json = Normalized.to_json
+  let of_json = Normalized.of_json
+
+  let initial () =
+    of_float_clamped (Swarm.initial_fitness ())
+
+  let combine a b =
+    of_float_clamped ((to_float a +. to_float b) /. 2.0)
+
+  let adjust t ~delta =
+    of_float_clamped (to_float t +. delta)
+end
+
+(** Strength: Normalized alias for pheromone strength *)
+module Strength = Normalized
+
+(** Threshold: Normalized alias for quorum thresholds *)
+module Threshold = Normalized
 
 (** Clamp float to valid range *)
 let clamp_float ~min ~max f =

--- a/lib/swarm_behaviors_eio.ml
+++ b/lib/swarm_behaviors_eio.ml
@@ -14,7 +14,6 @@ type flocking_params = {
 type foraging_state = {
   exploration_rate: float;
   discovered_solutions: (string * float) list;
-  current_target: string option;
 }
 
 type stigmergy_config = {
@@ -122,7 +121,6 @@ let flock_towards_fitness ~positions ~self ?(params = default_flocking_params) (
 let init_foraging ?(exploration_rate = 0.3) () = {
   exploration_rate;
   discovered_solutions = [];
-  current_target = None;
 }
 
 let select_solution ~rng ~foraging_state =
@@ -143,7 +141,8 @@ let record_discovery ~foraging_state ~solution_id ~quality =
   { foraging_state with discovered_solutions = solutions }
 
 let share_discovery ~fs config ~agent_id ~solution_id ~quality =
-  Swarm_eio.deposit_pheromone ~fs config ~path_id:solution_id ~agent_id ~strength:quality
+  let strength = Level4_config.Strength.of_float_clamped quality in
+  Swarm_eio.deposit_pheromone ~fs config ~path_id:solution_id ~agent_id ~strength
 
 (** {1 Stigmergy Behavior} *)
 
@@ -166,7 +165,8 @@ let follow_pheromone ~fs config ?(stigmergy = default_stigmergy_config)
       select 0.0 trails
 
 let mark_success ~fs config ~agent_id ~path_id ?(stigmergy = default_stigmergy_config) () =
-  Swarm_eio.deposit_pheromone ~fs config ~path_id ~agent_id ~strength:stigmergy.deposit_rate
+  let strength = Level4_config.Strength.of_float_clamped stigmergy.deposit_rate in
+  Swarm_eio.deposit_pheromone ~fs config ~path_id ~agent_id ~strength
 
 (** {1 Quorum Sensing Behavior} *)
 

--- a/lib/swarm_behaviors_eio.ml
+++ b/lib/swarm_behaviors_eio.ml
@@ -140,9 +140,8 @@ let record_discovery ~foraging_state ~solution_id ~quality =
   in
   { foraging_state with discovered_solutions = solutions }
 
-let share_discovery ~fs config ~agent_id ~solution_id ~quality =
-  let strength = Level4_config.Strength.of_float_clamped quality in
-  Swarm_eio.deposit_pheromone ~fs config ~path_id:solution_id ~agent_id ~strength
+let share_discovery ~fs config ~agent_id ~solution_id ~(quality : Level4_config.Strength.t) =
+  Swarm_eio.deposit_pheromone ~fs config ~path_id:solution_id ~agent_id ~strength:quality
 
 (** {1 Stigmergy Behavior} *)
 

--- a/lib/swarm_behaviors_eio.ml
+++ b/lib/swarm_behaviors_eio.ml
@@ -149,17 +149,18 @@ let share_discovery ~fs config ~agent_id ~solution_id ~quality =
 
 let follow_pheromone ~fs config ?(stigmergy = default_stigmergy_config)
     ?(rng = Level4_config.make_rng ()) () =
+  let nf = Level4_config.Normalized.to_float in
   let trails = Swarm_eio.get_strongest_trails ~fs config ~limit:5 in
-  let viable = List.filter (fun p -> p.Swarm_eio.strength >= stigmergy.following_threshold) trails in
+  let viable = List.filter (fun p -> nf p.Swarm_eio.strength >= stigmergy.following_threshold) trails in
   match viable with
   | [] -> None
   | trails ->
-      let total = List.fold_left (fun acc t -> acc +. t.Swarm_eio.strength) 0.0 trails in
+      let total = List.fold_left (fun acc t -> acc +. nf t.Swarm_eio.strength) 0.0 trails in
       let r = Random.State.float rng total in
       let rec select acc = function
         | [] -> None
         | t :: rest ->
-            let acc' = acc +. t.Swarm_eio.strength in
+            let acc' = acc +. nf t.Swarm_eio.strength in
             if r < acc' then Some t.Swarm_eio.path_id else select acc' rest
       in
       select 0.0 trails
@@ -176,11 +177,12 @@ let check_quorum ~fs config ~proposal_id =
       match List.find_opt (fun p -> p.Swarm_eio.proposal_id = proposal_id) swarm.proposals with
       | None -> `Not_found
       | Some proposal ->
+          let nf = Level4_config.Normalized.to_float in
           let total = List.length swarm.agents in
           let votes = List.length proposal.votes_for in
           let ratio = if total > 0 then float_of_int votes /. float_of_int total else 0.0 in
-          if ratio >= proposal.threshold then `Quorum_reached
-          else `Progress (votes, total, proposal.threshold)
+          if ratio >= nf proposal.threshold then `Quorum_reached
+          else `Progress (votes, total, nf proposal.threshold)
 
 let propose_action ~fs config ~agent_id ~description =
   Swarm_eio.propose ~fs config ~description ~proposed_by:agent_id ()

--- a/lib/swarm_behaviors_eio.ml
+++ b/lib/swarm_behaviors_eio.ml
@@ -125,8 +125,8 @@ let init_foraging ?(exploration_rate = 0.3) () = {
   current_target = None;
 }
 
-let select_solution ~foraging_state =
-  if Level4_config.random_float 1.0 < foraging_state.exploration_rate then None
+let select_solution ~rng ~foraging_state =
+  if Random.State.float rng 1.0 < foraging_state.exploration_rate then None
   else
     match List.sort (fun (_, q1) (_, q2) -> compare q2 q1) foraging_state.discovered_solutions with
     | (id, _) :: _ -> Some id
@@ -147,14 +147,15 @@ let share_discovery ~fs config ~agent_id ~solution_id ~quality =
 
 (** {1 Stigmergy Behavior} *)
 
-let follow_pheromone ~fs config ?(stigmergy = default_stigmergy_config) () =
+let follow_pheromone ~fs config ?(stigmergy = default_stigmergy_config)
+    ?(rng = Level4_config.make_rng ()) () =
   let trails = Swarm_eio.get_strongest_trails ~fs config ~limit:5 in
   let viable = List.filter (fun p -> p.Swarm_eio.strength >= stigmergy.following_threshold) trails in
   match viable with
   | [] -> None
   | trails ->
       let total = List.fold_left (fun acc t -> acc +. t.Swarm_eio.strength) 0.0 trails in
-      let r = Level4_config.random_float total in
+      let r = Random.State.float rng total in
       let rec select acc = function
         | [] -> None
         | t :: rest ->
@@ -170,8 +171,8 @@ let mark_success ~fs config ~agent_id ~path_id ?(stigmergy = default_stigmergy_c
 
 let check_quorum ~fs config ~proposal_id =
   match Swarm_eio.load_swarm ~fs config with
-  | None -> `No_swarm
-  | Some swarm ->
+  | Error _ -> `No_swarm
+  | Ok swarm ->
       match List.find_opt (fun p -> p.Swarm_eio.proposal_id = proposal_id) swarm.proposals with
       | None -> `Not_found
       | Some proposal ->
@@ -191,8 +192,8 @@ let vote_on_proposal ~fs config ~agent_id ~proposal_id ~support =
 
 let execute_behavior ~fs config ~agent_id =
   match Swarm_eio.load_swarm ~fs config with
-  | None -> `Error "No swarm exists"
-  | Some swarm ->
+  | Error _ -> `Error "No swarm exists"
+  | Ok swarm ->
       match swarm.swarm_cfg.behavior with
       | Swarm_eio.Flocking -> `Guidance "Cluster around high-fitness agents"
       | Swarm_eio.Foraging ->
@@ -213,8 +214,8 @@ let execute_behavior ~fs config ~agent_id =
 
 let recommend_behavior ~fs config =
   match Swarm_eio.load_swarm ~fs config with
-  | None -> Swarm_eio.Flocking
-  | Some swarm ->
+  | Error _ -> Swarm_eio.Flocking
+  | Ok swarm ->
       let agent_count = List.length swarm.agents in
       let pheromone_count = List.length swarm.pheromones in
       let pending_proposals = List.length (List.filter (fun (p : Swarm_eio.quorum_proposal) -> p.status = `Pending) swarm.proposals) in

--- a/lib/swarm_eio.ml
+++ b/lib/swarm_eio.ml
@@ -12,7 +12,7 @@ type swarm_behavior =
 type swarm_agent = {
   id: string;
   name: string;
-  fitness: float;
+  fitness: Level4_config.Fitness.t;
   generation: int;
   mutations: string list;
   joined_at: float;
@@ -21,10 +21,10 @@ type swarm_agent = {
 
 type pheromone = {
   path_id: string;
-  strength: float;
+  strength: Level4_config.Strength.t;
   deposited_by: string;
   deposited_at: float;
-  evaporation_rate: float;
+  evaporation_rate: Level4_config.Normalized.t;
 }
 
 type quorum_proposal = {
@@ -34,7 +34,7 @@ type quorum_proposal = {
   proposed_at: float;
   votes_for: string list;
   votes_against: string list;
-  threshold: float;
+  threshold: Level4_config.Threshold.t;
   deadline: float option;
   status: [`Pending | `Passed | `Rejected | `Expired];
 }
@@ -107,7 +107,7 @@ let agent_to_json (a : swarm_agent) : Yojson.Safe.t =
   `Assoc [
     ("id", `String a.id);
     ("name", `String a.name);
-    ("fitness", `Float a.fitness);
+    ("fitness", Level4_config.Fitness.to_json a.fitness);
     ("generation", `Int a.generation);
     ("mutations", `List (List.map (fun m -> `String m) a.mutations));
     ("joined_at", `Float a.joined_at);
@@ -120,7 +120,7 @@ let agent_of_json json : (swarm_agent, string) result =
     Ok {
       id = json |> member "id" |> to_string;
       name = json |> member "name" |> to_string;
-      fitness = json |> member "fitness" |> to_float;
+      fitness = json |> member "fitness" |> to_float |> Level4_config.Fitness.of_float_clamped;
       generation = json |> member "generation" |> to_int;
       mutations = json |> member "mutations" |> to_list |> List.map to_string;
       joined_at = json |> member "joined_at" |> to_float;
@@ -133,21 +133,22 @@ let agent_of_json json : (swarm_agent, string) result =
 let pheromone_to_json (p : pheromone) : Yojson.Safe.t =
   `Assoc [
     ("path_id", `String p.path_id);
-    ("strength", `Float p.strength);
+    ("strength", Level4_config.Strength.to_json p.strength);
     ("deposited_by", `String p.deposited_by);
     ("deposited_at", `Float p.deposited_at);
-    ("evaporation_rate", `Float p.evaporation_rate);
+    ("evaporation_rate", Level4_config.Normalized.to_json p.evaporation_rate);
   ]
 
 let pheromone_of_json json : (pheromone, string) result =
   try
     let open Yojson.Safe.Util in
+    let nc = Level4_config.Normalized.of_float_clamped in
     Ok {
       path_id = json |> member "path_id" |> to_string;
-      strength = json |> member "strength" |> to_float;
+      strength = json |> member "strength" |> to_float |> nc;
       deposited_by = json |> member "deposited_by" |> to_string;
       deposited_at = json |> member "deposited_at" |> to_float;
-      evaporation_rate = json |> member "evaporation_rate" |> to_float;
+      evaporation_rate = json |> member "evaporation_rate" |> to_float |> nc;
     }
   with
   | Yojson.Safe.Util.Type_error (msg, _) -> Error ("pheromone_of_json: " ^ msg)
@@ -161,7 +162,7 @@ let proposal_to_json (p : quorum_proposal) : Yojson.Safe.t =
     ("proposed_at", `Float p.proposed_at);
     ("votes_for", `List (List.map (fun v -> `String v) p.votes_for));
     ("votes_against", `List (List.map (fun v -> `String v) p.votes_against));
-    ("threshold", `Float p.threshold);
+    ("threshold", Level4_config.Threshold.to_json p.threshold);
     ("deadline", match p.deadline with Some d -> `Float d | None -> `Null);
     ("status", `String (status_to_string p.status));
   ]
@@ -176,7 +177,7 @@ let proposal_of_json json : (quorum_proposal, string) result =
       proposed_at = json |> member "proposed_at" |> to_float;
       votes_for = json |> member "votes_for" |> to_list |> List.map to_string;
       votes_against = json |> member "votes_against" |> to_list |> List.map to_string;
-      threshold = json |> member "threshold" |> to_float;
+      threshold = json |> member "threshold" |> to_float |> Level4_config.Threshold.of_float_clamped;
       deadline = json |> member "deadline" |> to_float_option;
       status = json |> member "status" |> to_string |> status_of_string;
     }
@@ -285,6 +286,10 @@ let save_swarm ~fs (config : config) (swarm : swarm) : unit =
 (** {1 Pure Transformations} *)
 
 module Pure = struct
+  (** Shorthand for unwrapping Normalized to float for arithmetic *)
+  let nf = Level4_config.Normalized.to_float
+  let nc = Level4_config.Normalized.of_float_clamped
+
   type join_result =
     | Joined of swarm
     | Already_member of swarm
@@ -296,11 +301,10 @@ module Pure = struct
     else if List.exists (fun (a : swarm_agent) -> a.id = agent_id) swarm.agents then
       Already_member swarm
     else
-      let initial_fitness = Level4_config.Swarm.initial_fitness () in
       let agent = {
         id = agent_id;
         name = agent_name;
-        fitness = initial_fitness;
+        fitness = Level4_config.Fitness.initial ();
         generation = swarm.generation;
         mutations = [];
         joined_at = now;
@@ -319,28 +323,27 @@ module Pure = struct
       match Level4_config.Fitness.of_float fitness with
       | None -> None
       | Some validated_fitness ->
-        let fitness_float = Level4_config.Fitness.to_float validated_fitness in
         let agents = List.map (fun (a : swarm_agent) ->
           if a.id = agent_id then
-            { a with fitness = fitness_float; last_active = now }
+            { a with fitness = validated_fitness; last_active = now }
           else a
         ) swarm.agents in
         Some { swarm with agents }
 
   let fitness_rankings swarm =
-    let rankings = List.map (fun (a : swarm_agent) -> (a.id, a.fitness)) swarm.agents in
+    let rankings = List.map (fun (a : swarm_agent) -> (a.id, nf a.fitness)) swarm.agents in
     List.sort (fun (_, f1) (_, f2) -> compare f2 f1) rankings
 
   let select_elite_agents swarm =
-    let sorted = List.sort (fun a b -> compare b.fitness a.fitness) swarm.agents in
+    let sorted = List.sort (fun a b -> compare (nf b.fitness) (nf a.fitness)) swarm.agents in
     let elite_count = max 1 (int_of_float (
-      float_of_int (List.length sorted) *. Level4_config.Normalized.to_float swarm.swarm_cfg.selection_pressure
+      float_of_int (List.length sorted) *. nf swarm.swarm_cfg.selection_pressure
     )) in
     List.filteri (fun i _ -> i < elite_count) sorted
 
   let evolve_agents swarm ~rng ~now =
     let agents = List.map (fun (a : swarm_agent) ->
-      if Random.State.float rng 1.0 < Level4_config.Normalized.to_float swarm.swarm_cfg.mutation_rate then
+      if Random.State.float rng 1.0 < nf swarm.swarm_cfg.mutation_rate then
         let mutation = Printf.sprintf "gen%d-mut%d" (swarm.generation + 1) (Random.State.int rng 1000) in
         { a with
           mutations = mutation :: a.mutations;
@@ -356,12 +359,12 @@ module Pure = struct
     }
 
   let deposit_pheromone swarm ~path_id ~agent_id ~strength ~now =
-    let evap_rate = Level4_config.Normalized.to_float swarm.swarm_cfg.evaporation_rate in
+    let evap_rate = swarm.swarm_cfg.evaporation_rate in
     let existing = List.find_opt (fun p -> p.path_id = path_id) swarm.pheromones in
     let pheromones = match existing with
       | Some p ->
         let updated = { p with
-          strength = min 1.0 (p.strength +. strength);
+          strength = nc (nf p.strength +. strength);
           deposited_by = agent_id;
           deposited_at = now;
         } in
@@ -369,7 +372,7 @@ module Pure = struct
       | None ->
         let new_pheromone = {
           path_id;
-          strength = min 1.0 strength;
+          strength = nc strength;
           deposited_by = agent_id;
           deposited_at = now;
           evaporation_rate = evap_rate;
@@ -381,15 +384,17 @@ module Pure = struct
   let evaporate_pheromones swarm ~now =
     let pheromones = List.filter_map (fun p ->
       let elapsed_hours = (now -. p.deposited_at) /. 3600.0 in
-      let decay = p.evaporation_rate *. elapsed_hours in
-      let new_strength = p.strength -. decay in
+      let decay = nf p.evaporation_rate *. elapsed_hours in
+      let new_strength = nf p.strength -. decay in
       if new_strength <= 0.0 then None
-      else Some { p with strength = new_strength }
+      else Some { p with strength = nc new_strength }
     ) swarm.pheromones in
     { swarm with pheromones }
 
   let strongest_trails swarm ~limit =
-    let sorted = List.sort (fun a b -> compare b.strength a.strength) swarm.pheromones in
+    let sorted = List.sort (fun a b ->
+      compare (nf b.strength) (nf a.strength)
+    ) swarm.pheromones in
     List.filteri (fun i _ -> i < limit) sorted
 
   let add_proposal swarm ~proposal =
@@ -416,13 +421,14 @@ module Pure = struct
         if p.proposal_id = proposal_id && p.status = `Pending then
           let for_ratio = float_of_int (List.length p.votes_for) /. float_of_int total_agents in
           let against_ratio = float_of_int (List.length p.votes_against) /. float_of_int total_agents in
+          let threshold_f = nf p.threshold in
           let expired = match p.deadline with
             | Some d -> now > d
             | None -> false
           in
           let status =
-            if for_ratio >= p.threshold then `Passed
-            else if against_ratio > (1.0 -. p.threshold) then `Rejected
+            if for_ratio >= threshold_f then `Passed
+            else if against_ratio > (1.0 -. threshold_f) then `Rejected
             else if expired then `Expired
             else `Pending
           in
@@ -508,7 +514,6 @@ let deposit_pheromone ~fs (config : config) ~path_id ~agent_id ~strength : swarm
   | Error _ -> None
   | Ok swarm ->
     let now = Unix.gettimeofday () in
-    let strength = max 0.0 (min 1.0 strength) in
     let updated = Pure.deposit_pheromone swarm ~path_id ~agent_id ~strength ~now in
     save_swarm ~fs config updated;
     Some updated
@@ -521,8 +526,9 @@ let read_pheromone ~fs (config : config) ~path_id : float =
     match List.find_opt (fun p -> p.path_id = path_id) swarm.pheromones with
     | None -> 0.0
     | Some p ->
+      let nf = Level4_config.Normalized.to_float in
       let hours_elapsed = (now -. p.deposited_at) /. 3600.0 in
-      let decayed = p.strength *. exp (-. p.evaporation_rate *. hours_elapsed) in
+      let decayed = nf p.strength *. exp (-. nf p.evaporation_rate *. hours_elapsed) in
       max 0.0 decayed
 
 let evaporate_pheromones ~fs (config : config) : swarm option =
@@ -553,7 +559,9 @@ let propose ~fs (config : config) ~description ~proposed_by ?threshold ?deadline
       proposed_at = now;
       votes_for = [proposed_by];
       votes_against = [];
-      threshold = Option.value threshold ~default:(Level4_config.Normalized.to_float swarm.swarm_cfg.quorum_threshold);
+      threshold = (match threshold with
+        | Some t -> Level4_config.Threshold.of_float_clamped t
+        | None -> swarm.swarm_cfg.quorum_threshold);
       deadline;
       status = `Pending;
     } in

--- a/lib/swarm_eio.ml
+++ b/lib/swarm_eio.ml
@@ -42,10 +42,10 @@ type quorum_proposal = {
 type swarm_config = {
   id: string;
   name: string;
-  selection_pressure: float;
-  mutation_rate: float;
-  evaporation_rate: float;
-  quorum_threshold: float;
+  selection_pressure: Level4_config.Normalized.t;
+  mutation_rate: Level4_config.Normalized.t;
+  evaporation_rate: Level4_config.Normalized.t;
+  quorum_threshold: Level4_config.Normalized.t;
   max_agents: int;
   behavior: swarm_behavior;
 }
@@ -64,13 +64,13 @@ type config = Room_utils.config
 
 (** {1 Default Configuration} *)
 
-let default_config ?(id = "") ?(name = "default-swarm") () = {
-  id = if id = "" then Printf.sprintf "swarm-%d" (Level4_config.random_int 100000) else id;
+let default_config ?(id = "") ?(name = "default-swarm") ?(rng = Level4_config.make_rng ()) () = {
+  id = if id = "" then Printf.sprintf "swarm-%d" (Random.State.int rng 100000) else id;
   name;
-  selection_pressure = 0.3;
-  mutation_rate = 0.1;
-  evaporation_rate = 0.1;
-  quorum_threshold = 0.6;
+  selection_pressure = Level4_config.Normalized.of_float_clamped 0.3;
+  mutation_rate = Level4_config.Normalized.of_float_clamped 0.1;
+  evaporation_rate = Level4_config.Normalized.of_float_clamped 0.1;
+  quorum_threshold = Level4_config.Normalized.of_float_clamped 0.6;
   max_agents = 50;
   behavior = Flocking;
 }
@@ -114,17 +114,21 @@ let agent_to_json (a : swarm_agent) : Yojson.Safe.t =
     ("last_active", `Float a.last_active);
   ]
 
-let agent_of_json json =
-  let open Yojson.Safe.Util in
-  {
-    id = json |> member "id" |> to_string;
-    name = json |> member "name" |> to_string;
-    fitness = json |> member "fitness" |> to_float;
-    generation = json |> member "generation" |> to_int;
-    mutations = json |> member "mutations" |> to_list |> List.map to_string;
-    joined_at = json |> member "joined_at" |> to_float;
-    last_active = json |> member "last_active" |> to_float;
-  }
+let agent_of_json json : (swarm_agent, string) result =
+  try
+    let open Yojson.Safe.Util in
+    Ok {
+      id = json |> member "id" |> to_string;
+      name = json |> member "name" |> to_string;
+      fitness = json |> member "fitness" |> to_float;
+      generation = json |> member "generation" |> to_int;
+      mutations = json |> member "mutations" |> to_list |> List.map to_string;
+      joined_at = json |> member "joined_at" |> to_float;
+      last_active = json |> member "last_active" |> to_float;
+    }
+  with
+  | Yojson.Safe.Util.Type_error (msg, _) -> Error ("agent_of_json: " ^ msg)
+  | Yojson.Json_error msg -> Error ("agent_of_json: " ^ msg)
 
 let pheromone_to_json (p : pheromone) : Yojson.Safe.t =
   `Assoc [
@@ -135,15 +139,19 @@ let pheromone_to_json (p : pheromone) : Yojson.Safe.t =
     ("evaporation_rate", `Float p.evaporation_rate);
   ]
 
-let pheromone_of_json json =
-  let open Yojson.Safe.Util in
-  {
-    path_id = json |> member "path_id" |> to_string;
-    strength = json |> member "strength" |> to_float;
-    deposited_by = json |> member "deposited_by" |> to_string;
-    deposited_at = json |> member "deposited_at" |> to_float;
-    evaporation_rate = json |> member "evaporation_rate" |> to_float;
-  }
+let pheromone_of_json json : (pheromone, string) result =
+  try
+    let open Yojson.Safe.Util in
+    Ok {
+      path_id = json |> member "path_id" |> to_string;
+      strength = json |> member "strength" |> to_float;
+      deposited_by = json |> member "deposited_by" |> to_string;
+      deposited_at = json |> member "deposited_at" |> to_float;
+      evaporation_rate = json |> member "evaporation_rate" |> to_float;
+    }
+  with
+  | Yojson.Safe.Util.Type_error (msg, _) -> Error ("pheromone_of_json: " ^ msg)
+  | Yojson.Json_error msg -> Error ("pheromone_of_json: " ^ msg)
 
 let proposal_to_json (p : quorum_proposal) : Yojson.Safe.t =
   `Assoc [
@@ -158,44 +166,53 @@ let proposal_to_json (p : quorum_proposal) : Yojson.Safe.t =
     ("status", `String (status_to_string p.status));
   ]
 
-let proposal_of_json json =
-  let open Yojson.Safe.Util in
-  {
-    proposal_id = json |> member "proposal_id" |> to_string;
-    description = json |> member "description" |> to_string;
-    proposed_by = json |> member "proposed_by" |> to_string;
-    proposed_at = json |> member "proposed_at" |> to_float;
-    votes_for = json |> member "votes_for" |> to_list |> List.map to_string;
-    votes_against = json |> member "votes_against" |> to_list |> List.map to_string;
-    threshold = json |> member "threshold" |> to_float;
-    deadline = json |> member "deadline" |> to_float_option;
-    status = json |> member "status" |> to_string |> status_of_string;
-  }
+let proposal_of_json json : (quorum_proposal, string) result =
+  try
+    let open Yojson.Safe.Util in
+    Ok {
+      proposal_id = json |> member "proposal_id" |> to_string;
+      description = json |> member "description" |> to_string;
+      proposed_by = json |> member "proposed_by" |> to_string;
+      proposed_at = json |> member "proposed_at" |> to_float;
+      votes_for = json |> member "votes_for" |> to_list |> List.map to_string;
+      votes_against = json |> member "votes_against" |> to_list |> List.map to_string;
+      threshold = json |> member "threshold" |> to_float;
+      deadline = json |> member "deadline" |> to_float_option;
+      status = json |> member "status" |> to_string |> status_of_string;
+    }
+  with
+  | Yojson.Safe.Util.Type_error (msg, _) -> Error ("proposal_of_json: " ^ msg)
+  | Yojson.Json_error msg -> Error ("proposal_of_json: " ^ msg)
 
 let config_to_json (c : swarm_config) : Yojson.Safe.t =
   `Assoc [
     ("id", `String c.id);
     ("name", `String c.name);
-    ("selection_pressure", `Float c.selection_pressure);
-    ("mutation_rate", `Float c.mutation_rate);
-    ("evaporation_rate", `Float c.evaporation_rate);
-    ("quorum_threshold", `Float c.quorum_threshold);
+    ("selection_pressure", Level4_config.Normalized.to_json c.selection_pressure);
+    ("mutation_rate", Level4_config.Normalized.to_json c.mutation_rate);
+    ("evaporation_rate", Level4_config.Normalized.to_json c.evaporation_rate);
+    ("quorum_threshold", Level4_config.Normalized.to_json c.quorum_threshold);
     ("max_agents", `Int c.max_agents);
     ("behavior", `String (behavior_to_string c.behavior));
   ]
 
-let config_of_json json =
-  let open Yojson.Safe.Util in
-  {
-    id = json |> member "id" |> to_string;
-    name = json |> member "name" |> to_string;
-    selection_pressure = json |> member "selection_pressure" |> to_float;
-    mutation_rate = json |> member "mutation_rate" |> to_float;
-    evaporation_rate = json |> member "evaporation_rate" |> to_float;
-    quorum_threshold = json |> member "quorum_threshold" |> to_float;
-    max_agents = json |> member "max_agents" |> to_int;
-    behavior = json |> member "behavior" |> to_string |> behavior_of_string;
-  }
+let config_of_json json : (swarm_config, string) result =
+  try
+    let open Yojson.Safe.Util in
+    let n f = Level4_config.Normalized.of_float_clamped f in
+    Ok {
+      id = json |> member "id" |> to_string;
+      name = json |> member "name" |> to_string;
+      selection_pressure = json |> member "selection_pressure" |> to_float |> n;
+      mutation_rate = json |> member "mutation_rate" |> to_float |> n;
+      evaporation_rate = json |> member "evaporation_rate" |> to_float |> n;
+      quorum_threshold = json |> member "quorum_threshold" |> to_float |> n;
+      max_agents = json |> member "max_agents" |> to_int;
+      behavior = json |> member "behavior" |> to_string |> behavior_of_string;
+    }
+  with
+  | Yojson.Safe.Util.Type_error (msg, _) -> Error ("config_of_json: " ^ msg)
+  | Yojson.Json_error msg -> Error ("config_of_json: " ^ msg)
 
 let swarm_to_json (s : swarm) : Yojson.Safe.t =
   `Assoc [
@@ -208,31 +225,53 @@ let swarm_to_json (s : swarm) : Yojson.Safe.t =
     ("last_evolution", `Float s.last_evolution);
   ]
 
-let swarm_of_json json =
-  let open Yojson.Safe.Util in
-  {
-    swarm_cfg = json |> member "config" |> config_of_json;
-    agents = json |> member "agents" |> to_list |> List.map agent_of_json;
-    pheromones = json |> member "pheromones" |> to_list |> List.map pheromone_of_json;
-    proposals = json |> member "proposals" |> to_list |> List.map proposal_of_json;
-    generation = json |> member "generation" |> to_int;
-    created_at = json |> member "created_at" |> to_float;
-    last_evolution = json |> member "last_evolution" |> to_float;
-  }
+let result_map_list f xs =
+  List.fold_left (fun acc x ->
+    match acc with
+    | Error _ as e -> e
+    | Ok lst ->
+      match f x with
+      | Ok v -> Ok (v :: lst)
+      | Error _ as e -> e
+  ) (Ok []) xs
+  |> Result.map List.rev
+
+let swarm_of_json json : (swarm, string) result =
+  try
+    let open Yojson.Safe.Util in
+    Result.bind (json |> member "config" |> config_of_json) (fun swarm_cfg ->
+    Result.bind (json |> member "agents" |> to_list |> result_map_list agent_of_json) (fun agents ->
+    Result.bind (json |> member "pheromones" |> to_list |> result_map_list pheromone_of_json) (fun pheromones ->
+    Result.bind (json |> member "proposals" |> to_list |> result_map_list proposal_of_json) (fun proposals ->
+    Ok {
+      swarm_cfg;
+      agents;
+      pheromones;
+      proposals;
+      generation = json |> member "generation" |> to_int;
+      created_at = json |> member "created_at" |> to_float;
+      last_evolution = json |> member "last_evolution" |> to_float;
+    }))))
+  with
+  | Yojson.Safe.Util.Type_error (msg, _) -> Error ("swarm_of_json: " ^ msg)
+  | Yojson.Json_error msg -> Error ("swarm_of_json: " ^ msg)
 
 (** {1 Persistence (Eio Native)} *)
 
 let swarm_file (config : config) =
   Filename.concat config.base_path ".masc/swarm.json"
 
-let load_swarm ~fs (config : config) : swarm option =
+let load_swarm ~fs (config : config) : (swarm, string) result =
   let file = swarm_file config in
   let path = Eio.Path.(fs / file) in
   try
     let content = Eio.Path.load path in
     let json = Yojson.Safe.from_string content in
-    Some (swarm_of_json json)
-  with Eio.Io _ | Yojson.Json_error _ | Yojson.Safe.Util.Type_error _ -> None
+    swarm_of_json json
+  with
+  | Eio.Io _ as exn -> Error ("load_swarm IO: " ^ Printexc.to_string exn)
+  | Yojson.Json_error msg -> Error ("load_swarm JSON: " ^ msg)
+  | Yojson.Safe.Util.Type_error (msg, _) -> Error ("load_swarm: " ^ msg)
 
 let save_swarm ~fs (config : config) (swarm : swarm) : unit =
   let file = swarm_file config in
@@ -295,14 +334,14 @@ module Pure = struct
   let select_elite_agents swarm =
     let sorted = List.sort (fun a b -> compare b.fitness a.fitness) swarm.agents in
     let elite_count = max 1 (int_of_float (
-      float_of_int (List.length sorted) *. swarm.swarm_cfg.selection_pressure
+      float_of_int (List.length sorted) *. Level4_config.Normalized.to_float swarm.swarm_cfg.selection_pressure
     )) in
     List.filteri (fun i _ -> i < elite_count) sorted
 
-  let evolve_agents swarm ~now =
+  let evolve_agents swarm ~rng ~now =
     let agents = List.map (fun (a : swarm_agent) ->
-      if Level4_config.random_float 1.0 < swarm.swarm_cfg.mutation_rate then
-        let mutation = Printf.sprintf "gen%d-mut%d" (swarm.generation + 1) (Level4_config.random_int 1000) in
+      if Random.State.float rng 1.0 < Level4_config.Normalized.to_float swarm.swarm_cfg.mutation_rate then
+        let mutation = Printf.sprintf "gen%d-mut%d" (swarm.generation + 1) (Random.State.int rng 1000) in
         { a with
           mutations = mutation :: a.mutations;
           generation = swarm.generation + 1;
@@ -317,7 +356,7 @@ module Pure = struct
     }
 
   let deposit_pheromone swarm ~path_id ~agent_id ~strength ~now =
-    let evap_rate = swarm.swarm_cfg.evaporation_rate in
+    let evap_rate = Level4_config.Normalized.to_float swarm.swarm_cfg.evaporation_rate in
     let existing = List.find_opt (fun p -> p.path_id = path_id) swarm.pheromones in
     let pheromones = match existing with
       | Some p ->
@@ -411,8 +450,8 @@ let create ~fs (config : config) ?(swarm_config = default_config ()) () : swarm 
 
 let join ~fs (config : config) ~agent_id ~agent_name : swarm option =
   match load_swarm ~fs config with
-  | None -> None
-  | Some swarm ->
+  | Error _ -> None
+  | Ok swarm ->
     let now = Unix.gettimeofday () in
     match Pure.join_agent swarm ~agent_id ~agent_name ~now with
     | Pure.Joined updated ->
@@ -423,8 +462,8 @@ let join ~fs (config : config) ~agent_id ~agent_name : swarm option =
 
 let leave ~fs (config : config) ~agent_id : swarm option =
   match load_swarm ~fs config with
-  | None -> None
-  | Some swarm ->
+  | Error _ -> None
+  | Ok swarm ->
     let updated = Pure.leave_agent swarm ~agent_id in
     save_swarm ~fs config updated;
     Some updated
@@ -436,8 +475,8 @@ let dissolve ~fs (config : config) : unit =
 
 let update_fitness ~fs (config : config) ~agent_id ~fitness : swarm option =
   match load_swarm ~fs config with
-  | None -> None
-  | Some swarm ->
+  | Error _ -> None
+  | Ok swarm ->
     let now = Unix.gettimeofday () in
     match Pure.update_agent_fitness swarm ~agent_id ~fitness ~now with
     | None -> None
@@ -447,27 +486,27 @@ let update_fitness ~fs (config : config) ~agent_id ~fitness : swarm option =
 
 let get_fitness_rankings ~fs (config : config) : (string * float) list =
   match load_swarm ~fs config with
-  | None -> []
-  | Some swarm -> Pure.fitness_rankings swarm
+  | Error _ -> []
+  | Ok swarm -> Pure.fitness_rankings swarm
 
 let select_elite ~fs (config : config) : swarm_agent list =
   match load_swarm ~fs config with
-  | None -> []
-  | Some swarm -> Pure.select_elite_agents swarm
+  | Error _ -> []
+  | Ok swarm -> Pure.select_elite_agents swarm
 
-let evolve ~fs (config : config) : swarm option =
+let evolve ~fs (config : config) ?(rng = Level4_config.make_rng ()) () : swarm option =
   match load_swarm ~fs config with
-  | None -> None
-  | Some swarm ->
+  | Error _ -> None
+  | Ok swarm ->
     let now = Unix.gettimeofday () in
-    let updated = Pure.evolve_agents swarm ~now in
+    let updated = Pure.evolve_agents swarm ~rng ~now in
     save_swarm ~fs config updated;
     Some updated
 
 let deposit_pheromone ~fs (config : config) ~path_id ~agent_id ~strength : swarm option =
   match load_swarm ~fs config with
-  | None -> None
-  | Some swarm ->
+  | Error _ -> None
+  | Ok swarm ->
     let now = Unix.gettimeofday () in
     let strength = max 0.0 (min 1.0 strength) in
     let updated = Pure.deposit_pheromone swarm ~path_id ~agent_id ~strength ~now in
@@ -476,8 +515,8 @@ let deposit_pheromone ~fs (config : config) ~path_id ~agent_id ~strength : swarm
 
 let read_pheromone ~fs (config : config) ~path_id : float =
   match load_swarm ~fs config with
-  | None -> 0.0
-  | Some swarm ->
+  | Error _ -> 0.0
+  | Ok swarm ->
     let now = Unix.gettimeofday () in
     match List.find_opt (fun p -> p.path_id = path_id) swarm.pheromones with
     | None -> 0.0
@@ -488,8 +527,8 @@ let read_pheromone ~fs (config : config) ~path_id : float =
 
 let evaporate_pheromones ~fs (config : config) : swarm option =
   match load_swarm ~fs config with
-  | None -> None
-  | Some swarm ->
+  | Error _ -> None
+  | Ok swarm ->
     let now = Unix.gettimeofday () in
     let updated = Pure.evaporate_pheromones swarm ~now in
     save_swarm ~fs config updated;
@@ -497,23 +536,24 @@ let evaporate_pheromones ~fs (config : config) : swarm option =
 
 let get_strongest_trails ~fs (config : config) ~limit : pheromone list =
   match load_swarm ~fs config with
-  | None -> []
-  | Some swarm -> Pure.strongest_trails swarm ~limit
+  | Error _ -> []
+  | Ok swarm -> Pure.strongest_trails swarm ~limit
 
-let propose ~fs (config : config) ~description ~proposed_by ?threshold ?deadline ()
+let propose ~fs (config : config) ~description ~proposed_by ?threshold ?deadline
+    ?(rng = Level4_config.make_rng ()) ()
     : quorum_proposal option =
   match load_swarm ~fs config with
-  | None -> None
-  | Some swarm ->
+  | Error _ -> None
+  | Ok swarm ->
     let now = Unix.gettimeofday () in
     let proposal = {
-      proposal_id = Printf.sprintf "prop-%d-%d" (int_of_float (now *. 1000.0)) (Level4_config.random_int 10000);
+      proposal_id = Printf.sprintf "prop-%d-%d" (int_of_float (now *. 1000.0)) (Random.State.int rng 10000);
       description;
       proposed_by;
       proposed_at = now;
       votes_for = [proposed_by];
       votes_against = [];
-      threshold = Option.value threshold ~default:swarm.swarm_cfg.quorum_threshold;
+      threshold = Option.value threshold ~default:(Level4_config.Normalized.to_float swarm.swarm_cfg.quorum_threshold);
       deadline;
       status = `Pending;
     } in
@@ -523,8 +563,8 @@ let propose ~fs (config : config) ~description ~proposed_by ?threshold ?deadline
 
 let vote ~fs (config : config) ~proposal_id ~agent_id ~vote_for : quorum_proposal option =
   match load_swarm ~fs config with
-  | None -> None
-  | Some swarm ->
+  | Error _ -> None
+  | Ok swarm ->
     let now = Unix.gettimeofday () in
     let with_vote = Pure.record_vote swarm ~proposal_id ~agent_id ~vote_for in
     let updated = Pure.update_proposal_status with_vote ~proposal_id ~now in
@@ -533,21 +573,21 @@ let vote ~fs (config : config) ~proposal_id ~agent_id ~vote_for : quorum_proposa
 
 let get_pending_proposals ~fs (config : config) : quorum_proposal list =
   match load_swarm ~fs config with
-  | None -> []
-  | Some swarm -> List.filter (fun p -> p.status = `Pending) swarm.proposals
+  | Error _ -> []
+  | Ok swarm -> List.filter (fun p -> p.status = `Pending) swarm.proposals
 
 let set_behavior ~fs (config : config) ~behavior : swarm option =
   match load_swarm ~fs config with
-  | None -> None
-  | Some swarm ->
+  | Error _ -> None
+  | Ok swarm ->
     let updated = { swarm with swarm_cfg = { swarm.swarm_cfg with behavior } } in
     save_swarm ~fs config updated;
     Some updated
 
 let status ~fs (config : config) : Yojson.Safe.t =
   match load_swarm ~fs config with
-  | None -> `Assoc [("exists", `Bool false); ("message", `String "No swarm exists")]
-  | Some swarm ->
+  | Error _ -> `Assoc [("exists", `Bool false); ("message", `String "No swarm exists")]
+  | Ok swarm ->
     let elite = select_elite ~fs config in
     `Assoc [
       ("exists", `Bool true);
@@ -559,8 +599,8 @@ let status ~fs (config : config) : Yojson.Safe.t =
       ("max_agents", `Int swarm.swarm_cfg.max_agents);
       ("pheromone_count", `Int (List.length swarm.pheromones));
       ("pending_proposals", `Int (List.length (List.filter (fun p -> p.status = `Pending) swarm.proposals)));
-      ("selection_pressure", `Float swarm.swarm_cfg.selection_pressure);
-      ("mutation_rate", `Float swarm.swarm_cfg.mutation_rate);
+      ("selection_pressure", Level4_config.Normalized.to_json swarm.swarm_cfg.selection_pressure);
+      ("mutation_rate", Level4_config.Normalized.to_json swarm.swarm_cfg.mutation_rate);
       ("elite_agents", `List (List.map (fun (a : swarm_agent) -> `String a.id) elite));
       ("created_at", `Float swarm.created_at);
       ("last_evolution", `Float swarm.last_evolution);

--- a/lib/swarm_eio.ml
+++ b/lib/swarm_eio.ml
@@ -358,13 +358,13 @@ module Pure = struct
       last_evolution = now;
     }
 
-  let deposit_pheromone swarm ~path_id ~agent_id ~strength ~now =
+  let deposit_pheromone swarm ~path_id ~agent_id ~(strength : Level4_config.Strength.t) ~now =
     let evap_rate = swarm.swarm_cfg.evaporation_rate in
     let existing = List.find_opt (fun p -> p.path_id = path_id) swarm.pheromones in
     let pheromones = match existing with
       | Some p ->
         let updated = { p with
-          strength = nc (nf p.strength +. strength);
+          strength = nc (nf p.strength +. nf strength);
           deposited_by = agent_id;
           deposited_at = now;
         } in
@@ -372,7 +372,7 @@ module Pure = struct
       | None ->
         let new_pheromone = {
           path_id;
-          strength = nc strength;
+          strength;
           deposited_by = agent_id;
           deposited_at = now;
           evaporation_rate = evap_rate;
@@ -454,41 +454,41 @@ let create ~fs (config : config) ?(swarm_config = default_config ()) () : swarm 
   save_swarm ~fs config swarm;
   swarm
 
-let join ~fs (config : config) ~agent_id ~agent_name : swarm option =
+let join ~fs (config : config) ~agent_id ~agent_name : (swarm, string) result =
   match load_swarm ~fs config with
-  | Error _ -> None
+  | Error e -> Error ("join: " ^ e)
   | Ok swarm ->
     let now = Unix.gettimeofday () in
     match Pure.join_agent swarm ~agent_id ~agent_name ~now with
     | Pure.Joined updated ->
       save_swarm ~fs config updated;
-      Some updated
-    | Pure.Already_member s -> Some s
-    | Pure.Swarm_full -> None
+      Ok updated
+    | Pure.Already_member s -> Ok s
+    | Pure.Swarm_full -> Error "join: swarm is full"
 
-let leave ~fs (config : config) ~agent_id : swarm option =
+let leave ~fs (config : config) ~agent_id : (swarm, string) result =
   match load_swarm ~fs config with
-  | Error _ -> None
+  | Error e -> Error ("leave: " ^ e)
   | Ok swarm ->
     let updated = Pure.leave_agent swarm ~agent_id in
     save_swarm ~fs config updated;
-    Some updated
+    Ok updated
 
 let dissolve ~fs (config : config) : unit =
   let file = swarm_file config in
   let path = Eio.Path.(fs / file) in
   try Eio.Path.unlink path with Eio.Io _ -> ()
 
-let update_fitness ~fs (config : config) ~agent_id ~fitness : swarm option =
+let update_fitness ~fs (config : config) ~agent_id ~fitness : (swarm, string) result =
   match load_swarm ~fs config with
-  | Error _ -> None
+  | Error e -> Error ("update_fitness: " ^ e)
   | Ok swarm ->
     let now = Unix.gettimeofday () in
     match Pure.update_agent_fitness swarm ~agent_id ~fitness ~now with
-    | None -> None
+    | None -> Error (Printf.sprintf "update_fitness: agent %s not found" agent_id)
     | Some updated ->
       save_swarm ~fs config updated;
-      Some updated
+      Ok updated
 
 let get_fitness_rankings ~fs (config : config) : (string * float) list =
   match load_swarm ~fs config with
@@ -500,23 +500,23 @@ let select_elite ~fs (config : config) : swarm_agent list =
   | Error _ -> []
   | Ok swarm -> Pure.select_elite_agents swarm
 
-let evolve ~fs (config : config) ?(rng = Level4_config.make_rng ()) () : swarm option =
+let evolve ~fs (config : config) ?(rng = Level4_config.make_rng ()) () : (swarm, string) result =
   match load_swarm ~fs config with
-  | Error _ -> None
+  | Error e -> Error ("evolve: " ^ e)
   | Ok swarm ->
     let now = Unix.gettimeofday () in
     let updated = Pure.evolve_agents swarm ~rng ~now in
     save_swarm ~fs config updated;
-    Some updated
+    Ok updated
 
-let deposit_pheromone ~fs (config : config) ~path_id ~agent_id ~strength : swarm option =
+let deposit_pheromone ~fs (config : config) ~path_id ~agent_id ~(strength : Level4_config.Strength.t) : (swarm, string) result =
   match load_swarm ~fs config with
-  | Error _ -> None
+  | Error e -> Error ("deposit_pheromone: " ^ e)
   | Ok swarm ->
     let now = Unix.gettimeofday () in
     let updated = Pure.deposit_pheromone swarm ~path_id ~agent_id ~strength ~now in
     save_swarm ~fs config updated;
-    Some updated
+    Ok updated
 
 let read_pheromone ~fs (config : config) ~path_id : float =
   match load_swarm ~fs config with
@@ -531,14 +531,14 @@ let read_pheromone ~fs (config : config) ~path_id : float =
       let decayed = nf p.strength *. exp (-. nf p.evaporation_rate *. hours_elapsed) in
       max 0.0 decayed
 
-let evaporate_pheromones ~fs (config : config) : swarm option =
+let evaporate_pheromones ~fs (config : config) : (swarm, string) result =
   match load_swarm ~fs config with
-  | Error _ -> None
+  | Error e -> Error ("evaporate_pheromones: " ^ e)
   | Ok swarm ->
     let now = Unix.gettimeofday () in
     let updated = Pure.evaporate_pheromones swarm ~now in
     save_swarm ~fs config updated;
-    Some updated
+    Ok updated
 
 let get_strongest_trails ~fs (config : config) ~limit : pheromone list =
   match load_swarm ~fs config with
@@ -547,9 +547,9 @@ let get_strongest_trails ~fs (config : config) ~limit : pheromone list =
 
 let propose ~fs (config : config) ~description ~proposed_by ?threshold ?deadline
     ?(rng = Level4_config.make_rng ()) ()
-    : quorum_proposal option =
+    : (quorum_proposal, string) result =
   match load_swarm ~fs config with
-  | Error _ -> None
+  | Error e -> Error ("propose: " ^ e)
   | Ok swarm ->
     let now = Unix.gettimeofday () in
     let proposal = {
@@ -567,30 +567,32 @@ let propose ~fs (config : config) ~description ~proposed_by ?threshold ?deadline
     } in
     let updated = Pure.add_proposal swarm ~proposal in
     save_swarm ~fs config updated;
-    Some proposal
+    Ok proposal
 
-let vote ~fs (config : config) ~proposal_id ~agent_id ~vote_for : quorum_proposal option =
+let vote ~fs (config : config) ~proposal_id ~agent_id ~vote_for : (quorum_proposal, string) result =
   match load_swarm ~fs config with
-  | Error _ -> None
+  | Error e -> Error ("vote: " ^ e)
   | Ok swarm ->
     let now = Unix.gettimeofday () in
     let with_vote = Pure.record_vote swarm ~proposal_id ~agent_id ~vote_for in
     let updated = Pure.update_proposal_status with_vote ~proposal_id ~now in
     save_swarm ~fs config updated;
-    List.find_opt (fun p -> p.proposal_id = proposal_id) updated.proposals
+    match List.find_opt (fun p -> p.proposal_id = proposal_id) updated.proposals with
+    | Some p -> Ok p
+    | None -> Error (Printf.sprintf "vote: proposal %s not found after update" proposal_id)
 
 let get_pending_proposals ~fs (config : config) : quorum_proposal list =
   match load_swarm ~fs config with
   | Error _ -> []
   | Ok swarm -> List.filter (fun p -> p.status = `Pending) swarm.proposals
 
-let set_behavior ~fs (config : config) ~behavior : swarm option =
+let set_behavior ~fs (config : config) ~behavior : (swarm, string) result =
   match load_swarm ~fs config with
-  | Error _ -> None
+  | Error e -> Error ("set_behavior: " ^ e)
   | Ok swarm ->
     let updated = { swarm with swarm_cfg = { swarm.swarm_cfg with behavior } } in
     save_swarm ~fs config updated;
-    Some updated
+    Ok updated
 
 let status ~fs (config : config) : Yojson.Safe.t =
   match load_swarm ~fs config with

--- a/lib/tool_swarm.ml
+++ b/lib/tool_swarm.ml
@@ -48,8 +48,8 @@ let handle_join ctx args : result =
   match ctx.fs with
   | Some fs ->
       (match Swarm_eio.join ~fs ctx.config ~agent_id:join_agent_name ~agent_name:join_agent_name with
-       | Some _ -> (true, Printf.sprintf "✅ Agent %s joined the swarm" join_agent_name)
-       | None -> (false, "❌ Failed to join swarm (full or nonexistent)"))
+       | Ok _ -> (true, Printf.sprintf "✅ Agent %s joined the swarm" join_agent_name)
+       | Error e -> (false, "❌ " ^ e))
   | None -> (false, "❌ Filesystem not available")
 
 (** Handle masc_swarm_leave *)
@@ -58,8 +58,8 @@ let handle_leave ctx args : result =
   match ctx.fs with
   | Some fs ->
       (match Swarm_eio.leave ~fs ctx.config ~agent_id:leave_agent_name with
-       | Some _ -> (true, Printf.sprintf "✅ Agent %s left the swarm" leave_agent_name)
-       | None -> (false, "❌ Failed to leave swarm"))
+       | Ok _ -> (true, Printf.sprintf "✅ Agent %s left the swarm" leave_agent_name)
+       | Error e -> (false, "❌ " ^ e))
   | None -> (false, "❌ Filesystem not available")
 
 (** Handle masc_swarm_status *)
@@ -73,8 +73,8 @@ let handle_evolve ctx _args : result =
   match ctx.fs with
   | Some fs ->
       (match Swarm_eio.evolve ~fs ctx.config () with
-       | Some s -> (true, Printf.sprintf "✅ Swarm evolved to generation %d" s.generation)
-       | None -> (false, "❌ Evolution failed"))
+       | Ok s -> (true, Printf.sprintf "✅ Swarm evolved to generation %d" s.generation)
+       | Error e -> (false, "❌ " ^ e))
   | None -> (false, "❌ Filesystem not available")
 
 (** Handle masc_swarm_propose *)
@@ -84,8 +84,8 @@ let handle_propose ctx args : result =
   match ctx.fs with
   | Some fs ->
       (match Swarm_eio.propose ~fs ctx.config ~description ~proposed_by:ctx.agent_name ?threshold () with
-       | Some p -> (true, Printf.sprintf "✅ Proposal %s created" p.proposal_id)
-       | None -> (false, "❌ Failed to create proposal"))
+       | Ok p -> (true, Printf.sprintf "✅ Proposal %s created" p.proposal_id)
+       | Error e -> (false, "❌ " ^ e))
   | None -> (false, "❌ Filesystem not available")
 
 (** Handle masc_swarm_vote *)
@@ -95,19 +95,19 @@ let handle_vote ctx args : result =
   match ctx.fs with
   | Some fs ->
       (match Swarm_eio.vote ~fs ctx.config ~proposal_id ~agent_id:ctx.agent_name ~vote_for with
-       | Some p -> (true, Printf.sprintf "✅ Vote recorded. Status: %s" (Swarm_eio.status_to_string p.status))
-       | None -> (false, "❌ Failed to record vote"))
+       | Ok p -> (true, Printf.sprintf "✅ Vote recorded. Status: %s" (Swarm_eio.status_to_string p.status))
+       | Error e -> (false, "❌ " ^ e))
   | None -> (false, "❌ Filesystem not available")
 
 (** Handle masc_swarm_deposit *)
 let handle_deposit ctx args : result =
   let path_id = get_string args "path_id" "" in
-  let strength = get_float args "strength" 0.2 in
+  let strength = Level4_config.Strength.of_float_clamped (get_float args "strength" 0.2) in
   match ctx.fs with
   | Some fs ->
       (match Swarm_eio.deposit_pheromone ~fs ctx.config ~path_id ~agent_id:ctx.agent_name ~strength with
-       | Some _ -> (true, Printf.sprintf "✅ Pheromone deposited on path: %s" path_id)
-       | None -> (false, "❌ Failed to deposit pheromone"))
+       | Ok _ -> (true, Printf.sprintf "✅ Pheromone deposited on path: %s" path_id)
+       | Error e -> (false, "❌ " ^ e))
   | None -> (false, "❌ Filesystem not available")
 
 (** Handle masc_swarm_trails *)

--- a/lib/tool_swarm.ml
+++ b/lib/tool_swarm.ml
@@ -25,8 +25,10 @@ type result = bool * string
 (** Handle masc_swarm_init *)
 let handle_init ctx args : result =
   let behavior = get_string args "behavior" "flocking" |> Swarm_eio.behavior_of_string in
-  let selection_pressure = get_float args "selection_pressure" 0.3 in
-  let mutation_rate = get_float args "mutation_rate" 0.1 in
+  let selection_pressure = get_float args "selection_pressure" 0.3
+    |> Level4_config.Normalized.of_float_clamped in
+  let mutation_rate = get_float args "mutation_rate" 0.1
+    |> Level4_config.Normalized.of_float_clamped in
   let swarm_cfg = {
     (Swarm_eio.default_config ()) with
     behavior;
@@ -70,7 +72,7 @@ let handle_status ctx _args : result =
 let handle_evolve ctx _args : result =
   match ctx.fs with
   | Some fs ->
-      (match Swarm_eio.evolve ~fs ctx.config with
+      (match Swarm_eio.evolve ~fs ctx.config () with
        | Some s -> (true, Printf.sprintf "✅ Swarm evolved to generation %d" s.generation)
        | None -> (false, "❌ Evolution failed"))
   | None -> (false, "❌ Filesystem not available")

--- a/test/dune
+++ b/test/dune
@@ -16,13 +16,15 @@
         test_subscriptions test_session test_progress test_mitosis test_spawn
         test_validation test_response test_voice_stream test_sctp
         test_datachannel_rfc test_dtls_crypto test_dashboard
-        test_multi_room test_worktree_detection test_bounded test_mention test_hat)
+        test_multi_room test_worktree_detection test_bounded test_mention test_hat
+        test_swarm)
  (modules test_room test_types test_checkpoint test_auth test_http_negotiation
           test_sse test_encryption test_backend test_cancellation test_graphql_api
           test_subscriptions test_session test_progress test_mitosis test_spawn
           test_validation test_response test_voice_stream test_sctp
           test_datachannel_rfc test_dtls_crypto test_dashboard
-          test_multi_room test_worktree_detection test_bounded test_mention test_hat)
+          test_multi_room test_worktree_detection test_bounded test_mention test_hat
+          test_swarm)
  (libraries masc_mcp mcp_protocol alcotest str yojson mirage-crypto
             mirage-crypto-rng cohttp cstruct))
 

--- a/test/test_level4_config_coverage.ml
+++ b/test/test_level4_config_coverage.ml
@@ -165,82 +165,6 @@ let test_is_finite_neg_infinity () =
 let test_is_finite_nan () =
   check bool "nan" false (Level4_config.is_finite nan)
 
-(* ============================================================
-   clamp_float Tests
-   ============================================================ *)
-
-let test_clamp_float_in_range () =
-  let result = Level4_config.clamp_float ~min:0.0 ~max:1.0 0.5 in
-  check (float 0.001) "in range" 0.5 result
-
-let test_clamp_float_below_min () =
-  let result = Level4_config.clamp_float ~min:0.0 ~max:1.0 (-0.5) in
-  check (float 0.001) "clamped to min" 0.0 result
-
-let test_clamp_float_above_max () =
-  let result = Level4_config.clamp_float ~min:0.0 ~max:1.0 1.5 in
-  check (float 0.001) "clamped to max" 1.0 result
-
-let test_clamp_float_at_min () =
-  let result = Level4_config.clamp_float ~min:0.0 ~max:1.0 0.0 in
-  check (float 0.001) "at min" 0.0 result
-
-let test_clamp_float_at_max () =
-  let result = Level4_config.clamp_float ~min:0.0 ~max:1.0 1.0 in
-  check (float 0.001) "at max" 1.0 result
-
-(* ============================================================
-   validate_fitness Tests
-   ============================================================ *)
-
-let test_validate_fitness_valid () =
-  match Level4_config.validate_fitness 0.5 with
-  | Some f -> check (float 0.001) "valid" 0.5 f
-  | None -> fail "expected Some"
-
-let test_validate_fitness_below_zero () =
-  match Level4_config.validate_fitness (-0.5) with
-  | Some f -> check (float 0.001) "clamped to 0" 0.0 f
-  | None -> fail "expected Some"
-
-let test_validate_fitness_above_one () =
-  match Level4_config.validate_fitness 1.5 with
-  | Some f -> check (float 0.001) "clamped to 1" 1.0 f
-  | None -> fail "expected Some"
-
-let test_validate_fitness_nan () =
-  match Level4_config.validate_fitness nan with
-  | None -> check bool "nan invalid" true true
-  | Some _ -> fail "expected None"
-
-let test_validate_fitness_infinity () =
-  match Level4_config.validate_fitness infinity with
-  | None -> check bool "infinity invalid" true true
-  | Some _ -> fail "expected None"
-
-(* ============================================================
-   validate_positive Tests
-   ============================================================ *)
-
-let test_validate_positive_valid () =
-  match Level4_config.validate_positive 1.0 with
-  | Some f -> check (float 0.001) "valid" 1.0 f
-  | None -> fail "expected Some"
-
-let test_validate_positive_zero () =
-  match Level4_config.validate_positive 0.0 with
-  | Some f -> check (float 0.001) "zero" 0.0 f
-  | None -> fail "expected Some"
-
-let test_validate_positive_negative () =
-  match Level4_config.validate_positive (-1.0) with
-  | None -> check bool "negative invalid" true true
-  | Some _ -> fail "expected None"
-
-let test_validate_positive_nan () =
-  match Level4_config.validate_positive nan with
-  | None -> check bool "nan invalid" true true
-  | Some _ -> fail "expected None"
 
 (* ============================================================
    Fitness Module Tests
@@ -441,26 +365,6 @@ let () =
       test_case "infinity" `Quick test_is_finite_infinity;
       test_case "neg_infinity" `Quick test_is_finite_neg_infinity;
       test_case "nan" `Quick test_is_finite_nan;
-    ];
-    "clamp_float", [
-      test_case "in_range" `Quick test_clamp_float_in_range;
-      test_case "below_min" `Quick test_clamp_float_below_min;
-      test_case "above_max" `Quick test_clamp_float_above_max;
-      test_case "at_min" `Quick test_clamp_float_at_min;
-      test_case "at_max" `Quick test_clamp_float_at_max;
-    ];
-    "validate_fitness", [
-      test_case "valid" `Quick test_validate_fitness_valid;
-      test_case "below_zero" `Quick test_validate_fitness_below_zero;
-      test_case "above_one" `Quick test_validate_fitness_above_one;
-      test_case "nan" `Quick test_validate_fitness_nan;
-      test_case "infinity" `Quick test_validate_fitness_infinity;
-    ];
-    "validate_positive", [
-      test_case "valid" `Quick test_validate_positive_valid;
-      test_case "zero" `Quick test_validate_positive_zero;
-      test_case "negative" `Quick test_validate_positive_negative;
-      test_case "nan" `Quick test_validate_positive_nan;
     ];
     "fitness", [
       test_case "of_float valid" `Quick test_fitness_of_float_valid;

--- a/test/test_swarm.ml
+++ b/test/test_swarm.ml
@@ -2,7 +2,9 @@
 
 open Masc_mcp
 
-let test_rng = Level4_config.make_rng ~seed:42 ()
+module Swarm = Swarm_eio
+
+let _test_rng = Level4_config.make_rng ~seed:42 ()
 let n = Level4_config.Normalized.of_float_clamped
 let nf = Level4_config.Normalized.to_float
 
@@ -30,7 +32,7 @@ let make_test_swarm ?(behavior = Swarm.Flocking) () : Swarm.swarm =
   }
 
 (** Helper: Create a test agent *)
-let make_test_agent ~id ~name ~fitness ~generation : Swarm.swarm_agent =
+let make_test_agent ~id ~name ~(fitness : Level4_config.Fitness.t) ~generation : Swarm.swarm_agent =
   let now = Unix.gettimeofday () in
   {
     id;
@@ -78,8 +80,8 @@ let test_join_agent_swarm_full () =
   let swarm = { base with
     swarm_cfg = { base.swarm_cfg with max_agents = 2 };
     agents = [
-      make_test_agent ~id:"a1" ~name:"A1" ~fitness:0.5 ~generation:0;
-      make_test_agent ~id:"a2" ~name:"A2" ~fitness:0.5 ~generation:0;
+      make_test_agent ~id:"a1" ~name:"A1" ~fitness:(n 0.5) ~generation:0;
+      make_test_agent ~id:"a2" ~name:"A2" ~fitness:(n 0.5) ~generation:0;
     ]
   } in
   let now = Unix.gettimeofday () in
@@ -142,9 +144,9 @@ let test_update_fitness_not_found () =
 let test_fitness_rankings () =
   let swarm = { (make_test_swarm ()) with
     agents = [
-      make_test_agent ~id:"a1" ~name:"A1" ~fitness:0.3 ~generation:0;
-      make_test_agent ~id:"a2" ~name:"A2" ~fitness:0.9 ~generation:0;
-      make_test_agent ~id:"a3" ~name:"A3" ~fitness:0.6 ~generation:0;
+      make_test_agent ~id:"a1" ~name:"A1" ~fitness:(n 0.3) ~generation:0;
+      make_test_agent ~id:"a2" ~name:"A2" ~fitness:(n 0.9) ~generation:0;
+      make_test_agent ~id:"a3" ~name:"A3" ~fitness:(n 0.6) ~generation:0;
     ]
   } in
   let rankings = Swarm.Pure.fitness_rankings swarm in
@@ -165,10 +167,10 @@ let test_fitness_rankings () =
 let test_select_elite () =
   let swarm = { (make_test_swarm ()) with
     agents = [
-      make_test_agent ~id:"a1" ~name:"A1" ~fitness:0.3 ~generation:0;
-      make_test_agent ~id:"a2" ~name:"A2" ~fitness:0.9 ~generation:0;
-      make_test_agent ~id:"a3" ~name:"A3" ~fitness:0.6 ~generation:0;
-      make_test_agent ~id:"a4" ~name:"A4" ~fitness:0.8 ~generation:0;
+      make_test_agent ~id:"a1" ~name:"A1" ~fitness:(n 0.3) ~generation:0;
+      make_test_agent ~id:"a2" ~name:"A2" ~fitness:(n 0.9) ~generation:0;
+      make_test_agent ~id:"a3" ~name:"A3" ~fitness:(n 0.6) ~generation:0;
+      make_test_agent ~id:"a4" ~name:"A4" ~fitness:(n 0.8) ~generation:0;
     ]
   } in
   let elite = Swarm.Pure.select_elite_agents swarm in
@@ -315,8 +317,8 @@ let test_vote_against () =
 let test_evolve_increments_generation () =
   let swarm = { (make_test_swarm ()) with
     agents = [
-      make_test_agent ~id:"a1" ~name:"A1" ~fitness:0.8 ~generation:0;
-      make_test_agent ~id:"a2" ~name:"A2" ~fitness:0.6 ~generation:0;
+      make_test_agent ~id:"a1" ~name:"A1" ~fitness:(n 0.8) ~generation:0;
+      make_test_agent ~id:"a2" ~name:"A2" ~fitness:(n 0.6) ~generation:0;
     ]
   } in
   let now = Unix.gettimeofday () in

--- a/test/test_swarm.ml
+++ b/test/test_swarm.ml
@@ -2,7 +2,7 @@
 
 open Masc_mcp
 
-let () = Random.init 42
+let test_rng = Level4_config.make_rng ~seed:42 ()
 
 (** Helper: Create a fresh swarm for testing *)
 let make_test_swarm ?(behavior = Swarm.Flocking) () : Swarm.swarm =
@@ -10,10 +10,10 @@ let make_test_swarm ?(behavior = Swarm.Flocking) () : Swarm.swarm =
   let swarm_cfg : Swarm.swarm_config = {
     id = "test-swarm";
     name = "Test Swarm";
-    selection_pressure = 0.5;
-    mutation_rate = 0.1;
-    evaporation_rate = 0.05;
-    quorum_threshold = 0.6;
+    selection_pressure = Level4_config.Normalized.of_float_clamped 0.5;
+    mutation_rate = Level4_config.Normalized.of_float_clamped 0.1;
+    evaporation_rate = Level4_config.Normalized.of_float_clamped 0.05;
+    quorum_threshold = Level4_config.Normalized.of_float_clamped 0.6;
     max_agents = 10;
     behavior;
   } in
@@ -215,7 +215,7 @@ let test_evaporate_pheromones () =
       strength = 0.8;
       deposited_by = "claude";
       deposited_at = past;
-      evaporation_rate = 0.05;
+      evaporation_rate = Level4_config.Normalized.of_float_clamped 0.05;
     }]
   } in
   let now = Unix.gettimeofday () in
@@ -318,7 +318,8 @@ let test_evolve_increments_generation () =
     ]
   } in
   let now = Unix.gettimeofday () in
-  let evolved = Swarm.Pure.evolve_agents swarm ~now in
+  let rng = Level4_config.make_rng ~seed:42 () in
+  let evolved = Swarm.Pure.evolve_agents swarm ~rng ~now in
   assert (evolved.generation = 1);
   Printf.printf "✓ test_evolve_increments_generation\n%!"
 

--- a/test/test_swarm.ml
+++ b/test/test_swarm.ml
@@ -3,6 +3,8 @@
 open Masc_mcp
 
 let test_rng = Level4_config.make_rng ~seed:42 ()
+let n = Level4_config.Normalized.of_float_clamped
+let nf = Level4_config.Normalized.to_float
 
 (** Helper: Create a fresh swarm for testing *)
 let make_test_swarm ?(behavior = Swarm.Flocking) () : Swarm.swarm =
@@ -53,7 +55,7 @@ let test_join_agent_empty_swarm () =
     let agent = List.hd new_swarm.agents in
     assert (agent.id = "claude");
     assert (agent.name = "Claude");
-    assert (agent.fitness = 0.5);  (* default fitness *)
+    assert (Level4_config.Normalized.to_float agent.fitness = 0.5);  (* default fitness *)
     Printf.printf "✓ test_join_agent_empty_swarm\n%!"
   | _ -> failwith "Expected Joined result"
 
@@ -122,7 +124,7 @@ let test_update_fitness () =
   match Swarm.Pure.update_agent_fitness swarm ~agent_id:"claude" ~fitness:0.85 ~now with
   | Some updated ->
     let agent = List.find (fun (a : Swarm.swarm_agent) -> a.id = "claude") updated.agents in
-    assert (agent.fitness = 0.85);
+    assert (Level4_config.Normalized.to_float agent.fitness = 0.85);
     Printf.printf "✓ test_update_fitness\n%!"
   | None -> failwith "Update should succeed"
 
@@ -185,11 +187,11 @@ let test_deposit_pheromone () =
   let swarm = make_test_swarm ~behavior:Swarm.Stigmergy () in
   let now = Unix.gettimeofday () in
   let swarm = Swarm.Pure.deposit_pheromone swarm
-    ~path_id:"path-a" ~agent_id:"claude" ~strength:0.8 ~now in
+    ~path_id:"path-a" ~agent_id:"claude" ~strength:(n 0.8) ~now in
   assert (List.length swarm.pheromones = 1);
   let p = List.hd swarm.pheromones in
   assert (p.path_id = "path-a");
-  assert (p.strength = 0.8);
+  assert (nf p.strength = 0.8);
   assert (p.deposited_by = "claude");
   Printf.printf "✓ test_deposit_pheromone\n%!"
 
@@ -197,13 +199,13 @@ let test_deposit_pheromone_accumulate () =
   let swarm = make_test_swarm ~behavior:Swarm.Stigmergy () in
   let now = Unix.gettimeofday () in
   let swarm = Swarm.Pure.deposit_pheromone swarm
-    ~path_id:"path-a" ~agent_id:"claude" ~strength:0.5 ~now in
+    ~path_id:"path-a" ~agent_id:"claude" ~strength:(n 0.5) ~now in
   let swarm = Swarm.Pure.deposit_pheromone swarm
-    ~path_id:"path-a" ~agent_id:"gemini" ~strength:0.3 ~now in
+    ~path_id:"path-a" ~agent_id:"gemini" ~strength:(n 0.3) ~now in
   assert (List.length swarm.pheromones = 1);
   let p = List.hd swarm.pheromones in
   (* Strength should accumulate with cap at 1.0 *)
-  assert (p.strength >= 0.8 && p.strength <= 1.0);
+  assert (nf p.strength >= 0.8 && nf p.strength <= 1.0);
   Printf.printf "✓ test_deposit_pheromone_accumulate\n%!"
 
 let test_evaporate_pheromones () =
@@ -212,10 +214,10 @@ let test_evaporate_pheromones () =
   let swarm = { swarm with
     pheromones = [{
       path_id = "path-a";
-      strength = 0.8;
+      strength = n 0.8;
       deposited_by = "claude";
       deposited_at = past;
-      evaporation_rate = Level4_config.Normalized.of_float_clamped 0.05;
+      evaporation_rate = n 0.05;
     }]
   } in
   let now = Unix.gettimeofday () in
@@ -223,15 +225,15 @@ let test_evaporate_pheromones () =
   (* After 100 seconds with rate 0.05, should decay significantly *)
   assert (List.length evaporated.pheromones = 1);
   let p = List.hd evaporated.pheromones in
-  assert (p.strength < 0.8);  (* Should have decayed *)
+  assert (nf p.strength < 0.8);  (* Should have decayed *)
   Printf.printf "✓ test_evaporate_pheromones\n%!"
 
 let test_strongest_trails () =
   let swarm = { (make_test_swarm ()) with
     pheromones = [
-      { path_id = "p1"; strength = 0.3; deposited_by = "a"; deposited_at = 0.0; evaporation_rate = 0.05 };
-      { path_id = "p2"; strength = 0.9; deposited_by = "b"; deposited_at = 0.0; evaporation_rate = 0.05 };
-      { path_id = "p3"; strength = 0.6; deposited_by = "c"; deposited_at = 0.0; evaporation_rate = 0.05 };
+      { path_id = "p1"; strength = n 0.3; deposited_by = "a"; deposited_at = 0.0; evaporation_rate = n 0.05 };
+      { path_id = "p2"; strength = n 0.9; deposited_by = "b"; deposited_at = 0.0; evaporation_rate = n 0.05 };
+      { path_id = "p3"; strength = n 0.6; deposited_by = "c"; deposited_at = 0.0; evaporation_rate = n 0.05 };
     ]
   } in
   let top2 = Swarm.Pure.strongest_trails swarm ~limit:2 in
@@ -254,7 +256,7 @@ let test_add_proposal () =
     proposed_at = now;
     votes_for = ["claude"];
     votes_against = [];
-    threshold = 0.6;
+    threshold = n 0.6;
     deadline = None;
     status = `Pending;
   } in
@@ -274,7 +276,7 @@ let test_vote_for () =
     proposed_at = now;
     votes_for = [];
     votes_against = [];
-    threshold = 0.6;
+    threshold = n 0.6;
     deadline = None;
     status = `Pending;
   } in
@@ -295,7 +297,7 @@ let test_vote_against () =
     proposed_at = now;
     votes_for = [];
     votes_against = [];
-    threshold = 0.6;
+    threshold = n 0.6;
     deadline = None;
     status = `Pending;
   } in

--- a/test/test_swarm_behaviors_eio_coverage.ml
+++ b/test/test_swarm_behaviors_eio_coverage.ml
@@ -115,20 +115,17 @@ let test_foraging_state_type () =
   let s : Swarm_behaviors_eio.foraging_state = {
     exploration_rate = 0.3;
     discovered_solutions = [("solution_a", 0.9); ("solution_b", 0.7)];
-    current_target = Some "solution_a";
   } in
   check (float 0.01) "exploration_rate" 0.3 s.exploration_rate;
   check int "solutions count" 2 (List.length s.discovered_solutions)
 
-let test_foraging_state_no_target () =
+let test_foraging_state_empty () =
   let s : Swarm_behaviors_eio.foraging_state = {
     exploration_rate = 0.5;
     discovered_solutions = [];
-    current_target = None;
   } in
-  match s.current_target with
-  | None -> check bool "no target" true true
-  | Some _ -> fail "expected None"
+  check (float 0.01) "exploration_rate" 0.5 s.exploration_rate;
+  check int "no solutions" 0 (List.length s.discovered_solutions)
 
 (* ============================================================
    stigmergy_config Type Tests
@@ -257,8 +254,7 @@ let test_flock_towards_fitness_with_high () =
 let test_init_foraging_default () =
   let state = Swarm_behaviors_eio.init_foraging () in
   check (float 0.01) "default exploration rate" 0.3 state.exploration_rate;
-  check int "no solutions" 0 (List.length state.discovered_solutions);
-  check bool "no target" true (state.current_target = None)
+  check int "no solutions" 0 (List.length state.discovered_solutions)
 
 let test_init_foraging_custom () =
   let state = Swarm_behaviors_eio.init_foraging ~exploration_rate:0.5 () in
@@ -275,7 +271,7 @@ let test_select_solution_with_solutions () =
   let state : Swarm_behaviors_eio.foraging_state = {
     exploration_rate = 0.0; (* Never explore, always exploit *)
     discovered_solutions = [("sol1", 0.5); ("sol2", 0.9); ("sol3", 0.3)];
-    current_target = None;
+
   } in
   let selected = Swarm_behaviors_eio.select_solution ~rng ~foraging_state:state in
   match selected with
@@ -291,7 +287,7 @@ let test_record_discovery_better () =
   let state : Swarm_behaviors_eio.foraging_state = {
     exploration_rate = 0.3;
     discovered_solutions = [("sol1", 0.5)];
-    current_target = None;
+
   } in
   let updated = Swarm_behaviors_eio.record_discovery ~foraging_state:state ~solution_id:"sol1" ~quality:0.9 in
   check int "still one solution" 1 (List.length updated.discovered_solutions);
@@ -302,7 +298,7 @@ let test_record_discovery_worse () =
   let state : Swarm_behaviors_eio.foraging_state = {
     exploration_rate = 0.3;
     discovered_solutions = [("sol1", 0.9)];
-    current_target = None;
+
   } in
   let updated = Swarm_behaviors_eio.record_discovery ~foraging_state:state ~solution_id:"sol1" ~quality:0.3 in
   let q = List.assoc "sol1" updated.discovered_solutions in
@@ -350,8 +346,8 @@ let test_share_discovery () =
   (* Create swarm first *)
   let _ = Swarm_eio.create ~fs config () in
   match Swarm_behaviors_eio.share_discovery ~fs config ~agent_id:"a1" ~solution_id:"sol1" ~quality:0.8 with
-  | Some swarm -> check int "one pheromone" 1 (List.length swarm.pheromones)
-  | None -> fail "expected share success"
+  | Ok swarm -> check int "one pheromone" 1 (List.length swarm.pheromones)
+  | Error e -> fail ("expected share success: " ^ e)
 
 let test_follow_pheromone_empty () =
   with_eio_env @@ fun ~fs config ->
@@ -365,7 +361,7 @@ let test_follow_pheromone_with_trail () =
   with_eio_env @@ fun ~fs config ->
   let _ = Swarm_eio.create ~fs config () in
   (* Deposit a strong pheromone *)
-  let _ = Swarm_eio.deposit_pheromone ~fs config ~path_id:"path1" ~agent_id:"a1" ~strength:0.9 in
+  let _ = Swarm_eio.deposit_pheromone ~fs config ~path_id:"path1" ~agent_id:"a1" ~strength:(Level4_config.Strength.of_float_clamped 0.9) in
   match Swarm_behaviors_eio.follow_pheromone ~fs config () with
   | Some "path1" -> check bool "found trail" true true
   | _ -> check bool "found or random" true true (* Could be random selection *)
@@ -374,9 +370,9 @@ let test_mark_success () =
   with_eio_env @@ fun ~fs config ->
   let _ = Swarm_eio.create ~fs config () in
   match Swarm_behaviors_eio.mark_success ~fs config ~agent_id:"a1" ~path_id:"success-path" () with
-  | Some swarm ->
+  | Ok swarm ->
       check bool "has pheromone" true (List.length swarm.pheromones > 0)
-  | None -> fail "expected mark success"
+  | Error e -> fail ("expected mark success: " ^ e)
 
 let test_check_quorum_no_swarm () =
   with_eio_env @@ fun ~fs config ->
@@ -419,7 +415,7 @@ let () =
     ];
     "foraging_state", [
       test_case "type" `Quick test_foraging_state_type;
-      test_case "no target" `Quick test_foraging_state_no_target;
+      test_case "empty" `Quick test_foraging_state_empty;
     ];
     "stigmergy_config", [
       test_case "type" `Quick test_stigmergy_config_type;

--- a/test/test_swarm_behaviors_eio_coverage.ml
+++ b/test/test_swarm_behaviors_eio_coverage.ml
@@ -13,6 +13,7 @@
 open Alcotest
 
 module Swarm_behaviors_eio = Masc_mcp.Swarm_behaviors_eio
+module Level4_config = Masc_mcp.Level4_config
 
 (* ============================================================
    vector2d Type Tests
@@ -264,17 +265,19 @@ let test_init_foraging_custom () =
   check (float 0.01) "custom exploration rate" 0.5 state.exploration_rate
 
 let test_select_solution_empty () =
+  let rng = Level4_config.make_rng ~seed:42 () in
   let state = Swarm_behaviors_eio.init_foraging ~exploration_rate:0.0 () in
-  let selected = Swarm_behaviors_eio.select_solution ~foraging_state:state in
+  let selected = Swarm_behaviors_eio.select_solution ~rng ~foraging_state:state in
   check bool "none for empty" true (selected = None)
 
 let test_select_solution_with_solutions () =
+  let rng = Level4_config.make_rng ~seed:42 () in
   let state : Swarm_behaviors_eio.foraging_state = {
     exploration_rate = 0.0; (* Never explore, always exploit *)
     discovered_solutions = [("sol1", 0.5); ("sol2", 0.9); ("sol3", 0.3)];
     current_target = None;
   } in
-  let selected = Swarm_behaviors_eio.select_solution ~foraging_state:state in
+  let selected = Swarm_behaviors_eio.select_solution ~rng ~foraging_state:state in
   match selected with
   | Some "sol2" -> check bool "best solution" true true
   | _ -> fail "expected sol2"

--- a/test/test_swarm_behaviors_eio_coverage.ml
+++ b/test/test_swarm_behaviors_eio_coverage.ml
@@ -345,7 +345,7 @@ let test_share_discovery () =
   with_eio_env @@ fun ~fs config ->
   (* Create swarm first *)
   let _ = Swarm_eio.create ~fs config () in
-  match Swarm_behaviors_eio.share_discovery ~fs config ~agent_id:"a1" ~solution_id:"sol1" ~quality:0.8 with
+  match Swarm_behaviors_eio.share_discovery ~fs config ~agent_id:"a1" ~solution_id:"sol1" ~quality:(Level4_config.Strength.of_float_clamped 0.8) with
   | Ok swarm -> check int "one pheromone" 1 (List.length swarm.pheromones)
   | Error e -> fail ("expected share success: " ^ e)
 

--- a/test/test_swarm_eio_coverage.ml
+++ b/test/test_swarm_eio_coverage.ml
@@ -13,6 +13,10 @@
 open Alcotest
 
 module Swarm_eio = Masc_mcp.Swarm_eio
+module Level4_config = Masc_mcp.Level4_config
+
+(** Convenience: create Normalized.t from float literal *)
+let n = Level4_config.Normalized.of_float_clamped
 
 (* ============================================================
    swarm_behavior Type Tests
@@ -125,17 +129,17 @@ let test_swarm_config_type () =
   let c : Swarm_eio.swarm_config = {
     id = "swarm-001";
     name = "test-swarm";
-    selection_pressure = 0.3;
-    mutation_rate = 0.1;
-    evaporation_rate = 0.05;
-    quorum_threshold = 0.6;
+    selection_pressure = n 0.3;
+    mutation_rate = n 0.1;
+    evaporation_rate = n 0.05;
+    quorum_threshold = n 0.6;
     max_agents = 10;
     behavior = Swarm_eio.Flocking;
   } in
   check string "id" "swarm-001" c.id;
   check string "name" "test-swarm" c.name;
   check int "max_agents" 10 c.max_agents;
-  check (float 0.01) "selection_pressure" 0.3 c.selection_pressure
+  check (float 0.01) "selection_pressure" 0.3 (Level4_config.Normalized.to_float c.selection_pressure)
 
 (* ============================================================
    swarm Type Tests
@@ -145,10 +149,10 @@ let test_swarm_type_empty () =
   let cfg : Swarm_eio.swarm_config = {
     id = "swarm-002";
     name = "empty-swarm";
-    selection_pressure = 0.3;
-    mutation_rate = 0.1;
-    evaporation_rate = 0.05;
-    quorum_threshold = 0.6;
+    selection_pressure = n 0.3;
+    mutation_rate = n 0.1;
+    evaporation_rate = n 0.05;
+    quorum_threshold = n 0.6;
     max_agents = 5;
     behavior = Swarm_eio.Stigmergy;
   } in
@@ -172,7 +176,7 @@ let test_default_config () =
   let cfg = Swarm_eio.default_config () in
   check bool "has name" true (String.length cfg.name > 0);
   check bool "has id" true (String.length cfg.id > 0);
-  check bool "selection_pressure > 0" true (cfg.selection_pressure > 0.0);
+  check bool "selection_pressure > 0" true (Level4_config.Normalized.to_float cfg.selection_pressure > 0.0);
   check bool "max_agents > 0" true (cfg.max_agents > 0)
 
 let test_default_config_custom_name () =
@@ -252,7 +256,7 @@ let test_agent_json_roundtrip () =
     last_active = 1704070800.0;
   } in
   let json = Swarm_eio.agent_to_json a in
-  let decoded = Swarm_eio.agent_of_json json in
+  let decoded = Result.get_ok (Swarm_eio.agent_of_json json) in
   check string "id" a.id decoded.id;
   check string "name" a.name decoded.name;
   check (float 0.001) "fitness" a.fitness decoded.fitness;
@@ -268,7 +272,7 @@ let test_pheromone_json_roundtrip () =
     evaporation_rate = 0.15;
   } in
   let json = Swarm_eio.pheromone_to_json p in
-  let decoded = Swarm_eio.pheromone_of_json json in
+  let decoded = Result.get_ok (Swarm_eio.pheromone_of_json json) in
   check string "path_id" p.path_id decoded.path_id;
   check (float 0.001) "strength" p.strength decoded.strength;
   check string "deposited_by" p.deposited_by decoded.deposited_by
@@ -286,7 +290,7 @@ let test_proposal_json_roundtrip () =
     status = `Pending;
   } in
   let json = Swarm_eio.proposal_to_json p in
-  let decoded = Swarm_eio.proposal_of_json json in
+  let decoded = Result.get_ok (Swarm_eio.proposal_of_json json) in
   check string "proposal_id" p.proposal_id decoded.proposal_id;
   check string "description" p.description decoded.description;
   check int "votes_for" (List.length p.votes_for) (List.length decoded.votes_for);
@@ -305,7 +309,7 @@ let test_proposal_json_no_deadline () =
     status = `Passed;
   } in
   let json = Swarm_eio.proposal_to_json p in
-  let decoded = Swarm_eio.proposal_of_json json in
+  let decoded = Result.get_ok (Swarm_eio.proposal_of_json json) in
   check bool "no deadline" true (decoded.deadline = None);
   check bool "passed status" true (decoded.status = `Passed)
 
@@ -313,18 +317,20 @@ let test_config_json_roundtrip () =
   let c : Swarm_eio.swarm_config = {
     id = "cfg-rt-001";
     name = "test-config";
-    selection_pressure = 0.35;
-    mutation_rate = 0.12;
-    evaporation_rate = 0.08;
-    quorum_threshold = 0.65;
+    selection_pressure = n 0.35;
+    mutation_rate = n 0.12;
+    evaporation_rate = n 0.08;
+    quorum_threshold = n 0.65;
     max_agents = 25;
     behavior = Swarm_eio.Stigmergy;
   } in
   let json = Swarm_eio.config_to_json c in
-  let decoded = Swarm_eio.config_of_json json in
+  let decoded = Result.get_ok (Swarm_eio.config_of_json json) in
   check string "id" c.id decoded.id;
   check string "name" c.name decoded.name;
-  check (float 0.001) "selection_pressure" c.selection_pressure decoded.selection_pressure;
+  check (float 0.001) "selection_pressure"
+    (Level4_config.Normalized.to_float c.selection_pressure)
+    (Level4_config.Normalized.to_float decoded.selection_pressure);
   check int "max_agents" c.max_agents decoded.max_agents;
   check string "behavior" "stigmergy" (Swarm_eio.behavior_to_string decoded.behavior)
 
@@ -332,10 +338,10 @@ let test_swarm_json_roundtrip () =
   let cfg : Swarm_eio.swarm_config = {
     id = "swarm-rt";
     name = "roundtrip-swarm";
-    selection_pressure = 0.3;
-    mutation_rate = 0.1;
-    evaporation_rate = 0.1;
-    quorum_threshold = 0.6;
+    selection_pressure = n 0.3;
+    mutation_rate = n 0.1;
+    evaporation_rate = n 0.1;
+    quorum_threshold = n 0.6;
     max_agents = 10;
     behavior = Swarm_eio.Flocking;
   } in
@@ -354,7 +360,7 @@ let test_swarm_json_roundtrip () =
     last_evolution = 900.0;
   } in
   let json = Swarm_eio.swarm_to_json s in
-  let decoded = Swarm_eio.swarm_of_json json in
+  let decoded = Result.get_ok (Swarm_eio.swarm_of_json json) in
   check string "config id" s.swarm_cfg.id decoded.swarm_cfg.id;
   check int "agents count" 1 (List.length decoded.agents);
   check int "generation" s.generation decoded.generation
@@ -367,10 +373,10 @@ let make_test_swarm () : Swarm_eio.swarm =
   let cfg : Swarm_eio.swarm_config = {
     id = "test-swarm";
     name = "pure-test";
-    selection_pressure = 0.3;
-    mutation_rate = 0.1;
-    evaporation_rate = 0.1;
-    quorum_threshold = 0.6;
+    selection_pressure = n 0.3;
+    mutation_rate = n 0.1;
+    evaporation_rate = n 0.1;
+    quorum_threshold = n 0.6;
     max_agents = 5;
     behavior = Swarm_eio.Flocking;
   } in
@@ -402,9 +408,9 @@ let test_pure_join_agent_already_member () =
 
 let test_pure_join_agent_swarm_full () =
   let cfg : Swarm_eio.swarm_config = {
-    id = "full"; name = "full"; selection_pressure = 0.3;
-    mutation_rate = 0.1; evaporation_rate = 0.1;
-    quorum_threshold = 0.6; max_agents = 1;
+    id = "full"; name = "full"; selection_pressure = n 0.3;
+    mutation_rate = n 0.1; evaporation_rate = n 0.1;
+    quorum_threshold = n 0.6; max_agents = 1;
     behavior = Swarm_eio.Flocking;
   } in
   let swarm : Swarm_eio.swarm = {
@@ -450,7 +456,8 @@ let test_pure_evolve_agents () =
   let swarm = make_test_swarm () in
   match Swarm_eio.Pure.join_agent swarm ~agent_id:"a1" ~agent_name:"c1" ~now:2000.0 with
   | Swarm_eio.Pure.Joined s1 ->
-      let evolved = Swarm_eio.Pure.evolve_agents s1 ~now:3000.0 in
+      let rng = Level4_config.make_rng ~seed:42 () in
+      let evolved = Swarm_eio.Pure.evolve_agents s1 ~rng ~now:3000.0 in
       check int "generation +1" 1 evolved.generation
   | _ -> fail "expected Joined"
 
@@ -664,9 +671,75 @@ let test_eio_evolve () =
   with_eio_env @@ fun ~fs config ->
   let _ = Swarm_eio.create ~fs config () in
   let _ = Swarm_eio.join ~fs config ~agent_id:"a1" ~agent_name:"claude" in
-  match Swarm_eio.evolve ~fs config with
+  match Swarm_eio.evolve ~fs config () with
   | Some swarm -> check int "generation 1" 1 swarm.generation
   | None -> fail "expected evolve success"
+
+(* ============================================================
+   P0 #4: Integration Tests (JSON errors, RNG determinism)
+   ============================================================ *)
+
+let test_agent_of_json_error () =
+  let bad = `String "not an object" in
+  match Swarm_eio.agent_of_json bad with
+  | Error msg ->
+    check bool "has error prefix" true (String.length msg > 0)
+  | Ok _ -> fail "expected Error for bad JSON"
+
+let test_pheromone_of_json_error () =
+  let bad = `Assoc [("path_id", `Int 42)] in
+  match Swarm_eio.pheromone_of_json bad with
+  | Error _ -> ()
+  | Ok _ -> fail "expected Error for bad JSON"
+
+let test_config_of_json_error () =
+  let bad = `List [] in
+  match Swarm_eio.config_of_json bad with
+  | Error _ -> ()
+  | Ok _ -> fail "expected Error for bad JSON"
+
+let test_swarm_of_json_error () =
+  let bad = `Assoc [("config", `String "bad")] in
+  match Swarm_eio.swarm_of_json bad with
+  | Error _ -> ()
+  | Ok _ -> fail "expected Error for bad JSON"
+
+let make_populated_swarm () : Swarm_eio.swarm =
+  let base = make_test_swarm () in
+  let agents = List.init 3 (fun i ->
+    { Swarm_eio.id = Printf.sprintf "a%d" i;
+      name = Printf.sprintf "agent-%d" i;
+      fitness = 0.5 +. (float_of_int i *. 0.1);
+      generation = 0; mutations = [];
+      joined_at = 1000.0; last_active = 1000.0; }
+  ) in
+  { base with agents;
+    swarm_cfg = { base.swarm_cfg with
+      mutation_rate = Level4_config.Normalized.of_float_clamped 1.0 } }
+
+let test_rng_determinism () =
+  let swarm = make_populated_swarm () in
+  let rng1 = Random.State.make [|42|] in
+  let rng2 = Random.State.make [|42|] in
+  let now = 2000.0 in
+  let result1 = Swarm_eio.Pure.evolve_agents swarm ~rng:rng1 ~now in
+  let result2 = Swarm_eio.Pure.evolve_agents swarm ~rng:rng2 ~now in
+  check int "same generation" result1.generation result2.generation;
+  check int "same agent count" (List.length result1.agents) (List.length result2.agents);
+  let muts1 = List.concat_map (fun a -> a.Swarm_eio.mutations) result1.agents in
+  let muts2 = List.concat_map (fun a -> a.Swarm_eio.mutations) result2.agents in
+  check bool "same mutations" true (muts1 = muts2)
+
+let test_rng_different_seeds () =
+  let swarm = make_populated_swarm () in
+  let rng1 = Random.State.make [|42|] in
+  let rng2 = Random.State.make [|99|] in
+  let now = 2000.0 in
+  let result1 = Swarm_eio.Pure.evolve_agents swarm ~rng:rng1 ~now in
+  let result2 = Swarm_eio.Pure.evolve_agents swarm ~rng:rng2 ~now in
+  let muts1 = List.concat_map (fun a -> a.Swarm_eio.mutations) result1.agents in
+  let muts2 = List.concat_map (fun a -> a.Swarm_eio.mutations) result2.agents in
+  check bool "different mutation IDs" true (muts1 <> muts2)
 
 (* ============================================================
    Test Runners
@@ -756,5 +829,15 @@ let () =
       test_case "fitness rankings" `Quick test_eio_get_fitness_rankings;
       test_case "select elite" `Quick test_eio_select_elite;
       test_case "evolve" `Quick test_eio_evolve;
+    ];
+    "json_error_cases", [
+      test_case "agent bad json" `Quick test_agent_of_json_error;
+      test_case "pheromone bad json" `Quick test_pheromone_of_json_error;
+      test_case "config bad json" `Quick test_config_of_json_error;
+      test_case "swarm bad json" `Quick test_swarm_of_json_error;
+    ];
+    "rng_determinism", [
+      test_case "same seed same result" `Quick test_rng_determinism;
+      test_case "different seeds differ" `Quick test_rng_different_seeds;
     ];
   ]

--- a/test/test_swarm_eio_coverage.ml
+++ b/test/test_swarm_eio_coverage.ml
@@ -210,29 +210,24 @@ let test_behavior_to_string_quorum () =
   check string "quorum_sensing" "quorum_sensing" (Swarm_eio.behavior_to_string Swarm_eio.Quorum_sensing)
 
 let test_behavior_of_string_flocking () =
-  match Swarm_eio.behavior_of_string "flocking" with
-  | Swarm_eio.Flocking -> check bool "flocking" true true
-  | _ -> fail "expected Flocking"
+  let b = Swarm_eio.behavior_of_string "flocking" in
+  check string "flocking roundtrip" "flocking" (Swarm_eio.behavior_to_string b)
 
 let test_behavior_of_string_foraging () =
-  match Swarm_eio.behavior_of_string "foraging" with
-  | Swarm_eio.Foraging -> check bool "foraging" true true
-  | _ -> fail "expected Foraging"
+  let b = Swarm_eio.behavior_of_string "foraging" in
+  check string "foraging roundtrip" "foraging" (Swarm_eio.behavior_to_string b)
 
 let test_behavior_of_string_stigmergy () =
-  match Swarm_eio.behavior_of_string "stigmergy" with
-  | Swarm_eio.Stigmergy -> check bool "stigmergy" true true
-  | _ -> fail "expected Stigmergy"
+  let b = Swarm_eio.behavior_of_string "stigmergy" in
+  check string "stigmergy roundtrip" "stigmergy" (Swarm_eio.behavior_to_string b)
 
 let test_behavior_of_string_quorum () =
-  match Swarm_eio.behavior_of_string "quorum_sensing" with
-  | Swarm_eio.Quorum_sensing -> check bool "quorum_sensing" true true
-  | _ -> fail "expected Quorum_sensing"
+  let b = Swarm_eio.behavior_of_string "quorum_sensing" in
+  check string "quorum roundtrip" "quorum_sensing" (Swarm_eio.behavior_to_string b)
 
 let test_behavior_of_string_unknown () =
-  match Swarm_eio.behavior_of_string "unknown" with
-  | Swarm_eio.Flocking -> check bool "default flocking" true true
-  | _ -> fail "expected default Flocking"
+  let b = Swarm_eio.behavior_of_string "unknown" in
+  check string "unknown defaults to flocking" "flocking" (Swarm_eio.behavior_to_string b)
 
 let test_status_to_string () =
   check string "pending" "pending" (Swarm_eio.status_to_string `Pending);
@@ -241,11 +236,11 @@ let test_status_to_string () =
   check string "expired" "expired" (Swarm_eio.status_to_string `Expired)
 
 let test_status_of_string () =
-  check bool "pending" true (Swarm_eio.status_of_string "pending" = `Pending);
-  check bool "passed" true (Swarm_eio.status_of_string "passed" = `Passed);
-  check bool "rejected" true (Swarm_eio.status_of_string "rejected" = `Rejected);
-  check bool "expired" true (Swarm_eio.status_of_string "expired" = `Expired);
-  check bool "unknown" true (Swarm_eio.status_of_string "unknown" = `Pending)
+  check string "pending" "pending" (Swarm_eio.status_to_string (Swarm_eio.status_of_string "pending"));
+  check string "passed" "passed" (Swarm_eio.status_to_string (Swarm_eio.status_of_string "passed"));
+  check string "rejected" "rejected" (Swarm_eio.status_to_string (Swarm_eio.status_of_string "rejected"));
+  check string "expired" "expired" (Swarm_eio.status_to_string (Swarm_eio.status_of_string "expired"));
+  check string "unknown defaults to pending" "pending" (Swarm_eio.status_to_string (Swarm_eio.status_of_string "unknown"))
 
 (* ============================================================
    JSON Roundtrip Tests
@@ -470,15 +465,15 @@ let test_pure_evolve_agents () =
 let test_pure_deposit_pheromone () =
   let swarm = make_test_swarm () in
   let updated = Swarm_eio.Pure.deposit_pheromone swarm
-    ~path_id:"path1" ~agent_id:"a1" ~strength:0.5 ~now:2000.0 in
+    ~path_id:"path1" ~agent_id:"a1" ~strength:(n 0.5) ~now:2000.0 in
   check int "one pheromone" 1 (List.length updated.pheromones)
 
 let test_pure_deposit_pheromone_update () =
   let swarm = make_test_swarm () in
   let s1 = Swarm_eio.Pure.deposit_pheromone swarm
-    ~path_id:"path1" ~agent_id:"a1" ~strength:0.5 ~now:2000.0 in
+    ~path_id:"path1" ~agent_id:"a1" ~strength:(n 0.5) ~now:2000.0 in
   let s2 = Swarm_eio.Pure.deposit_pheromone s1
-    ~path_id:"path1" ~agent_id:"a2" ~strength:0.3 ~now:2001.0 in
+    ~path_id:"path1" ~agent_id:"a2" ~strength:(n 0.3) ~now:2001.0 in
   check int "still one pheromone" 1 (List.length s2.pheromones);
   let p = List.hd s2.pheromones in
   check bool "strength increased" true (nf p.strength > 0.5)
@@ -486,7 +481,7 @@ let test_pure_deposit_pheromone_update () =
 let test_pure_evaporate_pheromones () =
   let swarm = make_test_swarm () in
   let s1 = Swarm_eio.Pure.deposit_pheromone swarm
-    ~path_id:"path1" ~agent_id:"a1" ~strength:0.1 ~now:1000.0 in
+    ~path_id:"path1" ~agent_id:"a1" ~strength:(n 0.1) ~now:1000.0 in
   (* After many hours, pheromone should evaporate *)
   let s2 = Swarm_eio.Pure.evaporate_pheromones s1 ~now:100000.0 in
   check int "pheromone evaporated" 0 (List.length s2.pheromones)
@@ -494,9 +489,9 @@ let test_pure_evaporate_pheromones () =
 let test_pure_strongest_trails () =
   let swarm = make_test_swarm () in
   let s1 = Swarm_eio.Pure.deposit_pheromone swarm
-    ~path_id:"path1" ~agent_id:"a1" ~strength:0.9 ~now:2000.0 in
+    ~path_id:"path1" ~agent_id:"a1" ~strength:(n 0.9) ~now:2000.0 in
   let s2 = Swarm_eio.Pure.deposit_pheromone s1
-    ~path_id:"path2" ~agent_id:"a1" ~strength:0.3 ~now:2001.0 in
+    ~path_id:"path2" ~agent_id:"a1" ~strength:(n 0.3) ~now:2001.0 in
   let trails = Swarm_eio.Pure.strongest_trails s2 ~limit:1 in
   check int "one trail" 1 (List.length trails);
   check string "strongest path" "path1" (List.hd trails).path_id
@@ -631,23 +626,23 @@ let test_eio_join () =
   with_eio_env @@ fun ~fs config ->
   let _ = Swarm_eio.create ~fs config () in
   match Swarm_eio.join ~fs config ~agent_id:"a1" ~agent_name:"claude" with
-  | Some swarm -> check int "one agent" 1 (List.length swarm.agents)
-  | None -> fail "expected join success"
+  | Ok swarm -> check int "one agent" 1 (List.length swarm.agents)
+  | Error e -> fail ("expected join success: " ^ e)
 
 let test_eio_join_no_swarm () =
   with_eio_env @@ fun ~fs config ->
   (* Don't create swarm first *)
   match Swarm_eio.join ~fs config ~agent_id:"a1" ~agent_name:"claude" with
-  | None -> check bool "no swarm" true true
-  | Some _ -> fail "expected None"
+  | Error _ -> ()
+  | Ok _ -> fail "expected Error for missing swarm"
 
 let test_eio_leave () =
   with_eio_env @@ fun ~fs config ->
   let _ = Swarm_eio.create ~fs config () in
   let _ = Swarm_eio.join ~fs config ~agent_id:"a1" ~agent_name:"claude" in
   match Swarm_eio.leave ~fs config ~agent_id:"a1" with
-  | Some swarm -> check int "no agents" 0 (List.length swarm.agents)
-  | None -> fail "expected leave success"
+  | Ok swarm -> check int "no agents" 0 (List.length swarm.agents)
+  | Error e -> fail ("expected leave success: " ^ e)
 
 let test_eio_dissolve () =
   with_eio_env @@ fun ~fs config ->
@@ -655,8 +650,8 @@ let test_eio_dissolve () =
   Swarm_eio.dissolve ~fs config;
   (* join should fail after dissolve *)
   match Swarm_eio.join ~fs config ~agent_id:"a1" ~agent_name:"claude" with
-  | None -> check bool "dissolved" true true
-  | Some _ -> fail "expected dissolved"
+  | Error _ -> ()
+  | Ok _ -> fail "expected Error after dissolve"
 
 let test_eio_get_fitness_rankings () =
   with_eio_env @@ fun ~fs config ->
@@ -678,8 +673,8 @@ let test_eio_evolve () =
   let _ = Swarm_eio.create ~fs config () in
   let _ = Swarm_eio.join ~fs config ~agent_id:"a1" ~agent_name:"claude" in
   match Swarm_eio.evolve ~fs config () with
-  | Some swarm -> check int "generation 1" 1 swarm.generation
-  | None -> fail "expected evolve success"
+  | Ok swarm -> check int "generation 1" 1 swarm.generation
+  | Error e -> fail ("expected evolve success: " ^ e)
 
 (* ============================================================
    P0 #4: Integration Tests (JSON errors, RNG determinism)

--- a/test/test_swarm_eio_coverage.ml
+++ b/test/test_swarm_eio_coverage.ml
@@ -15,8 +15,14 @@ open Alcotest
 module Swarm_eio = Masc_mcp.Swarm_eio
 module Level4_config = Masc_mcp.Level4_config
 
-(** Convenience: create Normalized.t from float literal *)
+(** Convenience: create/unwrap Normalized.t *)
 let n = Level4_config.Normalized.of_float_clamped
+let nf = Level4_config.Normalized.to_float
+
+(** Unwrap Result or fail with context *)
+let expect_ok label = function
+  | Ok v -> v
+  | Error msg -> Alcotest.fail (Printf.sprintf "%s: %s" label msg)
 
 (* ============================================================
    swarm_behavior Type Tests
@@ -54,7 +60,7 @@ let test_swarm_agent_type () =
   let a : Swarm_eio.swarm_agent = {
     id = "agent-001";
     name = "claude";
-    fitness = 0.85;
+    fitness = n 0.85;
     generation = 5;
     mutations = ["mutation_a"; "mutation_b"];
     joined_at = 1704067200.0;
@@ -62,7 +68,7 @@ let test_swarm_agent_type () =
   } in
   check string "id" "agent-001" a.id;
   check string "name" "claude" a.name;
-  check (float 0.01) "fitness" 0.85 a.fitness;
+  check (float 0.01) "fitness" 0.85 (nf a.fitness);
   check int "generation" 5 a.generation;
   check int "mutations count" 2 (List.length a.mutations)
 
@@ -73,14 +79,14 @@ let test_swarm_agent_type () =
 let test_pheromone_type () =
   let p : Swarm_eio.pheromone = {
     path_id = "path-001";
-    strength = 0.9;
+    strength = n 0.9;
     deposited_by = "agent-001";
     deposited_at = 1704067200.0;
-    evaporation_rate = 0.1;
+    evaporation_rate = n 0.1;
   } in
   check string "path_id" "path-001" p.path_id;
-  check (float 0.01) "strength" 0.9 p.strength;
-  check (float 0.01) "evaporation_rate" 0.1 p.evaporation_rate
+  check (float 0.01) "strength" 0.9 (nf p.strength);
+  check (float 0.01) "evaporation_rate" 0.1 (nf p.evaporation_rate)
 
 (* ============================================================
    quorum_proposal Type Tests
@@ -94,7 +100,7 @@ let test_quorum_proposal_pending () =
     proposed_at = 1704067200.0;
     votes_for = ["agent-002"; "agent-003"];
     votes_against = ["agent-004"];
-    threshold = 0.6;
+    threshold = n 0.6;
     deadline = Some 1704153600.0;
     status = `Pending;
   } in
@@ -113,7 +119,7 @@ let test_quorum_proposal_passed () =
     proposed_at = 0.0;
     votes_for = [];
     votes_against = [];
-    threshold = 0.5;
+    threshold = n 0.5;
     deadline = None;
     status = `Passed;
   } in
@@ -249,32 +255,32 @@ let test_agent_json_roundtrip () =
   let a : Swarm_eio.swarm_agent = {
     id = "agent-rt-001";
     name = "test-agent";
-    fitness = 0.75;
+    fitness = n 0.75;
     generation = 3;
     mutations = ["mut1"; "mut2"];
     joined_at = 1704067200.0;
     last_active = 1704070800.0;
   } in
   let json = Swarm_eio.agent_to_json a in
-  let decoded = Result.get_ok (Swarm_eio.agent_of_json json) in
+  let decoded = expect_ok "agent_of_json" (Swarm_eio.agent_of_json json) in
   check string "id" a.id decoded.id;
   check string "name" a.name decoded.name;
-  check (float 0.001) "fitness" a.fitness decoded.fitness;
+  check (float 0.001) "fitness" (nf a.fitness) (nf decoded.fitness);
   check int "generation" a.generation decoded.generation;
   check int "mutations count" (List.length a.mutations) (List.length decoded.mutations)
 
 let test_pheromone_json_roundtrip () =
   let p : Swarm_eio.pheromone = {
     path_id = "path-rt-001";
-    strength = 0.65;
+    strength = n 0.65;
     deposited_by = "agent-001";
     deposited_at = 1704067200.0;
-    evaporation_rate = 0.15;
+    evaporation_rate = n 0.15;
   } in
   let json = Swarm_eio.pheromone_to_json p in
-  let decoded = Result.get_ok (Swarm_eio.pheromone_of_json json) in
+  let decoded = expect_ok "pheromone_of_json" (Swarm_eio.pheromone_of_json json) in
   check string "path_id" p.path_id decoded.path_id;
-  check (float 0.001) "strength" p.strength decoded.strength;
+  check (float 0.001) "strength" (nf p.strength) (nf decoded.strength);
   check string "deposited_by" p.deposited_by decoded.deposited_by
 
 let test_proposal_json_roundtrip () =
@@ -285,12 +291,12 @@ let test_proposal_json_roundtrip () =
     proposed_at = 1704067200.0;
     votes_for = ["a1"; "a2"];
     votes_against = ["a3"];
-    threshold = 0.6;
+    threshold = n 0.6;
     deadline = Some 1704153600.0;
     status = `Pending;
   } in
   let json = Swarm_eio.proposal_to_json p in
-  let decoded = Result.get_ok (Swarm_eio.proposal_of_json json) in
+  let decoded = expect_ok "proposal_of_json" (Swarm_eio.proposal_of_json json) in
   check string "proposal_id" p.proposal_id decoded.proposal_id;
   check string "description" p.description decoded.description;
   check int "votes_for" (List.length p.votes_for) (List.length decoded.votes_for);
@@ -304,12 +310,12 @@ let test_proposal_json_no_deadline () =
     proposed_at = 0.0;
     votes_for = [];
     votes_against = [];
-    threshold = 0.5;
+    threshold = n 0.5;
     deadline = None;
     status = `Passed;
   } in
   let json = Swarm_eio.proposal_to_json p in
-  let decoded = Result.get_ok (Swarm_eio.proposal_of_json json) in
+  let decoded = expect_ok "proposal_of_json(no_deadline)" (Swarm_eio.proposal_of_json json) in
   check bool "no deadline" true (decoded.deadline = None);
   check bool "passed status" true (decoded.status = `Passed)
 
@@ -325,7 +331,7 @@ let test_config_json_roundtrip () =
     behavior = Swarm_eio.Stigmergy;
   } in
   let json = Swarm_eio.config_to_json c in
-  let decoded = Result.get_ok (Swarm_eio.config_of_json json) in
+  let decoded = expect_ok "config_of_json" (Swarm_eio.config_of_json json) in
   check string "id" c.id decoded.id;
   check string "name" c.name decoded.name;
   check (float 0.001) "selection_pressure"
@@ -346,7 +352,7 @@ let test_swarm_json_roundtrip () =
     behavior = Swarm_eio.Flocking;
   } in
   let agent : Swarm_eio.swarm_agent = {
-    id = "a1"; name = "agent1"; fitness = 0.8;
+    id = "a1"; name = "agent1"; fitness = n 0.8;
     generation = 1; mutations = [];
     joined_at = 1000.0; last_active = 1000.0;
   } in
@@ -360,7 +366,7 @@ let test_swarm_json_roundtrip () =
     last_evolution = 900.0;
   } in
   let json = Swarm_eio.swarm_to_json s in
-  let decoded = Result.get_ok (Swarm_eio.swarm_of_json json) in
+  let decoded = expect_ok "swarm_of_json" (Swarm_eio.swarm_of_json json) in
   check string "config id" s.swarm_cfg.id decoded.swarm_cfg.id;
   check int "agents count" 1 (List.length decoded.agents);
   check int "generation" s.generation decoded.generation
@@ -475,7 +481,7 @@ let test_pure_deposit_pheromone_update () =
     ~path_id:"path1" ~agent_id:"a2" ~strength:0.3 ~now:2001.0 in
   check int "still one pheromone" 1 (List.length s2.pheromones);
   let p = List.hd s2.pheromones in
-  check bool "strength increased" true (p.strength > 0.5)
+  check bool "strength increased" true (nf p.strength > 0.5)
 
 let test_pure_evaporate_pheromones () =
   let swarm = make_test_swarm () in
@@ -501,7 +507,7 @@ let test_pure_add_proposal () =
     proposal_id = "p1"; description = "Test";
     proposed_by = "a1"; proposed_at = 2000.0;
     votes_for = []; votes_against = [];
-    threshold = 0.6; deadline = None;
+    threshold = n 0.6; deadline = None;
     status = `Pending;
   } in
   let updated = Swarm_eio.Pure.add_proposal swarm ~proposal in
@@ -513,7 +519,7 @@ let test_pure_record_vote_for () =
     proposal_id = "p1"; description = "Test";
     proposed_by = "a1"; proposed_at = 2000.0;
     votes_for = []; votes_against = [];
-    threshold = 0.6; deadline = None;
+    threshold = n 0.6; deadline = None;
     status = `Pending;
   } in
   let s1 = Swarm_eio.Pure.add_proposal swarm ~proposal in
@@ -527,7 +533,7 @@ let test_pure_record_vote_against () =
     proposal_id = "p1"; description = "Test";
     proposed_by = "a1"; proposed_at = 2000.0;
     votes_for = []; votes_against = [];
-    threshold = 0.6; deadline = None;
+    threshold = n 0.6; deadline = None;
     status = `Pending;
   } in
   let s1 = Swarm_eio.Pure.add_proposal swarm ~proposal in
@@ -546,7 +552,7 @@ let test_pure_update_proposal_status_passed () =
              proposal_id = "p1"; description = "Test";
              proposed_by = "a1"; proposed_at = 2000.0;
              votes_for = ["a1"; "a2"]; votes_against = [];
-             threshold = 0.6; deadline = None;
+             threshold = n 0.6; deadline = None;
              status = `Pending;
            } in
            let s3 = Swarm_eio.Pure.add_proposal s2 ~proposal in
@@ -564,7 +570,7 @@ let test_pure_update_proposal_status_expired () =
         proposal_id = "p1"; description = "Test";
         proposed_by = "a1"; proposed_at = 2000.0;
         votes_for = []; votes_against = [];
-        threshold = 0.6; deadline = Some 2500.0;
+        threshold = n 0.6; deadline = Some 2500.0;
         status = `Pending;
       } in
       let s2 = Swarm_eio.Pure.add_proposal s1 ~proposal in
@@ -709,7 +715,7 @@ let make_populated_swarm () : Swarm_eio.swarm =
   let agents = List.init 3 (fun i ->
     { Swarm_eio.id = Printf.sprintf "a%d" i;
       name = Printf.sprintf "agent-%d" i;
-      fitness = 0.5 +. (float_of_int i *. 0.1);
+      fitness = n (0.5 +. (float_of_int i *. 0.1));
       generation = 0; mutations = [];
       joined_at = 1000.0; last_active = 1000.0; }
   ) in


### PR DESCRIPTION
## Summary
- **P0 #1**: RNG parameterization — `~rng:Random.State.t` to `Pure.evolve_agents`, `select_solution`, `follow_pheromone` for deterministic testing
- **P0 #2**: `Normalized` abstract type `[0.0, 1.0]` — `swarm_config` fields use `Normalized.t`, `Fitness` delegates to `Normalized`
- **P0 #3**: `*_of_json` → `(t, string) result` with `result_map_list` short-circuit helper
- **P0 #4**: Integration tests — JSON error cases (4), RNG determinism (2)

## Changes
| File | Lines | What |
|------|-------|------|
| `lib/level4_config.ml` | +91/-49 | `Normalized` module, `make_rng`, `Strength`/`Threshold` aliases |
| `lib/swarm_eio.ml` | +174/-109 | Result types, `result_map_list`, RNG params, Normalized fields |
| `lib/swarm_behaviors_eio.ml` | +12/-9 | `~rng` params, `Ok/Error` callers |
| `lib/tool_swarm.ml` | +5/-3 | `Normalized.of_float_clamped` for user input, `()` for evolve |
| `test/test_swarm_eio_coverage.ml` | +88/-24 | `Result.get_ok`, error tests, RNG determinism tests |
| `test/test_swarm_behaviors_eio_coverage.ml` | +4/-3 | `~rng` params, module alias |

## Test plan
- [x] `dune build --root .` — clean compile
- [x] `dune test --root .` — all swarm tests pass (only pre-existing `dispatch_auth_enable` failure)
- [x] JSON roundtrip tests pass with Result types
- [x] RNG determinism: same seed → identical mutations
- [x] RNG divergence: different seeds → different mutation IDs
- [x] JSON error cases: bad input → `Error _`

Closes #300

🤖 Generated with [Claude Code](https://claude.com/claude-code)