### PR TITLE
fix(viewer): route non-TRPG modes to /sse and align TRPG endpoints

### DIFF
--- a/lib/llm_client.ml
+++ b/lib/llm_client.ml
@@ -330,8 +330,26 @@ let parse_openai_response (json_str : string) : (completion_response, string) re
        raise (Failure msg));
     let choice = json |> member "choices" |> index 0 in
     let msg = choice |> member "message" in
-    let content = msg |> member "content" |> to_string_option
-                  |> Option.value ~default:"" in
+    let finish_reason =
+      choice |> member "finish_reason" |> to_string_option
+      |> Option.value ~default:""
+    in
+    let content =
+      match msg |> member "content" with
+      | `String s -> s
+      | `List blocks ->
+          blocks
+          |> List.filter_map (fun block ->
+                 match block with
+                 | `String s -> Some s
+                 | `Assoc _ ->
+                     (match block |> member "text" with
+                     | `String s -> Some s
+                     | _ -> None)
+                 | _ -> None)
+          |> String.concat ""
+      | _ -> ""
+    in
     (* Parse tool calls if present *)
     let tool_calls = match msg |> member "tool_calls" with
       | `List calls ->
@@ -345,8 +363,37 @@ let parse_openai_response (json_str : string) : (completion_response, string) re
             }
           with _ -> None
         ) calls
-      | _ -> []
+      | _ -> (
+          match msg |> member "function_call" with
+          | `Assoc _ as fn ->
+              let name = fn |> member "name" |> to_string_option in
+              let arguments =
+                fn |> member "arguments" |> to_string_option
+                |> Option.value ~default:"{}"
+              in
+              (match name with
+              | Some call_name when String.trim call_name <> "" ->
+                  [
+                    {
+                      call_id = "function_call";
+                      call_name;
+                      call_arguments = arguments;
+                    };
+                  ]
+              | _ -> [])
+          | _ -> [])
     in
+    if String.trim content = "" && tool_calls = [] then (
+      let reason =
+        match String.lowercase_ascii finish_reason with
+        | "length" ->
+            "Empty completion (finish_reason=length)"
+        | "content_filter" ->
+            "Empty completion (content filtered)"
+        | _ -> "Empty completion (no content/tool_calls)"
+      in
+      raise (Failure reason)
+    );
     (* Parse usage *)
     let usage_json = json |> member "usage" in
     let usage = {

--- a/lib/web_dashboard.ml
+++ b/lib/web_dashboard.ml
@@ -9167,6 +9167,17 @@ let cached_html = lazy ({|<!DOCTYPE html>
       if (parsedRaw) {
         return parsedRaw;
       }
+      const dataCandidates = raw
+        .split(/\r?\n/)
+        .filter((line) => line.startsWith('data:'))
+        .map((line) => line.slice(5).trimStart())
+        .filter((line) => line !== '' && line !== '[DONE]');
+      for (let i = dataCandidates.length - 1; i >= 0; i -= 1) {
+        const parsedDataLine = trpgUnwrapRpcObject(trpgTryParseJson(dataCandidates[i]));
+        if (parsedDataLine) {
+          return parsedDataLine;
+        }
+      }
       throw new Error(`${toolName} SSE 응답 파싱 실패: ${trpgShortText(raw, 220)}`);
     }
 
@@ -9243,7 +9254,25 @@ let cached_html = lazy ({|<!DOCTYPE html>
       if (rpc && rpc.error) {
         throw new Error(String(rpc.error.message || `${toolName} RPC 오류`));
       }
+      if (rpc && typeof rpc === 'object' && !Array.isArray(rpc)
+          && !Object.prototype.hasOwnProperty.call(rpc, 'result')
+          && !Object.prototype.hasOwnProperty.call(rpc, 'error')
+          && (Object.prototype.hasOwnProperty.call(rpc, 'payload')
+            || Object.prototype.hasOwnProperty.call(rpc, 'status'))) {
+        return (rpc.payload !== undefined && rpc.payload !== null) ? rpc.payload : rpc;
+      }
       const result = (rpc && rpc.result && typeof rpc.result === 'object') ? rpc.result : {};
+      if (result && typeof result === 'object' && !Array.isArray(result)
+          && result.structuredContent && typeof result.structuredContent === 'object') {
+        const structured = result.structuredContent;
+        return (structured.payload !== undefined && structured.payload !== null)
+          ? structured.payload
+          : structured;
+      }
+      if (result && typeof result === 'object' && !Array.isArray(result)
+          && result.payload !== undefined && result.payload !== null) {
+        return result.payload;
+      }
       const content = Array.isArray(result.content) ? result.content : [];
       const textChunk = content.find((row) => row && row.type === 'text' && typeof row.text === 'string');
       const text = textChunk ? textChunk.text : '';

--- a/viewer/Trunk.toml
+++ b/viewer/Trunk.toml
@@ -20,3 +20,8 @@ backend = "http://localhost:8935/api/"
 [[proxy]]
 rewrite = "/mcp"
 backend = "http://localhost:8935/mcp"
+
+# Proxy legacy SSE stream used by non-TRPG viewer modes
+[[proxy]]
+rewrite = "/sse"
+backend = "http://localhost:8935/sse"

--- a/viewer/src/config.rs
+++ b/viewer/src/config.rs
@@ -133,11 +133,20 @@ pub fn trpg_uses_polling() -> bool {
 }
 
 pub fn trpg_state_url() -> String {
-    format!("{}/api/v1/trpg/state/{}", MASC_MCP_URL, current_room_id())
+    format!(
+        "{}/api/v1/trpg/state?room_id={}",
+        MASC_MCP_URL,
+        current_room_id()
+    )
 }
 
 pub fn trpg_stream_poll_url(after_seq: i64) -> String {
-    format!("{}/api/v1/trpg/stream/poll/{}?after={}", MASC_MCP_URL, current_room_id(), after_seq)
+    format!(
+        "{}/api/v1/trpg/stream?room_id={}&after_seq={}",
+        MASC_MCP_URL,
+        current_room_id(),
+        after_seq
+    )
 }
 
 pub fn sse_endpoint(mode: &ViewerMode) -> Option<String> {

--- a/viewer/src/config.rs
+++ b/viewer/src/config.rs
@@ -121,6 +121,9 @@ fn parse_query_param(search: &str, key: &str) -> Option<String> {
 
 // ─── Endpoints ──────────────────────────────
 
+/// Fallback polling interval for TRPG stream (milliseconds).
+pub const TRPG_POLL_INTERVAL_MS: u64 = 2000;
+
 pub fn trpg_uses_polling() -> bool {
     // MASC API supports SSE, so polling is fallback or for legacy engine.
     // If using MASC API, we use SSE.

--- a/viewer/src/config.rs
+++ b/viewer/src/config.rs
@@ -140,10 +140,10 @@ pub fn trpg_stream_poll_url(after_seq: i64) -> String {
 pub fn sse_endpoint(mode: &ViewerMode) -> Option<String> {
     match mode {
         ViewerMode::Trpg => Some(format!("{}/api/v1/trpg/stream/sse/{}", MASC_MCP_URL, current_room_id())),
-        ViewerMode::Monitor => Some(format!("{}/api/v1/monitor/stream", MASC_MCP_URL)),
-        ViewerMode::Experiment => Some(format!("{}/api/v1/experiment/stream", MASC_MCP_URL)),
-        ViewerMode::Council => Some(format!("{}/api/v1/council/stream", MASC_MCP_URL)),
-        ViewerMode::Social => Some(format!("{}/api/v1/social/stream", MASC_MCP_URL)),
+        ViewerMode::Monitor => Some(format!("{}/sse?session_id=viewer-monitor", MASC_MCP_URL)),
+        ViewerMode::Experiment => Some(format!("{}/sse?session_id=viewer-experiment", MASC_MCP_URL)),
+        ViewerMode::Council => Some(format!("{}/sse?session_id=viewer-council", MASC_MCP_URL)),
+        ViewerMode::Social => Some(format!("{}/sse?session_id=viewer-social", MASC_MCP_URL)),
         ViewerMode::Lobby => None,
     }
 }

--- a/viewer/src/game/http.rs
+++ b/viewer/src/game/http.rs
@@ -419,7 +419,8 @@ fn parse_masc_state_response(root: &Value) -> GameStateResponse {
         .get("characters")
         .cloned()
         .and_then(|v| serde_json::from_value::<Vec<CharacterData>>(v).ok())
-        .unwrap_or_default();
+        .filter(|rows| !rows.is_empty())
+        .unwrap_or_else(|| parse_party_characters(state));
 
     GameStateResponse {
         room: Some(RoomResponse {
@@ -446,6 +447,94 @@ fn parse_masc_state_response(root: &Value) -> GameStateResponse {
         current_area,
         area_label,
     }
+}
+
+fn parse_party_characters(state: &Value) -> Vec<CharacterData> {
+    let Some(party) = state.get("party").and_then(Value::as_object) else {
+        return Vec::new();
+    };
+
+    party
+        .iter()
+        .map(|(actor_id, info)| {
+            let name = info
+                .get("name")
+                .and_then(Value::as_str)
+                .unwrap_or(actor_id)
+                .to_string();
+            let class = info
+                .get("class")
+                .and_then(Value::as_str)
+                .or_else(|| info.get("role").and_then(Value::as_str))
+                .or_else(|| info.get("archetype").and_then(Value::as_str))
+                .unwrap_or("")
+                .to_string();
+            let hp = info.get("hp").and_then(Value::as_i64).unwrap_or(20) as i32;
+            let max_hp = info
+                .get("max_hp")
+                .and_then(Value::as_i64)
+                .unwrap_or(i64::from(hp.max(1))) as i32;
+            let area = info
+                .get("position")
+                .and_then(Value::as_str)
+                .or_else(|| info.get("area").and_then(Value::as_str))
+                .unwrap_or("A")
+                .to_string();
+            let is_dead = info
+                .get("alive")
+                .and_then(Value::as_bool)
+                .map(|alive| !alive)
+                .unwrap_or_else(|| hp <= 0);
+            let inventory = info
+                .get("inventory")
+                .and_then(Value::as_array)
+                .map(|rows| {
+                    rows.iter()
+                        .filter_map(Value::as_str)
+                        .map(str::to_string)
+                        .collect::<Vec<_>>()
+                })
+                .unwrap_or_default();
+            let buffs = info
+                .get("buffs")
+                .and_then(Value::as_array)
+                .map(|rows| {
+                    rows.iter()
+                        .filter_map(Value::as_str)
+                        .map(str::to_string)
+                        .collect::<Vec<_>>()
+                })
+                .unwrap_or_default();
+            let debuffs = info
+                .get("debuffs")
+                .and_then(Value::as_array)
+                .map(|rows| {
+                    rows.iter()
+                        .filter_map(Value::as_str)
+                        .map(str::to_string)
+                        .collect::<Vec<_>>()
+                })
+                .unwrap_or_default();
+            let stats = info
+                .get("stats")
+                .cloned()
+                .and_then(|v| serde_json::from_value::<StatsData>(v).ok());
+
+            CharacterData {
+                id: actor_id.to_string(),
+                name,
+                class,
+                hp,
+                max_hp,
+                stats,
+                area,
+                is_dead,
+                inventory,
+                buffs,
+                debuffs,
+            }
+        })
+        .collect()
 }
 
 /// When the fetched room is not resumable, auto-show the new-game panel
@@ -548,6 +637,35 @@ mod tests {
         assert_eq!(parsed.room.as_ref().map(|r| r.turn), Some(5));
         assert_eq!(parsed.current_area, "C");
         assert!(parsed.characters.is_empty(), "no fallback party should be injected");
+    }
+
+    #[test]
+    fn normalize_masc_shape_reads_party_as_characters() {
+        let root = json!({
+            "ok": true,
+            "room_id": "default",
+            "state": {
+                "turn": 3,
+                "phase": "round",
+                "party": {
+                    "grimja": {
+                        "name": "그림자",
+                        "role": "fighter",
+                        "hp": 28,
+                        "max_hp": 30,
+                        "position": "C",
+                        "alive": true
+                    }
+                }
+            }
+        });
+
+        let parsed = normalize_state_response(root).expect("masc parse should succeed");
+        assert_eq!(parsed.characters.len(), 1);
+        assert_eq!(parsed.characters[0].id, "grimja");
+        assert_eq!(parsed.characters[0].name, "그림자");
+        assert_eq!(parsed.characters[0].class, "fighter");
+        assert_eq!(parsed.characters[0].hp, 28);
     }
 
     #[test]

--- a/viewer/src/mode.rs
+++ b/viewer/src/mode.rs
@@ -1207,6 +1207,13 @@ async fn mcp_tool_call(tool_name: &str, args: Value) -> Result<Value, String> {
         return Err(msg.to_string());
     }
 
+    if rpc.get("result").is_none()
+        && rpc.get("error").is_none()
+        && (rpc.get("payload").is_some() || rpc.get("status").is_some())
+    {
+        return Ok(rpc.get("payload").cloned().unwrap_or(rpc));
+    }
+
     let result = rpc.get("result").cloned().unwrap_or_else(|| json!({}));
     if result
         .get("isError")
@@ -1229,6 +1236,19 @@ async fn mcp_tool_call(tool_name: &str, args: Value) -> Result<Value, String> {
         return Err(text.to_string());
     }
 
+    if let Some(structured) = result.get("structuredContent") {
+        return Ok(
+            structured
+                .get("payload")
+                .cloned()
+                .unwrap_or_else(|| structured.clone()),
+        );
+    }
+
+    if let Some(payload) = result.get("payload") {
+        return Ok(payload.clone());
+    }
+
     let text = result
         .get("content")
         .and_then(Value::as_array)
@@ -1249,8 +1269,18 @@ async fn mcp_tool_call(tool_name: &str, args: Value) -> Result<Value, String> {
         return Ok(json!({}));
     }
 
-    let parsed: Value = serde_json::from_str(&text)
-        .map_err(|e| format!("{} 응답 JSON 파싱 실패: {} / {}", tool_name, e, text))?;
+    let parsed: Value = match serde_json::from_str(&text) {
+        Ok(v) => v,
+        Err(primary) => parse_mcp_rpc_response(&text).map_err(|secondary| {
+            format!(
+                "{} 응답 JSON 파싱 실패: {} / {} / raw={}",
+                tool_name,
+                primary,
+                secondary,
+                text
+            )
+        })?,
+    };
     Ok(parsed.get("payload").cloned().unwrap_or(parsed))
 }
 


### PR DESCRIPTION
## Summary
- route Monitor/Experiment/Council/Social SSE endpoints to shared `/sse?session_id=...`
- add Trunk proxy rule for `/sse` so non-TRPG modes are forwarded to masc-mcp
- align TRPG state/poll URLs with current server API (`state?room_id=...`, `stream?room_id=...&after_seq=...`)
- restore missing `TRPG_POLL_INTERVAL_MS` constant used by polling fallback
- harden TRPG parsing for empty LLM completions and party-state edge cases

## Validation
- `make viewer-build` succeeds in worktree
- `trunk serve --port 8081` serves successfully
- `GET /api/v1/trpg/state?room_id=default` works via proxy
- `GET /sse?session_id=viewer-monitor` returns `text/event-stream` via proxy

## Notes
- PR remains `draft` as requested
- main worktree was not modified by these commits