### PR TITLE
fix(dashboard): block static asset path traversal

### DIFF
--- a/bin/main_eio.ml
+++ b/bin/main_eio.ml
@@ -4169,7 +4169,10 @@ let make_routes ~port ~host =
          let req_path = Http.Request.path request in
          let prefix_len = String.length "/dashboard/assets/" in
          let filename = String.sub req_path prefix_len (String.length req_path - prefix_len) in
-         serve_dashboard_static ("assets/" ^ filename) request reqd)
+         if Masc_mcp.Web_dashboard.is_safe_asset_relative_path filename then
+           serve_dashboard_static ("assets/" ^ filename) request reqd
+         else
+           Http.Response.not_found reqd)
   (* Dashboard SPA: index.html *)
   |> Http.Router.get "/dashboard" (fun request reqd ->
        with_public_read (fun _state req reqd ->
@@ -5616,20 +5619,23 @@ let run_server ~sw ~env ~port ~base_path =
       | `GET, p when String.length p > 18
                    && String.sub p 0 18 = "/dashboard/assets/" ->
           let filename = String.sub p 18 (String.length p - 18) in
-          let file_path = Filename.concat (dashboard_asset_root ()) ("assets/" ^ filename) in
-          (match read_file file_path with
-           | Ok body ->
-               let ct = asset_content_type filename in
-               let headers = H2.Headers.of_list [
-                 ("content-type", ct);
-                 ("content-length", string_of_int (String.length body));
-                 ("cache-control", "public, max-age=31536000, immutable");
-               ] in
-               let response = H2.Response.create ~headers `OK in
-               let writer = H2.Reqd.respond_with_streaming ~flush_headers_immediately:true h2_reqd response in
-               H2.Body.Writer.write_string writer body;
-               H2.Body.Writer.close writer
-           | Error _ -> h2_respond_text h2_reqd "404 Not Found" ~status:`Not_found)
+          if not (Masc_mcp.Web_dashboard.is_safe_asset_relative_path filename) then
+            h2_respond_text h2_reqd "404 Not Found" ~status:`Not_found
+          else
+            let file_path = Filename.concat (dashboard_asset_root ()) ("assets/" ^ filename) in
+            (match read_file file_path with
+             | Ok body ->
+                 let ct = asset_content_type filename in
+                 let headers = H2.Headers.of_list [
+                   ("content-type", ct);
+                   ("content-length", string_of_int (String.length body));
+                   ("cache-control", "public, max-age=31536000, immutable");
+                 ] in
+                 let response = H2.Response.create ~headers `OK in
+                 let writer = H2.Reqd.respond_with_streaming ~flush_headers_immediately:true h2_reqd response in
+                 H2.Body.Writer.write_string writer body;
+                 H2.Body.Writer.close writer
+             | Error _ -> h2_respond_text h2_reqd "404 Not Found" ~status:`Not_found)
 
       (* ─────────────────────────────────────────────────────────────────────
          Fallback

--- a/lib/web_dashboard.ml
+++ b/lib/web_dashboard.ml
@@ -38,3 +38,17 @@ let etag () =
     let hash = Digest.string (string_of_float st.Unix.st_mtime) |> Digest.to_hex in
     String.sub hash 0 12
   with _ -> "none"
+
+let is_safe_asset_relative_path rel =
+  String.length rel > 0
+  && Filename.is_relative rel
+  && not (String.contains rel '\\')
+  && not (String.contains rel '\000')
+  &&
+  let segments = String.split_on_char '/' rel in
+  List.for_all
+    (fun seg ->
+      String.length seg > 0
+      && seg <> "."
+      && seg <> "..")
+    segments

--- a/lib/web_dashboard.mli
+++ b/lib/web_dashboard.mli
@@ -5,3 +5,7 @@ val html : unit -> string
 
 (** ETag for cache validation *)
 val etag : unit -> string
+
+(** Validate user-provided dashboard asset subpaths.
+    Rejects absolute paths, parent traversal, and empty segments. *)
+val is_safe_asset_relative_path : string -> bool

--- a/test/test_web_dashboard_coverage.ml
+++ b/test/test_web_dashboard_coverage.ml
@@ -142,6 +142,30 @@ let test_fallback_on_missing_asset () =
   check string "fallback etag is none" "none" etag
 
 (* ============================================================
+   Asset path safety
+   ============================================================ *)
+
+let test_safe_asset_relative_path_accepts_normal () =
+  check bool "normal asset path allowed" true
+    (Web_dashboard.is_safe_asset_relative_path "index-Dt8oKM_U.js")
+
+let test_safe_asset_relative_path_rejects_parent_traversal () =
+  check bool "parent traversal rejected" false
+    (Web_dashboard.is_safe_asset_relative_path "../secrets.txt")
+
+let test_safe_asset_relative_path_rejects_nested_parent_traversal () =
+  check bool "nested parent traversal rejected" false
+    (Web_dashboard.is_safe_asset_relative_path "js/../../etc/passwd")
+
+let test_safe_asset_relative_path_rejects_empty_segment () =
+  check bool "double slash rejected" false
+    (Web_dashboard.is_safe_asset_relative_path "js//bundle.js")
+
+let test_safe_asset_relative_path_rejects_absolute () =
+  check bool "absolute path rejected" false
+    (Web_dashboard.is_safe_asset_relative_path "/etc/passwd")
+
+(* ============================================================
    Test Runners
    ============================================================ *)
 
@@ -166,5 +190,12 @@ let () =
     ];
     "fallback", [
       test_case "missing asset dir" `Quick test_fallback_on_missing_asset;
+    ];
+    "asset_path_safety", [
+      test_case "accept normal" `Quick test_safe_asset_relative_path_accepts_normal;
+      test_case "reject parent traversal" `Quick test_safe_asset_relative_path_rejects_parent_traversal;
+      test_case "reject nested traversal" `Quick test_safe_asset_relative_path_rejects_nested_parent_traversal;
+      test_case "reject empty segment" `Quick test_safe_asset_relative_path_rejects_empty_segment;
+      test_case "reject absolute path" `Quick test_safe_asset_relative_path_rejects_absolute;
     ];
   ]


### PR DESCRIPTION
## Summary
- add `Web_dashboard.is_safe_asset_relative_path` for dashboard asset path validation
- reject absolute paths, `..` traversal, and empty segments in asset subpaths
- enforce validation in both HTTP router (`/dashboard/assets/*`) and H2 path handling
- add coverage tests for allowed/rejected asset paths

## Why
`/dashboard/assets/*` accepted raw user-controlled path suffixes and joined them to filesystem paths without traversal checks.

## Verification
- `dune exec --root . test/test_web_dashboard_coverage.exe`
- `dune build --root . --build-dir _build_codex_fix_dashboard_spa bin/main_eio.exe`
