### PR TITLE
feat(viewer): end-to-end TRPG gameplay with round runner and endgame detection

### DIFF
--- a/viewer/Cargo.toml
+++ b/viewer/Cargo.toml
@@ -24,6 +24,8 @@ web-sys = { version = "0.3", features = [
     "HtmlButtonElement",
     "HtmlElement",
     "HtmlInputElement",
+    "HtmlOptionsCollection",
+    "HtmlOptionElement",
     "HtmlSelectElement",
     "CssStyleDeclaration",
     "KeyboardEvent",

--- a/viewer/src/dom/choice_panel.rs
+++ b/viewer/src/dom/choice_panel.rs
@@ -1,0 +1,76 @@
+use bevy::prelude::*;
+
+use crate::game::events::{ChoiceAvailable, ChoiceResolved, CombatStarted};
+
+/// Renders choice and combat events into the `#narrative-log` DOM element.
+/// Uses the same append-child pattern as `narrative.rs` and `dice_log.rs`.
+pub fn update_choice_dom(
+    mut choices: MessageReader<ChoiceAvailable>,
+    mut resolutions: MessageReader<ChoiceResolved>,
+    mut combats: MessageReader<CombatStarted>,
+) {
+    #[cfg(target_arch = "wasm32")]
+    {
+        let doc = match web_sys::window().and_then(|w| w.document()) {
+            Some(d) => d,
+            None => return,
+        };
+        let log = match doc.get_element_by_id("narrative-log") {
+            Some(el) => el,
+            None => return,
+        };
+
+        for ChoiceAvailable(p) in choices.read() {
+            let Ok(div) = doc.create_element("div") else { continue };
+            div.set_class_name("narrative-entry choice-block");
+            let opts: String = p
+                .options
+                .iter()
+                .map(|o| format!("<li class=\"choice-option\">{}</li>", html_escape(o)))
+                .collect();
+            div.set_inner_html(&format!(
+                "<span class=\"choice-character\">{}</span> \
+                 <span class=\"choice-desc\">{}</span>\
+                 <ul class=\"choice-list\">{}</ul>",
+                html_escape(&p.character),
+                html_escape(&p.description),
+                opts
+            ));
+            let _ = log.append_child(&div);
+        }
+
+        for ChoiceResolved(p) in resolutions.read() {
+            let Ok(div) = doc.create_element("div") else { continue };
+            div.set_class_name("narrative-entry choice-resolved");
+            let text = format!("{} chose: {}", &p.character, &p.description);
+            div.set_text_content(Some(&text));
+            let _ = log.append_child(&div);
+        }
+
+        for CombatStarted(p) in combats.read() {
+            let Ok(div) = doc.create_element("div") else { continue };
+            div.set_class_name("narrative-entry combat-block");
+            let enemies = if p.enemies.is_empty() {
+                "???".to_string()
+            } else {
+                p.enemies.join(", ")
+            };
+            div.set_inner_html(&format!(
+                "<span class=\"combat-alert\">\u{2694}\u{fe0f} Combat</span> {} \u{2014} enemies: {}",
+                html_escape(&p.area),
+                html_escape(&enemies)
+            ));
+            let _ = log.append_child(&div);
+        }
+    }
+
+    // Suppress unused-variable warnings on non-wasm targets
+    let _ = (&mut choices, &mut resolutions, &mut combats);
+}
+
+#[cfg(target_arch = "wasm32")]
+fn html_escape(s: &str) -> String {
+    s.replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+}

--- a/viewer/src/dom/endgame.rs
+++ b/viewer/src/dom/endgame.rs
@@ -1,0 +1,115 @@
+//! Endgame detection and overlay rendering.
+//!
+//! Three detection paths:
+//! 1. **TPK** — all `Actor` entities have `is_dead = true`
+//! 2. **Quest complete** — `NarrativeReceived` with `phase == "endgame"`
+//! 3. **Round runner signal** — `RoundRunner.game_ended` atomic flag
+
+use bevy::prelude::*;
+use std::sync::atomic::Ordering;
+
+use crate::game::components::Actor;
+use crate::game::events::NarrativeReceived;
+use crate::game::round_runner::RoundRunner;
+
+/// Tracks whether the endgame overlay has been shown (prevents re-trigger).
+#[derive(Resource, Default)]
+pub struct EndgameState {
+    pub triggered: bool,
+}
+
+/// Monitors multiple signals and triggers the endgame overlay once.
+pub fn detect_endgame(
+    actors: Query<&Actor>,
+    runner: Option<Res<RoundRunner>>,
+    mut narratives: MessageReader<NarrativeReceived>,
+    mut endgame: ResMut<EndgameState>,
+) {
+    if endgame.triggered {
+        // Drain the reader even when already triggered to avoid stale buffers.
+        for _ in narratives.read() {}
+        return;
+    }
+
+    // Path 1: TPK — all actors dead.
+    let actor_count = actors.iter().count();
+    if actor_count > 0 {
+        let dead_count = actors.iter().filter(|a| a.is_dead).count();
+        if dead_count == actor_count {
+            endgame.triggered = true;
+            show_endgame_overlay("파티가 전멸했습니다.", false);
+            if let Some(runner) = &runner {
+                runner.game_ended.store(true, Ordering::SeqCst);
+            }
+            // Drain remaining narratives.
+            for _ in narratives.read() {}
+            return;
+        }
+    }
+
+    // Path 2: Quest complete — endgame narrative phase.
+    for NarrativeReceived(payload) in narratives.read() {
+        if payload.phase == "endgame" {
+            endgame.triggered = true;
+            show_endgame_overlay(&payload.text, true);
+            return;
+        }
+    }
+
+    // Path 3: Round runner detected game ended via response JSON.
+    if let Some(runner) = &runner {
+        if runner.game_ended.load(Ordering::SeqCst) {
+            endgame.triggered = true;
+            show_endgame_overlay("모험이 끝났습니다.", true);
+        }
+    }
+}
+
+/// Render a full-screen endgame overlay via DOM.
+fn show_endgame_overlay(message: &str, is_victory: bool) {
+    #[cfg(target_arch = "wasm32")]
+    {
+        let Some(doc) = web_sys::window().and_then(|w| w.document()) else {
+            return;
+        };
+        let Some(body) = doc.body() else { return };
+
+        let overlay = match doc.create_element("div") {
+            Ok(el) => el,
+            Err(_) => return,
+        };
+
+        let class = if is_victory {
+            "endgame-overlay victory"
+        } else {
+            "endgame-overlay defeat"
+        };
+        overlay.set_class_name(class);
+
+        let title = if is_victory { "임무 완료" } else { "전멸" };
+
+        // Build inner HTML with safe text insertion for the message.
+        // Title is a fixed Korean string (safe). Message uses set_text_content below.
+        let html = format!(
+            "<div class=\"endgame-content\">\
+                <h1 class=\"endgame-title\">{title}</h1>\
+                <p class=\"endgame-message\"></p>\
+                <button class=\"endgame-btn\" \
+                    onclick=\"this.closest('.endgame-overlay').remove()\">닫기</button>\
+            </div>"
+        );
+        overlay.set_inner_html(&html);
+
+        // Set message text safely (auto-escapes HTML entities).
+        if let Ok(msg_el) = overlay.query_selector(".endgame-message") {
+            if let Some(el) = msg_el {
+                el.set_text_content(Some(message));
+            }
+        }
+
+        body.append_child(&overlay).ok();
+    }
+
+    // Suppress unused warnings on native builds.
+    let _ = (message, is_victory);
+}

--- a/viewer/src/dom/mod.rs
+++ b/viewer/src/dom/mod.rs
@@ -3,6 +3,7 @@ pub mod actor_join;
 pub mod character_panel;
 pub mod connection;
 pub mod dice_log;
+pub mod endgame;
 pub mod narrative;
 pub mod overlay;
 pub mod turn_controls;
@@ -29,6 +30,7 @@ impl Plugin for DomBridgePlugin {
             .init_resource::<turn_runtime::TurnRuntimeCache>()
             .init_resource::<connection::ConnectionStatusCache>()
             .init_resource::<overlay::OverlayCache>()
+            .init_resource::<endgame::EndgameState>()
             .add_systems(OnEnter(ViewerMode::Trpg), reset_trpg_dom_state)
             // TRPG-specific DOM update systems
             .add_systems(Update, (
@@ -64,6 +66,7 @@ fn reset_trpg_dom_state(
     mut runtime_cache: ResMut<turn_runtime::TurnRuntimeCache>,
     mut connection_cache: ResMut<connection::ConnectionStatusCache>,
     mut overlay_cache: ResMut<overlay::OverlayCache>,
+    mut endgame_state: ResMut<endgame::EndgameState>,
 ) {
     character_cache.last_snapshot.clear();
     turn_cache.last_turn = 0;
@@ -71,6 +74,7 @@ fn reset_trpg_dom_state(
     runtime_cache.last_snapshot.clear();
     connection_cache.last_status.clear();
     *overlay_cache = overlay::OverlayCache::default();
+    endgame_state.triggered = false;
 
     #[cfg(target_arch = "wasm32")]
     {

--- a/viewer/src/dom/mod.rs
+++ b/viewer/src/dom/mod.rs
@@ -1,6 +1,7 @@
 pub mod action_panel;
 pub mod actor_join;
 pub mod character_panel;
+pub mod choice_panel;
 pub mod connection;
 pub mod dice_log;
 pub mod endgame;
@@ -37,6 +38,7 @@ impl Plugin for DomBridgePlugin {
                 narrative::update_narrative_dom,
                 dice_log::update_dice_log_dom,
                 character_panel::update_character_panel_dom,
+                choice_panel::update_choice_dom,
                 turn_phase::update_turn_phase_dom,
                 turn_runtime::update_turn_runtime_dom,
                 connection::update_connection_dom,

--- a/viewer/src/game/mod.rs
+++ b/viewer/src/game/mod.rs
@@ -1,6 +1,7 @@
 pub mod components;
 pub mod events;
 pub mod http;
+pub mod round_runner;
 pub mod state;
 pub mod systems;
 
@@ -28,6 +29,7 @@ impl Plugin for GameStatePlugin {
             .init_resource::<ChoiceState>()
             .init_resource::<CombatState>()
             .init_resource::<http::ActiveTrpgRoom>()
+            .init_resource::<round_runner::RoundRunner>()
             // Events (type registrations — always available)
             .add_message::<DiceRolled>()
             .add_message::<HpChanged>()
@@ -45,7 +47,11 @@ impl Plugin for GameStatePlugin {
             // ── TRPG-gated systems ──
             .add_systems(
                 OnEnter(ViewerMode::Trpg),
-                (systems::reset_turn_progress, http::fetch_initial_state),
+                (systems::reset_turn_progress, http::fetch_initial_state, round_runner::start_round_loop),
+            )
+            .add_systems(
+                OnExit(ViewerMode::Trpg),
+                round_runner::stop_round_loop,
             )
             .add_systems(Update, (
                 http::refresh_state_on_room_change,
@@ -61,6 +67,7 @@ impl Plugin for GameStatePlugin {
                 systems::apply_choice_available,
                 systems::apply_choice_resolved,
                 systems::apply_combat_started,
+                crate::dom::endgame::detect_endgame,
             ).run_if(in_state(ViewerMode::Trpg)));
     }
 }

--- a/viewer/src/game/round_runner.rs
+++ b/viewer/src/game/round_runner.rs
@@ -1,0 +1,305 @@
+//! Round Runner — auto-triggers TRPG game rounds via `POST /api/v1/trpg/rounds/run`.
+//!
+//! On TRPG entry the runner waits for initial state, then repeatedly POSTs to
+//! the rounds/run endpoint.  SSE polling picks up the resulting events.
+//! Stops when the room status reaches "ended" / "completed" or the safety cap
+//! is hit.
+
+use bevy::prelude::*;
+use std::sync::{
+    atomic::{AtomicBool, Ordering},
+    Arc, Mutex,
+};
+
+use crate::config;
+use crate::game::state::TurnProgressState;
+
+// ─── Resource ──────────────────────────────────
+
+/// Shared state between the Bevy ECS world and the async WASM loop.
+#[derive(Resource)]
+pub struct RoundRunner {
+    /// Whether an auto-run loop is currently active.
+    pub running: Arc<AtomicBool>,
+    /// Signal to stop the loop from any Bevy system.
+    pub game_ended: Arc<AtomicBool>,
+    /// Most recent round-run response (for debug display).
+    pub last_result: Arc<Mutex<Option<String>>>,
+    /// How many rounds have been executed so far.
+    pub rounds_completed: Arc<Mutex<u32>>,
+}
+
+impl Default for RoundRunner {
+    fn default() -> Self {
+        Self {
+            running: Arc::new(AtomicBool::new(false)),
+            game_ended: Arc::new(AtomicBool::new(false)),
+            last_result: Arc::new(Mutex::new(None)),
+            rounds_completed: Arc::new(Mutex::new(0)),
+        }
+    }
+}
+
+/// Safety cap — prevent infinite runaway.
+const MAX_ROUNDS: u32 = 50;
+
+/// Delay between rounds (ms) — gives SSE events time to stream + user to read.
+const INTER_ROUND_DELAY_MS: i32 = 5000;
+
+/// Initial delay before first round (ms) — wait for SSE + initial state.
+const STARTUP_DELAY_MS: i32 = 3000;
+
+// ─── OnEnter System ────────────────────────────
+
+/// Spawns the async round-run loop when entering TRPG mode.
+pub fn start_round_loop(
+    mut commands: Commands,
+    progress: Res<TurnProgressState>,
+) {
+    let runner = RoundRunner::default();
+    runner.running.store(true, Ordering::SeqCst);
+
+    #[cfg(target_arch = "wasm32")]
+    {
+        let running = runner.running.clone();
+        let game_ended = runner.game_ended.clone();
+        let last_result = runner.last_result.clone();
+        let rounds_completed = runner.rounds_completed.clone();
+
+        // Snapshot keeper info available at entry time.
+        // The async loop will re-read from DOM on each iteration for freshness.
+        let dm_keeper_snapshot = progress.dm_keeper.clone();
+
+        wasm_bindgen_futures::spawn_local(async move {
+            // Wait for SSE connection + initial state fetch.
+            sleep_ms(STARTUP_DELAY_MS).await;
+
+            let mut round_num = 0u32;
+
+            while running.load(Ordering::SeqCst)
+                && !game_ended.load(Ordering::SeqCst)
+                && round_num < MAX_ROUNDS
+            {
+                round_num += 1;
+                log::info!("RoundRunner: triggering round {}", round_num);
+
+                let body = build_round_body(&dm_keeper_snapshot);
+
+                let url = format!("{}/api/v1/trpg/rounds/run", config::MASC_MCP_URL);
+                match fetch_json_post(&url, &body).await {
+                    Ok(resp) => {
+                        log::info!("RoundRunner: round {} done — {}", round_num, &resp[..resp.len().min(200)]);
+                        if let Ok(mut guard) = last_result.lock() {
+                            *guard = Some(resp.clone());
+                        }
+                        if let Ok(mut guard) = rounds_completed.lock() {
+                            *guard = round_num;
+                        }
+                        // Detect game-ended signals in response JSON.
+                        if resp.contains("\"status\":\"ended\"")
+                            || resp.contains("\"status\":\"completed\"")
+                            || resp.contains("\"game_over\":true")
+                        {
+                            game_ended.store(true, Ordering::SeqCst);
+                            log::info!("RoundRunner: game ended signal in response");
+                        }
+                    }
+                    Err(e) => {
+                        let detail = e
+                            .as_string()
+                            .unwrap_or_else(|| format!("{:?}", e));
+                        log::warn!("RoundRunner: POST failed — {}", detail);
+
+                        // If the room doesn't exist or the server returns a fatal error,
+                        // don't spin endlessly.
+                        if detail.contains("404") || detail.contains("422") {
+                            log::warn!("RoundRunner: stopping due to fatal HTTP error");
+                            break;
+                        }
+                    }
+                }
+
+                // Pause between rounds for events to stream back via SSE.
+                sleep_ms(INTER_ROUND_DELAY_MS).await;
+            }
+
+            running.store(false, Ordering::SeqCst);
+            log::info!(
+                "RoundRunner: loop finished (rounds={}, ended={})",
+                round_num,
+                game_ended.load(Ordering::SeqCst)
+            );
+        });
+    }
+
+    let _ = &progress; // suppress unused on native
+    commands.insert_resource(runner);
+}
+
+// ─── OnExit System ─────────────────────────────
+
+/// Signals the async loop to stop when leaving TRPG mode.
+pub fn stop_round_loop(runner: Option<Res<RoundRunner>>) {
+    if let Some(runner) = runner {
+        runner.running.store(false, Ordering::SeqCst);
+        log::info!("RoundRunner: stop signalled");
+    }
+}
+
+// ─── HTTP POST ─────────────────────────────────
+
+/// POST JSON to a URL and return the response body text.
+#[cfg(target_arch = "wasm32")]
+async fn fetch_json_post(url: &str, body: &str) -> Result<String, wasm_bindgen::JsValue> {
+    use wasm_bindgen::JsCast;
+    use wasm_bindgen::JsValue;
+    use wasm_bindgen_futures::JsFuture;
+
+    let opts = web_sys::RequestInit::new();
+    opts.set_method("POST");
+    opts.set_mode(web_sys::RequestMode::Cors);
+    opts.set_body(&JsValue::from_str(body));
+
+    let request = web_sys::Request::new_with_str_and_init(url, &opts)?;
+    request.headers().set("Content-Type", "application/json")?;
+
+    let window = web_sys::window().ok_or_else(|| JsValue::from_str("no window"))?;
+    let resp_value = JsFuture::from(window.fetch_with_request(&request)).await?;
+    let resp: web_sys::Response = resp_value.dyn_into()?;
+
+    if !resp.ok() {
+        let err_body = JsFuture::from(resp.text()?)
+            .await
+            .ok()
+            .and_then(|v| v.as_string())
+            .unwrap_or_default();
+        let err_body = err_body.trim();
+        if err_body.is_empty() {
+            return Err(JsValue::from_str(&format!("HTTP {}", resp.status())));
+        }
+        return Err(JsValue::from_str(&format!(
+            "HTTP {}: {}",
+            resp.status(),
+            err_body
+        )));
+    }
+
+    let text = JsFuture::from(resp.text()?)
+        .await
+        .ok()
+        .and_then(|v| v.as_string())
+        .unwrap_or_default();
+    Ok(text)
+}
+
+// ─── Body Builder ──────────────────────────────
+
+/// Build the JSON body for `POST /api/v1/trpg/rounds/run`.
+///
+/// Reads keeper configuration from DOM inputs (fresh each round) with a
+/// fallback to the ECS snapshot taken at session start.
+#[cfg(target_arch = "wasm32")]
+fn build_round_body(dm_keeper_fallback: &str) -> String {
+    use serde_json::json;
+
+    let room_id = config::current_room_id();
+
+    // 1. DM keeper — prefer DOM input, fallback to ECS snapshot.
+    let dm_keeper = read_dom_input("claimed-keeper")
+        .or_else(|| read_dom_input("new-game-dm-select"))
+        .unwrap_or_else(|| {
+            if dm_keeper_fallback.is_empty() {
+                "auto".to_string()
+            } else {
+                dm_keeper_fallback.to_string()
+            }
+        });
+
+    // 2. Player keepers — build { actor_id: keeper_name } mapping.
+    //    If we can read selected players from DOM, use them.
+    //    Otherwise, send an empty object and let the backend use defaults.
+    let player_keepers = build_player_keepers_from_dom();
+
+    let body = json!({
+        "room_id": room_id,
+        "dm_keeper": dm_keeper,
+        "player_keepers": player_keepers,
+        "phase": "round",
+        "timeout_sec": 90,
+        "lang": "ko"
+    });
+
+    body.to_string()
+}
+
+/// Read a value from a DOM input element by ID.
+#[cfg(target_arch = "wasm32")]
+fn read_dom_input(id: &str) -> Option<String> {
+    use wasm_bindgen::JsCast;
+
+    let doc = web_sys::window()?.document()?;
+    let el = doc.get_element_by_id(id)?;
+    let value = el
+        .dyn_ref::<web_sys::HtmlInputElement>()
+        .map(|i| i.value())
+        .or_else(|| {
+            el.dyn_ref::<web_sys::HtmlSelectElement>()
+                .map(|s| s.value())
+        })?;
+    let trimmed = value.trim().to_string();
+    if trimmed.is_empty() {
+        None
+    } else {
+        Some(trimmed)
+    }
+}
+
+/// Build player_keepers mapping from DOM multi-select options.
+/// Returns a serde_json::Value (object or empty object).
+#[cfg(target_arch = "wasm32")]
+fn build_player_keepers_from_dom() -> serde_json::Value {
+    use serde_json::{json, Map, Value};
+    use wasm_bindgen::JsCast;
+
+    let mut map = Map::new();
+
+    let doc = match web_sys::window().and_then(|w| w.document()) {
+        Some(d) => d,
+        None => return json!({}),
+    };
+
+    // Try to read selected player options from the multi-select.
+    if let Some(el) = doc.get_element_by_id("new-game-player-select") {
+        if let Some(select) = el.dyn_ref::<web_sys::HtmlSelectElement>() {
+            let options = select.options();
+            for i in 0..options.length() {
+                if let Some(opt) = options.item(i) {
+                    if let Some(opt) = opt.dyn_ref::<web_sys::HtmlOptionElement>() {
+                        if opt.selected() {
+                            let actor_id = opt.value();
+                            if !actor_id.trim().is_empty() {
+                                // Use "auto" as keeper name — backend resolves the actual keeper.
+                                map.insert(actor_id, Value::String("auto".to_string()));
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    Value::Object(map)
+}
+
+// ─── Sleep Helper ──────────────────────────────
+
+#[cfg(target_arch = "wasm32")]
+async fn sleep_ms(ms: i32) {
+    let promise = js_sys::Promise::new(&mut |resolve, _| {
+        web_sys::window()
+            .unwrap()
+            .set_timeout_with_callback_and_timeout_and_arguments_0(&resolve, ms)
+            .unwrap();
+    });
+    wasm_bindgen_futures::JsFuture::from(promise).await.ok();
+}

--- a/viewer/src/sse/client.rs
+++ b/viewer/src/sse/client.rs
@@ -481,6 +481,44 @@ fn map_trpg_event(
             });
             out.push(("narrative".to_string(), mapped.to_string()));
         }
+        // -- choice.available → choice_available --
+        "choice.available" => {
+            let mapped = json!({
+                "character": payload.get("actor_id").and_then(Value::as_str)
+                    .or(actor_id).unwrap_or("unknown"),
+                "description": payload.get("description").and_then(Value::as_str).unwrap_or(""),
+                "options": payload.get("options").and_then(Value::as_array)
+                    .cloned().unwrap_or_default()
+            });
+            out.push(("choice_available".to_string(), mapped.to_string()));
+        }
+        // -- choice.resolved → choice_resolved --
+        "choice.resolved" => {
+            let mapped = json!({
+                "character": payload.get("actor_id").and_then(Value::as_str)
+                    .or(actor_id).unwrap_or("unknown"),
+                "description": payload.get("chosen").and_then(Value::as_str).unwrap_or(""),
+                "options": []
+            });
+            out.push(("choice_resolved".to_string(), mapped.to_string()));
+        }
+        // -- combat.started → combat_start --
+        "combat.started" => {
+            let mapped = json!({
+                "area": payload.get("area").and_then(Value::as_str).unwrap_or("unknown"),
+                "enemies": payload.get("enemies").and_then(Value::as_array)
+                    .cloned().unwrap_or_default()
+            });
+            out.push(("combat_start".to_string(), mapped.to_string()));
+        }
+        // -- game.ended / quest.completed → narrative with endgame phase --
+        "game.ended" | "quest.completed" => {
+            let text = payload.get("summary").and_then(Value::as_str)
+                .or_else(|| payload.get("text").and_then(Value::as_str))
+                .unwrap_or("The adventure has ended.");
+            let mapped = json!({ "text": text, "phase": "endgame", "speaker": "DM" });
+            out.push(("narrative".to_string(), mapped.to_string()));
+        }
         // -- actor lifecycle → turn_progress only (handled below) --
         "actor.spawned" | "actor.updated" | "actor.deleted"
         | "actor.claimed" | "actor.released" => {

--- a/viewer/style.css
+++ b/viewer/style.css
@@ -2337,3 +2337,69 @@ body.mode-lobby #dashboard {
     opacity: 0.5;
     cursor: not-allowed;
 }
+
+/* ─── Endgame Overlay ────────────────────── */
+
+.endgame-overlay {
+    position: fixed;
+    inset: 0;
+    z-index: 9999;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: rgba(0, 0, 0, 0.88);
+    animation: endgame-fade-in 0.6s ease;
+}
+
+@keyframes endgame-fade-in {
+    from { opacity: 0; }
+    to   { opacity: 1; }
+}
+
+.endgame-content {
+    text-align: center;
+    padding: 2.5em;
+    max-width: 600px;
+}
+
+.endgame-title {
+    font-family: var(--font-display, 'Cinzel', serif);
+    font-size: 2.8em;
+    margin: 0 0 0.3em;
+    letter-spacing: 0.05em;
+}
+
+.endgame-overlay.victory .endgame-title {
+    color: var(--accent-primary, #c4a265);
+    text-shadow: 0 0 20px rgba(196, 162, 101, 0.4);
+}
+
+.endgame-overlay.defeat .endgame-title {
+    color: var(--accent-secondary, #8b2500);
+    text-shadow: 0 0 20px rgba(139, 37, 0, 0.4);
+}
+
+.endgame-message {
+    font-family: var(--font-body, 'EB Garamond', serif);
+    font-size: 1.2em;
+    color: var(--text-dim, #6a5d4d);
+    line-height: 1.6;
+    margin: 0 auto 1.8em;
+}
+
+.endgame-btn {
+    padding: 0.6em 2.4em;
+    border: 1px solid var(--accent-primary, #c4a265);
+    background: transparent;
+    color: var(--text-primary, #d4c4a8);
+    cursor: pointer;
+    font-family: var(--font-ui, 'Noto Sans KR', sans-serif);
+    font-size: 0.95em;
+    border-radius: var(--panel-radius, 2px);
+    transition: background 0.2s, color 0.2s;
+}
+
+.endgame-btn:hover {
+    background: var(--accent-primary, #c4a265);
+    color: var(--bg-deep, #0a0a12);
+}

--- a/viewer/style.css
+++ b/viewer/style.css
@@ -2403,3 +2403,46 @@ body.mode-lobby #dashboard {
     background: var(--accent-primary, #c4a265);
     color: var(--bg-deep, #0a0a12);
 }
+
+/* ── Choice blocks in narrative log ── */
+.choice-block {
+    border-left: 3px solid var(--accent-primary, #c4a265);
+    padding-left: 0.8em;
+    margin: 0.5em 0;
+}
+.choice-character {
+    font-weight: bold;
+    color: var(--accent-primary, #c4a265);
+}
+.choice-desc {
+    color: var(--text-dim, #999);
+}
+.choice-list {
+    margin: 0.3em 0 0 1em;
+    padding: 0;
+    list-style: none;
+}
+.choice-option {
+    padding: 0.2em 0.5em;
+    margin: 0.1em 0;
+    border: 1px solid var(--border-main, #2a1f1a);
+    border-radius: 3px;
+    font-size: 0.9em;
+}
+.choice-resolved {
+    opacity: 0.7;
+    font-style: italic;
+}
+
+/* ── Combat alert in narrative log ── */
+.combat-block {
+    border-left: 3px solid var(--accent-secondary, #8b2500);
+    padding-left: 0.8em;
+    margin: 0.5em 0;
+}
+.combat-alert {
+    color: #e74c3c;
+    font-weight: bold;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+}


### PR DESCRIPTION
## Summary

Viewer를 read-only 디스플레이에서 완전한 TRPG 게임 루프로 확장합니다.

- **RoundRunner**: TRPG 모드 진입 시 자동으로 `POST /api/v1/trpg/rounds/run`을 호출하는 async WASM 루프. 설정 가능한 room, DM/player keepers, 라운드 간 딜레이, 안전 상한 (MAX_ROUNDS=50)
- **Endgame Detection**: 세 가지 경로로 게임 종료를 감지
  1. **TPK** — 모든 Actor 엔티티의 `is_dead == true`
  2. **Quest Complete** — `NarrativeReceived` 이벤트의 `phase == "endgame"`
  3. **Round Runner Signal** — `game_ended` atomic flag (응답 JSON에서 감지)
- **Endgame Overlay**: Victory/Defeat 전체 화면 오버레이 (Cinzel/EB Garamond 타이포그래피, fade-in 애니메이션)
- **Cargo.toml**: `HtmlOptionsCollection`, `HtmlOptionElement` web-sys features 추가

### 이전 PR
- #210: SSE 이벤트 매핑 확장
- #216: Choice/Combat ECS 시스템 + 오버레이 DOM

### New Files
| File | Lines | Purpose |
|------|-------|---------|
| `viewer/src/game/round_runner.rs` | 306 | Auto-trigger rounds via POST |
| `viewer/src/dom/endgame.rs` | 116 | TPK/quest detection + overlay |

### Modified Files
| File | Changes | Purpose |
|------|---------|---------|
| `viewer/src/game/mod.rs` | +9/-1 | Register round_runner + endgame systems |
| `viewer/src/dom/mod.rs` | +4 | EndgameState resource + reset |
| `viewer/style.css` | +66 | Endgame overlay CSS |
| `viewer/Cargo.toml` | +2 | web-sys features |

## Test plan

- [ ] `cargo check --target wasm32-unknown-unknown` passes (verified locally)
- [ ] `trunk build` produces valid WASM bundle
- [ ] Enter TRPG mode → rounds auto-trigger via POST
- [ ] Narrative, dice, HP events display correctly
- [ ] TPK → "전멸" overlay appears
- [ ] Quest complete → "임무 완료" overlay appears
- [ ] "닫기" button dismisses overlay
- [ ] Re-entering TRPG mode resets endgame state

Generated with [Claude Code](https://claude.com/claude-code)