### PR TITLE
fix(release): pin neo4j deps in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,6 +35,9 @@ jobs:
           opam pin add ocaml-webrtc https://github.com/jeong-sik/ocaml-webrtc.git#main -n -y
           opam pin add grpc-direct-core https://github.com/jeong-sik/grpc-direct.git#main -n -y
           opam pin add grpc-direct https://github.com/jeong-sik/grpc-direct.git#main -n -y
+          opam pin add neo4j_packstream https://github.com/jeong-sik/ocaml-neo4j-bolt.git#main -n -y
+          opam pin add neo4j_bolt https://github.com/jeong-sik/ocaml-neo4j-bolt.git#main -n -y
+          opam pin add neo4j_bolt_eio https://github.com/jeong-sik/ocaml-neo4j-bolt.git#main -n -y
 
       - name: Install libpq (macOS)
         if: runner.os == 'macOS'


### PR DESCRIPTION
## Summary
- add Neo4j package pins to `release.yml` build job
- align release dependency pin set with CI/Deploy workflows

## Why
The recent tag release workflow failed in `Install dependencies`.
This was caused by dependency resolution drift in the release workflow pin set.

## Change
In `.github/workflows/release.yml` under `Pin private dependencies`, add:
- `neo4j_packstream#main`
- `neo4j_bolt#main`
- `neo4j_bolt_eio#main`

## Validation
- analyzed failed run: `22013452209`
- this is a workflow-only change; no runtime code changes
