### PR TITLE
feat(viewer): activate turn-runtime display and turn advance controls

### DIFF
--- a/viewer/index.html
+++ b/viewer/index.html
@@ -192,6 +192,13 @@
                             <div class="phase" data-phase="transition">Move</div>
                         </div>
                     </div>
+                    <!-- Turn Runtime: live game status grid (populated by turn_runtime.rs) -->
+                    <div id="turn-runtime"></div>
+                    <!-- Turn Controls: advance turn (Keeper/GM only) -->
+                    <div id="turn-controls" style="display:none">
+                        <button id="advance-turn-btn" title="Advance to next turn">Advance Turn</button>
+                        <span id="turn-control-status"></span>
+                    </div>
                     <div id="narrative-log"></div>
                     <!-- Join Panel: claim an actor before playing -->
                     <div id="join-panel">

--- a/viewer/src/dom/mod.rs
+++ b/viewer/src/dom/mod.rs
@@ -4,6 +4,7 @@ pub mod character_panel;
 pub mod connection;
 pub mod dice_log;
 pub mod narrative;
+pub mod turn_controls;
 pub mod turn_runtime;
 pub mod turn_phase;
 
@@ -36,15 +37,18 @@ impl Plugin for DomBridgePlugin {
                 turn_runtime::update_turn_runtime_dom,
                 connection::update_connection_dom,
                 action_panel::sync_action_panel_visibility,
+                turn_controls::sync_turn_controls_visibility,
             ).run_if(in_state(ViewerMode::Trpg)))
             // Action panel lifecycle: bind listeners on enter, unbind on exit
             .add_systems(OnEnter(ViewerMode::Trpg), (
                 action_panel::bind_action_panel,
                 actor_join::bind_actor_join,
+                turn_controls::bind_turn_controls,
             ))
             .add_systems(OnExit(ViewerMode::Trpg), (
                 action_panel::unbind_action_panel,
                 actor_join::unbind_actor_join,
+                turn_controls::unbind_turn_controls,
             ));
     }
 }

--- a/viewer/src/dom/turn_controls.rs
+++ b/viewer/src/dom/turn_controls.rs
@@ -1,0 +1,192 @@
+//! Turn Controls — advance turn and session management buttons.
+//!
+//! Binds DOM event listeners on `#turn-controls`:
+//! - Advance Turn button → POST `/api/v1/trpg/turns/advance`
+//!
+//! Visible only when the player has claimed a keeper role.
+//! Follows the same OnEnter/OnExit lifecycle as `action_panel.rs`.
+
+use bevy::prelude::*;
+
+#[cfg(target_arch = "wasm32")]
+use serde_json::json;
+
+#[cfg(target_arch = "wasm32")]
+use wasm_bindgen::prelude::*;
+
+#[cfg(target_arch = "wasm32")]
+use crate::config;
+
+// ─── Marker Resource ────────────────────────
+
+/// Inserted on enter, removed on exit — signals that the turn controls are bound.
+#[derive(Resource)]
+pub struct TurnControlsBound;
+
+// ─── OnEnter System ─────────────────────────
+
+pub fn bind_turn_controls(mut commands: Commands) {
+    #[cfg(target_arch = "wasm32")]
+    {
+        bind_advance_button();
+        clear_turn_status();
+        log::info!("TurnControls: bound");
+    }
+
+    commands.insert_resource(TurnControlsBound);
+}
+
+pub fn unbind_turn_controls(mut commands: Commands) {
+    #[cfg(target_arch = "wasm32")]
+    {
+        clear_turn_status();
+        log::info!("TurnControls: unbound");
+    }
+
+    commands.remove_resource::<TurnControlsBound>();
+}
+
+// ─── Visibility Sync ────────────────────────
+
+/// Show turn controls only when a keeper is claimed (Keeper/GM privilege).
+pub fn sync_turn_controls_visibility() {
+    #[cfg(target_arch = "wasm32")]
+    {
+        let Some(doc) = web_sys::window().and_then(|w| w.document()) else {
+            return;
+        };
+        let Some(panel) = doc.get_element_by_id("turn-controls") else {
+            return;
+        };
+        let keeper = doc
+            .get_element_by_id("claimed-keeper")
+            .and_then(|el| el.dyn_ref::<web_sys::HtmlInputElement>().map(|i| i.value()));
+        let has_keeper = keeper.map_or(false, |v| !v.trim().is_empty());
+
+        let style = if has_keeper { "" } else { "display:none" };
+        let _ = panel.set_attribute("style", style);
+    }
+}
+
+// ─── Event: Advance Button ──────────────────
+
+#[cfg(target_arch = "wasm32")]
+fn bind_advance_button() {
+    let Some(doc) = web_sys::window().and_then(|w| w.document()) else {
+        return;
+    };
+    let Some(btn) = doc.get_element_by_id("advance-turn-btn") else {
+        return;
+    };
+
+    let cb = Closure::wrap(Box::new(move || {
+        on_advance_click();
+    }) as Box<dyn Fn()>);
+
+    let _ = btn.add_event_listener_with_callback("click", cb.as_ref().unchecked_ref());
+    cb.forget();
+}
+
+#[cfg(target_arch = "wasm32")]
+fn on_advance_click() {
+    set_turn_status("Advancing...", "");
+    set_advance_disabled(true);
+
+    wasm_bindgen_futures::spawn_local(async move {
+        match advance_turn().await {
+            Ok(msg) => set_turn_status(&msg, "status-ok"),
+            Err(e) => {
+                let detail = e
+                    .as_string()
+                    .unwrap_or_else(|| format!("{:?}", e));
+                log::warn!("Advance turn failed: {}", detail);
+                set_turn_status(&format!("Failed: {}", detail), "status-error");
+            }
+        }
+        set_advance_disabled(false);
+    });
+}
+
+// ─── HTTP: Advance Turn ─────────────────────
+
+#[cfg(target_arch = "wasm32")]
+async fn advance_turn() -> Result<String, JsValue> {
+    use wasm_bindgen_futures::JsFuture;
+
+    let url = format!("{}/api/v1/trpg/turns/advance", config::MASC_MCP_URL);
+    let room_id = config::current_room_id();
+
+    let body = json!({
+        "room_id": room_id
+    })
+    .to_string();
+
+    let opts = web_sys::RequestInit::new();
+    opts.set_method("POST");
+    opts.set_mode(web_sys::RequestMode::Cors);
+    opts.set_body(&JsValue::from_str(&body));
+
+    let request = web_sys::Request::new_with_str_and_init(&url, &opts)?;
+    request.headers().set("Content-Type", "application/json")?;
+
+    let window = web_sys::window().ok_or_else(|| JsValue::from_str("no window"))?;
+    let resp_value = JsFuture::from(window.fetch_with_request(&request)).await?;
+    let resp: web_sys::Response = resp_value.dyn_into()?;
+
+    if !resp.ok() {
+        let err_body = JsFuture::from(resp.text()?)
+            .await
+            .ok()
+            .and_then(|v| v.as_string())
+            .unwrap_or_default();
+        let err_body = err_body.trim();
+        if err_body.is_empty() {
+            return Err(JsValue::from_str(&format!("HTTP {}", resp.status())));
+        }
+        return Err(JsValue::from_str(&format!(
+            "HTTP {}: {}",
+            resp.status(),
+            err_body
+        )));
+    }
+
+    // Extract the new turn number from the response JSON
+    let resp_text = JsFuture::from(resp.text()?)
+        .await
+        .ok()
+        .and_then(|v| v.as_string())
+        .unwrap_or_default();
+    log::info!("TurnControls: turn advanced — {}", resp_text);
+
+    Ok("Turn advanced.".to_string())
+}
+
+// ─── DOM Helpers ─────────────────────────────
+
+#[cfg(target_arch = "wasm32")]
+fn set_turn_status(text: &str, css_class: &str) {
+    let Some(doc) = web_sys::window().and_then(|w| w.document()) else {
+        return;
+    };
+    if let Some(el) = doc.get_element_by_id("turn-control-status") {
+        el.set_text_content(Some(text));
+        let _ = el.set_attribute("class", css_class);
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+fn clear_turn_status() {
+    set_turn_status("", "");
+}
+
+#[cfg(target_arch = "wasm32")]
+fn set_advance_disabled(disabled: bool) {
+    let Some(doc) = web_sys::window().and_then(|w| w.document()) else {
+        return;
+    };
+    if let Some(el) = doc.get_element_by_id("advance-turn-btn") {
+        if let Some(btn) = el.dyn_ref::<web_sys::HtmlButtonElement>() {
+            btn.set_disabled(disabled);
+        }
+    }
+}

--- a/viewer/style.css
+++ b/viewer/style.css
@@ -1094,6 +1094,114 @@ body.mode-lobby #dashboard {
     border-color: rgba(255, 255, 255, 0.04);
 }
 
+/* ─── Turn Runtime Grid (live game status) ─── */
+
+#turn-runtime {
+    margin-bottom: 8px;
+}
+
+.turn-runtime-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(120px, 1fr));
+    gap: 4px;
+    padding: 6px;
+    background: var(--bg-deep);
+    border: 1px solid var(--border-main);
+    border-radius: var(--card-radius, 6px);
+}
+
+.turn-runtime-item {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    padding: 4px 8px;
+    background: var(--bg-panel-alt);
+    border-radius: 4px;
+    border: 1px solid transparent;
+}
+
+.turn-runtime-item .k {
+    font-family: var(--font-ui);
+    font-size: 9px;
+    color: var(--text-dim);
+    text-transform: uppercase;
+    letter-spacing: 1px;
+}
+
+.turn-runtime-item .v {
+    font-family: var(--font-body);
+    font-size: 12px;
+    color: var(--text-primary);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.turn-runtime-item .v.status-active {
+    color: var(--accent-primary);
+}
+
+.turn-runtime-item .v.status-ended {
+    color: var(--text-dim);
+    font-style: italic;
+}
+
+.turn-runtime-item .v.status-idle {
+    color: var(--text-secondary, var(--text-dim));
+}
+
+.turn-runtime-item .v.status-wipe {
+    color: #d44;
+    font-weight: 600;
+}
+
+/* ─── Turn Controls (advance turn button) ─── */
+
+#turn-controls {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    margin-bottom: 8px;
+}
+
+#advance-turn-btn {
+    background: var(--bg-card);
+    border: 1px solid var(--border-highlight, rgba(196, 162, 101, 0.2));
+    border-radius: var(--card-radius, 6px);
+    color: var(--accent-primary);
+    cursor: pointer;
+    font-family: var(--font-ui);
+    font-size: 0.8rem;
+    padding: 6px 14px;
+    transition: background 0.2s, color 0.2s;
+    white-space: nowrap;
+}
+
+#advance-turn-btn:hover {
+    background: var(--accent-glow);
+    color: var(--text-bright);
+}
+
+#advance-turn-btn:disabled {
+    opacity: 0.4;
+    cursor: not-allowed;
+}
+
+#turn-control-status {
+    font-size: 0.75rem;
+    font-family: var(--font-ui);
+    color: var(--text-dim);
+    transition: color 0.3s;
+}
+
+#turn-control-status.status-ok {
+    color: var(--accent-primary);
+}
+
+#turn-control-status.status-error {
+    color: #d44;
+}
+
 #dice-log {
     min-height: 100%;
 }


### PR DESCRIPTION
## Summary

- `turn_runtime.rs` 가 매 프레임 실행되지만 target DOM element (`#turn-runtime`) 이 `index.html` 에 없어 168줄의 상태 그리드 렌더링이 dead code 상태였음 — 이를 수정
- Turn advance 버튼 (`#turn-controls`) 추가 — Keeper/GM 역할 claim 시에만 표시
- `POST /api/v1/trpg/turns/advance` 를 Viewer 에서 호출 가능하게 연결

## Changes

| File | Description |
|------|-------------|
| `viewer/index.html` | `#turn-runtime` + `#turn-controls` DOM elements 추가 |
| `viewer/style.css` | 7-item status grid + advance button CSS (108 lines) |
| `viewer/src/dom/turn_controls.rs` | New module — advance turn POST, keeper-gated visibility |
| `viewer/src/dom/mod.rs` | Module registration + OnEnter/OnExit lifecycle wiring |

## How it works

```
[turn_runtime.rs] --every frame--> reads RoomState/TurnProgress/Actors
                                   --> renders 7-item grid to #turn-runtime

[turn_controls.rs] --keeper claimed--> shows #turn-controls
                   --click Advance--> POST /api/v1/trpg/turns/advance
                                      --> status feedback in #turn-control-status
```

## Test plan

- [ ] `cargo check --target wasm32-unknown-unknown` passes (verified)
- [ ] `make viewer-serve` → turn-runtime grid displays Room/Turn/Phase/Now/Next/Last/Party
- [ ] Claim keeper → advance button appears; release → disappears
- [ ] Click advance → turn number increments, status shows success/failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)