### PR TITLE
feat(viewer): clarify lifecycle states and gate TRPG controls

### DIFF
--- a/viewer/src/dom/action_panel.rs
+++ b/viewer/src/dom/action_panel.rs
@@ -17,6 +17,7 @@ use wasm_bindgen::prelude::*;
 
 #[cfg(target_arch = "wasm32")]
 use crate::config;
+use crate::game::state::{RoomState, TurnProgressState};
 use crate::mode::ViewerMode;
 
 // ─── Marker Resource ────────────────────────
@@ -350,6 +351,42 @@ pub(crate) fn friendly_js_error(e: &JsValue) -> String {
     debug.chars().take(120).collect()
 }
 
+#[cfg(target_arch = "wasm32")]
+fn normalize_room_status(raw: &str) -> String {
+    let normalized = raw.trim().to_ascii_lowercase();
+    if normalized.is_empty() {
+        "unknown".to_string()
+    } else {
+        normalized
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+fn effective_room_status(room_state: &RoomState, progress: &TurnProgressState) -> String {
+    if !progress.room_status.trim().is_empty() {
+        normalize_room_status(&progress.room_status)
+    } else {
+        normalize_room_status(&room_state.status)
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+fn room_accepts_actions(status: &str) -> bool {
+    matches!(status, "active" | "running")
+}
+
+#[cfg(target_arch = "wasm32")]
+fn blocked_action_placeholder(status: &str) -> &'static str {
+    match status {
+        "paused" => "게임 일시정지 상태입니다. 재개 후 액션을 제출하세요.",
+        "ended" => "게임이 종료되었습니다. 새 게임을 시작하세요.",
+        "idle" => "진행 중 게임이 없습니다. 새 게임을 시작하세요.",
+        "loading" => "방 상태를 불러오는 중입니다.",
+        "unavailable" => "엔진 연결 불가 상태입니다.",
+        _ => "현재 방 상태에서는 액션을 제출할 수 없습니다.",
+    }
+}
+
 // ─── DOM Helpers ────────────────────────────
 
 #[cfg(target_arch = "wasm32")]
@@ -453,24 +490,57 @@ fn refresh_action_panel_interaction_state() {
 
 /// Hides the action panel when not in TRPG mode.
 /// The panel HTML always exists in index.html but should only be visible in TRPG.
-pub fn sync_action_panel_visibility(mode: Res<State<ViewerMode>>) {
+pub fn sync_action_panel_visibility(
+    mode: Res<State<ViewerMode>>,
+    room_state: Res<RoomState>,
+    progress: Res<TurnProgressState>,
+) {
     let _ = mode; // read to register as system parameter
+    let _ = (&room_state, &progress);
 
     #[cfg(target_arch = "wasm32")]
     {
-        let visible = matches!(mode.get(), ViewerMode::Trpg);
+        let trpg_visible = matches!(mode.get(), ViewerMode::Trpg);
+        let status = effective_room_status(&room_state, &progress);
         let Some(doc) = web_sys::window().and_then(|w| w.document()) else {
             return;
         };
+        let claimed_actor = doc
+            .get_element_by_id("claimed-actor-id")
+            .and_then(|el| el.dyn_ref::<web_sys::HtmlInputElement>().map(|i| i.value()))
+            .unwrap_or_default();
+        let has_claim = !claimed_actor.trim().is_empty();
+        let panel_visible = trpg_visible && has_claim;
+
         if let Some(el) = doc.get_element_by_id("action-panel") {
             if let Some(html_el) = el.dyn_ref::<web_sys::HtmlElement>() {
                 let _ = html_el
                     .style()
-                    .set_property("display", if visible { "block" } else { "none" });
+                    .set_property("display", if panel_visible { "block" } else { "none" });
             }
         }
-        if visible {
+        if panel_visible {
             refresh_action_panel_interaction_state();
+
+            let has_actor = current_playable_actor_id().is_some();
+            let can_act = has_actor && room_accepts_actions(&status);
+
+            if let Some(el) = doc.get_element_by_id("action-input") {
+                if let Some(input) = el.dyn_ref::<web_sys::HtmlInputElement>() {
+                    input.set_disabled(!can_act);
+                    if !room_accepts_actions(&status) {
+                        input.set_placeholder(blocked_action_placeholder(&status));
+                    }
+                }
+            }
+
+            for id in &["action-submit-btn", "dice-roll-btn"] {
+                if let Some(el) = doc.get_element_by_id(id) {
+                    if let Some(btn) = el.dyn_ref::<web_sys::HtmlButtonElement>() {
+                        btn.set_disabled(!can_act);
+                    }
+                }
+            }
         }
     }
 }

--- a/viewer/src/dom/actor_join.rs
+++ b/viewer/src/dom/actor_join.rs
@@ -14,6 +14,7 @@ use wasm_bindgen::prelude::*;
 
 #[cfg(target_arch = "wasm32")]
 use crate::config;
+use crate::game::state::{RoomState, TurnProgressState};
 
 // ─── Marker Resource ────────────────────────
 
@@ -46,6 +47,42 @@ pub fn unbind_actor_join(mut commands: Commands) {
     }
 
     commands.remove_resource::<ActorJoinBound>();
+}
+
+#[cfg(target_arch = "wasm32")]
+fn normalize_room_status(raw: &str) -> String {
+    let normalized = raw.trim().to_ascii_lowercase();
+    if normalized.is_empty() {
+        "unknown".to_string()
+    } else {
+        normalized
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+fn effective_room_status(room_state: &RoomState, progress: &TurnProgressState) -> String {
+    if !progress.room_status.trim().is_empty() {
+        normalize_room_status(&progress.room_status)
+    } else {
+        normalize_room_status(&room_state.status)
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+fn room_accepts_join(status: &str) -> bool {
+    matches!(status, "active" | "running")
+}
+
+#[cfg(target_arch = "wasm32")]
+fn room_blocked_join_message(status: &str) -> &'static str {
+    match status {
+        "paused" => "ROOM: 게임이 일시정지 상태입니다. 재개 후 참여할 수 있습니다.",
+        "ended" => "ROOM: 게임이 종료되었습니다. 새 게임을 시작하세요.",
+        "idle" => "ROOM: 진행 중 게임이 없습니다. 새 게임을 시작하세요.",
+        "loading" => "ROOM: 방 상태를 불러오는 중입니다.",
+        "unavailable" => "ROOM: 엔진 연결 상태를 확인할 수 없습니다.",
+        _ => "ROOM: 현재 상태에서는 참여할 수 없습니다.",
+    }
 }
 
 // ─── Event: Join Button ─────────────────────
@@ -311,6 +348,53 @@ fn restore_join_panel_state() {
         set_display(&doc, "action-panel", "block");
         if let Some(el) = doc.get_element_by_id("player-actor-id") {
             el.set_text_content(Some(&actor_id));
+        }
+    }
+}
+
+/// Disable join controls when the room is not in an interactive state.
+/// This prevents confusing claim errors for ended/idle/unavailable rooms.
+pub fn sync_join_panel_interaction_state(
+    room_state: Res<RoomState>,
+    progress: Res<TurnProgressState>,
+) {
+    let _ = (&room_state, &progress);
+
+    #[cfg(target_arch = "wasm32")]
+    {
+        let Some(doc) = web_sys::window().and_then(|w| w.document()) else {
+            return;
+        };
+        let claimed_actor = read_hidden_value(&doc, "claimed-actor-id");
+        if !claimed_actor.trim().is_empty() {
+            return;
+        }
+
+        let status = effective_room_status(&room_state, &progress);
+        let join_enabled = room_accepts_join(&status);
+
+        if let Some(el) = doc.get_element_by_id("join-btn") {
+            if let Some(btn) = el.dyn_ref::<web_sys::HtmlButtonElement>() {
+                btn.set_disabled(!join_enabled);
+            }
+        }
+        for input_id in &["actor-id-input", "keeper-input"] {
+            if let Some(el) = doc.get_element_by_id(input_id) {
+                if let Some(input) = el.dyn_ref::<web_sys::HtmlInputElement>() {
+                    input.set_disabled(!join_enabled);
+                }
+            }
+        }
+
+        if join_enabled {
+            if let Some(status_el) = doc.get_element_by_id("join-status") {
+                let current = status_el.text_content().unwrap_or_default();
+                if current.starts_with("ROOM: ") {
+                    set_join_status("", "");
+                }
+            }
+        } else {
+            set_join_status(room_blocked_join_message(&status), "status-error");
         }
     }
 }

--- a/viewer/src/dom/mod.rs
+++ b/viewer/src/dom/mod.rs
@@ -36,6 +36,7 @@ impl Plugin for DomBridgePlugin {
                 turn_phase::update_turn_phase_dom,
                 turn_runtime::update_turn_runtime_dom,
                 connection::update_connection_dom,
+                actor_join::sync_join_panel_interaction_state,
                 action_panel::sync_action_panel_visibility,
                 turn_controls::sync_turn_controls_visibility,
             ).run_if(in_state(ViewerMode::Trpg)))

--- a/viewer/src/dom/turn_controls.rs
+++ b/viewer/src/dom/turn_controls.rs
@@ -16,6 +16,7 @@ use wasm_bindgen::prelude::*;
 
 #[cfg(target_arch = "wasm32")]
 use crate::config;
+use crate::game::state::{RoomState, TurnProgressState};
 
 // ─── Marker Resource ────────────────────────
 
@@ -49,9 +50,30 @@ pub fn unbind_turn_controls(mut commands: Commands) {
 // ─── Visibility Sync ────────────────────────
 
 /// Show turn controls only when a keeper is claimed (Keeper/GM privilege).
-pub fn sync_turn_controls_visibility() {
+pub fn sync_turn_controls_visibility(
+    room_state: Res<RoomState>,
+    progress: Res<TurnProgressState>,
+) {
+    let _ = (&room_state, &progress);
+
     #[cfg(target_arch = "wasm32")]
     {
+        fn normalize_room_status(raw: &str) -> String {
+            let normalized = raw.trim().to_ascii_lowercase();
+            if normalized.is_empty() {
+                "unknown".to_string()
+            } else {
+                normalized
+            }
+        }
+
+        let status = if !progress.room_status.trim().is_empty() {
+            normalize_room_status(&progress.room_status)
+        } else {
+            normalize_room_status(&room_state.status)
+        };
+        let room_allows_control = matches!(status.as_str(), "active" | "running");
+
         let Some(doc) = web_sys::window().and_then(|w| w.document()) else {
             return;
         };
@@ -63,7 +85,11 @@ pub fn sync_turn_controls_visibility() {
             .and_then(|el| el.dyn_ref::<web_sys::HtmlInputElement>().map(|i| i.value()));
         let has_keeper = keeper.map_or(false, |v| !v.trim().is_empty());
 
-        let style = if has_keeper { "" } else { "display:none" };
+        let style = if has_keeper && room_allows_control {
+            ""
+        } else {
+            "display:none"
+        };
         let _ = panel.set_attribute("style", style);
     }
 }

--- a/viewer/src/dom/turn_runtime.rs
+++ b/viewer/src/dom/turn_runtime.rs
@@ -26,6 +26,44 @@ fn pretty_phase(phase: &str) -> String {
     }
 }
 
+fn normalize_room_status(raw: &str) -> String {
+    let normalized = raw.trim().to_ascii_lowercase();
+    if normalized.is_empty() {
+        "unknown".to_string()
+    } else {
+        normalized
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+fn room_status_class(status: &str) -> &'static str {
+    match status {
+        "active" | "running" => "status-active",
+        "paused" => "status-paused",
+        "ended" => "status-ended",
+        "unavailable" => "status-unavailable",
+        "loading" => "status-loading",
+        _ => "status-idle",
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+fn room_status_label(status: &str) -> &'static str {
+    match status {
+        "active" | "running" => "RUNNING",
+        "paused" => "PAUSED",
+        "ended" => "ENDED",
+        "idle" => "IDLE",
+        "loading" => "LOADING",
+        "unavailable" => "UNAVAILABLE",
+        _ => "UNKNOWN",
+    }
+}
+
+fn room_accepts_input(status: &str) -> bool {
+    matches!(status, "active" | "running")
+}
+
 /// Render live TRPG runtime progress:
 /// room/turn/phase, current thinker, next actor, last outcome, and party survival.
 pub fn update_turn_runtime_dom(
@@ -34,13 +72,14 @@ pub fn update_turn_runtime_dom(
     actors: Query<&Actor>,
     mut cache: ResMut<TurnRuntimeCache>,
 ) {
-    let room_status = if !progress.room_status.trim().is_empty() {
+    let room_status_raw = if !progress.room_status.trim().is_empty() {
         progress.room_status.trim().to_string()
     } else if !room_state.status.trim().is_empty() {
         room_state.status.trim().to_string()
     } else {
         "unknown".to_string()
     };
+    let room_status = normalize_room_status(&room_status_raw);
     let turn = if progress.turn > 0 {
         progress.turn
     } else if room_state.turn > 0 {
@@ -95,16 +134,22 @@ pub fn update_turn_runtime_dom(
         format!("{}/{} alive", alive_party, total_party)
     };
 
-    let current_status = if current_actor != "-" {
+    let current_status = if !room_accepts_input(&room_status) {
+        room_status.as_str()
+    } else if current_actor != "-" {
         "thinking"
-    } else if room_status == "ended" {
-        "ended"
     } else {
-        "idle"
+        "waiting"
+    };
+
+    let input_status = if room_accepts_input(&room_status) {
+        "enabled"
+    } else {
+        "disabled"
     };
 
     let snapshot = format!(
-        "{}|{}|{}|{}|{}|{}|{}|{}",
+        "{}|{}|{}|{}|{}|{}|{}|{}|{}",
         room_status,
         turn,
         phase,
@@ -112,7 +157,8 @@ pub fn update_turn_runtime_dom(
         next_actor,
         last_result,
         party_status,
-        current_status
+        current_status,
+        input_status
     );
     if cache.last_snapshot == snapshot {
         return;
@@ -128,23 +174,25 @@ pub fn update_turn_runtime_dom(
             return;
         };
 
-        let room_class = match room_status.as_str() {
-            "ended" => "status-ended",
-            "active" => "status-active",
-            _ => "status-idle",
-        };
+        let room_class = room_status_class(&room_status);
         let party_class = if total_party > 0 && alive_party <= 0 {
             "status-wipe"
         } else {
             "status-active"
         };
+        let input_class = if room_accepts_input(&room_status) {
+            "status-active"
+        } else {
+            room_class
+        };
 
         let html = format!(
             r#"
 <div class="turn-runtime-grid">
-  <div class="turn-runtime-item"><span class="k">Room</span><span class="v {room_class}">{room}</span></div>
+  <div class="turn-runtime-item"><span class="k">State</span><span class="v {room_class}">{room}</span></div>
   <div class="turn-runtime-item"><span class="k">Turn</span><span class="v">{turn}</span></div>
   <div class="turn-runtime-item"><span class="k">Phase</span><span class="v">{phase}</span></div>
+  <div class="turn-runtime-item"><span class="k">Input</span><span class="v {input_class}">{input}</span></div>
   <div class="turn-runtime-item"><span class="k">Now</span><span class="v">{current} · {current_status}</span></div>
   <div class="turn-runtime-item"><span class="k">Next</span><span class="v">{next}</span></div>
   <div class="turn-runtime-item"><span class="k">Last</span><span class="v">{last}</span></div>
@@ -152,9 +200,11 @@ pub fn update_turn_runtime_dom(
 </div>
 "#,
             room_class = room_class,
-            room = sanitize_text(&room_status.to_uppercase()),
+            room = sanitize_text(room_status_label(&room_status)),
             turn = turn,
             phase = sanitize_text(&pretty_phase(&phase)),
+            input_class = input_class,
+            input = sanitize_text(input_status),
             current = sanitize_text(&current_actor),
             current_status = sanitize_text(current_status),
             next = sanitize_text(&next_actor),

--- a/viewer/src/game/http.rs
+++ b/viewer/src/game/http.rs
@@ -103,6 +103,17 @@ pub struct ActiveTrpgRoom {
     pub room_id: String,
 }
 
+fn normalize_room_status(raw: &str) -> String {
+    raw.trim().to_ascii_lowercase()
+}
+
+fn room_requires_new_game(raw_status: &str) -> bool {
+    matches!(
+        normalize_room_status(raw_status).as_str(),
+        "" | "idle" | "ended" | "unavailable"
+    )
+}
+
 fn queue_initial_state_fetch(commands: &mut Commands) {
     let buffer: Arc<Mutex<Option<GameStateResponse>>> = Arc::new(Mutex::new(None));
     let shared = buffer.clone();
@@ -228,18 +239,17 @@ pub fn apply_initial_state(
         *connection = ConnectionStatus::Connected;
     }
 
-    // Stale room detection: if the room isn't actively running a game,
-    // skip spawning old actors and prompt the user to start a new game.
-    let room_is_active = room_state.status.trim() == "active";
-    if !room_is_active {
+    // Rooms in terminal/empty states should open the new-game flow instead of
+    // replaying stale entities. Paused/running rooms are resumable and keep state.
+    if room_requires_new_game(&room_state.status) {
         turn_progress.room_status = room_state.status.clone();
         turn_progress.turn = room_state.turn;
         turn_progress.phase = room_state.phase.as_str().to_string();
         buffer.consumed = true;
 
-        prompt_new_game_for_stale_room(room_state.status.trim());
+        prompt_new_game_for_inactive_room(room_state.status.trim());
         log::info!(
-            "Room '{}' not active (status: '{}') — skipping actor spawn, showing new-game panel",
+            "Room '{}' is not resumable (status: '{}') — skipping actor spawn, showing new-game panel",
             room_state.id,
             room_state.status,
         );
@@ -417,9 +427,11 @@ fn parse_masc_state_response(root: &Value) -> GameStateResponse {
     }
 }
 
-/// When the fetched room is not "active", auto-show the new-game panel
+/// When the fetched room is not resumable, auto-show the new-game panel
 /// and pre-fill a fresh room ID so the user can start a new session.
-fn prompt_new_game_for_stale_room(_room_status: &str) {
+fn prompt_new_game_for_inactive_room(room_status: &str) {
+    let _ = room_status;
+
     #[cfg(target_arch = "wasm32")]
     {
         let Some(document) = web_sys::window().and_then(|w| w.document()) else {
@@ -447,10 +459,10 @@ fn prompt_new_game_for_stale_room(_room_status: &str) {
 
         // Set a status message appropriate to the room state
         if let Some(el) = document.get_element_by_id("new-game-status") {
-            let msg = if _room_status == "unavailable" {
-                "엔진에 연결할 수 없습니다. 새 게임을 시작하면 재연결을 시도합니다."
-            } else {
-                "활성 게임이 없습니다. 새 게임을 시작하세요."
+            let msg = match normalize_room_status(room_status).as_str() {
+                "ended" => "이 게임은 종료되었습니다. 새 게임을 시작하세요.",
+                "unavailable" => "엔진에 연결할 수 없습니다. 새 게임을 시작하면 재연결을 시도합니다.",
+                _ => "진행 중인 게임이 없습니다. 새 게임을 시작하세요.",
             };
             el.set_inner_html(msg);
         }
@@ -569,5 +581,20 @@ mod tests {
         assert_eq!(room.id, "test-room");
         assert_eq!(room.status, "unavailable");
         assert!(state.characters.is_empty());
+    }
+
+    #[test]
+    fn paused_room_is_resumable() {
+        assert!(!room_requires_new_game("paused"));
+    }
+
+    #[test]
+    fn ended_room_requires_new_game() {
+        assert!(room_requires_new_game("ended"));
+    }
+
+    #[test]
+    fn normalize_room_status_is_case_insensitive() {
+        assert_eq!(normalize_room_status("  AcTiVe "), "active");
     }
 }

--- a/viewer/style.css
+++ b/viewer/style.css
@@ -1146,7 +1146,13 @@ body.mode-lobby #dashboard {
     color: var(--status-connected);
 }
 
+.turn-runtime-item .v.status-paused,
+.turn-runtime-item .v.status-loading {
+    color: var(--status-connecting);
+}
+
 .turn-runtime-item .v.status-ended,
+.turn-runtime-item .v.status-unavailable,
 .turn-runtime-item .v.status-wipe {
     color: var(--status-disconnected);
 }


### PR DESCRIPTION
## Summary
- classify room lifecycle states in viewer (active/paused/ended/idle/unavailable/loading)
- stop treating paused rooms as stale; keep resumable state visible
- gate Join/Action/Turn controls by lifecycle state so ended/idle sessions are not interactive
- improve turn-runtime panel with explicit STATE and INPUT fields plus paused/unavailable color states

## Validation
- cargo check --manifest-path viewer/Cargo.toml
- cargo test --manifest-path viewer/Cargo.toml paused_room_is_resumable -- --nocapture
- scripts/viewer-trunk.sh build
