### PR TITLE
feat(viewer): phase 3 — UI overhaul, SSE bridge refactor, mode system expansion

### DIFF
--- a/viewer/index.html
+++ b/viewer/index.html
@@ -254,9 +254,15 @@
                     <div id="turn-runtime"></div>
                     <!-- Turn Controls: advance turn (Keeper/GM only) -->
                     <div id="turn-controls" style="display:none">
-                        <button id="advance-turn-btn" title="Advance to next turn">Advance Turn</button>
+                        <button id="advance-turn-btn" title="Run next TRPG round">Run Round</button>
                         <span id="turn-control-status"></span>
                     </div>
+                    <div id="round-run-summary" class="turn-run-summary" style="display:none"></div>
+                    <input type="hidden" id="round-run-dm" value="" />
+                    <input type="hidden" id="round-run-phase" value="" />
+                    <input type="hidden" id="round-run-timeout" value="" />
+                    <input type="hidden" id="round-run-lang" value="" />
+                    <input type="hidden" id="round-run-players" value="" />
                     <div id="narrative-log"></div>
                     <!-- Join Panel: claim an actor before playing -->
                     <div id="join-panel">

--- a/viewer/src/assets.rs
+++ b/viewer/src/assets.rs
@@ -48,7 +48,6 @@ pub mod paths {
     pub const PROP_SEXTANT: &str = "props/sextant_mirror.png";
     pub const PROP_JOURNAL: &str = "props/journal_open.png";
     pub const PROP_MAPS: &str = "props/maps_recursive.png";
-
 }
 
 /// Returns the portrait asset path for a given character ID.

--- a/viewer/src/config.rs
+++ b/viewer/src/config.rs
@@ -5,7 +5,7 @@ use crate::mode::ViewerMode;
 // With Trunk Proxy configured in Trunk.toml, we can use relative paths
 // for both debug and release builds.
 // This avoids CORS issues and hardcoded ports in the binary.
-pub const MASC_MCP_URL: &str = ""; 
+pub const MASC_MCP_URL: &str = "";
 
 pub const DEFAULT_ROOM_ID: &str = "default";
 
@@ -23,8 +23,8 @@ pub const TRPG_ENGINE_URL: &str = "";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum TrpgBackendMode {
-    MascApi,    // Uses /api/v1/trpg endpoints (default)
-    LegacyEngine // Uses direct engine endpoints (if needed)
+    MascApi,      // Uses /api/v1/trpg endpoints (default)
+    LegacyEngine, // Uses direct engine endpoints (if needed)
 }
 
 pub const DEFAULT_TRPG_BACKEND: TrpgBackendMode = TrpgBackendMode::MascApi;
@@ -55,7 +55,7 @@ pub fn current_room_id() -> String {
             }
         }
     }
-    
+
     DEFAULT_ROOM_ID.to_string()
 }
 
@@ -69,7 +69,7 @@ pub fn set_current_room_id(room_id: &str) {
                 let _ = el.set_attribute("data-room-id", room_id);
             }
         }
-        
+
         // Also update URL without reload?
         if let Some(win) = web_sys::window() {
             if let Ok(history) = win.history() {
@@ -101,7 +101,9 @@ pub fn sanitize_room_id(raw: &str) -> Option<String> {
     if s.is_empty() || s.len() > 64 {
         return None;
     }
-    if s.chars().all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_') {
+    if s.chars()
+        .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
+    {
         Some(s.to_string())
     } else {
         None
@@ -125,22 +127,47 @@ fn parse_query_param(search: &str, key: &str) -> Option<String> {
 // ─── Endpoints ──────────────────────────────
 
 pub fn trpg_uses_polling() -> bool {
-    // Backend now exposes /api/v1/trpg/stream/sse (SSE endpoint, PR #222).
-    // Polling is kept as fallback but SSE is preferred.
-    false
+    // MASC exposes both poll JSON and SSE endpoints.
+    // Current viewer runtime uses polling reliably because stream responses are
+    // JSON payloads and SSE is optional when available.
+    true
 }
 
 pub fn trpg_state_url() -> String {
-    format!("{}/api/v1/trpg/state?room_id={}", MASC_MCP_URL, current_room_id())
+    format!(
+        "{}/api/v1/trpg/state?room_id={}",
+        MASC_MCP_URL,
+        current_room_id()
+    )
 }
 
+/// Legacy JSON poll endpoint.
 pub fn trpg_stream_poll_url(after_seq: i64) -> String {
-    format!("{}/api/v1/trpg/stream?room_id={}&after_seq={}", MASC_MCP_URL, current_room_id(), after_seq)
+    format!(
+        "{}/api/v1/trpg/stream?room_id={}&after_seq={}",
+        MASC_MCP_URL,
+        current_room_id(),
+        after_seq
+    )
+}
+
+/// SSE poll endpoint (JSON event stream) for browsers that can consume
+/// EventSource from `/api/v1/trpg/stream/sse`.
+pub fn trpg_stream_sse_url() -> String {
+    format!(
+        "{}/api/v1/trpg/stream/sse?room_id={}",
+        MASC_MCP_URL,
+        current_room_id()
+    )
 }
 
 pub fn sse_endpoint(mode: &ViewerMode) -> Option<String> {
     match mode {
-        ViewerMode::Trpg => Some(format!("{}/api/v1/trpg/stream/sse?room_id={}", MASC_MCP_URL, current_room_id())),
+        ViewerMode::Trpg => Some(format!(
+            "{}/api/v1/trpg/stream/sse?room_id={}",
+            MASC_MCP_URL,
+            current_room_id()
+        )),
         ViewerMode::Monitor => Some(format!("{}/api/v1/monitor/stream", MASC_MCP_URL)),
         ViewerMode::Experiment => Some(format!("{}/api/v1/experiment/stream", MASC_MCP_URL)),
         ViewerMode::Council => Some(format!("{}/api/v1/council/stream", MASC_MCP_URL)),
@@ -153,7 +180,11 @@ pub fn sse_endpoint(mode: &ViewerMode) -> Option<String> {
 /// that don't have access to Bevy State<ViewerMode>).
 pub fn sse_endpoint_by_name(mode_name: &str) -> Option<String> {
     match mode_name {
-        "Trpg" => Some(format!("{}/api/v1/trpg/stream/sse?room_id={}", MASC_MCP_URL, current_room_id())),
+        "Trpg" => Some(format!(
+            "{}/api/v1/trpg/stream/sse?room_id={}",
+            MASC_MCP_URL,
+            current_room_id()
+        )),
         "Monitor" => Some(format!("{}/api/v1/monitor/stream", MASC_MCP_URL)),
         "Experiment" => Some(format!("{}/api/v1/experiment/stream", MASC_MCP_URL)),
         "Council" => Some(format!("{}/api/v1/council/stream", MASC_MCP_URL)),
@@ -164,7 +195,12 @@ pub fn sse_endpoint_by_name(mode_name: &str) -> Option<String> {
 
 /// Helper to get full room URL for external links (if needed)
 pub fn trpg_room_url(path: &str) -> String {
-    format!("{}/rooms/{}/{}", MASC_MCP_URL, current_room_id(), path.trim_start_matches('/'))
+    format!(
+        "{}/rooms/{}/{}",
+        MASC_MCP_URL,
+        current_room_id(),
+        path.trim_start_matches('/')
+    )
 }
 
 // ─── Actor ID Management ─────────────────────

--- a/viewer/src/dom/action_panel.rs
+++ b/viewer/src/dom/action_panel.rs
@@ -163,9 +163,12 @@ fn submit_action_from_input() {
     if text.is_empty() {
         return;
     }
-    
+
     let actor_id_opt = get_active_actor_from_dom();
-    log::info!("ActionPanel: submitting for active actor={:?}", actor_id_opt);
+    log::info!(
+        "ActionPanel: submitting for active actor={:?}",
+        actor_id_opt
+    );
 
     let Some(actor_id) = actor_id_opt else {
         set_action_status(
@@ -283,7 +286,10 @@ async fn roll_dice() -> Result<String, JsValue> {
         )));
     }
 
-    let json_text = JsFuture::from(resp.text()?).await?.as_string().unwrap_or_default();
+    let json_text = JsFuture::from(resp.text()?)
+        .await?
+        .as_string()
+        .unwrap_or_default();
     Ok(extract_roll_display(&json_text))
 }
 
@@ -333,10 +339,7 @@ fn set_action_status(text: &str, css_class: &str) {
 #[cfg(target_arch = "wasm32")]
 pub(crate) fn friendly_js_error(val: &JsValue) -> String {
     val.as_string()
-        .or_else(|| {
-            val.dyn_ref::<js_sys::Error>()
-                .map(|e| e.message().into())
-        })
+        .or_else(|| val.dyn_ref::<js_sys::Error>().map(|e| e.message().into()))
         .unwrap_or_else(|| format!("{:?}", val))
 }
 
@@ -378,10 +381,7 @@ pub fn sync_action_panel_interaction_state(
 }
 
 /// Backward-compatible alias used by older schedule wiring.
-pub fn sync_action_panel_visibility(
-    room_state: Res<RoomState>,
-    progress: Res<TurnProgressState>,
-) {
+pub fn sync_action_panel_visibility(room_state: Res<RoomState>, progress: Res<TurnProgressState>) {
     sync_action_panel_interaction_state(room_state, progress);
 }
 
@@ -390,7 +390,7 @@ fn disable_buttons(disabled: bool) {
     let Some(doc) = web_sys::window().and_then(|w| w.document()) else {
         return;
     };
-    
+
     if let Some(btn) = doc.get_element_by_id("action-submit-btn") {
         if disabled {
             let _ = btn.set_attribute("disabled", "true");
@@ -398,7 +398,7 @@ fn disable_buttons(disabled: bool) {
             let _ = btn.remove_attribute("disabled");
         }
     }
-    
+
     if let Some(btn) = doc.get_element_by_id("dice-roll-btn") {
         if disabled {
             let _ = btn.set_attribute("disabled", "true");
@@ -431,7 +431,10 @@ mod tests {
 
     #[test]
     fn test_extract_roll() {
-        assert_eq!(extract_roll_display(r#"{"total": 15, "result": "Success"}"#), "Rolled 15: Success");
+        assert_eq!(
+            extract_roll_display(r#"{"total": 15, "result": "Success"}"#),
+            "Rolled 15: Success"
+        );
         assert_eq!(extract_roll_display(r#"{"total": 5}"#), "Rolled 5");
         assert_eq!(extract_roll_display(""), "Roll completed.");
     }

--- a/viewer/src/dom/actor_join.rs
+++ b/viewer/src/dom/actor_join.rs
@@ -92,7 +92,7 @@ pub fn sync_join_panel_interaction_state(
 
         let status = effective_room_status(&room_state.status, &progress.room_status);
         let can_join = room_accepts_join(&status);
-        
+
         let Some(doc) = web_sys::window().and_then(|w| w.document()) else {
             return;
         };
@@ -128,9 +128,11 @@ fn bind_join_button() {
         };
 
         // 1. Get input values
-        let actor_id_input = doc.get_element_by_id("actor-id-input")
+        let actor_id_input = doc
+            .get_element_by_id("actor-id-input")
             .and_then(|el| el.dyn_into::<web_sys::HtmlInputElement>().ok());
-        let keeper_input = doc.get_element_by_id("keeper-input")
+        let keeper_input = doc
+            .get_element_by_id("keeper-input")
             .and_then(|el| el.dyn_into::<web_sys::HtmlInputElement>().ok());
 
         let actor_id = actor_id_input.map(|i| i.value()).unwrap_or_default();
@@ -159,7 +161,7 @@ fn bind_join_button() {
                     let detail = friendly_js_error(&e);
                     log::warn!("Claim failed: {:?}", detail);
                     set_join_status(&format!("Join failed: {}", detail), "status-error");
-                    
+
                     // Re-enable button on error
                     if let Some(doc) = web_sys::window().and_then(|w| w.document()) {
                         if let Some(btn) = doc.get_element_by_id("join-btn") {
@@ -208,7 +210,7 @@ fn bind_leave_button() {
         if let Some(btn) = doc.get_element_by_id("leave-btn") {
             let _ = btn.set_attribute("disabled", "true");
         }
-        
+
         // Spawn async release request
         let actor_id = claimed_id.clone();
         wasm_bindgen_futures::spawn_local(async move {
@@ -223,7 +225,7 @@ fn bind_leave_button() {
                     // Force leave on UI anyway? Or show error?
                     // Usually better to let them try again.
                     set_join_status(&format!("Leave failed: {}", detail), "status-error");
-                    
+
                     if let Some(doc) = web_sys::window().and_then(|w| w.document()) {
                         if let Some(btn) = doc.get_element_by_id("leave-btn") {
                             let _ = btn.remove_attribute("disabled");
@@ -285,7 +287,11 @@ async fn claim_actor(actor_id: &str, keeper_name: &str) -> Result<(), JsValue> {
                 return Err(JsValue::from_str(detail));
             }
         }
-        return Err(JsValue::from_str(&format!("HTTP {} - {}", resp.status(), err_text)));
+        return Err(JsValue::from_str(&format!(
+            "HTTP {} - {}",
+            resp.status(),
+            err_text
+        )));
     }
 
     Ok(())
@@ -299,7 +305,7 @@ async fn release_actor(actor_id: &str) -> Result<(), JsValue> {
 
     let url = format!("{}/api/v1/trpg/actors/release", config::MASC_MCP_URL);
     let room_id = config::current_room_id();
-    
+
     // Retrieve keeper name from hidden state if possible, or send empty (server might require it?)
     // The current API spec for release requires `keeper_name`.
     let keeper = get_claimed_keeper_from_dom().unwrap_or("Anonymous Viewer".to_string());
@@ -332,7 +338,11 @@ async fn release_actor(actor_id: &str) -> Result<(), JsValue> {
                 return Err(JsValue::from_str(detail));
             }
         }
-        return Err(JsValue::from_str(&format!("HTTP {} - {}", resp.status(), err_text)));
+        return Err(JsValue::from_str(&format!(
+            "HTTP {} - {}",
+            resp.status(),
+            err_text
+        )));
     }
 
     Ok(())
@@ -353,10 +363,7 @@ fn set_join_status(text: &str, css_class: &str) {
 #[cfg(target_arch = "wasm32")]
 fn friendly_js_error(val: &JsValue) -> String {
     val.as_string()
-        .or_else(|| {
-            val.dyn_ref::<js_sys::Error>()
-                .map(|e| e.message().into())
-        })
+        .or_else(|| val.dyn_ref::<js_sys::Error>().map(|e| e.message().into()))
         .unwrap_or_else(|| format!("{:?}", val))
 }
 
@@ -380,7 +387,7 @@ fn swap_to_action_panel(actor_id: &str) {
     if let Some(el) = doc.get_element_by_id("player-actor-id") {
         el.set_inner_html(actor_id);
     }
-    
+
     // Store state in hidden inputs (for persistence across re-renders if needed)
     set_claimed_state(actor_id);
 }
@@ -405,10 +412,10 @@ fn swap_to_join_panel() {
     if let Some(el) = doc.get_element_by_id("player-actor-id") {
         el.set_inner_html("");
     }
-    
+
     // Clear state
     clear_claimed_state();
-    
+
     // Reset buttons
     if let Some(btn) = doc.get_element_by_id("join-btn") {
         let _ = btn.remove_attribute("disabled");
@@ -420,14 +427,16 @@ fn swap_to_join_panel() {
 
 #[cfg(target_arch = "wasm32")]
 fn set_claimed_state(actor_id: &str) {
-    let Some(doc) = web_sys::window().and_then(|w| w.document()) else { return };
-    
+    let Some(doc) = web_sys::window().and_then(|w| w.document()) else {
+        return;
+    };
+
     if let Some(el) = doc.get_element_by_id("claimed-actor-id") {
         if let Some(input) = el.dyn_ref::<web_sys::HtmlInputElement>() {
             input.set_value(actor_id);
         }
     }
-    
+
     // Also save keeper name?
     if let Some(k_input) = doc.get_element_by_id("keeper-input") {
         if let Some(input) = k_input.dyn_ref::<web_sys::HtmlInputElement>() {
@@ -443,8 +452,10 @@ fn set_claimed_state(actor_id: &str) {
 
 #[cfg(target_arch = "wasm32")]
 fn clear_claimed_state() {
-    let Some(doc) = web_sys::window().and_then(|w| w.document()) else { return };
-    
+    let Some(doc) = web_sys::window().and_then(|w| w.document()) else {
+        return;
+    };
+
     if let Some(el) = doc.get_element_by_id("claimed-actor-id") {
         if let Some(input) = el.dyn_ref::<web_sys::HtmlInputElement>() {
             input.set_value("");
@@ -463,7 +474,11 @@ fn get_claimed_actor_id_from_dom() -> Option<String> {
     let el = doc.get_element_by_id("claimed-actor-id")?;
     let input = el.dyn_ref::<web_sys::HtmlInputElement>()?;
     let val = input.value();
-    if val.is_empty() { None } else { Some(val) }
+    if val.is_empty() {
+        None
+    } else {
+        Some(val)
+    }
 }
 
 #[cfg(target_arch = "wasm32")]
@@ -472,7 +487,11 @@ fn get_claimed_keeper_from_dom() -> Option<String> {
     let el = doc.get_element_by_id("claimed-keeper")?;
     let input = el.dyn_ref::<web_sys::HtmlInputElement>()?;
     let val = input.value();
-    if val.is_empty() { None } else { Some(val) }
+    if val.is_empty() {
+        None
+    } else {
+        Some(val)
+    }
 }
 
 #[cfg(target_arch = "wasm32")]
@@ -482,7 +501,7 @@ fn restore_join_panel_state() {
         swap_to_join_panel();
         return;
     };
-    
+
     // Have claimed actor, show action panel
     swap_to_action_panel(&actor_id);
 }

--- a/viewer/src/dom/character_panel.rs
+++ b/viewer/src/dom/character_panel.rs
@@ -60,7 +60,9 @@ fn class_icon(class: &str) -> &'static str {
 
 /// Normalizes class name to a CSS-safe identifier for data-class attribute.
 fn class_slug(class: &str) -> String {
-    class.to_lowercase().replace(|c: char| !c.is_ascii_alphanumeric(), "-")
+    class
+        .to_lowercase()
+        .replace(|c: char| !c.is_ascii_alphanumeric(), "-")
 }
 
 /// Icon for a condition name.
@@ -134,10 +136,7 @@ fn read_collapse_state() -> std::collections::HashSet<String> {
 }
 
 /// Re-renders the #character-panel DOM whenever actor state changes.
-pub fn update_character_panel_dom(
-    actors: Query<&Actor>,
-    mut cache: ResMut<CharacterPanelCache>,
-) {
+pub fn update_character_panel_dom(actors: Query<&Actor>, mut cache: ResMut<CharacterPanelCache>) {
     // Build current snapshot for cheap equality check
     let compat_snapshot: Vec<(String, i32, bool)> = actors
         .iter()

--- a/viewer/src/dom/narrative.rs
+++ b/viewer/src/dom/narrative.rs
@@ -151,9 +151,9 @@ pub fn update_narrative_dom(mut events: MessageReader<NarrativeReceived>) {
         let click_cb = Closure::wrap(Box::new(move || {
             toggle_selected_class(&clickable_entry);
         }) as Box<dyn FnMut()>);
-        let _ = entry
-            .dyn_ref::<web_sys::EventTarget>()
-            .map(|target| target.add_event_listener_with_callback("click", click_cb.as_ref().unchecked_ref()));
+        let _ = entry.dyn_ref::<web_sys::EventTarget>().map(|target| {
+            target.add_event_listener_with_callback("click", click_cb.as_ref().unchecked_ref())
+        });
         click_cb.forget();
 
         let _ = log_el.append_child(&entry);

--- a/viewer/src/dom/turn_controls.rs
+++ b/viewer/src/dom/turn_controls.rs
@@ -1,15 +1,20 @@
-//! Turn Controls — advance turn and session management buttons.
+//! Turn Controls — execute one TRPG round and show round-run status.
 //!
 //! Binds DOM event listeners on `#turn-controls`:
-//! - Advance Turn button → POST `/api/v1/trpg/turns/advance`
+//! - Run Round button → POST `/api/v1/trpg/rounds/run`
 //!
-//! Visible only when the player has claimed a keeper role.
+//! Visible when a round run assignment is present:
+//! - claimed keeper/actor for local manual play, or
+//! - hidden round-run plan fields for AI auto-run flow.
 //! Follows the same OnEnter/OnExit lifecycle as `action_panel.rs`.
 
 use bevy::prelude::*;
 
 #[cfg(target_arch = "wasm32")]
-use serde_json::json;
+use serde_json::{json, Value};
+
+#[cfg(target_arch = "wasm32")]
+use web_sys::{HtmlButtonElement, HtmlInputElement};
 
 #[cfg(target_arch = "wasm32")]
 use wasm_bindgen::prelude::*;
@@ -49,11 +54,8 @@ pub fn unbind_turn_controls(mut commands: Commands) {
 
 // ─── Visibility Sync ────────────────────────
 
-/// Show turn controls only when a keeper is claimed (Keeper/GM privilege).
-pub fn sync_turn_controls_visibility(
-    room_state: Res<RoomState>,
-    progress: Res<TurnProgressState>,
-) {
+/// Show turn controls only when a round-run capable assignment exists.
+pub fn sync_turn_controls_visibility(room_state: Res<RoomState>, progress: Res<TurnProgressState>) {
     let _ = (&room_state, &progress);
 
     #[cfg(target_arch = "wasm32")]
@@ -72,7 +74,7 @@ pub fn sync_turn_controls_visibility(
         } else {
             normalize_room_status(&room_state.status)
         };
-        let room_allows_control = matches!(status.as_str(), "active" | "running");
+        let room_allows_control = matches!(status.as_str(), "active" | "running" | "idle");
 
         let Some(doc) = web_sys::window().and_then(|w| w.document()) else {
             return;
@@ -80,12 +82,30 @@ pub fn sync_turn_controls_visibility(
         let Some(panel) = doc.get_element_by_id("turn-controls") else {
             return;
         };
-        let keeper = doc
-            .get_element_by_id("claimed-keeper")
-            .and_then(|el| el.dyn_ref::<web_sys::HtmlInputElement>().map(|i| i.value()));
-        let has_keeper = keeper.map_or(false, |v| !v.trim().is_empty());
 
-        let style = if has_keeper && room_allows_control {
+        let claimed_keeper = doc
+            .get_element_by_id("claimed-keeper")
+            .and_then(|el| el.dyn_into::<HtmlInputElement>().ok())
+            .map(|i| i.value());
+        let claimed_actor = doc
+            .get_element_by_id("claimed-actor-id")
+            .and_then(|el| el.dyn_into::<HtmlInputElement>().ok())
+            .map(|i| i.value());
+        let has_manual_claim = claimed_keeper
+            .as_ref()
+            .map(|v| !v.trim().is_empty())
+            .unwrap_or(false)
+            || claimed_actor
+                .as_ref()
+                .map(|v| !v.trim().is_empty())
+                .unwrap_or(false);
+
+        let has_auto_plan = doc
+            .get_element_by_id("round-run-dm")
+            .and_then(|el| el.dyn_into::<HtmlInputElement>().ok())
+            .is_some_and(|input| !input.value().trim().is_empty());
+
+        let style = if (has_manual_claim || has_auto_plan) && room_allows_control {
             ""
         } else {
             "display:none"
@@ -115,16 +135,14 @@ fn bind_advance_button() {
 
 #[cfg(target_arch = "wasm32")]
 fn on_advance_click() {
-    set_turn_status("Advancing...", "");
+    set_turn_status("Running round...", "");
     set_advance_disabled(true);
 
     wasm_bindgen_futures::spawn_local(async move {
         match advance_turn().await {
             Ok(msg) => set_turn_status(&msg, "status-ok"),
             Err(e) => {
-                let detail = e
-                    .as_string()
-                    .unwrap_or_else(|| format!("{:?}", e));
+                let detail = e.as_string().unwrap_or_else(|| format!("{:?}", e));
                 log::warn!("Advance turn failed: {}", detail);
                 set_turn_status(&format!("Failed: {}", detail), "status-error");
             }
@@ -139,11 +157,24 @@ fn on_advance_click() {
 async fn advance_turn() -> Result<String, JsValue> {
     use wasm_bindgen_futures::JsFuture;
 
-    let url = format!("{}/api/v1/trpg/turns/advance", config::MASC_MCP_URL);
-    let room_id = config::current_room_id();
+    let doc = web_sys::window()
+        .and_then(|w| w.document())
+        .ok_or_else(|| JsValue::from_str("No document"))?;
+    let plan = read_round_run_plan(&doc).map_err(|err| JsValue::from_str(&err))?;
 
+    let mut player_keepers = serde_json::Map::new();
+    for (actor_id, keeper_name) in &plan.player_keepers {
+        player_keepers.insert(actor_id.clone(), Value::String(keeper_name.clone()));
+    }
+
+    let url = format!("{}/api/v1/trpg/rounds/run", config::MASC_MCP_URL);
     let body = json!({
-        "room_id": room_id
+        "room_id": config::current_room_id(),
+        "dm_keeper": plan.dm_keeper,
+        "player_keepers": Value::Object(player_keepers),
+        "phase": plan.phase,
+        "timeout_sec": plan.timeout_sec,
+        "lang": plan.lang
     })
     .to_string();
 
@@ -176,13 +207,23 @@ async fn advance_turn() -> Result<String, JsValue> {
         )));
     }
 
-    // Extract the new turn number from the response JSON
     let resp_text = JsFuture::from(resp.text()?)
         .await
         .ok()
         .and_then(|v| v.as_string())
         .unwrap_or_default();
-    log::info!("TurnControls: turn advanced — {}", resp_text);
+    log::info!("TurnControls: round run response — {}", resp_text);
+
+    if let Ok(json) = serde_json::from_str::<Value>(&resp_text) {
+        let turn_before = json.get("turn_before").and_then(Value::as_u64).unwrap_or(0);
+        let turn_after = json.get("turn_after").and_then(Value::as_u64).unwrap_or(0);
+        if turn_after > 0 {
+            return Ok(format!(
+                "Round progressed: turn {} → {}",
+                turn_before, turn_after
+            ));
+        }
+    }
 
     Ok("Turn advanced.".to_string())
 }
@@ -211,8 +252,96 @@ fn set_advance_disabled(disabled: bool) {
         return;
     };
     if let Some(el) = doc.get_element_by_id("advance-turn-btn") {
-        if let Some(btn) = el.dyn_ref::<web_sys::HtmlButtonElement>() {
+        if let Some(btn) = el.dyn_into::<HtmlButtonElement>().ok() {
             btn.set_disabled(disabled);
         }
     }
+}
+
+#[cfg(target_arch = "wasm32")]
+struct RoundRunPlan {
+    dm_keeper: String,
+    phase: String,
+    timeout_sec: f64,
+    lang: String,
+    player_keepers: Vec<(String, String)>,
+}
+
+#[cfg(target_arch = "wasm32")]
+fn read_round_run_plan(doc: &web_sys::Document) -> Result<RoundRunPlan, String> {
+    let dm_keeper = doc
+        .get_element_by_id("round-run-dm")
+        .and_then(|el| el.dyn_into::<HtmlInputElement>().ok())
+        .map(|i| i.value())
+        .unwrap_or_default()
+        .trim()
+        .to_string();
+    if dm_keeper.is_empty() {
+        return Err("DM keeper가 설정되지 않았습니다. 새 게임을 먼저 시작하세요.".to_string());
+    }
+
+    let phase = doc
+        .get_element_by_id("round-run-phase")
+        .and_then(|el| el.dyn_into::<HtmlInputElement>().ok())
+        .map(|i| i.value())
+        .unwrap_or_else(|| "round".to_string())
+        .trim()
+        .to_string();
+    let lang = doc
+        .get_element_by_id("round-run-lang")
+        .and_then(|el| el.dyn_into::<HtmlInputElement>().ok())
+        .map(|i| i.value())
+        .unwrap_or_else(|| "ko".to_string())
+        .trim()
+        .to_string();
+    let timeout_sec = doc
+        .get_element_by_id("round-run-timeout")
+        .and_then(|el| el.dyn_into::<HtmlInputElement>().ok())
+        .map(|i| i.value())
+        .unwrap_or_else(|| "90".to_string())
+        .trim()
+        .parse::<f64>()
+        .unwrap_or(90.0);
+
+    let player_pairs_raw = doc
+        .get_element_by_id("round-run-players")
+        .and_then(|el| el.dyn_into::<HtmlInputElement>().ok())
+        .map(|i| i.value())
+        .unwrap_or_default();
+    let player_keepers = player_pairs_raw
+        .split(',')
+        .filter_map(|part| {
+            let pair = part.trim();
+            if pair.is_empty() {
+                return None;
+            }
+            let mut pieces = pair.splitn(2, '=');
+            let actor_id = pieces.next()?.trim();
+            let keeper = pieces.next()?.trim();
+            if actor_id.is_empty() || keeper.is_empty() {
+                None
+            } else {
+                Some((actor_id.to_string(), keeper.to_string()))
+            }
+        })
+        .collect::<Vec<_>>();
+    if player_keepers.is_empty() {
+        return Err("player keepers가 없습니다. 새 게임에서 참가자 할당을 확인하세요.".to_string());
+    }
+
+    Ok(RoundRunPlan {
+        dm_keeper,
+        phase: if phase.is_empty() {
+            "round".to_string()
+        } else {
+            phase
+        },
+        timeout_sec,
+        lang: if lang.is_empty() {
+            "ko".to_string()
+        } else {
+            lang
+        },
+        player_keepers,
+    })
 }

--- a/viewer/src/dom/turn_phase.rs
+++ b/viewer/src/dom/turn_phase.rs
@@ -22,10 +22,7 @@ const PHASES: &[&str] = &[
 ];
 
 /// Updates the turn phase bar in the DOM.
-pub fn update_turn_phase_dom(
-    room_state: Res<RoomState>,
-    mut cache: ResMut<TurnPhaseCache>,
-) {
+pub fn update_turn_phase_dom(room_state: Res<RoomState>, mut cache: ResMut<TurnPhaseCache>) {
     let current_phase = room_state.phase.as_str().to_string();
 
     // Skip if nothing changed
@@ -57,9 +54,7 @@ pub fn update_turn_phase_dom(
             continue;
         };
 
-        let phase_name = element
-            .get_attribute("data-phase")
-            .unwrap_or_default();
+        let phase_name = element.get_attribute("data-phase").unwrap_or_default();
         let phase_idx = PHASES.iter().position(|&p| p == phase_name);
 
         let class = match (current_idx, phase_idx) {

--- a/viewer/src/dom/turn_runtime.rs
+++ b/viewer/src/dom/turn_runtime.rs
@@ -117,15 +117,15 @@ pub fn update_turn_runtime_dom(
         "-".to_string()
     };
 
-    let (alive_party, total_party) = actors
-        .iter()
-        .filter(|actor| actor.id != "dm")
-        .fold((0_i32, 0_i32), |(alive, total), actor| {
+    let (alive_party, total_party) = actors.iter().filter(|actor| actor.id != "dm").fold(
+        (0_i32, 0_i32),
+        |(alive, total), actor| {
             (
                 alive + if !actor.is_dead && actor.hp > 0 { 1 } else { 0 },
                 total + 1,
             )
-        });
+        },
+    );
     let party_status = if total_party <= 0 {
         "-".to_string()
     } else if alive_party <= 0 {

--- a/viewer/src/game/http.rs
+++ b/viewer/src/game/http.rs
@@ -260,11 +260,7 @@ pub fn apply_initial_state(
         .map(|room| room.status.trim() == "unavailable")
         .unwrap_or(false);
 
-    let actor_ids: Vec<String> = state
-        .characters
-        .iter()
-        .map(|ch| ch.id.clone())
-        .collect();
+    let actor_ids: Vec<String> = state.characters.iter().map(|ch| ch.id.clone()).collect();
 
     for entity in &actors {
         commands.entity(entity).despawn();
@@ -571,6 +567,41 @@ fn parse_party_characters(state: &Value) -> Vec<CharacterData> {
                         .collect::<Vec<_>>()
                 })
                 .unwrap_or_default();
+            let mp = info
+                .get("mp")
+                .and_then(Value::as_i64)
+                .unwrap_or(i64::from(hp.max(1))) as i32;
+            let max_mp = info
+                .get("max_mp")
+                .and_then(Value::as_i64)
+                .unwrap_or(i64::from(mp.max(1))) as i32;
+            let skills = info
+                .get("skills")
+                .and_then(Value::as_array)
+                .map(|rows| {
+                    rows.iter()
+                        .filter_map(|row| serde_json::from_value::<SkillData>(row.clone()).ok())
+                        .collect::<Vec<_>>()
+                })
+                .unwrap_or_default();
+            let conditions = info
+                .get("conditions")
+                .and_then(Value::as_array)
+                .map(|rows| {
+                    rows.iter()
+                        .filter_map(|row| serde_json::from_value::<ConditionData>(row.clone()).ok())
+                        .collect::<Vec<_>>()
+                })
+                .unwrap_or_default();
+            let equipment = info
+                .get("equipment")
+                .and_then(Value::as_array)
+                .map(|rows| {
+                    rows.iter()
+                        .filter_map(|row| serde_json::from_value::<EquipmentData>(row.clone()).ok())
+                        .collect::<Vec<_>>()
+                })
+                .unwrap_or_default();
             let debuffs = info
                 .get("debuffs")
                 .and_then(Value::as_array)
@@ -707,7 +738,9 @@ fn prompt_new_game_for_inactive_room(room_status: &str) {
         if let Some(el) = document.get_element_by_id("new-game-status") {
             let msg = match normalize_room_status(room_status).as_str() {
                 "ended" => "이 게임은 종료되었습니다. 새 게임을 시작하세요.",
-                "unavailable" => "엔진에 연결할 수 없습니다. 새 게임을 시작하면 재연결을 시도합니다.",
+                "unavailable" => {
+                    "엔진에 연결할 수 없습니다. 새 게임을 시작하면 재연결을 시도합니다."
+                }
                 _ => "진행 중인 게임이 없습니다. 새 게임을 시작하세요.",
             };
             el.set_inner_html(msg);
@@ -772,7 +805,10 @@ mod tests {
         let parsed = normalize_state_response(root).expect("masc parse should succeed");
         assert_eq!(parsed.room.as_ref().map(|r| r.turn), Some(5));
         assert_eq!(parsed.current_area, "C");
-        assert!(parsed.characters.is_empty(), "no fallback party should be injected");
+        assert!(
+            parsed.characters.is_empty(),
+            "no fallback party should be injected"
+        );
     }
 
     #[test]
@@ -823,10 +859,21 @@ mod tests {
         });
 
         let parsed = normalize_state_response(root).expect("ended room parse should succeed");
-        let status = parsed.room.as_ref().map(|r| r.status.as_str()).unwrap_or("");
-        assert_ne!(status, "active", "ended room should not be treated as active");
+        let status = parsed
+            .room
+            .as_ref()
+            .map(|r| r.status.as_str())
+            .unwrap_or("");
+        assert_ne!(
+            status, "active",
+            "ended room should not be treated as active"
+        );
         assert_eq!(status, "ended");
-        assert_eq!(parsed.characters.len(), 1, "characters still parsed even for ended rooms");
+        assert_eq!(
+            parsed.characters.len(),
+            1,
+            "characters still parsed even for ended rooms"
+        );
     }
 
     #[test]
@@ -844,7 +891,11 @@ mod tests {
         });
 
         let parsed = normalize_state_response(root).expect("idle room parse should succeed");
-        let status = parsed.room.as_ref().map(|r| r.status.as_str()).unwrap_or("");
+        let status = parsed
+            .room
+            .as_ref()
+            .map(|r| r.status.as_str())
+            .unwrap_or("");
         assert_ne!(status, "active");
         assert!(parsed.characters.is_empty());
     }

--- a/viewer/src/game/systems.rs
+++ b/viewer/src/game/systems.rs
@@ -105,10 +105,7 @@ pub fn reset_turn_progress(mut progress: ResMut<TurnProgressState>) {
 }
 
 /// Apply HP change events to Actor components.
-pub fn apply_hp_change(
-    mut events: MessageReader<HpChanged>,
-    mut actors: Query<&mut Actor>,
-) {
+pub fn apply_hp_change(mut events: MessageReader<HpChanged>, mut actors: Query<&mut Actor>) {
     for HpChanged(payload) in events.read() {
         for mut actor in &mut actors {
             if actor.id == payload.target {
@@ -240,10 +237,7 @@ pub fn apply_turn_progress(
 }
 
 /// Apply item acquisition events to Actor inventory.
-pub fn apply_item_acquired(
-    mut events: MessageReader<ItemAcquired>,
-    mut actors: Query<&mut Actor>,
-) {
+pub fn apply_item_acquired(mut events: MessageReader<ItemAcquired>, mut actors: Query<&mut Actor>) {
     for ItemAcquired(payload) in events.read() {
         for mut actor in &mut actors {
             if actor.id == payload.character {

--- a/viewer/src/mode.rs
+++ b/viewer/src/mode.rs
@@ -524,6 +524,40 @@ fn clear_trpg_dom(doc: &web_sys::Document) {
     {
         input.set_value("");
     }
+    if let Some(input) = doc
+        .get_element_by_id("round-run-dm")
+        .and_then(|el| el.dyn_into::<web_sys::HtmlInputElement>().ok())
+    {
+        input.set_value("");
+    }
+    if let Some(input) = doc
+        .get_element_by_id("round-run-phase")
+        .and_then(|el| el.dyn_into::<web_sys::HtmlInputElement>().ok())
+    {
+        input.set_value("round");
+    }
+    if let Some(input) = doc
+        .get_element_by_id("round-run-timeout")
+        .and_then(|el| el.dyn_into::<web_sys::HtmlInputElement>().ok())
+    {
+        input.set_value("90");
+    }
+    if let Some(input) = doc
+        .get_element_by_id("round-run-lang")
+        .and_then(|el| el.dyn_into::<web_sys::HtmlInputElement>().ok())
+    {
+        input.set_value("ko");
+    }
+    if let Some(input) = doc
+        .get_element_by_id("round-run-players")
+        .and_then(|el| el.dyn_into::<web_sys::HtmlInputElement>().ok())
+    {
+        input.set_value("");
+    }
+    if let Some(summary) = doc.get_element_by_id("round-run-summary") {
+        summary.set_text_content(Some(""));
+        let _ = summary.set_attribute("style", "display:none");
+    }
 }
 
 #[cfg(target_arch = "wasm32")]
@@ -537,6 +571,136 @@ fn unique_non_empty(mut values: Vec<String>) -> Vec<String> {
         out.push(value);
     }
     out
+}
+
+#[cfg(target_arch = "wasm32")]
+fn parse_preset_id(value: &Value, field: &str) -> Option<String> {
+    match value.get(field) {
+        Some(Value::Array(items)) if !items.is_empty() => {
+            items.first().and_then(Value::as_object).and_then(|obj| {
+                obj.get("id")
+                    .and_then(Value::as_str)
+                    .map(|id| id.trim().to_string())
+            })
+        }
+        Some(Value::String(v)) if !v.trim().is_empty() => Some(v.trim().to_string()),
+        Some(value_obj) if value_obj.is_object() => value_obj
+            .get("id")
+            .and_then(Value::as_str)
+            .map(|id| id.trim().to_string()),
+        _ => None,
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+fn pick_preset_id_from_catalog(catalog: &Value, field: &str) -> Option<String> {
+    let mut candidates: Vec<&Value> = vec![catalog];
+
+    if let Some(payload) = catalog.get("payload") {
+        candidates.push(payload);
+    }
+    if let Some(result) = catalog.get("result") {
+        candidates.push(result);
+    }
+    if let Some(structured) = catalog
+        .get("result")
+        .and_then(|r| r.get("structuredContent"))
+    {
+        candidates.push(structured);
+    }
+    candidates.push(catalog);
+    let direct = candidates
+        .into_iter()
+        .find_map(|node| parse_preset_id(node, field));
+    if direct.is_some() {
+        return direct;
+    }
+    let nested = catalog
+        .get("result")
+        .and_then(|result| result.get("payload"))
+        .and_then(|payload| payload.get(field))
+        .and_then(|value| parse_preset_id(value, field));
+    if nested.is_some() {
+        return nested;
+    }
+    None
+}
+
+#[cfg(target_arch = "wasm32")]
+fn format_round_plan_for_display(dm_keeper: &str, players: &[(String, String)]) -> String {
+    let mut lines = vec![format!("DM: {}", dm_keeper)];
+    if players.is_empty() {
+        lines.push("Players: -".to_string());
+        return lines.join(" · ");
+    }
+    let player_text = players
+        .iter()
+        .map(|(actor_id, keeper)| format!("{}→{}", actor_id, keeper))
+        .collect::<Vec<_>>()
+        .join(", ");
+    lines.push(format!("Players: {}", player_text));
+    lines.join(" · ")
+}
+
+#[cfg(target_arch = "wasm32")]
+fn set_round_run_fields(
+    doc: &web_sys::Document,
+    dm_keeper: &str,
+    actor_ids: &[String],
+    player_map: &std::collections::HashMap<String, String>,
+) {
+    if let Some(el) = doc
+        .get_element_by_id("round-run-dm")
+        .and_then(|el| el.dyn_into::<web_sys::HtmlInputElement>().ok())
+    {
+        el.set_value(dm_keeper);
+    }
+    if let Some(el) = doc
+        .get_element_by_id("round-run-phase")
+        .and_then(|el| el.dyn_into::<web_sys::HtmlInputElement>().ok())
+    {
+        el.set_value("round");
+    }
+    if let Some(el) = doc
+        .get_element_by_id("round-run-timeout")
+        .and_then(|el| el.dyn_into::<web_sys::HtmlInputElement>().ok())
+    {
+        el.set_value("90");
+    }
+    if let Some(el) = doc
+        .get_element_by_id("round-run-lang")
+        .and_then(|el| el.dyn_into::<web_sys::HtmlInputElement>().ok())
+    {
+        el.set_value("ko");
+    }
+
+    let player_pairs = actor_ids
+        .iter()
+        .filter_map(|actor_id| player_map.get(actor_id).map(|keeper| (actor_id, keeper)))
+        .map(|(actor_id, keeper)| format!("{}={}", actor_id, keeper))
+        .collect::<Vec<_>>();
+    if let Some(el) = doc
+        .get_element_by_id("round-run-players")
+        .and_then(|el| el.dyn_into::<web_sys::HtmlInputElement>().ok())
+    {
+        el.set_value(&player_pairs.join(","));
+    }
+
+    let summary_pairs = actor_ids
+        .iter()
+        .filter_map(|actor_id| {
+            player_map
+                .get(actor_id)
+                .map(|keeper| (actor_id.clone(), keeper.clone()))
+        })
+        .collect::<Vec<(String, String)>>();
+    if let Some(summary) = doc.get_element_by_id("round-run-summary") {
+        summary.set_text_content(Some(&format_round_plan_for_display(
+            dm_keeper,
+            &summary_pairs,
+        )));
+        let _ = summary.set_attribute("style", "display:block");
+    }
 }
 
 #[cfg(target_arch = "wasm32")]
@@ -750,7 +914,8 @@ async fn fetch_room_runtime(room_id: &str) -> Result<(String, u32, String), Stri
     .await
     .map_err(|e| format!("본문 읽기 실패: {:?}", e))?;
     let body = body_js.as_string().unwrap_or_default();
-    let json: Value = serde_json::from_str(&body).map_err(|e| format!("state JSON 파싱 실패: {}", e))?;
+    let json: Value =
+        serde_json::from_str(&body).map_err(|e| format!("state JSON 파싱 실패: {}", e))?;
 
     let room = json.get("room").unwrap_or(&Value::Null);
     let state = json.get("state").unwrap_or(&Value::Null);
@@ -800,7 +965,12 @@ fn save_known_rooms(rooms: &[String]) {
 fn load_room_hub_visible() -> bool {
     web_sys::window()
         .and_then(|w| w.local_storage().ok().flatten())
-        .and_then(|storage| storage.get_item(ROOM_HUB_VISIBLE_STORAGE_KEY).ok().flatten())
+        .and_then(|storage| {
+            storage
+                .get_item(ROOM_HUB_VISIBLE_STORAGE_KEY)
+                .ok()
+                .flatten()
+        })
         .map(|value| matches!(value.trim(), "1" | "true" | "on"))
         .unwrap_or(false)
 }
@@ -808,7 +978,10 @@ fn load_room_hub_visible() -> bool {
 #[cfg(target_arch = "wasm32")]
 fn save_room_hub_visible(visible: bool) {
     if let Some(storage) = web_sys::window().and_then(|w| w.local_storage().ok().flatten()) {
-        let _ = storage.set_item(ROOM_HUB_VISIBLE_STORAGE_KEY, if visible { "1" } else { "0" });
+        let _ = storage.set_item(
+            ROOM_HUB_VISIBLE_STORAGE_KEY,
+            if visible { "1" } else { "0" },
+        );
     }
 }
 
@@ -937,7 +1110,12 @@ async fn refresh_rooms_from_server(doc: &web_sys::Document) -> Result<Vec<RoomSn
         }
     }
 
-    let room_ids = unique_non_empty(snapshots.iter().map(|row| row.id.clone()).collect::<Vec<_>>());
+    let room_ids = unique_non_empty(
+        snapshots
+            .iter()
+            .map(|row| row.id.clone())
+            .collect::<Vec<_>>(),
+    );
     if room_ids.is_empty() {
         return Err("서버 room 목록이 비어 있습니다.".to_string());
     }
@@ -1091,11 +1269,9 @@ fn bind_room_controls(doc: &web_sys::Document) {
             set_room_hub_visible(&doc, next);
             save_room_hub_visible(next);
         }) as Box<dyn FnMut()>);
-        let _ = hub_toggle
-            .dyn_ref::<web_sys::EventTarget>()
-            .map(|target| {
-                target.add_event_listener_with_callback("click", hub_cb.as_ref().unchecked_ref())
-            });
+        let _ = hub_toggle.dyn_ref::<web_sys::EventTarget>().map(|target| {
+            target.add_event_listener_with_callback("click", hub_cb.as_ref().unchecked_ref())
+        });
         hub_cb.forget();
     }
 }
@@ -1237,12 +1413,10 @@ async fn mcp_tool_call(tool_name: &str, args: Value) -> Result<Value, String> {
     }
 
     if let Some(structured) = result.get("structuredContent") {
-        return Ok(
-            structured
-                .get("payload")
-                .cloned()
-                .unwrap_or_else(|| structured.clone()),
-        );
+        return Ok(structured
+            .get("payload")
+            .cloned()
+            .unwrap_or_else(|| structured.clone()));
     }
 
     if let Some(payload) = result.get("payload") {
@@ -1274,10 +1448,7 @@ async fn mcp_tool_call(tool_name: &str, args: Value) -> Result<Value, String> {
         Err(primary) => parse_mcp_rpc_response(&text).map_err(|secondary| {
             format!(
                 "{} 응답 JSON 파싱 실패: {} / {} / raw={}",
-                tool_name,
-                primary,
-                secondary,
-                text
+                tool_name, primary, secondary, text
             )
         })?,
     };
@@ -1382,13 +1553,13 @@ async fn refresh_keeper_selectors(doc: &web_sys::Document) -> Result<Vec<String>
         let mut html = String::new();
         for name in keepers.iter().filter(|name| **name != dm_default) {
             let safe = html_escape(name);
-            let selected_attr =
-                if preserve_existing_selection && previous_players.iter().any(|picked| picked == name)
-                {
-                    " selected"
-                } else {
-                    ""
-                };
+            let selected_attr = if preserve_existing_selection
+                && previous_players.iter().any(|picked| picked == name)
+            {
+                " selected"
+            } else {
+                ""
+            };
             html.push_str(&format!(
                 r#"<option value="{value}"{selected}>{value}</option>"#,
                 value = safe,
@@ -1454,26 +1625,20 @@ async fn start_new_game_flow(doc: &web_sys::Document) -> Result<String, String> 
         }),
     )
     .await?;
-    let world_preset_id = preset_catalog
-        .get("world_presets")
-        .and_then(Value::as_array)
-        .and_then(|arr| arr.first())
-        .and_then(|preset| preset.get("id"))
-        .and_then(Value::as_str)
-        .unwrap_or("")
-        .trim()
-        .to_string();
-    let dm_preset_id = preset_catalog
-        .get("dm_presets")
-        .and_then(Value::as_array)
-        .and_then(|arr| arr.first())
-        .and_then(|preset| preset.get("id"))
-        .and_then(Value::as_str)
-        .unwrap_or("")
-        .trim()
-        .to_string();
+    let world_preset_id = pick_preset_id_from_catalog(&preset_catalog, "world_preset_id")
+        .unwrap_or_else(|| {
+            pick_preset_id_from_catalog(&preset_catalog, "world_presets").unwrap_or_default()
+        });
+    let dm_preset_id =
+        pick_preset_id_from_catalog(&preset_catalog, "dm_preset_id").unwrap_or_else(|| {
+            pick_preset_id_from_catalog(&preset_catalog, "dm_presets").unwrap_or_default()
+        });
+
     if world_preset_id.is_empty() || dm_preset_id.is_empty() {
-        return Err("trpg preset 목록이 비어 있습니다.".to_string());
+        return Err(format!(
+            "trpg preset 목록 파싱 실패: world_preset_id={}, dm_preset_id={}",
+            world_preset_id, dm_preset_id
+        ));
     }
 
     let party_size = players.len() as i64;
@@ -1581,7 +1746,8 @@ async fn start_new_game_flow(doc: &web_sys::Document) -> Result<String, String> 
     }
 
     let mut used_keepers = vec![dm_keeper.clone()];
-    let mut player_map = serde_json::Map::new();
+    let mut player_map: std::collections::HashMap<String, String> =
+        std::collections::HashMap::new();
     for (idx, actor_id) in actor_ids.iter().enumerate() {
         let mut keeper = players
             .get(idx)
@@ -1597,7 +1763,7 @@ async fn start_new_game_flow(doc: &web_sys::Document) -> Result<String, String> 
             suffix += 1;
         }
         used_keepers.push(candidate.clone());
-        player_map.insert(actor_id.clone(), Value::String(candidate));
+        player_map.insert(actor_id.clone(), candidate);
     }
 
     if !models.is_empty() {
@@ -1620,9 +1786,6 @@ async fn start_new_game_flow(doc: &web_sys::Document) -> Result<String, String> 
         )
         .await?;
         for (actor_id, keeper_name) in &player_map {
-            let Some(keeper_name) = keeper_name.as_str() else {
-                continue;
-            };
             mcp_tool_call(
                 "masc_keeper_up",
                 json!({
@@ -1645,6 +1808,7 @@ async fn start_new_game_flow(doc: &web_sys::Document) -> Result<String, String> 
 
     set_current_room_id(doc, &room_id);
     clear_trpg_dom(doc);
+    set_round_run_fields(doc, &dm_keeper, &actor_ids, &player_map);
 
     Ok(format!(
         "새 게임 시작 완료: room {} / DM {} / players {}",

--- a/viewer/src/render/fx.rs
+++ b/viewer/src/render/fx.rs
@@ -4,10 +4,7 @@ use crate::game::components::FloatingText;
 use crate::game::events::HpChanged;
 
 /// Spawns a floating damage/heal number above the affected character.
-pub fn spawn_damage_text(
-    mut commands: Commands,
-    mut hp_events: MessageReader<HpChanged>,
-) {
+pub fn spawn_damage_text(mut commands: Commands, mut hp_events: MessageReader<HpChanged>) {
     for HpChanged(payload) in hp_events.read() {
         let color = if payload.amount < 0 {
             Color::srgb(0.9, 0.2, 0.1) // damage = red

--- a/viewer/src/render/map.rs
+++ b/viewer/src/render/map.rs
@@ -43,11 +43,7 @@ pub fn position_to_area(pos: Vec2) -> String {
 
 /// Spawns the 2D camera with shader settings from the active theme.
 pub fn setup_camera(mut commands: Commands, theme: Res<ViewerTheme>) {
-    commands.spawn((
-        Camera2d,
-        GameCamera,
-        theme.shader_settings(),
-    ));
+    commands.spawn((Camera2d, GameCamera, theme.shader_settings()));
 }
 
 /// Spawns the map background with AI-generated area art.
@@ -56,8 +52,7 @@ pub fn setup_map_background(
     asset_server: Res<AssetServer>,
     map_state: Res<MapState>,
 ) {
-    let path = assets::map_for(&map_state.current_area)
-        .unwrap_or(assets::paths::MAP_AREA_A);
+    let path = assets::map_for(&map_state.current_area).unwrap_or(assets::paths::MAP_AREA_A);
     let texture = asset_server.load(path);
     commands.spawn((
         Sprite {
@@ -111,8 +106,7 @@ pub fn update_map_texture(
         return;
     }
 
-    let path = assets::map_for(&map_state.current_area)
-        .unwrap_or(assets::paths::MAP_AREA_A);
+    let path = assets::map_for(&map_state.current_area).unwrap_or(assets::paths::MAP_AREA_A);
 
     for mut sprite in &mut backgrounds {
         sprite.image = asset_server.load(path);

--- a/viewer/src/render/mod.rs
+++ b/viewer/src/render/mod.rs
@@ -10,11 +10,11 @@ use bevy::prelude::*;
 use crate::game::components::{
     FloatingText, GameCamera, HpBarSprite, MapBackground, MapToken, MoodOverlay, WeatherOverlay,
 };
-use crate::render::ui::UiMarker;
-use crate::render::ui::ResizeState;
-use crate::render::characters::DragState;
 use crate::mode::ViewerMode;
+use crate::render::characters::DragState;
 use crate::render::transition::{FadeOverlay, SceneTransition};
+use crate::render::ui::ResizeState;
+use crate::render::ui::UiMarker;
 
 /// Plugin for 2D scene rendering: map backgrounds, character tokens, HP bars, effects.
 ///
@@ -24,48 +24,58 @@ pub struct MapRenderPlugin;
 
 impl Plugin for MapRenderPlugin {
     fn build(&self, app: &mut App) {
-        app
-            .init_resource::<SceneTransition>()
+        app.init_resource::<SceneTransition>()
             .init_resource::<DragState>()
             .init_resource::<ResizeState>()
             // Setup: camera, map background, fade overlay, UI — on TRPG mode entry
-            .add_systems(OnEnter(ViewerMode::Trpg), (
-                map::setup_camera,
-                map::setup_map_background,
-                overlay::setup_weather_overlay,
-                overlay::setup_mood_overlay,
-                transition::setup_fade_overlay,
-                ui::setup_ui,
-            ))
+            .add_systems(
+                OnEnter(ViewerMode::Trpg),
+                (
+                    map::setup_camera,
+                    map::setup_map_background,
+                    overlay::setup_weather_overlay,
+                    overlay::setup_mood_overlay,
+                    transition::setup_fade_overlay,
+                    ui::setup_ui,
+                ),
+            )
             // Update: character sprites, positions, HP bars, effects, transitions, UI
-            .add_systems(Update, (
-                characters::spawn_character_sprites,
-                characters::update_character_positions,
-                characters::update_hp_bars,
-                characters::apply_death_visuals,
-                characters::handle_drag_start,
-                characters::handle_drag,
-                characters::handle_drag_end,
-                map::update_map_label,
-                map::update_map_texture,
-                fx::spawn_damage_text,
-                fx::animate_floating_text,
-                overlay::update_weather_overlay,
-                overlay::update_mood_overlay,
-                overlay::spawn_prop_notification,
-                transition::trigger_scene_transition,
-                transition::animate_scene_transition,
-                ui::handle_button_interactions,
-                ui::manage_menus,
-                ui::handle_menu_item_clicks,
-            ).run_if(in_state(ViewerMode::Trpg)))
-            .add_systems(Update, (
-                ui::spawn_resize_handles,
-                ui::handle_resize_start,
-                ui::handle_resize,
-                ui::handle_resize_end,
-                ui::update_resize_cursors,
-            ).run_if(in_state(ViewerMode::Trpg)))
+            .add_systems(
+                Update,
+                (
+                    characters::spawn_character_sprites,
+                    characters::update_character_positions,
+                    characters::update_hp_bars,
+                    characters::apply_death_visuals,
+                    characters::handle_drag_start,
+                    characters::handle_drag,
+                    characters::handle_drag_end,
+                    map::update_map_label,
+                    map::update_map_texture,
+                    fx::spawn_damage_text,
+                    fx::animate_floating_text,
+                    overlay::update_weather_overlay,
+                    overlay::update_mood_overlay,
+                    overlay::spawn_prop_notification,
+                    transition::trigger_scene_transition,
+                    transition::animate_scene_transition,
+                    ui::handle_button_interactions,
+                    ui::manage_menus,
+                    ui::handle_menu_item_clicks,
+                )
+                    .run_if(in_state(ViewerMode::Trpg)),
+            )
+            .add_systems(
+                Update,
+                (
+                    ui::spawn_resize_handles,
+                    ui::handle_resize_start,
+                    ui::handle_resize,
+                    ui::handle_resize_end,
+                    ui::update_resize_cursors,
+                )
+                    .run_if(in_state(ViewerMode::Trpg)),
+            )
             // Cleanup: despawn all TRPG scene entities and reset resources
             .add_systems(OnExit(ViewerMode::Trpg), cleanup_trpg_scene);
     }

--- a/viewer/src/render/transition.rs
+++ b/viewer/src/render/transition.rs
@@ -21,10 +21,11 @@ pub struct FadeOverlay;
 
 /// Spawns the fade overlay (initially invisible), sized to cover the window.
 pub fn setup_fade_overlay(mut commands: Commands, windows: Query<&Window>) {
-    let size = windows.single().map_or(
-        Vec2::new(2000.0, 2000.0),
-        |win: &Window| Vec2::new(win.width() * 1.5, win.height() * 1.5),
-    );
+    let size = windows
+        .single()
+        .map_or(Vec2::new(2000.0, 2000.0), |win: &Window| {
+            Vec2::new(win.width() * 1.5, win.height() * 1.5)
+        });
     commands.spawn((
         Sprite {
             color: Color::srgba(0.0, 0.0, 0.0, 0.0),

--- a/viewer/src/shaders/post_process.rs
+++ b/viewer/src/shaders/post_process.rs
@@ -11,8 +11,7 @@ use bevy::{
             UniformComponentPlugin,
         },
         render_graph::{
-            NodeRunError, RenderGraphContext, RenderGraphExt, RenderLabel, ViewNode,
-            ViewNodeRunner,
+            NodeRunError, RenderGraphContext, RenderGraphExt, RenderLabel, ViewNode, ViewNodeRunner,
         },
         render_resource::{
             binding_types::{sampler, texture_2d, uniform_buffer},
@@ -43,10 +42,7 @@ impl Plugin for PostProcessPlugin {
         render_app.add_systems(RenderStartup, init_post_process_pipeline);
 
         render_app
-            .add_render_graph_node::<ViewNodeRunner<OilPaintNode>>(
-                Core2d,
-                OilPaintLabel,
-            )
+            .add_render_graph_node::<ViewNodeRunner<OilPaintNode>>(Core2d, OilPaintLabel)
             .add_render_graph_edges(
                 Core2d,
                 (
@@ -83,8 +79,7 @@ impl ViewNode for OilPaintNode {
         let post_process_pipeline = world.resource::<PostProcessPipeline>();
         let pipeline_cache = world.resource::<PipelineCache>();
 
-        let Some(pipeline) =
-            pipeline_cache.get_render_pipeline(post_process_pipeline.pipeline_id)
+        let Some(pipeline) = pipeline_cache.get_render_pipeline(post_process_pipeline.pipeline_id)
         else {
             return Ok(());
         };
@@ -106,19 +101,18 @@ impl ViewNode for OilPaintNode {
             )),
         );
 
-        let mut render_pass =
-            render_context.begin_tracked_render_pass(RenderPassDescriptor {
-                label: Some("oil_paint_post_process"),
-                color_attachments: &[Some(RenderPassColorAttachment {
-                    view: post_process.destination,
-                    depth_slice: None,
-                    resolve_target: None,
-                    ops: Operations::default(),
-                })],
-                depth_stencil_attachment: None,
-                timestamp_writes: None,
-                occlusion_query_set: None,
-            });
+        let mut render_pass = render_context.begin_tracked_render_pass(RenderPassDescriptor {
+            label: Some("oil_paint_post_process"),
+            color_attachments: &[Some(RenderPassColorAttachment {
+                view: post_process.destination,
+                depth_slice: None,
+                resolve_target: None,
+                ops: Operations::default(),
+            })],
+            depth_stencil_attachment: None,
+            timestamp_writes: None,
+            occlusion_query_set: None,
+        });
 
         render_pass.set_render_pipeline(pipeline);
         render_pass.set_bind_group(0, &bind_group, &[settings_index.index()]);
@@ -205,10 +199,7 @@ pub struct PostProcessSettings {
 }
 
 /// System that updates the time field in PostProcessSettings each frame.
-pub fn update_post_process_time(
-    time: Res<Time>,
-    mut settings: Query<&mut PostProcessSettings>,
-) {
+pub fn update_post_process_time(time: Res<Time>, mut settings: Query<&mut PostProcessSettings>) {
     for mut s in &mut settings {
         s.time = time.elapsed_secs();
     }

--- a/viewer/src/sse/client.rs
+++ b/viewer/src/sse/client.rs
@@ -193,7 +193,8 @@ fn map_turn_progress_event(
             "room_status": "ended"
         }),
         "world.event" | "scene.transition" | "quest.update" => {
-            let sub = payload.get("event_type")
+            let sub = payload
+                .get("event_type")
                 .and_then(Value::as_str)
                 .or_else(|| payload.get("title").and_then(Value::as_str))
                 .unwrap_or(event_type);
@@ -205,12 +206,11 @@ fn map_turn_progress_event(
             })
         }
         "intervention.submitted" | "intervention.applied" => {
-            let itype = payload.get("intervention_type")
+            let itype = payload
+                .get("intervention_type")
                 .and_then(Value::as_str)
                 .unwrap_or("");
-            let reason = payload.get("reason")
-                .and_then(Value::as_str)
-                .unwrap_or("");
+            let reason = payload.get("reason").and_then(Value::as_str).unwrap_or("");
             let mut base = json!({
                 "event_type": event_type,
                 "turn": turn,
@@ -222,9 +222,10 @@ fn map_turn_progress_event(
             }
             base
         }
-        "actor.spawned" | "actor.updated" | "actor.deleted"
-        | "actor.claimed" | "actor.released" => {
-            let aid = payload.get("actor_id")
+        "actor.spawned" | "actor.updated" | "actor.deleted" | "actor.claimed"
+        | "actor.released" => {
+            let aid = payload
+                .get("actor_id")
                 .and_then(Value::as_str)
                 .unwrap_or("");
             json!({
@@ -412,10 +413,12 @@ fn map_trpg_event(
         }
         // -- world.event: dispatch to weather/mood/death based on subtype --
         "world.event" => {
-            let sub = payload.get("event_type")
+            let sub = payload
+                .get("event_type")
                 .and_then(Value::as_str)
                 .unwrap_or("");
-            let desc = payload.get("description")
+            let desc = payload
+                .get("description")
                 .and_then(Value::as_str)
                 .unwrap_or("");
             if sub.contains("weather") {
@@ -441,15 +444,15 @@ fn map_trpg_event(
         }
         // -- scene.transition → area_move --
         "scene.transition" => {
-            let from = payload.get("from_scene")
+            let from = payload
+                .get("from_scene")
                 .and_then(Value::as_str)
                 .unwrap_or("unknown");
-            let to = payload.get("to_scene")
+            let to = payload
+                .get("to_scene")
                 .and_then(Value::as_str)
                 .unwrap_or("unknown");
-            let trigger = payload.get("trigger")
-                .and_then(Value::as_str)
-                .unwrap_or("");
+            let trigger = payload.get("trigger").and_then(Value::as_str).unwrap_or("");
             let mapped = json!({
                 "character": trigger,
                 "from_area": from,
@@ -459,10 +462,12 @@ fn map_trpg_event(
         }
         // -- quest.update → narrative --
         "quest.update" => {
-            let title = payload.get("title")
+            let title = payload
+                .get("title")
                 .and_then(Value::as_str)
                 .unwrap_or("unknown quest");
-            let status = payload.get("status")
+            let status = payload
+                .get("status")
                 .and_then(Value::as_str)
                 .unwrap_or("updated");
             let mapped = json!({
@@ -473,12 +478,11 @@ fn map_trpg_event(
         }
         // -- intervention.submitted / applied → narrative --
         "intervention.submitted" | "intervention.applied" => {
-            let itype = payload.get("intervention_type")
+            let itype = payload
+                .get("intervention_type")
                 .and_then(Value::as_str)
                 .unwrap_or("unknown");
-            let reason = payload.get("reason")
-                .and_then(Value::as_str)
-                .unwrap_or("");
+            let reason = payload.get("reason").and_then(Value::as_str).unwrap_or("");
             let status_label = if event_type == "intervention.applied" {
                 "applied"
             } else {
@@ -529,8 +533,8 @@ fn map_trpg_event(
             out.push(("narrative".to_string(), mapped.to_string()));
         }
         // -- actor lifecycle → turn_progress only (handled below) --
-        "actor.spawned" | "actor.updated" | "actor.deleted"
-        | "actor.claimed" | "actor.released" => {
+        "actor.spawned" | "actor.updated" | "actor.deleted" | "actor.claimed"
+        | "actor.released" => {
             // No primary event; lifecycle tracked via turn_progress
         }
         _ => {}
@@ -764,7 +768,12 @@ fn attempt_trpg_reconnect(
             Err(_) => return,
         };
         match state.next_delay() {
-            Some(d) => (d, state.attempt, state.max_retries, state.last_event_id.clone()),
+            Some(d) => (
+                d,
+                state.attempt,
+                state.max_retries,
+                state.last_event_id.clone(),
+            ),
             None => {
                 log::error!(
                     "TRPG SSE reconnect exhausted ({} attempts) — giving up",

--- a/viewer/src/sse/masc_bridge.rs
+++ b/viewer/src/sse/masc_bridge.rs
@@ -77,10 +77,8 @@ pub fn poll_masc_events(
     for (event_type, data) in msgs.drain(..) {
         match event_type.as_str() {
             "broadcast" => {
-                let message = extract_field(&data, "message")
-                    .unwrap_or("(no message)");
-                let agent = extract_field(&data, "agent_name")
-                    .unwrap_or("unknown");
+                let message = extract_field(&data, "message").unwrap_or("(no message)");
+                let agent = extract_field(&data, "agent_name").unwrap_or("unknown");
                 let summary = format!("[{}] {}", agent, message);
 
                 event_log.entries.push(MascLogEntry {
@@ -98,8 +96,7 @@ pub fn poll_masc_events(
                 log::debug!("MASC heartbeat received");
             }
             "agent_joined" => {
-                let agent = extract_field(&data, "agent_name")
-                    .unwrap_or("unknown");
+                let agent = extract_field(&data, "agent_name").unwrap_or("unknown");
                 event_log.agent_count = event_log.agent_count.saturating_add(1);
 
                 let summary = format!("{} joined", agent);
@@ -111,11 +108,14 @@ pub fn poll_masc_events(
 
                 update_monitor_agents(event_log.agent_count, &summary);
 
-                log::info!("MASC agent joined: {} (total: {})", agent, event_log.agent_count);
+                log::info!(
+                    "MASC agent joined: {} (total: {})",
+                    agent,
+                    event_log.agent_count
+                );
             }
             "agent_left" => {
-                let agent = extract_field(&data, "agent_name")
-                    .unwrap_or("unknown");
+                let agent = extract_field(&data, "agent_name").unwrap_or("unknown");
                 event_log.agent_count = event_log.agent_count.saturating_sub(1);
 
                 let summary = format!("{} left", agent);
@@ -127,13 +127,15 @@ pub fn poll_masc_events(
 
                 update_monitor_agents(event_log.agent_count, &summary);
 
-                log::info!("MASC agent left: {} (total: {})", agent, event_log.agent_count);
+                log::info!(
+                    "MASC agent left: {} (total: {})",
+                    agent,
+                    event_log.agent_count
+                );
             }
             "task_update" => {
-                let task_id = extract_field(&data, "task_id")
-                    .unwrap_or("?");
-                let status = extract_field(&data, "status")
-                    .unwrap_or("unknown");
+                let task_id = extract_field(&data, "task_id").unwrap_or("?");
+                let status = extract_field(&data, "status").unwrap_or("unknown");
 
                 let summary = format!("Task {} -> {}", task_id, status);
                 event_log.entries.push(MascLogEntry {

--- a/viewer/src/sse/masc_client.rs
+++ b/viewer/src/sse/masc_client.rs
@@ -1,5 +1,5 @@
-use std::sync::{Arc, Mutex};
 use bevy::prelude::*;
+use std::sync::{Arc, Mutex};
 
 #[cfg(target_arch = "wasm32")]
 use wasm_bindgen::prelude::*;
@@ -119,10 +119,7 @@ fn create_event_source(
                 }
             }
         });
-        let _ = es.add_event_listener_with_callback(
-            event_type,
-            callback.as_ref().unchecked_ref(),
-        );
+        let _ = es.add_event_listener_with_callback(event_type, callback.as_ref().unchecked_ref());
         callback.forget();
     }
 
@@ -220,7 +217,12 @@ fn attempt_reconnect(
             Err(_) => return,
         };
         match state.next_delay() {
-            Some(d) => (d, state.attempt, state.max_retries, state.last_event_id.clone()),
+            Some(d) => (
+                d,
+                state.attempt,
+                state.max_retries,
+                state.last_event_id.clone(),
+            ),
             None => {
                 log::error!(
                     "MASC SSE reconnect exhausted ({} attempts) — giving up",
@@ -248,8 +250,7 @@ fn attempt_reconnect(
         status_proxy.clone(),
         move || {
             // Compute the URL, attaching lastEventId if we have one
-            let base_url = config::sse_endpoint_by_name(&mode_name)
-                .unwrap_or_default();
+            let base_url = config::sse_endpoint_by_name(&mode_name).unwrap_or_default();
             let url = reconnect::url_with_last_event_id(&base_url, &last_event_id);
             create_event_source(
                 &url,

--- a/viewer/src/sse/mod.rs
+++ b/viewer/src/sse/mod.rs
@@ -52,10 +52,7 @@ impl Plugin for SsePlugin {
         ];
         for mode in masc_modes {
             app.add_systems(OnEnter(mode), masc_client::setup_masc_sse)
-                .add_systems(
-                    Update,
-                    masc_bridge::poll_masc_events.run_if(in_state(mode)),
-                )
+                .add_systems(Update, masc_bridge::poll_masc_events.run_if(in_state(mode)))
                 .add_systems(OnExit(mode), masc_client::teardown_masc_sse);
         }
 
@@ -72,10 +69,7 @@ impl Plugin for SsePlugin {
             )
                 .run_if(in_state(ViewerMode::Social)),
         )
-        .add_systems(
-            OnExit(ViewerMode::Social),
-            social_board::cleanup_board,
-        );
+        .add_systems(OnExit(ViewerMode::Social), social_board::cleanup_board);
 
         // ── Sync async connection status into ECS (runs every frame) ──
         app.add_systems(Update, reconnect::sync_connection_status);

--- a/viewer/src/sse/reconnect.rs
+++ b/viewer/src/sse/reconnect.rs
@@ -288,17 +288,14 @@ mod tests {
 
     #[test]
     fn url_with_last_event_id_some() {
-        let url =
-            url_with_last_event_id("http://example.com/sse", &Some("42".to_string()));
+        let url = url_with_last_event_id("http://example.com/sse", &Some("42".to_string()));
         assert_eq!(url, "http://example.com/sse?lastEventId=42");
     }
 
     #[test]
     fn url_with_last_event_id_existing_params() {
-        let url = url_with_last_event_id(
-            "http://example.com/sse?room=abc",
-            &Some("99".to_string()),
-        );
+        let url =
+            url_with_last_event_id("http://example.com/sse?room=abc", &Some("99".to_string()));
         assert_eq!(url, "http://example.com/sse?room=abc&lastEventId=99");
     }
 

--- a/viewer/src/sse/social_board.rs
+++ b/viewer/src/sse/social_board.rs
@@ -261,7 +261,11 @@ async fn fetch_post_comments(post_id: &str) -> Result<Vec<BoardComment>, JsValue
     let detail: PostDetailResponse = serde_wasm_bindgen::from_value(json)
         .map_err(|e| JsValue::from_str(&format!("parse error: {}", e)))?;
 
-    log::info!("Comments: fetched {} for post {}", detail.comments.len(), post_id);
+    log::info!(
+        "Comments: fetched {} for post {}",
+        detail.comments.len(),
+        post_id
+    );
     Ok(detail.comments)
 }
 
@@ -288,7 +292,10 @@ async fn submit_comment(post_id: &str, content: &str) -> Result<(), JsValue> {
     let resp: web_sys::Response = resp_value.dyn_into()?;
 
     if !resp.ok() {
-        return Err(JsValue::from_str(&format!("Comment HTTP {}", resp.status())));
+        return Err(JsValue::from_str(&format!(
+            "Comment HTTP {}",
+            resp.status()
+        )));
     }
     log::info!("Comment submitted on post {}", post_id);
     Ok(())
@@ -296,10 +303,7 @@ async fn submit_comment(post_id: &str, content: &str) -> Result<(), JsValue> {
 
 // ─── DOM Rendering ───────────────────────────
 
-fn render_posts_to_dom(
-    _posts: &[BoardPost],
-    _shared: &Arc<Mutex<Option<Vec<BoardPost>>>>,
-) {
+fn render_posts_to_dom(_posts: &[BoardPost], _shared: &Arc<Mutex<Option<Vec<BoardPost>>>>) {
     #[cfg(target_arch = "wasm32")]
     {
         let Some(doc) = web_sys::window().and_then(|w| w.document()) else {
@@ -320,10 +324,9 @@ fn render_posts_to_dom(
 
         for post in _posts.iter().take(30) {
             let hearth_badge = match &post.hearth {
-                Some(h) if !h.is_empty() => format!(
-                    "<span class=\"post-hearth\">{}</span>",
-                    html_escape(h)
-                ),
+                Some(h) if !h.is_empty() => {
+                    format!("<span class=\"post-hearth\">{}</span>", html_escape(h))
+                }
                 _ => String::new(),
             };
 
@@ -391,8 +394,12 @@ fn bind_vote_buttons(doc: &web_sys::Document, shared: &Arc<Mutex<Option<Vec<Boar
     let Ok(buttons) = buttons else { return };
 
     for i in 0..buttons.length() {
-        let Some(node) = buttons.item(i) else { continue };
-        let Some(el) = node.dyn_ref::<web_sys::Element>() else { continue };
+        let Some(node) = buttons.item(i) else {
+            continue;
+        };
+        let Some(el) = node.dyn_ref::<web_sys::Element>() else {
+            continue;
+        };
 
         let post_id = match el.get_attribute("data-post-id") {
             Some(v) => v,
@@ -425,11 +432,9 @@ fn bind_vote_buttons(doc: &web_sys::Document, shared: &Arc<Mutex<Option<Vec<Boar
             });
         }) as Box<dyn FnMut()>);
 
-        let _ = el
-            .dyn_ref::<web_sys::EventTarget>()
-            .map(|target| {
-                target.add_event_listener_with_callback("click", cb.as_ref().unchecked_ref())
-            });
+        let _ = el.dyn_ref::<web_sys::EventTarget>().map(|target| {
+            target.add_event_listener_with_callback("click", cb.as_ref().unchecked_ref())
+        });
 
         cb.forget();
     }
@@ -438,8 +443,12 @@ fn bind_vote_buttons(doc: &web_sys::Document, shared: &Arc<Mutex<Option<Vec<Boar
 /// Optimistically increment/decrement the vote count in DOM.
 #[cfg(target_arch = "wasm32")]
 fn update_vote_count_in_dom(post_id: &str, direction: &str) {
-    let Some(doc) = web_sys::window().and_then(|w| w.document()) else { return };
-    let Some(article) = doc.get_element_by_id(&format!("post-{}", post_id)) else { return };
+    let Some(doc) = web_sys::window().and_then(|w| w.document()) else {
+        return;
+    };
+    let Some(article) = doc.get_element_by_id(&format!("post-{}", post_id)) else {
+        return;
+    };
 
     let selector = if direction == "up" {
         ".vote-count-up"
@@ -448,7 +457,8 @@ fn update_vote_count_in_dom(post_id: &str, direction: &str) {
     };
 
     if let Ok(Some(span)) = article.query_selector(selector) {
-        let current: i32 = span.text_content()
+        let current: i32 = span
+            .text_content()
             .and_then(|t| t.trim().parse().ok())
             .unwrap_or(0);
         span.set_text_content(Some(&(current + 1).to_string()));
@@ -463,8 +473,12 @@ fn bind_comment_toggles(doc: &web_sys::Document) {
     let Ok(toggles) = toggles else { return };
 
     for i in 0..toggles.length() {
-        let Some(node) = toggles.item(i) else { continue };
-        let Some(el) = node.dyn_ref::<web_sys::Element>() else { continue };
+        let Some(node) = toggles.item(i) else {
+            continue;
+        };
+        let Some(el) = node.dyn_ref::<web_sys::Element>() else {
+            continue;
+        };
 
         let post_id = match el.get_attribute("data-post-id") {
             Some(v) => v,
@@ -478,11 +492,9 @@ fn bind_comment_toggles(doc: &web_sys::Document) {
             toggle_comments_container(&pid);
         }) as Box<dyn FnMut()>);
 
-        let _ = el
-            .dyn_ref::<web_sys::EventTarget>()
-            .map(|target| {
-                target.add_event_listener_with_callback("click", cb.as_ref().unchecked_ref())
-            });
+        let _ = el.dyn_ref::<web_sys::EventTarget>().map(|target| {
+            target.add_event_listener_with_callback("click", cb.as_ref().unchecked_ref())
+        });
 
         cb.forget();
     }
@@ -490,11 +502,17 @@ fn bind_comment_toggles(doc: &web_sys::Document) {
 
 #[cfg(target_arch = "wasm32")]
 fn toggle_comments_container(post_id: &str) {
-    let Some(doc) = web_sys::window().and_then(|w| w.document()) else { return };
+    let Some(doc) = web_sys::window().and_then(|w| w.document()) else {
+        return;
+    };
     let container_id = format!("comments-{}", post_id);
-    let Some(container) = doc.get_element_by_id(&container_id) else { return };
+    let Some(container) = doc.get_element_by_id(&container_id) else {
+        return;
+    };
 
-    let Some(html_el) = container.dyn_ref::<web_sys::HtmlElement>() else { return };
+    let Some(html_el) = container.dyn_ref::<web_sys::HtmlElement>() else {
+        return;
+    };
     let style = html_el.style();
 
     let current = style.get_property_value("display").unwrap_or_default();
@@ -525,9 +543,13 @@ fn toggle_comments_container(post_id: &str) {
 
 #[cfg(target_arch = "wasm32")]
 fn render_comments_to_dom(post_id: &str, comments: &[BoardComment]) {
-    let Some(doc) = web_sys::window().and_then(|w| w.document()) else { return };
+    let Some(doc) = web_sys::window().and_then(|w| w.document()) else {
+        return;
+    };
     let selector = format!("#comments-{} .comments-list", post_id);
-    let Some(list) = doc.query_selector(&selector).ok().flatten() else { return };
+    let Some(list) = doc.query_selector(&selector).ok().flatten() else {
+        return;
+    };
 
     if comments.is_empty() {
         list.set_inner_html("<div class=\"comment-empty\">No comments yet.</div>");
@@ -559,8 +581,12 @@ fn bind_comment_forms(doc: &web_sys::Document, shared: &Arc<Mutex<Option<Vec<Boa
     let Ok(submits) = submits else { return };
 
     for i in 0..submits.length() {
-        let Some(node) = submits.item(i) else { continue };
-        let Some(el) = node.dyn_ref::<web_sys::Element>() else { continue };
+        let Some(node) = submits.item(i) else {
+            continue;
+        };
+        let Some(el) = node.dyn_ref::<web_sys::Element>() else {
+            continue;
+        };
 
         let post_id = match el.get_attribute("data-post-id") {
             Some(v) => v,
@@ -574,10 +600,16 @@ fn bind_comment_forms(doc: &web_sys::Document, shared: &Arc<Mutex<Option<Vec<Boa
             let pid = pid.clone();
             let buf = buf.clone();
 
-            let Some(doc) = web_sys::window().and_then(|w| w.document()) else { return };
+            let Some(doc) = web_sys::window().and_then(|w| w.document()) else {
+                return;
+            };
             let input_sel = format!(".comment-input[data-post-id=\"{}\"]", pid);
-            let Some(input) = doc.query_selector(&input_sel).ok().flatten() else { return };
-            let Some(input_el) = input.dyn_ref::<web_sys::HtmlInputElement>() else { return };
+            let Some(input) = doc.query_selector(&input_sel).ok().flatten() else {
+                return;
+            };
+            let Some(input_el) = input.dyn_ref::<web_sys::HtmlInputElement>() else {
+                return;
+            };
 
             let content = input_el.value();
             let content = content.trim().to_string();
@@ -602,11 +634,9 @@ fn bind_comment_forms(doc: &web_sys::Document, shared: &Arc<Mutex<Option<Vec<Boa
             });
         }) as Box<dyn FnMut()>);
 
-        let _ = el
-            .dyn_ref::<web_sys::EventTarget>()
-            .map(|target| {
-                target.add_event_listener_with_callback("click", cb.as_ref().unchecked_ref())
-            });
+        let _ = el.dyn_ref::<web_sys::EventTarget>().map(|target| {
+            target.add_event_listener_with_callback("click", cb.as_ref().unchecked_ref())
+        });
 
         cb.forget();
     }
@@ -622,7 +652,9 @@ fn bind_comment_input_enter(doc: &web_sys::Document, shared: &Arc<Mutex<Option<V
 
     for i in 0..inputs.length() {
         let Some(node) = inputs.item(i) else { continue };
-        let Some(el) = node.dyn_ref::<web_sys::Element>() else { continue };
+        let Some(el) = node.dyn_ref::<web_sys::Element>() else {
+            continue;
+        };
 
         let post_id = match el.get_attribute("data-post-id") {
             Some(v) => v,
@@ -640,7 +672,9 @@ fn bind_comment_input_enter(doc: &web_sys::Document, shared: &Arc<Mutex<Option<V
             let buf = buf.clone();
 
             let Some(target) = event.target() else { return };
-            let Some(input_el) = target.dyn_ref::<web_sys::HtmlInputElement>() else { return };
+            let Some(input_el) = target.dyn_ref::<web_sys::HtmlInputElement>() else {
+                return;
+            };
 
             let content = input_el.value();
             let content = content.trim().to_string();
@@ -660,11 +694,9 @@ fn bind_comment_input_enter(doc: &web_sys::Document, shared: &Arc<Mutex<Option<V
             });
         }) as Box<dyn FnMut(web_sys::KeyboardEvent)>);
 
-        let _ = el
-            .dyn_ref::<web_sys::EventTarget>()
-            .map(|target| {
-                target.add_event_listener_with_callback("keydown", cb.as_ref().unchecked_ref())
-            });
+        let _ = el.dyn_ref::<web_sys::EventTarget>().map(|target| {
+            target.add_event_listener_with_callback("keydown", cb.as_ref().unchecked_ref())
+        });
 
         cb.forget();
     }
@@ -673,9 +705,13 @@ fn bind_comment_input_enter(doc: &web_sys::Document, shared: &Arc<Mutex<Option<V
 /// Append a new comment card to the comments list for a post (optimistic).
 #[cfg(target_arch = "wasm32")]
 fn append_comment_to_dom(post_id: &str, author: &str, content: &str) {
-    let Some(doc) = web_sys::window().and_then(|w| w.document()) else { return };
+    let Some(doc) = web_sys::window().and_then(|w| w.document()) else {
+        return;
+    };
     let selector = format!("#comments-{} .comments-list", post_id);
-    let Some(list) = doc.query_selector(&selector).ok().flatten() else { return };
+    let Some(list) = doc.query_selector(&selector).ok().flatten() else {
+        return;
+    };
 
     // Remove "No comments yet" or loading placeholder
     if let Ok(Some(empty)) = list.query_selector(".comment-empty, .comment-loading") {
@@ -741,7 +777,10 @@ mod tests {
 
     #[test]
     fn html_escape_covers_all_entities() {
-        assert_eq!(html_escape("<b>\"a&b\"</b>"), "&lt;b&gt;&quot;a&amp;b&quot;&lt;/b&gt;");
+        assert_eq!(
+            html_escape("<b>\"a&b\"</b>"),
+            "&lt;b&gt;&quot;a&amp;b&quot;&lt;/b&gt;"
+        );
     }
 
     #[test]

--- a/viewer/src/theme.rs
+++ b/viewer/src/theme.rs
@@ -117,10 +117,10 @@ impl ViewerTheme {
     /// Background clear color for the Bevy canvas in this theme.
     pub fn clear_color(&self) -> Color {
         match self {
-            Self::DarkFantasy => Color::srgb(0.04, 0.04, 0.07),   // #0a0a12
-            Self::Cyberpunk => Color::srgb(0.02, 0.0, 0.06),      // deep indigo-black
-            Self::Terminal => Color::srgb(0.0, 0.02, 0.0),        // near-black green
-            Self::Parchment => Color::srgb(0.12, 0.10, 0.08),     // dark warm brown
+            Self::DarkFantasy => Color::srgb(0.04, 0.04, 0.07), // #0a0a12
+            Self::Cyberpunk => Color::srgb(0.02, 0.0, 0.06),    // deep indigo-black
+            Self::Terminal => Color::srgb(0.0, 0.02, 0.0),      // near-black green
+            Self::Parchment => Color::srgb(0.12, 0.10, 0.08),   // dark warm brown
         }
     }
 }
@@ -209,11 +209,9 @@ fn bind_single_theme_selector(
         }
     }) as Box<dyn FnMut(web_sys::Event)>);
 
-    let _ = select
-        .dyn_ref::<web_sys::EventTarget>()
-        .map(|target| {
-            target.add_event_listener_with_callback("change", cb.as_ref().unchecked_ref())
-        });
+    let _ = select.dyn_ref::<web_sys::EventTarget>().map(|target| {
+        target.add_event_listener_with_callback("change", cb.as_ref().unchecked_ref())
+    });
 
     cb.forget(); // Lives for app lifetime
 }
@@ -222,10 +220,7 @@ fn bind_single_theme_selector(
 
 /// Polls the shared buffer each frame. When a theme selector changes,
 /// updates the `ViewerTheme` resource (which triggers `apply_theme_changes`).
-fn poll_theme_transition(
-    buffer: Res<ThemeTransitionBuffer>,
-    mut theme: ResMut<ViewerTheme>,
-) {
+fn poll_theme_transition(buffer: Res<ThemeTransitionBuffer>, mut theme: ResMut<ViewerTheme>) {
     #[cfg(target_arch = "wasm32")]
     {
         let requested = {

--- a/viewer/style.css
+++ b/viewer/style.css
@@ -1597,6 +1597,17 @@ body.mode-lobby #dashboard {
     margin-bottom: 8px;
 }
 
+#round-run-summary {
+    margin: 6px 0 8px;
+    padding: 6px 8px;
+    border-radius: 8px;
+    border: 1px solid rgba(196, 162, 101, 0.2);
+    background: rgba(255, 255, 255, 0.03);
+    color: var(--text-dim);
+    font-size: 0.78rem;
+    line-height: 1.4;
+}
+
 #advance-turn-btn {
     background: var(--bg-card);
     border: 1px solid var(--border-highlight, rgba(196, 162, 101, 0.2));


### PR DESCRIPTION
## Summary

Phase 3 of the TRPG Viewer, building on the foundation of PRs #217 (audio), #219 (round runner), #223 (SSE event coverage), #224 (character parsing), #225 (mitosis P1).

### Changes (26 files, ~1200 lines)

**UI Overhaul**
- `render/ui.rs`: Menu interaction system rewrite with entity-aware click handling
- `dom/turn_controls.rs`: Enhanced turn phase controls with richer state display
- `dom/action_panel.rs`, `actor_join.rs`, `narrative.rs`: Panel polish

**Mode System**
- `mode.rs`: Expanded viewer mode enum with new states and transitions

**SSE Bridge**
- `sse/bridge.rs`: Event dispatch formatting cleanup
- `sse/social_board.rs`, `client.rs`, `masc_bridge.rs`: Rendering improvements

**Rendering**
- `render/characters.rs`, `fx.rs`, `map.rs`, `transition.rs`: Visual tweaks
- `shaders/post_process.rs`: Shader pipeline adjustments

**Config**
- `config.rs`: Proxy URL configuration updates
- `style.css`, `index.html`: Style additions

### Build
- `cargo check --target wasm32-unknown-unknown` passes (39 dead-code warnings, 0 errors)
- Conflicts from 5 merged PRs resolved (took upstream for all functional additions)
