### PR TITLE
refactor(viewer): cfg-gate wasm32-only functions (0 warnings)

### DIFF
--- a/viewer/src/dom/turn_controls.rs
+++ b/viewer/src/dom/turn_controls.rs
@@ -21,13 +21,16 @@ use wasm_bindgen::prelude::*;
 
 #[cfg(target_arch = "wasm32")]
 use crate::config;
+#[cfg(any(target_arch = "wasm32", test))]
 use crate::game::lifecycle::TrpgLifecycleState;
 use crate::game::state::{ConnectionStatus, RoomState, TurnProgressState};
 
+#[cfg(any(target_arch = "wasm32", test))]
 fn connection_ready(status: &ConnectionStatus) -> bool {
     matches!(status, ConnectionStatus::Connected)
 }
 
+#[cfg(any(target_arch = "wasm32", test))]
 fn derive_round_control_state(
     lifecycle: TrpgLifecycleState,
     connection_ok: bool,
@@ -63,6 +66,7 @@ fn control_status_to_ops_class(css_class: &str) -> &'static str {
     }
 }
 
+#[cfg(any(target_arch = "wasm32", test))]
 fn round_advanced(turn_before: u64, turn_after: u64, summary_advanced: Option<bool>) -> bool {
     summary_advanced.unwrap_or(turn_after > turn_before)
 }

--- a/viewer/src/game/lifecycle.rs
+++ b/viewer/src/game/lifecycle.rs
@@ -93,6 +93,7 @@ impl TrpgLifecycleState {
         }
     }
 
+    #[cfg(any(target_arch = "wasm32", test))]
     pub fn help_text(self) -> &'static str {
         match self {
             Self::Lobby => "세션 미시작 또는 초기 대기 상태",
@@ -105,6 +106,7 @@ impl TrpgLifecycleState {
         }
     }
 
+    #[cfg(any(target_arch = "wasm32", test))]
     pub fn allows_round_control(self) -> bool {
         matches!(self, Self::Running | Self::Stopped)
     }


### PR DESCRIPTION
## Summary
- Gate 4 dead-code warnings behind `#[cfg(any(target_arch = "wasm32", test))]`
- Additionally gate the `TrpgLifecycleState` import that became unused after gating `derive_round_control_state`

## Changes
**`viewer/src/dom/turn_controls.rs`** (4 gates added):
- `connection_ready` fn
- `derive_round_control_state` fn
- `round_advanced` fn
- `use crate::game::lifecycle::TrpgLifecycleState` import

**`viewer/src/game/lifecycle.rs`** (2 gates added):
- `help_text` method
- `allows_round_control` method

## Gate choice: `cfg(any(target_arch = "wasm32", test))`
All gated items are called from `#[cfg(target_arch = "wasm32")]` blocks AND from `#[cfg(test)]` modules. Using `any(wasm32, test)` keeps test coverage while eliminating native-target warnings.

## Verification
- `cargo check`: 0 warnings (native)
- `cargo test -p viewer`: 53 passed, 0 failed
- `cargo check --target wasm32-unknown-unknown`: 0 errors