### PR TITLE
fix(viewer): add AssetMetaCheck::Never for WASM builds

### DIFF
--- a/viewer/src/main.rs
+++ b/viewer/src/main.rs
@@ -10,6 +10,7 @@ mod render;
 mod shaders;
 mod sse;
 
+use bevy::asset::{AssetMetaCheck, AssetPlugin};
 use bevy::prelude::*;
 
 use mode::ModePlugin;
@@ -19,15 +20,22 @@ fn main() {
     let default_theme = ViewerTheme::default();
 
     App::new()
-        .add_plugins(DefaultPlugins.set(WindowPlugin {
-            primary_window: Some(Window {
-                title: "MASC Viewer".into(),
-                canvas: Some("#bevy-canvas".into()),
-                prevent_default_event_handling: false,
-                ..default()
-            }),
-            ..default()
-        }))
+        .add_plugins(
+            DefaultPlugins
+                .set(WindowPlugin {
+                    primary_window: Some(Window {
+                        title: "MASC Viewer".into(),
+                        canvas: Some("#bevy-canvas".into()),
+                        prevent_default_event_handling: false,
+                        ..default()
+                    }),
+                    ..default()
+                })
+                .set(AssetPlugin {
+                    meta_check: AssetMetaCheck::Never,
+                    ..default()
+                }),
+        )
         // Initial clear color from default theme (ThemePlugin takes over on changes)
         .insert_resource(ClearColor(default_theme.clear_color()))
         // ── Mode infrastructure (always active) ──


### PR DESCRIPTION
## 변경 사항\n\n### AssetMetaCheck::Never\nBevy WASM 빌드에서 .meta 사이드카 파일을 HTTP로 요청하면 404 → RON 파싱 실패가 발생합니다. AssetPlugin { meta_check: AssetMetaCheck::Never } 설정으로 메타 파일 검사를 비활성화합니다.\n\n### web-sys deprecated 메서드\nhttp.rs를 확인한 결과, 이미 set_method() / set_mode() (비-deprecated 버전)을 사용하고 있어 변경 불필요했습니다.\n\n## 변경 파일\n- viewer/src/main.rs — AssetMetaCheck::Never 설정 추가, DefaultPlugins 체이닝 포맷 정리\n\n## 테스트\n- cargo check --target wasm32-unknown-unknown — 0 errors, 30 warnings (기존 dead code 경고만 존재)