### PR TITLE
[TRPG] Actor ID fallback for action panel

### DIFF
--- a/viewer/src/config.rs
+++ b/viewer/src/config.rs
@@ -179,3 +179,26 @@ pub fn sse_endpoint(mode: &ViewerMode) -> Option<String> {
 pub fn trpg_room_url(path: &str) -> String {
     format!("{}/rooms/{}/{}", MASC_MCP_URL, current_room_id(), path.trim_start_matches('/'))
 }
+
+// ─── Actor ID Management ─────────────────────
+
+/// Get current actor ID from dashboard attribute (selected player in lobby).
+/// This serves as a fallback when TurnProgressState doesn't have an active actor.
+pub fn current_actor_id() -> Option<String> {
+    #[cfg(target_arch = "wasm32")]
+    {
+        if let Some(doc) = web_sys::window().and_then(|w| w.document()) {
+            // 1. Try dashboard attribute (set by lobby/character selection)
+            if let Some(el) = doc.get_element_by_id("dashboard") {
+                if let Some(actor) = el.get_attribute("data-current-actor") {
+                    let actor = actor.trim().to_string();
+                    if !actor.is_empty() {
+                        return Some(actor);
+                    }
+                }
+            }
+        }
+    }
+
+    None
+}

--- a/viewer/src/dom/action_panel.rs
+++ b/viewer/src/dom/action_panel.rs
@@ -350,7 +350,12 @@ pub fn sync_action_panel_interaction_state(
 
     #[cfg(target_arch = "wasm32")]
     {
-        let active_actor = progress.current_actor.trim().to_string();
+        // Primary: Use turn progress state
+        // Fallback: Dashboard-selected actor (for lobby/pre-turn scenarios)
+        let mut active_actor = progress.current_actor.trim().to_string();
+        if active_actor.is_empty() {
+            active_actor = config::current_actor_id().unwrap_or_default();
+        }
         let can_act = !active_actor.is_empty() && active_actor != "dm";
 
         if let Some(doc) = web_sys::window().and_then(|w| w.document()) {
@@ -406,16 +411,18 @@ fn disable_buttons(disabled: bool) {
 #[cfg(target_arch = "wasm32")]
 fn get_active_actor_from_dom() -> Option<String> {
     let doc = web_sys::window().and_then(|w| w.document())?;
-    let panel = doc.get_element_by_id("action-panel");
-    let actor_id = panel
-        .and_then(|el| el.get_attribute("data-active-actor"))
-        .unwrap_or_default();
 
-    if actor_id.trim().is_empty() {
-        None
-    } else {
-        Some(actor_id)
+    // 1. Try action-panel attribute (set by sync function)
+    if let Some(panel) = doc.get_element_by_id("action-panel") {
+        if let Some(actor_id) = panel.get_attribute("data-active-actor") {
+            if !actor_id.trim().is_empty() {
+                return Some(actor_id);
+            }
+        }
     }
+
+    // 2. Fallback: Dashboard-selected actor
+    config::current_actor_id()
 }
 
 #[cfg(test)]
@@ -429,4 +436,3 @@ mod tests {
         assert_eq!(extract_roll_display(""), "Roll completed.");
     }
 }
-// Forced update


### PR DESCRIPTION
## Summary
- `config::current_actor_id()` 추가: `#dashboard[data-current-actor]` 속성에서 actor ID 읽기
- `sync_action_panel_interaction_state()`에서 turn state가 비어있을 때 fallback 사용
- `get_active_actor_from_dom()`에 동일한 fallback 로직 적용
- 불필요한 "Forced update" 주석 제거

## Test Plan
- [ ] wasm32 타겟 빌드 확인 (`cargo build --target wasm32-unknown-unknown`)
- [ ] Dashboard에서 actor 선택 후 action panel 동작 확인
- [ ] Turn 진행 중 정상 동작 확인

Reimplements closed PR #204 with cleaner architecture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)