### PR TITLE
test(sse): add storm reconnect e2e and fix router dispatch

### DIFF
--- a/lib/http_server_eio.ml
+++ b/lib/http_server_eio.ml
@@ -390,14 +390,16 @@ module Router = struct
   let dispatch routes request reqd =
     let req_path = Request.path request in
     let req_method = Request.method_ request in
-    match List.find_opt (fun r -> String.equal r.path req_path) routes with
-    | Some route ->
-        if List.mem req_method route.methods then
-          route.handler request reqd
+    let path_matches =
+      List.filter (fun route -> String.equal route.path req_path) routes
+    in
+    match List.find_opt (fun route -> List.mem req_method route.methods) path_matches with
+    | Some route -> route.handler request reqd
+    | None ->
+        if path_matches = [] then
+          Response.not_found reqd
         else
           Response.method_not_allowed reqd
-    | None ->
-        Response.not_found reqd
 end
 
 (** Health check endpoint - JSON response *)

--- a/test/dune
+++ b/test/dune
@@ -283,6 +283,13 @@
  (modules test_mcp_full_cycle)
  (libraries masc_mcp alcotest eio eio_main yojson))
 
+; SSE storm guard endpoint-level integration tests
+(test
+ (name test_sse_storm_e2e)
+ (modules test_sse_storm_e2e)
+ (libraries alcotest yojson unix)
+ (deps ../bin/main_eio.exe))
+
 ; Agent Registry Eio tests
 (test
  (name test_agent_registry_eio)

--- a/test/test_sse_storm_e2e.ml
+++ b/test/test_sse_storm_e2e.ml
@@ -1,0 +1,332 @@
+open Alcotest
+open Yojson.Safe.Util
+
+type http_result = {
+  status: int option;
+  headers: (string * string) list;
+  body: string;
+  curl_exit: int;
+  stderr: string;
+}
+
+let read_all ic =
+  let buf = Buffer.create 1024 in
+  (try
+     while true do
+       Buffer.add_channel buf ic 4096
+     done
+   with End_of_file -> ());
+  Buffer.contents buf
+
+let read_file path =
+  let ic = open_in_bin path in
+  Fun.protect
+    ~finally:(fun () -> close_in_noerr ic)
+    (fun () ->
+      let len = in_channel_length ic in
+      really_input_string ic len)
+
+let trim_cr s =
+  let n = String.length s in
+  if n > 0 && s.[n - 1] = '\r' then String.sub s 0 (n - 1) else s
+
+let parse_headers raw =
+  let lines = String.split_on_char '\n' raw |> List.map trim_cr in
+  let rec collect blocks current = function
+    | [] ->
+        let blocks =
+          if current = [] then blocks else List.rev current :: blocks
+        in
+        List.rev blocks
+    | line :: rest ->
+        if line = "" then
+          let blocks =
+            if current = [] then blocks else List.rev current :: blocks
+          in
+          collect blocks [] rest
+        else
+          collect blocks (line :: current) rest
+  in
+  let blocks = collect [] [] lines in
+  let last_http_block =
+    List.fold_left
+      (fun acc block ->
+         match block with
+         | status_line :: _ when String.length status_line >= 5
+                                && String.sub status_line 0 5 = "HTTP/" ->
+             Some block
+         | _ -> acc)
+      None blocks
+  in
+  match last_http_block with
+  | None -> (None, [])
+  | Some (status_line :: header_lines) ->
+      let status =
+        match String.split_on_char ' ' status_line with
+        | _proto :: code :: _ -> (try Some (int_of_string code) with _ -> None)
+        | _ -> None
+      in
+      let headers =
+        List.filter_map
+          (fun line ->
+             match String.index_opt line ':' with
+             | None -> None
+             | Some idx ->
+                 let key =
+                   String.sub line 0 idx |> String.trim |> String.lowercase_ascii
+                 in
+                 let value =
+                   String.sub line (idx + 1) (String.length line - idx - 1)
+                   |> String.trim
+                 in
+                 Some (key, value))
+          header_lines
+      in
+      (status, headers)
+  | Some [] -> (None, [])
+
+let run_curl ?(headers=[]) ?max_time ~port ~path () =
+  let header_file = Filename.temp_file "sse-storm-header-" ".txt" in
+  let body_file = Filename.temp_file "sse-storm-body-" ".txt" in
+  let url = Printf.sprintf "http://127.0.0.1:%d%s" port path in
+  let max_time_args =
+    match max_time with
+    | None -> []
+    | Some t -> ["--max-time"; Printf.sprintf "%.3f" t]
+  in
+  let header_args =
+    List.concat_map
+      (fun (k, v) -> ["-H"; Printf.sprintf "%s: %s" k v])
+      headers
+  in
+  let args =
+    [|
+      "curl";
+      "-sS";
+      "--http1.1";
+      "-X";
+      "GET";
+      "-o";
+      body_file;
+      "-D";
+      header_file;
+    |]
+    |> Array.to_list
+    |> fun base -> base @ max_time_args @ header_args @ [url]
+    |> Array.of_list
+  in
+  let (ic, oc, ec) = Unix.open_process_args_full "curl" args (Unix.environment ()) in
+  close_out_noerr oc;
+  let _stdout = read_all ic in
+  let stderr = read_all ec in
+  let curl_exit =
+    match Unix.close_process_full (ic, oc, ec) with
+    | Unix.WEXITED code -> code
+    | Unix.WSIGNALED code -> 128 + code
+    | Unix.WSTOPPED code -> 256 + code
+  in
+  let header_raw = read_file header_file in
+  let body = read_file body_file in
+  (try Sys.remove header_file with _ -> ());
+  (try Sys.remove body_file with _ -> ());
+  let (status, parsed_headers) = parse_headers header_raw in
+  { status; headers = parsed_headers; body; curl_exit; stderr }
+
+let header_value result name =
+  List.assoc_opt (String.lowercase_ascii name) result.headers
+
+let find_main_eio_exe () =
+  let env_override = Sys.getenv_opt "MASC_MAIN_EIO_EXE" in
+  let candidates =
+    match env_override with
+    | Some p -> [p]
+    | None ->
+        let build_roots = [ "."; ".."; "../.."; "../../.."; "../../../.." ] in
+        let build_candidates =
+          List.map
+            (fun root -> Filename.concat root "_build/default/bin/main_eio.exe")
+            build_roots
+        in
+        [
+          "./bin/main_eio.exe";
+          "../bin/main_eio.exe";
+          "../../bin/main_eio.exe";
+          "../../../bin/main_eio.exe";
+          "../../../../bin/main_eio.exe";
+        ] @ build_candidates
+  in
+  match List.find_opt Sys.file_exists candidates with
+  | Some path -> path
+  | None ->
+      fail
+        "main_eio executable not found. Set MASC_MAIN_EIO_EXE or build with `dune build bin/main_eio.exe`."
+
+let find_free_port () =
+  let socket = Unix.socket Unix.PF_INET Unix.SOCK_STREAM 0 in
+  Fun.protect
+    ~finally:(fun () -> Unix.close socket)
+    (fun () ->
+      Unix.setsockopt socket Unix.SO_REUSEADDR true;
+      Unix.bind socket (Unix.ADDR_INET (Unix.inet_addr_loopback, 0));
+      match Unix.getsockname socket with
+      | Unix.ADDR_INET (_, port) -> port
+      | _ -> fail "unexpected socket address")
+
+let wait_for_health ~port ~timeout_s =
+  let deadline = Unix.gettimeofday () +. timeout_s in
+  let rec loop () =
+    if Unix.gettimeofday () > deadline then
+      false
+    else
+      let res = run_curl ~max_time:0.2 ~port ~path:"/health" () in
+      match res.status with
+      | Some 200 -> true
+      | _ ->
+          Unix.sleepf 0.1;
+          loop ()
+  in
+  loop ()
+
+let wait_pid_exit ~pid ~timeout_s =
+  let deadline = Unix.gettimeofday () +. timeout_s in
+  let rec loop () =
+    match Unix.waitpid [Unix.WNOHANG] pid with
+    | 0, _ ->
+        if Unix.gettimeofday () > deadline then
+          false
+        else begin
+          Unix.sleepf 0.05;
+          loop ()
+        end
+    | _pid, _status -> true
+    | exception Unix.Unix_error (Unix.ECHILD, _, _) -> true
+  in
+  loop ()
+
+let merge_env_overrides overrides =
+  let override_keys =
+    List.map fst overrides
+  in
+  let is_override_key entry =
+    match String.index_opt entry '=' with
+    | None -> false
+    | Some idx ->
+        let key = String.sub entry 0 idx in
+        List.mem key override_keys
+  in
+  let base =
+    Unix.environment ()
+    |> Array.to_list
+    |> List.filter (fun entry -> not (is_override_key entry))
+  in
+  let injected =
+    List.map (fun (k, v) -> k ^ "=" ^ v) overrides
+  in
+  Array.of_list (base @ injected)
+
+let with_server f =
+  let exe = find_main_eio_exe () in
+  let port = find_free_port () in
+  let log_file = Filename.temp_file "sse-storm-e2e-" ".log" in
+  let base_path = Filename.temp_file "sse-storm-base-" "" in
+  (try Sys.remove base_path with _ -> ());
+  Unix.mkdir base_path 0o755;
+  let log_fd =
+    Unix.openfile log_file [Unix.O_CREAT; Unix.O_WRONLY; Unix.O_TRUNC] 0o644
+  in
+  let env =
+    merge_env_overrides
+      [
+        ("MASC_SSE_RECONNECT_MIN_INTERVAL_S", "1.5");
+        ("MASC_SSE_CONNECT_WINDOW_S", "5.0");
+        ("MASC_SSE_CONNECT_MAX_IN_WINDOW", "1000");
+        ("MASC_LODGE_ENABLED", "0");
+        ("MASC_LODGE_DAEMON_ENABLED", "0");
+        ("GRAPHQL_API_KEY", "");
+        ("GRAPHQL_URL", "http://127.0.0.1:9/graphql");
+      ]
+  in
+  let argv =
+    [|
+      exe;
+      "--port";
+      string_of_int port;
+      "--base-path";
+      base_path;
+    |]
+  in
+  let pid =
+    Unix.create_process_env exe argv env Unix.stdin log_fd log_fd
+  in
+  Unix.close log_fd;
+  let cleanup () =
+    (try Unix.kill pid Sys.sigterm with _ -> ());
+    if not (wait_pid_exit ~pid ~timeout_s:2.0) then
+      (try Unix.kill pid Sys.sigkill with _ -> ());
+    ignore (wait_pid_exit ~pid ~timeout_s:1.0)
+  in
+  if not (wait_for_health ~port ~timeout_s:20.0) then begin
+    cleanup ();
+    let logs = read_file log_file in
+    fail (Printf.sprintf "server failed to become ready on port %d\n%s" port logs)
+  end;
+  Fun.protect ~finally:cleanup (fun () -> f ~port)
+
+let check_status label expected result =
+  match result.status with
+  | Some code -> check int label expected code
+  | None ->
+      fail
+        (Printf.sprintf
+           "%s: no HTTP status (curl_exit=%d, stderr=%s)"
+           label
+           result.curl_exit
+           result.stderr)
+
+let test_mcp_rejects_reconnect_then_recovers () =
+  with_server @@ fun ~port ->
+  let sid = Printf.sprintf "storm-mcp-%06d" (Random.int 1_000_000) in
+  let headers = [("Accept", "text/event-stream"); ("Mcp-Session-Id", sid)] in
+
+  let first = run_curl ~headers ~max_time:0.6 ~port ~path:"/mcp" () in
+  check_status "first /mcp connect accepted" 200 first;
+
+  let second = run_curl ~headers ~max_time:0.6 ~port ~path:"/mcp" () in
+  check_status "immediate /mcp reconnect rejected" 429 second;
+  check bool "retry-after header present" true (Option.is_some (header_value second "retry-after"));
+
+  let json = Yojson.Safe.from_string second.body in
+  check string "error code" "sse_connection_rate_limited" (json |> member "error" |> to_string);
+  check string "reason is session cooldown" "session_cooldown" (json |> member "reason" |> to_string);
+
+  Unix.sleepf 1.7;
+  let third = run_curl ~headers ~max_time:0.6 ~port ~path:"/mcp" () in
+  check_status "post-cooldown /mcp reconnect accepted" 200 third
+
+let test_ag_ui_rejects_reconnect_then_recovers () =
+  with_server @@ fun ~port ->
+  let sid = Printf.sprintf "storm-agui-%06d" (Random.int 1_000_000) in
+  let headers = [("Accept", "text/event-stream"); ("Mcp-Session-Id", sid)] in
+
+  let first = run_curl ~headers ~max_time:0.6 ~port ~path:"/ag-ui/events?room=default" () in
+  check_status "first /ag-ui/events connect accepted" 200 first;
+
+  let second = run_curl ~headers ~max_time:0.6 ~port ~path:"/ag-ui/events?room=default" () in
+  check_status "immediate /ag-ui/events reconnect rejected" 429 second;
+  check bool "retry-after header present" true (Option.is_some (header_value second "retry-after"));
+
+  let json = Yojson.Safe.from_string second.body in
+  check string "error code" "sse_connection_rate_limited" (json |> member "error" |> to_string);
+  check string "reason is session cooldown" "session_cooldown" (json |> member "reason" |> to_string);
+
+  Unix.sleepf 1.7;
+  let third = run_curl ~headers ~max_time:0.6 ~port ~path:"/ag-ui/events?room=default" () in
+  check_status "post-cooldown /ag-ui/events reconnect accepted" 200 third
+
+let () =
+  Random.self_init ();
+  run "sse_storm_e2e"
+    [
+      ("mcp", [test_case "reconnect cooldown + recovery" `Slow test_mcp_rejects_reconnect_then_recovers]);
+      ("ag_ui", [test_case "reconnect cooldown + recovery" `Slow test_ag_ui_rejects_reconnect_then_recovers]);
+    ]


### PR DESCRIPTION
## Summary
- add endpoint-level SSE storm regression test (`test/test_sse_storm_e2e.ml`)
- validate both `/mcp` and `/ag-ui/events` reconnect behavior (`200 -> 429 -> 200`)
- fix `Http_server_eio.Router.dispatch` to match by `path + method` across duplicate-path routes

## Why
`Router.dispatch` previously picked the first matching path and returned `405` on method mismatch, making duplicate-method routes order-dependent (e.g. `/mcp` GET vs POST).

## Verification
- `./_build/default/test/test_sse_storm_e2e.exe`
- `./_build/default/test/test_http_server_eio.exe`
- `./_build/default/test/test_sse.exe`