### PR TITLE
fix(viewer): prevent auto 5-keeper bootstrap and stale session replay

### DIFF
--- a/viewer/src/config.rs
+++ b/viewer/src/config.rs
@@ -8,8 +8,6 @@
 
 #[cfg(target_arch = "wasm32")]
 use crate::mode::ViewerMode;
-#[cfg(target_arch = "wasm32")]
-use wasm_bindgen::JsValue;
 
 /// Legacy TRPG Engine server (FastAPI + SQLite event store).
 pub const TRPG_ENGINE_URL: &str = "http://localhost:8940";
@@ -19,8 +17,6 @@ pub const MASC_MCP_URL: &str = "http://localhost:8935";
 
 /// Default TRPG room identifier.
 pub const DEFAULT_ROOM_ID: &str = "default";
-#[cfg(target_arch = "wasm32")]
-pub const ROOM_STORAGE_KEY: &str = "masc_viewer_room_id";
 
 #[cfg(target_arch = "wasm32")]
 pub fn sanitize_room_id(raw: &str) -> Option<String> {
@@ -73,27 +69,23 @@ pub fn current_room_id() -> String {
         return room;
     }
 
-    let from_url = web_sys::window().and_then(|window| {
+    if let Some(room) = room_id_from_url() {
+        return room;
+    }
+
+    DEFAULT_ROOM_ID.to_string()
+}
+
+#[cfg(target_arch = "wasm32")]
+pub fn room_id_from_url() -> Option<String> {
+    web_sys::window().and_then(|window| {
         let location = window.location();
         let search = location.search().ok().unwrap_or_default();
         room_from_query_like_text(&search).or_else(|| {
             let hash = location.hash().ok().unwrap_or_default();
             room_from_query_like_text(&hash)
         })
-    });
-    if let Some(room) = from_url {
-        return room;
-    }
-
-    let from_storage = web_sys::window()
-        .and_then(|w| w.local_storage().ok().flatten())
-        .and_then(|storage| storage.get_item(ROOM_STORAGE_KEY).ok().flatten())
-        .and_then(|raw| sanitize_room_id(&raw));
-    if let Some(room) = from_storage {
-        return room;
-    }
-
-    DEFAULT_ROOM_ID.to_string()
+    })
 }
 
 #[cfg(target_arch = "wasm32")]
@@ -122,18 +114,6 @@ pub fn set_current_room_id(room_id: &str) {
             if let Some(dashboard) = doc.get_element_by_id("dashboard") {
                 let _ = dashboard.set_attribute("data-room-id", &room);
             }
-        }
-
-        if let Ok(Some(storage)) = window.local_storage() {
-            let _ = storage.set_item(ROOM_STORAGE_KEY, &room);
-        }
-
-        let location = window.location();
-        let path = location.pathname().ok().unwrap_or_else(|| "/".to_string());
-        let hash = location.hash().ok().unwrap_or_default();
-        let next_url = format!("{}?room={}{}", path, room, hash);
-        if let Ok(history) = window.history() {
-            let _ = history.replace_state_with_url(&JsValue::NULL, "", Some(&next_url));
         }
     }
 }

--- a/viewer/src/game/http.rs
+++ b/viewer/src/game/http.rs
@@ -192,6 +192,7 @@ pub fn refresh_state_on_room_change(
 pub fn apply_initial_state(
     mut commands: Commands,
     mut buffer: ResMut<InitialStateBuffer>,
+    actors: Query<Entity, With<Actor>>,
     mut room_state: ResMut<RoomState>,
     mut map_state: ResMut<MapState>,
     mut turn_progress: ResMut<TurnProgressState>,
@@ -223,6 +224,10 @@ pub fn apply_initial_state(
         .map(|ch| ch.id.clone())
         .collect();
 
+    for entity in &actors {
+        commands.entity(entity).despawn();
+    }
+
     // Apply room state
     if let Some(room) = &state.room {
         room_state.id = room.id.clone();
@@ -245,6 +250,14 @@ pub fn apply_initial_state(
         turn_progress.room_status = room_state.status.clone();
         turn_progress.turn = room_state.turn;
         turn_progress.phase = room_state.phase.as_str().to_string();
+        turn_progress.player_order.clear();
+        turn_progress.actor_order.clear();
+        turn_progress.actor_states.clear();
+        turn_progress.current_actor.clear();
+        turn_progress.next_actor.clear();
+        turn_progress.last_actor.clear();
+        turn_progress.last_result.clear();
+        *map_state = MapState::default();
         buffer.consumed = true;
 
         prompt_new_game_for_inactive_room(room_state.status.trim());

--- a/viewer/src/mode.rs
+++ b/viewer/src/mode.rs
@@ -171,6 +171,10 @@ fn on_enter_lobby(buffer: Res<ModeTransitionBuffer>) {
             return;
         };
 
+        clear_trpg_dom(&doc);
+        let lobby_room = crate::config::room_id_from_url()
+            .unwrap_or_else(|| crate::config::DEFAULT_ROOM_ID.to_string());
+        crate::config::set_current_room_id(&lobby_room);
         // Show lobby UI, hide dashboard
         if let Some(body) = doc.body() {
             body.set_class_name("mode-lobby");
@@ -222,6 +226,7 @@ fn enter_trpg() {
         set_element_display(&doc, "dashboard", "grid");
         set_element_display(&doc, "lobby-screen", "none");
         set_element_display(&doc, "new-game-panel", "none");
+        clear_trpg_dom(&doc);
         bind_debug_controls(&doc);
         bind_new_game_controls(&doc);
         let room = crate::config::current_room_id();
@@ -1314,10 +1319,18 @@ async fn refresh_keeper_selectors(doc: &web_sys::Document) -> Result<Vec<String>
         ];
     }
 
-    let dm_default = keepers
-        .iter()
-        .find(|name| name.starts_with("dm"))
-        .cloned()
+    let previous_dm = doc
+        .get_element_by_id("new-game-dm-select")
+        .and_then(|el| {
+            el.dyn_ref::<web_sys::HtmlSelectElement>()
+                .map(|s| s.value())
+        })
+        .map(|v| v.trim().to_string())
+        .filter(|v| !v.is_empty());
+    let previous_players = selected_player_keepers(doc);
+    let dm_default = previous_dm
+        .filter(|prev| keepers.iter().any(|name| name == prev))
+        .or_else(|| keepers.iter().find(|name| name.starts_with("dm")).cloned())
         .unwrap_or_else(|| keepers[0].clone());
 
     if let Some(dm_select) = doc.get_element_by_id("new-game-dm-select") {
@@ -1336,14 +1349,17 @@ async fn refresh_keeper_selectors(doc: &web_sys::Document) -> Result<Vec<String>
     }
 
     if let Some(player_select) = doc.get_element_by_id("new-game-player-select") {
-        let mut selected = 0;
+        let preserve_existing_selection = !previous_players.is_empty();
         let mut html = String::new();
         for name in keepers.iter().filter(|name| **name != dm_default) {
             let safe = html_escape(name);
-            let selected_attr = if selected < 4 { " selected" } else { "" };
-            if selected < 4 {
-                selected += 1;
-            }
+            let selected_attr =
+                if preserve_existing_selection && previous_players.iter().any(|picked| picked == name)
+                {
+                    " selected"
+                } else {
+                    ""
+                };
             html.push_str(&format!(
                 r#"<option value="{value}"{selected}>{value}</option>"#,
                 value = safe,

--- a/viewer/src/sse/client.rs
+++ b/viewer/src/sse/client.rs
@@ -426,36 +426,45 @@ async fn sleep_ms(ms: i32) -> Result<(), JsValue> {
 }
 
 #[cfg(target_arch = "wasm32")]
+async fn bootstrap_after_seq(state: &mut TrpgMapperState) -> i64 {
+    let bootstrap_url = config::trpg_stream_poll_url(0);
+    match fetch_text(&bootstrap_url).await {
+        Ok(body) => match decode_stream_events(&body, state) {
+            Ok((max_seq, _)) => {
+                let seq = max_seq.max(0);
+                if seq > 0 {
+                    log::info!(
+                        "TRPG poll bootstrap: skipping historical events up to seq {}",
+                        seq
+                    );
+                }
+                seq
+            }
+            Err(e) => {
+                log::warn!("Failed to decode TRPG bootstrap payload: {}", e);
+                0
+            }
+        },
+        Err(e) => {
+            log::debug!("TRPG bootstrap request failed: {:?}", e);
+            0
+        }
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
 fn start_polling_loop(messages: Arc<Mutex<Vec<(String, String)>>>, active: Arc<AtomicBool>) {
     wasm_bindgen_futures::spawn_local(async move {
         let mut state = TrpgMapperState::default();
         let mut active_room = config::current_room_id();
-        let mut after_seq = 0_i64;
-
-        // Skip historical backlog on viewer enter so old sessions do not flood narrative.
-        let bootstrap_url = config::trpg_stream_poll_url(0);
-        match fetch_text(&bootstrap_url).await {
-            Ok(body) => match decode_stream_events(&body, &mut state) {
-                Ok((max_seq, _)) => {
-                    after_seq = max_seq.max(0);
-                    if after_seq > 0 {
-                        log::info!(
-                            "TRPG poll bootstrap: skipping historical events up to seq {}",
-                            after_seq
-                        );
-                    }
-                }
-                Err(e) => log::warn!("Failed to decode TRPG bootstrap payload: {}", e),
-            },
-            Err(e) => log::debug!("TRPG bootstrap request failed: {:?}", e),
-        }
+        let mut after_seq = bootstrap_after_seq(&mut state).await;
 
         while active.load(Ordering::Relaxed) {
             let room_now = config::current_room_id();
             if room_now != active_room {
                 active_room = room_now.clone();
-                after_seq = 0;
                 state = TrpgMapperState::default();
+                after_seq = bootstrap_after_seq(&mut state).await;
                 log::info!("TRPG poll room switched: {}", room_now);
             }
             let url = config::trpg_stream_poll_url(after_seq);


### PR DESCRIPTION
Summary\n- remove implicit player auto-selection in viewer new-game panel (explicit AI Player selection only)\n- clear TRPG DOM on lobby enter / TRPG enter to avoid leftover UI from previous play\n- always despawn existing Actor entities before applying initial room snapshot\n- when room is inactive (idle/ended/unavailable), clear runtime turn/map state before opening new-game panel\n- prevent stream backlog replay when switching rooms by bootstrapping after_seq per room\n- stop auto-restoring room from local storage; default entry is clean unless URL has room=...\n\nProblem\n- keepers were implicitly expanded to DM + 4 players because player options were preselected\n- old game logs/state could reappear when room switched due backlog replay and stale state remnants\n\nValidation\n- cargo check --manifest-path viewer/Cargo.toml\n- scripts/viewer-trunk.sh build