### PR TITLE
fix(viewer): replace emoji with ASCII in Bevy UI text

### DIFF
--- a/viewer/src/render/ui.rs
+++ b/viewer/src/render/ui.rs
@@ -82,7 +82,7 @@ pub fn setup_ui(mut commands: Commands) {
                 ))
                 .with_children(|parent| {
                     parent.spawn((
-                        Text::new("⚙"),
+                        Text::new("S"),
                         TextFont {
                             font_size: 20.0,
                             ..default()
@@ -111,7 +111,7 @@ pub fn setup_ui(mut commands: Commands) {
                 ))
                 .with_children(|parent| {
                     parent.spawn((
-                        Text::new("🔧"),
+                        Text::new("D"),
                         TextFont {
                             font_size: 20.0,
                             ..default()
@@ -212,7 +212,7 @@ fn spawn_settings_menu(commands: &mut Commands) {
         .with_children(|parent| {
             // Title
             parent.spawn((
-                Text::new("⚙️ Settings"),
+                Text::new("Settings"),
                 TextFont {
                     font_size: 16.0,
                     ..default()
@@ -351,7 +351,7 @@ fn spawn_dev_menu(commands: &mut Commands) {
         .with_children(|parent| {
             // Title
             parent.spawn((
-                Text::new("🔧 Developer"),
+                Text::new("Developer"),
                 TextFont {
                     font_size: 16.0,
                     ..default()


### PR DESCRIPTION
## Summary
- Bevy default FiraMono-subset font lacks emoji glyphs causing garbled text in WASM canvas
- Settings button: gear emoji to S, Dev button: wrench emoji to D
- Settings/Dev panel titles: drop emoji prefixes
- trunk build --release verified