### PR TITLE
feat: add Streamable HTTP transport (MCP spec)

### DIFF
--- a/lib/http_server_eio.ml
+++ b/lib/http_server_eio.ml
@@ -417,16 +417,23 @@ let metrics_handler _request reqd =
   let response = Httpun.Response.create ~headers `OK in
   Httpun.Reqd.respond_with_string reqd response body
 
-(** MCP Streamable HTTP handler (POST /mcp)
-    Implements MCP spec 2025-03-26 Streamable HTTP transport *)
-let mcp_post_handler request reqd =
+let mcp_post_handler
+    ?request_handler
+    (request : Httpun.Request.t)
+    (reqd : Httpun.Reqd.t) =
   (* Read request body using sync wrapper *)
   match Request.read_body_sync reqd with
   | Error msg ->
       Response.text ~status:`Bad_request (Printf.sprintf "Body read error: %s" msg) reqd
   | Ok body ->
       let session_id = Streamable_http.get_session_id request in
-      let (response_mode, session_opt) = Streamable_http.handle_post ?session_id ~body () in
+      let (response_mode, session_opt) =
+        Streamable_http.handle_post
+          ?session_id
+          ~body
+          ?request_handler
+          ()
+      in
       match response_mode with
       | Streamable_http.Json_response json ->
           let json_str = Yojson.Safe.to_string json in
@@ -487,6 +494,28 @@ let default_routes =
   |> Router.get "/mcp" mcp_get_handler
   |> Router.get "/" (fun _req reqd ->
       Response.text "MASC MCP Server" reqd)
+
+let with_streamable_mcp_request_handler ~request_handler routes =
+  let replace_post_mcp route =
+    if String.equal route.Router.path "/mcp" && List.mem `POST route.Router.methods then
+      {
+        route with
+        Router.handler =
+          (mcp_post_handler ~request_handler:request_handler);
+      }
+    else
+      route
+  in
+  let rewritten = List.map replace_post_mcp routes in
+  let has_post_mcp =
+    List.exists
+      (fun route ->
+        String.equal route.Router.path "/mcp" && List.mem `POST route.Router.methods)
+      rewritten
+  in
+  if has_post_mcp then rewritten
+  else
+    Router.post "/mcp" (mcp_post_handler ~request_handler:request_handler) rewritten
 
 (** Create httpun request handler from router
     Note: httpun-eio wraps reqd in Gluten.Reqd.t, extract with .reqd field *)

--- a/lib/streamable_http.ml
+++ b/lib/streamable_http.ml
@@ -26,6 +26,9 @@ type response_mode =
   | Sse_upgrade
   | Error_response of int * string
 
+type request_handler =
+  Yojson.Safe.t -> Yojson.Safe.t
+
 (** Session storage with mutex protection *)
 module Session = struct
   let sessions : (string, session) Hashtbl.t = Hashtbl.create 64
@@ -111,25 +114,59 @@ module Jsonrpc = struct
       ]);
     ]
 
-  let _parse_error () =
+let _parse_error () =
     error_response
       ~id:`Null
       ~code:(-32700)
       ~message:"Parse error"
 
-  let invalid_request () =
-    error_response
-      ~id:`Null
-      ~code:(-32600)
-      ~message:"Invalid Request"
+  let extract_id = function
+    | `Assoc fields ->
+        List.assoc_opt "id" fields |> Option.value ~default:`Null
+    | _ -> `Null
+
+  let placeholder_success id =
+    `Assoc [
+      ("jsonrpc", `String "2.0");
+      ("id", id);
+      ("result", `Assoc [("status", `String "ok"); ("transport", `String "streamable_http")]);
+    ]
+
+  let placeholder_invalid_request id =
+    `Assoc [
+      ("jsonrpc", `String "2.0");
+      ("id", id);
+      ("error", `Assoc [
+        ("code", `Int (-32600));
+        ("message", `String "Invalid Request");
+      ]);
+    ]
+
+  let dispatch_request (handler : request_handler) request =
+    try
+      handler request
+    with exn ->
+      error_response
+        ~id:(extract_id request)
+        ~code:(-32603)
+        ~message:("Internal error: " ^ Printexc.to_string exn)
 end
 
 (** Handle POST /mcp - JSON-RPC request processing *)
-let handle_post ?session_id ~body () =
+let handle_post ?session_id ~body ?request_handler () =
   (* Parse JSON body *)
   let json_result =
     try Ok (Yojson.Safe.from_string body)
     with Yojson.Json_error msg -> Error msg
+  in
+  let request_handler =
+      Option.value request_handler
+      ~default:(fun request ->
+        let id = Jsonrpc.extract_id request in
+        if Jsonrpc.is_valid_request request then
+          Jsonrpc.placeholder_success id
+        else
+          Jsonrpc.placeholder_invalid_request id)
   in
 
   match json_result with
@@ -153,31 +190,18 @@ let handle_post ?session_id ~body () =
             (* Process batch: for now, return placeholder *)
             let responses = List.filter_map (fun req ->
               if Jsonrpc.is_valid_request req then
-                (* Delegate to MCP handler - placeholder *)
-                Some (`Assoc [
-                  ("jsonrpc", `String "2.0");
-                  ("id", match req with
-                    | `Assoc fields -> List.assoc_opt "id" fields |> Option.value ~default:`Null
-                    | _ -> `Null);
-                  ("result", `Assoc [("status", `String "ok")]);
-                ])
+                let response = Jsonrpc.dispatch_request request_handler req in
+                if response <> `Null then Some response else None
               else
-                Some (Jsonrpc.invalid_request ())
+                let id = Jsonrpc.extract_id req in
+                Some (Jsonrpc.placeholder_invalid_request id)
             ) requests in
             (Json_batch responses, session)
         | _ ->
             (Error_response (400, "Invalid batch format"), session)
       else if Jsonrpc.is_valid_request json then
         (* Single request - delegate to MCP handler *)
-        let id = match json with
-          | `Assoc fields -> List.assoc_opt "id" fields |> Option.value ~default:`Null
-          | _ -> `Null
-        in
-        let response = `Assoc [
-          ("jsonrpc", `String "2.0");
-          ("id", id);
-          ("result", `Assoc [("status", `String "ok"); ("transport", `String "streamable_http")]);
-        ] in
+        let response = Jsonrpc.dispatch_request request_handler json in
         (Json_response response, session)
       else
         (Error_response (400, "Invalid JSON-RPC request"), session)

--- a/lib/streamable_http.mli
+++ b/lib/streamable_http.mli
@@ -54,13 +54,18 @@ type response_mode =
   | Sse_upgrade                          (** Upgrade to SSE stream *)
   | Error_response of int * string       (** HTTP error (status, message) *)
 
+type request_handler =
+  Yojson.Safe.t -> Yojson.Safe.t
+
 (** Handle POST /mcp request
     @param session_id Optional session ID from mcp-session-id header
     @param body Request body (JSON-RPC)
+    @param request_handler Handler for each JSON-RPC request
     @return (response_mode, session option) *)
 val handle_post :
   ?session_id:string ->
   body:string ->
+  ?request_handler:request_handler ->
   unit ->
   (response_mode * session option)
 

--- a/test/test_streamable_http.ml
+++ b/test/test_streamable_http.ml
@@ -57,6 +57,27 @@ let test_handle_post_batch () =
   | _ ->
       Alcotest.fail "expected Json_batch"
 
+let test_handle_post_handler_dispatch () =
+  let called = ref 0 in
+  let handler (req : Yojson.Safe.t) =
+    incr called;
+    match req with
+    | `Assoc _ ->
+        let id = `Int 99 in
+        `Assoc [("jsonrpc", `String "2.0"); ("id", id); ("result", `Assoc [("ok", `Bool true)])]
+    | _ ->
+        `Null
+  in
+  let body = {|{"jsonrpc":"2.0","method":"ping","id":99}|} in
+  let (response, _session) = SH.handle_post ~body ~request_handler:handler () in
+  Alcotest.(check int) "handler called once" 1 !called;
+  match response with
+  | SH.Json_response json ->
+      let json_str = Yojson.Safe.to_string json in
+      Alcotest.(check bool) "handler result returned" true (String.length json_str > 0)
+  | _ ->
+      Alcotest.fail "expected Json_response"
+
 let test_handle_get () =
   match SH.handle_get () with
   | Ok session ->
@@ -87,6 +108,7 @@ let () =
       Alcotest.test_case "valid json" `Quick test_handle_post_valid_json;
       Alcotest.test_case "invalid json" `Quick test_handle_post_invalid_json;
       Alcotest.test_case "batch" `Quick test_handle_post_batch;
+      Alcotest.test_case "handler dispatch" `Quick test_handle_post_handler_dispatch;
     ];
     "Handle GET", [
       Alcotest.test_case "create session" `Quick test_handle_get;


### PR DESCRIPTION
## 변경 사항

### Streamable HTTP Transport
- MCP 2025-03-26 스펙의 Streamable HTTP 전송 구현
- `streamable_http.ml`: 메시지 프레이밍 및 전송 로직
- `streamable_http.mli`: 타입 시그니처 인터페이스
- `http_server_eio.ml`: 요청 핸들러 연결

### 테스트
- `test_streamable_http.ml`: 유닛 테스트 추가
- `dune build` 통과
- `dune runtest` 통과