### PR TITLE
fix(viewer): restore TRPG DOM panel bindings

### DIFF
--- a/viewer/index.html
+++ b/viewer/index.html
@@ -170,26 +170,42 @@
             <!-- Primary Zone: Bevy Canvas -->
             <section id="primary-zone">
                 <canvas id="bevy-canvas"></canvas>
-                <div id="zone-label" class="overlay-label"></div>
+                <div id="map-label" class="overlay-label"></div>
             </section>
 
             <!-- Secondary Zone: Mode-specific panels (DOM) -->
             <section id="secondary-zone">
-                <h2 class="panel-title" id="secondary-title">—</h2>
-                <div id="secondary-content" class="scrollable"></div>
+                <h2 class="panel-title" id="secondary-title">Narrative</h2>
+                <div id="secondary-content" class="scrollable">
+                    <div id="turn-phase" class="phase-indicator">
+                        <div class="turn-number">TURN <span id="turn-num">1</span></div>
+                        <div class="phase-track">
+                            <div class="phase active" data-phase="dm_narration">DM</div>
+                            <div class="phase" data-phase="party_discussion">Discuss</div>
+                            <div class="phase" data-phase="action_declaration">Action</div>
+                            <div class="phase" data-phase="dice_resolution">Dice</div>
+                            <div class="phase" data-phase="outcome_narration">Outcome</div>
+                            <div class="phase" data-phase="state_update">Update</div>
+                            <div class="phase" data-phase="transition">Move</div>
+                        </div>
+                    </div>
+                    <div id="narrative-log"></div>
+                </div>
             </section>
 
             <!-- Tertiary Zone: Side panel (DOM) -->
             <aside id="tertiary-zone">
-                <h2 class="panel-title" id="tertiary-title">—</h2>
-                <div id="tertiary-content" class="scrollable"></div>
+                <h2 class="panel-title" id="tertiary-title">Party</h2>
+                <div id="tertiary-content" class="scrollable">
+                    <div id="character-panel"></div>
+                </div>
             </aside>
         </main>
 
         <!-- Bottom Zone -->
         <footer id="bottom-zone">
-            <h2 class="panel-title" id="bottom-title">—</h2>
-            <div id="bottom-content" class="scrollable horizontal"></div>
+            <h2 class="panel-title" id="bottom-title">Dice Log</h2>
+            <div id="dice-log" class="scrollable horizontal"></div>
         </footer>
     </div>
 

--- a/viewer/src/render/map.rs
+++ b/viewer/src/render/map.rs
@@ -58,7 +58,11 @@ pub fn update_map_label(map_state: Res<MapState>) {
     let Some(document) = web_sys::window().and_then(|w| w.document()) else {
         return;
     };
-    let Some(label) = document.get_element_by_id("map-label") else {
+    // Backward-compatible fallback for pre-refactor id.
+    let Some(label) = document
+        .get_element_by_id("map-label")
+        .or_else(|| document.get_element_by_id("zone-label"))
+    else {
         return;
     };
 

--- a/viewer/style.css
+++ b/viewer/style.css
@@ -589,6 +589,10 @@ body.mode-lobby #dashboard {
     font-style: italic;
 }
 
+#narrative-log {
+    margin-top: 12px;
+}
+
 /* Character cards */
 .character-card {
     background: var(--bg-panel-alt);
@@ -596,6 +600,11 @@ body.mode-lobby #dashboard {
     border-radius: var(--panel-radius);
     padding: 10px;
     margin-bottom: 6px;
+}
+
+#character-panel {
+    display: flex;
+    flex-direction: column;
 }
 
 .character-card.dead {
@@ -707,6 +716,9 @@ body.mode-lobby #dashboard {
     align-items: center;
     gap: 24px;
     width: 100%;
+    margin-bottom: 12px;
+    padding-bottom: 8px;
+    border-bottom: 1px solid var(--border-main);
 }
 
 .turn-number {
@@ -746,6 +758,10 @@ body.mode-lobby #dashboard {
 .phase.completed {
     background: var(--bg-panel-alt);
     color: var(--text-primary);
+}
+
+#dice-log {
+    min-height: 100%;
 }
 
 /* ═══════════════════════════════════════════


### PR DESCRIPTION
## Summary
- restore missing TRPG dashboard DOM containers (`#narrative-log`, `#character-panel`, `#dice-log`, `#turn-num`, `.phase[data-phase]`)
- switch map overlay id to `#map-label` in HTML and keep renderer fallback to legacy `#zone-label`
- add minimal layout styling so restored panels render correctly in secondary/tertiary/bottom zones

## Verification
- `cd viewer && cargo check`
- `cd viewer && cargo test`