### PR TITLE
fix(viewer): restore wasm build by aligning round runner snapshot type

### DIFF
--- a/viewer/src/game/round_runner.rs
+++ b/viewer/src/game/round_runner.rs
@@ -40,7 +40,7 @@ struct RoundRunnerControl {
     game_ended: Arc<AtomicBool>,
     last_result: Arc<Mutex<Option<String>>>,
     rounds_completed: Arc<Mutex<u32>>,
-    dm_keeper_snapshot: Option<String>,
+    dm_keeper_snapshot: String,
 }
 
 #[cfg(target_arch = "wasm32")]


### PR DESCRIPTION
## Summary
- fix `RoundRunnerControl.dm_keeper_snapshot` type mismatch in `viewer/src/game/round_runner.rs`
- change field type from `Option<String>` to `String` to match current call sites and `build_round_body(&str)` contract

## Why
`viewer` trunk build failed on main with 2 type errors:
- expected `Option<String>`, found `String` at control snapshot assignment
- expected `&str`, found `&Option<String>` at `build_round_body` call

## Verification
- `cargo check -p masc-viewer --target wasm32-unknown-unknown --release` (PASS)
- `scripts/viewer-local-e2e-check.sh --build-viewer --run-round --rounds 1 --round-timeout-sec 30 --keeper-models 'gemini:gemini-2.5-flash'` (PASS 6/6)
