### PR TITLE
feat(sse): add reconnect storm guard and 429 backpressure

### DIFF
--- a/bin/main_eio.ml
+++ b/bin/main_eio.ml
@@ -1152,6 +1152,40 @@ let set_sse_active_connections_metric () =
   Masc_mcp.Prometheus.set_gauge "masc_sse_connections_active"
     (float_of_int (Sse.client_count ()))
 
+let record_sse_reject_metric ~endpoint ~reason =
+  Masc_mcp.Prometheus.inc_counter "masc_sse_rejects_total"
+    ~labels:[("endpoint", endpoint); ("reason", reason)] ()
+
+let respond_sse_rejected
+    reqd
+    ~session_id
+    ~protocol_version
+    ~origin
+    ~endpoint
+    ~(reason : Sse.admission_reject_reason)
+    ~retry_ms
+  =
+  let reason_label = Sse.admission_reason_to_string reason in
+  let retry_after_s =
+    max 1 (int_of_float (ceil (float_of_int retry_ms /. 1000.0)))
+  in
+  record_sse_reject_metric ~endpoint ~reason:reason_label;
+  let body =
+    Yojson.Safe.to_string (`Assoc [
+      ("error", `String "sse_connection_rate_limited");
+      ("reason", `String reason_label);
+      ("retry_after_ms", `Int retry_ms);
+      ("session_id", `String session_id);
+    ])
+  in
+  let headers = Httpun.Headers.of_list (
+    ("content-length", string_of_int (String.length body))
+    :: ("retry-after", string_of_int retry_after_s)
+    :: json_headers session_id protocol_version origin
+  ) in
+  let response = Httpun.Response.create ~headers `Too_many_requests in
+  Httpun.Reqd.respond_with_string reqd response body
+
 let close_sse_conn info =
   if not info.closed then begin
     info.closed <- true;
@@ -1216,100 +1250,106 @@ let handle_get_mcp ?legacy_messages_endpoint request reqd =
     | None -> "mcp"
   in
 
-  (* Replace existing connection for session_id *)
-  if Hashtbl.mem sse_conn_by_session session_id then
-    Masc_mcp.Prometheus.inc_counter "masc_sse_reconnects_total"
-      ~labels:[("endpoint", endpoint_label)] ();
-  stop_sse_session session_id;
+  match Sse.admit_connection session_id with
+  | Rejected { reason; retry_ms } ->
+      respond_sse_rejected reqd
+        ~session_id ~protocol_version ~origin
+        ~endpoint:endpoint_label ~reason ~retry_ms
+  | Allowed ->
+      (* Replace existing connection for session_id *)
+      if Hashtbl.mem sse_conn_by_session session_id then
+        Masc_mcp.Prometheus.inc_counter "masc_sse_reconnects_total"
+          ~labels:[("endpoint", endpoint_label)] ();
+      stop_sse_session session_id;
 
-  let headers = Httpun.Headers.of_list (sse_stream_headers session_id protocol_version origin) in
-  let response = Httpun.Response.create ~headers `OK in
-  let writer = Httpun.Reqd.respond_with_streaming reqd response in
-  let mutex = Eio.Mutex.create () in
-  let info_ref : sse_conn_info option ref = ref None in
-  let push event =
-    match !info_ref with
-    | None -> ()
-    | Some info -> ignore (send_raw info event)
-  in
-  let (client_id, evicted) =
-    Sse.register session_id ~push
-      ~last_event_id:(Option.value ~default:0 last_event_id)
-  in
-  (* Clean up writer for evicted session *)
-  (match evicted with
-   | Some evicted_sid ->
-       Masc_mcp.Prometheus.inc_counter "masc_sse_capacity_evictions_total"
-         ~labels:[("endpoint", endpoint_label)] ();
-       stop_sse_session evicted_sid
-   | None -> ());
-  let info = {
-    session_id;
-    client_id;
-    writer;
-    mutex;
-    stop = ref false;
-    closed = false;
-  } in
-  info_ref := Some info;
-  Hashtbl.replace sse_conn_by_session session_id info;
-  set_sse_active_connections_metric ();
+      let headers = Httpun.Headers.of_list (sse_stream_headers session_id protocol_version origin) in
+      let response = Httpun.Response.create ~headers `OK in
+      let writer = Httpun.Reqd.respond_with_streaming reqd response in
+      let mutex = Eio.Mutex.create () in
+      let info_ref : sse_conn_info option ref = ref None in
+      let push event =
+        match !info_ref with
+        | None -> ()
+        | Some info -> ignore (send_raw info event)
+      in
+      let (client_id, evicted) =
+        Sse.register session_id ~push
+          ~last_event_id:(Option.value ~default:0 last_event_id)
+      in
+      (* Clean up writer for evicted session *)
+      (match evicted with
+       | Some evicted_sid ->
+           Masc_mcp.Prometheus.inc_counter "masc_sse_capacity_evictions_total"
+             ~labels:[("endpoint", endpoint_label)] ();
+           stop_sse_session evicted_sid
+       | None -> ());
+      let info = {
+        session_id;
+        client_id;
+        writer;
+        mutex;
+        stop = ref false;
+        closed = false;
+      } in
+      info_ref := Some info;
+      Hashtbl.replace sse_conn_by_session session_id info;
+      set_sse_active_connections_metric ();
 
-  (* Send priming event first *)
-  ignore (send_raw info (sse_prime_event ()));
+      (* Send priming event first *)
+      ignore (send_raw info (sse_prime_event ()));
 
-  (* Legacy SSE transport: provide messages endpoint (event: endpoint) *)
-  (match legacy_messages_endpoint with
-   | None -> ()
-   | Some f ->
-       let endpoint_url = f session_id in
-       ignore (send_raw info (Sse.format_event ~event_type:"endpoint" endpoint_url)));
+      (* Legacy SSE transport: provide messages endpoint (event: endpoint) *)
+      (match legacy_messages_endpoint with
+       | None -> ()
+       | Some f ->
+           let endpoint_url = f session_id in
+           ignore (send_raw info (Sse.format_event ~event_type:"endpoint" endpoint_url)));
 
-  (* Replay missed events if Last-Event-ID provided (MCP spec MUST) *)
-  (match last_event_id with
-   | Some last_id ->
-       let missed = Sse.get_events_after last_id in
-       List.iter (fun ev -> ignore (send_raw info ev)) missed
-   | None -> ());
+      (* Replay missed events if Last-Event-ID provided (MCP spec MUST) *)
+      (match last_event_id with
+       | Some last_id ->
+           let missed = Sse.get_events_after last_id in
+           List.iter (fun ev -> ignore (send_raw info ev)) missed
+       | None -> ());
 
-  (* Keep-alive ping loop *)
-  (match !current_sw, !current_clock with
-   | Some sw, Some clock ->
-       Eio.Fiber.fork ~sw (fun () ->
-         let is_cancelled exn =
-           match exn with
-           | Eio.Cancel.Cancelled _ -> true
-           | _ -> false
-         in
-         let rec loop () =
-           if not !(info.stop) then begin
-             (try
-                Eio.Time.sleep clock sse_ping_interval_s
-              with exn ->
-                if is_cancelled exn then raise exn;
-                Printf.eprintf "[SSE] ping sleep error: %s\n%!" (Printexc.to_string exn));
-             (try
-                if info.closed then
-                  stop_sse_session info.session_id
-                else if not !(info.stop) then
-                  ignore (send_raw info ": ping\n\n")
-              with exn ->
-                if is_cancelled exn then raise exn;
-                Printf.eprintf "[SSE] ping send error: %s\n%!" (Printexc.to_string exn);
-                stop_sse_session info.session_id);
-             loop ()
-           end
-         in
-         try loop () with exn ->
-           if is_cancelled exn then ()
-           else Printf.eprintf "[SSE] ping loop error: %s\n%!" (Printexc.to_string exn))
-   | _ -> ());
+      (* Keep-alive ping loop *)
+      (match !current_sw, !current_clock with
+       | Some sw, Some clock ->
+           Eio.Fiber.fork ~sw (fun () ->
+             let is_cancelled exn =
+               match exn with
+               | Eio.Cancel.Cancelled _ -> true
+               | _ -> false
+             in
+             let rec loop () =
+               if not !(info.stop) then begin
+                 (try
+                    Eio.Time.sleep clock sse_ping_interval_s
+                  with exn ->
+                    if is_cancelled exn then raise exn;
+                    Printf.eprintf "[SSE] ping sleep error: %s\n%!" (Printexc.to_string exn));
+                 (try
+                    if info.closed then
+                      stop_sse_session info.session_id
+                    else if not !(info.stop) then
+                      ignore (send_raw info ": ping\n\n")
+                  with exn ->
+                    if is_cancelled exn then raise exn;
+                    Printf.eprintf "[SSE] ping send error: %s\n%!" (Printexc.to_string exn);
+                    stop_sse_session info.session_id);
+                 loop ()
+               end
+             in
+             try loop () with exn ->
+               if is_cancelled exn then ()
+               else Printf.eprintf "[SSE] ping loop error: %s\n%!" (Printexc.to_string exn))
+       | _ -> ());
 
-  (* Only log when approaching capacity or in debug mode *)
-  let client_count = Sse.client_count () in
-  if client_count > Sse.max_clients / 2 then
-    Printf.eprintf "📡 SSE connected: %s (active: %d/%d)\n%!"
-      session_id client_count Sse.max_clients
+      (* Only log when approaching capacity or in debug mode *)
+      let client_count = Sse.client_count () in
+      if client_count > Sse.max_clients / 2 then
+        Printf.eprintf "📡 SSE connected: %s (active: %d/%d)\n%!"
+          session_id client_count Sse.max_clients
 
 (** SSE simple handler - for compatibility, returns single event *)
 let sse_simple_handler request reqd =
@@ -1427,97 +1467,103 @@ let make_routes ~port ~host =
        let room_id = Option.value ~default:"default" (query_param request "room") in
        let last_event_id = get_last_event_id request in
 
-       if Hashtbl.mem sse_conn_by_session session_id then
-         Masc_mcp.Prometheus.inc_counter "masc_sse_reconnects_total"
-           ~labels:[("endpoint", "ag_ui")] ();
-       stop_sse_session session_id;
+       match Sse.admit_connection session_id with
+       | Rejected { reason; retry_ms } ->
+           respond_sse_rejected reqd
+             ~session_id ~protocol_version ~origin
+             ~endpoint:"ag_ui" ~reason ~retry_ms
+       | Allowed ->
+           if Hashtbl.mem sse_conn_by_session session_id then
+             Masc_mcp.Prometheus.inc_counter "masc_sse_reconnects_total"
+               ~labels:[("endpoint", "ag_ui")] ();
+           stop_sse_session session_id;
 
-       let headers = Httpun.Headers.of_list (sse_stream_headers session_id protocol_version origin) in
-       let response = Httpun.Response.create ~headers `OK in
-       let writer = Httpun.Reqd.respond_with_streaming reqd response in
-       let mutex = Eio.Mutex.create () in
-       let info_ref : sse_conn_info option ref = ref None in
-       let push event =
-         match !info_ref with
-         | None -> ()
-         | Some info ->
-           (* Translate MASC SSE data to AG-UI event format.
-              Parse the JSON from the SSE data line and re-emit as AG-UI CUSTOM. *)
-           let ag_ui_event =
-             try
-               (* Extract JSON from SSE format: "id: N\nevent: type\ndata: {...}\n\n" *)
-               let lines = String.split_on_char '\n' event in
-               let data_line = List.find_opt (fun l ->
-                 String.length l > 6 && String.sub l 0 6 = "data: "
-               ) lines in
-               match data_line with
-               | Some dl ->
-                 let json_str = String.sub dl 6 (String.length dl - 6) in
-                 let json = Yojson.Safe.from_string json_str in
-                 let ag_event = Masc_mcp.Ag_ui.of_custom ~room_id
-                   ~name:"MASC_EVENT" json in
-                 Masc_mcp.Ag_ui.event_to_sse ag_event
-               | None -> event  (* Pass through if no data line *)
-             with _ -> event  (* Pass through on parse error *)
+           let headers = Httpun.Headers.of_list (sse_stream_headers session_id protocol_version origin) in
+           let response = Httpun.Response.create ~headers `OK in
+           let writer = Httpun.Reqd.respond_with_streaming reqd response in
+           let mutex = Eio.Mutex.create () in
+           let info_ref : sse_conn_info option ref = ref None in
+           let push event =
+             match !info_ref with
+             | None -> ()
+             | Some info ->
+               (* Translate MASC SSE data to AG-UI event format.
+                  Parse the JSON from the SSE data line and re-emit as AG-UI CUSTOM. *)
+               let ag_ui_event =
+                 try
+                   (* Extract JSON from SSE format: "id: N\nevent: type\ndata: {...}\n\n" *)
+                   let lines = String.split_on_char '\n' event in
+                   let data_line = List.find_opt (fun l ->
+                     String.length l > 6 && String.sub l 0 6 = "data: "
+                   ) lines in
+                   match data_line with
+                   | Some dl ->
+                     let json_str = String.sub dl 6 (String.length dl - 6) in
+                     let json = Yojson.Safe.from_string json_str in
+                     let ag_event = Masc_mcp.Ag_ui.of_custom ~room_id
+                       ~name:"MASC_EVENT" json in
+                     Masc_mcp.Ag_ui.event_to_sse ag_event
+                   | None -> event  (* Pass through if no data line *)
+                 with _ -> event  (* Pass through on parse error *)
+               in
+               ignore (send_raw info ag_ui_event)
            in
-           ignore (send_raw info ag_ui_event)
-       in
-       let (client_id, evicted) =
-         Sse.register session_id ~push
-           ~last_event_id:(Option.value ~default:0 last_event_id)
-       in
-       (match evicted with
-        | Some evicted_sid ->
-            Masc_mcp.Prometheus.inc_counter "masc_sse_capacity_evictions_total"
-              ~labels:[("endpoint", "ag_ui")] ();
-            stop_sse_session evicted_sid
-        | None -> ());
-       let info = {
-         session_id;
-         client_id;
-         writer;
-         mutex;
-         stop = ref false;
-         closed = false;
-       } in
-       info_ref := Some info;
-       Hashtbl.replace sse_conn_by_session session_id info;
-       set_sse_active_connections_metric ();
+           let (client_id, evicted) =
+             Sse.register session_id ~push
+               ~last_event_id:(Option.value ~default:0 last_event_id)
+           in
+           (match evicted with
+            | Some evicted_sid ->
+                Masc_mcp.Prometheus.inc_counter "masc_sse_capacity_evictions_total"
+                  ~labels:[("endpoint", "ag_ui")] ();
+                stop_sse_session evicted_sid
+            | None -> ());
+           let info = {
+             session_id;
+             client_id;
+             writer;
+             mutex;
+             stop = ref false;
+             closed = false;
+           } in
+           info_ref := Some info;
+           Hashtbl.replace sse_conn_by_session session_id info;
+           set_sse_active_connections_metric ();
 
-       (* Send AG-UI priming: RUN_STARTED event *)
-       let prime = Masc_mcp.Ag_ui.(
-         make_event ~thread_id:room_id
-           ~run_id:(Some session_id)
-           Run_started
-         |> event_to_sse
-       ) in
-       ignore (send_raw info prime);
+           (* Send AG-UI priming: RUN_STARTED event *)
+           let prime = Masc_mcp.Ag_ui.(
+             make_event ~thread_id:room_id
+               ~run_id:(Some session_id)
+               Run_started
+             |> event_to_sse
+           ) in
+           ignore (send_raw info prime);
 
-       (* Replay missed events *)
-       (match last_event_id with
-        | Some last_id ->
-          let missed = Sse.get_events_after last_id in
-          List.iter (fun ev -> ignore (send_raw info ev)) missed
-        | None -> ());
+           (* Replay missed events *)
+           (match last_event_id with
+            | Some last_id ->
+              let missed = Sse.get_events_after last_id in
+              List.iter (fun ev -> ignore (send_raw info ev)) missed
+            | None -> ());
 
-       (* Keep-alive ping *)
-       (match !current_sw, !current_clock with
-        | Some sw, Some clock ->
-          Eio.Fiber.fork ~sw (fun () ->
-            let rec loop () =
-              if not !(info.stop) then begin
-                (try Eio.Time.sleep clock sse_ping_interval_s
-                 with _ -> ());
-                (try
-                   if info.closed then stop_sse_session info.session_id
-                   else if not !(info.stop) then
-                     ignore (send_raw info ": ping\n\n")
-                 with _ -> stop_sse_session info.session_id);
-                loop ()
-              end
-            in
-            try loop () with _ -> ())
-        | _ -> ()))
+           (* Keep-alive ping *)
+           (match !current_sw, !current_clock with
+            | Some sw, Some clock ->
+              Eio.Fiber.fork ~sw (fun () ->
+                let rec loop () =
+                  if not !(info.stop) then begin
+                    (try Eio.Time.sleep clock sse_ping_interval_s
+                     with _ -> ());
+                    (try
+                       if info.closed then stop_sse_session info.session_id
+                       else if not !(info.stop) then
+                         ignore (send_raw info ": ping\n\n")
+                     with _ -> stop_sse_session info.session_id);
+                    loop ()
+                  end
+                in
+                try loop () with _ -> ())
+            | _ -> ()))
   |> Http.Router.get "/dashboard" (fun request reqd ->
        with_public_read (fun _state req reqd ->
          Http.Response.html_cached

--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -123,7 +123,8 @@ let init () =
   add "masc_sse_reconnects_total" "Total SSE reconnects (same session reattached)" Counter;
   add "masc_sse_idle_evictions_total" "Total SSE clients evicted by idle reaper" Counter;
   add "masc_sse_capacity_evictions_total" "Total SSE clients evicted due to max client capacity" Counter;
-  add "masc_sse_write_failures_total" "Total SSE write failures by reason" Counter
+  add "masc_sse_write_failures_total" "Total SSE write failures by reason" Counter;
+  add "masc_sse_rejects_total" "Total SSE connections rejected by storm guard" Counter
 
 let start_time = Time_compat.now ()
 

--- a/lib/sse.ml
+++ b/lib/sse.ml
@@ -5,6 +5,114 @@
     Increased from 50 to 200 to handle Claude.ai MCP client reconnections. *)
 let max_clients = 200
 
+(** SSE reconnect storm guard defaults.
+    - session cooldown: minimum time between reconnects per session_id
+    - global window: max accepted new SSE connections per window *)
+let parse_float_env ~name ~default =
+  match Sys.getenv_opt name with
+  | None -> default
+  | Some raw ->
+      (try float_of_string (String.trim raw) with _ -> default)
+
+let parse_int_env ~name ~default =
+  match Sys.getenv_opt name with
+  | None -> default
+  | Some raw ->
+      (try int_of_string (String.trim raw) with _ -> default)
+
+let reconnect_min_interval_s =
+  max 0.0
+    (parse_float_env
+       ~name:"MASC_SSE_RECONNECT_MIN_INTERVAL_S"
+       ~default:1.0)
+
+let connect_rate_window_s =
+  max 0.1
+    (parse_float_env
+       ~name:"MASC_SSE_CONNECT_WINDOW_S"
+       ~default:10.0)
+
+let connect_rate_max_in_window =
+  max 1
+    (parse_int_env
+       ~name:"MASC_SSE_CONNECT_MAX_IN_WINDOW"
+       ~default:120)
+
+type admission_reject_reason =
+  | Session_cooldown
+  | Global_rate_limit
+
+type admission =
+  | Allowed
+  | Rejected of {
+      reason: admission_reject_reason;
+      retry_ms: int;
+    }
+
+(** Sliding window for accepted SSE connections (storm guard) *)
+let accepted_connect_timestamps : float Queue.t = Queue.create ()
+
+(** Last accepted connection time per session_id *)
+let last_connect_by_session : (string, float) Hashtbl.t = Hashtbl.create 128
+
+let admission_reason_to_string = function
+  | Session_cooldown -> "session_cooldown"
+  | Global_rate_limit -> "global_rate_limit"
+
+let retry_ms_of_seconds s =
+  max 250 (int_of_float (ceil (s *. 1000.0)))
+
+let rec trim_connect_window ~now ~window_s =
+  match Queue.peek_opt accepted_connect_timestamps with
+  | Some ts when now -. ts > window_s ->
+      ignore (Queue.pop accepted_connect_timestamps);
+      trim_connect_window ~now ~window_s
+  | _ -> ()
+
+let prune_old_session_connects ~now ~ttl_s =
+  if Hashtbl.length last_connect_by_session > (max_clients * 4) then begin
+    let stale = Hashtbl.fold (fun sid ts acc ->
+      if now -. ts > ttl_s then sid :: acc else acc
+    ) last_connect_by_session [] in
+    List.iter (Hashtbl.remove last_connect_by_session) stale
+  end
+
+let admit_connection_at
+    ?(min_interval_s = reconnect_min_interval_s)
+    ?(window_s = connect_rate_window_s)
+    ?(max_in_window = connect_rate_max_in_window)
+    ~now
+    session_id
+  =
+  trim_connect_window ~now ~window_s;
+  let prune_ttl_s = max 60.0 (4.0 *. max min_interval_s window_s) in
+  prune_old_session_connects ~now ~ttl_s:prune_ttl_s;
+  match Hashtbl.find_opt last_connect_by_session session_id with
+  | Some last_ts when min_interval_s > 0.0 && now -. last_ts < min_interval_s ->
+      let wait_s = min_interval_s -. (now -. last_ts) in
+      Rejected { reason = Session_cooldown; retry_ms = retry_ms_of_seconds wait_s }
+  | _ when Queue.length accepted_connect_timestamps >= max_in_window ->
+      let retry_ms =
+        match Queue.peek_opt accepted_connect_timestamps with
+        | None -> retry_ms_of_seconds window_s
+        | Some oldest_ts ->
+            let wait_s = window_s -. (now -. oldest_ts) in
+            retry_ms_of_seconds (max 0.0 wait_s)
+      in
+      Rejected { reason = Global_rate_limit; retry_ms }
+  | _ ->
+      Queue.push now accepted_connect_timestamps;
+      Hashtbl.replace last_connect_by_session session_id now;
+      Allowed
+
+let admit_connection session_id =
+  admit_connection_at ~now:(Time_compat.now ()) session_id
+
+(** Test helper: clears in-memory storm guard state. *)
+let reset_admission_state_for_test () =
+  Queue.clear accepted_connect_timestamps;
+  Hashtbl.clear last_connect_by_session
+
 (** SSE client state *)
 type client = {
   id: int;

--- a/test/test_prometheus_coverage.ml
+++ b/test/test_prometheus_coverage.ml
@@ -212,7 +212,8 @@ let test_to_prometheus_text_has_sse_metrics () =
   check bool "has sse active gauge" true (has "masc_sse_connections_active");
   check bool "has sse reconnect counter" true (has "masc_sse_reconnects_total");
   check bool "has sse idle eviction counter" true (has "masc_sse_idle_evictions_total");
-  check bool "has sse write failure counter" true (has "masc_sse_write_failures_total")
+  check bool "has sse write failure counter" true (has "masc_sse_write_failures_total");
+  check bool "has sse reject counter" true (has "masc_sse_rejects_total")
 
 (* ============================================================
    Convenience Functions Tests

--- a/test/test_sse.ml
+++ b/test/test_sse.ml
@@ -39,9 +39,74 @@ let test_cleanup_stale_respects_touch () =
 
   unregister alive_sid
 
+let test_admit_connection_session_cooldown () =
+  let open Masc_mcp.Sse in
+  reset_admission_state_for_test ();
+  let sid = "cooldown_session" in
+  (match admit_connection_at
+           ~now:100.0
+           ~min_interval_s:1.0
+           ~window_s:10.0
+           ~max_in_window:100
+           sid with
+   | Allowed -> ()
+   | Rejected _ -> fail "first connection should be allowed");
+  match admit_connection_at
+          ~now:100.2
+          ~min_interval_s:1.0
+          ~window_s:10.0
+          ~max_in_window:100
+          sid with
+  | Allowed -> fail "immediate reconnect should be rejected"
+  | Rejected { reason = Session_cooldown; retry_ms } ->
+      check bool "retry_ms positive" true (retry_ms > 0)
+  | Rejected { reason = Global_rate_limit; _ } ->
+      fail "unexpected global rate limit"
+
+let test_admit_connection_global_rate_limit () =
+  let open Masc_mcp.Sse in
+  reset_admission_state_for_test ();
+  let cfg_min = 0.0 in
+  let cfg_window = 5.0 in
+  let cfg_max = 2 in
+  (match admit_connection_at ~now:200.0 ~min_interval_s:cfg_min ~window_s:cfg_window ~max_in_window:cfg_max "a" with
+   | Allowed -> ()
+   | Rejected _ -> fail "first connection should be allowed");
+  (match admit_connection_at ~now:200.1 ~min_interval_s:cfg_min ~window_s:cfg_window ~max_in_window:cfg_max "b" with
+   | Allowed -> ()
+   | Rejected _ -> fail "second connection should be allowed");
+  match admit_connection_at ~now:200.2 ~min_interval_s:cfg_min ~window_s:cfg_window ~max_in_window:cfg_max "c" with
+  | Allowed -> fail "third connection in window should be rejected"
+  | Rejected { reason = Global_rate_limit; retry_ms } ->
+      check bool "retry_ms positive" true (retry_ms > 0)
+  | Rejected { reason = Session_cooldown; _ } ->
+      fail "unexpected session cooldown"
+
+let test_admit_connection_window_reopens () =
+  let open Masc_mcp.Sse in
+  reset_admission_state_for_test ();
+  let cfg_min = 0.0 in
+  let cfg_window = 1.0 in
+  let cfg_max = 1 in
+  (match admit_connection_at ~now:300.0 ~min_interval_s:cfg_min ~window_s:cfg_window ~max_in_window:cfg_max "a" with
+   | Allowed -> ()
+   | Rejected _ -> fail "first connection should be allowed");
+  (match admit_connection_at ~now:300.1 ~min_interval_s:cfg_min ~window_s:cfg_window ~max_in_window:cfg_max "b" with
+   | Allowed -> fail "should still be rate limited in window"
+   | Rejected { reason = Global_rate_limit; _ } -> ()
+   | Rejected { reason = Session_cooldown; _ } -> fail "unexpected session cooldown");
+  match admit_connection_at ~now:301.2 ~min_interval_s:cfg_min ~window_s:cfg_window ~max_in_window:cfg_max "b" with
+  | Allowed -> ()
+  | Rejected _ -> fail "window should allow connection again"
+
 let () =
   run "sse"
     [
       ("unregister_if_current", [test_case "guards reconnect" `Quick test_unregister_if_current]);
       ("cleanup_stale", [test_case "uses idle time" `Quick test_cleanup_stale_respects_touch]);
+      ("admit_connection", [
+        test_case "session cooldown" `Quick test_admit_connection_session_cooldown;
+        test_case "global rate limit" `Quick test_admit_connection_global_rate_limit;
+        test_case "window reopens" `Quick test_admit_connection_window_reopens;
+      ]);
     ]


### PR DESCRIPTION
## Summary
- add SSE storm guard admission logic with per-session reconnect cooldown and global connect-window limits
- reject burst reconnects with HTTP 429 + Retry-After instead of tearing down existing streams
- track rejections via `masc_sse_rejects_total{endpoint,reason}` and expose in Prometheus
- add unit tests for session cooldown, global rate limit, and window reopening behavior

## Config
- `MASC_SSE_RECONNECT_MIN_INTERVAL_S` (default: `1.0`)
- `MASC_SSE_CONNECT_WINDOW_S` (default: `10.0`)
- `MASC_SSE_CONNECT_MAX_IN_WINDOW` (default: `120`)

## Validation
- `dune exec --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/feat-sse-storm-guard --build-dir /tmp/dune-feat-sse-storm-guard ./test/test_sse.exe`
- `dune exec --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/feat-sse-storm-guard --build-dir /tmp/dune-feat-sse-storm-guard ./test/test_prometheus_coverage.exe`
- `dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/feat-sse-storm-guard --build-dir /tmp/dune-feat-sse-storm-guard bin/main_eio.exe`