### PR TITLE
masc-mcp: argv-only subprocesses (no shell exec)

### DIFF
--- a/lib/auto_recall.ml
+++ b/lib/auto_recall.ml
@@ -139,31 +139,62 @@ let fetch_from_broadcasts (room_config : Room_utils.config) ~(config : recall_co
     }
   ) messages
 
-(** {1 Non-blocking Shell Execution} *)
-
-(** Run shell command and read lines (Eio-native) *)
-let run_shell_lines cmd =
-  Process_eio.run ~timeout_sec:30.0 cmd
-  |> String.split_on_char '\n'
-  |> List.map String.trim
-  |> List.filter (fun s -> s <> "")
-
 (** Fetch recently modified files from working directory *)
 let fetch_from_file_context (room_config : Room_utils.config) ~(config : recall_config) ~query =
   let _ = config in  (* suppress unused warning *)
   let masc_dir = Room_utils.masc_dir room_config in
   let work_dir = Filename.dirname masc_dir in (* Parent of .masc *)
   
-  (* Get recently modified files using find *)
+  (* Get recently modified files without shelling out (no find/xargs). *)
   let max_files = 10 in
   let max_preview_bytes = 500 in
   
-  let cmd = Printf.sprintf 
-    "find %s -maxdepth 3 -type f -name '*.ml' -o -name '*.mli' -o -name '*.py' -o -name '*.ts' -o -name '*.js' -o -name '*.md' 2>/dev/null | head -50 | xargs ls -t 2>/dev/null | head -%d"
-    (Filename.quote work_dir) max_files
+  let is_allowed_file path =
+    Filename.check_suffix path ".ml"
+    || Filename.check_suffix path ".mli"
+    || Filename.check_suffix path ".py"
+    || Filename.check_suffix path ".ts"
+    || Filename.check_suffix path ".js"
+    || Filename.check_suffix path ".md"
   in
-  
-  let files = run_shell_lines cmd in
+
+  let should_skip_dir name =
+    name = ".git"
+    || name = "node_modules"
+    || name = "_build"
+    || name = ".worktrees"
+    || name = ".masc"
+  in
+
+  let rec walk depth dir acc =
+    if depth > 3 then acc
+    else
+      match Safe_ops.list_dir_safe dir with
+      | Error _ -> acc
+      | Ok names ->
+          List.fold_left (fun acc name ->
+            if should_skip_dir name then acc
+            else
+              let path = Filename.concat dir name in
+              try
+                if Sys.is_directory path then walk (depth + 1) path acc
+                else if is_allowed_file path then path :: acc
+                else acc
+              with _ -> acc
+          ) acc names
+  in
+
+  let files =
+    walk 0 work_dir []
+    |> List.filter_map (fun path ->
+        try
+          let st = Unix.stat path in
+          Some (st.Unix.st_mtime, path)
+        with _ -> None)
+    |> List.sort (fun (a_m, _) (b_m, _) -> compare b_m a_m)
+    |> List.filteri (fun i _ -> i < max_files)
+    |> List.map snd
+  in
   
   (* Read preview of each file *)
   let read_preview path =

--- a/lib/auto_responder.ml
+++ b/lib/auto_responder.ml
@@ -1,131 +1,95 @@
-(** Auto-Responder Daemon - Automatic @mention response via spawn
+(** Auto-Responder Daemon - Automatic @mention response
 
-    When a broadcast message contains @mention, automatically spawn
-    the mentioned agent to respond.
+    When a broadcast message contains an @mention, optionally:
+    - Spawn the mentioned CLI agent to respond (Spawn mode)
+    - Use direct LLM call + in-process MASC tool calls to respond (Llm mode)
 
-    Enable with: MASC_AUTO_RESPOND=true
+    Enable with: MASC_AUTO_RESPOND=true|spawn|llm
 
-    Chain limit: Max 3 responses per minute to prevent infinite loops
+    Design:
+    - No shell execution (argv-only)
+    - Non-blocking: work runs in an Eio fiber forked from the server switch
+    - Rate-limited to prevent runaway mention loops
 *)
 
-(** Auto-respond mode *)
+open Yojson.Safe.Util
+
 type mode = Disabled | Spawn | Llm
 
-(** Check auto-respond mode *)
 let get_mode () =
   match Sys.getenv_opt "MASC_AUTO_RESPOND" with
   | Some "true" | Some "1" | Some "yes" | Some "spawn" -> Spawn
   | Some "llm" | Some "fast" -> Llm
   | _ -> Disabled
 
-(** Check if auto-respond is enabled *)
 let is_enabled () = get_mode () <> Disabled
 
-(** Activity log file - human readable, shared across all modes *)
 let activity_log_file () =
   match Sys.getenv_opt "ME_ROOT" with
   | Some root -> root ^ "/logs/auto-responder.log"
   | None -> "/tmp/auto-responder.log"
 
-(** Debug logging to file *)
 let debug_log msg =
   let oc = open_out_gen [Open_creat; Open_append; Open_text] 0o644 "/tmp/auto_debug.log" in
-  Common.protect ~module_name:"auto_responder" ~finally_label:"finalizer" ~finally:(fun () -> close_out_noerr oc) (fun () ->
-    Printf.fprintf oc "[%f] %s\n%!" (Time_compat.now ()) msg)
+  Common.protect ~module_name:"auto_responder" ~finally_label:"finalizer"
+    ~finally:(fun () -> close_out_noerr oc)
+    (fun () -> Printf.fprintf oc "[%f] %s\n%!" (Time_compat.now ()) msg)
 
-(** Activity logging - human readable format *)
 let activity_log ~mode ~from_agent ~mention ~status ~detail =
   let log_file = activity_log_file () in
   let oc = open_out_gen [Open_creat; Open_append; Open_text] 0o644 log_file in
-  Common.protect ~module_name:"auto_responder" ~finally_label:"finalizer" ~finally:(fun () -> close_out_noerr oc) (fun () ->
-    let time = Unix.localtime (Time_compat.now ()) in
-    let timestamp = Printf.sprintf "%04d-%02d-%02d %02d:%02d:%02d"
-      (time.Unix.tm_year + 1900) (time.Unix.tm_mon + 1) time.Unix.tm_mday
-      time.Unix.tm_hour time.Unix.tm_min time.Unix.tm_sec
-    in
-    let mode_str = match mode with Disabled -> "OFF" | Spawn -> "SPAWN" | Llm -> "LLM" in
-    Printf.fprintf oc "[%s] [%s] %s → @%s | %s | %s\n%!"
-      timestamp mode_str from_agent mention status detail)
+  Common.protect ~module_name:"auto_responder" ~finally_label:"finalizer"
+    ~finally:(fun () -> close_out_noerr oc)
+    (fun () ->
+      let time = Unix.localtime (Time_compat.now ()) in
+      let timestamp =
+        Printf.sprintf "%04d-%02d-%02d %02d:%02d:%02d"
+          (time.Unix.tm_year + 1900)
+          (time.Unix.tm_mon + 1)
+          time.Unix.tm_mday
+          time.Unix.tm_hour
+          time.Unix.tm_min
+          time.Unix.tm_sec
+      in
+      let mode_str = match mode with Disabled -> "OFF" | Spawn -> "SPAWN" | Llm -> "LLM" in
+      Printf.fprintf oc "[%s] [%s] %s → @%s | %s | %s\n%!"
+        timestamp mode_str from_agent mention status detail)
 
-(** Chain limit: track recent responses to prevent infinite loops *)
+(* --- Loop prevention / throttling --- *)
+
 let recent_responses : (string, float) Hashtbl.t = Hashtbl.create 16
-let chain_limit = 3  (* max responses per agent type per minute *)
-let chain_window = 60.0  (* seconds *)
+let chain_limit = 3
+let chain_window = 60.0
 
-(** Check if we should throttle this response *)
 let should_throttle ~agent_type =
   let now = Time_compat.now () in
-  let key = agent_type in
-  (* Clean old entries *)
-  Hashtbl.filter_map_inplace (fun _ ts ->
-    if now -. ts < chain_window then Some ts else None
-  ) recent_responses;
-  (* Count recent responses for this agent type *)
-  let count = Hashtbl.fold (fun k _ acc ->
-    if String.length k >= String.length agent_type &&
-       String.sub k 0 (String.length agent_type) = agent_type
-    then acc + 1 else acc
-  ) recent_responses 0 in
-  if count >= chain_limit then begin
+  Hashtbl.filter_map_inplace (fun _ ts -> if now -. ts < chain_window then Some ts else None) recent_responses;
+  let count =
+    Hashtbl.fold (fun k _ acc ->
+      if String.length k >= String.length agent_type
+         && String.sub k 0 (String.length agent_type) = agent_type
+      then acc + 1 else acc
+    ) recent_responses 0
+  in
+  if count >= chain_limit then (
     debug_log (Printf.sprintf "THROTTLE: %s has %d responses in last %.0fs" agent_type count chain_window);
     true
-  end else begin
-    Hashtbl.add recent_responses (Printf.sprintf "%s-%f" key now) now;
+  ) else (
+    Hashtbl.add recent_responses (Printf.sprintf "%s-%f" agent_type now) now;
     false
-  end
+  )
 
-(** [DEPRECATED] LLM-MCP endpoint — kept for backward compatibility, not used in new code.
-    New code should use Llm_direct.dispatch instead. *)
-let llm_mcp_url () = Env_config.Endpoints.llm_mcp_url
+(* --- Mention helpers (re-export) --- *)
 
-(** Re-export from Mention module for convenience *)
 let spawnable_agents = Mention.spawnable_agents
 let agent_type_of_mention = Mention.agent_type_of_mention
 let is_spawnable = Mention.is_spawnable
 
-(** {1 Non-blocking Shell Execution} *)
+(* --- CLI spawn (Spawn mode) --- *)
 
-(** Run shell command (Eio-native).
-    Delegates to Process_eio.run_with_status (global proc_mgr/clock). *)
-let run_shell_nonblocking cmd =
-  Process_eio.run_with_status ~timeout_sec:60.0 cmd
+let has_timeout =
+  lazy (String.trim (Process_eio.run_argv ~timeout_sec:2.0 ["which"; "timeout"]) <> "")
 
-(** Run shell command and get single line (Eio-native) *)
-let run_shell_line cmd =
-  let output = Process_eio.run ~timeout_sec:10.0 cmd in
-  match String.split_on_char '\n' (String.trim output) with
-  | first :: _ -> first
-  | [] -> ""
-
-(** Run command, ignore result (Eio-native) *)
-let run_system_nonblocking cmd =
-  let (status, _) = Process_eio.run_with_status ~timeout_sec:60.0 cmd in
-  status
-
-(** Build shell command for spawning an agent *)
-let build_spawn_command ~agent_type ~prompt ~working_dir =
-  let escaped_prompt = Filename.quote prompt in
-  let base_cmd = match agent_type with
-    | "claude" -> Printf.sprintf "echo %s | claude -p --allowedTools 'mcp__masc__*'" escaped_prompt
-    | "gemini" -> Printf.sprintf "echo %s | gemini --yolo" escaped_prompt
-    | "codex" -> Printf.sprintf "echo %s | codex exec" escaped_prompt
-    | "ollama" -> Printf.sprintf "echo %s | ollama run %s" escaped_prompt Env_config.Ollama.default_model
-    | "glm" ->
-        (* GLM via direct Z.ai API - no llm-mcp dependency.
-           API key passed via ZAI_API_KEY env var, not in command string. *)
-        let model = "glm-4.7" in
-        let json_escaped =
-          prompt
-          |> String.split_on_char '"' |> String.concat {|\"|}
-          |> String.split_on_char '\n' |> String.concat {|\\n|}
-        in
-        (* Use env var expansion in bash, key never appears in process list *)
-        Printf.sprintf "echo '{\"model\":\"%s\",\"messages\":[{\"role\":\"user\",\"content\":\"%s\"}],\"stream\":false}' | curl -s 'https://api.z.ai/api/coding/paas/v4/chat/completions' -H 'Content-Type: application/json' -H \"Authorization: Bearer $ZAI_API_KEY\" -d @- | jq -r '.choices[0].message.content // \"error\"'" model json_escaped
-    | _ -> Printf.sprintf "echo %s | %s" escaped_prompt agent_type
-  in
-  Printf.sprintf "cd %s && timeout 120 %s" (Filename.quote working_dir) base_cmd
-
-(** Build prompt for auto-response *)
 let build_response_prompt ~from_agent ~content ~mention =
   Printf.sprintf {|You received a mention in the MASC room from %s.
 
@@ -142,89 +106,108 @@ Quick response protocol:
 Respond in 1-2 sentences. Be helpful and concise.|}
     from_agent content mention mention
 
-(** Spawn agent in background (non-blocking) - Heavy mode *)
-let spawn_in_background ~agent_type ~prompt ~working_dir =
-  let cmd = build_spawn_command ~agent_type ~prompt ~working_dir in
-  let log_file = Printf.sprintf "/tmp/auto_respond_%s_%d.log"
-    agent_type (int_of_float (Time_compat.now () *. 1000.) mod 10000)
-  in
-  (* Write command to file for debugging *)
-  let debug_file = "/tmp/auto_spawn_cmd.txt" in
-  (let oc = open_out debug_file in
-   Common.protect ~module_name:"auto_responder" ~finally_label:"finalizer" ~finally:(fun () -> close_out_noerr oc) (fun () ->
-     Printf.fprintf oc "CMD: %s\nLOG: %s\n" cmd log_file));
-  (* Run in background with nohup - use script file to avoid quoting issues *)
-  let script_file = "/tmp/auto_spawn_script.sh" in
-  (let sc = open_out script_file in
-   Common.protect ~module_name:"auto_responder" ~finally_label:"finalizer" ~finally:(fun () -> close_out_noerr sc) (fun () ->
-     Printf.fprintf sc "#!/bin/bash\n%s\n" cmd));
-  ignore (Unix.chmod script_file 0o755);
-  let bg_cmd = Printf.sprintf "nohup %s > %s 2>&1 &" script_file log_file in
-  debug_log (Printf.sprintf "SPAWN_CMD: %s" bg_cmd);
-  let ret = run_system_nonblocking bg_cmd in
-  debug_log (Printf.sprintf "SPAWN_RET: %s" (match ret with Unix.WEXITED n -> string_of_int n | _ -> "signal"))
+let cli_argv_of_agent_type (agent_type : string) : string list =
+  match agent_type with
+  | "claude" -> ["claude"; "-p"; "--allowedTools"; "mcp__masc__*"]
+  | "gemini" -> ["gemini"; "--yolo"]
+  | "codex" -> ["codex"; "exec"]
+  | "ollama" -> ["ollama"; "run"; Env_config.Ollama.default_model]
+  | other -> [other]
 
-(** Call LLM directly via Llm_direct - Returns LLM response or error.
-    No llm-mcp dependency — uses direct API calls to GLM/Ollama/Claude. *)
-let call_llm_direct_sync ~agent_type ~prompt =
-  let tool_name = match agent_type with
-    | "gemini" -> "glm"  (* Gemini not directly supported, use GLM *)
-    | "claude" -> "claude-cli"
-    | "codex" -> "ollama"  (* Codex not supported, use Ollama *)
-    | "glm" -> "glm"
-    | _ -> "ollama"  (* ollama is the fallback for unknown types *)
+let run_cli_agent ~agent_type ~prompt =
+  let base = cli_argv_of_agent_type agent_type in
+  let argv = if Lazy.force has_timeout then ["timeout"; "120"] @ base else base in
+  debug_log (Printf.sprintf "SPAWN argv=%s" (String.concat " " (List.map Filename.quote argv)));
+  let (status, output) =
+    Process_eio.run_argv_with_stdin_and_status
+      ~timeout_sec:140.0
+      ~stdin_content:prompt
+      argv
   in
-  let model = match tool_name with
+  let status_s = match status with
+    | Unix.WEXITED n -> Printf.sprintf "exit=%d" n
+    | Unix.WSIGNALED n -> Printf.sprintf "signaled=%d" n
+    | Unix.WSTOPPED n -> Printf.sprintf "stopped=%d" n
+  in
+  let preview =
+    let s = String.trim output in
+    if String.length s > 200 then String.sub s 0 200 ^ "..." else s
+  in
+  debug_log (Printf.sprintf "SPAWN_DONE %s output=%s" status_s preview)
+
+(* --- LLM mode: direct call + in-process MASC HTTP tools/call --- *)
+
+let call_llm_direct_sync ~agent_type ~prompt =
+  let tool_name =
+    match agent_type with
+    | "gemini" -> "glm" (* Gemini not directly supported, use GLM *)
+    | "claude" -> "claude-cli"
+    | "codex" -> "ollama" (* Codex not directly supported, use Ollama *)
+    | "glm" -> "glm"
+    | _ -> "ollama"
+  in
+  let model =
+    match tool_name with
     | "glm" -> "glm-4.7"
     | "ollama" -> Env_config.Ollama.default_model
     | "claude-cli" -> "claude-sonnet-4-20250514"
     | _ -> "glm-4-flash"
   in
   try
-    let response = Llm_direct.dispatch
-      ~tool_name
-      ~model
-      ~prompt
-      ~timeout_sec:30
-      ~max_chars:500
-      ()
+    let response =
+      Llm_direct.dispatch ~tool_name ~model ~prompt ~timeout_sec:30 ~max_chars:500 ()
     in
     if response = "" then "no response" else response
   with exn ->
     Printf.eprintf "[auto_responder] LLM call failed: %s\n%!" (Printexc.to_string exn);
     "no response"
 
-(** [DEPRECATED] Call llm-mcp — use call_llm_direct_sync instead *)
-let call_llm_mcp_sync ~agent_type ~prompt =
-  call_llm_direct_sync ~agent_type ~prompt
+let masc_call ~sw ~tool_name ~(args : Yojson.Safe.t) : (string, string) result =
+  let masc_port = match Sys.getenv_opt "MASC_HTTP_PORT" with Some p -> p | None -> "8935" in
+  let uri = Uri.of_string (Printf.sprintf "http://127.0.0.1:%s/mcp" masc_port) in
+  let body =
+    `Assoc [
+      ("jsonrpc", `String "2.0");
+      ("method", `String "tools/call");
+      ("id", `Int 1);
+      ("params", `Assoc [
+        ("name", `String tool_name);
+        ("arguments", args);
+      ]);
+    ]
+    |> Yojson.Safe.to_string
+  in
+  match Eio_context.get_net_opt () with
+  | None -> Error "Eio net not initialized"
+  | Some net ->
+      let client = Cohttp_eio.Client.make ~https:None net in
+      let headers = Cohttp.Header.of_list [
+        ("Content-Type", "application/json");
+        ("Accept", "application/json, text/event-stream");
+      ] in
+      let body_content = Eio.Flow.string_source body in
+      try
+        let resp, resp_body = Cohttp_eio.Client.post client ~sw uri ~headers ~body:body_content in
+        let status = Cohttp.Response.status resp |> Cohttp.Code.code_of_status in
+        let body_str = Eio.Buf_read.(parse_exn take_all) resp_body ~max_size:(8 * 1024 * 1024) in
+        if not (Cohttp.Code.is_success status) then
+          Error (Printf.sprintf "MASC HTTP %d" status)
+        else
+          (* Extract MCP tool text: result.content[0].text *)
+          try
+            let json = Yojson.Safe.from_string body_str in
+            let txt =
+              json |> member "result" |> member "content" |> to_list |> List.hd
+                  |> member "text" |> to_string
+            in
+            Ok txt
+          with _ ->
+            Ok body_str
+      with exn ->
+        Error (Printexc.to_string exn)
 
-(** MASC HTTP helper - call MASC tool via HTTP (using temp file to avoid escaping issues) *)
-let masc_call ~tool_name ~args =
-  let masc_url = Printf.sprintf "http://127.0.0.1:%d/mcp"
-    (match Sys.getenv_opt "MASC_HTTP_PORT" with Some p -> int_of_string p | None -> 8935)
-  in
-  let body = Printf.sprintf
-    {|{"jsonrpc":"2.0","method":"tools/call","id":1,"params":{"name":"%s","arguments":%s}}|}
-    tool_name args
-  in
-  (* Use temp file to avoid shell escaping issues *)
-  let tmp_file = Printf.sprintf "/tmp/masc_call_%d_%d.json"
-    (Unix.getpid ()) (int_of_float (Time_compat.now () *. 1000000.) mod 1000000) in
-  (let oc = open_out tmp_file in
-   Common.protect ~module_name:"auto_responder" ~finally_label:"finalizer" ~finally:(fun () -> close_out_noerr oc) (fun () ->
-     output_string oc body));
-  let cmd = Printf.sprintf
-    "curl -s '%s' -H 'Content-Type: application/json' -H 'Accept: application/json, text/event-stream' -d @%s 2>/dev/null"
-    masc_url tmp_file
-  in
-  let (_, content) = run_shell_nonblocking cmd in
-  Safe_ops.remove_file_logged ~context:"auto_responder" tmp_file;
-  content
-
-(** Extract nickname from MASC join response *)
-let extract_nickname response =
-  (* Look for "Nickname: xxx" pattern *)
-  let lines = String.split_on_char '\n' response in
+let extract_nickname (response_text : string) : string option =
+  let lines = String.split_on_char '\n' response_text in
   let rec find = function
     | [] -> None
     | line :: rest ->
@@ -234,131 +217,44 @@ let extract_nickname response =
   in
   find lines
 
-(** Call LLM directly and broadcast response (fast mode, background)
-    Auto-responder handles MASC join/broadcast/leave directly.
-    No llm-mcp dependency — uses Llm_direct. *)
-let call_llm_and_broadcast ~agent_type ~prompt ~mention ~base_path =
-  ignore base_path;
-  (* Step 1: Get simple answer from LLM via direct API *)
+let call_llm_and_broadcast ~sw ~agent_type ~prompt ~mention =
   let response = call_llm_direct_sync ~agent_type ~prompt in
-  debug_log (Printf.sprintf "LLM_RESPONSE: %s" (if String.length response > 100 then String.sub response 0 100 ^ "..." else response));
-
-  if response <> "" && response <> "no response" then begin
-    (* Step 2: Join MASC to get assigned nickname *)
-    let join_args = Printf.sprintf {|{"agent_name":"%s","capabilities":["llm-auto-responder"]}|} agent_type in
-    let join_resp = masc_call ~tool_name:"masc_join" ~args:join_args in
-    debug_log (Printf.sprintf "MASC_JOIN: %s" (if String.length join_resp > 200 then String.sub join_resp 0 200 ^ "..." else join_resp));
-
-    match extract_nickname join_resp with
-    | None ->
-        debug_log "MASC_JOIN_FAILED: Could not extract nickname";
-        Printf.eprintf "[Auto-Responder/LLM] Failed to join MASC\n%!"
-    | Some nickname ->
-        debug_log (Printf.sprintf "MASC_NICKNAME: %s" nickname);
-
-        (* Step 3: Broadcast response with proper nickname *)
-        let message = Printf.sprintf "@%s %s" mention (String.escaped response) in
-        let broadcast_args = Printf.sprintf {|{"agent_name":"%s","message":"%s"}|} nickname message in
-        let _ = masc_call ~tool_name:"masc_broadcast" ~args:broadcast_args in
-        debug_log "MASC_BROADCAST: sent";
-
-        (* Step 4: Leave MASC *)
-        let leave_args = Printf.sprintf {|{"agent_name":"%s"}|} nickname in
-        let _ = masc_call ~tool_name:"masc_leave" ~args:leave_args in
-        debug_log "MASC_LEAVE: done";
-
-        let short_resp = if String.length response > 50 then String.sub response 0 50 ^ "..." else response in
-        Printf.eprintf "[Auto-Responder/LLM] %s: %s\n%!" nickname short_resp
-  end else
+  debug_log (Printf.sprintf "LLM_RESPONSE: %s"
+    (if String.length response > 100 then String.sub response 0 100 ^ "..." else response));
+  if response = "" || response = "no response" then
     Printf.eprintf "[Auto-Responder/LLM] LLM returned empty response\n%!"
+  else begin
+    let join_args =
+      `Assoc [
+        ("agent_name", `String agent_type);
+        ("capabilities", `List [`String "llm-auto-responder"]);
+      ]
+    in
+    match masc_call ~sw ~tool_name:"masc_join" ~args:join_args with
+    | Error e ->
+        debug_log (Printf.sprintf "MASC_JOIN_FAILED: %s" e);
+        Printf.eprintf "[Auto-Responder/LLM] Failed to join MASC (%s)\n%!" e
+    | Ok join_resp -> (
+        debug_log (Printf.sprintf "MASC_JOIN: %s"
+          (if String.length join_resp > 200 then String.sub join_resp 0 200 ^ "..." else join_resp));
+        match extract_nickname join_resp with
+        | None ->
+            debug_log "MASC_JOIN_FAILED: Could not extract nickname";
+            Printf.eprintf "[Auto-Responder/LLM] Failed to join MASC (no nickname)\n%!"
+        | Some nickname ->
+            let msg = Printf.sprintf "@%s %s" mention response in
+            let broadcast_args = `Assoc [("agent_name", `String nickname); ("message", `String msg)] in
+            ignore (masc_call ~sw ~tool_name:"masc_broadcast" ~args:broadcast_args);
+            let leave_args = `Assoc [("agent_name", `String nickname)] in
+            ignore (masc_call ~sw ~tool_name:"masc_leave" ~args:leave_args);
+            let short_resp = if String.length response > 50 then String.sub response 0 50 ^ "..." else response in
+            Printf.eprintf "[Auto-Responder/LLM] %s: %s\n%!" nickname short_resp
+      )
+  end
 
-(** Run LLM call in background process (Thread.create doesn't work well with Eio)
-    Creates a shell script that does: LLM call -> MASC join -> broadcast -> leave.
-    Uses direct API calls (GLM/Ollama) — no llm-mcp dependency. *)
-let llm_call_in_background ~agent_type ~prompt ~mention ~base_path =
-  ignore base_path;
-  let masc_port = match Sys.getenv_opt "MASC_HTTP_PORT" with Some p -> p | None -> "8935" in
-  let masc_url = Printf.sprintf "http://127.0.0.1:%s/mcp" masc_port in
-  let escaped_prompt =
-    prompt
-    |> String.split_on_char '"' |> String.concat {|\\\"|}
-    |> String.split_on_char '\n' |> String.concat " "
-    |> String.split_on_char '\'' |> String.concat {|'\\''|}
-  in
-  (* MASC requires Accept header with both application/json and text/event-stream *)
-  let accept_header = "-H 'Accept: application/json, text/event-stream'" in
-  (* Determine LLM call based on agent_type — direct API, no llm-mcp *)
-  let llm_call_cmd = match agent_type with
-    | "glm" | "gemini" ->
-        (* GLM via Z.ai API — key from env var, not in command *)
-        let model = "glm-4.7" in
-        Printf.sprintf {|echo '{"model":"%s","messages":[{"role":"user","content":"%s"}],"stream":false}' | curl -s 'https://api.z.ai/api/coding/paas/v4/chat/completions' -H 'Content-Type: application/json' -H "Authorization: Bearer $ZAI_API_KEY" -d @- | jq -r '.choices[0].message.content // "no response"' | head -c 300|} model escaped_prompt
-    | "ollama" | "codex" | _ ->
-        (* Ollama local API *)
-        let model = Env_config.Ollama.default_model in
-        Printf.sprintf {|echo '{"model":"%s","prompt":"%s","stream":false}' | curl -s 'http://127.0.0.1:11434/api/generate' -H 'Content-Type: application/json' -d @- | jq -r '.response // "no response"' | head -c 300|} model escaped_prompt
-  in
-  let script = Printf.sprintf {|#!/bin/bash
-# LLM call in background for %s (direct API, no llm-mcp)
-set -e
+(* --- Public API --- *)
 
-# Step 1: Call LLM directly
-RESPONSE=$(%s)
-
-echo "[LLM] Response: $RESPONSE" >> /tmp/auto_debug.log
-
-if [ "$RESPONSE" = "no response" ] || [ -z "$RESPONSE" ]; then
-  echo "[LLM] Empty response, skipping MASC" >> /tmp/auto_debug.log
-  exit 0
-fi
-
-# Step 2: Join MASC (with Accept header for SSE support)
-JOIN_RESP=$(curl -s '%s' -H 'Content-Type: application/json' %s \
-  -d '{"jsonrpc":"2.0","method":"tools/call","id":1,"params":{"name":"masc_join","arguments":{"agent_name":"%s","capabilities":["llm-auto-responder"]}}}')
-
-# macOS compatible: use sed instead of grep -oP
-NICKNAME=$(echo "$JOIN_RESP" | sed -n 's/.*Nickname: \([a-z]*-[a-z]*-[a-z]*\).*/\1/p' | head -1)
-echo "[MASC] Nickname: $NICKNAME" >> /tmp/auto_debug.log
-
-if [ -z "$NICKNAME" ]; then
-  echo "[MASC] Failed to join, no nickname" >> /tmp/auto_debug.log
-  exit 1
-fi
-
-# Step 3: Broadcast (escape response for JSON)
-ESCAPED_RESP=$(echo "$RESPONSE" | sed 's/"/\\"/g' | tr '\n' ' ')
-curl -s '%s' -H 'Content-Type: application/json' %s \
-  -d "{\"jsonrpc\":\"2.0\",\"method\":\"tools/call\",\"id\":1,\"params\":{\"name\":\"masc_broadcast\",\"arguments\":{\"agent_name\":\"$NICKNAME\",\"message\":\"@%s $ESCAPED_RESP\"}}}" > /dev/null
-
-echo "[MASC] Broadcast sent" >> /tmp/auto_debug.log
-
-# Step 4: Leave
-curl -s '%s' -H 'Content-Type: application/json' %s \
-  -d "{\"jsonrpc\":\"2.0\",\"method\":\"tools/call\",\"id\":1,\"params\":{\"name\":\"masc_leave\",\"arguments\":{\"agent_name\":\"$NICKNAME\"}}}" > /dev/null
-
-echo "[MASC] Left room" >> /tmp/auto_debug.log
-|} agent_type llm_call_cmd masc_url accept_header agent_type masc_url accept_header mention masc_url accept_header
-  in
-  let script_file = Printf.sprintf "/tmp/llm_bg_%d_%d.sh"
-    (Unix.getpid ()) (int_of_float (Time_compat.now () *. 1000.) mod 10000) in
-  let log_file = Printf.sprintf "/tmp/llm_bg_%s_%d.log"
-    agent_type (int_of_float (Time_compat.now () *. 1000.) mod 10000) in
-  (let oc = open_out script_file in
-   Common.protect ~module_name:"auto_responder" ~finally_label:"finalizer" ~finally:(fun () -> close_out_noerr oc) (fun () ->
-     output_string oc script));
-  ignore (Unix.chmod script_file 0o755);
-  let bg_cmd = Printf.sprintf "nohup %s > %s 2>&1 &" script_file log_file in
-  debug_log (Printf.sprintf "LLM_BG_CMD: %s" bg_cmd);
-  let ret = run_system_nonblocking bg_cmd in
-  debug_log (Printf.sprintf "LLM_BG_RET: %s" (match ret with Unix.WEXITED n -> string_of_int n | _ -> "signal"))
-
-(** Maybe spawn a response agent if mention detected and enabled
-
-    Returns:
-    - Some task_id if spawn was triggered
-    - None if no spawn needed
-*)
-let maybe_respond ~base_path ~from_agent ~content ~mention =
+let maybe_respond ~sw ~base_path:_ ~from_agent ~content ~mention =
   let mode = get_mode () in
   let mode_str = match mode with Disabled -> "Disabled" | Spawn -> "Spawn" | Llm -> "Llm" in
   debug_log (Printf.sprintf "CALLED: from=%s mention=%s mode=%s enabled=%b"
@@ -367,7 +263,7 @@ let maybe_respond ~base_path ~from_agent ~content ~mention =
   | None ->
       debug_log "EXIT: No mention";
       None
-  | Some _m when not (is_enabled ()) ->
+  | Some _ when not (is_enabled ()) ->
       let env_val = match Sys.getenv_opt "MASC_AUTO_RESPOND" with Some v -> v | None -> "not set" in
       debug_log (Printf.sprintf "EXIT: Disabled (env=%s)" env_val);
       Printf.eprintf "[Auto-Responder] Disabled (MASC_AUTO_RESPOND=%s)\n%!" env_val;
@@ -376,52 +272,50 @@ let maybe_respond ~base_path ~from_agent ~content ~mention =
       let from_base = agent_type_of_mention from_agent in
       let mention_base = agent_type_of_mention m in
       debug_log (Printf.sprintf "CHECK: from_base=%s mention_base=%s spawnable=%b" from_base mention_base (is_spawnable m));
-      (* Prevent infinite loop: don't respond to same agent type *)
-      if from_base = mention_base then begin
+      if from_base = mention_base then (
         debug_log "EXIT: Self-mention";
         Printf.eprintf "[Auto-Responder] Skip self-mention @%s from %s\n%!" m from_agent;
         None
-      end
-      else if not (is_spawnable m) then begin
+      ) else if not (is_spawnable m) then (
         debug_log "EXIT: Not spawnable";
         activity_log ~mode ~from_agent ~mention:m ~status:"SKIP" ~detail:"Not spawnable agent type";
         Printf.eprintf "[Auto-Responder] @%s not spawnable\n%!" m;
         None
-      end
-      else if should_throttle ~agent_type:mention_base then begin
+      ) else if should_throttle ~agent_type:mention_base then (
         debug_log "EXIT: Throttled";
-        activity_log ~mode ~from_agent ~mention:m ~status:"THROTTLE" ~detail:(Printf.sprintf "Max %d responses per %.0fs" chain_limit chain_window);
+        activity_log ~mode ~from_agent ~mention:m ~status:"THROTTLE"
+          ~detail:(Printf.sprintf "Max %d responses per %.0fs" chain_limit chain_window);
         Printf.eprintf "[Auto-Responder] Throttled @%s (chain limit)\n%!" m;
         None
-      end
-      else begin
-        let prompt = build_response_prompt ~from_agent ~content ~mention:m in
-        let task_id = Printf.sprintf "auto-respond-%s-%d" mention_base
-          (int_of_float (Time_compat.now () *. 1000.) mod 10000) in
+      ) else (
+        let task_id =
+          Printf.sprintf "auto-respond-%s-%d" mention_base
+            (int_of_float (Time_compat.now () *. 1000.) mod 10000)
+        in
         debug_log (Printf.sprintf "DISPATCH: mode=%s task_id=%s" mode_str task_id);
-        (* Mode-based dispatch *)
-        (match mode with
-        | Llm ->
-            debug_log "ACTION: LLM call";
-            activity_log ~mode ~from_agent ~mention:m ~status:"LLM" ~detail:task_id;
-            Printf.eprintf "[Auto-Responder/LLM] Fast-calling %s for @%s\n%!" mention_base m;
-            (* LLM mode: run in background process (Thread.create doesn't work well with Eio) *)
-            llm_call_in_background ~agent_type:mention_base ~prompt:content ~mention:from_agent ~base_path
-        | Spawn ->
-            (* glm has no CLI - use LLM mode approach (auto-responder handles MASC) *)
-            if mention_base = "glm" then begin
-              debug_log "ACTION: LLM call (glm has no CLI)";
-              activity_log ~mode ~from_agent ~mention:m ~status:"LLM-GLM" ~detail:task_id;
-              Printf.eprintf "[Auto-Responder/LLM-GLM] Fast-calling glm for @%s\n%!" m;
-              (* Run in background process *)
-              llm_call_in_background ~agent_type:"glm" ~prompt:content ~mention:from_agent ~base_path
-            end else begin
-              debug_log "ACTION: Spawn";
-              activity_log ~mode ~from_agent ~mention:m ~status:"SPAWN" ~detail:task_id;
-              Printf.eprintf "[Auto-Responder/Spawn] Spawning %s for @%s from %s\n%!" mention_base m from_agent;
-              spawn_in_background ~agent_type:mention_base ~prompt ~working_dir:base_path
-            end
-        | Disabled ->
-            debug_log "ACTION: Mode disabled (should not reach here)");
+        activity_log ~mode ~from_agent ~mention:m
+          ~status:(match mode with Spawn -> "SPAWN" | Llm -> "LLM" | Disabled -> "OFF")
+          ~detail:task_id;
+        Eio.Fiber.fork ~sw (fun () ->
+          try
+            match mode with
+            | Disabled -> ()
+            | Llm ->
+                Printf.eprintf "[Auto-Responder/LLM] Calling %s for @%s\n%!" mention_base m;
+                call_llm_and_broadcast ~sw ~agent_type:mention_base ~prompt:content ~mention:from_agent
+            | Spawn ->
+                if mention_base = "glm" then (
+                  (* No CLI for glm; use LLM mode path. *)
+                  Printf.eprintf "[Auto-Responder/LLM-GLM] Calling glm for @%s\n%!" m;
+                  call_llm_and_broadcast ~sw ~agent_type:"glm" ~prompt:content ~mention:from_agent
+                ) else (
+                  let prompt = build_response_prompt ~from_agent ~content ~mention:m in
+                  Printf.eprintf "[Auto-Responder/Spawn] Spawning %s for @%s from %s\n%!" mention_base m from_agent;
+                  run_cli_agent ~agent_type:mention_base ~prompt
+                )
+          with exn ->
+            debug_log (Printf.sprintf "ERROR: %s" (Printexc.to_string exn))
+        );
         Some task_id
-      end
+      )
+

--- a/lib/council/conversation.ml
+++ b/lib/council/conversation.ml
@@ -79,8 +79,8 @@ let list_dir_safe dir =
 
 (** {1 Directory Management} *)
 
-let masc_dir _config =
-  Sys.getcwd () ^ "/.masc"
+let masc_dir (config : config) =
+  Filename.concat config.base_path ".masc"
 
 let conversations_dir config =
   Filename.concat (masc_dir config) "conversations"

--- a/lib/llm_direct.ml
+++ b/lib/llm_direct.ml
@@ -7,23 +7,14 @@ open Printf
 
 (* ---------- Helpers ---------- *)
 
-(** Write string to tmp file with restricted permissions, return path.
-    Uses Filename.temp_file for uniqueness (PID + counter).
-    Permissions: 0o600 (owner-only) to prevent credential leakage. *)
-let write_tmp ~prefix content =
-  let path = Filename.temp_file prefix ".json" in
-  let fd = Unix.openfile path [Unix.O_WRONLY; Unix.O_TRUNC] 0o600 in
-  Fun.protect ~finally:(fun () -> Unix.close fd) (fun () ->
-    let _ = Unix.write_substring fd content 0 (String.length content) in ());
-  path
-
-(** Run shell command with guaranteed tmp file cleanup. *)
-let run_with_cleanup ~tmp_files ~timeout_sec cmd =
-  let cleanup () = List.iter (fun f ->
-    try Sys.remove f with Sys_error _ -> ()
-  ) tmp_files in
-  Fun.protect ~finally:cleanup (fun () ->
-    Process_eio.run ~timeout_sec cmd)
+let env_set (env : string array) (k : string) (v : string) : string array =
+  let prefix = k ^ "=" in
+  let rest =
+    env
+    |> Array.to_list
+    |> List.filter (fun kv -> not (String.starts_with ~prefix kv))
+  in
+  Array.of_list ((prefix ^ v) :: rest)
 
 (** Strip [Extra] metadata and hook outputs from LLM responses. *)
 let strip_extra s =
@@ -97,20 +88,22 @@ let call_glm ?(api_key="") ~model ~prompt ~timeout_sec ~max_chars () =
 (** Call Claude CLI as subprocess.
     Uses CLAUDE_CODE_OAUTH_TOKEN env var for auth. *)
 let call_claude_cli ?(api_key="") ~model ~prompt ~timeout_sec ~max_chars () =
-  (* Set up env: if api_key provided, inject as CLAUDE_CODE_OAUTH_TOKEN *)
-  let env_prefix = if api_key <> "" then
-    sprintf "CLAUDE_CODE_OAUTH_TOKEN=%s " (Filename.quote api_key)
-  else "" in
-  (* Write prompt to tmp file to avoid shell escaping issues *)
-  let tmp_prompt = write_tmp ~prefix:"llm_direct_claude_prompt" prompt in
-  let cmd = sprintf
-    "TMPDIR=/tmp/claude-safe && mkdir -p $TMPDIR && \
-     %sclaude -p --model %s --max-turns 1 < %s 2>/dev/null | head -c %d"
-    env_prefix (Filename.quote model) tmp_prompt max_chars
+  let env =
+    let env = Unix.environment () in
+    let env = env_set env "TMPDIR" "/tmp/claude-safe" in
+    if api_key = "" then env else env_set env "CLAUDE_CODE_OAUTH_TOKEN" api_key
   in
-  let result = run_with_cleanup ~tmp_files:[tmp_prompt]
-    ~timeout_sec:(Float.of_int timeout_sec +. 5.0) cmd in
-  strip_extra result
+  let raw =
+    Process_eio.run_argv_with_stdin
+      ~timeout_sec:(Float.of_int timeout_sec +. 5.0)
+      ~env
+      ~stdin_content:prompt
+      ["claude"; "-p"; "--model"; model; "--max-turns"; "1"]
+  in
+  let truncated =
+    if String.length raw > max_chars then String.sub raw 0 max_chars else raw
+  in
+  strip_extra truncated
 
 (* ---------- Ollama ---------- *)
 

--- a/lib/lodge_heartbeat.ml
+++ b/lib/lodge_heartbeat.ml
@@ -371,7 +371,7 @@ let needs_rewrite ~name =
       let usage = float_of_int ctx.token_count /. float_of_int ctx.max_tokens in
       usage >= ctx.rewrite_threshold
 
-(** Forward reference for rewrite_context (defined after run_shell_nonblocking) *)
+(** Forward reference for rewrite_context (defined later) *)
 let rewrite_context_ref : (name:string -> unit) ref = ref (fun ~name:_ -> ())
 
 (** Rewrite context - calls forward reference *)
@@ -411,27 +411,38 @@ let cleanup_inactive_lodge_agents () =
   (* Cleanup happens automatically via timeout check in is_agent_active *)
   ()
 
-(** {1 Non-blocking Shell Execution} *)
+(** {1 External CLI helpers (argv-based, no shell)} *)
 
-(** Run shell command via Eio-native process execution.
-    Delegates to Process_eio.run (global proc_mgr/clock). *)
-let run_shell_nonblocking cmd =
-  Process_eio.run ~timeout_sec:60.0 cmd
+let sb_path () =
+  match Sys.getenv_opt "ME_ROOT" with
+  | Some root -> Printf.sprintf "%s/scripts/sb" root
+  | None -> (
+      match Sys.getenv_opt "HOME" with
+      | Some home -> Printf.sprintf "%s/me/scripts/sb" home
+      | None -> "./scripts/sb")
 
 (** curl-based GraphQL request — reliable DNS resolution in Railway containers *)
 let graphql_request_curl body : (string, string) Stdlib.result =
   let default_url = "https://second-brain-graphql-production.up.railway.app/graphql" in
   let url = Sys.getenv_opt "GRAPHQL_URL" |> Option.value ~default:default_url in
   let api_key = Sys.getenv_opt "GRAPHQL_API_KEY" |> Option.value ~default:"" in
-  let escaped_body = String.concat "\\\"" (String.split_on_char '"' body) in
-  let auth_header = if api_key = "" then "" else Printf.sprintf "-H 'Authorization: Bearer %s'" api_key in
-  let cmd = Printf.sprintf "curl -s -m 10 '%s' -H 'Content-Type: application/json' %s -d \"%s\"" url auth_header escaped_body in
+  if api_key = "" then
+    Error "GRAPHQL_API_KEY not set"
+  else
+  let argv =
+    [ "curl"; "-s"; "-m"; "10"; url;
+      "-H"; "Content-Type: application/json"
+    ]
+    |> fun base -> base @ [ "-H"; "Authorization: Bearer " ^ api_key ]
+    |> fun with_auth ->
+    (* Read request body from stdin to avoid quoting/escaping issues. *)
+    with_auth @ [ "-d"; "@-" ]
+  in
   try
-    let ic = Unix.open_process_in cmd in
-    let output = In_channel.input_all ic in
-    let _ = Unix.close_process_in ic in
-    if String.length output = 0 then Error "curl: empty response"
-    else Ok output
+    let output =
+      Process_eio.run_argv_with_stdin ~timeout_sec:15.0 ~stdin_content:body argv
+    in
+    if String.length output = 0 then Error "curl: empty response" else Ok output
   with exn -> Error (Printf.sprintf "curl: %s" (Printexc.to_string exn))
 
 (** GraphQL request via Cohttp_eio with curl fallback.
@@ -440,6 +451,9 @@ let graphql_request ?(timeout_sec=5.0) body : (string, string) Stdlib.result =
   let default_url = "https://second-brain-graphql-production.up.railway.app/graphql" in
   let url = Sys.getenv_opt "GRAPHQL_URL" |> Option.value ~default:default_url in
   let api_key = Sys.getenv_opt "GRAPHQL_API_KEY" |> Option.value ~default:"" in
+  if api_key = "" then
+    Error "GRAPHQL_API_KEY not set"
+  else
   let max_response_bytes = 1_000_000 in
   let suppress_body _s = "body suppressed" in
   let cohttp_result = match Eio_context.get_net_opt () with
@@ -518,13 +532,7 @@ let utf8_truncate s max_bytes =
     String.sub s 0 end_pos
   end
 
-(** Run shell command and get all output (up to 500 chars) *)
-let run_shell_line cmd =
-  let output = Process_eio.run ~timeout_sec:10.0 cmd in
-  let s = String.trim output in
-  if String.length s > 4000 then String.sub s 0 4000 else s
-
-(** Initialize rewrite_context implementation (now that run_shell_nonblocking is available) *)
+(** Initialize rewrite_context implementation *)
 let () =
   rewrite_context_ref := fun ~name ->
     match Hashtbl.find_opt agent_contexts name with
@@ -869,10 +877,8 @@ let create_agent_in_neo4j ~name ~traits ~description ~preferred_hours =
     "MERGE (a:Agent {name: '%s'}) SET a.traits = [%s], a.description = '%s', a.preferred_hours = [%s], a.activity_level = 0.7, a.created_at = datetime(), a.created_by = 'ecosystem_evolution' RETURN a.name"
     (esc name) traits_str (esc description) hours_str
   in
-  let me_root = Sys.getenv_opt "ME_ROOT" |> Option.value ~default:"/Users/dancer/me" in
-  let cmd = Printf.sprintf "cd %s && sb neo4j query %s 2>/dev/null"
-    (Filename.quote me_root) (Filename.quote query) in
-  let result = run_shell_nonblocking cmd in
+  let sb = sb_path () in
+  let result = Process_eio.run_argv ~timeout_sec:30.0 [sb; "neo4j"; "query"; query] in
   if String.length result > 0 && not (String.sub result 0 (min 5 (String.length result)) = "Error") then begin
     Eio.traceln "   ✅ [Neo4j] Agent '%s' created successfully" name;
     (* Invalidate cache so new agent is loaded *)
@@ -1369,11 +1375,10 @@ let load_agent_profile ~agent_name : agent_profile =
   | Some (profile, ts) when now -. ts < profile_cache_ttl -> profile
   | _ ->
     let profile =
-      let cmd = Printf.sprintf
-        "cd /Users/dancer/me && ./scripts/sb graphql agent %s 2>/dev/null"
-        agent_name
+      let sb = sb_path () in
+      let json_str =
+        Process_eio.run_argv ~timeout_sec:30.0 [sb; "graphql"; "agent"; agent_name]
       in
-      let json_str = run_shell_nonblocking cmd in
       try
         let json = Yojson.Safe.from_string json_str in
         let open Yojson.Safe.Util in
@@ -2788,10 +2793,8 @@ let trigger_heartbeat room_config =
 (** Load agent specialties dynamically from Neo4j *)
 let load_agent_specialties_from_neo4j () =
   let query = "MATCH (a:Agent) WHERE a.traits IS NOT NULL RETURN a.name, a.traits, a.description" in
-  let me_root = Sys.getenv_opt "ME_ROOT" |> Option.value ~default:"/Users/dancer/me" in
-  let cmd = Printf.sprintf "cd %s && sb neo4j query %s 2>/dev/null"
-    (Filename.quote me_root) (Filename.quote query) in
-  let json_str = run_shell_nonblocking cmd in
+  let sb = sb_path () in
+  let json_str = Process_eio.run_argv ~timeout_sec:30.0 [sb; "neo4j"; "query"; query] in
   try
     let json = Yojson.Safe.from_string json_str in
     let records = Yojson.Safe.Util.(json |> member "records" |> to_list) in

--- a/lib/lodge_memory.ml
+++ b/lib/lodge_memory.ml
@@ -45,15 +45,21 @@ let graphql_request_curl body : (string, string) Stdlib.result =
   let default_url = "https://second-brain-graphql-production.up.railway.app/graphql" in
   let url = Sys.getenv_opt "GRAPHQL_URL" |> Option.value ~default:default_url in
   let api_key = Sys.getenv_opt "GRAPHQL_API_KEY" |> Option.value ~default:"" in
-  let escaped_body = String.concat "\\\"" (String.split_on_char '"' body) in
-  let auth_header = if api_key = "" then "" else Printf.sprintf "-H 'Authorization: Bearer %s'" api_key in
-  let cmd = Printf.sprintf "curl -s -m 10 '%s' -H 'Content-Type: application/json' %s -d \"%s\"" url auth_header escaped_body in
+  let argv =
+    [ "curl"; "-s"; "-m"; "10"; url;
+      "-H"; "Content-Type: application/json"
+    ]
+    |> fun base ->
+    if api_key = "" then base else base @ [ "-H"; "Authorization: Bearer " ^ api_key ]
+    |> fun with_auth ->
+    (* Read request body from stdin to avoid quoting/escaping issues. *)
+    with_auth @ [ "-d"; "@-" ]
+  in
   try
-    let ic = Unix.open_process_in cmd in
-    let output = In_channel.input_all ic in
-    let _ = Unix.close_process_in ic in
-    if String.length output = 0 then Error "curl: empty response"
-    else Ok output
+    let output =
+      Process_eio.run_argv_with_stdin ~timeout_sec:15.0 ~stdin_content:body argv
+    in
+    if String.length output = 0 then Error "curl: empty response" else Ok output
   with exn -> Error (Printf.sprintf "curl: %s" (Printexc.to_string exn))
 
 (** GraphQL request via Cohttp_eio with curl fallback.

--- a/lib/mcp_server_eio.ml
+++ b/lib/mcp_server_eio.ml
@@ -1324,6 +1324,7 @@ let execute_tool_eio ~sw ~clock ?mcp_session_id ?auth_token state ~name ~argumen
           ]);
         (* Auto-Responder: spawn mentioned agent if enabled *)
         let _ = Auto_responder.maybe_respond
+          ~sw
           ~base_path:config.base_path
           ~from_agent:agent_name
           ~content:message

--- a/lib/notify.ml
+++ b/lib/notify.ml
@@ -18,16 +18,15 @@ type focus_payload = {
 
 (** {1 Non-blocking Shell Execution} *)
 
-(** Run shell command and get single line (Eio-native) *)
-let run_shell_line cmd =
-  let output = Process_eio.run ~timeout_sec:10.0 cmd in
+(** Run argv and get single line (Eio-native, no shell) *)
+let run_argv_line argv =
+  let output = Process_eio.run_argv ~timeout_sec:10.0 argv in
   match String.split_on_char '\n' output with
   | [] -> ""
-  | h :: _ -> h
+  | h :: _ -> String.trim h
 
-(** Run system command in background (Eio-native) *)
-let run_system_nonblocking cmd =
-  ignore (Process_eio.run ~timeout_sec:60.0 cmd)
+let run_argv_ignore argv =
+  ignore (Process_eio.run_argv_with_status ~timeout_sec:60.0 argv)
 
 (** Get non-empty environment variable *)
 let getenv_nonempty name =
@@ -71,14 +70,14 @@ let render_focus_template template payload =
 (** Check if running on macOS *)
 let is_macos () =
   try
-    let os = run_shell_line "uname -s" in
+    let os = run_argv_line ["uname"; "-s"] in
     os = "Darwin"
   with End_of_file | Unix.Unix_error _ -> false
 
 (** Check if terminal-notifier is available *)
 let has_terminal_notifier =
   lazy (
-    let result = run_shell_line "which terminal-notifier 2>/dev/null" in
+    let result = run_argv_line ["which"; "terminal-notifier"] in
     result <> ""
   )
 
@@ -156,20 +155,18 @@ let agent_emoji = function
 
 (** Send notification via terminal-notifier (preferred) *)
 let send_via_terminal_notifier ~title ~subtitle ~message ~sound ~focus_cmd =
-  let title = escape_shell title in
-  let subtitle = escape_shell subtitle in
-  let message = escape_shell message in
-  let sound_arg = if sound then "-sound default" else "" in
-  let focus_arg = match focus_cmd with
-    | Some cmd -> Printf.sprintf " -execute '%s'" (escape_shell cmd)
-    | None -> ""
+  let argv =
+    ["terminal-notifier";
+     "-title"; title;
+     "-subtitle"; subtitle;
+     "-message"; message;
+     "-group"; "masc"]
+    |> fun base -> if sound then base @ ["-sound"; "default"] else base
+    |> fun base -> match focus_cmd with
+      | Some cmd -> base @ ["-execute"; cmd]
+      | None -> base
   in
-  let cmd = Printf.sprintf
-    "terminal-notifier -title '%s' -subtitle '%s' -message '%s' -group masc %s%s >/dev/null 2>&1 &"
-    title subtitle message sound_arg focus_arg
-  in
-  run_system_nonblocking cmd;
-  ()
+  run_argv_ignore argv
 
 (** Send notification via osascript (fallback) *)
 let send_via_osascript ~title ~subtitle ~message =
@@ -180,16 +177,7 @@ let send_via_osascript ~title ~subtitle ~message =
     "display notification \"%s\" with title \"%s\" subtitle \"%s\""
     message title subtitle
   in
-  let cmd = Printf.sprintf "osascript -e %s 2>/dev/null &" (Filename.quote script) in
-  run_system_nonblocking cmd;
-  ()
-
-let run_focus_command = function
-  | Some cmd ->
-      let cmd = Printf.sprintf "%s >/dev/null 2>&1 &" cmd in
-      run_system_nonblocking cmd;
-      ()
-  | None -> ()
+  run_argv_ignore ["osascript"; "-e"; script]
 
 (** Send macOS notification - uses terminal-notifier if available *)
 let send_notification ?(sound=false) ?focus_cmd ~title ~subtitle ~message () =
@@ -200,8 +188,10 @@ let send_notification ?(sound=false) ?focus_cmd ~title ~subtitle ~message () =
     send_via_terminal_notifier ~title ~subtitle ~message ~sound ~focus_cmd
   else begin
     send_via_osascript ~title ~subtitle ~message;
-    if focus_on_osascript () then
-      run_focus_command focus_cmd
+    ignore (focus_on_osascript ());
+    (* NOTE: For osascript fallback, we intentionally do not execute focus_cmd.
+       focus_cmd can contain arbitrary shell snippets (user-configured) and would
+       require `sh -c` execution. terminal-notifier handles click actions. *)
   end
 
 (** Send notification for MASC event *)

--- a/lib/process_eio.ml
+++ b/lib/process_eio.ml
@@ -1,103 +1,15 @@
 (** Async process execution helpers for Eio
 
-    Replaces blocking Unix.open_process_in calls with Eio-native async execution.
-    This prevents blocking the HTTP server when running external commands.
+    - argv-only APIs (no shell)
+    - Global proc_mgr/clock initialized once from main_eio.ml
+
+    This module is used by tool handlers where we want:
+    - Non-blocking execution (Eio fibers)
+    - Injection safety (no `sh -c`)
+    - Consistent output capture (stdout only)
 *)
 
-(** Run a shell command and capture stdout.
-    Returns the output as a string, or empty string on failure.
-
-    @param sw The Eio switch for resource management
-    @param proc_mgr The Eio process manager
-    @param cmd The shell command to run
-    @param timeout_sec Optional timeout in seconds (default: 30.0)
-*)
-let run_capture_stdout ~sw:_sw ~proc_mgr ~clock ?(timeout_sec=30.0) cmd : string =
-  let buf = Buffer.create 1024 in
-  try
-    Eio.Time.with_timeout_exn clock timeout_sec (fun () ->
-      Eio.Process.run proc_mgr
-        ~stdout:(Eio.Flow.buffer_sink buf)
-        ["sh"; "-c"; cmd];
-      Buffer.contents buf
-    )
-  with
-  | Eio.Time.Timeout ->
-      Eio.traceln "[Process] Timeout after %.0fs: %s" timeout_sec cmd;
-      ""
-  | exn ->
-      Eio.traceln "[Process] Error running command: %s - %s" cmd (Printexc.to_string exn);
-      ""
-
-(** Run a shell command and capture stdout with clock parameter.
-    Use this when you have access to the clock.
-*)
-let run_capture_stdout_with_clock ~sw:_sw ~proc_mgr ~clock ?(timeout_sec=30.0) cmd : string =
-  let buf = Buffer.create 1024 in
-  try
-    Eio.Time.with_timeout_exn clock timeout_sec (fun () ->
-      Eio.Process.run proc_mgr
-        ~stdout:(Eio.Flow.buffer_sink buf)
-        ["sh"; "-c"; cmd];
-      Buffer.contents buf
-    )
-  with
-  | Eio.Time.Timeout ->
-      Eio.traceln "[Process] Timeout after %.0fs: %s" timeout_sec cmd;
-      ""
-  | exn ->
-      Eio.traceln "[Process] Error running command: %s - %s" cmd (Printexc.to_string exn);
-      ""
-
-(** Run a shell command and return exit status.
-    Returns true if command succeeded (exit code 0).
-*)
-let run_status ~sw:_sw ~proc_mgr ~clock ?(timeout_sec=30.0) cmd : bool =
-  try
-    Eio.Time.with_timeout_exn clock timeout_sec (fun () ->
-      Eio.Process.run proc_mgr ["sh"; "-c"; cmd];
-      true
-    )
-  with
-  | Eio.Time.Timeout ->
-      Eio.traceln "[Process] Timeout after %.0fs: %s" timeout_sec cmd;
-      false
-  | _ -> false
-
-(** Run command with stdin input and capture stdout *)
-let run_with_stdin ~sw:_sw ~proc_mgr ~clock ?(timeout_sec=30.0) ~stdin_content cmd : string =
-  let stdout_buf = Buffer.create 1024 in
-  try
-    Eio.Time.with_timeout_exn clock timeout_sec (fun () ->
-      Eio.Process.run proc_mgr
-        ~stdin:(Eio.Flow.string_source stdin_content)
-        ~stdout:(Eio.Flow.buffer_sink stdout_buf)
-        ["sh"; "-c"; cmd];
-      Buffer.contents stdout_buf
-    )
-  with
-  | Eio.Time.Timeout ->
-      Eio.traceln "[Process] Timeout after %.0fs: %s" timeout_sec cmd;
-      ""
-  | exn ->
-      Eio.traceln "[Process] Error: %s - %s" cmd (Printexc.to_string exn);
-      ""
-
-(** Read all lines from a process output (replacement for input_line loop) *)
-let read_all_lines ~sw:_sw ~proc_mgr ~clock ?(timeout_sec=30.0) cmd : string list =
-  let output = run_capture_stdout_with_clock ~sw:_sw ~proc_mgr ~clock ~timeout_sec cmd in
-  String.split_on_char '\n' output
-  |> List.filter (fun s -> String.length s > 0)
-
-(** Run command in background (fire and forget) *)
-let run_detached ~sw ~proc_mgr cmd : unit =
-  Eio.Fiber.fork ~sw (fun () ->
-    try
-      Eio.Process.run proc_mgr ["sh"; "-c"; cmd ^ " &"]
-    with _ -> ()
-  )
-
-(* ── Global state (initialized once from main_eio.ml) ──────────── *)
+(** ── Global state (initialized once from main_eio.ml) ──────────── *)
 
 let _proc_mgr : Eio_unix.Process.mgr_ty Eio.Resource.t option ref = ref None
 let _clock : float Eio.Time.clock_ty Eio.Resource.t option ref = ref None
@@ -108,188 +20,198 @@ let init ~proc_mgr ~clock =
 
 let is_initialized () = Option.is_some !_proc_mgr
 
-let get_proc_mgr () = match !_proc_mgr with
+let get_proc_mgr () =
+  match !_proc_mgr with
   | Some pm -> pm
   | None -> failwith "Process_eio.init not called"
 
-let get_clock () = match !_clock with
+let get_clock () =
+  match !_clock with
   | Some c -> c
   | None -> failwith "Process_eio.init not called"
 
-(* ── Unix fallback for tests (when Eio not initialized) ──────────── *)
+(** ── Unix fallback for tests (when Eio not initialized) ──────────── *)
 
-let run_unix_fallback cmd =
-  try
-    let ic = Unix.open_process_in cmd in
-    Fun.protect ~finally:(fun () -> ignore (Unix.close_process_in ic)) (fun () ->
-      In_channel.input_all ic
-    )
-  with _ -> ""
+let run_unix_argv_fallback (argv : string list) : string =
+  match argv with
+  | [] -> ""
+  | prog :: _ ->
+      (try
+         let ic = Unix.open_process_args_in prog (Array.of_list argv) in
+         Fun.protect
+           ~finally:(fun () -> ignore (Unix.close_process_in ic))
+           (fun () -> In_channel.input_all ic)
+       with _ -> "")
 
-let run_unix_fallback_with_status cmd =
-  try
-    let ic, oc, ec = Unix.open_process_full cmd (Unix.environment ()) in
-    let output = In_channel.input_all ic in
-    close_out_noerr oc;
-    ignore (In_channel.input_all ec);
-    let status = Unix.close_process_full (ic, oc, ec) in
-    (status, output)
-  with _ -> (Unix.WEXITED 1, "")
+let run_unix_argv_with_status_fallback (argv : string list) : Unix.process_status * string =
+  match argv with
+  | [] -> (Unix.WEXITED 1, "")
+  | prog :: _ ->
+      (try
+         let ic = Unix.open_process_args_in prog (Array.of_list argv) in
+         let output = In_channel.input_all ic in
+         let status = Unix.close_process_in ic in
+         (status, output)
+       with _ -> (Unix.WEXITED 1, ""))
 
-(* ── Eio-native replacements for run_in_systhread ──────────────── *)
+let run_unix_argv_with_stdin_fallback ~(stdin_content : string) (argv : string list) : string =
+  match argv with
+  | [] -> ""
+  | prog :: _ ->
+      (try
+         let stdin_r, stdin_w = Unix.pipe () in
+         let stdout_r, stdout_w = Unix.pipe () in
+         let args = Array.of_list argv in
+         let pid = Unix.create_process prog args stdin_r stdout_w Unix.stderr in
+         Unix.close stdin_r;
+         Unix.close stdout_w;
+         Fun.protect
+           ~finally:(fun () -> try Unix.close stdin_w with _ -> ())
+           (fun () ->
+             let rec write_all off =
+               if off < String.length stdin_content then begin
+                 let n =
+                   Unix.write_substring stdin_w stdin_content off (String.length stdin_content - off)
+                 in
+                 write_all (off + n)
+               end
+             in
+             write_all 0);
+         let ic = Unix.in_channel_of_descr stdout_r in
+         let output = In_channel.input_all ic in
+         In_channel.close ic;
+         ignore (Unix.waitpid [] pid);
+         output
+       with _ -> "")
 
-(** Run a shell command, capture stdout. Empty on timeout/error.
-    Uses Eio.Process.run (raises on non-zero exit → caught).
-    Falls back to Unix when Eio not initialized (for tests). *)
-let run ?(timeout_sec=60.0) cmd =
-  if not (is_initialized ()) then run_unix_fallback cmd
-  else begin
-    let pm = get_proc_mgr () and clk = get_clock () in
-    let buf = Buffer.create 1024 in
-    try
-      Eio.Time.with_timeout_exn clk timeout_sec (fun () ->
-        Eio.Process.run pm
-          ~stdout:(Eio.Flow.buffer_sink buf)
-          ["sh"; "-c"; cmd];
-        Buffer.contents buf)
-    with
-    | Eio.Time.Timeout ->
-      Eio.traceln "[Process_eio] Timeout after %.0fs: %s" timeout_sec cmd; ""
-    | exn ->
-      Eio.traceln "[Process_eio] Error: %s — %s" cmd (Printexc.to_string exn); ""
-  end
+let run_unix_argv_with_stdin_and_status_fallback
+    ~(stdin_content : string)
+    (argv : string list) : Unix.process_status * string =
+  match argv with
+  | [] -> (Unix.WEXITED 1, "")
+  | prog :: _ ->
+      (try
+         let stdin_r, stdin_w = Unix.pipe () in
+         let stdout_r, stdout_w = Unix.pipe () in
+         let args = Array.of_list argv in
+         let pid = Unix.create_process prog args stdin_r stdout_w Unix.stderr in
+         Unix.close stdin_r;
+         Unix.close stdout_w;
+         Fun.protect
+           ~finally:(fun () -> try Unix.close stdin_w with _ -> ())
+           (fun () ->
+             let rec write_all off =
+               if off < String.length stdin_content then begin
+                 let n =
+                   Unix.write_substring stdin_w stdin_content off (String.length stdin_content - off)
+                 in
+                 write_all (off + n)
+               end
+             in
+             write_all 0);
+         let ic = Unix.in_channel_of_descr stdout_r in
+         let output = In_channel.input_all ic in
+         In_channel.close ic;
+         let (_pid, status) = Unix.waitpid [] pid in
+         (status, output)
+       with _ -> (Unix.WEXITED 1, ""))
 
-(* Unix fallback for argv-based commands *)
-let run_unix_argv_fallback argv =
-  try
-    let cmd = List.hd argv in
-    let args = Array.of_list argv in
-    let ic = Unix.open_process_args_in cmd args in
-    Fun.protect ~finally:(fun () -> ignore (Unix.close_process_in ic)) (fun () ->
-      In_channel.input_all ic
-    )
-  with _ -> ""
+(** ── Eio-native process execution (global refs) ─────────────────── *)
 
-let run_unix_argv_with_status_fallback argv =
-  try
-    let cmd = List.hd argv in
-    let args = Array.of_list argv in
-    let ic = Unix.open_process_args_in cmd args in
-    let output = In_channel.input_all ic in
-    let status = Unix.close_process_in ic in
-    (status, output)
-  with _ -> (Unix.WEXITED 1, "")
-
-(** Run a command with explicit argv (NO shell). Safe from injection.
-    Use this instead of [run] when the command doesn't need pipes/redirects.
-
-    Example: [run_argv ~timeout_sec:10.0 ["curl"; "-s"; url]]
-
-    @since 2.45.0 *)
-let run_argv ?(timeout_sec=60.0) argv =
+let run_argv ?(timeout_sec = 60.0) ?env (argv : string list) : string =
   if not (is_initialized ()) then run_unix_argv_fallback argv
-  else begin
+  else
     let pm = get_proc_mgr () and clk = get_clock () in
     let buf = Buffer.create 1024 in
     let label = String.concat " " (List.map Filename.quote argv) in
     try
       Eio.Time.with_timeout_exn clk timeout_sec (fun () ->
-        Eio.Process.run pm
-          ~stdout:(Eio.Flow.buffer_sink buf)
-          argv;
+        Eio.Process.run pm ?env ~stdout:(Eio.Flow.buffer_sink buf) argv;
         Buffer.contents buf)
     with
     | Eio.Time.Timeout ->
-      Eio.traceln "[Process_eio] Timeout after %.0fs: %s" timeout_sec label; ""
+        Eio.traceln "[Process_eio] Timeout after %.0fs: %s" timeout_sec label;
+        ""
     | exn ->
-      Eio.traceln "[Process_eio] argv error: %s — %s" label (Printexc.to_string exn); ""
-  end
+        Eio.traceln "[Process_eio] argv error: %s — %s" label (Printexc.to_string exn);
+        ""
 
-(** Run a command with explicit argv and stdin input (NO shell).
-    Body is piped to the process's stdin.
-
-    Example: [run_argv_with_stdin ~stdin_content:json_body ["curl"; "-s"; "-d"; "@-"; url]]
-
-    @since 2.45.0 *)
-let run_argv_with_stdin ?(timeout_sec=60.0) ~stdin_content argv =
-  if not (is_initialized ()) then begin
-    (* Fallback: write stdin to temp file and use shell *)
-    let tmp = Filename.temp_file "stdin_" ".txt" in
-    Fun.protect ~finally:(fun () -> try Sys.remove tmp with _ -> ()) (fun () ->
-      Out_channel.with_open_bin tmp (fun oc -> Out_channel.output_string oc stdin_content);
-      let cmd = Printf.sprintf "%s < %s" (String.concat " " (List.map Filename.quote argv)) (Filename.quote tmp) in
-      run_unix_fallback cmd
-    )
-  end else begin
+let run_argv_with_stdin ?(timeout_sec = 60.0) ?env ~(stdin_content : string) (argv : string list) : string =
+  if not (is_initialized ()) then run_unix_argv_with_stdin_fallback ~stdin_content argv
+  else
     let pm = get_proc_mgr () and clk = get_clock () in
     let buf = Buffer.create 1024 in
     let label = String.concat " " (List.map Filename.quote argv) in
     try
       Eio.Time.with_timeout_exn clk timeout_sec (fun () ->
-        Eio.Process.run pm
+        Eio.Process.run pm ?env
           ~stdin:(Eio.Flow.string_source stdin_content)
           ~stdout:(Eio.Flow.buffer_sink buf)
           argv;
         Buffer.contents buf)
     with
     | Eio.Time.Timeout ->
-      Eio.traceln "[Process_eio] Timeout after %.0fs: %s" timeout_sec label; ""
+        Eio.traceln "[Process_eio] Timeout after %.0fs: %s" timeout_sec label;
+        ""
     | exn ->
-      Eio.traceln "[Process_eio] argv error: %s — %s" label (Printexc.to_string exn); ""
-  end
+        Eio.traceln "[Process_eio] argv error: %s — %s" label (Printexc.to_string exn);
+        ""
 
-(** Run a command with explicit argv, return (Unix.process_status, stdout).
-    Uses Eio.Process.spawn + await to get exit status without raising.
-    @since 2.45.0 *)
-let run_argv_with_status ?(timeout_sec=60.0) argv =
-  if not (is_initialized ()) then run_unix_argv_with_status_fallback argv
-  else begin
+let run_argv_with_stdin_and_status
+    ?(timeout_sec = 60.0)
+    ?env
+    ~(stdin_content : string)
+    (argv : string list) : Unix.process_status * string =
+  if not (is_initialized ()) then run_unix_argv_with_stdin_and_status_fallback ~stdin_content argv
+  else
     let pm = get_proc_mgr () and clk = get_clock () in
     let buf = Buffer.create 1024 in
     let label = String.concat " " (List.map Filename.quote argv) in
     try
       Eio.Time.with_timeout_exn clk timeout_sec (fun () ->
         Eio.Switch.run (fun sw ->
-          let proc = Eio.Process.spawn ~sw pm
-            ~stdout:(Eio.Flow.buffer_sink buf)
-            argv in
+          let proc =
+            Eio.Process.spawn ~sw pm ?env
+              ~stdin:(Eio.Flow.string_source stdin_content)
+              ~stdout:(Eio.Flow.buffer_sink buf)
+              argv
+          in
           let status = Eio.Process.await proc in
-          let unix_status = match status with
+          let unix_status =
+            match status with
             | `Exited n -> Unix.WEXITED n
-            | `Signaled n -> Unix.WSIGNALED n in
+            | `Signaled n -> Unix.WSIGNALED n
+          in
           (unix_status, Buffer.contents buf)))
     with
     | Eio.Time.Timeout ->
-      Eio.traceln "[Process_eio] Timeout after %.0fs: %s" timeout_sec label;
-      (Unix.WSIGNALED Sys.sigterm, Buffer.contents buf)
+        Eio.traceln "[Process_eio] Timeout after %.0fs: %s" timeout_sec label;
+        (Unix.WSIGNALED Sys.sigterm, Buffer.contents buf)
     | exn ->
-      Eio.traceln "[Process_eio] argv error: %s — %s" label (Printexc.to_string exn);
-      (Unix.WEXITED 1, "")
-  end
+        Eio.traceln "[Process_eio] argv error: %s — %s" label (Printexc.to_string exn);
+        (Unix.WEXITED 1, "")
 
-(** Run a shell command, return (Unix.process_status, stdout).
-    Uses Eio.Process.spawn + await to get exit status without raising. *)
-let run_with_status ?(timeout_sec=60.0) cmd =
-  if not (is_initialized ()) then run_unix_fallback_with_status cmd
-  else begin
+let run_argv_with_status ?(timeout_sec = 60.0) ?env (argv : string list) : Unix.process_status * string =
+  if not (is_initialized ()) then run_unix_argv_with_status_fallback argv
+  else
     let pm = get_proc_mgr () and clk = get_clock () in
     let buf = Buffer.create 1024 in
+    let label = String.concat " " (List.map Filename.quote argv) in
     try
       Eio.Time.with_timeout_exn clk timeout_sec (fun () ->
         Eio.Switch.run (fun sw ->
-          let proc = Eio.Process.spawn ~sw pm
-            ~stdout:(Eio.Flow.buffer_sink buf)
-            ["sh"; "-c"; cmd] in
+          let proc = Eio.Process.spawn ~sw pm ?env ~stdout:(Eio.Flow.buffer_sink buf) argv in
           let status = Eio.Process.await proc in
-          let unix_status = match status with
+          let unix_status =
+            match status with
             | `Exited n -> Unix.WEXITED n
-            | `Signaled n -> Unix.WSIGNALED n in
+            | `Signaled n -> Unix.WSIGNALED n
+          in
           (unix_status, Buffer.contents buf)))
     with
     | Eio.Time.Timeout ->
-      Eio.traceln "[Process_eio] Timeout after %.0fs: %s" timeout_sec cmd;
-      (Unix.WSIGNALED Sys.sigterm, Buffer.contents buf)
+        Eio.traceln "[Process_eio] Timeout after %.0fs: %s" timeout_sec label;
+        (Unix.WSIGNALED Sys.sigterm, Buffer.contents buf)
     | exn ->
-      Eio.traceln "[Process_eio] Error: %s — %s" cmd (Printexc.to_string exn);
-      (Unix.WEXITED 1, "")
-  end
+        Eio.traceln "[Process_eio] argv error: %s — %s" label (Printexc.to_string exn);
+        (Unix.WEXITED 1, "")

--- a/lib/process_eio.mli
+++ b/lib/process_eio.mli
@@ -1,51 +1,8 @@
-(** Async process execution helpers for Eio *)
+(** Async process execution helpers for Eio.
 
-val run_capture_stdout :
-  sw:Eio.Switch.t ->
-  proc_mgr:[> [> `Generic ] Eio.Process.mgr_ty ] Eio.Resource.t ->
-  clock:_ Eio.Time.clock ->
-  ?timeout_sec:float ->
-  string ->
-  string
-
-val run_capture_stdout_with_clock :
-  sw:Eio.Switch.t ->
-  proc_mgr:[> [> `Generic ] Eio.Process.mgr_ty ] Eio.Resource.t ->
-  clock:_ Eio.Time.clock ->
-  ?timeout_sec:float ->
-  string ->
-  string
-
-val run_status :
-  sw:Eio.Switch.t ->
-  proc_mgr:[> [> `Generic ] Eio.Process.mgr_ty ] Eio.Resource.t ->
-  clock:_ Eio.Time.clock ->
-  ?timeout_sec:float ->
-  string ->
-  bool
-
-val run_with_stdin :
-  sw:Eio.Switch.t ->
-  proc_mgr:[> [> `Generic ] Eio.Process.mgr_ty ] Eio.Resource.t ->
-  clock:_ Eio.Time.clock ->
-  ?timeout_sec:float ->
-  stdin_content:string ->
-  string ->
-  string
-
-val read_all_lines :
-  sw:Eio.Switch.t ->
-  proc_mgr:[> [> `Generic ] Eio.Process.mgr_ty ] Eio.Resource.t ->
-  clock:_ Eio.Time.clock ->
-  ?timeout_sec:float ->
-  string ->
-  string list
-
-val run_detached :
-  sw:Eio.Switch.t ->
-  proc_mgr:[> [> `Generic ] Eio.Process.mgr_ty ] Eio.Resource.t ->
-  string ->
-  unit
+    NOTE: This module intentionally exposes argv-based APIs only.
+    Avoid shell-based execution (`sh -c`) to prevent injection bugs and
+    inconsistent semantics across platforms. *)
 
 (** {1 Global init (call once from main_eio.ml)} *)
 
@@ -61,28 +18,34 @@ val get_clock : unit -> float Eio.Time.clock_ty Eio.Resource.t
 
 (** {1 Eio-native process execution (global refs)} *)
 
-(** Run shell command, capture stdout. Empty on timeout/error.
-    @param timeout_sec Timeout in seconds (default: 60.0) *)
-val run : ?timeout_sec:float -> string -> string
-
 (** Run command with explicit argv (no shell). Safe from injection.
     @param timeout_sec Timeout in seconds (default: 60.0)
+    @param env Optional environment (Unix-style ["K=V"; ...]).
     @since 2.45.0 *)
-val run_argv : ?timeout_sec:float -> string list -> string
+val run_argv : ?timeout_sec:float -> ?env:string array -> string list -> string
 
 (** Run command with explicit argv and stdin input (no shell).
     @param timeout_sec Timeout in seconds (default: 60.0)
+    @param env Optional environment (Unix-style ["K=V"; ...]).
     @param stdin_content Body piped to process stdin
     @since 2.45.0 *)
-val run_argv_with_stdin : ?timeout_sec:float -> stdin_content:string -> string list -> string
+val run_argv_with_stdin : ?timeout_sec:float -> ?env:string array -> stdin_content:string -> string list -> string
+
+(** Run command with explicit argv and stdin input (no shell), return (Unix.process_status, stdout).
+    Uses spawn + await to get exit status without raising.
+    @param timeout_sec Timeout in seconds (default: 60.0)
+    @param env Optional environment (Unix-style ["K=V"; ...]).
+    @param stdin_content Body piped to process stdin *)
+val run_argv_with_stdin_and_status :
+  ?timeout_sec:float ->
+  ?env:string array ->
+  stdin_content:string ->
+  string list ->
+  (Unix.process_status * string)
 
 (** Run command with explicit argv, return (Unix.process_status, stdout).
     Uses spawn + await to get exit status without raising.
     @param timeout_sec Timeout in seconds (default: 60.0)
+    @param env Optional environment (Unix-style ["K=V"; ...]).
     @since 2.45.0 *)
-val run_argv_with_status : ?timeout_sec:float -> string list -> (Unix.process_status * string)
-
-(** Run shell command, return (Unix.process_status, stdout).
-    On timeout returns (WSIGNALED sigterm, partial_output).
-    @param timeout_sec Timeout in seconds (default: 60.0) *)
-val run_with_status : ?timeout_sec:float -> string -> (Unix.process_status * string)
+val run_argv_with_status : ?timeout_sec:float -> ?env:string array -> string list -> (Unix.process_status * string)

--- a/lib/room.ml
+++ b/lib/room.ml
@@ -168,8 +168,8 @@ let get_tty () =
     match Sys.getenv_opt "TTY" with
     | Some tty -> Some tty
     | None ->
-        (* Try to read from tty command — Eio-native *)
-        let output = Process_eio.run ~timeout_sec:5.0 "tty 2>/dev/null" in
+        (* Try to read from tty command — argv-based (no shell) *)
+        let output = Process_eio.run_argv ~timeout_sec:5.0 ["tty"] in
         let trimmed = String.trim output in
         if String.length trimmed > 0 then Some trimmed else None
   with e ->

--- a/lib/room_git.ml
+++ b/lib/room_git.ml
@@ -1,33 +1,33 @@
 (** MASC Git Worktree Operations
 
     Provides Git worktree isolation for multi-agent parallel work.
-    Separated from room.ml for better modularity.
+    Implementation is argv-based (no shell) to avoid injection and quoting bugs.
 *)
 
 open Types
 
 (* ============================================ *)
-(* Non-blocking Shell Execution                 *)
+(* argv-based process helpers                   *)
 (* ============================================ *)
 
-(** Run shell command and get single line (Eio-native) *)
-let run_shell_line cmd =
-  let output = Process_eio.run ~timeout_sec:30.0 cmd in
-  match String.split_on_char '\n' output |> List.filter (fun s -> s <> "") with
+(** Run argv and return first non-empty line. *)
+let run_argv_line (argv : string list) : string option =
+  let output = Process_eio.run_argv ~timeout_sec:30.0 argv in
+  match String.split_on_char '\n' output |> List.map String.trim |> List.filter (fun s -> s <> "") with
   | [] -> None
   | h :: _ -> Some h
 
-(** Run shell command and get exit code (Eio-native) *)
-let run_shell_exit cmd =
-  match Process_eio.run_with_status ~timeout_sec:30.0 cmd with
+(** Run argv and return exit code. *)
+let run_argv_exit (argv : string list) : int =
+  match Process_eio.run_argv_with_status ~timeout_sec:30.0 argv with
   | Unix.WEXITED n, _ -> n
   | Unix.WSIGNALED _, _ -> 128
   | Unix.WSTOPPED _, _ -> 128
 
-(** Run shell command and get all lines (Eio-native) *)
-let run_shell_lines cmd =
-  Process_eio.run ~timeout_sec:30.0 cmd
+let run_argv_lines (argv : string list) : string list =
+  Process_eio.run_argv ~timeout_sec:30.0 argv
   |> String.split_on_char '\n'
+  |> List.map String.trim
   |> List.filter (fun s -> s <> "")
 
 (* ============================================ *)
@@ -36,10 +36,16 @@ let run_shell_lines cmd =
 
 (** Validate branch/path components — alphanumeric + /_-. only *)
 let is_valid_branch_name s =
-  String.length s > 0 && String.length s < 256 &&
-  s |> String.to_seq |> Seq.for_all (fun c ->
-    (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') ||
-    (c >= '0' && c <= '9') || c = '/' || c = '_' || c = '-' || c = '.')
+  String.length s > 0
+  && String.length s < 256
+  && s |> String.to_seq |> Seq.for_all (fun c ->
+       (c >= 'a' && c <= 'z')
+       || (c >= 'A' && c <= 'Z')
+       || (c >= '0' && c <= '9')
+       || c = '/'
+       || c = '_'
+       || c = '-'
+       || c = '.')
 
 (* ============================================ *)
 (* Git Repository Utilities                     *)
@@ -47,8 +53,7 @@ let is_valid_branch_name s =
 
 (** Get git root directory *)
 let git_root ~base_path =
-  let cmd = Printf.sprintf "cd %s && git rev-parse --show-toplevel 2>/dev/null" (Filename.quote base_path) in
-  run_shell_line cmd
+  run_argv_line ["git"; "-C"; base_path; "rev-parse"; "--show-toplevel"]
 
 (** Check if directory is a git repository *)
 let is_git_repo ~base_path =
@@ -59,26 +64,29 @@ let is_git_repo ~base_path =
 let remote_branch_exists root branch =
   if not (is_valid_branch_name branch) then false
   else
-    let cmd = Printf.sprintf
-      "cd %s && git show-ref --verify --quiet refs/remotes/origin/%s" (Filename.quote root) (Filename.quote branch)
-    in
-    run_shell_exit cmd = 0
+    run_argv_exit
+      [
+        "git";
+        "-C";
+        root;
+        "show-ref";
+        "--verify";
+        "--quiet";
+        Printf.sprintf "refs/remotes/origin/%s" branch;
+      ]
+    = 0
 
 let origin_head_branch root =
-  let cmd = Printf.sprintf
-    "cd %s && git symbolic-ref -q refs/remotes/origin/HEAD 2>/dev/null" (Filename.quote root)
-  in
-  let line = run_shell_line cmd in
+  let line = run_argv_line ["git"; "-C"; root; "symbolic-ref"; "-q"; "refs/remotes/origin/HEAD"] in
   match line with
   | None -> None
-  | Some refname ->
-      (match List.rev (String.split_on_char '/' refname) with
+  | Some refname -> (
+      match List.rev (String.split_on_char '/' refname) with
       | branch :: _ -> Some branch
       | [] -> None)
 
 let resolve_base_branch root base_branch =
-  if remote_branch_exists root base_branch then
-    Ok (base_branch, None)
+  if remote_branch_exists root base_branch then Ok (base_branch, None)
   else
     let candidates =
       match origin_head_branch root with
@@ -87,25 +95,21 @@ let resolve_base_branch root base_branch =
     in
     match List.find_opt (remote_branch_exists root) candidates with
     | Some fallback -> Ok (fallback, Some base_branch)
-    | None -> Error (IoError (Printf.sprintf
-        "Base branch origin/%s not found and no fallback branch detected." base_branch))
+    | None ->
+        Error
+          (IoError
+             (Printf.sprintf
+                "Base branch origin/%s not found and no fallback branch detected." base_branch))
 
 (* ============================================ *)
 (* Worktree Operations                          *)
 (* ============================================ *)
 
-(** Create worktree for agent
-
-    @param base_path Project root path
-    @param agent_name Agent creating the worktree (e.g., "claude")
-    @param task_id Task or feature ID (e.g., "PK-12345")
-    @param base_branch Branch to base off (e.g., "develop", "main")
-    @return Result with success message or error
-*)
+(** Create worktree for agent *)
 let create ~base_path ~agent_name ~task_id ~base_branch : string masc_result =
   if not (is_git_repo ~base_path) then
     Error (IoError "Not a git repository. MASC v2 requires .git directory for worktree isolation.")
-  else begin
+  else
     match git_root ~base_path with
     | None -> Error (IoError "Cannot determine git root")
     | Some root ->
@@ -115,47 +119,47 @@ let create ~base_path ~agent_name ~task_id ~base_branch : string masc_result =
 
         (* Create .worktrees directory if not exists *)
         let worktrees_dir = Filename.concat root ".worktrees" in
-        if not (Sys.file_exists worktrees_dir) then
-          Unix.mkdir worktrees_dir 0o755;
+        if not (Sys.file_exists worktrees_dir) then Unix.mkdir worktrees_dir 0o755;
 
-        (* Check if worktree already exists *)
         if Sys.file_exists worktree_path then
-          Ok (Printf.sprintf "✅ Worktree already exists:\n  Path: %s\n  Branch: %s\n\nNext: cd %s"
-              worktree_path branch_name worktree_path)
-        else begin
+          Ok
+            (Printf.sprintf "✅ Worktree already exists:\n  Path: %s\n  Branch: %s\n\nNext: cd %s"
+               worktree_path branch_name worktree_path)
+        else (
           (* Fetch origin first *)
-          let fetch_cmd = Printf.sprintf "cd %s && git fetch origin 2>&1" (Filename.quote root) in
-          let _ = run_shell_exit fetch_cmd in
+          let _ = run_argv_exit ["git"; "-C"; root; "fetch"; "origin"] in
           match resolve_base_branch root base_branch with
           | Error e -> Error e
           | Ok (resolved_base, fallback_from) ->
-              let note = match fallback_from with
+              let note =
+                match fallback_from with
                 | None -> ""
                 | Some missing ->
-                    Printf.sprintf "\n  Note: origin/%s not found; used origin/%s" missing resolved_base
+                    Printf.sprintf "\n  Note: origin/%s not found; used origin/%s" missing
+                      resolved_base
               in
-              (* Create worktree with new branch from base *)
-              let cmd = Printf.sprintf
-                "cd %s && git worktree add %s -b %s origin/%s 2>&1"
-                (Filename.quote root) (Filename.quote worktree_path) (Filename.quote branch_name) (Filename.quote resolved_base) in
-              let exit_code = run_shell_exit cmd in
+              let exit_code =
+                run_argv_exit
+                  [
+                    "git";
+                    "-C";
+                    root;
+                    "worktree";
+                    "add";
+                    worktree_path;
+                    "-b";
+                    branch_name;
+                    Printf.sprintf "origin/%s" resolved_base;
+                  ]
+              in
+              if exit_code = 0 then
+                Ok
+                  (Printf.sprintf
+                     "✅ Worktree created:\n  Path: %s\n  Branch: %s%s\n\nNext: cd %s && work && gh pr create --draft"
+                     worktree_path branch_name note worktree_path)
+              else Error (IoError (Printf.sprintf "Failed to create worktree from origin/%s." resolved_base)))
 
-              if exit_code = 0 then begin
-                Ok (Printf.sprintf "✅ Worktree created:\n  Path: %s\n  Branch: %s%s\n\nNext: cd %s && work && gh pr create --draft"
-                    worktree_path branch_name note worktree_path)
-              end
-              else
-                Error (IoError (Printf.sprintf "Failed to create worktree from origin/%s." resolved_base))
-        end
-  end
-
-(** Remove worktree after work is merged
-
-    @param base_path Project root path
-    @param agent_name Agent that owns the worktree
-    @param task_id Task ID used when creating
-    @return Result with success message or error
-*)
+(** Remove worktree after work is merged *)
 let remove ~base_path ~agent_name ~task_id : string masc_result =
   match git_root ~base_path with
   | None -> Error (IoError "Cannot determine git root")
@@ -166,75 +170,66 @@ let remove ~base_path ~agent_name ~task_id : string masc_result =
 
       if not (Sys.file_exists worktree_path) then
         Error (IoError (Printf.sprintf "Worktree not found: %s" worktree_path))
-      else begin
-        (* Remove worktree *)
-        let remove_cmd = Printf.sprintf "cd %s && git worktree remove %s 2>&1" (Filename.quote root) (Filename.quote worktree_path) in
-        let exit_code = run_shell_exit remove_cmd in
-
-        if exit_code = 0 then begin
-          (* Try to delete the branch (may fail if not merged, which is ok) *)
-          let branch_cmd = Printf.sprintf "cd %s && git branch -d %s 2>&1" (Filename.quote root) (Filename.quote branch_name) in
-          let _ = run_shell_exit branch_cmd in
-
-          (* Prune stale worktrees *)
-          let prune_cmd = Printf.sprintf "cd %s && git worktree prune 2>&1" (Filename.quote root) in
-          let _ = run_shell_exit prune_cmd in
-
-          Ok (Printf.sprintf "✅ Worktree removed: %s\n   Branch: %s" worktree_path branch_name)
-        end
-        else
-          Error (IoError "Failed to remove worktree. It may have uncommitted changes.")
-      end
+      else
+        let exit_code =
+          run_argv_exit ["git"; "-C"; root; "worktree"; "remove"; worktree_path]
+        in
+        if exit_code = 0 then (
+          let _ = run_argv_exit ["git"; "-C"; root; "branch"; "-d"; branch_name] in
+          let _ = run_argv_exit ["git"; "-C"; root; "worktree"; "prune"] in
+          Ok (Printf.sprintf "✅ Worktree removed: %s\n   Branch: %s" worktree_path branch_name))
+        else Error (IoError "Failed to remove worktree. It may have uncommitted changes.")
 
 (** List all worktrees in the repository *)
 let list ~base_path =
   match git_root ~base_path with
   | None -> `Assoc [("error", `String "Not a git repository")]
   | Some root ->
-      let cmd = Printf.sprintf "cd %s && git worktree list --porcelain 2>/dev/null" (Filename.quote root) in
-      let lines = run_shell_lines cmd in
+      let lines = run_argv_lines ["git"; "-C"; root; "worktree"; "list"; "--porcelain"] in
 
       (* Parse porcelain output into worktree info *)
       let rec parse_worktrees lines current acc =
         match lines with
         | [] ->
-            if current <> [] then List.rev (List.rev current :: acc)
-            else List.rev acc
+            if current <> [] then List.rev (List.rev current :: acc) else List.rev acc
         | "" :: rest ->
             if current <> [] then parse_worktrees rest [] (List.rev current :: acc)
             else parse_worktrees rest [] acc
-        | line :: rest ->
-            parse_worktrees rest (line :: current) acc
+        | line :: rest -> parse_worktrees rest (line :: current) acc
       in
       let worktree_blocks = parse_worktrees lines [] [] in
 
       let parse_block block =
         let path = ref "" in
         let branch = ref "" in
-        List.iter (fun line ->
-          if String.length line > 9 && String.sub line 0 9 = "worktree " then
-            path := String.sub line 9 (String.length line - 9)
-          else if String.length line > 7 && String.sub line 0 7 = "branch " then
-            branch := String.sub line 7 (String.length line - 7)
-        ) block;
+        List.iter
+          (fun line ->
+            if String.length line > 9 && String.sub line 0 9 = "worktree " then
+              path := String.sub line 9 (String.length line - 9)
+            else if String.length line > 7 && String.sub line 0 7 = "branch " then
+              branch := String.sub line 7 (String.length line - 7))
+          block;
         if !path <> "" then
-          Some (`Assoc [
-            ("path", `String !path);
-            ("branch", `String !branch);
-            (* Check if path contains .worktrees - stdlib compatible *)
-            ("is_masc", `Bool (try
-              let _ = Str.search_forward (Str.regexp_string ".worktrees") !path 0 in true
-            with Not_found -> false));
-          ])
+          Some
+            (`Assoc
+              [
+                ("path", `String !path);
+                ("branch", `String !branch);
+                (* Check if path contains .worktrees - stdlib compatible *)
+                ("is_masc", `Bool (try
+                  let _ = Str.search_forward (Str.regexp_string ".worktrees") !path 0 in true
+                with Not_found -> false));
+              ])
         else None
       in
 
       let worktrees = List.filter_map parse_block worktree_blocks in
-      `Assoc [
-        ("worktrees", `List worktrees);
-        ("count", `Int (List.length worktrees));
-        ("masc_hint", `String "Use masc_worktree_create to add a new worktree for your task");
-      ]
+      `Assoc
+        [
+          ("worktrees", `List worktrees);
+          ("count", `Int (List.length worktrees));
+          ("masc_hint", `String "Use masc_worktree_create to add a new worktree for your task");
+        ]
 
 (** Get worktree info for a specific agent/task *)
 let get_info ~base_path ~agent_name ~task_id =
@@ -244,7 +239,4 @@ let get_info ~base_path ~agent_name ~task_id =
       let worktree_name = Printf.sprintf "%s-%s" agent_name task_id in
       let worktree_path = Filename.concat root (Filename.concat ".worktrees" worktree_name) in
       let branch_name = Printf.sprintf "%s/%s" agent_name task_id in
-      if Sys.file_exists worktree_path then
-        Some (worktree_path, branch_name)
-      else
-        None
+      if Sys.file_exists worktree_path then Some (worktree_path, branch_name) else None

--- a/lib/room_worktree.ml
+++ b/lib/room_worktree.ml
@@ -9,15 +9,15 @@
 open Types
 open Room_utils
 
-(** Run shell command and get lines (Eio-native) *)
-let run_shell_lines cmd =
-  Process_eio.run ~timeout_sec:30.0 cmd
+(** Run argv and get lines (Eio-native, no shell) *)
+let run_argv_lines argv =
+  Process_eio.run_argv ~timeout_sec:30.0 argv
   |> String.split_on_char '\n'
   |> List.filter (fun s -> s <> "")
 
-(** Run shell command and get exit code (Eio-native) *)
-let run_shell_exit cmd =
-  match Process_eio.run_with_status ~timeout_sec:30.0 cmd with
+(** Run argv and get exit code (Eio-native, no shell) *)
+let run_argv_exit argv =
+  match Process_eio.run_argv_with_status ~timeout_sec:30.0 argv with
   | Unix.WEXITED n, _ -> n
   | Unix.WSIGNALED _, _ -> 128
   | Unix.WSTOPPED _, _ -> 128
@@ -122,8 +122,7 @@ let worktree_create_r ?(link_task=true) config ~agent_name ~task_id ~base_branch
               worktree_path branch_name repo_name link_note worktree_path)
         end else begin
           (* Fetch origin first *)
-          let fetch_cmd = Printf.sprintf "cd %s && git fetch origin 2>&1" (Filename.quote root) in
-          let _ = run_shell_exit fetch_cmd in
+          let _ = run_argv_exit ["git"; "-C"; root; "fetch"; "origin"] in
 
           match Room_git.resolve_base_branch root base_branch with
           | Error e -> Error e
@@ -134,10 +133,20 @@ let worktree_create_r ?(link_task=true) config ~agent_name ~task_id ~base_branch
                     Printf.sprintf "\n  Note: origin/%s not found; used origin/%s" missing resolved_base
               in
               (* Create worktree with new branch from base *)
-              let cmd = Printf.sprintf
-                "cd %s && git worktree add %s -b %s origin/%s 2>&1"
-                (Filename.quote root) (Filename.quote worktree_path) (Filename.quote branch_name) (Filename.quote resolved_base) in
-              let exit_code = run_shell_exit cmd in
+              let exit_code =
+                run_argv_exit
+                  [
+                    "git";
+                    "-C";
+                    root;
+                    "worktree";
+                    "add";
+                    worktree_path;
+                    "-b";
+                    branch_name;
+                    Printf.sprintf "origin/%s" resolved_base;
+                  ]
+              in
 
               if exit_code = 0 then begin
                 (* Update agent's current_worktree in state *)
@@ -186,17 +195,14 @@ let worktree_remove_r config ~agent_name ~task_id : string masc_result =
           Error (IoError (Printf.sprintf "Worktree not found: %s" worktree_path))
         else begin
           (* Remove worktree *)
-          let remove_cmd = Printf.sprintf "cd %s && git worktree remove %s 2>&1" (Filename.quote root) (Filename.quote worktree_path) in
-          let exit_code = run_shell_exit remove_cmd in
+          let exit_code = run_argv_exit ["git"; "-C"; root; "worktree"; "remove"; worktree_path] in
 
           if exit_code = 0 then begin
             (* Try to delete the branch (may fail if not merged, which is ok) *)
-            let branch_cmd = Printf.sprintf "cd %s && git branch -d %s 2>&1" (Filename.quote root) (Filename.quote branch_name) in
-            let _ = run_shell_exit branch_cmd in
+            let _ = run_argv_exit ["git"; "-C"; root; "branch"; "-d"; branch_name] in
 
             (* Prune stale worktrees *)
-            let prune_cmd = Printf.sprintf "cd %s && git worktree prune 2>&1" (Filename.quote root) in
-            let _ = run_shell_exit prune_cmd in
+            let _ = run_argv_exit ["git"; "-C"; root; "worktree"; "prune"] in
 
             (* Log event *)
             let event = Printf.sprintf
@@ -226,8 +232,7 @@ let worktree_list config =
     match git_root config with
     | None -> `Assoc [("error", `String "Not a git repository")]
     | Some root ->
-        let cmd = Printf.sprintf "cd %s && git worktree list --porcelain 2>/dev/null" (Filename.quote root) in
-        let lines = run_shell_lines cmd in
+        let lines = run_argv_lines ["git"; "-C"; root; "worktree"; "list"; "--porcelain"] in
 
         (* Parse porcelain output into worktree info *)
         let rec parse_worktrees lines current acc =

--- a/lib/safe_ops.ml
+++ b/lib/safe_ops.ml
@@ -173,25 +173,4 @@ let json_float_opt key json =
 
 (** {1 Safe Process Execution} *)
 
-(** Read all stdout from a process, guaranteeing close_process_in is called.
-    Returns (exit_ok, output) where exit_ok is true for WEXITED 0. *)
-let read_process_safe cmd : bool * string =
-  let ic = Unix.open_process_in cmd in
-  let closed = ref false in
-  let close () =
-    if not !closed then begin
-      closed := true;
-      ignore (Unix.close_process_in ic)
-    end
-  in
-  Fun.protect ~finally:close
-    (fun () ->
-      let buf = Buffer.create 4096 in
-      (try while true do Buffer.add_char buf (input_char ic) done
-       with End_of_file -> ());
-      let output = Buffer.contents buf in
-      closed := true;
-      let status = Unix.close_process_in ic in
-      let ok = match status with Unix.WEXITED 0 -> true | _ -> false in
-      (ok, output)
-    )
+(* Intentionally empty: process execution lives in Process_eio (argv-only). *)

--- a/lib/tool_lodge.ml
+++ b/lib/tool_lodge.ml
@@ -116,36 +116,26 @@ let source_of_string = function
 
 (** {1 HTTP helpers} *)
 
-(** Escape single quotes for shell command *)
-let shell_escape s = Str.global_replace (Str.regexp "'") "'\\''" s
+let run_cmd_with_status ?(timeout_sec = 60.0) (argv : string list) : Unix.process_status * string =
+  Process_eio.run_argv_with_status ~timeout_sec argv
 
-(** {1 Non-blocking Shell Execution}
+let run_cmd ?(timeout_sec = 10.0) (argv : string list) : string =
+  Process_eio.run_argv ~timeout_sec argv
 
-    All shell commands use Eio-native process execution via Process_eio
-    (global proc_mgr/clock initialized from main_eio.ml).
-*)
+let sb_argv args = (sb_path ()) :: args
 
-(** Run shell command and capture all output (Eio-native).
-    Delegates to Process_eio.run_with_status (global proc_mgr/clock). *)
-let run_shell_nonblocking cmd =
-  Process_eio.run_with_status ~timeout_sec:60.0 cmd
-
-(** Run shell command and get single line result (Eio-native) *)
-let run_shell_line cmd =
-  let output = Process_eio.run ~timeout_sec:10.0 cmd in
-  match String.split_on_char '\n' (String.trim output) with
-  | first :: _ -> first
-  | [] -> ""
+let sb_neo4j_query ?(timeout_sec = 60.0) (cypher : string) : Unix.process_status * string =
+  run_cmd_with_status ~timeout_sec (sb_argv ["neo4j"; "query"; cypher])
 
 (** HTTP GET via curl subprocess — supports both HTTP and HTTPS *)
 let http_get_json ~net:_ url =
   try
-    let safe_url = shell_escape url in
-    let cmd = Printf.sprintf "curl -sf --max-time 10 '%s'" safe_url in
-    let (status, content) = run_shell_nonblocking cmd in
+    let (status, content) =
+      run_cmd_with_status ~timeout_sec:15.0 ["curl"; "-sf"; "--max-time"; "10"; url]
+    in
     match status with
     | Unix.WEXITED 0 -> Ok content
-    | Unix.WEXITED n -> Error (Printf.sprintf "❌ HTTP: curl exit %d [url=%s]" n (String.sub safe_url 0 (min 60 (String.length safe_url))))
+    | Unix.WEXITED n -> Error (Printf.sprintf "❌ HTTP: curl exit %d [url=%s]" n (String.sub url 0 (min 60 (String.length url))))
     | _ -> Error "❌ HTTP: curl signaled"
   with exn -> Error (Printf.sprintf "❌ HTTP: %s" (Printexc.to_string exn))
 
@@ -156,27 +146,19 @@ let graphql_request_curl body : (string, string) Stdlib.result =
   let default_url = "https://second-brain-graphql-production.up.railway.app/graphql" in
   let url = Sys.getenv_opt "GRAPHQL_URL" |> Option.value ~default:default_url in
   let api_key = Sys.getenv_opt "GRAPHQL_API_KEY" |> Option.value ~default:"" in
-  let argv =
-    [ "curl"; "-s"; "-m"; "10"; url;
-      "-H"; "Content-Type: application/json"
-    ]
-    |> fun base ->
-    if api_key = "" then base
-    else base @ [ "-H"; "Authorization: Bearer " ^ api_key ]
-    |> fun with_auth ->
-    (* Use --data-raw to avoid treating leading '@' specially. *)
-    with_auth @ [ "--data-raw"; body ]
-  in
   try
-    let ic = Unix.open_process_args_in "curl" (Array.of_list argv) in
-    let output = In_channel.input_all ic in
-    let status = Unix.close_process_in ic in
-    match status with
-    | Unix.WEXITED 0 ->
-        if String.length output = 0 then Error "❌ GraphQL curl: empty response"
-        else Ok output
-    | Unix.WEXITED n -> Error (Printf.sprintf "❌ GraphQL curl: exit %d" n)
-    | _ -> Error "❌ GraphQL curl: signaled"
+    let argv =
+      [ "curl"; "-s"; "-m"; "10"; "-f"; url;
+        "-H"; "Content-Type: application/json"
+      ]
+      |> fun base ->
+      if api_key = "" then base else base @ [ "-H"; "Authorization: Bearer " ^ api_key ]
+      |> fun with_auth ->
+      (* Read request body from stdin to avoid quoting/escaping issues. *)
+      with_auth @ [ "-d"; "@-" ]
+    in
+    let output = Process_eio.run_argv_with_stdin ~timeout_sec:15.0 ~stdin_content:body argv in
+    if String.length output = 0 then Error "❌ GraphQL curl: empty response" else Ok output
   with exn -> Error (Printf.sprintf "❌ GraphQL curl: %s" (Printexc.to_string exn))
 
 (** GraphQL request via Cohttp_eio with curl fallback.
@@ -267,7 +249,9 @@ let next_cli_provider () =
 (** Check if ollama has a small model loaded (not blocking with 30b) *)
 let ollama_is_light () =
   try
-    let (_, content) = run_shell_nonblocking "curl -sf http://localhost:11434/api/ps 2>/dev/null" in
+    let (_status, content) =
+      run_cmd_with_status ~timeout_sec:10.0 ["curl"; "-sf"; "http://localhost:11434/api/ps"]
+    in
     let json = Yojson.Safe.from_string content in
     let models = json |> member "models" |> to_list in
     (* If no models loaded or only small models, ollama is light *)
@@ -287,29 +271,24 @@ let cli_generate provider ~system prompt =
     | Codex_cli -> "codex"
     | _ -> failwith "Not a CLI provider"
   in
-  (* Create secure temp file with restricted permissions *)
-  let tmp_file = Filename.temp_file "llm-prompt-" ".txt" in
-  let cleanup () = try Unix.unlink tmp_file with Unix.Unix_error _ -> () in
   try
-    (* Write prompt with owner-only permissions (0600) *)
-    let fd = Unix.openfile tmp_file [Unix.O_WRONLY; Unix.O_TRUNC] 0o600 in
-    let _ = Unix.write_substring fd full_prompt 0 (String.length full_prompt) in
-    Unix.close fd;
-    (* Use stdin for prompt (-) to avoid shell escaping issues with long prompts *)
-    let cmd = match provider with
-      | Gemini_cli -> Printf.sprintf "cat '%s' | gemini 2>/dev/null" tmp_file
-      | Claude_cli -> Printf.sprintf "cat '%s' | claude -p - 2>/dev/null" tmp_file
-      | Codex_cli -> Printf.sprintf "cat '%s' | codex exec - 2>/dev/null" tmp_file
+    let argv = match provider with
+      | Gemini_cli -> ["gemini"]
+      | Claude_cli -> ["claude"; "-p"; "-"]
+      | Codex_cli -> ["codex"; "exec"; "-"]
       | _ -> failwith "Not a CLI provider"
     in
-    let (status, content) = run_shell_nonblocking cmd in
-    cleanup ();
+    let (status, content) =
+      Process_eio.run_argv_with_stdin_and_status
+        ~timeout_sec:120.0
+        ~stdin_content:full_prompt
+        argv
+    in
     match status with
     | Unix.WEXITED 0 -> Ok content
     | Unix.WEXITED n -> Error (Printf.sprintf "❌ LLM: %s exit %d" cli_cmd n)
     | _ -> Error (Printf.sprintf "❌ LLM: %s signaled" cli_cmd)
   with exn ->
-    cleanup ();
     Error (Printf.sprintf "❌ LLM: %s exception [%s]" cli_cmd (Printexc.to_string exn))
 
 (** Unified LLM generate with automatic provider selection *)
@@ -355,10 +334,18 @@ let ollama_generate ~net:_ ?(model = Env_config.Ollama.default_model) ?(temperat
         ("num_ctx", `Int 8192);
       ]);
     ]) in
-    (* Escape single quotes in body for shell *)
-    let escaped_body = Str.global_replace (Str.regexp "'") "'\\''" body in
-    let cmd = Printf.sprintf "curl -sf --max-time 120 -X POST http://127.0.0.1:11434/api/generate -H 'Content-Type: application/json' -d '%s'" escaped_body in
-    let (status, content) = run_shell_nonblocking cmd in
+    let argv =
+      ["curl"; "-sf"; "--max-time"; "120";
+       "-X"; "POST"; "http://127.0.0.1:11434/api/generate";
+       "-H"; "Content-Type: application/json";
+       "-d"; "@-"]
+    in
+    let (status, content) =
+      Process_eio.run_argv_with_stdin_and_status
+        ~timeout_sec:125.0
+        ~stdin_content:body
+        argv
+    in
     match status with
     | Unix.WEXITED 0 ->
         let json = Yojson.Safe.from_string content in
@@ -480,10 +467,18 @@ let extract_interests ~net content =
     with Yojson.Safe.Util.Type_error _ | Yojson.Json_error _ -> []
 
 (** Save agent's new interests to Neo4j via sb CLI *)
+let cypher_escape s =
+  let buf = Buffer.create (String.length s) in
+  String.iter (fun c -> if c = '\'' then Buffer.add_string buf "\\'" else Buffer.add_char buf c) s;
+  Buffer.contents buf
+
 let save_interests_to_neo4j ~agent_name interests =
   if interests = [] then Ok "no interests to save"
   else
-    let topics_str = String.concat ", " (List.map (Printf.sprintf "'%s'") interests) in
+    let esc = cypher_escape in
+    let topics_str =
+      String.concat ", " (List.map (fun t -> Printf.sprintf "'%s'" (esc t)) interests)
+    in
     let cypher = Printf.sprintf
       "MERGE (a:Agent {name: '%s'}) \
        WITH a \
@@ -493,51 +488,50 @@ let save_interests_to_neo4j ~agent_name interests =
        ON CREATE SET r.first_seen = datetime(), r.count = 1 \
        ON MATCH SET r.count = r.count + 1, r.last_seen = datetime() \
        RETURN count(r) as connections"
-      agent_name topics_str
+      (esc agent_name) topics_str
     in
-    (* Use sb neo4j query via subprocess.
-       In double-quoted shell string, single quotes don't need escaping.
-       We only escape: backslash, double-quote, dollar sign. *)
-    let escaped_cypher = cypher
-      |> Str.global_replace (Str.regexp "\\\\") "\\\\\\\\"
-      |> Str.global_replace (Str.regexp "\"") "\\\""
-      |> Str.global_replace (Str.regexp "\\$") "\\$"
-    in
-    let cmd = Printf.sprintf "%s neo4j query \"%s\"" (sb_path ()) escaped_cypher in
     try
-      let _ = run_shell_nonblocking cmd in
-      Ok (Printf.sprintf "saved %d interests for %s" (List.length interests) agent_name)
+      let (status, _output) = sb_neo4j_query ~timeout_sec:60.0 cypher in
+      match status with
+      | Unix.WEXITED 0 ->
+          Ok (Printf.sprintf "saved %d interests for %s" (List.length interests) agent_name)
+      | Unix.WEXITED n -> Error (Printf.sprintf "Neo4j exit %d" n)
+      | _ -> Error "Neo4j signaled"
     with exn -> Error (Printf.sprintf "Neo4j error: %s" (Printexc.to_string exn))
 
 (** Get agent's existing interests from Neo4j *)
 let get_agent_interests ~agent_name =
+  let esc = cypher_escape in
   let cypher = Printf.sprintf
     "MATCH (a:Agent {name: '%s'})-[r:INTERESTED_IN]->(t:Topic) \
      RETURN t.name as topic, r.count as count \
      ORDER BY r.count DESC LIMIT 10"
-    agent_name
+    (esc agent_name)
   in
-  let cmd = Printf.sprintf "%s neo4j query \"%s\" 2>/dev/null" (sb_path ()) cypher in
   try
-    let (_, output) = run_shell_nonblocking cmd in
+    let (status, output) = sb_neo4j_query ~timeout_sec:60.0 cypher in
     (* Parse JSON result *)
-    try
-      let json = Yojson.Safe.from_string output in
-      let records = json |> member "records" |> to_list in
-      List.map (fun r ->
-        let arr = to_list r in
-        match arr with
-        | [topic_arr; _] ->
-          (match to_list topic_arr with
-           | [t] -> to_string t
-           | _ -> "")
-        | _ -> ""
-      ) records |> List.filter (fun s -> s <> "")
-    with Yojson.Safe.Util.Type_error _ | Yojson.Json_error _ -> []
+    match status with
+    | Unix.WEXITED 0 -> (
+        try
+          let json = Yojson.Safe.from_string output in
+          let records = json |> member "records" |> to_list in
+          List.map (fun r ->
+            let arr = to_list r in
+            match arr with
+            | [topic_arr; _] ->
+              (match to_list topic_arr with
+               | [t] -> to_string t
+               | _ -> "")
+            | _ -> ""
+          ) records |> List.filter (fun s -> s <> "")
+        with Yojson.Safe.Util.Type_error _ | Yojson.Json_error _ -> [])
+    | _ -> []
   with Unix.Unix_error _ | Sys_error _ -> []
 
 (** Record agent visit to Lodge *)
 let record_lodge_visit ~agent_name ~article_title =
+  let esc = cypher_escape in
   let cypher = Printf.sprintf
     "MERGE (a:Agent {name: '%s'}) \
      SET a.last_visit = datetime(), \
@@ -546,11 +540,10 @@ let record_lodge_visit ~agent_name ~article_title =
      CREATE (v:LodgeVisit {timestamp: datetime(), article: '%s'}) \
      CREATE (a)-[:VISITED]->(v) \
      RETURN a.visit_count as visits"
-    agent_name (Str.global_replace (Str.regexp "'") "" article_title)
+    (esc agent_name) (esc article_title)
   in
-  let cmd = Printf.sprintf "%s neo4j query \"%s\" 2>/dev/null" (sb_path ()) cypher in
   try
-    let _ = run_shell_nonblocking cmd in
+    let _ = sb_neo4j_query ~timeout_sec:60.0 cypher in
     ()
   with Unix.Unix_error _ | Sys_error _ -> ()
 
@@ -840,16 +833,22 @@ let evolve_agent ~name ~dimension ~outcome =
       let new_weights_json = serialize_value_weights new_weights in
       let new_gen = config.generation + 1 in
       (* Update Neo4j via cypher-shell *)
+      let esc = cypher_escape in
       let cypher = Printf.sprintf
         "MATCH (a:Agent {name: '%s'}) SET a.value_weights = '%s', a.generation = %d, a.last_updated = datetime() RETURN a.name"
-        name new_weights_json new_gen
+        (esc name) (esc new_weights_json) new_gen
       in
       let neo4j_uri = Sys.getenv_opt "NEO4J_URI" |> Option.value ~default:"" in
       let neo4j_pw = Sys.getenv_opt "NEO4J_PASSWORD" |> Option.value ~default:"" in
-      let cmd = Printf.sprintf "cypher-shell -a %s -u neo4j -p %s --format plain %s 2>/dev/null"
-        (Filename.quote neo4j_uri) (Filename.quote neo4j_pw) (Filename.quote cypher) in
       try
-        let _ = Safe_ops.read_process_safe cmd in
+        let argv =
+          ["cypher-shell"; "-a"; neo4j_uri;
+           "-u"; "neo4j"; "-p"; neo4j_pw;
+           "--format"; "plain";
+           cypher]
+        in
+        let (status, _output) = run_cmd_with_status ~timeout_sec:60.0 argv in
+        (match status with Unix.WEXITED 0 -> () | _ -> raise (Failure "cypher-shell failed"));
         (* Update cache *)
         Mutex.lock agent_cache_mu;
         Hashtbl.replace agent_cache name {
@@ -1554,27 +1553,33 @@ let neo4j_http_cypher cypher =
       else if String.length neo4j_uri > 7 && String.sub neo4j_uri 0 7 = "bolt://" then
         "https://" ^ String.sub neo4j_uri 7 (String.length neo4j_uri - 7)
       else neo4j_uri
-    in
-    (* Neo4j HTTP API endpoint for Cypher *)
-    let url = http_uri ^ "/db/neo4j/tx/commit" in
-    (* Escape cypher for JSON *)
-    let escaped_cypher = Str.global_replace (Str.regexp "\"") "\\\"" cypher in
-    let escaped_cypher = Str.global_replace (Str.regexp "\n") "\\n" escaped_cypher in
-    let body = Printf.sprintf {|{"statements":[{"statement":"%s"}]}|} escaped_cypher in
-    let auth = Base64.encode_exn ("neo4j:" ^ neo4j_password) in
-    let cmd = Printf.sprintf
-      "curl -s -X POST '%s' -H 'Content-Type: application/json' -H 'Authorization: Basic %s' -d '%s'"
-      url auth body
-    in
-    Printf.eprintf "[neo4j_http] cmd: curl -s -X POST '%s' ... (body=%d chars)\n%!" url (String.length body);
-    try
-      let ic = Unix.open_process_in cmd in
-      let output = In_channel.input_all ic in
-      let _ = Unix.close_process_in ic in
-      Printf.eprintf "[neo4j_http] response: %s\n%!" (if String.length output < 200 then output else String.sub output 0 200 ^ "...");
-      if String.length output > 0 then Ok output
-      else Error "empty response"
-    with exn -> Error (Printexc.to_string exn)
+	    in
+	    (* Neo4j HTTP API endpoint for Cypher *)
+	    let url = http_uri ^ "/db/neo4j/tx/commit" in
+	    let body =
+	      Yojson.Safe.to_string (`Assoc [
+	        ("statements", `List [
+	          `Assoc [("statement", `String cypher)]
+	        ])
+	      ])
+	    in
+	    let auth = Base64.encode_exn ("neo4j:" ^ neo4j_password) in
+	    let argv =
+	      ["curl"; "-s";
+	       "-X"; "POST"; url;
+	       "-H"; "Content-Type: application/json";
+	       "-H"; "Authorization: Basic " ^ auth;
+	       "-d"; "@-"]
+	    in
+	    Printf.eprintf "[neo4j_http] POST %s (body=%d chars)\n%!" url (String.length body);
+	    try
+	      let output =
+	        Process_eio.run_argv_with_stdin ~timeout_sec:30.0 ~stdin_content:body argv
+	      in
+	      Printf.eprintf "[neo4j_http] response: %s\n%!" (if String.length output < 200 then output else String.sub output 0 200 ^ "...");
+	      if String.length output > 0 then Ok output
+	      else Error "empty response"
+	    with exn -> Error (Printexc.to_string exn)
 
 (** Spawn a new agent — can be called by another agent.
     Uses GraphQL createAgent mutation (works in Railway production). *)
@@ -1601,27 +1606,30 @@ let spawn_agent ~net:_ ~parent_name ~child_name ~child_role ~child_prompt =
       in
       let escaped_role = escape_gql child_role in
       let escaped_prompt = escape_gql child_prompt in
-      (* Generate random activity hours for diversity *)
-      let peak_hour = 9 + Random.int 12 in (* 9-20 KST *)
-      (* Build GraphQL mutation *)
-      let mutation = Printf.sprintf
-        {|{"query":"mutation { createAgent(name: \"%s\", role: \"%s\", description: \"%s\", peakHour: %d, preferredHours: [%d, %d, %d], traits: [\"%s\"], model: \"glm-4.7\", status: \"active\") { success message agent { name } } }"}|}
-        agent_name escaped_role escaped_prompt
-        peak_hour ((peak_hour - 1 + 24) mod 24) peak_hour ((peak_hour + 1) mod 24)
-        escaped_role
-      in
-      Printf.eprintf "[spawn_agent] GraphQL mutation: createAgent(name=%s, role=%s)\n%!" agent_name child_role;
-      let cmd = Printf.sprintf
-        "curl -s '%s' -H 'Content-Type: application/json' -H 'Authorization: Bearer %s' -d '%s'"
-        graphql_url api_key mutation
-      in
-      try
-        let ic = Unix.open_process_in cmd in
-        let output = In_channel.input_all ic in
-        let _ = Unix.close_process_in ic in
-        Printf.eprintf "[spawn_agent] GraphQL response: %s\n%!" (if String.length output < 300 then output else String.sub output 0 300 ^ "...");
-        (* Parse response *)
-        let json = Yojson.Safe.from_string output in
+	      (* Generate random activity hours for diversity *)
+	      let peak_hour = 9 + Random.int 12 in (* 9-20 KST *)
+	      (* Build GraphQL query string, then wrap with JSON (no shell quoting). *)
+	      let gql = Printf.sprintf
+	        "mutation { createAgent(name: \"%s\", role: \"%s\", description: \"%s\", peakHour: %d, preferredHours: [%d, %d, %d], traits: [\"%s\"], model: \"glm-4.7\", status: \"active\") { success message agent { name } } }"
+	        agent_name escaped_role escaped_prompt
+	        peak_hour ((peak_hour - 1 + 24) mod 24) peak_hour ((peak_hour + 1) mod 24)
+	        escaped_role
+	      in
+	      let body = Yojson.Safe.to_string (`Assoc [("query", `String gql)]) in
+	      Printf.eprintf "[spawn_agent] GraphQL mutation: createAgent(name=%s, role=%s)\n%!" agent_name child_role;
+	      try
+	        let argv =
+	          ["curl"; "-s"; graphql_url;
+	           "-H"; "Content-Type: application/json";
+	           "-H"; "Authorization: Bearer " ^ api_key;
+	           "-d"; "@-"]
+	        in
+	        let output =
+	          Process_eio.run_argv_with_stdin ~timeout_sec:30.0 ~stdin_content:body argv
+	        in
+	        Printf.eprintf "[spawn_agent] GraphQL response: %s\n%!" (if String.length output < 300 then output else String.sub output 0 300 ^ "...");
+	        (* Parse response *)
+	        let json = Yojson.Safe.from_string output in
         let data = json |> member "data" in
         if data = `Null then
           let errs = json |> member "errors" in
@@ -1726,30 +1734,32 @@ let get_all_agent_interests () =
      RETURN a.name as agent, collect(t.name) as topics, a.visit_count as visits \
      ORDER BY a.name"
   in
-  let cmd = Printf.sprintf "%s neo4j query \"%s\" 2>/dev/null" (sb_path ()) cypher in
   try
-    let (_, output) = run_shell_nonblocking cmd in
-    try
-      let json = Yojson.Safe.from_string output in
-      let records = json |> member "records" |> to_list in
-      List.filter_map (fun r ->
-        (* Neo4j result: [ [ [agent, topics] ] ] — unwrap twice *)
+    let (status, output) = sb_neo4j_query ~timeout_sec:60.0 cypher in
+    match status with
+    | Unix.WEXITED 0 -> (
         try
-          let row = match to_list r with
-            | [inner] -> to_list inner
-            | other -> other
-          in
-          match row with
-          | agent_json :: topics_json :: _ ->
-            let agent = to_string agent_json in
-            let topics = to_list topics_json |> List.filter_map (fun t ->
-              try Some (to_string t) with Yojson.Safe.Util.Type_error _ -> None
-            ) in
-            if agent <> "" then Some (agent, topics) else None
-          | _ -> None
-        with Yojson.Safe.Util.Type_error _ -> None
-      ) records
-    with Yojson.Safe.Util.Type_error _ | Yojson.Json_error _ -> []
+          let json = Yojson.Safe.from_string output in
+          let records = json |> member "records" |> to_list in
+          List.filter_map (fun r ->
+            (* Neo4j result: [ [ [agent, topics] ] ] — unwrap twice *)
+            try
+              let row = match to_list r with
+                | [inner] -> to_list inner
+                | other -> other
+              in
+              match row with
+              | agent_json :: topics_json :: _ ->
+                let agent = to_string agent_json in
+                let topics = to_list topics_json |> List.filter_map (fun t ->
+                  try Some (to_string t) with Yojson.Safe.Util.Type_error _ -> None
+                ) in
+                if agent <> "" then Some (agent, topics) else None
+              | _ -> None
+            with Yojson.Safe.Util.Type_error _ -> None
+          ) records
+        with Yojson.Safe.Util.Type_error _ | Yojson.Json_error _ -> [])
+    | _ -> []
   with Unix.Unix_error _ | Sys_error _ -> []
 
 let evolve ~net:_ (args : Yojson.Safe.t) =
@@ -2074,17 +2084,17 @@ let get_profile ~net:_ args =
     let (_, posts_result) = Tool_board.handle_tool "masc_board_search" (`Assoc [("query", `String agent_name); ("limit", `Int 10)]) in
 
     (* Get agent info from Neo4j *)
+    let esc = cypher_escape in
     let cypher = Printf.sprintf
       "MATCH (a:Agent {name: '%s'}) \
        OPTIONAL MATCH (a)-[:SPAWNED_BY]->(parent:Agent) \
        RETURN a.role as role, a.created_at as created, a.visit_count as visits, \
               a.reaction_count as reactions, parent.name as parent"
-      agent_name
+      (esc agent_name)
     in
-    let cmd = Printf.sprintf "%s neo4j query \"%s\"" (sb_path ()) cypher in
     let neo4j_info =
       try
-        let (_, content) = run_shell_nonblocking cmd in
+        let (_status, content) = sb_neo4j_query ~timeout_sec:60.0 cypher in
         content
       with Unix.Unix_error _ | Sys_error _ -> "Neo4j unavailable"
     in
@@ -2106,16 +2116,16 @@ let lodge_search ~net:_ args =
       (`Assoc [("query", `String query); ("limit", `Int limit)]) in
 
     (* Search agents in Neo4j *)
+    let esc = cypher_escape in
     let cypher = Printf.sprintf
       "MATCH (a:Agent) WHERE toLower(a.name) CONTAINS toLower('%s') \
        OR toLower(a.role) CONTAINS toLower('%s') \
        RETURN a.name, a.role, a.visit_count LIMIT 5"
-      query query
+      (esc query) (esc query)
     in
-    let cmd = Printf.sprintf "%s neo4j query \"%s\" 2>/dev/null" (sb_path ()) cypher in
     let agent_results =
       try
-        let (_, output) = run_shell_nonblocking cmd in
+        let (_status, output) = sb_neo4j_query ~timeout_sec:60.0 cypher in
         if String.length output > 10 then
           Printf.sprintf "\n\n👥 **에이전트 검색 결과:**\n%s" output
         else ""
@@ -2153,31 +2163,33 @@ let lodge_progress ~net:_ _args =
             COALESCE(a.visit_count, 0) as visits, interests \
      ORDER BY visits DESC LIMIT 10"
   in
-  let cmd = Printf.sprintf "%s neo4j query \"%s\" 2>/dev/null" (sb_path ()) cypher in
   let agent_stats =
     try
-      let (_, output) = run_shell_nonblocking cmd in
-      try
-        let json = Yojson.Safe.from_string output in
-        let records = json |> Yojson.Safe.Util.member "records" |> Yojson.Safe.Util.to_list in
-        List.filter_map (fun r ->
+      let (status, output) = sb_neo4j_query ~timeout_sec:60.0 cypher in
+      match status with
+      | Unix.WEXITED 0 -> (
           try
-            let row = match Yojson.Safe.Util.to_list r with
-              | [inner] -> Yojson.Safe.Util.to_list inner
-              | other -> other
-            in
-            match row with
-            | agent :: agent_role :: visits :: interests :: _ ->
-              let name = Yojson.Safe.Util.to_string agent in
-              let p = (try Yojson.Safe.Util.to_string agent_role with Yojson.Safe.Util.Type_error _ -> "unknown") in
-              let v = (try Yojson.Safe.Util.to_int visits with Yojson.Safe.Util.Type_error _ -> 0) in
-              let i = (try Yojson.Safe.Util.to_int interests with Yojson.Safe.Util.Type_error _ -> 0) in
-              let emoji = emoji_of_agent p in
-              Some (Printf.sprintf "   %s %s: %d visits, %d topics" emoji name v i)
-            | _ -> None
-          with Yojson.Safe.Util.Type_error _ -> None
-        ) records
-      with Yojson.Safe.Util.Type_error _ | Yojson.Json_error _ -> []
+            let json = Yojson.Safe.from_string output in
+            let records = json |> Yojson.Safe.Util.member "records" |> Yojson.Safe.Util.to_list in
+            List.filter_map (fun r ->
+              try
+                let row = match Yojson.Safe.Util.to_list r with
+                  | [inner] -> Yojson.Safe.Util.to_list inner
+                  | other -> other
+                in
+                match row with
+                | agent :: agent_role :: visits :: interests :: _ ->
+                  let name = Yojson.Safe.Util.to_string agent in
+                  let p = (try Yojson.Safe.Util.to_string agent_role with Yojson.Safe.Util.Type_error _ -> "unknown") in
+                  let v = (try Yojson.Safe.Util.to_int visits with Yojson.Safe.Util.Type_error _ -> 0) in
+                  let i = (try Yojson.Safe.Util.to_int interests with Yojson.Safe.Util.Type_error _ -> 0) in
+                  let emoji = emoji_of_agent p in
+                  Some (Printf.sprintf "   %s %s: %d visits, %d topics" emoji name v i)
+                | _ -> None
+              with Yojson.Safe.Util.Type_error _ -> None
+            ) records
+          with Yojson.Safe.Util.Type_error _ | Yojson.Json_error _ -> [])
+      | _ -> []
     with Unix.Unix_error _ | Sys_error _ -> []
   in
 

--- a/test/dune
+++ b/test/dune
@@ -5,7 +5,10 @@
 (env
  (_
   (env-vars
-   (MASC_STORAGE_TYPE filesystem))))
+   (MASC_STORAGE_TYPE filesystem)
+   ; Avoid non-deterministic external network calls during unit tests.
+   (GRAPHQL_API_KEY "")
+   (ZAI_API_KEY ""))))
 
 ; ============================================================
 ; Pure synchronous tests

--- a/test/test_auto_responder_coverage.ml
+++ b/test/test_auto_responder_coverage.ml
@@ -3,8 +3,6 @@
     Tests for MASC Auto-responder:
     - mode type (Disabled, Spawn, Llm)
     - activity_log_file: log file path
-    - llm_mcp_url: LLM MCP endpoint
-    - build_spawn_command: shell command builder
     - build_response_prompt: prompt string builder
     - extract_nickname: nickname extraction from response
     - re-exports from Mention
@@ -43,79 +41,6 @@ let test_activity_log_file_ends_with_log () =
   check bool "ends with .log" true
     (String.length path > 4 &&
      String.sub path (String.length path - 4) 4 = ".log")
-
-(* ============================================================
-   llm_mcp_url Tests
-   ============================================================ *)
-
-let test_llm_mcp_url_empty_or_http () =
-  let url = Auto_responder.llm_mcp_url () in
-  (* LLM_MCP_URL is deprecated (and unset in CI); treat empty as valid.
-     If set, it must be an http(s) URL. *)
-  check bool "empty or http(s)" true
-    (String.length url = 0 ||
-     (String.length url > 7 &&
-      (String.sub url 0 7 = "http://" || String.sub url 0 8 = "https://")))
-
-(* ============================================================
-   build_spawn_command Tests
-   ============================================================ *)
-
-let test_build_spawn_command_claude () =
-  let cmd = Auto_responder.build_spawn_command ~agent_type:"claude" ~prompt:"hello" ~working_dir:"/tmp" in
-  check bool "contains claude" true
-    (try
-      let _ = Str.search_forward (Str.regexp "claude") cmd 0 in true
-    with Not_found -> false)
-
-let test_build_spawn_command_gemini () =
-  let cmd = Auto_responder.build_spawn_command ~agent_type:"gemini" ~prompt:"test" ~working_dir:"/tmp" in
-  check bool "contains gemini" true
-    (try
-      let _ = Str.search_forward (Str.regexp "gemini") cmd 0 in true
-    with Not_found -> false)
-
-let test_build_spawn_command_codex () =
-  let cmd = Auto_responder.build_spawn_command ~agent_type:"codex" ~prompt:"test" ~working_dir:"/tmp" in
-  check bool "contains codex" true
-    (try
-      let _ = Str.search_forward (Str.regexp "codex") cmd 0 in true
-    with Not_found -> false)
-
-let test_build_spawn_command_ollama () =
-  let cmd = Auto_responder.build_spawn_command ~agent_type:"ollama" ~prompt:"test" ~working_dir:"/tmp" in
-  check bool "contains ollama" true
-    (try
-      let _ = Str.search_forward (Str.regexp "ollama") cmd 0 in true
-    with Not_found -> false)
-
-let test_build_spawn_command_glm () =
-  let cmd = Auto_responder.build_spawn_command ~agent_type:"glm" ~prompt:"test" ~working_dir:"/tmp" in
-  check bool "contains curl" true
-    (try
-      let _ = Str.search_forward (Str.regexp "curl") cmd 0 in true
-    with Not_found -> false)
-
-let test_build_spawn_command_unknown () =
-  let cmd = Auto_responder.build_spawn_command ~agent_type:"unknown" ~prompt:"test" ~working_dir:"/tmp" in
-  check bool "contains unknown" true
-    (try
-      let _ = Str.search_forward (Str.regexp "unknown") cmd 0 in true
-    with Not_found -> false)
-
-let test_build_spawn_command_has_cd () =
-  let cmd = Auto_responder.build_spawn_command ~agent_type:"claude" ~prompt:"test" ~working_dir:"/home/user" in
-  check bool "has cd" true
-    (try
-      let _ = Str.search_forward (Str.regexp "cd") cmd 0 in true
-    with Not_found -> false)
-
-let test_build_spawn_command_has_timeout () =
-  let cmd = Auto_responder.build_spawn_command ~agent_type:"claude" ~prompt:"test" ~working_dir:"/tmp" in
-  check bool "has timeout" true
-    (try
-      let _ = Str.search_forward (Str.regexp "timeout") cmd 0 in true
-    with Not_found -> false)
 
 (* ============================================================
    build_response_prompt Tests
@@ -259,18 +184,10 @@ let test_get_mode_returns_valid () =
    Edge Cases
    ============================================================ *)
 
-let test_build_spawn_command_special_chars () =
-  let cmd = Auto_responder.build_spawn_command ~agent_type:"claude" ~prompt:"hello's \"world\"" ~working_dir:"/tmp" in
-  check bool "handles special chars" true (String.length cmd > 0)
-
 let test_build_response_prompt_long_content () =
   let long_content = String.make 1000 'x' in
   let prompt = Auto_responder.build_response_prompt ~from_agent:"a" ~content:long_content ~mention:"b" in
   check bool "handles long content" true (String.length prompt > 1000)
-
-let test_build_spawn_command_escapes_prompt () =
-  let cmd = Auto_responder.build_spawn_command ~agent_type:"claude" ~prompt:"test\nwith\nnewlines" ~working_dir:"/tmp" in
-  check bool "handles newlines" true (String.length cmd > 0)
 
 (* ============================================================
    Test Runners
@@ -286,19 +203,6 @@ let () =
     "activity_log_file", [
       test_case "nonempty" `Quick test_activity_log_file_nonempty;
       test_case "ends with .log" `Quick test_activity_log_file_ends_with_log;
-    ];
-    "llm_mcp_url", [
-      test_case "empty or http(s)" `Quick test_llm_mcp_url_empty_or_http;
-    ];
-    "build_spawn_command", [
-      test_case "claude" `Quick test_build_spawn_command_claude;
-      test_case "gemini" `Quick test_build_spawn_command_gemini;
-      test_case "codex" `Quick test_build_spawn_command_codex;
-      test_case "ollama" `Quick test_build_spawn_command_ollama;
-      test_case "glm" `Quick test_build_spawn_command_glm;
-      test_case "unknown" `Quick test_build_spawn_command_unknown;
-      test_case "has cd" `Quick test_build_spawn_command_has_cd;
-      test_case "has timeout" `Quick test_build_spawn_command_has_timeout;
     ];
     "build_response_prompt", [
       test_case "nonempty" `Quick test_build_response_prompt_nonempty;
@@ -335,8 +239,6 @@ let () =
       test_case "returns valid" `Quick test_get_mode_returns_valid;
     ];
     "edge_cases", [
-      test_case "special chars" `Quick test_build_spawn_command_special_chars;
       test_case "long content" `Quick test_build_response_prompt_long_content;
-      test_case "escapes prompt" `Quick test_build_spawn_command_escapes_prompt;
     ];
   ]

--- a/test/test_council.ml
+++ b/test/test_council.ml
@@ -21,15 +21,34 @@ module Balance = Council.Balance
 
 let test_base_path = "/tmp/masc-test-council"
 
+let rec mkdir_p path =
+  if Sys.file_exists path then
+    ()
+  else begin
+    let parent = Filename.dirname path in
+    if parent <> path then mkdir_p parent;
+    try Unix.mkdir path 0o755
+    with Unix.Unix_error (Unix.EEXIST, _, _) -> ()
+  end
+
+let rec rm_rf path =
+  if Sys.file_exists path then
+    if Sys.is_directory path then begin
+      Sys.readdir path
+      |> Array.iter (fun name -> rm_rf (Filename.concat path name));
+      Unix.rmdir path
+    end else
+      Unix.unlink path
+
 let setup () =
   (* Create test directories *)
   let masc_dir = Filename.concat test_base_path ".masc" in
   let debates_dir = Filename.concat masc_dir "debates" in
-  ignore (Sys.command (Printf.sprintf "mkdir -p %s" debates_dir));
+  mkdir_p debates_dir;
   ()
 
 let teardown () =
-  ignore (Sys.command (Printf.sprintf "rm -rf %s" test_base_path));
+  (try rm_rf test_base_path with _ -> ());
   ()
 
 (* ============================================================
@@ -516,16 +535,11 @@ let convo_config : Conversation.config = {
 }
 
 let convo_setup () =
-  (* Since conversation.ml uses Sys.getcwd()/.masc, we need to create
-     the actual dir at CWD/.masc/conversations/threads too.
-     For unit tests, we also create our test dir for direct file checks. *)
-  ignore (Sys.command (Printf.sprintf "rm -rf %s" convo_test_root));
-  let cwd_convo = Sys.getcwd () ^ "/.masc/conversations/threads" in
-  ignore (Sys.command (Printf.sprintf "mkdir -p %s" cwd_convo));
-  ignore (Sys.command (Printf.sprintf "mkdir -p %s/.masc/conversations/threads" convo_test_root))
+  (try rm_rf convo_test_root with _ -> ());
+  mkdir_p (Filename.concat convo_test_root ".masc/conversations/threads")
 
 let convo_teardown () =
-  ignore (Sys.command (Printf.sprintf "rm -rf %s" convo_test_root))
+  (try rm_rf convo_test_root with _ -> ())
 
 let test_convo_start () =
   convo_setup ();

--- a/test/test_lodge_graphql_failure_coverage.ml
+++ b/test/test_lodge_graphql_failure_coverage.ml
@@ -19,7 +19,11 @@ let test name f =
 let () = test "load_agents_from_neo4j_curl_fallback" (fun () ->
   (* When Eio net is not initialized, Cohttp fails but curl fallback succeeds.
      If GRAPHQL_API_KEY is set and network is available, agents are returned. *)
-  let has_api_key = Sys.getenv_opt "GRAPHQL_API_KEY" <> None in
+  let has_api_key =
+    match Sys.getenv_opt "GRAPHQL_API_KEY" with
+    | Some s when String.length s > 0 -> true
+    | _ -> false
+  in
   let agents = Lodge_heartbeat.load_agents_from_neo4j () in
   if has_api_key then
     (* With API key, curl fallback should return agents (or [] if network down) *)
@@ -31,7 +35,11 @@ let () = test "load_agents_from_neo4j_curl_fallback" (fun () ->
 
 (* Test: load_lodge_agents_full also uses curl fallback *)
 let () = test "load_lodge_agents_full_curl_fallback" (fun () ->
-  let has_api_key = Sys.getenv_opt "GRAPHQL_API_KEY" <> None in
+  let has_api_key =
+    match Sys.getenv_opt "GRAPHQL_API_KEY" with
+    | Some s when String.length s > 0 -> true
+    | _ -> false
+  in
   match Lodge_heartbeat.load_lodge_agents_full () with
   | Ok json ->
       if has_api_key then begin

--- a/test/test_lodge_reaction.ml
+++ b/test/test_lodge_reaction.ml
@@ -6,14 +6,23 @@ open Masc_mcp
 (* Test helpers *)
 let tmp_dir = ref ""
 
+let rec rm_rf path =
+  if Sys.file_exists path then
+    if Sys.is_directory path then begin
+      Sys.readdir path
+      |> Array.iter (fun name -> rm_rf (Filename.concat path name));
+      Unix.rmdir path
+    end else
+      Unix.unlink path
+
 let setup () =
   tmp_dir := Filename.temp_dir "lodge_reaction_test" "";
   Unix.putenv "ME_ROOT" !tmp_dir;
-  ignore (Sys.command (Printf.sprintf "mkdir -p %s/.masc" !tmp_dir))
+  Fs_compat.mkdir_p (Filename.concat !tmp_dir ".masc")
 
 let teardown () =
   if !tmp_dir <> "" then
-    ignore (Sys.command (Printf.sprintf "rm -rf %s" !tmp_dir))
+    (try rm_rf !tmp_dir with _ -> ())
 
 (* Type conversion tests *)
 let test_reaction_type_roundtrip () =

--- a/test/test_multi_room.ml
+++ b/test/test_multi_room.ml
@@ -4,6 +4,15 @@ open Alcotest
 open Masc_mcp
 
 (* Test helpers *)
+let rec rm_rf path =
+  if Sys.file_exists path then
+    if Sys.is_directory path then begin
+      Sys.readdir path
+      |> Array.iter (fun name -> rm_rf (Filename.concat path name));
+      Unix.rmdir path
+    end else
+      Unix.unlink path
+
 let setup_test_room () =
   (* Use PID + timestamp for deterministic unique dir *)
   let test_dir = Filename.concat (Filename.get_temp_dir_name ())
@@ -13,7 +22,7 @@ let setup_test_room () =
   (config, test_dir)
 
 let cleanup_test_room test_dir =
-  ignore (Sys.command (Printf.sprintf "rm -rf %s" test_dir))
+  (try rm_rf test_dir with _ -> ())
 
 let task_count config =
   let backlog = Room.read_backlog config in

--- a/test/test_planning.ml
+++ b/test/test_planning.ml
@@ -4,10 +4,19 @@ open Masc_mcp
 
 let test_dir = Filename.concat (Filename.get_temp_dir_name ()) "masc_planning_test"
 
+let rec rm_rf path =
+  if Sys.file_exists path then
+    if Sys.is_directory path then begin
+      Sys.readdir path
+      |> Array.iter (fun name -> rm_rf (Filename.concat path name));
+      Unix.rmdir path
+    end else
+      Unix.unlink path
+
 let setup_config () =
   (* Clean up and recreate test directory *)
-  ignore (Sys.command (Printf.sprintf "rm -rf %s" test_dir));
-  ignore (Sys.command (Printf.sprintf "mkdir -p %s" test_dir));
+  (try rm_rf test_dir with _ -> ());
+  Fs_compat.mkdir_p test_dir;
   (* Use memory backend for tests to avoid filesystem dependencies *)
   Unix.putenv "MASC_STORAGE_TYPE" "memory";
   Room.default_config test_dir

--- a/test/test_planning_eio.ml
+++ b/test/test_planning_eio.ml
@@ -5,6 +5,15 @@ open Masc_mcp
 
 let temp_dir = ref ""
 
+let rec rm_rf path =
+  if Sys.file_exists path then
+    if Sys.is_directory path then begin
+      Sys.readdir path
+      |> Array.iter (fun name -> rm_rf (Filename.concat path name));
+      Unix.rmdir path
+    end else
+      Unix.unlink path
+
 let setup () =
   let dir = Filename.concat (Filename.get_temp_dir_name ())
     (Printf.sprintf "planning_eio_test_%d" (int_of_float (Unix.gettimeofday () *. 1000.))) in
@@ -14,8 +23,7 @@ let setup () =
 let teardown () =
   (* Clean up temp directory *)
   if !temp_dir <> "" then begin
-    let cmd = Printf.sprintf "rm -rf %s" (Filename.quote !temp_dir) in
-    ignore (Sys.command cmd)
+    (try rm_rf !temp_dir with _ -> ())
   end
 
 let make_config () : Room.config =

--- a/test/test_ralph_eio.ml
+++ b/test/test_ralph_eio.ml
@@ -9,6 +9,15 @@
 
 open Alcotest
 
+let rec rm_rf path =
+  if Sys.file_exists path then
+    if Sys.is_directory path then begin
+      Sys.readdir path
+      |> Array.iter (fun name -> rm_rf (Filename.concat path name));
+      Unix.rmdir path
+    end else
+      Unix.unlink path
+
 (** Test fixture: Create isolated config with Eio environment *)
 let with_test_config name f =
   Eio_main.run @@ fun env ->
@@ -22,12 +31,7 @@ let with_test_config name f =
   Fun.protect
     ~finally:(fun () ->
       let _ = Masc_mcp.Room.reset config in
-      let path = Masc_mcp.Room.masc_dir config in
-      if Sys.file_exists path then
-        let _ = Sys.command (Printf.sprintf "rm -rf %s" path) in ();
-      let parent = Filename.dirname path in
-      if Sys.file_exists parent then
-        try Unix.rmdir parent with _ -> ())
+      (try rm_rf tmp_dir with _ -> ()))
     (fun () -> f env fs config)
 
 (** Test: Basic state machine in Eio context *)

--- a/test/test_walph_eio.ml
+++ b/test/test_walph_eio.ml
@@ -9,6 +9,15 @@
 
 open Alcotest
 
+let rec rm_rf path =
+  if Sys.file_exists path then
+    if Sys.is_directory path then begin
+      Sys.readdir path
+      |> Array.iter (fun name -> rm_rf (Filename.concat path name));
+      Unix.rmdir path
+    end else
+      Unix.unlink path
+
 (** Test fixture: Create isolated config with Eio environment *)
 let with_test_config name f =
   Eio_main.run @@ fun env ->
@@ -22,12 +31,7 @@ let with_test_config name f =
   Fun.protect
     ~finally:(fun () ->
       let _ = Masc_mcp.Room.reset config in
-      let path = Masc_mcp.Room.masc_dir config in
-      if Sys.file_exists path then
-        let _ = Sys.command (Printf.sprintf "rm -rf %s" path) in ();
-      let parent = Filename.dirname path in
-      if Sys.file_exists parent then
-        try Unix.rmdir parent with _ -> ())
+      (try rm_rf tmp_dir with _ -> ()))
     (fun () -> f env fs config)
 
 (** Test: Basic state machine in Eio context *)


### PR DESCRIPTION
- Remove shell-based subprocess execution; use argv-only Process_eio APIs\n- Refactor git/worktree ops to use "git -C" (no "cd &&")\n- Replace Unix.open_process_in/full + Sys.command in tests with safe OCaml helpers\n- Fix conversation storage path to respect config.base_path\n- Make unit tests deterministic by clearing GRAPHQL_API_KEY/ZAI_API_KEY in test env\n\nTest: dune test