### PR TITLE
fix(sse): guard reconnect storms and idle reaper

### DIFF
--- a/bin/main_eio.ml
+++ b/bin/main_eio.ml
@@ -128,11 +128,29 @@ let get_session_id_query target =
           | _ -> None)
   | _ -> None
 
+let get_cookie_value (request : Httpun.Request.t) cookie_name =
+  match Httpun.Headers.get request.headers "cookie" with
+  | None -> None
+  | Some raw ->
+      raw
+      |> String.split_on_char ';'
+      |> List.find_map (fun part ->
+           match String.split_on_char '=' (String.trim part) with
+           | key :: value_parts
+             when String.lowercase_ascii (String.trim key)
+                  = String.lowercase_ascii cookie_name ->
+               let value = String.concat "=" value_parts |> String.trim in
+               if value = "" then None else Some value
+           | _ -> None)
+
 (** Get session_id from either query param or header *)
 let get_session_id_any (request : Httpun.Request.t) =
   match get_session_id_query request.target with
   | Some _ as id -> id
-  | None -> Httpun.Headers.get request.headers "mcp-session-id"
+  | None ->
+      (match Httpun.Headers.get request.headers "mcp-session-id" with
+       | Some _ as id -> id
+       | None -> get_cookie_value request "mcp-session-id")
 
 (** Build legacy SSE messages endpoint URL (event: endpoint) *)
 let legacy_messages_endpoint_url (request : Httpun.Request.t) session_id =
@@ -664,9 +682,16 @@ let mcp_headers session_id protocol_version = [
   ("mcp-protocol-version", protocol_version);
 ]
 
+let session_cookie_header session_id =
+  ("set-cookie",
+   Printf.sprintf "mcp-session-id=%s; Path=/; Max-Age=86400; SameSite=Lax" session_id)
+
 (** SSE response headers *)
 let sse_headers session_id protocol_version origin =
-  [("content-type", Http_negotiation.sse_content_type)]
+  [
+    ("content-type", Http_negotiation.sse_content_type);
+    session_cookie_header session_id;
+  ]
   @ mcp_headers session_id protocol_version
   @ cors_headers origin
 
@@ -676,6 +701,7 @@ let sse_stream_headers session_id protocol_version origin =
     ("content-type", Http_negotiation.sse_content_type);
     ("cache-control", "no-cache");
     ("connection", "keep-alive");
+    session_cookie_header session_id;
   ]
   @ mcp_headers session_id protocol_version
   @ cors_headers origin
@@ -1160,6 +1186,7 @@ let send_raw info data =
         Httpun.Body.Writer.write_string info.writer data;
         Httpun.Body.Writer.flush info.writer (fun _ -> ())
       );
+      Sse.touch info.session_id;
       true
     with _exn ->
       (* Expected during client disconnect - silent close *)

--- a/lib/sse.ml
+++ b/lib/sse.ml
@@ -173,8 +173,11 @@ let cleanup_stale ?(max_age_s=1800.0) () =
     if now -. c.last_seen_at > max_age_s then sid :: acc else acc
   ) clients [] in
   List.iter (fun sid ->
-    Printf.eprintf "[SSE] idle evict: %s (idle %.0fs)\n%!"
-      sid (now -. (Hashtbl.find clients sid).last_seen_at);
+    (match Hashtbl.find_opt clients sid with
+     | Some client ->
+         Printf.eprintf "[SSE] idle evict: %s (idle %.0fs)\n%!"
+           sid (now -. client.last_seen_at)
+     | None -> ());
     Hashtbl.remove clients sid
   ) stale;
   stale

--- a/lib/sse.ml
+++ b/lib/sse.ml
@@ -11,10 +11,14 @@ type client = {
   push: string -> unit;
   mutable last_event_id: int;
   created_at: float;
+  mutable last_seen_at: float;
 }
 
 (** Client registry - maps session_id to client *)
 let clients : (string, client) Hashtbl.t = Hashtbl.create 16
+
+let mark_seen (client : client) =
+  client.last_seen_at <- Time_compat.now ()
 
 (** Monotonic client id for safe replacement/unregister *)
 let client_id_counter = Atomic.make 0
@@ -78,8 +82,9 @@ let register session_id ~push ~last_event_id =
       | None -> None
     else None
   in
+  let now = Time_compat.now () in
   let new_id = Atomic.fetch_and_add client_id_counter 1 + 1 in
-  let client = { id = new_id; push; last_event_id; created_at = Time_compat.now () } in
+  let client = { id = new_id; push; last_event_id; created_at = now; last_seen_at = now } in
   Hashtbl.replace clients session_id client;
   (client.id, evicted)
 
@@ -99,10 +104,18 @@ let unregister_if_current session_id client_id =
 let exists session_id =
   Hashtbl.mem clients session_id
 
+(** Mark a client as recently active *)
+let touch session_id =
+  match Hashtbl.find_opt clients session_id with
+  | Some client -> mark_seen client
+  | None -> ()
+
 (** Update client's last event ID *)
 let update_last_event_id session_id event_id =
   match Hashtbl.find_opt clients session_id with
-  | Some client -> client.last_event_id <- event_id
+  | Some client ->
+      client.last_event_id <- event_id;
+      mark_seen client
   | None -> ()
 
 (** Broadcast event to all connected clients
@@ -152,15 +165,16 @@ let close_all_clients () =
   List.iter (Hashtbl.remove clients) sessions;
   List.length sessions
 
-(** Remove stale clients older than max_age_s (default 30 min).
+(** Remove clients idle longer than max_age_s (default 30 min).
     Returns list of evicted session_ids so caller can clean up writers. *)
 let cleanup_stale ?(max_age_s=1800.0) () =
   let now = Time_compat.now () in
   let stale = Hashtbl.fold (fun sid c acc ->
-    if now -. c.created_at > max_age_s then sid :: acc else acc
+    if now -. c.last_seen_at > max_age_s then sid :: acc else acc
   ) clients [] in
   List.iter (fun sid ->
-    Printf.eprintf "[SSE] TTL evict: %s (age %.0fs)\n%!" sid (now -. (Hashtbl.find clients sid).created_at);
+    Printf.eprintf "[SSE] idle evict: %s (idle %.0fs)\n%!"
+      sid (now -. (Hashtbl.find clients sid).last_seen_at);
     Hashtbl.remove clients sid
   ) stale;
   stale

--- a/lib/web_dashboard.ml
+++ b/lib/web_dashboard.ml
@@ -1292,9 +1292,49 @@ let cached_html = lazy ({|<!DOCTYPE html>
     let fetchDataTimer = null;
     let fetchBoardTimer = null;
     let periodicRefreshId = null;
+    let sseSource = null;
+    let sseReconnectTimer = null;
+    let sseReconnectAttempts = 0;
+    const sseReconnectBaseMs = 1000;
+    const sseReconnectMaxMs = 15000;
+    const sseSessionStorageKey = 'masc_dashboard_sse_session_id';
     const connStatus = document.getElementById('connection-status');
     const connText = document.getElementById('conn-text');
     const eventCounter = document.getElementById('event-counter');
+
+    function createSseSessionId() {
+      if (window.crypto && typeof window.crypto.randomUUID === 'function') {
+        return 'dash_' + window.crypto.randomUUID();
+      }
+      return 'dash_' + Date.now().toString(36) + '_' + Math.random().toString(36).slice(2, 10);
+    }
+
+    function getOrCreateSseSessionId() {
+      let sid = sessionStorage.getItem(sseSessionStorageKey);
+      if (!sid) {
+        sid = createSseSessionId();
+        sessionStorage.setItem(sseSessionStorageKey, sid);
+      }
+      return sid;
+    }
+
+    function clearSseReconnectTimer() {
+      if (sseReconnectTimer) {
+        clearTimeout(sseReconnectTimer);
+        sseReconnectTimer = null;
+      }
+    }
+
+    function scheduleSseReconnect() {
+      if (sseReconnectTimer) return;
+      sseReconnectAttempts++;
+      const exp = Math.min(sseReconnectAttempts, 5);
+      const delay = Math.min(sseReconnectMaxMs, sseReconnectBaseMs * Math.pow(2, exp));
+      sseReconnectTimer = setTimeout(() => {
+        sseReconnectTimer = null;
+        connectSSE();
+      }, delay);
+    }
 
     function startPeriodicRefresh() {
       if (periodicRefreshId) return;
@@ -1332,19 +1372,32 @@ let cached_html = lazy ({|<!DOCTYPE html>
 
     // SSE for real-time updates
     function connectSSE() {
+      clearSseReconnectTimer();
+      if (sseSource) {
+        sseSource.close();
+        sseSource = null;
+      }
+
       const sseParams = new URLSearchParams();
       if (agent) sseParams.set('agent', agent);
       if (token) sseParams.set('token', token);
+      sseParams.set('session_id', getOrCreateSseSessionId());
       const sseUrl = sseParams.toString() ? ('/sse?' + sseParams.toString()) : '/sse';
       const es = new EventSource(sseUrl);
+      sseSource = es;
       es.onopen = () => {
+        if (sseSource !== es) return;
+        sseReconnectAttempts = 0;
         updateConnectionStatus(true);
         console.log('SSE connected');
       };
       es.onerror = () => {
+        if (sseSource !== es) return;
         updateConnectionStatus(false);
         showToast('Connection lost. Reconnecting...', 'warning');
-        setTimeout(connectSSE, 3000);
+        es.close();
+        sseSource = null;
+        scheduleSseReconnect();
       };
       es.onmessage = (e) => {
         try {
@@ -2269,6 +2322,13 @@ let cached_html = lazy ({|<!DOCTYPE html>
     startPeriodicRefresh();
     fetchData();
     connectSSE();
+    window.addEventListener('beforeunload', () => {
+      if (sseSource) {
+        sseSource.close();
+        sseSource = null;
+      }
+      clearSseReconnectTimer();
+    });
 
 
   </script>

--- a/test/test_sse.ml
+++ b/test/test_sse.ml
@@ -21,9 +21,27 @@ let test_unregister_if_current () =
   check bool "unregistered" false (exists session_id);
   ()
 
+let test_cleanup_stale_respects_touch () =
+  let open Masc_mcp.Sse in
+  let stale_sid = "stale_session_" ^ string_of_int (Random.int 1000000) in
+  let alive_sid = "alive_session_" ^ string_of_int (Random.int 1000000) in
+  let noop _ = () in
+  let (_id1, _) = register stale_sid ~push:noop ~last_event_id:0 in
+  let (_id2, _) = register alive_sid ~push:noop ~last_event_id:0 in
+
+  Unix.sleepf 0.05;
+  touch alive_sid;
+
+  let evicted = cleanup_stale ~max_age_s:0.02 () in
+  check bool "stale evicted" true (List.mem stale_sid evicted);
+  check bool "stale removed" false (exists stale_sid);
+  check bool "touched connection survives" true (exists alive_sid);
+
+  unregister alive_sid
+
 let () =
   run "sse"
     [
       ("unregister_if_current", [test_case "guards reconnect" `Quick test_unregister_if_current]);
+      ("cleanup_stale", [test_case "uses idle time" `Quick test_cleanup_stale_respects_touch]);
     ]
-

--- a/web/index.html
+++ b/web/index.html
@@ -557,7 +557,21 @@
     // Single SSE connection with reconnection logic
     let evtSource = null;
     let reconnectAttempts = 0;
+    let reconnectTimer = null;
     const maxReconnectDelay = 30000;  // max 30s between retries
+    const lobbySseSessionStorageKey = 'masc_lobby_sse_session_id';
+
+    function getOrCreateLobbySseSessionId() {
+      let sid = sessionStorage.getItem(lobbySseSessionStorageKey);
+      if (sid) return sid;
+      if (window.crypto && typeof window.crypto.randomUUID === 'function') {
+        sid = 'lobby_' + window.crypto.randomUUID();
+      } else {
+        sid = 'lobby_' + Date.now().toString(36) + '_' + Math.random().toString(36).slice(2, 10);
+      }
+      sessionStorage.setItem(lobbySseSessionStorageKey, sid);
+      return sid;
+    }
 
     function updateSSEStatus(status) {
       const el = document.getElementById('sse-status');
@@ -570,10 +584,15 @@
       }
 
       updateSSEStatus('🟡');  // connecting
-      evtSource = new EventSource('http://127.0.0.1:8935/sse?room=me');
+      const sid = encodeURIComponent(getOrCreateLobbySseSessionId());
+      evtSource = new EventSource(`http://127.0.0.1:8935/sse?room=me&session_id=${sid}`);
 
       evtSource.onopen = () => {
         reconnectAttempts = 0;
+        if (reconnectTimer) {
+          clearTimeout(reconnectTimer);
+          reconnectTimer = null;
+        }
         updateSSEStatus('🟢');  // connected
         addLocalEvent('✅ SSE connected');
       };
@@ -594,12 +613,17 @@
       evtSource.onerror = (err) => {
         updateSSEStatus('🔴');  // disconnected
         evtSource.close();
+        evtSource = null;
 
         // Exponential backoff reconnect
+        if (reconnectTimer) return;
         reconnectAttempts++;
         const delay = Math.min(1000 * Math.pow(2, reconnectAttempts), maxReconnectDelay);
         addLocalEvent(`⚠️ SSE disconnected, reconnecting in ${delay/1000}s...`);
-        setTimeout(connectSSE, delay);
+        reconnectTimer = setTimeout(() => {
+          reconnectTimer = null;
+          connectSSE();
+        }, delay);
       };
     }
 
@@ -608,6 +632,10 @@
       if (evtSource) {
         evtSource.close();
         evtSource = null;
+      }
+      if (reconnectTimer) {
+        clearTimeout(reconnectTimer);
+        reconnectTimer = null;
       }
       // Leave room
       navigator.sendBeacon(MCP_URL, JSON.stringify({


### PR DESCRIPTION
## Summary
- Prevent duplicate SSE reconnect loops in dashboard clients (`lib/web_dashboard.ml`, `web/index.html`)
- Stabilize session continuity via `mcp-session-id` cookie fallback + header emission (`bin/main_eio.ml`)
- Switch stale cleanup from connection age to idle age, and mark activity on successful writes (`lib/sse.ml`, `bin/main_eio.ml`)
- Add regression test for idle-based cleanup semantics (`test/test_sse.ml`)

## Why
Frequent SSE disconnect/reconnect bursts could create parallel reconnection attempts and session churn, which amplified traffic and reduced stability.

## Validation
- `dune exec --root . ./test/test_sse.exe`
- `dune build --root .`