### PR TITLE
feat(viewer): add TRPG action panel for player input

### DIFF
--- a/viewer/Cargo.toml
+++ b/viewer/Cargo.toml
@@ -19,6 +19,7 @@ web-sys = { version = "0.3", features = [
     "EventSource",
     "MessageEvent",
     "Document",
+    "HtmlButtonElement",
     "HtmlElement",
     "HtmlInputElement",
     "HtmlSelectElement",

--- a/viewer/index.html
+++ b/viewer/index.html
@@ -193,6 +193,18 @@
                         </div>
                     </div>
                     <div id="narrative-log"></div>
+                    <!-- Action Panel: player input for TRPG actions -->
+                    <div id="action-panel">
+                        <div id="action-input-row">
+                            <input type="text" id="action-input"
+                                   placeholder="Describe your action..."
+                                   maxlength="500"
+                                   autocomplete="off" />
+                            <button id="action-submit-btn" title="Submit action">Submit</button>
+                            <button id="dice-roll-btn" title="Roll 1d20">Roll</button>
+                        </div>
+                        <div id="action-status"></div>
+                    </div>
                 </div>
             </section>
 

--- a/viewer/src/dom/action_panel.rs
+++ b/viewer/src/dom/action_panel.rs
@@ -1,0 +1,380 @@
+//! TRPG Action Panel — player action submission and dice rolling.
+//!
+//! Binds DOM event listeners on `#action-panel` elements:
+//! - Submit button / Enter key → POST `/api/v1/trpg/events`
+//! - Dice Roll button → POST `/api/v1/trpg/dice/roll`
+//!
+//! Follows the same lifecycle pattern as `social_board.rs`:
+//! OnEnter binds listeners, OnExit cleans up the panel DOM.
+
+use bevy::prelude::*;
+
+#[cfg(target_arch = "wasm32")]
+use wasm_bindgen::prelude::*;
+
+#[cfg(target_arch = "wasm32")]
+use crate::config;
+use crate::mode::ViewerMode;
+
+// ─── Marker Resource ────────────────────────
+
+/// Inserted on enter, removed on exit — signals that the action panel is bound.
+#[derive(Resource)]
+pub struct ActionPanelBound;
+
+// ─── OnEnter System ─────────────────────────
+
+/// Bind DOM event listeners when entering TRPG mode.
+pub fn bind_action_panel(mut commands: Commands) {
+    #[cfg(target_arch = "wasm32")]
+    {
+        bind_submit_button();
+        bind_enter_key();
+        bind_dice_roll_button();
+        clear_action_status();
+        log::info!("ActionPanel: bound");
+    }
+
+    commands.insert_resource(ActionPanelBound);
+}
+
+/// Cleanup when leaving TRPG mode.
+pub fn unbind_action_panel(mut commands: Commands) {
+    // Clear the status text; listeners will be garbage-collected
+    // when the DOM elements are removed or replaced on mode switch.
+    #[cfg(target_arch = "wasm32")]
+    {
+        clear_action_status();
+        clear_action_input();
+        log::info!("ActionPanel: unbound");
+    }
+
+    commands.remove_resource::<ActionPanelBound>();
+}
+
+// ─── Event: Submit Button ───────────────────
+
+#[cfg(target_arch = "wasm32")]
+fn bind_submit_button() {
+    let Some(doc) = web_sys::window().and_then(|w| w.document()) else {
+        return;
+    };
+    let Some(btn) = doc.get_element_by_id("action-submit-btn") else {
+        log::warn!("ActionPanel: #action-submit-btn not found");
+        return;
+    };
+
+    let cb = Closure::wrap(Box::new(move || {
+        submit_action_from_input();
+    }) as Box<dyn FnMut()>);
+
+    let _ = btn
+        .dyn_ref::<web_sys::EventTarget>()
+        .map(|t| t.add_event_listener_with_callback("click", cb.as_ref().unchecked_ref()));
+
+    cb.forget();
+}
+
+// ─── Event: Enter Key on Input ──────────────
+
+#[cfg(target_arch = "wasm32")]
+fn bind_enter_key() {
+    let Some(doc) = web_sys::window().and_then(|w| w.document()) else {
+        return;
+    };
+    let Some(input) = doc.get_element_by_id("action-input") else {
+        return;
+    };
+
+    let cb = Closure::wrap(Box::new(move |event: web_sys::KeyboardEvent| {
+        if event.key() == "Enter" {
+            submit_action_from_input();
+        }
+    }) as Box<dyn FnMut(web_sys::KeyboardEvent)>);
+
+    let _ = input
+        .dyn_ref::<web_sys::EventTarget>()
+        .map(|t| t.add_event_listener_with_callback("keydown", cb.as_ref().unchecked_ref()));
+
+    cb.forget();
+}
+
+// ─── Event: Dice Roll Button ────────────────
+
+#[cfg(target_arch = "wasm32")]
+fn bind_dice_roll_button() {
+    let Some(doc) = web_sys::window().and_then(|w| w.document()) else {
+        return;
+    };
+    let Some(btn) = doc.get_element_by_id("dice-roll-btn") else {
+        log::warn!("ActionPanel: #dice-roll-btn not found");
+        return;
+    };
+
+    let cb = Closure::wrap(Box::new(move || {
+        set_action_status("Rolling dice...", "");
+        disable_buttons(true);
+
+        wasm_bindgen_futures::spawn_local(async move {
+            match roll_dice().await {
+                Ok(text) => set_action_status(&text, "status-ok"),
+                Err(e) => {
+                    let msg = format!("Dice roll failed: {:?}", e);
+                    log::warn!("{}", msg);
+                    set_action_status(&msg, "status-error");
+                }
+            }
+            disable_buttons(false);
+        });
+    }) as Box<dyn FnMut()>);
+
+    let _ = btn
+        .dyn_ref::<web_sys::EventTarget>()
+        .map(|t| t.add_event_listener_with_callback("click", cb.as_ref().unchecked_ref()));
+
+    cb.forget();
+}
+
+// ─── Action Submission Logic ────────────────
+
+#[cfg(target_arch = "wasm32")]
+fn submit_action_from_input() {
+    let Some(doc) = web_sys::window().and_then(|w| w.document()) else {
+        return;
+    };
+    let Some(el) = doc.get_element_by_id("action-input") else {
+        return;
+    };
+    let Some(input) = el.dyn_ref::<web_sys::HtmlInputElement>() else {
+        return;
+    };
+
+    let text = input.value();
+    let text = text.trim().to_string();
+    if text.is_empty() {
+        return;
+    }
+
+    // Clear input immediately (optimistic UX)
+    input.set_value("");
+    set_action_status("Submitting...", "");
+    disable_buttons(true);
+
+    wasm_bindgen_futures::spawn_local(async move {
+        match submit_action(&text).await {
+            Ok(()) => set_action_status("Action submitted.", "status-ok"),
+            Err(e) => {
+                let msg = format!("Submit failed: {:?}", e);
+                log::warn!("{}", msg);
+                set_action_status(&msg, "status-error");
+            }
+        }
+        disable_buttons(false);
+    });
+}
+
+// ─── HTTP: Submit Action ────────────────────
+
+#[cfg(target_arch = "wasm32")]
+async fn submit_action(action_text: &str) -> Result<(), JsValue> {
+    use wasm_bindgen_futures::JsFuture;
+
+    let url = format!("{}/api/v1/trpg/events", config::MASC_MCP_URL);
+
+    // Escape for JSON string embedding
+    let escaped = action_text
+        .replace('\\', "\\\\")
+        .replace('"', "\\\"")
+        .replace('\n', "\\n");
+
+    let body = format!(
+        r#"{{"event_type":"turn.action.proposed","data":{{"character":"player","action_text":"{}"}}}}"#,
+        escaped
+    );
+
+    let opts = web_sys::RequestInit::new();
+    opts.set_method("POST");
+    opts.set_mode(web_sys::RequestMode::Cors);
+    opts.set_body(&JsValue::from_str(&body));
+
+    let request = web_sys::Request::new_with_str_and_init(&url, &opts)?;
+    request.headers().set("Content-Type", "application/json")?;
+
+    let window = web_sys::window().ok_or_else(|| JsValue::from_str("no window"))?;
+    let resp_value = JsFuture::from(window.fetch_with_request(&request)).await?;
+    let resp: web_sys::Response = resp_value.dyn_into()?;
+
+    if !resp.ok() {
+        return Err(JsValue::from_str(&format!("HTTP {}", resp.status())));
+    }
+
+    log::info!("ActionPanel: action submitted");
+    Ok(())
+}
+
+// ─── HTTP: Dice Roll ────────────────────────
+
+#[cfg(target_arch = "wasm32")]
+async fn roll_dice() -> Result<String, JsValue> {
+    use wasm_bindgen_futures::JsFuture;
+
+    let url = format!("{}/api/v1/trpg/dice/roll", config::MASC_MCP_URL);
+    let room_id = config::DEFAULT_ROOM_ID;
+
+    let body = format!(
+        r#"{{"room":"{}","dice":"1d20","reason":"Player roll"}}"#,
+        room_id
+    );
+
+    let opts = web_sys::RequestInit::new();
+    opts.set_method("POST");
+    opts.set_mode(web_sys::RequestMode::Cors);
+    opts.set_body(&JsValue::from_str(&body));
+
+    let request = web_sys::Request::new_with_str_and_init(&url, &opts)?;
+    request.headers().set("Content-Type", "application/json")?;
+
+    let window = web_sys::window().ok_or_else(|| JsValue::from_str("no window"))?;
+    let resp_value = JsFuture::from(window.fetch_with_request(&request)).await?;
+    let resp: web_sys::Response = resp_value.dyn_into()?;
+
+    if !resp.ok() {
+        return Err(JsValue::from_str(&format!("HTTP {}", resp.status())));
+    }
+
+    // Parse response to extract the roll result for status display
+    let json = JsFuture::from(resp.json()?).await?;
+    let result_str = js_sys::JSON::stringify(&json)
+        .map(|s| String::from(s))
+        .unwrap_or_else(|_| "Roll completed.".to_string());
+
+    // Try to extract a human-readable result
+    let display = extract_roll_display(&result_str);
+    log::info!("ActionPanel: dice rolled — {}", display);
+    Ok(display)
+}
+
+/// Extract a short display string from the dice roll JSON response.
+/// Falls back to the raw response if parsing fails.
+fn extract_roll_display(json_str: &str) -> String {
+    // Try to find "total":N or "result":N in the JSON
+    for key in &["total", "result", "value"] {
+        let pattern = format!("\"{}\":", key);
+        if let Some(idx) = json_str.find(&pattern) {
+            let after = &json_str[idx + pattern.len()..];
+            let num_str: String = after
+                .chars()
+                .take_while(|c| c.is_ascii_digit() || *c == '-')
+                .collect();
+            if !num_str.is_empty() {
+                return format!("Rolled: {}", num_str);
+            }
+        }
+    }
+    "Roll completed.".to_string()
+}
+
+// ─── DOM Helpers ────────────────────────────
+
+#[cfg(target_arch = "wasm32")]
+fn set_action_status(msg: &str, class: &str) {
+    let Some(doc) = web_sys::window().and_then(|w| w.document()) else {
+        return;
+    };
+    let Some(el) = doc.get_element_by_id("action-status") else {
+        return;
+    };
+    el.set_text_content(Some(msg));
+    // Reset classes, then add the specified one
+    el.set_class_name(if class.is_empty() { "" } else { class });
+}
+
+#[cfg(target_arch = "wasm32")]
+fn clear_action_status() {
+    set_action_status("", "");
+}
+
+#[cfg(target_arch = "wasm32")]
+fn clear_action_input() {
+    let Some(doc) = web_sys::window().and_then(|w| w.document()) else {
+        return;
+    };
+    if let Some(el) = doc.get_element_by_id("action-input") {
+        if let Some(input) = el.dyn_ref::<web_sys::HtmlInputElement>() {
+            input.set_value("");
+        }
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+fn disable_buttons(disabled: bool) {
+    let Some(doc) = web_sys::window().and_then(|w| w.document()) else {
+        return;
+    };
+    for id in &["action-submit-btn", "dice-roll-btn"] {
+        if let Some(el) = doc.get_element_by_id(id) {
+            if let Some(btn) = el.dyn_ref::<web_sys::HtmlButtonElement>() {
+                btn.set_disabled(disabled);
+            }
+        }
+    }
+}
+
+// ─── Bevy System: Visibility Sync ───────────
+
+/// Hides the action panel when not in TRPG mode.
+/// The panel HTML always exists in index.html but should only be visible in TRPG.
+pub fn sync_action_panel_visibility(mode: Res<State<ViewerMode>>) {
+    let _ = mode; // read to register as system parameter
+
+    #[cfg(target_arch = "wasm32")]
+    {
+        let visible = matches!(mode.get(), ViewerMode::Trpg);
+        let Some(doc) = web_sys::window().and_then(|w| w.document()) else {
+            return;
+        };
+        if let Some(el) = doc.get_element_by_id("action-panel") {
+            if let Some(html_el) = el.dyn_ref::<web_sys::HtmlElement>() {
+                let _ = html_el
+                    .style()
+                    .set_property("display", if visible { "block" } else { "none" });
+            }
+        }
+    }
+}
+
+// ─── Tests ──────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn extract_roll_display_with_total() {
+        let json = r#"{"dice":"1d20","total":17,"rolls":[17]}"#;
+        assert_eq!(extract_roll_display(json), "Rolled: 17");
+    }
+
+    #[test]
+    fn extract_roll_display_with_result() {
+        let json = r#"{"result":4}"#;
+        assert_eq!(extract_roll_display(json), "Rolled: 4");
+    }
+
+    #[test]
+    fn extract_roll_display_with_value() {
+        let json = r#"{"value":20,"critical":true}"#;
+        assert_eq!(extract_roll_display(json), "Rolled: 20");
+    }
+
+    #[test]
+    fn extract_roll_display_fallback() {
+        let json = r#"{"status":"ok"}"#;
+        assert_eq!(extract_roll_display(json), "Roll completed.");
+    }
+
+    #[test]
+    fn extract_roll_display_empty() {
+        assert_eq!(extract_roll_display(""), "Roll completed.");
+    }
+}

--- a/viewer/src/dom/mod.rs
+++ b/viewer/src/dom/mod.rs
@@ -1,3 +1,4 @@
+pub mod action_panel;
 pub mod character_panel;
 pub mod connection;
 pub mod dice_log;
@@ -29,6 +30,10 @@ impl Plugin for DomBridgePlugin {
                 character_panel::update_character_panel_dom,
                 turn_phase::update_turn_phase_dom,
                 connection::update_connection_dom,
-            ).run_if(in_state(ViewerMode::Trpg)));
+                action_panel::sync_action_panel_visibility,
+            ).run_if(in_state(ViewerMode::Trpg)))
+            // Action panel lifecycle: bind listeners on enter, unbind on exit
+            .add_systems(OnEnter(ViewerMode::Trpg), action_panel::bind_action_panel)
+            .add_systems(OnExit(ViewerMode::Trpg), action_panel::unbind_action_panel);
     }
 }

--- a/viewer/style.css
+++ b/viewer/style.css
@@ -1710,3 +1710,95 @@ body.mode-lobby #dashboard {
     background: var(--scrollbar-thumb);
     border-radius: 2px;
 }
+
+/* ═══════════════════════════════════════════
+   TRPG Action Panel
+   ═══════════════════════════════════════════ */
+
+#action-panel {
+    margin-top: 12px;
+    padding: 10px 12px;
+    background: var(--bg-panel-alt);
+    border-top: 1px solid var(--border-main, rgba(196, 162, 101, 0.12));
+    border-radius: 0 0 var(--card-radius, 6px) var(--card-radius, 6px);
+}
+
+#action-input-row {
+    display: flex;
+    gap: 6px;
+    align-items: center;
+}
+
+#action-input {
+    flex: 1;
+    background: var(--bg-deep);
+    border: 1px solid var(--border-main, rgba(196, 162, 101, 0.12));
+    border-radius: var(--card-radius, 6px);
+    color: var(--text-primary);
+    font-family: var(--font-body);
+    font-size: 0.9rem;
+    padding: 8px 12px;
+    outline: none;
+    transition: border-color 0.2s;
+}
+
+#action-input::placeholder {
+    color: var(--text-dim);
+    font-style: italic;
+}
+
+#action-input:focus {
+    border-color: var(--accent-primary-dim);
+}
+
+#action-submit-btn,
+#dice-roll-btn {
+    background: var(--bg-card);
+    border: 1px solid var(--border-highlight, rgba(196, 162, 101, 0.2));
+    border-radius: var(--card-radius, 6px);
+    color: var(--accent-primary);
+    cursor: pointer;
+    font-family: var(--font-ui);
+    font-size: 0.8rem;
+    padding: 8px 16px;
+    transition: background 0.2s, color 0.2s;
+    white-space: nowrap;
+}
+
+#action-submit-btn:hover,
+#dice-roll-btn:hover {
+    background: var(--accent-glow);
+    color: var(--text-bright);
+}
+
+#action-submit-btn:disabled,
+#dice-roll-btn:disabled {
+    opacity: 0.4;
+    cursor: not-allowed;
+}
+
+#dice-roll-btn {
+    border-color: var(--accent-tertiary, #4a3f8a);
+    color: var(--accent-tertiary, #4a3f8a);
+}
+
+#dice-roll-btn:hover {
+    background: rgba(74, 63, 138, 0.15);
+}
+
+#action-status {
+    margin-top: 6px;
+    font-size: 0.75rem;
+    font-family: var(--font-ui);
+    color: var(--text-dim);
+    min-height: 1.2em;
+    transition: color 0.3s;
+}
+
+#action-status.status-ok {
+    color: var(--accent-primary);
+}
+
+#action-status.status-error {
+    color: var(--accent-secondary, #8b2500);
+}


### PR DESCRIPTION
## Summary
- TRPG Viewer에서 플레이어 행동 제출 및 주사위 굴리기 지원 (첫 upstream 기능)
- `web_dashboard.ml`에서 Rust/WASM Viewer로 TRPG 조작 이관의 시작점
- 서버 변경 없음 — 기존 REST endpoints (`/api/v1/trpg/events`, `/api/v1/trpg/dice/roll`) 활용

## Changes
| File | Description |
|------|-------------|
| `viewer/index.html` | Action panel HTML (input, submit btn, dice btn, status) |
| `viewer/style.css` | Dark-fantasy themed action panel styling |
| `viewer/src/dom/action_panel.rs` | DOM event binding + async HTTP fetch via wasm-bindgen |
| `viewer/src/dom/mod.rs` | Module registration + Bevy system scheduling |
| `viewer/Cargo.toml` | Added `HtmlButtonElement` web-sys feature |

## Architecture
```
[#action-input] → Submit btn / Enter key
    → Closure::wrap + spawn_local
    → fetch POST /api/v1/trpg/events
    → status feedback in #action-status

[#dice-roll-btn] → Closure::wrap + spawn_local
    → fetch POST /api/v1/trpg/dice/roll
    → parse JSON → display result
```

## Test plan
- [x] `cargo check --target wasm32-unknown-unknown` — passes
- [x] `cargo test action_panel` — 5/5 tests pass (extract_roll_display)
- [ ] `make viewer-serve` → browser action panel rendering
- [ ] Submit action → server log receives event
- [ ] Dice roll → server log receives roll + result displayed

Generated with [Claude Code](https://claude.com/claude-code)