### PR TITLE
feat(viewer): DM narration voice only during active TRPG

### DIFF
--- a/viewer/Cargo.toml
+++ b/viewer/Cargo.toml
@@ -42,7 +42,11 @@ web-sys = { version = "0.3", features = [
     "RequestMode",
     "Response",
     "Headers",
+    "Blob",
+    "Url",
     "HtmlAudioElement",
+    "SpeechSynthesis",
+    "SpeechSynthesisUtterance",
 ] }
 js-sys = "0.3"
 serde = { version = "1", features = ["derive"] }

--- a/viewer/index.html
+++ b/viewer/index.html
@@ -444,6 +444,37 @@
                     <input type="hidden" id="round-run-timeout" value="" />
                     <input type="hidden" id="round-run-lang" value="" />
                     <input type="hidden" id="round-run-players" value="" />
+                    <details id="dm-voice-config" class="dm-voice-config">
+                        <summary>DM 음성 설정</summary>
+                        <div class="dm-voice-grid">
+                            <label class="new-game-field">
+                                <span>음성 모드</span>
+                                <select id="dm-voice-mode-select" title="DM 내레이션 음성 모드를 선택합니다">
+                                    <option value="browser">Browser TTS</option>
+                                    <option value="elevenlabs">ElevenLabs Proxy</option>
+                                    <option value="off">Off</option>
+                                </select>
+                            </label>
+                            <label class="new-game-field dm-voice-field-wide">
+                                <span>Proxy URL</span>
+                                <input id="dm-voice-proxy-url" type="text" maxlength="500" placeholder="https://.../tts" />
+                            </label>
+                            <label class="new-game-field">
+                                <span>응답 음성 모델</span>
+                                <input id="dm-voice-model" type="text" maxlength="120" placeholder="eleven_turbo_v2_5" />
+                            </label>
+                            <label class="new-game-field">
+                                <span>응답 Voice ID</span>
+                                <input id="dm-voice-id" type="text" maxlength="120" placeholder="21m00Tcm4TlvDq8ikWAM" />
+                            </label>
+                        </div>
+                        <div class="dm-voice-actions">
+                            <button id="dm-voice-save-btn" class="inline-toggle" type="button">음성 설정 저장</button>
+                        </div>
+                        <div id="dm-voice-status" class="turn-control-gate status-info">
+                            DM 음성은 세션 진행 중일 때만 재생됩니다.
+                        </div>
+                    </details>
                     <div id="atmosphere-strip" class="atmosphere-strip" aria-live="polite">
                         <div id="weather-chip" class="atmo-chip">
                             <img id="weather-icon" class="atmo-icon" alt="" />

--- a/viewer/index.html
+++ b/viewer/index.html
@@ -461,11 +461,38 @@
                             </label>
                             <label class="new-game-field">
                                 <span>응답 음성 모델</span>
-                                <input id="dm-voice-model" type="text" maxlength="120" placeholder="eleven_turbo_v2_5" />
+                                <select id="dm-voice-model-select" title="응답 음성 모델을 선택합니다">
+                                    <option value="">자동 (프록시 기본값)</option>
+                                    <option value="eleven_turbo_v2_5">Eleven Turbo v2.5</option>
+                                    <option value="eleven_flash_v2_5">Eleven Flash v2.5</option>
+                                    <option value="eleven_multilingual_v2">Eleven Multilingual v2</option>
+                                    <option value="custom">직접 입력</option>
+                                </select>
+                            </label>
+                            <label id="dm-voice-model-custom-wrap" class="new-game-field dm-voice-custom" hidden>
+                                <span>모델 직접 입력</span>
+                                <input id="dm-voice-model-custom" type="text" maxlength="120" placeholder="eleven_turbo_v2_5" />
                             </label>
                             <label class="new-game-field">
                                 <span>응답 Voice ID</span>
-                                <input id="dm-voice-id" type="text" maxlength="120" placeholder="21m00Tcm4TlvDq8ikWAM" />
+                                <select id="dm-voice-id-select" title="응답 Voice ID를 선택합니다">
+                                    <option value="">자동 (프록시 기본값)</option>
+                                    <option value="random_preset">랜덤 (추천 Voice 중 선택)</option>
+                                    <option value="21m00Tcm4TlvDq8ikWAM">Rachel</option>
+                                    <option value="AZnzlk1XvdvUeBnXmlld">Domi</option>
+                                    <option value="EXAVITQu4vr4xnSDxMaL">Bella</option>
+                                    <option value="ErXwobaYiN019PkySvjV">Antoni</option>
+                                    <option value="MF3mGyEYCl7XYWbV9V6O">Elli</option>
+                                    <option value="TxGEqnHWrfWFTfGW9XjX">Josh</option>
+                                    <option value="VR6AewLTigWG4xSOukaG">Arnold</option>
+                                    <option value="pNInz6obpgDQGcFmaJgB">Adam</option>
+                                    <option value="yoZ06aMxZJJ28mfd3POQ">Sam</option>
+                                    <option value="custom">직접 입력</option>
+                                </select>
+                            </label>
+                            <label id="dm-voice-id-custom-wrap" class="new-game-field dm-voice-custom" hidden>
+                                <span>Voice ID 직접 입력</span>
+                                <input id="dm-voice-id-custom" type="text" maxlength="120" placeholder="21m00Tcm4TlvDq8ikWAM" />
                             </label>
                         </div>
                         <div class="dm-voice-actions">

--- a/viewer/index.html
+++ b/viewer/index.html
@@ -455,8 +455,17 @@
                                     <option value="off">Off</option>
                                 </select>
                             </label>
-                            <label class="new-game-field dm-voice-field-wide">
+                            <label class="new-game-field">
                                 <span>Proxy URL</span>
+                                <select id="dm-voice-proxy-select" title="ElevenLabs 프록시 URL 템플릿을 선택합니다">
+                                    <option value="custom">직접 입력</option>
+                                    <option value="origin:/api/v1/trpg/tts">현재 서버 /api/v1/trpg/tts</option>
+                                    <option value="origin:/api/v1/tts">현재 서버 /api/v1/tts</option>
+                                    <option value="origin:/tts">현재 서버 /tts</option>
+                                </select>
+                            </label>
+                            <label id="dm-voice-proxy-custom-wrap" class="new-game-field dm-voice-field-wide dm-voice-custom" hidden>
+                                <span>Proxy URL 직접 입력</span>
                                 <input id="dm-voice-proxy-url" type="text" maxlength="500" placeholder="https://.../tts" />
                             </label>
                             <label class="new-game-field">
@@ -496,6 +505,7 @@
                             </label>
                         </div>
                         <div class="dm-voice-actions">
+                            <button id="dm-voice-preview-btn" class="inline-toggle" type="button">미리듣기</button>
                             <button id="dm-voice-save-btn" class="inline-toggle" type="button">음성 설정 저장</button>
                         </div>
                         <div id="dm-voice-status" class="turn-control-gate status-info">

--- a/viewer/src/dom/dm_voice.rs
+++ b/viewer/src/dom/dm_voice.rs
@@ -1,0 +1,482 @@
+use crate::game::events::NarrativePayload;
+use crate::game::lifecycle::TrpgLifecycleState;
+use crate::game::state::{RoomState, TurnProgressState};
+
+#[cfg_attr(not(target_arch = "wasm32"), allow(dead_code))]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum DmVoiceMode {
+    Off,
+    Browser,
+    ElevenLabs,
+}
+
+fn normalize_phase(raw: &str) -> String {
+    raw.trim().to_ascii_lowercase().replace('-', "_")
+}
+
+fn is_dm_phase(phase: &str) -> bool {
+    matches!(
+        normalize_phase(phase).as_str(),
+        "dm_narration" | "briefing" | "dm"
+    )
+}
+
+fn is_dm_speaker(speaker: Option<&str>) -> bool {
+    let normalized = speaker
+        .unwrap_or_default()
+        .trim()
+        .to_ascii_lowercase()
+        .replace(' ', "_");
+    matches!(normalized.as_str(), "dm" | "game_master" | "gm")
+}
+
+fn is_room_running(room_state: &RoomState, progress: &TurnProgressState) -> bool {
+    TrpgLifecycleState::from_room_progress(&room_state.status, &progress.room_status)
+        .accepts_player_input()
+}
+
+fn should_play_dm_voice(
+    payload: &NarrativePayload,
+    clean_text: &str,
+    room_state: &RoomState,
+    progress: &TurnProgressState,
+) -> bool {
+    if clean_text.trim().is_empty() {
+        return false;
+    }
+    if !is_room_running(room_state, progress) {
+        return false;
+    }
+    is_dm_phase(&payload.phase) || is_dm_speaker(payload.speaker.as_deref())
+}
+
+pub fn maybe_play_dm_voice(
+    payload: &NarrativePayload,
+    clean_text: &str,
+    room_state: &RoomState,
+    progress: &TurnProgressState,
+) {
+    if !should_play_dm_voice(payload, clean_text, room_state, progress) {
+        return;
+    }
+
+    #[cfg(target_arch = "wasm32")]
+    {
+        dispatch_voice(payload, clean_text, room_state);
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+fn dispatch_voice(payload: &NarrativePayload, clean_text: &str, room_state: &RoomState) {
+    let text = clean_text.trim().to_string();
+    if text.is_empty() {
+        return;
+    }
+    let room_id = if room_state.id.trim().is_empty() {
+        crate::config::current_room_id()
+    } else {
+        room_state.id.trim().to_string()
+    };
+    let phase = payload.phase.trim().to_string();
+    let turn = payload.turn;
+
+    match resolve_dm_voice_mode() {
+        DmVoiceMode::Off => {}
+        DmVoiceMode::Browser => speak_with_browser(&text),
+        DmVoiceMode::ElevenLabs => {
+            if let Some(proxy_url) = resolve_dm_voice_proxy_url() {
+                speak_with_proxy(proxy_url, text, room_id, phase, turn);
+            } else {
+                speak_with_browser(&text);
+            }
+        }
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+fn parse_dm_voice_mode(raw: &str) -> DmVoiceMode {
+    match raw.trim().to_ascii_lowercase().as_str() {
+        "off" | "none" | "mute" | "muted" | "0" => DmVoiceMode::Off,
+        "elevenlabs" | "eleven" | "proxy" | "remote" => DmVoiceMode::ElevenLabs,
+        _ => DmVoiceMode::Browser,
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+fn resolve_dm_voice_mode() -> DmVoiceMode {
+    let Some(win) = web_sys::window() else {
+        return DmVoiceMode::Browser;
+    };
+
+    if let Some(raw) = global_string(&win, "__TRPG_DM_VOICE_MODE")
+        .or_else(|| global_string(&win, "__DM_VOICE_MODE"))
+    {
+        return parse_dm_voice_mode(&raw);
+    }
+
+    if let Ok(search) = win.location().search() {
+        if let Some(raw) = parse_query_param(&search, "dm_voice")
+            .or_else(|| parse_query_param(&search, "dm_voice_mode"))
+        {
+            if let Ok(Some(storage)) = win.local_storage() {
+                let _ = storage.set_item("trpg_dm_voice_mode", raw.trim());
+            }
+            return parse_dm_voice_mode(&raw);
+        }
+    }
+
+    if let Ok(Some(storage)) = win.local_storage() {
+        if let Ok(Some(raw)) = storage.get_item("trpg_dm_voice_mode") {
+            return parse_dm_voice_mode(&raw);
+        }
+    }
+
+    if let Some(doc) = win.document() {
+        if let Ok(Some(meta)) = doc.query_selector("meta[name='trpg-dm-voice-mode']") {
+            if let Some(raw) = meta.get_attribute("content") {
+                return parse_dm_voice_mode(&raw);
+            }
+        }
+    }
+
+    DmVoiceMode::Browser
+}
+
+#[cfg(target_arch = "wasm32")]
+fn resolve_dm_voice_proxy_url() -> Option<String> {
+    let win = web_sys::window()?;
+    let normalize = |raw: &str| {
+        let trimmed = raw.trim();
+        if trimmed.is_empty() {
+            None
+        } else {
+            Some(trimmed.to_string())
+        }
+    };
+
+    if let Some(raw) = global_string(&win, "__TRPG_DM_VOICE_PROXY_URL")
+        .or_else(|| global_string(&win, "__ELEVENLABS_PROXY_URL"))
+    {
+        if let Some(url) = normalize(&raw) {
+            return Some(url);
+        }
+    }
+
+    if let Ok(search) = win.location().search() {
+        if let Some(raw) = parse_query_param(&search, "dm_voice_proxy_url")
+            .or_else(|| parse_query_param(&search, "elevenlabs_proxy_url"))
+        {
+            if let Ok(Some(storage)) = win.local_storage() {
+                let _ = storage.set_item("trpg_dm_voice_proxy_url", raw.trim());
+            }
+            if let Some(url) = normalize(&raw) {
+                return Some(url);
+            }
+        }
+    }
+
+    if let Ok(Some(storage)) = win.local_storage() {
+        if let Ok(Some(raw)) = storage.get_item("trpg_dm_voice_proxy_url") {
+            if let Some(url) = normalize(&raw) {
+                return Some(url);
+            }
+        }
+    }
+
+    if let Some(doc) = win.document() {
+        if let Ok(Some(meta)) = doc.query_selector("meta[name='trpg-dm-voice-proxy-url']") {
+            if let Some(raw) = meta.get_attribute("content") {
+                if let Some(url) = normalize(&raw) {
+                    return Some(url);
+                }
+            }
+        }
+    }
+
+    None
+}
+
+#[cfg(target_arch = "wasm32")]
+fn parse_query_param(search: &str, key: &str) -> Option<String> {
+    let search = search.trim_start_matches('?');
+    for pair in search.split('&') {
+        let mut parts = pair.splitn(2, '=');
+        if let Some(k) = parts.next() {
+            if k == key {
+                return parts.next().map(|v| v.to_string());
+            }
+        }
+    }
+    None
+}
+
+#[cfg(target_arch = "wasm32")]
+fn global_string(win: &web_sys::Window, key: &str) -> Option<String> {
+    let value = js_sys::Reflect::get(win.as_ref(), &wasm_bindgen::JsValue::from_str(key)).ok()?;
+    value.as_string()
+}
+
+#[cfg(target_arch = "wasm32")]
+fn speak_with_browser(text: &str) {
+    let Some(win) = web_sys::window() else {
+        return;
+    };
+    let Ok(synth) = win.speech_synthesis() else {
+        return;
+    };
+    let Ok(utterance) = web_sys::SpeechSynthesisUtterance::new_with_text(text) else {
+        return;
+    };
+    utterance.set_lang("ko-KR");
+    utterance.set_rate(1.0);
+    utterance.set_pitch(1.0);
+    synth.cancel();
+    synth.speak(&utterance);
+}
+
+#[cfg(target_arch = "wasm32")]
+fn speak_with_proxy(proxy_url: String, text: String, room_id: String, phase: String, turn: u32) {
+    wasm_bindgen_futures::spawn_local(async move {
+        if let Err(err) =
+            speak_with_proxy_inner(proxy_url, text.clone(), room_id, phase, turn).await
+        {
+            log::warn!("dm voice proxy failed, fallback to browser speech: {}", err);
+            speak_with_browser(&text);
+        }
+    });
+}
+
+#[cfg(target_arch = "wasm32")]
+async fn speak_with_proxy_inner(
+    proxy_url: String,
+    text: String,
+    room_id: String,
+    phase: String,
+    turn: u32,
+) -> Result<(), String> {
+    use wasm_bindgen::JsCast;
+    use wasm_bindgen_futures::JsFuture;
+
+    let Some(win) = web_sys::window() else {
+        return Err("window unavailable".to_string());
+    };
+
+    let body = serde_json::json!({
+        "text": text,
+        "speaker": "dm",
+        "phase": phase,
+        "room_id": room_id,
+        "turn": turn,
+    })
+    .to_string();
+
+    let init = web_sys::RequestInit::new();
+    init.set_method("POST");
+    init.set_mode(web_sys::RequestMode::Cors);
+    init.set_body(&wasm_bindgen::JsValue::from_str(&body));
+
+    let request = web_sys::Request::new_with_str_and_init(&proxy_url, &init)
+        .map_err(|_| "failed to create request".to_string())?;
+    request
+        .headers()
+        .set("content-type", "application/json")
+        .map_err(|_| "failed to set content-type header".to_string())?;
+
+    let resp_value = JsFuture::from(win.fetch_with_request(&request))
+        .await
+        .map_err(|_| "fetch failed".to_string())?;
+    let response: web_sys::Response = resp_value
+        .dyn_into()
+        .map_err(|_| "response cast failed".to_string())?;
+
+    if !response.ok() {
+        return Err(format!("proxy HTTP {}", response.status()));
+    }
+
+    let content_type = response
+        .headers()
+        .get("content-type")
+        .ok()
+        .flatten()
+        .unwrap_or_default()
+        .to_ascii_lowercase();
+
+    if content_type.contains("application/json") {
+        let json = JsFuture::from(
+            response
+                .json()
+                .map_err(|_| "failed to decode json response".to_string())?,
+        )
+        .await
+        .map_err(|_| "json parse failed".to_string())?;
+        if let Some(src) = extract_audio_source_from_json(&json) {
+            play_audio_source(&src)?;
+            return Ok(());
+        }
+        return Err("json response has no playable audio source".to_string());
+    }
+
+    if content_type.starts_with("audio/") {
+        let blob = JsFuture::from(
+            response
+                .blob()
+                .map_err(|_| "failed to read audio blob".to_string())?,
+        )
+        .await
+        .map_err(|_| "blob parse failed".to_string())?;
+        let blob: web_sys::Blob = blob
+            .dyn_into()
+            .map_err(|_| "blob cast failed".to_string())?;
+        let object_url = web_sys::Url::create_object_url_with_blob(&blob)
+            .map_err(|_| "failed to create blob object url".to_string())?;
+        play_audio_source(&object_url)?;
+        return Ok(());
+    }
+
+    let text_resp = JsFuture::from(
+        response
+            .text()
+            .map_err(|_| "failed to read text response".to_string())?,
+    )
+    .await
+    .map_err(|_| "text parse failed".to_string())?;
+    if let Some(raw) = text_resp.as_string() {
+        if let Some(src) = normalize_audio_source_candidate(&raw) {
+            play_audio_source(&src)?;
+            return Ok(());
+        }
+    }
+
+    Err("unsupported proxy response format".to_string())
+}
+
+#[cfg(target_arch = "wasm32")]
+fn extract_audio_source_from_json(value: &wasm_bindgen::JsValue) -> Option<String> {
+    let keys = [
+        "audio_url",
+        "audioUrl",
+        "url",
+        "signed_url",
+        "signedUrl",
+        "base64_audio",
+        "audio_base64",
+        "audioBase64",
+    ];
+    for key in keys {
+        if let Some(src) = extract_string_field(value, key) {
+            if key.contains("base64") {
+                return Some(format!("data:audio/mpeg;base64,{}", src));
+            }
+            if let Some(normalized) = normalize_audio_source_candidate(&src) {
+                return Some(normalized);
+            }
+        }
+    }
+    for nested in ["data", "payload", "result"] {
+        if let Some(obj) = extract_js_field(value, nested) {
+            if let Some(src) = extract_audio_source_from_json(&obj) {
+                return Some(src);
+            }
+        }
+    }
+    None
+}
+
+#[cfg(target_arch = "wasm32")]
+fn extract_string_field(value: &wasm_bindgen::JsValue, key: &str) -> Option<String> {
+    let field = extract_js_field(value, key)?;
+    let raw = field.as_string()?;
+    Some(raw.trim().to_string())
+}
+
+#[cfg(target_arch = "wasm32")]
+fn extract_js_field(value: &wasm_bindgen::JsValue, key: &str) -> Option<wasm_bindgen::JsValue> {
+    js_sys::Reflect::get(value, &wasm_bindgen::JsValue::from_str(key)).ok()
+}
+
+#[cfg(target_arch = "wasm32")]
+fn normalize_audio_source_candidate(raw: &str) -> Option<String> {
+    let trimmed = raw.trim();
+    if trimmed.starts_with("https://")
+        || trimmed.starts_with("http://")
+        || trimmed.starts_with("data:audio/")
+        || trimmed.starts_with("blob:")
+    {
+        return Some(trimmed.to_string());
+    }
+    None
+}
+
+#[cfg(target_arch = "wasm32")]
+fn play_audio_source(source: &str) -> Result<(), String> {
+    let audio = web_sys::HtmlAudioElement::new_with_src(source)
+        .map_err(|_| "failed to create HtmlAudioElement".to_string())?;
+    audio.set_preload("auto");
+    let _ = audio.play().map_err(|_| "audio play failed".to_string())?;
+    std::mem::forget(audio);
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::should_play_dm_voice;
+    use crate::game::events::NarrativePayload;
+    use crate::game::state::{RoomState, TurnPhase, TurnProgressState};
+
+    fn payload(phase: &str, speaker: Option<&str>, text: &str) -> NarrativePayload {
+        NarrativePayload {
+            text: text.to_string(),
+            phase: phase.to_string(),
+            turn: 3,
+            room_id: "adventure-room".to_string(),
+            speaker: speaker.map(|s| s.to_string()),
+        }
+    }
+
+    fn running_state() -> (RoomState, TurnProgressState) {
+        let room = RoomState {
+            id: "adventure-room".to_string(),
+            status: "active".to_string(),
+            turn: 3,
+            phase: TurnPhase::DmNarration,
+            current_scenario: "".to_string(),
+            current_node: "".to_string(),
+        };
+        let progress = TurnProgressState::default();
+        (room, progress)
+    }
+
+    #[test]
+    fn dm_voice_requires_running_lifecycle() {
+        let (mut room, progress) = running_state();
+        room.status = "ended".to_string();
+        assert!(!should_play_dm_voice(
+            &payload("dm_narration", Some("dm"), "테스트"),
+            "테스트",
+            &room,
+            &progress
+        ));
+    }
+
+    #[test]
+    fn dm_voice_accepts_dm_phase_during_running() {
+        let (room, progress) = running_state();
+        assert!(should_play_dm_voice(
+            &payload("dm_narration", None, "짙은 안개가 깔린다."),
+            "짙은 안개가 깔린다.",
+            &room,
+            &progress
+        ));
+    }
+
+    #[test]
+    fn dm_voice_skips_non_dm_events() {
+        let (room, progress) = running_state();
+        assert!(!should_play_dm_voice(
+            &payload("action_declaration", Some("luna"), "플레이어 행동"),
+            "플레이어 행동",
+            &room,
+            &progress
+        ));
+    }
+}

--- a/viewer/src/dom/dm_voice.rs
+++ b/viewer/src/dom/dm_voice.rs
@@ -1,3 +1,5 @@
+use bevy::prelude::Res;
+
 use crate::game::events::NarrativePayload;
 use crate::game::lifecycle::TrpgLifecycleState;
 use crate::game::state::{RoomState, TurnProgressState};
@@ -9,6 +11,30 @@ enum DmVoiceMode {
     Browser,
     ElevenLabs,
 }
+
+#[cfg(target_arch = "wasm32")]
+const STORAGE_DM_VOICE_MODE: &str = "trpg_dm_voice_mode";
+#[cfg(target_arch = "wasm32")]
+const STORAGE_DM_VOICE_PROXY_URL: &str = "trpg_dm_voice_proxy_url";
+#[cfg(target_arch = "wasm32")]
+const STORAGE_DM_VOICE_MODEL: &str = "trpg_dm_voice_model";
+#[cfg(target_arch = "wasm32")]
+const STORAGE_DM_VOICE_ID: &str = "trpg_dm_voice_id";
+
+#[cfg(target_arch = "wasm32")]
+const DM_VOICE_PANEL_ID: &str = "dm-voice-config";
+#[cfg(target_arch = "wasm32")]
+const DM_VOICE_MODE_SELECT_ID: &str = "dm-voice-mode-select";
+#[cfg(target_arch = "wasm32")]
+const DM_VOICE_PROXY_INPUT_ID: &str = "dm-voice-proxy-url";
+#[cfg(target_arch = "wasm32")]
+const DM_VOICE_MODEL_INPUT_ID: &str = "dm-voice-model";
+#[cfg(target_arch = "wasm32")]
+const DM_VOICE_ID_INPUT_ID: &str = "dm-voice-id";
+#[cfg(target_arch = "wasm32")]
+const DM_VOICE_SAVE_BUTTON_ID: &str = "dm-voice-save-btn";
+#[cfg(target_arch = "wasm32")]
+const DM_VOICE_STATUS_ID: &str = "dm-voice-status";
 
 fn normalize_phase(raw: &str) -> String {
     raw.trim().to_ascii_lowercase().replace('-', "_")
@@ -66,6 +92,76 @@ pub fn maybe_play_dm_voice(
     }
 }
 
+pub fn bind_dm_voice_controls() {
+    #[cfg(target_arch = "wasm32")]
+    {
+        bind_dm_voice_controls_impl();
+    }
+}
+
+pub fn unbind_dm_voice_controls() {
+    #[cfg(target_arch = "wasm32")]
+    {
+        if let Some(doc) = web_sys::window().and_then(|w| w.document()) {
+            set_dm_voice_status(
+                &doc,
+                "status-info",
+                "DM 음성은 세션 진행 중일 때만 재생됩니다.",
+            );
+        }
+    }
+}
+
+pub fn sync_dm_voice_controls(_room_state: Res<RoomState>, _progress: Res<TurnProgressState>) {
+    #[cfg(target_arch = "wasm32")]
+    {
+        let Some(doc) = web_sys::window().and_then(|w| w.document()) else {
+            return;
+        };
+        if doc.get_element_by_id(DM_VOICE_STATUS_ID).is_none() {
+            return;
+        }
+
+        let mode = resolve_dm_voice_mode();
+        let running = is_room_running(&_room_state, &_progress);
+        match (running, mode) {
+            (false, _) => {
+                set_dm_voice_status(
+                    &doc,
+                    "status-info",
+                    "대기 상태: 세션이 진행 중일 때만 DM 음성이 재생됩니다.",
+                );
+            }
+            (true, DmVoiceMode::Off) => {
+                set_dm_voice_status(
+                    &doc,
+                    "status-warn",
+                    "진행 중이지만 DM 음성 모드가 OFF 입니다.",
+                );
+            }
+            (true, DmVoiceMode::Browser) => {
+                set_dm_voice_status(
+                    &doc,
+                    "status-ok",
+                    "진행 중: Browser TTS로 DM 내레이션을 재생합니다.",
+                );
+            }
+            (true, DmVoiceMode::ElevenLabs) => {
+                let model = resolve_dm_voice_model().unwrap_or_else(|| "-".to_string());
+                let voice_id = resolve_dm_voice_id().unwrap_or_else(|| "-".to_string());
+                set_dm_voice_status(
+                    &doc,
+                    "status-ok",
+                    &format!(
+                        "진행 중: ElevenLabs proxy 사용 (model: {}, voice_id: {})",
+                        model, voice_id
+                    ),
+                );
+            }
+        }
+    }
+}
+
 #[cfg(target_arch = "wasm32")]
 fn dispatch_voice(payload: &NarrativePayload, clean_text: &str, room_state: &RoomState) {
     let text = clean_text.trim().to_string();
@@ -79,13 +175,15 @@ fn dispatch_voice(payload: &NarrativePayload, clean_text: &str, room_state: &Roo
     };
     let phase = payload.phase.trim().to_string();
     let turn = payload.turn;
+    let voice_model = resolve_dm_voice_model();
+    let voice_id = resolve_dm_voice_id();
 
     match resolve_dm_voice_mode() {
         DmVoiceMode::Off => {}
         DmVoiceMode::Browser => speak_with_browser(&text),
         DmVoiceMode::ElevenLabs => {
             if let Some(proxy_url) = resolve_dm_voice_proxy_url() {
-                speak_with_proxy(proxy_url, text, room_id, phase, turn);
+                speak_with_proxy(proxy_url, text, room_id, phase, turn, voice_model, voice_id);
             } else {
                 speak_with_browser(&text);
             }
@@ -103,97 +201,266 @@ fn parse_dm_voice_mode(raw: &str) -> DmVoiceMode {
 }
 
 #[cfg(target_arch = "wasm32")]
+fn dm_voice_mode_value(mode: DmVoiceMode) -> &'static str {
+    match mode {
+        DmVoiceMode::Off => "off",
+        DmVoiceMode::Browser => "browser",
+        DmVoiceMode::ElevenLabs => "elevenlabs",
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
 fn resolve_dm_voice_mode() -> DmVoiceMode {
-    let Some(win) = web_sys::window() else {
-        return DmVoiceMode::Browser;
-    };
-
-    if let Some(raw) = global_string(&win, "__TRPG_DM_VOICE_MODE")
-        .or_else(|| global_string(&win, "__DM_VOICE_MODE"))
-    {
-        return parse_dm_voice_mode(&raw);
-    }
-
-    if let Ok(search) = win.location().search() {
-        if let Some(raw) = parse_query_param(&search, "dm_voice")
-            .or_else(|| parse_query_param(&search, "dm_voice_mode"))
-        {
-            if let Ok(Some(storage)) = win.local_storage() {
-                let _ = storage.set_item("trpg_dm_voice_mode", raw.trim());
-            }
-            return parse_dm_voice_mode(&raw);
-        }
-    }
-
-    if let Ok(Some(storage)) = win.local_storage() {
-        if let Ok(Some(raw)) = storage.get_item("trpg_dm_voice_mode") {
-            return parse_dm_voice_mode(&raw);
-        }
-    }
-
-    if let Some(doc) = win.document() {
-        if let Ok(Some(meta)) = doc.query_selector("meta[name='trpg-dm-voice-mode']") {
-            if let Some(raw) = meta.get_attribute("content") {
-                return parse_dm_voice_mode(&raw);
-            }
-        }
-    }
-
-    DmVoiceMode::Browser
+    resolve_string_setting(
+        &["__TRPG_DM_VOICE_MODE", "__DM_VOICE_MODE"],
+        &["dm_voice", "dm_voice_mode"],
+        STORAGE_DM_VOICE_MODE,
+        "meta[name='trpg-dm-voice-mode']",
+    )
+    .map(|raw| parse_dm_voice_mode(&raw))
+    .unwrap_or(DmVoiceMode::Browser)
 }
 
 #[cfg(target_arch = "wasm32")]
 fn resolve_dm_voice_proxy_url() -> Option<String> {
-    let win = web_sys::window()?;
-    let normalize = |raw: &str| {
-        let trimmed = raw.trim();
-        if trimmed.is_empty() {
-            None
-        } else {
-            Some(trimmed.to_string())
-        }
-    };
+    resolve_string_setting(
+        &["__TRPG_DM_VOICE_PROXY_URL", "__ELEVENLABS_PROXY_URL"],
+        &["dm_voice_proxy_url", "elevenlabs_proxy_url"],
+        STORAGE_DM_VOICE_PROXY_URL,
+        "meta[name='trpg-dm-voice-proxy-url']",
+    )
+}
 
-    if let Some(raw) = global_string(&win, "__TRPG_DM_VOICE_PROXY_URL")
-        .or_else(|| global_string(&win, "__ELEVENLABS_PROXY_URL"))
-    {
-        if let Some(url) = normalize(&raw) {
-            return Some(url);
+#[cfg(target_arch = "wasm32")]
+fn resolve_dm_voice_model() -> Option<String> {
+    resolve_string_setting(
+        &["__TRPG_DM_VOICE_MODEL", "__ELEVENLABS_MODEL"],
+        &["dm_voice_model", "elevenlabs_model"],
+        STORAGE_DM_VOICE_MODEL,
+        "meta[name='trpg-dm-voice-model']",
+    )
+}
+
+#[cfg(target_arch = "wasm32")]
+fn resolve_dm_voice_id() -> Option<String> {
+    resolve_string_setting(
+        &["__TRPG_DM_VOICE_ID", "__ELEVENLABS_VOICE_ID"],
+        &["dm_voice_id", "dm_voice_voice_id", "elevenlabs_voice_id"],
+        STORAGE_DM_VOICE_ID,
+        "meta[name='trpg-dm-voice-id']",
+    )
+}
+
+#[cfg(target_arch = "wasm32")]
+fn normalize_optional(raw: &str) -> Option<String> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        None
+    } else {
+        Some(trimmed.to_string())
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+fn resolve_string_setting(
+    global_keys: &[&str],
+    query_keys: &[&str],
+    storage_key: &str,
+    meta_selector: &str,
+) -> Option<String> {
+    let win = web_sys::window()?;
+
+    for key in global_keys {
+        if let Some(raw) = global_string(&win, key) {
+            if let Some(value) = normalize_optional(&raw) {
+                return Some(value);
+            }
         }
     }
 
     if let Ok(search) = win.location().search() {
-        if let Some(raw) = parse_query_param(&search, "dm_voice_proxy_url")
-            .or_else(|| parse_query_param(&search, "elevenlabs_proxy_url"))
-        {
-            if let Ok(Some(storage)) = win.local_storage() {
-                let _ = storage.set_item("trpg_dm_voice_proxy_url", raw.trim());
-            }
-            if let Some(url) = normalize(&raw) {
-                return Some(url);
+        for key in query_keys {
+            if let Some(raw) = parse_query_param(&search, key) {
+                if let Some(value) = normalize_optional(&raw) {
+                    if let Ok(Some(storage)) = win.local_storage() {
+                        let _ = storage.set_item(storage_key, &value);
+                    }
+                    return Some(value);
+                }
             }
         }
     }
 
     if let Ok(Some(storage)) = win.local_storage() {
-        if let Ok(Some(raw)) = storage.get_item("trpg_dm_voice_proxy_url") {
-            if let Some(url) = normalize(&raw) {
-                return Some(url);
+        if let Ok(Some(raw)) = storage.get_item(storage_key) {
+            if let Some(value) = normalize_optional(&raw) {
+                return Some(value);
             }
         }
     }
 
     if let Some(doc) = win.document() {
-        if let Ok(Some(meta)) = doc.query_selector("meta[name='trpg-dm-voice-proxy-url']") {
+        if let Ok(Some(meta)) = doc.query_selector(meta_selector) {
             if let Some(raw) = meta.get_attribute("content") {
-                if let Some(url) = normalize(&raw) {
-                    return Some(url);
+                if let Some(value) = normalize_optional(&raw) {
+                    return Some(value);
                 }
             }
         }
     }
 
     None
+}
+
+#[cfg(target_arch = "wasm32")]
+fn get_input_value(doc: &web_sys::Document, id: &str) -> Option<String> {
+    use wasm_bindgen::JsCast;
+    doc.get_element_by_id(id)
+        .and_then(|el| el.dyn_into::<web_sys::HtmlInputElement>().ok())
+        .map(|input| input.value())
+}
+
+#[cfg(target_arch = "wasm32")]
+fn set_input_value(doc: &web_sys::Document, id: &str, value: &str) {
+    use wasm_bindgen::JsCast;
+    if let Some(input) = doc
+        .get_element_by_id(id)
+        .and_then(|el| el.dyn_into::<web_sys::HtmlInputElement>().ok())
+    {
+        input.set_value(value);
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+fn get_select_value(doc: &web_sys::Document, id: &str) -> Option<String> {
+    use wasm_bindgen::JsCast;
+    doc.get_element_by_id(id)
+        .and_then(|el| el.dyn_into::<web_sys::HtmlSelectElement>().ok())
+        .map(|select| select.value())
+}
+
+#[cfg(target_arch = "wasm32")]
+fn set_select_value(doc: &web_sys::Document, id: &str, value: &str) {
+    use wasm_bindgen::JsCast;
+    if let Some(select) = doc
+        .get_element_by_id(id)
+        .and_then(|el| el.dyn_into::<web_sys::HtmlSelectElement>().ok())
+    {
+        select.set_value(value);
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+fn persist_storage_value(key: &str, value: Option<String>) {
+    let Some(win) = web_sys::window() else {
+        return;
+    };
+    let Ok(Some(storage)) = win.local_storage() else {
+        return;
+    };
+    match value.and_then(|v| normalize_optional(&v)) {
+        Some(v) => {
+            let _ = storage.set_item(key, &v);
+        }
+        None => {
+            let _ = storage.remove_item(key);
+        }
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+fn set_dm_voice_status(doc: &web_sys::Document, level_class: &str, message: &str) {
+    if let Some(el) = doc.get_element_by_id(DM_VOICE_STATUS_ID) {
+        el.set_class_name(&format!("turn-control-gate {}", level_class));
+        el.set_text_content(Some(message));
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+fn hydrate_dm_voice_controls(doc: &web_sys::Document) {
+    set_select_value(
+        doc,
+        DM_VOICE_MODE_SELECT_ID,
+        dm_voice_mode_value(resolve_dm_voice_mode()),
+    );
+    set_input_value(
+        doc,
+        DM_VOICE_PROXY_INPUT_ID,
+        &resolve_dm_voice_proxy_url().unwrap_or_default(),
+    );
+    set_input_value(
+        doc,
+        DM_VOICE_MODEL_INPUT_ID,
+        &resolve_dm_voice_model().unwrap_or_default(),
+    );
+    set_input_value(
+        doc,
+        DM_VOICE_ID_INPUT_ID,
+        &resolve_dm_voice_id().unwrap_or_default(),
+    );
+}
+
+#[cfg(target_arch = "wasm32")]
+fn bind_dm_voice_save_button(doc: &web_sys::Document) {
+    use wasm_bindgen::prelude::Closure;
+    use wasm_bindgen::JsCast;
+
+    let Some(button) = doc.get_element_by_id(DM_VOICE_SAVE_BUTTON_ID) else {
+        return;
+    };
+    if button.get_attribute("data-bound").as_deref() == Some("1") {
+        return;
+    }
+    let _ = button.set_attribute("data-bound", "1");
+
+    let cb = Closure::wrap(Box::new(move || {
+        let Some(doc) = web_sys::window().and_then(|w| w.document()) else {
+            return;
+        };
+        let mode = get_select_value(&doc, DM_VOICE_MODE_SELECT_ID)
+            .map(|raw| parse_dm_voice_mode(&raw))
+            .unwrap_or(DmVoiceMode::Browser);
+        let proxy_url = get_input_value(&doc, DM_VOICE_PROXY_INPUT_ID).unwrap_or_default();
+        let voice_model = get_input_value(&doc, DM_VOICE_MODEL_INPUT_ID).unwrap_or_default();
+        let voice_id = get_input_value(&doc, DM_VOICE_ID_INPUT_ID).unwrap_or_default();
+
+        persist_storage_value(
+            STORAGE_DM_VOICE_MODE,
+            Some(dm_voice_mode_value(mode).to_string()),
+        );
+        persist_storage_value(STORAGE_DM_VOICE_PROXY_URL, Some(proxy_url));
+        persist_storage_value(STORAGE_DM_VOICE_MODEL, Some(voice_model));
+        persist_storage_value(STORAGE_DM_VOICE_ID, Some(voice_id));
+
+        set_dm_voice_status(&doc, "status-ok", "DM 음성 설정을 저장했습니다.");
+    }) as Box<dyn FnMut()>);
+
+    let _ = button.dyn_ref::<web_sys::EventTarget>().map(|target| {
+        target.add_event_listener_with_callback("click", cb.as_ref().unchecked_ref())
+    });
+    cb.forget();
+}
+
+#[cfg(target_arch = "wasm32")]
+fn bind_dm_voice_controls_impl() {
+    let Some(doc) = web_sys::window().and_then(|w| w.document()) else {
+        return;
+    };
+    let Some(panel) = doc.get_element_by_id(DM_VOICE_PANEL_ID) else {
+        return;
+    };
+    if panel.get_attribute("data-bound").as_deref() == Some("1") {
+        return;
+    }
+    let _ = panel.set_attribute("data-bound", "1");
+
+    hydrate_dm_voice_controls(&doc);
+    bind_dm_voice_save_button(&doc);
+    set_dm_voice_status(
+        &doc,
+        "status-info",
+        "DM 음성은 세션 진행 중일 때만 재생됩니다.",
+    );
 }
 
 #[cfg(target_arch = "wasm32")]
@@ -235,10 +502,26 @@ fn speak_with_browser(text: &str) {
 }
 
 #[cfg(target_arch = "wasm32")]
-fn speak_with_proxy(proxy_url: String, text: String, room_id: String, phase: String, turn: u32) {
+fn speak_with_proxy(
+    proxy_url: String,
+    text: String,
+    room_id: String,
+    phase: String,
+    turn: u32,
+    voice_model: Option<String>,
+    voice_id: Option<String>,
+) {
     wasm_bindgen_futures::spawn_local(async move {
-        if let Err(err) =
-            speak_with_proxy_inner(proxy_url, text.clone(), room_id, phase, turn).await
+        if let Err(err) = speak_with_proxy_inner(
+            proxy_url,
+            text.clone(),
+            room_id,
+            phase,
+            turn,
+            voice_model,
+            voice_id,
+        )
+        .await
         {
             log::warn!("dm voice proxy failed, fallback to browser speech: {}", err);
             speak_with_browser(&text);
@@ -253,6 +536,8 @@ async fn speak_with_proxy_inner(
     room_id: String,
     phase: String,
     turn: u32,
+    voice_model: Option<String>,
+    voice_id: Option<String>,
 ) -> Result<(), String> {
     use wasm_bindgen::JsCast;
     use wasm_bindgen_futures::JsFuture;
@@ -261,14 +546,20 @@ async fn speak_with_proxy_inner(
         return Err("window unavailable".to_string());
     };
 
-    let body = serde_json::json!({
+    let mut body_json = serde_json::json!({
         "text": text,
         "speaker": "dm",
         "phase": phase,
         "room_id": room_id,
         "turn": turn,
-    })
-    .to_string();
+    });
+    if let Some(model) = voice_model.and_then(|v| normalize_optional(&v)) {
+        body_json["voice_model"] = serde_json::Value::String(model);
+    }
+    if let Some(id) = voice_id.and_then(|v| normalize_optional(&v)) {
+        body_json["voice_id"] = serde_json::Value::String(id);
+    }
+    let body = body_json.to_string();
 
     let init = web_sys::RequestInit::new();
     init.set_method("POST");

--- a/viewer/src/dom/dm_voice.rs
+++ b/viewer/src/dom/dm_voice.rs
@@ -28,13 +28,45 @@ const DM_VOICE_MODE_SELECT_ID: &str = "dm-voice-mode-select";
 #[cfg(target_arch = "wasm32")]
 const DM_VOICE_PROXY_INPUT_ID: &str = "dm-voice-proxy-url";
 #[cfg(target_arch = "wasm32")]
-const DM_VOICE_MODEL_INPUT_ID: &str = "dm-voice-model";
+const DM_VOICE_MODEL_SELECT_ID: &str = "dm-voice-model-select";
 #[cfg(target_arch = "wasm32")]
-const DM_VOICE_ID_INPUT_ID: &str = "dm-voice-id";
+const DM_VOICE_MODEL_CUSTOM_WRAP_ID: &str = "dm-voice-model-custom-wrap";
+#[cfg(target_arch = "wasm32")]
+const DM_VOICE_MODEL_CUSTOM_INPUT_ID: &str = "dm-voice-model-custom";
+#[cfg(target_arch = "wasm32")]
+const DM_VOICE_ID_SELECT_ID: &str = "dm-voice-id-select";
+#[cfg(target_arch = "wasm32")]
+const DM_VOICE_ID_CUSTOM_WRAP_ID: &str = "dm-voice-id-custom-wrap";
+#[cfg(target_arch = "wasm32")]
+const DM_VOICE_ID_CUSTOM_INPUT_ID: &str = "dm-voice-id-custom";
 #[cfg(target_arch = "wasm32")]
 const DM_VOICE_SAVE_BUTTON_ID: &str = "dm-voice-save-btn";
 #[cfg(target_arch = "wasm32")]
 const DM_VOICE_STATUS_ID: &str = "dm-voice-status";
+#[cfg(target_arch = "wasm32")]
+const DM_VOICE_CUSTOM_VALUE: &str = "custom";
+#[cfg(target_arch = "wasm32")]
+const DM_VOICE_RANDOM_PRESET_VALUE: &str = "random_preset";
+#[cfg(target_arch = "wasm32")]
+const DM_VOICE_RANDOM_PRESET_LABEL: &str = "랜덤 (추천 Voice 중 선택)";
+#[cfg(target_arch = "wasm32")]
+const DM_VOICE_MODEL_PRESETS: &[&str] = &[
+    "eleven_turbo_v2_5",
+    "eleven_flash_v2_5",
+    "eleven_multilingual_v2",
+];
+#[cfg(target_arch = "wasm32")]
+const DM_VOICE_ID_PRESETS: &[(&str, &str)] = &[
+    ("21m00Tcm4TlvDq8ikWAM", "Rachel"),
+    ("AZnzlk1XvdvUeBnXmlld", "Domi"),
+    ("EXAVITQu4vr4xnSDxMaL", "Bella"),
+    ("ErXwobaYiN019PkySvjV", "Antoni"),
+    ("MF3mGyEYCl7XYWbV9V6O", "Elli"),
+    ("TxGEqnHWrfWFTfGW9XjX", "Josh"),
+    ("VR6AewLTigWG4xSOukaG", "Arnold"),
+    ("pNInz6obpgDQGcFmaJgB", "Adam"),
+    ("yoZ06aMxZJJ28mfd3POQ", "Sam"),
+];
 
 fn normalize_phase(raw: &str) -> String {
     raw.trim().to_ascii_lowercase().replace('-', "_")
@@ -351,6 +383,87 @@ fn set_select_value(doc: &web_sys::Document, id: &str, value: &str) {
 }
 
 #[cfg(target_arch = "wasm32")]
+fn set_hidden(doc: &web_sys::Document, id: &str, hidden: bool) {
+    let Some(el) = doc.get_element_by_id(id) else {
+        return;
+    };
+    if hidden {
+        let _ = el.set_attribute("hidden", "");
+    } else {
+        let _ = el.remove_attribute("hidden");
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+fn hydrate_preset_select(
+    doc: &web_sys::Document,
+    select_id: &str,
+    custom_wrap_id: &str,
+    custom_input_id: &str,
+    current_value: Option<String>,
+    is_known_preset: fn(&str) -> bool,
+) {
+    match current_value.and_then(|v| normalize_optional(&v)) {
+        None => {
+            set_select_value(doc, select_id, "");
+            set_hidden(doc, custom_wrap_id, true);
+            set_input_value(doc, custom_input_id, "");
+        }
+        Some(value) if is_known_preset(&value) => {
+            set_select_value(doc, select_id, &value);
+            set_hidden(doc, custom_wrap_id, true);
+            set_input_value(doc, custom_input_id, "");
+        }
+        Some(value) => {
+            set_select_value(doc, select_id, DM_VOICE_CUSTOM_VALUE);
+            set_hidden(doc, custom_wrap_id, false);
+            set_input_value(doc, custom_input_id, &value);
+        }
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+fn select_storage_value(
+    doc: &web_sys::Document,
+    select_id: &str,
+    custom_wrap_id: &str,
+    custom_input_id: &str,
+) -> Option<String> {
+    let selected = get_select_value(doc, select_id).unwrap_or_default();
+    if selected == DM_VOICE_CUSTOM_VALUE {
+        set_hidden(doc, custom_wrap_id, false);
+        return get_input_value(doc, custom_input_id);
+    }
+    set_hidden(doc, custom_wrap_id, true);
+    if selected == DM_VOICE_RANDOM_PRESET_VALUE && select_id == DM_VOICE_ID_SELECT_ID {
+        return pick_random_voice_id();
+    }
+    Some(selected)
+}
+
+#[cfg(target_arch = "wasm32")]
+fn is_model_preset(value: &str) -> bool {
+    DM_VOICE_MODEL_PRESETS.iter().any(|preset| *preset == value)
+}
+
+#[cfg(target_arch = "wasm32")]
+fn is_voice_id_preset(value: &str) -> bool {
+    DM_VOICE_ID_PRESETS
+        .iter()
+        .any(|(preset, _name)| *preset == value)
+}
+
+#[cfg(target_arch = "wasm32")]
+fn pick_random_voice_id() -> Option<String> {
+    if DM_VOICE_ID_PRESETS.is_empty() {
+        return None;
+    }
+    let index = (js_sys::Math::random() * DM_VOICE_ID_PRESETS.len() as f64).floor() as usize;
+    let bounded = index.min(DM_VOICE_ID_PRESETS.len().saturating_sub(1));
+    Some(DM_VOICE_ID_PRESETS[bounded].0.to_string())
+}
+
+#[cfg(target_arch = "wasm32")]
 fn persist_storage_value(key: &str, value: Option<String>) {
     let Some(win) = web_sys::window() else {
         return;
@@ -388,16 +501,72 @@ fn hydrate_dm_voice_controls(doc: &web_sys::Document) {
         DM_VOICE_PROXY_INPUT_ID,
         &resolve_dm_voice_proxy_url().unwrap_or_default(),
     );
-    set_input_value(
+    hydrate_preset_select(
         doc,
-        DM_VOICE_MODEL_INPUT_ID,
-        &resolve_dm_voice_model().unwrap_or_default(),
+        DM_VOICE_MODEL_SELECT_ID,
+        DM_VOICE_MODEL_CUSTOM_WRAP_ID,
+        DM_VOICE_MODEL_CUSTOM_INPUT_ID,
+        resolve_dm_voice_model(),
+        is_model_preset,
     );
-    set_input_value(
+    hydrate_preset_select(
         doc,
-        DM_VOICE_ID_INPUT_ID,
-        &resolve_dm_voice_id().unwrap_or_default(),
+        DM_VOICE_ID_SELECT_ID,
+        DM_VOICE_ID_CUSTOM_WRAP_ID,
+        DM_VOICE_ID_CUSTOM_INPUT_ID,
+        resolve_dm_voice_id(),
+        is_voice_id_preset,
     );
+}
+
+#[cfg(target_arch = "wasm32")]
+fn sync_custom_field_visibility(
+    doc: &web_sys::Document,
+    select_id: &str,
+    custom_wrap_id: &str,
+    custom_input_id: &str,
+) {
+    let is_custom = get_select_value(doc, select_id).as_deref() == Some(DM_VOICE_CUSTOM_VALUE);
+    set_hidden(doc, custom_wrap_id, !is_custom);
+    if !is_custom {
+        set_input_value(doc, custom_input_id, "");
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+fn bind_custom_field_toggle(
+    doc: &web_sys::Document,
+    select_id: &str,
+    custom_wrap_id: &str,
+    custom_input_id: &str,
+) {
+    use wasm_bindgen::prelude::Closure;
+    use wasm_bindgen::JsCast;
+
+    let Some(select) = doc.get_element_by_id(select_id) else {
+        return;
+    };
+    let attr = format!("data-toggle-bound-{}", select_id);
+    if select.get_attribute(&attr).as_deref() == Some("1") {
+        return;
+    }
+    let _ = select.set_attribute(&attr, "1");
+
+    let select_id = select_id.to_string();
+    let custom_wrap_id = custom_wrap_id.to_string();
+    let custom_input_id = custom_input_id.to_string();
+
+    let cb = Closure::wrap(Box::new(move || {
+        let Some(doc) = web_sys::window().and_then(|w| w.document()) else {
+            return;
+        };
+        sync_custom_field_visibility(&doc, &select_id, &custom_wrap_id, &custom_input_id);
+    }) as Box<dyn FnMut()>);
+
+    let _ = select.dyn_ref::<web_sys::EventTarget>().map(|target| {
+        target.add_event_listener_with_callback("change", cb.as_ref().unchecked_ref())
+    });
+    cb.forget();
 }
 
 #[cfg(target_arch = "wasm32")]
@@ -421,18 +590,45 @@ fn bind_dm_voice_save_button(doc: &web_sys::Document) {
             .map(|raw| parse_dm_voice_mode(&raw))
             .unwrap_or(DmVoiceMode::Browser);
         let proxy_url = get_input_value(&doc, DM_VOICE_PROXY_INPUT_ID).unwrap_or_default();
-        let voice_model = get_input_value(&doc, DM_VOICE_MODEL_INPUT_ID).unwrap_or_default();
-        let voice_id = get_input_value(&doc, DM_VOICE_ID_INPUT_ID).unwrap_or_default();
+        let voice_model = select_storage_value(
+            &doc,
+            DM_VOICE_MODEL_SELECT_ID,
+            DM_VOICE_MODEL_CUSTOM_WRAP_ID,
+            DM_VOICE_MODEL_CUSTOM_INPUT_ID,
+        );
+        let voice_id = select_storage_value(
+            &doc,
+            DM_VOICE_ID_SELECT_ID,
+            DM_VOICE_ID_CUSTOM_WRAP_ID,
+            DM_VOICE_ID_CUSTOM_INPUT_ID,
+        );
 
         persist_storage_value(
             STORAGE_DM_VOICE_MODE,
             Some(dm_voice_mode_value(mode).to_string()),
         );
         persist_storage_value(STORAGE_DM_VOICE_PROXY_URL, Some(proxy_url));
-        persist_storage_value(STORAGE_DM_VOICE_MODEL, Some(voice_model));
-        persist_storage_value(STORAGE_DM_VOICE_ID, Some(voice_id));
+        persist_storage_value(STORAGE_DM_VOICE_MODEL, voice_model);
+        persist_storage_value(STORAGE_DM_VOICE_ID, voice_id.clone());
 
-        set_dm_voice_status(&doc, "status-ok", "DM 음성 설정을 저장했습니다.");
+        if get_select_value(&doc, DM_VOICE_ID_SELECT_ID).as_deref()
+            == Some(DM_VOICE_RANDOM_PRESET_VALUE)
+        {
+            if let Some(selected_id) = voice_id.and_then(|v| normalize_optional(&v)) {
+                set_dm_voice_status(
+                    &doc,
+                    "status-ok",
+                    &format!(
+                        "DM 음성 설정 저장 완료. {}: {}",
+                        DM_VOICE_RANDOM_PRESET_LABEL, selected_id
+                    ),
+                );
+            } else {
+                set_dm_voice_status(&doc, "status-ok", "DM 음성 설정을 저장했습니다.");
+            }
+        } else {
+            set_dm_voice_status(&doc, "status-ok", "DM 음성 설정을 저장했습니다.");
+        }
     }) as Box<dyn FnMut()>);
 
     let _ = button.dyn_ref::<web_sys::EventTarget>().map(|target| {
@@ -455,6 +651,30 @@ fn bind_dm_voice_controls_impl() {
     let _ = panel.set_attribute("data-bound", "1");
 
     hydrate_dm_voice_controls(&doc);
+    bind_custom_field_toggle(
+        &doc,
+        DM_VOICE_MODEL_SELECT_ID,
+        DM_VOICE_MODEL_CUSTOM_WRAP_ID,
+        DM_VOICE_MODEL_CUSTOM_INPUT_ID,
+    );
+    bind_custom_field_toggle(
+        &doc,
+        DM_VOICE_ID_SELECT_ID,
+        DM_VOICE_ID_CUSTOM_WRAP_ID,
+        DM_VOICE_ID_CUSTOM_INPUT_ID,
+    );
+    sync_custom_field_visibility(
+        &doc,
+        DM_VOICE_MODEL_SELECT_ID,
+        DM_VOICE_MODEL_CUSTOM_WRAP_ID,
+        DM_VOICE_MODEL_CUSTOM_INPUT_ID,
+    );
+    sync_custom_field_visibility(
+        &doc,
+        DM_VOICE_ID_SELECT_ID,
+        DM_VOICE_ID_CUSTOM_WRAP_ID,
+        DM_VOICE_ID_CUSTOM_INPUT_ID,
+    );
     bind_dm_voice_save_button(&doc);
     set_dm_voice_status(
         &doc,

--- a/viewer/src/dom/dm_voice.rs
+++ b/viewer/src/dom/dm_voice.rs
@@ -26,6 +26,10 @@ const DM_VOICE_PANEL_ID: &str = "dm-voice-config";
 #[cfg(target_arch = "wasm32")]
 const DM_VOICE_MODE_SELECT_ID: &str = "dm-voice-mode-select";
 #[cfg(target_arch = "wasm32")]
+const DM_VOICE_PROXY_SELECT_ID: &str = "dm-voice-proxy-select";
+#[cfg(target_arch = "wasm32")]
+const DM_VOICE_PROXY_CUSTOM_WRAP_ID: &str = "dm-voice-proxy-custom-wrap";
+#[cfg(target_arch = "wasm32")]
 const DM_VOICE_PROXY_INPUT_ID: &str = "dm-voice-proxy-url";
 #[cfg(target_arch = "wasm32")]
 const DM_VOICE_MODEL_SELECT_ID: &str = "dm-voice-model-select";
@@ -39,6 +43,8 @@ const DM_VOICE_ID_SELECT_ID: &str = "dm-voice-id-select";
 const DM_VOICE_ID_CUSTOM_WRAP_ID: &str = "dm-voice-id-custom-wrap";
 #[cfg(target_arch = "wasm32")]
 const DM_VOICE_ID_CUSTOM_INPUT_ID: &str = "dm-voice-id-custom";
+#[cfg(target_arch = "wasm32")]
+const DM_VOICE_PREVIEW_BUTTON_ID: &str = "dm-voice-preview-btn";
 #[cfg(target_arch = "wasm32")]
 const DM_VOICE_SAVE_BUTTON_ID: &str = "dm-voice-save-btn";
 #[cfg(target_arch = "wasm32")]
@@ -56,6 +62,8 @@ const DM_VOICE_MODEL_PRESETS: &[&str] = &[
     "eleven_multilingual_v2",
 ];
 #[cfg(target_arch = "wasm32")]
+const DM_VOICE_PROXY_ORIGIN_PRESETS: &[&str] = &["/api/v1/trpg/tts", "/api/v1/tts", "/tts"];
+#[cfg(target_arch = "wasm32")]
 const DM_VOICE_ID_PRESETS: &[(&str, &str)] = &[
     ("21m00Tcm4TlvDq8ikWAM", "Rachel"),
     ("AZnzlk1XvdvUeBnXmlld", "Domi"),
@@ -67,6 +75,8 @@ const DM_VOICE_ID_PRESETS: &[(&str, &str)] = &[
     ("pNInz6obpgDQGcFmaJgB", "Adam"),
     ("yoZ06aMxZJJ28mfd3POQ", "Sam"),
 ];
+#[cfg(target_arch = "wasm32")]
+const DM_VOICE_PREVIEW_TEXT: &str = "지금은 DM 음성 미리듣기 테스트 중입니다.";
 
 fn normalize_phase(raw: &str) -> String {
     raw.trim().to_ascii_lowercase().replace('-', "_")
@@ -284,6 +294,50 @@ fn resolve_dm_voice_id() -> Option<String> {
 }
 
 #[cfg(target_arch = "wasm32")]
+fn window_origin() -> Option<String> {
+    let win = web_sys::window()?;
+    let origin = win.location().origin().ok()?;
+    normalize_optional(&origin)
+}
+
+#[cfg(target_arch = "wasm32")]
+fn proxy_origin_value(path: &str) -> String {
+    format!("origin:{}", path)
+}
+
+#[cfg(target_arch = "wasm32")]
+fn resolve_proxy_url_from_select(raw: &str) -> Option<String> {
+    let selected = normalize_optional(raw)?;
+    if selected == DM_VOICE_CUSTOM_VALUE {
+        return None;
+    }
+    if let Some(path) = selected.strip_prefix("origin:") {
+        let origin = window_origin()?;
+        return Some(format!("{}{}", origin, path));
+    }
+    Some(selected)
+}
+
+#[cfg(target_arch = "wasm32")]
+fn detect_proxy_select_value(current_url: &str) -> Option<String> {
+    let current = normalize_optional(current_url)?;
+    if let Some(origin) = window_origin() {
+        for path in DM_VOICE_PROXY_ORIGIN_PRESETS {
+            let preset = format!("{}{}", origin, path);
+            if current == preset {
+                return Some(proxy_origin_value(path));
+            }
+        }
+    }
+    for path in DM_VOICE_PROXY_ORIGIN_PRESETS {
+        if current == *path {
+            return Some(proxy_origin_value(path));
+        }
+    }
+    None
+}
+
+#[cfg(target_arch = "wasm32")]
 fn normalize_optional(raw: &str) -> Option<String> {
     let trimmed = raw.trim();
     if trimmed.is_empty() {
@@ -423,6 +477,39 @@ fn hydrate_preset_select(
 }
 
 #[cfg(target_arch = "wasm32")]
+fn hydrate_proxy_select(doc: &web_sys::Document, current_url: Option<String>) {
+    match current_url.and_then(|v| normalize_optional(&v)) {
+        None => {
+            set_select_value(doc, DM_VOICE_PROXY_SELECT_ID, DM_VOICE_CUSTOM_VALUE);
+            set_hidden(doc, DM_VOICE_PROXY_CUSTOM_WRAP_ID, false);
+            set_input_value(doc, DM_VOICE_PROXY_INPUT_ID, "");
+        }
+        Some(value) => {
+            if let Some(preset) = detect_proxy_select_value(&value) {
+                set_select_value(doc, DM_VOICE_PROXY_SELECT_ID, &preset);
+                set_hidden(doc, DM_VOICE_PROXY_CUSTOM_WRAP_ID, true);
+                set_input_value(doc, DM_VOICE_PROXY_INPUT_ID, "");
+            } else {
+                set_select_value(doc, DM_VOICE_PROXY_SELECT_ID, DM_VOICE_CUSTOM_VALUE);
+                set_hidden(doc, DM_VOICE_PROXY_CUSTOM_WRAP_ID, false);
+                set_input_value(doc, DM_VOICE_PROXY_INPUT_ID, &value);
+            }
+        }
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+fn select_proxy_storage_value(doc: &web_sys::Document) -> Option<String> {
+    let selected = get_select_value(doc, DM_VOICE_PROXY_SELECT_ID).unwrap_or_default();
+    if selected == DM_VOICE_CUSTOM_VALUE {
+        set_hidden(doc, DM_VOICE_PROXY_CUSTOM_WRAP_ID, false);
+        return get_input_value(doc, DM_VOICE_PROXY_INPUT_ID);
+    }
+    set_hidden(doc, DM_VOICE_PROXY_CUSTOM_WRAP_ID, true);
+    resolve_proxy_url_from_select(&selected)
+}
+
+#[cfg(target_arch = "wasm32")]
 fn select_storage_value(
     doc: &web_sys::Document,
     select_id: &str,
@@ -496,11 +583,7 @@ fn hydrate_dm_voice_controls(doc: &web_sys::Document) {
         DM_VOICE_MODE_SELECT_ID,
         dm_voice_mode_value(resolve_dm_voice_mode()),
     );
-    set_input_value(
-        doc,
-        DM_VOICE_PROXY_INPUT_ID,
-        &resolve_dm_voice_proxy_url().unwrap_or_default(),
-    );
+    hydrate_proxy_select(doc, resolve_dm_voice_proxy_url());
     hydrate_preset_select(
         doc,
         DM_VOICE_MODEL_SELECT_ID,
@@ -589,7 +672,7 @@ fn bind_dm_voice_save_button(doc: &web_sys::Document) {
         let mode = get_select_value(&doc, DM_VOICE_MODE_SELECT_ID)
             .map(|raw| parse_dm_voice_mode(&raw))
             .unwrap_or(DmVoiceMode::Browser);
-        let proxy_url = get_input_value(&doc, DM_VOICE_PROXY_INPUT_ID).unwrap_or_default();
+        let proxy_url = select_proxy_storage_value(&doc);
         let voice_model = select_storage_value(
             &doc,
             DM_VOICE_MODEL_SELECT_ID,
@@ -607,7 +690,7 @@ fn bind_dm_voice_save_button(doc: &web_sys::Document) {
             STORAGE_DM_VOICE_MODE,
             Some(dm_voice_mode_value(mode).to_string()),
         );
-        persist_storage_value(STORAGE_DM_VOICE_PROXY_URL, Some(proxy_url));
+        persist_storage_value(STORAGE_DM_VOICE_PROXY_URL, proxy_url);
         persist_storage_value(STORAGE_DM_VOICE_MODEL, voice_model);
         persist_storage_value(STORAGE_DM_VOICE_ID, voice_id.clone());
 
@@ -638,6 +721,91 @@ fn bind_dm_voice_save_button(doc: &web_sys::Document) {
 }
 
 #[cfg(target_arch = "wasm32")]
+fn bind_dm_voice_preview_button(doc: &web_sys::Document) {
+    use wasm_bindgen::prelude::Closure;
+    use wasm_bindgen::JsCast;
+
+    let Some(button) = doc.get_element_by_id(DM_VOICE_PREVIEW_BUTTON_ID) else {
+        return;
+    };
+    if button.get_attribute("data-bound").as_deref() == Some("1") {
+        return;
+    }
+    let _ = button.set_attribute("data-bound", "1");
+
+    let cb = Closure::wrap(Box::new(move || {
+        let Some(doc) = web_sys::window().and_then(|w| w.document()) else {
+            return;
+        };
+        let mode = get_select_value(&doc, DM_VOICE_MODE_SELECT_ID)
+            .map(|raw| parse_dm_voice_mode(&raw))
+            .unwrap_or(DmVoiceMode::Browser);
+        let proxy_url = select_proxy_storage_value(&doc);
+        let voice_model = select_storage_value(
+            &doc,
+            DM_VOICE_MODEL_SELECT_ID,
+            DM_VOICE_MODEL_CUSTOM_WRAP_ID,
+            DM_VOICE_MODEL_CUSTOM_INPUT_ID,
+        );
+        let voice_id = select_storage_value(
+            &doc,
+            DM_VOICE_ID_SELECT_ID,
+            DM_VOICE_ID_CUSTOM_WRAP_ID,
+            DM_VOICE_ID_CUSTOM_INPUT_ID,
+        );
+
+        match mode {
+            DmVoiceMode::Off => {
+                set_dm_voice_status(
+                    &doc,
+                    "status-warn",
+                    "미리듣기는 OFF 모드에서 동작하지 않습니다. Browser 또는 ElevenLabs를 선택하세요.",
+                );
+            }
+            DmVoiceMode::Browser => {
+                speak_with_browser(DM_VOICE_PREVIEW_TEXT);
+                set_dm_voice_status(&doc, "status-ok", "Browser TTS 미리듣기를 재생했습니다.");
+            }
+            DmVoiceMode::ElevenLabs => {
+                let Some(proxy_url) = proxy_url else {
+                    set_dm_voice_status(
+                        &doc,
+                        "status-warn",
+                        "ElevenLabs 미리듣기에는 Proxy URL이 필요합니다.",
+                    );
+                    return;
+                };
+                speak_with_proxy(
+                    proxy_url,
+                    DM_VOICE_PREVIEW_TEXT.to_string(),
+                    crate::config::current_room_id(),
+                    "dm_narration".to_string(),
+                    0,
+                    voice_model.clone(),
+                    voice_id.clone(),
+                );
+
+                let model_label = voice_model.unwrap_or_else(|| "auto".to_string());
+                let voice_label = voice_id.unwrap_or_else(|| "auto".to_string());
+                set_dm_voice_status(
+                    &doc,
+                    "status-info",
+                    &format!(
+                        "ElevenLabs 미리듣기 요청 전송 (model: {}, voice_id: {})",
+                        model_label, voice_label
+                    ),
+                );
+            }
+        }
+    }) as Box<dyn FnMut()>);
+
+    let _ = button.dyn_ref::<web_sys::EventTarget>().map(|target| {
+        target.add_event_listener_with_callback("click", cb.as_ref().unchecked_ref())
+    });
+    cb.forget();
+}
+
+#[cfg(target_arch = "wasm32")]
 fn bind_dm_voice_controls_impl() {
     let Some(doc) = web_sys::window().and_then(|w| w.document()) else {
         return;
@@ -653,6 +821,12 @@ fn bind_dm_voice_controls_impl() {
     hydrate_dm_voice_controls(&doc);
     bind_custom_field_toggle(
         &doc,
+        DM_VOICE_PROXY_SELECT_ID,
+        DM_VOICE_PROXY_CUSTOM_WRAP_ID,
+        DM_VOICE_PROXY_INPUT_ID,
+    );
+    bind_custom_field_toggle(
+        &doc,
         DM_VOICE_MODEL_SELECT_ID,
         DM_VOICE_MODEL_CUSTOM_WRAP_ID,
         DM_VOICE_MODEL_CUSTOM_INPUT_ID,
@@ -662,6 +836,12 @@ fn bind_dm_voice_controls_impl() {
         DM_VOICE_ID_SELECT_ID,
         DM_VOICE_ID_CUSTOM_WRAP_ID,
         DM_VOICE_ID_CUSTOM_INPUT_ID,
+    );
+    sync_custom_field_visibility(
+        &doc,
+        DM_VOICE_PROXY_SELECT_ID,
+        DM_VOICE_PROXY_CUSTOM_WRAP_ID,
+        DM_VOICE_PROXY_INPUT_ID,
     );
     sync_custom_field_visibility(
         &doc,
@@ -676,6 +856,7 @@ fn bind_dm_voice_controls_impl() {
         DM_VOICE_ID_CUSTOM_INPUT_ID,
     );
     bind_dm_voice_save_button(&doc);
+    bind_dm_voice_preview_button(&doc);
     set_dm_voice_status(
         &doc,
         "status-info",

--- a/viewer/src/dom/mod.rs
+++ b/viewer/src/dom/mod.rs
@@ -5,6 +5,7 @@ pub mod character_panel;
 pub mod choice_panel;
 pub mod connection;
 pub mod dice_log;
+pub mod dm_voice;
 pub mod endgame;
 pub mod escape;
 pub mod gameplay_events;

--- a/viewer/src/dom/mod.rs
+++ b/viewer/src/dom/mod.rs
@@ -65,6 +65,10 @@ impl Plugin for DomBridgePlugin {
                 )
                     .run_if(in_state(ViewerMode::Trpg)),
             )
+            .add_systems(
+                Update,
+                dm_voice::sync_dm_voice_controls.run_if(in_state(ViewerMode::Trpg)),
+            )
             // Action panel lifecycle: bind listeners on enter, unbind on exit
             .add_systems(
                 OnEnter(ViewerMode::Trpg),
@@ -73,6 +77,7 @@ impl Plugin for DomBridgePlugin {
                     action_panel::sync_action_panel_interaction_state,
                     actor_join::bind_actor_join,
                     turn_controls::bind_turn_controls,
+                    dm_voice::bind_dm_voice_controls,
                 ),
             )
             .add_systems(
@@ -81,6 +86,7 @@ impl Plugin for DomBridgePlugin {
                     action_panel::unbind_action_panel,
                     actor_join::unbind_actor_join,
                     turn_controls::unbind_turn_controls,
+                    dm_voice::unbind_dm_voice_controls,
                 ),
             );
     }

--- a/viewer/src/dom/narrative.rs
+++ b/viewer/src/dom/narrative.rs
@@ -3,7 +3,9 @@ use wasm_bindgen::closure::Closure;
 use wasm_bindgen::JsCast;
 
 use crate::game::events::NarrativeReceived;
+use crate::game::state::{RoomState, TurnProgressState};
 
+use super::dm_voice;
 use super::escape::{sanitize_text, scroll_to_bottom, trim_log};
 use super::session_history::sync_history_focus_from_dashboard;
 
@@ -229,7 +231,11 @@ fn is_duplicate_narrative_entry(log_el: &web_sys::Element, dedup_key: &str) -> b
 }
 
 /// Appends narrative entries to the #narrative-log DOM element.
-pub fn update_narrative_dom(mut events: MessageReader<NarrativeReceived>) {
+pub fn update_narrative_dom(
+    mut events: MessageReader<NarrativeReceived>,
+    room_state: Res<RoomState>,
+    progress: Res<TurnProgressState>,
+) {
     let Some(document) = web_sys::window().and_then(|w| w.document()) else {
         return;
     };
@@ -316,9 +322,9 @@ pub fn update_narrative_dom(mut events: MessageReader<NarrativeReceived>) {
         if let Ok(text_el) = document.create_element("span") {
             text_el.set_class_name("narrative-text");
             let text = if speaker.is_some() {
-                format!(" {}", clean_text.clone())
+                format!(" {}", clean_text)
             } else {
-                clean_text
+                clean_text.clone()
             };
             text_el.set_text_content(Some(&text));
             let _ = entry.append_child(&text_el);
@@ -354,6 +360,9 @@ pub fn update_narrative_dom(mut events: MessageReader<NarrativeReceived>) {
         apply_debug_visibility(&entry, debug_enabled, is_debug_entry);
         scroll_to_bottom(&log_el);
         trim_log(&log_el, 200);
+        if !is_debug_entry {
+            dm_voice::maybe_play_dm_voice(&payload, &clean_text, &room_state, &progress);
+        }
     }
 }
 

--- a/viewer/style.css
+++ b/viewer/style.css
@@ -2557,6 +2557,52 @@ body.wasm-dom-fallback #bevy-canvas {
     margin-bottom: 8px;
 }
 
+.dm-voice-config {
+    margin: 0 0 8px;
+    border: 1px solid var(--border-main);
+    border-radius: var(--panel-radius);
+    background: rgba(15, 20, 36, 0.6);
+    overflow: hidden;
+}
+
+.dm-voice-config summary {
+    cursor: pointer;
+    list-style: none;
+    padding: 6px 8px;
+    font-size: 10px;
+    letter-spacing: 0.5px;
+    text-transform: uppercase;
+    color: var(--text-dim);
+    border-bottom: 1px solid rgba(109, 122, 164, 0.2);
+}
+
+.dm-voice-config summary::-webkit-details-marker {
+    display: none;
+}
+
+.dm-voice-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+    gap: 8px 10px;
+    padding: 8px;
+}
+
+.dm-voice-field-wide {
+    grid-column: 1 / -1;
+}
+
+.dm-voice-actions {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    flex-wrap: wrap;
+    padding: 0 8px 8px;
+}
+
+#dm-voice-status {
+    margin: 0 8px 8px;
+}
+
 .turn-recovery-actions {
     display: flex;
     align-items: center;

--- a/viewer/style.css
+++ b/viewer/style.css
@@ -2591,6 +2591,10 @@ body.wasm-dom-fallback #bevy-canvas {
     grid-column: 1 / -1;
 }
 
+.dm-voice-custom[hidden] {
+    display: none !important;
+}
+
 .dm-voice-actions {
     display: flex;
     align-items: center;


### PR DESCRIPTION
## Summary
- add DM narration voice playback hook in TRPG viewer DOM pipeline
- gate playback to active/running lifecycle only (`accepts_player_input`)
- support runtime voice modes: `off | browser | elevenlabs`
- add ElevenLabs proxy call path with automatic browser speech fallback
- keep debug/timeout narrative entries out of voice playback

## Runtime controls
- mode query: `?dm_voice=off|browser|elevenlabs`
- proxy query (when `dm_voice=elevenlabs`): `?dm_voice_proxy_url=https://...`
- localStorage keys are also respected and persisted from query values

## Validation
- `cd viewer && cargo check`
- `cd viewer && cargo test dm_voice --bin masc-viewer -- --nocapture`
- `cd viewer && cargo check --target wasm32-unknown-unknown`
