### PR TITLE
fix(llm): distinguish timeout from empty response in curl_post

### DIFF
--- a/lib/llm_client.ml
+++ b/lib/llm_client.ml
@@ -456,7 +456,9 @@ let get_api_key (spec : model_spec) : string =
   | Some env_var -> Sys.getenv_opt env_var |> Option.value ~default:""
   | None -> ""
 
-(** Run curl with body via stdin, return response string. *)
+(** Run curl with body via stdin, return response string.
+    Uses status-aware execution to distinguish timeout (exit 28)
+    from connection failure (exit 7) and other errors. *)
 let curl_post ~url ~headers ~body ~timeout_sec : (string, string) result =
   let header_args = List.concat_map (fun (k, v) ->
     ["-H"; sprintf "%s: %s" k v]
@@ -464,12 +466,24 @@ let curl_post ~url ~headers ~body ~timeout_sec : (string, string) result =
   let argv = ["curl"; "-s"; "--max-time"; string_of_int timeout_sec;
               "-X"; "POST"; url] @ header_args @ ["-d"; "@-"] in
   try
-    let raw = Process_eio.run_argv_with_stdin
+    let (status, raw) = Process_eio.run_argv_with_stdin_and_status
       ~timeout_sec:(Float.of_int timeout_sec +. 5.0)
       ~stdin_content:body
       argv in
-    if String.length raw = 0 then Error "Empty response from API"
-    else Ok raw
+    match status with
+    | Unix.WEXITED 0 ->
+      if String.length raw = 0 then Error "Empty response from API"
+      else Ok raw
+    | Unix.WEXITED 28 ->
+      Error (sprintf "Request timed out after %ds (%s)" timeout_sec url)
+    | Unix.WEXITED 7 ->
+      Error (sprintf "Connection refused (%s)" url)
+    | Unix.WEXITED code ->
+      Error (sprintf "curl exit %d (%s)" code url)
+    | Unix.WSIGNALED sig_num ->
+      Error (sprintf "curl killed by signal %d after %ds (%s)" sig_num timeout_sec url)
+    | Unix.WSTOPPED _ ->
+      Error "curl stopped unexpectedly"
   with exn ->
     Error (sprintf "HTTP error: %s" (Printexc.to_string exn))
 


### PR DESCRIPTION
## Summary

- `curl_post`에서 `Process_eio.run_argv_with_stdin` → `run_argv_with_stdin_and_status`로 교체
- curl exit code를 pattern match하여 정확한 에러 메시지 생성
  - exit 28: `"Request timed out after 45s (http://...)"`
  - exit 7: `"Connection refused (http://...)"`
  - exit 0 + empty: `"Empty response from API"` (기존 동작 유지)

## Before / After

```
# Before (원인 불명)
[llm_client] cascade: glm-4.7-flash failed: Empty response from API

# After (원인 명확)
[llm_client] cascade: glm-4.7-flash failed: Request timed out after 45s (http://127.0.0.1:11434/api/chat)
```

## Test plan

- [x] `dune build` 성공
- [x] `test_perpetual.exe` 103/103 통과
- [x] `dune test` (MCP server 33 + eio 15 + SSE storm 2) 전체 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)