### PR TITLE
feat(trpg): unify session bootstrap with presets + interventions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # masc-mcp Makefile
 # Enterprise-ready development commands
 
-.PHONY: build test clean coverage coverage-summary coverage-html doc install-deps dev-setup fmt fmt-check ci viewer-build viewer-serve
+.PHONY: build test clean coverage coverage-summary coverage-html doc install-deps dev-setup fmt fmt-check ci viewer-build viewer-serve harness-game-view-contract harness-trpg-session-contract harness-trpg-grimland-smoke
 
 # Default target
 all: build
@@ -74,3 +74,15 @@ viewer-build:
 # Serve viewer locally at http://127.0.0.1:8080
 viewer-serve:
 	scripts/viewer-trunk.sh serve
+
+# GAME-VIEW contract harness (decision/experiment/trpg gate checks)
+harness-game-view-contract:
+	scripts/harness_game_view_precondition.sh
+
+# TRPG session bootstrap contract harness (preset/pool/party/session/intervention)
+harness-trpg-session-contract:
+	scripts/harness_trpg_session_contract.sh
+
+# TRPG Grimland smoke workload (manual/nightly; set RUN_ROUND=1 for keeper rounds)
+harness-trpg-grimland-smoke:
+	scripts/run_trpg_grimland_smoke.sh

--- a/config/trpg/presets/character.json
+++ b/config/trpg/presets/character.json
@@ -1,0 +1,56 @@
+[
+  {
+    "id": "vowblade",
+    "name": "Kael Vowblade",
+    "archetype": "zealot-tank",
+    "persona": "Absolute duty, distrusts compromise.",
+    "traits": ["stubborn", "protective", "honor-bound"],
+    "skill_ids": ["frontline_shield", "oath_intercept", "morale_anchor"],
+    "prompt": "Prioritize oath and party survival over personal gain."
+  },
+  {
+    "id": "silkwhisper",
+    "name": "Mira Silkwhisper",
+    "archetype": "social-infiltrator",
+    "persona": "Manipulative diplomat who treats trust as currency.",
+    "traits": ["calculating", "charming", "risk-seeking"],
+    "skill_ids": ["deception_feint", "favor_broker", "shadow_entry"],
+    "prompt": "Seek leverage in every conversation and trade information strategically."
+  },
+  {
+    "id": "ironledger",
+    "name": "Brom Ironledger",
+    "archetype": "resource-optimizer",
+    "persona": "Cold utilitarian quartermaster.",
+    "traits": ["pragmatic", "frugal", "impatient"],
+    "skill_ids": ["supply_scan", "ration_shift", "logistics_patch"],
+    "prompt": "Preserve resources first; every action must have measurable return."
+  },
+  {
+    "id": "stormseer",
+    "name": "Ena Stormseer",
+    "archetype": "oracle-caster",
+    "persona": "Vision-driven mystic torn between mercy and inevitability.",
+    "traits": ["intense", "empathetic", "fatalistic"],
+    "skill_ids": ["omen_trace", "arc_flash", "ward_bloom"],
+    "prompt": "Interpret signs and push party toward long-term destiny."
+  },
+  {
+    "id": "gravehound",
+    "name": "Rook Gravehound",
+    "archetype": "hunter-assassin",
+    "persona": "Paranoid tracker who expects betrayal.",
+    "traits": ["suspicious", "precise", "vengeful"],
+    "skill_ids": ["mark_prey", "silent_route", "finisher_strike"],
+    "prompt": "Act first on threats; trust must be earned with evidence."
+  },
+  {
+    "id": "lumenfriar",
+    "name": "Sera Lumenfriar",
+    "archetype": "healer-mediator",
+    "persona": "Pacifist negotiator who absorbs team conflict.",
+    "traits": ["calm", "self-sacrificing", "idealistic"],
+    "skill_ids": ["field_mend", "truce_window", "resolve_hymn"],
+    "prompt": "Reduce bloodshed and stabilize group cohesion whenever possible."
+  }
+]

--- a/config/trpg/presets/dm.json
+++ b/config/trpg/presets/dm.json
@@ -1,0 +1,18 @@
+[
+  {
+    "id": "grim-warden",
+    "title": "Grim Warden",
+    "description": "Low-fantasy keeper focused on consequence and scarcity.",
+    "style": "strict_consequence",
+    "opening_prompt": "You are the DM of Grimland Chronicle. Keep tone grounded, costly, and political.",
+    "tags": ["grim", "political", "scarcity"]
+  },
+  {
+    "id": "mythic-weaver",
+    "title": "Mythic Weaver",
+    "description": "High-fantasy keeper that emphasizes mythic arcs and prophecy.",
+    "style": "mythic_epic",
+    "opening_prompt": "You are the DM. Emphasize fate, symbols, and ancient pacts in every scene.",
+    "tags": ["mythic", "epic", "prophecy"]
+  }
+]

--- a/config/trpg/presets/world.json
+++ b/config/trpg/presets/world.json
@@ -1,0 +1,16 @@
+[
+  {
+    "id": "grimland-chronicle",
+    "title": "Grimland Chronicle",
+    "description": "A fractured peninsula where guilds and city-states compete for survival.",
+    "intro": "Famine followed by uneasy peace. Supply lines are thin and alliances are brittle.",
+    "initial_flags": ["scarcity.high", "rumor.black-fleet", "trust.public-low"]
+  },
+  {
+    "id": "emberfall-siege",
+    "title": "Emberfall Siege",
+    "description": "Fortress-city under siege with internal factions and limited time.",
+    "intro": "Day 47 of the siege. Food reserves are measured in days, not weeks.",
+    "initial_flags": ["siege.active", "morale.volatile"]
+  }
+]

--- a/config/trpg/skills/agent_skills.json
+++ b/config/trpg/skills/agent_skills.json
@@ -1,0 +1,44 @@
+[
+  {
+    "id": "frontline_shield",
+    "name": "Frontline Shield",
+    "category": "defense",
+    "description": "Absorb incoming threat targeting nearby allies.",
+    "usage_hint": "Use during direct confrontation to prevent party collapse."
+  },
+  {
+    "id": "favor_broker",
+    "name": "Favor Broker",
+    "category": "social",
+    "description": "Trade concessions for delayed obligations.",
+    "usage_hint": "Useful before scarce-resource negotiations."
+  },
+  {
+    "id": "supply_scan",
+    "name": "Supply Scan",
+    "category": "resource",
+    "description": "Estimate resource burn and shortage horizon.",
+    "usage_hint": "Run before committing to long missions."
+  },
+  {
+    "id": "omen_trace",
+    "name": "Omen Trace",
+    "category": "arcane",
+    "description": "Infer likely next event from symbolic anomalies.",
+    "usage_hint": "Best in uncertain branching scenes."
+  },
+  {
+    "id": "mark_prey",
+    "name": "Mark Prey",
+    "category": "combat",
+    "description": "Expose target weakness for coordinated strike.",
+    "usage_hint": "Combine with another actor's attack action."
+  },
+  {
+    "id": "field_mend",
+    "name": "Field Mend",
+    "category": "support",
+    "description": "Emergency stabilization to prevent actor knockout.",
+    "usage_hint": "Use when hp trend is negative for two turns."
+  }
+]

--- a/lib/dune
+++ b/lib/dune
@@ -191,6 +191,7 @@
    tool_perpetual
    tool_keeper
    tool_trpg
+   trpg_preset_store
    trpg_engine_types
    trpg_engine_event
    trpg_engine_state_machine

--- a/lib/http_server_eio.ml
+++ b/lib/http_server_eio.ml
@@ -87,11 +87,18 @@ end
 
 (** Simple response helpers *)
 module Response = struct
+  let cors_headers = [
+    ("access-control-allow-origin", "*");
+    ("access-control-allow-methods", "GET, POST, PUT, DELETE, OPTIONS");
+    ("access-control-allow-headers", "Content-Type, Accept, Mcp-Session-Id, Mcp-Protocol-Version, Last-Event-Id");
+    ("access-control-expose-headers", "Mcp-Session-Id, Mcp-Protocol-Version");
+  ]
+
   let text ?(status = `OK) body reqd =
-    let headers = Httpun.Headers.of_list [
+    let headers = Httpun.Headers.of_list ([
       ("content-type", "text/plain; charset=utf-8");
       ("content-length", string_of_int (String.length body));
-    ] in
+    ] @ cors_headers) in
     let response = Httpun.Response.create ~headers status in
     Httpun.Reqd.respond_with_string reqd response body
 
@@ -99,7 +106,7 @@ module Response = struct
     let base_headers = [
       ("content-type", "text/html; charset=utf-8");
       ("content-length", string_of_int (String.length body));
-    ] in
+    ] @ cors_headers in
     let response = Httpun.Response.create
       ~headers:(Httpun.Headers.of_list (base_headers @ headers))
       status
@@ -110,7 +117,7 @@ module Response = struct
     let base_headers = [
       ("content-type", content_type);
       ("content-length", string_of_int (String.length body));
-    ] in
+    ] @ cors_headers in
     let response = Httpun.Response.create
       ~headers:(Httpun.Headers.of_list (base_headers @ headers))
       status
@@ -142,7 +149,7 @@ module Response = struct
       ("content-type", "application/json; charset=utf-8");
       ("content-length", string_of_int (String.length final_body));
       ("vary", "Accept-Encoding");
-    ] in
+    ] @ cors_headers in
     let headers = match encoding with
       | Some enc -> ("content-encoding", enc) :: base_headers
       | None -> base_headers
@@ -153,10 +160,10 @@ module Response = struct
 
   (** Legacy JSON response without compression check (backwards compatible) *)
   let json_raw ?(status = `OK) body reqd =
-    let headers = Httpun.Headers.of_list [
+    let headers = Httpun.Headers.of_list ([
       ("content-type", "application/json; charset=utf-8");
       ("content-length", string_of_int (String.length body));
-    ] in
+    ] @ cors_headers) in
     let response = Httpun.Response.create ~headers status in
     Httpun.Reqd.respond_with_string reqd response body
 
@@ -192,7 +199,7 @@ module Response = struct
           ("etag", etag_value);
           ("cache-control", "no-cache");
           ("vary", "Accept-Encoding");
-        ] in
+        ] @ cors_headers in
         let headers = match encoding with
           | Some enc -> ("content-encoding", enc) :: base_headers
           | None -> base_headers

--- a/lib/http_server_h2.ml
+++ b/lib/http_server_h2.ml
@@ -40,6 +40,13 @@ let request_of_reqd reqd =
 
 (** Simple response helpers - H2 streaming API *)
 module Response = struct
+  let cors_headers = [
+    ("access-control-allow-origin", "*");
+    ("access-control-allow-methods", "GET, POST, PUT, DELETE, OPTIONS");
+    ("access-control-allow-headers", "Content-Type, Accept, Mcp-Session-Id, Mcp-Protocol-Version, Last-Event-Id");
+    ("access-control-expose-headers", "Mcp-Session-Id, Mcp-Protocol-Version");
+  ]
+
   (** Send a complete response body *)
   let send_body reqd response body =
     (* H2 API: respond_with_streaming returns Body.Writer.t directly
@@ -49,10 +56,10 @@ module Response = struct
     H2.Body.Writer.close writer
 
   let text ?(status = `OK) body reqd =
-    let headers = H2.Headers.of_list [
+    let headers = H2.Headers.of_list ([
       ("content-type", "text/plain; charset=utf-8");
       ("content-length", string_of_int (String.length body));
-    ] in
+    ] @ cors_headers) in
     let response = H2.Response.create ~headers status in
     send_body reqd response body
 
@@ -60,7 +67,7 @@ module Response = struct
     let base_headers = [
       ("content-type", "text/html; charset=utf-8");
       ("content-length", string_of_int (String.length body));
-    ] in
+    ] @ cors_headers in
     let response = H2.Response.create
       ~headers:(H2.Headers.of_list (base_headers @ headers))
       status
@@ -68,10 +75,10 @@ module Response = struct
     send_body reqd response body
 
   let json ?(status = `OK) body reqd =
-    let headers = H2.Headers.of_list [
+    let headers = H2.Headers.of_list ([
       ("content-type", "application/json; charset=utf-8");
       ("content-length", string_of_int (String.length body));
-    ] in
+    ] @ cors_headers) in
     let response = H2.Response.create ~headers status in
     send_body reqd response body
 
@@ -89,8 +96,7 @@ module Response = struct
     let base_headers = [
       ("content-type", "text/event-stream");
       ("cache-control", "no-cache");
-      ("access-control-allow-origin", "*");
-    ] in
+    ] @ cors_headers in
     let all_headers = H2.Headers.of_list (base_headers @ headers) in
     let response = H2.Response.create ~headers:all_headers `OK in
     (* H2.Reqd.respond_with_streaming returns Body.Writer.t
@@ -101,7 +107,7 @@ module Response = struct
     let base_headers = [
       ("content-type", content_type);
       ("content-length", string_of_int (String.length body));
-    ] in
+    ] @ cors_headers in
     let response = H2.Response.create
       ~headers:(H2.Headers.of_list (base_headers @ headers))
       status

--- a/lib/masc_mcp.ml
+++ b/lib/masc_mcp.ml
@@ -184,6 +184,7 @@ module Perpetual_loop = Perpetual_loop
 module Tool_perpetual = Tool_perpetual
 module Tool_keeper = Tool_keeper
 module Tool_trpg = Tool_trpg
+module Trpg_preset_store = Trpg_preset_store
 module Trpg_engine_types = Trpg_engine_types
 module Trpg_engine_event = Trpg_engine_event
 module Trpg_engine_state_machine = Trpg_engine_state_machine

--- a/lib/tool_protocol_game_view.ml
+++ b/lib/tool_protocol_game_view.ml
@@ -950,6 +950,11 @@ let legacy_alias_to_canonical = function
   | "masc_trpg_turn_advance" -> Some "trpg.turn.advance"
   | "masc_trpg_stream" -> Some "trpg.stream.read"
   | "masc_trpg_round_run" -> Some "trpg.round.run"
+  | "masc_trpg_preset_list" -> Some "trpg.preset.list"
+  | "masc_trpg_pool_generate" -> Some "trpg.pool.generate"
+  | "masc_trpg_party_select" -> Some "trpg.party.select"
+  | "masc_trpg_session_start" -> Some "trpg.session.start"
+  | "masc_trpg_intervention_submit" -> Some "trpg.intervention.submit"
   | "masc_trpg_scene_transition" -> Some "trpg.scene.transition"
   | "masc_trpg_quest_update" -> Some "trpg.quest.update"
   | "masc_trpg_world_event" -> Some "trpg.world.event"
@@ -1075,6 +1080,26 @@ let dispatch (ctx : context) ~name ~args : tool_result option =
         (match handle_trpg_world_query ctx ~canonical_tool:name args with
         | Ok r -> r
         | Error e -> e)
+  | "trpg.preset.list" ->
+      Some
+        (handle_trpg_canonical ctx ~canonical_tool:name
+           ~legacy_name:"masc_trpg_preset_list" args)
+  | "trpg.pool.generate" ->
+      Some
+        (handle_trpg_canonical ctx ~canonical_tool:name
+           ~legacy_name:"masc_trpg_pool_generate" args)
+  | "trpg.party.select" ->
+      Some
+        (handle_trpg_canonical ctx ~canonical_tool:name
+           ~legacy_name:"masc_trpg_party_select" args)
+  | "trpg.session.start" ->
+      Some
+        (handle_trpg_canonical ctx ~canonical_tool:name
+           ~legacy_name:"masc_trpg_session_start" args)
+  | "trpg.intervention.submit" ->
+      Some
+        (handle_trpg_canonical ctx ~canonical_tool:name
+           ~legacy_name:"masc_trpg_intervention_submit" args)
   | "trpg.dice.roll" ->
       Some (handle_trpg_canonical ctx ~canonical_tool:name ~legacy_name:"masc_trpg_dice_roll" args)
   | "trpg.turn.advance" ->
@@ -1269,6 +1294,64 @@ let schemas : Types.tool_schema list =
            ("room_id", string_schema);
            ("after_seq", int_schema);
            ("event_limit", int_schema);
+         ]);
+    schema "trpg.preset.list"
+      "Canonical alias of masc_trpg_preset_list."
+      (object_schema
+         [
+           ("include_characters", bool_schema);
+           ("include_skills", bool_schema);
+         ]);
+    schema "trpg.pool.generate"
+      "Canonical alias of masc_trpg_pool_generate."
+      (object_schema
+         ~required:[ "session_id" ]
+         [
+           ("session_id", string_schema);
+           ("world_preset_id", string_schema);
+           ("dm_preset_id", string_schema);
+           ("pool_size", int_schema);
+           ("party_size", int_schema);
+           ("seed", int_schema);
+         ]);
+    schema "trpg.party.select"
+      "Canonical alias of masc_trpg_party_select."
+      (object_schema
+         ~required:[ "session_id"; "pool"; "selected_player_ids" ]
+         [
+           ("session_id", string_schema);
+           ("room_id", string_schema);
+           ("pool", array_of (object_schema []));
+           ("selected_player_ids", array_of string_schema);
+         ]);
+    schema "trpg.session.start"
+      "Canonical alias of masc_trpg_session_start."
+      (object_schema
+         ~required:[ "session_id" ]
+         [
+           ("session_id", string_schema);
+           ("room_id", string_schema);
+           ("dm_preset_id", string_schema);
+           ("world_preset_id", string_schema);
+           ("dm_keeper", string_schema);
+           ("party", array_of (object_schema []));
+           ("phase", string_schema);
+           ("rule_module", string_schema);
+           ("force", bool_schema);
+         ]);
+    schema "trpg.intervention.submit"
+      "Canonical alias of masc_trpg_intervention_submit."
+      (object_schema
+         ~required:[ "room_id"; "intervention_type" ]
+         [
+           ("room_id", string_schema);
+           ("session_id", string_schema);
+           ("intervention_type", string_schema);
+           ("scope", string_schema);
+           ("target_actor", string_schema);
+           ("expected_turn", int_schema);
+           ("reason", string_schema);
+           ("payload", object_schema []);
          ]);
     schema "trpg.dice.roll"
       "Canonical alias of masc_trpg_dice_roll."

--- a/lib/tool_trpg.ml
+++ b/lib/tool_trpg.ml
@@ -5,6 +5,11 @@
     - masc_trpg_turn_advance
     - masc_trpg_stream
     - masc_trpg_round_run
+    - masc_trpg_preset_list
+    - masc_trpg_pool_generate
+    - masc_trpg_party_select
+    - masc_trpg_session_start
+    - masc_trpg_intervention_submit
 *)
 
 open Yojson.Safe.Util
@@ -24,6 +29,31 @@ type context = {
 type trpg_role = [ `Dm | `Player ]
 
 let role_to_string = function `Dm -> "dm" | `Player -> "player"
+
+type pool_member = {
+  actor_id : string;
+  name : string;
+  archetype : string;
+  persona : string;
+  traits : string list;
+  skill_ids : string list;
+  keeper_name : string option;
+  source_preset_id : string;
+}
+
+let pool_member_to_yojson (m : pool_member) : Yojson.Safe.t =
+  `Assoc
+    [
+      ("actor_id", `String m.actor_id);
+      ("name", `String m.name);
+      ("archetype", `String m.archetype);
+      ("persona", `String m.persona);
+      ("traits", `List (List.map (fun s -> `String s) m.traits));
+      ("skill_ids", `List (List.map (fun s -> `String s) m.skill_ids));
+      ( "keeper_name",
+        Option.fold ~none:`Null ~some:(fun s -> `String s) m.keeper_name );
+      ("source_preset_id", `String m.source_preset_id);
+    ]
 
 let schemas : Types.tool_schema list =
   [
@@ -250,6 +280,115 @@ let schemas : Types.tool_schema list =
                 [ `String "room_id"; `String "event_type"; `String "description" ] );
           ];
     };
+    {
+      name = "masc_trpg_preset_list";
+      description =
+        "List TRPG DM/world/character presets and game-usable agent skills from repo JSON SSOT.";
+      input_schema =
+        `Assoc
+          [
+            ("type", `String "object");
+            ( "properties",
+              `Assoc
+                [
+                  ("include_characters", `Assoc [ ("type", `String "boolean") ]);
+                  ("include_skills", `Assoc [ ("type", `String "boolean") ]);
+                ] );
+          ];
+    };
+    {
+      name = "masc_trpg_pool_generate";
+      description =
+        "Generate a playable character pool from presets. \
+         Required: session_id. Optional: world_preset_id, dm_preset_id, pool_size, party_size, seed.";
+      input_schema =
+        `Assoc
+          [
+            ("type", `String "object");
+            ( "properties",
+              `Assoc
+                [
+                  ("session_id", `Assoc [ ("type", `String "string") ]);
+                  ("world_preset_id", `Assoc [ ("type", `String "string") ]);
+                  ("dm_preset_id", `Assoc [ ("type", `String "string") ]);
+                  ("pool_size", `Assoc [ ("type", `String "integer") ]);
+                  ("party_size", `Assoc [ ("type", `String "integer") ]);
+                  ("seed", `Assoc [ ("type", `String "integer") ]);
+                ] );
+            ("required", `List [ `String "session_id" ]);
+          ];
+    };
+    {
+      name = "masc_trpg_party_select";
+      description =
+        "Select a party from generated pool and persist party.selected event. \
+         Required: session_id, pool, selected_player_ids.";
+      input_schema =
+        `Assoc
+          [
+            ("type", `String "object");
+            ( "properties",
+              `Assoc
+                [
+                  ("session_id", `Assoc [ ("type", `String "string") ]);
+                  ("room_id", `Assoc [ ("type", `String "string") ]);
+                  ( "pool",
+                    `Assoc [ ("type", `String "array"); ("items", `Assoc [ ("type", `String "object") ]) ] );
+                  ("selected_player_ids", `Assoc [ ("type", `String "array"); ("items", `Assoc [ ("type", `String "string") ]) ]);
+                ] );
+            ( "required",
+              `List [ `String "session_id"; `String "pool"; `String "selected_player_ids" ] );
+          ];
+    };
+    {
+      name = "masc_trpg_session_start";
+      description =
+        "Start a TRPG session from DM/world presets and selected party. \
+         Required: session_id. Optional: room_id, dm/world preset ids, dm_keeper, party, phase.";
+      input_schema =
+        `Assoc
+          [
+            ("type", `String "object");
+            ( "properties",
+              `Assoc
+                [
+                  ("session_id", `Assoc [ ("type", `String "string") ]);
+                  ("room_id", `Assoc [ ("type", `String "string") ]);
+                  ("dm_preset_id", `Assoc [ ("type", `String "string") ]);
+                  ("world_preset_id", `Assoc [ ("type", `String "string") ]);
+                  ("dm_keeper", `Assoc [ ("type", `String "string") ]);
+                  ("party", `Assoc [ ("type", `String "array"); ("items", `Assoc [ ("type", `String "object") ]) ]);
+                  ("phase", `Assoc [ ("type", `String "string") ]);
+                  ("rule_module", `Assoc [ ("type", `String "string") ]);
+                  ("force", `Assoc [ ("type", `String "boolean") ]);
+                ] );
+            ("required", `List [ `String "session_id" ]);
+          ];
+    };
+    {
+      name = "masc_trpg_intervention_submit";
+      description =
+        "Submit a human intervention to apply before next AI round run. \
+         Required: room_id, intervention_type. Optional: scope, target_actor, expected_turn, payload.";
+      input_schema =
+        `Assoc
+          [
+            ("type", `String "object");
+            ( "properties",
+              `Assoc
+                [
+                  ("room_id", `Assoc [ ("type", `String "string") ]);
+                  ("session_id", `Assoc [ ("type", `String "string") ]);
+                  ("intervention_type", `Assoc [ ("type", `String "string") ]);
+                  ("scope", `Assoc [ ("type", `String "string") ]);
+                  ("target_actor", `Assoc [ ("type", `String "string") ]);
+                  ("expected_turn", `Assoc [ ("type", `String "integer") ]);
+                  ("reason", `Assoc [ ("type", `String "string") ]);
+                  ("payload", `Assoc [ ("type", `String "object") ]);
+                ] );
+            ("required", `List [ `String "room_id"; `String "intervention_type" ]);
+          ];
+    };
   ]
 
 let ok_json json = (true, Yojson.Safe.to_string json)
@@ -304,6 +443,61 @@ let get_required_assoc args key =
   | `Assoc fields -> Ok fields
   | `Null -> Error (Printf.sprintf "%s is required" key)
   | _ -> Error (Printf.sprintf "%s must be object" key)
+
+let get_required_list args key =
+  match args |> member key with
+  | `List xs -> Ok xs
+  | `Null -> Error (Printf.sprintf "%s is required" key)
+  | _ -> Error (Printf.sprintf "%s must be array" key)
+
+let get_optional_bool args key ~default =
+  match args |> member key with
+  | `Bool b -> Ok b
+  | `Null -> Ok default
+  | _ -> Error (Printf.sprintf "%s must be boolean" key)
+
+let get_optional_object args key =
+  match args |> member key with
+  | `Assoc _ as obj -> Ok (Some obj)
+  | `Null -> Ok None
+  | _ -> Error (Printf.sprintf "%s must be object" key)
+
+let get_string_list_from_json = function
+  | `List xs ->
+      Ok
+        (List.filter_map
+           (function
+             | `String s ->
+                 let s = String.trim s in
+                 if s = "" then None else Some s
+             | _ -> None)
+           xs)
+  | _ -> Error "value must be string array"
+
+let dedupe_keep_order xs =
+  let rec loop seen acc = function
+    | [] -> List.rev acc
+    | x :: tl ->
+        if List.mem x seen then loop seen acc tl
+        else loop (x :: seen) (x :: acc) tl
+  in
+  loop [] [] xs
+
+let sanitize_room_id (s : string) =
+  let s = String.trim s in
+  let b = Bytes.of_string s in
+  for i = 0 to Bytes.length b - 1 do
+    let c = Bytes.get b i in
+    let valid =
+      (c >= 'a' && c <= 'z')
+      || (c >= 'A' && c <= 'Z')
+      || (c >= '0' && c <= '9')
+      || c = '.' || c = '_' || c = '-'
+    in
+    if not valid then Bytes.set b i '-'
+  done;
+  let out = Bytes.to_string b in
+  if out = "" then "session-default" else out
 
 let validate_rule_module = function
   | "" | "dnd5e-lite" -> Ok ()
@@ -430,6 +624,152 @@ let build_keeper_prompt ~room_id ~phase ~turn ~role ~actor_id ~state_json =
     role_s
     actor_id
     (Yojson.Safe.pretty_to_string state_json)
+
+let room_id_for_session session_id =
+  sanitize_room_id (Printf.sprintf "session-%s" session_id)
+
+let json_of_strings xs = `List (List.map (fun s -> `String s) xs)
+
+let pool_member_of_json (json : Yojson.Safe.t) :
+    (pool_member, string) Stdlib.result =
+  let ( let* ) = Result.bind in
+  let string_list_field json key =
+    match json |> member key with
+    | `List _ as value -> get_string_list_from_json value
+    | `Null -> Ok []
+    | _ -> Error (Printf.sprintf "pool item.%s must be string array" key)
+  in
+  let as_assoc =
+    match json with
+    | `Assoc _ -> Ok json
+    | _ -> Error "pool item must be object"
+  in
+  let* json = as_assoc in
+  let* actor_id =
+    match json |> member "actor_id" with
+    | `String s when String.trim s <> "" -> Ok (String.trim s)
+    | _ -> Error "pool item.actor_id is required"
+  in
+  let* name =
+    match json |> member "name" with
+    | `String s when String.trim s <> "" -> Ok (String.trim s)
+    | _ -> Error (Printf.sprintf "pool item.name is required for actor_id=%s" actor_id)
+  in
+  let archetype =
+    match json |> member "archetype" with
+    | `String s when String.trim s <> "" -> String.trim s
+    | _ -> "unknown"
+  in
+  let persona =
+    match json |> member "persona" with
+    | `String s -> s
+    | _ -> ""
+  in
+  let* traits = string_list_field json "traits" in
+  let* skill_ids = string_list_field json "skill_ids" in
+  let keeper_name = json |> member "keeper_name" |> to_string_option in
+  let source_preset_id =
+    match json |> member "source_preset_id" with
+    | `String s when String.trim s <> "" -> String.trim s
+    | _ -> actor_id
+  in
+  Ok
+    {
+      actor_id;
+      name;
+      archetype;
+      persona;
+      traits;
+      skill_ids;
+      keeper_name;
+      source_preset_id;
+    }
+
+let pool_members_of_json_list xs =
+  let ( let* ) = Result.bind in
+  let rec loop acc = function
+    | [] -> Ok (List.rev acc)
+    | x :: tl ->
+        let* m = pool_member_of_json x in
+        loop (m :: acc) tl
+  in
+  let* members = loop [] xs in
+  Ok
+    (members
+    |> List.sort (fun a b -> String.compare a.actor_id b.actor_id))
+
+let party_member_config (m : pool_member) : Yojson.Safe.t =
+  `Assoc
+    [
+      ("name", `String m.name);
+      ("archetype", `String m.archetype);
+      ("persona", `String m.persona);
+      ("traits", json_of_strings m.traits);
+      ("skills", json_of_strings m.skill_ids);
+      ("hp", `Int 10);
+      ("max_hp", `Int 10);
+      ("alive", `Bool true);
+      ("inventory", `List []);
+    ]
+
+let party_config (members : pool_member list) : Yojson.Safe.t =
+  `Assoc
+    (List.map
+       (fun (m : pool_member) -> (m.actor_id, party_member_config m))
+       members)
+
+let world_config ~(preset : Trpg_preset_store.world_preset) : Yojson.Safe.t =
+  `Assoc
+    [
+      ("preset_id", `String preset.id);
+      ("title", `String preset.title);
+      ("description", `String preset.description);
+      ("intro", `String preset.intro);
+      ("story_flags", json_of_strings preset.initial_flags);
+    ]
+
+let dm_config ~(preset : Trpg_preset_store.dm_preset) ~dm_keeper : Yojson.Safe.t =
+  `Assoc
+    [
+      ("preset_id", `String preset.id);
+      ("title", `String preset.title);
+      ("style", `String preset.style);
+      ("opening_prompt", `String preset.opening_prompt);
+      ("tags", json_of_strings preset.tags);
+      ("keeper_name", `String dm_keeper);
+    ]
+
+let derive_pending_interventions (events : Trpg_engine_event.t list) :
+    (int * string * Yojson.Safe.t) list =
+  let submitted = ref [] in
+  let applied = Hashtbl.create 16 in
+  List.iter
+    (fun (ev : Trpg_engine_event.t) ->
+      match ev.event_type with
+      | Trpg_engine_event.Intervention_submitted -> (
+          match ev.payload |> member "intervention_id" with
+          | `String intervention_id when String.trim intervention_id <> "" ->
+              submitted := (ev.seq, intervention_id, ev.payload) :: !submitted
+          | _ -> ())
+      | Trpg_engine_event.Intervention_applied -> (
+          match ev.payload |> member "intervention_id" with
+          | `String intervention_id when String.trim intervention_id <> "" ->
+              Hashtbl.replace applied intervention_id true
+          | _ -> ())
+      | _ -> ())
+    events;
+  !submitted
+  |> List.filter (fun (_, intervention_id, _) ->
+         not (Hashtbl.mem applied intervention_id))
+  |> List.sort (fun (a, _, _) (b, _, _) -> Int.compare a b)
+
+let inject_interventions_into_state state interventions =
+  match state with
+  | `Assoc fields ->
+      `Assoc
+        (("interventions", `List interventions)
+        :: List.filter (fun (k, _) -> k <> "interventions") fields)
+  | _ -> state
 
 let call_keeper ctx ~name ~message ~timeout_sec =
   match ctx.keeper_call with
@@ -723,6 +1063,474 @@ let handle_stream ctx args : result =
   in
   match result_json with Ok j -> ok_json j | Error e -> err e
 
+let resolve_dm_preset catalog dm_preset_id_opt =
+  match dm_preset_id_opt with
+  | Some preset_id -> (
+      match Trpg_preset_store.find_dm_preset catalog ~id:preset_id with
+      | Some preset -> Ok preset
+      | None -> Error (Printf.sprintf "unknown dm_preset_id: %s" preset_id))
+  | None -> (
+      match catalog.Trpg_preset_store.dm_presets with
+      | head :: _ -> Ok head
+      | [] -> Error "no dm presets available")
+
+let resolve_world_preset catalog world_preset_id_opt =
+  match world_preset_id_opt with
+  | Some preset_id -> (
+      match Trpg_preset_store.find_world_preset catalog ~id:preset_id with
+      | Some preset -> Ok preset
+      | None -> Error (Printf.sprintf "unknown world_preset_id: %s" preset_id))
+  | None -> (
+      match catalog.Trpg_preset_store.world_presets with
+      | head :: _ -> Ok head
+      | [] -> Error "no world presets available")
+
+let shuffle_with_seed ~seed xs =
+  let arr = Array.of_list xs in
+  let rng = Random.State.make [| seed |] in
+  for i = Array.length arr - 1 downto 1 do
+    let j = Random.State.int rng (i + 1) in
+    let tmp = arr.(i) in
+    arr.(i) <- arr.(j);
+    arr.(j) <- tmp
+  done;
+  Array.to_list arr
+
+let generate_pool_members ~catalog ~pool_size ~seed =
+  let templates =
+    shuffle_with_seed ~seed catalog.Trpg_preset_store.character_presets
+  in
+  match templates with
+  | [] -> Error "no character presets available"
+  | _ ->
+      let rec build idx acc =
+        if idx > pool_size then List.rev acc
+        else
+          let base =
+            List.nth templates ((idx - 1) mod List.length templates)
+          in
+          let actor_id = Printf.sprintf "p%02d" idx in
+          let member : pool_member =
+            {
+              actor_id;
+              name = base.name;
+              archetype = base.archetype;
+              persona = base.persona;
+              traits = base.traits;
+              skill_ids = base.skill_ids;
+              keeper_name = None;
+              source_preset_id = base.id;
+            }
+          in
+          build (idx + 1) (member :: acc)
+      in
+      Ok (build 1 [])
+
+let default_party_from_catalog catalog party_size =
+  let capped = max 1 (min party_size 8) in
+  match generate_pool_members ~catalog ~pool_size:capped ~seed:42 with
+  | Ok members -> members
+  | Error _ -> []
+
+let assoc_put key value fields =
+  (key, value) :: List.remove_assoc key fields
+
+let append_pending_interventions ~base_dir ~room_id ~phase ~turn =
+  let ( let* ) = Result.bind in
+  let* events = Trpg_engine_store_sqlite.read_events ~base_dir ~room_id in
+  let pending = derive_pending_interventions events in
+  let rec loop applied_payloads applied_events = function
+    | [] -> Ok (List.rev applied_payloads, List.rev applied_events)
+    | (_, intervention_id, payload) :: tl ->
+        let applied_payload =
+          match payload with
+          | `Assoc fields ->
+              `Assoc
+                (fields
+                |> assoc_put "status" (`String "applied")
+                |> assoc_put "applied_phase" (`String phase)
+                |> assoc_put "applied_turn" (`Int turn)
+                |> assoc_put "intervention_id" (`String intervention_id))
+          | _ ->
+              `Assoc
+                [
+                  ("intervention_id", `String intervention_id);
+                  ("status", `String "applied");
+                  ("applied_phase", `String phase);
+                  ("applied_turn", `Int turn);
+                ]
+        in
+        let* ev =
+          append_event ~base_dir ~room_id
+            ~event_type:Trpg_engine_event.Intervention_applied
+            ~payload:applied_payload ()
+        in
+        loop (applied_payload :: applied_payloads) (ev :: applied_events) tl
+  in
+  loop [] [] pending
+
+let handle_preset_list ctx args : result =
+  let ( let* ) = Result.bind in
+  let include_characters =
+    get_optional_bool args "include_characters" ~default:true
+  in
+  let include_skills = get_optional_bool args "include_skills" ~default:true in
+  let result_json =
+    let* include_characters = include_characters in
+    let* include_skills = include_skills in
+    let* catalog = Trpg_preset_store.load_catalog ~base_dir:ctx.config.base_path in
+    let payload =
+      `Assoc
+        [
+          ("ok", `Bool true);
+          ( "dm_presets",
+            `List
+              (List.map
+                 Trpg_preset_store.dm_preset_to_yojson
+                 catalog.dm_presets) );
+          ( "world_presets",
+            `List
+              (List.map
+                 Trpg_preset_store.world_preset_to_yojson
+                 catalog.world_presets) );
+          ( "character_presets",
+            if include_characters then
+              `List
+                (List.map
+                   Trpg_preset_store.character_preset_to_yojson
+                   catalog.character_presets)
+            else `List [] );
+          ( "skills",
+            if include_skills then
+              `List
+                (List.map
+                   Trpg_preset_store.skill_to_yojson
+                   catalog.skills)
+            else `List [] );
+        ]
+    in
+    Ok payload
+  in
+  match result_json with Ok j -> ok_json j | Error e -> err e
+
+let handle_pool_generate ctx args : result =
+  let ( let* ) = Result.bind in
+  let result_json =
+    let* session_id = get_required_string args "session_id" in
+    let* world_preset_id = get_optional_string args "world_preset_id" in
+    let* dm_preset_id = get_optional_string args "dm_preset_id" in
+    let* pool_size_opt = get_optional_int args "pool_size" in
+    let* party_size_opt = get_optional_int args "party_size" in
+    let* seed_opt = get_optional_int args "seed" in
+    let pool_size = Option.value ~default:8 pool_size_opt |> max 2 |> min 16 in
+    let party_size =
+      Option.value ~default:4 party_size_opt
+      |> max 1 |> min 8 |> min pool_size
+    in
+    let seed = Option.value ~default:42 seed_opt in
+    let* catalog = Trpg_preset_store.load_catalog ~base_dir:ctx.config.base_path in
+    let* dm_preset = resolve_dm_preset catalog dm_preset_id in
+    let* world_preset = resolve_world_preset catalog world_preset_id in
+    let* pool = generate_pool_members ~catalog ~pool_size ~seed in
+    let suggested =
+      pool
+      |> List.map (fun (m : pool_member) -> m.actor_id)
+      |> List.filteri (fun i _ -> i < party_size)
+    in
+    let pool_id =
+      let material =
+        Printf.sprintf "%s|%s|%s|%d|%d|%d" session_id dm_preset.id world_preset.id
+          pool_size party_size seed
+      in
+      "pool-" ^ Digest.to_hex (Digest.string material)
+    in
+    Ok
+      (`Assoc
+        [
+          ("ok", `Bool true);
+          ("session_id", `String session_id);
+          ("pool_id", `String pool_id);
+          ("dm_preset", Trpg_preset_store.dm_preset_to_yojson dm_preset);
+          ("world_preset", Trpg_preset_store.world_preset_to_yojson world_preset);
+          ("pool", `List (List.map pool_member_to_yojson pool));
+          ("suggested_party_ids", json_of_strings suggested);
+          ("party_size", `Int party_size);
+          ("pool_size", `Int pool_size);
+        ])
+  in
+  match result_json with Ok j -> ok_json j | Error e -> err e
+
+let handle_party_select ctx args : result =
+  let ( let* ) = Result.bind in
+  let base_dir = ctx.config.base_path in
+  let result_json =
+    let* session_id = get_required_string args "session_id" in
+    let* room_id_opt = get_optional_string args "room_id" in
+    let room_id =
+      room_id_opt |> Option.value ~default:(room_id_for_session session_id)
+    in
+    let* pool_json = get_required_list args "pool" in
+    let* selected_ids_json = get_required_list args "selected_player_ids" in
+    let* pool = pool_members_of_json_list pool_json in
+    let* selected_ids = get_string_list_from_json (`List selected_ids_json) in
+    let selected_ids = dedupe_keep_order selected_ids in
+    if selected_ids = [] then Error "selected_player_ids must not be empty"
+    else
+      let pool_by_id : (string, pool_member) Hashtbl.t = Hashtbl.create 32 in
+      List.iter
+        (fun (m : pool_member) -> Hashtbl.replace pool_by_id m.actor_id m)
+        pool;
+      let rec pick acc = function
+        | [] -> Ok (List.rev acc)
+        | actor_id :: tl -> (
+            match Hashtbl.find_opt pool_by_id actor_id with
+            | Some m -> pick (m :: acc) tl
+            | None ->
+                Error
+                  (Printf.sprintf
+                     "selected_player_ids contains unknown actor_id: %s"
+                     actor_id))
+      in
+      let* selected_party = pick [] selected_ids in
+      let payload =
+        `Assoc
+          [
+            ("session_id", `String session_id);
+            ("room_id", `String room_id);
+            ("selected_player_ids", json_of_strings selected_ids);
+            ("party", `List (List.map pool_member_to_yojson selected_party));
+          ]
+      in
+      let* event =
+        append_event ~base_dir ~room_id
+          ~event_type:Trpg_engine_event.Party_selected ~payload ()
+      in
+      Ok
+        (`Assoc
+          [
+            ("ok", `Bool true);
+            ("room_id", `String room_id);
+            ("session_id", `String session_id);
+            ("party_count", `Int (List.length selected_party));
+            ("party", `List (List.map pool_member_to_yojson selected_party));
+            ("event", Trpg_engine_event.to_yojson event);
+          ])
+  in
+  match result_json with Ok j -> ok_json j | Error e -> err e
+
+let handle_session_start ctx args : result =
+  let ( let* ) = Result.bind in
+  let base_dir = ctx.config.base_path in
+  let result_json =
+    let* session_id = get_required_string args "session_id" in
+    let* room_id_opt = get_optional_string args "room_id" in
+    let room_id =
+      room_id_opt |> Option.value ~default:(room_id_for_session session_id)
+    in
+    let* dm_preset_id = get_optional_string args "dm_preset_id" in
+    let* world_preset_id = get_optional_string args "world_preset_id" in
+    let* dm_keeper_opt = get_optional_string args "dm_keeper" in
+    let dm_keeper = dm_keeper_opt |> Option.value ~default:"dm-keeper" in
+    let* phase_opt = get_optional_string args "phase" in
+    let phase = phase_opt |> Option.value ~default:"briefing" in
+    let* rule_opt = get_optional_string args "rule_module" in
+    let rule_module = Option.value ~default:"dnd5e-lite" rule_opt in
+    let* force = get_optional_bool args "force" ~default:false in
+    let* () =
+      match Trpg_engine_types.phase_of_string phase with
+      | Ok _ -> Ok ()
+      | Error e -> Error e
+    in
+    let* () = validate_rule_module rule_module in
+    let* catalog = Trpg_preset_store.load_catalog ~base_dir in
+    let* dm_preset = resolve_dm_preset catalog dm_preset_id in
+    let* world_preset = resolve_world_preset catalog world_preset_id in
+    let* party =
+      match args |> member "party" with
+      | `List xs when xs <> [] -> pool_members_of_json_list xs
+      | _ ->
+          let fallback_party = default_party_from_catalog catalog 4 in
+          if fallback_party = [] then Error "party is required (no character presets available)"
+          else Ok fallback_party
+    in
+    let* existing_events =
+      Trpg_engine_store_sqlite.read_events ~base_dir ~room_id
+    in
+    let has_existing_bootstrap_event =
+      List.exists
+        (fun (ev : Trpg_engine_event.t) ->
+          match ev.event_type with
+          | Trpg_engine_event.Room_created
+          | Trpg_engine_event.Room_started
+          | Trpg_engine_event.Session_started ->
+              true
+          | _ -> false)
+        existing_events
+    in
+    let* () =
+      if (not force) && has_existing_bootstrap_event then
+        Error
+          (Printf.sprintf
+             "room_id is already bootstrapped; pass force=true to append anyway: %s"
+             room_id)
+      else Ok ()
+    in
+    let room_created_payload =
+      `Assoc
+        [
+          ("session_id", `String session_id);
+          ("rule_module", `String rule_module);
+          ("scenario_id", `String world_preset.id);
+          ("dm_preset_id", `String dm_preset.id);
+          ("world_preset_id", `String world_preset.id);
+          ( "config",
+            `Assoc
+              [
+                ("party", party_config party);
+                ("world", world_config ~preset:world_preset);
+                ("dm", dm_config ~preset:dm_preset ~dm_keeper);
+              ] );
+        ]
+    in
+    let* room_created =
+      append_event ~base_dir ~room_id
+        ~event_type:Trpg_engine_event.Room_created
+        ~actor_id:ctx.agent_name ~payload:room_created_payload ()
+    in
+    let session_started_payload =
+      `Assoc
+        [
+          ("session_id", `String session_id);
+          ("room_id", `String room_id);
+          ("dm_keeper", `String dm_keeper);
+          ("dm_preset_id", `String dm_preset.id);
+          ("world_preset_id", `String world_preset.id);
+          ("party_count", `Int (List.length party));
+          ("mode", `String "ai_auto_with_human_nudge");
+        ]
+    in
+    let* session_started =
+      append_event ~base_dir ~room_id
+        ~event_type:Trpg_engine_event.Session_started
+        ~actor_id:ctx.agent_name ~payload:session_started_payload ()
+    in
+    let party_selected_payload =
+      `Assoc
+        [
+          ("session_id", `String session_id);
+          ("selected_player_ids", json_of_strings (List.map (fun p -> p.actor_id) party));
+          ("party", `List (List.map pool_member_to_yojson party));
+        ]
+    in
+    let* party_selected =
+      append_event ~base_dir ~room_id
+        ~event_type:Trpg_engine_event.Party_selected
+        ~actor_id:ctx.agent_name ~payload:party_selected_payload ()
+    in
+    let* phase_event =
+      append_event ~base_dir ~room_id
+        ~event_type:Trpg_engine_event.Phase_changed
+        ~payload:(`Assoc [ ("phase", `String phase) ])
+        ()
+    in
+    let* room_started =
+      append_event ~base_dir ~room_id
+        ~event_type:Trpg_engine_event.Room_started
+        ~payload:(`Assoc [ ("phase", `String phase) ])
+        ()
+    in
+    let player_keepers_json =
+      `Assoc
+        (List.map
+           (fun (member_ : pool_member) ->
+             let keeper =
+               member_.keeper_name
+               |> Option.value ~default:(Printf.sprintf "pk-%s" member_.actor_id)
+             in
+             (member_.actor_id, `String keeper))
+           party)
+    in
+    Ok
+      (`Assoc
+        [
+          ("ok", `Bool true);
+          ("room_id", `String room_id);
+          ("session_id", `String session_id);
+          ("phase", `String phase);
+          ("dm_keeper", `String dm_keeper);
+          ("dm_preset", Trpg_preset_store.dm_preset_to_yojson dm_preset);
+          ("world_preset", Trpg_preset_store.world_preset_to_yojson world_preset);
+          ("party", `List (List.map pool_member_to_yojson party));
+          ( "round_run_template",
+            `Assoc
+              [
+                ("room_id", `String room_id);
+                ("dm_keeper", `String dm_keeper);
+                ("player_keepers", player_keepers_json);
+                ("phase", `String "round");
+              ] );
+          ( "events",
+            `List
+              [
+                Trpg_engine_event.to_yojson room_created;
+                Trpg_engine_event.to_yojson session_started;
+                Trpg_engine_event.to_yojson party_selected;
+                Trpg_engine_event.to_yojson phase_event;
+                Trpg_engine_event.to_yojson room_started;
+              ] );
+        ])
+  in
+  match result_json with Ok j -> ok_json j | Error e -> err e
+
+let handle_intervention_submit ctx args : result =
+  let ( let* ) = Result.bind in
+  let base_dir = ctx.config.base_path in
+  let result_json =
+    let* room_id = get_required_string args "room_id" in
+    let* session_id_opt = get_optional_string args "session_id" in
+    let* intervention_type = get_required_string args "intervention_type" in
+    let* scope_opt = get_optional_string args "scope" in
+    let scope = scope_opt |> Option.value ~default:"turn.before" in
+    let* target_actor = get_optional_string args "target_actor" in
+    let* expected_turn = get_optional_int args "expected_turn" in
+    let* reason = get_optional_string args "reason" in
+    let* payload_opt = get_optional_object args "payload" in
+    let intervention_id =
+      Printf.sprintf "intrv-%Ld"
+        (Int64.of_float (Unix.gettimeofday () *. 1000.0))
+    in
+    let payload =
+      `Assoc
+        [
+          ("intervention_id", `String intervention_id);
+          ("intervention_type", `String intervention_type);
+          ("scope", `String scope);
+          ("session_id", Option.fold ~none:`Null ~some:(fun v -> `String v) session_id_opt);
+          ("target_actor", Option.fold ~none:`Null ~some:(fun v -> `String v) target_actor);
+          ("expected_turn", Option.fold ~none:`Null ~some:(fun v -> `Int v) expected_turn);
+          ("reason", Option.fold ~none:`Null ~some:(fun v -> `String v) reason);
+          ("payload", Option.value ~default:(`Assoc []) payload_opt);
+          ("status", `String "pending");
+          ("submitted_by", `String ctx.agent_name);
+        ]
+    in
+    let* event =
+      append_event ~base_dir ~room_id
+        ~event_type:Trpg_engine_event.Intervention_submitted
+        ~actor_id:ctx.agent_name ~payload ()
+    in
+    Ok
+      (`Assoc
+        [
+          ("ok", `Bool true);
+          ("room_id", `String room_id);
+          ("intervention_id", `String intervention_id);
+          ("status", `String "pending");
+          ("event", Trpg_engine_event.to_yojson event);
+        ])
+  in
+  match result_json with Ok j -> ok_json j | Error e -> err e
+
 let handle_round_run ctx args : result =
   let ( let* ) = Result.bind in
   let base_dir = ctx.config.base_path in
@@ -761,8 +1569,14 @@ let handle_round_run ctx args : result =
           ~payload:(`Assoc [ ("phase", `String phase) ])
           ()
       in
+      let* interventions_applied, intervention_events =
+        append_pending_interventions ~base_dir ~room_id ~phase ~turn:turn_before
+      in
+      let state_for_prompt =
+        inject_interventions_into_state state interventions_applied
+      in
 
-      let appended_events = ref [ phase_event ] in
+      let appended_events = ref (phase_event :: intervention_events) in
       let statuses = ref [] in
       let success_count = ref 0 in
       let unavailable_count = ref 0 in
@@ -776,7 +1590,7 @@ let handle_round_run ctx args : result =
             ~turn:turn_before
             ~role
             ~actor_id
-            ~state_json:state
+            ~state_json:state_for_prompt
         in
         match call_keeper ctx ~name:keeper_name ~message:prompt ~timeout_sec with
         | `Timeout ->
@@ -917,6 +1731,7 @@ let handle_round_run ctx args : result =
             ("turn_after", `Int next_turn);
             ("timeout_sec", `Float timeout_sec);
             ("statuses", `List statuses);
+            ("interventions_applied", `List interventions_applied);
             ( "summary",
               `Assoc
                 [
@@ -924,6 +1739,7 @@ let handle_round_run ctx args : result =
                   ("successes", `Int !success_count);
                   ("timeouts", `Int !timeout_count);
                   ("unavailable", `Int !unavailable_count);
+                  ("interventions", `Int (List.length interventions_applied));
                 ] );
             ("events", `List events_json);
             ("state", state_of_derived next_derived);
@@ -1050,6 +1866,11 @@ let dispatch ctx ~name ~args : result option =
   | "masc_trpg_dice_roll" -> Some (handle_dice_roll ctx args)
   | "masc_trpg_turn_advance" -> Some (handle_turn_advance ctx args)
   | "masc_trpg_stream" -> Some (handle_stream ctx args)
+  | "masc_trpg_preset_list" -> Some (handle_preset_list ctx args)
+  | "masc_trpg_pool_generate" -> Some (handle_pool_generate ctx args)
+  | "masc_trpg_party_select" -> Some (handle_party_select ctx args)
+  | "masc_trpg_session_start" -> Some (handle_session_start ctx args)
+  | "masc_trpg_intervention_submit" -> Some (handle_intervention_submit ctx args)
   | "masc_trpg_round_run" -> Some (handle_round_run ctx args)
   | "masc_trpg_scene_transition" -> Some (handle_scene_transition ctx args)
   | "masc_trpg_quest_update" -> Some (handle_quest_update ctx args)

--- a/lib/trpg_engine_event.ml
+++ b/lib/trpg_engine_event.ml
@@ -18,6 +18,10 @@ type event_type =
   | Scene_transition
   | Quest_update
   | World_event
+  | Session_started
+  | Party_selected
+  | Intervention_submitted
+  | Intervention_applied
 
 type t = {
   seq : int;
@@ -48,6 +52,10 @@ let string_of_event_type = function
   | Scene_transition -> "scene.transition"
   | Quest_update -> "quest.update"
   | World_event -> "world.event"
+  | Session_started -> "session.started"
+  | Party_selected -> "party.selected"
+  | Intervention_submitted -> "intervention.submitted"
+  | Intervention_applied -> "intervention.applied"
 
 let event_type_of_string = function
   | "room.created" -> Ok Room_created
@@ -69,6 +77,10 @@ let event_type_of_string = function
   | "scene.transition" -> Ok Scene_transition
   | "quest.update" -> Ok Quest_update
   | "world.event" -> Ok World_event
+  | "session.started" -> Ok Session_started
+  | "party.selected" -> Ok Party_selected
+  | "intervention.submitted" -> Ok Intervention_submitted
+  | "intervention.applied" -> Ok Intervention_applied
   | s -> Error (Printf.sprintf "unknown event_type: %s" s)
 
 let make ~seq ~room_id ~ts ~event_type ?actor_id ~payload () =

--- a/lib/trpg_engine_event.mli
+++ b/lib/trpg_engine_event.mli
@@ -18,6 +18,10 @@ type event_type =
   | Scene_transition
   | Quest_update
   | World_event
+  | Session_started
+  | Party_selected
+  | Intervention_submitted
+  | Intervention_applied
 
 type t = {
   seq : int;

--- a/lib/trpg_preset_store.ml
+++ b/lib/trpg_preset_store.ml
@@ -1,0 +1,316 @@
+open Yojson.Safe.Util
+
+let ( let* ) = Result.bind
+
+type dm_preset = {
+  id : string;
+  title : string;
+  description : string;
+  style : string;
+  opening_prompt : string;
+  tags : string list;
+}
+
+type world_preset = {
+  id : string;
+  title : string;
+  description : string;
+  intro : string;
+  initial_flags : string list;
+}
+
+type character_preset = {
+  id : string;
+  name : string;
+  archetype : string;
+  persona : string;
+  traits : string list;
+  skill_ids : string list;
+  prompt : string;
+}
+
+type skill = {
+  id : string;
+  name : string;
+  category : string;
+  description : string;
+  usage_hint : string option;
+}
+
+type catalog = {
+  dm_presets : dm_preset list;
+  world_presets : world_preset list;
+  character_presets : character_preset list;
+  skills : skill list;
+}
+
+let string_list_of_member json key =
+  (match json |> member key with `List xs -> xs | _ -> [])
+  |> List.filter_map
+       (function `String s when String.trim s <> "" -> Some s | _ -> None)
+
+let parse_dm_preset json =
+  {
+    id = json |> member "id" |> to_string;
+    title = json |> member "title" |> to_string;
+    description = json |> member "description" |> to_string;
+    style = json |> member "style" |> to_string;
+    opening_prompt = json |> member "opening_prompt" |> to_string;
+    tags = string_list_of_member json "tags";
+  }
+
+let parse_world_preset json =
+  {
+    id = json |> member "id" |> to_string;
+    title = json |> member "title" |> to_string;
+    description = json |> member "description" |> to_string;
+    intro = json |> member "intro" |> to_string;
+    initial_flags = string_list_of_member json "initial_flags";
+  }
+
+let parse_character_preset json =
+  {
+    id = json |> member "id" |> to_string;
+    name = json |> member "name" |> to_string;
+    archetype = json |> member "archetype" |> to_string;
+    persona = json |> member "persona" |> to_string;
+    traits = string_list_of_member json "traits";
+    skill_ids = string_list_of_member json "skill_ids";
+    prompt = json |> member "prompt" |> to_string;
+  }
+
+let parse_skill json =
+  {
+    id = json |> member "id" |> to_string;
+    name = json |> member "name" |> to_string;
+    category = json |> member "category" |> to_string;
+    description = json |> member "description" |> to_string;
+    usage_hint = json |> member "usage_hint" |> to_string_option;
+  }
+
+let dm_preset_to_yojson (p : dm_preset) : Yojson.Safe.t =
+  `Assoc
+    [
+      ("id", `String p.id);
+      ("title", `String p.title);
+      ("description", `String p.description);
+      ("style", `String p.style);
+      ("opening_prompt", `String p.opening_prompt);
+      ("tags", `List (List.map (fun s -> `String s) p.tags));
+    ]
+
+let world_preset_to_yojson (p : world_preset) : Yojson.Safe.t =
+  `Assoc
+    [
+      ("id", `String p.id);
+      ("title", `String p.title);
+      ("description", `String p.description);
+      ("intro", `String p.intro);
+      ("initial_flags", `List (List.map (fun s -> `String s) p.initial_flags));
+    ]
+
+let character_preset_to_yojson (p : character_preset) : Yojson.Safe.t =
+  `Assoc
+    [
+      ("id", `String p.id);
+      ("name", `String p.name);
+      ("archetype", `String p.archetype);
+      ("persona", `String p.persona);
+      ("traits", `List (List.map (fun s -> `String s) p.traits));
+      ("skill_ids", `List (List.map (fun s -> `String s) p.skill_ids));
+      ("prompt", `String p.prompt);
+    ]
+
+let skill_to_yojson (s : skill) : Yojson.Safe.t =
+  `Assoc
+    [
+      ("id", `String s.id);
+      ("name", `String s.name);
+      ("category", `String s.category);
+      ("description", `String s.description);
+      ("usage_hint", Option.fold ~none:`Null ~some:(fun x -> `String x) s.usage_hint);
+    ]
+
+let default_catalog : catalog =
+  {
+    dm_presets =
+      [
+        {
+          id = "grim-warden";
+          title = "Grim Warden";
+          description = "Low-fantasy keeper focused on consequence and scarcity.";
+          style = "strict_consequence";
+          opening_prompt =
+            "You are the DM of Grimland Chronicle. Keep tone grounded, costly, and political.";
+          tags = [ "grim"; "political"; "scarcity" ];
+        };
+        {
+          id = "mythic-weaver";
+          title = "Mythic Weaver";
+          description = "High-fantasy keeper that emphasizes mythic arcs and prophecy.";
+          style = "mythic_epic";
+          opening_prompt =
+            "You are the DM. Emphasize fate, symbols, and ancient pacts in every scene.";
+          tags = [ "mythic"; "epic"; "prophecy" ];
+        };
+      ];
+    world_presets =
+      [
+        {
+          id = "grimland-chronicle";
+          title = "Grimland Chronicle";
+          description = "A fractured peninsula where guilds and city-states compete for survival.";
+          intro =
+            "Famine followed by uneasy peace. Supply lines are thin and alliances are brittle.";
+          initial_flags =
+            [ "scarcity.high"; "rumor.black-fleet"; "trust.public-low" ];
+        };
+        {
+          id = "emberfall-siege";
+          title = "Emberfall Siege";
+          description = "Fortress-city under siege with internal factions and limited time.";
+          intro =
+            "Day 47 of the siege. Food reserves are measured in days, not weeks.";
+          initial_flags = [ "siege.active"; "morale.volatile" ];
+        };
+      ];
+    character_presets =
+      [
+        {
+          id = "vowblade";
+          name = "Kael Vowblade";
+          archetype = "zealot-tank";
+          persona = "Absolute duty, distrusts compromise.";
+          traits = [ "stubborn"; "protective"; "honor-bound" ];
+          skill_ids = [ "frontline_shield"; "oath_intercept"; "morale_anchor" ];
+          prompt = "Prioritize oath and party survival over personal gain.";
+        };
+        {
+          id = "silkwhisper";
+          name = "Mira Silkwhisper";
+          archetype = "social-infiltrator";
+          persona = "Manipulative diplomat who treats trust as currency.";
+          traits = [ "calculating"; "charming"; "risk-seeking" ];
+          skill_ids = [ "deception_feint"; "favor_broker"; "shadow_entry" ];
+          prompt = "Seek leverage in every conversation and trade information strategically.";
+        };
+        {
+          id = "ironledger";
+          name = "Brom Ironledger";
+          archetype = "resource-optimizer";
+          persona = "Cold utilitarian quartermaster.";
+          traits = [ "pragmatic"; "frugal"; "impatient" ];
+          skill_ids = [ "supply_scan"; "ration_shift"; "logistics_patch" ];
+          prompt = "Preserve resources first; every action must have measurable return.";
+        };
+        {
+          id = "stormseer";
+          name = "Ena Stormseer";
+          archetype = "oracle-caster";
+          persona = "Vision-driven mystic torn between mercy and inevitability.";
+          traits = [ "intense"; "empathetic"; "fatalistic" ];
+          skill_ids = [ "omen_trace"; "arc_flash"; "ward_bloom" ];
+          prompt = "Interpret signs and push party toward long-term destiny.";
+        };
+        {
+          id = "gravehound";
+          name = "Rook Gravehound";
+          archetype = "hunter-assassin";
+          persona = "Paranoid tracker who expects betrayal.";
+          traits = [ "suspicious"; "precise"; "vengeful" ];
+          skill_ids = [ "mark_prey"; "silent_route"; "finisher_strike" ];
+          prompt = "Act first on threats; trust must be earned with evidence.";
+        };
+        {
+          id = "lumenfriar";
+          name = "Sera Lumenfriar";
+          archetype = "healer-mediator";
+          persona = "Pacifist negotiator who absorbs team conflict.";
+          traits = [ "calm"; "self-sacrificing"; "idealistic" ];
+          skill_ids = [ "field_mend"; "truce_window"; "resolve_hymn" ];
+          prompt = "Reduce bloodshed and stabilize group cohesion whenever possible.";
+        };
+      ];
+    skills =
+      [
+        {
+          id = "frontline_shield";
+          name = "Frontline Shield";
+          category = "defense";
+          description = "Absorb incoming threat targeting nearby allies.";
+          usage_hint = Some "Use during direct confrontation to prevent party collapse.";
+        };
+        {
+          id = "favor_broker";
+          name = "Favor Broker";
+          category = "social";
+          description = "Trade concessions for delayed obligations.";
+          usage_hint = Some "Useful before scarce-resource negotiations.";
+        };
+        {
+          id = "supply_scan";
+          name = "Supply Scan";
+          category = "resource";
+          description = "Estimate resource burn and shortage horizon.";
+          usage_hint = Some "Run before committing to long missions.";
+        };
+        {
+          id = "omen_trace";
+          name = "Omen Trace";
+          category = "arcane";
+          description = "Infer likely next event from symbolic anomalies.";
+          usage_hint = Some "Best in uncertain branching scenes.";
+        };
+        {
+          id = "mark_prey";
+          name = "Mark Prey";
+          category = "combat";
+          description = "Expose target weakness for coordinated strike.";
+          usage_hint = Some "Combine with another actor's attack action.";
+        };
+        {
+          id = "field_mend";
+          name = "Field Mend";
+          category = "support";
+          description = "Emergency stabilization to prevent actor knockout.";
+          usage_hint = Some "Use when hp trend is negative for two turns.";
+        };
+      ];
+  }
+
+let find_dm_preset catalog ~id =
+  List.find_opt (fun (p : dm_preset) -> p.id = id) catalog.dm_presets
+
+let find_world_preset catalog ~id =
+  List.find_opt (fun (p : world_preset) -> p.id = id) catalog.world_presets
+
+let find_skill catalog ~id =
+  List.find_opt (fun (s : skill) -> s.id = id) catalog.skills
+
+let load_json_list path parse fallback =
+  if Sys.file_exists path then
+    try
+      let json = Yojson.Safe.from_file path in
+      let items = json |> to_list |> List.map parse in
+      Ok items
+    with exn -> Error (Printf.sprintf "failed to parse %s: %s" path (Printexc.to_string exn))
+  else Ok fallback
+
+let config_path base_dir rel = Filename.concat base_dir rel
+
+let load_catalog ~base_dir =
+  let dm_path = config_path base_dir "config/trpg/presets/dm.json" in
+  let world_path = config_path base_dir "config/trpg/presets/world.json" in
+  let character_path = config_path base_dir "config/trpg/presets/character.json" in
+  let skill_path = config_path base_dir "config/trpg/skills/agent_skills.json" in
+  let* dm_presets =
+    load_json_list dm_path parse_dm_preset default_catalog.dm_presets
+  in
+  let* world_presets =
+    load_json_list world_path parse_world_preset default_catalog.world_presets
+  in
+  let* character_presets =
+    load_json_list character_path parse_character_preset default_catalog.character_presets
+  in
+  let* skills = load_json_list skill_path parse_skill default_catalog.skills in
+  Ok { dm_presets; world_presets; character_presets; skills }

--- a/lib/trpg_preset_store.mli
+++ b/lib/trpg_preset_store.mli
@@ -1,0 +1,54 @@
+type dm_preset = {
+  id : string;
+  title : string;
+  description : string;
+  style : string;
+  opening_prompt : string;
+  tags : string list;
+}
+
+type world_preset = {
+  id : string;
+  title : string;
+  description : string;
+  intro : string;
+  initial_flags : string list;
+}
+
+type character_preset = {
+  id : string;
+  name : string;
+  archetype : string;
+  persona : string;
+  traits : string list;
+  skill_ids : string list;
+  prompt : string;
+}
+
+type skill = {
+  id : string;
+  name : string;
+  category : string;
+  description : string;
+  usage_hint : string option;
+}
+
+type catalog = {
+  dm_presets : dm_preset list;
+  world_presets : world_preset list;
+  character_presets : character_preset list;
+  skills : skill list;
+}
+
+val default_catalog : catalog
+
+val load_catalog : base_dir:string -> (catalog, string) result
+
+val find_dm_preset : catalog -> id:string -> dm_preset option
+val find_world_preset : catalog -> id:string -> world_preset option
+val find_skill : catalog -> id:string -> skill option
+
+val dm_preset_to_yojson : dm_preset -> Yojson.Safe.t
+val world_preset_to_yojson : world_preset -> Yojson.Safe.t
+val character_preset_to_yojson : character_preset -> Yojson.Safe.t
+val skill_to_yojson : skill -> Yojson.Safe.t

--- a/lib/trpg_rule_dnd5e_lite.ml
+++ b/lib/trpg_rule_dnd5e_lite.ml
@@ -247,7 +247,11 @@ let apply_event ~state ~(event : Trpg_engine_event.t) =
   | Trpg_engine_event.Metric_updated
   | Trpg_engine_event.Scene_transition
   | Trpg_engine_event.Quest_update
-  | Trpg_engine_event.World_event ->
+  | Trpg_engine_event.World_event
+  | Trpg_engine_event.Session_started
+  | Trpg_engine_event.Party_selected
+  | Trpg_engine_event.Intervention_submitted
+  | Trpg_engine_event.Intervention_applied ->
       state
 
 let derive_state ~state = state

--- a/lib/trpg_visibility.ml
+++ b/lib/trpg_visibility.ml
@@ -7,6 +7,10 @@ let public_event_types =
     Trpg_engine_event.Quest_update;
     Trpg_engine_event.World_event;
     Trpg_engine_event.Dice_rolled;
+    Trpg_engine_event.Session_started;
+    Trpg_engine_event.Party_selected;
+    Trpg_engine_event.Intervention_submitted;
+    Trpg_engine_event.Intervention_applied;
   ]
 
 let is_public_event (ev : Trpg_engine_event.t) =

--- a/scripts/harness/contract/trpg_session_contract.sh
+++ b/scripts/harness/contract/trpg_session_contract.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+MCP_URL="${MCP_URL:-http://127.0.0.1:8935/mcp}"
+SESSION_ID="${SESSION_ID:-harness-trpg-session-001}"
+
+call_tool() {
+  local id="$1"
+  local name="$2"
+  local args_json="$3"
+  local raw
+  local sse_data
+
+  raw="$(curl -sS -m 25 -X POST "$MCP_URL" \
+    -H 'Content-Type: application/json' \
+    -H 'Accept: application/json, text/event-stream' \
+    -d "{\"jsonrpc\":\"2.0\",\"id\":$id,\"method\":\"tools/call\",\"params\":{\"name\":\"$name\",\"arguments\":$args_json}}")"
+
+  sse_data="$(printf "%s" "$raw" | sed -n 's/^data: //p' | tail -n1)"
+  if [ -n "$sse_data" ]; then
+    printf "%s" "$sse_data"
+  else
+    printf "%s" "$raw"
+  fi
+}
+
+extract_payload() {
+  jq -c 'try (.result.content[0].text | fromjson | .payload) catch empty'
+}
+
+echo "[1/6] trpg.preset.list"
+r1="$(call_tool 2001 "trpg.preset.list" "{}")"
+if ! printf "%s" "$r1" | extract_payload | jq -e '.dm_presets | length >= 1' >/dev/null; then
+  echo "FAIL: trpg.preset.list should return dm_presets"
+  printf "%s\n" "$r1"
+  exit 1
+fi
+
+echo "[2/6] trpg.pool.generate"
+r2="$(call_tool 2002 "trpg.pool.generate" "{\"session_id\":\"$SESSION_ID\",\"pool_size\":6,\"party_size\":4,\"seed\":11}")"
+pool_json="$(printf "%s" "$r2" | extract_payload | jq -c '.pool // []')"
+suggested_json="$(printf "%s" "$r2" | extract_payload | jq -c '.suggested_party_ids // []')"
+if [ "$(printf "%s" "$pool_json" | jq -r 'length')" -lt 4 ]; then
+  echo "FAIL: pool_size too small"
+  printf "%s\n" "$r2"
+  exit 1
+fi
+if [ "$(printf "%s" "$suggested_json" | jq -r 'length')" -ne 4 ]; then
+  echo "FAIL: suggested_party_ids should contain 4 players"
+  printf "%s\n" "$r2"
+  exit 1
+fi
+
+echo "[3/6] trpg.party.select"
+args_party="$(jq -cn --arg sid "$SESSION_ID" --argjson pool "$pool_json" --argjson ids "$suggested_json" '{session_id:$sid,pool:$pool,selected_player_ids:$ids}')"
+r3="$(call_tool 2003 "trpg.party.select" "$args_party")"
+party_json="$(printf "%s" "$r3" | extract_payload | jq -c '.party // []')"
+if [ "$(printf "%s" "$party_json" | jq -r 'length')" -ne 4 ]; then
+  echo "FAIL: party.select should return exactly 4 members"
+  printf "%s\n" "$r3"
+  exit 1
+fi
+
+echo "[4/6] trpg.session.start"
+args_start="$(jq -cn --arg sid "$SESSION_ID" --argjson party "$party_json" '{session_id:$sid,party:$party,phase:"briefing"}')"
+r4="$(call_tool 2004 "trpg.session.start" "$args_start")"
+room_id="$(printf "%s" "$r4" | extract_payload | jq -r '.room_id // empty')"
+if [ -z "$room_id" ]; then
+  echo "FAIL: trpg.session.start should return room_id"
+  printf "%s\n" "$r4"
+  exit 1
+fi
+if ! printf "%s" "$r4" | extract_payload | jq -e '.events | map(.type) | index("session.started") != null' >/dev/null; then
+  echo "FAIL: trpg.session.start should emit session.started"
+  printf "%s\n" "$r4"
+  exit 1
+fi
+
+echo "[5/6] trpg.intervention.submit"
+r5="$(call_tool 2005 "trpg.intervention.submit" "{\"room_id\":\"$room_id\",\"session_id\":\"$SESSION_ID\",\"intervention_type\":\"nudge\",\"reason\":\"contract-harness\",\"payload\":{\"delta\":0.1}}")"
+if [ "$(printf "%s" "$r5" | extract_payload | jq -r '.status // empty')" != "pending" ]; then
+  echo "FAIL: trpg.intervention.submit should return pending"
+  printf "%s\n" "$r5"
+  exit 1
+fi
+
+echo "[6/6] trpg.stream.read (submitted intervention visible)"
+r6="$(call_tool 2006 "trpg.stream.read" "{\"room_id\":\"$room_id\",\"event_type\":\"intervention.submitted\"}")"
+if ! printf "%s" "$r6" | extract_payload | jq -e '.count >= 1' >/dev/null; then
+  echo "FAIL: trpg.stream.read should include intervention.submitted"
+  printf "%s\n" "$r6"
+  exit 1
+fi
+
+echo "PASS: TRPG session contract harness"

--- a/scripts/harness/workload/trpg_grimland_smoke.sh
+++ b/scripts/harness/workload/trpg_grimland_smoke.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+MCP_URL="${MCP_URL:-http://127.0.0.1:8935/mcp}"
+SESSION_ID="${SESSION_ID:-smoke-grimland-$(date +%s)}"
+ROUNDS="${ROUNDS:-2}"
+RUN_ROUND="${RUN_ROUND:-0}"  # 0: bootstrap only, 1: include trpg.round.run
+
+call_tool() {
+  local id="$1"
+  local name="$2"
+  local args_json="$3"
+  local raw
+  local sse_data
+  raw="$(curl -sS -m 30 -X POST "$MCP_URL" \
+    -H 'Content-Type: application/json' \
+    -H 'Accept: application/json, text/event-stream' \
+    -d "{\"jsonrpc\":\"2.0\",\"id\":$id,\"method\":\"tools/call\",\"params\":{\"name\":\"$name\",\"arguments\":$args_json}}")"
+  sse_data="$(printf "%s" "$raw" | sed -n 's/^data: //p' | tail -n1)"
+  if [ -n "$sse_data" ]; then
+    printf "%s" "$sse_data"
+  else
+    printf "%s" "$raw"
+  fi
+}
+
+payload() {
+  jq -c 'try (.result.content[0].text | fromjson | .payload) catch empty'
+}
+
+echo "[bootstrap] trpg.pool.generate"
+r_pool="$(call_tool 3001 "trpg.pool.generate" "{\"session_id\":\"$SESSION_ID\",\"world_preset_id\":\"grimland-chronicle\",\"pool_size\":6,\"party_size\":4}")"
+pool="$(printf "%s" "$r_pool" | payload | jq -c '.pool')"
+suggested="$(printf "%s" "$r_pool" | payload | jq -c '.suggested_party_ids')"
+
+echo "[bootstrap] trpg.party.select"
+args_party="$(jq -cn --arg sid "$SESSION_ID" --argjson pool "$pool" --argjson ids "$suggested" '{session_id:$sid,pool:$pool,selected_player_ids:$ids}')"
+r_party="$(call_tool 3002 "trpg.party.select" "$args_party")"
+party="$(printf "%s" "$r_party" | payload | jq -c '.party')"
+
+echo "[bootstrap] trpg.session.start"
+args_start="$(jq -cn --arg sid "$SESSION_ID" --argjson party "$party" '{session_id:$sid,party:$party,phase:"briefing"}')"
+r_start="$(call_tool 3003 "trpg.session.start" "$args_start")"
+room_id="$(printf "%s" "$r_start" | payload | jq -r '.room_id')"
+round_template="$(printf "%s" "$r_start" | payload | jq -c '.round_run_template')"
+
+echo "[bootstrap] room_id=$room_id"
+
+if [ "$RUN_ROUND" = "1" ]; then
+  echo "[round] RUN_ROUND=1, executing $ROUNDS rounds"
+  i=1
+  while [ "$i" -le "$ROUNDS" ]; do
+    echo "  - round $i"
+    args_round="$(jq -cn --argjson t "$round_template" '{room_id:$t.room_id,dm_keeper:$t.dm_keeper,player_keepers:$t.player_keepers,phase:"round",timeout_sec:2.0}')"
+    call_tool $((4000 + i)) "trpg.round.run" "$args_round" >/dev/null
+    i=$((i + 1))
+  done
+fi
+
+echo "[intervention] trpg.intervention.submit"
+call_tool 3500 "trpg.intervention.submit" "{\"room_id\":\"$room_id\",\"session_id\":\"$SESSION_ID\",\"intervention_type\":\"nudge\",\"payload\":{\"target\":\"trust\",\"delta\":0.1}}" >/dev/null
+
+echo "[stream] trpg.stream.read"
+r_stream="$(call_tool 3600 "trpg.stream.read" "{\"room_id\":\"$room_id\"}")"
+count="$(printf "%s" "$r_stream" | payload | jq -r '.count // 0')"
+
+echo "PASS: grimland smoke (events=$count, room_id=$room_id, run_round=$RUN_ROUND)"

--- a/scripts/harness_trpg_session_contract.sh
+++ b/scripts/harness_trpg_session_contract.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+exec "$SCRIPT_DIR/harness/contract/trpg_session_contract.sh" "$@"

--- a/scripts/run_trpg_grimland_smoke.sh
+++ b/scripts/run_trpg_grimland_smoke.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+exec "$SCRIPT_DIR/harness/workload/trpg_grimland_smoke.sh" "$@"

--- a/test/test_protocol_game_view.ml
+++ b/test/test_protocol_game_view.ml
@@ -351,6 +351,94 @@ let test_trpg_world_query_merge_and_visibility () =
          |> List.length )
         <= 1))
 
+let test_trpg_session_protocol_bootstrap () =
+  let base_dir = temp_dir () in
+  let _, ctx = mk_ctx base_dir in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base_dir)
+    (fun () ->
+      let ok_preset, body_preset =
+        dispatch_exn ctx ~name:"trpg.preset.list" ~args:(`Assoc [])
+      in
+      check bool "preset.list ok" true ok_preset;
+      check bool "has dm presets" true
+        ((body_preset |> parse_json |> member "payload" |> member "dm_presets" |> to_list |> List.length) >= 1);
+
+      let session_id = "proto-boot-1" in
+      let ok_pool, body_pool =
+        dispatch_exn ctx ~name:"trpg.pool.generate"
+          ~args:
+            (`Assoc
+              [
+                ("session_id", `String session_id);
+                ("pool_size", `Int 6);
+                ("party_size", `Int 4);
+                ("seed", `Int 13);
+              ])
+      in
+      check bool "pool.generate ok" true ok_pool;
+      let payload_pool = body_pool |> parse_json |> member "payload" in
+      let pool = payload_pool |> member "pool" |> to_list in
+      let suggested_ids = payload_pool |> member "suggested_party_ids" |> to_list in
+      check int "pool size" 6 (List.length pool);
+      check int "suggested size" 4 (List.length suggested_ids);
+
+      let ok_party, body_party =
+        dispatch_exn ctx ~name:"trpg.party.select"
+          ~args:
+            (`Assoc
+              [
+                ("session_id", `String session_id);
+                ("pool", `List pool);
+                ("selected_player_ids", `List suggested_ids);
+              ])
+      in
+      check bool "party.select ok" true ok_party;
+      let selected_party =
+        body_party |> parse_json |> member "payload" |> member "party" |> to_list
+      in
+      check int "selected party size" 4 (List.length selected_party);
+
+      let ok_start, body_start =
+        dispatch_exn ctx ~name:"trpg.session.start"
+          ~args:
+            (`Assoc
+              [
+                ("session_id", `String session_id);
+                ("party", `List selected_party);
+                ("phase", `String "briefing");
+              ])
+      in
+      check bool "session.start ok" true ok_start;
+      let payload_start = body_start |> parse_json |> member "payload" in
+      let room_id = payload_start |> member "room_id" |> to_string in
+      check bool "room_id derived from session" true (String.length room_id > 0);
+      let events = payload_start |> member "events" |> to_list in
+      let has_session_started =
+        List.exists
+          (fun ev ->
+            try ev |> member "type" |> to_string = "session.started" with _ -> false)
+          events
+      in
+      check bool "session.started emitted" true has_session_started;
+
+      let ok_intrv, body_intrv =
+        dispatch_exn ctx ~name:"trpg.intervention.submit"
+          ~args:
+            (`Assoc
+              [
+                ("room_id", `String room_id);
+                ("session_id", `String session_id);
+                ("intervention_type", `String "nudge");
+                ("reason", `String "human small tweak");
+                ("payload", `Assoc [ ("delta", `Float 0.1) ]);
+              ])
+      in
+      check bool "intervention.submit ok" true ok_intrv;
+      check string "intervention status"
+        "pending"
+        (body_intrv |> parse_json |> member "payload" |> member "status" |> to_string))
+
 let test_client_session_open_success () =
   let base_dir = temp_dir () in
   let config, ctx = mk_ctx base_dir in
@@ -641,6 +729,8 @@ let () =
             test_trpg_world_query_default_room_and_skills;
           test_case "trpg.world.query merge + visibility" `Quick
             test_trpg_world_query_merge_and_visibility;
+          test_case "trpg session bootstrap protocol flow" `Quick
+            test_trpg_session_protocol_bootstrap;
           test_case "client.session.open success" `Quick
             test_client_session_open_success;
           test_case "client.session.open idempotent refresh" `Quick

--- a/test/test_tool_trpg_coverage.ml
+++ b/test/test_tool_trpg_coverage.ml
@@ -185,9 +185,143 @@ let test_round_run_requires_keeper_runtime () =
     (contains_substring msg "keeper_call is not available");
   cleanup_dir base_dir
 
+let test_session_bootstrap_and_intervention_flow () =
+  let base_dir = make_temp_dir () in
+  let config = Room.default_config base_dir in
+  let _ = Room.init config ~agent_name:(Some "tester") in
+  let keeper_call ~name ~message:_ ~timeout_sec:_ : Tool_trpg.keeper_call_result
+      =
+    if name = "dm-keeper" then
+      `Ok (`Assoc [ ("reply", `String "The DM advances the grim plot.") ])
+    else if String.starts_with ~prefix:"pk-" name then
+      `Ok (`Assoc [ ("reply", `String "Player executes assigned tactic.") ])
+    else
+      `Error ("unknown keeper: " ^ name)
+  in
+  let ctx : Tool_trpg.context =
+    { config; agent_name = "tester"; keeper_call = Some keeper_call }
+  in
+  let session_id = "session-bootstrap-1" in
+  let ok_preset, preset_body =
+    dispatch_exn ctx ~name:"masc_trpg_preset_list" ~args:(`Assoc [])
+  in
+  Alcotest.(check bool) "preset list ok" true ok_preset;
+  Alcotest.(check bool) "preset list has dm presets" true
+    ((parse_json_exn preset_body |> Yojson.Safe.Util.member "dm_presets" |> Yojson.Safe.Util.to_list |> List.length) >= 1);
+
+  let ok_pool, pool_body =
+    dispatch_exn ctx ~name:"masc_trpg_pool_generate"
+      ~args:
+        (`Assoc
+          [
+            ("session_id", `String session_id);
+            ("pool_size", `Int 6);
+            ("party_size", `Int 4);
+            ("seed", `Int 7);
+          ])
+  in
+  Alcotest.(check bool) "pool generate ok" true ok_pool;
+  let pool_json = parse_json_exn pool_body in
+  let pool = pool_json |> Yojson.Safe.Util.member "pool" |> Yojson.Safe.Util.to_list in
+  let suggested =
+    pool_json |> Yojson.Safe.Util.member "suggested_party_ids"
+    |> Yojson.Safe.Util.to_list
+  in
+  Alcotest.(check int) "pool size" 6 (List.length pool);
+  Alcotest.(check int) "suggested party size" 4 (List.length suggested);
+
+  let ok_party, party_body =
+    dispatch_exn ctx ~name:"masc_trpg_party_select"
+      ~args:
+        (`Assoc
+          [
+            ("session_id", `String session_id);
+            ("pool", `List pool);
+            ("selected_player_ids", `List suggested);
+          ])
+  in
+  Alcotest.(check bool) "party select ok" true ok_party;
+  let party_json = parse_json_exn party_body in
+  let party = party_json |> Yojson.Safe.Util.member "party" |> Yojson.Safe.Util.to_list in
+  Alcotest.(check int) "party size" 4 (List.length party);
+
+  let ok_start, start_body =
+    dispatch_exn ctx ~name:"masc_trpg_session_start"
+      ~args:
+        (`Assoc
+          [
+            ("session_id", `String session_id);
+            ("party", `List party);
+          ])
+  in
+  Alcotest.(check bool) "session start ok" true ok_start;
+  let start_json = parse_json_exn start_body in
+  let room_id =
+    start_json |> Yojson.Safe.Util.member "room_id" |> Yojson.Safe.Util.to_string
+  in
+  let round_template =
+    start_json
+    |> Yojson.Safe.Util.member "round_run_template"
+    |> Yojson.Safe.Util.member "player_keepers"
+  in
+
+  let ok_intrv, intrv_body =
+    dispatch_exn ctx ~name:"masc_trpg_intervention_submit"
+      ~args:
+        (`Assoc
+          [
+            ("room_id", `String room_id);
+            ("session_id", `String session_id);
+            ("intervention_type", `String "nudge");
+            ("payload", `Assoc [ ("target", `String "trust"); ("delta", `Float 0.1) ]);
+          ])
+  in
+  Alcotest.(check bool) "intervention submit ok" true ok_intrv;
+  let intrv_json = parse_json_exn intrv_body in
+  Alcotest.(check string) "intervention status" "pending"
+    (intrv_json |> Yojson.Safe.Util.member "status" |> Yojson.Safe.Util.to_string);
+
+  let ok_round, round_body =
+    dispatch_exn ctx ~name:"masc_trpg_round_run"
+      ~args:
+        (`Assoc
+          [
+            ("room_id", `String room_id);
+            ("dm_keeper", `String "dm-keeper");
+            ("player_keepers", round_template);
+            ("phase", `String "round");
+            ("timeout_sec", `Float 0.5);
+          ])
+  in
+  Alcotest.(check bool) "round run ok" true ok_round;
+  let round_json = parse_json_exn round_body in
+  let summary = round_json |> Yojson.Safe.Util.member "summary" in
+  Alcotest.(check int) "interventions applied count" 1
+    (summary |> Yojson.Safe.Util.member "interventions" |> Yojson.Safe.Util.to_int);
+
+  let _, stream_applied =
+    dispatch_exn ctx ~name:"masc_trpg_stream"
+      ~args:
+        (`Assoc
+          [
+            ("room_id", `String room_id);
+            ("event_type", `String "intervention.applied");
+          ])
+  in
+  Alcotest.(check int) "intervention.applied event count" 1
+    (count_from_json (parse_json_exn stream_applied));
+  cleanup_dir base_dir
+
 let () =
   Alcotest.run "Tool_trpg coverage"
     [
+      ( "session",
+        [
+          Alcotest.test_case
+            "bootstrap + intervention + round"
+            `Quick
+            test_session_bootstrap_and_intervention_flow;
+        ] );
       ( "round_run",
         [
           Alcotest.test_case


### PR DESCRIPTION
## Summary
- add TRPG preset/skill catalog store with JSON SSOT + fallback defaults
- add dot-namespace protocol routes for preset/pool/party/session/intervention
- extend TRPG events and visibility for session and intervention lifecycle
- wire pending interventions into round run execution
- add contract/workload harness scripts and make targets
- add protocol and tool coverage tests for session bootstrap flow

## Verification
- dune build --root .
- dune exec --root . ./test/test_tool_trpg_coverage.exe
- dune exec --root . ./test/test_protocol_game_view.exe
