### PR TITLE
ci: add concurrency guard to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,10 @@ on:
 permissions:
   contents: write
 
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     strategy:


### PR DESCRIPTION
## Summary
- add workflow-level concurrency to `release.yml`
- cancel older in-progress run for same ref
- keep behavior aligned with CI/Deploy workflows

## Validation
- minimal YAML-only change
- runtime validation via GitHub Actions checks after PR creation