### PR TITLE
feat(viewer): implement weather/mood overlay and prop notification systems

### DIFF
--- a/viewer/src/game/components.rs
+++ b/viewer/src/game/components.rs
@@ -50,3 +50,11 @@ pub struct GameCamera;
 /// Marker for the map background sprite (needed for OnExit despawn).
 #[derive(Component, Debug)]
 pub struct MapBackground;
+
+/// Marker for the full-screen weather overlay sprite (z = -9.0).
+#[derive(Component, Debug)]
+pub struct WeatherOverlay;
+
+/// Marker for the full-screen mood overlay sprite (z = -8.0).
+#[derive(Component, Debug)]
+pub struct MoodOverlay;

--- a/viewer/src/game/events.rs
+++ b/viewer/src/game/events.rs
@@ -79,6 +79,16 @@ pub struct CombatPayload {
     pub enemies: Vec<String>,
 }
 
+#[derive(Debug, Clone, Deserialize)]
+pub struct WeatherChangePayload {
+    pub weather: String,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct MoodChangePayload {
+    pub mood: String,
+}
+
 // ─── Bevy Events ──────────────────────────
 
 #[derive(Message, Debug, Clone)]
@@ -113,3 +123,9 @@ pub struct CharacterDied(pub DeathPayload);
 #[allow(dead_code)]
 #[derive(Message, Debug, Clone)]
 pub struct CombatStarted(pub CombatPayload);
+
+#[derive(Message, Debug, Clone)]
+pub struct WeatherChanged(pub WeatherChangePayload);
+
+#[derive(Message, Debug, Clone)]
+pub struct MoodChanged(pub MoodChangePayload);

--- a/viewer/src/game/mod.rs
+++ b/viewer/src/game/mod.rs
@@ -23,6 +23,7 @@ impl Plugin for GameStatePlugin {
             .init_resource::<RoomState>()
             .init_resource::<MapState>()
             .init_resource::<ConnectionStatus>()
+            .init_resource::<OverlayState>()
             // Events (type registrations — always available)
             .add_message::<DiceRolled>()
             .add_message::<HpChanged>()
@@ -34,6 +35,8 @@ impl Plugin for GameStatePlugin {
             .add_message::<ItemAcquired>()
             .add_message::<CharacterDied>()
             .add_message::<CombatStarted>()
+            .add_message::<WeatherChanged>()
+            .add_message::<MoodChanged>()
             // ── TRPG-gated systems ──
             .add_systems(OnEnter(ViewerMode::Trpg), http::fetch_initial_state)
             .add_systems(Update, (
@@ -43,6 +46,8 @@ impl Plugin for GameStatePlugin {
                 systems::apply_turn_advance,
                 systems::apply_item_acquired,
                 systems::apply_character_death,
+                systems::apply_weather_change,
+                systems::apply_mood_change,
             ).run_if(in_state(ViewerMode::Trpg)));
     }
 }

--- a/viewer/src/game/state.rs
+++ b/viewer/src/game/state.rs
@@ -58,6 +58,13 @@ pub struct MapState {
     pub area_label: String,
 }
 
+/// Current weather and mood overlay state.
+#[derive(Resource, Debug, Default)]
+pub struct OverlayState {
+    pub weather: String,
+    pub mood: String,
+}
+
 /// Connection status for the SSE stream.
 #[derive(Resource, Debug, Default)]
 pub enum ConnectionStatus {

--- a/viewer/src/game/systems.rs
+++ b/viewer/src/game/systems.rs
@@ -63,6 +63,26 @@ pub fn apply_item_acquired(
     }
 }
 
+/// Apply weather change events to OverlayState.
+pub fn apply_weather_change(
+    mut events: MessageReader<WeatherChanged>,
+    mut overlay_state: ResMut<OverlayState>,
+) {
+    for WeatherChanged(payload) in events.read() {
+        overlay_state.weather = payload.weather.clone();
+    }
+}
+
+/// Apply mood change events to OverlayState.
+pub fn apply_mood_change(
+    mut events: MessageReader<MoodChanged>,
+    mut overlay_state: ResMut<OverlayState>,
+) {
+    for MoodChanged(payload) in events.read() {
+        overlay_state.mood = payload.mood.clone();
+    }
+}
+
 /// Apply character death events.
 pub fn apply_character_death(
     mut events: MessageReader<CharacterDied>,

--- a/viewer/src/render/mod.rs
+++ b/viewer/src/render/mod.rs
@@ -1,12 +1,13 @@
 pub mod characters;
 pub mod fx;
 pub mod map;
+pub mod overlay;
 pub mod transition;
 
 use bevy::prelude::*;
 
 use crate::game::components::{
-    FloatingText, GameCamera, HpBarSprite, MapBackground, MapToken,
+    FloatingText, GameCamera, HpBarSprite, MapBackground, MapToken, MoodOverlay, WeatherOverlay,
 };
 use crate::mode::ViewerMode;
 use crate::render::transition::{FadeOverlay, SceneTransition};
@@ -25,6 +26,8 @@ impl Plugin for MapRenderPlugin {
             .add_systems(OnEnter(ViewerMode::Trpg), (
                 map::setup_camera,
                 map::setup_map_background,
+                overlay::setup_weather_overlay,
+                overlay::setup_mood_overlay,
                 transition::setup_fade_overlay,
             ))
             // Update: character sprites, positions, HP bars, effects, transitions
@@ -37,6 +40,9 @@ impl Plugin for MapRenderPlugin {
                 map::update_map_texture,
                 fx::spawn_damage_text,
                 fx::animate_floating_text,
+                overlay::update_weather_overlay,
+                overlay::update_mood_overlay,
+                overlay::spawn_prop_notification,
                 transition::trigger_scene_transition,
                 transition::animate_scene_transition,
             ).run_if(in_state(ViewerMode::Trpg)))
@@ -60,6 +66,8 @@ fn cleanup_trpg_scene(
             With<FadeOverlay>,
             With<FloatingText>,
             With<HpBarSprite>,
+            With<WeatherOverlay>,
+            With<MoodOverlay>,
         )>,
     >,
     mut scene_transition: ResMut<SceneTransition>,

--- a/viewer/src/render/overlay.rs
+++ b/viewer/src/render/overlay.rs
@@ -1,0 +1,107 @@
+use bevy::prelude::*;
+
+use crate::assets;
+use crate::game::components::{FloatingText, MapToken, MoodOverlay, WeatherOverlay};
+use crate::game::events::ItemAcquired;
+use crate::game::state::OverlayState;
+
+/// Spawns the weather overlay sprite (full-screen, z = -9.0).
+/// Starts fully transparent until a weather state is received via SSE.
+pub fn setup_weather_overlay(mut commands: Commands) {
+    commands.spawn((
+        Sprite {
+            color: Color::srgba(1.0, 1.0, 1.0, 0.0),
+            custom_size: Some(Vec2::new(1280.0, 720.0)),
+            ..default()
+        },
+        Transform::from_xyz(0.0, 0.0, -9.0),
+        WeatherOverlay,
+    ));
+}
+
+/// Spawns the mood overlay sprite (full-screen, z = -8.0).
+/// Starts fully transparent until a mood state is received via SSE.
+pub fn setup_mood_overlay(mut commands: Commands) {
+    commands.spawn((
+        Sprite {
+            color: Color::srgba(1.0, 1.0, 1.0, 0.0),
+            custom_size: Some(Vec2::new(1280.0, 720.0)),
+            ..default()
+        },
+        Transform::from_xyz(0.0, 0.0, -8.0),
+        MoodOverlay,
+    ));
+}
+
+/// Swaps the weather overlay texture when `OverlayState.weather` changes.
+pub fn update_weather_overlay(
+    overlay_state: Res<OverlayState>,
+    asset_server: Res<AssetServer>,
+    mut overlays: Query<&mut Sprite, With<WeatherOverlay>>,
+) {
+    if !overlay_state.is_changed() {
+        return;
+    }
+
+    for mut sprite in &mut overlays {
+        if let Some(path) = assets::weather_for(&overlay_state.weather) {
+            sprite.image = asset_server.load(path);
+            sprite.color = Color::srgba(1.0, 1.0, 1.0, 0.6);
+        } else {
+            sprite.color = Color::srgba(1.0, 1.0, 1.0, 0.0);
+        }
+    }
+}
+
+/// Swaps the mood overlay texture when `OverlayState.mood` changes.
+pub fn update_mood_overlay(
+    overlay_state: Res<OverlayState>,
+    asset_server: Res<AssetServer>,
+    mut overlays: Query<&mut Sprite, With<MoodOverlay>>,
+) {
+    if !overlay_state.is_changed() {
+        return;
+    }
+
+    for mut sprite in &mut overlays {
+        if let Some(path) = assets::mood_for(&overlay_state.mood) {
+            sprite.image = asset_server.load(path);
+            sprite.color = Color::srgba(1.0, 1.0, 1.0, 0.4);
+        } else {
+            sprite.color = Color::srgba(1.0, 1.0, 1.0, 0.0);
+        }
+    }
+}
+
+/// Spawns a floating prop icon above the character when an item is acquired.
+/// Reuses the `FloatingText` component so `fx::animate_floating_text` handles
+/// the upward drift and despawn — no extra cleanup needed.
+pub fn spawn_prop_notification(
+    mut commands: Commands,
+    mut events: MessageReader<ItemAcquired>,
+    asset_server: Res<AssetServer>,
+    actors: Query<(&crate::game::components::Actor, &Transform), With<MapToken>>,
+) {
+    for ItemAcquired(payload) in events.read() {
+        let pos = actors
+            .iter()
+            .find(|(a, _)| a.id == payload.character)
+            .map(|(_, t)| t.translation)
+            .unwrap_or(Vec3::ZERO);
+
+        if let Some(path) = assets::prop_for(&payload.item) {
+            commands.spawn((
+                Sprite {
+                    image: asset_server.load(path),
+                    custom_size: Some(Vec2::new(32.0, 32.0)),
+                    ..default()
+                },
+                Transform::from_xyz(pos.x + 40.0, pos.y + 30.0, 2.0),
+                FloatingText {
+                    timer: Timer::from_seconds(2.0, TimerMode::Once),
+                    velocity: Vec2::new(0.0, 20.0),
+                },
+            ));
+        }
+    }
+}

--- a/viewer/src/sse/bridge.rs
+++ b/viewer/src/sse/bridge.rs
@@ -17,6 +17,8 @@ pub fn poll_sse_events(
     mut item_events: MessageWriter<ItemAcquired>,
     mut death_events: MessageWriter<CharacterDied>,
     mut combat_events: MessageWriter<CombatStarted>,
+    mut weather_events: MessageWriter<WeatherChanged>,
+    mut mood_events: MessageWriter<MoodChanged>,
     mut connection: ResMut<ConnectionStatus>,
 ) {
     let Some(receiver) = receiver else { return };
@@ -91,6 +93,18 @@ pub fn poll_sse_events(
                 match serde_json::from_str::<CombatPayload>(&data) {
                     Ok(payload) => { combat_events.write(CombatStarted(payload)); }
                     Err(e) => log::warn!("Failed to parse combat_start: {}", e),
+                }
+            }
+            "weather_change" => {
+                match serde_json::from_str::<WeatherChangePayload>(&data) {
+                    Ok(payload) => { weather_events.write(WeatherChanged(payload)); }
+                    Err(e) => log::warn!("Failed to parse weather_change: {}", e),
+                }
+            }
+            "mood_change" => {
+                match serde_json::from_str::<MoodChangePayload>(&data) {
+                    Ok(payload) => { mood_events.write(MoodChanged(payload)); }
+                    Err(e) => log::warn!("Failed to parse mood_change: {}", e),
                 }
             }
             other => {


### PR DESCRIPTION
## Summary
- Weather overlay (z=-9.0) and mood overlay (z=-8.0) full-screen sprites that swap textures on SSE state changes
- Prop notification system — floating item icons above characters on `ItemAcquired` events, reusing `FloatingText` for animation
- SSE bridge handles `weather_change` and `mood_change` event types
- All 3 previously-dead asset lookup functions (`weather_for`, `mood_for`, `prop_for`) are now consumed by real ECS systems

## Changes (8 files, +186/-1)
| File | Change |
|------|--------|
| `game/components.rs` | `WeatherOverlay`, `MoodOverlay` marker components |
| `game/state.rs` | `OverlayState` resource (weather + mood strings) |
| `game/events.rs` | `WeatherChanged`, `MoodChanged` events + payloads |
| `game/systems.rs` | `apply_weather_change`, `apply_mood_change` |
| `game/mod.rs` | Register resource, events, systems in plugin |
| `sse/bridge.rs` | Dispatch `weather_change`, `mood_change` SSE events |
| `render/overlay.rs` | **NEW** — 5 systems (setup x2, update x2, prop notification) |
| `render/mod.rs` | Wire overlay module into `MapRenderPlugin` + cleanup query |

## Test plan
- [x] `cargo check` passes — 0 warnings from assets/overlay code
- [ ] `trunk build` produces WASM without dead_code warnings for weather/mood/prop
- [ ] SSE `weather_change` event swaps overlay texture (manual test with TRPG session)