### PR TITLE
fix(trpg): enforce player quorum and drop meta-only keeper replies

### DIFF
--- a/lib/tool_trpg.ml
+++ b/lib/tool_trpg.ml
@@ -968,6 +968,27 @@ let sanitize_keeper_reply (raw : string) : string =
   in
   String.concat "\n" cleaned_lines |> String.trim
 
+let is_reply_noise_text (raw : string) : bool =
+  let t = String.trim raw in
+  t = ""
+  || starts_with t "```"
+  || starts_with t "[STATE]"
+  || starts_with t "[/STATE]"
+  || starts_with t "\"reply\":"
+  || starts_with t "SKILL:"
+  || starts_with t "SKILL_REASON:"
+  || starts_with t "room_id="
+  || starts_with t "phase="
+  || starts_with t "turn="
+  || starts_with t "role="
+  || starts_with t "actor_id="
+  || starts_with t "\"TRPG 실행 요청"
+  || starts_with t "TRPG 실행 요청입니다."
+  || starts_with t "TRPG execution request."
+  || starts_with t "내 기록상 가장 처음 물어본 건 이거야"
+  || starts_with t "반드시 한국어로 응답하세요."
+  || contains_substring t "visible_state_json:"
+
 let parse_keeper_reply keeper_json =
   match keeper_json |> member "reply" with
   | `String s ->
@@ -980,11 +1001,13 @@ let parse_keeper_reply keeper_json =
            || contains_substring s "내 기록상 가장 처음 물어본 건 이거야")
       in
       let reply =
-        if cleaned <> "" then cleaned
-        else if prompt_echo then "상황이 긴박합니다. 현재 장면을 유지하고 다음 행동을 간결히 선언하세요."
-        else fallback
+        if cleaned <> "" then Some cleaned
+        else if prompt_echo || is_reply_noise_text fallback then None
+        else Some fallback
       in
-      if reply = "" then Error "keeper response reply is empty" else Ok reply
+      (match reply with
+      | Some reply when String.trim reply <> "" -> Ok reply
+      | _ -> Error "keeper response reply contains only prompt/meta artifacts")
   | _ -> Error "keeper response missing string field: reply"
 
 type prompt_language = [ `Ko | `En ]
@@ -2685,11 +2708,30 @@ let handle_round_run ctx args : result =
         else base_state_for_prompt
       in
       let* () =
-        process_one
-          ~state_json:state_for_dm_prompt
-          ~role:`Dm ~actor_id:"dm" ~keeper_name:dm_keeper
+        if player_quorum_met then
+          process_one
+            ~state_json:state_for_dm_prompt
+            ~role:`Dm ~actor_id:"dm" ~keeper_name:dm_keeper
+        else (
+          statuses :=
+            `Assoc
+              [
+                ("actor_id", `String "dm");
+                ("role", `String "dm");
+                ("keeper", `String dm_keeper);
+                ("status", `String "skipped");
+                ( "reason",
+                  `String
+                    (Printf.sprintf
+                       "player quorum not met: success=%d required=%d; dm execution skipped"
+                       !player_success_count
+                       player_required_successes) );
+                ("stage", `String "player_quorum");
+              ]
+            :: !statuses;
+          Ok () )
       in
-      let advanced = !dm_success in
+      let advanced = player_quorum_met && !dm_success in
       let turn_after = if advanced then next_turn else turn_before in
       let* () =
         if advanced then

--- a/test/test_tool_trpg_coverage.ml
+++ b/test/test_tool_trpg_coverage.ml
@@ -217,16 +217,29 @@ let test_round_run_timeout_policy () =
   let summary = Yojson.Safe.Util.member "summary" json in
   Alcotest.(check int) "timeouts" 1 (Yojson.Safe.Util.member "timeouts" summary |> Yojson.Safe.Util.to_int);
   Alcotest.(check int) "unavailable" 1 (Yojson.Safe.Util.member "unavailable" summary |> Yojson.Safe.Util.to_int);
-  (* Player timeout does not block DM execution; DM response can still advance. *)
-  Alcotest.(check int) "successes" 1 (Yojson.Safe.Util.member "successes" summary |> Yojson.Safe.Util.to_int);
+  (* Player timeout blocks DM execution until full quorum is restored. *)
+  Alcotest.(check int) "successes" 0 (Yojson.Safe.Util.member "successes" summary |> Yojson.Safe.Util.to_int);
   Alcotest.(check bool)
     "dm success"
-    true
+    false
     (Yojson.Safe.Util.member "dm_success" summary |> Yojson.Safe.Util.to_bool);
   Alcotest.(check bool)
     "round advanced"
-    true
+    false
     (Yojson.Safe.Util.member "advanced" summary |> Yojson.Safe.Util.to_bool);
+  let dm_status =
+    List.find_opt
+      (fun s ->
+        s |> Yojson.Safe.Util.member "actor_id" |> Yojson.Safe.Util.to_string = "dm")
+      statuses
+  in
+  (match dm_status with
+  | Some status_json ->
+      Alcotest.(check string)
+        "dm status is skipped"
+        "skipped"
+        (status_json |> Yojson.Safe.Util.member "status" |> Yojson.Safe.Util.to_string)
+  | None -> Alcotest.fail "dm status is missing");
   let events = json |> Yojson.Safe.Util.member "events" |> Yojson.Safe.Util.to_list in
   let timeout_event =
     List.find_opt
@@ -296,7 +309,7 @@ let test_round_run_timeout_policy () =
     (count_from_json (parse_json_exn unavailable_stream));
   cleanup_dir base_dir
 
-let test_round_run_allows_dm_without_full_player_quorum () =
+let test_round_run_requires_full_player_quorum () =
   let base_dir = make_temp_dir () in
   let config = Room.default_config base_dir in
   let _ = Room.init config ~agent_name:(Some "tester") in
@@ -328,7 +341,7 @@ let test_round_run_allows_dm_without_full_player_quorum () =
   in
   let ok, body = dispatch_exn ctx ~name:"masc_trpg_round_run" ~args in
   Alcotest.(check bool) "round_run returns payload" true ok;
-  Alcotest.(check bool) "dm call executes with partial quorum" true !dm_called;
+  Alcotest.(check bool) "dm call is skipped when quorum fails" false !dm_called;
 
   let json = parse_json_exn body in
   let summary = Yojson.Safe.Util.member "summary" json in
@@ -346,15 +359,15 @@ let test_round_run_allows_dm_without_full_player_quorum () =
     (Yojson.Safe.Util.member "player_quorum_met" summary |> Yojson.Safe.Util.to_bool);
   Alcotest.(check bool)
     "dm success"
-    true
+    false
     (Yojson.Safe.Util.member "dm_success" summary |> Yojson.Safe.Util.to_bool);
   Alcotest.(check bool)
     "round advanced"
-    true
+    false
     (Yojson.Safe.Util.member "advanced" summary |> Yojson.Safe.Util.to_bool);
   Alcotest.(check int)
-    "turn_after advanced"
-    2
+    "turn_after unchanged"
+    1
     (Yojson.Safe.Util.member "turn_after" json |> Yojson.Safe.Util.to_int);
 
   let statuses = json |> Yojson.Safe.Util.member "statuses" |> Yojson.Safe.Util.to_list in
@@ -367,10 +380,85 @@ let test_round_run_allows_dm_without_full_player_quorum () =
   (match dm_status with
   | Some status_json ->
       Alcotest.(check string)
-        "dm status is ok"
-        "ok"
+        "dm status is skipped"
+        "skipped"
         (status_json |> Yojson.Safe.Util.member "status" |> Yojson.Safe.Util.to_string)
+      ;
+      Alcotest.(check bool)
+        "dm skip reason mentions quorum"
+        true
+        (contains_substring
+           (status_json |> Yojson.Safe.Util.member "reason" |> Yojson.Safe.Util.to_string)
+           "player quorum not met")
   | None -> Alcotest.fail "dm status is missing");
+  cleanup_dir base_dir
+
+let test_round_run_rejects_meta_only_keeper_reply () =
+  let base_dir = make_temp_dir () in
+  let config = Room.default_config base_dir in
+  let _ = Room.init config ~agent_name:(Some "tester") in
+  bootstrap_room_with_actors ~base_dir ~room_id:"room-round-meta-reply" ~actor_ids:["p1"];
+  let dm_called = ref false in
+  let keeper_call ~name ~message:_ ~timeout_sec:_ : Tool_trpg.keeper_call_result =
+    match name with
+    | "dm-keeper" ->
+        dm_called := true;
+        `Ok (`Assoc [ ("reply", `String "DM should be skipped.") ])
+    | "pk-meta" -> `Ok (`Assoc [ ("reply", `String "[/STATE]") ])
+    | _ -> `Error "unknown keeper"
+  in
+  let ctx : Tool_trpg.context =
+    { config; agent_name = "tester"; keeper_call = Some keeper_call; keeper_probe = None }
+  in
+  let args =
+    `Assoc
+      [
+        ("room_id", `String "room-round-meta-reply");
+        ("dm_keeper", `String "dm-keeper");
+        ("player_keepers", `Assoc [ ("p1", `String "pk-meta") ]);
+        ("timeout_sec", `Float 0.2);
+      ]
+  in
+  let ok, body = dispatch_exn ctx ~name:"masc_trpg_round_run" ~args in
+  Alcotest.(check bool) "round_run returns payload" true ok;
+  Alcotest.(check bool)
+    "dm call is skipped when player reply is meta-only"
+    false
+    !dm_called;
+
+  let json = parse_json_exn body in
+  let summary = Yojson.Safe.Util.member "summary" json in
+  Alcotest.(check int)
+    "player_successes"
+    0
+    (Yojson.Safe.Util.member "player_successes" summary |> Yojson.Safe.Util.to_int);
+  Alcotest.(check bool)
+    "player quorum met"
+    false
+    (Yojson.Safe.Util.member "player_quorum_met" summary |> Yojson.Safe.Util.to_bool);
+  Alcotest.(check bool)
+    "round advanced"
+    false
+    (Yojson.Safe.Util.member "advanced" summary |> Yojson.Safe.Util.to_bool);
+
+  let statuses = json |> Yojson.Safe.Util.member "statuses" |> Yojson.Safe.Util.to_list in
+  let p1_status =
+    List.find_opt
+      (fun s ->
+        s |> Yojson.Safe.Util.member "actor_id" |> Yojson.Safe.Util.to_string = "p1")
+      statuses
+  in
+  (match p1_status with
+  | Some status_json ->
+      Alcotest.(check string)
+        "p1 status is invalid_response"
+        "invalid_response"
+        (status_json |> Yojson.Safe.Util.member "status" |> Yojson.Safe.Util.to_string);
+      Alcotest.(check string)
+        "p1 stage is parse_keeper_reply"
+        "parse_keeper_reply"
+        (status_json |> Yojson.Safe.Util.member "stage" |> Yojson.Safe.Util.to_string)
+  | None -> Alcotest.fail "p1 status is missing");
   cleanup_dir base_dir
 
 let test_round_run_requires_keeper_runtime () =
@@ -1146,9 +1234,13 @@ let () =
             `Quick
             test_round_run_timeout_policy;
           Alcotest.test_case
-            "allows dm execution with partial player quorum"
+            "requires full player quorum before dm/advance"
             `Quick
-            test_round_run_allows_dm_without_full_player_quorum;
+            test_round_run_requires_full_player_quorum;
+          Alcotest.test_case
+            "rejects meta-only keeper replies"
+            `Quick
+            test_round_run_rejects_meta_only_keeper_reply;
           Alcotest.test_case
             "requires keeper runtime"
             `Quick


### PR DESCRIPTION
## Summary
- reject keeper replies that contain only prompt/meta artifacts (e.g. `[/STATE]`, prompt echo remnants)
- require full player quorum before executing DM turn in `trpg.round.run`
- keep round blocked (no turn advance) when player timeout/invalid_response prevents quorum
- update and extend TRPG round-run coverage tests for the new behavior

## Reproduction noted
- grimland smoke round produced `turn.action.proposed` and DM `narration.posted` payloads as `[/STATE]`
- this made viewer appear like player replies were missing / DM flow was inconsistent

## Validation
- `dune exec --root . ./test/test_tool_trpg_coverage.exe`
- `RUN_ROUND=1 ROUNDS=1 ROUND_TIMEOUT_SEC=18 KEEPER_MODELS='gemini:gemini-2.5-flash' scripts/run_trpg_grimland_smoke.sh` (pre-fix reproduction capture)
