### PR TITLE
fix(keeper): gate debug logs, raise min keepalive 5→30, add sleep jitter

### DIFF
--- a/lib/tool_keeper.ml
+++ b/lib/tool_keeper.ml
@@ -19,6 +19,9 @@
 
 open Types
 
+let keeper_debug =
+  try Sys.getenv "MASC_KEEPER_DEBUG" = "1" with Not_found -> false
+
 type 'a context = {
   config: Room.config;
   sw: Eio.Switch.t;
@@ -1260,7 +1263,8 @@ let write_meta config (m : keeper_meta) : (unit, string) result =
 
 let read_meta config name : (keeper_meta option, string) result =
   let path = keeper_meta_path config name in
-  Printf.eprintf "[KEEPER-DEBUG] read_meta name=%s path=%s exists=%b\n%!" name path (Sys.file_exists path);
+  if keeper_debug then
+    Printf.eprintf "[KEEPER-DEBUG] read_meta name=%s path=%s exists=%b\n%!" name path (Sys.file_exists path);
   if not (Sys.file_exists path) then Ok None
   else
     match Safe_ops.read_json_file_safe path with
@@ -5020,9 +5024,9 @@ let start_keepalive (ctx : _ context) (m : keeper_meta) : unit =
           let meta_after_proactive =
             try maybe_emit_proactive ctx meta_current with _ -> meta_current
           in
-          Eio.Time.sleep
-            ctx.clock
-            (float_of_int (max 5 (min 300 meta_after_proactive.presence_keepalive_sec)));
+          let base = float_of_int (max 30 (min 300 meta_after_proactive.presence_keepalive_sec)) in
+          let jitter = base *. 0.2 *. Random.float 1.0 in
+          Eio.Time.sleep ctx.clock (base +. jitter);
           loop ()
         end
       in


### PR DESCRIPTION
## 변경 사항

- `[KEEPER-DEBUG] read_meta` 로그를 `MASC_KEEPER_DEBUG=1` 환경변수 게이팅
- `presence_keepalive_sec` 최소값 5초 → 30초 (불필요한 I/O 빈도 6배 감소)
- keeper sleep에 0~20% 랜덤 jitter 추가 (thundering herd 방지)

## 배경

20개 perpetual keeper가 매 틱마다 무조건 stderr에 디버그 로그를 출력하여 분당 240줄 스팸 발생.

## 테스트

- `dune build` 통과