### PR TITLE
ci(release): add workflow_dispatch with tag-only publish guard

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,7 @@ on:
   push:
     tags:
       - 'v*'
+  workflow_dispatch:
 
 permissions:
   contents: write
@@ -76,6 +77,7 @@ jobs:
   release:
     needs: build
     runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/v')
 
     steps:
       - name: Download all artifacts


### PR DESCRIPTION
## Summary
- enable manual trigger for release workflow via `workflow_dispatch`
- guard `release` job so publishing only runs on tag refs (`refs/tags/v*`)

## Why
We recently stabilized release build dependencies, but release workflow is still tag-only and hard to validate ahead of a real tag.
This allows safe manual build-path validation without accidentally publishing a GitHub Release.

## Scope
- Workflow-only change in `.github/workflows/release.yml`
- No runtime/app code changes
