### PR TITLE
fix(viewer): resolve TRPG turn sync mismatch for hybrid state payload

### DIFF
--- a/viewer/src/game/http.rs
+++ b/viewer/src/game/http.rs
@@ -50,6 +50,10 @@ pub struct SkillData {
     pub name: String,
     #[serde(default = "default_skill_level")]
     pub level: i32,
+    #[serde(default)]
+    pub description: String,
+    #[serde(default)]
+    pub usage_hint: String,
 }
 
 fn default_skill_level() -> i32 {
@@ -499,7 +503,13 @@ async fn fetch_game_state() -> Result<GameStateResponse, JsValue> {
 
 fn normalize_state_response(root: Value) -> Result<GameStateResponse, String> {
     if root.get("room").is_some() {
-        return serde_json::from_value(root).map_err(|e| e.to_string());
+        let mut parsed: GameStateResponse =
+            serde_json::from_value(root.clone()).map_err(|e| e.to_string())?;
+        if root.get("state").is_some() {
+            let fallback = parse_masc_state_response(&root);
+            merge_state_fallback(&mut parsed, &fallback);
+        }
+        return Ok(parsed);
     }
 
     if root.get("state").is_some() {
@@ -511,6 +521,53 @@ fn normalize_state_response(root: Value) -> Result<GameStateResponse, String> {
     }
 
     Err("unsupported state payload shape".to_string())
+}
+
+fn merge_state_fallback(primary: &mut GameStateResponse, fallback: &GameStateResponse) {
+    match (&mut primary.room, fallback.room.as_ref()) {
+        (None, Some(room)) => primary.room = Some(room.clone()),
+        (Some(primary_room), Some(fallback_room)) => {
+            if primary_room.id.trim().is_empty() && !fallback_room.id.trim().is_empty() {
+                primary_room.id = fallback_room.id.clone();
+            }
+            if primary_room.status.trim().is_empty()
+                || primary_room.status.eq_ignore_ascii_case("unknown")
+            {
+                primary_room.status = fallback_room.status.clone();
+            }
+            if primary_room.turn == 0 && fallback_room.turn > 0 {
+                primary_room.turn = fallback_room.turn;
+            }
+            if primary_room.phase.trim().is_empty() && !fallback_room.phase.trim().is_empty() {
+                primary_room.phase = fallback_room.phase.clone();
+            }
+            if primary_room.current_scenario.trim().is_empty()
+                && !fallback_room.current_scenario.trim().is_empty()
+            {
+                primary_room.current_scenario = fallback_room.current_scenario.clone();
+            }
+            if primary_room.current_node.trim().is_empty() && !fallback_room.current_node.trim().is_empty() {
+                primary_room.current_node = fallback_room.current_node.clone();
+            }
+        }
+        _ => {}
+    }
+
+    if primary.characters.is_empty() && !fallback.characters.is_empty() {
+        primary.characters = fallback.characters.clone();
+    }
+    if primary.dm_keeper.trim().is_empty() && !fallback.dm_keeper.trim().is_empty() {
+        primary.dm_keeper = fallback.dm_keeper.clone();
+    }
+    if primary.current_area.trim().is_empty() && !fallback.current_area.trim().is_empty() {
+        primary.current_area = fallback.current_area.clone();
+    }
+    if primary.area_label.trim().is_empty() && !fallback.area_label.trim().is_empty() {
+        primary.area_label = fallback.area_label.clone();
+    }
+    if primary.dice_log.is_empty() && !fallback.dice_log.is_empty() {
+        primary.dice_log = fallback.dice_log.clone();
+    }
 }
 
 fn parse_masc_state_response(root: &Value) -> GameStateResponse {
@@ -626,13 +683,33 @@ fn parse_actor_control_map(state: &Value) -> HashMap<String, String> {
     actor_control
 }
 
+fn current_turn_marker(state: &Value) -> Option<u32> {
+    state
+        .get("turn")
+        .and_then(Value::as_u64)
+        .and_then(|turn| u32::try_from(turn).ok())
+        .filter(|turn| *turn > 0)
+}
+
+fn entry_turn_matches(entry: &Value, current_turn: u32) -> bool {
+    entry
+        .get("turn")
+        .and_then(Value::as_u64)
+        .and_then(|turn| u32::try_from(turn).ok())
+        .is_some_and(|turn| turn == current_turn)
+}
+
 fn infer_actor_control_from_dice(state: &Value) -> HashMap<String, String> {
+    let Some(current_turn) = current_turn_marker(state) else {
+        return HashMap::new();
+    };
     state
         .get("dice_log")
         .and_then(Value::as_array)
         .map(|entries| {
             entries
                 .iter()
+                .filter(|entry| entry_turn_matches(entry, current_turn))
                 .filter_map(|entry| {
                     let actor_id = entry
                         .get("actor_id")
@@ -662,12 +739,16 @@ fn infer_actor_control_from_dice(state: &Value) -> HashMap<String, String> {
 }
 
 fn infer_actor_control_from_narration(state: &Value) -> HashMap<String, String> {
+    let Some(current_turn) = current_turn_marker(state) else {
+        return HashMap::new();
+    };
     state
         .get("narration_log")
         .and_then(Value::as_array)
         .map(|entries| {
             entries
                 .iter()
+                .filter(|entry| entry_turn_matches(entry, current_turn))
                 .filter_map(|entry| {
                     let actor_id = entry
                         .get("actor_id")
@@ -695,11 +776,17 @@ fn infer_actor_control_from_narration(state: &Value) -> HashMap<String, String> 
 }
 
 fn infer_dm_keeper_from_narration(state: &Value) -> Option<String> {
+    let current_turn = current_turn_marker(state);
     state
         .get("narration_log")
         .and_then(Value::as_array)
         .and_then(|entries| {
             entries.iter().rev().find_map(|entry| {
+                if let Some(turn) = current_turn {
+                    if !entry_turn_matches(entry, turn) {
+                        return None;
+                    }
+                }
                 let role = entry.get("role").and_then(Value::as_str).unwrap_or("");
                 let actor_id = entry.get("actor_id").and_then(Value::as_str).unwrap_or("");
                 if role.eq_ignore_ascii_case("dm") || actor_id.eq_ignore_ascii_case("dm") {
@@ -957,6 +1044,8 @@ fn parse_party_characters(
                                 skill.as_str().map(|name| SkillData {
                                     name: name.to_string(),
                                     level: 10,
+                                    description: String::new(),
+                                    usage_hint: String::new(),
                                 })
                             }
                         })
@@ -1125,6 +1214,42 @@ mod tests {
     }
 
     #[test]
+    fn normalize_hybrid_shape_backfills_room_from_state() {
+        let root = json!({
+            "room": {
+                "id": "default"
+            },
+            "state": {
+                "room_id": "default",
+                "status": "active",
+                "turn": 40,
+                "phase": "round",
+                "current_area": "A",
+                "area_label": "Forest Entrance",
+                "party": {
+                    "hero-1": {
+                        "name": "Hero",
+                        "role": "fighter",
+                        "hp": 10,
+                        "max_hp": 10,
+                        "position": "A",
+                        "alive": true
+                    }
+                }
+            }
+        });
+
+        let parsed = normalize_state_response(root).expect("hybrid parse should succeed");
+        let room = parsed.room.as_ref().expect("room should exist");
+        assert_eq!(room.status, "active");
+        assert_eq!(room.turn, 40);
+        assert_eq!(room.phase, "round");
+        assert_eq!(parsed.current_area, "A");
+        assert_eq!(parsed.area_label, "Forest Entrance");
+        assert_eq!(parsed.characters.len(), 1);
+    }
+
+    #[test]
     fn normalize_masc_shape_uses_defaults_without_fallback_party() {
         let root = json!({
             "ok": true,
@@ -1238,11 +1363,13 @@ mod tests {
                 },
                 "narration_log": [
                     {
+                        "turn": 1,
                         "role": "player",
                         "actor_id": "grimja",
                         "keeper": "trpg-grimja"
                     },
                     {
+                        "turn": 2,
                         "role": "dm",
                         "actor_id": "dm",
                         "keeper": "  trpg-dm  "
@@ -1253,6 +1380,40 @@ mod tests {
 
         let parsed = normalize_state_response(root).expect("masc parse should succeed");
         assert_eq!(parsed.dm_keeper, "trpg-dm");
+    }
+
+    #[test]
+    fn normalize_masc_shape_ignores_stale_narration_keeper_mapping() {
+        let root = json!({
+            "ok": true,
+            "room_id": "default",
+            "state": {
+                "turn": 2,
+                "phase": "round",
+                "party": {
+                    "grimja": {
+                        "name": "그림자",
+                        "role": "fighter",
+                        "hp": 28,
+                        "max_hp": 30,
+                        "position": "C",
+                        "alive": true
+                    }
+                },
+                "narration_log": [
+                    {
+                        "turn": 1,
+                        "role": "player",
+                        "actor_id": "grimja",
+                        "keeper": "old-keeper"
+                    }
+                ]
+            }
+        });
+
+        let parsed = normalize_state_response(root).expect("masc parse should succeed");
+        assert_eq!(parsed.characters.len(), 1);
+        assert_eq!(parsed.characters[0].keeper, "");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- fix TRPG state normalization when `/api/v1/trpg/state` returns a hybrid payload (`room` + `state`)
- backfill missing/empty `room` fields from `state` data so turn/phase/status remain consistent
- keep actor-control inference scoped to current turn to avoid stale keeper mappings
- add regression tests for hybrid payload fallback and stale narration keeper mapping

## Problem
In some responses, `room` was present but mostly empty while fresh values lived under `state`.
The viewer parsed `room` first and ignored `state`, causing UI drift like `turn 1≠40`.

## Validation
- `cargo test normalize_hybrid_shape_backfills_room_from_state -- --nocapture`
- `cargo test normalize_masc_shape_ignores_stale_narration_keeper_mapping -- --nocapture`
