### PR TITLE
feat(viewer): ops HUD + quick-start + round sync debug

### DIFF
--- a/viewer/index.html
+++ b/viewer/index.html
@@ -184,12 +184,45 @@
             </div>
         </header>
 
+        <section id="ops-hud" aria-label="TRPG 운영 상태">
+            <div class="ops-hud-item">
+                <span class="ops-k">Room</span>
+                <span id="ops-room-id" class="ops-v">default</span>
+            </div>
+            <div class="ops-hud-item">
+                <span class="ops-k">Session</span>
+                <span id="ops-session-state" class="ops-v">lobby</span>
+            </div>
+            <div class="ops-hud-item">
+                <span class="ops-k">Round</span>
+                <span id="ops-round-phase" class="ops-v">T1 / dm narration</span>
+            </div>
+            <div class="ops-hud-item">
+                <span class="ops-k">Connection</span>
+                <span id="ops-connection-state" class="ops-v">disconnected</span>
+            </div>
+            <div class="ops-hud-item">
+                <span class="ops-k">Control</span>
+                <span id="ops-control-state" class="ops-v">waiting</span>
+            </div>
+            <div class="ops-hud-item">
+                <span class="ops-k">Sync</span>
+                <span id="ops-sync-state" class="ops-v">idle</span>
+            </div>
+        </section>
+
         <section id="new-game-panel" style="display: none;">
             <div class="new-game-card">
                 <div class="new-game-panel-head">
                     <strong>새 게임 시작</strong>
                     <button id="new-game-close" class="inline-toggle" type="button">닫기</button>
                 </div>
+                <div class="new-game-steps" id="new-game-steps">
+                    <span id="new-game-step-1" class="new-game-step" data-step="1">1) 사전 점검</span>
+                    <span id="new-game-step-2" class="new-game-step" data-step="2">2) DM/플레이어 선택</span>
+                    <span id="new-game-step-3" class="new-game-step" data-step="3">3) 세션 시작</span>
+                </div>
+                <div id="new-game-step-hint" class="new-game-step-hint">1단계부터 순서대로 진행하세요.</div>
                 <div class="new-game-grid">
                     <label class="new-game-field">
                         <span>방 이름</span>
@@ -225,6 +258,8 @@
                         <select id="new-game-player-select" multiple size="6" title="게임에 참여할 AI 에이전트 선택 (Ctrl/Cmd+클릭)">
                             <option value="">로딩 중...</option>
                         </select>
+                        <div id="new-game-player-hint" class="new-game-inline-hint">플레이어 0명 선택됨</div>
+                        <button id="new-game-autopick-btn" class="inline-toggle" type="button">4인 자동선택</button>
                     </label>
 
                     <label class="new-game-field">
@@ -234,6 +269,7 @@
                 </div>
 
                 <div class="new-game-actions">
+                    <button id="new-game-quick-start" class="inline-toggle" type="button">빠른 시작</button>
                     <button id="new-game-preflight-btn" class="inline-toggle" type="button">사전 점검</button>
                     <button id="new-game-refresh" class="inline-toggle" type="button">Keeper 새로고침</button>
                     <button id="new-game-start" class="inline-toggle primary" type="button">세션 시작</button>
@@ -327,12 +363,42 @@
                         <span class="state-chip state-ended">ENDED: 세션 종료</span>
                         <span class="state-chip state-unavailable">UNAVAILABLE: 연결/키퍼 오류</span>
                     </div>
+                    <div id="lifecycle-diagram" class="lifecycle-diagram" aria-label="TRPG 상태 전이 다이어그램">
+                        <div class="lifecycle-track">
+                            <span class="lifecycle-node" data-state="lobby">LOBBY</span>
+                            <span class="lifecycle-edge">→</span>
+                            <span class="lifecycle-node" data-state="running">RUNNING</span>
+                            <span class="lifecycle-edge">↔</span>
+                            <span class="lifecycle-node" data-state="stopped">STOPPED</span>
+                            <span class="lifecycle-edge">→</span>
+                            <span class="lifecycle-node" data-state="ended">ENDED</span>
+                        </div>
+                        <div class="lifecycle-track lifecycle-track-alt">
+                            <span class="lifecycle-node" data-state="unavailable">UNAVAILABLE</span>
+                            <span class="lifecycle-edge">↩</span>
+                            <span class="lifecycle-node" data-state="recover">RECOVER</span>
+                        </div>
+                    </div>
+                    <div id="lifecycle-diagram-hint" class="lifecycle-diagram-hint">현재 상태를 불러오는 중...</div>
                     <!-- Turn Controls: advance turn (Keeper/GM only) -->
                     <div id="turn-controls" style="display:none">
                         <button id="advance-turn-btn" title="다음 TRPG 라운드를 실행합니다">라운드 실행</button>
                         <span id="turn-control-status"></span>
+                        <button id="round-recovery-btn" type="button" style="display:none">복구 가이드 보기</button>
                     </div>
+                    <div id="round-recovery-actions" class="turn-recovery-actions" style="display:none">
+                        <button id="round-recovery-refresh" type="button" title="키퍼/프리셋을 다시 동기화합니다">Keeper 새로고침</button>
+                        <button id="round-recovery-timeout" type="button" title="라운드 timeout을 30초 늘립니다">Timeout +30s</button>
+                        <button id="round-recovery-retry" type="button" title="현재 설정으로 라운드를 다시 실행합니다">재실행</button>
+                    </div>
+                    <div id="round-recovery-note" class="turn-recovery-note" style="display:none"></div>
                     <div id="round-run-summary" class="turn-run-summary" style="display:none"></div>
+                    <details id="round-sync-debug" class="round-sync-debug">
+                        <summary>라운드 동기화 디버그</summary>
+                        <div id="round-sync-debug-body" class="round-sync-debug-body">
+                            라운드 실행 후 동기화 상태를 표시합니다.
+                        </div>
+                    </details>
                     <input type="hidden" id="round-run-dm" value="" />
                     <input type="hidden" id="round-run-phase" value="" />
                     <input type="hidden" id="round-run-timeout" value="" />

--- a/viewer/src/audio.rs
+++ b/viewer/src/audio.rs
@@ -16,14 +16,17 @@ impl Plugin for AudioPlugin {
     fn build(&self, app: &mut App) {
         app.init_resource::<AudioSettings>()
             .init_resource::<AudioState>()
-            .add_systems(Update, (
-                sync_bgm_on_mood_change,
-                play_sfx_on_dice_roll,
-                play_sfx_on_turn_advance,
-                play_sfx_on_combat_start,
-                play_sfx_on_death,
-                update_bgm_volume,
-            ));
+            .add_systems(
+                Update,
+                (
+                    sync_bgm_on_mood_change,
+                    play_sfx_on_dice_roll,
+                    play_sfx_on_turn_advance,
+                    play_sfx_on_combat_start,
+                    play_sfx_on_death,
+                    update_bgm_volume,
+                ),
+            );
     }
 }
 
@@ -156,10 +159,7 @@ fn sync_bgm_on_mood_change(
 }
 
 /// Adjust BGM volume when settings change (called every frame, early-outs fast).
-fn update_bgm_volume(
-    settings: Res<AudioSettings>,
-    state: Res<AudioState>,
-) {
+fn update_bgm_volume(settings: Res<AudioSettings>, state: Res<AudioState>) {
     if !settings.is_changed() {
         return;
     }
@@ -175,10 +175,7 @@ fn update_bgm_volume(
 }
 
 /// Play dice SFX on roll events.
-fn play_sfx_on_dice_roll(
-    mut events: MessageReader<DiceRolled>,
-    settings: Res<AudioSettings>,
-) {
+fn play_sfx_on_dice_roll(mut events: MessageReader<DiceRolled>, settings: Res<AudioSettings>) {
     for ev in events.read() {
         if !settings.sound_enabled {
             continue;
@@ -195,10 +192,7 @@ fn play_sfx_on_dice_roll(
 }
 
 /// Play turn advance chime.
-fn play_sfx_on_turn_advance(
-    mut events: MessageReader<TurnAdvanced>,
-    settings: Res<AudioSettings>,
-) {
+fn play_sfx_on_turn_advance(mut events: MessageReader<TurnAdvanced>, settings: Res<AudioSettings>) {
     for _ev in events.read() {
         if settings.sound_enabled {
             play_one_shot(paths::SFX_TURN_ADVANCE, settings.sound_volume);
@@ -219,10 +213,7 @@ fn play_sfx_on_combat_start(
 }
 
 /// Play death SFX.
-fn play_sfx_on_death(
-    mut events: MessageReader<CharacterDied>,
-    settings: Res<AudioSettings>,
-) {
+fn play_sfx_on_death(mut events: MessageReader<CharacterDied>, settings: Res<AudioSettings>) {
     for _ev in events.read() {
         if settings.sound_enabled {
             play_one_shot(paths::SFX_DEATH, settings.sound_volume);

--- a/viewer/src/dom/action_panel.rs
+++ b/viewer/src/dom/action_panel.rs
@@ -20,6 +20,8 @@ use wasm_bindgen::prelude::*;
 
 #[cfg(target_arch = "wasm32")]
 use crate::config;
+#[cfg(target_arch = "wasm32")]
+use crate::game::lifecycle::TrpgLifecycleState;
 use crate::game::state::{RoomState, TurnProgressState};
 
 // ─── Marker Resource ────────────────────────
@@ -37,7 +39,7 @@ pub fn bind_action_panel(mut commands: Commands) {
         bind_enter_key();
         bind_dice_roll_button();
         clear_action_status();
-        
+
         log::info!("ActionPanel: bound complete");
     }
 
@@ -59,23 +61,40 @@ pub fn unbind_action_panel(mut commands: Commands) {
 
 #[cfg(target_arch = "wasm32")]
 fn bind_submit_button() {
-    let Some(doc) = web_sys::window().and_then(|w| w.document()) else { return };
-    let Some(btn) = doc.get_element_by_id("action-submit-btn") else { return };
+    let Some(doc) = web_sys::window().and_then(|w| w.document()) else {
+        return;
+    };
+    let Some(btn) = doc.get_element_by_id("action-submit-btn") else {
+        return;
+    };
+    if btn.get_attribute("data-bound").as_deref() == Some("1") {
+        return;
+    }
+    let _ = btn.set_attribute("data-bound", "1");
 
     let cb = Closure::wrap(Box::new(move || {
         log::info!("ActionPanel: Submit intervention");
         submit_intervention_from_input();
     }) as Box<dyn FnMut()>);
 
-    let _ = btn.dyn_ref::<web_sys::EventTarget>()
+    let _ = btn
+        .dyn_ref::<web_sys::EventTarget>()
         .map(|t| t.add_event_listener_with_callback("click", cb.as_ref().unchecked_ref()));
     cb.forget();
 }
 
 #[cfg(target_arch = "wasm32")]
 fn bind_enter_key() {
-    let Some(doc) = web_sys::window().and_then(|w| w.document()) else { return };
-    let Some(input) = doc.get_element_by_id("action-input") else { return };
+    let Some(doc) = web_sys::window().and_then(|w| w.document()) else {
+        return;
+    };
+    let Some(input) = doc.get_element_by_id("action-input") else {
+        return;
+    };
+    if input.get_attribute("data-bound").as_deref() == Some("1") {
+        return;
+    }
+    let _ = input.set_attribute("data-bound", "1");
 
     let cb = Closure::wrap(Box::new(move |event: web_sys::KeyboardEvent| {
         if event.key() == "Enter" {
@@ -83,15 +102,24 @@ fn bind_enter_key() {
         }
     }) as Box<dyn FnMut(web_sys::KeyboardEvent)>);
 
-    let _ = input.dyn_ref::<web_sys::EventTarget>()
+    let _ = input
+        .dyn_ref::<web_sys::EventTarget>()
         .map(|t| t.add_event_listener_with_callback("keydown", cb.as_ref().unchecked_ref()));
     cb.forget();
 }
 
 #[cfg(target_arch = "wasm32")]
 fn bind_dice_roll_button() {
-    let Some(doc) = web_sys::window().and_then(|w| w.document()) else { return };
-    let Some(btn) = doc.get_element_by_id("dice-roll-btn") else { return };
+    let Some(doc) = web_sys::window().and_then(|w| w.document()) else {
+        return;
+    };
+    let Some(btn) = doc.get_element_by_id("dice-roll-btn") else {
+        return;
+    };
+    if btn.get_attribute("data-bound").as_deref() == Some("1") {
+        return;
+    }
+    let _ = btn.set_attribute("data-bound", "1");
 
     let cb = Closure::wrap(Box::new(move || {
         log::info!("ActionPanel: Manual Dice Roll (Divine Intervention)");
@@ -110,7 +138,8 @@ fn bind_dice_roll_button() {
         });
     }) as Box<dyn FnMut()>);
 
-    let _ = btn.dyn_ref::<web_sys::EventTarget>()
+    let _ = btn
+        .dyn_ref::<web_sys::EventTarget>()
         .map(|t| t.add_event_listener_with_callback("click", cb.as_ref().unchecked_ref()));
     cb.forget();
 }
@@ -119,17 +148,25 @@ fn bind_dice_roll_button() {
 
 #[cfg(target_arch = "wasm32")]
 fn submit_intervention_from_input() {
-    let Some(doc) = web_sys::window().and_then(|w| w.document()) else { return };
-    let Some(el) = doc.get_element_by_id("action-input") else { return };
-    let Some(input) = el.dyn_ref::<web_sys::HtmlInputElement>() else { return };
+    let Some(doc) = web_sys::window().and_then(|w| w.document()) else {
+        return;
+    };
+    let Some(el) = doc.get_element_by_id("action-input") else {
+        return;
+    };
+    let Some(input) = el.dyn_ref::<web_sys::HtmlInputElement>() else {
+        return;
+    };
 
     let text = input.value().trim().to_string();
-    if text.is_empty() { return; }
-    
+    if text.is_empty() {
+        return;
+    }
+
     // We send this to the CURRENT ACTOR.
     // "I suggest you do this..."
     let actor_id_opt = get_active_actor_from_dom();
-    
+
     let Some(actor_id) = actor_id_opt else {
         set_action_status("No active agent to whisper to.", "status-error");
         return;
@@ -144,7 +181,10 @@ fn submit_intervention_from_input() {
             Ok(_) => set_action_status("Whisper sent. Waiting for agent...", "status-ok"),
             Err(e) => {
                 let detail = friendly_js_error(&e);
-                set_action_status(&format!("Failed to reach agent: {}", detail), "status-error");
+                set_action_status(
+                    &format!("Failed to reach agent: {}", detail),
+                    "status-error",
+                );
             }
         }
     });
@@ -178,7 +218,8 @@ async fn submit_intervention(actor_id: &str, suggestion: &str) -> Result<(), JsV
             }
         },
         "id": js_sys::Math::random().to_string()
-    }).to_string();
+    })
+    .to_string();
 
     let opts = web_sys::RequestInit::new();
     opts.set_method("POST");
@@ -188,7 +229,7 @@ async fn submit_intervention(actor_id: &str, suggestion: &str) -> Result<(), JsV
     let request = web_sys::Request::new_with_str_and_init(&url, &opts)?;
     request.headers().set("Content-Type", "application/json")?;
     // Streamable HTTP headers
-    request.headers().set("Accept", "application/json")?; 
+    request.headers().set("Accept", "application/json")?;
 
     let window = web_sys::window().ok_or_else(|| JsValue::from_str("no window"))?;
     let resp_value = JsFuture::from(window.fetch_with_request(&request)).await?;
@@ -196,7 +237,11 @@ async fn submit_intervention(actor_id: &str, suggestion: &str) -> Result<(), JsV
 
     if !resp.ok() {
         let err_body = JsFuture::from(resp.text()?).await?;
-        return Err(JsValue::from_str(&format!("RPC Error {}: {:?}", resp.status(), err_body.as_string())));
+        return Err(JsValue::from_str(&format!(
+            "RPC Error {}: {:?}",
+            resp.status(),
+            err_body.as_string()
+        )));
     }
 
     // We don't parse the full tool response here, just assume success if HTTP 200.
@@ -232,7 +277,8 @@ async fn roll_dice_intervention() -> Result<String, JsValue> {
             }
         },
         "id": js_sys::Math::random().to_string()
-    }).to_string();
+    })
+    .to_string();
 
     let opts = web_sys::RequestInit::new();
     opts.set_method("POST");
@@ -253,7 +299,10 @@ async fn roll_dice_intervention() -> Result<String, JsValue> {
 
     // Parse result to show something immediately?
     // Usually result is in `result.content[0].text`
-    let json_text = JsFuture::from(resp.text()?).await?.as_string().unwrap_or_default();
+    let json_text = JsFuture::from(resp.text()?)
+        .await?
+        .as_string()
+        .unwrap_or_default();
     Ok(parse_rpc_result(&json_text))
 }
 
@@ -289,7 +338,7 @@ fn clear_action_input() {
 fn set_action_status(text: &str, css_class: &str) {
     if let Some(doc) = web_sys::window().and_then(|w| w.document()) {
         if let Some(el) = doc.get_element_by_id("action-status") {
-            el.set_inner_html(text);
+            el.set_text_content(Some(text));
             el.set_class_name(css_class);
         }
     }
@@ -298,10 +347,7 @@ fn set_action_status(text: &str, css_class: &str) {
 #[cfg(target_arch = "wasm32")]
 pub(crate) fn friendly_js_error(val: &JsValue) -> String {
     val.as_string()
-        .or_else(|| {
-            val.dyn_ref::<js_sys::Error>()
-                .map(|e| e.message().into())
-        })
+        .or_else(|| val.dyn_ref::<js_sys::Error>().map(|e| e.message().into()))
         .unwrap_or_else(|| format!("{:?}", val))
 }
 
@@ -310,20 +356,32 @@ fn get_active_actor_from_dom() -> Option<String> {
     let doc = web_sys::window().and_then(|w| w.document())?;
     let panel = doc.get_element_by_id("action-panel")?;
     let actor_id = panel.get_attribute("data-active-actor").unwrap_or_default();
-    if actor_id.is_empty() { None } else { Some(actor_id) }
+    if actor_id.is_empty() {
+        None
+    } else {
+        Some(actor_id)
+    }
 }
 
 #[cfg(target_arch = "wasm32")]
 fn disable_buttons(disabled: bool) {
-    let Some(doc) = web_sys::window().and_then(|w| w.document()) else { return };
-    
+    let Some(doc) = web_sys::window().and_then(|w| w.document()) else {
+        return;
+    };
+
     if let Some(btn) = doc.get_element_by_id("action-submit-btn") {
-        if disabled { let _ = btn.set_attribute("disabled", "true"); }
-        else { let _ = btn.remove_attribute("disabled"); }
+        if disabled {
+            let _ = btn.set_attribute("disabled", "true");
+        } else {
+            let _ = btn.remove_attribute("disabled");
+        }
     }
     if let Some(btn) = doc.get_element_by_id("dice-roll-btn") {
-        if disabled { let _ = btn.set_attribute("disabled", "true"); }
-        else { let _ = btn.remove_attribute("disabled"); }
+        if disabled {
+            let _ = btn.set_attribute("disabled", "true");
+        } else {
+            let _ = btn.remove_attribute("disabled");
+        }
     }
 }
 
@@ -331,25 +389,30 @@ fn disable_buttons(disabled: bool) {
 
 #[allow(unused_variables)]
 pub fn sync_action_panel_interaction_state(
-    _room_state: Res<RoomState>,
+    room_state: Res<RoomState>,
     progress: Res<TurnProgressState>,
 ) {
+    let _ = &room_state;
     #[cfg(target_arch = "wasm32")]
     {
         let active_actor = &progress.current_actor;
-        let can_act = !active_actor.is_empty() && active_actor != "dm"; 
+        let lifecycle =
+            TrpgLifecycleState::from_room_progress(&room_state.status, &progress.room_status);
+        let can_act =
+            lifecycle.accepts_player_input() && !active_actor.is_empty() && active_actor != "dm";
 
         if let Some(doc) = web_sys::window().and_then(|w| w.document()) {
             if let Some(panel) = doc.get_element_by_id("action-panel") {
                 let _ = panel.set_attribute("data-active-actor", active_actor);
             }
-            
-            // Enable buttons if there's an actor (even if not strictly ours - we are Whisperers)
+
             disable_buttons(!can_act);
 
             if let Some(input) = doc.get_element_by_id("action-input") {
                 let placeholder = if can_act {
-                    format!("Whisper suggestion to {}...", active_actor) // Changed text
+                    format!("Whisper suggestion to {}...", active_actor)
+                } else if !lifecycle.accepts_player_input() {
+                    format!("{}...", lifecycle.help_text())
                 } else {
                     "Waiting for agent turn...".to_string()
                 };

--- a/viewer/src/dom/actor_join.rs
+++ b/viewer/src/dom/actor_join.rs
@@ -92,6 +92,10 @@ fn bind_join_button() {
         log::warn!("ActorJoin: #join-btn not found");
         return;
     };
+    if btn.get_attribute("data-bound").as_deref() == Some("1") {
+        return;
+    }
+    let _ = btn.set_attribute("data-bound", "1");
 
     let cb = Closure::wrap(Box::new(move || {
         let Some(doc) = web_sys::window().and_then(|w| w.document()) else {
@@ -162,6 +166,10 @@ fn bind_leave_button() {
         log::warn!("ActorJoin: #leave-btn not found");
         return;
     };
+    if btn.get_attribute("data-bound").as_deref() == Some("1") {
+        return;
+    }
+    let _ = btn.set_attribute("data-bound", "1");
 
     let cb = Closure::wrap(Box::new(move || {
         let Some(doc) = web_sys::window().and_then(|w| w.document()) else {
@@ -325,7 +333,7 @@ async fn release_actor(actor_id: &str) -> Result<(), JsValue> {
 fn set_join_status(text: &str, css_class: &str) {
     if let Some(doc) = web_sys::window().and_then(|w| w.document()) {
         if let Some(el) = doc.get_element_by_id("join-status") {
-            el.set_inner_html(text);
+            el.set_text_content(Some(text));
             el.set_class_name(css_class);
         }
     }
@@ -349,7 +357,7 @@ fn swap_to_action_panel(actor_id: &str) {
 
     // Update player info display
     if let Some(el) = doc.get_element_by_id("player-actor-id") {
-        el.set_inner_html(actor_id);
+        el.set_text_content(Some(actor_id));
     }
 
     // Store state in hidden inputs (for persistence across re-renders if needed)
@@ -374,7 +382,7 @@ fn swap_to_join_panel() {
 
     // Clear player info
     if let Some(el) = doc.get_element_by_id("player-actor-id") {
-        el.set_inner_html("");
+        el.set_text_content(Some(""));
     }
 
     // Clear state

--- a/viewer/src/dom/actor_lifecycle.rs
+++ b/viewer/src/dom/actor_lifecycle.rs
@@ -26,9 +26,15 @@ pub fn update_actor_lifecycle_dom(
         };
 
         for ActorSpawned(p) in spawns.read() {
-            let div = doc.create_element("div").expect("create div for actor-spawn");
+            let div = doc
+                .create_element("div")
+                .expect("create div for actor-spawn");
             div.set_class_name("narrative-entry actor-spawn");
-            let name = if p.name.is_empty() { &p.actor_id } else { &p.name };
+            let name = if p.name.is_empty() {
+                &p.actor_id
+            } else {
+                &p.name
+            };
             let class_info = if p.class.is_empty() {
                 String::new()
             } else {
@@ -43,9 +49,15 @@ pub fn update_actor_lifecycle_dom(
         }
 
         for ActorDeleted(p) in deletes.read() {
-            let div = doc.create_element("div").expect("create div for actor-delete");
+            let div = doc
+                .create_element("div")
+                .expect("create div for actor-delete");
             div.set_class_name("narrative-entry actor-delete");
-            let name = if p.name.is_empty() { &p.actor_id } else { &p.name };
+            let name = if p.name.is_empty() {
+                &p.actor_id
+            } else {
+                &p.name
+            };
             div.set_inner_html(&format!(
                 "<span class=\"actor-icon\">-</span> <strong>{}</strong> has left the adventure",
                 html_escape(name),
@@ -54,9 +66,15 @@ pub fn update_actor_lifecycle_dom(
         }
 
         for ActorClaimed(p) in claims.read() {
-            let div = doc.create_element("div").expect("create div for actor-claim");
+            let div = doc
+                .create_element("div")
+                .expect("create div for actor-claim");
             div.set_class_name("narrative-entry actor-claim");
-            let name = if p.name.is_empty() { &p.actor_id } else { &p.name };
+            let name = if p.name.is_empty() {
+                &p.actor_id
+            } else {
+                &p.name
+            };
             let keeper = if p.keeper.is_empty() {
                 "a keeper"
             } else {
@@ -71,9 +89,15 @@ pub fn update_actor_lifecycle_dom(
         }
 
         for ActorReleased(p) in releases.read() {
-            let div = doc.create_element("div").expect("create div for actor-release");
+            let div = doc
+                .create_element("div")
+                .expect("create div for actor-release");
             div.set_class_name("narrative-entry actor-release");
-            let name = if p.name.is_empty() { &p.actor_id } else { &p.name };
+            let name = if p.name.is_empty() {
+                &p.actor_id
+            } else {
+                &p.name
+            };
             div.set_inner_html(&format!(
                 "<span class=\"actor-icon\">&lt;</span> <strong>{}</strong> is now uncontrolled",
                 html_escape(name),
@@ -82,7 +106,9 @@ pub fn update_actor_lifecycle_dom(
         }
 
         for SceneTransitioned(p) in scenes.read() {
-            let div = doc.create_element("div").expect("create div for scene-transition");
+            let div = doc
+                .create_element("div")
+                .expect("create div for scene-transition");
             div.set_class_name("narrative-entry scene-transition");
             let desc = if p.description.is_empty() {
                 String::new()

--- a/viewer/src/dom/choice_panel.rs
+++ b/viewer/src/dom/choice_panel.rs
@@ -24,7 +24,9 @@ pub fn update_choice_dom(
         };
 
         for ChoiceAvailable(p) in choices.read() {
-            let Ok(div) = doc.create_element("div") else { continue };
+            let Ok(div) = doc.create_element("div") else {
+                continue;
+            };
             div.set_class_name("narrative-entry choice-block");
             let opts: String = p
                 .options
@@ -45,7 +47,9 @@ pub fn update_choice_dom(
         }
 
         for ChoiceResolved(p) in resolutions.read() {
-            let Ok(div) = doc.create_element("div") else { continue };
+            let Ok(div) = doc.create_element("div") else {
+                continue;
+            };
             div.set_class_name("narrative-entry choice-resolved");
             let text = format!("{} chose: {}", &p.character, &p.description);
             div.set_text_content(Some(&text));
@@ -55,7 +59,9 @@ pub fn update_choice_dom(
         }
 
         for CombatStarted(p) in combats.read() {
-            let Ok(div) = doc.create_element("div") else { continue };
+            let Ok(div) = doc.create_element("div") else {
+                continue;
+            };
             div.set_class_name("narrative-entry combat-block");
             let enemies = if p.enemies.is_empty() {
                 "???".to_string()
@@ -76,4 +82,3 @@ pub fn update_choice_dom(
     // Suppress unused-variable warnings on non-wasm targets
     let _ = (&mut choices, &mut resolutions, &mut combats);
 }
-

--- a/viewer/src/dom/dice_log.rs
+++ b/viewer/src/dom/dice_log.rs
@@ -50,7 +50,12 @@ pub fn update_dice_log_dom(mut events: MessageReader<DiceRolled>) {
         let note_html = payload
             .note
             .as_deref()
-            .map(|n| format!("<div class=\"dice-note\">{}</div>", html_escape(&sanitize_text(n))))
+            .map(|n| {
+                format!(
+                    "<div class=\"dice-note\">{}</div>",
+                    html_escape(&sanitize_text(n))
+                )
+            })
             .unwrap_or_default();
 
         entry.set_inner_html(&format!(

--- a/viewer/src/dom/endgame.rs
+++ b/viewer/src/dom/endgame.rs
@@ -86,7 +86,11 @@ fn show_endgame_overlay(message: &str, is_victory: bool) {
         };
         overlay.set_class_name(class);
 
-        let title = if is_victory { "임무 완료" } else { "전멸" };
+        let title = if is_victory {
+            "임무 완료"
+        } else {
+            "전멸"
+        };
 
         // Build inner HTML with safe text insertion for the message.
         // Title is a fixed Korean string (safe). Message uses set_text_content below.

--- a/viewer/src/dom/mod.rs
+++ b/viewer/src/dom/mod.rs
@@ -1,20 +1,20 @@
 pub mod action_panel;
 pub mod actor_join;
 pub mod actor_lifecycle;
-pub mod session_events;
 pub mod character_panel;
-pub mod session_history;
 pub mod choice_panel;
 pub mod connection;
-pub mod escape;
-pub mod gameplay_events;
 pub mod dice_log;
 pub mod endgame;
+pub mod escape;
+pub mod gameplay_events;
 pub mod narrative;
 pub mod overlay;
+pub mod session_events;
+pub mod session_history;
 pub mod turn_controls;
-pub mod turn_runtime;
 pub mod turn_phase;
+pub mod turn_runtime;
 
 use bevy::prelude::*;
 
@@ -31,7 +31,7 @@ impl Plugin for DomBridgePlugin {
     fn build(&self, app: &mut App) {
         app
             // DOM caches for change detection (inert when unused)
-        .init_resource::<character_panel::CharacterPanelCache>()
+            .init_resource::<character_panel::CharacterPanelCache>()
             .init_resource::<session_history::SessionHistoryCache>()
             .init_resource::<turn_phase::TurnPhaseCache>()
             .init_resource::<turn_runtime::TurnRuntimeCache>()
@@ -40,35 +40,45 @@ impl Plugin for DomBridgePlugin {
             .init_resource::<endgame::EndgameState>()
             .add_systems(OnEnter(ViewerMode::Trpg), reset_trpg_dom_state)
             // TRPG-specific DOM update systems
-            .add_systems(Update, (
-                narrative::update_narrative_dom,
-                dice_log::update_dice_log_dom,
-                session_history::update_session_history_dom,
-                character_panel::update_character_panel_dom,
-                choice_panel::update_choice_dom,
-                gameplay_events::update_gameplay_events_dom,
-                turn_phase::update_turn_phase_dom,
-                turn_runtime::update_turn_runtime_dom,
-                connection::update_connection_dom,
-                actor_join::sync_join_panel_interaction_state,
-                action_panel::sync_action_panel_interaction_state,
-                turn_controls::sync_turn_controls_visibility,
-                overlay::update_overlay_dom,
-                actor_lifecycle::update_actor_lifecycle_dom,
-                session_events::update_session_events_dom,
-            ).run_if(in_state(ViewerMode::Trpg)))
+            .add_systems(
+                Update,
+                (
+                    narrative::update_narrative_dom,
+                    dice_log::update_dice_log_dom,
+                    session_history::update_session_history_dom,
+                    character_panel::update_character_panel_dom,
+                    choice_panel::update_choice_dom,
+                    gameplay_events::update_gameplay_events_dom,
+                    turn_phase::update_turn_phase_dom,
+                    turn_runtime::update_turn_runtime_dom,
+                    connection::update_connection_dom,
+                    actor_join::sync_join_panel_interaction_state,
+                    action_panel::sync_action_panel_interaction_state,
+                    turn_controls::sync_turn_controls_visibility,
+                    overlay::update_overlay_dom,
+                    actor_lifecycle::update_actor_lifecycle_dom,
+                    session_events::update_session_events_dom,
+                )
+                    .run_if(in_state(ViewerMode::Trpg)),
+            )
             // Action panel lifecycle: bind listeners on enter, unbind on exit
-            .add_systems(OnEnter(ViewerMode::Trpg), (
-                action_panel::bind_action_panel,
-                action_panel::sync_action_panel_interaction_state,
-                actor_join::bind_actor_join,
-                turn_controls::bind_turn_controls,
-            ))
-            .add_systems(OnExit(ViewerMode::Trpg), (
-                action_panel::unbind_action_panel,
-                actor_join::unbind_actor_join,
-                turn_controls::unbind_turn_controls,
-            ));
+            .add_systems(
+                OnEnter(ViewerMode::Trpg),
+                (
+                    action_panel::bind_action_panel,
+                    action_panel::sync_action_panel_interaction_state,
+                    actor_join::bind_actor_join,
+                    turn_controls::bind_turn_controls,
+                ),
+            )
+            .add_systems(
+                OnExit(ViewerMode::Trpg),
+                (
+                    action_panel::unbind_action_panel,
+                    actor_join::unbind_actor_join,
+                    turn_controls::unbind_turn_controls,
+                ),
+            );
     }
 }
 

--- a/viewer/src/dom/narrative.rs
+++ b/viewer/src/dom/narrative.rs
@@ -94,10 +94,7 @@ fn bump_dedup_narrative(document: &web_sys::Document, sample: &str) {
     let _ = dashboard.set_attribute("data-dedup-samples-narrative", &lines.join("\n"));
 }
 
-fn is_duplicate_narrative_entry(
-    log_el: &web_sys::Element,
-    dedup_key: &str,
-) -> bool {
+fn is_duplicate_narrative_entry(log_el: &web_sys::Element, dedup_key: &str) -> bool {
     let mut scanned = 0_u32;
     let mut cursor = log_el.last_element_child();
     while scanned < 40 {

--- a/viewer/src/dom/session_events.rs
+++ b/viewer/src/dom/session_events.rs
@@ -1,11 +1,10 @@
-use bevy::prelude::*;
-use crate::game::events::{
-    InterventionApplied, InterventionSubmitted, KeeperUnavailable,
-    PartySelected, PhaseChanged, RoomCreated, RoomStarted,
-    SessionStarted, TurnActionResolved, TurnStarted,
-};
 #[cfg(target_arch = "wasm32")]
 use crate::dom::escape::html_escape;
+use crate::game::events::{
+    InterventionApplied, InterventionSubmitted, KeeperUnavailable, PartySelected, PhaseChanged,
+    RoomCreated, RoomStarted, SessionStarted, TurnActionResolved, TurnStarted,
+};
+use bevy::prelude::*;
 
 #[allow(clippy::too_many_arguments)]
 pub fn update_session_events_dom(
@@ -35,52 +34,113 @@ pub fn update_session_events_dom(
             let ids = if p.selected_player_ids.is_empty() {
                 "...".to_string()
             } else {
-                p.selected_player_ids.iter()
+                p.selected_player_ids
+                    .iter()
                     .map(|id| html_escape(id))
                     .collect::<Vec<_>>()
                     .join(", ")
             };
-            append_entry(&doc, &log, "session-event",
-                &format!("<span class=\"session-icon\">\u{25cb}</span> Party formed: {}", ids));
+            append_entry(
+                &doc,
+                &log,
+                "session-event",
+                &format!(
+                    "<span class=\"session-icon\">\u{25cb}</span> Party formed: {}",
+                    ids
+                ),
+            );
         }
 
         for RoomCreated(p) in room_created.read() {
-            let preset = if p.preset.is_empty() { "default" } else { &p.preset };
-            append_entry(&doc, &log, "session-event",
-                &format!("<span class=\"session-icon\">\u{25cb}</span> Room created ({})",
-                    html_escape(preset)));
+            let preset = if p.preset.is_empty() {
+                "default"
+            } else {
+                &p.preset
+            };
+            append_entry(
+                &doc,
+                &log,
+                "session-event",
+                &format!(
+                    "<span class=\"session-icon\">\u{25cb}</span> Room created ({})",
+                    html_escape(preset)
+                ),
+            );
         }
 
         for RoomStarted(p) in room_started.read() {
-            let status = if p.status.is_empty() { "started" } else { &p.status };
-            append_entry(&doc, &log, "session-event session-start",
-                &format!("<span class=\"session-icon\">\u{25b6}</span> Adventure {} \u{2014} {}",
-                    html_escape(status), html_escape(&p.room_id)));
+            let status = if p.status.is_empty() {
+                "started"
+            } else {
+                &p.status
+            };
+            append_entry(
+                &doc,
+                &log,
+                "session-event session-start",
+                &format!(
+                    "<span class=\"session-icon\">\u{25b6}</span> Adventure {} \u{2014} {}",
+                    html_escape(status),
+                    html_escape(&p.room_id)
+                ),
+            );
         }
 
         for SessionStarted(p) in session_started.read() {
-            let sid = if p.session_id.is_empty() { "?" } else { &p.session_id };
-            append_entry(&doc, &log, "session-event",
-                &format!("<span class=\"session-icon\">\u{25cb}</span> Session: {}",
-                    html_escape(sid)));
+            let sid = if p.session_id.is_empty() {
+                "?"
+            } else {
+                &p.session_id
+            };
+            append_entry(
+                &doc,
+                &log,
+                "session-event",
+                &format!(
+                    "<span class=\"session-icon\">\u{25cb}</span> Session: {}",
+                    html_escape(sid)
+                ),
+            );
         }
 
         for PhaseChanged(p) in phase_changed.read() {
-            append_entry(&doc, &log, "turn-event",
-                &format!("<span class=\"turn-icon\">\u{25c6}</span> Phase \u{2192} {} (Turn {})",
-                    html_escape(&p.phase), p.turn));
+            append_entry(
+                &doc,
+                &log,
+                "turn-event",
+                &format!(
+                    "<span class=\"turn-icon\">\u{25c6}</span> Phase \u{2192} {} (Turn {})",
+                    html_escape(&p.phase),
+                    p.turn
+                ),
+            );
         }
 
         for TurnStarted(p) in turn_started.read() {
-            append_entry(&doc, &log, "turn-event turn-start",
-                &format!("<span class=\"turn-icon\">\u{25c6}</span> Turn {} begins \u{2014} {}",
-                    p.turn, html_escape(&p.phase)));
+            append_entry(
+                &doc,
+                &log,
+                "turn-event turn-start",
+                &format!(
+                    "<span class=\"turn-icon\">\u{25c6}</span> Turn {} begins \u{2014} {}",
+                    p.turn,
+                    html_escape(&p.phase)
+                ),
+            );
         }
 
         for TurnActionResolved(p) in action_resolved.read() {
-            append_entry(&doc, &log, "action-result",
-                &format!("<span class=\"action-icon\">\u{2713}</span> {} performed {} \u{2192} {}",
-                    html_escape(&p.actor_id), html_escape(&p.action), html_escape(&p.result)));
+            append_entry(
+                &doc,
+                &log,
+                "action-result",
+                &format!(
+                    "<span class=\"action-icon\">\u{2713}</span> {} performed {} \u{2192} {}",
+                    html_escape(&p.actor_id),
+                    html_escape(&p.action),
+                    html_escape(&p.result)
+                ),
+            );
         }
 
         for InterventionSubmitted(p) in intervention_sub.read() {
@@ -94,15 +154,29 @@ pub fn update_session_events_dom(
 
         for InterventionApplied(p) in intervention_app.read() {
             let target = if p.target.is_empty() { "" } else { &p.target };
-            append_entry(&doc, &log, "intervention-event intervention-applied",
-                &format!("<span class=\"intervention-icon\">\u{2691}</span> Applied: {} {} \u{2014} {}",
+            append_entry(
+                &doc,
+                &log,
+                "intervention-event intervention-applied",
+                &format!(
+                    "<span class=\"intervention-icon\">\u{2691}</span> Applied: {} {} \u{2014} {}",
                     html_escape(&p.intervention_type),
-                    if target.is_empty() { String::new() } else { format!("\u{2192} {}", html_escape(target)) },
-                    html_escape(&p.description)));
+                    if target.is_empty() {
+                        String::new()
+                    } else {
+                        format!("\u{2192} {}", html_escape(target))
+                    },
+                    html_escape(&p.description)
+                ),
+            );
         }
 
         for KeeperUnavailable(p) in keeper_unavail.read() {
-            let reason = if p.reason.is_empty() { "no reason given" } else { &p.reason };
+            let reason = if p.reason.is_empty() {
+                "no reason given"
+            } else {
+                &p.reason
+            };
             append_entry(&doc, &log, "keeper-warning",
                 &format!("<span class=\"warning-icon\">\u{26a0}</span> Keeper {} unavailable \u{2014} {}",
                     html_escape(&p.keeper), html_escape(reason)));
@@ -110,18 +184,22 @@ pub fn update_session_events_dom(
     }
 
     // Suppress unused-variable warnings on non-wasm targets
-    let _ = (&mut party, &mut room_created, &mut room_started, &mut session_started,
-             &mut phase_changed, &mut turn_started, &mut action_resolved,
-             &mut intervention_sub, &mut intervention_app, &mut keeper_unavail);
+    let _ = (
+        &mut party,
+        &mut room_created,
+        &mut room_started,
+        &mut session_started,
+        &mut phase_changed,
+        &mut turn_started,
+        &mut action_resolved,
+        &mut intervention_sub,
+        &mut intervention_app,
+        &mut keeper_unavail,
+    );
 }
 
 #[cfg(target_arch = "wasm32")]
-fn append_entry(
-    doc: &web_sys::Document,
-    log: &web_sys::Element,
-    class: &str,
-    inner_html: &str,
-) {
+fn append_entry(doc: &web_sys::Document, log: &web_sys::Element, class: &str, inner_html: &str) {
     if let Ok(div) = doc.create_element("div") {
         div.set_class_name(&format!("narrative-entry {}", class));
         div.set_inner_html(inner_html);

--- a/viewer/src/dom/session_history.rs
+++ b/viewer/src/dom/session_history.rs
@@ -123,7 +123,9 @@ fn append_event(
     true
 }
 
-fn label_progress_event(payload: &crate::game::events::TurnProgressPayload) -> (&'static str, String, String) {
+fn label_progress_event(
+    payload: &crate::game::events::TurnProgressPayload,
+) -> (&'static str, String, String) {
     let actor = payload.actor_id.trim();
     let label = match payload.event_type.as_str() {
         "turn.started" => "턴 시작",
@@ -177,7 +179,8 @@ fn label_progress_event(payload: &crate::game::events::TurnProgressPayload) -> (
 #[cfg(target_arch = "wasm32")]
 fn render_session_history_html(turns: &[TurnHistory]) -> String {
     if turns.is_empty() {
-        return "<div class=\"session-history-empty\">아직 세션 히스토리가 없습니다.</div>".to_string();
+        return "<div class=\"session-history-empty\">아직 세션 히스토리가 없습니다.</div>"
+            .to_string();
     }
 
     let turn_chips = turns
@@ -404,7 +407,9 @@ fn apply_history_focus(document: &web_sys::Document, turn: Option<u32>, kind: Op
             continue;
         };
         for idx in 0..nodes.length() {
-            let Some(node) = nodes.item(idx) else { continue };
+            let Some(node) = nodes.item(idx) else {
+                continue;
+            };
             let Some(el) = node.dyn_ref::<web_sys::Element>() else {
                 continue;
             };
@@ -431,7 +436,9 @@ fn apply_history_focus(document: &web_sys::Document, turn: Option<u32>, kind: Op
 
     if let Ok(chips) = document.query_selector_all("#session-history .history-turn-chip") {
         for idx in 0..chips.length() {
-            let Some(node) = chips.item(idx) else { continue };
+            let Some(node) = chips.item(idx) else {
+                continue;
+            };
             let Some(el) = node.dyn_ref::<web_sys::Element>() else {
                 continue;
             };
@@ -450,7 +457,9 @@ fn apply_history_focus(document: &web_sys::Document, turn: Option<u32>, kind: Op
 
     if let Ok(chips) = document.query_selector_all("#session-history .history-kind-chip") {
         for idx in 0..chips.length() {
-            let Some(node) = chips.item(idx) else { continue };
+            let Some(node) = chips.item(idx) else {
+                continue;
+            };
             let Some(el) = node.dyn_ref::<web_sys::Element>() else {
                 continue;
             };
@@ -473,7 +482,9 @@ fn apply_history_focus(document: &web_sys::Document, turn: Option<u32>, kind: Op
 
     if let Ok(nodes) = document.query_selector_all("#session-history .history-event") {
         for idx in 0..nodes.length() {
-            let Some(node) = nodes.item(idx) else { continue };
+            let Some(node) = nodes.item(idx) else {
+                continue;
+            };
             let Some(el) = node.dyn_ref::<web_sys::Element>() else {
                 continue;
             };
@@ -496,7 +507,9 @@ fn apply_history_focus(document: &web_sys::Document, turn: Option<u32>, kind: Op
 
     if let Ok(nodes) = document.query_selector_all("#session-history .history-turn") {
         for idx in 0..nodes.length() {
-            let Some(node) = nodes.item(idx) else { continue };
+            let Some(node) = nodes.item(idx) else {
+                continue;
+            };
             let Some(el) = node.dyn_ref::<web_sys::Element>() else {
                 continue;
             };
@@ -520,7 +533,9 @@ fn apply_history_focus(document: &web_sys::Document, turn: Option<u32>, kind: Op
 fn bind_history_focus_controls(document: &web_sys::Document) {
     if let Ok(chips) = document.query_selector_all("#session-history .history-turn-chip") {
         for idx in 0..chips.length() {
-            let Some(node) = chips.item(idx) else { continue };
+            let Some(node) = chips.item(idx) else {
+                continue;
+            };
             let Some(el) = node.dyn_ref::<web_sys::Element>() else {
                 continue;
             };
@@ -548,7 +563,9 @@ fn bind_history_focus_controls(document: &web_sys::Document) {
 
     if let Ok(chips) = document.query_selector_all("#session-history .history-kind-chip") {
         for idx in 0..chips.length() {
-            let Some(node) = chips.item(idx) else { continue };
+            let Some(node) = chips.item(idx) else {
+                continue;
+            };
             let Some(el) = node.dyn_ref::<web_sys::Element>() else {
                 continue;
             };
@@ -677,7 +694,15 @@ pub fn update_session_history_dom(
                 "turn",
                 "",
                 "턴 진행",
-                &format!("Turn {} ({})", current_turn, if current_phase.is_empty() { "-" } else { &current_phase }),
+                &format!(
+                    "Turn {} ({})",
+                    current_turn,
+                    if current_phase.is_empty() {
+                        "-"
+                    } else {
+                        &current_phase
+                    }
+                ),
             );
             if !appended {
                 bump_dedup_history(
@@ -701,18 +726,18 @@ pub fn update_session_history_dom(
             if !appended {
                 bump_dedup_history(
                     &document,
-                    &format!(
-                        "t{} | narrative | {}",
-                        current_turn,
-                        event.text.trim()
-                    ),
+                    &format!("t{} | narrative | {}", current_turn, event.text.trim()),
                 );
             }
             changed = true;
         }
 
         for DiceRolled(payload) in dice_events.read() {
-            let turn = if payload.turn > 0 { payload.turn } else { current_turn };
+            let turn = if payload.turn > 0 {
+                payload.turn
+            } else {
+                current_turn
+            };
             if turn > 0 {
                 current_turn = turn;
             }
@@ -738,9 +763,7 @@ pub fn update_session_history_dom(
                     &document,
                     &format!(
                         "t{} | dice | {}:{}",
-                        current_turn,
-                        payload.character,
-                        payload.action
+                        current_turn, payload.character, payload.action
                     ),
                 );
             }
@@ -761,17 +784,17 @@ pub fn update_session_history_dom(
                 &current_phase,
                 kind,
                 &actor,
-                if summary.is_empty() { "turn progress" } else { &summary },
+                if summary.is_empty() {
+                    "turn progress"
+                } else {
+                    &summary
+                },
                 &event.event_type,
             );
             if !appended {
                 bump_dedup_history(
                     &document,
-                    &format!(
-                        "t{} | progress | {}",
-                        current_turn,
-                        event.event_type
-                    ),
+                    &format!("t{} | progress | {}", current_turn, event.event_type),
                 );
             }
             changed = true;

--- a/viewer/src/dom/turn_controls.rs
+++ b/viewer/src/dom/turn_controls.rs
@@ -21,9 +21,51 @@ use wasm_bindgen::prelude::*;
 
 #[cfg(target_arch = "wasm32")]
 use crate::config;
-use crate::game::state::{RoomState, TurnProgressState};
-#[cfg(target_arch = "wasm32")]
 use crate::game::lifecycle::TrpgLifecycleState;
+use crate::game::state::{ConnectionStatus, RoomState, TurnProgressState};
+
+fn connection_ready(status: &ConnectionStatus) -> bool {
+    matches!(status, ConnectionStatus::Connected)
+}
+
+fn derive_round_control_state(
+    lifecycle: TrpgLifecycleState,
+    connection_ok: bool,
+    plan_error: Option<&str>,
+) -> (bool, String, &'static str) {
+    if !lifecycle.allows_round_control() {
+        return (
+            false,
+            format!("실행 대기: {}", lifecycle.help_text()),
+            "status-info",
+        );
+    }
+    if !connection_ok {
+        return (
+            false,
+            "실행 대기: 엔진 연결이 완료될 때까지 기다려주세요.".to_string(),
+            "status-info",
+        );
+    }
+    if let Some(err) = plan_error {
+        return (false, format!("준비 필요: {}", err), "status-warn");
+    }
+    (true, "라운드 실행 가능".to_string(), "status-ok")
+}
+
+#[cfg(target_arch = "wasm32")]
+fn control_status_to_ops_class(css_class: &str) -> &'static str {
+    match css_class {
+        "status-ok" => "status-active",
+        "status-warn" => "status-warn",
+        "status-error" => "status-error",
+        _ => "status-idle",
+    }
+}
+
+fn round_advanced(turn_before: u64, turn_after: u64, summary_advanced: Option<bool>) -> bool {
+    summary_advanced.unwrap_or(turn_after > turn_before)
+}
 
 // ─── Marker Resource ────────────────────────
 
@@ -37,6 +79,9 @@ pub fn bind_turn_controls(mut commands: Commands) {
     #[cfg(target_arch = "wasm32")]
     {
         bind_advance_button();
+        bind_recovery_button();
+        bind_recovery_action_buttons();
+        clear_round_recovery();
         set_turn_status("라운드 실행 준비 중...", "status-info");
         log::info!("TurnControls: bound");
     }
@@ -48,6 +93,7 @@ pub fn unbind_turn_controls(mut commands: Commands) {
     #[cfg(target_arch = "wasm32")]
     {
         clear_turn_status();
+        clear_round_recovery();
         log::info!("TurnControls: unbound");
     }
 
@@ -57,14 +103,19 @@ pub fn unbind_turn_controls(mut commands: Commands) {
 // ─── Visibility Sync ────────────────────────
 
 /// Show turn controls only when a round-run capable assignment exists.
-pub fn sync_turn_controls_visibility(room_state: Res<RoomState>, progress: Res<TurnProgressState>) {
+pub fn sync_turn_controls_visibility(
+    room_state: Res<RoomState>,
+    progress: Res<TurnProgressState>,
+    connection: Res<ConnectionStatus>,
+) {
     let _ = (&room_state, &progress);
+    let _ = &connection;
 
     #[cfg(target_arch = "wasm32")]
     {
         let lifecycle =
             TrpgLifecycleState::from_room_progress(&room_state.status, &progress.room_status);
-        let room_allows_control = lifecycle.allows_round_control();
+        let connection_ok = connection_ready(&connection);
 
         let Some(doc) = web_sys::window().and_then(|w| w.document()) else {
             return;
@@ -75,20 +126,9 @@ pub fn sync_turn_controls_visibility(room_state: Res<RoomState>, progress: Res<T
         let _ = panel.set_attribute("style", "");
         let _ = panel.set_attribute("data-lifecycle", lifecycle.css_class());
 
-        let plan = read_round_run_plan(&doc);
-        let can_run = room_allows_control && plan.is_ok();
-        let reason = if !room_allows_control {
-            format!("실행 대기: {}", lifecycle.help_text())
-        } else {
-            match plan {
-                Ok(ref row) => format!(
-                    "라운드 실행 가능 · DM {} · players {}명",
-                    row.dm_keeper,
-                    row.player_keepers.len()
-                ),
-                Err(ref err) => format!("준비 필요: {}", err),
-            }
-        };
+        let plan_error = read_round_run_plan(&doc).err();
+        let (can_run, reason, reason_class) =
+            derive_round_control_state(lifecycle, connection_ok, plan_error.as_deref());
 
         let busy = doc
             .get_element_by_id("advance-turn-btn")
@@ -96,15 +136,18 @@ pub fn sync_turn_controls_visibility(room_state: Res<RoomState>, progress: Res<T
             .and_then(|btn| btn.get_attribute("data-busy"))
             .is_some_and(|v| v == "1");
 
+        if let Some(btn) = doc
+            .get_element_by_id("advance-turn-btn")
+            .and_then(|el| el.dyn_into::<HtmlButtonElement>().ok())
+        {
+            let _ = btn.set_attribute("data-can-run", if can_run { "1" } else { "0" });
+            let _ = btn.set_attribute("data-gate-reason", &reason);
+            btn.set_title(&reason);
+        }
+
         if !busy {
             set_advance_disabled(!can_run);
-            if can_run {
-                set_turn_status(&reason, "status-ok");
-            } else if room_allows_control {
-                set_turn_status(&reason, "status-warn");
-            } else {
-                set_turn_status(&reason, "status-info");
-            }
+            set_turn_status(&reason, reason_class);
         }
     }
 }
@@ -119,6 +162,10 @@ fn bind_advance_button() {
     let Some(btn) = doc.get_element_by_id("advance-turn-btn") else {
         return;
     };
+    if btn.get_attribute("data-bound").as_deref() == Some("1") {
+        return;
+    }
+    let _ = btn.set_attribute("data-bound", "1");
 
     let cb = Closure::wrap(Box::new(move || {
         on_advance_click();
@@ -133,20 +180,36 @@ fn on_advance_click() {
     let Some(doc) = web_sys::window().and_then(|w| w.document()) else {
         return;
     };
+    if is_advance_busy(&doc) {
+        return;
+    }
+    if let Err(reason) = read_advance_gate(&doc) {
+        set_turn_status(&format!("실행 불가: {}", reason), "status-warn");
+        return;
+    }
     if let Err(reason) = read_round_run_plan(&doc) {
         set_turn_status(&format!("실행 불가: {}", reason), "status-warn");
         return;
     }
 
+    clear_round_recovery();
     set_turn_status("라운드 실행 중...", "status-info");
     set_advance_busy(true);
 
     wasm_bindgen_futures::spawn_local(async move {
         match advance_turn().await {
-            Ok(msg) => set_turn_status(&msg, "status-ok"),
+            Ok(RoundRunOutcome::Advanced(msg)) => {
+                clear_round_recovery();
+                set_turn_status(&msg, "status-ok");
+            }
+            Ok(RoundRunOutcome::Stalled { status, guide }) => {
+                set_round_recovery(Some(&guide));
+                set_turn_status(&status, "status-warn");
+            }
             Err(e) => {
                 let detail = e.as_string().unwrap_or_else(|| format!("{:?}", e));
                 log::warn!("Advance turn failed: {}", detail);
+                clear_round_recovery();
                 set_turn_status(&format!("Failed: {}", detail), "status-error");
             }
         }
@@ -157,7 +220,133 @@ fn on_advance_click() {
 // ─── HTTP: Advance Turn ─────────────────────
 
 #[cfg(target_arch = "wasm32")]
-async fn advance_turn() -> Result<String, JsValue> {
+enum RoundRunOutcome {
+    Advanced(String),
+    Stalled { status: String, guide: String },
+}
+
+#[cfg(target_arch = "wasm32")]
+fn shorten_reason(raw: &str, max_chars: usize) -> String {
+    let text = raw.trim().replace('\n', " ");
+    if text.chars().count() <= max_chars {
+        return text;
+    }
+    let mut truncated = text
+        .chars()
+        .take(max_chars.saturating_sub(1))
+        .collect::<String>();
+    truncated.push('…');
+    truncated
+}
+
+#[cfg(target_arch = "wasm32")]
+fn collect_stall_reasons(json: &Value) -> Vec<String> {
+    let mut rows = Vec::new();
+    let Some(statuses) = json.get("statuses").and_then(Value::as_array) else {
+        return rows;
+    };
+
+    for status in statuses {
+        let status_name = status
+            .get("status")
+            .and_then(Value::as_str)
+            .unwrap_or_default()
+            .trim();
+        if status_name.is_empty() || status_name.eq_ignore_ascii_case("ok") {
+            continue;
+        }
+        let actor_id = status
+            .get("actor_id")
+            .and_then(Value::as_str)
+            .unwrap_or("-")
+            .trim();
+        let keeper = status
+            .get("keeper")
+            .and_then(Value::as_str)
+            .unwrap_or("-")
+            .trim();
+        let stage = status
+            .get("stage")
+            .and_then(Value::as_str)
+            .unwrap_or("")
+            .trim();
+        let reason = status
+            .get("reason")
+            .or_else(|| status.get("error"))
+            .or_else(|| status.get("reply"))
+            .and_then(Value::as_str)
+            .unwrap_or("")
+            .trim();
+
+        let mut row = format!(
+            "{}({})={} @{}",
+            actor_id,
+            keeper,
+            status_name,
+            if stage.is_empty() { "-" } else { stage }
+        );
+        if !reason.is_empty() {
+            row.push_str(&format!(" · {}", shorten_reason(reason, 90)));
+        }
+        rows.push(row);
+        if rows.len() >= 3 {
+            break;
+        }
+    }
+    rows
+}
+
+#[cfg(target_arch = "wasm32")]
+fn build_stalled_round_guide(json: &Value, turn_before: u64, turn_after: u64) -> String {
+    let summary = json.get("summary");
+    let successes = summary
+        .and_then(|s| s.get("successes"))
+        .and_then(Value::as_u64)
+        .unwrap_or(0);
+    let player_successes = summary
+        .and_then(|s| s.get("player_successes"))
+        .and_then(Value::as_u64)
+        .unwrap_or(0);
+    let dm_success = summary
+        .and_then(|s| s.get("dm_success"))
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
+    let timeouts = summary
+        .and_then(|s| s.get("timeouts"))
+        .and_then(Value::as_u64)
+        .unwrap_or(0);
+    let unavailable = summary
+        .and_then(|s| s.get("unavailable"))
+        .and_then(Value::as_u64)
+        .unwrap_or(0);
+
+    let mut lines = vec![
+        format!(
+            "턴 미진행: {} -> {} (라운드 응답은 성공)",
+            turn_before, turn_after
+        ),
+        format!(
+            "요약: success {} / player {} / dm {} / timeout {} / unavailable {}",
+            successes,
+            player_successes,
+            if dm_success { "ok" } else { "fail" },
+            timeouts,
+            unavailable
+        ),
+    ];
+    let reasons = collect_stall_reasons(json);
+    if !reasons.is_empty() {
+        lines.push(format!("차단 원인: {}", reasons.join(" | ")));
+    }
+    lines.push(
+        "권장 조치: 1) keeper 상태 확인 2) actor=keeper 할당/중복 확인 3) timeout 늘려 재실행"
+            .to_string(),
+    );
+    lines.join("\n")
+}
+
+#[cfg(target_arch = "wasm32")]
+async fn advance_turn() -> Result<RoundRunOutcome, JsValue> {
     use wasm_bindgen_futures::JsFuture;
 
     let doc = web_sys::window()
@@ -221,15 +410,28 @@ async fn advance_turn() -> Result<String, JsValue> {
     if let Ok(json) = serde_json::from_str::<Value>(&resp_text) {
         let turn_before = json.get("turn_before").and_then(Value::as_u64).unwrap_or(0);
         let turn_after = json.get("turn_after").and_then(Value::as_u64).unwrap_or(0);
-        if turn_after > 0 {
-            return Ok(format!(
+        let summary_advanced = json
+            .get("summary")
+            .and_then(|summary| summary.get("advanced"))
+            .and_then(Value::as_bool);
+        if round_advanced(turn_before, turn_after, summary_advanced) {
+            return Ok(RoundRunOutcome::Advanced(format!(
                 "Round progressed: turn {} → {}",
                 turn_before, turn_after
-            ));
+            )));
         }
+        let stalled_status = format!(
+            "턴이 진행되지 않았습니다 ({} → {}).",
+            turn_before, turn_after
+        );
+        let guide = build_stalled_round_guide(&json, turn_before, turn_after);
+        return Ok(RoundRunOutcome::Stalled {
+            status: stalled_status,
+            guide,
+        });
     }
 
-    Ok("Turn advanced.".to_string())
+    Ok(RoundRunOutcome::Advanced("Turn advanced.".to_string()))
 }
 
 // ─── DOM Helpers ─────────────────────────────
@@ -243,11 +445,203 @@ fn set_turn_status(text: &str, css_class: &str) {
         el.set_text_content(Some(text));
         let _ = el.set_attribute("class", css_class);
     }
+    if let Some(el) = doc.get_element_by_id("ops-control-state") {
+        let class_name = format!("ops-v {}", control_status_to_ops_class(css_class));
+        el.set_text_content(Some(text));
+        let _ = el.set_attribute("class", &class_name);
+        let _ = el.set_attribute("title", text);
+    }
 }
 
 #[cfg(target_arch = "wasm32")]
 fn clear_turn_status() {
     set_turn_status("", "");
+}
+
+#[cfg(target_arch = "wasm32")]
+fn bind_recovery_button() {
+    let Some(doc) = web_sys::window().and_then(|w| w.document()) else {
+        return;
+    };
+    let Some(btn) = doc.get_element_by_id("round-recovery-btn") else {
+        return;
+    };
+    if btn.get_attribute("data-bound").as_deref() == Some("1") {
+        return;
+    }
+    let _ = btn.set_attribute("data-bound", "1");
+
+    let cb = Closure::wrap(Box::new(move || {
+        toggle_round_recovery();
+    }) as Box<dyn Fn()>);
+    let _ = btn.add_event_listener_with_callback("click", cb.as_ref().unchecked_ref());
+    cb.forget();
+}
+
+#[cfg(target_arch = "wasm32")]
+fn bind_recovery_action_buttons() {
+    let Some(doc) = web_sys::window().and_then(|w| w.document()) else {
+        return;
+    };
+
+    if let Some(btn) = doc.get_element_by_id("round-recovery-refresh") {
+        if btn.get_attribute("data-bound").as_deref() != Some("1") {
+            let _ = btn.set_attribute("data-bound", "1");
+            let cb = Closure::wrap(Box::new(move || {
+                let Some(doc) = web_sys::window().and_then(|w| w.document()) else {
+                    return;
+                };
+                if let Some(refresh_btn) = doc
+                    .get_element_by_id("new-game-refresh")
+                    .and_then(|el| el.dyn_into::<HtmlButtonElement>().ok())
+                {
+                    refresh_btn.click();
+                    set_turn_status("복구 액션: Keeper 새로고침 요청", "status-info");
+                } else {
+                    set_turn_status(
+                        "복구 액션 실패: 새로고침 버튼을 찾지 못했습니다.",
+                        "status-error",
+                    );
+                }
+            }) as Box<dyn Fn()>);
+            let _ = btn.add_event_listener_with_callback("click", cb.as_ref().unchecked_ref());
+            cb.forget();
+        }
+    }
+
+    if let Some(btn) = doc.get_element_by_id("round-recovery-timeout") {
+        if btn.get_attribute("data-bound").as_deref() != Some("1") {
+            let _ = btn.set_attribute("data-bound", "1");
+            let cb = Closure::wrap(Box::new(move || {
+                let Some(doc) = web_sys::window().and_then(|w| w.document()) else {
+                    return;
+                };
+                let current = read_dom_input(&doc, "round-run-timeout")
+                    .and_then(|raw| raw.parse::<f64>().ok())
+                    .filter(|value| *value > 0.0)
+                    .unwrap_or(90.0);
+                let next = (current + 30.0).min(600.0);
+                if let Some(input) = doc
+                    .get_element_by_id("round-run-timeout")
+                    .and_then(|el| el.dyn_into::<HtmlInputElement>().ok())
+                {
+                    input.set_value(&format!("{:.0}", next));
+                    set_turn_status(
+                        &format!("복구 액션: timeout {:.0}s → {:.0}s", current, next),
+                        "status-info",
+                    );
+                } else {
+                    set_turn_status(
+                        "복구 액션 실패: timeout 필드를 찾지 못했습니다.",
+                        "status-error",
+                    );
+                }
+            }) as Box<dyn Fn()>);
+            let _ = btn.add_event_listener_with_callback("click", cb.as_ref().unchecked_ref());
+            cb.forget();
+        }
+    }
+
+    if let Some(btn) = doc.get_element_by_id("round-recovery-retry") {
+        if btn.get_attribute("data-bound").as_deref() != Some("1") {
+            let _ = btn.set_attribute("data-bound", "1");
+            let cb = Closure::wrap(Box::new(move || {
+                let Some(doc) = web_sys::window().and_then(|w| w.document()) else {
+                    return;
+                };
+                if is_advance_busy(&doc) {
+                    return;
+                }
+                on_advance_click();
+            }) as Box<dyn Fn()>);
+            let _ = btn.add_event_listener_with_callback("click", cb.as_ref().unchecked_ref());
+            cb.forget();
+        }
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+fn toggle_round_recovery() {
+    let Some(doc) = web_sys::window().and_then(|w| w.document()) else {
+        return;
+    };
+    let Some(btn) = doc
+        .get_element_by_id("round-recovery-btn")
+        .and_then(|el| el.dyn_into::<HtmlButtonElement>().ok())
+    else {
+        return;
+    };
+    let Some(note) = doc.get_element_by_id("round-recovery-note") else {
+        return;
+    };
+    let is_open = btn.get_attribute("data-open").as_deref() == Some("1");
+    if is_open {
+        let _ = btn.set_attribute("data-open", "0");
+        btn.set_text_content(Some("복구 가이드 보기"));
+        let _ = note.set_attribute("style", "display:none");
+        return;
+    }
+    let message = btn
+        .get_attribute("data-guide")
+        .unwrap_or_else(|| "복구 가이드를 불러올 수 없습니다.".to_string());
+    note.set_text_content(Some(&message));
+    let _ = note.set_attribute("style", "display:block");
+    let _ = btn.set_attribute("data-open", "1");
+    btn.set_text_content(Some("복구 가이드 숨기기"));
+}
+
+#[cfg(target_arch = "wasm32")]
+fn clear_round_recovery() {
+    set_round_recovery(None);
+}
+
+#[cfg(target_arch = "wasm32")]
+fn set_recovery_actions_visible(visible: bool) {
+    let Some(doc) = web_sys::window().and_then(|w| w.document()) else {
+        return;
+    };
+    if let Some(actions) = doc.get_element_by_id("round-recovery-actions") {
+        let _ = actions.set_attribute("style", if visible { "" } else { "display:none" });
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+fn set_round_recovery(guide: Option<&str>) {
+    let Some(doc) = web_sys::window().and_then(|w| w.document()) else {
+        return;
+    };
+    let Some(btn) = doc
+        .get_element_by_id("round-recovery-btn")
+        .and_then(|el| el.dyn_into::<HtmlButtonElement>().ok())
+    else {
+        return;
+    };
+    let note = doc.get_element_by_id("round-recovery-note");
+
+    let guide = guide.unwrap_or("").trim();
+    if guide.is_empty() {
+        set_recovery_actions_visible(false);
+        let _ = btn.set_attribute("style", "display:none");
+        let _ = btn.remove_attribute("data-guide");
+        let _ = btn.remove_attribute("data-open");
+        btn.set_text_content(Some("복구 가이드 보기"));
+        if let Some(note) = note {
+            note.set_text_content(None);
+            let _ = note.set_attribute("style", "display:none");
+        }
+        return;
+    }
+
+    set_recovery_actions_visible(true);
+    let _ = btn.set_attribute("style", "");
+    let _ = btn.set_attribute("data-guide", guide);
+    let _ = btn.set_attribute("data-open", "0");
+    btn.set_text_content(Some("복구 가이드 보기"));
+    btn.set_title("턴이 진행되지 않았습니다. 원인/조치 가이드를 확인하세요.");
+    if let Some(note) = note {
+        note.set_text_content(Some(guide));
+        let _ = note.set_attribute("style", "display:none");
+    }
 }
 
 #[cfg(target_arch = "wasm32")]
@@ -272,10 +666,38 @@ fn set_advance_busy(busy: bool) {
             btn.set_disabled(busy);
             if busy {
                 let _ = btn.set_attribute("data-busy", "1");
+                let _ = btn.set_attribute("aria-busy", "true");
             } else {
                 let _ = btn.remove_attribute("data-busy");
+                let _ = btn.remove_attribute("aria-busy");
             }
         }
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+fn is_advance_busy(doc: &web_sys::Document) -> bool {
+    doc.get_element_by_id("advance-turn-btn")
+        .and_then(|el| el.dyn_into::<HtmlButtonElement>().ok())
+        .and_then(|btn| btn.get_attribute("data-busy"))
+        .is_some_and(|v| v == "1")
+}
+
+#[cfg(target_arch = "wasm32")]
+fn read_advance_gate(doc: &web_sys::Document) -> Result<(), String> {
+    let Some(btn) = doc
+        .get_element_by_id("advance-turn-btn")
+        .and_then(|el| el.dyn_into::<HtmlButtonElement>().ok())
+    else {
+        return Err("라운드 실행 버튼을 찾을 수 없습니다.".to_string());
+    };
+    let can_run = btn.get_attribute("data-can-run").is_some_and(|v| v == "1");
+    if can_run {
+        Ok(())
+    } else {
+        Err(btn
+            .get_attribute("data-gate-reason")
+            .unwrap_or_else(|| "라운드 제어 상태를 아직 계산 중입니다.".to_string()))
     }
 }
 
@@ -376,4 +798,68 @@ fn read_round_run_plan(doc: &web_sys::Document) -> Result<RoundRunPlan, String> 
         },
         player_keepers,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn derive_round_control_state_requires_running_or_stopped() {
+        let (can_run, reason, css) =
+            derive_round_control_state(TrpgLifecycleState::Lobby, true, None);
+        assert!(!can_run);
+        assert!(reason.contains("실행 대기"));
+        assert_eq!(css, "status-info");
+    }
+
+    #[test]
+    fn derive_round_control_state_requires_connection() {
+        let (can_run, reason, css) =
+            derive_round_control_state(TrpgLifecycleState::Running, false, None);
+        assert!(!can_run);
+        assert!(reason.contains("엔진 연결"));
+        assert_eq!(css, "status-info");
+    }
+
+    #[test]
+    fn derive_round_control_state_requires_plan() {
+        let (can_run, reason, css) = derive_round_control_state(
+            TrpgLifecycleState::Running,
+            true,
+            Some("player keepers가 없습니다"),
+        );
+        assert!(!can_run);
+        assert!(reason.contains("준비 필요"));
+        assert_eq!(css, "status-warn");
+    }
+
+    #[test]
+    fn derive_round_control_state_allows_run_when_ready() {
+        let (can_run, reason, css) =
+            derive_round_control_state(TrpgLifecycleState::Running, true, None);
+        assert!(can_run);
+        assert!(reason.contains("실행 가능"));
+        assert_eq!(css, "status-ok");
+    }
+
+    #[test]
+    fn connection_ready_true_only_for_connected() {
+        assert!(connection_ready(&ConnectionStatus::Connected));
+        assert!(!connection_ready(&ConnectionStatus::Disconnected));
+        assert!(!connection_ready(&ConnectionStatus::Connecting));
+        assert!(!connection_ready(&ConnectionStatus::Failed));
+    }
+
+    #[test]
+    fn round_advanced_prefers_summary_flag() {
+        assert!(!round_advanced(3, 4, Some(false)));
+        assert!(round_advanced(4, 4, Some(true)));
+    }
+
+    #[test]
+    fn round_advanced_falls_back_to_turn_delta() {
+        assert!(round_advanced(2, 3, None));
+        assert!(!round_advanced(2, 2, None));
+    }
 }

--- a/viewer/src/dom/turn_runtime.rs
+++ b/viewer/src/dom/turn_runtime.rs
@@ -2,7 +2,8 @@ use bevy::prelude::*;
 
 use crate::game::components::Actor;
 use crate::game::lifecycle::TrpgLifecycleState;
-use crate::game::state::{RoomState, TurnProgressState};
+use crate::game::round_runner::RoundRunner;
+use crate::game::state::{ConnectionStatus, RoomState, TurnProgressState};
 
 /// Tracks last-rendered runtime status snapshot to avoid redundant DOM updates.
 #[derive(Resource, Default)]
@@ -44,11 +45,66 @@ fn room_status_label(state: TrpgLifecycleState) -> &'static str {
     state.label()
 }
 
+fn connection_status_class(status: &ConnectionStatus) -> &'static str {
+    match status {
+        ConnectionStatus::Connected => "status-active",
+        ConnectionStatus::Connecting | ConnectionStatus::Reconnecting(_, _) => "status-loading",
+        ConnectionStatus::Disconnected => "status-idle",
+        ConnectionStatus::Failed => "status-error",
+    }
+}
+
+fn connection_status_label(status: &ConnectionStatus) -> &'static str {
+    match status {
+        ConnectionStatus::Connected => "connected",
+        ConnectionStatus::Connecting => "connecting",
+        ConnectionStatus::Reconnecting(_, _) => "reconnecting",
+        ConnectionStatus::Disconnected => "disconnected",
+        ConnectionStatus::Failed => "failed",
+    }
+}
+
+fn normalize_phase_for_sync(phase: &str) -> String {
+    phase.trim().to_ascii_lowercase().replace('-', "_")
+}
+
+fn phase_is_aggregate_round(phase: &str) -> bool {
+    normalize_phase_for_sync(phase) == "round"
+}
+
+fn phase_matches_for_sync(room_phase: &str, progress_phase: &str) -> bool {
+    let room_norm = normalize_phase_for_sync(room_phase);
+    let progress_norm = normalize_phase_for_sync(progress_phase);
+    if room_norm == progress_norm {
+        return true;
+    }
+    if room_norm.is_empty() || progress_norm.is_empty() {
+        return false;
+    }
+    phase_is_aggregate_round(&room_norm) || phase_is_aggregate_round(&progress_norm)
+}
+
+#[cfg(target_arch = "wasm32")]
+fn set_ops_hud_value(document: &web_sys::Document, id: &str, text: &str, status_class: &str) {
+    let Some(el) = document.get_element_by_id(id) else {
+        return;
+    };
+    let class_name = if status_class.trim().is_empty() {
+        "ops-v".to_string()
+    } else {
+        format!("ops-v {}", status_class.trim())
+    };
+    el.set_text_content(Some(text));
+    el.set_class_name(&class_name);
+}
+
 /// Render live TRPG runtime progress:
 /// room/turn/phase, current thinker, next actor, last outcome, and party survival.
 pub fn update_turn_runtime_dom(
     room_state: Res<RoomState>,
     progress: Res<TurnProgressState>,
+    connection: Res<ConnectionStatus>,
+    runner: Option<Res<RoundRunner>>,
     actors: Query<&Actor>,
     mut cache: ResMut<TurnRuntimeCache>,
 ) {
@@ -59,7 +115,8 @@ pub fn update_turn_runtime_dom(
     } else {
         "unknown".to_string()
     };
-    let lifecycle = TrpgLifecycleState::from_room_progress(&room_state.status, &progress.room_status);
+    let lifecycle =
+        TrpgLifecycleState::from_room_progress(&room_state.status, &progress.room_status);
     let room_status_key = crate::game::lifecycle::normalize_status(&room_status_raw);
     let turn = if progress.turn > 0 {
         progress.turn
@@ -129,8 +186,93 @@ pub fn update_turn_runtime_dom(
         "disabled"
     };
 
+    let room_turn_for_sync = if room_state.turn > 0 {
+        room_state.turn
+    } else {
+        turn
+    };
+    let room_phase_for_sync = room_state.phase.as_str().to_string();
+    let progress_turn_for_sync = if progress.turn > 0 {
+        progress.turn
+    } else {
+        turn
+    };
+    let progress_phase_for_sync = if progress.phase.trim().is_empty() {
+        room_phase_for_sync.clone()
+    } else {
+        progress.phase.trim().to_string()
+    };
+    let turn_mismatch = room_turn_for_sync != progress_turn_for_sync;
+    let phase_mismatch = !phase_matches_for_sync(&room_phase_for_sync, &progress_phase_for_sync);
+
+    let (sync_state, sync_class) = if turn_mismatch || phase_mismatch {
+        let mut reasons = Vec::new();
+        if turn_mismatch {
+            reasons.push(format!(
+                "turn {}≠{}",
+                room_turn_for_sync, progress_turn_for_sync
+            ));
+        }
+        if phase_mismatch {
+            reasons.push(format!(
+                "phase {}≠{}",
+                room_phase_for_sync, progress_phase_for_sync
+            ));
+        }
+        (format!("mismatch: {}", reasons.join(" · ")), "status-error")
+    } else if progress.last_event.trim().is_empty() {
+        ("waiting event".to_string(), "status-idle")
+    } else {
+        (
+            format!("ok · {}", progress.last_event.trim()),
+            "status-active",
+        )
+    };
+
+    let control_state = if lifecycle.accepts_player_input() {
+        if current_actor != "-" {
+            "manual-ready / actor-thinking".to_string()
+        } else {
+            "manual-ready".to_string()
+        }
+    } else {
+        lifecycle.label_ko().to_string()
+    };
+
+    let (runner_running, runner_rounds, runner_last_result) = if let Some(runner) = runner.as_ref()
+    {
+        let running = runner.running.load(std::sync::atomic::Ordering::SeqCst);
+        let rounds = runner
+            .rounds_completed
+            .lock()
+            .ok()
+            .map(|guard| *guard)
+            .unwrap_or(0);
+        let last = runner
+            .last_result
+            .lock()
+            .ok()
+            .and_then(|guard| guard.clone())
+            .unwrap_or_default();
+        (running, rounds, last)
+    } else {
+        (false, 0, String::new())
+    };
+
+    let runner_state = if runner_running {
+        format!("auto-run {} rounds", runner_rounds)
+    } else {
+        "idle".to_string()
+    };
+
+    let connection_label = connection_status_label(&connection);
+    let connection_class = connection_status_class(&connection);
+
+    #[cfg(not(target_arch = "wasm32"))]
+    let _ = (&sync_class, &control_state, &runner_last_result);
+
     let snapshot = format!(
-        "{}|{}|{}|{}|{}|{}|{}|{}|{}",
+        "{}|{}|{}|{}|{}|{}|{}|{}|{}|{}|{}|{}|{}|{}",
         room_status_key,
         turn,
         phase,
@@ -139,7 +281,12 @@ pub fn update_turn_runtime_dom(
         last_result,
         party_status,
         current_status,
-        input_status
+        input_status,
+        connection_label,
+        connection_class,
+        sync_state,
+        runner_state,
+        progress.last_event
     );
     if cache.last_snapshot == snapshot {
         return;
@@ -187,6 +334,38 @@ pub fn update_turn_runtime_dom(
             );
         }
 
+        let room_id = crate::config::current_room_id();
+        set_ops_hud_value(&document, "ops-room-id", &room_id, room_class);
+        set_ops_hud_value(
+            &document,
+            "ops-session-state",
+            lifecycle.label_ko(),
+            room_class,
+        );
+        set_ops_hud_value(
+            &document,
+            "ops-round-phase",
+            &format!("T{} / {}", turn, pretty_phase(&phase)),
+            room_class,
+        );
+        set_ops_hud_value(
+            &document,
+            "ops-connection-state",
+            connection_label,
+            connection_class,
+        );
+        set_ops_hud_value(
+            &document,
+            "ops-control-state",
+            &control_state,
+            if lifecycle.accepts_player_input() {
+                "status-active"
+            } else {
+                room_class
+            },
+        );
+        set_ops_hud_value(&document, "ops-sync-state", &sync_state, sync_class);
+
         let inferred_dm = if !progress.dm_keeper.trim().is_empty() {
             progress.dm_keeper.trim().to_string()
         } else {
@@ -233,8 +412,62 @@ pub fn update_turn_runtime_dom(
             }
         }
 
+        if let Some(debug_el) = document.get_element_by_id("round-sync-debug-body") {
+            let runner_preview = if runner_last_result.trim().is_empty() {
+                "-".to_string()
+            } else {
+                let compact = runner_last_result.trim().replace('\n', " ");
+                compact.chars().take(180).collect::<String>()
+            };
+            let phase_sync_class = if phase_mismatch {
+                "sync-error"
+            } else {
+                "sync-ok"
+            };
+            let turn_sync_class = if turn_mismatch {
+                "sync-error"
+            } else {
+                "sync-ok"
+            };
+            let html = format!(
+                concat!(
+                    "<div class=\"round-sync-row\"><span class=\"round-sync-label\">Room</span><span class=\"round-sync-value\">{room_id}</span></div>",
+                    "<div class=\"round-sync-row\"><span class=\"round-sync-label\">Lifecycle</span><span class=\"round-sync-value {room_class}\">{lifecycle}</span></div>",
+                    "<div class=\"round-sync-row\"><span class=\"round-sync-label\">Turn Sync</span><span class=\"round-sync-value {turn_sync_class}\">room {room_turn} / progress {progress_turn}</span></div>",
+                    "<div class=\"round-sync-row\"><span class=\"round-sync-label\">Phase Sync</span><span class=\"round-sync-value {phase_sync_class}\">room {room_phase} / progress {progress_phase}</span></div>",
+                    "<div class=\"round-sync-row\"><span class=\"round-sync-label\">Last Event</span><span class=\"round-sync-value\">{last_event}</span></div>",
+                    "<div class=\"round-sync-row\"><span class=\"round-sync-label\">Last Result</span><span class=\"round-sync-value\">{last_result}</span></div>",
+                    "<div class=\"round-sync-row\"><span class=\"round-sync-label\">Runner</span><span class=\"round-sync-value\">{runner_state}</span></div>",
+                    "<div class=\"round-sync-row\"><span class=\"round-sync-label\">Runner Resp</span><span class=\"round-sync-value\">{runner_preview}</span></div>"
+                ),
+                room_id = html_escape(&room_id),
+                room_class = room_class,
+                lifecycle = html_escape(lifecycle.label_ko()),
+                turn_sync_class = turn_sync_class,
+                room_turn = room_turn_for_sync,
+                progress_turn = progress_turn_for_sync,
+                phase_sync_class = phase_sync_class,
+                room_phase = html_escape(&room_phase_for_sync),
+                progress_phase = html_escape(&progress_phase_for_sync),
+                last_event = html_escape(if progress.last_event.trim().is_empty() {
+                    "-"
+                } else {
+                    progress.last_event.trim()
+                }),
+                last_result = html_escape(if progress.last_result.trim().is_empty() {
+                    "-"
+                } else {
+                    progress.last_result.trim()
+                }),
+                runner_state = html_escape(&runner_state),
+                runner_preview = html_escape(&runner_preview),
+            );
+            debug_el.set_inner_html(&html);
+        }
+
         let lifecycle_class = format!("{} {}", room_class, lifecycle.css_class());
-        let lifecycle_label = html_escape(&format!("{} ({})", lifecycle.label(), lifecycle.label_ko()));
+        let lifecycle_label =
+            html_escape(&format!("{} ({})", lifecycle.label(), lifecycle.label_ko()));
         let html = format!(
             r#"
 <div class="turn-runtime-grid">

--- a/viewer/src/game/http.rs
+++ b/viewer/src/game/http.rs
@@ -1,5 +1,5 @@
-use std::sync::{Arc, Mutex};
 use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
 
 use bevy::prelude::*;
 use serde::Deserialize;
@@ -8,8 +8,8 @@ use wasm_bindgen::prelude::*;
 use wasm_bindgen_futures::JsFuture;
 
 use crate::config;
-use crate::game::events::*;
 use crate::game::components::{Actor, Condition, Equipment, Skill, Stats};
+use crate::game::events::*;
 use crate::game::state::{ConnectionStatus, MapState, RoomState, TurnPhase, TurnProgressState};
 
 // ─── Expected API Response Types ─────────────
@@ -560,7 +560,8 @@ fn parse_masc_state_response(root: &Value) -> GameStateResponse {
         .unwrap_or("")
         .trim()
         .to_string();
-    let dice_log = parse_dice_log(root).unwrap_or_else(|| parse_dice_log(state).unwrap_or_default());
+    let dice_log =
+        parse_dice_log(root).unwrap_or_else(|| parse_dice_log(state).unwrap_or_default());
 
     GameStateResponse {
         room: Some(RoomResponse {
@@ -704,14 +705,19 @@ fn parse_dice_log_entry(
         total,
         dc,
         result,
-        note: entry.get("note").and_then(Value::as_str).map(str::to_string),
+        note: entry
+            .get("note")
+            .and_then(Value::as_str)
+            .map(str::to_string),
     })
 }
 
 fn map_dice_result_label(raw: &str) -> String {
     let raw = raw.trim().to_ascii_lowercase();
     match raw.as_str() {
-        "critical_fail" | "critical failure" | "fumble" | "대실패" => "critical_fail".to_string(),
+        "critical_fail" | "critical failure" | "fumble" | "대실패" => {
+            "critical_fail".to_string()
+        }
         "fail" | "failure" | "실패" => "fail".to_string(),
         "partial" | "partial_success" | "부분성공" => "partial_success".to_string(),
         "success" | "성공" => "success".to_string(),
@@ -722,12 +728,7 @@ fn map_dice_result_label(raw: &str) -> String {
         "false" | "0" => "fail".to_string(),
         _ => {
             let passed = entry_passed_marker(&raw);
-            if passed {
-                "success"
-            } else {
-                "fail"
-            }
-            .to_string()
+            if passed { "success" } else { "fail" }.to_string()
         }
     }
 }
@@ -737,9 +738,7 @@ fn entry_passed_marker(raw: &str) -> bool {
     compact
         .split_whitespace()
         .find(|token| !token.is_empty())
-        .is_some_and(|token| {
-            matches!(token, "pass" | "passed" | "success" | "성공" | "true" | "1")
-        })
+        .is_some_and(|token| matches!(token, "pass" | "passed" | "success" | "성공" | "true" | "1"))
 }
 
 fn parse_party_characters(
@@ -833,10 +832,12 @@ fn parse_party_characters(
                         .filter_map(|skill| {
                             if let Ok(parsed) = serde_json::from_value::<SkillData>(skill.clone()) {
                                 Some(parsed)
-                            } else { skill.as_str().map(|name| SkillData {
+                            } else {
+                                skill.as_str().map(|name| SkillData {
                                     name: name.to_string(),
                                     level: 10,
-                                }) }
+                                })
+                            }
                         })
                         .collect::<Vec<_>>()
                 })
@@ -847,12 +848,16 @@ fn parse_party_characters(
                 .map(|rows| {
                     rows.iter()
                         .filter_map(|cond| {
-                            if let Ok(parsed) = serde_json::from_value::<ConditionData>(cond.clone()) {
+                            if let Ok(parsed) =
+                                serde_json::from_value::<ConditionData>(cond.clone())
+                            {
                                 Some(parsed)
-                            } else { cond.as_str().map(|name| ConditionData {
+                            } else {
+                                cond.as_str().map(|name| ConditionData {
                                     name: name.to_string(),
                                     remaining_turns: None,
-                                }) }
+                                })
+                            }
                         })
                         .collect::<Vec<_>>()
                 })
@@ -863,20 +868,21 @@ fn parse_party_characters(
                 .map(|rows| {
                     rows.iter()
                         .filter_map(|slot| {
-                            if let Ok(parsed) = serde_json::from_value::<EquipmentData>(slot.clone()) {
+                            if let Ok(parsed) =
+                                serde_json::from_value::<EquipmentData>(slot.clone())
+                            {
                                 Some(parsed)
-                            } else { slot.as_str().map(|name| EquipmentData {
+                            } else {
+                                slot.as_str().map(|name| EquipmentData {
                                     slot: "item".to_string(),
                                     name: name.to_string(),
-                                }) }
+                                })
+                            }
                         })
                         .collect::<Vec<_>>()
                 })
                 .unwrap_or_default();
-            let keeper = actor_control
-                .get(actor_id)
-                .cloned()
-                .unwrap_or_default();
+            let keeper = actor_control.get(actor_id).cloned().unwrap_or_default();
 
             CharacterData {
                 id: actor_id.to_string(),

--- a/viewer/src/game/lifecycle.rs
+++ b/viewer/src/game/lifecycle.rs
@@ -22,19 +22,9 @@ impl TrpgLifecycleState {
     pub fn from_status(raw: &str) -> Self {
         let status = normalize_status(raw);
         match status.as_str() {
-            "active"
-            | "running"
-            | "in_progress"
-            | "round"
-            | "combat"
-            | "briefing"
-            | "dm_narration"
-            | "party_discussion"
-            | "action_declaration"
-            | "dice_resolution"
-            | "outcome_narration"
-            | "state_update"
-            | "transition" => Self::Running,
+            "active" | "running" | "in_progress" | "round" | "combat" | "briefing"
+            | "dm_narration" | "party_discussion" | "action_declaration" | "dice_resolution"
+            | "outcome_narration" | "state_update" | "transition" => Self::Running,
             "paused" | "stopped" | "suspended" | "halted" => Self::Stopped,
             "ended" | "completed" | "done" | "retired" | "closed" | "archived" => Self::Ended,
             "loading" | "bootstrapping" | "syncing" => Self::Loading,
@@ -103,7 +93,6 @@ impl TrpgLifecycleState {
         }
     }
 
-    #[cfg(target_arch = "wasm32")]
     pub fn help_text(self) -> &'static str {
         match self {
             Self::Lobby => "세션 미시작 또는 초기 대기 상태",
@@ -116,7 +105,6 @@ impl TrpgLifecycleState {
         }
     }
 
-    #[cfg(target_arch = "wasm32")]
     pub fn allows_round_control(self) -> bool {
         matches!(self, Self::Running | Self::Stopped)
     }

--- a/viewer/src/game/mod.rs
+++ b/viewer/src/game/mod.rs
@@ -67,37 +67,46 @@ impl Plugin for GameStatePlugin {
             // ── TRPG-gated systems ──
             .add_systems(
                 OnEnter(ViewerMode::Trpg),
-                (systems::reset_turn_progress, http::fetch_initial_state, round_runner::start_round_loop),
+                (
+                    systems::reset_turn_progress,
+                    http::fetch_initial_state,
+                    round_runner::start_round_loop,
+                ),
+            )
+            .add_systems(OnExit(ViewerMode::Trpg), round_runner::stop_round_loop)
+            .add_systems(
+                Update,
+                (
+                    http::refresh_state_on_room_change,
+                    http::apply_initial_state,
+                    systems::apply_hp_change,
+                    systems::apply_area_move,
+                    systems::apply_turn_advance,
+                    systems::apply_turn_progress,
+                    systems::apply_item_acquired,
+                    systems::apply_character_death,
+                    systems::apply_weather_change,
+                    systems::apply_mood_change,
+                    systems::apply_choice_available,
+                    systems::apply_choice_resolved,
+                    systems::apply_combat_started,
+                )
+                    .run_if(in_state(ViewerMode::Trpg)),
             )
             .add_systems(
-                OnExit(ViewerMode::Trpg),
-                round_runner::stop_round_loop,
+                Update,
+                (
+                    systems::apply_actor_spawned,
+                    systems::apply_actor_updated,
+                    systems::apply_actor_deleted,
+                    systems::apply_actor_claimed,
+                    systems::apply_actor_released,
+                    systems::apply_room_ended,
+                    systems::apply_scene_transitioned,
+                    crate::dom::endgame::detect_endgame,
+                )
+                    .run_if(in_state(ViewerMode::Trpg)),
             )
-            .add_systems(Update, (
-                http::refresh_state_on_room_change,
-                http::apply_initial_state,
-                systems::apply_hp_change,
-                systems::apply_area_move,
-                systems::apply_turn_advance,
-                systems::apply_turn_progress,
-                systems::apply_item_acquired,
-                systems::apply_character_death,
-                systems::apply_weather_change,
-                systems::apply_mood_change,
-                systems::apply_choice_available,
-                systems::apply_choice_resolved,
-                systems::apply_combat_started,
-            ).run_if(in_state(ViewerMode::Trpg)))
-            .add_systems(Update, (
-                systems::apply_actor_spawned,
-                systems::apply_actor_updated,
-                systems::apply_actor_deleted,
-                systems::apply_actor_claimed,
-                systems::apply_actor_released,
-                systems::apply_room_ended,
-                systems::apply_scene_transitioned,
-                crate::dom::endgame::detect_endgame,
-            ).run_if(in_state(ViewerMode::Trpg)))
             .add_systems(
                 Update,
                 (

--- a/viewer/src/game/round_runner.rs
+++ b/viewer/src/game/round_runner.rs
@@ -57,10 +57,7 @@ const STARTUP_DELAY_MS: i32 = 3000;
 // ─── OnEnter System ────────────────────────────
 
 /// Spawns the async round-run loop when entering TRPG mode.
-pub fn start_round_loop(
-    mut commands: Commands,
-    progress: Res<TurnProgressState>,
-) {
+pub fn start_round_loop(mut commands: Commands, progress: Res<TurnProgressState>) {
     let runner = RoundRunner::default();
 
     #[cfg(target_arch = "wasm32")]
@@ -137,9 +134,7 @@ pub fn start_round_loop(
                         }
                     }
                     Err(e) => {
-                        let detail = e
-                            .as_string()
-                            .unwrap_or_else(|| format!("{:?}", e));
+                        let detail = e.as_string().unwrap_or_else(|| format!("{:?}", e));
                         log::warn!("RoundRunner: POST failed — {}", detail);
 
                         // Stop on non-retriable client errors to prevent runaway loops.
@@ -305,8 +300,7 @@ fn read_dom_value(id: &str) -> Option<String> {
 
     let doc = web_sys::window()?.document()?;
     let el = doc.get_element_by_id(id)?;
-    el
-        .dyn_ref::<web_sys::HtmlInputElement>()
+    el.dyn_ref::<web_sys::HtmlInputElement>()
         .map(|i| i.value())
         .or_else(|| {
             el.dyn_ref::<web_sys::HtmlSelectElement>()

--- a/viewer/src/game/systems.rs
+++ b/viewer/src/game/systems.rs
@@ -332,13 +332,22 @@ pub fn apply_actor_spawned(
         }
         let actor = Actor {
             id: payload.actor_id.clone(),
-            name: if payload.name.is_empty() { payload.actor_id.clone() } else { payload.name.clone() },
+            name: if payload.name.is_empty() {
+                payload.actor_id.clone()
+            } else {
+                payload.name.clone()
+            },
             class: payload.class.clone(),
             hp: 100,
             max_hp: 100,
             mp: 50,
             max_mp: 50,
-            stats: Stats { atk: 10, def: 10, int: 10, luck: 10 },
+            stats: Stats {
+                atk: 10,
+                def: 10,
+                int: 10,
+                luck: 10,
+            },
             area: String::new(),
             is_dead: false,
             inventory: Vec::new(),
@@ -355,10 +364,7 @@ pub fn apply_actor_spawned(
 
 /// Update Actor fields when ActorUpdated fires.
 /// Only overwrites non-empty payload fields.
-pub fn apply_actor_updated(
-    mut events: MessageReader<ActorUpdated>,
-    mut actors: Query<&mut Actor>,
-) {
+pub fn apply_actor_updated(mut events: MessageReader<ActorUpdated>, mut actors: Query<&mut Actor>) {
     for ActorUpdated(payload) in events.read() {
         for mut actor in &mut actors {
             if actor.id == payload.actor_id {
@@ -392,10 +398,7 @@ pub fn apply_actor_deleted(
 }
 
 /// Bind a keeper to an Actor when ActorClaimed fires.
-pub fn apply_actor_claimed(
-    mut events: MessageReader<ActorClaimed>,
-    mut actors: Query<&mut Actor>,
-) {
+pub fn apply_actor_claimed(mut events: MessageReader<ActorClaimed>, mut actors: Query<&mut Actor>) {
     for ActorClaimed(payload) in events.read() {
         for mut actor in &mut actors {
             if actor.id == payload.actor_id {
@@ -420,10 +423,7 @@ pub fn apply_actor_released(
 }
 
 /// Mark room as ended when RoomEnded event fires.
-pub fn apply_room_ended(
-    mut events: MessageReader<RoomEnded>,
-    mut room_state: ResMut<RoomState>,
-) {
+pub fn apply_room_ended(mut events: MessageReader<RoomEnded>, mut room_state: ResMut<RoomState>) {
     for RoomEnded(payload) in events.read() {
         if room_state.id == payload.room_id || payload.room_id.is_empty() {
             room_state.status = "ended".to_string();
@@ -443,9 +443,7 @@ pub fn apply_scene_transitioned(
 
 // --- Session / Turn lifecycle systems ---
 
-pub fn apply_party_selected(
-    mut events: MessageReader<PartySelected>,
-) {
+pub fn apply_party_selected(mut events: MessageReader<PartySelected>) {
     for PartySelected(_p) in events.read() {
         // Log-only: no ECS state mutation needed
     }
@@ -474,9 +472,7 @@ pub fn apply_room_started(
     }
 }
 
-pub fn apply_session_started(
-    mut events: MessageReader<SessionStarted>,
-) {
+pub fn apply_session_started(mut events: MessageReader<SessionStarted>) {
     for SessionStarted(_p) in events.read() {
         // Log-only: session ID is informational
     }
@@ -501,33 +497,25 @@ pub fn apply_turn_started(
     }
 }
 
-pub fn apply_turn_action_resolved(
-    mut events: MessageReader<TurnActionResolved>,
-) {
+pub fn apply_turn_action_resolved(mut events: MessageReader<TurnActionResolved>) {
     for TurnActionResolved(_p) in events.read() {
         // Log-only: action result is rendered by DOM system
     }
 }
 
-pub fn apply_intervention_submitted(
-    mut events: MessageReader<InterventionSubmitted>,
-) {
+pub fn apply_intervention_submitted(mut events: MessageReader<InterventionSubmitted>) {
     for InterventionSubmitted(_p) in events.read() {
         // Log-only: rendered by DOM system
     }
 }
 
-pub fn apply_intervention_applied(
-    mut events: MessageReader<InterventionApplied>,
-) {
+pub fn apply_intervention_applied(mut events: MessageReader<InterventionApplied>) {
     for InterventionApplied(_p) in events.read() {
         // Log-only: rendered by DOM system
     }
 }
 
-pub fn apply_keeper_unavailable(
-    mut events: MessageReader<KeeperUnavailable>,
-) {
+pub fn apply_keeper_unavailable(mut events: MessageReader<KeeperUnavailable>) {
     for KeeperUnavailable(_p) in events.read() {
         // Log-only: warning rendered by DOM system
     }

--- a/viewer/src/mode/mcp_rpc.rs
+++ b/viewer/src/mode/mcp_rpc.rs
@@ -57,15 +57,15 @@ pub(super) async fn mcp_tool_call(tool_name: &str, args: Value) -> Result<Value,
     let rpc: Value = if body_text.trim().is_empty() {
         json!({})
     } else {
-        parse_mcp_rpc_response(&body_text).or_else(|_| {
-            parse_embedded_tool_payload(&body_text)
-        }).map_err(|e| {
-            format!(
-                "RPC 응답 JSON 파싱 실패: {} / {}",
-                e,
-                body_text.chars().take(240).collect::<String>()
-            )
-        })?
+        parse_mcp_rpc_response(&body_text)
+            .or_else(|_| parse_embedded_tool_payload(&body_text))
+            .map_err(|e| {
+                format!(
+                    "RPC 응답 JSON 파싱 실패: {} / {}",
+                    e,
+                    body_text.chars().take(240).collect::<String>()
+                )
+            })?
     };
 
     if !resp.ok() {
@@ -147,7 +147,8 @@ pub(super) async fn mcp_tool_call(tool_name: &str, args: Value) -> Result<Value,
     let parsed: Value = match parse_embedded_tool_payload(&text) {
         Ok(v) => v,
         Err(primary) => {
-            let secondary = parse_mcp_rpc_response(&text).unwrap_or_else(|e| Value::String(format!("파싱 실패: {}", e)));
+            let secondary = parse_mcp_rpc_response(&text)
+                .unwrap_or_else(|e| Value::String(format!("파싱 실패: {}", e)));
             return Err(format!(
                 "{} 응답 JSON 파싱 실패: {} / {} / raw={}",
                 tool_name, primary, secondary, text
@@ -224,8 +225,7 @@ fn collect_json_candidates(raw: &str) -> Vec<String> {
 
     // 2) SSE payload-only lines
     candidates.extend(
-        src
-            .lines()
+        src.lines()
             .filter_map(|line| line.strip_prefix("data:"))
             .map(str::trim_start)
             .filter(|line| !line.is_empty() && *line != "[DONE]")

--- a/viewer/src/mode/mod.rs
+++ b/viewer/src/mode/mod.rs
@@ -22,11 +22,11 @@ use wasm_bindgen::prelude::*;
 use wasm_bindgen::JsCast;
 
 #[cfg(target_arch = "wasm32")]
-use wasm_bindgen_futures::JsFuture;
+use crate::dom::escape::html_escape;
 #[cfg(target_arch = "wasm32")]
 use crate::game::lifecycle::TrpgLifecycleState;
 #[cfg(target_arch = "wasm32")]
-use crate::dom::escape::html_escape;
+use wasm_bindgen_futures::JsFuture;
 
 /// Top-level viewer mode. Determines which plugins/systems are active
 /// and which SSE endpoint the viewer connects to.
@@ -564,7 +564,10 @@ pub(super) fn set_new_game_preflight_status(doc: &web_sys::Document, message: &s
 }
 
 #[cfg(target_arch = "wasm32")]
-pub(super) fn set_new_game_preflight_rows(doc: &web_sys::Document, rows: &[(bool, String, String)]) {
+pub(super) fn set_new_game_preflight_rows(
+    doc: &web_sys::Document,
+    rows: &[(bool, String, String)],
+) {
     if let Some(el) = doc.get_element_by_id("new-game-preflight") {
         let html = rows
             .iter()
@@ -840,7 +843,6 @@ pub(super) fn set_round_run_fields(
         let _ = summary.set_attribute("style", "display:block");
     }
 }
-
 
 #[cfg(target_arch = "wasm32")]
 fn render_room_hub(doc: &web_sys::Document, rooms: &[RoomSnapshot], selected_room: &str) {
@@ -1161,7 +1163,11 @@ fn set_room_hub_visible(doc: &web_sys::Document, visible: bool) {
     set_element_display(doc, "room-hub", if visible { "grid" } else { "none" });
     if let Some(toggle) = doc.get_element_by_id("room-hub-toggle") {
         let _ = toggle.set_attribute("aria-pressed", if visible { "true" } else { "false" });
-        toggle.set_text_content(Some(if visible { "방 목록 닫기" } else { "방 목록" }));
+        toggle.set_text_content(Some(if visible {
+            "방 목록 닫기"
+        } else {
+            "방 목록"
+        }));
     }
 }
 
@@ -1481,8 +1487,7 @@ use room_hub::{
 mod trpg_controls;
 #[cfg(target_arch = "wasm32")]
 use trpg_controls::{
-    actor_admin_room_id, actor_admin_set_status, bind_new_game_controls,
-    refresh_actor_admin_list,
+    actor_admin_room_id, actor_admin_set_status, bind_new_game_controls, refresh_actor_admin_list,
 };
 
 /// Refresh TRPG widget status counters (narrative, party, history, dedup).
@@ -1491,7 +1496,6 @@ fn refresh_trpg_widget_status() {
     #[cfg(target_arch = "wasm32")]
     trpg_controls::refresh_trpg_widget_status();
 }
-
 
 // ─── Generic MASC Panel Enter/Exit ───────────
 

--- a/viewer/src/mode/room_hub.rs
+++ b/viewer/src/mode/room_hub.rs
@@ -373,7 +373,11 @@ fn set_room_hub_visible(doc: &web_sys::Document, visible: bool) {
     set_element_display(doc, "room-hub", if visible { "grid" } else { "none" });
     if let Some(toggle) = doc.get_element_by_id("room-hub-toggle") {
         let _ = toggle.set_attribute("aria-pressed", if visible { "true" } else { "false" });
-        toggle.set_text_content(Some(if visible { "방 목록 닫기" } else { "방 목록" }));
+        toggle.set_text_content(Some(if visible {
+            "방 목록 닫기"
+        } else {
+            "방 목록"
+        }));
     }
 }
 
@@ -459,7 +463,9 @@ fn apply_room_switch_from_ui(doc: &web_sys::Document, raw_room: &str) {
     log::info!("Viewer room switched to {}", room);
 }
 
-pub(super) async fn refresh_rooms_from_server(doc: &web_sys::Document) -> Result<Vec<RoomSnapshot>, String> {
+pub(super) async fn refresh_rooms_from_server(
+    doc: &web_sys::Document,
+) -> Result<Vec<RoomSnapshot>, String> {
     let payload = mcp_tool_call("masc_rooms_list", json!({})).await?;
 
     let mut snapshots = payload

--- a/viewer/src/mode/trpg_controls.rs
+++ b/viewer/src/mode/trpg_controls.rs
@@ -75,6 +75,270 @@ fn selected_player_keepers(doc: &web_sys::Document) -> Vec<String> {
     unique_non_empty(keepers)
 }
 
+fn selected_dm_keeper(doc: &web_sys::Document) -> String {
+    doc.get_element_by_id("new-game-dm-select")
+        .and_then(|el| {
+            el.dyn_ref::<web_sys::HtmlSelectElement>()
+                .map(|select| select.value())
+        })
+        .unwrap_or_default()
+        .trim()
+        .to_string()
+}
+
+fn set_new_game_preflight_state(doc: &web_sys::Document, state: &str) {
+    if let Some(panel) = doc.get_element_by_id("new-game-panel") {
+        let normalized = match state {
+            "ok" | "fail" | "pending" => state,
+            _ => "pending",
+        };
+        let _ = panel.set_attribute("data-preflight-state", normalized);
+        let _ = panel.set_attribute(
+            "data-preflight-ok",
+            if normalized == "ok" { "1" } else { "0" },
+        );
+    }
+}
+
+fn new_game_preflight_state(doc: &web_sys::Document) -> String {
+    doc.get_element_by_id("new-game-panel")
+        .and_then(|panel| panel.get_attribute("data-preflight-state"))
+        .unwrap_or_else(|| "pending".to_string())
+}
+
+fn set_new_game_wizard_busy(doc: &web_sys::Document, busy: bool) {
+    if let Some(panel) = doc.get_element_by_id("new-game-panel") {
+        let _ = panel.set_attribute("data-wizard-busy", if busy { "1" } else { "0" });
+    }
+    for id in [
+        "new-game-quick-start",
+        "new-game-preflight-btn",
+        "new-game-refresh",
+        "new-game-autopick-btn",
+    ] {
+        if let Some(btn) = doc
+            .get_element_by_id(id)
+            .and_then(|el| el.dyn_into::<web_sys::HtmlButtonElement>().ok())
+        {
+            btn.set_disabled(busy);
+        }
+    }
+}
+
+fn new_game_wizard_busy(doc: &web_sys::Document) -> bool {
+    doc.get_element_by_id("new-game-panel")
+        .and_then(|panel| panel.get_attribute("data-wizard-busy"))
+        .is_some_and(|flag| flag == "1")
+}
+
+fn set_step_state(doc: &web_sys::Document, id: &str, state: &str) {
+    let Some(el) = doc.get_element_by_id(id) else {
+        return;
+    };
+    let _ = el.class_list().remove_1("is-active");
+    let _ = el.class_list().remove_1("is-done");
+    let _ = el.class_list().remove_1("is-error");
+    match state {
+        "active" => {
+            let _ = el.class_list().add_1("is-active");
+        }
+        "done" => {
+            let _ = el.class_list().add_1("is-done");
+        }
+        "error" => {
+            let _ = el.class_list().add_1("is-error");
+        }
+        _ => {}
+    }
+}
+
+fn sync_new_game_wizard_ui(doc: &web_sys::Document) {
+    let preflight_state = new_game_preflight_state(doc);
+    let dm_keeper = selected_dm_keeper(doc);
+    let players = selected_player_keepers(doc);
+    let dm_selected = !dm_keeper.is_empty();
+    let has_conflict = dm_selected && players.iter().any(|player| player == &dm_keeper);
+    let players_ok = !players.is_empty() && !has_conflict;
+    let assignment_ok = dm_selected && players_ok;
+    let ready = preflight_state == "ok" && assignment_ok;
+    let busy = new_game_wizard_busy(doc);
+
+    let step1_state = match preflight_state.as_str() {
+        "ok" => "done",
+        "fail" => "error",
+        _ => "active",
+    };
+    let step2_state = if has_conflict {
+        "error"
+    } else if assignment_ok {
+        if preflight_state == "ok" {
+            "done"
+        } else {
+            "active"
+        }
+    } else if preflight_state == "ok" {
+        "active"
+    } else {
+        "pending"
+    };
+    let step3_state = if busy {
+        "active"
+    } else if ready {
+        "active"
+    } else {
+        "pending"
+    };
+
+    set_step_state(doc, "new-game-step-1", step1_state);
+    set_step_state(doc, "new-game-step-2", step2_state);
+    set_step_state(doc, "new-game-step-3", step3_state);
+
+    if let Some(start_btn) = doc
+        .get_element_by_id("new-game-start")
+        .and_then(|el| el.dyn_into::<web_sys::HtmlButtonElement>().ok())
+    {
+        start_btn.set_disabled(!ready || busy);
+    }
+
+    if let Some(hint) = doc.get_element_by_id("new-game-step-hint") {
+        let text = if busy {
+            "세션 시작 작업 실행 중입니다. 완료될 때까지 기다려주세요.".to_string()
+        } else if preflight_state != "ok" {
+            "1단계: 사전 점검을 먼저 통과해야 세션 시작이 가능합니다.".to_string()
+        } else if !dm_selected {
+            "2단계: DM keeper를 선택하세요.".to_string()
+        } else if has_conflict {
+            "2단계: DM과 플레이어 keeper가 중복되었습니다. 서로 다른 keeper를 선택하세요."
+                .to_string()
+        } else if players.is_empty() {
+            "2단계: 플레이어 keeper를 최소 1명 선택하세요.".to_string()
+        } else {
+            format!(
+                "3단계 준비 완료: DM {} · 플레이어 {}명. 세션 시작 버튼을 누르세요.",
+                dm_keeper,
+                players.len()
+            )
+        };
+        hint.set_text_content(Some(&text));
+    }
+}
+
+fn ensure_new_game_ready(doc: &web_sys::Document) -> Result<(), String> {
+    if new_game_preflight_state(doc) != "ok" {
+        return Err("사전 점검이 완료되지 않았습니다. 1) 사전 점검을 먼저 실행하세요.".to_string());
+    }
+    let dm_keeper = selected_dm_keeper(doc);
+    if dm_keeper.is_empty() {
+        return Err("DM keeper를 선택하세요.".to_string());
+    }
+    let players = selected_player_keepers(doc);
+    if players.is_empty() {
+        return Err("플레이어 keeper를 최소 1명 선택하세요.".to_string());
+    }
+    if players.iter().any(|player| player == &dm_keeper) {
+        return Err("DM keeper와 플레이어 keeper가 중복되었습니다.".to_string());
+    }
+    Ok(())
+}
+
+fn update_new_game_player_hint(doc: &web_sys::Document) {
+    let Some(hint) = doc.get_element_by_id("new-game-player-hint") else {
+        return;
+    };
+    let players = selected_player_keepers(doc);
+    let dm_keeper = selected_dm_keeper(doc);
+
+    let mut message = format!("플레이어 {}명 선택됨", players.len());
+    if !dm_keeper.is_empty() && players.iter().any(|name| name == &dm_keeper) {
+        message.push_str(&format!(" · DM 중복: {}", dm_keeper));
+    }
+    hint.set_text_content(Some(&message));
+    sync_new_game_wizard_ui(doc);
+}
+
+fn auto_select_player_keepers(doc: &web_sys::Document, target_count: usize) -> usize {
+    let Some(select) = doc
+        .get_element_by_id("new-game-player-select")
+        .and_then(|el| el.dyn_into::<web_sys::HtmlSelectElement>().ok())
+    else {
+        return 0;
+    };
+    let dm_keeper = doc
+        .get_element_by_id("new-game-dm-select")
+        .and_then(|el| {
+            el.dyn_ref::<web_sys::HtmlSelectElement>()
+                .map(|s| s.value())
+        })
+        .unwrap_or_default()
+        .trim()
+        .to_string();
+
+    let options = select.options();
+    let mut selected = 0_usize;
+    for idx in 0..options.length() {
+        let Some(option) = options
+            .item(idx)
+            .and_then(|el| el.dyn_into::<web_sys::HtmlOptionElement>().ok())
+        else {
+            continue;
+        };
+        let value = option.value().trim().to_string();
+        if value.is_empty() || (!dm_keeper.is_empty() && value == dm_keeper) {
+            option.set_selected(false);
+            continue;
+        }
+        if selected < target_count {
+            option.set_selected(true);
+            selected += 1;
+        } else {
+            option.set_selected(false);
+        }
+    }
+    update_new_game_player_hint(doc);
+    selected
+}
+
+fn bind_new_game_selection_watchers(doc: &web_sys::Document) {
+    let Some(player_select) = doc.get_element_by_id("new-game-player-select") else {
+        return;
+    };
+    if player_select.get_attribute("data-hint-bound").as_deref() == Some("1") {
+        update_new_game_player_hint(doc);
+        return;
+    }
+    let _ = player_select.set_attribute("data-hint-bound", "1");
+
+    if let Some(dm_select) = doc.get_element_by_id("new-game-dm-select") {
+        let dm_cb = Closure::wrap(Box::new(move |_event: web_sys::Event| {
+            let Some(doc) = web_sys::window().and_then(|w| w.document()) else {
+                return;
+            };
+            let selected = selected_player_keepers(&doc).len().max(1);
+            let _ = auto_select_player_keepers(&doc, selected);
+            update_new_game_player_hint(&doc);
+        }) as Box<dyn FnMut(_)>);
+        let _ = dm_select.dyn_ref::<web_sys::EventTarget>().map(|target| {
+            target.add_event_listener_with_callback("change", dm_cb.as_ref().unchecked_ref())
+        });
+        dm_cb.forget();
+    }
+
+    let player_cb = Closure::wrap(Box::new(move |_event: web_sys::Event| {
+        let Some(doc) = web_sys::window().and_then(|w| w.document()) else {
+            return;
+        };
+        update_new_game_player_hint(&doc);
+    }) as Box<dyn FnMut(_)>);
+    let _ = player_select
+        .dyn_ref::<web_sys::EventTarget>()
+        .map(|target| {
+            target.add_event_listener_with_callback("change", player_cb.as_ref().unchecked_ref())
+        });
+    player_cb.forget();
+
+    update_new_game_player_hint(doc);
+}
+
 fn available_player_keepers(doc: &web_sys::Document) -> Vec<String> {
     let Ok(nodes) = doc.query_selector_all("#new-game-player-select option") else {
         return Vec::new();
@@ -145,7 +409,13 @@ fn extract_keeper_name_from_value(row: &Value) -> Option<String> {
 
 async fn refresh_keeper_selectors(doc: &web_sys::Document) -> Result<Vec<String>, String> {
     let payload = mcp_tool_call("masc_keeper_list", json!({ "limit": 200 })).await?;
-    web_sys::console::log_1(&format!("[refresh_keeper_selectors] payload keys={:?}", payload.as_object().map(|m| m.keys().collect::<Vec<_>>())).into());
+    web_sys::console::log_1(
+        &format!(
+            "[refresh_keeper_selectors] payload keys={:?}",
+            payload.as_object().map(|m| m.keys().collect::<Vec<_>>())
+        )
+        .into(),
+    );
     let mut keepers = payload
         .get("keepers")
         .and_then(Value::as_array)
@@ -177,7 +447,11 @@ async fn refresh_keeper_selectors(doc: &web_sys::Document) -> Result<Vec<String>
                     fallback.push(value);
                 }
             }
-            let text = claimed.text_content().unwrap_or_default().trim().to_string();
+            let text = claimed
+                .text_content()
+                .unwrap_or_default()
+                .trim()
+                .to_string();
             if !text.is_empty() {
                 fallback.push(text);
             }
@@ -242,6 +516,7 @@ async fn refresh_keeper_selectors(doc: &web_sys::Document) -> Result<Vec<String>
         player_select.set_inner_html(&html);
     }
 
+    update_new_game_player_hint(doc);
     Ok(keepers)
 }
 
@@ -550,7 +825,9 @@ fn bind_actor_admin_row_clicks(doc: &web_sys::Document) {
     }
 }
 
-pub(super) async fn refresh_actor_admin_list(doc: &web_sys::Document) -> Result<Vec<ActorAdminRow>, String> {
+pub(super) async fn refresh_actor_admin_list(
+    doc: &web_sys::Document,
+) -> Result<Vec<ActorAdminRow>, String> {
     let room_id = actor_admin_room_id();
     let payload = fetch_room_state_payload(&room_id).await?;
     let rows = parse_actor_admin_rows(&payload);
@@ -590,8 +867,10 @@ async fn run_new_game_preflight(doc: &web_sys::Document) -> Result<(), String> {
                 &catalog,
                 &["world_presets", "world", "world_preset", "worlds"],
             );
-            let dm =
-                collect_preset_options_from_catalog(&catalog, &["dm_presets", "dm", "dm_preset", "dms"]);
+            let dm = collect_preset_options_from_catalog(
+                &catalog,
+                &["dm_presets", "dm", "dm_preset", "dms"],
+            );
             let ok = !world.is_empty() && !dm.is_empty();
             let detail = if ok {
                 format!("월드 {}개 · DM {}개", world.len(), dm.len())
@@ -600,11 +879,7 @@ async fn run_new_game_preflight(doc: &web_sys::Document) -> Result<(), String> {
             };
             (ok, "프리셋".to_string(), detail)
         }
-        Err(e) => (
-            false,
-            "프리셋".to_string(),
-            format!("조회 실패: {}", e),
-        ),
+        Err(e) => (false, "프리셋".to_string(), format!("조회 실패: {}", e)),
     };
     rows.push(preset_row);
 
@@ -629,11 +904,7 @@ async fn run_new_game_preflight(doc: &web_sys::Document) -> Result<(), String> {
                 )
             }
         }
-        Err(e) => (
-            false,
-            "키퍼 풀".to_string(),
-            format!("조회 실패: {}", e),
-        ),
+        Err(e) => (false, "키퍼 풀".to_string(), format!("조회 실패: {}", e)),
     };
     rows.push(keeper_row);
 
@@ -663,7 +934,10 @@ async fn run_new_game_preflight(doc: &web_sys::Document) -> Result<(), String> {
     rows.push(room_row);
 
     set_new_game_preflight_rows(doc, &rows);
-    if rows.iter().all(|(ok, _, _)| *ok) {
+    let all_ok = rows.iter().all(|(ok, _, _)| *ok);
+    set_new_game_preflight_state(doc, if all_ok { "ok" } else { "fail" });
+    sync_new_game_wizard_ui(doc);
+    if all_ok {
         Ok(())
     } else {
         Err("사전 점검 실패 항목이 있습니다.".to_string())
@@ -793,6 +1067,42 @@ async fn actor_admin_delete(doc: &web_sys::Document) -> Result<String, String> {
 
 // ─── New Game Flow ──────────────────────────────────────────────
 
+async fn run_new_game_quick_start(doc: &web_sys::Document) -> Result<String, String> {
+    set_new_game_status(doc, "빠른 시작: keeper/preset 동기화 중...");
+    set_new_game_preflight_state(doc, "pending");
+    sync_new_game_wizard_ui(doc);
+
+    let bootstrap = refresh_new_game_bootstrap(doc).await?;
+    set_new_game_status(
+        doc,
+        &format!(
+            "빠른 시작: Keeper {}개 · 월드 {}개 · DM 프리셋 {}개 로드됨",
+            bootstrap.keepers.len(),
+            bootstrap.world_presets.len(),
+            bootstrap.dm_presets.len()
+        ),
+    );
+
+    set_new_game_preflight_status(doc, "사전 점검 실행 중...");
+    run_new_game_preflight(doc).await?;
+
+    if selected_player_keepers(doc).is_empty() {
+        let selected = auto_select_player_keepers(doc, 4);
+        if selected > 0 {
+            set_new_game_status(
+                doc,
+                &format!(
+                    "빠른 시작: 플레이어 keeper {}명을 자동 선택했습니다.",
+                    selected
+                ),
+            );
+        }
+    }
+    update_new_game_player_hint(doc);
+    ensure_new_game_ready(doc)?;
+    start_new_game_flow(doc).await
+}
+
 async fn start_new_game_flow(doc: &web_sys::Document) -> Result<String, String> {
     let room_input = doc
         .get_element_by_id("new-game-room-id")
@@ -878,7 +1188,9 @@ async fn start_new_game_flow(doc: &web_sys::Document) -> Result<String, String> 
         apply_player_keeper_selection(doc, &players);
     }
     if players.is_empty() {
-        return Err("AI Player keeper를 선택할 수 없습니다. keeper 목록을 먼저 새로고침하세요.".to_string());
+        return Err(
+            "AI Player keeper를 선택할 수 없습니다. keeper 목록을 먼저 새로고침하세요.".to_string(),
+        );
     }
 
     let model_text = doc
@@ -943,8 +1255,10 @@ async fn start_new_game_flow(doc: &web_sys::Document) -> Result<String, String> 
                 .unwrap_or_default();
         }
         if dm_preset_id.is_empty() {
-            let dm_options =
-                collect_preset_options_from_catalog(&preset_catalog, &["dm_presets", "dm", "dm_preset", "dms"]);
+            let dm_options = collect_preset_options_from_catalog(
+                &preset_catalog,
+                &["dm_presets", "dm", "dm_preset", "dms"],
+            );
             dm_preset_id = dm_options
                 .first()
                 .map(|row| row.id.clone())
@@ -1066,8 +1380,7 @@ async fn start_new_game_flow(doc: &web_sys::Document) -> Result<String, String> 
     }
 
     let assignments = assign_keepers_to_actor_ids(&actor_ids, &dm_keeper, &players)?;
-    let player_map: std::collections::HashMap<String, String> =
-        assignments.into_iter().collect();
+    let player_map: std::collections::HashMap<String, String> = assignments.into_iter().collect();
 
     for (actor_id, keeper_name) in &player_map {
         mcp_tool_call(
@@ -1149,7 +1462,11 @@ async fn start_new_game_flow(doc: &web_sys::Document) -> Result<String, String> 
         room_id,
         dm_keeper,
         player_map.len(),
-        if auto_selected_players { " (플레이어 자동 선택 적용)" } else { "" }
+        if auto_selected_players {
+            " (플레이어 자동 선택 적용)"
+        } else {
+            ""
+        }
     ))
 }
 
@@ -1223,12 +1540,7 @@ fn preset_unwrap_payload(value: &Value) -> Option<Value> {
         .or_else(|| value.get("structuredContent"))
         .filter(|v| v.is_object())
         .cloned()
-        .or_else(|| {
-            value
-                .get("presets")
-                .filter(|v| v.is_object())
-                .cloned()
-        })
+        .or_else(|| value.get("presets").filter(|v| v.is_object()).cloned())
 }
 
 fn preset_unwrap_content(value: &Value) -> Option<Value> {
@@ -1257,8 +1569,16 @@ fn extract_first_preset_id(catalog: &Value, list_key: &str) -> Option<String> {
     catalog
         .get(list_key)
         .and_then(extract_first_preset_id_from_node)
-        .or_else(|| catalog.get("items").and_then(extract_first_preset_id_from_node))
-        .or_else(|| catalog.get("presets").and_then(extract_first_preset_id_from_node))
+        .or_else(|| {
+            catalog
+                .get("items")
+                .and_then(extract_first_preset_id_from_node)
+        })
+        .or_else(|| {
+            catalog
+                .get("presets")
+                .and_then(extract_first_preset_id_from_node)
+        })
         .map(|id| id.trim().to_string())
         .filter(|id| !id.is_empty())
 }
@@ -1267,10 +1587,7 @@ fn extract_first_preset_id_from_node(raw: &Value) -> Option<String> {
     if let Some(id) = raw.get("id").and_then(Value::as_str) {
         return Some(id.to_string());
     }
-    if let Some(id) = raw
-        .get("preset_id")
-        .and_then(Value::as_str)
-    {
+    if let Some(id) = raw.get("preset_id").and_then(Value::as_str) {
         return Some(id.to_string());
     }
     if let Some(id) = raw.get("uid").and_then(Value::as_str) {
@@ -1331,11 +1648,7 @@ fn preset_option_from_value(node: &Value) -> Option<PresetOption> {
     Some(PresetOption { id, title })
 }
 
-fn collect_preset_options_from_node(
-    node: &Value,
-    out: &mut Vec<PresetOption>,
-    depth: usize,
-) {
+fn collect_preset_options_from_node(node: &Value, out: &mut Vec<PresetOption>, depth: usize) {
     if depth > 6 {
         return;
     }
@@ -1420,13 +1733,12 @@ fn select_options_set(
         .join("");
     select.set_inner_html(&html);
 
-    let selected = if !previous.trim().is_empty()
-        && options.iter().any(|option| option.id == previous)
-    {
-        previous
-    } else {
-        options[0].id.clone()
-    };
+    let selected =
+        if !previous.trim().is_empty() && options.iter().any(|option| option.id == previous) {
+            previous
+        } else {
+            options[0].id.clone()
+        };
     select.set_value(&selected);
     Some(selected)
 }
@@ -1481,6 +1793,9 @@ pub(super) fn bind_new_game_controls(doc: &web_sys::Document) {
                 room_input.set_value(&generate_room_id());
             }
         }
+        set_new_game_wizard_busy(&doc, false);
+        set_new_game_preflight_state(&doc, "pending");
+        sync_new_game_wizard_ui(&doc);
         set_new_game_status(&doc, "Keeper 목록을 불러오는 중...");
         set_new_game_preflight_status(&doc, "사전 점검 준비 중...");
         actor_admin_set_status(&doc, "액터 목록을 불러오는 중...", "status-info");
@@ -1502,13 +1817,21 @@ pub(super) fn bind_new_game_controls(doc: &web_sys::Document) {
                     let _ = run_new_game_preflight(&doc_for_fetch).await;
                 }
                 Err(e) => {
-                    web_sys::console::error_1(&format!("[bind_new_game_controls] bootstrap FAILED: {}", e).into());
+                    web_sys::console::error_1(
+                        &format!("[bind_new_game_controls] bootstrap FAILED: {}", e).into(),
+                    );
                     set_new_game_status(&doc_for_fetch, &format!("초기 로드 실패: {}", e));
-                    actor_admin_set_status(&doc_for_fetch, &format!("로드 실패: {}", e), "status-error");
+                    actor_admin_set_status(
+                        &doc_for_fetch,
+                        &format!("로드 실패: {}", e),
+                        "status-error",
+                    );
+                    set_new_game_preflight_state(&doc_for_fetch, "fail");
                     set_new_game_preflight_status(
                         &doc_for_fetch,
                         &format!("사전 점검 불가: {}", e),
                     );
+                    sync_new_game_wizard_ui(&doc_for_fetch);
                 }
             }
         });
@@ -1549,11 +1872,40 @@ pub(super) fn bind_new_game_controls(doc: &web_sys::Document) {
         regen_cb.forget();
     }
 
+    if let Some(autopick_btn) = doc.get_element_by_id("new-game-autopick-btn") {
+        let autopick_cb = Closure::wrap(Box::new(move || {
+            let Some(doc) = web_sys::window().and_then(|w| w.document()) else {
+                return;
+            };
+            if new_game_wizard_busy(&doc) {
+                return;
+            }
+            let selected = auto_select_player_keepers(&doc, 4);
+            set_new_game_status(
+                &doc,
+                &format!("플레이어 keeper {}명을 자동 선택했습니다.", selected),
+            );
+            update_new_game_player_hint(&doc);
+        }) as Box<dyn FnMut()>);
+        let _ = autopick_btn
+            .dyn_ref::<web_sys::EventTarget>()
+            .map(|target| {
+                target
+                    .add_event_listener_with_callback("click", autopick_cb.as_ref().unchecked_ref())
+            });
+        autopick_cb.forget();
+    }
+
     if let Some(refresh_btn) = doc.get_element_by_id("new-game-refresh") {
         let refresh_cb = Closure::wrap(Box::new(move || {
             let Some(doc) = web_sys::window().and_then(|w| w.document()) else {
                 return;
             };
+            if new_game_wizard_busy(&doc) {
+                return;
+            }
+            set_new_game_preflight_state(&doc, "pending");
+            sync_new_game_wizard_ui(&doc);
             set_new_game_status(&doc, "세션/프리셋/keeper 정보를 새로고침 중...");
             set_new_game_preflight_status(&doc, "사전 점검 실행 중...");
             actor_admin_set_status(&doc, "액터 목록 새로고침 중...", "status-info");
@@ -1570,16 +1922,26 @@ pub(super) fn bind_new_game_controls(doc: &web_sys::Document) {
                                 bootstrap.dm_presets.len()
                             ),
                         );
-                        actor_admin_set_status(&doc_for_fetch, "액터 목록 새로고침 완료", "status-ok");
+                        actor_admin_set_status(
+                            &doc_for_fetch,
+                            "액터 목록 새로고침 완료",
+                            "status-ok",
+                        );
                         let _ = run_new_game_preflight(&doc_for_fetch).await;
                     }
                     Err(e) => {
                         set_new_game_status(&doc_for_fetch, &format!("새로고침 실패: {}", e));
-                        actor_admin_set_status(&doc_for_fetch, &format!("새로고침 실패: {}", e), "status-error");
+                        actor_admin_set_status(
+                            &doc_for_fetch,
+                            &format!("새로고침 실패: {}", e),
+                            "status-error",
+                        );
+                        set_new_game_preflight_state(&doc_for_fetch, "fail");
                         set_new_game_preflight_status(
                             &doc_for_fetch,
                             &format!("사전 점검 실패: {}", e),
                         );
+                        sync_new_game_wizard_ui(&doc_for_fetch);
                     }
                 }
             });
@@ -1595,6 +1957,11 @@ pub(super) fn bind_new_game_controls(doc: &web_sys::Document) {
             let Some(doc) = web_sys::window().and_then(|w| w.document()) else {
                 return;
             };
+            if new_game_wizard_busy(&doc) {
+                return;
+            }
+            set_new_game_preflight_state(&doc, "pending");
+            sync_new_game_wizard_ui(&doc);
             set_new_game_preflight_status(&doc, "사전 점검 실행 중...");
             let doc_for_task = doc.clone();
             wasm_bindgen_futures::spawn_local(async move {
@@ -1603,10 +1970,52 @@ pub(super) fn bind_new_game_controls(doc: &web_sys::Document) {
                 }
             });
         }) as Box<dyn FnMut()>);
-        let _ = preflight_btn.dyn_ref::<web_sys::EventTarget>().map(|target| {
-            target.add_event_listener_with_callback("click", preflight_cb.as_ref().unchecked_ref())
-        });
+        let _ = preflight_btn
+            .dyn_ref::<web_sys::EventTarget>()
+            .map(|target| {
+                target.add_event_listener_with_callback(
+                    "click",
+                    preflight_cb.as_ref().unchecked_ref(),
+                )
+            });
         preflight_cb.forget();
+    }
+
+    if let Some(quick_start_btn) = doc.get_element_by_id("new-game-quick-start") {
+        let quick_start_cb = Closure::wrap(Box::new(move || {
+            let Some(doc) = web_sys::window().and_then(|w| w.document()) else {
+                return;
+            };
+            if new_game_wizard_busy(&doc) {
+                return;
+            }
+            set_new_game_wizard_busy(&doc, true);
+            sync_new_game_wizard_ui(&doc);
+            let doc_for_start = doc.clone();
+            wasm_bindgen_futures::spawn_local(async move {
+                let result = run_new_game_quick_start(&doc_for_start).await;
+                match result {
+                    Ok(message) => {
+                        set_new_game_status(&doc_for_start, &message);
+                        set_element_display(&doc_for_start, "new-game-panel", "none");
+                    }
+                    Err(e) => {
+                        set_new_game_status(&doc_for_start, &format!("빠른 시작 실패: {}", e));
+                    }
+                }
+                set_new_game_wizard_busy(&doc_for_start, false);
+                sync_new_game_wizard_ui(&doc_for_start);
+            });
+        }) as Box<dyn FnMut()>);
+        let _ = quick_start_btn
+            .dyn_ref::<web_sys::EventTarget>()
+            .map(|target| {
+                target.add_event_listener_with_callback(
+                    "click",
+                    quick_start_cb.as_ref().unchecked_ref(),
+                )
+            });
+        quick_start_cb.forget();
     }
 
     if let Some(start_btn) = doc.get_element_by_id("new-game-start") {
@@ -1614,10 +2023,17 @@ pub(super) fn bind_new_game_controls(doc: &web_sys::Document) {
             let Some(doc) = web_sys::window().and_then(|w| w.document()) else {
                 return;
             };
-            set_new_game_status(&doc, "새 게임 시작 중...");
-            if let Some(btn) = doc.get_element_by_id("new-game-start") {
-                let _ = btn.set_attribute("disabled", "true");
+            if new_game_wizard_busy(&doc) {
+                return;
             }
+            if let Err(reason) = ensure_new_game_ready(&doc) {
+                set_new_game_status(&doc, &format!("시작 불가: {}", reason));
+                sync_new_game_wizard_ui(&doc);
+                return;
+            }
+            set_new_game_status(&doc, "새 게임 시작 중...");
+            set_new_game_wizard_busy(&doc, true);
+            sync_new_game_wizard_ui(&doc);
             let doc_for_start = doc.clone();
             wasm_bindgen_futures::spawn_local(async move {
                 let result = start_new_game_flow(&doc_for_start).await;
@@ -1630,9 +2046,8 @@ pub(super) fn bind_new_game_controls(doc: &web_sys::Document) {
                         set_new_game_status(&doc_for_start, &format!("시작 실패: {}", e));
                     }
                 }
-                if let Some(btn) = doc_for_start.get_element_by_id("new-game-start") {
-                    let _ = btn.remove_attribute("disabled");
-                }
+                set_new_game_wizard_busy(&doc_for_start, false);
+                sync_new_game_wizard_ui(&doc_for_start);
             });
         }) as Box<dyn FnMut()>);
         let _ = start_btn.dyn_ref::<web_sys::EventTarget>().map(|target| {
@@ -1641,6 +2056,8 @@ pub(super) fn bind_new_game_controls(doc: &web_sys::Document) {
         start_cb.forget();
     }
 
+    bind_new_game_selection_watchers(doc);
+    sync_new_game_wizard_ui(doc);
     bind_actor_admin_controls(doc);
 }
 

--- a/viewer/src/render/characters.rs
+++ b/viewer/src/render/characters.rs
@@ -1,8 +1,8 @@
 use bevy::prelude::*;
 
+use super::map::{area_to_position, position_to_area};
 use crate::assets;
 use crate::game::components::*;
-use super::map::{area_to_position, position_to_area};
 
 /// Marker component for entities that can be dragged by the player.
 #[derive(Component)]
@@ -20,20 +20,20 @@ pub struct DragState {
 fn character_color(id: &str) -> Color {
     match id {
         // Grimland originals
-        "grimja" => Color::srgb(0.8, 0.3, 0.2),    // warrior red
-        "luna" => Color::srgb(0.3, 0.4, 0.8),       // mage blue
-        "songarak" => Color::srgb(0.3, 0.7, 0.3),   // rogue green
-        "miso" => Color::srgb(0.8, 0.7, 0.3),       // cleric gold
+        "grimja" => Color::srgb(0.8, 0.3, 0.2), // warrior red
+        "luna" => Color::srgb(0.3, 0.4, 0.8),   // mage blue
+        "songarak" => Color::srgb(0.3, 0.7, 0.3), // rogue green
+        "miso" => Color::srgb(0.8, 0.7, 0.3),   // cleric gold
         // Identity Erosion
-        "iron" => Color::srgb(0.9, 0.9, 0.85),      // ivory white (uncanny saint)
-        "moth" => Color::srgb(0.4, 0.3, 0.5),       // murky purple (J-horror)
-        "bell" => Color::srgb(1.0, 0.85, 0.3),      // bright gold (cult leader glow)
-        "dust" => Color::srgb(0.4, 0.4, 0.35),      // muted brown-grey (shrinking)
+        "iron" => Color::srgb(0.9, 0.9, 0.85), // ivory white (uncanny saint)
+        "moth" => Color::srgb(0.4, 0.3, 0.5),  // murky purple (J-horror)
+        "bell" => Color::srgb(1.0, 0.85, 0.3), // bright gold (cult leader glow)
+        "dust" => Color::srgb(0.4, 0.4, 0.35), // muted brown-grey (shrinking)
         // Conformity Pressure
-        "aldric" => Color::srgb(0.6, 0.2, 0.15),    // dark crimson (authority)
-        "brenna" => Color::srgb(0.7, 0.55, 0.4),    // warm tan (agreeable)
-        "cedric" => Color::srgb(0.5, 0.6, 0.7),     // pale blue (uncertain)
-        "dara" => Color::srgb(0.5, 0.45, 0.55),     // sage purple (observer)
+        "aldric" => Color::srgb(0.6, 0.2, 0.15), // dark crimson (authority)
+        "brenna" => Color::srgb(0.7, 0.55, 0.4), // warm tan (agreeable)
+        "cedric" => Color::srgb(0.5, 0.6, 0.7),  // pale blue (uncertain)
+        "dara" => Color::srgb(0.5, 0.45, 0.55),  // sage purple (observer)
         _ => Color::srgb(0.6, 0.6, 0.6),
     }
 }
@@ -71,24 +71,24 @@ pub fn spawn_character_sprites(
         ));
 
         // HP bar as child entity (positioned below the sprite)
-        let hp_bar = commands.spawn((
-            Sprite {
-                color: Color::srgb(0.2, 0.7, 0.2),
-                custom_size: Some(Vec2::new(36.0, 3.0)),
-                ..default()
-            },
-            Transform::from_xyz(0.0, -38.0, 0.1),
-            HpBarSprite { max_width: 36.0 },
-        )).id();
+        let hp_bar = commands
+            .spawn((
+                Sprite {
+                    color: Color::srgb(0.2, 0.7, 0.2),
+                    custom_size: Some(Vec2::new(36.0, 3.0)),
+                    ..default()
+                },
+                Transform::from_xyz(0.0, -38.0, 0.1),
+                HpBarSprite { max_width: 36.0 },
+            ))
+            .id();
 
         commands.entity(entity).add_child(hp_bar);
     }
 }
 
 /// Updates character positions when they move between areas.
-pub fn update_character_positions(
-    mut actors: Query<(&Actor, &mut Transform), With<MapToken>>,
-) {
+pub fn update_character_positions(mut actors: Query<(&Actor, &mut Transform), With<MapToken>>) {
     for (actor, mut transform) in &mut actors {
         let target = area_to_position(&actor.area);
         // Lerp toward target position for smooth movement
@@ -106,7 +106,6 @@ pub fn update_hp_bars(
 ) {
     for (actor, children) in &actors {
         for child in children.iter() {
-
             if let Ok((mut sprite, hp_bar)) = hp_bars.get_mut(child) {
                 let ratio = if actor.max_hp > 0 {
                     (actor.hp as f32 / actor.max_hp as f32).clamp(0.0, 1.0)
@@ -237,7 +236,11 @@ pub fn handle_drag_end(
     // Snap to nearest named area using the same coordinate system as area_to_position
     if let Ok(mut actor) = actors.get_mut(entity) {
         actor.area = position_to_area(final_pos);
-        log::info!("Drag ended: entity {:?} moved to area {}", entity, actor.area);
+        log::info!(
+            "Drag ended: entity {:?} moved to area {}",
+            entity,
+            actor.area
+        );
     }
 
     drag_state.dragged_entity = None;

--- a/viewer/src/render/ui.rs
+++ b/viewer/src/render/ui.rs
@@ -1,7 +1,7 @@
 //! UI widgets and interaction systems for TRPG viewer.
 
-use bevy::prelude::*;
 use bevy::ecs::relationship::Relationship;
+use bevy::prelude::*;
 
 use crate::audio::AudioSettings;
 
@@ -228,105 +228,109 @@ fn spawn_settings_menu(commands: &mut Commands) {
             ));
 
             // Menu items (inline to avoid type annotation issues)
-            parent.spawn((
-                Button,
-                MenuItem(MenuAction::SoundToggle),
-                Node {
-                    width: Val::Percent(100.0),
-                    height: Val::Px(25.0),
-                    padding: UiRect::horizontal(Val::Px(5.0)),
-                    justify_content: JustifyContent::FlexStart,
-                    align_items: AlignItems::Center,
-                    ..default()
-                },
-                BackgroundColor(Color::srgb(0.1, 0.1, 0.15)),
-                UiMarker,
-            ))
-            .with_children(|parent| {
-                parent.spawn((
-                    Text::new("Sound: ON"),
-                    TextFont {
-                        font_size: 13.0,
+            parent
+                .spawn((
+                    Button,
+                    MenuItem(MenuAction::SoundToggle),
+                    Node {
+                        width: Val::Percent(100.0),
+                        height: Val::Px(25.0),
+                        padding: UiRect::horizontal(Val::Px(5.0)),
+                        justify_content: JustifyContent::FlexStart,
+                        align_items: AlignItems::Center,
                         ..default()
                     },
-                    TextColor(Color::srgb(0.8, 0.8, 0.8)),
-                ));
-            });
+                    BackgroundColor(Color::srgb(0.1, 0.1, 0.15)),
+                    UiMarker,
+                ))
+                .with_children(|parent| {
+                    parent.spawn((
+                        Text::new("Sound: ON"),
+                        TextFont {
+                            font_size: 13.0,
+                            ..default()
+                        },
+                        TextColor(Color::srgb(0.8, 0.8, 0.8)),
+                    ));
+                });
 
-            parent.spawn((
-                Button,
-                MenuItem(MenuAction::MusicToggle),
-                Node {
-                    width: Val::Percent(100.0),
-                    height: Val::Px(25.0),
-                    padding: UiRect::horizontal(Val::Px(5.0)),
-                    justify_content: JustifyContent::FlexStart,
-                    align_items: AlignItems::Center,
-                    ..default()
-                },
-                BackgroundColor(Color::srgb(0.1, 0.1, 0.15)),
-                UiMarker,
-            ))
-            .with_children(|parent| {
-                parent.spawn((
-                    Text::new("Music: ON"),
-                    TextFont {
-                        font_size: 13.0,
+            parent
+                .spawn((
+                    Button,
+                    MenuItem(MenuAction::MusicToggle),
+                    Node {
+                        width: Val::Percent(100.0),
+                        height: Val::Px(25.0),
+                        padding: UiRect::horizontal(Val::Px(5.0)),
+                        justify_content: JustifyContent::FlexStart,
+                        align_items: AlignItems::Center,
                         ..default()
                     },
-                    TextColor(Color::srgb(0.8, 0.8, 0.8)),
-                ));
-            });
+                    BackgroundColor(Color::srgb(0.1, 0.1, 0.15)),
+                    UiMarker,
+                ))
+                .with_children(|parent| {
+                    parent.spawn((
+                        Text::new("Music: ON"),
+                        TextFont {
+                            font_size: 13.0,
+                            ..default()
+                        },
+                        TextColor(Color::srgb(0.8, 0.8, 0.8)),
+                    ));
+                });
 
-            parent.spawn((
-                Button,
-                MenuItem(MenuAction::AutoSaveToggle),
-                Node {
-                    width: Val::Percent(100.0),
-                    height: Val::Px(25.0),
-                    padding: UiRect::horizontal(Val::Px(5.0)),
-                    justify_content: JustifyContent::FlexStart,
-                    align_items: AlignItems::Center,
-                    ..default()
-                },
-                BackgroundColor(Color::srgb(0.1, 0.1, 0.15)),
-                UiMarker,
-            ))
-            .with_children(|parent| {
-                parent.spawn((
-                    Text::new("Auto-save: ON"),
-                    TextFont {
-                        font_size: 13.0,
+            parent
+                .spawn((
+                    Button,
+                    MenuItem(MenuAction::AutoSaveToggle),
+                    Node {
+                        width: Val::Percent(100.0),
+                        height: Val::Px(25.0),
+                        padding: UiRect::horizontal(Val::Px(5.0)),
+                        justify_content: JustifyContent::FlexStart,
+                        align_items: AlignItems::Center,
                         ..default()
                     },
-                    TextColor(Color::srgb(0.8, 0.8, 0.8)),
-                ));
-            });
+                    BackgroundColor(Color::srgb(0.1, 0.1, 0.15)),
+                    UiMarker,
+                ))
+                .with_children(|parent| {
+                    parent.spawn((
+                        Text::new("Auto-save: ON"),
+                        TextFont {
+                            font_size: 13.0,
+                            ..default()
+                        },
+                        TextColor(Color::srgb(0.8, 0.8, 0.8)),
+                    ));
+                });
 
-            parent.spawn((
-                Button,
-                MenuItem(MenuAction::Fullscreen),
-                Node {
-                    width: Val::Percent(100.0),
-                    height: Val::Px(25.0),
-                    padding: UiRect::horizontal(Val::Px(5.0)),
-                    justify_content: JustifyContent::FlexStart,
-                    align_items: AlignItems::Center,
-                    ..default()
-                },
-                BackgroundColor(Color::srgb(0.1, 0.1, 0.15)),
-                UiMarker,
-            ))
-            .with_children(|parent| {
-                parent.spawn((
-                    Text::new("Fullscreen"),
-                    TextFont {
-                        font_size: 13.0,
+            parent
+                .spawn((
+                    Button,
+                    MenuItem(MenuAction::Fullscreen),
+                    Node {
+                        width: Val::Percent(100.0),
+                        height: Val::Px(25.0),
+                        padding: UiRect::horizontal(Val::Px(5.0)),
+                        justify_content: JustifyContent::FlexStart,
+                        align_items: AlignItems::Center,
                         ..default()
                     },
-                    TextColor(Color::srgb(0.8, 0.8, 0.8)),
-                ));
-            });
+                    BackgroundColor(Color::srgb(0.1, 0.1, 0.15)),
+                    UiMarker,
+                ))
+                .with_children(|parent| {
+                    parent.spawn((
+                        Text::new("Fullscreen"),
+                        TextFont {
+                            font_size: 13.0,
+                            ..default()
+                        },
+                        TextColor(Color::srgb(0.8, 0.8, 0.8)),
+                    ));
+                });
         });
 }
 
@@ -367,105 +371,109 @@ fn spawn_dev_menu(commands: &mut Commands) {
             ));
 
             // Dev options
-            parent.spawn((
-                Button,
-                MenuItem(MenuAction::ShowFps),
-                Node {
-                    width: Val::Percent(100.0),
-                    height: Val::Px(25.0),
-                    padding: UiRect::horizontal(Val::Px(5.0)),
-                    justify_content: JustifyContent::FlexStart,
-                    align_items: AlignItems::Center,
-                    ..default()
-                },
-                BackgroundColor(Color::srgb(0.1, 0.1, 0.15)),
-                UiMarker,
-            ))
-            .with_children(|parent| {
-                parent.spawn((
-                    Text::new("Show FPS"),
-                    TextFont {
-                        font_size: 13.0,
+            parent
+                .spawn((
+                    Button,
+                    MenuItem(MenuAction::ShowFps),
+                    Node {
+                        width: Val::Percent(100.0),
+                        height: Val::Px(25.0),
+                        padding: UiRect::horizontal(Val::Px(5.0)),
+                        justify_content: JustifyContent::FlexStart,
+                        align_items: AlignItems::Center,
                         ..default()
                     },
-                    TextColor(Color::srgb(0.8, 0.8, 0.8)),
-                ));
-            });
+                    BackgroundColor(Color::srgb(0.1, 0.1, 0.15)),
+                    UiMarker,
+                ))
+                .with_children(|parent| {
+                    parent.spawn((
+                        Text::new("Show FPS"),
+                        TextFont {
+                            font_size: 13.0,
+                            ..default()
+                        },
+                        TextColor(Color::srgb(0.8, 0.8, 0.8)),
+                    ));
+                });
 
-            parent.spawn((
-                Button,
-                MenuItem(MenuAction::DebugOverlay),
-                Node {
-                    width: Val::Percent(100.0),
-                    height: Val::Px(25.0),
-                    padding: UiRect::horizontal(Val::Px(5.0)),
-                    justify_content: JustifyContent::FlexStart,
-                    align_items: AlignItems::Center,
-                    ..default()
-                },
-                BackgroundColor(Color::srgb(0.1, 0.1, 0.15)),
-                UiMarker,
-            ))
-            .with_children(|parent| {
-                parent.spawn((
-                    Text::new("Debug Overlay"),
-                    TextFont {
-                        font_size: 13.0,
+            parent
+                .spawn((
+                    Button,
+                    MenuItem(MenuAction::DebugOverlay),
+                    Node {
+                        width: Val::Percent(100.0),
+                        height: Val::Px(25.0),
+                        padding: UiRect::horizontal(Val::Px(5.0)),
+                        justify_content: JustifyContent::FlexStart,
+                        align_items: AlignItems::Center,
                         ..default()
                     },
-                    TextColor(Color::srgb(0.8, 0.8, 0.8)),
-                ));
-            });
+                    BackgroundColor(Color::srgb(0.1, 0.1, 0.15)),
+                    UiMarker,
+                ))
+                .with_children(|parent| {
+                    parent.spawn((
+                        Text::new("Debug Overlay"),
+                        TextFont {
+                            font_size: 13.0,
+                            ..default()
+                        },
+                        TextColor(Color::srgb(0.8, 0.8, 0.8)),
+                    ));
+                });
 
-            parent.spawn((
-                Button,
-                MenuItem(MenuAction::ReloadAssets),
-                Node {
-                    width: Val::Percent(100.0),
-                    height: Val::Px(25.0),
-                    padding: UiRect::horizontal(Val::Px(5.0)),
-                    justify_content: JustifyContent::FlexStart,
-                    align_items: AlignItems::Center,
-                    ..default()
-                },
-                BackgroundColor(Color::srgb(0.1, 0.1, 0.15)),
-                UiMarker,
-            ))
-            .with_children(|parent| {
-                parent.spawn((
-                    Text::new("Reload Assets"),
-                    TextFont {
-                        font_size: 13.0,
+            parent
+                .spawn((
+                    Button,
+                    MenuItem(MenuAction::ReloadAssets),
+                    Node {
+                        width: Val::Percent(100.0),
+                        height: Val::Px(25.0),
+                        padding: UiRect::horizontal(Val::Px(5.0)),
+                        justify_content: JustifyContent::FlexStart,
+                        align_items: AlignItems::Center,
                         ..default()
                     },
-                    TextColor(Color::srgb(0.8, 0.8, 0.8)),
-                ));
-            });
+                    BackgroundColor(Color::srgb(0.1, 0.1, 0.15)),
+                    UiMarker,
+                ))
+                .with_children(|parent| {
+                    parent.spawn((
+                        Text::new("Reload Assets"),
+                        TextFont {
+                            font_size: 13.0,
+                            ..default()
+                        },
+                        TextColor(Color::srgb(0.8, 0.8, 0.8)),
+                    ));
+                });
 
-            parent.spawn((
-                Button,
-                MenuItem(MenuAction::DumpState),
-                Node {
-                    width: Val::Percent(100.0),
-                    height: Val::Px(25.0),
-                    padding: UiRect::horizontal(Val::Px(5.0)),
-                    justify_content: JustifyContent::FlexStart,
-                    align_items: AlignItems::Center,
-                    ..default()
-                },
-                BackgroundColor(Color::srgb(0.1, 0.1, 0.15)),
-                UiMarker,
-            ))
-            .with_children(|parent| {
-                parent.spawn((
-                    Text::new("Dump State"),
-                    TextFont {
-                        font_size: 13.0,
+            parent
+                .spawn((
+                    Button,
+                    MenuItem(MenuAction::DumpState),
+                    Node {
+                        width: Val::Percent(100.0),
+                        height: Val::Px(25.0),
+                        padding: UiRect::horizontal(Val::Px(5.0)),
+                        justify_content: JustifyContent::FlexStart,
+                        align_items: AlignItems::Center,
                         ..default()
                     },
-                    TextColor(Color::srgb(0.8, 0.8, 0.8)),
-                ));
-            });
+                    BackgroundColor(Color::srgb(0.1, 0.1, 0.15)),
+                    UiMarker,
+                ))
+                .with_children(|parent| {
+                    parent.spawn((
+                        Text::new("Dump State"),
+                        TextFont {
+                            font_size: 13.0,
+                            ..default()
+                        },
+                        TextColor(Color::srgb(0.8, 0.8, 0.8)),
+                    ));
+                });
         });
 }
 
@@ -475,10 +483,7 @@ fn spawn_dev_menu(commands: &mut Commands) {
 /// (audio toggles, FPS counter, state dump, etc.).
 #[allow(clippy::type_complexity)]
 pub fn handle_menu_item_clicks(
-    interactions: Query<
-        (Entity, &Interaction, &MenuItem),
-        (Changed<Interaction>, With<Button>),
-    >,
+    interactions: Query<(Entity, &Interaction, &MenuItem), (Changed<Interaction>, With<Button>)>,
     children_query: Query<&Children>,
     mut text_query: Query<&mut Text>,
     mut audio: ResMut<AudioSettings>,
@@ -491,13 +496,21 @@ pub fn handle_menu_item_clicks(
         match menu_item.0 {
             MenuAction::SoundToggle => {
                 audio.sound_enabled = !audio.sound_enabled;
-                let label = if audio.sound_enabled { "Sound: ON" } else { "Sound: OFF" };
+                let label = if audio.sound_enabled {
+                    "Sound: ON"
+                } else {
+                    "Sound: OFF"
+                };
                 update_button_text(entity, label, &children_query, &mut text_query);
                 log::info!("Sound toggled: {}", audio.sound_enabled);
             }
             MenuAction::MusicToggle => {
                 audio.music_enabled = !audio.music_enabled;
-                let label = if audio.music_enabled { "Music: ON" } else { "Music: OFF" };
+                let label = if audio.music_enabled {
+                    "Music: ON"
+                } else {
+                    "Music: OFF"
+                };
                 update_button_text(entity, label, &children_query, &mut text_query);
                 log::info!("Music toggled: {}", audio.music_enabled);
             }
@@ -617,30 +630,60 @@ pub fn spawn_resize_handles(
         // Spawn 8 handles (corners + edges)
         let edges = [
             (ResizeEdge::NorthWest, Val::Px(0.0), Val::Px(0.0)),
-            (ResizeEdge::North, Val::Px(size.x / 2.0 - HANDLE_SIZE / 2.0), Val::Px(0.0)),
-            (ResizeEdge::NorthEast, Val::Px(size.x - HANDLE_SIZE), Val::Px(0.0)),
-            (ResizeEdge::West, Val::Px(0.0), Val::Px(size.y / 2.0 - HANDLE_SIZE / 2.0)),
-            (ResizeEdge::East, Val::Px(size.x - HANDLE_SIZE), Val::Px(size.y / 2.0 - HANDLE_SIZE / 2.0)),
-            (ResizeEdge::SouthWest, Val::Px(0.0), Val::Px(size.y - HANDLE_SIZE)),
-            (ResizeEdge::South, Val::Px(size.x / 2.0 - HANDLE_SIZE / 2.0), Val::Px(size.y - HANDLE_SIZE)),
-            (ResizeEdge::SouthEast, Val::Px(size.x - HANDLE_SIZE), Val::Px(size.y - HANDLE_SIZE)),
+            (
+                ResizeEdge::North,
+                Val::Px(size.x / 2.0 - HANDLE_SIZE / 2.0),
+                Val::Px(0.0),
+            ),
+            (
+                ResizeEdge::NorthEast,
+                Val::Px(size.x - HANDLE_SIZE),
+                Val::Px(0.0),
+            ),
+            (
+                ResizeEdge::West,
+                Val::Px(0.0),
+                Val::Px(size.y / 2.0 - HANDLE_SIZE / 2.0),
+            ),
+            (
+                ResizeEdge::East,
+                Val::Px(size.x - HANDLE_SIZE),
+                Val::Px(size.y / 2.0 - HANDLE_SIZE / 2.0),
+            ),
+            (
+                ResizeEdge::SouthWest,
+                Val::Px(0.0),
+                Val::Px(size.y - HANDLE_SIZE),
+            ),
+            (
+                ResizeEdge::South,
+                Val::Px(size.x / 2.0 - HANDLE_SIZE / 2.0),
+                Val::Px(size.y - HANDLE_SIZE),
+            ),
+            (
+                ResizeEdge::SouthEast,
+                Val::Px(size.x - HANDLE_SIZE),
+                Val::Px(size.y - HANDLE_SIZE),
+            ),
         ];
 
         for (edge, left, top) in edges {
-            let handle = commands.spawn((
-                Button,
-                ResizeHandle { edge },
-                Node {
-                    position_type: PositionType::Absolute,
-                    left,
-                    top,
-                    width: Val::Px(HANDLE_SIZE),
-                    height: Val::Px(HANDLE_SIZE),
-                    ..default()
-                },
-                BackgroundColor(HANDLE_COLOR),
-                UiMarker,
-            )).id();
+            let handle = commands
+                .spawn((
+                    Button,
+                    ResizeHandle { edge },
+                    Node {
+                        position_type: PositionType::Absolute,
+                        left,
+                        top,
+                        width: Val::Px(HANDLE_SIZE),
+                        height: Val::Px(HANDLE_SIZE),
+                        ..default()
+                    },
+                    BackgroundColor(HANDLE_COLOR),
+                    UiMarker,
+                ))
+                .id();
             commands.entity(entity).add_child(handle);
         }
     }
@@ -651,7 +694,10 @@ pub fn spawn_resize_handles(
 pub fn handle_resize_start(
     mut resize_state: ResMut<ResizeState>,
     windows: Query<&Window>,
-    resize_handles: Query<(Entity, &ResizeHandle, &ChildOf, &Interaction), (With<Button>, Changed<Interaction>)>,
+    resize_handles: Query<
+        (Entity, &ResizeHandle, &ChildOf, &Interaction),
+        (With<Button>, Changed<Interaction>),
+    >,
     nodes: Query<&Node>,
 ) {
     let Ok(window) = windows.single() else {
@@ -771,12 +817,11 @@ pub fn handle_resize_end(
     mut resize_state: ResMut<ResizeState>,
     mouse_buttons: Res<ButtonInput<MouseButton>>,
 ) {
-    if mouse_buttons.just_released(MouseButton::Left)
-        && resize_state.resizing_entity.is_some() {
-            log::info!("Resize ended");
-            resize_state.resizing_entity = None;
-            resize_state.resize_edge = None;
-        }
+    if mouse_buttons.just_released(MouseButton::Left) && resize_state.resizing_entity.is_some() {
+        log::info!("Resize ended");
+        resize_state.resizing_entity = None;
+        resize_state.resize_edge = None;
+    }
 }
 
 /// Updates handle cursor to indicate resize direction.

--- a/viewer/src/sse/bridge.rs
+++ b/viewer/src/sse/bridge.rs
@@ -1,5 +1,5 @@
-use bevy::prelude::*;
 use bevy::ecs::system::SystemParam;
+use bevy::prelude::*;
 
 use super::client::SseReceiver;
 use crate::game::events::*;
@@ -9,7 +9,9 @@ use crate::game::state::ConnectionStatus;
 macro_rules! dispatch_event {
     ($event_type:expr, $data:expr, $writer:expr, $payload_ty:ty, $event_ty:ident) => {
         match serde_json::from_str::<$payload_ty>($data) {
-            Ok(payload) => { $writer.write($event_ty(payload)); }
+            Ok(payload) => {
+                $writer.write($event_ty(payload));
+            }
             Err(e) => log::warn!("Failed to parse {}: {}", $event_type, e),
         }
     };
@@ -87,38 +89,206 @@ pub fn poll_sse_events(
     for (event_type, data) in msgs.drain(..) {
         match event_type.as_str() {
             // ── Original events (underscore format) ──
-            "dice_roll" => dispatch_event!(event_type, &data, original.dice, DiceRollPayload, DiceRolled),
-            "hp_change" => dispatch_event!(event_type, &data, original.hp, HpChangePayload, HpChanged),
-            "narrative" => dispatch_event!(event_type, &data, original.narrative, NarrativePayload, NarrativeReceived),
-            "area_move" => dispatch_event!(event_type, &data, original.area, AreaMovePayload, AreaMoved),
-            "turn_advance" => dispatch_event!(event_type, &data, original.turn, TurnAdvancePayload, TurnAdvanced),
-            "choice_available" => dispatch_event!(event_type, &data, original.choice, ChoicePayload, ChoiceAvailable),
-            "choice_resolved" => dispatch_event!(event_type, &data, original.choice_resolved, ChoicePayload, ChoiceResolved),
-            "item_acquired" => dispatch_event!(event_type, &data, original.item, ItemPayload, ItemAcquired),
-            "character_death" => dispatch_event!(event_type, &data, original.death, DeathPayload, CharacterDied),
-            "combat_start" => dispatch_event!(event_type, &data, original.combat, CombatPayload, CombatStarted),
-            "weather_change" => dispatch_event!(event_type, &data, original.weather, WeatherChangePayload, WeatherChanged),
-            "mood_change" => dispatch_event!(event_type, &data, original.mood, MoodChangePayload, MoodChanged),
-            "turn_progress" => dispatch_event!(event_type, &data, original.progress, TurnProgressPayload, TurnProgressUpdated),
+            "dice_roll" => dispatch_event!(
+                event_type,
+                &data,
+                original.dice,
+                DiceRollPayload,
+                DiceRolled
+            ),
+            "hp_change" => {
+                dispatch_event!(event_type, &data, original.hp, HpChangePayload, HpChanged)
+            }
+            "narrative" => dispatch_event!(
+                event_type,
+                &data,
+                original.narrative,
+                NarrativePayload,
+                NarrativeReceived
+            ),
+            "area_move" => {
+                dispatch_event!(event_type, &data, original.area, AreaMovePayload, AreaMoved)
+            }
+            "turn_advance" => dispatch_event!(
+                event_type,
+                &data,
+                original.turn,
+                TurnAdvancePayload,
+                TurnAdvanced
+            ),
+            "choice_available" => dispatch_event!(
+                event_type,
+                &data,
+                original.choice,
+                ChoicePayload,
+                ChoiceAvailable
+            ),
+            "choice_resolved" => dispatch_event!(
+                event_type,
+                &data,
+                original.choice_resolved,
+                ChoicePayload,
+                ChoiceResolved
+            ),
+            "item_acquired" => {
+                dispatch_event!(event_type, &data, original.item, ItemPayload, ItemAcquired)
+            }
+            "character_death" => dispatch_event!(
+                event_type,
+                &data,
+                original.death,
+                DeathPayload,
+                CharacterDied
+            ),
+            "combat_start" => dispatch_event!(
+                event_type,
+                &data,
+                original.combat,
+                CombatPayload,
+                CombatStarted
+            ),
+            "weather_change" => dispatch_event!(
+                event_type,
+                &data,
+                original.weather,
+                WeatherChangePayload,
+                WeatherChanged
+            ),
+            "mood_change" => dispatch_event!(
+                event_type,
+                &data,
+                original.mood,
+                MoodChangePayload,
+                MoodChanged
+            ),
+            "turn_progress" => dispatch_event!(
+                event_type,
+                &data,
+                original.progress,
+                TurnProgressPayload,
+                TurnProgressUpdated
+            ),
             // ── Phase 1: High-frequency events (dot format) ──
-            "party.selected" => dispatch_event!(event_type, &data, phase1.party_selected, PartySelectedPayload, PartySelected),
-            "room.created" => dispatch_event!(event_type, &data, phase1.room_created, RoomCreatedPayload, RoomCreated),
-            "room.started" => dispatch_event!(event_type, &data, phase1.room_started, RoomLifecyclePayload, RoomStarted),
-            "session.started" => dispatch_event!(event_type, &data, phase1.session_started, SessionStartedPayload, SessionStarted),
-            "phase.changed" => dispatch_event!(event_type, &data, phase1.phase_changed, TurnAdvancePayload, PhaseChanged),
-            "turn.started" => dispatch_event!(event_type, &data, phase1.turn_started, TurnAdvancePayload, TurnStarted),
-            "keeper.unavailable" => dispatch_event!(event_type, &data, phase1.keeper_unavailable, KeeperUnavailablePayload, KeeperUnavailable),
+            "party.selected" => dispatch_event!(
+                event_type,
+                &data,
+                phase1.party_selected,
+                PartySelectedPayload,
+                PartySelected
+            ),
+            "room.created" => dispatch_event!(
+                event_type,
+                &data,
+                phase1.room_created,
+                RoomCreatedPayload,
+                RoomCreated
+            ),
+            "room.started" => dispatch_event!(
+                event_type,
+                &data,
+                phase1.room_started,
+                RoomLifecyclePayload,
+                RoomStarted
+            ),
+            "session.started" => dispatch_event!(
+                event_type,
+                &data,
+                phase1.session_started,
+                SessionStartedPayload,
+                SessionStarted
+            ),
+            "phase.changed" => dispatch_event!(
+                event_type,
+                &data,
+                phase1.phase_changed,
+                TurnAdvancePayload,
+                PhaseChanged
+            ),
+            "turn.started" => dispatch_event!(
+                event_type,
+                &data,
+                phase1.turn_started,
+                TurnAdvancePayload,
+                TurnStarted
+            ),
+            "keeper.unavailable" => dispatch_event!(
+                event_type,
+                &data,
+                phase1.keeper_unavailable,
+                KeeperUnavailablePayload,
+                KeeperUnavailable
+            ),
             // ── Phase 2: Intervention + Actor events (dot format) ──
-            "intervention.submitted" => dispatch_event!(event_type, &data, phase2.intervention_submitted, InterventionPayload, InterventionSubmitted),
-            "intervention.applied" => dispatch_event!(event_type, &data, phase2.intervention_applied, InterventionPayload, InterventionApplied),
-            "actor.spawned" => dispatch_event!(event_type, &data, phase2.actor_spawned, ActorLifecyclePayload, ActorSpawned),
-            "actor.deleted" => dispatch_event!(event_type, &data, phase2.actor_deleted, ActorLifecyclePayload, ActorDeleted),
-            "actor.claimed" => dispatch_event!(event_type, &data, phase2.actor_claimed, ActorLifecyclePayload, ActorClaimed),
-            "actor.released" => dispatch_event!(event_type, &data, phase2.actor_released, ActorLifecyclePayload, ActorReleased),
-            "actor.updated" => dispatch_event!(event_type, &data, phase2.actor_updated, ActorLifecyclePayload, ActorUpdated),
-            "room.ended" => dispatch_event!(event_type, &data, phase2.room_ended, RoomEndedPayload, RoomEnded),
-            "turn.action.resolved" => dispatch_event!(event_type, &data, phase2.turn_action_resolved, TurnActionResolvedPayload, TurnActionResolved),
-            "scene.transition" => dispatch_event!(event_type, &data, phase2.scene_transitioned, SceneTransitionPayload, SceneTransitioned),
+            "intervention.submitted" => dispatch_event!(
+                event_type,
+                &data,
+                phase2.intervention_submitted,
+                InterventionPayload,
+                InterventionSubmitted
+            ),
+            "intervention.applied" => dispatch_event!(
+                event_type,
+                &data,
+                phase2.intervention_applied,
+                InterventionPayload,
+                InterventionApplied
+            ),
+            "actor.spawned" => dispatch_event!(
+                event_type,
+                &data,
+                phase2.actor_spawned,
+                ActorLifecyclePayload,
+                ActorSpawned
+            ),
+            "actor.deleted" => dispatch_event!(
+                event_type,
+                &data,
+                phase2.actor_deleted,
+                ActorLifecyclePayload,
+                ActorDeleted
+            ),
+            "actor.claimed" => dispatch_event!(
+                event_type,
+                &data,
+                phase2.actor_claimed,
+                ActorLifecyclePayload,
+                ActorClaimed
+            ),
+            "actor.released" => dispatch_event!(
+                event_type,
+                &data,
+                phase2.actor_released,
+                ActorLifecyclePayload,
+                ActorReleased
+            ),
+            "actor.updated" => dispatch_event!(
+                event_type,
+                &data,
+                phase2.actor_updated,
+                ActorLifecyclePayload,
+                ActorUpdated
+            ),
+            "room.ended" => dispatch_event!(
+                event_type,
+                &data,
+                phase2.room_ended,
+                RoomEndedPayload,
+                RoomEnded
+            ),
+            "turn.action.resolved" => dispatch_event!(
+                event_type,
+                &data,
+                phase2.turn_action_resolved,
+                TurnActionResolvedPayload,
+                TurnActionResolved
+            ),
+            "scene.transition" => dispatch_event!(
+                event_type,
+                &data,
+                phase2.scene_transitioned,
+                SceneTransitionPayload,
+                SceneTransitioned
+            ),
             // ── Fallback ──
             other => {
                 log::debug!("Unhandled SSE event type: {}", other);

--- a/viewer/src/sse/client.rs
+++ b/viewer/src/sse/client.rs
@@ -1,7 +1,7 @@
-use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::{Arc, Mutex};
 #[cfg(any(target_arch = "wasm32", test))]
 use std::collections::VecDeque;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
 
 use bevy::prelude::*;
 #[cfg(any(target_arch = "wasm32", test))]
@@ -148,7 +148,7 @@ fn resolve_actor_id(payload: &Value, actor_id: Option<&str>) -> String {
         .and_then(Value::as_str)
         .or(actor_id)
         .unwrap_or("")
-    .to_string()
+        .to_string()
 }
 
 #[cfg(any(target_arch = "wasm32", test))]
@@ -157,7 +157,12 @@ fn snapshot_fingerprint(snapshot: &Value) -> String {
 }
 
 #[cfg(any(target_arch = "wasm32", test))]
-fn stream_event_fingerprint(event_type: &str, seq: i64, actor_id: Option<&str>, payload: &Value) -> String {
+fn stream_event_fingerprint(
+    event_type: &str,
+    seq: i64,
+    actor_id: Option<&str>,
+    payload: &Value,
+) -> String {
     let actor = actor_id.unwrap_or("").trim();
     format!("{seq}|{event_type}|{actor}|{payload}")
 }
@@ -211,9 +216,12 @@ fn snapshot_phase(root: &Value, fallback: &str) -> String {
 
 #[cfg(any(target_arch = "wasm32", test))]
 fn snapshot_dice_entries(root: &Value) -> Vec<Value> {
-    let source = root.get("dice_log").or_else(|| snapshot_root(root).get("dice_log"));
+    let source = root
+        .get("dice_log")
+        .or_else(|| snapshot_root(root).get("dice_log"));
     source
-        .and_then(Value::as_array).cloned()
+        .and_then(Value::as_array)
+        .cloned()
         .unwrap_or_default()
 }
 
@@ -236,7 +244,10 @@ fn map_snapshot_result(result: &Value) -> String {
         "miracle" | "기적" => "miracle",
         "success!" => "success",
         _ => {
-            let passed = result.get("passed").and_then(Value::as_bool).unwrap_or(false);
+            let passed = result
+                .get("passed")
+                .and_then(Value::as_bool)
+                .unwrap_or(false);
             if passed {
                 "success"
             } else {
@@ -248,7 +259,11 @@ fn map_snapshot_result(result: &Value) -> String {
 }
 
 #[cfg(any(target_arch = "wasm32", test))]
-fn map_snapshot_dice_roll(entry: &Value, fallback_turn: u32, _fallback_phase: &str) -> Option<(String, String)> {
+fn map_snapshot_dice_roll(
+    entry: &Value,
+    fallback_turn: u32,
+    _fallback_phase: &str,
+) -> Option<(String, String)> {
     if !entry.is_object() {
         return None;
     }
@@ -698,7 +713,9 @@ fn map_trpg_event(
         }
         // -- game.ended / quest.completed → narrative with endgame phase --
         "game.ended" | "quest.completed" => {
-            let text = payload.get("summary").and_then(Value::as_str)
+            let text = payload
+                .get("summary")
+                .and_then(Value::as_str)
                 .or_else(|| payload.get("text").and_then(Value::as_str))
                 .unwrap_or("The adventure has ended.");
             let mapped = json!({ "text": text, "phase": "endgame", "speaker": "DM" });
@@ -724,10 +741,7 @@ fn map_trpg_event(
 }
 
 #[cfg(any(target_arch = "wasm32", test))]
-fn decode_snapshot_events(
-    body: &Value,
-    state: &mut TrpgMapperState,
-) -> Vec<(String, String)> {
+fn decode_snapshot_events(body: &Value, state: &mut TrpgMapperState) -> Vec<(String, String)> {
     let status = snapshot_status(body);
     let signature = snapshot_fingerprint(body);
     if state.snapshot_signature.as_deref() == Some(signature.as_str()) {
@@ -752,10 +766,7 @@ fn decode_snapshot_events(
     let mut out = Vec::new();
 
     out.push(snapshot_room_status_progress_payload(
-        body,
-        &status,
-        turn,
-        &phase,
+        body, &status, turn, &phase,
     ));
 
     if turn > 0 {
@@ -1375,8 +1386,7 @@ mod tests {
             .iter()
             .find(|(event_type, _)| event_type == "narrative")
             .expect("narrative should exist");
-        let n_payload: Value =
-            serde_json::from_str(&narrative.1).expect("narrative payload json");
+        let n_payload: Value = serde_json::from_str(&narrative.1).expect("narrative payload json");
         assert_eq!(n_payload["text"], "Victory!");
         assert_eq!(n_payload["phase"], "endgame");
 
@@ -1384,16 +1394,14 @@ mod tests {
             .iter()
             .find(|(event_type, _)| event_type == "party.selected")
             .expect("party.selected should exist");
-        let p_payload: Value =
-            serde_json::from_str(&party.1).expect("party.selected payload json");
+        let p_payload: Value = serde_json::from_str(&party.1).expect("party.selected payload json");
         assert_eq!(p_payload["player_ids"], json!(["p1", "p2"]));
 
         let room = mapped
             .iter()
             .find(|(event_type, _)| event_type == "room.created")
             .expect("room.created should exist");
-        let r_payload: Value =
-            serde_json::from_str(&room.1).expect("room.created payload json");
+        let r_payload: Value = serde_json::from_str(&room.1).expect("room.created payload json");
         assert_eq!(r_payload["room_id"], "r1");
     }
 }

--- a/viewer/src/sse/masc_bridge.rs
+++ b/viewer/src/sse/masc_bridge.rs
@@ -11,14 +11,12 @@ pub struct MascLogEntry {
 }
 
 /// Resource holding MASC event state for DOM rendering.
-#[derive(Resource)]
-#[derive(Default)]
+#[derive(Resource, Default)]
 pub struct MascEventLog {
     pub entries: Vec<MascLogEntry>,
     pub agent_count: u32,
     pub task_count: u32,
 }
-
 
 /// Lightweight JSON field extractor.
 /// Finds `"key": "value"` or `"key": number` in a JSON string.

--- a/viewer/src/sse/masc_client.rs
+++ b/viewer/src/sse/masc_client.rs
@@ -12,12 +12,12 @@ use crate::config;
 use crate::mode::ViewerMode;
 
 #[cfg(target_arch = "wasm32")]
-use crate::game::state::ConnectionStatus;
-#[cfg(target_arch = "wasm32")]
 use super::reconnect;
+use super::reconnect::{ConnectionStatusBridge, SseReconnectManager};
 #[cfg(target_arch = "wasm32")]
 use super::reconnect::{ConnectionStatusProxy, ReconnectState};
-use super::reconnect::{ConnectionStatusBridge, SseReconnectManager};
+#[cfg(target_arch = "wasm32")]
+use crate::game::state::ConnectionStatus;
 
 /// Wrapper around `EventSource` that is `Send + Sync`.
 /// Safe because WASM is single-threaded — there are no real threads to race with.

--- a/viewer/src/sse/reconnect.rs
+++ b/viewer/src/sse/reconnect.rs
@@ -234,17 +234,23 @@ mod tests {
     fn reconnect_state_exponential_backoff() {
         let mut state = ReconnectState::default();
         // First delay should be around 1000ms (with jitter)
-        let d1 = state.next_delay().expect("next_delay should return Some on attempt 1");
+        let d1 = state
+            .next_delay()
+            .expect("next_delay should return Some on attempt 1");
         assert!(d1 >= 750 && d1 <= 1250, "d1={}", d1);
         assert_eq!(state.attempt, 1);
 
         // Second delay should be around 2000ms
-        let d2 = state.next_delay().expect("next_delay should return Some on attempt 2");
+        let d2 = state
+            .next_delay()
+            .expect("next_delay should return Some on attempt 2");
         assert!(d2 >= 1500 && d2 <= 2500, "d2={}", d2);
         assert_eq!(state.attempt, 2);
 
         // Third delay should be around 4000ms
-        let d3 = state.next_delay().expect("next_delay should return Some on attempt 3");
+        let d3 = state
+            .next_delay()
+            .expect("next_delay should return Some on attempt 3");
         assert!(d3 >= 3000 && d3 <= 5000, "d3={}", d3);
     }
 
@@ -256,7 +262,9 @@ mod tests {
             state.next_delay();
         }
         // By attempt 8, base delay should be capped at 30000ms
-        let d = state.next_delay().expect("next_delay should return Some before exhaustion");
+        let d = state
+            .next_delay()
+            .expect("next_delay should return Some before exhaustion");
         assert!(d <= 37500, "d={} should be <= 37500 (30000 + 25%)", d);
     }
 

--- a/viewer/src/sse/social_board.rs
+++ b/viewer/src/sse/social_board.rs
@@ -780,7 +780,8 @@ mod tests {
     #[test]
     fn deserialize_board_response() {
         let json = r#"{"posts":[{"id":"p1","author":"dreamer","content":"Hello","votes_up":3,"votes_down":1,"reply_count":2}]}"#;
-        let resp: BoardResponse = serde_json::from_str(json).expect("JSON: BoardResponse deserialization");
+        let resp: BoardResponse =
+            serde_json::from_str(json).expect("JSON: BoardResponse deserialization");
         assert_eq!(resp.posts.len(), 1);
         assert_eq!(resp.posts[0].author, "dreamer");
         assert_eq!(resp.posts[0].votes_up, 3);
@@ -789,14 +790,16 @@ mod tests {
     #[test]
     fn deserialize_empty_board() {
         let json = r#"{"posts":[]}"#;
-        let resp: BoardResponse = serde_json::from_str(json).expect("JSON: empty BoardResponse deserialization");
+        let resp: BoardResponse =
+            serde_json::from_str(json).expect("JSON: empty BoardResponse deserialization");
         assert!(resp.posts.is_empty());
     }
 
     #[test]
     fn deserialize_with_hearth() {
         let json = r#"{"posts":[{"id":"p2","author":"sage","content":"Thought","hearth":"philosophy","created_at":1700000000.0,"votes_up":0,"votes_down":0,"reply_count":0}]}"#;
-        let resp: BoardResponse = serde_json::from_str(json).expect("JSON: BoardResponse with hearth deserialization");
+        let resp: BoardResponse =
+            serde_json::from_str(json).expect("JSON: BoardResponse with hearth deserialization");
         assert_eq!(resp.posts[0].hearth.as_deref(), Some("philosophy"));
     }
 
@@ -809,7 +812,8 @@ mod tests {
                 {"id":"c2","author":"muse","content":"Interesting","created_at":1700000200.0,"votes_up":0,"votes_down":0}
             ]
         }"#;
-        let resp: PostDetailResponse = serde_json::from_str(json).expect("JSON: PostDetailResponse deserialization");
+        let resp: PostDetailResponse =
+            serde_json::from_str(json).expect("JSON: PostDetailResponse deserialization");
         assert_eq!(resp.post.id, "p1");
         assert_eq!(resp.comments.len(), 2);
         assert_eq!(resp.comments[0].author, "sage");
@@ -819,14 +823,16 @@ mod tests {
     #[test]
     fn deserialize_comment_with_parent() {
         let json = r#"{"id":"c3","author":"oracle","content":"Reply","parent_id":"c1","created_at":0.0,"votes_up":0,"votes_down":0}"#;
-        let comment: BoardComment = serde_json::from_str(json).expect("JSON: BoardComment deserialization");
+        let comment: BoardComment =
+            serde_json::from_str(json).expect("JSON: BoardComment deserialization");
         assert_eq!(comment.parent_id.as_deref(), Some("c1"));
     }
 
     #[test]
     fn deserialize_post_detail_no_comments() {
         let json = r#"{"post":{"id":"p3","author":"wanderer","content":"Solo"}}"#;
-        let resp: PostDetailResponse = serde_json::from_str(json).expect("JSON: PostDetailResponse no-comments deserialization");
+        let resp: PostDetailResponse = serde_json::from_str(json)
+            .expect("JSON: PostDetailResponse no-comments deserialization");
         assert!(resp.comments.is_empty());
     }
 

--- a/viewer/style.css
+++ b/viewer/style.css
@@ -360,7 +360,7 @@ body.mode-lobby #dashboard {
 
 #dashboard {
     display: grid;
-    grid-template-rows: 44px 1fr 120px;
+    grid-template-rows: 44px auto 1fr 120px;
     grid-template-columns: 1fr;
     height: 100vh;
     position: relative;
@@ -369,7 +369,7 @@ body.mode-lobby #dashboard {
 }
 
 #dashboard[data-debug="off"] {
-    grid-template-rows: 44px 1fr;
+    grid-template-rows: 44px auto 1fr;
 }
 
 #dashboard[data-debug="off"] #bottom-zone {
@@ -377,6 +377,64 @@ body.mode-lobby #dashboard {
 }
 #dashboard[data-debug="off"] .debug-only {
     display: none !important;
+}
+
+body:not(.mode-trpg) #ops-hud {
+    display: none !important;
+}
+
+#ops-hud {
+    background: var(--bg-panel);
+    border-bottom: 1px solid var(--border-main);
+    padding: 5px 12px;
+    display: grid;
+    grid-template-columns: repeat(6, minmax(110px, 1fr));
+    gap: 8px;
+    align-items: center;
+}
+
+.ops-hud-item {
+    min-width: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+}
+
+.ops-k {
+    font-size: 9px;
+    letter-spacing: 0.65px;
+    text-transform: uppercase;
+    color: var(--text-dim);
+}
+
+.ops-v {
+    font-size: 11px;
+    color: var(--text-primary);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.ops-v.status-active {
+    color: var(--status-connected);
+}
+
+.ops-v.status-loading {
+    color: var(--status-connecting);
+}
+
+.ops-v.status-warn {
+    color: #c4a265;
+}
+
+.ops-v.status-error,
+.ops-v.status-ended,
+.ops-v.status-unavailable {
+    color: var(--status-disconnected);
+}
+
+.ops-v.status-idle {
+    color: var(--text-dim);
 }
 
 /* ─── Top Bar ──────────────────────────── */
@@ -533,6 +591,49 @@ body.mode-lobby #dashboard {
     color: var(--text-primary);
 }
 
+.new-game-steps {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+}
+
+.new-game-steps span {
+    font-size: 10px;
+    border: 1px solid rgba(109, 122, 164, 0.35);
+    border-radius: 999px;
+    padding: 2px 8px;
+    color: var(--text-dim);
+    background: rgba(20, 26, 44, 0.6);
+}
+
+.new-game-step {
+    transition: border-color 0.2s, color 0.2s, background 0.2s;
+}
+
+.new-game-step.is-active {
+    border-color: rgba(196, 162, 101, 0.58);
+    color: #e4c895;
+    background: rgba(70, 52, 23, 0.28);
+}
+
+.new-game-step.is-done {
+    border-color: rgba(122, 206, 155, 0.55);
+    color: #96d8b3;
+    background: rgba(23, 56, 44, 0.32);
+}
+
+.new-game-step.is-error {
+    border-color: rgba(215, 118, 118, 0.58);
+    color: #dfa1a1;
+    background: rgba(80, 29, 29, 0.35);
+}
+
+.new-game-step-hint {
+    font-size: 10px;
+    color: var(--text-dim);
+    letter-spacing: 0.35px;
+}
+
 .new-game-grid {
     display: grid;
     grid-template-columns: repeat(2, minmax(180px, 1fr));
@@ -578,6 +679,7 @@ body.mode-lobby #dashboard {
     display: flex;
     align-items: center;
     gap: 8px;
+    flex-wrap: wrap;
 }
 
 .new-game-status {
@@ -586,6 +688,18 @@ body.mode-lobby #dashboard {
     border: 1px dashed var(--border-main);
     border-radius: var(--panel-radius);
     padding: 6px 8px;
+}
+
+.new-game-inline-hint {
+    margin-top: 2px;
+    font-size: 10px;
+    color: var(--text-dim);
+    text-transform: none;
+    letter-spacing: normal;
+}
+
+#new-game-autopick-btn {
+    align-self: flex-start;
 }
 
 .room-hub {
@@ -726,6 +840,9 @@ body.mode-lobby #dashboard {
 }
 
 @media (max-width: 1280px) {
+    #ops-hud {
+        grid-template-columns: repeat(3, minmax(120px, 1fr));
+    }
     .new-game-grid {
         grid-template-columns: 1fr;
     }
@@ -741,6 +858,12 @@ body.mode-lobby #dashboard {
     .bottom-pane + .bottom-pane {
         border-left: none;
         border-top: 1px solid var(--border-main);
+    }
+}
+
+@media (max-width: 820px) {
+    #ops-hud {
+        grid-template-columns: repeat(2, minmax(120px, 1fr));
     }
 }
 
@@ -1769,13 +1892,101 @@ body.mode-lobby #dashboard {
     text-transform: uppercase;
 }
 
+.lifecycle-diagram {
+    border: 1px solid rgba(109, 122, 164, 0.24);
+    border-radius: var(--panel-radius);
+    background: rgba(12, 16, 30, 0.64);
+    padding: 6px 8px;
+    margin: 0 0 8px;
+    display: grid;
+    gap: 5px;
+}
+
+.lifecycle-track {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 4px;
+}
+
+.lifecycle-track-alt {
+    opacity: 0.85;
+}
+
+.lifecycle-node {
+    border: 1px solid rgba(109, 122, 164, 0.34);
+    border-radius: 999px;
+    padding: 2px 8px;
+    font-size: 9px;
+    letter-spacing: 0.6px;
+    color: var(--text-dim);
+    background: rgba(20, 26, 44, 0.58);
+    text-transform: uppercase;
+    transition: border-color 0.2s, color 0.2s, background 0.2s;
+}
+
+.lifecycle-node.is-done {
+    border-color: rgba(124, 209, 161, 0.45);
+    color: #95d9b2;
+}
+
+.lifecycle-node.is-active {
+    border-color: rgba(196, 162, 101, 0.62);
+    color: #e4c895;
+    background: rgba(70, 52, 23, 0.32);
+}
+
+.lifecycle-node.is-error {
+    border-color: rgba(215, 118, 118, 0.62);
+    color: #dfa1a1;
+    background: rgba(80, 29, 29, 0.34);
+}
+
+.lifecycle-edge {
+    color: rgba(160, 170, 198, 0.75);
+    font-size: 10px;
+}
+
+.lifecycle-diagram-hint {
+    margin: -2px 0 8px;
+    color: var(--text-dim);
+    font-size: 10px;
+    line-height: 1.4;
+}
+
 /* ─── Turn Controls (advance turn button) ─── */
 
 #turn-controls {
     display: flex;
     align-items: center;
+    flex-wrap: wrap;
     gap: 8px;
     margin-bottom: 8px;
+}
+
+.turn-recovery-actions {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 6px;
+    margin: -2px 0 8px;
+}
+
+.turn-recovery-actions button {
+    background: rgba(16, 20, 34, 0.86);
+    border: 1px solid rgba(109, 122, 164, 0.42);
+    border-radius: 999px;
+    color: var(--text-secondary);
+    cursor: pointer;
+    font-family: var(--font-ui);
+    font-size: 0.66rem;
+    letter-spacing: 0.28px;
+    padding: 3px 9px;
+}
+
+.turn-recovery-actions button:hover {
+    border-color: rgba(196, 162, 101, 0.52);
+    color: #e4c895;
 }
 
 #session-history {
@@ -1922,6 +2133,75 @@ body.mode-lobby #dashboard {
     line-height: 1.4;
 }
 
+.round-sync-debug {
+    margin: 0 0 8px;
+    border: 1px solid var(--border-main);
+    border-radius: var(--panel-radius);
+    background: rgba(15, 20, 36, 0.62);
+    overflow: hidden;
+}
+
+.round-sync-debug summary {
+    cursor: pointer;
+    list-style: none;
+    padding: 6px 8px;
+    font-size: 10px;
+    letter-spacing: 0.5px;
+    color: var(--text-dim);
+    text-transform: uppercase;
+    border-bottom: 1px solid rgba(109, 122, 164, 0.2);
+}
+
+.round-sync-debug summary::-webkit-details-marker {
+    display: none;
+}
+
+.round-sync-debug-body {
+    display: grid;
+    gap: 4px;
+    padding: 8px;
+    font-size: 10px;
+    color: var(--text-dim);
+}
+
+.round-sync-row {
+    display: grid;
+    grid-template-columns: 84px 1fr;
+    gap: 6px;
+    align-items: baseline;
+}
+
+.round-sync-label {
+    color: var(--text-dim);
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+}
+
+.round-sync-value {
+    color: var(--text-primary);
+    overflow-wrap: anywhere;
+}
+
+.round-sync-value.sync-ok {
+    color: var(--status-connected);
+}
+
+.round-sync-value.sync-error {
+    color: var(--status-disconnected);
+}
+
+.round-sync-value.status-active {
+    color: var(--status-connected);
+}
+
+.round-sync-value.status-loading {
+    color: var(--status-connecting);
+}
+
+.round-sync-value.status-error {
+    color: var(--status-disconnected);
+}
+
 #advance-turn-btn {
     background: var(--bg-card);
     border: 1px solid var(--border-highlight, rgba(196, 162, 101, 0.2));
@@ -1966,6 +2246,35 @@ body.mode-lobby #dashboard {
 
 #turn-control-status.status-error {
     color: #d44;
+}
+
+#round-recovery-btn {
+    background: transparent;
+    border: 1px solid rgba(196, 162, 101, 0.4);
+    border-radius: 999px;
+    color: #c4a265;
+    cursor: pointer;
+    font-family: var(--font-ui);
+    font-size: 0.68rem;
+    letter-spacing: 0.3px;
+    padding: 3px 10px;
+}
+
+#round-recovery-btn:hover {
+    background: rgba(196, 162, 101, 0.12);
+    color: var(--text-bright);
+}
+
+.turn-recovery-note {
+    margin: 0 0 8px;
+    padding: 8px 10px;
+    border: 1px solid rgba(196, 162, 101, 0.25);
+    border-radius: 8px;
+    background: rgba(80, 56, 20, 0.2);
+    color: #e3d1aa;
+    font-size: 0.72rem;
+    line-height: 1.45;
+    white-space: pre-line;
 }
 
 #dice-log {


### PR DESCRIPTION
## Summary\n- add TRPG ops HUD (room/session/round/connection/control/sync)\n- simplify New Game UX with step chips, player hint, auto-pick, and quick-start\n- add round sync debug panel and wire runtime sync diagnostics\n- reset new HUD/debug state on room/game clear\n\n## Validation\n- cargo test --manifest-path viewer/Cargo.toml --release\n- scripts/viewer-trunk.sh build\n