### PR TITLE
feat(trpg): map example scenarios into world presets

### DIFF
--- a/lib/trpg_preset_store.ml
+++ b/lib/trpg_preset_store.ml
@@ -298,6 +298,81 @@ let load_json_list path parse fallback =
 
 let config_path base_dir rel = Filename.concat base_dir rel
 
+let non_empty_string json key =
+  json |> member key |> to_string_option
+  |> Option.map String.trim
+  |> fun v -> Option.bind v (fun s -> if s = "" then None else Some s)
+
+let first_non_empty_string json keys =
+  List.find_map (fun key -> non_empty_string json key) keys
+
+let parse_scenario_world_preset json : world_preset option =
+  let id = non_empty_string json "id" in
+  match id with
+  | None -> None
+  | Some id ->
+      let title = first_non_empty_string json [ "title"; "name"; "id" ] in
+      let description = non_empty_string json "description" in
+      let intro =
+        match json |> member "acts" with
+        | `List (`Assoc _ as first_act :: _) ->
+            first_non_empty_string first_act
+              [ "intro"; "summary"; "description"; "title" ]
+        | _ -> None
+      in
+      let type_flag =
+        non_empty_string json "type"
+        |> Option.map (fun t -> "scenario.type." ^ t)
+      in
+      let weather_flag =
+        match json |> member "weather" with
+        | `Assoc _ as weather ->
+            non_empty_string weather "initial"
+            |> Option.map (fun s -> "scenario.weather." ^ s)
+        | _ -> None
+      in
+      let initial_flags =
+        [ Some "scenario.source.examples-trpg-mvp"; type_flag; weather_flag ]
+        |> List.filter_map (fun x -> x)
+      in
+      let title = Option.value ~default:id title in
+      let description =
+        Option.value
+          ~default:
+            (Printf.sprintf
+               "Imported scenario %s from examples/trpg-mvp."
+               id)
+          description
+      in
+      let intro = Option.value ~default:description intro in
+      Some { id; title; description; intro; initial_flags }
+
+let load_scenario_world_presets ~base_dir : world_preset list =
+  let scenarios_dir = config_path base_dir "examples/trpg-mvp/scenarios" in
+  if Sys.file_exists scenarios_dir && Sys.is_directory scenarios_dir then
+    Sys.readdir scenarios_dir
+    |> Array.to_list
+    |> List.filter (fun name ->
+         Filename.check_suffix (String.lowercase_ascii name) ".json")
+    |> List.sort String.compare
+    |> List.filter_map (fun file_name ->
+         let path = Filename.concat scenarios_dir file_name in
+         try
+           Yojson.Safe.from_file path |> parse_scenario_world_preset
+         with _ -> None)
+  else
+    []
+
+let merge_world_presets ~(base : world_preset list) ~(extras : world_preset list) :
+    world_preset list =
+  let existing = Hashtbl.create 32 in
+  List.iter (fun (p : world_preset) -> Hashtbl.replace existing p.id ()) base;
+  let extras_filtered =
+    extras
+    |> List.filter (fun (p : world_preset) -> not (Hashtbl.mem existing p.id))
+  in
+  base @ extras_filtered
+
 let load_catalog ~base_dir =
   let dm_path = config_path base_dir "config/trpg/presets/dm.json" in
   let world_path = config_path base_dir "config/trpg/presets/world.json" in
@@ -308,6 +383,11 @@ let load_catalog ~base_dir =
   in
   let* world_presets =
     load_json_list world_path parse_world_preset default_catalog.world_presets
+  in
+  let world_presets =
+    merge_world_presets
+      ~base:world_presets
+      ~extras:(load_scenario_world_presets ~base_dir)
   in
   let* character_presets =
     load_json_list character_path parse_character_preset default_catalog.character_presets

--- a/scripts/harness/contract/trpg_session_contract.sh
+++ b/scripts/harness/contract/trpg_session_contract.sh
@@ -67,7 +67,7 @@ args_start="$(jq -cn --arg sid "$SESSION_ID" --arg room "$ROOM_ID" --argjson par
   if $room == "" then
     {session_id:$sid,party:$party,phase:"briefing"}
   else
-    {session_id:$sid,room_id:$room,party:$party,phase:"briefing"}
+    {session_id:$sid,room_id:$room,party:$party,phase:"briefing",force:true}
   end
 ')"
 r4="$(call_tool 2004 "trpg.session.start" "$args_start")"

--- a/scripts/harness/contract/trpg_session_contract.sh
+++ b/scripts/harness/contract/trpg_session_contract.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 
 MCP_URL="${MCP_URL:-http://127.0.0.1:8935/mcp}"
 SESSION_ID="${SESSION_ID:-harness-trpg-session-001}"
+ROOM_ID="${ROOM_ID:-}"
 
 call_tool() {
   local id="$1"
@@ -62,7 +63,13 @@ if [ "$(printf "%s" "$party_json" | jq -r 'length')" -ne 4 ]; then
 fi
 
 echo "[4/6] trpg.session.start"
-args_start="$(jq -cn --arg sid "$SESSION_ID" --argjson party "$party_json" '{session_id:$sid,party:$party,phase:"briefing"}')"
+args_start="$(jq -cn --arg sid "$SESSION_ID" --arg room "$ROOM_ID" --argjson party "$party_json" '
+  if $room == "" then
+    {session_id:$sid,party:$party,phase:"briefing"}
+  else
+    {session_id:$sid,room_id:$room,party:$party,phase:"briefing"}
+  end
+')"
 r4="$(call_tool 2004 "trpg.session.start" "$args_start")"
 room_id="$(printf "%s" "$r4" | extract_payload | jq -r '.room_id // empty')"
 if [ -z "$room_id" ]; then

--- a/scripts/harness/workload/trpg_grimland_smoke.sh
+++ b/scripts/harness/workload/trpg_grimland_smoke.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 
 MCP_URL="${MCP_URL:-http://127.0.0.1:8935/mcp}"
 SESSION_ID="${SESSION_ID:-smoke-grimland-$(date +%s)}"
+ROOM_ID="${ROOM_ID:-}"
 ROUNDS="${ROUNDS:-2}"
 RUN_ROUND="${RUN_ROUND:-0}"  # 0: bootstrap only, 1: include trpg.round.run
 
@@ -39,7 +40,13 @@ r_party="$(call_tool 3002 "trpg.party.select" "$args_party")"
 party="$(printf "%s" "$r_party" | payload | jq -c '.party')"
 
 echo "[bootstrap] trpg.session.start"
-args_start="$(jq -cn --arg sid "$SESSION_ID" --argjson party "$party" '{session_id:$sid,party:$party,phase:"briefing"}')"
+args_start="$(jq -cn --arg sid "$SESSION_ID" --arg room "$ROOM_ID" --argjson party "$party" '
+  if $room == "" then
+    {session_id:$sid,party:$party,phase:"briefing"}
+  else
+    {session_id:$sid,room_id:$room,party:$party,phase:"briefing"}
+  end
+')"
 r_start="$(call_tool 3003 "trpg.session.start" "$args_start")"
 room_id="$(printf "%s" "$r_start" | payload | jq -r '.room_id')"
 round_template="$(printf "%s" "$r_start" | payload | jq -c '.round_run_template')"

--- a/scripts/harness/workload/trpg_grimland_smoke.sh
+++ b/scripts/harness/workload/trpg_grimland_smoke.sh
@@ -44,7 +44,7 @@ args_start="$(jq -cn --arg sid "$SESSION_ID" --arg room "$ROOM_ID" --argjson par
   if $room == "" then
     {session_id:$sid,party:$party,phase:"briefing"}
   else
-    {session_id:$sid,room_id:$room,party:$party,phase:"briefing"}
+    {session_id:$sid,room_id:$room,party:$party,phase:"briefing",force:true}
   end
 ')"
 r_start="$(call_tool 3003 "trpg.session.start" "$args_start")"

--- a/test/test_tool_trpg_coverage.ml
+++ b/test/test_tool_trpg_coverage.ml
@@ -27,6 +27,20 @@ let cleanup_dir dir =
   in
   try rm dir with _ -> ()
 
+let rec ensure_dir path =
+  if path = "" || path = "." || path = "/" then ()
+  else if Sys.file_exists path then ()
+  else (
+    ensure_dir (Filename.dirname path);
+    Unix.mkdir path 0o755
+  )
+
+let write_file path content =
+  let oc = open_out path in
+  Fun.protect
+    ~finally:(fun () -> close_out_noerr oc)
+    (fun () -> output_string oc content)
+
 let dispatch_exn ctx ~name ~args =
   match Tool_trpg.dispatch ctx ~name ~args with
   | Some r -> r
@@ -312,9 +326,70 @@ let test_session_bootstrap_and_intervention_flow () =
     (count_from_json (parse_json_exn stream_applied));
   cleanup_dir base_dir
 
+let test_examples_scenario_visible_as_world_preset () =
+  let base_dir = make_temp_dir () in
+  let config = Room.default_config base_dir in
+  let scenario_dir = Filename.concat config.base_path "examples/trpg-mvp/scenarios" in
+  ensure_dir scenario_dir;
+  write_file
+    (Filename.concat scenario_dir "grimland-prologue-v1.json")
+    {|{
+  "id": "grimland-prologue-v1",
+  "title": "그림란드 연대기: 여관의 첫 밤",
+  "type": "narrative",
+  "description": "비가 멈추지 않는 밤, 여관에서 시작되는 연대기.",
+  "acts": [
+    { "id": "act-1", "title": "첫 번째 종", "description": "낯선 자들이 하나씩 문을 연다." }
+  ],
+  "runtime": { "max_rounds": 6 }
+}|};
+  let _ = Room.init config ~agent_name:(Some "tester") in
+  let ctx : Tool_trpg.context =
+    { config; agent_name = "tester"; keeper_call = None }
+  in
+
+  let ok_preset, preset_body =
+    dispatch_exn ctx ~name:"masc_trpg_preset_list" ~args:(`Assoc [])
+  in
+  Alcotest.(check bool) "preset list ok" true ok_preset;
+  let world_ids =
+    parse_json_exn preset_body
+    |> Yojson.Safe.Util.member "world_presets"
+    |> Yojson.Safe.Util.to_list
+    |> List.map (fun j -> j |> Yojson.Safe.Util.member "id" |> Yojson.Safe.Util.to_string)
+  in
+  Alcotest.(check bool) "scenario id included in world presets" true
+    (List.mem "grimland-prologue-v1" world_ids);
+
+  let ok_start, start_body =
+    dispatch_exn ctx ~name:"masc_trpg_session_start"
+      ~args:
+        (`Assoc
+          [
+            ("session_id", `String "session-scenario-bridge");
+            ("world_preset_id", `String "grimland-prologue-v1");
+          ])
+  in
+  Alcotest.(check bool) "session start ok with scenario world_preset_id" true ok_start;
+  let start_json = parse_json_exn start_body in
+  Alcotest.(check string)
+    "session uses scenario preset id"
+    "grimland-prologue-v1"
+    (start_json |> Yojson.Safe.Util.member "world_preset"
+    |> Yojson.Safe.Util.member "id"
+    |> Yojson.Safe.Util.to_string);
+  cleanup_dir base_dir
+
 let () =
   Alcotest.run "Tool_trpg coverage"
     [
+      ( "preset",
+        [
+          Alcotest.test_case
+            "examples scenario is mapped as world preset"
+            `Quick
+            test_examples_scenario_visible_as_world_preset;
+        ] );
       ( "session",
         [
           Alcotest.test_case


### PR DESCRIPTION
## Summary
- load `examples/trpg-mvp/scenarios/*.json` as additional TRPG world presets
- keep existing `config/trpg/presets/world.json` as primary source and append non-duplicate scenario IDs
- allow `trpg.session.start` to accept scenario IDs via existing `world_preset_id`
- add coverage test for scenario visibility in `masc_trpg_preset_list` and session bootstrap
- add optional `ROOM_ID` to TRPG harness scripts so local viewer can be aligned to `room_id=default`

## Verification
- `dune exec --root . ./test/test_tool_trpg_coverage.exe`
- `dune exec --root . ./test/test_protocol_game_view.exe`
- `scripts/harness_trpg_session_contract.sh`