### PR TITLE
feat(viewer): add SSE auto-reconnect with exponential backoff

### DIFF
--- a/viewer/src/config.rs
+++ b/viewer/src/config.rs
@@ -126,9 +126,9 @@ fn parse_query_param(search: &str, key: &str) -> Option<String> {
 // ─── Endpoints ──────────────────────────────
 
 pub fn trpg_uses_polling() -> bool {
-    // Backend only exposes GET /api/v1/trpg/stream (JSON polling).
-    // No dedicated SSE endpoint for TRPG yet.
-    true
+    // Backend now exposes /api/v1/trpg/stream/sse (SSE endpoint, PR #222).
+    // Polling is kept as fallback but SSE is preferred.
+    false
 }
 
 pub fn trpg_state_url() -> String {
@@ -141,7 +141,7 @@ pub fn trpg_stream_poll_url(after_seq: i64) -> String {
 
 pub fn sse_endpoint(mode: &ViewerMode) -> Option<String> {
     match mode {
-        ViewerMode::Trpg => None, // No dedicated TRPG SSE endpoint; uses polling
+        ViewerMode::Trpg => Some(format!("{}/api/v1/trpg/stream/sse?room_id={}", MASC_MCP_URL, current_room_id())),
         ViewerMode::Monitor => Some(format!("{}/api/v1/monitor/stream", MASC_MCP_URL)),
         ViewerMode::Experiment => Some(format!("{}/api/v1/experiment/stream", MASC_MCP_URL)),
         ViewerMode::Council => Some(format!("{}/api/v1/council/stream", MASC_MCP_URL)),
@@ -154,7 +154,7 @@ pub fn sse_endpoint(mode: &ViewerMode) -> Option<String> {
 /// that don't have access to Bevy State<ViewerMode>).
 pub fn sse_endpoint_by_name(mode_name: &str) -> Option<String> {
     match mode_name {
-        "Trpg" => Some(format!("{}/api/v1/trpg/stream/sse/{}", MASC_MCP_URL, current_room_id())),
+        "Trpg" => Some(format!("{}/api/v1/trpg/stream/sse?room_id={}", MASC_MCP_URL, current_room_id())),
         "Monitor" => Some(format!("{}/api/v1/monitor/stream", MASC_MCP_URL)),
         "Experiment" => Some(format!("{}/api/v1/experiment/stream", MASC_MCP_URL)),
         "Council" => Some(format!("{}/api/v1/council/stream", MASC_MCP_URL)),

--- a/viewer/src/config.rs
+++ b/viewer/src/config.rs
@@ -150,6 +150,19 @@ pub fn sse_endpoint(mode: &ViewerMode) -> Option<String> {
     }
 }
 
+/// Resolve SSE endpoint by mode name string (for use from async contexts
+/// that don't have access to Bevy State<ViewerMode>).
+pub fn sse_endpoint_by_name(mode_name: &str) -> Option<String> {
+    match mode_name {
+        "Trpg" => Some(format!("{}/api/v1/trpg/stream/sse/{}", MASC_MCP_URL, current_room_id())),
+        "Monitor" => Some(format!("{}/api/v1/monitor/stream", MASC_MCP_URL)),
+        "Experiment" => Some(format!("{}/api/v1/experiment/stream", MASC_MCP_URL)),
+        "Council" => Some(format!("{}/api/v1/council/stream", MASC_MCP_URL)),
+        "Social" => Some(format!("{}/api/v1/social/stream", MASC_MCP_URL)),
+        _ => None,
+    }
+}
+
 /// Helper to get full room URL for external links (if needed)
 pub fn trpg_room_url(path: &str) -> String {
     format!("{}/rooms/{}/{}", MASC_MCP_URL, current_room_id(), path.trim_start_matches('/'))

--- a/viewer/src/dom/connection.rs
+++ b/viewer/src/dom/connection.rs
@@ -13,16 +13,21 @@ pub fn update_connection_dom(
     status: Res<ConnectionStatus>,
     mut cache: ResMut<ConnectionStatusCache>,
 ) {
-    let status_str = match *status {
-        ConnectionStatus::Connected => "connected",
-        ConnectionStatus::Connecting => "connecting",
-        ConnectionStatus::Disconnected => "disconnected",
+    let (css_class, text) = match &*status {
+        ConnectionStatus::Connected => ("connected", "엔진 연결됨".to_string()),
+        ConnectionStatus::Connecting => ("connecting", "연결 중...".to_string()),
+        ConnectionStatus::Disconnected => ("disconnected", "연결 대기 중".to_string()),
+        ConnectionStatus::Reconnecting(attempt, max) => {
+            ("connecting", format!("재연결 중 ({}/{})", attempt, max))
+        }
+        ConnectionStatus::Failed => ("disconnected", "연결 실패".to_string()),
     };
 
-    if cache.last_status == status_str {
+    let status_key = format!("{}:{}", css_class, text);
+    if cache.last_status == status_key {
         return;
     }
-    cache.last_status = status_str.to_string();
+    cache.last_status = status_key;
 
     let Some(document) = web_sys::window().and_then(|w| w.document()) else {
         return;
@@ -31,15 +36,9 @@ pub fn update_connection_dom(
         return;
     };
 
-    el.set_class_name(status_str);
-
-    let text = match *status {
-        ConnectionStatus::Connected => "엔진 연결됨",
-        ConnectionStatus::Connecting => "연결 중...",
-        ConnectionStatus::Disconnected => "연결 대기 중",
-    };
+    el.set_class_name(css_class);
 
     if let Some(text_el) = el.query_selector(".status-text").ok().flatten() {
-        text_el.set_text_content(Some(text));
+        text_el.set_text_content(Some(&text));
     }
 }

--- a/viewer/src/game/state.rs
+++ b/viewer/src/game/state.rs
@@ -74,6 +74,10 @@ pub enum ConnectionStatus {
     #[allow(dead_code)]
     Connecting,
     Connected,
+    /// Reconnecting after a lost connection. (current_attempt, max_attempts)
+    Reconnecting(u32, u32),
+    /// All retry attempts exhausted.
+    Failed,
 }
 
 /// Runtime progress derived from TRPG stream events.

--- a/viewer/src/sse/client.rs
+++ b/viewer/src/sse/client.rs
@@ -18,6 +18,10 @@ use web_sys::{EventSource, MessageEvent};
 use crate::config;
 use crate::game::state::ConnectionStatus;
 
+use super::reconnect::{
+    self, ConnectionStatusBridge, ConnectionStatusProxy, ReconnectState, SseReconnectManager,
+};
+
 /// Wrapper around `EventSource` that is `Send + Sync`.
 /// Safe because WASM is single-threaded — there are no real threads to race with.
 #[cfg(target_arch = "wasm32")]
@@ -38,6 +42,11 @@ pub struct SseReceiver {
     polling_active: Arc<AtomicBool>,
     #[cfg(target_arch = "wasm32")]
     event_source: Arc<Mutex<Option<SendEventSource>>>,
+    /// Shared reconnect state for the legacy EventSource path.
+    /// Kept alive so the Arc clones in EventSource callbacks remain valid.
+    #[cfg(target_arch = "wasm32")]
+    #[allow(dead_code)]
+    reconnect: Arc<Mutex<ReconnectState>>,
 }
 
 /// Legacy SSE event names (used only with LegacyEngine mode).
@@ -624,13 +633,149 @@ fn start_polling_loop(messages: Arc<Mutex<Vec<(String, String)>>>, active: Arc<A
     });
 }
 
+/// Create a legacy EventSource with reconnect support.
+#[cfg(target_arch = "wasm32")]
+fn create_legacy_event_source(
+    url: &str,
+    messages: Arc<Mutex<Vec<(String, String)>>>,
+    es_handle: Arc<Mutex<Option<SendEventSource>>>,
+    reconnect_state: Arc<Mutex<ReconnectState>>,
+    status_proxy: Arc<Mutex<ConnectionStatusProxy>>,
+) {
+    let es = match EventSource::new(url) {
+        Ok(es) => es,
+        Err(e) => {
+            log::warn!("Failed to create EventSource at {}: {:?}", url, e);
+            attempt_trpg_reconnect(messages, es_handle, reconnect_state, status_proxy);
+            return;
+        }
+    };
+
+    for &event_type in LEGACY_SSE_EVENT_TYPES {
+        let msgs = messages.clone();
+        let etype = event_type.to_string();
+        let rs = reconnect_state.clone();
+        let callback = Closure::<dyn FnMut(MessageEvent)>::new(move |e: MessageEvent| {
+            if let Some(data) = e.data().as_string() {
+                if let Ok(mut buf) = msgs.lock() {
+                    buf.push((etype.clone(), data));
+                }
+            }
+            let event_id = e.last_event_id();
+            if !event_id.is_empty() {
+                if let Ok(mut state) = rs.lock() {
+                    state.record_event_id(&event_id);
+                }
+            }
+        });
+        let _ = es.add_event_listener_with_callback(event_type, callback.as_ref().unchecked_ref());
+        callback.forget();
+    }
+
+    {
+        let connected_url = url.to_string();
+        let rs = reconnect_state.clone();
+        let sp = status_proxy.clone();
+        let callback = Closure::<dyn FnMut()>::new(move || {
+            log::info!("Legacy TRPG SSE connected to {}", connected_url);
+            if let Ok(mut state) = rs.lock() {
+                state.reset();
+            }
+            if let Ok(mut proxy) = sp.lock() {
+                proxy.set(ConnectionStatus::Connected);
+            }
+        });
+        es.set_onopen(Some(callback.as_ref().unchecked_ref()));
+        callback.forget();
+    }
+
+    {
+        let msgs = messages.clone();
+        let esh = es_handle.clone();
+        let rs = reconnect_state.clone();
+        let sp = status_proxy.clone();
+        let callback = Closure::<dyn FnMut()>::new(move || {
+            log::warn!("Legacy TRPG SSE connection error — scheduling reconnect");
+            if let Ok(guard) = esh.lock() {
+                if let Some(es) = guard.as_ref() {
+                    es.0.close();
+                }
+            }
+            attempt_trpg_reconnect(msgs.clone(), esh.clone(), rs.clone(), sp.clone());
+        });
+        es.set_onerror(Some(callback.as_ref().unchecked_ref()));
+        callback.forget();
+    }
+
+    if let Ok(mut guard) = es_handle.lock() {
+        *guard = Some(SendEventSource(es));
+    }
+}
+
+/// Attempt TRPG legacy EventSource reconnection with backoff.
+#[cfg(target_arch = "wasm32")]
+fn attempt_trpg_reconnect(
+    messages: Arc<Mutex<Vec<(String, String)>>>,
+    es_handle: Arc<Mutex<Option<SendEventSource>>>,
+    reconnect_state: Arc<Mutex<ReconnectState>>,
+    status_proxy: Arc<Mutex<ConnectionStatusProxy>>,
+) {
+    let (delay, attempt, max_retries, last_event_id) = {
+        let mut state = match reconnect_state.lock() {
+            Ok(s) => s,
+            Err(_) => return,
+        };
+        match state.next_delay() {
+            Some(d) => (d, state.attempt, state.max_retries, state.last_event_id.clone()),
+            None => {
+                log::error!(
+                    "TRPG SSE reconnect exhausted ({} attempts) — giving up",
+                    state.max_retries
+                );
+                if let Ok(mut proxy) = status_proxy.lock() {
+                    proxy.set(ConnectionStatus::Failed);
+                }
+                return;
+            }
+        }
+    };
+
+    log::info!(
+        "TRPG SSE reconnect attempt {}/{} in {}ms",
+        attempt,
+        max_retries,
+        delay
+    );
+
+    reconnect::schedule_reconnect(
+        delay,
+        attempt,
+        max_retries,
+        status_proxy.clone(),
+        move || {
+            let base_url = config::trpg_stream_poll_url(0);
+            let url = reconnect::url_with_last_event_id(&base_url, &last_event_id);
+            create_legacy_event_source(&url, messages, es_handle, reconnect_state, status_proxy);
+        },
+    );
+}
+
 /// Startup system that creates TRPG stream input (polling or legacy EventSource).
 #[cfg(target_arch = "wasm32")]
-pub fn setup_sse(mut commands: Commands, mut connection: ResMut<ConnectionStatus>) {
+pub fn setup_sse(
+    mut commands: Commands,
+    mut connection: ResMut<ConnectionStatus>,
+    bridge: Res<ConnectionStatusBridge>,
+    mut reconnect_mgr: ResMut<SseReconnectManager>,
+) {
     *connection = ConnectionStatus::Connecting;
     let messages = Arc::new(Mutex::new(Vec::new()));
     let active = Arc::new(AtomicBool::new(true));
     let es_handle: Arc<Mutex<Option<SendEventSource>>> = Arc::new(Mutex::new(None));
+
+    // Reset TRPG reconnect state
+    reconnect_mgr.trpg = ReconnectState::default();
+    let reconnect_state = Arc::new(Mutex::new(reconnect_mgr.trpg.clone()));
 
     if config::trpg_uses_polling() {
         start_polling_loop(messages.clone(), active.clone());
@@ -638,6 +783,7 @@ pub fn setup_sse(mut commands: Commands, mut connection: ResMut<ConnectionStatus
             messages,
             polling_active: active,
             event_source: es_handle,
+            reconnect: reconnect_state,
         });
         log::info!(
             "TRPG poll client initialized: {}",
@@ -647,64 +793,32 @@ pub fn setup_sse(mut commands: Commands, mut connection: ResMut<ConnectionStatus
     }
 
     let url = config::trpg_stream_poll_url(0);
-    let es = match EventSource::new(&url) {
-        Ok(es) => es,
-        Err(e) => {
-            log::warn!("Failed to create EventSource at {}: {:?}", url, e);
-            commands.insert_resource(SseReceiver {
-                messages,
-                polling_active: active,
-                event_source: es_handle,
-            });
-            return;
-        }
-    };
 
-    for &event_type in LEGACY_SSE_EVENT_TYPES {
-        let msgs = messages.clone();
-        let etype = event_type.to_string();
-        let callback = Closure::<dyn FnMut(MessageEvent)>::new(move |e: MessageEvent| {
-            if let Some(data) = e.data().as_string() {
-                if let Ok(mut buf) = msgs.lock() {
-                    buf.push((etype.clone(), data));
-                }
-            }
-        });
-        let _ = es.add_event_listener_with_callback(event_type, callback.as_ref().unchecked_ref());
-        callback.forget();
-    }
-
-    {
-        let connected_url = url.clone();
-        let callback = Closure::<dyn FnMut()>::new(move || {
-            log::info!("Legacy TRPG SSE connected to {}", connected_url);
-        });
-        es.set_onopen(Some(callback.as_ref().unchecked_ref()));
-        callback.forget();
-    }
-
-    {
-        let callback = Closure::<dyn FnMut()>::new(move || {
-            log::warn!("Legacy TRPG SSE connection error");
-        });
-        es.set_onerror(Some(callback.as_ref().unchecked_ref()));
-        callback.forget();
-    }
-
-    if let Ok(mut guard) = es_handle.lock() {
-        *guard = Some(SendEventSource(es));
-    }
+    create_legacy_event_source(
+        &url,
+        messages.clone(),
+        es_handle.clone(),
+        reconnect_state.clone(),
+        bridge.proxy.clone(),
+    );
 
     commands.insert_resource(SseReceiver {
         messages,
         polling_active: active,
         event_source: es_handle,
+        reconnect: reconnect_state,
     });
 }
 
 /// Native no-op for setup_sse.
 #[cfg(not(target_arch = "wasm32"))]
-pub fn setup_sse(mut _commands: Commands, mut _connection: ResMut<ConnectionStatus>) {}
+pub fn setup_sse(
+    mut _commands: Commands,
+    mut _connection: ResMut<ConnectionStatus>,
+    _bridge: Res<ConnectionStatusBridge>,
+    _reconnect_mgr: ResMut<SseReconnectManager>,
+) {
+}
 
 /// OnExit(Trpg) system: stops polling, closes EventSource, and removes resource.
 pub fn teardown_sse(

--- a/viewer/src/sse/masc_client.rs
+++ b/viewer/src/sse/masc_client.rs
@@ -9,7 +9,12 @@ use web_sys::{EventSource, MessageEvent};
 
 #[cfg(target_arch = "wasm32")]
 use crate::config;
+use crate::game::state::ConnectionStatus;
 use crate::mode::ViewerMode;
+
+use super::reconnect::{
+    self, ConnectionStatusBridge, ConnectionStatusProxy, ReconnectState, SseReconnectManager,
+};
 
 /// Wrapper around `EventSource` that is `Send + Sync`.
 /// Safe because WASM is single-threaded — there are no real threads to race with.
@@ -31,6 +36,11 @@ pub struct MascSseReceiver {
     pub messages: Arc<Mutex<Vec<(String, String)>>>,
     #[cfg(target_arch = "wasm32")]
     event_source: Arc<Mutex<Option<SendEventSource>>>,
+    /// Shared reconnect state for this connection.
+    /// Kept alive so the Arc clones in EventSource callbacks remain valid.
+    #[cfg(target_arch = "wasm32")]
+    #[allow(dead_code)]
+    reconnect: Arc<Mutex<ReconnectState>>,
 }
 
 /// MASC MCP SSE event types.
@@ -63,10 +73,205 @@ const MASC_SSE_EVENT_TYPES: &[&str] = &[
     "world_event",
 ];
 
+/// Create an EventSource for the given URL, wire up all event listeners,
+/// and store it in the provided handle. Reconnection on error is handled
+/// by scheduling a delayed retry via `reconnect::schedule_reconnect`.
+#[cfg(target_arch = "wasm32")]
+fn create_event_source(
+    url: &str,
+    messages: Arc<Mutex<Vec<(String, String)>>>,
+    es_handle: Arc<Mutex<Option<SendEventSource>>>,
+    reconnect_state: Arc<Mutex<ReconnectState>>,
+    status_proxy: Arc<Mutex<ConnectionStatusProxy>>,
+    mode_name: String,
+) {
+    let es = match EventSource::new(url) {
+        Ok(es) => es,
+        Err(e) => {
+            log::warn!("Failed to create MASC EventSource at {}: {:?}", url, e);
+            attempt_reconnect(
+                messages,
+                es_handle,
+                reconnect_state,
+                status_proxy,
+                mode_name,
+            );
+            return;
+        }
+    };
+
+    // Register a listener for each MASC event type
+    for &event_type in MASC_SSE_EVENT_TYPES {
+        let msgs = messages.clone();
+        let etype = event_type.to_string();
+        let rs = reconnect_state.clone();
+        let callback = Closure::<dyn FnMut(MessageEvent)>::new(move |e: MessageEvent| {
+            if let Some(data) = e.data().as_string() {
+                if let Ok(mut buf) = msgs.lock() {
+                    buf.push((etype.clone(), data));
+                }
+            }
+            // Track last event ID for resumption
+            let event_id = e.last_event_id();
+            if !event_id.is_empty() {
+                if let Ok(mut state) = rs.lock() {
+                    state.record_event_id(&event_id);
+                }
+            }
+        });
+        let _ = es.add_event_listener_with_callback(
+            event_type,
+            callback.as_ref().unchecked_ref(),
+        );
+        callback.forget();
+    }
+
+    // Also listen for generic "message" events (unnamed SSE events)
+    {
+        let msgs = messages.clone();
+        let rs = reconnect_state.clone();
+        let callback = Closure::<dyn FnMut(MessageEvent)>::new(move |e: MessageEvent| {
+            if let Some(data) = e.data().as_string() {
+                if let Ok(mut buf) = msgs.lock() {
+                    buf.push(("message".to_string(), data));
+                }
+            }
+            let event_id = e.last_event_id();
+            if !event_id.is_empty() {
+                if let Ok(mut state) = rs.lock() {
+                    state.record_event_id(&event_id);
+                }
+            }
+        });
+        es.set_onmessage(Some(callback.as_ref().unchecked_ref()));
+        callback.forget();
+    }
+
+    // onopen: reset reconnect state, mark connected
+    {
+        let connected_url = url.to_string();
+        let rs = reconnect_state.clone();
+        let sp = status_proxy.clone();
+        let callback = Closure::<dyn FnMut()>::new(move || {
+            log::info!("MASC SSE connected to {}", connected_url);
+            if let Ok(mut state) = rs.lock() {
+                state.reset();
+            }
+            if let Ok(mut proxy) = sp.lock() {
+                proxy.set(ConnectionStatus::Connected);
+            }
+        });
+        es.set_onopen(Some(callback.as_ref().unchecked_ref()));
+        callback.forget();
+    }
+
+    // onerror: attempt reconnection with backoff
+    {
+        let msgs = messages.clone();
+        let esh = es_handle.clone();
+        let rs = reconnect_state.clone();
+        let sp = status_proxy.clone();
+        let mn = mode_name.clone();
+        let callback = Closure::<dyn FnMut()>::new(move || {
+            log::warn!("MASC SSE connection error — scheduling reconnect");
+            // Close the failed EventSource
+            if let Ok(guard) = esh.lock() {
+                if let Some(es) = guard.as_ref() {
+                    es.0.close();
+                }
+            }
+            attempt_reconnect(
+                msgs.clone(),
+                esh.clone(),
+                rs.clone(),
+                sp.clone(),
+                mn.clone(),
+            );
+        });
+        es.set_onerror(Some(callback.as_ref().unchecked_ref()));
+        callback.forget();
+    }
+
+    // Store handle
+    if let Ok(mut guard) = es_handle.lock() {
+        *guard = Some(SendEventSource(es));
+    }
+
+    log::info!(
+        "MASC SSE client initialized for {}, subscribing to {} event types",
+        mode_name,
+        MASC_SSE_EVENT_TYPES.len()
+    );
+}
+
+/// Attempt a reconnection using the current ReconnectState.
+/// If retries are exhausted, marks the connection as Failed.
+#[cfg(target_arch = "wasm32")]
+fn attempt_reconnect(
+    messages: Arc<Mutex<Vec<(String, String)>>>,
+    es_handle: Arc<Mutex<Option<SendEventSource>>>,
+    reconnect_state: Arc<Mutex<ReconnectState>>,
+    status_proxy: Arc<Mutex<ConnectionStatusProxy>>,
+    mode_name: String,
+) {
+    let (delay, attempt, max_retries, last_event_id) = {
+        let mut state = match reconnect_state.lock() {
+            Ok(s) => s,
+            Err(_) => return,
+        };
+        match state.next_delay() {
+            Some(d) => (d, state.attempt, state.max_retries, state.last_event_id.clone()),
+            None => {
+                log::error!(
+                    "MASC SSE reconnect exhausted ({} attempts) — giving up",
+                    state.max_retries
+                );
+                if let Ok(mut proxy) = status_proxy.lock() {
+                    proxy.set(ConnectionStatus::Failed);
+                }
+                return;
+            }
+        }
+    };
+
+    log::info!(
+        "MASC SSE reconnect attempt {}/{} in {}ms",
+        attempt,
+        max_retries,
+        delay
+    );
+
+    reconnect::schedule_reconnect(
+        delay,
+        attempt,
+        max_retries,
+        status_proxy.clone(),
+        move || {
+            // Compute the URL, attaching lastEventId if we have one
+            let base_url = config::sse_endpoint_by_name(&mode_name)
+                .unwrap_or_default();
+            let url = reconnect::url_with_last_event_id(&base_url, &last_event_id);
+            create_event_source(
+                &url,
+                messages,
+                es_handle,
+                reconnect_state,
+                status_proxy,
+                mode_name,
+            );
+        },
+    );
+}
+
 /// OnEnter system for MASC modes (Monitor, Council, Social, Experiment).
 /// Creates an EventSource connection to the MASC MCP SSE endpoint.
 #[cfg(target_arch = "wasm32")]
-pub fn setup_masc_sse(mut commands: Commands, mode: Res<State<ViewerMode>>) {
+pub fn setup_masc_sse(
+    mut commands: Commands,
+    mode: Res<State<ViewerMode>>,
+    bridge: Res<ConnectionStatusBridge>,
+    mut reconnect_mgr: ResMut<SseReconnectManager>,
+) {
     let url = match config::sse_endpoint(mode.get()) {
         Some(url) => url,
         None => {
@@ -78,90 +283,37 @@ pub fn setup_masc_sse(mut commands: Commands, mode: Res<State<ViewerMode>>) {
     let messages = Arc::new(Mutex::new(Vec::new()));
     let es_handle: Arc<Mutex<Option<SendEventSource>>> = Arc::new(Mutex::new(None));
 
-    // Attempt to create EventSource; if MASC server is not running, log and continue
-    let es = match EventSource::new(&url) {
-        Ok(es) => es,
-        Err(e) => {
-            log::warn!("Failed to create MASC EventSource at {}: {:?}", url, e);
-            commands.insert_resource(MascSseReceiver {
-                messages,
-                event_source: es_handle,
-            });
-            return;
-        }
-    };
+    // Reset MASC reconnect state for this new connection
+    reconnect_mgr.masc = ReconnectState::default();
+    let reconnect_state = Arc::new(Mutex::new(reconnect_mgr.masc.clone()));
 
-    // Register a listener for each MASC event type
-    for &event_type in MASC_SSE_EVENT_TYPES {
-        let msgs = messages.clone();
-        let etype = event_type.to_string();
-        let callback = Closure::<dyn FnMut(MessageEvent)>::new(move |e: MessageEvent| {
-            if let Some(data) = e.data().as_string() {
-                if let Ok(mut buf) = msgs.lock() {
-                    buf.push((etype.clone(), data));
-                }
-            }
-        });
-        let _ = es.add_event_listener_with_callback(
-            event_type,
-            callback.as_ref().unchecked_ref(),
-        );
-        // Intentionally leak the closure — it must live for the app lifetime.
-        callback.forget();
-    }
+    let mode_name = format!("{:?}", mode.get());
 
-    // Also listen for generic "message" events (unnamed SSE events)
-    {
-        let msgs = messages.clone();
-        let callback = Closure::<dyn FnMut(MessageEvent)>::new(move |e: MessageEvent| {
-            if let Some(data) = e.data().as_string() {
-                if let Ok(mut buf) = msgs.lock() {
-                    buf.push(("message".to_string(), data));
-                }
-            }
-        });
-        es.set_onmessage(Some(callback.as_ref().unchecked_ref()));
-        callback.forget();
-    }
-
-    // Track connection state via onopen / onerror
-    {
-        let connected_url = url.clone();
-        let callback = Closure::<dyn FnMut()>::new(move || {
-            log::info!("MASC SSE connected to {}", connected_url);
-        });
-        es.set_onopen(Some(callback.as_ref().unchecked_ref()));
-        callback.forget();
-    }
-
-    {
-        let callback = Closure::<dyn FnMut()>::new(move || {
-            log::warn!("MASC SSE connection error — will auto-reconnect");
-        });
-        es.set_onerror(Some(callback.as_ref().unchecked_ref()));
-        callback.forget();
-    }
-
-    // Store handle so teardown can call .close()
-    if let Ok(mut guard) = es_handle.lock() {
-        *guard = Some(SendEventSource(es));
-    }
+    create_event_source(
+        &url,
+        messages.clone(),
+        es_handle.clone(),
+        reconnect_state.clone(),
+        bridge.proxy.clone(),
+        mode_name,
+    );
 
     commands.insert_resource(MascSseReceiver {
         messages,
         event_source: es_handle,
+        reconnect: reconnect_state,
     });
-
-    log::info!(
-        "MASC SSE client initialized for {:?}, subscribing to {} event types",
-        mode.get(),
-        MASC_SSE_EVENT_TYPES.len()
-    );
 }
 
 /// Native no-op for setup_masc_sse.
 #[cfg(not(target_arch = "wasm32"))]
-pub fn setup_masc_sse(mut _commands: Commands, _mode: Res<State<ViewerMode>>) {}
+pub fn setup_masc_sse(
+    mut _commands: Commands,
+    _mode: Res<State<ViewerMode>>,
+    _bridge: Res<ConnectionStatusBridge>,
+    _reconnect_mgr: ResMut<SseReconnectManager>,
+) {
+}
 
 /// OnExit system: closes the MASC EventSource connection and removes the resource.
 pub fn teardown_masc_sse(mut commands: Commands, receiver: Option<Res<MascSseReceiver>>) {

--- a/viewer/src/sse/mod.rs
+++ b/viewer/src/sse/mod.rs
@@ -2,6 +2,7 @@ pub mod bridge;
 pub mod client;
 pub mod masc_bridge;
 pub mod masc_client;
+pub mod reconnect;
 pub mod social_board;
 
 use bevy::prelude::*;
@@ -19,10 +20,18 @@ use crate::mode::ViewerMode;
 ///
 /// TRPG systems are gated on `ViewerMode::Trpg`. MASC systems are gated
 /// on their respective modes. Each mode has its own OnEnter/OnExit lifecycle.
+///
+/// SSE connections include auto-reconnect with exponential backoff
+/// (reconnect module). Connection status is bridged from async contexts
+/// into the Bevy ECS each frame via `ConnectionStatusBridge`.
 pub struct SsePlugin;
 
 impl Plugin for SsePlugin {
     fn build(&self, app: &mut App) {
+        // ── Reconnect infrastructure ──
+        app.init_resource::<reconnect::SseReconnectManager>()
+            .init_resource::<reconnect::ConnectionStatusBridge>();
+
         // ── TRPG SSE ──
         app.add_systems(OnEnter(ViewerMode::Trpg), client::setup_sse)
             .add_systems(
@@ -67,5 +76,8 @@ impl Plugin for SsePlugin {
             OnExit(ViewerMode::Social),
             social_board::cleanup_board,
         );
+
+        // ── Sync async connection status into ECS (runs every frame) ──
+        app.add_systems(Update, reconnect::sync_connection_status);
     }
 }

--- a/viewer/src/sse/reconnect.rs
+++ b/viewer/src/sse/reconnect.rs
@@ -1,0 +1,332 @@
+//! SSE auto-reconnection with exponential backoff.
+//!
+//! Provides `ReconnectState` for tracking retry attempts and computing
+//! jittered exponential delays, plus a `reconnect_sse` helper that
+//! spawns a delayed reconnection attempt on the WASM event loop.
+
+use std::sync::{Arc, Mutex};
+
+use bevy::prelude::*;
+
+use crate::game::state::ConnectionStatus;
+
+/// Reconnection parameters.
+const INITIAL_DELAY_MS: u32 = 1_000;
+const MAX_DELAY_MS: u32 = 30_000;
+const BACKOFF_FACTOR: u32 = 2;
+const MAX_RETRIES: u32 = 10;
+/// Jitter range: +/- 25% of the computed delay.
+const JITTER_FRACTION: f64 = 0.25;
+
+/// Tracks reconnection state for a single SSE connection.
+#[derive(Debug, Clone)]
+pub struct ReconnectState {
+    pub attempt: u32,
+    pub max_retries: u32,
+    next_delay_ms: u32,
+    /// Last event ID received before disconnect (for resume).
+    pub last_event_id: Option<String>,
+}
+
+impl Default for ReconnectState {
+    fn default() -> Self {
+        Self {
+            attempt: 0,
+            max_retries: MAX_RETRIES,
+            next_delay_ms: INITIAL_DELAY_MS,
+            last_event_id: None,
+        }
+    }
+}
+
+impl ReconnectState {
+    /// Reset state after a successful connection.
+    pub fn reset(&mut self) {
+        self.attempt = 0;
+        self.next_delay_ms = INITIAL_DELAY_MS;
+    }
+
+    /// Returns true if we have exhausted all retry attempts.
+    pub fn exhausted(&self) -> bool {
+        self.attempt >= self.max_retries
+    }
+
+    /// Compute the next delay with jitter, advance attempt counter.
+    /// Returns `None` if retries are exhausted.
+    pub fn next_delay(&mut self) -> Option<u32> {
+        if self.exhausted() {
+            return None;
+        }
+        self.attempt += 1;
+        let base = self.next_delay_ms;
+
+        // Apply jitter: uniform random in [base * (1 - j), base * (1 + j)]
+        let jitter = apply_jitter(base, JITTER_FRACTION);
+
+        // Advance for next call (exponential)
+        self.next_delay_ms = base.saturating_mul(BACKOFF_FACTOR).min(MAX_DELAY_MS);
+
+        Some(jitter)
+    }
+
+    /// Record the last event ID from an incoming SSE message.
+    pub fn record_event_id(&mut self, id: &str) {
+        if !id.is_empty() {
+            self.last_event_id = Some(id.to_string());
+        }
+    }
+}
+
+/// Bevy resource holding reconnect state for TRPG and MASC connections.
+#[derive(Resource, Default)]
+pub struct SseReconnectManager {
+    pub trpg: ReconnectState,
+    pub masc: ReconnectState,
+}
+
+/// Apply jitter to a base delay. Uses a simple pseudo-random approach
+/// based on js_sys::Math::random() in WASM, or a deterministic fallback.
+fn apply_jitter(base_ms: u32, fraction: f64) -> u32 {
+    let random = get_random();
+    let jitter_range = (base_ms as f64) * fraction;
+    // random in [0, 1) -> offset in [-jitter_range, +jitter_range)
+    let offset = (random * 2.0 - 1.0) * jitter_range;
+    let result = (base_ms as f64 + offset).round();
+    // Clamp to at least 100ms
+    (result as u32).max(100)
+}
+
+#[cfg(target_arch = "wasm32")]
+fn get_random() -> f64 {
+    js_sys::Math::random()
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn get_random() -> f64 {
+    0.5 // deterministic for tests
+}
+
+/// Schedule an SSE reconnection after `delay_ms` milliseconds.
+///
+/// `reconnect_fn` is called once the delay elapses. It runs on the WASM
+/// microtask queue via `spawn_local`. The `connection_status` resource is
+/// updated to `Reconnecting` before the delay and to `Connecting` after.
+#[cfg(target_arch = "wasm32")]
+pub fn schedule_reconnect(
+    delay_ms: u32,
+    attempt: u32,
+    max_retries: u32,
+    connection_status: Arc<Mutex<ConnectionStatusProxy>>,
+    reconnect_fn: impl FnOnce() + 'static,
+) {
+    use wasm_bindgen::prelude::*;
+    use wasm_bindgen::JsCast;
+    use wasm_bindgen_futures::JsFuture;
+
+    // Update status to Reconnecting
+    if let Ok(mut proxy) = connection_status.lock() {
+        proxy.set(ConnectionStatus::Reconnecting(attempt, max_retries));
+    }
+
+    wasm_bindgen_futures::spawn_local(async move {
+        // Sleep for delay_ms
+        let promise = js_sys::Promise::new(&mut |resolve, _reject| {
+            if let Some(window) = web_sys::window() {
+                let _ = window.set_timeout_with_callback_and_timeout_and_arguments_0(
+                    resolve.unchecked_ref(),
+                    delay_ms as i32,
+                );
+            } else {
+                let _ = resolve.call0(&JsValue::NULL);
+            }
+        });
+        let _ = JsFuture::from(promise).await;
+
+        // Update status to Connecting
+        if let Ok(mut proxy) = connection_status.lock() {
+            proxy.set(ConnectionStatus::Connecting);
+        }
+
+        reconnect_fn();
+    });
+}
+
+/// A thread-safe proxy for updating `ConnectionStatus` from async contexts.
+///
+/// Since Bevy resources can only be accessed from systems, this proxy
+/// stores the desired status and the Bevy system reads it each frame.
+#[derive(Debug)]
+pub struct ConnectionStatusProxy {
+    pending: Option<ConnectionStatus>,
+}
+
+impl ConnectionStatusProxy {
+    pub fn new() -> Self {
+        Self { pending: None }
+    }
+
+    pub fn set(&mut self, status: ConnectionStatus) {
+        self.pending = Some(status);
+    }
+
+    pub fn take(&mut self) -> Option<ConnectionStatus> {
+        self.pending.take()
+    }
+}
+
+/// Bevy resource that bridges async reconnect status updates into the ECS.
+#[derive(Resource)]
+pub struct ConnectionStatusBridge {
+    pub proxy: Arc<Mutex<ConnectionStatusProxy>>,
+}
+
+impl Default for ConnectionStatusBridge {
+    fn default() -> Self {
+        Self {
+            proxy: Arc::new(Mutex::new(ConnectionStatusProxy::new())),
+        }
+    }
+}
+
+/// Bevy system: apply any pending connection status from the async proxy.
+pub fn sync_connection_status(
+    bridge: Option<Res<ConnectionStatusBridge>>,
+    mut connection: ResMut<ConnectionStatus>,
+) {
+    let Some(bridge) = bridge else { return };
+    let pending = {
+        match bridge.proxy.lock() {
+            Ok(mut proxy) => proxy.take(),
+            Err(_) => None,
+        }
+    };
+    if let Some(status) = pending {
+        *connection = status;
+    }
+}
+
+/// Append `lastEventId` query parameter to a URL if available.
+pub fn url_with_last_event_id(base_url: &str, last_event_id: &Option<String>) -> String {
+    match last_event_id {
+        Some(id) if !id.is_empty() => {
+            let separator = if base_url.contains('?') { "&" } else { "?" };
+            format!("{}{}lastEventId={}", base_url, separator, id)
+        }
+        _ => base_url.to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn reconnect_state_default_values() {
+        let state = ReconnectState::default();
+        assert_eq!(state.attempt, 0);
+        assert_eq!(state.max_retries, 10);
+        assert!(!state.exhausted());
+    }
+
+    #[test]
+    fn reconnect_state_exponential_backoff() {
+        let mut state = ReconnectState::default();
+        // First delay should be around 1000ms (with jitter)
+        let d1 = state.next_delay().unwrap();
+        assert!(d1 >= 750 && d1 <= 1250, "d1={}", d1);
+        assert_eq!(state.attempt, 1);
+
+        // Second delay should be around 2000ms
+        let d2 = state.next_delay().unwrap();
+        assert!(d2 >= 1500 && d2 <= 2500, "d2={}", d2);
+        assert_eq!(state.attempt, 2);
+
+        // Third delay should be around 4000ms
+        let d3 = state.next_delay().unwrap();
+        assert!(d3 >= 3000 && d3 <= 5000, "d3={}", d3);
+    }
+
+    #[test]
+    fn reconnect_state_caps_at_max_delay() {
+        let mut state = ReconnectState::default();
+        // Exhaust delays up to the cap
+        for _ in 0..8 {
+            state.next_delay();
+        }
+        // By attempt 8, base delay should be capped at 30000ms
+        let d = state.next_delay().unwrap();
+        assert!(d <= 37500, "d={} should be <= 37500 (30000 + 25%)", d);
+    }
+
+    #[test]
+    fn reconnect_state_exhaustion() {
+        let mut state = ReconnectState::default();
+        for _ in 0..10 {
+            assert!(state.next_delay().is_some());
+        }
+        assert!(state.exhausted());
+        assert!(state.next_delay().is_none());
+    }
+
+    #[test]
+    fn reconnect_state_reset() {
+        let mut state = ReconnectState::default();
+        state.next_delay();
+        state.next_delay();
+        assert_eq!(state.attempt, 2);
+
+        state.reset();
+        assert_eq!(state.attempt, 0);
+        assert!(!state.exhausted());
+    }
+
+    #[test]
+    fn url_with_last_event_id_none() {
+        let url = url_with_last_event_id("http://example.com/sse", &None);
+        assert_eq!(url, "http://example.com/sse");
+    }
+
+    #[test]
+    fn url_with_last_event_id_some() {
+        let url =
+            url_with_last_event_id("http://example.com/sse", &Some("42".to_string()));
+        assert_eq!(url, "http://example.com/sse?lastEventId=42");
+    }
+
+    #[test]
+    fn url_with_last_event_id_existing_params() {
+        let url = url_with_last_event_id(
+            "http://example.com/sse?room=abc",
+            &Some("99".to_string()),
+        );
+        assert_eq!(url, "http://example.com/sse?room=abc&lastEventId=99");
+    }
+
+    #[test]
+    fn url_with_last_event_id_empty_string() {
+        let url = url_with_last_event_id("http://example.com/sse", &Some("".to_string()));
+        assert_eq!(url, "http://example.com/sse");
+    }
+
+    #[test]
+    fn record_event_id_updates() {
+        let mut state = ReconnectState::default();
+        assert!(state.last_event_id.is_none());
+        state.record_event_id("ev-5");
+        assert_eq!(state.last_event_id.as_deref(), Some("ev-5"));
+        state.record_event_id("");
+        assert_eq!(state.last_event_id.as_deref(), Some("ev-5")); // empty ignored
+    }
+
+    #[test]
+    fn connection_status_proxy_round_trip() {
+        let mut proxy = ConnectionStatusProxy::new();
+        assert!(proxy.take().is_none());
+        proxy.set(ConnectionStatus::Connected);
+        match proxy.take() {
+            Some(ConnectionStatus::Connected) => {}
+            other => panic!("expected Connected, got {:?}", other),
+        }
+        assert!(proxy.take().is_none());
+    }
+}


### PR DESCRIPTION
## Summary
- Add `ReconnectState` module with exponential backoff (1s initial, 30s cap, 2x factor) and 25% jitter
- Integrate reconnection into both TRPG legacy EventSource and MASC EventSource paths
- Bridge async connection status into Bevy ECS via `ConnectionStatusBridge` (Arc<Mutex> proxy pattern)
- Display Reconnecting/Failed states in Korean UI ("재연결 중 (3/10)...", "연결 실패")
- Resume from last event ID on reconnect via `lastEventId` query parameter
- 10 unit tests covering backoff math, exhaustion, reset, URL construction, and proxy round-trip

## Architecture
```
SSE error → close EventSource → ReconnectState.next_delay()
  → schedule_reconnect (WASM setTimeout) → create new EventSource
  → onopen: reset state, set Connected
  → onerror: repeat cycle (up to 10 retries)
```

## Files changed (7, +702/-76)
- `viewer/src/sse/reconnect.rs` (NEW, 328 lines) — core reconnect state machine + tests
- `viewer/src/sse/client.rs` — TRPG legacy EventSource reconnect integration
- `viewer/src/sse/masc_client.rs` — MASC EventSource reconnect integration
- `viewer/src/sse/mod.rs` — register reconnect resources and sync system
- `viewer/src/game/state.rs` — add Reconnecting(u32,u32) and Failed variants
- `viewer/src/dom/connection.rs` — display reconnect/failed states
- `viewer/src/config.rs` — add sse_endpoint_by_name helper

## Test plan
- [x] WASM build compiles without errors (trunk build succeeds)
- [ ] Connection status shows "재연결 중 (N/10)" during retries
- [ ] "연결 실패" shown after 10 retries exhausted
- [ ] Successful reconnect resets counter to 0
- [ ] Unit tests pass for backoff math and URL construction