### PR TITLE
TRPG/Viewer UX: fast keeper routing, clean sessions, debug toggle

### DIFF
--- a/bin/main_eio.ml
+++ b/bin/main_eio.ml
@@ -694,7 +694,7 @@ let trpg_keeper_call_with_runtime
   in
   let inline_goal =
     Printf.sprintf
-      "TRPG runtime keeper for %s. Stay in character, keep continuity, and answer concisely."
+      "TRPG runtime keeper for %s. You are an in-world keeper of this setting; avoid out-of-world meta narration, stay in character, keep continuity, and answer concisely."
       keeper_name
   in
   let keeper_args =

--- a/lib/web_dashboard.ml
+++ b/lib/web_dashboard.ml
@@ -2071,6 +2071,12 @@ let cached_html = lazy ({|<!DOCTYPE html>
                   <span>세션 시작 후 즉시 1라운드 실행</span>
                 </label>
               </div>
+              <div class="trpg-control-help" style="margin-top:2px;">
+                <label style="display:flex;align-items:center;gap:6px;cursor:pointer;">
+                  <input id="trpg-show-past-sessions" type="checkbox" onchange="trpgToggleSessionView(this.checked)">
+                  <span>이전 세션 로그 포함 보기</span>
+                </label>
+              </div>
               <div id="trpg-round-run-status" class="trpg-run-status">1) 세션 시작 → 2) 라운드 실행 순서로 진행하세요.</div>
               <div id="trpg-next-action" class="trpg-next-action">
                 <div class="title">다음 액션</div>
@@ -6999,6 +7005,7 @@ let cached_html = lazy ({|<!DOCTYPE html>
     let trpgPresetsLoaded = false;
     let trpgKeepersLoaded = false;
     let trpgKeeperSelectorsKey = '';
+    let trpgIncludePastSessions = false;
     let trpgMcpCallSeq = 1000;
     let trpgMcpSessionId = null;
     let trpgPresetCatalog = { dm_presets: [], world_presets: [] };
@@ -7057,6 +7064,35 @@ let cached_html = lazy ({|<!DOCTYPE html>
       return summary;
     }
 
+    function trpgLatestSessionStartSeq(events) {
+      let startSeq = 0;
+      (Array.isArray(events) ? events : []).forEach((ev) => {
+        if (trpgEventType(ev) !== 'session.started') return;
+        const seq = Number(ev && ev.seq);
+        if (Number.isFinite(seq) && seq > startSeq) startSeq = seq;
+      });
+      return startSeq;
+    }
+
+    function trpgCurrentSessionEvents(events) {
+      const xs = Array.isArray(events) ? events : [];
+      if (trpgIncludePastSessions) return xs;
+      const startSeq = trpgLatestSessionStartSeq(xs);
+      if (startSeq <= 0) return xs;
+      return xs.filter((ev) => {
+        const seq = Number(ev && ev.seq);
+        return Number.isFinite(seq) ? seq >= startSeq : true;
+      });
+    }
+
+    function trpgToggleSessionView(checked) {
+      trpgIncludePastSessions = !!checked;
+      renderTrpgNarrative(trpgEventsCache);
+      renderTrpgState(trpgStateCache, trpgEventsCache);
+      const mode = trpgIncludePastSessions ? '전체 세션 로그 표시' : '현재 세션 로그만 표시';
+      showToast(mode, 'success');
+    }
+
     function trpgSetNextAction(kind, label, desc, enabled = true) {
       trpgNextActionKind = String(kind || 'none');
       trpgCanRunRound = trpgNextActionKind === 'run_round' && !!enabled;
@@ -7082,6 +7118,7 @@ let cached_html = lazy ({|<!DOCTYPE html>
     }
 
     function trpgUpdateNextAction(state, events) {
+      const viewEvents = trpgCurrentSessionEvents(events);
       if (trpgBootstrapping) {
         trpgSetNextAction('wait', '준비 중...', '세션 시작 준비가 진행 중입니다. 잠시만 기다리세요.', false);
         return;
@@ -7090,12 +7127,12 @@ let cached_html = lazy ({|<!DOCTYPE html>
         trpgSetNextAction('wait', '라운드 실행 중...', '현재 라운드가 진행 중입니다. 완료 후 상태가 자동 갱신됩니다.', false);
         return;
       }
-      const sessions = trpgBuildSessionHistory(events);
+      const sessions = trpgBuildSessionHistory(viewEvents);
       if (sessions.length === 0) {
         trpgSetNextAction('bootstrap', '1) 세션 시작', '아직 세션이 없습니다. world/dm preset 확인 후 세션을 시작하세요.', true);
         return;
       }
-      const expectedActors = trpgPartyActorsFromStateOrEvents(state, events);
+      const expectedActors = trpgPartyActorsFromStateOrEvents(state, viewEvents);
       if (expectedActors.length === 0) {
         trpgSetNextAction('wait', '세션 준비 중', '파티 actor_id를 아직 확인하지 못했습니다. 1) 세션 시작을 다시 실행하세요.', false);
         return;
@@ -7275,6 +7312,8 @@ let cached_html = lazy ({|<!DOCTYPE html>
       } else if (langSelect && String(langSelect.value || '').trim() === 'auto' && browserLang.startsWith('ko')) {
         langSelect.value = 'ko';
       }
+      const showPastEl = document.getElementById('trpg-show-past-sessions');
+      if (showPastEl) showPastEl.checked = trpgIncludePastSessions;
       const dmInput = document.getElementById('trpg-dm-keeper-input');
       if (dmInput && String(dmInput.value || '').trim() === '') {
         const preferredDm =
@@ -7919,6 +7958,18 @@ let cached_html = lazy ({|<!DOCTYPE html>
         if (partySize > poolSize) {
           throw new Error('party size는 pool size보다 클 수 없습니다.');
         }
+        const requestedDmKeeper =
+          String((document.getElementById('trpg-dm-keeper-input') || {}).value || '').trim();
+        const requestedPlayerRaw =
+          String((document.getElementById('trpg-player-keepers-input') || {}).value || '');
+        const parsedRequestedPlayers = parseTrpgPlayerKeepers(requestedPlayerRaw);
+        const requestedPlayerKeepers = parsedRequestedPlayers.ok
+          ? trpgUniqueStrings(
+            Object.values(parsedRequestedPlayers.mapping || {})
+              .map((name) => String(name || '').trim())
+              .filter((name) => name !== '')
+          )
+          : trpgExtractKeeperNamesFromPlayerText(requestedPlayerRaw);
 
         const sessionId = `dashboard-${roomId}-${Date.now()}`;
         const seed = Math.floor(Date.now() % 100000);
@@ -7965,17 +8016,32 @@ let cached_html = lazy ({|<!DOCTYPE html>
           (startResult.round_run_template && typeof startResult.round_run_template === 'object' && !Array.isArray(startResult.round_run_template))
             ? startResult.round_run_template
             : {};
-        const dmKeeper = String(template.dm_keeper || startResult.dm_keeper || 'dm-keeper').trim() || 'dm-keeper';
+        const dmKeeper =
+          requestedDmKeeper
+          || String(template.dm_keeper || startResult.dm_keeper || 'dm-keeper').trim()
+          || 'dm-keeper';
         const playerMapRaw =
           (template.player_keepers && typeof template.player_keepers === 'object' && !Array.isArray(template.player_keepers))
             ? template.player_keepers
             : {};
+        const partyActorIds = (Array.isArray(party) ? party : [])
+          .map((member) => String((member && member.actor_id) || '').trim())
+          .filter((id) => id !== '');
+        const templateActorIds = Object.keys(playerMapRaw)
+          .map((actorId) => String(actorId || '').trim())
+          .filter((id) => id !== '');
+        const actorIds = trpgUniqueStrings(partyActorIds.length > 0 ? partyActorIds : templateActorIds);
+        if (actorIds.length === 0) {
+          throw new Error('세션 파티 actor_id를 확인하지 못했습니다.');
+        }
+
         const usedKeepers = new Set([dmKeeper]);
+        const preferredKeepers = requestedPlayerKeepers.filter((name) => name !== dmKeeper);
         const playerMap = {};
-        Object.entries(playerMapRaw).forEach(([actorIdRaw, keeperRaw]) => {
-          const actorId = String(actorIdRaw || '').trim();
-          if (!actorId) return;
-          let keeper = String(keeperRaw || '').trim();
+        actorIds.forEach((actorId, idx) => {
+          let keeper = idx < preferredKeepers.length
+            ? preferredKeepers[idx]
+            : String(playerMapRaw[actorId] || '').trim();
           if (!keeper || usedKeepers.has(keeper)) {
             keeper = `pk-${actorId}`;
           }
@@ -7991,7 +8057,7 @@ let cached_html = lazy ({|<!DOCTYPE html>
         const dmInput = document.getElementById('trpg-dm-keeper-input');
         if (dmInput) dmInput.value = dmKeeper;
         const playerInput = document.getElementById('trpg-player-keepers-input');
-        if (playerInput && playerLines) playerInput.value = playerLines;
+        if (playerInput) playerInput.value = playerLines;
         const phaseSelect = document.getElementById('trpg-phase-select');
         if (phaseSelect) phaseSelect.value = phase;
         trpgSyncKeeperSelectorsFromInputs();
@@ -8103,7 +8169,7 @@ let cached_html = lazy ({|<!DOCTYPE html>
     }
 
     function trpgShortText(raw, maxLen = 120) {
-      const text = String(raw || '').replace(/\s+/g, ' ').trim();
+      const text = trpgNormalizeDisplayText(raw).replace(/\s+/g, ' ').trim();
       if (text.length <= maxLen) return text;
       return text.slice(0, Math.max(0, maxLen - 1)) + '…';
     }
@@ -8148,7 +8214,10 @@ let cached_html = lazy ({|<!DOCTYPE html>
         );
         return;
       }
-      const expectedActors = trpgPartyActorsFromStateOrEvents(trpgStateCache, trpgEventsCache);
+      const expectedActors = trpgPartyActorsFromStateOrEvents(
+        trpgStateCache,
+        trpgCurrentSessionEvents(trpgEventsCache)
+      );
       if (expectedActors.length > 0) {
         const expectedSet = new Set(expectedActors);
         const inputActors = Object.keys(parsedPlayers.mapping || {});
@@ -8305,26 +8374,38 @@ let cached_html = lazy ({|<!DOCTYPE html>
       trpgUpdateNextAction(trpgStateCache, trpgEventsCache);
     }
 
+    function trpgNormalizeDisplayText(raw) {
+      return String(raw || '')
+        .replace(/\uFEFF/g, '')
+        .replace(/\uFFFD/g, '')
+        .replace(/[\u0000-\u0008\u000B\u000C\u000E-\u001F]/g, '');
+    }
+
     function trpgSanitizeNarrative(raw) {
-      let text = String(raw || '').replace(/\r\n/g, '\n');
+      let text = trpgNormalizeDisplayText(raw).replace(/\r\n/g, '\n');
       text = text.replace(/^SKILL:.*$/gmi, '');
       text = text.replace(/^SKILL_REASON:.*$/gmi, '');
       text = text.replace(/```[\s\S]*?```/g, '');
       text = text.replace(/\[STATE\][\s\S]*?\[\/STATE\]/gmi, '');
       text = text.replace(/\n{3,}/g, '\n\n').trim();
       if (text !== '') return text;
-      return String(raw || '').replace(/\n{3,}/g, '\n\n').trim();
+      return trpgNormalizeDisplayText(raw).replace(/\n{3,}/g, '\n\n').trim();
     }
 
     function renderTrpgNarrative(events) {
       const el = document.getElementById('trpg-narrative');
       if (!el) return;
-      const narrations = (Array.isArray(events) ? events : [])
+      const sourceEvents = trpgCurrentSessionEvents(events);
+      const narrations = sourceEvents
         .filter((ev) => trpgEventType(ev) === 'narration.posted')
         .sort((a, b) => (Number(a.seq) || 0) - (Number(b.seq) || 0))
         .slice(-80);
       if (!narrations.length) {
-        el.innerHTML = '<div class="trpg-empty">아직 서사가 없습니다. 1) 세션 시작 후 2) 라운드를 실행하세요.</div>';
+        const historyCount = trpgBuildSessionHistory(Array.isArray(events) ? events : []).length;
+        const hiddenText = (!trpgIncludePastSessions && historyCount > 1)
+          ? `<div class="trpg-control-help" style="margin-top:8px;">이전 ${historyCount - 1}개 세션 로그는 숨겨져 있습니다. "이전 세션 로그 포함 보기"를 켜면 확인할 수 있습니다.</div>`
+          : '';
+        el.innerHTML = `<div class="trpg-empty">아직 서사가 없습니다. 1) 세션 시작 후 2) 라운드를 실행하세요.</div>${hiddenText}`;
         return;
       }
       let html = '';
@@ -8396,14 +8477,15 @@ let cached_html = lazy ({|<!DOCTYPE html>
     }
 
     function renderTrpgState(state, events) {
-      const phase = trpgLatestPhase(events);
-      const round = trpgLatestRound(state, events);
-      const summary = trpgRoundSummary(events, round);
-      renderTrpgSessionMeta(state, events, summary, phase);
-      renderTrpgPartyAssignment(state, events);
-      trpgUpdateNextAction(state, events);
+      const viewEvents = trpgCurrentSessionEvents(events);
+      const phase = trpgLatestPhase(viewEvents);
+      const round = trpgLatestRound(state, viewEvents);
+      const summary = trpgRoundSummary(viewEvents, round);
+      renderTrpgSessionMeta(state, viewEvents, summary, phase);
+      renderTrpgPartyAssignment(state, viewEvents);
+      trpgUpdateNextAction(state, viewEvents);
       renderTrpgStatus(state, summary, phase);
-      renderTrpgRoundLog(events, round);
+      renderTrpgRoundLog(viewEvents, round);
       renderTrpgGameHistory(events);
       renderTrpgParty(state);
       renderTrpgMap(state, summary);
@@ -8531,12 +8613,14 @@ let cached_html = lazy ({|<!DOCTYPE html>
     function renderTrpgGameHistory(events) {
       const el = document.getElementById('trpg-game-history');
       if (!el) return;
-      const history = trpgBuildSessionHistory(events);
-      if (!history.length) {
+      const fullHistory = trpgBuildSessionHistory(events);
+      if (!fullHistory.length) {
         el.innerHTML = '<div class="trpg-empty" style="padding:18px 8px;">이 room의 이전 세션 기록이 없습니다.</div>';
         return;
       }
-      el.innerHTML = history.map((session, idx) => {
+      const visibleHistory = trpgIncludePastSessions ? fullHistory : fullHistory.slice(0, 1);
+      const hiddenCount = Math.max(0, fullHistory.length - visibleHistory.length);
+      const cards = visibleHistory.map((session, idx) => {
         const isLatest = idx === 0;
         const cls = isLatest ? 'ok' : '';
         const roomText = session.roomId ? ` · room ${escapeHtml(session.roomId)}` : '';
@@ -8547,7 +8631,16 @@ let cached_html = lazy ({|<!DOCTYPE html>
             <div class="meta">시작 ${escapeHtml(trpgFmtDateTime(session.startedAt))} · 최근 ${escapeHtml(trpgFmtDateTime(session.lastTs))} · round ${session.maxTurn || 0} · events ${session.eventCount}</div>
           </div>
         `;
-      }).join('');
+      });
+      if (hiddenCount > 0) {
+        cards.push(`
+          <div class="trpg-round-item">
+            <div class="meta">history</div>
+            <div>이전 ${hiddenCount}개 세션은 숨김 상태입니다. "이전 세션 로그 포함 보기"를 켜면 모두 표시됩니다.</div>
+          </div>
+        `);
+      }
+      el.innerHTML = cards.join('');
     }
 
     function renderTrpgStatus(state, summary, phase) {

--- a/lib/web_dashboard.ml
+++ b/lib/web_dashboard.ml
@@ -7914,9 +7914,9 @@ let cached_html = lazy ({|<!DOCTYPE html>
 
     function trpgDmGoalText(lang, roomId, worldPresetTitle) {
       if (lang === 'ko') {
-        return `TRPG room ${roomId}의 DM으로 ${worldPresetTitle} 시나리오를 운영하세요. 장면 연속성과 규칙 일관성을 유지하세요.`;
+        return `TRPG room ${roomId}의 세계관 주민인 DM Keeper로 ${worldPresetTitle} 시나리오를 진행하세요. 메타 설명을 피하고 인월드 관점으로 장면 연속성과 규칙 일관성을 유지하세요.`;
       }
-      return `Run TRPG room ${roomId} as DM for ${worldPresetTitle}. Keep consistent scene state and enforce rules.`;
+      return `Act as an in-world DM Keeper for TRPG room ${roomId} in ${worldPresetTitle}. Avoid out-of-world meta narration, keep scene continuity, and enforce rules consistently.`;
     }
 
     function trpgPlayerGoalText(lang, roomId, actorId) {

--- a/viewer/index.html
+++ b/viewer/index.html
@@ -158,6 +158,9 @@
                     <option value="terminal">Terminal</option>
                     <option value="parchment">Parchment</option>
                 </select>
+                <button id="debug-log-toggle" class="inline-toggle" type="button" aria-pressed="true">Debug ON</button>
+                <span id="debug-log-status" class="widget-pill">DEBUG ON</span>
+                <span id="widget-status" class="widget-pill">Widgets N:0 P:0 D:0</span>
                 <div id="connection-status" class="disconnected">
                     <span class="status-dot"></span>
                     <span class="status-text">Disconnected</span>

--- a/viewer/src/dom/dice_log.rs
+++ b/viewer/src/dom/dice_log.rs
@@ -28,6 +28,26 @@ fn tier_label(result: &str) -> &'static str {
     }
 }
 
+fn sanitize_text(raw: &str) -> String {
+    raw.chars()
+        .filter(|ch| {
+            let code = *ch as u32;
+            *ch != '\u{feff}'
+                && *ch != '\u{fffd}'
+                && !(code <= 0x08 || code == 0x0b || code == 0x0c || (0x0e..=0x1f).contains(&code))
+        })
+        .collect()
+}
+
+fn escape_html(raw: &str) -> String {
+    sanitize_text(raw)
+        .replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+        .replace('"', "&quot;")
+        .replace('\'', "&#39;")
+}
+
 /// Appends dice roll entries to the #dice-log DOM element.
 pub fn update_dice_log_dom(mut events: MessageReader<DiceRolled>) {
     let Some(document) = web_sys::window().and_then(|w| w.document()) else {
@@ -43,11 +63,12 @@ pub fn update_dice_log_dom(mut events: MessageReader<DiceRolled>) {
         };
         let tier = tier_class(&payload.result);
         entry.set_class_name(&format!("dice-entry {}", tier));
-
+        let character = escape_html(&payload.character);
+        let action = escape_html(&payload.action);
         let note_html = payload
             .note
             .as_deref()
-            .map(|n| format!("<div class=\"dice-note\">{}</div>", n))
+            .map(|n| format!("<div class=\"dice-note\">{}</div>", escape_html(n)))
             .unwrap_or_default();
 
         entry.set_inner_html(&format!(
@@ -57,8 +78,8 @@ pub fn update_dice_log_dom(mut events: MessageReader<DiceRolled>) {
 <div class="dice-detail">d20: {} + {} = {} (DC {})</div>
 <div class="dice-tier">{}</div>
 {}"#,
-            payload.character,
-            payload.action,
+            character,
+            action,
             payload.total,
             payload.d20,
             payload.bonus,

--- a/viewer/src/dom/narrative.rs
+++ b/viewer/src/dom/narrative.rs
@@ -1,4 +1,5 @@
 use bevy::prelude::*;
+use wasm_bindgen::closure::Closure;
 use wasm_bindgen::JsCast;
 
 use crate::game::events::NarrativeReceived;
@@ -22,6 +23,34 @@ fn normalize_phase_suffix(phase: &str) -> String {
     }
 }
 
+fn sanitize_text(raw: &str) -> String {
+    raw.chars()
+        .filter(|ch| {
+            let code = *ch as u32;
+            *ch != '\u{feff}'
+                && *ch != '\u{fffd}'
+                && !(code <= 0x08 || code == 0x0b || code == 0x0c || (0x0e..=0x1f).contains(&code))
+        })
+        .collect()
+}
+
+fn toggle_selected_class(el: &web_sys::Element) {
+    let current = el.class_name();
+    let has_selected = current.split_whitespace().any(|cls| cls == "selected");
+    let next = if has_selected {
+        current
+            .split_whitespace()
+            .filter(|cls| *cls != "selected")
+            .collect::<Vec<_>>()
+            .join(" ")
+    } else if current.trim().is_empty() {
+        "selected".to_string()
+    } else {
+        format!("{} selected", current.trim())
+    };
+    el.set_class_name(next.trim());
+}
+
 /// Appends narrative entries to the #narrative-log DOM element.
 pub fn update_narrative_dom(mut events: MessageReader<NarrativeReceived>) {
     let Some(document) = web_sys::window().and_then(|w| w.document()) else {
@@ -35,16 +64,33 @@ pub fn update_narrative_dom(mut events: MessageReader<NarrativeReceived>) {
         let Ok(entry) = document.create_element("div") else {
             continue;
         };
-        let phase_suffix = normalize_phase_suffix(&payload.phase);
+        let phase_text = sanitize_text(&payload.phase);
+        let phase_suffix = normalize_phase_suffix(&phase_text);
         entry.set_class_name(&format!("narrative-entry phase-{}", phase_suffix));
+        let _ = entry.set_attribute("role", "button");
+        let _ = entry.set_attribute("tabindex", "0");
+        let _ = entry.set_attribute("title", "클릭하면 이 내러티브를 강조합니다.");
 
-        // Never insert streamed text via innerHTML.
-        if let Some(speaker) = payload
+        let speaker = payload
             .speaker
             .as_deref()
             .map(str::trim)
             .filter(|s| !s.is_empty())
-        {
+            .map(sanitize_text);
+
+        if let Ok(meta_el) = document.create_element("div") {
+            meta_el.set_class_name("narrative-meta");
+            let meta_text = if let Some(speaker) = speaker.as_deref() {
+                format!("{} · {}", phase_text, speaker)
+            } else {
+                phase_text.clone()
+            };
+            meta_el.set_text_content(Some(&meta_text));
+            let _ = entry.append_child(&meta_el);
+        }
+
+        // Never insert streamed text via innerHTML.
+        if let Some(speaker) = speaker.as_deref() {
             if let Ok(speaker_el) = document.create_element("span") {
                 speaker_el.set_class_name("narrative-speaker");
                 speaker_el.set_text_content(Some(speaker));
@@ -53,14 +99,24 @@ pub fn update_narrative_dom(mut events: MessageReader<NarrativeReceived>) {
         }
         if let Ok(text_el) = document.create_element("span") {
             text_el.set_class_name("narrative-text");
-            let text = if payload.speaker.as_deref().is_some() {
-                format!(" {}", payload.text)
+            let clean_text = sanitize_text(&payload.text);
+            let text = if speaker.is_some() {
+                format!(" {}", clean_text)
             } else {
-                payload.text.clone()
+                clean_text
             };
             text_el.set_text_content(Some(&text));
             let _ = entry.append_child(&text_el);
         }
+
+        let clickable_entry = entry.clone();
+        let click_cb = Closure::wrap(Box::new(move || {
+            toggle_selected_class(&clickable_entry);
+        }) as Box<dyn FnMut()>);
+        let _ = entry
+            .dyn_ref::<web_sys::EventTarget>()
+            .map(|target| target.add_event_listener_with_callback("click", click_cb.as_ref().unchecked_ref()));
+        click_cb.forget();
 
         let _ = log_el.append_child(&entry);
 

--- a/viewer/src/mode.rs
+++ b/viewer/src/mode.rs
@@ -160,6 +160,7 @@ impl Plugin for ModePlugin {
             .add_systems(OnExit(ViewerMode::Social), exit_social)
             .add_systems(OnEnter(ViewerMode::Experiment), enter_experiment)
             .add_systems(OnExit(ViewerMode::Experiment), exit_experiment)
+            .add_systems(Update, refresh_trpg_widget_status.run_if(in_state(ViewerMode::Trpg)))
             .add_systems(Update, poll_mode_transition);
     }
 }
@@ -186,6 +187,7 @@ fn on_enter_lobby(buffer: Res<ModeTransitionBuffer>) {
 
         // Bind back-to-lobby button
         bind_back_button(&doc, &buffer.pending);
+        bind_debug_controls(&doc);
 
         // Hide loading screen once Bevy is initialized
         if let Some(loading) = doc.get_element_by_id("loading-screen") {
@@ -311,6 +313,77 @@ fn bind_back_button(doc: &web_sys::Document, pending: &Arc<Mutex<Option<ViewerMo
         .map(|target| target.add_event_listener_with_callback("click", cb.as_ref().unchecked_ref()));
 
     cb.forget();
+}
+
+#[cfg(target_arch = "wasm32")]
+fn set_debug_state(doc: &web_sys::Document, enabled: bool) {
+    if let Some(dashboard) = doc.get_element_by_id("dashboard") {
+        let _ = dashboard.set_attribute("data-debug", if enabled { "on" } else { "off" });
+    }
+    if let Some(toggle) = doc.get_element_by_id("debug-log-toggle") {
+        toggle.set_text_content(Some(if enabled { "Debug ON" } else { "Debug OFF" }));
+        let _ = toggle.set_attribute("aria-pressed", if enabled { "true" } else { "false" });
+    }
+    if let Some(status) = doc.get_element_by_id("debug-log-status") {
+        status.set_text_content(Some(if enabled { "DEBUG ON" } else { "DEBUG OFF" }));
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+fn bind_debug_controls(doc: &web_sys::Document) {
+    let Some(toggle) = doc.get_element_by_id("debug-log-toggle") else {
+        return;
+    };
+    if toggle.get_attribute("data-bound").as_deref() == Some("1") {
+        return;
+    }
+    let _ = toggle.set_attribute("data-bound", "1");
+    set_debug_state(doc, true);
+
+    let cb = Closure::wrap(Box::new(move || {
+        let Some(doc) = web_sys::window().and_then(|w| w.document()) else {
+            return;
+        };
+        let enabled = doc
+            .get_element_by_id("dashboard")
+            .and_then(|el| el.get_attribute("data-debug"))
+            .map(|v| v != "off")
+            .unwrap_or(true);
+        set_debug_state(&doc, !enabled);
+    }) as Box<dyn FnMut()>);
+
+    let _ = toggle
+        .dyn_ref::<web_sys::EventTarget>()
+        .map(|target| target.add_event_listener_with_callback("click", cb.as_ref().unchecked_ref()));
+
+    cb.forget();
+}
+
+fn refresh_trpg_widget_status() {
+    #[cfg(target_arch = "wasm32")]
+    {
+        let Some(doc) = web_sys::window().and_then(|w| w.document()) else {
+            return;
+        };
+        let narrative_count = doc
+            .get_element_by_id("narrative-log")
+            .map(|el| el.child_element_count())
+            .unwrap_or(0);
+        let party_count = doc
+            .get_element_by_id("character-panel")
+            .map(|el| el.child_element_count())
+            .unwrap_or(0);
+        let dice_count = doc
+            .get_element_by_id("dice-log")
+            .map(|el| el.child_element_count())
+            .unwrap_or(0);
+        if let Some(status) = doc.get_element_by_id("widget-status") {
+            status.set_text_content(Some(&format!(
+                "Widgets N:{} P:{} D:{}",
+                narrative_count, party_count, dice_count
+            )));
+        }
+    }
 }
 
 // ─── Monitor Mode Enter/Exit ─────────────────

--- a/viewer/style.css
+++ b/viewer/style.css
@@ -367,6 +367,14 @@ body.mode-lobby #dashboard {
     background: var(--border-main);
 }
 
+#dashboard[data-debug="off"] {
+    grid-template-rows: 44px 1fr;
+}
+
+#dashboard[data-debug="off"] #bottom-zone {
+    display: none;
+}
+
 /* ─── Top Bar ──────────────────────────── */
 
 #top-bar {
@@ -412,6 +420,32 @@ body.mode-lobby #dashboard {
 .inline-select {
     font-size: 10px;
     padding: 2px 6px;
+}
+
+.inline-toggle {
+    font-size: 10px;
+    padding: 3px 8px;
+    border-radius: var(--panel-radius);
+    border: 1px solid var(--border-main);
+    background: var(--bg-panel-alt);
+    color: var(--text-primary);
+    cursor: pointer;
+}
+
+.inline-toggle[aria-pressed="false"] {
+    opacity: 0.72;
+    color: var(--text-dim);
+}
+
+.widget-pill {
+    font-family: var(--font-ui);
+    font-size: 10px;
+    color: var(--text-dim);
+    border: 1px solid var(--border-main);
+    border-radius: var(--panel-radius);
+    padding: 3px 8px;
+    background: var(--bg-panel-alt);
+    white-space: nowrap;
 }
 
 /* ─── Connection Status ────────────────── */
@@ -570,10 +604,24 @@ body.mode-lobby #dashboard {
     margin-bottom: 14px;
     padding: 8px 12px;
     border-left: 2px solid var(--border-main);
+    border-radius: var(--panel-radius);
     font-size: 14px;
     line-height: 1.7;
     color: var(--text-primary);
     animation: fade-in 0.4s ease;
+    cursor: pointer;
+    transition: background 0.18s ease, border-left-color 0.18s ease;
+}
+
+.narrative-entry:hover {
+    background: var(--bg-panel-alt);
+    border-left-color: var(--accent-primary-dim);
+}
+
+.narrative-entry.selected {
+    background: var(--bg-panel-alt);
+    border-left-color: var(--accent-primary);
+    box-shadow: 0 0 0 1px var(--border-main) inset;
 }
 
 .narrative-entry.phase-dm_narration {
@@ -591,6 +639,24 @@ body.mode-lobby #dashboard {
 
 #narrative-log {
     margin-top: 12px;
+}
+
+.narrative-meta {
+    font-family: var(--font-ui);
+    font-size: 10px;
+    color: var(--text-dim);
+    margin-bottom: 4px;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+}
+
+.narrative-speaker {
+    color: var(--accent-primary);
+    font-weight: 700;
+}
+
+.narrative-text {
+    white-space: pre-wrap;
 }
 
 /* Character cards */


### PR DESCRIPTION
## Summary
- force TRPG runtime keeper calls to prefer fast model cascade (`glm` / `gemini` / fallback)
- allow runtime keeper auto-create by sending inline `goal` when missing
- add guided flow in dashboard: `새 게임 -> DM 선택 -> AI Player 선택 -> 1) 세션 시작`
- make bootstrap reuse selected DM/Player keepers (prevents keeper count from growing every new run)
- add session-focused rendering by default (hide stale previous session logs unless explicitly enabled)
- sanitize noisy broken characters in TRPG narrative/status snippets
- improve Bevy viewer UX:
  - clickable narrative entries (highlight on click)
  - top bar widget activity indicators
  - `Debug ON/OFF` toggle to hide/show bottom dice debug log panel
  - sanitize/escape dice log text rendering

## Why
- fix common run failure (`keeper not found and goal not provided`) on fresh sessions
- reduce empty/slow responses by prioritizing fast providers
- remove clutter from old session data lingering in narrative/log panels
- make viewer controls actionable and visible for debugging

## Verification
- dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix-trpg-fast-models
- cargo check --manifest-path viewer/Cargo.toml
