### PR TITLE
fix(viewer): remove 19 dead code warnings

### DIFF
--- a/viewer/src/audio.rs
+++ b/viewer/src/audio.rs
@@ -85,7 +85,6 @@ pub mod paths {
     pub const SFX_TURN_ADVANCE: &str = "audio/sfx_turn_advance.ogg";
     pub const SFX_COMBAT_START: &str = "audio/sfx_combat_start.ogg";
     pub const SFX_DEATH: &str = "audio/sfx_death.ogg";
-    pub const SFX_ITEM_ACQUIRE: &str = "audio/sfx_item_acquire.ogg";
 }
 
 /// Map mood string to BGM path.

--- a/viewer/src/config.rs
+++ b/viewer/src/config.rs
@@ -9,26 +9,6 @@ pub const MASC_MCP_URL: &str = "";
 
 pub const DEFAULT_ROOM_ID: &str = "default";
 
-/// Polling interval for TRPG stream fallback (milliseconds).
-/// Backend exposes GET /api/v1/trpg/stream (JSON), no dedicated SSE endpoint.
-pub const TRPG_POLL_INTERVAL_MS: u64 = 2000;
-/// Legacy TRPG Engine URL (for direct mode)
-#[cfg(debug_assertions)]
-pub const TRPG_ENGINE_URL: &str = "http://localhost:8000";
-
-#[cfg(not(debug_assertions))]
-pub const TRPG_ENGINE_URL: &str = "";
-
-// ─── Backend Mode ───────────────────────────
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum TrpgBackendMode {
-    MascApi,      // Uses /api/v1/trpg endpoints (default)
-    LegacyEngine, // Uses direct engine endpoints (if needed)
-}
-
-pub const DEFAULT_TRPG_BACKEND: TrpgBackendMode = TrpgBackendMode::MascApi;
-
 // ─── Room ID Management ─────────────────────
 
 /// Get current room ID from DOM attribute (set by dashboard/lobby) or URL param.
@@ -151,16 +131,6 @@ pub fn trpg_stream_poll_url(after_seq: i64) -> String {
     )
 }
 
-/// SSE poll endpoint (JSON event stream) for browsers that can consume
-/// EventSource from `/api/v1/trpg/stream/sse`.
-pub fn trpg_stream_sse_url() -> String {
-    format!(
-        "{}/api/v1/trpg/stream/sse?room_id={}",
-        MASC_MCP_URL,
-        current_room_id()
-    )
-}
-
 pub fn sse_endpoint(mode: &ViewerMode) -> Option<String> {
     match mode {
         ViewerMode::Trpg => Some(format!(
@@ -193,35 +163,3 @@ pub fn sse_endpoint_by_name(mode_name: &str) -> Option<String> {
     }
 }
 
-/// Helper to get full room URL for external links (if needed)
-pub fn trpg_room_url(path: &str) -> String {
-    format!(
-        "{}/rooms/{}/{}",
-        MASC_MCP_URL,
-        current_room_id(),
-        path.trim_start_matches('/')
-    )
-}
-
-// ─── Actor ID Management ─────────────────────
-
-/// Get current actor ID from dashboard attribute (selected player in lobby).
-/// This serves as a fallback when TurnProgressState doesn't have an active actor.
-pub fn current_actor_id() -> Option<String> {
-    #[cfg(target_arch = "wasm32")]
-    {
-        if let Some(doc) = web_sys::window().and_then(|w| w.document()) {
-            // 1. Try dashboard attribute (set by lobby/character selection)
-            if let Some(el) = doc.get_element_by_id("dashboard") {
-                if let Some(actor) = el.get_attribute("data-current-actor") {
-                    let actor = actor.trim().to_string();
-                    if !actor.is_empty() {
-                        return Some(actor);
-                    }
-                }
-            }
-        }
-    }
-
-    None
-}

--- a/viewer/src/game/events.rs
+++ b/viewer/src/game/events.rs
@@ -32,6 +32,7 @@ pub struct NarrativePayload {
     pub text: String,
     pub phase: String,
     #[serde(default)]
+    #[allow(dead_code)]
     pub turn: u32,
     #[serde(default)]
     pub speaker: Option<String>,
@@ -159,6 +160,7 @@ pub struct TurnProgressUpdated(pub TurnProgressPayload);
 
 #[derive(Debug, Clone, Deserialize)]
 pub struct PartySelectedPayload {
+    #[allow(dead_code)]
     pub room_id: String,
     #[serde(default)]
     pub selected_player_ids: Vec<String>,
@@ -180,6 +182,7 @@ pub struct RoomLifecyclePayload {
 
 #[derive(Debug, Clone, Deserialize)]
 pub struct SessionStartedPayload {
+    #[allow(dead_code)]
     pub room_id: String,
     #[serde(default)]
     pub session_id: String,
@@ -239,12 +242,14 @@ pub struct ActorLifecyclePayload {
 pub struct RoomEndedPayload {
     pub room_id: String,
     #[serde(default)]
+    #[allow(dead_code)]
     pub reason: String,
 }
 
 #[derive(Debug, Clone, Deserialize)]
 pub struct TurnActionResolvedPayload {
     #[serde(default)]
+    #[allow(dead_code)]
     pub turn: u32,
     pub actor_id: String,
     pub action: String,

--- a/viewer/src/game/http.rs
+++ b/viewer/src/game/http.rs
@@ -585,7 +585,7 @@ fn parse_dice_log(root: &Value) -> Option<Vec<DiceRollPayload>> {
 fn parse_dice_log_entry(
     entry: &Value,
     fallback_turn: u32,
-    fallback_phase: &str,
+    _fallback_phase: &str,
 ) -> Option<DiceRollPayload> {
     if !entry.is_object() {
         return None;

--- a/viewer/src/mode.rs
+++ b/viewer/src/mode.rs
@@ -627,59 +627,6 @@ fn assign_keepers_to_actor_ids(
 }
 
 #[cfg(target_arch = "wasm32")]
-fn parse_preset_id(value: &Value, field: &str) -> Option<String> {
-    match value.get(field) {
-        Some(Value::Array(items)) if !items.is_empty() => {
-            items.first().and_then(Value::as_object).and_then(|obj| {
-                obj.get("id")
-                    .and_then(Value::as_str)
-                    .map(|id| id.trim().to_string())
-            })
-        }
-        Some(Value::String(v)) if !v.trim().is_empty() => Some(v.trim().to_string()),
-        Some(value_obj) if value_obj.is_object() => value_obj
-            .get("id")
-            .and_then(Value::as_str)
-            .map(|id| id.trim().to_string()),
-        _ => None,
-    }
-}
-
-#[cfg(target_arch = "wasm32")]
-fn pick_preset_id_from_catalog(catalog: &Value, field: &str) -> Option<String> {
-    let mut candidates: Vec<&Value> = vec![catalog];
-
-    if let Some(payload) = catalog.get("payload") {
-        candidates.push(payload);
-    }
-    if let Some(result) = catalog.get("result") {
-        candidates.push(result);
-    }
-    if let Some(structured) = catalog
-        .get("result")
-        .and_then(|r| r.get("structuredContent"))
-    {
-        candidates.push(structured);
-    }
-    candidates.push(catalog);
-    let direct = candidates
-        .into_iter()
-        .find_map(|node| parse_preset_id(node, field));
-    if direct.is_some() {
-        return direct;
-    }
-    let nested = catalog
-        .get("result")
-        .and_then(|result| result.get("payload"))
-        .and_then(|payload| payload.get(field))
-        .and_then(|value| parse_preset_id(value, field));
-    if nested.is_some() {
-        return nested;
-    }
-    None
-}
-
-#[cfg(target_arch = "wasm32")]
 fn format_round_plan_for_display(dm_keeper: &str, players: &[(String, String)]) -> String {
     let mut lines = vec![format!("DM: {}", dm_keeper)];
     if players.is_empty() {
@@ -1976,33 +1923,6 @@ async fn start_new_game_flow(doc: &web_sys::Document) -> Result<String, String> 
         dm_keeper,
         player_map.len()
     ))
-}
-
-#[cfg(target_arch = "wasm32")]
-fn set_new_game_assignment(
-    doc: &web_sys::Document,
-    dm_keeper: &str,
-    player_map: &std::collections::HashMap<String, String>,
-    actor_ids: &[String],
-) {
-    let Some(el) = doc.get_element_by_id("new-game-assignment") else {
-        return;
-    };
-    let mut html = String::from("<strong>배정 확인</strong><ul>");
-    html.push_str(&format!("<li>DM: {}</li>", html_escape(dm_keeper)));
-    for actor_id in actor_ids {
-        let keeper = player_map
-            .get(actor_id)
-            .map(String::as_str)
-            .unwrap_or("미정");
-        html.push_str(&format!(
-            "<li>{} → {}</li>",
-            html_escape(actor_id),
-            html_escape(keeper)
-        ));
-    }
-    html.push_str("</ul>");
-    el.set_inner_html(&html);
 }
 
 #[cfg(target_arch = "wasm32")]

--- a/viewer/src/sse/client.rs
+++ b/viewer/src/sse/client.rs
@@ -215,7 +215,7 @@ fn map_snapshot_result(result: &Value) -> String {
 }
 
 #[allow(dead_code)]
-fn map_snapshot_dice_roll(entry: &Value, fallback_turn: u32, fallback_phase: &str) -> Option<(String, String)> {
+fn map_snapshot_dice_roll(entry: &Value, fallback_turn: u32, _fallback_phase: &str) -> Option<(String, String)> {
     if !entry.is_object() {
         return None;
     }
@@ -770,7 +770,7 @@ fn decode_stream_events(
     }
 
     let out = decode_snapshot_events(&parsed, state);
-    let mut max_seq = 0_i64;
+    let max_seq = 0_i64;
     Ok((max_seq, out))
 }
 


### PR DESCRIPTION
## Summary
- Viewer 빌드 시 19개 컴파일러 경고를 모두 제거
- 사용하지 않는 상수, enum, 함수 삭제 (−146 lines)
- serde 역직렬화 전용 struct 필드에 `#[allow(dead_code)]` 적용
- 사용하지 않는 매개변수 `_` 접두사, 불필요한 `mut` 제거

## Changes

| Category | Items | Fix |
|----------|-------|-----|
| Dead constants/enum | `TRPG_POLL_INTERVAL_MS`, `TRPG_ENGINE_URL`, `TrpgBackendMode`, `DEFAULT_TRPG_BACKEND`, `SFX_ITEM_ACQUIRE` | Deleted |
| Dead functions | `trpg_stream_sse_url`, `trpg_room_url`, `current_actor_id`, `parse_preset_id`, `pick_preset_id_from_catalog`, `set_new_game_assignment` | Deleted |
| Unused params | `fallback_phase` (x2) | `_fallback_phase` |
| Unnecessary mut | `max_seq` | Removed `mut` |
| Serde-only fields | `NarrativePayload.turn`, `PartySelectedPayload.room_id`, `SessionStartedPayload.room_id`, `RoomEndedPayload.reason`, `TurnActionResolvedPayload.turn` | `#[allow(dead_code)]` |

## Test plan
- [x] `cargo check --target wasm32-unknown-unknown` — 0 warnings, 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)