### PR TITLE
feat(viewer): visualize canonical combat and session outcome events

### DIFF
--- a/viewer/index.html
+++ b/viewer/index.html
@@ -413,6 +413,21 @@
                     <input type="hidden" id="round-run-timeout" value="" />
                     <input type="hidden" id="round-run-lang" value="" />
                     <input type="hidden" id="round-run-players" value="" />
+                    <div id="atmosphere-strip" class="atmosphere-strip" aria-live="polite">
+                        <div id="weather-chip" class="atmo-chip">
+                            <img id="weather-icon" class="atmo-icon" alt="" />
+                            <span class="atmo-label">Weather</span>
+                            <span id="weather-indicator" class="atmo-value"></span>
+                        </div>
+                        <div id="mood-chip" class="atmo-chip">
+                            <img id="mood-icon" class="atmo-icon" alt="" />
+                            <span class="atmo-label">Mood</span>
+                            <span id="mood-indicator" class="atmo-value"></span>
+                        </div>
+                        <div id="event-beacon" class="event-beacon"></div>
+                    </div>
+                    <div id="choice-overlay" class="floating-overlay choice-overlay" style="display:none"></div>
+                    <div id="combat-overlay" class="floating-overlay combat-overlay" style="display:none"></div>
                     <div id="narrative-log"></div>
                     <!-- Join Panel: claim an actor before playing -->
                     <div id="join-panel">

--- a/viewer/src/dom/endgame.rs
+++ b/viewer/src/dom/endgame.rs
@@ -9,7 +9,7 @@ use bevy::prelude::*;
 use std::sync::atomic::Ordering;
 
 use crate::game::components::Actor;
-use crate::game::events::NarrativeReceived;
+use crate::game::events::{NarrativeReceived, SessionOutcome};
 use crate::game::round_runner::RoundRunner;
 
 /// Tracks whether the endgame overlay has been shown (prevents re-trigger).
@@ -18,15 +18,45 @@ pub struct EndgameState {
     pub triggered: bool,
 }
 
+#[derive(Copy, Clone)]
+enum EndgameTone {
+    Victory,
+    Defeat,
+    Draw,
+}
+
 /// Monitors multiple signals and triggers the endgame overlay once.
 pub fn detect_endgame(
     actors: Query<&Actor>,
     runner: Option<Res<RoundRunner>>,
     mut narratives: MessageReader<NarrativeReceived>,
+    mut outcomes: MessageReader<SessionOutcome>,
     mut endgame: ResMut<EndgameState>,
 ) {
     if endgame.triggered {
         // Drain the reader even when already triggered to avoid stale buffers.
+        for _ in narratives.read() {}
+        for _ in outcomes.read() {}
+        return;
+    }
+
+    // Path 0: Canonical session outcome.
+    for SessionOutcome(payload) in outcomes.read() {
+        endgame.triggered = true;
+        let tone = match payload.outcome.as_str() {
+            "victory" => EndgameTone::Victory,
+            "defeat" => EndgameTone::Defeat,
+            _ => EndgameTone::Draw,
+        };
+        let message = if payload.summary.trim().is_empty() {
+            "모험이 마무리되었습니다."
+        } else {
+            payload.summary.as_str()
+        };
+        show_endgame_overlay(message, tone);
+        if let Some(runner) = &runner {
+            runner.game_ended.store(true, Ordering::SeqCst);
+        }
         for _ in narratives.read() {}
         return;
     }
@@ -37,12 +67,13 @@ pub fn detect_endgame(
         let dead_count = actors.iter().filter(|a| a.is_dead).count();
         if dead_count == actor_count {
             endgame.triggered = true;
-            show_endgame_overlay("파티가 전멸했습니다.", false);
+            show_endgame_overlay("파티가 전멸했습니다.", EndgameTone::Defeat);
             if let Some(runner) = &runner {
                 runner.game_ended.store(true, Ordering::SeqCst);
             }
             // Drain remaining narratives.
             for _ in narratives.read() {}
+            for _ in outcomes.read() {}
             return;
         }
     }
@@ -51,7 +82,7 @@ pub fn detect_endgame(
     for NarrativeReceived(payload) in narratives.read() {
         if payload.phase == "endgame" {
             endgame.triggered = true;
-            show_endgame_overlay(&payload.text, true);
+            show_endgame_overlay(&payload.text, EndgameTone::Victory);
             return;
         }
     }
@@ -60,13 +91,13 @@ pub fn detect_endgame(
     if let Some(runner) = &runner {
         if runner.game_ended.load(Ordering::SeqCst) {
             endgame.triggered = true;
-            show_endgame_overlay("모험이 끝났습니다.", true);
+            show_endgame_overlay("모험이 끝났습니다.", EndgameTone::Victory);
         }
     }
 }
 
 /// Render a full-screen endgame overlay via DOM.
-fn show_endgame_overlay(message: &str, is_victory: bool) {
+fn show_endgame_overlay(message: &str, tone: EndgameTone) {
     #[cfg(target_arch = "wasm32")]
     {
         let Some(doc) = web_sys::window().and_then(|w| w.document()) else {
@@ -79,23 +110,24 @@ fn show_endgame_overlay(message: &str, is_victory: bool) {
             Err(_) => return,
         };
 
-        let class = if is_victory {
-            "endgame-overlay victory"
-        } else {
-            "endgame-overlay defeat"
+        let class = match tone {
+            EndgameTone::Victory => "endgame-overlay victory",
+            EndgameTone::Defeat => "endgame-overlay defeat",
+            EndgameTone::Draw => "endgame-overlay draw",
         };
         overlay.set_class_name(class);
 
-        let title = if is_victory {
-            "임무 완료"
-        } else {
-            "전멸"
+        let (title, crest) = match tone {
+            EndgameTone::Victory => ("승리", "⛧"),
+            EndgameTone::Defeat => ("패배", "✕"),
+            EndgameTone::Draw => ("무승부", "◈"),
         };
 
         // Build inner HTML with safe text insertion for the message.
         // Title is a fixed Korean string (safe). Message uses set_text_content below.
         let html = format!(
             "<div class=\"endgame-content\">\
+                <div class=\"endgame-crest\">{crest}</div>\
                 <h1 class=\"endgame-title\">{title}</h1>\
                 <p class=\"endgame-message\"></p>\
                 <button class=\"endgame-btn\" \
@@ -113,5 +145,5 @@ fn show_endgame_overlay(message: &str, is_victory: bool) {
     }
 
     // Suppress unused warnings on native builds.
-    let _ = (message, is_victory);
+    let _ = (message, tone);
 }

--- a/viewer/src/dom/mod.rs
+++ b/viewer/src/dom/mod.rs
@@ -125,14 +125,28 @@ fn reset_trpg_dom_state(
         if let Some(el) = document.get_element_by_id("weather-indicator") {
             el.set_text_content(None);
         }
+        if let Some(el) = document.get_element_by_id("weather-icon") {
+            let _ = el.set_attribute("src", "");
+            let _ = el.set_attribute("alt", "");
+        }
         if let Some(el) = document.get_element_by_id("mood-indicator") {
             el.set_text_content(None);
         }
+        if let Some(el) = document.get_element_by_id("mood-icon") {
+            let _ = el.set_attribute("src", "");
+            let _ = el.set_attribute("alt", "");
+        }
         if let Some(el) = document.get_element_by_id("choice-overlay") {
             el.set_inner_html("");
+            let _ = el.set_attribute("style", "display:none");
         }
         if let Some(el) = document.get_element_by_id("combat-overlay") {
             el.set_inner_html("");
+            let _ = el.set_attribute("style", "display:none");
+        }
+        if let Some(el) = document.get_element_by_id("event-beacon") {
+            el.set_inner_html("");
+            el.set_class_name("event-beacon");
         }
     }
 }

--- a/viewer/src/dom/overlay.rs
+++ b/viewer/src/dom/overlay.rs
@@ -17,6 +17,41 @@ pub struct OverlayCache {
     pub last_combat_active: bool,
 }
 
+#[cfg(target_arch = "wasm32")]
+fn pretty_label(raw: &str) -> String {
+    raw.split('_')
+        .map(|word| {
+            let mut chars = word.chars();
+            match chars.next() {
+                Some(first) => format!("{}{}", first.to_ascii_uppercase(), chars.as_str()),
+                None => String::new(),
+            }
+        })
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+#[cfg(target_arch = "wasm32")]
+fn weather_icon_path(id: &str) -> Option<&'static str> {
+    match id {
+        "drizzle" => Some("assets/weather/weather_drizzle.png"),
+        "heavy_rain" => Some("assets/weather/weather_heavy_rain.png"),
+        "fog" => Some("assets/weather/weather_fog.png"),
+        "silence" => Some("assets/weather/weather_silence.png"),
+        _ => None,
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+fn mood_icon_path(id: &str) -> Option<&'static str> {
+    match id {
+        "quiet_unease" => Some("assets/moods/mood_quiet_unease.png"),
+        "tension_rising" => Some("assets/moods/mood_tension_rising.png"),
+        "ambiguous_calm" => Some("assets/moods/mood_ambiguous_calm.png"),
+        _ => None,
+    }
+}
+
 /// Sync OverlayState, ChoiceState, and CombatState to DOM elements.
 ///
 /// Expected HTML elements:
@@ -51,7 +86,19 @@ pub fn update_overlay_dom(
                 if overlay.weather.is_empty() {
                     el.set_text_content(None);
                 } else {
-                    el.set_text_content(Some(&overlay.weather));
+                    el.set_text_content(Some(&pretty_label(&overlay.weather)));
+                }
+            }
+            if let Some(img) = document
+                .get_element_by_id("weather-icon")
+                .and_then(|el| el.dyn_into::<web_sys::HtmlImageElement>().ok())
+            {
+                if let Some(path) = weather_icon_path(overlay.weather.trim()) {
+                    img.set_src(path);
+                    img.set_alt(&pretty_label(&overlay.weather));
+                } else {
+                    img.set_src("");
+                    img.set_alt("");
                 }
             }
             cache.last_weather = overlay.weather.clone();
@@ -62,7 +109,19 @@ pub fn update_overlay_dom(
                 if overlay.mood.is_empty() {
                     el.set_text_content(None);
                 } else {
-                    el.set_text_content(Some(&overlay.mood));
+                    el.set_text_content(Some(&pretty_label(&overlay.mood)));
+                }
+            }
+            if let Some(img) = document
+                .get_element_by_id("mood-icon")
+                .and_then(|el| el.dyn_into::<web_sys::HtmlImageElement>().ok())
+            {
+                if let Some(path) = mood_icon_path(overlay.mood.trim()) {
+                    img.set_src(path);
+                    img.set_alt(&pretty_label(&overlay.mood));
+                } else {
+                    img.set_src("");
+                    img.set_alt("");
                 }
             }
             cache.last_mood = overlay.mood.clone();

--- a/viewer/src/dom/session_events.rs
+++ b/viewer/src/dom/session_events.rs
@@ -1,8 +1,9 @@
 #[cfg(target_arch = "wasm32")]
 use crate::dom::escape::html_escape;
 use crate::game::events::{
-    InterventionApplied, InterventionSubmitted, KeeperUnavailable, PartySelected, PhaseChanged,
-    RoomCreated, RoomStarted, SessionStarted, TurnActionResolved, TurnStarted,
+    CombatAttack, CombatDefense, InterventionApplied, InterventionSubmitted, KeeperUnavailable,
+    PartySelected, PhaseChanged, RoomCreated, RoomStarted, SessionOutcome, SessionStarted,
+    TurnActionResolved, TurnStarted,
 };
 use bevy::prelude::*;
 
@@ -15,6 +16,9 @@ pub fn update_session_events_dom(
     mut phase_changed: MessageReader<PhaseChanged>,
     mut turn_started: MessageReader<TurnStarted>,
     mut action_resolved: MessageReader<TurnActionResolved>,
+    mut combat_attack: MessageReader<CombatAttack>,
+    mut combat_defense: MessageReader<CombatDefense>,
+    mut session_outcome: MessageReader<SessionOutcome>,
     mut intervention_sub: MessageReader<InterventionSubmitted>,
     mut intervention_app: MessageReader<InterventionApplied>,
     mut keeper_unavail: MessageReader<KeeperUnavailable>,
@@ -45,7 +49,7 @@ pub fn update_session_events_dom(
                 &log,
                 "session-event",
                 &format!(
-                    "<span class=\"session-icon\">\u{25cb}</span> Party formed: {}",
+                    "<span class=\"session-icon\">○</span> Party formed: {}",
                     ids
                 ),
             );
@@ -62,7 +66,7 @@ pub fn update_session_events_dom(
                 &log,
                 "session-event",
                 &format!(
-                    "<span class=\"session-icon\">\u{25cb}</span> Room created ({})",
+                    "<span class=\"session-icon\">○</span> Room created ({})",
                     html_escape(preset)
                 ),
             );
@@ -79,7 +83,7 @@ pub fn update_session_events_dom(
                 &log,
                 "session-event session-start",
                 &format!(
-                    "<span class=\"session-icon\">\u{25b6}</span> Adventure {} \u{2014} {}",
+                    "<span class=\"session-icon\">▶</span> Adventure {} — {}",
                     html_escape(status),
                     html_escape(&p.room_id)
                 ),
@@ -97,7 +101,7 @@ pub fn update_session_events_dom(
                 &log,
                 "session-event",
                 &format!(
-                    "<span class=\"session-icon\">\u{25cb}</span> Session: {}",
+                    "<span class=\"session-icon\">○</span> Session: {}",
                     html_escape(sid)
                 ),
             );
@@ -109,7 +113,7 @@ pub fn update_session_events_dom(
                 &log,
                 "turn-event",
                 &format!(
-                    "<span class=\"turn-icon\">\u{25c6}</span> Phase \u{2192} {} (Turn {})",
+                    "<span class=\"turn-icon\">◆</span> Phase → {} (Turn {})",
                     html_escape(&p.phase),
                     p.turn
                 ),
@@ -122,7 +126,7 @@ pub fn update_session_events_dom(
                 &log,
                 "turn-event turn-start",
                 &format!(
-                    "<span class=\"turn-icon\">\u{25c6}</span> Turn {} begins \u{2014} {}",
+                    "<span class=\"turn-icon\">◆</span> Turn {} begins — {}",
                     p.turn,
                     html_escape(&p.phase)
                 ),
@@ -135,7 +139,7 @@ pub fn update_session_events_dom(
                 &log,
                 "action-result",
                 &format!(
-                    "<span class=\"action-icon\">\u{2713}</span> {} performed {} \u{2192} {}",
+                    "<span class=\"action-icon\">✓</span> {} performed {} → {}",
                     html_escape(&p.actor_id),
                     html_escape(&p.action),
                     html_escape(&p.result)
@@ -143,13 +147,93 @@ pub fn update_session_events_dom(
             );
         }
 
+        for CombatAttack(p) in combat_attack.read() {
+            append_entry(
+                &doc,
+                &log,
+                "action-result combat-attack fx-attack",
+                &format!(
+                    "<span class=\"event-badge badge-attack\">⚔ ATTACK</span>\
+                     <span class=\"event-main\">{}</span>\
+                     <span class=\"event-sep\">→</span>\
+                     <span class=\"event-detail\">{}</span>",
+                    html_escape(&p.actor_id),
+                    html_escape(&p.action)
+                ),
+            );
+            set_event_beacon(
+                &doc,
+                "attack",
+                "공격",
+                &format!("{} · {}", p.actor_id, p.action),
+            );
+        }
+
+        for CombatDefense(p) in combat_defense.read() {
+            append_entry(
+                &doc,
+                &log,
+                "action-result combat-defense fx-defense",
+                &format!(
+                    "<span class=\"event-badge badge-defense\">🛡 DEFENSE</span>\
+                     <span class=\"event-main\">{}</span>\
+                     <span class=\"event-sep\">·</span>\
+                     <span class=\"event-detail\">{}</span>",
+                    html_escape(&p.actor_id),
+                    html_escape(&p.method)
+                ),
+            );
+            set_event_beacon(
+                &doc,
+                "defense",
+                "방어",
+                &format!("{} · {}", p.actor_id, p.method),
+            );
+        }
+
+        for SessionOutcome(p) in session_outcome.read() {
+            let (tone_class, label, icon) = match p.outcome.trim().to_ascii_lowercase().as_str() {
+                "victory" => ("outcome-victory", "승리", "🏆"),
+                "defeat" => ("outcome-defeat", "패배", "☠"),
+                _ => ("outcome-draw", "무승부", "⚖"),
+            };
+            let summary = if p.summary.trim().is_empty() {
+                format!("세션 종료 · {}", label)
+            } else {
+                p.summary.trim().to_string()
+            };
+            append_entry(
+                &doc,
+                &log,
+                &format!("session-event session-outcome {}", tone_class),
+                &format!(
+                    "<span class=\"event-badge badge-outcome\">{} {}</span>\
+                     <span class=\"event-detail\">{}</span>",
+                    icon,
+                    label,
+                    html_escape(&summary)
+                ),
+            );
+            set_event_beacon(&doc, &p.outcome, label, &summary);
+        }
+
         for InterventionSubmitted(p) in intervention_sub.read() {
             let target = if p.target.is_empty() { "" } else { &p.target };
-            append_entry(&doc, &log, "intervention-event",
-                &format!("<span class=\"intervention-icon\">\u{2691}</span> Intervention: {} {} \u{2014} {}",
+            append_entry(
+                &doc,
+                &log,
+                "intervention-event",
+                &format!(
+                    "<span class=\"intervention-icon\">⚑</span> Intervention: {} {} — {}",
                     html_escape(&p.intervention_type),
-                    if target.is_empty() { String::new() } else { format!("\u{2192} {}", html_escape(target)) },
-                    html_escape(&p.description)));
+                    if target.is_empty() {
+                        String::new()
+                    } else {
+                        format!("→ {}", html_escape(target))
+                    },
+                    html_escape(&p.description)
+                ),
+            );
         }
 
         for InterventionApplied(p) in intervention_app.read() {
@@ -159,12 +243,12 @@ pub fn update_session_events_dom(
                 &log,
                 "intervention-event intervention-applied",
                 &format!(
-                    "<span class=\"intervention-icon\">\u{2691}</span> Applied: {} {} \u{2014} {}",
+                    "<span class=\"intervention-icon\">⚑</span> Applied: {} {} — {}",
                     html_escape(&p.intervention_type),
                     if target.is_empty() {
                         String::new()
                     } else {
-                        format!("\u{2192} {}", html_escape(target))
+                        format!("→ {}", html_escape(target))
                     },
                     html_escape(&p.description)
                 ),
@@ -177,9 +261,16 @@ pub fn update_session_events_dom(
             } else {
                 &p.reason
             };
-            append_entry(&doc, &log, "keeper-warning",
-                &format!("<span class=\"warning-icon\">\u{26a0}</span> Keeper {} unavailable \u{2014} {}",
-                    html_escape(&p.keeper), html_escape(reason)));
+            append_entry(
+                &doc,
+                &log,
+                "keeper-warning",
+                &format!(
+                    "<span class=\"warning-icon\">⚠</span> Keeper {} unavailable — {}",
+                    html_escape(&p.keeper),
+                    html_escape(reason)
+                ),
+            );
         }
     }
 
@@ -192,6 +283,9 @@ pub fn update_session_events_dom(
         &mut phase_changed,
         &mut turn_started,
         &mut action_resolved,
+        &mut combat_attack,
+        &mut combat_defense,
+        &mut session_outcome,
         &mut intervention_sub,
         &mut intervention_app,
         &mut keeper_unavail,
@@ -215,4 +309,43 @@ fn append_entry(doc: &web_sys::Document, log: &web_sys::Element, class: &str, in
         // Auto-scroll
         log.set_scroll_top(log.scroll_height());
     }
+}
+
+#[cfg(target_arch = "wasm32")]
+fn beacon_tone(raw: &str) -> &'static str {
+    match raw.trim().to_ascii_lowercase().as_str() {
+        "victory" => "victory",
+        "defeat" => "defeat",
+        "draw" => "draw",
+        "attack" => "attack",
+        "defense" => "defense",
+        _ => "info",
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+fn set_event_beacon(doc: &web_sys::Document, tone: &str, title: &str, detail: &str) {
+    let Some(el) = doc.get_element_by_id("event-beacon") else {
+        return;
+    };
+    let tone = beacon_tone(tone);
+    let icon = match tone {
+        "attack" => "⚔",
+        "defense" => "🛡",
+        "victory" => "🏆",
+        "defeat" => "☠",
+        "draw" => "⚖",
+        _ => "✶",
+    };
+    el.set_class_name(&format!("event-beacon tone-{tone}"));
+    el.set_inner_html(&format!(
+        "<span class=\"beacon-icon\">{}</span>\
+         <span class=\"beacon-copy\">\
+           <span class=\"beacon-title\">{}</span>\
+           <span class=\"beacon-detail\">{}</span>\
+         </span>",
+        icon,
+        html_escape(title),
+        html_escape(detail)
+    ));
 }

--- a/viewer/src/dom/session_history.rs
+++ b/viewer/src/dom/session_history.rs
@@ -55,11 +55,14 @@ fn sanitize_key(raw: &str) -> String {
 }
 
 fn normalize_room_id(raw: &str) -> String {
-    let trimmed = raw.trim();
-    if trimmed.is_empty() {
+    let normalized = crate::config::sanitize_room_id(raw)
+        .unwrap_or_else(|| raw.trim().to_string())
+        .trim()
+        .to_ascii_lowercase();
+    if normalized.is_empty() {
         "room-unknown".to_string()
     } else {
-        trimmed.to_string()
+        normalized
     }
 }
 
@@ -69,7 +72,8 @@ fn normalize_room_status(raw: &str) -> String {
         "active" | "running" | "started" | "in_progress" | "in-progress" | "playing" | "open" => {
             "active"
         }
-        "paused" | "pause" | "stopped" | "idle" | "on_hold" | "on-hold" => "paused",
+        "paused" | "pause" | "stopped" | "on_hold" | "on-hold" => "paused",
+        "idle" | "lobby" | "created" | "ready" => "unknown",
         "ended" | "finished" | "completed" | "closed" | "done" | "archived" | "terminated" => {
             "ended"
         }
@@ -276,6 +280,9 @@ fn label_progress_event(
         "turn.action.proposed" => "행동 제안",
         "turn.timeout" => "턴 타임아웃",
         "keeper.unavailable" => "Keeper 사용 불가",
+        "combat.attack" => "공격",
+        "combat.defense" => "방어",
+        "session.outcome" => "세션 결과",
         "room.started" => "룸 시작",
         "room.ended" => "룸 종료",
         "world.event" => "월드 이벤트",
@@ -305,6 +312,11 @@ fn label_progress_event(
         || payload.event_type == "turn.started"
     {
         "turn"
+    } else if matches!(
+        payload.event_type.as_str(),
+        "combat.attack" | "combat.defense" | "session.outcome"
+    ) {
+        "system"
     } else if matches!(payload.event_type.as_str(), "room.started" | "room.ended") {
         "system"
     } else {

--- a/viewer/src/game/events.rs
+++ b/viewer/src/game/events.rs
@@ -274,6 +274,46 @@ pub struct TurnActionResolvedPayload {
 }
 
 #[derive(Debug, Clone, Deserialize)]
+pub struct CombatAttackPayload {
+    #[serde(default)]
+    pub turn: u32,
+    #[serde(default)]
+    pub actor_id: String,
+    #[serde(default)]
+    pub action: String,
+    #[serde(default)]
+    #[allow(dead_code)] // read only in wasm32 DOM code
+    pub target_id: String,
+    #[serde(default)]
+    #[allow(dead_code)] // read only in wasm32 DOM code
+    pub skill: String,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct CombatDefensePayload {
+    #[serde(default)]
+    pub turn: u32,
+    #[serde(default)]
+    pub actor_id: String,
+    #[serde(default)]
+    pub method: String,
+    #[serde(default)]
+    #[allow(dead_code)] // read only in wasm32 DOM code
+    pub source_actor_id: String,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct SessionOutcomePayload {
+    pub outcome: String,
+    #[serde(default)]
+    pub reason: String,
+    #[serde(default)]
+    pub summary: String,
+    #[serde(default)]
+    pub turn: u32,
+}
+
+#[derive(Debug, Clone, Deserialize)]
 pub struct SceneTransitionPayload {
     #[allow(dead_code)] // read only in wasm32 DOM code
     pub from_scene: String,
@@ -309,6 +349,15 @@ pub struct RoomEnded(pub RoomEndedPayload);
 
 #[derive(Message, Debug, Clone)]
 pub struct TurnActionResolved(pub TurnActionResolvedPayload);
+
+#[derive(Message, Debug, Clone)]
+pub struct CombatAttack(pub CombatAttackPayload);
+
+#[derive(Message, Debug, Clone)]
+pub struct CombatDefense(pub CombatDefensePayload);
+
+#[derive(Message, Debug, Clone)]
+pub struct SessionOutcome(pub SessionOutcomePayload);
 
 #[derive(Message, Debug, Clone)]
 pub struct SceneTransitioned(pub SceneTransitionPayload);

--- a/viewer/src/game/mod.rs
+++ b/viewer/src/game/mod.rs
@@ -63,6 +63,9 @@ impl Plugin for GameStatePlugin {
             .add_message::<ActorUpdated>()
             .add_message::<RoomEnded>()
             .add_message::<TurnActionResolved>()
+            .add_message::<CombatAttack>()
+            .add_message::<CombatDefense>()
+            .add_message::<SessionOutcome>()
             .add_message::<SceneTransitioned>()
             // ── TRPG-gated systems ──
             .add_systems(
@@ -117,6 +120,9 @@ impl Plugin for GameStatePlugin {
                     systems::apply_phase_changed,
                     systems::apply_turn_started,
                     systems::apply_turn_action_resolved,
+                    systems::apply_combat_attack,
+                    systems::apply_combat_defense,
+                    systems::apply_session_outcome,
                     systems::apply_intervention_submitted,
                     systems::apply_intervention_applied,
                     systems::apply_keeper_unavailable,

--- a/viewer/src/game/systems.rs
+++ b/viewer/src/game/systems.rs
@@ -235,6 +235,13 @@ pub fn apply_turn_progress(
                 complete_actor(&mut progress, &payload.actor_id, "unavailable");
                 set_actor_reason(&mut progress, &payload.actor_id, &payload.reason);
             }
+            "combat.attack" | "combat.defense" => {
+                let actor_id = payload.actor_id.trim();
+                if !actor_id.is_empty() {
+                    complete_actor(&mut progress, actor_id, "ok");
+                    set_actor_reason(&mut progress, actor_id, "");
+                }
+            }
             "room.started" => {
                 if progress.room_status.is_empty() {
                     progress.room_status = "active".to_string();
@@ -242,6 +249,12 @@ pub fn apply_turn_progress(
                 progress.actor_reasons.clear();
             }
             "room.ended" => {
+                progress.room_status = "ended".to_string();
+                progress.current_actor.clear();
+                progress.next_actor.clear();
+                progress.actor_reasons.clear();
+            }
+            "session.outcome" => {
                 progress.room_status = "ended".to_string();
                 progress.current_actor.clear();
                 progress.next_actor.clear();
@@ -535,6 +548,33 @@ pub fn apply_turn_started(
 pub fn apply_turn_action_resolved(mut events: MessageReader<TurnActionResolved>) {
     for TurnActionResolved(_p) in events.read() {
         // Log-only: action result is rendered by DOM system
+    }
+}
+
+pub fn apply_combat_attack(mut events: MessageReader<CombatAttack>) {
+    for CombatAttack(_p) in events.read() {
+        // Log-only: semantic combat event rendered by DOM systems
+    }
+}
+
+pub fn apply_combat_defense(mut events: MessageReader<CombatDefense>) {
+    for CombatDefense(_p) in events.read() {
+        // Log-only: semantic combat event rendered by DOM systems
+    }
+}
+
+pub fn apply_session_outcome(
+    mut events: MessageReader<SessionOutcome>,
+    mut room_state: ResMut<RoomState>,
+    mut progress: ResMut<TurnProgressState>,
+) {
+    for SessionOutcome(payload) in events.read() {
+        room_state.status = "ended".to_string();
+        if payload.turn > 0 {
+            room_state.turn = payload.turn;
+            progress.turn = payload.turn;
+        }
+        progress.room_status = "ended".to_string();
     }
 }
 

--- a/viewer/src/sse/bridge.rs
+++ b/viewer/src/sse/bridge.rs
@@ -63,6 +63,9 @@ pub struct Phase2EventWriters<'w> {
     pub actor_updated: MessageWriter<'w, ActorUpdated>,
     pub room_ended: MessageWriter<'w, RoomEnded>,
     pub turn_action_resolved: MessageWriter<'w, TurnActionResolved>,
+    pub combat_attack: MessageWriter<'w, CombatAttack>,
+    pub combat_defense: MessageWriter<'w, CombatDefense>,
+    pub session_outcome: MessageWriter<'w, SessionOutcome>,
     pub scene_transitioned: MessageWriter<'w, SceneTransitioned>,
 }
 
@@ -281,6 +284,27 @@ pub fn poll_sse_events(
                 phase2.turn_action_resolved,
                 TurnActionResolvedPayload,
                 TurnActionResolved
+            ),
+            "combat.attack" => dispatch_event!(
+                event_type,
+                &data,
+                phase2.combat_attack,
+                CombatAttackPayload,
+                CombatAttack
+            ),
+            "combat.defense" => dispatch_event!(
+                event_type,
+                &data,
+                phase2.combat_defense,
+                CombatDefensePayload,
+                CombatDefense
+            ),
+            "session.outcome" => dispatch_event!(
+                event_type,
+                &data,
+                phase2.session_outcome,
+                SessionOutcomePayload,
+                SessionOutcome
             ),
             "scene.transition" => dispatch_event!(
                 event_type,

--- a/viewer/src/sse/client.rs
+++ b/viewer/src/sse/client.rs
@@ -144,6 +144,61 @@ fn value_to_string_vec(v: Option<&Value>) -> Vec<String> {
 }
 
 #[cfg(any(target_arch = "wasm32", test))]
+fn canonical_weather_id(raw: &str) -> Option<&'static str> {
+    let key = raw.trim().to_ascii_lowercase();
+    if key.is_empty() {
+        return None;
+    }
+    if key.contains("drizzle") || key.contains("light_rain") || key.contains("light rain") {
+        return Some("drizzle");
+    }
+    if key.contains("heavy_rain")
+        || key.contains("heavy rain")
+        || key.contains("storm")
+        || key.contains("downpour")
+    {
+        return Some("heavy_rain");
+    }
+    if key.contains("fog") || key.contains("mist") {
+        return Some("fog");
+    }
+    if key.contains("silence") || key.contains("still") || key.contains("calm") {
+        return Some("silence");
+    }
+    None
+}
+
+#[cfg(any(target_arch = "wasm32", test))]
+fn canonical_mood_id(raw: &str) -> Option<&'static str> {
+    let key = raw.trim().to_ascii_lowercase();
+    if key.is_empty() {
+        return None;
+    }
+    if key.contains("quiet_unease")
+        || key.contains("quiet unease")
+        || key.contains("unease")
+        || key.contains("eerie")
+    {
+        return Some("quiet_unease");
+    }
+    if key.contains("tension_rising")
+        || key.contains("tension rising")
+        || key.contains("tension")
+        || key.contains("urgent")
+    {
+        return Some("tension_rising");
+    }
+    if key.contains("ambiguous_calm")
+        || key.contains("ambiguous calm")
+        || key.contains("calm")
+        || key.contains("neutral")
+    {
+        return Some("ambiguous_calm");
+    }
+    None
+}
+
+#[cfg(any(target_arch = "wasm32", test))]
 fn resolve_actor_id(payload: &Value, actor_id: Option<&str>) -> String {
     payload
         .get("actor_id")
@@ -432,6 +487,31 @@ fn map_turn_progress_event(
                 "reason": payload.get("reason").and_then(Value::as_str).unwrap_or("")
             })
         }
+        "combat.attack" => json!({
+            "event_type": event_type,
+            "turn": turn,
+            "phase": phase,
+            "actor_id": resolve_actor_id(payload, actor_id),
+            "reason": payload.get("action").and_then(Value::as_str).unwrap_or("")
+        }),
+        "combat.defense" => json!({
+            "event_type": event_type,
+            "turn": turn,
+            "phase": phase,
+            "actor_id": resolve_actor_id(payload, actor_id),
+            "reason": payload.get("method").and_then(Value::as_str).unwrap_or("")
+        }),
+        "session.outcome" => json!({
+            "event_type": event_type,
+            "turn": turn,
+            "phase": phase,
+            "room_status": "ended",
+            "reason": payload
+                .get("summary")
+                .and_then(Value::as_str)
+                .or_else(|| payload.get("reason").and_then(Value::as_str))
+                .unwrap_or("")
+        }),
         "room.started" => json!({
             "event_type": event_type,
             "turn": turn,
@@ -701,6 +781,79 @@ fn map_trpg_event(
             );
             out.push(("narrative".to_string(), mapped.to_string()));
         }
+        "combat.attack" => {
+            let mapped = attach_room_id(
+                json!({
+                    "turn": value_to_u32(payload.get("turn"), state.last_turn),
+                    "actor_id": payload.get("actor_id").and_then(Value::as_str).or(actor_id).unwrap_or(""),
+                    "action": payload.get("action").and_then(Value::as_str).unwrap_or(""),
+                    "target_id": payload.get("target_id").and_then(Value::as_str).unwrap_or(""),
+                    "skill": payload.get("skill").and_then(Value::as_str).unwrap_or("")
+                }),
+                payload,
+                stream_room_id,
+            );
+            out.push(("combat.attack".to_string(), mapped.to_string()));
+        }
+        "combat.defense" => {
+            let mapped = attach_room_id(
+                json!({
+                    "turn": value_to_u32(payload.get("turn"), state.last_turn),
+                    "actor_id": payload.get("actor_id").and_then(Value::as_str).or(actor_id).unwrap_or(""),
+                    "method": payload.get("method").and_then(Value::as_str).unwrap_or(""),
+                    "source_actor_id": payload.get("source_actor_id").and_then(Value::as_str).unwrap_or("")
+                }),
+                payload,
+                stream_room_id,
+            );
+            out.push(("combat.defense".to_string(), mapped.to_string()));
+        }
+        "session.outcome" => {
+            let outcome = payload
+                .get("outcome")
+                .and_then(Value::as_str)
+                .unwrap_or("draw");
+            let summary = payload
+                .get("summary")
+                .and_then(Value::as_str)
+                .unwrap_or("");
+            let reason = payload.get("reason").and_then(Value::as_str).unwrap_or("");
+            let turn = value_to_u32(payload.get("turn"), state.last_turn);
+            if turn > 0 {
+                state.last_turn = turn;
+            }
+            let mapped = attach_room_id(
+                json!({
+                    "outcome": outcome,
+                    "reason": reason,
+                    "summary": summary,
+                    "turn": turn
+                }),
+                payload,
+                stream_room_id,
+            );
+            out.push(("session.outcome".to_string(), mapped.to_string()));
+
+            let narrative_text = if summary.trim().is_empty() {
+                match outcome {
+                    "victory" => "승리로 세션이 종료되었습니다.",
+                    "defeat" => "패배로 세션이 종료되었습니다.",
+                    _ => "세션이 종료되었습니다.",
+                }
+            } else {
+                summary
+            };
+            let narrative = attach_room_id(
+                json!({
+                    "text": narrative_text,
+                    "phase": "endgame",
+                    "speaker": "DM"
+                }),
+                payload,
+                stream_room_id,
+            );
+            out.push(("narrative".to_string(), narrative.to_string()));
+        }
         // -- world.event: dispatch to weather/mood/death based on subtype --
         "world.event" => {
             let sub = payload
@@ -711,11 +864,49 @@ fn map_trpg_event(
                 .get("description")
                 .and_then(Value::as_str)
                 .unwrap_or("");
+            let severity = payload
+                .get("severity")
+                .and_then(Value::as_str)
+                .unwrap_or("");
             if sub.contains("weather") {
-                let mapped = json!({ "weather": desc });
+                let id_hint = payload
+                    .get("id")
+                    .and_then(Value::as_str)
+                    .or_else(|| payload.get("weather").and_then(Value::as_str))
+                    .unwrap_or("");
+                let weather = canonical_weather_id(id_hint)
+                    .or_else(|| canonical_weather_id(desc))
+                    .or_else(|| canonical_weather_id(sub))
+                    .unwrap_or(id_hint);
+                let weather = if weather.trim().is_empty() {
+                    desc
+                } else {
+                    weather
+                };
+                let mapped = json!({
+                    "weather": weather,
+                    "intensity": severity
+                });
                 out.push(("weather_change".to_string(), mapped.to_string()));
             } else if sub.contains("mood") || sub.contains("atmosphere") {
-                let mapped = json!({ "mood": desc });
+                let id_hint = payload
+                    .get("id")
+                    .and_then(Value::as_str)
+                    .or_else(|| payload.get("mood").and_then(Value::as_str))
+                    .unwrap_or("");
+                let mood = canonical_mood_id(id_hint)
+                    .or_else(|| canonical_mood_id(desc))
+                    .or_else(|| canonical_mood_id(sub))
+                    .unwrap_or(id_hint);
+                let mood = if mood.trim().is_empty() {
+                    desc
+                } else {
+                    mood
+                };
+                let mapped = json!({
+                    "mood": mood,
+                    "intensity": severity
+                });
                 out.push(("mood_change".to_string(), mapped.to_string()));
             } else if sub.contains("death") || sub.contains("died") || sub.contains("kill") {
                 let actor = resolve_actor_id(payload, actor_id);
@@ -1488,6 +1679,76 @@ mod tests {
             serde_json::from_str(&combat_start.1).expect("combat_start payload json");
         assert_eq!(cs_payload["area"], "Dark Cave");
         assert_eq!(cs_payload["enemies"], json!(["Goblin", "Orc"]));
+    }
+
+    #[test]
+    fn decode_stream_maps_combat_semantic_events() {
+        let body = r#"{
+            "events": [
+                {"seq": 1, "type": "combat.attack", "actor_id": "grimja", "payload": {"turn": 4, "action": "Longsword Slash", "target_id": "ghoul-1", "skill": "melee"}},
+                {"seq": 2, "type": "combat.defense", "actor_id": "luna", "payload": {"turn": 4, "method": "shield block", "source_actor_id": "ghoul-1"}}
+            ]
+        }"#;
+
+        let mut state = TrpgMapperState::default();
+        let (_, mapped) = decode_stream_events(body, &mut state).expect("decode should succeed");
+
+        let attack = mapped
+            .iter()
+            .find(|(event_type, _)| event_type == "combat.attack")
+            .expect("combat.attack should exist");
+        let attack_payload: Value =
+            serde_json::from_str(&attack.1).expect("combat.attack payload json");
+        assert_eq!(attack_payload["actor_id"], "grimja");
+        assert_eq!(attack_payload["action"], "Longsword Slash");
+
+        let defense = mapped
+            .iter()
+            .find(|(event_type, _)| event_type == "combat.defense")
+            .expect("combat.defense should exist");
+        let defense_payload: Value =
+            serde_json::from_str(&defense.1).expect("combat.defense payload json");
+        assert_eq!(defense_payload["actor_id"], "luna");
+        assert_eq!(defense_payload["method"], "shield block");
+
+        let progress_events: Vec<&(String, String)> = mapped
+            .iter()
+            .filter(|(event_type, _)| event_type == "turn_progress")
+            .collect();
+        assert_eq!(progress_events.len(), 2);
+    }
+
+    #[test]
+    fn decode_stream_maps_session_outcome_event() {
+        let body = r#"{
+            "events": [
+                {"seq": 7, "type": "session.outcome", "payload": {"outcome": "victory", "reason": "objective_complete", "summary": "Relic recovered and party extracted.", "turn": 9}}
+            ]
+        }"#;
+
+        let mut state = TrpgMapperState::default();
+        let (_, mapped) = decode_stream_events(body, &mut state).expect("decode should succeed");
+
+        let outcome = mapped
+            .iter()
+            .find(|(event_type, _)| event_type == "session.outcome")
+            .expect("session.outcome should exist");
+        let payload: Value =
+            serde_json::from_str(&outcome.1).expect("session.outcome payload json");
+        assert_eq!(payload["outcome"], "victory");
+        assert_eq!(payload["turn"], 9);
+
+        let narrative = mapped
+            .iter()
+            .find(|(event_type, _)| event_type == "narrative")
+            .expect("narrative should exist");
+        let narrative_payload: Value =
+            serde_json::from_str(&narrative.1).expect("narrative payload json");
+        assert_eq!(narrative_payload["phase"], "endgame");
+        assert_eq!(
+            narrative_payload["text"],
+            "Relic recovered and party extracted."
+        );
     }
 
     #[test]

--- a/viewer/style.css
+++ b/viewer/style.css
@@ -1150,6 +1150,144 @@ body:not(.mode-trpg) #ops-hud {
     margin-top: 12px;
 }
 
+.atmosphere-strip {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 8px;
+    margin-top: 10px;
+    margin-bottom: 8px;
+}
+
+.atmo-chip {
+    display: grid;
+    grid-template-columns: 26px auto;
+    gap: 8px;
+    align-items: center;
+    min-height: 42px;
+    padding: 6px 10px;
+    border: 1px solid var(--border-main);
+    border-radius: 4px;
+    background: linear-gradient(160deg, rgba(255, 255, 255, 0.03), rgba(0, 0, 0, 0.18));
+}
+
+.atmo-icon {
+    width: 22px;
+    height: 22px;
+    object-fit: cover;
+    border-radius: 3px;
+    opacity: 0.88;
+}
+
+.atmo-label {
+    display: block;
+    font-family: var(--font-ui);
+    font-size: 9px;
+    letter-spacing: 1.4px;
+    color: var(--text-dim);
+    text-transform: uppercase;
+}
+
+.atmo-value {
+    display: block;
+    font-family: var(--font-display);
+    font-size: 11px;
+    letter-spacing: 0.7px;
+    color: var(--text-primary);
+}
+
+.event-beacon {
+    grid-column: 1 / -1;
+    min-height: 40px;
+    padding: 8px 10px;
+    border: 1px solid var(--border-main);
+    border-radius: 4px;
+    background: rgba(0, 0, 0, 0.22);
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    opacity: 0;
+    transform: translateY(-3px);
+    transition: opacity 0.25s ease, transform 0.25s ease, border-color 0.25s ease;
+}
+
+.event-beacon .beacon-icon {
+    font-size: 16px;
+    line-height: 1;
+}
+
+.event-beacon .beacon-copy {
+    display: flex;
+    flex-direction: column;
+}
+
+.event-beacon .beacon-title {
+    font-family: var(--font-ui);
+    font-size: 10px;
+    letter-spacing: 1.2px;
+    text-transform: uppercase;
+    color: var(--text-dim);
+}
+
+.event-beacon .beacon-detail {
+    font-family: var(--font-body);
+    font-size: 12px;
+    color: var(--text-primary);
+}
+
+.event-beacon[class*="tone-"] {
+    opacity: 1;
+    transform: translateY(0);
+}
+
+.event-beacon.tone-attack {
+    border-color: rgba(200, 84, 47, 0.65);
+    box-shadow: 0 0 0 1px rgba(200, 84, 47, 0.2) inset;
+}
+
+.event-beacon.tone-defense {
+    border-color: rgba(82, 119, 173, 0.68);
+    box-shadow: 0 0 0 1px rgba(82, 119, 173, 0.2) inset;
+}
+
+.event-beacon.tone-victory {
+    border-color: rgba(196, 162, 101, 0.68);
+    box-shadow: 0 0 0 1px rgba(196, 162, 101, 0.25) inset;
+}
+
+.event-beacon.tone-defeat {
+    border-color: rgba(157, 71, 53, 0.68);
+    box-shadow: 0 0 0 1px rgba(157, 71, 53, 0.25) inset;
+}
+
+.event-beacon.tone-draw {
+    border-color: rgba(120, 142, 173, 0.68);
+    box-shadow: 0 0 0 1px rgba(120, 142, 173, 0.25) inset;
+}
+
+.floating-overlay {
+    display: none;
+    margin-top: 8px;
+    margin-bottom: 8px;
+    border: 1px solid var(--border-main);
+    border-radius: 4px;
+    padding: 10px 12px;
+    font-family: var(--font-body);
+    background: rgba(0, 0, 0, 0.25);
+}
+
+.choice-overlay {
+    border-left: 3px solid var(--accent-primary);
+}
+
+.choice-overlay ul {
+    margin: 6px 0 0 16px;
+}
+
+.combat-overlay {
+    border-left: 3px solid var(--accent-secondary);
+    box-shadow: 0 0 0 1px rgba(157, 71, 53, 0.25) inset;
+}
+
 .narrative-meta {
     font-family: var(--font-ui);
     font-size: 10px;
@@ -3880,6 +4018,19 @@ body:not(.mode-trpg) #ops-hud {
     max-width: 600px;
 }
 
+.endgame-crest {
+    width: 70px;
+    height: 70px;
+    margin: 0 auto 10px;
+    border: 1px solid rgba(255, 255, 255, 0.16);
+    border-radius: 50%;
+    display: grid;
+    place-items: center;
+    font-size: 28px;
+    color: var(--text-bright);
+    background: radial-gradient(circle at 35% 30%, rgba(255, 255, 255, 0.18), rgba(0, 0, 0, 0.35));
+}
+
 .endgame-title {
     font-family: var(--font-display, 'Cinzel', serif);
     font-size: 2.8em;
@@ -3891,10 +4042,27 @@ body:not(.mode-trpg) #ops-hud {
     color: var(--accent-primary, #c4a265);
     text-shadow: 0 0 20px rgba(196, 162, 101, 0.4);
 }
+.endgame-overlay.victory .endgame-crest {
+    border-color: rgba(196, 162, 101, 0.7);
+    box-shadow: 0 0 18px rgba(196, 162, 101, 0.25);
+}
 
 .endgame-overlay.defeat .endgame-title {
     color: var(--accent-secondary, #8b2500);
     text-shadow: 0 0 20px rgba(139, 37, 0, 0.4);
+}
+.endgame-overlay.defeat .endgame-crest {
+    border-color: rgba(155, 73, 53, 0.72);
+    box-shadow: 0 0 18px rgba(155, 73, 53, 0.25);
+}
+
+.endgame-overlay.draw .endgame-title {
+    color: #8ea6c2;
+    text-shadow: 0 0 20px rgba(142, 166, 194, 0.35);
+}
+.endgame-overlay.draw .endgame-crest {
+    border-color: rgba(120, 142, 173, 0.72);
+    box-shadow: 0 0 18px rgba(120, 142, 173, 0.25);
 }
 
 .endgame-message {
@@ -3983,6 +4151,10 @@ body:not(.mode-trpg) #ops-hud {
 
 /* Session lifecycle events */
 .session-event { border-left: 3px solid #95a5a6; padding-left: 0.8em; margin: 0.3em 0; color: var(--text-secondary, #999); font-size: 0.9em; }
+.session-event.session-outcome { border-left-width: 4px; font-weight: 600; }
+.session-event.session-outcome.outcome-victory { border-left-color: var(--accent-primary, #c4a265); color: #d8c18b; }
+.session-event.session-outcome.outcome-defeat { border-left-color: var(--accent-secondary, #8b2500); color: #d28d75; }
+.session-event.session-outcome.outcome-draw { border-left-color: #8ea6c2; color: #b5c4d6; }
 .session-start { color: var(--text, #eee); font-weight: bold; }
 .session-icon { margin-right: 0.3em; }
 
@@ -3994,6 +4166,80 @@ body:not(.mode-trpg) #ops-hud {
 /* Turn action result */
 .action-result { border-left: 3px solid #27ae60; padding-left: 0.8em; margin: 0.3em 0; }
 .action-icon { color: #2ecc71; margin-right: 0.3em; font-weight: bold; }
+
+.event-badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    font-family: var(--font-ui);
+    font-size: 10px;
+    letter-spacing: 0.8px;
+    text-transform: uppercase;
+    border: 1px solid transparent;
+    border-radius: 3px;
+    padding: 2px 7px;
+    margin-right: 8px;
+}
+
+.event-main {
+    font-family: var(--font-display);
+    margin-right: 5px;
+}
+
+.event-sep {
+    color: var(--text-dim);
+    margin-right: 5px;
+}
+
+.event-detail {
+    color: var(--text-primary);
+}
+
+.badge-attack {
+    border-color: rgba(200, 84, 47, 0.68);
+    background: rgba(200, 84, 47, 0.16);
+    color: #e4b4a3;
+}
+
+.badge-defense {
+    border-color: rgba(82, 119, 173, 0.72);
+    background: rgba(82, 119, 173, 0.16);
+    color: #b5c7df;
+}
+
+.badge-outcome {
+    border-color: rgba(196, 162, 101, 0.68);
+    background: rgba(196, 162, 101, 0.16);
+    color: #dfcca1;
+}
+
+.combat-attack {
+    border-left-color: #c8542f;
+}
+
+.combat-defense {
+    border-left-color: #5277ad;
+}
+
+.fx-attack {
+    animation: event-impact 560ms cubic-bezier(0.2, 0.8, 0.2, 1);
+}
+
+.fx-defense {
+    animation: event-guard 560ms cubic-bezier(0.2, 0.8, 0.2, 1);
+}
+
+@keyframes event-impact {
+    0% { transform: translateX(-5px); box-shadow: 0 0 0 rgba(200, 84, 47, 0); }
+    30% { box-shadow: 0 0 14px rgba(200, 84, 47, 0.3); }
+    100% { transform: translateX(0); box-shadow: 0 0 0 rgba(200, 84, 47, 0); }
+}
+
+@keyframes event-guard {
+    0% { transform: translateX(-3px); box-shadow: 0 0 0 rgba(82, 119, 173, 0); }
+    35% { box-shadow: 0 0 14px rgba(82, 119, 173, 0.28); }
+    100% { transform: translateX(0); box-shadow: 0 0 0 rgba(82, 119, 173, 0); }
+}
 
 /* Intervention events */
 .intervention-event { border-left: 3px solid #8e44ad; padding-left: 0.8em; margin: 0.3em 0; font-style: italic; }
@@ -4010,3 +4256,9 @@ body:not(.mode-trpg) #ops-hud {
 
 /* Social SSE notifications */
 .social-sse-notification { padding: 0.3em 0.5em; border-bottom: 1px solid var(--border, #333); font-size: 0.85em; color: var(--text-secondary, #999); }
+
+@media (max-width: 980px) {
+    .atmosphere-strip {
+        grid-template-columns: 1fr;
+    }
+}


### PR DESCRIPTION
## Summary
- extend viewer event bridge/handlers for `combat.attack`, `combat.defense`, `session.outcome`
- map canonical world weather/mood IDs for asset-friendly rendering
- add atmosphere strip (weather/mood icons), event beacon, combat/result badges, and endgame draw tone
- add SSE mapper tests for combat semantic events and session outcome event

## Verification
- cargo test --manifest-path /Users/dancer/me/workspace/yousleepwhen/masc-mcp/viewer/Cargo.toml sse::client
- cargo test --manifest-path /Users/dancer/me/workspace/yousleepwhen/masc-mcp/viewer/Cargo.toml