### PR TITLE
fix(viewer): add runtime upstream override for TRPG/MCP calls

### DIFF
--- a/viewer/src/config.rs
+++ b/viewer/src/config.rs
@@ -4,12 +4,107 @@ use crate::mode::ViewerMode;
 
 // ─── Configuration ──────────────────────────
 
-// With Trunk Proxy configured in Trunk.toml, we can use relative paths
-// for both debug and release builds.
-// This avoids CORS issues and hardcoded ports in the binary.
-pub const MASC_MCP_URL: &str = "";
+// Optional compile-time upstream override.
+// Keep empty by default so local dev still uses relative paths + Trunk proxy.
+#[cfg(target_arch = "wasm32")]
+const COMPILE_TIME_MASC_MCP_URL: &str = match option_env!("MASC_MCP_URL") {
+    Some(v) => v,
+    None => "",
+};
+#[cfg(not(target_arch = "wasm32"))]
+const COMPILE_TIME_MASC_MCP_URL: &str = "";
+
+/// Backward-compatible static base URL for legacy call sites.
+pub const MASC_MCP_URL: &str = COMPILE_TIME_MASC_MCP_URL;
 
 pub const DEFAULT_ROOM_ID: &str = "default";
+
+fn normalize_base_url(base: &str) -> String {
+    base.trim().trim_end_matches('/').to_string()
+}
+
+fn compose_masc_url(base: &str, path: &str) -> String {
+    let normalized_base = normalize_base_url(base);
+    let normalized_path = path.trim_start_matches('/');
+    if normalized_base.is_empty() {
+        format!("/{}", normalized_path)
+    } else {
+        format!("{}/{}", normalized_base, normalized_path)
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+fn runtime_base_url_override() -> Option<String> {
+    let win = web_sys::window()?;
+
+    // 1) Explicit global override:
+    //    window.__MASC_MCP_URL = "https://your-masc.up.railway.app"
+    if let Ok(value) = js_sys::Reflect::get(
+        win.as_ref(),
+        &wasm_bindgen::JsValue::from_str("__MASC_MCP_URL"),
+    ) {
+        if let Some(raw) = value.as_string() {
+            let normalized = normalize_base_url(&raw);
+            if !normalized.is_empty() {
+                return Some(normalized);
+            }
+        }
+    }
+
+    // 2) URL query override:
+    //    ?masc_mcp_url=https://your-masc.up.railway.app
+    if let Ok(search) = win.location().search() {
+        if let Some(raw) = parse_query_param(&search, "masc_mcp_url") {
+            let normalized = normalize_base_url(&raw);
+            if !normalized.is_empty() {
+                if let Ok(Some(storage)) = win.local_storage() {
+                    let _ = storage.set_item("masc_mcp_url", &normalized);
+                }
+                return Some(normalized);
+            }
+        }
+    }
+
+    // 3) localStorage fallback:
+    //    localStorage.setItem("masc_mcp_url", "https://your-masc.up.railway.app")
+    if let Ok(Some(storage)) = win.local_storage() {
+        if let Ok(Some(raw)) = storage.get_item("masc_mcp_url") {
+            let normalized = normalize_base_url(&raw);
+            if !normalized.is_empty() {
+                return Some(normalized);
+            }
+        }
+    }
+
+    // 4) Meta tag fallback:
+    //    <meta name="masc-mcp-url" content="https://your-masc.up.railway.app">
+    if let Some(doc) = win.document() {
+        if let Ok(Some(meta)) = doc.query_selector("meta[name='masc-mcp-url']") {
+            if let Some(raw) = meta.get_attribute("content") {
+                let normalized = normalize_base_url(&raw);
+                if !normalized.is_empty() {
+                    return Some(normalized);
+                }
+            }
+        }
+    }
+
+    None
+}
+
+pub fn masc_mcp_base_url() -> String {
+    #[cfg(target_arch = "wasm32")]
+    {
+        if let Some(runtime) = runtime_base_url_override() {
+            return runtime;
+        }
+    }
+    normalize_base_url(COMPILE_TIME_MASC_MCP_URL)
+}
+
+pub fn build_masc_url(path: &str) -> String {
+    compose_masc_url(&masc_mcp_base_url(), path)
+}
 
 // ─── Room ID Management ─────────────────────
 
@@ -127,34 +222,28 @@ pub fn trpg_uses_polling() -> bool {
 }
 
 pub fn trpg_state_url() -> String {
-    format!(
-        "{}/api/v1/trpg/state?room_id={}",
-        MASC_MCP_URL,
-        current_room_id()
-    )
+    build_masc_url(&format!("api/v1/trpg/state?room_id={}", current_room_id()))
 }
 
 /// Legacy JSON poll endpoint.
 pub fn trpg_stream_poll_url(after_seq: i64) -> String {
-    format!(
-        "{}/api/v1/trpg/stream?room_id={}&after_seq={}",
-        MASC_MCP_URL,
+    build_masc_url(&format!(
+        "api/v1/trpg/stream?room_id={}&after_seq={}",
         current_room_id(),
         after_seq
-    )
+    ))
 }
 
 pub fn sse_endpoint(mode: &ViewerMode) -> Option<String> {
     match mode {
-        ViewerMode::Trpg => Some(format!(
-            "{}/api/v1/trpg/stream/sse?room_id={}",
-            MASC_MCP_URL,
+        ViewerMode::Trpg => Some(build_masc_url(&format!(
+            "api/v1/trpg/stream/sse?room_id={}",
             current_room_id()
-        )),
-        ViewerMode::Monitor => Some(format!("{}/sse?room=monitor", MASC_MCP_URL)),
-        ViewerMode::Experiment => Some(format!("{}/sse?room=experiment", MASC_MCP_URL)),
-        ViewerMode::Council => Some(format!("{}/sse?room=council", MASC_MCP_URL)),
-        ViewerMode::Social => Some(format!("{}/sse?room=social", MASC_MCP_URL)),
+        ))),
+        ViewerMode::Monitor => Some(build_masc_url("sse?room=monitor")),
+        ViewerMode::Experiment => Some(build_masc_url("sse?room=experiment")),
+        ViewerMode::Council => Some(build_masc_url("sse?room=council")),
+        ViewerMode::Social => Some(build_masc_url("sse?room=social")),
         ViewerMode::Lobby => None,
     }
 }
@@ -163,15 +252,14 @@ pub fn sse_endpoint(mode: &ViewerMode) -> Option<String> {
 /// that don't have access to Bevy State<ViewerMode>).
 pub fn sse_endpoint_by_name(mode_name: &str) -> Option<String> {
     match mode_name {
-        "Trpg" => Some(format!(
-            "{}/api/v1/trpg/stream/sse?room_id={}",
-            MASC_MCP_URL,
+        "Trpg" => Some(build_masc_url(&format!(
+            "api/v1/trpg/stream/sse?room_id={}",
             current_room_id()
-        )),
-        "Monitor" => Some(format!("{}/sse?room=monitor", MASC_MCP_URL)),
-        "Experiment" => Some(format!("{}/sse?room=experiment", MASC_MCP_URL)),
-        "Council" => Some(format!("{}/sse?room=council", MASC_MCP_URL)),
-        "Social" => Some(format!("{}/sse?room=social", MASC_MCP_URL)),
+        ))),
+        "Monitor" => Some(build_masc_url("sse?room=monitor")),
+        "Experiment" => Some(build_masc_url("sse?room=experiment")),
+        "Council" => Some(build_masc_url("sse?room=council")),
+        "Social" => Some(build_masc_url("sse?room=social")),
         _ => None,
     }
 }
@@ -179,6 +267,36 @@ pub fn sse_endpoint_by_name(mode_name: &str) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn compose_masc_url_supports_relative_mode() {
+        assert_eq!(
+            compose_masc_url("", "api/v1/trpg/state"),
+            "/api/v1/trpg/state"
+        );
+        assert_eq!(
+            compose_masc_url("", "/sse?room=monitor"),
+            "/sse?room=monitor"
+        );
+    }
+
+    #[test]
+    fn compose_masc_url_supports_absolute_upstream() {
+        assert_eq!(
+            compose_masc_url(
+                "https://masc-mcp-production.up.railway.app",
+                "api/v1/trpg/state?room_id=default"
+            ),
+            "https://masc-mcp-production.up.railway.app/api/v1/trpg/state?room_id=default"
+        );
+        assert_eq!(
+            compose_masc_url(
+                "https://masc-mcp-production.up.railway.app/",
+                "/sse?room=monitor"
+            ),
+            "https://masc-mcp-production.up.railway.app/sse?room=monitor"
+        );
+    }
 
     #[test]
     fn sse_endpoint_routes_masc_modes_to_legacy_sse() {

--- a/viewer/src/dom/action_panel.rs
+++ b/viewer/src/dom/action_panel.rs
@@ -358,7 +358,7 @@ fn submit_intervention_from_input() {
 
 #[cfg(target_arch = "wasm32")]
 async fn submit_intervention(actor_id: &str, suggestion: &str) -> Result<(), String> {
-    let url = format!("{}/mcp", config::MASC_MCP_URL);
+    let url = config::build_masc_url("mcp");
     let room_id = config::current_room_id();
 
     let params = json!({
@@ -390,7 +390,7 @@ async fn roll_dice_intervention() -> Result<String, String> {
         return Err("No active actor".into());
     };
 
-    let url = format!("{}/mcp", config::MASC_MCP_URL);
+    let url = config::build_masc_url("mcp");
     let room_id = config::current_room_id();
 
     let params = json!({

--- a/viewer/src/dom/actor_join.rs
+++ b/viewer/src/dom/actor_join.rs
@@ -228,7 +228,7 @@ fn bind_leave_button() {
 async fn claim_actor(actor_id: &str, keeper_name: &str) -> Result<(), JsValue> {
     use wasm_bindgen_futures::JsFuture;
 
-    let url = format!("{}/api/v1/trpg/actors/claim", config::MASC_MCP_URL);
+    let url = config::build_masc_url("api/v1/trpg/actors/claim");
     let room_id = config::current_room_id();
 
     // If keeper_name is empty, default to "Anonymous Viewer"
@@ -282,7 +282,7 @@ async fn claim_actor(actor_id: &str, keeper_name: &str) -> Result<(), JsValue> {
 async fn release_actor(actor_id: &str) -> Result<(), JsValue> {
     use wasm_bindgen_futures::JsFuture;
 
-    let url = format!("{}/api/v1/trpg/actors/release", config::MASC_MCP_URL);
+    let url = config::build_masc_url("api/v1/trpg/actors/release");
     let room_id = config::current_room_id();
 
     // Retrieve keeper name from hidden state if possible, or send empty (server might require it?)

--- a/viewer/src/dom/turn_controls.rs
+++ b/viewer/src/dom/turn_controls.rs
@@ -426,9 +426,9 @@ pub fn sync_turn_controls_visibility(
 
         let dm_ready = !progress.dm_keeper.trim().is_empty()
             || read_dom_input(&doc, "round-run-dm")
-            .or_else(|| read_claimed_keeper_for_current_room(&doc))
-            .or_else(|| read_dom_input(&doc, "new-game-dm-select"))
-            .is_some();
+                .or_else(|| read_claimed_keeper_for_current_room(&doc))
+                .or_else(|| read_dom_input(&doc, "new-game-dm-select"))
+                .is_some();
         let player_pairs_raw = read_dom_text_value(&doc, "round-run-players").unwrap_or_default();
         let mut player_count = parse_player_keeper_pairs(&player_pairs_raw).len();
         if player_count == 0 {
@@ -785,7 +785,7 @@ async fn advance_turn() -> Result<RoundRunOutcome, JsValue> {
         player_keepers.insert(actor_id.clone(), Value::String(keeper_name.clone()));
     }
 
-    let url = format!("{}/api/v1/trpg/rounds/run", config::MASC_MCP_URL);
+    let url = config::build_masc_url("api/v1/trpg/rounds/run");
     let body = json!({
         "room_id": config::current_room_id(),
         "dm_keeper": plan.dm_keeper,
@@ -1427,9 +1427,7 @@ fn read_claimed_keeper_for_current_room(doc: &web_sys::Document) -> Option<Strin
 }
 
 #[cfg(target_arch = "wasm32")]
-fn read_claimed_actor_keeper_for_current_room(
-    doc: &web_sys::Document,
-) -> Option<(String, String)> {
+fn read_claimed_actor_keeper_for_current_room(doc: &web_sys::Document) -> Option<(String, String)> {
     if !claim_matches_current_room(doc) {
         return None;
     }
@@ -1485,7 +1483,8 @@ fn read_round_run_plan(doc: &web_sys::Document) -> Result<RoundRunPlan, String> 
     let player_pairs_raw = read_dom_text_value(doc, "round-run-players").unwrap_or_default();
     let mut player_keepers = parse_player_keeper_pairs(&player_pairs_raw);
     if player_keepers.is_empty() {
-        if let Some((claimed_actor, claimed_keeper)) = read_claimed_actor_keeper_for_current_room(doc)
+        if let Some((claimed_actor, claimed_keeper)) =
+            read_claimed_actor_keeper_for_current_room(doc)
         {
             player_keepers.push((claimed_actor, claimed_keeper));
         }

--- a/viewer/src/game/round_runner.rs
+++ b/viewer/src/game/round_runner.rs
@@ -214,7 +214,7 @@ fn spawn_round_loop(control: RoundRunnerControl) {
             round_num += 1;
             log::info!("RoundRunner: triggering round {}", round_num);
 
-            let url = format!("{}/api/v1/trpg/rounds/run", config::MASC_MCP_URL);
+            let url = config::build_masc_url("api/v1/trpg/rounds/run");
             let post_result = fetch_json_post(&url, &body).await;
             release_round_flight("auto");
             match post_result {

--- a/viewer/src/mode/mcp_rpc.rs
+++ b/viewer/src/mode/mcp_rpc.rs
@@ -9,7 +9,7 @@ use wasm_bindgen::JsCast;
 use wasm_bindgen_futures::JsFuture;
 
 pub(super) async fn mcp_tool_call(tool_name: &str, args: Value) -> Result<Value, String> {
-    let url = format!("{}/mcp", crate::config::MASC_MCP_URL);
+    let url = crate::config::build_masc_url("mcp");
     let body = json!({
         "jsonrpc": "2.0",
         "id": (js_sys::Date::now() as i64),

--- a/viewer/src/mode/mod.rs
+++ b/viewer/src/mode/mod.rs
@@ -526,7 +526,7 @@ fn set_session_control_busy(doc: &web_sys::Document, busy: bool) {
 
 #[cfg(target_arch = "wasm32")]
 async fn post_tool_action(tool_name: &str, args: Value) -> Result<String, String> {
-    let url = format!("{}/mcp", crate::config::MASC_MCP_URL);
+    let url = crate::config::build_masc_url("mcp");
     let body = json!({
         "jsonrpc": "2.0",
         "id": (js_sys::Date::now() as i64),
@@ -1740,11 +1740,7 @@ fn sync_room_hub_selection(doc: &web_sys::Document, selected_room: &str) {
 
 #[cfg(target_arch = "wasm32")]
 async fn fetch_room_runtime(room_id: &str) -> Result<(String, u32, String), String> {
-    let url = format!(
-        "{}/api/v1/trpg/state?room_id={}",
-        crate::config::MASC_MCP_URL,
-        room_id
-    );
+    let url = crate::config::build_masc_url(&format!("api/v1/trpg/state?room_id={}", room_id));
     let opts = web_sys::RequestInit::new();
     opts.set_method("GET");
     opts.set_mode(web_sys::RequestMode::Cors);

--- a/viewer/src/mode/room_hub.rs
+++ b/viewer/src/mode/room_hub.rs
@@ -227,11 +227,7 @@ fn sync_room_hub_selection(doc: &web_sys::Document, selected_room: &str) {
 }
 
 async fn fetch_room_runtime(room_id: &str) -> Result<(String, u32, String), String> {
-    let url = format!(
-        "{}/api/v1/trpg/state?room_id={}",
-        crate::config::MASC_MCP_URL,
-        room_id
-    );
+    let url = crate::config::build_masc_url(&format!("api/v1/trpg/state?room_id={}", room_id));
     let opts = web_sys::RequestInit::new();
     opts.set_method("GET");
     opts.set_mode(web_sys::RequestMode::Cors);

--- a/viewer/src/mode/trpg_controls.rs
+++ b/viewer/src/mode/trpg_controls.rs
@@ -1725,11 +1725,7 @@ fn actor_admin_input_i64(doc: &web_sys::Document, id: &str) -> Option<i64> {
 }
 
 async fn fetch_room_state_payload(room_id: &str) -> Result<Value, String> {
-    let url = format!(
-        "{}/api/v1/trpg/state?room_id={}",
-        crate::config::MASC_MCP_URL,
-        room_id
-    );
+    let url = crate::config::build_masc_url(&format!("api/v1/trpg/state?room_id={}", room_id));
     let opts = web_sys::RequestInit::new();
     opts.set_method("GET");
     opts.set_mode(web_sys::RequestMode::Cors);

--- a/viewer/src/sse/social_board.rs
+++ b/viewer/src/sse/social_board.rs
@@ -200,7 +200,7 @@ fn format_fetch_error(err: &JsValue) -> String {
 
 #[cfg(target_arch = "wasm32")]
 async fn fetch_board_posts() -> Result<Vec<BoardPost>, JsValue> {
-    let url = format!("{}/api/v1/board", config::MASC_MCP_URL);
+    let url = config::build_masc_url("api/v1/board");
 
     let opts = web_sys::RequestInit::new();
     opts.set_method("GET");
@@ -229,7 +229,7 @@ async fn fetch_board_posts() -> Result<Vec<BoardPost>, JsValue> {
 
 #[cfg(target_arch = "wasm32")]
 async fn submit_vote(post_id: &str, direction: &str) -> Result<(), JsValue> {
-    let url = format!("{}/api/v1/tools/masc_board_vote", config::MASC_MCP_URL);
+    let url = config::build_masc_url("api/v1/tools/masc_board_vote");
 
     let body = format!(
         r#"{{"post_id":"{}","voter":"viewer","direction":"{}"}}"#,
@@ -259,7 +259,7 @@ async fn submit_vote(post_id: &str, direction: &str) -> Result<(), JsValue> {
 
 #[cfg(target_arch = "wasm32")]
 async fn fetch_post_comments(post_id: &str) -> Result<Vec<BoardComment>, JsValue> {
-    let url = format!("{}/api/v1/board/{}", config::MASC_MCP_URL, post_id);
+    let url = config::build_masc_url(&format!("api/v1/board/{}", post_id));
 
     let opts = web_sys::RequestInit::new();
     opts.set_method("GET");
@@ -290,7 +290,7 @@ async fn fetch_post_comments(post_id: &str) -> Result<Vec<BoardComment>, JsValue
 
 #[cfg(target_arch = "wasm32")]
 async fn submit_comment(post_id: &str, content: &str) -> Result<(), JsValue> {
-    let url = format!("{}/api/v1/tools/masc_board_comment", config::MASC_MCP_URL);
+    let url = config::build_masc_url("api/v1/tools/masc_board_comment");
 
     let body = format!(
         r#"{{"post_id":"{}","content":"{}","author":"viewer"}}"#,


### PR DESCRIPTION
## Summary
- add runtime/compile-time MASC upstream URL resolution in viewer config
- support runtime overrides via:
  - `window.__MASC_MCP_URL`
  - `?masc_mcp_url=https://...` (persisted to `localStorage.masc_mcp_url`)
  - `<meta name="masc-mcp-url" content="https://...">`
- migrate viewer HTTP call sites from static `MASC_MCP_URL` concatenation to `build_masc_url()`

## Why
Production/local proxy paths can still point to `localhost:8935`, causing 500 when backend is unavailable. Runtime override gives immediate bypass without rebuild.

## Verification
- `cargo check --quiet` (viewer)
- `cargo test compose_masc_url --quiet` (viewer)
