### PR TITLE
fix(viewer): enable Monitor/Council/Experiment mode cards

### DIFF
--- a/viewer/index.html
+++ b/viewer/index.html
@@ -23,25 +23,22 @@
                 <span class="mode-desc">Dark fantasy TRPG — 5 AI agents play D&amp;D 5e</span>
             </button>
 
-            <button class="mode-card mode-card-disabled" data-mode="experiment" disabled>
+            <button class="mode-card" data-mode="experiment">
                 <span class="mode-icon">⬡</span>
                 <span class="mode-name">Experiment Lab</span>
                 <span class="mode-desc">Live experiment metrics and flow visualization</span>
-                <span class="coming-soon">Coming Soon</span>
             </button>
 
-            <button class="mode-card mode-card-disabled" data-mode="monitor" disabled>
+            <button class="mode-card" data-mode="monitor">
                 <span class="mode-icon">◉</span>
                 <span class="mode-name">System Monitor</span>
                 <span class="mode-desc">Agent health, keeper metrics, system dashboard</span>
-                <span class="coming-soon">Coming Soon</span>
             </button>
 
-            <button class="mode-card mode-card-disabled" data-mode="council" disabled>
+            <button class="mode-card" data-mode="council">
                 <span class="mode-icon">△</span>
                 <span class="mode-name">MAGI Council</span>
                 <span class="mode-desc">MAGI deliberation — consensus and debate viewer</span>
-                <span class="coming-soon">Coming Soon</span>
             </button>
 
             <button class="mode-card" data-mode="social">


### PR DESCRIPTION
## Summary
- enable lobby mode cards for `Experiment`, `System Monitor`, and `MAGI Council`
- remove `disabled` attribute and `mode-card-disabled` class from those three cards
- remove `Coming Soon` badge text so users can actually enter the panels

## Why
The panels exist and have runtime systems, but the lobby blocked entry at the HTML layer.
Users could not click into these modes, which looked like the modes were broken.

## Verification
- code diff check: `viewer/index.html` only
- attempted: `cargo check -p masc-viewer --target wasm32-unknown-unknown`
- note: compile currently fails on baseline unrelated viewer sources (`viewer/src/sse/client.rs`, `viewer/src/game/round_runner.rs`), not in this change set
