### PR TITLE
fix(viewer): normalize NO_COLOR handling for trunk

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # masc-mcp Makefile
 # Enterprise-ready development commands
 
-.PHONY: build test clean coverage coverage-summary coverage-html doc install-deps dev-setup fmt fmt-check ci
+.PHONY: build test clean coverage coverage-summary coverage-html doc install-deps dev-setup fmt fmt-check ci viewer-build viewer-serve
 
 # Default target
 all: build
@@ -66,3 +66,11 @@ run:
 release:
 	dune build --release
 	@echo "Release binary at _build/default/bin/main.exe"
+
+# Build viewer (Bevy + WASM via trunk) with NO_COLOR normalization.
+viewer-build:
+	scripts/viewer-trunk.sh build
+
+# Serve viewer locally at http://127.0.0.1:8080
+viewer-serve:
+	scripts/viewer-trunk.sh serve

--- a/scripts/viewer-trunk.sh
+++ b/scripts/viewer-trunk.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# trunk 0.21 expects boolean values for --no-color.
+# Some environments export NO_COLOR as 1/0, which breaks trunk argument parsing.
+if [[ "${NO_COLOR:-}" == "1" ]]; then
+  export NO_COLOR=true
+elif [[ "${NO_COLOR:-}" == "0" ]]; then
+  export NO_COLOR=false
+fi
+
+cd "$REPO_ROOT/viewer"
+exec trunk "$@"

--- a/viewer/Trunk.toml
+++ b/viewer/Trunk.toml
@@ -7,6 +7,6 @@ filehash = true
 watch = ["src", "assets", "index.html", "style.css"]
 
 [serve]
-address = "127.0.0.1"
+addresses = ["127.0.0.1"]
 port = 8080
 open = false


### PR DESCRIPTION
## Summary\n- add  wrapper that normalizes  to  before invoking trunk\n- add scripts/viewer-trunk.sh build
2026-02-16T07:14:11.004742Z  INFO 🚀 Starting trunk 0.21.14
2026-02-16T07:14:11.005058Z  INFO 📦 starting build
2026-02-16T07:14:13.089949Z  INFO applying new distribution
2026-02-16T07:14:13.092405Z  INFO ✅ success and scripts/viewer-trunk.sh serve
2026-02-16T07:14:13.120555Z  INFO 🚀 Starting trunk 0.21.14
2026-02-16T07:14:13.125638Z  INFO 📦 starting build
2026-02-16T07:14:15.200644Z  INFO applying new distribution
2026-02-16T07:14:15.203498Z  INFO ✅ success
2026-02-16T07:14:15.204614Z  INFO 📡 serving static assets at -> /
2026-02-16T07:14:15.204661Z  INFO 📡 server listening at:
2026-02-16T07:14:15.204664Z  INFO     🏠 http://127.0.0.1:8080/
2026-02-16T07:14:15.205812Z  INFO     🏠 http://cardoc-front-local.cardoc.co.kr.:8080/
2026-02-16T07:14:15.205815Z  INFO     🏠 http://local.familynote.com.:8080/
2026-02-16T07:14:15.205817Z  INFO     🏠 http://shop-admin-local.cardoc.co.kr.:8080/
2026-02-16T07:14:15.205818Z  INFO     🏠 http://local.ssr.cardoc.co.kr.:8080/
2026-02-16T07:14:15.205820Z  INFO     🏠 http://local.kidsnote.com.:8080/
2026-02-16T07:14:15.205821Z  INFO     🏠 http://techshop-app-local.cardoc.co.kr.:8080/
2026-02-16T07:14:15.205823Z  INFO     🏠 http://local.cardoc.co.kr.:8080/
2026-02-16T07:14:15.205830Z  INFO     🏠 http://localhost.:8080/
2026-02-16T07:14:15.205833Z  INFO     🏠 http://local.classnote.com.:8080/ targets to use the wrapper\n- update  to use non-deprecated  field\n\n## Verification\n- scripts/viewer-trunk.sh build
2026-02-16T07:24:10.392618Z  INFO 🚀 Starting trunk 0.21.14
2026-02-16T07:24:10.393151Z  INFO 📦 starting build
2026-02-16T07:24:12.786370Z  INFO applying new distribution
2026-02-16T07:24:12.789042Z  INFO ✅ success (with )\n