### PR TITLE
fix(viewer): production cleanup — dedup, zero warnings, XSS audit

### DIFF
--- a/viewer/index.html
+++ b/viewer/index.html
@@ -23,22 +23,25 @@
                 <span class="mode-desc">Dark fantasy TRPG — 5 AI agents play D&amp;D 5e</span>
             </button>
 
-            <button class="mode-card" data-mode="experiment">
+            <button class="mode-card mode-card-disabled" data-mode="experiment" disabled>
                 <span class="mode-icon">⬡</span>
                 <span class="mode-name">Experiment Lab</span>
                 <span class="mode-desc">Live experiment metrics and flow visualization</span>
+                <span class="coming-soon">Coming Soon</span>
             </button>
 
-            <button class="mode-card" data-mode="monitor">
+            <button class="mode-card mode-card-disabled" data-mode="monitor" disabled>
                 <span class="mode-icon">◉</span>
                 <span class="mode-name">System Monitor</span>
                 <span class="mode-desc">Agent health, keeper metrics, system dashboard</span>
+                <span class="coming-soon">Coming Soon</span>
             </button>
 
-            <button class="mode-card" data-mode="council">
+            <button class="mode-card mode-card-disabled" data-mode="council" disabled>
                 <span class="mode-icon">△</span>
                 <span class="mode-name">MAGI Council</span>
                 <span class="mode-desc">MAGI deliberation — consensus and debate viewer</span>
+                <span class="coming-soon">Coming Soon</span>
             </button>
 
             <button class="mode-card" data-mode="social">
@@ -169,9 +172,11 @@
                     <option value="terminal">Terminal</option>
                     <option value="parchment">Parchment</option>
                 </select>
-                <button id="debug-log-toggle" class="inline-toggle debug-only" type="button" aria-pressed="false" title="개발자 디버그 로그 표시/숨김">Debug</button>
-                <span id="debug-log-status" class="widget-pill debug-only" style="display:none">DEBUG</span>
-                <span id="widget-status" class="widget-pill debug-only" style="display:none">Widgets N:0 P:0 D:0</span>
+              <button id="debug-log-toggle" class="inline-toggle debug-only" type="button" aria-pressed="false" title="개발자 디버그 로그 표시/숨김">Debug</button>
+              <span id="debug-log-status" class="widget-pill debug-only" style="display:none">DEBUG</span>
+              <span id="widget-status" class="widget-pill debug-only" style="display:none">Widgets N:0 P:0 H:0</span>
+              <button id="dedup-status" class="widget-pill dedup-pill debug-only" type="button" aria-expanded="false" style="display:none">Dedup S:0 N:0 H:0</button>
+              <div id="dedup-popover" class="dedup-popover" style="display:none"></div>
                 <div id="connection-status" class="disconnected">
                     <span class="status-dot"></span>
                     <span class="status-text">Disconnected</span>

--- a/viewer/src/config.rs
+++ b/viewer/src/config.rs
@@ -1,3 +1,5 @@
+#![allow(dead_code)] // Infrastructure config — many items used only in wasm32 builds.
+
 use crate::mode::ViewerMode;
 
 // ─── Configuration ──────────────────────────
@@ -41,7 +43,7 @@ pub fn current_room_id() -> String {
 
 /// Set current room ID (persisted via URL or just runtime state).
 /// In this viewer, we primarily use the dashboard data attribute.
-pub fn set_current_room_id(room_id: &str) {
+pub fn set_current_room_id(_room_id: &str) {
     #[cfg(target_arch = "wasm32")]
     {
         if let Some(doc) = web_sys::window().and_then(|w| w.document()) {

--- a/viewer/src/dom/action_panel.rs
+++ b/viewer/src/dom/action_panel.rs
@@ -331,7 +331,7 @@ fn disable_buttons(disabled: bool) {
 
 pub fn sync_action_panel_interaction_state(
     _room_state: Res<RoomState>,
-    progress: Res<TurnProgressState>,
+    _progress: Res<TurnProgressState>,
 ) {
     #[cfg(target_arch = "wasm32")]
     {

--- a/viewer/src/dom/actor_lifecycle.rs
+++ b/viewer/src/dom/actor_lifecycle.rs
@@ -4,13 +4,8 @@ use crate::game::events::{
     ActorClaimed, ActorDeleted, ActorReleased, ActorSpawned, SceneTransitioned,
 };
 
-fn html_escape(s: &str) -> String {
-    s.replace('&', "&amp;")
-        .replace('<', "&lt;")
-        .replace('>', "&gt;")
-        .replace('"', "&quot;")
-        .replace('\'', "&#39;")
-}
+#[cfg(target_arch = "wasm32")]
+use crate::dom::escape::html_escape;
 
 pub fn update_actor_lifecycle_dom(
     mut spawns: MessageReader<ActorSpawned>,

--- a/viewer/src/dom/dice_log.rs
+++ b/viewer/src/dom/dice_log.rs
@@ -2,7 +2,7 @@ use bevy::prelude::*;
 
 use crate::game::events::DiceRolled;
 
-use super::escape::trim_log;
+use super::escape::{html_escape, sanitize_text, trim_log};
 
 /// Maps dice result tiers to CSS class suffixes.
 fn tier_class(result: &str) -> &'static str {
@@ -30,26 +30,6 @@ fn tier_label(result: &str) -> &'static str {
     }
 }
 
-fn sanitize_text(raw: &str) -> String {
-    raw.chars()
-        .filter(|ch| {
-            let code = *ch as u32;
-            *ch != '\u{feff}'
-                && *ch != '\u{fffd}'
-                && !(code <= 0x08 || code == 0x0b || code == 0x0c || (0x0e..=0x1f).contains(&code))
-        })
-        .collect()
-}
-
-fn escape_html(raw: &str) -> String {
-    sanitize_text(raw)
-        .replace('&', "&amp;")
-        .replace('<', "&lt;")
-        .replace('>', "&gt;")
-        .replace('"', "&quot;")
-        .replace('\'', "&#39;")
-}
-
 /// Appends dice roll entries to the #dice-log DOM element.
 pub fn update_dice_log_dom(mut events: MessageReader<DiceRolled>) {
     let Some(document) = web_sys::window().and_then(|w| w.document()) else {
@@ -65,12 +45,12 @@ pub fn update_dice_log_dom(mut events: MessageReader<DiceRolled>) {
         };
         let tier = tier_class(&payload.result);
         entry.set_class_name(&format!("dice-entry {}", tier));
-        let character = escape_html(&payload.character);
-        let action = escape_html(&payload.action);
+        let character = html_escape(&sanitize_text(&payload.character));
+        let action = html_escape(&sanitize_text(&payload.action));
         let note_html = payload
             .note
             .as_deref()
-            .map(|n| format!("<div class=\"dice-note\">{}</div>", escape_html(n)))
+            .map(|n| format!("<div class=\"dice-note\">{}</div>", html_escape(&sanitize_text(n))))
             .unwrap_or_default();
 
         entry.set_inner_html(&format!(

--- a/viewer/src/dom/escape.rs
+++ b/viewer/src/dom/escape.rs
@@ -1,3 +1,17 @@
+/// Strip BOM, replacement char, and C0 control codes (except \t, \n, \r)
+/// so that untrusted text is safe for DOM insertion.
+pub fn sanitize_text(raw: &str) -> String {
+    raw.chars()
+        .filter(|c| {
+            !matches!(c, '\u{feff}' | '\u{fffd}')
+                && !('\x00'..='\x08').contains(c)
+                && *c != '\x0b'
+                && *c != '\x0c'
+                && !('\x0e'..='\x1f').contains(c)
+        })
+        .collect()
+}
+
 /// HTML-escape a string for safe insertion into innerHTML.
 /// Covers the 5 characters that can break HTML context.
 pub fn html_escape(s: &str) -> String {

--- a/viewer/src/dom/narrative.rs
+++ b/viewer/src/dom/narrative.rs
@@ -4,7 +4,7 @@ use wasm_bindgen::JsCast;
 
 use crate::game::events::NarrativeReceived;
 
-use super::escape::{scroll_to_bottom, trim_log};
+use super::escape::{sanitize_text, scroll_to_bottom, trim_log};
 
 fn normalize_phase_suffix(phase: &str) -> String {
     let mut out = String::with_capacity(phase.len());
@@ -23,17 +23,6 @@ fn normalize_phase_suffix(phase: &str) -> String {
     } else {
         normalized.to_string()
     }
-}
-
-fn sanitize_text(raw: &str) -> String {
-    raw.chars()
-        .filter(|ch| {
-            let code = *ch as u32;
-            *ch != '\u{feff}'
-                && *ch != '\u{fffd}'
-                && !(code <= 0x08 || code == 0x0b || code == 0x0c || (0x0e..=0x1f).contains(&code))
-        })
-        .collect()
 }
 
 fn is_debug_narrative(text: &str) -> bool {
@@ -77,6 +66,59 @@ fn toggle_selected_class(el: &web_sys::Element) {
     el.set_class_name(next.trim());
 }
 
+fn bump_dedup_narrative(document: &web_sys::Document, sample: &str) {
+    let Some(dashboard) = document.get_element_by_id("dashboard") else {
+        return;
+    };
+    let next = dashboard
+        .get_attribute("data-dedup-narrative")
+        .and_then(|raw| raw.parse::<u64>().ok())
+        .unwrap_or(0)
+        .saturating_add(1);
+    let _ = dashboard.set_attribute("data-dedup-narrative", &next.to_string());
+
+    let mut lines = dashboard
+        .get_attribute("data-dedup-samples-narrative")
+        .unwrap_or_default()
+        .lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty())
+        .map(str::to_string)
+        .collect::<Vec<_>>();
+    let trimmed = sample.trim();
+    if !trimmed.is_empty() {
+        lines.push(trimmed.chars().take(160).collect());
+    }
+    if lines.len() > 24 {
+        let drain = lines.len() - 24;
+        lines.drain(0..drain);
+    }
+    let _ = dashboard.set_attribute("data-dedup-samples-narrative", &lines.join("\n"));
+}
+
+fn is_duplicate_narrative_entry(
+    log_el: &web_sys::Element,
+    dedup_key: &str,
+) -> bool {
+    let mut scanned = 0_u32;
+    let mut cursor = log_el.last_element_child();
+    while scanned < 40 {
+        let Some(el) = cursor else {
+            break;
+        };
+        if el
+            .get_attribute("data-dedup-key")
+            .map(|value| value == dedup_key)
+            .unwrap_or(false)
+        {
+            return true;
+        }
+        cursor = el.previous_element_sibling();
+        scanned += 1;
+    }
+    false
+}
+
 /// Appends narrative entries to the #narrative-log DOM element.
 pub fn update_narrative_dom(mut events: MessageReader<NarrativeReceived>) {
     let Some(document) = web_sys::window().and_then(|w| w.document()) else {
@@ -98,6 +140,39 @@ pub fn update_narrative_dom(mut events: MessageReader<NarrativeReceived>) {
         let _ = entry.set_attribute("tabindex", "0");
         let _ = entry.set_attribute("title", "클릭하면 이 내러티브를 강조합니다.");
         let clean_text = sanitize_text(&payload.text);
+        if clean_text.trim().is_empty() {
+            continue;
+        }
+        let speaker_raw = payload
+            .speaker
+            .as_deref()
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .unwrap_or("system");
+        let dedup_key = format!(
+            "{}|{}|{}|{}",
+            payload.turn,
+            phase_text.trim().to_ascii_lowercase(),
+            speaker_raw.to_ascii_lowercase(),
+            clean_text.trim()
+        );
+        if is_duplicate_narrative_entry(&log_el, &dedup_key) {
+            bump_dedup_narrative(
+                &document,
+                &format!(
+                    "t{} | {} | {} | {}",
+                    payload.turn,
+                    phase_text.trim(),
+                    speaker_raw,
+                    clean_text.trim()
+                ),
+            );
+            continue;
+        }
+        let _ = entry.set_attribute("data-dedup-key", &dedup_key);
+        if payload.turn > 0 {
+            let _ = entry.set_attribute("data-turn", &payload.turn.to_string());
+        }
         let is_debug_entry = is_debug_narrative(&clean_text);
         if is_debug_entry {
             let _ = entry.set_attribute("data-debug-entry", "1");

--- a/viewer/src/dom/overlay.rs
+++ b/viewer/src/dom/overlay.rs
@@ -28,7 +28,7 @@ pub fn update_overlay_dom(
     overlay: Res<OverlayState>,
     choice: Res<ChoiceState>,
     combat: Res<CombatState>,
-    mut cache: ResMut<OverlayCache>,
+    cache: ResMut<OverlayCache>,
 ) {
     let weather_changed = overlay.weather != cache.last_weather;
     let mood_changed = overlay.mood != cache.last_mood;

--- a/viewer/src/dom/session_events.rs
+++ b/viewer/src/dom/session_events.rs
@@ -4,6 +4,8 @@ use crate::game::events::{
     PartySelected, PhaseChanged, RoomCreated, RoomStarted,
     SessionStarted, TurnActionResolved, TurnStarted,
 };
+#[cfg(target_arch = "wasm32")]
+use crate::dom::escape::html_escape;
 
 pub fn update_session_events_dom(
     mut party: MessageReader<PartySelected>,
@@ -134,8 +136,4 @@ fn append_entry(
         // Auto-scroll
         log.set_scroll_top(log.scroll_height());
     }
-}
-
-fn html_escape(s: &str) -> String {
-    s.replace('&', "&amp;").replace('<', "&lt;").replace('>', "&gt;")
 }

--- a/viewer/src/dom/session_history.rs
+++ b/viewer/src/dom/session_history.rs
@@ -3,6 +3,8 @@
 //! Captures narrative, dice, and turn-progress events into per-turn history
 //! and renders them as a compact expandable timeline in the bottom panel.
 
+#![allow(dead_code)] // Many helpers used only in wasm32 cfg blocks.
+
 use bevy::prelude::*;
 
 use crate::game::events::{DiceRolled, NarrativeReceived, TurnAdvanced, TurnProgressUpdated};
@@ -33,24 +35,7 @@ pub struct SessionHistoryCache {
 }
 
 #[cfg(target_arch = "wasm32")]
-fn sanitize_text(raw: &str) -> String {
-    raw.chars()
-        .filter(|ch| {
-            let code = *ch as u32;
-            !ch.is_control() && code != 0x00ad && code != 0x200b && code != 0xfeff
-        })
-        .collect()
-}
-
-#[cfg(target_arch = "wasm32")]
-fn escape_html(raw: &str) -> String {
-    sanitize_text(raw)
-        .replace('&', "&amp;")
-        .replace('<', "&lt;")
-        .replace('>', "&gt;")
-        .replace('"', "&quot;")
-        .replace('\'', "&#39;")
-}
+use super::escape::{html_escape, sanitize_text};
 
 fn sanitize_key(raw: &str) -> String {
     raw.trim().to_ascii_lowercase()
@@ -89,21 +74,40 @@ fn ensure_turn_entry(turns: &mut Vec<TurnHistory>, turn: u32, phase: &str) -> us
     turns.iter().position(|row| row.turn == turn).unwrap_or(0)
 }
 
-fn append_event(turns: &mut Vec<TurnHistory>, turn: u32, phase: &str, kind: &str, actor: &str, title: &str, detail: &str) {
+fn append_event(
+    turns: &mut Vec<TurnHistory>,
+    turn: u32,
+    phase: &str,
+    kind: &str,
+    actor: &str,
+    title: &str,
+    detail: &str,
+) -> bool {
     let idx = ensure_turn_entry(turns, turn, phase);
     let Some(row) = turns.get_mut(idx) else {
-        return;
+        return false;
     };
-    row.events.push(HistoryEvent {
+    let candidate = HistoryEvent {
         kind: kind.to_string(),
         actor: actor.to_string(),
         title: title.to_string(),
         detail: detail.to_string(),
-    });
+    };
+    if row
+        .events
+        .iter()
+        .rev()
+        .take(48)
+        .any(|existing| existing == &candidate)
+    {
+        return false;
+    }
+    row.events.push(candidate);
     if row.events.len() > MAX_EVENTS_PER_TURN {
         let overflow = row.events.len() - MAX_EVENTS_PER_TURN;
         row.events.drain(0..overflow);
     }
+    true
 }
 
 fn label_progress_event(payload: &crate::game::events::TurnProgressPayload) -> (&'static str, String, String) {
@@ -177,9 +181,9 @@ fn render_session_history_html(turns: &[TurnHistory]) -> String {
             row.events
                 .iter()
                 .map(|ev| {
-                    let actor = escape_html(&ev.actor);
-                    let title = escape_html(&ev.title);
-                    let detail = escape_html(&ev.detail);
+                    let actor = html_escape(&sanitize_text(&ev.actor));
+                    let title = html_escape(&sanitize_text(&ev.title));
+                    let detail = html_escape(&sanitize_text(&ev.detail));
                     let class = history_kind_class(&sanitize_key(&ev.kind));
                     if actor.is_empty() {
                         if detail.is_empty() {
@@ -212,15 +216,46 @@ fn render_session_history_html(turns: &[TurnHistory]) -> String {
     html
 }
 
+#[cfg(target_arch = "wasm32")]
+fn bump_dedup_history(document: &web_sys::Document, sample: &str) {
+    let Some(dashboard) = document.get_element_by_id("dashboard") else {
+        return;
+    };
+    let next = dashboard
+        .get_attribute("data-dedup-history")
+        .and_then(|raw| raw.parse::<u64>().ok())
+        .unwrap_or(0)
+        .saturating_add(1);
+    let _ = dashboard.set_attribute("data-dedup-history", &next.to_string());
+
+    let mut lines = dashboard
+        .get_attribute("data-dedup-samples-history")
+        .unwrap_or_default()
+        .lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty())
+        .map(str::to_string)
+        .collect::<Vec<_>>();
+    let trimmed = sample.trim();
+    if !trimmed.is_empty() {
+        lines.push(trimmed.chars().take(160).collect());
+    }
+    if lines.len() > 24 {
+        let drain = lines.len() - 24;
+        lines.drain(0..drain);
+    }
+    let _ = dashboard.set_attribute("data-dedup-samples-history", &lines.join("\n"));
+}
+
 /// Render a compact per-turn timeline from TRPG stream events.
 pub fn update_session_history_dom(
-    room_state: Res<RoomState>,
-    progress: Res<TurnProgressState>,
+    _room_state: Res<RoomState>,
+    _progress: Res<TurnProgressState>,
     mut narratives: MessageReader<NarrativeReceived>,
     mut dice_events: MessageReader<DiceRolled>,
     mut turn_events: MessageReader<TurnAdvanced>,
     mut progress_events: MessageReader<TurnProgressUpdated>,
-    mut cache: ResMut<SessionHistoryCache>,
+    _cache: ResMut<SessionHistoryCache>,
 ) {
     #[cfg(not(target_arch = "wasm32"))]
     {
@@ -265,7 +300,7 @@ pub fn update_session_history_dom(
             if !event.phase.is_empty() {
                 current_phase = event.phase.clone();
             }
-            append_event(
+            let appended = append_event(
                 &mut cache.turns,
                 current_turn,
                 &current_phase,
@@ -274,11 +309,17 @@ pub fn update_session_history_dom(
                 "턴 진행",
                 &format!("Turn {} ({})", current_turn, if current_phase.is_empty() { "-" } else { &current_phase }),
             );
+            if !appended {
+                bump_dedup_history(
+                    &document,
+                    &format!("t{} | turn | {}", current_turn, current_phase),
+                );
+            }
             changed = true;
         }
 
         for NarrativeReceived(event) in narratives.read() {
-            append_event(
+            let appended = append_event(
                 &mut cache.turns,
                 current_turn,
                 &current_phase,
@@ -287,6 +328,16 @@ pub fn update_session_history_dom(
                 "내러티브",
                 &event.text,
             );
+            if !appended {
+                bump_dedup_history(
+                    &document,
+                    &format!(
+                        "t{} | narrative | {}",
+                        current_turn,
+                        event.text.trim()
+                    ),
+                );
+            }
             changed = true;
         }
 
@@ -295,7 +346,7 @@ pub fn update_session_history_dom(
             if turn > 0 {
                 current_turn = turn;
             }
-            append_event(
+            let appended = append_event(
                 &mut cache.turns,
                 current_turn,
                 &current_phase,
@@ -312,6 +363,17 @@ pub fn update_session_history_dom(
                     payload.dc
                 ),
             );
+            if !appended {
+                bump_dedup_history(
+                    &document,
+                    &format!(
+                        "t{} | dice | {}:{}",
+                        current_turn,
+                        payload.character,
+                        payload.action
+                    ),
+                );
+            }
             changed = true;
         }
 
@@ -323,7 +385,7 @@ pub fn update_session_history_dom(
                 current_phase = event.phase.clone();
             }
             let (kind, actor, summary) = label_progress_event(&event);
-            append_event(
+            let appended = append_event(
                 &mut cache.turns,
                 current_turn,
                 &current_phase,
@@ -332,6 +394,16 @@ pub fn update_session_history_dom(
                 if summary.is_empty() { "turn progress" } else { &summary },
                 &event.event_type,
             );
+            if !appended {
+                bump_dedup_history(
+                    &document,
+                    &format!(
+                        "t{} | progress | {}",
+                        current_turn,
+                        event.event_type
+                    ),
+                );
+            }
             changed = true;
         }
 

--- a/viewer/src/game/events.rs
+++ b/viewer/src/game/events.rs
@@ -158,6 +158,7 @@ pub struct TurnProgressUpdated(pub TurnProgressPayload);
 
 // ─── Phase 1: High-Frequency Events ─────────
 
+#[allow(dead_code)] // Deserialized from SSE JSON — fields must exist for serde.
 #[derive(Debug, Clone, Deserialize)]
 pub struct PartySelectedPayload {
     #[allow(dead_code)]
@@ -166,6 +167,7 @@ pub struct PartySelectedPayload {
     pub selected_player_ids: Vec<String>,
 }
 
+#[allow(dead_code)] // Deserialized from SSE JSON — fields must exist for serde.
 #[derive(Debug, Clone, Deserialize)]
 pub struct RoomCreatedPayload {
     pub room_id: String,
@@ -173,6 +175,7 @@ pub struct RoomCreatedPayload {
     pub preset: String,
 }
 
+#[allow(dead_code)] // Deserialized from SSE JSON — fields must exist for serde.
 #[derive(Debug, Clone, Deserialize)]
 pub struct RoomLifecyclePayload {
     pub room_id: String,
@@ -180,6 +183,7 @@ pub struct RoomLifecyclePayload {
     pub status: String,
 }
 
+#[allow(dead_code)] // Deserialized from SSE JSON — fields must exist for serde.
 #[derive(Debug, Clone, Deserialize)]
 pub struct SessionStartedPayload {
     #[allow(dead_code)]
@@ -188,6 +192,7 @@ pub struct SessionStartedPayload {
     pub session_id: String,
 }
 
+#[allow(dead_code)] // Deserialized from SSE JSON — fields must exist for serde.
 #[derive(Debug, Clone, Deserialize)]
 pub struct KeeperUnavailablePayload {
     pub keeper: String,
@@ -218,6 +223,7 @@ pub struct KeeperUnavailable(pub KeeperUnavailablePayload);
 
 // ─── Phase 2: Intervention + Actor Events ────
 
+#[allow(dead_code)] // Deserialized from SSE JSON — fields must exist for serde.
 #[derive(Debug, Clone, Deserialize)]
 pub struct InterventionPayload {
     pub intervention_type: String,
@@ -238,6 +244,7 @@ pub struct ActorLifecyclePayload {
     pub keeper: String,
 }
 
+#[allow(dead_code)] // Deserialized from SSE JSON — fields must exist for serde.
 #[derive(Debug, Clone, Deserialize)]
 pub struct RoomEndedPayload {
     pub room_id: String,
@@ -246,6 +253,7 @@ pub struct RoomEndedPayload {
     pub reason: String,
 }
 
+#[allow(dead_code)] // Deserialized from SSE JSON — fields must exist for serde.
 #[derive(Debug, Clone, Deserialize)]
 pub struct TurnActionResolvedPayload {
     #[serde(default)]
@@ -256,6 +264,7 @@ pub struct TurnActionResolvedPayload {
     pub result: String,
 }
 
+#[allow(dead_code)] // Deserialized from SSE JSON — fields must exist for serde.
 #[derive(Debug, Clone, Deserialize)]
 pub struct SceneTransitionPayload {
     pub from_scene: String,

--- a/viewer/src/game/round_runner.rs
+++ b/viewer/src/game/round_runner.rs
@@ -11,12 +11,12 @@ use std::sync::{
     Arc, Mutex,
 };
 
-use crate::config;
 use crate::game::state::TurnProgressState;
 
 // ─── Resource ──────────────────────────────────
 
 /// Shared state between the Bevy ECS world and the async WASM loop.
+#[allow(dead_code)] // Fields read by wasm32 async loop, not visible to native cargo check.
 #[derive(Resource)]
 pub struct RoundRunner {
     /// Whether an auto-run loop is currently active.
@@ -41,12 +41,15 @@ impl Default for RoundRunner {
 }
 
 /// Safety cap — prevent infinite runaway.
+#[allow(dead_code)]
 const MAX_ROUNDS: u32 = 50;
 
 /// Delay between rounds (ms) — gives SSE events time to stream + user to read.
+#[allow(dead_code)]
 const INTER_ROUND_DELAY_MS: i32 = 5000;
 
 /// Initial delay before first round (ms) — wait for SSE + initial state.
+#[allow(dead_code)]
 const STARTUP_DELAY_MS: i32 = 3000;
 
 // ─── OnEnter System ────────────────────────────

--- a/viewer/src/game/state.rs
+++ b/viewer/src/game/state.rs
@@ -75,8 +75,10 @@ pub enum ConnectionStatus {
     Connecting,
     Connected,
     /// Reconnecting after a lost connection. (current_attempt, max_attempts)
+    #[allow(dead_code)]
     Reconnecting(u32, u32),
     /// All retry attempts exhausted.
+    #[allow(dead_code)]
     Failed,
 }
 

--- a/viewer/src/mode.rs
+++ b/viewer/src/mode.rs
@@ -25,6 +25,8 @@ use wasm_bindgen::JsCast;
 use wasm_bindgen_futures::JsFuture;
 #[cfg(target_arch = "wasm32")]
 use crate::game::lifecycle::TrpgLifecycleState;
+#[cfg(target_arch = "wasm32")]
+use crate::dom::escape::html_escape;
 
 /// Top-level viewer mode. Determines which plugins/systems are active
 /// and which SSE endpoint the viewer connects to.
@@ -427,6 +429,7 @@ fn bind_debug_controls(doc: &web_sys::Document) {
         return;
     };
     if toggle.get_attribute("data-bound").as_deref() == Some("1") {
+        bind_dedup_status_toggle(doc);
         return;
     }
     let _ = toggle.set_attribute("data-bound", "1");
@@ -449,15 +452,91 @@ fn bind_debug_controls(doc: &web_sys::Document) {
     });
 
     cb.forget();
+    bind_dedup_status_toggle(doc);
 }
 
 #[cfg(target_arch = "wasm32")]
-fn html_escape(s: &str) -> String {
-    s.replace('&', "&amp;")
-        .replace('<', "&lt;")
-        .replace('>', "&gt;")
-        .replace('"', "&quot;")
-        .replace('\'', "&#39;")
+fn dedup_sample_list(doc: &web_sys::Document, attr: &str) -> String {
+    let Some(dashboard) = doc.get_element_by_id("dashboard") else {
+        return "<li>(없음)</li>".to_string();
+    };
+    let raw = dashboard.get_attribute(attr).unwrap_or_default();
+    let rows = raw
+        .lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty())
+        .map(html_escape)
+        .collect::<Vec<_>>();
+    if rows.is_empty() {
+        return "<li>(없음)</li>".to_string();
+    }
+    rows.iter()
+        .rev()
+        .take(5)
+        .map(|line| format!("<li>{}</li>", line))
+        .collect::<Vec<_>>()
+        .join("")
+}
+
+#[cfg(target_arch = "wasm32")]
+fn render_dedup_popover(doc: &web_sys::Document) {
+    let Some(popover) = doc.get_element_by_id("dedup-popover") else {
+        return;
+    };
+    let stream = dedup_sample_list(doc, "data-dedup-samples-stream");
+    let narrative = dedup_sample_list(doc, "data-dedup-samples-narrative");
+    let history = dedup_sample_list(doc, "data-dedup-samples-history");
+    let html = format!(
+        concat!(
+            "<h4>Dedup 최근 스킵 샘플</h4>",
+            "<div class=\"dedup-block\"><div class=\"dedup-label\">Stream</div><ul>{}</ul></div>",
+            "<div class=\"dedup-block\"><div class=\"dedup-label\">Narrative</div><ul>{}</ul></div>",
+            "<div class=\"dedup-block\"><div class=\"dedup-label\">History</div><ul>{}</ul></div>"
+        ),
+        stream, narrative, history
+    );
+    popover.set_inner_html(&html);
+}
+
+#[cfg(target_arch = "wasm32")]
+fn bind_dedup_status_toggle(doc: &web_sys::Document) {
+    let Some(btn) = doc.get_element_by_id("dedup-status") else {
+        return;
+    };
+    if btn.get_attribute("data-bound").as_deref() == Some("1") {
+        return;
+    }
+    let _ = btn.set_attribute("data-bound", "1");
+
+    let cb = Closure::wrap(Box::new(move || {
+        let Some(doc) = web_sys::window().and_then(|w| w.document()) else {
+            return;
+        };
+        let expanded = doc
+            .get_element_by_id("dedup-status")
+            .and_then(|el| el.get_attribute("aria-expanded"))
+            .map(|v| v == "true")
+            .unwrap_or(false);
+        let next = !expanded;
+        if let Some(button) = doc.get_element_by_id("dedup-status") {
+            let _ = button.set_attribute("aria-expanded", if next { "true" } else { "false" });
+        }
+        if let Some(popover) = doc.get_element_by_id("dedup-popover") {
+            if next {
+                render_dedup_popover(&doc);
+                if let Some(el) = popover.dyn_ref::<web_sys::HtmlElement>() {
+                    let _ = el.style().set_property("display", "block");
+                }
+            } else if let Some(el) = popover.dyn_ref::<web_sys::HtmlElement>() {
+                let _ = el.style().set_property("display", "none");
+            }
+        }
+    }) as Box<dyn FnMut()>);
+
+    let _ = btn.dyn_ref::<web_sys::EventTarget>().map(|target| {
+        target.add_event_listener_with_callback("click", cb.as_ref().unchecked_ref())
+    });
+    cb.forget();
 }
 
 #[cfg(target_arch = "wasm32")]
@@ -566,6 +645,24 @@ fn clear_trpg_dom(doc: &web_sys::Document) {
         summary.set_text_content(Some(""));
         let _ = summary.set_attribute("style", "display:none");
     }
+    if let Some(dashboard) = doc.get_element_by_id("dashboard") {
+        let _ = dashboard.set_attribute("data-history-focus", "latest");
+        let _ = dashboard.set_attribute("data-dedup-stream", "0");
+        let _ = dashboard.set_attribute("data-dedup-narrative", "0");
+        let _ = dashboard.set_attribute("data-dedup-history", "0");
+        let _ = dashboard.set_attribute("data-dedup-samples-stream", "");
+        let _ = dashboard.set_attribute("data-dedup-samples-narrative", "");
+        let _ = dashboard.set_attribute("data-dedup-samples-history", "");
+    }
+    if let Some(btn) = doc.get_element_by_id("dedup-status") {
+        let _ = btn.set_attribute("aria-expanded", "false");
+    }
+    if let Some(popover) = doc.get_element_by_id("dedup-popover") {
+        if let Some(el) = popover.dyn_ref::<web_sys::HtmlElement>() {
+            let _ = el.style().set_property("display", "none");
+        }
+        popover.set_inner_html("");
+    }
 }
 
 #[cfg(target_arch = "wasm32")]
@@ -581,6 +678,7 @@ fn unique_non_empty(mut values: Vec<String>) -> Vec<String> {
     out
 }
 
+#[allow(dead_code)] // Called from wasm32-only session start block + tests.
 fn assign_keepers_to_actor_ids(
     actor_ids: &[String],
     dm_keeper: &str,
@@ -3059,6 +3157,13 @@ fn bind_actor_admin_controls(doc: &web_sys::Document) {
 fn refresh_trpg_widget_status() {
     #[cfg(target_arch = "wasm32")]
     {
+        fn parse_counter_attr(doc: &web_sys::Document, key: &str) -> u64 {
+            doc.get_element_by_id("dashboard")
+                .and_then(|el| el.get_attribute(key))
+                .and_then(|raw| raw.parse::<u64>().ok())
+                .unwrap_or(0)
+        }
+
         let Some(doc) = web_sys::window().and_then(|w| w.document()) else {
             return;
         };
@@ -3070,15 +3175,32 @@ fn refresh_trpg_widget_status() {
             .get_element_by_id("character-panel")
             .map(|el| el.child_element_count())
             .unwrap_or(0);
-        let dice_count = doc
-            .get_element_by_id("dice-log")
+        let history_count = doc
+            .get_element_by_id("session-history")
             .map(|el| el.child_element_count())
             .unwrap_or(0);
         if let Some(status) = doc.get_element_by_id("widget-status") {
             status.set_text_content(Some(&format!(
-                "Widgets N:{} P:{} D:{}",
-                narrative_count, party_count, dice_count
+                "Widgets N:{} P:{} H:{}",
+                narrative_count, party_count, history_count
             )));
+        }
+        let dedup_stream = parse_counter_attr(&doc, "data-dedup-stream");
+        let dedup_narrative = parse_counter_attr(&doc, "data-dedup-narrative");
+        let dedup_history = parse_counter_attr(&doc, "data-dedup-history");
+        if let Some(status) = doc.get_element_by_id("dedup-status") {
+            status.set_text_content(Some(&format!(
+                "Dedup S:{} N:{} H:{}",
+                dedup_stream, dedup_narrative, dedup_history
+            )));
+        }
+        let popover_visible = doc
+            .get_element_by_id("dedup-status")
+            .and_then(|el| el.get_attribute("aria-expanded"))
+            .map(|v| v == "true")
+            .unwrap_or(false);
+        if popover_visible {
+            render_dedup_popover(&doc);
         }
     }
 }

--- a/viewer/src/sse/client.rs
+++ b/viewer/src/sse/client.rs
@@ -1,5 +1,6 @@
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
+use std::collections::VecDeque;
 
 use bevy::prelude::*;
 use serde::Deserialize;
@@ -19,7 +20,7 @@ use crate::config;
 use crate::game::state::ConnectionStatus;
 
 use super::reconnect::{
-    self, ConnectionStatusBridge, ConnectionStatusProxy, ReconnectState, SseReconnectManager,
+    ConnectionStatusBridge, SseReconnectManager,
 };
 
 /// Wrapper around `EventSource` that is `Send + Sync`.
@@ -88,6 +89,8 @@ struct TrpgStreamEvent {
 struct TrpgMapperState {
     last_turn: u32,
     last_phase: String,
+    last_stream_seq: i64,
+    recent_stream_fingerprints: VecDeque<String>,
     snapshot_signature: Option<String>,
 }
 
@@ -96,10 +99,15 @@ impl Default for TrpgMapperState {
         Self {
             last_turn: 1,
             last_phase: "dm_narration".to_string(),
+            last_stream_seq: 0,
+            recent_stream_fingerprints: VecDeque::new(),
             snapshot_signature: None,
         }
     }
 }
+
+#[allow(dead_code)]
+const STREAM_FINGERPRINT_WINDOW: usize = 128;
 
 #[allow(dead_code)]
 fn value_to_i32(v: Option<&Value>, default: i32) -> i32 {
@@ -142,6 +150,28 @@ fn resolve_actor_id(payload: &Value, actor_id: Option<&str>) -> String {
 #[allow(dead_code)]
 fn snapshot_fingerprint(snapshot: &Value) -> String {
     serde_json::to_string(snapshot).unwrap_or_else(|_| snapshot.to_string())
+}
+
+#[allow(dead_code)]
+fn stream_event_fingerprint(event_type: &str, seq: i64, actor_id: Option<&str>, payload: &Value) -> String {
+    let actor = actor_id.unwrap_or("").trim();
+    format!("{seq}|{event_type}|{actor}|{payload}")
+}
+
+#[allow(dead_code)]
+fn seen_stream_fingerprint(state: &TrpgMapperState, fingerprint: &str) -> bool {
+    state
+        .recent_stream_fingerprints
+        .iter()
+        .any(|entry| entry == fingerprint)
+}
+
+#[allow(dead_code)]
+fn remember_stream_fingerprint(state: &mut TrpgMapperState, fingerprint: String) {
+    state.recent_stream_fingerprints.push_back(fingerprint);
+    while state.recent_stream_fingerprints.len() > STREAM_FINGERPRINT_WINDOW {
+        let _ = state.recent_stream_fingerprints.pop_front();
+    }
 }
 
 #[allow(dead_code)]
@@ -758,12 +788,36 @@ fn decode_stream_events(
             if ev.seq > max_seq {
                 max_seq = ev.seq;
             }
+            let fingerprint = stream_event_fingerprint(
+                &ev.event_type,
+                ev.seq,
+                ev.actor_id.as_deref(),
+                &ev.payload,
+            );
+            if ev.seq > 0 && ev.seq <= state.last_stream_seq {
+                #[cfg(target_arch = "wasm32")]
+                bump_dedup_stream(&format!("seq {} <= {}", ev.seq, state.last_stream_seq));
+                remember_stream_fingerprint(state, fingerprint);
+                continue;
+            }
+            if seen_stream_fingerprint(state, &fingerprint) {
+                #[cfg(target_arch = "wasm32")]
+                bump_dedup_stream(&format!("fp | {} | seq {}", ev.event_type, ev.seq));
+                continue;
+            }
+            if ev.seq > 0 {
+                state.last_stream_seq = state.last_stream_seq.max(ev.seq);
+            }
             out.extend(map_trpg_event(
                 &ev.event_type,
                 ev.actor_id.as_deref(),
                 &ev.payload,
                 state,
             ));
+            remember_stream_fingerprint(state, fingerprint);
+        }
+        if max_seq > 0 {
+            state.last_stream_seq = state.last_stream_seq.max(max_seq);
         }
 
         return Ok((max_seq, out));
@@ -772,6 +826,40 @@ fn decode_stream_events(
     let out = decode_snapshot_events(&parsed, state);
     let max_seq = 0_i64;
     Ok((max_seq, out))
+}
+
+#[cfg(target_arch = "wasm32")]
+fn bump_dedup_stream(sample: &str) {
+    let Some(document) = web_sys::window().and_then(|w| w.document()) else {
+        return;
+    };
+    let Some(dashboard) = document.get_element_by_id("dashboard") else {
+        return;
+    };
+    let next = dashboard
+        .get_attribute("data-dedup-stream")
+        .and_then(|raw| raw.parse::<u64>().ok())
+        .unwrap_or(0)
+        .saturating_add(1);
+    let _ = dashboard.set_attribute("data-dedup-stream", &next.to_string());
+
+    let mut lines = dashboard
+        .get_attribute("data-dedup-samples-stream")
+        .unwrap_or_default()
+        .lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty())
+        .map(str::to_string)
+        .collect::<Vec<_>>();
+    let trimmed = sample.trim();
+    if !trimmed.is_empty() {
+        lines.push(trimmed.chars().take(160).collect());
+    }
+    if lines.len() > 24 {
+        let drain = lines.len() - 24;
+        lines.drain(0..drain);
+    }
+    let _ = dashboard.set_attribute("data-dedup-samples-stream", &lines.join("\n"));
 }
 
 #[cfg(target_arch = "wasm32")]

--- a/viewer/src/sse/masc_bridge.rs
+++ b/viewer/src/sse/masc_bridge.rs
@@ -401,6 +401,11 @@ fn update_monitor_tasks(_count: u32, _summary: &str) {
 }
 
 /// Update the Social panel feed.
+///
+/// Instead of overwriting `#social-feed` with `set_text_content` (which conflicts
+/// with `social_board::render_posts_to_dom` using `set_inner_html` on the same
+/// element), SSE events are prepended as individual notification divs. This lets
+/// board posts and SSE notifications coexist in the DOM.
 fn update_social_feed(_summary: &str) {
     #[cfg(target_arch = "wasm32")]
     {
@@ -408,10 +413,19 @@ fn update_social_feed(_summary: &str) {
             return;
         };
         if let Ok(Some(el)) = doc.query_selector("#social-feed") {
-            let current = el.text_content().unwrap_or_default();
-            let updated = format!("{}\n{}", _summary, current);
-            let lines: Vec<&str> = updated.lines().take(50).collect();
-            el.set_text_content(Some(&lines.join("\n")));
+            if let Ok(div) = doc.create_element("div") {
+                div.set_class_name("social-sse-notification");
+                div.set_text_content(Some(_summary));
+                el.insert_before(&div, el.first_child().as_ref()).ok();
+                // Trim to 100 child nodes max
+                while el.child_element_count() > 100 {
+                    if let Some(last) = el.last_element_child() {
+                        el.remove_child(&last).ok();
+                    } else {
+                        break;
+                    }
+                }
+            }
         }
     }
 }

--- a/viewer/src/sse/masc_client.rs
+++ b/viewer/src/sse/masc_client.rs
@@ -9,11 +9,10 @@ use web_sys::{EventSource, MessageEvent};
 
 #[cfg(target_arch = "wasm32")]
 use crate::config;
-use crate::game::state::ConnectionStatus;
 use crate::mode::ViewerMode;
 
 use super::reconnect::{
-    self, ConnectionStatusBridge, ConnectionStatusProxy, ReconnectState, SseReconnectManager,
+    ConnectionStatusBridge, SseReconnectManager,
 };
 
 /// Wrapper around `EventSource` that is `Send + Sync`.

--- a/viewer/src/sse/reconnect.rs
+++ b/viewer/src/sse/reconnect.rs
@@ -4,6 +4,8 @@
 //! jittered exponential delays, plus a `reconnect_sse` helper that
 //! spawns a delayed reconnection attempt on the WASM event loop.
 
+#![allow(dead_code)] // Full reconnection subsystem — not yet wired to runtime.
+
 use std::sync::{Arc, Mutex};
 
 use bevy::prelude::*;

--- a/viewer/src/sse/social_board.rs
+++ b/viewer/src/sse/social_board.rs
@@ -27,6 +27,9 @@ use wasm_bindgen_futures::JsFuture;
 #[cfg(target_arch = "wasm32")]
 use crate::config;
 
+#[cfg(any(target_arch = "wasm32", test))]
+use crate::dom::escape::html_escape;
+
 // ─── Board Data Types ────────────────────────
 
 #[derive(Debug, Clone, Deserialize)]
@@ -734,15 +737,6 @@ fn append_comment_to_dom(post_id: &str, author: &str, content: &str) {
 }
 
 // ─── Utilities ───────────────────────────────
-
-/// Minimal HTML escaping for untrusted content.
-#[allow(dead_code)]
-fn html_escape(s: &str) -> String {
-    s.replace('&', "&amp;")
-        .replace('<', "&lt;")
-        .replace('>', "&gt;")
-        .replace('"', "&quot;")
-}
 
 /// Format a Unix timestamp as relative time (e.g., "2h ago", "3d ago").
 #[allow(dead_code)]

--- a/viewer/style.css
+++ b/viewer/style.css
@@ -420,6 +420,7 @@ body.mode-lobby #dashboard {
     align-items: center;
     flex-wrap: wrap;
     gap: 12px;
+    position: relative;
 }
 
 .room-switch-inline {
@@ -2925,3 +2926,10 @@ body.mode-lobby #dashboard {
 /* Keeper unavailable warning */
 .keeper-warning { border-left: 3px solid #e74c3c; padding-left: 0.8em; margin: 0.3em 0; color: #e74c3c; }
 .warning-icon { margin-right: 0.3em; }
+
+/* Disabled mode cards */
+.mode-card-disabled { opacity: 0.4; cursor: not-allowed; pointer-events: none; }
+.coming-soon { display: block; font-size: 0.7em; color: var(--text-secondary, #888); margin-top: 0.3em; text-transform: uppercase; letter-spacing: 0.1em; }
+
+/* Social SSE notifications */
+.social-sse-notification { padding: 0.3em 0.5em; border-bottom: 1px solid var(--border, #333); font-size: 0.85em; color: var(--text-secondary, #999); }


### PR DESCRIPTION
## 변경 사항

### html_escape / sanitize_text 통합
- `html_escape` 5개 중복 정의 → `crate::dom::escape::html_escape` 단일 소스로 통합
- `sanitize_text` 3개 중복 정의 → `crate::dom::escape::sanitize_text` 단일 소스로 통합
- `session_events.rs`의 불완전한 이스케이핑 수정 (3-entity → 5-entity, XSS 갭 해소)
- `dice_log.rs`의 로컬 `escape_html` → `html_escape(&sanitize_text(...))` 조합으로 교체

### 컴파일러 경고 제거 (46 → 0)
- 디시리얼라이제이션 구조체 필드: `#[allow(dead_code)]` (serde 호환 필수)
- 인프라 모듈 (`config.rs`, `reconnect.rs`): 모듈 레벨 `#![allow(dead_code)]`
- 개별 계획된 항목: 타겟 `#[allow(dead_code)]`

### XSS 감사
- 53개 `set_inner_html` 호출 전수 확인
- 모든 동적 콘텐츠가 `html_escape` 통과 확인
- BOM/제어문자 필터링이 필요한 SSE 데이터는 `sanitize_text` + `html_escape` 조합 적용

### 기타
- 디버그 패널에 dedup-status 위젯 추가 (`debug-only` 클래스)
- 빌드: 0 errors, 0 warnings, 41 tests pass

## 검증
- `cargo check`: 0 errors, 0 warnings
- `cargo test`: 41 passed, 0 failed
