### PR TITLE
fix(ci): align Neo4j pin set in Railway deploy

### DIFF
--- a/.github/workflows/deploy-railway.yml
+++ b/.github/workflows/deploy-railway.yml
@@ -25,7 +25,7 @@ jobs:
           opam pin add grpc-direct-core https://github.com/jeong-sik/grpc-direct.git#main -n -y
           opam pin add grpc-direct https://github.com/jeong-sik/grpc-direct.git#main -n -y
           opam pin add neo4j_packstream https://github.com/jeong-sik/ocaml-neo4j-bolt.git#main -n -y
-          opam pin add neo4j_bolt_eio https://github.com/jeong-sik/ocaml-neo4j-bolt.git#v0.4.1 -n -y
+          opam pin add neo4j_bolt_eio https://github.com/jeong-sik/ocaml-neo4j-bolt.git#main -n -y
 
       - name: Install dependencies
         run: opam install . --deps-only -y


### PR DESCRIPTION
## Summary
- align `neo4j_bolt_eio` pin with `neo4j_packstream` on `main` in deploy workflow
- remove incompatible mix of `neo4j_packstream#main` + `neo4j_bolt_eio#v0.4.1`

## Why
Deploy workflow failed during `opam install . --deps-only` with:
- `neo4j_bolt_eio -> neo4j_packstream < 0.5.1` (no solution)

CI workflow already pins Neo4j packages to `#main`; this makes deploy consistent and solvable.

## Validation
- inspected failing run: `22016418496`
- change is one-line pin alignment in `.github/workflows/deploy-railway.yml`