### PR TITLE
fix: complete TRPG viewer progress + dashboard mapping integration

### DIFF
--- a/lib/web_dashboard.ml
+++ b/lib/web_dashboard.ml
@@ -7200,15 +7200,17 @@ let cached_html = lazy ({|<!DOCTYPE html>
         trpgSetNextAction('wait', '세션 준비 중', '파티 actor_id를 아직 확인하지 못했습니다. 1) 세션 시작을 다시 실행하세요.', false);
         return;
       }
-      const parsed = parseTrpgPlayerKeepers(String((document.getElementById('trpg-player-keepers-input') || {}).value || ''));
-      if (!parsed.ok) {
+      const resolved = trpgResolvePlayerKeeperMapping(
+        state,
+        viewEvents,
+        String((document.getElementById('trpg-player-keepers-input') || {}).value || '')
+      );
+      if (!resolved.ok) {
         trpgSetNextAction('wait', '입력 수정 필요', 'Player keepers 입력 형식 오류를 먼저 해결하세요.', false);
         return;
       }
-      const expectedSet = new Set(expectedActors);
-      const inputActors = Object.keys(parsed.mapping || {});
-      const missingActors = expectedActors.filter((actor) => !inputActors.includes(actor));
-      const unknownActors = inputActors.filter((actor) => !expectedSet.has(actor));
+      const missingActors = resolved.missingActors || [];
+      const unknownActors = resolved.unknownActors || [];
       if (missingActors.length > 0 || unknownActors.length > 0) {
         trpgSetNextAction(
           'wait',
@@ -7217,6 +7219,14 @@ let cached_html = lazy ({|<!DOCTYPE html>
           false
         );
         return;
+      }
+
+      if ((resolved.renamed || []).length > 0) {
+        const input = document.getElementById('trpg-player-keepers-input');
+        if (input) {
+          input.value = playerKeeperMapToText(resolved.mapping || {});
+          trpgSyncKeeperSelectorsFromInputs();
+        }
       }
       trpgSetNextAction('run_round', '다음 라운드 실행', '준비 완료. 다음 라운드를 실행해 서사를 진행하세요.', true);
     }
@@ -7260,6 +7270,121 @@ let cached_html = lazy ({|<!DOCTYPE html>
         if (actors.length > 0) return actors;
       }
       return [];
+    }
+
+    function trpgPartyActorAliasMap(state, events) {
+      const aliases = {};
+      const put = (aliasRaw, actorRaw) => {
+        const alias = String(aliasRaw || '').trim().toLowerCase();
+        const actorId = String(actorRaw || '').trim();
+        if (!alias || !actorId) return;
+        if (!Object.prototype.hasOwnProperty.call(aliases, alias)) {
+          aliases[alias] = actorId;
+        }
+      };
+
+      const partyObj =
+        state && state.party && typeof state.party === 'object' && !Array.isArray(state.party)
+          ? state.party
+          : null;
+      if (partyObj) {
+        Object.entries(partyObj).forEach(([actorId, infoRaw]) => {
+          const actor = String(actorId || '').trim();
+          if (!actor) return;
+          const info = (infoRaw && typeof infoRaw === 'object' && !Array.isArray(infoRaw)) ? infoRaw : {};
+          put(actor, actor);
+          put(info.actor_id, actor);
+          put(info.name, actor);
+        });
+      } else {
+        for (let i = (events || []).length - 1; i >= 0; i -= 1) {
+          const ev = events[i];
+          if (trpgEventType(ev) !== 'party.selected') continue;
+          const payload = trpgEventPayload(ev);
+          const party = Array.isArray(payload.party) ? payload.party : [];
+          party.forEach((member) => {
+            const actor = String((member && member.actor_id) || '').trim();
+            if (!actor) return;
+            put(actor, actor);
+            put((member && member.name) || '', actor);
+          });
+          break;
+        }
+      }
+      return aliases;
+    }
+
+    function trpgResolvePlayerKeeperMapping(state, events, rawText) {
+      const parsed = parseTrpgPlayerKeepers(rawText);
+      if (!parsed.ok) {
+        return {
+          ok: false,
+          error: parsed.error || 'invalid player keeper mapping',
+          mapping: {},
+          expectedActors: [],
+          unknownActors: [],
+          missingActors: [],
+          renamed: [],
+        };
+      }
+
+      const expectedActors = trpgPartyActorsFromStateOrEvents(state, events);
+      if (expectedActors.length === 0) {
+        return {
+          ok: true,
+          mapping: parsed.mapping,
+          expectedActors: [],
+          unknownActors: [],
+          missingActors: [],
+          renamed: [],
+        };
+      }
+
+      const expectedSet = new Set(expectedActors);
+      const aliasMap = trpgPartyActorAliasMap(state, events);
+      const mapping = {};
+      const unknownActors = [];
+      const renamed = [];
+
+      Object.entries(parsed.mapping || {}).forEach(([rawActor, keeperNameRaw]) => {
+        const originalActor = String(rawActor || '').trim();
+        const keeperName = String(keeperNameRaw || '').trim();
+        if (!originalActor || !keeperName) return;
+
+        let actorId = originalActor;
+        if (!expectedSet.has(actorId)) {
+          const aliasKey = originalActor.toLowerCase();
+          if (Object.prototype.hasOwnProperty.call(aliasMap, aliasKey)) {
+            actorId = aliasMap[aliasKey];
+          }
+        }
+
+        if (!expectedSet.has(actorId)) {
+          unknownActors.push(originalActor);
+          return;
+        }
+        if (Object.prototype.hasOwnProperty.call(mapping, actorId)) {
+          unknownActors.push(originalActor);
+          return;
+        }
+
+        mapping[actorId] = keeperName;
+        if (originalActor !== actorId) {
+          renamed.push([originalActor, actorId]);
+        }
+      });
+
+      const missingActors = expectedActors.filter(
+        (actorId) => !Object.prototype.hasOwnProperty.call(mapping, actorId)
+      );
+      return {
+        ok: true,
+        mapping,
+        expectedActors,
+        unknownActors: trpgUniqueStrings(unknownActors),
+        missingActors,
+        renamed,
+      };
     }
 
     function trpgBuildSessionHistory(events) {
@@ -7613,7 +7738,22 @@ let cached_html = lazy ({|<!DOCTYPE html>
           .filter((name) => name !== '' && name !== dmKeeper)
       );
       if (playerInput && selectedPlayers.length > 0) {
-        playerInput.value = selectedPlayers.map((name) => `${name}=${name}`).join('\n');
+        const sessionEvents = trpgCurrentSessionEvents(trpgEventsCache);
+        const expectedActors = trpgPartyActorsFromStateOrEvents(trpgStateCache, sessionEvents);
+        if (expectedActors.length > 0) {
+          const existingParsed = parseTrpgPlayerKeepers(String(playerInput.value || ''));
+          const existingMap = existingParsed.ok ? existingParsed.mapping : {};
+          const nextMap = {};
+          expectedActors.forEach((actorId, idx) => {
+            const keeper =
+              String(selectedPlayers[idx] || '').trim()
+              || String(existingMap[actorId] || '').trim();
+            if (keeper) nextMap[actorId] = keeper;
+          });
+          playerInput.value = playerKeeperMapToText(nextMap);
+        } else {
+          playerInput.value = selectedPlayers.map((name) => `${name}=${name}`).join('\n');
+        }
       }
 
       trpgSyncKeeperSelectorsFromInputs();
@@ -8536,7 +8676,14 @@ let cached_html = lazy ({|<!DOCTYPE html>
         setTrpgRoundRunStatus('오류: ' + escapeHtml(parsedPlayers.error || 'invalid player_keepers'), 'error');
         return;
       }
-      const playerKeeperNames = Object.values(parsedPlayers.mapping || {})
+      const sessionEvents = trpgCurrentSessionEvents(trpgEventsCache);
+      const resolvedPlayers = trpgResolvePlayerKeeperMapping(trpgStateCache, sessionEvents, playerRaw);
+      if (!resolvedPlayers.ok) {
+        setTrpgRoundRunStatus('오류: ' + escapeHtml(resolvedPlayers.error || 'invalid player_keepers'), 'error');
+        return;
+      }
+      const playerMapping = resolvedPlayers.mapping || parsedPlayers.mapping || {};
+      const playerKeeperNames = Object.values(playerMapping || {})
         .map((name) => String(name || '').trim())
         .filter((name) => name !== '');
       if (playerKeeperNames.includes(dmKeeper)) {
@@ -8546,16 +8693,10 @@ let cached_html = lazy ({|<!DOCTYPE html>
         );
         return;
       }
-      const expectedActors = trpgPartyActorsFromStateOrEvents(
-        trpgStateCache,
-        trpgCurrentSessionEvents(trpgEventsCache)
-      );
+      const expectedActors = resolvedPlayers.expectedActors || [];
       if (expectedActors.length > 0) {
-        const expectedSet = new Set(expectedActors);
-        const inputActors = Object.keys(parsedPlayers.mapping || {});
-        const inputSet = new Set(inputActors);
-        const unknownActors = inputActors.filter((actor) => !expectedSet.has(actor));
-        const missingActors = expectedActors.filter((actor) => !inputSet.has(actor));
+        const unknownActors = resolvedPlayers.unknownActors || [];
+        const missingActors = resolvedPlayers.missingActors || [];
         if (unknownActors.length > 0 || missingActors.length > 0) {
           const unknownText = unknownActors.length > 0 ? `입력만 존재: ${unknownActors.join(', ')}` : '-';
           const missingText = missingActors.length > 0 ? `누락: ${missingActors.join(', ')}` : '-';
@@ -8569,7 +8710,15 @@ let cached_html = lazy ({|<!DOCTYPE html>
         }
       }
 
-      const participantCount = 1 + Object.keys(parsedPlayers.mapping || {}).length;
+      if ((resolvedPlayers.renamed || []).length > 0) {
+        const playerInput = document.getElementById('trpg-player-keepers-input');
+        if (playerInput) {
+          playerInput.value = playerKeeperMapToText(playerMapping);
+          trpgSyncKeeperSelectorsFromInputs();
+        }
+      }
+
+      const participantCount = 1 + Object.keys(playerMapping || {}).length;
       const estimatedMaxSec = Math.max(1, Math.ceil(timeoutSec * participantCount));
       let roundDone = false;
       let pollInFlight = false;
@@ -8605,7 +8754,7 @@ let cached_html = lazy ({|<!DOCTYPE html>
         const body = {
           room_id: roomId,
           dm_keeper: dmKeeper,
-          player_keepers: parsedPlayers.mapping,
+          player_keepers: playerMapping,
           phase,
           timeout_sec: timeoutSec,
           lang,
@@ -8859,10 +9008,11 @@ let cached_html = lazy ({|<!DOCTYPE html>
     function renderTrpgPartyAssignment(state, events) {
       const el = document.getElementById('trpg-party-assignment');
       if (!el) return;
-      const expectedActors = trpgPartyActorsFromStateOrEvents(state, events);
       const inputRaw = String((document.getElementById('trpg-player-keepers-input') || {}).value || '');
+      const resolved = trpgResolvePlayerKeeperMapping(state, events, inputRaw);
+      const expectedActors = resolved.expectedActors || trpgPartyActorsFromStateOrEvents(state, events);
       const parsed = parseTrpgPlayerKeepers(inputRaw);
-      const mapping = parsed.ok ? parsed.mapping : {};
+      const mapping = resolved.ok ? resolved.mapping : {};
       const assignedActors = Object.keys(mapping);
       const actorSet = new Set(expectedActors);
       const keeperUse = {};
@@ -8874,8 +9024,13 @@ let cached_html = lazy ({|<!DOCTYPE html>
       });
       const duplicateKeepers = Object.entries(keeperUse).filter(([, actors]) => actors.length > 1);
 
-      const unknownActors = assignedActors.filter((actor) => !actorSet.has(actor));
-      const missingActors = expectedActors.filter((actor) => !Object.prototype.hasOwnProperty.call(mapping, actor));
+      const unknownActors = resolved.ok
+        ? (resolved.unknownActors || [])
+        : assignedActors.filter((actor) => !actorSet.has(actor));
+      const missingActors = resolved.ok
+        ? (resolved.missingActors || [])
+        : expectedActors.filter((actor) => !Object.prototype.hasOwnProperty.call(mapping, actor));
+      const renamedRows = resolved.ok ? (resolved.renamed || []) : [];
 
       const rows = [];
       if (!parsed.ok) {
@@ -8925,6 +9080,14 @@ let cached_html = lazy ({|<!DOCTYPE html>
           <div class="trpg-round-item mismatch">
             <div class="meta">${escapeHtml(actor)}</div>
             <div>파티에 없는 actor_id 입니다. (현재 입력만 존재)</div>
+          </div>
+        `);
+      });
+      renamedRows.forEach(([fromActor, toActor]) => {
+        rows.push(`
+          <div class="trpg-round-item">
+            <div class="meta">정규화</div>
+            <div>${escapeHtml(String(fromActor || ''))} → ${escapeHtml(String(toActor || ''))}</div>
           </div>
         `);
       });

--- a/viewer/index.html
+++ b/viewer/index.html
@@ -193,6 +193,7 @@
                             <div class="phase" data-phase="transition">Move</div>
                         </div>
                     </div>
+                    <div id="turn-runtime" class="turn-runtime"></div>
                     <div id="narrative-log"></div>
                     <!-- Action Panel: player input for TRPG actions -->
                     <div id="action-panel">

--- a/viewer/src/config.rs
+++ b/viewer/src/config.rs
@@ -6,6 +6,7 @@
 //!
 //! The Lobby mode has no SSE connection — it's a pure UI state.
 
+#[cfg(target_arch = "wasm32")]
 use crate::mode::ViewerMode;
 
 /// Legacy TRPG Engine server (FastAPI + SQLite event store).

--- a/viewer/src/config.rs
+++ b/viewer/src/config.rs
@@ -61,7 +61,7 @@ pub fn current_room_id() -> String {
     DEFAULT_ROOM_ID.to_string()
 }
 
-#[cfg(target_arch = "wasm32")]
+#[allow(dead_code)]
 pub fn trpg_uses_polling() -> bool {
     matches!(TRPG_BACKEND_MODE, TrpgBackendMode::MascApi)
 }

--- a/viewer/src/dom/mod.rs
+++ b/viewer/src/dom/mod.rs
@@ -3,6 +3,7 @@ pub mod character_panel;
 pub mod connection;
 pub mod dice_log;
 pub mod narrative;
+pub mod turn_runtime;
 pub mod turn_phase;
 
 use bevy::prelude::*;
@@ -22,6 +23,7 @@ impl Plugin for DomBridgePlugin {
             // DOM caches for change detection (inert when unused)
             .init_resource::<character_panel::CharacterPanelCache>()
             .init_resource::<turn_phase::TurnPhaseCache>()
+            .init_resource::<turn_runtime::TurnRuntimeCache>()
             .init_resource::<connection::ConnectionStatusCache>()
             .add_systems(OnEnter(ViewerMode::Trpg), reset_trpg_dom_state)
             // TRPG-specific DOM update systems
@@ -30,6 +32,7 @@ impl Plugin for DomBridgePlugin {
                 dice_log::update_dice_log_dom,
                 character_panel::update_character_panel_dom,
                 turn_phase::update_turn_phase_dom,
+                turn_runtime::update_turn_runtime_dom,
                 connection::update_connection_dom,
                 action_panel::sync_action_panel_visibility,
             ).run_if(in_state(ViewerMode::Trpg)))
@@ -72,11 +75,13 @@ fn reset_trpg_dom_state(
 fn reset_trpg_dom_state(
     mut character_cache: ResMut<character_panel::CharacterPanelCache>,
     mut turn_cache: ResMut<turn_phase::TurnPhaseCache>,
+    mut runtime_cache: ResMut<turn_runtime::TurnRuntimeCache>,
     mut connection_cache: ResMut<connection::ConnectionStatusCache>,
 ) {
     character_cache.last_snapshot.clear();
     turn_cache.last_turn = 0;
     turn_cache.last_phase.clear();
+    runtime_cache.last_snapshot.clear();
     connection_cache.last_status.clear();
 
     #[cfg(target_arch = "wasm32")]
@@ -95,6 +100,9 @@ fn reset_trpg_dom_state(
         }
         if let Some(el) = document.get_element_by_id("turn-num") {
             el.set_text_content(Some("1"));
+        }
+        if let Some(el) = document.get_element_by_id("turn-runtime") {
+            el.set_inner_html("");
         }
     }
 }

--- a/viewer/src/dom/mod.rs
+++ b/viewer/src/dom/mod.rs
@@ -45,36 +45,6 @@ impl Plugin for DomBridgePlugin {
 fn reset_trpg_dom_state(
     mut character_cache: ResMut<character_panel::CharacterPanelCache>,
     mut turn_cache: ResMut<turn_phase::TurnPhaseCache>,
-    mut connection_cache: ResMut<connection::ConnectionStatusCache>,
-) {
-    character_cache.last_snapshot.clear();
-    turn_cache.last_turn = 0;
-    turn_cache.last_phase.clear();
-    connection_cache.last_status.clear();
-
-    #[cfg(target_arch = "wasm32")]
-    {
-        let Some(document) = web_sys::window().and_then(|w| w.document()) else {
-            return;
-        };
-        if let Some(el) = document.get_element_by_id("narrative-log") {
-            el.set_inner_html("");
-        }
-        if let Some(el) = document.get_element_by_id("dice-log") {
-            el.set_inner_html("");
-        }
-        if let Some(el) = document.get_element_by_id("character-panel") {
-            el.set_inner_html("");
-        }
-        if let Some(el) = document.get_element_by_id("turn-num") {
-            el.set_text_content(Some("1"));
-        }
-    }
-}
-
-fn reset_trpg_dom_state(
-    mut character_cache: ResMut<character_panel::CharacterPanelCache>,
-    mut turn_cache: ResMut<turn_phase::TurnPhaseCache>,
     mut runtime_cache: ResMut<turn_runtime::TurnRuntimeCache>,
     mut connection_cache: ResMut<connection::ConnectionStatusCache>,
 ) {

--- a/viewer/src/dom/mod.rs
+++ b/viewer/src/dom/mod.rs
@@ -68,3 +68,33 @@ fn reset_trpg_dom_state(
         }
     }
 }
+
+fn reset_trpg_dom_state(
+    mut character_cache: ResMut<character_panel::CharacterPanelCache>,
+    mut turn_cache: ResMut<turn_phase::TurnPhaseCache>,
+    mut connection_cache: ResMut<connection::ConnectionStatusCache>,
+) {
+    character_cache.last_snapshot.clear();
+    turn_cache.last_turn = 0;
+    turn_cache.last_phase.clear();
+    connection_cache.last_status.clear();
+
+    #[cfg(target_arch = "wasm32")]
+    {
+        let Some(document) = web_sys::window().and_then(|w| w.document()) else {
+            return;
+        };
+        if let Some(el) = document.get_element_by_id("narrative-log") {
+            el.set_inner_html("");
+        }
+        if let Some(el) = document.get_element_by_id("dice-log") {
+            el.set_inner_html("");
+        }
+        if let Some(el) = document.get_element_by_id("character-panel") {
+            el.set_inner_html("");
+        }
+        if let Some(el) = document.get_element_by_id("turn-num") {
+            el.set_text_content(Some("1"));
+        }
+    }
+}

--- a/viewer/src/dom/turn_runtime.rs
+++ b/viewer/src/dom/turn_runtime.rs
@@ -1,0 +1,167 @@
+use bevy::prelude::*;
+
+use crate::game::components::Actor;
+use crate::game::state::{RoomState, TurnProgressState};
+
+/// Tracks last-rendered runtime status snapshot to avoid redundant DOM updates.
+#[derive(Resource, Default)]
+pub struct TurnRuntimeCache {
+    pub last_snapshot: String,
+}
+
+#[cfg(target_arch = "wasm32")]
+fn sanitize_text(raw: &str) -> String {
+    raw.chars()
+        .filter(|c| *c != '<' && *c != '>' && *c != '"')
+        .collect::<String>()
+}
+
+#[cfg(target_arch = "wasm32")]
+fn pretty_phase(phase: &str) -> String {
+    let normalized = phase.trim().replace('_', " ");
+    if normalized.is_empty() {
+        "-".to_string()
+    } else {
+        normalized
+    }
+}
+
+/// Render live TRPG runtime progress:
+/// room/turn/phase, current thinker, next actor, last outcome, and party survival.
+pub fn update_turn_runtime_dom(
+    room_state: Res<RoomState>,
+    progress: Res<TurnProgressState>,
+    actors: Query<&Actor>,
+    mut cache: ResMut<TurnRuntimeCache>,
+) {
+    let room_status = if !progress.room_status.trim().is_empty() {
+        progress.room_status.trim().to_string()
+    } else if !room_state.status.trim().is_empty() {
+        room_state.status.trim().to_string()
+    } else {
+        "unknown".to_string()
+    };
+    let turn = if progress.turn > 0 {
+        progress.turn
+    } else if room_state.turn > 0 {
+        room_state.turn
+    } else {
+        1
+    };
+    let phase = if !progress.phase.trim().is_empty() {
+        progress.phase.trim().to_string()
+    } else {
+        room_state.phase.as_str().to_string()
+    };
+
+    let current_actor = if !progress.current_actor.trim().is_empty() {
+        progress.current_actor.trim().to_string()
+    } else {
+        "-".to_string()
+    };
+    let next_actor = if !progress.next_actor.trim().is_empty() {
+        progress.next_actor.trim().to_string()
+    } else {
+        "-".to_string()
+    };
+    let last_result = if !progress.last_actor.trim().is_empty() {
+        format!(
+            "{} ({})",
+            progress.last_actor.trim(),
+            if progress.last_result.trim().is_empty() {
+                "ok"
+            } else {
+                progress.last_result.trim()
+            }
+        )
+    } else {
+        "-".to_string()
+    };
+
+    let (alive_party, total_party) = actors
+        .iter()
+        .filter(|actor| actor.id != "dm")
+        .fold((0_i32, 0_i32), |(alive, total), actor| {
+            (
+                alive + if !actor.is_dead && actor.hp > 0 { 1 } else { 0 },
+                total + 1,
+            )
+        });
+    let party_status = if total_party <= 0 {
+        "-".to_string()
+    } else if alive_party <= 0 {
+        "WIPE".to_string()
+    } else {
+        format!("{}/{} alive", alive_party, total_party)
+    };
+
+    let current_status = if current_actor != "-" {
+        "thinking"
+    } else if room_status == "ended" {
+        "ended"
+    } else {
+        "idle"
+    };
+
+    let snapshot = format!(
+        "{}|{}|{}|{}|{}|{}|{}|{}",
+        room_status,
+        turn,
+        phase,
+        current_actor,
+        next_actor,
+        last_result,
+        party_status,
+        current_status
+    );
+    if cache.last_snapshot == snapshot {
+        return;
+    }
+    cache.last_snapshot = snapshot;
+
+    #[cfg(target_arch = "wasm32")]
+    {
+        let Some(document) = web_sys::window().and_then(|w| w.document()) else {
+            return;
+        };
+        let Some(el) = document.get_element_by_id("turn-runtime") else {
+            return;
+        };
+
+        let room_class = match room_status.as_str() {
+            "ended" => "status-ended",
+            "active" => "status-active",
+            _ => "status-idle",
+        };
+        let party_class = if total_party > 0 && alive_party <= 0 {
+            "status-wipe"
+        } else {
+            "status-active"
+        };
+
+        let html = format!(
+            r#"
+<div class="turn-runtime-grid">
+  <div class="turn-runtime-item"><span class="k">Room</span><span class="v {room_class}">{room}</span></div>
+  <div class="turn-runtime-item"><span class="k">Turn</span><span class="v">{turn}</span></div>
+  <div class="turn-runtime-item"><span class="k">Phase</span><span class="v">{phase}</span></div>
+  <div class="turn-runtime-item"><span class="k">Now</span><span class="v">{current} · {current_status}</span></div>
+  <div class="turn-runtime-item"><span class="k">Next</span><span class="v">{next}</span></div>
+  <div class="turn-runtime-item"><span class="k">Last</span><span class="v">{last}</span></div>
+  <div class="turn-runtime-item"><span class="k">Party</span><span class="v {party_class}">{party}</span></div>
+</div>
+"#,
+            room_class = room_class,
+            room = sanitize_text(&room_status.to_uppercase()),
+            turn = turn,
+            phase = sanitize_text(&pretty_phase(&phase)),
+            current = sanitize_text(&current_actor),
+            current_status = sanitize_text(current_status),
+            next = sanitize_text(&next_actor),
+            last = sanitize_text(&last_result),
+            party_class = party_class,
+            party = sanitize_text(&party_status),
+        );
+        el.set_inner_html(&html);
+    }
+}

--- a/viewer/src/game/events.rs
+++ b/viewer/src/game/events.rs
@@ -87,6 +87,31 @@ pub struct MoodChangePayload {
     pub mood: String,
 }
 
+#[derive(Debug, Clone, Deserialize)]
+pub struct TurnProgressPayload {
+    pub event_type: String,
+    #[serde(default)]
+    pub turn: u32,
+    #[serde(default)]
+    pub phase: String,
+    #[serde(default)]
+    pub actor_id: String,
+    #[serde(default)]
+    pub keeper: String,
+    #[serde(default)]
+    #[allow(dead_code)]
+    pub role: String,
+    #[serde(default)]
+    #[allow(dead_code)]
+    pub reason: String,
+    #[serde(default)]
+    pub room_status: String,
+    #[serde(default)]
+    pub dm_keeper: String,
+    #[serde(default)]
+    pub selected_player_ids: Vec<String>,
+}
+
 // ─── Bevy Events ──────────────────────────
 
 #[derive(Message, Debug, Clone)]
@@ -124,3 +149,6 @@ pub struct WeatherChanged(pub WeatherChangePayload);
 
 #[derive(Message, Debug, Clone)]
 pub struct MoodChanged(pub MoodChangePayload);
+
+#[derive(Message, Debug, Clone)]
+pub struct TurnProgressUpdated(pub TurnProgressPayload);

--- a/viewer/src/game/http.rs
+++ b/viewer/src/game/http.rs
@@ -8,7 +8,7 @@ use wasm_bindgen_futures::JsFuture;
 
 use crate::config;
 use crate::game::components::{Actor, Stats};
-use crate::game::state::{MapState, RoomState, TurnPhase};
+use crate::game::state::{MapState, RoomState, TurnPhase, TurnProgressState};
 
 // ─── Expected API Response Types ─────────────
 
@@ -149,6 +149,7 @@ pub fn refresh_state_on_room_change(
     actors: Query<Entity, With<Actor>>,
     mut room_state: ResMut<RoomState>,
     mut map_state: ResMut<MapState>,
+    mut turn_progress: ResMut<TurnProgressState>,
 ) {
     let current_room = config::current_room_id();
     if active_room.room_id == current_room {
@@ -164,6 +165,8 @@ pub fn refresh_state_on_room_change(
     *room_state = RoomState::default();
     room_state.id = current_room.clone();
     *map_state = MapState::default();
+    *turn_progress = TurnProgressState::default();
+    turn_progress.room_status = "loading".to_string();
 
     queue_initial_state_fetch(&mut commands);
     log::info!("TRPG room changed — reloading state for room {}", current_room);
@@ -176,6 +179,7 @@ pub fn apply_initial_state(
     mut buffer: ResMut<InitialStateBuffer>,
     mut room_state: ResMut<RoomState>,
     mut map_state: ResMut<MapState>,
+    mut turn_progress: ResMut<TurnProgressState>,
 ) {
     if buffer.consumed {
         return;
@@ -192,6 +196,12 @@ pub fn apply_initial_state(
         return;
     };
 
+    let actor_ids: Vec<String> = state
+        .characters
+        .iter()
+        .map(|ch| ch.id.clone())
+        .collect();
+
     // Apply room state
     if let Some(room) = state.room {
         room_state.id = room.id;
@@ -201,6 +211,34 @@ pub fn apply_initial_state(
         room_state.current_scenario = room.current_scenario;
         room_state.current_node = room.current_node;
     }
+
+    turn_progress.room_status = room_state.status.clone();
+    turn_progress.turn = room_state.turn;
+    turn_progress.phase = room_state.phase.as_str().to_string();
+    turn_progress.player_order = actor_ids
+        .iter()
+        .filter(|id| id.as_str() != "dm")
+        .cloned()
+        .collect();
+    let player_order = turn_progress.player_order.clone();
+    turn_progress.actor_order.clear();
+    turn_progress.actor_order.push("dm".to_string());
+    for actor_id in &player_order {
+        if actor_id != "dm" && !turn_progress.actor_order.iter().any(|id| id == actor_id) {
+            turn_progress.actor_order.push(actor_id.clone());
+        }
+    }
+    turn_progress.actor_states.clear();
+    let actor_order = turn_progress.actor_order.clone();
+    for actor_id in &actor_order {
+        turn_progress
+            .actor_states
+            .insert(actor_id.clone(), "pending".to_string());
+    }
+    turn_progress.current_actor.clear();
+    turn_progress.next_actor.clear();
+    turn_progress.last_actor.clear();
+    turn_progress.last_result.clear();
 
     // Apply map state
     if !state.current_area.is_empty() {

--- a/viewer/src/game/mod.rs
+++ b/viewer/src/game/mod.rs
@@ -24,6 +24,7 @@ impl Plugin for GameStatePlugin {
             .init_resource::<MapState>()
             .init_resource::<ConnectionStatus>()
             .init_resource::<OverlayState>()
+            .init_resource::<TurnProgressState>()
             .init_resource::<http::ActiveTrpgRoom>()
             // Events (type registrations — always available)
             .add_message::<DiceRolled>()
@@ -38,14 +39,19 @@ impl Plugin for GameStatePlugin {
             .add_message::<CombatStarted>()
             .add_message::<WeatherChanged>()
             .add_message::<MoodChanged>()
+            .add_message::<TurnProgressUpdated>()
             // ── TRPG-gated systems ──
-            .add_systems(OnEnter(ViewerMode::Trpg), http::fetch_initial_state)
+            .add_systems(
+                OnEnter(ViewerMode::Trpg),
+                (systems::reset_turn_progress, http::fetch_initial_state),
+            )
             .add_systems(Update, (
                 http::refresh_state_on_room_change,
                 http::apply_initial_state,
                 systems::apply_hp_change,
                 systems::apply_area_move,
                 systems::apply_turn_advance,
+                systems::apply_turn_progress,
                 systems::apply_item_acquired,
                 systems::apply_character_death,
                 systems::apply_weather_change,

--- a/viewer/src/game/state.rs
+++ b/viewer/src/game/state.rs
@@ -1,4 +1,5 @@
 use bevy::prelude::*;
+use std::collections::BTreeMap;
 
 /// Turn phases as defined in engine.json.
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
@@ -72,4 +73,21 @@ pub enum ConnectionStatus {
     Disconnected,
     Connecting,
     Connected,
+}
+
+/// Runtime progress derived from TRPG stream events.
+#[derive(Resource, Debug, Default)]
+pub struct TurnProgressState {
+    pub room_status: String,
+    pub turn: u32,
+    pub phase: String,
+    pub dm_keeper: String,
+    pub player_order: Vec<String>,
+    pub actor_order: Vec<String>,
+    pub actor_states: BTreeMap<String, String>,
+    pub current_actor: String,
+    pub next_actor: String,
+    pub last_actor: String,
+    pub last_result: String,
+    pub last_event: String,
 }

--- a/viewer/src/game/systems.rs
+++ b/viewer/src/game/systems.rs
@@ -4,6 +4,106 @@ use super::components::*;
 use super::events::*;
 use super::state::*;
 
+fn rebuild_actor_order(progress: &mut TurnProgressState) {
+    progress.actor_order.clear();
+    progress.actor_order.push("dm".to_string());
+    for actor_id in &progress.player_order {
+        if actor_id != "dm" && !progress.actor_order.iter().any(|id| id == actor_id) {
+            progress.actor_order.push(actor_id.clone());
+        }
+    }
+}
+
+fn mark_current_and_next(progress: &mut TurnProgressState, actor_index: usize) {
+    progress.current_actor = progress
+        .actor_order
+        .get(actor_index)
+        .cloned()
+        .unwrap_or_default();
+    progress.next_actor = progress
+        .actor_order
+        .get(actor_index.saturating_add(1))
+        .cloned()
+        .unwrap_or_default();
+
+    if !progress.current_actor.is_empty() {
+        progress
+            .actor_states
+            .insert(progress.current_actor.clone(), "thinking".to_string());
+    }
+}
+
+fn reset_round_progress(progress: &mut TurnProgressState) {
+    if progress.actor_order.is_empty() {
+        rebuild_actor_order(progress);
+    }
+    progress.actor_states.clear();
+    for actor_id in &progress.actor_order {
+        progress
+            .actor_states
+            .insert(actor_id.clone(), "pending".to_string());
+    }
+    progress.last_actor.clear();
+    progress.last_result.clear();
+    progress.current_actor.clear();
+    progress.next_actor.clear();
+    if !progress.actor_order.is_empty() {
+        mark_current_and_next(progress, 0);
+    }
+}
+
+fn complete_actor(progress: &mut TurnProgressState, actor_id: &str, result: &str) {
+    let actor_id = actor_id.trim();
+    if actor_id.is_empty() {
+        return;
+    }
+    if progress.actor_order.is_empty() {
+        rebuild_actor_order(progress);
+    }
+
+    progress
+        .actor_states
+        .insert(actor_id.to_string(), result.to_string());
+    progress.last_actor = actor_id.to_string();
+    progress.last_result = result.to_string();
+
+    let actor_index = progress
+        .actor_order
+        .iter()
+        .position(|id| id == actor_id)
+        .or_else(|| {
+            if progress.current_actor.is_empty() {
+                None
+            } else {
+                progress
+                    .actor_order
+                    .iter()
+                    .position(|id| id == &progress.current_actor)
+            }
+        });
+
+    match actor_index {
+        Some(idx) => {
+            let next_idx = idx.saturating_add(1);
+            if next_idx < progress.actor_order.len() {
+                mark_current_and_next(progress, next_idx);
+            } else {
+                progress.current_actor.clear();
+                progress.next_actor.clear();
+            }
+        }
+        None => {
+            progress.current_actor.clear();
+            progress.next_actor.clear();
+        }
+    }
+}
+
+/// Reset runtime turn progress when entering TRPG mode or switching rooms.
+pub fn reset_turn_progress(mut progress: ResMut<TurnProgressState>) {
+    *progress = TurnProgressState::default();
+}
+
 /// Apply HP change events to Actor components.
 pub fn apply_hp_change(
     mut events: MessageReader<HpChanged>,
@@ -46,6 +146,96 @@ pub fn apply_turn_advance(
     for TurnAdvanced(payload) in events.read() {
         room_state.turn = payload.turn;
         room_state.phase = TurnPhase::from_str(&payload.phase);
+    }
+}
+
+/// Apply stream progress events to runtime turn progress state.
+pub fn apply_turn_progress(
+    mut events: MessageReader<TurnProgressUpdated>,
+    mut progress: ResMut<TurnProgressState>,
+    room_state: Res<RoomState>,
+) {
+    for TurnProgressUpdated(payload) in events.read() {
+        if payload.turn > 0 {
+            progress.turn = payload.turn;
+        }
+        if !payload.phase.is_empty() {
+            progress.phase = payload.phase.clone();
+        }
+        if !payload.room_status.is_empty() {
+            progress.room_status = payload.room_status.clone();
+        }
+        if !payload.dm_keeper.is_empty() {
+            progress.dm_keeper = payload.dm_keeper.clone();
+        }
+        if !payload.selected_player_ids.is_empty() {
+            progress.player_order = payload.selected_player_ids.clone();
+            rebuild_actor_order(&mut progress);
+        }
+        if !payload.keeper.is_empty() {
+            let actor_id = payload.actor_id.trim();
+            if !actor_id.is_empty() {
+                progress
+                    .actor_states
+                    .entry(actor_id.to_string())
+                    .or_insert_with(|| "pending".to_string());
+            }
+        }
+
+        progress.last_event = payload.event_type.clone();
+
+        match payload.event_type.as_str() {
+            "phase.changed" => {
+                if progress.phase == "round" {
+                    reset_round_progress(&mut progress);
+                }
+            }
+            "turn.started" => {
+                if payload.turn > 0 {
+                    progress.turn = payload.turn;
+                }
+                progress.current_actor.clear();
+                progress.next_actor.clear();
+            }
+            "narration.posted" => {
+                let actor_id = if payload.actor_id.is_empty() {
+                    "dm"
+                } else {
+                    payload.actor_id.as_str()
+                };
+                complete_actor(&mut progress, actor_id, "ok");
+            }
+            "turn.action.proposed" => {
+                complete_actor(&mut progress, &payload.actor_id, "ok");
+            }
+            "turn.timeout" => {
+                complete_actor(&mut progress, &payload.actor_id, "timeout");
+            }
+            "keeper.unavailable" => {
+                complete_actor(&mut progress, &payload.actor_id, "unavailable");
+            }
+            "room.started" => {
+                if progress.room_status.is_empty() {
+                    progress.room_status = "active".to_string();
+                }
+            }
+            "room.ended" => {
+                progress.room_status = "ended".to_string();
+                progress.current_actor.clear();
+                progress.next_actor.clear();
+            }
+            _ => {}
+        }
+    }
+
+    if progress.turn == 0 {
+        progress.turn = room_state.turn;
+    }
+    if progress.phase.is_empty() {
+        progress.phase = room_state.phase.as_str().to_string();
+    }
+    if progress.room_status.is_empty() {
+        progress.room_status = room_state.status.clone();
     }
 }
 

--- a/viewer/src/sse/bridge.rs
+++ b/viewer/src/sse/bridge.rs
@@ -19,6 +19,7 @@ pub fn poll_sse_events(
     mut combat_events: MessageWriter<CombatStarted>,
     mut weather_events: MessageWriter<WeatherChanged>,
     mut mood_events: MessageWriter<MoodChanged>,
+    mut progress_events: MessageWriter<TurnProgressUpdated>,
     mut connection: ResMut<ConnectionStatus>,
 ) {
     let Some(receiver) = receiver else { return };
@@ -105,6 +106,12 @@ pub fn poll_sse_events(
                 match serde_json::from_str::<MoodChangePayload>(&data) {
                     Ok(payload) => { mood_events.write(MoodChanged(payload)); }
                     Err(e) => log::warn!("Failed to parse mood_change: {}", e),
+                }
+            }
+            "turn_progress" => {
+                match serde_json::from_str::<TurnProgressPayload>(&data) {
+                    Ok(payload) => { progress_events.write(TurnProgressUpdated(payload)); }
+                    Err(e) => log::warn!("Failed to parse turn_progress: {}", e),
                 }
             }
             other => {

--- a/viewer/src/sse/client.rs
+++ b/viewer/src/sse/client.rs
@@ -98,12 +98,96 @@ fn value_to_u32(v: Option<&Value>, default: u32) -> u32 {
         .unwrap_or(default)
 }
 
+fn value_to_string_vec(v: Option<&Value>) -> Vec<String> {
+    match v.and_then(Value::as_array) {
+        Some(xs) => xs
+            .iter()
+            .filter_map(Value::as_str)
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .map(ToString::to_string)
+            .collect(),
+        None => Vec::new(),
+    }
+}
+
+fn resolve_actor_id(payload: &Value, actor_id: Option<&str>) -> String {
+    payload
+        .get("actor_id")
+        .and_then(Value::as_str)
+        .or(actor_id)
+        .unwrap_or("")
+        .to_string()
+}
+
+fn map_turn_progress_event(
+    event_type: &str,
+    actor_id: Option<&str>,
+    payload: &Value,
+    state: &TrpgMapperState,
+) -> Option<(String, String)> {
+    let turn = value_to_u32(payload.get("turn"), state.last_turn);
+    let phase = payload
+        .get("phase")
+        .and_then(Value::as_str)
+        .unwrap_or(&state.last_phase)
+        .to_string();
+
+    let mapped = match event_type {
+        "session.started" => json!({
+            "event_type": event_type,
+            "turn": turn,
+            "phase": phase,
+            "dm_keeper": payload.get("dm_keeper").and_then(Value::as_str).unwrap_or("")
+        }),
+        "party.selected" => json!({
+            "event_type": event_type,
+            "turn": turn,
+            "phase": phase,
+            "selected_player_ids": value_to_string_vec(payload.get("selected_player_ids"))
+        }),
+        "phase.changed" | "turn.started" => json!({
+            "event_type": event_type,
+            "turn": turn,
+            "phase": phase
+        }),
+        "narration.posted" | "turn.action.proposed" | "turn.timeout" | "keeper.unavailable" => {
+            json!({
+                "event_type": event_type,
+                "turn": turn,
+                "phase": phase,
+                "actor_id": resolve_actor_id(payload, actor_id),
+                "keeper": payload.get("keeper").and_then(Value::as_str).unwrap_or(""),
+                "role": payload.get("role").and_then(Value::as_str).unwrap_or(""),
+                "reason": payload.get("reason").and_then(Value::as_str).unwrap_or("")
+            })
+        }
+        "room.started" => json!({
+            "event_type": event_type,
+            "turn": turn,
+            "phase": phase,
+            "room_status": "active"
+        }),
+        "room.ended" => json!({
+            "event_type": event_type,
+            "turn": turn,
+            "phase": phase,
+            "room_status": "ended"
+        }),
+        _ => return None,
+    };
+
+    Some(("turn_progress".to_string(), mapped.to_string()))
+}
+
 fn map_trpg_event(
     event_type: &str,
     actor_id: Option<&str>,
     payload: &Value,
     state: &mut TrpgMapperState,
-) -> Option<(String, String)> {
+) -> Vec<(String, String)> {
+    let mut out = Vec::new();
+
     match event_type {
         "dice.rolled" => {
             let mapped = json!({
@@ -116,7 +200,7 @@ fn map_trpg_event(
                 "dc": value_to_i32(payload.get("dc"), 0),
                 "result": payload.get("label").and_then(Value::as_str).unwrap_or("unknown")
             });
-            Some(("dice_roll".to_string(), mapped.to_string()))
+            out.push(("dice_roll".to_string(), mapped.to_string()));
         }
         "hp.changed" => {
             let mapped = json!({
@@ -125,7 +209,7 @@ fn map_trpg_event(
                 "remaining_hp": value_to_i32(payload.get("remaining_hp"), 0),
                 "source": payload.get("source").and_then(Value::as_str).unwrap_or("system")
             });
-            Some(("hp_change".to_string(), mapped.to_string()))
+            out.push(("hp_change".to_string(), mapped.to_string()));
         }
         "narration.posted" => {
             let text = payload
@@ -139,10 +223,11 @@ fn map_trpg_event(
                 "speaker": payload
                     .get("speaker")
                     .and_then(Value::as_str)
-                    .or_else(|| payload.get("keeper").and_then(Value::as_str))
+                    .or_else(|| payload.get("actor_id").and_then(Value::as_str))
                     .or(actor_id)
+                    .or_else(|| payload.get("keeper").and_then(Value::as_str))
             });
-            Some(("narrative".to_string(), mapped.to_string()))
+            out.push(("narrative".to_string(), mapped.to_string()));
         }
         "turn.action.proposed" => {
             let proposed = payload
@@ -158,7 +243,7 @@ fn map_trpg_event(
                     .and_then(Value::as_str)
                     .or(actor_id)
             });
-            Some(("narrative".to_string(), mapped.to_string()))
+            out.push(("narrative".to_string(), mapped.to_string()));
         }
         "turn.timeout" => {
             let actor = payload
@@ -176,7 +261,7 @@ fn map_trpg_event(
                 "phase": payload.get("phase").and_then(Value::as_str).unwrap_or(&state.last_phase),
                 "speaker": payload.get("keeper").and_then(Value::as_str)
             });
-            Some(("narrative".to_string(), mapped.to_string()))
+            out.push(("narrative".to_string(), mapped.to_string()));
         }
         "keeper.unavailable" => {
             let actor = payload
@@ -193,7 +278,7 @@ fn map_trpg_event(
                 "phase": payload.get("phase").and_then(Value::as_str).unwrap_or(&state.last_phase),
                 "speaker": payload.get("keeper").and_then(Value::as_str)
             });
-            Some(("narrative".to_string(), mapped.to_string()))
+            out.push(("narrative".to_string(), mapped.to_string()));
         }
         "turn.started" => {
             let turn = value_to_u32(payload.get("turn"), state.last_turn);
@@ -212,7 +297,7 @@ fn map_trpg_event(
                 "turn": state.last_turn,
                 "phase": state.last_phase
             });
-            Some(("turn_advance".to_string(), mapped.to_string()))
+            out.push(("turn_advance".to_string(), mapped.to_string()));
         }
         "phase.changed" => {
             let phase = payload
@@ -231,7 +316,7 @@ fn map_trpg_event(
                 "turn": state.last_turn,
                 "phase": state.last_phase
             });
-            Some(("turn_advance".to_string(), mapped.to_string()))
+            out.push(("turn_advance".to_string(), mapped.to_string()));
         }
         "node.advanced" => {
             let mapped = json!({
@@ -239,14 +324,14 @@ fn map_trpg_event(
                 "from_area": payload.get("from_area").and_then(Value::as_str).unwrap_or(""),
                 "to_area": payload.get("to_area").and_then(Value::as_str).unwrap_or(""),
             });
-            Some(("area_move".to_string(), mapped.to_string()))
+            out.push(("area_move".to_string(), mapped.to_string()));
         }
         "inventory.changed" => {
             let mapped = json!({
                 "character": payload.get("character").and_then(Value::as_str).or(actor_id).unwrap_or("unknown"),
                 "item": payload.get("item").and_then(Value::as_str).unwrap_or("item")
             });
-            Some(("item_acquired".to_string(), mapped.to_string()))
+            out.push(("item_acquired".to_string(), mapped.to_string()));
         }
         "turn.action.resolved" => {
             let narrative = payload
@@ -261,10 +346,16 @@ fn map_trpg_event(
                 "phase": state.last_phase,
                 "speaker": actor_id
             });
-            Some(("narrative".to_string(), mapped.to_string()))
+            out.push(("narrative".to_string(), mapped.to_string()));
         }
-        _ => None,
+        _ => {}
     }
+
+    if let Some(progress) = map_turn_progress_event(event_type, actor_id, payload, state) {
+        out.push(progress);
+    }
+
+    out
 }
 
 fn decode_stream_events(
@@ -279,11 +370,12 @@ fn decode_stream_events(
         if ev.seq > max_seq {
             max_seq = ev.seq;
         }
-        if let Some(mapped) =
-            map_trpg_event(&ev.event_type, ev.actor_id.as_deref(), &ev.payload, state)
-        {
-            out.push(mapped);
-        }
+        out.extend(map_trpg_event(
+            &ev.event_type,
+            ev.actor_id.as_deref(),
+            &ev.payload,
+            state,
+        ));
     }
 
     Ok((max_seq, out))
@@ -476,16 +568,28 @@ mod tests {
             decode_stream_events(body, &mut state).expect("decode should succeed");
 
         assert_eq!(max_seq, 3);
-        assert_eq!(mapped.len(), 3);
-        assert_eq!(mapped[0].0, "turn_advance");
-        assert_eq!(mapped[1].0, "turn_advance");
-        assert_eq!(mapped[2].0, "dice_roll");
+        let turn_events: Vec<&(String, String)> = mapped
+            .iter()
+            .filter(|(event_type, _)| event_type == "turn_advance")
+            .collect();
+        assert_eq!(turn_events.len(), 2);
+        let dice_event = mapped
+            .iter()
+            .find(|(event_type, _)| event_type == "dice_roll")
+            .expect("dice_roll should exist");
+        let progress_events: Vec<&(String, String)> = mapped
+            .iter()
+            .filter(|(event_type, _)| event_type == "turn_progress")
+            .collect();
+        assert_eq!(progress_events.len(), 2);
 
-        let turn_payload: Value = serde_json::from_str(&mapped[1].1).expect("turn payload json");
+        let turn_payload: Value =
+            serde_json::from_str(&turn_events[1].1).expect("turn payload json");
         assert_eq!(turn_payload["turn"], 3);
         assert_eq!(turn_payload["phase"], "player_action");
 
-        let dice_payload: Value = serde_json::from_str(&mapped[2].1).expect("dice payload json");
+        let dice_payload: Value =
+            serde_json::from_str(&dice_event.1).expect("dice payload json");
         assert_eq!(dice_payload["character"], "grimja");
         assert_eq!(dice_payload["d20"], 17);
     }
@@ -499,10 +603,13 @@ mod tests {
         }"#;
         let mut state = TrpgMapperState::default();
         let (_, mapped) = decode_stream_events(body, &mut state).expect("decode should succeed");
-        assert_eq!(mapped.len(), 1);
-        assert_eq!(mapped[0].0, "narrative");
+        let narrative_event = mapped
+            .iter()
+            .find(|(event_type, _)| event_type == "narrative")
+            .expect("narrative should exist");
 
-        let payload: Value = serde_json::from_str(&mapped[0].1).expect("narrative payload json");
+        let payload: Value =
+            serde_json::from_str(&narrative_event.1).expect("narrative payload json");
         assert_eq!(payload["text"], "문이 열린다");
         assert_eq!(payload["speaker"], "dm");
     }
@@ -516,12 +623,24 @@ mod tests {
         }"#;
         let mut state = TrpgMapperState::default();
         let (_, mapped) = decode_stream_events(body, &mut state).expect("decode should succeed");
-        assert_eq!(mapped.len(), 1);
-        assert_eq!(mapped[0].0, "narrative");
+        let narrative_event = mapped
+            .iter()
+            .find(|(event_type, _)| event_type == "narrative")
+            .expect("narrative should exist");
 
-        let payload: Value = serde_json::from_str(&mapped[0].1).expect("narrative payload json");
+        let payload: Value =
+            serde_json::from_str(&narrative_event.1).expect("narrative payload json");
         assert_eq!(payload["text"], "안개가 짙어집니다.");
-        assert_eq!(payload["speaker"], "dm-keeper");
+        assert_eq!(payload["speaker"], "dm");
+
+        let progress_event = mapped
+            .iter()
+            .find(|(event_type, _)| event_type == "turn_progress")
+            .expect("turn_progress should exist");
+        let progress_payload: Value =
+            serde_json::from_str(&progress_event.1).expect("turn_progress payload json");
+        assert_eq!(progress_payload["event_type"], "narration.posted");
+        assert_eq!(progress_payload["actor_id"], "dm");
     }
 
     #[test]
@@ -534,12 +653,19 @@ mod tests {
         }"#;
         let mut state = TrpgMapperState::default();
         let (_, mapped) = decode_stream_events(body, &mut state).expect("decode should succeed");
-        assert_eq!(mapped.len(), 2);
-        assert_eq!(mapped[0].0, "narrative");
-        assert_eq!(mapped[1].0, "narrative");
+        let narrative_events: Vec<&(String, String)> = mapped
+            .iter()
+            .filter(|(event_type, _)| event_type == "narrative")
+            .collect();
+        assert_eq!(narrative_events.len(), 2);
+        let progress_events: Vec<&(String, String)> = mapped
+            .iter()
+            .filter(|(event_type, _)| event_type == "turn_progress")
+            .collect();
+        assert_eq!(progress_events.len(), 2);
 
         let timeout_payload: Value =
-            serde_json::from_str(&mapped[0].1).expect("timeout narrative payload json");
+            serde_json::from_str(&narrative_events[0].1).expect("timeout narrative payload json");
         assert!(
             timeout_payload["text"]
                 .as_str()
@@ -548,7 +674,7 @@ mod tests {
         );
 
         let unavailable_payload: Value =
-            serde_json::from_str(&mapped[1].1).expect("unavailable narrative payload json");
+            serde_json::from_str(&narrative_events[1].1).expect("unavailable narrative payload json");
         assert_eq!(unavailable_payload["text"], "[unavailable] p02: LLM failed");
     }
 }

--- a/viewer/style.css
+++ b/viewer/style.css
@@ -650,11 +650,13 @@ body.mode-lobby #dashboard {
     box-shadow: 0 0 0 1px var(--border-main) inset, 0 0 12px rgba(255, 140, 50, 0.08);
 }
 
-.narrative-entry.phase-dm-narration {
+.narrative-entry.phase-dm-narration,
+.narrative-entry.phase-dm_narration {
     border-left-color: var(--accent-primary-dim);
     background: rgba(255, 140, 50, 0.03);
 }
 
+.narrative-entry.phase-dm-narration .narrative-speaker,
 .narrative-entry.phase-dm_narration .narrative-speaker {
     color: var(--accent-primary);
     text-shadow: 0 0 6px rgba(255, 140, 50, 0.2);

--- a/viewer/style.css
+++ b/viewer/style.css
@@ -1100,6 +1100,57 @@ body.mode-lobby #dashboard {
     border-color: rgba(255, 255, 255, 0.04);
 }
 
+.turn-runtime {
+    margin-bottom: 12px;
+    padding: 8px 10px;
+    border: 1px solid var(--border-main);
+    border-radius: var(--panel-radius);
+    background: var(--bg-panel-alt);
+}
+
+.turn-runtime-grid {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 6px 12px;
+}
+
+.turn-runtime-item {
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+    gap: 8px;
+    padding-bottom: 2px;
+    border-bottom: 1px dashed var(--border-main);
+}
+
+.turn-runtime-item .k {
+    font-family: var(--font-ui);
+    font-size: 10px;
+    letter-spacing: 1px;
+    text-transform: uppercase;
+    color: var(--text-dim);
+}
+
+.turn-runtime-item .v {
+    font-family: var(--font-ui);
+    font-size: 11px;
+    color: var(--text-primary);
+    text-align: right;
+}
+
+.turn-runtime-item .v.status-active {
+    color: var(--status-connected);
+}
+
+.turn-runtime-item .v.status-ended,
+.turn-runtime-item .v.status-wipe {
+    color: var(--status-disconnected);
+}
+
+.turn-runtime-item .v.status-idle {
+    color: var(--text-dim);
+}
+
 #dice-log {
     min-height: 100%;
 }


### PR DESCRIPTION
## Summary
- complete integration of live TRPG turn progress widget and stream mapping
- include remaining viewer/game/sse wiring changes not reflected in merged PR #183
- normalize dashboard player keeper mapping against current session party actor IDs

## Validation
- cargo check --manifest-path viewer/Cargo.toml
- dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix-viewer-new-game-flow-ui