### PR TITLE
fix(viewer): stabilize TRPG session UI and room-scoped state

### DIFF
--- a/lib/mcp_server_eio.ml
+++ b/lib/mcp_server_eio.ml
@@ -673,7 +673,7 @@ let mcp_session_of_json (json : Yojson.Safe.t) : mcp_session_record option =
     let created_at = match Json_util.get_float json "created_at" with Some v -> v | None -> raise Not_found in
     let last_seen = match Json_util.get_float json "last_seen" with Some v -> v | None -> raise Not_found in
     Some { id; agent_name; created_at; last_seen }
-  with Yojson.Safe.Util.Type_error _ -> None
+  with Not_found | Yojson.Safe.Util.Type_error _ -> None
 
 let load_mcp_sessions (config : Room.config) : mcp_session_record list =
   let path = mcp_sessions_path config in

--- a/viewer/index.html
+++ b/viewer/index.html
@@ -158,6 +158,7 @@
                     <option value="terminal">Terminal</option>
                     <option value="parchment">Parchment</option>
                 </select>
+                <button id="new-game-toggle" class="inline-button" type="button">새 게임</button>
                 <button id="debug-log-toggle" class="inline-toggle" type="button" aria-pressed="true">Debug ON</button>
                 <span id="debug-log-status" class="widget-pill">DEBUG ON</span>
                 <span id="widget-status" class="widget-pill">Widgets N:0 P:0 D:0</span>
@@ -192,7 +193,6 @@
                             <div class="phase" data-phase="transition">Move</div>
                         </div>
                     </div>
-                    <!-- Turn Runtime: live game status grid (populated by turn_runtime.rs) -->
                     <div id="turn-runtime"></div>
                     <!-- Turn Controls: advance turn (Keeper/GM only) -->
                     <div id="turn-controls" style="display:none">
@@ -250,6 +250,41 @@
             <h2 class="panel-title" id="bottom-title">Dice Log</h2>
             <div id="dice-log" class="scrollable horizontal"></div>
         </footer>
+
+        <div id="new-game-panel" style="display: none;">
+            <div class="new-game-card">
+                <div class="new-game-head">
+                    <h3>새 게임 시작</h3>
+                    <button id="new-game-close" type="button">닫기</button>
+                </div>
+
+                <label class="new-game-label" for="new-game-room-id">Room ID</label>
+                <div class="new-game-row">
+                    <input id="new-game-room-id" type="text" placeholder="room id (auto)" />
+                    <button id="new-game-room-regenerate" type="button">재생성</button>
+                </div>
+
+                <label class="new-game-label" for="new-game-dm-select">DM Keeper</label>
+                <select id="new-game-dm-select"></select>
+
+                <label class="new-game-label" for="new-game-player-select">AI Player Keepers (다중 선택)</label>
+                <select id="new-game-player-select" multiple size="6"></select>
+
+                <label class="new-game-label" for="new-game-models">Models (빠른 우선)</label>
+                <input
+                    id="new-game-models"
+                    type="text"
+                    value="glm:glm-4.7,gemini:gemini-2.5-flash"
+                    placeholder="glm:glm-4.7,gemini:gemini-2.5-flash"
+                />
+
+                <div class="new-game-actions">
+                    <button id="new-game-refresh" type="button">Keeper 새로고침</button>
+                    <button id="new-game-start" type="button">시작</button>
+                </div>
+                <div id="new-game-status"></div>
+            </div>
+        </div>
     </div>
 
 </body>

--- a/viewer/src/dom/actor_join.rs
+++ b/viewer/src/dom/actor_join.rs
@@ -182,14 +182,14 @@ async fn claim_actor(actor_id: &str, keeper: &str) -> Result<(), JsValue> {
     use wasm_bindgen_futures::JsFuture;
 
     let url = format!("{}/api/v1/trpg/actors/claim", config::MASC_MCP_URL);
-    let room_id = config::DEFAULT_ROOM_ID;
+    let room_id = config::current_room_id();
 
-    let body = format!(
-        r#"{{"room":"{}","actor_id":"{}","keeper":"{}"}}"#,
-        room_id,
-        escape_json(actor_id),
-        escape_json(keeper)
-    );
+    let body = serde_json::json!({
+        "room_id": room_id,
+        "actor_id": actor_id,
+        "keeper": keeper,
+    })
+    .to_string();
 
     let opts = web_sys::RequestInit::new();
     opts.set_method("POST");
@@ -221,14 +221,14 @@ async fn release_actor(actor_id: &str, keeper: &str) -> Result<(), JsValue> {
     use wasm_bindgen_futures::JsFuture;
 
     let url = format!("{}/api/v1/trpg/actors/release", config::MASC_MCP_URL);
-    let room_id = config::DEFAULT_ROOM_ID;
+    let room_id = config::current_room_id();
 
-    let body = format!(
-        r#"{{"room":"{}","actor_id":"{}","keeper":"{}"}}"#,
-        room_id,
-        escape_json(actor_id),
-        escape_json(keeper)
-    );
+    let body = serde_json::json!({
+        "room_id": room_id,
+        "actor_id": actor_id,
+        "keeper": keeper,
+    })
+    .to_string();
 
     let opts = web_sys::RequestInit::new();
     opts.set_method("POST");
@@ -388,12 +388,4 @@ fn set_display(doc: &web_sys::Document, id: &str, display: &str) {
             let _ = html_el.style().set_property("display", display);
         }
     }
-}
-
-/// Minimal JSON string escaping for embedding in format! templates.
-#[cfg(target_arch = "wasm32")]
-fn escape_json(s: &str) -> String {
-    s.replace('\\', "\\\\")
-        .replace('"', "\\\"")
-        .replace('\n', "\\n")
 }

--- a/viewer/src/game/http.rs
+++ b/viewer/src/game/http.rs
@@ -8,7 +8,7 @@ use wasm_bindgen_futures::JsFuture;
 
 use crate::config;
 use crate::game::components::{Actor, Stats};
-use crate::game::state::{MapState, RoomState, TurnPhase, TurnProgressState};
+use crate::game::state::{ConnectionStatus, MapState, RoomState, TurnPhase, TurnProgressState};
 
 // ─── Expected API Response Types ─────────────
 
@@ -117,9 +117,9 @@ fn queue_initial_state_fetch(commands: &mut Commands) {
                 log::info!("Initial game state loaded from engine");
             }
             Err(e) => {
-                log::warn!("Engine not available, using mock data: {:?}", e);
+                log::warn!("Engine not available, using unavailable state: {:?}", e);
                 if let Ok(mut buf) = shared.lock() {
-                    *buf = Some(mock_game_state());
+                    *buf = Some(unavailable_game_state(&config::current_room_id()));
                 }
             }
         }
@@ -137,8 +137,10 @@ fn queue_initial_state_fetch(commands: &mut Commands) {
 pub fn fetch_initial_state(
     mut commands: Commands,
     mut active_room: ResMut<ActiveTrpgRoom>,
+    mut connection: ResMut<ConnectionStatus>,
 ) {
     active_room.room_id = config::current_room_id();
+    *connection = ConnectionStatus::Connecting;
     queue_initial_state_fetch(&mut commands);
 }
 
@@ -150,6 +152,7 @@ pub fn refresh_state_on_room_change(
     mut room_state: ResMut<RoomState>,
     mut map_state: ResMut<MapState>,
     mut turn_progress: ResMut<TurnProgressState>,
+    mut connection: ResMut<ConnectionStatus>,
 ) {
     let current_room = config::current_room_id();
     if active_room.room_id == current_room {
@@ -167,6 +170,7 @@ pub fn refresh_state_on_room_change(
     *map_state = MapState::default();
     *turn_progress = TurnProgressState::default();
     turn_progress.room_status = "loading".to_string();
+    *connection = ConnectionStatus::Connecting;
 
     queue_initial_state_fetch(&mut commands);
     log::info!("TRPG room changed — reloading state for room {}", current_room);
@@ -180,6 +184,7 @@ pub fn apply_initial_state(
     mut room_state: ResMut<RoomState>,
     mut map_state: ResMut<MapState>,
     mut turn_progress: ResMut<TurnProgressState>,
+    mut connection: ResMut<ConnectionStatus>,
 ) {
     if buffer.consumed {
         return;
@@ -195,6 +200,11 @@ pub fn apply_initial_state(
     let Some(state) = state else {
         return;
     };
+    let state_unavailable = state
+        .room
+        .as_ref()
+        .map(|room| room.status.trim() == "unavailable")
+        .unwrap_or(false);
 
     let actor_ids: Vec<String> = state
         .characters
@@ -203,13 +213,19 @@ pub fn apply_initial_state(
         .collect();
 
     // Apply room state
-    if let Some(room) = state.room {
-        room_state.id = room.id;
-        room_state.status = room.status;
+    if let Some(room) = &state.room {
+        room_state.id = room.id.clone();
+        room_state.status = room.status.clone();
         room_state.turn = room.turn;
         room_state.phase = TurnPhase::from_str(&room.phase);
-        room_state.current_scenario = room.current_scenario;
-        room_state.current_node = room.current_node;
+        room_state.current_scenario = room.current_scenario.clone();
+        room_state.current_node = room.current_node.clone();
+    }
+
+    if state_unavailable {
+        *connection = ConnectionStatus::Disconnected;
+    } else {
+        *connection = ConnectionStatus::Connected;
     }
 
     turn_progress.room_status = room_state.status.clone();
@@ -332,7 +348,7 @@ fn parse_masc_state_response(root: &Value) -> GameStateResponse {
         .unwrap_or(config::DEFAULT_ROOM_ID)
         .to_string();
 
-    let turn = state.get("turn").and_then(Value::as_u64).unwrap_or(1) as u32;
+    let turn = state.get("turn").and_then(Value::as_u64).unwrap_or(0) as u32;
     let phase = state
         .get("phase")
         .and_then(Value::as_str)
@@ -342,23 +358,19 @@ fn parse_masc_state_response(root: &Value) -> GameStateResponse {
     let current_area = state
         .get("current_area")
         .and_then(Value::as_str)
-        .unwrap_or("A")
+        .unwrap_or("")
         .to_string();
     let area_label = state
         .get("area_label")
         .and_then(Value::as_str)
-        .unwrap_or("미상 지역")
+        .unwrap_or("")
         .to_string();
 
-    let mut characters = state
+    let characters = state
         .get("characters")
         .cloned()
         .and_then(|v| serde_json::from_value::<Vec<CharacterData>>(v).ok())
         .unwrap_or_default();
-
-    if characters.is_empty() {
-        characters = mock_game_state().characters;
-    }
 
     GameStateResponse {
         room: Some(RoomResponse {
@@ -366,7 +378,7 @@ fn parse_masc_state_response(root: &Value) -> GameStateResponse {
             status: state
                 .get("status")
                 .and_then(Value::as_str)
-                .unwrap_or("active")
+                .unwrap_or("idle")
                 .to_string(),
             turn,
             phase,
@@ -387,96 +399,19 @@ fn parse_masc_state_response(root: &Value) -> GameStateResponse {
     }
 }
 
-// ─── Mock Data ───────────────────────────────
-
-/// Fallback data when the engine is not running.
-/// Matches the 4-character party from scenarios.json.
-fn mock_game_state() -> GameStateResponse {
+fn unavailable_game_state(room_id: &str) -> GameStateResponse {
     GameStateResponse {
         room: Some(RoomResponse {
-            id: "default".to_string(),
-            status: "active".to_string(),
-            turn: 1,
+            id: room_id.to_string(),
+            status: "unavailable".to_string(),
+            turn: 0,
             phase: "dm_narration".to_string(),
-            current_scenario: "prologue".to_string(),
-            current_node: "tavern_entrance".to_string(),
+            current_scenario: "".to_string(),
+            current_node: "".to_string(),
         }),
-        characters: vec![
-            CharacterData {
-                id: "grimja".to_string(),
-                name: "그림자".to_string(),
-                class: "fighter".to_string(),
-                hp: 28,
-                max_hp: 28,
-                stats: Some(StatsData {
-                    atk: 16,
-                    def: 14,
-                    int: 8,
-                    luck: 10,
-                }),
-                area: "A".to_string(),
-                is_dead: false,
-                inventory: vec![],
-                buffs: vec![],
-                debuffs: vec![],
-            },
-            CharacterData {
-                id: "luna".to_string(),
-                name: "루나".to_string(),
-                class: "wizard".to_string(),
-                hp: 18,
-                max_hp: 18,
-                stats: Some(StatsData {
-                    atk: 8,
-                    def: 10,
-                    int: 18,
-                    luck: 12,
-                }),
-                area: "B".to_string(),
-                is_dead: false,
-                inventory: vec![],
-                buffs: vec![],
-                debuffs: vec![],
-            },
-            CharacterData {
-                id: "songarak".to_string(),
-                name: "손가락".to_string(),
-                class: "rogue".to_string(),
-                hp: 22,
-                max_hp: 22,
-                stats: Some(StatsData {
-                    atk: 12,
-                    def: 12,
-                    int: 14,
-                    luck: 16,
-                }),
-                area: "C".to_string(),
-                is_dead: false,
-                inventory: vec![],
-                buffs: vec![],
-                debuffs: vec![],
-            },
-            CharacterData {
-                id: "miso".to_string(),
-                name: "미소".to_string(),
-                class: "cleric".to_string(),
-                hp: 24,
-                max_hp: 24,
-                stats: Some(StatsData {
-                    atk: 10,
-                    def: 12,
-                    int: 16,
-                    luck: 14,
-                }),
-                area: "D".to_string(),
-                is_dead: false,
-                inventory: vec![],
-                buffs: vec![],
-                debuffs: vec![],
-            },
-        ],
-        current_area: "A".to_string(),
-        area_label: "폐허의 입구".to_string(),
+        characters: Vec::new(),
+        current_area: "".to_string(),
+        area_label: "".to_string(),
     }
 }
 
@@ -507,7 +442,7 @@ mod tests {
     }
 
     #[test]
-    fn normalize_masc_shape_uses_defaults_and_fallback_party() {
+    fn normalize_masc_shape_uses_defaults_without_fallback_party() {
         let root = json!({
             "ok": true,
             "room_id": "default",
@@ -521,6 +456,6 @@ mod tests {
         let parsed = normalize_state_response(root).expect("masc parse should succeed");
         assert_eq!(parsed.room.as_ref().map(|r| r.turn), Some(5));
         assert_eq!(parsed.current_area, "C");
-        assert!(!parsed.characters.is_empty(), "fallback party should exist");
+        assert!(parsed.characters.is_empty(), "no fallback party should be injected");
     }
 }

--- a/viewer/src/game/http.rs
+++ b/viewer/src/game/http.rs
@@ -228,6 +228,24 @@ pub fn apply_initial_state(
         *connection = ConnectionStatus::Connected;
     }
 
+    // Stale room detection: if the room isn't actively running a game,
+    // skip spawning old actors and prompt the user to start a new game.
+    let room_is_active = room_state.status.trim() == "active";
+    if !room_is_active {
+        turn_progress.room_status = room_state.status.clone();
+        turn_progress.turn = room_state.turn;
+        turn_progress.phase = room_state.phase.as_str().to_string();
+        buffer.consumed = true;
+
+        prompt_new_game_for_stale_room(room_state.status.trim());
+        log::info!(
+            "Room '{}' not active (status: '{}') — skipping actor spawn, showing new-game panel",
+            room_state.id,
+            room_state.status,
+        );
+        return;
+    }
+
     turn_progress.room_status = room_state.status.clone();
     turn_progress.turn = room_state.turn;
     turn_progress.phase = room_state.phase.as_str().to_string();
@@ -399,6 +417,46 @@ fn parse_masc_state_response(root: &Value) -> GameStateResponse {
     }
 }
 
+/// When the fetched room is not "active", auto-show the new-game panel
+/// and pre-fill a fresh room ID so the user can start a new session.
+fn prompt_new_game_for_stale_room(_room_status: &str) {
+    #[cfg(target_arch = "wasm32")]
+    {
+        let Some(document) = web_sys::window().and_then(|w| w.document()) else {
+            return;
+        };
+
+        // Show the new-game panel
+        if let Some(panel) = document.get_element_by_id("new-game-panel") {
+            if let Some(html_el) = panel.dyn_ref::<web_sys::HtmlElement>() {
+                let _ = html_el.style().set_property("display", "flex");
+            }
+        }
+
+        // Pre-populate room ID input with a fresh generated ID
+        if let Some(input) = document
+            .get_element_by_id("new-game-room-id")
+            .and_then(|el| el.dyn_into::<web_sys::HtmlInputElement>().ok())
+        {
+            if input.value().trim().is_empty() {
+                let ts = js_sys::Date::now() as i64;
+                let rand = (js_sys::Math::random() * 1000.0).floor() as i64;
+                input.set_value(&format!("adventure-{}-{:03}", ts, rand));
+            }
+        }
+
+        // Set a status message appropriate to the room state
+        if let Some(el) = document.get_element_by_id("new-game-status") {
+            let msg = if _room_status == "unavailable" {
+                "엔진에 연결할 수 없습니다. 새 게임을 시작하면 재연결을 시도합니다."
+            } else {
+                "활성 게임이 없습니다. 새 게임을 시작하세요."
+            };
+            el.set_inner_html(msg);
+        }
+    }
+}
+
 fn unavailable_game_state(room_id: &str) -> GameStateResponse {
     GameStateResponse {
         room: Some(RoomResponse {
@@ -457,5 +515,59 @@ mod tests {
         assert_eq!(parsed.room.as_ref().map(|r| r.turn), Some(5));
         assert_eq!(parsed.current_area, "C");
         assert!(parsed.characters.is_empty(), "no fallback party should be injected");
+    }
+
+    #[test]
+    fn ended_room_is_not_active() {
+        let root = json!({
+            "room": {
+                "id": "adventure-123",
+                "status": "ended",
+                "turn": 8,
+                "phase": "transition",
+                "current_scenario": "epilogue",
+                "current_node": "end"
+            },
+            "characters": [
+                { "id": "warrior-1", "name": "Kael" }
+            ],
+            "current_area": "D",
+            "area_label": "왕좌의 간"
+        });
+
+        let parsed = normalize_state_response(root).expect("ended room parse should succeed");
+        let status = parsed.room.as_ref().map(|r| r.status.as_str()).unwrap_or("");
+        assert_ne!(status, "active", "ended room should not be treated as active");
+        assert_eq!(status, "ended");
+        assert_eq!(parsed.characters.len(), 1, "characters still parsed even for ended rooms");
+    }
+
+    #[test]
+    fn idle_room_is_not_active() {
+        let root = json!({
+            "room": {
+                "id": "default",
+                "status": "idle",
+                "turn": 0,
+                "phase": "dm_narration"
+            },
+            "characters": [],
+            "current_area": "",
+            "area_label": ""
+        });
+
+        let parsed = normalize_state_response(root).expect("idle room parse should succeed");
+        let status = parsed.room.as_ref().map(|r| r.status.as_str()).unwrap_or("");
+        assert_ne!(status, "active");
+        assert!(parsed.characters.is_empty());
+    }
+
+    #[test]
+    fn unavailable_game_state_has_correct_shape() {
+        let state = unavailable_game_state("test-room");
+        let room = state.room.as_ref().expect("room should be present");
+        assert_eq!(room.id, "test-room");
+        assert_eq!(room.status, "unavailable");
+        assert!(state.characters.is_empty());
     }
 }

--- a/viewer/src/mode.rs
+++ b/viewer/src/mode.rs
@@ -465,6 +465,32 @@ fn clear_trpg_dom(doc: &web_sys::Document) {
     if let Some(el) = doc.get_element_by_id("turn-num") {
         el.set_text_content(Some("1"));
     }
+    if let Some(el) = doc.get_element_by_id("turn-runtime") {
+        el.set_inner_html("");
+    }
+    for hidden_id in &["claimed-actor-id", "claimed-keeper"] {
+        if let Some(input) = doc
+            .get_element_by_id(hidden_id)
+            .and_then(|el| el.dyn_into::<web_sys::HtmlInputElement>().ok())
+        {
+            input.set_value("");
+        }
+    }
+    if let Some(el) = doc.get_element_by_id("player-actor-id") {
+        el.set_text_content(Some(""));
+    }
+    if let Some(join_panel) = doc
+        .get_element_by_id("join-panel")
+        .and_then(|el| el.dyn_ref::<web_sys::HtmlElement>().cloned())
+    {
+        let _ = join_panel.style().set_property("display", "block");
+    }
+    if let Some(action_panel) = doc
+        .get_element_by_id("action-panel")
+        .and_then(|el| el.dyn_ref::<web_sys::HtmlElement>().cloned())
+    {
+        let _ = action_panel.style().set_property("display", "none");
+    }
 }
 
 #[cfg(target_arch = "wasm32")]
@@ -487,6 +513,14 @@ fn parse_keeper_models(raw: &str) -> Vec<String> {
             .map(|part| part.trim().to_string())
             .collect::<Vec<_>>(),
     )
+}
+
+#[cfg(target_arch = "wasm32")]
+fn default_keeper_models() -> Vec<String> {
+    vec![
+        "glm:glm-4.7".to_string(),
+        "gemini:gemini-2.5-flash".to_string(),
+    ]
 }
 
 #[cfg(target_arch = "wasm32")]
@@ -689,13 +723,7 @@ async fn refresh_keeper_selectors(doc: &web_sys::Document) -> Result<Vec<String>
         .unwrap_or_default();
     keepers = unique_non_empty(keepers);
     if keepers.is_empty() {
-        keepers = vec![
-            "dm-keeper".to_string(),
-            "grimja".to_string(),
-            "luna".to_string(),
-            "songarak".to_string(),
-            "miso".to_string(),
-        ];
+        return Err("사용 가능한 keeper가 없습니다. 먼저 keeper를 실행하세요.".to_string());
     }
 
     let dm_default = keepers
@@ -780,7 +808,10 @@ async fn start_new_game_flow(doc: &web_sys::Document) -> Result<String, String> 
         .get_element_by_id("new-game-models")
         .and_then(|el| el.dyn_ref::<web_sys::HtmlInputElement>().map(|i| i.value()))
         .unwrap_or_default();
-    let models = parse_keeper_models(&model_text);
+    let mut models = parse_keeper_models(&model_text);
+    if models.is_empty() {
+        models = default_keeper_models();
+    }
 
     let preset_catalog = mcp_tool_call(
         "trpg.preset.list",
@@ -1198,12 +1229,20 @@ fn set_element_display(doc: &web_sys::Document, id: &str, display: &str) {
 #[cfg(target_arch = "wasm32")]
 fn set_panel_active(doc: &web_sys::Document, id: &str, active: bool) {
     if let Some(el) = doc.get_element_by_id(id) {
-        let class_list = el.class_list();
+        let class_name = el.get_attribute("class").unwrap_or_default();
+        let mut parts = class_name
+            .split_whitespace()
+            .map(ToString::to_string)
+            .collect::<Vec<_>>();
+        let has_active = parts.iter().any(|v| v == "active");
         if active {
-            let _ = class_list.add_1("active");
-        } else {
-            let _ = class_list.remove_1("active");
+            if !has_active {
+                parts.push("active".to_string());
+            }
+        } else if has_active {
+            parts.retain(|v| v != "active");
         }
+        let _ = el.set_attribute("class", &parts.join(" "));
     }
 }
 

--- a/viewer/src/sse/client.rs
+++ b/viewer/src/sse/client.rs
@@ -16,6 +16,7 @@ use web_sys::{EventSource, MessageEvent};
 
 #[cfg(target_arch = "wasm32")]
 use crate::config;
+use crate::game::state::ConnectionStatus;
 
 /// Wrapper around `EventSource` that is `Send + Sync`.
 /// Safe because WASM is single-threaded — there are no real threads to race with.
@@ -427,8 +428,26 @@ async fn sleep_ms(ms: i32) -> Result<(), JsValue> {
 #[cfg(target_arch = "wasm32")]
 fn start_polling_loop(messages: Arc<Mutex<Vec<(String, String)>>>, active: Arc<AtomicBool>) {
     wasm_bindgen_futures::spawn_local(async move {
-        let mut after_seq = 0_i64;
         let mut state = TrpgMapperState::default();
+        let mut after_seq = 0_i64;
+
+        // Skip historical backlog on viewer enter so old sessions do not flood narrative.
+        let bootstrap_url = config::trpg_stream_poll_url(0);
+        match fetch_text(&bootstrap_url).await {
+            Ok(body) => match decode_stream_events(&body, &mut state) {
+                Ok((max_seq, _)) => {
+                    after_seq = max_seq.max(0);
+                    if after_seq > 0 {
+                        log::info!(
+                            "TRPG poll bootstrap: skipping historical events up to seq {}",
+                            after_seq
+                        );
+                    }
+                }
+                Err(e) => log::warn!("Failed to decode TRPG bootstrap payload: {}", e),
+            },
+            Err(e) => log::debug!("TRPG bootstrap request failed: {:?}", e),
+        }
 
         while active.load(Ordering::Relaxed) {
             let url = config::trpg_stream_poll_url(after_seq);
@@ -462,7 +481,8 @@ fn start_polling_loop(messages: Arc<Mutex<Vec<(String, String)>>>, active: Arc<A
 
 /// Startup system that creates TRPG stream input (polling or legacy EventSource).
 #[cfg(target_arch = "wasm32")]
-pub fn setup_sse(mut commands: Commands) {
+pub fn setup_sse(mut commands: Commands, mut connection: ResMut<ConnectionStatus>) {
+    *connection = ConnectionStatus::Connecting;
     let messages = Arc::new(Mutex::new(Vec::new()));
     let active = Arc::new(AtomicBool::new(true));
     let es_handle: Arc<Mutex<Option<SendEventSource>>> = Arc::new(Mutex::new(None));
@@ -539,10 +559,14 @@ pub fn setup_sse(mut commands: Commands) {
 
 /// Native no-op for setup_sse.
 #[cfg(not(target_arch = "wasm32"))]
-pub fn setup_sse(mut _commands: Commands) {}
+pub fn setup_sse(mut _commands: Commands, mut _connection: ResMut<ConnectionStatus>) {}
 
 /// OnExit(Trpg) system: stops polling, closes EventSource, and removes resource.
-pub fn teardown_sse(mut commands: Commands, receiver: Option<Res<SseReceiver>>) {
+pub fn teardown_sse(
+    mut commands: Commands,
+    receiver: Option<Res<SseReceiver>>,
+    connection: Option<ResMut<ConnectionStatus>>,
+) {
     if let Some(recv) = receiver {
         recv.polling_active.store(false, Ordering::Relaxed);
         #[cfg(target_arch = "wasm32")]
@@ -554,6 +578,9 @@ pub fn teardown_sse(mut commands: Commands, receiver: Option<Res<SseReceiver>>) 
                 }
             }
         }
+    }
+    if let Some(mut status) = connection {
+        *status = ConnectionStatus::Disconnected;
     }
     commands.remove_resource::<SseReceiver>();
     log::info!("SseReceiver resource removed");

--- a/viewer/style.css
+++ b/viewer/style.css
@@ -363,6 +363,7 @@ body.mode-lobby #dashboard {
     grid-template-rows: 44px 1fr 120px;
     grid-template-columns: 1fr;
     height: 100vh;
+    position: relative;
     gap: 1px;
     background: var(--border-main);
 }
@@ -422,6 +423,7 @@ body.mode-lobby #dashboard {
     padding: 2px 6px;
 }
 
+.inline-button,
 .inline-toggle {
     font-size: 10px;
     padding: 3px 8px;
@@ -435,6 +437,15 @@ body.mode-lobby #dashboard {
 .inline-toggle[aria-pressed="false"] {
     opacity: 0.72;
     color: var(--text-dim);
+}
+
+.inline-button {
+    border-color: var(--accent-primary-dim);
+    color: var(--accent-primary);
+}
+
+.inline-button:hover {
+    background: rgba(255, 140, 50, 0.14);
 }
 
 .widget-pill {
@@ -1094,65 +1105,54 @@ body.mode-lobby #dashboard {
     border-color: rgba(255, 255, 255, 0.04);
 }
 
-/* ─── Turn Runtime Grid (live game status) ─── */
-
 #turn-runtime {
-    margin-bottom: 8px;
+    margin-bottom: 10px;
+    border: 1px solid var(--border-main);
+    border-radius: var(--panel-radius);
+    background: var(--bg-panel-alt);
+    padding: 8px 10px;
 }
 
 .turn-runtime-grid {
     display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(120px, 1fr));
-    gap: 4px;
-    padding: 6px;
-    background: var(--bg-deep);
-    border: 1px solid var(--border-main);
-    border-radius: var(--card-radius, 6px);
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 6px 10px;
 }
 
 .turn-runtime-item {
     display: flex;
-    flex-direction: column;
-    gap: 2px;
-    padding: 4px 8px;
-    background: var(--bg-panel-alt);
-    border-radius: 4px;
-    border: 1px solid transparent;
+    justify-content: space-between;
+    gap: 8px;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.04);
+    padding-bottom: 3px;
 }
 
 .turn-runtime-item .k {
-    font-family: var(--font-ui);
-    font-size: 9px;
     color: var(--text-dim);
+    font-family: var(--font-ui);
+    font-size: 10px;
     text-transform: uppercase;
-    letter-spacing: 1px;
+    letter-spacing: 0.8px;
 }
 
 .turn-runtime-item .v {
-    font-family: var(--font-body);
-    font-size: 12px;
     color: var(--text-primary);
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
+    font-family: var(--font-ui);
+    font-size: 11px;
+    text-align: right;
 }
 
 .turn-runtime-item .v.status-active {
-    color: var(--accent-primary);
+    color: var(--status-connected);
 }
 
-.turn-runtime-item .v.status-ended {
-    color: var(--text-dim);
-    font-style: italic;
+.turn-runtime-item .v.status-ended,
+.turn-runtime-item .v.status-wipe {
+    color: var(--status-disconnected);
 }
 
 .turn-runtime-item .v.status-idle {
-    color: var(--text-secondary, var(--text-dim));
-}
-
-.turn-runtime-item .v.status-wipe {
-    color: #d44;
-    font-weight: 600;
+    color: var(--text-dim);
 }
 
 /* ─── Turn Controls (advance turn button) ─── */
@@ -1204,6 +1204,113 @@ body.mode-lobby #dashboard {
 
 #dice-log {
     min-height: 100%;
+}
+
+#new-game-panel {
+    position: absolute;
+    inset: 44px 0 0 0;
+    background: rgba(0, 0, 0, 0.52);
+    z-index: 20;
+    display: flex;
+    align-items: flex-start;
+    justify-content: center;
+    padding-top: 28px;
+}
+
+.new-game-card {
+    width: min(520px, calc(100vw - 24px));
+    background: var(--bg-panel);
+    border: 1px solid var(--border-main);
+    border-radius: 10px;
+    box-shadow: 0 14px 46px rgba(0, 0, 0, 0.55);
+    padding: 14px;
+    display: grid;
+    gap: 8px;
+}
+
+.new-game-head {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+}
+
+.new-game-head h3 {
+    margin: 0;
+    font-family: var(--font-display);
+    font-size: 14px;
+    letter-spacing: 1px;
+    color: var(--accent-primary);
+}
+
+.new-game-head button {
+    border: 1px solid var(--border-main);
+    border-radius: var(--panel-radius);
+    background: var(--bg-panel-alt);
+    color: var(--text-primary);
+    font-size: 11px;
+    padding: 4px 10px;
+    cursor: pointer;
+}
+
+.new-game-label {
+    font-family: var(--font-ui);
+    font-size: 10px;
+    color: var(--text-dim);
+    letter-spacing: 0.8px;
+    text-transform: uppercase;
+}
+
+.new-game-row {
+    display: flex;
+    gap: 8px;
+}
+
+#new-game-panel input,
+#new-game-panel select {
+    width: 100%;
+    background: var(--bg-deep);
+    border: 1px solid var(--border-main);
+    border-radius: var(--panel-radius);
+    color: var(--text-primary);
+    font-family: var(--font-ui);
+    font-size: 12px;
+    padding: 7px 9px;
+    outline: none;
+}
+
+#new-game-player-select {
+    min-height: 132px;
+}
+
+#new-game-room-regenerate,
+#new-game-refresh,
+#new-game-start {
+    border: 1px solid var(--border-main);
+    border-radius: var(--panel-radius);
+    background: var(--bg-panel-alt);
+    color: var(--text-primary);
+    font-family: var(--font-ui);
+    font-size: 11px;
+    padding: 7px 10px;
+    cursor: pointer;
+}
+
+#new-game-start {
+    border-color: var(--accent-primary-dim);
+    color: var(--accent-primary);
+}
+
+.new-game-actions {
+    display: flex;
+    justify-content: space-between;
+    gap: 8px;
+}
+
+#new-game-status {
+    min-height: 1.3em;
+    font-family: var(--font-ui);
+    font-size: 11px;
+    color: var(--text-dim);
 }
 
 /* ═══════════════════════════════════════════
@@ -1915,8 +2022,8 @@ body.mode-lobby #dashboard {
 
 #join-panel {
     padding: 8px 10px;
-    border-top: 1px solid var(--border);
-    background: var(--bg-secondary);
+    border-top: 1px solid var(--border-main);
+    background: var(--bg-panel-alt);
 }
 
 #join-input-row {
@@ -1931,9 +2038,9 @@ body.mode-lobby #dashboard {
     padding: 5px 8px;
     font-size: 0.8rem;
     font-family: var(--font-ui);
-    background: var(--bg-primary);
+    background: var(--bg-deep);
     color: var(--text-primary);
-    border: 1px solid var(--border);
+    border: 1px solid var(--border-main);
     border-radius: 3px;
     outline: none;
     transition: border-color 0.2s;
@@ -1992,7 +2099,7 @@ body.mode-lobby #dashboard {
     padding: 4px 0 6px;
     font-size: 0.8rem;
     font-family: var(--font-ui);
-    color: var(--text-secondary);
+    color: var(--text-dim);
 }
 
 #player-actor-id {


### PR DESCRIPTION
## Summary
- add real New Game controls to TRPG viewer (room, DM, players, model list)
- add/restore runtime status panel in TRPG view and keep turn controls visible
- scope actor claim/release and action flows to current room_id instead of hardcoded default
- remove fake fallback party/state injection; show unavailable/empty state when backend is not ready
- skip historical TRPG event backlog on viewer enter to avoid stale previous-session narrative
- replace class_list panel toggle logic with attribute-based class handling for wasm compatibility

## Validation
- cargo check --manifest-path viewer/Cargo.toml
- cargo test --manifest-path viewer/Cargo.toml normalize_masc_shape_uses_defaults_without_fallback_party -- --nocapture
- cargo test --manifest-path viewer/Cargo.toml decode_stream_maps_timeout_and_unavailable_to_narrative -- --nocapture
- scripts/viewer-trunk.sh build