### PR TITLE
fix(viewer): unstick TRPG runtime panels and narrative flow

### DIFF
--- a/viewer/index.html
+++ b/viewer/index.html
@@ -462,12 +462,17 @@
                     <div id="narrative-log"></div>
                     <!-- Join Panel: claim an actor before playing -->
                     <div id="join-panel">
+                        <div id="join-help" class="join-help">
+                            참여를 누르면 선택한 캐릭터를 점유(Claim)하고, 해당 캐릭터 행동을 직접 입력할 수 있습니다.
+                        </div>
                         <div id="join-input-row">
                             <input type="text" id="actor-id-input"
                                    placeholder="캐릭터 ID (예: warrior-1)"
+                                   list="actor-id-suggestions"
                                    maxlength="100"
                                    autocomplete="off"
                                    title="참여할 캐릭터의 ID를 입력하세요" />
+                            <datalist id="actor-id-suggestions"></datalist>
                             <input type="text" id="keeper-input"
                                    placeholder="플레이어 이름"
                                    maxlength="100"
@@ -492,6 +497,7 @@
                             <button id="action-submit-btn" title="행동을 제출합니다">제출</button>
                             <button id="dice-roll-btn" title="1d20 주사위를 굴립니다">주사위</button>
                         </div>
+                        <div id="action-help" class="action-help">예: 주변 탐색, 파티 이동, NPC와 대화, 함정 해제, 공격 시도</div>
                         <div id="action-status"></div>
                         <div id="action-history" class="action-history"></div>
                         <input type="hidden" id="claimed-actor-id" value="" />

--- a/viewer/src/dom/actor_join.rs
+++ b/viewer/src/dom/actor_join.rs
@@ -11,6 +11,8 @@ use bevy::prelude::*;
 
 #[cfg(target_arch = "wasm32")]
 use wasm_bindgen::prelude::*;
+#[cfg(target_arch = "wasm32")]
+use wasm_bindgen::JsCast;
 
 #[cfg(target_arch = "wasm32")]
 use crate::config;
@@ -35,6 +37,7 @@ pub fn bind_actor_join(mut commands: Commands) {
         bind_join_button();
         bind_leave_button();
         restore_join_panel_state(); // Restore UI state from hidden inputs if available
+        sync_actor_suggestions();
         log::info!("ActorJoin: bound");
     }
 
@@ -69,13 +72,35 @@ pub fn sync_join_panel_interaction_state(
             return;
         };
 
+        let join_visible = doc
+            .get_element_by_id("join-panel")
+            .map(|panel| {
+                let inline = panel.get_attribute("style").unwrap_or_default();
+                !inline.to_ascii_lowercase().contains("display: none")
+            })
+            .unwrap_or(true);
+        if join_visible {
+            sync_actor_suggestions_for_doc(&doc);
+        }
+
         if let Some(btn) = doc.get_element_by_id("join-btn") {
             if can_join {
                 let _ = btn.remove_attribute("disabled");
-                let _ = btn.set_attribute("title", "Claim actor and join game");
+                let _ = btn.set_attribute("title", "캐릭터를 점유하고 수동 플레이를 시작합니다");
             } else {
                 let _ = btn.set_attribute("disabled", "true");
                 let _ = btn.set_attribute("title", lifecycle.help_text());
+            }
+        }
+
+        if join_visible {
+            if let Some(help) = doc.get_element_by_id("join-help") {
+                let text = if can_join {
+                    "참여를 누르면 선택한 캐릭터를 점유(Claim)하고, 해당 캐릭터 행동을 직접 입력할 수 있습니다."
+                } else {
+                    lifecycle.help_text()
+                };
+                help.set_text_content(Some(text));
             }
         }
     }
@@ -114,7 +139,10 @@ fn bind_join_button() {
         let keeper_name = keeper_input.map(|i| i.value()).unwrap_or_default();
 
         if actor_id.trim().is_empty() {
-            set_join_status("Actor ID is required", "status-error");
+            set_join_status(
+                "캐릭터 ID가 필요합니다. 오른쪽 PARTY에서 ID를 확인해 입력하세요.",
+                "status-error",
+            );
             return;
         }
 
@@ -122,20 +150,26 @@ fn bind_join_button() {
         if let Some(btn) = doc.get_element_by_id("join-btn") {
             let _ = btn.set_attribute("disabled", "true");
         }
-        set_join_status("Joining...", "");
+        set_join_status("캐릭터 점유 요청 중...", "");
 
         // 3. Spawn async claim request
         let actor_id_clone = actor_id.clone();
         wasm_bindgen_futures::spawn_local(async move {
             match claim_actor(&actor_id, &keeper_name).await {
                 Ok(_) => {
-                    set_join_status("Joined successfully", "status-ok");
+                    set_join_status(
+                        "점유 완료. 아래 액션 입력창에서 행동/주사위를 실행할 수 있습니다.",
+                        "status-ok",
+                    );
                     swap_to_action_panel(&actor_id_clone);
                 }
                 Err(e) => {
                     let detail = friendly_js_error(&e);
                     log::warn!("Claim failed: {:?}", detail);
-                    set_join_status(&format!("Join failed: {}", detail), "status-error");
+                    set_join_status(
+                        &format!("참여 실패: {}", friendly_claim_error(&detail)),
+                        "status-error",
+                    );
 
                     // Re-enable button on error
                     if let Some(doc) = web_sys::window().and_then(|w| w.document()) {
@@ -181,7 +215,7 @@ fn bind_leave_button() {
         // or rely on the stored hidden input.
         let claimed_id = get_claimed_actor_id_from_dom().unwrap_or_default();
         if claimed_id.is_empty() {
-            set_join_status("No active session to leave", "status-error");
+            set_join_status("현재 점유 중인 캐릭터가 없습니다.", "status-error");
             return;
         }
 
@@ -196,14 +230,17 @@ fn bind_leave_button() {
             match release_actor(&actor_id).await {
                 Ok(_) => {
                     swap_to_join_panel();
-                    set_join_status("Left game", "status-ok");
+                    set_join_status("점유를 해제했습니다.", "status-ok");
                 }
                 Err(e) => {
                     let detail = friendly_js_error(&e);
                     log::warn!("Release failed: {:?}", detail);
                     // Force leave on UI anyway? Or show error?
                     // Usually better to let them try again.
-                    set_join_status(&format!("Leave failed: {}", detail), "status-error");
+                    set_join_status(
+                        &format!("나가기 실패: {}", friendly_claim_error(&detail)),
+                        "status-error",
+                    );
 
                     if let Some(doc) = web_sys::window().and_then(|w| w.document()) {
                         if let Some(btn) = doc.get_element_by_id("leave-btn") {
@@ -509,4 +546,97 @@ fn restore_join_panel_state() {
 
     // Have claimed actor, show action panel
     swap_to_action_panel(&actor_id);
+}
+
+#[cfg(target_arch = "wasm32")]
+fn friendly_claim_error(raw: &str) -> String {
+    let text = raw.trim();
+    let lower = text.to_ascii_lowercase();
+    if lower.contains("already claimed") || lower.contains("already controlled") {
+        "이미 다른 keeper가 점유한 캐릭터입니다.".to_string()
+    } else if lower.contains("not found") || lower.contains("unknown actor") {
+        "캐릭터 ID를 찾을 수 없습니다.".to_string()
+    } else if lower.contains("room ended") || lower.contains("session ended") {
+        "종료된 세션에서는 참여할 수 없습니다.".to_string()
+    } else if lower.contains("unavailable") {
+        "현재 세션 상태에서는 참여할 수 없습니다.".to_string()
+    } else if text.is_empty() {
+        "알 수 없는 오류".to_string()
+    } else {
+        text.to_string()
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+fn sync_actor_suggestions() {
+    let Some(doc) = web_sys::window().and_then(|w| w.document()) else {
+        return;
+    };
+    sync_actor_suggestions_for_doc(&doc);
+}
+
+#[cfg(target_arch = "wasm32")]
+fn sync_actor_suggestions_for_doc(doc: &web_sys::Document) {
+    let Some(datalist) = doc.get_element_by_id("actor-id-suggestions") else {
+        return;
+    };
+    let Some(input) = doc
+        .get_element_by_id("actor-id-input")
+        .and_then(|el| el.dyn_into::<web_sys::HtmlInputElement>().ok())
+    else {
+        return;
+    };
+
+    let Ok(cards) = doc.query_selector_all("#character-panel .character-card[data-actor-id]") else {
+        return;
+    };
+
+    let mut ids = Vec::new();
+    for idx in 0..cards.length() {
+        let Some(node) = cards.item(idx) else {
+            continue;
+        };
+        let Some(el) = node.dyn_ref::<web_sys::Element>() else {
+            continue;
+        };
+        let actor_id = el
+            .get_attribute("data-actor-id")
+            .unwrap_or_default()
+            .trim()
+            .to_string();
+        if actor_id.is_empty() || actor_id.eq_ignore_ascii_case("dm") {
+            continue;
+        }
+        ids.push(actor_id);
+    }
+    ids.sort();
+    ids.dedup();
+
+    let placeholder = if let Some(first) = ids.first() {
+        format!("캐릭터 ID (예: {})", first)
+    } else {
+        "캐릭터 ID (오른쪽 PARTY 참고)".to_string()
+    };
+    if input.value().trim().is_empty() && input.placeholder() != placeholder {
+        input.set_placeholder(&placeholder);
+    }
+
+    let signature = ids.join("|");
+    if datalist
+        .get_attribute("data-actor-signature")
+        .map(|value| value == signature)
+        .unwrap_or(false)
+    {
+        return;
+    }
+
+    datalist.set_inner_html("");
+    for actor_id in ids.iter() {
+        let Ok(option) = doc.create_element("option") else {
+            continue;
+        };
+        let _ = option.set_attribute("value", actor_id);
+        let _ = datalist.append_child(&option);
+    }
+    let _ = datalist.set_attribute("data-actor-signature", &signature);
 }

--- a/viewer/src/dom/session_history.rs
+++ b/viewer/src/dom/session_history.rs
@@ -806,20 +806,9 @@ fn apply_history_focus(document: &web_sys::Document, room: Option<&str>, turn: O
             let Some(el) = node.dyn_ref::<web_sys::Element>() else {
                 continue;
             };
-            let turn_ok = match turn_key.as_deref() {
-                Some(target) => el
-                    .get_attribute("data-turn")
-                    .map(|value| value == target)
-                    .unwrap_or(false),
-                None => true,
-            };
-            if turn_ok {
-                let _ = el.class_list().remove_1("turn-dim");
-                let _ = el.class_list().add_1("turn-match");
-            } else {
-                let _ = el.class_list().remove_1("turn-match");
-                let _ = el.class_list().add_1("turn-dim");
-            }
+            // Keep main logs fully readable; focus state is reflected in history chips/panels.
+            let _ = el.class_list().remove_1("turn-dim");
+            let _ = el.class_list().remove_1("turn-match");
         }
     }
 

--- a/viewer/src/dom/turn_controls.rs
+++ b/viewer/src/dom/turn_controls.rs
@@ -569,6 +569,15 @@ fn on_advance_click() {
                 set_turn_status(&status, "status-warn");
                 set_turn_gate_reason(&format!("실행 보류: {}", status), "status-warn");
             }
+            Ok(RoundRunOutcome::InFlight { status }) => {
+                clear_round_recovery();
+                set_round_stall_badges(None);
+                set_turn_status(&status, "status-info");
+                set_turn_gate_reason(
+                    "실행 대기: 현재 라운드가 처리 중입니다. 완료 이벤트를 기다리세요.",
+                    "status-info",
+                );
+            }
             Err(e) => {
                 let detail = e.as_string().unwrap_or_else(|| format!("{:?}", e));
                 log::warn!("Advance turn failed: {}", detail);
@@ -594,6 +603,9 @@ enum RoundRunOutcome {
         status: String,
         has_warning: bool,
     },
+    InFlight {
+        status: String,
+    },
     Stalled {
         status: String,
         guide: String,
@@ -613,6 +625,31 @@ fn shorten_reason(raw: &str, max_chars: usize) -> String {
         .collect::<String>();
     truncated.push('…');
     truncated
+}
+
+#[cfg(target_arch = "wasm32")]
+fn is_round_in_flight_error(raw: &str) -> bool {
+    let lowered = raw.trim().to_ascii_lowercase();
+    lowered.contains("round run already in progress") || lowered.contains("single-flight")
+}
+
+#[cfg(target_arch = "wasm32")]
+fn is_keeper_busy_error(raw: &str) -> bool {
+    let lowered = raw.trim().to_ascii_lowercase();
+    lowered.contains("keeper busy")
+        || lowered.contains("can handle only one round at a time")
+        || lowered.contains("each spawned keeper can handle only one round")
+}
+
+#[cfg(target_arch = "wasm32")]
+fn transient_round_wait_message(raw: &str) -> Option<String> {
+    if is_round_in_flight_error(raw) {
+        return Some("이미 라운드 실행 중입니다. 이전 요청 완료를 기다리는 중입니다.".to_string());
+    }
+    if is_keeper_busy_error(raw) {
+        return Some("키퍼가 이전 라운드를 처리 중입니다. 잠시 후 자동으로 다시 진행됩니다.".to_string());
+    }
+    None
 }
 
 #[cfg(target_arch = "wasm32")]
@@ -816,6 +853,11 @@ async fn advance_turn() -> Result<RoundRunOutcome, JsValue> {
             .and_then(|v| v.as_string())
             .unwrap_or_default();
         let err_body = err_body.trim();
+        if let Some(wait_message) = transient_round_wait_message(err_body) {
+            return Ok(RoundRunOutcome::InFlight {
+                status: wait_message,
+            });
+        }
         if err_body.is_empty() {
             return Err(JsValue::from_str(&format!("HTTP {}", resp.status())));
         }
@@ -834,6 +876,22 @@ async fn advance_turn() -> Result<RoundRunOutcome, JsValue> {
     log::info!("TurnControls: round run response — {}", resp_text);
 
     if let Ok(json) = serde_json::from_str::<Value>(&resp_text) {
+        if json.get("ok").and_then(Value::as_bool) == Some(false) {
+            let detail = json
+                .get("error")
+                .or_else(|| json.get("message"))
+                .or_else(|| json.get("detail"))
+                .and_then(Value::as_str)
+                .map(str::trim)
+                .filter(|s| !s.is_empty())
+                .unwrap_or("라운드 실행이 거절되었습니다.");
+            if let Some(wait_message) = transient_round_wait_message(detail) {
+                return Ok(RoundRunOutcome::InFlight {
+                    status: wait_message,
+                });
+            }
+            return Err(JsValue::from_str(detail));
+        }
         let turn_before = json.get("turn_before").and_then(Value::as_u64).unwrap_or(0);
         let turn_after = json.get("turn_after").and_then(Value::as_u64).unwrap_or(0);
         let summary_advanced = json
@@ -1195,7 +1253,7 @@ fn bind_recovery_action_buttons() {
                 let current = read_dom_input(&doc, "round-run-timeout")
                     .and_then(|raw| raw.parse::<f64>().ok())
                     .filter(|value| *value > 0.0)
-                    .unwrap_or(90.0);
+                    .unwrap_or(30.0);
                 let next = (current + 30.0).min(600.0);
                 if let Some(input) = doc
                     .get_element_by_id("round-run-timeout")
@@ -1480,7 +1538,7 @@ fn read_round_run_plan(doc: &web_sys::Document) -> Result<RoundRunPlan, String> 
     let timeout_sec = read_dom_input(doc, "round-run-timeout")
         .and_then(|raw| raw.parse::<f64>().ok())
         .filter(|value| *value > 0.0)
-        .unwrap_or(90.0);
+        .unwrap_or(30.0);
 
     let player_pairs_raw = read_dom_text_value(doc, "round-run-players").unwrap_or_default();
     let mut player_keepers = parse_player_keeper_pairs(&player_pairs_raw);

--- a/viewer/src/game/round_runner.rs
+++ b/viewer/src/game/round_runner.rs
@@ -86,6 +86,10 @@ const STALL_RETRY_BASE_DELAY_MS: i32 = 2000;
 #[allow(dead_code)] // Used by stall_retry_delay_ms in wasm/runtime builds.
 const STALL_RETRY_MAX_DELAY_MS: i32 = 12000;
 
+/// Retry delay for transient round-run conflicts (ms).
+#[cfg(any(target_arch = "wasm32", test))]
+const TRANSIENT_CONFLICT_RETRY_DELAY_MS: i32 = 1200;
+
 #[cfg(any(target_arch = "wasm32", test))]
 fn stall_retry_delay_ms(retry_count: u32) -> i32 {
     let exponent = retry_count.saturating_sub(1).min(6);
@@ -219,6 +223,28 @@ fn spawn_round_loop(control: RoundRunnerControl) {
             release_round_flight("auto");
             match post_result {
                 Ok(resp) => {
+                    if let Some(api_error) = round_response_api_error(&resp) {
+                        if is_transient_round_conflict(&api_error) {
+                            round_num = round_num.saturating_sub(1);
+                            stalled_retries = 0;
+                            log::info!(
+                                "RoundRunner: transient conflict from API; retrying in {}ms — {}",
+                                TRANSIENT_CONFLICT_RETRY_DELAY_MS,
+                                api_error
+                            );
+                            if let Ok(mut guard) = last_result.lock() {
+                                *guard = Some(format!("WAIT: {}", api_error));
+                            }
+                            sleep_ms(TRANSIENT_CONFLICT_RETRY_DELAY_MS).await;
+                            continue;
+                        }
+                        log::warn!("RoundRunner: API rejected round run — {}", api_error);
+                        if let Ok(mut guard) = last_result.lock() {
+                            *guard = Some(format!("ERROR: {}", api_error));
+                        }
+                        break;
+                    }
+
                     log::info!(
                         "RoundRunner: round {} done — {}",
                         round_num,
@@ -261,6 +287,17 @@ fn spawn_round_loop(control: RoundRunnerControl) {
                 Err(e) => {
                     let detail = e.as_string().unwrap_or_else(|| format!("{:?}", e));
                     log::warn!("RoundRunner: POST failed — {}", detail);
+
+                    if is_transient_round_conflict(&detail) {
+                        round_num = round_num.saturating_sub(1);
+                        stalled_retries = 0;
+                        log::info!(
+                            "RoundRunner: transient in-flight/busy conflict; retrying in {}ms",
+                            TRANSIENT_CONFLICT_RETRY_DELAY_MS
+                        );
+                        sleep_ms(TRANSIENT_CONFLICT_RETRY_DELAY_MS).await;
+                        continue;
+                    }
 
                     if let Some(status) = parse_http_status(&detail) {
                         if (400..500).contains(&status) && status != 429 {
@@ -367,7 +404,7 @@ fn build_round_body(dm_keeper_fallback: &str) -> Result<String, String> {
     let timeout_sec = read_dom_input("round-run-timeout")
         .and_then(|raw| raw.parse::<f64>().ok())
         .filter(|value| *value > 0.0)
-        .unwrap_or(90.0);
+        .unwrap_or(30.0);
     let lang = read_dom_input("round-run-lang").unwrap_or_else(|| "ko".to_string());
 
     // 2) Player keeper mapping from hidden round plan (`actor=keeper,actor=keeper,...`).
@@ -446,6 +483,25 @@ fn round_response_advanced(resp: &str) -> Option<bool> {
         .and_then(serde_json::Value::as_bool)
 }
 
+#[cfg(any(target_arch = "wasm32", test))]
+fn round_response_api_error(resp: &str) -> Option<String> {
+    let parsed = serde_json::from_str::<serde_json::Value>(resp).ok()?;
+    if parsed.get("ok").and_then(serde_json::Value::as_bool) != Some(false) {
+        return None;
+    }
+    Some(
+        parsed
+            .get("error")
+            .or_else(|| parsed.get("message"))
+            .or_else(|| parsed.get("detail"))
+            .and_then(serde_json::Value::as_str)
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .unwrap_or("round run request was rejected")
+            .to_string(),
+    )
+}
+
 #[cfg(target_arch = "wasm32")]
 fn parse_player_keeper_pairs(raw: &str) -> Vec<(String, String)> {
     raw.split(',')
@@ -475,6 +531,27 @@ fn parse_http_status(detail: &str) -> Option<u16> {
     } else {
         code_text.parse::<u16>().ok()
     }
+}
+
+#[cfg(any(target_arch = "wasm32", test))]
+fn is_round_in_flight_error(raw: &str) -> bool {
+    let lowered = raw.trim().to_ascii_lowercase();
+    lowered.contains("round run already in progress")
+        || lowered.contains("single-flight")
+        || lowered.contains("already in progress for room")
+}
+
+#[cfg(any(target_arch = "wasm32", test))]
+fn is_keeper_busy_error(raw: &str) -> bool {
+    let lowered = raw.trim().to_ascii_lowercase();
+    lowered.contains("keeper busy")
+        || lowered.contains("can handle only one round at a time")
+        || lowered.contains("each spawned keeper can handle only one round")
+}
+
+#[cfg(any(target_arch = "wasm32", test))]
+fn is_transient_round_conflict(raw: &str) -> bool {
+    is_round_in_flight_error(raw) || is_keeper_busy_error(raw)
 }
 
 #[cfg(target_arch = "wasm32")]
@@ -580,7 +657,7 @@ async fn sleep_ms(ms: i32) {
 
 #[cfg(test)]
 mod tests {
-    use super::stall_retry_delay_ms;
+    use super::{is_transient_round_conflict, round_response_api_error, stall_retry_delay_ms};
 
     #[test]
     fn stall_retry_delay_scales_and_caps() {
@@ -594,5 +671,26 @@ mod tests {
     #[test]
     fn stall_retry_delay_handles_zero_retry_input() {
         assert_eq!(stall_retry_delay_ms(0), 2000);
+    }
+
+    #[test]
+    fn transient_round_conflicts_detected() {
+        assert!(is_transient_round_conflict(
+            "HTTP 400: round run already in progress for room adventure-123"
+        ));
+        assert!(is_transient_round_conflict(
+            "keeper busy: each spawned keeper can handle only one round at a time"
+        ));
+        assert!(!is_transient_round_conflict("HTTP 404: not found"));
+    }
+
+    #[test]
+    fn round_response_api_error_extracts_ok_false_payload() {
+        assert_eq!(
+            round_response_api_error(r#"{"ok":false,"error":"keeper busy: p01"}"#).as_deref(),
+            Some("keeper busy: p01")
+        );
+        assert_eq!(round_response_api_error(r#"{"ok":true}"#), None);
+        assert_eq!(round_response_api_error(r#"{"turn_after":5}"#), None);
     }
 }

--- a/viewer/src/mode/mod.rs
+++ b/viewer/src/mode/mod.rs
@@ -1384,7 +1384,7 @@ pub(super) fn clear_trpg_dom(doc: &web_sys::Document) {
         .get_element_by_id("round-run-timeout")
         .and_then(|el| el.dyn_into::<web_sys::HtmlInputElement>().ok())
     {
-        input.set_value("90");
+        input.set_value("30");
     }
     if let Some(input) = doc
         .get_element_by_id("round-run-lang")
@@ -1518,7 +1518,7 @@ pub(super) fn set_round_run_fields(
         .get_element_by_id("round-run-timeout")
         .and_then(|el| el.dyn_into::<web_sys::HtmlInputElement>().ok())
     {
-        el.set_value("90");
+        el.set_value("30");
     }
     if let Some(el) = doc
         .get_element_by_id("round-run-lang")

--- a/viewer/src/sse/client.rs
+++ b/viewer/src/sse/client.rs
@@ -225,6 +225,29 @@ fn stream_event_fingerprint(
 }
 
 #[cfg(any(target_arch = "wasm32", test))]
+fn canonical_trpg_event_type(raw: &str) -> String {
+    match raw.trim() {
+        "turn_started" => "turn.started".to_string(),
+        "phase_changed" => "phase.changed".to_string(),
+        "narration_posted" | "narrative.posted" => "narration.posted".to_string(),
+        "turn_action_proposed" => "turn.action.proposed".to_string(),
+        "turn_action_resolved" => "turn.action.resolved".to_string(),
+        "keeper_unavailable" => "keeper.unavailable".to_string(),
+        "turn_timeout" => "turn.timeout".to_string(),
+        "scene_transition" => "scene.transition".to_string(),
+        "quest_update" => "quest.update".to_string(),
+        "world_event" => "world.event".to_string(),
+        "session_outcome" => "session.outcome".to_string(),
+        "actor_spawned" => "actor.spawned".to_string(),
+        "actor_updated" => "actor.updated".to_string(),
+        "actor_deleted" => "actor.deleted".to_string(),
+        "actor_claimed" => "actor.claimed".to_string(),
+        "actor_released" => "actor.released".to_string(),
+        other => other.to_string(),
+    }
+}
+
+#[cfg(any(target_arch = "wasm32", test))]
 fn seen_stream_fingerprint(state: &TrpgMapperState, fingerprint: &str) -> bool {
     state
         .recent_stream_fingerprints
@@ -308,6 +331,64 @@ fn snapshot_dice_entries(root: &Value) -> Vec<Value> {
         .and_then(Value::as_array)
         .cloned()
         .unwrap_or_default()
+}
+
+#[cfg(any(target_arch = "wasm32", test))]
+fn snapshot_narration_entries(root: &Value) -> Vec<Value> {
+    let source = root
+        .get("narration_log")
+        .or_else(|| root.get("narrative_log"))
+        .or_else(|| snapshot_root(root).get("narration_log"))
+        .or_else(|| snapshot_root(root).get("narrative_log"));
+    source
+        .and_then(Value::as_array)
+        .cloned()
+        .unwrap_or_default()
+}
+
+#[cfg(any(target_arch = "wasm32", test))]
+fn snapshot_narration_text(entry: &Value) -> Option<String> {
+    let text = entry
+        .get("text")
+        .and_then(Value::as_str)
+        .or_else(|| entry.get("reply").and_then(Value::as_str))
+        .or_else(|| entry.get("proposed_action").and_then(Value::as_str))
+        .or_else(|| entry.get("action").and_then(Value::as_str))
+        .or_else(|| entry.get("description").and_then(Value::as_str))
+        .or_else(|| entry.get("result").and_then(Value::as_str))
+        .unwrap_or("")
+        .trim()
+        .to_string();
+    if text.is_empty() { None } else { Some(text) }
+}
+
+#[cfg(any(target_arch = "wasm32", test))]
+fn map_snapshot_narration(
+    entry: &Value,
+    fallback_turn: u32,
+    stream_room_id: &str,
+    fallback_phase: &str,
+) -> Option<(String, String)> {
+    let text = snapshot_narration_text(entry)?;
+    let phase = entry
+        .get("phase")
+        .and_then(Value::as_str)
+        .unwrap_or(fallback_phase);
+    let mapped = attach_room_id(
+        json!({
+            "text": text,
+            "phase": phase,
+            "turn": value_to_u32(entry.get("turn"), fallback_turn),
+            "speaker": entry
+                .get("speaker")
+                .and_then(Value::as_str)
+                .or_else(|| entry.get("actor_id").and_then(Value::as_str))
+                .or_else(|| entry.get("keeper").and_then(Value::as_str))
+        }),
+        entry,
+        Some(stream_room_id),
+    );
+    Some(("narrative".to_string(), mapped.to_string()))
 }
 
 #[cfg(any(target_arch = "wasm32", test))]
@@ -1082,6 +1163,27 @@ fn decode_snapshot_events(body: &Value, state: &mut TrpgMapperState) -> Vec<(Str
         ));
     }
 
+    let mut narration_mapped = 0_u32;
+    for entry in snapshot_narration_entries(body).into_iter().rev().take(40).rev() {
+        if let Some(mapped) = map_snapshot_narration(&entry, turn, &room_id, &phase) {
+            narration_mapped += 1;
+            out.push(mapped);
+        }
+    }
+    if narration_mapped == 0 && turn <= 1 {
+        let opening = attach_room_id(
+            json!({
+                "text": "모험이 시작되었습니다. DM 오프닝 또는 플레이어 행동 입력을 기다립니다.",
+                "phase": phase,
+                "turn": turn,
+                "speaker": "system"
+            }),
+            snapshot_root(body),
+            Some(&room_id),
+        );
+        out.push(("narrative".to_string(), opening.to_string()));
+    }
+
     for entry in snapshot_dice_entries(body) {
         if let Some(mapped) = map_snapshot_dice_roll(&entry, turn, &room_id, &phase) {
             out.push(mapped);
@@ -1105,31 +1207,35 @@ fn decode_stream_events(
         let mut out = Vec::new();
 
         for ev in parsed.events {
+            let event_type = canonical_trpg_event_type(&ev.event_type);
             if ev.seq > max_seq {
                 max_seq = ev.seq;
             }
             let fingerprint = stream_event_fingerprint(
-                &ev.event_type,
+                &event_type,
                 ev.seq,
                 ev.actor_id.as_deref(),
                 &ev.payload,
             );
             if ev.seq > 0 && ev.seq <= state.last_stream_seq {
                 #[cfg(target_arch = "wasm32")]
-                bump_dedup_stream(&format!("seq {} <= {}", ev.seq, state.last_stream_seq));
+                bump_dedup_stream(&format!(
+                    "seq {} <= {} ({})",
+                    ev.seq, state.last_stream_seq, event_type
+                ));
                 remember_stream_fingerprint(state, fingerprint);
                 continue;
             }
             if seen_stream_fingerprint(state, &fingerprint) {
                 #[cfg(target_arch = "wasm32")]
-                bump_dedup_stream(&format!("fp | {} | seq {}", ev.event_type, ev.seq));
+                bump_dedup_stream(&format!("fp | {} | seq {}", event_type, ev.seq));
                 continue;
             }
             if ev.seq > 0 {
                 state.last_stream_seq = state.last_stream_seq.max(ev.seq);
             }
             out.extend(map_trpg_event(
-                &ev.event_type,
+                &event_type,
                 ev.actor_id.as_deref(),
                 ev.room_id.as_deref(),
                 &ev.payload,
@@ -1780,5 +1886,69 @@ mod tests {
             .expect("room.created should exist");
         let r_payload: Value = serde_json::from_str(&room.1).expect("room.created payload json");
         assert_eq!(r_payload["room_id"], "r1");
+    }
+
+    #[test]
+    fn decode_snapshot_restores_narration_log() {
+        let body = r#"{
+            "state": {
+                "room_id": "adventure-1",
+                "status": "running",
+                "turn": 3,
+                "phase": "dm_narration",
+                "narration_log": [
+                    {"turn": 1, "phase": "dm_narration", "actor_id": "dm", "reply": "짙은 안개가 길을 덮습니다."},
+                    {"turn": 2, "phase": "action_declaration", "actor_id": "p01", "proposed_action": "횃불을 밝히고 앞을 살핀다."}
+                ]
+            }
+        }"#;
+
+        let mut state = TrpgMapperState::default();
+        let (_, mapped) = decode_stream_events(body, &mut state).expect("decode should succeed");
+
+        let narrative_events: Vec<&(String, String)> = mapped
+            .iter()
+            .filter(|(event_type, _)| event_type == "narrative")
+            .collect();
+        assert_eq!(narrative_events.len(), 2);
+
+        let first: Value =
+            serde_json::from_str(&narrative_events[0].1).expect("first narrative payload");
+        assert_eq!(first["text"], "짙은 안개가 길을 덮습니다.");
+        assert_eq!(first["speaker"], "dm");
+
+        let second: Value =
+            serde_json::from_str(&narrative_events[1].1).expect("second narrative payload");
+        assert_eq!(second["text"], "횃불을 밝히고 앞을 살핀다.");
+        assert_eq!(second["speaker"], "p01");
+    }
+
+    #[test]
+    fn decode_stream_accepts_snake_case_event_aliases() {
+        let body = r#"{
+            "events": [
+                {"seq": 1, "type": "turn_started", "payload": {"turn": 2, "phase": "briefing"}},
+                {"seq": 2, "type": "phase_changed", "payload": {"turn": 2, "phase": "action_declaration"}},
+                {"seq": 3, "type": "scene_transition", "payload": {"from_scene": "forest", "to_scene": "ruins", "trigger": "party"}}
+            ]
+        }"#;
+
+        let mut state = TrpgMapperState::default();
+        let (_, mapped) = decode_stream_events(body, &mut state).expect("decode should succeed");
+
+        let turn_advances = mapped
+            .iter()
+            .filter(|(event_type, _)| event_type == "turn_advance")
+            .count();
+        assert_eq!(turn_advances, 2);
+
+        let area_move = mapped
+            .iter()
+            .find(|(event_type, _)| event_type == "area_move")
+            .expect("area_move should exist");
+        let move_payload: Value =
+            serde_json::from_str(&area_move.1).expect("area_move payload json");
+        assert_eq!(move_payload["from_area"], "forest");
+        assert_eq!(move_payload["to_area"], "ruins");
     }
 }

--- a/viewer/style.css
+++ b/viewer/style.css
@@ -4243,6 +4243,13 @@ body.wasm-dom-fallback #bevy-canvas {
     color: var(--text-dim, #f0ad4e);
 }
 
+#action-help {
+    margin-top: 6px;
+    font-size: 0.72rem;
+    color: var(--text-dim);
+    line-height: 1.35;
+}
+
 .action-history {
     font-size: 0.85em;
     opacity: 0.7;
@@ -4265,6 +4272,13 @@ body.wasm-dom-fallback #bevy-canvas {
     padding: 8px 10px;
     border-top: 1px solid var(--border-main);
     background: var(--bg-panel-alt);
+}
+
+#join-help {
+    margin-bottom: 6px;
+    font-size: 0.72rem;
+    color: var(--text-dim);
+    line-height: 1.35;
 }
 
 #join-input-row {


### PR DESCRIPTION
## Summary
- keep narrative/dice logs readable while using history focus chips (remove dimming side-effects)
- improve join UX with actor-id suggestions, clearer help text, and localized error messages
- treat transient round conflicts (in-flight / keeper busy) as wait states instead of hard failures
- normalize TRPG stream event aliases and restore snapshot narration into narrative events

## Validation
- cargo test --manifest-path viewer/Cargo.toml -- --nocapture
- cargo check --manifest-path viewer/Cargo.toml --target wasm32-unknown-unknown

## Context
PR #346 was already merged, so this is a follow-up fix PR on top of current main.