### PR TITLE
fix(viewer): unblock wasm build by exposing friendly_js_error

### DIFF
--- a/viewer/src/dom/action_panel.rs
+++ b/viewer/src/dom/action_panel.rs
@@ -332,7 +332,7 @@ fn set_action_status(text: &str, css_class: &str) {
 }
 
 #[cfg(target_arch = "wasm32")]
-fn friendly_js_error(val: &JsValue) -> String {
+pub(crate) fn friendly_js_error(val: &JsValue) -> String {
     val.as_string()
         .or_else(|| {
             val.dyn_ref::<js_sys::Error>()


### PR DESCRIPTION
## Summary
- make `friendly_js_error` in `viewer/src/dom/action_panel.rs` visible as `pub(crate)`
- this unblocks call site in `viewer/src/dom/actor_join.rs` and resolves `E0603`

## Validation
- `cargo build --target=wasm32-unknown-unknown --manifest-path viewer/Cargo.toml --release`
