### PR TITLE
improve(viewer): separate current game lane and clarify runtime status copy

### DIFF
--- a/viewer/index.html
+++ b/viewer/index.html
@@ -162,7 +162,7 @@
                     <button id="room-apply-btn" class="inline-toggle" type="button" title="입력한 방으로 이동합니다">이동</button>
                     <button id="room-refresh-btn" class="inline-toggle" type="button" title="서버에서 방 목록을 다시 불러옵니다">방 새로고침</button>
                     <button id="room-hub-toggle" class="inline-toggle" type="button" aria-pressed="false" title="전체 방 목록 패널을 열거나 닫습니다">방 목록</button>
-                    <span id="room-status" class="widget-pill">현재 방: default</span>
+                    <span id="room-status" class="widget-pill">현재 게임: default</span>
                 </div>
                 <button id="new-game-toggle" class="inline-toggle" type="button" title="새로운 TRPG 세션을 시작합니다">새 게임</button>
                 <button id="auto-round-toggle" class="inline-toggle" type="button" aria-pressed="true" title="AI 턴 자동 진행을 멈춥니다">자동 진행: ON</button>
@@ -191,7 +191,7 @@
             </div>
             <div class="ops-hud-item">
                 <span class="ops-k">Session</span>
-                <span id="ops-session-state" class="ops-v">lobby</span>
+                <span id="ops-session-state" class="ops-v">로비</span>
             </div>
             <div class="ops-hud-item">
                 <span class="ops-k">Round</span>
@@ -199,15 +199,15 @@
             </div>
             <div class="ops-hud-item">
                 <span class="ops-k">Connection</span>
-                <span id="ops-connection-state" class="ops-v">disconnected</span>
+                <span id="ops-connection-state" class="ops-v">연결 끊김</span>
             </div>
             <div class="ops-hud-item">
                 <span class="ops-k">Control</span>
-                <span id="ops-control-state" class="ops-v">waiting</span>
+                <span id="ops-control-state" class="ops-v">대기</span>
             </div>
             <div class="ops-hud-item">
                 <span class="ops-k">Sync</span>
-                <span id="ops-sync-state" class="ops-v">idle</span>
+                <span id="ops-sync-state" class="ops-v">대기</span>
             </div>
         </section>
 
@@ -471,7 +471,7 @@
                 <div id="dice-log" class="scrollable horizontal"></div>
             </section>
             <section class="bottom-pane">
-                <h2 class="panel-title">게임 히스토리</h2>
+                <h2 class="panel-title">현재 게임 / 이전 세션</h2>
                 <div id="session-history" class="scrollable"></div>
             </section>
         </footer>

--- a/viewer/src/dom/session_history.rs
+++ b/viewer/src/dom/session_history.rs
@@ -466,11 +466,11 @@ fn render_session_history_html(rooms: &[RoomHistory], current_room_id: &str) -> 
 
     let current_bucket = if current_rooms.is_empty() {
         format!(
-            r#"<section class="history-room-bucket history-room-bucket-current"><h4 class="history-room-bucket-title">현재 세션</h4><p class="history-room-empty">현재 room({room})의 기록이 아직 없습니다.</p></section>"#,
+            r#"<section class="history-room-bucket history-room-bucket-current"><h4 class="history-room-bucket-title">현재 게임 (실시간)</h4><p class="history-room-empty">현재 game room({room})의 기록이 없습니다. 새 게임을 시작하거나 라운드를 실행하세요.</p></section>"#,
             room = html_escape(&sanitize_text(&current_room))
         )
     } else {
-        render_room_bucket_html("현재 세션", &current_rooms, "history-room-bucket-current")
+        render_room_bucket_html("현재 게임 (실시간)", &current_rooms, "history-room-bucket-current")
     };
 
     let summary_class = if current_rooms.is_empty() {
@@ -479,7 +479,7 @@ fn render_session_history_html(rooms: &[RoomHistory], current_room_id: &str) -> 
         "history-session-summary"
     };
     let summary_html = format!(
-        r#"<div class="{summary_class}"><span>현재 room: <strong>{room}</strong></span><span>진행 {active} · 멈춤 {paused} · 종료 {ended}</span></div>"#,
+        r#"<div class="{summary_class}"><span>현재 게임 room: <strong>{room}</strong></span><span>이전 세션 진행 {active} · 멈춤 {paused} · 종료 {ended}</span></div>"#,
         summary_class = summary_class,
         room = html_escape(&sanitize_text(&current_room)),
         active = active_count,
@@ -488,10 +488,10 @@ fn render_session_history_html(rooms: &[RoomHistory], current_room_id: &str) -> 
     );
 
     let room_column = format!(
-        r#"<section class="history-browser-column history-room-column"><h3 class="history-column-title">세션</h3>{summary}{current}{active}{paused}{ended}{other}</section>"#,
+        r#"<section class="history-browser-column history-room-column"><h3 class="history-column-title">현재 게임 / 이전 세션</h3>{summary}{current}{active}{paused}{ended}{other}</section>"#,
         summary = summary_html,
         current = current_bucket,
-        active = render_room_bucket_html("이전 세션 · 진행중", &active_rooms, ""),
+        active = render_room_bucket_html("이전 세션 · 진행 중", &active_rooms, ""),
         paused = render_room_bucket_html("이전 세션 · 멈춤", &paused_rooms, ""),
         ended = render_room_bucket_html("이전 세션 · 종료", &ended_rooms, ""),
         other = render_room_bucket_html("이전 세션 · 기타", &other_rooms, "")

--- a/viewer/src/dom/turn_controls.rs
+++ b/viewer/src/dom/turn_controls.rs
@@ -565,7 +565,7 @@ fn on_advance_click() {
                 log::warn!("Advance turn failed: {}", detail);
                 clear_round_recovery();
                 set_round_stall_badges(None);
-                set_turn_status(&format!("Failed: {}", detail), "status-error");
+                set_turn_status(&format!("실패: {}", detail), "status-error");
                 set_turn_gate_reason(
                     &format!("실행 실패: {}", shorten_reason(&detail, 180)),
                     "status-error",
@@ -739,10 +739,10 @@ fn build_stalled_round_guide(
             turn_before, turn_after
         ),
         format!(
-            "요약: success {} / player {} / dm {} / timeout {} / unavailable {}",
+            "요약: 성공 {} / 플레이어 성공 {} / DM {} / timeout {} / unavailable {}",
             successes,
             player_successes,
-            if dm_success { "ok" } else { "fail" },
+            if dm_success { "성공" } else { "실패" },
             timeouts,
             unavailable
         ),
@@ -832,11 +832,11 @@ async fn advance_turn() -> Result<RoundRunOutcome, JsValue> {
             .and_then(|summary| summary.get("advanced"))
             .and_then(Value::as_bool);
         if round_advanced(turn_before, turn_after, summary_advanced) {
-            let mut status = format!("Round progressed: turn {} → {}", turn_before, turn_after);
+            let mut status = format!("라운드 진행: 턴 {} → {}", turn_before, turn_after);
             let mut warnings = Vec::new();
             if let Some(preflight_warning) = preflight_warning_text(&json) {
                 warnings.push(format!(
-                    "preflight {}",
+                    "사전 점검 {}",
                     shorten_reason(&preflight_warning, 90)
                 ));
             }
@@ -867,7 +867,7 @@ async fn advance_turn() -> Result<RoundRunOutcome, JsValue> {
     }
 
     Ok(RoundRunOutcome::Advanced {
-        status: "Turn advanced.".to_string(),
+        status: "라운드가 진행되었습니다.".to_string(),
         has_warning: false,
     })
 }

--- a/viewer/src/dom/turn_runtime.rs
+++ b/viewer/src/dom/turn_runtime.rs
@@ -43,7 +43,7 @@ fn room_status_class(state: TrpgLifecycleState) -> &'static str {
 
 #[cfg(target_arch = "wasm32")]
 fn room_status_label(state: TrpgLifecycleState) -> &'static str {
-    state.label()
+    state.label_ko()
 }
 
 fn connection_status_class(status: &ConnectionStatus) -> &'static str {
@@ -57,11 +57,11 @@ fn connection_status_class(status: &ConnectionStatus) -> &'static str {
 
 fn connection_status_label(status: &ConnectionStatus) -> &'static str {
     match status {
-        ConnectionStatus::Connected => "connected",
-        ConnectionStatus::Connecting => "connecting",
-        ConnectionStatus::Reconnecting(_, _) => "reconnecting",
-        ConnectionStatus::Disconnected => "disconnected",
-        ConnectionStatus::Failed => "failed",
+        ConnectionStatus::Connected => "연결됨",
+        ConnectionStatus::Connecting => "연결 중",
+        ConnectionStatus::Reconnecting(_, _) => "재연결 중",
+        ConnectionStatus::Disconnected => "연결 끊김",
+        ConnectionStatus::Failed => "연결 실패",
     }
 }
 
@@ -166,7 +166,7 @@ fn build_next_action_hint(
     has_actor_issues: bool,
 ) -> String {
     if runner_running {
-        return "Auto Run 진행 중입니다. 이벤트 수신을 기다리세요.".to_string();
+        return "자동 진행 중입니다. 이벤트 수신을 기다리세요.".to_string();
     }
     if !lifecycle.accepts_player_input() {
         return match lifecycle {
@@ -174,26 +174,26 @@ fn build_next_action_hint(
                 "로딩 중입니다. 상태 동기화 완료를 기다리세요.".to_string()
             }
             TrpgLifecycleState::Stopped => {
-                "세션이 멈춰 있습니다. Start/Run으로 재개하세요.".to_string()
+                "세션이 멈춰 있습니다. 라운드 실행으로 재개하세요.".to_string()
             }
             TrpgLifecycleState::Ended => {
-                "세션이 종료되었습니다. New Game으로 시작하세요.".to_string()
+                "세션이 종료되었습니다. 새 게임으로 시작하세요.".to_string()
             }
             TrpgLifecycleState::Unavailable => {
                 "엔진/키퍼 연결을 복구한 뒤 다시 시도하세요.".to_string()
             }
-            TrpgLifecycleState::Lobby => "세션을 시작한 뒤 Run Round를 실행하세요.".to_string(),
-            TrpgLifecycleState::Unknown => "상태 확인 후 Run Round를 다시 실행하세요.".to_string(),
+            TrpgLifecycleState::Lobby => "세션을 시작한 뒤 라운드 실행을 누르세요.".to_string(),
+            TrpgLifecycleState::Unknown => "상태 확인 후 라운드 실행을 다시 누르세요.".to_string(),
             TrpgLifecycleState::Running => "진행 상태를 확인하세요.".to_string(),
         };
     }
     if has_actor_issues {
-        return "keeper 상태를 확인한 뒤 Run Round를 다시 실행하세요.".to_string();
+        return "keeper 상태를 확인한 뒤 라운드 실행을 다시 누르세요.".to_string();
     }
 
     let actor = current_actor.trim();
     if actor.is_empty() || actor == "-" {
-        "Run Round를 실행하거나 플레이어 액션을 입력하세요.".to_string()
+        "라운드 실행을 누르거나 플레이어 액션을 입력하세요.".to_string()
     } else {
         format!("{} 응답을 기다리는 중입니다.", actor)
     }
@@ -232,7 +232,7 @@ fn build_flow_banner(
             TrpgLifecycleState::Stopped => (
                 "일시 정지",
                 "is-alert",
-                "세션이 멈춰 있습니다. Run Round로 다시 진행할 수 있습니다.".to_string(),
+                "세션이 멈춰 있습니다. 라운드 실행으로 다시 진행할 수 있습니다.".to_string(),
             ),
             TrpgLifecycleState::Loading => (
                 "세션 준비",
@@ -433,22 +433,22 @@ pub fn update_turn_runtime_dom(
     } else if alive_party <= 0 {
         "WIPE".to_string()
     } else {
-        format!("{}/{} alive", alive_party, total_party)
+        format!("{}/{} 생존", alive_party, total_party)
     };
     let (issues_summary, has_actor_issues) = summarize_actor_issues(&progress);
 
     let current_status = if !lifecycle.accepts_player_input() {
         lifecycle.label_ko()
     } else if current_actor != "-" {
-        "thinking"
+        "응답 생성 중"
     } else {
-        "waiting"
+        "대기 중"
     };
 
     let input_status = if lifecycle.accepts_player_input() {
-        "enabled"
+        "입력 가능"
     } else {
-        "disabled"
+        "입력 잠금"
     };
 
     let room_turn_for_sync = if room_state.turn > 0 {
@@ -484,21 +484,21 @@ pub fn update_turn_runtime_dom(
                 room_phase_for_sync, progress_phase_for_sync
             ));
         }
-        (format!("mismatch: {}", reasons.join(" · ")), "status-error")
+        (format!("불일치: {}", reasons.join(" · ")), "status-error")
     } else if progress.last_event.trim().is_empty() {
-        ("waiting event".to_string(), "status-idle")
+        ("이벤트 대기".to_string(), "status-idle")
     } else {
         (
-            format!("ok · {}", progress.last_event.trim()),
+            format!("정상 · {}", progress.last_event.trim()),
             "status-active",
         )
     };
 
     let control_state = if lifecycle.accepts_player_input() {
         if current_actor != "-" {
-            "manual-ready / actor-thinking".to_string()
+            "수동 실행 가능 · 액터 처리 중".to_string()
         } else {
-            "manual-ready".to_string()
+            "수동 실행 가능".to_string()
         }
     } else {
         lifecycle.label_ko().to_string()
@@ -525,9 +525,9 @@ pub fn update_turn_runtime_dom(
     };
 
     let runner_state = if runner_running {
-        format!("auto-run {} rounds", runner_rounds)
+        format!("자동 진행 {} 라운드", runner_rounds)
     } else {
-        "idle".to_string()
+        "대기".to_string()
     };
     let next_action =
         build_next_action_hint(lifecycle, runner_running, &current_actor, has_actor_issues);
@@ -609,7 +609,7 @@ pub fn update_turn_runtime_dom(
         if let Some(room_status_el) = document.get_element_by_id("room-status") {
             let room_id = crate::config::current_room_id();
             room_status_el.set_text_content(Some(&format!(
-                "room {} · {}",
+                "현재 게임 {} · {}",
                 room_id,
                 lifecycle.label_ko()
             )));
@@ -617,7 +617,7 @@ pub fn update_turn_runtime_dom(
             let _ = room_status_el.set_attribute(
                 "title",
                 &format!(
-                    "{} | turn {} | phase {} | raw {}",
+                    "{} | 턴 {} | 페이즈 {} | raw {}",
                     lifecycle.help_text(),
                     turn,
                     phase,
@@ -737,7 +737,7 @@ pub fn update_turn_runtime_dom(
                 && !inferred_player_pairs.is_empty()
             {
                 summary.set_text_content(Some(&format!(
-                    "DM: {} · Players: {}",
+                    "DM: {} · 플레이어: {}",
                     inferred_dm,
                     inferred_player_pairs.join(", ")
                 )));
@@ -765,14 +765,14 @@ pub fn update_turn_runtime_dom(
             };
             let html = format!(
                 concat!(
-                    "<div class=\"round-sync-row\"><span class=\"round-sync-label\">Room</span><span class=\"round-sync-value\">{room_id}</span></div>",
-                    "<div class=\"round-sync-row\"><span class=\"round-sync-label\">Lifecycle</span><span class=\"round-sync-value {room_class}\">{lifecycle}</span></div>",
-                    "<div class=\"round-sync-row\"><span class=\"round-sync-label\">Turn Sync</span><span class=\"round-sync-value {turn_sync_class}\">room {room_turn} / progress {progress_turn}</span></div>",
-                    "<div class=\"round-sync-row\"><span class=\"round-sync-label\">Phase Sync</span><span class=\"round-sync-value {phase_sync_class}\">room {room_phase} / progress {progress_phase}</span></div>",
-                    "<div class=\"round-sync-row\"><span class=\"round-sync-label\">Last Event</span><span class=\"round-sync-value\">{last_event}</span></div>",
-                    "<div class=\"round-sync-row\"><span class=\"round-sync-label\">Last Result</span><span class=\"round-sync-value\">{last_result}</span></div>",
-                    "<div class=\"round-sync-row\"><span class=\"round-sync-label\">Runner</span><span class=\"round-sync-value\">{runner_state}</span></div>",
-                    "<div class=\"round-sync-row\"><span class=\"round-sync-label\">Runner Resp</span><span class=\"round-sync-value\">{runner_preview}</span></div>"
+                    "<div class=\"round-sync-row\"><span class=\"round-sync-label\">게임 방</span><span class=\"round-sync-value\">{room_id}</span></div>",
+                    "<div class=\"round-sync-row\"><span class=\"round-sync-label\">세션 상태</span><span class=\"round-sync-value {room_class}\">{lifecycle}</span></div>",
+                    "<div class=\"round-sync-row\"><span class=\"round-sync-label\">턴 동기화</span><span class=\"round-sync-value {turn_sync_class}\">room {room_turn} / progress {progress_turn}</span></div>",
+                    "<div class=\"round-sync-row\"><span class=\"round-sync-label\">페이즈 동기화</span><span class=\"round-sync-value {phase_sync_class}\">room {room_phase} / progress {progress_phase}</span></div>",
+                    "<div class=\"round-sync-row\"><span class=\"round-sync-label\">마지막 이벤트</span><span class=\"round-sync-value\">{last_event}</span></div>",
+                    "<div class=\"round-sync-row\"><span class=\"round-sync-label\">마지막 결과</span><span class=\"round-sync-value\">{last_result}</span></div>",
+                    "<div class=\"round-sync-row\"><span class=\"round-sync-label\">자동 진행 상태</span><span class=\"round-sync-value\">{runner_state}</span></div>",
+                    "<div class=\"round-sync-row\"><span class=\"round-sync-label\">자동 진행 응답</span><span class=\"round-sync-value\">{runner_preview}</span></div>"
                 ),
                 room_id = html_escape(&room_id),
                 room_class = room_class,
@@ -801,22 +801,22 @@ pub fn update_turn_runtime_dom(
 
         let lifecycle_class = format!("{} {}", room_class, lifecycle.css_class());
         let lifecycle_label =
-            html_escape(&format!("{} ({})", lifecycle.label(), lifecycle.label_ko()));
+            html_escape(&format!("{} ({})", lifecycle.label_ko(), lifecycle.label()));
         let html = format!(
             r#"
 <div class="turn-runtime-grid">
-  <div class="turn-runtime-item turn-runtime-item-wide"><span class="k">Lifecycle</span><span class="v {lifecycle_class}">{lifecycle_label}</span></div>
-  <div class="turn-runtime-item turn-runtime-item-wide"><span class="k">Definition</span><span class="v">{lifecycle_help}</span></div>
-  <div class="turn-runtime-item"><span class="k">State</span><span class="v {room_class}">{room}</span></div>
-  <div class="turn-runtime-item"><span class="k">Turn</span><span class="v">{turn}</span></div>
-  <div class="turn-runtime-item"><span class="k">Phase</span><span class="v">{phase}</span></div>
-  <div class="turn-runtime-item"><span class="k">Input</span><span class="v {input_class}">{input}</span></div>
-  <div class="turn-runtime-item"><span class="k">Now</span><span class="v">{current} · {current_status}</span></div>
-  <div class="turn-runtime-item"><span class="k">Next</span><span class="v">{next}</span></div>
-  <div class="turn-runtime-item"><span class="k">Last</span><span class="v">{last}</span></div>
-  <div class="turn-runtime-item turn-runtime-item-wide"><span class="k">Issues</span><span class="v {issues_class}">{issues}</span></div>
-  <div class="turn-runtime-item turn-runtime-item-wide"><span class="k">Next Action</span><span class="v">{next_action}</span></div>
-  <div class="turn-runtime-item"><span class="k">Party</span><span class="v {party_class}">{party}</span></div>
+  <div class="turn-runtime-item turn-runtime-item-wide"><span class="k">세션 상태</span><span class="v {lifecycle_class}">{lifecycle_label}</span></div>
+  <div class="turn-runtime-item turn-runtime-item-wide"><span class="k">설명</span><span class="v">{lifecycle_help}</span></div>
+  <div class="turn-runtime-item"><span class="k">상태</span><span class="v {room_class}">{room}</span></div>
+  <div class="turn-runtime-item"><span class="k">턴</span><span class="v">{turn}</span></div>
+  <div class="turn-runtime-item"><span class="k">페이즈</span><span class="v">{phase}</span></div>
+  <div class="turn-runtime-item"><span class="k">입력</span><span class="v {input_class}">{input}</span></div>
+  <div class="turn-runtime-item"><span class="k">현재</span><span class="v">{current} · {current_status}</span></div>
+  <div class="turn-runtime-item"><span class="k">다음</span><span class="v">{next}</span></div>
+  <div class="turn-runtime-item"><span class="k">직전</span><span class="v">{last}</span></div>
+  <div class="turn-runtime-item turn-runtime-item-wide"><span class="k">이슈</span><span class="v {issues_class}">{issues}</span></div>
+  <div class="turn-runtime-item turn-runtime-item-wide"><span class="k">다음 행동</span><span class="v">{next_action}</span></div>
+  <div class="turn-runtime-item"><span class="k">파티</span><span class="v {party_class}">{party}</span></div>
 </div>
 "#,
             lifecycle_help = html_escape(lifecycle.help_text()),
@@ -873,7 +873,7 @@ mod tests {
     #[test]
     fn next_action_prefers_issue_recovery_when_running() {
         let hint = build_next_action_hint(TrpgLifecycleState::Running, false, "-", true);
-        assert_eq!(hint, "keeper 상태를 확인한 뒤 Run Round를 다시 실행하세요.");
+        assert_eq!(hint, "keeper 상태를 확인한 뒤 라운드 실행을 다시 누르세요.");
     }
 
     #[test]
@@ -890,7 +890,7 @@ mod tests {
             false,
             false,
             "-",
-            "Run Round를 실행하세요.",
+            "라운드 실행을 누르세요.",
         );
         assert_eq!(state, "연결 오류");
         assert_eq!(class_name, "is-error");
@@ -905,7 +905,7 @@ mod tests {
             true,
             false,
             "p01",
-            "Auto Run 진행 중입니다.",
+            "자동 진행 중입니다.",
         );
         assert_eq!(state, "자동 진행");
         assert_eq!(class_name, "is-running");

--- a/viewer/src/mode/mod.rs
+++ b/viewer/src/mode/mod.rs
@@ -252,7 +252,7 @@ fn enter_trpg() {
         crate::game::round_runner::set_auto_round_running(auto_round_enabled_from_dom(&doc));
 
         if let Some(pill) = doc.get_element_by_id("room-status") {
-            pill.set_text_content(Some(&format!("현재 방: {} · 목록 불러오는 중...", room)));
+            pill.set_text_content(Some(&format!("현재 게임: {} · 목록 불러오는 중...", room)));
         }
         let doc_for_rooms = doc.clone();
         wasm_bindgen_futures::spawn_local(async move {
@@ -261,7 +261,7 @@ fn enter_trpg() {
                     let room_now = crate::config::current_room_id();
                     if let Some(pill) = doc_for_rooms.get_element_by_id("room-status") {
                         pill.set_text_content(Some(&format!(
-                            "현재 방: {} · {}개 방",
+                            "현재 게임: {} · {}개 방",
                             room_now,
                             rooms.len()
                         )));
@@ -271,7 +271,7 @@ fn enter_trpg() {
                     log::warn!("room 목록 로딩 실패: {}", e);
                     let room_now = crate::config::current_room_id();
                     if let Some(pill) = doc_for_rooms.get_element_by_id("room-status") {
-                        pill.set_text_content(Some(&format!("현재 방: {} · 목록 실패", room_now)));
+                        pill.set_text_content(Some(&format!("현재 게임: {} · 목록 실패", room_now)));
                     }
                 }
             }
@@ -943,6 +943,7 @@ fn render_room_hub(doc: &web_sys::Document, rooms: &[RoomSnapshot], selected_roo
         return;
     };
     let running_only = load_room_hub_running_only();
+    let mut current = Vec::new();
     let mut running = Vec::new();
     let mut stopped = Vec::new();
     let mut lobby = Vec::new();
@@ -951,7 +952,8 @@ fn render_room_hub(doc: &web_sys::Document, rooms: &[RoomSnapshot], selected_roo
 
     for room in rooms {
         let lane = room_lane_label(&room.status);
-        let current_attr = if room.id == selected_room {
+        let is_current = room.id == selected_room;
+        let current_attr = if is_current {
             " data-current=\"1\""
         } else {
             " data-current=\"0\""
@@ -979,6 +981,10 @@ fn render_room_hub(doc: &web_sys::Document, rooms: &[RoomSnapshot], selected_roo
             agents = room.agent_count,
             tasks = room.task_count
         );
+        if is_current {
+            current.push(card);
+            continue;
+        }
         match lane {
             "running" => running.push(card),
             "stopped" => stopped.push(card),
@@ -1002,27 +1008,38 @@ fn render_room_hub(doc: &web_sys::Document, rooms: &[RoomSnapshot], selected_roo
         )
     };
 
+    let previous_count = running.len() + stopped.len() + lobby.len() + unavailable.len() + ended.len();
     let lanes_html = if running_only {
-        lane_html("진행 중", running, "running")
+        format!(
+            "{}{}",
+            lane_html("현재 게임", current, "current"),
+            lane_html("이전 세션 · 진행 중", running, "running")
+        )
     } else {
         format!(
-            "{}{}{}{}{}",
-            lane_html("진행 중", running, "running"),
-            lane_html("멈춤", stopped, "stopped"),
-            lane_html("로비", lobby, "lobby"),
-            lane_html("오류", unavailable, "unavailable"),
-            lane_html("종료", ended, "ended")
+            "{}{}{}{}{}{}",
+            lane_html("현재 게임", current, "current"),
+            lane_html("이전 세션 · 진행 중", running, "running"),
+            lane_html("이전 세션 · 멈춤", stopped, "stopped"),
+            lane_html("이전 세션 · 로비", lobby, "lobby"),
+            lane_html("이전 세션 · 오류", unavailable, "unavailable"),
+            lane_html("이전 세션 · 종료", ended, "ended")
         )
     };
+    let current_text = crate::config::sanitize_room_id(selected_room)
+        .unwrap_or_else(|| crate::config::DEFAULT_ROOM_ID.to_string());
     let html = format!(
         concat!(
             "<div class=\"room-hub-tools\">",
+            "<span class=\"room-hub-summary\">현재 게임: <code>{current}</code> · 이전 세션 {previous_count}개</span>",
             "<button id=\"room-hub-running-toggle\" class=\"room-hub-filter\" type=\"button\" aria-pressed=\"{pressed}\">",
             "진행 중만",
             "</button>",
             "</div>",
             "{lanes}"
         ),
+        current = html_escape(&current_text),
+        previous_count = previous_count,
         pressed = if running_only { "true" } else { "false" },
         lanes = lanes_html
     );
@@ -1316,7 +1333,7 @@ fn sync_room_controls(doc: &web_sys::Document, selected_room: &str) {
     if let Some(pill) = doc.get_element_by_id("room-status") {
         let lifecycle = TrpgLifecycleState::Loading;
         pill.set_text_content(Some(&format!(
-            "현재 방: {} · {}",
+            "현재 게임: {} · {}",
             selected,
             lifecycle.label_ko()
         )));
@@ -1508,7 +1525,7 @@ fn bind_room_controls(doc: &web_sys::Document) {
             };
             if let Some(pill) = doc.get_element_by_id("room-status") {
                 let current = crate::config::current_room_id();
-                pill.set_text_content(Some(&format!("현재 방: {} · 목록 불러오는 중...", current)));
+                pill.set_text_content(Some(&format!("현재 게임: {} · 목록 불러오는 중...", current)));
             }
             let doc_for_fetch = doc.clone();
             wasm_bindgen_futures::spawn_local(async move {
@@ -1517,7 +1534,7 @@ fn bind_room_controls(doc: &web_sys::Document) {
                         let current = crate::config::current_room_id();
                         if let Some(pill) = doc_for_fetch.get_element_by_id("room-status") {
                             pill.set_text_content(Some(&format!(
-                                "현재 방: {} · {}개 방",
+                                "현재 게임: {} · {}개 방",
                                 current,
                                 rooms.len()
                             )));
@@ -1528,7 +1545,7 @@ fn bind_room_controls(doc: &web_sys::Document) {
                         let current = crate::config::current_room_id();
                         if let Some(pill) = doc_for_fetch.get_element_by_id("room-status") {
                             pill.set_text_content(Some(&format!(
-                                "현재 방: {} · 목록 실패",
+                                "현재 게임: {} · 목록 실패",
                                 current
                             )));
                         }

--- a/viewer/style.css
+++ b/viewer/style.css
@@ -747,7 +747,7 @@ body:not(.mode-trpg) #ops-hud {
     border-radius: var(--panel-radius);
     background: rgba(10, 14, 28, 0.86);
     display: grid;
-    grid-template-columns: repeat(5, minmax(120px, 1fr));
+    grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
     gap: 8px;
     max-height: 192px;
     overflow: hidden;
@@ -762,8 +762,26 @@ body:not(.mode-trpg) #ops-hud {
 .room-hub-tools {
     grid-column: 1 / -1;
     display: flex;
-    justify-content: flex-end;
+    align-items: center;
+    justify-content: space-between;
     margin-bottom: 2px;
+    gap: 8px;
+}
+
+.room-hub-summary {
+    font-size: 10px;
+    color: var(--text-dim);
+    letter-spacing: 0.2px;
+}
+
+.room-hub-summary code {
+    font-family: var(--font-ui);
+    font-size: 10px;
+    color: var(--text-primary);
+    border: 1px solid rgba(109, 122, 164, 0.35);
+    border-radius: 6px;
+    padding: 1px 5px;
+    background: rgba(13, 18, 32, 0.78);
 }
 
 .room-hub-filter {
@@ -792,6 +810,11 @@ body:not(.mode-trpg) #ops-hud {
 
 .room-lane[data-lane="running"] {
     border-color: rgba(88, 184, 116, 0.42);
+}
+
+.room-lane[data-lane="current"] {
+    border-color: rgba(196, 162, 101, 0.55);
+    background: rgba(42, 33, 18, 0.28);
 }
 
 .room-lane[data-lane="stopped"] {


### PR DESCRIPTION
## Summary\n- split room hub into a dedicated `현재 게임` lane and explicit `이전 세션` lanes\n- update session history panel wording to distinguish current realtime game vs prior sessions\n- localize TRPG runtime/control copy so flow/status text is Korean-first and action-oriented\n\n## Verification\n- cargo check --manifest-path viewer/Cargo.toml\n- cargo check --manifest-path viewer/Cargo.toml --target wasm32-unknown-unknown\n- cargo test --manifest-path viewer/Cargo.toml --lib --bins\n