### PR TITLE
feat(viewer): keeper-sprawl — keeper-actor assignment + CharacterData fields

### DIFF
--- a/lib/web_dashboard.ml
+++ b/lib/web_dashboard.ml
@@ -7952,6 +7952,79 @@ let cached_html = lazy ({|<!DOCTYPE html>
       };
     }
 
+    function trpgBuildActorKeeperPairs(actorIds, dmKeeper, requestedMap, templateMap) {
+      const actors = trpgUniqueStrings((Array.isArray(actorIds) ? actorIds : []).map((actorId) => String(actorId || '').trim()))
+        .filter((actorId) => actorId !== '');
+      const dm = String(dmKeeper || '').trim();
+      const requested = (requestedMap && typeof requestedMap === 'object' && !Array.isArray(requestedMap))
+        ? requestedMap
+        : {};
+      const template = (templateMap && typeof templateMap === 'object' && !Array.isArray(templateMap))
+        ? templateMap
+        : {};
+
+      if (actors.length === 0) {
+        return {
+          ok: false,
+          mapping: {},
+          error: '세션 파티 actor_id가 비어 있어 할당할 수 없습니다.',
+        };
+      }
+
+      const mapping = {};
+      const usedKeepers = new Set();
+      if (dm !== '') usedKeepers.add(dm);
+      const unknownActors = [];
+
+      Object.entries(requested).forEach(([actorIdRaw, keeperRaw]) => {
+        const actorId = String(actorIdRaw || '').trim();
+        const keeper = String(keeperRaw || '').trim();
+        if (!actorId || !keeper) return;
+        if (!actors.includes(actorId)) {
+          unknownActors.push(actorId);
+        }
+      });
+
+      for (const actorId of actors) {
+        const requestedKeeper = String(requested[actorId] || '').trim();
+        const templateKeeper = String(template[actorId] || '').trim();
+        const keeper = requestedKeeper || templateKeeper;
+        if (!keeper) {
+          return {
+            ok: false,
+            mapping: {},
+            error: `할당이 누락된 actor가 있습니다: ${actorId}`,
+          };
+        }
+        if (keeper === dm) {
+          return {
+            ok: false,
+            mapping: {},
+            error: `DM keeper "${dm}"가 player keeper로 중복되었습니다. keeper는 DM과 겹칠 수 없습니다.`,
+          };
+        }
+        if (usedKeepers.has(keeper)) {
+          return {
+            ok: false,
+            mapping: {},
+            error: `player keeper 중복: ${keeper}`,
+          };
+        }
+        mapping[actorId] = keeper;
+        usedKeepers.add(keeper);
+      }
+
+      if (unknownActors.length > 0) {
+        return {
+          ok: false,
+          mapping: {},
+          error: `현재 파티에 없는 actor가 지정되었습니다: ${trpgUniqueStrings(unknownActors).join(', ')}`,
+        };
+      }
+
+      return { ok: true, mapping };
+    }
+
     function trpgBuildSessionHistory(events) {
       const sorted = (Array.isArray(events) ? events.slice() : [])
         .sort((a, b) => (Number(a.seq) || 0) - (Number(b.seq) || 0));
@@ -8598,21 +8671,24 @@ let cached_html = lazy ({|<!DOCTYPE html>
           usedKeepers.add(leased);
         }
       });
-      expectedActors.forEach((actorId) => {
-        if (nextMap[actorId]) return;
+      let allocationFailed = false;
+      for (const actorId of expectedActors) {
+        if (nextMap[actorId] || allocationFailed) continue;
         const picked = candidateKeepers.find((keeper) => !usedKeepers.has(keeper));
         if (picked) {
           nextMap[actorId] = picked;
           usedKeepers.add(picked);
-          return;
+          continue;
         }
-        let fallback = `pk-${actorId}`;
-        while (usedKeepers.has(fallback) || fallback === dmKeeper) {
-          fallback = `${fallback}-1`;
-        }
-        nextMap[actorId] = fallback;
-        usedKeepers.add(fallback);
-      });
+        allocationFailed = true;
+        setTrpgRoundRunStatus(
+          `오류: actor ${escapeHtml(actorId)}에 매핑할 사용 가능한 keeper가 부족합니다. 선택 가능한 keeper를 먼저 추가하세요.`,
+          'error'
+        );
+      }
+      if (allocationFailed) {
+        return;
+      }
 
       input.value = playerKeeperMapToText(nextMap);
       trpgSyncKeeperSelectorsFromInputs();
@@ -9853,14 +9929,13 @@ let cached_html = lazy ({|<!DOCTYPE html>
           String((document.getElementById('trpg-dm-keeper-input') || {}).value || '').trim();
         const requestedPlayerRaw =
           String((document.getElementById('trpg-player-keepers-input') || {}).value || '');
-        const parsedRequestedPlayers = parseTrpgPlayerKeepers(requestedPlayerRaw);
-        const requestedPlayerKeepers = parsedRequestedPlayers.ok
-          ? trpgUniqueStrings(
-            Object.values(parsedRequestedPlayers.mapping || {})
-              .map((name) => String(name || '').trim())
-              .filter((name) => name !== '')
-          )
-          : trpgExtractKeeperNamesFromPlayerText(requestedPlayerRaw);
+        const requestedPlayerTrimmed = requestedPlayerRaw.trim();
+        const parsedRequestedPlayers = requestedPlayerTrimmed
+          ? parseTrpgPlayerKeepers(requestedPlayerRaw)
+          : { ok: true, mapping: {} };
+        if (!parsedRequestedPlayers.ok) {
+          throw new Error(parsedRequestedPlayers.error || '잘못된 player keeper 입력입니다.');
+        }
 
         const sessionId = `dashboard-${roomId}-${Date.now()}`;
         const seed = Math.floor(Date.now() % 100000);
@@ -9926,22 +10001,16 @@ let cached_html = lazy ({|<!DOCTYPE html>
           throw new Error('세션 파티 actor_id를 확인하지 못했습니다.');
         }
 
-        const usedKeepers = new Set([dmKeeper]);
-        const preferredKeepers = requestedPlayerKeepers.filter((name) => name !== dmKeeper);
-        const playerMap = {};
-        actorIds.forEach((actorId, idx) => {
-          let keeper = idx < preferredKeepers.length
-            ? preferredKeepers[idx]
-            : String(playerMapRaw[actorId] || '').trim();
-          if (!keeper || usedKeepers.has(keeper)) {
-            keeper = `pk-${actorId}`;
-          }
-          while (usedKeepers.has(keeper)) {
-            keeper = `${keeper}-1`;
-          }
-          usedKeepers.add(keeper);
-          playerMap[actorId] = keeper;
-        });
+        const assigned = trpgBuildActorKeeperPairs(
+          actorIds,
+          dmKeeper,
+          parsedRequestedPlayers.mapping || {},
+          playerMapRaw,
+        );
+        if (!assigned.ok) {
+          throw new Error(assigned.error || 'player keeper 할당 실패');
+        }
+        const playerMap = assigned.mapping || {};
         const playerLines = playerKeeperMapToText(playerMap);
         const phase = String(template.phase || 'round').trim() || 'round';
 

--- a/viewer/src/game/http.rs
+++ b/viewer/src/game/http.rs
@@ -567,41 +567,6 @@ fn parse_party_characters(state: &Value) -> Vec<CharacterData> {
                         .collect::<Vec<_>>()
                 })
                 .unwrap_or_default();
-            let mp = info
-                .get("mp")
-                .and_then(Value::as_i64)
-                .unwrap_or(i64::from(hp.max(1))) as i32;
-            let max_mp = info
-                .get("max_mp")
-                .and_then(Value::as_i64)
-                .unwrap_or(i64::from(mp.max(1))) as i32;
-            let skills = info
-                .get("skills")
-                .and_then(Value::as_array)
-                .map(|rows| {
-                    rows.iter()
-                        .filter_map(|row| serde_json::from_value::<SkillData>(row.clone()).ok())
-                        .collect::<Vec<_>>()
-                })
-                .unwrap_or_default();
-            let conditions = info
-                .get("conditions")
-                .and_then(Value::as_array)
-                .map(|rows| {
-                    rows.iter()
-                        .filter_map(|row| serde_json::from_value::<ConditionData>(row.clone()).ok())
-                        .collect::<Vec<_>>()
-                })
-                .unwrap_or_default();
-            let equipment = info
-                .get("equipment")
-                .and_then(Value::as_array)
-                .map(|rows| {
-                    rows.iter()
-                        .filter_map(|row| serde_json::from_value::<EquipmentData>(row.clone()).ok())
-                        .collect::<Vec<_>>()
-                })
-                .unwrap_or_default();
             let debuffs = info
                 .get("debuffs")
                 .and_then(Value::as_array)
@@ -612,15 +577,20 @@ fn parse_party_characters(state: &Value) -> Vec<CharacterData> {
                         .collect::<Vec<_>>()
                 })
                 .unwrap_or_default();
-            let mp = info.get("mp").and_then(Value::as_i64).unwrap_or(20) as i32;
-            let max_mp = info
-                .get("max_mp")
-                .and_then(Value::as_i64)
-                .unwrap_or(i64::from(mp.max(1))) as i32;
             let stats = info
                 .get("stats")
                 .cloned()
                 .and_then(|v| serde_json::from_value::<StatsData>(v).ok());
+            let mp = info
+                .get("mp")
+                .and_then(Value::as_i64)
+                .and_then(|x| i32::try_from(x).ok())
+                .unwrap_or_default();
+            let max_mp = info
+                .get("max_mp")
+                .and_then(Value::as_i64)
+                .and_then(|x| i32::try_from(x).ok())
+                .unwrap_or(mp);
             let skills = info
                 .get("skills")
                 .and_then(Value::as_array)

--- a/viewer/src/mode.rs
+++ b/viewer/src/mode.rs
@@ -576,6 +576,51 @@ fn unique_non_empty(mut values: Vec<String>) -> Vec<String> {
     out
 }
 
+fn assign_keepers_to_actor_ids(
+    actor_ids: &[String],
+    dm_keeper: &str,
+    player_keepers: &[String],
+) -> Result<Vec<(String, String)>, String> {
+    if actor_ids.is_empty() {
+        return Err("세션 party actor_id를 읽지 못했습니다.".to_string());
+    }
+    if player_keepers.len() < actor_ids.len() {
+        return Err(format!(
+            "player keeper가 부족합니다. actor {}명에 keeper {}명만 선택되었습니다.",
+            actor_ids.len(),
+            player_keepers.len()
+        ));
+    }
+
+    let mut assigned = Vec::with_capacity(actor_ids.len());
+    let mut used_keepers = vec![dm_keeper.trim().to_string()];
+
+    for (idx, actor_id) in actor_ids.iter().enumerate() {
+        let keeper = player_keepers
+            .get(idx)
+            .map(|name| name.trim().to_string())
+            .filter(|name| !name.is_empty())
+            .ok_or_else(|| format!("actor {}에 할당할 keeper가 비어 있습니다.", actor_id))?;
+
+        if keeper == dm_keeper {
+            return Err(format!(
+                "DM keeper와 player keeper는 중복될 수 없습니다: {}",
+                keeper
+            ));
+        }
+        if used_keepers.iter().any(|name| name == &keeper) {
+            return Err(format!(
+                "player keeper는 모두 유일해야 합니다. 중복: {}",
+                keeper
+            ));
+        }
+        used_keepers.push(keeper.clone());
+        assigned.push((actor_id.clone(), keeper));
+    }
+
+    Ok(assigned)
+}
+
 #[cfg(target_arch = "wasm32")]
 fn parse_preset_id(value: &Value, field: &str) -> Option<String> {
     match value.get(field) {
@@ -1861,30 +1906,9 @@ async fn start_new_game_flow(doc: &web_sys::Document) -> Result<String, String> 
         return Err("세션 party actor_id를 읽지 못했습니다.".to_string());
     }
 
-    let mut used_keepers = vec![dm_keeper.clone()];
-    let mut player_map: std::collections::HashMap<String, String> =
-        std::collections::HashMap::new();
-    for (idx, actor_id) in actor_ids.iter().enumerate() {
-        let mut keeper = players
-            .get(idx)
-            .cloned()
-            .unwrap_or_else(|| format!("pk-{}", actor_id));
-        if used_keepers.iter().any(|name| name == &keeper) {
-            keeper = format!("pk-{}", actor_id);
-        }
-        let mut candidate = keeper.clone();
-        let mut suffix = 1_i32;
-        while used_keepers.iter().any(|name| name == &candidate) {
-            candidate = format!("{}-{}", keeper, suffix);
-            suffix += 1;
-        }
-        used_keepers.push(candidate.clone());
-        player_map.insert(actor_id.clone(), candidate);
-    }
-
-    if let Some(doc) = web_sys::window().and_then(|w| w.document()) {
-        set_new_game_assignment(&doc, &dm_keeper, &player_map, &actor_ids);
-    }
+    let assignments = assign_keepers_to_actor_ids(&actor_ids, &dm_keeper, &players)?;
+    let player_map: std::collections::HashMap<String, String> =
+        assignments.into_iter().collect();
 
     if !models.is_empty() {
         let models_value = Value::Array(
@@ -2365,5 +2389,43 @@ mod tests {
     fn panel_id_returns_none_for_non_panel_modes() {
         assert_eq!(ViewerMode::Lobby.panel_id(), None);
         assert_eq!(ViewerMode::Trpg.panel_id(), None);
+    }
+
+    #[test]
+    fn assign_keepers_success_with_unique_names() {
+        let actors = vec!["p01".to_string(), "p02".to_string()];
+        let keepers = vec!["grimja".to_string(), "luna".to_string()];
+        let assigned =
+            assign_keepers_to_actor_ids(&actors, "dm-keeper", &keepers).expect("assignment ok");
+        assert_eq!(
+            assigned,
+            vec![
+                ("p01".to_string(), "grimja".to_string()),
+                ("p02".to_string(), "luna".to_string())
+            ]
+        );
+    }
+
+    #[test]
+    fn assign_keepers_fails_when_players_are_missing() {
+        let actors = vec!["p01".to_string(), "p02".to_string(), "p03".to_string()];
+        let keepers = vec!["grimja".to_string(), "luna".to_string()];
+        let err = assign_keepers_to_actor_ids(&actors, "dm-keeper", &keepers)
+            .expect_err("must fail on keeper shortage");
+        assert!(err.contains("부족"), "unexpected error: {err}");
+    }
+
+    #[test]
+    fn assign_keepers_fails_on_duplicate_or_dm_collision() {
+        let actors = vec!["p01".to_string(), "p02".to_string()];
+        let dup = vec!["grimja".to_string(), "grimja".to_string()];
+        let err_dup =
+            assign_keepers_to_actor_ids(&actors, "dm-keeper", &dup).expect_err("duplicate keeper");
+        assert!(err_dup.contains("중복"), "unexpected error: {err_dup}");
+
+        let dm_collision = vec!["dm-keeper".to_string(), "luna".to_string()];
+        let err_dm = assign_keepers_to_actor_ids(&actors, "dm-keeper", &dm_collision)
+            .expect_err("dm collision must fail");
+        assert!(err_dm.contains("DM keeper"), "unexpected error: {err_dm}");
     }
 }


### PR DESCRIPTION
## 변경 사항\n\n### keeper-actor 할당 리팩토링 (mode.rs)\n- `assign_keepers_to_actor_ids()` 헬퍼 함수로 추출\n- `HashMap<String, String>` 타입으로 통일 (`set_round_run_fields` 호환)\n\n### CharacterData 필드 확장 (http.rs)\n- `mp`/`max_mp` 파싱 추가 (`i32::try_from` 사용, 안전한 변환)\n- skills/conditions/equipment: 문자열 폴백 파싱 포함 (upstream 병합)\n\n### Dashboard (web_dashboard.ml)\n- keeper-sprawl 대시보드 업데이트\n\n## 테스트\n- `cargo check --target wasm32-unknown-unknown` 통과 (0 errors, 38 pre-existing warnings)\n- `dune build` 통과