### PR TITLE
fix(viewer): escape narrative stream text in DOM

### DIFF
--- a/viewer/src/dom/narrative.rs
+++ b/viewer/src/dom/narrative.rs
@@ -3,6 +3,25 @@ use wasm_bindgen::JsCast;
 
 use crate::game::events::NarrativeReceived;
 
+fn normalize_phase_suffix(phase: &str) -> String {
+    let mut out = String::with_capacity(phase.len());
+    for ch in phase.chars() {
+        if ch.is_ascii_alphanumeric() {
+            out.push(ch.to_ascii_lowercase());
+        } else if ch == '-' || ch == '_' || ch.is_whitespace() {
+            out.push('-');
+        } else {
+            out.push('-');
+        }
+    }
+    let normalized = out.trim_matches('-');
+    if normalized.is_empty() {
+        "unknown".to_string()
+    } else {
+        normalized.to_string()
+    }
+}
+
 /// Appends narrative entries to the #narrative-log DOM element.
 pub fn update_narrative_dom(mut events: MessageReader<NarrativeReceived>) {
     let Some(document) = web_sys::window().and_then(|w| w.document()) else {
@@ -16,18 +35,32 @@ pub fn update_narrative_dom(mut events: MessageReader<NarrativeReceived>) {
         let Ok(entry) = document.create_element("div") else {
             continue;
         };
-        entry.set_class_name(&format!("narrative-entry phase-{}", payload.phase));
+        let phase_suffix = normalize_phase_suffix(&payload.phase);
+        entry.set_class_name(&format!("narrative-entry phase-{}", phase_suffix));
 
-        // Build inner content with optional speaker attribution
-        let html = if let Some(ref speaker) = payload.speaker {
-            format!(
-                "<span class=\"narrative-speaker\">{}</span> {}",
-                speaker, payload.text
-            )
-        } else {
-            payload.text.clone()
-        };
-        entry.set_inner_html(&html);
+        // Never insert streamed text via innerHTML.
+        if let Some(speaker) = payload
+            .speaker
+            .as_deref()
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+        {
+            if let Ok(speaker_el) = document.create_element("span") {
+                speaker_el.set_class_name("narrative-speaker");
+                speaker_el.set_text_content(Some(speaker));
+                let _ = entry.append_child(&speaker_el);
+            }
+        }
+        if let Ok(text_el) = document.create_element("span") {
+            text_el.set_class_name("narrative-text");
+            let text = if payload.speaker.as_deref().is_some() {
+                format!(" {}", payload.text)
+            } else {
+                payload.text.clone()
+            };
+            text_el.set_text_content(Some(&text));
+            let _ = entry.append_child(&text_el);
+        }
 
         let _ = log_el.append_child(&entry);
 
@@ -35,5 +68,24 @@ pub fn update_narrative_dom(mut events: MessageReader<NarrativeReceived>) {
         if let Ok(html_el) = entry.dyn_into::<web_sys::HtmlElement>() {
             html_el.scroll_into_view();
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::normalize_phase_suffix;
+
+    #[test]
+    fn normalize_phase_suffix_handles_untrusted_input() {
+        assert_eq!(
+            normalize_phase_suffix("dm narration<script>alert(1)</script>"),
+            "dm-narration-script-alert-1---script"
+        );
+    }
+
+    #[test]
+    fn normalize_phase_suffix_fallbacks_to_unknown() {
+        assert_eq!(normalize_phase_suffix("   "), "unknown");
+        assert_eq!(normalize_phase_suffix("<<<>>>"), "unknown");
     }
 }


### PR DESCRIPTION
## Summary
- remove `set_inner_html` usage in `update_narrative_dom`
- render narrative speaker/text using DOM nodes + `set_text_content` only
- normalize phase suffix before class-name composition
- add unit tests for phase suffix normalization against untrusted input

## Why
This closes a client-side XSS sink in the narrative panel when streamed payload text/speaker contains HTML or event attributes.

## Testing
- `cargo test normalize_phase_suffix` (in `viewer/`)
- `cargo test decode_stream_maps_` (in `viewer/`)