### PR TITLE
fix(viewer): localize game history heading

### DIFF
--- a/viewer/index.html
+++ b/viewer/index.html
@@ -462,7 +462,7 @@
                 <div id="dice-log" class="scrollable horizontal"></div>
             </section>
             <section class="bottom-pane">
-                <h2 class="panel-title">Turn History</h2>
+                <h2 class="panel-title">게임 히스토리</h2>
                 <div id="session-history" class="scrollable"></div>
             </section>
         </footer>


### PR DESCRIPTION
## Summary
- change viewer footer panel title from Turn History to 게임 히스토리

## Why
- align the in-viewer heading text with Korean UI wording

## Validation
- static HTML text change only (no runtime behavior change)