### PR TITLE
fix(viewer): align URL patterns with backend query params

### DIFF
--- a/viewer/src/config.rs
+++ b/viewer/src/config.rs
@@ -9,6 +9,10 @@ pub const MASC_MCP_URL: &str = "";
 
 pub const DEFAULT_ROOM_ID: &str = "default";
 
+/// Polling interval for TRPG stream (milliseconds).
+/// Backend exposes GET /api/v1/trpg/stream (JSON), no dedicated SSE endpoint.
+pub const TRPG_POLL_INTERVAL_MS: u64 = 500;
+
 /// Legacy TRPG Engine URL (for direct mode)
 #[cfg(debug_assertions)]
 pub const TRPG_ENGINE_URL: &str = "http://localhost:8000";
@@ -122,24 +126,22 @@ fn parse_query_param(search: &str, key: &str) -> Option<String> {
 // ─── Endpoints ──────────────────────────────
 
 pub fn trpg_uses_polling() -> bool {
-    // MASC API supports SSE, so polling is fallback or for legacy engine.
-    // If using MASC API, we use SSE.
-    // If using Legacy Engine, we might need polling if SSE not exposed?
-    // Actually MASC API exposes /stream/sse.
-    false
+    // Backend only exposes GET /api/v1/trpg/stream (JSON polling).
+    // No dedicated SSE endpoint for TRPG yet.
+    true
 }
 
 pub fn trpg_state_url() -> String {
-    format!("{}/api/v1/trpg/state/{}", MASC_MCP_URL, current_room_id())
+    format!("{}/api/v1/trpg/state?room_id={}", MASC_MCP_URL, current_room_id())
 }
 
 pub fn trpg_stream_poll_url(after_seq: i64) -> String {
-    format!("{}/api/v1/trpg/stream/poll/{}?after={}", MASC_MCP_URL, current_room_id(), after_seq)
+    format!("{}/api/v1/trpg/stream?room_id={}&after_seq={}", MASC_MCP_URL, current_room_id(), after_seq)
 }
 
 pub fn sse_endpoint(mode: &ViewerMode) -> Option<String> {
     match mode {
-        ViewerMode::Trpg => Some(format!("{}/api/v1/trpg/stream/sse/{}", MASC_MCP_URL, current_room_id())),
+        ViewerMode::Trpg => None, // No dedicated TRPG SSE endpoint; uses polling
         ViewerMode::Monitor => Some(format!("{}/api/v1/monitor/stream", MASC_MCP_URL)),
         ViewerMode::Experiment => Some(format!("{}/api/v1/experiment/stream", MASC_MCP_URL)),
         ViewerMode::Council => Some(format!("{}/api/v1/council/stream", MASC_MCP_URL)),


### PR DESCRIPTION
## Summary

PR #211 merged config cleanup but introduced URL pattern mismatches between
the Rust viewer and the OCaml backend (`main_eio.ml`).

**Problem**: Viewer generated path-segment URLs (`/state/{room_id}`) but
backend expects query parameters (`/state?room_id=X`). Also referenced a
nonexistent TRPG SSE endpoint.

**Verified** by reading all 10 TRPG routes in `bin/main_eio.ml`:
- All GET endpoints use `query_param req "room_id"` (not path segments)
- No `/api/v1/trpg/stream/sse` route exists

## Changes

| Before | After |
|--------|-------|
| `/api/v1/trpg/state/{room_id}` | `/api/v1/trpg/state?room_id={room_id}` |
| `/api/v1/trpg/stream/poll/{room_id}?after={seq}` | `/api/v1/trpg/stream?room_id={room_id}&after_seq={seq}` |
| `trpg_uses_polling() → false` | `trpg_uses_polling() → true` |
| `sse_endpoint(Trpg) → Some(...)` | `sse_endpoint(Trpg) → None` |
| (missing) | `TRPG_POLL_INTERVAL_MS = 500` |

## Test plan

- [x] `cargo build --target wasm32-unknown-unknown` passes (warnings only)
- [ ] Manual test: viewer connects and fetches TRPG state via corrected URLs

🤖 Generated with [Claude Code](https://claude.com/claude-code)