### PR TITLE
fix(viewer): restore bevy/trunk build and re-enable basic UI hooks

### DIFF
--- a/viewer/Cargo.toml
+++ b/viewer/Cargo.toml
@@ -9,6 +9,9 @@ bevy = { version = "0.18", default-features = false, features = [
     "2d",
     "webgpu",
     "jpeg",
+    "bevy_ui",
+    "bevy_text",
+    "bevy_picking",
 ] }
 wasm-bindgen = "0.2"
 wasm-bindgen-futures = "0.4"

--- a/viewer/src/render/mod.rs
+++ b/viewer/src/render/mod.rs
@@ -3,6 +3,7 @@ pub mod fx;
 pub mod map;
 pub mod overlay;
 pub mod transition;
+pub mod ui;
 
 use bevy::prelude::*;
 
@@ -29,6 +30,7 @@ impl Plugin for MapRenderPlugin {
                 overlay::setup_weather_overlay,
                 overlay::setup_mood_overlay,
                 transition::setup_fade_overlay,
+                ui::setup_ui,
             ))
             // Update: character sprites, positions, HP bars, effects, transitions
             .add_systems(Update, (
@@ -45,6 +47,7 @@ impl Plugin for MapRenderPlugin {
                 overlay::spawn_prop_notification,
                 transition::trigger_scene_transition,
                 transition::animate_scene_transition,
+                ui::handle_button_interactions,
             ).run_if(in_state(ViewerMode::Trpg)))
             // Cleanup: despawn all TRPG scene entities and reset resources
             .add_systems(OnExit(ViewerMode::Trpg), cleanup_trpg_scene);
@@ -68,6 +71,7 @@ fn cleanup_trpg_scene(
             With<HpBarSprite>,
             With<WeatherOverlay>,
             With<MoodOverlay>,
+            With<ui::UiMarker>,
         )>,
     >,
     mut scene_transition: ResMut<SceneTransition>,

--- a/viewer/src/render/ui.rs
+++ b/viewer/src/render/ui.rs
@@ -19,7 +19,7 @@ pub struct SettingsMenu;
 pub struct DevMenu;
 
 #[derive(Component)]
-pub struct CloseMenuButton;
+pub struct CloseButton;
 
 /// Tracks UI state toggles.
 #[derive(Resource, Default)]

--- a/viewer/src/render/ui.rs
+++ b/viewer/src/render/ui.rs
@@ -1,0 +1,141 @@
+//! UI widgets and interaction systems for TRPG viewer.
+
+use bevy::prelude::*;
+
+/// Marker component for UI entities spawned by the TRPG viewer.
+#[derive(Component)]
+pub struct UiMarker;
+
+#[derive(Component)]
+pub struct SettingsButton;
+
+#[derive(Component)]
+pub struct DevButton;
+
+#[derive(Component)]
+pub struct SettingsMenu;
+
+#[derive(Component)]
+pub struct DevMenu;
+
+#[derive(Component)]
+pub struct CloseMenuButton;
+
+/// Tracks UI state toggles.
+#[derive(Resource, Default)]
+pub struct UiState {
+    pub settings_menu_open: bool,
+    pub dev_menu_open: bool,
+}
+
+/// Spawns lightweight in-canvas UI controls.
+pub fn setup_ui(mut commands: Commands) {
+    commands.insert_resource(UiState::default());
+
+    commands
+        .spawn((
+            Node {
+                width: Val::Percent(100.0),
+                height: Val::Percent(100.0),
+                position_type: PositionType::Absolute,
+                ..default()
+            },
+            UiMarker,
+        ))
+        .with_children(|parent| {
+            parent
+                .spawn((
+                    Button,
+                    SettingsButton,
+                    UiMarker,
+                    Node {
+                        position_type: PositionType::Absolute,
+                        right: Val::Px(10.0),
+                        top: Val::Px(10.0),
+                        width: Val::Px(40.0),
+                        height: Val::Px(40.0),
+                        justify_content: JustifyContent::Center,
+                        align_items: AlignItems::Center,
+                        ..default()
+                    },
+                    BackgroundColor(Color::srgb(0.2, 0.2, 0.3)),
+                ))
+                .with_children(|parent| {
+                    parent.spawn((
+                        Text::new("⚙"),
+                        TextFont {
+                            font_size: 20.0,
+                            ..default()
+                        },
+                        TextColor(Color::srgb(1.0, 1.0, 1.0)),
+                    ));
+                });
+
+            parent
+                .spawn((
+                    Button,
+                    DevButton,
+                    UiMarker,
+                    Node {
+                        position_type: PositionType::Absolute,
+                        left: Val::Px(10.0),
+                        bottom: Val::Px(10.0),
+                        width: Val::Px(40.0),
+                        height: Val::Px(40.0),
+                        justify_content: JustifyContent::Center,
+                        align_items: AlignItems::Center,
+                        ..default()
+                    },
+                    BackgroundColor(Color::srgb(0.3, 0.2, 0.2)),
+                ))
+                .with_children(|parent| {
+                    parent.spawn((
+                        Text::new("🔧"),
+                        TextFont {
+                            font_size: 20.0,
+                            ..default()
+                        },
+                        TextColor(Color::srgb(1.0, 1.0, 1.0)),
+                    ));
+                });
+
+            parent.spawn((
+                UiMarker,
+                Text::new("MASC Viewer v0.1.0"),
+                TextFont {
+                    font_size: 14.0,
+                    ..default()
+                },
+                TextColor(Color::srgb(0.7, 0.7, 0.7)),
+                Node {
+                    position_type: PositionType::Absolute,
+                    left: Val::Px(10.0),
+                    top: Val::Px(10.0),
+                    ..default()
+                },
+            ));
+        });
+}
+
+/// Handles button click interactions.
+pub fn handle_button_interactions(
+    mut ui_state: ResMut<UiState>,
+    interactions: Query<
+        (&Interaction, Option<&SettingsButton>, Option<&DevButton>),
+        (Changed<Interaction>, With<Button>),
+    >,
+) {
+    for (interaction, settings_btn, dev_btn) in &interactions {
+        if *interaction != Interaction::Pressed {
+            continue;
+        }
+        if settings_btn.is_some() {
+            ui_state.settings_menu_open = !ui_state.settings_menu_open;
+            log::info!("Settings menu toggled: {}", ui_state.settings_menu_open);
+        }
+        if dev_btn.is_some() {
+            ui_state.dev_menu_open = !ui_state.dev_menu_open;
+            log::info!("Dev menu toggled: {}", ui_state.dev_menu_open);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- restore `render::ui` module wiring in map render plugin
- add missing Bevy feature flags required by viewer UI (`bevy_ui`, `bevy_text`, `bevy_picking`)
- reintroduce a minimal `viewer/src/render/ui.rs` with settings/dev toggle buttons and UI state resource
- ensure TRPG cleanup despawns viewer UI entities via `UiMarker`

## Validation
- `cargo check --manifest-path viewer/Cargo.toml`
- `cd viewer && NO_COLOR=false trunk build`