### PR TITLE
feat(viewer): wire MASC SSE for 4 non-TRPG viewer modes

### DIFF
--- a/viewer/src/config.rs
+++ b/viewer/src/config.rs
@@ -12,7 +12,6 @@ use crate::mode::ViewerMode;
 pub const TRPG_ENGINE_URL: &str = "http://localhost:8940";
 
 /// MASC MCP server (OCaml + Eio, SSE + JSON-RPC).
-#[allow(dead_code)]
 pub const MASC_MCP_URL: &str = "http://localhost:8935";
 
 /// Default TRPG room identifier.
@@ -20,7 +19,6 @@ pub const DEFAULT_ROOM_ID: &str = "default";
 
 /// SSE endpoint for a given viewer mode.
 /// Returns `None` for Lobby (no live data connection).
-#[allow(dead_code)]
 pub fn sse_endpoint(mode: &ViewerMode) -> Option<String> {
     match mode {
         ViewerMode::Lobby => None,

--- a/viewer/src/game/events.rs
+++ b/viewer/src/game/events.rs
@@ -3,9 +3,9 @@ use serde::Deserialize;
 
 // ─── SSE Payload Types ────────────────────
 
-#[allow(dead_code)]
 #[derive(Debug, Clone, Deserialize)]
 pub struct DiceRollPayload {
+    #[allow(dead_code)]
     pub turn: u32,
     pub character: String,
     pub action: String,
@@ -18,12 +18,12 @@ pub struct DiceRollPayload {
     pub note: Option<String>,
 }
 
-#[allow(dead_code)]
 #[derive(Debug, Clone, Deserialize)]
 pub struct HpChangePayload {
     pub target: String,
     pub amount: i32,
     pub remaining_hp: i32,
+    #[allow(dead_code)]
     pub source: String,
 }
 
@@ -35,10 +35,10 @@ pub struct NarrativePayload {
     pub speaker: Option<String>,
 }
 
-#[allow(dead_code)]
 #[derive(Debug, Clone, Deserialize)]
 pub struct AreaMovePayload {
     pub character: String,
+    #[allow(dead_code)]
     pub from_area: String,
     pub to_area: String,
 }
@@ -64,10 +64,10 @@ pub struct ItemPayload {
     pub item: String,
 }
 
-#[allow(dead_code)]
 #[derive(Debug, Clone, Deserialize)]
 pub struct DeathPayload {
     pub character: String,
+    #[allow(dead_code)]
     pub cause: String,
 }
 
@@ -81,7 +81,6 @@ pub struct CombatPayload {
 
 // ─── Bevy Events ──────────────────────────
 
-#[allow(dead_code)]
 #[derive(Message, Debug, Clone)]
 pub struct DiceRolled(pub DiceRollPayload);
 

--- a/viewer/src/sse/masc_bridge.rs
+++ b/viewer/src/sse/masc_bridge.rs
@@ -1,0 +1,244 @@
+use bevy::prelude::*;
+
+use super::masc_client::MascSseReceiver;
+
+/// A single MASC event log entry.
+#[allow(dead_code)]
+pub struct MascLogEntry {
+    pub timestamp: f64,
+    pub event_type: String,
+    pub summary: String,
+}
+
+/// Resource holding MASC event state for DOM rendering.
+#[derive(Resource)]
+pub struct MascEventLog {
+    pub entries: Vec<MascLogEntry>,
+    pub agent_count: u32,
+    pub task_count: u32,
+}
+
+impl Default for MascEventLog {
+    fn default() -> Self {
+        Self {
+            entries: Vec::new(),
+            agent_count: 0,
+            task_count: 0,
+        }
+    }
+}
+
+/// Lightweight JSON field extractor.
+/// Finds `"key": "value"` or `"key": number` in a JSON string.
+/// No serde dependency needed — MASC events have simple flat structures.
+fn extract_field<'a>(json: &'a str, key: &str) -> Option<&'a str> {
+    let pattern = format!("\"{}\"", key);
+    let key_pos = json.find(&pattern)?;
+    let after_key = &json[key_pos + pattern.len()..];
+
+    // Skip optional whitespace and colon
+    let after_colon = after_key.trim_start().strip_prefix(':')?;
+    let trimmed = after_colon.trim_start();
+
+    if trimmed.starts_with('"') {
+        // String value: find closing quote
+        let value_start = 1; // skip opening quote
+        let rest = &trimmed[value_start..];
+        let end = rest.find('"')?;
+        Some(&rest[..end])
+    } else {
+        // Non-string value (number, bool): find delimiter
+        let end = trimmed
+            .find(|c: char| c == ',' || c == '}' || c == ']' || c.is_whitespace())
+            .unwrap_or(trimmed.len());
+        Some(trimmed[..end].trim())
+    }
+}
+
+/// Each frame, drain the MASC SSE message buffer and update DOM panels.
+/// MASC events render as text in HTML panels, NOT as typed Bevy events.
+pub fn poll_masc_events(
+    receiver: Option<Res<MascSseReceiver>>,
+    mut event_log: ResMut<MascEventLog>,
+) {
+    let Some(receiver) = receiver else { return };
+
+    let mut msgs = match receiver.messages.lock() {
+        Ok(guard) => guard,
+        Err(_) => return,
+    };
+
+    if msgs.is_empty() {
+        return;
+    }
+
+    let now = 0.0_f64; // Timestamp placeholder — no js_sys::Date dependency needed
+
+    for (event_type, data) in msgs.drain(..) {
+        match event_type.as_str() {
+            "broadcast" => {
+                let message = extract_field(&data, "message")
+                    .unwrap_or("(no message)");
+                let agent = extract_field(&data, "agent_name")
+                    .unwrap_or("unknown");
+                let summary = format!("[{}] {}", agent, message);
+
+                event_log.entries.push(MascLogEntry {
+                    timestamp: now,
+                    event_type: "broadcast".to_string(),
+                    summary: summary.clone(),
+                });
+
+                update_monitor_events(&summary);
+                update_social_feed(&summary);
+
+                log::info!("MASC broadcast: {}", summary);
+            }
+            "heartbeat" => {
+                log::debug!("MASC heartbeat received");
+            }
+            "agent_joined" => {
+                let agent = extract_field(&data, "agent_name")
+                    .unwrap_or("unknown");
+                event_log.agent_count = event_log.agent_count.saturating_add(1);
+
+                let summary = format!("{} joined", agent);
+                event_log.entries.push(MascLogEntry {
+                    timestamp: now,
+                    event_type: "agent_joined".to_string(),
+                    summary: summary.clone(),
+                });
+
+                update_monitor_agents(event_log.agent_count, &summary);
+
+                log::info!("MASC agent joined: {} (total: {})", agent, event_log.agent_count);
+            }
+            "agent_left" => {
+                let agent = extract_field(&data, "agent_name")
+                    .unwrap_or("unknown");
+                event_log.agent_count = event_log.agent_count.saturating_sub(1);
+
+                let summary = format!("{} left", agent);
+                event_log.entries.push(MascLogEntry {
+                    timestamp: now,
+                    event_type: "agent_left".to_string(),
+                    summary: summary.clone(),
+                });
+
+                update_monitor_agents(event_log.agent_count, &summary);
+
+                log::info!("MASC agent left: {} (total: {})", agent, event_log.agent_count);
+            }
+            "task_update" => {
+                let task_id = extract_field(&data, "task_id")
+                    .unwrap_or("?");
+                let status = extract_field(&data, "status")
+                    .unwrap_or("unknown");
+
+                let summary = format!("Task {} -> {}", task_id, status);
+                event_log.entries.push(MascLogEntry {
+                    timestamp: now,
+                    event_type: "task_update".to_string(),
+                    summary: summary.clone(),
+                });
+
+                // Crude task count tracking based on status
+                match status {
+                    "claimed" => {
+                        event_log.task_count = event_log.task_count.saturating_add(1);
+                    }
+                    "done" | "cancelled" => {
+                        event_log.task_count = event_log.task_count.saturating_sub(1);
+                    }
+                    _ => {}
+                }
+
+                update_monitor_tasks(event_log.task_count, &summary);
+
+                log::info!("MASC task update: {}", summary);
+            }
+            "endpoint" => {
+                let summary = format!("endpoint: {}", &data);
+                event_log.entries.push(MascLogEntry {
+                    timestamp: now,
+                    event_type: "endpoint".to_string(),
+                    summary,
+                });
+
+                log::info!("MASC endpoint info received");
+            }
+            other => {
+                log::debug!("Unhandled MASC SSE event type: {}", other);
+            }
+        }
+    }
+}
+
+// ─── DOM Update Helpers ──────────────────────
+//
+// All DOM access is gated on wasm32. On native, these are no-ops.
+
+/// Update the Monitor panel "Agent Status" card.
+fn update_monitor_agents(_count: u32, _summary: &str) {
+    #[cfg(target_arch = "wasm32")]
+    {
+        let Some(doc) = web_sys::window().and_then(|w| w.document()) else {
+            return;
+        };
+        // Monitor panel > first monitor-card > placeholder-text
+        if let Ok(Some(el)) = doc.query_selector(
+            "#monitor-panel .monitor-card:nth-child(1) .placeholder-text",
+        ) {
+            let text = format!("{} agent(s) online\n{}", _count, _summary);
+            el.set_text_content(Some(&text));
+        }
+    }
+}
+
+/// Update the Monitor panel "Room Activity" card.
+fn update_monitor_events(_summary: &str) {
+    #[cfg(target_arch = "wasm32")]
+    {
+        let Some(doc) = web_sys::window().and_then(|w| w.document()) else {
+            return;
+        };
+        // Monitor panel > second monitor-card > placeholder-text
+        if let Ok(Some(el)) = doc.query_selector(
+            "#monitor-panel .monitor-card:nth-child(2) .placeholder-text",
+        ) {
+            el.set_text_content(Some(_summary));
+        }
+    }
+}
+
+/// Update the Monitor panel "Task Queue" card.
+fn update_monitor_tasks(_count: u32, _summary: &str) {
+    #[cfg(target_arch = "wasm32")]
+    {
+        let Some(doc) = web_sys::window().and_then(|w| w.document()) else {
+            return;
+        };
+        // Monitor panel > third monitor-card > placeholder-text
+        if let Ok(Some(el)) = doc.query_selector(
+            "#monitor-panel .monitor-card:nth-child(3) .placeholder-text",
+        ) {
+            let text = format!("{} active task(s)\n{}", _count, _summary);
+            el.set_text_content(Some(&text));
+        }
+    }
+}
+
+/// Update the Social panel feed.
+fn update_social_feed(_summary: &str) {
+    #[cfg(target_arch = "wasm32")]
+    {
+        let Some(doc) = web_sys::window().and_then(|w| w.document()) else {
+            return;
+        };
+        if let Ok(Some(el)) =
+            doc.query_selector("#social-panel .social-feed .placeholder-text")
+        {
+            el.set_text_content(Some(_summary));
+        }
+    }
+}

--- a/viewer/src/sse/masc_client.rs
+++ b/viewer/src/sse/masc_client.rs
@@ -1,0 +1,162 @@
+use std::sync::{Arc, Mutex};
+use bevy::prelude::*;
+
+#[cfg(target_arch = "wasm32")]
+use wasm_bindgen::prelude::*;
+
+#[cfg(target_arch = "wasm32")]
+use web_sys::{EventSource, MessageEvent};
+
+use crate::config;
+use crate::mode::ViewerMode;
+
+/// Wrapper around `EventSource` that is `Send + Sync`.
+/// Safe because WASM is single-threaded — there are no real threads to race with.
+#[cfg(target_arch = "wasm32")]
+struct SendEventSource(EventSource);
+
+#[cfg(target_arch = "wasm32")]
+unsafe impl Send for SendEventSource {}
+#[cfg(target_arch = "wasm32")]
+unsafe impl Sync for SendEventSource {}
+
+/// Shared buffer for incoming MASC SSE messages.
+/// Separate from `SseReceiver` (TRPG) — they coexist independently.
+///
+/// The EventSource callbacks push (event_type, data) tuples,
+/// and the Bevy system drains them each frame.
+#[derive(Resource, Clone)]
+pub struct MascSseReceiver {
+    pub messages: Arc<Mutex<Vec<(String, String)>>>,
+    #[cfg(target_arch = "wasm32")]
+    event_source: Arc<Mutex<Option<SendEventSource>>>,
+}
+
+/// MASC MCP SSE event types.
+/// These must match the event names emitted by the MASC MCP server.
+const MASC_SSE_EVENT_TYPES: &[&str] = &[
+    "broadcast",
+    "heartbeat",
+    "agent_joined",
+    "agent_left",
+    "task_update",
+    "endpoint",
+];
+
+/// OnEnter system for MASC modes (Monitor, Council, Social, Experiment).
+/// Creates an EventSource connection to the MASC MCP SSE endpoint.
+#[cfg(target_arch = "wasm32")]
+pub fn setup_masc_sse(mut commands: Commands, mode: Res<State<ViewerMode>>) {
+    let url = match config::sse_endpoint(mode.get()) {
+        Some(url) => url,
+        None => {
+            log::warn!("No SSE endpoint for mode {:?}", mode.get());
+            return;
+        }
+    };
+
+    let messages = Arc::new(Mutex::new(Vec::new()));
+    let es_handle: Arc<Mutex<Option<SendEventSource>>> = Arc::new(Mutex::new(None));
+
+    // Attempt to create EventSource; if MASC server is not running, log and continue
+    let es = match EventSource::new(&url) {
+        Ok(es) => es,
+        Err(e) => {
+            log::warn!("Failed to create MASC EventSource at {}: {:?}", url, e);
+            commands.insert_resource(MascSseReceiver {
+                messages,
+                event_source: es_handle,
+            });
+            return;
+        }
+    };
+
+    // Register a listener for each MASC event type
+    for &event_type in MASC_SSE_EVENT_TYPES {
+        let msgs = messages.clone();
+        let etype = event_type.to_string();
+        let callback = Closure::<dyn FnMut(MessageEvent)>::new(move |e: MessageEvent| {
+            if let Some(data) = e.data().as_string() {
+                if let Ok(mut buf) = msgs.lock() {
+                    buf.push((etype.clone(), data));
+                }
+            }
+        });
+        let _ = es.add_event_listener_with_callback(
+            event_type,
+            callback.as_ref().unchecked_ref(),
+        );
+        // Intentionally leak the closure — it must live for the app lifetime.
+        callback.forget();
+    }
+
+    // Also listen for generic "message" events (unnamed SSE events)
+    {
+        let msgs = messages.clone();
+        let callback = Closure::<dyn FnMut(MessageEvent)>::new(move |e: MessageEvent| {
+            if let Some(data) = e.data().as_string() {
+                if let Ok(mut buf) = msgs.lock() {
+                    buf.push(("message".to_string(), data));
+                }
+            }
+        });
+        es.set_onmessage(Some(callback.as_ref().unchecked_ref()));
+        callback.forget();
+    }
+
+    // Track connection state via onopen / onerror
+    {
+        let connected_url = url.clone();
+        let callback = Closure::<dyn FnMut()>::new(move || {
+            log::info!("MASC SSE connected to {}", connected_url);
+        });
+        es.set_onopen(Some(callback.as_ref().unchecked_ref()));
+        callback.forget();
+    }
+
+    {
+        let callback = Closure::<dyn FnMut()>::new(move || {
+            log::warn!("MASC SSE connection error — will auto-reconnect");
+        });
+        es.set_onerror(Some(callback.as_ref().unchecked_ref()));
+        callback.forget();
+    }
+
+    // Store handle so teardown can call .close()
+    if let Ok(mut guard) = es_handle.lock() {
+        *guard = Some(SendEventSource(es));
+    }
+
+    commands.insert_resource(MascSseReceiver {
+        messages,
+        event_source: es_handle,
+    });
+
+    log::info!(
+        "MASC SSE client initialized for {:?}, subscribing to {} event types",
+        mode.get(),
+        MASC_SSE_EVENT_TYPES.len()
+    );
+}
+
+/// Native no-op for setup_masc_sse.
+#[cfg(not(target_arch = "wasm32"))]
+pub fn setup_masc_sse(mut _commands: Commands, _mode: Res<State<ViewerMode>>) {}
+
+/// OnExit system: closes the MASC EventSource connection and removes the resource.
+pub fn teardown_masc_sse(mut commands: Commands, receiver: Option<Res<MascSseReceiver>>) {
+    if let Some(recv) = receiver {
+        #[cfg(target_arch = "wasm32")]
+        {
+            if let Ok(guard) = recv.event_source.lock() {
+                if let Some(es) = guard.as_ref() {
+                    es.0.close();
+                    log::info!("MASC SSE EventSource closed");
+                }
+            }
+        }
+        let _ = &recv;
+    }
+    commands.remove_resource::<MascSseReceiver>();
+    log::info!("MascSseReceiver resource removed");
+}

--- a/viewer/src/sse/mod.rs
+++ b/viewer/src/sse/mod.rs
@@ -1,5 +1,7 @@
 pub mod bridge;
 pub mod client;
+pub mod masc_bridge;
+pub mod masc_client;
 
 use bevy::prelude::*;
 
@@ -8,15 +10,40 @@ use crate::mode::ViewerMode;
 /// Plugin that establishes the SSE connection to the TRPG Engine
 /// and bridges SSE events into the Bevy event system.
 ///
-/// All systems are gated on `ViewerMode::Trpg` — the SSE connection
-/// is created when entering TRPG mode and events are only polled while active.
+/// Also manages MASC MCP SSE connections for Monitor, Council,
+/// Social, and Experiment modes — rendering events as text in DOM panels.
+///
+/// TRPG systems are gated on `ViewerMode::Trpg`. MASC systems are gated
+/// on their respective modes. Each mode has its own OnEnter/OnExit lifecycle.
 pub struct SsePlugin;
 
 impl Plugin for SsePlugin {
     fn build(&self, app: &mut App) {
-        app
-            .add_systems(OnEnter(ViewerMode::Trpg), client::setup_sse)
-            .add_systems(Update, bridge::poll_sse_events.run_if(in_state(ViewerMode::Trpg)))
+        // ── TRPG SSE ──
+        app.add_systems(OnEnter(ViewerMode::Trpg), client::setup_sse)
+            .add_systems(
+                Update,
+                bridge::poll_sse_events.run_if(in_state(ViewerMode::Trpg)),
+            )
             .add_systems(OnExit(ViewerMode::Trpg), client::teardown_sse);
+
+        // ── MASC SSE (shared event log resource) ──
+        app.init_resource::<masc_bridge::MascEventLog>();
+
+        // ── MASC modes: Monitor, Council, Social, Experiment ──
+        let masc_modes = [
+            ViewerMode::Monitor,
+            ViewerMode::Council,
+            ViewerMode::Social,
+            ViewerMode::Experiment,
+        ];
+        for mode in masc_modes {
+            app.add_systems(OnEnter(mode), masc_client::setup_masc_sse)
+                .add_systems(
+                    Update,
+                    masc_bridge::poll_masc_events.run_if(in_state(mode)),
+                )
+                .add_systems(OnExit(mode), masc_client::teardown_masc_sse);
+        }
     }
 }


### PR DESCRIPTION
## Summary

Monitor, Council, Social, Experiment 모드에서 MASC MCP SSE 연결을 추가합니다.

## Changes

### New Files
- `sse/masc_client.rs`: MASC MCP EventSource client (6 event types: broadcast, heartbeat, agent_joined, agent_left, task_update, endpoint)
- `sse/masc_bridge.rs`: SSE event → DOM panel update bridge (lightweight JSON extraction, no serde dependency for MASC events)

### Modified Files
- `sse/mod.rs`: Register OnEnter/Update/OnExit systems for 4 MASC modes
- `config.rs`: Remove `#[allow(dead_code)]` from now-used `MASC_MCP_URL` and `sse_endpoint()`

## Architecture

```
MASC MCP (:8935)          Viewer (WASM)
┌──────────────┐          ┌───────────────────┐
│ /sse?room=X  │──SSE──→  │ MascSseReceiver   │
└──────────────┘          │   ↓ poll each frame│
                          │ MascEventLog       │
                          │   ↓ web_sys        │
                          │ DOM panels         │
                          └───────────────────┘
```

각 ViewerMode는 독립적인 EventSource lifecycle을 가집니다:
- OnEnter → `setup_masc_sse` (connect to mode-specific SSE room)
- Update → `poll_masc_events` (drain buffer → update DOM)
- OnExit → `teardown_masc_sse` (close EventSource, remove resource)

## Testing

- `trunk build` passes with 0 warnings
- Browser testing pending (MASC MCP server must be running on :8935)

## Related

- PR #131 (Phase 2 scaffold — merged)
- PR #129 (Phase 1 — merged)
