### PR TITLE
fix(trpg): harden round-run UX and language flow

### DIFF
--- a/lib/tool_trpg.ml
+++ b/lib/tool_trpg.ml
@@ -133,7 +133,7 @@ let schemas : Types.tool_schema list =
         "Run one TRPG round by messaging DM keeper then player keepers. \
          Records strict timeout/unavailable events. \
          Required: room_id, dm_keeper, player_keepers(object actor_id->keeper_name). \
-         Optional: phase(default round), rule_module(default dnd5e-lite), timeout_sec(default 30).";
+         Optional: phase(default round), rule_module(default dnd5e-lite), timeout_sec(default 30), lang(ko|en).";
       input_schema =
         `Assoc
           [
@@ -152,6 +152,7 @@ let schemas : Types.tool_schema list =
                   ("phase", `Assoc [ ("type", `String "string") ]);
                   ("rule_module", `Assoc [ ("type", `String "string") ]);
                   ("timeout_sec", `Assoc [ ("type", `String "number") ]);
+                  ("lang", `Assoc [ ("type", `String "string") ]);
                 ] );
             ( "required",
               `List
@@ -603,27 +604,62 @@ let parse_keeper_reply keeper_json =
       if s = "" then Error "keeper response reply is empty" else Ok s
   | _ -> Error "keeper response missing string field: reply"
 
-let build_keeper_prompt ~room_id ~phase ~turn ~role ~actor_id ~state_json =
+type prompt_language = [ `Ko | `En ]
+
+let prompt_language_of_string_opt = function
+  | Some raw -> (
+      match String.lowercase_ascii (String.trim raw) with
+      | "ko" | "kr" | "korean" -> `Ko
+      | "en" | "english" -> `En
+      | _ -> `Ko)
+  | None -> `Ko
+
+let build_keeper_prompt ~room_id ~phase ~turn ~role ~actor_id ~state_json ~lang =
   let role_s = role_to_string role in
-  Printf.sprintf
-    "TRPG execution request.\n\
-     room_id=%s\n\
-     phase=%s\n\
-     turn=%d\n\
-     role=%s\n\
-     actor_id=%s\n\
-     \n\
-     visible_state_json:\n\
-     %s\n\
-     \n\
-     Return your response as normal text. \
-     If you can provide structured_action, include it in your reply JSON field."
-    room_id
-    phase
-    turn
-    role_s
-    actor_id
-    (Yojson.Safe.pretty_to_string state_json)
+  let state_text = Yojson.Safe.pretty_to_string state_json in
+  match lang with
+  | `Ko ->
+      Printf.sprintf
+        "TRPG 실행 요청입니다.\n\
+         room_id=%s\n\
+         phase=%s\n\
+         turn=%d\n\
+         role=%s\n\
+         actor_id=%s\n\
+         \n\
+         visible_state_json:\n\
+         %s\n\
+         \n\
+         반드시 한국어로 응답하세요. \
+         일반 텍스트로 답하되 structured_action을 만들 수 있으면 \
+         reply JSON 필드에 함께 포함하세요."
+        room_id
+        phase
+        turn
+        role_s
+        actor_id
+        state_text
+  | `En ->
+      Printf.sprintf
+        "TRPG execution request.\n\
+         room_id=%s\n\
+         phase=%s\n\
+         turn=%d\n\
+         role=%s\n\
+         actor_id=%s\n\
+         \n\
+         visible_state_json:\n\
+         %s\n\
+         \n\
+         Respond in English. \
+         Return your response as normal text. \
+         If you can provide structured_action, include it in your reply JSON field."
+        room_id
+        phase
+        turn
+        role_s
+        actor_id
+        state_text
 
 let room_id_for_session session_id =
   sanitize_room_id (Printf.sprintf "session-%s" session_id)
@@ -1543,8 +1579,10 @@ let handle_round_run ctx args : result =
     else
       let* rule_opt = get_optional_string args "rule_module" in
       let* phase_opt = get_optional_string args "phase" in
+      let* lang_opt = get_optional_string args "lang" in
       let rule_module = Option.value ~default:"dnd5e-lite" rule_opt in
       let phase = Option.value ~default:"round" phase_opt in
+      let prompt_lang = prompt_language_of_string_opt lang_opt in
       let* () =
         match ctx.keeper_call with
         | Some _ -> Ok ()
@@ -1591,6 +1629,7 @@ let handle_round_run ctx args : result =
             ~role
             ~actor_id
             ~state_json:state_for_prompt
+            ~lang:prompt_lang
         in
         match call_keeper ctx ~name:keeper_name ~message:prompt ~timeout_sec with
         | `Timeout ->

--- a/lib/web_dashboard.ml
+++ b/lib/web_dashboard.ml
@@ -1582,7 +1582,7 @@ let cached_html = lazy ({|<!DOCTYPE html>
     }
     .trpg-action-row {
       display: grid;
-      grid-template-columns: repeat(2, minmax(0, 1fr));
+      grid-template-columns: repeat(3, minmax(0, 1fr));
       gap: 8px;
     }
     .trpg-control-help {
@@ -1590,6 +1590,50 @@ let cached_html = lazy ({|<!DOCTYPE html>
       color: #94a3b8;
       line-height: 1.35;
       margin-top: 2px;
+    }
+    .trpg-keeper-quick {
+      display: flex;
+      flex-direction: column;
+      gap: 6px;
+      max-height: 180px;
+      overflow-y: auto;
+      padding-right: 2px;
+    }
+    .trpg-keeper-chip {
+      display: flex;
+      align-items: center;
+      gap: 6px;
+      background: rgba(15,23,42,0.6);
+      border: 1px solid rgba(148,163,184,0.22);
+      border-radius: 8px;
+      padding: 5px 7px;
+    }
+    .trpg-keeper-name {
+      flex: 1;
+      min-width: 0;
+      font-size: 0.76em;
+      color: #e2e8f0;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+    .trpg-mini-btn {
+      border: 1px solid rgba(148,163,184,0.35);
+      border-radius: 6px;
+      background: rgba(30,41,59,0.72);
+      color: #cbd5e1;
+      font-size: 0.7em;
+      padding: 3px 7px;
+      cursor: pointer;
+    }
+    .trpg-mini-btn:hover {
+      border-color: rgba(34,211,238,0.6);
+      color: #e2e8f0;
+    }
+    .trpg-empty-inline {
+      font-size: 0.75em;
+      color: #94a3b8;
+      padding: 6px 2px;
     }
     .trpg-run-status {
       font-size: 0.75em;
@@ -1901,6 +1945,7 @@ let cached_html = lazy ({|<!DOCTYPE html>
                 <div class="trpg-control-field">
                   <label for="trpg-dm-keeper-input">DM Keeper</label>
                   <input id="trpg-dm-keeper-input" type="text" placeholder="dm-keeper">
+                  <div class="trpg-control-help">직접 입력하거나 아래 Keeper Quick Pick의 DM 버튼으로 지정하세요.</div>
                 </div>
                 <div class="trpg-control-field">
                   <label for="trpg-pool-size-input">Pool Size</label>
@@ -1923,17 +1968,33 @@ let cached_html = lazy ({|<!DOCTYPE html>
                   <label for="trpg-timeout-sec-input">Timeout (sec)</label>
                   <input id="trpg-timeout-sec-input" type="number" min="1" step="1" value="90">
                 </div>
+                <div class="trpg-control-field">
+                  <label for="trpg-lang-select">응답 언어</label>
+                  <select id="trpg-lang-select">
+                    <option value="auto">auto (browser)</option>
+                    <option value="ko">한국어</option>
+                    <option value="en">English</option>
+                  </select>
+                </div>
                 <div class="trpg-control-field full">
-                  <label for="trpg-player-keepers-input">Player Keepers (actor=keeper, one per line)</label>
+                  <label for="trpg-player-keepers-input">Player Keepers (한 줄에 1명, actor=keeper 또는 keeper)</label>
                   <textarea id="trpg-player-keepers-input" placeholder="grimja=grimja&#10;luna=luna&#10;songarak=songarak&#10;miso=miso"></textarea>
+                  <div class="trpg-control-help">예: grimja 또는 grimja=grimja. keeper만 쓰면 actor와 keeper를 동일 이름으로 처리합니다.</div>
                 </div>
                 <div class="trpg-control-field full">
                   <label for="trpg-keeper-models-input">Keeper Models (comma-separated)</label>
                   <input id="trpg-keeper-models-input" type="text" value="ollama:glm-4.7-flash" placeholder="ollama:glm-4.7-flash, gemini:gemini-2.5-flash">
                   <div class="trpg-control-help">세션 자동 시작 시 DM/플레이어 Keeper를 생성/갱신할 때 사용합니다.</div>
                 </div>
+                <div class="trpg-control-field full">
+                  <label>Keeper Quick Pick</label>
+                  <div id="trpg-keeper-quick" class="trpg-keeper-quick">
+                    <div class="trpg-empty-inline">Keeper 목록을 불러오는 중...</div>
+                  </div>
+                </div>
               </div>
               <div class="trpg-action-row">
+                <button id="trpg-reload-btn" class="trpg-run-btn secondary" onclick="reloadTrpgCatalogs()">프리셋 새로고침</button>
                 <button id="trpg-bootstrap-btn" class="trpg-run-btn secondary" onclick="bootstrapTrpgSession()">세션 자동 시작</button>
                 <button id="trpg-run-round-btn" class="trpg-run-btn" onclick="runTrpgRound()">라운드 실행</button>
               </div>
@@ -6841,9 +6902,11 @@ let cached_html = lazy ({|<!DOCTYPE html>
     let trpgRoundRunning = false;
     let trpgBootstrapping = false;
     let trpgPresetsLoaded = false;
+    let trpgKeepersLoaded = false;
     let trpgMcpCallSeq = 1000;
     let trpgMcpSessionId = null;
     let trpgPresetCatalog = { dm_presets: [], world_presets: [] };
+    let trpgKeeperCatalog = [];
 
     function trpgEventType(ev) {
       return (ev && (ev.type || ev.event_type || ev.event)) || '';
@@ -6933,11 +6996,27 @@ let cached_html = lazy ({|<!DOCTYPE html>
       if (modelsInput && String(modelsInput.value || '').trim() === '') {
         modelsInput.value = TRPG_DEFAULT_KEEPER_MODELS;
       }
+      const langSelect = document.getElementById('trpg-lang-select');
+      if (langSelect && String(langSelect.value || '').trim() === '') {
+        langSelect.value = browserLang.startsWith('ko') ? 'ko' : 'auto';
+      } else if (langSelect && String(langSelect.value || '').trim() === 'auto' && browserLang.startsWith('ko')) {
+        langSelect.value = 'ko';
+      }
       const dmInput = document.getElementById('trpg-dm-keeper-input');
-      if (dmInput && String(dmInput.value || '').trim() === '') dmInput.value = 'dm-keeper';
+      if (dmInput && String(dmInput.value || '').trim() === '') {
+        const preferredDm =
+          (Array.isArray(trpgKeeperCatalog) ? trpgKeeperCatalog : []).find((name) => trpgIsDmLikeKeeper(name))
+          || 'dm-keeper';
+        dmInput.value = preferredDm;
+      }
       const playerInput = document.getElementById('trpg-player-keepers-input');
       if (playerInput && String(playerInput.value || '').trim() === '') {
-        playerInput.value = TRPG_DEFAULT_PLAYER_KEEPERS.join('\n');
+        if (Array.isArray(trpgKeeperCatalog) && trpgKeeperCatalog.length > 0) {
+          const suggested = trpgSuggestedPlayerKeepers(trpgKeeperCatalog, TRPG_DEFAULT_PARTY_SIZE);
+          playerInput.value = suggested.length > 0 ? suggested.join('\n') : TRPG_DEFAULT_PLAYER_KEEPERS.join('\n');
+        } else {
+          playerInput.value = TRPG_DEFAULT_PLAYER_KEEPERS.join('\n');
+        }
       }
     }
 
@@ -6999,6 +7078,160 @@ let cached_html = lazy ({|<!DOCTYPE html>
         .filter((part) => part !== '');
     }
 
+    function trpgLanguageFromSelect() {
+      const el = document.getElementById('trpg-lang-select');
+      const raw = String((el && el.value) || 'auto').trim().toLowerCase();
+      if (raw === 'ko' || raw === 'en') return raw;
+      return browserLang.startsWith('ko') ? 'ko' : 'en';
+    }
+
+    function trpgNormalizeKeeperNames(raw) {
+      if (!Array.isArray(raw)) return [];
+      const seen = new Set();
+      const out = [];
+      raw.forEach((entry) => {
+        const name = String(entry || '').trim();
+        if (!name || seen.has(name)) return;
+        seen.add(name);
+        out.push(name);
+      });
+      return out;
+    }
+
+    function trpgIsDmLikeKeeper(name) {
+      const n = String(name || '').trim().toLowerCase();
+      if (!n) return false;
+      return (
+        n === 'dm'
+        || n.startsWith('dm-')
+        || n.includes('-dm')
+        || n.includes('dm_keeper')
+        || n.includes('dm-keeper')
+        || n.includes('trpg-dm')
+        || n.startsWith('gm')
+      );
+    }
+
+    function trpgSuggestedPlayerKeepers(keepers, limit = TRPG_DEFAULT_PARTY_SIZE) {
+      const xs = Array.isArray(keepers) ? keepers : [];
+      const capped = Math.max(1, Math.min(8, Number(limit) || TRPG_DEFAULT_PARTY_SIZE));
+      return xs.filter((name) => !trpgIsDmLikeKeeper(name)).slice(0, capped);
+    }
+
+    function renderTrpgKeeperQuickList() {
+      const el = document.getElementById('trpg-keeper-quick');
+      if (!el) return;
+      const keepers = Array.isArray(trpgKeeperCatalog) ? trpgKeeperCatalog : [];
+      if (keepers.length === 0) {
+        el.innerHTML = '<div class="trpg-empty-inline">사용 가능한 Keeper를 찾지 못했습니다. 직접 이름을 입력해도 됩니다.</div>';
+        return;
+      }
+      el.innerHTML = keepers.map((name) => {
+        const safe = escapeHtml(name);
+        const token = encodeURIComponent(name);
+        return `<div class="trpg-keeper-chip">
+          <span class="trpg-keeper-name" title="${safe}">${safe}</span>
+          <button type="button" class="trpg-mini-btn" onclick="setTrpgDmKeeperFromQuick('${token}')">DM</button>
+          <button type="button" class="trpg-mini-btn" onclick="addTrpgPlayerKeeperFromQuick('${token}')">+Player</button>
+        </div>`;
+      }).join('');
+    }
+
+    function setTrpgDmKeeperFromQuick(token) {
+      let name = '';
+      try { name = decodeURIComponent(String(token || '')); } catch (_) { name = String(token || ''); }
+      name = name.trim();
+      if (!name) return;
+      const dmInput = document.getElementById('trpg-dm-keeper-input');
+      if (dmInput) dmInput.value = name;
+      showToast(`DM Keeper 선택: ${name}`, 'success');
+    }
+
+    function addTrpgPlayerKeeperFromQuick(token) {
+      let name = '';
+      try { name = decodeURIComponent(String(token || '')); } catch (_) { name = String(token || ''); }
+      name = name.trim();
+      if (!name) return;
+      const input = document.getElementById('trpg-player-keepers-input');
+      if (!input) return;
+      const lines = String(input.value || '')
+        .split(/\r?\n/)
+        .map((line) => line.trim())
+        .filter((line) => line !== '');
+      const exists = lines.some((line) => {
+        if (line === name || line === `${name}=${name}`) return true;
+        const eqIdx = line.indexOf('=');
+        if (eqIdx < 0) return false;
+        const actorId = line.slice(0, eqIdx).trim();
+        const keeperName = line.slice(eqIdx + 1).trim();
+        return actorId === name || keeperName === name;
+      });
+      if (!exists) lines.push(name);
+      input.value = lines.join('\n');
+      showToast(`Player Keeper 추가: ${name}`, 'success');
+    }
+
+    function clearTrpgPlayerKeepers() {
+      const input = document.getElementById('trpg-player-keepers-input');
+      if (!input) return;
+      input.value = '';
+      showToast('Player Keeper 입력을 비웠습니다.', 'success');
+    }
+
+    function applyTrpgKeeperAutofill(force = false) {
+      const keepers = Array.isArray(trpgKeeperCatalog) ? trpgKeeperCatalog : [];
+      if (keepers.length === 0) return;
+      const dmInput = document.getElementById('trpg-dm-keeper-input');
+      const playerInput = document.getElementById('trpg-player-keepers-input');
+      const partySizeRaw = Number((document.getElementById('trpg-party-size-input') || {}).value);
+      const partySize = Number.isFinite(partySizeRaw)
+        ? Math.max(1, Math.min(8, Math.floor(partySizeRaw)))
+        : TRPG_DEFAULT_PARTY_SIZE;
+      if (dmInput && (force || String(dmInput.value || '').trim() === '')) {
+        const preferredDm = keepers.find((name) => trpgIsDmLikeKeeper(name)) || keepers[0];
+        if (preferredDm) dmInput.value = preferredDm;
+      }
+      if (playerInput && (force || String(playerInput.value || '').trim() === '')) {
+        const preferred = trpgSuggestedPlayerKeepers(keepers, partySize);
+        if (preferred.length > 0) {
+          playerInput.value = preferred.join('\n');
+        }
+      }
+    }
+
+    async function ensureTrpgKeeperCatalog(force = false) {
+      if (trpgKeepersLoaded && !force) return trpgKeeperCatalog;
+      const data = await mcpToolCall('masc_keeper_list', { limit: 200 });
+      trpgKeeperCatalog = trpgNormalizeKeeperNames(data && data.keepers);
+      trpgKeepersLoaded = true;
+      renderTrpgKeeperQuickList();
+      applyTrpgKeeperAutofill(false);
+      return trpgKeeperCatalog;
+    }
+
+    async function reloadTrpgCatalogs() {
+      if (trpgRoundRunning || trpgBootstrapping) return;
+      setTrpgRoundRunStatus('프리셋/키퍼 목록 새로고침 중...', 'running');
+      try {
+        const [presets, keepers] = await Promise.all([
+          ensureTrpgPresetCatalog(true),
+          ensureTrpgKeeperCatalog(true),
+        ]);
+        const worldCount = Array.isArray(presets.world_presets) ? presets.world_presets.length : 0;
+        const dmCount = Array.isArray(presets.dm_presets) ? presets.dm_presets.length : 0;
+        const keeperCount = Array.isArray(keepers) ? keepers.length : 0;
+        setTrpgRoundRunStatus(
+          `프리셋 로드 완료: world ${worldCount}, dm ${dmCount}, keeper ${keeperCount}`,
+          'ok'
+        );
+        showToast('TRPG 카탈로그 새로고침 완료', 'success');
+      } catch (e) {
+        const msg = String((e && e.message) || e || 'unknown error');
+        setTrpgRoundRunStatus(`카탈로그 새로고침 실패: ${escapeHtml(msg)}`, 'error');
+        showToast('TRPG 카탈로그 새로고침 실패', 'error');
+      }
+    }
+
     function playerKeeperMapToText(mapping) {
       if (!mapping || typeof mapping !== 'object' || Array.isArray(mapping)) return '';
       return Object.entries(mapping)
@@ -7035,6 +7268,14 @@ let cached_html = lazy ({|<!DOCTYPE html>
       for (let i = chunks.length - 1; i >= 0; i -= 1) {
         const chunk = String(chunks[i] || '').trim();
         if (chunk === '') continue;
+        if (chunk.startsWith('{') || chunk.startsWith('[')) {
+          try {
+            const parsedChunk = JSON.parse(chunk);
+            if (parsedChunk && typeof parsedChunk === 'object') return parsedChunk;
+          } catch (_) {
+            // keep scanning older frames
+          }
+        }
         const dataLines = chunk
           .split(/\r?\n/)
           .filter((line) => line.startsWith('data:'))
@@ -7047,6 +7288,15 @@ let cached_html = lazy ({|<!DOCTYPE html>
           if (parsed && typeof parsed === 'object') return parsed;
         } catch (_) {
           // keep scanning older frames
+        }
+      }
+      const trimmed = raw.trim();
+      if (trimmed.startsWith('{') || trimmed.startsWith('[')) {
+        try {
+          const parsedRaw = JSON.parse(trimmed);
+          if (parsedRaw && typeof parsedRaw === 'object') return parsedRaw;
+        } catch (_) {
+          // fallthrough to detailed parse error
         }
       }
       throw new Error(`${toolName} SSE 응답 파싱 실패: ${trpgShortText(raw, 220)}`);
@@ -7151,10 +7401,32 @@ let cached_html = lazy ({|<!DOCTYPE html>
       updateTrpgButtons();
     }
 
+    function trpgKeeperLanguageInstruction(lang) {
+      if (lang === 'ko') {
+        return '모든 응답은 한국어로 작성하세요. 구조화된 action이 있으면 reply에 함께 담아주세요.';
+      }
+      return 'Respond in English. If you have structured actions, include them in your reply.';
+    }
+
+    function trpgDmGoalText(lang, roomId, worldPresetTitle) {
+      if (lang === 'ko') {
+        return `TRPG room ${roomId}의 DM으로 ${worldPresetTitle} 시나리오를 운영하세요. 장면 연속성과 규칙 일관성을 유지하세요.`;
+      }
+      return `Run TRPG room ${roomId} as DM for ${worldPresetTitle}. Keep consistent scene state and enforce rules.`;
+    }
+
+    function trpgPlayerGoalText(lang, roomId, actorId) {
+      if (lang === 'ko') {
+        return `TRPG room ${roomId}에서 ${actorId} 역할을 플레이하세요. 각 라운드마다 간결하고 일관된 인캐릭터 행동을 제출하세요.`;
+      }
+      return `Play actor ${actorId} in TRPG room ${roomId}. Submit concise in-character actions each round.`;
+    }
+
     async function bootstrapTrpgSession() {
       if (trpgRoundRunning || trpgBootstrapping) return;
       ensureTrpgControlDefaults();
       const roomId = applyTrpgRoomFromInput();
+      const lang = trpgLanguageFromSelect();
       setTrpgBootstrapBusy(true);
       setTrpgRoundRunStatus(`세션 자동 시작 중: room <b>${escapeHtml(roomId)}</b>`, 'running');
       try {
@@ -7247,10 +7519,12 @@ let cached_html = lazy ({|<!DOCTYPE html>
           const worldPresetTitle =
             (((catalog || {}).world_presets || []).find((preset) => String((preset && preset.id) || '') === worldPresetId) || {}).title
             || worldPresetId;
+          const dmInstruction = trpgKeeperLanguageInstruction(lang);
           await mcpToolCall('masc_keeper_up', {
             name: dmKeeper,
-            goal: `Run TRPG room ${roomId} as DM for ${worldPresetTitle}. Keep consistent scene state and enforce rules.`,
+            goal: trpgDmGoalText(lang, roomId, worldPresetTitle),
             models,
+            instructions: dmInstruction,
             proactive_enabled: false,
             presence_keepalive: true,
           });
@@ -7260,12 +7534,19 @@ let cached_html = lazy ({|<!DOCTYPE html>
           for (const [actorId, keeperName] of keeperPairs) {
             await mcpToolCall('masc_keeper_up', {
               name: keeperName,
-              goal: `Play actor ${actorId} in TRPG room ${roomId}. Submit concise in-character actions each round.`,
+              goal: trpgPlayerGoalText(lang, roomId, actorId),
               models,
+              instructions: trpgKeeperLanguageInstruction(lang),
               proactive_enabled: false,
               presence_keepalive: true,
             });
           }
+        }
+
+        try {
+          await ensureTrpgKeeperCatalog(true);
+        } catch (_) {
+          renderTrpgKeeperQuickList();
         }
 
         resetTrpgEventWindow();
@@ -7341,6 +7622,7 @@ let cached_html = lazy ({|<!DOCTYPE html>
       const roomId = applyTrpgRoomFromInput();
       const dmKeeper = String((document.getElementById('trpg-dm-keeper-input') || {}).value || '').trim();
       const phase = String((document.getElementById('trpg-phase-select') || {}).value || 'round').trim() || 'round';
+      const lang = trpgLanguageFromSelect();
       const timeoutRaw = Number((document.getElementById('trpg-timeout-sec-input') || {}).value);
       const timeoutSec = Number.isFinite(timeoutRaw) && timeoutRaw > 0 ? timeoutRaw : 90;
       const playerRaw = String((document.getElementById('trpg-player-keepers-input') || {}).value || '');
@@ -7354,11 +7636,37 @@ let cached_html = lazy ({|<!DOCTYPE html>
         return;
       }
 
+      const participantCount = 1 + Object.keys(parsedPlayers.mapping || {}).length;
+      const estimatedMaxSec = Math.max(1, Math.ceil(timeoutSec * participantCount));
+      let roundDone = false;
+      let pollInFlight = false;
+      const startedAtMs = Date.now();
+
       setTrpgRoundRunBusy(true);
       setTrpgRoundRunStatus(
-        `실행 중: room <b>${escapeHtml(roomId)}</b>, phase <b>${escapeHtml(phase)}</b>, timeout <b>${timeoutSec}s</b>`,
+        `실행 중: room <b>${escapeHtml(roomId)}</b>, phase <b>${escapeHtml(phase)}</b>, 언어 <b>${escapeHtml(lang)}</b><br>` +
+        `참여자 <b>${participantCount}명</b>, 최대 약 <b>${estimatedMaxSec}s</b> (순차 실행 기준)`,
         'running'
       );
+      try { await fetchTrpg(); } catch (_) {}
+      const livePollId = setInterval(async () => {
+        if (roundDone || pollInFlight) return;
+        pollInFlight = true;
+        try {
+          const elapsedSec = Math.max(0, Math.floor((Date.now() - startedAtMs) / 1000));
+          setTrpgRoundRunStatus(
+            `실행 중: room <b>${escapeHtml(roomId)}</b>, phase <b>${escapeHtml(phase)}</b>, 언어 <b>${escapeHtml(lang)}</b><br>` +
+            `경과 <b>${elapsedSec}s</b> / 예상 최대 <b>${estimatedMaxSec}s</b>`,
+            'running'
+          );
+          await fetchTrpg();
+        } catch (_) {
+          // ignore polling errors while round run request is in-flight
+        } finally {
+          pollInFlight = false;
+        }
+      }, 2500);
+
       try {
         const headers = Object.assign({ 'Content-Type': 'application/json' }, authHeaders());
         const body = {
@@ -7367,6 +7675,7 @@ let cached_html = lazy ({|<!DOCTYPE html>
           player_keepers: parsedPlayers.mapping,
           phase,
           timeout_sec: timeoutSec,
+          lang,
         };
         const res = await fetch('/api/v1/trpg/rounds/run', {
           method: 'POST',
@@ -7388,6 +7697,7 @@ let cached_html = lazy ({|<!DOCTYPE html>
           const detail = st.reply || st.error || '';
           return `<div>• ${actor} (${keeper}) <b>${status}</b>${detail ? ` — ${escapeHtml(trpgShortText(detail))}` : ''}</div>`;
         }).join('');
+        roundDone = true;
         setTrpgRoundRunStatus(
           `<div>완료: turn ${escapeHtml(String(data.turn_before || '-'))} → <b>${escapeHtml(String(data.turn_after || '-'))}</b></div>
            <div>요약: success ${escapeHtml(String(summary.successes || 0))}, timeout ${escapeHtml(String(summary.timeouts || 0))}, unavailable ${escapeHtml(String(summary.unavailable || 0))}</div>
@@ -7397,9 +7707,11 @@ let cached_html = lazy ({|<!DOCTYPE html>
         showToast(`TRPG round 완료 (room=${roomId})`, 'success');
         await fetchTrpg();
       } catch (e) {
+        roundDone = true;
         setTrpgRoundRunStatus(`실패: ${escapeHtml(String((e && e.message) || e || 'unknown error'))}`, 'error');
         showToast('TRPG round 실행 실패', 'error');
       } finally {
+        clearInterval(livePollId);
         setTrpgRoundRunBusy(false);
       }
     }
@@ -7412,6 +7724,13 @@ let cached_html = lazy ({|<!DOCTYPE html>
           await ensureTrpgPresetCatalog(false);
         } catch (_) {
           // Keep UI usable even if preset loading fails.
+        }
+      }
+      if (!trpgKeepersLoaded) {
+        try {
+          await ensureTrpgKeeperCatalog(false);
+        } catch (_) {
+          renderTrpgKeeperQuickList();
         }
       }
       const activeRoomId = trpgRoomId;

--- a/test/test_tool_trpg_coverage.ml
+++ b/test/test_tool_trpg_coverage.ml
@@ -199,6 +199,40 @@ let test_round_run_requires_keeper_runtime () =
     (contains_substring msg "keeper_call is not available");
   cleanup_dir base_dir
 
+let test_round_run_lang_english_prompt () =
+  let base_dir = make_temp_dir () in
+  let config = Room.default_config base_dir in
+  let _ = Room.init config ~agent_name:(Some "tester") in
+  let prompts = ref [] in
+  let keeper_call ~name ~message ~timeout_sec:_ : Tool_trpg.keeper_call_result =
+    prompts := (name, message) :: !prompts;
+    match name with
+    | "dm-keeper" -> `Ok (`Assoc [ ("reply", `String "Scene starts.") ])
+    | "pk-1" -> `Ok (`Assoc [ ("reply", `String "I move to cover.") ])
+    | _ -> `Error "unknown keeper"
+  in
+  let ctx : Tool_trpg.context =
+    { config; agent_name = "tester"; keeper_call = Some keeper_call }
+  in
+  let args =
+    `Assoc
+      [
+        ("room_id", `String "room-round-lang-en");
+        ("dm_keeper", `String "dm-keeper");
+        ("player_keepers", `Assoc [ ("p1", `String "pk-1") ]);
+        ("lang", `String "en");
+      ]
+  in
+  let ok, _body = dispatch_exn ctx ~name:"masc_trpg_round_run" ~args in
+  Alcotest.(check bool) "round_run success (lang=en)" true ok;
+  let has_en_instruction =
+    List.exists
+      (fun (_name, prompt) -> contains_substring prompt "Respond in English.")
+      !prompts
+  in
+  Alcotest.(check bool) "english prompt instruction injected" true has_en_instruction;
+  cleanup_dir base_dir
+
 let test_session_bootstrap_and_intervention_flow () =
   let base_dir = make_temp_dir () in
   let config = Room.default_config base_dir in
@@ -411,5 +445,9 @@ let () =
             "requires keeper runtime"
             `Quick
             test_round_run_requires_keeper_runtime;
+          Alcotest.test_case
+            "supports lang=en prompt"
+            `Quick
+            test_round_run_lang_english_prompt;
         ] );
     ]

--- a/test/test_web_dashboard_coverage.ml
+++ b/test/test_web_dashboard_coverage.ml
@@ -136,6 +136,16 @@ let test_html_contains_trpg_round_run_controls () =
     && contains_substr "function runTrpgRound()" html
     && contains_substr "/api/v1/trpg/rounds/run" html)
 
+let test_html_contains_trpg_keeper_quickpick_and_lang () =
+  let html = Web_dashboard.html () in
+  check bool "trpg keeper quickpick + lang" true
+    (String.length html > 0
+    && contains_substr "id=\"trpg-lang-select\"" html
+    && contains_substr "id=\"trpg-reload-btn\"" html
+    && contains_substr "id=\"trpg-keeper-quick\"" html
+    && contains_substr "function ensureTrpgKeeperCatalog(force = false)" html
+    && contains_substr "function reloadTrpgCatalogs()" html)
+
 let test_html_contains_keeper_goal_horizon_kpis () =
   let html = Web_dashboard.html () in
   check bool "keeper goal horizon kpis" true
@@ -171,6 +181,10 @@ let () =
       test_case "notify uses normalized payload" `Quick test_html_notify_uses_normalized_payload;
       test_case "life state pills" `Quick test_html_life_state_pills_present;
       test_case "trpg round run controls" `Quick test_html_contains_trpg_round_run_controls;
+      test_case
+        "trpg keeper quickpick + lang"
+        `Quick
+        test_html_contains_trpg_keeper_quickpick_and_lang;
       test_case "keeper goal horizon kpis" `Quick test_html_contains_keeper_goal_horizon_kpis;
     ];
   ]


### PR DESCRIPTION
## Summary
- add TRPG keeper quick-pick UI and preset/keeper reload flow in dashboard
- add language selector (auto/ko/en) and pass language through session bootstrap + round run
- improve round run UX with participant/timeout estimate and live polling while request is in-flight
- harden MCP response parsing fallback for mixed SSE/JSON payloads
- expose "lang" in "masc_trpg_round_run" schema and support localized keeper prompt generation
- add coverage tests for new TRPG language and dashboard quick-pick controls

## Validation
- DUNE_BUILD_DIR=_build_codex_trpg dune build --root . bin/main_eio.exe lib/masc_mcp.cma
- DUNE_BUILD_DIR=_build_codex_trpg dune exec ./test/test_tool_trpg_coverage.exe
- DUNE_BUILD_DIR=_build_codex_trpg dune exec ./test/test_web_dashboard_coverage.exe