### PR TITLE
feat(viewer): room-aware session history browser

### DIFF
--- a/viewer/src/dom/session_history.rs
+++ b/viewer/src/dom/session_history.rs
@@ -133,15 +133,18 @@ fn ensure_turn_entry(turns: &mut Vec<TurnHistory>, turn: u32, phase: &str) -> (u
             return (idx, changed);
         }
     }
+
     turns.push(TurnHistory {
         turn: normalized_turn,
         phase: phase.to_string(),
         events: Vec::new(),
     });
     turns.sort_by_key(|row| row.turn);
+
     while turns.len() > MAX_TURNS_TO_KEEP {
         let _ = turns.remove(0);
     }
+
     let idx = turns
         .iter()
         .position(|row| row.turn == normalized_turn)
@@ -157,6 +160,7 @@ fn ensure_room_entry(
 ) -> (usize, bool) {
     let normalized_room_id = normalize_room_id(room_id);
     let normalized_status = normalize_room_status(status);
+
     for (idx, room) in rooms.iter_mut().enumerate() {
         if room.room_id == normalized_room_id {
             let mut changed = false;
@@ -217,15 +221,16 @@ fn append_event(
     detail: &str,
 ) -> (bool, bool) {
     let normalized_turn = turn.max(1);
-    let (room_idx, mut changed) =
-        ensure_room_entry(rooms, room_id, room_status, normalized_turn);
+    let (room_idx, mut changed) = ensure_room_entry(rooms, room_id, room_status, normalized_turn);
     let Some(room) = rooms.get_mut(room_idx) else {
         return (false, changed);
     };
+
     if normalized_turn > room.updated_turn {
         room.updated_turn = normalized_turn;
         changed = true;
     }
+
     let (turn_idx, turn_changed) = ensure_turn_entry(&mut room.turns, normalized_turn, phase);
     changed = changed || turn_changed;
     let Some(row) = room.turns.get_mut(turn_idx) else {
@@ -588,7 +593,6 @@ fn read_focus_from_hash() -> (Option<String>, Option<u32>) {
 
     let mut room = None;
     let mut turn = None;
-
     for pair in params.split('&') {
         if pair.is_empty() {
             continue;
@@ -610,7 +614,6 @@ fn read_focus_from_hash() -> (Option<String>, Option<u32>) {
             _ => {}
         }
     }
-
     (room, turn)
 }
 
@@ -641,7 +644,6 @@ fn write_focus_hash(room: Option<&str>, turn: Option<u32>) {
     } else {
         format!("{}&{}", base, params.join("&"))
     };
-
     if fragment == next_fragment {
         return;
     }
@@ -972,8 +974,8 @@ pub fn update_session_history_dom(
         };
 
         let mut changed = false;
-        let room_id = normalize_room_id(&room_state.id);
-        let mut room_status = {
+        let base_room_id = normalize_room_id(&room_state.id);
+        let mut base_room_status = {
             let from_progress = normalize_room_status(&progress.room_status);
             if from_progress == "unknown" {
                 normalize_room_status(&room_state.status)
@@ -981,8 +983,8 @@ pub fn update_session_history_dom(
                 from_progress
             }
         };
-        if room_status == "unknown" {
-            room_status = "active".to_string();
+        if base_room_status == "unknown" {
+            base_room_status = "active".to_string();
         }
 
         let mut current_turn = if progress.turn > 0 {
@@ -997,7 +999,7 @@ pub fn update_session_history_dom(
         };
 
         let (room_idx, room_changed) =
-            ensure_room_entry(&mut cache.rooms, &room_id, &room_status, current_turn);
+            ensure_room_entry(&mut cache.rooms, &base_room_id, &base_room_status, current_turn);
         changed = changed || room_changed;
         if let Some(room) = cache.rooms.get_mut(room_idx) {
             let (_, turn_changed) = ensure_turn_entry(&mut room.turns, current_turn, &current_phase);
@@ -1011,10 +1013,17 @@ pub fn update_session_history_dom(
             if !event.phase.is_empty() {
                 current_phase = event.phase.clone();
             }
+
+            let event_room_id = if event.room_id.trim().is_empty() {
+                base_room_id.clone()
+            } else {
+                normalize_room_id(&event.room_id)
+            };
+
             let (appended, updated) = append_event(
                 &mut cache.rooms,
-                &room_id,
-                &room_status,
+                &event_room_id,
+                &base_room_status,
                 current_turn,
                 &current_phase,
                 "turn",
@@ -1033,32 +1042,38 @@ pub fn update_session_history_dom(
             if !appended {
                 bump_dedup_history(
                     &document,
-                    &format!("{} | t{} | turn | {}", room_id, current_turn, current_phase),
+                    &format!(
+                        "{} | t{} | turn | {}",
+                        event_room_id, current_turn, current_phase
+                    ),
                 );
             }
             changed = changed || updated;
         }
 
         for NarrativeReceived(event) in narratives.read() {
-            let turn = if event.turn > 0 {
+            let event_turn = if event.turn > 0 {
                 event.turn
             } else {
                 current_turn
             };
-            let phase = if !event.phase.trim().is_empty() {
+            let event_phase = if !event.phase.trim().is_empty() {
                 event.phase.clone()
             } else {
                 current_phase.clone()
             };
-            current_turn = turn.max(1);
-            current_phase = phase.clone();
+            let event_room_id = if event.room_id.trim().is_empty() {
+                base_room_id.clone()
+            } else {
+                normalize_room_id(&event.room_id)
+            };
 
             let (appended, updated) = append_event(
                 &mut cache.rooms,
-                &room_id,
-                &room_status,
-                current_turn,
-                &current_phase,
+                &event_room_id,
+                &base_room_status,
+                event_turn,
+                &event_phase,
                 "narrative",
                 event.speaker.as_deref().unwrap_or(""),
                 "내러티브",
@@ -1067,31 +1082,42 @@ pub fn update_session_history_dom(
             if !appended {
                 bump_dedup_history(
                     &document,
-                    &format!("{} | t{} | narrative | {}", room_id, current_turn, event.text.trim()),
+                    &format!(
+                        "{} | t{} | narrative | {}",
+                        event_room_id,
+                        event_turn,
+                        event.text.trim()
+                    ),
                 );
             }
             changed = changed || updated;
+            current_turn = event_turn.max(1);
+            current_phase = event_phase;
         }
 
         for DiceRolled(payload) in dice_events.read() {
-            let turn = if payload.turn > 0 {
+            let event_turn = if payload.turn > 0 {
                 payload.turn
             } else {
                 current_turn
             };
-            current_turn = turn.max(1);
+            let event_room_id = if payload.room_id.trim().is_empty() {
+                base_room_id.clone()
+            } else {
+                normalize_room_id(&payload.room_id)
+            };
 
             let (appended, updated) = append_event(
                 &mut cache.rooms,
-                &room_id,
-                &room_status,
-                current_turn,
+                &event_room_id,
+                &base_room_status,
+                event_turn,
                 &current_phase,
                 "dice",
                 &payload.character,
                 "주사위",
                 &format!(
-                    "{} — {} (d20 {} + {} = {}, DC {})",
+                    "{} - {} (d20 {} + {} = {}, DC {})",
                     payload.character,
                     payload.action,
                     payload.d20,
@@ -1105,32 +1131,46 @@ pub fn update_session_history_dom(
                     &document,
                     &format!(
                         "{} | t{} | dice | {}:{}",
-                        room_id, current_turn, payload.character, payload.action
+                        event_room_id, event_turn, payload.character, payload.action
                     ),
                 );
             }
             changed = changed || updated;
+            current_turn = event_turn.max(1);
         }
 
         for TurnProgressUpdated(event) in progress_events.read() {
-            if event.turn > 0 {
-                current_turn = event.turn;
-            }
-            if !event.phase.is_empty() {
-                current_phase = event.phase.clone();
-            }
-            let event_status = normalize_room_status(&event.room_status);
-            if event_status != "unknown" && event_status != room_status {
-                room_status = event_status;
-            }
+            let event_turn = if event.turn > 0 {
+                event.turn
+            } else {
+                current_turn
+            };
+            let event_phase = if !event.phase.is_empty() {
+                event.phase.clone()
+            } else {
+                current_phase.clone()
+            };
+            let event_room_id = if event.room_id.trim().is_empty() {
+                base_room_id.clone()
+            } else {
+                normalize_room_id(&event.room_id)
+            };
+            let event_status = {
+                let normalized = normalize_room_status(&event.room_status);
+                if normalized == "unknown" {
+                    base_room_status.clone()
+                } else {
+                    normalized
+                }
+            };
 
             let (kind, actor, summary) = label_progress_event(event);
             let (appended, updated) = append_event(
                 &mut cache.rooms,
-                &room_id,
-                &room_status,
-                current_turn,
-                &current_phase,
+                &event_room_id,
+                &event_status,
+                event_turn,
+                &event_phase,
                 kind,
                 &actor,
                 if summary.is_empty() {
@@ -1143,14 +1183,20 @@ pub fn update_session_history_dom(
             if !appended {
                 bump_dedup_history(
                     &document,
-                    &format!("{} | t{} | progress | {}", room_id, current_turn, event.event_type),
+                    &format!(
+                        "{} | t{} | progress | {}",
+                        event_room_id, event_turn, event.event_type
+                    ),
                 );
             }
             changed = changed || updated;
+            current_turn = event_turn.max(1);
+            current_phase = event_phase;
+            base_room_status = event_status;
         }
 
         let (room_idx, room_changed) =
-            ensure_room_entry(&mut cache.rooms, &room_id, &room_status, current_turn);
+            ensure_room_entry(&mut cache.rooms, &base_room_id, &base_room_status, current_turn);
         changed = changed || room_changed;
         if let Some(room) = cache.rooms.get_mut(room_idx) {
             let (_, turn_changed) = ensure_turn_entry(&mut room.turns, current_turn, &current_phase);
@@ -1167,10 +1213,11 @@ pub fn update_session_history_dom(
         let (hash_room, hash_turn) = read_focus_from_hash();
         let preferred_room = read_focus_room(&document)
             .or(hash_room)
-            .or_else(|| Some(room_id.clone()));
+            .or_else(|| Some(base_room_id.clone()));
         let preferred_turn = read_focus_turn(&document)
             .or(hash_turn)
             .or(Some(current_turn.max(1)));
+
         let focus_room = resolve_focus_room(&cache.rooms, preferred_room.as_deref());
         let focus_turn = resolve_focus_turn(&cache.rooms, focus_room.as_deref(), preferred_turn);
 

--- a/viewer/src/sse/client.rs
+++ b/viewer/src/sse/client.rs
@@ -84,8 +84,6 @@ struct TrpgStreamEvent {
     #[serde(default)]
     actor_id: Option<String>,
     #[serde(default)]
-    room_id: Option<String>,
-    #[serde(default)]
     payload: Value,
 }
 
@@ -154,34 +152,6 @@ fn resolve_actor_id(payload: &Value, actor_id: Option<&str>) -> String {
 }
 
 #[cfg(any(target_arch = "wasm32", test))]
-fn resolve_room_id(payload: &Value, stream_room_id: Option<&str>) -> String {
-    payload
-        .get("room_id")
-        .and_then(Value::as_str)
-        .or_else(|| {
-            payload
-                .get("room")
-                .and_then(Value::as_object)
-                .and_then(|room| room.get("id"))
-                .and_then(Value::as_str)
-        })
-        .or_else(|| payload.get("session_id").and_then(Value::as_str))
-        .or(stream_room_id)
-        .unwrap_or("")
-        .trim()
-        .to_string()
-}
-
-#[cfg(any(target_arch = "wasm32", test))]
-fn attach_room_id(mut mapped: Value, payload: &Value, stream_room_id: Option<&str>) -> Value {
-    let room_id = resolve_room_id(payload, stream_room_id);
-    if !room_id.is_empty() {
-        mapped["room_id"] = json!(room_id);
-    }
-    mapped
-}
-
-#[cfg(any(target_arch = "wasm32", test))]
 fn snapshot_fingerprint(snapshot: &Value) -> String {
     serde_json::to_string(snapshot).unwrap_or_else(|_| snapshot.to_string())
 }
@@ -245,18 +215,6 @@ fn snapshot_phase(root: &Value, fallback: &str) -> String {
 }
 
 #[cfg(any(target_arch = "wasm32", test))]
-fn snapshot_room_id(root: &Value) -> String {
-    snapshot_root(root)
-        .get("room_id")
-        .or_else(|| snapshot_root(root).get("id"))
-        .or_else(|| root.get("room_id"))
-        .and_then(Value::as_str)
-        .unwrap_or("")
-        .trim()
-        .to_string()
-}
-
-#[cfg(any(target_arch = "wasm32", test))]
 fn snapshot_dice_entries(root: &Value) -> Vec<Value> {
     let source = root
         .get("dice_log")
@@ -304,7 +262,6 @@ fn map_snapshot_result(result: &Value) -> String {
 fn map_snapshot_dice_roll(
     entry: &Value,
     fallback_turn: u32,
-    fallback_room_id: &str,
     _fallback_phase: &str,
 ) -> Option<(String, String)> {
     if !entry.is_object() {
@@ -322,15 +279,8 @@ fn map_snapshot_dice_roll(
         .and_then(Value::as_str)
         .unwrap_or("manual_roll")
         .to_string();
-    let room_id = entry
-        .get("room_id")
-        .and_then(Value::as_str)
-        .unwrap_or(fallback_room_id)
-        .trim()
-        .to_string();
     let mapped = json!({
         "turn": value_to_u32(entry.get("turn"), fallback_turn),
-        "room_id": room_id,
         "character": character,
         "action": action,
         "d20": value_to_i32(entry.get("raw_d20"), value_to_i32(entry.get("d20"), 0)),
@@ -352,7 +302,6 @@ fn snapshot_room_status_progress_payload(
 ) -> (String, String) {
     let turn = snapshot_turn(root, fallback_turn);
     let phase = snapshot_phase(root, fallback_phase);
-    let room_id = snapshot_room_id(root);
     let event_type = match status {
         "ended" | "completed" | "done" | "retired" | "closed" => "room.ended",
         _ => "room.started",
@@ -361,7 +310,6 @@ fn snapshot_room_status_progress_payload(
         "event_type": event_type,
         "turn": turn,
         "phase": phase,
-        "room_id": room_id,
         "room_status": status,
         "actor_id": "",
         "keeper": "",
@@ -376,7 +324,6 @@ fn snapshot_room_status_progress_payload(
 fn map_turn_progress_event(
     event_type: &str,
     actor_id: Option<&str>,
-    stream_room_id: Option<&str>,
     payload: &Value,
     state: &TrpgMapperState,
 ) -> Option<(String, String)> {
@@ -479,7 +426,6 @@ fn map_turn_progress_event(
         _ => return None,
     };
 
-    let mapped = attach_room_id(mapped, payload, stream_room_id);
     Some(("turn_progress".to_string(), mapped.to_string()))
 }
 
@@ -487,7 +433,6 @@ fn map_turn_progress_event(
 fn map_trpg_event(
     event_type: &str,
     actor_id: Option<&str>,
-    stream_room_id: Option<&str>,
     payload: &Value,
     state: &mut TrpgMapperState,
 ) -> Vec<(String, String)> {
@@ -495,7 +440,8 @@ fn map_trpg_event(
 
     match event_type {
         "dice.rolled" => {
-            let mapped = json!({
+            let mapped = attach_room_id(
+                json!({
                 "turn": value_to_u32(payload.get("turn"), state.last_turn),
                 "character": payload.get("actor_id").and_then(Value::as_str).or(actor_id).unwrap_or("unknown"),
                 "action": payload.get("action").and_then(Value::as_str).unwrap_or("action"),
@@ -504,7 +450,10 @@ fn map_trpg_event(
                 "total": value_to_i32(payload.get("total"), 0),
                 "dc": value_to_i32(payload.get("dc"), 0),
                 "result": payload.get("label").and_then(Value::as_str).unwrap_or("unknown")
-            });
+            }),
+                payload,
+                stream_room_id,
+            );
             out.push(("dice_roll".to_string(), mapped.to_string()));
         }
         "hp.changed" => {
@@ -522,7 +471,8 @@ fn map_trpg_event(
                 .and_then(Value::as_str)
                 .or_else(|| payload.get("reply").and_then(Value::as_str))
                 .unwrap_or("");
-            let mapped = json!({
+            let mapped = attach_room_id(
+                json!({
                 "text": text,
                 "phase": payload.get("phase").and_then(Value::as_str).unwrap_or(&state.last_phase),
                 "speaker": payload
@@ -531,7 +481,10 @@ fn map_trpg_event(
                     .or_else(|| payload.get("actor_id").and_then(Value::as_str))
                     .or(actor_id)
                     .or_else(|| payload.get("keeper").and_then(Value::as_str))
-            });
+            }),
+                payload,
+                stream_room_id,
+            );
             out.push(("narrative".to_string(), mapped.to_string()));
         }
         "turn.action.proposed" => {
@@ -540,14 +493,18 @@ fn map_trpg_event(
                 .and_then(Value::as_str)
                 .or_else(|| payload.get("reply").and_then(Value::as_str))
                 .unwrap_or("action proposed");
-            let mapped = json!({
+            let mapped = attach_room_id(
+                json!({
                 "text": proposed,
                 "phase": payload.get("phase").and_then(Value::as_str).unwrap_or(&state.last_phase),
                 "speaker": payload
                     .get("actor_id")
                     .and_then(Value::as_str)
                     .or(actor_id)
-            });
+            }),
+                payload,
+                stream_room_id,
+            );
             out.push(("narrative".to_string(), mapped.to_string()));
         }
         "turn.timeout" => {
@@ -561,11 +518,15 @@ fn map_trpg_event(
                 Some(sec) => format!("[timeout] {} ({}s)", actor, sec.round()),
                 None => format!("[timeout] {}", actor),
             };
-            let mapped = json!({
+            let mapped = attach_room_id(
+                json!({
                 "text": text,
                 "phase": payload.get("phase").and_then(Value::as_str).unwrap_or(&state.last_phase),
                 "speaker": payload.get("keeper").and_then(Value::as_str)
-            });
+            }),
+                payload,
+                stream_room_id,
+            );
             out.push(("narrative".to_string(), mapped.to_string()));
         }
         "keeper.unavailable" => {
@@ -578,11 +539,15 @@ fn map_trpg_event(
                 .get("reason")
                 .and_then(Value::as_str)
                 .unwrap_or("unknown");
-            let mapped = json!({
+            let mapped = attach_room_id(
+                json!({
                 "text": format!("[unavailable] {}: {}", actor, reason),
                 "phase": payload.get("phase").and_then(Value::as_str).unwrap_or(&state.last_phase),
                 "speaker": payload.get("keeper").and_then(Value::as_str)
-            });
+            }),
+                payload,
+                stream_room_id,
+            );
             out.push(("narrative".to_string(), mapped.to_string()));
         }
         "turn.started" => {
@@ -598,10 +563,14 @@ fn map_trpg_event(
             if !phase.is_empty() {
                 state.last_phase = phase.clone();
             }
-            let mapped = json!({
+            let mapped = attach_room_id(
+                json!({
                 "turn": state.last_turn,
                 "phase": state.last_phase
-            });
+            }),
+                payload,
+                stream_room_id,
+            );
             out.push(("turn_advance".to_string(), mapped.to_string()));
         }
         "phase.changed" => {
@@ -617,10 +586,14 @@ fn map_trpg_event(
             if turn > 0 {
                 state.last_turn = turn;
             }
-            let mapped = json!({
+            let mapped = attach_room_id(
+                json!({
                 "turn": state.last_turn,
                 "phase": state.last_phase
-            });
+            }),
+                payload,
+                stream_room_id,
+            );
             out.push(("turn_advance".to_string(), mapped.to_string()));
         }
         "node.advanced" => {
@@ -646,11 +619,15 @@ fn map_trpg_event(
                 .and_then(Value::as_str)
                 .or_else(|| payload.get("result").and_then(Value::as_str))
                 .unwrap_or("action resolved");
-            let mapped = json!({
+            let mapped = attach_room_id(
+                json!({
                 "text": narrative,
                 "phase": state.last_phase,
                 "speaker": actor_id
-            });
+            }),
+                payload,
+                stream_room_id,
+            );
             out.push(("narrative".to_string(), mapped.to_string()));
         }
         // -- world.event: dispatch to weather/mood/death based on subtype --
@@ -677,10 +654,14 @@ fn map_trpg_event(
                 });
                 out.push(("character_death".to_string(), mapped.to_string()));
             } else {
-                let mapped = json!({
+                let mapped = attach_room_id(
+                    json!({
                     "text": format!("[world] {}", desc),
                     "phase": state.last_phase,
-                });
+                }),
+                    payload,
+                    stream_room_id,
+                );
                 out.push(("narrative".to_string(), mapped.to_string()));
             }
         }
@@ -712,10 +693,14 @@ fn map_trpg_event(
                 .get("status")
                 .and_then(Value::as_str)
                 .unwrap_or("updated");
-            let mapped = json!({
+            let mapped = attach_room_id(
+                json!({
                 "text": format!("[quest] {} \u{2014} {}", title, status),
                 "phase": state.last_phase,
-            });
+            }),
+                payload,
+                stream_room_id,
+            );
             out.push(("narrative".to_string(), mapped.to_string()));
         }
         // -- intervention.submitted / applied → narrative --
@@ -730,10 +715,14 @@ fn map_trpg_event(
             } else {
                 "pending"
             };
-            let mapped = json!({
+            let mapped = attach_room_id(
+                json!({
                 "text": format!("[intervention:{}] {} \u{2014} {}", status_label, itype, reason),
                 "phase": state.last_phase,
-            });
+            }),
+                payload,
+                stream_room_id,
+            );
             out.push(("narrative".to_string(), mapped.to_string()));
         }
         // -- choice.available → choice_available --
@@ -773,7 +762,11 @@ fn map_trpg_event(
                 .and_then(Value::as_str)
                 .or_else(|| payload.get("text").and_then(Value::as_str))
                 .unwrap_or("The adventure has ended.");
-            let mapped = json!({ "text": text, "phase": "endgame", "speaker": "DM" });
+            let mapped = attach_room_id(
+                json!({ "text": text, "phase": "endgame", "speaker": "DM" }),
+                payload,
+                stream_room_id,
+            );
             out.push(("narrative".to_string(), mapped.to_string()));
         }
         // -- actor lifecycle → turn_progress only (handled below) --
@@ -788,7 +781,9 @@ fn map_trpg_event(
         _ => {}
     }
 
-    if let Some(progress) = map_turn_progress_event(event_type, actor_id, stream_room_id, payload, state) {
+    if let Some(progress) =
+        map_turn_progress_event(event_type, actor_id, stream_room_id, payload, state)
+    {
         out.push(progress);
     }
 
@@ -798,6 +793,7 @@ fn map_trpg_event(
 #[cfg(any(target_arch = "wasm32", test))]
 fn decode_snapshot_events(body: &Value, state: &mut TrpgMapperState) -> Vec<(String, String)> {
     let status = snapshot_status(body);
+    let room_id = snapshot_room_id(body);
     let signature = snapshot_fingerprint(body);
     if state.snapshot_signature.as_deref() == Some(signature.as_str()) {
         return Vec::new();
@@ -823,8 +819,6 @@ fn decode_snapshot_events(body: &Value, state: &mut TrpgMapperState) -> Vec<(Str
     out.push(snapshot_room_status_progress_payload(
         body, &status, turn, &phase,
     ));
-
-    let room_id = snapshot_room_id(body);
 
     if turn > 0 {
         out.push((


### PR DESCRIPTION
## Summary
- refine room-aware history browser behavior on top of mainline redesign
- adjust room focus/selection handling in session history logic
- align SSE room-scoped mapping behavior with latest main branch

## Notes
- supersedes #292 (GitHub cannot reopen after branch force-push/recreation)

## Validation
- cargo check --manifest-path viewer/Cargo.toml