### PR TITLE
feat(dashboard): run TRPG rounds directly from TRPG tab

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,12 +54,20 @@ jobs:
         run: |
           opam exec -- dune build
 
-      - name: Run tests
+      - name: Run tests (quick suite)
+        env:
+          ME_ROOT: /tmp/me
+          ALCOTEST_QUICK_TESTS: "1"
+        run: |
+          mkdir -p /tmp/me
+          opam exec -- dune test
+
+      - name: Run SSE reconnect e2e
         env:
           ME_ROOT: /tmp/me
         run: |
           mkdir -p /tmp/me
-          opam exec -- dune test
+          opam exec -- dune exec ./test/test_sse_storm_e2e.exe
 
       - name: Check formatting
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
   build:
     name: Build and Test
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 60
 
     steps:
       - name: Checkout

--- a/bin/main_eio.ml
+++ b/bin/main_eio.ml
@@ -2540,6 +2540,31 @@ let sse_prime_event () =
 (** SSE keep-alive ping interval in seconds *)
 let sse_ping_interval_s = 30.0
 
+let env_float_or ~name ~default =
+  match Sys.getenv_opt name with
+  | None -> default
+  | Some raw ->
+      (try float_of_string raw with _ -> default)
+
+let env_int_or ~name ~default =
+  match Sys.getenv_opt name with
+  | None -> default
+  | Some raw ->
+      (try int_of_string raw with _ -> default)
+
+(** SSE reconnect guard (disabled by default unless env is set). *)
+let sse_reconnect_min_interval_s =
+  env_float_or ~name:"MASC_SSE_RECONNECT_MIN_INTERVAL_S" ~default:0.0
+  |> Float.max 0.0
+
+let sse_connect_window_s =
+  env_float_or ~name:"MASC_SSE_CONNECT_WINDOW_S" ~default:0.0
+  |> Float.max 0.0
+
+let sse_connect_max_in_window =
+  env_int_or ~name:"MASC_SSE_CONNECT_MAX_IN_WINDOW" ~default:0
+  |> max 0
+
 (** Get Last-Event-ID from headers for resumability *)
 let get_last_event_id (request : Httpun.Request.t) =
   match Httpun.Headers.get request.headers "last-event-id" with
@@ -3019,6 +3044,80 @@ type sse_conn_info = {
 
 let sse_conn_by_session : (string, sse_conn_info) Hashtbl.t = Hashtbl.create 128
 
+type sse_connect_guard_state = {
+  mutable last_connect_at: float;
+  mutable connect_times: float list;  (* newest first *)
+}
+
+let sse_connect_guard_by_session : (string, sse_connect_guard_state) Hashtbl.t =
+  Hashtbl.create 256
+
+let prune_connect_times ~now times =
+  if sse_connect_window_s <= 0.0 then times
+  else List.filter (fun ts -> now -. ts <= sse_connect_window_s) times
+
+let check_sse_connect_guard session_id =
+  let now = Time_compat.now () in
+  let state =
+    match Hashtbl.find_opt sse_connect_guard_by_session session_id with
+    | Some v -> v
+    | None -> { last_connect_at = -.1.0; connect_times = [] }
+  in
+  let recent = prune_connect_times ~now state.connect_times in
+  state.connect_times <- recent;
+  let session_wait_s =
+    if sse_reconnect_min_interval_s <= 0.0 then
+      0.0
+    else
+      sse_reconnect_min_interval_s -. (now -. state.last_connect_at)
+  in
+  if session_wait_s > 0.0 then
+    Error ("session_cooldown", session_wait_s)
+  else
+    let window_wait_s =
+      if sse_connect_window_s <= 0.0 || sse_connect_max_in_window <= 0 then
+        0.0
+      else if List.length recent >= sse_connect_max_in_window then
+        match List.rev recent with
+        | oldest :: _ -> sse_connect_window_s -. (now -. oldest)
+        | [] -> 0.0
+      else
+        0.0
+    in
+    if window_wait_s > 0.0 then
+      Error ("window_limit", window_wait_s)
+    else begin
+      state.last_connect_at <- now;
+      state.connect_times <- now :: recent;
+      Hashtbl.replace sse_connect_guard_by_session session_id state;
+      Ok ()
+    end
+
+let respond_sse_rate_limited ~origin ~session_id ~protocol_version ~reason ~retry_after_s reqd =
+  let retry_after_s = Float.max retry_after_s 0.001 in
+  let retry_after_header =
+    retry_after_s
+    |> Float.ceil
+    |> int_of_float
+    |> max 1
+    |> string_of_int
+  in
+  let body =
+    `Assoc [
+      ("error", `String "sse_connection_rate_limited");
+      ("reason", `String reason);
+      ("retry_after_seconds", `Float retry_after_s);
+    ]
+    |> Yojson.Safe.to_string
+  in
+  let headers = Httpun.Headers.of_list (
+    ("content-length", string_of_int (String.length body))
+    :: ("retry-after", retry_after_header)
+    :: json_headers session_id protocol_version origin
+  ) in
+  let response = Httpun.Response.create ~headers `Too_many_requests in
+  Httpun.Reqd.respond_with_string reqd response body
+
 let close_sse_conn info =
   if not info.closed then begin
     info.closed <- true;
@@ -3069,94 +3168,103 @@ let handle_get_mcp ?legacy_messages_endpoint request reqd =
   let session_id = Mcp_session.get_or_generate (get_session_id_any request) in
   let protocol_version = get_protocol_version_for_session ~session_id request in
   let last_event_id = get_last_event_id request in
+  match check_sse_connect_guard session_id with
+  | Error (reason, retry_after_s) ->
+      respond_sse_rate_limited
+        ~origin
+        ~session_id
+        ~protocol_version
+        ~reason
+        ~retry_after_s
+        reqd
+  | Ok () ->
+      (* Replace existing connection for session_id *)
+      stop_sse_session session_id;
 
-  (* Replace existing connection for session_id *)
-  stop_sse_session session_id;
+      let headers = Httpun.Headers.of_list (sse_stream_headers session_id protocol_version origin) in
+      let response = Httpun.Response.create ~headers `OK in
+      let writer = Httpun.Reqd.respond_with_streaming reqd response in
+      let mutex = Eio.Mutex.create () in
+      let info_ref : sse_conn_info option ref = ref None in
+      let push event =
+        match !info_ref with
+        | None -> ()
+        | Some info -> ignore (send_raw info event)
+      in
+      let (client_id, evicted) =
+        Sse.register session_id ~push
+          ~last_event_id:(Option.value ~default:0 last_event_id)
+      in
+      (* Clean up writer for evicted session *)
+      (match evicted with
+       | Some evicted_sid -> stop_sse_session evicted_sid
+       | None -> ());
+      let info = {
+        session_id;
+        client_id;
+        writer;
+        mutex;
+        stop = ref false;
+        closed = false;
+      } in
+      info_ref := Some info;
+      Hashtbl.replace sse_conn_by_session session_id info;
 
-  let headers = Httpun.Headers.of_list (sse_stream_headers session_id protocol_version origin) in
-  let response = Httpun.Response.create ~headers `OK in
-  let writer = Httpun.Reqd.respond_with_streaming reqd response in
-  let mutex = Eio.Mutex.create () in
-  let info_ref : sse_conn_info option ref = ref None in
-  let push event =
-    match !info_ref with
-    | None -> ()
-    | Some info -> ignore (send_raw info event)
-  in
-  let (client_id, evicted) =
-    Sse.register session_id ~push
-      ~last_event_id:(Option.value ~default:0 last_event_id)
-  in
-  (* Clean up writer for evicted session *)
-  (match evicted with
-   | Some evicted_sid -> stop_sse_session evicted_sid
-   | None -> ());
-  let info = {
-    session_id;
-    client_id;
-    writer;
-    mutex;
-    stop = ref false;
-    closed = false;
-  } in
-  info_ref := Some info;
-  Hashtbl.replace sse_conn_by_session session_id info;
+      (* Send priming event first *)
+      ignore (send_raw info (sse_prime_event ()));
 
-  (* Send priming event first *)
-  ignore (send_raw info (sse_prime_event ()));
+      (* Legacy SSE transport: provide messages endpoint (event: endpoint) *)
+      (match legacy_messages_endpoint with
+       | None -> ()
+       | Some f ->
+           let endpoint_url = f session_id in
+           ignore (send_raw info (Sse.format_event ~event_type:"endpoint" endpoint_url)));
 
-  (* Legacy SSE transport: provide messages endpoint (event: endpoint) *)
-  (match legacy_messages_endpoint with
-   | None -> ()
-   | Some f ->
-       let endpoint_url = f session_id in
-       ignore (send_raw info (Sse.format_event ~event_type:"endpoint" endpoint_url)));
+      (* Replay missed events if Last-Event-ID provided (MCP spec MUST) *)
+      (match last_event_id with
+       | Some last_id ->
+           let missed = Sse.get_events_after last_id in
+           List.iter (fun ev -> ignore (send_raw info ev)) missed
+       | None -> ());
 
-  (* Replay missed events if Last-Event-ID provided (MCP spec MUST) *)
-  (match last_event_id with
-   | Some last_id ->
-       let missed = Sse.get_events_after last_id in
-       List.iter (fun ev -> ignore (send_raw info ev)) missed
-   | None -> ());
+      (* Keep-alive ping loop *)
+      (match !current_sw, !current_clock with
+       | Some sw, Some clock ->
+           Eio.Fiber.fork ~sw (fun () ->
+             let is_cancelled exn =
+               match exn with
+               | Eio.Cancel.Cancelled _ -> true
+               | _ -> false
+             in
+             let rec loop () =
+               if not !(info.stop) then begin
+                 (try
+                    Eio.Time.sleep clock sse_ping_interval_s
+                  with exn ->
+                    if is_cancelled exn then raise exn;
+                    Printf.eprintf "[SSE] ping sleep error: %s\n%!" (Printexc.to_string exn));
+                 (try
+                    if info.closed then
+                      stop_sse_session info.session_id
+                    else if not !(info.stop) then
+                      ignore (send_raw info ": ping\n\n")
+                  with exn ->
+                    if is_cancelled exn then raise exn;
+                    Printf.eprintf "[SSE] ping send error: %s\n%!" (Printexc.to_string exn);
+                    stop_sse_session info.session_id);
+                 loop ()
+               end
+             in
+             try loop () with exn ->
+               if is_cancelled exn then ()
+               else Printf.eprintf "[SSE] ping loop error: %s\n%!" (Printexc.to_string exn))
+       | _ -> ());
 
-  (* Keep-alive ping loop *)
-  (match !current_sw, !current_clock with
-   | Some sw, Some clock ->
-       Eio.Fiber.fork ~sw (fun () ->
-         let is_cancelled exn =
-           match exn with
-           | Eio.Cancel.Cancelled _ -> true
-           | _ -> false
-         in
-         let rec loop () =
-           if not !(info.stop) then begin
-             (try
-                Eio.Time.sleep clock sse_ping_interval_s
-              with exn ->
-                if is_cancelled exn then raise exn;
-                Printf.eprintf "[SSE] ping sleep error: %s\n%!" (Printexc.to_string exn));
-             (try
-                if info.closed then
-                  stop_sse_session info.session_id
-                else if not !(info.stop) then
-                  ignore (send_raw info ": ping\n\n")
-              with exn ->
-                if is_cancelled exn then raise exn;
-                Printf.eprintf "[SSE] ping send error: %s\n%!" (Printexc.to_string exn);
-                stop_sse_session info.session_id);
-             loop ()
-           end
-         in
-         try loop () with exn ->
-           if is_cancelled exn then ()
-           else Printf.eprintf "[SSE] ping loop error: %s\n%!" (Printexc.to_string exn))
-   | _ -> ());
-
-  (* Only log when approaching capacity or in debug mode *)
-  let client_count = Sse.client_count () in
-  if client_count > Sse.max_clients / 2 then
-    Printf.eprintf "📡 SSE connected: %s (active: %d/%d)\n%!"
-      session_id client_count Sse.max_clients
+      (* Only log when approaching capacity or in debug mode *)
+      let client_count = Sse.client_count () in
+      if client_count > Sse.max_clients / 2 then
+        Printf.eprintf "📡 SSE connected: %s (active: %d/%d)\n%!"
+          session_id client_count Sse.max_clients
 
 (** SSE simple handler - for compatibility, returns single event *)
 let sse_simple_handler request reqd =
@@ -3272,91 +3380,100 @@ let make_routes ~port ~host =
        let protocol_version = get_protocol_version_for_session ~session_id request in
        let room_id = Option.value ~default:"default" (query_param request "room") in
        let last_event_id = get_last_event_id request in
+       match check_sse_connect_guard session_id with
+       | Error (reason, retry_after_s) ->
+           respond_sse_rate_limited
+             ~origin
+             ~session_id
+             ~protocol_version
+             ~reason
+             ~retry_after_s
+             reqd
+       | Ok () ->
+           stop_sse_session session_id;
 
-       stop_sse_session session_id;
-
-       let headers = Httpun.Headers.of_list (sse_stream_headers session_id protocol_version origin) in
-       let response = Httpun.Response.create ~headers `OK in
-       let writer = Httpun.Reqd.respond_with_streaming reqd response in
-       let mutex = Eio.Mutex.create () in
-       let info_ref : sse_conn_info option ref = ref None in
-       let push event =
-         match !info_ref with
-         | None -> ()
-         | Some info ->
-           (* Translate MASC SSE data to AG-UI event format.
-              Parse the JSON from the SSE data line and re-emit as AG-UI CUSTOM. *)
-           let ag_ui_event =
-             try
-               (* Extract JSON from SSE format: "id: N\nevent: type\ndata: {...}\n\n" *)
-               let lines = String.split_on_char '\n' event in
-               let data_line = List.find_opt (fun l ->
-                 String.length l > 6 && String.sub l 0 6 = "data: "
-               ) lines in
-               match data_line with
-               | Some dl ->
-                 let json_str = String.sub dl 6 (String.length dl - 6) in
-                 let json = Yojson.Safe.from_string json_str in
-                 let ag_event = Masc_mcp.Ag_ui.of_custom ~room_id
-                   ~name:"MASC_EVENT" json in
-                 Masc_mcp.Ag_ui.event_to_sse ag_event
-               | None -> event  (* Pass through if no data line *)
-             with _ -> event  (* Pass through on parse error *)
+           let headers = Httpun.Headers.of_list (sse_stream_headers session_id protocol_version origin) in
+           let response = Httpun.Response.create ~headers `OK in
+           let writer = Httpun.Reqd.respond_with_streaming reqd response in
+           let mutex = Eio.Mutex.create () in
+           let info_ref : sse_conn_info option ref = ref None in
+           let push event =
+             match !info_ref with
+             | None -> ()
+             | Some info ->
+               (* Translate MASC SSE data to AG-UI event format.
+                  Parse the JSON from the SSE data line and re-emit as AG-UI CUSTOM. *)
+               let ag_ui_event =
+                 try
+                   (* Extract JSON from SSE format: "id: N\nevent: type\ndata: {...}\n\n" *)
+                   let lines = String.split_on_char '\n' event in
+                   let data_line = List.find_opt (fun l ->
+                     String.length l > 6 && String.sub l 0 6 = "data: "
+                   ) lines in
+                   match data_line with
+                   | Some dl ->
+                     let json_str = String.sub dl 6 (String.length dl - 6) in
+                     let json = Yojson.Safe.from_string json_str in
+                     let ag_event = Masc_mcp.Ag_ui.of_custom ~room_id
+                       ~name:"MASC_EVENT" json in
+                     Masc_mcp.Ag_ui.event_to_sse ag_event
+                   | None -> event  (* Pass through if no data line *)
+                 with _ -> event  (* Pass through on parse error *)
+               in
+               ignore (send_raw info ag_ui_event)
            in
-           ignore (send_raw info ag_ui_event)
-       in
-       let (client_id, evicted) =
-         Sse.register session_id ~push
-           ~last_event_id:(Option.value ~default:0 last_event_id)
-       in
-       (match evicted with
-        | Some evicted_sid -> stop_sse_session evicted_sid
-        | None -> ());
-       let info = {
-         session_id;
-         client_id;
-         writer;
-         mutex;
-         stop = ref false;
-         closed = false;
-       } in
-       info_ref := Some info;
-       Hashtbl.replace sse_conn_by_session session_id info;
+           let (client_id, evicted) =
+             Sse.register session_id ~push
+               ~last_event_id:(Option.value ~default:0 last_event_id)
+           in
+           (match evicted with
+            | Some evicted_sid -> stop_sse_session evicted_sid
+            | None -> ());
+           let info = {
+             session_id;
+             client_id;
+             writer;
+             mutex;
+             stop = ref false;
+             closed = false;
+           } in
+           info_ref := Some info;
+           Hashtbl.replace sse_conn_by_session session_id info;
 
-       (* Send AG-UI priming: RUN_STARTED event *)
-       let prime = Masc_mcp.Ag_ui.(
-         make_event ~thread_id:room_id
-           ~run_id:(Some session_id)
-           Run_started
-         |> event_to_sse
-       ) in
-       ignore (send_raw info prime);
+           (* Send AG-UI priming: RUN_STARTED event *)
+           let prime = Masc_mcp.Ag_ui.(
+             make_event ~thread_id:room_id
+               ~run_id:(Some session_id)
+               Run_started
+             |> event_to_sse
+           ) in
+           ignore (send_raw info prime);
 
-       (* Replay missed events *)
-       (match last_event_id with
-        | Some last_id ->
-          let missed = Sse.get_events_after last_id in
-          List.iter (fun ev -> ignore (send_raw info ev)) missed
-        | None -> ());
+           (* Replay missed events *)
+           (match last_event_id with
+            | Some last_id ->
+              let missed = Sse.get_events_after last_id in
+              List.iter (fun ev -> ignore (send_raw info ev)) missed
+            | None -> ());
 
-       (* Keep-alive ping *)
-       (match !current_sw, !current_clock with
-        | Some sw, Some clock ->
-          Eio.Fiber.fork ~sw (fun () ->
-            let rec loop () =
-              if not !(info.stop) then begin
-                (try Eio.Time.sleep clock sse_ping_interval_s
-                 with _ -> ());
-                (try
-                   if info.closed then stop_sse_session info.session_id
-                   else if not !(info.stop) then
-                     ignore (send_raw info ": ping\n\n")
-                 with _ -> stop_sse_session info.session_id);
-                loop ()
-              end
-            in
-            try loop () with _ -> ())
-        | _ -> ()))
+           (* Keep-alive ping *)
+           (match !current_sw, !current_clock with
+            | Some sw, Some clock ->
+              Eio.Fiber.fork ~sw (fun () ->
+                let rec loop () =
+                  if not !(info.stop) then begin
+                    (try Eio.Time.sleep clock sse_ping_interval_s
+                     with _ -> ());
+                    (try
+                       if info.closed then stop_sse_session info.session_id
+                       else if not !(info.stop) then
+                         ignore (send_raw info ": ping\n\n")
+                     with _ -> stop_sse_session info.session_id);
+                    loop ()
+                  end
+                in
+                try loop () with _ -> ())
+            | _ -> ()))
   |> Http.Router.get "/dashboard" (fun request reqd ->
        with_public_read (fun _state req reqd ->
          Http.Response.html_cached

--- a/lib/web_dashboard.ml
+++ b/lib/web_dashboard.ml
@@ -1507,6 +1507,86 @@ let cached_html = lazy ({|<!DOCTYPE html>
     .trpg-round-item.unavailable { border-left-color: rgba(251,191,36,0.9); }
     .trpg-round-item .meta { color: #64748b; font-size: 0.95em; }
     .trpg-empty { text-align: center; color: #64748b; padding: 60px 20px; font-style: italic; }
+    .trpg-control-box {
+      border: 1px solid rgba(148,163,184,0.18);
+      border-radius: 10px;
+      background: rgba(2,6,23,0.35);
+      padding: 10px;
+      display: flex;
+      flex-direction: column;
+      gap: 8px;
+    }
+    .trpg-control-grid {
+      display: grid;
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+      gap: 8px;
+    }
+    .trpg-control-field {
+      display: flex;
+      flex-direction: column;
+      gap: 4px;
+    }
+    .trpg-control-field.full { grid-column: 1 / -1; }
+    .trpg-control-field label {
+      font-size: 0.7em;
+      color: #94a3b8;
+      text-transform: uppercase;
+      letter-spacing: 0.04em;
+    }
+    .trpg-control-field input,
+    .trpg-control-field select,
+    .trpg-control-field textarea {
+      width: 100%;
+      box-sizing: border-box;
+      background: rgba(15,23,42,0.8);
+      border: 1px solid rgba(148,163,184,0.24);
+      border-radius: 6px;
+      color: #e2e8f0;
+      padding: 6px 8px;
+      font-size: 0.78em;
+    }
+    .trpg-control-field textarea {
+      min-height: 66px;
+      resize: vertical;
+      font-family: 'SF Mono', Monaco, monospace;
+      line-height: 1.4;
+    }
+    .trpg-control-field input:focus,
+    .trpg-control-field select:focus,
+    .trpg-control-field textarea:focus {
+      outline: none;
+      border-color: rgba(34,211,238,0.75);
+      box-shadow: 0 0 0 2px rgba(34,211,238,0.14);
+    }
+    .trpg-run-btn {
+      border: 1px solid rgba(34,211,238,0.45);
+      border-radius: 8px;
+      background: rgba(8,47,73,0.86);
+      color: #e2e8f0;
+      font-weight: 600;
+      font-size: 0.82em;
+      padding: 8px 10px;
+      cursor: pointer;
+      transition: all 0.16s ease;
+    }
+    .trpg-run-btn:hover { border-color: rgba(34,211,238,0.78); background: rgba(14,116,144,0.45); }
+    .trpg-run-btn:disabled { opacity: 0.55; cursor: not-allowed; }
+    .trpg-run-status {
+      font-size: 0.75em;
+      border: 1px solid rgba(148,163,184,0.2);
+      border-radius: 8px;
+      background: rgba(15,23,42,0.55);
+      color: #cbd5e1;
+      padding: 8px 9px;
+      line-height: 1.45;
+      word-break: break-word;
+    }
+    .trpg-run-status.ok { border-color: rgba(74,222,128,0.35); color: #bbf7d0; }
+    .trpg-run-status.error { border-color: rgba(239,68,68,0.45); color: #fecaca; }
+    .trpg-run-status.running { border-color: rgba(251,191,36,0.4); color: #fde68a; }
+    @media (max-width: 600px) {
+      .trpg-control-grid { grid-template-columns: 1fr; }
+    }
   </style>
 </head>
 <body>
@@ -1779,6 +1859,37 @@ let cached_html = lazy ({|<!DOCTYPE html>
           <div class="trpg-sidebar">
             <div class="trpg-section-title">세션</div>
             <div class="trpg-room-label" id="trpg-room-label">room: -</div>
+            <div class="trpg-control-box">
+              <div class="trpg-control-grid">
+                <div class="trpg-control-field">
+                  <label for="trpg-room-input">Room</label>
+                  <input id="trpg-room-input" type="text" placeholder="grimland-chronicle" onchange="applyTrpgRoomInputAndRefresh()">
+                </div>
+                <div class="trpg-control-field">
+                  <label for="trpg-dm-keeper-input">DM Keeper</label>
+                  <input id="trpg-dm-keeper-input" type="text" placeholder="dm-keeper">
+                </div>
+                <div class="trpg-control-field">
+                  <label for="trpg-phase-select">Phase</label>
+                  <select id="trpg-phase-select">
+                    <option value="round">round</option>
+                    <option value="briefing">briefing</option>
+                    <option value="resolution">resolution</option>
+                    <option value="ended">ended</option>
+                  </select>
+                </div>
+                <div class="trpg-control-field">
+                  <label for="trpg-timeout-sec-input">Timeout (sec)</label>
+                  <input id="trpg-timeout-sec-input" type="number" min="1" step="1" value="30">
+                </div>
+                <div class="trpg-control-field full">
+                  <label for="trpg-player-keepers-input">Player Keepers (actor=keeper, one per line)</label>
+                  <textarea id="trpg-player-keepers-input" placeholder="grimja=grimja&#10;luna=luna&#10;songarak=songarak&#10;miso=miso"></textarea>
+                </div>
+              </div>
+              <button id="trpg-run-round-btn" class="trpg-run-btn" onclick="runTrpgRound()">라운드 실행</button>
+              <div id="trpg-round-run-status" class="trpg-run-status">대기 중: 설정 후 라운드 실행 버튼을 누르세요.</div>
+            </div>
             <div class="trpg-status-grid" id="trpg-status-grid"></div>
             <div class="trpg-section-title" style="margin-top:8px;">최근 라운드</div>
             <div id="trpg-round-log" class="trpg-round-list">
@@ -6581,7 +6692,14 @@ let cached_html = lazy ({|<!DOCTYPE html>
     }
 
     // === TRPG — Dark Fantasy Narrative ===
-    const TRPG_ROOM_ID = trpgRoomParam || 'grimland-chronicle';
+    const TRPG_DEFAULT_ROOM_ID = 'grimland-chronicle';
+    let trpgRoomId = trpgRoomParam || TRPG_DEFAULT_ROOM_ID;
+    const TRPG_DEFAULT_PLAYER_KEEPERS = [
+      'grimja=grimja',
+      'luna=luna',
+      'songarak=songarak',
+      'miso=miso',
+    ];
     const TRPG_PARTY_FALLBACK = [
       { name: '그림자', cls: '전사', hp: 30, maxHp: 30, emoji: '⚔', area: 'C' },
       { name: '루나', cls: '마법사', hp: 13, maxHp: 15, emoji: '🔮', area: 'F' },
@@ -6601,6 +6719,7 @@ let cached_html = lazy ({|<!DOCTYPE html>
     let trpgTyping = false;
     let trpgLastSeq = 0;
     let trpgEventsCache = [];
+    let trpgRoundRunning = false;
 
     function trpgEventType(ev) {
       return (ev && (ev.type || ev.event_type || ev.event)) || '';
@@ -6663,22 +6782,184 @@ let cached_html = lazy ({|<!DOCTYPE html>
       return d.toLocaleTimeString('ko-KR');
     }
 
+    function setTrpgRoomQueryState() {
+      const url = new URL(window.location.href);
+      if (trpgRoomId && trpgRoomId !== TRPG_DEFAULT_ROOM_ID) {
+        url.searchParams.set('trpg_room', trpgRoomId);
+      } else {
+        url.searchParams.delete('trpg_room');
+      }
+      history.replaceState(history.state || {}, '', url.pathname + url.search + url.hash);
+    }
+
+    function resetTrpgEventWindow() {
+      trpgLastSeq = 0;
+      trpgEventsCache = [];
+      trpgKnownIds.clear();
+    }
+
+    function ensureTrpgControlDefaults() {
+      const roomInput = document.getElementById('trpg-room-input');
+      if (roomInput && String(roomInput.value || '').trim() === '') roomInput.value = trpgRoomId;
+      const dmInput = document.getElementById('trpg-dm-keeper-input');
+      if (dmInput && String(dmInput.value || '').trim() === '') dmInput.value = 'dm';
+      const playerInput = document.getElementById('trpg-player-keepers-input');
+      if (playerInput && String(playerInput.value || '').trim() === '') {
+        playerInput.value = TRPG_DEFAULT_PLAYER_KEEPERS.join('\n');
+      }
+    }
+
+    function applyTrpgRoomFromInput() {
+      const roomInput = document.getElementById('trpg-room-input');
+      const nextRoom = String((roomInput && roomInput.value) || '').trim() || TRPG_DEFAULT_ROOM_ID;
+      if (nextRoom !== trpgRoomId) {
+        trpgRoomId = nextRoom;
+        resetTrpgEventWindow();
+        setTrpgRoomQueryState();
+      }
+      if (roomInput) roomInput.value = trpgRoomId;
+      return trpgRoomId;
+    }
+
+    async function applyTrpgRoomInputAndRefresh() {
+      const nextRoomId = applyTrpgRoomFromInput();
+      showToast(`TRPG room: ${nextRoomId}`, 'success');
+      await fetchTrpg();
+    }
+
+    function parseTrpgPlayerKeepers(rawText) {
+      const lines = String(rawText || '')
+        .split(/\r?\n/)
+        .map((line) => line.trim())
+        .filter((line) => line !== '');
+      const mapping = {};
+      for (const line of lines) {
+        const eqIdx = line.indexOf('=');
+        if (eqIdx <= 0 || eqIdx === line.length - 1) {
+          return { ok: false, error: `잘못된 player keeper 형식: ${line}` };
+        }
+        const actorId = line.slice(0, eqIdx).trim();
+        const keeperName = line.slice(eqIdx + 1).trim();
+        if (!actorId || !keeperName) {
+          return { ok: false, error: `actor/keeper 값이 비어 있습니다: ${line}` };
+        }
+        mapping[actorId] = keeperName;
+      }
+      if (Object.keys(mapping).length === 0) {
+        return { ok: false, error: '최소 1명의 player keeper가 필요합니다.' };
+      }
+      return { ok: true, mapping };
+    }
+
+    function trpgShortText(raw, maxLen = 120) {
+      const text = String(raw || '').replace(/\s+/g, ' ').trim();
+      if (text.length <= maxLen) return text;
+      return text.slice(0, Math.max(0, maxLen - 1)) + '…';
+    }
+
+    function setTrpgRoundRunStatus(html, cls = '') {
+      const statusEl = document.getElementById('trpg-round-run-status');
+      if (!statusEl) return;
+      statusEl.className = `trpg-run-status ${cls}`.trim();
+      statusEl.innerHTML = html;
+    }
+
+    function setTrpgRoundRunBusy(isBusy) {
+      trpgRoundRunning = isBusy;
+      const runBtn = document.getElementById('trpg-run-round-btn');
+      if (runBtn) {
+        runBtn.disabled = isBusy;
+        runBtn.textContent = isBusy ? '실행 중...' : '라운드 실행';
+      }
+    }
+
+    async function runTrpgRound() {
+      if (trpgRoundRunning) return;
+      ensureTrpgControlDefaults();
+      const roomId = applyTrpgRoomFromInput();
+      const dmKeeper = String((document.getElementById('trpg-dm-keeper-input') || {}).value || '').trim();
+      const phase = String((document.getElementById('trpg-phase-select') || {}).value || 'round').trim() || 'round';
+      const timeoutRaw = Number((document.getElementById('trpg-timeout-sec-input') || {}).value);
+      const timeoutSec = Number.isFinite(timeoutRaw) && timeoutRaw > 0 ? timeoutRaw : 30;
+      const playerRaw = String((document.getElementById('trpg-player-keepers-input') || {}).value || '');
+      if (!dmKeeper) {
+        setTrpgRoundRunStatus('오류: DM keeper를 입력하세요.', 'error');
+        return;
+      }
+      const parsedPlayers = parseTrpgPlayerKeepers(playerRaw);
+      if (!parsedPlayers.ok) {
+        setTrpgRoundRunStatus('오류: ' + escapeHtml(parsedPlayers.error || 'invalid player_keepers'), 'error');
+        return;
+      }
+
+      setTrpgRoundRunBusy(true);
+      setTrpgRoundRunStatus(
+        `실행 중: room <b>${escapeHtml(roomId)}</b>, phase <b>${escapeHtml(phase)}</b>, timeout <b>${timeoutSec}s</b>`,
+        'running'
+      );
+      try {
+        const headers = Object.assign({ 'Content-Type': 'application/json' }, authHeaders());
+        const body = {
+          room_id: roomId,
+          dm_keeper: dmKeeper,
+          player_keepers: parsedPlayers.mapping,
+          phase,
+          timeout_sec: timeoutSec,
+        };
+        const res = await fetch('/api/v1/trpg/rounds/run', {
+          method: 'POST',
+          headers,
+          body: JSON.stringify(body),
+        });
+        let data = {};
+        try { data = await res.json(); } catch (_) {}
+        if (!res.ok || data.ok === false) {
+          const msg = data.error || data.message || `HTTP ${res.status}`;
+          throw new Error(String(msg));
+        }
+        const summary = (data && typeof data.summary === 'object' && data.summary) ? data.summary : {};
+        const statuses = Array.isArray(data.statuses) ? data.statuses : [];
+        const statusRows = statuses.slice(0, 5).map((st) => {
+          const actor = escapeHtml(String(st.actor_id || '-'));
+          const keeper = escapeHtml(String(st.keeper || '-'));
+          const status = escapeHtml(String(st.status || '-'));
+          const detail = st.reply || st.error || '';
+          return `<div>• ${actor} (${keeper}) <b>${status}</b>${detail ? ` — ${escapeHtml(trpgShortText(detail))}` : ''}</div>`;
+        }).join('');
+        setTrpgRoundRunStatus(
+          `<div>완료: turn ${escapeHtml(String(data.turn_before || '-'))} → <b>${escapeHtml(String(data.turn_after || '-'))}</b></div>
+           <div>요약: success ${escapeHtml(String(summary.successes || 0))}, timeout ${escapeHtml(String(summary.timeouts || 0))}, unavailable ${escapeHtml(String(summary.unavailable || 0))}</div>
+           ${statusRows || '<div>상태 로그 없음</div>'}`,
+          'ok'
+        );
+        showToast(`TRPG round 완료 (room=${roomId})`, 'success');
+        await fetchTrpg();
+      } catch (e) {
+        setTrpgRoundRunStatus(`실패: ${escapeHtml(String((e && e.message) || e || 'unknown error'))}`, 'error');
+        showToast('TRPG round 실행 실패', 'error');
+      } finally {
+        setTrpgRoundRunBusy(false);
+      }
+    }
+
     async function fetchTrpg() {
+      ensureTrpgControlDefaults();
+      const activeRoomId = trpgRoomId;
       const roomLabel = document.getElementById('trpg-room-label');
-      if (roomLabel) roomLabel.textContent = `room: ${TRPG_ROOM_ID}`;
+      if (roomLabel) roomLabel.textContent = `room: ${activeRoomId}`;
 
       try {
         const boardReq = fetch('/api/v1/board?hearth=trpg', { headers: authHeaders() })
           .then(r => r.json())
           .catch(() => ({ posts: [] }));
         const eventsReq = fetch(
-          `/api/v1/trpg/events?room_id=${encodeURIComponent(TRPG_ROOM_ID)}&after_seq=${trpgLastSeq}`,
+          `/api/v1/trpg/events?room_id=${encodeURIComponent(activeRoomId)}&after_seq=${trpgLastSeq}`,
           { headers: authHeaders() }
         )
           .then(r => r.json())
           .catch(() => ({ events: [] }));
         const stateReq = fetch(
-          `/api/v1/trpg/state?room_id=${encodeURIComponent(TRPG_ROOM_ID)}`,
+          `/api/v1/trpg/state?room_id=${encodeURIComponent(activeRoomId)}`,
           { headers: authHeaders() }
         )
           .then(r => r.json())

--- a/test/test_tool_mitosis_coverage.ml
+++ b/test/test_tool_mitosis_coverage.ml
@@ -132,7 +132,12 @@ let test_dispatch_unknown_tool () =
 (* T1: Negative context_ratio should be clamped to 0.0 *)
 let test_negative_context_ratio () =
   let ctx = make_ctx () in
-  let args = `Assoc [("context_ratio", `Float (-1.0)); ("full_context", `String "test")] in
+  let args = `Assoc [
+    ("context_ratio", `Float (-1.0));
+    ("full_context", `String "test");
+    ("async", `Bool false);
+    ("verify", `Bool false);
+  ] in
   match Tool_mitosis.dispatch ctx ~name:"masc_mitosis_handoff" ~args with
   | Some (true, result) ->
       (* Should succeed with clamped ratio *)
@@ -146,6 +151,8 @@ let test_over_one_context_ratio () =
   let args = `Assoc [
     ("context_ratio", `Float 2.0);
     ("full_context", `String "test");
+    ("async", `Bool false);
+    ("verify", `Bool false);
     (* Avoid spawn in tests: keep handoff threshold above clamped ratio *)
     ("handoff_threshold", `Float 2.0);
   ] in
@@ -168,6 +175,8 @@ let test_mitosis_handoff_spawn_timeout_configurable () =
   let args = `Assoc [
     ("context_ratio", `Float 0.3);
     ("spawn_timeout", `Int 300);  (* Custom timeout *)
+    ("async", `Bool false);
+    ("verify", `Bool false);
   ] in
   match Tool_mitosis.dispatch ctx ~name:"masc_mitosis_handoff" ~args with
   | Some (_, _result) -> check bool "custom timeout accepted" true true
@@ -187,6 +196,7 @@ let test_handoff_verifier_advisory_with_invalid_model () =
     ("context_ratio", `Float 0.3);
     ("async", `Bool false);
     ("verify", `Bool true);
+    ("verification_judge_timeout_sec", `Float 0.2);
     ("verification_policy", `String "advisory");
     ("verification_min_judges", `Int 1);
     ("verifier_models", `List [`String "invalid-model-spec"]);
@@ -209,6 +219,7 @@ let test_handoff_verifier_gate_blocks_with_invalid_model () =
     ("context_ratio", `Float 0.3);
     ("async", `Bool false);
     ("verify", `Bool true);
+    ("verification_judge_timeout_sec", `Float 0.2);
     ("verification_policy", `String "gate");
     ("verification_min_judges", `Int 1);
     ("verification_pass_ratio", `Float 1.0);
@@ -247,6 +258,7 @@ let test_handoff_verifier_profile_and_research_metrics () =
     ("context_ratio", `Float 0.3);
     ("async", `Bool false);
     ("verify", `Bool true);
+    ("verification_judge_timeout_sec", `Float 0.2);
     ("verification_policy", `String "advisory");
     ("verifier_profile", `String "abc_neutral");
     ("verifier_models", `List [
@@ -288,9 +300,10 @@ let test_handoff_verifier_min_judges_clamped_to_available_models () =
     ("context_ratio", `Float 0.3);
     ("async", `Bool false);
     ("verify", `Bool true);
+    ("verification_judge_timeout_sec", `Float 0.2);
     ("verification_policy", `String "gate");
     ("verification_min_judges", `Int 3);
-    ("verifier_models", `List [`String "gemini:gemini-2.5-flash"]);
+    ("verifier_models", `List [`String "invalid-single-model"]);
     ("verifier_profile", `String "abc_neutral");
   ] in
   match Tool_mitosis.dispatch ctx ~name:"masc_mitosis_handoff" ~args with
@@ -386,11 +399,11 @@ let () =
       test_case "handoff configurable" `Quick test_mitosis_handoff_spawn_timeout_configurable;
     ];
     "verifier", [
-      test_case "advisory invalid model" `Quick test_handoff_verifier_advisory_with_invalid_model;
-      test_case "gate blocks invalid model" `Quick test_handoff_verifier_gate_blocks_with_invalid_model;
-      test_case "gate bypass when verify=false" `Quick test_handoff_verifier_gate_bypassed_when_verify_false;
-      test_case "profile + research metrics" `Quick test_handoff_verifier_profile_and_research_metrics;
-      test_case "min_judges clamp to model count" `Quick
+      test_case "advisory invalid model" `Slow test_handoff_verifier_advisory_with_invalid_model;
+      test_case "gate blocks invalid model" `Slow test_handoff_verifier_gate_blocks_with_invalid_model;
+      test_case "gate bypass when verify=false" `Slow test_handoff_verifier_gate_bypassed_when_verify_false;
+      test_case "profile + research metrics" `Slow test_handoff_verifier_profile_and_research_metrics;
+      test_case "min_judges clamp to model count" `Slow
         test_handoff_verifier_min_judges_clamped_to_available_models;
     ];
   ]

--- a/test/test_web_dashboard_coverage.ml
+++ b/test/test_web_dashboard_coverage.ml
@@ -126,6 +126,16 @@ let test_html_life_state_pills_present () =
     && contains_re "life_status" html
     && contains_re "Life Pulse" html)
 
+let test_html_contains_trpg_round_run_controls () =
+  let html = Web_dashboard.html () in
+  check bool "trpg round run controls" true
+    (String.length html > 0
+    && contains_substr "id=\"trpg-run-round-btn\"" html
+    && contains_substr "id=\"trpg-dm-keeper-input\"" html
+    && contains_substr "id=\"trpg-player-keepers-input\"" html
+    && contains_substr "function runTrpgRound()" html
+    && contains_substr "/api/v1/trpg/rounds/run" html)
+
 (* ============================================================
    Test Runners
    ============================================================ *)
@@ -149,5 +159,6 @@ let () =
       test_case "life state normalizer" `Quick test_html_contains_life_state_normalizer;
       test_case "notify uses normalized payload" `Quick test_html_notify_uses_normalized_payload;
       test_case "life state pills" `Quick test_html_life_state_pills_present;
+      test_case "trpg round run controls" `Quick test_html_contains_trpg_round_run_controls;
     ];
   ]


### PR DESCRIPTION
## Summary
- add TRPG control panel in dashboard sidebar (room, DM keeper, phase, timeout, player keeper mapping)
- wire `runTrpgRound()` to `POST /api/v1/trpg/rounds/run`
- show round execution summary/statuses inline and refresh TRPG state after run
- keep selected `trpg_room` synced in URL query param
- add coverage assertion for TRPG round-run controls in web dashboard HTML test

## Validation
- _build/default/test/test_web_dashboard_coverage.exe
- _build/default/test/test_dashboard_coverage.exe
- _build/default/test/test_tool_trpg_coverage.exe
