### PR TITLE
ci: add explicit timeout guards to workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,7 @@ jobs:
   build:
     name: Build and Test
     runs-on: ubuntu-latest
+    timeout-minutes: 30
 
     steps:
       - name: Checkout
@@ -64,6 +65,7 @@ jobs:
   lint:
     name: Lint
     runs-on: ubuntu-latest
+    timeout-minutes: 20
 
     steps:
       - name: Checkout
@@ -107,6 +109,7 @@ jobs:
     name: Documentation
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/main'
+    timeout-minutes: 20
 
     steps:
       - name: Checkout

--- a/.github/workflows/deploy-railway.yml
+++ b/.github/workflows/deploy-railway.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,7 @@ jobs:
             arch: linux-x64
 
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 45
 
     steps:
       - uses: actions/checkout@v4
@@ -78,6 +79,7 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/v')
+    timeout-minutes: 15
 
     steps:
       - name: Download all artifacts


### PR DESCRIPTION
## Summary
Add explicit `timeout-minutes` guards to workflow jobs:
- `.github/workflows/ci.yml`
  - Build and Test: 30
  - Lint: 20
  - Documentation: 20
- `.github/workflows/deploy-railway.yml`
  - deploy: 30
- `.github/workflows/release.yml`
  - build (matrix): 45
  - release: 15

## Why
Some dependency/network steps can stall for long periods. Timeouts prevent indefinite runner occupation and make failures deterministic.

## Scope
Workflow-only reliability change; no runtime code changes.
