### PR TITLE
feat(viewer): Phase 2 — SSE event wiring, mode panels, release build

### DIFF
--- a/viewer/Trunk.toml
+++ b/viewer/Trunk.toml
@@ -1,6 +1,6 @@
 [build]
 target = "index.html"
-release = false
+release = true
 filehash = true
 
 [watch]

--- a/viewer/index.html
+++ b/viewer/index.html
@@ -75,15 +75,21 @@
             <div class="monitor-grid">
                 <div class="monitor-card">
                     <h3>Agent Status</h3>
-                    <p class="placeholder-text">Connecting to MASC...</p>
+                    <div id="monitor-agent-list">
+                        <p class="placeholder-text">Connecting to MASC...</p>
+                    </div>
                 </div>
                 <div class="monitor-card">
                     <h3>Room Activity</h3>
-                    <p class="placeholder-text">Waiting for events...</p>
+                    <div id="monitor-events" class="monitor-event-feed">
+                        <p class="placeholder-text">Waiting for events...</p>
+                    </div>
                 </div>
                 <div class="monitor-card">
                     <h3>Task Queue</h3>
-                    <p class="placeholder-text">No active tasks</p>
+                    <div id="monitor-task-list">
+                        <p class="placeholder-text">No active tasks</p>
+                    </div>
                 </div>
             </div>
         </div>
@@ -96,8 +102,12 @@
             <button class="back-btn" data-back="lobby">◂ Back</button>
         </div>
         <div class="mode-panel-content">
-            <div class="council-deliberation">
-                <p class="placeholder-text">No active deliberation. Awaiting decision issues...</p>
+            <div class="panel-header">
+                <h2>Council — MAGI Deliberation</h2>
+                <div class="council-status">Waiting for issues...</div>
+            </div>
+            <div class="council-feed" id="council-deliberation">
+                <div class="council-empty">No deliberations in progress. Issues will appear when submitted.</div>
             </div>
         </div>
     </div>
@@ -109,8 +119,11 @@
             <button class="back-btn" data-back="lobby">◂ Back</button>
         </div>
         <div class="mode-panel-content">
-            <div class="social-feed">
-                <p class="placeholder-text">Loading social feed...</p>
+            <div class="panel-header">
+                <h2>Social — Lodge Board</h2>
+            </div>
+            <div class="social-feed" id="social-feed">
+                <div class="social-empty">Connecting to Lodge...</div>
             </div>
         </div>
     </div>
@@ -122,8 +135,12 @@
             <button class="back-btn" data-back="lobby">◂ Back</button>
         </div>
         <div class="mode-panel-content">
-            <div class="experiment-dashboard">
-                <p class="placeholder-text">No active experiments. Awaiting hypothesis...</p>
+            <div class="panel-header">
+                <h2>Experiments — A/B Testing</h2>
+                <div class="experiment-status">No active experiments</div>
+            </div>
+            <div class="experiment-feed" id="experiment-dashboard">
+                <div class="experiment-empty">No experiments running. Start one via MASC tools.</div>
             </div>
         </div>
     </div>

--- a/viewer/src/config.rs
+++ b/viewer/src/config.rs
@@ -19,6 +19,8 @@ pub const DEFAULT_ROOM_ID: &str = "default";
 
 /// SSE endpoint for a given viewer mode.
 /// Returns `None` for Lobby (no live data connection).
+/// Called by `masc_client::setup_masc_sse` (wasm32 only).
+#[allow(dead_code)]
 pub fn sse_endpoint(mode: &ViewerMode) -> Option<String> {
     match mode {
         ViewerMode::Lobby => None,

--- a/viewer/src/mode.rs
+++ b/viewer/src/mode.rs
@@ -49,6 +49,8 @@ pub enum ViewerMode {
 
 impl ViewerMode {
     /// Human-readable display name for UI rendering.
+    /// Used by `poll_mode_transition` (wasm32 only).
+    #[allow(dead_code)]
     pub fn display_name(&self) -> &'static str {
         match self {
             Self::Lobby => "MASC Viewer",
@@ -86,6 +88,8 @@ impl ViewerMode {
     }
 
     /// CSS class name applied to the HTML body for mode-specific DOM styling.
+    /// Used by `poll_mode_transition` (wasm32 only).
+    #[allow(dead_code)]
     pub fn css_class(&self) -> &'static str {
         match self {
             Self::Lobby => "mode-lobby",
@@ -98,6 +102,8 @@ impl ViewerMode {
     }
 
     /// Parse from the HTML `data-mode` attribute value.
+    /// Used by `bind_mode_cards` (wasm32 only).
+    #[allow(dead_code)]
     pub fn from_data_attr(s: &str) -> Option<ViewerMode> {
         match s {
             "trpg" => Some(Self::Trpg),

--- a/viewer/src/render/mod.rs
+++ b/viewer/src/render/mod.rs
@@ -66,7 +66,10 @@ fn cleanup_trpg_scene(
 ) {
     let count = trpg_entities.iter().count();
     for entity in &trpg_entities {
-        commands.entity(entity).despawn();
+        // Use try_despawn to avoid panics when parent despawn already
+        // recursively removed child entities (e.g., HpBarSprite children
+        // of MapToken entities).
+        commands.entity(entity).try_despawn();
     }
 
     // Reset the scene transition resource so re-entering Trpg starts clean

--- a/viewer/src/sse/client.rs
+++ b/viewer/src/sse/client.rs
@@ -7,6 +7,7 @@ use wasm_bindgen::prelude::*;
 #[cfg(target_arch = "wasm32")]
 use web_sys::{EventSource, MessageEvent};
 
+#[cfg(target_arch = "wasm32")]
 use crate::config;
 
 /// Wrapper around `EventSource` that is `Send + Sync`.
@@ -33,6 +34,8 @@ pub struct SseReceiver {
 
 /// List of SSE event types the viewer subscribes to.
 /// These must match the event names emitted by the TRPG Engine.
+/// Used by `setup_sse` (wasm32 only).
+#[allow(dead_code)]
 const SSE_EVENT_TYPES: &[&str] = &[
     "dice_roll",
     "hp_change",
@@ -110,8 +113,16 @@ pub fn setup_sse(mut commands: Commands) {
     }
 
     {
+        // Log the first connection error at warn level, then suppress to debug
+        // to avoid flooding the browser console when no backend is running.
+        let error_count = std::sync::Arc::new(std::sync::atomic::AtomicU32::new(0));
         let callback = Closure::<dyn FnMut()>::new(move || {
-            log::warn!("SSE connection error — will auto-reconnect");
+            let count = error_count.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+            if count == 0 {
+                log::warn!("SSE connection error — will auto-reconnect (subsequent errors suppressed to debug)");
+            } else {
+                log::debug!("SSE reconnect attempt #{}", count + 1);
+            }
         });
         es.set_onerror(Some(callback.as_ref().unchecked_ref()));
         callback.forget();

--- a/viewer/src/sse/masc_bridge.rs
+++ b/viewer/src/sse/masc_bridge.rs
@@ -167,6 +167,182 @@ pub fn poll_masc_events(
 
                 log::info!("MASC endpoint info received");
             }
+
+            // ─── Council (MAGI Deliberation) ─────────────
+            "decision_issue" => {
+                let title = extract_field(&data, "title").unwrap_or("untitled");
+                let urgency = extract_field(&data, "urgency").unwrap_or("normal");
+                let summary = format!("[ISSUE] {} (urgency: {})", title, urgency);
+                event_log.entries.push(MascLogEntry {
+                    timestamp: now,
+                    event_type: "decision_issue".to_string(),
+                    summary: summary.clone(),
+                });
+                update_council_deliberation(&summary);
+                log::info!("MASC council: {}", summary);
+            }
+            "decision_option" => {
+                let label = extract_field(&data, "label").unwrap_or("?");
+                let proposed_by = extract_field(&data, "proposed_by").unwrap_or("unknown");
+                let summary = format!("[OPTION] {} by {}", label, proposed_by);
+                event_log.entries.push(MascLogEntry {
+                    timestamp: now,
+                    event_type: "decision_option".to_string(),
+                    summary: summary.clone(),
+                });
+                update_council_deliberation(&summary);
+                log::info!("MASC council: {}", summary);
+            }
+            "decision_argument" => {
+                let agent = extract_field(&data, "agent").unwrap_or("unknown");
+                let position = extract_field(&data, "position").unwrap_or("neutral");
+                let reasoning = extract_field(&data, "reasoning").unwrap_or("...");
+                let summary = format!("[{}] {}: {}", position.to_uppercase(), agent, reasoning);
+                event_log.entries.push(MascLogEntry {
+                    timestamp: now,
+                    event_type: "decision_argument".to_string(),
+                    summary: summary.clone(),
+                });
+                update_council_deliberation(&summary);
+                log::info!("MASC council: {}", summary);
+            }
+            "decision_vote" => {
+                let agent = extract_field(&data, "agent").unwrap_or("unknown");
+                let option_id = extract_field(&data, "option_id").unwrap_or("?");
+                let weight = extract_field(&data, "weight").unwrap_or("1");
+                let summary = format!("[VOTE] {} -> {} (weight: {})", agent, option_id, weight);
+                event_log.entries.push(MascLogEntry {
+                    timestamp: now,
+                    event_type: "decision_vote".to_string(),
+                    summary: summary.clone(),
+                });
+                update_council_deliberation(&summary);
+                log::info!("MASC council: {}", summary);
+            }
+            "decision_consensus" => {
+                let chosen = extract_field(&data, "chosen_option_id").unwrap_or("?");
+                let method = extract_field(&data, "method").unwrap_or("unknown");
+                let margin = extract_field(&data, "margin").unwrap_or("?");
+                let summary = format!("[CONSENSUS] {} via {} (margin: {})", chosen, method, margin);
+                event_log.entries.push(MascLogEntry {
+                    timestamp: now,
+                    event_type: "decision_consensus".to_string(),
+                    summary: summary.clone(),
+                });
+                update_council_deliberation(&summary);
+                log::info!("MASC council: {}", summary);
+            }
+            "decision_phase" => {
+                let phase = extract_field(&data, "phase").unwrap_or("unknown");
+                let summary = format!("[PHASE] {}", phase);
+                event_log.entries.push(MascLogEntry {
+                    timestamp: now,
+                    event_type: "decision_phase".to_string(),
+                    summary: summary.clone(),
+                });
+                update_council_deliberation(&summary);
+                log::info!("MASC council: {}", summary);
+            }
+
+            // ─── Experiment (A/B Testing) ────────────────
+            "experiment_created" => {
+                let hypothesis = extract_field(&data, "hypothesis").unwrap_or("(no hypothesis)");
+                let summary = format!("[NEW] {}", hypothesis);
+                event_log.entries.push(MascLogEntry {
+                    timestamp: now,
+                    event_type: "experiment_created".to_string(),
+                    summary: summary.clone(),
+                });
+                update_experiment_dashboard(&summary);
+                log::info!("MASC experiment: {}", summary);
+            }
+            "experiment_assignment" => {
+                let subject_id = extract_field(&data, "subject_id").unwrap_or("?");
+                let group = extract_field(&data, "group").unwrap_or("?");
+                let summary = format!("[ASSIGN] {} -> {}", subject_id, group);
+                event_log.entries.push(MascLogEntry {
+                    timestamp: now,
+                    event_type: "experiment_assignment".to_string(),
+                    summary: summary.clone(),
+                });
+                update_experiment_dashboard(&summary);
+                log::info!("MASC experiment: {}", summary);
+            }
+            "experiment_observation" => {
+                let metric_name = extract_field(&data, "metric_name").unwrap_or("?");
+                let value = extract_field(&data, "value").unwrap_or("?");
+                let summary = format!("[OBS] {}: {}", metric_name, value);
+                event_log.entries.push(MascLogEntry {
+                    timestamp: now,
+                    event_type: "experiment_observation".to_string(),
+                    summary: summary.clone(),
+                });
+                update_experiment_dashboard(&summary);
+                log::info!("MASC experiment: {}", summary);
+            }
+            "experiment_checkpoint" => {
+                let elapsed_pct = extract_field(&data, "elapsed_pct").unwrap_or("?");
+                let p_value = extract_field(&data, "p_value").unwrap_or("?");
+                let summary = format!("[CHECK] {}% complete, p={}", elapsed_pct, p_value);
+                event_log.entries.push(MascLogEntry {
+                    timestamp: now,
+                    event_type: "experiment_checkpoint".to_string(),
+                    summary: summary.clone(),
+                });
+                update_experiment_dashboard(&summary);
+                log::info!("MASC experiment: {}", summary);
+            }
+            "experiment_concluded" => {
+                let result = extract_field(&data, "result").unwrap_or("?");
+                let effect_size = extract_field(&data, "effect_size").unwrap_or("?");
+                let summary = format!("[DONE] {}, effect={}", result, effect_size);
+                event_log.entries.push(MascLogEntry {
+                    timestamp: now,
+                    event_type: "experiment_concluded".to_string(),
+                    summary: summary.clone(),
+                });
+                update_experiment_dashboard(&summary);
+                log::info!("MASC experiment: {}", summary);
+            }
+
+            // ─── TRPG Extensions ─────────────────────────
+            "scene_transition" => {
+                let from_scene = extract_field(&data, "from_scene").unwrap_or("?");
+                let to_scene = extract_field(&data, "to_scene").unwrap_or("?");
+                let summary = format!("[SCENE] {} -> {}", from_scene, to_scene);
+                event_log.entries.push(MascLogEntry {
+                    timestamp: now,
+                    event_type: "scene_transition".to_string(),
+                    summary: summary.clone(),
+                });
+                update_monitor_events(&summary);
+                log::info!("MASC trpg: {}", summary);
+            }
+            "quest_update" => {
+                let title = extract_field(&data, "title").unwrap_or("?");
+                let status = extract_field(&data, "status").unwrap_or("?");
+                let summary = format!("[QUEST] {}: {}", title, status);
+                event_log.entries.push(MascLogEntry {
+                    timestamp: now,
+                    event_type: "quest_update".to_string(),
+                    summary: summary.clone(),
+                });
+                update_monitor_events(&summary);
+                log::info!("MASC trpg: {}", summary);
+            }
+            "world_event" => {
+                let description = extract_field(&data, "description").unwrap_or("?");
+                let severity = extract_field(&data, "severity").unwrap_or("info");
+                let summary = format!("[WORLD] {} ({})", description, severity);
+                event_log.entries.push(MascLogEntry {
+                    timestamp: now,
+                    event_type: "world_event".to_string(),
+                    summary: summary.clone(),
+                });
+                update_monitor_events(&summary);
+                log::info!("MASC trpg: {}", summary);
+            }
+
             other => {
                 log::debug!("Unhandled MASC SSE event type: {}", other);
             }
@@ -185,28 +361,25 @@ fn update_monitor_agents(_count: u32, _summary: &str) {
         let Some(doc) = web_sys::window().and_then(|w| w.document()) else {
             return;
         };
-        // Monitor panel > first monitor-card > placeholder-text
-        if let Ok(Some(el)) = doc.query_selector(
-            "#monitor-panel .monitor-card:nth-child(1) .placeholder-text",
-        ) {
+        if let Ok(Some(el)) = doc.query_selector("#monitor-agent-list") {
             let text = format!("{} agent(s) online\n{}", _count, _summary);
             el.set_text_content(Some(&text));
         }
     }
 }
 
-/// Update the Monitor panel "Room Activity" card.
+/// Update the Monitor panel "Room Activity" event feed.
 fn update_monitor_events(_summary: &str) {
     #[cfg(target_arch = "wasm32")]
     {
         let Some(doc) = web_sys::window().and_then(|w| w.document()) else {
             return;
         };
-        // Monitor panel > second monitor-card > placeholder-text
-        if let Ok(Some(el)) = doc.query_selector(
-            "#monitor-panel .monitor-card:nth-child(2) .placeholder-text",
-        ) {
-            el.set_text_content(Some(_summary));
+        if let Ok(Some(el)) = doc.query_selector("#monitor-events") {
+            let current = el.text_content().unwrap_or_default();
+            let updated = format!("{}\n{}", _summary, current);
+            let lines: Vec<&str> = updated.lines().take(50).collect();
+            el.set_text_content(Some(&lines.join("\n")));
         }
     }
 }
@@ -218,10 +391,7 @@ fn update_monitor_tasks(_count: u32, _summary: &str) {
         let Some(doc) = web_sys::window().and_then(|w| w.document()) else {
             return;
         };
-        // Monitor panel > third monitor-card > placeholder-text
-        if let Ok(Some(el)) = doc.query_selector(
-            "#monitor-panel .monitor-card:nth-child(3) .placeholder-text",
-        ) {
+        if let Ok(Some(el)) = doc.query_selector("#monitor-task-list") {
             let text = format!("{} active task(s)\n{}", _count, _summary);
             el.set_text_content(Some(&text));
         }
@@ -235,10 +405,43 @@ fn update_social_feed(_summary: &str) {
         let Some(doc) = web_sys::window().and_then(|w| w.document()) else {
             return;
         };
-        if let Ok(Some(el)) =
-            doc.query_selector("#social-panel .social-feed .placeholder-text")
-        {
-            el.set_text_content(Some(_summary));
+        if let Ok(Some(el)) = doc.query_selector("#social-feed") {
+            let current = el.text_content().unwrap_or_default();
+            let updated = format!("{}\n{}", _summary, current);
+            let lines: Vec<&str> = updated.lines().take(50).collect();
+            el.set_text_content(Some(&lines.join("\n")));
+        }
+    }
+}
+
+/// Update the Council panel deliberation feed.
+fn update_council_deliberation(_summary: &str) {
+    #[cfg(target_arch = "wasm32")]
+    {
+        let Some(doc) = web_sys::window().and_then(|w| w.document()) else {
+            return;
+        };
+        if let Ok(Some(el)) = doc.query_selector("#council-deliberation") {
+            let current = el.text_content().unwrap_or_default();
+            let updated = format!("{}\n{}", _summary, current);
+            let lines: Vec<&str> = updated.lines().take(50).collect();
+            el.set_text_content(Some(&lines.join("\n")));
+        }
+    }
+}
+
+/// Update the Experiment panel dashboard feed.
+fn update_experiment_dashboard(_summary: &str) {
+    #[cfg(target_arch = "wasm32")]
+    {
+        let Some(doc) = web_sys::window().and_then(|w| w.document()) else {
+            return;
+        };
+        if let Ok(Some(el)) = doc.query_selector("#experiment-dashboard") {
+            let current = el.text_content().unwrap_or_default();
+            let updated = format!("{}\n{}", _summary, current);
+            let lines: Vec<&str> = updated.lines().take(50).collect();
+            el.set_text_content(Some(&lines.join("\n")));
         }
     }
 }

--- a/viewer/src/sse/masc_client.rs
+++ b/viewer/src/sse/masc_client.rs
@@ -7,6 +7,7 @@ use wasm_bindgen::prelude::*;
 #[cfg(target_arch = "wasm32")]
 use web_sys::{EventSource, MessageEvent};
 
+#[cfg(target_arch = "wasm32")]
 use crate::config;
 use crate::mode::ViewerMode;
 
@@ -34,13 +35,32 @@ pub struct MascSseReceiver {
 
 /// MASC MCP SSE event types.
 /// These must match the event names emitted by the MASC MCP server.
+#[cfg(target_arch = "wasm32")]
 const MASC_SSE_EVENT_TYPES: &[&str] = &[
+    // Core events
     "broadcast",
     "heartbeat",
     "agent_joined",
     "agent_left",
     "task_update",
     "endpoint",
+    // Council (MAGI deliberation)
+    "decision_issue",
+    "decision_option",
+    "decision_argument",
+    "decision_vote",
+    "decision_consensus",
+    "decision_phase",
+    // Experiment (A/B testing)
+    "experiment_created",
+    "experiment_assignment",
+    "experiment_observation",
+    "experiment_checkpoint",
+    "experiment_concluded",
+    // TRPG extensions
+    "scene_transition",
+    "quest_update",
+    "world_event",
 ];
 
 /// OnEnter system for MASC modes (Monitor, Council, Social, Experiment).

--- a/viewer/src/theme.rs
+++ b/viewer/src/theme.rs
@@ -66,6 +66,8 @@ impl ViewerTheme {
 
     /// CSS `data-theme` attribute value applied to `<html>` element.
     /// CSS selectors: `[data-theme="dark-fantasy"] { --bg-deep: #0a0a12; ... }`
+    /// Used by `poll_theme_transition` and `apply_theme_changes` (wasm32 only).
+    #[allow(dead_code)]
     pub fn css_value(&self) -> &'static str {
         match self {
             Self::DarkFantasy => "dark-fantasy",
@@ -76,6 +78,8 @@ impl ViewerTheme {
     }
 
     /// Parse from the `<select>` option `value` attribute.
+    /// Used by `bind_single_theme_selector` closure (wasm32 only).
+    #[allow(dead_code)]
     pub fn from_css_value(s: &str) -> Option<ViewerTheme> {
         match s {
             "dark-fantasy" => Some(Self::DarkFantasy),

--- a/viewer/style.css
+++ b/viewer/style.css
@@ -995,3 +995,117 @@ body.mode-lobby #dashboard {
     max-width: 900px;
     margin: 0 auto;
 }
+
+/* ═══════════════════════════════════════════
+   ENHANCED PANEL SECTIONS (Phase 2)
+   ═══════════════════════════════════════════ */
+
+/* ─── Panel Header (shared across modes) ─── */
+
+.panel-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: 16px;
+}
+
+.panel-header h2 {
+    font-family: var(--font-display);
+    font-size: 18px;
+    color: var(--accent-primary);
+    letter-spacing: 3px;
+    text-transform: uppercase;
+}
+
+/* ─── Status Badges ──────────────────────── */
+
+.council-status,
+.experiment-status {
+    font-family: var(--font-ui);
+    font-size: 11px;
+    color: var(--text-dim);
+    background: var(--bg-card);
+    border: 1px solid var(--border-main);
+    border-radius: var(--panel-radius);
+    padding: 4px 10px;
+    letter-spacing: 1px;
+}
+
+/* ─── Feed Containers (scrollable) ───────── */
+
+.council-feed,
+.social-feed,
+.experiment-feed {
+    max-height: 80vh;
+    overflow-y: auto;
+    padding: 8px 0;
+    font-family: var(--font-ui);
+    font-size: 13px;
+    line-height: 1.8;
+    color: var(--text-primary);
+    white-space: pre-wrap;
+    word-break: break-word;
+}
+
+.council-feed::-webkit-scrollbar,
+.social-feed::-webkit-scrollbar,
+.experiment-feed::-webkit-scrollbar {
+    width: 4px;
+}
+
+.council-feed::-webkit-scrollbar-track,
+.social-feed::-webkit-scrollbar-track,
+.experiment-feed::-webkit-scrollbar-track {
+    background: var(--bg-deep);
+}
+
+.council-feed::-webkit-scrollbar-thumb,
+.social-feed::-webkit-scrollbar-thumb,
+.experiment-feed::-webkit-scrollbar-thumb {
+    background: var(--scrollbar-thumb);
+    border-radius: 2px;
+}
+
+.council-feed::-webkit-scrollbar-thumb:hover,
+.social-feed::-webkit-scrollbar-thumb:hover,
+.experiment-feed::-webkit-scrollbar-thumb:hover {
+    background: var(--scrollbar-thumb-hover);
+}
+
+/* ─── Empty State Placeholders ───────────── */
+
+.council-empty,
+.social-empty,
+.experiment-empty {
+    color: var(--text-dim);
+    font-style: italic;
+    font-size: 13px;
+    padding: 24px 0;
+    text-align: center;
+}
+
+/* ─── Monitor Event Feed ─────────────────── */
+
+.monitor-event-feed {
+    max-height: 300px;
+    overflow-y: auto;
+    font-family: var(--font-ui);
+    font-size: 12px;
+    line-height: 1.6;
+    color: var(--text-primary);
+    white-space: pre-wrap;
+    word-break: break-word;
+}
+
+.monitor-event-feed::-webkit-scrollbar {
+    width: 4px;
+}
+
+.monitor-event-feed::-webkit-scrollbar-track {
+    background: var(--bg-deep);
+}
+
+.monitor-event-feed::-webkit-scrollbar-thumb {
+    background: var(--scrollbar-thumb);
+    border-radius: 2px;
+}


### PR DESCRIPTION
## Summary

- 14 new SSE event types wired into MASC viewer bridge (Council 6, Experiment 5, TRPG Extensions 3)
- DOM panels with scrollable feeds for Monitor, Council, Social, and Experiment modes
- Release build enabled (34MB WASM, down from ~116MB dev build)
- Entity despawn race fixed (`despawn()` → `try_despawn()`)
- SSE reconnection log flooding suppressed (AtomicU32 counter — warn on first, debug on subsequent)
- Dead code warnings eliminated (7 → 0, wasm32-only function cfg gating)

## Files Changed (10)

| File | Change |
|------|--------|
| `masc_bridge.rs` | +14 match arms, 2 DOM helpers (`update_council_deliberation`, `update_experiment_dashboard`) |
| `masc_client.rs` | EventSource subscriptions expanded 6 → 20 event types |
| `index.html` | DOM panels with proper IDs for each mode |
| `style.css` | +117 lines: panel headers, status badges, scrollable feeds |
| `Trunk.toml` | `release = true` |
| `render/mod.rs` | `despawn()` → `try_despawn()` |
| `client.rs` | AtomicU32 SSE error counter |
| `config.rs` | `#[allow(dead_code)]` on wasm32-only fn |
| `mode.rs` | `#[allow(dead_code)]` on wasm32-only fns |
| `theme.rs` | `#[allow(dead_code)]` on wasm32-only fns |

## Build Verification

- `cargo check`: 0 errors, 0 warnings
- `trunk build --release`: 34MB WASM output

## Cross-Session Protocol

This PR implements the **viewer side** (Track B) of the Engine↔Viewer SSE contract. The engine side (Track A) was merged in PR #140. Event types and payloads are documented in the plan file.

## Test Plan

- [ ] `cargo check` passes with 0 warnings
- [ ] `trunk build --release` produces working WASM
- [ ] Mode cards in Lobby navigate to correct panels
- [ ] SSE events from MASC server render in corresponding mode panels
- [ ] Theme switching still works after camera spawn fix
- [ ] No console warnings on mode transitions (TRPG → Lobby etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)