### PR TITLE
feat(viewer): add new game flow and room-aware TRPG reset

### DIFF
--- a/viewer/Cargo.toml
+++ b/viewer/Cargo.toml
@@ -22,6 +22,7 @@ web-sys = { version = "0.3", features = [
     "HtmlElement",
     "HtmlInputElement",
     "HtmlSelectElement",
+    "CssStyleDeclaration",
     "KeyboardEvent",
     "Window",
     "Element",

--- a/viewer/index.html
+++ b/viewer/index.html
@@ -146,7 +146,7 @@
     </div>
 
     <!-- ═══ Dashboard (Active Mode View) ═══ -->
-    <div id="dashboard" style="display: none;">
+    <div id="dashboard" data-room-id="default" style="display: none;">
         <!-- Top Bar -->
         <header id="top-bar">
             <button id="back-to-lobby" class="icon-btn" title="Back to Lobby">◂</button>
@@ -158,6 +158,7 @@
                     <option value="terminal">Terminal</option>
                     <option value="parchment">Parchment</option>
                 </select>
+                <button id="new-game-toggle" class="inline-toggle" type="button">새 게임</button>
                 <button id="debug-log-toggle" class="inline-toggle" type="button" aria-pressed="true">Debug ON</button>
                 <span id="debug-log-status" class="widget-pill">DEBUG ON</span>
                 <span id="widget-status" class="widget-pill">Widgets N:0 P:0 D:0</span>
@@ -211,6 +212,42 @@
             <div id="dice-log" class="scrollable horizontal"></div>
         </footer>
     </div>
+
+    <!-- ═══ TRPG New Game Panel ═══ -->
+    <aside id="new-game-panel" class="new-game-panel" style="display: none;">
+        <div class="new-game-header">
+            <h3>새 게임</h3>
+            <button id="new-game-close" class="inline-toggle" type="button">닫기</button>
+        </div>
+        <div class="new-game-body">
+            <label class="new-game-label" for="new-game-room-id">Room</label>
+            <div class="new-game-room-row">
+                <input id="new-game-room-id" class="new-game-input" type="text" readonly>
+                <button id="new-game-room-regenerate" class="inline-toggle" type="button">재생성</button>
+            </div>
+
+            <label class="new-game-label" for="new-game-dm-select">DM Keeper</label>
+            <select id="new-game-dm-select" class="new-game-select"></select>
+
+            <label class="new-game-label" for="new-game-player-select">AI Players (multi-select)</label>
+            <select id="new-game-player-select" class="new-game-select" multiple size="8"></select>
+
+            <label class="new-game-label" for="new-game-models">Keeper Models</label>
+            <input
+                id="new-game-models"
+                class="new-game-input"
+                type="text"
+                value="glm:glm-4.7,gemini:gemini-2.5-flash"
+                placeholder="glm:glm-4.7,gemini:gemini-2.5-flash"
+            >
+
+            <div id="new-game-status" class="new-game-status">DM과 Player를 선택한 뒤 시작하세요.</div>
+        </div>
+        <div class="new-game-actions">
+            <button id="new-game-refresh" class="inline-toggle" type="button">Keeper 새로고침</button>
+            <button id="new-game-start" class="inline-toggle new-game-start" type="button">시작</button>
+        </div>
+    </aside>
 
 </body>
 </html>

--- a/viewer/src/config.rs
+++ b/viewer/src/config.rs
@@ -37,6 +37,30 @@ pub enum TrpgBackendMode {
 /// source used by server-side tool contracts.
 pub const TRPG_BACKEND_MODE: TrpgBackendMode = TrpgBackendMode::MascApi;
 
+/// Returns the active TRPG room id.
+///
+/// WASM runtime reads `#dashboard[data-room-id]` so UI can switch rooms
+/// without recompiling. Falls back to `DEFAULT_ROOM_ID`.
+#[cfg(target_arch = "wasm32")]
+pub fn current_room_id() -> String {
+    let room = web_sys::window()
+        .and_then(|w| w.document())
+        .and_then(|doc| doc.get_element_by_id("dashboard"))
+        .and_then(|el| el.get_attribute("data-room-id"))
+        .unwrap_or_default();
+    let room = room.trim();
+    if room.is_empty() {
+        DEFAULT_ROOM_ID.to_string()
+    } else {
+        room.to_string()
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+pub fn current_room_id() -> String {
+    DEFAULT_ROOM_ID.to_string()
+}
+
 #[allow(dead_code)]
 pub fn trpg_uses_polling() -> bool {
     matches!(TRPG_BACKEND_MODE, TrpgBackendMode::MascApi)
@@ -44,10 +68,11 @@ pub fn trpg_uses_polling() -> bool {
 
 /// URL for initial TRPG state load.
 pub fn trpg_state_url() -> String {
+    let room_id = current_room_id();
     match TRPG_BACKEND_MODE {
         TrpgBackendMode::MascApi => format!(
             "{}/api/v1/trpg/state?room_id={}",
-            MASC_MCP_URL, DEFAULT_ROOM_ID
+            MASC_MCP_URL, room_id
         ),
         TrpgBackendMode::LegacyEngine => trpg_room_url("/state"),
     }
@@ -56,10 +81,11 @@ pub fn trpg_state_url() -> String {
 /// URL for incremental TRPG stream reads.
 #[allow(dead_code)]
 pub fn trpg_stream_poll_url(after_seq: i64) -> String {
+    let room_id = current_room_id();
     match TRPG_BACKEND_MODE {
         TrpgBackendMode::MascApi => format!(
             "{}/api/v1/trpg/stream?room_id={}&after_seq={}",
-            MASC_MCP_URL, DEFAULT_ROOM_ID, after_seq
+            MASC_MCP_URL, room_id, after_seq
         ),
         TrpgBackendMode::LegacyEngine => trpg_room_url("/stream"),
     }
@@ -74,7 +100,8 @@ pub fn sse_endpoint(mode: &ViewerMode) -> Option<String> {
         ViewerMode::Lobby => None,
         ViewerMode::Trpg => Some(format!(
             "{}/rooms/{}/stream",
-            TRPG_ENGINE_URL, DEFAULT_ROOM_ID
+            TRPG_ENGINE_URL,
+            current_room_id()
         )),
         ViewerMode::Experiment => Some(format!("{}/sse?room=experiment", MASC_MCP_URL)),
         ViewerMode::Monitor => Some(format!("{}/sse?room=monitor", MASC_MCP_URL)),
@@ -97,5 +124,5 @@ pub fn http_base_url(mode: &ViewerMode) -> &'static str {
 
 /// TRPG-specific room URL helper (used by game state loader).
 pub fn trpg_room_url(path: &str) -> String {
-    format!("{}/rooms/{}{}", TRPG_ENGINE_URL, DEFAULT_ROOM_ID, path)
+    format!("{}/rooms/{}{}", TRPG_ENGINE_URL, current_room_id(), path)
 }

--- a/viewer/src/dom/dice_log.rs
+++ b/viewer/src/dom/dice_log.rs
@@ -48,6 +48,15 @@ fn escape_html(raw: &str) -> String {
         .replace('\'', "&#39;")
 }
 
+fn trim_dice_log(log_el: &web_sys::Element, max_entries: u32) {
+    while log_el.child_element_count() > max_entries {
+        let Some(first) = log_el.first_element_child() else {
+            break;
+        };
+        let _ = log_el.remove_child(&first);
+    }
+}
+
 /// Appends dice roll entries to the #dice-log DOM element.
 pub fn update_dice_log_dom(mut events: MessageReader<DiceRolled>) {
     let Some(document) = web_sys::window().and_then(|w| w.document()) else {
@@ -90,6 +99,7 @@ pub fn update_dice_log_dom(mut events: MessageReader<DiceRolled>) {
         ));
 
         let _ = log_el.append_child(&entry);
+        trim_dice_log(&log_el, 120);
 
         // Auto-scroll horizontally to the newest entry
         let scroll_width = log_el.scroll_width();

--- a/viewer/src/dom/mod.rs
+++ b/viewer/src/dom/mod.rs
@@ -22,6 +22,7 @@ impl Plugin for DomBridgePlugin {
             .init_resource::<character_panel::CharacterPanelCache>()
             .init_resource::<turn_phase::TurnPhaseCache>()
             .init_resource::<connection::ConnectionStatusCache>()
+            .add_systems(OnEnter(ViewerMode::Trpg), reset_trpg_dom_state)
             // TRPG-specific DOM update systems
             .add_systems(Update, (
                 narrative::update_narrative_dom,
@@ -30,5 +31,35 @@ impl Plugin for DomBridgePlugin {
                 turn_phase::update_turn_phase_dom,
                 connection::update_connection_dom,
             ).run_if(in_state(ViewerMode::Trpg)));
+    }
+}
+
+fn reset_trpg_dom_state(
+    mut character_cache: ResMut<character_panel::CharacterPanelCache>,
+    mut turn_cache: ResMut<turn_phase::TurnPhaseCache>,
+    mut connection_cache: ResMut<connection::ConnectionStatusCache>,
+) {
+    character_cache.last_snapshot.clear();
+    turn_cache.last_turn = 0;
+    turn_cache.last_phase.clear();
+    connection_cache.last_status.clear();
+
+    #[cfg(target_arch = "wasm32")]
+    {
+        let Some(document) = web_sys::window().and_then(|w| w.document()) else {
+            return;
+        };
+        if let Some(el) = document.get_element_by_id("narrative-log") {
+            el.set_inner_html("");
+        }
+        if let Some(el) = document.get_element_by_id("dice-log") {
+            el.set_inner_html("");
+        }
+        if let Some(el) = document.get_element_by_id("character-panel") {
+            el.set_inner_html("");
+        }
+        if let Some(el) = document.get_element_by_id("turn-num") {
+            el.set_text_content(Some("1"));
+        }
     }
 }

--- a/viewer/src/dom/narrative.rs
+++ b/viewer/src/dom/narrative.rs
@@ -34,6 +34,39 @@ fn sanitize_text(raw: &str) -> String {
         .collect()
 }
 
+fn is_debug_narrative(text: &str) -> bool {
+    let lower = text.to_ascii_lowercase();
+    lower.contains("[timeout]") || lower.contains("[unavailable]")
+}
+
+fn debug_mode_enabled(document: &web_sys::Document) -> bool {
+    document
+        .get_element_by_id("dashboard")
+        .and_then(|el| el.get_attribute("data-debug"))
+        .map(|mode| mode != "off")
+        .unwrap_or(true)
+}
+
+fn apply_debug_visibility(el: &web_sys::Element, debug_enabled: bool, is_debug_entry: bool) {
+    let display = if !debug_enabled && is_debug_entry {
+        "none"
+    } else {
+        "block"
+    };
+    if let Some(html_el) = el.dyn_ref::<web_sys::HtmlElement>() {
+        let _ = html_el.style().set_property("display", display);
+    }
+}
+
+fn trim_narrative_log(log_el: &web_sys::Element, max_entries: u32) {
+    while log_el.child_element_count() > max_entries {
+        let Some(first) = log_el.first_element_child() else {
+            break;
+        };
+        let _ = log_el.remove_child(&first);
+    }
+}
+
 fn toggle_selected_class(el: &web_sys::Element) {
     let current = el.class_name();
     let has_selected = current.split_whitespace().any(|cls| cls == "selected");
@@ -59,6 +92,7 @@ pub fn update_narrative_dom(mut events: MessageReader<NarrativeReceived>) {
     let Some(log_el) = document.get_element_by_id("narrative-log") else {
         return;
     };
+    let debug_enabled = debug_mode_enabled(&document);
 
     for NarrativeReceived(payload) in events.read() {
         let Ok(entry) = document.create_element("div") else {
@@ -70,6 +104,11 @@ pub fn update_narrative_dom(mut events: MessageReader<NarrativeReceived>) {
         let _ = entry.set_attribute("role", "button");
         let _ = entry.set_attribute("tabindex", "0");
         let _ = entry.set_attribute("title", "클릭하면 이 내러티브를 강조합니다.");
+        let clean_text = sanitize_text(&payload.text);
+        let is_debug_entry = is_debug_narrative(&clean_text);
+        if is_debug_entry {
+            let _ = entry.set_attribute("data-debug-entry", "1");
+        }
 
         let speaker = payload
             .speaker
@@ -99,9 +138,8 @@ pub fn update_narrative_dom(mut events: MessageReader<NarrativeReceived>) {
         }
         if let Ok(text_el) = document.create_element("span") {
             text_el.set_class_name("narrative-text");
-            let clean_text = sanitize_text(&payload.text);
             let text = if speaker.is_some() {
-                format!(" {}", clean_text)
+                format!(" {}", clean_text.clone())
             } else {
                 clean_text
             };
@@ -119,6 +157,8 @@ pub fn update_narrative_dom(mut events: MessageReader<NarrativeReceived>) {
         click_cb.forget();
 
         let _ = log_el.append_child(&entry);
+        apply_debug_visibility(&entry, debug_enabled, is_debug_entry);
+        trim_narrative_log(&log_el, 180);
 
         // Auto-scroll to the newest entry
         if let Ok(html_el) = entry.dyn_into::<web_sys::HtmlElement>() {

--- a/viewer/src/game/http.rs
+++ b/viewer/src/game/http.rs
@@ -97,10 +97,13 @@ pub struct InitialStateBuffer {
     consumed: bool,
 }
 
-// ─── Systems ─────────────────────────────────
+/// Tracks the currently active TRPG room for runtime room switching.
+#[derive(Resource, Default)]
+pub struct ActiveTrpgRoom {
+    pub room_id: String,
+}
 
-/// Startup system: fires async HTTP fetch for initial game state.
-pub fn fetch_initial_state(mut commands: Commands) {
+fn queue_initial_state_fetch(commands: &mut Commands) {
     let buffer: Arc<Mutex<Option<GameStateResponse>>> = Arc::new(Mutex::new(None));
     let shared = buffer.clone();
 
@@ -126,6 +129,44 @@ pub fn fetch_initial_state(mut commands: Commands) {
         data: buffer,
         consumed: false,
     });
+}
+
+// ─── Systems ─────────────────────────────────
+
+/// Startup system: fires async HTTP fetch for initial game state.
+pub fn fetch_initial_state(
+    mut commands: Commands,
+    mut active_room: ResMut<ActiveTrpgRoom>,
+) {
+    active_room.room_id = config::current_room_id();
+    queue_initial_state_fetch(&mut commands);
+}
+
+/// Detects TRPG room changes at runtime and reloads state for the new room.
+pub fn refresh_state_on_room_change(
+    mut commands: Commands,
+    mut active_room: ResMut<ActiveTrpgRoom>,
+    actors: Query<Entity, With<Actor>>,
+    mut room_state: ResMut<RoomState>,
+    mut map_state: ResMut<MapState>,
+) {
+    let current_room = config::current_room_id();
+    if active_room.room_id == current_room {
+        return;
+    }
+
+    active_room.room_id = current_room.clone();
+
+    for entity in &actors {
+        commands.entity(entity).despawn();
+    }
+
+    *room_state = RoomState::default();
+    room_state.id = current_room.clone();
+    *map_state = MapState::default();
+
+    queue_initial_state_fetch(&mut commands);
+    log::info!("TRPG room changed — reloading state for room {}", current_room);
 }
 
 /// Update system: polls the buffer each frame. Once data arrives,

--- a/viewer/src/game/mod.rs
+++ b/viewer/src/game/mod.rs
@@ -24,6 +24,7 @@ impl Plugin for GameStatePlugin {
             .init_resource::<MapState>()
             .init_resource::<ConnectionStatus>()
             .init_resource::<OverlayState>()
+            .init_resource::<http::ActiveTrpgRoom>()
             // Events (type registrations — always available)
             .add_message::<DiceRolled>()
             .add_message::<HpChanged>()
@@ -40,6 +41,7 @@ impl Plugin for GameStatePlugin {
             // ── TRPG-gated systems ──
             .add_systems(OnEnter(ViewerMode::Trpg), http::fetch_initial_state)
             .add_systems(Update, (
+                http::refresh_state_on_room_change,
                 http::apply_initial_state,
                 systems::apply_hp_change,
                 systems::apply_area_move,

--- a/viewer/src/mode.rs
+++ b/viewer/src/mode.rs
@@ -10,6 +10,9 @@
 use bevy::prelude::*;
 
 #[cfg(target_arch = "wasm32")]
+use serde_json::{json, Value};
+
+#[cfg(target_arch = "wasm32")]
 use std::sync::{Arc, Mutex};
 
 #[cfg(target_arch = "wasm32")]
@@ -17,6 +20,9 @@ use wasm_bindgen::prelude::*;
 
 #[cfg(target_arch = "wasm32")]
 use wasm_bindgen::JsCast;
+
+#[cfg(target_arch = "wasm32")]
+use wasm_bindgen_futures::JsFuture;
 
 /// Top-level viewer mode. Determines which plugins/systems are active
 /// and which SSE endpoint the viewer connects to.
@@ -152,6 +158,8 @@ impl Plugin for ModePlugin {
             .init_resource::<ModeTransitionBuffer>()
             .add_systems(OnEnter(ViewerMode::Lobby), on_enter_lobby)
             .add_systems(OnExit(ViewerMode::Lobby), on_exit_lobby)
+            .add_systems(OnEnter(ViewerMode::Trpg), enter_trpg)
+            .add_systems(OnExit(ViewerMode::Trpg), exit_trpg)
             .add_systems(OnEnter(ViewerMode::Monitor), enter_monitor)
             .add_systems(OnExit(ViewerMode::Monitor), exit_monitor)
             .add_systems(OnEnter(ViewerMode::Council), enter_council)
@@ -188,6 +196,7 @@ fn on_enter_lobby(buffer: Res<ModeTransitionBuffer>) {
         // Bind back-to-lobby button
         bind_back_button(&doc, &buffer.pending);
         bind_debug_controls(&doc);
+        bind_new_game_controls(&doc);
 
         // Hide loading screen once Bevy is initialized
         if let Some(loading) = doc.get_element_by_id("loading-screen") {
@@ -212,6 +221,42 @@ fn on_exit_lobby() {
 
         set_element_display(&doc, "lobby-screen", "none");
         set_element_display(&doc, "dashboard", "grid");
+    }
+}
+
+fn enter_trpg() {
+    #[cfg(target_arch = "wasm32")]
+    {
+        let Some(doc) = web_sys::window().and_then(|w| w.document()) else {
+            return;
+        };
+
+        set_element_display(&doc, "dashboard", "grid");
+        set_element_display(&doc, "lobby-screen", "none");
+        set_element_display(&doc, "new-game-panel", "none");
+        bind_debug_controls(&doc);
+        bind_new_game_controls(&doc);
+
+        if let Some(dashboard) = doc.get_element_by_id("dashboard") {
+            let room = dashboard
+                .get_attribute("data-room-id")
+                .unwrap_or_default()
+                .trim()
+                .to_string();
+            if room.is_empty() {
+                let _ = dashboard.set_attribute("data-room-id", crate::config::DEFAULT_ROOM_ID);
+            }
+        }
+    }
+}
+
+fn exit_trpg() {
+    #[cfg(target_arch = "wasm32")]
+    {
+        let Some(doc) = web_sys::window().and_then(|w| w.document()) else {
+            return;
+        };
+        set_element_display(&doc, "new-game-panel", "none");
     }
 }
 
@@ -316,6 +361,24 @@ fn bind_back_button(doc: &web_sys::Document, pending: &Arc<Mutex<Option<ViewerMo
 }
 
 #[cfg(target_arch = "wasm32")]
+fn apply_debug_visibility_in_dom(doc: &web_sys::Document, enabled: bool) {
+    let Ok(entries) = doc.query_selector_all("#narrative-log .narrative-entry[data-debug-entry=\"1\"]")
+    else {
+        return;
+    };
+
+    for i in 0..entries.length() {
+        let Some(node) = entries.item(i) else { continue };
+        let Some(el) = node.dyn_ref::<web_sys::HtmlElement>() else {
+            continue;
+        };
+        let _ = el
+            .style()
+            .set_property("display", if enabled { "block" } else { "none" });
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
 fn set_debug_state(doc: &web_sys::Document, enabled: bool) {
     if let Some(dashboard) = doc.get_element_by_id("dashboard") {
         let _ = dashboard.set_attribute("data-debug", if enabled { "on" } else { "off" });
@@ -327,6 +390,7 @@ fn set_debug_state(doc: &web_sys::Document, enabled: bool) {
     if let Some(status) = doc.get_element_by_id("debug-log-status") {
         status.set_text_content(Some(if enabled { "DEBUG ON" } else { "DEBUG OFF" }));
     }
+    apply_debug_visibility_in_dom(doc, enabled);
 }
 
 #[cfg(target_arch = "wasm32")]
@@ -357,6 +421,706 @@ fn bind_debug_controls(doc: &web_sys::Document) {
         .map(|target| target.add_event_listener_with_callback("click", cb.as_ref().unchecked_ref()));
 
     cb.forget();
+}
+
+#[cfg(target_arch = "wasm32")]
+fn html_escape(s: &str) -> String {
+    s.replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+        .replace('"', "&quot;")
+        .replace('\'', "&#39;")
+}
+
+#[cfg(target_arch = "wasm32")]
+fn generate_room_id() -> String {
+    let millis = js_sys::Date::now() as i64;
+    let rand = (js_sys::Math::random() * 1000.0).floor() as i64;
+    format!("adventure-{}-{:03}", millis, rand)
+}
+
+#[cfg(target_arch = "wasm32")]
+fn set_new_game_status(doc: &web_sys::Document, message: &str) {
+    if let Some(el) = doc.get_element_by_id("new-game-status") {
+        el.set_inner_html(&html_escape(message));
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+fn set_current_room_id(doc: &web_sys::Document, room_id: &str) {
+    if let Some(dashboard) = doc.get_element_by_id("dashboard") {
+        let _ = dashboard.set_attribute("data-room-id", room_id);
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+fn clear_trpg_dom(doc: &web_sys::Document) {
+    if let Some(el) = doc.get_element_by_id("narrative-log") {
+        el.set_inner_html("");
+    }
+    if let Some(el) = doc.get_element_by_id("dice-log") {
+        el.set_inner_html("");
+    }
+    if let Some(el) = doc.get_element_by_id("character-panel") {
+        el.set_inner_html("");
+    }
+    if let Some(el) = doc.get_element_by_id("turn-num") {
+        el.set_text_content(Some("1"));
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+fn unique_non_empty(mut values: Vec<String>) -> Vec<String> {
+    values.retain(|v| !v.trim().is_empty());
+    let mut out = Vec::with_capacity(values.len());
+    for value in values {
+        if out.iter().any(|x: &String| x == &value) {
+            continue;
+        }
+        out.push(value);
+    }
+    out
+}
+
+#[cfg(target_arch = "wasm32")]
+fn parse_keeper_models(raw: &str) -> Vec<String> {
+    unique_non_empty(
+        raw.split(',')
+            .map(|part| part.trim().to_string())
+            .collect::<Vec<_>>(),
+    )
+}
+
+#[cfg(target_arch = "wasm32")]
+fn selected_player_keepers(doc: &web_sys::Document) -> Vec<String> {
+    let Ok(nodes) = doc.query_selector_all("#new-game-player-select option:checked") else {
+        return Vec::new();
+    };
+    let mut keepers = Vec::new();
+    for i in 0..nodes.length() {
+        let Some(node) = nodes.item(i) else { continue };
+        let Some(el) = node.dyn_ref::<web_sys::Element>() else {
+            continue;
+        };
+        let Some(value) = el.get_attribute("value") else {
+            continue;
+        };
+        let value = value.trim();
+        if value.is_empty() {
+            continue;
+        }
+        keepers.push(value.to_string());
+    }
+    unique_non_empty(keepers)
+}
+
+#[cfg(target_arch = "wasm32")]
+async fn mcp_tool_call(tool_name: &str, args: Value) -> Result<Value, String> {
+    let url = format!("{}/mcp", crate::config::MASC_MCP_URL);
+    let body = json!({
+        "jsonrpc": "2.0",
+        "id": (js_sys::Date::now() as i64),
+        "method": "tools/call",
+        "params": {
+            "name": tool_name,
+            "arguments": args,
+        }
+    })
+    .to_string();
+
+    let opts = web_sys::RequestInit::new();
+    opts.set_method("POST");
+    opts.set_mode(web_sys::RequestMode::Cors);
+    opts.set_body(&JsValue::from_str(&body));
+
+    let request = web_sys::Request::new_with_str_and_init(&url, &opts)
+        .map_err(|e| format!("request 생성 실패: {:?}", e))?;
+    request
+        .headers()
+        .set("Content-Type", "application/json")
+        .map_err(|e| format!("헤더 설정 실패: {:?}", e))?;
+    request
+        .headers()
+        .set("Accept", "application/json, text/event-stream")
+        .map_err(|e| format!("헤더 설정 실패: {:?}", e))?;
+
+    let window = web_sys::window().ok_or_else(|| "window unavailable".to_string())?;
+    let resp_value = JsFuture::from(window.fetch_with_request(&request))
+        .await
+        .map_err(|e| format!("fetch 실패: {:?}", e))?;
+    let resp: web_sys::Response = resp_value
+        .dyn_into()
+        .map_err(|_| "response 변환 실패".to_string())?;
+    let status = resp.status();
+
+    let body_js = JsFuture::from(
+        resp.text()
+            .map_err(|e| format!("response.text() 실패: {:?}", e))?,
+    )
+    .await
+    .map_err(|e| format!("본문 읽기 실패: {:?}", e))?;
+    let body_text = body_js.as_string().unwrap_or_default();
+
+    let rpc: Value = if body_text.trim().is_empty() {
+        json!({})
+    } else {
+        parse_mcp_rpc_response(&body_text).map_err(|e| {
+            format!(
+                "RPC 응답 JSON 파싱 실패: {} / {}",
+                e,
+                body_text.chars().take(240).collect::<String>()
+            )
+        })?
+    };
+
+    if !resp.ok() {
+        let msg = rpc
+            .get("error")
+            .and_then(|e| e.get("message"))
+            .and_then(Value::as_str)
+            .unwrap_or("HTTP 오류");
+        return Err(format!("{} (status {})", msg, status));
+    }
+    if let Some(err) = rpc.get("error") {
+        let msg = err
+            .get("message")
+            .and_then(Value::as_str)
+            .unwrap_or("RPC 오류");
+        return Err(msg.to_string());
+    }
+
+    let result = rpc.get("result").cloned().unwrap_or_else(|| json!({}));
+    if result
+        .get("isError")
+        .and_then(Value::as_bool)
+        .unwrap_or(false)
+    {
+        let text = result
+            .get("content")
+            .and_then(Value::as_array)
+            .and_then(|rows| {
+                rows.iter().find_map(|row| {
+                    if row.get("type").and_then(Value::as_str) == Some("text") {
+                        row.get("text").and_then(Value::as_str)
+                    } else {
+                        None
+                    }
+                })
+            })
+            .unwrap_or("tool call failed");
+        return Err(text.to_string());
+    }
+
+    let text = result
+        .get("content")
+        .and_then(Value::as_array)
+        .and_then(|rows| {
+            rows.iter().find_map(|row| {
+                if row.get("type").and_then(Value::as_str) == Some("text") {
+                    row.get("text").and_then(Value::as_str)
+                } else {
+                    None
+                }
+            })
+        })
+        .unwrap_or("")
+        .trim()
+        .to_string();
+
+    if text.is_empty() {
+        return Ok(json!({}));
+    }
+
+    let parsed: Value = serde_json::from_str(&text)
+        .map_err(|e| format!("{} 응답 JSON 파싱 실패: {} / {}", tool_name, e, text))?;
+    Ok(parsed.get("payload").cloned().unwrap_or(parsed))
+}
+
+#[cfg(target_arch = "wasm32")]
+fn parse_mcp_rpc_response(raw: &str) -> Result<Value, String> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return Ok(json!({}));
+    }
+    if let Ok(v) = serde_json::from_str::<Value>(trimmed) {
+        return Ok(v);
+    }
+
+    let chunks = trimmed.split("\n\n").collect::<Vec<_>>();
+    for chunk in chunks.into_iter().rev() {
+        let piece = chunk.trim();
+        if piece.is_empty() {
+            continue;
+        }
+        if piece.starts_with('{') || piece.starts_with('[') {
+            if let Ok(v) = serde_json::from_str::<Value>(piece) {
+                return Ok(v);
+            }
+        }
+
+        let data_text = piece
+            .lines()
+            .filter_map(|line| line.strip_prefix("data:"))
+            .map(str::trim_start)
+            .collect::<Vec<_>>()
+            .join("\n");
+        let data_text = data_text.trim();
+        if data_text.is_empty() || data_text == "[DONE]" {
+            continue;
+        }
+        if let Ok(v) = serde_json::from_str::<Value>(data_text) {
+            return Ok(v);
+        }
+    }
+
+    Err("SSE frame parsing failed".to_string())
+}
+
+#[cfg(target_arch = "wasm32")]
+async fn refresh_keeper_selectors(doc: &web_sys::Document) -> Result<Vec<String>, String> {
+    let payload = mcp_tool_call("masc_keeper_list", json!({ "limit": 200 })).await?;
+    let mut keepers = payload
+        .get("keepers")
+        .and_then(Value::as_array)
+        .map(|arr| {
+            arr.iter()
+                .filter_map(Value::as_str)
+                .map(|name| name.trim().to_string())
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default();
+    keepers = unique_non_empty(keepers);
+    if keepers.is_empty() {
+        keepers = vec![
+            "dm-keeper".to_string(),
+            "grimja".to_string(),
+            "luna".to_string(),
+            "songarak".to_string(),
+            "miso".to_string(),
+        ];
+    }
+
+    let dm_default = keepers
+        .iter()
+        .find(|name| name.starts_with("dm"))
+        .cloned()
+        .unwrap_or_else(|| keepers[0].clone());
+
+    if let Some(dm_select) = doc.get_element_by_id("new-game-dm-select") {
+        let html = keepers
+            .iter()
+            .map(|name| {
+                let safe = html_escape(name);
+                format!(r#"<option value="{}">{}</option>"#, safe, safe)
+            })
+            .collect::<Vec<_>>()
+            .join("");
+        dm_select.set_inner_html(&html);
+        if let Some(select) = dm_select.dyn_ref::<web_sys::HtmlSelectElement>() {
+            select.set_value(&dm_default);
+        }
+    }
+
+    if let Some(player_select) = doc.get_element_by_id("new-game-player-select") {
+        let mut selected = 0;
+        let mut html = String::new();
+        for name in keepers.iter().filter(|name| **name != dm_default) {
+            let safe = html_escape(name);
+            let selected_attr = if selected < 4 { " selected" } else { "" };
+            if selected < 4 {
+                selected += 1;
+            }
+            html.push_str(&format!(
+                r#"<option value="{value}"{selected}>{value}</option>"#,
+                value = safe,
+                selected = selected_attr
+            ));
+        }
+        player_select.set_inner_html(&html);
+    }
+
+    Ok(keepers)
+}
+
+#[cfg(target_arch = "wasm32")]
+async fn start_new_game_flow(doc: &web_sys::Document) -> Result<String, String> {
+    let room_input = doc
+        .get_element_by_id("new-game-room-id")
+        .and_then(|el| el.dyn_ref::<web_sys::HtmlInputElement>().map(|i| i.value()))
+        .unwrap_or_default();
+    let room_id = if room_input.trim().is_empty() {
+        generate_room_id()
+    } else {
+        room_input.trim().to_string()
+    };
+    if let Some(input) = doc
+        .get_element_by_id("new-game-room-id")
+        .and_then(|el| el.dyn_into::<web_sys::HtmlInputElement>().ok())
+    {
+        input.set_value(&room_id);
+    }
+
+    let dm_keeper = doc
+        .get_element_by_id("new-game-dm-select")
+        .and_then(|el| el.dyn_ref::<web_sys::HtmlSelectElement>().map(|s| s.value()))
+        .unwrap_or_default()
+        .trim()
+        .to_string();
+    if dm_keeper.is_empty() {
+        return Err("DM keeper를 선택하세요.".to_string());
+    }
+
+    let players = selected_player_keepers(doc);
+    if players.is_empty() {
+        return Err("AI Player를 1명 이상 선택하세요.".to_string());
+    }
+    if players.iter().any(|keeper| keeper == &dm_keeper) {
+        return Err("DM keeper와 player keeper는 중복될 수 없습니다.".to_string());
+    }
+
+    let model_text = doc
+        .get_element_by_id("new-game-models")
+        .and_then(|el| el.dyn_ref::<web_sys::HtmlInputElement>().map(|i| i.value()))
+        .unwrap_or_default();
+    let models = parse_keeper_models(&model_text);
+
+    let preset_catalog = mcp_tool_call(
+        "trpg.preset.list",
+        json!({
+            "include_characters": false,
+            "include_skills": false
+        }),
+    )
+    .await?;
+    let world_preset_id = preset_catalog
+        .get("world_presets")
+        .and_then(Value::as_array)
+        .and_then(|arr| arr.first())
+        .and_then(|preset| preset.get("id"))
+        .and_then(Value::as_str)
+        .unwrap_or("")
+        .trim()
+        .to_string();
+    let dm_preset_id = preset_catalog
+        .get("dm_presets")
+        .and_then(Value::as_array)
+        .and_then(|arr| arr.first())
+        .and_then(|preset| preset.get("id"))
+        .and_then(Value::as_str)
+        .unwrap_or("")
+        .trim()
+        .to_string();
+    if world_preset_id.is_empty() || dm_preset_id.is_empty() {
+        return Err("trpg preset 목록이 비어 있습니다.".to_string());
+    }
+
+    let party_size = players.len() as i64;
+    let pool_size = std::cmp::max(8_i64, party_size);
+    let session_id = format!("viewer-{}-{}", room_id, js_sys::Date::now() as i64);
+
+    let pool_result = mcp_tool_call(
+        "trpg.pool.generate",
+        json!({
+            "session_id": session_id,
+            "world_preset_id": world_preset_id,
+            "dm_preset_id": dm_preset_id,
+            "pool_size": pool_size,
+            "party_size": party_size,
+            "seed": (js_sys::Date::now() as i64) % 100_000
+        }),
+    )
+    .await?;
+    let pool = pool_result
+        .get("pool")
+        .and_then(Value::as_array)
+        .cloned()
+        .unwrap_or_default();
+    if pool.is_empty() {
+        return Err("pool.generate 결과가 비어 있습니다.".to_string());
+    }
+
+    let mut selected_player_ids = pool_result
+        .get("suggested_party_ids")
+        .and_then(Value::as_array)
+        .map(|arr| {
+            arr.iter()
+                .filter_map(Value::as_str)
+                .map(|id| id.trim().to_string())
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default();
+    selected_player_ids = unique_non_empty(selected_player_ids);
+
+    if selected_player_ids.len() < party_size as usize {
+        for row in &pool {
+            let Some(actor_id) = row
+                .get("actor_id")
+                .and_then(Value::as_str)
+                .map(str::trim)
+                .filter(|id| !id.is_empty())
+            else {
+                continue;
+            };
+            if selected_player_ids.iter().any(|id| id == actor_id) {
+                continue;
+            }
+            selected_player_ids.push(actor_id.to_string());
+            if selected_player_ids.len() >= party_size as usize {
+                break;
+            }
+        }
+    }
+    if selected_player_ids.is_empty() {
+        return Err("선택 가능한 actor_id를 찾지 못했습니다.".to_string());
+    }
+
+    let party_result = mcp_tool_call(
+        "trpg.party.select",
+        json!({
+            "session_id": session_id,
+            "room_id": room_id,
+            "pool": pool,
+            "selected_player_ids": selected_player_ids
+        }),
+    )
+    .await?;
+    let party = party_result
+        .get("party")
+        .and_then(Value::as_array)
+        .cloned()
+        .unwrap_or_default();
+    if party.is_empty() {
+        return Err("party.select 결과가 비어 있습니다.".to_string());
+    }
+
+    let _start_result = mcp_tool_call(
+        "trpg.session.start",
+        json!({
+            "session_id": session_id,
+            "room_id": room_id,
+            "dm_preset_id": dm_preset_id,
+            "world_preset_id": world_preset_id,
+            "party": party,
+            "phase": "briefing",
+            "force": true
+        }),
+    )
+    .await?;
+
+    let mut actor_ids = party
+        .iter()
+        .filter_map(|row| row.get("actor_id").and_then(Value::as_str))
+        .map(|id| id.trim().to_string())
+        .filter(|id| !id.is_empty())
+        .collect::<Vec<_>>();
+    actor_ids = unique_non_empty(actor_ids);
+    if actor_ids.is_empty() {
+        return Err("세션 party actor_id를 읽지 못했습니다.".to_string());
+    }
+
+    let mut used_keepers = vec![dm_keeper.clone()];
+    let mut player_map = serde_json::Map::new();
+    for (idx, actor_id) in actor_ids.iter().enumerate() {
+        let mut keeper = players
+            .get(idx)
+            .cloned()
+            .unwrap_or_else(|| format!("pk-{}", actor_id));
+        if used_keepers.iter().any(|name| name == &keeper) {
+            keeper = format!("pk-{}", actor_id);
+        }
+        let mut candidate = keeper.clone();
+        let mut suffix = 1_i32;
+        while used_keepers.iter().any(|name| name == &candidate) {
+            candidate = format!("{}-{}", keeper, suffix);
+            suffix += 1;
+        }
+        used_keepers.push(candidate.clone());
+        player_map.insert(actor_id.clone(), Value::String(candidate));
+    }
+
+    if !models.is_empty() {
+        let models_value = Value::Array(
+            models
+                .iter()
+                .map(|m| Value::String(m.clone()))
+                .collect::<Vec<_>>(),
+        );
+        mcp_tool_call(
+            "masc_keeper_up",
+            json!({
+                "name": dm_keeper,
+                "goal": format!("TRPG room {}의 세계관 주민 DM keeper로 장면을 진행하세요.", room_id),
+                "models": models_value,
+                "instructions": "모든 응답은 한국어로 작성하세요.",
+                "proactive_enabled": false,
+                "presence_keepalive": true
+            }),
+        )
+        .await?;
+        for (actor_id, keeper_name) in &player_map {
+            let Some(keeper_name) = keeper_name.as_str() else {
+                continue;
+            };
+            mcp_tool_call(
+                "masc_keeper_up",
+                json!({
+                    "name": keeper_name,
+                    "goal": format!("TRPG room {}에서 {} actor를 플레이하세요.", room_id, actor_id),
+                    "models": Value::Array(
+                        models
+                            .iter()
+                            .map(|m| Value::String(m.clone()))
+                            .collect::<Vec<_>>()
+                    ),
+                    "instructions": "모든 응답은 한국어로 작성하세요.",
+                    "proactive_enabled": false,
+                    "presence_keepalive": true
+                }),
+            )
+            .await?;
+        }
+    }
+
+    set_current_room_id(doc, &room_id);
+    clear_trpg_dom(doc);
+
+    Ok(format!(
+        "새 게임 시작 완료: room {} / DM {} / players {}",
+        room_id,
+        dm_keeper,
+        player_map.len()
+    ))
+}
+
+#[cfg(target_arch = "wasm32")]
+fn bind_new_game_controls(doc: &web_sys::Document) {
+    let Some(open_btn) = doc.get_element_by_id("new-game-toggle") else {
+        return;
+    };
+    if open_btn.get_attribute("data-bound").as_deref() == Some("1") {
+        return;
+    }
+    let _ = open_btn.set_attribute("data-bound", "1");
+
+    let open_cb = Closure::wrap(Box::new(move || {
+        let Some(doc) = web_sys::window().and_then(|w| w.document()) else {
+            return;
+        };
+        set_element_display(&doc, "new-game-panel", "flex");
+        if let Some(room_input) = doc
+            .get_element_by_id("new-game-room-id")
+            .and_then(|el| el.dyn_into::<web_sys::HtmlInputElement>().ok())
+        {
+            if room_input.value().trim().is_empty() {
+                room_input.set_value(&generate_room_id());
+            }
+        }
+        set_new_game_status(&doc, "Keeper 목록을 불러오는 중...");
+        let doc_for_fetch = doc.clone();
+        wasm_bindgen_futures::spawn_local(async move {
+            match refresh_keeper_selectors(&doc_for_fetch).await {
+                Ok(keepers) => {
+                    set_new_game_status(
+                        &doc_for_fetch,
+                        &format!("Keeper {}개 로드됨. DM/Player를 선택하세요.", keepers.len()),
+                    );
+                }
+                Err(e) => set_new_game_status(&doc_for_fetch, &format!("Keeper 로드 실패: {}", e)),
+            }
+        });
+    }) as Box<dyn FnMut()>);
+    let _ = open_btn
+        .dyn_ref::<web_sys::EventTarget>()
+        .map(|target| target.add_event_listener_with_callback("click", open_cb.as_ref().unchecked_ref()));
+    open_cb.forget();
+
+    if let Some(close_btn) = doc.get_element_by_id("new-game-close") {
+        let close_cb = Closure::wrap(Box::new(move || {
+            let Some(doc) = web_sys::window().and_then(|w| w.document()) else {
+                return;
+            };
+            set_element_display(&doc, "new-game-panel", "none");
+        }) as Box<dyn FnMut()>);
+        let _ = close_btn
+            .dyn_ref::<web_sys::EventTarget>()
+            .map(|target| target.add_event_listener_with_callback("click", close_cb.as_ref().unchecked_ref()));
+        close_cb.forget();
+    }
+
+    if let Some(regen_btn) = doc.get_element_by_id("new-game-room-regenerate") {
+        let regen_cb = Closure::wrap(Box::new(move || {
+            let Some(doc) = web_sys::window().and_then(|w| w.document()) else {
+                return;
+            };
+            if let Some(room_input) = doc
+                .get_element_by_id("new-game-room-id")
+                .and_then(|el| el.dyn_into::<web_sys::HtmlInputElement>().ok())
+            {
+                room_input.set_value(&generate_room_id());
+            }
+        }) as Box<dyn FnMut()>);
+        let _ = regen_btn
+            .dyn_ref::<web_sys::EventTarget>()
+            .map(|target| target.add_event_listener_with_callback("click", regen_cb.as_ref().unchecked_ref()));
+        regen_cb.forget();
+    }
+
+    if let Some(refresh_btn) = doc.get_element_by_id("new-game-refresh") {
+        let refresh_cb = Closure::wrap(Box::new(move || {
+            let Some(doc) = web_sys::window().and_then(|w| w.document()) else {
+                return;
+            };
+            set_new_game_status(&doc, "Keeper 목록을 새로고침 중...");
+            let doc_for_fetch = doc.clone();
+            wasm_bindgen_futures::spawn_local(async move {
+                match refresh_keeper_selectors(&doc_for_fetch).await {
+                    Ok(keepers) => {
+                        set_new_game_status(
+                            &doc_for_fetch,
+                            &format!("Keeper {}개 새로고침 완료", keepers.len()),
+                        );
+                    }
+                    Err(e) => set_new_game_status(&doc_for_fetch, &format!("새로고침 실패: {}", e)),
+                }
+            });
+        }) as Box<dyn FnMut()>);
+        let _ = refresh_btn
+            .dyn_ref::<web_sys::EventTarget>()
+            .map(|target| target.add_event_listener_with_callback("click", refresh_cb.as_ref().unchecked_ref()));
+        refresh_cb.forget();
+    }
+
+    if let Some(start_btn) = doc.get_element_by_id("new-game-start") {
+        let start_cb = Closure::wrap(Box::new(move || {
+            let Some(doc) = web_sys::window().and_then(|w| w.document()) else {
+                return;
+            };
+            set_new_game_status(&doc, "새 게임 시작 중...");
+            if let Some(btn) = doc.get_element_by_id("new-game-start") {
+                let _ = btn.set_attribute("disabled", "true");
+            }
+            let doc_for_start = doc.clone();
+            wasm_bindgen_futures::spawn_local(async move {
+                let result = start_new_game_flow(&doc_for_start).await;
+                match result {
+                    Ok(message) => {
+                        set_new_game_status(&doc_for_start, &message);
+                        set_element_display(&doc_for_start, "new-game-panel", "none");
+                    }
+                    Err(e) => {
+                        set_new_game_status(&doc_for_start, &format!("시작 실패: {}", e));
+                    }
+                }
+                if let Some(btn) = doc_for_start.get_element_by_id("new-game-start") {
+                    let _ = btn.remove_attribute("disabled");
+                }
+            });
+        }) as Box<dyn FnMut()>);
+        let _ = start_btn
+            .dyn_ref::<web_sys::EventTarget>()
+            .map(|target| target.add_event_listener_with_callback("click", start_cb.as_ref().unchecked_ref()));
+        start_cb.forget();
+    }
 }
 
 fn refresh_trpg_widget_status() {

--- a/viewer/style.css
+++ b/viewer/style.css
@@ -375,6 +375,10 @@ body.mode-lobby #dashboard {
     display: none;
 }
 
+#dashboard[data-debug="off"] .narrative-entry[data-debug-entry="1"] {
+    display: none !important;
+}
+
 /* ─── Top Bar ──────────────────────────── */
 
 #top-bar {
@@ -624,15 +628,15 @@ body.mode-lobby #dashboard {
     box-shadow: 0 0 0 1px var(--border-main) inset;
 }
 
-.narrative-entry.phase-dm_narration {
+.narrative-entry.phase-dm-narration {
     border-left-color: var(--accent-primary-dim);
 }
 
-.narrative-entry.phase-outcome_narration {
+.narrative-entry.phase-outcome-narration {
     border-left-color: var(--accent-secondary);
 }
 
-.narrative-entry.phase-party_discussion {
+.narrative-entry.phase-party-discussion {
     border-left-color: var(--accent-tertiary);
     font-style: italic;
 }
@@ -828,6 +832,98 @@ body.mode-lobby #dashboard {
 
 #dice-log {
     min-height: 100%;
+}
+
+/* TRPG New Game panel */
+.new-game-panel {
+    position: fixed;
+    top: 56px;
+    right: 12px;
+    width: 360px;
+    max-height: calc(100vh - 72px);
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    background: var(--bg-panel);
+    border: 1px solid var(--border-main);
+    box-shadow: var(--panel-shadow);
+    border-radius: var(--panel-radius);
+    padding: 12px;
+    z-index: 180;
+}
+
+.new-game-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+}
+
+.new-game-header h3 {
+    font-family: var(--font-display);
+    font-size: 14px;
+    letter-spacing: 2px;
+    color: var(--accent-primary);
+}
+
+.new-game-body {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    overflow-y: auto;
+}
+
+.new-game-label {
+    font-family: var(--font-ui);
+    font-size: 10px;
+    letter-spacing: 1px;
+    text-transform: uppercase;
+    color: var(--text-dim);
+}
+
+.new-game-room-row {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.new-game-input,
+.new-game-select {
+    width: 100%;
+    background: var(--bg-panel-alt);
+    color: var(--text-primary);
+    border: 1px solid var(--border-main);
+    border-radius: var(--panel-radius);
+    padding: 6px 8px;
+    font-family: var(--font-ui);
+    font-size: 11px;
+}
+
+.new-game-select[multiple] {
+    min-height: 132px;
+}
+
+.new-game-status {
+    margin-top: 2px;
+    border: 1px solid var(--border-main);
+    border-radius: var(--panel-radius);
+    padding: 8px;
+    font-family: var(--font-ui);
+    font-size: 11px;
+    color: var(--text-dim);
+    background: var(--bg-panel-alt);
+    line-height: 1.5;
+    white-space: pre-wrap;
+}
+
+.new-game-actions {
+    display: flex;
+    justify-content: space-between;
+    gap: 8px;
+}
+
+.new-game-start {
+    border-color: var(--accent-primary-dim);
+    color: var(--text-bright);
 }
 
 /* ═══════════════════════════════════════════


### PR DESCRIPTION
## Summary
- add a TRPG `새 게임` setup panel in viewer (`DM 선택 → AI Player 선택 → 시작`)
- wire setup flow to MCP tool calls (`masc_keeper_list`, `trpg.preset.list`, `trpg.pool.generate`, `trpg.party.select`, `trpg.session.start`, `masc_keeper_up`)
- switch TRPG room from fixed `default` to runtime room id via `#dashboard[data-room-id]`
- reload TRPG state when room changes and clear stale UI data on new session/enter
- improve debug toggle behavior by hiding/showing debug narrative entries (`[timeout]`, `[unavailable]`)
- fix phase-specific narrative CSS class mismatch (`phase-dm-narration` etc.)

## Validation
- `cargo check --manifest-path viewer/Cargo.toml`
- `cd viewer && NO_COLOR=false trunk build`
