### PR TITLE
fix(harness): isolate game-view precondition session id

### DIFF
--- a/scripts/harness/contract/game_view_precondition.sh
+++ b/scripts/harness/contract/game_view_precondition.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 MCP_URL="${MCP_URL:-http://127.0.0.1:8935/mcp}"
-SESSION_ID="${SESSION_ID:-harness-gv-001}"
+SESSION_ID="${SESSION_ID:-harness-gv-$(date +%s)-$$}"
 
 call_tool() {
   local id="$1"


### PR DESCRIPTION
## Summary
- make GAME-VIEW precondition harness use a unique default SESSION_ID per run
- prevent stale finalized decisions from previous runs from bypassing precondition checks

## Verification
- ./scripts/harness_game_view_precondition.sh (PASS)