### PR TITLE
feat(keeper): goal horizons + reflection metrics

### DIFF
--- a/bin/main_eio.ml
+++ b/bin/main_eio.ml
@@ -1523,6 +1523,19 @@ let keepers_dashboard_json (config : Room.config) : Yojson.Safe.t =
             let heartbeat_points = ref 0 in
             let proactive_points = ref 0 in
             let drift_applied_count = ref 0 in
+            let auto_reflect_count = ref 0 in
+            let auto_plan_count = ref 0 in
+            let auto_compact_count = ref 0 in
+            let auto_handoff_count = ref 0 in
+            let guardrail_stop_count = ref 0 in
+            let repetition_risk_sum = ref 0.0 in
+            let repetition_risk_points = ref 0 in
+            let goal_alignment_sum = ref 0.0 in
+            let goal_alignment_points = ref 0 in
+            let response_alignment_sum = ref 0.0 in
+            let response_alignment_points = ref 0 in
+            let goal_drift_sum = ref 0.0 in
+            let goal_drift_points = ref 0 in
             let memory_checks = ref 0 in
             let memory_passed = ref 0 in
             let memory_corrections = ref 0 in
@@ -1650,6 +1663,41 @@ let keepers_dashboard_json (config : Room.config) : Yojson.Safe.t =
                      | Some s when s <> "" -> Some s
                      | _ -> None
                 in
+                let auto_rules_obj = j |> member "auto_rules" in
+                let auto_reflect_now =
+                  Safe_ops.json_bool
+                    ~default:(Safe_ops.json_bool ~default:false "reflect" auto_rules_obj)
+                    "auto_reflect"
+                    j
+                in
+                let auto_plan_now =
+                  Safe_ops.json_bool
+                    ~default:(Safe_ops.json_bool ~default:false "plan" auto_rules_obj)
+                    "auto_plan"
+                    j
+                in
+                let auto_compact_now =
+                  Safe_ops.json_bool
+                    ~default:(Safe_ops.json_bool ~default:false "compact" auto_rules_obj)
+                    "auto_compact"
+                    j
+                in
+                let auto_handoff_now =
+                  Safe_ops.json_bool
+                    ~default:(Safe_ops.json_bool ~default:false "handoff" auto_rules_obj)
+                    "auto_handoff"
+                    j
+                in
+                let guardrail_stop_now =
+                  Safe_ops.json_bool
+                    ~default:(Safe_ops.json_bool ~default:false "guardrail_stop" auto_rules_obj)
+                    "guardrail_stop"
+                    j
+                in
+                let repetition_risk_opt = Safe_ops.json_float_opt "repetition_risk" j in
+                let goal_alignment_opt = Safe_ops.json_float_opt "goal_alignment" j in
+                let response_alignment_opt = Safe_ops.json_float_opt "response_alignment" j in
+                let goal_drift_opt = Safe_ops.json_float_opt "goal_drift" j in
                 let memory_notes_added_now =
                   Safe_ops.json_int ~default:0 "memory_notes_added" j
                 in
@@ -1768,6 +1816,31 @@ let keepers_dashboard_json (config : Room.config) : Yojson.Safe.t =
                        proactive_previews_rev := preview :: !proactive_previews_rev
                    | None -> ());
                 if is_interaction then begin
+                  if auto_reflect_now then incr auto_reflect_count;
+                  if auto_plan_now then incr auto_plan_count;
+                  if auto_compact_now then incr auto_compact_count;
+                  if auto_handoff_now then incr auto_handoff_count;
+                  if guardrail_stop_now then incr guardrail_stop_count;
+                  (match repetition_risk_opt with
+                   | Some v ->
+                       repetition_risk_sum := !repetition_risk_sum +. v;
+                       incr repetition_risk_points
+                   | None -> ());
+                  (match goal_alignment_opt with
+                   | Some v ->
+                       goal_alignment_sum := !goal_alignment_sum +. v;
+                       incr goal_alignment_points
+                   | None -> ());
+                  (match response_alignment_opt with
+                   | Some v ->
+                       response_alignment_sum := !response_alignment_sum +. v;
+                       incr response_alignment_points
+                   | None -> ());
+                  (match goal_drift_opt with
+                   | Some v ->
+                       goal_drift_sum := !goal_drift_sum +. v;
+                       incr goal_drift_points
+                   | None -> ());
                   if drift_applied_now then begin
                     incr drift_applied_count;
                     (match drift_reason_now with
@@ -1893,6 +1966,19 @@ let keepers_dashboard_json (config : Room.config) : Yojson.Safe.t =
                     match drift_reason_now with
                     | Some s -> `String s
                     | None -> `Null);
+                  ("auto_reflect", `Bool auto_reflect_now);
+                  ("auto_plan", `Bool auto_plan_now);
+                  ("auto_compact", `Bool auto_compact_now);
+                  ("auto_handoff", `Bool auto_handoff_now);
+                  ("guardrail_stop", `Bool guardrail_stop_now);
+                  ("repetition_risk",
+                    match repetition_risk_opt with Some v -> `Float v | None -> `Null);
+                  ("goal_alignment",
+                    match goal_alignment_opt with Some v -> `Float v | None -> `Null);
+                  ("response_alignment",
+                    match response_alignment_opt with Some v -> `Float v | None -> `Null);
+                  ("goal_drift",
+                    match goal_drift_opt with Some v -> `Float v | None -> `Null);
                   ("memory_performed", `Bool memory_performed);
                   ("memory_query_kind", `String memory_query_kind);
                   ("memory_passed", `Bool memory_passed_now);
@@ -1942,6 +2028,26 @@ let keepers_dashboard_json (config : Room.config) : Yojson.Safe.t =
             let drift_applied_rate =
               if interaction_points_int = 0 then 0.0
               else float_of_int !drift_applied_count /. float_of_int interaction_points_int
+            in
+            let auto_reflect_rate =
+              if interaction_points_int = 0 then 0.0
+              else float_of_int !auto_reflect_count /. float_of_int interaction_points_int
+            in
+            let auto_plan_rate =
+              if interaction_points_int = 0 then 0.0
+              else float_of_int !auto_plan_count /. float_of_int interaction_points_int
+            in
+            let auto_compact_rate =
+              if interaction_points_int = 0 then 0.0
+              else float_of_int !auto_compact_count /. float_of_int interaction_points_int
+            in
+            let auto_handoff_rate =
+              if interaction_points_int = 0 then 0.0
+              else float_of_int !auto_handoff_count /. float_of_int interaction_points_int
+            in
+            let guardrail_stop_rate =
+              if interaction_points_int = 0 then 0.0
+              else float_of_int !guardrail_stop_count /. float_of_int interaction_points_int
             in
             let proactive_previews = List.rev !proactive_previews_rev in
             let proactive_similarity_warn_threshold =
@@ -1996,6 +2102,22 @@ let keepers_dashboard_json (config : Room.config) : Yojson.Safe.t =
               else
                 float_of_int !memory_weather_passed
                 /. float_of_int !memory_weather_checks
+            in
+            let repetition_risk_avg =
+              if !repetition_risk_points = 0 then 0.0
+              else !repetition_risk_sum /. float_of_int !repetition_risk_points
+            in
+            let goal_alignment_avg =
+              if !goal_alignment_points = 0 then 0.0
+              else !goal_alignment_sum /. float_of_int !goal_alignment_points
+            in
+            let response_alignment_avg =
+              if !response_alignment_points = 0 then 0.0
+              else !response_alignment_sum /. float_of_int !response_alignment_points
+            in
+            let goal_drift_avg =
+              if !goal_drift_points = 0 then 0.0
+              else !goal_drift_sum /. float_of_int !goal_drift_points
             in
             let top_work_kinds =
               top_counts_json ~limit:5 ~name_key:"kind" work_kind_counts
@@ -2092,8 +2214,22 @@ let keepers_dashboard_json (config : Room.config) : Yojson.Safe.t =
               ("proactive_template_fallback_denominator", `Int proactive_points_int);
               ("intervention_share", `Float intervention_share);
               ("intervention_per_turn", `Float intervention_per_turn);
+              ("auto_reflect_count", `Int !auto_reflect_count);
+              ("auto_plan_count", `Int !auto_plan_count);
+              ("auto_compact_count", `Int !auto_compact_count);
+              ("auto_handoff_count", `Int !auto_handoff_count);
+              ("guardrail_stop_count", `Int !guardrail_stop_count);
+              ("auto_reflect_rate", `Float auto_reflect_rate);
+              ("auto_plan_rate", `Float auto_plan_rate);
+              ("auto_compact_rate", `Float auto_compact_rate);
+              ("auto_handoff_rate", `Float auto_handoff_rate);
+              ("guardrail_stop_rate", `Float guardrail_stop_rate);
               ("drift_applied_count", `Int !drift_applied_count);
               ("drift_applied_rate", `Float drift_applied_rate);
+              ("repetition_risk_avg", `Float repetition_risk_avg);
+              ("goal_alignment_avg", `Float goal_alignment_avg);
+              ("response_alignment_avg", `Float response_alignment_avg);
+              ("goal_drift_avg", `Float goal_drift_avg);
               ("proactive_preview_sample_count", `Int proactive_preview_sample_count);
               ("proactive_preview_pair_count", `Int proactive_preview_pair_count);
               ("proactive_preview_similarity_avg", `Float proactive_preview_similarity_avg);

--- a/bin/main_eio.ml
+++ b/bin/main_eio.ml
@@ -2245,6 +2245,18 @@ let keepers_dashboard_json (config : Room.config) : Yojson.Safe.t =
               ("updated_at", `String m.updated_at);
               ("trace_history_count", `Int trace_history_count);
               ("goal", if include_goals then `String m.goal else `Null);
+              ("short_goal", if include_goals then `String m.short_goal else `Null);
+              ("mid_goal", if include_goals then `String m.mid_goal else `Null);
+              ("long_goal", if include_goals then `String m.long_goal else `Null);
+              ( "goal_horizons",
+                if include_goals then
+                  `Assoc [
+                    ("short", `String m.short_goal);
+                    ("mid", `String m.mid_goal);
+                    ("long", `String m.long_goal);
+                  ]
+                else
+                  `Null );
               ("soul_profile", `String m.soul_profile);
               ("will", if String.trim m.will = "" then `Null else `String m.will);
               ("needs", if String.trim m.needs = "" then `Null else `String m.needs);

--- a/bin/main_eio.ml
+++ b/bin/main_eio.ml
@@ -1979,6 +1979,7 @@ let keepers_dashboard_json (config : Room.config) : Yojson.Safe.t =
                     match response_alignment_opt with Some v -> `Float v | None -> `Null);
                   ("goal_drift",
                     match goal_drift_opt with Some v -> `Float v | None -> `Null);
+                  ("reflection", j |> member "reflection");
                   ("memory_performed", `Bool memory_performed);
                   ("memory_query_kind", `String memory_query_kind);
                   ("memory_passed", `Bool memory_passed_now);

--- a/lib/tool_keeper.ml
+++ b/lib/tool_keeper.ml
@@ -740,6 +740,55 @@ let normalize_proactive_cooldown_sec (v : int) : int =
 let normalize_drift_min_turn_gap (v : int) : int =
   clamp_int v ~min_v:1 ~max_v:500
 
+let keeper_rule_reflect_repetition_threshold () : float =
+  float_of_env_default
+    "MASC_KEEPER_RULE_REFLECT_REPETITION"
+    ~default:0.86
+    ~min_v:0.0
+    ~max_v:1.0
+
+let keeper_rule_plan_goal_alignment_threshold () : float =
+  float_of_env_default
+    "MASC_KEEPER_RULE_PLAN_GOAL_ALIGNMENT_MAX"
+    ~default:0.06
+    ~min_v:0.0
+    ~max_v:1.0
+
+let keeper_rule_plan_response_alignment_threshold () : float =
+  float_of_env_default
+    "MASC_KEEPER_RULE_PLAN_RESPONSE_ALIGNMENT_MAX"
+    ~default:0.10
+    ~min_v:0.0
+    ~max_v:1.0
+
+let keeper_rule_guardrail_repetition_threshold () : float =
+  float_of_env_default
+    "MASC_KEEPER_RULE_GUARDRAIL_REPETITION"
+    ~default:0.90
+    ~min_v:0.0
+    ~max_v:1.0
+
+let keeper_rule_guardrail_goal_alignment_threshold () : float =
+  float_of_env_default
+    "MASC_KEEPER_RULE_GUARDRAIL_GOAL_ALIGNMENT_MAX"
+    ~default:0.04
+    ~min_v:0.0
+    ~max_v:1.0
+
+let keeper_rule_guardrail_response_alignment_threshold () : float =
+  float_of_env_default
+    "MASC_KEEPER_RULE_GUARDRAIL_RESPONSE_ALIGNMENT_MAX"
+    ~default:0.08
+    ~min_v:0.0
+    ~max_v:1.0
+
+let keeper_rule_guardrail_context_threshold () : float =
+  float_of_env_default
+    "MASC_KEEPER_RULE_GUARDRAIL_CONTEXT_MIN"
+    ~default:0.70
+    ~min_v:0.0
+    ~max_v:1.0
+
 let short_preview ?(max_len = 220) (s : string) : string =
   let s = String.trim s in
   if String.length s <= max_len then s
@@ -2369,6 +2418,155 @@ let repetition_risk_score
       | Some prev, Some latest -> jaccard_similarity latest prev
       | _ -> 0.0)
 
+type keeper_auto_rule_eval = {
+  repetition_risk: float;
+  goal_alignment: float;
+  response_alignment: float;
+  goal_drift: float;
+  reflect: bool;
+  plan: bool;
+  compact: bool;
+  handoff: bool;
+  guardrail_stop: bool;
+  guardrail_reason: string option;
+  reasons: string list;
+}
+
+let keeper_auto_rule_eval_to_json (e : keeper_auto_rule_eval) : Yojson.Safe.t =
+  `Assoc [
+    ("repetition_risk", `Float e.repetition_risk);
+    ("goal_alignment", `Float e.goal_alignment);
+    ("response_alignment", `Float e.response_alignment);
+    ("goal_drift", `Float e.goal_drift);
+    ("reflect", `Bool e.reflect);
+    ("plan", `Bool e.plan);
+    ("compact", `Bool e.compact);
+    ("handoff", `Bool e.handoff);
+    ("guardrail_stop", `Bool e.guardrail_stop);
+    ("guardrail_reason",
+      match e.guardrail_reason with
+      | Some reason -> `String reason
+      | None -> `Null);
+    ("reasons", `List (List.map (fun reason -> `String reason) e.reasons));
+  ]
+
+let evaluate_keeper_auto_rules
+    ~(meta : keeper_meta)
+    ~(context_ratio : float)
+    ~(message_count : int)
+    ~(token_count : int)
+    ~(repetition_risk : float)
+    ~(goal_alignment : float)
+    ~(response_alignment : float) : keeper_auto_rule_eval =
+  let ratio_gate = meta.compaction_ratio_gate in
+  let message_gate = meta.compaction_message_gate in
+  let token_gate = meta.compaction_token_gate in
+  let reflect_threshold = keeper_rule_reflect_repetition_threshold () in
+  let plan_goal_alignment_threshold = keeper_rule_plan_goal_alignment_threshold () in
+  let plan_response_alignment_threshold = keeper_rule_plan_response_alignment_threshold () in
+  let guardrail_repetition_threshold = keeper_rule_guardrail_repetition_threshold () in
+  let guardrail_goal_alignment_threshold = keeper_rule_guardrail_goal_alignment_threshold () in
+  let guardrail_response_alignment_threshold = keeper_rule_guardrail_response_alignment_threshold () in
+  let guardrail_context_threshold =
+    max ratio_gate (keeper_rule_guardrail_context_threshold ())
+  in
+  let goal_drift =
+    1.0 -. max 0.0 (min 1.0 (max goal_alignment response_alignment))
+    |> max 0.0
+    |> min 1.0
+  in
+  let reflect = repetition_risk >= reflect_threshold in
+  let plan =
+    goal_alignment <= plan_goal_alignment_threshold
+    && response_alignment <= plan_response_alignment_threshold
+  in
+  let compact =
+    context_ratio >= ratio_gate
+    || (message_gate > 0 && message_count >= message_gate)
+    || (token_gate > 0 && token_count >= token_gate)
+  in
+  let handoff = meta.auto_handoff && context_ratio >= meta.handoff_threshold in
+  let guardrail_stop =
+    repetition_risk >= guardrail_repetition_threshold
+    && goal_alignment <= guardrail_goal_alignment_threshold
+    && response_alignment <= guardrail_response_alignment_threshold
+    && context_ratio >= guardrail_context_threshold
+  in
+  let guardrail_reason =
+    if guardrail_stop then
+      Some
+        (Printf.sprintf
+           "guardrail_stop(rep=%.3f>=%.3f,goal=%.3f<=%.3f,response=%.3f<=%.3f,ctx=%.3f>=%.3f)"
+           repetition_risk
+           guardrail_repetition_threshold
+           goal_alignment
+           guardrail_goal_alignment_threshold
+           response_alignment
+           guardrail_response_alignment_threshold
+           context_ratio
+           guardrail_context_threshold)
+    else
+      None
+  in
+  let reasons = [] in
+  let reasons =
+    if reflect then
+      (Printf.sprintf
+         "reflect(repetition_risk=%.3f>=%.3f)"
+         repetition_risk
+         reflect_threshold)
+      :: reasons
+    else reasons
+  in
+  let reasons =
+    if plan then
+      (Printf.sprintf
+         "plan(goal_alignment=%.3f<=%.3f,response_alignment=%.3f<=%.3f)"
+         goal_alignment
+         plan_goal_alignment_threshold
+         response_alignment
+         plan_response_alignment_threshold)
+      :: reasons
+    else reasons
+  in
+  let reasons =
+    if compact then
+      (Printf.sprintf
+         "compact(ctx=%.3f,msg=%d,tokens=%d)"
+         context_ratio
+         message_count
+         token_count)
+      :: reasons
+    else reasons
+  in
+  let reasons =
+    if handoff then
+      (Printf.sprintf
+         "handoff(ctx=%.3f>=%.3f)"
+         context_ratio
+         meta.handoff_threshold)
+      :: reasons
+    else reasons
+  in
+  let reasons =
+    match guardrail_reason with
+    | Some reason -> reason :: reasons
+    | None -> reasons
+  in
+  {
+    repetition_risk;
+    goal_alignment;
+    response_alignment;
+    goal_drift;
+    reflect;
+    plan;
+    compact;
+    handoff;
+    guardrail_stop;
+    guardrail_reason;
+    reasons = List.rev reasons;
+  }
+
 let recent_user_messages (msgs : Llm_client.message list) ~(max_n : int) : string list =
   msgs
   |> List.rev
@@ -3321,6 +3519,11 @@ type metrics_summary = {
   turn_points: int;
   heartbeat_points: int;
   proactive_points: int;
+  auto_reflect_count: int;
+  auto_plan_count: int;
+  auto_compact_count: int;
+  auto_handoff_count: int;
+  guardrail_stop_count: int;
   drift_applied_count: int;
   handoff_count: int;
   compaction_events: int;
@@ -3341,6 +3544,10 @@ type metrics_summary = {
   repetition_risk_points: int;
   goal_alignment_sum: float;
   goal_alignment_points: int;
+  response_alignment_sum: float;
+  response_alignment_points: int;
+  goal_drift_sum: float;
+  goal_drift_points: int;
   last_handoff: Yojson.Safe.t option;
   last_compaction: Yojson.Safe.t option;
 }
@@ -3350,6 +3557,11 @@ let empty_metrics_summary = {
   turn_points = 0;
   heartbeat_points = 0;
   proactive_points = 0;
+  auto_reflect_count = 0;
+  auto_plan_count = 0;
+  auto_compact_count = 0;
+  auto_handoff_count = 0;
+  guardrail_stop_count = 0;
   drift_applied_count = 0;
   handoff_count = 0;
   compaction_events = 0;
@@ -3370,6 +3582,10 @@ let empty_metrics_summary = {
   repetition_risk_points = 0;
   goal_alignment_sum = 0.0;
   goal_alignment_points = 0;
+  response_alignment_sum = 0.0;
+  response_alignment_points = 0;
+  goal_drift_sum = 0.0;
+  goal_drift_points = 0;
   last_handoff = None;
   last_compaction = None;
 }
@@ -3387,6 +3603,26 @@ let metrics_summary_to_json (s : metrics_summary) : Yojson.Safe.t =
   let drift_applied_rate =
     if interaction_points = 0 then 0.0
     else float_of_int s.drift_applied_count /. float_of_int interaction_points
+  in
+  let auto_reflect_rate =
+    if interaction_points = 0 then 0.0
+    else float_of_int s.auto_reflect_count /. float_of_int interaction_points
+  in
+  let auto_plan_rate =
+    if interaction_points = 0 then 0.0
+    else float_of_int s.auto_plan_count /. float_of_int interaction_points
+  in
+  let auto_compact_rate =
+    if interaction_points = 0 then 0.0
+    else float_of_int s.auto_compact_count /. float_of_int interaction_points
+  in
+  let auto_handoff_rate =
+    if interaction_points = 0 then 0.0
+    else float_of_int s.auto_handoff_count /. float_of_int interaction_points
+  in
+  let guardrail_stop_rate =
+    if interaction_points = 0 then 0.0
+    else float_of_int s.guardrail_stop_count /. float_of_int interaction_points
   in
   let memory_pass_rate =
     if s.memory_checks = 0 then 0.0
@@ -3420,6 +3656,14 @@ let metrics_summary_to_json (s : metrics_summary) : Yojson.Safe.t =
     if s.goal_alignment_points = 0 then 0.0
     else s.goal_alignment_sum /. float_of_int s.goal_alignment_points
   in
+  let response_alignment_avg =
+    if s.response_alignment_points = 0 then 0.0
+    else s.response_alignment_sum /. float_of_int s.response_alignment_points
+  in
+  let goal_drift_avg =
+    if s.goal_drift_points = 0 then 0.0
+    else s.goal_drift_sum /. float_of_int s.goal_drift_points
+  in
   `Assoc [
     ("sample_points", `Int s.sample_points);
     ("turn_points", `Int s.turn_points);
@@ -3428,6 +3672,16 @@ let metrics_summary_to_json (s : metrics_summary) : Yojson.Safe.t =
     ("window_interactions", `Int interaction_points);
     ("intervention_share", `Float intervention_share);
     ("intervention_per_turn", `Float intervention_per_turn);
+    ("auto_reflect_count", `Int s.auto_reflect_count);
+    ("auto_plan_count", `Int s.auto_plan_count);
+    ("auto_compact_count", `Int s.auto_compact_count);
+    ("auto_handoff_count", `Int s.auto_handoff_count);
+    ("guardrail_stop_count", `Int s.guardrail_stop_count);
+    ("auto_reflect_rate", `Float auto_reflect_rate);
+    ("auto_plan_rate", `Float auto_plan_rate);
+    ("auto_compact_rate", `Float auto_compact_rate);
+    ("auto_handoff_rate", `Float auto_handoff_rate);
+    ("guardrail_stop_rate", `Float guardrail_stop_rate);
     ("drift_applied_count", `Int s.drift_applied_count);
     ("drift_applied_rate", `Float drift_applied_rate);
     ("handoff_count", `Int s.handoff_count);
@@ -3451,6 +3705,8 @@ let metrics_summary_to_json (s : metrics_summary) : Yojson.Safe.t =
     ("memory_weather_pass_rate", `Float memory_weather_pass_rate);
     ("repetition_risk_avg", `Float repetition_risk_avg);
     ("goal_alignment_avg", `Float goal_alignment_avg);
+    ("response_alignment_avg", `Float response_alignment_avg);
+    ("goal_drift_avg", `Float goal_drift_avg);
     ("last_handoff", match s.last_handoff with Some j -> j | None -> `Null);
     ("last_compaction", match s.last_compaction with Some j -> j | None -> `Null);
   ]
@@ -3509,8 +3765,41 @@ let summarize_metrics_lines (lines : string list) ~(default_generation : int) : 
       let memory_is_weather =
         match memory_expected_topic with Some "weather" -> true | _ -> false
       in
+      let auto_rules = j |> member "auto_rules" in
+      let auto_reflect_now =
+        Safe_ops.json_bool
+          ~default:(Safe_ops.json_bool ~default:false "reflect" auto_rules)
+          "auto_reflect"
+          j
+      in
+      let auto_plan_now =
+        Safe_ops.json_bool
+          ~default:(Safe_ops.json_bool ~default:false "plan" auto_rules)
+          "auto_plan"
+          j
+      in
+      let auto_compact_now =
+        Safe_ops.json_bool
+          ~default:(Safe_ops.json_bool ~default:false "compact" auto_rules)
+          "auto_compact"
+          j
+      in
+      let auto_handoff_now =
+        Safe_ops.json_bool
+          ~default:(Safe_ops.json_bool ~default:false "handoff" auto_rules)
+          "auto_handoff"
+          j
+      in
+      let guardrail_stop_now =
+        Safe_ops.json_bool
+          ~default:(Safe_ops.json_bool ~default:false "guardrail_stop" auto_rules)
+          "guardrail_stop"
+          j
+      in
       let repetition_risk_opt = Safe_ops.json_float_opt "repetition_risk" j in
       let goal_alignment_opt = Safe_ops.json_float_opt "goal_alignment" j in
+      let response_alignment_opt = Safe_ops.json_float_opt "response_alignment" j in
+      let goal_drift_opt = Safe_ops.json_float_opt "goal_drift" j in
       let handoff_json =
         if handoff_performed then
           Some (`Assoc [
@@ -3549,6 +3838,16 @@ let summarize_metrics_lines (lines : string list) ~(default_generation : int) : 
         turn_points = acc.turn_points + (if is_turn then 1 else 0);
         heartbeat_points = acc.heartbeat_points + (if is_heartbeat then 1 else 0);
         proactive_points = acc.proactive_points + (if is_proactive then 1 else 0);
+        auto_reflect_count =
+          acc.auto_reflect_count + (if is_interaction && auto_reflect_now then 1 else 0);
+        auto_plan_count =
+          acc.auto_plan_count + (if is_interaction && auto_plan_now then 1 else 0);
+        auto_compact_count =
+          acc.auto_compact_count + (if is_interaction && auto_compact_now then 1 else 0);
+        auto_handoff_count =
+          acc.auto_handoff_count + (if is_interaction && auto_handoff_now then 1 else 0);
+        guardrail_stop_count =
+          acc.guardrail_stop_count + (if is_interaction && guardrail_stop_now then 1 else 0);
         drift_applied_count =
           acc.drift_applied_count + (if is_interaction && drift_applied_now then 1 else 0);
         handoff_count = acc.handoff_count + (if is_interaction && handoff_performed then 1 else 0);
@@ -3599,6 +3898,18 @@ let summarize_metrics_lines (lines : string list) ~(default_generation : int) : 
         goal_alignment_points =
           acc.goal_alignment_points
           + (if Option.is_some goal_alignment_opt then 1 else 0);
+        response_alignment_sum =
+          acc.response_alignment_sum
+          +. (if is_interaction then Option.value ~default:0.0 response_alignment_opt else 0.0);
+        response_alignment_points =
+          acc.response_alignment_points
+          + (if is_interaction && Option.is_some response_alignment_opt then 1 else 0);
+        goal_drift_sum =
+          acc.goal_drift_sum
+          +. (if is_interaction then Option.value ~default:0.0 goal_drift_opt else 0.0);
+        goal_drift_points =
+          acc.goal_drift_points
+          + (if is_interaction && Option.is_some goal_drift_opt then 1 else 0);
         last_handoff = handoff_json;
         last_compaction = compaction_json;
       }
@@ -4568,27 +4879,53 @@ let start_keepalive (ctx : _ context) (m : keeper_meta) : unit =
                    ~primary_model_max_tokens:primary_model.max_context
                    ~base_dir
                in
-               (match ctx_opt with
-                | None -> ()
-                | Some c ->
-                    let continuity_snapshot = latest_state_snapshot_from_messages c.messages in
-                    let continuity_summary =
-                      match continuity_snapshot with
-                      | Some s -> keeper_state_snapshot_to_summary_text s
-                      | None ->
-                          let trimmed = String.trim meta_current.continuity_summary in
-                          if trimmed = "" then "No continuity snapshot available." else trimmed
+	               (match ctx_opt with
+	                | None -> ()
+	                | Some c ->
+                    let latest_user_message =
+                      latest_message_content_by_role
+                        ~role:Llm_client.User
+                        c.messages
                     in
-                    let repetition_risk =
-                      repetition_risk_score ~messages:c.messages ~candidate_reply:None
+                    let latest_assistant_message =
+                      latest_message_content_by_role
+                        ~role:Llm_client.Assistant
+                        c.messages
                     in
-                    let goal_alignment =
-                      goal_alignment_score
+	                    let continuity_snapshot = latest_state_snapshot_from_messages c.messages in
+	                    let continuity_summary =
+	                      match continuity_snapshot with
+	                      | Some s -> keeper_state_snapshot_to_summary_text s
+	                      | None ->
+	                          let trimmed = String.trim meta_current.continuity_summary in
+	                          if trimmed = "" then "No continuity snapshot available." else trimmed
+	                    in
+	                    let repetition_risk =
+	                      repetition_risk_score ~messages:c.messages ~candidate_reply:None
+	                    in
+	                    let goal_alignment =
+	                      goal_alignment_score
+	                        ~meta:meta_current
+	                        ~user_message:latest_user_message
+	                        ~assistant_reply:latest_assistant_message
+	                    in
+                    let response_alignment =
+                      match latest_user_message, latest_assistant_message with
+                      | Some user_message, Some assistant_message ->
+                        jaccard_similarity user_message assistant_message
+                      | _ -> 0.0
+                    in
+                    let auto_rules =
+                      evaluate_keeper_auto_rules
                         ~meta:meta_current
-                        ~user_message:(latest_message_content_by_role ~role:Llm_client.User c.messages)
-                        ~assistant_reply:(latest_message_content_by_role ~role:Llm_client.Assistant c.messages)
+                        ~context_ratio:(Context_manager.context_ratio c)
+                        ~message_count:(List.length c.messages)
+                        ~token_count:c.token_count
+                        ~repetition_risk
+                        ~goal_alignment
+                        ~response_alignment
                     in
-                    let snapshot = `Assoc [
+	                    let snapshot = `Assoc [
                       ("ts", `String (now_iso ()));
                       ("ts_unix", `Float now_ts);
                       ("channel", `String "heartbeat");
@@ -4621,11 +4958,23 @@ let start_keepalive (ctx : _ context) (m : keeper_meta) : unit =
                       ("tool_call_count", `Int 0);
                       ("tools_used", `List []);
                       ("snapshot_source", `String "keeper_context_status");
-                      ("memory_check", memory_check_default_json ());
-                      ("repetition_risk", `Float repetition_risk);
-                      ("goal_alignment", `Float goal_alignment);
-                      ("handoff", `Assoc [("performed", `Bool false)]);
-                    ] in
+	                      ("memory_check", memory_check_default_json ());
+                      ("auto_rules", keeper_auto_rule_eval_to_json auto_rules);
+                      ("auto_reflect", `Bool auto_rules.reflect);
+                      ("auto_plan", `Bool auto_rules.plan);
+                      ("auto_compact", `Bool auto_rules.compact);
+                      ("auto_handoff", `Bool auto_rules.handoff);
+	                      ("repetition_risk", `Float repetition_risk);
+	                      ("goal_alignment", `Float goal_alignment);
+                      ("response_alignment", `Float response_alignment);
+                      ("goal_drift", `Float auto_rules.goal_drift);
+                      ("guardrail_stop", `Bool auto_rules.guardrail_stop);
+                      ("guardrail_stop_reason",
+                        match auto_rules.guardrail_reason with
+                        | Some reason -> `String reason
+                        | None -> `Null);
+	                      ("handoff", `Assoc [("performed", `Bool false)]);
+	                    ] in
                     append_jsonl_line metrics_path snapshot)
              with _ -> ());
             last_snapshot_ts := now_ts
@@ -6108,14 +6457,15 @@ let handle_keeper_msg ctx args : tool_result =
                   ~messages:ctx_work.messages
                   ~candidate_reply:(Some safe_reply)
               in
-              let goal_alignment =
-                goal_alignment_score
-                  ~meta
-                  ~user_message:(Some message)
-                  ~assistant_reply:(Some safe_reply)
-              in
+	              let goal_alignment =
+	                goal_alignment_score
+	                  ~meta
+	                  ~user_message:(Some message)
+	                  ~assistant_reply:(Some safe_reply)
+	              in
+              let response_alignment = jaccard_similarity message safe_reply in
 
-	              let assistant_msg = Llm_client.assistant_msg safe_reply in
+		              let assistant_msg = Llm_client.assistant_msg safe_reply in
 	              let ctx_work = Context_manager.append ctx_work assistant_msg in
               Context_manager.persist_message session assistant_msg;
               let now_ts = Time_compat.now () in
@@ -6202,13 +6552,39 @@ let handle_keeper_msg ctx args : tool_result =
 
               ignore (save_checkpoint session ctx_work ~generation:meta_turn.generation);
 
-              let do_handoff =
-                meta_turn.auto_handoff &&
-                ctx_ratio >= meta_turn.handoff_threshold &&
-                (now_ts -. meta_turn.last_handoff_ts >= float_of_int meta_turn.handoff_cooldown_sec)
-              in
+		              let handoff_eval =
+                let auto_rules =
+                  evaluate_keeper_auto_rules
+                    ~meta:meta_turn
+                    ~context_ratio:ctx_ratio
+                    ~message_count:(List.length ctx_work.messages)
+                    ~token_count:ctx_work.token_count
+                    ~repetition_risk
+                    ~goal_alignment
+                    ~response_alignment
+                in
+                (if auto_rules.guardrail_stop then
+                   (try
+                      ignore
+                        (Room.broadcast
+                           ctx.config
+                           ~from_agent:meta_turn.agent_name
+                           ~content:
+                             (Printf.sprintf
+                                "🛑 keeper guardrail_stop: %s"
+                                (Option.value
+                                   ~default:"policy threshold exceeded"
+                                   auto_rules.guardrail_reason)))
+                    with _ -> ()));
+                let do_handoff =
+                  auto_rules.handoff &&
+		                (now_ts -. meta_turn.last_handoff_ts >= float_of_int meta_turn.handoff_cooldown_sec)
+		              in
+                (do_handoff, auto_rules)
+	              in
+	              let (do_handoff, auto_rules) = handoff_eval in
 
-              let metrics_path = keeper_metrics_path ctx.config meta_turn.name in
+	              let metrics_path = keeper_metrics_path ctx.config meta_turn.name in
 
               if not do_handoff then begin
                 (match write_meta ctx.config meta_turn with
@@ -6251,10 +6627,22 @@ let handle_keeper_msg ctx args : tool_result =
 		                     ("skill_secondary",
 		                       `List (List.map (fun s -> `String s) effective_skill_route.secondary_skills));
 			                     ("skill_reason", `String effective_skill_route.reason);
-	                     ("memory_check", memory_check_json);
-                     ("repetition_risk", `Float repetition_risk);
-                     ("goal_alignment", `Float goal_alignment);
-	                     ("drift", `Assoc [
+		                     ("memory_check", memory_check_json);
+                     ("auto_rules", keeper_auto_rule_eval_to_json auto_rules);
+                     ("auto_reflect", `Bool auto_rules.reflect);
+                     ("auto_plan", `Bool auto_rules.plan);
+                     ("auto_compact", `Bool auto_rules.compact);
+                     ("auto_handoff", `Bool auto_rules.handoff);
+                     ("guardrail_stop", `Bool auto_rules.guardrail_stop);
+                     ("guardrail_stop_reason",
+                       match auto_rules.guardrail_reason with
+                       | Some reason -> `String reason
+                       | None -> `Null);
+	                     ("repetition_risk", `Float repetition_risk);
+	                     ("goal_alignment", `Float goal_alignment);
+                     ("response_alignment", `Float response_alignment);
+                     ("goal_drift", `Float auto_rules.goal_drift);
+		                     ("drift", `Assoc [
 	                       ("enabled", `Bool meta_turn.drift_enabled);
                        ("applied", `Bool drift_applied);
                        ("reason",
@@ -6322,10 +6710,22 @@ let handle_keeper_msg ctx args : tool_result =
 		                  ("skill_secondary",
 		                    `List (List.map (fun s -> `String s) effective_skill_route.secondary_skills));
 			                  ("skill_reason", `String effective_skill_route.reason);
-		                  ("memory_check", memory_check_json);
-                  ("repetition_risk", `Float repetition_risk);
-                  ("goal_alignment", `Float goal_alignment);
-	                  ("drift", `Assoc [
+			                  ("memory_check", memory_check_json);
+                  ("auto_rules", keeper_auto_rule_eval_to_json auto_rules);
+                  ("auto_reflect", `Bool auto_rules.reflect);
+                  ("auto_plan", `Bool auto_rules.plan);
+                  ("auto_compact", `Bool auto_rules.compact);
+                  ("auto_handoff", `Bool auto_rules.handoff);
+                  ("guardrail_stop", `Bool auto_rules.guardrail_stop);
+                  ("guardrail_stop_reason",
+                    match auto_rules.guardrail_reason with
+                    | Some reason -> `String reason
+                    | None -> `Null);
+	                  ("repetition_risk", `Float repetition_risk);
+	                  ("goal_alignment", `Float goal_alignment);
+                  ("response_alignment", `Float response_alignment);
+                  ("goal_drift", `Float auto_rules.goal_drift);
+		                  ("drift", `Assoc [
 	                    ("enabled", `Bool meta_turn.drift_enabled);
                     ("applied", `Bool drift_applied);
                     ("reason",
@@ -6442,10 +6842,22 @@ let handle_keeper_msg ctx args : tool_result =
 		                     ("skill_secondary",
 		                       `List (List.map (fun s -> `String s) effective_skill_route.secondary_skills));
 			                     ("skill_reason", `String effective_skill_route.reason);
-		                     ("memory_check", memory_check_json);
-                     ("repetition_risk", `Float repetition_risk);
-                     ("goal_alignment", `Float goal_alignment);
-	                     ("drift", `Assoc [
+			                     ("memory_check", memory_check_json);
+                     ("auto_rules", keeper_auto_rule_eval_to_json auto_rules);
+                     ("auto_reflect", `Bool auto_rules.reflect);
+                     ("auto_plan", `Bool auto_rules.plan);
+                     ("auto_compact", `Bool auto_rules.compact);
+                     ("auto_handoff", `Bool auto_rules.handoff);
+                     ("guardrail_stop", `Bool auto_rules.guardrail_stop);
+                     ("guardrail_stop_reason",
+                       match auto_rules.guardrail_reason with
+                       | Some reason -> `String reason
+                       | None -> `Null);
+	                     ("repetition_risk", `Float repetition_risk);
+	                     ("goal_alignment", `Float goal_alignment);
+                     ("response_alignment", `Float response_alignment);
+                     ("goal_drift", `Float auto_rules.goal_drift);
+		                     ("drift", `Assoc [
 	                       ("enabled", `Bool meta_turn.drift_enabled);
                        ("applied", `Bool drift_applied);
                        ("reason",
@@ -6512,10 +6924,22 @@ let handle_keeper_msg ctx args : tool_result =
 		                  ("skill_secondary",
 		                    `List (List.map (fun s -> `String s) effective_skill_route.secondary_skills));
 			                  ("skill_reason", `String effective_skill_route.reason);
-		                  ("memory_check", memory_check_json);
-                  ("repetition_risk", `Float repetition_risk);
-                  ("goal_alignment", `Float goal_alignment);
-	                  ("drift", `Assoc [
+			                  ("memory_check", memory_check_json);
+                  ("auto_rules", keeper_auto_rule_eval_to_json auto_rules);
+                  ("auto_reflect", `Bool auto_rules.reflect);
+                  ("auto_plan", `Bool auto_rules.plan);
+                  ("auto_compact", `Bool auto_rules.compact);
+                  ("auto_handoff", `Bool auto_rules.handoff);
+                  ("guardrail_stop", `Bool auto_rules.guardrail_stop);
+                  ("guardrail_stop_reason",
+                    match auto_rules.guardrail_reason with
+                    | Some reason -> `String reason
+                    | None -> `Null);
+	                  ("repetition_risk", `Float repetition_risk);
+	                  ("goal_alignment", `Float goal_alignment);
+                  ("response_alignment", `Float response_alignment);
+                  ("goal_drift", `Float auto_rules.goal_drift);
+		                  ("drift", `Assoc [
 	                    ("enabled", `Bool meta_turn.drift_enabled);
                     ("applied", `Bool drift_applied);
                     ("reason",

--- a/lib/tool_keeper.ml
+++ b/lib/tool_keeper.ml
@@ -47,6 +47,18 @@ Stores context on disk and keeps presence alive. Auto-handoff is enabled by defa
           ("type", `String "string");
           ("description", `String "Keeper goal/system purpose (required when creating)");
         ]);
+        ("short_goal", `Assoc [
+          ("type", `String "string");
+          ("description", `String "Optional: short-term goal horizon (default: goal).");
+        ]);
+        ("mid_goal", `Assoc [
+          ("type", `String "string");
+          ("description", `String "Optional: mid-term goal horizon (default: goal).");
+        ]);
+        ("long_goal", `Assoc [
+          ("type", `String "string");
+          ("description", `String "Optional: long-term goal horizon (default: goal).");
+        ]);
         ("instructions", `Assoc [
           ("type", `String "string");
           ("description", `String "Optional: additional system instructions (kept across compaction/handoff).");
@@ -219,6 +231,18 @@ Persists context + checkpoints. Auto-handoff is applied when needed.";
           ("type", `String "string");
           ("description", `String "Optional: set goal when creating keeper inline");
         ]);
+        ("short_goal", `Assoc [
+          ("type", `String "string");
+          ("description", `String "Optional: set short-term goal horizon when creating keeper inline");
+        ]);
+        ("mid_goal", `Assoc [
+          ("type", `String "string");
+          ("description", `String "Optional: set mid-term goal horizon when creating keeper inline");
+        ]);
+        ("long_goal", `Assoc [
+          ("type", `String "string");
+          ("description", `String "Optional: set long-term goal horizon when creating keeper inline");
+        ]);
         ("instructions", `Assoc [
           ("type", `String "string");
           ("description", `String "Optional: set instructions when creating keeper inline");
@@ -255,6 +279,18 @@ Persists context + checkpoints. Auto-handoff is applied when needed.";
         ("new_goal", `Assoc [
           ("type", `String "string");
           ("description", `String "Optional: replace keeper goal (persisted)");
+        ]);
+        ("new_short_goal", `Assoc [
+          ("type", `String "string");
+          ("description", `String "Optional: replace keeper short-term goal horizon (persisted)");
+        ]);
+        ("new_mid_goal", `Assoc [
+          ("type", `String "string");
+          ("description", `String "Optional: replace keeper mid-term goal horizon (persisted)");
+        ]);
+        ("new_long_goal", `Assoc [
+          ("type", `String "string");
+          ("description", `String "Optional: replace keeper long-term goal horizon (persisted)");
         ]);
         ("new_instructions", `Assoc [
           ("type", `String "string");
@@ -393,6 +429,7 @@ let default_drift_min_turn_gap = 6
 let default_keeper_will = ""
 let default_keeper_needs = ""
 let default_keeper_desires = ""
+let default_goal_horizon_max_chars = 480
 let default_drift_max_clauses = 6
 let default_drift_max_chars = 320
 
@@ -461,6 +498,40 @@ let normalize_self_model_text ?(max_len = default_drift_max_chars) (raw : string
   let s = String.trim raw in
   if s = "" then ""
   else utf8_safe_prefix_bytes s ~max_bytes:max_len
+
+let normalize_goal_horizon_text ?(max_len = default_goal_horizon_max_chars) (raw : string) : string =
+  let s = String.trim raw in
+  if s = "" then ""
+  else utf8_safe_prefix_bytes s ~max_bytes:max_len
+
+let normalize_goal_horizon_opt (raw_opt : string option) : string option =
+  match raw_opt with
+  | None -> None
+  | Some raw ->
+    let normalized = normalize_goal_horizon_text raw in
+    if normalized = "" then None else Some normalized
+
+let parse_goal_horizon_opt args key : string option =
+  normalize_goal_horizon_opt (get_string_opt args key)
+
+let resolve_goal_horizons
+    ~(goal : string)
+    ~(short_goal_opt : string option)
+    ~(mid_goal_opt : string option)
+    ~(long_goal_opt : string option) : string * string * string =
+  let short_goal =
+    Option.value ~default:goal short_goal_opt
+    |> normalize_goal_horizon_text
+  in
+  let mid_goal =
+    Option.value ~default:goal mid_goal_opt
+    |> normalize_goal_horizon_text
+  in
+  let long_goal =
+    Option.value ~default:goal long_goal_opt
+    |> normalize_goal_horizon_text
+  in
+  (short_goal, mid_goal, long_goal)
 
 let split_semicolon_clauses (raw : string) : string list =
   raw
@@ -799,6 +870,9 @@ type keeper_meta = {
   trace_id: string;
   trace_history: string list;
   goal: string;
+  short_goal: string;
+  mid_goal: string;
+  long_goal: string;
   soul_profile: string;
   will: string;
   needs: string;
@@ -863,6 +937,9 @@ let meta_to_json (m : keeper_meta) : Yojson.Safe.t =
     ("trace_id", `String m.trace_id);
     ("trace_history", `List (List.map (fun s -> `String s) m.trace_history));
     ("goal", `String m.goal);
+    ("short_goal", `String m.short_goal);
+    ("mid_goal", `String m.mid_goal);
+    ("long_goal", `String m.long_goal);
     ("soul_profile", `String m.soul_profile);
     ("will", `String m.will);
     ("needs", `String m.needs);
@@ -926,7 +1003,17 @@ let meta_of_json (json : Yojson.Safe.t) : (keeper_meta, string) result =
     let trace_history =
       Safe_ops.json_string_list "trace_history" json |> List.filter validate_name
     in
-    let goal = Safe_ops.json_string ~default:"" "goal" json in
+    let goal =
+      Safe_ops.json_string ~default:"" "goal" json
+      |> normalize_goal_horizon_text
+    in
+    let (short_goal, mid_goal, long_goal) =
+      resolve_goal_horizons
+        ~goal
+        ~short_goal_opt:(normalize_goal_horizon_opt (Safe_ops.json_string_opt "short_goal" json))
+        ~mid_goal_opt:(normalize_goal_horizon_opt (Safe_ops.json_string_opt "mid_goal" json))
+        ~long_goal_opt:(normalize_goal_horizon_opt (Safe_ops.json_string_opt "long_goal" json))
+    in
     let soul_profile =
       Safe_ops.json_string ~default:default_soul_profile "soul_profile" json
       |> canonical_soul_profile
@@ -1046,6 +1133,9 @@ let meta_of_json (json : Yojson.Safe.t) : (keeper_meta, string) result =
         trace_id;
         trace_history;
         goal;
+        short_goal;
+        mid_goal;
+        long_goal;
         soul_profile;
         will;
         needs;
@@ -2191,6 +2281,94 @@ let jaccard_similarity (a : string) (b : string) : float =
     let union = (List.length ta) + !uniq_b in
     if union = 0 then 0.0 else float_of_int !inter /. float_of_int union
 
+let latest_message_content_by_role
+    ~(role : Llm_client.role)
+    (messages : Llm_client.message list) : string option =
+  match
+    messages
+    |> List.rev
+    |> List.find_opt (fun (m : Llm_client.message) -> m.role = role)
+  with
+  | None -> None
+  | Some m -> trim_nonempty (String.trim m.content)
+
+let previous_assistant_message_content
+    (messages : Llm_client.message list) : string option =
+  let assistants =
+    messages
+    |> List.rev
+    |> List.filter_map (fun (m : Llm_client.message) ->
+         if m.role = Llm_client.Assistant then trim_nonempty m.content else None)
+  in
+  match assistants with
+  | _latest :: previous :: _ -> Some previous
+  | _ -> None
+
+let goal_horizon_candidates (meta : keeper_meta) : string list =
+  [meta.short_goal; meta.mid_goal; meta.long_goal; meta.goal]
+  |> List.filter_map (fun raw ->
+       raw
+       |> normalize_goal_horizon_text
+       |> trim_nonempty)
+  |> List.fold_left
+       (fun acc goal ->
+         let key = normalize_memory_text_key goal in
+         if List.exists (fun existing -> normalize_memory_text_key existing = key) acc then
+           acc
+         else
+           goal :: acc)
+       []
+  |> List.rev
+
+let best_goal_similarity ~(text : string) ~(goals : string list) : float =
+  if goals = [] then 0.0
+  else
+    let candidate = String.trim text in
+    if candidate = "" then 0.0
+    else
+      goals
+      |> List.fold_left
+           (fun best goal -> max best (jaccard_similarity candidate goal))
+           0.0
+
+let goal_alignment_score
+    ~(meta : keeper_meta)
+    ~(user_message : string option)
+    ~(assistant_reply : string option) : float =
+  let goals = goal_horizon_candidates meta in
+  if goals = [] then 0.0
+  else
+    let user_score =
+      match user_message with
+      | None -> None
+      | Some text -> Some (best_goal_similarity ~text ~goals)
+    in
+    let reply_score =
+      match assistant_reply with
+      | None -> None
+      | Some text -> Some (best_goal_similarity ~text ~goals)
+    in
+    match user_score, reply_score with
+    | None, None -> 0.0
+    | Some s, None | None, Some s -> s
+    | Some u, Some r -> (u +. r) /. 2.0
+
+let repetition_risk_score
+    ~(messages : Llm_client.message list)
+    ~(candidate_reply : string option) : float =
+  match candidate_reply with
+  | Some reply -> (
+      match latest_message_content_by_role ~role:Llm_client.Assistant messages with
+      | Some prev -> jaccard_similarity reply prev
+      | None -> 0.0)
+  | None -> (
+      match
+        previous_assistant_message_content messages,
+        latest_message_content_by_role ~role:Llm_client.Assistant messages
+      with
+      | Some prev, Some latest -> jaccard_similarity latest prev
+      | _ -> 0.0)
+
 let recent_user_messages (msgs : Llm_client.message list) ~(max_n : int) : string list =
   msgs
   |> List.rev
@@ -3159,6 +3337,10 @@ type metrics_summary = {
   memory_score_sum: float;
   memory_weather_checks: int;
   memory_weather_passed: int;
+  repetition_risk_sum: float;
+  repetition_risk_points: int;
+  goal_alignment_sum: float;
+  goal_alignment_points: int;
   last_handoff: Yojson.Safe.t option;
   last_compaction: Yojson.Safe.t option;
 }
@@ -3184,6 +3366,10 @@ let empty_metrics_summary = {
   memory_score_sum = 0.0;
   memory_weather_checks = 0;
   memory_weather_passed = 0;
+  repetition_risk_sum = 0.0;
+  repetition_risk_points = 0;
+  goal_alignment_sum = 0.0;
+  goal_alignment_points = 0;
   last_handoff = None;
   last_compaction = None;
 }
@@ -3226,6 +3412,14 @@ let metrics_summary_to_json (s : metrics_summary) : Yojson.Safe.t =
       float_of_int s.memory_compaction_dropped_notes
       /. float_of_int s.memory_compaction_events
   in
+  let repetition_risk_avg =
+    if s.repetition_risk_points = 0 then 0.0
+    else s.repetition_risk_sum /. float_of_int s.repetition_risk_points
+  in
+  let goal_alignment_avg =
+    if s.goal_alignment_points = 0 then 0.0
+    else s.goal_alignment_sum /. float_of_int s.goal_alignment_points
+  in
   `Assoc [
     ("sample_points", `Int s.sample_points);
     ("turn_points", `Int s.turn_points);
@@ -3255,6 +3449,8 @@ let metrics_summary_to_json (s : metrics_summary) : Yojson.Safe.t =
     ("memory_weather_checks", `Int s.memory_weather_checks);
     ("memory_weather_passed", `Int s.memory_weather_passed);
     ("memory_weather_pass_rate", `Float memory_weather_pass_rate);
+    ("repetition_risk_avg", `Float repetition_risk_avg);
+    ("goal_alignment_avg", `Float goal_alignment_avg);
     ("last_handoff", match s.last_handoff with Some j -> j | None -> `Null);
     ("last_compaction", match s.last_compaction with Some j -> j | None -> `Null);
   ]
@@ -3313,6 +3509,8 @@ let summarize_metrics_lines (lines : string list) ~(default_generation : int) : 
       let memory_is_weather =
         match memory_expected_topic with Some "weather" -> true | _ -> false
       in
+      let repetition_risk_opt = Safe_ops.json_float_opt "repetition_risk" j in
+      let goal_alignment_opt = Safe_ops.json_float_opt "goal_alignment" j in
       let handoff_json =
         if handoff_performed then
           Some (`Assoc [
@@ -3389,6 +3587,18 @@ let summarize_metrics_lines (lines : string list) ~(default_generation : int) : 
         memory_weather_passed =
           acc.memory_weather_passed
           + (if is_interaction && memory_performed && memory_is_weather && memory_passed then 1 else 0);
+        repetition_risk_sum =
+          acc.repetition_risk_sum
+          +. (match repetition_risk_opt with Some v -> v | None -> 0.0);
+        repetition_risk_points =
+          acc.repetition_risk_points
+          + (if Option.is_some repetition_risk_opt then 1 else 0);
+        goal_alignment_sum =
+          acc.goal_alignment_sum
+          +. (match goal_alignment_opt with Some v -> v | None -> 0.0);
+        goal_alignment_points =
+          acc.goal_alignment_points
+          + (if Option.is_some goal_alignment_opt then 1 else 0);
         last_handoff = handoff_json;
         last_compaction = compaction_json;
       }
@@ -3459,9 +3669,26 @@ let keeper_constitution =
    Constraints: <0-3 items separated by ';'>\n\
    [/STATE]\n"
 
-let build_keeper_system_prompt ~goal ~soul_profile ~will ~needs ~desires ~instructions =
+let build_keeper_system_prompt
+    ~goal
+    ~short_goal
+    ~mid_goal
+    ~long_goal
+    ~soul_profile
+    ~will
+    ~needs
+    ~desires
+    ~instructions =
   let profile =
     canonical_soul_profile soul_profile |> Option.value ~default:default_soul_profile
+  in
+  let goal = normalize_goal_horizon_text goal in
+  let (short_goal, mid_goal, long_goal) =
+    resolve_goal_horizons
+      ~goal
+      ~short_goal_opt:(Some short_goal)
+      ~mid_goal_opt:(Some mid_goal)
+      ~long_goal_opt:(Some long_goal)
   in
   let profile_policy = soul_profile_policy profile in
   let will =
@@ -3484,6 +3711,10 @@ let build_keeper_system_prompt ~goal ~soul_profile ~will ~needs ~desires ~instru
   Printf.sprintf
     "You are a keeper agent with persistent memory.\n\
      Goal: %s\n\
+     Goal horizons:\n\
+     - Short: %s\n\
+     - Mid: %s\n\
+     - Long: %s\n\
      \n\
      Tool guidance:\n\
      - You can call tools for time/context/memory/weather checks.\n\
@@ -3499,7 +3730,7 @@ let build_keeper_system_prompt ~goal ~soul_profile ~will ~needs ~desires ~instru
      \n\
     %s\
     %s"
-    goal will needs desires profile_policy keeper_constitution custom
+    goal short_goal mid_goal long_goal will needs desires profile_policy keeper_constitution custom
 
 let append_trait_clause ~(base : string) ~(clause : string) : string =
   let b = String.trim base in
@@ -4348,6 +4579,15 @@ let start_keepalive (ctx : _ context) (m : keeper_meta) : unit =
                           let trimmed = String.trim meta_current.continuity_summary in
                           if trimmed = "" then "No continuity snapshot available." else trimmed
                     in
+                    let repetition_risk =
+                      repetition_risk_score ~messages:c.messages ~candidate_reply:None
+                    in
+                    let goal_alignment =
+                      goal_alignment_score
+                        ~meta:meta_current
+                        ~user_message:(latest_message_content_by_role ~role:Llm_client.User c.messages)
+                        ~assistant_reply:(latest_message_content_by_role ~role:Llm_client.Assistant c.messages)
+                    in
                     let snapshot = `Assoc [
                       ("ts", `String (now_iso ()));
                       ("ts_unix", `Float now_ts);
@@ -4382,6 +4622,8 @@ let start_keepalive (ctx : _ context) (m : keeper_meta) : unit =
                       ("tools_used", `List []);
                       ("snapshot_source", `String "keeper_context_status");
                       ("memory_check", memory_check_default_json ());
+                      ("repetition_risk", `Float repetition_risk);
+                      ("goal_alignment", `Float goal_alignment);
                       ("handoff", `Assoc [("performed", `Bool false)]);
                     ] in
                     append_jsonl_line metrics_path snapshot)
@@ -4424,6 +4666,9 @@ let handle_keeper_up ctx args : tool_result =
     | Error e, _ | _, Error e -> (false, "❌ " ^ e)
     | Ok soul_profile_opt, Ok compaction_profile_opt ->
     let goal_opt = get_string_opt args "goal" in
+    let short_goal_opt = parse_goal_horizon_opt args "short_goal" in
+    let mid_goal_opt = parse_goal_horizon_opt args "mid_goal" in
+    let long_goal_opt = parse_goal_horizon_opt args "long_goal" in
     let models_in = get_string_list args "models" in
     let verify_opt = get_bool_opt args "verify" in
     let presence_keepalive_opt = get_bool_opt args "presence_keepalive" in
@@ -4452,7 +4697,7 @@ let handle_keeper_up ctx args : tool_result =
   | Ok None ->
       (* Create new keeper *)
       let now_ts = Time_compat.now () in
-      let goal = Option.value ~default:"" goal_opt in
+      let goal = Option.value ~default:"" goal_opt |> normalize_goal_horizon_text in
       if goal = "" then
         (false, "❌ goal is required when creating a keeper")
       else if models_in = [] then
@@ -4487,6 +4732,13 @@ let handle_keeper_up ctx args : tool_result =
         let will = Option.value ~default:default_keeper_will will_opt in
         let needs = Option.value ~default:default_keeper_needs needs_opt in
         let desires = Option.value ~default:default_keeper_desires desires_opt in
+        let (short_goal, mid_goal, long_goal) =
+          resolve_goal_horizons
+            ~goal
+            ~short_goal_opt
+            ~mid_goal_opt
+            ~long_goal_opt
+        in
         let instructions = Option.value ~default:"" instructions_opt in
         let (env_ratio_gate, env_message_gate, env_token_gate) =
           keeper_compaction_policy_from_env ()
@@ -4522,8 +4774,17 @@ let handle_keeper_up ctx args : tool_result =
              let base_dir = session_base_dir ctx.config in
              mkdir_p base_dir;
              let session = Context_manager.create_session ~session_id:trace_id ~base_dir in
-             let system_prompt =
-               build_keeper_system_prompt ~goal ~soul_profile ~will ~needs ~desires ~instructions
+               let system_prompt =
+                 build_keeper_system_prompt
+                   ~goal
+                   ~short_goal
+                   ~mid_goal
+                   ~long_goal
+                   ~soul_profile
+                   ~will
+                   ~needs
+                   ~desires
+                   ~instructions
              in
              let ctx0 = Context_manager.create ~system_prompt ~max_tokens:primary.max_context in
              ignore (save_checkpoint session ctx0 ~generation:0);
@@ -4533,6 +4794,9 @@ let handle_keeper_up ctx args : tool_result =
                trace_id;
                trace_history = [];
                goal;
+               short_goal;
+               mid_goal;
+               long_goal;
                soul_profile;
                will;
                needs;
@@ -4597,6 +4861,9 @@ let handle_keeper_up ctx args : tool_result =
                  ("trace_id", `String meta.trace_id);
                  ("generation", `Int meta.generation);
                  ("goal", `String meta.goal);
+                 ("short_goal", `String meta.short_goal);
+                 ("mid_goal", `String meta.mid_goal);
+                 ("long_goal", `String meta.long_goal);
                  ("soul_profile", `String meta.soul_profile);
                  ("will", `String meta.will);
                  ("needs", `String meta.needs);
@@ -4620,7 +4887,27 @@ let handle_keeper_up ctx args : tool_result =
                (true, Yojson.Safe.pretty_to_string json)))
     | Ok (Some old) ->
       (* Update existing keeper meta (goal/models optional) *)
-      let goal = match get_string_opt args "goal" with Some g -> g | None -> old.goal in
+      let goal_provided = Option.is_some goal_opt in
+      let goal =
+        match goal_opt with
+        | Some g -> normalize_goal_horizon_text g
+        | None -> old.goal
+      in
+      let short_goal_default = if goal_provided then goal else old.short_goal in
+      let mid_goal_default = if goal_provided then goal else old.mid_goal in
+      let long_goal_default = if goal_provided then goal else old.long_goal in
+      let short_goal =
+        Option.value ~default:short_goal_default short_goal_opt
+        |> normalize_goal_horizon_text
+      in
+      let mid_goal =
+        Option.value ~default:mid_goal_default mid_goal_opt
+        |> normalize_goal_horizon_text
+      in
+      let long_goal =
+        Option.value ~default:long_goal_default long_goal_opt
+        |> normalize_goal_horizon_text
+      in
       let models = if models_in <> [] then models_in else old.models in
       let (compaction_profile, compaction_ratio_gate, compaction_message_gate, compaction_token_gate) =
         resolve_compaction_policy
@@ -4635,6 +4922,9 @@ let handle_keeper_up ctx args : tool_result =
       in
       let updated = { old with
         goal;
+        short_goal;
+        mid_goal;
+        long_goal;
         soul_profile = Option.value ~default:old.soul_profile soul_profile_opt;
         will = Option.value ~default:old.will will_opt;
         needs = Option.value ~default:old.needs needs_opt;
@@ -5021,6 +5311,15 @@ let handle_keeper_status ctx args : tool_result =
 
          let json = `Assoc [
            ("meta", meta_to_json m);
+           ("goal", `String m.goal);
+           ("short_goal", `String m.short_goal);
+           ("mid_goal", `String m.mid_goal);
+           ("long_goal", `String m.long_goal);
+           ("goal_horizons", `Assoc [
+             ("short", `String m.short_goal);
+             ("mid", `String m.mid_goal);
+             ("long", `String m.long_goal);
+           ]);
            ("soul_profile", `String m.soul_profile);
            ("will", if String.trim m.will = "" then `Null else `String m.will);
            ("needs", if String.trim m.needs = "" then `Null else `String m.needs);
@@ -5124,6 +5423,9 @@ let handle_keeper_msg ctx args : tool_result =
     (false, "❌ message is required")
   else
     let inline_goal = get_string_opt args "goal" in
+    let inline_short_goal = parse_goal_horizon_opt args "short_goal" in
+    let inline_mid_goal = parse_goal_horizon_opt args "mid_goal" in
+    let inline_long_goal = parse_goal_horizon_opt args "long_goal" in
     let inline_instructions = get_string_opt args "instructions" in
     let inline_will = parse_self_model_opt args "will" in
     let inline_needs = parse_self_model_opt args "needs" in
@@ -5132,6 +5434,9 @@ let handle_keeper_msg ctx args : tool_result =
     let inline_drift_min_turn_gap_opt = Safe_ops.json_int_opt "drift_min_turn_gap" args in
     let inline_soul_profile_res = parse_soul_profile_opt args "soul_profile" in
     let new_soul_profile_res = parse_soul_profile_opt args "new_soul_profile" in
+    let new_short_goal = parse_goal_horizon_opt args "new_short_goal" in
+    let new_mid_goal = parse_goal_horizon_opt args "new_mid_goal" in
+    let new_long_goal = parse_goal_horizon_opt args "new_long_goal" in
     let new_will = parse_self_model_opt args "new_will" in
     let new_needs = parse_self_model_opt args "new_needs" in
     let new_desires = parse_self_model_opt args "new_desires" in
@@ -5147,7 +5452,7 @@ let handle_keeper_msg ctx args : tool_result =
       | Error e -> Error e
       | Ok (Some m) -> Ok m
   | Ok None ->
-          let goal = Option.value ~default:"" inline_goal in
+          let goal = Option.value ~default:"" inline_goal |> normalize_goal_horizon_text in
           if goal = "" then Error "keeper not found and goal not provided"
           else if inline_models = [] then Error "keeper not found and models not provided"
           else
@@ -5173,6 +5478,13 @@ let handle_keeper_msg ctx args : tool_result =
             keeper_continuity_compaction_cooldown_sec ()
             |> normalize_continuity_compaction_cooldown_sec
           in
+          let (short_goal, mid_goal, long_goal) =
+            resolve_goal_horizons
+              ~goal
+              ~short_goal_opt:inline_short_goal
+              ~mid_goal_opt:inline_mid_goal
+              ~long_goal_opt:inline_long_goal
+          in
           let instructions = Option.value ~default:"" inline_instructions in
           let meta = {
             name;
@@ -5180,6 +5492,9 @@ let handle_keeper_msg ctx args : tool_result =
             trace_id;
             trace_history = [];
             goal;
+            short_goal;
+            mid_goal;
+            long_goal;
             soul_profile;
             will;
             needs;
@@ -5245,7 +5560,16 @@ let handle_keeper_msg ctx args : tool_result =
                 let primary = match specs with m0 :: _ -> m0 | [] -> Llm_client.ollama_glm in
                 let session = Context_manager.create_session ~session_id:trace_id ~base_dir in
                 let system_prompt =
-                  build_keeper_system_prompt ~goal ~soul_profile ~will ~needs ~desires ~instructions
+                  build_keeper_system_prompt
+                    ~goal
+                    ~short_goal
+                    ~mid_goal
+                    ~long_goal
+                    ~soul_profile
+                    ~will
+                    ~needs
+                    ~desires
+                    ~instructions
                 in
                 let ctx0 = Context_manager.create ~system_prompt ~max_tokens:primary.max_context in
                 ignore (save_checkpoint session ctx0 ~generation:0);
@@ -5258,10 +5582,27 @@ let handle_keeper_msg ctx args : tool_result =
     | Ok meta0 ->
       (* Update keeper settings inline if requested. *)
       let meta =
+        let new_goal_opt = normalize_goal_horizon_opt (get_string_opt args "new_goal") in
         let goal =
-          match get_string_opt args "new_goal" with
+          match new_goal_opt with
           | None -> meta0.goal
           | Some ng -> ng
+        in
+        let goal_provided = Option.is_some new_goal_opt in
+        let short_goal_default = if goal_provided then goal else meta0.short_goal in
+        let mid_goal_default = if goal_provided then goal else meta0.mid_goal in
+        let long_goal_default = if goal_provided then goal else meta0.long_goal in
+        let short_goal =
+          Option.value ~default:short_goal_default new_short_goal
+          |> normalize_goal_horizon_text
+        in
+        let mid_goal =
+          Option.value ~default:mid_goal_default new_mid_goal
+          |> normalize_goal_horizon_text
+        in
+        let long_goal =
+          Option.value ~default:long_goal_default new_long_goal
+          |> normalize_goal_horizon_text
         in
         let soul_profile =
           match new_soul_profile with
@@ -5299,6 +5640,9 @@ let handle_keeper_msg ctx args : tool_result =
           | Some v -> normalize_drift_min_turn_gap v
         in
         if goal = meta0.goal
+           && short_goal = meta0.short_goal
+           && mid_goal = meta0.mid_goal
+           && long_goal = meta0.long_goal
            && soul_profile = meta0.soul_profile
            && will = meta0.will
            && needs = meta0.needs
@@ -5312,6 +5656,9 @@ let handle_keeper_msg ctx args : tool_result =
           let updated = {
             meta0 with
             goal;
+            short_goal;
+            mid_goal;
+            long_goal;
             soul_profile;
             will;
             needs;
@@ -5344,6 +5691,9 @@ let handle_keeper_msg ctx args : tool_result =
                   ~system_prompt:(
                     build_keeper_system_prompt
                       ~goal:meta.goal
+                      ~short_goal:meta.short_goal
+                      ~mid_goal:meta.mid_goal
+                      ~long_goal:meta.long_goal
                       ~soul_profile:meta.soul_profile
                       ~will:meta.will
                       ~needs:meta.needs
@@ -5358,6 +5708,9 @@ let handle_keeper_msg ctx args : tool_result =
                 ~system_prompt:(
                   build_keeper_system_prompt
                     ~goal:meta.goal
+                    ~short_goal:meta.short_goal
+                    ~mid_goal:meta.mid_goal
+                    ~long_goal:meta.long_goal
                     ~soul_profile:meta.soul_profile
                     ~will:meta.will
                     ~needs:meta.needs
@@ -5745,14 +6098,25 @@ let handle_keeper_msg ctx args : tool_result =
 	                     | Some parsed -> parsed
 	                     | None -> fallback_skill_route)
 	              in
-	              let safe_reply =
-	                ensure_skill_route_header
-	                  ~route:effective_skill_route
-	                  safe_reply_raw
-	              in
+		              let safe_reply =
+		                ensure_skill_route_header
+		                  ~route:effective_skill_route
+		                  safe_reply_raw
+		              in
+              let repetition_risk =
+                repetition_risk_score
+                  ~messages:ctx_work.messages
+                  ~candidate_reply:(Some safe_reply)
+              in
+              let goal_alignment =
+                goal_alignment_score
+                  ~meta
+                  ~user_message:(Some message)
+                  ~assistant_reply:(Some safe_reply)
+              in
 
-              let assistant_msg = Llm_client.assistant_msg safe_reply in
-              let ctx_work = Context_manager.append ctx_work assistant_msg in
+	              let assistant_msg = Llm_client.assistant_msg safe_reply in
+	              let ctx_work = Context_manager.append ctx_work assistant_msg in
               Context_manager.persist_message session assistant_msg;
               let now_ts = Time_compat.now () in
               let continuity_summary_from_reply =
@@ -5886,10 +6250,12 @@ let handle_keeper_msg ctx args : tool_result =
 		                     ("skill_primary", `String effective_skill_route.primary_skill);
 		                     ("skill_secondary",
 		                       `List (List.map (fun s -> `String s) effective_skill_route.secondary_skills));
-		                     ("skill_reason", `String effective_skill_route.reason);
-                     ("memory_check", memory_check_json);
-                     ("drift", `Assoc [
-                       ("enabled", `Bool meta_turn.drift_enabled);
+			                     ("skill_reason", `String effective_skill_route.reason);
+	                     ("memory_check", memory_check_json);
+                     ("repetition_risk", `Float repetition_risk);
+                     ("goal_alignment", `Float goal_alignment);
+	                     ("drift", `Assoc [
+	                       ("enabled", `Bool meta_turn.drift_enabled);
                        ("applied", `Bool drift_applied);
                        ("reason",
                          match drift_reason with
@@ -5955,10 +6321,12 @@ let handle_keeper_msg ctx args : tool_result =
 		                  ("skill_primary", `String effective_skill_route.primary_skill);
 		                  ("skill_secondary",
 		                    `List (List.map (fun s -> `String s) effective_skill_route.secondary_skills));
-		                  ("skill_reason", `String effective_skill_route.reason);
-	                  ("memory_check", memory_check_json);
-                  ("drift", `Assoc [
-                    ("enabled", `Bool meta_turn.drift_enabled);
+			                  ("skill_reason", `String effective_skill_route.reason);
+		                  ("memory_check", memory_check_json);
+                  ("repetition_risk", `Float repetition_risk);
+                  ("goal_alignment", `Float goal_alignment);
+	                  ("drift", `Assoc [
+	                    ("enabled", `Bool meta_turn.drift_enabled);
                     ("applied", `Bool drift_applied);
                     ("reason",
                       match drift_reason with
@@ -6073,10 +6441,12 @@ let handle_keeper_msg ctx args : tool_result =
 		                     ("skill_primary", `String effective_skill_route.primary_skill);
 		                     ("skill_secondary",
 		                       `List (List.map (fun s -> `String s) effective_skill_route.secondary_skills));
-		                     ("skill_reason", `String effective_skill_route.reason);
-	                     ("memory_check", memory_check_json);
-                     ("drift", `Assoc [
-                       ("enabled", `Bool meta_turn.drift_enabled);
+			                     ("skill_reason", `String effective_skill_route.reason);
+		                     ("memory_check", memory_check_json);
+                     ("repetition_risk", `Float repetition_risk);
+                     ("goal_alignment", `Float goal_alignment);
+	                     ("drift", `Assoc [
+	                       ("enabled", `Bool meta_turn.drift_enabled);
                        ("applied", `Bool drift_applied);
                        ("reason",
                          match drift_reason with
@@ -6141,10 +6511,12 @@ let handle_keeper_msg ctx args : tool_result =
 		                  ("skill_primary", `String effective_skill_route.primary_skill);
 		                  ("skill_secondary",
 		                    `List (List.map (fun s -> `String s) effective_skill_route.secondary_skills));
-		                  ("skill_reason", `String effective_skill_route.reason);
-	                  ("memory_check", memory_check_json);
-                  ("drift", `Assoc [
-                    ("enabled", `Bool meta_turn.drift_enabled);
+			                  ("skill_reason", `String effective_skill_route.reason);
+		                  ("memory_check", memory_check_json);
+                  ("repetition_risk", `Float repetition_risk);
+                  ("goal_alignment", `Float goal_alignment);
+	                  ("drift", `Assoc [
+	                    ("enabled", `Bool meta_turn.drift_enabled);
                     ("applied", `Bool drift_applied);
                     ("reason",
                       match drift_reason with
@@ -6356,10 +6728,19 @@ let handle_keeper_list ctx args : tool_result =
 	                  ]
 	            in
 	            Some (`Assoc [
-	              ("name", `String m.name);
+              ("name", `String m.name);
               ("agent_name", `String m.agent_name);
               ("trace_id", `String m.trace_id);
               ("generation", `Int m.generation);
+              ("goal", `String m.goal);
+              ("short_goal", `String m.short_goal);
+              ("mid_goal", `String m.mid_goal);
+              ("long_goal", `String m.long_goal);
+              ("goal_horizons", `Assoc [
+                ("short", `String m.short_goal);
+                ("mid", `String m.mid_goal);
+                ("long", `String m.long_goal);
+              ]);
               ("soul_profile", `String m.soul_profile);
               ("will", if String.trim m.will = "" then `Null else `String m.will);
               ("needs", if String.trim m.needs = "" then `Null else `String m.needs);

--- a/lib/tool_keeper.ml
+++ b/lib/tool_keeper.ml
@@ -2450,6 +2450,39 @@ let keeper_auto_rule_eval_to_json (e : keeper_auto_rule_eval) : Yojson.Safe.t =
     ("reasons", `List (List.map (fun reason -> `String reason) e.reasons));
   ]
 
+let keeper_reflection_payload_of_auto_rules (e : keeper_auto_rule_eval) : Yojson.Safe.t =
+  let actions_rev = [] in
+  let actions_rev =
+    if e.reflect then `String "reflect" :: actions_rev else actions_rev
+  in
+  let actions_rev =
+    if e.plan then `String "plan" :: actions_rev else actions_rev
+  in
+  let actions_rev =
+    if e.compact then `String "compact" :: actions_rev else actions_rev
+  in
+  let actions_rev =
+    if e.handoff then `String "handoff" :: actions_rev else actions_rev
+  in
+  let actions_rev =
+    if e.guardrail_stop then `String "guardrail_stop" :: actions_rev else actions_rev
+  in
+  let has_action = actions_rev <> [] in
+  `Assoc [
+    ("triggered", `Bool has_action);
+    ("actions", `List (List.rev actions_rev));
+    ("guardrail_stop", `Bool e.guardrail_stop);
+    ("guardrail_reason",
+      match e.guardrail_reason with
+      | Some reason -> `String reason
+      | None -> `Null);
+    ("goal_drift", `Float e.goal_drift);
+    ("repetition_risk", `Float e.repetition_risk);
+    ("goal_alignment", `Float e.goal_alignment);
+    ("response_alignment", `Float e.response_alignment);
+    ("reasons", `List (List.map (fun reason -> `String reason) e.reasons));
+  ]
+
 let evaluate_keeper_auto_rules
     ~(meta : keeper_meta)
     ~(context_ratio : float)
@@ -4958,8 +4991,9 @@ let start_keepalive (ctx : _ context) (m : keeper_meta) : unit =
                       ("tool_call_count", `Int 0);
                       ("tools_used", `List []);
                       ("snapshot_source", `String "keeper_context_status");
-	                      ("memory_check", memory_check_default_json ());
+                      ("memory_check", memory_check_default_json ());
                       ("auto_rules", keeper_auto_rule_eval_to_json auto_rules);
+                      ("reflection", keeper_reflection_payload_of_auto_rules auto_rules);
                       ("auto_reflect", `Bool auto_rules.reflect);
                       ("auto_plan", `Bool auto_rules.plan);
                       ("auto_compact", `Bool auto_rules.compact);
@@ -6629,6 +6663,7 @@ let handle_keeper_msg ctx args : tool_result =
 			                     ("skill_reason", `String effective_skill_route.reason);
 		                     ("memory_check", memory_check_json);
                      ("auto_rules", keeper_auto_rule_eval_to_json auto_rules);
+                     ("reflection", keeper_reflection_payload_of_auto_rules auto_rules);
                      ("auto_reflect", `Bool auto_rules.reflect);
                      ("auto_plan", `Bool auto_rules.plan);
                      ("auto_compact", `Bool auto_rules.compact);
@@ -6712,6 +6747,7 @@ let handle_keeper_msg ctx args : tool_result =
 			                  ("skill_reason", `String effective_skill_route.reason);
 			                  ("memory_check", memory_check_json);
                   ("auto_rules", keeper_auto_rule_eval_to_json auto_rules);
+                  ("reflection", keeper_reflection_payload_of_auto_rules auto_rules);
                   ("auto_reflect", `Bool auto_rules.reflect);
                   ("auto_plan", `Bool auto_rules.plan);
                   ("auto_compact", `Bool auto_rules.compact);
@@ -6844,6 +6880,7 @@ let handle_keeper_msg ctx args : tool_result =
 			                     ("skill_reason", `String effective_skill_route.reason);
 			                     ("memory_check", memory_check_json);
                      ("auto_rules", keeper_auto_rule_eval_to_json auto_rules);
+                     ("reflection", keeper_reflection_payload_of_auto_rules auto_rules);
                      ("auto_reflect", `Bool auto_rules.reflect);
                      ("auto_plan", `Bool auto_rules.plan);
                      ("auto_compact", `Bool auto_rules.compact);
@@ -6926,6 +6963,7 @@ let handle_keeper_msg ctx args : tool_result =
 			                  ("skill_reason", `String effective_skill_route.reason);
 			                  ("memory_check", memory_check_json);
                   ("auto_rules", keeper_auto_rule_eval_to_json auto_rules);
+                  ("reflection", keeper_reflection_payload_of_auto_rules auto_rules);
                   ("auto_reflect", `Bool auto_rules.reflect);
                   ("auto_plan", `Bool auto_rules.plan);
                   ("auto_compact", `Bool auto_rules.compact);

--- a/lib/web_dashboard.ml
+++ b/lib/web_dashboard.ml
@@ -3155,6 +3155,25 @@ let cached_html = lazy ({|<!DOCTYPE html>
       const alertThresholds = currentAlertThresholds();
       const lifeState = keeperLifeState(keeper, alertThresholds);
       const soulProfile = (keeper.soul_profile || 'balanced');
+      const goalBaseText =
+        (typeof keeper.goal === 'string' && keeper.goal.trim() !== '')
+          ? keeper.goal.trim()
+          : '-';
+      const shortGoalText =
+        (typeof keeper.short_goal === 'string' && keeper.short_goal.trim() !== '')
+          ? keeper.short_goal.trim()
+          : goalBaseText;
+      const midGoalText =
+        (typeof keeper.mid_goal === 'string' && keeper.mid_goal.trim() !== '')
+          ? keeper.mid_goal.trim()
+          : goalBaseText;
+      const longGoalText =
+        (typeof keeper.long_goal === 'string' && keeper.long_goal.trim() !== '')
+          ? keeper.long_goal.trim()
+          : goalBaseText;
+      const shortGoalKpi = shortText(shortGoalText, 72);
+      const midGoalKpi = shortText(midGoalText, 72);
+      const longGoalKpi = shortText(longGoalText, 72);
       const willText = (typeof keeper.will === 'string' && keeper.will.trim() !== '') ? keeper.will.trim() : '-';
       const needsText = (typeof keeper.needs === 'string' && keeper.needs.trim() !== '') ? keeper.needs.trim() : '-';
       const desiresText = (typeof keeper.desires === 'string' && keeper.desires.trim() !== '') ? keeper.desires.trim() : '-';
@@ -3462,6 +3481,30 @@ let cached_html = lazy ({|<!DOCTYPE html>
           formula: 'keeper.desires',
           source: 'keeper.desires',
           interpretation: 'Drives proactive behavior intensity and exploration tendency.',
+        },
+        short_goal: {
+          label: 'Short Goal',
+          short: 'Immediate execution target in current keeper horizon.',
+          definition: 'Near-term objective the keeper should complete in the next turns.',
+          formula: 'keeper.short_goal (fallback keeper.goal)',
+          source: 'keeper.short_goal, keeper.goal',
+          interpretation: 'Use this to validate tactical focus and short-loop continuity.',
+        },
+        mid_goal: {
+          label: 'Mid Goal',
+          short: 'Mid-range mission objective for this keeper lifecycle.',
+          definition: 'Bridge objective between immediate actions and long-term identity.',
+          formula: 'keeper.mid_goal (fallback keeper.goal)',
+          source: 'keeper.mid_goal, keeper.goal',
+          interpretation: 'Shows whether day-scale planning aligns with active work.',
+        },
+        long_goal: {
+          label: 'Long Goal',
+          short: 'Long-horizon purpose keeper should preserve across handoffs.',
+          definition: 'Persistent strategic direction expected to survive compaction/handoff.',
+          formula: 'keeper.long_goal (fallback keeper.goal)',
+          source: 'keeper.long_goal, keeper.goal',
+          interpretation: 'Use as continuity anchor across generations and drift checks.',
         },
         active_model: {
           label: 'Active Model',
@@ -3869,6 +3912,24 @@ let cached_html = lazy ({|<!DOCTYPE html>
           definition: '운영 니즈를 넘어선 선호 기반 추진 방향입니다.',
           interpretation: '프로액티브 강도와 탐색 성향에 영향을 줍니다.',
         },
+        short_goal: {
+          label: '단기 목표',
+          short: '현재 구간에서 바로 달성해야 하는 실행 목표입니다.',
+          definition: '다음 몇 턴 안에 완료되어야 하는 근거리 목표입니다.',
+          interpretation: '전술적 집중도와 단기 연속성 점검에 사용합니다.',
+        },
+        mid_goal: {
+          label: '중기 목표',
+          short: '단기 실행과 장기 방향을 잇는 중간 목적입니다.',
+          definition: '현재 생애 구간에서 유지할 중간 범위의 진행 목표입니다.',
+          interpretation: '일 단위 계획과 실제 행동의 정렬 상태를 보여줍니다.',
+        },
+        long_goal: {
+          label: '장기 목표',
+          short: '승계/컴팩팅 이후에도 유지해야 하는 장기 목적입니다.',
+          definition: '세대 전환을 거쳐도 보존되어야 하는 전략적 방향입니다.',
+          interpretation: '세대 간 연속성 검증의 기준점으로 사용합니다.',
+        },
         active_model: {
           label: '활성 모델',
           short: '가장 최근 턴에서 실제 사용된 모델입니다.',
@@ -4104,6 +4165,9 @@ let cached_html = lazy ({|<!DOCTYPE html>
         'will',
         'needs',
         'desires',
+        'short_goal',
+        'mid_goal',
+        'long_goal',
         'active_model',
         'next_model',
         'primary_model',
@@ -4776,6 +4840,9 @@ let cached_html = lazy ({|<!DOCTYPE html>
           <div class="keeper-kpi">${kpiLabelHtml('Will (의지)', 'will')}<div class="keeper-kpi-value">${escHtml(willKpi)}</div></div>
           <div class="keeper-kpi">${kpiLabelHtml('Needs (니즈)', 'needs')}<div class="keeper-kpi-value">${escHtml(needsKpi)}</div></div>
           <div class="keeper-kpi">${kpiLabelHtml('Desires (욕구)', 'desires')}<div class="keeper-kpi-value">${escHtml(desiresKpi)}</div></div>
+          <div class="keeper-kpi">${kpiLabelHtml('Short Goal', 'short_goal')}<div class="keeper-kpi-value">${escHtml(shortGoalKpi)}</div></div>
+          <div class="keeper-kpi">${kpiLabelHtml('Mid Goal', 'mid_goal')}<div class="keeper-kpi-value">${escHtml(midGoalKpi)}</div></div>
+          <div class="keeper-kpi">${kpiLabelHtml('Long Goal', 'long_goal')}<div class="keeper-kpi-value">${escHtml(longGoalKpi)}</div></div>
           <div class="keeper-kpi">${kpiLabelHtml('Active Model', 'active_model')}<div class="keeper-kpi-value">${escHtml(modelUsed)}</div></div>
           <div class="keeper-kpi">${kpiLabelHtml('Next Model', 'next_model')}<div class="keeper-kpi-value">${escHtml(nextModel)}</div></div>
           <div class="keeper-kpi">${kpiLabelHtml('Primary Model', 'primary_model')}<div class="keeper-kpi-value">${escHtml(primaryModel || '-')}</div></div>

--- a/test/test_web_dashboard_coverage.ml
+++ b/test/test_web_dashboard_coverage.ml
@@ -136,6 +136,17 @@ let test_html_contains_trpg_round_run_controls () =
     && contains_substr "function runTrpgRound()" html
     && contains_substr "/api/v1/trpg/rounds/run" html)
 
+let test_html_contains_keeper_goal_horizon_kpis () =
+  let html = Web_dashboard.html () in
+  check bool "keeper goal horizon kpis" true
+    (String.length html > 0
+    && contains_substr "'short_goal'" html
+    && contains_substr "'mid_goal'" html
+    && contains_substr "'long_goal'" html
+    && contains_substr "Short Goal" html
+    && contains_substr "Mid Goal" html
+    && contains_substr "Long Goal" html)
+
 (* ============================================================
    Test Runners
    ============================================================ *)
@@ -160,5 +171,6 @@ let () =
       test_case "notify uses normalized payload" `Quick test_html_notify_uses_normalized_payload;
       test_case "life state pills" `Quick test_html_life_state_pills_present;
       test_case "trpg round run controls" `Quick test_html_contains_trpg_round_run_controls;
+      test_case "keeper goal horizon kpis" `Quick test_html_contains_keeper_goal_horizon_kpis;
     ];
   ]


### PR DESCRIPTION
## Summary
- add keeper goal horizon fields (`short_goal`, `mid_goal`, `long_goal`) across schema/meta/create-update flows
- expose goal horizon data in keeper status/list and dashboard batch JSON
- show short/mid/long goal KPIs + glossary entries in web dashboard
- add reflection metrics (`repetition_risk`, `goal_alignment`) to heartbeat/turn metric snapshots and aggregate averages

## Verification
- dune build --root .
- dune exec --root . ./test/test_web_dashboard_coverage.exe
- dune exec --root . ./test/test_tools_coverage.exe
- dune exec --root . ./test/test_tool_heartbeat_coverage.exe
