### PR TITLE
fix(viewer): remove claimed-actor fallback for round run

### DIFF
--- a/viewer/src/dom/turn_controls.rs
+++ b/viewer/src/dom/turn_controls.rs
@@ -1077,14 +1077,7 @@ fn read_round_run_plan(doc: &web_sys::Document) -> Result<RoundRunPlan, String> 
         .unwrap_or(90.0);
 
     let player_pairs_raw = read_dom_text_value(doc, "round-run-players").unwrap_or_default();
-    let mut player_keepers = parse_player_keeper_pairs(&player_pairs_raw);
-    if player_keepers.is_empty() {
-        let claimed_actor = read_dom_input(doc, "claimed-actor-id").unwrap_or_default();
-        let claimed_keeper = read_dom_input(doc, "claimed-keeper").unwrap_or_default();
-        if !claimed_actor.is_empty() && !claimed_keeper.is_empty() {
-            player_keepers.push((claimed_actor, claimed_keeper));
-        }
-    }
+    let player_keepers = parse_player_keeper_pairs(&player_pairs_raw);
     if player_keepers.is_empty() {
         return Err("player keepers가 없습니다. 새 게임에서 참가자 할당을 확인하세요.".to_string());
     }

--- a/viewer/src/game/round_runner.rs
+++ b/viewer/src/game/round_runner.rs
@@ -367,17 +367,9 @@ fn build_round_body(dm_keeper_fallback: &str) -> Result<String, String> {
     let lang = read_dom_input("round-run-lang").unwrap_or_else(|| "ko".to_string());
 
     // 2) Player keeper mapping from hidden round plan (`actor=keeper,actor=keeper,...`).
-    let mut player_pairs = read_dom_value("round-run-players")
+    let player_pairs = read_dom_value("round-run-players")
         .map(|raw| parse_player_keeper_pairs(&raw))
         .unwrap_or_default();
-    if player_pairs.is_empty() {
-        if let (Some(actor_id), Some(keeper_name)) = (
-            read_dom_input("claimed-actor-id"),
-            read_dom_input("claimed-keeper"),
-        ) {
-            player_pairs.push((actor_id, keeper_name));
-        }
-    }
     if player_pairs.is_empty() {
         return Err("player keeper 매핑이 비어 있습니다.".to_string());
     }


### PR DESCRIPTION
## Summary
- remove single-actor fallback (`claimed-actor-id` / `claimed-keeper`) when round plan player mapping is empty
- require explicit `round-run-players` mapping for both manual run and auto round runner payload build
- keep existing guard behavior: empty player mapping now fails fast with user-facing error

## Test
- `cargo check -p masc-viewer --target wasm32-unknown-unknown --release`
