### PR TITLE
feat(viewer): expand character panel with skills, conditions, and equipment

### DIFF
--- a/viewer/src/dom/character_panel.rs
+++ b/viewer/src/dom/character_panel.rs
@@ -2,10 +2,26 @@ use bevy::prelude::*;
 
 use crate::game::components::Actor;
 
-/// Tracks the last known HP values so we only re-render on change.
+/// Snapshot of actor state used for change detection.
+/// Re-render only fires when this changes.
+#[derive(Clone, PartialEq)]
+pub struct ActorSnapshot {
+    id: String,
+    hp: i32,
+    mp: i32,
+    is_dead: bool,
+    buff_count: usize,
+    debuff_count: usize,
+    skill_count: usize,
+    condition_count: usize,
+    equip_count: usize,
+}
+
+/// Tracks the last known state so we only re-render on change.
 #[derive(Resource, Default)]
 pub struct CharacterPanelCache {
-    pub last_snapshot: Vec<(String, i32, bool)>, // (id, hp, is_dead)
+    pub last_snapshot: Vec<(String, i32, bool)>,
+    pub last_full: Vec<ActorSnapshot>,
 }
 
 /// Determines HP bar color class based on percentage.
@@ -15,6 +31,16 @@ fn hp_class(hp: i32, max_hp: i32) -> &'static str {
         0..=25 => "critical",
         26..=60 => "wounded",
         _ => "healthy",
+    }
+}
+
+/// Determines MP bar color class based on percentage.
+fn mp_class(mp: i32, max_mp: i32) -> &'static str {
+    let pct = if max_mp > 0 { mp * 100 / max_mp } else { 0 };
+    match pct {
+        0..=20 => "mp-depleted",
+        21..=50 => "mp-low",
+        _ => "mp-full",
     }
 }
 
@@ -37,22 +63,108 @@ fn class_slug(class: &str) -> String {
     class.to_lowercase().replace(|c: char| !c.is_ascii_alphanumeric(), "-")
 }
 
-/// Re-renders the #character-panel DOM whenever actor HP changes.
+/// Icon for a condition name.
+fn condition_icon(name: &str) -> &'static str {
+    match name.to_lowercase().as_str() {
+        "poisoned" => "\u{2620}\u{FE0F}",
+        "stunned" => "\u{1F4AB}",
+        "charmed" => "\u{1F496}",
+        "frightened" => "\u{1F631}",
+        "blinded" => "\u{1F576}\u{FE0F}",
+        "paralyzed" => "\u{26A1}",
+        "prone" => "\u{1F938}",
+        "restrained" => "\u{26D3}\u{FE0F}",
+        "invisible" => "\u{1F47B}",
+        "blessed" => "\u{2728}",
+        "burning" => "\u{1F525}",
+        "frozen" | "cold" => "\u{2744}\u{FE0F}",
+        "sleeping" | "unconscious" => "\u{1F4A4}",
+        _ => "\u{26A0}\u{FE0F}",
+    }
+}
+
+/// Icon for an equipment slot.
+fn slot_icon(slot: &str) -> &'static str {
+    match slot.to_lowercase().as_str() {
+        "weapon" | "main hand" | "mainhand" => "\u{2694}\u{FE0F}",
+        "off hand" | "offhand" | "shield" => "\u{1F6E1}\u{FE0F}",
+        "armor" | "body" | "chest" => "\u{1F6E1}\u{FE0F}",
+        "head" | "helmet" | "helm" => "\u{1FA96}",
+        "ring" | "accessory" => "\u{1F48D}",
+        "amulet" | "necklace" => "\u{1F4FF}",
+        "boots" | "feet" => "\u{1F97E}",
+        "gloves" | "hands" => "\u{1F9E4}",
+        "cloak" | "cape" | "back" => "\u{1F9E3}",
+        _ => "\u{1F4E6}",
+    }
+}
+
+/// Formats a modifier with sign: +2, -1, +0.
+fn fmt_modifier(m: i32) -> String {
+    if m >= 0 {
+        format!("+{}", m)
+    } else {
+        format!("{}", m)
+    }
+}
+
+/// Reads the current collapse state from the DOM to preserve it across re-renders.
+/// Returns a set of section IDs that are currently expanded.
+#[cfg(target_arch = "wasm32")]
+fn read_collapse_state(document: &web_sys::Document) -> std::collections::HashSet<String> {
+    use wasm_bindgen::JsCast;
+    let mut expanded = std::collections::HashSet::new();
+    if let Ok(inputs) = document.query_selector_all("input.section-toggle") {
+        for i in 0..inputs.length() {
+            if let Some(node) = inputs.item(i) {
+                if let Some(input) = node.dyn_ref::<web_sys::HtmlInputElement>() {
+                    if input.checked() {
+                        expanded.insert(input.id());
+                    }
+                }
+            }
+        }
+    }
+    expanded
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn read_collapse_state(_document: &()) -> std::collections::HashSet<String> {
+    std::collections::HashSet::new()
+}
+
+/// Re-renders the #character-panel DOM whenever actor state changes.
 pub fn update_character_panel_dom(
     actors: Query<&Actor>,
     mut cache: ResMut<CharacterPanelCache>,
 ) {
-    // Build current snapshot
-    let snapshot: Vec<(String, i32, bool)> = actors
+    // Build current snapshot for cheap equality check
+    let compat_snapshot: Vec<(String, i32, bool)> = actors
         .iter()
         .map(|a| (a.id.clone(), a.hp, a.is_dead))
         .collect();
 
+    let full_snapshot: Vec<ActorSnapshot> = actors
+        .iter()
+        .map(|a| ActorSnapshot {
+            id: a.id.clone(),
+            hp: a.hp,
+            mp: a.mp,
+            is_dead: a.is_dead,
+            buff_count: a.buffs.len(),
+            debuff_count: a.debuffs.len(),
+            skill_count: a.skills.len(),
+            condition_count: a.conditions.len(),
+            equip_count: a.equipment.len(),
+        })
+        .collect();
+
     // Skip if nothing changed
-    if snapshot == cache.last_snapshot {
+    if compat_snapshot == cache.last_snapshot && full_snapshot == cache.last_full {
         return;
     }
-    cache.last_snapshot = snapshot;
+    cache.last_snapshot = compat_snapshot;
+    cache.last_full = full_snapshot;
 
     let Some(document) = web_sys::window().and_then(|w| w.document()) else {
         return;
@@ -60,6 +172,9 @@ pub fn update_character_panel_dom(
     let Some(panel) = document.get_element_by_id("character-panel") else {
         return;
     };
+
+    // Read which sections are expanded before we wipe innerHTML
+    let expanded = read_collapse_state(&document);
 
     let mut html = String::new();
 
@@ -69,11 +184,18 @@ pub fn update_character_panel_dom(
         } else {
             0.0
         };
+        let mp_pct = if actor.max_mp > 0 {
+            (actor.mp as f32 / actor.max_mp as f32 * 100.0).max(0.0)
+        } else {
+            0.0
+        };
         let dead_class = if actor.is_dead { " dead" } else { "" };
         let bar_class = hp_class(actor.hp, actor.max_hp);
+        let mp_bar_class = mp_class(actor.mp, actor.max_mp);
         let icon = class_icon(&actor.class);
         let slug = class_slug(&actor.class);
 
+        // Buffs / debuffs
         let buffs_html = actor
             .buffs
             .iter()
@@ -87,26 +209,152 @@ pub fn update_character_panel_dom(
             .collect::<Vec<_>>()
             .join("");
 
+        // Conditions section
+        let conditions_html = if actor.conditions.is_empty() {
+            String::new()
+        } else {
+            let items: String = actor
+                .conditions
+                .iter()
+                .map(|c| {
+                    let turns = c
+                        .remaining_turns
+                        .map(|t| format!(" <span class=\"condition-turns\">{t}t</span>"))
+                        .unwrap_or_default();
+                    format!(
+                        "<span class=\"condition-badge\">{} {}{}</span>",
+                        condition_icon(&c.name),
+                        c.name,
+                        turns,
+                    )
+                })
+                .collect::<Vec<_>>()
+                .join("");
+            format!("<div class=\"conditions-row\">{}</div>", items)
+        };
+
+        // Collapsible section IDs
+        let skills_id = format!("toggle-skills-{}", actor.id);
+        let equip_id = format!("toggle-equip-{}", actor.id);
+
+        let skills_checked = if expanded.contains(&skills_id) {
+            " checked"
+        } else {
+            ""
+        };
+        let equip_checked = if expanded.contains(&equip_id) {
+            " checked"
+        } else {
+            ""
+        };
+
+        // Skills section
+        let skills_section = if actor.skills.is_empty() {
+            String::new()
+        } else {
+            let rows: String = actor
+                .skills
+                .iter()
+                .map(|s| {
+                    let m = s.modifier();
+                    let mod_class = if m > 0 {
+                        "mod-positive"
+                    } else if m < 0 {
+                        "mod-negative"
+                    } else {
+                        "mod-neutral"
+                    };
+                    format!(
+                        "<div class=\"skill-row\"><span class=\"skill-name\">{}</span><span class=\"skill-level\">{}</span><span class=\"skill-mod {}\">{}</span></div>",
+                        s.name, s.level, mod_class, fmt_modifier(m),
+                    )
+                })
+                .collect::<Vec<_>>()
+                .join("");
+            format!(
+                concat!(
+                    "<input type=\"checkbox\" class=\"section-toggle\" id=\"{}\"{}/>",
+                    "<label class=\"section-header\" for=\"{}\">Skills <span class=\"section-count\">({})</span></label>",
+                    "<div class=\"section-body skills-list\">{}</div>",
+                ),
+                skills_id, skills_checked,
+                skills_id,
+                actor.skills.len(),
+                rows,
+            )
+        };
+
+        // Equipment section
+        let equip_section = if actor.equipment.is_empty() {
+            String::new()
+        } else {
+            let rows: String = actor
+                .equipment
+                .iter()
+                .map(|e| {
+                    format!(
+                        "<div class=\"equip-row\"><span class=\"equip-icon\">{}</span><span class=\"equip-slot\">{}</span><span class=\"equip-name\">{}</span></div>",
+                        slot_icon(&e.slot), e.slot, e.name,
+                    )
+                })
+                .collect::<Vec<_>>()
+                .join("");
+            format!(
+                concat!(
+                    "<input type=\"checkbox\" class=\"section-toggle\" id=\"{}\"{}/>",
+                    "<label class=\"section-header\" for=\"{}\">Equipment <span class=\"section-count\">({})</span></label>",
+                    "<div class=\"section-body equip-list\">{}</div>",
+                ),
+                equip_id, equip_checked,
+                equip_id,
+                actor.equipment.len(),
+                rows,
+            )
+        };
+
+        // MP bar (only if max_mp > 0)
+        let mp_row = if actor.max_mp > 0 {
+            format!(
+                concat!(
+                    "<div class=\"mp-row\">",
+                    "<div class=\"mp-bar-container\">",
+                    "<div class=\"mp-bar-fill {}\" style=\"width: {}%\"></div>",
+                    "</div>",
+                    "<div class=\"mp-text\">{} / {}</div>",
+                    "</div>",
+                ),
+                mp_bar_class, mp_pct, actor.mp, actor.max_mp,
+            )
+        } else {
+            String::new()
+        };
+
         html.push_str(&format!(
-            r#"<div class="character-card{}" data-actor-id="{}" data-class="{}">
-  <div class="char-header">
-    <span class="char-name">{}</span>
-    <span class="char-class"><span class="class-icon">{}</span> {}</span>
-  </div>
-  <div class="hp-row">
-    <div class="hp-bar-container">
-      <div class="hp-bar-fill {}" style="width: {}%"></div>
-    </div>
-    <div class="hp-text">{} / {}</div>
-  </div>
-  <div class="char-stats">
-    <div class="stat"><div class="stat-value">{}</div><div class="stat-label">ATK</div></div>
-    <div class="stat"><div class="stat-value">{}</div><div class="stat-label">DEF</div></div>
-    <div class="stat"><div class="stat-value">{}</div><div class="stat-label">INT</div></div>
-    <div class="stat"><div class="stat-value">{}</div><div class="stat-label">LCK</div></div>
-  </div>
-  <div class="char-effects">{}{}</div>
-</div>"#,
+            concat!(
+                "<div class=\"character-card{}\" data-actor-id=\"{}\" data-class=\"{}\">",
+                "<div class=\"char-header\">",
+                "<span class=\"char-name\">{}</span>",
+                "<span class=\"char-class\"><span class=\"class-icon\">{}</span> {}</span>",
+                "</div>",
+                "<div class=\"hp-row\">",
+                "<div class=\"hp-bar-container\">",
+                "<div class=\"hp-bar-fill {}\" style=\"width: {}%\"></div>",
+                "</div>",
+                "<div class=\"hp-text\">{} / {}</div>",
+                "</div>",
+                "{}",
+                "<div class=\"char-stats\">",
+                "<div class=\"stat\"><div class=\"stat-value\">{}</div><div class=\"stat-label\">ATK</div></div>",
+                "<div class=\"stat\"><div class=\"stat-value\">{}</div><div class=\"stat-label\">DEF</div></div>",
+                "<div class=\"stat\"><div class=\"stat-value\">{}</div><div class=\"stat-label\">INT</div></div>",
+                "<div class=\"stat\"><div class=\"stat-value\">{}</div><div class=\"stat-label\">LCK</div></div>",
+                "</div>",
+                "{}",
+                "<div class=\"char-effects\">{}{}</div>",
+                "{}",
+                "{}",
+                "</div>",
+            ),
             dead_class,
             actor.id,
             slug,
@@ -117,12 +365,16 @@ pub fn update_character_panel_dom(
             hp_pct,
             actor.hp,
             actor.max_hp,
+            mp_row,
             actor.stats.atk,
             actor.stats.def,
             actor.stats.int,
             actor.stats.luck,
+            conditions_html,
             buffs_html,
             debuffs_html,
+            skills_section,
+            equip_section,
         ));
     }
 

--- a/viewer/src/dom/mod.rs
+++ b/viewer/src/dom/mod.rs
@@ -66,6 +66,7 @@ fn reset_trpg_dom_state(
     mut overlay_cache: ResMut<overlay::OverlayCache>,
 ) {
     character_cache.last_snapshot.clear();
+    character_cache.last_full.clear();
     turn_cache.last_turn = 0;
     turn_cache.last_phase.clear();
     runtime_cache.last_snapshot.clear();

--- a/viewer/src/game/components.rs
+++ b/viewer/src/game/components.rs
@@ -10,6 +10,35 @@ pub struct Stats {
     pub luck: i32,
 }
 
+/// A single skill with name and proficiency level (1-20).
+#[derive(Debug, Clone, Deserialize)]
+pub struct Skill {
+    pub name: String,
+    pub level: i32,
+}
+
+impl Skill {
+    /// Modifier derived from proficiency level: (level - 10) / 2, floored.
+    pub fn modifier(&self) -> i32 {
+        (self.level - 10) / 2
+    }
+}
+
+/// An active condition affecting the character (e.g. poisoned, stunned).
+#[derive(Debug, Clone, Deserialize)]
+pub struct Condition {
+    pub name: String,
+    #[serde(default)]
+    pub remaining_turns: Option<i32>,
+}
+
+/// A piece of equipped gear.
+#[derive(Debug, Clone, Deserialize)]
+pub struct Equipment {
+    pub slot: String,
+    pub name: String,
+}
+
 /// Core actor component — represents a party member or NPC on the map.
 #[derive(Component, Debug, Clone)]
 pub struct Actor {
@@ -18,12 +47,17 @@ pub struct Actor {
     pub class: String,
     pub hp: i32,
     pub max_hp: i32,
+    pub mp: i32,
+    pub max_mp: i32,
     pub stats: Stats,
     pub area: String,
     pub is_dead: bool,
     pub inventory: Vec<String>,
     pub buffs: Vec<String>,
     pub debuffs: Vec<String>,
+    pub skills: Vec<Skill>,
+    pub conditions: Vec<Condition>,
+    pub equipment: Vec<Equipment>,
 }
 
 /// Marker component for entities rendered as map tokens.

--- a/viewer/src/game/http.rs
+++ b/viewer/src/game/http.rs
@@ -7,7 +7,7 @@ use wasm_bindgen::prelude::*;
 use wasm_bindgen_futures::JsFuture;
 
 use crate::config;
-use crate::game::components::{Actor, Stats};
+use crate::game::components::{Actor, Condition, Equipment, Skill, Stats};
 use crate::game::state::{ConnectionStatus, MapState, RoomState, TurnPhase, TurnProgressState};
 
 // ─── Expected API Response Types ─────────────
@@ -44,6 +44,30 @@ fn default_int_field() -> i32 {
 }
 
 #[derive(Debug, Clone, Deserialize)]
+pub struct SkillData {
+    pub name: String,
+    #[serde(default = "default_skill_level")]
+    pub level: i32,
+}
+
+fn default_skill_level() -> i32 {
+    10
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct ConditionData {
+    pub name: String,
+    #[serde(default)]
+    pub remaining_turns: Option<i32>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct EquipmentData {
+    pub slot: String,
+    pub name: String,
+}
+
+#[derive(Debug, Clone, Deserialize)]
 pub struct CharacterData {
     pub id: String,
     pub name: String,
@@ -53,6 +77,10 @@ pub struct CharacterData {
     pub hp: i32,
     #[serde(default = "default_hp")]
     pub max_hp: i32,
+    #[serde(default)]
+    pub mp: i32,
+    #[serde(default)]
+    pub max_mp: i32,
     #[serde(default)]
     pub stats: Option<StatsData>,
     #[serde(default = "default_area")]
@@ -65,6 +93,12 @@ pub struct CharacterData {
     pub buffs: Vec<String>,
     #[serde(default)]
     pub debuffs: Vec<String>,
+    #[serde(default)]
+    pub skills: Vec<SkillData>,
+    #[serde(default)]
+    pub conditions: Vec<ConditionData>,
+    #[serde(default)]
+    pub equipment: Vec<EquipmentData>,
 }
 
 fn default_hp() -> i32 {
@@ -330,18 +364,50 @@ pub fn apply_initial_state(
                 luck: 10,
             });
 
+        let skills: Vec<Skill> = ch
+            .skills
+            .into_iter()
+            .map(|s| Skill {
+                name: s.name,
+                level: s.level,
+            })
+            .collect();
+
+        let conditions: Vec<Condition> = ch
+            .conditions
+            .into_iter()
+            .map(|c| Condition {
+                name: c.name,
+                remaining_turns: c.remaining_turns,
+            })
+            .collect();
+
+        let equipment: Vec<Equipment> = ch
+            .equipment
+            .into_iter()
+            .map(|e| Equipment {
+                slot: e.slot,
+                name: e.name,
+            })
+            .collect();
+
         commands.spawn(Actor {
             id: ch.id,
             name: ch.name,
             class: ch.class,
             hp: ch.hp,
             max_hp: ch.max_hp,
+            mp: ch.mp,
+            max_mp: ch.max_mp,
             stats,
             area: ch.area,
             is_dead: ch.is_dead,
             inventory: ch.inventory,
             buffs: ch.buffs,
             debuffs: ch.debuffs,
+            skills,
+            conditions,
+            equipment,
         });
     }
 

--- a/viewer/style.css
+++ b/viewer/style.css
@@ -1107,6 +1107,230 @@ body.mode-lobby #dashboard {
     border: 1px solid rgba(204, 68, 34, 0.25);
 }
 
+/* MP bar */
+.mp-row {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    margin-bottom: 6px;
+}
+
+.mp-bar-container {
+    flex: 1;
+    height: 8px;
+    background: var(--bg-deep);
+    border-radius: 4px;
+    overflow: hidden;
+    border: 1px solid rgba(255, 255, 255, 0.04);
+    box-shadow: inset 0 1px 3px rgba(0, 0, 0, 0.3);
+    position: relative;
+}
+
+.mp-bar-fill {
+    height: 100%;
+    transition: width 0.5s ease;
+    border-radius: 3px;
+    position: relative;
+}
+
+.mp-bar-fill::after {
+    content: "";
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    height: 40%;
+    background: linear-gradient(180deg, rgba(255,255,255,0.15), transparent);
+    border-radius: 3px 3px 0 0;
+}
+
+.mp-bar-fill.mp-full {
+    background: linear-gradient(90deg, #1a3a6b, #3366cc, #4488ee);
+    box-shadow: 0 0 6px rgba(68, 136, 238, 0.3);
+}
+
+.mp-bar-fill.mp-low {
+    background: linear-gradient(90deg, #2a2a5a, #5555aa, #7777cc);
+    box-shadow: 0 0 4px rgba(119, 119, 204, 0.2);
+}
+
+.mp-bar-fill.mp-depleted {
+    background: linear-gradient(90deg, #1a1a3a, #333366, #444488);
+    box-shadow: 0 0 4px rgba(68, 68, 136, 0.2);
+}
+
+.mp-text {
+    font-family: 'JetBrains Mono', var(--font-ui);
+    font-size: 10px;
+    color: #7799cc;
+    font-weight: 600;
+    white-space: nowrap;
+    min-width: 52px;
+    text-align: right;
+}
+
+/* Conditions row */
+.conditions-row {
+    margin-top: 4px;
+    margin-bottom: 2px;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 4px;
+}
+
+.condition-badge {
+    font-size: 9px;
+    padding: 2px 6px;
+    border-radius: 3px;
+    background: rgba(180, 60, 180, 0.15);
+    color: #cc88cc;
+    border: 1px solid rgba(180, 60, 180, 0.25);
+    white-space: nowrap;
+}
+
+.condition-turns {
+    font-size: 8px;
+    color: var(--text-dim);
+    margin-left: 2px;
+}
+
+/* Collapsible section toggle (CSS checkbox hack) */
+.section-toggle {
+    display: none;
+}
+
+.section-header {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    font-family: var(--font-ui);
+    font-size: 10px;
+    color: var(--text-dim);
+    letter-spacing: 1px;
+    text-transform: uppercase;
+    cursor: pointer;
+    padding: 4px 0 2px;
+    margin-top: 4px;
+    border-top: 1px solid rgba(255, 255, 255, 0.04);
+    user-select: none;
+    transition: color 0.15s ease;
+}
+
+.section-header::before {
+    content: "\25B6";
+    font-size: 7px;
+    transition: transform 0.2s ease;
+    display: inline-block;
+}
+
+.section-header:hover {
+    color: var(--accent-primary);
+}
+
+.section-count {
+    font-weight: 400;
+    color: var(--text-dim);
+    opacity: 0.7;
+}
+
+.section-body {
+    max-height: 0;
+    overflow: hidden;
+    transition: max-height 0.25s ease;
+}
+
+.section-toggle:checked + .section-header::before {
+    transform: rotate(90deg);
+}
+
+.section-toggle:checked + .section-header + .section-body {
+    max-height: 500px;
+}
+
+/* Skills list */
+.skills-list {
+    padding: 0 2px;
+}
+
+.skill-row {
+    display: grid;
+    grid-template-columns: 1fr 28px 32px;
+    gap: 4px;
+    padding: 2px 4px;
+    font-family: var(--font-ui);
+    font-size: 10px;
+    align-items: center;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.02);
+}
+
+.skill-row:last-child {
+    border-bottom: none;
+}
+
+.skill-name {
+    color: var(--text-primary);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.skill-level {
+    text-align: center;
+    color: var(--text-dim);
+    font-family: 'JetBrains Mono', var(--font-ui);
+}
+
+.skill-mod {
+    text-align: right;
+    font-family: 'JetBrains Mono', var(--font-ui);
+    font-weight: 700;
+    font-size: 9px;
+}
+
+.mod-positive { color: #66cc66; }
+.mod-negative { color: #cc6644; }
+.mod-neutral  { color: var(--text-dim); }
+
+/* Equipment list */
+.equip-list {
+    padding: 0 2px;
+}
+
+.equip-row {
+    display: grid;
+    grid-template-columns: 18px auto 1fr;
+    gap: 4px;
+    padding: 2px 4px;
+    font-family: var(--font-ui);
+    font-size: 10px;
+    align-items: center;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.02);
+}
+
+.equip-row:last-child {
+    border-bottom: none;
+}
+
+.equip-icon {
+    font-size: 11px;
+    line-height: 1;
+    text-align: center;
+}
+
+.equip-slot {
+    color: var(--text-dim);
+    font-size: 9px;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+}
+
+.equip-name {
+    color: var(--text-primary);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
 /* Dice entries */
 .dice-entry {
     flex-shrink: 0;


### PR DESCRIPTION
## Summary
- TRPG viewer character panel에 상세 캐릭터 정보 섹션을 추가합니다.
- MP 바, 상태이상(Conditions), 스킬 목록, 장비 목록을 새로운 접기/펼치기 가능한 섹션으로 표시합니다.

## Changes

### Data Layer (`components.rs`, `http.rs`)
- `Actor` 컴포넌트에 `mp`, `max_mp`, `skills`, `conditions`, `equipment` 필드 추가
- `Skill` (name + level + modifier 계산), `Condition` (name + remaining_turns), `Equipment` (slot + name) 구조체 추가
- `CharacterData` serde 역직렬화에 대응하는 `SkillData`, `ConditionData`, `EquipmentData` 추가
- 모든 새 필드는 `#[serde(default)]`로 하위 호환성 유지

### Character Panel (`character_panel.rs`)
- MP 바: 파란색 3단계 그라디언트 (full/low/depleted)
- 상태이상 뱃지: 맥락별 아이콘 (독, 기절, 매혹, 실명 등)
- 접기/펼치기 스킬 섹션: 이름, 숙련도(1-20), 수정치(modifier)
- 접기/펼치기 장비 섹션: 슬롯 아이콘 + 이름
- CSS checkbox hack으로 re-render 시에도 접기 상태 유지
- `ActorSnapshot` 기반 변경 감지 캐시 확장

### Styling (`style.css`)
- MP 바 스타일 (`.mp-row`, `.mp-bar-fill.mp-full/mp-low/mp-depleted`)
- 상태이상 뱃지 (`.condition-badge`, `.condition-turns`)
- 접기/펼치기 토글 (`.section-toggle`, `.section-header`, `.section-body`)
- 스킬 그리드 (`.skill-row`, `.skill-mod.mod-positive/mod-negative`)
- 장비 그리드 (`.equip-row`, `.equip-icon`, `.equip-slot`)

## Test plan
- [x] `cargo build --target wasm32-unknown-unknown` 성공 (no new warnings)
- [ ] TRPG 엔진에서 skills/conditions/equipment 데이터가 포함된 캐릭터로 시각적 검증
- [ ] 접기/펼치기 토글이 HP 변경 re-render 후에도 상태 유지 확인
- [ ] MP가 0인 캐릭터에서 MP 바가 숨겨지는지 확인