### PR TITLE
fix(viewer): map server turn phases correctly

### DIFF
--- a/viewer/index.html
+++ b/viewer/index.html
@@ -16,7 +16,7 @@
             <p class="lobby-subtitle">Multi-Agent Streaming Coordination</p>
         </div>
 
-        <div class="mode-grid">
+        <div id="mode-cards" class="mode-grid">
             <button class="mode-card" data-mode="trpg">
                 <span class="mode-icon">⚔</span>
                 <span class="mode-name">그림란드 연대기</span>
@@ -166,6 +166,11 @@
                 </div>
                 <button id="new-game-toggle" class="inline-toggle" type="button" title="새로운 TRPG 세션을 시작합니다">새 게임</button>
                 <button id="auto-round-toggle" class="inline-toggle" type="button" aria-pressed="true" title="AI 턴 자동 진행을 멈춥니다">자동 진행: ON</button>
+                <div class="session-control-inline">
+                    <button id="session-pause-btn" class="inline-toggle" type="button" title="현재 세션을 멈춥니다">멈춤</button>
+                    <button id="session-resume-btn" class="inline-toggle" type="button" title="멈춘 세션을 재개합니다">재개</button>
+                    <span id="session-control-status" class="widget-pill">세션 제어 대기</span>
+                </div>
                 <select id="theme-selector-inline" class="inline-select">
                     <option value="dark-fantasy">Dark Fantasy</option>
                     <option value="cyberpunk">Cyberpunk</option>
@@ -466,6 +471,7 @@
                         <div id="action-history" class="action-history"></div>
                         <input type="hidden" id="claimed-actor-id" value="" />
                         <input type="hidden" id="claimed-keeper" value="" />
+                        <input type="hidden" id="claimed-room-id" value="" />
                     </div>
                 </div>
             </section>

--- a/viewer/src/dom/actor_join.rs
+++ b/viewer/src/dom/actor_join.rs
@@ -402,6 +402,7 @@ fn set_claimed_state(actor_id: &str) {
     let Some(doc) = web_sys::window().and_then(|w| w.document()) else {
         return;
     };
+    let room_id = config::current_room_id();
 
     if let Some(el) = doc.get_element_by_id("claimed-actor-id") {
         if let Some(input) = el.dyn_ref::<web_sys::HtmlInputElement>() {
@@ -420,6 +421,12 @@ fn set_claimed_state(actor_id: &str) {
             }
         }
     }
+
+    if let Some(el) = doc.get_element_by_id("claimed-room-id") {
+        if let Some(input) = el.dyn_ref::<web_sys::HtmlInputElement>() {
+            input.set_value(&room_id);
+        }
+    }
 }
 
 #[cfg(target_arch = "wasm32")]
@@ -434,6 +441,11 @@ fn clear_claimed_state() {
         }
     }
     if let Some(el) = doc.get_element_by_id("claimed-keeper") {
+        if let Some(input) = el.dyn_ref::<web_sys::HtmlInputElement>() {
+            input.set_value("");
+        }
+    }
+    if let Some(el) = doc.get_element_by_id("claimed-room-id") {
         if let Some(input) = el.dyn_ref::<web_sys::HtmlInputElement>() {
             input.set_value("");
         }
@@ -467,12 +479,33 @@ fn get_claimed_keeper_from_dom() -> Option<String> {
 }
 
 #[cfg(target_arch = "wasm32")]
+fn get_claimed_room_id_from_dom() -> Option<String> {
+    let doc = web_sys::window().and_then(|w| w.document())?;
+    let el = doc.get_element_by_id("claimed-room-id")?;
+    let input = el.dyn_ref::<web_sys::HtmlInputElement>()?;
+    let val = input.value();
+    if val.is_empty() {
+        None
+    } else {
+        Some(val)
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
 fn restore_join_panel_state() {
     let Some(actor_id) = get_claimed_actor_id_from_dom() else {
         // No claimed actor, ensure join panel is visible
         swap_to_join_panel();
         return;
     };
+
+    let current_room = config::current_room_id();
+    let claimed_room = get_claimed_room_id_from_dom().unwrap_or_default();
+    if claimed_room.trim().is_empty() || claimed_room.trim() != current_room {
+        clear_claimed_state();
+        swap_to_join_panel();
+        return;
+    }
 
     // Have claimed actor, show action panel
     swap_to_action_panel(&actor_id);

--- a/viewer/src/dom/session_history.rs
+++ b/viewer/src/dom/session_history.rs
@@ -1108,7 +1108,16 @@ pub fn update_session_history_dom(
 
             let mut room_reset = false;
             if let Some(room) = cache.rooms.get_mut(room_idx) {
-                if !incoming_session_id.is_empty() && room.session_id != incoming_session_id {
+                let has_progress_history = room.updated_turn > 1
+                    || room.turns.iter().any(|row| row.turn > 1)
+                    || room.turns.iter().any(|row| !row.events.is_empty());
+                let should_reset = if incoming_session_id.is_empty() {
+                    has_progress_history
+                } else {
+                    room.session_id != incoming_session_id
+                };
+
+                if should_reset {
                     room.session_id = incoming_session_id.clone();
                     room.turns.clear();
                     room.updated_turn = 1;

--- a/viewer/src/dom/turn_controls.rs
+++ b/viewer/src/dom/turn_controls.rs
@@ -415,15 +415,13 @@ pub fn sync_turn_controls_visibility(
         set_round_run_controls_locked(&doc, locked);
 
         let dm_ready = read_dom_input(&doc, "round-run-dm")
-            .or_else(|| read_dom_input(&doc, "claimed-keeper"))
+            .or_else(|| read_claimed_keeper_for_current_room(&doc))
             .or_else(|| read_dom_input(&doc, "new-game-dm-select"))
             .is_some();
         let player_pairs_raw = read_dom_text_value(&doc, "round-run-players").unwrap_or_default();
         let mut player_count = parse_player_keeper_pairs(&player_pairs_raw).len();
         if player_count == 0 {
-            let claimed_actor = read_dom_input(&doc, "claimed-actor-id").unwrap_or_default();
-            let claimed_keeper = read_dom_input(&doc, "claimed-keeper").unwrap_or_default();
-            if !claimed_actor.is_empty() && !claimed_keeper.is_empty() {
+            if read_claimed_actor_keeper_for_current_room(&doc).is_some() {
                 player_count = 1;
             }
         }
@@ -1403,6 +1401,37 @@ fn read_dom_input(doc: &web_sys::Document, id: &str) -> Option<String> {
 }
 
 #[cfg(target_arch = "wasm32")]
+fn claim_matches_current_room(doc: &web_sys::Document) -> bool {
+    let claimed_room = read_dom_input(doc, "claimed-room-id").unwrap_or_default();
+    !claimed_room.is_empty() && claimed_room == config::current_room_id()
+}
+
+#[cfg(target_arch = "wasm32")]
+fn read_claimed_keeper_for_current_room(doc: &web_sys::Document) -> Option<String> {
+    if claim_matches_current_room(doc) {
+        read_dom_input(doc, "claimed-keeper")
+    } else {
+        None
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+fn read_claimed_actor_keeper_for_current_room(
+    doc: &web_sys::Document,
+) -> Option<(String, String)> {
+    if !claim_matches_current_room(doc) {
+        return None;
+    }
+    let claimed_actor = read_dom_input(doc, "claimed-actor-id").unwrap_or_default();
+    let claimed_keeper = read_dom_input(doc, "claimed-keeper").unwrap_or_default();
+    if claimed_actor.is_empty() || claimed_keeper.is_empty() {
+        None
+    } else {
+        Some((claimed_actor, claimed_keeper))
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
 fn parse_player_keeper_pairs(raw: &str) -> Vec<(String, String)> {
     raw.split(',')
         .filter_map(|part| {
@@ -1425,7 +1454,7 @@ fn parse_player_keeper_pairs(raw: &str) -> Vec<(String, String)> {
 #[cfg(target_arch = "wasm32")]
 fn read_round_run_plan(doc: &web_sys::Document) -> Result<RoundRunPlan, String> {
     let dm_keeper = read_dom_input(doc, "round-run-dm")
-        .or_else(|| read_dom_input(doc, "claimed-keeper"))
+        .or_else(|| read_claimed_keeper_for_current_room(doc))
         .or_else(|| read_dom_input(doc, "new-game-dm-select"))
         .unwrap_or_default();
     if dm_keeper.is_empty() {
@@ -1445,9 +1474,8 @@ fn read_round_run_plan(doc: &web_sys::Document) -> Result<RoundRunPlan, String> 
     let player_pairs_raw = read_dom_text_value(doc, "round-run-players").unwrap_or_default();
     let mut player_keepers = parse_player_keeper_pairs(&player_pairs_raw);
     if player_keepers.is_empty() {
-        let claimed_actor = read_dom_input(doc, "claimed-actor-id").unwrap_or_default();
-        let claimed_keeper = read_dom_input(doc, "claimed-keeper").unwrap_or_default();
-        if !claimed_actor.is_empty() && !claimed_keeper.is_empty() {
+        if let Some((claimed_actor, claimed_keeper)) = read_claimed_actor_keeper_for_current_room(doc)
+        {
             player_keepers.push((claimed_actor, claimed_keeper));
         }
     }

--- a/viewer/src/dom/turn_runtime.rs
+++ b/viewer/src/dom/turn_runtime.rs
@@ -651,6 +651,33 @@ pub fn update_turn_runtime_dom(
             {
                 players_input.set_value("");
             }
+            if let Some(claimed_actor) = document
+                .get_element_by_id("claimed-actor-id")
+                .and_then(|el| el.dyn_into::<HtmlInputElement>().ok())
+            {
+                claimed_actor.set_value("");
+            }
+            if let Some(claimed_keeper) = document
+                .get_element_by_id("claimed-keeper")
+                .and_then(|el| el.dyn_into::<HtmlInputElement>().ok())
+            {
+                claimed_keeper.set_value("");
+            }
+            if let Some(claimed_room) = document
+                .get_element_by_id("claimed-room-id")
+                .and_then(|el| el.dyn_into::<HtmlInputElement>().ok())
+            {
+                claimed_room.set_value("");
+            }
+            if let Some(el) = document.get_element_by_id("action-panel") {
+                let _ = el.set_attribute("style", "display: none;");
+            }
+            if let Some(el) = document.get_element_by_id("join-panel") {
+                let _ = el.remove_attribute("style");
+            }
+            if let Some(el) = document.get_element_by_id("player-actor-id") {
+                el.set_text_content(Some(""));
+            }
             if let Some(summary) = document.get_element_by_id("round-run-summary") {
                 summary.set_text_content(Some(""));
                 let _ = summary.set_attribute("style", "display:none");

--- a/viewer/src/game/round_runner.rs
+++ b/viewer/src/game/round_runner.rs
@@ -156,14 +156,17 @@ pub fn set_auto_round_running(enabled: bool) {
         if enabled {
             if control.running.swap(true, Ordering::SeqCst) {
                 set_dom_runner_active(true);
+                sync_auto_round_ui(true);
                 return;
             }
             control.game_ended.store(false, Ordering::SeqCst);
             set_dom_runner_active(true);
+            sync_auto_round_ui(true);
             spawn_round_loop(control);
         } else {
             control.running.store(false, Ordering::SeqCst);
             set_dom_runner_active(false);
+            sync_auto_round_ui(false);
             release_round_flight("auto");
             log::info!("RoundRunner: auto round loop stopped by UI");
         }
@@ -279,6 +282,7 @@ fn spawn_round_loop(control: RoundRunnerControl) {
 
         running.store(false, Ordering::SeqCst);
         set_dom_runner_active(false);
+        sync_auto_round_ui(false);
         log::info!(
             "RoundRunner: loop finished (rounds={}, ended={})",
             round_num,
@@ -347,7 +351,7 @@ fn build_round_body(dm_keeper_fallback: &str) -> Result<String, String> {
 
     // 1) DM keeper: explicit round-run field > claimed keeper > new-game picker > ECS snapshot.
     let dm_keeper = read_dom_input("round-run-dm")
-        .or_else(|| read_dom_input("claimed-keeper"))
+        .or_else(read_claimed_keeper_for_current_room)
         .or_else(|| read_dom_input("new-game-dm-select"))
         .or_else(|| {
             let fallback = dm_keeper_fallback.trim();
@@ -419,6 +423,21 @@ fn read_dom_input(id: &str) -> Option<String> {
 }
 
 #[cfg(target_arch = "wasm32")]
+fn claim_matches_current_room() -> bool {
+    let claimed_room = read_dom_input("claimed-room-id").unwrap_or_default();
+    !claimed_room.is_empty() && claimed_room == config::current_room_id()
+}
+
+#[cfg(target_arch = "wasm32")]
+fn read_claimed_keeper_for_current_room() -> Option<String> {
+    if claim_matches_current_room() {
+        read_dom_input("claimed-keeper")
+    } else {
+        None
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
 fn round_response_advanced(resp: &str) -> Option<bool> {
     let parsed = serde_json::from_str::<serde_json::Value>(resp).ok()?;
     parsed
@@ -481,6 +500,32 @@ fn set_dom_runner_active(active: bool) {
         return;
     };
     let _ = dashboard.set_attribute("data-round-runner-active", if active { "1" } else { "0" });
+}
+
+#[cfg(target_arch = "wasm32")]
+fn sync_auto_round_ui(enabled: bool) {
+    let Some(document) = web_sys::window().and_then(|w| w.document()) else {
+        return;
+    };
+    if let Some(dashboard) = document.get_element_by_id("dashboard") {
+        let _ = dashboard.set_attribute("data-auto-round", if enabled { "1" } else { "0" });
+    }
+    if let Some(button) = document.get_element_by_id("auto-round-toggle") {
+        button.set_text_content(Some(if enabled {
+            "자동 진행: ON"
+        } else {
+            "자동 진행: OFF"
+        }));
+        let _ = button.set_attribute("aria-pressed", if enabled { "true" } else { "false" });
+        let _ = button.set_attribute(
+            "title",
+            if enabled {
+                "AI 턴 자동 진행을 멈춥니다"
+            } else {
+                "AI 턴 자동 진행을 시작합니다"
+            },
+        );
+    }
 }
 
 #[cfg(target_arch = "wasm32")]

--- a/viewer/src/game/state.rs
+++ b/viewer/src/game/state.rs
@@ -17,11 +17,11 @@ pub enum TurnPhase {
 impl TurnPhase {
     pub fn from_str(s: &str) -> Self {
         match s {
-            "dm_narration" => Self::DmNarration,
-            "party_discussion" => Self::PartyDiscussion,
-            "action_declaration" => Self::ActionDeclaration,
-            "dice_resolution" => Self::DiceResolution,
-            "outcome_narration" => Self::OutcomeNarration,
+            "dm_narration" | "briefing" => Self::DmNarration,
+            "party_discussion" | "round" | "discuss" => Self::PartyDiscussion,
+            "action_declaration" | "action" => Self::ActionDeclaration,
+            "dice_resolution" | "dice" => Self::DiceResolution,
+            "outcome_narration" | "outcome" => Self::OutcomeNarration,
             "state_update" => Self::StateUpdate,
             "transition" => Self::Transition,
             _ => Self::DmNarration,

--- a/viewer/src/mode/mod.rs
+++ b/viewer/src/mode/mod.rs
@@ -466,9 +466,13 @@ fn bind_session_pause_controls(doc: &web_sys::Document) {
 
                 let doc_async = doc_for_pause.clone();
                 wasm_bindgen_futures::spawn_local(async move {
+                    let room_id = crate::config::current_room_id();
                     match post_tool_action(
                         "masc_pause",
-                        json!({ "reason": "viewer trpg manual pause" }),
+                        json!({
+                            "room_id": room_id,
+                            "reason": "viewer trpg manual pause"
+                        }),
                     )
                     .await
                     {
@@ -517,7 +521,8 @@ fn bind_session_pause_controls(doc: &web_sys::Document) {
 
                 let doc_async = doc_for_resume.clone();
                 wasm_bindgen_futures::spawn_local(async move {
-                    match post_tool_action("masc_resume", json!({})).await {
+                    let room_id = crate::config::current_room_id();
+                    match post_tool_action("masc_resume", json!({ "room_id": room_id })).await {
                         Ok(raw) => {
                             let status = if raw.is_empty() {
                                 "세션 재개 완료".to_string()
@@ -1611,6 +1616,11 @@ fn apply_room_switch_from_ui(doc: &web_sys::Document, raw_room: &str) {
     };
     remember_known_rooms(std::slice::from_ref(&room));
     set_current_room_id(doc, &room);
+    if let Some(dashboard) = doc.get_element_by_id("dashboard") {
+        let _ = dashboard.set_attribute("data-auto-round", "0");
+    }
+    render_auto_round_toggle(doc);
+    crate::game::round_runner::set_auto_round_running(false);
     clear_trpg_dom(doc);
     sync_room_hub_selection(doc, &room);
     let doc_for_refresh = doc.clone();

--- a/viewer/src/mode/trpg_controls.rs
+++ b/viewer/src/mode/trpg_controls.rs
@@ -1094,20 +1094,29 @@ async fn refresh_keeper_selectors(doc: &web_sys::Document) -> Result<Vec<String>
         if !dm_from_ui.is_empty() {
             fallback.push(dm_from_ui);
         }
-        if let Some(claimed) = doc.get_element_by_id("claimed-keeper") {
-            if let Some(input) = claimed.dyn_ref::<web_sys::HtmlInputElement>() {
-                let value = input.value().trim().to_string();
-                if !value.is_empty() {
-                    fallback.push(value);
+        let current_room = read_new_game_room_id(doc);
+        let claimed_room = doc
+            .get_element_by_id("claimed-room-id")
+            .and_then(|el| el.dyn_ref::<web_sys::HtmlInputElement>().map(|i| i.value()))
+            .unwrap_or_default()
+            .trim()
+            .to_string();
+        if claimed_room == current_room {
+            if let Some(claimed) = doc.get_element_by_id("claimed-keeper") {
+                if let Some(input) = claimed.dyn_ref::<web_sys::HtmlInputElement>() {
+                    let value = input.value().trim().to_string();
+                    if !value.is_empty() {
+                        fallback.push(value);
+                    }
                 }
-            }
-            let text = claimed
-                .text_content()
-                .unwrap_or_default()
-                .trim()
-                .to_string();
-            if !text.is_empty() {
-                fallback.push(text);
+                let text = claimed
+                    .text_content()
+                    .unwrap_or_default()
+                    .trim()
+                    .to_string();
+                if !text.is_empty() {
+                    fallback.push(text);
+                }
             }
         }
         keepers = unique_non_empty(fallback);

--- a/viewer/style.css
+++ b/viewer/style.css
@@ -488,6 +488,12 @@ body:not(.mode-trpg) #ops-hud {
     gap: 6px;
 }
 
+.session-control-inline {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+}
+
 .inline-select {
     font-size: 10px;
     padding: 2px 6px;
@@ -564,6 +570,26 @@ body:not(.mode-trpg) #ops-hud {
 .widget-pill[data-lifecycle="state-ended"],
 .widget-pill[data-lifecycle="state-unavailable"] {
     border-color: rgba(177, 116, 116, 0.32);
+    color: var(--status-disconnected);
+}
+
+.widget-pill.status-info {
+    border-color: rgba(109, 122, 164, 0.45);
+    color: var(--text-primary);
+}
+
+.widget-pill.status-ok {
+    border-color: rgba(88, 184, 116, 0.42);
+    color: var(--status-connected);
+}
+
+.widget-pill.status-warn {
+    border-color: rgba(168, 119, 45, 0.42);
+    color: var(--status-connecting);
+}
+
+.widget-pill.status-error {
+    border-color: rgba(177, 116, 116, 0.5);
     color: var(--status-disconnected);
 }
 


### PR DESCRIPTION
Handle server-sent turn phases (round, discuss, action, dice, outcome) by mapping them to viewer TurnPhase enum.