### PR TITLE
fix(harness): handle SSE framing in game-view precondition script

### DIFF
--- a/scripts/harness_game_view_precondition.sh
+++ b/scripts/harness_game_view_precondition.sh
@@ -8,15 +8,24 @@ call_tool() {
   local id="$1"
   local name="$2"
   local args_json="$3"
-  curl -sS -m 20 -X POST "$MCP_URL" \
+  local raw
+  local sse_data
+  raw="$(curl -sS -m 20 -X POST "$MCP_URL" \
     -H 'Content-Type: application/json' \
     -H 'Accept: application/json, text/event-stream' \
-    -d "{\"jsonrpc\":\"2.0\",\"id\":$id,\"method\":\"tools/call\",\"params\":{\"name\":\"$name\",\"arguments\":$args_json}}"
+    -d "{\"jsonrpc\":\"2.0\",\"id\":$id,\"method\":\"tools/call\",\"params\":{\"name\":\"$name\",\"arguments\":$args_json}}")"
+
+  sse_data="$(printf "%s" "$raw" | sed -n 's/^data: //p' | tail -n1)"
+  if [ -n "$sse_data" ]; then
+    printf "%s" "$sse_data"
+  else
+    printf "%s" "$raw"
+  fi
 }
 
 echo "[1/5] experiment.start without decision.finalize => expect PRECONDITION_REQUIRED"
 r1="$(call_tool 1001 "experiment.start" "{\"session_id\":\"$SESSION_ID\",\"hypothesis\":\"h\"}")"
-if ! printf "%s" "$r1" | rg -q 'PRECONDITION_REQUIRED'; then
+if ! printf "%s" "$r1" | jq -er 'try (.result.content[0].text | fromjson | tostring | contains("PRECONDITION_REQUIRED")) catch false' >/dev/null; then
   echo "FAIL: experiment.start should return PRECONDITION_REQUIRED"
   printf "%s\n" "$r1"
   exit 1
@@ -24,7 +33,7 @@ fi
 
 echo "[2/5] decision.create"
 r2="$(call_tool 1002 "decision.create" "{\"session_id\":\"$SESSION_ID\",\"issue\":\"route\",\"options\":[\"A\",\"B\"]}")"
-decision_id="$(printf "%s" "$r2" | rg -o '"decision_id"\s*:\s*"[^"]+"' | head -n1 | sed -E 's/.*"decision_id"\s*:\s*"([^"]+)".*/\1/' || true)"
+decision_id="$(printf "%s" "$r2" | jq -r 'try (.result.content[0].text | fromjson | .payload.decision_id // empty) catch empty')"
 if [ -z "$decision_id" ]; then
   echo "FAIL: decision_id not found"
   printf "%s\n" "$r2"
@@ -33,7 +42,8 @@ fi
 
 echo "[3/5] decision.finalize"
 r3="$(call_tool 1003 "decision.finalize" "{\"session_id\":\"$SESSION_ID\",\"decision_id\":\"$decision_id\",\"selected_option\":\"A\",\"rationale\":\"best\",\"verifier\":\"PASS\"}")"
-if ! printf "%s" "$r3" | rg -q '"status"\s*:\s*"finalized"'; then
+status3="$(printf "%s" "$r3" | jq -r 'try (.result.content[0].text | fromjson | .payload.status // empty) catch empty')"
+if [ "$status3" != "finalized" ]; then
   echo "FAIL: decision.finalize should finalize decision"
   printf "%s\n" "$r3"
   exit 1
@@ -41,7 +51,8 @@ fi
 
 echo "[4/5] experiment.start after finalize => expect running"
 r4="$(call_tool 1004 "experiment.start" "{\"session_id\":\"$SESSION_ID\",\"hypothesis\":\"h2\",\"metrics\":[\"engagement\"]}")"
-if ! printf "%s" "$r4" | rg -q '"status"\s*:\s*"running"'; then
+status4="$(printf "%s" "$r4" | jq -r 'try (.result.content[0].text | fromjson | .payload.status // empty) catch empty')"
+if [ "$status4" != "running" ]; then
   echo "FAIL: experiment.start should be running after finalize"
   printf "%s\n" "$r4"
   exit 1
@@ -49,7 +60,8 @@ fi
 
 echo "[5/5] trpg.action.submit after finalize => expect result"
 r5="$(call_tool 1005 "trpg.action.submit" "{\"session_id\":\"$SESSION_ID\",\"action\":\"scan area\",\"intent\":\"collect info\",\"stakes\":\"medium\"}")"
-if ! printf "%s" "$r5" | rg -q '"story_log"'; then
+story_len="$(printf "%s" "$r5" | jq -r 'try (.result.content[0].text | fromjson | (.payload.story_log | length)) catch 0')"
+if [ "${story_len:-0}" -lt 1 ]; then
   echo "FAIL: trpg.action.submit should return story_log"
   printf "%s\n" "$r5"
   exit 1


### PR DESCRIPTION
## Summary
- parse SSE event stream and extract final data frame in harness call_tool
- switch field assertions to jq-based payload parsing
- fix decision_id extraction failure under escaped JSON text payload

## Why
- previous harness failed at step 2 (decision.create) even when server behavior was correct
- failure came from parsing escaped JSON inside SSE framing

## Validation
- scripts/harness_game_view_precondition.sh
- result: PASS (all 5 steps)

## Scope
- only scripts/harness_game_view_precondition.sh
