### PR TITLE
fix(trpg): sample keeper.unavailable with per-turn cap

### DIFF
--- a/lib/tool_trpg.ml
+++ b/lib/tool_trpg.ml
@@ -1635,7 +1635,97 @@ let call_keeper ctx ~name ~message ~timeout_sec =
   | None -> `Error "keeper_call is not available in this runtime"
   | Some f -> f ~name ~message ~timeout_sec
 
-let append_timeout_and_unavailable_events
+let keeper_unavailable_max_per_turn_default = 8
+
+let keeper_unavailable_max_per_turn_env =
+  "MASC_TRPG_KEEPER_UNAVAILABLE_MAX_PER_TURN"
+
+let keeper_unavailable_max_per_turn () =
+  match Sys.getenv_opt keeper_unavailable_max_per_turn_env with
+  | None -> keeper_unavailable_max_per_turn_default
+  | Some raw -> (
+      match int_of_string_opt (String.trim raw) with
+      | Some value when value >= 0 -> value
+      | _ -> keeper_unavailable_max_per_turn_default)
+
+type unavailable_sampling_state = {
+  max_per_turn : int;
+  mutable count_in_turn : int;
+  seen_keys : (string, unit) Hashtbl.t;
+}
+
+type unavailable_append_result =
+  [ `Appended of Trpg_engine_event.t | `Sampled of string ]
+
+let unavailable_sampling_key ~turn ~actor_id ~keeper_name ~stage ~reason =
+  Printf.sprintf "%d|%s|%s|%s|%s" turn actor_id
+    (normalize_keeper_name keeper_name)
+    (String.lowercase_ascii (String.trim stage))
+    (String.lowercase_ascii (String.trim reason))
+
+let make_unavailable_sampling_state ~(events : Trpg_engine_event.t list) ~turn :
+    unavailable_sampling_state =
+  let seen_keys = Hashtbl.create 64 in
+  let count_in_turn = ref 0 in
+  List.iter
+    (fun (event : Trpg_engine_event.t) ->
+      if event.event_type = Trpg_engine_event.Keeper_unavailable then
+        let payload_turn =
+          match event.payload |> member "turn" with
+          | `Int i -> Some i
+          | _ -> None
+        in
+        match payload_turn with
+        | Some payload_turn when payload_turn = turn ->
+            count_in_turn := !count_in_turn + 1;
+            let actor_id =
+              match event.payload |> member "actor_id" with
+              | `String v -> v
+              | _ ->
+                  Option.value ~default:"" event.actor_id |> String.trim
+            in
+            let keeper_name =
+              match event.payload |> member "keeper" with
+              | `String v -> v
+              | _ -> ""
+            in
+            let stage =
+              match event.payload |> member "stage" with
+              | `String v -> v
+              | _ -> ""
+            in
+            let reason =
+              match event.payload |> member "reason" with
+              | `String v -> v
+              | _ -> ""
+            in
+            if actor_id <> "" && keeper_name <> "" && stage <> "" then
+              let key =
+                unavailable_sampling_key ~turn ~actor_id ~keeper_name ~stage
+                  ~reason
+              in
+              Hashtbl.replace seen_keys key ()
+        | _ -> ())
+    events;
+  {
+    max_per_turn = keeper_unavailable_max_per_turn ();
+    count_in_turn = !count_in_turn;
+    seen_keys;
+  }
+
+let decide_unavailable_append ~sampling_state ~turn ~actor_id ~keeper_name ~stage
+    ~reason : [ `Append | `Sampled of string ] =
+  let key = unavailable_sampling_key ~turn ~actor_id ~keeper_name ~stage ~reason in
+  if Hashtbl.mem sampling_state.seen_keys key then `Sampled "duplicate"
+  else if sampling_state.count_in_turn >= sampling_state.max_per_turn then
+    `Sampled
+      (Printf.sprintf "cap:%d" (max 0 sampling_state.max_per_turn))
+  else (
+    Hashtbl.replace sampling_state.seen_keys key ();
+    sampling_state.count_in_turn <- sampling_state.count_in_turn + 1;
+    `Append)
+
+let rec append_timeout_and_unavailable_events
     ~base_dir
     ~room_id
     ~phase
@@ -1644,6 +1734,7 @@ let append_timeout_and_unavailable_events
     ~actor_id
     ~keeper_name
     ~timeout_sec
+    ~sampling_state
     =
   let ( let* ) = Result.bind in
   let timeout_reason = "timeout" in
@@ -1670,52 +1761,64 @@ let append_timeout_and_unavailable_events
       ~payload:timeout_payload
       ()
   in
-  let unavailable_payload =
-    `Assoc
-      [
-        ("phase", `String phase);
-        ("turn", `Int turn);
-        ("role", `String (role_to_string role));
-        ("actor_id", `String actor_id);
-        ("keeper", `String keeper_name);
-        ("reason", `String timeout_reason);
-        ("timeout_sec", `Float timeout_sec);
-        ("stage", `String timeout_stage);
-      ]
-  in
-  let* unavailable_event =
-    append_event
+  let* unavailable_result =
+    append_unavailable_event
       ~base_dir
       ~room_id
-      ~event_type:Trpg_engine_event.Keeper_unavailable
+      ~phase
+      ~turn
+      ~role
       ~actor_id
-      ~payload:unavailable_payload
+      ~keeper_name
+      ~reason:timeout_reason
+      ~stage:timeout_stage
+      ~sampling_state
+      ~extra_payload_fields:[ ("timeout_sec", `Float timeout_sec) ]
       ()
   in
-  Ok [ timeout_event; unavailable_event ]
+  Ok (timeout_event, unavailable_result)
 
-let append_unavailable_event
-    ~base_dir ~room_id ~phase ~turn ~role ~actor_id ~keeper_name ~reason ~stage ()
-    =
-  let payload =
-    `Assoc
-      [
-        ("phase", `String phase);
-        ("turn", `Int turn);
-        ("role", `String (role_to_string role));
-        ("actor_id", `String actor_id);
-        ("keeper", `String keeper_name);
-        ("reason", `String reason);
-        ("stage", `String stage);
-      ]
-  in
-  append_event
+and append_unavailable_event
     ~base_dir
     ~room_id
-    ~event_type:Trpg_engine_event.Keeper_unavailable
+    ~phase
+    ~turn
+    ~role
     ~actor_id
-    ~payload
+    ~keeper_name
+    ~reason
+    ~stage
+    ~sampling_state
+    ?(extra_payload_fields = [])
     ()
+    =
+  match
+    decide_unavailable_append ~sampling_state ~turn ~actor_id ~keeper_name
+      ~stage ~reason
+  with
+  | `Sampled sampled_reason -> Ok (`Sampled sampled_reason)
+  | `Append ->
+      let payload =
+        `Assoc
+          ([
+             ("phase", `String phase);
+             ("turn", `Int turn);
+             ("role", `String (role_to_string role));
+             ("actor_id", `String actor_id);
+             ("keeper", `String keeper_name);
+             ("reason", `String reason);
+             ("stage", `String stage);
+           ]
+          @ extra_payload_fields)
+      in
+      append_event
+        ~base_dir
+        ~room_id
+        ~event_type:Trpg_engine_event.Keeper_unavailable
+        ~actor_id
+        ~payload
+        ()
+      |> Result.map (fun event -> `Appended event)
 
 let append_keeper_reply_event
     ~base_dir
@@ -2854,6 +2957,10 @@ let handle_round_run ctx args : result =
         ref (latest_session_outcome_payload existing_events_before)
       in
       let* turn_before = read_state_turn derived in
+      let unavailable_sampling =
+        make_unavailable_sampling_state ~events:existing_events_before
+          ~turn:turn_before
+      in
       let next_turn = max 1 (turn_before + 1) in
       let* () =
         if player_keepers = [] then
@@ -2917,7 +3024,7 @@ let handle_round_run ctx args : result =
 
       let process_one ~state_json ~role ~actor_id ~keeper_name =
         let record_unavailable_status ~status ~error ~stage =
-          let* unavailable_event =
+          let* unavailable_result =
             append_unavailable_event
               ~base_dir
               ~room_id
@@ -2928,10 +3035,17 @@ let handle_round_run ctx args : result =
               ~keeper_name
               ~reason:error
               ~stage
+              ~sampling_state:unavailable_sampling
               ()
           in
-          unavailable_count := !unavailable_count + 1;
-          appended_events := !appended_events @ [ unavailable_event ];
+          let sampled, sampled_reason =
+            match unavailable_result with
+            | `Appended unavailable_event ->
+                unavailable_count := !unavailable_count + 1;
+                appended_events := !appended_events @ [ unavailable_event ];
+                (false, None)
+            | `Sampled reason -> (true, Some reason)
+          in
           statuses :=
             `Assoc
               [
@@ -2942,6 +3056,10 @@ let handle_round_run ctx args : result =
                 ("reason", `String error);
                 ("stage", `String stage);
                 ("error", `String error);
+                ("sampled", `Bool sampled);
+                ( "sampled_reason",
+                  Option.fold ~none:`Null ~some:(fun v -> `String v)
+                    sampled_reason );
               ]
             :: !statuses;
           Ok ()
@@ -2982,7 +3100,7 @@ let handle_round_run ctx args : result =
         in
         match call_keeper ctx ~name:keeper_name ~message:prompt ~timeout_sec with
         | `Timeout ->
-            let* timeout_events =
+            let* timeout_event, unavailable_result =
               append_timeout_and_unavailable_events
                 ~base_dir
                 ~room_id
@@ -2992,10 +3110,18 @@ let handle_round_run ctx args : result =
                 ~actor_id
                 ~keeper_name
                 ~timeout_sec
+                ~sampling_state:unavailable_sampling
             in
             timeout_count := !timeout_count + 1;
-            unavailable_count := !unavailable_count + 1;
-            appended_events := !appended_events @ timeout_events;
+            appended_events := !appended_events @ [ timeout_event ];
+            let sampled, sampled_reason =
+              match unavailable_result with
+              | `Appended unavailable_event ->
+                  unavailable_count := !unavailable_count + 1;
+                  appended_events := !appended_events @ [ unavailable_event ];
+                  (false, None)
+              | `Sampled reason -> (true, Some reason)
+            in
             statuses :=
               `Assoc
                 [
@@ -3006,6 +3132,10 @@ let handle_round_run ctx args : result =
                   ("reason", `String "timeout");
                   ("stage", `String "masc_keeper_msg");
                   ("timeout_sec", `Float timeout_sec);
+                  ("sampled", `Bool sampled);
+                  ( "sampled_reason",
+                    Option.fold ~none:`Null ~some:(fun v -> `String v)
+                      sampled_reason );
                 ]
               :: !statuses;
             Ok ()

--- a/scripts/trpg-prune-loop.sh
+++ b/scripts/trpg-prune-loop.sh
@@ -1,0 +1,180 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage:
+  scripts/trpg-prune-loop.sh <command> [options]
+
+Commands:
+  once                Run one prune pass immediately
+  start               Start periodic prune loop in tmux
+  stop                Stop periodic prune loop tmux session
+  status              Show loop status and recent log lines
+
+Options:
+  --session <name>       tmux session name (default: masc-trpg-prune)
+  --interval-sec <n>     loop interval seconds for start (default: 300)
+  --room-id <id>         TRPG room id (default: default)
+  --base-path <path>     Base path containing trpg/events.sqlite3 (default: /Users/dancer/me)
+  --keep-sessions <n>    Keep last N room.created sessions (default: 1)
+  --vacuum               Run VACUUM on each prune pass
+  --help                 Show this help
+
+Examples:
+  scripts/trpg-prune-loop.sh once --room-id default --keep-sessions 1
+  scripts/trpg-prune-loop.sh start --interval-sec 600
+  scripts/trpg-prune-loop.sh status
+  scripts/trpg-prune-loop.sh stop
+EOF
+}
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SELF_PATH="$SCRIPT_DIR/$(basename "${BASH_SOURCE[0]}")"
+PRUNE_SCRIPT="$SCRIPT_DIR/trpg-room-prune.sh"
+
+COMMAND="${1:-status}"
+if [[ $# -gt 0 ]]; then
+  shift
+fi
+
+SESSION_NAME="masc-trpg-prune"
+INTERVAL_SEC=300
+ROOM_ID="default"
+BASE_PATH="/Users/dancer/me"
+KEEP_SESSIONS=1
+VACUUM=0
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --session)
+      SESSION_NAME="${2:-}"
+      shift 2
+      ;;
+    --interval-sec)
+      INTERVAL_SEC="${2:-}"
+      shift 2
+      ;;
+    --room-id)
+      ROOM_ID="${2:-}"
+      shift 2
+      ;;
+    --base-path)
+      BASE_PATH="${2:-}"
+      shift 2
+      ;;
+    --keep-sessions)
+      KEEP_SESSIONS="${2:-}"
+      shift 2
+      ;;
+    --vacuum)
+      VACUUM=1
+      shift
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown option: $1" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+
+if [[ -z "$SESSION_NAME" ]]; then
+  echo "ERROR: --session cannot be empty" >&2
+  exit 1
+fi
+
+if ! [[ "$INTERVAL_SEC" =~ ^[0-9]+$ ]] || [[ "$INTERVAL_SEC" -lt 1 ]]; then
+  echo "ERROR: --interval-sec must be a positive integer" >&2
+  exit 1
+fi
+
+if ! [[ "$KEEP_SESSIONS" =~ ^[0-9]+$ ]] || [[ "$KEEP_SESSIONS" -lt 1 ]]; then
+  echo "ERROR: --keep-sessions must be a positive integer" >&2
+  exit 1
+fi
+
+if [[ ! -x "$PRUNE_SCRIPT" ]]; then
+  echo "ERROR: prune script not executable: $PRUNE_SCRIPT" >&2
+  exit 1
+fi
+
+run_once() {
+  local -a args=(
+    --room-id "$ROOM_ID"
+    --base-path "$BASE_PATH"
+    --keep-sessions "$KEEP_SESSIONS"
+    --apply
+  )
+  if [[ "$VACUUM" -eq 1 ]]; then
+    args+=(--vacuum)
+  fi
+  "$PRUNE_SCRIPT" "${args[@]}"
+}
+
+require_tmux() {
+  if ! command -v tmux >/dev/null 2>&1; then
+    echo "ERROR: tmux is required for '$COMMAND'" >&2
+    exit 1
+  fi
+}
+
+loop_body() {
+  while true; do
+    echo "[trpg-prune-loop] $(date '+%Y-%m-%d %H:%M:%S') run_once"
+    if ! run_once; then
+      echo "[trpg-prune-loop] prune failed; retry after sleep"
+    fi
+    echo "[trpg-prune-loop] sleep ${INTERVAL_SEC}s"
+    sleep "$INTERVAL_SEC"
+  done
+}
+
+case "$COMMAND" in
+  once)
+    run_once
+    ;;
+  _loop)
+    loop_body
+    ;;
+  start)
+    require_tmux
+    if tmux has-session -t "$SESSION_NAME" 2>/dev/null; then
+      echo "already running: tmux session '$SESSION_NAME'"
+      exit 0
+    fi
+    loop_cmd="$(printf '%q ' "$SELF_PATH" _loop --session "$SESSION_NAME" --interval-sec "$INTERVAL_SEC" --room-id "$ROOM_ID" --base-path "$BASE_PATH" --keep-sessions "$KEEP_SESSIONS")"
+    if [[ "$VACUUM" -eq 1 ]]; then
+      loop_cmd+=$(printf '%q ' --vacuum)
+    fi
+    tmux new-session -d -s "$SESSION_NAME" "$loop_cmd"
+    echo "started: tmux session '$SESSION_NAME' (interval=${INTERVAL_SEC}s, room_id=${ROOM_ID})"
+    ;;
+  stop)
+    require_tmux
+    if tmux has-session -t "$SESSION_NAME" 2>/dev/null; then
+      tmux kill-session -t "$SESSION_NAME"
+      echo "stopped: tmux session '$SESSION_NAME'"
+    else
+      echo "not running: tmux session '$SESSION_NAME'"
+    fi
+    ;;
+  status)
+    require_tmux
+    if tmux has-session -t "$SESSION_NAME" 2>/dev/null; then
+      echo "running: tmux session '$SESSION_NAME'"
+      tmux capture-pane -pt "$SESSION_NAME" -S -20 || true
+    else
+      echo "stopped: tmux session '$SESSION_NAME'"
+    fi
+    ;;
+  *)
+    echo "Unknown command: $COMMAND" >&2
+    usage >&2
+    exit 1
+    ;;
+esac

--- a/scripts/trpg-room-prune.sh
+++ b/scripts/trpg-room-prune.sh
@@ -1,0 +1,163 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage:
+  scripts/trpg-room-prune.sh [options]
+
+Options:
+  --room-id <id>         TRPG room id to prune (default: default)
+  --base-path <path>     Base path containing trpg/events.sqlite3 (default: /Users/dancer/me)
+  --db-path <path>       Explicit sqlite db path (overrides --base-path)
+  --keep-sessions <n>    Keep last N room.created sessions (default: 1)
+  --apply                Apply deletion (default: dry-run)
+  --vacuum               Run VACUUM after deletion (only with --apply)
+  --help                 Show this help
+
+Examples:
+  scripts/trpg-room-prune.sh --room-id default
+  scripts/trpg-room-prune.sh --room-id default --keep-sessions 2 --apply --vacuum
+EOF
+}
+
+ROOM_ID="default"
+BASE_PATH="/Users/dancer/me"
+DB_PATH=""
+KEEP_SESSIONS=1
+APPLY=0
+VACUUM=0
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --room-id)
+      ROOM_ID="${2:-}"
+      shift 2
+      ;;
+    --base-path)
+      BASE_PATH="${2:-}"
+      shift 2
+      ;;
+    --db-path)
+      DB_PATH="${2:-}"
+      shift 2
+      ;;
+    --keep-sessions)
+      KEEP_SESSIONS="${2:-}"
+      shift 2
+      ;;
+    --apply)
+      APPLY=1
+      shift
+      ;;
+    --vacuum)
+      VACUUM=1
+      shift
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown option: $1" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+
+if ! [[ "$KEEP_SESSIONS" =~ ^[0-9]+$ ]] || [[ "$KEEP_SESSIONS" -lt 1 ]]; then
+  echo "ERROR: --keep-sessions must be a positive integer" >&2
+  exit 1
+fi
+
+if [[ -z "$DB_PATH" ]]; then
+  DB_PATH="${BASE_PATH%/}/trpg/events.sqlite3"
+fi
+
+if [[ ! -f "$DB_PATH" ]]; then
+  echo "ERROR: sqlite db not found: $DB_PATH" >&2
+  exit 1
+fi
+
+if ! command -v sqlite3 >/dev/null 2>&1; then
+  echo "ERROR: sqlite3 command is required" >&2
+  exit 1
+fi
+
+sql_one() {
+  local sql="$1"
+  sqlite3 "$DB_PATH" "$sql"
+}
+
+escape_sql() {
+  # Escape single quotes for SQL string literal.
+  printf "%s" "$1" | sed "s/'/''/g"
+}
+
+ROOM_ESCAPED="$(escape_sql "$ROOM_ID")"
+OFFSET=$((KEEP_SESSIONS - 1))
+
+TOTAL_BEFORE="$(sql_one "SELECT COUNT(*) FROM trpg_events WHERE room_id='${ROOM_ESCAPED}';")"
+if [[ "$TOTAL_BEFORE" -eq 0 ]]; then
+  echo "No events found for room_id='${ROOM_ID}'. Nothing to do."
+  exit 0
+fi
+
+SESSIONS_TOTAL="$(sql_one "SELECT COUNT(*) FROM trpg_events WHERE room_id='${ROOM_ESCAPED}' AND event_type='room.created';")"
+
+CUTOFF_SEQ="$(sql_one "SELECT seq FROM trpg_events WHERE room_id='${ROOM_ESCAPED}' AND event_type='room.created' ORDER BY seq DESC LIMIT 1 OFFSET ${OFFSET};")"
+if [[ -z "$CUTOFF_SEQ" ]]; then
+  CUTOFF_SEQ=1
+fi
+
+TO_DELETE="$(sql_one "SELECT COUNT(*) FROM trpg_events WHERE room_id='${ROOM_ESCAPED}' AND seq < ${CUTOFF_SEQ};")"
+TOTAL_AFTER_ESTIMATE=$((TOTAL_BEFORE - TO_DELETE))
+
+echo "TRPG prune plan"
+echo "  db_path         : $DB_PATH"
+echo "  room_id         : $ROOM_ID"
+echo "  keep_sessions   : $KEEP_SESSIONS"
+echo "  sessions_total  : $SESSIONS_TOTAL"
+echo "  cutoff_seq      : $CUTOFF_SEQ"
+echo "  total_before    : $TOTAL_BEFORE"
+echo "  delete_rows     : $TO_DELETE"
+echo "  total_after_est : $TOTAL_AFTER_ESTIMATE"
+
+if [[ "$APPLY" -ne 1 ]]; then
+  echo
+  echo "Dry-run only. Re-run with --apply to execute."
+  exit 0
+fi
+
+if [[ "$TO_DELETE" -le 0 ]]; then
+  echo "No rows to delete. Done."
+  exit 0
+fi
+
+BACKUP_PATH="${DB_PATH}.bak.$(date +%Y%m%d-%H%M%S)"
+cp -p "$DB_PATH" "$BACKUP_PATH"
+echo "Backup created: $BACKUP_PATH"
+
+sqlite3 "$DB_PATH" <<EOF
+BEGIN IMMEDIATE;
+DELETE FROM trpg_events
+ WHERE room_id='${ROOM_ESCAPED}'
+   AND seq < ${CUTOFF_SEQ};
+DELETE FROM trpg_snapshots
+ WHERE room_id='${ROOM_ESCAPED}';
+COMMIT;
+EOF
+
+if [[ "$VACUUM" -eq 1 ]]; then
+  echo "Running VACUUM..."
+  sqlite3 "$DB_PATH" "VACUUM;"
+fi
+
+TOTAL_AFTER="$(sql_one "SELECT COUNT(*) FROM trpg_events WHERE room_id='${ROOM_ESCAPED}';")"
+MIN_SEQ_AFTER="$(sql_one "SELECT COALESCE(MIN(seq),0) FROM trpg_events WHERE room_id='${ROOM_ESCAPED}';")"
+MAX_SEQ_AFTER="$(sql_one "SELECT COALESCE(MAX(seq),0) FROM trpg_events WHERE room_id='${ROOM_ESCAPED}';")"
+
+echo "Prune completed"
+echo "  total_after : $TOTAL_AFTER"
+echo "  seq_range   : $MIN_SEQ_AFTER..$MAX_SEQ_AFTER"

--- a/test/test_tool_trpg_coverage.ml
+++ b/test/test_tool_trpg_coverage.ml
@@ -109,6 +109,16 @@ let parse_json_exn s =
 
 let count_from_json json = json |> Yojson.Safe.Util.member "count" |> Yojson.Safe.Util.to_int
 
+let with_env name value f =
+  let previous = Sys.getenv_opt name in
+  Unix.putenv name value;
+  Fun.protect
+    ~finally:(fun () ->
+      match previous with
+      | Some v -> Unix.putenv name v
+      | None -> Unix.putenv name "")
+    f
+
 let test_round_run_success_path () =
   let base_dir = make_temp_dir () in
   let config = Room.default_config base_dir in
@@ -546,6 +556,99 @@ let test_round_run_timeout_policy () =
     1
     (count_from_json (parse_json_exn unavailable_stream));
   cleanup_dir base_dir
+
+let test_round_run_unavailable_sampling_cap () =
+  with_env "MASC_TRPG_KEEPER_UNAVAILABLE_MAX_PER_TURN" "1" (fun () ->
+    let base_dir = make_temp_dir () in
+    let config = Room.default_config base_dir in
+    let _ = Room.init config ~agent_name:(Some "tester") in
+    bootstrap_room_with_actors ~base_dir ~room_id:"room-round-unavailable-sampled"
+      ~actor_ids:["p1"];
+    let seeded_unavailable =
+      Trpg_engine_event.make ~seq:3 ~room_id:"room-round-unavailable-sampled"
+        ~ts:(Types.now_iso ()) ~event_type:Trpg_engine_event.Keeper_unavailable
+        ~actor_id:"p1"
+        ~payload:
+          (`Assoc
+            [
+              ("phase", `String "round");
+              ("turn", `Int 1);
+              ("role", `String "player");
+              ("actor_id", `String "p1");
+              ("keeper", `String "pk-timeout");
+              ("reason", `String "timeout");
+              ("stage", `String "masc_keeper_msg");
+            ])
+        ()
+    in
+    append_event_exn ~base_dir ~event:seeded_unavailable;
+    let keeper_call ~name ~message:_ ~timeout_sec:_ : Tool_trpg.keeper_call_result =
+      match name with
+      | "dm-keeper" -> `Ok (`Assoc [ ("reply", `String "Round starts.") ])
+      | "pk-timeout" -> `Timeout
+      | _ -> `Error "unknown keeper"
+    in
+    let ctx : Tool_trpg.context =
+      {
+        config;
+        agent_name = "tester";
+        keeper_call = Some keeper_call;
+        keeper_probe = None;
+      }
+    in
+    let args =
+      `Assoc
+        [
+          ("room_id", `String "room-round-unavailable-sampled");
+          ("dm_keeper", `String "dm-keeper");
+          ("player_keepers", `Assoc [ ("p1", `String "pk-timeout") ]);
+          ("timeout_sec", `Float 0.2);
+        ]
+    in
+    let ok, body = dispatch_exn ctx ~name:"masc_trpg_round_run" ~args in
+    Alcotest.(check bool) "round_run success despite sampling" true ok;
+    let json = parse_json_exn body in
+    let summary = Yojson.Safe.Util.member "summary" json in
+    Alcotest.(check int)
+      "timeouts remain tracked"
+      1
+      (Yojson.Safe.Util.member "timeouts" summary |> Yojson.Safe.Util.to_int);
+    Alcotest.(check int)
+      "unavailable summary counts appended events only"
+      0
+      (Yojson.Safe.Util.member "unavailable" summary |> Yojson.Safe.Util.to_int);
+    let statuses = json |> Yojson.Safe.Util.member "statuses" |> Yojson.Safe.Util.to_list in
+    let timeout_status =
+      List.find_opt
+        (fun s ->
+          s |> Yojson.Safe.Util.member "status" |> Yojson.Safe.Util.to_string = "timeout")
+        statuses
+    in
+    (match timeout_status with
+    | Some status_json ->
+        Alcotest.(check bool)
+          "timeout unavailable sampled"
+          true
+          (status_json |> Yojson.Safe.Util.member "sampled" |> Yojson.Safe.Util.to_bool);
+        Alcotest.(check string)
+          "sampled reason duplicate"
+          "duplicate"
+          (status_json |> Yojson.Safe.Util.member "sampled_reason" |> Yojson.Safe.Util.to_string)
+    | None -> Alcotest.fail "timeout status is missing");
+    let _, unavailable_stream =
+      dispatch_exn ctx ~name:"masc_trpg_stream"
+        ~args:
+          (`Assoc
+            [
+              ("room_id", `String "room-round-unavailable-sampled");
+              ("event_type", `String "keeper.unavailable");
+            ])
+    in
+    Alcotest.(check int)
+      "keeper.unavailable count unchanged"
+      1
+      (count_from_json (parse_json_exn unavailable_stream));
+    cleanup_dir base_dir)
 
 let test_round_run_uses_majority_player_quorum () =
   let base_dir = make_temp_dir () in
@@ -1465,6 +1568,10 @@ let () =
             "timeout policy emits events"
             `Quick
             test_round_run_timeout_policy;
+          Alcotest.test_case
+            "samples keeper.unavailable when cap reached"
+            `Quick
+            test_round_run_unavailable_sampling_cap;
           Alcotest.test_case
             "uses majority player quorum before dm/advance"
             `Quick

--- a/test/test_tool_trpg_coverage.ml
+++ b/test/test_tool_trpg_coverage.ml
@@ -594,6 +594,7 @@ let test_round_run_unavailable_sampling_cap () =
         agent_name = "tester";
         keeper_call = Some keeper_call;
         keeper_probe = None;
+        dm_voice_emit = None;
       }
     in
     let args =


### PR DESCRIPTION
## Summary\n- add per-turn cap for keeper.unavailable append events via `MASC_TRPG_KEEPER_UNAVAILABLE_MAX_PER_TURN`\n- dedupe per-turn unavailable append events and expose sampled metadata in round_run statuses\n- add coverage regression test for unavailable sampling/cap behavior\n- add TRPG prune helper scripts for room event DB maintenance\n\n## Validation\n- dune exec --root . ./test/test_tool_trpg_coverage.exe\n- curl http://127.0.0.1:8935/api/v1/trpg/state?room_id=default\n- curl http://127.0.0.1:8080/api/v1/trpg/state?room_id=default