### PR TITLE
feat(viewer): stabilize TRPG round controls and new-game bootstrap

### DIFF
--- a/viewer/index.html
+++ b/viewer/index.html
@@ -195,6 +195,20 @@
                     </label>
 
                     <label class="new-game-field">
+                        <span>월드 프리셋</span>
+                        <select id="new-game-world-select" title="실행할 세계/시나리오 프리셋 선택">
+                            <option value="">로딩 중...</option>
+                        </select>
+                    </label>
+
+                    <label class="new-game-field">
+                        <span>DM 프리셋</span>
+                        <select id="new-game-dm-preset-select" title="DM 캐릭터 프롬프트 프리셋 선택">
+                            <option value="">로딩 중...</option>
+                        </select>
+                    </label>
+
+                    <label class="new-game-field">
                         <span>진행자 (DM)</span>
                         <select id="new-game-dm-select" title="게임을 진행할 AI 에이전트 선택">
                             <option value="">로딩 중...</option>
@@ -219,6 +233,53 @@
                     <button id="new-game-start" class="inline-toggle primary" type="button">세션 시작</button>
                 </div>
                 <div id="new-game-status" class="new-game-status">버튼을 눌러 준비하세요.</div>
+                <div id="new-game-assignment" class="new-game-assignment">세션 정보를 준비 중입니다.</div>
+
+                <div class="actor-admin">
+                    <div class="actor-admin-head">액터 관리 (현재 room)</div>
+                    <div class="actor-admin-grid">
+                        <label class="new-game-field">
+                            <span>Actor ID</span>
+                            <input id="actor-admin-id" type="text" maxlength="64" placeholder="warrior-1" />
+                        </label>
+                        <label class="new-game-field">
+                            <span>이름</span>
+                            <input id="actor-admin-name" type="text" maxlength="64" placeholder="그림자 전사" />
+                        </label>
+                        <label class="new-game-field">
+                            <span>역할</span>
+                            <select id="actor-admin-role">
+                                <option value="player" selected>player</option>
+                                <option value="npc">npc</option>
+                                <option value="dm">dm</option>
+                            </select>
+                        </label>
+                        <label class="new-game-field">
+                            <span>Keeper</span>
+                            <input id="actor-admin-keeper" type="text" maxlength="64" placeholder="grimja" />
+                        </label>
+                        <label class="new-game-field">
+                            <span>HP</span>
+                            <input id="actor-admin-hp" type="number" min="0" step="1" placeholder="20" />
+                        </label>
+                        <label class="new-game-field">
+                            <span>Max HP</span>
+                            <input id="actor-admin-max-hp" type="number" min="1" step="1" placeholder="20" />
+                        </label>
+                        <label class="new-game-field actor-admin-field-wide">
+                            <span>삭제 사유</span>
+                            <input id="actor-admin-delete-reason" type="text" maxlength="120" placeholder="out of story" />
+                        </label>
+                    </div>
+                    <div class="actor-admin-actions">
+                        <button id="actor-admin-refresh" class="inline-toggle" type="button">목록 새로고침</button>
+                        <button id="actor-admin-spawn" class="inline-toggle" type="button">생성</button>
+                        <button id="actor-admin-update" class="inline-toggle" type="button">수정</button>
+                        <button id="actor-admin-delete" class="inline-toggle" type="button">삭제</button>
+                    </div>
+                    <div id="actor-admin-status" class="new-game-status">액터 목록을 불러오세요.</div>
+                    <div id="actor-admin-list" class="actor-admin-list"></div>
+                </div>
             </div>
         </section>
 
@@ -261,7 +322,7 @@
                     </div>
                     <!-- Turn Controls: advance turn (Keeper/GM only) -->
                     <div id="turn-controls" style="display:none">
-                        <button id="advance-turn-btn" title="Run next TRPG round">Run Round</button>
+                        <button id="advance-turn-btn" title="다음 TRPG 라운드를 실행합니다">라운드 실행</button>
                         <span id="turn-control-status"></span>
                     </div>
                     <div id="round-run-summary" class="turn-run-summary" style="display:none"></div>

--- a/viewer/src/dom/character_panel.rs
+++ b/viewer/src/dom/character_panel.rs
@@ -202,6 +202,14 @@ pub fn update_character_panel_dom(actors: Query<&Actor>, mut cache: ResMut<Chara
         let mp_bar_class = mp_class(actor.mp, actor.max_mp);
         let icon = class_icon(&actor.class);
         let slug = class_slug(&actor.class);
+        let keeper_line = if actor.keeper.trim().is_empty() {
+            "<div class=\"char-owner owner-unassigned\">keeper: (unassigned)</div>".to_string()
+        } else {
+            format!(
+                "<div class=\"char-owner owner-assigned\">keeper: {}</div>",
+                actor.keeper
+            )
+        };
 
         // Buffs / debuffs
         let buffs_html = actor
@@ -344,6 +352,7 @@ pub fn update_character_panel_dom(actors: Query<&Actor>, mut cache: ResMut<Chara
                 "<span class=\"char-name\">{}</span>",
                 "<span class=\"char-class\"><span class=\"class-icon\">{}</span> {}</span>",
                 "</div>",
+                "{}",
                 "<div class=\"hp-row\">",
                 "<div class=\"hp-bar-container\">",
                 "<div class=\"hp-bar-fill {}\" style=\"width: {}%\"></div>",
@@ -369,6 +378,7 @@ pub fn update_character_panel_dom(actors: Query<&Actor>, mut cache: ResMut<Chara
             actor.name,
             icon,
             actor.class,
+            keeper_line,
             bar_class,
             hp_pct,
             actor.hp,

--- a/viewer/src/dom/turn_controls.rs
+++ b/viewer/src/dom/turn_controls.rs
@@ -37,7 +37,7 @@ pub fn bind_turn_controls(mut commands: Commands) {
     #[cfg(target_arch = "wasm32")]
     {
         bind_advance_button();
-        clear_turn_status();
+        set_turn_status("라운드 실행 준비 중...", "status-info");
         log::info!("TurnControls: bound");
     }
 
@@ -72,37 +72,35 @@ pub fn sync_turn_controls_visibility(room_state: Res<RoomState>, progress: Res<T
         let Some(panel) = doc.get_element_by_id("turn-controls") else {
             return;
         };
-
-
-        let claimed_keeper = doc
-            .get_element_by_id("claimed-keeper")
-            .and_then(|el| el.dyn_into::<HtmlInputElement>().ok())
-            .map(|i| i.value());
-        let claimed_actor = doc
-            .get_element_by_id("claimed-actor-id")
-            .and_then(|el| el.dyn_into::<HtmlInputElement>().ok())
-            .map(|i| i.value());
-        let has_manual_claim = claimed_keeper
-            .as_ref()
-            .map(|v| !v.trim().is_empty())
-            .unwrap_or(false)
-            || claimed_actor
-                .as_ref()
-                .map(|v| !v.trim().is_empty())
-                .unwrap_or(false);
-
-        let has_auto_plan = doc
-            .get_element_by_id("round-run-dm")
-            .and_then(|el| el.dyn_into::<HtmlInputElement>().ok())
-            .is_some_and(|input| !input.value().trim().is_empty());
-
-        let style = if (has_manual_claim || has_auto_plan) && room_allows_control {
-            ""
-        } else {
-            "display:none"
-        };
-        let _ = panel.set_attribute("style", style);
+        let _ = panel.set_attribute("style", "");
         let _ = panel.set_attribute("data-lifecycle", lifecycle.css_class());
+
+        let plan_error = read_round_run_plan(&doc).err();
+        let can_run = room_allows_control && plan_error.is_none();
+        let reason = if !room_allows_control {
+            format!("실행 대기: {}", lifecycle.help_text())
+        } else if let Some(err) = &plan_error {
+            format!("준비 필요: {}", err)
+        } else {
+            "라운드 실행 가능".to_string()
+        };
+
+        let busy = doc
+            .get_element_by_id("advance-turn-btn")
+            .and_then(|el| el.dyn_into::<HtmlButtonElement>().ok())
+            .and_then(|btn| btn.get_attribute("data-busy"))
+            .is_some_and(|v| v == "1");
+
+        if !busy {
+            set_advance_disabled(!can_run);
+            if can_run {
+                set_turn_status(&reason, "status-ok");
+            } else if room_allows_control {
+                set_turn_status(&reason, "status-warn");
+            } else {
+                set_turn_status(&reason, "status-info");
+            }
+        }
     }
 }
 
@@ -127,8 +125,16 @@ fn bind_advance_button() {
 
 #[cfg(target_arch = "wasm32")]
 fn on_advance_click() {
-    set_turn_status("Running round...", "");
-    set_advance_disabled(true);
+    let Some(doc) = web_sys::window().and_then(|w| w.document()) else {
+        return;
+    };
+    if let Err(reason) = read_round_run_plan(&doc) {
+        set_turn_status(&format!("실행 불가: {}", reason), "status-warn");
+        return;
+    }
+
+    set_turn_status("라운드 실행 중...", "status-info");
+    set_advance_busy(true);
 
     wasm_bindgen_futures::spawn_local(async move {
         match advance_turn().await {
@@ -139,7 +145,7 @@ fn on_advance_click() {
                 set_turn_status(&format!("Failed: {}", detail), "status-error");
             }
         }
-        set_advance_disabled(false);
+        set_advance_busy(false);
     });
 }
 
@@ -251,6 +257,23 @@ fn set_advance_disabled(disabled: bool) {
 }
 
 #[cfg(target_arch = "wasm32")]
+fn set_advance_busy(busy: bool) {
+    let Some(doc) = web_sys::window().and_then(|w| w.document()) else {
+        return;
+    };
+    if let Some(el) = doc.get_element_by_id("advance-turn-btn") {
+        if let Some(btn) = el.dyn_into::<HtmlButtonElement>().ok() {
+            btn.set_disabled(busy);
+            if busy {
+                let _ = btn.set_attribute("data-busy", "1");
+            } else {
+                let _ = btn.remove_attribute("data-busy");
+            }
+        }
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
 struct RoundRunPlan {
     dm_keeper: String,
     phase: String,
@@ -300,7 +323,7 @@ fn read_round_run_plan(doc: &web_sys::Document) -> Result<RoundRunPlan, String> 
         .and_then(|el| el.dyn_into::<HtmlInputElement>().ok())
         .map(|i| i.value())
         .unwrap_or_default();
-    let player_keepers = player_pairs_raw
+    let mut player_keepers = player_pairs_raw
         .split(',')
         .filter_map(|part| {
             let pair = part.trim();
@@ -317,6 +340,25 @@ fn read_round_run_plan(doc: &web_sys::Document) -> Result<RoundRunPlan, String> 
             }
         })
         .collect::<Vec<_>>();
+    if player_keepers.is_empty() {
+        let claimed_actor = doc
+            .get_element_by_id("claimed-actor-id")
+            .and_then(|el| el.dyn_into::<HtmlInputElement>().ok())
+            .map(|i| i.value())
+            .unwrap_or_default()
+            .trim()
+            .to_string();
+        let claimed_keeper = doc
+            .get_element_by_id("claimed-keeper")
+            .and_then(|el| el.dyn_into::<HtmlInputElement>().ok())
+            .map(|i| i.value())
+            .unwrap_or_default()
+            .trim()
+            .to_string();
+        if !claimed_actor.is_empty() && !claimed_keeper.is_empty() {
+            player_keepers.push((claimed_actor, claimed_keeper));
+        }
+    }
     if player_keepers.is_empty() {
         return Err("player keepers가 없습니다. 새 게임에서 참가자 할당을 확인하세요.".to_string());
     }

--- a/viewer/src/dom/turn_runtime.rs
+++ b/viewer/src/dom/turn_runtime.rs
@@ -12,6 +12,10 @@ pub struct TurnRuntimeCache {
 
 #[cfg(target_arch = "wasm32")]
 use super::escape::html_escape;
+#[cfg(target_arch = "wasm32")]
+use wasm_bindgen::JsCast;
+#[cfg(target_arch = "wasm32")]
+use web_sys::HtmlInputElement;
 
 #[cfg(target_arch = "wasm32")]
 fn pretty_phase(phase: &str) -> String {
@@ -181,6 +185,52 @@ pub fn update_turn_runtime_dom(
                     room_status_key
                 ),
             );
+        }
+
+        let inferred_dm = if !progress.dm_keeper.trim().is_empty() {
+            progress.dm_keeper.trim().to_string()
+        } else {
+            actors
+                .iter()
+                .find(|actor| actor.id == "dm" && !actor.keeper.trim().is_empty())
+                .map(|actor| actor.keeper.trim().to_string())
+                .unwrap_or_default()
+        };
+        if let Some(dm_input) = document
+            .get_element_by_id("round-run-dm")
+            .and_then(|el| el.dyn_into::<HtmlInputElement>().ok())
+        {
+            if dm_input.value().trim().is_empty() && !inferred_dm.is_empty() {
+                dm_input.set_value(&inferred_dm);
+            }
+        }
+
+        let inferred_player_pairs = actors
+            .iter()
+            .filter(|actor| actor.id != "dm" && !actor.keeper.trim().is_empty())
+            .map(|actor| format!("{}={}", actor.id.trim(), actor.keeper.trim()))
+            .collect::<Vec<_>>();
+        if let Some(players_input) = document
+            .get_element_by_id("round-run-players")
+            .and_then(|el| el.dyn_into::<HtmlInputElement>().ok())
+        {
+            if players_input.value().trim().is_empty() && !inferred_player_pairs.is_empty() {
+                players_input.set_value(&inferred_player_pairs.join(","));
+            }
+        }
+
+        if let Some(summary) = document.get_element_by_id("round-run-summary") {
+            if summary.text_content().unwrap_or_default().trim().is_empty()
+                && !inferred_dm.is_empty()
+                && !inferred_player_pairs.is_empty()
+            {
+                summary.set_text_content(Some(&format!(
+                    "DM: {} · Players: {}",
+                    inferred_dm,
+                    inferred_player_pairs.join(", ")
+                )));
+                let _ = summary.set_attribute("style", "display:block");
+            }
         }
 
         let html = format!(

--- a/viewer/src/game/http.rs
+++ b/viewer/src/game/http.rs
@@ -1,4 +1,5 @@
 use std::sync::{Arc, Mutex};
+use std::collections::HashMap;
 
 use bevy::prelude::*;
 use serde::Deserialize;
@@ -100,6 +101,8 @@ pub struct CharacterData {
     pub conditions: Vec<ConditionData>,
     #[serde(default)]
     pub equipment: Vec<EquipmentData>,
+    #[serde(default)]
+    pub keeper: String,
 }
 
 fn default_hp() -> i32 {
@@ -116,6 +119,8 @@ pub struct GameStateResponse {
     pub room: Option<RoomResponse>,
     #[serde(default)]
     pub characters: Vec<CharacterData>,
+    #[serde(default)]
+    pub dm_keeper: String,
     #[serde(default)]
     pub current_area: String,
     #[serde(default)]
@@ -355,6 +360,9 @@ pub fn apply_initial_state(
     turn_progress.room_status = room_state.status.clone();
     turn_progress.turn = room_state.turn;
     turn_progress.phase = room_state.phase.as_str().to_string();
+    if !state.dm_keeper.trim().is_empty() {
+        turn_progress.dm_keeper = state.dm_keeper.trim().to_string();
+    }
     turn_progress.player_order = actor_ids
         .iter()
         .filter(|id| id.as_str() != "dm")
@@ -449,7 +457,7 @@ pub fn apply_initial_state(
             skills,
             conditions,
             equipment,
-            keeper: String::new(),
+            keeper: ch.keeper,
         });
     }
 
@@ -502,6 +510,7 @@ fn normalize_state_response(root: Value) -> Result<GameStateResponse, String> {
 
 fn parse_masc_state_response(root: &Value) -> GameStateResponse {
     let state = root.get("state").unwrap_or(root);
+    let actor_control = parse_actor_control_map(state);
 
     let room_id = root
         .get("room_id")
@@ -528,12 +537,28 @@ fn parse_masc_state_response(root: &Value) -> GameStateResponse {
         .unwrap_or("")
         .to_string();
 
-    let characters = state
+    let mut characters = state
         .get("characters")
         .cloned()
         .and_then(|v| serde_json::from_value::<Vec<CharacterData>>(v).ok())
         .filter(|rows| !rows.is_empty())
-        .unwrap_or_else(|| parse_party_characters(state));
+        .unwrap_or_else(|| parse_party_characters(state, &actor_control));
+    apply_actor_control_to_characters(&mut characters, &actor_control);
+
+    let dm_keeper = state
+        .get("dm_keeper")
+        .and_then(Value::as_str)
+        .or_else(|| {
+            state
+                .get("dm")
+                .and_then(Value::as_object)
+                .and_then(|dm| dm.get("keeper_name"))
+                .and_then(Value::as_str)
+        })
+        .or_else(|| actor_control.get("dm").map(|value| value.as_str()))
+        .unwrap_or("")
+        .trim()
+        .to_string();
     let dice_log = parse_dice_log(root).unwrap_or_else(|| parse_dice_log(state).unwrap_or_default());
 
     GameStateResponse {
@@ -559,9 +584,41 @@ fn parse_masc_state_response(root: &Value) -> GameStateResponse {
                 .to_string(),
         }),
         characters,
+        dm_keeper,
         current_area,
         area_label,
         dice_log,
+    }
+}
+
+fn parse_actor_control_map(state: &Value) -> HashMap<String, String> {
+    state
+        .get("actor_control")
+        .and_then(Value::as_object)
+        .map(|rows| {
+            rows.iter()
+                .filter_map(|(actor_id, keeper)| {
+                    keeper
+                        .as_str()
+                        .map(str::trim)
+                        .filter(|value| !value.is_empty())
+                        .map(|keeper_name| (actor_id.trim().to_string(), keeper_name.to_string()))
+                })
+                .collect::<HashMap<_, _>>()
+        })
+        .unwrap_or_default()
+}
+
+fn apply_actor_control_to_characters(
+    characters: &mut Vec<CharacterData>,
+    actor_control: &HashMap<String, String>,
+) {
+    for row in characters.iter_mut() {
+        if row.keeper.trim().is_empty() {
+            if let Some(keeper) = actor_control.get(&row.id) {
+                row.keeper = keeper.clone();
+            }
+        }
     }
 }
 
@@ -684,7 +741,10 @@ fn entry_passed_marker(raw: &str) -> bool {
         })
 }
 
-fn parse_party_characters(state: &Value) -> Vec<CharacterData> {
+fn parse_party_characters(
+    state: &Value,
+    actor_control: &HashMap<String, String>,
+) -> Vec<CharacterData> {
     let Some(party) = state.get("party").and_then(Value::as_object) else {
         return Vec::new();
     };
@@ -824,6 +884,10 @@ fn parse_party_characters(state: &Value) -> Vec<CharacterData> {
                         .collect::<Vec<_>>()
                 })
                 .unwrap_or_default();
+            let keeper = actor_control
+                .get(actor_id)
+                .cloned()
+                .unwrap_or_default();
 
             CharacterData {
                 id: actor_id.to_string(),
@@ -842,6 +906,7 @@ fn parse_party_characters(state: &Value) -> Vec<CharacterData> {
                 skills,
                 conditions,
                 equipment,
+                keeper,
             }
         })
         .collect()
@@ -902,6 +967,7 @@ fn unavailable_game_state(room_id: &str) -> GameStateResponse {
             current_node: "".to_string(),
         }),
         characters: Vec::new(),
+        dm_keeper: String::new(),
         current_area: "".to_string(),
         area_label: "".to_string(),
         dice_log: Vec::new(),
@@ -982,6 +1048,57 @@ mod tests {
         assert_eq!(parsed.characters[0].name, "그림자");
         assert_eq!(parsed.characters[0].class, "fighter");
         assert_eq!(parsed.characters[0].hp, 28);
+    }
+
+    #[test]
+    fn normalize_masc_shape_maps_actor_control_and_dm_keeper() {
+        let root = json!({
+            "ok": true,
+            "room_id": "default",
+            "state": {
+                "turn": 4,
+                "phase": "round",
+                "dm": { "keeper_name": "trpg-dm" },
+                "actor_control": {
+                    "grimja": "trpg-grimja",
+                    "luna": "trpg-luna"
+                },
+                "party": {
+                    "grimja": {
+                        "name": "그림자",
+                        "role": "fighter",
+                        "hp": 28,
+                        "max_hp": 30,
+                        "position": "C",
+                        "alive": true
+                    },
+                    "luna": {
+                        "name": "루나",
+                        "role": "mage",
+                        "hp": 13,
+                        "max_hp": 15,
+                        "position": "F",
+                        "alive": true
+                    }
+                }
+            }
+        });
+
+        let parsed = normalize_state_response(root).expect("masc parse should succeed");
+        assert_eq!(parsed.dm_keeper, "trpg-dm");
+        assert_eq!(parsed.characters.len(), 2);
+        let grimja = parsed
+            .characters
+            .iter()
+            .find(|row| row.id == "grimja")
+            .expect("grimja row");
+        assert_eq!(grimja.keeper, "trpg-grimja");
+        let luna = parsed
+            .characters
+            .iter()
+            .find(|row| row.id == "luna")
+            .expect("luna row");
+        assert_eq!(luna.keeper, "trpg-luna");
     }
 
     #[test]

--- a/viewer/src/mode.rs
+++ b/viewer/src/mode.rs
@@ -1710,12 +1710,16 @@ async fn refresh_keeper_selectors(doc: &web_sys::Document) -> Result<Vec<String>
 
     if let Some(player_select) = doc.get_element_by_id("new-game-player-select") {
         let preserve_existing_selection = !previous_players.is_empty();
+        let mut default_selected = 0_usize;
         let mut html = String::new();
         for name in keepers.iter().filter(|name| **name != dm_default) {
             let safe = html_escape(name);
             let selected_attr = if preserve_existing_selection
                 && previous_players.iter().any(|picked| picked == name)
             {
+                " selected"
+            } else if !preserve_existing_selection && default_selected < 4 {
+                default_selected += 1;
                 " selected"
             } else {
                 ""

--- a/viewer/src/mode.rs
+++ b/viewer/src/mode.rs
@@ -627,59 +627,6 @@ fn assign_keepers_to_actor_ids(
 }
 
 #[cfg(target_arch = "wasm32")]
-fn parse_preset_id(value: &Value, field: &str) -> Option<String> {
-    match value.get(field) {
-        Some(Value::Array(items)) if !items.is_empty() => {
-            items.first().and_then(Value::as_object).and_then(|obj| {
-                obj.get("id")
-                    .and_then(Value::as_str)
-                    .map(|id| id.trim().to_string())
-            })
-        }
-        Some(Value::String(v)) if !v.trim().is_empty() => Some(v.trim().to_string()),
-        Some(value_obj) if value_obj.is_object() => value_obj
-            .get("id")
-            .and_then(Value::as_str)
-            .map(|id| id.trim().to_string()),
-        _ => None,
-    }
-}
-
-#[cfg(target_arch = "wasm32")]
-fn pick_preset_id_from_catalog(catalog: &Value, field: &str) -> Option<String> {
-    let mut candidates: Vec<&Value> = vec![catalog];
-
-    if let Some(payload) = catalog.get("payload") {
-        candidates.push(payload);
-    }
-    if let Some(result) = catalog.get("result") {
-        candidates.push(result);
-    }
-    if let Some(structured) = catalog
-        .get("result")
-        .and_then(|r| r.get("structuredContent"))
-    {
-        candidates.push(structured);
-    }
-    candidates.push(catalog);
-    let direct = candidates
-        .into_iter()
-        .find_map(|node| parse_preset_id(node, field));
-    if direct.is_some() {
-        return direct;
-    }
-    let nested = catalog
-        .get("result")
-        .and_then(|result| result.get("payload"))
-        .and_then(|payload| payload.get(field))
-        .and_then(|value| parse_preset_id(value, field));
-    if nested.is_some() {
-        return nested;
-    }
-    None
-}
-
-#[cfg(target_arch = "wasm32")]
 fn format_round_plan_for_display(dm_keeper: &str, players: &[(String, String)]) -> String {
     let mut lines = vec![format!("DM: {}", dm_keeper)];
     if players.is_empty() {
@@ -807,6 +754,32 @@ struct RoomSnapshot {
     phase: String,
     agent_count: i64,
     task_count: i64,
+}
+
+#[cfg(target_arch = "wasm32")]
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct PresetOption {
+    id: String,
+    title: String,
+}
+
+#[cfg(target_arch = "wasm32")]
+#[derive(Debug, Clone)]
+struct NewGameBootstrap {
+    keepers: Vec<String>,
+    world_presets: Vec<PresetOption>,
+    dm_presets: Vec<PresetOption>,
+}
+
+#[cfg(target_arch = "wasm32")]
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ActorAdminRow {
+    actor_id: String,
+    name: String,
+    role: String,
+    hp: i32,
+    max_hp: i32,
+    keeper: String,
 }
 
 #[cfg(target_arch = "wasm32")]
@@ -1123,6 +1096,16 @@ fn apply_room_switch_from_ui(doc: &web_sys::Document, raw_room: &str) {
     set_current_room_id(doc, &room);
     clear_trpg_dom(doc);
     sync_room_hub_selection(doc, &room);
+    let doc_for_refresh = doc.clone();
+    wasm_bindgen_futures::spawn_local(async move {
+        if let Ok(rows) = refresh_actor_admin_list(&doc_for_refresh).await {
+            actor_admin_set_status(
+                &doc_for_refresh,
+                &format!("room {} 액터 {}명", actor_admin_room_id(), rows.len()),
+                "status-ok",
+            );
+        }
+    });
     log::info!("Viewer room switched to {}", room);
 }
 
@@ -1750,6 +1733,467 @@ async fn refresh_keeper_selectors(doc: &web_sys::Document) -> Result<Vec<String>
 }
 
 #[cfg(target_arch = "wasm32")]
+fn actor_admin_room_id() -> String {
+    crate::config::current_room_id()
+}
+
+#[cfg(target_arch = "wasm32")]
+fn actor_admin_set_status(doc: &web_sys::Document, message: &str, css_class: &str) {
+    if let Some(el) = doc.get_element_by_id("actor-admin-status") {
+        el.set_inner_html(&html_escape(message));
+        let class_name = if css_class.trim().is_empty() {
+            "new-game-status".to_string()
+        } else {
+            format!("new-game-status {}", css_class)
+        };
+        let _ = el.set_attribute("class", &class_name);
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+fn actor_admin_set_busy(doc: &web_sys::Document, busy: bool) {
+    for id in [
+        "actor-admin-refresh",
+        "actor-admin-spawn",
+        "actor-admin-update",
+        "actor-admin-delete",
+    ] {
+        if let Some(btn) = doc
+            .get_element_by_id(id)
+            .and_then(|el| el.dyn_into::<web_sys::HtmlButtonElement>().ok())
+        {
+            btn.set_disabled(busy);
+        }
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+fn actor_admin_input_value(doc: &web_sys::Document, id: &str) -> String {
+    doc.get_element_by_id(id)
+        .and_then(|el| el.dyn_into::<web_sys::HtmlInputElement>().ok())
+        .map(|input| input.value().trim().to_string())
+        .unwrap_or_default()
+}
+
+#[cfg(target_arch = "wasm32")]
+fn actor_admin_select_value(doc: &web_sys::Document, id: &str) -> String {
+    doc.get_element_by_id(id)
+        .and_then(|el| el.dyn_into::<web_sys::HtmlSelectElement>().ok())
+        .map(|select| select.value().trim().to_string())
+        .unwrap_or_default()
+}
+
+#[cfg(target_arch = "wasm32")]
+fn actor_admin_input_i64(doc: &web_sys::Document, id: &str) -> Option<i64> {
+    let raw = actor_admin_input_value(doc, id);
+    if raw.is_empty() {
+        None
+    } else {
+        raw.parse::<i64>().ok()
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+async fn fetch_room_state_payload(room_id: &str) -> Result<Value, String> {
+    let url = format!(
+        "{}/api/v1/trpg/state?room_id={}",
+        crate::config::MASC_MCP_URL,
+        room_id
+    );
+    let opts = web_sys::RequestInit::new();
+    opts.set_method("GET");
+    opts.set_mode(web_sys::RequestMode::Cors);
+
+    let request = web_sys::Request::new_with_str_and_init(&url, &opts)
+        .map_err(|e| format!("request 생성 실패: {:?}", e))?;
+    request
+        .headers()
+        .set("Accept", "application/json")
+        .map_err(|e| format!("헤더 설정 실패: {:?}", e))?;
+
+    let window = web_sys::window().ok_or_else(|| "window unavailable".to_string())?;
+    let resp_value = JsFuture::from(window.fetch_with_request(&request))
+        .await
+        .map_err(|e| format!("fetch 실패: {:?}", e))?;
+    let resp: web_sys::Response = resp_value
+        .dyn_into()
+        .map_err(|_| "response 변환 실패".to_string())?;
+    if !resp.ok() {
+        return Err(format!("HTTP {}", resp.status()));
+    }
+
+    let body_js = JsFuture::from(
+        resp.text()
+            .map_err(|e| format!("response.text() 실패: {:?}", e))?,
+    )
+    .await
+    .map_err(|e| format!("본문 읽기 실패: {:?}", e))?;
+    let body = body_js.as_string().unwrap_or_default();
+    if body.trim().is_empty() {
+        return Ok(json!({}));
+    }
+    serde_json::from_str::<Value>(&body).map_err(|e| format!("state JSON 파싱 실패: {}", e))
+}
+
+#[cfg(target_arch = "wasm32")]
+fn parse_actor_admin_rows(state_root: &Value) -> Vec<ActorAdminRow> {
+    let state = state_root.get("state").unwrap_or(state_root);
+    let actor_control = state
+        .get("actor_control")
+        .and_then(Value::as_object)
+        .cloned()
+        .unwrap_or_default();
+    let control_keeper = |actor_id: &str| -> String {
+        actor_control
+            .get(actor_id)
+            .and_then(Value::as_str)
+            .unwrap_or("")
+            .trim()
+            .to_string()
+    };
+
+    let mut rows = Vec::new();
+    if let Some(characters) = state.get("characters").and_then(Value::as_array) {
+        for ch in characters {
+            let actor_id = ch
+                .get("id")
+                .or_else(|| ch.get("actor_id"))
+                .and_then(Value::as_str)
+                .unwrap_or("")
+                .trim()
+                .to_string();
+            if actor_id.is_empty() {
+                continue;
+            }
+            let name = ch
+                .get("name")
+                .and_then(Value::as_str)
+                .unwrap_or(&actor_id)
+                .trim()
+                .to_string();
+            let role = ch
+                .get("role")
+                .or_else(|| ch.get("class"))
+                .or_else(|| ch.get("archetype"))
+                .and_then(Value::as_str)
+                .unwrap_or("player")
+                .trim()
+                .to_string();
+            let hp = ch.get("hp").and_then(Value::as_i64).unwrap_or(0) as i32;
+            let max_hp = ch.get("max_hp").and_then(Value::as_i64).unwrap_or(0) as i32;
+            let keeper = ch
+                .get("keeper")
+                .and_then(Value::as_str)
+                .unwrap_or("")
+                .trim()
+                .to_string();
+            rows.push(ActorAdminRow {
+                actor_id: actor_id.clone(),
+                name,
+                role,
+                hp,
+                max_hp,
+                keeper: if keeper.is_empty() {
+                    control_keeper(&actor_id)
+                } else {
+                    keeper
+                },
+            });
+        }
+    } else if let Some(party) = state.get("party").and_then(Value::as_object) {
+        for (actor_id, row) in party {
+            let actor_id = actor_id.trim();
+            if actor_id.is_empty() {
+                continue;
+            }
+            let name = row
+                .get("name")
+                .and_then(Value::as_str)
+                .unwrap_or(actor_id)
+                .trim()
+                .to_string();
+            let role = row
+                .get("role")
+                .or_else(|| row.get("class"))
+                .or_else(|| row.get("archetype"))
+                .and_then(Value::as_str)
+                .unwrap_or("player")
+                .trim()
+                .to_string();
+            let hp = row.get("hp").and_then(Value::as_i64).unwrap_or(0) as i32;
+            let max_hp = row.get("max_hp").and_then(Value::as_i64).unwrap_or(0) as i32;
+            rows.push(ActorAdminRow {
+                actor_id: actor_id.to_string(),
+                name,
+                role,
+                hp,
+                max_hp,
+                keeper: control_keeper(actor_id),
+            });
+        }
+    }
+    rows.sort_by(|a, b| a.actor_id.cmp(&b.actor_id));
+    rows
+}
+
+#[cfg(target_arch = "wasm32")]
+fn render_actor_admin_rows(doc: &web_sys::Document, rows: &[ActorAdminRow]) {
+    let Some(list) = doc.get_element_by_id("actor-admin-list") else {
+        return;
+    };
+    if rows.is_empty() {
+        list.set_inner_html("<div class=\"room-chip-empty\">액터가 없습니다.</div>");
+        return;
+    }
+    let html = rows
+        .iter()
+        .map(|row| {
+            format!(
+                concat!(
+                    "<button class=\"actor-admin-row\" ",
+                    "data-actor-id=\"{id}\" data-name=\"{name}\" data-role=\"{role}\" ",
+                    "data-keeper=\"{keeper}\" data-hp=\"{hp}\" data-max-hp=\"{max_hp}\">",
+                    "{id} · {role} · HP {hp}/{max_hp}{keeper_text}",
+                    "</button>"
+                ),
+                id = html_escape(&row.actor_id),
+                name = html_escape(&row.name),
+                role = html_escape(&row.role),
+                keeper = html_escape(&row.keeper),
+                hp = row.hp,
+                max_hp = row.max_hp,
+                keeper_text = if row.keeper.is_empty() {
+                    "".to_string()
+                } else {
+                    format!(" · keeper {}", html_escape(&row.keeper))
+                },
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("");
+    list.set_inner_html(&html);
+}
+
+#[cfg(target_arch = "wasm32")]
+fn bind_actor_admin_row_clicks(doc: &web_sys::Document) {
+    let Ok(nodes) = doc.query_selector_all("#actor-admin-list .actor-admin-row") else {
+        return;
+    };
+    for i in 0..nodes.length() {
+        let Some(node) = nodes.item(i) else { continue };
+        let Some(el) = node.dyn_ref::<web_sys::Element>() else {
+            continue;
+        };
+        if el.get_attribute("data-bound").as_deref() == Some("1") {
+            continue;
+        }
+        let _ = el.set_attribute("data-bound", "1");
+        let id = el.get_attribute("data-actor-id").unwrap_or_default();
+        let name = el.get_attribute("data-name").unwrap_or_default();
+        let role = el.get_attribute("data-role").unwrap_or_default();
+        let keeper = el.get_attribute("data-keeper").unwrap_or_default();
+        let hp = el.get_attribute("data-hp").unwrap_or_default();
+        let max_hp = el.get_attribute("data-max-hp").unwrap_or_default();
+        let cb = Closure::wrap(Box::new(move || {
+            let Some(doc) = web_sys::window().and_then(|w| w.document()) else {
+                return;
+            };
+
+            if let Some(input) = doc
+                .get_element_by_id("actor-admin-id")
+                .and_then(|el| el.dyn_into::<web_sys::HtmlInputElement>().ok())
+            {
+                input.set_value(&id);
+            }
+            if let Some(input) = doc
+                .get_element_by_id("actor-admin-name")
+                .and_then(|el| el.dyn_into::<web_sys::HtmlInputElement>().ok())
+            {
+                input.set_value(&name);
+            }
+            if let Some(select) = doc
+                .get_element_by_id("actor-admin-role")
+                .and_then(|el| el.dyn_into::<web_sys::HtmlSelectElement>().ok())
+            {
+                if !role.trim().is_empty() {
+                    select.set_value(&role);
+                }
+            }
+            if let Some(input) = doc
+                .get_element_by_id("actor-admin-keeper")
+                .and_then(|el| el.dyn_into::<web_sys::HtmlInputElement>().ok())
+            {
+                input.set_value(&keeper);
+            }
+            if let Some(input) = doc
+                .get_element_by_id("actor-admin-hp")
+                .and_then(|el| el.dyn_into::<web_sys::HtmlInputElement>().ok())
+            {
+                input.set_value(&hp);
+            }
+            if let Some(input) = doc
+                .get_element_by_id("actor-admin-max-hp")
+                .and_then(|el| el.dyn_into::<web_sys::HtmlInputElement>().ok())
+            {
+                input.set_value(&max_hp);
+            }
+        }) as Box<dyn FnMut()>);
+        let _ = el.dyn_ref::<web_sys::EventTarget>().map(|target| {
+            target.add_event_listener_with_callback("click", cb.as_ref().unchecked_ref())
+        });
+        cb.forget();
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+async fn refresh_actor_admin_list(doc: &web_sys::Document) -> Result<Vec<ActorAdminRow>, String> {
+    let room_id = actor_admin_room_id();
+    let payload = fetch_room_state_payload(&room_id).await?;
+    let rows = parse_actor_admin_rows(&payload);
+    render_actor_admin_rows(doc, &rows);
+    bind_actor_admin_row_clicks(doc);
+    Ok(rows)
+}
+
+#[cfg(target_arch = "wasm32")]
+async fn refresh_new_game_bootstrap(doc: &web_sys::Document) -> Result<NewGameBootstrap, String> {
+    let keepers = refresh_keeper_selectors(doc).await?;
+    let (world_presets, dm_presets) = refresh_preset_selectors(doc).await?;
+    if let Err(err) = refresh_actor_admin_list(doc).await {
+        actor_admin_set_status(doc, &format!("액터 목록 로드 실패: {}", err), "status-warn");
+    }
+    Ok(NewGameBootstrap {
+        keepers,
+        world_presets,
+        dm_presets,
+    })
+}
+
+#[cfg(target_arch = "wasm32")]
+async fn actor_admin_spawn(doc: &web_sys::Document) -> Result<String, String> {
+    let room_id = actor_admin_room_id();
+    let actor_id = actor_admin_input_value(doc, "actor-admin-id");
+    if actor_id.is_empty() {
+        return Err("Actor ID를 입력하세요.".to_string());
+    }
+    let role = {
+        let role_raw = actor_admin_select_value(doc, "actor-admin-role");
+        if role_raw.is_empty() {
+            "player".to_string()
+        } else {
+            role_raw
+        }
+    };
+    let name = actor_admin_input_value(doc, "actor-admin-name");
+    let keeper = actor_admin_input_value(doc, "actor-admin-keeper");
+    let max_hp = actor_admin_input_i64(doc, "actor-admin-max-hp").unwrap_or(20);
+    let hp = actor_admin_input_i64(doc, "actor-admin-hp").unwrap_or(max_hp);
+
+    let mut args = json!({
+        "room_id": room_id,
+        "actor_id": actor_id,
+        "role": role,
+        "hp": hp.max(0),
+        "max_hp": max_hp.max(1),
+        "alive": hp > 0
+    });
+    if !name.is_empty() {
+        args["name"] = Value::String(name);
+    }
+    mcp_tool_call("trpg.actor.spawn", args).await?;
+    if !keeper.is_empty() {
+        mcp_tool_call(
+            "trpg.actor.claim",
+            json!({
+                "room_id": actor_admin_room_id(),
+                "actor_id": actor_id,
+                "keeper_name": keeper
+            }),
+        )
+        .await?;
+    }
+    let rows = refresh_actor_admin_list(doc).await?;
+    Ok(format!("액터 생성 완료 ({}명): {}", rows.len(), actor_id))
+}
+
+#[cfg(target_arch = "wasm32")]
+async fn actor_admin_update(doc: &web_sys::Document) -> Result<String, String> {
+    let room_id = actor_admin_room_id();
+    let actor_id = actor_admin_input_value(doc, "actor-admin-id");
+    if actor_id.is_empty() {
+        return Err("수정할 Actor ID를 입력하세요.".to_string());
+    }
+    let name = actor_admin_input_value(doc, "actor-admin-name");
+    let role = actor_admin_select_value(doc, "actor-admin-role");
+    let keeper = actor_admin_input_value(doc, "actor-admin-keeper");
+    let hp = actor_admin_input_i64(doc, "actor-admin-hp");
+    let max_hp = actor_admin_input_i64(doc, "actor-admin-max-hp");
+
+    let mut args = json!({
+        "room_id": room_id,
+        "actor_id": actor_id
+    });
+    let mut has_patch = false;
+    if !name.is_empty() {
+        args["name"] = Value::String(name);
+        has_patch = true;
+    }
+    if !role.is_empty() {
+        args["role"] = Value::String(role);
+        has_patch = true;
+    }
+    if let Some(hp) = hp {
+        args["hp"] = Value::Number(hp.max(0).into());
+        args["alive"] = Value::Bool(hp > 0);
+        has_patch = true;
+    }
+    if let Some(max_hp) = max_hp {
+        args["max_hp"] = Value::Number(max_hp.max(1).into());
+        has_patch = true;
+    }
+    if !has_patch && keeper.is_empty() {
+        return Err("수정할 필드 또는 keeper를 입력하세요.".to_string());
+    }
+
+    if has_patch {
+        mcp_tool_call("trpg.actor.update", args).await?;
+    }
+    if !keeper.is_empty() {
+        mcp_tool_call(
+            "trpg.actor.claim",
+            json!({
+                "room_id": actor_admin_room_id(),
+                "actor_id": actor_id,
+                "keeper_name": keeper
+            }),
+        )
+        .await?;
+    }
+    let rows = refresh_actor_admin_list(doc).await?;
+    Ok(format!("액터 수정 완료 ({}명): {}", rows.len(), actor_id))
+}
+
+#[cfg(target_arch = "wasm32")]
+async fn actor_admin_delete(doc: &web_sys::Document) -> Result<String, String> {
+    let room_id = actor_admin_room_id();
+    let actor_id = actor_admin_input_value(doc, "actor-admin-id");
+    if actor_id.is_empty() {
+        return Err("삭제할 Actor ID를 입력하세요.".to_string());
+    }
+    let reason = actor_admin_input_value(doc, "actor-admin-delete-reason");
+    let mut args = json!({
+        "room_id": room_id,
+        "actor_id": actor_id
+    });
+    if !reason.is_empty() {
+        args["reason"] = Value::String(reason);
+    }
+    mcp_tool_call("trpg.actor.delete", args).await?;
+    let rows = refresh_actor_admin_list(doc).await?;
+    Ok(format!("액터 삭제 완료 ({}명): {}", rows.len(), actor_id))
+}
+
+#[cfg(target_arch = "wasm32")]
 async fn start_new_game_flow(doc: &web_sys::Document) -> Result<String, String> {
     let room_input = doc
         .get_element_by_id("new-game-room-id")
@@ -1794,23 +2238,61 @@ async fn start_new_game_flow(doc: &web_sys::Document) -> Result<String, String> 
         .unwrap_or_default();
     let models = parse_keeper_models(&model_text);
 
-    let preset_catalog = mcp_tool_call(
-        "trpg.preset.list",
-        json!({
-            "include_characters": false,
-            "include_skills": false
-        }),
-    )
-    .await?;
-    let preset_catalog = normalize_preset_catalog(&preset_catalog);
-    let world_preset_id = extract_first_preset_id(&preset_catalog, "world_presets")
-        .or_else(|| extract_first_preset_id(&preset_catalog, "world"))
-        .or_else(|| extract_first_preset_id_by_key(&preset_catalog, "world"))
-        .unwrap_or_default();
-    let dm_preset_id = extract_first_preset_id(&preset_catalog, "dm_presets")
-        .or_else(|| extract_first_preset_id(&preset_catalog, "dm"))
-        .or_else(|| extract_first_preset_id_by_key(&preset_catalog, "dm"))
-        .unwrap_or_default();
+    let mut world_preset_id = doc
+        .get_element_by_id("new-game-world-select")
+        .and_then(|el| el.dyn_into::<web_sys::HtmlSelectElement>().ok())
+        .map(|select| select.value())
+        .unwrap_or_default()
+        .trim()
+        .to_string();
+    let mut dm_preset_id = doc
+        .get_element_by_id("new-game-dm-preset-select")
+        .and_then(|el| el.dyn_into::<web_sys::HtmlSelectElement>().ok())
+        .map(|select| select.value())
+        .unwrap_or_default()
+        .trim()
+        .to_string();
+
+    if world_preset_id.is_empty() || dm_preset_id.is_empty() {
+        if let Ok((world_options, dm_options)) = refresh_preset_selectors(doc).await {
+            if world_preset_id.is_empty() {
+                world_preset_id = world_options
+                    .first()
+                    .map(|row| row.id.clone())
+                    .unwrap_or_default();
+            }
+            if dm_preset_id.is_empty() {
+                dm_preset_id = dm_options
+                    .first()
+                    .map(|row| row.id.clone())
+                    .unwrap_or_default();
+            }
+        }
+    }
+
+    if world_preset_id.is_empty() || dm_preset_id.is_empty() {
+        let preset_catalog = mcp_tool_call(
+            "trpg.preset.list",
+            json!({
+                "include_characters": false,
+                "include_skills": false
+            }),
+        )
+        .await?;
+        let preset_catalog = normalize_preset_catalog(&preset_catalog);
+        if world_preset_id.is_empty() {
+            world_preset_id = extract_first_preset_id(&preset_catalog, "world_presets")
+                .or_else(|| extract_first_preset_id(&preset_catalog, "world"))
+                .or_else(|| extract_first_preset_id_by_key(&preset_catalog, "world"))
+                .unwrap_or_default();
+        }
+        if dm_preset_id.is_empty() {
+            dm_preset_id = extract_first_preset_id(&preset_catalog, "dm_presets")
+                .or_else(|| extract_first_preset_id(&preset_catalog, "dm"))
+                .or_else(|| extract_first_preset_id_by_key(&preset_catalog, "dm"))
+                .unwrap_or_default();
+        }
+    }
     if world_preset_id.is_empty() || dm_preset_id.is_empty() {
         return Err(format!(
             "trpg preset 목록 파싱 실패: world_preset_id={}, dm_preset_id={}",
@@ -1969,6 +2451,7 @@ async fn start_new_game_flow(doc: &web_sys::Document) -> Result<String, String> 
     set_current_room_id(doc, &room_id);
     clear_trpg_dom(doc);
     set_round_run_fields(doc, &dm_keeper, &actor_ids, &player_map);
+    set_new_game_assignment(doc, &dm_keeper, &player_map, &actor_ids);
 
     Ok(format!(
         "새 게임 시작 완료: room {} / DM {} / players {}",
@@ -2130,6 +2613,161 @@ fn extract_first_preset_id_by_key(catalog: &Value, alt_key: &str) -> Option<Stri
 }
 
 #[cfg(target_arch = "wasm32")]
+fn preset_option_from_value(node: &Value) -> Option<PresetOption> {
+    let id = node
+        .get("id")
+        .and_then(Value::as_str)
+        .or_else(|| node.get("preset_id").and_then(Value::as_str))
+        .or_else(|| node.get("uid").and_then(Value::as_str))
+        .or_else(|| node.get("name").and_then(Value::as_str))
+        .map(str::trim)
+        .filter(|value| !value.is_empty())?
+        .to_string();
+
+    let title = node
+        .get("title")
+        .and_then(Value::as_str)
+        .or_else(|| node.get("label").and_then(Value::as_str))
+        .or_else(|| node.get("name").and_then(Value::as_str))
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .unwrap_or(&id)
+        .to_string();
+
+    Some(PresetOption { id, title })
+}
+
+#[cfg(target_arch = "wasm32")]
+fn collect_preset_options_from_node(
+    node: &Value,
+    out: &mut Vec<PresetOption>,
+    depth: usize,
+) {
+    if depth > 6 {
+        return;
+    }
+    match node {
+        Value::String(raw) => {
+            let value = raw.trim();
+            if value.is_empty() {
+                return;
+            }
+            if out.iter().any(|item| item.id == value) {
+                return;
+            }
+            out.push(PresetOption {
+                id: value.to_string(),
+                title: value.to_string(),
+            });
+        }
+        Value::Array(rows) => {
+            for row in rows {
+                collect_preset_options_from_node(row, out, depth + 1);
+            }
+        }
+        Value::Object(fields) => {
+            if let Some(option) = preset_option_from_value(node) {
+                if !out.iter().any(|item| item.id == option.id) {
+                    out.push(option);
+                }
+            }
+            for value in fields.values() {
+                if value.is_array() || value.is_object() {
+                    collect_preset_options_from_node(value, out, depth + 1);
+                }
+            }
+        }
+        _ => {}
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+fn collect_preset_options_from_catalog(catalog: &Value, keys: &[&str]) -> Vec<PresetOption> {
+    let mut out = Vec::new();
+    for key in keys {
+        if let Some(node) = catalog.get(*key) {
+            collect_preset_options_from_node(node, &mut out, 0);
+        }
+    }
+    if out.is_empty() {
+        for fallback_key in ["items", "presets"] {
+            if let Some(node) = catalog.get(fallback_key) {
+                collect_preset_options_from_node(node, &mut out, 0);
+            }
+        }
+    }
+    out
+}
+
+#[cfg(target_arch = "wasm32")]
+fn select_options_set(
+    doc: &web_sys::Document,
+    select_id: &str,
+    options: &[PresetOption],
+) -> Option<String> {
+    let select = doc
+        .get_element_by_id(select_id)
+        .and_then(|el| el.dyn_into::<web_sys::HtmlSelectElement>().ok())?;
+
+    let previous = select.value();
+    if options.is_empty() {
+        select.set_inner_html(r#"<option value="">(none)</option>"#);
+        select.set_value("");
+        return None;
+    }
+
+    let html = options
+        .iter()
+        .map(|option| {
+            format!(
+                r#"<option value="{id}">{title} ({id})</option>"#,
+                id = html_escape(&option.id),
+                title = html_escape(&option.title),
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("");
+    select.set_inner_html(&html);
+
+    let selected = if !previous.trim().is_empty()
+        && options.iter().any(|option| option.id == previous)
+    {
+        previous
+    } else {
+        options[0].id.clone()
+    };
+    select.set_value(&selected);
+    Some(selected)
+}
+
+#[cfg(target_arch = "wasm32")]
+async fn refresh_preset_selectors(
+    doc: &web_sys::Document,
+) -> Result<(Vec<PresetOption>, Vec<PresetOption>), String> {
+    let raw_catalog = mcp_tool_call(
+        "trpg.preset.list",
+        json!({
+            "include_characters": false,
+            "include_skills": false
+        }),
+    )
+    .await?;
+    let catalog = normalize_preset_catalog(&raw_catalog);
+
+    let world_presets = collect_preset_options_from_catalog(
+        &catalog,
+        &["world_presets", "world", "world_preset", "worlds"],
+    );
+    let dm_presets =
+        collect_preset_options_from_catalog(&catalog, &["dm_presets", "dm", "dm_preset", "dms"]);
+
+    let _ = select_options_set(doc, "new-game-world-select", &world_presets);
+    let _ = select_options_set(doc, "new-game-dm-preset-select", &dm_presets);
+
+    Ok((world_presets, dm_presets))
+}
+
+#[cfg(target_arch = "wasm32")]
 fn bind_new_game_controls(doc: &web_sys::Document) {
     let Some(open_btn) = doc.get_element_by_id("new-game-toggle") else {
         return;
@@ -2153,16 +2791,26 @@ fn bind_new_game_controls(doc: &web_sys::Document) {
             }
         }
         set_new_game_status(&doc, "Keeper 목록을 불러오는 중...");
+        actor_admin_set_status(&doc, "액터 목록을 불러오는 중...", "status-info");
         let doc_for_fetch = doc.clone();
         wasm_bindgen_futures::spawn_local(async move {
-            match refresh_keeper_selectors(&doc_for_fetch).await {
-                Ok(keepers) => {
+            match refresh_new_game_bootstrap(&doc_for_fetch).await {
+                Ok(bootstrap) => {
                     set_new_game_status(
                         &doc_for_fetch,
-                        &format!("Keeper {}개 로드됨. DM/Player를 선택하세요.", keepers.len()),
+                        &format!(
+                            "Keeper {}개 · 월드 {}개 · DM 프리셋 {}개 로드됨",
+                            bootstrap.keepers.len(),
+                            bootstrap.world_presets.len(),
+                            bootstrap.dm_presets.len()
+                        ),
                     );
+                    actor_admin_set_status(&doc_for_fetch, "액터 목록 로드 완료", "status-ok");
                 }
-                Err(e) => set_new_game_status(&doc_for_fetch, &format!("Keeper 로드 실패: {}", e)),
+                Err(e) => {
+                    set_new_game_status(&doc_for_fetch, &format!("초기 로드 실패: {}", e));
+                    actor_admin_set_status(&doc_for_fetch, &format!("로드 실패: {}", e), "status-error");
+                }
             }
         });
     }) as Box<dyn FnMut()>);
@@ -2207,17 +2855,27 @@ fn bind_new_game_controls(doc: &web_sys::Document) {
             let Some(doc) = web_sys::window().and_then(|w| w.document()) else {
                 return;
             };
-            set_new_game_status(&doc, "Keeper 목록을 새로고침 중...");
+            set_new_game_status(&doc, "세션/프리셋/keeper 정보를 새로고침 중...");
+            actor_admin_set_status(&doc, "액터 목록 새로고침 중...", "status-info");
             let doc_for_fetch = doc.clone();
             wasm_bindgen_futures::spawn_local(async move {
-                match refresh_keeper_selectors(&doc_for_fetch).await {
-                    Ok(keepers) => {
+                match refresh_new_game_bootstrap(&doc_for_fetch).await {
+                    Ok(bootstrap) => {
                         set_new_game_status(
                             &doc_for_fetch,
-                            &format!("Keeper {}개 새로고침 완료", keepers.len()),
+                            &format!(
+                                "Keeper {}개 · 월드 {}개 · DM 프리셋 {}개 새로고침 완료",
+                                bootstrap.keepers.len(),
+                                bootstrap.world_presets.len(),
+                                bootstrap.dm_presets.len()
+                            ),
                         );
+                        actor_admin_set_status(&doc_for_fetch, "액터 목록 새로고침 완료", "status-ok");
                     }
-                    Err(e) => set_new_game_status(&doc_for_fetch, &format!("새로고침 실패: {}", e)),
+                    Err(e) => {
+                        set_new_game_status(&doc_for_fetch, &format!("새로고침 실패: {}", e));
+                        actor_admin_set_status(&doc_for_fetch, &format!("새로고침 실패: {}", e), "status-error");
+                    }
                 }
             });
         }) as Box<dyn FnMut()>);
@@ -2257,6 +2915,147 @@ fn bind_new_game_controls(doc: &web_sys::Document) {
             target.add_event_listener_with_callback("click", start_cb.as_ref().unchecked_ref())
         });
         start_cb.forget();
+    }
+
+    bind_actor_admin_controls(doc);
+}
+
+#[cfg(target_arch = "wasm32")]
+fn bind_actor_admin_controls(doc: &web_sys::Document) {
+    let Some(refresh_btn) = doc.get_element_by_id("actor-admin-refresh") else {
+        return;
+    };
+    if refresh_btn.get_attribute("data-bound").as_deref() == Some("1") {
+        return;
+    }
+    let _ = refresh_btn.set_attribute("data-bound", "1");
+
+    let refresh_cb = Closure::wrap(Box::new(move || {
+        let Some(doc) = web_sys::window().and_then(|w| w.document()) else {
+            return;
+        };
+        actor_admin_set_busy(&doc, true);
+        actor_admin_set_status(&doc, "액터 목록을 불러오는 중...", "status-info");
+        let doc_for_task = doc.clone();
+        wasm_bindgen_futures::spawn_local(async move {
+            let result = refresh_actor_admin_list(&doc_for_task).await;
+            match result {
+                Ok(rows) => actor_admin_set_status(
+                    &doc_for_task,
+                    &format!(
+                        "room {} 액터 {}명",
+                        html_escape(&actor_admin_room_id()),
+                        rows.len()
+                    ),
+                    "status-ok",
+                ),
+                Err(e) => actor_admin_set_status(
+                    &doc_for_task,
+                    &format!("액터 목록 조회 실패: {}", e),
+                    "status-error",
+                ),
+            }
+            actor_admin_set_busy(&doc_for_task, false);
+        });
+    }) as Box<dyn FnMut()>);
+    let _ = refresh_btn.dyn_ref::<web_sys::EventTarget>().map(|target| {
+        target.add_event_listener_with_callback("click", refresh_cb.as_ref().unchecked_ref())
+    });
+    refresh_cb.forget();
+
+    if let Some(spawn_btn) = doc.get_element_by_id("actor-admin-spawn") {
+        let spawn_cb = Closure::wrap(Box::new(move || {
+            let Some(doc) = web_sys::window().and_then(|w| w.document()) else {
+                return;
+            };
+            actor_admin_set_busy(&doc, true);
+            actor_admin_set_status(&doc, "액터 생성 중...", "status-info");
+            let doc_for_task = doc.clone();
+            wasm_bindgen_futures::spawn_local(async move {
+                let result = actor_admin_spawn(&doc_for_task).await;
+                match result {
+                    Ok(msg) => actor_admin_set_status(&doc_for_task, &msg, "status-ok"),
+                    Err(e) => actor_admin_set_status(
+                        &doc_for_task,
+                        &format!("액터 생성 실패: {}", e),
+                        "status-error",
+                    ),
+                }
+                actor_admin_set_busy(&doc_for_task, false);
+            });
+        }) as Box<dyn FnMut()>);
+        let _ = spawn_btn.dyn_ref::<web_sys::EventTarget>().map(|target| {
+            target.add_event_listener_with_callback("click", spawn_cb.as_ref().unchecked_ref())
+        });
+        spawn_cb.forget();
+    }
+
+    if let Some(update_btn) = doc.get_element_by_id("actor-admin-update") {
+        let update_cb = Closure::wrap(Box::new(move || {
+            let Some(doc) = web_sys::window().and_then(|w| w.document()) else {
+                return;
+            };
+            actor_admin_set_busy(&doc, true);
+            actor_admin_set_status(&doc, "액터 수정 중...", "status-info");
+            let doc_for_task = doc.clone();
+            wasm_bindgen_futures::spawn_local(async move {
+                let result = actor_admin_update(&doc_for_task).await;
+                match result {
+                    Ok(msg) => actor_admin_set_status(&doc_for_task, &msg, "status-ok"),
+                    Err(e) => actor_admin_set_status(
+                        &doc_for_task,
+                        &format!("액터 수정 실패: {}", e),
+                        "status-error",
+                    ),
+                }
+                actor_admin_set_busy(&doc_for_task, false);
+            });
+        }) as Box<dyn FnMut()>);
+        let _ = update_btn.dyn_ref::<web_sys::EventTarget>().map(|target| {
+            target.add_event_listener_with_callback("click", update_cb.as_ref().unchecked_ref())
+        });
+        update_cb.forget();
+    }
+
+    if let Some(delete_btn) = doc.get_element_by_id("actor-admin-delete") {
+        let delete_cb = Closure::wrap(Box::new(move || {
+            let Some(doc) = web_sys::window().and_then(|w| w.document()) else {
+                return;
+            };
+            let actor_id = actor_admin_input_value(&doc, "actor-admin-id");
+            if actor_id.is_empty() {
+                actor_admin_set_status(&doc, "삭제할 Actor ID를 입력하세요.", "status-error");
+                return;
+            }
+            let confirmed = web_sys::window()
+                .and_then(|w| {
+                    w.confirm_with_message(&format!("actor {} 를 삭제할까요?", actor_id))
+                        .ok()
+                })
+                .unwrap_or(false);
+            if !confirmed {
+                return;
+            }
+            actor_admin_set_busy(&doc, true);
+            actor_admin_set_status(&doc, "액터 삭제 중...", "status-info");
+            let doc_for_task = doc.clone();
+            wasm_bindgen_futures::spawn_local(async move {
+                let result = actor_admin_delete(&doc_for_task).await;
+                match result {
+                    Ok(msg) => actor_admin_set_status(&doc_for_task, &msg, "status-ok"),
+                    Err(e) => actor_admin_set_status(
+                        &doc_for_task,
+                        &format!("액터 삭제 실패: {}", e),
+                        "status-error",
+                    ),
+                }
+                actor_admin_set_busy(&doc_for_task, false);
+            });
+        }) as Box<dyn FnMut()>);
+        let _ = delete_btn.dyn_ref::<web_sys::EventTarget>().map(|target| {
+            target.add_event_listener_with_callback("click", delete_cb.as_ref().unchecked_ref())
+        });
+        delete_cb.forget();
     }
 }
 

--- a/viewer/style.css
+++ b/viewer/style.css
@@ -705,6 +705,9 @@ body.mode-lobby #dashboard {
     .new-game-grid {
         grid-template-columns: 1fr;
     }
+    .actor-admin-grid {
+        grid-template-columns: 1fr;
+    }
     .room-hub {
         grid-template-columns: 1fr;
     }
@@ -1006,6 +1009,21 @@ body.mode-lobby #dashboard {
     justify-content: space-between;
     align-items: center;
     margin-bottom: 6px;
+}
+
+.char-owner {
+    margin-bottom: 6px;
+    font-size: 10px;
+    letter-spacing: 0.4px;
+    font-family: var(--font-ui);
+}
+
+.char-owner.owner-assigned {
+    color: #7ccfa0;
+}
+
+.char-owner.owner-unassigned {
+    color: var(--text-dim);
 }
 
 .char-name {
@@ -1741,6 +1759,14 @@ body.mode-lobby #dashboard {
     color: var(--accent-primary);
 }
 
+#turn-control-status.status-info {
+    color: var(--text-dim);
+}
+
+#turn-control-status.status-warn {
+    color: #c4a265;
+}
+
 #turn-control-status.status-error {
     color: #d44;
 }
@@ -1855,6 +1881,81 @@ body.mode-lobby #dashboard {
     font-family: var(--font-ui);
     font-size: 11px;
     color: var(--text-dim);
+}
+
+.new-game-assignment {
+    border: 1px dashed rgba(196, 162, 101, 0.22);
+    border-radius: var(--panel-radius);
+    background: rgba(16, 18, 30, 0.72);
+    color: var(--text-secondary);
+    font-size: 11px;
+    line-height: 1.35;
+    padding: 7px 9px;
+}
+
+.actor-admin {
+    border: 1px solid rgba(196, 162, 101, 0.2);
+    border-radius: var(--panel-radius);
+    background: rgba(14, 16, 28, 0.86);
+    padding: 10px;
+    display: grid;
+    gap: 8px;
+}
+
+.actor-admin-head {
+    font-size: 11px;
+    letter-spacing: 0.75px;
+    text-transform: uppercase;
+    color: var(--accent-primary);
+}
+
+.actor-admin-grid {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 8px 10px;
+}
+
+.actor-admin-field-wide {
+    grid-column: 1 / -1;
+}
+
+.actor-admin-actions {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    flex-wrap: wrap;
+}
+
+.actor-admin-list {
+    border: 1px solid var(--border-main);
+    border-radius: var(--panel-radius);
+    background: rgba(8, 10, 18, 0.76);
+    min-height: 96px;
+    max-height: 168px;
+    overflow: auto;
+    padding: 4px;
+}
+
+.actor-admin-row {
+    width: 100%;
+    border: 1px solid transparent;
+    border-radius: 6px;
+    background: rgba(22, 24, 36, 0.65);
+    color: var(--text-primary);
+    text-align: left;
+    padding: 6px 8px;
+    margin-bottom: 4px;
+    font-size: 11px;
+    cursor: pointer;
+}
+
+.actor-admin-row:hover {
+    border-color: rgba(196, 162, 101, 0.4);
+    background: rgba(34, 36, 52, 0.78);
+}
+
+.actor-admin-row:last-child {
+    margin-bottom: 0;
 }
 
 /* ═══════════════════════════════════════════


### PR DESCRIPTION
## Summary
- harden new-game bootstrap by loading keeper/preset/actor data together and surfacing assignment summary
- add actor admin UI for spawn/update/delete/refresh directly in viewer
- keep round controls visible with explicit run-state reasons, and block invalid round runs before request
- hydrate hidden round-run fields from runtime state + initial state actor_control mapping
- show keeper ownership on character cards

## Validation
- cargo test --manifest-path viewer/Cargo.toml --release
- scripts/viewer-trunk.sh build
