### PR TITLE
fix(viewer): prevent layout break after stop/resume

### DIFF
--- a/viewer/src/mode/mod.rs
+++ b/viewer/src/mode/mod.rs
@@ -493,18 +493,110 @@ fn bind_auto_round_toggle(doc: &web_sys::Document) {
 }
 
 #[cfg(target_arch = "wasm32")]
+const SESSION_CONTROL_BADGE_CHAR_LIMIT: usize = 120;
+
+#[cfg(target_arch = "wasm32")]
+fn collapse_inline_whitespace(text: &str) -> String {
+    text.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
+#[cfg(target_arch = "wasm32")]
+fn truncate_status_text(text: &str, limit: usize) -> String {
+    if text.chars().count() <= limit {
+        return text.to_string();
+    }
+    if limit <= 3 {
+        return "...".to_string();
+    }
+    let mut out = text.chars().take(limit - 3).collect::<String>();
+    out.push_str("...");
+    out
+}
+
+#[cfg(target_arch = "wasm32")]
+fn summarize_session_control_payload(raw: &str) -> String {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return String::new();
+    }
+
+    if let Ok(value) = serde_json::from_str::<Value>(trimmed) {
+        if let Some(message) = value.get("message").and_then(Value::as_str) {
+            let collapsed = collapse_inline_whitespace(message);
+            if !collapsed.is_empty() {
+                return collapsed;
+            }
+        }
+
+        let ok = value.get("ok").and_then(Value::as_bool);
+        let room_id = value
+            .get("room_id")
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .filter(|v| !v.is_empty())
+            .map(|v| format!("room {v}"));
+        let phase = value
+            .get("phase")
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .filter(|v| !v.is_empty())
+            .map(|v| format!("phase {v}"));
+        let turn_after = value
+            .get("turn_after")
+            .and_then(Value::as_i64)
+            .map(|turn| format!("turn {turn}"));
+        let statuses = value
+            .get("statuses")
+            .and_then(Value::as_array)
+            .map(|rows| format!("actors {}", rows.len()));
+
+        let mut parts = Vec::new();
+        if let Some(room) = room_id {
+            parts.push(room);
+        }
+        if let Some(phase) = phase {
+            parts.push(phase);
+        }
+        if let Some(turn) = turn_after {
+            parts.push(turn);
+        }
+        if let Some(statuses) = statuses {
+            parts.push(statuses);
+        }
+
+        if ok == Some(true) {
+            if parts.is_empty() {
+                return "ok".to_string();
+            }
+            return parts.join(" | ");
+        }
+    }
+
+    collapse_inline_whitespace(trimmed)
+}
+
+#[cfg(target_arch = "wasm32")]
 fn set_session_control_status(doc: &web_sys::Document, text: &str, tone: &str) {
     let Some(el) = doc.get_element_by_id("session-control-status") else {
         return;
     };
+    let full_text = {
+        let collapsed = collapse_inline_whitespace(text);
+        if collapsed.is_empty() {
+            "세션 제어 대기".to_string()
+        } else {
+            collapsed
+        }
+    };
+    let display_text = truncate_status_text(&full_text, SESSION_CONTROL_BADGE_CHAR_LIMIT);
     let class_name = if tone.trim().is_empty() {
         "widget-pill".to_string()
     } else {
         format!("widget-pill {}", tone.trim())
     };
-    el.set_text_content(Some(text));
+    el.set_text_content(Some(&display_text));
     let _ = el.set_attribute("class", &class_name);
-    let _ = el.set_attribute("title", text);
+    let _ = el.set_attribute("title", &full_text);
 }
 
 #[cfg(target_arch = "wasm32")]
@@ -661,10 +753,11 @@ fn bind_session_pause_controls(doc: &web_sys::Document) {
                             }
                             render_auto_round_toggle(&doc_async);
                             crate::game::round_runner::set_auto_round_running(false);
-                            let status = if raw.is_empty() {
+                            let detail = summarize_session_control_payload(&raw);
+                            let status = if detail.is_empty() {
                                 "세션 멈춤 완료".to_string()
                             } else {
-                                format!("세션 멈춤 완료: {}", raw)
+                                format!("세션 멈춤 완료: {}", detail)
                             };
                             set_session_control_status(&doc_async, &status, "status-warn");
                             let doc_for_refresh = doc_async.clone();
@@ -703,10 +796,11 @@ fn bind_session_pause_controls(doc: &web_sys::Document) {
                     let room_id = crate::config::current_room_id();
                     match post_tool_action("masc_resume", json!({ "room_id": room_id })).await {
                         Ok(raw) => {
-                            let status = if raw.is_empty() {
+                            let detail = summarize_session_control_payload(&raw);
+                            let status = if detail.is_empty() {
                                 "세션 재개 완료".to_string()
                             } else {
-                                format!("세션 재개 완료: {}", raw)
+                                format!("세션 재개 완료: {}", detail)
                             };
                             set_session_control_status(&doc_async, &status, "status-ok");
                             let doc_for_refresh = doc_async.clone();

--- a/viewer/style.css
+++ b/viewer/style.css
@@ -537,6 +537,15 @@ body:not(.mode-trpg) #ops-hud {
     display: flex;
     align-items: center;
     gap: 6px;
+    min-width: 0;
+}
+
+#session-control-status {
+    flex: 0 1 min(44vw, 520px);
+    max-width: min(44vw, 520px);
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
 }
 
 .inline-select {
@@ -2411,6 +2420,8 @@ body.wasm-dom-fallback #bevy-canvas {
     line-height: 1.45;
     color: var(--text-primary);
     letter-spacing: 0.2px;
+    overflow-wrap: anywhere;
+    word-break: break-word;
 }
 
 .turn-flow-banner.is-running {


### PR DESCRIPTION
## Summary
- prevent top-bar layout collapse when stop/resume status text becomes very long
- normalize and truncate session control badge text for display, while keeping full text in tooltip
- summarize JSON-like tool payloads before rendering in the badge
- allow turn flow banner body text to wrap safely without widening the panel

## Changes
- `viewer/src/mode/mod.rs`
  - add status-text normalization/truncation helpers
  - summarize `masc_pause`/`masc_resume` payload text before displaying
  - keep full untruncated message in `title` attribute
- `viewer/style.css`
  - clamp `#session-control-status` width with ellipsis
  - set `min-width: 0` on `.session-control-inline`
  - add wrapping guards on `.turn-flow-banner .flow-text`

## Validation
- `cargo check` (viewer)
- `cargo check --target wasm32-unknown-unknown` (viewer)
- manual browser smoke: stop/resume + injected long status payload no longer changes top-bar/content geometry
