### PR TITLE
Hardening: Fs_compat mkdir_p without shell

### DIFF
--- a/lib/fs_compat/fs_compat.ml
+++ b/lib/fs_compat/fs_compat.ml
@@ -84,9 +84,16 @@ let mkdir_p (path : string) : unit =
     let eio_path = Eio.Path.(fs / path) in
     Eio.Path.mkdirs ~exists_ok:true ~perm:0o755 eio_path
   | None ->
-    (* Fallback: use mkdir -p command *)
-    if not (Sys.file_exists path) then
-      ignore (Sys.command (Printf.sprintf "mkdir -p %s" path))
+    (* Fallback: recursive mkdir without invoking a shell. *)
+    let rec ensure_dir (p : string) : unit =
+      if p = "" || p = "." || p = "/" then ()
+      else if Sys.file_exists p then ()
+      else begin
+        ensure_dir (Filename.dirname p);
+        try Unix.mkdir p 0o755 with Unix.Unix_error (Unix.EEXIST, _, _) -> ()
+      end
+    in
+    ensure_dir path
 
 (** Load JSONL file as list of JSON values.
     Filters out malformed lines. *)

--- a/test/dune
+++ b/test/dune
@@ -158,6 +158,12 @@
  (modules test_pubsub_postgres)
  (libraries masc_mcp alcotest))
 
+; Fs_compat tests (mkdir_p fallback must be shell-free and safe)
+(test
+ (name test_fs_compat)
+ (modules test_fs_compat)
+ (libraries masc_mcp alcotest unix))
+
 ; ============================================================
 ; Concurrency stress tests (20+ agents)
 ; Phase 4: MCP Unify project

--- a/test/test_fs_compat.ml
+++ b/test/test_fs_compat.ml
@@ -1,0 +1,52 @@
+(** test_fs_compat.ml - Fs_compat safety + behavior tests
+
+    Focus: ensure mkdir_p fallback does not invoke a shell and correctly creates
+    nested directories with tricky path characters.
+*)
+
+open Alcotest
+
+let rec rm_rf (path : string) : unit =
+  if Sys.file_exists path then
+    if Sys.is_directory path then begin
+      Sys.readdir path
+      |> Array.iter (fun name -> rm_rf (Filename.concat path name));
+      Unix.rmdir path
+    end else
+      Sys.remove path
+
+let with_tmp_dir (f : string -> unit) : unit =
+  let tmp = Filename.temp_file "masc_fs_compat_" ".tmp" in
+  Sys.remove tmp;
+  Unix.mkdir tmp 0o755;
+  Fun.protect
+    ~finally:(fun () -> rm_rf tmp)
+    (fun () -> f tmp)
+
+let test_mkdir_p_creates_nested_dirs () =
+  Fs_compat.clear_fs ();
+  with_tmp_dir @@ fun base ->
+  let path = Filename.concat base "a/b/c" in
+  Fs_compat.mkdir_p path;
+  check bool "created leaf dir" true (Sys.file_exists path && Sys.is_directory path)
+
+let test_mkdir_p_does_not_shell_inject () =
+  Fs_compat.clear_fs ();
+  with_tmp_dir @@ fun base ->
+  let pwned = Filename.concat base "pwned" in
+  let dangerous = Filename.concat base ("dir;touch " ^ pwned ^ "/x") in
+  Fs_compat.mkdir_p dangerous;
+  (* If mkdir_p used a shell (`mkdir -p <path>`), this would create pwned. *)
+  check bool "no shell side-effect file created" false (Sys.file_exists pwned);
+  check bool "dangerous path exists" true (Sys.file_exists dangerous && Sys.is_directory dangerous)
+
+let () =
+  run "fs_compat" [
+    ( "mkdir_p"
+    , [
+        test_case "creates nested dirs" `Quick test_mkdir_p_creates_nested_dirs;
+        test_case "no shell injection" `Quick test_mkdir_p_does_not_shell_inject;
+      ]
+    );
+  ]
+


### PR DESCRIPTION
Removes shell-based mkdir -p fallback from Fs_compat and adds a regression test to prevent reintroducing shell execution.