### PR TITLE
fix(board): search scans all posts instead of limited subset

### DIFF
--- a/lib/board.ml
+++ b/lib/board.ml
@@ -510,6 +510,25 @@ let list_posts store ?(visibility_filter=None) ?hearth ?(limit=50) () : post lis
     take (min limit 100) filtered  (* Hard cap at 100 *)
   )
 
+(** Full-scan search over all posts (no limit on scan, only on results).
+    Used by Board_dispatch.search to avoid the list_posts hard cap. *)
+let search_posts store ~predicate ~limit : post list =
+  maybe_sweep store;
+  with_lock store (fun () ->
+    let matches = Hashtbl.fold (fun _ (p : post) acc ->
+      if predicate p then p :: acc else acc
+    ) store.posts [] in
+    (* Sort by recency for search results *)
+    let sorted = List.sort (fun (a : post) (b : post) ->
+      compare b.created_at a.created_at
+    ) matches in
+    let rec take n lst = match n, lst with
+      | 0, _ | _, [] -> []
+      | n, x :: xs -> x :: take (n-1) xs
+    in
+    take limit sorted
+  )
+
 (** {1 Comment Operations} *)
 
 let add_comment store ~post_id ~author ~content ?parent_id ?(ttl_hours=Limits.default_ttl_hours) ()

--- a/lib/board_dispatch.ml
+++ b/lib/board_dispatch.ml
@@ -179,20 +179,20 @@ let set_thread_id ~post_id ~thread_id =
 let search ~query ~limit =
   match backend () with
   | Jsonl store ->
-      (* JSONL: reuse existing in-memory search logic *)
-      let all_posts = Board.list_posts store ~limit:(max limit 100) () in
+      (* Full-scan search: match query against content, author, hearth.
+         Uses Board.search_posts to scan all posts (not limited by list_posts cap). *)
       let query_lower = String.lowercase_ascii query in
       let pattern = Str.regexp_string query_lower in
       let matches_str s =
         try ignore (Str.search_forward pattern (String.lowercase_ascii s) 0); true
         with Not_found -> false
       in
-      List.filter (fun (p : Board.post) ->
+      let predicate (p : Board.post) =
         matches_str p.content
         || matches_str (Board.Agent_id.to_string p.author)
         || (match p.hearth with Some h -> matches_str h | None -> false)
-      ) all_posts
-      |> List.filteri (fun i _ -> i < limit)
+      in
+      Board.search_posts store ~predicate ~limit
   | Postgres t ->
       Board_pg.search t ~query ~limit
 


### PR DESCRIPTION
## Summary

- `Board_dispatch.search` was calling `Board.list_posts` with a hard cap of 100 results, then filtering for matches within that subset
- When the store contained more than 100 posts (752 in production via `ME_ROOT/.masc/board_posts.jsonl`), newly created posts with 0 votes could fall outside the top-100-by-score window, causing search to miss them
- Added `Board.search_posts` which does a full hashtable scan with predicate filtering, then limits results after matching
- The `test_board_dispatch` "misc search" test now passes reliably regardless of ambient `.masc/` state

## Root cause

`Board.list_posts` sorts by `(votes_up - votes_down, created_at DESC)` and caps at `min limit 100`. The search function passed `~limit:(max limit 100)` = 100. With 752 loaded posts (many with votes), a freshly created 0-vote test post was excluded from the top 100.

## Changes

| File | Change |
|------|--------|
| `lib/board.ml` | Add `search_posts` — full-scan with predicate, sorted by recency |
| `lib/board_dispatch.ml` | Use `Board.search_posts` instead of `Board.list_posts` + filter |

## Test results

```
15 tests run, 0 failures (was 1 failure before fix)
Full test suite: 0 failures
```