### PR TITLE
feat(trpg): add actor browser panel for edit workflow

### DIFF
--- a/lib/web_dashboard.ml
+++ b/lib/web_dashboard.ml
@@ -2500,6 +2500,11 @@ let cached_html = lazy ({|<!DOCTYPE html>
                 <button id="trpg-actor-delete-btn" class="trpg-run-btn secondary danger" onclick="deleteTrpgActor()">액터 삭제</button>
               </div>
               <div id="trpg-actor-run-status" class="trpg-run-status">액터 ID를 입력한 뒤 생성/수정/삭제를 실행하세요.</div>
+              <div class="trpg-section-title" style="margin-top:8px;">액터 목록</div>
+              <div id="trpg-actor-browser" class="trpg-round-list">
+                <div class="trpg-empty" style="padding:18px 8px;">세션 시작 후 액터 목록이 표시됩니다.</div>
+              </div>
+              <div class="trpg-control-help" style="margin-top:4px;">목록에서 "불러오기"를 누르면 아래 액터 관리 폼이 자동 채워집니다.</div>
               <div class="trpg-control-help" style="margin-top:4px;">생성 시 Keeper를 입력하면 lease claim을 자동 시도합니다. 수정은 입력한 필드만 patch하고, 삭제 시 actor lease도 함께 정리됩니다.</div>
               <div class="trpg-dev-note">라운드 실행은 DM + 플레이어 Keeper 순차 호출로 진행되며 timeout × 참여자 수만큼 시간이 걸릴 수 있습니다.</div>
             </div>
@@ -7436,6 +7441,7 @@ let cached_html = lazy ({|<!DOCTYPE html>
     let trpgPresetCatalog = { dm_presets: [], world_presets: [] };
     let trpgKeeperCatalog = [];
     let trpgKeeperCatalogDetails = {};
+    let trpgActorBrowserCache = {};
     const TRPG_AUTO_ROUND_DELAY_DEFAULT_SEC = 3;
 
     function trpgEventType(ev) {
@@ -7796,6 +7802,68 @@ let cached_html = lazy ({|<!DOCTYPE html>
         }
       }
       return aliases;
+    }
+
+    function trpgActorsFromStateOrEvents(state, events) {
+      const actors = [];
+      const seen = new Set();
+      const inputRaw = String((document.getElementById('trpg-player-keepers-input') || {}).value || '');
+      const parsed = parseTrpgPlayerKeepers(inputRaw);
+      const keeperMap = parsed.ok ? (parsed.mapping || {}) : {};
+
+      const pushActor = (actorIdRaw, infoRaw = {}) => {
+        const actorId = String(actorIdRaw || '').trim();
+        if (!actorId || seen.has(actorId)) return;
+        seen.add(actorId);
+        const info = (infoRaw && typeof infoRaw === 'object' && !Array.isArray(infoRaw)) ? infoRaw : {};
+        const hpRaw = Number(info.hp);
+        const maxHpRaw = Number(info.max_hp ?? info.maxHp);
+        const hp = Number.isFinite(hpRaw) ? hpRaw : null;
+        const maxHp = Number.isFinite(maxHpRaw) && maxHpRaw > 0 ? maxHpRaw : null;
+        const alive = typeof info.alive === 'boolean'
+          ? info.alive
+          : (Number.isFinite(hp) ? hp > 0 : true);
+        const traits = Array.isArray(info.traits) ? info.traits : [];
+        const skills = Array.isArray(info.skills) ? info.skills : [];
+        const inventory = Array.isArray(info.inventory) ? info.inventory : [];
+        actors.push({
+          actorId,
+          name: String(info.name || actorId).trim() || actorId,
+          role: String(info.role || info.class || info.job || '').trim(),
+          archetype: String(info.archetype || '').trim(),
+          persona: String(info.persona || '').trim(),
+          keeper: String(info.keeper || info.keeper_name || info.keeperName || info.claimed_by || keeperMap[actorId] || '').trim(),
+          hp,
+          maxHp,
+          alive,
+          traits,
+          skills,
+          inventory,
+        });
+      };
+
+      const partyObj =
+        state && state.party && typeof state.party === 'object' && !Array.isArray(state.party)
+          ? state.party
+          : null;
+      if (partyObj) {
+        Object.entries(partyObj).forEach(([actorId, info]) => pushActor(actorId, info));
+      } else {
+        for (let i = (events || []).length - 1; i >= 0; i -= 1) {
+          const ev = events[i];
+          if (trpgEventType(ev) !== 'party.selected') continue;
+          const payload = trpgEventPayload(ev);
+          const party = Array.isArray(payload.party) ? payload.party : [];
+          party.forEach((member) => {
+            const actorId = String((member && member.actor_id) || '').trim();
+            pushActor(actorId, member);
+          });
+          break;
+        }
+      }
+
+      actors.sort((a, b) => a.actorId.localeCompare(b.actorId, 'en'));
+      return actors;
     }
 
     function trpgResolvePlayerKeeperMapping(state, events, rawText) {
@@ -10291,6 +10359,7 @@ let cached_html = lazy ({|<!DOCTYPE html>
       renderTrpgFlowState(state, viewEvents, summary, phase);
       renderTrpgSessionMeta(state, viewEvents, summary, phase);
       renderTrpgPartyAssignment(state, viewEvents);
+      renderTrpgActorBrowser(state, viewEvents);
       trpgRenderAssignmentEditor(state, viewEvents);
       renderTrpgSelectionSummary(state, viewEvents);
       trpgUpdateNextAction(state, viewEvents);
@@ -10440,6 +10509,73 @@ let cached_html = lazy ({|<!DOCTYPE html>
         rows.push('<div class="trpg-empty" style="padding:18px 8px;">할당 정보가 없습니다.</div>');
       }
       el.innerHTML = rows.join('');
+    }
+
+    function renderTrpgActorBrowser(state, events) {
+      const el = document.getElementById('trpg-actor-browser');
+      if (!el) return;
+      const actors = trpgActorsFromStateOrEvents(state, events);
+      if (!actors.length) {
+        trpgActorBrowserCache = {};
+        el.innerHTML = '<div class="trpg-empty" style="padding:18px 8px;">세션 시작 후 액터 목록이 표시됩니다.</div>';
+        return;
+      }
+
+      const nextCache = {};
+      const cards = actors.map((actor) => {
+        nextCache[actor.actorId] = actor;
+        const token = encodeURIComponent(actor.actorId);
+        const hpText = (Number.isFinite(actor.hp) && Number.isFinite(actor.maxHp))
+          ? `HP ${actor.hp}/${actor.maxHp}`
+          : (Number.isFinite(actor.hp) ? `HP ${actor.hp}` : 'HP -');
+        const roleText = actor.role || '-';
+        const keeperText = actor.keeper || '-';
+        const stateCls = actor.alive ? 'ok' : 'mismatch';
+        const stateText = actor.alive ? 'alive' : 'dead';
+        return `
+          <div class="trpg-round-item ${stateCls}">
+            <div class="meta">${escapeHtml(actor.actorId)} · ${escapeHtml(roleText)} · ${escapeHtml(stateText)} · ${escapeHtml(hpText)}</div>
+            <div><b>${escapeHtml(actor.name)}</b> · keeper <b>${escapeHtml(keeperText)}</b></div>
+            <div style="margin-top:6px;">
+              <button type="button" class="trpg-mini-btn" onclick="loadTrpgActorToForm('${token}')">불러오기</button>
+            </div>
+          </div>
+        `;
+      });
+      trpgActorBrowserCache = nextCache;
+      el.innerHTML = cards.join('');
+    }
+
+    function loadTrpgActorToForm(token) {
+      const actorId = decodeURIComponent(String(token || ''));
+      const actor = trpgActorBrowserCache && trpgActorBrowserCache[actorId];
+      if (!actor) {
+        showToast('액터 정보를 찾지 못했습니다. 새로고침 후 다시 시도하세요.', 'error');
+        return;
+      }
+      const setText = (id, value) => {
+        const input = document.getElementById(id);
+        if (!input) return;
+        input.value = String(value == null ? '' : value);
+      };
+      const setList = (id, xs) => setText(id, Array.isArray(xs) ? xs.join(',') : '');
+      setText('trpg-actor-id-input', actor.actorId);
+      const roleSelect = document.getElementById('trpg-actor-role-select');
+      if (roleSelect) {
+        const role = String(actor.role || '').trim();
+        const has = Array.from(roleSelect.options || []).some((opt) => String(opt.value || '') === role);
+        roleSelect.value = has ? role : '';
+      }
+      setText('trpg-actor-name-input', actor.name || '');
+      setText('trpg-actor-archetype-input', actor.archetype || '');
+      setText('trpg-actor-persona-input', actor.persona || '');
+      setText('trpg-actor-keeper-input', actor.keeper || '');
+      setText('trpg-actor-hp-input', Number.isFinite(actor.hp) ? actor.hp : '');
+      setText('trpg-actor-maxhp-input', Number.isFinite(actor.maxHp) ? actor.maxHp : '');
+      setList('trpg-actor-traits-input', actor.traits);
+      setList('trpg-actor-skills-input', actor.skills);
+      setList('trpg-actor-inventory-input', actor.inventory);
+      showToast(`액터 불러오기: ${actor.actorId}`, 'success');
     }
 
     function renderTrpgGameHistory(events) {

--- a/lib/web_dashboard.ml
+++ b/lib/web_dashboard.ml
@@ -9546,7 +9546,7 @@ let cached_html = lazy ({|<!DOCTYPE html>
       try {
         await mcpToolCall('trpg.actor.spawn', spawnArgs);
         if (form.keeperName) {
-          await mcpToolCall('trpg.actor.claim', {
+          await trpgActorClaimCall({
             room_id: form.roomId,
             actor_id: form.actorId,
             keeper_name: form.keeperName,
@@ -9620,7 +9620,7 @@ let cached_html = lazy ({|<!DOCTYPE html>
           await mcpToolCall('trpg.actor.update', updateArgs);
         }
         if (hasKeeperClaim) {
-          await mcpToolCall('trpg.actor.claim', {
+          await trpgActorClaimCall({
             room_id: form.roomId,
             actor_id: form.actorId,
             keeper_name: form.keeperName,
@@ -10532,12 +10532,21 @@ let cached_html = lazy ({|<!DOCTYPE html>
         const keeperText = actor.keeper || '-';
         const stateCls = actor.alive ? 'ok' : 'mismatch';
         const stateText = actor.alive ? 'alive' : 'dead';
+        const busy = trpgRoundRunning || trpgBootstrapping || trpgActorMutating;
+        const claimDisabled = busy;
+        const releaseDisabled = busy || !actor.keeper;
+        const claimTitle = busy ? '실행 중에는 변경할 수 없습니다.' : '이 actor를 지정한 keeper로 claim합니다.';
+        const releaseTitle = busy
+          ? '실행 중에는 변경할 수 없습니다.'
+          : (!actor.keeper ? '현재 keeper 할당 정보가 없어 release할 수 없습니다.' : '현재 keeper 점유를 해제합니다.');
         return `
           <div class="trpg-round-item ${stateCls}">
             <div class="meta">${escapeHtml(actor.actorId)} · ${escapeHtml(roleText)} · ${escapeHtml(stateText)} · ${escapeHtml(hpText)}</div>
             <div><b>${escapeHtml(actor.name)}</b> · keeper <b>${escapeHtml(keeperText)}</b></div>
             <div style="margin-top:6px;">
               <button type="button" class="trpg-mini-btn" onclick="loadTrpgActorToForm('${token}')">불러오기</button>
+              <button type="button" class="trpg-mini-btn" ${claimDisabled ? 'disabled' : ''} title="${escapeHtml(claimTitle)}" onclick="quickClaimTrpgActor('${token}')">Claim</button>
+              <button type="button" class="trpg-mini-btn" ${releaseDisabled ? 'disabled' : ''} title="${escapeHtml(releaseTitle)}" onclick="quickReleaseTrpgActor('${token}')">Release</button>
             </div>
           </div>
         `;
@@ -10576,6 +10585,142 @@ let cached_html = lazy ({|<!DOCTYPE html>
       setList('trpg-actor-skills-input', actor.skills);
       setList('trpg-actor-inventory-input', actor.inventory);
       showToast(`액터 불러오기: ${actor.actorId}`, 'success');
+    }
+
+    function trpgActorDefaultKeeper(actorId) {
+      return `pk-${String(actorId || '').trim()}`;
+    }
+
+    function trpgActorKeeperFromFormOrPrompt(actor) {
+      const actorId = String((actor && actor.actorId) || '').trim();
+      const formKeeper = trpgActorTextInput('trpg-actor-keeper-input');
+      if (formKeeper) return formKeeper;
+      const existing = String((actor && actor.keeper) || '').trim();
+      if (existing) return existing;
+      const suggested = trpgActorDefaultKeeper(actorId);
+      const entered = window.prompt(`keeper 이름을 입력하세요 (actor ${actorId})`, suggested);
+      return String(entered || '').trim();
+    }
+
+    async function trpgActorClaimCall(args) {
+      try {
+        return await mcpToolCall('trpg.actor.claim', args);
+      } catch (primaryErr) {
+        try {
+          return await mcpToolCall('masc_trpg_actor_claim', args);
+        } catch (legacyErr) {
+          const primaryMsg = String((primaryErr && primaryErr.message) || primaryErr || 'unknown error');
+          const legacyMsg = String((legacyErr && legacyErr.message) || legacyErr || 'unknown error');
+          throw new Error(`actor claim 실패: canonical(${primaryMsg}) / legacy(${legacyMsg})`);
+        }
+      }
+    }
+
+    async function trpgActorReleaseCall(args) {
+      try {
+        return await mcpToolCall('trpg.actor.release', args);
+      } catch (primaryErr) {
+        try {
+          return await mcpToolCall('masc_trpg_actor_release', args);
+        } catch (legacyErr) {
+          const primaryMsg = String((primaryErr && primaryErr.message) || primaryErr || 'unknown error');
+          const legacyMsg = String((legacyErr && legacyErr.message) || legacyErr || 'unknown error');
+          throw new Error(`actor release 실패: canonical(${primaryMsg}) / legacy(${legacyMsg})`);
+        }
+      }
+    }
+
+    async function quickClaimTrpgActor(token) {
+      if (trpgRoundRunning || trpgBootstrapping || trpgActorMutating) return;
+      const actorId = decodeURIComponent(String(token || ''));
+      const actor = trpgActorBrowserCache && trpgActorBrowserCache[actorId];
+      if (!actor) {
+        showToast('액터 정보를 찾지 못했습니다. 새로고침 후 다시 시도하세요.', 'error');
+        return;
+      }
+      const roomId = applyTrpgRoomFromInput();
+      const keeperName = trpgActorKeeperFromFormOrPrompt(actor);
+      if (!keeperName) {
+        setTrpgStatusBoth('오류: claim할 keeper 이름이 필요합니다.', 'error');
+        return;
+      }
+      setTrpgActorMutationBusy(true);
+      setTrpgStatusBoth(
+        `액터 claim 중: <b>${escapeHtml(actorId)}</b> → keeper <b>${escapeHtml(keeperName)}</b> / room <b>${escapeHtml(roomId)}</b>`,
+        'running'
+      );
+      try {
+        await trpgActorClaimCall({
+          room_id: roomId,
+          actor_id: actorId,
+          keeper_name: keeperName,
+        });
+        const role = String((actor && actor.role) || '').trim().toLowerCase();
+        if (role === 'player') {
+          upsertTrpgPlayerKeeperLine(actorId, keeperName);
+        }
+        setTrpgStatusBoth(
+          `액터 claim 완료: <b>${escapeHtml(actorId)}</b> → keeper <b>${escapeHtml(keeperName)}</b>`,
+          'ok'
+        );
+        showToast(`Actor claim 완료: ${actorId}`, 'success');
+        await fetchTrpg();
+      } catch (e) {
+        const msg = String((e && e.message) || e || 'unknown error');
+        setTrpgStatusBoth(`액터 claim 실패: ${escapeHtml(msg)}`, 'error');
+        showToast('Actor claim 실패', 'error');
+      } finally {
+        setTrpgActorMutationBusy(false);
+      }
+    }
+
+    async function quickReleaseTrpgActor(token) {
+      if (trpgRoundRunning || trpgBootstrapping || trpgActorMutating) return;
+      const actorId = decodeURIComponent(String(token || ''));
+      const actor = trpgActorBrowserCache && trpgActorBrowserCache[actorId];
+      if (!actor) {
+        showToast('액터 정보를 찾지 못했습니다. 새로고침 후 다시 시도하세요.', 'error');
+        return;
+      }
+      const roomId = applyTrpgRoomFromInput();
+      const keeperName = String((actor && actor.keeper) || '').trim() || trpgActorTextInput('trpg-actor-keeper-input');
+      if (!keeperName) {
+        setTrpgStatusBoth(
+          `오류: actor <b>${escapeHtml(actorId)}</b>의 keeper 정보가 없어 release를 실행할 수 없습니다.`,
+          'error'
+        );
+        return;
+      }
+      setTrpgActorMutationBusy(true);
+      setTrpgStatusBoth(
+        `액터 release 중: <b>${escapeHtml(actorId)}</b> / keeper <b>${escapeHtml(keeperName)}</b> / room <b>${escapeHtml(roomId)}</b>`,
+        'running'
+      );
+      try {
+        await trpgActorReleaseCall({
+          room_id: roomId,
+          actor_id: actorId,
+          keeper_name: keeperName,
+        });
+        removeTrpgPlayerKeeperLine(actorId);
+        const keeperInput = document.getElementById('trpg-actor-keeper-input');
+        const formActorId = trpgActorTextInput('trpg-actor-id-input');
+        if (keeperInput && formActorId === actorId) {
+          keeperInput.value = '';
+        }
+        setTrpgStatusBoth(
+          `액터 release 완료: <b>${escapeHtml(actorId)}</b> (keeper <b>${escapeHtml(keeperName)}</b>)`,
+          'ok'
+        );
+        showToast(`Actor release 완료: ${actorId}`, 'success');
+        await fetchTrpg();
+      } catch (e) {
+        const msg = String((e && e.message) || e || 'unknown error');
+        setTrpgStatusBoth(`액터 release 실패: ${escapeHtml(msg)}`, 'error');
+        showToast('Actor release 실패', 'error');
+      } finally {
+        setTrpgActorMutationBusy(false);
+      }
     }
 
     function renderTrpgGameHistory(events) {

--- a/test/test_web_dashboard_coverage.ml
+++ b/test/test_web_dashboard_coverage.ml
@@ -160,6 +160,12 @@ let test_html_contains_trpg_session_history_and_assignment () =
     && contains_substr "function trpgActorsFromStateOrEvents(state, events)" html
     && contains_substr "function renderTrpgActorBrowser(state, events)" html
     && contains_substr "function loadTrpgActorToForm(token)" html
+    && contains_substr "function quickClaimTrpgActor(token)" html
+    && contains_substr "function quickReleaseTrpgActor(token)" html
+    && contains_substr "function trpgActorClaimCall(args)" html
+    && contains_substr "function trpgActorReleaseCall(args)" html
+    && contains_substr "Actor claim 완료" html
+    && contains_substr "Actor release 완료" html
     && contains_substr "function renderTrpgSessionMeta(_state, events, summary, phase)" html
     && contains_substr "function renderTrpgPartyAssignment(state, events)" html
     && contains_substr "function renderTrpgGameHistory(events)" html)

--- a/test/test_web_dashboard_coverage.ml
+++ b/test/test_web_dashboard_coverage.ml
@@ -153,9 +153,13 @@ let test_html_contains_trpg_session_history_and_assignment () =
     (String.length html > 0
     && contains_substr "id=\"trpg-session-meta\"" html
     && contains_substr "id=\"trpg-party-assignment\"" html
+    && contains_substr "id=\"trpg-actor-browser\"" html
     && contains_substr "id=\"trpg-game-history\"" html
     && contains_substr "function trpgBuildSessionHistory(events)" html
     && contains_substr "function trpgPartyActorsFromStateOrEvents(state, events)" html
+    && contains_substr "function trpgActorsFromStateOrEvents(state, events)" html
+    && contains_substr "function renderTrpgActorBrowser(state, events)" html
+    && contains_substr "function loadTrpgActorToForm(token)" html
     && contains_substr "function renderTrpgSessionMeta(_state, events, summary, phase)" html
     && contains_substr "function renderTrpgPartyAssignment(state, events)" html
     && contains_substr "function renderTrpgGameHistory(events)" html)


### PR DESCRIPTION
## Summary
- add `액터 목록` panel in TRPG sidebar to display current room actors
- add `불러오기` action per actor to populate actor management form fields
- derive actor browser rows from `state.party` (fallback to latest `party.selected` event)
- include keeper mapping fallback from current player-keeper input for visibility
- extend web dashboard coverage test for actor browser IDs/functions

## Test
- `opam exec -- env DUNE_BUILD_DIR=_build_actorbrowser dune exec --root . test/test_web_dashboard_coverage.exe`
- `opam exec -- env DUNE_BUILD_DIR=_build_actorbrowser dune exec --root . test/test_tool_trpg_coverage.exe`
