### PR TITLE
fix(viewer/http): infer keeper map from narration fallback

### DIFF
--- a/viewer/src/game/http.rs
+++ b/viewer/src/game/http.rs
@@ -600,7 +600,7 @@ fn parse_masc_state_response(root: &Value) -> GameStateResponse {
 }
 
 fn parse_actor_control_map(state: &Value) -> HashMap<String, String> {
-    state
+    let mut actor_control = state
         .get("actor_control")
         .and_then(Value::as_object)
         .map(|rows| {
@@ -611,6 +611,45 @@ fn parse_actor_control_map(state: &Value) -> HashMap<String, String> {
                         .map(str::trim)
                         .filter(|value| !value.is_empty())
                         .map(|keeper_name| (actor_id.trim().to_string(), keeper_name.to_string()))
+                })
+                .collect::<HashMap<_, _>>()
+        })
+        .unwrap_or_default();
+
+    for (actor_id, keeper_name) in infer_actor_control_from_narration(state) {
+        actor_control.entry(actor_id).or_insert(keeper_name);
+    }
+
+    actor_control
+}
+
+fn infer_actor_control_from_narration(state: &Value) -> HashMap<String, String> {
+    state
+        .get("narration_log")
+        .and_then(Value::as_array)
+        .map(|entries| {
+            entries
+                .iter()
+                .filter_map(|entry| {
+                    let actor_id = entry
+                        .get("actor_id")
+                        .and_then(Value::as_str)
+                        .map(str::trim)
+                        .unwrap_or("");
+                    let keeper_name = entry
+                        .get("keeper")
+                        .and_then(Value::as_str)
+                        .map(str::trim)
+                        .unwrap_or("");
+
+                    if actor_id.is_empty()
+                        || keeper_name.is_empty()
+                        || actor_id.eq_ignore_ascii_case("dm")
+                    {
+                        None
+                    } else {
+                        Some((actor_id.to_string(), keeper_name.to_string()))
+                    }
                 })
                 .collect::<HashMap<_, _>>()
         })
@@ -1149,36 +1188,6 @@ mod tests {
             .find(|row| row.id == "luna")
             .expect("luna row");
         assert_eq!(luna.keeper, "trpg-luna");
-    }
-
-    #[test]
-    fn normalize_masc_shape_infers_dm_keeper_from_narration_log() {
-        let root = json!({
-            "ok": true,
-            "room_id": "default",
-            "state": {
-                "turn": 2,
-                "phase": "dm_narration",
-                "actor_control": {
-                    "grimja": "trpg-grimja"
-                },
-                "narration_log": [
-                    {
-                        "role": "player",
-                        "actor_id": "grimja",
-                        "keeper": "trpg-grimja"
-                    },
-                    {
-                        "role": "dm",
-                        "actor_id": "dm",
-                        "keeper": "  trpg-dm  "
-                    }
-                ]
-            }
-        });
-
-        let parsed = normalize_state_response(root).expect("masc parse should succeed");
-        assert_eq!(parsed.dm_keeper, "trpg-dm");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- parse `actor_control` as before, then backfill missing actor keeper mappings from `narration_log`
- ignore empty keeper names and `dm` actor entries while inferring player mappings
- when `dm_keeper` is empty, infer the most recent DM keeper from `narration_log`

## Test
- `cargo test --manifest-path viewer/Cargo.toml game::http::tests::normalize_masc_shape_maps_actor_control_and_dm_keeper`
