### PR TITLE
feat(viewer): clarify lobby/session/history runtime flow

### DIFF
--- a/viewer/src/dom/session_history.rs
+++ b/viewer/src/dom/session_history.rs
@@ -66,11 +66,13 @@ fn normalize_room_id(raw: &str) -> String {
 fn normalize_room_status(raw: &str) -> String {
     let key = sanitize_key(raw);
     match key.as_str() {
-        "active" | "running" | "started" | "in_progress" | "in-progress" | "playing"
-        | "open" => "active",
+        "active" | "running" | "started" | "in_progress" | "in-progress" | "playing" | "open" => {
+            "active"
+        }
         "paused" | "pause" | "stopped" | "idle" | "on_hold" | "on-hold" => "paused",
-        "ended" | "finished" | "completed" | "closed" | "done" | "archived"
-        | "terminated" => "ended",
+        "ended" | "finished" | "completed" | "closed" | "done" | "archived" | "terminated" => {
+            "ended"
+        }
         _ => "unknown",
     }
     .to_string()
@@ -324,7 +326,7 @@ fn sorted_room_refs(rooms: &[RoomHistory]) -> Vec<&RoomHistory> {
 }
 
 #[cfg(target_arch = "wasm32")]
-fn render_room_bucket_html(title: &str, rooms: &[&RoomHistory]) -> String {
+fn render_room_bucket_html(title: &str, rooms: &[&RoomHistory], extra_class: &str) -> String {
     if rooms.is_empty() {
         return String::new();
     }
@@ -358,8 +360,9 @@ fn render_room_bucket_html(title: &str, rooms: &[&RoomHistory]) -> String {
         .join("");
 
     format!(
-        r#"<section class="history-room-bucket"><h4 class="history-room-bucket-title">{title}</h4><div class="history-room-list">{chips}</div></section>"#,
+        r#"<section class="history-room-bucket {extra_class}"><h4 class="history-room-bucket-title">{title}</h4><div class="history-room-list">{chips}</div></section>"#,
         title = html_escape(&sanitize_text(title)),
+        extra_class = html_escape(extra_class),
         chips = chips
     )
 }
@@ -421,19 +424,38 @@ fn render_turn_panel_html(room: &RoomHistory, row: &TurnHistory) -> String {
 }
 
 #[cfg(target_arch = "wasm32")]
-fn render_session_history_html(rooms: &[RoomHistory]) -> String {
+fn render_session_history_html(rooms: &[RoomHistory], current_room_id: &str) -> String {
     if rooms.is_empty() {
         return "<div class=\"session-history-empty\">아직 세션 히스토리가 없습니다.</div>"
             .to_string();
     }
 
     let sorted = sorted_room_refs(rooms);
+    let current_room = normalize_room_id(current_room_id);
+    let active_count = sorted
+        .iter()
+        .filter(|room| normalize_room_status(&room.status) == "active")
+        .count();
+    let paused_count = sorted
+        .iter()
+        .filter(|room| normalize_room_status(&room.status) == "paused")
+        .count();
+    let ended_count = sorted
+        .iter()
+        .filter(|room| normalize_room_status(&room.status) == "ended")
+        .count();
+
+    let mut current_rooms = Vec::new();
     let mut active_rooms = Vec::new();
     let mut paused_rooms = Vec::new();
     let mut ended_rooms = Vec::new();
     let mut other_rooms = Vec::new();
 
     for room in &sorted {
+        if room.room_id == current_room {
+            current_rooms.push(*room);
+            continue;
+        }
         match room_status_bucket(&room.status) {
             0 => active_rooms.push(*room),
             1 => paused_rooms.push(*room),
@@ -442,12 +464,37 @@ fn render_session_history_html(rooms: &[RoomHistory]) -> String {
         }
     }
 
+    let current_bucket = if current_rooms.is_empty() {
+        format!(
+            r#"<section class="history-room-bucket history-room-bucket-current"><h4 class="history-room-bucket-title">현재 세션</h4><p class="history-room-empty">현재 room({room})의 기록이 아직 없습니다.</p></section>"#,
+            room = html_escape(&sanitize_text(&current_room))
+        )
+    } else {
+        render_room_bucket_html("현재 세션", &current_rooms, "history-room-bucket-current")
+    };
+
+    let summary_class = if current_rooms.is_empty() {
+        "history-session-summary is-missing"
+    } else {
+        "history-session-summary"
+    };
+    let summary_html = format!(
+        r#"<div class="{summary_class}"><span>현재 room: <strong>{room}</strong></span><span>진행 {active} · 멈춤 {paused} · 종료 {ended}</span></div>"#,
+        summary_class = summary_class,
+        room = html_escape(&sanitize_text(&current_room)),
+        active = active_count,
+        paused = paused_count,
+        ended = ended_count
+    );
+
     let room_column = format!(
-        r#"<section class="history-browser-column history-room-column"><h3 class="history-column-title">게임</h3>{active}{paused}{ended}{other}</section>"#,
-        active = render_room_bucket_html("진행중", &active_rooms),
-        paused = render_room_bucket_html("멈춤", &paused_rooms),
-        ended = render_room_bucket_html("종료", &ended_rooms),
-        other = render_room_bucket_html("기타", &other_rooms)
+        r#"<section class="history-browser-column history-room-column"><h3 class="history-column-title">세션</h3>{summary}{current}{active}{paused}{ended}{other}</section>"#,
+        summary = summary_html,
+        current = current_bucket,
+        active = render_room_bucket_html("이전 세션 · 진행중", &active_rooms, ""),
+        paused = render_room_bucket_html("이전 세션 · 멈춤", &paused_rooms, ""),
+        ended = render_room_bucket_html("이전 세션 · 종료", &ended_rooms, ""),
+        other = render_room_bucket_html("이전 세션 · 기타", &other_rooms, "")
     );
 
     let turn_groups = sorted
@@ -724,7 +771,9 @@ fn resolve_focus_turn(
 #[cfg(target_arch = "wasm32")]
 fn apply_history_focus(document: &web_sys::Document, room: Option<&str>, turn: Option<u32>) {
     let room_key = room.and_then(normalize_focus_room);
-    let turn_key = turn.filter(|value| *value > 0).map(|value| value.to_string());
+    let turn_key = turn
+        .filter(|value| *value > 0)
+        .map(|value| value.to_string());
 
     for selector in ["#narrative-log .narrative-entry", "#dice-log .dice-entry"] {
         let Ok(nodes) = document.query_selector_all(selector) else {
@@ -1009,11 +1058,16 @@ pub fn update_session_history_dom(
             room_state.phase.as_str().to_string()
         };
 
-        let (room_idx, room_changed) =
-            ensure_room_entry(&mut cache.rooms, &base_room_id, &base_room_status, current_turn);
+        let (room_idx, room_changed) = ensure_room_entry(
+            &mut cache.rooms,
+            &base_room_id,
+            &base_room_status,
+            current_turn,
+        );
         changed = changed || room_changed;
         if let Some(room) = cache.rooms.get_mut(room_idx) {
-            let (_, turn_changed) = ensure_turn_entry(&mut room.turns, current_turn, &current_phase);
+            let (_, turn_changed) =
+                ensure_turn_entry(&mut room.turns, current_turn, &current_phase);
             changed = changed || turn_changed;
         }
 
@@ -1206,11 +1260,16 @@ pub fn update_session_history_dom(
             base_room_status = event_status;
         }
 
-        let (room_idx, room_changed) =
-            ensure_room_entry(&mut cache.rooms, &base_room_id, &base_room_status, current_turn);
+        let (room_idx, room_changed) = ensure_room_entry(
+            &mut cache.rooms,
+            &base_room_id,
+            &base_room_status,
+            current_turn,
+        );
         changed = changed || room_changed;
         if let Some(room) = cache.rooms.get_mut(room_idx) {
-            let (_, turn_changed) = ensure_turn_entry(&mut room.turns, current_turn, &current_phase);
+            let (_, turn_changed) =
+                ensure_turn_entry(&mut room.turns, current_turn, &current_phase);
             changed = changed || turn_changed;
         }
 
@@ -1218,7 +1277,8 @@ pub fn update_session_history_dom(
             return;
         }
 
-        history.set_inner_html(&render_session_history_html(&cache.rooms));
+        let current_room_id = crate::config::current_room_id();
+        history.set_inner_html(&render_session_history_html(&cache.rooms, &current_room_id));
         bind_history_focus_controls(&document);
 
         let (hash_room, hash_turn) = read_focus_from_hash();

--- a/viewer/src/dom/turn_runtime.rs
+++ b/viewer/src/dom/turn_runtime.rs
@@ -140,7 +140,11 @@ fn summarize_actor_issues(progress: &TurnProgressState) -> (String, bool) {
         if !is_issue_state && reason.is_empty() {
             continue;
         }
-        let state_label = if is_issue_state { state.as_str() } else { "issue" };
+        let state_label = if is_issue_state {
+            state.as_str()
+        } else {
+            "issue"
+        };
         if reason.is_empty() {
             issues.push(format!("{}: {}", actor_id, state_label));
         } else {
@@ -169,8 +173,12 @@ fn build_next_action_hint(
             TrpgLifecycleState::Loading => {
                 "로딩 중입니다. 상태 동기화 완료를 기다리세요.".to_string()
             }
-            TrpgLifecycleState::Stopped => "세션이 멈춰 있습니다. Start/Run으로 재개하세요.".to_string(),
-            TrpgLifecycleState::Ended => "세션이 종료되었습니다. New Game으로 시작하세요.".to_string(),
+            TrpgLifecycleState::Stopped => {
+                "세션이 멈춰 있습니다. Start/Run으로 재개하세요.".to_string()
+            }
+            TrpgLifecycleState::Ended => {
+                "세션이 종료되었습니다. New Game으로 시작하세요.".to_string()
+            }
             TrpgLifecycleState::Unavailable => {
                 "엔진/키퍼 연결을 복구한 뒤 다시 시도하세요.".to_string()
             }
@@ -203,6 +211,106 @@ fn set_ops_hud_value(document: &web_sys::Document, id: &str, text: &str, status_
     };
     el.set_text_content(Some(text));
     el.set_class_name(&class_name);
+}
+
+#[cfg(target_arch = "wasm32")]
+fn lifecycle_is_done_node(lifecycle: TrpgLifecycleState, node_state: &str) -> bool {
+    match lifecycle {
+        TrpgLifecycleState::Lobby => false,
+        TrpgLifecycleState::Loading => node_state == "lobby",
+        TrpgLifecycleState::Running => node_state == "lobby",
+        TrpgLifecycleState::Stopped => matches!(node_state, "lobby" | "running"),
+        TrpgLifecycleState::Ended => matches!(node_state, "lobby" | "running" | "stopped"),
+        TrpgLifecycleState::Unavailable | TrpgLifecycleState::Unknown => false,
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+fn lifecycle_active_node(lifecycle: TrpgLifecycleState) -> Option<&'static str> {
+    match lifecycle {
+        TrpgLifecycleState::Lobby => Some("lobby"),
+        TrpgLifecycleState::Loading => Some("recover"),
+        TrpgLifecycleState::Running => Some("running"),
+        TrpgLifecycleState::Stopped => Some("stopped"),
+        TrpgLifecycleState::Ended => Some("ended"),
+        TrpgLifecycleState::Unavailable => Some("unavailable"),
+        TrpgLifecycleState::Unknown => None,
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+fn lifecycle_hint(lifecycle: TrpgLifecycleState, runner_running: bool) -> String {
+    match lifecycle {
+        TrpgLifecycleState::Lobby => {
+            "LOBBY 단계: 새 게임에서 DM/플레이어를 배정하고 세션 시작을 실행하세요.".to_string()
+        }
+        TrpgLifecycleState::Loading => {
+            "SESSION STARTING 단계: 초기화/동기화 중입니다. 완료되면 RUNNING으로 전환됩니다."
+                .to_string()
+        }
+        TrpgLifecycleState::Running => {
+            if runner_running {
+                "RUNNING 단계: 자동 라운드가 순환 중입니다. 이벤트 수신을 기다리세요.".to_string()
+            } else {
+                "RUNNING 단계: 라운드 실행 또는 플레이어 액션으로 다음 페이즈로 진행됩니다."
+                    .to_string()
+            }
+        }
+        TrpgLifecycleState::Stopped => {
+            "STOPPED 단계: 세션은 유지되며 재개 가능합니다. 조건을 점검 후 다시 실행하세요."
+                .to_string()
+        }
+        TrpgLifecycleState::Ended => {
+            "ENDED 단계: 현재 세션이 종료되었습니다. 새 게임으로 새 라운드 루프를 시작하세요."
+                .to_string()
+        }
+        TrpgLifecycleState::Unavailable => {
+            "UNAVAILABLE 단계: keeper/엔진 연결 문제입니다. 연결 복구 후 재시도하세요.".to_string()
+        }
+        TrpgLifecycleState::Unknown => {
+            "상태 불명: LOBBY → RUNNING ↔ STOPPED → ENDED 순서를 기준으로 로그를 확인하세요."
+                .to_string()
+        }
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+fn sync_lifecycle_diagram(
+    document: &web_sys::Document,
+    lifecycle: TrpgLifecycleState,
+    runner_running: bool,
+) {
+    let active = lifecycle_active_node(lifecycle);
+    if let Ok(nodes) = document.query_selector_all("#lifecycle-diagram .lifecycle-node") {
+        for idx in 0..nodes.length() {
+            let Some(node) = nodes.item(idx) else {
+                continue;
+            };
+            let Some(el) = node.dyn_ref::<web_sys::Element>() else {
+                continue;
+            };
+            let state = el.get_attribute("data-state").unwrap_or_default();
+            let _ = el.class_list().remove_1("is-active");
+            let _ = el.class_list().remove_1("is-done");
+            let _ = el.class_list().remove_1("is-error");
+
+            if lifecycle_is_done_node(lifecycle, &state) {
+                let _ = el.class_list().add_1("is-done");
+            }
+            if active == Some(state.as_str()) {
+                let _ = el.class_list().add_1("is-active");
+            }
+            if lifecycle == TrpgLifecycleState::Unavailable && state == "unavailable" {
+                let _ = el.class_list().add_1("is-error");
+            }
+        }
+    }
+
+    if let Some(hint) = document.get_element_by_id("lifecycle-diagram-hint") {
+        let message = lifecycle_hint(lifecycle, runner_running);
+        hint.set_text_content(Some(&message));
+        let _ = hint.set_attribute("title", &message);
+    }
 }
 
 /// Render live TRPG runtime progress:
@@ -337,16 +445,6 @@ pub fn update_turn_runtime_dom(
         )
     };
 
-    let control_state = if lifecycle.accepts_player_input() {
-        if current_actor != "-" {
-            "manual-ready / actor-thinking".to_string()
-        } else {
-            "manual-ready".to_string()
-        }
-    } else {
-        lifecycle.label_ko().to_string()
-    };
-
     let (runner_running, runner_rounds, runner_last_result) = if let Some(runner) = runner.as_ref()
     {
         let running = runner.running.load(std::sync::atomic::Ordering::SeqCst);
@@ -372,18 +470,14 @@ pub fn update_turn_runtime_dom(
     } else {
         "idle".to_string()
     };
-    let next_action = build_next_action_hint(
-        lifecycle,
-        runner_running,
-        &current_actor,
-        has_actor_issues,
-    );
+    let next_action =
+        build_next_action_hint(lifecycle, runner_running, &current_actor, has_actor_issues);
 
     let connection_label = connection_status_label(&connection);
     let connection_class = connection_status_class(&connection);
 
     #[cfg(not(target_arch = "wasm32"))]
-    let _ = (&sync_class, &control_state, &runner_last_result);
+    let _ = (&sync_class, &runner_last_result);
 
     let snapshot = format!(
         "{}|{}|{}|{}|{}|{}|{}|{}|{}|{}|{}|{}|{}|{}|{}|{}",
@@ -478,7 +572,7 @@ pub fn update_turn_runtime_dom(
         set_ops_hud_value(
             &document,
             "ops-control-state",
-            &control_state,
+            &lifecycle_hint(lifecycle, runner_running),
             if lifecycle.accepts_player_input() {
                 "status-active"
             } else {
@@ -486,6 +580,7 @@ pub fn update_turn_runtime_dom(
             },
         );
         set_ops_hud_value(&document, "ops-sync-state", &sync_state, sync_class);
+        sync_lifecycle_diagram(&document, lifecycle, runner_running);
 
         let inferred_dm = if !progress.dm_keeper.trim().is_empty() {
             progress.dm_keeper.trim().to_string()
@@ -642,10 +737,9 @@ mod tests {
         progress
             .actor_states
             .insert("p01".to_string(), "timeout".to_string());
-        progress.actor_reasons.insert(
-            "p01".to_string(),
-            "keeper heartbeat timeout".to_string(),
-        );
+        progress
+            .actor_reasons
+            .insert("p01".to_string(), "keeper heartbeat timeout".to_string());
         progress
             .actor_reasons
             .insert("p99".to_string(), "no keeper".to_string());

--- a/viewer/src/mode/mod.rs
+++ b/viewer/src/mode/mod.rs
@@ -293,9 +293,9 @@ fn bind_auto_round_toggle(doc: &web_sys::Document) {
         crate::game::round_runner::set_auto_round_running(next);
     }) as Box<dyn FnMut()>);
 
-    let _ = button
-        .dyn_ref::<web_sys::EventTarget>()
-        .map(|target| target.add_event_listener_with_callback("click", cb.as_ref().unchecked_ref()));
+    let _ = button.dyn_ref::<web_sys::EventTarget>().map(|target| {
+        target.add_event_listener_with_callback("click", cb.as_ref().unchecked_ref())
+    });
     cb.forget();
 }
 
@@ -1199,7 +1199,7 @@ fn load_room_hub_visible() -> bool {
                 .flatten()
         })
         .map(|value| matches!(value.trim(), "1" | "true" | "on"))
-        .unwrap_or(false)
+        .unwrap_or(true)
 }
 
 #[cfg(target_arch = "wasm32")]
@@ -1299,7 +1299,7 @@ fn sync_room_controls(doc: &web_sys::Document, selected_room: &str) {
         input.set_value(&selected);
     }
     if let Some(pill) = doc.get_element_by_id("room-status") {
-        let lifecycle = TrpgLifecycleState::Lobby;
+        let lifecycle = TrpgLifecycleState::Loading;
         pill.set_text_content(Some(&format!(
             "현재 방: {} · {}",
             selected,

--- a/viewer/style.css
+++ b/viewer/style.css
@@ -2030,6 +2030,32 @@ body:not(.mode-trpg) #ops-hud {
     color: var(--text-dim);
 }
 
+.history-session-summary {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px 12px;
+    margin: 0 0 8px;
+    padding: 6px 8px;
+    border: 1px solid rgba(109, 122, 164, 0.28);
+    border-radius: 8px;
+    background: rgba(18, 23, 38, 0.62);
+    font-size: 10px;
+    color: var(--text-dim);
+}
+
+.history-session-summary strong {
+    color: var(--text-primary);
+}
+
+.history-session-summary.is-missing {
+    border-color: rgba(196, 162, 101, 0.42);
+    background: rgba(53, 39, 17, 0.3);
+}
+
+.history-room-bucket-current .history-room-bucket-title {
+    color: #e4c895;
+}
+
 .history-room-bucket + .history-room-bucket {
     margin-top: 10px;
 }


### PR DESCRIPTION
## Summary
- clarify lifecycle guidance by syncing lifecycle diagram node states and Korean action hints in runtime HUD
- split session history view into current session vs previous sessions with explicit room summary counts
- make room hub visible by default and show room status as loading while runtime is being fetched
- add style updates for new session summary blocks

## Verification
- cargo check --manifest-path viewer/Cargo.toml --lib
- cargo test --manifest-path viewer/Cargo.toml --lib

## Note
- `cargo check --manifest-path viewer/Cargo.toml` (bin) is currently blocked by pre-existing main-branch compile errors in `viewer/src/sse/client.rs` and `viewer/src/game/round_runner.rs` unrelated to this PR.