### PR TITLE
feat(llm): GLM Cloud multi-model load balancer pool

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -41,6 +41,7 @@
    encryption
    federation
    gcm_compat
+   glm_pool
    graphql_api
    handover_eio
    hat

--- a/lib/glm_pool.ml
+++ b/lib/glm_pool.ml
@@ -1,0 +1,189 @@
+(** GLM Cloud Multi-Model Load Balancer
+
+    Distributes requests across GLM models with different concurrency limits
+    to maximize throughput for MASC social experiments and games.
+
+    Model Concurrency Limits (from Z.ai docs):
+    - GLM-4.5: 10 concurrent
+    - GLM-4.6V: 10 concurrent
+    - GLM-5: 5 concurrent
+    - GLM-4.7: 5 concurrent
+    - GLM-4.6: 3 concurrent
+    - GLM-4.6V-FlashX: 3 concurrent
+    - GLM-4.7-FlashX: 3 concurrent
+    - GLM-4.7-Flash: 1 concurrent
+    - Total: ~39 concurrent calls possible
+
+    @since 2.66.0 *)
+
+type glm_model = {
+  model_id: string;
+  concurrency_limit: int;
+  description: string;
+}
+
+(** All available GLM Cloud models with their concurrency limits.
+    Ordered by preference (higher concurrency models first for better throughput). *)
+let available_models : glm_model array = [|
+  { model_id = "glm-4.5"; concurrency_limit = 10; description = "High concurrency, general purpose" };
+  { model_id = "glm-4.6v"; concurrency_limit = 10; description = "High concurrency, vision-capable" };
+  { model_id = "glm-5"; concurrency_limit = 5; description = "Flagship model" };
+  { model_id = "glm-4.7"; concurrency_limit = 5; description = "Latest generation" };
+  { model_id = "glm-4.6"; concurrency_limit = 3; description = "Balanced performance" };
+  { model_id = "glm-4.6v-flashx"; concurrency_limit = 3; description = "Fast variant with vision" };
+  { model_id = "glm-4.7-flashx"; concurrency_limit = 3; description = "Fast latest generation" };
+  (* glm-4.7-flash has limit 1, excluded from pool for efficiency *)
+|]
+
+(** Pool state: tracks in-flight requests per model. *)
+type pool_state = {
+  mutable in_flight: int array;  (* Parallel to available_models *)
+  mutable last_index: int;       (* For round-robin selection *)
+}
+
+(** Global pool state (lazy initialization). *)
+let pool_state = lazy (
+  let len = Array.length available_models in
+  { in_flight = Array.make len 0; last_index = 0 }
+)
+
+let get_pool () = Lazy.force pool_state
+
+(** Find model index by model_id, returns -1 if not found. *)
+let find_model_index (model_id : string) : int =
+  let rec loop i =
+    if i >= Array.length available_models then -1
+    else if String.equal (String.lowercase_ascii available_models.(i).model_id)
+                    (String.lowercase_ascii model_id) then i
+    else loop (i + 1)
+  in
+  loop 0
+
+(** Check if a model_id is in our pool. *)
+let is_pool_model (model_id : string) : bool =
+  find_model_index model_id >= 0
+
+(** Select best model using least-loaded strategy.
+    Returns model_id with lowest in_flight/concurrency_ratio.
+    Falls back to round-robin if all at capacity. *)
+let select_model () : string =
+  let pool = get_pool () in
+  let len = Array.length available_models in
+
+  (* Find model with best availability ratio *)
+  let best_idx = ref 0 in
+  let best_ratio = ref max_float in
+
+  for i = 0 to len - 1 do
+    let model = available_models.(i) in
+    let in_flight = pool.in_flight.(i) in
+    let ratio = float_of_int in_flight /. float_of_int model.concurrency_limit in
+    (* Also consider that we can still add requests if under limit *)
+    if ratio < !best_ratio && in_flight < model.concurrency_limit then begin
+      best_ratio := ratio;
+      best_idx := i
+    end
+  done;
+
+  (* If best_ratio is still max_float, all models at capacity - use round-robin *)
+  if !best_ratio = max_float then begin
+    pool.last_index <- (pool.last_index + 1) mod len;
+    available_models.(pool.last_index).model_id
+  end else
+    available_models.(!best_idx).model_id
+
+(** Select a specific model if requested and available,
+    otherwise fall back to pool selection. *)
+let select_model_preferring (preferred : string option) : string =
+  match preferred with
+  | None -> select_model ()
+  | Some model_id ->
+    (* If the requested model is in pool and has capacity, use it *)
+    let idx = find_model_index model_id in
+    if idx >= 0 then begin
+      let pool = get_pool () in
+      let model = available_models.(idx) in
+      if pool.in_flight.(idx) < model.concurrency_limit then
+        model_id
+      else
+        (* Requested model at capacity, select from pool *)
+        select_model ()
+    end else
+      (* Not a pool model, use as-is *)
+      model_id
+
+(** Increment in-flight count for a model.
+    Call before making the API request. *)
+let acquire (model_id : string) : unit =
+  let idx = find_model_index model_id in
+  if idx >= 0 then begin
+    let pool = get_pool () in
+    pool.in_flight.(idx) <- pool.in_flight.(idx) + 1;
+    (* Debug logging *)
+    let model = available_models.(idx) in
+    Printf.eprintf "[glm_pool] acquire %s: %d/%d\n%!"
+      model_id pool.in_flight.(idx) model.concurrency_limit
+  end
+
+(** Decrement in-flight count for a model.
+    Call after API response or error. *)
+let release (model_id : string) : unit =
+  let idx = find_model_index model_id in
+  if idx >= 0 then begin
+    let pool = get_pool () in
+    let new_count = max 0 (pool.in_flight.(idx) - 1) in
+    pool.in_flight.(idx) <- new_count;
+    let model = available_models.(idx) in
+    Printf.eprintf "[glm_pool] release %s: %d/%d\n%!"
+      model_id new_count model.concurrency_limit
+  end
+
+(** Execute a GLM request with automatic load balancing.
+    Selects best model, tracks in-flight requests, and handles cleanup.
+
+    Usage:
+    {[
+      Glm_pool.with_model (fun model_id ->
+        (* make API call with model_id *)
+        ...
+      )
+    ]}
+*)
+let with_model (preferred_model : string option) (f : string -> 'a) : 'a =
+  let model_id = select_model_preferring preferred_model in
+  acquire model_id;
+  try
+    let result = f model_id in
+    release model_id;
+    result
+  with exn ->
+    release model_id;
+    raise exn
+
+(** Get pool statistics for monitoring. *)
+let get_stats () : (string * int * int) list =
+  let pool = get_pool () in
+  Array.mapi (fun i model ->
+    (model.model_id, pool.in_flight.(i), model.concurrency_limit)
+  ) available_models
+  |> Array.to_list
+
+(** Total capacity across all pool models. *)
+let total_capacity : int =
+  Array.fold_left (fun acc m -> acc + m.concurrency_limit) 0 available_models
+
+(** Current total in-flight requests. *)
+let current_load () : int =
+  let pool = get_pool () in
+  Array.fold_left (fun acc n -> acc + n) 0 pool.in_flight
+
+(** Check if pool has available capacity (any model under limit). *)
+let has_capacity () : bool =
+  let pool = get_pool () in
+  let len = Array.length available_models in
+  let rec loop i =
+    if i >= len then false
+    else if pool.in_flight.(i) < available_models.(i).concurrency_limit then true
+    else loop (i + 1)
+  in
+  loop 0

--- a/lib/llm_client.ml
+++ b/lib/llm_client.ml
@@ -564,6 +564,29 @@ let call_openai_compatible (req : completion_request) : (completion_response, st
     Printf.eprintf "[llm_client] openai-compat raw (%d bytes): %s\n%!" (String.length raw) trunc;
     parse_openai_response raw
 
+(** GLM Cloud call with pool-based load balancing.
+    Uses Glm_pool.with_model to select best available model and track usage. *)
+let call_glm_cloud_with_pool (req : completion_request) : (completion_response, string) result =
+  (* Check if the requested model is in our pool for load balancing *)
+  let preferred_model =
+    if Glm_pool.is_pool_model req.model.model_id then
+      Some req.model.model_id
+    else
+      None
+  in
+  (* Use pool selection - will pick best available or use preferred if has capacity *)
+  Glm_pool.with_model preferred_model (fun pool_model_id ->
+    (* Create modified request with pool-selected model *)
+    let modified_model = { req.model with model_id = pool_model_id } in
+    let modified_req = { req with model = modified_model } in
+    (* Make the actual API call *)
+    match call_openai_compatible modified_req with
+    | Ok resp ->
+      (* Return response with pool model_id reflected in model_used *)
+      Ok { resp with model_used = pool_model_id }
+    | Error e -> Error e
+  )
+
 (* ================================================================ *)
 (* Core: complete                                                   *)
 (* ================================================================ *)
@@ -583,7 +606,8 @@ let complete ?ollama_timeout_sec (req : completion_request) : (completion_respon
            call_ollama_generate ?timeout_sec:ollama_timeout_sec req
          else Error e)
     | Claude -> call_claude req
-    | Gemini | Glm_cloud | OpenRouter | Custom _ ->
+    | Glm_cloud -> call_glm_cloud_with_pool req
+    | Gemini | OpenRouter | Custom _ ->
       call_openai_compatible req
   in
   let elapsed_ms = int_of_float ((Time_compat.now () -. t0) *. 1000.0) in


### PR DESCRIPTION
## Summary

- **Glm_pool 모듈 추가**: GLM Cloud 모델들에 대한 로드 밸런싱 풀 구현
- **최대 ~39개 동시 호출 가능**: 각 모델의 concurrency limit을 활용한 병렬 처리 최적화
- **Least-loaded 전략**: 가장 여유 있는 모델을 선택하여 요청 분산

## Model Concurrency Limits (Z.ai 공식)

| Model | Concurrency |
|-------|-------------|
| GLM-4.5 | 10 |
| GLM-4.6V | 10 |
| GLM-5 | 5 |
| GLM-4.7 | 5 |
| GLM-4.6 | 3 |
| GLM-4.6V-FlashX | 3 |
| GLM-4.7-FlashX | 3 |
| **Total** | **~39** |

## Architecture

```
call_glm_cloud_with_pool
  ↓
Glm_pool.with_model (selects best model)
  ↓
call_openai_compatible (actual API call)
```

## Key Features

- **Least-loaded selection**: `in_flight / concurrency_limit` 비율이 가장 낮은 모델 선택
- **Round-robin fallback**: 모든 모델이 capacity에 도달하면 순환 선택
- **In-flight tracking**: 각 모델별 진행 중인 요청 수 추적
- **Automatic lifecycle**: `with_model` 함수로 acquire/release 자동 처리

## Files Changed

- `lib/glm_pool.ml` (new) - 190 lines
- `lib/llm_client.ml` - call_glm_cloud_with_pool 함수 추가, complete 함수 수정
- `lib/dune` - glm_pool 모듈 추가

## Test Plan

- [x] `dune build` 컴파일 성공
- [x] `dune runtest` 모든 테스트 통과
- [ ] 실제 GLM Cloud API 호출 테스트 (머지 전 수동)

## Use Case

MASC Lodge heartbeat, social experiments, games에서 다수의 GLM 호출이 필요할 때
단일 모델의 concurrency limit(최대 10)을 넘어서는 병렬 처리 가능.

🤖 Generated with [Claude Code](https://claude.com/claude-code)