### PR TITLE
fix(viewer): make round gate state and keeper selection explicit

### DIFF
--- a/viewer/index.html
+++ b/viewer/index.html
@@ -251,6 +251,7 @@
                         <select id="new-game-dm-select" title="게임을 진행할 AI 에이전트 선택">
                             <option value="">로딩 중...</option>
                         </select>
+                        <div id="new-game-dm-hint" class="new-game-inline-hint">DM을 1명 선택하세요.</div>
                     </label>
 
                     <label class="new-game-field">
@@ -258,7 +259,7 @@
                         <select id="new-game-player-select" multiple size="6" title="게임에 참여할 AI 에이전트 선택 (Ctrl/Cmd+클릭)">
                             <option value="">로딩 중...</option>
                         </select>
-                        <div id="new-game-player-hint" class="new-game-inline-hint">플레이어 0명 선택됨</div>
+                        <div id="new-game-player-hint" class="new-game-inline-hint">플레이어 0명 선택됨 · DM과 중복 불가</div>
                         <button id="new-game-autopick-btn" class="inline-toggle" type="button">4인 자동선택</button>
                     </label>
 
@@ -385,6 +386,7 @@
                         <button id="advance-turn-btn" title="다음 TRPG 라운드를 실행합니다">라운드 실행</button>
                         <span id="turn-control-status"></span>
                         <button id="round-recovery-btn" type="button" style="display:none">복구 가이드 보기</button>
+                        <div id="turn-control-gate" class="turn-control-gate status-info">실행 조건 점검 중...</div>
                     </div>
                     <div id="round-recovery-actions" class="turn-recovery-actions" style="display:none">
                         <button id="round-recovery-refresh" type="button" title="키퍼/프리셋을 다시 동기화합니다">Keeper 새로고침</button>

--- a/viewer/src/dom/turn_controls.rs
+++ b/viewer/src/dom/turn_controls.rs
@@ -87,6 +87,7 @@ pub fn bind_turn_controls(mut commands: Commands) {
         bind_recovery_action_buttons();
         clear_round_recovery();
         set_turn_status("라운드 실행 준비 중...", "status-info");
+        set_turn_gate_reason("실행 조건 점검 중...", "status-info");
         log::info!("TurnControls: bound");
     }
 
@@ -98,6 +99,7 @@ pub fn unbind_turn_controls(mut commands: Commands) {
     {
         clear_turn_status();
         clear_round_recovery();
+        set_turn_gate_reason("", "");
         log::info!("TurnControls: unbound");
     }
 
@@ -153,6 +155,14 @@ pub fn sync_turn_controls_visibility(
             set_advance_disabled(!can_run);
             set_turn_status(&reason, reason_class);
         }
+        let gate_message = if busy {
+            "라운드 실행 중입니다. 완료 후 조건을 다시 계산합니다.".to_string()
+        } else if can_run {
+            "실행 가능: DM/플레이어 keeper 배정이 준비되었습니다.".to_string()
+        } else {
+            format!("실행 대기: {}", reason)
+        };
+        set_turn_gate_reason(&gate_message, reason_class);
     }
 }
 
@@ -189,15 +199,18 @@ fn on_advance_click() {
     }
     if let Err(reason) = read_advance_gate(&doc) {
         set_turn_status(&format!("실행 불가: {}", reason), "status-warn");
+        set_turn_gate_reason(&format!("실행 대기: {}", reason), "status-warn");
         return;
     }
     if let Err(reason) = read_round_run_plan(&doc) {
         set_turn_status(&format!("실행 불가: {}", reason), "status-warn");
+        set_turn_gate_reason(&format!("실행 대기: {}", reason), "status-warn");
         return;
     }
 
     clear_round_recovery();
     set_turn_status("라운드 실행 중...", "status-info");
+    set_turn_gate_reason("라운드 실행 요청 전송 중...", "status-info");
     set_advance_busy(true);
 
     wasm_bindgen_futures::spawn_local(async move {
@@ -205,16 +218,25 @@ fn on_advance_click() {
             Ok(RoundRunOutcome::Advanced(msg)) => {
                 clear_round_recovery();
                 set_turn_status(&msg, "status-ok");
+                set_turn_gate_reason(
+                    "실행 완료: 다음 라운드 조건을 다시 계산합니다.",
+                    "status-ok",
+                );
             }
             Ok(RoundRunOutcome::Stalled { status, guide }) => {
                 set_round_recovery(Some(&guide));
                 set_turn_status(&status, "status-warn");
+                set_turn_gate_reason(&format!("실행 보류: {}", status), "status-warn");
             }
             Err(e) => {
                 let detail = e.as_string().unwrap_or_else(|| format!("{:?}", e));
                 log::warn!("Advance turn failed: {}", detail);
                 clear_round_recovery();
                 set_turn_status(&format!("Failed: {}", detail), "status-error");
+                set_turn_gate_reason(
+                    &format!("실행 실패: {}", shorten_reason(&detail, 180)),
+                    "status-error",
+                );
             }
         }
         set_advance_busy(false);
@@ -455,6 +477,24 @@ fn set_turn_status(text: &str, css_class: &str) {
         let _ = el.set_attribute("class", &class_name);
         let _ = el.set_attribute("title", text);
     }
+}
+
+#[cfg(target_arch = "wasm32")]
+fn set_turn_gate_reason(text: &str, css_class: &str) {
+    let Some(doc) = web_sys::window().and_then(|w| w.document()) else {
+        return;
+    };
+    let Some(el) = doc.get_element_by_id("turn-control-gate") else {
+        return;
+    };
+    el.set_text_content(Some(text));
+
+    let class_name = if css_class.trim().is_empty() {
+        "turn-control-gate".to_string()
+    } else {
+        format!("turn-control-gate {}", css_class)
+    };
+    let _ = el.set_attribute("class", &class_name);
 }
 
 #[cfg(target_arch = "wasm32")]

--- a/viewer/src/mode/mod.rs
+++ b/viewer/src/mode/mod.rs
@@ -630,6 +630,14 @@ pub(super) fn clear_trpg_dom(doc: &web_sys::Document) {
     if let Some(el) = doc.get_element_by_id("turn-controls") {
         let _ = el.set_attribute("style", "display:none");
     }
+    if let Some(el) = doc.get_element_by_id("turn-control-status") {
+        el.set_text_content(Some(""));
+        let _ = el.set_attribute("class", "");
+    }
+    if let Some(el) = doc.get_element_by_id("turn-control-gate") {
+        el.set_text_content(Some("실행 조건 점검 중..."));
+        let _ = el.set_attribute("class", "turn-control-gate status-info");
+    }
     if let Some(el) = doc.get_element_by_id("action-panel") {
         let _ = el.set_attribute("style", "display:none");
     }

--- a/viewer/src/mode/trpg_controls.rs
+++ b/viewer/src/mode/trpg_controls.rs
@@ -152,6 +152,31 @@ fn set_step_state(doc: &web_sys::Document, id: &str, state: &str) {
     }
 }
 
+fn set_inline_hint(doc: &web_sys::Document, id: &str, text: &str, state: &str) {
+    let Some(el) = doc.get_element_by_id(id) else {
+        return;
+    };
+    let class_name = match state {
+        "ok" => "new-game-inline-hint is-ok",
+        "warn" => "new-game-inline-hint is-warn",
+        "error" => "new-game-inline-hint is-error",
+        _ => "new-game-inline-hint",
+    };
+    let _ = el.set_attribute("class", class_name);
+    el.set_text_content(Some(text));
+}
+
+fn summarize_names(names: &[String], max_preview: usize) -> String {
+    if names.is_empty() {
+        return "-".to_string();
+    }
+    if names.len() <= max_preview {
+        return names.join(", ");
+    }
+    let preview = names[..max_preview].join(", ");
+    format!("{} 외 {}명", preview, names.len() - max_preview)
+}
+
 fn sync_new_game_wizard_ui(doc: &web_sys::Document) {
     let preflight_state = new_game_preflight_state(doc);
     let dm_keeper = selected_dm_keeper(doc);
@@ -193,34 +218,85 @@ fn sync_new_game_wizard_ui(doc: &web_sys::Document) {
     set_step_state(doc, "new-game-step-2", step2_state);
     set_step_state(doc, "new-game-step-3", step3_state);
 
+    let start_gate_reason = if busy {
+        "세션 시작 작업 실행 중입니다. 완료까지 기다려주세요.".to_string()
+    } else if preflight_state != "ok" {
+        "사전 점검을 먼저 통과해야 세션 시작이 가능합니다.".to_string()
+    } else if !dm_selected {
+        "DM keeper를 선택하세요.".to_string()
+    } else if has_conflict {
+        "DM keeper와 플레이어 keeper가 중복되었습니다.".to_string()
+    } else if players.is_empty() {
+        "플레이어 keeper를 최소 1명 선택하세요.".to_string()
+    } else {
+        format!(
+            "세션 시작 가능: DM {} / 플레이어 {}명",
+            dm_keeper,
+            players.len()
+        )
+    };
+
     if let Some(start_btn) = doc
         .get_element_by_id("new-game-start")
         .and_then(|el| el.dyn_into::<web_sys::HtmlButtonElement>().ok())
     {
         start_btn.set_disabled(!ready || busy);
+        start_btn.set_title(&start_gate_reason);
     }
 
     if let Some(hint) = doc.get_element_by_id("new-game-step-hint") {
-        let text = if busy {
-            "세션 시작 작업 실행 중입니다. 완료될 때까지 기다려주세요.".to_string()
-        } else if preflight_state != "ok" {
-            "1단계: 사전 점검을 먼저 통과해야 세션 시작이 가능합니다.".to_string()
-        } else if !dm_selected {
-            "2단계: DM keeper를 선택하세요.".to_string()
-        } else if has_conflict {
-            "2단계: DM과 플레이어 keeper가 중복되었습니다. 서로 다른 keeper를 선택하세요."
-                .to_string()
-        } else if players.is_empty() {
-            "2단계: 플레이어 keeper를 최소 1명 선택하세요.".to_string()
-        } else {
+        let text = if ready {
             format!(
-                "3단계 준비 완료: DM {} · 플레이어 {}명. 세션 시작 버튼을 누르세요.",
+                "3단계 준비 완료: DM {} · 플레이어 {}명({}). 세션 시작 버튼을 누르세요.",
                 dm_keeper,
-                players.len()
+                players.len(),
+                summarize_names(&players, 3)
             )
+        } else {
+            format!("진행 가이드: {}", start_gate_reason)
         };
         hint.set_text_content(Some(&text));
     }
+
+    let dm_hint = if dm_selected {
+        format!("선택된 DM: {}", dm_keeper)
+    } else {
+        "DM을 1명 선택하세요.".to_string()
+    };
+    set_inline_hint(
+        doc,
+        "new-game-dm-hint",
+        &dm_hint,
+        if dm_selected { "ok" } else { "warn" },
+    );
+
+    let player_hint = if has_conflict {
+        format!(
+            "플레이어 {}명 선택됨 · DM({})과 중복됨",
+            players.len(),
+            dm_keeper
+        )
+    } else if players.is_empty() {
+        "플레이어 0명 선택됨 · DM과 중복 불가".to_string()
+    } else {
+        format!(
+            "플레이어 {}명 선택됨 · {}",
+            players.len(),
+            summarize_names(&players, 4)
+        )
+    };
+    set_inline_hint(
+        doc,
+        "new-game-player-hint",
+        &player_hint,
+        if has_conflict {
+            "error"
+        } else if players.is_empty() {
+            "warn"
+        } else {
+            "ok"
+        },
+    );
 }
 
 fn ensure_new_game_ready(doc: &web_sys::Document) -> Result<(), String> {
@@ -247,12 +323,47 @@ fn update_new_game_player_hint(doc: &web_sys::Document) {
     };
     let players = selected_player_keepers(doc);
     let dm_keeper = selected_dm_keeper(doc);
-
-    let mut message = format!("플레이어 {}명 선택됨", players.len());
-    if !dm_keeper.is_empty() && players.iter().any(|name| name == &dm_keeper) {
-        message.push_str(&format!(" · DM 중복: {}", dm_keeper));
-    }
+    let conflict = !dm_keeper.is_empty() && players.iter().any(|name| name == &dm_keeper);
+    let message = if conflict {
+        format!(
+            "플레이어 {}명 선택됨 · DM({})과 중복됨",
+            players.len(),
+            dm_keeper
+        )
+    } else if players.is_empty() {
+        "플레이어 0명 선택됨 · DM과 중복 불가".to_string()
+    } else {
+        format!(
+            "플레이어 {}명 선택됨 · {}",
+            players.len(),
+            summarize_names(&players, 4)
+        )
+    };
+    let state = if conflict {
+        "error"
+    } else if players.is_empty() {
+        "warn"
+    } else {
+        "ok"
+    };
+    let class_name = match state {
+        "ok" => "new-game-inline-hint is-ok",
+        "warn" => "new-game-inline-hint is-warn",
+        "error" => "new-game-inline-hint is-error",
+        _ => "new-game-inline-hint",
+    };
+    let _ = hint.set_attribute("class", class_name);
     hint.set_text_content(Some(&message));
+
+    if let Some(dm_hint) = doc.get_element_by_id("new-game-dm-hint") {
+        if dm_keeper.is_empty() {
+            let _ = dm_hint.set_attribute("class", "new-game-inline-hint is-warn");
+            dm_hint.set_text_content(Some("DM을 1명 선택하세요."));
+        } else {
+            let _ = dm_hint.set_attribute("class", "new-game-inline-hint is-ok");
+            dm_hint.set_text_content(Some(&format!("선택된 DM: {}", dm_keeper)));
+        }
+    }
     sync_new_game_wizard_ui(doc);
 }
 

--- a/viewer/style.css
+++ b/viewer/style.css
@@ -696,6 +696,19 @@ body:not(.mode-trpg) #ops-hud {
     color: var(--text-dim);
     text-transform: none;
     letter-spacing: normal;
+    line-height: 1.35;
+}
+
+.new-game-inline-hint.is-ok {
+    color: #96d8b3;
+}
+
+.new-game-inline-hint.is-warn {
+    color: #d9b06c;
+}
+
+.new-game-inline-hint.is-error {
+    color: #dfa1a1;
 }
 
 #new-game-autopick-btn {
@@ -2246,6 +2259,40 @@ body:not(.mode-trpg) #ops-hud {
 
 #turn-control-status.status-error {
     color: #d44;
+}
+
+.turn-control-gate {
+    flex: 1 1 100%;
+    border: 1px solid var(--border-main);
+    border-radius: 8px;
+    padding: 5px 8px;
+    font-size: 0.7rem;
+    line-height: 1.35;
+    color: var(--text-dim);
+    background: rgba(255, 255, 255, 0.03);
+}
+
+.turn-control-gate.status-ok {
+    border-color: rgba(122, 206, 155, 0.4);
+    color: #96d8b3;
+    background: rgba(23, 56, 44, 0.22);
+}
+
+.turn-control-gate.status-info {
+    border-color: rgba(109, 122, 164, 0.4);
+    color: var(--text-dim);
+}
+
+.turn-control-gate.status-warn {
+    border-color: rgba(196, 162, 101, 0.42);
+    color: #d9b06c;
+    background: rgba(70, 52, 23, 0.24);
+}
+
+.turn-control-gate.status-error {
+    border-color: rgba(215, 118, 118, 0.46);
+    color: #dfa1a1;
+    background: rgba(80, 29, 29, 0.28);
 }
 
 #round-recovery-btn {


### PR DESCRIPTION
## Summary
- make round-run gate reason always visible in TRPG controls (`#turn-control-gate`)
- show clearer gate messages for ready/running/stalled/error paths in turn control flow
- improve new-game keeper selection hints:
  - explicit DM selection hint
  - explicit player selection summary + DM overlap warning
  - start button tooltip now tells why start is blocked
- reset gate/hint text in `clear_trpg_dom` so stale state does not leak across rooms/sessions

## Why
Users were seeing cases where the round button looked inactive/unclear and DM/player keeper selection felt ambiguous. This patch makes the UI explain *why* actions are blocked and what to fix next.

## Validation
- `cargo fmt --manifest-path viewer/Cargo.toml`
- `cargo test --manifest-path viewer/Cargo.toml --bin masc-viewer turn_controls`
- `cargo check --manifest-path viewer/Cargo.toml --target wasm32-unknown-unknown --bin masc-viewer`
