### PR TITLE
feat(trpg): add actor lease protocol (spawn/claim/release)

### DIFF
--- a/lib/tool_protocol_game_view.ml
+++ b/lib/tool_protocol_game_view.ml
@@ -954,6 +954,9 @@ let legacy_alias_to_canonical = function
   | "masc_trpg_pool_generate" -> Some "trpg.pool.generate"
   | "masc_trpg_party_select" -> Some "trpg.party.select"
   | "masc_trpg_session_start" -> Some "trpg.session.start"
+  | "masc_trpg_actor_spawn" -> Some "trpg.actor.spawn"
+  | "masc_trpg_actor_claim" -> Some "trpg.actor.claim"
+  | "masc_trpg_actor_release" -> Some "trpg.actor.release"
   | "masc_trpg_intervention_submit" -> Some "trpg.intervention.submit"
   | "masc_trpg_scene_transition" -> Some "trpg.scene.transition"
   | "masc_trpg_quest_update" -> Some "trpg.quest.update"
@@ -1096,6 +1099,18 @@ let dispatch (ctx : context) ~name ~args : tool_result option =
       Some
         (handle_trpg_canonical ctx ~canonical_tool:name
            ~legacy_name:"masc_trpg_session_start" args)
+  | "trpg.actor.spawn" ->
+      Some
+        (handle_trpg_canonical ctx ~canonical_tool:name
+           ~legacy_name:"masc_trpg_actor_spawn" args)
+  | "trpg.actor.claim" ->
+      Some
+        (handle_trpg_canonical ctx ~canonical_tool:name
+           ~legacy_name:"masc_trpg_actor_claim" args)
+  | "trpg.actor.release" ->
+      Some
+        (handle_trpg_canonical ctx ~canonical_tool:name
+           ~legacy_name:"masc_trpg_actor_release" args)
   | "trpg.intervention.submit" ->
       Some
         (handle_trpg_canonical ctx ~canonical_tool:name
@@ -1339,6 +1354,44 @@ let schemas : Types.tool_schema list =
            ("rule_module", string_schema);
            ("force", bool_schema);
          ]);
+    schema "trpg.actor.spawn"
+      "Canonical alias of masc_trpg_actor_spawn."
+      (object_schema
+         ~required:[ "room_id"; "actor_id" ]
+         [
+           ("room_id", string_schema);
+           ("actor_id", string_schema);
+           ("role", string_schema);
+           ("name", string_schema);
+           ("archetype", string_schema);
+           ("persona", string_schema);
+           ("hp", int_schema);
+           ("max_hp", int_schema);
+           ("alive", bool_schema);
+           ("traits", array_of string_schema);
+           ("skills", array_of string_schema);
+         ]);
+    schema "trpg.actor.claim"
+      "Canonical alias of masc_trpg_actor_claim."
+      (object_schema
+         ~required:[ "room_id"; "actor_id"; "keeper_name" ]
+         [
+           ("room_id", string_schema);
+           ("actor_id", string_schema);
+           ("keeper_name", string_schema);
+           ("rule_module", string_schema);
+         ]);
+    schema "trpg.actor.release"
+      "Canonical alias of masc_trpg_actor_release."
+      (object_schema
+         ~required:[ "room_id"; "actor_id"; "keeper_name" ]
+         [
+           ("room_id", string_schema);
+           ("actor_id", string_schema);
+           ("keeper_name", string_schema);
+           ("reason", string_schema);
+           ("rule_module", string_schema);
+         ]);
     schema "trpg.intervention.submit"
       "Canonical alias of masc_trpg_intervention_submit."
       (object_schema
@@ -1395,6 +1448,7 @@ let schemas : Types.tool_schema list =
            ("phase", string_schema);
            ("rule_module", string_schema);
            ("timeout_sec", number_schema);
+           ("require_claim", bool_schema);
          ]);
     schema "trpg.scene.transition"
       "Canonical alias of masc_trpg_scene_transition."

--- a/lib/tool_trpg.ml
+++ b/lib/tool_trpg.ml
@@ -9,6 +9,9 @@
     - masc_trpg_pool_generate
     - masc_trpg_party_select
     - masc_trpg_session_start
+    - masc_trpg_actor_spawn
+    - masc_trpg_actor_claim
+    - masc_trpg_actor_release
     - masc_trpg_intervention_submit
 *)
 
@@ -216,7 +219,7 @@ let schemas : Types.tool_schema list =
         "Run one TRPG round by messaging DM keeper then player keepers. \
          Records strict timeout/unavailable events. \
          Required: room_id, dm_keeper, player_keepers(object actor_id->keeper_name). \
-         Optional: phase(default round), rule_module(default dnd5e-lite), timeout_sec(default 30), lang(ko|en).";
+         Optional: phase(default round), rule_module(default dnd5e-lite), timeout_sec(default 30), lang(ko|en), require_claim(boolean).";
       input_schema =
         `Assoc
           [
@@ -235,6 +238,7 @@ let schemas : Types.tool_schema list =
                   ("phase", `Assoc [ ("type", `String "string") ]);
                   ("rule_module", `Assoc [ ("type", `String "string") ]);
                   ("timeout_sec", `Assoc [ ("type", `String "number") ]);
+                  ("require_claim", `Assoc [ ("type", `String "boolean") ]);
                   ("lang", `Assoc [ ("type", `String "string") ]);
                 ] );
             ( "required",
@@ -450,6 +454,76 @@ let schemas : Types.tool_schema list =
           ];
     };
     {
+      name = "masc_trpg_actor_spawn";
+      description =
+        "Spawn an actor entity in room state. \
+         Required: room_id, actor_id. \
+         Optional: role(dm|player|npc), name, archetype, persona, hp, max_hp, alive, traits, skills.";
+      input_schema =
+        `Assoc
+          [
+            ("type", `String "object");
+            ( "properties",
+              `Assoc
+                [
+                  ("room_id", `Assoc [ ("type", `String "string") ]);
+                  ("actor_id", `Assoc [ ("type", `String "string") ]);
+                  ("role", `Assoc [ ("type", `String "string") ]);
+                  ("name", `Assoc [ ("type", `String "string") ]);
+                  ("archetype", `Assoc [ ("type", `String "string") ]);
+                  ("persona", `Assoc [ ("type", `String "string") ]);
+                  ("hp", `Assoc [ ("type", `String "integer") ]);
+                  ("max_hp", `Assoc [ ("type", `String "integer") ]);
+                  ("alive", `Assoc [ ("type", `String "boolean") ]);
+                  ("traits", `Assoc [ ("type", `String "array"); ("items", `Assoc [ ("type", `String "string") ]) ]);
+                  ("skills", `Assoc [ ("type", `String "array"); ("items", `Assoc [ ("type", `String "string") ]) ]);
+                ] );
+            ("required", `List [ `String "room_id"; `String "actor_id" ]);
+          ];
+    };
+    {
+      name = "masc_trpg_actor_claim";
+      description =
+        "Claim an actor lease for a keeper. \
+         Required: room_id, actor_id, keeper_name. \
+         Enforces one keeper -> one actor and denies claim when actor is dead.";
+      input_schema =
+        `Assoc
+          [
+            ("type", `String "object");
+            ( "properties",
+              `Assoc
+                [
+                  ("room_id", `Assoc [ ("type", `String "string") ]);
+                  ("actor_id", `Assoc [ ("type", `String "string") ]);
+                  ("keeper_name", `Assoc [ ("type", `String "string") ]);
+                ] );
+            ( "required",
+              `List [ `String "room_id"; `String "actor_id"; `String "keeper_name" ] );
+          ];
+    };
+    {
+      name = "masc_trpg_actor_release";
+      description =
+        "Release an actor lease held by a keeper. \
+         Required: room_id, actor_id, keeper_name. Optional: reason.";
+      input_schema =
+        `Assoc
+          [
+            ("type", `String "object");
+            ( "properties",
+              `Assoc
+                [
+                  ("room_id", `Assoc [ ("type", `String "string") ]);
+                  ("actor_id", `Assoc [ ("type", `String "string") ]);
+                  ("keeper_name", `Assoc [ ("type", `String "string") ]);
+                  ("reason", `Assoc [ ("type", `String "string") ]);
+                ] );
+            ( "required",
+              `List [ `String "room_id"; `String "actor_id"; `String "keeper_name" ] );
+          ];
+    };
+    {
       name = "masc_trpg_intervention_submit";
       description =
         "Submit a human intervention to apply before next AI round run. \
@@ -558,6 +632,12 @@ let get_string_list_from_json = function
            xs)
   | _ -> Error "value must be string array"
 
+let get_optional_string_list args key =
+  match args |> member key with
+  | `Null -> Ok []
+  | `List _ as list_json -> get_string_list_from_json list_json
+  | _ -> Error (Printf.sprintf "%s must be string array" key)
+
 let dedupe_keep_order xs =
   let rec loop seen acc = function
     | [] -> List.rev acc
@@ -586,6 +666,10 @@ let sanitize_room_id (s : string) =
 let validate_rule_module = function
   | "" | "dnd5e-lite" -> Ok ()
   | other -> Error (Printf.sprintf "unsupported rule_module: %s" other)
+
+let validate_actor_role = function
+  | "player" | "npc" | "dm" -> Ok ()
+  | other -> Error (Printf.sprintf "role must be one of: player, npc, dm (got %s)" other)
 
 let extract_config_from_events (events : Trpg_engine_event.t list) : Yojson.Safe.t =
   let rec loop = function
@@ -657,6 +741,42 @@ let derive_state ~base_dir ~room_id ~rule_module =
 
 let state_of_derived derived =
   match derived |> member "state" with `Null -> `Assoc [] | v -> v
+
+let state_party_fields state =
+  match state |> member "party" with
+  | `Assoc fields -> fields
+  | _ -> []
+
+let actor_exists_in_state state actor_id =
+  state_party_fields state |> List.mem_assoc actor_id
+
+let actor_alive_in_state state actor_id =
+  match state_party_fields state |> List.assoc_opt actor_id with
+  | Some actor_json ->
+      actor_json |> member "alive" |> to_bool_option |> Option.value ~default:true
+  | None -> false
+
+let state_actor_control_fields state =
+  match state |> member "actor_control" with
+  | `Assoc fields ->
+      fields
+      |> List.filter_map (function
+           | actor_id, `String keeper_name ->
+               let actor_id = String.trim actor_id in
+               let keeper_name = String.trim keeper_name in
+               if actor_id = "" || keeper_name = "" then None
+               else Some (actor_id, keeper_name)
+           | _ -> None)
+  | _ -> []
+
+let owner_for_actor state actor_id =
+  state_actor_control_fields state |> List.assoc_opt actor_id
+
+let actor_for_keeper state keeper_name =
+  let keeper_key = normalize_keeper_name keeper_name in
+  state_actor_control_fields state
+  |> List.find_map (fun (actor_id, owner) ->
+         if normalize_keeper_name owner = keeper_key then Some actor_id else None)
 
 let read_state_turn derived =
   match state_of_derived derived |> member "turn" with
@@ -1601,6 +1721,207 @@ let handle_session_start ctx args : result =
   in
   match result_json with Ok j -> ok_json j | Error e -> err e
 
+let actor_payload_from_spawn_args args ~actor_id =
+  let ( let* ) = Result.bind in
+  let* role_opt = get_optional_string args "role" in
+  let role = Option.value ~default:"player" role_opt |> String.lowercase_ascii in
+  let* () = validate_actor_role role in
+  let* name_opt = get_optional_string args "name" in
+  let* archetype_opt = get_optional_string args "archetype" in
+  let* persona_opt = get_optional_string args "persona" in
+  let* hp_opt = get_optional_int args "hp" in
+  let* max_hp_opt = get_optional_int args "max_hp" in
+  let* alive = get_optional_bool args "alive" ~default:true in
+  let* traits = get_optional_string_list args "traits" in
+  let* skills = get_optional_string_list args "skills" in
+  let max_hp = Option.value ~default:10 max_hp_opt in
+  if max_hp <= 0 then Error "max_hp must be > 0"
+  else
+    let hp = Option.value ~default:max_hp hp_opt in
+    if hp < 0 then Error "hp must be >= 0"
+    else
+      let hp = min hp max_hp in
+      let actor_json =
+        `Assoc
+          [
+            ("name", `String (Option.value ~default:actor_id name_opt));
+            ("role", `String role);
+            ("archetype", Option.fold ~none:`Null ~some:(fun v -> `String v) archetype_opt);
+            ("persona", Option.fold ~none:`Null ~some:(fun v -> `String v) persona_opt);
+            ("hp", `Int hp);
+            ("max_hp", `Int max_hp);
+            ("alive", `Bool alive);
+            ("traits", json_of_strings traits);
+            ("skills", json_of_strings skills);
+            ("inventory", `List []);
+          ]
+      in
+      Ok actor_json
+
+let handle_actor_spawn ctx args : result =
+  let ( let* ) = Result.bind in
+  let base_dir = ctx.config.base_path in
+  let result_json =
+    let* room_id = get_required_string args "room_id" in
+    let* actor_id = get_required_string args "actor_id" in
+    let* rule_opt = get_optional_string args "rule_module" in
+    let rule_module = Option.value ~default:"dnd5e-lite" rule_opt in
+    let* () = validate_rule_module rule_module in
+    let* derived = derive_state ~base_dir ~room_id ~rule_module in
+    let state = state_of_derived derived in
+    if actor_exists_in_state state actor_id then
+      Error (Printf.sprintf "actor already exists: %s" actor_id)
+    else
+      let* actor_json = actor_payload_from_spawn_args args ~actor_id in
+      let payload =
+        `Assoc
+          [
+            ("actor_id", `String actor_id);
+            ("actor", actor_json);
+            ("spawned_by", `String ctx.agent_name);
+          ]
+      in
+      let* event =
+        append_event ~base_dir ~room_id
+          ~event_type:Trpg_engine_event.Actor_spawned
+          ~actor_id ~payload ()
+      in
+      let* next_derived = derive_state ~base_dir ~room_id ~rule_module in
+      Ok
+        (`Assoc
+          [
+            ("ok", `Bool true);
+            ("room_id", `String room_id);
+            ("actor_id", `String actor_id);
+            ("event", Trpg_engine_event.to_yojson event);
+            ("state", state_of_derived next_derived);
+          ])
+  in
+  match result_json with Ok j -> ok_json j | Error e -> err e
+
+let handle_actor_claim ctx args : result =
+  let ( let* ) = Result.bind in
+  let base_dir = ctx.config.base_path in
+  let result_json =
+    let* room_id = get_required_string args "room_id" in
+    let* actor_id = get_required_string args "actor_id" in
+    let* keeper_name = get_required_string args "keeper_name" in
+    let* rule_opt = get_optional_string args "rule_module" in
+    let rule_module = Option.value ~default:"dnd5e-lite" rule_opt in
+    let* () = validate_rule_module rule_module in
+    let* derived = derive_state ~base_dir ~room_id ~rule_module in
+    let state = state_of_derived derived in
+    if not (actor_exists_in_state state actor_id) then
+      Error (Printf.sprintf "unknown actor_id: %s" actor_id)
+    else if not (actor_alive_in_state state actor_id) then
+      Error (Printf.sprintf "actor is not alive: %s" actor_id)
+    else
+      let normalized_keeper = normalize_keeper_name keeper_name in
+      match owner_for_actor state actor_id with
+      | Some owner when normalize_keeper_name owner = normalized_keeper ->
+          Ok
+            (`Assoc
+              [
+                ("ok", `Bool true);
+                ("room_id", `String room_id);
+                ("actor_id", `String actor_id);
+                ("keeper_name", `String owner);
+                ("status", `String "already_claimed");
+                ("state", state);
+              ])
+      | Some owner ->
+          Error
+            (Printf.sprintf
+               "actor already claimed: actor_id=%s owner=%s"
+               actor_id owner)
+      | None -> (
+          match actor_for_keeper state keeper_name with
+          | Some current_actor ->
+              Error
+                (Printf.sprintf
+                   "keeper already controls actor: keeper=%s actor_id=%s"
+                   keeper_name current_actor)
+          | None ->
+              let payload =
+                `Assoc
+                  [
+                    ("actor_id", `String actor_id);
+                    ("keeper_name", `String keeper_name);
+                    ("claimed_by", `String ctx.agent_name);
+                  ]
+              in
+              let* event =
+                append_event ~base_dir ~room_id
+                  ~event_type:Trpg_engine_event.Actor_claimed
+                  ~actor_id ~payload ()
+              in
+              let* next_derived = derive_state ~base_dir ~room_id ~rule_module in
+              Ok
+                (`Assoc
+                  [
+                    ("ok", `Bool true);
+                    ("room_id", `String room_id);
+                    ("actor_id", `String actor_id);
+                    ("keeper_name", `String keeper_name);
+                    ("status", `String "claimed");
+                    ("event", Trpg_engine_event.to_yojson event);
+                    ("state", state_of_derived next_derived);
+                  ]) )
+  in
+  match result_json with Ok j -> ok_json j | Error e -> err e
+
+let handle_actor_release ctx args : result =
+  let ( let* ) = Result.bind in
+  let base_dir = ctx.config.base_path in
+  let result_json =
+    let* room_id = get_required_string args "room_id" in
+    let* actor_id = get_required_string args "actor_id" in
+    let* keeper_name = get_required_string args "keeper_name" in
+    let* reason_opt = get_optional_string args "reason" in
+    let* rule_opt = get_optional_string args "rule_module" in
+    let rule_module = Option.value ~default:"dnd5e-lite" rule_opt in
+    let* () = validate_rule_module rule_module in
+    let* derived = derive_state ~base_dir ~room_id ~rule_module in
+    let state = state_of_derived derived in
+    let normalized_keeper = normalize_keeper_name keeper_name in
+    match owner_for_actor state actor_id with
+    | None ->
+        Error (Printf.sprintf "actor is not claimed: %s" actor_id)
+    | Some owner when normalize_keeper_name owner <> normalized_keeper ->
+        Error
+          (Printf.sprintf
+             "actor is claimed by another keeper: actor_id=%s owner=%s"
+             actor_id owner)
+    | Some owner ->
+        let payload =
+          `Assoc
+            [
+              ("actor_id", `String actor_id);
+              ("keeper_name", `String owner);
+              ("reason", Option.fold ~none:`Null ~some:(fun v -> `String v) reason_opt);
+              ("released_by", `String ctx.agent_name);
+            ]
+        in
+        let* event =
+          append_event ~base_dir ~room_id
+            ~event_type:Trpg_engine_event.Actor_released
+            ~actor_id ~payload ()
+        in
+        let* next_derived = derive_state ~base_dir ~room_id ~rule_module in
+        Ok
+          (`Assoc
+            [
+              ("ok", `Bool true);
+              ("room_id", `String room_id);
+              ("actor_id", `String actor_id);
+              ("keeper_name", `String owner);
+              ("status", `String "released");
+              ("event", Trpg_engine_event.to_yojson event);
+              ("state", state_of_derived next_derived);
+            ])
+  in
+  match result_json with Ok j -> ok_json j | Error e -> err e
+
 let handle_intervention_submit ctx args : result =
   let ( let* ) = Result.bind in
   let base_dir = ctx.config.base_path in
@@ -1665,6 +1986,7 @@ let handle_round_run ctx args : result =
       let* rule_opt = get_optional_string args "rule_module" in
       let* phase_opt = get_optional_string args "phase" in
       let* lang_opt = get_optional_string args "lang" in
+      let* require_claim = get_optional_bool args "require_claim" ~default:false in
       let rule_module = Option.value ~default:"dnd5e-lite" rule_opt in
       let phase = Option.value ~default:"round" phase_opt in
       let prompt_lang = prompt_language_of_string_opt lang_opt in
@@ -1710,6 +2032,53 @@ let handle_round_run ctx args : result =
       let timeout_count = ref 0 in
 
       let process_one ~role ~actor_id ~keeper_name =
+        let record_unavailable_status ~status ~error =
+          let* unavailable_event =
+            append_unavailable_event
+              ~base_dir
+              ~room_id
+              ~phase
+              ~turn:turn_before
+              ~role
+              ~actor_id
+              ~keeper_name
+              ~reason:error
+              ()
+          in
+          unavailable_count := !unavailable_count + 1;
+          appended_events := !appended_events @ [ unavailable_event ];
+          statuses :=
+            `Assoc
+              [
+                ("actor_id", `String actor_id);
+                ("role", `String (role_to_string role));
+                ("keeper", `String keeper_name);
+                ("status", `String status);
+                ("error", `String error);
+              ]
+            :: !statuses;
+          Ok ()
+        in
+        let lease_check =
+          match role with
+          | `Dm -> Ok ()
+          | `Player -> (
+              match owner_for_actor state actor_id with
+              | Some owner when normalize_keeper_name owner <> normalize_keeper_name keeper_name ->
+                  Error
+                    (Printf.sprintf
+                       "actor lease mismatch: actor_id=%s owner=%s requested=%s"
+                       actor_id owner keeper_name)
+              | None when require_claim ->
+                  Error
+                    (Printf.sprintf
+                       "actor must be claimed before round_run: actor_id=%s"
+                       actor_id)
+              | _ -> Ok () )
+        in
+        match lease_check with
+        | Error lease_error -> record_unavailable_status ~status:"lease_denied" ~error:lease_error
+        | Ok () ->
         let prompt =
           build_keeper_prompt
             ~room_id
@@ -1748,59 +2117,11 @@ let handle_round_run ctx args : result =
               :: !statuses;
             Ok ()
         | `Error keeper_error ->
-            let* unavailable_event =
-              append_unavailable_event
-                ~base_dir
-                ~room_id
-                ~phase
-                ~turn:turn_before
-                ~role
-                ~actor_id
-                ~keeper_name
-                ~reason:keeper_error
-                ()
-            in
-            unavailable_count := !unavailable_count + 1;
-            appended_events := !appended_events @ [ unavailable_event ];
-            statuses :=
-              `Assoc
-                [
-                  ("actor_id", `String actor_id);
-                  ("role", `String (role_to_string role));
-                  ("keeper", `String keeper_name);
-                  ("status", `String "unavailable");
-                  ("error", `String keeper_error);
-                ]
-              :: !statuses;
-            Ok ()
+            record_unavailable_status ~status:"unavailable" ~error:keeper_error
         | `Ok keeper_json -> (
             match parse_keeper_reply keeper_json with
             | Error parse_error ->
-                let* unavailable_event =
-                  append_unavailable_event
-                    ~base_dir
-                    ~room_id
-                    ~phase
-                    ~turn:turn_before
-                    ~role
-                    ~actor_id
-                    ~keeper_name
-                    ~reason:parse_error
-                    ()
-                in
-                unavailable_count := !unavailable_count + 1;
-                appended_events := !appended_events @ [ unavailable_event ];
-                statuses :=
-                  `Assoc
-                    [
-                      ("actor_id", `String actor_id);
-                      ("role", `String (role_to_string role));
-                      ("keeper", `String keeper_name);
-                      ("status", `String "invalid_response");
-                      ("error", `String parse_error);
-                    ]
-                  :: !statuses;
-                Ok ()
+                record_unavailable_status ~status:"invalid_response" ~error:parse_error
             | Ok reply ->
                 let* reply_event =
                   append_keeper_reply_event
@@ -1998,6 +2319,9 @@ let dispatch ctx ~name ~args : result option =
   | "masc_trpg_pool_generate" -> Some (handle_pool_generate ctx args)
   | "masc_trpg_party_select" -> Some (handle_party_select ctx args)
   | "masc_trpg_session_start" -> Some (handle_session_start ctx args)
+  | "masc_trpg_actor_spawn" -> Some (handle_actor_spawn ctx args)
+  | "masc_trpg_actor_claim" -> Some (handle_actor_claim ctx args)
+  | "masc_trpg_actor_release" -> Some (handle_actor_release ctx args)
   | "masc_trpg_intervention_submit" -> Some (handle_intervention_submit ctx args)
   | "masc_trpg_round_run" -> Some (handle_round_run ctx args)
   | "masc_trpg_scene_transition" -> Some (handle_scene_transition ctx args)

--- a/lib/trpg_engine_event.ml
+++ b/lib/trpg_engine_event.ml
@@ -20,6 +20,9 @@ type event_type =
   | World_event
   | Session_started
   | Party_selected
+  | Actor_spawned
+  | Actor_claimed
+  | Actor_released
   | Intervention_submitted
   | Intervention_applied
 
@@ -54,6 +57,9 @@ let string_of_event_type = function
   | World_event -> "world.event"
   | Session_started -> "session.started"
   | Party_selected -> "party.selected"
+  | Actor_spawned -> "actor.spawned"
+  | Actor_claimed -> "actor.claimed"
+  | Actor_released -> "actor.released"
   | Intervention_submitted -> "intervention.submitted"
   | Intervention_applied -> "intervention.applied"
 
@@ -79,6 +85,9 @@ let event_type_of_string = function
   | "world.event" -> Ok World_event
   | "session.started" -> Ok Session_started
   | "party.selected" -> Ok Party_selected
+  | "actor.spawned" -> Ok Actor_spawned
+  | "actor.claimed" -> Ok Actor_claimed
+  | "actor.released" -> Ok Actor_released
   | "intervention.submitted" -> Ok Intervention_submitted
   | "intervention.applied" -> Ok Intervention_applied
   | s -> Error (Printf.sprintf "unknown event_type: %s" s)

--- a/lib/trpg_engine_event.mli
+++ b/lib/trpg_engine_event.mli
@@ -20,6 +20,9 @@ type event_type =
   | World_event
   | Session_started
   | Party_selected
+  | Actor_spawned
+  | Actor_claimed
+  | Actor_released
   | Intervention_submitted
   | Intervention_applied
 

--- a/lib/trpg_rule_dnd5e_lite.ml
+++ b/lib/trpg_rule_dnd5e_lite.ml
@@ -82,6 +82,7 @@ let init_state ~config =
       ("turn", `Int 1);
       ("current_node", `Null);
       ("party", if party = `Null then `Assoc [] else party);
+      ("actor_control", `Assoc []);
       ("world", world);
       ("dice_log", `List []);
       ("narration_log", `List []);
@@ -112,37 +113,61 @@ let update_party_actor state actor_id f =
       `Assoc (assoc_put "party" next_party fields)
   | _ -> state
 
+let update_actor_control state actor_id keeper_name_opt =
+  match state with
+  | `Assoc fields ->
+      let control_fields =
+        match assoc_get "actor_control" fields with
+        | Some (`Assoc xs) -> xs
+        | _ -> []
+      in
+      let next_control =
+        match keeper_name_opt with
+        | Some keeper_name -> `Assoc (assoc_put actor_id (`String keeper_name) control_fields)
+        | None -> `Assoc (List.remove_assoc actor_id control_fields)
+      in
+      `Assoc (assoc_put "actor_control" next_control fields)
+  | _ -> state
+
+let resolve_actor_id payload event =
+  match get_string_opt "actor_id" payload with
+  | Some id when String.trim id <> "" -> Some (String.trim id)
+  | _ -> event.Trpg_engine_event.actor_id
+
 let apply_hp_changed ~state ~event =
   let payload = event.Trpg_engine_event.payload in
-  let actor_id =
-    match get_string_opt "actor_id" payload with
-    | Some id -> Some id
-    | None -> event.actor_id
-  in
+  let actor_id = resolve_actor_id payload event in
   match actor_id with
   | None -> state
   | Some actor_id ->
-      update_party_actor state actor_id (fun actor_json ->
-          let old_hp = actor_json |> member "hp" |> to_int_option |> Option.value ~default:0 in
-          let max_hp = actor_json |> member "max_hp" |> to_int_option |> Option.value ~default:old_hp in
-          let delta = get_int_opt "delta" payload |> Option.value ~default:0 in
-          let computed_hp = clamp_int 0 max_hp (old_hp + delta) in
-          let new_hp = get_int_opt "new_hp" payload |> Option.value ~default:computed_hp in
-          let alive = get_bool_opt "alive" payload |> Option.value ~default:(new_hp > 0) in
-          let actor_fields = assoc_fields_or_empty actor_json in
-          `Assoc
-            (actor_fields
-            |> assoc_put "hp" (`Int new_hp)
-            |> assoc_put "max_hp" (`Int max_hp)
-            |> assoc_put "alive" (`Bool alive)))
+      let next_state =
+        update_party_actor state actor_id (fun actor_json ->
+            let old_hp = actor_json |> member "hp" |> to_int_option |> Option.value ~default:0 in
+            let max_hp =
+              actor_json |> member "max_hp" |> to_int_option |> Option.value ~default:old_hp
+            in
+            let delta = get_int_opt "delta" payload |> Option.value ~default:0 in
+            let computed_hp = clamp_int 0 max_hp (old_hp + delta) in
+            let new_hp = get_int_opt "new_hp" payload |> Option.value ~default:computed_hp in
+            let alive = get_bool_opt "alive" payload |> Option.value ~default:(new_hp > 0) in
+            let actor_fields = assoc_fields_or_empty actor_json in
+            `Assoc
+              (actor_fields
+              |> assoc_put "hp" (`Int new_hp)
+              |> assoc_put "max_hp" (`Int max_hp)
+              |> assoc_put "alive" (`Bool alive)))
+      in
+      let alive_after =
+        next_state |> member "party" |> member actor_id |> member "alive"
+        |> to_bool_option
+        |> Option.value ~default:true
+      in
+      if alive_after then next_state
+      else update_actor_control next_state actor_id None
 
 let apply_inventory_changed ~state ~event =
   let payload = event.Trpg_engine_event.payload in
-  let actor_id =
-    match get_string_opt "actor_id" payload with
-    | Some id -> Some id
-    | None -> event.actor_id
-  in
+  let actor_id = resolve_actor_id payload event in
   match actor_id with
   | None -> state
   | Some actor_id ->
@@ -172,6 +197,73 @@ let apply_inventory_changed ~state ~event =
               | _ -> inv @ [ `String item ]
             in
             `Assoc (assoc_put "inventory" (`List updated) actor_fields))
+
+let apply_actor_spawned ~state ~event =
+  let payload = event.Trpg_engine_event.payload in
+  match resolve_actor_id payload event with
+  | None -> state
+  | Some actor_id ->
+      let actor_json =
+        match payload |> member "actor" with
+        | `Assoc _ as actor -> actor
+        | _ -> `Assoc []
+      in
+      let actor_fields =
+        actor_json
+        |> assoc_fields_or_empty
+        |> assoc_put "name"
+             (`String
+               (get_string_opt "name" actor_json
+               |> Option.value ~default:actor_id))
+        |> assoc_put "role"
+             (`String
+               (get_string_opt "role" actor_json
+               |> Option.value ~default:"player"))
+      in
+      let max_hp =
+        match List.assoc_opt "max_hp" actor_fields with
+        | Some (`Int v) when v > 0 -> v
+        | _ -> 10
+      in
+      let hp =
+        match List.assoc_opt "hp" actor_fields with
+        | Some (`Int v) -> clamp_int 0 max_hp v
+        | _ -> max_hp
+      in
+      let alive =
+        match List.assoc_opt "alive" actor_fields with
+        | Some (`Bool b) -> b
+        | _ -> hp > 0
+      in
+      update_party_actor state actor_id (fun _existing ->
+          `Assoc
+            (actor_fields
+            |> assoc_put "max_hp" (`Int max_hp)
+            |> assoc_put "hp" (`Int hp)
+            |> assoc_put "alive" (`Bool alive)
+            |> assoc_put "inventory"
+                 (match List.assoc_opt "inventory" actor_fields with
+                 | Some (`List _ as inv) -> inv
+                 | _ -> `List [])))
+
+let apply_actor_claimed ~state ~event =
+  let payload = event.Trpg_engine_event.payload in
+  let actor_id = resolve_actor_id payload event in
+  let keeper_name =
+    match get_string_opt "keeper_name" payload with
+    | Some keeper when String.trim keeper <> "" -> Some (String.trim keeper)
+    | _ -> None
+  in
+  match actor_id, keeper_name with
+  | Some actor_id, Some keeper_name ->
+      update_actor_control state actor_id (Some keeper_name)
+  | _ -> state
+
+let apply_actor_released ~state ~event =
+  let payload = event.Trpg_engine_event.payload in
+  match resolve_actor_id payload event with
+  | Some actor_id -> update_actor_control state actor_id None
+  | None -> state
 
 let apply_flag_set ~state ~event =
   let payload = event.Trpg_engine_event.payload in
@@ -240,6 +332,9 @@ let apply_event ~state ~(event : Trpg_engine_event.t) =
   | Trpg_engine_event.Inventory_changed -> apply_inventory_changed ~state ~event
   | Trpg_engine_event.Flag_set -> apply_flag_set ~state ~event
   | Trpg_engine_event.Node_advanced -> apply_node_advanced ~state ~event
+  | Trpg_engine_event.Actor_spawned -> apply_actor_spawned ~state ~event
+  | Trpg_engine_event.Actor_claimed -> apply_actor_claimed ~state ~event
+  | Trpg_engine_event.Actor_released -> apply_actor_released ~state ~event
   | Trpg_engine_event.Phase_changed
   | Trpg_engine_event.Turn_action_proposed
   | Trpg_engine_event.Turn_timeout

--- a/lib/trpg_visibility.ml
+++ b/lib/trpg_visibility.ml
@@ -9,6 +9,9 @@ let public_event_types =
     Trpg_engine_event.Dice_rolled;
     Trpg_engine_event.Session_started;
     Trpg_engine_event.Party_selected;
+    Trpg_engine_event.Actor_spawned;
+    Trpg_engine_event.Actor_claimed;
+    Trpg_engine_event.Actor_released;
     Trpg_engine_event.Intervention_submitted;
     Trpg_engine_event.Intervention_applied;
   ]

--- a/test/test_tool_trpg_coverage.ml
+++ b/test/test_tool_trpg_coverage.ml
@@ -445,6 +445,195 @@ let test_examples_scenario_visible_as_world_preset () =
     |> Yojson.Safe.Util.to_string);
   cleanup_dir base_dir
 
+let test_actor_spawn_claim_release_flow () =
+  let base_dir = make_temp_dir () in
+  let config = Room.default_config base_dir in
+  let _ = Room.init config ~agent_name:(Some "tester") in
+  let ctx : Tool_trpg.context =
+    { config; agent_name = "tester"; keeper_call = None }
+  in
+  let room_id = "room-actor-lease-flow" in
+
+  let ok_spawn1, _spawn1 =
+    dispatch_exn ctx ~name:"masc_trpg_actor_spawn"
+      ~args:
+        (`Assoc
+          [
+            ("room_id", `String room_id);
+            ("actor_id", `String "npc-raven");
+            ("role", `String "npc");
+            ("name", `String "Raven");
+            ("skills", `List [ `String "scout" ]);
+          ])
+  in
+  Alcotest.(check bool) "spawn actor1 ok" true ok_spawn1;
+
+  let ok_claim1, _claim1 =
+    dispatch_exn ctx ~name:"masc_trpg_actor_claim"
+      ~args:
+        (`Assoc
+          [
+            ("room_id", `String room_id);
+            ("actor_id", `String "npc-raven");
+            ("keeper_name", `String "keeper-raven");
+          ])
+  in
+  Alcotest.(check bool) "claim actor1 ok" true ok_claim1;
+
+  let ok_claim_same, claim_same_body =
+    dispatch_exn ctx ~name:"masc_trpg_actor_claim"
+      ~args:
+        (`Assoc
+          [
+            ("room_id", `String room_id);
+            ("actor_id", `String "npc-raven");
+            ("keeper_name", `String "keeper-raven");
+          ])
+  in
+  Alcotest.(check bool) "idempotent same-keeper claim ok" true ok_claim_same;
+  Alcotest.(check string)
+    "same claim returns already_claimed"
+    "already_claimed"
+    (parse_json_exn claim_same_body |> Yojson.Safe.Util.member "status"
+   |> Yojson.Safe.Util.to_string);
+
+  let ok_spawn2, _spawn2 =
+    dispatch_exn ctx ~name:"masc_trpg_actor_spawn"
+      ~args:
+        (`Assoc
+          [
+            ("room_id", `String room_id);
+            ("actor_id", `String "npc-owl");
+            ("role", `String "npc");
+          ])
+  in
+  Alcotest.(check bool) "spawn actor2 ok" true ok_spawn2;
+
+  let ok_claim2_conflict, claim2_conflict_msg =
+    dispatch_exn ctx ~name:"masc_trpg_actor_claim"
+      ~args:
+        (`Assoc
+          [
+            ("room_id", `String room_id);
+            ("actor_id", `String "npc-owl");
+            ("keeper_name", `String "keeper-raven");
+          ])
+  in
+  Alcotest.(check bool) "keeper cannot control two actors" false ok_claim2_conflict;
+  Alcotest.(check bool)
+    "error mentions keeper already controls actor"
+    true
+    (contains_substring claim2_conflict_msg "keeper already controls actor");
+
+  let ok_release_wrong, release_wrong_msg =
+    dispatch_exn ctx ~name:"masc_trpg_actor_release"
+      ~args:
+        (`Assoc
+          [
+            ("room_id", `String room_id);
+            ("actor_id", `String "npc-raven");
+            ("keeper_name", `String "keeper-wrong");
+          ])
+  in
+  Alcotest.(check bool) "release by non-owner fails" false ok_release_wrong;
+  Alcotest.(check bool)
+    "release error mentions another keeper"
+    true
+    (contains_substring release_wrong_msg "another keeper");
+
+  let ok_release, _release_body =
+    dispatch_exn ctx ~name:"masc_trpg_actor_release"
+      ~args:
+        (`Assoc
+          [
+            ("room_id", `String room_id);
+            ("actor_id", `String "npc-raven");
+            ("keeper_name", `String "keeper-raven");
+          ])
+  in
+  Alcotest.(check bool) "release by owner ok" true ok_release;
+
+  let ok_claim2, _claim2 =
+    dispatch_exn ctx ~name:"masc_trpg_actor_claim"
+      ~args:
+        (`Assoc
+          [
+            ("room_id", `String room_id);
+            ("actor_id", `String "npc-owl");
+            ("keeper_name", `String "keeper-raven");
+          ])
+  in
+  Alcotest.(check bool) "claim actor2 after release ok" true ok_claim2;
+
+  let _, stream_claimed =
+    dispatch_exn ctx ~name:"masc_trpg_stream"
+      ~args:
+        (`Assoc
+          [
+            ("room_id", `String room_id);
+            ("event_type", `String "actor.claimed");
+          ])
+  in
+  Alcotest.(check int)
+    "actor.claimed count"
+    2
+    (count_from_json (parse_json_exn stream_claimed));
+
+  let _, stream_released =
+    dispatch_exn ctx ~name:"masc_trpg_stream"
+      ~args:
+        (`Assoc
+          [
+            ("room_id", `String room_id);
+            ("event_type", `String "actor.released");
+          ])
+  in
+  Alcotest.(check int)
+    "actor.released count"
+    1
+    (count_from_json (parse_json_exn stream_released));
+  cleanup_dir base_dir
+
+let test_actor_claim_rejects_dead_actor () =
+  let base_dir = make_temp_dir () in
+  let config = Room.default_config base_dir in
+  let _ = Room.init config ~agent_name:(Some "tester") in
+  let ctx : Tool_trpg.context =
+    { config; agent_name = "tester"; keeper_call = None }
+  in
+  let room_id = "room-actor-dead-claim" in
+  let ok_spawn, _spawn =
+    dispatch_exn ctx ~name:"masc_trpg_actor_spawn"
+      ~args:
+        (`Assoc
+          [
+            ("room_id", `String room_id);
+            ("actor_id", `String "npc-fallen");
+            ("role", `String "npc");
+            ("hp", `Int 0);
+            ("max_hp", `Int 10);
+            ("alive", `Bool false);
+          ])
+  in
+  Alcotest.(check bool) "spawn dead actor ok" true ok_spawn;
+
+  let ok_claim, claim_msg =
+    dispatch_exn ctx ~name:"masc_trpg_actor_claim"
+      ~args:
+        (`Assoc
+          [
+            ("room_id", `String room_id);
+            ("actor_id", `String "npc-fallen");
+            ("keeper_name", `String "keeper-fallen");
+          ])
+  in
+  Alcotest.(check bool) "claim dead actor fails" false ok_claim;
+  Alcotest.(check bool)
+    "error mentions not alive"
+    true
+    (contains_substring claim_msg "not alive");
+  cleanup_dir base_dir
+
 let () =
   Alcotest.run "Tool_trpg coverage"
     [
@@ -484,5 +673,16 @@ let () =
             "rejects non-unique keepers"
             `Quick
             test_round_run_rejects_non_unique_keepers;
+        ] );
+      ( "actor_control",
+        [
+          Alcotest.test_case
+            "spawn + claim + release flow"
+            `Quick
+            test_actor_spawn_claim_release_flow;
+          Alcotest.test_case
+            "reject dead actor claim"
+            `Quick
+            test_actor_claim_rejects_dead_actor;
         ] );
     ]


### PR DESCRIPTION
## Summary
- add TRPG actor lifecycle events: `actor.spawned`, `actor.claimed`, `actor.released`
- add new TRPG tools:
  - `masc_trpg_actor_spawn`
  - `masc_trpg_actor_claim`
  - `masc_trpg_actor_release`
- extend round execution with optional lease gate (`require_claim=true`) so player turns can enforce claim ownership
- expose canonical protocol aliases for dot namespace:
  - `trpg.actor.spawn`, `trpg.actor.claim`, `trpg.actor.release`
- wire actor lease visibility into derived rule state (`state.actor_control`) and auto-release on death (`hp/alive`)

## Why
This decouples world entities (actors) from controller processes (keepers): keepers hold temporary leases, actors stay world-owned and replayable.

## Validation
- `dune build --root .`
- `dune runtest --root .`
- `dune exec --root . test/test_tool_trpg_coverage.exe`
- `dune exec --root . test/test_protocol_game_view.exe`
- `dune exec --root . test/test_trpg_rule_dnd5e_lite.exe`

## Tests added
- actor lease flow: spawn -> claim -> release -> reclaim
- keeper uniqueness enforcement (one keeper cannot control two actors)
- dead actor claim rejection