### PR TITLE
fix(trpg): stabilize round harness and expose stalled-round badges

### DIFF
--- a/scripts/harness/contract/trpg_session_contract.sh
+++ b/scripts/harness/contract/trpg_session_contract.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 MCP_URL="${MCP_URL:-http://127.0.0.1:8935/mcp}"
-SESSION_ID="${SESSION_ID:-harness-trpg-session-001}"
+SESSION_ID="${SESSION_ID:-harness-trpg-session-$(date +%s)-$$}"
 ROOM_ID="${ROOM_ID:-}"
 CURL_RETRY_COUNT="${CURL_RETRY_COUNT:-12}"
 CURL_RETRY_DELAY_SEC="${CURL_RETRY_DELAY_SEC:-1}"

--- a/scripts/harness/workload/trpg_grimland_smoke.sh
+++ b/scripts/harness/workload/trpg_grimland_smoke.sh
@@ -19,6 +19,7 @@ CLAIMED_ACTORS=""
 CURL_TIMEOUT_SEC="${CURL_TIMEOUT_SEC:-120}"
 CURL_RETRY_COUNT="${CURL_RETRY_COUNT:-12}"
 CURL_RETRY_DELAY_SEC="${CURL_RETRY_DELAY_SEC:-1}"
+ROUND_HTTP_TIMEOUT_SEC="${ROUND_HTTP_TIMEOUT_SEC:-$((ROUND_TIMEOUT_SEC + 180))}"
 
 cleanup_keepers() {
   if [ -n "${room_id:-}" ] && [ -n "${CLAIMED_ACTORS:-}" ]; then
@@ -44,23 +45,25 @@ call_tool() {
   local id="$1"
   local name="$2"
   local args_json="$3"
+  local timeout_sec="${4:-$CURL_TIMEOUT_SEC}"
+  local retry_count="${5:-$CURL_RETRY_COUNT}"
   local raw=""
   local sse_data
   local attempt=1
-  while [ "$attempt" -le "$CURL_RETRY_COUNT" ]; do
-    if raw="$(curl -sS -m "$CURL_TIMEOUT_SEC" -X POST "$MCP_URL" \
+  while [ "$attempt" -le "$retry_count" ]; do
+    if raw="$(curl -sS -m "$timeout_sec" -X POST "$MCP_URL" \
       -H 'Content-Type: application/json' \
       -H 'Accept: application/json, text/event-stream' \
       -d "{\"jsonrpc\":\"2.0\",\"id\":$id,\"method\":\"tools/call\",\"params\":{\"name\":\"$name\",\"arguments\":$args_json}}")"; then
       break
     fi
-    if [ "$attempt" -lt "$CURL_RETRY_COUNT" ]; then
+    if [ "$attempt" -lt "$retry_count" ]; then
       sleep "$CURL_RETRY_DELAY_SEC"
     fi
     attempt=$((attempt + 1))
   done
   if [ -z "$raw" ]; then
-    printf '{"error":{"message":"curl failed after retries: tool=%s timeout_sec=%s retries=%s"}}' "$name" "$CURL_TIMEOUT_SEC" "$CURL_RETRY_COUNT"
+    printf '{"error":{"message":"curl failed after retries: tool=%s timeout_sec=%s retries=%s"}}' "$name" "$timeout_sec" "$retry_count"
     return 0
   fi
   sse_data="$(printf "%s" "$raw" | sed -n 's/^data: //p' | tail -n1)"
@@ -87,9 +90,11 @@ call_tool_checked() {
   local id="$1"
   local name="$2"
   local args_json="$3"
+  local timeout_sec="${4:-$CURL_TIMEOUT_SEC}"
+  local retry_count="${5:-$CURL_RETRY_COUNT}"
   local raw
   local err
-  raw="$(call_tool "$id" "$name" "$args_json")"
+  raw="$(call_tool "$id" "$name" "$args_json" "$timeout_sec" "$retry_count")"
   if [ -z "$(printf "%s" "$raw" | tr -d '[:space:]')" ]; then
     echo "FAIL: $name: empty response from MCP" >&2
     exit 1
@@ -191,10 +196,18 @@ if [ "$RUN_ROUND" = "1" ]; then
   while [ "$i" -le "$ROUNDS" ]; do
     echo "  - round $i"
     args_round="$(jq -cn --argjson t "$round_template" --argjson timeout "$ROUND_TIMEOUT_SEC" '{room_id:$t.room_id,dm_keeper:$t.dm_keeper,player_keepers:$t.player_keepers,phase:"round",timeout_sec:$timeout,require_claim:true}')"
-    r_round="$(call_tool_checked $((4000 + i)) "trpg.round.run" "$args_round")"
+    r_round="$(call_tool_checked $((4000 + i)) "trpg.round.run" "$args_round" "$ROUND_HTTP_TIMEOUT_SEC" "1")"
     advanced="$(printf "%s" "$r_round" | payload | jq -r '.summary.advanced // empty')"
     if [ "$advanced" = "false" ]; then
-      echo "FAIL: round $i did not advance"
+      timeouts="$(printf "%s" "$r_round" | payload | jq -r '.summary.timeouts // 0')"
+      unavailable="$(printf "%s" "$r_round" | payload | jq -r '.summary.unavailable // 0')"
+      player_successes="$(printf "%s" "$r_round" | payload | jq -r '.summary.player_successes // 0')"
+      dm_success="$(printf "%s" "$r_round" | payload | jq -r '.summary.dm_success // false')"
+      first_issue="$(printf "%s" "$r_round" | payload | jq -r '[.statuses[]? | select(.status != "ok" and .status != "skipped") | .reason] | map(select(. != null and . != "")) | .[0] // empty')"
+      echo "FAIL: round $i did not advance (player_successes=$player_successes dm_success=$dm_success timeouts=$timeouts unavailable=$unavailable)"
+      if [ -n "$first_issue" ]; then
+        echo "hint: first issue => $first_issue"
+      fi
       printf "%s\n" "$r_round"
       exit 1
     fi

--- a/viewer/index.html
+++ b/viewer/index.html
@@ -385,6 +385,7 @@
                         <span id="turn-control-status"></span>
                         <button id="round-recovery-btn" type="button" style="display:none">복구 가이드 보기</button>
                         <div id="turn-control-gate" class="turn-control-gate status-info">실행 조건 점검 중...</div>
+                        <div id="round-run-badges" class="round-run-badges" style="display:none" aria-live="polite"></div>
                     </div>
                     <div id="round-recovery-actions" class="turn-recovery-actions" style="display:none">
                         <button id="round-recovery-refresh" type="button" title="키퍼/프리셋을 다시 동기화합니다">Keeper 새로고침</button>

--- a/viewer/src/dom/turn_controls.rs
+++ b/viewer/src/dom/turn_controls.rs
@@ -14,7 +14,7 @@ use bevy::prelude::*;
 use serde_json::{json, Value};
 
 #[cfg(target_arch = "wasm32")]
-use web_sys::{HtmlButtonElement, HtmlInputElement, HtmlSelectElement};
+use web_sys::{Element, HtmlButtonElement, HtmlInputElement, HtmlSelectElement};
 
 #[cfg(target_arch = "wasm32")]
 use wasm_bindgen::prelude::*;
@@ -71,6 +71,139 @@ fn round_advanced(turn_before: u64, turn_after: u64, summary_advanced: Option<bo
     summary_advanced.unwrap_or(turn_after > turn_before)
 }
 
+#[cfg(target_arch = "wasm32")]
+#[derive(Clone, Debug)]
+struct RoundStallSummary {
+    successes: u64,
+    player_successes: u64,
+    dm_success: bool,
+    timeouts: u64,
+    unavailable: u64,
+    first_issue: Option<String>,
+}
+
+#[cfg(any(target_arch = "wasm32", test))]
+fn derive_trpg_ui_state(
+    lifecycle: TrpgLifecycleState,
+    connection_ok: bool,
+    wizard_busy: bool,
+    preflight_ok: bool,
+    wizard_ready: bool,
+    round_running: bool,
+) -> TrpgUiState {
+    if !connection_ok || matches!(lifecycle, TrpgLifecycleState::Unavailable) {
+        return TrpgUiState::Error;
+    }
+    if round_running {
+        return TrpgUiState::RoundRunning;
+    }
+    if wizard_busy || matches!(lifecycle, TrpgLifecycleState::Loading) {
+        return TrpgUiState::SessionStarting;
+    }
+    match lifecycle {
+        TrpgLifecycleState::Running => TrpgUiState::SessionRunning,
+        TrpgLifecycleState::Stopped => TrpgUiState::Paused,
+        TrpgLifecycleState::Ended => TrpgUiState::Ended,
+        TrpgLifecycleState::Lobby | TrpgLifecycleState::Unknown => {
+            if preflight_ok && wizard_ready {
+                TrpgUiState::ConfigReady
+            } else {
+                TrpgUiState::Lobby
+            }
+        }
+        TrpgLifecycleState::Loading => TrpgUiState::SessionStarting,
+        TrpgLifecycleState::Unavailable => TrpgUiState::Error,
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+fn read_new_game_wizard_busy(doc: &web_sys::Document) -> bool {
+    doc.get_element_by_id("new-game-panel")
+        .and_then(|panel| panel.get_attribute("data-wizard-busy"))
+        .is_some_and(|flag| flag == "1")
+}
+
+#[cfg(target_arch = "wasm32")]
+fn read_new_game_preflight_ok(doc: &web_sys::Document) -> bool {
+    doc.get_element_by_id("new-game-panel")
+        .and_then(|panel| panel.get_attribute("data-preflight-state"))
+        .is_some_and(|state| state == "ok")
+}
+
+#[cfg(target_arch = "wasm32")]
+fn read_new_game_assignment_ready(doc: &web_sys::Document) -> bool {
+    let dm = doc
+        .get_element_by_id("new-game-dm-select")
+        .and_then(|el| el.dyn_into::<HtmlSelectElement>().ok())
+        .map(|select| select.value().trim().to_string())
+        .unwrap_or_default();
+    if dm.is_empty() {
+        return false;
+    }
+
+    let Ok(nodes) = doc.query_selector_all("#new-game-player-select option:checked") else {
+        return false;
+    };
+    let mut selected_count = 0_u32;
+    let mut has_conflict = false;
+    for idx in 0..nodes.length() {
+        let Some(node) = nodes.item(idx) else {
+            continue;
+        };
+        let Some(option) = node.dyn_ref::<web_sys::HtmlOptionElement>() else {
+            continue;
+        };
+        let value = option.value().trim().to_string();
+        if value.is_empty() {
+            continue;
+        }
+        if value == dm {
+            has_conflict = true;
+            continue;
+        }
+        selected_count += 1;
+    }
+    selected_count > 0 && !has_conflict
+}
+
+#[cfg(target_arch = "wasm32")]
+fn summarize_ops_detail(detail: &str, max_chars: usize) -> String {
+    let compact = detail.trim().replace('\n', " ");
+    if compact.chars().count() <= max_chars {
+        return compact;
+    }
+    let mut shortened = compact
+        .chars()
+        .take(max_chars.saturating_sub(1))
+        .collect::<String>();
+    shortened.push('…');
+    shortened
+}
+
+#[cfg(target_arch = "wasm32")]
+fn sync_dashboard_ui_state(doc: &web_sys::Document, state: TrpgUiState, detail: &str) {
+    if let Some(dashboard) = doc.get_element_by_id("dashboard") {
+        let _ = dashboard.set_attribute("data-trpg-ui-state", state.code());
+        let _ = dashboard.set_attribute("data-trpg-ui-label", state.label_ko());
+        let _ = dashboard.set_attribute("data-trpg-ui-help", state.help_text());
+    }
+
+    if let Some(el) = doc.get_element_by_id("ops-control-state") {
+        let summary = summarize_ops_detail(detail, 96);
+        let text = if summary.is_empty() {
+            state.label_ko().to_string()
+        } else {
+            format!("{} · {}", state.label_ko(), summary)
+        };
+        let class_name = format!("ops-v {}", state.ops_class());
+        el.set_text_content(Some(&text));
+        let _ = el.set_attribute("class", &class_name);
+        let _ = el.set_attribute(
+            "title",
+            &format!("{} | {}", state.help_text(), detail.trim()),
+        );
+    }
+}
 // ─── Marker Resource ────────────────────────
 
 /// Inserted on enter, removed on exit — signals that the turn controls are bound.
@@ -86,6 +219,7 @@ pub fn bind_turn_controls(mut commands: Commands) {
         bind_recovery_button();
         bind_recovery_action_buttons();
         clear_round_recovery();
+        set_round_stall_badges(None);
         set_turn_status("라운드 실행 준비 중...", "status-info");
         set_turn_gate_reason("실행 조건 점검 중...", "status-info");
         log::info!("TurnControls: bound");
@@ -103,6 +237,7 @@ pub fn unbind_turn_controls(mut commands: Commands) {
         }
         clear_turn_status();
         clear_round_recovery();
+        set_round_stall_badges(None);
         set_turn_gate_reason("", "");
         log::info!("TurnControls: unbound");
     }
@@ -246,6 +381,7 @@ fn on_advance_click() {
     }
 
     clear_round_recovery();
+    set_round_stall_badges(None);
     set_turn_status("라운드 실행 중...", "status-info");
     set_turn_gate_reason("라운드 실행 요청 전송 중...", "status-info");
     set_advance_busy(true);
@@ -254,14 +390,20 @@ fn on_advance_click() {
         match advance_turn().await {
             Ok(RoundRunOutcome::Advanced(msg)) => {
                 clear_round_recovery();
+                set_round_stall_badges(None);
                 set_turn_status(&msg, "status-ok");
                 set_turn_gate_reason(
                     "실행 완료: 다음 라운드 조건을 다시 계산합니다.",
                     "status-ok",
                 );
             }
-            Ok(RoundRunOutcome::Stalled { status, guide }) => {
+            Ok(RoundRunOutcome::Stalled {
+                status,
+                guide,
+                summary,
+            }) => {
                 set_round_recovery(Some(&guide));
+                set_round_stall_badges(Some(&summary));
                 set_turn_status(&status, "status-warn");
                 set_turn_gate_reason(&format!("실행 보류: {}", status), "status-warn");
             }
@@ -269,6 +411,7 @@ fn on_advance_click() {
                 let detail = e.as_string().unwrap_or_else(|| format!("{:?}", e));
                 log::warn!("Advance turn failed: {}", detail);
                 clear_round_recovery();
+                set_round_stall_badges(None);
                 set_turn_status(&format!("Failed: {}", detail), "status-error");
                 set_turn_gate_reason(
                     &format!("실행 실패: {}", shorten_reason(&detail, 180)),
@@ -286,7 +429,11 @@ fn on_advance_click() {
 #[cfg(target_arch = "wasm32")]
 enum RoundRunOutcome {
     Advanced(String),
-    Stalled { status: String, guide: String },
+    Stalled {
+        status: String,
+        guide: String,
+        summary: RoundStallSummary,
+    },
 }
 
 #[cfg(target_arch = "wasm32")]
@@ -361,28 +508,41 @@ fn collect_stall_reasons(json: &Value) -> Vec<String> {
 }
 
 #[cfg(target_arch = "wasm32")]
-fn build_stalled_round_guide(json: &Value, turn_before: u64, turn_after: u64) -> String {
+fn extract_stalled_round_summary(json: &Value) -> RoundStallSummary {
     let summary = json.get("summary");
-    let successes = summary
-        .and_then(|s| s.get("successes"))
-        .and_then(Value::as_u64)
-        .unwrap_or(0);
-    let player_successes = summary
-        .and_then(|s| s.get("player_successes"))
-        .and_then(Value::as_u64)
-        .unwrap_or(0);
-    let dm_success = summary
-        .and_then(|s| s.get("dm_success"))
-        .and_then(Value::as_bool)
-        .unwrap_or(false);
-    let timeouts = summary
-        .and_then(|s| s.get("timeouts"))
-        .and_then(Value::as_u64)
-        .unwrap_or(0);
-    let unavailable = summary
-        .and_then(|s| s.get("unavailable"))
-        .and_then(Value::as_u64)
-        .unwrap_or(0);
+    let reasons = collect_stall_reasons(json);
+    RoundStallSummary {
+        successes: summary
+            .and_then(|s| s.get("successes"))
+            .and_then(Value::as_u64)
+            .unwrap_or(0),
+        player_successes: summary
+            .and_then(|s| s.get("player_successes"))
+            .and_then(Value::as_u64)
+            .unwrap_or(0),
+        dm_success: summary
+            .and_then(|s| s.get("dm_success"))
+            .and_then(Value::as_bool)
+            .unwrap_or(false),
+        timeouts: summary
+            .and_then(|s| s.get("timeouts"))
+            .and_then(Value::as_u64)
+            .unwrap_or(0),
+        unavailable: summary
+            .and_then(|s| s.get("unavailable"))
+            .and_then(Value::as_u64)
+            .unwrap_or(0),
+        first_issue: reasons.first().cloned(),
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+fn build_stalled_round_guide(summary: &RoundStallSummary, turn_before: u64, turn_after: u64) -> String {
+    let successes = summary.successes;
+    let player_successes = summary.player_successes;
+    let dm_success = summary.dm_success;
+    let timeouts = summary.timeouts;
+    let unavailable = summary.unavailable;
 
     let mut lines = vec![
         format!(
@@ -398,7 +558,11 @@ fn build_stalled_round_guide(json: &Value, turn_before: u64, turn_after: u64) ->
             unavailable
         ),
     ];
-    let reasons = collect_stall_reasons(json);
+    let reasons = summary
+        .first_issue
+        .as_ref()
+        .map(|reason| vec![reason.clone()])
+        .unwrap_or_default();
     if !reasons.is_empty() {
         lines.push(format!("차단 원인: {}", reasons.join(" | ")));
     }
@@ -488,10 +652,12 @@ async fn advance_turn() -> Result<RoundRunOutcome, JsValue> {
             "턴이 진행되지 않았습니다 ({} → {}).",
             turn_before, turn_after
         );
-        let guide = build_stalled_round_guide(&json, turn_before, turn_after);
+        let summary = extract_stalled_round_summary(&json);
+        let guide = build_stalled_round_guide(&summary, turn_before, turn_after);
         return Ok(RoundRunOutcome::Stalled {
             status: stalled_status,
             guide,
+            summary,
         });
     }
 
@@ -533,6 +699,121 @@ fn set_turn_gate_reason(text: &str, css_class: &str) {
         format!("turn-control-gate {}", css_class)
     };
     let _ = el.set_attribute("class", &class_name);
+}
+
+#[cfg(target_arch = "wasm32")]
+fn append_round_stall_badge(
+    doc: &web_sys::Document,
+    container: &Element,
+    label: &str,
+    value: &str,
+    tone_class: &str,
+    title: Option<&str>,
+) {
+    let Ok(badge) = doc.create_element("span") else {
+        return;
+    };
+    badge.set_class_name(&format!("round-run-badge {}", tone_class));
+    if let Some(title) = title {
+        let _ = badge.set_attribute("title", title);
+    }
+
+    let Ok(k) = doc.create_element("span") else {
+        return;
+    };
+    k.set_class_name("badge-k");
+    k.set_text_content(Some(label));
+    let _ = badge.append_child(&k);
+
+    let Ok(v) = doc.create_element("span") else {
+        return;
+    };
+    v.set_class_name("badge-v");
+    v.set_text_content(Some(value));
+    let _ = badge.append_child(&v);
+
+    let _ = container.append_child(&badge);
+}
+
+#[cfg(target_arch = "wasm32")]
+fn set_round_stall_badges(summary: Option<&RoundStallSummary>) {
+    let Some(doc) = web_sys::window().and_then(|w| w.document()) else {
+        return;
+    };
+    let Some(container) = doc.get_element_by_id("round-run-badges") else {
+        return;
+    };
+
+    container.set_text_content(None);
+    if summary.is_none() {
+        let _ = container.set_attribute("style", "display:none");
+        return;
+    }
+    let summary = summary.expect("checked is_some");
+    let _ = container.set_attribute("style", "");
+
+    append_round_stall_badge(
+        &doc,
+        &container,
+        "SUCCESS",
+        &summary.successes.to_string(),
+        if summary.successes > 0 { "is-ok" } else { "is-warn" },
+        Some("이번 라운드 전체 성공 응답 수"),
+    );
+    append_round_stall_badge(
+        &doc,
+        &container,
+        "PLAYER",
+        &summary.player_successes.to_string(),
+        if summary.player_successes > 0 {
+            "is-ok"
+        } else {
+            "is-warn"
+        },
+        Some("이번 라운드에서 성공한 플레이어 액션 수"),
+    );
+    append_round_stall_badge(
+        &doc,
+        &container,
+        "DM",
+        if summary.dm_success { "ok" } else { "fail" },
+        if summary.dm_success { "is-ok" } else { "is-error" },
+        Some("DM 내레이션/판정 성공 여부"),
+    );
+    append_round_stall_badge(
+        &doc,
+        &container,
+        "TIMEOUT",
+        &summary.timeouts.to_string(),
+        if summary.timeouts > 0 {
+            "is-warn"
+        } else {
+            "is-ok"
+        },
+        Some("턴 타임아웃 발생 횟수"),
+    );
+    append_round_stall_badge(
+        &doc,
+        &container,
+        "UNAVAILABLE",
+        &summary.unavailable.to_string(),
+        if summary.unavailable > 0 {
+            "is-error"
+        } else {
+            "is-ok"
+        },
+        Some("keeper unavailable 발생 횟수"),
+    );
+    if let Some(issue) = summary.first_issue.as_deref() {
+        append_round_stall_badge(
+            &doc,
+            &container,
+            "ISSUE",
+            &shorten_reason(issue, 80),
+            "is-warn",
+            Some(issue),
+        );
+    }
 }
 
 #[cfg(target_arch = "wasm32")]

--- a/viewer/src/dom/turn_controls.rs
+++ b/viewer/src/dom/turn_controls.rs
@@ -22,7 +22,7 @@ use wasm_bindgen::prelude::*;
 #[cfg(target_arch = "wasm32")]
 use crate::config;
 #[cfg(any(target_arch = "wasm32", test))]
-use crate::game::lifecycle::TrpgLifecycleState;
+use crate::game::lifecycle::{TrpgLifecycleState, TrpgUiState};
 use crate::game::state::{ConnectionStatus, RoomState, TurnProgressState};
 
 #[cfg(any(target_arch = "wasm32", test))]

--- a/viewer/src/mode/mod.rs
+++ b/viewer/src/mode/mod.rs
@@ -754,6 +754,10 @@ pub(super) fn clear_trpg_dom(doc: &web_sys::Document) {
         summary.set_text_content(Some(""));
         let _ = summary.set_attribute("style", "display:none");
     }
+    if let Some(badges) = doc.get_element_by_id("round-run-badges") {
+        badges.set_text_content(Some(""));
+        let _ = badges.set_attribute("style", "display:none");
+    }
     if let Some(dashboard) = doc.get_element_by_id("dashboard") {
         let _ = dashboard.set_attribute("data-history-focus", "latest");
         let _ = dashboard.set_attribute("data-dedup-stream", "0");

--- a/viewer/style.css
+++ b/viewer/style.css
@@ -2444,6 +2444,54 @@ body:not(.mode-trpg) #ops-hud {
     background: rgba(80, 29, 29, 0.28);
 }
 
+.round-run-badges {
+    width: 100%;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+    margin-top: 2px;
+}
+
+.round-run-badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    border: 1px solid var(--border-main);
+    border-radius: 999px;
+    padding: 2px 8px;
+    font-size: 0.66rem;
+    line-height: 1.2;
+    background: rgba(255, 255, 255, 0.03);
+    color: var(--text-dim);
+}
+
+.round-run-badge .badge-k {
+    letter-spacing: 0.3px;
+    opacity: 0.82;
+}
+
+.round-run-badge .badge-v {
+    color: var(--text-primary);
+}
+
+.round-run-badge.is-ok {
+    border-color: rgba(122, 206, 155, 0.45);
+    background: rgba(23, 56, 44, 0.24);
+    color: #96d8b3;
+}
+
+.round-run-badge.is-warn {
+    border-color: rgba(196, 162, 101, 0.45);
+    background: rgba(70, 52, 23, 0.24);
+    color: #d9b06c;
+}
+
+.round-run-badge.is-error {
+    border-color: rgba(215, 118, 118, 0.5);
+    background: rgba(80, 29, 29, 0.3);
+    color: #dfa1a1;
+}
+
 #round-recovery-btn {
     background: transparent;
     border: 1px solid rgba(196, 162, 101, 0.4);


### PR DESCRIPTION
## Summary
- make TRPG session contract harness use a unique default `SESSION_ID` to avoid bootstrap collisions on repeated runs
- harden grimland smoke round call path with per-tool timeout/retry override and no-retry for `trpg.round.run` to prevent duplicate keeper-busy follow-up calls
- improve smoke failure output with summary metrics (`player_successes`, `dm_success`, `timeouts`, `unavailable`) and first issue hint
- add Viewer stalled-round badge strip (`SUCCESS/PLAYER/DM/TIMEOUT/UNAVAILABLE/ISSUE`) so the same failure signal is visible in UI

## Validation
- `cargo check --manifest-path viewer/Cargo.toml`
- `cargo check --manifest-path viewer/Cargo.toml --target wasm32-unknown-unknown`
- `cargo test --manifest-path viewer/Cargo.toml --lib`
- `scripts/viewer-local-e2e-check.sh --run-round --rounds 1 --round-timeout-sec 45 --keeper-models "ollama:glm-4.7-flash"`
