### PR TITLE
ci: add heartbeat+timeout diagnostics for test steps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,16 +58,22 @@ jobs:
         env:
           ME_ROOT: /tmp/me
           ALCOTEST_QUICK_TESTS: "1"
+          CI_TEST_TIMEOUT_SEC: 1200
+          CI_TEST_HEARTBEAT_SEC: 30
         run: |
           mkdir -p /tmp/me
-          opam exec -- dune test
+          chmod +x scripts/ci-run-tests.sh
+          scripts/ci-run-tests.sh "opam exec -- dune test"
 
       - name: Run SSE reconnect e2e
         env:
           ME_ROOT: /tmp/me
+          CI_TEST_TIMEOUT_SEC: 900
+          CI_TEST_HEARTBEAT_SEC: 15
         run: |
           mkdir -p /tmp/me
-          opam exec -- dune exec ./test/test_sse_storm_e2e.exe
+          chmod +x scripts/ci-run-tests.sh
+          scripts/ci-run-tests.sh "opam exec -- dune exec ./test/test_sse_storm_e2e.exe"
 
       - name: Check formatting
         run: |

--- a/scripts/ci-run-tests.sh
+++ b/scripts/ci-run-tests.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# CI test runner with:
+# 1) periodic heartbeat logs (prevents "silent hang" confusion),
+# 2) explicit timeout,
+# 3) diagnostics dump on timeout/failure.
+
+TEST_CMD="${1:-opam exec -- dune test}"
+TEST_TIMEOUT_SEC="${CI_TEST_TIMEOUT_SEC:-1200}"
+HEARTBEAT_SEC="${CI_TEST_HEARTBEAT_SEC:-30}"
+
+if [[ -z "${TEST_TIMEOUT_SEC}" || "${TEST_TIMEOUT_SEC}" -le 0 ]]; then
+  TEST_TIMEOUT_SEC=1200
+fi
+if [[ -z "${HEARTBEAT_SEC}" || "${HEARTBEAT_SEC}" -le 0 ]]; then
+  HEARTBEAT_SEC=30
+fi
+
+diag_dump() {
+  local reason="${1:-unknown}"
+  echo "[ci-diag] reason=${reason}"
+  echo "[ci-diag] timestamp=$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+  echo "[ci-diag] pwd=$(pwd)"
+
+  echo "[ci-diag] process snapshot (dune/ocaml/test):"
+  ps -eo pid,ppid,etime,%cpu,%mem,comm,args \
+    | grep -Ei 'dune|ocaml|alcotest|test_' \
+    | grep -v grep \
+    || true
+
+  local tests_root="_build/default/test/_build/_tests"
+  if [[ -d "${tests_root}" ]]; then
+    echo "[ci-diag] test output files (latest 20):"
+    find "${tests_root}" -type f -name "*.output" -print | tail -n 20 || true
+
+    # Print tail of the most recent output file for quick signal.
+    local last_output
+    last_output="$(find "${tests_root}" -type f -name "*.output" -print | tail -n 1 || true)"
+    if [[ -n "${last_output}" && -f "${last_output}" ]]; then
+      echo "[ci-diag] tail -n 120 ${last_output}"
+      tail -n 120 "${last_output}" || true
+    fi
+  else
+    echo "[ci-diag] no test output directory yet: ${tests_root}"
+  fi
+}
+
+heartbeat() {
+  while true; do
+    echo "[ci-heartbeat] $(date -u +"%Y-%m-%dT%H:%M:%SZ") dune test still running"
+    sleep "${HEARTBEAT_SEC}"
+  done
+}
+
+hb_pid=""
+cleanup() {
+  if [[ -n "${hb_pid}" ]]; then
+    kill "${hb_pid}" >/dev/null 2>&1 || true
+    wait "${hb_pid}" >/dev/null 2>&1 || true
+  fi
+}
+trap cleanup EXIT
+
+echo "[ci-run] command: ${TEST_CMD}"
+echo "[ci-run] timeout_sec=${TEST_TIMEOUT_SEC} heartbeat_sec=${HEARTBEAT_SEC}"
+
+heartbeat &
+hb_pid="$!"
+
+set +e
+timeout --foreground "${TEST_TIMEOUT_SEC}" bash -lc "${TEST_CMD}"
+status=$?
+set -e
+
+if [[ "${status}" -eq 124 ]]; then
+  diag_dump "timeout"
+  echo "[ci-run] ERROR: test command timed out after ${TEST_TIMEOUT_SEC}s"
+  exit 124
+fi
+
+if [[ "${status}" -ne 0 ]]; then
+  diag_dump "nonzero_exit_${status}"
+  echo "[ci-run] ERROR: test command failed with exit=${status}"
+  exit "${status}"
+fi
+
+echo "[ci-run] tests completed successfully"


### PR DESCRIPTION
## Summary
- add `scripts/ci-run-tests.sh` to run tests with periodic heartbeat logs
- apply explicit timeout and diagnostics dump on timeout/non-zero exit
- wire CI `Run tests (quick suite)` and `Run SSE reconnect e2e` steps to use the script

## Why
- avoid silent long-running test steps
- keep actionable diagnostics in logs when tests hang or timeout

## Local validation
- `CI_TEST_TIMEOUT_SEC=20 CI_TEST_HEARTBEAT_SEC=1 scripts/ci-run-tests.sh "echo smoke-pass"`
- `CI_TEST_TIMEOUT_SEC=2 CI_TEST_HEARTBEAT_SEC=1 scripts/ci-run-tests.sh "sleep 5"` (expected timeout + diagnostics)
- `timeout 180 dune exec --root . ./test/test_tool_heartbeat_coverage.exe`
- `timeout 180 dune exec --root . ./test/test_tools_coverage.exe`
