### PR TITLE
fix(web): proxy /mcp and normalize CORS headers

### DIFF
--- a/web/cors_server.py
+++ b/web/cors_server.py
@@ -1,17 +1,24 @@
 from http.server import HTTPServer, SimpleHTTPRequestHandler
 import sys
 
+
 class CORSHandler(SimpleHTTPRequestHandler):
+    def _cors_origin(self):
+        origin = self.headers.get("Origin")
+        return origin if origin else "*"
+
     def end_headers(self):
-        self.send_header('Access-Control-Allow-Origin', '*')
-        self.send_header('Access-Control-Allow-Methods', 'GET, POST, OPTIONS')
-        self.send_header('Access-Control-Allow-Headers', '*')
+        self.send_header("Access-Control-Allow-Origin", self._cors_origin())
+        self.send_header("Vary", "Origin")
+        self.send_header("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
+        self.send_header("Access-Control-Allow-Headers", "Content-Type, Accept")
         super().end_headers()
 
     def do_OPTIONS(self):
         self.send_response(200)
         self.end_headers()
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     port = int(sys.argv[1]) if len(sys.argv) > 1 else 8080
-    HTTPServer(('', port), CORSHandler).serve_forever()
+    HTTPServer(("", port), CORSHandler).serve_forever()

--- a/web/proxy_server.py
+++ b/web/proxy_server.py
@@ -1,50 +1,109 @@
 #!/usr/bin/env python3
-"""Simple reverse proxy with CORS for MASC SSE"""
 from http.server import HTTPServer, SimpleHTTPRequestHandler
-import urllib.request
 import sys
+import urllib.error
+import urllib.request
+
 
 class ProxyHandler(SimpleHTTPRequestHandler):
+    BACKEND = "http://127.0.0.1:8935"
+
+    def _cors_origin(self):
+        origin = self.headers.get("Origin")
+        return origin if origin else "*"
+
     def send_cors_headers(self):
-        self.send_header('Access-Control-Allow-Origin', '*')
-        self.send_header('Access-Control-Allow-Methods', 'GET, POST, OPTIONS')
-        self.send_header('Access-Control-Allow-Headers', '*')
-    
+        self.send_header("Access-Control-Allow-Origin", self._cors_origin())
+        self.send_header("Vary", "Origin")
+        self.send_header("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
+        self.send_header("Access-Control-Allow-Headers", "Content-Type, Accept")
+
+    def _is_proxy_path(self):
+        return (
+            self.path.startswith("/api")
+            or self.path.startswith("/sse")
+            or self.path.startswith("/mcp")
+        )
+
+    def _read_request_body(self):
+        length = int(self.headers.get("Content-Length", "0") or "0")
+        if length <= 0:
+            return None
+        return self.rfile.read(length)
+
+    def _forward_headers(self):
+        blocked = {"host", "connection", "accept-encoding", "origin", "content-length"}
+        return {
+            key: value
+            for key, value in self.headers.items()
+            if key.lower() not in blocked
+        }
+
+    def _copy_backend_headers(self, response):
+        skip = {
+            "transfer-encoding",
+            "connection",
+            "server",
+            "date",
+            "content-encoding",
+        }
+        for key, value in response.headers.items():
+            lowered = key.lower()
+            if lowered in skip:
+                continue
+            if lowered.startswith("access-control-"):
+                continue
+            self.send_header(key, value)
+
+    def _proxy(self):
+        req = urllib.request.Request(
+            f"{self.BACKEND}{self.path}",
+            data=self._read_request_body(),
+            method=self.command,
+            headers=self._forward_headers(),
+        )
+        try:
+            with urllib.request.urlopen(req, timeout=45) as resp:
+                self.send_response(resp.status)
+                self._copy_backend_headers(resp)
+                self.end_headers()
+                while True:
+                    chunk = resp.read(65536)
+                    if not chunk:
+                        break
+                    self.wfile.write(chunk)
+                    self.wfile.flush()
+        except urllib.error.HTTPError as err:
+            self.send_response(err.code)
+            self._copy_backend_headers(err)
+            self.end_headers()
+            self.wfile.write(err.read() or b"")
+        except Exception as err:
+            self.send_error(502, f"Proxy error: {err}")
+
     def do_OPTIONS(self):
         self.send_response(200)
-        self.send_cors_headers()
         self.end_headers()
-    
+
     def do_GET(self):
-        # Proxy SSE requests to MASC server
-        if self.path.startswith('/sse') or self.path.startswith('/api'):
-            try:
-                url = f"http://127.0.0.1:8935{self.path}"
-                req = urllib.request.Request(url)
-                with urllib.request.urlopen(req, timeout=30) as resp:
-                    self.send_response(200)
-                    self.send_header('Content-Type', resp.headers.get('Content-Type', 'text/event-stream'))
-                    self.send_cors_headers()
-                    self.end_headers()
-                    # Stream response
-                    while True:
-                        chunk = resp.read(1024)
-                        if not chunk:
-                            break
-                        self.wfile.write(chunk)
-                        self.wfile.flush()
-            except Exception as e:
-                self.send_error(502, f"Proxy error: {e}")
+        if self._is_proxy_path():
+            self._proxy()
         else:
-            # Serve static files
             super().do_GET()
-    
+
+    def do_POST(self):
+        if self._is_proxy_path():
+            self._proxy()
+        else:
+            self.send_error(405)
+
     def end_headers(self):
         self.send_cors_headers()
         super().end_headers()
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     port = int(sys.argv[1]) if len(sys.argv) > 1 else 8080
     print(f"Proxy server on http://localhost:{port}")
-    print(f"Proxying /sse and /api to http://127.0.0.1:8935")
-    HTTPServer(('', port), ProxyHandler).serve_forever()
+    print("Proxying /api, /sse, /mcp to http://127.0.0.1:8935")
+    HTTPServer(("", port), ProxyHandler).serve_forever()

--- a/web/server.py
+++ b/web/server.py
@@ -1,45 +1,106 @@
 #!/usr/bin/env python3
 from http.server import HTTPServer, SimpleHTTPRequestHandler
-import urllib.request
 import os
+import sys
+import urllib.error
+import urllib.request
+
 
 class Handler(SimpleHTTPRequestHandler):
+    BACKEND = "http://127.0.0.1:8935"
+
+    def _cors_origin(self):
+        origin = self.headers.get("Origin")
+        return origin if origin else "*"
+
     def end_headers(self):
-        self.send_header('Access-Control-Allow-Origin', '*')
-        self.send_header('Access-Control-Allow-Headers', '*')
+        self.send_header("Access-Control-Allow-Origin", self._cors_origin())
+        self.send_header("Vary", "Origin")
+        self.send_header("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
+        self.send_header("Access-Control-Allow-Headers", "Content-Type, Accept")
         super().end_headers()
 
-    def do_GET(self):
-        if self.path.startswith('/sse'):
-            # SSE proxy
-            self.send_response(200)
-            self.send_header('Content-Type', 'text/event-stream')
-            self.send_header('Cache-Control', 'no-cache')
-            self.send_header('Access-Control-Allow-Origin', '*')
-            self.end_headers()
-            
-            import socket
-            s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-            s.connect(('127.0.0.1', 8935))
-            s.send(f"GET {self.path} HTTP/1.1\r\nHost: 127.0.0.1:8935\r\n\r\n".encode())
-            
-            # Skip HTTP headers
-            buf = b''
-            while b'\r\n\r\n' not in buf:
-                buf += s.recv(1)
-            
-            # Stream data
-            try:
+    def _is_proxy_path(self):
+        return (
+            self.path.startswith("/api")
+            or self.path.startswith("/sse")
+            or self.path.startswith("/mcp")
+        )
+
+    def _read_request_body(self):
+        length = int(self.headers.get("Content-Length", "0") or "0")
+        if length <= 0:
+            return None
+        return self.rfile.read(length)
+
+    def _copy_headers(self, response):
+        skip = {
+            "transfer-encoding",
+            "connection",
+            "server",
+            "date",
+            "content-encoding",
+        }
+        for key, value in response.headers.items():
+            lowered = key.lower()
+            if lowered in skip:
+                continue
+            if lowered.startswith("access-control-"):
+                continue
+            self.send_header(key, value)
+
+    def _forward_headers(self):
+        blocked = {"host", "connection", "accept-encoding", "origin", "content-length"}
+        return {
+            key: value
+            for key, value in self.headers.items()
+            if key.lower() not in blocked
+        }
+
+    def _proxy(self):
+        req = urllib.request.Request(
+            f"{self.BACKEND}{self.path}",
+            data=self._read_request_body(),
+            method=self.command,
+            headers=self._forward_headers(),
+        )
+        try:
+            with urllib.request.urlopen(req, timeout=45) as resp:
+                self.send_response(resp.status)
+                self._copy_headers(resp)
+                self.end_headers()
                 while True:
-                    data = s.recv(4096)
+                    data = resp.read(65536)
                     if not data:
                         break
                     self.wfile.write(data)
                     self.wfile.flush()
-            except:
-                pass
-            s.close()
+        except urllib.error.HTTPError as err:
+            self.send_response(err.code)
+            self._copy_headers(err)
+            self.end_headers()
+            self.wfile.write(err.read() or b"")
+        except Exception as err:
+            self.send_error(502, f"Proxy error: {err}")
+
+    def do_OPTIONS(self):
+        self.send_response(200)
+        self.end_headers()
+
+    def do_GET(self):
+        if self._is_proxy_path():
+            self._proxy()
         else:
             super().do_GET()
 
-HTTPServer(('', 8080), Handler).serve_forever()
+    def do_POST(self):
+        if self._is_proxy_path():
+            self._proxy()
+        else:
+            self.send_error(405)
+
+
+if __name__ == "__main__":
+    port = int(sys.argv[1]) if len(sys.argv) > 1 else 8080
+    os.chdir(os.path.dirname(os.path.realpath(__file__)))
+    HTTPServer(("", port), Handler).serve_forever()


### PR DESCRIPTION
## Summary
- add reverse proxy support for `/mcp` in local web proxy servers
- normalize CORS headers to avoid duplicate/multiple `Access-Control-Allow-Origin` values
- keep `/api` and `/sse` forwarding with the same CORS policy

## Why
Viewer new-game/session bootstrap calls MCP tools over `/mcp`.
Without `/mcp` proxying, requests fail in browser and `trpg.preset.list` parsing/start flow breaks.

## Validation
- `python3 -m py_compile web/proxy_server.py web/server.py web/cors_server.py`
- `OPTIONS /mcp` returns a single CORS origin header
- `POST /mcp tools/call trpg.preset.list` succeeds through both `web/proxy_server.py` and `web/server.py`
