### PR TITLE
fix(viewer/dom): persist round-plan inputs by room

### DIFF
--- a/viewer/src/dom/turn_controls.rs
+++ b/viewer/src/dom/turn_controls.rs
@@ -22,7 +22,7 @@ use wasm_bindgen::prelude::*;
 #[cfg(target_arch = "wasm32")]
 use crate::config;
 #[cfg(any(target_arch = "wasm32", test))]
-use crate::game::lifecycle::{TrpgLifecycleState, TrpgUiState};
+use crate::game::lifecycle::TrpgLifecycleState;
 use crate::game::state::{ConnectionStatus, RoomState, TurnProgressState};
 
 #[cfg(any(target_arch = "wasm32", test))]
@@ -69,129 +69,6 @@ fn control_status_to_ops_class(css_class: &str) -> &'static str {
 #[cfg(any(target_arch = "wasm32", test))]
 fn round_advanced(turn_before: u64, turn_after: u64, summary_advanced: Option<bool>) -> bool {
     summary_advanced.unwrap_or(turn_after > turn_before)
-}
-
-#[cfg(any(target_arch = "wasm32", test))]
-fn derive_trpg_ui_state(
-    lifecycle: TrpgLifecycleState,
-    connection_ok: bool,
-    wizard_busy: bool,
-    preflight_ok: bool,
-    wizard_ready: bool,
-    round_running: bool,
-) -> TrpgUiState {
-    if !connection_ok || matches!(lifecycle, TrpgLifecycleState::Unavailable) {
-        return TrpgUiState::Error;
-    }
-    if round_running {
-        return TrpgUiState::RoundRunning;
-    }
-    if wizard_busy || matches!(lifecycle, TrpgLifecycleState::Loading) {
-        return TrpgUiState::SessionStarting;
-    }
-    match lifecycle {
-        TrpgLifecycleState::Running => TrpgUiState::SessionRunning,
-        TrpgLifecycleState::Stopped => TrpgUiState::Paused,
-        TrpgLifecycleState::Ended => TrpgUiState::Ended,
-        TrpgLifecycleState::Lobby | TrpgLifecycleState::Unknown => {
-            if preflight_ok && wizard_ready {
-                TrpgUiState::ConfigReady
-            } else {
-                TrpgUiState::Lobby
-            }
-        }
-        TrpgLifecycleState::Loading => TrpgUiState::SessionStarting,
-        TrpgLifecycleState::Unavailable => TrpgUiState::Error,
-    }
-}
-
-#[cfg(target_arch = "wasm32")]
-fn read_new_game_wizard_busy(doc: &web_sys::Document) -> bool {
-    doc.get_element_by_id("new-game-panel")
-        .and_then(|panel| panel.get_attribute("data-wizard-busy"))
-        .is_some_and(|flag| flag == "1")
-}
-
-#[cfg(target_arch = "wasm32")]
-fn read_new_game_preflight_ok(doc: &web_sys::Document) -> bool {
-    doc.get_element_by_id("new-game-panel")
-        .and_then(|panel| panel.get_attribute("data-preflight-state"))
-        .is_some_and(|state| state == "ok")
-}
-
-#[cfg(target_arch = "wasm32")]
-fn read_new_game_assignment_ready(doc: &web_sys::Document) -> bool {
-    let dm = doc
-        .get_element_by_id("new-game-dm-select")
-        .and_then(|el| el.dyn_into::<HtmlSelectElement>().ok())
-        .map(|select| select.value().trim().to_string())
-        .unwrap_or_default();
-    if dm.is_empty() {
-        return false;
-    }
-
-    let Ok(nodes) = doc.query_selector_all("#new-game-player-select option:checked") else {
-        return false;
-    };
-    let mut selected_count = 0_u32;
-    let mut has_conflict = false;
-    for idx in 0..nodes.length() {
-        let Some(node) = nodes.item(idx) else {
-            continue;
-        };
-        let Some(option) = node.dyn_ref::<web_sys::HtmlOptionElement>() else {
-            continue;
-        };
-        let value = option.value().trim().to_string();
-        if value.is_empty() {
-            continue;
-        }
-        if value == dm {
-            has_conflict = true;
-            continue;
-        }
-        selected_count += 1;
-    }
-    selected_count > 0 && !has_conflict
-}
-
-#[cfg(target_arch = "wasm32")]
-fn summarize_ops_detail(detail: &str, max_chars: usize) -> String {
-    let compact = detail.trim().replace('\n', " ");
-    if compact.chars().count() <= max_chars {
-        return compact;
-    }
-    let mut shortened = compact
-        .chars()
-        .take(max_chars.saturating_sub(1))
-        .collect::<String>();
-    shortened.push('…');
-    shortened
-}
-
-#[cfg(target_arch = "wasm32")]
-fn sync_dashboard_ui_state(doc: &web_sys::Document, state: TrpgUiState, detail: &str) {
-    if let Some(dashboard) = doc.get_element_by_id("dashboard") {
-        let _ = dashboard.set_attribute("data-trpg-ui-state", state.code());
-        let _ = dashboard.set_attribute("data-trpg-ui-label", state.label_ko());
-        let _ = dashboard.set_attribute("data-trpg-ui-help", state.help_text());
-    }
-
-    if let Some(el) = doc.get_element_by_id("ops-control-state") {
-        let summary = summarize_ops_detail(detail, 96);
-        let text = if summary.is_empty() {
-            state.label_ko().to_string()
-        } else {
-            format!("{} · {}", state.label_ko(), summary)
-        };
-        let class_name = format!("ops-v {}", state.ops_class());
-        el.set_text_content(Some(&text));
-        let _ = el.set_attribute("class", &class_name);
-        let _ = el.set_attribute(
-            "title",
-            &format!("{} | {}", state.help_text(), detail.trim()),
-        );
-    }
 }
 
 // ─── Marker Resource ────────────────────────
@@ -266,9 +143,8 @@ pub fn sync_turn_controls_visibility(
         let runner_active = auto_round_runner_active(&doc);
         if runner_active {
             can_run = false;
-            reason =
-                "실행 대기: 자동 라운드 실행 중입니다. 관전 모드에서는 수동 실행이 잠금됩니다."
-                    .to_string();
+            reason = "실행 대기: 자동 라운드 실행 중입니다. 관전 모드에서는 수동 실행이 잠금됩니다."
+                .to_string();
             reason_class = "status-info";
         } else if let Some(owner) = lock_owner.as_deref() {
             if owner != "manual" {
@@ -311,16 +187,6 @@ pub fn sync_turn_controls_visibility(
             format!("실행 대기: {}", reason)
         };
         set_turn_gate_reason(&gate_message, reason_class);
-
-        let ui_state = derive_trpg_ui_state(
-            lifecycle,
-            connection_ok,
-            read_new_game_wizard_busy(&doc),
-            read_new_game_preflight_ok(&doc),
-            read_new_game_assignment_ready(&doc),
-            busy || locked,
-        );
-        sync_dashboard_ui_state(&doc, ui_state, &gate_message);
     }
 }
 
@@ -1066,7 +932,10 @@ fn read_round_run_plan(doc: &web_sys::Document) -> Result<RoundRunPlan, String> 
         .or_else(|| read_dom_input(doc, "new-game-dm-select"))
         .unwrap_or_default();
     if dm_keeper.is_empty() {
-        return Err("DM keeper가 설정되지 않았습니다. 새 게임을 먼저 시작하세요.".to_string());
+        return Err(
+            "DM keeper가 설정되지 않았습니다. `새 게임`에서 DM을 선택하거나 현재 방에서 DM claim을 먼저 완료하세요."
+                .to_string(),
+        );
     }
 
     let phase = read_dom_input(doc, "round-run-phase").unwrap_or_else(|| "round".to_string());
@@ -1086,7 +955,10 @@ fn read_round_run_plan(doc: &web_sys::Document) -> Result<RoundRunPlan, String> 
         }
     }
     if player_keepers.is_empty() {
-        return Err("player keepers가 없습니다. 새 게임에서 참가자 할당을 확인하세요.".to_string());
+        return Err(
+            "player keepers가 없습니다. `새 게임`에서 AI PLAYER 선택 후 `파티 자동 할당`으로 actor→keeper를 채우세요."
+                .to_string(),
+        );
     }
 
     Ok(RoundRunPlan {
@@ -1167,35 +1039,5 @@ mod tests {
     fn round_advanced_falls_back_to_turn_delta() {
         assert!(round_advanced(2, 3, None));
         assert!(!round_advanced(2, 2, None));
-    }
-
-    #[test]
-    fn derive_trpg_ui_state_prioritizes_round_running() {
-        let state =
-            derive_trpg_ui_state(TrpgLifecycleState::Running, true, false, true, true, true);
-        assert_eq!(state, TrpgUiState::RoundRunning);
-    }
-
-    #[test]
-    fn derive_trpg_ui_state_detects_config_ready_before_start() {
-        let state = derive_trpg_ui_state(TrpgLifecycleState::Lobby, true, false, true, true, false);
-        assert_eq!(state, TrpgUiState::ConfigReady);
-    }
-
-    #[test]
-    fn derive_trpg_ui_state_maps_paused_and_error() {
-        let paused = derive_trpg_ui_state(
-            TrpgLifecycleState::Stopped,
-            true,
-            false,
-            false,
-            false,
-            false,
-        );
-        assert_eq!(paused, TrpgUiState::Paused);
-
-        let error =
-            derive_trpg_ui_state(TrpgLifecycleState::Running, false, false, true, true, false);
-        assert_eq!(error, TrpgUiState::Error);
     }
 }

--- a/viewer/src/dom/turn_runtime.rs
+++ b/viewer/src/dom/turn_runtime.rs
@@ -140,11 +140,7 @@ fn summarize_actor_issues(progress: &TurnProgressState) -> (String, bool) {
         if !is_issue_state && reason.is_empty() {
             continue;
         }
-        let state_label = if is_issue_state {
-            state.as_str()
-        } else {
-            "issue"
-        };
+        let state_label = if is_issue_state { state.as_str() } else { "issue" };
         if reason.is_empty() {
             issues.push(format!("{}: {}", actor_id, state_label));
         } else {
@@ -173,12 +169,8 @@ fn build_next_action_hint(
             TrpgLifecycleState::Loading => {
                 "로딩 중입니다. 상태 동기화 완료를 기다리세요.".to_string()
             }
-            TrpgLifecycleState::Stopped => {
-                "세션이 멈춰 있습니다. Start/Run으로 재개하세요.".to_string()
-            }
-            TrpgLifecycleState::Ended => {
-                "세션이 종료되었습니다. New Game으로 시작하세요.".to_string()
-            }
+            TrpgLifecycleState::Stopped => "세션이 멈춰 있습니다. Start/Run으로 재개하세요.".to_string(),
+            TrpgLifecycleState::Ended => "세션이 종료되었습니다. New Game으로 시작하세요.".to_string(),
             TrpgLifecycleState::Unavailable => {
                 "엔진/키퍼 연결을 복구한 뒤 다시 시도하세요.".to_string()
             }
@@ -214,103 +206,76 @@ fn set_ops_hud_value(document: &web_sys::Document, id: &str, text: &str, status_
 }
 
 #[cfg(target_arch = "wasm32")]
-fn lifecycle_is_done_node(lifecycle: TrpgLifecycleState, node_state: &str) -> bool {
-    match lifecycle {
-        TrpgLifecycleState::Lobby => false,
-        TrpgLifecycleState::Loading => node_state == "lobby",
-        TrpgLifecycleState::Running => node_state == "lobby",
-        TrpgLifecycleState::Stopped => matches!(node_state, "lobby" | "running"),
-        TrpgLifecycleState::Ended => matches!(node_state, "lobby" | "running" | "stopped"),
-        TrpgLifecycleState::Unavailable | TrpgLifecycleState::Unknown => false,
-    }
+fn round_plan_storage_key(room_id: &str) -> String {
+    format!("masc.viewer.round_plan.{}", room_id.trim())
 }
 
 #[cfg(target_arch = "wasm32")]
-fn lifecycle_active_node(lifecycle: TrpgLifecycleState) -> Option<&'static str> {
-    match lifecycle {
-        TrpgLifecycleState::Lobby => Some("lobby"),
-        TrpgLifecycleState::Loading => Some("recover"),
-        TrpgLifecycleState::Running => Some("running"),
-        TrpgLifecycleState::Stopped => Some("stopped"),
-        TrpgLifecycleState::Ended => Some("ended"),
-        TrpgLifecycleState::Unavailable => Some("unavailable"),
-        TrpgLifecycleState::Unknown => None,
-    }
-}
+fn restore_round_plan_inputs(document: &web_sys::Document, room_id: &str) {
+    let Some(storage) = web_sys::window()
+        .and_then(|w| w.local_storage().ok())
+        .flatten()
+    else {
+        return;
+    };
+    let Ok(Some(raw)) = storage.get_item(&round_plan_storage_key(room_id)) else {
+        return;
+    };
+    let Ok(payload) = serde_json::from_str::<serde_json::Value>(&raw) else {
+        return;
+    };
 
-#[cfg(target_arch = "wasm32")]
-fn lifecycle_hint(lifecycle: TrpgLifecycleState, runner_running: bool) -> String {
-    match lifecycle {
-        TrpgLifecycleState::Lobby => {
-            "LOBBY 단계: 새 게임에서 DM/플레이어를 배정하고 세션 시작을 실행하세요.".to_string()
-        }
-        TrpgLifecycleState::Loading => {
-            "SESSION STARTING 단계: 초기화/동기화 중입니다. 완료되면 RUNNING으로 전환됩니다."
-                .to_string()
-        }
-        TrpgLifecycleState::Running => {
-            if runner_running {
-                "RUNNING 단계: 자동 라운드가 순환 중입니다. 이벤트 수신을 기다리세요.".to_string()
-            } else {
-                "RUNNING 단계: 라운드 실행 또는 플레이어 액션으로 다음 페이즈로 진행됩니다."
-                    .to_string()
+    if let Some(dm) = payload.get("dm").and_then(serde_json::Value::as_str) {
+        if let Some(dm_input) = document
+            .get_element_by_id("round-run-dm")
+            .and_then(|el| el.dyn_into::<HtmlInputElement>().ok())
+        {
+            if dm_input.value().trim().is_empty() && !dm.trim().is_empty() {
+                dm_input.set_value(dm.trim());
             }
         }
-        TrpgLifecycleState::Stopped => {
-            "STOPPED 단계: 세션은 유지되며 재개 가능합니다. 조건을 점검 후 다시 실행하세요."
-                .to_string()
-        }
-        TrpgLifecycleState::Ended => {
-            "ENDED 단계: 현재 세션이 종료되었습니다. 새 게임으로 새 라운드 루프를 시작하세요."
-                .to_string()
-        }
-        TrpgLifecycleState::Unavailable => {
-            "UNAVAILABLE 단계: keeper/엔진 연결 문제입니다. 연결 복구 후 재시도하세요.".to_string()
-        }
-        TrpgLifecycleState::Unknown => {
-            "상태 불명: LOBBY → RUNNING ↔ STOPPED → ENDED 순서를 기준으로 로그를 확인하세요."
-                .to_string()
+    }
+    if let Some(players) = payload.get("players").and_then(serde_json::Value::as_str) {
+        if let Some(players_input) = document
+            .get_element_by_id("round-run-players")
+            .and_then(|el| el.dyn_into::<HtmlInputElement>().ok())
+        {
+            if players_input.value().trim().is_empty() && !players.trim().is_empty() {
+                players_input.set_value(players.trim());
+            }
         }
     }
 }
 
 #[cfg(target_arch = "wasm32")]
-fn sync_lifecycle_diagram(
-    document: &web_sys::Document,
-    lifecycle: TrpgLifecycleState,
-    runner_running: bool,
-) {
-    let active = lifecycle_active_node(lifecycle);
-    if let Ok(nodes) = document.query_selector_all("#lifecycle-diagram .lifecycle-node") {
-        for idx in 0..nodes.length() {
-            let Some(node) = nodes.item(idx) else {
-                continue;
-            };
-            let Some(el) = node.dyn_ref::<web_sys::Element>() else {
-                continue;
-            };
-            let state = el.get_attribute("data-state").unwrap_or_default();
-            let _ = el.class_list().remove_1("is-active");
-            let _ = el.class_list().remove_1("is-done");
-            let _ = el.class_list().remove_1("is-error");
+fn persist_round_plan_inputs(document: &web_sys::Document, room_id: &str) {
+    let Some(storage) = web_sys::window()
+        .and_then(|w| w.local_storage().ok())
+        .flatten()
+    else {
+        return;
+    };
 
-            if lifecycle_is_done_node(lifecycle, &state) {
-                let _ = el.class_list().add_1("is-done");
-            }
-            if active == Some(state.as_str()) {
-                let _ = el.class_list().add_1("is-active");
-            }
-            if lifecycle == TrpgLifecycleState::Unavailable && state == "unavailable" {
-                let _ = el.class_list().add_1("is-error");
-            }
-        }
+    let dm = document
+        .get_element_by_id("round-run-dm")
+        .and_then(|el| el.dyn_into::<HtmlInputElement>().ok())
+        .map(|input| input.value())
+        .unwrap_or_default();
+    let players = document
+        .get_element_by_id("round-run-players")
+        .and_then(|el| el.dyn_into::<HtmlInputElement>().ok())
+        .map(|input| input.value())
+        .unwrap_or_default();
+
+    if dm.trim().is_empty() && players.trim().is_empty() {
+        return;
     }
 
-    if let Some(hint) = document.get_element_by_id("lifecycle-diagram-hint") {
-        let message = lifecycle_hint(lifecycle, runner_running);
-        hint.set_text_content(Some(&message));
-        let _ = hint.set_attribute("title", &message);
-    }
+    let payload = serde_json::json!({
+        "dm": dm.trim(),
+        "players": players.trim(),
+    });
+    let _ = storage.set_item(&round_plan_storage_key(room_id), &payload.to_string());
 }
 
 /// Render live TRPG runtime progress:
@@ -445,6 +410,16 @@ pub fn update_turn_runtime_dom(
         )
     };
 
+    let control_state = if lifecycle.accepts_player_input() {
+        if current_actor != "-" {
+            "manual-ready / actor-thinking".to_string()
+        } else {
+            "manual-ready".to_string()
+        }
+    } else {
+        lifecycle.label_ko().to_string()
+    };
+
     let (runner_running, runner_rounds, runner_last_result) = if let Some(runner) = runner.as_ref()
     {
         let running = runner.running.load(std::sync::atomic::Ordering::SeqCst);
@@ -470,14 +445,18 @@ pub fn update_turn_runtime_dom(
     } else {
         "idle".to_string()
     };
-    let next_action =
-        build_next_action_hint(lifecycle, runner_running, &current_actor, has_actor_issues);
+    let next_action = build_next_action_hint(
+        lifecycle,
+        runner_running,
+        &current_actor,
+        has_actor_issues,
+    );
 
     let connection_label = connection_status_label(&connection);
     let connection_class = connection_status_class(&connection);
 
     #[cfg(not(target_arch = "wasm32"))]
-    let _ = (&sync_class, &runner_last_result);
+    let _ = (&sync_class, &control_state, &runner_last_result);
 
     let snapshot = format!(
         "{}|{}|{}|{}|{}|{}|{}|{}|{}|{}|{}|{}|{}|{}|{}|{}",
@@ -550,6 +529,37 @@ pub fn update_turn_runtime_dom(
         }
 
         let room_id = crate::config::current_room_id();
+        let mut room_switched = false;
+        if let Some(dashboard) = document.get_element_by_id("dashboard") {
+            let previous_room = dashboard
+                .get_attribute("data-round-plan-room")
+                .unwrap_or_default();
+            if previous_room.trim() != room_id {
+                room_switched = true;
+                let _ = dashboard.set_attribute("data-round-plan-room", &room_id);
+            }
+        }
+
+        if room_switched {
+            if let Some(dm_input) = document
+                .get_element_by_id("round-run-dm")
+                .and_then(|el| el.dyn_into::<HtmlInputElement>().ok())
+            {
+                dm_input.set_value("");
+            }
+            if let Some(players_input) = document
+                .get_element_by_id("round-run-players")
+                .and_then(|el| el.dyn_into::<HtmlInputElement>().ok())
+            {
+                players_input.set_value("");
+            }
+            if let Some(summary) = document.get_element_by_id("round-run-summary") {
+                summary.set_text_content(Some(""));
+                let _ = summary.set_attribute("style", "display:none");
+            }
+            restore_round_plan_inputs(&document, &room_id);
+        }
+
         set_ops_hud_value(&document, "ops-room-id", &room_id, room_class);
         set_ops_hud_value(
             &document,
@@ -572,7 +582,7 @@ pub fn update_turn_runtime_dom(
         set_ops_hud_value(
             &document,
             "ops-control-state",
-            &lifecycle_hint(lifecycle, runner_running),
+            &control_state,
             if lifecycle.accepts_player_input() {
                 "status-active"
             } else {
@@ -580,7 +590,6 @@ pub fn update_turn_runtime_dom(
             },
         );
         set_ops_hud_value(&document, "ops-sync-state", &sync_state, sync_class);
-        sync_lifecycle_diagram(&document, lifecycle, runner_running);
 
         let inferred_dm = if !progress.dm_keeper.trim().is_empty() {
             progress.dm_keeper.trim().to_string()
@@ -627,6 +636,7 @@ pub fn update_turn_runtime_dom(
                 let _ = summary.set_attribute("style", "display:block");
             }
         }
+        persist_round_plan_inputs(&document, &room_id);
 
         if let Some(debug_el) = document.get_element_by_id("round-sync-debug-body") {
             let runner_preview = if runner_last_result.trim().is_empty() {
@@ -737,9 +747,10 @@ mod tests {
         progress
             .actor_states
             .insert("p01".to_string(), "timeout".to_string());
-        progress
-            .actor_reasons
-            .insert("p01".to_string(), "keeper heartbeat timeout".to_string());
+        progress.actor_reasons.insert(
+            "p01".to_string(),
+            "keeper heartbeat timeout".to_string(),
+        );
         progress
             .actor_reasons
             .insert("p99".to_string(), "no keeper".to_string());


### PR DESCRIPTION
## Summary
- remove redundant TRPG UI-state derivation/sync path from turn-controls and keep gate messaging focused on actionable run conditions
- persist `round-run-dm` and `round-run-players` per room in localStorage during runtime updates
- restore saved round-plan inputs when room changes, so operator context survives panel resets and room switching
- show compact control-state text in ops HUD based on lifecycle/input readiness

## Test
- `cargo test --manifest-path viewer/Cargo.toml dom::turn_controls::tests`
- `cargo test --manifest-path viewer/Cargo.toml dom::turn_runtime::tests`
