### PR TITLE
feat(viewer): Phase 2 — expand SSE event coverage + character rendering fixes

### DIFF
--- a/viewer/src/game/events.rs
+++ b/viewer/src/game/events.rs
@@ -152,3 +152,137 @@ pub struct MoodChanged(pub MoodChangePayload);
 
 #[derive(Message, Debug, Clone)]
 pub struct TurnProgressUpdated(pub TurnProgressPayload);
+
+// ─── Phase 1: High-Frequency Events ─────────
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct PartySelectedPayload {
+    pub room_id: String,
+    #[serde(default)]
+    pub selected_player_ids: Vec<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct RoomCreatedPayload {
+    pub room_id: String,
+    #[serde(default)]
+    pub preset: String,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct RoomLifecyclePayload {
+    pub room_id: String,
+    #[serde(default)]
+    pub status: String,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct SessionStartedPayload {
+    pub room_id: String,
+    #[serde(default)]
+    pub session_id: String,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct KeeperUnavailablePayload {
+    pub keeper: String,
+    #[serde(default)]
+    pub reason: String,
+}
+
+#[derive(Message, Debug, Clone)]
+pub struct PartySelected(pub PartySelectedPayload);
+
+#[derive(Message, Debug, Clone)]
+pub struct RoomCreated(pub RoomCreatedPayload);
+
+#[derive(Message, Debug, Clone)]
+pub struct RoomStarted(pub RoomLifecyclePayload);
+
+#[derive(Message, Debug, Clone)]
+pub struct SessionStarted(pub SessionStartedPayload);
+
+#[derive(Message, Debug, Clone)]
+pub struct PhaseChanged(pub TurnAdvancePayload);
+
+#[derive(Message, Debug, Clone)]
+pub struct TurnStarted(pub TurnAdvancePayload);
+
+#[derive(Message, Debug, Clone)]
+pub struct KeeperUnavailable(pub KeeperUnavailablePayload);
+
+// ─── Phase 2: Intervention + Actor Events ────
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct InterventionPayload {
+    pub intervention_type: String,
+    #[serde(default)]
+    pub target: String,
+    #[serde(default)]
+    pub description: String,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct ActorLifecyclePayload {
+    pub actor_id: String,
+    #[serde(default)]
+    pub name: String,
+    #[serde(default)]
+    pub class: String,
+    #[serde(default)]
+    pub keeper: String,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct RoomEndedPayload {
+    pub room_id: String,
+    #[serde(default)]
+    pub reason: String,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct TurnActionResolvedPayload {
+    #[serde(default)]
+    pub turn: u32,
+    pub actor_id: String,
+    pub action: String,
+    pub result: String,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct SceneTransitionPayload {
+    pub from_scene: String,
+    pub to_scene: String,
+    #[serde(default)]
+    pub description: String,
+}
+
+#[derive(Message, Debug, Clone)]
+pub struct InterventionSubmitted(pub InterventionPayload);
+
+#[derive(Message, Debug, Clone)]
+pub struct InterventionApplied(pub InterventionPayload);
+
+#[derive(Message, Debug, Clone)]
+pub struct ActorSpawned(pub ActorLifecyclePayload);
+
+#[derive(Message, Debug, Clone)]
+pub struct ActorDeleted(pub ActorLifecyclePayload);
+
+#[derive(Message, Debug, Clone)]
+pub struct ActorClaimed(pub ActorLifecyclePayload);
+
+#[derive(Message, Debug, Clone)]
+pub struct ActorReleased(pub ActorLifecyclePayload);
+
+#[derive(Message, Debug, Clone)]
+pub struct ActorUpdated(pub ActorLifecyclePayload);
+
+#[derive(Message, Debug, Clone)]
+pub struct RoomEnded(pub RoomEndedPayload);
+
+#[derive(Message, Debug, Clone)]
+pub struct TurnActionResolved(pub TurnActionResolvedPayload);
+
+#[derive(Message, Debug, Clone)]
+pub struct SceneTransitioned(pub SceneTransitionPayload);

--- a/viewer/src/game/http.rs
+++ b/viewer/src/game/http.rs
@@ -592,12 +592,17 @@ fn parse_party_characters(state: &Value) -> Vec<CharacterData> {
                 class,
                 hp,
                 max_hp,
+                mp: 0,
+                max_mp: 0,
                 stats,
                 area,
                 is_dead,
                 inventory,
                 buffs,
                 debuffs,
+                skills: vec![],
+                conditions: vec![],
+                equipment: vec![],
             }
         })
         .collect()

--- a/viewer/src/game/mod.rs
+++ b/viewer/src/game/mod.rs
@@ -42,6 +42,25 @@ impl Plugin for GameStatePlugin {
             .add_message::<WeatherChanged>()
             .add_message::<MoodChanged>()
             .add_message::<TurnProgressUpdated>()
+            // Phase 1: High-frequency events
+            .add_message::<PartySelected>()
+            .add_message::<RoomCreated>()
+            .add_message::<RoomStarted>()
+            .add_message::<SessionStarted>()
+            .add_message::<PhaseChanged>()
+            .add_message::<TurnStarted>()
+            .add_message::<KeeperUnavailable>()
+            // Phase 2: Intervention + Actor events
+            .add_message::<InterventionSubmitted>()
+            .add_message::<InterventionApplied>()
+            .add_message::<ActorSpawned>()
+            .add_message::<ActorDeleted>()
+            .add_message::<ActorClaimed>()
+            .add_message::<ActorReleased>()
+            .add_message::<ActorUpdated>()
+            .add_message::<RoomEnded>()
+            .add_message::<TurnActionResolved>()
+            .add_message::<SceneTransitioned>()
             // ── TRPG-gated systems ──
             .add_systems(
                 OnEnter(ViewerMode::Trpg),

--- a/viewer/src/render/characters.rs
+++ b/viewer/src/render/characters.rs
@@ -2,7 +2,7 @@ use bevy::prelude::*;
 
 use crate::assets;
 use crate::game::components::*;
-use super::map::area_to_position;
+use super::map::{area_to_position, position_to_area};
 
 /// Marker component for entities that can be dragged by the player.
 #[derive(Component)]
@@ -133,15 +133,14 @@ pub fn update_hp_bars(
 pub fn handle_drag_start(
     mut drag_state: ResMut<DragState>,
     windows: Query<&Window>,
+    camera_query: Query<(&Camera, &GlobalTransform), With<GameCamera>>,
     mut query: Query<(Entity, &Transform), (With<Draggable>, Without<ChildOf>)>,
     mouse_button_input: Res<ButtonInput<MouseButton>>,
 ) {
-    // Only start drag on left mouse button press
     if !mouse_button_input.just_pressed(MouseButton::Left) {
         return;
     }
 
-    // Check if cursor is over any draggable entity
     let Ok(window) = windows.single() else {
         return;
     };
@@ -149,19 +148,22 @@ pub fn handle_drag_start(
         return;
     };
 
-    // Convert cursor position to world space
-    // TODO: Proper camera projection - for now use simple mapping
-    // This is a simplified approach; proper implementation needs camera query
+    // Project screen cursor to world space via the game camera
+    let Ok((camera, camera_transform)) = camera_query.single() else {
+        return;
+    };
+    let Ok(world_pos) = camera.viewport_to_world_2d(camera_transform, cursor_pos) else {
+        return;
+    };
 
     for (entity, transform) in &mut query {
         let entity_pos = Vec2::new(transform.translation.x, transform.translation.y);
         let size = 32.0; // Approximate token size
 
-        // Simple hit test
-        let diff = cursor_pos - entity_pos;
+        let diff = world_pos - entity_pos;
         if diff.x.abs() < size && diff.y.abs() < size {
             drag_state.dragged_entity = Some(entity);
-            drag_state.drag_offset = entity_pos - cursor_pos;
+            drag_state.drag_offset = entity_pos - world_pos;
             log::info!("Drag started: entity {:?}", entity);
             break;
         }
@@ -172,6 +174,7 @@ pub fn handle_drag_start(
 pub fn handle_drag(
     mut drag_state: ResMut<DragState>,
     windows: Query<&Window>,
+    camera_query: Query<(&Camera, &GlobalTransform), With<GameCamera>>,
     mut query: Query<&mut Transform, With<Draggable>>,
     mouse_button_input: Res<ButtonInput<MouseButton>>,
 ) {
@@ -179,7 +182,6 @@ pub fn handle_drag(
         return;
     };
 
-    // Cancel drag if mouse released
     if !mouse_button_input.pressed(MouseButton::Left) {
         drag_state.dragged_entity = None;
         return;
@@ -197,8 +199,14 @@ pub fn handle_drag(
         return;
     };
 
-    // Update position with offset
-    let new_pos = cursor_pos + drag_state.drag_offset;
+    let Ok((camera, camera_transform)) = camera_query.single() else {
+        return;
+    };
+    let Ok(world_pos) = camera.viewport_to_world_2d(camera_transform, cursor_pos) else {
+        return;
+    };
+
+    let new_pos = world_pos + drag_state.drag_offset;
     transform.translation.x = new_pos.x;
     transform.translation.y = new_pos.y;
 }
@@ -210,7 +218,6 @@ pub fn handle_drag_end(
     mouse_button_input: Res<ButtonInput<MouseButton>>,
     map_query: Query<&Transform, (With<MapToken>, With<Draggable>)>,
 ) {
-    // Check if mouse was just released
     if !mouse_button_input.just_released(MouseButton::Left) {
         return;
     }
@@ -219,7 +226,6 @@ pub fn handle_drag_end(
         return;
     };
 
-    // Get final position
     let Ok(transform) = map_query.get(entity) else {
         drag_state.dragged_entity = None;
         return;
@@ -227,14 +233,9 @@ pub fn handle_drag_end(
 
     let final_pos = Vec2::new(transform.translation.x, transform.translation.y);
 
-    // Convert position to area (simple grid-based approach)
-    // TODO: Implement proper reverse mapping from position to area
-    let grid_x = (final_pos.x / 64.0).floor() as i32;
-    let grid_y = (final_pos.y / 64.0).floor() as i32;
-
-    // Update actor's area
+    // Snap to nearest named area using the same coordinate system as area_to_position
     if let Ok(mut actor) = actors.get_mut(entity) {
-        actor.area = format!("{}_{}", grid_x, grid_y);
+        actor.area = position_to_area(final_pos);
         log::info!("Drag ended: entity {:?} moved to area {}", entity, actor.area);
     }
 

--- a/viewer/src/render/map.rs
+++ b/viewer/src/render/map.rs
@@ -5,18 +5,40 @@ use crate::game::components::{GameCamera, MapBackground};
 use crate::game::state::MapState;
 use crate::theme::ViewerTheme;
 
+/// All named area labels and their world positions.
+const AREA_POSITIONS: &[(&str, Vec2)] = &[
+    ("A", Vec2::new(-300.0, 150.0)),
+    ("B", Vec2::new(-100.0, 150.0)),
+    ("C", Vec2::new(100.0, 0.0)),
+    ("D", Vec2::new(-200.0, -100.0)),
+    ("E", Vec2::new(0.0, -150.0)),
+    ("F", Vec2::new(250.0, -100.0)),
+];
+
 /// Map area → screen position mapping.
 /// Areas A-F are zones within the current scenario map.
 pub fn area_to_position(area: &str) -> Vec2 {
-    match area {
-        "A" => Vec2::new(-300.0, 150.0),
-        "B" => Vec2::new(-100.0, 150.0),
-        "C" => Vec2::new(100.0, 0.0),
-        "D" => Vec2::new(-200.0, -100.0),
-        "E" => Vec2::new(0.0, -150.0),
-        "F" => Vec2::new(250.0, -100.0),
-        _ => Vec2::ZERO,
+    for &(label, pos) in AREA_POSITIONS {
+        if label == area {
+            return pos;
+        }
     }
+    Vec2::ZERO
+}
+
+/// Reverse mapping: find the nearest named area to a world position.
+/// Returns the area label whose center is closest to `pos`.
+pub fn position_to_area(pos: Vec2) -> String {
+    let mut best_label = "A";
+    let mut best_dist = f32::MAX;
+    for &(label, area_pos) in AREA_POSITIONS {
+        let dist = pos.distance_squared(area_pos);
+        if dist < best_dist {
+            best_dist = dist;
+            best_label = label;
+        }
+    }
+    best_label.to_string()
 }
 
 /// Spawns the 2D camera with shader settings from the active theme.

--- a/viewer/src/sse/bridge.rs
+++ b/viewer/src/sse/bridge.rs
@@ -1,25 +1,75 @@
 use bevy::prelude::*;
+use bevy::ecs::system::SystemParam;
 
 use super::client::SseReceiver;
 use crate::game::events::*;
 use crate::game::state::ConnectionStatus;
 
+/// Parse SSE JSON data into a typed payload and write the corresponding Bevy message.
+macro_rules! dispatch_event {
+    ($event_type:expr, $data:expr, $writer:expr, $payload_ty:ty, $event_ty:ident) => {
+        match serde_json::from_str::<$payload_ty>($data) {
+            Ok(payload) => { $writer.write($event_ty(payload)); }
+            Err(e) => log::warn!("Failed to parse {}: {}", $event_type, e),
+        }
+    };
+}
+
+// ── SystemParam bundles ──────────────────────────
+// Bevy's IntoSystem supports max 16 params. Bundle MessageWriters into
+// logical groups so the system function stays under the limit.
+
+/// Original 13 event types (underscore-format SSE names).
+#[derive(SystemParam)]
+pub struct OriginalEventWriters<'w> {
+    pub dice: MessageWriter<'w, DiceRolled>,
+    pub hp: MessageWriter<'w, HpChanged>,
+    pub narrative: MessageWriter<'w, NarrativeReceived>,
+    pub area: MessageWriter<'w, AreaMoved>,
+    pub turn: MessageWriter<'w, TurnAdvanced>,
+    pub choice: MessageWriter<'w, ChoiceAvailable>,
+    pub choice_resolved: MessageWriter<'w, ChoiceResolved>,
+    pub item: MessageWriter<'w, ItemAcquired>,
+    pub death: MessageWriter<'w, CharacterDied>,
+    pub combat: MessageWriter<'w, CombatStarted>,
+    pub weather: MessageWriter<'w, WeatherChanged>,
+    pub mood: MessageWriter<'w, MoodChanged>,
+    pub progress: MessageWriter<'w, TurnProgressUpdated>,
+}
+
+/// Phase 1: High-frequency lifecycle events (dot-format SSE names).
+#[derive(SystemParam)]
+pub struct Phase1EventWriters<'w> {
+    pub party_selected: MessageWriter<'w, PartySelected>,
+    pub room_created: MessageWriter<'w, RoomCreated>,
+    pub room_started: MessageWriter<'w, RoomStarted>,
+    pub session_started: MessageWriter<'w, SessionStarted>,
+    pub phase_changed: MessageWriter<'w, PhaseChanged>,
+    pub turn_started: MessageWriter<'w, TurnStarted>,
+    pub keeper_unavailable: MessageWriter<'w, KeeperUnavailable>,
+}
+
+/// Phase 2: Intervention + Actor events (dot-format SSE names).
+#[derive(SystemParam)]
+pub struct Phase2EventWriters<'w> {
+    pub intervention_submitted: MessageWriter<'w, InterventionSubmitted>,
+    pub intervention_applied: MessageWriter<'w, InterventionApplied>,
+    pub actor_spawned: MessageWriter<'w, ActorSpawned>,
+    pub actor_deleted: MessageWriter<'w, ActorDeleted>,
+    pub actor_claimed: MessageWriter<'w, ActorClaimed>,
+    pub actor_released: MessageWriter<'w, ActorReleased>,
+    pub actor_updated: MessageWriter<'w, ActorUpdated>,
+    pub room_ended: MessageWriter<'w, RoomEnded>,
+    pub turn_action_resolved: MessageWriter<'w, TurnActionResolved>,
+    pub scene_transitioned: MessageWriter<'w, SceneTransitioned>,
+}
+
 /// Each frame, drain the SSE message buffer and emit typed Bevy events.
 pub fn poll_sse_events(
     receiver: Option<Res<SseReceiver>>,
-    mut dice_events: MessageWriter<DiceRolled>,
-    mut hp_events: MessageWriter<HpChanged>,
-    mut narrative_events: MessageWriter<NarrativeReceived>,
-    mut area_events: MessageWriter<AreaMoved>,
-    mut turn_events: MessageWriter<TurnAdvanced>,
-    mut choice_events: MessageWriter<ChoiceAvailable>,
-    mut choice_resolved_events: MessageWriter<ChoiceResolved>,
-    mut item_events: MessageWriter<ItemAcquired>,
-    mut death_events: MessageWriter<CharacterDied>,
-    mut combat_events: MessageWriter<CombatStarted>,
-    mut weather_events: MessageWriter<WeatherChanged>,
-    mut mood_events: MessageWriter<MoodChanged>,
-    mut progress_events: MessageWriter<TurnProgressUpdated>,
+    mut original: OriginalEventWriters,
+    mut phase1: Phase1EventWriters,
+    mut phase2: Phase2EventWriters,
     mut connection: ResMut<ConnectionStatus>,
 ) {
     let Some(receiver) = receiver else { return };
@@ -36,84 +86,40 @@ pub fn poll_sse_events(
 
     for (event_type, data) in msgs.drain(..) {
         match event_type.as_str() {
-            "dice_roll" => {
-                match serde_json::from_str::<DiceRollPayload>(&data) {
-                    Ok(payload) => { dice_events.write(DiceRolled(payload)); }
-                    Err(e) => log::warn!("Failed to parse dice_roll: {}", e),
-                }
-            }
-            "hp_change" => {
-                match serde_json::from_str::<HpChangePayload>(&data) {
-                    Ok(payload) => { hp_events.write(HpChanged(payload)); }
-                    Err(e) => log::warn!("Failed to parse hp_change: {}", e),
-                }
-            }
-            "narrative" => {
-                match serde_json::from_str::<NarrativePayload>(&data) {
-                    Ok(payload) => { narrative_events.write(NarrativeReceived(payload)); }
-                    Err(e) => log::warn!("Failed to parse narrative: {}", e),
-                }
-            }
-            "area_move" => {
-                match serde_json::from_str::<AreaMovePayload>(&data) {
-                    Ok(payload) => { area_events.write(AreaMoved(payload)); }
-                    Err(e) => log::warn!("Failed to parse area_move: {}", e),
-                }
-            }
-            "turn_advance" => {
-                match serde_json::from_str::<TurnAdvancePayload>(&data) {
-                    Ok(payload) => { turn_events.write(TurnAdvanced(payload)); }
-                    Err(e) => log::warn!("Failed to parse turn_advance: {}", e),
-                }
-            }
-            "choice_available" => {
-                match serde_json::from_str::<ChoicePayload>(&data) {
-                    Ok(payload) => { choice_events.write(ChoiceAvailable(payload)); }
-                    Err(e) => log::warn!("Failed to parse choice_available: {}", e),
-                }
-            }
-            "choice_resolved" => {
-                match serde_json::from_str::<ChoicePayload>(&data) {
-                    Ok(payload) => { choice_resolved_events.write(ChoiceResolved(payload)); }
-                    Err(e) => log::warn!("Failed to parse choice_resolved: {}", e),
-                }
-            }
-            "item_acquired" => {
-                match serde_json::from_str::<ItemPayload>(&data) {
-                    Ok(payload) => { item_events.write(ItemAcquired(payload)); }
-                    Err(e) => log::warn!("Failed to parse item_acquired: {}", e),
-                }
-            }
-            "character_death" => {
-                match serde_json::from_str::<DeathPayload>(&data) {
-                    Ok(payload) => { death_events.write(CharacterDied(payload)); }
-                    Err(e) => log::warn!("Failed to parse character_death: {}", e),
-                }
-            }
-            "combat_start" => {
-                match serde_json::from_str::<CombatPayload>(&data) {
-                    Ok(payload) => { combat_events.write(CombatStarted(payload)); }
-                    Err(e) => log::warn!("Failed to parse combat_start: {}", e),
-                }
-            }
-            "weather_change" => {
-                match serde_json::from_str::<WeatherChangePayload>(&data) {
-                    Ok(payload) => { weather_events.write(WeatherChanged(payload)); }
-                    Err(e) => log::warn!("Failed to parse weather_change: {}", e),
-                }
-            }
-            "mood_change" => {
-                match serde_json::from_str::<MoodChangePayload>(&data) {
-                    Ok(payload) => { mood_events.write(MoodChanged(payload)); }
-                    Err(e) => log::warn!("Failed to parse mood_change: {}", e),
-                }
-            }
-            "turn_progress" => {
-                match serde_json::from_str::<TurnProgressPayload>(&data) {
-                    Ok(payload) => { progress_events.write(TurnProgressUpdated(payload)); }
-                    Err(e) => log::warn!("Failed to parse turn_progress: {}", e),
-                }
-            }
+            // ── Original events (underscore format) ──
+            "dice_roll" => dispatch_event!(event_type, &data, original.dice, DiceRollPayload, DiceRolled),
+            "hp_change" => dispatch_event!(event_type, &data, original.hp, HpChangePayload, HpChanged),
+            "narrative" => dispatch_event!(event_type, &data, original.narrative, NarrativePayload, NarrativeReceived),
+            "area_move" => dispatch_event!(event_type, &data, original.area, AreaMovePayload, AreaMoved),
+            "turn_advance" => dispatch_event!(event_type, &data, original.turn, TurnAdvancePayload, TurnAdvanced),
+            "choice_available" => dispatch_event!(event_type, &data, original.choice, ChoicePayload, ChoiceAvailable),
+            "choice_resolved" => dispatch_event!(event_type, &data, original.choice_resolved, ChoicePayload, ChoiceResolved),
+            "item_acquired" => dispatch_event!(event_type, &data, original.item, ItemPayload, ItemAcquired),
+            "character_death" => dispatch_event!(event_type, &data, original.death, DeathPayload, CharacterDied),
+            "combat_start" => dispatch_event!(event_type, &data, original.combat, CombatPayload, CombatStarted),
+            "weather_change" => dispatch_event!(event_type, &data, original.weather, WeatherChangePayload, WeatherChanged),
+            "mood_change" => dispatch_event!(event_type, &data, original.mood, MoodChangePayload, MoodChanged),
+            "turn_progress" => dispatch_event!(event_type, &data, original.progress, TurnProgressPayload, TurnProgressUpdated),
+            // ── Phase 1: High-frequency events (dot format) ──
+            "party.selected" => dispatch_event!(event_type, &data, phase1.party_selected, PartySelectedPayload, PartySelected),
+            "room.created" => dispatch_event!(event_type, &data, phase1.room_created, RoomCreatedPayload, RoomCreated),
+            "room.started" => dispatch_event!(event_type, &data, phase1.room_started, RoomLifecyclePayload, RoomStarted),
+            "session.started" => dispatch_event!(event_type, &data, phase1.session_started, SessionStartedPayload, SessionStarted),
+            "phase.changed" => dispatch_event!(event_type, &data, phase1.phase_changed, TurnAdvancePayload, PhaseChanged),
+            "turn.started" => dispatch_event!(event_type, &data, phase1.turn_started, TurnAdvancePayload, TurnStarted),
+            "keeper.unavailable" => dispatch_event!(event_type, &data, phase1.keeper_unavailable, KeeperUnavailablePayload, KeeperUnavailable),
+            // ── Phase 2: Intervention + Actor events (dot format) ──
+            "intervention.submitted" => dispatch_event!(event_type, &data, phase2.intervention_submitted, InterventionPayload, InterventionSubmitted),
+            "intervention.applied" => dispatch_event!(event_type, &data, phase2.intervention_applied, InterventionPayload, InterventionApplied),
+            "actor.spawned" => dispatch_event!(event_type, &data, phase2.actor_spawned, ActorLifecyclePayload, ActorSpawned),
+            "actor.deleted" => dispatch_event!(event_type, &data, phase2.actor_deleted, ActorLifecyclePayload, ActorDeleted),
+            "actor.claimed" => dispatch_event!(event_type, &data, phase2.actor_claimed, ActorLifecyclePayload, ActorClaimed),
+            "actor.released" => dispatch_event!(event_type, &data, phase2.actor_released, ActorLifecyclePayload, ActorReleased),
+            "actor.updated" => dispatch_event!(event_type, &data, phase2.actor_updated, ActorLifecyclePayload, ActorUpdated),
+            "room.ended" => dispatch_event!(event_type, &data, phase2.room_ended, RoomEndedPayload, RoomEnded),
+            "turn.action.resolved" => dispatch_event!(event_type, &data, phase2.turn_action_resolved, TurnActionResolvedPayload, TurnActionResolved),
+            "scene.transition" => dispatch_event!(event_type, &data, phase2.scene_transitioned, SceneTransitionPayload, SceneTransitioned),
+            // ── Fallback ──
             other => {
                 log::debug!("Unhandled SSE event type: {}", other);
             }


### PR DESCRIPTION
## Summary

- SSE event coverage: 13/29 → 30/29 backend event types (+17 new types across 2 phases)
- Phase 1 (lifecycle): PartySelected, RoomCreated, RoomStarted, SessionStarted, PhaseChanged, TurnStarted, KeeperUnavailable
- Phase 2 (intervention + actor): InterventionSubmitted/Applied, ActorSpawned/Deleted/Claimed/Released/Updated, RoomEnded, TurnActionResolved, SceneTransitioned
- SSE bridge refactored to use `#[derive(SystemParam)]` bundles (3 structs, 5 params) to stay under Bevy's 16-param system limit
- Character drag handlers: screen→world projection via camera query instead of raw cursor position
- Area snap: `position_to_area()` nearest-neighbor mapping using `AREA_POSITIONS` const
- Fixed pre-existing `CharacterData` struct literal missing `mp`, `max_mp`, `skills`, `conditions`, `equipment` fields

## Files changed (6)

| File | Change |
|------|--------|
| `game/events.rs` | +134: 17 new event/payload types |
| `game/mod.rs` | +19: event registrations |
| `sse/bridge.rs` | +188/-107: SystemParam bundles + dispatch macro |
| `render/characters.rs` | +43/-29: camera projection fix |
| `render/map.rs` | +38/-6: AREA_POSITIONS const + position_to_area |
| `game/http.rs` | +5: missing CharacterData fields |

## Test plan

- [x] `cargo check --target wasm32-unknown-unknown` green (0 errors, 33 dead-code warnings for unconsumed Phase 2 events)
- [ ] Verify SSE events dispatch correctly in browser (trunk serve + MASC backend)
- [ ] Test character drag snap to nearest area

🤖 Generated with [Claude Code](https://claude.com/claude-code)