### PR TITLE
fix(trpg): add phase tracking and staleness detection to dnd5e-lite

### DIFF
--- a/lib/trpg_rule_dnd5e_lite.ml
+++ b/lib/trpg_rule_dnd5e_lite.ml
@@ -79,7 +79,9 @@ let init_state ~config =
   `Assoc
     [
       ("status", `String "lobby");
+      ("phase", `String "lobby");
       ("turn", `Int 1);
+      ("last_event_ts", `Null);
       ("current_node", `Null);
       ("party", if party = `Null then `Assoc [] else party);
       ("actor_control", `Assoc []);
@@ -390,26 +392,52 @@ let apply_node_advanced ~state ~event =
   | _ -> state
 
 let apply_event ~state ~(event : Trpg_engine_event.t) =
+  (* Track last_event_ts for every event — enables staleness detection *)
+  let state =
+    match state with
+    | `Assoc fields ->
+        `Assoc (assoc_put "last_event_ts" (`String event.ts) fields)
+    | _ -> state
+  in
   match event.event_type with
   | Trpg_engine_event.Room_created ->
       (match state with
-      | `Assoc fields -> `Assoc (assoc_put "status" (`String "lobby") fields)
+      | `Assoc fields ->
+          `Assoc (fields
+            |> assoc_put "status" (`String "lobby")
+            |> assoc_put "phase" (`String "lobby"))
       | _ -> state)
   | Trpg_engine_event.Room_started ->
       (match state with
-      | `Assoc fields -> `Assoc (assoc_put "status" (`String "active") fields)
+      | `Assoc fields ->
+          `Assoc (fields
+            |> assoc_put "status" (`String "active")
+            |> assoc_put "phase" (`String "briefing"))
       | _ -> state)
   | Trpg_engine_event.Room_ended ->
       (match state with
-      | `Assoc fields -> `Assoc (assoc_put "status" (`String "ended") fields)
+      | `Assoc fields ->
+          `Assoc (fields
+            |> assoc_put "status" (`String "ended")
+            |> assoc_put "phase" (`String "ended"))
       | _ -> state)
   | Trpg_engine_event.Turn_started ->
       let next_turn =
         event.payload |> member "turn" |> to_int_option |> Option.value ~default:1
       in
       (match state with
-      | `Assoc fields -> `Assoc (assoc_put "turn" (`Int next_turn) fields)
+      | `Assoc fields ->
+          `Assoc (fields
+            |> assoc_put "turn" (`Int next_turn)
+            |> assoc_put "phase" (`String "round"))
       | _ -> state)
+  | Trpg_engine_event.Phase_changed ->
+      let phase = get_string_opt "phase" event.payload |> Option.value ~default:"" in
+      if phase = "" then state
+      else
+        (match state with
+        | `Assoc fields -> `Assoc (assoc_put "phase" (`String phase) fields)
+        | _ -> state)
   | Trpg_engine_event.Dice_rolled | Trpg_engine_event.Turn_action_resolved ->
       append_to_list "dice_log" event.payload state
   | Trpg_engine_event.Narration_posted ->
@@ -423,7 +451,6 @@ let apply_event ~state ~(event : Trpg_engine_event.t) =
   | Trpg_engine_event.Actor_deleted -> apply_actor_deleted ~state ~event
   | Trpg_engine_event.Actor_claimed -> apply_actor_claimed ~state ~event
   | Trpg_engine_event.Actor_released -> apply_actor_released ~state ~event
-  | Trpg_engine_event.Phase_changed
   | Trpg_engine_event.Turn_action_proposed
   | Trpg_engine_event.Turn_timeout
   | Trpg_engine_event.Keeper_unavailable

--- a/viewer/src/mode.rs
+++ b/viewer/src/mode.rs
@@ -924,7 +924,7 @@ async fn fetch_room_runtime(room_id: &str) -> Result<(String, u32, String), Stri
     let room = json.get("room").unwrap_or(&Value::Null);
     let state = json.get("state").unwrap_or(&Value::Null);
 
-    let status = room
+    let mut status = room
         .get("status")
         .and_then(Value::as_str)
         .or_else(|| state.get("status").and_then(Value::as_str))
@@ -941,6 +941,26 @@ async fn fetch_room_runtime(room_id: &str) -> Result<(String, u32, String), Stri
         .or_else(|| state.get("phase").and_then(Value::as_str))
         .unwrap_or("-")
         .to_string();
+
+    // Staleness detection: override "active" to "paused" when last event is old
+    if status == "active" {
+        let last_event_ts = state
+            .get("last_event_ts")
+            .and_then(Value::as_str)
+            .unwrap_or("");
+        if !last_event_ts.is_empty() {
+            let event_ms = js_sys::Date::parse(last_event_ts);
+            if event_ms.is_finite() {
+                let now_ms = js_sys::Date::now();
+                let elapsed_sec = (now_ms - event_ms) / 1000.0;
+                // 30 minutes without any event → stale game
+                if elapsed_sec > 1800.0 {
+                    status = "paused".to_string();
+                }
+            }
+        }
+    }
+
     Ok((status, turn, phase))
 }
 


### PR DESCRIPTION
## Summary

- dnd5e-lite의 3-status 모델(lobby/active/ended)에 phase 추적과 staleness 감지 추가
- 모든 시작된 게임이 "진행 중"에만 표시되는 kanban 버그 수정
- 30분 이상 이벤트 없는 게임은 "멈춤" 상태로 자동 전환

## Changes

### OCaml (lib/trpg_rule_dnd5e_lite.ml)
- `init_state`에 `phase`와 `last_event_ts` 필드 추가
- 모든 이벤트에서 `last_event_ts` 자동 갱신 (staleness 감지용)
- Room_created → phase "lobby", Room_started → "briefing", Turn_started → "round", Room_ended → "ended"
- Phase_changed 이벤트를 no-op에서 실제 phase 업데이트로 변경

### Rust Viewer (viewer/src/mode.rs)
- `fetch_room_runtime`에서 `last_event_ts` 추출
- status="active"이고 마지막 이벤트가 30분 이상 경과하면 "paused"로 override
- `lifecycle.rs`의 기존 매핑: "paused" → `Stopped` → "멈춤" kanban lane

## Test plan
- [x] OCaml 빌드 성공
- [x] Rust viewer `cargo check --target wasm32-unknown-unknown` 성공
- [x] TRPG rule 테스트 3/3 통과 (test_trpg_rule_dnd5e_lite)
- [x] TRPG state machine 테스트 5/5 통과
- [x] TRPG coverage 테스트 10/10 통과
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)