### PR TITLE
fix(viewer): restore build after cleanup regressions

### DIFF
--- a/viewer/src/config.rs
+++ b/viewer/src/config.rs
@@ -43,7 +43,7 @@ pub fn current_room_id() -> String {
 
 /// Set current room ID (persisted via URL or just runtime state).
 /// In this viewer, we primarily use the dashboard data attribute.
-pub fn set_current_room_id(_room_id: &str) {
+pub fn set_current_room_id(room_id: &str) {
     #[cfg(target_arch = "wasm32")]
     {
         if let Some(doc) = web_sys::window().and_then(|w| w.document()) {
@@ -164,4 +164,3 @@ pub fn sse_endpoint_by_name(mode_name: &str) -> Option<String> {
         _ => None,
     }
 }
-

--- a/viewer/src/dom/action_panel.rs
+++ b/viewer/src/dom/action_panel.rs
@@ -331,7 +331,7 @@ fn disable_buttons(disabled: bool) {
 
 pub fn sync_action_panel_interaction_state(
     _room_state: Res<RoomState>,
-    _progress: Res<TurnProgressState>,
+    progress: Res<TurnProgressState>,
 ) {
     #[cfg(target_arch = "wasm32")]
     {

--- a/viewer/src/dom/overlay.rs
+++ b/viewer/src/dom/overlay.rs
@@ -28,7 +28,7 @@ pub fn update_overlay_dom(
     overlay: Res<OverlayState>,
     choice: Res<ChoiceState>,
     combat: Res<CombatState>,
-    cache: ResMut<OverlayCache>,
+    mut cache: ResMut<OverlayCache>,
 ) {
     let weather_changed = overlay.weather != cache.last_weather;
     let mood_changed = overlay.mood != cache.last_mood;

--- a/viewer/src/dom/session_history.rs
+++ b/viewer/src/dom/session_history.rs
@@ -249,13 +249,13 @@ fn bump_dedup_history(document: &web_sys::Document, sample: &str) {
 
 /// Render a compact per-turn timeline from TRPG stream events.
 pub fn update_session_history_dom(
-    _room_state: Res<RoomState>,
-    _progress: Res<TurnProgressState>,
+    room_state: Res<RoomState>,
+    progress: Res<TurnProgressState>,
     mut narratives: MessageReader<NarrativeReceived>,
     mut dice_events: MessageReader<DiceRolled>,
     mut turn_events: MessageReader<TurnAdvanced>,
     mut progress_events: MessageReader<TurnProgressUpdated>,
-    _cache: ResMut<SessionHistoryCache>,
+    mut cache: ResMut<SessionHistoryCache>,
 ) {
     #[cfg(not(target_arch = "wasm32"))]
     {

--- a/viewer/src/game/round_runner.rs
+++ b/viewer/src/game/round_runner.rs
@@ -11,6 +11,7 @@ use std::sync::{
     Arc, Mutex,
 };
 
+use crate::config;
 use crate::game::state::TurnProgressState;
 
 // ─── Resource ──────────────────────────────────

--- a/viewer/src/mode.rs
+++ b/viewer/src/mode.rs
@@ -2584,6 +2584,34 @@ async fn start_new_game_flow(doc: &web_sys::Document) -> Result<String, String> 
 }
 
 #[cfg(target_arch = "wasm32")]
+fn set_new_game_assignment(
+    doc: &web_sys::Document,
+    dm_keeper: &str,
+    player_map: &std::collections::HashMap<String, String>,
+    actor_ids: &[String],
+) {
+    let Some(el) = doc.get_element_by_id("new-game-assignment") else {
+        return;
+    };
+
+    let mut html = String::from("<strong>배정 확인</strong><ul>");
+    html.push_str(&format!("<li>DM: {}</li>", html_escape(dm_keeper)));
+    for actor_id in actor_ids {
+        let keeper = player_map
+            .get(actor_id)
+            .map(String::as_str)
+            .unwrap_or("미정");
+        html.push_str(&format!(
+            "<li>{} → {}</li>",
+            html_escape(actor_id),
+            html_escape(keeper)
+        ));
+    }
+    html.push_str("</ul>");
+    el.set_inner_html(&html);
+}
+
+#[cfg(target_arch = "wasm32")]
 fn normalize_preset_catalog(raw: &Value) -> Value {
     let mut value = raw.clone();
     for _ in 0..6 {

--- a/viewer/src/sse/client.rs
+++ b/viewer/src/sse/client.rs
@@ -20,7 +20,7 @@ use crate::config;
 use crate::game::state::ConnectionStatus;
 
 use super::reconnect::{
-    ConnectionStatusBridge, SseReconnectManager,
+    self, ConnectionStatusBridge, ConnectionStatusProxy, ReconnectState, SseReconnectManager,
 };
 
 /// Wrapper around `EventSource` that is `Send + Sync`.

--- a/viewer/src/sse/masc_client.rs
+++ b/viewer/src/sse/masc_client.rs
@@ -9,10 +9,11 @@ use web_sys::{EventSource, MessageEvent};
 
 #[cfg(target_arch = "wasm32")]
 use crate::config;
+use crate::game::state::ConnectionStatus;
 use crate::mode::ViewerMode;
 
 use super::reconnect::{
-    ConnectionStatusBridge, SseReconnectManager,
+    self, ConnectionStatusBridge, ConnectionStatusProxy, ReconnectState, SseReconnectManager,
 };
 
 /// Wrapper around `EventSource` that is `Send + Sync`.


### PR DESCRIPTION
## What
- restore missing symbols/imports broken by cleanup refactor
- re-add  helper used by new game flow
- fix underscore-renamed bindings that were still referenced at runtime

## Fixed errors
- unresolved  /  /  module in  and 
- missing  in 
- invalid references from underscore-renamed params in config/dom modules
- mutable cache binding in overlay DOM sync

## Validation
- 2026-02-17T17:51:39.220001Z  INFO 🚀 Starting trunk 0.21.14
2026-02-17T17:51:39.220344Z  INFO 📦 starting build
2026-02-17T17:51:41.270132Z  INFO applying new distribution
2026-02-17T17:51:41.273710Z  INFO ✅ success
- 
running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 42 tests
test dom::narrative::tests::normalize_phase_suffix_fallbacks_to_unknown ... ok
test dom::narrative::tests::normalize_phase_suffix_handles_untrusted_input ... ok
test game::http::tests::ended_room_requires_new_game ... ok
test game::http::tests::ended_room_is_not_active ... ok
test game::http::tests::idle_room_is_not_active ... ok
test game::http::tests::normalize_legacy_shape ... ok
test game::http::tests::normalize_masc_shape_reads_party_as_characters ... ok
test game::http::tests::normalize_masc_shape_maps_actor_control_and_dm_keeper ... ok
test game::http::tests::normalize_masc_shape_uses_defaults_without_fallback_party ... ok
test game::http::tests::normalize_room_status_is_case_insensitive ... ok
test game::http::tests::paused_room_is_resumable ... ok
test game::http::tests::unavailable_game_state_has_correct_shape ... ok
test mode::tests::assign_keepers_fails_on_duplicate_or_dm_collision ... ok
test mode::tests::assign_keepers_fails_when_players_are_missing ... ok
test mode::tests::assign_keepers_success_with_unique_names ... ok
test mode::tests::panel_id_returns_correct_ids_for_masc_modes ... ok
test mode::tests::panel_id_returns_none_for_non_panel_modes ... ok
test sse::client::tests::decode_stream_maps_action_resolved_to_narrative ... ok
test sse::client::tests::decode_stream_maps_choice_and_combat_events ... ok
test sse::client::tests::decode_stream_maps_lifecycle_and_endgame_events ... ok
test sse::client::tests::decode_stream_maps_narration_reply_field ... ok
test sse::client::tests::decode_stream_maps_timeout_and_unavailable_to_narrative ... ok
test sse::reconnect::tests::connection_status_proxy_round_trip ... ok
test sse::client::tests::decode_stream_maps_turn_and_dice_events ... ok
test sse::reconnect::tests::reconnect_state_caps_at_max_delay ... ok
test sse::reconnect::tests::reconnect_state_default_values ... ok
test sse::reconnect::tests::reconnect_state_exhaustion ... ok
test sse::reconnect::tests::reconnect_state_exponential_backoff ... ok
test sse::reconnect::tests::reconnect_state_reset ... ok
test sse::reconnect::tests::record_event_id_updates ... ok
test sse::reconnect::tests::url_with_last_event_id_empty_string ... ok
test sse::reconnect::tests::url_with_last_event_id_existing_params ... ok
test sse::reconnect::tests::url_with_last_event_id_none ... ok
test sse::reconnect::tests::url_with_last_event_id_some ... ok
test sse::social_board::tests::deserialize_board_response ... ok
test sse::social_board::tests::deserialize_comment_with_parent ... ok
test sse::social_board::tests::deserialize_empty_board ... ok
test sse::social_board::tests::deserialize_post_detail_no_comments ... ok
test sse::social_board::tests::deserialize_post_detail_with_comments ... ok
test sse::social_board::tests::deserialize_with_hearth ... ok
test sse::social_board::tests::html_escape_covers_all_entities ... ok
test sse::social_board::tests::html_escape_in_comment_content ... ok

test result: ok. 42 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
