### PR TITLE
fix(viewer): merge PR226 changes and resolve conflicts

### DIFF
--- a/viewer/Cargo.toml
+++ b/viewer/Cargo.toml
@@ -39,6 +39,7 @@ web-sys = { version = "0.3", features = [
     "RequestMode",
     "Response",
     "Headers",
+    "HtmlAudioElement",
 ] }
 js-sys = "0.3"
 serde = { version = "1", features = ["derive"] }

--- a/viewer/index.html
+++ b/viewer/index.html
@@ -254,7 +254,8 @@
                     <div id="turn-runtime"></div>
                     <!-- Turn Controls: advance turn (Keeper/GM only) -->
                     <div id="turn-controls" style="display:none">
-                        <button id="advance-turn-btn" title="Advance to next turn">Advance Turn</button>
+                        <button id="advance-turn-btn" title="Run one TRPG round">Run Round</button>
+                        <span id="round-run-summary" class="turn-summary"></span>
                         <span id="turn-control-status"></span>
                     </div>
                     <div id="narrative-log"></div>
@@ -290,6 +291,11 @@
                         <div id="action-status"></div>
                         <input type="hidden" id="claimed-actor-id" value="" />
                         <input type="hidden" id="claimed-keeper" value="" />
+                        <input type="hidden" id="round-run-dm" value="" />
+                        <input type="hidden" id="round-run-phase" value="round" />
+                        <input type="hidden" id="round-run-timeout" value="90" />
+                        <input type="hidden" id="round-run-lang" value="ko" />
+                        <input type="hidden" id="round-run-players" value="{}" />
                     </div>
                 </div>
             </section>

--- a/viewer/src/audio.rs
+++ b/viewer/src/audio.rs
@@ -1,0 +1,232 @@
+//! Audio system for TRPG viewer (WASM-native via web-sys HtmlAudioElement).
+//!
+//! BGM: looping background music per mood/scene.
+//! SFX: one-shot sound effects for game events (dice, combat, transitions).
+
+use bevy::prelude::*;
+use web_sys::HtmlAudioElement;
+
+use crate::game::events::*;
+
+// ─── Plugin ─────────────────────────────────
+
+pub struct AudioPlugin;
+
+impl Plugin for AudioPlugin {
+    fn build(&self, app: &mut App) {
+        app.init_resource::<AudioSettings>()
+            .init_resource::<AudioState>()
+            .add_systems(Update, (
+                sync_bgm_on_mood_change,
+                play_sfx_on_dice_roll,
+                play_sfx_on_turn_advance,
+                play_sfx_on_combat_start,
+                play_sfx_on_death,
+                update_bgm_volume,
+            ));
+    }
+}
+
+// ─── Resources ──────────────────────────────
+
+#[derive(Resource, Debug)]
+pub struct AudioSettings {
+    pub sound_enabled: bool,
+    pub music_enabled: bool,
+    pub sound_volume: f64,
+    pub music_volume: f64,
+}
+
+impl Default for AudioSettings {
+    fn default() -> Self {
+        Self {
+            sound_enabled: true,
+            music_enabled: true,
+            sound_volume: 0.7,
+            music_volume: 0.4,
+        }
+    }
+}
+
+/// Wrapper to make HtmlAudioElement Send+Sync for Bevy resources.
+/// Safe in WASM: single-threaded environment, no real concurrency.
+struct SendAudioElement(HtmlAudioElement);
+
+// SAFETY: WASM is single-threaded; JsValue pointers are never shared across threads.
+unsafe impl Send for SendAudioElement {}
+unsafe impl Sync for SendAudioElement {}
+
+impl std::fmt::Debug for SendAudioElement {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("SendAudioElement(..)")
+    }
+}
+
+#[derive(Resource, Default, Debug)]
+pub struct AudioState {
+    bgm_element: Option<SendAudioElement>,
+    current_bgm_track: String,
+}
+
+// ─── Asset paths ────────────────────────────
+
+pub mod paths {
+    // BGM tracks — ambient loops per mood/scene
+    pub const BGM_QUIET_UNEASE: &str = "audio/bgm_quiet_unease.ogg";
+    pub const BGM_TENSION_RISING: &str = "audio/bgm_tension_rising.ogg";
+    pub const BGM_AMBIGUOUS_CALM: &str = "audio/bgm_ambiguous_calm.ogg";
+    pub const BGM_COMBAT: &str = "audio/bgm_combat.ogg";
+    pub const BGM_DEFAULT: &str = "audio/bgm_default.ogg";
+
+    // SFX — one-shot effects
+    pub const SFX_DICE_ROLL: &str = "audio/sfx_dice_roll.ogg";
+    pub const SFX_DICE_SUCCESS: &str = "audio/sfx_dice_success.ogg";
+    pub const SFX_DICE_FAIL: &str = "audio/sfx_dice_fail.ogg";
+    pub const SFX_TURN_ADVANCE: &str = "audio/sfx_turn_advance.ogg";
+    pub const SFX_COMBAT_START: &str = "audio/sfx_combat_start.ogg";
+    pub const SFX_DEATH: &str = "audio/sfx_death.ogg";
+    pub const SFX_ITEM_ACQUIRE: &str = "audio/sfx_item_acquire.ogg";
+}
+
+/// Map mood string to BGM path.
+fn bgm_for_mood(mood: &str) -> &'static str {
+    match mood {
+        "quiet_unease" => paths::BGM_QUIET_UNEASE,
+        "tension_rising" => paths::BGM_TENSION_RISING,
+        "ambiguous_calm" => paths::BGM_AMBIGUOUS_CALM,
+        "combat" => paths::BGM_COMBAT,
+        _ => paths::BGM_DEFAULT,
+    }
+}
+
+// ─── Web Audio helpers ──────────────────────
+
+fn create_audio_element(src: &str, looping: bool, volume: f64) -> Option<HtmlAudioElement> {
+    let el = HtmlAudioElement::new_with_src(src).ok()?;
+    el.set_loop(looping);
+    el.set_volume(volume);
+    Some(el)
+}
+
+fn play_element(el: &HtmlAudioElement) {
+    // Browser autoplay policy: play() returns a Promise that may reject.
+    // We fire-and-forget; the user's first click on the menu satisfies the
+    // gesture requirement for subsequent plays.
+    let _ = el.play().ok();
+}
+
+fn play_one_shot(src: &str, volume: f64) {
+    if let Some(el) = create_audio_element(src, false, volume) {
+        play_element(&el);
+        // Element is GC'd by the browser after playback ends.
+        // To prevent early collection, leak a reference that the browser holds
+        // via the playing state. No explicit cleanup needed for short SFX.
+        std::mem::forget(el);
+    }
+}
+
+// ─── Systems ────────────────────────────────
+
+/// Switch BGM when the mood changes.
+fn sync_bgm_on_mood_change(
+    mut events: MessageReader<MoodChanged>,
+    settings: Res<AudioSettings>,
+    mut state: ResMut<AudioState>,
+) {
+    for ev in events.read() {
+        let track = bgm_for_mood(&ev.0.mood);
+        if track == state.current_bgm_track {
+            continue;
+        }
+
+        // Stop previous BGM
+        if let Some(ref el) = state.bgm_element {
+            el.0.pause().ok();
+        }
+
+        if settings.music_enabled {
+            if let Some(el) = create_audio_element(track, true, settings.music_volume) {
+                play_element(&el);
+                state.bgm_element = Some(SendAudioElement(el));
+            }
+        } else {
+            state.bgm_element = None;
+        }
+        state.current_bgm_track = track.to_string();
+    }
+}
+
+/// Adjust BGM volume when settings change (called every frame, early-outs fast).
+fn update_bgm_volume(
+    settings: Res<AudioSettings>,
+    state: Res<AudioState>,
+) {
+    if !settings.is_changed() {
+        return;
+    }
+
+    if let Some(ref el) = state.bgm_element {
+        if settings.music_enabled {
+            el.0.set_volume(settings.music_volume);
+            let _ = el.0.play().ok();
+        } else {
+            el.0.pause().ok();
+        }
+    }
+}
+
+/// Play dice SFX on roll events.
+fn play_sfx_on_dice_roll(
+    mut events: MessageReader<DiceRolled>,
+    settings: Res<AudioSettings>,
+) {
+    for ev in events.read() {
+        if !settings.sound_enabled {
+            continue;
+        }
+        play_one_shot(paths::SFX_DICE_ROLL, settings.sound_volume);
+
+        let result_sfx = if ev.0.result == "success" || ev.0.result == "critical_success" {
+            paths::SFX_DICE_SUCCESS
+        } else {
+            paths::SFX_DICE_FAIL
+        };
+        play_one_shot(result_sfx, settings.sound_volume);
+    }
+}
+
+/// Play turn advance chime.
+fn play_sfx_on_turn_advance(
+    mut events: MessageReader<TurnAdvanced>,
+    settings: Res<AudioSettings>,
+) {
+    for _ev in events.read() {
+        if settings.sound_enabled {
+            play_one_shot(paths::SFX_TURN_ADVANCE, settings.sound_volume);
+        }
+    }
+}
+
+/// Play combat start sting.
+fn play_sfx_on_combat_start(
+    mut events: MessageReader<CombatStarted>,
+    settings: Res<AudioSettings>,
+) {
+    for _ev in events.read() {
+        if settings.sound_enabled {
+            play_one_shot(paths::SFX_COMBAT_START, settings.sound_volume);
+        }
+    }
+}
+
+/// Play death SFX.
+fn play_sfx_on_death(
+    mut events: MessageReader<CharacterDied>,
+    settings: Res<AudioSettings>,
+) {
+    for _ev in events.read() {
+        if settings.sound_enabled {
+            play_one_shot(paths::SFX_DEATH, settings.sound_volume);
+        }
+    }
+}

--- a/viewer/src/config.rs
+++ b/viewer/src/config.rs
@@ -9,10 +9,8 @@ pub const MASC_MCP_URL: &str = "";
 
 pub const DEFAULT_ROOM_ID: &str = "default";
 
-/// Polling interval for TRPG stream (milliseconds).
-/// Backend exposes GET /api/v1/trpg/stream (JSON), no dedicated SSE endpoint.
-pub const TRPG_POLL_INTERVAL_MS: u64 = 500;
-
+/// Polling interval for TRPG stream fallback (milliseconds).
+pub const TRPG_POLL_INTERVAL_MS: u64 = 2000;
 /// Legacy TRPG Engine URL (for direct mode)
 #[cfg(debug_assertions)]
 pub const TRPG_ENGINE_URL: &str = "http://localhost:8000";
@@ -142,10 +140,10 @@ pub fn trpg_stream_poll_url(after_seq: i64) -> String {
 pub fn sse_endpoint(mode: &ViewerMode) -> Option<String> {
     match mode {
         ViewerMode::Trpg => Some(format!("{}/api/v1/trpg/stream/sse?room_id={}", MASC_MCP_URL, current_room_id())),
-        ViewerMode::Monitor => Some(format!("{}/api/v1/monitor/stream", MASC_MCP_URL)),
-        ViewerMode::Experiment => Some(format!("{}/api/v1/experiment/stream", MASC_MCP_URL)),
-        ViewerMode::Council => Some(format!("{}/api/v1/council/stream", MASC_MCP_URL)),
-        ViewerMode::Social => Some(format!("{}/api/v1/social/stream", MASC_MCP_URL)),
+        ViewerMode::Monitor => Some(format!("{}/sse?room=monitor", MASC_MCP_URL)),
+        ViewerMode::Experiment => Some(format!("{}/sse?room=experiment", MASC_MCP_URL)),
+        ViewerMode::Council => Some(format!("{}/sse?room=council", MASC_MCP_URL)),
+        ViewerMode::Social => Some(format!("{}/sse?room=social", MASC_MCP_URL)),
         ViewerMode::Lobby => None,
     }
 }
@@ -155,10 +153,10 @@ pub fn sse_endpoint(mode: &ViewerMode) -> Option<String> {
 pub fn sse_endpoint_by_name(mode_name: &str) -> Option<String> {
     match mode_name {
         "Trpg" => Some(format!("{}/api/v1/trpg/stream/sse?room_id={}", MASC_MCP_URL, current_room_id())),
-        "Monitor" => Some(format!("{}/api/v1/monitor/stream", MASC_MCP_URL)),
-        "Experiment" => Some(format!("{}/api/v1/experiment/stream", MASC_MCP_URL)),
-        "Council" => Some(format!("{}/api/v1/council/stream", MASC_MCP_URL)),
-        "Social" => Some(format!("{}/api/v1/social/stream", MASC_MCP_URL)),
+        "Monitor" => Some(format!("{}/sse?room=monitor", MASC_MCP_URL)),
+        "Experiment" => Some(format!("{}/sse?room=experiment", MASC_MCP_URL)),
+        "Council" => Some(format!("{}/sse?room=council", MASC_MCP_URL)),
+        "Social" => Some(format!("{}/sse?room=social", MASC_MCP_URL)),
         _ => None,
     }
 }

--- a/viewer/src/dom/action_panel.rs
+++ b/viewer/src/dom/action_panel.rs
@@ -421,6 +421,16 @@ fn get_active_actor_from_dom() -> Option<String> {
         }
     }
 
+    // 2. Fallback: claimed actor state stored in join panel (survives UI transitions).
+    if let Some(el) = doc.get_element_by_id("claimed-actor-id") {
+        if let Some(input) = el.dyn_ref::<web_sys::HtmlInputElement>() {
+            let claimed = input.value();
+            if !claimed.trim().is_empty() {
+                return Some(claimed);
+            }
+        }
+    }
+
     // 2. Fallback: Dashboard-selected actor
     config::current_actor_id()
 }

--- a/viewer/src/dom/actor_join.rs
+++ b/viewer/src/dom/actor_join.rs
@@ -14,6 +14,8 @@ use wasm_bindgen::prelude::*;
 
 #[cfg(target_arch = "wasm32")]
 use crate::config;
+#[cfg(target_arch = "wasm32")]
+use crate::dom::action_panel::friendly_js_error;
 use crate::game::state::{RoomState, TurnProgressState};
 
 // ─── Marker Resource ────────────────────────
@@ -75,10 +77,23 @@ pub fn sync_join_panel_interaction_state(
         }
 
         fn room_accepts_join(status: &str) -> bool {
-            match status {
-                "idle" | "active" | "combat" | "roleplay" => true,
-                _ => false, // "ended", "archived", "error", etc.
-            }
+            matches!(
+                status,
+                "active"
+                    | "running"
+                    | "in_progress"
+                    | "round"
+                    | "combat"
+                    | "briefing"
+                    | "dm_narration"
+                    | "party_discussion"
+                    | "action_declaration"
+                    | "dice_resolution"
+                    | "outcome_narration"
+                    | "state_update"
+                    | "transition"
+                    | "paused"
+            )
         }
 
         fn room_blocked_join_message(status: &str) -> Option<&'static str> {
@@ -348,16 +363,6 @@ fn set_join_status(text: &str, css_class: &str) {
             el.set_class_name(css_class);
         }
     }
-}
-
-#[cfg(target_arch = "wasm32")]
-fn friendly_js_error(val: &JsValue) -> String {
-    val.as_string()
-        .or_else(|| {
-            val.dyn_ref::<js_sys::Error>()
-                .map(|e| e.message().into())
-        })
-        .unwrap_or_else(|| format!("{:?}", val))
 }
 
 #[cfg(target_arch = "wasm32")]

--- a/viewer/src/dom/character_panel.rs
+++ b/viewer/src/dom/character_panel.rs
@@ -174,16 +174,10 @@ pub fn update_character_panel_dom(
     };
 
     // Read which sections are expanded before we wipe innerHTML
-    let expanded = {
-        #[cfg(target_arch = "wasm32")]
-        {
-            read_collapse_state(&document)
-        }
-        #[cfg(not(target_arch = "wasm32"))]
-        {
-            read_collapse_state()
-        }
-    };
+    #[cfg(target_arch = "wasm32")]
+    let expanded = read_collapse_state(&document);
+    #[cfg(not(target_arch = "wasm32"))]
+    let expanded: std::collections::HashSet<String> = std::collections::HashSet::new();
 
     let mut html = String::new();
 

--- a/viewer/src/dom/character_panel.rs
+++ b/viewer/src/dom/character_panel.rs
@@ -129,7 +129,7 @@ fn read_collapse_state(document: &web_sys::Document) -> std::collections::HashSe
 }
 
 #[cfg(not(target_arch = "wasm32"))]
-fn read_collapse_state(_document: &()) -> std::collections::HashSet<String> {
+fn read_collapse_state() -> std::collections::HashSet<String> {
     std::collections::HashSet::new()
 }
 
@@ -174,7 +174,16 @@ pub fn update_character_panel_dom(
     };
 
     // Read which sections are expanded before we wipe innerHTML
-    let expanded = read_collapse_state(&document);
+    let expanded = {
+        #[cfg(target_arch = "wasm32")]
+        {
+            read_collapse_state(&document)
+        }
+        #[cfg(not(target_arch = "wasm32"))]
+        {
+            read_collapse_state()
+        }
+    };
 
     let mut html = String::new();
 

--- a/viewer/src/dom/turn_controls.rs
+++ b/viewer/src/dom/turn_controls.rs
@@ -3,8 +3,7 @@
 //! Binds DOM event listeners on `#turn-controls`:
 //! - Advance Turn button → POST `/api/v1/trpg/turns/advance`
 //!
-//! Visible only when the player has claimed a keeper role.
-//! Follows the same OnEnter/OnExit lifecycle as `action_panel.rs`.
+//! Visible when the room is in an active TRPG phase.
 
 use bevy::prelude::*;
 
@@ -72,7 +71,7 @@ pub fn sync_turn_controls_visibility(
         } else {
             normalize_room_status(&room_state.status)
         };
-        let room_allows_control = matches!(status.as_str(), "active" | "running");
+        let room_allows_control = is_room_active_for_controls(&status);
 
         let Some(doc) = web_sys::window().and_then(|w| w.document()) else {
             return;
@@ -80,18 +79,39 @@ pub fn sync_turn_controls_visibility(
         let Some(panel) = doc.get_element_by_id("turn-controls") else {
             return;
         };
-        let keeper = doc
+        let has_keeper = doc
             .get_element_by_id("claimed-keeper")
-            .and_then(|el| el.dyn_ref::<web_sys::HtmlInputElement>().map(|i| i.value()));
-        let has_keeper = keeper.map_or(false, |v| !v.trim().is_empty());
+            .and_then(|el| el.dyn_ref::<web_sys::HtmlInputElement>().map(|i| i.value()))
+            .map_or(false, |v| !v.trim().is_empty());
 
-        let style = if has_keeper && room_allows_control {
+        let style = if room_allows_control || has_keeper {
             ""
         } else {
             "display:none"
         };
         let _ = panel.set_attribute("style", style);
     }
+}
+
+#[cfg(target_arch = "wasm32")]
+fn is_room_active_for_controls(status: &str) -> bool {
+    matches!(
+        status,
+        "active"
+            | "running"
+            | "in_progress"
+            | "round"
+            | "combat"
+            | "briefing"
+            | "dm_narration"
+            | "party_discussion"
+            | "action_declaration"
+            | "dice_resolution"
+            | "outcome_narration"
+            | "state_update"
+            | "transition"
+            | "paused"
+    )
 }
 
 // ─── Event: Advance Button ──────────────────

--- a/viewer/src/dom/turn_runtime.rs
+++ b/viewer/src/dom/turn_runtime.rs
@@ -38,7 +38,11 @@ fn normalize_room_status(raw: &str) -> String {
 #[cfg(target_arch = "wasm32")]
 fn room_status_class(status: &str) -> &'static str {
     match status {
-        "active" | "running" => "status-active",
+        "active" | "running" | "in_progress" | "round" | "combat" | "briefing" => {
+            "status-active"
+        }
+        "dm_narration" | "party_discussion" | "action_declaration" | "dice_resolution"
+        | "outcome_narration" | "state_update" | "transition" => "status-active",
         "paused" => "status-paused",
         "ended" => "status-ended",
         "unavailable" => "status-unavailable",
@@ -50,7 +54,9 @@ fn room_status_class(status: &str) -> &'static str {
 #[cfg(target_arch = "wasm32")]
 fn room_status_label(status: &str) -> &'static str {
     match status {
-        "active" | "running" => "RUNNING",
+        "active" | "running" | "in_progress" | "round" | "combat" | "briefing" => "RUNNING",
+        "dm_narration" | "party_discussion" | "action_declaration" | "dice_resolution"
+        | "outcome_narration" | "state_update" | "transition" => "RUNNING",
         "paused" => "PAUSED",
         "ended" => "ENDED",
         "idle" => "IDLE",
@@ -61,7 +67,22 @@ fn room_status_label(status: &str) -> &'static str {
 }
 
 fn room_accepts_input(status: &str) -> bool {
-    matches!(status, "active" | "running")
+    matches!(
+        status,
+        "active"
+            | "running"
+            | "in_progress"
+            | "round"
+            | "combat"
+            | "briefing"
+            | "dm_narration"
+            | "party_discussion"
+            | "action_declaration"
+            | "dice_resolution"
+            | "outcome_narration"
+            | "state_update"
+            | "transition"
+    )
 }
 
 /// Render live TRPG runtime progress:

--- a/viewer/src/game/http.rs
+++ b/viewer/src/game/http.rs
@@ -581,10 +581,75 @@ fn parse_party_characters(state: &Value) -> Vec<CharacterData> {
                         .collect::<Vec<_>>()
                 })
                 .unwrap_or_default();
+            let mp = info.get("mp").and_then(Value::as_i64).unwrap_or(20) as i32;
+            let max_mp = info
+                .get("max_mp")
+                .and_then(Value::as_i64)
+                .unwrap_or(i64::from(mp.max(1))) as i32;
             let stats = info
                 .get("stats")
                 .cloned()
                 .and_then(|v| serde_json::from_value::<StatsData>(v).ok());
+            let skills = info
+                .get("skills")
+                .and_then(Value::as_array)
+                .map(|rows| {
+                    rows.iter()
+                        .filter_map(|skill| {
+                            if let Ok(parsed) = serde_json::from_value::<SkillData>(skill.clone()) {
+                                Some(parsed)
+                            } else if let Some(name) = skill.as_str() {
+                                Some(SkillData {
+                                    name: name.to_string(),
+                                    level: 10,
+                                })
+                            } else {
+                                None
+                            }
+                        })
+                        .collect::<Vec<_>>()
+                })
+                .unwrap_or_default();
+            let conditions = info
+                .get("conditions")
+                .and_then(Value::as_array)
+                .map(|rows| {
+                    rows.iter()
+                        .filter_map(|cond| {
+                            if let Ok(parsed) = serde_json::from_value::<ConditionData>(cond.clone()) {
+                                Some(parsed)
+                            } else if let Some(name) = cond.as_str() {
+                                Some(ConditionData {
+                                    name: name.to_string(),
+                                    remaining_turns: None,
+                                })
+                            } else {
+                                None
+                            }
+                        })
+                        .collect::<Vec<_>>()
+                })
+                .unwrap_or_default();
+            let equipment = info
+                .get("equipment")
+                .and_then(Value::as_array)
+                .map(|rows| {
+                    rows.iter()
+                        .filter_map(|slot| {
+                            if let Ok(parsed) = serde_json::from_value::<EquipmentData>(slot.clone()) {
+                                Some(parsed)
+                            } else if let Some(name) = slot.as_str() {
+                                Some(EquipmentData {
+                                    slot: "item".to_string(),
+                                    name: name.to_string(),
+                                })
+                            } else {
+                                None
+                            }
+                        })
+                        .collect::<Vec<_>>()
+                })
+                .unwrap_or_default();
 
             CharacterData {
                 id: actor_id.to_string(),
@@ -592,12 +657,17 @@ fn parse_party_characters(state: &Value) -> Vec<CharacterData> {
                 class,
                 hp,
                 max_hp,
+                mp,
+                max_mp,
                 stats,
                 area,
                 is_dead,
                 inventory,
                 buffs,
                 debuffs,
+                skills,
+                conditions,
+                equipment,
             }
         })
         .collect()

--- a/viewer/src/game/http.rs
+++ b/viewer/src/game/http.rs
@@ -540,6 +540,12 @@ fn parse_party_characters(state: &Value) -> Vec<CharacterData> {
                 .get("max_hp")
                 .and_then(Value::as_i64)
                 .unwrap_or(i64::from(hp.max(1))) as i32;
+            let mp = info.get("mp").and_then(Value::as_i64).unwrap_or(0) as i32;
+            let max_mp = info
+                .get("max_mp")
+                .and_then(Value::as_i64)
+                .or_else(|| info.get("mp_max").and_then(Value::as_i64))
+                .unwrap_or(i64::from(mp.max(0))) as i32;
             let area = info
                 .get("position")
                 .and_then(Value::as_str)
@@ -590,66 +596,9 @@ fn parse_party_characters(state: &Value) -> Vec<CharacterData> {
                 .get("stats")
                 .cloned()
                 .and_then(|v| serde_json::from_value::<StatsData>(v).ok());
-            let skills = info
-                .get("skills")
-                .and_then(Value::as_array)
-                .map(|rows| {
-                    rows.iter()
-                        .filter_map(|skill| {
-                            if let Ok(parsed) = serde_json::from_value::<SkillData>(skill.clone()) {
-                                Some(parsed)
-                            } else if let Some(name) = skill.as_str() {
-                                Some(SkillData {
-                                    name: name.to_string(),
-                                    level: 10,
-                                })
-                            } else {
-                                None
-                            }
-                        })
-                        .collect::<Vec<_>>()
-                })
-                .unwrap_or_default();
-            let conditions = info
-                .get("conditions")
-                .and_then(Value::as_array)
-                .map(|rows| {
-                    rows.iter()
-                        .filter_map(|cond| {
-                            if let Ok(parsed) = serde_json::from_value::<ConditionData>(cond.clone()) {
-                                Some(parsed)
-                            } else if let Some(name) = cond.as_str() {
-                                Some(ConditionData {
-                                    name: name.to_string(),
-                                    remaining_turns: None,
-                                })
-                            } else {
-                                None
-                            }
-                        })
-                        .collect::<Vec<_>>()
-                })
-                .unwrap_or_default();
-            let equipment = info
-                .get("equipment")
-                .and_then(Value::as_array)
-                .map(|rows| {
-                    rows.iter()
-                        .filter_map(|slot| {
-                            if let Ok(parsed) = serde_json::from_value::<EquipmentData>(slot.clone()) {
-                                Some(parsed)
-                            } else if let Some(name) = slot.as_str() {
-                                Some(EquipmentData {
-                                    slot: "item".to_string(),
-                                    name: name.to_string(),
-                                })
-                            } else {
-                                None
-                            }
-                        })
-                        .collect::<Vec<_>>()
-                })
-                .unwrap_or_default();
+            let skills = parse_party_skills(info.get("skills"));
+            let conditions = parse_party_conditions(info.get("conditions"));
+            let equipment = parse_party_equipment(info.get("equipment"));
 
             CharacterData {
                 id: actor_id.to_string(),
@@ -662,13 +611,126 @@ fn parse_party_characters(state: &Value) -> Vec<CharacterData> {
                 stats,
                 area,
                 is_dead,
-                inventory,
-                buffs,
-                debuffs,
                 skills,
                 conditions,
                 equipment,
+                inventory,
+                buffs,
+                debuffs,
             }
+        })
+        .collect()
+}
+
+fn parse_party_skills(raw: Option<&Value>) -> Vec<SkillData> {
+    let Some(raw) = raw else {
+        return Vec::new();
+    };
+
+    let arr = match raw {
+        Value::Array(rows) => rows,
+        _ => return Vec::new(),
+    };
+
+    arr.iter()
+        .filter_map(|row| {
+            if let Some(name) = row.as_str() {
+                return Some(SkillData {
+                    name: name.to_string(),
+                    level: default_skill_level(),
+                });
+            }
+
+            let obj = row.as_object()?;
+            Some(SkillData {
+                name: obj
+                    .get("name")
+                    .and_then(Value::as_str)
+                    .or_else(|| obj.get("skill").and_then(Value::as_str))
+                    .unwrap_or("")
+                    .to_string(),
+                level: obj
+                    .get("level")
+                    .and_then(Value::as_i64)
+                    .and_then(|v| i32::try_from(v).ok())
+                    .unwrap_or_else(default_skill_level),
+            })
+            .filter(|s| !s.name.is_empty())
+        })
+        .collect()
+}
+
+fn parse_party_conditions(raw: Option<&Value>) -> Vec<ConditionData> {
+    let Some(raw) = raw else {
+        return Vec::new();
+    };
+
+    let arr = match raw {
+        Value::Array(rows) => rows,
+        _ => return Vec::new(),
+    };
+
+    arr.iter()
+        .filter_map(|row| {
+            if let Some(name) = row.as_str() {
+                return Some(ConditionData {
+                    name: name.to_string(),
+                    remaining_turns: None,
+                });
+            }
+
+            let obj = row.as_object()?;
+            let name = obj
+                .get("name")
+                .and_then(Value::as_str)
+                .or_else(|| obj.get("condition").and_then(Value::as_str))
+                .unwrap_or("")
+                .to_string();
+            let remaining_turns = obj
+                .get("remaining_turns")
+                .and_then(Value::as_i64)
+                .and_then(|v| i32::try_from(v).ok());
+            Some(ConditionData { name, remaining_turns })
+                .filter(|c| !c.name.is_empty())
+        })
+        .collect()
+}
+
+fn parse_party_equipment(raw: Option<&Value>) -> Vec<EquipmentData> {
+    let Some(raw) = raw else {
+        return Vec::new();
+    };
+
+    let arr = match raw {
+        Value::Array(rows) => rows,
+        _ => return Vec::new(),
+    };
+
+    arr.iter()
+        .filter_map(|row| {
+            if let Some(name) = row.as_str() {
+                return Some(EquipmentData {
+                    slot: "item".to_string(),
+                    name: name.to_string(),
+                });
+            }
+
+            let obj = row.as_object()?;
+            Some(EquipmentData {
+                slot: obj
+                    .get("slot")
+                    .and_then(Value::as_str)
+                    .or_else(|| obj.get("slot_name").and_then(Value::as_str))
+                    .unwrap_or("")
+                    .to_string(),
+                name: obj
+                    .get("name")
+                    .and_then(Value::as_str)
+                    .or_else(|| obj.get("item").and_then(Value::as_str))
+                    .unwrap_or("")
+                    .to_string(),
+            })
+            .filter(|e| !e.name.is_empty() && !e.slot.is_empty())
         })
         .collect()
 }

--- a/viewer/src/game/http.rs
+++ b/viewer/src/game/http.rs
@@ -540,12 +540,6 @@ fn parse_party_characters(state: &Value) -> Vec<CharacterData> {
                 .get("max_hp")
                 .and_then(Value::as_i64)
                 .unwrap_or(i64::from(hp.max(1))) as i32;
-            let mp = info.get("mp").and_then(Value::as_i64).unwrap_or(0) as i32;
-            let max_mp = info
-                .get("max_mp")
-                .and_then(Value::as_i64)
-                .or_else(|| info.get("mp_max").and_then(Value::as_i64))
-                .unwrap_or(i64::from(mp.max(0))) as i32;
             let area = info
                 .get("position")
                 .and_then(Value::as_str)

--- a/viewer/src/main.rs
+++ b/viewer/src/main.rs
@@ -4,6 +4,7 @@ mod theme;
 
 // Domain modules — compiled unconditionally, but systems are gated on ViewerMode.
 mod assets;
+mod audio;
 mod dom;
 mod game;
 mod render;
@@ -47,6 +48,7 @@ fn main() {
             render::MapRenderPlugin,
             shaders::PostProcessPlugin,
             dom::DomBridgePlugin,
+            audio::AudioPlugin,
         ))
         .add_systems(Update, shaders::post_process::update_post_process_time)
         .run();

--- a/viewer/src/mode.rs
+++ b/viewer/src/mode.rs
@@ -1813,7 +1813,7 @@ fn normalize_preset_catalog(raw: &Value) -> Value {
         presets.clone()
     } else {
         value
-    };
+    }
 }
 
 #[cfg(target_arch = "wasm32")]
@@ -1823,9 +1823,14 @@ fn preset_unwrap_payload(value: &Value) -> Option<Value> {
         .or_else(|| value.get("result"))
         .or_else(|| value.get("data"))
         .or_else(|| value.get("structuredContent"))
-        .filter(Value::is_object)
+        .filter(|v| v.is_object())
         .cloned()
-        .or_else(|| value.get("presets").filter(Value::is_object).cloned())
+        .or_else(|| {
+            value
+                .get("presets")
+                .filter(|v| v.is_object())
+                .cloned()
+        })
 }
 
 #[cfg(target_arch = "wasm32")]

--- a/viewer/src/mode.rs
+++ b/viewer/src/mode.rs
@@ -509,6 +509,9 @@ fn clear_trpg_dom(doc: &web_sys::Document) {
     if let Some(el) = doc.get_element_by_id("join-status") {
         el.set_text_content(Some(""));
     }
+    if let Some(el) = doc.get_element_by_id("new-game-assignment") {
+        el.set_inner_html("세션 정보를 준비 중입니다.");
+    }
     if let Some(el) = doc.get_element_by_id("action-status") {
         el.set_text_content(Some(""));
     }
@@ -1182,7 +1185,9 @@ async fn mcp_tool_call(tool_name: &str, args: Value) -> Result<Value, String> {
     let rpc: Value = if body_text.trim().is_empty() {
         json!({})
     } else {
-        parse_mcp_rpc_response(&body_text).map_err(|e| {
+        parse_mcp_rpc_response(&body_text).or_else(|_| {
+            parse_embedded_tool_payload(&body_text)
+        }).map_err(|e| {
             format!(
                 "RPC 응답 JSON 파싱 실패: {} / {}",
                 e,
@@ -1269,28 +1274,30 @@ async fn mcp_tool_call(tool_name: &str, args: Value) -> Result<Value, String> {
         return Ok(json!({}));
     }
 
-    let parsed: Value = match serde_json::from_str(&text) {
+    let parsed: Value = match parse_embedded_tool_payload(&text) {
         Ok(v) => v,
-        Err(primary) => parse_mcp_rpc_response(&text).map_err(|secondary| {
-            format!(
+        Err(primary) => {
+            let secondary = parse_mcp_rpc_response(&text).unwrap_or_else(|e| Value::String(format!("파싱 실패: {}", e)));
+            return Err(format!(
                 "{} 응답 JSON 파싱 실패: {} / {} / raw={}",
-                tool_name,
-                primary,
-                secondary,
-                text
-            )
-        })?,
+                tool_name, primary, secondary, text
+            ));
+        }
     };
     Ok(parsed.get("payload").cloned().unwrap_or(parsed))
 }
 
 #[cfg(target_arch = "wasm32")]
 fn parse_mcp_rpc_response(raw: &str) -> Result<Value, String> {
+    if let Some(v) = parse_embedded_json(raw) {
+        return Ok(v);
+    }
+
     let trimmed = raw.trim();
     if trimmed.is_empty() {
         return Ok(json!({}));
     }
-    if let Ok(v) = serde_json::from_str::<Value>(trimmed) {
+    if let Some(v) = parse_embedded_json(trimmed) {
         return Ok(v);
     }
 
@@ -1300,10 +1307,8 @@ fn parse_mcp_rpc_response(raw: &str) -> Result<Value, String> {
         if piece.is_empty() {
             continue;
         }
-        if piece.starts_with('{') || piece.starts_with('[') {
-            if let Ok(v) = serde_json::from_str::<Value>(piece) {
-                return Ok(v);
-            }
+        if let Some(v) = parse_embedded_json(piece) {
+            return Ok(v);
         }
 
         let data_text = piece
@@ -1316,12 +1321,120 @@ fn parse_mcp_rpc_response(raw: &str) -> Result<Value, String> {
         if data_text.is_empty() || data_text == "[DONE]" {
             continue;
         }
-        if let Ok(v) = serde_json::from_str::<Value>(data_text) {
+        if let Some(v) = parse_embedded_json(data_text) {
             return Ok(v);
         }
     }
 
     Err("SSE frame parsing failed".to_string())
+}
+
+#[cfg(target_arch = "wasm32")]
+fn parse_embedded_tool_payload(raw: &str) -> Result<Value, String> {
+    parse_embedded_json(raw).ok_or_else(|| "JSON payload를 찾지 못했습니다".to_string())
+}
+
+#[cfg(target_arch = "wasm32")]
+fn parse_embedded_json(raw: &str) -> Option<Value> {
+    for candidate in collect_json_candidates(raw) {
+        if let Ok(v) = serde_json::from_str::<Value>(&candidate) {
+            return Some(v);
+        }
+    }
+    None
+}
+
+#[cfg(target_arch = "wasm32")]
+fn collect_json_candidates(raw: &str) -> Vec<String> {
+    let mut candidates = Vec::new();
+    let src = raw.trim();
+    if src.is_empty() {
+        return candidates;
+    }
+
+    // 1) Strict full-text parse
+    candidates.push(src.to_string());
+
+    // 2) SSE payload-only lines
+    candidates.extend(
+        src
+            .lines()
+            .filter_map(|line| line.strip_prefix("data:"))
+            .map(str::trim_start)
+            .filter(|line| !line.is_empty() && *line != "[DONE]")
+            .map(ToString::to_string),
+    );
+
+    // 3) Event-frame chunks
+    candidates.extend(
+        src.split("\n\n")
+            .map(str::trim)
+            .filter(|piece| !piece.is_empty() && *piece != "[DONE]")
+            .map(ToString::to_string),
+    );
+
+    // 4) Top-level embedded JSON span
+    if let Some((start, end)) = extract_top_level_json_span(src) {
+        candidates.push(src[start..end].to_string());
+    }
+
+    candidates
+}
+
+#[cfg(target_arch = "wasm32")]
+fn extract_top_level_json_span(raw: &str) -> Option<(usize, usize)> {
+    let mut stack: Vec<u8> = Vec::new();
+    let mut in_string = false;
+    let mut escape = false;
+    let mut start: Option<usize> = None;
+
+    for (idx, byte) in raw.bytes().enumerate() {
+        if in_string {
+            if escape {
+                escape = false;
+                continue;
+            }
+            match byte {
+                b'\\' => escape = true,
+                b'"' => in_string = false,
+                _ => {}
+            }
+            continue;
+        }
+
+        match byte {
+            b'"' => in_string = true,
+            b'{' => {
+                if stack.is_empty() {
+                    start = Some(idx);
+                }
+                stack.push(b'}');
+            }
+            b'[' => {
+                if stack.is_empty() {
+                    start = Some(idx);
+                }
+                stack.push(b']');
+            }
+            b'}' | b']' => {
+                if let Some(expected) = stack.pop() {
+                    if expected != byte {
+                        return None;
+                    }
+                    if stack.is_empty() {
+                        if let Some(begin) = start {
+                            return Some((begin, idx + 1));
+                        }
+                    }
+                } else {
+                    return None;
+                }
+            }
+            _ => {}
+        }
+    }
+
+    None
 }
 
 #[cfg(target_arch = "wasm32")]
@@ -1454,24 +1567,15 @@ async fn start_new_game_flow(doc: &web_sys::Document) -> Result<String, String> 
         }),
     )
     .await?;
-    let world_preset_id = preset_catalog
-        .get("world_presets")
-        .and_then(Value::as_array)
-        .and_then(|arr| arr.first())
-        .and_then(|preset| preset.get("id"))
-        .and_then(Value::as_str)
-        .unwrap_or("")
-        .trim()
-        .to_string();
-    let dm_preset_id = preset_catalog
-        .get("dm_presets")
-        .and_then(Value::as_array)
-        .and_then(|arr| arr.first())
-        .and_then(|preset| preset.get("id"))
-        .and_then(Value::as_str)
-        .unwrap_or("")
-        .trim()
-        .to_string();
+    let preset_catalog = normalize_preset_catalog(&preset_catalog);
+    let world_preset_id = extract_first_preset_id(&preset_catalog, "world_presets")
+        .or_else(|| extract_first_preset_id(&preset_catalog, "world"))
+        .or_else(|| extract_first_preset_id_by_key(&preset_catalog, "world"))
+        .unwrap_or_default();
+    let dm_preset_id = extract_first_preset_id(&preset_catalog, "dm_presets")
+        .or_else(|| extract_first_preset_id(&preset_catalog, "dm"))
+        .or_else(|| extract_first_preset_id_by_key(&preset_catalog, "dm"))
+        .unwrap_or_default();
     if world_preset_id.is_empty() || dm_preset_id.is_empty() {
         return Err("trpg preset 목록이 비어 있습니다.".to_string());
     }
@@ -1600,6 +1704,10 @@ async fn start_new_game_flow(doc: &web_sys::Document) -> Result<String, String> 
         player_map.insert(actor_id.clone(), Value::String(candidate));
     }
 
+    if let Some(doc) = web_sys::window().and_then(|w| w.document()) {
+        set_new_game_assignment(&doc, &dm_keeper, &player_map, &actor_ids);
+    }
+
     if !models.is_empty() {
         let models_value = Value::Array(
             models
@@ -1652,6 +1760,152 @@ async fn start_new_game_flow(doc: &web_sys::Document) -> Result<String, String> 
         dm_keeper,
         player_map.len()
     ))
+}
+
+#[cfg(target_arch = "wasm32")]
+fn set_new_game_assignment(
+    doc: &web_sys::Document,
+    dm_keeper: &str,
+    player_map: &serde_json::Map<String, Value>,
+    actor_ids: &[String],
+) {
+    let Some(el) = doc.get_element_by_id("new-game-assignment") else {
+        return;
+    };
+    let mut html = String::from("<strong>배정 확인</strong><ul>");
+    html.push_str(&format!("<li>DM: {}</li>", html_escape(dm_keeper)));
+    for actor_id in actor_ids {
+        let keeper = player_map
+            .get(actor_id)
+            .and_then(Value::as_str)
+            .unwrap_or("미정");
+        html.push_str(&format!(
+            "<li>{} → {}</li>",
+            html_escape(actor_id),
+            html_escape(keeper)
+        ));
+    }
+    html.push_str("</ul>");
+    el.set_inner_html(&html);
+}
+
+#[cfg(target_arch = "wasm32")]
+fn normalize_preset_catalog(raw: &Value) -> Value {
+    let mut value = raw.clone();
+    for _ in 0..6 {
+        if let Some(next_value) = preset_unwrap_payload(&value) {
+            value = next_value;
+            continue;
+        }
+        if let Some(parsed) = preset_unwrap_content(&value) {
+            value = parsed;
+            continue;
+        }
+        break;
+    }
+
+    if value.is_array() {
+        let mut obj = serde_json::Map::new();
+        obj.insert("items".to_string(), value);
+        return Value::Object(obj);
+    }
+    if let Some(presets) = value.get("presets") {
+        presets.clone()
+    } else {
+        value
+    };
+}
+
+#[cfg(target_arch = "wasm32")]
+fn preset_unwrap_payload(value: &Value) -> Option<Value> {
+    value
+        .get("payload")
+        .or_else(|| value.get("result"))
+        .or_else(|| value.get("data"))
+        .or_else(|| value.get("structuredContent"))
+        .filter(Value::is_object)
+        .cloned()
+        .or_else(|| value.get("presets").filter(Value::is_object).cloned())
+}
+
+#[cfg(target_arch = "wasm32")]
+fn preset_unwrap_content(value: &Value) -> Option<Value> {
+    if let Some(presets_text) = value
+        .get("content")
+        .and_then(Value::as_array)
+        .and_then(|rows| {
+            rows.iter().find_map(|row| {
+                if row.get("type").and_then(Value::as_str) == Some("text") {
+                    row.get("text").and_then(Value::as_str)
+                } else {
+                    None
+                }
+            })
+        })
+    {
+        parse_embedded_tool_payload(presets_text).ok()
+    } else if let Some(raw_text) = value.get("content").and_then(Value::as_str) {
+        parse_embedded_tool_payload(raw_text).ok()
+    } else {
+        None
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+fn extract_first_preset_id(catalog: &Value, list_key: &str) -> Option<String> {
+    catalog
+        .get(list_key)
+        .and_then(extract_first_preset_id_from_node)
+        .or_else(|| catalog.get("items").and_then(extract_first_preset_id_from_node))
+        .or_else(|| catalog.get("presets").and_then(extract_first_preset_id_from_node))
+        .map(|id| id.trim().to_string())
+        .filter(|id| !id.is_empty())
+}
+
+#[cfg(target_arch = "wasm32")]
+fn extract_first_preset_id_from_node(raw: &Value) -> Option<String> {
+    if let Some(id) = raw.get("id").and_then(Value::as_str) {
+        return Some(id.to_string());
+    }
+    if let Some(id) = raw
+        .get("preset_id")
+        .and_then(Value::as_str)
+    {
+        return Some(id.to_string());
+    }
+    if let Some(id) = raw.get("uid").and_then(Value::as_str) {
+        return Some(id.to_string());
+    }
+    if let Some(id) = raw.get("name").and_then(Value::as_str) {
+        return Some(id.to_string());
+    }
+    if let Some(items) = raw.get("items").or_else(|| raw.get("presets")) {
+        return extract_first_preset_id_from_node(items);
+    }
+    if let Some(list) = raw.as_array() {
+        for item in list {
+            if let Some(id) = extract_first_preset_id_from_node(item) {
+                return Some(id);
+            }
+        }
+    }
+    if let Some(obj) = raw.as_object() {
+        for (_, value) in obj {
+            if let Some(id) = extract_first_preset_id_from_node(value) {
+                return Some(id);
+            }
+        }
+    }
+    raw.as_str().map(|raw| raw.to_string())
+}
+
+#[cfg(target_arch = "wasm32")]
+fn extract_first_preset_id_by_key(catalog: &Value, alt_key: &str) -> Option<String> {
+    catalog
+        .get(alt_key)
+        .and_then(Value::as_str)
+        .filter(|name| !name.trim().is_empty())
+        .map(|name| name.trim().to_string())
 }
 
 #[cfg(target_arch = "wasm32")]

--- a/viewer/src/render/ui.rs
+++ b/viewer/src/render/ui.rs
@@ -3,6 +3,8 @@
 use bevy::prelude::*;
 use bevy::ecs::relationship::Relationship;
 
+use crate::audio::AudioSettings;
+
 /// Marker component for UI entities spawned by the TRPG viewer.
 #[derive(Component)]
 pub struct UiMarker;
@@ -472,23 +474,30 @@ fn spawn_dev_menu(commands: &mut Commands) {
 /// (audio toggles, FPS counter, state dump, etc.).
 pub fn handle_menu_item_clicks(
     interactions: Query<
-        (&Interaction, &MenuItem),
+        (Entity, &Interaction, &MenuItem),
         (Changed<Interaction>, With<Button>),
     >,
+    children_query: Query<&Children>,
+    mut text_query: Query<&mut Text>,
+    mut audio: ResMut<AudioSettings>,
 ) {
-    for (interaction, menu_item) in &interactions {
+    for (entity, interaction, menu_item) in &interactions {
         if *interaction != Interaction::Pressed {
             continue;
         }
 
         match menu_item.0 {
             MenuAction::SoundToggle => {
-                log::info!("Menu action: Sound toggled");
-                // TODO: Connect to audio system
+                audio.sound_enabled = !audio.sound_enabled;
+                let label = if audio.sound_enabled { "Sound: ON" } else { "Sound: OFF" };
+                update_button_text(entity, label, &children_query, &mut text_query);
+                log::info!("Sound toggled: {}", audio.sound_enabled);
             }
             MenuAction::MusicToggle => {
-                log::info!("Menu action: Music toggled");
-                // TODO: Connect to audio system
+                audio.music_enabled = !audio.music_enabled;
+                let label = if audio.music_enabled { "Music: ON" } else { "Music: OFF" };
+                update_button_text(entity, label, &children_query, &mut text_query);
+                log::info!("Music toggled: {}", audio.music_enabled);
             }
             MenuAction::AutoSaveToggle => {
                 log::info!("Menu action: Auto-save toggled");
@@ -513,6 +522,23 @@ pub fn handle_menu_item_clicks(
             MenuAction::DumpState => {
                 log::info!("Menu action: Dump game state");
                 // TODO: Serialize and log current state
+            }
+        }
+    }
+}
+
+/// Walk the entity's children to find the first `Text` component and overwrite it.
+fn update_button_text(
+    button: Entity,
+    label: &str,
+    children_query: &Query<&Children>,
+    text_query: &mut Query<&mut Text>,
+) {
+    if let Ok(children) = children_query.get(button) {
+        for child in children.iter() {
+            if let Ok(mut text) = text_query.get_mut(child) {
+                *text = Text::new(label);
+                return;
             }
         }
     }


### PR DESCRIPTION
## Summary
- Merge and resolve conflicts from gh pr/226 with current viewer fixes.
- Keep non-TRPG viewer SSE routing at /sse?room=... and preserve TRPG polling constants.
- Expand TRPG room status handling and CharacterData parsing.
- Preserve claimed actor fallback and minor preset helper cleanup from 226.

## Testing
- cargo check --target wasm32-unknown-unknown -p masc-viewer
- ./scripts/viewer-trunk.sh build