### PR TITLE
chore: remove contradictory .gitignore negation for native binary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,8 +34,6 @@ _coverage/
 # Downloaded release binary
 masc-mcp-macos-arm64
 masc-mcp-linux-x64
-# Track the local release artifact
-!masc-mcp-macos-arm64
 
 # Downloaded release binary
 figma-mcp-macos-arm64


### PR DESCRIPTION
## Summary
- `.gitignore` line 35 ignores `masc-mcp-macos-arm64`, but line 38 negated it with `!masc-mcp-macos-arm64`
- Removed the negation line so native binaries stay ignored as intended

## Test plan
- [ ] CI passes (no code changes, gitignore-only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)