### PR TITLE
feat(pulse): add Pulse tick engine for Space abstraction

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -92,6 +92,7 @@
    planning_eio
    process_eio
    progress
+   pulse
    relay
    resilience
    response

--- a/lib/masc_mcp.ml
+++ b/lib/masc_mcp.ml
@@ -55,6 +55,7 @@ module Web_dashboard = Web_dashboard
 module Credits_dashboard = Credits_dashboard
 module Lodge_dashboard = Lodge_dashboard
 module Progress = Progress
+module Pulse = Pulse
 module Cancellation = Cancellation
 module Subscriptions = Subscriptions
 

--- a/lib/pulse.ml
+++ b/lib/pulse.ml
@@ -1,0 +1,262 @@
+(** Pulse — the beating heart of any Space.
+
+    Implementation notes:
+    - [Eio.Fiber.first] races timer vs nudge-wait. First to complete wins.
+    - Nudge signaling: [Eio.Stream] (capacity 1) — cancellation-safe, no mutex.
+    - Shutdown signaling: [Eio.Promise] — one-shot, non-blocking resolve.
+    - Quiet hours stretch the interval by 3x (configurable via rhythm).
+    - Consumer errors are logged but never crash the pulse.
+*)
+
+(* ── Types ───────────────────────────────────────────────────── *)
+
+type trigger =
+  | Rhythm
+  | Nudge of string
+  | Demand
+
+type beat = {
+  seq     : int;
+  ts      : float;
+  trigger : trigger;
+}
+
+type rhythm = {
+  base_s  : float;
+  min_s   : float;
+  max_s   : float;
+  quiet   : int * int;
+}
+
+type lifecycle =
+  | Perpetual
+  | Bounded of (beat -> bool)
+
+type stats = {
+  total_beats   : int;
+  total_nudges  : int;
+  uptime_s      : float;
+  avg_interval  : float;
+}
+
+module type Consumer = sig
+  val name       : string
+  val should_act : beat -> bool
+  val on_beat    : beat -> (unit, string) result
+end
+
+(* ── Internal state ──────────────────────────────────────────── *)
+
+type any_clock = Clock : _ Eio.Time.clock -> any_clock
+
+type t = {
+  clock      : any_clock;
+  rhythm     : rhythm;
+  lifecycle  : lifecycle;
+  mutable consumers : (module Consumer) list;
+  (* nudge signaling — Stream is cancellation-safe under Fiber.first *)
+  nudge_stream : string Eio.Stream.t;
+  (* shutdown signaling — Promise is one-shot and non-blocking *)
+  shutdown_p   : unit Eio.Promise.t;
+  shutdown_r   : unit Eio.Promise.u;
+  (* engine state *)
+  mutable seq         : int;
+  mutable last_beat_v : beat option;
+  mutable alive       : bool;
+  mutable total_nudges: int;
+  mutable start_ts    : float;
+}
+
+(* ── Defaults ────────────────────────────────────────────────── *)
+
+let default_rhythm = {
+  base_s = 60.0;
+  min_s  = 30.0;
+  max_s  = 300.0;
+  quiet  = (1, 6);
+}
+
+(* ── Helpers ─────────────────────────────────────────────────── *)
+
+let now (Clock c) = Eio.Time.now c
+let sleep (Clock c) s = Eio.Time.sleep c s
+
+(** Current KST hour (UTC+9). *)
+let kst_hour clock =
+  let t = Unix.gmtime (now clock) in
+  (t.tm_hour + 9) mod 24
+
+(** Is the current hour within the quiet window? *)
+let is_quiet_hour clock rhythm =
+  let h = kst_hour clock in
+  let (qs, qe) = rhythm.quiet in
+  if qs <= qe then
+    (* e.g., 1..6 *)
+    h >= qs && h < qe
+  else
+    (* wrap-around, e.g., 22..6 *)
+    h >= qs || h < qe
+
+(** Compute the effective interval for the next beat.
+    Quiet hours stretch the base interval by 3x, clamped to [min, max]. *)
+let effective_interval clock rhythm =
+  let base =
+    if is_quiet_hour clock rhythm then
+      rhythm.base_s *. 3.0
+    else
+      rhythm.base_s
+  in
+  Float.max rhythm.min_s (Float.min rhythm.max_s base)
+
+(* ── Consumer dispatch ───────────────────────────────────────── *)
+
+let trigger_to_string = function
+  | Rhythm    -> "rhythm"
+  | Nudge r   -> Printf.sprintf "nudge(%s)" r
+  | Demand    -> "demand"
+
+let dispatch_consumers consumers beat =
+  List.iter (fun (module C : Consumer) ->
+    if C.should_act beat then begin
+      match C.on_beat beat with
+      | Ok () -> ()
+      | Error msg ->
+        Eio.traceln "[pulse] consumer %s error on beat #%d: %s"
+          C.name beat.seq msg
+    end
+  ) consumers
+
+(* ── Core loop ───────────────────────────────────────────────── *)
+
+(** Is shutdown requested? Non-blocking check. *)
+let is_shutdown t =
+  match Eio.Promise.peek t.shutdown_p with
+  | Some () -> true
+  | None -> false
+
+(** One tick: determine trigger, make beat, dispatch consumers, check lifecycle. *)
+let tick t trigger =
+  t.seq <- t.seq + 1;
+  let beat = {
+    seq     = t.seq;
+    ts      = now t.clock;
+    trigger;
+  } in
+  t.last_beat_v <- Some beat;
+  (match trigger with Nudge _ -> t.total_nudges <- t.total_nudges + 1 | _ -> ());
+  Eio.traceln "[pulse] beat #%d trigger=%s" beat.seq (trigger_to_string trigger);
+  dispatch_consumers t.consumers beat;
+  (* Check bounded lifecycle *)
+  (match t.lifecycle with
+   | Perpetual -> ()
+   | Bounded pred ->
+     if pred beat && not (is_shutdown t) then begin
+       Eio.traceln "[pulse] bounded lifecycle condition met at beat #%d" beat.seq;
+       Eio.Promise.resolve t.shutdown_r ()
+     end);
+  beat
+
+(** The main pulse loop. Races timer vs nudge vs shutdown on each iteration.
+
+    The three-way race uses nested [Eio.Fiber.first]:
+    - Outer: timer vs (nudge | shutdown)
+    - Inner: nudge (Stream.take) vs shutdown (Promise.await)
+
+    All three blocking primitives (sleep, Stream.take, Promise.await) are
+    cleanly cancellable — no Mutex involvement, no Poisoned risk. *)
+let loop t =
+  (* Beat 0: startup demand *)
+  let _startup_beat = tick t Demand in
+  while not (is_shutdown t) do
+    let interval = effective_interval t.clock t.rhythm in
+    (* Non-blocking drain: if a nudge arrived between beats, handle it now *)
+    match Eio.Stream.take_nonblocking t.nudge_stream with
+    | Some reason ->
+      let _b = tick t (Nudge reason) in ()
+    | None ->
+      (* Three-way race: timer vs (nudge | shutdown) *)
+      let trigger =
+        Eio.Fiber.first
+          (fun () ->
+             sleep t.clock interval;
+             Rhythm)
+          (fun () ->
+             Eio.Fiber.first
+               (fun () ->
+                  let reason = Eio.Stream.take t.nudge_stream in
+                  Nudge reason)
+               (fun () ->
+                  Eio.Promise.await t.shutdown_p;
+                  Demand))
+      in
+      if not (is_shutdown t) then
+        let _b = tick t trigger in ()
+  done;
+  (* Final beat: shutdown demand *)
+  let _shutdown_beat = tick t Demand in
+  t.alive <- false;
+  Eio.traceln "[pulse] stopped after %d beats" t.seq
+
+(* ── Public API ──────────────────────────────────────────────── *)
+
+let create ~clock ~rhythm ~lifecycle ~consumers =
+  let ac = Clock clock in
+  let (shutdown_p, shutdown_r) = Eio.Promise.create () in
+  {
+    clock = ac;
+    rhythm;
+    lifecycle;
+    consumers;
+    nudge_stream = Eio.Stream.create 1;
+    shutdown_p;
+    shutdown_r;
+    seq         = 0;
+    last_beat_v = None;
+    alive       = false;
+    total_nudges= 0;
+    start_ts    = now ac;
+  }
+
+let run ~sw t =
+  t.alive    <- true;
+  t.start_ts <- now t.clock;
+  Eio.Fiber.fork ~sw (fun () ->
+    Fun.protect
+      (fun () -> loop t)
+      ~finally:(fun () -> t.alive <- false)
+  )
+
+let nudge t ~reason =
+  if t.alive && Eio.Stream.is_empty t.nudge_stream then
+    (* Capacity-1 mailbox: buffer one nudge. If already pending, coalesce
+       (skip the new one — the loop will fire a Nudge beat soon anyway).
+       The is_empty guard avoids blocking on a full stream. *)
+    Eio.Stream.add t.nudge_stream reason
+
+let shutdown t =
+  if not (is_shutdown t) then
+    Eio.Promise.resolve t.shutdown_r ()
+
+let stats t =
+  let uptime = (now t.clock) -. t.start_ts in
+  let avg =
+    if t.seq > 0 then uptime /. (Float.of_int t.seq)
+    else 0.0
+  in
+  {
+    total_beats  = t.seq;
+    total_nudges = t.total_nudges;
+    uptime_s     = uptime;
+    avg_interval = avg;
+  }
+
+let last_beat t = t.last_beat_v
+let is_alive t  = t.alive
+
+let add_consumer t consumer =
+  t.consumers <- t.consumers @ [consumer]
+
+let remove_consumer t name =
+  let before = List.length t.consumers in
+  t.consumers <- List.filter (fun (module C : Consumer) -> C.name <> name) t.consumers;
+  List.length t.consumers < before

--- a/lib/pulse.mli
+++ b/lib/pulse.mli
@@ -1,0 +1,125 @@
+(** Pulse — the beating heart of any Space.
+
+    A Space is an abstracted environment where agents exist and act.
+    Lodge (perpetual, no end) and TRPG (bounded, session ends) are both Spaces.
+    The only axis of variation is lifecycle: when does the heart stop?
+
+    The Pulse is a tick engine driven by two forces:
+    - Rhythm: a timer that fires at adaptive intervals (the SA node)
+    - Nudge: an external stimulus that demands an immediate beat (adrenaline)
+
+    Consumers register callbacks and ride each beat. The Pulse doesn't know
+    what its consumers do — it only knows when to beat and whom to notify.
+
+    Concurrency model: Eio.Fiber.first races the timer fiber against
+    the nudge-wait fiber. Whichever completes first triggers the next beat.
+
+    @since 2.62.0 *)
+
+(** {1 Core Types} *)
+
+(** Why did this beat happen? *)
+type trigger =
+  | Rhythm                (** Regular interval elapsed *)
+  | Nudge of string       (** External stimulus with reason *)
+  | Demand                (** Forced immediate beat (startup, shutdown) *)
+
+(** A single heartbeat event. *)
+type beat = {
+  seq     : int;          (** Monotonically increasing beat counter *)
+  ts      : float;        (** Unix timestamp when this beat fired *)
+  trigger : trigger;      (** What caused this beat *)
+}
+
+(** Adaptive rhythm configuration. *)
+type rhythm = {
+  base_s  : float;        (** Base interval in seconds *)
+  min_s   : float;        (** Floor: never beat faster than this *)
+  max_s   : float;        (** Ceiling: never beat slower than this *)
+  quiet   : int * int;    (** (start_hour, end_hour) in KST — stretch interval during these hours *)
+}
+
+(** Space lifecycle. The only difference between spaces. *)
+type lifecycle =
+  | Perpetual             (** Never stops (Lodge). Runs until explicit shutdown. *)
+  | Bounded of (beat -> bool)
+    (** Stops when predicate returns true (TRPG session end, time limit, etc.) *)
+
+(** Runtime statistics. *)
+type stats = {
+  total_beats   : int;
+  total_nudges  : int;
+  uptime_s      : float;
+  avg_interval  : float;
+}
+
+(** {1 Consumer — who rides each beat} *)
+
+(** A consumer is a first-class module that reacts to beats.
+    The Pulse calls [should_act] to filter, then [on_beat] to execute.
+    Consumers are fully decoupled — they don't know about each other. *)
+module type Consumer = sig
+  val name       : string
+  val should_act : beat -> bool
+  val on_beat    : beat -> (unit, string) result
+end
+
+(** {1 Engine} *)
+
+(** The Pulse engine. Opaque mutable state. *)
+type t
+
+(** Create a new Pulse engine.
+
+    @param clock Eio clock for sleeping and timestamps
+    @param rhythm Adaptive rhythm configuration
+    @param lifecycle Perpetual or Bounded
+    @param consumers First-class consumer modules to notify on each beat *)
+val create :
+  clock:_ Eio.Time.clock ->
+  rhythm:rhythm ->
+  lifecycle:lifecycle ->
+  consumers:(module Consumer) list ->
+  t
+
+(** Start the pulse loop. Blocks the calling fiber until the lifecycle ends.
+    Call this inside [Eio.Switch.run] or [Eio.Fiber.fork].
+
+    @param sw Eio switch for managing child fibers *)
+val run : sw:Eio.Switch.t -> t -> unit
+
+(** Send an immediate nudge to the pulse from outside.
+    Thread-safe. Can be called from any fiber. The next beat will fire
+    immediately with [Nudge reason] as its trigger.
+
+    @param reason Human-readable reason for the nudge *)
+val nudge : t -> reason:string -> unit
+
+(** Request a graceful shutdown. The current beat (if any) will complete,
+    then the loop exits. For [Bounded] spaces, this is also called
+    automatically when the predicate returns true. *)
+val shutdown : t -> unit
+
+(** {1 Queries} *)
+
+(** Current runtime statistics. *)
+val stats : t -> stats
+
+(** The most recent beat, or [None] if the engine hasn't started. *)
+val last_beat : t -> beat option
+
+(** Is the engine currently running? *)
+val is_alive : t -> bool
+
+(** {1 Dynamic Consumer Management} *)
+
+(** Add a consumer while the engine is running. Takes effect on the next beat. *)
+val add_consumer : t -> (module Consumer) -> unit
+
+(** Remove a consumer by name. Returns [true] if found and removed. *)
+val remove_consumer : t -> string -> bool
+
+(** {1 Defaults} *)
+
+(** Default rhythm: 60s base, 30s min, 300s max, quiet 01:00-06:00 KST. *)
+val default_rhythm : rhythm

--- a/test/dune
+++ b/test/dune
@@ -360,6 +360,12 @@
  (modules test_agent_ecosystem)
  (libraries masc_mcp alcotest str))
 
+; Pulse module tests (Space heartbeat engine — Eio real clock)
+(test
+ (name test_pulse)
+ (modules test_pulse)
+ (libraries masc_mcp eio eio_main unix))
+
 ; Perpetual Agent Runtime tests (infinite context system)
 (test
  (name test_perpetual)

--- a/test/test_pulse.ml
+++ b/test/test_pulse.ml
@@ -1,0 +1,283 @@
+(** Pulse module tests.
+
+    Tests the tick engine using Eio.Stdenv.clock (real clock).
+    Each test uses very short intervals (0.05s-0.2s) to keep tests fast. *)
+
+open Masc_mcp
+
+let passed = ref 0
+let failed = ref 0
+
+let test name fn =
+  try
+    fn ();
+    incr passed;
+    Printf.printf "  PASS  %s\n%!" name
+  with e ->
+    incr failed;
+    Printf.printf "  FAIL  %s: %s\n%!" name (Printexc.to_string e)
+
+(* ── Test: create and basic properties ─────────────────────── *)
+
+let () = test "create returns not-alive engine" (fun () ->
+  Eio_main.run @@ fun env ->
+  let clock = Eio.Stdenv.clock env in
+  let t = Pulse.create
+    ~clock
+    ~rhythm:{ Pulse.base_s = 1.0; min_s = 0.5; max_s = 5.0; quiet = (1, 6) }
+    ~lifecycle:Pulse.Perpetual
+    ~consumers:[]
+  in
+  assert (not (Pulse.is_alive t));
+  assert (Pulse.last_beat t = None);
+  let s = Pulse.stats t in
+  assert (s.total_beats = 0)
+)
+
+(* ── Test: run fires startup demand beat ───────────────────── *)
+
+let () = test "run fires startup demand beat and can shutdown" (fun () ->
+  Eio_main.run @@ fun env ->
+  let clock = Eio.Stdenv.clock env in
+  let beats = ref [] in
+  let consumer = (module struct
+    let name = "recorder"
+    let should_act _b = true
+    let on_beat b =
+      beats := b :: !beats;
+      Ok ()
+  end : Pulse.Consumer) in
+  let t = Pulse.create
+    ~clock
+    ~rhythm:{ Pulse.base_s = 0.1; min_s = 0.05; max_s = 1.0; quiet = (1, 6) }
+    ~lifecycle:Pulse.Perpetual
+    ~consumers:[consumer]
+  in
+  Eio.Switch.run @@ fun sw ->
+  Pulse.run ~sw t;
+  (* Wait for startup beat + one rhythm beat *)
+  Eio.Time.sleep clock 0.25;
+  Pulse.shutdown t;
+  Eio.Time.sleep clock 0.15;
+  (* Should have at least: startup(Demand) + rhythm + shutdown(Demand) *)
+  let n = List.length !beats in
+  if n < 2 then
+    failwith (Printf.sprintf "expected >=2 beats, got %d" n);
+  (* First beat should be Demand (startup) *)
+  let first = List.rev !beats |> List.hd in
+  (match first.trigger with
+   | Pulse.Demand -> ()
+   | _ -> failwith "first beat should be Demand (startup)");
+  assert (not (Pulse.is_alive t))
+)
+
+(* ── Test: nudge triggers immediate beat ───────────────────── *)
+
+let () = test "nudge triggers immediate beat" (fun () ->
+  Eio_main.run @@ fun env ->
+  let clock = Eio.Stdenv.clock env in
+  let triggers = ref [] in
+  let consumer = (module struct
+    let name = "trigger-spy"
+    let should_act _b = true
+    let on_beat b =
+      triggers := b.Pulse.trigger :: !triggers;
+      Ok ()
+  end : Pulse.Consumer) in
+  let t = Pulse.create
+    ~clock
+    ~rhythm:{ Pulse.base_s = 10.0; min_s = 5.0; max_s = 20.0; quiet = (1, 6) }
+    ~lifecycle:Pulse.Perpetual
+    ~consumers:[consumer]
+  in
+  Eio.Switch.run @@ fun sw ->
+  Pulse.run ~sw t;
+  Eio.Time.sleep clock 0.05;  (* let startup beat fire *)
+  Pulse.nudge t ~reason:"test-nudge";
+  Eio.Time.sleep clock 0.15;  (* let nudge beat process *)
+  Pulse.shutdown t;
+  Eio.Time.sleep clock 0.15;
+  let has_nudge = List.exists (function
+    | Pulse.Nudge r -> r = "test-nudge"
+    | _ -> false
+  ) !triggers in
+  if not has_nudge then
+    failwith "expected a Nudge(test-nudge) trigger in beats"
+)
+
+(* ── Test: bounded lifecycle stops engine ──────────────────── *)
+
+let () = test "bounded lifecycle stops after predicate" (fun () ->
+  Eio_main.run @@ fun env ->
+  let clock = Eio.Stdenv.clock env in
+  let beat_count = ref 0 in
+  let consumer = (module struct
+    let name = "counter"
+    let should_act _b = true
+    let on_beat _b =
+      incr beat_count;
+      Ok ()
+  end : Pulse.Consumer) in
+  (* Stop after 3 beats (including startup demand) *)
+  let lifecycle = Pulse.Bounded (fun b -> b.Pulse.seq >= 3) in
+  let t = Pulse.create
+    ~clock
+    ~rhythm:{ Pulse.base_s = 0.05; min_s = 0.03; max_s = 1.0; quiet = (1, 6) }
+    ~lifecycle
+    ~consumers:[consumer]
+  in
+  Eio.Switch.run @@ fun sw ->
+  Pulse.run ~sw t;
+  (* Wait enough for several beats *)
+  Eio.Time.sleep clock 0.5;
+  (* Engine should have stopped *)
+  assert (not (Pulse.is_alive t));
+  let s = Pulse.stats t in
+  (* seq >= 3 at the point of stop, plus shutdown demand = seq >= 4 *)
+  if s.total_beats < 3 then
+    failwith (Printf.sprintf "expected >=3 beats, got %d" s.total_beats)
+)
+
+(* ── Test: consumer error doesn't crash pulse ─────────────── *)
+
+let () = test "consumer error doesn't crash pulse" (fun () ->
+  Eio_main.run @@ fun env ->
+  let clock = Eio.Stdenv.clock env in
+  let good_count = ref 0 in
+  let bad_consumer = (module struct
+    let name = "bomb"
+    let should_act _b = true
+    let on_beat _b = Error "boom"
+  end : Pulse.Consumer) in
+  let good_consumer = (module struct
+    let name = "survivor"
+    let should_act _b = true
+    let on_beat _b =
+      incr good_count;
+      Ok ()
+  end : Pulse.Consumer) in
+  let t = Pulse.create
+    ~clock
+    ~rhythm:{ Pulse.base_s = 0.05; min_s = 0.03; max_s = 1.0; quiet = (1, 6) }
+    ~lifecycle:Pulse.Perpetual
+    ~consumers:[bad_consumer; good_consumer]
+  in
+  Eio.Switch.run @@ fun sw ->
+  Pulse.run ~sw t;
+  Eio.Time.sleep clock 0.2;
+  Pulse.shutdown t;
+  Eio.Time.sleep clock 0.1;
+  if !good_count < 2 then
+    failwith (Printf.sprintf "good consumer should have been called >=2 times, got %d" !good_count)
+)
+
+(* ── Test: should_act filtering ────────────────────────────── *)
+
+let () = test "should_act filters beats" (fun () ->
+  Eio_main.run @@ fun env ->
+  let clock = Eio.Stdenv.clock env in
+  let even_count = ref 0 in
+  let consumer = (module struct
+    let name = "even-only"
+    let should_act b = b.Pulse.seq mod 2 = 0
+    let on_beat _b =
+      incr even_count;
+      Ok ()
+  end : Pulse.Consumer) in
+  let t = Pulse.create
+    ~clock
+    ~rhythm:{ Pulse.base_s = 0.05; min_s = 0.03; max_s = 1.0; quiet = (1, 6) }
+    ~lifecycle:(Pulse.Bounded (fun b -> b.Pulse.seq >= 6))
+    ~consumers:[consumer]
+  in
+  Eio.Switch.run @@ fun sw ->
+  Pulse.run ~sw t;
+  Eio.Time.sleep clock 0.8;
+  (* Only even-numbered beats should have triggered the consumer *)
+  if !even_count = 0 then
+    failwith "even-only consumer was never called"
+)
+
+(* ── Test: add/remove consumer dynamically ─────────────────── *)
+
+let () = test "add and remove consumer dynamically" (fun () ->
+  Eio_main.run @@ fun env ->
+  let clock = Eio.Stdenv.clock env in
+  let late_count = ref 0 in
+  let t = Pulse.create
+    ~clock
+    ~rhythm:{ Pulse.base_s = 0.05; min_s = 0.03; max_s = 1.0; quiet = (1, 6) }
+    ~lifecycle:Pulse.Perpetual
+    ~consumers:[]
+  in
+  Eio.Switch.run @@ fun sw ->
+  Pulse.run ~sw t;
+  Eio.Time.sleep clock 0.1;
+  (* Add consumer after engine started *)
+  let late_consumer = (module struct
+    let name = "late-joiner"
+    let should_act _b = true
+    let on_beat _b =
+      incr late_count;
+      Ok ()
+  end : Pulse.Consumer) in
+  Pulse.add_consumer t late_consumer;
+  Eio.Time.sleep clock 0.15;
+  (* Remove it *)
+  let removed = Pulse.remove_consumer t "late-joiner" in
+  assert removed;
+  let count_at_remove = !late_count in
+  Eio.Time.sleep clock 0.15;
+  Pulse.shutdown t;
+  Eio.Time.sleep clock 0.1;
+  (* Should have been called at least once *)
+  if count_at_remove < 1 then
+    failwith "late-joiner was never called";
+  (* Should not increase after removal *)
+  if !late_count > count_at_remove + 1 then
+    failwith (Printf.sprintf "late-joiner called after removal: before=%d after=%d"
+      count_at_remove !late_count)
+)
+
+(* ── Test: default_rhythm values ───────────────────────────── *)
+
+let () = test "default_rhythm has sane values" (fun () ->
+  let r = Pulse.default_rhythm in
+  assert (r.base_s = 60.0);
+  assert (r.min_s = 30.0);
+  assert (r.max_s = 300.0);
+  assert (r.quiet = (1, 6))
+)
+
+(* ── Test: stats accuracy ──────────────────────────────────── *)
+
+let () = test "stats tracks beats and nudges" (fun () ->
+  Eio_main.run @@ fun env ->
+  let clock = Eio.Stdenv.clock env in
+  let t = Pulse.create
+    ~clock
+    ~rhythm:{ Pulse.base_s = 10.0; min_s = 5.0; max_s = 20.0; quiet = (1, 6) }
+    ~lifecycle:Pulse.Perpetual
+    ~consumers:[]
+  in
+  Eio.Switch.run @@ fun sw ->
+  Pulse.run ~sw t;
+  Eio.Time.sleep clock 0.05;
+  Pulse.nudge t ~reason:"n1";
+  Eio.Time.sleep clock 0.1;
+  Pulse.nudge t ~reason:"n2";
+  Eio.Time.sleep clock 0.1;
+  Pulse.shutdown t;
+  Eio.Time.sleep clock 0.15;
+  let s = Pulse.stats t in
+  if s.total_nudges < 2 then
+    failwith (Printf.sprintf "expected >=2 nudges, got %d" s.total_nudges);
+  if s.total_beats < 3 then
+    failwith (Printf.sprintf "expected >=3 beats (startup + 2 nudges), got %d" s.total_beats)
+)
+
+(* ── Summary ───────────────────────────────────────────────── *)
+
+let () =
+  Printf.printf "\nPulse tests: %d passed, %d failed\n%!" !passed !failed;
+  if !failed > 0 then exit 1


### PR DESCRIPTION
## Summary

- Pulse is the heartbeat of any Space (Lodge, TRPG, etc.)
- Lifecycle is the only axis of variation: `Perpetual` (never stops) vs `Bounded` (predicate-driven shutdown)
- Concurrency: `Eio.Stream` (nudge) + `Eio.Promise` (shutdown) + nested `Eio.Fiber.first` (three-way race)
- No Mutex/Condition — avoids Eio Poisoned mutex under structured cancellation

## Files

| File | Lines | Description |
|------|-------|-------------|
| `lib/pulse.mli` | 125 | Public interface (opaque `type t`, Consumer module type) |
| `lib/pulse.ml` | 262 | Implementation (Stream+Promise, three-way fiber race) |
| `test/test_pulse.ml` | 283 | 9 tests covering all public API |

## Test plan

- [x] `dune exec test/test_pulse.exe` — 9/9 passing
- [ ] Integration: wire Pulse into Lodge heartbeat (follow-up)
- [ ] Integration: wire Pulse into TRPG session (follow-up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)