### PR TITLE
Fix join-required tools: auto-init/join and persist nickname

### DIFF
--- a/lib/mcp_server_eio.ml
+++ b/lib/mcp_server_eio.ml
@@ -963,7 +963,9 @@ let execute_tool_eio ~sw ~clock ?mcp_session_id ?auth_token state ~name ~argumen
     "masc_lock"; "masc_unlock";
   ] in
 
-  (* Auto-init/auto-join for better UX (only when auth is disabled). *)
+  (* Auto-init/auto-join for better UX.
+     - Auto-init only when auth is disabled (avoid side effects in secured rooms).
+     - Auto-join when allowed by auth (and safe for token-based auth). *)
   let join_required = List.mem name requires_join in
 
   let init_error =
@@ -989,8 +991,26 @@ let execute_tool_eio ~sw ~clock ?mcp_session_id ?auth_token state ~name ~argumen
                          "masc_cost_report"; "masc_portal_status"] in
   let is_read_only = List.mem name read_only_tools in
 
+  let can_auto_join =
+    if (not join_required) || agent_name = "unknown" then
+      false
+    else if not auth_enabled then
+      true
+    else
+      (* If per-agent tokens are required, only auto-join when agent_name already
+         looks like a stable nickname. Otherwise Room.join would generate a new
+         nickname, breaking token verification for subsequent calls. *)
+      let auth_cfg = Auth.load_auth_config config.base_path in
+      if auth_cfg.require_token && not (Nickname.is_generated_nickname agent_name) then
+        false
+      else
+        match Auth.authorize_tool config.base_path ~agent_name ~token ~tool_name:"masc_join" with
+        | Ok () -> true
+        | Error _ -> false
+  in
+
   let agent_name =
-    if (not auth_enabled) && join_required && agent_name <> "unknown" then begin
+    if can_auto_join then begin
       let room_initialized = Room.is_initialized config in
       let is_joined =
         if room_initialized then

--- a/lib/mcp_server_eio.ml
+++ b/lib/mcp_server_eio.ml
@@ -872,9 +872,44 @@ let execute_tool_eio ~sw ~clock ?mcp_session_id ?auth_token state ~name ~argumen
     | None -> auth_token
   in
 
+  let read_term_session_agent () =
+    match Sys.getenv_opt "TERM_SESSION_ID" with
+    | None -> None
+    | Some sid ->
+        let file = Printf.sprintf "/tmp/.masc_agent_%s" sid in
+        try
+          let ic = open_in file in
+          let name =
+            Common.protect ~module_name:"mcp_server_eio" ~finally_label:"finalizer"
+              ~finally:(fun () -> close_in_noerr ic)
+              (fun () -> input_line ic)
+          in
+          if name = "" then None else Some name
+        with Sys_error _ | End_of_file -> None
+  in
+
+  let persisted_agent_name () =
+    match read_mcp_session_agent () with
+    | Some n -> Some n
+    | None -> read_term_session_agent ()
+  in
+
+  (* If the client keeps sending a legacy agent type (e.g. "claude") but we've
+     already joined and have a generated nickname, prefer the nickname. This
+     avoids repeated auto-joins and makes join-required tools "just work". *)
+  let agent_name =
+    match persisted_agent_name () with
+    | Some persisted
+      when Nickname.is_generated_nickname persisted
+           && not (Nickname.is_generated_nickname agent_name) ->
+        persisted
+    | _ -> agent_name
+  in
+
   (* Enforce tool authorization when enabled *)
+  let auth_enabled = Auth.is_auth_enabled config.base_path in
   let auth_result =
-    if Auth.is_auth_enabled config.base_path then
+    if auth_enabled then
       match Auth.authorize_tool config.base_path ~agent_name ~token ~tool_name:name with
       | Ok () -> Ok ()
       | Error err -> Error err
@@ -885,36 +920,36 @@ let execute_tool_eio ~sw ~clock ?mcp_session_id ?auth_token state ~name ~argumen
   match auth_result with
   | Error err -> (false, Types.masc_error_to_string err)
   | Ok () ->
-  (* Log tool call *)
-  Log.Mcp.debug "[%s] %s" agent_name name;
+  let extract_nickname_from_join_result ~fallback result =
+    try
+      let prefix = "  Nickname: " in
+      let start_idx =
+        let idx = ref 0 in
+        while !idx < String.length result - String.length prefix &&
+              String.sub result !idx (String.length prefix) <> prefix do
+          incr idx
+        done;
+        !idx + String.length prefix
+      in
+      let end_idx = String.index_from result start_idx '\n' in
+      String.sub result start_idx (end_idx - start_idx)
+    with Not_found | Invalid_argument _ -> fallback
+  in
 
-  (* Update activity for any tool call - TODO: migrate to Session_eio when ready *)
-  if agent_name <> "unknown" then begin
-    Session.update_activity registry ~agent_name ();
-    (* Also update disk-based heartbeat for zombie detection across restarts *)
-    if Room.is_initialized config then
-      ignore (Room.heartbeat config ~agent_name)
-  end;
-
-  (* Auto-join: if agent not in session and tool requires agent, auto-register *)
-  let read_only_tools = ["masc_status"; "masc_tasks"; "masc_who"; "masc_agents";
-                         "masc_messages"; "masc_task_history"; "masc_votes"; "masc_vote_status";
-                         "masc_worktree_list"; "masc_pending_interrupts";
-                         "masc_cost_report"; "masc_portal_status"] in
-  if agent_name <> "unknown" && not (List.mem name read_only_tools) then begin
-    match Hashtbl.find_opt registry.sessions agent_name with
-    | Some _ -> ()  (* Already joined *)
-    | None ->
-        (* Auto-join silently *)
-        let agent_file = Filename.concat config.base_path ".masc/agents" |> fun d ->
-          Filename.concat d (agent_name ^ ".json") in
-        if not (Sys.file_exists agent_file) && Room.is_initialized config then begin
-          let _ = Room.join config ~agent_name ~capabilities:[] () in
-          Log.Mcp.info "Auto-joined: %s" agent_name
-        end;
-        let _ = Session.register registry ~agent_name in
-        ()
-  end;
+  let write_term_session_agent nickname =
+    match Sys.getenv_opt "TERM_SESSION_ID" with
+    | None -> ()
+    | Some sid ->
+        let file = Printf.sprintf "/tmp/.masc_agent_%s" sid in
+        (try
+          let oc = open_out file in
+          Common.protect ~module_name:"mcp_server_eio" ~finally_label:"finalizer"
+            ~finally:(fun () -> close_out_noerr oc)
+            (fun () -> output_string oc nickname)
+        with e ->
+          Printf.eprintf "[WARN] Failed to write agent file %s: %s\n%!"
+            file (Printexc.to_string e))
+  in
 
   (* Tools that require agent to be joined first *)
   let requires_join = [
@@ -928,8 +963,74 @@ let execute_tool_eio ~sw ~clock ?mcp_session_id ?auth_token state ~name ~argumen
     "masc_lock"; "masc_unlock";
   ] in
 
-  (* Check if agent must join first *)
+  (* Auto-init/auto-join for better UX (only when auth is disabled). *)
   let join_required = List.mem name requires_join in
+
+  let init_error =
+    if (not auth_enabled) && join_required && not (Room.is_initialized config) then
+      (try
+         ignore (Room.init config ~agent_name:None);
+         None
+       with Invalid_argument msg -> Some msg
+          | Sys_error msg -> Some msg
+          | Yojson.Json_error msg -> Some msg
+          | exn -> Some (Printexc.to_string exn))
+    else
+      None
+  in
+  match init_error with
+  | Some msg ->
+      (false, Printf.sprintf "❌ %s" msg)
+  | None ->
+
+  let read_only_tools = ["masc_status"; "masc_tasks"; "masc_who"; "masc_agents";
+                         "masc_messages"; "masc_task_history"; "masc_votes"; "masc_vote_status";
+                         "masc_worktree_list"; "masc_pending_interrupts";
+                         "masc_cost_report"; "masc_portal_status"] in
+  let is_read_only = List.mem name read_only_tools in
+
+  let agent_name =
+    if (not auth_enabled) && join_required && agent_name <> "unknown" then begin
+      let room_initialized = Room.is_initialized config in
+      let is_joined =
+        if room_initialized then
+          try Room.is_agent_joined config ~agent_name
+          with Sys_error _ | Yojson.Json_error _ | Invalid_argument _ -> false
+        else
+          false
+      in
+      if is_joined then
+        agent_name
+      else begin
+        let join_result = Room.join config ~agent_name ~capabilities:[] () in
+        let nickname = extract_nickname_from_join_result ~fallback:agent_name join_result in
+        Log.Mcp.info "Auto-joined for %s: %s -> %s" name agent_name nickname;
+        (* Persist nickname so subsequent calls can use it. *)
+        write_mcp_session_agent nickname;
+        write_term_session_agent nickname;
+        ignore (Session.register registry ~agent_name:nickname);
+        nickname
+      end
+    end else
+      agent_name
+  in
+
+  (* Auto-register session for non-read-only tools *)
+  if agent_name <> "unknown" && not is_read_only then
+    ignore (Session.register registry ~agent_name);
+
+  (* Log tool call *)
+  Log.Mcp.debug "[%s] %s" agent_name name;
+
+  (* Update activity for any tool call - TODO: migrate to Session_eio when ready *)
+  if agent_name <> "unknown" then begin
+    Session.update_activity registry ~agent_name ();
+    (* Also update disk-based heartbeat for zombie detection across restarts *)
+    if Room.is_initialized config then
+      ignore (Room.heartbeat config ~agent_name)
+  end;
+
+  (* Check if agent must join first *)
   let room_initialized = Room.is_initialized config in
   let is_joined =
     if room_initialized then
@@ -946,8 +1047,14 @@ let execute_tool_eio ~sw ~clock ?mcp_session_id ?auth_token state ~name ~argumen
     "[DEBUG] tool=%s agent_name=%s join_required=%b room_initialized=%b is_joined=%b\n%!"
     name agent_name join_required room_initialized is_joined;
 
-  if join_required && not is_joined then
-    (false, Printf.sprintf "❌ Join required: Call masc_join first before using %s.\n\n💡 Workflow: masc_join → masc_status → %s\n📚 See: @~/me/instructions/masc-workflow.md\n[DEBUG] agent_name=%s is_joined=%b" name name agent_name is_joined)
+  if join_required && not room_initialized then
+    (false, Printf.sprintf
+      "⚠️ MASC room not initialized.\n\n💡 Workflow: masc_init → masc_join → masc_status → %s\n📚 See: @~/me/instructions/masc-workflow.md\n[DEBUG] agent_name=%s room_initialized=%b"
+      name agent_name room_initialized)
+  else if join_required && not is_joined then
+    (false, Printf.sprintf
+      "❌ Join required: Call masc_join first before using %s.\n\n💡 Workflow: masc_join → masc_status → %s\n📚 See: @~/me/instructions/masc-workflow.md\n[DEBUG] agent_name=%s is_joined=%b"
+      name name agent_name is_joined)
   else
 
   (* Safe exec for checkpoint commands - Eio-native *)

--- a/test/test_mcp_server_coverage.ml
+++ b/test/test_mcp_server_coverage.ml
@@ -9,6 +9,7 @@ module Mcp = Masc_mcp.Mcp_server
 module Room = Masc_mcp.Room
 module Session = Masc_mcp.Session
 module Types = Masc_mcp.Types
+module Common = Masc_mcp.Common
 
 (* ===== Test Helpers ===== *)
 
@@ -538,6 +539,69 @@ let test_execute_tool_unknown_tool () =
 
   cleanup_dir base_path
 
+let test_execute_tool_auto_init_and_join_for_broadcast () =
+  Eio_main.run @@ fun env ->
+  let clock = Eio.Stdenv.clock env in
+  Eio.Switch.run @@ fun sw ->
+
+  let base_path = temp_dir () in
+  let state = Mcp_eio.create_state ~test_mode:true ~base_path () in
+
+  (* Simulate a stable MCP session so auto-join can persist the generated nickname. *)
+  let mcp_session_id = "testsession_auto_join" in
+  let agent_file = Printf.sprintf "/tmp/.masc_agent_mcp_%s" mcp_session_id in
+  (try if Sys.file_exists agent_file then Unix.unlink agent_file with _ -> ());
+
+  (* Call a join-required tool without prior init/join: should auto-init + auto-join. *)
+  let (success1, msg1) = Mcp_eio.execute_tool_eio ~sw ~clock ~mcp_session_id state
+    ~name:"masc_broadcast"
+    ~arguments:(`Assoc [
+      ("agent_name", `String "claude-opus");
+      ("message", `String "hello");
+    ]) in
+
+  Alcotest.(check bool) "success1" true success1;
+  Alcotest.(check bool) "broadcast response" true
+    (try let _ = Str.search_forward (Str.regexp_string "📢 [") msg1 0 in true with Not_found -> false);
+
+  (* Nickname should be persisted to the MCP session file. *)
+  Alcotest.(check bool) "agent file created" true (Sys.file_exists agent_file);
+  let nickname =
+    let ic = open_in agent_file in
+    Common.protect ~module_name:"test_mcp_server_coverage" ~finally_label:"finalizer"
+      ~finally:(fun () -> close_in_noerr ic)
+      (fun () -> input_line ic)
+  in
+  Alcotest.(check bool) "nickname non-empty" true (nickname <> "");
+  Alcotest.(check bool) "msg1 contains nickname" true
+    (try let _ = Str.search_forward (Str.regexp_string nickname) msg1 0 in true with Not_found -> false);
+
+  (* Second call with the legacy type should reuse the persisted nickname (no re-join). *)
+  let (success2, msg2) = Mcp_eio.execute_tool_eio ~sw ~clock ~mcp_session_id state
+    ~name:"masc_broadcast"
+    ~arguments:(`Assoc [
+      ("agent_name", `String "claude-opus");
+      ("message", `String "second");
+    ]) in
+  Alcotest.(check bool) "success2" true success2;
+  Alcotest.(check bool) "msg2 contains nickname" true
+    (try let _ = Str.search_forward (Str.regexp_string nickname) msg2 0 in true with Not_found -> false);
+
+  (* Should have exactly one agent file in the room. *)
+  let agents_dir = Filename.concat base_path ".masc/agents" in
+  let json_files =
+    if Sys.file_exists agents_dir then
+      Sys.readdir agents_dir
+      |> Array.to_list
+      |> List.filter (fun f -> Filename.check_suffix f ".json")
+    else
+      []
+  in
+  Alcotest.(check int) "single agent file" 1 (List.length json_files);
+
+  (try if Sys.file_exists agent_file then Unix.unlink agent_file with _ -> ());
+  cleanup_dir base_path
+
 (* ===== Test Suites ===== *)
 
 
@@ -613,6 +677,7 @@ let execute_tool_tests = [
   "masc_set_room", `Quick, test_execute_tool_masc_set_room;
   "masc_set_room_not_found", `Quick, test_execute_tool_masc_set_room_not_found;
   "unknown_tool", `Quick, test_execute_tool_unknown_tool;
+  "auto_init_and_join_broadcast", `Quick, test_execute_tool_auto_init_and_join_for_broadcast;
 ]
 
 let () =


### PR DESCRIPTION
## Problem
- `masc_broadcast` (and other join-required tools) failed with `Join required` when the room wasn't initialized.
- Clients often keep sending legacy agent types (e.g. `claude-opus`) even after `masc_join` generated a nickname, causing repeated join failures.

## Fix
- When auth is disabled: auto-init the room for join-required tools.
- Auto-join on-demand and persist the generated nickname to the MCP/terminal session files so subsequent calls reuse it.
- Improve error messaging: not-initialized vs join-required.

## Tests
- Added coverage test for auto-init + auto-join + nickname reuse.
- `dune test` passes.
