### PR TITLE
feat: agent heartbeat context + cleanup

### DIFF
--- a/docs/HEARTBEAT-AUDIT.md
+++ b/docs/HEARTBEAT-AUDIT.md
@@ -1,0 +1,35 @@
+# Heartbeat Audit (Spec vs Implementation)
+
+목적: Agent Heartbeat / Lodge Heartbeat의 스펙 대비 구현 차이를 정리하고, 고장 위험과 개선 목표를 명확히 한다.
+
+## 핵심 요약
+
+- **두 개의 heartbeat 시스템이 공존**하며, 역할과 생존 판정 대상이 다르다.
+- **Room 생존 판정은 Agent Heartbeat 기준**이며, Lodge Heartbeat는 별개다.
+- **이 PR에서 해결된 차이점**: leave/zombie 시 heartbeat stop, context 저장/ratio 계산, GraphQL auth header 정합성.
+
+## Spec ↔ Implementation Gaps
+
+| # | 항목 | 스펙/의도 | 구현 상태 | 영향/리스크 | 상태 |
+|---|------|-----------|-----------|-------------|------|
+| 1 | Agent vs Lodge Heartbeat 구분 | Agent Heartbeat는 Room 생존/컨텍스트, Lodge는 소셜/발견 | 문서에 명시 없음 | 운영자가 두 heartbeat를 동일하게 인식할 위험 | **문서화(이번 PR)** |
+| 2 | leave 시 heartbeat 중지 | `leave`는 해당 agent heartbeat 정지 | 기존엔 heartbeat loop 잔존 가능 | 떠난 에이전트가 broadcast 지속 가능 | **수정(이번 PR)** |
+| 3 | cleanup_zombies 시 heartbeat 중지 | zombie 정리 시 loop까지 정리 | 기존엔 loop 잔존 가능 | 좀비 정리 후에도 활동 지속 | **수정(이번 PR)** |
+| 4 | Agent context report | heartbeat마다 context 보고 가능 | `masc_heartbeat`는 지원하지만 ratio 자동 계산 없음 | context 불완전/불일치 가능 | **수정(이번 PR)** |
+| 5 | Lodge GraphQL 인증 헤더 | Bearer 토큰 사용 | 일부 코드가 `X-API-Key` | 401/데이터 미로딩 | **수정(이번 PR)** |
+| 6 | Lodge enable flag 불일치 | 단일 플래그로 제어 | `LODGE_ENABLED` vs `LODGE_DAEMON_ENABLED` 혼재 | 설정 혼동/예상치 못한 동작 | **미해결(추가 개선 필요)** |
+| 7 | Lodge self-heartbeat → Room 생존 | Lodge heartbeat가 Room last_seen 갱신 | 없음 | Lodge만 켜져도 Room에서는 좀비로 판정 | **의도 분리(문서화)** |
+
+## 개선 목표 (Feedback Loop)
+
+1. **정합성 목표**: Heartbeat 관련 플래그는 단일 소스로 통일 (`LODGE_ENABLED` 단일화 or 명확한 분리).
+2. **운영 안정성 목표**: leave/zombie 시 heartbeat loop 0개 보장.
+3. **컨텍스트 목표**: Agent Heartbeat에 context 보고 누락률 0% (ratio 자동 계산 포함).
+4. **관찰 가능성 목표**: `masc_agents`/A2A 응답에 context 필드 포함, 상태 확인 가능.
+
+## 추적 기준
+
+- `Room.leave` 호출 후 `Heartbeat.list()`에서 해당 agent loop 0개
+- `Room.cleanup_zombies` 실행 후 해당 agent loop 0개
+- `masc_heartbeat` 호출 시 `agents`/`a2a_discover` 응답에 `context` 포함
+- Lodge GraphQL 호출 시 Authorization Bearer 헤더 사용

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -179,6 +179,15 @@ Client Request
 | A2A Tools | a2a_discover, a2a_query_skill, a2a_delegate, a2a_subscribe, a2a_unsubscribe |
 | MCP Spec Support | mcp_session, cancellation, subscription |
 
+### Heartbeat Systems (Agent vs Lodge)
+
+| 구분 | 역할 | 주요 엔드포인트/동작 | 비고 |
+|------|------|-----------------------|------|
+| **Agent Heartbeat** | Room 내 에이전트 생존/좀비 판정, 컨텍스트 상태 보고 | `masc_heartbeat`, `masc_heartbeat_start`, `masc_cleanup_zombies` | `masc_heartbeat`에 `context`를 포함하면 컨텍스트 지표가 저장됨. `used_tokens`+`max_tokens`가 있으면 `ratio` 자동 계산. |
+| **Lodge Heartbeat** | Lodge(에이전트 소셜/발견) 시스템의 주기 실행 | `lodge_heartbeat`(daemon) | **Agent Heartbeat와 별개**. Lodge self-heartbeat는 Room의 `last_seen`을 갱신하지 않음. |
+
+**권장**: 에이전트는 2–3분 주기로 `masc_heartbeat`를 호출하고, 컨텍스트 정보를 함께 보고한다.
+
 ### Cellular Agent Tools Detail (New in v3.0)
 
 #### Handover (DNA Transfer)
@@ -399,7 +408,7 @@ masc_handover_create --source claude --reason context_limit
 |--------------|---------|----------|
 | Polling `masc_messages` | Wastes resources | Use `masc_listen` |
 | Skip `masc_claim` | Task conflicts | Always claim first |
-| Ignore heartbeat | Marked as zombie | Call every 2-3 mins |
+| Ignore heartbeat/context report | Marked as zombie or stale context data | Call every 2-3 mins; include context metrics when available |
 | Direct file edit | Bypasses tracking | Use worktree |
 | No handover on exit | Lost context | Always create DNA |
 

--- a/lib/a2a_tools.ml
+++ b/lib/a2a_tools.ml
@@ -227,6 +227,22 @@ let discover config ?(endpoint : string option) ?(capability : string option) ()
     (* Include local agent card *)
     let local_card = Agent_card.generate_default () in
     let agents_json = List.map (fun (a : agent) ->
+      let context_json =
+        match a.context with
+        | None -> `Null
+        | Some ctx ->
+            let int_opt = function Some v -> `Int v | None -> `Null in
+            let float_opt = function Some v -> `Float v | None -> `Null in
+            let string_opt = function Some v -> `String v | None -> `Null in
+            `Assoc [
+              ("used_tokens", int_opt ctx.used_tokens);
+              ("max_tokens", int_opt ctx.max_tokens);
+              ("ratio", float_opt ctx.ratio);
+              ("messages", int_opt ctx.messages);
+              ("tool_calls", int_opt ctx.tool_calls);
+              ("reported_at", string_opt ctx.reported_at);
+            ]
+      in
       `Assoc [
         ("name", `String a.name);
         ("status", `String (agent_status_to_string a.status));
@@ -236,6 +252,7 @@ let discover config ?(endpoint : string option) ?(capability : string option) ()
           | Some t -> `String t);
         ("joined_at", `String a.joined_at);
         ("last_seen", `String a.last_seen);
+        ("context", context_json);
       ]
     ) filtered in
     Ok (`Assoc [

--- a/lib/heartbeat.ml
+++ b/lib/heartbeat.ml
@@ -33,6 +33,16 @@ let stop id =
       true
   | None -> false
 
+let stop_by_agent ~agent_name =
+  let ids =
+    Hashtbl.fold
+      (fun id hb acc -> if hb.agent_name = agent_name then id :: acc else acc)
+      heartbeats
+      []
+  in
+  List.iter (fun id -> ignore (stop id)) ids;
+  List.length ids
+
 let list () =
   Hashtbl.fold (fun _ hb acc -> hb :: acc) heartbeats []
 

--- a/lib/heartbeat.mli
+++ b/lib/heartbeat.mli
@@ -12,5 +12,6 @@ type t = {
 val generate_id : unit -> string
 val start : agent_name:string -> interval:int -> message:string -> string
 val stop : string -> bool
+val stop_by_agent : agent_name:string -> int
 val list : unit -> t list
 val get : string -> t option

--- a/lib/lodge_heartbeat.ml
+++ b/lib/lodge_heartbeat.ml
@@ -446,7 +446,7 @@ let load_agents_from_neo4j () =
   let gql_query = "{\"query\": \"{ agents(first: 10) { edges { node { name preferredHours peakHour traits activityLevel } } } }\"}" in
   let api_key = Sys.getenv_opt "GRAPHQL_API_KEY" |> Option.value ~default:"" in
   let cmd = Printf.sprintf
-    "curl -s --connect-timeout 3 --max-time 5 https://second-brain-graphql-production.up.railway.app/graphql -H 'Content-Type: application/json' -H 'X-API-Key: %s' -d '%s' 2>/dev/null"
+    "curl -s --connect-timeout 3 --max-time 5 https://second-brain-graphql-production.up.railway.app/graphql -H 'Content-Type: application/json' -H 'Authorization: Bearer %s' -d '%s' 2>/dev/null"
     api_key gql_query
   in
   Printf.eprintf "[Heartbeat] Loading agents via GraphQL (key=%d chars)...\n%!" (String.length api_key);

--- a/lib/mcp_server_eio.ml
+++ b/lib/mcp_server_eio.ml
@@ -732,7 +732,7 @@ let execute_tool_eio ~sw ~clock ?mcp_session_id ?auth_token state ~name ~argumen
     Session.update_activity registry ~agent_name ();
     (* Also update disk-based heartbeat for zombie detection across restarts *)
     if Room.is_initialized config then
-      ignore (Room.heartbeat config ~agent_name)
+      ignore (Room.heartbeat config ~agent_name ~context:None)
   end;
 
   (* Auto-join: if agent not in session and tool requires agent, auto-register *)

--- a/lib/room.ml
+++ b/lib/room.ml
@@ -290,6 +290,7 @@ and join config ~agent_name ?(agent_type_override=None) ~capabilities
     current_task = None;
     joined_at = now_iso ();
     last_seen = now_iso ();
+    context = None;
     meta = Some meta;
   } in
   write_json config agent_file (agent_to_yojson agent);
@@ -343,9 +344,41 @@ and leave config ~agent_name =
 
   (* Support both exact nickname match and agent_type prefix match *)
   let actual_name = resolve_agent_name config agent_name in
-
   let agent_file = Filename.concat (agents_dir config) (safe_filename actual_name ^ ".json") in
+  let agent_record =
+    if Sys.file_exists agent_file then
+      match agent_of_yojson (read_json config agent_file) with
+      | Ok agent -> Some agent
+      | Error _ -> None
+    else
+      None
+  in
+  let agent_type =
+    match agent_record with
+    | Some agent -> agent.agent_type
+    | None -> agent_name
+  in
+  let same_type_count =
+    let agents_path = agents_dir config in
+    if not (Sys.file_exists agents_path) then 0
+    else
+      let count = ref 0 in
+      Sys.readdir agents_path |> Array.iter (fun name ->
+        if Filename.check_suffix name ".json" then begin
+          let path = Filename.concat agents_path name in
+          match agent_of_yojson (read_json config path) with
+          | Ok agent when agent.agent_type = agent_type -> incr count
+          | _ -> ()
+        end
+      );
+      !count
+  in
+
   if Sys.file_exists agent_file then begin
+    (* Stop any active heartbeat loops for this agent *)
+    ignore (Heartbeat.stop_by_agent ~agent_name:actual_name);
+    if agent_type <> actual_name && same_type_count <= 1 then
+      ignore (Heartbeat.stop_by_agent ~agent_name:agent_type);
     Sys.remove agent_file;
 
     let _ = update_state config (fun s ->
@@ -1680,7 +1713,7 @@ include Room_worktree
    and is_zombie_agent are defined earlier in the file for use in status *)
 
 (** Update agent heartbeat - must be called periodically *)
-let heartbeat config ~agent_name =
+let heartbeat config ~agent_name ~context =
   ensure_initialized config;
 
   (* Support both exact nickname and agent_type prefix match *)
@@ -1691,7 +1724,46 @@ let heartbeat config ~agent_name =
       let json = read_json config agent_file in
       match agent_of_yojson json with
       | Ok agent ->
-          let updated = { agent with last_seen = now_iso () } in
+          let now = now_iso () in
+          let merged_context =
+            match context with
+            | None -> agent.context
+            | Some ctx ->
+                let merge_field new_val old_val =
+                  match new_val with
+                  | Some _ -> new_val
+                  | None -> old_val
+                in
+                let prev = Option.value agent.context ~default:{
+                  used_tokens = None;
+                  max_tokens = None;
+                  ratio = None;
+                  messages = None;
+                  tool_calls = None;
+                  reported_at = None;
+                } in
+                Some {
+                  used_tokens = merge_field ctx.used_tokens prev.used_tokens;
+                  max_tokens = merge_field ctx.max_tokens prev.max_tokens;
+                  ratio = merge_field ctx.ratio prev.ratio;
+                  messages = merge_field ctx.messages prev.messages;
+                  tool_calls = merge_field ctx.tool_calls prev.tool_calls;
+                  reported_at = Some now;
+                }
+          in
+          let merged_context =
+            match merged_context with
+            | None -> None
+            | Some ctx ->
+                let ratio =
+                  match ctx.ratio, ctx.used_tokens, ctx.max_tokens with
+                  | None, Some used, Some max when max > 0 ->
+                      Some (float_of_int used /. float_of_int max)
+                  | _ -> ctx.ratio
+                in
+                Some { ctx with ratio }
+          in
+          let updated = { agent with last_seen = now; context = merged_context } in
           write_json config agent_file (agent_to_yojson updated);
           Printf.sprintf "💓 %s heartbeat updated" actual_name
       | Error _ ->
@@ -1709,20 +1781,29 @@ let cleanup_zombies config =
     "📋 No agents directory"
   else begin
     let zombies = ref [] in
+    let agents = get_agents_raw config in
+    let live_type_counts = Hashtbl.create 16 in
+    List.iter (fun (agent : Types.agent) ->
+      if not (is_zombie_agent agent.last_seen) then begin
+        let prev = match Hashtbl.find_opt live_type_counts agent.agent_type with Some v -> v | None -> 0 in
+        Hashtbl.replace live_type_counts agent.agent_type (prev + 1)
+      end
+    ) agents;
 
     (* Find zombie agents *)
-    Sys.readdir agents_path |> Array.iter (fun name ->
-      if Filename.check_suffix name ".json" then begin
-        let path = Filename.concat agents_path name in
-        let json = read_json config path in
-        match agent_of_yojson json with
-        | Ok agent when is_zombie_agent agent.last_seen ->
-            zombies := agent.name :: !zombies;
-            (* Remove agent file *)
-            Sys.remove path
-        | _ -> ()
+    List.iter (fun (agent : Types.agent) ->
+      if is_zombie_agent agent.last_seen then begin
+        zombies := agent.name :: !zombies;
+        (* Stop any active heartbeat loops for this agent *)
+        ignore (Heartbeat.stop_by_agent ~agent_name:agent.name);
+        let live_count = match Hashtbl.find_opt live_type_counts agent.agent_type with Some v -> v | None -> 0 in
+        if agent.agent_type <> agent.name && live_count = 0 then
+          ignore (Heartbeat.stop_by_agent ~agent_name:agent.agent_type);
+        (* Remove agent file *)
+        let path = Filename.concat agents_path (safe_filename agent.name ^ ".json") in
+        if Sys.file_exists path then Sys.remove path
       end
-    );
+    ) agents;
 
     (* Update state to remove zombie agents *)
     if !zombies <> [] then begin
@@ -1876,6 +1957,22 @@ let get_agents_status config =
         | Ok agent ->
             let is_zombie = is_zombie_agent agent.last_seen in
             let status = if is_zombie then "zombie" else agent_status_to_string agent.status in
+            let context_json =
+              match agent.context with
+              | None -> `Null
+              | Some ctx ->
+                  let int_opt = function Some v -> `Int v | None -> `Null in
+                  let float_opt = function Some v -> `Float v | None -> `Null in
+                  let string_opt = function Some v -> `String v | None -> `Null in
+                  `Assoc [
+                    ("used_tokens", int_opt ctx.used_tokens);
+                    ("max_tokens", int_opt ctx.max_tokens);
+                    ("ratio", float_opt ctx.ratio);
+                    ("messages", int_opt ctx.messages);
+                    ("tool_calls", int_opt ctx.tool_calls);
+                    ("reported_at", string_opt ctx.reported_at);
+                  ]
+            in
             agents := `Assoc [
               ("name", `String agent.name);
               ("status", `String status);
@@ -1883,6 +1980,7 @@ let get_agents_status config =
               ("current_task", match agent.current_task with Some t -> `String t | None -> `Null);
               ("last_seen", `String agent.last_seen);
               ("capabilities", `List (List.map (fun s -> `String s) agent.capabilities));
+              ("context", context_json);
             ] :: !agents
         | Error _ -> ()
       end

--- a/lib/tool_heartbeat.ml
+++ b/lib/tool_heartbeat.ml
@@ -10,6 +10,17 @@ let get_int args key default =
   | `Int n -> n
   | _ -> default
 
+let get_int_opt args key =
+  match Yojson.Safe.Util.member key args with
+  | `Int n -> Some n
+  | _ -> None
+
+let get_float_opt args key =
+  match Yojson.Safe.Util.member key args with
+  | `Float f -> Some f
+  | `Int n -> Some (float_of_int n)
+  | _ -> None
+
 let get_bool args key default =
   match Yojson.Safe.Util.member key args with
   | `Bool b -> b
@@ -24,16 +35,41 @@ type 'a context = {
 
 type result = bool * string
 
-let handle_heartbeat ctx _args =
-  (true, Room.heartbeat ctx.config ~agent_name:ctx.agent_name)
+let parse_context args =
+  match Yojson.Safe.Util.member "context" args with
+  | `Assoc _ as ctx_json ->
+      let used_tokens = get_int_opt ctx_json "used_tokens" in
+      let max_tokens = get_int_opt ctx_json "max_tokens" in
+      let ratio = get_float_opt ctx_json "ratio" in
+      let messages = get_int_opt ctx_json "messages" in
+      let tool_calls = get_int_opt ctx_json "tool_calls" in
+      if used_tokens = None && max_tokens = None && ratio = None && messages = None && tool_calls = None then
+        None
+      else
+        let open Types in
+        Some {
+          used_tokens;
+          max_tokens;
+          ratio;
+          messages;
+          tool_calls;
+          reported_at = None;
+        }
+  | _ -> None
+
+let handle_heartbeat ctx args =
+  let context = parse_context args in
+  (true, Room.heartbeat ctx.config ~agent_name:ctx.agent_name ~context)
 
 let handle_heartbeat_start ctx args =
   let interval = get_int args "interval" 30 in
   let message = get_string args "message" "🏓 heartbeat" in
   let smart = get_bool args "smart" false in
+  let context = parse_context args in
+  let actual_name = Room.resolve_agent_name ctx.config ctx.agent_name in
   (* Validate interval: min 5, max 300 *)
   let interval = max 5 (min 300 interval) in
-  let hb_id = Heartbeat.start ~agent_name:ctx.agent_name ~interval ~message in
+  let hb_id = Heartbeat.start ~agent_name:actual_name ~interval ~message in
 
   (* Smart heartbeat config *)
   let smart_config = Heartbeat_smart.make_config
@@ -57,7 +93,7 @@ let handle_heartbeat_start ctx args =
               (* Get agent status for busy detection *)
               let room_agents = Room.get_agents_raw ctx.config in
               let agent_status : Types.agent_status =
-                match List.find_opt (fun (a : Types.agent) -> a.name = ctx.agent_name) room_agents with
+                match List.find_opt (fun (a : Types.agent) -> a.name = actual_name) room_agents with
                 | Some a -> a.status
                 | None -> Types.Active  (* Default: not busy *)
               in
@@ -73,9 +109,16 @@ let handle_heartbeat_start ctx args =
             end else
               true
           in
+          (* Always update liveness on each tick (with optional context) *)
+          (try
+             ignore (Room.heartbeat ctx.config ~agent_name:actual_name ~context)
+           with exn ->
+             Printf.eprintf "[Heartbeat] liveness update error: %s\n%!"
+               (Printexc.to_string exn));
+
           if should_send then begin
             (try
-               ignore (Room.broadcast ctx.config ~from_agent:ctx.agent_name ~content:message)
+               ignore (Room.broadcast ctx.config ~from_agent:actual_name ~content:message)
              with exn ->
                Printf.eprintf "[Heartbeat] broadcast error: %s\n%!"
                  (Printexc.to_string exn));

--- a/lib/tool_heartbeat.mli
+++ b/lib/tool_heartbeat.mli
@@ -2,6 +2,8 @@
 
 val get_string : Yojson.Safe.t -> string -> string -> string
 val get_int : Yojson.Safe.t -> string -> int -> int
+val get_int_opt : Yojson.Safe.t -> string -> int option
+val get_float_opt : Yojson.Safe.t -> string -> float option
 
 type 'a context = {
   config: Room.config;

--- a/lib/tool_lodge.ml
+++ b/lib/tool_lodge.ml
@@ -529,7 +529,7 @@ let load_agents_config () =
   (* Query all Lodge identity fields for dynamic agent system *)
   let query = "{\"query\": \"{ agents(first: 10) { edges { node { name primaryValue status emoji koreanName model interests } } } }\"}" in
   let api_key = Sys.getenv_opt "GRAPHQL_API_KEY" |> Option.value ~default:"" in
-  let cmd = Printf.sprintf "curl -s --connect-timeout 3 --max-time 5 https://second-brain-graphql-production.up.railway.app/graphql -H 'Content-Type: application/json' -H 'X-API-Key: %s' -d '%s' 2>/dev/null" api_key query in
+  let cmd = Printf.sprintf "curl -s --connect-timeout 3 --max-time 5 https://second-brain-graphql-production.up.railway.app/graphql -H 'Content-Type: application/json' -H 'Authorization: Bearer %s' -d '%s' 2>/dev/null" api_key query in
   try
     let ic = Unix.open_process_in cmd in
     let buf = Buffer.create 4096 in
@@ -1308,7 +1308,7 @@ let get_all_agents () =
   (* Simplified query to stay under cost limit (1000) *)
   let query = "{\"query\": \"{ agents(first: 10) { edges { node { name primaryValue status } } } }\"}" in
   let api_key = Sys.getenv_opt "GRAPHQL_API_KEY" |> Option.value ~default:"" in
-  let cmd = Printf.sprintf "curl -s --max-time 5 https://second-brain-graphql-production.up.railway.app/graphql -H 'Content-Type: application/json' -H 'X-API-Key: %s' -d '%s' 2>/dev/null" api_key query in
+  let cmd = Printf.sprintf "curl -s --max-time 5 https://second-brain-graphql-production.up.railway.app/graphql -H 'Content-Type: application/json' -H 'Authorization: Bearer %s' -d '%s' 2>/dev/null" api_key query in
   try
     let (_, output) = run_shell_nonblocking cmd in
     try

--- a/lib/tools.ml
+++ b/lib/tools.ml
@@ -723,13 +723,39 @@ Auto-closes on masc_leave. Check masc_portal_status for active portals.";
 
   {
     name = "masc_heartbeat";
-    description = "Update your heartbeat timestamp. Call periodically (every few minutes) to indicate you're still active. Agents without heartbeat for 5+ minutes are considered 'zombies' and can be cleaned up.";
+    description = "Update your heartbeat timestamp (and optionally report context health). Call periodically (every few minutes) to indicate you're still active. Agents without heartbeat for 5+ minutes are considered 'zombies' and can be cleaned up.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
         ("agent_name", `Assoc [
           ("type", `String "string");
           ("description", `String "Your agent name");
+        ]);
+        ("context", `Assoc [
+          ("type", `String "object");
+          ("description", `String "Optional context health report (agent self-report)");
+          ("properties", `Assoc [
+            ("used_tokens", `Assoc [
+              ("type", `String "integer");
+              ("description", `String "Estimated total tokens used in current context");
+            ]);
+            ("max_tokens", `Assoc [
+              ("type", `String "integer");
+              ("description", `String "Model context window max tokens");
+            ]);
+            ("ratio", `Assoc [
+              ("type", `String "number");
+              ("description", `String "Context usage ratio (0.0-1.0)");
+            ]);
+            ("messages", `Assoc [
+              ("type", `String "integer");
+              ("description", `String "Approximate message count in context");
+            ]);
+            ("tool_calls", `Assoc [
+              ("type", `String "integer");
+              ("description", `String "Approximate tool call count in context");
+            ]);
+          ]);
         ]);
       ]);
       ("required", `List [`String "agent_name"]);
@@ -747,7 +773,7 @@ Auto-closes on masc_leave. Check masc_portal_status for active portals.";
 
   {
     name = "masc_heartbeat_start";
-    description = "Start periodic heartbeat broadcasts. Runs in background, sending pings at specified interval. Smart mode skips heartbeats when agent is busy (60-80% token savings).";
+    description = "Start periodic heartbeat broadcasts. Runs in background, sending pings at specified interval and updating liveness. Smart mode skips broadcasts when agent is busy (60-80% token savings).";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -765,6 +791,32 @@ Auto-closes on masc_leave. Check masc_portal_status for active portals.";
           ("type", `String "boolean");
           ("description", `String "Enable smart mode: skip when busy, 3x interval when idle >5min");
           ("default", `Bool false);
+        ]);
+        ("context", `Assoc [
+          ("type", `String "object");
+          ("description", `String "Optional static context health report to attach on each tick. For dynamic context, call masc_heartbeat directly with updated context.");
+          ("properties", `Assoc [
+            ("used_tokens", `Assoc [
+              ("type", `String "integer");
+              ("description", `String "Estimated total tokens used in current context");
+            ]);
+            ("max_tokens", `Assoc [
+              ("type", `String "integer");
+              ("description", `String "Model context window max tokens");
+            ]);
+            ("ratio", `Assoc [
+              ("type", `String "number");
+              ("description", `String "Context usage ratio (0.0-1.0)");
+            ]);
+            ("messages", `Assoc [
+              ("type", `String "integer");
+              ("description", `String "Approximate message count in context");
+            ]);
+            ("tool_calls", `Assoc [
+              ("type", `String "integer");
+              ("description", `String "Approximate tool call count in context");
+            ]);
+          ]);
         ]);
       ]);
     ];

--- a/lib/types.ml
+++ b/lib/types.ml
@@ -167,6 +167,16 @@ type agent_meta = {
   parent_task: string option; [@default None] (* task that spawned this agent *)
 } [@@deriving yojson { strict = false }, show]
 
+(** Agent context report - lifecycle and context health info *)
+type agent_context = {
+  used_tokens: int option; [@default None]
+  max_tokens: int option; [@default None]
+  ratio: float option; [@default None]
+  messages: int option; [@default None]
+  tool_calls: int option; [@default None]
+  reported_at: string option; [@default None]
+} [@@deriving yojson { strict = false }, show]
+
 (** Agent info *)
 type agent = {
   name: string;                           (* unique nickname: claude-swift-fox *)
@@ -176,6 +186,7 @@ type agent = {
   current_task: string option; [@default None]
   joined_at: string;
   last_seen: string;
+  context: agent_context option; [@default None]
   meta: agent_meta option; [@default None] (* session metadata *)
 } [@@deriving yojson { strict = false }, show]
 

--- a/test/test_room.ml
+++ b/test/test_room.ml
@@ -271,6 +271,25 @@ let test_leave_removes_agent () =
     Alcotest.(check bool) "leave success" true (contains_check result)
   )
 
+let test_leave_stops_heartbeat () =
+  with_test_env (fun config ->
+    let _ = Room.join config ~agent_name:"gemini" ~capabilities:["test"] () in
+    let agents = Room.get_agents_raw config in
+    let gemini_agent =
+      match List.find_opt (fun (a : Types.agent) -> a.agent_type = "gemini") agents with
+      | Some agent -> agent
+      | None -> Alcotest.fail "gemini agent missing after join"
+    in
+    let hb_id = Heartbeat.start ~agent_name:gemini_agent.name ~interval:30 ~message:"ping" in
+
+    let result = Room.leave config ~agent_name:"gemini" in
+    Alcotest.(check bool) "leave success" true (contains_check result);
+
+    let hbs = Heartbeat.list () in
+    let still_exists = List.exists (fun hb -> hb.Heartbeat.id = hb_id) hbs in
+    Alcotest.(check bool) "heartbeat removed" false still_exists
+  )
+
 let test_double_join () =
   with_test_env (fun config ->
     let _ = Room.join config ~agent_name:"gemini" ~capabilities:["test"] () in
@@ -504,17 +523,43 @@ let test_heartbeat_updates_lastseen () =
     let _ = Room.join config ~agent_name:"gemini" ~capabilities:[] () in
 
     (* Send heartbeat *)
-    let result = Room.heartbeat config ~agent_name:"gemini" in
+    let result = Room.heartbeat config ~agent_name:"gemini" ~context:None in
     Alcotest.(check bool) "heartbeat success" true (contains_heartbeat result)
   )
 
 let test_heartbeat_nonexistent_agent () =
   with_test_env (fun config ->
     (* Heartbeat for non-joined agent *)
-    let result = Room.heartbeat config ~agent_name:"nonexistent" in
+    let result = Room.heartbeat config ~agent_name:"nonexistent" ~context:None in
     Alcotest.(check bool) "heartbeat for nonexistent" true (contains_warning result)
   )
 
+let test_heartbeat_updates_context () =
+  with_test_env (fun config ->
+    let _ = Room.join config ~agent_name:"gemini" ~capabilities:[] () in
+    let ctx : Types.agent_context = {
+      used_tokens = Some 4200;
+      max_tokens = Some 16384;
+      ratio = Some 0.256;
+      messages = Some 42;
+      tool_calls = Some 7;
+      reported_at = None;
+    } in
+
+    let _ = Room.heartbeat config ~agent_name:"gemini" ~context:(Some ctx) in
+    let agents = Room.get_agents_raw config in
+    match List.find_opt (fun (a : Types.agent) -> a.agent_type = "gemini") agents with
+    | None -> Alcotest.fail "agent missing after heartbeat"
+    | Some agent ->
+        (match agent.context with
+         | None -> Alcotest.fail "context not stored"
+         | Some stored ->
+             Alcotest.(check (option int)) "used_tokens" (Some 4200) stored.used_tokens;
+             Alcotest.(check (option int)) "max_tokens" (Some 16384) stored.max_tokens;
+             Alcotest.(check (option int)) "messages" (Some 42) stored.messages;
+             Alcotest.(check (option int)) "tool_calls" (Some 7) stored.tool_calls;
+             Alcotest.(check bool) "reported_at set" true (stored.reported_at <> None))
+  )
 let test_get_agents_status () =
   with_test_env (fun config ->
     let _ = Room.join config ~agent_name:"gemini" ~capabilities:["python"] () in
@@ -1008,6 +1053,7 @@ let () =
     ];
     "leave", [
       Alcotest.test_case "removes agent" `Quick test_leave_removes_agent;
+      Alcotest.test_case "stops heartbeat" `Quick test_leave_stops_heartbeat;
     ];
     "tasks", [
       Alcotest.test_case "add and claim" `Quick test_add_and_claim_task;
@@ -1079,6 +1125,7 @@ let () =
     "heartbeat", [
       Alcotest.test_case "updates last_seen" `Quick test_heartbeat_updates_lastseen;
       Alcotest.test_case "nonexistent agent" `Quick test_heartbeat_nonexistent_agent;
+      Alcotest.test_case "updates context" `Quick test_heartbeat_updates_context;
       Alcotest.test_case "get agents status" `Quick test_get_agents_status;
       Alcotest.test_case "cleanup zombies empty" `Quick test_cleanup_zombies_empty;
     ];

--- a/test/test_tool_heartbeat_coverage.ml
+++ b/test/test_tool_heartbeat_coverage.ml
@@ -70,6 +70,22 @@ let () = test "heartbeat_list_multiple" (fun () ->
   ignore (Heartbeat.stop id2)
 )
 
+let () = test "heartbeat_stop_by_agent" (fun () ->
+  let id1 = Heartbeat.start ~agent_name:"agent-x" ~interval:10 ~message:"m1" in
+  let id2 = Heartbeat.start ~agent_name:"agent-x" ~interval:20 ~message:"m2" in
+  let id3 = Heartbeat.start ~agent_name:"agent-y" ~interval:30 ~message:"m3" in
+
+  let removed = Heartbeat.stop_by_agent ~agent_name:"agent-x" in
+  assert (removed = 2);
+
+  let hbs = Heartbeat.list () in
+  assert (not (List.exists (fun hb -> hb.Heartbeat.id = id1) hbs));
+  assert (not (List.exists (fun hb -> hb.Heartbeat.id = id2) hbs));
+  assert (List.exists (fun hb -> hb.Heartbeat.id = id3) hbs);
+
+  ignore (Heartbeat.stop id3)
+)
+
 (* Tool_heartbeat tests *)
 let () = test "get_string_present" (fun () ->
   let args = `Assoc [("key", `String "value")] in


### PR DESCRIPTION
## Summary
- add agent heartbeat context fields and expose via agent status/A2A
- stop heartbeat loops on leave/zombie cleanup; resolve heartbeat names to nickname
- fix Lodge GraphQL Authorization header (Bearer)
- docs: heartbeat spec section + audit gaps
- tests for heartbeat context + stop_by_agent

## Tests
- dune test --root . (fails: worktree list/create tests due to Eio_unix thread_pool in non-git temp dir; pre-existing)