### PR TITLE
fix(viewer,trpg): clarify room lifecycle and timeout observability

### DIFF
--- a/lib/tool_trpg.ml
+++ b/lib/tool_trpg.ml
@@ -1086,6 +1086,8 @@ let append_timeout_and_unavailable_events
     ~timeout_sec
     =
   let ( let* ) = Result.bind in
+  let timeout_reason = "timeout" in
+  let timeout_stage = "masc_keeper_msg" in
   let timeout_payload =
     `Assoc
       [
@@ -1094,8 +1096,9 @@ let append_timeout_and_unavailable_events
         ("role", `String (role_to_string role));
         ("actor_id", `String actor_id);
         ("keeper", `String keeper_name);
+        ("reason", `String timeout_reason);
         ("timeout_sec", `Float timeout_sec);
-        ("stage", `String "masc_keeper_msg");
+        ("stage", `String timeout_stage);
       ]
   in
   let* timeout_event =
@@ -1115,7 +1118,9 @@ let append_timeout_and_unavailable_events
         ("role", `String (role_to_string role));
         ("actor_id", `String actor_id);
         ("keeper", `String keeper_name);
-        ("reason", `String "timeout");
+        ("reason", `String timeout_reason);
+        ("timeout_sec", `Float timeout_sec);
+        ("stage", `String timeout_stage);
       ]
   in
   let* unavailable_event =
@@ -1130,7 +1135,8 @@ let append_timeout_and_unavailable_events
   Ok [ timeout_event; unavailable_event ]
 
 let append_unavailable_event
-    ~base_dir ~room_id ~phase ~turn ~role ~actor_id ~keeper_name ~reason () =
+    ~base_dir ~room_id ~phase ~turn ~role ~actor_id ~keeper_name ~reason ~stage ()
+    =
   let payload =
     `Assoc
       [
@@ -1140,6 +1146,7 @@ let append_unavailable_event
         ("actor_id", `String actor_id);
         ("keeper", `String keeper_name);
         ("reason", `String reason);
+        ("stage", `String stage);
       ]
   in
   append_event
@@ -2247,7 +2254,7 @@ let handle_round_run ctx args : result =
       let timeout_count = ref 0 in
 
       let process_one ~role ~actor_id ~keeper_name =
-        let record_unavailable_status ~status ~error =
+        let record_unavailable_status ~status ~error ~stage =
           let* unavailable_event =
             append_unavailable_event
               ~base_dir
@@ -2258,6 +2265,7 @@ let handle_round_run ctx args : result =
               ~actor_id
               ~keeper_name
               ~reason:error
+              ~stage
               ()
           in
           unavailable_count := !unavailable_count + 1;
@@ -2269,6 +2277,8 @@ let handle_round_run ctx args : result =
                 ("role", `String (role_to_string role));
                 ("keeper", `String keeper_name);
                 ("status", `String status);
+                ("reason", `String error);
+                ("stage", `String stage);
                 ("error", `String error);
               ]
             :: !statuses;
@@ -2292,7 +2302,11 @@ let handle_round_run ctx args : result =
               | _ -> Ok () )
         in
         match lease_check with
-        | Error lease_error -> record_unavailable_status ~status:"lease_denied" ~error:lease_error
+        | Error lease_error ->
+            record_unavailable_status
+              ~status:"lease_denied"
+              ~error:lease_error
+              ~stage:"lease_check"
         | Ok () ->
         let prompt =
           build_keeper_prompt
@@ -2327,16 +2341,24 @@ let handle_round_run ctx args : result =
                   ("role", `String (role_to_string role));
                   ("keeper", `String keeper_name);
                   ("status", `String "timeout");
+                  ("reason", `String "timeout");
+                  ("stage", `String "masc_keeper_msg");
                   ("timeout_sec", `Float timeout_sec);
                 ]
               :: !statuses;
             Ok ()
         | `Error keeper_error ->
-            record_unavailable_status ~status:"unavailable" ~error:keeper_error
+            record_unavailable_status
+              ~status:"unavailable"
+              ~error:keeper_error
+              ~stage:"keeper_call"
         | `Ok keeper_json -> (
             match parse_keeper_reply keeper_json with
             | Error parse_error ->
-                record_unavailable_status ~status:"invalid_response" ~error:parse_error
+                record_unavailable_status
+                  ~status:"invalid_response"
+                  ~error:parse_error
+                  ~stage:"parse_keeper_reply"
             | Ok reply ->
                 let* reply_event =
                   append_keeper_reply_event

--- a/test/test_tool_trpg_coverage.ml
+++ b/test/test_tool_trpg_coverage.ml
@@ -142,10 +142,67 @@ let test_round_run_timeout_policy () =
   let ok, body = dispatch_exn ctx ~name:"masc_trpg_round_run" ~args in
   Alcotest.(check bool) "round_run success despite timeout" true ok;
   let json = parse_json_exn body in
+  let statuses = json |> Yojson.Safe.Util.member "statuses" |> Yojson.Safe.Util.to_list in
+  let timeout_status =
+    List.find_opt
+      (fun s ->
+        s |> Yojson.Safe.Util.member "status" |> Yojson.Safe.Util.to_string = "timeout")
+      statuses
+  in
+  (match timeout_status with
+  | Some status_json ->
+      Alcotest.(check string)
+        "timeout status reason"
+        "timeout"
+        (status_json |> Yojson.Safe.Util.member "reason" |> Yojson.Safe.Util.to_string);
+      Alcotest.(check string)
+        "timeout status stage"
+        "masc_keeper_msg"
+        (status_json |> Yojson.Safe.Util.member "stage" |> Yojson.Safe.Util.to_string)
+  | None -> Alcotest.fail "timeout status is missing");
   let summary = Yojson.Safe.Util.member "summary" json in
   Alcotest.(check int) "timeouts" 1 (Yojson.Safe.Util.member "timeouts" summary |> Yojson.Safe.Util.to_int);
   Alcotest.(check int) "unavailable" 1 (Yojson.Safe.Util.member "unavailable" summary |> Yojson.Safe.Util.to_int);
   Alcotest.(check int) "successes" 1 (Yojson.Safe.Util.member "successes" summary |> Yojson.Safe.Util.to_int);
+  let events = json |> Yojson.Safe.Util.member "events" |> Yojson.Safe.Util.to_list in
+  let timeout_event =
+    List.find_opt
+      (fun event_json ->
+        event_json |> Yojson.Safe.Util.member "type" |> Yojson.Safe.Util.to_string
+        = "turn.timeout")
+      events
+  in
+  (match timeout_event with
+  | Some event_json ->
+      let payload = event_json |> Yojson.Safe.Util.member "payload" in
+      Alcotest.(check string)
+        "turn.timeout payload reason"
+        "timeout"
+        (payload |> Yojson.Safe.Util.member "reason" |> Yojson.Safe.Util.to_string);
+      Alcotest.(check string)
+        "turn.timeout payload stage"
+        "masc_keeper_msg"
+        (payload |> Yojson.Safe.Util.member "stage" |> Yojson.Safe.Util.to_string)
+  | None -> Alcotest.fail "turn.timeout event is missing");
+  let unavailable_event =
+    List.find_opt
+      (fun event_json ->
+        event_json |> Yojson.Safe.Util.member "type" |> Yojson.Safe.Util.to_string
+        = "keeper.unavailable")
+      events
+  in
+  (match unavailable_event with
+  | Some event_json ->
+      let payload = event_json |> Yojson.Safe.Util.member "payload" in
+      Alcotest.(check string)
+        "keeper.unavailable payload reason"
+        "timeout"
+        (payload |> Yojson.Safe.Util.member "reason" |> Yojson.Safe.Util.to_string);
+      Alcotest.(check string)
+        "keeper.unavailable payload stage"
+        "masc_keeper_msg"
+        (payload |> Yojson.Safe.Util.member "stage" |> Yojson.Safe.Util.to_string)
+  | None -> Alcotest.fail "keeper.unavailable event is missing");
 
   let _, timeout_stream =
     dispatch_exn ctx ~name:"masc_trpg_stream"

--- a/viewer/index.html
+++ b/viewer/index.html
@@ -252,6 +252,13 @@
                     </div>
                     <!-- Turn Runtime: live game status grid (populated by turn_runtime.rs) -->
                     <div id="turn-runtime"></div>
+                    <div id="state-legend" class="state-legend">
+                        <span class="state-chip state-running">RUNNING: 라운드 순환 중</span>
+                        <span class="state-chip state-stopped">STOPPED: 일시 정지/재개 대기</span>
+                        <span class="state-chip state-lobby">LOBBY: 세션 시작 전</span>
+                        <span class="state-chip state-ended">ENDED: 세션 종료</span>
+                        <span class="state-chip state-unavailable">UNAVAILABLE: 연결/키퍼 오류</span>
+                    </div>
                     <!-- Turn Controls: advance turn (Keeper/GM only) -->
                     <div id="turn-controls" style="display:none">
                         <button id="advance-turn-btn" title="Run next TRPG round">Run Round</button>

--- a/viewer/src/dom/actor_join.rs
+++ b/viewer/src/dom/actor_join.rs
@@ -16,6 +16,8 @@ use wasm_bindgen::prelude::*;
 use crate::config;
 #[cfg(target_arch = "wasm32")]
 use crate::dom::action_panel::friendly_js_error;
+#[cfg(target_arch = "wasm32")]
+use crate::game::lifecycle::TrpgLifecycleState;
 use crate::game::state::{RoomState, TurnProgressState};
 
 // ─── Marker Resource ────────────────────────
@@ -59,53 +61,9 @@ pub fn sync_join_panel_interaction_state(
 
     #[cfg(target_arch = "wasm32")]
     {
-        fn normalize_room_status(raw: &str) -> String {
-            let normalized = raw.trim().to_ascii_lowercase();
-            if normalized.is_empty() {
-                "unknown".to_string()
-            } else {
-                normalized
-            }
-        }
-
-        fn effective_room_status(room_status: &str, progress_status: &str) -> String {
-            if !progress_status.is_empty() {
-                normalize_room_status(progress_status)
-            } else {
-                normalize_room_status(room_status)
-            }
-        }
-
-        fn room_accepts_join(status: &str) -> bool {
-            matches!(
-                status,
-                "active"
-                    | "running"
-                    | "in_progress"
-                    | "round"
-                    | "combat"
-                    | "briefing"
-                    | "dm_narration"
-                    | "party_discussion"
-                    | "action_declaration"
-                    | "dice_resolution"
-                    | "outcome_narration"
-                    | "state_update"
-                    | "transition"
-            )
-        }
-
-        fn room_blocked_join_message(status: &str) -> Option<&'static str> {
-            match status {
-                "ended" => Some("Game Ended"),
-                "archived" => Some("Archived"),
-                "error" => Some("Error State"),
-                _ => None,
-            }
-        }
-
-        let status = effective_room_status(&room_state.status, &progress.room_status);
-        let can_join = room_accepts_join(&status);
+        let lifecycle =
+            TrpgLifecycleState::from_room_progress(&room_state.status, &progress.room_status);
+        let can_join = lifecycle.accepts_player_input();
 
         let Some(doc) = web_sys::window().and_then(|w| w.document()) else {
             return;
@@ -117,8 +75,7 @@ pub fn sync_join_panel_interaction_state(
                 let _ = btn.set_attribute("title", "Claim actor and join game");
             } else {
                 let _ = btn.set_attribute("disabled", "true");
-                let reason = room_blocked_join_message(&status).unwrap_or("Unavailable");
-                let _ = btn.set_attribute("title", reason);
+                let _ = btn.set_attribute("title", lifecycle.help_text());
             }
         }
     }

--- a/viewer/src/dom/turn_controls.rs
+++ b/viewer/src/dom/turn_controls.rs
@@ -22,6 +22,8 @@ use wasm_bindgen::prelude::*;
 #[cfg(target_arch = "wasm32")]
 use crate::config;
 use crate::game::state::{RoomState, TurnProgressState};
+#[cfg(target_arch = "wasm32")]
+use crate::game::lifecycle::TrpgLifecycleState;
 
 // ─── Marker Resource ────────────────────────
 
@@ -60,21 +62,9 @@ pub fn sync_turn_controls_visibility(room_state: Res<RoomState>, progress: Res<T
 
     #[cfg(target_arch = "wasm32")]
     {
-        fn normalize_room_status(raw: &str) -> String {
-            let normalized = raw.trim().to_ascii_lowercase();
-            if normalized.is_empty() {
-                "unknown".to_string()
-            } else {
-                normalized
-            }
-        }
-
-        let status = if !progress.room_status.trim().is_empty() {
-            normalize_room_status(&progress.room_status)
-        } else {
-            normalize_room_status(&room_state.status)
-        };
-        let room_allows_control = is_room_active_for_controls(&status);
+        let lifecycle =
+            TrpgLifecycleState::from_room_progress(&room_state.status, &progress.room_status);
+        let room_allows_control = lifecycle.allows_round_control();
 
         let Some(doc) = web_sys::window().and_then(|w| w.document()) else {
             return;
@@ -112,28 +102,8 @@ pub fn sync_turn_controls_visibility(room_state: Res<RoomState>, progress: Res<T
             "display:none"
         };
         let _ = panel.set_attribute("style", style);
+        let _ = panel.set_attribute("data-lifecycle", lifecycle.css_class());
     }
-}
-
-#[cfg(target_arch = "wasm32")]
-fn is_room_active_for_controls(status: &str) -> bool {
-    matches!(
-        status,
-        "active"
-            | "running"
-            | "in_progress"
-            | "round"
-            | "combat"
-            | "briefing"
-            | "dm_narration"
-            | "party_discussion"
-            | "action_declaration"
-            | "dice_resolution"
-            | "outcome_narration"
-            | "state_update"
-            | "transition"
-            | "paused"
-    )
 }
 
 // ─── Event: Advance Button ──────────────────

--- a/viewer/src/dom/turn_runtime.rs
+++ b/viewer/src/dom/turn_runtime.rs
@@ -1,6 +1,7 @@
 use bevy::prelude::*;
 
 use crate::game::components::Actor;
+use crate::game::lifecycle::TrpgLifecycleState;
 use crate::game::state::{RoomState, TurnProgressState};
 
 /// Tracks last-rendered runtime status snapshot to avoid redundant DOM updates.
@@ -22,64 +23,21 @@ fn pretty_phase(phase: &str) -> String {
     }
 }
 
-fn normalize_room_status(raw: &str) -> String {
-    let normalized = raw.trim().to_ascii_lowercase();
-    if normalized.is_empty() {
-        "unknown".to_string()
-    } else {
-        normalized
+#[cfg(target_arch = "wasm32")]
+fn room_status_class(state: TrpgLifecycleState) -> &'static str {
+    match state {
+        TrpgLifecycleState::Running => "status-active",
+        TrpgLifecycleState::Stopped => "status-paused",
+        TrpgLifecycleState::Ended => "status-ended",
+        TrpgLifecycleState::Unavailable => "status-unavailable",
+        TrpgLifecycleState::Loading => "status-loading",
+        TrpgLifecycleState::Lobby | TrpgLifecycleState::Unknown => "status-idle",
     }
 }
 
 #[cfg(target_arch = "wasm32")]
-fn room_status_class(status: &str) -> &'static str {
-    match status {
-        "active" | "running" | "in_progress" | "round" | "combat" | "briefing" => {
-            "status-active"
-        }
-        "dm_narration" | "party_discussion" | "action_declaration" | "dice_resolution"
-        | "outcome_narration" | "state_update" | "transition" => "status-active",
-        "paused" | "stopped" => "status-paused",
-        "ended" => "status-ended",
-        "unavailable" => "status-unavailable",
-        "loading" => "status-loading",
-        _ => "status-idle",
-    }
-}
-
-#[cfg(target_arch = "wasm32")]
-fn room_status_label(status: &str) -> &'static str {
-    match status {
-        "active" | "running" | "in_progress" | "round" | "combat" | "briefing" => "RUNNING",
-        "dm_narration" | "party_discussion" | "action_declaration" | "dice_resolution"
-        | "outcome_narration" | "state_update" | "transition" => "RUNNING",
-        "paused" => "PAUSED",
-        "stopped" => "STOPPED",
-        "ended" => "ENDED",
-        "idle" => "IDLE",
-        "loading" => "LOADING",
-        "unavailable" => "UNAVAILABLE",
-        _ => "UNKNOWN",
-    }
-}
-
-fn room_accepts_input(status: &str) -> bool {
-    matches!(
-        status,
-        "active"
-            | "running"
-            | "in_progress"
-            | "round"
-            | "combat"
-            | "briefing"
-            | "dm_narration"
-            | "party_discussion"
-            | "action_declaration"
-            | "dice_resolution"
-            | "outcome_narration"
-            | "state_update"
-            | "transition"
-    )
+fn room_status_label(state: TrpgLifecycleState) -> &'static str {
+    state.label()
 }
 
 /// Render live TRPG runtime progress:
@@ -97,7 +55,8 @@ pub fn update_turn_runtime_dom(
     } else {
         "unknown".to_string()
     };
-    let room_status = normalize_room_status(&room_status_raw);
+    let lifecycle = TrpgLifecycleState::from_room_progress(&room_state.status, &progress.room_status);
+    let room_status_key = crate::game::lifecycle::normalize_status(&room_status_raw);
     let turn = if progress.turn > 0 {
         progress.turn
     } else if room_state.turn > 0 {
@@ -152,15 +111,15 @@ pub fn update_turn_runtime_dom(
         format!("{}/{} alive", alive_party, total_party)
     };
 
-    let current_status = if !room_accepts_input(&room_status) {
-        room_status.as_str()
+    let current_status = if !lifecycle.accepts_player_input() {
+        lifecycle.label_ko()
     } else if current_actor != "-" {
         "thinking"
     } else {
         "waiting"
     };
 
-    let input_status = if room_accepts_input(&room_status) {
+    let input_status = if lifecycle.accepts_player_input() {
         "enabled"
     } else {
         "disabled"
@@ -168,7 +127,7 @@ pub fn update_turn_runtime_dom(
 
     let snapshot = format!(
         "{}|{}|{}|{}|{}|{}|{}|{}|{}",
-        room_status,
+        room_status_key,
         turn,
         phase,
         current_actor,
@@ -192,21 +151,43 @@ pub fn update_turn_runtime_dom(
             return;
         };
 
-        let room_class = room_status_class(&room_status);
+        let room_class = room_status_class(lifecycle);
         let party_class = if total_party > 0 && alive_party <= 0 {
             "status-wipe"
         } else {
             "status-active"
         };
-        let input_class = if room_accepts_input(&room_status) {
+        let input_class = if lifecycle.accepts_player_input() {
             "status-active"
         } else {
             room_class
         };
 
+        if let Some(room_status_el) = document.get_element_by_id("room-status") {
+            let room_id = crate::config::current_room_id();
+            room_status_el.set_text_content(Some(&format!(
+                "room {} · {}",
+                room_id,
+                lifecycle.label_ko()
+            )));
+            let _ = room_status_el.set_attribute("data-lifecycle", lifecycle.css_class());
+            let _ = room_status_el.set_attribute(
+                "title",
+                &format!(
+                    "{} | turn {} | phase {} | raw {}",
+                    lifecycle.help_text(),
+                    turn,
+                    phase,
+                    room_status_key
+                ),
+            );
+        }
+
         let html = format!(
             r#"
 <div class="turn-runtime-grid">
+  <div class="turn-runtime-item turn-runtime-item-wide"><span class="k">Lifecycle</span><span class="v {lifecycle_class}">{lifecycle_label}</span></div>
+  <div class="turn-runtime-item turn-runtime-item-wide"><span class="k">Definition</span><span class="v">{lifecycle_help}</span></div>
   <div class="turn-runtime-item"><span class="k">State</span><span class="v {room_class}">{room}</span></div>
   <div class="turn-runtime-item"><span class="k">Turn</span><span class="v">{turn}</span></div>
   <div class="turn-runtime-item"><span class="k">Phase</span><span class="v">{phase}</span></div>
@@ -217,8 +198,11 @@ pub fn update_turn_runtime_dom(
   <div class="turn-runtime-item"><span class="k">Party</span><span class="v {party_class}">{party}</span></div>
 </div>
 "#,
+            lifecycle_class = format!("{} {}", room_class, lifecycle.css_class()),
+            lifecycle_label = html_escape(&format!("{} ({})", lifecycle.label(), lifecycle.label_ko())),
+            lifecycle_help = html_escape(lifecycle.help_text()),
             room_class = room_class,
-            room = html_escape(room_status_label(&room_status)),
+            room = html_escape(room_status_label(lifecycle)),
             turn = turn,
             phase = html_escape(&pretty_phase(&phase)),
             input_class = input_class,

--- a/viewer/src/game/lifecycle.rs
+++ b/viewer/src/game/lifecycle.rs
@@ -1,0 +1,131 @@
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TrpgLifecycleState {
+    Lobby,
+    Loading,
+    Running,
+    Stopped,
+    Ended,
+    Unavailable,
+    Unknown,
+}
+
+pub fn normalize_status(raw: &str) -> String {
+    let normalized = raw.trim().to_ascii_lowercase();
+    if normalized.is_empty() {
+        "unknown".to_string()
+    } else {
+        normalized
+    }
+}
+
+impl TrpgLifecycleState {
+    #[allow(dead_code)]
+    pub fn from_status(raw: &str) -> Self {
+        let status = normalize_status(raw);
+        match status.as_str() {
+            "active"
+            | "running"
+            | "in_progress"
+            | "round"
+            | "combat"
+            | "briefing"
+            | "dm_narration"
+            | "party_discussion"
+            | "action_declaration"
+            | "dice_resolution"
+            | "outcome_narration"
+            | "state_update"
+            | "transition" => Self::Running,
+            "paused" | "stopped" | "suspended" | "halted" => Self::Stopped,
+            "ended" | "completed" | "done" | "retired" | "closed" | "archived" => Self::Ended,
+            "loading" | "bootstrapping" | "syncing" => Self::Loading,
+            "unavailable" | "error" | "failed" => Self::Unavailable,
+            "idle" | "lobby" | "created" | "ready" => Self::Lobby,
+            "unknown" => Self::Unknown,
+            _ => Self::Unknown,
+        }
+    }
+
+    #[allow(dead_code)]
+    pub fn from_room_progress(room_status: &str, progress_status: &str) -> Self {
+        let source = if progress_status.trim().is_empty() {
+            room_status
+        } else {
+            progress_status
+        };
+        Self::from_status(source)
+    }
+
+    #[allow(dead_code)]
+    pub fn lane(self) -> &'static str {
+        match self {
+            Self::Running => "running",
+            Self::Stopped => "stopped",
+            Self::Ended => "ended",
+            Self::Unavailable => "unavailable",
+            Self::Lobby | Self::Loading | Self::Unknown => "lobby",
+        }
+    }
+
+    #[allow(dead_code)]
+    pub fn css_class(self) -> &'static str {
+        match self {
+            Self::Lobby => "state-lobby",
+            Self::Loading => "state-loading",
+            Self::Running => "state-running",
+            Self::Stopped => "state-stopped",
+            Self::Ended => "state-ended",
+            Self::Unavailable => "state-unavailable",
+            Self::Unknown => "state-unknown",
+        }
+    }
+
+    #[allow(dead_code)]
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Lobby => "LOBBY",
+            Self::Loading => "LOADING",
+            Self::Running => "RUNNING",
+            Self::Stopped => "STOPPED",
+            Self::Ended => "ENDED",
+            Self::Unavailable => "UNAVAILABLE",
+            Self::Unknown => "UNKNOWN",
+        }
+    }
+
+    #[allow(dead_code)]
+    pub fn label_ko(self) -> &'static str {
+        match self {
+            Self::Lobby => "로비",
+            Self::Loading => "로딩",
+            Self::Running => "진행 중",
+            Self::Stopped => "멈춤",
+            Self::Ended => "종료",
+            Self::Unavailable => "연결 오류",
+            Self::Unknown => "상태 불명",
+        }
+    }
+
+    #[allow(dead_code)]
+    pub fn help_text(self) -> &'static str {
+        match self {
+            Self::Lobby => "세션 미시작 또는 초기 대기 상태",
+            Self::Loading => "상태 동기화/초기화 진행 중",
+            Self::Running => "라운드가 순환 중이며 입력/결과가 반영되는 상태",
+            Self::Stopped => "의도적으로 멈춘 상태(재개 가능)",
+            Self::Ended => "세션 종료 상태(새 게임 필요)",
+            Self::Unavailable => "엔진/키퍼/네트워크 오류로 진행 불가",
+            Self::Unknown => "분류되지 않은 상태 값",
+        }
+    }
+
+    #[allow(dead_code)]
+    pub fn allows_round_control(self) -> bool {
+        matches!(self, Self::Running | Self::Stopped)
+    }
+
+    #[allow(dead_code)]
+    pub fn accepts_player_input(self) -> bool {
+        matches!(self, Self::Running)
+    }
+}

--- a/viewer/src/game/mod.rs
+++ b/viewer/src/game/mod.rs
@@ -1,6 +1,7 @@
 pub mod components;
 pub mod events;
 pub mod http;
+pub mod lifecycle;
 pub mod round_runner;
 pub mod state;
 pub mod systems;

--- a/viewer/src/mode.rs
+++ b/viewer/src/mode.rs
@@ -23,6 +23,8 @@ use wasm_bindgen::JsCast;
 
 #[cfg(target_arch = "wasm32")]
 use wasm_bindgen_futures::JsFuture;
+#[cfg(target_arch = "wasm32")]
+use crate::game::lifecycle::TrpgLifecycleState;
 
 /// Top-level viewer mode. Determines which plugins/systems are active
 /// and which SSE endpoint the viewer connects to.
@@ -809,13 +811,7 @@ struct RoomSnapshot {
 
 #[cfg(target_arch = "wasm32")]
 fn room_lane_label(status: &str) -> &'static str {
-    let key = status.trim().to_ascii_lowercase();
-    match key.as_str() {
-        "active" | "running" | "in_progress" => "running",
-        "stopped" | "suspended" | "paused" => "stopped",
-        "ended" | "completed" | "done" | "retired" | "closed" => "ended",
-        _ => "lobby",
-    }
+    TrpgLifecycleState::from_status(status).lane()
 }
 
 #[cfg(target_arch = "wasm32")]
@@ -826,6 +822,7 @@ fn render_room_hub(doc: &web_sys::Document, rooms: &[RoomSnapshot], selected_roo
     let mut running = Vec::new();
     let mut stopped = Vec::new();
     let mut lobby = Vec::new();
+    let mut unavailable = Vec::new();
     let mut ended = Vec::new();
 
     for room in rooms {
@@ -840,16 +837,19 @@ fn render_room_hub(doc: &web_sys::Document, rooms: &[RoomSnapshot], selected_roo
         } else {
             room.status.clone()
         };
+        let lifecycle = TrpgLifecycleState::from_status(&status_text);
         let card = format!(
             concat!(
                 "<button class=\"room-chip\" data-room-id=\"{id}\" data-room-status=\"{status}\"{current}>",
-                "<span class=\"room-chip-id\">{id}</span>",
+                "<span class=\"room-chip-id\">{id}<span class=\"room-chip-state {state_class}\">{state_label}</span></span>",
                 "<span class=\"room-chip-meta\">turn {turn} · {phase} · a{agents}/t{tasks}</span>",
                 "</button>"
             ),
             id = html_escape(&room.id),
             status = html_escape(&status_text),
             current = current_attr,
+            state_class = lifecycle.css_class(),
+            state_label = lifecycle.label_ko(),
             turn = room.turn,
             phase = html_escape(&room.phase),
             agents = room.agent_count,
@@ -858,6 +858,7 @@ fn render_room_hub(doc: &web_sys::Document, rooms: &[RoomSnapshot], selected_roo
         match lane {
             "running" => running.push(card),
             "stopped" => stopped.push(card),
+            "unavailable" => unavailable.push(card),
             "ended" => ended.push(card),
             _ => lobby.push(card),
         }
@@ -878,10 +879,11 @@ fn render_room_hub(doc: &web_sys::Document, rooms: &[RoomSnapshot], selected_roo
     };
 
     let html = format!(
-        "{}{}{}{}",
+        "{}{}{}{}{}",
         lane_html("진행 중", running, "running"),
         lane_html("멈춤", stopped, "stopped"),
         lane_html("로비", lobby, "lobby"),
+        lane_html("오류", unavailable, "unavailable"),
         lane_html("종료", ended, "ended")
     );
     hub.set_inner_html(&html);
@@ -1099,7 +1101,14 @@ fn sync_room_controls(doc: &web_sys::Document, selected_room: &str) {
         input.set_value(&selected);
     }
     if let Some(pill) = doc.get_element_by_id("room-status") {
-        pill.set_text_content(Some(&format!("room {}", selected)));
+        let lifecycle = TrpgLifecycleState::Lobby;
+        pill.set_text_content(Some(&format!(
+            "room {} · {}",
+            selected,
+            lifecycle.label_ko()
+        )));
+        let _ = pill.set_attribute("data-lifecycle", lifecycle.css_class());
+        let _ = pill.set_attribute("title", lifecycle.help_text());
     }
     sync_room_hub_selection(doc, &selected);
 }

--- a/viewer/style.css
+++ b/viewer/style.css
@@ -483,6 +483,27 @@ body.mode-lobby #dashboard {
     white-space: nowrap;
 }
 
+.widget-pill[data-lifecycle] {
+    border-color: rgba(109, 122, 164, 0.45);
+}
+
+.widget-pill[data-lifecycle="state-running"] {
+    border-color: rgba(88, 184, 116, 0.42);
+    color: var(--status-connected);
+}
+
+.widget-pill[data-lifecycle="state-stopped"],
+.widget-pill[data-lifecycle="state-loading"] {
+    border-color: rgba(168, 119, 45, 0.42);
+    color: var(--status-connecting);
+}
+
+.widget-pill[data-lifecycle="state-ended"],
+.widget-pill[data-lifecycle="state-unavailable"] {
+    border-color: rgba(177, 116, 116, 0.32);
+    color: var(--status-disconnected);
+}
+
 .inline-toggle.primary {
     border-color: var(--accent-primary);
     box-shadow: inset 0 0 0 1px rgba(201, 165, 90, 0.35);
@@ -570,7 +591,7 @@ body.mode-lobby #dashboard {
     border-radius: var(--panel-radius);
     background: rgba(10, 14, 28, 0.86);
     display: grid;
-    grid-template-columns: repeat(4, minmax(120px, 1fr));
+    grid-template-columns: repeat(5, minmax(120px, 1fr));
     gap: 8px;
     max-height: 192px;
     overflow: hidden;
@@ -600,6 +621,11 @@ body.mode-lobby #dashboard {
 
 .room-lane[data-lane="ended"] {
     border-color: rgba(177, 116, 116, 0.32);
+}
+
+.room-lane[data-lane="unavailable"] {
+    border-color: rgba(177, 116, 116, 0.55);
+    box-shadow: inset 0 0 0 1px rgba(136, 66, 66, 0.35);
 }
 
 .room-lane-title {
@@ -650,11 +676,26 @@ body.mode-lobby #dashboard {
 .room-chip-id {
     font-size: 11px;
     font-weight: 600;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 6px;
 }
 
 .room-chip-meta {
     font-size: 10px;
     color: var(--text-dim);
+}
+
+.room-chip-state {
+    font-size: 9px;
+    font-family: var(--font-ui);
+    text-transform: uppercase;
+    letter-spacing: 0.7px;
+    color: var(--text-dim);
+    border: 1px solid rgba(100, 100, 120, 0.4);
+    border-radius: 999px;
+    padding: 1px 6px;
 }
 
 @media (max-width: 1280px) {
@@ -1550,6 +1591,10 @@ body.mode-lobby #dashboard {
     gap: 6px 10px;
 }
 
+.turn-runtime-item.turn-runtime-item-wide {
+    grid-column: 1 / -1;
+}
+
 .turn-runtime-item {
     display: flex;
     justify-content: space-between;
@@ -1590,6 +1635,53 @@ body.mode-lobby #dashboard {
 
 .turn-runtime-item .v.status-idle {
     color: var(--text-dim);
+}
+
+.turn-runtime-item .v.state-running,
+.room-chip-state.state-running {
+    color: var(--status-connected);
+    border-color: rgba(88, 184, 116, 0.42);
+}
+
+.turn-runtime-item .v.state-stopped,
+.room-chip-state.state-stopped,
+.turn-runtime-item .v.state-loading,
+.room-chip-state.state-loading {
+    color: var(--status-connecting);
+    border-color: rgba(168, 119, 45, 0.42);
+}
+
+.turn-runtime-item .v.state-ended,
+.room-chip-state.state-ended,
+.turn-runtime-item .v.state-unavailable,
+.room-chip-state.state-unavailable {
+    color: var(--status-disconnected);
+    border-color: rgba(177, 116, 116, 0.32);
+}
+
+.turn-runtime-item .v.state-lobby,
+.room-chip-state.state-lobby,
+.turn-runtime-item .v.state-unknown,
+.room-chip-state.state-unknown {
+    color: var(--text-dim);
+}
+
+#state-legend {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+    margin: 0 0 8px;
+}
+
+.state-chip {
+    font-size: 9px;
+    border: 1px solid var(--border-main);
+    border-radius: 999px;
+    padding: 2px 6px;
+    color: var(--text-dim);
+    background: rgba(20, 24, 40, 0.65);
+    letter-spacing: 0.55px;
+    text-transform: uppercase;
 }
 
 /* ─── Turn Controls (advance turn button) ─── */


### PR DESCRIPTION
## Summary
- add a shared TRPG lifecycle state model in viewer and use it to drive room lane, status pill, controls, and join gating
- add in-UI lifecycle legend and clearer state labels/help text for lobby/running/paused/ended/unavailable
- enrich trpg.round.run timeout/unavailable telemetry with explicit reason + stage in both emitted events and returned statuses
- add coverage assertions for timeout event/status payload shape

## Test
- cargo test --manifest-path viewer/Cargo.toml --release
- dune exec --root . test/test_tool_trpg_coverage.exe
