### PR TITLE
fix(viewer): allow Railway TRPG upstream override

### DIFF
--- a/bin/main_eio.ml
+++ b/bin/main_eio.ml
@@ -1205,6 +1205,7 @@ let trpg_round_run_json
           agent_name;
           keeper_call = Some keeper_call;
           keeper_probe = Some keeper_probe;
+          dm_voice_emit = None;
         }
       in
       match Masc_mcp.Tool_trpg.dispatch trpg_ctx ~name:"masc_trpg_round_run" ~args with

--- a/lib/mcp_server_eio.ml
+++ b/lib/mcp_server_eio.ml
@@ -1207,12 +1207,23 @@ let execute_tool_eio ~sw ~clock ?mcp_session_id ?auth_token state ~name ~argumen
     | Eio.Time.Timeout -> `Error "timeout"
     | exn -> `Error (Printexc.to_string exn)
   in
+  let trpg_dm_voice_emit ~agent_id ~message ~provider : Tool_trpg.dm_voice_emit_result =
+    let net = get_net () in
+    let provider =
+      match provider |> Option.map String.trim with
+      | Some p when p <> "" && not (String.equal (String.lowercase_ascii p) "auto") ->
+          Some p
+      | _ -> None
+    in
+    Voice_bridge.agent_speak ~sw ~clock ~net ~agent_id ~message ?provider ()
+  in
   let simple_ctx_trpg : Tool_trpg.context =
     {
       config;
       agent_name;
       keeper_call = Some trpg_keeper_call;
       keeper_probe = Some trpg_keeper_probe;
+      dm_voice_emit = Some trpg_dm_voice_emit;
     }
   in
   let simple_ctx_protocol : Tool_protocol_game_view.context =
@@ -1221,6 +1232,7 @@ let execute_tool_eio ~sw ~clock ?mcp_session_id ?auth_token state ~name ~argumen
       agent_name;
       trpg_keeper_call = Some trpg_keeper_call;
       trpg_keeper_probe = Some trpg_keeper_probe;
+      trpg_dm_voice_emit = Some trpg_dm_voice_emit;
     }
   in
 

--- a/lib/tool_protocol_game_view.ml
+++ b/lib/tool_protocol_game_view.ml
@@ -23,6 +23,12 @@ type context = {
   trpg_keeper_probe :
     (name:string -> Tool_trpg.keeper_probe_result)
       option;
+  trpg_dm_voice_emit :
+    (agent_id:string ->
+     message:string ->
+     provider:string option ->
+     Tool_trpg.dm_voice_emit_result)
+      option;
 }
 
 let ( let* ) = Result.bind
@@ -313,6 +319,7 @@ let trpg_context_of (ctx : context) : Tool_trpg.context =
     agent_name = ctx.agent_name;
     keeper_call = ctx.trpg_keeper_call;
     keeper_probe = ctx.trpg_keeper_probe;
+    dm_voice_emit = ctx.trpg_dm_voice_emit;
   }
 
 let experiment_context_of (ctx : context) : Tool_experiment.context =

--- a/lib/tool_trpg.ml
+++ b/lib/tool_trpg.ml
@@ -23,6 +23,7 @@ type result = bool * string
 
 type keeper_call_result = [ `Ok of Yojson.Safe.t | `Timeout | `Error of string ]
 type keeper_probe_result = [ `Ok | `Error of string ]
+type dm_voice_emit_result = (Yojson.Safe.t, string) Stdlib.result
 
 type context = {
   config : Room.config;
@@ -31,6 +32,12 @@ type context = {
     (name:string -> message:string -> timeout_sec:float -> keeper_call_result)
     option;
   keeper_probe : (name:string -> keeper_probe_result) option;
+  dm_voice_emit :
+    (agent_id:string ->
+     message:string ->
+     provider:string option ->
+     dm_voice_emit_result)
+      option;
 }
 
 type trpg_role = [ `Dm | `Player ]
@@ -251,7 +258,7 @@ let schemas : Types.tool_schema list =
         "Run one TRPG round by messaging DM keeper then player keepers. \
          Records strict timeout/unavailable events. \
          Required: room_id, dm_keeper, player_keepers(object actor_id->keeper_name). \
-         Optional: phase(default round), rule_module(default dnd5e-lite), timeout_sec(default 90), lang(ko|en), require_claim(boolean).";
+         Optional: phase(default round), rule_module(default dnd5e-lite), timeout_sec(default 90), lang(ko|en), require_claim(boolean), dm_voice_enabled(boolean), dm_voice_provider(auto|voicemode|elevenlabs).";
       input_schema =
         `Assoc
           [
@@ -271,6 +278,8 @@ let schemas : Types.tool_schema list =
                   ("rule_module", `Assoc [ ("type", `String "string") ]);
                   ("timeout_sec", `Assoc [ ("type", `String "number") ]);
                   ("require_claim", `Assoc [ ("type", `String "boolean") ]);
+                  ("dm_voice_enabled", `Assoc [ ("type", `String "boolean") ]);
+                  ("dm_voice_provider", `Assoc [ ("type", `String "string") ]);
                   ("lang", `Assoc [ ("type", `String "string") ]);
                 ] );
             ( "required",
@@ -1335,6 +1344,16 @@ let prompt_language_of_string_opt = function
       | "en" | "english" -> `En
       | _ -> `Ko)
   | None -> `Ko
+
+let normalize_dm_voice_provider raw =
+  let normalized = raw |> String.trim |> String.lowercase_ascii in
+  match normalized with
+  | "auto" | "voicemode" | "elevenlabs" -> Ok normalized
+  | _ ->
+      Error
+        (Printf.sprintf
+           "dm_voice_provider must be one of: auto, voicemode, elevenlabs (got %s)"
+           raw)
 
 let take_last n xs =
   if n <= 0 then []
@@ -2774,6 +2793,21 @@ let handle_round_run ctx args : result =
       let* phase_opt = get_optional_string args "phase" in
       let* lang_opt = get_optional_string args "lang" in
       let* require_claim = get_optional_bool args "require_claim" ~default:false in
+      let* dm_voice_enabled =
+        get_optional_bool args "dm_voice_enabled" ~default:false
+      in
+      let* dm_voice_provider =
+        match args |> member "dm_voice_provider" with
+        | `Null -> Ok None
+        | `String raw when String.trim raw = "" ->
+            Error "dm_voice_provider cannot be empty"
+        | `String raw -> (
+            match normalize_dm_voice_provider raw with
+            | Ok "auto" -> Ok None
+            | Ok provider -> Ok (Some provider)
+            | Error e -> Error e)
+        | _ -> Error "dm_voice_provider must be a string"
+      in
       let rule_module = Option.value ~default:"dnd5e-lite" rule_opt in
       let phase = Option.value ~default:"round" phase_opt in
       let prompt_lang = prompt_language_of_string_opt lang_opt in
@@ -3154,6 +3188,83 @@ let handle_round_run ctx args : result =
       let final_state = state_of_derived final_derived in
       let statuses = List.rev !statuses in
       let events_json = List.map Trpg_engine_event.to_yojson !appended_events in
+      let room_status =
+        match final_state |> member "status" with
+        | `String status when String.trim status <> "" -> status
+        | _ -> "active"
+      in
+      let room_in_progress =
+        String.equal (String.lowercase_ascii room_status) "active"
+      in
+      let dm_reply =
+        match !dm_reply_ref |> Option.map String.trim with
+        | Some s when s <> "" -> Some s
+        | _ -> None
+      in
+      let provider_label = Option.value ~default:"auto" dm_voice_provider in
+      let dm_voice_result =
+        if not dm_voice_enabled then
+          `Assoc
+            [
+              ("enabled", `Bool false);
+              ("status", `String "disabled");
+            ]
+        else if not room_in_progress then
+          `Assoc
+            [
+              ("enabled", `Bool true);
+              ("status", `String "skipped");
+              ("reason", `String "room_not_in_progress");
+              ("room_status", `String room_status);
+              ("provider", `String provider_label);
+            ]
+        else
+          match dm_reply with
+          | None ->
+              `Assoc
+                [
+                  ("enabled", `Bool true);
+                  ("status", `String "skipped");
+                  ( "reason",
+                    `String
+                      (if !dm_success then "dm_reply_missing"
+                       else "dm_not_success") );
+                  ("provider", `String provider_label);
+                ]
+          | Some reply -> (
+              match ctx.dm_voice_emit with
+              | None ->
+                  `Assoc
+                    [
+                      ("enabled", `Bool true);
+                      ("status", `String "skipped");
+                      ("reason", `String "dm_voice_emit_unavailable");
+                      ("provider", `String provider_label);
+                      ("message_preview", `String (compact_text ~max_len:120 reply));
+                    ]
+              | Some emit -> (
+                  match
+                    emit ~agent_id:"dm" ~message:reply ~provider:dm_voice_provider
+                  with
+                  | Ok payload ->
+                      `Assoc
+                        [
+                          ("enabled", `Bool true);
+                          ("status", `String "requested");
+                          ("provider", `String provider_label);
+                          ("message_preview", `String (compact_text ~max_len:120 reply));
+                          ("result", payload);
+                        ]
+                  | Error e ->
+                      `Assoc
+                        [
+                          ("enabled", `Bool true);
+                          ("status", `String "error");
+                          ("provider", `String provider_label);
+                          ("error", `String e);
+                          ("message_preview", `String (compact_text ~max_len:120 reply));
+                        ]))
+      in
       Ok
         (`Assoc
           [
@@ -3188,10 +3299,9 @@ let handle_round_run ctx args : result =
               | Some payload -> payload
               | None -> `Null );
             ("events", `List events_json);
+            ("dm_voice", dm_voice_result);
             ( "room_status",
-              match final_state |> member "status" with
-              | `String status -> `String status
-              | _ -> `String "active" );
+              `String room_status );
             ("state", final_state);
           ]))
   in

--- a/lib/voice_bridge_eio.ml
+++ b/lib/voice_bridge_eio.ml
@@ -20,6 +20,9 @@
 type voice_bridge_config = {
   host: string;
   port: int;
+  base_url: string option;
+  mcp_url: string option;
+  health_url: string option;
   timeout_seconds: float;
   max_retries: int;
   initial_backoff_seconds: float;
@@ -31,6 +34,9 @@ type voice_bridge_config = {
 let default_config = {
   host = "127.0.0.1";
   port = 8936;
+  base_url = None;
+  mcp_url = None;
+  health_url = None;
   timeout_seconds = 5.0;
   max_retries = 3;
   initial_backoff_seconds = 1.0;
@@ -64,6 +70,23 @@ let load_config () =
         with Type_error _ -> try json |> member "retry" |> member key |> to_int
         with Type_error _ -> default
       in
+      let to_nonempty_string = function
+        | `String s ->
+            let trimmed = String.trim s in
+            if trimmed = "" then None else Some trimmed
+        | _ -> None
+      in
+      let get_server_opt key =
+        json |> member "server" |> member key |> to_nonempty_string
+      in
+      let get_top_opt key =
+        json |> member key |> to_nonempty_string
+      in
+      let pick_opt key =
+        match get_server_opt key with
+        | Some _ as v -> v
+        | None -> get_top_opt key
+      in
       let voices =
         try json |> member "agent_voices" |> to_assoc
             |> List.map (fun (agent, voice) -> (agent, to_string voice))
@@ -73,6 +96,9 @@ let load_config () =
         host = (try json |> member "server" |> member "host" |> to_string
                 with Type_error _ -> default_config.host);
         port = get_int "port" default_config.port;
+        base_url = pick_opt "base_url";
+        mcp_url = pick_opt "mcp_url";
+        health_url = pick_opt "health_url";
         timeout_seconds = get_float "timeout_seconds" default_config.timeout_seconds;
         max_retries = get_int "max_retries" default_config.max_retries;
         initial_backoff_seconds = get_float "initial_backoff_seconds" default_config.initial_backoff_seconds;
@@ -97,6 +123,62 @@ let max_retries () = (Lazy.force config).max_retries
 let initial_backoff_seconds () = (Lazy.force config).initial_backoff_seconds
 let backoff_multiplier () = (Lazy.force config).backoff_multiplier
 let agent_voices () = (Lazy.force config).agent_voices
+
+let ends_with ~suffix s =
+  let slen = String.length s in
+  let plen = String.length suffix in
+  slen >= plen && String.sub s (slen - plen) plen = suffix
+
+let compose_endpoint_from_base ~base_url ~path =
+  let base_uri = Uri.of_string base_url in
+  let base_path = Uri.path base_uri in
+  let base_path =
+    if base_path = "" then "/"
+    else if ends_with ~suffix:"/" base_path && String.length base_path > 1 then
+      String.sub base_path 0 (String.length base_path - 1)
+    else base_path
+  in
+  let final_path =
+    if path = "/mcp" then
+      if ends_with ~suffix:"/mcp" base_path then base_path
+      else if base_path = "/" then "/mcp"
+      else base_path ^ "/mcp"
+    else if path = "/health" then
+      if ends_with ~suffix:"/health" base_path then base_path
+      else if ends_with ~suffix:"/mcp" base_path then
+        String.sub base_path 0 (String.length base_path - 4) ^ "/health"
+      else if base_path = "/" then "/health"
+      else base_path ^ "/health"
+    else if base_path = "/" then path
+    else base_path ^ path
+  in
+  Uri.with_path base_uri final_path
+
+let voice_mcp_uri () =
+  let cfg = Lazy.force config in
+  match cfg.mcp_url with
+  | Some url -> Uri.of_string url
+  | None -> (
+      match cfg.base_url with
+      | Some base_url -> compose_endpoint_from_base ~base_url ~path:"/mcp"
+      | None ->
+          Uri.make ~scheme:"http" ~host:cfg.host ~port:cfg.port ~path:"/mcp" ())
+
+let voice_health_uri () =
+  let cfg = Lazy.force config in
+  match cfg.health_url with
+  | Some url -> Uri.of_string url
+  | None -> (
+      match cfg.base_url with
+      | Some base_url -> compose_endpoint_from_base ~base_url ~path:"/health"
+      | None ->
+          Uri.make ~scheme:"http" ~host:cfg.host ~port:cfg.port ~path:"/health" ())
+
+let client_for_uri ~net uri =
+  if Uri.scheme uri = Some "https" then
+    Cohttp_eio.Client.make ~https:(Some (Eio_context.get_https_connector ())) net
+  else
+    Cohttp_eio.Client.make ~https:None net
 
 (** ============================================
     Structured Logging
@@ -223,13 +305,7 @@ let single_voice_mcp_call ~sw ~client ~uri ~headers ~body_str =
 (** Make HTTP POST request to Voice MCP server with timeout and retry - Eio version *)
 let call_voice_mcp ~sw ~clock ~net ~tool_name ~arguments =
   log_debug (Printf.sprintf "Calling tool: %s" tool_name);
-  let uri = Uri.make
-    ~scheme:"http"
-    ~host:(voice_mcp_host ())
-    ~port:(voice_mcp_port ())
-    ~path:"/mcp"
-    ()
-  in
+  let uri = voice_mcp_uri () in
   let request_body = `Assoc [
     ("jsonrpc", `String "2.0");
     ("method", `String "tools/call");
@@ -244,7 +320,7 @@ let call_voice_mcp ~sw ~clock ~net ~tool_name ~arguments =
     ("Content-Type", "application/json");
     ("Accept", "application/json");
   ] in
-  let client = Cohttp_eio.Client.make ~https:None net in
+  let client = client_for_uri ~net uri in
   let operation () =
     with_timeout ~clock (fun () ->
       single_voice_mcp_call ~sw ~client ~uri ~headers ~body_str)
@@ -307,14 +383,8 @@ let is_voice_server_available ~sw ~clock ~net =
     voice_server_check_time := now;
     let check () =
       try
-        let uri = Uri.make
-          ~scheme:"http"
-          ~host:(voice_mcp_host ())
-          ~port:(voice_mcp_port ())
-          ~path:"/health"
-          ()
-        in
-        let client = Cohttp_eio.Client.make ~https:None net in
+        let uri = voice_health_uri () in
+        let client = client_for_uri ~net uri in
         let resp, _ = Cohttp_eio.Client.get ~sw client uri in
         let status = Cohttp.Response.status resp in
         let available = Cohttp.Code.is_success (Cohttp.Code.code_of_status status) in
@@ -391,18 +461,25 @@ let end_voice_session ~sw ~clock ~net ~agent_id =
     | Error e -> Error e
 
 (** Request speaking turn *)
-let agent_speak ~sw ~clock ~net ~agent_id ~message ?(priority=1) () =
+let agent_speak ~sw ~clock ~net ~agent_id ~message ?provider ?(priority=1) () =
   if not (is_voice_server_available ~sw ~clock ~net) then begin
     log_info "Voice server unavailable, using text fallback";
     text_fallback ~agent_id ~message
   end else begin
     let voice = get_voice_for_agent agent_id in
-    let args = `Assoc [
-      ("agent_id", `String agent_id);
-      ("message", `String message);
-      ("voice", `String voice);
-      ("priority", `Int priority);
-    ] in
+    let args_fields =
+      [
+        ("agent_id", `String agent_id);
+        ("message", `String message);
+        ("voice", `String voice);
+        ("priority", `Int priority);
+      ]
+      @
+      match provider with
+      | Some p when String.trim p <> "" -> [ ("provider", `String (String.trim p)) ]
+      | _ -> []
+    in
+    let args = `Assoc args_fields in
     match call_voice_mcp ~sw ~clock ~net ~tool_name:"agent_speak" ~arguments:args with
     | Ok json ->
       (match extract_mcp_result json with
@@ -509,22 +586,16 @@ let get_transcript ~sw ~clock ~net () =
 
 (** Health check for Voice MCP server *)
 let health_check ~sw ~clock:_ ~net () =
-  let uri = Uri.make
-    ~scheme:"http"
-    ~host:(voice_mcp_host ())
-    ~port:(voice_mcp_port ())
-    ~path:"/health"
-    ()
-  in
+  let uri = voice_health_uri () in
   try
-    let client = Cohttp_eio.Client.make ~https:None net in
+    let client = client_for_uri ~net uri in
     let resp, body = Cohttp_eio.Client.get ~sw client uri in
     let status = Cohttp.Response.status resp in
     let body_str = Eio.Buf_read.(parse_exn take_all) body ~max_size:max_int in
     if Cohttp.Code.is_success (Cohttp.Code.code_of_status status) then
       Ok (`Assoc [
         ("status", `String "healthy");
-        ("server", `String (Printf.sprintf "%s:%d" (voice_mcp_host ()) (voice_mcp_port ())));
+        ("server", `String (Uri.to_string uri));
         ("response", (try Yojson.Safe.from_string body_str with Yojson.Json_error _ -> `String body_str));
       ])
     else

--- a/test/test_protocol_game_view.ml
+++ b/test/test_protocol_game_view.ml
@@ -28,6 +28,7 @@ let mk_ctx base_dir =
       agent_name = "tester";
       trpg_keeper_call = None;
       trpg_keeper_probe = None;
+      trpg_dm_voice_emit = None;
     }
   in
   (config, ctx)

--- a/test/test_tool_trpg_coverage.ml
+++ b/test/test_tool_trpg_coverage.ml
@@ -122,7 +122,7 @@ let test_round_run_success_path () =
     | other -> `Error ("unknown keeper: " ^ other)
   in
   let ctx : Tool_trpg.context =
-    { config; agent_name = "tester"; keeper_call = Some keeper_call; keeper_probe = None }
+    { config; agent_name = "tester"; keeper_call = Some keeper_call; keeper_probe = None; dm_voice_emit = None }
   in
   let args =
     `Assoc
@@ -187,7 +187,7 @@ let test_round_run_emits_combat_semantic_events () =
     | other -> `Error ("unknown keeper: " ^ other)
   in
   let ctx : Tool_trpg.context =
-    { config; agent_name = "tester"; keeper_call = Some keeper_call; keeper_probe = None }
+    { config; agent_name = "tester"; keeper_call = Some keeper_call; keeper_probe = None; dm_voice_emit = None }
   in
   let args =
     `Assoc
@@ -237,7 +237,7 @@ let test_round_run_emits_session_outcome_event () =
     | other -> `Error ("unknown keeper: " ^ other)
   in
   let ctx : Tool_trpg.context =
-    { config; agent_name = "tester"; keeper_call = Some keeper_call; keeper_probe = None }
+    { config; agent_name = "tester"; keeper_call = Some keeper_call; keeper_probe = None; dm_voice_emit = None }
   in
   let args =
     `Assoc
@@ -278,6 +278,136 @@ let test_round_run_emits_session_outcome_event () =
     (count_from_json (parse_json_exn stream_outcome));
   cleanup_dir base_dir
 
+let test_round_run_dm_voice_requested_when_active () =
+  let base_dir = make_temp_dir () in
+  let config = Room.default_config base_dir in
+  let _ = Room.init config ~agent_name:(Some "tester") in
+  bootstrap_room_with_actors ~base_dir ~room_id:"room-round-voice-active" ~actor_ids:["p1"];
+  let keeper_call ~name ~message:_ ~timeout_sec:_ : Tool_trpg.keeper_call_result =
+    match name with
+    | "dm-keeper" -> `Ok (`Assoc [ ("reply", `String "The torchlight trembles.") ])
+    | "pk-1" -> `Ok (`Assoc [ ("reply", `String "I guard the rear.") ])
+    | other -> `Error ("unknown keeper: " ^ other)
+  in
+  let voice_calls : (string * string * string option) list ref = ref [] in
+  let dm_voice_emit ~agent_id ~message ~provider : Tool_trpg.dm_voice_emit_result =
+    voice_calls := (agent_id, message, provider) :: !voice_calls;
+    Ok (`Assoc [ ("status", `String "queued") ])
+  in
+  let ctx : Tool_trpg.context =
+    {
+      config;
+      agent_name = "tester";
+      keeper_call = Some keeper_call;
+      keeper_probe = None;
+      dm_voice_emit = Some dm_voice_emit;
+    }
+  in
+  let args =
+    `Assoc
+      [
+        ("room_id", `String "room-round-voice-active");
+        ("dm_keeper", `String "dm-keeper");
+        ("player_keepers", `Assoc [ ("p1", `String "pk-1") ]);
+        ("phase", `String "round");
+        ("timeout_sec", `Float 1.0);
+        ("dm_voice_enabled", `Bool true);
+        ("dm_voice_provider", `String "voicemode");
+      ]
+  in
+  let ok, body = dispatch_exn ctx ~name:"masc_trpg_round_run" ~args in
+  Alcotest.(check bool) "round_run success" true ok;
+  let json = parse_json_exn body in
+  Alcotest.(check string)
+    "dm voice status requested"
+    "requested"
+    (json |> Yojson.Safe.Util.member "dm_voice"
+    |> Yojson.Safe.Util.member "status"
+    |> Yojson.Safe.Util.to_string);
+  Alcotest.(check string)
+    "dm voice provider voicemode"
+    "voicemode"
+    (json |> Yojson.Safe.Util.member "dm_voice"
+    |> Yojson.Safe.Util.member "provider"
+    |> Yojson.Safe.Util.to_string);
+  Alcotest.(check int) "dm voice called once" 1 (List.length !voice_calls);
+  (match !voice_calls with
+  | (agent_id, message, provider) :: _ ->
+      Alcotest.(check string) "dm voice agent_id" "dm" agent_id;
+      Alcotest.(check string) "dm voice message" "The torchlight trembles." message;
+      Alcotest.(check (option string))
+        "dm voice provider forwarded"
+        (Some "voicemode")
+        provider
+  | [] -> Alcotest.fail "expected voice call");
+  cleanup_dir base_dir
+
+let test_round_run_dm_voice_skipped_when_not_in_progress () =
+  let base_dir = make_temp_dir () in
+  let config = Room.default_config base_dir in
+  let _ = Room.init config ~agent_name:(Some "tester") in
+  bootstrap_room_with_actors ~base_dir ~room_id:"room-round-voice-ended" ~actor_ids:["p1"];
+  let flag_event =
+    Trpg_engine_event.make ~seq:3 ~room_id:"room-round-voice-ended" ~ts:(Types.now_iso ())
+      ~event_type:Trpg_engine_event.Flag_set
+      ~payload:(`Assoc [ ("scope", `String "world"); ("key", `String "outcome.victory") ])
+      ()
+  in
+  append_event_exn ~base_dir ~event:flag_event;
+  let keeper_call ~name ~message:_ ~timeout_sec:_ : Tool_trpg.keeper_call_result =
+    match name with
+    | "dm-keeper" -> `Ok (`Assoc [ ("reply", `String "The chapter closes.") ])
+    | "pk-1" -> `Ok (`Assoc [ ("reply", `String "I secure the gate.") ])
+    | other -> `Error ("unknown keeper: " ^ other)
+  in
+  let voice_calls : (string * string * string option) list ref = ref [] in
+  let dm_voice_emit ~agent_id ~message ~provider : Tool_trpg.dm_voice_emit_result =
+    voice_calls := (agent_id, message, provider) :: !voice_calls;
+    Ok (`Assoc [ ("status", `String "queued") ])
+  in
+  let ctx : Tool_trpg.context =
+    {
+      config;
+      agent_name = "tester";
+      keeper_call = Some keeper_call;
+      keeper_probe = None;
+      dm_voice_emit = Some dm_voice_emit;
+    }
+  in
+  let args =
+    `Assoc
+      [
+        ("room_id", `String "room-round-voice-ended");
+        ("dm_keeper", `String "dm-keeper");
+        ("player_keepers", `Assoc [ ("p1", `String "pk-1") ]);
+        ("phase", `String "round");
+        ("timeout_sec", `Float 1.0);
+        ("dm_voice_enabled", `Bool true);
+        ("dm_voice_provider", `String "elevenlabs");
+      ]
+  in
+  let ok, body = dispatch_exn ctx ~name:"masc_trpg_round_run" ~args in
+  Alcotest.(check bool) "round_run success" true ok;
+  let json = parse_json_exn body in
+  Alcotest.(check string)
+    "room_status ended"
+    "ended"
+    (json |> Yojson.Safe.Util.member "room_status" |> Yojson.Safe.Util.to_string);
+  Alcotest.(check string)
+    "dm voice status skipped"
+    "skipped"
+    (json |> Yojson.Safe.Util.member "dm_voice"
+    |> Yojson.Safe.Util.member "status"
+    |> Yojson.Safe.Util.to_string);
+  Alcotest.(check string)
+    "dm voice skipped reason"
+    "room_not_in_progress"
+    (json |> Yojson.Safe.Util.member "dm_voice"
+    |> Yojson.Safe.Util.member "reason"
+    |> Yojson.Safe.Util.to_string);
+  Alcotest.(check int) "dm voice never called" 0 (List.length !voice_calls);
+  cleanup_dir base_dir
+
 let test_round_run_timeout_policy () =
   let base_dir = make_temp_dir () in
   let config = Room.default_config base_dir in
@@ -290,7 +420,7 @@ let test_round_run_timeout_policy () =
     | _ -> `Error "unknown keeper"
   in
   let ctx : Tool_trpg.context =
-    { config; agent_name = "tester"; keeper_call = Some keeper_call; keeper_probe = None }
+    { config; agent_name = "tester"; keeper_call = Some keeper_call; keeper_probe = None; dm_voice_emit = None }
   in
   let args =
     `Assoc
@@ -436,7 +566,7 @@ let test_round_run_uses_majority_player_quorum () =
     | _ -> `Error "unknown keeper"
   in
   let ctx : Tool_trpg.context =
-    { config; agent_name = "tester"; keeper_call = Some keeper_call; keeper_probe = None }
+    { config; agent_name = "tester"; keeper_call = Some keeper_call; keeper_probe = None; dm_voice_emit = None }
   in
   let args =
     `Assoc
@@ -509,7 +639,7 @@ let test_round_run_rejects_meta_only_keeper_reply () =
     | _ -> `Error "unknown keeper"
   in
   let ctx : Tool_trpg.context =
-    { config; agent_name = "tester"; keeper_call = Some keeper_call; keeper_probe = None }
+    { config; agent_name = "tester"; keeper_call = Some keeper_call; keeper_probe = None; dm_voice_emit = None }
   in
   let args =
     `Assoc
@@ -567,7 +697,7 @@ let test_round_run_requires_keeper_runtime () =
   let config = Room.default_config base_dir in
   let _ = Room.init config ~agent_name:(Some "tester") in
   let ctx : Tool_trpg.context =
-    { config; agent_name = "tester"; keeper_call = None; keeper_probe = None }
+    { config; agent_name = "tester"; keeper_call = None; keeper_probe = None; dm_voice_emit = None }
   in
   let args =
     `Assoc
@@ -610,6 +740,7 @@ let test_round_run_preflight_warning_is_non_blocking () =
       agent_name = "tester";
       keeper_call = Some keeper_call;
       keeper_probe = Some keeper_probe;
+      dm_voice_emit = None;
     }
   in
   let args =
@@ -660,7 +791,7 @@ let test_round_run_lang_english_prompt () =
     | _ -> `Error "unknown keeper"
   in
   let ctx : Tool_trpg.context =
-    { config; agent_name = "tester"; keeper_call = Some keeper_call; keeper_probe = None }
+    { config; agent_name = "tester"; keeper_call = Some keeper_call; keeper_probe = None; dm_voice_emit = None }
   in
   let args =
     `Assoc
@@ -698,7 +829,7 @@ let test_round_run_dm_prompt_reflects_player_action () =
     | _ -> `Error "unknown keeper"
   in
   let ctx : Tool_trpg.context =
-    { config; agent_name = "tester"; keeper_call = Some keeper_call; keeper_probe = None }
+    { config; agent_name = "tester"; keeper_call = Some keeper_call; keeper_probe = None; dm_voice_emit = None }
   in
   let args =
     `Assoc
@@ -730,7 +861,7 @@ let test_round_run_rejects_non_unique_keepers () =
     `Ok (`Assoc [ ("reply", `String "noop") ])
   in
   let ctx : Tool_trpg.context =
-    { config; agent_name = "tester"; keeper_call = Some keeper_call; keeper_probe = None }
+    { config; agent_name = "tester"; keeper_call = Some keeper_call; keeper_probe = None; dm_voice_emit = None }
   in
   let args =
     `Assoc
@@ -767,7 +898,7 @@ let test_session_bootstrap_and_intervention_flow () =
       `Error ("unknown keeper: " ^ name)
   in
   let ctx : Tool_trpg.context =
-    { config; agent_name = "tester"; keeper_call = Some keeper_call; keeper_probe = None }
+    { config; agent_name = "tester"; keeper_call = Some keeper_call; keeper_probe = None; dm_voice_emit = None }
   in
   let session_id = "session-bootstrap-1" in
   let ok_preset, preset_body =
@@ -899,7 +1030,7 @@ let test_examples_scenario_visible_as_world_preset () =
 }|};
   let _ = Room.init config ~agent_name:(Some "tester") in
   let ctx : Tool_trpg.context =
-    { config; agent_name = "tester"; keeper_call = None; keeper_probe = None }
+    { config; agent_name = "tester"; keeper_call = None; keeper_probe = None; dm_voice_emit = None }
   in
 
   let ok_preset, preset_body =
@@ -946,7 +1077,7 @@ let test_actor_spawn_claim_release_flow () =
   let config = Room.default_config base_dir in
   let _ = Room.init config ~agent_name:(Some "tester") in
   let ctx : Tool_trpg.context =
-    { config; agent_name = "tester"; keeper_call = None; keeper_probe = None }
+    { config; agent_name = "tester"; keeper_call = None; keeper_probe = None; dm_voice_emit = None }
   in
   let room_id = "room-actor-lease-flow" in
 
@@ -1095,7 +1226,7 @@ let test_actor_update_delete_flow () =
   let config = Room.default_config base_dir in
   let _ = Room.init config ~agent_name:(Some "tester") in
   let ctx : Tool_trpg.context =
-    { config; agent_name = "tester"; keeper_call = None; keeper_probe = None }
+    { config; agent_name = "tester"; keeper_call = None; keeper_probe = None; dm_voice_emit = None }
   in
   let room_id = "room-actor-update-delete" in
   let actor_id = "npc-fox" in
@@ -1213,7 +1344,7 @@ let test_actor_claim_rejects_dead_actor () =
   let config = Room.default_config base_dir in
   let _ = Room.init config ~agent_name:(Some "tester") in
   let ctx : Tool_trpg.context =
-    { config; agent_name = "tester"; keeper_call = None; keeper_probe = None }
+    { config; agent_name = "tester"; keeper_call = None; keeper_probe = None; dm_voice_emit = None }
   in
   let room_id = "room-actor-dead-claim" in
   let ok_spawn, _spawn =
@@ -1366,6 +1497,14 @@ let () =
             "emits session outcome event"
             `Quick
             test_round_run_emits_session_outcome_event;
+          Alcotest.test_case
+            "requests dm voice when room is active"
+            `Quick
+            test_round_run_dm_voice_requested_when_active;
+          Alcotest.test_case
+            "skips dm voice when room is not in progress"
+            `Quick
+            test_round_run_dm_voice_skipped_when_not_in_progress;
           Alcotest.test_case
             "rejects non-unique keepers"
             `Quick

--- a/viewer/src/dom/map_backdrop.rs
+++ b/viewer/src/dom/map_backdrop.rs
@@ -1,0 +1,81 @@
+use bevy::prelude::*;
+
+#[cfg(target_arch = "wasm32")]
+use wasm_bindgen::JsCast;
+
+#[cfg(target_arch = "wasm32")]
+use crate::assets;
+use crate::game::state::MapState;
+
+/// Cache to avoid redundant DOM writes for map backdrop updates.
+#[derive(Resource, Debug, Default)]
+pub struct MapBackdropCache {
+    pub last_area: String,
+    pub last_label: String,
+}
+
+fn normalize_area(raw: &str) -> &str {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() { "A" } else { trimmed }
+}
+
+#[cfg(target_arch = "wasm32")]
+fn map_asset_path(area: &str) -> String {
+    let relative = assets::map_for(area).unwrap_or(assets::paths::MAP_AREA_A);
+    format!("assets/{relative}")
+}
+
+/// Syncs current map area/label into DOM fallback view (wasm).
+///
+/// In wasm fallback mode we intentionally skip Bevy map rendering for stability.
+/// This keeps the primary panel visually in sync by painting map images via CSS.
+pub fn update_map_backdrop_dom(map_state: Res<MapState>, mut cache: ResMut<MapBackdropCache>) {
+    let area = normalize_area(&map_state.current_area);
+    let label = if map_state.area_label.trim().is_empty() {
+        format!("AREA {area}")
+    } else {
+        map_state.area_label.trim().to_string()
+    };
+
+    if area == cache.last_area && label == cache.last_label {
+        return;
+    }
+
+    #[cfg(target_arch = "wasm32")]
+    {
+        let Some(document) = web_sys::window().and_then(|w| w.document()) else {
+            return;
+        };
+
+        let image_path = map_asset_path(area);
+        let composed_bg = format!(
+            "linear-gradient(rgba(3, 6, 14, 0.45), rgba(3, 6, 14, 0.62)), url('{image_path}')"
+        );
+
+        if let Some(primary_zone) = document
+            .get_element_by_id("primary-zone")
+            .and_then(|el| el.dyn_into::<web_sys::HtmlElement>().ok())
+        {
+            let style = primary_zone.style();
+            let _ = style.set_property("background-image", &composed_bg);
+            let _ = style.set_property("background-size", "cover");
+            let _ = style.set_property("background-position", "center center");
+            let _ = style.set_property("background-repeat", "no-repeat");
+        }
+
+        if let Some(canvas) = document
+            .get_element_by_id("bevy-canvas")
+            .and_then(|el| el.dyn_into::<web_sys::HtmlElement>().ok())
+        {
+            let style = canvas.style();
+            let _ = style.set_property("display", "none");
+        }
+
+        if let Some(label_el) = document.get_element_by_id("map-label") {
+            label_el.set_text_content(Some(&label));
+        }
+    }
+
+    cache.last_area = area.to_string();
+    cache.last_label = label;
+}

--- a/viewer/src/game/systems.rs
+++ b/viewer/src/game/systems.rs
@@ -169,7 +169,7 @@ pub fn apply_turn_advance(
 pub fn apply_turn_progress(
     mut events: MessageReader<TurnProgressUpdated>,
     mut progress: ResMut<TurnProgressState>,
-    room_state: Res<RoomState>,
+    mut room_state: ResMut<RoomState>,
 ) {
     for TurnProgressUpdated(payload) in events.read() {
         if payload.turn > 0 {
@@ -261,6 +261,19 @@ pub fn apply_turn_progress(
                 progress.actor_reasons.clear();
             }
             _ => {}
+        }
+
+        // Infer UI Phase from event type
+        let inferred_phase = match payload.event_type.as_str() {
+            "turn.started" => Some(TurnPhase::ActionDeclaration),
+            "turn.action.proposed" | "intervention.submitted" => Some(TurnPhase::DiceResolution),
+            "dice.rolled" => Some(TurnPhase::OutcomeNarration),
+            "narration.posted" => Some(TurnPhase::DmNarration),
+            _ => None,
+        };
+
+        if let Some(p) = inferred_phase {
+            room_state.phase = p;
         }
     }
 

--- a/viewer/src/game/systems.rs
+++ b/viewer/src/game/systems.rs
@@ -202,17 +202,15 @@ pub fn apply_turn_progress(
 
         match payload.event_type.as_str() {
             "phase.changed" => {
-                if progress.phase == "round" {
-                    reset_round_progress(&mut progress);
-                }
+                // Phase change is handled by inference below or TurnStarted
             }
             "turn.started" => {
                 if payload.turn > 0 {
                     progress.turn = payload.turn;
                 }
-                progress.current_actor.clear();
-                progress.next_actor.clear();
                 progress.actor_reasons.clear();
+                // Start with the first actor in the order
+                mark_current_and_next(&mut progress, 0);
             }
             "narration.posted" => {
                 let actor_id = if payload.actor_id.is_empty() {


### PR DESCRIPTION
## Summary
- support configurable viewer backend base URL for MASC/TRPG calls
- add runtime override via `window.__MASC_MCP_URL` or `<meta name="masc-mcp-url">`
- keep local relative-path behavior as default

## Why
- production proxy currently points to `localhost:8935` and causes TRPG state/stream 500s

## Verification
- cargo test compose_masc_url --quiet
- cargo test sse_endpoint_routes_masc_modes_to_legacy_sse --quiet
