### PR TITLE
fix(keeper): use cluster-independent paths for keeper_dir and session_base_dir

### DIFF
--- a/lib/tool_keeper.ml
+++ b/lib/tool_keeper.ml
@@ -715,17 +715,19 @@ let mkdir_p path =
   in
   go path
 
-let keeper_dir config =
-  let d = Filename.concat (Room.masc_dir config) "perpetual-keepers" in
+let keeper_dir (config : Room.config) =
+  (* Keepers are global — never scoped to cluster/room.
+     Use base_path directly, consistent with perpetual_loop.ml. *)
+  let d = Filename.concat (Filename.concat config.base_path ".masc") "perpetual-keepers" in
   mkdir_p d;
   d
 
 let keeper_meta_path config name =
   Filename.concat (keeper_dir config) (name ^ ".json")
 
-let session_base_dir config =
-  (* Keep consistent with Perpetual_loop.default_config. *)
-  Filename.concat (Room.masc_dir config) "perpetual"
+let session_base_dir (config : Room.config) =
+  (* Cluster-independent, consistent with Perpetual_loop.default_config. *)
+  Filename.concat (Filename.concat config.base_path ".masc") "perpetual"
 
 let keeper_agent_name name =
   (* Make it look like a generated nickname so Room.join uses it as-is. *)


### PR DESCRIPTION
## Summary

- `keeper_dir`과 `session_base_dir`이 `Room.masc_dir`을 사용하여 cluster-aware 경로로 resolve되는 버그 수정
- `MASC_CLUSTER_NAME=me` 설정 시 `.masc/clusters/me/perpetual-keepers/`로 경로가 잘못 resolve됨
- Keepers는 global entity이므로 항상 `.masc/perpetual-keepers/`를 사용해야 함
- `config.base_path`를 직접 사용하도록 변경 (`perpetual_loop.ml`과 일관성 유지)

## Root Cause

```
start-masc-mcp.sh → MASC_CLUSTER_NAME="me"
  → Room.masc_dir → .masc/clusters/me/
    → keeper_dir → .masc/clusters/me/perpetual-keepers/  ← BUG
    → 실제 파일: .masc/perpetual-keepers/trpg-dm.json    ← 여기에 있음
    → read_meta → Ok None (파일 못 찾음)
```

## Test plan

- [x] `dune build` — zero errors
- [x] Server started with `MASC_CLUSTER_NAME=me`
- [x] `masc_keeper_up(name: "trpg-dm")` returns meta successfully
- [x] `masc_keeper_up(name: "trpg-grimja")` returns meta successfully
- [x] `masc_board_list(hearth: "trpg")` returns 5 posts correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)