### PR TITLE
fix: keepers stay live across init/restart

### DIFF
--- a/bin/main_eio.ml
+++ b/bin/main_eio.ml
@@ -17,6 +17,7 @@ module Mcp_server = Masc_mcp.Mcp_server
 module Mcp_eio = Masc_mcp.Mcp_server_eio
 module Room = Masc_mcp.Room
 module Room_utils = Masc_mcp.Room_utils
+module Tool_keeper = Masc_mcp.Tool_keeper
 module Graphql_api = Masc_mcp.Graphql_api
 module Types = Masc_mcp.Types
 module Tempo = Masc_mcp.Tempo
@@ -1720,6 +1721,13 @@ let run_server ~sw ~env ~port ~base_path =
   let state = Mcp_eio.create_state_eio ~sw ~env:caqti_env ~proc_mgr ~fs ~clock ~base_path in
   server_state := Some state;
   Mcp_server.set_sse_callback state Sse.broadcast;
+
+  (* Keepers are meant to be long-lived. Start their keepalive fibers on startup
+     so liveness/last_seen stays up-to-date even if no tool calls happen. *)
+  (try
+     let keeper_ctx : _ Tool_keeper.context = { config = state.room_config; sw; clock } in
+     Tool_keeper.start_existing_keepalives keeper_ctx
+   with _ -> ());
 
   (* Initialize Task backend - share pool with Board if PostgreSQL available *)
   (match Board_dispatch.get_pg_pool () with

--- a/lib/room_utils.ml
+++ b/lib/room_utils.ml
@@ -675,9 +675,12 @@ let ensure_initialized_r config : (unit, masc_error) result =
 (* ============================================ *)
 
 let rec mkdir_p path =
-  if not (Sys.file_exists path) then begin
+  if path = "" || path = "/" then ()
+  else if Sys.file_exists path then ()
+  else begin
     mkdir_p (Filename.dirname path);
-    Unix.mkdir path 0o755
+    (try Unix.mkdir path 0o755
+     with Unix.Unix_error (Unix.EEXIST, _, _) -> ())
   end
 
 let read_json_local path =

--- a/lib/tool_keeper.ml
+++ b/lib/tool_keeper.ml
@@ -580,6 +580,11 @@ let start_keepalive (ctx : _ context) (m : keeper_meta) : unit =
   else begin
     let stop = ref false in
     Hashtbl.replace keepalives m.name stop;
+    (* Keepers should be usable even if the user hasn't called masc_init yet. *)
+    (try
+       if not (Room_utils.is_initialized ctx.config) then
+         ignore (Room.init ctx.config ~agent_name:None)
+     with _ -> ());
     (* Ensure the keeper agent exists in room (skip join if already present). *)
     (try
        if not (Room.is_agent_joined ctx.config ~agent_name:m.agent_name) then

--- a/scripts/masc-hub.sh
+++ b/scripts/masc-hub.sh
@@ -11,16 +11,54 @@
 # |   (tasks list)   |   (interactive)  |
 # +------------------+------------------+
 #
-# Usage: masc-hub [room] [port]
+# Usage: masc-hub [room] [port] [--with-server] [--respawn]
 #   room: MASC room/cluster name (default: from ME_ROOT or 'default')
 #   port: MASC server port (default: 8935)
 
 set -e
 
+WITH_SERVER="false"
+RESPAWN_SERVER="false"
+DO_KILL="false"
+DO_HELP="false"
+POSITIONAL_ARGS=()
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        -k|--kill)
+            DO_KILL="true"
+            shift
+            ;;
+        -h|--help)
+            DO_HELP="true"
+            shift
+            ;;
+        --with-server)
+            WITH_SERVER="true"
+            shift
+            ;;
+        --respawn)
+            RESPAWN_SERVER="true"
+            shift
+            ;;
+        --)
+            shift
+            break
+            ;;
+        *)
+            POSITIONAL_ARGS+=("$1")
+            shift
+            ;;
+    esac
+done
+
+if [[ $# -gt 0 ]]; then
+    POSITIONAL_ARGS+=("$@")
+fi
+
 # Configuration
-ROOM="${1:-${MASC_CLUSTER_NAME:-$(basename "${ME_ROOT:-$(pwd)}")}}"
-PORT="${2:-${MASC_PORT:-8935}}"
 SESSION_NAME="masc-hub"
+PORT="${POSITIONAL_ARGS[1]:-${MASC_PORT:-8935}}"
 MASC_URL="http://127.0.0.1:${PORT}"
 
 # Resolve base path (same logic as masc-watch)
@@ -60,6 +98,7 @@ resolve_base_path() {
 
 BASE_PATH="$(resolve_base_path)"
 SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+ROOM="${POSITIONAL_ARGS[0]:-${MASC_CLUSTER_NAME:-$(basename "${ME_ROOT:-$BASE_PATH}")}}"
 
 # Colors for echo
 RED='\033[0;31m'
@@ -162,6 +201,18 @@ create_session() {
     # Focus on shell pane for user interaction
     tmux select-pane -t "$SESSION_NAME:0.3"
 
+    if [ "$WITH_SERVER" = "true" ]; then
+        info "Starting server in tmux window: server"
+        tmux new-window -t "$SESSION_NAME" -n "server" -c "$SCRIPT_DIR"
+        tmux send-keys -t "$SESSION_NAME:server" "cd '$SCRIPT_DIR' && export ME_ROOT='$BASE_PATH' MASC_MCP_PORT='$PORT'" Enter
+        if [ "$RESPAWN_SERVER" = "true" ]; then
+            tmux send-keys -t "$SESSION_NAME:server" "while true; do ./start-masc-mcp.sh --port '$PORT' --base-path '$BASE_PATH'; echo '[masc-hub] server exited, restarting in 1s...'; sleep 1; done" Enter
+        else
+            tmux send-keys -t "$SESSION_NAME:server" "./start-masc-mcp.sh --port '$PORT' --base-path '$BASE_PATH'" Enter
+        fi
+        tmux select-window -t "$SESSION_NAME:masc"
+    fi
+
     success "Session created!"
 }
 
@@ -175,30 +226,33 @@ attach_session() {
 main() {
     check_deps
 
-    # Handle arguments
-    case "${1:-}" in
-        -k|--kill)
-            cleanup_session
-            exit 0
-            ;;
-        -h|--help)
-            echo "Usage: masc-hub [room] [port]"
-            echo "       masc-hub -k|--kill    Kill existing session"
-            echo "       masc-hub -h|--help    Show this help"
-            echo ""
-            echo "Environment:"
-            echo "  MASC_CLUSTER_NAME  Room name (default: basename of ME_ROOT)"
-            echo "  MASC_PORT          Server port (default: 8935)"
-            echo "  MASC_BASE_PATH     Override base path"
-            echo ""
-            echo "Panes:"
-            echo "  Top-left:     Dashboard (masc-watch)"
-            echo "  Bottom-left:  Task Board (watch tasks)"
-            echo "  Top-right:    SSE Events (curl stream)"
-            echo "  Bottom-right: Agent Shell (interactive)"
-            exit 0
-            ;;
-    esac
+    if [ "$DO_HELP" = "true" ]; then
+        echo "Usage: masc-hub [room] [port]"
+        echo "       masc-hub [room] [port] --with-server [--respawn]"
+        echo "       masc-hub -k|--kill    Kill existing session"
+        echo "       masc-hub -h|--help    Show this help"
+        echo ""
+        echo "Environment:"
+        echo "  MASC_CLUSTER_NAME  Room name (default: basename of ME_ROOT)"
+        echo "  MASC_PORT          Server port (default: 8935)"
+        echo "  MASC_BASE_PATH     Override base path"
+        echo ""
+        echo "Panes:"
+        echo "  Top-left:     Dashboard (masc-watch)"
+        echo "  Bottom-left:  Task Board (watch tasks)"
+        echo "  Top-right:    SSE Events (curl stream)"
+        echo "  Bottom-right: Agent Shell (interactive)"
+        echo ""
+        echo "Options:"
+        echo "  --with-server   Start MASC server in a dedicated tmux window (no launchd required)"
+        echo "  --respawn       Restart server automatically if it exits (only with --with-server)"
+        exit 0
+    fi
+
+    if [ "$DO_KILL" = "true" ]; then
+        cleanup_session
+        exit 0
+    fi
 
     # Reuse existing session if available
     if tmux has-session -t "$SESSION_NAME" 2>/dev/null; then
@@ -214,10 +268,14 @@ main() {
 
     # Optional: check server, but don't fail
     if ! check_server; then
-        echo -n "Continue anyway? [y/N] "
-        read -r response
-        if [ "${response,,}" != "y" ]; then
-            exit 1
+        if [ "$WITH_SERVER" = "true" ]; then
+            warn "Server will be started inside tmux (window: server)"
+        else
+            echo -n "Continue anyway? [y/N] "
+            read -r response
+            if [ "${response,,}" != "y" ]; then
+                exit 1
+            fi
         fi
     fi
 


### PR DESCRIPTION
## Why\nKeepers are intended to be long-lived, but liveness would silently break when the room wasn't initialized (no `masc_init`) or after a server restart (keepalive fibers only started after a keeper tool call).\n\n## What\n- Auto-initialize the room when starting a keeper keepalive (so `Room.join/heartbeat` works even if `masc_init` wasn't called).\n- Start existing keeper keepalive fibers on server boot (so `last_seen` stays fresh even with zero tool traffic).\n- Make `Room_utils.mkdir_p` tolerate concurrent `EEXIST` to avoid init races.\n\n## How To Test\n1. Start server\n2. Create keeper via `masc_keeper_up`\n3. Restart server\n4. Confirm `masc_keeper_status` shows agent.exists=true and last_seen_ago_s stays small.