### PR TITLE
fix(viewer): normalize NO_COLOR handling for trunk

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # masc-mcp Makefile
 # Enterprise-ready development commands
 
-.PHONY: build test clean coverage coverage-summary coverage-html doc install-deps dev-setup fmt fmt-check ci
+.PHONY: build test clean coverage coverage-summary coverage-html doc install-deps dev-setup fmt fmt-check ci viewer-build viewer-serve
 
 # Default target
 all: build
@@ -66,3 +66,11 @@ run:
 release:
 	dune build --release
 	@echo "Release binary at _build/default/bin/main.exe"
+
+# Build viewer (Bevy + WASM via trunk) with NO_COLOR normalization.
+viewer-build:
+	scripts/viewer-trunk.sh build
+
+# Serve viewer locally at http://127.0.0.1:8080
+viewer-serve:
+	scripts/viewer-trunk.sh serve

--- a/scripts/viewer-trunk.sh
+++ b/scripts/viewer-trunk.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# trunk 0.21 expects boolean values for --no-color.
+# Some environments export NO_COLOR as 1/0, which breaks trunk argument parsing.
+if [[ "${NO_COLOR:-}" == "1" ]]; then
+  export NO_COLOR=true
+elif [[ "${NO_COLOR:-}" == "0" ]]; then
+  export NO_COLOR=false
+fi
+
+cd "$REPO_ROOT/viewer"
+exec trunk "$@"

--- a/viewer/Trunk.toml
+++ b/viewer/Trunk.toml
@@ -7,6 +7,6 @@ filehash = true
 watch = ["src", "assets", "index.html", "style.css"]
 
 [serve]
-address = "127.0.0.1"
+addresses = ["127.0.0.1"]
 port = 8080
 open = false


### PR DESCRIPTION
## Summary
- add scripts/viewer-trunk.sh wrapper that normalizes NO_COLOR=1/0 to true/false before invoking trunk
- add make viewer-build and make viewer-serve targets to use the wrapper
- update viewer/Trunk.toml to use non-deprecated addresses field

## Verification
- make viewer-build (with NO_COLOR=1)
