### PR TITLE
fix(viewer): resolve all 25 clippy warnings

### DIFF
--- a/viewer/src/dom/endgame.rs
+++ b/viewer/src/dom/endgame.rs
@@ -101,10 +101,8 @@ fn show_endgame_overlay(message: &str, is_victory: bool) {
         overlay.set_inner_html(&html);
 
         // Set message text safely (auto-escapes HTML entities).
-        if let Ok(msg_el) = overlay.query_selector(".endgame-message") {
-            if let Some(el) = msg_el {
-                el.set_text_content(Some(message));
-            }
+        if let Ok(Some(el)) = overlay.query_selector(".endgame-message") {
+            el.set_text_content(Some(message));
         }
 
         body.append_child(&overlay).ok();

--- a/viewer/src/dom/narrative.rs
+++ b/viewer/src/dom/narrative.rs
@@ -11,8 +11,6 @@ fn normalize_phase_suffix(phase: &str) -> String {
     for ch in phase.chars() {
         if ch.is_ascii_alphanumeric() {
             out.push(ch.to_ascii_lowercase());
-        } else if ch == '-' || ch == '_' || ch.is_whitespace() {
-            out.push('-');
         } else {
             out.push('-');
         }

--- a/viewer/src/dom/session_events.rs
+++ b/viewer/src/dom/session_events.rs
@@ -7,6 +7,7 @@ use crate::game::events::{
 #[cfg(target_arch = "wasm32")]
 use crate::dom::escape::html_escape;
 
+#[allow(clippy::too_many_arguments)]
 pub fn update_session_events_dom(
     mut party: MessageReader<PartySelected>,
     mut room_created: MessageReader<RoomCreated>,

--- a/viewer/src/dom/session_history.rs
+++ b/viewer/src/dom/session_history.rs
@@ -652,7 +652,7 @@ pub fn update_session_history_dom(
             if !event.phase.is_empty() {
                 current_phase = event.phase.clone();
             }
-            let (kind, actor, summary) = label_progress_event(&event);
+            let (kind, actor, summary) = label_progress_event(event);
             let appended = append_event(
                 &mut cache.turns,
                 current_turn,

--- a/viewer/src/dom/turn_controls.rs
+++ b/viewer/src/dom/turn_controls.rs
@@ -6,7 +6,7 @@
 //! Visible when a round run assignment is present:
 //! - claimed keeper/actor for local manual play, or
 //! - hidden round-run plan fields for AI auto-run flow.
-//! Follows the same OnEnter/OnExit lifecycle as `action_panel.rs`.
+//!   Follows the same OnEnter/OnExit lifecycle as `action_panel.rs`.
 
 use bevy::prelude::*;
 
@@ -251,7 +251,7 @@ fn set_advance_disabled(disabled: bool) {
         return;
     };
     if let Some(el) = doc.get_element_by_id("advance-turn-btn") {
-        if let Some(btn) = el.dyn_into::<HtmlButtonElement>().ok() {
+        if let Ok(btn) = el.dyn_into::<HtmlButtonElement>() {
             btn.set_disabled(disabled);
         }
     }
@@ -263,7 +263,7 @@ fn set_advance_busy(busy: bool) {
         return;
     };
     if let Some(el) = doc.get_element_by_id("advance-turn-btn") {
-        if let Some(btn) = el.dyn_into::<HtmlButtonElement>().ok() {
+        if let Ok(btn) = el.dyn_into::<HtmlButtonElement>() {
             btn.set_disabled(busy);
             if busy {
                 let _ = btn.set_attribute("data-busy", "1");

--- a/viewer/src/dom/turn_runtime.rs
+++ b/viewer/src/dom/turn_runtime.rs
@@ -233,6 +233,8 @@ pub fn update_turn_runtime_dom(
             }
         }
 
+        let lifecycle_class = format!("{} {}", room_class, lifecycle.css_class());
+        let lifecycle_label = html_escape(&format!("{} ({})", lifecycle.label(), lifecycle.label_ko()));
         let html = format!(
             r#"
 <div class="turn-runtime-grid">
@@ -248,8 +250,6 @@ pub fn update_turn_runtime_dom(
   <div class="turn-runtime-item"><span class="k">Party</span><span class="v {party_class}">{party}</span></div>
 </div>
 "#,
-            lifecycle_class = format!("{} {}", room_class, lifecycle.css_class()),
-            lifecycle_label = html_escape(&format!("{} ({})", lifecycle.label(), lifecycle.label_ko())),
             lifecycle_help = html_escape(lifecycle.help_text()),
             room_class = room_class,
             room = html_escape(room_status_label(lifecycle)),

--- a/viewer/src/game/http.rs
+++ b/viewer/src/game/http.rs
@@ -239,6 +239,7 @@ pub fn refresh_state_on_room_change(
 
 /// Update system: polls the buffer each frame. Once data arrives,
 /// populates RoomState, MapState, and spawns Actor entities.
+#[allow(clippy::too_many_arguments)]
 pub fn apply_initial_state(
     mut commands: Commands,
     mut buffer: ResMut<InitialStateBuffer>,
@@ -610,7 +611,7 @@ fn parse_actor_control_map(state: &Value) -> HashMap<String, String> {
 }
 
 fn apply_actor_control_to_characters(
-    characters: &mut Vec<CharacterData>,
+    characters: &mut [CharacterData],
     actor_control: &HashMap<String, String>,
 ) {
     for row in characters.iter_mut() {
@@ -832,14 +833,10 @@ fn parse_party_characters(
                         .filter_map(|skill| {
                             if let Ok(parsed) = serde_json::from_value::<SkillData>(skill.clone()) {
                                 Some(parsed)
-                            } else if let Some(name) = skill.as_str() {
-                                Some(SkillData {
+                            } else { skill.as_str().map(|name| SkillData {
                                     name: name.to_string(),
                                     level: 10,
-                                })
-                            } else {
-                                None
-                            }
+                                }) }
                         })
                         .collect::<Vec<_>>()
                 })
@@ -852,14 +849,10 @@ fn parse_party_characters(
                         .filter_map(|cond| {
                             if let Ok(parsed) = serde_json::from_value::<ConditionData>(cond.clone()) {
                                 Some(parsed)
-                            } else if let Some(name) = cond.as_str() {
-                                Some(ConditionData {
+                            } else { cond.as_str().map(|name| ConditionData {
                                     name: name.to_string(),
                                     remaining_turns: None,
-                                })
-                            } else {
-                                None
-                            }
+                                }) }
                         })
                         .collect::<Vec<_>>()
                 })
@@ -872,14 +865,10 @@ fn parse_party_characters(
                         .filter_map(|slot| {
                             if let Ok(parsed) = serde_json::from_value::<EquipmentData>(slot.clone()) {
                                 Some(parsed)
-                            } else if let Some(name) = slot.as_str() {
-                                Some(EquipmentData {
+                            } else { slot.as_str().map(|name| EquipmentData {
                                     slot: "item".to_string(),
                                     name: name.to_string(),
-                                })
-                            } else {
-                                None
-                            }
+                                }) }
                         })
                         .collect::<Vec<_>>()
                 })

--- a/viewer/src/render/characters.rs
+++ b/viewer/src/render/characters.rs
@@ -130,6 +130,7 @@ pub fn update_hp_bars(
 }
 
 /// Handles drag start - captures entity and offset.
+#[allow(clippy::type_complexity)]
 pub fn handle_drag_start(
     mut drag_state: ResMut<DragState>,
     windows: Query<&Window>,
@@ -243,6 +244,7 @@ pub fn handle_drag_end(
 }
 
 /// Applies grayscale effect to dead actors.
+#[allow(clippy::type_complexity)]
 pub fn apply_death_visuals(
     mut actors: Query<(&Actor, &mut Sprite), (With<MapToken>, Changed<Actor>)>,
 ) {

--- a/viewer/src/render/mod.rs
+++ b/viewer/src/render/mod.rs
@@ -85,6 +85,7 @@ impl Plugin for MapRenderPlugin {
 ///
 /// Each entity type is identified by its marker component — this is why every
 /// spawned entity in the TRPG scene must carry at least one marker.
+#[allow(clippy::type_complexity)]
 fn cleanup_trpg_scene(
     mut commands: Commands,
     trpg_entities: Query<

--- a/viewer/src/render/ui.rs
+++ b/viewer/src/render/ui.rs
@@ -140,6 +140,7 @@ pub fn setup_ui(mut commands: Commands) {
 }
 
 /// Handles button click interactions.
+#[allow(clippy::type_complexity)]
 pub fn handle_button_interactions(
     mut ui_state: ResMut<UiState>,
     interactions: Query<
@@ -472,6 +473,7 @@ fn spawn_dev_menu(commands: &mut Commands) {
 ///
 /// Logs the action for now. Future expansion: connect to actual systems
 /// (audio toggles, FPS counter, state dump, etc.).
+#[allow(clippy::type_complexity)]
 pub fn handle_menu_item_clicks(
     interactions: Query<
         (Entity, &Interaction, &MenuItem),
@@ -602,6 +604,7 @@ const HANDLE_HOVER_COLOR: Color = Color::srgb(0.4, 0.6, 1.0);
 const HANDLE_COLOR: Color = Color::srgb(0.3, 0.3, 0.4);
 
 /// Spawns resize handles on resizable widgets.
+#[allow(clippy::type_complexity)]
 pub fn spawn_resize_handles(
     mut commands: Commands,
     resizable_widgets: Query<(Entity, &Node, &Resizable), (Added<Resizable>, With<UiMarker>)>,
@@ -646,6 +649,7 @@ pub fn spawn_resize_handles(
 }
 
 /// Handles resize start - captures initial state.
+#[allow(clippy::type_complexity)]
 pub fn handle_resize_start(
     mut resize_state: ResMut<ResizeState>,
     windows: Query<&Window>,
@@ -769,13 +773,12 @@ pub fn handle_resize_end(
     mut resize_state: ResMut<ResizeState>,
     mouse_buttons: Res<ButtonInput<MouseButton>>,
 ) {
-    if mouse_buttons.just_released(MouseButton::Left) {
-        if resize_state.resizing_entity.is_some() {
+    if mouse_buttons.just_released(MouseButton::Left)
+        && resize_state.resizing_entity.is_some() {
             log::info!("Resize ended");
             resize_state.resizing_entity = None;
             resize_state.resize_edge = None;
         }
-    }
 }
 
 /// Updates handle cursor to indicate resize direction.

--- a/viewer/src/sse/client.rs
+++ b/viewer/src/sse/client.rs
@@ -175,7 +175,7 @@ fn remember_stream_fingerprint(state: &mut TrpgMapperState, fingerprint: String)
 }
 
 #[allow(dead_code)]
-fn snapshot_root<'a>(root: &'a Value) -> &'a Value {
+fn snapshot_root(root: &Value) -> &Value {
     root.get("state").filter(|s| !s.is_null()).unwrap_or(root)
 }
 
@@ -209,8 +209,7 @@ fn snapshot_phase(root: &Value, fallback: &str) -> String {
 fn snapshot_dice_entries(root: &Value) -> Vec<Value> {
     let source = root.get("dice_log").or_else(|| snapshot_root(root).get("dice_log"));
     source
-        .and_then(Value::as_array)
-        .map(|rows| rows.clone())
+        .and_then(Value::as_array).cloned()
         .unwrap_or_default()
 }
 

--- a/viewer/src/sse/masc_bridge.rs
+++ b/viewer/src/sse/masc_bridge.rs
@@ -12,21 +12,13 @@ pub struct MascLogEntry {
 
 /// Resource holding MASC event state for DOM rendering.
 #[derive(Resource)]
+#[derive(Default)]
 pub struct MascEventLog {
     pub entries: Vec<MascLogEntry>,
     pub agent_count: u32,
     pub task_count: u32,
 }
 
-impl Default for MascEventLog {
-    fn default() -> Self {
-        Self {
-            entries: Vec::new(),
-            agent_count: 0,
-            task_count: 0,
-        }
-    }
-}
 
 /// Lightweight JSON field extractor.
 /// Finds `"key": "value"` or `"key": number` in a JSON string.

--- a/viewer/src/sse/social_board.rs
+++ b/viewer/src/sse/social_board.rs
@@ -718,7 +718,7 @@ fn append_comment_to_dom(post_id: &str, author: &str, content: &str) {
 
     // Remove "No comments yet" or loading placeholder
     if let Ok(Some(empty)) = list.query_selector(".comment-empty, .comment-loading") {
-        let _ = empty.remove();
+        empty.remove();
     }
 
     let comment_html = format!(


### PR DESCRIPTION
## Summary
- Resolve all 25 `cargo clippy` warnings in the viewer crate (25 → 0)
- Three-phase approach:
  - **Auto-fix** (11): `cargo clippy --fix` for machine-fixable issues (redundant `.ok()`, deref, lifetime elision, derivable Default)
  - **Manual code fixes** (5): collapsible if-let, identical branches, doc indentation, `&mut Vec` → `&mut [_]`, format-in-format extraction
  - **Bevy-convention allows** (9): `#[allow(clippy::type_complexity)]` (7) and `#[allow(clippy::too_many_arguments)]` (2) on Bevy ECS system functions

## Details
13 files changed, 30 insertions, 47 deletions (net -17 lines)

The 9 `#[allow]` attributes follow standard Bevy convention — ECS system functions inherently have complex Query generic types and many injected parameters that exceed clippy's defaults.

## Test plan
- [x] `cargo clippy --target wasm32-unknown-unknown` — 0 warnings
- [ ] CI build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)