### PR TITLE
feat: Dashboard Agent Creator + Board caching + ETag

### DIFF
--- a/bin/main_eio.ml
+++ b/bin/main_eio.ml
@@ -1069,8 +1069,11 @@ let make_routes ~port ~host =
          Http.Response.json json reqd
        ) request reqd)
   |> Http.Router.get "/dashboard" (fun request reqd ->
-       with_public_read (fun _state _req reqd ->
-         Http.Response.html (Masc_mcp.Web_dashboard.html ()) reqd
+       with_public_read (fun _state req reqd ->
+         Http.Response.html_cached
+           ~etag:(Masc_mcp.Web_dashboard.etag ())
+           ~request:req
+           (Masc_mcp.Web_dashboard.html ()) reqd
        ) request reqd)
   |> Http.Router.get "/dashboard/credits" (fun request reqd ->
        with_public_read (fun _state _req reqd ->
@@ -1283,6 +1286,60 @@ let make_routes ~port ~host =
                (Printf.sprintf {|{"ok":false,"error":"%s"}|} (Printexc.to_string e))
                reqd
          )
+       ) request reqd)
+
+  (* Batch dashboard endpoint: single request replaces 4 separate API calls *)
+  |> Http.Router.get "/api/v1/dashboard" (fun request reqd ->
+       with_public_read (fun state req reqd ->
+         let config = state.Mcp_server.room_config in
+         let room_state = Room.read_state config in
+         let tempo = Tempo.get_tempo config in
+         let tasks = Room.get_tasks_raw config in
+         let agents = Room.get_agents_raw config in
+         let msgs = Room.get_messages_raw config ~since_seq:0 ~limit:20 in
+         let status_json = `Assoc [
+           ("cluster", `String (Option.value ~default:"unknown" (Sys.getenv_opt "MASC_CLUSTER_NAME")));
+           ("project", `String room_state.project);
+           ("tempo_interval_s", `Float tempo.current_interval_s);
+           ("paused", `Bool room_state.paused);
+         ] in
+         let tasks_json = List.map (fun (t : Types.task) ->
+           `Assoc [
+             ("id", `String t.id);
+             ("title", `String t.title);
+             ("status", `String (Types.string_of_task_status t.task_status));
+             ("priority", `Int t.priority);
+             ("assignee", match t.task_status with
+               | Claimed { assignee; _ } | InProgress { assignee; _ } | Done { assignee; _ } -> `String assignee
+               | _ -> `Null);
+           ]
+         ) (List.filter (fun (t : Types.task) ->
+              match t.task_status with
+              | Types.Done _ | Types.Cancelled _ -> false
+              | _ -> true
+            ) tasks) in
+         let agents_json = List.map (fun (a : Types.agent) ->
+           `Assoc [
+             ("name", `String a.name);
+             ("status", `String (Types.string_of_agent_status a.status));
+             ("current_task", match a.current_task with Some t -> `String t | None -> `Null);
+           ]
+         ) agents in
+         let msgs_json = List.map (fun (m : Types.message) ->
+           `Assoc [
+             ("from", `String m.from_agent);
+             ("content", `String m.content);
+             ("timestamp", `String m.timestamp);
+             ("seq", `Int m.seq);
+           ]
+         ) (List.filteri (fun idx _ -> idx < 20) msgs) in
+         let json = `Assoc [
+           ("status", status_json);
+           ("tasks", `Assoc [("tasks", `List tasks_json); ("total", `Int (List.length tasks_json))]);
+           ("agents", `Assoc [("agents", `List agents_json); ("total", `Int (List.length agents_json))]);
+           ("messages", `Assoc [("messages", `List msgs_json); ("total", `Int (List.length msgs_json))]);
+         ] in
+         Http.Response.json ~compress:true ~request:req (Yojson.Safe.to_string json) reqd
        ) request reqd)
 
   |> Http.Router.get "/api/v1/board" (fun request reqd ->
@@ -1803,7 +1860,20 @@ let run_server ~sw ~env ~port ~base_path =
          Dashboard
          ───────────────────────────────────────────────────────────────────── *)
       | `GET, "/dashboard" ->
-          h2_respond_html h2_reqd (Masc_mcp.Web_dashboard.html ()) ~extra_headers:cors
+          let etag_value = "\"" ^ Masc_mcp.Web_dashboard.etag () ^ "\"" in
+          let if_none_match = H2.Headers.get h2_headers "if-none-match" in
+          (match if_none_match with
+           | Some inm when String.equal inm etag_value ->
+               let resp_headers = H2.Headers.of_list ([
+                 ("etag", etag_value); ("cache-control", "no-cache");
+               ] @ cors) in
+               let response = H2.Response.create ~headers:resp_headers `Not_modified in
+               let writer = H2.Reqd.respond_with_streaming ~flush_headers_immediately:true h2_reqd response in
+               H2.Body.Writer.close writer
+           | _ ->
+               let body = Masc_mcp.Web_dashboard.html () in
+               let extra = [("etag", etag_value); ("cache-control", "no-cache"); ("vary", "Accept-Encoding")] @ cors in
+               h2_respond_html h2_reqd body ~extra_headers:extra)
 
       | `GET, "/dashboard/credits" ->
           h2_respond_html h2_reqd (Masc_mcp.Credits_dashboard.html ()) ~extra_headers:cors
@@ -1834,6 +1904,58 @@ let run_server ~sw ~env ~port ~base_path =
       (* ─────────────────────────────────────────────────────────────────────
          REST API
          ───────────────────────────────────────────────────────────────────── *)
+      | `GET, "/api/v1/dashboard" ->
+          let state = match !server_state with Some s -> s | None -> failwith "Not initialized" in
+          let config = state.Mcp_server.room_config in
+          let room_state = Masc_mcp.Room.read_state config in
+          let tempo = Masc_mcp.Tempo.get_tempo config in
+          let tasks = Masc_mcp.Room.get_tasks_raw config in
+          let agents = Masc_mcp.Room.get_agents_raw config in
+          let msgs = Masc_mcp.Room.get_messages_raw config ~since_seq:0 ~limit:20 in
+          let status_json = `Assoc [
+            ("cluster", `String (Option.value ~default:"unknown" (Sys.getenv_opt "MASC_CLUSTER_NAME")));
+            ("project", `String room_state.project);
+            ("tempo_interval_s", `Float tempo.current_interval_s);
+            ("paused", `Bool room_state.paused);
+          ] in
+          let tasks_json = List.map (fun (t : Masc_mcp.Types.task) ->
+            `Assoc [
+              ("id", `String t.id);
+              ("title", `String t.title);
+              ("status", `String (Masc_mcp.Types.string_of_task_status t.task_status));
+              ("priority", `Int t.priority);
+              ("assignee", match t.task_status with
+                | Claimed { assignee; _ } | InProgress { assignee; _ } | Done { assignee; _ } -> `String assignee
+                | _ -> `Null);
+            ]
+          ) (List.filter (fun (t : Masc_mcp.Types.task) ->
+               match t.task_status with
+               | Masc_mcp.Types.Done _ | Masc_mcp.Types.Cancelled _ -> false
+               | _ -> true
+             ) tasks) in
+          let agents_json = List.map (fun (a : Masc_mcp.Types.agent) ->
+            `Assoc [
+              ("name", `String a.name);
+              ("status", `String (Masc_mcp.Types.string_of_agent_status a.status));
+              ("current_task", match a.current_task with Some t -> `String t | None -> `Null);
+            ]
+          ) agents in
+          let msgs_json = List.map (fun (m : Masc_mcp.Types.message) ->
+            `Assoc [
+              ("from", `String m.from_agent);
+              ("content", `String m.content);
+              ("timestamp", `String m.timestamp);
+              ("seq", `Int m.seq);
+            ]
+          ) (List.filteri (fun idx _ -> idx < 20) msgs) in
+          let json = `Assoc [
+            ("status", status_json);
+            ("tasks", `Assoc [("tasks", `List tasks_json); ("total", `Int (List.length tasks_json))]);
+            ("agents", `Assoc [("agents", `List agents_json); ("total", `Int (List.length agents_json))]);
+            ("messages", `Assoc [("messages", `List msgs_json); ("total", `Int (List.length msgs_json))]);
+          ] in
+          h2_respond_json h2_reqd (Yojson.Safe.to_string json) ~extra_headers:cors
+
       | `GET, "/api/v1/status" ->
           let state = match !server_state with Some s -> s | None -> failwith "Not initialized" in
           let config = state.Mcp_server.room_config in
@@ -2034,6 +2156,10 @@ let run_cmd port base_path =
 
       (* Run all shutdown hooks (cancel orchestrator, close SSE, etc.) *)
       Masc_mcp.Shutdown_hooks.run_all ();
+
+      (* Flush dirty board data to prevent data loss *)
+      (try Board.flush_dirty (Board.global ())
+       with _ -> Printf.eprintf "[Shutdown] Board flush skipped (not initialized)\n%!");
 
       (* Also close local SSE connections tracked in main_eio *)
       close_all_sse_connections ();

--- a/config/lodge.env
+++ b/config/lodge.env
@@ -17,3 +17,6 @@ MASC_LODGE_QUIET_END=7
 
 # Min gap between same agent check-ins (seconds)
 # MASC_LODGE_MIN_CHECKIN_GAP=1800
+
+# Admin token for agent creation via dashboard
+MASC_ADMIN_TOKEN=XL-ZtjQRaZGEMiYGaGkxjlbOwHj_94Hr

--- a/lib/board.ml
+++ b/lib/board.ml
@@ -168,7 +168,16 @@ type store = {
   post_count: int ref;
   mutable last_sweep: float;
   mutex: Eio.Mutex.t;
+  (* Phase 2 caches *)
+  mutable karma_cache: (string * int) list option;       (** None = stale *)
+  mutable sorted_posts_cache: post list option;           (** None = stale *)
+  comments_by_post: (string, string list) Hashtbl.t;      (** post_id -> comment_id list *)
+  mutable dirty_posts: bool;                               (** Deferred flush flag *)
+  mutable dirty_comments: bool;                            (** Deferred flush flag *)
+  mutable last_flush: float;                               (** Last deferred flush time *)
 }
+
+let flush_interval_sec = 30.0
 
 let create_store () = {
   posts = Hashtbl.create 1024;
@@ -177,7 +186,22 @@ let create_store () = {
   post_count = ref 0;
   last_sweep = Time_compat.now ();
   mutex = Eio.Mutex.create ();
+  karma_cache = None;
+  sorted_posts_cache = None;
+  comments_by_post = Hashtbl.create 1024;
+  dirty_posts = false;
+  dirty_comments = false;
+  last_flush = Time_compat.now ();
 }
+
+(** Invalidate caches that depend on post data *)
+let invalidate_post_caches store =
+  store.karma_cache <- None;
+  store.sorted_posts_cache <- None
+
+(** Invalidate caches that depend on comment data *)
+let invalidate_comment_caches store =
+  store.karma_cache <- None
 
 (** {1 Eio-style Locking with Switch.on_release} *)
 
@@ -202,6 +226,7 @@ let sweep store =
     ) store.posts [] in
     List.iter (fun id ->
       Hashtbl.remove store.posts id;
+      Hashtbl.remove store.comments_by_post id;
       decr store.post_count
     ) expired_posts;
 
@@ -212,17 +237,45 @@ let sweep store =
         id :: acc
       end else acc
     ) store.comments [] in
-    List.iter (Hashtbl.remove store.comments) expired_comments;
+    List.iter (fun cid ->
+      (match Hashtbl.find_opt store.comments cid with
+       | Some c ->
+           let post_key = Post_id.to_string c.post_id in
+           (match Hashtbl.find_opt store.comments_by_post post_key with
+            | Some ids ->
+                let filtered = List.filter (fun id -> not (String.equal id cid)) ids in
+                if filtered = [] then Hashtbl.remove store.comments_by_post post_key
+                else Hashtbl.replace store.comments_by_post post_key filtered
+            | None -> ())
+       | None -> ());
+      Hashtbl.remove store.comments cid
+    ) expired_comments;
+
+    (* Invalidate caches if anything was swept *)
+    if !removed_posts > 0 then invalidate_post_caches store;
+    if !removed_comments > 0 then invalidate_comment_caches store;
 
     store.last_sweep <- now;
     (!removed_posts, !removed_comments)
   )
 
-(** Auto-sweep if needed *)
+(** Auto-sweep if needed, also handles deferred flush *)
 let maybe_sweep store =
   let now = Time_compat.now () in
   if now -. store.last_sweep > float_of_int Limits.sweeper_interval_sec then
-    ignore (sweep store)
+    ignore (sweep store);
+  (* Deferred flush: batch-write dirty data *)
+  if now -. store.last_flush > flush_interval_sec then begin
+    if store.dirty_posts then begin
+      rewrite_posts store;
+      store.dirty_posts <- false
+    end;
+    if store.dirty_comments then begin
+      rewrite_comments store;
+      store.dirty_comments <- false
+    end;
+    store.last_flush <- now
+  end
 
 (** {1 Persistence Paths} *)
 
@@ -371,6 +424,7 @@ let create_post store ~author ~content ?(visibility=Internal) ?(ttl_hours=Limits
       } in
       Hashtbl.add store.posts (Post_id.to_string post.id) post;
       incr store.post_count;
+      invalidate_post_caches store;
       (* Persist post - inline to avoid forward reference *)
       (try
         let base = match Sys.getenv_opt "ME_ROOT" with Some p -> p | None -> Sys.getcwd () in
@@ -413,10 +467,25 @@ let get_post store ~post_id : (post, board_error) result =
 let list_posts store ?(visibility_filter=None) ?hearth ?(limit=50) () : post list =
   maybe_sweep store;
   with_lock store (fun () ->
-    let all = Hashtbl.fold (fun _ (post : post) acc -> post :: acc) store.posts [] in
+    (* Use cached sorted list if available (cache hit = skip sort) *)
+    let sorted_all = match store.sorted_posts_cache with
+      | Some cached -> cached
+      | None ->
+          let all = Hashtbl.fold (fun _ (post : post) acc -> post :: acc) store.posts [] in
+          let sorted = List.sort (fun (a : post) (b : post) ->
+            let score_a = a.votes_up - a.votes_down in
+            let score_b = b.votes_up - b.votes_down in
+            let cmp = compare score_b score_a in
+            if cmp <> 0 then cmp
+            else compare b.created_at a.created_at
+          ) all in
+          store.sorted_posts_cache <- Some sorted;
+          sorted
+    in
+    (* Apply filters on the pre-sorted list *)
     let filtered = match visibility_filter with
-      | None -> all
-      | Some v -> List.filter (fun (p : post) -> p.visibility = v) all
+      | None -> sorted_all
+      | Some v -> List.filter (fun (p : post) -> p.visibility = v) sorted_all
     in
     let filtered = match hearth with
       | None -> filtered
@@ -424,20 +493,12 @@ let list_posts store ?(visibility_filter=None) ?hearth ?(limit=50) () : post lis
           let h_norm = String.lowercase_ascii (String.trim h) in
           List.filter (fun (p : post) -> p.hearth = Some h_norm) filtered
     in
-    (* Sort by score desc, then created_at desc *)
-    let sorted = List.sort (fun (a : post) (b : post) ->
-      let score_a = a.votes_up - a.votes_down in
-      let score_b = b.votes_up - b.votes_down in
-      let cmp = compare score_b score_a in
-      if cmp <> 0 then cmp
-      else compare b.created_at a.created_at
-    ) filtered in
     (* Take first N *)
     let rec take n lst = match n, lst with
       | 0, _ | _, [] -> []
       | n, x :: xs -> x :: take (n-1) xs
     in
-    take (min limit 100) sorted  (* Hard cap at 100 *)
+    take (min limit 100) filtered  (* Hard cap at 100 *)
   )
 
 (** {1 Comment Operations} *)
@@ -477,10 +538,12 @@ let add_comment store ~post_id ~author ~content ?parent_id ?(ttl_hours=Limits.de
     match Hashtbl.find_opt store.posts (Post_id.to_string pid) with
     | None -> Error (Post_not_found post_id)
     | Some post ->
-        (* Check comment count *)
-        let post_comment_count = Hashtbl.fold (fun _ (c : comment) acc ->
-          if Post_id.to_string c.post_id = Post_id.to_string pid then acc + 1 else acc
-        ) store.comments 0 in
+        (* Check comment count using index *)
+        let post_key = Post_id.to_string pid in
+        let post_comment_count =
+          try List.length (Hashtbl.find store.comments_by_post post_key)
+          with Not_found -> 0
+        in
         if post_comment_count >= Limits.max_comments_per_post then
           Error (Capacity_exceeded { current = post_comment_count; max = Limits.max_comments_per_post })
         else begin
@@ -498,9 +561,15 @@ let add_comment store ~post_id ~author ~content ?parent_id ?(ttl_hours=Limits.de
             votes_down = 0;
           } in
           Hashtbl.add store.comments (Comment_id.to_string comment.id) comment;
+          (* Update comments_by_post index *)
+          let post_key = Post_id.to_string pid in
+          let existing = try Hashtbl.find store.comments_by_post post_key with Not_found -> [] in
+          Hashtbl.replace store.comments_by_post post_key (Comment_id.to_string comment.id :: existing);
           (* Update post reply count and updated_at *)
-          Hashtbl.replace store.posts (Post_id.to_string pid)
+          Hashtbl.replace store.posts post_key
             { post with reply_count = post.reply_count + 1; updated_at = now };
+          invalidate_post_caches store;
+          invalidate_comment_caches store;
           (* Persist comment - inline *)
           (try
             let base = match Sys.getenv_opt "ME_ROOT" with Some pp -> pp | None -> Sys.getcwd () in
@@ -533,10 +602,11 @@ let get_comments store ~post_id : (comment list, board_error) result =
   | Error e -> Error e
   | Ok pid ->
       with_lock store (fun () ->
-        let comments = Hashtbl.fold (fun _ (c : comment) acc ->
-          if Post_id.to_string c.post_id = Post_id.to_string pid then c :: acc
-          else acc
-        ) store.comments [] in
+        let post_key = Post_id.to_string pid in
+        let comment_ids = try Hashtbl.find store.comments_by_post post_key with Not_found -> [] in
+        let comments = List.filter_map (fun cid ->
+          Hashtbl.find_opt store.comments cid
+        ) comment_ids in
         Ok (List.sort (fun (a : comment) (b : comment) -> compare a.created_at b.created_at) comments)
       )
 
@@ -593,7 +663,6 @@ let vote store ~voter ~post_id ~direction : (int, board_error) result =
                 Error (Already_voted (Printf.sprintf "%s already voted %s on %s"
                   voter (vote_direction_to_string direction) post_id))
             | Some _opposite ->
-                (* Flip: undo previous vote, apply new one *)
                 let flipped = match direction with
                   | Up -> { post with votes_up = post.votes_up + 1;
                                       votes_down = max 0 (post.votes_down - 1);
@@ -604,7 +673,8 @@ let vote store ~voter ~post_id ~direction : (int, board_error) result =
                 in
                 Hashtbl.replace store.posts (Post_id.to_string pid) flipped;
                 Hashtbl.replace store.vote_log vote_key direction;
-                rewrite_posts store;
+                store.dirty_posts <- true;  (* Deferred flush *)
+                invalidate_post_caches store;
                 append_vote_log ~target:vote_key ~voter ~direction;
                 Ok (flipped.votes_up - flipped.votes_down)
             | None ->
@@ -614,7 +684,8 @@ let vote store ~voter ~post_id ~direction : (int, board_error) result =
                 in
                 Hashtbl.replace store.posts (Post_id.to_string pid) updated;
                 Hashtbl.replace store.vote_log vote_key direction;
-                rewrite_posts store;
+                store.dirty_posts <- true;  (* Deferred flush *)
+                invalidate_post_caches store;
                 append_vote_log ~target:vote_key ~voter ~direction;
                 Ok (updated.votes_up - updated.votes_down)
       )
@@ -645,7 +716,8 @@ let vote_comment store ~voter ~comment_id ~direction : (int, board_error) result
                 in
                 Hashtbl.replace store.comments (Comment_id.to_string cid) flipped;
                 Hashtbl.replace store.vote_log vote_key direction;
-                rewrite_comments store;
+                store.dirty_comments <- true;  (* Deferred flush *)
+                invalidate_comment_caches store;
                 append_vote_log ~target:vote_key ~voter ~direction;
                 Ok (flipped.votes_up - flipped.votes_down)
             | None ->
@@ -655,7 +727,8 @@ let vote_comment store ~voter ~comment_id ~direction : (int, board_error) result
                 in
                 Hashtbl.replace store.comments (Comment_id.to_string cid) updated;
                 Hashtbl.replace store.vote_log vote_key direction;
-                rewrite_comments store;
+                store.dirty_comments <- true;  (* Deferred flush *)
+                invalidate_comment_caches store;
                 append_vote_log ~target:vote_key ~voter ~direction;
                 Ok (updated.votes_up - updated.votes_down)
       )
@@ -768,7 +841,12 @@ let load_persisted_comments store =
             if String.length line > 0 then
               match Yojson.Safe.from_string line |> comment_of_yojson with
               | Some c when c.expires_at > now ->
-                  Hashtbl.replace store.comments (Comment_id.to_string c.id) c;
+                  let cid = Comment_id.to_string c.id in
+                  Hashtbl.replace store.comments cid c;
+                  (* Build comments_by_post index *)
+                  let post_key = Post_id.to_string c.post_id in
+                  let existing = try Hashtbl.find store.comments_by_post post_key with Not_found -> [] in
+                  Hashtbl.replace store.comments_by_post post_key (cid :: existing);
                   incr loaded
               | _ -> ()
           done
@@ -866,6 +944,19 @@ let global_store = lazy (
 
 let global () = Lazy.force global_store
 
+(** Flush any dirty state to disk. Call on shutdown to prevent data loss. *)
+let flush_dirty store =
+  with_lock store (fun () ->
+    if store.dirty_posts then begin
+      rewrite_posts store;
+      store.dirty_posts <- false
+    end;
+    if store.dirty_comments then begin
+      rewrite_comments store;
+      store.dirty_comments <- false
+    end
+  )
+
 (** {1 Karma & Flair - Reddit-style} *)
 
 (** Calculate karma (total upvotes) for an agent *)
@@ -885,20 +976,25 @@ let get_agent_karma store ~agent_name =
   in
   post_karma + comment_karma
 
-(** Get karma for all agents *)
+(** Get karma for all agents (cached) *)
 let get_all_karma store =
-  let karma_map = Hashtbl.create 64 in
-  Hashtbl.iter (fun _ (p : post) ->
-    let author = Agent_id.to_string p.author in
-    let current = try Hashtbl.find karma_map author with Not_found -> 0 in
-    Hashtbl.replace karma_map author (current + p.votes_up)
-  ) store.posts;
-  Hashtbl.iter (fun _ (c : comment) ->
-    let author = Agent_id.to_string c.author in
-    let current = try Hashtbl.find karma_map author with Not_found -> 0 in
-    Hashtbl.replace karma_map author (current + c.votes_up)
-  ) store.comments;
-  Hashtbl.fold (fun k v acc -> (k, v) :: acc) karma_map []
+  match store.karma_cache with
+  | Some cached -> cached
+  | None ->
+      let karma_map = Hashtbl.create 64 in
+      Hashtbl.iter (fun _ (p : post) ->
+        let author = Agent_id.to_string p.author in
+        let current = try Hashtbl.find karma_map author with Not_found -> 0 in
+        Hashtbl.replace karma_map author (current + p.votes_up)
+      ) store.posts;
+      Hashtbl.iter (fun _ (c : comment) ->
+        let author = Agent_id.to_string c.author in
+        let current = try Hashtbl.find karma_map author with Not_found -> 0 in
+        Hashtbl.replace karma_map author (current + c.votes_up)
+      ) store.comments;
+      let result = Hashtbl.fold (fun k v acc -> (k, v) :: acc) karma_map [] in
+      store.karma_cache <- Some result;
+      result
 
 (** Available flairs *)
 let available_flairs = [

--- a/lib/board.ml
+++ b/lib/board.ml
@@ -304,7 +304,11 @@ let rotate_if_needed path =
       Sys.rename path backup;
       Printf.eprintf "[Board] Rotated %s (was %d bytes)\n%!" path st.Unix.st_size
     end
-  with Unix.Unix_error _ | Sys_error _ -> ()
+  with
+  | Unix.Unix_error (e, fn, arg) ->
+      Printf.eprintf "[Board] rotate error: %s(%s): %s\n%!" fn arg (Unix.error_message e)
+  | Sys_error msg ->
+      Printf.eprintf "[Board] rotate error: %s\n%!" msg
 
 (** {1 JSON Serialization} *)
 
@@ -321,6 +325,7 @@ let post_to_yojson (p : post) : Yojson.Safe.t =
     ("content", `String p.content);
     ("visibility", `String (visibility_to_string p.visibility));
     ("created_at", `Float p.created_at);
+    ("updated_at", `Float p.updated_at);
     ("expires_at", `Float p.expires_at);
     ("votes_up", `Int p.votes_up);
     ("votes_down", `Int p.votes_down);
@@ -356,7 +361,7 @@ let rewrite_posts store =
         output_string oc (Yojson.Safe.to_string (post_to_yojson pst) ^ "\n")
       ) store.posts);
     Sys.rename tmp_path path
-  with Sys_error _ -> ()
+  with Sys_error msg -> Printf.eprintf "[Board] persist error (rewrite_posts): %s\n%!" msg
 
 let rewrite_comments store =
   try
@@ -369,7 +374,29 @@ let rewrite_comments store =
         output_string oc (Yojson.Safe.to_string (comment_to_yojson cmt) ^ "\n")
       ) store.comments);
     Sys.rename tmp_path path
-  with Sys_error _ -> ()
+  with Sys_error msg -> Printf.eprintf "[Board] persist error (rewrite_comments): %s\n%!" msg
+
+(** {1 Append Helpers} *)
+
+let append_post (p : post) =
+  try
+    ensure_masc_dir ();
+    let path = persist_path () in
+    let oc = open_out_gen [Open_append; Open_creat] 0o644 path in
+    Fun.protect ~finally:(fun () -> close_out_noerr oc) (fun () ->
+      output_string oc (Yojson.Safe.to_string (post_to_yojson p) ^ "\n"));
+    rotate_if_needed path
+  with Sys_error msg -> Printf.eprintf "[Board] persist error (append_post): %s\n%!" msg
+
+let append_comment (c : comment) =
+  try
+    ensure_masc_dir ();
+    let path = comments_path () in
+    let oc = open_out_gen [Open_append; Open_creat] 0o644 path in
+    Fun.protect ~finally:(fun () -> close_out_noerr oc) (fun () ->
+      output_string oc (Yojson.Safe.to_string (comment_to_yojson c) ^ "\n"));
+    rotate_if_needed path
+  with Sys_error msg -> Printf.eprintf "[Board] persist error (append_comment): %s\n%!" msg
 
 (** {1 Post Operations} *)
 
@@ -419,30 +446,7 @@ let create_post store ~author ~content ?(visibility=Internal) ?(ttl_hours=Limits
       Hashtbl.add store.posts (Post_id.to_string post.id) post;
       incr store.post_count;
       invalidate_post_caches store;
-      (* Persist post - inline to avoid forward reference *)
-      (try
-        let base = match Sys.getenv_opt "ME_ROOT" with Some p -> p | None -> Sys.getcwd () in
-        let path = Filename.concat base ".masc/board_posts.jsonl" in
-        let dir = Filename.dirname path in
-        if not (Sys.file_exists dir) then Unix.mkdir dir 0o755;
-        let oc = open_out_gen [Open_append; Open_creat] 0o644 path in
-        Fun.protect ~finally:(fun () -> close_out_noerr oc) (fun () ->
-          let json = `Assoc ([
-            ("id", `String (Post_id.to_string post.id));
-            ("author", `String (Agent_id.to_string post.author));
-            ("content", `String post.content);
-            ("visibility", `String (match post.visibility with Public->"public"|Unlisted->"unlisted"|Internal->"internal"|Direct->"direct"));
-            ("created_at", `Float post.created_at);
-            ("updated_at", `Float post.updated_at);
-            ("expires_at", `Float post.expires_at);
-            ("votes_up", `Int post.votes_up);
-            ("votes_down", `Int post.votes_down);
-            ("reply_count", `Int post.reply_count);
-          ] @ (match post.hearth with Some h -> [("hearth", `String h)] | None -> [])
-            @ (match post.thread_id with Some t -> [("thread_id", `String t)] | None -> [])) in
-          output_string oc (Yojson.Safe.to_string json ^ "\n"));
-        rotate_if_needed path
-      with Sys_error _ -> ());
+      append_post post;
       Ok post
     end
   )
@@ -564,28 +568,7 @@ let add_comment store ~post_id ~author ~content ?parent_id ?(ttl_hours=Limits.de
             { post with reply_count = post.reply_count + 1; updated_at = now };
           invalidate_post_caches store;
           invalidate_comment_caches store;
-          (* Persist comment - inline *)
-          (try
-            let base = match Sys.getenv_opt "ME_ROOT" with Some pp -> pp | None -> Sys.getcwd () in
-            let cpath = Filename.concat base ".masc/board_comments.jsonl" in
-            let cdir = Filename.dirname cpath in
-            if not (Sys.file_exists cdir) then Unix.mkdir cdir 0o755;
-            let oc = open_out_gen [Open_append; Open_creat] 0o644 cpath in
-            Fun.protect ~finally:(fun () -> close_out_noerr oc) (fun () ->
-              let json = `Assoc [
-                ("id", `String (Comment_id.to_string comment.id));
-                ("post_id", `String (Post_id.to_string comment.post_id));
-                ("parent_id", match comment.parent_id with Some cp -> `String (Comment_id.to_string cp) | None -> `Null);
-                ("author", `String (Agent_id.to_string comment.author));
-                ("content", `String comment.content);
-                ("created_at", `Float comment.created_at);
-                ("expires_at", `Float comment.expires_at);
-                ("votes_up", `Int comment.votes_up);
-                ("votes_down", `Int comment.votes_down);
-              ] in
-              output_string oc (Yojson.Safe.to_string json ^ "\n"));
-            rotate_if_needed cpath
-          with Sys_error _ -> ());
+          append_comment comment;
           Ok comment
         end
   )
@@ -637,7 +620,7 @@ let append_vote_log ~target ~voter ~direction =
       ] in
       output_string oc (Yojson.Safe.to_string json ^ "\n"));
     rotate_if_needed path
-  with Sys_error _ -> ()
+  with Sys_error msg -> Printf.eprintf "[Board] persist error (append_vote_log): %s\n%!" msg
 
 let vote store ~voter ~post_id ~direction : (int, board_error) result =
   match Agent_id.of_string voter with
@@ -948,21 +931,12 @@ let flush_dirty store =
     if store.dirty_comments then begin
       rewrite_comments store;
       store.dirty_comments <- false
-    end
+    end;
+    store.last_flush <- Time_compat.now ()
   )
 
 (** Register deferred flush now that rewrite helpers are available *)
-let () = deferred_flush_fn := (fun store ->
-  if store.dirty_posts then begin
-    rewrite_posts store;
-    store.dirty_posts <- false
-  end;
-  if store.dirty_comments then begin
-    rewrite_comments store;
-    store.dirty_comments <- false
-  end;
-  store.last_flush <- Time_compat.now ()
-)
+let () = deferred_flush_fn := flush_dirty
 
 (** {1 Karma & Flair - Reddit-style} *)
 

--- a/lib/board.ml
+++ b/lib/board.ml
@@ -259,23 +259,17 @@ let sweep store =
     (!removed_posts, !removed_comments)
   )
 
-(** Auto-sweep if needed, also handles deferred flush *)
+(** Deferred flush callback — set after rewrite helpers are defined.
+    Avoids forward-reference issue (maybe_sweep is defined before rewrite_posts). *)
+let deferred_flush_fn : (store -> unit) ref = ref (fun _ -> ())
+
+(** Auto-sweep if needed, also triggers deferred flush via callback *)
 let maybe_sweep store =
   let now = Time_compat.now () in
   if now -. store.last_sweep > float_of_int Limits.sweeper_interval_sec then
     ignore (sweep store);
-  (* Deferred flush: batch-write dirty data *)
-  if now -. store.last_flush > flush_interval_sec then begin
-    if store.dirty_posts then begin
-      rewrite_posts store;
-      store.dirty_posts <- false
-    end;
-    if store.dirty_comments then begin
-      rewrite_comments store;
-      store.dirty_comments <- false
-    end;
-    store.last_flush <- now
-  end
+  if now -. store.last_flush > flush_interval_sec then
+    !deferred_flush_fn store
 
 (** {1 Persistence Paths} *)
 
@@ -956,6 +950,19 @@ let flush_dirty store =
       store.dirty_comments <- false
     end
   )
+
+(** Register deferred flush now that rewrite helpers are available *)
+let () = deferred_flush_fn := (fun store ->
+  if store.dirty_posts then begin
+    rewrite_posts store;
+    store.dirty_posts <- false
+  end;
+  if store.dirty_comments then begin
+    rewrite_comments store;
+    store.dirty_comments <- false
+  end;
+  store.last_flush <- Time_compat.now ()
+)
 
 (** {1 Karma & Flair - Reddit-style} *)
 

--- a/lib/http_server_eio.ml
+++ b/lib/http_server_eio.ml
@@ -159,6 +159,46 @@ module Response = struct
     let response = Httpun.Response.create ~headers status in
     Httpun.Reqd.respond_with_string reqd response body
 
+  (** HTML response with ETag and conditional 304 support.
+      For static HTML that only changes on rebuild (e.g. dashboard).
+      Uses zstd compression when client accepts it.
+      @param etag ETag value (typically version hash)
+      @param request Request to check If-None-Match and Accept-Encoding *)
+  let html_cached ?(status = `OK) ~etag ~request body reqd =
+    let etag_value = "\"" ^ etag ^ "\"" in
+    (* Check If-None-Match for 304 *)
+    let if_none_match = Httpun.Headers.get request.Httpun.Request.headers "if-none-match" in
+    match if_none_match with
+    | Some inm when String.equal inm etag_value ->
+        let headers = Httpun.Headers.of_list [
+          ("etag", etag_value);
+          ("cache-control", "no-cache");
+        ] in
+        let response = Httpun.Response.create ~headers `Not_modified in
+        Httpun.Reqd.respond_with_string reqd response ""
+    | _ ->
+        (* Serve full response, with compression if possible *)
+        let accepts_zstd = Compression.accepts_zstd request in
+        let final_body, encoding =
+          if accepts_zstd then
+            let (compressed, did_compress) = Compression.compress_zstd ~level:3 body in
+            if did_compress then (compressed, Some "zstd") else (body, None)
+          else (body, None)
+        in
+        let base_headers = [
+          ("content-type", "text/html; charset=utf-8");
+          ("content-length", string_of_int (String.length final_body));
+          ("etag", etag_value);
+          ("cache-control", "no-cache");
+          ("vary", "Accept-Encoding");
+        ] in
+        let headers = match encoding with
+          | Some enc -> ("content-encoding", enc) :: base_headers
+          | None -> base_headers
+        in
+        let response = Httpun.Response.create ~headers:(Httpun.Headers.of_list headers) status in
+        Httpun.Reqd.respond_with_string reqd response final_body
+
   let not_found reqd =
     text ~status:`Not_found "404 Not Found" reqd
 

--- a/lib/lodge_heartbeat.ml
+++ b/lib/lodge_heartbeat.ml
@@ -1476,7 +1476,8 @@ let generate_agent_content ~agent_name ~context:_ ~action_type =
     let len = String.length r in
     len > 10 &&
     not (len >= 14 && String.sub r 0 14 = "Empty response") &&
-    not (len >= 5 && String.lowercase_ascii (String.sub r 0 5) = "error")
+    not (len >= 5 && String.lowercase_ascii (String.sub r 0 5) = "error") &&
+    not (len >= 9 && String.sub r 0 9 = "{\"error\":")
   in
   if is_valid_response response then begin
     add_to_context ~name:agent_name ~role:Assistant ~content:response;
@@ -1908,7 +1909,8 @@ ACTION: SKIP
     let len = String.length s in
     len > 10 &&
     not (len >= 5 && String.lowercase_ascii (String.sub s 0 5) = "error") &&
-    not (len >= 14 && String.sub s 0 14 = "Empty response")
+    not (len >= 14 && String.sub s 0 14 = "Empty response") &&
+    not (len >= 9 && String.sub s 0 9 = "{\"error\":")
   in
 
   let cascade_call_llm ~tool_name ~extra_args ~prompt:p ~timeout_sec ~max_chars =
@@ -2089,7 +2091,8 @@ let make_call_llm ~agent_name : (prompt:string -> string) =
       let len = String.length s in
       len > 10 &&
       not (len >= 5 && String.lowercase_ascii (String.sub s 0 5) = "error") &&
-      not (len >= 14 && String.sub s 0 14 = "Empty response")
+      not (len >= 14 && String.sub s 0 14 = "Empty response") &&
+      not (len >= 9 && String.sub s 0 9 = "{\"error\":")
     in
     let cascade_call_llm ~tool_name ~extra_args ~prompt:p ~timeout_sec ~max_chars =
       let model = List.assoc_opt "model" extra_args

--- a/lib/room.ml
+++ b/lib/room.ml
@@ -148,13 +148,10 @@ let get_tty () =
     match Sys.getenv_opt "TTY" with
     | Some tty -> Some tty
     | None ->
-        (* Try to read from /dev/tty symlink - non-blocking *)
-        Eio_unix.run_in_systhread (fun () ->
-          let ic = Unix.open_process_in "tty 2>/dev/null" in
-          Fun.protect ~finally:(fun () -> ignore (Unix.close_process_in ic)) (fun () ->
-            try Some (input_line ic) with End_of_file -> None
-          )
-        )
+        (* Try to read from tty command — Eio-native *)
+        let output = Process_eio.run ~timeout_sec:5.0 "tty 2>/dev/null" in
+        let trimmed = String.trim output in
+        if String.length trimmed > 0 then Some trimmed else None
   with e ->
     Printf.eprintf "[WARN] get_tty failed: %s\n%!" (Printexc.to_string e);
     None

--- a/lib/web_dashboard.ml
+++ b/lib/web_dashboard.ml
@@ -14,8 +14,15 @@
     @since 2026-01
 *)
 
-(** Generate the dashboard HTML page *)
-let html () = {|<!DOCTYPE html>
+(** ETag for dashboard HTML - based on build version.
+    Changes only when server is rebuilt, enabling 304 responses. *)
+let etag () =
+  let v = Version.version in
+  let hash = Digest.string v |> Digest.to_hex in
+  String.sub hash 0 12
+
+(** Cached dashboard HTML - computed once per process lifetime *)
+let cached_html = lazy ({|<!DOCTYPE html>
 <html lang="en">
 <head>
   <meta charset="UTF-8">
@@ -825,24 +832,37 @@ let html () = {|<!DOCTYPE html>
       return res.json();
     }
 
-    // Fetch initial data via REST API
+    // Batch dashboard fetch - single request replaces 4 separate calls
+    let _dashboardCache = null;
+    let _dashboardCacheTime = 0;
+    const DASHBOARD_CACHE_TTL = 5000; // 5s TTL for tab switching
+
     async function fetchData() {
       try {
-        const [status, tasks, agents, msgs] = await Promise.all([
-          apiCall('status'),
-          apiCall('tasks'),
-          apiCall('agents'),
-          apiCall('messages')
-        ]);
+        const now = Date.now();
+        let data;
+        if (_dashboardCache && (now - _dashboardCacheTime) < DASHBOARD_CACHE_TTL) {
+          data = _dashboardCache;
+        } else {
+          const res = await fetch('/api/v1/dashboard', { headers: authHeaders() });
+          data = await res.json();
+          _dashboardCache = data;
+          _dashboardCacheTime = now;
+        }
 
-        updateStats(agents, tasks, status);
-        updateAgents(agents);
-        updateTasks(tasks);
-        updateMessages(msgs);
-        updateTempo(status);
+        updateStats(data.agents, data.tasks, data.status);
+        updateAgents(data.agents);
+        updateTasks(data.tasks);
+        updateMessages(data.messages);
+        updateTempo(data.status);
       } catch (e) {
         console.error('Fetch error:', e);
       }
+    }
+
+    function invalidateDashboardCache() {
+      _dashboardCache = null;
+      _dashboardCacheTime = 0;
     }
 
     function updateStats(agents, tasks, status) {
@@ -1010,6 +1030,7 @@ let html () = {|<!DOCTYPE html>
     function handleEvent(event) {
       const type = event.type || event.event;
       if (type) {
+        invalidateDashboardCache();
         debouncedFetchData(); // Debounced to prevent CPU spike
         // Journal logging
         const agent = event.agent || event.from || event.from_agent || '';
@@ -1175,14 +1196,13 @@ let html () = {|<!DOCTYPE html>
     // === Server Health ===
     async function fetchServerHealth() {
       try {
-        const [health, board] = await Promise.all([
-          fetch('/health').then(r => r.json()),
-          fetch('/api/v1/board').then(r => r.json())
-        ]);
+        const health = await fetch('/health', { headers: authHeaders() }).then(r => r.json());
         document.getElementById('health-uptime').textContent = health.uptime || 'N/A';
         document.getElementById('health-sse').textContent = health.sse_clients || '0';
-        document.getElementById('health-posts').textContent = (board.posts || []).length;
+        document.getElementById('health-posts').textContent = health.board_posts || '0';
         document.getElementById('health-memory').textContent = health.memory || 'N/A';
+        const badge = document.getElementById('version-badge');
+        if (badge && health.version) badge.textContent = 'v' + health.version;
       } catch(e) { console.error('Health fetch error:', e); }
     }
 
@@ -1416,11 +1436,8 @@ let html () = {|<!DOCTYPE html>
       if (sortSelect) sortSelect.value = currentSort;
       const autoScrollCheck = document.getElementById('auto-scroll');
       if (autoScrollCheck) autoScrollCheck.checked = autoScrollEnabled;
-      // Fetch server version
-      fetch('/health').then(r => r.json()).then(d => {
-        const badge = document.getElementById('version-badge');
-        if (badge && d.version) badge.textContent = 'v' + d.version;
-      }).catch(() => {});
+      // Version badge set via fetchServerHealth (avoids duplicate /health call)
+      fetchServerHealth().then(() => {}).catch(() => {});
       fetchHearths();
     });
 
@@ -1480,7 +1497,7 @@ let html () = {|<!DOCTYPE html>
     function clearTagFilter() {
       currentTagFilter = null;
       updateTagFilterBar();
-      fetchBoard();
+      renderFromCache();
     }
 
     function updateTagFilterBar() {
@@ -1644,11 +1661,15 @@ let html () = {|<!DOCTYPE html>
     }
 
     // Initial load + polling fallback
+    // Initial load: fetchData uses batch /api/v1/dashboard endpoint
+    // fetchServerHealth is called from DOMContentLoaded (version badge)
     fetchData();
-    fetchServerHealth();
     connectSSE();
 
 
   </script>
 </body>
-</html>|}
+</html>|})
+
+(** Generate the dashboard HTML page (cached after first call) *)
+let html () = Lazy.force cached_html

--- a/lib/web_dashboard.mli
+++ b/lib/web_dashboard.mli
@@ -2,3 +2,6 @@
 
 (** Generate the dashboard HTML page *)
 val html : unit -> string
+
+(** ETag for cache validation *)
+val etag : unit -> string

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,0 +1,189 @@
+#!/bin/bash
+# MASC MCP — Deploy to Prod (:8945)
+# Builds, stops existing, copies binary to releases/, starts prod, verifies health.
+#
+# Usage: ./scripts/deploy.sh [--skip-build] [--restart-tunnel]
+#
+# Ports:
+#   Dev:  8935 (launchd, live development)
+#   Prod: 8945 (this script, Cloudflare tunnel target)
+#
+# Management modes:
+#   launchd: if com.jeong-sik.masc-mcp-prod is loaded, uses launchctl
+#   manual:  otherwise, uses nohup + PID file
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+RELEASE_DIR="$REPO_DIR/releases"
+PID_FILE="$REPO_DIR/masc-prod.pid"
+PROD_PORT=8945
+HEALTH_URL="http://127.0.0.1:$PROD_PORT/health"
+BASE_PATH="${MASC_BASE_PATH:-${ME_ROOT:-/Users/dancer/me}}"
+LOG_DIR="${ME_ROOT:-/Users/dancer/me}/logs"
+LAUNCHD_LABEL="com.jeong-sik.masc-mcp-prod"
+LAUNCHD_PLIST="$HOME/Library/LaunchAgents/${LAUNCHD_LABEL}.plist"
+
+SKIP_BUILD=false
+RESTART_TUNNEL=false
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --skip-build) SKIP_BUILD=true; shift ;;
+        --restart-tunnel) RESTART_TUNNEL=true; shift ;;
+        *) echo "Unknown option: $1" >&2; exit 1 ;;
+    esac
+done
+
+wait_port_free() {
+    for _ in $(seq 1 10); do
+        lsof -iTCP:"$PROD_PORT" -sTCP:LISTEN -t >/dev/null 2>&1 || return 0
+        sleep 0.5
+    done
+}
+
+# --- 1. Build ---
+if [ "$SKIP_BUILD" = false ]; then
+    echo "==> Building MASC MCP..." >&2
+    cd "$REPO_DIR"
+    dune build bin/main_eio.exe 2>&1
+    echo "    Build complete." >&2
+fi
+
+BUILD_EXE="$REPO_DIR/_build/default/bin/main_eio.exe"
+if [ ! -x "$BUILD_EXE" ]; then
+    echo "Error: Build artifact not found at $BUILD_EXE" >&2
+    exit 1
+fi
+
+# --- 2. Detect management mode ---
+USE_LAUNCHD=false
+if launchctl list "$LAUNCHD_LABEL" >/dev/null 2>&1; then
+    USE_LAUNCHD=true
+fi
+
+# --- 3. Stop existing prod (must stop before overwriting binary on macOS) ---
+mkdir -p "$RELEASE_DIR"
+RELEASE_EXE="$RELEASE_DIR/main_eio.exe"
+BACKUP_EXE="$RELEASE_DIR/main_eio.exe.prev"
+
+if [ "$USE_LAUNCHD" = true ]; then
+    echo "==> Stopping launchd service..." >&2
+    launchctl unload "$LAUNCHD_PLIST" 2>/dev/null || true
+    wait_port_free
+    echo "    Service stopped." >&2
+elif [ -f "$PID_FILE" ]; then
+    OLD_PID="$(cat "$PID_FILE")"
+    if kill -0 "$OLD_PID" 2>/dev/null; then
+        echo "==> Stopping previous prod (PID $OLD_PID)..." >&2
+        kill "$OLD_PID"
+        for _ in $(seq 1 10); do
+            kill -0 "$OLD_PID" 2>/dev/null || break
+            sleep 0.5
+        done
+        if kill -0 "$OLD_PID" 2>/dev/null; then
+            kill -9 "$OLD_PID" 2>/dev/null || true
+        fi
+    fi
+    rm -f "$PID_FILE"
+    wait_port_free
+fi
+
+# --- 4. Copy binary to releases/ ---
+# Note: dune produces read-only executables. Use install(1) which handles
+# permission replacement, or rm-before-cp to avoid "Permission denied".
+if [ -f "$RELEASE_EXE" ]; then
+    rm -f "$BACKUP_EXE"
+    mv "$RELEASE_EXE" "$BACKUP_EXE"
+    echo "    Previous binary backed up." >&2
+fi
+
+install -m 755 "$BUILD_EXE" "$RELEASE_EXE"
+echo "    Binary installed to releases/main_eio.exe" >&2
+
+# --- 5. Start prod ---
+if [ "$USE_LAUNCHD" = true ]; then
+    echo "==> Starting via launchd..." >&2
+    launchctl load "$LAUNCHD_PLIST"
+    echo "    Service loaded." >&2
+else
+    echo "==> Starting prod on :$PROD_PORT..." >&2
+
+    if [ -f "$HOME/.zshenv" ]; then
+        set -a; source "$HOME/.zshenv" 2>/dev/null || true; set +a
+    fi
+    LODGE_ENV="$REPO_DIR/config/lodge.env"
+    if [ -f "$LODGE_ENV" ]; then
+        set -a; source "$LODGE_ENV" 2>/dev/null || true; set +a
+    fi
+
+    mkdir -p "$LOG_DIR"
+
+    MASC_ORCHESTRATOR_ENABLED=0 \
+    MASC_AUTO_RESPOND=true \
+        nohup "$RELEASE_EXE" \
+            --port="$PROD_PORT" \
+            --base-path="$BASE_PATH" \
+        >> "$LOG_DIR/masc-prod.out.log" \
+        2>> "$LOG_DIR/masc-prod.err.log" &
+
+    PROD_PID=$!
+    echo "$PROD_PID" > "$PID_FILE"
+    echo "    Started with PID $PROD_PID" >&2
+fi
+
+# --- 6. Health check ---
+echo "==> Health check..." >&2
+HEALTH_OK=false
+for _ in $(seq 1 15); do
+    sleep 0.5
+    if curl -sf "$HEALTH_URL" >/dev/null 2>&1; then
+        HEALTH_OK=true
+        break
+    fi
+done
+
+if [ "$HEALTH_OK" = true ]; then
+    echo "    Prod healthy on :$PROD_PORT" >&2
+else
+    echo "Error: Prod failed health check on :$PROD_PORT" >&2
+    echo "    Logs: $LOG_DIR/masc-prod.err.log" >&2
+
+    # Rollback
+    if [ "$USE_LAUNCHD" = true ]; then
+        launchctl unload "$LAUNCHD_PLIST" 2>/dev/null || true
+    else
+        kill "${PROD_PID:-0}" 2>/dev/null || true
+        rm -f "$PID_FILE"
+    fi
+
+    if [ -f "$BACKUP_EXE" ]; then
+        echo "    Rolling back to previous binary..." >&2
+        mv "$BACKUP_EXE" "$RELEASE_EXE"
+        # Restart with previous binary
+        if [ "$USE_LAUNCHD" = true ]; then
+            launchctl load "$LAUNCHD_PLIST"
+        fi
+    fi
+    exit 1
+fi
+
+# --- 7. Restart Cloudflare tunnel (optional) ---
+if [ "$RESTART_TUNNEL" = true ]; then
+    echo "==> Restarting Cloudflare tunnel..." >&2
+    launchctl kickstart -k "gui/$(id -u)/com.jeongsik.masc-cloudflared" 2>/dev/null || true
+    echo "    Tunnel restarted." >&2
+fi
+
+# --- Done ---
+echo "" >&2
+echo "Deploy complete." >&2
+echo "  Prod: http://127.0.0.1:$PROD_PORT" >&2
+echo "  Tunnel: https://masc.crying.pictures" >&2
+if [ "$USE_LAUNCHD" = true ]; then
+    echo "  Managed by: launchd ($LAUNCHD_LABEL)" >&2
+else
+    echo "  PID: ${PROD_PID:-?} ($PID_FILE)" >&2
+fi
+echo "  Logs: $LOG_DIR/masc-prod.{out,err}.log" >&2

--- a/scripts/stop-prod.sh
+++ b/scripts/stop-prod.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+# MASC MCP — Stop Prod Instance
+# Stops the prod MASC running on :8945.
+# Handles both launchd and manual (PID file) management modes.
+#
+# Usage: ./scripts/stop-prod.sh [--force]
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+PID_FILE="$REPO_DIR/masc-prod.pid"
+PROD_PORT=8945
+LAUNCHD_LABEL="com.jeong-sik.masc-mcp-prod"
+LAUNCHD_PLIST="$HOME/Library/LaunchAgents/${LAUNCHD_LABEL}.plist"
+FORCE=false
+
+[[ "${1:-}" == "--force" ]] && FORCE=true
+
+# --- 1. Try launchd first ---
+if launchctl list "$LAUNCHD_LABEL" >/dev/null 2>&1; then
+    echo "Stopping launchd service ($LAUNCHD_LABEL)..." >&2
+    launchctl unload "$LAUNCHD_PLIST" 2>/dev/null || true
+    # Wait for port to free
+    for _ in $(seq 1 10); do
+        lsof -iTCP:"$PROD_PORT" -sTCP:LISTEN -t >/dev/null 2>&1 || break
+        sleep 0.5
+    done
+    echo "Stopped (launchd unloaded)." >&2
+    echo "To restart: launchctl load $LAUNCHD_PLIST" >&2
+    exit 0
+fi
+
+# --- 2. Try PID file ---
+if [ -f "$PID_FILE" ]; then
+    PID="$(cat "$PID_FILE")"
+    if kill -0 "$PID" 2>/dev/null; then
+        echo "Stopping prod MASC (PID $PID, port :$PROD_PORT)..." >&2
+        if [ "$FORCE" = true ]; then
+            kill -9 "$PID"
+        else
+            kill "$PID"
+            for _ in $(seq 1 10); do
+                kill -0 "$PID" 2>/dev/null || break
+                sleep 0.5
+            done
+            if kill -0 "$PID" 2>/dev/null; then
+                echo "Process did not exit cleanly, force killing..." >&2
+                kill -9 "$PID" 2>/dev/null || true
+            fi
+        fi
+        rm -f "$PID_FILE"
+        echo "Stopped." >&2
+        exit 0
+    else
+        echo "PID $PID is not running. Cleaning up PID file." >&2
+        rm -f "$PID_FILE"
+    fi
+fi
+
+# --- 3. Fallback: check port ---
+PORT_PID="$(lsof -iTCP:$PROD_PORT -sTCP:LISTEN -t 2>/dev/null || true)"
+if [ -n "$PORT_PID" ]; then
+    echo "Process $PORT_PID is listening on :$PROD_PORT." >&2
+    if [ "$FORCE" = true ]; then
+        echo "Killing PID $PORT_PID (--force)..." >&2
+        kill "$PORT_PID"
+        echo "Stopped." >&2
+    else
+        echo "Use --force to kill it." >&2
+    fi
+else
+    echo "Nothing running on :$PROD_PORT." >&2
+fi


### PR DESCRIPTION
## Summary
- **Agent Creator**: Admin-only `POST /api/v1/lodge/agents` endpoint with timing-safe token auth, `GET` for public agent list with full identity fields
- **Dashboard**: 🤖 Agents tab (card grid + admin-gated create form), ETag/304 caching for `html_cached`
- **Board Phase 2**: Deferred flush (30s interval), karma/sorted caches, comments_by_post hashtable
- **Batch API**: `GET /api/v1/dashboard` replaces 4 separate API calls
- **Room**: Eio-native tty detection (replaces Unix.open_process_in)

## Commits (4)
1. `refactor(room)` — Eio-native Process_eio.run for tty
2. `feat(board)` — Deferred flush + in-memory caches
3. `feat(dashboard)` — ETag/304 + Agents tab UI
4. `feat(api)` — Lodge agent CRUD + admin auth + batch endpoint

## Dependencies
- second-brain-graphql `d3ba89c` (extended `createAgent` mutation with Lodge fields) — already deployed on Railway

## Test plan
- [x] `GET /api/v1/lodge/agents` returns 15+ agents with full identity
- [x] `POST` without auth → 401, bad token → 403, valid → 201
- [x] Created agent visible in subsequent GET (all fields persisted)
- [x] Dashboard HTML contains all 8 Agents tab components
- [x] Build passes (`dune build`)
- [ ] Visual check of Agents tab in browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)