### PR TITLE
fix(lodge): local graphql fallback + token-safe curl headers

### DIFF
--- a/bin/main_eio.ml
+++ b/bin/main_eio.ml
@@ -4266,8 +4266,6 @@ let run_server ~sw ~env ~port ~base_path =
     ~https_connector:(Masc_mcp.Eio_context.get_https_connector ())
     net;
   Masc_mcp.Process_eio.init ~proc_mgr ~clock;
-  (* Initialize Lodge after Eio context is ready (requires net for GraphQL) *)
-  Masc_mcp.Tool_lodge.init ();
 
   (* Create Caqti-compatible stdenv adapter
      Note: net type coercion from [Generic|Unix] to [Generic] is safe
@@ -4357,6 +4355,12 @@ let run_server ~sw ~env ~port ~base_path =
   Printf.printf "   GET  /sse → legacy SSE stream (event: endpoint)\n%!";
   Printf.printf "   POST /messages → legacy client->server messages\n%!";
   Printf.printf "   GET  /health → Health check\n%!";
+
+  (* Defer Lodge init slightly to avoid startup race when GRAPHQL_URL points
+     to local /graphql on this same process. *)
+  Eio.Fiber.fork ~sw (fun () ->
+    Eio.Time.sleep clock 1.0;
+    Masc_mcp.Tool_lodge.init ());
 
   let is_cancelled exn =
     match exn with

--- a/config/lodge.env
+++ b/config/lodge.env
@@ -2,6 +2,11 @@
 # Loaded by start-masc-mcp.sh at startup
 # All env vars use MASC_LODGE_* prefix (read by Env_config.LodgeV2)
 
+# Local GraphQL (avoid external dependency in local/dev runs)
+GRAPHQL_URL=http://127.0.0.1:8935/graphql
+# Keep empty for local-only mode; external key is not required.
+GRAPHQL_API_KEY=
+
 # Tick interval (seconds) — 2700 = 45 minutes
 MASC_LODGE_TICK_INTERVAL_SEC=2700
 

--- a/lib/lodge_heartbeat.ml
+++ b/lib/lodge_heartbeat.ml
@@ -421,39 +421,55 @@ let sb_path () =
       | Some home -> Printf.sprintf "%s/me/scripts/sb" home
       | None -> "./scripts/sb")
 
+(** Use local GraphQL by default for local MCP runs.
+    Set GRAPHQL_URL explicitly to force remote endpoint. *)
+let default_graphql_url () =
+  let port = Sys.getenv_opt "MASC_MCP_PORT" |> Option.value ~default:"8935" in
+  Printf.sprintf "http://127.0.0.1:%s/graphql" port
+
+(** Keep auth token out of argv so process errors don't leak secrets. *)
+let with_auth_header_file api_key f =
+  if api_key = "" then f None
+  else
+    let path = Filename.temp_file "masc-gql-auth-" ".hdr" in
+    Fun.protect
+      ~finally:(fun () -> try Sys.remove path with _ -> ())
+      (fun () ->
+         let fd = Unix.openfile path [Unix.O_WRONLY; Unix.O_CREAT; Unix.O_TRUNC] 0o600 in
+         let oc = Unix.out_channel_of_descr fd in
+         output_string oc ("Authorization: Bearer " ^ api_key ^ "\n");
+         close_out oc;
+         f (Some path))
+
 (** curl-based GraphQL request — reliable DNS resolution in Railway containers *)
 let graphql_request_curl body : (string, string) Stdlib.result =
-  let default_url = "https://second-brain-graphql-production.up.railway.app/graphql" in
-  let url = Sys.getenv_opt "GRAPHQL_URL" |> Option.value ~default:default_url in
+  let url = Sys.getenv_opt "GRAPHQL_URL" |> Option.value ~default:(default_graphql_url ()) in
   let api_key = Sys.getenv_opt "GRAPHQL_API_KEY" |> Option.value ~default:"" in
-  if api_key = "" then
-    Error "GRAPHQL_API_KEY not set"
-  else
-  let argv =
-    [ "curl"; "-s"; "-m"; "10"; url;
-      "-H"; "Content-Type: application/json"
-    ]
-    |> fun base -> base @ [ "-H"; "Authorization: Bearer " ^ api_key ]
-    |> fun with_auth ->
-    (* Read request body from stdin to avoid quoting/escaping issues. *)
-    with_auth @ [ "-d"; "@-" ]
-  in
-  try
-    let output =
-      Process_eio.run_argv_with_stdin ~timeout_sec:15.0 ~stdin_content:body argv
-    in
-    if String.length output = 0 then Error "curl: empty response" else Ok output
-  with exn -> Error (Printf.sprintf "curl: %s" (Printexc.to_string exn))
+  with_auth_header_file api_key (fun auth_header_file ->
+      let argv =
+        [ "curl"; "-s"; "-m"; "10"; url;
+          "-H"; "Content-Type: application/json"
+        ]
+        |> fun base ->
+        match auth_header_file with
+        | None -> base
+        | Some header_file -> base @ [ "-H"; "@" ^ header_file ]
+        |> fun with_auth ->
+        (* Read request body from stdin to avoid quoting/escaping issues. *)
+        with_auth @ [ "-d"; "@-" ]
+      in
+      try
+        let output =
+          Process_eio.run_argv_with_stdin ~timeout_sec:15.0 ~stdin_content:body argv
+        in
+        if String.length output = 0 then Error "curl: empty response" else Ok output
+      with exn -> Error (Printf.sprintf "curl: %s" (Printexc.to_string exn)))
 
 (** GraphQL request via Cohttp_eio with curl fallback.
     Falls back to curl if Cohttp fails (Railway DNS issues). *)
 let graphql_request ?(timeout_sec=5.0) body : (string, string) Stdlib.result =
-  let default_url = "https://second-brain-graphql-production.up.railway.app/graphql" in
-  let url = Sys.getenv_opt "GRAPHQL_URL" |> Option.value ~default:default_url in
+  let url = Sys.getenv_opt "GRAPHQL_URL" |> Option.value ~default:(default_graphql_url ()) in
   let api_key = Sys.getenv_opt "GRAPHQL_API_KEY" |> Option.value ~default:"" in
-  if api_key = "" then
-    Error "GRAPHQL_API_KEY not set"
-  else
   let max_response_bytes = 1_000_000 in
   let suppress_body _s = "body suppressed" in
   let cohttp_result = match Eio_context.get_net_opt () with
@@ -617,6 +633,55 @@ type agent = {
   activity_level: float;
 }
 
+let builtin_core_agents () : agent list =
+  [
+    {
+      name = "dreamer";
+      preferred_hours = [9; 10; 11; 20; 21; 22];
+      peak_hour = Some 21;
+      traits = ["creative"; "imaginative"; "speculative"];
+      interests = ["vision"; "story"; "future"];
+      personality_hint = None;
+      activity_level = 0.7;
+    };
+    {
+      name = "skeptic";
+      preferred_hours = [10; 11; 14; 15; 16];
+      peak_hour = Some 15;
+      traits = ["critical"; "risk-aware"; "evidence-first"];
+      interests = ["risk"; "verification"; "failure-mode"];
+      personality_hint = None;
+      activity_level = 0.65;
+    };
+    {
+      name = "historian";
+      preferred_hours = [8; 9; 10; 13; 14];
+      peak_hour = Some 10;
+      traits = ["contextual"; "archival"; "pattern-aware"];
+      interests = ["history"; "lineage"; "memory"];
+      personality_hint = None;
+      activity_level = 0.6;
+    };
+    {
+      name = "pragmatist";
+      preferred_hours = [9; 10; 13; 14; 17; 18];
+      peak_hour = Some 14;
+      traits = ["execution-focused"; "concise"; "outcome-driven"];
+      interests = ["delivery"; "ops"; "reliability"];
+      personality_hint = None;
+      activity_level = 0.75;
+    };
+    {
+      name = "connector";
+      preferred_hours = [11; 12; 15; 16; 19; 20];
+      peak_hour = Some 16;
+      traits = ["social"; "integrative"; "bridge-builder"];
+      interests = ["collaboration"; "handoff"; "coordination"];
+      personality_hint = None;
+      activity_level = 0.7;
+    };
+  ]
+
 (** Why an agent is being checked in *)
 type checkin_trigger =
   | Scheduled                    (** Round-robin turn *)
@@ -709,32 +774,39 @@ let load_agents_from_neo4j () =
           |> Yojson.Safe.Util.member "edges"
           |> Yojson.Safe.Util.to_list
         in
-        List.filter_map (fun edge ->
-          try
-            let node = Yojson.Safe.Util.member "node" edge in
-            let name = Yojson.Safe.Util.(member "name" node |> to_string) in
-            let preferred_hours = Yojson.Safe.Util.(member "preferredHours" node |> to_list |> List.map to_int) in
-            let peak_hour = Yojson.Safe.Util.(member "peakHour" node |> to_int_option) in
-            let traits = Yojson.Safe.Util.(member "traits" node |> to_list |> List.map to_string) in
-            let activity_level =
-              match Yojson.Safe.Util.(member "activityLevel" node) with
-              | `Null -> 0.5
-              | v -> Yojson.Safe.Util.to_float v
-            in
-            (* Client-side filter: only agents with preferredHours *)
-            let interests =
-              try Yojson.Safe.Util.(member "interests" node |> to_list |> List.map to_string)
-              with Yojson.Safe.Util.Type_error _ | Failure _ -> []
-            in
-            if preferred_hours <> [] then
-              Some { name; preferred_hours; peak_hour; traits; interests;
-                     personality_hint = None; activity_level }
-            else
+        let parsed =
+          List.filter_map (fun edge ->
+            try
+              let node = Yojson.Safe.Util.member "node" edge in
+              let name = Yojson.Safe.Util.(member "name" node |> to_string) in
+              let preferred_hours = Yojson.Safe.Util.(member "preferredHours" node |> to_list |> List.map to_int) in
+              let peak_hour = Yojson.Safe.Util.(member "peakHour" node |> to_int_option) in
+              let traits = Yojson.Safe.Util.(member "traits" node |> to_list |> List.map to_string) in
+              let activity_level =
+                match Yojson.Safe.Util.(member "activityLevel" node) with
+                | `Null -> 0.5
+                | v -> Yojson.Safe.Util.to_float v
+              in
+              (* Client-side filter: only agents with preferredHours *)
+              let interests =
+                try Yojson.Safe.Util.(member "interests" node |> to_list |> List.map to_string)
+                with Yojson.Safe.Util.Type_error _ | Failure _ -> []
+              in
+              if preferred_hours <> [] then
+                Some { name; preferred_hours; peak_hour; traits; interests;
+                       personality_hint = None; activity_level }
+              else
+                None
+            with Yojson.Safe.Util.Type_error (msg, _) ->
+              Eio.traceln "⚠️ Agent parse error: %s" msg;
               None
-          with Yojson.Safe.Util.Type_error (msg, _) ->
-            Eio.traceln "⚠️ Agent parse error: %s" msg;
-            None
-        ) edges)
+          ) edges
+        in
+        if parsed <> [] then parsed
+        else begin
+          Eio.traceln "⚠️ GraphQL agents empty, using builtin core agents fallback";
+          builtin_core_agents ()
+        end)
       with e ->
         Eio.traceln "⚠️ Failed to load agents from GraphQL: %s" (Printexc.to_string e);
         []

--- a/lib/lodge_memory.ml
+++ b/lib/lodge_memory.ml
@@ -40,33 +40,54 @@ let truncate s n =
     in
     String.sub s 0 (find_boundary n)
 
+(** Use local GraphQL by default for local MCP runs.
+    Set GRAPHQL_URL explicitly to force remote endpoint. *)
+let default_graphql_url () =
+  let port = Sys.getenv_opt "MASC_MCP_PORT" |> Option.value ~default:"8935" in
+  Printf.sprintf "http://127.0.0.1:%s/graphql" port
+
+(** Keep auth token out of argv so process errors don't leak secrets. *)
+let with_auth_header_file api_key f =
+  if api_key = "" then f None
+  else
+    let path = Filename.temp_file "masc-gql-auth-" ".hdr" in
+    Fun.protect
+      ~finally:(fun () -> try Sys.remove path with _ -> ())
+      (fun () ->
+         let fd = Unix.openfile path [Unix.O_WRONLY; Unix.O_CREAT; Unix.O_TRUNC] 0o600 in
+         let oc = Unix.out_channel_of_descr fd in
+         output_string oc ("Authorization: Bearer " ^ api_key ^ "\n");
+         close_out oc;
+         f (Some path))
+
 (** curl-based GraphQL request — reliable DNS resolution in Railway containers *)
 let graphql_request_curl body : (string, string) Stdlib.result =
-  let default_url = "https://second-brain-graphql-production.up.railway.app/graphql" in
-  let url = Sys.getenv_opt "GRAPHQL_URL" |> Option.value ~default:default_url in
+  let url = Sys.getenv_opt "GRAPHQL_URL" |> Option.value ~default:(default_graphql_url ()) in
   let api_key = Sys.getenv_opt "GRAPHQL_API_KEY" |> Option.value ~default:"" in
-  let argv =
-    [ "curl"; "-s"; "-m"; "10"; url;
-      "-H"; "Content-Type: application/json"
-    ]
-    |> fun base ->
-    if api_key = "" then base else base @ [ "-H"; "Authorization: Bearer " ^ api_key ]
-    |> fun with_auth ->
-    (* Read request body from stdin to avoid quoting/escaping issues. *)
-    with_auth @ [ "-d"; "@-" ]
-  in
-  try
-    let output =
-      Process_eio.run_argv_with_stdin ~timeout_sec:15.0 ~stdin_content:body argv
-    in
-    if String.length output = 0 then Error "curl: empty response" else Ok output
-  with exn -> Error (Printf.sprintf "curl: %s" (Printexc.to_string exn))
+  with_auth_header_file api_key (fun auth_header_file ->
+      let argv =
+        [ "curl"; "-s"; "-m"; "10"; url;
+          "-H"; "Content-Type: application/json"
+        ]
+        |> fun base ->
+        match auth_header_file with
+        | None -> base
+        | Some header_file -> base @ [ "-H"; "@" ^ header_file ]
+        |> fun with_auth ->
+        (* Read request body from stdin to avoid quoting/escaping issues. *)
+        with_auth @ [ "-d"; "@-" ]
+      in
+      try
+        let output =
+          Process_eio.run_argv_with_stdin ~timeout_sec:15.0 ~stdin_content:body argv
+        in
+        if String.length output = 0 then Error "curl: empty response" else Ok output
+      with exn -> Error (Printf.sprintf "curl: %s" (Printexc.to_string exn)))
 
 (** GraphQL request via Cohttp_eio with curl fallback.
     Falls back to curl if Cohttp fails (Railway DNS issues). *)
 let graphql_request ?(timeout_sec=5.0) body : (string, string) Stdlib.result =
-  let default_url = "https://second-brain-graphql-production.up.railway.app/graphql" in
-  let url = Sys.getenv_opt "GRAPHQL_URL" |> Option.value ~default:default_url in
+  let url = Sys.getenv_opt "GRAPHQL_URL" |> Option.value ~default:(default_graphql_url ()) in
   let api_key = Sys.getenv_opt "GRAPHQL_API_KEY" |> Option.value ~default:"" in
   let max_response_bytes = 1_000_000 in
   let suppress_body _s = "body suppressed" in

--- a/lib/tool_lodge.ml
+++ b/lib/tool_lodge.ml
@@ -141,32 +141,53 @@ let http_get_json ~net:_ url =
 
 (* NOTE: http_get_local removed — using curl subprocess for all HTTP *)
 
+(** Use local GraphQL by default for local MCP runs.
+    Set GRAPHQL_URL explicitly to force remote endpoint. *)
+let default_graphql_url () =
+  let port = Sys.getenv_opt "MASC_MCP_PORT" |> Option.value ~default:"8935" in
+  Printf.sprintf "http://127.0.0.1:%s/graphql" port
+
+(** Keep auth token out of argv so process errors don't leak secrets. *)
+let with_auth_header_file api_key f =
+  if api_key = "" then f None
+  else
+    let path = Filename.temp_file "masc-gql-auth-" ".hdr" in
+    Fun.protect
+      ~finally:(fun () -> try Sys.remove path with _ -> ())
+      (fun () ->
+         let fd = Unix.openfile path [Unix.O_WRONLY; Unix.O_CREAT; Unix.O_TRUNC] 0o600 in
+         let oc = Unix.out_channel_of_descr fd in
+         output_string oc ("Authorization: Bearer " ^ api_key ^ "\n");
+         close_out oc;
+         f (Some path))
+
 (** curl-based GraphQL request — reliable DNS resolution in Railway containers *)
 let graphql_request_curl body : (string, string) Stdlib.result =
-  let default_url = "https://second-brain-graphql-production.up.railway.app/graphql" in
-  let url = Sys.getenv_opt "GRAPHQL_URL" |> Option.value ~default:default_url in
+  let url = Sys.getenv_opt "GRAPHQL_URL" |> Option.value ~default:(default_graphql_url ()) in
   let api_key = Sys.getenv_opt "GRAPHQL_API_KEY" |> Option.value ~default:"" in
-  try
-    let argv =
-      [ "curl"; "-s"; "-m"; "10"; "-f"; url;
-        "-H"; "Content-Type: application/json"
-      ]
-      |> fun base ->
-      if api_key = "" then base else base @ [ "-H"; "Authorization: Bearer " ^ api_key ]
-      |> fun with_auth ->
-      (* Read request body from stdin to avoid quoting/escaping issues. *)
-      with_auth @ [ "-d"; "@-" ]
-    in
-    let output = Process_eio.run_argv_with_stdin ~timeout_sec:15.0 ~stdin_content:body argv in
-    if String.length output = 0 then Error "❌ GraphQL curl: empty response" else Ok output
-  with exn -> Error (Printf.sprintf "❌ GraphQL curl: %s" (Printexc.to_string exn))
+  with_auth_header_file api_key (fun auth_header_file ->
+      try
+        let argv =
+          [ "curl"; "-s"; "-m"; "10"; "-f"; url;
+            "-H"; "Content-Type: application/json"
+          ]
+          |> fun base ->
+          match auth_header_file with
+          | None -> base
+          | Some header_file -> base @ [ "-H"; "@" ^ header_file ]
+          |> fun with_auth ->
+          (* Read request body from stdin to avoid quoting/escaping issues. *)
+          with_auth @ [ "-d"; "@-" ]
+        in
+        let output = Process_eio.run_argv_with_stdin ~timeout_sec:15.0 ~stdin_content:body argv in
+        if String.length output = 0 then Error "❌ GraphQL curl: empty response" else Ok output
+      with exn -> Error (Printf.sprintf "❌ GraphQL curl: %s" (Printexc.to_string exn)))
 
 (** GraphQL request via Cohttp_eio with curl fallback.
     Falls back to curl if Cohttp fails (Railway DNS issues).
     URL configurable via GRAPHQL_URL env var for Railway internal networking. *)
 let graphql_request ?(timeout_sec=5.0) body : (string, string) Stdlib.result =
-  let default_url = "https://second-brain-graphql-production.up.railway.app/graphql" in
-  let url = Sys.getenv_opt "GRAPHQL_URL" |> Option.value ~default:default_url in
+  let url = Sys.getenv_opt "GRAPHQL_URL" |> Option.value ~default:(default_graphql_url ()) in
   let api_key = Sys.getenv_opt "GRAPHQL_API_KEY" |> Option.value ~default:"" in
   let max_response_bytes = 1_000_000 in
   let cohttp_result = match Eio_context.get_net_opt () with
@@ -1623,7 +1644,7 @@ let spawn_agent ~net:_ ~parent_name ~child_name ~child_role ~child_prompt =
   else
     (* Create via GraphQL mutation *)
     let graphql_url = Sys.getenv_opt "GRAPHQL_URL"
-      |> Option.value ~default:"https://second-brain-graphql-production.up.railway.app/graphql" in
+      |> Option.value ~default:(default_graphql_url ()) in
     let api_key = Sys.getenv_opt "GRAPHQL_API_KEY" |> Option.value ~default:"" in
     if api_key = "" then
       (false, "❌ Lodge: GRAPHQL_API_KEY not configured")


### PR DESCRIPTION
## Summary
- default GraphQL target to local /graphql for local MCP runs
- remove bearer token exposure from process argv by using temporary header files
- allow local-mode operation without GRAPHQL_API_KEY hard requirement
- add heartbeat fallback to builtin core agents when GraphQL returns empty agents
- defer Tool_lodge init in server startup to reduce local /graphql bootstrap race

## Security
- mitigates secret leakage in process error logs
- local dev no longer depends on external GraphQL availability

## Config
- set local defaults in config/lodge.env
  - GRAPHQL_URL=http://127.0.0.1:8935/graphql
  - GRAPHQL_API_KEY=

## Notes
- previously exposed GRAPHQL_API_KEY should be rotated/revoked
