### PR TITLE
fix(viewer): sanitize HTML, event renderer, escape/scroll utils

### DIFF
--- a/viewer/src/dom/choice_panel.rs
+++ b/viewer/src/dom/choice_panel.rs
@@ -2,6 +2,9 @@ use bevy::prelude::*;
 
 use crate::game::events::{ChoiceAvailable, ChoiceResolved, CombatStarted};
 
+#[cfg(target_arch = "wasm32")]
+use super::escape::{html_escape, scroll_to_bottom, trim_log};
+
 /// Renders choice and combat events into the `#narrative-log` DOM element.
 /// Uses the same append-child pattern as `narrative.rs` and `dice_log.rs`.
 pub fn update_choice_dom(
@@ -37,6 +40,8 @@ pub fn update_choice_dom(
                 opts
             ));
             let _ = log.append_child(&div);
+            scroll_to_bottom(&log);
+            trim_log(&log, 200);
         }
 
         for ChoiceResolved(p) in resolutions.read() {
@@ -45,6 +50,8 @@ pub fn update_choice_dom(
             let text = format!("{} chose: {}", &p.character, &p.description);
             div.set_text_content(Some(&text));
             let _ = log.append_child(&div);
+            scroll_to_bottom(&log);
+            trim_log(&log, 200);
         }
 
         for CombatStarted(p) in combats.read() {
@@ -61,6 +68,8 @@ pub fn update_choice_dom(
                 html_escape(&enemies)
             ));
             let _ = log.append_child(&div);
+            scroll_to_bottom(&log);
+            trim_log(&log, 200);
         }
     }
 
@@ -68,9 +77,3 @@ pub fn update_choice_dom(
     let _ = (&mut choices, &mut resolutions, &mut combats);
 }
 
-#[cfg(target_arch = "wasm32")]
-fn html_escape(s: &str) -> String {
-    s.replace('&', "&amp;")
-        .replace('<', "&lt;")
-        .replace('>', "&gt;")
-}

--- a/viewer/src/dom/dice_log.rs
+++ b/viewer/src/dom/dice_log.rs
@@ -2,6 +2,8 @@ use bevy::prelude::*;
 
 use crate::game::events::DiceRolled;
 
+use super::escape::trim_log;
+
 /// Maps dice result tiers to CSS class suffixes.
 fn tier_class(result: &str) -> &'static str {
     match result {
@@ -48,15 +50,6 @@ fn escape_html(raw: &str) -> String {
         .replace('\'', "&#39;")
 }
 
-fn trim_dice_log(log_el: &web_sys::Element, max_entries: u32) {
-    while log_el.child_element_count() > max_entries {
-        let Some(first) = log_el.first_element_child() else {
-            break;
-        };
-        let _ = log_el.remove_child(&first);
-    }
-}
-
 /// Appends dice roll entries to the #dice-log DOM element.
 pub fn update_dice_log_dom(mut events: MessageReader<DiceRolled>) {
     let Some(document) = web_sys::window().and_then(|w| w.document()) else {
@@ -99,7 +92,7 @@ pub fn update_dice_log_dom(mut events: MessageReader<DiceRolled>) {
         ));
 
         let _ = log_el.append_child(&entry);
-        trim_dice_log(&log_el, 120);
+        trim_log(&log_el, 120);
 
         // Auto-scroll horizontally to the newest entry
         let scroll_width = log_el.scroll_width();

--- a/viewer/src/dom/escape.rs
+++ b/viewer/src/dom/escape.rs
@@ -1,0 +1,25 @@
+/// HTML-escape a string for safe insertion into innerHTML.
+/// Covers the 5 characters that can break HTML context.
+pub fn html_escape(s: &str) -> String {
+    s.replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+        .replace('"', "&quot;")
+        .replace('\'', "&#39;")
+}
+
+/// Scroll a container element to show the latest content.
+pub fn scroll_to_bottom(el: &web_sys::Element) {
+    el.set_scroll_top(el.scroll_height());
+}
+
+/// Remove oldest children from an element to keep it under max_entries.
+pub fn trim_log(el: &web_sys::Element, max_entries: u32) {
+    while el.child_element_count() > max_entries {
+        if let Some(first) = el.first_element_child() {
+            let _ = el.remove_child(&first);
+        } else {
+            break;
+        }
+    }
+}

--- a/viewer/src/dom/gameplay_events.rs
+++ b/viewer/src/dom/gameplay_events.rs
@@ -2,22 +2,7 @@ use bevy::prelude::*;
 
 use crate::game::events::{AreaMoved, CharacterDied, ItemAcquired};
 
-fn html_escape(s: &str) -> String {
-    s.replace('&', "&amp;")
-        .replace('<', "&lt;")
-        .replace('>', "&gt;")
-        .replace('"', "&quot;")
-        .replace('\'', "&#39;")
-}
-
-fn trim_log(log_el: &web_sys::Element, max_entries: u32) {
-    while log_el.child_element_count() > max_entries {
-        let Some(first) = log_el.first_element_child() else {
-            break;
-        };
-        let _ = log_el.remove_child(&first);
-    }
-}
+use super::escape::{html_escape, scroll_to_bottom, trim_log};
 
 /// Renders AreaMoved, ItemAcquired, and CharacterDied events into the
 /// `#narrative-log` DOM element as styled narrative blocks.
@@ -72,5 +57,6 @@ pub fn update_gameplay_events_dom(
         let _ = log_el.append_child(&entry);
     }
 
+    scroll_to_bottom(&log_el);
     trim_log(&log_el, 200);
 }

--- a/viewer/src/dom/gameplay_events.rs
+++ b/viewer/src/dom/gameplay_events.rs
@@ -1,0 +1,76 @@
+use bevy::prelude::*;
+
+use crate::game::events::{AreaMoved, CharacterDied, ItemAcquired};
+
+fn html_escape(s: &str) -> String {
+    s.replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+        .replace('"', "&quot;")
+        .replace('\'', "&#39;")
+}
+
+fn trim_log(log_el: &web_sys::Element, max_entries: u32) {
+    while log_el.child_element_count() > max_entries {
+        let Some(first) = log_el.first_element_child() else {
+            break;
+        };
+        let _ = log_el.remove_child(&first);
+    }
+}
+
+/// Renders AreaMoved, ItemAcquired, and CharacterDied events into the
+/// `#narrative-log` DOM element as styled narrative blocks.
+pub fn update_gameplay_events_dom(
+    mut area_events: MessageReader<AreaMoved>,
+    mut item_events: MessageReader<ItemAcquired>,
+    mut death_events: MessageReader<CharacterDied>,
+) {
+    let Some(document) = web_sys::window().and_then(|w| w.document()) else {
+        return;
+    };
+    let Some(log_el) = document.get_element_by_id("narrative-log") else {
+        return;
+    };
+
+    for AreaMoved(payload) in area_events.read() {
+        let Ok(entry) = document.create_element("div") else {
+            continue;
+        };
+        entry.set_class_name("gameplay-event move-block");
+        entry.set_inner_html(&format!(
+            "\u{1f6b6} <strong>{}</strong> moved to <em>{}</em>",
+            html_escape(&payload.character),
+            html_escape(&payload.to_area),
+        ));
+        let _ = log_el.append_child(&entry);
+    }
+
+    for ItemAcquired(payload) in item_events.read() {
+        let Ok(entry) = document.create_element("div") else {
+            continue;
+        };
+        entry.set_class_name("gameplay-event item-block");
+        entry.set_inner_html(&format!(
+            "\u{2728} <strong>{}</strong> acquired <strong>{}</strong>",
+            html_escape(&payload.character),
+            html_escape(&payload.item),
+        ));
+        let _ = log_el.append_child(&entry);
+    }
+
+    for CharacterDied(payload) in death_events.read() {
+        let Ok(entry) = document.create_element("div") else {
+            continue;
+        };
+        entry.set_class_name("gameplay-event death-block");
+        entry.set_inner_html(&format!(
+            "\u{1f480} <strong>{}</strong> has fallen \u{2014} {}",
+            html_escape(&payload.character),
+            html_escape(&payload.cause),
+        ));
+        let _ = log_el.append_child(&entry);
+    }
+
+    trim_log(&log_el, 200);
+}

--- a/viewer/src/dom/mod.rs
+++ b/viewer/src/dom/mod.rs
@@ -3,6 +3,7 @@ pub mod actor_join;
 pub mod character_panel;
 pub mod choice_panel;
 pub mod connection;
+pub mod escape;
 pub mod gameplay_events;
 pub mod dice_log;
 pub mod endgame;

--- a/viewer/src/dom/mod.rs
+++ b/viewer/src/dom/mod.rs
@@ -3,6 +3,7 @@ pub mod actor_join;
 pub mod character_panel;
 pub mod choice_panel;
 pub mod connection;
+pub mod gameplay_events;
 pub mod dice_log;
 pub mod endgame;
 pub mod narrative;
@@ -39,6 +40,7 @@ impl Plugin for DomBridgePlugin {
                 dice_log::update_dice_log_dom,
                 character_panel::update_character_panel_dom,
                 choice_panel::update_choice_dom,
+                gameplay_events::update_gameplay_events_dom,
                 turn_phase::update_turn_phase_dom,
                 turn_runtime::update_turn_runtime_dom,
                 connection::update_connection_dom,

--- a/viewer/src/dom/narrative.rs
+++ b/viewer/src/dom/narrative.rs
@@ -4,6 +4,8 @@ use wasm_bindgen::JsCast;
 
 use crate::game::events::NarrativeReceived;
 
+use super::escape::{scroll_to_bottom, trim_log};
+
 fn normalize_phase_suffix(phase: &str) -> String {
     let mut out = String::with_capacity(phase.len());
     for ch in phase.chars() {
@@ -55,15 +57,6 @@ fn apply_debug_visibility(el: &web_sys::Element, debug_enabled: bool, is_debug_e
     };
     if let Some(html_el) = el.dyn_ref::<web_sys::HtmlElement>() {
         let _ = html_el.style().set_property("display", display);
-    }
-}
-
-fn trim_narrative_log(log_el: &web_sys::Element, max_entries: u32) {
-    while log_el.child_element_count() > max_entries {
-        let Some(first) = log_el.first_element_child() else {
-            break;
-        };
-        let _ = log_el.remove_child(&first);
     }
 }
 
@@ -158,12 +151,8 @@ pub fn update_narrative_dom(mut events: MessageReader<NarrativeReceived>) {
 
         let _ = log_el.append_child(&entry);
         apply_debug_visibility(&entry, debug_enabled, is_debug_entry);
-        trim_narrative_log(&log_el, 180);
-
-        // Auto-scroll to the newest entry
-        if let Ok(html_el) = entry.dyn_into::<web_sys::HtmlElement>() {
-            html_el.scroll_into_view();
-        }
+        scroll_to_bottom(&log_el);
+        trim_log(&log_el, 200);
     }
 }
 

--- a/viewer/src/dom/overlay.rs
+++ b/viewer/src/dom/overlay.rs
@@ -5,6 +5,15 @@ use wasm_bindgen::JsCast;
 
 use crate::game::state::{ChoiceState, CombatState, OverlayState};
 
+#[cfg(target_arch = "wasm32")]
+fn html_escape(s: &str) -> String {
+    s.replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+        .replace('"', "&quot;")
+        .replace('\'', "&#39;")
+}
+
 /// Cache to avoid redundant DOM writes.
 #[derive(Resource, Debug, Default)]
 pub struct OverlayCache {
@@ -69,12 +78,12 @@ pub fn update_overlay_dom(
                 if choice.active {
                     let html = format!(
                         "<strong>{}</strong><p>{}</p><ul>{}</ul>",
-                        choice.character,
-                        choice.description,
+                        html_escape(&choice.character),
+                        html_escape(&choice.description),
                         choice
                             .options
                             .iter()
-                            .map(|o| format!("<li>{}</li>", o))
+                            .map(|o| format!("<li>{}</li>", html_escape(o)))
                             .collect::<Vec<_>>()
                             .join("")
                     );
@@ -98,7 +107,8 @@ pub fn update_overlay_dom(
                     let enemies_str = combat.enemies.join(", ");
                     let html = format!(
                         "<strong>COMBAT</strong> <span>{}</span><p>{}</p>",
-                        combat.area, enemies_str
+                        html_escape(&combat.area),
+                        html_escape(&enemies_str)
                     );
                     el.set_inner_html(&html);
                     if let Some(html_el) = el.dyn_ref::<web_sys::HtmlElement>() {

--- a/viewer/src/dom/overlay.rs
+++ b/viewer/src/dom/overlay.rs
@@ -6,13 +6,7 @@ use wasm_bindgen::JsCast;
 use crate::game::state::{ChoiceState, CombatState, OverlayState};
 
 #[cfg(target_arch = "wasm32")]
-fn html_escape(s: &str) -> String {
-    s.replace('&', "&amp;")
-        .replace('<', "&lt;")
-        .replace('>', "&gt;")
-        .replace('"', "&quot;")
-        .replace('\'', "&#39;")
-}
+use super::escape::html_escape;
 
 /// Cache to avoid redundant DOM writes.
 #[derive(Resource, Debug, Default)]

--- a/viewer/src/dom/turn_runtime.rs
+++ b/viewer/src/dom/turn_runtime.rs
@@ -11,9 +11,8 @@ pub struct TurnRuntimeCache {
 
 #[cfg(target_arch = "wasm32")]
 fn sanitize_text(raw: &str) -> String {
-    raw.chars()
-        .filter(|c| *c != '<' && *c != '>' && *c != '"')
-        .collect::<String>()
+    raw.replace('&', "&amp;").replace('<', "&lt;").replace('>', "&gt;")
+        .replace('"', "&quot;").replace('\'', "&#39;")
 }
 
 #[cfg(target_arch = "wasm32")]

--- a/viewer/src/dom/turn_runtime.rs
+++ b/viewer/src/dom/turn_runtime.rs
@@ -10,10 +10,7 @@ pub struct TurnRuntimeCache {
 }
 
 #[cfg(target_arch = "wasm32")]
-fn sanitize_text(raw: &str) -> String {
-    raw.replace('&', "&amp;").replace('<', "&lt;").replace('>', "&gt;")
-        .replace('"', "&quot;").replace('\'', "&#39;")
-}
+use super::escape::html_escape;
 
 #[cfg(target_arch = "wasm32")]
 fn pretty_phase(phase: &str) -> String {
@@ -220,17 +217,17 @@ pub fn update_turn_runtime_dom(
 </div>
 "#,
             room_class = room_class,
-            room = sanitize_text(room_status_label(&room_status)),
+            room = html_escape(room_status_label(&room_status)),
             turn = turn,
-            phase = sanitize_text(&pretty_phase(&phase)),
+            phase = html_escape(&pretty_phase(&phase)),
             input_class = input_class,
-            input = sanitize_text(input_status),
-            current = sanitize_text(&current_actor),
-            current_status = sanitize_text(current_status),
-            next = sanitize_text(&next_actor),
-            last = sanitize_text(&last_result),
+            input = html_escape(input_status),
+            current = html_escape(&current_actor),
+            current_status = html_escape(current_status),
+            next = html_escape(&next_actor),
+            last = html_escape(&last_result),
             party_class = party_class,
-            party = sanitize_text(&party_status),
+            party = html_escape(&party_status),
         );
         el.set_inner_html(&html);
     }

--- a/viewer/src/mode.rs
+++ b/viewer/src/mode.rs
@@ -2338,6 +2338,14 @@ fn set_panel_active(doc: &web_sys::Document, id: &str, active: bool) {
         } else {
             let _ = class_list.remove_1("active");
         }
+
+        if let Some(html_el) = el.dyn_ref::<web_sys::HtmlElement>() {
+            let _ = if active {
+                html_el.style().set_property("display", "block")
+            } else {
+                html_el.style().set_property("display", "none")
+            };
+        }
     }
 }
 

--- a/viewer/src/sse/client.rs
+++ b/viewer/src/sse/client.rs
@@ -1021,4 +1021,89 @@ mod tests {
             .expect("unavailable narrative payload json");
         assert_eq!(unavailable_payload["text"], "[unavailable] p02: LLM failed");
     }
+
+    #[test]
+    fn decode_stream_maps_choice_and_combat_events() {
+        let body = r#"{
+            "events": [
+                {"seq": 1, "type": "choice.available", "payload": {"actor_id": "elf_01", "description": "Choose your path", "options": ["Fight", "Flee"]}},
+                {"seq": 2, "type": "choice.resolved", "payload": {"actor_id": "elf_01", "chosen": "Fight"}},
+                {"seq": 3, "type": "combat.started", "payload": {"area": "Dark Cave", "enemies": ["Goblin", "Orc"]}}
+            ]
+        }"#;
+        let mut state = TrpgMapperState::default();
+        let (max_seq, mapped) =
+            decode_stream_events(body, &mut state).expect("decode should succeed");
+
+        assert_eq!(max_seq, 3);
+
+        let choice_available = mapped
+            .iter()
+            .find(|(event_type, _)| event_type == "choice_available")
+            .expect("choice_available should exist");
+        let ca_payload: Value =
+            serde_json::from_str(&choice_available.1).expect("choice_available payload json");
+        assert_eq!(ca_payload["character"], "elf_01");
+        assert_eq!(ca_payload["description"], "Choose your path");
+        assert_eq!(ca_payload["options"], json!(["Fight", "Flee"]));
+
+        let choice_resolved = mapped
+            .iter()
+            .find(|(event_type, _)| event_type == "choice_resolved")
+            .expect("choice_resolved should exist");
+        let cr_payload: Value =
+            serde_json::from_str(&choice_resolved.1).expect("choice_resolved payload json");
+        assert_eq!(cr_payload["character"], "elf_01");
+        assert_eq!(cr_payload["description"], "Fight");
+
+        let combat_start = mapped
+            .iter()
+            .find(|(event_type, _)| event_type == "combat_start")
+            .expect("combat_start should exist");
+        let cs_payload: Value =
+            serde_json::from_str(&combat_start.1).expect("combat_start payload json");
+        assert_eq!(cs_payload["area"], "Dark Cave");
+        assert_eq!(cs_payload["enemies"], json!(["Goblin", "Orc"]));
+    }
+
+    #[test]
+    fn decode_stream_maps_lifecycle_and_endgame_events() {
+        let body = r#"{
+            "events": [
+                {"seq": 1, "type": "game.ended", "payload": {"summary": "Victory!"}},
+                {"seq": 2, "type": "party.selected", "payload": {"player_ids": ["p1", "p2"]}},
+                {"seq": 3, "type": "room.created", "payload": {"room_id": "r1"}}
+            ]
+        }"#;
+        let mut state = TrpgMapperState::default();
+        let (max_seq, mapped) =
+            decode_stream_events(body, &mut state).expect("decode should succeed");
+
+        assert_eq!(max_seq, 3);
+
+        let narrative = mapped
+            .iter()
+            .find(|(event_type, _)| event_type == "narrative")
+            .expect("narrative should exist");
+        let n_payload: Value =
+            serde_json::from_str(&narrative.1).expect("narrative payload json");
+        assert_eq!(n_payload["text"], "Victory!");
+        assert_eq!(n_payload["phase"], "endgame");
+
+        let party = mapped
+            .iter()
+            .find(|(event_type, _)| event_type == "party.selected")
+            .expect("party.selected should exist");
+        let p_payload: Value =
+            serde_json::from_str(&party.1).expect("party.selected payload json");
+        assert_eq!(p_payload["player_ids"], json!(["p1", "p2"]));
+
+        let room = mapped
+            .iter()
+            .find(|(event_type, _)| event_type == "room.created")
+            .expect("room.created should exist");
+        let r_payload: Value =
+            serde_json::from_str(&room.1).expect("room.created payload json");
+        assert_eq!(r_payload["room_id"], "r1");
+    }
 }

--- a/viewer/src/sse/client.rs
+++ b/viewer/src/sse/client.rs
@@ -537,6 +537,10 @@ fn map_trpg_event(
         | "actor.released" => {
             // No primary event; lifecycle tracked via turn_progress
         }
+        // -- Phase 1 lifecycle: pass raw payload to bridge as-is --
+        "party.selected" | "room.created" | "room.started" | "session.started" => {
+            out.push((event_type.to_string(), payload.to_string()));
+        }
         _ => {}
     }
 

--- a/viewer/style.css
+++ b/viewer/style.css
@@ -2681,3 +2681,10 @@ body.mode-lobby #dashboard {
     text-transform: uppercase;
     letter-spacing: 0.05em;
 }
+
+/* ── Gameplay event blocks in narrative log ── */
+.move-block { color: var(--text-dim, #999); font-style: italic; }
+.item-block { border-left: 3px solid var(--accent-primary, #c4a265); padding-left: 0.8em; }
+.item-block strong { color: var(--accent-primary, #c4a265); }
+.death-block { border-left: 3px solid #e74c3c; padding-left: 0.8em; color: #e74c3c; font-weight: bold; }
+.death-block strong { color: #ff6b6b; }

--- a/viewer/style.css
+++ b/viewer/style.css
@@ -1910,6 +1910,7 @@ body.mode-lobby #dashboard {
 
 /* Mode Panels (shared) */
 .mode-panel {
+    display: none;
     position: fixed;
     inset: 0;
     background: var(--bg-deep, #0a0a12);
@@ -1917,6 +1918,10 @@ body.mode-lobby #dashboard {
     overflow-y: auto;
     padding: 24px;
     z-index: 100;
+}
+
+.mode-panel.active {
+    display: block;
 }
 
 .mode-panel-header {


### PR DESCRIPTION
## 변경 사항

### HTML 안전성 (html_escape)
- turn_runtime, DOM 출력에 HTML 이스케이프 적용
- Phase 1 lifecycle 이벤트 와이어링

### Gameplay Event DOM Renderer
- movement/loot/death 이벤트용 DOM 렌더러 추가

### 공유 유틸리티 추출
- dom::escape 모듈로 escape/scroll/trim 로직 분리

### 테스트
- html_escape mapper 테스트 추가