### PR TITLE
fix(viewer): simplify room hub UX and remove duplicate session CTA

### DIFF
--- a/lib/web_dashboard.ml
+++ b/lib/web_dashboard.ml
@@ -1654,6 +1654,11 @@ let cached_html = lazy ({|<!DOCTYPE html>
     }
     .trpg-run-btn:hover { border-color: rgba(34,211,238,0.78); background: rgba(14,116,144,0.45); }
     .trpg-run-btn:disabled { opacity: 0.55; cursor: not-allowed; }
+    .trpg-run-btn.recommend {
+      border-color: rgba(250,204,21,0.75);
+      box-shadow: 0 0 0 1px rgba(250,204,21,0.38), 0 0 16px rgba(250,204,21,0.18);
+      background: rgba(113,63,18,0.28);
+    }
     .trpg-run-btn.secondary {
       border-color: rgba(148,163,184,0.35);
       background: rgba(15,23,42,0.75);
@@ -1909,23 +1914,15 @@ let cached_html = lazy ({|<!DOCTYPE html>
       line-height: 1.45;
       word-break: break-word;
     }
-    .trpg-next-action .act {
-      border: 1px solid rgba(34,211,238,0.45);
+    .trpg-next-action .target {
+      border: 1px solid rgba(148,163,184,0.35);
       border-radius: 8px;
-      background: rgba(8,47,73,0.88);
+      background: rgba(15,23,42,0.6);
       color: #e2e8f0;
-      font-weight: 700;
+      font-weight: 600;
       font-size: 0.84em;
       padding: 8px 10px;
-      cursor: pointer;
-    }
-    .trpg-next-action .act:hover {
-      border-color: rgba(34,211,238,0.78);
-      background: rgba(14,116,144,0.45);
-    }
-    .trpg-next-action .act:disabled {
-      opacity: 0.55;
-      cursor: not-allowed;
+      line-height: 1.4;
     }
     .trpg-dev-note {
       margin-top: 6px;
@@ -2330,11 +2327,11 @@ let cached_html = lazy ({|<!DOCTYPE html>
                   <span>이전 세션 로그 포함 보기</span>
                 </label>
               </div>
-              <div id="trpg-round-run-status" class="trpg-run-status">0) 새 게임 시작(선택) → 1) 세션 시작 → 2) 라운드 실행 순서로 진행하세요.</div>
+              <div id="trpg-round-run-status" class="trpg-run-status">세션 상태: 미시작 · 0) 새 게임 시작(선택) → 1) 세션 시작 → 2) 라운드 실행 순서로 진행하세요.</div>
               <div id="trpg-next-action" class="trpg-next-action">
                 <div class="title">다음 액션</div>
-                <div id="trpg-next-action-desc" class="desc">세션을 시작하면 다음에 눌러야 할 버튼을 자동으로 안내합니다.</div>
-                <button id="trpg-next-action-btn" class="act" onclick="trpgRunNextAction()">1) 세션 시작</button>
+                <div id="trpg-next-action-desc" class="desc">세션 상태를 확인하고, 상단 메인 버튼에서 다음 단계를 진행하세요.</div>
+                <div id="trpg-next-action-target" class="target">권장 클릭: 1) 세션 시작 (상단 버튼)</div>
               </div>
               <div class="trpg-section-title" style="margin-top:10px;">액터 관리</div>
               <div class="trpg-control-grid">
@@ -7410,48 +7407,63 @@ let cached_html = lazy ({|<!DOCTYPE html>
       showToast(mode, 'success');
     }
 
+    function trpgActionButtonId(kind) {
+      const key = String(kind || '');
+      if (key === 'bootstrap') return 'trpg-bootstrap-btn';
+      if (key === 'run_round') return 'trpg-run-round-btn';
+      return '';
+    }
+
+    function trpgSetActionRowHighlight(buttonId, enabled = true) {
+      ['trpg-bootstrap-btn', 'trpg-run-round-btn', 'trpg-new-game-btn', 'trpg-reload-btn'].forEach((id) => {
+        const el = document.getElementById(id);
+        if (!el) return;
+        el.classList.remove('recommend');
+      });
+      if (!buttonId || !enabled) return;
+      const activeEl = document.getElementById(buttonId);
+      if (activeEl) activeEl.classList.add('recommend');
+    }
+
     function trpgSetNextAction(kind, label, desc, enabled = true) {
       trpgNextActionKind = String(kind || 'none');
       trpgCanRunRound = trpgNextActionKind === 'run_round' && !!enabled;
       trpgRunBlockedReason = trpgCanRunRound ? '' : String(desc || '실행 전 점검이 필요합니다.');
       const descEl = document.getElementById('trpg-next-action-desc');
-      const btnEl = document.getElementById('trpg-next-action-btn');
+      const targetEl = document.getElementById('trpg-next-action-target');
+      const targetBtnId = trpgActionButtonId(trpgNextActionKind);
       if (descEl) descEl.textContent = String(desc || '');
-      if (btnEl) {
-        btnEl.textContent = String(label || '새로고침');
-        btnEl.disabled = !enabled;
+      if (targetEl) {
+        if (targetBtnId && enabled) {
+          targetEl.textContent = `권장 클릭: ${String(label || '메인 버튼')} (상단 버튼)`;
+        } else if (targetBtnId && !enabled) {
+          targetEl.textContent = `권장 클릭: ${String(label || '메인 버튼')} (현재 실행 불가)`;
+        } else {
+          targetEl.textContent = '자동 대기: 상태 변화 감지 중';
+        }
       }
+      trpgSetActionRowHighlight(targetBtnId, !!enabled);
       updateTrpgButtons();
-    }
-
-    function trpgRunNextAction() {
-      if (trpgNextActionKind === 'bootstrap') {
-        bootstrapTrpgSession();
-      } else if (trpgNextActionKind === 'run_round') {
-        runTrpgRound();
-      } else {
-        fetchTrpg();
-      }
     }
 
     function trpgUpdateNextAction(state, events) {
       const viewEvents = trpgCurrentSessionEvents(events);
       if (trpgBootstrapping) {
-        trpgSetNextAction('wait', '준비 중...', '세션 시작 준비가 진행 중입니다. 잠시만 기다리세요.', false);
+        trpgSetNextAction('wait', '1) 세션 시작', '세션 상태: 시작 중 · 세션 구성 완료까지 잠시만 기다리세요.', false);
         return;
       }
       if (trpgRoundRunning) {
-        trpgSetNextAction('wait', '라운드 실행 중...', '현재 라운드가 진행 중입니다. 완료 후 상태가 자동 갱신됩니다.', false);
+        trpgSetNextAction('wait', '2) 라운드 실행', '세션 상태: 진행 중 · 현재 라운드 실행이 끝나면 자동 갱신됩니다.', false);
         return;
       }
       const sessions = trpgBuildSessionHistory(viewEvents);
       if (sessions.length === 0) {
-        trpgSetNextAction('bootstrap', '1) 세션 시작', '아직 세션이 없습니다. world/dm preset 확인 후 세션을 시작하세요.', true);
+        trpgSetNextAction('bootstrap', '1) 세션 시작', '세션 상태: 미시작 · world/dm preset 확인 후 세션을 시작하세요.', true);
         return;
       }
       const expectedActors = trpgPartyActorsFromStateOrEvents(state, viewEvents);
       if (expectedActors.length === 0) {
-        trpgSetNextAction('wait', '세션 준비 중', '파티 actor_id를 아직 확인하지 못했습니다. 1) 세션 시작을 다시 실행하세요.', false);
+        trpgSetNextAction('wait', '1) 세션 시작', '세션 상태: 시작됨(불완전) · 파티 actor_id를 아직 확인하지 못했습니다. 1) 세션 시작을 다시 실행하세요.', false);
         return;
       }
       const resolved = trpgResolvePlayerKeeperMapping(
@@ -7460,7 +7472,7 @@ let cached_html = lazy ({|<!DOCTYPE html>
         String((document.getElementById('trpg-player-keepers-input') || {}).value || '')
       );
       if (!resolved.ok) {
-        trpgSetNextAction('wait', '입력 수정 필요', 'Player keepers 입력 형식 오류를 먼저 해결하세요.', false);
+        trpgSetNextAction('wait', '입력 수정 필요', '세션 상태: 확인 필요 · Player keepers 입력 형식 오류를 먼저 해결하세요.', false);
         return;
       }
       const missingActors = resolved.missingActors || [];
@@ -7469,7 +7481,7 @@ let cached_html = lazy ({|<!DOCTYPE html>
         trpgSetNextAction(
           'wait',
           '할당 수정 필요',
-          '현재 파티 actor_id와 Player keepers actor_id가 일치하지 않습니다. 파티 할당 카드에서 빨간 항목을 먼저 정리하세요.',
+          '세션 상태: 확인 필요 · 파티 actor_id와 Player keepers actor_id가 일치하지 않습니다. 파티 할당 카드에서 빨간 항목을 먼저 정리하세요.',
           false
         );
         return;
@@ -7482,7 +7494,7 @@ let cached_html = lazy ({|<!DOCTYPE html>
           trpgSyncKeeperSelectorsFromInputs();
         }
       }
-      trpgSetNextAction('run_round', '다음 라운드 실행', '준비 완료. 다음 라운드를 실행해 서사를 진행하세요.', true);
+      trpgSetNextAction('run_round', '2) 라운드 실행', '세션 상태: 준비 완료 · 2) 라운드 실행으로 서사를 진행하세요.', true);
     }
 
     function trpgFmtDateTime(ts) {

--- a/viewer/index.html
+++ b/viewer/index.html
@@ -159,6 +159,7 @@
                     <input id="room-input-inline" class="inline-input" type="text" value="default" placeholder="room-id" maxlength="64" />
                     <button id="room-apply-btn" class="inline-toggle" type="button">Room 적용</button>
                     <button id="room-refresh-btn" class="inline-toggle" type="button">목록 새로고침</button>
+                    <button id="room-hub-toggle" class="inline-toggle" type="button" aria-pressed="false">Rooms OFF</button>
                     <span id="room-status" class="widget-pill">room default</span>
                 </div>
                 <button id="new-game-toggle" class="inline-toggle" type="button">새 게임</button>
@@ -178,48 +179,50 @@
             </div>
         </header>
 
-        <section id="new-game-panel" class="new-game-panel" style="display: none;">
-            <div class="new-game-panel-head">
-                <strong>새 게임 시작</strong>
-                <button id="new-game-close" class="inline-toggle" type="button">닫기</button>
+        <section id="new-game-panel" style="display: none;">
+            <div class="new-game-card">
+                <div class="new-game-panel-head">
+                    <strong>새 게임 시작</strong>
+                    <button id="new-game-close" class="inline-toggle" type="button">닫기</button>
+                </div>
+                <div class="new-game-grid">
+                    <label class="new-game-field">
+                        <span>Room ID</span>
+                        <div class="new-game-inline">
+                            <input id="new-game-room-id" type="text" maxlength="64" placeholder="adventure-..." />
+                            <button id="new-game-room-regenerate" class="inline-toggle" type="button">재생성</button>
+                        </div>
+                    </label>
+
+                    <label class="new-game-field">
+                        <span>DM Keeper</span>
+                        <select id="new-game-dm-select">
+                            <option value="">로딩 중...</option>
+                        </select>
+                    </label>
+
+                    <label class="new-game-field">
+                        <span>Player Keepers (다중 선택)</span>
+                        <select id="new-game-player-select" multiple size="6">
+                            <option value="">로딩 중...</option>
+                        </select>
+                    </label>
+
+                    <label class="new-game-field">
+                        <span>Keeper Models (comma-separated)</span>
+                        <input id="new-game-models" type="text" value="ollama:glm-4.7-flash" />
+                    </label>
+                </div>
+
+                <div class="new-game-actions">
+                    <button id="new-game-refresh" class="inline-toggle" type="button">Keeper 새로고침</button>
+                    <button id="new-game-start" class="inline-toggle primary" type="button">세션 시작</button>
+                </div>
+                <div id="new-game-status" class="new-game-status">버튼을 눌러 준비하세요.</div>
             </div>
-            <div class="new-game-grid">
-                <label class="new-game-field">
-                    <span>Room ID</span>
-                    <div class="new-game-inline">
-                        <input id="new-game-room-id" type="text" maxlength="64" placeholder="adventure-..." />
-                        <button id="new-game-room-regenerate" class="inline-toggle" type="button">재생성</button>
-                    </div>
-                </label>
-
-                <label class="new-game-field">
-                    <span>DM Keeper</span>
-                    <select id="new-game-dm-select">
-                        <option value="">로딩 중...</option>
-                    </select>
-                </label>
-
-                <label class="new-game-field">
-                    <span>Player Keepers (다중 선택)</span>
-                    <select id="new-game-player-select" multiple size="6">
-                        <option value="">로딩 중...</option>
-                    </select>
-                </label>
-
-                <label class="new-game-field">
-                    <span>Keeper Models (comma-separated)</span>
-                    <input id="new-game-models" type="text" value="ollama:glm-4.7-flash" />
-                </label>
-            </div>
-
-            <div class="new-game-actions">
-                <button id="new-game-refresh" class="inline-toggle" type="button">Keeper 새로고침</button>
-                <button id="new-game-start" class="inline-toggle primary" type="button">세션 시작</button>
-            </div>
-            <div id="new-game-status" class="new-game-status">버튼을 눌러 준비하세요.</div>
         </section>
 
-        <section id="room-hub" class="room-hub">
+        <section id="room-hub" class="room-hub" style="display: none;">
             <div class="room-hub-placeholder">방 목록을 불러오는 중...</div>
         </section>
 

--- a/viewer/src/mode.rs
+++ b/viewer/src/mode.rs
@@ -424,7 +424,7 @@ fn bind_debug_controls(doc: &web_sys::Document) {
         return;
     }
     let _ = toggle.set_attribute("data-bound", "1");
-    set_debug_state(doc, true);
+    set_debug_state(doc, false);
 
     let cb = Closure::wrap(Box::new(move || {
         let Some(doc) = web_sys::window().and_then(|w| w.document()) else {
@@ -493,6 +493,33 @@ fn clear_trpg_dom(doc: &web_sys::Document) {
     if let Some(el) = doc.get_element_by_id("turn-num") {
         el.set_text_content(Some("1"));
     }
+    if let Some(el) = doc.get_element_by_id("turn-runtime") {
+        el.set_inner_html("");
+    }
+    if let Some(el) = doc.get_element_by_id("turn-controls") {
+        let _ = el.set_attribute("style", "display:none");
+    }
+    if let Some(el) = doc.get_element_by_id("action-panel") {
+        let _ = el.set_attribute("style", "display:none");
+    }
+    if let Some(el) = doc.get_element_by_id("join-status") {
+        el.set_text_content(Some(""));
+    }
+    if let Some(el) = doc.get_element_by_id("action-status") {
+        el.set_text_content(Some(""));
+    }
+    if let Some(input) = doc
+        .get_element_by_id("claimed-actor-id")
+        .and_then(|el| el.dyn_into::<web_sys::HtmlInputElement>().ok())
+    {
+        input.set_value("");
+    }
+    if let Some(input) = doc
+        .get_element_by_id("claimed-keeper")
+        .and_then(|el| el.dyn_into::<web_sys::HtmlInputElement>().ok())
+    {
+        input.set_value("");
+    }
 }
 
 #[cfg(target_arch = "wasm32")]
@@ -512,6 +539,8 @@ fn unique_non_empty(mut values: Vec<String>) -> Vec<String> {
 const RECENT_ROOMS_STORAGE_KEY: &str = "masc_viewer_recent_rooms";
 #[cfg(target_arch = "wasm32")]
 const KNOWN_ROOMS_STORAGE_KEY: &str = "masc_viewer_known_rooms";
+#[cfg(target_arch = "wasm32")]
+const ROOM_HUB_VISIBLE_STORAGE_KEY: &str = "masc_viewer_room_hub_visible";
 
 #[cfg(target_arch = "wasm32")]
 fn load_recent_rooms() -> Vec<String> {
@@ -764,6 +793,31 @@ fn save_known_rooms(rooms: &[String]) {
 }
 
 #[cfg(target_arch = "wasm32")]
+fn load_room_hub_visible() -> bool {
+    web_sys::window()
+        .and_then(|w| w.local_storage().ok().flatten())
+        .and_then(|storage| storage.get_item(ROOM_HUB_VISIBLE_STORAGE_KEY).ok().flatten())
+        .map(|value| matches!(value.trim(), "1" | "true" | "on"))
+        .unwrap_or(false)
+}
+
+#[cfg(target_arch = "wasm32")]
+fn save_room_hub_visible(visible: bool) {
+    if let Some(storage) = web_sys::window().and_then(|w| w.local_storage().ok().flatten()) {
+        let _ = storage.set_item(ROOM_HUB_VISIBLE_STORAGE_KEY, if visible { "1" } else { "0" });
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+fn set_room_hub_visible(doc: &web_sys::Document, visible: bool) {
+    set_element_display(doc, "room-hub", if visible { "grid" } else { "none" });
+    if let Some(toggle) = doc.get_element_by_id("room-hub-toggle") {
+        let _ = toggle.set_attribute("aria-pressed", if visible { "true" } else { "false" });
+        toggle.set_text_content(Some(if visible { "Rooms ON" } else { "Rooms OFF" }));
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
 fn remember_known_rooms(extra_rooms: &[String]) {
     let mut rooms = load_known_rooms();
     for raw in extra_rooms {
@@ -913,6 +967,7 @@ fn bind_room_controls(doc: &web_sys::Document) {
     };
     let room_now = crate::config::current_room_id();
     sync_room_controls(doc, &room_now);
+    set_room_hub_visible(doc, load_room_hub_visible());
 
     if select_el.get_attribute("data-bound").as_deref() == Some("1") {
         return;
@@ -1016,6 +1071,28 @@ fn bind_room_controls(doc: &web_sys::Document) {
             target.add_event_listener_with_callback("click", refresh_cb.as_ref().unchecked_ref())
         });
         refresh_cb.forget();
+    }
+
+    if let Some(hub_toggle) = doc.get_element_by_id("room-hub-toggle") {
+        let hub_cb = Closure::wrap(Box::new(move || {
+            let Some(doc) = web_sys::window().and_then(|w| w.document()) else {
+                return;
+            };
+            let visible = doc
+                .get_element_by_id("room-hub-toggle")
+                .and_then(|el| el.get_attribute("aria-pressed"))
+                .map(|v| v == "true")
+                .unwrap_or(false);
+            let next = !visible;
+            set_room_hub_visible(&doc, next);
+            save_room_hub_visible(next);
+        }) as Box<dyn FnMut()>);
+        let _ = hub_toggle
+            .dyn_ref::<web_sys::EventTarget>()
+            .map(|target| {
+                target.add_event_listener_with_callback("click", hub_cb.as_ref().unchecked_ref())
+            });
+        hub_cb.forget();
     }
 }
 

--- a/viewer/style.css
+++ b/viewer/style.css
@@ -457,6 +457,12 @@ body.mode-lobby #dashboard {
     color: var(--text-dim);
 }
 
+#room-hub-toggle[aria-pressed="true"] {
+    border-color: var(--accent-primary);
+    color: var(--accent-primary);
+    box-shadow: inset 0 0 0 1px rgba(201, 165, 90, 0.35);
+}
+
 .inline-button {
     border-color: var(--accent-primary-dim);
     color: var(--accent-primary);
@@ -566,6 +572,8 @@ body.mode-lobby #dashboard {
     display: grid;
     grid-template-columns: repeat(3, minmax(120px, 1fr));
     gap: 8px;
+    max-height: 192px;
+    overflow: hidden;
 }
 
 .room-hub-placeholder {
@@ -579,7 +587,7 @@ body.mode-lobby #dashboard {
     border-radius: var(--panel-radius);
     padding: 6px;
     background: rgba(15, 20, 36, 0.7);
-    min-height: 56px;
+    min-height: 0;
 }
 
 .room-lane[data-lane="running"] {
@@ -602,7 +610,7 @@ body.mode-lobby #dashboard {
     display: flex;
     flex-direction: column;
     gap: 4px;
-    max-height: 132px;
+    max-height: 142px;
     overflow: auto;
 }
 
@@ -1410,12 +1418,13 @@ body.mode-lobby #dashboard {
 #new-game-panel {
     position: absolute;
     inset: 44px 0 0 0;
-    background: rgba(0, 0, 0, 0.52);
+    background: rgba(0, 0, 0, 0.56);
     z-index: 20;
     display: flex;
     align-items: flex-start;
     justify-content: center;
-    padding-top: 28px;
+    padding: 28px 12px 12px 12px;
+    overflow-y: auto;
 }
 
 .new-game-card {


### PR DESCRIPTION
Summary\n- hide room hub lanes by default and add explicit Rooms ON/OFF toggle in TRPG top bar\n- keep new-game modal as an overlay (no layout push) and constrain room hub height\n- reset TRPG DOM state more aggressively on room switch to avoid stale narrative/runtime leftovers\n- set debug log default to OFF for cleaner first view\n- remove duplicate dashboard CTA by making next-action guidance text-only and highlight the primary action row button\n\nWhy\nCurrent UI is confusing in two ways:\n1) room hub lanes always occupy large vertical space and make the game screen look broken\n2) dashboard showed duplicate actionable 1) 세션 시작 controls\n\nValidation\n- cargo check --manifest-path viewer/Cargo.toml\n- scripts/viewer-trunk.sh build\n- dune build --root .