### PR TITLE
fix(viewer): serialize manual and auto round execution

### DIFF
--- a/viewer/src/dom/turn_controls.rs
+++ b/viewer/src/dom/turn_controls.rs
@@ -97,6 +97,10 @@ pub fn bind_turn_controls(mut commands: Commands) {
 pub fn unbind_turn_controls(mut commands: Commands) {
     #[cfg(target_arch = "wasm32")]
     {
+        release_round_flight("manual");
+        if let Some(doc) = web_sys::window().and_then(|w| w.document()) {
+            set_round_run_controls_locked(&doc, false);
+        }
         clear_turn_status();
         clear_round_recovery();
         set_turn_gate_reason("", "");
@@ -133,14 +137,30 @@ pub fn sync_turn_controls_visibility(
         let _ = panel.set_attribute("data-lifecycle", lifecycle.css_class());
 
         let plan_error = read_round_run_plan(&doc).err();
-        let (can_run, reason, reason_class) =
+        let (mut can_run, mut reason, mut reason_class) =
             derive_round_control_state(lifecycle, connection_ok, plan_error.as_deref());
+        let lock_owner = current_round_flight_owner(&doc);
+        let runner_active = auto_round_runner_active(&doc);
+        if runner_active {
+            can_run = false;
+            reason = "실행 대기: 자동 라운드 실행 중입니다. 관전 모드에서는 수동 실행이 잠금됩니다."
+                .to_string();
+            reason_class = "status-info";
+        } else if let Some(owner) = lock_owner.as_deref() {
+            if owner != "manual" {
+                can_run = false;
+                reason = format!("실행 대기: {} 라운드 요청 처리 중입니다.", owner);
+                reason_class = "status-info";
+            }
+        }
 
         let busy = doc
             .get_element_by_id("advance-turn-btn")
             .and_then(|el| el.dyn_into::<HtmlButtonElement>().ok())
             .and_then(|btn| btn.get_attribute("data-busy"))
             .is_some_and(|v| v == "1");
+        let locked = lock_owner.is_some() || runner_active;
+        set_round_run_controls_locked(&doc, locked);
 
         if let Some(btn) = doc
             .get_element_by_id("advance-turn-btn")
@@ -152,11 +172,15 @@ pub fn sync_turn_controls_visibility(
         }
 
         if !busy {
-            set_advance_disabled(!can_run);
+            set_advance_disabled(!can_run || locked);
             set_turn_status(&reason, reason_class);
         }
         let gate_message = if busy {
             "라운드 실행 중입니다. 완료 후 조건을 다시 계산합니다.".to_string()
+        } else if runner_active {
+            "실행 대기: 자동 라운드 실행 중입니다. 수동 실행은 잠겨 있습니다.".to_string()
+        } else if let Some(owner) = lock_owner {
+            format!("실행 대기: {} 라운드 요청 처리 중입니다.", owner)
         } else if can_run {
             "실행 가능: DM/플레이어 keeper 배정이 준비되었습니다.".to_string()
         } else {
@@ -207,6 +231,19 @@ fn on_advance_click() {
         set_turn_gate_reason(&format!("실행 대기: {}", reason), "status-warn");
         return;
     }
+    if auto_round_runner_active(&doc) {
+        set_turn_status("실행 불가: 자동 라운드 실행 중입니다.", "status-warn");
+        set_turn_gate_reason(
+            "실행 대기: 자동 라운드 실행이 끝난 뒤 수동 실행이 가능합니다.",
+            "status-info",
+        );
+        return;
+    }
+    if let Err(reason) = acquire_round_flight(&doc, "manual") {
+        set_turn_status(&format!("실행 대기: {}", reason), "status-info");
+        set_turn_gate_reason(&format!("실행 대기: {}", reason), "status-info");
+        return;
+    }
 
     clear_round_recovery();
     set_turn_status("라운드 실행 중...", "status-info");
@@ -240,6 +277,7 @@ fn on_advance_click() {
             }
         }
         set_advance_busy(false);
+        release_round_flight("manual");
     });
 }
 
@@ -503,6 +541,94 @@ fn clear_turn_status() {
 }
 
 #[cfg(target_arch = "wasm32")]
+fn auto_round_runner_active(doc: &web_sys::Document) -> bool {
+    doc.get_element_by_id("dashboard")
+        .and_then(|el| el.get_attribute("data-round-runner-active"))
+        .is_some_and(|value| value == "1")
+}
+
+#[cfg(target_arch = "wasm32")]
+fn current_round_flight_owner(doc: &web_sys::Document) -> Option<String> {
+    doc.get_element_by_id("dashboard")
+        .and_then(|el| el.get_attribute("data-round-flight-owner"))
+        .map(|owner| owner.trim().to_string())
+        .filter(|owner| !owner.is_empty())
+}
+
+#[cfg(target_arch = "wasm32")]
+fn acquire_round_flight(doc: &web_sys::Document, owner: &str) -> Result<(), String> {
+    let Some(dashboard) = doc.get_element_by_id("dashboard") else {
+        return Ok(());
+    };
+    let existing = dashboard
+        .get_attribute("data-round-flight-owner")
+        .unwrap_or_default()
+        .trim()
+        .to_string();
+    if existing.is_empty() {
+        let _ = dashboard.set_attribute("data-round-flight-owner", owner);
+        return Ok(());
+    }
+    if existing == owner {
+        return Err("이미 수동 라운드 실행 중입니다.".to_string());
+    }
+    Err(format!("{} 라운드 실행이 진행 중입니다.", existing))
+}
+
+#[cfg(target_arch = "wasm32")]
+fn release_round_flight(owner: &str) {
+    let Some(doc) = web_sys::window().and_then(|w| w.document()) else {
+        return;
+    };
+    let Some(dashboard) = doc.get_element_by_id("dashboard") else {
+        return;
+    };
+    let existing = dashboard
+        .get_attribute("data-round-flight-owner")
+        .unwrap_or_default()
+        .trim()
+        .to_string();
+    if existing == owner {
+        let _ = dashboard.remove_attribute("data-round-flight-owner");
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+fn set_round_run_controls_locked(doc: &web_sys::Document, locked: bool) {
+    if let Some(panel) = doc.get_element_by_id("turn-controls") {
+        let _ = panel.set_attribute("data-round-controls-locked", if locked { "1" } else { "0" });
+    }
+    for id in [
+        "round-recovery-refresh",
+        "round-recovery-timeout",
+        "round-recovery-retry",
+    ] {
+        if let Some(btn) = doc
+            .get_element_by_id(id)
+            .and_then(|el| el.dyn_into::<HtmlButtonElement>().ok())
+        {
+            btn.set_disabled(locked);
+        }
+    }
+    for id in ["round-run-dm", "round-run-players", "round-run-timeout"] {
+        if let Some(input) = doc
+            .get_element_by_id(id)
+            .and_then(|el| el.dyn_into::<HtmlInputElement>().ok())
+        {
+            input.set_disabled(locked);
+        }
+    }
+    for id in ["round-run-phase", "round-run-lang"] {
+        if let Some(select) = doc
+            .get_element_by_id(id)
+            .and_then(|el| el.dyn_into::<HtmlSelectElement>().ok())
+        {
+            select.set_disabled(locked);
+        }
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
 fn bind_recovery_button() {
     let Some(doc) = web_sys::window().and_then(|w| w.document()) else {
         return;
@@ -717,6 +843,8 @@ fn set_advance_busy(busy: bool) {
             }
         }
     }
+    let lock_active = current_round_flight_owner(&doc).is_some();
+    set_round_run_controls_locked(&doc, busy || lock_active);
 }
 
 #[cfg(target_arch = "wasm32")]

--- a/viewer/src/game/round_runner.rs
+++ b/viewer/src/game/round_runner.rs
@@ -63,12 +63,15 @@ pub fn start_round_loop(mut commands: Commands, progress: Res<TurnProgressState>
     #[cfg(target_arch = "wasm32")]
     if !auto_round_enabled() {
         runner.running.store(false, Ordering::SeqCst);
+        set_dom_runner_active(false);
         log::info!("RoundRunner: auto round loop disabled (manual Run Round only)");
         commands.insert_resource(runner);
         return;
     }
 
     runner.running.store(true, Ordering::SeqCst);
+    #[cfg(target_arch = "wasm32")]
+    set_dom_runner_active(true);
 
     #[cfg(target_arch = "wasm32")]
     {
@@ -91,9 +94,6 @@ pub fn start_round_loop(mut commands: Commands, progress: Res<TurnProgressState>
                 && !game_ended.load(Ordering::SeqCst)
                 && round_num < MAX_ROUNDS
             {
-                round_num += 1;
-                log::info!("RoundRunner: triggering round {}", round_num);
-
                 let body = match build_round_body(&dm_keeper_snapshot) {
                     Ok(body) => body,
                     Err(reason) => {
@@ -104,9 +104,18 @@ pub fn start_round_loop(mut commands: Commands, progress: Res<TurnProgressState>
                         break;
                     }
                 };
+                if !try_acquire_round_flight("auto") {
+                    log::info!("RoundRunner: round flight locked by another request; waiting");
+                    sleep_ms(750).await;
+                    continue;
+                }
+                round_num += 1;
+                log::info!("RoundRunner: triggering round {}", round_num);
 
                 let url = format!("{}/api/v1/trpg/rounds/run", config::MASC_MCP_URL);
-                match fetch_json_post(&url, &body).await {
+                let post_result = fetch_json_post(&url, &body).await;
+                release_round_flight("auto");
+                match post_result {
                     Ok(resp) => {
                         log::info!(
                             "RoundRunner: round {} done — {}",
@@ -158,6 +167,7 @@ pub fn start_round_loop(mut commands: Commands, progress: Res<TurnProgressState>
             }
 
             running.store(false, Ordering::SeqCst);
+            set_dom_runner_active(false);
             log::info!(
                 "RoundRunner: loop finished (rounds={}, ended={})",
                 round_num,
@@ -177,6 +187,11 @@ pub fn stop_round_loop(runner: Option<Res<RoundRunner>>) {
     if let Some(runner) = runner {
         runner.running.store(false, Ordering::SeqCst);
         log::info!("RoundRunner: stop signalled");
+    }
+    #[cfg(target_arch = "wasm32")]
+    {
+        set_dom_runner_active(false);
+        release_round_flight("auto");
     }
 }
 
@@ -371,6 +386,55 @@ fn auto_round_enabled() -> bool {
         .get_attribute("data-auto-round")
         .map(|value| matches!(value.as_str(), "1" | "true" | "on"))
         .unwrap_or(false)
+}
+
+#[cfg(target_arch = "wasm32")]
+fn set_dom_runner_active(active: bool) {
+    let Some(document) = web_sys::window().and_then(|w| w.document()) else {
+        return;
+    };
+    let Some(dashboard) = document.get_element_by_id("dashboard") else {
+        return;
+    };
+    let _ = dashboard.set_attribute("data-round-runner-active", if active { "1" } else { "0" });
+}
+
+#[cfg(target_arch = "wasm32")]
+fn try_acquire_round_flight(owner: &str) -> bool {
+    let Some(document) = web_sys::window().and_then(|w| w.document()) else {
+        return true;
+    };
+    let Some(dashboard) = document.get_element_by_id("dashboard") else {
+        return true;
+    };
+    let existing = dashboard
+        .get_attribute("data-round-flight-owner")
+        .unwrap_or_default()
+        .trim()
+        .to_string();
+    if existing.is_empty() {
+        let _ = dashboard.set_attribute("data-round-flight-owner", owner);
+        return true;
+    }
+    false
+}
+
+#[cfg(target_arch = "wasm32")]
+fn release_round_flight(owner: &str) {
+    let Some(document) = web_sys::window().and_then(|w| w.document()) else {
+        return;
+    };
+    let Some(dashboard) = document.get_element_by_id("dashboard") else {
+        return;
+    };
+    let existing = dashboard
+        .get_attribute("data-round-flight-owner")
+        .unwrap_or_default()
+        .trim()
+        .to_string();
+    if existing == owner {
+        let _ = dashboard.remove_attribute("data-round-flight-owner");
+    }
 }
 
 // ─── Sleep Helper ──────────────────────────────


### PR DESCRIPTION
## Summary
- serialize round execution so manual and auto runner do not overlap
- block manual run while auto runner is active
- lock round-run controls while a round request is in-flight

## Validation
- cargo check --manifest-path viewer/Cargo.toml