### PR TITLE
fix(viewer): preserve round plan fields on TRPG reset

### DIFF
--- a/viewer/src/game/round_runner.rs
+++ b/viewer/src/game/round_runner.rs
@@ -40,7 +40,7 @@ struct RoundRunnerControl {
     game_ended: Arc<AtomicBool>,
     last_result: Arc<Mutex<Option<String>>>,
     rounds_completed: Arc<Mutex<u32>>,
-    dm_keeper_snapshot: Option<String>,
+    dm_keeper_snapshot: String,
 }
 
 #[cfg(target_arch = "wasm32")]

--- a/viewer/src/mode/mod.rs
+++ b/viewer/src/mode/mod.rs
@@ -733,12 +733,6 @@ pub(super) fn clear_trpg_dom(doc: &web_sys::Document) {
         input.set_value("");
     }
     if let Some(input) = doc
-        .get_element_by_id("round-run-dm")
-        .and_then(|el| el.dyn_into::<web_sys::HtmlInputElement>().ok())
-    {
-        input.set_value("");
-    }
-    if let Some(input) = doc
         .get_element_by_id("round-run-phase")
         .and_then(|el| el.dyn_into::<web_sys::HtmlInputElement>().ok())
     {
@@ -755,12 +749,6 @@ pub(super) fn clear_trpg_dom(doc: &web_sys::Document) {
         .and_then(|el| el.dyn_into::<web_sys::HtmlInputElement>().ok())
     {
         input.set_value("ko");
-    }
-    if let Some(input) = doc
-        .get_element_by_id("round-run-players")
-        .and_then(|el| el.dyn_into::<web_sys::HtmlInputElement>().ok())
-    {
-        input.set_value("");
     }
     if let Some(summary) = doc.get_element_by_id("round-run-summary") {
         summary.set_text_content(Some(""));


### PR DESCRIPTION
## Summary
- stop clearing `round-run-dm` and `round-run-players` in `clear_trpg_dom`, so the computed round plan survives TRPG panel reset
- make `RoundRunnerControl.dm_keeper_snapshot` a plain `String` to match `TurnProgressState.dm_keeper` snapshot usage

## Test
- `cargo test --manifest-path viewer/Cargo.toml mode::tests`
- `cargo test --manifest-path viewer/Cargo.toml game::round_runner::tests`
