### PR TITLE
feat(board): add POST endpoints for vote and comment

### DIFF
--- a/bin/dune
+++ b/bin/dune
@@ -12,7 +12,7 @@
  (modules masc_cost)
  (public_name masc-cost)
  (package masc_mcp)
- (libraries unix yojson))
+ (libraries masc_mcp unix yojson))
 
 ;; TUI Dashboard - Terminal interface for multi-agent coordination
 (executable

--- a/bin/main_eio.ml
+++ b/bin/main_eio.ml
@@ -34,6 +34,7 @@ module Safe_ops = Masc_mcp.Safe_ops
 module Context_manager = Masc_mcp.Context_manager
 module Llm_client = Masc_mcp.Llm_client
 module Tool_perpetual = Masc_mcp.Tool_perpetual
+module Tool_board = Masc_mcp.Tool_board
 
 (** MCP Protocol Versions *)
 (* ============================================ *)
@@ -4122,6 +4123,47 @@ let make_routes ~port ~host =
        let json = `Assoc [("flairs", `List flairs)] in
        Http.Response.json (Yojson.Safe.to_string json) reqd)
 
+
+  (* Board write APIs — used by Bevy Viewer *)
+  |> Http.Router.post "/api/v1/tools/masc_board_vote" (fun request reqd ->
+       with_public_read (fun _state _req reqd ->
+         Http.Request.read_body_async reqd (fun body_str ->
+           try
+             let args = Yojson.Safe.from_string body_str in
+             let (ok, msg) = Tool_board.handle_tool "masc_board_vote" args in
+             let status = if ok then `OK else `Bad_request in
+             respond_json_with_cors ~status request reqd
+               (Yojson.Safe.to_string (`Assoc [
+                 ("ok", `Bool ok); ("message", `String msg)
+               ]))
+           with exn ->
+             respond_json_with_cors ~status:`Bad_request request reqd
+               (Yojson.Safe.to_string (`Assoc [
+                 ("ok", `Bool false);
+                 ("message", `String (Printexc.to_string exn))
+               ]))
+         )
+       ) request reqd)
+
+  |> Http.Router.post "/api/v1/tools/masc_board_comment" (fun request reqd ->
+       with_public_read (fun _state _req reqd ->
+         Http.Request.read_body_async reqd (fun body_str ->
+           try
+             let args = Yojson.Safe.from_string body_str in
+             let (ok, msg) = Tool_board.handle_tool "masc_board_comment" args in
+             let status = if ok then `Created else `Bad_request in
+             respond_json_with_cors ~status request reqd
+               (Yojson.Safe.to_string (`Assoc [
+                 ("ok", `Bool ok); ("message", `String msg)
+               ]))
+           with exn ->
+             respond_json_with_cors ~status:`Bad_request request reqd
+               (Yojson.Safe.to_string (`Assoc [
+                 ("ok", `Bool false);
+                 ("message", `String (Printexc.to_string exn))
+               ]))
+         )
+       ) request reqd)
   |> Http.Router.get "/api/v1/karma" (fun request reqd ->
        with_public_read (fun _state _req reqd ->
          let karma_list = Board_dispatch.get_all_karma () in

--- a/bin/masc_cost.ml
+++ b/bin/masc_cost.ml
@@ -2,6 +2,7 @@
     Track token usage and costs per agent/task *)
 
 open Printf
+open Json_util
 
 (** Cost entry type *)
 type cost_entry = {
@@ -68,15 +69,14 @@ let log_cost ~agent ~task_id ~model ~input_tokens ~output_tokens ~cost_usd =
 let parse_cost_line line =
   try
     let json = Yojson.Safe.from_string line in
-    let open Yojson.Safe.Util in
     Some {
-      agent = json |> member "agent" |> to_string;
-      task_id = json |> member "task_id" |> to_string_option;
-      model = json |> member "model" |> to_string;
-      input_tokens = json |> member "input_tokens" |> to_int;
-      output_tokens = json |> member "output_tokens" |> to_int;
-      cost_usd = json |> member "cost_usd" |> to_float;
-      timestamp = json |> member "timestamp" |> to_string;
+      agent = get_string json "agent" |> Option.value ~default:"";
+      task_id = get_string json "task_id";
+      model = get_string json "model" |> Option.value ~default:"";
+      input_tokens = get_int json "input_tokens" |> Option.value ~default:0;
+      output_tokens = get_int json "output_tokens" |> Option.value ~default:0;
+      cost_usd = get_float json "cost_usd" |> Option.value ~default:0.0;
+      timestamp = get_string json "timestamp" |> Option.value ~default:"";
     }
   with _ -> None
 

--- a/bin/masc_cost.ml
+++ b/bin/masc_cost.ml
@@ -2,7 +2,7 @@
     Track token usage and costs per agent/task *)
 
 open Printf
-open Json_util
+open Masc_mcp.Json_util
 
 (** Cost entry type *)
 type cost_entry = {

--- a/lib/masc_mcp.ml
+++ b/lib/masc_mcp.ml
@@ -158,6 +158,7 @@ module Tool_room = Tool_room
 module Tool_control = Tool_control
 module Tool_verification = Tool_verification
 module Tool_misc = Tool_misc
+module Tool_board = Tool_board
 module Tool_lodge = Tool_lodge
 
 (* Lodge subsystem *)

--- a/lib/masc_mcp.ml
+++ b/lib/masc_mcp.ml
@@ -5,6 +5,7 @@ module Time_compat = Time_compat
 
 module Version = Version
 module Common = Common
+module Json_util = Json_util
 module Log = Log
 module Types = Types
 module Nickname = Nickname


### PR DESCRIPTION
## Summary
- Bevy WASM viewer calls `POST /api/v1/tools/masc_board_vote` and `POST /api/v1/tools/masc_board_comment` but these routes were missing from the OCaml server
- Added both POST endpoints routing through `Tool_board.handle_tool`
- Re-exported `Tool_board` and `Json_util` modules from `lib/masc_mcp.ml` so external binaries can access them
- Migrated `masc_cost` CLI from inline `Yojson.Safe.Util` to centralized `Json_util` helpers

## Changes
- `bin/main_eio.ml`: Two new POST route handlers for board vote/comment
- `lib/masc_mcp.ml`: Re-export `Tool_board` and `Json_util` modules
- `bin/masc_cost.ml`: Use `Masc_mcp.Json_util` instead of raw Yojson
- `bin/dune`: Add `masc_mcp` library dependency for `masc_cost`

## Test plan
- [x] `dune build` passes
- [x] `curl -X POST /api/v1/tools/masc_board_vote` returns correct response
- [x] `curl -X POST /api/v1/tools/masc_board_comment` returns correct response
- [ ] Viewer Social tab vote/comment buttons work end-to-end

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>