### PR TITLE
docs: add CI test harness usage note

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,21 @@ make test        # 최소 검증
 make ci          # 포맷 + 테스트 (CI 동일)
 ```
 
+### CI 테스트 하네스
+
+CI에서는 `scripts/ci-run-tests.sh`를 사용해 테스트를 실행합니다.
+
+- 주기 heartbeat 로그 출력 (`[ci-heartbeat] ...`)
+- 명시적 timeout 적용
+- timeout/실패 시 진단 덤프 출력 (프로세스 스냅샷, 최근 테스트 output tail)
+
+로컬에서 동일 하네스로 재현할 수 있습니다.
+
+```bash
+CI_TEST_TIMEOUT_SEC=1200 CI_TEST_HEARTBEAT_SEC=30 \
+  scripts/ci-run-tests.sh "opam exec -- dune test"
+```
+
 ## MCP 설정
 
 `~/.mcp.json` 예시:


### PR DESCRIPTION
## Summary
- document CI test harness usage in README
- explain heartbeat/timeout/diagnostics behavior
- add reproducible local command with tuning knobs

## Context
PR #132 added `scripts/ci-run-tests.sh` and wired CI workflow steps.
This PR adds the operator-facing usage note so the same harness can be reused locally.

## Validation
- `timeout 120 scripts/ci-run-tests.sh "echo readme-doc-smoke"`
