### PR TITLE
feat(goals): add phase1 goal tools and dispatch runtime

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -98,6 +98,10 @@
    progress
    pulse
    relay
+   goal_store
+   goal_guard
+   goal_orchestrator
+   goal_scheduler
    resilience
    response
    room
@@ -140,6 +144,7 @@
    tool_a2a
    tool_handover
    tool_relay
+   tool_goals
    tool_heartbeat
    tool_encryption
    tool_auth

--- a/lib/goal_guard.ml
+++ b/lib/goal_guard.ml
@@ -1,0 +1,43 @@
+type budget = {
+  max_depth : int;
+  parallel_children : int;
+  parallel_grandchildren : int;
+  fanout_short : int;
+  fanout_mid : int;
+  fanout_long : int;
+  require_approval : bool;
+}
+
+let int_env name ~default ~min_v ~max_v =
+  match Sys.getenv_opt name with
+  | None -> default
+  | Some raw -> (
+      try
+        let parsed = int_of_string (String.trim raw) in
+        max min_v (min max_v parsed)
+      with _ -> default)
+
+let bool_env name ~default =
+  match Sys.getenv_opt name with
+  | Some "1" | Some "true" | Some "TRUE" | Some "yes" | Some "on" -> true
+  | Some "0" | Some "false" | Some "FALSE" | Some "no" | Some "off" -> false
+  | Some _ | None -> default
+
+let load_budget () =
+  {
+    max_depth = int_env "MASC_GOAL_MAX_DEPTH" ~default:2 ~min_v:1 ~max_v:3;
+    parallel_children =
+      int_env "MASC_GOAL_PARALLEL_CHILDREN" ~default:12 ~min_v:1 ~max_v:128;
+    parallel_grandchildren =
+      int_env "MASC_GOAL_PARALLEL_GRANDCHILDREN" ~default:24 ~min_v:1 ~max_v:256;
+    fanout_short = int_env "MASC_GOAL_FANOUT_SHORT" ~default:6 ~min_v:1 ~max_v:64;
+    fanout_mid = int_env "MASC_GOAL_FANOUT_MID" ~default:4 ~min_v:1 ~max_v:64;
+    fanout_long = int_env "MASC_GOAL_FANOUT_LONG" ~default:2 ~min_v:1 ~max_v:64;
+    require_approval = bool_env "MASC_GOAL_REQUIRE_APPROVAL" ~default:true;
+  }
+
+let clamp_depth t requested =
+  max 1 (min t.max_depth requested)
+
+let approval_required t ~execute ~approved =
+  execute && t.require_approval && (not approved)

--- a/lib/goal_orchestrator.ml
+++ b/lib/goal_orchestrator.ml
@@ -1,0 +1,148 @@
+type dispatch_node = {
+  node_id : string;
+  goal_id : string;
+  title : string;
+  depth : int;
+  kind : string;
+  priority : int;
+  children : dispatch_node list;
+}
+[@@deriving yojson]
+
+type dispatch_plan = {
+  requested_depth : int;
+  effective_depth : int;
+  child_limit : int;
+  grandchild_limit : int;
+  estimated_actions : int;
+  nodes : dispatch_node list;
+}
+[@@deriving yojson]
+
+type execution_summary = {
+  executed : bool;
+  created_task_count : int;
+  created_task_results : string list;
+  errors : string list;
+}
+[@@deriving yojson]
+
+type build_options = {
+  requested_depth : int;
+  effective_depth : int;
+  child_limit : int;
+  grandchild_limit : int;
+  fanout_short : int;
+  fanout_mid : int;
+  fanout_long : int;
+}
+
+let rec take n xs =
+  if n <= 0 then []
+  else
+    match xs with
+    | [] -> []
+    | x :: rest -> x :: take (n - 1) rest
+
+let filter_horizon horizon goals =
+  List.filter (fun g -> g.Goal_store.horizon = horizon) goals
+
+let selected_children goals opts =
+  let short = filter_horizon "short" goals |> take opts.fanout_short in
+  let mid = filter_horizon "mid" goals |> take opts.fanout_mid in
+  let long = filter_horizon "long" goals |> take opts.fanout_long in
+  (short @ mid @ long) |> take opts.child_limit
+
+let build_plan ~goals opts =
+  let children = selected_children goals opts in
+  let child_count = List.length children in
+  let max_gc_per_child =
+    if child_count = 0 then 0
+    else max 1 (opts.grandchild_limit / child_count)
+  in
+  let nodes =
+    children
+    |> List.mapi (fun idx goal ->
+           let child_id = Printf.sprintf "child-%03d" (idx + 1) in
+           let grandchildren =
+             if opts.effective_depth < 2 then []
+             else
+               List.init max_gc_per_child (fun n ->
+                   {
+                     node_id = Printf.sprintf "%s-gc-%02d" child_id (n + 1);
+                     goal_id = goal.Goal_store.id;
+                     title =
+                       Printf.sprintf "%s / substep %d" goal.Goal_store.title
+                         (n + 1);
+                     depth = 2;
+                     kind = "grandchild";
+                     priority = goal.Goal_store.priority;
+                     children = [];
+                   })
+           in
+           {
+             node_id = child_id;
+             goal_id = goal.Goal_store.id;
+             title = goal.Goal_store.title;
+             depth = 1;
+             kind = "child";
+             priority = goal.Goal_store.priority;
+             children = grandchildren;
+           })
+  in
+  let estimated_actions =
+    List.fold_left
+      (fun acc node -> acc + 1 + List.length node.children)
+      0 nodes
+  in
+  {
+    requested_depth = opts.requested_depth;
+    effective_depth = opts.effective_depth;
+    child_limit = opts.child_limit;
+    grandchild_limit = opts.grandchild_limit;
+    estimated_actions;
+    nodes;
+  }
+
+let add_task_safe config ~title ~description =
+  try
+    let response = Room.add_task config ~title ~priority:3 ~description in
+    Ok response
+  with exn -> Error (Printexc.to_string exn)
+
+let execute_plan config ~agent_name:_ plan =
+  let created = ref [] in
+  let errors = ref [] in
+  let push_result = function
+    | Ok msg -> created := msg :: !created
+    | Error err -> errors := err :: !errors
+  in
+  List.iter
+    (fun node ->
+      let child_title =
+        Printf.sprintf "[goal:%s][child] %s" node.goal_id node.title
+      in
+      let child_desc =
+        Printf.sprintf "Goal dispatch child node %s (depth=%d)" node.node_id
+          node.depth
+      in
+      push_result (add_task_safe config ~title:child_title ~description:child_desc);
+      List.iter
+        (fun gc ->
+          let gc_title =
+            Printf.sprintf "[goal:%s][grandchild] %s" gc.goal_id gc.title
+          in
+          let gc_desc =
+            Printf.sprintf
+              "Goal dispatch grandchild node %s (parent=%s)"
+              gc.node_id node.node_id
+          in
+          push_result (add_task_safe config ~title:gc_title ~description:gc_desc))
+        node.children)
+    plan.nodes;
+  {
+    executed = true;
+    created_task_count = List.length !created;
+    created_task_results = List.rev !created;
+    errors = List.rev !errors;
+  }

--- a/lib/goal_scheduler.ml
+++ b/lib/goal_scheduler.ml
@@ -1,0 +1,60 @@
+type scheduler_state = {
+  last_daily : float option;
+  last_weekly : float option;
+  last_monthly : float option;
+}
+[@@deriving yojson]
+
+let default_state = { last_daily = None; last_weekly = None; last_monthly = None }
+
+let state_path config = Goal_store.scheduler_state_path config
+
+let read_state config =
+  let path = state_path config in
+  if Room.path_exists config path then
+    let json = Room.read_json config path in
+    match scheduler_state_of_yojson json with
+    | Ok s -> s
+    | Error _ -> default_state
+  else
+    default_state
+
+let write_state config state =
+  Room.write_json config (state_path config) (scheduler_state_to_yojson state)
+
+let interval_sec = function
+  | "daily" -> 86_400.0
+  | "weekly" -> 86_400.0 *. 7.0
+  | "monthly" -> 86_400.0 *. 30.0
+  | _ -> 0.0
+
+let last_run state = function
+  | "daily" -> state.last_daily
+  | "weekly" -> state.last_weekly
+  | "monthly" -> state.last_monthly
+  | _ -> None
+
+let should_run_mode state ~mode ~now =
+  let gap = interval_sec mode in
+  match last_run state mode with
+  | None -> true
+  | Some ts -> now -. ts >= gap
+
+let mark_run state ~mode ~now =
+  match mode with
+  | "daily" -> { state with last_daily = Some now }
+  | "weekly" -> { state with last_weekly = Some now }
+  | "monthly" -> { state with last_monthly = Some now }
+  | _ -> state
+
+let due_modes config ~now =
+  let state = read_state config in
+  [ "daily"; "weekly"; "monthly" ]
+  |> List.filter (fun mode -> should_run_mode state ~mode ~now)
+
+let commit_run config ~mode ~now =
+  let lock_path = state_path config in
+  Room.with_file_lock config lock_path (fun () ->
+      let state = read_state config in
+      let updated = mark_run state ~mode ~now in
+      write_state config updated)

--- a/lib/goal_store.ml
+++ b/lib/goal_store.ml
@@ -1,0 +1,394 @@
+type goal = {
+  id : string;
+  horizon : string;
+  title : string;
+  metric : string option;
+  target_value : string option;
+  due_date : string option;
+  priority : int;
+  status : string;
+  parent_goal_id : string option;
+  last_review_note : string option;
+  last_review_at : string option;
+  created_at : string;
+  updated_at : string;
+}
+[@@deriving yojson]
+
+type state = {
+  version : int;
+  updated_at : string;
+  goals : goal list;
+}
+[@@deriving yojson]
+
+type rollup = {
+  short_count : int;
+  mid_count : int;
+  long_count : int;
+  active_count : int;
+  paused_count : int;
+  done_count : int;
+  dropped_count : int;
+}
+[@@deriving yojson]
+
+type snapshot = {
+  snapshot_id : string;
+  created_at : string;
+  mode : string;
+  goals : goal list;
+  rollup : rollup;
+}
+[@@deriving yojson]
+
+type upsert_kind = [ `created | `updated ]
+
+type refresh_result = {
+  mode : string;
+  scanned : int;
+  updated : int;
+  snapshot_id : string;
+}
+[@@deriving yojson]
+
+let horizons = [ "short"; "mid"; "long" ]
+let statuses = [ "active"; "paused"; "done"; "dropped" ]
+
+let normalize_lower s =
+  String.trim s |> String.lowercase_ascii
+
+let normalize_horizon = function
+  | Some s ->
+      let v = normalize_lower s in
+      if List.mem v horizons then Some v else None
+  | None -> None
+
+let normalize_status = function
+  | Some s ->
+      let v = normalize_lower s in
+      if List.mem v statuses then Some v else None
+  | None -> None
+
+let clamp_priority p = max 1 (min 5 p)
+
+let goals_path config =
+  Filename.concat (Room.masc_dir config) "goals.json"
+
+let snapshots_dir config =
+  Filename.concat (Room.masc_dir config) "goals_snapshots"
+
+let scheduler_state_path config =
+  Filename.concat (Room.masc_dir config) "goals_scheduler_state.json"
+
+let ensure_dirs config =
+  Room.mkdir_p (Room.masc_dir config);
+  Room.mkdir_p (snapshots_dir config);
+  ()
+
+let default_state () =
+  { version = 1; updated_at = Types.now_iso (); goals = [] }
+
+let read_state config =
+  ensure_dirs config;
+  let path = goals_path config in
+  if Room.path_exists config path then
+    let json = Room.read_json config path in
+    match state_of_yojson json with
+    | Ok s -> s
+    | Error _ -> default_state ()
+  else
+    default_state ()
+
+let write_state config st =
+  ensure_dirs config;
+  Room.write_json config (goals_path config) (state_to_yojson st)
+
+let now_ms () =
+  int_of_float (Time_compat.now () *. 1000.0)
+
+let gen_goal_id () =
+  Printf.sprintf "goal-%d-%04x" (now_ms ()) (Random.int 0x10000)
+
+let find_goal goals id =
+  List.find_opt (fun g -> g.id = id) goals
+
+let replace_goal goals updated =
+  List.map (fun g -> if g.id = updated.id then updated else g) goals
+
+let update_state config f =
+  let lock_path = goals_path config in
+  Room.with_file_lock config lock_path (fun () ->
+    let st = read_state config in
+    let st' = f st in
+    write_state config st';
+    st')
+
+let sort_goals goals =
+  let horizon_rank = function
+    | "short" -> 0
+    | "mid" -> 1
+    | "long" -> 2
+    | _ -> 3
+  in
+  List.sort
+    (fun a b ->
+      let by_horizon = compare (horizon_rank a.horizon) (horizon_rank b.horizon) in
+      if by_horizon <> 0 then by_horizon
+      else
+        let by_prio = compare a.priority b.priority in
+        if by_prio <> 0 then by_prio
+        else String.compare b.updated_at a.updated_at)
+    goals
+
+let list_goals config ?horizon ?status () =
+  let st = read_state config in
+  st.goals
+  |> List.filter (fun g ->
+         match horizon with
+         | None -> true
+         | Some h -> g.horizon = h)
+  |> List.filter (fun g ->
+         match status with
+         | None -> true
+         | Some s -> g.status = s)
+  |> sort_goals
+
+let upsert_goal config ?id ?horizon ?title ?metric ?target_value ?due_date
+    ?priority ?status ?parent_goal_id () =
+  let normalized_horizon = normalize_horizon horizon in
+  let normalized_status = normalize_status status in
+  match horizon with
+  | Some _ when normalized_horizon = None -> Error "invalid horizon (short|mid|long)"
+  | _ -> (
+      match status with
+      | Some _ when normalized_status = None ->
+          Error "invalid status (active|paused|done|dropped)"
+      | _ ->
+          let now = Types.now_iso () in
+          let resolved_id = Option.value id ~default:(gen_goal_id ()) in
+          let was_created = ref false in
+          let updated_goal =
+            update_state config (fun st ->
+                match find_goal st.goals resolved_id with
+                | Some existing ->
+                    let next_goal =
+                      {
+                        existing with
+                        horizon =
+                          Option.value normalized_horizon ~default:existing.horizon;
+                        title = Option.value title ~default:existing.title;
+                        metric = (match metric with Some _ -> metric | None -> existing.metric);
+                        target_value =
+                          (match target_value with
+                          | Some _ -> target_value
+                          | None -> existing.target_value);
+                        due_date =
+                          (match due_date with Some _ -> due_date | None -> existing.due_date);
+                        priority =
+                          clamp_priority
+                            (Option.value priority ~default:existing.priority);
+                        status = Option.value normalized_status ~default:existing.status;
+                        parent_goal_id =
+                          (match parent_goal_id with
+                          | Some _ -> parent_goal_id
+                          | None -> existing.parent_goal_id);
+                        updated_at = now;
+                      }
+                    in
+                    {
+                      version = st.version + 1;
+                      updated_at = now;
+                      goals = replace_goal st.goals next_goal;
+                    }
+                | None ->
+                    let horizon_value =
+                      Option.value normalized_horizon ~default:"short"
+                    in
+                    let title_value = Option.value title ~default:"Untitled goal" in
+                    let new_goal =
+                      {
+                        id = resolved_id;
+                        horizon = horizon_value;
+                        title = title_value;
+                        metric;
+                        target_value;
+                        due_date;
+                        priority =
+                          clamp_priority (Option.value priority ~default:3);
+                        status = Option.value normalized_status ~default:"active";
+                        parent_goal_id;
+                        last_review_note = None;
+                        last_review_at = None;
+                        created_at = now;
+                        updated_at = now;
+                      }
+                    in
+                    was_created := true;
+                    {
+                      version = st.version + 1;
+                      updated_at = now;
+                      goals = st.goals @ [ new_goal ];
+                    })
+          in
+          let saved = find_goal updated_goal.goals resolved_id in
+          match saved with
+          | Some g ->
+              Ok (g, if !was_created then `created else `updated)
+          | None -> Error "failed to save goal")
+
+let compute_rollup goals =
+  let count p = List.length (List.filter p goals) in
+  {
+    short_count = count (fun g -> g.horizon = "short");
+    mid_count = count (fun g -> g.horizon = "mid");
+    long_count = count (fun g -> g.horizon = "long");
+    active_count = count (fun g -> g.status = "active");
+    paused_count = count (fun g -> g.status = "paused");
+    done_count = count (fun g -> g.status = "done");
+    dropped_count = count (fun g -> g.status = "dropped");
+  }
+
+let snapshot config ~mode =
+  ensure_dirs config;
+  let st = read_state config in
+  let snapshot_id = Printf.sprintf "gsnap-%d" (now_ms ()) in
+  let snap =
+    {
+      snapshot_id;
+      created_at = Types.now_iso ();
+      mode;
+      goals = st.goals;
+      rollup = compute_rollup st.goals;
+    }
+  in
+  let path =
+    Filename.concat (snapshots_dir config) (snapshot_id ^ ".json")
+  in
+  Room.write_json config path (snapshot_to_yojson snap);
+  snap
+
+let parse_yyyy_mm_dd s =
+  try
+    Scanf.sscanf s "%d-%d-%d" (fun year month day ->
+        let tm =
+          {
+            Unix.tm_sec = 0;
+            tm_min = 0;
+            tm_hour = 0;
+            tm_mday = day;
+            tm_mon = month - 1;
+            tm_year = year - 1900;
+            tm_wday = 0;
+            tm_yday = 0;
+            tm_isdst = false;
+          }
+        in
+        let ts, _ = Unix.mktime tm in
+        Some ts)
+  with _ -> None
+
+let days_until due_date =
+  match due_date with
+  | None -> None
+  | Some d -> (
+      match parse_yyyy_mm_dd d with
+      | None -> None
+      | Some ts ->
+          let diff = ts -. Unix.time () in
+          Some (int_of_float (diff /. 86400.0)))
+
+let should_refresh_goal mode goal =
+  match mode with
+  | "daily" -> goal.horizon = "short" && goal.status = "active"
+  | "weekly" -> goal.horizon = "mid" && goal.status = "active"
+  | "monthly" -> goal.horizon = "long" && goal.status = "active"
+  | _ -> false
+
+let reprioritize mode goal =
+  let next_priority =
+    match days_until goal.due_date with
+    | Some d when d < 0 -> 1
+    | Some d when mode = "daily" && d <= 3 -> max 1 (goal.priority - 1)
+    | Some d when mode = "weekly" && d <= 14 -> max 1 (goal.priority - 1)
+    | Some d when mode = "monthly" && d <= 45 -> max 1 (goal.priority - 1)
+    | _ -> goal.priority
+  in
+  if next_priority = goal.priority then
+    (goal, false)
+  else
+    ({ goal with priority = next_priority; updated_at = Types.now_iso () }, true)
+
+let refresh config ~mode =
+  let mode = normalize_lower mode in
+  if not (List.mem mode [ "daily"; "weekly"; "monthly" ]) then
+    Error "mode must be daily|weekly|monthly"
+  else
+    let scanned = ref 0 in
+    let updated = ref 0 in
+    ignore
+      (update_state config (fun st ->
+           let goals =
+             List.map
+               (fun g ->
+                 if should_refresh_goal mode g then (
+                   incr scanned;
+                   let g', changed = reprioritize mode g in
+                   if changed then incr updated;
+                   g')
+                 else g)
+               st.goals
+           in
+           { version = st.version + 1; updated_at = Types.now_iso (); goals }));
+    let snap = snapshot config ~mode in
+    Ok { mode; scanned = !scanned; updated = !updated; snapshot_id = snap.snapshot_id }
+
+let review_goal config ~goal_id ~outcome ?new_horizon ?note () =
+  let outcome = normalize_lower outcome in
+  let normalized_horizon = normalize_horizon new_horizon in
+  match new_horizon with
+  | Some _ when normalized_horizon = None ->
+      Error "invalid new_horizon (short|mid|long)"
+  | _ ->
+      let now = Types.now_iso () in
+      let found = ref false in
+      let st =
+        update_state config (fun state ->
+            let goals =
+              List.map
+                (fun g ->
+                  if g.id <> goal_id then g
+                  else (
+                    found := true;
+                    let status, priority =
+                      match outcome with
+                      | "done" -> ("done", g.priority)
+                      | "progress" -> ("active", max 1 (g.priority - 1))
+                      | "blocked" -> ("paused", min 5 (g.priority + 1))
+                      | "dropped" -> ("dropped", g.priority)
+                      | _ -> (g.status, g.priority)
+                    in
+                    {
+                      g with
+                      status;
+                      priority;
+                      horizon = Option.value normalized_horizon ~default:g.horizon;
+                      last_review_note = note;
+                      last_review_at = Some now;
+                      updated_at = now;
+                    }))
+                state.goals
+            in
+            { version = state.version + 1; updated_at = now; goals })
+      in
+      if not !found then Error "goal not found"
+      else
+        match find_goal st.goals goal_id with
+        | Some g -> Ok g
+        | None -> Error "goal not found after review"
+
+let active_goals config =
+  list_goals config ~status:"active" ()
+
+let has_scheduler_state config =
+  Room.path_exists config (scheduler_state_path config)

--- a/lib/masc_mcp.ml
+++ b/lib/masc_mcp.ml
@@ -115,6 +115,10 @@ module Federation = Federation
 module Level2_config = Level2_config
 module Level4_config = Level4_config
 module Relay = Relay
+module Goal_store = Goal_store
+module Goal_guard = Goal_guard
+module Goal_orchestrator = Goal_orchestrator
+module Goal_scheduler = Goal_scheduler
 module Compression_dict = Compression_dict
 (* Redis_common module removed - PostgreSQL is now the only distributed backend *)
 
@@ -190,6 +194,7 @@ module Succession = Succession
 module Perpetual_loop = Perpetual_loop
 module Tool_perpetual = Tool_perpetual
 module Tool_keeper = Tool_keeper
+module Tool_goals = Tool_goals
 module Tool_trpg = Tool_trpg
 module Trpg_preset_store = Trpg_preset_store
 module Trpg_engine_types = Trpg_engine_types

--- a/lib/mcp_server_eio.ml
+++ b/lib/mcp_server_eio.ml
@@ -961,6 +961,8 @@ let execute_tool_eio ~sw ~clock ?mcp_session_id ?auth_token state ~name ~argumen
     "masc_portal_open"; "masc_portal_send"; "masc_portal_close";
     "masc_deliver"; "masc_note_add"; "masc_error_add"; "masc_error_resolve";
     "masc_lock"; "masc_unlock";
+    "masc_goal_upsert"; "masc_goal_snapshot"; "masc_goal_refresh";
+    "masc_goal_dispatch"; "masc_goal_review";
   ] in
 
   (* Auto-init/auto-join for better UX.
@@ -988,7 +990,8 @@ let execute_tool_eio ~sw ~clock ?mcp_session_id ?auth_token state ~name ~argumen
   let read_only_tools = ["masc_status"; "masc_tasks"; "masc_who"; "masc_agents";
                          "masc_messages"; "masc_task_history"; "masc_votes"; "masc_vote_status";
                          "masc_worktree_list"; "masc_pending_interrupts";
-                         "masc_cost_report"; "masc_portal_status"] in
+                         "masc_cost_report"; "masc_portal_status";
+                         "masc_goal_list"] in
   let is_read_only = List.mem name read_only_tools in
 
   let can_auto_join =
@@ -1119,6 +1122,22 @@ let execute_tool_eio ~sw ~clock ?mcp_session_id ?auth_token state ~name ~argumen
     sw = Some sw;
   } in
   let simple_ctx_relay : Tool_relay.context = { config; agent_name; sw; proc_mgr = state.Mcp_server.proc_mgr } in
+  let simple_ctx_goals : Tool_goals.context =
+    {
+      config;
+      agent_name;
+      call_keeper_msg =
+        Some
+          (fun keeper_args ->
+            let keeper_ctx : _ Tool_keeper.context = { config; sw; clock } in
+            match
+              Tool_keeper.dispatch keeper_ctx ~name:"masc_keeper_msg"
+                ~args:keeper_args
+            with
+            | Some result -> result
+            | None -> (false, "masc_keeper_msg dispatch unavailable"));
+    }
+  in
   let simple_ctx_heartbeat = { Tool_heartbeat.config; agent_name; sw; clock } in
   let simple_ctx_encryption : Tool_encryption.context = { state } in
   let simple_ctx_auth : Tool_auth.context = { config; agent_name } in
@@ -1225,6 +1244,9 @@ let execute_tool_eio ~sw ~clock ?mcp_session_id ?auth_token state ~name ~argumen
   | Some result -> result
   | None ->
   match Tool_relay.dispatch simple_ctx_relay ~name ~args:arguments with
+  | Some result -> result
+  | None ->
+  match Tool_goals.dispatch simple_ctx_goals ~name ~args:arguments with
   | Some result -> result
   | None ->
   match Tool_heartbeat.dispatch simple_ctx_heartbeat ~name ~args:arguments with
@@ -2565,6 +2587,7 @@ let handle_list_tools_eio state id =
     @ Tool_lodge.tools
     @ Tool_perpetual.schemas
     @ Tool_keeper.schemas
+    @ Tool_goals.schemas
     @ Tool_protocol_game_view.schemas
   in
   let filtered_schemas = List.filter (fun (schema : Types.tool_schema) ->

--- a/lib/tool_goals.ml
+++ b/lib/tool_goals.ml
@@ -1,0 +1,666 @@
+open Types
+
+type context = {
+  config : Room.config;
+  agent_name : string;
+  call_keeper_msg : (Yojson.Safe.t -> (bool * string)) option;
+}
+
+let get_string_opt args key =
+  match Yojson.Safe.Util.member key args with
+  | `String s ->
+      let trimmed = String.trim s in
+      if trimmed = "" then None else Some trimmed
+  | _ -> None
+
+let get_string args key default =
+  match get_string_opt args key with
+  | Some s -> s
+  | None -> default
+
+let get_int_opt args key =
+  match Yojson.Safe.Util.member key args with
+  | `Int i -> Some i
+  | `Intlit s -> (
+      try Some (int_of_string s) with _ -> None)
+  | _ -> None
+
+let get_int args key default =
+  match get_int_opt args key with
+  | Some i -> i
+  | None -> default
+
+let get_bool args key default =
+  match Yojson.Safe.Util.member key args with
+  | `Bool b -> b
+  | _ -> default
+
+let get_string_list args key =
+  match Yojson.Safe.Util.member key args with
+  | `List xs ->
+      xs
+      |> List.filter_map (function
+             | `String s ->
+                 let t = String.trim s in
+                 if t = "" then None else Some t
+             | _ -> None)
+  | _ -> []
+
+let split_csv raw =
+  raw
+  |> String.split_on_char ','
+  |> List.map String.trim
+  |> List.filter (fun s -> s <> "")
+
+let tool_result_json fields =
+  Yojson.Safe.to_string (`Assoc (("status", `String "ok") :: fields))
+
+let error_result_json message =
+  Yojson.Safe.to_string (`Assoc [ ("status", `String "error"); ("message", `String message) ])
+
+let schemas : tool_schema list =
+  [
+    {
+      name = "masc_goal_upsert";
+      description =
+        "Create or update a goal (short/mid/long horizon). Supports partial updates when id exists.";
+      input_schema =
+        `Assoc
+          [
+            ("type", `String "object");
+            ( "properties",
+              `Assoc
+                [
+                  ("id", `Assoc [ ("type", `String "string") ]);
+                  ( "horizon",
+                    `Assoc
+                      [
+                        ("type", `String "string");
+                        ("enum", `List [ `String "short"; `String "mid"; `String "long" ]);
+                      ] );
+                  ("title", `Assoc [ ("type", `String "string") ]);
+                  ("metric", `Assoc [ ("type", `String "string") ]);
+                  ("target_value", `Assoc [ ("type", `String "string") ]);
+                  ("due_date", `Assoc [ ("type", `String "string") ]);
+                  ("priority", `Assoc [ ("type", `String "integer") ]);
+                  ( "status",
+                    `Assoc
+                      [
+                        ("type", `String "string");
+                        ( "enum",
+                          `List
+                            [
+                              `String "active";
+                              `String "paused";
+                              `String "done";
+                              `String "dropped";
+                            ] );
+                      ] );
+                  ("parent_goal_id", `Assoc [ ("type", `String "string") ]);
+                ] );
+          ];
+    };
+    {
+      name = "masc_goal_list";
+      description = "List goals with optional horizon/status filters.";
+      input_schema =
+        `Assoc
+          [
+            ("type", `String "object");
+            ( "properties",
+              `Assoc
+                [
+                  ( "horizon",
+                    `Assoc
+                      [
+                        ("type", `String "string");
+                        ("enum", `List [ `String "short"; `String "mid"; `String "long" ]);
+                      ] );
+                  ( "status",
+                    `Assoc
+                      [
+                        ("type", `String "string");
+                        ( "enum",
+                          `List
+                            [
+                              `String "active";
+                              `String "paused";
+                              `String "done";
+                              `String "dropped";
+                            ] );
+                      ] );
+                ] );
+          ];
+    };
+    {
+      name = "masc_goal_snapshot";
+      description = "Write a goal snapshot to .masc/goals_snapshots/*.json.";
+      input_schema =
+        `Assoc
+          [
+            ("type", `String "object");
+            ("properties", `Assoc [ ("mode", `Assoc [ ("type", `String "string") ]) ]);
+          ];
+    };
+    {
+      name = "masc_goal_refresh";
+      description =
+        "Refresh priorities by cadence: daily(short), weekly(mid), monthly(long), or auto.";
+      input_schema =
+        `Assoc
+          [
+            ("type", `String "object");
+            ( "properties",
+              `Assoc
+                [
+                  ( "mode",
+                    `Assoc
+                      [
+                        ("type", `String "string");
+                        ( "enum",
+                          `List
+                            [
+                              `String "daily";
+                              `String "weekly";
+                              `String "monthly";
+                              `String "auto";
+                            ] );
+                      ] );
+                  ("force", `Assoc [ ("type", `String "boolean") ]);
+                ] );
+          ];
+    };
+    {
+      name = "masc_goal_dispatch";
+      description =
+        "Build or execute hierarchical dispatch plan (child/grandchild). Uses approval gate when enabled.";
+      input_schema =
+        `Assoc
+          [
+            ("type", `String "object");
+            ( "properties",
+              `Assoc
+                [
+                  ("depth", `Assoc [ ("type", `String "integer") ]);
+                  ("execute", `Assoc [ ("type", `String "boolean") ]);
+                  ("approved", `Assoc [ ("type", `String "boolean") ]);
+                  ( "runtime",
+                    `Assoc
+                      [
+                        ("type", `String "string");
+                        ("enum", `List [ `String "task"; `String "keeper" ]);
+                      ] );
+                  ( "models",
+                    `Assoc
+                      [
+                        ("type", `String "array");
+                        ("items", `Assoc [ ("type", `String "string") ]);
+                      ] );
+                  ("fallback_to_task", `Assoc [ ("type", `String "boolean") ]);
+                  ("keeper_prefix", `Assoc [ ("type", `String "string") ]);
+                  ("goal_ids", `Assoc [ ("type", `String "array"); ("items", `Assoc [ ("type", `String "string") ]) ]);
+                ] );
+          ];
+    };
+    {
+      name = "masc_goal_review";
+      description = "Review one goal and apply outcome (done/progress/blocked/dropped).";
+      input_schema =
+        `Assoc
+          [
+            ("type", `String "object");
+            ( "properties",
+              `Assoc
+                [
+                  ("goal_id", `Assoc [ ("type", `String "string") ]);
+                  ( "outcome",
+                    `Assoc
+                      [
+                        ("type", `String "string");
+                        ( "enum",
+                          `List
+                            [
+                              `String "done";
+                              `String "progress";
+                              `String "blocked";
+                              `String "dropped";
+                            ] );
+                      ] );
+                  ( "new_horizon",
+                    `Assoc
+                      [
+                        ("type", `String "string");
+                        ("enum", `List [ `String "short"; `String "mid"; `String "long" ]);
+                      ] );
+                  ("note", `Assoc [ ("type", `String "string") ]);
+                ] );
+            ("required", `List [ `String "goal_id"; `String "outcome" ]);
+          ];
+    };
+  ]
+
+let handle_goal_upsert ctx args =
+  let id = get_string_opt args "id" in
+  let horizon = get_string_opt args "horizon" in
+  let title = get_string_opt args "title" in
+  let metric = get_string_opt args "metric" in
+  let target_value = get_string_opt args "target_value" in
+  let due_date = get_string_opt args "due_date" in
+  let priority = get_int_opt args "priority" in
+  let status = get_string_opt args "status" in
+  let parent_goal_id = get_string_opt args "parent_goal_id" in
+  match
+    Goal_store.upsert_goal ctx.config ?id ?horizon ?title ?metric ?target_value
+      ?due_date ?priority ?status ?parent_goal_id ()
+  with
+  | Ok (goal, kind) ->
+      let kind_str = match kind with `created -> "created" | `updated -> "updated" in
+      ( true,
+        tool_result_json
+          [
+            ("result", `String kind_str);
+            ("goal", Goal_store.goal_to_yojson goal);
+          ] )
+  | Error msg -> (false, error_result_json msg)
+
+let validate_horizon_filter args =
+  let raw = get_string_opt args "horizon" in
+  match raw with
+  | None -> Ok None
+  | Some _ -> (
+      match Goal_store.normalize_horizon raw with
+      | Some v -> Ok (Some v)
+      | None -> Error "invalid horizon filter")
+
+let validate_status_filter args =
+  let raw = get_string_opt args "status" in
+  match raw with
+  | None -> Ok None
+  | Some _ -> (
+      match Goal_store.normalize_status raw with
+      | Some v -> Ok (Some v)
+      | None -> Error "invalid status filter")
+
+let handle_goal_list ctx args =
+  match validate_horizon_filter args, validate_status_filter args with
+  | Error e, _ | _, Error e -> (false, error_result_json e)
+  | Ok horizon, Ok status ->
+      let goals = Goal_store.list_goals ctx.config ?horizon ?status () in
+      let rollup = Goal_store.compute_rollup goals in
+      ( true,
+        tool_result_json
+          [
+            ("count", `Int (List.length goals));
+            ("goals", `List (List.map Goal_store.goal_to_yojson goals));
+            ("rollup", Goal_store.rollup_to_yojson rollup);
+          ] )
+
+let handle_goal_snapshot ctx args =
+  let mode = get_string args "mode" "manual" in
+  let snap = Goal_store.snapshot ctx.config ~mode in
+  ( true,
+    tool_result_json
+      [
+        ("snapshot", Goal_store.snapshot_to_yojson snap);
+      ] )
+
+let refresh_one_mode ctx ~mode ~now =
+  match Goal_store.refresh ctx.config ~mode with
+  | Error e -> Error e
+  | Ok result ->
+      Goal_scheduler.commit_run ctx.config ~mode ~now;
+      Ok result
+
+let handle_goal_refresh ctx args =
+  let mode = get_string args "mode" "daily" |> String.lowercase_ascii in
+  let force = get_bool args "force" false in
+  let now = Time_compat.now () in
+  let valid_mode = mode = "auto" || List.mem mode [ "daily"; "weekly"; "monthly" ] in
+  if not valid_mode then
+    (false, error_result_json "mode must be daily|weekly|monthly|auto")
+  else
+  let selected_modes =
+    if mode = "auto" then
+      if force then [ "daily"; "weekly"; "monthly" ]
+      else Goal_scheduler.due_modes ctx.config ~now
+    else
+      if force then [ mode ]
+      else
+        let due = Goal_scheduler.due_modes ctx.config ~now in
+        if List.mem mode due then [ mode ] else []
+  in
+  if selected_modes = [] then
+    ( true,
+      tool_result_json
+        [
+          ("mode", `String mode);
+          ("skipped", `Bool true);
+          ("message", `String "no cadence window due");
+        ] )
+  else
+    let rec collect acc = function
+      | [] -> Ok (List.rev acc)
+      | m :: rest -> (
+          match refresh_one_mode ctx ~mode:m ~now with
+          | Ok r -> collect (r :: acc) rest
+          | Error e -> Error (Printf.sprintf "[%s] %s" m e))
+    in
+    match collect [] selected_modes with
+    | Error e -> (false, error_result_json e)
+    | Ok results ->
+        ( true,
+          tool_result_json
+            [
+              ("mode", `String mode);
+              ("skipped", `Bool false);
+              ( "results",
+                `List
+                  (List.map Goal_store.refresh_result_to_yojson results) );
+            ] )
+
+let filter_goal_ids goals ids =
+  if ids = [] then goals
+  else List.filter (fun g -> List.mem g.Goal_store.id ids) goals
+
+type keeper_call_outcome = {
+  node_id : string;
+  keeper_name : string;
+  depth : int;
+  ok : bool;
+  reply_preview : string option;
+  error : string option;
+  fallback_task : string option;
+}
+[@@deriving yojson]
+
+type keeper_execution = {
+  executed : bool;
+  call_count : int;
+  success_count : int;
+  failure_count : int;
+  fallback_task_count : int;
+  calls : keeper_call_outcome list;
+}
+[@@deriving yojson]
+
+let normalize_runtime value =
+  match String.lowercase_ascii (String.trim value) with
+  | "task" -> Some "task"
+  | "keeper" -> Some "keeper"
+  | _ -> None
+
+let env_keeper_models () =
+  match Sys.getenv_opt "MASC_GOAL_MODELS" with
+  | None -> []
+  | Some raw -> split_csv raw
+
+let default_keeper_models () =
+  let from_env = env_keeper_models () in
+  if from_env <> [] then from_env
+  else [ "ollama:glm-4.7-flash"; "gemini:gemini-3-pro-preview" ]
+
+let sanitize_keeper_name s =
+  let buf = Buffer.create (String.length s) in
+  let push_dash () =
+    if Buffer.length buf = 0 then ()
+    else if Buffer.nth buf (Buffer.length buf - 1) <> '-' then Buffer.add_char buf '-'
+  in
+  String.iter
+    (fun c ->
+      let lc = Char.lowercase_ascii c in
+      if (lc >= 'a' && lc <= 'z') || (lc >= '0' && lc <= '9') then
+        Buffer.add_char buf lc
+      else push_dash ())
+    s;
+  let raw = Buffer.contents buf in
+  let trimmed = String.trim raw in
+  let base = if trimmed = "" then "goal-keeper" else trimmed in
+  if String.length base > 48 then String.sub base 0 48 else base
+
+let reply_preview body =
+  try
+    let json = Yojson.Safe.from_string body in
+    match Yojson.Safe.Util.member "reply" json with
+    | `String s ->
+        if String.length s > 160 then Some (String.sub s 0 160 ^ "...")
+        else Some s
+    | _ -> None
+  with _ -> None
+
+let add_fallback_task ctx node err =
+  let title =
+    Printf.sprintf "[goal:%s][fallback] %s" node.Goal_orchestrator.goal_id
+      node.Goal_orchestrator.title
+  in
+  let desc =
+    Printf.sprintf "keeper dispatch failed at node=%s depth=%d error=%s"
+      node.Goal_orchestrator.node_id node.Goal_orchestrator.depth err
+  in
+  try Some (Room.add_task ctx.config ~title ~priority:2 ~description:desc)
+  with _ -> None
+
+let run_keeper_call ctx ~models ~keeper_prefix ?(fallback_to_task = true) node =
+  let keeper_name =
+    sanitize_keeper_name
+      (Printf.sprintf "%s-%s-%s" keeper_prefix node.Goal_orchestrator.goal_id
+         node.Goal_orchestrator.node_id)
+  in
+  let horizon =
+    if node.Goal_orchestrator.depth <= 1 then "short" else "mid"
+  in
+  let message =
+    if node.Goal_orchestrator.depth <= 1 then
+      Printf.sprintf
+        "Goal '%s' child executor. Return: 1) concrete next action 2) 3-step checklist."
+        node.Goal_orchestrator.title
+    else
+      Printf.sprintf
+        "Goal '%s' grandchild substep. Return one executable micro-task and acceptance criteria."
+        node.Goal_orchestrator.title
+  in
+  match ctx.call_keeper_msg with
+  | None ->
+      let fallback =
+        if fallback_to_task then
+          add_fallback_task ctx node "keeper runtime unavailable"
+        else None
+      in
+      {
+        node_id = node.node_id;
+        keeper_name;
+        depth = node.depth;
+        ok = false;
+        reply_preview = None;
+        error = Some "keeper runtime unavailable";
+        fallback_task = fallback;
+      }
+  | Some call_keeper_msg ->
+      let args =
+        `Assoc
+          [
+            ("name", `String keeper_name);
+            ("goal", `String node.title);
+            ("short_goal", `String node.title);
+            ("mid_goal", `String node.title);
+            ("long_goal", `String node.title);
+            ("message", `String message);
+            ("models", `List (List.map (fun m -> `String m) models));
+            ("new_soul_profile", `String "delivery");
+            ("presence_keepalive", `Bool true);
+            ("auto_handoff", `Bool true);
+            ("context_budget", `Float 0.6);
+            ("handoff_threshold", `Float 0.85);
+            ("drift_enabled", `Bool true);
+            ("instructions", `String "Respond concise and execution-first.");
+            ("new_short_goal", `String node.title);
+            ("new_mid_goal", `String node.title);
+            ("new_long_goal", `String node.title);
+            ("soul_profile", `String "delivery");
+            ("priority_hint", `Int node.priority);
+            ("dispatch_horizon", `String horizon);
+          ]
+      in
+      let ok, body = call_keeper_msg args in
+      if ok then
+        {
+          node_id = node.node_id;
+          keeper_name;
+          depth = node.depth;
+          ok = true;
+          reply_preview = reply_preview body;
+          error = None;
+          fallback_task = None;
+        }
+      else
+        let fallback =
+          if fallback_to_task then add_fallback_task ctx node body else None
+        in
+        {
+          node_id = node.node_id;
+          keeper_name;
+          depth = node.depth;
+          ok = false;
+          reply_preview = None;
+          error = Some body;
+          fallback_task = fallback;
+        }
+
+let run_keeper_dispatch ctx ~plan ~models ~fallback_to_task ~keeper_prefix =
+  let run_node node =
+    let parent_result =
+      run_keeper_call ctx ~models ~keeper_prefix ~fallback_to_task node
+    in
+    let child_results =
+      List.map
+        (fun gc -> run_keeper_call ctx ~models ~keeper_prefix ~fallback_to_task gc)
+        node.Goal_orchestrator.children
+    in
+    parent_result :: child_results
+  in
+  let calls = List.concat (List.map run_node plan.Goal_orchestrator.nodes) in
+  let success_count = List.length (List.filter (fun c -> c.ok) calls) in
+  let fallback_task_count =
+    List.length
+      (List.filter (fun c -> match c.fallback_task with Some _ -> true | None -> false) calls)
+  in
+  {
+    executed = true;
+    call_count = List.length calls;
+    success_count;
+    failure_count = List.length calls - success_count;
+    fallback_task_count;
+    calls;
+  }
+
+let handle_goal_dispatch ctx args =
+  let budget = Goal_guard.load_budget () in
+  let requested_depth = get_int args "depth" 2 in
+  let effective_depth = Goal_guard.clamp_depth budget requested_depth in
+  let execute = get_bool args "execute" true in
+  let approved = get_bool args "approved" false in
+  let runtime_raw =
+    match get_string_opt args "runtime" with
+    | Some v -> v
+    | None -> (
+        match Sys.getenv_opt "MASC_GOAL_DISPATCH_RUNTIME" with
+        | Some env_v -> env_v
+        | None -> "task")
+  in
+  let runtime_opt = normalize_runtime runtime_raw in
+  let goal_ids = get_string_list args "goal_ids" in
+  let models =
+    let explicit = get_string_list args "models" in
+    if explicit <> [] then explicit else default_keeper_models ()
+  in
+  let fallback_to_task = get_bool args "fallback_to_task" true in
+  let keeper_prefix = get_string args "keeper_prefix" "goal" in
+  let goals =
+    Goal_store.active_goals ctx.config
+    |> fun goals -> filter_goal_ids goals goal_ids
+  in
+  match runtime_opt with
+  | None -> (false, error_result_json "runtime must be task|keeper")
+  | Some runtime ->
+  let plan =
+    Goal_orchestrator.build_plan ~goals
+      {
+        Goal_orchestrator.requested_depth;
+        effective_depth;
+        child_limit = budget.parallel_children;
+        grandchild_limit = budget.parallel_grandchildren;
+        fanout_short = budget.fanout_short;
+        fanout_mid = budget.fanout_mid;
+        fanout_long = budget.fanout_long;
+      }
+  in
+  let needs_approval = Goal_guard.approval_required budget ~execute ~approved in
+  if needs_approval then
+    ( true,
+      tool_result_json
+        [
+          ("runtime", `String runtime);
+          ("approval_required", `Bool true);
+          ("executed", `Bool false);
+          ("plan", Goal_orchestrator.dispatch_plan_to_yojson plan);
+          ("message", `String "dispatch approved=false; execution skipped");
+        ] )
+  else if not execute then
+    ( true,
+      tool_result_json
+        [
+          ("runtime", `String runtime);
+          ("approval_required", `Bool false);
+          ("executed", `Bool false);
+          ("plan", Goal_orchestrator.dispatch_plan_to_yojson plan);
+        ] )
+  else if runtime = "task" then
+    let summary =
+      Goal_orchestrator.execute_plan ctx.config ~agent_name:ctx.agent_name plan
+    in
+    ( true,
+      tool_result_json
+        [
+          ("runtime", `String runtime);
+          ("approval_required", `Bool false);
+          ("plan", Goal_orchestrator.dispatch_plan_to_yojson plan);
+          ("execution", Goal_orchestrator.execution_summary_to_yojson summary);
+        ] )
+  else
+    let keeper_exec =
+      run_keeper_dispatch ctx ~plan ~models ~fallback_to_task ~keeper_prefix
+    in
+    ( true,
+      tool_result_json
+        [
+          ("runtime", `String runtime);
+          ("approval_required", `Bool false);
+          ("plan", Goal_orchestrator.dispatch_plan_to_yojson plan);
+          ("keeper_execution", keeper_execution_to_yojson keeper_exec);
+        ] )
+
+let handle_goal_review ctx args =
+  let goal_id = get_string args "goal_id" "" in
+  let outcome = get_string args "outcome" "" in
+  let new_horizon = get_string_opt args "new_horizon" in
+  let note = get_string_opt args "note" in
+  if goal_id = "" || outcome = "" then
+    (false, error_result_json "goal_id and outcome are required")
+  else
+    match Goal_store.review_goal ctx.config ~goal_id ~outcome ?new_horizon ?note () with
+    | Ok goal ->
+        ( true,
+          tool_result_json
+            [
+              ("goal", Goal_store.goal_to_yojson goal);
+            ] )
+    | Error msg -> (false, error_result_json msg)
+
+let dispatch ctx ~name ~args =
+  match name with
+  | "masc_goal_upsert" -> Some (handle_goal_upsert ctx args)
+  | "masc_goal_list" -> Some (handle_goal_list ctx args)
+  | "masc_goal_snapshot" -> Some (handle_goal_snapshot ctx args)
+  | "masc_goal_refresh" -> Some (handle_goal_refresh ctx args)
+  | "masc_goal_dispatch" -> Some (handle_goal_dispatch ctx args)
+  | "masc_goal_review" -> Some (handle_goal_review ctx args)
+  | _ -> None

--- a/lib/tools.ml
+++ b/lib/tools.ml
@@ -4338,7 +4338,7 @@ Example: masc_swarm_leave({agent_name: 'claude-xyz'})";
 
 (** All schemas including Perpetual Agent Runtime tools *)
 let all_schemas_with_perpetual =
-  all_schemas @ Tool_perpetual.schemas
+  all_schemas @ Tool_perpetual.schemas @ Tool_keeper.schemas @ Tool_goals.schemas
 
 (** Get tool by name *)
 let find_tool name =

--- a/test/dune
+++ b/test/dune
@@ -117,6 +117,11 @@
  (libraries masc_mcp alcotest yojson unix))
 
 (test
+ (name test_tool_goals)
+ (modules test_tool_goals)
+ (libraries masc_mcp alcotest yojson unix))
+
+(test
  (name test_protocol_game_view)
  (modules test_protocol_game_view)
  (libraries masc_mcp alcotest yojson unix))

--- a/test/test_mcp_server_eio.ml
+++ b/test/test_mcp_server_eio.ml
@@ -216,6 +216,10 @@ let test_handle_request_tools_list () =
                    true
                    (List.mem "trpg.round.run" names);
                  Alcotest.(check bool)
+                   "contains masc_goal_upsert"
+                   true
+                   (List.mem "masc_goal_upsert" names);
+                 Alcotest.(check bool)
                    "legacy masc_trpg_dice_roll hidden from list"
                    false
                    (List.mem "masc_trpg_dice_roll" names)

--- a/test/test_tool_goals.ml
+++ b/test/test_tool_goals.ml
@@ -1,0 +1,217 @@
+open Masc_mcp
+
+let temp_dir () =
+  let dir = Filename.temp_file "test_tool_goals_" "" in
+  Unix.unlink dir;
+  Unix.mkdir dir 0o755;
+  dir
+
+let cleanup_dir dir =
+  let rec rm path =
+    if Sys.file_exists path then
+      if Sys.is_directory path then (
+        Array.iter (fun name -> rm (Filename.concat path name)) (Sys.readdir path);
+        Unix.rmdir path)
+      else Unix.unlink path
+  in
+  try rm dir with _ -> ()
+
+let parse_json_exn s =
+  try Yojson.Safe.from_string s
+  with Yojson.Json_error e -> failwith ("invalid json: " ^ e)
+
+let dispatch_exn ctx ~name ~args =
+  match Tool_goals.dispatch ctx ~name ~args with
+  | Some result -> result
+  | None -> failwith ("dispatch returned None for " ^ name)
+
+let upsert_goal_exn ctx args =
+  let ok, body = dispatch_exn ctx ~name:"masc_goal_upsert" ~args in
+  Alcotest.(check bool) "goal upsert ok" true ok;
+  let json = parse_json_exn body in
+  json |> Yojson.Safe.Util.member "goal" |> Yojson.Safe.Util.member "id"
+  |> Yojson.Safe.Util.to_string
+
+let test_goal_upsert_and_list () =
+  let base_dir = temp_dir () in
+  let config = Room.default_config base_dir in
+  ignore (Room.init config ~agent_name:(Some "tester"));
+  let ctx : Tool_goals.context =
+    { config; agent_name = "tester"; call_keeper_msg = None }
+  in
+  let goal_id =
+    upsert_goal_exn ctx
+      (`Assoc
+        [
+          ("horizon", `String "short");
+          ("title", `String "Ship MVP");
+          ("priority", `Int 2);
+        ])
+  in
+  Alcotest.(check bool) "goal id generated" true (String.length goal_id > 0);
+  let ok, body = dispatch_exn ctx ~name:"masc_goal_list" ~args:(`Assoc []) in
+  Alcotest.(check bool) "goal list ok" true ok;
+  let json = parse_json_exn body in
+  Alcotest.(check int) "goal count" 1
+    (json |> Yojson.Safe.Util.member "count" |> Yojson.Safe.Util.to_int);
+  cleanup_dir base_dir
+
+let test_goal_refresh_daily_reprioritizes () =
+  let base_dir = temp_dir () in
+  let config = Room.default_config base_dir in
+  ignore (Room.init config ~agent_name:(Some "tester"));
+  let ctx : Tool_goals.context =
+    { config; agent_name = "tester"; call_keeper_msg = None }
+  in
+  let goal_id =
+    upsert_goal_exn ctx
+      (`Assoc
+        [
+          ("horizon", `String "short");
+          ("title", `String "Overdue short goal");
+          ("priority", `Int 5);
+          ("due_date", `String "2000-01-01");
+        ])
+  in
+  let ok_refresh, _refresh_body =
+    dispatch_exn ctx ~name:"masc_goal_refresh"
+      ~args:(`Assoc [ ("mode", `String "daily"); ("force", `Bool true) ])
+  in
+  Alcotest.(check bool) "goal refresh ok" true ok_refresh;
+  let ok_list, list_body = dispatch_exn ctx ~name:"masc_goal_list" ~args:(`Assoc []) in
+  Alcotest.(check bool) "goal list after refresh ok" true ok_list;
+  let json = parse_json_exn list_body in
+  let goals = json |> Yojson.Safe.Util.member "goals" |> Yojson.Safe.Util.to_list in
+  let goal =
+    List.find
+      (fun g ->
+        g |> Yojson.Safe.Util.member "id" |> Yojson.Safe.Util.to_string = goal_id)
+      goals
+  in
+  let priority = goal |> Yojson.Safe.Util.member "priority" |> Yojson.Safe.Util.to_int in
+  Alcotest.(check int) "overdue reprioritized to 1" 1 priority;
+  cleanup_dir base_dir
+
+let test_goal_dispatch_requires_approval () =
+  let base_dir = temp_dir () in
+  let config = Room.default_config base_dir in
+  ignore (Room.init config ~agent_name:(Some "tester"));
+  let ctx : Tool_goals.context =
+    { config; agent_name = "tester"; call_keeper_msg = None }
+  in
+  Unix.putenv "MASC_GOAL_REQUIRE_APPROVAL" "true";
+  ignore
+    (upsert_goal_exn ctx
+       (`Assoc [ ("horizon", `String "short"); ("title", `String "Dispatch target A") ]));
+  ignore
+    (upsert_goal_exn ctx
+       (`Assoc [ ("horizon", `String "mid"); ("title", `String "Dispatch target B") ]));
+  let ok_pending, pending_body =
+    dispatch_exn ctx ~name:"masc_goal_dispatch"
+      ~args:
+        (`Assoc
+          [ ("depth", `Int 2); ("execute", `Bool true); ("approved", `Bool false) ])
+  in
+  Alcotest.(check bool) "dispatch pending ok" true ok_pending;
+  let pending_json = parse_json_exn pending_body in
+  Alcotest.(check bool) "approval required true" true
+    (pending_json |> Yojson.Safe.Util.member "approval_required"
+   |> Yojson.Safe.Util.to_bool);
+  Alcotest.(check int) "no tasks created before approval" 0
+    (List.length (Room.get_tasks_raw config));
+
+  let ok_exec, exec_body =
+    dispatch_exn ctx ~name:"masc_goal_dispatch"
+      ~args:
+        (`Assoc
+          [ ("depth", `Int 2); ("execute", `Bool true); ("approved", `Bool true) ])
+  in
+  Alcotest.(check bool) "dispatch execute ok" true ok_exec;
+  let exec_json = parse_json_exn exec_body in
+  let created_count =
+    exec_json |> Yojson.Safe.Util.member "execution" |> Yojson.Safe.Util.member "created_task_count"
+    |> Yojson.Safe.Util.to_int
+  in
+  Alcotest.(check bool) "tasks created after approval" true (created_count > 0);
+  Alcotest.(check bool) "room backlog populated" true
+    (List.length (Room.get_tasks_raw config) > 0);
+  cleanup_dir base_dir
+
+let test_goal_review_done_and_promote () =
+  let base_dir = temp_dir () in
+  let config = Room.default_config base_dir in
+  ignore (Room.init config ~agent_name:(Some "tester"));
+  let ctx : Tool_goals.context =
+    { config; agent_name = "tester"; call_keeper_msg = None }
+  in
+  let goal_id =
+    upsert_goal_exn ctx
+      (`Assoc
+        [
+          ("horizon", `String "short");
+          ("title", `String "Review candidate");
+          ("priority", `Int 3);
+        ])
+  in
+  let ok_review, review_body =
+    dispatch_exn ctx ~name:"masc_goal_review"
+      ~args:
+        (`Assoc
+          [
+            ("goal_id", `String goal_id);
+            ("outcome", `String "done");
+            ("new_horizon", `String "long");
+            ("note", `String "Completed and promoted");
+          ])
+  in
+  Alcotest.(check bool) "goal review ok" true ok_review;
+  let json = parse_json_exn review_body in
+  let goal_json = json |> Yojson.Safe.Util.member "goal" in
+  Alcotest.(check string) "status done" "done"
+    (goal_json |> Yojson.Safe.Util.member "status" |> Yojson.Safe.Util.to_string);
+  Alcotest.(check string) "horizon long" "long"
+    (goal_json |> Yojson.Safe.Util.member "horizon" |> Yojson.Safe.Util.to_string);
+  cleanup_dir base_dir
+
+let test_goal_dispatch_runtime_validation () =
+  let base_dir = temp_dir () in
+  let config = Room.default_config base_dir in
+  ignore (Room.init config ~agent_name:(Some "tester"));
+  let ctx : Tool_goals.context =
+    { config; agent_name = "tester"; call_keeper_msg = None }
+  in
+  ignore
+    (upsert_goal_exn ctx
+       (`Assoc [ ("horizon", `String "short"); ("title", `String "Runtime target") ]));
+  let ok, body =
+    dispatch_exn ctx ~name:"masc_goal_dispatch"
+      ~args:
+        (`Assoc
+          [
+            ("runtime", `String "invalid-runtime");
+            ("execute", `Bool true);
+            ("approved", `Bool true);
+          ])
+  in
+  Alcotest.(check bool) "invalid runtime fails" false ok;
+  let json = parse_json_exn body in
+  Alcotest.(check string) "status error" "error"
+    (json |> Yojson.Safe.Util.member "status" |> Yojson.Safe.Util.to_string);
+  cleanup_dir base_dir
+
+let () =
+  Alcotest.run "Tool_goals"
+    [
+      ( "goal tools",
+        [
+          Alcotest.test_case "upsert and list" `Quick test_goal_upsert_and_list;
+          Alcotest.test_case "refresh daily reprioritize" `Quick
+            test_goal_refresh_daily_reprioritizes;
+          Alcotest.test_case "dispatch approval gate" `Quick
+            test_goal_dispatch_requires_approval;
+          Alcotest.test_case "review done promote" `Quick
+            test_goal_review_done_and_promote;
+          Alcotest.test_case "dispatch runtime validation" `Quick
+            test_goal_dispatch_runtime_validation;
+        ] );
+    ]


### PR DESCRIPTION
## Summary
- add phase1 goal modules (`goal_store`, `goal_guard`, `goal_scheduler`, `goal_orchestrator`)
- add MCP goal tools: `masc_goal_upsert`, `masc_goal_list`, `masc_goal_snapshot`, `masc_goal_refresh`, `masc_goal_dispatch`, `masc_goal_review`
- wire `Tool_goals` into MCP dispatch and tools/list
- support `masc_goal_dispatch` runtime modes:
  - `task` (default): backlog task fanout
  - `keeper`: keeper call path via `masc_keeper_msg` with optional task fallback
- add tests for goal tools and tools/list coverage

## Validation
- `dune build --root . @check`
- `dune exec --root . test/test_tool_goals.exe`
- `dune exec --root . test/test_mcp_server_eio.exe`

## Notes
- approval gate is enforced for goal dispatch execution
- keeper runtime falls back to task creation when configured (`fallback_to_task=true`)