### PR TITLE
improve(viewer): show MASC mode connection badges

### DIFF
--- a/viewer/index.html
+++ b/viewer/index.html
@@ -69,6 +69,7 @@
     <div id="monitor-panel" class="mode-panel" style="display: none;">
         <div class="mode-panel-header">
             <h2>System Monitor</h2>
+            <div id="monitor-status" class="mode-status status-disconnected">연결 대기 중</div>
             <button class="back-btn" data-back="lobby">◂ Back</button>
         </div>
         <div class="mode-panel-content">
@@ -104,7 +105,7 @@
         <div class="mode-panel-content">
             <div class="panel-header">
                 <h2>Council — MAGI Deliberation</h2>
-                <div class="council-status">Waiting for issues...</div>
+                <div id="council-status" class="council-status mode-status status-disconnected">연결 대기 중</div>
             </div>
             <div class="council-feed" id="council-deliberation">
                 <div class="council-empty">No deliberations in progress. Issues will appear when submitted.</div>
@@ -121,6 +122,7 @@
         <div class="mode-panel-content">
             <div class="panel-header">
                 <h2>Social — Lodge Board</h2>
+                <div id="social-status" class="mode-status status-disconnected">연결 대기 중</div>
             </div>
             <div class="social-feed" id="social-feed">
                 <div class="social-empty">Connecting to Lodge...</div>
@@ -137,7 +139,7 @@
         <div class="mode-panel-content">
             <div class="panel-header">
                 <h2>Experiments — A/B Testing</h2>
-                <div class="experiment-status">No active experiments</div>
+                <div id="experiment-status" class="experiment-status mode-status status-disconnected">연결 대기 중</div>
             </div>
             <div class="experiment-feed" id="experiment-dashboard">
                 <div class="experiment-empty">No experiments running. Start one via MASC tools.</div>

--- a/viewer/src/mode/mod.rs
+++ b/viewer/src/mode/mod.rs
@@ -25,6 +25,7 @@ use wasm_bindgen::JsCast;
 use crate::dom::escape::html_escape;
 #[cfg(target_arch = "wasm32")]
 use crate::game::lifecycle::TrpgLifecycleState;
+use crate::game::state::ConnectionStatus;
 #[cfg(target_arch = "wasm32")]
 use wasm_bindgen_futures::JsFuture;
 
@@ -82,6 +83,17 @@ impl ViewerMode {
             Self::Council => Some("council-panel"),
             Self::Social => Some("social-panel"),
             Self::Experiment => Some("experiment-panel"),
+            _ => None,
+        }
+    }
+
+    /// DOM status badge element ID for MASC mode panels.
+    pub fn status_badge_id(&self) -> Option<&'static str> {
+        match self {
+            Self::Monitor => Some("monitor-status"),
+            Self::Council => Some("council-status"),
+            Self::Social => Some("social-status"),
+            Self::Experiment => Some("experiment-status"),
             _ => None,
         }
     }
@@ -161,7 +173,8 @@ impl Plugin for ModePlugin {
                 Update,
                 refresh_trpg_widget_status.run_if(in_state(ViewerMode::Trpg)),
             )
-            .add_systems(Update, poll_mode_transition);
+            .add_systems(Update, poll_mode_transition)
+            .add_systems(Update, sync_masc_panel_connection_status);
     }
 }
 
@@ -1561,6 +1574,84 @@ use trpg_controls::{
 fn refresh_trpg_widget_status() {
     #[cfg(target_arch = "wasm32")]
     trpg_controls::refresh_trpg_widget_status();
+}
+
+fn count_mode_events(mode: ViewerMode, event_log: &crate::sse::masc_bridge::MascEventLog) -> usize {
+    match mode {
+        ViewerMode::Monitor => event_log.entries.len(),
+        ViewerMode::Council => event_log
+            .entries
+            .iter()
+            .filter(|entry| entry.event_type.starts_with("decision_"))
+            .count(),
+        ViewerMode::Experiment => event_log
+            .entries
+            .iter()
+            .filter(|entry| entry.event_type.starts_with("experiment_"))
+            .count(),
+        ViewerMode::Social => event_log
+            .entries
+            .iter()
+            .filter(|entry| entry.event_type == "broadcast")
+            .count(),
+        _ => 0,
+    }
+}
+
+fn sync_masc_panel_connection_status(
+    mode: Res<State<ViewerMode>>,
+    connection: Res<ConnectionStatus>,
+    event_log: Option<Res<crate::sse::masc_bridge::MascEventLog>>,
+) {
+    #[cfg(target_arch = "wasm32")]
+    {
+        let current_mode = *mode.get();
+        let Some(status_badge_id) = current_mode.status_badge_id() else {
+            return;
+        };
+        let Some(doc) = web_sys::window().and_then(|w| w.document()) else {
+            return;
+        };
+        let Some(el) = doc.get_element_by_id(status_badge_id) else {
+            return;
+        };
+
+        let mode_event_count = event_log
+            .as_ref()
+            .map(|log| count_mode_events(current_mode, log))
+            .unwrap_or(0);
+
+        let (status_class, text) = match &*connection {
+            ConnectionStatus::Connected => match current_mode {
+                ViewerMode::Social if mode_event_count == 0 => {
+                    ("status-connected", "연결됨 · 게시글 폴링 중".to_string())
+                }
+                ViewerMode::Social => (
+                    "status-connected",
+                    format!("연결됨 · 게시글 폴링 + 알림 {}건", mode_event_count),
+                ),
+                _ if mode_event_count == 0 => {
+                    ("status-connected", "연결됨 · 이벤트 대기 중".to_string())
+                }
+                _ => (
+                    "status-connected",
+                    format!("연결됨 · 이벤트 {}건 수신", mode_event_count),
+                ),
+            },
+            ConnectionStatus::Connecting => ("status-connecting", "연결 중...".to_string()),
+            ConnectionStatus::Reconnecting(attempt, max) => (
+                "status-connecting",
+                format!("재연결 중 ({}/{})", attempt, max),
+            ),
+            ConnectionStatus::Disconnected => ("status-disconnected", "연결 대기 중".to_string()),
+            ConnectionStatus::Failed => ("status-disconnected", "연결 실패".to_string()),
+        };
+
+        el.set_class_name(&format!("mode-status {}", status_class));
+        el.set_text_content(Some(&text));
+    }
+
+    let _ = (&mode, &connection, &event_log);
 }
 
 // ─── Generic MASC Panel Enter/Exit ───────────

--- a/viewer/style.css
+++ b/viewer/style.css
@@ -3048,6 +3048,7 @@ body:not(.mode-trpg) #ops-hud {
 
 /* ─── Status Badges ──────────────────────── */
 
+.mode-status,
 .council-status,
 .experiment-status {
     font-family: var(--font-ui);
@@ -3058,6 +3059,21 @@ body:not(.mode-trpg) #ops-hud {
     border-radius: var(--panel-radius);
     padding: 4px 10px;
     letter-spacing: 1px;
+}
+
+.mode-status.status-connected {
+    color: var(--status-connected);
+    border-color: var(--status-connected);
+}
+
+.mode-status.status-connecting {
+    color: var(--status-connecting);
+    border-color: var(--status-connecting);
+}
+
+.mode-status.status-disconnected {
+    color: var(--status-disconnected);
+    border-color: var(--status-disconnected);
 }
 
 /* ─── Feed Containers (scrollable) ───────── */


### PR DESCRIPTION
## Summary
- add status badges to Monitor/Council/Social/Experiment panels
- sync badge text/class from live SSE connection state
- show mode-aware event counters so users can distinguish "connected but idle" vs "not connected"

## Changes
- `viewer/index.html`
  - add status badge elements with IDs: `monitor-status`, `council-status`, `social-status`, `experiment-status`
- `viewer/style.css`
  - add shared `.mode-status` styles and connection-state variants
- `viewer/src/mode/mod.rs`
  - add `ViewerMode::status_badge_id()`
  - add `sync_masc_panel_connection_status` update system
  - compute mode-specific event counts for status text

## Validation
- `cargo check -p masc-viewer --target wasm32-unknown-unknown --release`
- `make viewer-build`
