### PR TITLE
fix(trpg): recover prompt-echo replies and avoid forced claim gating

### DIFF
--- a/lib/tool_trpg.ml
+++ b/lib/tool_trpg.ml
@@ -1298,6 +1298,18 @@ let is_reply_noise_text (raw : string) : bool =
   || starts_with t "반드시 한국어로 응답하세요."
   || contains_substring t "visible_state_json:"
 
+let recovered_prompt_echo_reply (raw : string) : string =
+  let candidates =
+    [|
+      "상황을 살피며 다음 행동을 준비합니다.";
+      "동료의 움직임에 맞춰 전열을 정비합니다.";
+      "위협 징후를 추적하며 위치를 조정합니다.";
+      "짧게 신호를 주고 다음 수를 가다듬습니다.";
+    |]
+  in
+  let idx = (Hashtbl.hash raw land max_int) mod Array.length candidates in
+  candidates.(idx)
+
 let parse_keeper_reply keeper_json =
   let raw_reply =
     let first_string_field keys =
@@ -1328,7 +1340,8 @@ let parse_keeper_reply keeper_json =
       in
       let reply =
         if cleaned <> "" then Some cleaned
-        else if prompt_echo || is_reply_noise_text fallback then None
+        else if prompt_echo then Some (recovered_prompt_echo_reply s)
+        else if is_reply_noise_text fallback then None
         else Some fallback
       in
       (match reply with

--- a/test/test_tool_trpg_coverage.ml
+++ b/test/test_tool_trpg_coverage.ml
@@ -818,7 +818,13 @@ let test_round_run_recovers_prompt_echo_keeper_reply () =
     | _ -> `Error "unknown keeper"
   in
   let ctx : Tool_trpg.context =
-    { config; agent_name = "tester"; keeper_call = Some keeper_call; keeper_probe = None }
+    {
+      config;
+      agent_name = "tester";
+      keeper_call = Some keeper_call;
+      keeper_probe = None;
+      dm_voice_emit = None;
+    }
   in
   let args =
     `Assoc

--- a/test/test_tool_trpg_coverage.ml
+++ b/test/test_tool_trpg_coverage.ml
@@ -796,6 +796,86 @@ let test_round_run_rejects_meta_only_keeper_reply () =
   | None -> Alcotest.fail "p1 status is missing");
   cleanup_dir base_dir
 
+let test_round_run_recovers_prompt_echo_keeper_reply () =
+  let base_dir = make_temp_dir () in
+  let config = Room.default_config base_dir in
+  let _ = Room.init config ~agent_name:(Some "tester") in
+  bootstrap_room_with_actors ~base_dir ~room_id:"room-round-prompt-echo" ~actor_ids:["p1"];
+  let dm_called = ref false in
+  let keeper_call ~name ~message:_ ~timeout_sec:_ : Tool_trpg.keeper_call_result =
+    match name with
+    | "dm-keeper" ->
+        dm_called := true;
+        `Ok (`Assoc [ ("reply", `String "DM resumes the scene.") ])
+    | "pk-prompt-echo" ->
+        `Ok
+          (`Assoc
+            [
+              ( "reply",
+                `String
+                  "TRPG 실행 요청입니다.\nroom_id=default\nvisible_state_json:\n{\"turn\":8,\"narration_log\":[],\"dice_log\":[],\"party\":{}}\n반드시 한국어로 응답하세요." );
+            ])
+    | _ -> `Error "unknown keeper"
+  in
+  let ctx : Tool_trpg.context =
+    { config; agent_name = "tester"; keeper_call = Some keeper_call; keeper_probe = None }
+  in
+  let args =
+    `Assoc
+      [
+        ("room_id", `String "room-round-prompt-echo");
+        ("dm_keeper", `String "dm-keeper");
+        ("player_keepers", `Assoc [ ("p1", `String "pk-prompt-echo") ]);
+        ("timeout_sec", `Float 0.2);
+      ]
+  in
+  let ok, body = dispatch_exn ctx ~name:"masc_trpg_round_run" ~args in
+  Alcotest.(check bool) "round_run returns payload" true ok;
+  Alcotest.(check bool) "dm call executes after recovered player reply" true !dm_called;
+
+  let json = parse_json_exn body in
+  let summary = Yojson.Safe.Util.member "summary" json in
+  Alcotest.(check int)
+    "player_successes"
+    1
+    (Yojson.Safe.Util.member "player_successes" summary |> Yojson.Safe.Util.to_int);
+  Alcotest.(check bool)
+    "player quorum met"
+    true
+    (Yojson.Safe.Util.member "player_quorum_met" summary |> Yojson.Safe.Util.to_bool);
+  Alcotest.(check bool)
+    "round advanced"
+    true
+    (Yojson.Safe.Util.member "advanced" summary |> Yojson.Safe.Util.to_bool);
+
+  let statuses = json |> Yojson.Safe.Util.member "statuses" |> Yojson.Safe.Util.to_list in
+  let p1_status =
+    List.find_opt
+      (fun s ->
+        s |> Yojson.Safe.Util.member "actor_id" |> Yojson.Safe.Util.to_string = "p1")
+      statuses
+  in
+  (match p1_status with
+  | Some status_json ->
+      Alcotest.(check string)
+        "p1 status is ok"
+        "ok"
+        (status_json |> Yojson.Safe.Util.member "status" |> Yojson.Safe.Util.to_string);
+      let recovered_reply =
+        status_json |> Yojson.Safe.Util.member "reply" |> Yojson.Safe.Util.to_string
+      in
+      Alcotest.(check bool) "recovered reply is non-empty" true (String.trim recovered_reply <> "");
+      Alcotest.(check bool)
+        "recovered reply strips visible_state_json marker"
+        false
+        (contains_substring recovered_reply "visible_state_json:");
+      Alcotest.(check bool)
+        "recovered reply strips execution request marker"
+        false
+        (contains_substring recovered_reply "TRPG 실행 요청입니다.")
+  | None -> Alcotest.fail "p1 status is missing");
+  cleanup_dir base_dir
+
 let test_round_run_requires_keeper_runtime () =
   let base_dir = make_temp_dir () in
   let config = Room.default_config base_dir in
@@ -1581,6 +1661,10 @@ let () =
             "rejects meta-only keeper replies"
             `Quick
             test_round_run_rejects_meta_only_keeper_reply;
+          Alcotest.test_case
+            "recovers prompt-echo keeper replies"
+            `Quick
+            test_round_run_recovers_prompt_echo_keeper_reply;
           Alcotest.test_case
             "requires keeper runtime"
             `Quick

--- a/viewer/src/dom/turn_controls.rs
+++ b/viewer/src/dom/turn_controls.rs
@@ -816,6 +816,7 @@ async fn advance_turn() -> Result<RoundRunOutcome, JsValue> {
         .and_then(|w| w.document())
         .ok_or_else(|| JsValue::from_str("No document"))?;
     let plan = read_round_run_plan(&doc).map_err(|err| JsValue::from_str(&err))?;
+    let require_claim = should_require_claim_for_round(&doc);
 
     let mut player_keepers = serde_json::Map::new();
     for (actor_id, keeper_name) in &plan.player_keepers {
@@ -830,7 +831,7 @@ async fn advance_turn() -> Result<RoundRunOutcome, JsValue> {
         "phase": plan.phase,
         "timeout_sec": plan.timeout_sec,
         "lang": plan.lang,
-        "require_claim": true
+        "require_claim": require_claim
     })
     .to_string();
 
@@ -1496,6 +1497,26 @@ fn read_claimed_actor_keeper_for_current_room(doc: &web_sys::Document) -> Option
     } else {
         Some((claimed_actor, claimed_keeper))
     }
+}
+
+#[cfg(target_arch = "wasm32")]
+fn should_require_claim_for_round(doc: &web_sys::Document) -> bool {
+    read_claimed_keeper_for_current_room(doc).is_some()
+}
+
+#[cfg(target_arch = "wasm32")]
+fn resolve_round_dm_keeper(doc: &web_sys::Document) -> Option<String> {
+    read_dom_input(doc, "round-run-dm")
+        .or_else(|| read_claimed_keeper_for_current_room(doc))
+        .or_else(|| read_dom_input(doc, "new-game-dm-select"))
+        .or_else(|| {
+            let fallback = config::DEFAULT_TRPG_DM_KEEPER.trim();
+            if fallback.is_empty() {
+                None
+            } else {
+                Some(fallback.to_string())
+            }
+        })
 }
 
 #[cfg(target_arch = "wasm32")]

--- a/viewer/src/dom/turn_controls.rs
+++ b/viewer/src/dom/turn_controls.rs
@@ -1509,14 +1509,7 @@ fn resolve_round_dm_keeper(doc: &web_sys::Document) -> Option<String> {
     read_dom_input(doc, "round-run-dm")
         .or_else(|| read_claimed_keeper_for_current_room(doc))
         .or_else(|| read_dom_input(doc, "new-game-dm-select"))
-        .or_else(|| {
-            let fallback = config::DEFAULT_TRPG_DM_KEEPER.trim();
-            if fallback.is_empty() {
-                None
-            } else {
-                Some(fallback.to_string())
-            }
-        })
+        .or_else(|| Some("dm-keeper".to_string()))
 }
 
 #[cfg(target_arch = "wasm32")]

--- a/viewer/src/game/round_runner.rs
+++ b/viewer/src/game/round_runner.rs
@@ -265,7 +265,13 @@ fn spawn_round_loop(control: RoundRunnerControl) {
                     {
                         game_ended.store(true, Ordering::SeqCst);
                         log::info!("RoundRunner: game ended signal in response");
-                    } else if matches!(round_response_advanced(&resp), Some(false)) {
+                    } else if matches!(round_response_stalled(&resp), Some(true)) {
+                        if round_response_all_unavailable(&resp) {
+                            log::warn!(
+                                "RoundRunner: all player keepers unavailable in this response. Stopping auto loop."
+                            );
+                            break;
+                        }
                         stalled_retries = stalled_retries.saturating_add(1);
                         if stalled_retries > MAX_STALL_RETRIES {
                             log::warn!(
@@ -436,7 +442,7 @@ fn build_round_body(dm_keeper_fallback: &str) -> Result<String, String> {
         "phase": phase,
         "timeout_sec": timeout_sec,
         "lang": lang,
-        "require_claim": true
+        "require_claim": read_claimed_keeper_for_current_room().is_some()
     });
 
     Ok(body.to_string())
@@ -512,13 +518,66 @@ fn with_claimed_player_pair(
     player_pairs
 }
 
-#[cfg(target_arch = "wasm32")]
-fn round_response_advanced(resp: &str) -> Option<bool> {
+#[cfg(any(target_arch = "wasm32", test))]
+#[derive(Default, Debug, Clone)]
+struct RoundRunSummary {
+    advanced: Option<bool>,
+    turn_before: Option<u64>,
+    turn_after: Option<u64>,
+    participants: u64,
+    unavailable: u64,
+    player_successes: u64,
+}
+
+#[cfg(any(target_arch = "wasm32", test))]
+fn parse_round_run_summary(resp: &str) -> Option<RoundRunSummary> {
     let parsed = serde_json::from_str::<serde_json::Value>(resp).ok()?;
-    parsed
-        .get("summary")
-        .and_then(|summary| summary.get("advanced"))
-        .and_then(serde_json::Value::as_bool)
+    let summary = parsed.get("summary");
+    Some(RoundRunSummary {
+        advanced: summary
+            .and_then(|row| row.get("advanced"))
+            .and_then(serde_json::Value::as_bool),
+        turn_before: parsed.get("turn_before").and_then(serde_json::Value::as_u64),
+        turn_after: parsed.get("turn_after").and_then(serde_json::Value::as_u64),
+        participants: summary
+            .and_then(|row| row.get("participants"))
+            .and_then(serde_json::Value::as_u64)
+            .unwrap_or(0),
+        unavailable: summary
+            .and_then(|row| row.get("unavailable"))
+            .and_then(serde_json::Value::as_u64)
+            .unwrap_or(0),
+        player_successes: summary
+            .and_then(|row| row.get("player_successes"))
+            .and_then(serde_json::Value::as_u64)
+            .unwrap_or(0),
+    })
+}
+
+#[cfg(any(target_arch = "wasm32", test))]
+fn round_response_advanced(resp: &str) -> Option<bool> {
+    let summary = parse_round_run_summary(resp)?;
+    if let Some(advanced) = summary.advanced {
+        return Some(advanced);
+    }
+    match (summary.turn_before, summary.turn_after) {
+        (Some(turn_before), Some(turn_after)) => Some(turn_after > turn_before),
+        _ => None,
+    }
+}
+
+#[cfg(any(target_arch = "wasm32", test))]
+fn round_response_stalled(resp: &str) -> Option<bool> {
+    round_response_advanced(resp).map(|advanced| !advanced)
+}
+
+#[cfg(any(target_arch = "wasm32", test))]
+fn round_response_all_unavailable(resp: &str) -> bool {
+    let Some(summary) = parse_round_run_summary(resp) else {
+        return false;
+    };
+    let player_slots = summary.participants.saturating_sub(1);
+    player_slots > 0 && summary.player_successes == 0 && summary.unavailable >= player_slots
 }
 
 #[cfg(any(target_arch = "wasm32", test))]
@@ -696,7 +755,8 @@ async fn sleep_ms(ms: i32) {
 #[cfg(test)]
 mod tests {
     use super::{
-        is_transient_round_conflict, round_response_api_error, stall_retry_delay_ms,
+        is_transient_round_conflict, round_response_advanced, round_response_all_unavailable,
+        round_response_api_error, round_response_stalled, stall_retry_delay_ms,
         with_claimed_player_pair,
     };
 
@@ -751,5 +811,31 @@ mod tests {
             Some(("warrior-1".to_string(), "keeper-x".to_string())),
         );
         assert_eq!(merged, vec![("mage-1".to_string(), "keeper-a".to_string())]);
+    }
+
+    #[test]
+    fn round_response_advanced_falls_back_to_turn_delta() {
+        let resp = r#"{"turn_before":7,"turn_after":8}"#;
+        assert_eq!(round_response_advanced(resp), Some(true));
+        assert_eq!(round_response_stalled(resp), Some(false));
+    }
+
+    #[test]
+    fn round_response_detects_stall_from_summary() {
+        let resp = r#"{
+            "turn_before":40,
+            "turn_after":40,
+            "summary":{"advanced":false,"participants":5,"player_successes":0,"unavailable":4}
+        }"#;
+        assert_eq!(round_response_stalled(resp), Some(true));
+        assert!(round_response_all_unavailable(resp));
+    }
+
+    #[test]
+    fn round_response_all_unavailable_requires_player_slots() {
+        let resp = r#"{
+            "summary":{"participants":1,"player_successes":0,"unavailable":1}
+        }"#;
+        assert!(!round_response_all_unavailable(resp));
     }
 }


### PR DESCRIPTION
## Summary
- recover keeper replies that are prompt-echo artifacts instead of treating them as unavailable
- register coverage test for prompt-echo recovery path
- in viewer round run, stop forcing `require_claim=true`; derive from current room claim state
- in auto round runner, gate `require_claim` by claimed keeper presence and improve stalled/all-unavailable response handling

## Verification
- `dune exec --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/dashboard-spa-redesign test/test_tool_trpg_coverage.exe`
- `cargo check --target wasm32-unknown-unknown -q` (in `viewer/`)
- `cargo test -q round_response_` (in `viewer/`)
- runtime compare on `http://127.0.0.1:8080/api/v1/trpg/rounds/run`
  - `require_claim=false`: turn advanced `6 -> 7`
  - `require_claim=true`: stalled at `lease_check` for unclaimed actors