### PR TITLE
fix(viewer): show narrative empty-state guidance

### DIFF
--- a/viewer/index.html
+++ b/viewer/index.html
@@ -527,7 +527,10 @@
                     </div>
                     <div id="choice-overlay" class="floating-overlay choice-overlay" style="display:none"></div>
                     <div id="combat-overlay" class="floating-overlay combat-overlay" style="display:none"></div>
-                    <div id="narrative-log"></div>
+                    <div
+                        id="narrative-log"
+                        data-empty-hint="아직 내러티브가 없습니다. 자동 진행을 켜거나 참여 후 액션을 입력해 첫 장면을 시작하세요."
+                    ></div>
                     <!-- Join Panel: claim an actor before playing -->
                     <div id="join-panel">
                         <div id="join-help" class="join-help">

--- a/viewer/style.css
+++ b/viewer/style.css
@@ -1362,6 +1362,21 @@ body.wasm-dom-fallback #bevy-canvas {
     padding-bottom: 12px;
 }
 
+#narrative-log:empty::before {
+    content: attr(data-empty-hint);
+    display: block;
+    margin: 6px 0 10px;
+    padding: 10px 12px;
+    border: 1px dashed rgba(90, 126, 176, 0.45);
+    border-radius: 4px;
+    background: rgba(19, 31, 52, 0.35);
+    color: rgba(188, 202, 228, 0.9);
+    font-family: var(--font-ui);
+    font-size: 11px;
+    line-height: 1.45;
+    letter-spacing: 0.2px;
+}
+
 .atmosphere-strip {
     display: grid;
     grid-template-columns: repeat(2, minmax(0, 1fr));


### PR DESCRIPTION
## Summary
- add contextual empty-state hint for the TRPG narrative panel
- render hint via  so it disappears automatically on first event
- keep logic changes minimal (HTML attribute + CSS only)

## Verification
- cargo test --manifest-path viewer/Cargo.toml -- --nocapture
- cargo check --manifest-path viewer/Cargo.toml --target wasm32-unknown-unknown