### PR TITLE
feat(viewer): sync narrative/dice interactions with session history focus

### DIFF
--- a/viewer/src/dom/dice_log.rs
+++ b/viewer/src/dom/dice_log.rs
@@ -1,8 +1,11 @@
 use bevy::prelude::*;
+use wasm_bindgen::closure::Closure;
+use wasm_bindgen::JsCast;
 
 use crate::game::events::DiceRolled;
 
 use super::escape::{html_escape, sanitize_text, trim_log};
+use super::session_history::sync_history_focus_from_dashboard;
 
 /// Maps dice result tiers to CSS class suffixes.
 fn tier_class(result: &str) -> &'static str {
@@ -30,6 +33,35 @@ fn tier_label(result: &str) -> &'static str {
     }
 }
 
+fn current_room_id(document: &web_sys::Document) -> String {
+    document
+        .get_element_by_id("dashboard")
+        .and_then(|el| el.get_attribute("data-room-id"))
+        .map(|raw| sanitize_text(raw.trim()))
+        .filter(|value| !value.is_empty())
+        .unwrap_or_default()
+}
+
+fn is_duplicate_dice_entry(log_el: &web_sys::Element, dedup_key: &str) -> bool {
+    let mut scanned = 0_u32;
+    let mut cursor = log_el.last_element_child();
+    while scanned < 50 {
+        let Some(el) = cursor else {
+            break;
+        };
+        if el
+            .get_attribute("data-dedup-key")
+            .map(|value| value == dedup_key)
+            .unwrap_or(false)
+        {
+            return true;
+        }
+        cursor = el.previous_element_sibling();
+        scanned += 1;
+    }
+    false
+}
+
 /// Appends dice roll entries to the #dice-log DOM element.
 pub fn update_dice_log_dom(mut events: MessageReader<DiceRolled>) {
     let Some(document) = web_sys::window().and_then(|w| w.document()) else {
@@ -38,25 +70,63 @@ pub fn update_dice_log_dom(mut events: MessageReader<DiceRolled>) {
     let Some(log_el) = document.get_element_by_id("dice-log") else {
         return;
     };
+    let fallback_room_id = current_room_id(&document);
 
     for DiceRolled(payload) in events.read() {
         let Ok(entry) = document.create_element("div") else {
             continue;
         };
+
         let tier = tier_class(&payload.result);
         entry.set_class_name(&format!("dice-entry {}", tier));
+
+        let room_id = if payload.room_id.trim().is_empty() {
+            fallback_room_id.clone()
+        } else {
+            sanitize_text(payload.room_id.trim())
+        };
+
         let character = html_escape(&sanitize_text(&payload.character));
         let action = html_escape(&sanitize_text(&payload.action));
-        let note_html = payload
+        let note_clean = payload
             .note
             .as_deref()
-            .map(|n| {
-                format!(
-                    "<div class=\"dice-note\">{}</div>",
-                    html_escape(&sanitize_text(n))
-                )
-            })
+            .map(sanitize_text)
             .unwrap_or_default();
+        let note_html = if note_clean.trim().is_empty() {
+            String::new()
+        } else {
+            format!("<div class=\"dice-note\">{}</div>", html_escape(&note_clean))
+        };
+
+        let dedup_key = format!(
+            "{}|{}|{}|{}|{}|{}|{}|{}|{}|{}",
+            room_id.to_ascii_lowercase(),
+            payload.turn,
+            payload.character.trim().to_ascii_lowercase(),
+            payload.action.trim().to_ascii_lowercase(),
+            payload.d20,
+            payload.bonus,
+            payload.total,
+            payload.dc,
+            payload.result.trim().to_ascii_lowercase(),
+            note_clean.trim()
+        );
+
+        if is_duplicate_dice_entry(&log_el, &dedup_key) {
+            continue;
+        }
+
+        let _ = entry.set_attribute("data-dedup-key", &dedup_key);
+        if !room_id.is_empty() {
+            let _ = entry.set_attribute("data-room-id", &room_id);
+        }
+        if payload.turn > 0 {
+            let _ = entry.set_attribute("data-turn", &payload.turn.to_string());
+        }
+        let _ = entry.set_attribute("role", "button");
+        let _ = entry.set_attribute("tabindex", "0");
+        let _ = entry.set_attribute("title", "클릭하면 해당 턴을 히스토리에서 강조합니다.");
 
         entry.set_inner_html(&format!(
             r#"<div class="dice-character">{}</div>
@@ -75,6 +145,31 @@ pub fn update_dice_log_dom(mut events: MessageReader<DiceRolled>) {
             tier_label(&payload.result),
             note_html,
         ));
+
+        let clickable_entry = entry.clone();
+        let click_cb = Closure::wrap(Box::new(move || {
+            let Some(document) = web_sys::window().and_then(|w| w.document()) else {
+                return;
+            };
+            let Some(dashboard) = document.get_element_by_id("dashboard") else {
+                return;
+            };
+            if let Some(room_id) = clickable_entry.get_attribute("data-room-id") {
+                if !room_id.trim().is_empty() {
+                    let _ = dashboard.set_attribute("data-focus-room", room_id.trim());
+                }
+            }
+            if let Some(turn) = clickable_entry.get_attribute("data-turn") {
+                if !turn.trim().is_empty() {
+                    let _ = dashboard.set_attribute("data-focus-turn", turn.trim());
+                }
+            }
+            sync_history_focus_from_dashboard(&document);
+        }) as Box<dyn FnMut()>);
+        let _ = entry.dyn_ref::<web_sys::EventTarget>().map(|target| {
+            target.add_event_listener_with_callback("click", click_cb.as_ref().unchecked_ref())
+        });
+        click_cb.forget();
 
         let _ = log_el.append_child(&entry);
         trim_log(&log_el, 120);

--- a/viewer/src/dom/narrative.rs
+++ b/viewer/src/dom/narrative.rs
@@ -5,6 +5,7 @@ use wasm_bindgen::JsCast;
 use crate::game::events::NarrativeReceived;
 
 use super::escape::{sanitize_text, scroll_to_bottom, trim_log};
+use super::session_history::sync_history_focus_from_dashboard;
 
 fn normalize_phase_suffix(phase: &str) -> String {
     let mut out = String::with_capacity(phase.len());
@@ -213,6 +214,23 @@ pub fn update_narrative_dom(mut events: MessageReader<NarrativeReceived>) {
         let clickable_entry = entry.clone();
         let click_cb = Closure::wrap(Box::new(move || {
             toggle_selected_class(&clickable_entry);
+            let Some(document) = web_sys::window().and_then(|w| w.document()) else {
+                return;
+            };
+            let Some(dashboard) = document.get_element_by_id("dashboard") else {
+                return;
+            };
+            if let Some(room_id) = clickable_entry.get_attribute("data-room-id") {
+                if !room_id.trim().is_empty() {
+                    let _ = dashboard.set_attribute("data-focus-room", room_id.trim());
+                }
+            }
+            if let Some(turn) = clickable_entry.get_attribute("data-turn") {
+                if !turn.trim().is_empty() {
+                    let _ = dashboard.set_attribute("data-focus-turn", turn.trim());
+                }
+            }
+            sync_history_focus_from_dashboard(&document);
         }) as Box<dyn FnMut()>);
         let _ = entry.dyn_ref::<web_sys::EventTarget>().map(|target| {
             target.add_event_listener_with_callback("click", click_cb.as_ref().unchecked_ref())

--- a/viewer/src/dom/session_history.rs
+++ b/viewer/src/dom/session_history.rs
@@ -664,6 +664,17 @@ fn sync_focus_state_to_hash(document: &web_sys::Document) {
 }
 
 #[cfg(target_arch = "wasm32")]
+pub(super) fn sync_history_focus_from_dashboard(document: &web_sys::Document) {
+    let room = read_focus_room(document);
+    let turn = read_focus_turn(document);
+    apply_history_focus(document, room.as_deref(), turn);
+    sync_focus_state_to_hash(document);
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+pub(super) fn sync_history_focus_from_dashboard(_document: &web_sys::Document) {}
+
+#[cfg(target_arch = "wasm32")]
 fn resolve_focus_room(rooms: &[RoomHistory], preferred: Option<&str>) -> Option<String> {
     if rooms.is_empty() {
         return None;


### PR DESCRIPTION
## Summary
- wire narrative log clicks to session-history focus sync
  - clicking a narrative item now updates `data-focus-room` / `data-focus-turn`
  - history panel focus and URL hash are synced via shared helper
- wire dice log clicks to session-history focus sync
  - dice entries now carry room/turn attributes and trigger same focus sync flow
- add dice-entry dedup guard for recently appended rows (last 50) to reduce duplicate UI noise
- expose a reusable session-history helper (`sync_history_focus_from_dashboard`) for cross-panel focus updates

## Why
When rounds progress quickly, users need to jump from live narrative/dice events to exact history turn context. Previously these panels were visually separate and required manual history navigation.

## Validation
- `cargo check --manifest-path viewer/Cargo.toml`
