### PR TITLE
fix(trpg): unblock round run by handling MCP SSE + timeout propagation

### DIFF
--- a/bin/main_eio.ml
+++ b/bin/main_eio.ml
@@ -633,7 +633,12 @@ let trpg_keeper_call_with_runtime
   : Masc_mcp.Tool_trpg.keeper_call_result =
   let keeper_ctx : _ Masc_mcp.Tool_keeper.context = { config; sw; clock } in
   let keeper_args =
-    `Assoc [ ("name", `String keeper_name); ("message", `String message) ]
+    `Assoc
+      [
+        ("name", `String keeper_name);
+        ("message", `String message);
+        ("ollama_timeout_sec", `Float timeout_sec);
+      ]
   in
   try
     Eio.Time.with_timeout_exn clock timeout_sec (fun () ->

--- a/lib/llm_client.ml
+++ b/lib/llm_client.ml
@@ -493,17 +493,17 @@ let build_ollama_chat_body (req : completion_request) : string =
   ] in
   Yojson.Safe.to_string (`Assoc body)
 
-let call_ollama_chat (req : completion_request) : (completion_response, string) result =
+let call_ollama_chat ?timeout_sec (req : completion_request) : (completion_response, string) result =
   let url = sprintf "%s/api/chat" req.model.api_url in
   let body = build_ollama_chat_body req in
   let headers = [("Content-Type", "application/json")] in
-  let timeout_sec = ollama_timeout_sec () in
+  let timeout_sec = Option.value timeout_sec ~default:(ollama_timeout_sec ()) in
   match curl_post ~url ~headers ~body ~timeout_sec with
   | Error e -> Error e
   | Ok raw -> parse_ollama_chat_response raw
 
 (** Ollama fallback: /api/generate for models without chat support. *)
-let call_ollama_generate (req : completion_request) : (completion_response, string) result =
+let call_ollama_generate ?timeout_sec (req : completion_request) : (completion_response, string) result =
   let url = sprintf "%s/api/generate" req.model.api_url in
   let prompt = List.fold_left (fun acc m ->
     match m.role with
@@ -519,7 +519,7 @@ let call_ollama_generate (req : completion_request) : (completion_response, stri
     ("stream", `Bool false);
   ]) in
   let headers = [("Content-Type", "application/json")] in
-  let timeout_sec = ollama_timeout_sec () in
+  let timeout_sec = Option.value timeout_sec ~default:(ollama_timeout_sec ()) in
   match curl_post ~url ~headers ~body ~timeout_sec with
   | Error e -> Error e
   | Ok raw -> parse_ollama_generate_response raw
@@ -568,18 +568,19 @@ let call_openai_compatible (req : completion_request) : (completion_response, st
 (* Core: complete                                                   *)
 (* ================================================================ *)
 
-let complete (req : completion_request) : (completion_response, string) result =
+let complete ?ollama_timeout_sec (req : completion_request) : (completion_response, string) result =
   let t0 = Time_compat.now () in
   let result = match req.model.provider with
     | Ollama ->
       (* Try chat API first.
          Fallback to /api/generate only for likely endpoint-support errors,
          because retrying on timeouts doubles latency and can exceed caller deadlines. *)
-      (match call_ollama_chat req with
+      (match call_ollama_chat ?timeout_sec:ollama_timeout_sec req with
        | Ok _ as ok -> ok
        | Error e ->
          if req.tools <> [] then Error e
-         else if ollama_should_fallback_to_generate e then call_ollama_generate req
+         else if ollama_should_fallback_to_generate e then
+           call_ollama_generate ?timeout_sec:ollama_timeout_sec req
          else Error e)
     | Claude -> call_claude req
     | Gemini | Glm_cloud | OpenRouter | Custom _ ->
@@ -593,7 +594,7 @@ let complete (req : completion_request) : (completion_response, string) result =
 (* Cascade: try models in order                                     *)
 (* ================================================================ *)
 
-let cascade (requests : completion_request list) : (completion_response, string) result =
+let cascade ?ollama_timeout_sec (requests : completion_request list) : (completion_response, string) result =
   let rec try_next errors = function
     | [] ->
       let all_errors = String.concat "; " (List.rev errors) in
@@ -601,7 +602,7 @@ let cascade (requests : completion_request list) : (completion_response, string)
     | req :: rest ->
       eprintf "[llm_client] cascade: trying %s (%s)\n%!"
         req.model.model_id (string_of_provider req.model.provider);
-      match complete req with
+      match complete ?ollama_timeout_sec req with
       | Ok resp ->
         eprintf "[llm_client] cascade: success with %s (%dms)\n%!"
           resp.model_used resp.latency_ms;

--- a/lib/llm_client.mli
+++ b/lib/llm_client.mli
@@ -91,13 +91,23 @@ type completion_response = {
 
 (** Call LLM with structured request.
     Uses subprocess curl for HTTP — no Eio runtime dependency.
+    Optional [ollama_timeout_sec] overrides Ollama request timeout (seconds)
+    for this call only.
     @return Ok response on success, Error message on failure. *)
-val complete : completion_request -> (completion_response, string) result
+val complete :
+  ?ollama_timeout_sec:int ->
+  completion_request ->
+  (completion_response, string) result
 
 (** Cascade — try models in order until one succeeds.
     Each request targets a different model. First success wins.
+    Optional [ollama_timeout_sec] overrides Ollama request timeout (seconds)
+    for all tries in this cascade.
     @return Ok response from first successful model, Error if all fail. *)
-val cascade : completion_request list -> (completion_response, string) result
+val cascade :
+  ?ollama_timeout_sec:int ->
+  completion_request list ->
+  (completion_response, string) result
 
 (** {1 Helpers} *)
 

--- a/lib/mcp_server_eio.ml
+++ b/lib/mcp_server_eio.ml
@@ -1148,7 +1148,12 @@ let execute_tool_eio ~sw ~clock ?mcp_session_id ?auth_token state ~name ~argumen
   let trpg_keeper_call ~name:keeper_name ~message ~timeout_sec :
       Tool_trpg.keeper_call_result =
     let keeper_args =
-      `Assoc [ ("name", `String keeper_name); ("message", `String message) ]
+      `Assoc
+        [
+          ("name", `String keeper_name);
+          ("message", `String message);
+          ("ollama_timeout_sec", `Float timeout_sec);
+        ]
     in
     try
       Eio.Time.with_timeout_exn clock timeout_sec (fun () ->

--- a/lib/tool_keeper.ml
+++ b/lib/tool_keeper.ml
@@ -276,6 +276,10 @@ Persists context + checkpoints. Auto-handoff is applied when needed.";
           ("items", `Assoc [("type", `String "string")]);
           ("description", `String "Optional: set models when creating keeper inline");
         ]);
+        ("ollama_timeout_sec", `Assoc [
+          ("type", `String "number");
+          ("description", `String "Optional: override Ollama timeout (sec) for this keeper message call");
+        ]);
         ("new_goal", `Assoc [
           ("type", `String "string");
           ("description", `String "Optional: replace keeper goal (persisted)");
@@ -5826,6 +5830,12 @@ let handle_keeper_msg ctx args : tool_result =
     let new_drift_enabled_opt = get_bool_opt args "new_drift_enabled" in
     let new_drift_min_turn_gap_opt = Safe_ops.json_int_opt "new_drift_min_turn_gap" args in
     let inline_models = get_string_list args "models" in
+    let ollama_timeout_sec_opt =
+      Safe_ops.json_float_opt "ollama_timeout_sec" args
+      |> Option.map (fun v ->
+             let sec = int_of_float (Float.ceil v) in
+             max 10 (min 300 sec))
+    in
     match inline_soul_profile_res, new_soul_profile_res with
     | Error e, _ | _, Error e -> (false, "❌ " ^ e)
     | Ok inline_soul_profile, Ok new_soul_profile ->
@@ -6151,7 +6161,7 @@ let handle_keeper_msg ctx args : tool_result =
             in
 
             (* Single-turn LLM call with cascade *)
-	            let requests =
+            let requests =
 	              List.map (fun (model : Llm_client.model_spec) ->
 	                let msgs =
 	                  (Llm_client.system_msg turn_system_prompt) :: ctx_work.messages
@@ -6166,8 +6176,14 @@ let handle_keeper_msg ctx args : tool_result =
                 } : Llm_client.completion_request)
               ) specs
             in
+            let run_cascade requests =
+              match ollama_timeout_sec_opt with
+              | Some timeout_sec ->
+                  Llm_client.cascade ~ollama_timeout_sec:timeout_sec requests
+              | None -> Llm_client.cascade requests
+            in
             let recall_candidates = recent_user_messages base_ctx.messages ~max_n:32 in
-            match Llm_client.cascade requests with
+            match run_cascade requests with
             | Error e ->
               (false, Printf.sprintf "❌ LLM failed: %s" e)
             | Ok resp0 ->
@@ -6253,7 +6269,7 @@ let handle_keeper_msg ctx args : tool_result =
                       } : Llm_client.completion_request)
                     ) specs
                   in
-                  match Llm_client.cascade followup_requests with
+                  match run_cascade followup_requests with
                   | Error _ ->
                     (* Cascade failed — return what we have *)
                     ( last_resp.Llm_client.content, acc_usage,
@@ -6329,7 +6345,7 @@ let handle_keeper_msg ctx args : tool_result =
                       } : Llm_client.completion_request)
                     ) specs
                   in
-                  match Llm_client.cascade correction_requests with
+                  match run_cascade correction_requests with
                   | Error _ ->
                     ( base_content, base_usage, base_model_used, base_latency_ms,
                       eval0, true, false, false, base_cost_usd, tools_used )
@@ -6393,7 +6409,7 @@ let handle_keeper_msg ctx args : tool_result =
                       } : Llm_client.completion_request)
                     ) specs
                   in
-                  match Llm_client.cascade forced_requests with
+                  match run_cascade forced_requests with
                   | Error _ ->
                       ( content_after_correction, usage_after_correction,
                         model_after_correction, latency_after_correction,

--- a/lib/web_dashboard.ml
+++ b/lib/web_dashboard.ml
@@ -1921,7 +1921,7 @@ let cached_html = lazy ({|<!DOCTYPE html>
                 </div>
                 <div class="trpg-control-field">
                   <label for="trpg-timeout-sec-input">Timeout (sec)</label>
-                  <input id="trpg-timeout-sec-input" type="number" min="1" step="1" value="30">
+                  <input id="trpg-timeout-sec-input" type="number" min="1" step="1" value="90">
                 </div>
                 <div class="trpg-control-field full">
                   <label for="trpg-player-keepers-input">Player Keepers (actor=keeper, one per line)</label>
@@ -7015,11 +7015,18 @@ let cached_html = lazy ({|<!DOCTYPE html>
     function parseTrpgToolText(name, text) {
       const raw = String(text || '').trim();
       if (raw === '') return {};
+      let parsed = {};
       try {
-        return JSON.parse(raw);
+        parsed = JSON.parse(raw);
       } catch (_) {
         throw new Error(`${name} 응답이 JSON이 아닙니다: ${trpgShortText(raw, 180)}`);
       }
+      if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)
+          && Object.prototype.hasOwnProperty.call(parsed, 'payload')) {
+        const payload = parsed.payload;
+        if (payload !== null && payload !== undefined) return payload;
+      }
+      return parsed;
     }
 
     function parseMcpRpcFromSse(toolName, rawBody) {
@@ -7034,12 +7041,12 @@ let cached_html = lazy ({|<!DOCTYPE html>
           .map((line) => line.slice(5).trimStart());
         if (dataLines.length === 0) continue;
         const dataText = dataLines.join('\n').trim();
-        if (dataText === '') continue;
+        if (dataText === '' || dataText === '[DONE]') continue;
         try {
           const parsed = JSON.parse(dataText);
           if (parsed && typeof parsed === 'object') return parsed;
         } catch (_) {
-          // keep scanning older chunks
+          // keep scanning older frames
         }
       }
       throw new Error(`${toolName} SSE 응답 파싱 실패: ${trpgShortText(raw, 220)}`);
@@ -7124,7 +7131,7 @@ let cached_html = lazy ({|<!DOCTYPE html>
     function updateTrpgButtons() {
       const runBtn = document.getElementById('trpg-run-round-btn');
       if (runBtn) {
-        runBtn.disabled = trpgRoundRunning || trpgBootstrapping;
+        runBtn.disabled = trpgRoundRunning;
         runBtn.textContent = trpgRoundRunning ? '실행 중...' : '라운드 실행';
       }
       const bootstrapBtn = document.getElementById('trpg-bootstrap-btn');
@@ -7322,13 +7329,13 @@ let cached_html = lazy ({|<!DOCTYPE html>
     }
 
     async function runTrpgRound() {
-      if (trpgRoundRunning || trpgBootstrapping) return;
+      if (trpgRoundRunning) return;
       ensureTrpgControlDefaults();
       const roomId = applyTrpgRoomFromInput();
       const dmKeeper = String((document.getElementById('trpg-dm-keeper-input') || {}).value || '').trim();
       const phase = String((document.getElementById('trpg-phase-select') || {}).value || 'round').trim() || 'round';
       const timeoutRaw = Number((document.getElementById('trpg-timeout-sec-input') || {}).value);
-      const timeoutSec = Number.isFinite(timeoutRaw) && timeoutRaw > 0 ? timeoutRaw : 30;
+      const timeoutSec = Number.isFinite(timeoutRaw) && timeoutRaw > 0 ? timeoutRaw : 90;
       const playerRaw = String((document.getElementById('trpg-player-keepers-input') || {}).value || '');
       if (!dmKeeper) {
         setTrpgRoundRunStatus('오류: DM keeper를 입력하세요.', 'error');

--- a/lib/web_dashboard.ml
+++ b/lib/web_dashboard.ml
@@ -7299,11 +7299,18 @@ let cached_html = lazy ({|<!DOCTYPE html>
       const mapping = {};
       for (const line of lines) {
         const eqIdx = line.indexOf('=');
-        if (eqIdx <= 0 || eqIdx === line.length - 1) {
-          return { ok: false, error: `잘못된 player keeper 형식: ${line}` };
+        let actorId = '';
+        let keeperName = '';
+        if (eqIdx < 0) {
+          actorId = line;
+          keeperName = line;
+        } else {
+          if (eqIdx <= 0 || eqIdx === line.length - 1) {
+            return { ok: false, error: `잘못된 player keeper 형식: ${line}` };
+          }
+          actorId = line.slice(0, eqIdx).trim();
+          keeperName = line.slice(eqIdx + 1).trim();
         }
-        const actorId = line.slice(0, eqIdx).trim();
-        const keeperName = line.slice(eqIdx + 1).trim();
         if (!actorId || !keeperName) {
           return { ok: false, error: `actor/keeper 값이 비어 있습니다: ${line}` };
         }

--- a/viewer/src/sse/client.rs
+++ b/viewer/src/sse/client.rs
@@ -128,10 +128,70 @@ fn map_trpg_event(
             Some(("hp_change".to_string(), mapped.to_string()))
         }
         "narration.posted" => {
+            let text = payload
+                .get("text")
+                .and_then(Value::as_str)
+                .or_else(|| payload.get("reply").and_then(Value::as_str))
+                .unwrap_or("");
             let mapped = json!({
-                "text": payload.get("text").and_then(Value::as_str).unwrap_or(""),
+                "text": text,
                 "phase": payload.get("phase").and_then(Value::as_str).unwrap_or(&state.last_phase),
-                "speaker": payload.get("speaker").and_then(Value::as_str)
+                "speaker": payload
+                    .get("speaker")
+                    .and_then(Value::as_str)
+                    .or_else(|| payload.get("keeper").and_then(Value::as_str))
+                    .or(actor_id)
+            });
+            Some(("narrative".to_string(), mapped.to_string()))
+        }
+        "turn.action.proposed" => {
+            let proposed = payload
+                .get("proposed_action")
+                .and_then(Value::as_str)
+                .or_else(|| payload.get("reply").and_then(Value::as_str))
+                .unwrap_or("action proposed");
+            let mapped = json!({
+                "text": proposed,
+                "phase": payload.get("phase").and_then(Value::as_str).unwrap_or(&state.last_phase),
+                "speaker": payload
+                    .get("actor_id")
+                    .and_then(Value::as_str)
+                    .or(actor_id)
+            });
+            Some(("narrative".to_string(), mapped.to_string()))
+        }
+        "turn.timeout" => {
+            let actor = payload
+                .get("actor_id")
+                .and_then(Value::as_str)
+                .or(actor_id)
+                .unwrap_or("unknown");
+            let timeout = payload.get("timeout_sec").and_then(Value::as_f64);
+            let text = match timeout {
+                Some(sec) => format!("[timeout] {} ({}s)", actor, sec.round()),
+                None => format!("[timeout] {}", actor),
+            };
+            let mapped = json!({
+                "text": text,
+                "phase": payload.get("phase").and_then(Value::as_str).unwrap_or(&state.last_phase),
+                "speaker": payload.get("keeper").and_then(Value::as_str)
+            });
+            Some(("narrative".to_string(), mapped.to_string()))
+        }
+        "keeper.unavailable" => {
+            let actor = payload
+                .get("actor_id")
+                .and_then(Value::as_str)
+                .or(actor_id)
+                .unwrap_or("unknown");
+            let reason = payload
+                .get("reason")
+                .and_then(Value::as_str)
+                .unwrap_or("unknown");
+            let mapped = json!({
+                "text": format!("[unavailable] {}: {}", actor, reason),
+                "phase": payload.get("phase").and_then(Value::as_str).unwrap_or(&state.last_phase),
+                "speaker": payload.get("keeper").and_then(Value::as_str)
             });
             Some(("narrative".to_string(), mapped.to_string()))
         }
@@ -445,5 +505,50 @@ mod tests {
         let payload: Value = serde_json::from_str(&mapped[0].1).expect("narrative payload json");
         assert_eq!(payload["text"], "문이 열린다");
         assert_eq!(payload["speaker"], "dm");
+    }
+
+    #[test]
+    fn decode_stream_maps_narration_reply_field() {
+        let body = r#"{
+            "events": [
+                {"seq": 1, "type": "narration.posted", "actor_id": "dm", "payload": {"phase": "round", "keeper": "dm-keeper", "reply": "안개가 짙어집니다."}}
+            ]
+        }"#;
+        let mut state = TrpgMapperState::default();
+        let (_, mapped) = decode_stream_events(body, &mut state).expect("decode should succeed");
+        assert_eq!(mapped.len(), 1);
+        assert_eq!(mapped[0].0, "narrative");
+
+        let payload: Value = serde_json::from_str(&mapped[0].1).expect("narrative payload json");
+        assert_eq!(payload["text"], "안개가 짙어집니다.");
+        assert_eq!(payload["speaker"], "dm-keeper");
+    }
+
+    #[test]
+    fn decode_stream_maps_timeout_and_unavailable_to_narrative() {
+        let body = r#"{
+            "events": [
+                {"seq": 1, "type": "turn.timeout", "payload": {"actor_id": "p01", "keeper": "pk-p01", "timeout_sec": 90, "phase": "round"}},
+                {"seq": 2, "type": "keeper.unavailable", "payload": {"actor_id": "p02", "keeper": "pk-p02", "reason": "LLM failed", "phase": "round"}}
+            ]
+        }"#;
+        let mut state = TrpgMapperState::default();
+        let (_, mapped) = decode_stream_events(body, &mut state).expect("decode should succeed");
+        assert_eq!(mapped.len(), 2);
+        assert_eq!(mapped[0].0, "narrative");
+        assert_eq!(mapped[1].0, "narrative");
+
+        let timeout_payload: Value =
+            serde_json::from_str(&mapped[0].1).expect("timeout narrative payload json");
+        assert!(
+            timeout_payload["text"]
+                .as_str()
+                .unwrap_or_default()
+                .contains("[timeout] p01")
+        );
+
+        let unavailable_payload: Value =
+            serde_json::from_str(&mapped[1].1).expect("unavailable narrative payload json");
+        assert_eq!(unavailable_payload["text"], "[unavailable] p02: LLM failed");
     }
 }


### PR DESCRIPTION
## Summary
- parse `/mcp` responses as either JSON or SSE data frames in dashboard `mcpToolCall`
- unwrap protocol wrapper payload for TRPG tool responses
- propagate TRPG round `timeout_sec` to `masc_keeper_msg` via `ollama_timeout_sec`
- allow round button while bootstrap is in progress to avoid UI deadlock
- raise default TRPG timeout input from 30s to 90s

## Why
- `trpg.preset.list 응답 파싱 실패 (HTTP 200)` occurred when `/mcp` returned `text/event-stream`
- round execution appeared stalled because keeper LLM calls were still capped at 45s on Ollama path

## Validation
- `dune build bin/main_eio.exe lib/masc_mcp.cma`
- embedded dashboard script syntax check (`new Function(script)`)
- `SESSION_ID=harness-trpg-session-$(date +%s) ROOM_ID=default scripts/harness/contract/trpg_session_contract.sh`
