### PR TITLE
feat(viewer): TRPG UI state machine for control gating

### DIFF
--- a/viewer/src/dom/turn_controls.rs
+++ b/viewer/src/dom/turn_controls.rs
@@ -22,7 +22,7 @@ use wasm_bindgen::prelude::*;
 #[cfg(target_arch = "wasm32")]
 use crate::config;
 #[cfg(any(target_arch = "wasm32", test))]
-use crate::game::lifecycle::TrpgLifecycleState;
+use crate::game::lifecycle::{TrpgLifecycleState, TrpgUiState};
 use crate::game::state::{ConnectionStatus, RoomState, TurnProgressState};
 
 #[cfg(any(target_arch = "wasm32", test))]
@@ -69,6 +69,129 @@ fn control_status_to_ops_class(css_class: &str) -> &'static str {
 #[cfg(any(target_arch = "wasm32", test))]
 fn round_advanced(turn_before: u64, turn_after: u64, summary_advanced: Option<bool>) -> bool {
     summary_advanced.unwrap_or(turn_after > turn_before)
+}
+
+#[cfg(any(target_arch = "wasm32", test))]
+fn derive_trpg_ui_state(
+    lifecycle: TrpgLifecycleState,
+    connection_ok: bool,
+    wizard_busy: bool,
+    preflight_ok: bool,
+    wizard_ready: bool,
+    round_running: bool,
+) -> TrpgUiState {
+    if !connection_ok || matches!(lifecycle, TrpgLifecycleState::Unavailable) {
+        return TrpgUiState::Error;
+    }
+    if round_running {
+        return TrpgUiState::RoundRunning;
+    }
+    if wizard_busy || matches!(lifecycle, TrpgLifecycleState::Loading) {
+        return TrpgUiState::SessionStarting;
+    }
+    match lifecycle {
+        TrpgLifecycleState::Running => TrpgUiState::SessionRunning,
+        TrpgLifecycleState::Stopped => TrpgUiState::Paused,
+        TrpgLifecycleState::Ended => TrpgUiState::Ended,
+        TrpgLifecycleState::Lobby | TrpgLifecycleState::Unknown => {
+            if preflight_ok && wizard_ready {
+                TrpgUiState::ConfigReady
+            } else {
+                TrpgUiState::Lobby
+            }
+        }
+        TrpgLifecycleState::Loading => TrpgUiState::SessionStarting,
+        TrpgLifecycleState::Unavailable => TrpgUiState::Error,
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+fn read_new_game_wizard_busy(doc: &web_sys::Document) -> bool {
+    doc.get_element_by_id("new-game-panel")
+        .and_then(|panel| panel.get_attribute("data-wizard-busy"))
+        .is_some_and(|flag| flag == "1")
+}
+
+#[cfg(target_arch = "wasm32")]
+fn read_new_game_preflight_ok(doc: &web_sys::Document) -> bool {
+    doc.get_element_by_id("new-game-panel")
+        .and_then(|panel| panel.get_attribute("data-preflight-state"))
+        .is_some_and(|state| state == "ok")
+}
+
+#[cfg(target_arch = "wasm32")]
+fn read_new_game_assignment_ready(doc: &web_sys::Document) -> bool {
+    let dm = doc
+        .get_element_by_id("new-game-dm-select")
+        .and_then(|el| el.dyn_into::<HtmlSelectElement>().ok())
+        .map(|select| select.value().trim().to_string())
+        .unwrap_or_default();
+    if dm.is_empty() {
+        return false;
+    }
+
+    let Ok(nodes) = doc.query_selector_all("#new-game-player-select option:checked") else {
+        return false;
+    };
+    let mut selected_count = 0_u32;
+    let mut has_conflict = false;
+    for idx in 0..nodes.length() {
+        let Some(node) = nodes.item(idx) else {
+            continue;
+        };
+        let Some(option) = node.dyn_ref::<web_sys::HtmlOptionElement>() else {
+            continue;
+        };
+        let value = option.value().trim().to_string();
+        if value.is_empty() {
+            continue;
+        }
+        if value == dm {
+            has_conflict = true;
+            continue;
+        }
+        selected_count += 1;
+    }
+    selected_count > 0 && !has_conflict
+}
+
+#[cfg(target_arch = "wasm32")]
+fn summarize_ops_detail(detail: &str, max_chars: usize) -> String {
+    let compact = detail.trim().replace('\n', " ");
+    if compact.chars().count() <= max_chars {
+        return compact;
+    }
+    let mut shortened = compact
+        .chars()
+        .take(max_chars.saturating_sub(1))
+        .collect::<String>();
+    shortened.push('…');
+    shortened
+}
+
+#[cfg(target_arch = "wasm32")]
+fn sync_dashboard_ui_state(doc: &web_sys::Document, state: TrpgUiState, detail: &str) {
+    if let Some(dashboard) = doc.get_element_by_id("dashboard") {
+        let _ = dashboard.set_attribute("data-trpg-ui-state", state.code());
+        let _ = dashboard.set_attribute("data-trpg-ui-label", state.label_ko());
+        let _ = dashboard.set_attribute("data-trpg-ui-help", state.help_text());
+    }
+
+    if let Some(el) = doc.get_element_by_id("ops-control-state") {
+        let summary = summarize_ops_detail(detail, 96);
+        let text = if summary.is_empty() {
+            state.label_ko().to_string()
+        } else {
+            format!("{} · {}", state.label_ko(), summary)
+        };
+        let class_name = format!("ops-v {}", state.ops_class());
+        el.set_text_content(Some(&text));
+        let _ = el.set_attribute("class", &class_name);
+        let _ = el.set_attribute(
+            "title",
+            &format!("{} | {}", state.help_text(), detail.trim()),
+        );
+    }
 }
 
 // ─── Marker Resource ────────────────────────
@@ -143,8 +266,9 @@ pub fn sync_turn_controls_visibility(
         let runner_active = auto_round_runner_active(&doc);
         if runner_active {
             can_run = false;
-            reason = "실행 대기: 자동 라운드 실행 중입니다. 관전 모드에서는 수동 실행이 잠금됩니다."
-                .to_string();
+            reason =
+                "실행 대기: 자동 라운드 실행 중입니다. 관전 모드에서는 수동 실행이 잠금됩니다."
+                    .to_string();
             reason_class = "status-info";
         } else if let Some(owner) = lock_owner.as_deref() {
             if owner != "manual" {
@@ -187,6 +311,16 @@ pub fn sync_turn_controls_visibility(
             format!("실행 대기: {}", reason)
         };
         set_turn_gate_reason(&gate_message, reason_class);
+
+        let ui_state = derive_trpg_ui_state(
+            lifecycle,
+            connection_ok,
+            read_new_game_wizard_busy(&doc),
+            read_new_game_preflight_ok(&doc),
+            read_new_game_assignment_ready(&doc),
+            busy || locked,
+        );
+        sync_dashboard_ui_state(&doc, ui_state, &gate_message);
     }
 }
 
@@ -1033,5 +1167,35 @@ mod tests {
     fn round_advanced_falls_back_to_turn_delta() {
         assert!(round_advanced(2, 3, None));
         assert!(!round_advanced(2, 2, None));
+    }
+
+    #[test]
+    fn derive_trpg_ui_state_prioritizes_round_running() {
+        let state =
+            derive_trpg_ui_state(TrpgLifecycleState::Running, true, false, true, true, true);
+        assert_eq!(state, TrpgUiState::RoundRunning);
+    }
+
+    #[test]
+    fn derive_trpg_ui_state_detects_config_ready_before_start() {
+        let state = derive_trpg_ui_state(TrpgLifecycleState::Lobby, true, false, true, true, false);
+        assert_eq!(state, TrpgUiState::ConfigReady);
+    }
+
+    #[test]
+    fn derive_trpg_ui_state_maps_paused_and_error() {
+        let paused = derive_trpg_ui_state(
+            TrpgLifecycleState::Stopped,
+            true,
+            false,
+            false,
+            false,
+            false,
+        );
+        assert_eq!(paused, TrpgUiState::Paused);
+
+        let error =
+            derive_trpg_ui_state(TrpgLifecycleState::Running, false, false, true, true, false);
+        assert_eq!(error, TrpgUiState::Error);
     }
 }

--- a/viewer/src/game/lifecycle.rs
+++ b/viewer/src/game/lifecycle.rs
@@ -9,6 +9,19 @@ pub enum TrpgLifecycleState {
     Unknown,
 }
 
+#[cfg(any(target_arch = "wasm32", test))]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TrpgUiState {
+    Lobby,
+    ConfigReady,
+    SessionStarting,
+    SessionRunning,
+    RoundRunning,
+    Paused,
+    Ended,
+    Error,
+}
+
 pub fn normalize_status(raw: &str) -> String {
     let normalized = raw.trim().to_ascii_lowercase();
     if normalized.is_empty() {
@@ -113,5 +126,114 @@ impl TrpgLifecycleState {
 
     pub fn accepts_player_input(self) -> bool {
         matches!(self, Self::Running)
+    }
+}
+
+#[cfg(any(target_arch = "wasm32", test))]
+impl TrpgUiState {
+    pub fn code(self) -> &'static str {
+        match self {
+            Self::Lobby => "lobby",
+            Self::ConfigReady => "config_ready",
+            Self::SessionStarting => "session_starting",
+            Self::SessionRunning => "session_running",
+            Self::RoundRunning => "round_running",
+            Self::Paused => "paused",
+            Self::Ended => "ended",
+            Self::Error => "error",
+        }
+    }
+
+    pub fn from_code(raw: &str) -> Self {
+        match raw.trim().to_ascii_lowercase().as_str() {
+            "config_ready" => Self::ConfigReady,
+            "session_starting" => Self::SessionStarting,
+            "session_running" => Self::SessionRunning,
+            "round_running" => Self::RoundRunning,
+            "paused" => Self::Paused,
+            "ended" => Self::Ended,
+            "error" => Self::Error,
+            _ => Self::Lobby,
+        }
+    }
+
+    pub fn label_ko(self) -> &'static str {
+        match self {
+            Self::Lobby => "로비",
+            Self::ConfigReady => "설정 완료",
+            Self::SessionStarting => "세션 시작 중",
+            Self::SessionRunning => "세션 진행 중",
+            Self::RoundRunning => "라운드 실행 중",
+            Self::Paused => "일시정지",
+            Self::Ended => "종료",
+            Self::Error => "오류",
+        }
+    }
+
+    pub fn help_text(self) -> &'static str {
+        match self {
+            Self::Lobby => "새 세션 시작 전 대기 상태",
+            Self::ConfigReady => "사전 점검과 keeper 할당이 완료되어 시작 가능한 상태",
+            Self::SessionStarting => "세션 생성/부트스트랩이 진행 중인 상태",
+            Self::SessionRunning => "세션이 실행 중이며 라운드 실행 가능 상태",
+            Self::RoundRunning => "라운드 요청이 실행 중인 상태",
+            Self::Paused => "세션이 멈춰 있으며 재개 또는 종료 판단 필요",
+            Self::Ended => "세션이 종료된 상태",
+            Self::Error => "연결 또는 실행 오류로 진행할 수 없는 상태",
+        }
+    }
+
+    pub fn ops_class(self) -> &'static str {
+        match self {
+            Self::ConfigReady | Self::SessionRunning => "status-active",
+            Self::SessionStarting | Self::RoundRunning => "status-info",
+            Self::Paused => "status-warn",
+            Self::Ended | Self::Lobby => "status-idle",
+            Self::Error => "status-error",
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::TrpgUiState;
+
+    #[test]
+    fn trpg_ui_state_code_roundtrip() {
+        let cases = [
+            TrpgUiState::Lobby,
+            TrpgUiState::ConfigReady,
+            TrpgUiState::SessionStarting,
+            TrpgUiState::SessionRunning,
+            TrpgUiState::RoundRunning,
+            TrpgUiState::Paused,
+            TrpgUiState::Ended,
+            TrpgUiState::Error,
+        ];
+
+        for state in cases {
+            assert_eq!(TrpgUiState::from_code(state.code()), state);
+        }
+        assert_eq!(TrpgUiState::from_code("unknown-state"), TrpgUiState::Lobby);
+    }
+
+    #[test]
+    fn trpg_ui_state_labels_and_classes_are_defined() {
+        let cases = [
+            TrpgUiState::Lobby,
+            TrpgUiState::ConfigReady,
+            TrpgUiState::SessionStarting,
+            TrpgUiState::SessionRunning,
+            TrpgUiState::RoundRunning,
+            TrpgUiState::Paused,
+            TrpgUiState::Ended,
+            TrpgUiState::Error,
+        ];
+
+        for state in cases {
+            assert!(!state.label_ko().trim().is_empty());
+            assert!(!state.help_text().trim().is_empty());
+            assert!(!state.ops_class().trim().is_empty());
+        }
     }
 }

--- a/viewer/src/mode/trpg_controls.rs
+++ b/viewer/src/mode/trpg_controls.rs
@@ -10,6 +10,7 @@ use wasm_bindgen::JsCast;
 use wasm_bindgen_futures::JsFuture;
 
 use crate::dom::escape::html_escape;
+use crate::game::lifecycle::TrpgUiState;
 
 use super::{
     assign_keepers_to_actor_ids, clear_trpg_dom, generate_room_id, mcp_tool_call,
@@ -84,6 +85,20 @@ fn selected_dm_keeper(doc: &web_sys::Document) -> String {
         .unwrap_or_default()
         .trim()
         .to_string()
+}
+
+fn read_dashboard_ui_state(doc: &web_sys::Document) -> TrpgUiState {
+    doc.get_element_by_id("dashboard")
+        .and_then(|dashboard| dashboard.get_attribute("data-trpg-ui-state"))
+        .map(|raw| TrpgUiState::from_code(&raw))
+        .unwrap_or(TrpgUiState::Lobby)
+}
+
+fn ui_state_blocks_new_session_start(state: TrpgUiState) -> bool {
+    matches!(
+        state,
+        TrpgUiState::SessionStarting | TrpgUiState::SessionRunning | TrpgUiState::RoundRunning
+    )
 }
 
 fn set_new_game_preflight_state(doc: &web_sys::Document, state: &str) {
@@ -181,11 +196,13 @@ fn sync_new_game_wizard_ui(doc: &web_sys::Document) {
     let preflight_state = new_game_preflight_state(doc);
     let dm_keeper = selected_dm_keeper(doc);
     let players = selected_player_keepers(doc);
+    let ui_state = read_dashboard_ui_state(doc);
     let dm_selected = !dm_keeper.is_empty();
     let has_conflict = dm_selected && players.iter().any(|player| player == &dm_keeper);
     let players_ok = !players.is_empty() && !has_conflict;
     let assignment_ok = dm_selected && players_ok;
-    let ready = preflight_state == "ok" && assignment_ok;
+    let runtime_locked = ui_state_blocks_new_session_start(ui_state);
+    let ready = preflight_state == "ok" && assignment_ok && !runtime_locked;
     let busy = new_game_wizard_busy(doc);
 
     let step1_state = match preflight_state.as_str() {
@@ -208,7 +225,7 @@ fn sync_new_game_wizard_ui(doc: &web_sys::Document) {
     };
     let step3_state = if busy {
         "active"
-    } else if ready {
+    } else if runtime_locked || ready {
         "active"
     } else {
         "pending"
@@ -220,6 +237,11 @@ fn sync_new_game_wizard_ui(doc: &web_sys::Document) {
 
     let start_gate_reason = if busy {
         "세션 시작 작업 실행 중입니다. 완료까지 기다려주세요.".to_string()
+    } else if runtime_locked {
+        format!(
+            "현재 {} 상태입니다. 진행 중 라운드/세션이 멈춘 뒤 시작하세요.",
+            ui_state.label_ko()
+        )
     } else if preflight_state != "ok" {
         "사전 점검을 먼저 통과해야 세션 시작이 가능합니다.".to_string()
     } else if !dm_selected {
@@ -244,16 +266,31 @@ fn sync_new_game_wizard_ui(doc: &web_sys::Document) {
         start_btn.set_title(&start_gate_reason);
     }
 
+    for id in [
+        "new-game-quick-start",
+        "new-game-preflight-btn",
+        "new-game-refresh",
+    ] {
+        if let Some(btn) = doc
+            .get_element_by_id(id)
+            .and_then(|el| el.dyn_into::<web_sys::HtmlButtonElement>().ok())
+        {
+            btn.set_disabled(busy || runtime_locked);
+        }
+    }
+
     if let Some(hint) = doc.get_element_by_id("new-game-step-hint") {
+        let state_badge = format!("[상태: {}]", ui_state.label_ko());
         let text = if ready {
             format!(
-                "3단계 준비 완료: DM {} · 플레이어 {}명({}). 세션 시작 버튼을 누르세요.",
+                "{} 3단계 준비 완료: DM {} · 플레이어 {}명({}). 세션 시작 버튼을 누르세요.",
+                state_badge,
                 dm_keeper,
                 players.len(),
                 summarize_names(&players, 3)
             )
         } else {
-            format!("진행 가이드: {}", start_gate_reason)
+            format!("{} 진행 가이드: {}", state_badge, start_gate_reason)
         };
         hint.set_text_content(Some(&text));
     }


### PR DESCRIPTION
## Summary
- add a dedicated TrpgUiState model for viewer runtime control flow
- derive dashboard UI state from lifecycle + connection + new game wizard readiness
- gate new-game actions when a session/round is already running and expose state-aware hints
- add unit tests for UI state derivation and code/label mapping

## Verification
- cargo test --manifest-path viewer/Cargo.toml
- cargo check --manifest-path viewer/Cargo.toml --target wasm32-unknown-unknown