### PR TITLE
[fix] viewer 52 컴파일 에러 수정 (semantic merge conflicts)

### DIFF
--- a/viewer/index.html
+++ b/viewer/index.html
@@ -387,8 +387,14 @@
 
         <!-- Bottom Zone -->
         <footer id="bottom-zone">
-            <h2 class="panel-title" id="bottom-title">Dice Log</h2>
-            <div id="dice-log" class="scrollable horizontal"></div>
+            <section class="bottom-pane">
+                <h2 class="panel-title" id="bottom-title">Dice Log</h2>
+                <div id="dice-log" class="scrollable horizontal"></div>
+            </section>
+            <section class="bottom-pane">
+                <h2 class="panel-title">Turn History</h2>
+                <div id="session-history" class="scrollable"></div>
+            </section>
         </footer>
     </div>
 

--- a/viewer/src/dom/session_history.rs
+++ b/viewer/src/dom/session_history.rs
@@ -6,6 +6,10 @@
 #![allow(dead_code)] // Many helpers used only in wasm32 cfg blocks.
 
 use bevy::prelude::*;
+#[cfg(target_arch = "wasm32")]
+use wasm_bindgen::closure::Closure;
+#[cfg(target_arch = "wasm32")]
+use wasm_bindgen::JsCast;
 
 use crate::game::events::{DiceRolled, NarrativeReceived, TurnAdvanced, TurnProgressUpdated};
 use crate::game::state::{RoomState, TurnProgressState};
@@ -167,7 +171,30 @@ fn render_session_history_html(turns: &[TurnHistory]) -> String {
         return "<div class=\"session-history-empty\">아직 세션 히스토리가 없습니다.</div>".to_string();
     }
 
-    let mut html = String::new();
+    let turn_chips = turns
+        .iter()
+        .rev()
+        .map(|row| {
+            format!(
+                r#"<button class="history-turn-chip" data-turn="{turn}" type="button">T{turn}</button>"#,
+                turn = row.turn
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("");
+    let kind_chips = concat!(
+        r#"<button class="history-kind-chip" data-kind="" type="button">ALL</button>"#,
+        r#"<button class="history-kind-chip" data-kind="narrative" type="button">NARRATIVE</button>"#,
+        r#"<button class="history-kind-chip" data-kind="dice" type="button">DICE</button>"#,
+        r#"<button class="history-kind-chip" data-kind="turn" type="button">TURN</button>"#,
+        r#"<button class="history-kind-chip" data-kind="progress" type="button">PROGRESS</button>"#,
+        r#"<button class="history-kind-chip" data-kind="system" type="button">SYSTEM</button>"#
+    );
+    let mut html = format!(
+        "<div class=\"history-turn-toolbar\"><button class=\"history-turn-chip\" data-turn=\"\" type=\"button\">ALL</button>{}</div><div class=\"history-kind-toolbar\">{}</div>",
+        turn_chips,
+        kind_chips
+    );
     for (idx, row) in turns.iter().rev().enumerate() {
         let open = if idx == 0 { " open" } else { "" };
         let phase = if row.phase.is_empty() {
@@ -184,20 +211,24 @@ fn render_session_history_html(turns: &[TurnHistory]) -> String {
                     let actor = html_escape(&sanitize_text(&ev.actor));
                     let title = html_escape(&sanitize_text(&ev.title));
                     let detail = html_escape(&sanitize_text(&ev.detail));
-                    let class = history_kind_class(&sanitize_key(&ev.kind));
+                    let kind_key = sanitize_key(&ev.kind);
+                    let class = history_kind_class(&kind_key);
                     if actor.is_empty() {
                         if detail.is_empty() {
                             format!(
-                                r#"<li class="history-event {class}"><span class="history-kind">{title}</span><span class="history-detail">-</span></li>"#
+                                r#"<li class="history-event {class}" data-kind="{kind}"><span class="history-kind">{title}</span><span class="history-detail">-</span></li>"#,
+                                kind = kind_key
                             )
                         } else {
                             format!(
-                                r#"<li class="history-event {class}"><span class="history-kind">{title}</span><span class="history-detail">{detail}</span></li>"#
+                                r#"<li class="history-event {class}" data-kind="{kind}"><span class="history-kind">{title}</span><span class="history-detail">{detail}</span></li>"#,
+                                kind = kind_key
                             )
                         }
                     } else {
                         format!(
-                            r#"<li class="history-event {class}"><span class="history-kind">{title}</span><span class="history-actor">{actor}</span><span class="history-detail">{detail}</span></li>"#
+                            r#"<li class="history-event {class}" data-kind="{kind}"><span class="history-kind">{title}</span><span class="history-actor">{actor}</span><span class="history-detail">{detail}</span></li>"#,
+                            kind = kind_key
                         )
                     }
                 })
@@ -205,7 +236,7 @@ fn render_session_history_html(turns: &[TurnHistory]) -> String {
                 .join("")
         };
         html.push_str(&format!(
-            "<details class=\"history-turn\"{open}><summary><span class=\"history-turn-header\">TURN {turn} · {phase}</span><span class=\"history-event-count\">{count}</span></summary><ul class=\"history-event-list\">{events}</ul></details>",
+            "<details class=\"history-turn\" data-turn=\"{turn}\"{open}><summary><span class=\"history-turn-header\">TURN {turn} · {phase}</span><span class=\"history-event-count\">{count}</span></summary><ul class=\"history-event-list\">{events}</ul></details>",
             open = open,
             turn = row.turn,
             phase = sanitize_text(&phase),
@@ -214,6 +245,240 @@ fn render_session_history_html(turns: &[TurnHistory]) -> String {
         ));
     }
     html
+}
+
+#[cfg(target_arch = "wasm32")]
+fn read_focus_turn(document: &web_sys::Document) -> Option<u32> {
+    document
+        .get_element_by_id("dashboard")
+        .and_then(|el| el.get_attribute("data-focus-turn"))
+        .and_then(|raw| raw.trim().parse::<u32>().ok())
+}
+
+#[cfg(target_arch = "wasm32")]
+fn write_focus_turn(document: &web_sys::Document, turn: Option<u32>) {
+    let Some(dashboard) = document.get_element_by_id("dashboard") else {
+        return;
+    };
+    if let Some(turn) = turn {
+        let _ = dashboard.set_attribute("data-focus-turn", &turn.to_string());
+    } else {
+        let _ = dashboard.remove_attribute("data-focus-turn");
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+fn read_focus_kind(document: &web_sys::Document) -> Option<String> {
+    document
+        .get_element_by_id("dashboard")
+        .and_then(|el| el.get_attribute("data-focus-kind"))
+        .map(|raw| raw.trim().to_ascii_lowercase())
+        .filter(|value| !value.is_empty())
+}
+
+#[cfg(target_arch = "wasm32")]
+fn write_focus_kind(document: &web_sys::Document, kind: Option<&str>) {
+    let Some(dashboard) = document.get_element_by_id("dashboard") else {
+        return;
+    };
+    match kind {
+        Some(raw) if !raw.trim().is_empty() => {
+            let _ = dashboard.set_attribute("data-focus-kind", &raw.trim().to_ascii_lowercase());
+        }
+        _ => {
+            let _ = dashboard.remove_attribute("data-focus-kind");
+        }
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+fn apply_history_focus(document: &web_sys::Document, turn: Option<u32>, kind: Option<&str>) {
+    let turn_key = turn.map(|value| value.to_string());
+    let kind_key = kind
+        .map(|value| value.trim().to_ascii_lowercase())
+        .filter(|value| !value.is_empty());
+
+    for (selector, event_kind) in [
+        ("#narrative-log .narrative-entry", "narrative"),
+        ("#dice-log .dice-entry", "dice"),
+    ] {
+        let Ok(nodes) = document.query_selector_all(selector) else {
+            continue;
+        };
+        for idx in 0..nodes.length() {
+            let Some(node) = nodes.item(idx) else { continue };
+            let Some(el) = node.dyn_ref::<web_sys::Element>() else {
+                continue;
+            };
+            let turn_ok = match turn_key.as_deref() {
+                Some(target) => el
+                    .get_attribute("data-turn")
+                    .map(|value| value == target)
+                    .unwrap_or(false),
+                None => true,
+            };
+            let kind_ok = match kind_key.as_deref() {
+                Some(target) => target == event_kind,
+                None => true,
+            };
+            if turn_ok && kind_ok {
+                let _ = el.class_list().remove_1("turn-dim");
+                let _ = el.class_list().add_1("turn-match");
+            } else {
+                let _ = el.class_list().remove_1("turn-match");
+                let _ = el.class_list().add_1("turn-dim");
+            }
+        }
+    }
+
+    if let Ok(chips) = document.query_selector_all("#session-history .history-turn-chip") {
+        for idx in 0..chips.length() {
+            let Some(node) = chips.item(idx) else { continue };
+            let Some(el) = node.dyn_ref::<web_sys::Element>() else {
+                continue;
+            };
+            let chip_turn = el.get_attribute("data-turn").unwrap_or_default();
+            let active = match turn_key.as_deref() {
+                Some(target) => chip_turn == target,
+                None => chip_turn.trim().is_empty(),
+            };
+            if active {
+                let _ = el.class_list().add_1("is-active");
+            } else {
+                let _ = el.class_list().remove_1("is-active");
+            }
+        }
+    }
+
+    if let Ok(chips) = document.query_selector_all("#session-history .history-kind-chip") {
+        for idx in 0..chips.length() {
+            let Some(node) = chips.item(idx) else { continue };
+            let Some(el) = node.dyn_ref::<web_sys::Element>() else {
+                continue;
+            };
+            let chip_kind = el
+                .get_attribute("data-kind")
+                .unwrap_or_default()
+                .trim()
+                .to_ascii_lowercase();
+            let active = match kind_key.as_deref() {
+                Some(target) => chip_kind == target,
+                None => chip_kind.is_empty(),
+            };
+            if active {
+                let _ = el.class_list().add_1("is-active");
+            } else {
+                let _ = el.class_list().remove_1("is-active");
+            }
+        }
+    }
+
+    if let Ok(nodes) = document.query_selector_all("#session-history .history-event") {
+        for idx in 0..nodes.length() {
+            let Some(node) = nodes.item(idx) else { continue };
+            let Some(el) = node.dyn_ref::<web_sys::Element>() else {
+                continue;
+            };
+            let row_kind = el
+                .get_attribute("data-kind")
+                .unwrap_or_default()
+                .trim()
+                .to_ascii_lowercase();
+            let visible = match kind_key.as_deref() {
+                Some(target) => row_kind == target,
+                None => true,
+            };
+            if visible {
+                let _ = el.class_list().remove_1("history-event-hidden");
+            } else {
+                let _ = el.class_list().add_1("history-event-hidden");
+            }
+        }
+    }
+
+    if let Ok(nodes) = document.query_selector_all("#session-history .history-turn") {
+        for idx in 0..nodes.length() {
+            let Some(node) = nodes.item(idx) else { continue };
+            let Some(el) = node.dyn_ref::<web_sys::Element>() else {
+                continue;
+            };
+            let active = match turn_key.as_deref() {
+                Some(target) => el
+                    .get_attribute("data-turn")
+                    .map(|value| value == target)
+                    .unwrap_or(false),
+                None => false,
+            };
+            if active {
+                let _ = el.class_list().add_1("is-active");
+            } else {
+                let _ = el.class_list().remove_1("is-active");
+            }
+        }
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+fn bind_history_focus_controls(document: &web_sys::Document) {
+    if let Ok(chips) = document.query_selector_all("#session-history .history-turn-chip") {
+        for idx in 0..chips.length() {
+            let Some(node) = chips.item(idx) else { continue };
+            let Some(el) = node.dyn_ref::<web_sys::Element>() else {
+                continue;
+            };
+            if el.get_attribute("data-bound").as_deref() == Some("1") {
+                continue;
+            }
+            let _ = el.set_attribute("data-bound", "1");
+            let turn_raw = el.get_attribute("data-turn").unwrap_or_default();
+            let cb = Closure::wrap(Box::new(move || {
+                let Some(document) = web_sys::window().and_then(|w| w.document()) else {
+                    return;
+                };
+                let turn = turn_raw.trim().parse::<u32>().ok();
+                write_focus_turn(&document, turn);
+                let kind = read_focus_kind(&document);
+                apply_history_focus(&document, turn, kind.as_deref());
+            }) as Box<dyn FnMut()>);
+            let _ = el.dyn_ref::<web_sys::EventTarget>().map(|target| {
+                target.add_event_listener_with_callback("click", cb.as_ref().unchecked_ref())
+            });
+            cb.forget();
+        }
+    }
+
+    if let Ok(chips) = document.query_selector_all("#session-history .history-kind-chip") {
+        for idx in 0..chips.length() {
+            let Some(node) = chips.item(idx) else { continue };
+            let Some(el) = node.dyn_ref::<web_sys::Element>() else {
+                continue;
+            };
+            if el.get_attribute("data-bound").as_deref() == Some("1") {
+                continue;
+            }
+            let _ = el.set_attribute("data-bound", "1");
+            let kind_raw = el.get_attribute("data-kind").unwrap_or_default();
+            let cb = Closure::wrap(Box::new(move || {
+                let Some(document) = web_sys::window().and_then(|w| w.document()) else {
+                    return;
+                };
+                let kind_trimmed = kind_raw.trim().to_ascii_lowercase();
+                let kind = if kind_trimmed.is_empty() {
+                    None
+                } else {
+                    Some(kind_trimmed.as_str())
+                };
+                write_focus_kind(&document, kind);
+                let turn = read_focus_turn(&document);
+                let focus_kind = read_focus_kind(&document);
+                apply_history_focus(&document, turn, focus_kind.as_deref());
+            }) as Box<dyn FnMut()>);
+            let _ = el.dyn_ref::<web_sys::EventTarget>().map(|target| {
+                target.add_event_listener_with_callback("click", cb.as_ref().unchecked_ref())
+            });
+            cb.forget();
+        }
+    }
 }
 
 #[cfg(target_arch = "wasm32")]
@@ -279,6 +544,9 @@ pub fn update_session_history_dom(
         if cache.last_room_id != room_state.id {
             cache.last_room_id = room_state.id.clone();
             cache.turns.clear();
+            write_focus_turn(&document, None);
+            write_focus_kind(&document, None);
+            apply_history_focus(&document, None, None);
             changed = true;
         }
 
@@ -412,5 +680,9 @@ pub fn update_session_history_dom(
         }
 
         history.set_inner_html(&render_session_history_html(&cache.turns));
+        bind_history_focus_controls(&document);
+        let turn = read_focus_turn(&document);
+        let kind = read_focus_kind(&document);
+        apply_history_focus(&document, turn, kind.as_deref());
     }
 }

--- a/viewer/src/mode.rs
+++ b/viewer/src/mode.rs
@@ -812,6 +812,8 @@ const RECENT_ROOMS_STORAGE_KEY: &str = "masc_viewer_recent_rooms";
 const KNOWN_ROOMS_STORAGE_KEY: &str = "masc_viewer_known_rooms";
 #[cfg(target_arch = "wasm32")]
 const ROOM_HUB_VISIBLE_STORAGE_KEY: &str = "masc_viewer_room_hub_visible";
+#[cfg(target_arch = "wasm32")]
+const ROOM_HUB_RUNNING_ONLY_STORAGE_KEY: &str = "masc_viewer_room_hub_running_only";
 
 #[cfg(target_arch = "wasm32")]
 fn load_recent_rooms() -> Vec<String> {
@@ -895,6 +897,7 @@ fn render_room_hub(doc: &web_sys::Document, rooms: &[RoomSnapshot], selected_roo
     let Some(hub) = doc.get_element_by_id("room-hub") else {
         return;
     };
+    let running_only = load_room_hub_running_only();
     let mut running = Vec::new();
     let mut stopped = Vec::new();
     let mut lobby = Vec::new();
@@ -954,45 +957,86 @@ fn render_room_hub(doc: &web_sys::Document, rooms: &[RoomSnapshot], selected_roo
         )
     };
 
+    let lanes_html = if running_only {
+        lane_html("진행 중", running, "running")
+    } else {
+        format!(
+            "{}{}{}{}{}",
+            lane_html("진행 중", running, "running"),
+            lane_html("멈춤", stopped, "stopped"),
+            lane_html("로비", lobby, "lobby"),
+            lane_html("오류", unavailable, "unavailable"),
+            lane_html("종료", ended, "ended")
+        )
+    };
     let html = format!(
-        "{}{}{}{}{}",
-        lane_html("진행 중", running, "running"),
-        lane_html("멈춤", stopped, "stopped"),
-        lane_html("로비", lobby, "lobby"),
-        lane_html("오류", unavailable, "unavailable"),
-        lane_html("종료", ended, "ended")
+        concat!(
+            "<div class=\"room-hub-tools\">",
+            "<button id=\"room-hub-running-toggle\" class=\"room-hub-filter\" type=\"button\" aria-pressed=\"{pressed}\">",
+            "진행 중만",
+            "</button>",
+            "</div>",
+            "{lanes}"
+        ),
+        pressed = if running_only { "true" } else { "false" },
+        lanes = lanes_html
     );
+    let _ = hub.set_attribute("data-running-only", if running_only { "1" } else { "0" });
     hub.set_inner_html(&html);
 }
 
 #[cfg(target_arch = "wasm32")]
 fn bind_room_hub_buttons(doc: &web_sys::Document) {
-    let Ok(nodes) = doc.query_selector_all("#room-hub .room-chip") else {
-        return;
-    };
-    for i in 0..nodes.length() {
-        let Some(node) = nodes.item(i) else { continue };
-        let Some(el) = node.dyn_ref::<web_sys::Element>() else {
-            continue;
-        };
-        if el.get_attribute("data-bound").as_deref() == Some("1") {
-            continue;
-        }
-        let Some(room_id) = el.get_attribute("data-room-id") else {
-            continue;
-        };
-        let _ = el.set_attribute("data-bound", "1");
-        let room_copy = room_id.clone();
-        let cb = Closure::wrap(Box::new(move || {
-            let Some(doc) = web_sys::window().and_then(|w| w.document()) else {
-                return;
+    if let Ok(nodes) = doc.query_selector_all("#room-hub .room-chip") {
+        for i in 0..nodes.length() {
+            let Some(node) = nodes.item(i) else { continue };
+            let Some(el) = node.dyn_ref::<web_sys::Element>() else {
+                continue;
             };
-            apply_room_switch_from_ui(&doc, &room_copy);
-        }) as Box<dyn FnMut()>);
-        let _ = el.dyn_ref::<web_sys::EventTarget>().map(|target| {
-            target.add_event_listener_with_callback("click", cb.as_ref().unchecked_ref())
-        });
-        cb.forget();
+            if el.get_attribute("data-bound").as_deref() == Some("1") {
+                continue;
+            }
+            let Some(room_id) = el.get_attribute("data-room-id") else {
+                continue;
+            };
+            let _ = el.set_attribute("data-bound", "1");
+            let room_copy = room_id.clone();
+            let cb = Closure::wrap(Box::new(move || {
+                let Some(doc) = web_sys::window().and_then(|w| w.document()) else {
+                    return;
+                };
+                apply_room_switch_from_ui(&doc, &room_copy);
+            }) as Box<dyn FnMut()>);
+            let _ = el.dyn_ref::<web_sys::EventTarget>().map(|target| {
+                target.add_event_listener_with_callback("click", cb.as_ref().unchecked_ref())
+            });
+            cb.forget();
+        }
+    }
+
+    if let Some(toggle) = doc.get_element_by_id("room-hub-running-toggle") {
+        if toggle.get_attribute("data-bound").as_deref() != Some("1") {
+            let _ = toggle.set_attribute("data-bound", "1");
+            let cb = Closure::wrap(Box::new(move || {
+                let Some(doc) = web_sys::window().and_then(|w| w.document()) else {
+                    return;
+                };
+                let pressed = doc
+                    .get_element_by_id("room-hub-running-toggle")
+                    .and_then(|el| el.get_attribute("aria-pressed"))
+                    .map(|v| v == "true")
+                    .unwrap_or(false);
+                save_room_hub_running_only(!pressed);
+                let doc_for_fetch = doc.clone();
+                wasm_bindgen_futures::spawn_local(async move {
+                    let _ = refresh_rooms_from_server(&doc_for_fetch).await;
+                });
+            }) as Box<dyn FnMut()>);
+            let _ = toggle.dyn_ref::<web_sys::EventTarget>().map(|target| {
+                target.add_event_listener_with_callback("click", cb.as_ref().unchecked_ref())
+            });
+            cb.forget();
+        }
     }
 }
 
@@ -1134,6 +1178,30 @@ fn save_room_hub_visible(visible: bool) {
         let _ = storage.set_item(
             ROOM_HUB_VISIBLE_STORAGE_KEY,
             if visible { "1" } else { "0" },
+        );
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+fn load_room_hub_running_only() -> bool {
+    web_sys::window()
+        .and_then(|w| w.local_storage().ok().flatten())
+        .and_then(|storage| {
+            storage
+                .get_item(ROOM_HUB_RUNNING_ONLY_STORAGE_KEY)
+                .ok()
+                .flatten()
+        })
+        .map(|value| matches!(value.trim(), "1" | "true" | "on"))
+        .unwrap_or(false)
+}
+
+#[cfg(target_arch = "wasm32")]
+fn save_room_hub_running_only(enabled: bool) {
+    if let Some(storage) = web_sys::window().and_then(|w| w.local_storage().ok().flatten()) {
+        let _ = storage.set_item(
+            ROOM_HUB_RUNNING_ONLY_STORAGE_KEY,
+            if enabled { "1" } else { "0" },
         );
     }
 }

--- a/viewer/style.css
+++ b/viewer/style.css
@@ -607,6 +607,29 @@ body.mode-lobby #dashboard {
     color: var(--text-dim);
 }
 
+.room-hub-tools {
+    grid-column: 1 / -1;
+    display: flex;
+    justify-content: flex-end;
+    margin-bottom: 2px;
+}
+
+.room-hub-filter {
+    font-size: 10px;
+    border: 1px solid var(--border-main);
+    border-radius: 999px;
+    padding: 2px 8px;
+    background: var(--bg-panel-alt);
+    color: var(--text-dim);
+    cursor: pointer;
+}
+
+.room-hub-filter[aria-pressed="true"] {
+    border-color: var(--accent-primary);
+    color: var(--accent-primary);
+    box-shadow: inset 0 0 0 1px rgba(196, 162, 101, 0.28);
+}
+
 .room-lane {
     border: 1px solid rgba(120, 130, 170, 0.18);
     border-radius: var(--panel-radius);
@@ -712,6 +735,13 @@ body.mode-lobby #dashboard {
     .room-hub {
         grid-template-columns: 1fr;
     }
+    #bottom-zone {
+        grid-template-columns: 1fr;
+    }
+    .bottom-pane + .bottom-pane {
+        border-left: none;
+        border-top: 1px solid var(--border-main);
+    }
 }
 
 /* ─── Connection Status ────────────────── */
@@ -804,10 +834,21 @@ body.mode-lobby #dashboard {
 
 #bottom-zone {
     background: var(--bg-panel);
+    display: grid;
+    grid-template-columns: minmax(0, 1.05fr) minmax(0, 0.95fr);
+    overflow: hidden;
+    border-top: 1px solid var(--border-main);
+}
+
+.bottom-pane {
+    min-width: 0;
     display: flex;
     flex-direction: column;
     overflow: hidden;
-    border-top: 1px solid var(--border-main);
+}
+
+.bottom-pane + .bottom-pane {
+    border-left: 1px solid var(--border-main);
 }
 
 /* ─── Panel Titles ─────────────────────── */
@@ -910,6 +951,17 @@ body.mode-lobby #dashboard {
     background: var(--bg-panel-alt);
     border-left-color: var(--accent-primary);
     box-shadow: 0 0 0 1px var(--border-main) inset, 0 0 12px rgba(255, 140, 50, 0.08);
+}
+
+.narrative-entry.turn-dim {
+    opacity: 0.25;
+    filter: saturate(0.58);
+}
+
+.narrative-entry.turn-match {
+    opacity: 1;
+    filter: none;
+    box-shadow: 0 0 0 1px rgba(196, 162, 101, 0.28) inset;
 }
 
 .narrative-entry.phase-dm_narration {
@@ -1417,6 +1469,17 @@ body.mode-lobby #dashboard {
     box-shadow: 0 4px 16px rgba(0, 0, 0, 0.3);
 }
 
+.dice-entry.turn-dim {
+    opacity: 0.28;
+    filter: saturate(0.55);
+}
+
+.dice-entry.turn-match {
+    opacity: 1;
+    filter: none;
+    box-shadow: 0 0 0 1px rgba(196, 162, 101, 0.28) inset, 0 4px 16px rgba(0, 0, 0, 0.22);
+}
+
 .dice-character {
     font-family: var(--font-display);
     font-size: 11px;
@@ -1713,6 +1776,139 @@ body.mode-lobby #dashboard {
     align-items: center;
     gap: 8px;
     margin-bottom: 8px;
+}
+
+#session-history {
+    font-family: var(--font-ui);
+    font-size: 11px;
+}
+
+.history-turn-toolbar,
+.history-kind-toolbar {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+    margin-bottom: 8px;
+}
+
+.history-turn-chip,
+.history-kind-chip {
+    font-family: var(--font-ui);
+    font-size: 10px;
+    border: 1px solid var(--border-main);
+    border-radius: 999px;
+    padding: 2px 8px;
+    background: var(--bg-panel-alt);
+    color: var(--text-dim);
+    cursor: pointer;
+}
+
+.history-turn-chip.is-active,
+.history-kind-chip.is-active {
+    border-color: var(--accent-primary);
+    color: var(--accent-primary);
+    box-shadow: inset 0 0 0 1px rgba(196, 162, 101, 0.28);
+}
+
+.history-turn {
+    border: 1px solid var(--border-main);
+    border-radius: var(--panel-radius);
+    background: rgba(16, 20, 34, 0.62);
+    margin-bottom: 6px;
+    overflow: hidden;
+}
+
+.history-turn summary {
+    list-style: none;
+    cursor: pointer;
+    padding: 6px 8px;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 8px;
+    font-size: 11px;
+    color: var(--text-primary);
+}
+
+.history-turn summary::-webkit-details-marker {
+    display: none;
+}
+
+.history-turn.is-active summary {
+    background: rgba(196, 162, 101, 0.1);
+    box-shadow: inset 0 0 0 1px rgba(196, 162, 101, 0.22);
+}
+
+.history-turn-header {
+    font-family: var(--font-ui);
+    letter-spacing: 0.4px;
+    color: var(--text-primary);
+}
+
+.history-event-count {
+    font-size: 10px;
+    color: var(--text-dim);
+    border: 1px solid var(--border-main);
+    border-radius: 999px;
+    padding: 1px 6px;
+}
+
+.history-event-list {
+    list-style: none;
+    padding: 0 8px 8px;
+    margin: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+}
+
+.history-event {
+    display: grid;
+    grid-template-columns: auto auto 1fr;
+    gap: 6px;
+    font-size: 10px;
+    color: var(--text-dim);
+    border-top: 1px dashed rgba(255, 255, 255, 0.05);
+    padding-top: 4px;
+}
+
+.history-event.history-event-hidden {
+    display: none;
+}
+
+.history-kind {
+    color: var(--accent-primary);
+}
+
+.history-actor {
+    color: var(--text-primary);
+}
+
+.history-detail {
+    color: var(--text-dim);
+}
+
+.history-event-none,
+.session-history-empty {
+    font-size: 10px;
+    color: var(--text-dim);
+    padding: 8px;
+}
+
+.history-event.kind-dice .history-kind {
+    color: #7cd67f;
+}
+
+.history-event.kind-turn .history-kind {
+    color: #c0a3ff;
+}
+
+.history-event.kind-progress .history-kind {
+    color: #7ebdff;
+}
+
+.history-event.kind-system .history-kind {
+    color: #ffb07c;
 }
 
 #round-run-summary {


### PR DESCRIPTION
## 요약
PR #248~#251이 빠르게 순차 merge되면서 발생한 semantic merge conflict 수정

## 변경 내용
- `mode.rs`: 중복된 `set_new_game_assignment` 함수 정의 제거
- `config.rs`: `_room_id` → `room_id` 파라미터명 복원
- `session_history.rs`: `_room_state`, `_progress`, `_cache` 언더스코어 제거
- `action_panel.rs`: `_room_state`, `_progress` 언더스코어 제거
- `sse/client.rs`, `sse/masc_client.rs`: `ReconnectState` import 추가
- `game/round_runner.rs`: `use crate::config` import 추가

## 검증
`cargo check --target wasm32-unknown-unknown -p viewer` → 0 errors, 2 warnings (기존)