### PR TITLE
feat(viewer): action panel P0-P3 improvements

### DIFF
--- a/viewer/index.html
+++ b/viewer/index.html
@@ -441,6 +441,7 @@
                             <button id="dice-roll-btn" title="1d20 주사위를 굴립니다">주사위</button>
                         </div>
                         <div id="action-status"></div>
+                        <div id="action-history" class="action-history"></div>
                         <input type="hidden" id="claimed-actor-id" value="" />
                         <input type="hidden" id="claimed-keeper" value="" />
                     </div>

--- a/viewer/src/dom/action_panel.rs
+++ b/viewer/src/dom/action_panel.rs
@@ -3,12 +3,19 @@
 //! Binds DOM event listeners on `#action-panel` elements:
 //! - Submit button / Enter key → MCP Tool `masc_trpg_intervention_submit`
 //! - Dice Roll button → MCP Tool `masc_trpg_dice_roll` (Manual override)
+//! - Escape key → clear input and blur
 //!
 //! **Philosophy:**
 //! We do NOT directly mutate the game state. We submit *Interventions*.
 //! The AI Agents (Keepers) living in this society receive these interventions,
 //! contemplate them, and decide whether to act upon them.
 //! We are whispers in their ears, not puppeteers.
+//!
+//! **Closure lifecycle:** Event listeners use `Closure::forget()` intentionally.
+//! WASM closures passed to JS must live as long as the DOM element. Since the
+//! action panel DOM elements are removed on `OnExit(ViewerMode::Trpg)`, the JS
+//! garbage collector reclaims the closure references when the elements are destroyed.
+//! The `data-bound` attribute prevents double-binding on re-entry.
 
 use bevy::prelude::*;
 
@@ -22,7 +29,70 @@ use wasm_bindgen::prelude::*;
 use crate::config;
 #[cfg(target_arch = "wasm32")]
 use crate::game::lifecycle::TrpgLifecycleState;
-use crate::game::state::{RoomState, TurnProgressState};
+#[cfg(target_arch = "wasm32")]
+use crate::http::{self, RpcResult};
+use crate::game::state::{ConnectionStatus, RoomState, TurnProgressState};
+
+// ─── Constants ──────────────────────────────
+
+/// Maximum length for action input text.
+const MAX_ACTION_LEN: usize = 500;
+
+/// Maximum number of entries in the action history panel.
+const MAX_HISTORY_ENTRIES: u32 = 5;
+
+/// Milliseconds before auto-clearing a success status message.
+#[cfg(target_arch = "wasm32")]
+const STATUS_CLEAR_DELAY_MS: i32 = 3000;
+
+// ─── Pure validation (testable without DOM) ─
+
+/// Validate action input text. Returns `Ok(())` or an error message.
+#[cfg(any(target_arch = "wasm32", test))]
+pub(crate) fn validate_action_input(text: &str) -> Result<(), &'static str> {
+    if text.is_empty() {
+        return Err("Enter an action first");
+    }
+    if text.len() > MAX_ACTION_LEN {
+        return Err("Action too long (max 500 chars)");
+    }
+    Ok(())
+}
+
+/// Extract a user-friendly display string from a successful dice roll RPC result.
+#[cfg(any(target_arch = "wasm32", test))]
+pub(crate) fn format_dice_result(rpc_result_json: &str) -> String {
+    // Try to extract total from the MCP tool result content
+    if let Ok(val) = serde_json::from_str::<serde_json::Value>(rpc_result_json) {
+        // MCP tool results are usually in result.content[0].text
+        if let Some(content) = val.get("content").and_then(|c| c.as_array()) {
+            if let Some(text) = content.first().and_then(|c| c.get("text")).and_then(|t| t.as_str())
+            {
+                // Try to parse the text as JSON for structured dice results
+                if let Ok(inner) = serde_json::from_str::<serde_json::Value>(text) {
+                    if let Some(total) = inner.get("total").and_then(|t| t.as_i64()) {
+                        return format!("Rolled: {}", total);
+                    }
+                }
+                // Fallback: use the text as-is if short enough
+                if text.len() <= 80 {
+                    return text.to_string();
+                }
+            }
+        }
+        // Direct result with total field
+        if let Some(total) = val.get("total").and_then(|t| t.as_i64()) {
+            return format!("Rolled: {}", total);
+        }
+    }
+    "Rolled.".to_string()
+}
+
+/// Check if connection status allows player input.
+#[cfg(any(target_arch = "wasm32", test))]
+fn connection_ready(status: &ConnectionStatus) -> bool {
+    matches!(status, ConnectionStatus::Connected)
+}
 
 // ─── Marker Resource ────────────────────────
 
@@ -37,6 +107,7 @@ pub fn bind_action_panel(mut commands: Commands) {
         log::info!("ActionPanel: Binding listeners (Intervention Mode)...");
         bind_submit_button();
         bind_enter_key();
+        bind_escape_key();
         bind_dice_roll_button();
         clear_action_status();
 
@@ -55,6 +126,30 @@ pub fn unbind_action_panel(mut commands: Commands) {
     }
 
     commands.remove_resource::<ActionPanelBound>();
+}
+
+// ─── Flight Lock ────────────────────────────
+//
+// Prevents concurrent async operations using a DOM attribute as a mutex.
+// Adopted from turn_controls.rs `data-round-flight-owner` pattern.
+
+#[cfg(target_arch = "wasm32")]
+fn try_acquire_flight(doc: &web_sys::Document, owner: &str) -> bool {
+    let Some(panel) = doc.get_element_by_id("action-panel") else {
+        return false;
+    };
+    if panel.get_attribute("data-action-flight").is_some() {
+        return false;
+    }
+    let _ = panel.set_attribute("data-action-flight", owner);
+    true
+}
+
+#[cfg(target_arch = "wasm32")]
+fn release_flight(doc: &web_sys::Document) {
+    if let Some(panel) = doc.get_element_by_id("action-panel") {
+        let _ = panel.remove_attribute("data-action-flight");
+    }
 }
 
 // ─── Event Bindings ─────────────────────────
@@ -91,14 +186,46 @@ fn bind_enter_key() {
     let Some(input) = doc.get_element_by_id("action-input") else {
         return;
     };
-    if input.get_attribute("data-bound").as_deref() == Some("1") {
+    if input.get_attribute("data-enter-bound").as_deref() == Some("1") {
         return;
     }
-    let _ = input.set_attribute("data-bound", "1");
+    let _ = input.set_attribute("data-enter-bound", "1");
 
     let cb = Closure::wrap(Box::new(move |event: web_sys::KeyboardEvent| {
         if event.key() == "Enter" {
             submit_intervention_from_input();
+        }
+    }) as Box<dyn FnMut(web_sys::KeyboardEvent)>);
+
+    let _ = input
+        .dyn_ref::<web_sys::EventTarget>()
+        .map(|t| t.add_event_listener_with_callback("keydown", cb.as_ref().unchecked_ref()));
+    cb.forget();
+}
+
+#[cfg(target_arch = "wasm32")]
+fn bind_escape_key() {
+    let Some(doc) = web_sys::window().and_then(|w| w.document()) else {
+        return;
+    };
+    let Some(input) = doc.get_element_by_id("action-input") else {
+        return;
+    };
+    if input.get_attribute("data-escape-bound").as_deref() == Some("1") {
+        return;
+    }
+    let _ = input.set_attribute("data-escape-bound", "1");
+
+    let cb = Closure::wrap(Box::new(move |event: web_sys::KeyboardEvent| {
+        if event.key() == "Escape" {
+            if let Some(doc) = web_sys::window().and_then(|w| w.document()) {
+                if let Some(el) = doc.get_element_by_id("action-input") {
+                    if let Some(input) = el.dyn_ref::<web_sys::HtmlInputElement>() {
+                        input.set_value("");
+                        let _ = input.blur();
+                    }
+                }
+            }
         }
     }) as Box<dyn FnMut(web_sys::KeyboardEvent)>);
 
@@ -122,19 +249,37 @@ fn bind_dice_roll_button() {
     let _ = btn.set_attribute("data-bound", "1");
 
     let cb = Closure::wrap(Box::new(move || {
+        let Some(doc) = web_sys::window().and_then(|w| w.document()) else {
+            return;
+        };
+
+        if !try_acquire_flight(&doc, "dice") {
+            set_action_status("Action in progress...", "status-pending");
+            return;
+        }
+
         log::info!("ActionPanel: Manual Dice Roll (Divine Intervention)");
-        set_action_status("Rolling destiny...", "");
+        set_action_status("Rolling destiny...", "status-pending");
         disable_buttons(true);
 
         wasm_bindgen_futures::spawn_local(async move {
-            match roll_dice_intervention().await {
-                Ok(text) => set_action_status(&text, "status-ok"),
-                Err(e) => {
-                    let detail = friendly_js_error(&e);
-                    set_action_status(&format!("Roll failed: {}", detail), "status-error");
+            let result = roll_dice_intervention().await;
+
+            // Always re-enable buttons and release flight lock
+            disable_buttons(false);
+            if let Some(doc) = web_sys::window().and_then(|w| w.document()) {
+                release_flight(&doc);
+            }
+
+            match result {
+                Ok(text) => {
+                    set_action_status(&text, "status-ok");
+                    schedule_status_clear();
+                }
+                Err(msg) => {
+                    set_action_status(&format!("Roll failed: {}", msg), "status-error");
                 }
             }
-            // State refresh handled by system
         });
     }) as Box<dyn FnMut()>);
 
@@ -159,30 +304,49 @@ fn submit_intervention_from_input() {
     };
 
     let text = input.value().trim().to_string();
-    if text.is_empty() {
+
+    // P1: Input validation
+    if let Err(msg) = validate_action_input(&text) {
+        set_action_status(msg, "status-error");
         return;
     }
 
-    // We send this to the CURRENT ACTOR.
-    // "I suggest you do this..."
     let actor_id_opt = get_active_actor_from_dom();
-
     let Some(actor_id) = actor_id_opt else {
         set_action_status("No active agent to whisper to.", "status-error");
         return;
     };
 
+    // P1: Flight lock — prevent concurrent submits
+    if !try_acquire_flight(&doc, "submit") {
+        set_action_status("Action in progress...", "status-pending");
+        return;
+    }
+
     input.set_value("");
-    set_action_status("Whispering to agent...", "");
+    set_action_status("Whispering to agent...", "status-pending");
     disable_buttons(true);
 
+    let text_for_history = text.clone();
+
     wasm_bindgen_futures::spawn_local(async move {
-        match submit_intervention(&actor_id, &text).await {
-            Ok(_) => set_action_status("Whisper sent. Waiting for agent...", "status-ok"),
-            Err(e) => {
-                let detail = friendly_js_error(&e);
+        let result = submit_intervention(&actor_id, &text).await;
+
+        // Always re-enable buttons and release flight lock (P0 fix)
+        disable_buttons(false);
+        if let Some(doc) = web_sys::window().and_then(|w| w.document()) {
+            release_flight(&doc);
+        }
+
+        match result {
+            Ok(()) => {
+                set_action_status("Whisper sent. Waiting for agent...", "status-ok");
+                append_to_history(&text_for_history);
+                schedule_status_clear();
+            }
+            Err(msg) => {
                 set_action_status(
-                    &format!("Failed to reach agent: {}", detail),
+                    &format!("Failed to reach agent: {}", msg),
                     "status-error",
                 );
             }
@@ -193,126 +357,56 @@ fn submit_intervention_from_input() {
 // ─── JSON-RPC: Submit Intervention ──────────
 
 #[cfg(target_arch = "wasm32")]
-async fn submit_intervention(actor_id: &str, suggestion: &str) -> Result<(), JsValue> {
-    use wasm_bindgen_futures::JsFuture;
-
-    let url = format!("{}/mcp", config::MASC_MCP_URL); // Using /mcp endpoint
+async fn submit_intervention(actor_id: &str, suggestion: &str) -> Result<(), String> {
+    let url = format!("{}/mcp", config::MASC_MCP_URL);
     let room_id = config::current_room_id();
 
-    // Construct MCP Tool Call
-    let body = json!({
-        "jsonrpc": "2.0",
-        "method": "tools/call",
-        "params": {
-            "name": "masc_trpg_intervention_submit",
-            "arguments": {
-                "session_id": room_id, // tool uses session_id as room_id usually
-                "room_id": room_id,
-                "target_actor": actor_id,
-                "intervention_type": "human_suggestion",
-                "reason": "Viewer user input",
-                "payload": {
-                    "suggestion": suggestion,
-                    "priority": "high"
-                }
+    let params = json!({
+        "name": "masc_trpg_intervention_submit",
+        "arguments": {
+            "session_id": room_id,
+            "room_id": room_id,
+            "target_actor": actor_id,
+            "intervention_type": "human_suggestion",
+            "reason": "Viewer user input",
+            "payload": {
+                "suggestion": suggestion,
+                "priority": "high"
             }
-        },
-        "id": js_sys::Math::random().to_string()
-    })
-    .to_string();
+        }
+    });
 
-    let opts = web_sys::RequestInit::new();
-    opts.set_method("POST");
-    opts.set_mode(web_sys::RequestMode::Cors);
-    opts.set_body(&JsValue::from_str(&body));
-
-    let request = web_sys::Request::new_with_str_and_init(&url, &opts)?;
-    request.headers().set("Content-Type", "application/json")?;
-    // Streamable HTTP headers
-    request.headers().set("Accept", "application/json")?;
-
-    let window = web_sys::window().ok_or_else(|| JsValue::from_str("no window"))?;
-    let resp_value = JsFuture::from(window.fetch_with_request(&request)).await?;
-    let resp: web_sys::Response = resp_value.dyn_into()?;
-
-    if !resp.ok() {
-        let err_body = JsFuture::from(resp.text()?).await?;
-        return Err(JsValue::from_str(&format!(
-            "RPC Error {}: {:?}",
-            resp.status(),
-            err_body.as_string()
-        )));
+    match http::rpc_call(&url, "tools/call", params).await {
+        RpcResult::Ok(_) => Ok(()),
+        other => Err(other.display_error()),
     }
-
-    // We don't parse the full tool response here, just assume success if HTTP 200.
-    // The Agent will see the intervention in their event stream.
-    Ok(())
 }
 
 // ─── JSON-RPC: Manual Dice Roll ─────────────
 
 #[cfg(target_arch = "wasm32")]
-async fn roll_dice_intervention() -> Result<String, JsValue> {
-    use wasm_bindgen_futures::JsFuture;
-
+async fn roll_dice_intervention() -> Result<String, String> {
     let Some(actor_id) = get_active_actor_from_dom() else {
-        return Err(JsValue::from_str("No active actor"));
+        return Err("No active actor".into());
     };
 
     let url = format!("{}/mcp", config::MASC_MCP_URL);
     let room_id = config::current_room_id();
 
-    // Call masc_trpg_dice_roll tool
-    let body = json!({
-        "jsonrpc": "2.0",
-        "method": "tools/call",
-        "params": {
-            "name": "masc_trpg_dice_roll",
-            "arguments": {
-                "room_id": room_id,
-                "actor_id": actor_id,
-                "action": "manual_check",
-                "stat_value": 0,
-                "dc": 0
-            }
-        },
-        "id": js_sys::Math::random().to_string()
-    })
-    .to_string();
+    let params = json!({
+        "name": "masc_trpg_dice_roll",
+        "arguments": {
+            "room_id": room_id,
+            "actor_id": actor_id,
+            "action": "manual_check",
+            "stat_value": 0,
+            "dc": 0
+        }
+    });
 
-    let opts = web_sys::RequestInit::new();
-    opts.set_method("POST");
-    opts.set_mode(web_sys::RequestMode::Cors);
-    opts.set_body(&JsValue::from_str(&body));
-
-    let request = web_sys::Request::new_with_str_and_init(&url, &opts)?;
-    request.headers().set("Content-Type", "application/json")?;
-    request.headers().set("Accept", "application/json")?;
-
-    let window = web_sys::window().ok_or_else(|| JsValue::from_str("no window"))?;
-    let resp_value = JsFuture::from(window.fetch_with_request(&request)).await?;
-    let resp: web_sys::Response = resp_value.dyn_into()?;
-
-    if !resp.ok() {
-        return Err(JsValue::from_str("Dice roll RPC failed"));
-    }
-
-    // Parse result to show something immediately?
-    // Usually result is in `result.content[0].text`
-    let json_text = JsFuture::from(resp.text()?)
-        .await?
-        .as_string()
-        .unwrap_or_default();
-    Ok(parse_rpc_result(&json_text))
-}
-
-#[cfg(target_arch = "wasm32")]
-fn parse_rpc_result(json: &str) -> String {
-    // Very naive parsing for "total": 15
-    if json.contains("total") {
-        "Rolled!".to_string() // Simplify, let the event stream update the UI
-    } else {
-        "Command sent.".to_string()
+    match http::rpc_call(&url, "tools/call", params).await {
+        RpcResult::Ok(result_json) => Ok(format_dice_result(&result_json)),
+        other => Err(other.display_error()),
     }
 }
 
@@ -342,6 +436,30 @@ fn set_action_status(text: &str, css_class: &str) {
             el.set_class_name(css_class);
         }
     }
+}
+
+/// Schedule auto-clear of the status message after a delay.
+#[cfg(target_arch = "wasm32")]
+fn schedule_status_clear() {
+    let cb = Closure::once(Box::new(move || {
+        if let Some(doc) = web_sys::window().and_then(|w| w.document()) {
+            if let Some(el) = doc.get_element_by_id("action-status") {
+                // Only clear if the current message is a success message
+                if el.class_name() == "status-ok" {
+                    el.set_text_content(Some("Ready"));
+                    el.set_class_name("");
+                }
+            }
+        }
+    }) as Box<dyn FnOnce()>);
+
+    if let Some(window) = web_sys::window() {
+        let _ = window.set_timeout_with_callback_and_timeout_and_arguments_0(
+            cb.as_ref().unchecked_ref(),
+            STATUS_CLEAR_DELAY_MS,
+        );
+    }
+    cb.forget();
 }
 
 #[cfg(target_arch = "wasm32")]
@@ -385,31 +503,87 @@ fn disable_buttons(disabled: bool) {
     }
 }
 
+// ─── Action History ─────────────────────────
+
+/// Append a completed action to the action history panel (max 5 entries).
+#[cfg(target_arch = "wasm32")]
+fn append_to_history(text: &str) {
+    let Some(doc) = web_sys::window().and_then(|w| w.document()) else {
+        return;
+    };
+    let Some(history) = doc.get_element_by_id("action-history") else {
+        return;
+    };
+
+    let Ok(entry) = doc.create_element("div") else {
+        return;
+    };
+    entry.set_class_name("history-entry");
+
+    // Truncate display text for readability
+    let display = if text.len() > 60 {
+        format!("{}...", &text[..60])
+    } else {
+        text.to_string()
+    };
+    entry.set_text_content(Some(&display));
+
+    // Prepend (newest first)
+    let _ = history.prepend_with_node_1(&entry);
+
+    // Trim to max entries
+    while history.child_element_count() > MAX_HISTORY_ENTRIES {
+        if let Some(last) = history.last_element_child() {
+            last.remove();
+        } else {
+            break;
+        }
+    }
+}
+
 // ─── System ─────────────────────────────────
 
 #[allow(unused_variables)]
 pub fn sync_action_panel_interaction_state(
     room_state: Res<RoomState>,
     progress: Res<TurnProgressState>,
+    connection: Res<ConnectionStatus>,
 ) {
     let _ = &room_state;
+    let _ = &connection;
     #[cfg(target_arch = "wasm32")]
     {
         let active_actor = &progress.current_actor;
         let lifecycle =
             TrpgLifecycleState::from_room_progress(&room_state.status, &progress.room_status);
-        let can_act =
-            lifecycle.accepts_player_input() && !active_actor.is_empty() && active_actor != "dm";
+        let connected = connection_ready(&connection);
+
+        // P2: Connection-aware disable — all three conditions must be true
+        let can_act = lifecycle.accepts_player_input()
+            && !active_actor.is_empty()
+            && active_actor != "dm"
+            && connected;
 
         if let Some(doc) = web_sys::window().and_then(|w| w.document()) {
             if let Some(panel) = doc.get_element_by_id("action-panel") {
                 let _ = panel.set_attribute("data-active-actor", active_actor);
             }
 
-            disable_buttons(!can_act);
+            // Only disable from system sync if no flight is in progress
+            // (flight lock handles its own button state)
+            let flight_active = doc
+                .get_element_by_id("action-panel")
+                .and_then(|p| p.get_attribute("data-action-flight"))
+                .is_some();
+
+            if !flight_active {
+                disable_buttons(!can_act);
+            }
 
             if let Some(input) = doc.get_element_by_id("action-input") {
-                let placeholder = if can_act {
+                let placeholder = if !connected {
+                    "Connecting to engine...".to_string()
+                } else if can_act {
                     format!("Whisper suggestion to {}...", active_actor)
                 } else if !lifecycle.accepts_player_input() {
                     format!("{}...", lifecycle.help_text())
@@ -419,5 +593,69 @@ pub fn sync_action_panel_interaction_state(
                 let _ = input.set_attribute("placeholder", &placeholder);
             }
         }
+    }
+}
+
+// ─── Tests ──────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn validate_empty_input() {
+        assert_eq!(validate_action_input(""), Err("Enter an action first"));
+    }
+
+    #[test]
+    fn validate_normal_input() {
+        assert!(validate_action_input("I attack the goblin").is_ok());
+    }
+
+    #[test]
+    fn validate_max_length_input() {
+        let text = "a".repeat(MAX_ACTION_LEN);
+        assert!(validate_action_input(&text).is_ok());
+    }
+
+    #[test]
+    fn validate_too_long_input() {
+        let text = "a".repeat(MAX_ACTION_LEN + 1);
+        assert_eq!(
+            validate_action_input(&text),
+            Err("Action too long (max 500 chars)")
+        );
+    }
+
+    #[test]
+    fn format_dice_with_total() {
+        let json = r#"{"total":15,"roll":12,"modifier":3}"#;
+        assert_eq!(format_dice_result(json), "Rolled: 15");
+    }
+
+    #[test]
+    fn format_dice_with_mcp_content() {
+        let json = r#"{"content":[{"type":"text","text":"{\"total\":18,\"roll\":15}"}]}"#;
+        assert_eq!(format_dice_result(json), "Rolled: 18");
+    }
+
+    #[test]
+    fn format_dice_with_plain_text_content() {
+        let json = r#"{"content":[{"type":"text","text":"Natural 20!"}]}"#;
+        assert_eq!(format_dice_result(json), "Natural 20!");
+    }
+
+    #[test]
+    fn format_dice_fallback() {
+        assert_eq!(format_dice_result("not json"), "Rolled.");
+        assert_eq!(format_dice_result(r#"{"foo":"bar"}"#), "Rolled.");
+    }
+
+    #[test]
+    fn connection_ready_variants() {
+        assert!(connection_ready(&ConnectionStatus::Connected));
+        assert!(!connection_ready(&ConnectionStatus::Disconnected));
+        assert!(!connection_ready(&ConnectionStatus::Connecting));
+        assert!(!connection_ready(&ConnectionStatus::Failed));
     }
 }

--- a/viewer/src/http/mod.rs
+++ b/viewer/src/http/mod.rs
@@ -1,0 +1,239 @@
+//! Shared JSON-RPC HTTP client for MCP server communication.
+//!
+//! Extracts the common fetch → parse → error-classify pattern used by
+//! `action_panel`, `actor_join`, and `turn_controls`.
+
+/// Classified result of a JSON-RPC call.
+#[derive(Debug, Clone)]
+pub enum RpcResult {
+    /// Parsed `"result"` field from the JSON-RPC response body.
+    Ok(String),
+    /// JSON-RPC level error — the server returned `{"error": {"code": .., "message": ..}}`.
+    RpcError(i64, String),
+    /// HTTP-level failure (non-2xx status).
+    HttpError(u16, String),
+    /// Network / parse failure before we could read the response.
+    NetworkError(String),
+}
+
+impl RpcResult {
+    /// Returns `true` when the call succeeded.
+    pub fn is_ok(&self) -> bool {
+        matches!(self, RpcResult::Ok(_))
+    }
+
+    /// Human-readable one-liner for status display.
+    pub fn display_error(&self) -> String {
+        match self {
+            RpcResult::Ok(_) => String::new(),
+            RpcResult::RpcError(code, msg) => format!("RPC error {}: {}", code, msg),
+            RpcResult::HttpError(status, body) => {
+                let snippet = if body.len() > 120 {
+                    format!("{}...", &body[..120])
+                } else {
+                    body.clone()
+                };
+                format!("HTTP {}: {}", status, snippet)
+            }
+            RpcResult::NetworkError(msg) => format!("Network error: {}", msg),
+        }
+    }
+}
+
+/// Parse a raw JSON-RPC response body into an `RpcResult`.
+///
+/// Exposed as a standalone function so it can be unit-tested without wasm/DOM.
+pub fn parse_jsonrpc_body(body: &str) -> RpcResult {
+    // Try to parse as JSON
+    let parsed: serde_json::Value = match serde_json::from_str(body) {
+        Ok(v) => v,
+        Err(e) => return RpcResult::NetworkError(format!("JSON parse error: {}", e)),
+    };
+
+    // Check for JSON-RPC error field
+    if let Some(err_obj) = parsed.get("error") {
+        let code = err_obj
+            .get("code")
+            .and_then(|c| c.as_i64())
+            .unwrap_or(-1);
+        let message = err_obj
+            .get("message")
+            .and_then(|m| m.as_str())
+            .unwrap_or("Unknown RPC error")
+            .to_string();
+        return RpcResult::RpcError(code, message);
+    }
+
+    // Extract result field
+    if let Some(result) = parsed.get("result") {
+        return RpcResult::Ok(result.to_string());
+    }
+
+    // No error, no result — unexpected format
+    RpcResult::NetworkError("Unexpected JSON-RPC response: missing both 'result' and 'error'".into())
+}
+
+/// Perform a JSON-RPC POST to the given endpoint.
+///
+/// Builds the `{"jsonrpc":"2.0", "method": .., "params": .., "id": ..}` envelope,
+/// sends via `fetch`, and classifies the response into `RpcResult`.
+#[cfg(target_arch = "wasm32")]
+pub async fn rpc_call(endpoint: &str, method: &str, params: serde_json::Value) -> RpcResult {
+    use wasm_bindgen::prelude::*;
+    use wasm_bindgen_futures::JsFuture;
+
+    let body = serde_json::json!({
+        "jsonrpc": "2.0",
+        "method": method,
+        "params": params,
+        "id": js_sys::Math::random().to_string()
+    })
+    .to_string();
+
+    let opts = web_sys::RequestInit::new();
+    opts.set_method("POST");
+    opts.set_mode(web_sys::RequestMode::Cors);
+    opts.set_body(&JsValue::from_str(&body));
+
+    let request = match web_sys::Request::new_with_str_and_init(endpoint, &opts) {
+        Ok(r) => r,
+        Err(e) => {
+            return RpcResult::NetworkError(format!("Failed to build request: {:?}", e));
+        }
+    };
+
+    if let Err(e) = request.headers().set("Content-Type", "application/json") {
+        return RpcResult::NetworkError(format!("Failed to set Content-Type: {:?}", e));
+    }
+    if let Err(e) = request.headers().set("Accept", "application/json") {
+        return RpcResult::NetworkError(format!("Failed to set Accept: {:?}", e));
+    }
+
+    let window = match web_sys::window() {
+        Some(w) => w,
+        None => return RpcResult::NetworkError("No window object".into()),
+    };
+
+    let resp_value = match JsFuture::from(window.fetch_with_request(&request)).await {
+        Ok(v) => v,
+        Err(e) => {
+            let detail = e
+                .as_string()
+                .or_else(|| e.dyn_ref::<js_sys::Error>().map(|err| err.message().into()))
+                .unwrap_or_else(|| format!("{:?}", e));
+            return RpcResult::NetworkError(detail);
+        }
+    };
+
+    let resp: web_sys::Response = match resp_value.dyn_into() {
+        Ok(r) => r,
+        Err(_) => return RpcResult::NetworkError("Response is not a Response object".into()),
+    };
+
+    let status = resp.status();
+
+    let body_text = match resp.text() {
+        Ok(promise) => match JsFuture::from(promise).await {
+            Ok(val) => val.as_string().unwrap_or_default(),
+            Err(_) => String::new(),
+        },
+        Err(_) => String::new(),
+    };
+
+    if status < 200 || status >= 300 {
+        return RpcResult::HttpError(status, body_text);
+    }
+
+    parse_jsonrpc_body(&body_text)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_success_result() {
+        let body = r#"{"jsonrpc":"2.0","result":{"total":15,"roll":12,"modifier":3},"id":"1"}"#;
+        match parse_jsonrpc_body(body) {
+            RpcResult::Ok(result) => {
+                assert!(result.contains("total"));
+                assert!(result.contains("15"));
+            }
+            other => panic!("Expected Ok, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn parse_rpc_error() {
+        let body = r#"{"jsonrpc":"2.0","error":{"code":-32600,"message":"Invalid Request"},"id":"1"}"#;
+        match parse_jsonrpc_body(body) {
+            RpcResult::RpcError(code, msg) => {
+                assert_eq!(code, -32600);
+                assert_eq!(msg, "Invalid Request");
+            }
+            other => panic!("Expected RpcError, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn parse_malformed_json() {
+        let body = "not json at all";
+        match parse_jsonrpc_body(body) {
+            RpcResult::NetworkError(msg) => assert!(msg.contains("JSON parse")),
+            other => panic!("Expected NetworkError, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn parse_missing_both_fields() {
+        let body = r#"{"jsonrpc":"2.0","id":"1"}"#;
+        match parse_jsonrpc_body(body) {
+            RpcResult::NetworkError(msg) => assert!(msg.contains("missing both")),
+            other => panic!("Expected NetworkError, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn parse_string_result() {
+        let body = r#"{"jsonrpc":"2.0","result":"Command accepted","id":"1"}"#;
+        match parse_jsonrpc_body(body) {
+            RpcResult::Ok(result) => assert!(result.contains("Command accepted")),
+            other => panic!("Expected Ok, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn display_error_formats() {
+        assert_eq!(RpcResult::Ok("x".into()).display_error(), "");
+        assert!(RpcResult::RpcError(-32600, "bad".into())
+            .display_error()
+            .contains("-32600"));
+        assert!(RpcResult::HttpError(503, "unavailable".into())
+            .display_error()
+            .contains("503"));
+        assert!(RpcResult::NetworkError("timeout".into())
+            .display_error()
+            .contains("timeout"));
+    }
+
+    #[test]
+    fn display_error_truncates_long_body() {
+        let long_body = "x".repeat(200);
+        let err = RpcResult::HttpError(500, long_body);
+        let display = err.display_error();
+        assert!(display.len() < 200);
+        assert!(display.ends_with("..."));
+    }
+
+    #[test]
+    fn rpc_error_with_missing_code() {
+        let body = r#"{"jsonrpc":"2.0","error":{"message":"oops"},"id":"1"}"#;
+        match parse_jsonrpc_body(body) {
+            RpcResult::RpcError(code, msg) => {
+                assert_eq!(code, -1);
+                assert_eq!(msg, "oops");
+            }
+            other => panic!("Expected RpcError, got {:?}", other),
+        }
+    }
+}

--- a/viewer/src/main.rs
+++ b/viewer/src/main.rs
@@ -7,6 +7,7 @@ mod assets;
 mod audio;
 mod dom;
 mod game;
+mod http;
 mod render;
 mod shaders;
 mod sse;

--- a/viewer/style.css
+++ b/viewer/style.css
@@ -3546,6 +3546,26 @@ body:not(.mode-trpg) #ops-hud {
     color: var(--accent-secondary, #8b2500);
 }
 
+#action-status.status-pending {
+    color: var(--text-dim, #f0ad4e);
+}
+
+.action-history {
+    font-size: 0.85em;
+    opacity: 0.7;
+    max-height: 100px;
+    overflow-y: auto;
+    margin-top: 4px;
+}
+
+.history-entry {
+    padding: 2px 4px;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
 /* ─── Join Panel ───────────────────────────── */
 
 #join-panel {


### PR DESCRIPTION
## Summary

- **P0 Bug fixes**: Buttons re-enable after async RPC calls; proper JSON-RPC parsing via serde_json (replaces `json.contains("total")`); error messages show HTTP status
- **P1 Safety**: Input validation (empty/500-char max); round-flight mutual exclusion via `data-action-flight` DOM attribute
- **P2 UX**: Connection-aware disable; Escape clears input; action history (last 5); optimistic UI with 3s auto-clear
- **P3 Structure**: New `http::rpc_call` shared module eliminating ~200 lines of duplicated fetch boilerplate; 16 unit tests

Also includes uncommitted room_id tracking fixes from main repo working tree (first commit) that are required for WASM compilation.

## Files changed

| File | Changes |
|------|---------|
| `viewer/src/http/mod.rs` | **NEW** — shared JSON-RPC HTTP client (239 lines) |
| `viewer/src/dom/action_panel.rs` | Rewritten with all P0-P3 fixes (661 lines) |
| `viewer/src/main.rs` | Added `mod http;` |
| `viewer/index.html` | Added `#action-history` container |
| `viewer/style.css` | History + status CSS classes |
| `viewer/src/sse/client.rs` | Pre-existing room_id tracking (from main WIP) |
| `viewer/src/game/http.rs` | Pre-existing room_id helpers (from main WIP) |
| `viewer/src/game/round_runner.rs` | Pre-existing room fix (from main WIP) |

## Test plan

- [x] `cargo check --target=wasm32-unknown-unknown` passes (19 warnings, 0 errors)
- [x] `cargo test` passes (75 tests, 0 failures)
- [ ] Manual E2E: `make viewer-serve` → submit action → verify buttons re-enable
- [ ] Manual E2E: empty input shows validation error
- [ ] Manual E2E: Escape key clears input
- [ ] Manual E2E: action history shows last 5 entries
- [ ] Manual E2E: disconnect → panel disables

🤖 Generated with [Claude Code](https://claude.com/claude-code)