### PR TITLE
fix(viewer): session history timeline + TRPG playability fixes

### DIFF
--- a/viewer/src/dom/actor_join.rs
+++ b/viewer/src/dom/actor_join.rs
@@ -92,7 +92,6 @@ pub fn sync_join_panel_interaction_state(
                     | "outcome_narration"
                     | "state_update"
                     | "transition"
-                    | "paused"
             )
         }
 

--- a/viewer/src/dom/mod.rs
+++ b/viewer/src/dom/mod.rs
@@ -1,6 +1,7 @@
 pub mod action_panel;
 pub mod actor_join;
 pub mod character_panel;
+pub mod session_history;
 pub mod choice_panel;
 pub mod connection;
 pub mod escape;
@@ -28,7 +29,8 @@ impl Plugin for DomBridgePlugin {
     fn build(&self, app: &mut App) {
         app
             // DOM caches for change detection (inert when unused)
-            .init_resource::<character_panel::CharacterPanelCache>()
+        .init_resource::<character_panel::CharacterPanelCache>()
+            .init_resource::<session_history::SessionHistoryCache>()
             .init_resource::<turn_phase::TurnPhaseCache>()
             .init_resource::<turn_runtime::TurnRuntimeCache>()
             .init_resource::<connection::ConnectionStatusCache>()
@@ -39,6 +41,7 @@ impl Plugin for DomBridgePlugin {
             .add_systems(Update, (
                 narrative::update_narrative_dom,
                 dice_log::update_dice_log_dom,
+                session_history::update_session_history_dom,
                 character_panel::update_character_panel_dom,
                 choice_panel::update_choice_dom,
                 gameplay_events::update_gameplay_events_dom,
@@ -91,6 +94,9 @@ fn reset_trpg_dom_state(
             el.set_inner_html("");
         }
         if let Some(el) = document.get_element_by_id("dice-log") {
+            el.set_inner_html("");
+        }
+        if let Some(el) = document.get_element_by_id("session-history") {
             el.set_inner_html("");
         }
         if let Some(el) = document.get_element_by_id("character-panel") {

--- a/viewer/src/dom/session_history.rs
+++ b/viewer/src/dom/session_history.rs
@@ -1,0 +1,344 @@
+//! TRPG session timeline.
+//!
+//! Captures narrative, dice, and turn-progress events into per-turn history
+//! and renders them as a compact expandable timeline in the bottom panel.
+
+use bevy::prelude::*;
+
+use crate::game::events::{DiceRolled, NarrativeReceived, TurnAdvanced, TurnProgressUpdated};
+use crate::game::state::{RoomState, TurnProgressState};
+
+const MAX_TURNS_TO_KEEP: usize = 24;
+const MAX_EVENTS_PER_TURN: usize = 80;
+
+#[derive(Clone, Debug, PartialEq)]
+struct HistoryEvent {
+    kind: String,
+    actor: String,
+    title: String,
+    detail: String,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+struct TurnHistory {
+    turn: u32,
+    phase: String,
+    events: Vec<HistoryEvent>,
+}
+
+#[derive(Resource, Default)]
+pub struct SessionHistoryCache {
+    last_room_id: String,
+    turns: Vec<TurnHistory>,
+}
+
+#[cfg(target_arch = "wasm32")]
+fn sanitize_text(raw: &str) -> String {
+    raw.chars()
+        .filter(|ch| {
+            let code = *ch as u32;
+            !ch.is_control() && code != 0x00ad && code != 0x200b && code != 0xfeff
+        })
+        .collect()
+}
+
+#[cfg(target_arch = "wasm32")]
+fn escape_html(raw: &str) -> String {
+    sanitize_text(raw)
+        .replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+        .replace('"', "&quot;")
+        .replace('\'', "&#39;")
+}
+
+fn sanitize_key(raw: &str) -> String {
+    raw.trim().to_ascii_lowercase()
+}
+
+#[cfg(target_arch = "wasm32")]
+fn history_kind_class(kind: &str) -> &'static str {
+    match kind {
+        "dice" => "kind-dice",
+        "turn" => "kind-turn",
+        "progress" => "kind-progress",
+        "system" => "kind-system",
+        "narrative" => "kind-narrative",
+        _ => "kind-narrative",
+    }
+}
+
+fn ensure_turn_entry(turns: &mut Vec<TurnHistory>, turn: u32, phase: &str) -> usize {
+    for (idx, row) in turns.iter_mut().enumerate() {
+        if row.turn == turn {
+            if !phase.trim().is_empty() {
+                row.phase = phase.to_string();
+            }
+            return idx;
+        }
+    }
+    turns.push(TurnHistory {
+        turn,
+        phase: phase.to_string(),
+        events: Vec::new(),
+    });
+    turns.sort_by_key(|row| row.turn);
+    while turns.len() > MAX_TURNS_TO_KEEP {
+        let _ = turns.remove(0);
+    }
+    turns.iter().position(|row| row.turn == turn).unwrap_or(0)
+}
+
+fn append_event(turns: &mut Vec<TurnHistory>, turn: u32, phase: &str, kind: &str, actor: &str, title: &str, detail: &str) {
+    let idx = ensure_turn_entry(turns, turn, phase);
+    let Some(row) = turns.get_mut(idx) else {
+        return;
+    };
+    row.events.push(HistoryEvent {
+        kind: kind.to_string(),
+        actor: actor.to_string(),
+        title: title.to_string(),
+        detail: detail.to_string(),
+    });
+    if row.events.len() > MAX_EVENTS_PER_TURN {
+        let overflow = row.events.len() - MAX_EVENTS_PER_TURN;
+        row.events.drain(0..overflow);
+    }
+}
+
+fn label_progress_event(payload: &crate::game::events::TurnProgressPayload) -> (&'static str, String, String) {
+    let actor = payload.actor_id.trim();
+    let label = match payload.event_type.as_str() {
+        "turn.started" => "턴 시작",
+        "phase.changed" => "페이즈 변경",
+        "narration.posted" => "내레이션",
+        "turn.action.proposed" => "행동 제안",
+        "turn.timeout" => "턴 타임아웃",
+        "keeper.unavailable" => "Keeper 사용 불가",
+        "room.started" => "룸 시작",
+        "room.ended" => "룸 종료",
+        "world.event" => "월드 이벤트",
+        "scene.transition" => "씬 이동",
+        "quest.update" => "퀘스트 업데이트",
+        "intervention.submitted" => "개입 제안됨",
+        "intervention.applied" => "개입 적용",
+        "actor.spawned" => "액터 추가",
+        "actor.updated" => "액터 갱신",
+        "actor.deleted" => "액터 삭제",
+        "actor.claimed" => "액터 점유",
+        "actor.released" => "액터 해제",
+        _ => "진행 상태",
+    };
+
+    let mut detail = payload.reason.trim().to_string();
+    if detail.is_empty() {
+        detail = payload.event_type.clone();
+    }
+    let actor_label = if actor.is_empty() {
+        "system".to_string()
+    } else {
+        actor.to_string()
+    };
+    let kind = if payload.event_type.contains("phase")
+        || payload.event_type.contains("turn")
+        || payload.event_type == "turn.started"
+    {
+        "turn"
+    } else if matches!(payload.event_type.as_str(), "room.started" | "room.ended") {
+        "system"
+    } else {
+        "progress"
+    };
+    let summary = if detail.is_empty() {
+        label.to_string()
+    } else {
+        format!("{}: {}", label, detail)
+    };
+    (kind, actor_label, summary)
+}
+
+#[cfg(target_arch = "wasm32")]
+fn render_session_history_html(turns: &[TurnHistory]) -> String {
+    if turns.is_empty() {
+        return "<div class=\"session-history-empty\">아직 세션 히스토리가 없습니다.</div>".to_string();
+    }
+
+    let mut html = String::new();
+    for (idx, row) in turns.iter().rev().enumerate() {
+        let open = if idx == 0 { " open" } else { "" };
+        let phase = if row.phase.is_empty() {
+            "unknown".to_string()
+        } else {
+            row.phase.clone()
+        };
+        let row_events = if row.events.is_empty() {
+            "<li class=\"history-event-none\">이 턴에는 기록이 없습니다.</li>".to_string()
+        } else {
+            row.events
+                .iter()
+                .map(|ev| {
+                    let actor = escape_html(&ev.actor);
+                    let title = escape_html(&ev.title);
+                    let detail = escape_html(&ev.detail);
+                    let class = history_kind_class(&sanitize_key(&ev.kind));
+                    if actor.is_empty() {
+                        if detail.is_empty() {
+                            format!(
+                                r#"<li class="history-event {class}"><span class="history-kind">{title}</span><span class="history-detail">-</span></li>"#
+                            )
+                        } else {
+                            format!(
+                                r#"<li class="history-event {class}"><span class="history-kind">{title}</span><span class="history-detail">{detail}</span></li>"#
+                            )
+                        }
+                    } else {
+                        format!(
+                            r#"<li class="history-event {class}"><span class="history-kind">{title}</span><span class="history-actor">{actor}</span><span class="history-detail">{detail}</span></li>"#
+                        )
+                    }
+                })
+                .collect::<Vec<_>>()
+                .join("")
+        };
+        html.push_str(&format!(
+            "<details class=\"history-turn\"{open}><summary><span class=\"history-turn-header\">TURN {turn} · {phase}</span><span class=\"history-event-count\">{count}</span></summary><ul class=\"history-event-list\">{events}</ul></details>",
+            open = open,
+            turn = row.turn,
+            phase = sanitize_text(&phase),
+            count = row.events.len(),
+            events = row_events
+        ));
+    }
+    html
+}
+
+/// Render a compact per-turn timeline from TRPG stream events.
+pub fn update_session_history_dom(
+    room_state: Res<RoomState>,
+    progress: Res<TurnProgressState>,
+    mut narratives: MessageReader<NarrativeReceived>,
+    mut dice_events: MessageReader<DiceRolled>,
+    mut turn_events: MessageReader<TurnAdvanced>,
+    mut progress_events: MessageReader<TurnProgressUpdated>,
+    mut cache: ResMut<SessionHistoryCache>,
+) {
+    #[cfg(not(target_arch = "wasm32"))]
+    {
+        for _ in turn_events.read() {}
+        for _ in narratives.read() {}
+        for _ in dice_events.read() {}
+        for _ in progress_events.read() {}
+        return;
+    }
+
+    #[cfg(target_arch = "wasm32")]
+    {
+        let Some(document) = web_sys::window().and_then(|w| w.document()) else {
+            return;
+        };
+        let Some(history) = document.get_element_by_id("session-history") else {
+            return;
+        };
+
+        let mut changed = false;
+        if cache.last_room_id != room_state.id {
+            cache.last_room_id = room_state.id.clone();
+            cache.turns.clear();
+            changed = true;
+        }
+
+        let mut current_turn = if progress.turn > 0 {
+            progress.turn
+        } else {
+            room_state.turn.max(1)
+        };
+        let mut current_phase = if !progress.phase.is_empty() {
+            progress.phase.clone()
+        } else {
+            room_state.phase.as_str().to_string()
+        };
+
+        for TurnAdvanced(event) in turn_events.read() {
+            if event.turn > 0 {
+                current_turn = event.turn;
+            }
+            if !event.phase.is_empty() {
+                current_phase = event.phase.clone();
+            }
+            append_event(
+                &mut cache.turns,
+                current_turn,
+                &current_phase,
+                "turn",
+                "",
+                "턴 진행",
+                &format!("Turn {} ({})", current_turn, if current_phase.is_empty() { "-" } else { &current_phase }),
+            );
+            changed = true;
+        }
+
+        for NarrativeReceived(event) in narratives.read() {
+            append_event(
+                &mut cache.turns,
+                current_turn,
+                &current_phase,
+                "narrative",
+                event.speaker.as_deref().unwrap_or(""),
+                "내러티브",
+                &event.text,
+            );
+            changed = true;
+        }
+
+        for DiceRolled(payload) in dice_events.read() {
+            let turn = if payload.turn > 0 { payload.turn } else { current_turn };
+            if turn > 0 {
+                current_turn = turn;
+            }
+            append_event(
+                &mut cache.turns,
+                current_turn,
+                &current_phase,
+                "dice",
+                &payload.character,
+                "주사위",
+                &format!(
+                    "{} — {} (d20 {} + {} = {}, DC {})",
+                    payload.character,
+                    payload.action,
+                    payload.d20,
+                    payload.bonus,
+                    payload.total,
+                    payload.dc
+                ),
+            );
+            changed = true;
+        }
+
+        for TurnProgressUpdated(event) in progress_events.read() {
+            if event.turn > 0 {
+                current_turn = event.turn;
+            }
+            if !event.phase.is_empty() {
+                current_phase = event.phase.clone();
+            }
+            let (kind, actor, summary) = label_progress_event(&event);
+            append_event(
+                &mut cache.turns,
+                current_turn,
+                &current_phase,
+                kind,
+                &actor,
+                if summary.is_empty() { "turn progress" } else { &summary },
+                &event.event_type,
+            );
+            changed = true;
+        }
+
+        if !changed {
+            return;
+        }
+
+        history.set_inner_html(&render_session_history_html(&cache.turns));
+    }
+}

--- a/viewer/src/dom/turn_runtime.rs
+++ b/viewer/src/dom/turn_runtime.rs
@@ -39,7 +39,7 @@ fn room_status_class(status: &str) -> &'static str {
         }
         "dm_narration" | "party_discussion" | "action_declaration" | "dice_resolution"
         | "outcome_narration" | "state_update" | "transition" => "status-active",
-        "paused" => "status-paused",
+        "paused" | "stopped" => "status-paused",
         "ended" => "status-ended",
         "unavailable" => "status-unavailable",
         "loading" => "status-loading",
@@ -54,6 +54,7 @@ fn room_status_label(status: &str) -> &'static str {
         "dm_narration" | "party_discussion" | "action_declaration" | "dice_resolution"
         | "outcome_narration" | "state_update" | "transition" => "RUNNING",
         "paused" => "PAUSED",
+        "stopped" => "STOPPED",
         "ended" => "ENDED",
         "idle" => "IDLE",
         "loading" => "LOADING",

--- a/viewer/src/game/events.rs
+++ b/viewer/src/game/events.rs
@@ -32,6 +32,8 @@ pub struct NarrativePayload {
     pub text: String,
     pub phase: String,
     #[serde(default)]
+    pub turn: u32,
+    #[serde(default)]
     pub speaker: Option<String>,
 }
 

--- a/viewer/src/game/http.rs
+++ b/viewer/src/game/http.rs
@@ -2,11 +2,12 @@ use std::sync::{Arc, Mutex};
 
 use bevy::prelude::*;
 use serde::Deserialize;
-use serde_json::Value;
+use serde_json::{json, Value};
 use wasm_bindgen::prelude::*;
 use wasm_bindgen_futures::JsFuture;
 
 use crate::config;
+use crate::game::events::*;
 use crate::game::components::{Actor, Condition, Equipment, Skill, Stats};
 use crate::game::state::{ConnectionStatus, MapState, RoomState, TurnPhase, TurnProgressState};
 
@@ -119,6 +120,8 @@ pub struct GameStateResponse {
     pub current_area: String,
     #[serde(default)]
     pub area_label: String,
+    #[serde(default)]
+    pub dice_log: Vec<DiceRollPayload>,
 }
 
 // ─── Shared Buffer Resource ──────────────────
@@ -239,6 +242,9 @@ pub fn apply_initial_state(
     mut map_state: ResMut<MapState>,
     mut turn_progress: ResMut<TurnProgressState>,
     mut connection: ResMut<ConnectionStatus>,
+    mut dice_writer: MessageWriter<DiceRolled>,
+    mut turn_writer: MessageWriter<TurnAdvanced>,
+    mut progress_writer: MessageWriter<TurnProgressUpdated>,
 ) {
     if buffer.consumed {
         return;
@@ -261,6 +267,45 @@ pub fn apply_initial_state(
         .unwrap_or(false);
 
     let actor_ids: Vec<String> = state.characters.iter().map(|ch| ch.id.clone()).collect();
+    if let Some(room) = &state.room {
+        if !state_unavailable {
+            let status = normalize_room_status(&room.status);
+            let room_event = if matches!(
+                status.as_str(),
+                "ended" | "completed" | "done" | "retired" | "closed"
+            ) {
+                "room.ended"
+            } else {
+                "room.started"
+            };
+            let selected_players = actor_ids
+                .iter()
+                .filter(|id| id.as_str() != "dm")
+                .cloned()
+                .collect::<Vec<_>>();
+            progress_writer.write(TurnProgressUpdated(TurnProgressPayload {
+                event_type: room_event.to_string(),
+                turn: room.turn,
+                phase: room.phase.clone(),
+                actor_id: "".to_string(),
+                keeper: "".to_string(),
+                role: "".to_string(),
+                reason: "".to_string(),
+                room_status: room.status.clone(),
+                dm_keeper: "".to_string(),
+                selected_player_ids: selected_players,
+            }));
+            if room.turn > 0 {
+                turn_writer.write(TurnAdvanced(TurnAdvancePayload {
+                    turn: room.turn,
+                    phase: room.phase.clone(),
+                }));
+            }
+            for roll in &state.dice_log {
+                dice_writer.write(DiceRolled(roll.clone()));
+            }
+        }
+    }
 
     for entity in &actors {
         commands.entity(entity).despawn();
@@ -447,14 +492,19 @@ fn normalize_state_response(root: Value) -> Result<GameStateResponse, String> {
         return Ok(parse_masc_state_response(&root));
     }
 
+    if root.get("dice_log").is_some() || root.get("status").is_some() {
+        return Ok(parse_masc_state_response(&root));
+    }
+
     Err("unsupported state payload shape".to_string())
 }
 
 fn parse_masc_state_response(root: &Value) -> GameStateResponse {
-    let state = root.get("state").unwrap_or(&Value::Null);
+    let state = root.get("state").unwrap_or(root);
 
     let room_id = root
         .get("room_id")
+        .or_else(|| state.get("room_id"))
         .and_then(Value::as_str)
         .unwrap_or(config::DEFAULT_ROOM_ID)
         .to_string();
@@ -483,12 +533,14 @@ fn parse_masc_state_response(root: &Value) -> GameStateResponse {
         .and_then(|v| serde_json::from_value::<Vec<CharacterData>>(v).ok())
         .filter(|rows| !rows.is_empty())
         .unwrap_or_else(|| parse_party_characters(state));
+    let dice_log = parse_dice_log(root).unwrap_or_else(|| parse_dice_log(state).unwrap_or_default());
 
     GameStateResponse {
         room: Some(RoomResponse {
             id: room_id,
             status: state
                 .get("status")
+                .or_else(|| root.get("status"))
                 .and_then(Value::as_str)
                 .unwrap_or("idle")
                 .to_string(),
@@ -508,7 +560,127 @@ fn parse_masc_state_response(root: &Value) -> GameStateResponse {
         characters,
         current_area,
         area_label,
+        dice_log,
     }
+}
+
+fn parse_dice_log(root: &Value) -> Option<Vec<DiceRollPayload>> {
+    let entries = root.get("dice_log")?.as_array()?;
+    let fallback_turn = root.get("turn").and_then(Value::as_u64).unwrap_or(0) as u32;
+    let fallback_phase = root
+        .get("phase")
+        .and_then(Value::as_str)
+        .unwrap_or("dm_narration");
+
+    let mut output = Vec::new();
+    for entry in entries {
+        if let Some(row) = parse_dice_log_entry(entry, fallback_turn, fallback_phase) {
+            output.push(row);
+        }
+    }
+    Some(output)
+}
+
+fn parse_dice_log_entry(
+    entry: &Value,
+    fallback_turn: u32,
+    fallback_phase: &str,
+) -> Option<DiceRollPayload> {
+    if !entry.is_object() {
+        return None;
+    }
+
+    let turn = entry
+        .get("turn")
+        .and_then(Value::as_u64)
+        .and_then(|v| u32::try_from(v).ok())
+        .unwrap_or(fallback_turn);
+    let character = entry
+        .get("character")
+        .or_else(|| entry.get("actor_id"))
+        .and_then(Value::as_str)
+        .unwrap_or("unknown")
+        .to_string();
+    let action = entry
+        .get("action")
+        .or_else(|| entry.get("result"))
+        .and_then(Value::as_str)
+        .unwrap_or("manual_roll")
+        .to_string();
+    let bonus = entry
+        .get("bonus")
+        .and_then(Value::as_i64)
+        .and_then(|v| i32::try_from(v).ok())
+        .unwrap_or(0);
+    let raw_d20 = entry
+        .get("raw_d20")
+        .or_else(|| entry.get("d20"))
+        .and_then(Value::as_i64)
+        .and_then(|v| i32::try_from(v).ok())
+        .unwrap_or(0);
+    let dc = entry
+        .get("dc")
+        .or_else(|| entry.get("difficulty"))
+        .and_then(Value::as_i64)
+        .and_then(|v| i32::try_from(v).ok())
+        .unwrap_or(0);
+    let total = entry
+        .get("total")
+        .and_then(Value::as_i64)
+        .and_then(|v| i32::try_from(v).ok())
+        .unwrap_or(raw_d20 + bonus);
+    let raw_result = entry
+        .get("label")
+        .or_else(|| entry.get("tier"))
+        .and_then(Value::as_str)
+        .unwrap_or("");
+    let result = map_dice_result_label(raw_result);
+
+    Some(DiceRollPayload {
+        turn,
+        character,
+        action,
+        d20: raw_d20,
+        bonus,
+        total,
+        dc,
+        result,
+        note: entry.get("note").and_then(Value::as_str).map(str::to_string),
+    })
+}
+
+fn map_dice_result_label(raw: &str) -> String {
+    let raw = raw.trim().to_ascii_lowercase();
+    match raw.as_str() {
+        "critical_fail" | "critical failure" | "fumble" | "대실패" => "critical_fail".to_string(),
+        "fail" | "failure" | "실패" => "fail".to_string(),
+        "partial" | "partial_success" | "부분성공" => "partial_success".to_string(),
+        "success" | "성공" => "success".to_string(),
+        "great" | "great_success" | "대성공" => "great_success".to_string(),
+        "miracle" | "기적" => "miracle".to_string(),
+        "대승리" => "miracle".to_string(),
+        "pass" | "passed" | "true" | "1" | "success!" => "success".to_string(),
+        "false" | "0" => "fail".to_string(),
+        _ => {
+            let passed = entry_passed_marker(&raw);
+            if passed {
+                "success"
+            } else {
+                "fail"
+            }
+            .to_string()
+        }
+    }
+}
+
+fn entry_passed_marker(raw: &str) -> bool {
+    let compact = raw.replace(['\n', '\r', '\t'], " ");
+    compact
+        .split_whitespace()
+        .find(|token| !token.is_empty())
+        .is_some_and(|token| {
+            matches!(token, "pass" | "passed" | "success" | "성공" | "true" | "1")
+        })
 }
 
 fn parse_party_characters(state: &Value) -> Vec<CharacterData> {
@@ -731,6 +903,7 @@ fn unavailable_game_state(room_id: &str) -> GameStateResponse {
         characters: Vec::new(),
         current_area: "".to_string(),
         area_label: "".to_string(),
+        dice_log: Vec::new(),
     }
 }
 

--- a/viewer/src/mode.rs
+++ b/viewer/src/mode.rs
@@ -491,6 +491,9 @@ fn clear_trpg_dom(doc: &web_sys::Document) {
     if let Some(el) = doc.get_element_by_id("dice-log") {
         el.set_inner_html("");
     }
+    if let Some(el) = doc.get_element_by_id("session-history") {
+        el.set_inner_html("");
+    }
     if let Some(el) = doc.get_element_by_id("character-panel") {
         el.set_inner_html("");
     }

--- a/viewer/src/sse/client.rs
+++ b/viewer/src/sse/client.rs
@@ -88,6 +88,7 @@ struct TrpgStreamEvent {
 struct TrpgMapperState {
     last_turn: u32,
     last_phase: String,
+    snapshot_signature: Option<String>,
 }
 
 impl Default for TrpgMapperState {
@@ -95,6 +96,7 @@ impl Default for TrpgMapperState {
         Self {
             last_turn: 1,
             last_phase: "dm_narration".to_string(),
+            snapshot_signature: None,
         }
     }
 }
@@ -134,7 +136,140 @@ fn resolve_actor_id(payload: &Value, actor_id: Option<&str>) -> String {
         .and_then(Value::as_str)
         .or(actor_id)
         .unwrap_or("")
+    .to_string()
+}
+
+#[allow(dead_code)]
+fn snapshot_fingerprint(snapshot: &Value) -> String {
+    serde_json::to_string(snapshot).unwrap_or_else(|_| snapshot.to_string())
+}
+
+#[allow(dead_code)]
+fn snapshot_root<'a>(root: &'a Value) -> &'a Value {
+    root.get("state").filter(|s| !s.is_null()).unwrap_or(root)
+}
+
+#[allow(dead_code)]
+fn snapshot_status(root: &Value) -> String {
+    let source = snapshot_root(root);
+    source
+        .get("status")
+        .and_then(Value::as_str)
+        .or_else(|| root.get("status").and_then(Value::as_str))
+        .unwrap_or("")
+        .trim()
+        .to_ascii_lowercase()
+}
+
+#[allow(dead_code)]
+fn snapshot_turn(root: &Value, fallback: u32) -> u32 {
+    value_to_u32(snapshot_root(root).get("turn"), fallback)
+}
+
+#[allow(dead_code)]
+fn snapshot_phase(root: &Value, fallback: &str) -> String {
+    snapshot_root(root)
+        .get("phase")
+        .and_then(Value::as_str)
+        .unwrap_or(fallback)
         .to_string()
+}
+
+#[allow(dead_code)]
+fn snapshot_dice_entries(root: &Value) -> Vec<Value> {
+    let source = root.get("dice_log").or_else(|| snapshot_root(root).get("dice_log"));
+    source
+        .and_then(Value::as_array)
+        .map(|rows| rows.clone())
+        .unwrap_or_default()
+}
+
+#[allow(dead_code)]
+fn map_snapshot_result(result: &Value) -> String {
+    let raw = result
+        .get("label")
+        .and_then(Value::as_str)
+        .or_else(|| result.get("tier").and_then(Value::as_str))
+        .or_else(|| result.get("result").and_then(Value::as_str))
+        .unwrap_or("")
+        .trim()
+        .to_ascii_lowercase();
+    match raw.as_str() {
+        "critical_fail" => "critical_fail",
+        "fail" => "fail",
+        "partial" | "partial_success" | "부분성공" => "partial_success",
+        "success" | "성공" => "success",
+        "great" | "great_success" | "대성공" => "great_success",
+        "miracle" | "기적" => "miracle",
+        "success!" => "success",
+        _ => {
+            let passed = result.get("passed").and_then(Value::as_bool).unwrap_or(false);
+            if passed {
+                "success"
+            } else {
+                "fail"
+            }
+        }
+    }
+    .to_string()
+}
+
+#[allow(dead_code)]
+fn map_snapshot_dice_roll(entry: &Value, fallback_turn: u32, fallback_phase: &str) -> Option<(String, String)> {
+    if !entry.is_object() {
+        return None;
+    }
+
+    let character = entry
+        .get("character")
+        .or_else(|| entry.get("actor_id"))
+        .and_then(Value::as_str)
+        .unwrap_or("unknown")
+        .to_string();
+    let action = entry
+        .get("action")
+        .and_then(Value::as_str)
+        .unwrap_or("manual_roll")
+        .to_string();
+    let mapped = json!({
+        "turn": value_to_u32(entry.get("turn"), fallback_turn),
+        "character": character,
+        "action": action,
+        "d20": value_to_i32(entry.get("raw_d20"), value_to_i32(entry.get("d20"), 0)),
+        "bonus": value_to_i32(entry.get("bonus"), 0),
+        "total": value_to_i32(entry.get("total"), 0),
+        "dc": value_to_i32(entry.get("dc"), 0),
+        "result": map_snapshot_result(entry),
+        "note": entry.get("note").and_then(Value::as_str).unwrap_or("")
+    });
+    Some(("dice_roll".to_string(), mapped.to_string()))
+}
+
+#[allow(dead_code)]
+fn snapshot_room_status_progress_payload(
+    root: &Value,
+    status: &str,
+    fallback_turn: u32,
+    fallback_phase: &str,
+) -> (String, String) {
+    let turn = snapshot_turn(root, fallback_turn);
+    let phase = snapshot_phase(root, fallback_phase);
+    let event_type = match status {
+        "ended" | "completed" | "done" | "retired" | "closed" => "room.ended",
+        _ => "room.started",
+    };
+    let payload = json!({
+        "event_type": event_type,
+        "turn": turn,
+        "phase": phase,
+        "room_status": status,
+        "actor_id": "",
+        "keeper": "",
+        "role": "",
+        "reason": "",
+        "dm_keeper": snapshot_root(root).get("dm_keeper").and_then(Value::as_str).unwrap_or(""),
+    });
+    (event_type.to_string(), payload.to_string())
 }
 
 #[allow(dead_code)]
@@ -184,7 +319,11 @@ fn map_turn_progress_event(
             "event_type": event_type,
             "turn": turn,
             "phase": phase,
-            "room_status": "active"
+            "room_status": payload
+                .get("room_status")
+                .or_else(|| payload.get("status"))
+                .and_then(Value::as_str)
+                .unwrap_or("active")
         }),
         "room.ended" => json!({
             "event_type": event_type,
@@ -552,26 +691,86 @@ fn map_trpg_event(
 }
 
 #[allow(dead_code)]
+fn decode_snapshot_events(
+    body: &Value,
+    state: &mut TrpgMapperState,
+) -> Vec<(String, String)> {
+    let status = snapshot_status(body);
+    let signature = snapshot_fingerprint(body);
+    if state.snapshot_signature.as_deref() == Some(signature.as_str()) {
+        return Vec::new();
+    }
+    state.snapshot_signature = Some(signature);
+
+    let status = if status.is_empty() {
+        "unknown".to_string()
+    } else {
+        status
+    };
+    let turn = snapshot_turn(body, state.last_turn);
+    if turn > 0 {
+        state.last_turn = turn;
+    }
+    let phase = snapshot_phase(body, &state.last_phase);
+    if !phase.is_empty() {
+        state.last_phase = phase.clone();
+    }
+
+    let mut out = Vec::new();
+
+    out.push(snapshot_room_status_progress_payload(
+        body,
+        &status,
+        turn,
+        &phase,
+    ));
+
+    if turn > 0 {
+        out.push((
+            "turn_advance".to_string(),
+            json!({ "turn": turn, "phase": phase.clone() }).to_string(),
+        ));
+    }
+
+    for entry in snapshot_dice_entries(body) {
+        if let Some(mapped) = map_snapshot_dice_roll(&entry, turn, &phase) {
+            out.push(mapped);
+        }
+    }
+
+    out
+}
+
+#[allow(dead_code)]
 fn decode_stream_events(
     body: &str,
     state: &mut TrpgMapperState,
 ) -> Result<(i64, Vec<(String, String)>), String> {
-    let parsed: TrpgStreamResponse = serde_json::from_str(body).map_err(|e| e.to_string())?;
-    let mut max_seq = 0_i64;
-    let mut out = Vec::new();
+    let parsed: Value = serde_json::from_str(body).map_err(|e| e.to_string())?;
 
-    for ev in parsed.events {
-        if ev.seq > max_seq {
-            max_seq = ev.seq;
+    if parsed.get("events").is_some() {
+        let parsed: TrpgStreamResponse =
+            serde_json::from_value(parsed).map_err(|e| e.to_string())?;
+        let mut max_seq = 0_i64;
+        let mut out = Vec::new();
+
+        for ev in parsed.events {
+            if ev.seq > max_seq {
+                max_seq = ev.seq;
+            }
+            out.extend(map_trpg_event(
+                &ev.event_type,
+                ev.actor_id.as_deref(),
+                &ev.payload,
+                state,
+            ));
         }
-        out.extend(map_trpg_event(
-            &ev.event_type,
-            ev.actor_id.as_deref(),
-            &ev.payload,
-            state,
-        ));
+
+        return Ok((max_seq, out));
     }
 
+    let out = decode_snapshot_events(&parsed, state);
+    let mut max_seq = 0_i64;
     Ok((max_seq, out))
 }
 


### PR DESCRIPTION
## 변경 사항\n### Session History (session_history.rs, 344줄)\n- TRPG 세션 타임라인: 턴별 narrative/dice/progress 이벤트 기록\n- 하단 패널에 확장 가능한 compact 타임라인 렌더링\n- MAX_TURNS_TO_KEEP=24, MAX_EVENTS_PER_TURN=80\n### SSE Client 확장 (sse/client.rs, +225줄)\n- 세션 히스토리 이벤트 수신 파이프라인\n- 새 이벤트 타입 핸들러 추가\n### HTTP 파싱 확장 (game/http.rs, +177줄)\n- 추가 데이터 파싱 로직\n### 빌드\n- `cargo check --target wasm32-unknown-unknown` 통과 (43 warnings, 0 errors)\n- `dune build` 통과