### PR TITLE
fix(harness): add retry for transient MCP connection failures in local e2e

### DIFF
--- a/scripts/harness/contract/game_view_precondition.sh
+++ b/scripts/harness/contract/game_view_precondition.sh
@@ -3,6 +3,28 @@ set -euo pipefail
 
 MCP_URL="${MCP_URL:-http://127.0.0.1:8935/mcp}"
 SESSION_ID="${SESSION_ID:-harness-gv-$(date +%s)-$$}"
+CURL_RETRY_COUNT="${CURL_RETRY_COUNT:-12}"
+CURL_RETRY_DELAY_SEC="${CURL_RETRY_DELAY_SEC:-1}"
+
+curl_post_mcp() {
+  local body="$1"
+  local attempt=1
+  while [ "$attempt" -le "$CURL_RETRY_COUNT" ]; do
+    local raw
+    if raw="$(curl -sS -m 20 -X POST "$MCP_URL" \
+      -H 'Content-Type: application/json' \
+      -H 'Accept: application/json, text/event-stream' \
+      -d "$body")"; then
+      printf "%s" "$raw"
+      return 0
+    fi
+    if [ "$attempt" -lt "$CURL_RETRY_COUNT" ]; then
+      sleep "$CURL_RETRY_DELAY_SEC"
+    fi
+    attempt=$((attempt + 1))
+  done
+  return 1
+}
 
 call_tool() {
   local id="$1"
@@ -10,10 +32,7 @@ call_tool() {
   local args_json="$3"
   local raw
   local sse_data
-  raw="$(curl -sS -m 20 -X POST "$MCP_URL" \
-    -H 'Content-Type: application/json' \
-    -H 'Accept: application/json, text/event-stream' \
-    -d "{\"jsonrpc\":\"2.0\",\"id\":$id,\"method\":\"tools/call\",\"params\":{\"name\":\"$name\",\"arguments\":$args_json}}")"
+  raw="$(curl_post_mcp "{\"jsonrpc\":\"2.0\",\"id\":$id,\"method\":\"tools/call\",\"params\":{\"name\":\"$name\",\"arguments\":$args_json}}")"
 
   sse_data="$(printf "%s" "$raw" | sed -n 's/^data: //p' | tail -n1)"
   if [ -n "$sse_data" ]; then

--- a/scripts/harness/contract/trpg_session_contract.sh
+++ b/scripts/harness/contract/trpg_session_contract.sh
@@ -4,6 +4,28 @@ set -euo pipefail
 MCP_URL="${MCP_URL:-http://127.0.0.1:8935/mcp}"
 SESSION_ID="${SESSION_ID:-harness-trpg-session-001}"
 ROOM_ID="${ROOM_ID:-}"
+CURL_RETRY_COUNT="${CURL_RETRY_COUNT:-12}"
+CURL_RETRY_DELAY_SEC="${CURL_RETRY_DELAY_SEC:-1}"
+
+curl_post_mcp() {
+  local body="$1"
+  local attempt=1
+  while [ "$attempt" -le "$CURL_RETRY_COUNT" ]; do
+    local raw
+    if raw="$(curl -sS -m 25 -X POST "$MCP_URL" \
+      -H 'Content-Type: application/json' \
+      -H 'Accept: application/json, text/event-stream' \
+      -d "$body")"; then
+      printf "%s" "$raw"
+      return 0
+    fi
+    if [ "$attempt" -lt "$CURL_RETRY_COUNT" ]; then
+      sleep "$CURL_RETRY_DELAY_SEC"
+    fi
+    attempt=$((attempt + 1))
+  done
+  return 1
+}
 
 call_tool() {
   local id="$1"
@@ -12,10 +34,7 @@ call_tool() {
   local raw
   local sse_data
 
-  raw="$(curl -sS -m 25 -X POST "$MCP_URL" \
-    -H 'Content-Type: application/json' \
-    -H 'Accept: application/json, text/event-stream' \
-    -d "{\"jsonrpc\":\"2.0\",\"id\":$id,\"method\":\"tools/call\",\"params\":{\"name\":\"$name\",\"arguments\":$args_json}}")"
+  raw="$(curl_post_mcp "{\"jsonrpc\":\"2.0\",\"id\":$id,\"method\":\"tools/call\",\"params\":{\"name\":\"$name\",\"arguments\":$args_json}}")"
 
   sse_data="$(printf "%s" "$raw" | sed -n 's/^data: //p' | tail -n1)"
   if [ -n "$sse_data" ]; then

--- a/scripts/harness/workload/trpg_grimland_smoke.sh
+++ b/scripts/harness/workload/trpg_grimland_smoke.sh
@@ -16,6 +16,8 @@ ROUND_TIMEOUT_SEC="${ROUND_TIMEOUT_SEC:-12}"
 KEEPER_MODELS="${KEEPER_MODELS:-}"
 PLAYER_KEEPER_NAMES=""
 CURL_TIMEOUT_SEC="${CURL_TIMEOUT_SEC:-120}"
+CURL_RETRY_COUNT="${CURL_RETRY_COUNT:-12}"
+CURL_RETRY_DELAY_SEC="${CURL_RETRY_DELAY_SEC:-1}"
 
 cleanup_keepers() {
   if [ -n "${DM_KEEPER:-}" ]; then
@@ -34,15 +36,25 @@ call_tool() {
   local id="$1"
   local name="$2"
   local args_json="$3"
-  local raw
+  local raw=""
   local sse_data
-  raw="$(curl -sS -m "$CURL_TIMEOUT_SEC" -X POST "$MCP_URL" \
-    -H 'Content-Type: application/json' \
-    -H 'Accept: application/json, text/event-stream' \
-    -d "{\"jsonrpc\":\"2.0\",\"id\":$id,\"method\":\"tools/call\",\"params\":{\"name\":\"$name\",\"arguments\":$args_json}}")" || {
-    printf '{"error":{"message":"curl failed: tool=%s timeout_sec=%s"}}' "$name" "$CURL_TIMEOUT_SEC"
+  local attempt=1
+  while [ "$attempt" -le "$CURL_RETRY_COUNT" ]; do
+    if raw="$(curl -sS -m "$CURL_TIMEOUT_SEC" -X POST "$MCP_URL" \
+      -H 'Content-Type: application/json' \
+      -H 'Accept: application/json, text/event-stream' \
+      -d "{\"jsonrpc\":\"2.0\",\"id\":$id,\"method\":\"tools/call\",\"params\":{\"name\":\"$name\",\"arguments\":$args_json}}")"; then
+      break
+    fi
+    if [ "$attempt" -lt "$CURL_RETRY_COUNT" ]; then
+      sleep "$CURL_RETRY_DELAY_SEC"
+    fi
+    attempt=$((attempt + 1))
+  done
+  if [ -z "$raw" ]; then
+    printf '{"error":{"message":"curl failed after retries: tool=%s timeout_sec=%s retries=%s"}}' "$name" "$CURL_TIMEOUT_SEC" "$CURL_RETRY_COUNT"
     return 0
-  }
+  fi
   sse_data="$(printf "%s" "$raw" | sed -n 's/^data: //p' | tail -n1)"
   if [ -n "$sse_data" ]; then
     printf "%s" "$sse_data"

--- a/scripts/viewer-local-e2e-check.sh
+++ b/scripts/viewer-local-e2e-check.sh
@@ -6,6 +6,8 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 
 MCP_URL="${MCP_URL:-http://127.0.0.1:8935/mcp}"
 MCP_PING_TIMEOUT_SEC="${MCP_PING_TIMEOUT_SEC:-8}"
+MCP_PING_RETRY_COUNT="${MCP_PING_RETRY_COUNT:-12}"
+MCP_PING_RETRY_DELAY_SEC="${MCP_PING_RETRY_DELAY_SEC:-1}"
 
 RUN_VIEWER_BUILD=0
 RUN_SMOKE=0
@@ -127,14 +129,23 @@ step_check_commands() {
 
 step_check_mcp() {
   local response
-  response="$(curl -sS -m "$MCP_PING_TIMEOUT_SEC" -X POST "$MCP_URL" \
-    -H 'Content-Type: application/json' \
-    -H 'Accept: application/json, text/event-stream' \
-    -d '{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}')"
-  if [ -z "$(printf "%s" "$response" | tr -d '[:space:]')" ]; then
-    echo "MCP endpoint returned empty response: $MCP_URL"
-    return 1
-  fi
+  local attempt=1
+  while [ "$attempt" -le "$MCP_PING_RETRY_COUNT" ]; do
+    if response="$(curl -sS -m "$MCP_PING_TIMEOUT_SEC" -X POST "$MCP_URL" \
+      -H 'Content-Type: application/json' \
+      -H 'Accept: application/json, text/event-stream' \
+      -d '{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}')"; then
+      if [ -n "$(printf "%s" "$response" | tr -d '[:space:]')" ]; then
+        return 0
+      fi
+    fi
+    if [ "$attempt" -lt "$MCP_PING_RETRY_COUNT" ]; then
+      sleep "$MCP_PING_RETRY_DELAY_SEC"
+    fi
+    attempt=$((attempt + 1))
+  done
+  echo "MCP endpoint returned empty response after ${MCP_PING_RETRY_COUNT} retries: $MCP_URL"
+  return 1
 }
 
 step_viewer_build() {


### PR DESCRIPTION
## Summary
- add retry/backoff for MCP reachability check in `viewer-local-e2e-check.sh`
- add retry wrappers for MCP tool calls in contract harness scripts
- add retry wrapper for workload tool calls in grimland smoke script
- keep defaults configurable via env (`*_RETRY_COUNT`, `*_RETRY_DELAY_SEC`)

## Why
Local TRPG checks intermittently hit `curl (7) Failed to connect to 127.0.0.1:8935` even when MCP recovers shortly after. This made the checklist flaky.

## Validation
- `scripts/viewer-local-e2e-check.sh --run-round --rounds 2 --round-timeout-sec 90 --keeper-models "glm:glm-4.7,glm:glm-4.6v,ollama:glm-4.7-flash"`
- Result: PASS (all 5 steps)
