### PR TITLE
ci: retry opam dependency installs across workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,15 @@ jobs:
 
       - name: Install dependencies
         run: |
-          opam install . --deps-only --with-test --yes
+          for attempt in 1 2 3; do
+            opam install . --deps-only --with-test --yes && break
+            if [ "$attempt" -eq 3 ]; then
+              echo "opam install failed after ${attempt} attempts"
+              exit 1
+            fi
+            echo "opam install failed (attempt ${attempt}); retrying in 15s..."
+            sleep 15
+          done
 
       - name: Build
         run: |
@@ -79,7 +87,15 @@ jobs:
 
       - name: Install dependencies
         run: |
-          opam install . --deps-only --yes
+          for attempt in 1 2 3; do
+            opam install . --deps-only --yes && break
+            if [ "$attempt" -eq 3 ]; then
+              echo "opam install failed after ${attempt} attempts"
+              exit 1
+            fi
+            echo "opam install failed (attempt ${attempt}); retrying in 15s..."
+            sleep 15
+          done
 
       - name: Build with warnings as errors
         run: |
@@ -114,8 +130,24 @@ jobs:
 
       - name: Install dependencies
         run: |
-          opam install . --deps-only --with-doc --yes
-          opam install odoc --yes
+          for attempt in 1 2 3; do
+            opam install . --deps-only --with-doc --yes && break
+            if [ "$attempt" -eq 3 ]; then
+              echo "opam install --with-doc failed after ${attempt} attempts"
+              exit 1
+            fi
+            echo "opam install --with-doc failed (attempt ${attempt}); retrying in 15s..."
+            sleep 15
+          done
+          for attempt in 1 2 3; do
+            opam install odoc --yes && break
+            if [ "$attempt" -eq 3 ]; then
+              echo "opam install odoc failed after ${attempt} attempts"
+              exit 1
+            fi
+            echo "opam install odoc failed (attempt ${attempt}); retrying in 15s..."
+            sleep 15
+          done
 
       - name: Build documentation
         run: |

--- a/.github/workflows/deploy-railway.yml
+++ b/.github/workflows/deploy-railway.yml
@@ -28,7 +28,16 @@ jobs:
           opam pin add neo4j_bolt_eio https://github.com/jeong-sik/ocaml-neo4j-bolt.git#main -n -y
 
       - name: Install dependencies
-        run: opam install . --deps-only -y
+        run: |
+          for attempt in 1 2 3; do
+            opam install . --deps-only -y && break
+            if [ "$attempt" -eq 3 ]; then
+              echo "opam install failed after ${attempt} attempts"
+              exit 1
+            fi
+            echo "opam install failed (attempt ${attempt}); retrying in 15s..."
+            sleep 15
+          done
 
       - name: Build release binary
         run: opam exec -- dune build --release bin/main_eio.exe

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,7 +48,15 @@ jobs:
 
       - name: Install dependencies
         run: |
-          opam install . --deps-only -y
+          for attempt in 1 2 3; do
+            opam install . --deps-only -y && break
+            if [ "$attempt" -eq 3 ]; then
+              echo "opam install failed after ${attempt} attempts"
+              exit 1
+            fi
+            echo "opam install failed (attempt ${attempt}); retrying in 15s..."
+            sleep 15
+          done
 
       - name: Build
         run: opam exec -- dune build --release bin/main_eio.exe


### PR DESCRIPTION
## Summary
- add retry loops for `opam install` in CI workflows
- apply to:
  - `.github/workflows/ci.yml`
  - `.github/workflows/deploy-railway.yml`
  - `.github/workflows/release.yml`

## Why
We observed transient upstream fetch failures (e.g. GitHub release tarball `502`) causing non-deterministic CI failures.

## Change
Each dependency install step now retries up to 3 times with 15s backoff before failing.

## Scope
Workflow-only reliability improvement. No runtime/application code changes.
