### PR TITLE
refactor: specify exception types instead of catch-all

### DIFF
--- a/lib/auto_recall.ml
+++ b/lib/auto_recall.ml
@@ -166,7 +166,7 @@ let fetch_from_file_context (room_config : Room_utils.config) ~(config : recall_
           List.rev acc
       in
       read_lines []
-    with _ -> []
+    with Unix.Unix_error _ | Sys_error _ -> []
   in
   
   (* Read preview of each file *)
@@ -178,7 +178,7 @@ let fetch_from_file_context (room_config : Room_utils.config) ~(config : recall_
       close_in ic;
       let truncated = in_channel_length ic > max_preview_bytes in
       if truncated then content ^ "\n... [truncated]" else content
-    with _ -> ""
+    with Sys_error _ -> ""
   in
   
   (* Calculate relevance based on query match and recency *)

--- a/lib/mcp_server_eio.ml
+++ b/lib/mcp_server_eio.ml
@@ -253,7 +253,8 @@ let handle_read_resource_eio state id params =
                   let json = Room.read_json config file in
                   let inst = Institution_eio.institution_of_json json in
                   ("text/markdown", Some (Institution_eio.format_for_injection inst))
-                with _ ->
+                with
+                | Yojson.Json_error _ | Sys_error _ ->
                   (* Fallback: return raw JSON if parsing fails *)
                   let content = In_channel.with_open_text file In_channel.input_all in
                   ("application/json", Some content)
@@ -1691,7 +1692,8 @@ Time: %s
                 let agent_ok = match agent_filter with None -> true | Some a -> ep_agent = a in
                 let gen_ok = match gen_filter with None -> true | Some g -> ep_gen = g in
                 if agent_ok && gen_ok then Some json else None
-              with _ -> None
+              with
+              | Yojson.Json_error _ | Yojson.Safe.Util.Type_error _ -> None
             )
         with Sys_error _ -> []
       in
@@ -1846,7 +1848,9 @@ Time: %s
               let json = Yojson.Safe.from_string
                 (String.sub message idx (String.length message - idx)) in
               Yojson.Safe.Util.(json |> member "id" |> to_string)
-            with _ -> "unknown"
+            with
+            | Not_found | Invalid_argument _
+            | Yojson.Json_error _ | Yojson.Safe.Util.Type_error _ -> "unknown"
           ));
           ("timestamp", `String (Types.now_iso ()));
         ] in

--- a/lib/social.ml
+++ b/lib/social.ml
@@ -187,10 +187,10 @@ let write_json path json =
   let closed = ref false in
   Common.protect ~module_name:"social" ~finally_label:"finalizer" ~finally:(fun () ->
     (* Only close if not already closed in protected block *)
-    if not !closed then (try close_out oc with _ -> ());
+    if not !closed then (try close_out oc with Sys_error _ -> ());
     (* Clean up temp file on error (won't exist after successful rename) *)
     if Sys.file_exists tmp_path then
-      try Sys.remove tmp_path with _ -> ()
+      try Sys.remove tmp_path with Sys_error _ -> ()
   ) (fun () ->
     output_string oc content;
     flush oc;
@@ -341,7 +341,7 @@ let with_file_lock path f =
   let lock_path = path ^ ".lock" in
   let fd = Unix.openfile lock_path [Unix.O_CREAT; Unix.O_WRONLY] 0o644 in
   Common.protect ~module_name:"social" ~finally_label:"finalizer" ~finally:(fun () ->
-    (try Unix.lockf fd Unix.F_ULOCK 0 with _ -> ());
+    (try Unix.lockf fd Unix.F_ULOCK 0 with Unix.Unix_error _ -> ());
     Unix.close fd
   ) (fun () ->
     Unix.lockf fd Unix.F_LOCK 0;


### PR DESCRIPTION
## Summary
- Replace `with _ ->` catch-all patterns with specific exception types
- Improves debugging and makes error handling explicit

## Changes
- **mcp_server_eio.ml**: `Yojson.Json_error`, `Sys_error`, `Type_error`, `Not_found`, `Invalid_argument`
- **social.ml**: `Sys_error`, `Unix.Unix_error`
- **auto_recall.ml**: `Unix.Unix_error`, `Sys_error`

## Testing
- `dune build @check` passes