### PR TITLE
feat(viewer): add choice/combat ECS systems and overlay DOM rendering

### DIFF
--- a/viewer/src/dom/mod.rs
+++ b/viewer/src/dom/mod.rs
@@ -4,6 +4,7 @@ pub mod character_panel;
 pub mod connection;
 pub mod dice_log;
 pub mod narrative;
+pub mod overlay;
 pub mod turn_controls;
 pub mod turn_runtime;
 pub mod turn_phase;
@@ -27,6 +28,7 @@ impl Plugin for DomBridgePlugin {
             .init_resource::<turn_phase::TurnPhaseCache>()
             .init_resource::<turn_runtime::TurnRuntimeCache>()
             .init_resource::<connection::ConnectionStatusCache>()
+            .init_resource::<overlay::OverlayCache>()
             .add_systems(OnEnter(ViewerMode::Trpg), reset_trpg_dom_state)
             // TRPG-specific DOM update systems
             .add_systems(Update, (
@@ -39,6 +41,7 @@ impl Plugin for DomBridgePlugin {
                 actor_join::sync_join_panel_interaction_state,
                 action_panel::sync_action_panel_interaction_state,
                 turn_controls::sync_turn_controls_visibility,
+                overlay::update_overlay_dom,
             ).run_if(in_state(ViewerMode::Trpg)))
             // Action panel lifecycle: bind listeners on enter, unbind on exit
             .add_systems(OnEnter(ViewerMode::Trpg), (
@@ -60,12 +63,14 @@ fn reset_trpg_dom_state(
     mut turn_cache: ResMut<turn_phase::TurnPhaseCache>,
     mut runtime_cache: ResMut<turn_runtime::TurnRuntimeCache>,
     mut connection_cache: ResMut<connection::ConnectionStatusCache>,
+    mut overlay_cache: ResMut<overlay::OverlayCache>,
 ) {
     character_cache.last_snapshot.clear();
     turn_cache.last_turn = 0;
     turn_cache.last_phase.clear();
     runtime_cache.last_snapshot.clear();
     connection_cache.last_status.clear();
+    *overlay_cache = overlay::OverlayCache::default();
 
     #[cfg(target_arch = "wasm32")]
     {
@@ -85,6 +90,18 @@ fn reset_trpg_dom_state(
             el.set_text_content(Some("1"));
         }
         if let Some(el) = document.get_element_by_id("turn-runtime") {
+            el.set_inner_html("");
+        }
+        if let Some(el) = document.get_element_by_id("weather-indicator") {
+            el.set_text_content(None);
+        }
+        if let Some(el) = document.get_element_by_id("mood-indicator") {
+            el.set_text_content(None);
+        }
+        if let Some(el) = document.get_element_by_id("choice-overlay") {
+            el.set_inner_html("");
+        }
+        if let Some(el) = document.get_element_by_id("combat-overlay") {
             el.set_inner_html("");
         }
     }

--- a/viewer/src/dom/overlay.rs
+++ b/viewer/src/dom/overlay.rs
@@ -1,0 +1,117 @@
+use bevy::prelude::*;
+
+#[cfg(target_arch = "wasm32")]
+use wasm_bindgen::JsCast;
+
+use crate::game::state::{ChoiceState, CombatState, OverlayState};
+
+/// Cache to avoid redundant DOM writes.
+#[derive(Resource, Debug, Default)]
+pub struct OverlayCache {
+    pub last_weather: String,
+    pub last_mood: String,
+    pub last_choice_active: bool,
+    pub last_combat_active: bool,
+}
+
+/// Sync OverlayState, ChoiceState, and CombatState to DOM elements.
+///
+/// Expected HTML elements:
+/// - `#weather-indicator` — weather text
+/// - `#mood-indicator` — mood/atmosphere text
+/// - `#choice-overlay` — choice panel (hidden when inactive)
+/// - `#combat-overlay` — combat indicator (hidden when inactive)
+pub fn update_overlay_dom(
+    overlay: Res<OverlayState>,
+    choice: Res<ChoiceState>,
+    combat: Res<CombatState>,
+    mut cache: ResMut<OverlayCache>,
+) {
+    let weather_changed = overlay.weather != cache.last_weather;
+    let mood_changed = overlay.mood != cache.last_mood;
+    let choice_changed = choice.active != cache.last_choice_active;
+    let combat_changed = combat.active != cache.last_combat_active;
+
+    if !weather_changed && !mood_changed && !choice_changed && !combat_changed {
+        return;
+    }
+
+    #[cfg(target_arch = "wasm32")]
+    {
+        let Some(document) = web_sys::window().and_then(|w| w.document()) else {
+            return;
+        };
+
+        if weather_changed {
+            if let Some(el) = document.get_element_by_id("weather-indicator") {
+                if overlay.weather.is_empty() {
+                    el.set_text_content(None);
+                } else {
+                    el.set_text_content(Some(&overlay.weather));
+                }
+            }
+            cache.last_weather = overlay.weather.clone();
+        }
+
+        if mood_changed {
+            if let Some(el) = document.get_element_by_id("mood-indicator") {
+                if overlay.mood.is_empty() {
+                    el.set_text_content(None);
+                } else {
+                    el.set_text_content(Some(&overlay.mood));
+                }
+            }
+            cache.last_mood = overlay.mood.clone();
+        }
+
+        if choice_changed {
+            if let Some(el) = document.get_element_by_id("choice-overlay") {
+                if choice.active {
+                    let html = format!(
+                        "<strong>{}</strong><p>{}</p><ul>{}</ul>",
+                        choice.character,
+                        choice.description,
+                        choice
+                            .options
+                            .iter()
+                            .map(|o| format!("<li>{}</li>", o))
+                            .collect::<Vec<_>>()
+                            .join("")
+                    );
+                    el.set_inner_html(&html);
+                    if let Some(html_el) = el.dyn_ref::<web_sys::HtmlElement>() {
+                        let _ = html_el.style().set_property("display", "block");
+                    }
+                } else {
+                    el.set_inner_html("");
+                    if let Some(html_el) = el.dyn_ref::<web_sys::HtmlElement>() {
+                        let _ = html_el.style().set_property("display", "none");
+                    }
+                }
+            }
+            cache.last_choice_active = choice.active;
+        }
+
+        if combat_changed {
+            if let Some(el) = document.get_element_by_id("combat-overlay") {
+                if combat.active {
+                    let enemies_str = combat.enemies.join(", ");
+                    let html = format!(
+                        "<strong>COMBAT</strong> <span>{}</span><p>{}</p>",
+                        combat.area, enemies_str
+                    );
+                    el.set_inner_html(&html);
+                    if let Some(html_el) = el.dyn_ref::<web_sys::HtmlElement>() {
+                        let _ = html_el.style().set_property("display", "block");
+                    }
+                } else {
+                    el.set_inner_html("");
+                    if let Some(html_el) = el.dyn_ref::<web_sys::HtmlElement>() {
+                        let _ = html_el.style().set_property("display", "none");
+                    }
+                }
+            }
+            cache.last_combat_active = combat.active;
+        }
+    }
+}

--- a/viewer/src/game/events.rs
+++ b/viewer/src/game/events.rs
@@ -51,12 +51,9 @@ pub struct TurnAdvancePayload {
 
 #[derive(Debug, Clone, Deserialize)]
 pub struct ChoicePayload {
-    #[allow(dead_code)]
     pub character: String,
-    #[allow(dead_code)]
     pub description: String,
     #[serde(default)]
-    #[allow(dead_code)]
     pub options: Vec<String>,
 }
 
@@ -75,10 +72,8 @@ pub struct DeathPayload {
 
 #[derive(Debug, Clone, Deserialize)]
 pub struct CombatPayload {
-    #[allow(dead_code)]
     pub area: String,
     #[serde(default)]
-    #[allow(dead_code)]
     pub enemies: Vec<String>,
 }
 
@@ -135,10 +130,10 @@ pub struct AreaMoved(pub AreaMovePayload);
 pub struct TurnAdvanced(pub TurnAdvancePayload);
 
 #[derive(Message, Debug, Clone)]
-pub struct ChoiceAvailable(#[allow(dead_code)] pub ChoicePayload);
+pub struct ChoiceAvailable(pub ChoicePayload);
 
 #[derive(Message, Debug, Clone)]
-pub struct ChoiceResolved(#[allow(dead_code)] pub ChoicePayload);
+pub struct ChoiceResolved(pub ChoicePayload);
 
 #[derive(Message, Debug, Clone)]
 pub struct ItemAcquired(pub ItemPayload);
@@ -147,7 +142,7 @@ pub struct ItemAcquired(pub ItemPayload);
 pub struct CharacterDied(pub DeathPayload);
 
 #[derive(Message, Debug, Clone)]
-pub struct CombatStarted(#[allow(dead_code)] pub CombatPayload);
+pub struct CombatStarted(pub CombatPayload);
 
 #[derive(Message, Debug, Clone)]
 pub struct WeatherChanged(pub WeatherChangePayload);

--- a/viewer/src/game/mod.rs
+++ b/viewer/src/game/mod.rs
@@ -25,6 +25,8 @@ impl Plugin for GameStatePlugin {
             .init_resource::<ConnectionStatus>()
             .init_resource::<OverlayState>()
             .init_resource::<TurnProgressState>()
+            .init_resource::<ChoiceState>()
+            .init_resource::<CombatState>()
             .init_resource::<http::ActiveTrpgRoom>()
             // Events (type registrations — always available)
             .add_message::<DiceRolled>()
@@ -56,6 +58,9 @@ impl Plugin for GameStatePlugin {
                 systems::apply_character_death,
                 systems::apply_weather_change,
                 systems::apply_mood_change,
+                systems::apply_choice_available,
+                systems::apply_choice_resolved,
+                systems::apply_combat_started,
             ).run_if(in_state(ViewerMode::Trpg)));
     }
 }

--- a/viewer/src/game/state.rs
+++ b/viewer/src/game/state.rs
@@ -92,3 +92,18 @@ pub struct TurnProgressState {
     pub last_result: String,
     pub last_event: String,
 }
+
+#[derive(Resource, Debug, Default)]
+pub struct ChoiceState {
+    pub active: bool,
+    pub character: String,
+    pub description: String,
+    pub options: Vec<String>,
+}
+
+#[derive(Resource, Debug, Default)]
+pub struct CombatState {
+    pub active: bool,
+    pub area: String,
+    pub enemies: Vec<String>,
+}

--- a/viewer/src/game/systems.rs
+++ b/viewer/src/game/systems.rs
@@ -287,3 +287,38 @@ pub fn apply_character_death(
         }
     }
 }
+
+/// Apply choice available events to ChoiceState.
+pub fn apply_choice_available(
+    mut events: MessageReader<ChoiceAvailable>,
+    mut choice_state: ResMut<ChoiceState>,
+) {
+    for ChoiceAvailable(payload) in events.read() {
+        choice_state.active = true;
+        choice_state.character = payload.character.clone();
+        choice_state.description = payload.description.clone();
+        choice_state.options = payload.options.clone();
+    }
+}
+
+/// Apply choice resolved events — deactivate choice state.
+pub fn apply_choice_resolved(
+    mut events: MessageReader<ChoiceResolved>,
+    mut choice_state: ResMut<ChoiceState>,
+) {
+    for ChoiceResolved(_payload) in events.read() {
+        choice_state.active = false;
+    }
+}
+
+/// Apply combat started events to CombatState.
+pub fn apply_combat_started(
+    mut events: MessageReader<CombatStarted>,
+    mut combat_state: ResMut<CombatState>,
+) {
+    for CombatStarted(payload) in events.read() {
+        combat_state.active = true;
+        combat_state.area = payload.area.clone();
+        combat_state.enemies = payload.enemies.clone();
+    }
+}

--- a/viewer/src/sse/client.rs
+++ b/viewer/src/sse/client.rs
@@ -617,7 +617,7 @@ fn start_polling_loop(messages: Arc<Mutex<Vec<(String, String)>>>, active: Arc<A
                 }
             }
 
-            if sleep_ms(config::TRPG_POLL_INTERVAL_MS as i32).await.is_err() {
+            if sleep_ms(500).await.is_err() {
                 break;
             }
         }


### PR DESCRIPTION
## Summary

Closes the remaining end-to-end event coverage gaps in the TRPG viewer.

### Changes

**ECS Resources** (`state.rs`)
- `ChoiceState`: tracks active choice (character, description, options)
- `CombatState`: tracks active combat (area, enemies)

**ECS Systems** (`systems.rs`)
- `apply_choice_available`: populates ChoiceState from ChoiceAvailable events
- `apply_choice_resolved`: deactivates ChoiceState on resolution
- `apply_combat_started`: populates CombatState from CombatStarted events

**DOM Rendering** (`dom/overlay.rs`) — NEW
- Weather indicator (`#weather-indicator`)
- Mood indicator (`#mood-indicator`)
- Choice overlay (`#choice-overlay`) with options list
- Combat overlay (`#combat-overlay`) with enemy list
- Change-detection cache to avoid redundant DOM writes

**Bug fix**
- Inline `TRPG_POLL_INTERVAL_MS` (removed in #211 but reference left in client.rs)

### Event Coverage After This PR

| Layer | Before | After |
|-------|--------|-------|
| Mapper → Bridge | 7/13 | 13/13 (PR #210) |
| Bridge → ECS System | 10/13 | 13/13 |
| ECS → DOM | 7/13 | 13/13 |

### Testing
- `cargo check --target wasm32-unknown-unknown` passes
- Library + binary compilation verified