### PR TITLE
fix(viewer): prevent DM runaway and require keeper readiness

### DIFF
--- a/viewer/src/game/round_runner.rs
+++ b/viewer/src/game/round_runner.rs
@@ -62,6 +62,15 @@ pub fn start_round_loop(
     progress: Res<TurnProgressState>,
 ) {
     let runner = RoundRunner::default();
+
+    #[cfg(target_arch = "wasm32")]
+    if !auto_round_enabled() {
+        runner.running.store(false, Ordering::SeqCst);
+        log::info!("RoundRunner: auto round loop disabled (manual Run Round only)");
+        commands.insert_resource(runner);
+        return;
+    }
+
     runner.running.store(true, Ordering::SeqCst);
 
     #[cfg(target_arch = "wasm32")]
@@ -354,6 +363,20 @@ fn parse_http_status(detail: &str) -> Option<u16> {
     } else {
         code_text.parse::<u16>().ok()
     }
+}
+
+#[cfg(target_arch = "wasm32")]
+fn auto_round_enabled() -> bool {
+    let Some(document) = web_sys::window().and_then(|w| w.document()) else {
+        return false;
+    };
+    let Some(dashboard) = document.get_element_by_id("dashboard") else {
+        return false;
+    };
+    dashboard
+        .get_attribute("data-auto-round")
+        .map(|value| matches!(value.as_str(), "1" | "true" | "on"))
+        .unwrap_or(false)
 }
 
 // ─── Sleep Helper ──────────────────────────────

--- a/viewer/src/mode.rs
+++ b/viewer/src/mode.rs
@@ -2749,44 +2749,55 @@ async fn start_new_game_flow(doc: &web_sys::Document) -> Result<String, String> 
         .await?;
     }
 
-    if !models.is_empty() {
-        let models_value = Value::Array(
+    let models_value = if models.is_empty() {
+        None
+    } else {
+        Some(Value::Array(
             models
                 .iter()
                 .map(|m| Value::String(m.clone()))
                 .collect::<Vec<_>>(),
-        );
-        mcp_tool_call(
-            "masc_keeper_up",
-            json!({
-                "name": dm_keeper,
-                "goal": format!("TRPG room {}의 세계관 주민 DM keeper로 장면을 진행하세요.", room_id),
-                "models": models_value,
-                "instructions": "모든 응답은 한국어로 작성하세요.",
-                "proactive_enabled": false,
-                "presence_keepalive": true
-            }),
-        )
-        .await?;
-        for (actor_id, keeper_name) in &player_map {
-            mcp_tool_call(
-                "masc_keeper_up",
-                json!({
-                    "name": keeper_name,
-                    "goal": format!("TRPG room {}에서 {} actor를 플레이하세요.", room_id, actor_id),
-                    "models": Value::Array(
-                        models
-                            .iter()
-                            .map(|m| Value::String(m.clone()))
-                            .collect::<Vec<_>>()
-                    ),
-                    "instructions": "모든 응답은 한국어로 작성하세요.",
-                    "proactive_enabled": false,
-                    "presence_keepalive": true
-                }),
+        ))
+    };
+
+    let mut dm_keeper_up_args = json!({
+        "name": dm_keeper,
+        "goal": format!("TRPG room {}의 세계관 주민 DM keeper로 장면을 진행하세요.", room_id),
+        "instructions": "모든 응답은 한국어로 작성하세요.",
+        "proactive_enabled": false,
+        "presence_keepalive": true
+    });
+    if let Some(models_value) = &models_value {
+        dm_keeper_up_args["models"] = models_value.clone();
+    }
+    mcp_tool_call("masc_keeper_up", dm_keeper_up_args)
+        .await
+        .map_err(|e| {
+            format!(
+                "DM keeper 준비 실패 ({}): {}. 새 keeper 생성 시 모델 입력이 필요합니다.",
+                dm_keeper, e
             )
-            .await?;
+        })?;
+
+    for (actor_id, keeper_name) in &player_map {
+        let mut player_keeper_up_args = json!({
+            "name": keeper_name,
+            "goal": format!("TRPG room {}에서 {} actor를 플레이하세요.", room_id, actor_id),
+            "instructions": "모든 응답은 한국어로 작성하세요.",
+            "proactive_enabled": false,
+            "presence_keepalive": true
+        });
+        if let Some(models_value) = &models_value {
+            player_keeper_up_args["models"] = models_value.clone();
         }
+        mcp_tool_call("masc_keeper_up", player_keeper_up_args)
+            .await
+            .map_err(|e| {
+                format!(
+                    "Player keeper 준비 실패 (actor {} / keeper {}): {}. 새 keeper 생성 시 모델 입력이 필요합니다.",
+                    actor_id, keeper_name, e
+                )
+            })?;
     }
 
     set_current_room_id(doc, &room_id);


### PR DESCRIPTION
## Summary
- disable TRPG auto round loop by default in viewer (`data-auto-round` opt-in)
- keep manual `Run Round` flow as the default execution path
- always run `masc_keeper_up` during new-game bootstrap so DM/player keepers are verified early
- surface clearer error when keepers are missing and models are required for creation

## Why
- users observed DM auto-advancing like a runaway loop
- sessions could start with missing player keepers, causing no player responses / inconsistent round behavior

## Verification
- `cd viewer && cargo build --target wasm32-unknown-unknown`
- `cd viewer && cargo test`
