### PR TITLE
fix(board-api): return 404 for missing post detail

### DIFF
--- a/bin/main_eio.ml
+++ b/bin/main_eio.ml
@@ -3401,6 +3401,25 @@ let health_handler _request reqd =
   ] in
   Http.Response.json (Yojson.Safe.to_string health_json) reqd
 
+let board_post_detail_json ~post_id =
+  match Board_dispatch.get_post ~post_id with
+  | Error _ ->
+      (`Not_found, {|{"error":"Post not found"}|})
+  | Ok post ->
+      let comments =
+        match Board_dispatch.get_comments ~post_id with
+        | Ok cs -> cs
+        | Error _ -> []
+      in
+      let json =
+        `Assoc
+          [
+            ("post", Board.post_to_yojson post);
+            ("comments", `List (List.map Board.comment_to_yojson comments));
+          ]
+      in
+      (`OK, Yojson.Safe.to_string json)
+
 (** CORS preflight handler *)
 let options_handler request reqd =
   let origin = get_origin request in
@@ -4823,18 +4842,8 @@ let make_extended_handler routes =
             Http.Response.json (Yojson.Safe.to_string json) reqd
         | `GET, p when String.length p > 14 && String.sub p 0 14 = "/api/v1/board/" ->
             let post_id = String.sub p 14 (String.length p - 14) in
-            (match Board_dispatch.get_post ~post_id with
-            | Error _ ->
-                Http.Response.json {|{"error":"Post not found"}|} reqd
-            | Ok post ->
-                let comments = match Board_dispatch.get_comments ~post_id with
-                  | Ok cs -> cs | Error _ -> []
-                in
-                let json = `Assoc [
-                  ("post", Board.post_to_yojson post);
-                  ("comments", `List (List.map Board.comment_to_yojson comments));
-                ] in
-                Http.Response.json (Yojson.Safe.to_string json) reqd)
+            let (status, body) = board_post_detail_json ~post_id in
+            Http.Response.json ~status body reqd
         | _ -> Http.Router.dispatch routes request reqd
     with exn ->
       let msg = Printexc.to_string exn in
@@ -5575,6 +5584,11 @@ let run_server ~sw ~env ~port ~base_path =
           let flairs = List.map Board.flair_to_yojson Board.available_flairs in
           let json = `Assoc [("flairs", `List flairs)] in
           h2_respond_json h2_reqd (Yojson.Safe.to_string json) ~extra_headers:cors
+
+      | `GET, p when String.length p > 14 && String.sub p 0 14 = "/api/v1/board/" ->
+          let post_id = String.sub p 14 (String.length p - 14) in
+          let (status, body) = board_post_detail_json ~post_id in
+          h2_respond_json h2_reqd body ~status ~extra_headers:cors
 
       | `GET, "/api/v1/karma" ->
           let karma_list = Board_dispatch.get_all_karma () in

--- a/test/dune
+++ b/test/dune
@@ -338,6 +338,13 @@
  (libraries alcotest yojson unix)
  (deps ../bin/main_eio.exe))
 
+; Board API endpoint-level integration tests
+(test
+ (name test_board_api_e2e)
+ (modules test_board_api_e2e)
+ (libraries alcotest unix)
+ (deps ../bin/main_eio.exe))
+
 ; Agent Registry Eio tests
 (test
  (name test_agent_registry_eio)

--- a/test/test_board_api_e2e.ml
+++ b/test/test_board_api_e2e.ml
@@ -1,0 +1,245 @@
+open Alcotest
+
+type http_result = {
+  status: int option;
+  body: string;
+  curl_exit: int;
+  stderr: string;
+}
+
+let read_all ic =
+  let buf = Buffer.create 1024 in
+  (try
+     while true do
+       Buffer.add_channel buf ic 4096
+     done
+   with End_of_file -> ());
+  Buffer.contents buf
+
+let read_file path =
+  let ic = open_in_bin path in
+  Fun.protect
+    ~finally:(fun () -> close_in_noerr ic)
+    (fun () ->
+      let len = in_channel_length ic in
+      really_input_string ic len)
+
+let trim_cr s =
+  let n = String.length s in
+  if n > 0 && s.[n - 1] = '\r' then String.sub s 0 (n - 1) else s
+
+let parse_status header_raw =
+  let lines = String.split_on_char '\n' header_raw |> List.map trim_cr in
+  let rec find_http = function
+    | [] -> None
+    | line :: rest ->
+        if String.length line >= 5 && String.sub line 0 5 = "HTTP/" then
+          (match String.split_on_char ' ' line with
+           | _proto :: code :: _ -> (try Some (int_of_string code) with _ -> None)
+           | _ -> None)
+        else
+          find_http rest
+  in
+  find_http lines
+
+let run_curl ~port ~path () =
+  let header_file = Filename.temp_file "board-api-header-" ".txt" in
+  let body_file = Filename.temp_file "board-api-body-" ".txt" in
+  let url = Printf.sprintf "http://127.0.0.1:%d%s" port path in
+  let args =
+    [|
+      "curl";
+      "-sS";
+      "--http1.1";
+      "--max-time";
+      "3";
+      "-X";
+      "GET";
+      "-o";
+      body_file;
+      "-D";
+      header_file;
+      url;
+    |]
+  in
+  let (ic, oc, ec) = Unix.open_process_args_full "curl" args (Unix.environment ()) in
+  close_out_noerr oc;
+  let _stdout = read_all ic in
+  let stderr = read_all ec in
+  let curl_exit =
+    match Unix.close_process_full (ic, oc, ec) with
+    | Unix.WEXITED code -> code
+    | Unix.WSIGNALED code -> 128 + code
+    | Unix.WSTOPPED code -> 256 + code
+  in
+  let status = parse_status (read_file header_file) in
+  let body = read_file body_file in
+  (try Sys.remove header_file with _ -> ());
+  (try Sys.remove body_file with _ -> ());
+  { status; body; curl_exit; stderr }
+
+let contains_substr needle haystack =
+  let n = String.length needle in
+  let h = String.length haystack in
+  let rec loop i =
+    if i + n > h then false
+    else if String.sub haystack i n = needle then true
+    else loop (i + 1)
+  in
+  n = 0 || loop 0
+
+let find_main_eio_exe () =
+  let env_override = Sys.getenv_opt "MASC_MAIN_EIO_EXE" in
+  let candidates =
+    match env_override with
+    | Some p -> [p]
+    | None ->
+        let build_roots = [ "."; ".."; "../.."; "../../.."; "../../../.." ] in
+        let build_candidates =
+          List.map
+            (fun root -> Filename.concat root "_build/default/bin/main_eio.exe")
+            build_roots
+        in
+        [
+          "./bin/main_eio.exe";
+          "../bin/main_eio.exe";
+          "../../bin/main_eio.exe";
+          "../../../bin/main_eio.exe";
+          "../../../../bin/main_eio.exe";
+        ] @ build_candidates
+  in
+  match List.find_opt Sys.file_exists candidates with
+  | Some path -> path
+  | None ->
+      fail
+        "main_eio executable not found. Set MASC_MAIN_EIO_EXE or build with `dune build bin/main_eio.exe`."
+
+let find_free_port () =
+  let socket = Unix.socket Unix.PF_INET Unix.SOCK_STREAM 0 in
+  Fun.protect
+    ~finally:(fun () -> Unix.close socket)
+    (fun () ->
+      Unix.setsockopt socket Unix.SO_REUSEADDR true;
+      match Unix.bind socket (Unix.ADDR_INET (Unix.inet_addr_loopback, 0)) with
+      | () ->
+          begin
+            match Unix.getsockname socket with
+            | Unix.ADDR_INET (_, port) -> Some port
+            | _ -> fail "unexpected socket address"
+          end
+      | exception Unix.Unix_error ((Unix.EPERM | Unix.EACCES), "bind", _) -> None)
+
+let wait_for_health ~port ~timeout_s =
+  let deadline = Unix.gettimeofday () +. timeout_s in
+  let rec loop () =
+    if Unix.gettimeofday () > deadline then
+      false
+    else
+      let res = run_curl ~port ~path:"/health" () in
+      match res.status with
+      | Some 200 -> true
+      | _ ->
+          Unix.sleepf 0.1;
+          loop ()
+  in
+  loop ()
+
+let wait_pid_exit ~pid ~timeout_s =
+  let deadline = Unix.gettimeofday () +. timeout_s in
+  let rec loop () =
+    match Unix.waitpid [Unix.WNOHANG] pid with
+    | 0, _ ->
+        if Unix.gettimeofday () > deadline then
+          false
+        else begin
+          Unix.sleepf 0.05;
+          loop ()
+        end
+    | _pid, _status -> true
+    | exception Unix.Unix_error (Unix.ECHILD, _, _) -> true
+  in
+  loop ()
+
+let merge_env_overrides overrides =
+  let override_keys = List.map fst overrides in
+  let is_override_key entry =
+    match String.index_opt entry '=' with
+    | None -> false
+    | Some idx ->
+        let key = String.sub entry 0 idx in
+        List.mem key override_keys
+  in
+  let base =
+    Unix.environment ()
+    |> Array.to_list
+    |> List.filter (fun entry -> not (is_override_key entry))
+  in
+  let injected = List.map (fun (k, v) -> k ^ "=" ^ v) overrides in
+  Array.of_list (base @ injected)
+
+let with_server f =
+  let exe = find_main_eio_exe () in
+  let port =
+    match find_free_port () with
+    | Some p -> p
+    | None -> Alcotest.skip ()
+  in
+  let log_file = Filename.temp_file "board-api-e2e-" ".log" in
+  let base_path = Filename.temp_file "board-api-base-" "" in
+  (try Sys.remove base_path with _ -> ());
+  Unix.mkdir base_path 0o755;
+  let log_fd =
+    Unix.openfile log_file [Unix.O_CREAT; Unix.O_WRONLY; Unix.O_TRUNC] 0o644
+  in
+  let env =
+    merge_env_overrides
+      [
+        ("MASC_LODGE_ENABLED", "0");
+        ("MASC_LODGE_DAEMON_ENABLED", "0");
+        ("GRAPHQL_API_KEY", "");
+        ("GRAPHQL_URL", "http://127.0.0.1:9/graphql");
+      ]
+  in
+  let argv =
+    [|
+      exe;
+      "--port";
+      string_of_int port;
+      "--base-path";
+      base_path;
+    |]
+  in
+  let pid = Unix.create_process_env exe argv env Unix.stdin log_fd log_fd in
+  Unix.close log_fd;
+  let cleanup () =
+    (try Unix.kill pid Sys.sigterm with _ -> ());
+    if not (wait_pid_exit ~pid ~timeout_s:2.0) then
+      (try Unix.kill pid Sys.sigkill with _ -> ());
+    ignore (wait_pid_exit ~pid ~timeout_s:1.0)
+  in
+  if not (wait_for_health ~port ~timeout_s:20.0) then begin
+    cleanup ();
+    let logs = read_file log_file in
+    fail (Printf.sprintf "server failed to become ready on port %d\n%s" port logs)
+  end;
+  Fun.protect ~finally:cleanup (fun () -> f ~port)
+
+let test_board_missing_post_returns_404 () =
+  with_server @@ fun ~port ->
+  let res = run_curl ~port ~path:"/api/v1/board/post-not-exists-12345" () in
+  (match res.status with
+   | Some code -> check int "missing post returns 404" 404 code
+   | None ->
+       fail
+         (Printf.sprintf
+            "missing HTTP status (curl_exit=%d, stderr=%s)"
+            res.curl_exit
+            res.stderr));
+  check bool "error payload contains message" true
+    (contains_substr "Post not found" res.body)
+
+let () =
+  run "board_api_e2e"
+    [
+      ("board", [ test_case "missing post returns 404" `Slow test_board_missing_post_returns_404 ]);
+    ]


### PR DESCRIPTION
## Summary
- return HTTP 404 (not 200) when `/api/v1/board/<post_id>` misses
- unify board post detail response generation via `board_post_detail_json`
- add the same `/api/v1/board/<post_id>` handling to H2 route map for parity
- add endpoint-level e2e test `test_board_api_e2e`

## Why
Previously missing board posts returned JSON error payload with status 200, which breaks client-side error handling and HTTP semantics.

## Verification
- `dune exec --root . test/test_board_api_e2e.exe`
- `dune build --root . bin/main_eio.exe`
