### PR TITLE
Add internal guardian loops

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,8 +176,8 @@ masc_leave(agent_name: "codex")
 - 기본 HTTP 엔드포인트: `/mcp`, `/health`, `/sse`
 - 시작 스크립트: `start-masc-mcp.sh` (Eio 런타임)
 - 내부 Guardian: 좀비 정리/GC/Lodge 루프 자동 실행 (프로세스 재기동은 하지 않음)
-- 자동 시작은 환경별로 선택 (예: launchd 등 외부 도구)
-- 로그: `~/me/logs/masc-mcp-launchd.{out,err}.log`
+- 자동 시작은 환경별로 선택
+- 로그는 실행 방식에 따라 다름 (stdout/stderr 확인)
 - SSE를 별도 터미널에서 모니터링하면 디버깅이 쉽습니다: `curl -N http://127.0.0.1:8935/sse`
 
 ## Agent Identity System

--- a/README.md
+++ b/README.md
@@ -147,6 +147,16 @@ masc_leave(agent_name: "codex")
 | `MASC_LODGE_TICK_INTERVAL_SEC` | 2700 | Heartbeat 간격 (초, 45분) |
 | `MASC_LODGE_QUIET_START` / `MASC_LODGE_QUIET_END` | 3 / 7 | 조용한 시간 (KST) |
 | `MASC_ORCHESTRATOR_ENABLED` | 0 | Orchestrator 활성화 |
+| `MASC_GUARDIAN_ENABLED` | false | 내부 수호자 루프 활성화 |
+| `MASC_GUARDIAN_MODE` | masc | `masc` / `lodge` / `both` |
+| `MASC_GUARDIAN_ZOMBIE_INTERVAL_SEC` | 60 | 좀비 정리 주기 (초) |
+| `MASC_GUARDIAN_GC_INTERVAL_SEC` | 3600 | GC 주기 (초, 0=비활성) |
+| `MASC_GUARDIAN_GC_DAYS` | 7 | GC 기준 일수 |
+| `MASC_GUARDIAN_LODGE_INTERVAL_SEC` | 300 | Lodge 루프 주기 (초) |
+| `MASC_GUARDIAN_LODGE_ITERATIONS` | 10 | Lodge 루프 반복 횟수 |
+| `MASC_GUARDIAN_LODGE_DELAY_MS` | 10000 | Lodge 루프 액션 간 딜레이 (ms) |
+| `MASC_GUARDIAN_LODGE_VERBOSE` | false | Lodge 루프 상세 로그 |
+| `MASC_GUARDIAN_LODGE_RESPECT_QUIET_HOURS` | true | Quiet hours 존중 |
 
 ## 문서
 

--- a/README.md
+++ b/README.md
@@ -175,7 +175,8 @@ masc_leave(agent_name: "codex")
 
 - 기본 HTTP 엔드포인트: `/mcp`, `/health`, `/sse`
 - 시작 스크립트: `start-masc-mcp.sh` (Eio 런타임)
-- launchd 서비스: `com.jeong-sik.masc-mcp` (macOS 자동 시작)
+- 내부 Guardian: 좀비 정리/GC/Lodge 루프 자동 실행 (프로세스 재기동은 하지 않음)
+- 자동 시작은 환경별로 선택 (예: launchd 등 외부 도구)
 - 로그: `~/me/logs/masc-mcp-launchd.{out,err}.log`
 - SSE를 별도 터미널에서 모니터링하면 디버깅이 쉽습니다: `curl -N http://127.0.0.1:8935/sse`
 

--- a/README.md
+++ b/README.md
@@ -176,6 +176,7 @@ masc_leave(agent_name: "codex")
 - 기본 HTTP 엔드포인트: `/mcp`, `/health`, `/sse`
 - 시작 스크립트: `start-masc-mcp.sh` (Eio 런타임)
 - 내부 Guardian: 좀비 정리/GC/Lodge 루프 자동 실행 (프로세스 재기동은 하지 않음)
+- `start-masc-mcp.sh`는 기본으로 `MASC_GUARDIAN_ENABLED=true` 설정
 - 자동 시작은 환경별로 선택
 - 로그는 실행 방식에 따라 다름 (stdout/stderr 확인)
 - SSE를 별도 터미널에서 모니터링하면 디버깅이 쉽습니다: `curl -N http://127.0.0.1:8935/sse`

--- a/bin/main_eio.ml
+++ b/bin/main_eio.ml
@@ -650,6 +650,7 @@ let health_handler _request reqd =
     else Printf.sprintf "%dh %dm" (uptime_secs / 3600) ((uptime_secs mod 3600) / 60)
   in
   let lodge_json = Masc_mcp.Lodge_heartbeat.(lodge_status () |> lodge_status_to_json) in
+  let guardian_json = Masc_mcp.Guardian.status_json () in
   let health_json = `Assoc [
     ("status", `String "ok");
     ("server", `String "masc-mcp");
@@ -657,6 +658,7 @@ let health_handler _request reqd =
     ("uptime", `String uptime_str);
     ("sse_clients", `Int (Masc_mcp.Sse.client_count ()));
     ("lodge", lodge_json);
+    ("guardian", guardian_json);
   ] in
   Http.Response.json (Yojson.Safe.to_string health_json) reqd
 
@@ -1620,6 +1622,8 @@ let run_server ~sw ~env ~port ~base_path =
   Masc_mcp.Shutdown_hooks.register_cancel_orchestrator cancel_orchestrator;
   (* Lodge world heartbeat - wakes agents every 60s *)
   Masc_mcp.Lodge_heartbeat.start ~sw ~clock state.room_config;
+  (* Internal guardian loops (no external watchdog dependency) *)
+  Masc_mcp.Guardian.start ~sw ~clock ~net state.room_config;
   (* Start MCP session cleanup loop *)
   Masc_mcp.Session.start_mcp_session_cleanup_loop ~sw ~clock ();
 
@@ -1776,6 +1780,7 @@ let run_server ~sw ~env ~port ~base_path =
             else Printf.sprintf "%dh %dm" (uptime_secs / 3600) ((uptime_secs mod 3600) / 60)
           in
           let lodge_json = Masc_mcp.Lodge_heartbeat.(lodge_status () |> lodge_status_to_json) in
+          let guardian_json = Masc_mcp.Guardian.status_json () in
           let health_json = `Assoc [
             ("status", `String "ok");
             ("server", `String "masc-mcp");
@@ -1784,6 +1789,7 @@ let run_server ~sw ~env ~port ~base_path =
             ("uptime", `String uptime_str);
             ("sse_clients", `Int (Sse.client_count ()));
             ("lodge", lodge_json);
+            ("guardian", guardian_json);
           ] in
           let body = Yojson.Safe.to_string health_json in
           h2_respond_json h2_reqd body ~extra_headers:cors

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -42,6 +42,13 @@ curl http://127.0.0.1:8935/health
 프로세스 내부에서 주기적으로 `zombie cleanup` / `GC` / (선택) `Lodge 루프`를 돌립니다.  
 프로세스 재기동은 하지 않으며, 필요 시 외부 watchdog에 위임합니다.
 
+`start-masc-mcp.sh`는 기본으로 `MASC_GUARDIAN_ENABLED=true`를 설정합니다.
+비활성화하려면 아래처럼 명시하세요:
+
+```bash
+export MASC_GUARDIAN_ENABLED=false
+```
+
 ```bash
 export MASC_GUARDIAN_ENABLED=true
 export MASC_GUARDIAN_MODE=both  # masc|lodge|both

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -37,6 +37,22 @@ dune build
 curl http://127.0.0.1:8935/health
 ```
 
+## 내부 Guardian (수호자)
+
+프로세스 내부에서 주기적으로 `zombie cleanup` / `GC` / (선택) `Lodge 루프`를 돌립니다.  
+프로세스 재기동은 하지 않으며, 필요 시 외부 watchdog에 위임합니다.
+
+```bash
+export MASC_GUARDIAN_ENABLED=true
+export MASC_GUARDIAN_MODE=both  # masc|lodge|both
+# 필요 시 주기 조정:
+# export MASC_GUARDIAN_ZOMBIE_INTERVAL_SEC=60
+# export MASC_GUARDIAN_GC_INTERVAL_SEC=3600
+# export MASC_GUARDIAN_LODGE_INTERVAL_SEC=300
+```
+
+상태는 `/health` 응답의 `guardian` 필드에서 확인할 수 있습니다.
+
 ## MCP 설정
 
 README의 예시 구성(Claude Code) 참고:

--- a/lib/dune
+++ b/lib/dune
@@ -40,6 +40,7 @@
    handover_eio
    hat
    heartbeat
+   guardian
    heartbeat_smart
    hebbian_eio
    http_server_eio

--- a/lib/env_config.ml
+++ b/lib/env_config.ml
@@ -139,6 +139,50 @@ module Cancellation = struct
     get_float ~default:3600.0 "MASC_CANCELLATION_TOKEN_MAX_AGE_SEC"
 end
 
+(** {1 Internal Guardian Configuration} *)
+
+module Guardian = struct
+  (** Enable internal guardian loops (default: false) *)
+  let enabled =
+    get_bool ~default:false "MASC_GUARDIAN_ENABLED"
+
+  (** Mode: masc | lodge | both *)
+  let mode =
+    get_string ~default:"masc" "MASC_GUARDIAN_MODE"
+
+  (** Zombie cleanup interval (seconds) *)
+  let zombie_interval_seconds =
+    get_float ~default:Zombie.cleanup_interval_seconds "MASC_GUARDIAN_ZOMBIE_INTERVAL_SEC"
+
+  (** GC interval (seconds); 0 disables *)
+  let gc_interval_seconds =
+    get_float ~default:3600.0 "MASC_GUARDIAN_GC_INTERVAL_SEC"
+
+  (** GC threshold in days *)
+  let gc_days =
+    get_int ~default:7 "MASC_GUARDIAN_GC_DAYS"
+
+  (** Lodge loop interval between runs (seconds) *)
+  let lodge_interval_seconds =
+    get_float ~default:300.0 "MASC_GUARDIAN_LODGE_INTERVAL_SEC"
+
+  (** Lodge loop iterations per run *)
+  let lodge_iterations =
+    get_int ~default:10 "MASC_GUARDIAN_LODGE_ITERATIONS"
+
+  (** Lodge loop delay between actions (ms) *)
+  let lodge_delay_ms =
+    get_int ~default:10000 "MASC_GUARDIAN_LODGE_DELAY_MS"
+
+  (** Lodge loop verbose logging *)
+  let lodge_verbose =
+    get_bool ~default:false "MASC_GUARDIAN_LODGE_VERBOSE"
+
+  (** Respect Lodge quiet hours *)
+  let lodge_respect_quiet_hours =
+    get_bool ~default:true "MASC_GUARDIAN_LODGE_RESPECT_QUIET_HOURS"
+end
+
 (** {1 Qdrant Configuration} *)
 
 module Qdrant = struct

--- a/lib/guardian.ml
+++ b/lib/guardian.ml
@@ -1,0 +1,183 @@
+(** Internal guardian loops (no external watchdog dependency). *)
+
+open Printf
+
+module Mode = struct
+  type t = Masc | Lodge | Both
+
+  let of_string s =
+    match String.lowercase_ascii s with
+    | "masc" | "mcp" -> Masc
+    | "lodge" -> Lodge
+    | "both" | "all" -> Both
+    | _ -> Masc
+
+  let to_string = function
+    | Masc -> "masc"
+    | Lodge -> "lodge"
+    | Both -> "both"
+end
+
+let enabled = Env_config.Guardian.enabled
+let mode = Mode.of_string Env_config.Guardian.mode
+let masc_enabled =
+  enabled && (match mode with Masc | Both -> true | Lodge -> false)
+
+let lodge_enabled =
+  enabled
+  && Env_config.LodgeV2.enabled
+  && (match mode with Lodge | Both -> true | Masc -> false)
+
+let zombie_interval_s = Env_config.Guardian.zombie_interval_seconds
+let gc_interval_s = Env_config.Guardian.gc_interval_seconds
+let gc_days = Env_config.Guardian.gc_days
+
+let lodge_interval_s = Env_config.Guardian.lodge_interval_seconds
+let lodge_iterations = Env_config.Guardian.lodge_iterations
+let lodge_delay_ms = Env_config.Guardian.lodge_delay_ms
+let lodge_verbose = Env_config.Guardian.lodge_verbose
+let lodge_respect_quiet_hours = Env_config.Guardian.lodge_respect_quiet_hours
+
+let last_zombie_cleanup : string option ref = ref None
+let last_gc : string option ref = ref None
+let last_lodge : string option ref = ref None
+let last_zombie_result : string option ref = ref None
+let last_gc_result : string option ref = ref None
+let last_lodge_result : (bool * string) option ref = ref None
+let lodge_running = ref false
+
+let log msg =
+  eprintf "[guardian] %s\n%!" msg
+
+let set_last r =
+  r := Some (Types.now_iso ())
+
+let is_quiet_hours () =
+  if not lodge_respect_quiet_hours then false
+  else
+    let tm = Unix.localtime (Time_compat.now ()) in
+    let hour = tm.Unix.tm_hour in
+    let quiet_start = Env_config.LodgeV2.quiet_start in
+    let quiet_end = Env_config.LodgeV2.quiet_end in
+    quiet_start < quiet_end && hour >= quiet_start && hour < quiet_end
+
+let status_json () : Yojson.Safe.t =
+  let assoc = ref [
+    ("enabled", `Bool enabled);
+    ("mode", `String (Mode.to_string mode));
+    ("masc_enabled", `Bool masc_enabled);
+    ("lodge_enabled", `Bool lodge_enabled);
+    ("zombie_interval_s", `Float zombie_interval_s);
+    ("gc_interval_s", `Float gc_interval_s);
+    ("gc_days", `Int gc_days);
+    ("lodge_interval_s", `Float lodge_interval_s);
+    ("lodge_iterations", `Int lodge_iterations);
+    ("lodge_delay_ms", `Int lodge_delay_ms);
+    ("lodge_verbose", `Bool lodge_verbose);
+    ("lodge_respect_quiet_hours", `Bool lodge_respect_quiet_hours);
+    ("lodge_running", `Bool !lodge_running);
+  ] in
+  let add_opt name = function
+    | None -> ()
+    | Some v -> assoc := (name, `String v) :: !assoc
+  in
+  add_opt "last_zombie_cleanup" !last_zombie_cleanup;
+  add_opt "last_gc" !last_gc;
+  add_opt "last_lodge" !last_lodge;
+  (match !last_zombie_result with
+   | None -> ()
+   | Some v -> assoc := ("last_zombie_result", `String v) :: !assoc);
+  (match !last_gc_result with
+   | None -> ()
+   | Some v -> assoc := ("last_gc_result", `String v) :: !assoc);
+  (match !last_lodge_result with
+   | None -> ()
+   | Some (ok, msg) ->
+       assoc := ("last_lodge_result", `Assoc [
+         ("ok", `Bool ok);
+         ("message", `String msg);
+       ]) :: !assoc);
+  `Assoc (List.rev !assoc)
+
+let start_masc_loops ~sw ~clock config =
+  if not masc_enabled then begin
+    log "masc guardian disabled";
+    ()
+  end else begin
+    if zombie_interval_s > 0.0 then
+      Eio.Fiber.fork ~sw (fun () ->
+        let rec loop () =
+          (try
+             let result = Room.cleanup_zombies config in
+             last_zombie_result := Some result;
+             set_last last_zombie_cleanup;
+             log result
+           with exn ->
+             log (sprintf "zombie cleanup failed: %s" (Printexc.to_string exn)));
+          Eio.Time.sleep clock zombie_interval_s;
+          loop ()
+        in
+        loop ()
+      );
+    if gc_interval_s > 0.0 then
+      Eio.Fiber.fork ~sw (fun () ->
+        let rec loop () =
+          (try
+             let result = Room.gc config ~days:gc_days () in
+             last_gc_result := Some result;
+             set_last last_gc;
+             log (sprintf "gc: %s" result)
+           with exn ->
+             log (sprintf "gc failed: %s" (Printexc.to_string exn)));
+          Eio.Time.sleep clock gc_interval_s;
+          loop ()
+        in
+        loop ()
+      )
+  end
+
+let start_lodge_loop ~sw ~clock ~net =
+  if not lodge_enabled then begin
+    log "lodge guardian disabled";
+    ()
+  end else if lodge_interval_s <= 0.0 || lodge_iterations <= 0 then begin
+    log "lodge guardian disabled by interval/iterations";
+    ()
+  end else
+    Eio.Fiber.fork ~sw (fun () ->
+      let rec loop () =
+        if is_quiet_hours () then begin
+          log "quiet hours - skipping lodge loop";
+        end else begin
+          lodge_running := true;
+          let args = `Assoc [
+            ("iterations", `Int lodge_iterations);
+            ("delay_ms", `Int lodge_delay_ms);
+            ("verbose", `Bool lodge_verbose);
+          ] in
+          let result =
+            try Tool_lodge.autonomous_loop ~net args
+            with exn ->
+              (false, sprintf "exception: %s" (Printexc.to_string exn))
+          in
+          last_lodge_result := Some result;
+          set_last last_lodge;
+          lodge_running := false;
+          (match result with
+           | (true, msg) -> log (sprintf "lodge loop ok: %s" msg)
+           | (false, msg) -> log (sprintf "lodge loop failed: %s" msg))
+        end;
+        Eio.Time.sleep clock lodge_interval_s;
+        loop ()
+      in
+      loop ()
+    )
+
+let start ~sw ~clock ~net room_config =
+  if not enabled then begin
+    log "guardian disabled (set MASC_GUARDIAN_ENABLED=true)";
+  end else begin
+    start_masc_loops ~sw ~clock room_config;
+    start_lodge_loop ~sw ~clock ~net;
+    log (sprintf "guardian started (mode=%s)" (Mode.to_string mode))
+  end

--- a/lib/masc_mcp.ml
+++ b/lib/masc_mcp.ml
@@ -92,6 +92,7 @@ module Gcm_compat = Gcm_compat
 module Mention = Mention
 module Hat = Hat
 module Heartbeat = Heartbeat
+module Guardian = Guardian
 module Mitosis = Mitosis
 module Dashboard = Dashboard
 module Tempo = Tempo

--- a/start-masc-mcp.sh
+++ b/start-masc-mcp.sh
@@ -33,6 +33,11 @@ if [ -f "$LODGE_ENV" ]; then
     set -a; source "$LODGE_ENV"; set +a
 fi
 
+# Default: enable internal guardian unless explicitly disabled
+if [ -z "$MASC_GUARDIAN_ENABLED" ]; then
+    export MASC_GUARDIAN_ENABLED=true
+fi
+
 # Resolve executable path
 # Priority: 1. Release binary  2. Workspace build  3. Local build  4. Installed  5. Auto-download
 RELEASE_BINARY="$SCRIPT_DIR/masc-mcp-macos-arm64"


### PR DESCRIPTION
## Summary
- add internal guardian loops (MASC + Lodge) without external watchdog
- expose guardian status in /health and /health (h2)
- add env config + README docs

## Testing
- dune build --root .
- dune test --root .