### PR TITLE
docs: align README vector DB with pgvector SSOT

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ masc_leave(agent_name: "codex")
 │ Agents │ Votes  │ Planner│ Consensus        │
 ├────────┴────────┴────────┴──────────────────┤
 │  Backend: FileSystem (.masc/) or PostgreSQL │
-│  + Neo4j (agent graph) + Qdrant (vectors)   │
+│  + Neo4j (agent graph) + Supabase pgvector  │
 └─────────────────────────────────────────────┘
 ```
 


### PR DESCRIPTION
## Summary
- replace outdated `Qdrant` mention in architecture diagram
- align README with repository SSOT: vector DB is Supabase pgvector

## Validation
- `rg -n "Qdrant|qdrant" README.md` returns no result
