### PR TITLE
feat(viewer): wire audio system with BGM mood-sync and SFX events

### DIFF
--- a/viewer/Cargo.toml
+++ b/viewer/Cargo.toml
@@ -39,6 +39,7 @@ web-sys = { version = "0.3", features = [
     "RequestMode",
     "Response",
     "Headers",
+    "HtmlAudioElement",
 ] }
 js-sys = "0.3"
 serde = { version = "1", features = ["derive"] }

--- a/viewer/src/audio.rs
+++ b/viewer/src/audio.rs
@@ -1,0 +1,232 @@
+//! Audio system for TRPG viewer (WASM-native via web-sys HtmlAudioElement).
+//!
+//! BGM: looping background music per mood/scene.
+//! SFX: one-shot sound effects for game events (dice, combat, transitions).
+
+use bevy::prelude::*;
+use web_sys::HtmlAudioElement;
+
+use crate::game::events::*;
+
+// ─── Plugin ─────────────────────────────────
+
+pub struct AudioPlugin;
+
+impl Plugin for AudioPlugin {
+    fn build(&self, app: &mut App) {
+        app.init_resource::<AudioSettings>()
+            .init_resource::<AudioState>()
+            .add_systems(Update, (
+                sync_bgm_on_mood_change,
+                play_sfx_on_dice_roll,
+                play_sfx_on_turn_advance,
+                play_sfx_on_combat_start,
+                play_sfx_on_death,
+                update_bgm_volume,
+            ));
+    }
+}
+
+// ─── Resources ──────────────────────────────
+
+#[derive(Resource, Debug)]
+pub struct AudioSettings {
+    pub sound_enabled: bool,
+    pub music_enabled: bool,
+    pub sound_volume: f64,
+    pub music_volume: f64,
+}
+
+impl Default for AudioSettings {
+    fn default() -> Self {
+        Self {
+            sound_enabled: true,
+            music_enabled: true,
+            sound_volume: 0.7,
+            music_volume: 0.4,
+        }
+    }
+}
+
+/// Wrapper to make HtmlAudioElement Send+Sync for Bevy resources.
+/// Safe in WASM: single-threaded environment, no real concurrency.
+struct SendAudioElement(HtmlAudioElement);
+
+// SAFETY: WASM is single-threaded; JsValue pointers are never shared across threads.
+unsafe impl Send for SendAudioElement {}
+unsafe impl Sync for SendAudioElement {}
+
+impl std::fmt::Debug for SendAudioElement {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("SendAudioElement(..)")
+    }
+}
+
+#[derive(Resource, Default, Debug)]
+pub struct AudioState {
+    bgm_element: Option<SendAudioElement>,
+    current_bgm_track: String,
+}
+
+// ─── Asset paths ────────────────────────────
+
+pub mod paths {
+    // BGM tracks — ambient loops per mood/scene
+    pub const BGM_QUIET_UNEASE: &str = "audio/bgm_quiet_unease.ogg";
+    pub const BGM_TENSION_RISING: &str = "audio/bgm_tension_rising.ogg";
+    pub const BGM_AMBIGUOUS_CALM: &str = "audio/bgm_ambiguous_calm.ogg";
+    pub const BGM_COMBAT: &str = "audio/bgm_combat.ogg";
+    pub const BGM_DEFAULT: &str = "audio/bgm_default.ogg";
+
+    // SFX — one-shot effects
+    pub const SFX_DICE_ROLL: &str = "audio/sfx_dice_roll.ogg";
+    pub const SFX_DICE_SUCCESS: &str = "audio/sfx_dice_success.ogg";
+    pub const SFX_DICE_FAIL: &str = "audio/sfx_dice_fail.ogg";
+    pub const SFX_TURN_ADVANCE: &str = "audio/sfx_turn_advance.ogg";
+    pub const SFX_COMBAT_START: &str = "audio/sfx_combat_start.ogg";
+    pub const SFX_DEATH: &str = "audio/sfx_death.ogg";
+    pub const SFX_ITEM_ACQUIRE: &str = "audio/sfx_item_acquire.ogg";
+}
+
+/// Map mood string to BGM path.
+fn bgm_for_mood(mood: &str) -> &'static str {
+    match mood {
+        "quiet_unease" => paths::BGM_QUIET_UNEASE,
+        "tension_rising" => paths::BGM_TENSION_RISING,
+        "ambiguous_calm" => paths::BGM_AMBIGUOUS_CALM,
+        "combat" => paths::BGM_COMBAT,
+        _ => paths::BGM_DEFAULT,
+    }
+}
+
+// ─── Web Audio helpers ──────────────────────
+
+fn create_audio_element(src: &str, looping: bool, volume: f64) -> Option<HtmlAudioElement> {
+    let el = HtmlAudioElement::new_with_src(src).ok()?;
+    el.set_loop(looping);
+    el.set_volume(volume);
+    Some(el)
+}
+
+fn play_element(el: &HtmlAudioElement) {
+    // Browser autoplay policy: play() returns a Promise that may reject.
+    // We fire-and-forget; the user's first click on the menu satisfies the
+    // gesture requirement for subsequent plays.
+    let _ = el.play().ok();
+}
+
+fn play_one_shot(src: &str, volume: f64) {
+    if let Some(el) = create_audio_element(src, false, volume) {
+        play_element(&el);
+        // Element is GC'd by the browser after playback ends.
+        // To prevent early collection, leak a reference that the browser holds
+        // via the playing state. No explicit cleanup needed for short SFX.
+        std::mem::forget(el);
+    }
+}
+
+// ─── Systems ────────────────────────────────
+
+/// Switch BGM when the mood changes.
+fn sync_bgm_on_mood_change(
+    mut events: MessageReader<MoodChanged>,
+    settings: Res<AudioSettings>,
+    mut state: ResMut<AudioState>,
+) {
+    for ev in events.read() {
+        let track = bgm_for_mood(&ev.0.mood);
+        if track == state.current_bgm_track {
+            continue;
+        }
+
+        // Stop previous BGM
+        if let Some(ref el) = state.bgm_element {
+            el.0.pause().ok();
+        }
+
+        if settings.music_enabled {
+            if let Some(el) = create_audio_element(track, true, settings.music_volume) {
+                play_element(&el);
+                state.bgm_element = Some(SendAudioElement(el));
+            }
+        } else {
+            state.bgm_element = None;
+        }
+        state.current_bgm_track = track.to_string();
+    }
+}
+
+/// Adjust BGM volume when settings change (called every frame, early-outs fast).
+fn update_bgm_volume(
+    settings: Res<AudioSettings>,
+    state: Res<AudioState>,
+) {
+    if !settings.is_changed() {
+        return;
+    }
+
+    if let Some(ref el) = state.bgm_element {
+        if settings.music_enabled {
+            el.0.set_volume(settings.music_volume);
+            let _ = el.0.play().ok();
+        } else {
+            el.0.pause().ok();
+        }
+    }
+}
+
+/// Play dice SFX on roll events.
+fn play_sfx_on_dice_roll(
+    mut events: MessageReader<DiceRolled>,
+    settings: Res<AudioSettings>,
+) {
+    for ev in events.read() {
+        if !settings.sound_enabled {
+            continue;
+        }
+        play_one_shot(paths::SFX_DICE_ROLL, settings.sound_volume);
+
+        let result_sfx = if ev.0.result == "success" || ev.0.result == "critical_success" {
+            paths::SFX_DICE_SUCCESS
+        } else {
+            paths::SFX_DICE_FAIL
+        };
+        play_one_shot(result_sfx, settings.sound_volume);
+    }
+}
+
+/// Play turn advance chime.
+fn play_sfx_on_turn_advance(
+    mut events: MessageReader<TurnAdvanced>,
+    settings: Res<AudioSettings>,
+) {
+    for _ev in events.read() {
+        if settings.sound_enabled {
+            play_one_shot(paths::SFX_TURN_ADVANCE, settings.sound_volume);
+        }
+    }
+}
+
+/// Play combat start sting.
+fn play_sfx_on_combat_start(
+    mut events: MessageReader<CombatStarted>,
+    settings: Res<AudioSettings>,
+) {
+    for _ev in events.read() {
+        if settings.sound_enabled {
+            play_one_shot(paths::SFX_COMBAT_START, settings.sound_volume);
+        }
+    }
+}
+
+/// Play death SFX.
+fn play_sfx_on_death(
+    mut events: MessageReader<CharacterDied>,
+    settings: Res<AudioSettings>,
+) {
+    for _ev in events.read() {
+        if settings.sound_enabled {
+            play_one_shot(paths::SFX_DEATH, settings.sound_volume);
+        }
+    }
+}

--- a/viewer/src/config.rs
+++ b/viewer/src/config.rs
@@ -9,6 +9,9 @@ pub const MASC_MCP_URL: &str = "";
 
 pub const DEFAULT_ROOM_ID: &str = "default";
 
+/// Polling interval for TRPG stream fallback (milliseconds).
+pub const TRPG_POLL_INTERVAL_MS: u64 = 2000;
+
 /// Legacy TRPG Engine URL (for direct mode)
 #[cfg(debug_assertions)]
 pub const TRPG_ENGINE_URL: &str = "http://localhost:8000";

--- a/viewer/src/main.rs
+++ b/viewer/src/main.rs
@@ -4,6 +4,7 @@ mod theme;
 
 // Domain modules — compiled unconditionally, but systems are gated on ViewerMode.
 mod assets;
+mod audio;
 mod dom;
 mod game;
 mod render;
@@ -47,6 +48,7 @@ fn main() {
             render::MapRenderPlugin,
             shaders::PostProcessPlugin,
             dom::DomBridgePlugin,
+            audio::AudioPlugin,
         ))
         .add_systems(Update, shaders::post_process::update_post_process_time)
         .run();

--- a/viewer/src/render/ui.rs
+++ b/viewer/src/render/ui.rs
@@ -3,6 +3,8 @@
 use bevy::prelude::*;
 use bevy::ecs::relationship::Relationship;
 
+use crate::audio::AudioSettings;
+
 /// Marker component for UI entities spawned by the TRPG viewer.
 #[derive(Component)]
 pub struct UiMarker;
@@ -472,23 +474,30 @@ fn spawn_dev_menu(commands: &mut Commands) {
 /// (audio toggles, FPS counter, state dump, etc.).
 pub fn handle_menu_item_clicks(
     interactions: Query<
-        (&Interaction, &MenuItem),
+        (Entity, &Interaction, &MenuItem),
         (Changed<Interaction>, With<Button>),
     >,
+    children_query: Query<&Children>,
+    mut text_query: Query<&mut Text>,
+    mut audio: ResMut<AudioSettings>,
 ) {
-    for (interaction, menu_item) in &interactions {
+    for (entity, interaction, menu_item) in &interactions {
         if *interaction != Interaction::Pressed {
             continue;
         }
 
         match menu_item.0 {
             MenuAction::SoundToggle => {
-                log::info!("Menu action: Sound toggled");
-                // TODO: Connect to audio system
+                audio.sound_enabled = !audio.sound_enabled;
+                let label = if audio.sound_enabled { "Sound: ON" } else { "Sound: OFF" };
+                update_button_text(entity, label, &children_query, &mut text_query);
+                log::info!("Sound toggled: {}", audio.sound_enabled);
             }
             MenuAction::MusicToggle => {
-                log::info!("Menu action: Music toggled");
-                // TODO: Connect to audio system
+                audio.music_enabled = !audio.music_enabled;
+                let label = if audio.music_enabled { "Music: ON" } else { "Music: OFF" };
+                update_button_text(entity, label, &children_query, &mut text_query);
+                log::info!("Music toggled: {}", audio.music_enabled);
             }
             MenuAction::AutoSaveToggle => {
                 log::info!("Menu action: Auto-save toggled");
@@ -513,6 +522,23 @@ pub fn handle_menu_item_clicks(
             MenuAction::DumpState => {
                 log::info!("Menu action: Dump game state");
                 // TODO: Serialize and log current state
+            }
+        }
+    }
+}
+
+/// Walk the entity's children to find the first `Text` component and overwrite it.
+fn update_button_text(
+    button: Entity,
+    label: &str,
+    children_query: &Query<&Children>,
+    text_query: &mut Query<&mut Text>,
+) {
+    if let Ok(children) = children_query.get(button) {
+        for child in children.iter() {
+            if let Ok(mut text) = text_query.get_mut(child) {
+                *text = Text::new(label);
+                return;
             }
         }
     }


### PR DESCRIPTION
## Summary

- Add `audio.rs` module with web-sys `HtmlAudioElement`-based audio for WASM
- BGM: looping tracks per mood/scene (quiet_unease, tension_rising, combat, ambiguous_calm, default)
- SFX: one-shot effects for dice rolls (success/fail), turn advance, combat start, death
- Wire Sound/Music toggle buttons in dev menu to `AudioSettings` resource
- `SendAudioElement` newtype wrapper for Bevy `Send+Sync` requirement (safe: WASM single-threaded)
- Fix missing `TRPG_POLL_INTERVAL_MS` constant in config

## Files Changed

| File | Change |
|------|--------|
| `viewer/src/audio.rs` | New — AudioPlugin, 6 systems, BGM/SFX paths |
| `viewer/Cargo.toml` | Add `HtmlAudioElement` to web-sys features |
| `viewer/src/main.rs` | Register `mod audio` + `AudioPlugin` |
| `viewer/src/render/ui.rs` | Wire menu toggles to `AudioSettings` |
| `viewer/src/config.rs` | Add `TRPG_POLL_INTERVAL_MS` constant |

## Test Plan

- [ ] `cargo check --target wasm32-unknown-unknown` passes (verified locally)
- [ ] `trunk serve` → open browser → verify no JS console errors
- [ ] Click Sound/Music toggles → verify `AudioSettings` state changes (log output)
- [ ] Place `.ogg` files in `viewer/assets/audio/` → verify BGM plays on mood change
- [ ] Trigger dice roll event → verify SFX plays

🤖 Generated with [Claude Code](https://claude.com/claude-code)