### PR TITLE
viewer: add actionable turn-flow guidance chips

### DIFF
--- a/viewer/index.html
+++ b/viewer/index.html
@@ -411,8 +411,9 @@
                     </div>
                     <div id="lifecycle-diagram-hint" class="lifecycle-diagram-hint">현재 상태를 불러오는 중...</div>
                     <div id="turn-flow-banner" class="turn-flow-banner is-idle" aria-live="polite">
-                        <span class="flow-state">대기</span>
-                        <span class="flow-text">세션 상태를 불러오는 중입니다.</span>
+                        <span id="turn-flow-state" class="flow-state">대기</span>
+                        <span id="turn-flow-text" class="flow-text">세션 상태를 불러오는 중입니다.</span>
+                        <span id="turn-flow-actions" class="flow-actions" aria-label="추천 작업"></span>
                     </div>
                     <div id="agent-round-flow" class="agent-round-flow" aria-live="polite">
                         <div class="agent-flow-empty">에이전트 라운드 흐름을 불러오는 중입니다.</div>

--- a/viewer/src/dom/turn_runtime.rs
+++ b/viewer/src/dom/turn_runtime.rs
@@ -10,14 +10,17 @@ use crate::game::state::{ConnectionStatus, RoomState, TurnProgressState};
 #[derive(Resource, Default)]
 pub struct TurnRuntimeCache {
     pub last_snapshot: String,
+    pub last_flow_action_snapshot: String,
 }
 
 #[cfg(target_arch = "wasm32")]
 use super::escape::html_escape;
 #[cfg(target_arch = "wasm32")]
+use wasm_bindgen::closure::Closure;
+#[cfg(target_arch = "wasm32")]
 use wasm_bindgen::JsCast;
 #[cfg(target_arch = "wasm32")]
-use web_sys::{HtmlInputElement, HtmlSelectElement};
+use web_sys::{HtmlElement, HtmlInputElement, HtmlSelectElement};
 
 #[cfg(target_arch = "wasm32")]
 fn pretty_phase(phase: &str) -> String {
@@ -569,6 +572,371 @@ fn build_flow_banner(
     }
 }
 
+fn build_flow_action_signature(
+    lifecycle: TrpgLifecycleState,
+    runner_running: bool,
+    has_actor_issues: bool,
+    has_runner_issue: bool,
+    current_actor: &str,
+) -> String {
+    let mut parts = Vec::new();
+    if matches!(
+        lifecycle,
+        TrpgLifecycleState::Lobby
+            | TrpgLifecycleState::Loading
+            | TrpgLifecycleState::Ended
+            | TrpgLifecycleState::Unavailable
+            | TrpgLifecycleState::Unknown
+    ) {
+        parts.push("new_game");
+    }
+    if runner_running {
+        parts.push("auto");
+    } else {
+        parts.push("manual");
+    }
+    if has_actor_issues {
+        parts.push("actor_issue");
+    }
+    if has_runner_issue {
+        parts.push("runner_issue");
+    }
+    let actor = current_actor.trim();
+    if actor.is_empty() || actor == "-" {
+        parts.push("actor_idle");
+    } else {
+        parts.push("actor_active");
+    }
+    parts.join(",")
+}
+
+#[cfg(target_arch = "wasm32")]
+#[derive(Clone)]
+struct FlowBannerAction {
+    key: &'static str,
+    label: String,
+    title: &'static str,
+}
+
+#[cfg(target_arch = "wasm32")]
+fn flow_banner_action_snapshot(actions: &[FlowBannerAction]) -> String {
+    actions
+        .iter()
+        .map(|action| format!("{}:{}", action.key, action.label))
+        .collect::<Vec<_>>()
+        .join("|")
+}
+
+#[cfg(target_arch = "wasm32")]
+fn push_flow_action(actions: &mut Vec<FlowBannerAction>, action: FlowBannerAction) {
+    if actions.iter().any(|existing| existing.key == action.key) {
+        return;
+    }
+    actions.push(action);
+}
+
+#[cfg(target_arch = "wasm32")]
+fn dom_element_visible(document: &web_sys::Document, id: &str) -> bool {
+    let Some(el) = document.get_element_by_id(id) else {
+        return false;
+    };
+    if el.has_attribute("hidden") {
+        return false;
+    }
+    if let Some(style) = el.get_attribute("style") {
+        let style = style.to_ascii_lowercase().replace(' ', "");
+        if style.contains("display:none") || style.contains("visibility:hidden") {
+            return false;
+        }
+    }
+    true
+}
+
+#[cfg(target_arch = "wasm32")]
+fn dom_element_disabled(document: &web_sys::Document, id: &str) -> bool {
+    let Some(el) = document.get_element_by_id(id) else {
+        return true;
+    };
+    if el.has_attribute("disabled") {
+        return true;
+    }
+    el.get_attribute("aria-disabled")
+        .map(|value| value.trim().eq_ignore_ascii_case("true"))
+        .unwrap_or(false)
+}
+
+#[cfg(target_arch = "wasm32")]
+fn auto_toggle_action_label(document: &web_sys::Document) -> String {
+    let current = document
+        .get_element_by_id("auto-round-toggle")
+        .and_then(|el| el.text_content())
+        .unwrap_or_default()
+        .to_ascii_uppercase();
+    if current.contains("OFF") {
+        "자동 진행 켜기".to_string()
+    } else {
+        "자동 진행 끄기".to_string()
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+fn collect_flow_banner_actions(
+    document: &web_sys::Document,
+    lifecycle: TrpgLifecycleState,
+    runner_running: bool,
+    has_actor_issues: bool,
+    has_runner_issue: bool,
+    current_actor: &str,
+) -> Vec<FlowBannerAction> {
+    let mut actions = Vec::new();
+    let turn_controls_visible = dom_element_visible(document, "turn-controls");
+    let can_run_round =
+        turn_controls_visible && !dom_element_disabled(document, "advance-turn-btn");
+    let recovery_visible = dom_element_visible(document, "round-recovery-btn");
+    let join_panel_visible = dom_element_visible(document, "join-panel");
+    let action_panel_visible = dom_element_visible(document, "action-panel");
+
+    if matches!(
+        lifecycle,
+        TrpgLifecycleState::Lobby
+            | TrpgLifecycleState::Loading
+            | TrpgLifecycleState::Ended
+            | TrpgLifecycleState::Unavailable
+            | TrpgLifecycleState::Unknown
+    ) {
+        push_flow_action(
+            &mut actions,
+            FlowBannerAction {
+                key: "open-new-game",
+                label: "새 게임".to_string(),
+                title: "새 게임 패널을 열어 세션과 파티를 다시 구성합니다.",
+            },
+        );
+    }
+
+    if can_run_round {
+        push_flow_action(
+            &mut actions,
+            FlowBannerAction {
+                key: "run-round",
+                label: "라운드 실행".to_string(),
+                title: "현재 상태로 라운드를 한 번 실행합니다.",
+            },
+        );
+    }
+
+    if document.get_element_by_id("auto-round-toggle").is_some() {
+        push_flow_action(
+            &mut actions,
+            FlowBannerAction {
+                key: "toggle-auto",
+                label: auto_toggle_action_label(document),
+                title: "자동 라운드 진행을 켜거나 끕니다.",
+            },
+        );
+    }
+
+    if recovery_visible
+        && (has_actor_issues
+            || has_runner_issue
+            || matches!(
+                lifecycle,
+                TrpgLifecycleState::Stopped | TrpgLifecycleState::Unavailable
+            ))
+    {
+        push_flow_action(
+            &mut actions,
+            FlowBannerAction {
+                key: "open-recovery",
+                label: "복구 가이드".to_string(),
+                title: "라운드 복구 가이드를 열어 timeout/keeper 이슈를 점검합니다.",
+            },
+        );
+    }
+
+    if join_panel_visible {
+        push_flow_action(
+            &mut actions,
+            FlowBannerAction {
+                key: "focus-join",
+                label: "참여 입력칸".to_string(),
+                title: "플레이어 참여용 액터 ID 입력칸으로 이동합니다.",
+            },
+        );
+    } else if action_panel_visible
+        && (!runner_running
+            || current_actor.trim().is_empty()
+            || current_actor.trim() == "-"
+            || lifecycle.accepts_player_input())
+    {
+        push_flow_action(
+            &mut actions,
+            FlowBannerAction {
+                key: "focus-action",
+                label: "행동 입력칸".to_string(),
+                title: "플레이어 행동 입력칸으로 이동합니다.",
+            },
+        );
+    }
+
+    if actions.is_empty() && can_run_round {
+        push_flow_action(
+            &mut actions,
+            FlowBannerAction {
+                key: "run-round",
+                label: "라운드 실행".to_string(),
+                title: "현재 상태로 라운드를 한 번 실행합니다.",
+            },
+        );
+    }
+
+    if actions.len() > 4 {
+        actions.truncate(4);
+    }
+    actions
+}
+
+#[cfg(target_arch = "wasm32")]
+fn click_dom_button(document: &web_sys::Document, id: &str) {
+    let Some(el) = document.get_element_by_id(id) else {
+        return;
+    };
+    if el.has_attribute("disabled") {
+        return;
+    }
+    if el
+        .get_attribute("aria-disabled")
+        .map(|value| value.trim().eq_ignore_ascii_case("true"))
+        .unwrap_or(false)
+    {
+        return;
+    }
+    if let Ok(el) = el.dyn_into::<HtmlElement>() {
+        el.click();
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+fn focus_dom_input(document: &web_sys::Document, id: &str) {
+    let Some(input) = document
+        .get_element_by_id(id)
+        .and_then(|el| el.dyn_into::<HtmlInputElement>().ok())
+    else {
+        return;
+    };
+    let _ = input.focus();
+}
+
+#[cfg(target_arch = "wasm32")]
+fn trigger_flow_banner_action(document: &web_sys::Document, action: &str) {
+    match action.trim() {
+        "open-new-game" => click_dom_button(document, "new-game-toggle"),
+        "run-round" => click_dom_button(document, "advance-turn-btn"),
+        "toggle-auto" => click_dom_button(document, "auto-round-toggle"),
+        "open-recovery" => click_dom_button(document, "round-recovery-btn"),
+        "focus-join" => focus_dom_input(document, "actor-id-input"),
+        "focus-action" => focus_dom_input(document, "action-input"),
+        _ => {}
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+fn ensure_flow_banner_action_binding(document: &web_sys::Document) {
+    let Some(actions_el) = document.get_element_by_id("turn-flow-actions") else {
+        return;
+    };
+    if actions_el
+        .get_attribute("data-bound")
+        .as_deref()
+        .map(|value| value == "1")
+        .unwrap_or(false)
+    {
+        return;
+    }
+
+    let cb = Closure::wrap(Box::new(move |evt: web_sys::Event| {
+        let Some(target) = evt.target() else {
+            return;
+        };
+        let Some(mut el) = target.dyn_into::<web_sys::Element>().ok() else {
+            return;
+        };
+
+        let mut action = None;
+        loop {
+            if let Some(value) = el.get_attribute("data-flow-action") {
+                action = Some(value);
+                break;
+            }
+            let Some(parent) = el.parent_element() else {
+                break;
+            };
+            el = parent;
+        }
+        let Some(action) = action else {
+            return;
+        };
+
+        evt.prevent_default();
+        if let Some(document) = web_sys::window().and_then(|window| window.document()) {
+            trigger_flow_banner_action(&document, &action);
+        }
+    }) as Box<dyn FnMut(_)>);
+    let _ = actions_el.add_event_listener_with_callback("click", cb.as_ref().unchecked_ref());
+    cb.forget();
+    let _ = actions_el.set_attribute("data-bound", "1");
+}
+
+#[cfg(target_arch = "wasm32")]
+fn render_flow_banner_actions(
+    document: &web_sys::Document,
+    cache: &mut TurnRuntimeCache,
+    lifecycle: TrpgLifecycleState,
+    runner_running: bool,
+    has_actor_issues: bool,
+    has_runner_issue: bool,
+    current_actor: &str,
+) {
+    let Some(actions_el) = document.get_element_by_id("turn-flow-actions") else {
+        return;
+    };
+    ensure_flow_banner_action_binding(document);
+
+    let actions = collect_flow_banner_actions(
+        document,
+        lifecycle,
+        runner_running,
+        has_actor_issues,
+        has_runner_issue,
+        current_actor,
+    );
+    let snapshot = flow_banner_action_snapshot(&actions);
+    if cache.last_flow_action_snapshot == snapshot {
+        return;
+    }
+    cache.last_flow_action_snapshot = snapshot.clone();
+    let _ = actions_el.set_attribute("data-snapshot", &snapshot);
+
+    if actions.is_empty() {
+        actions_el.set_inner_html("");
+        return;
+    }
+
+    let html = actions
+        .iter()
+        .map(|action| {
+            format!(
+                "<button type=\"button\" class=\"flow-action-chip\" data-flow-action=\"{key}\" title=\"{title}\">{label}</button>",
+                key = html_escape(action.key),
+                title = html_escape(action.title),
+                label = html_escape(&action.label),
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("");
+    actions_el.set_inner_html(&html);
+}
+
 #[cfg(target_arch = "wasm32")]
 fn set_ops_hud_value(document: &web_sys::Document, id: &str, text: &str, status_class: &str) {
     let Some(el) = document.get_element_by_id(id) else {
@@ -881,6 +1249,13 @@ pub fn update_turn_runtime_dom(
         &next_action,
         &runner_preview,
     );
+    let flow_action_signature = build_flow_action_signature(
+        lifecycle,
+        runner_running,
+        has_actor_issues,
+        has_runner_issue,
+        &current_actor,
+    );
 
     let connection_label = connection_status_label(&connection);
     let connection_class = connection_status_class(&connection);
@@ -895,32 +1270,47 @@ pub fn update_turn_runtime_dom(
         &flow_state,
         &flow_class,
         &flow_detail,
+        &flow_action_signature,
+        &cache.last_flow_action_snapshot,
     );
 
-    let snapshot = format!(
-        "{}|{}|{}|{}|{}|{}|{}|{}|{}|{}|{}|{}|{}|{}|{}|{}|{}|{}|{}|{}",
-        room_status_key,
-        turn,
-        phase,
-        current_actor,
-        next_actor,
-        last_result,
-        party_status,
-        current_status,
-        input_status,
-        connection_label,
-        connection_class,
-        sync_state,
-        runner_state,
-        runner_preview,
-        progress.last_event,
-        issues_summary,
-        next_action,
-        flow_state,
-        flow_class,
-        flow_detail,
-    );
+    let snapshot = vec![
+        room_status_key.clone(),
+        turn.to_string(),
+        phase.clone(),
+        current_actor.clone(),
+        next_actor.clone(),
+        last_result.clone(),
+        party_status.clone(),
+        current_status.to_string(),
+        input_status.to_string(),
+        connection_label.to_string(),
+        connection_class.to_string(),
+        sync_state.clone(),
+        runner_state.clone(),
+        runner_preview.clone(),
+        progress.last_event.clone(),
+        issues_summary.clone(),
+        next_action.clone(),
+        flow_state.to_string(),
+        flow_class.to_string(),
+        flow_detail.clone(),
+        flow_action_signature,
+    ]
+    .join("|");
     if cache.last_snapshot == snapshot {
+        #[cfg(target_arch = "wasm32")]
+        if let Some(document) = web_sys::window().and_then(|w| w.document()) {
+            render_flow_banner_actions(
+                &document,
+                &mut cache,
+                lifecycle,
+                runner_running,
+                has_actor_issues,
+                has_runner_issue,
+                &current_actor,
+            );
+        }
         return;
     }
     cache.last_snapshot = snapshot;
@@ -1078,14 +1468,23 @@ pub fn update_turn_runtime_dom(
         set_ops_hud_value(&document, "ops-sync-state", &sync_state, sync_class);
         if let Some(flow_banner) = document.get_element_by_id("turn-flow-banner") {
             let _ = flow_banner.set_attribute("class", &format!("turn-flow-banner {}", flow_class));
-            let html = format!(
-                "<span class=\"flow-state\">{}</span><span class=\"flow-text\">{}</span>",
-                html_escape(flow_state),
-                html_escape(&flow_detail),
-            );
-            flow_banner.set_inner_html(&html);
             let _ = flow_banner.set_attribute("title", &next_action);
         }
+        if let Some(flow_state_el) = document.get_element_by_id("turn-flow-state") {
+            flow_state_el.set_text_content(Some(flow_state));
+        }
+        if let Some(flow_text_el) = document.get_element_by_id("turn-flow-text") {
+            flow_text_el.set_text_content(Some(&flow_detail));
+        }
+        render_flow_banner_actions(
+            &document,
+            &mut cache,
+            lifecycle,
+            runner_running,
+            has_actor_issues,
+            has_runner_issue,
+            &current_actor,
+        );
         render_agent_round_flow(&document, &progress);
 
         let inferred_dm = if !progress.dm_keeper.trim().is_empty() {

--- a/viewer/src/mode/mod.rs
+++ b/viewer/src/mode/mod.rs
@@ -1421,9 +1421,17 @@ pub(super) fn clear_trpg_dom(doc: &web_sys::Document) {
     }
     if let Some(el) = doc.get_element_by_id("turn-flow-banner") {
         let _ = el.set_attribute("class", "turn-flow-banner is-idle");
-        el.set_inner_html(
-            "<span class=\"flow-state\">대기</span><span class=\"flow-text\">세션 상태를 불러오는 중입니다.</span>",
-        );
+        let _ = el.set_attribute("title", "세션 상태를 불러오는 중입니다.");
+    }
+    if let Some(el) = doc.get_element_by_id("turn-flow-state") {
+        el.set_text_content(Some("대기"));
+    }
+    if let Some(el) = doc.get_element_by_id("turn-flow-text") {
+        el.set_text_content(Some("세션 상태를 불러오는 중입니다."));
+    }
+    if let Some(el) = doc.get_element_by_id("turn-flow-actions") {
+        el.set_inner_html("");
+        let _ = el.remove_attribute("data-snapshot");
     }
     if let Some(el) = doc.get_element_by_id("agent-round-flow") {
         el.set_inner_html(

--- a/viewer/style.css
+++ b/viewer/style.css
@@ -2506,6 +2506,7 @@ body.wasm-dom-fallback #bevy-canvas {
     background: rgba(12, 18, 33, 0.84);
     display: flex;
     align-items: flex-start;
+    flex-wrap: wrap;
     gap: 8px;
     padding: 7px 9px;
 }
@@ -2524,6 +2525,7 @@ body.wasm-dom-fallback #bevy-canvas {
 }
 
 .turn-flow-banner .flow-text {
+    flex: 1 1 180px;
     min-width: 0;
     font-size: 11px;
     line-height: 1.45;
@@ -2531,6 +2533,40 @@ body.wasm-dom-fallback #bevy-canvas {
     letter-spacing: 0.2px;
     overflow-wrap: anywhere;
     word-break: break-word;
+}
+
+.turn-flow-banner .flow-actions {
+    flex: 1 1 100%;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+    margin-top: 1px;
+}
+
+.turn-flow-banner .flow-action-chip {
+    appearance: none;
+    border: 1px solid rgba(109, 122, 164, 0.42);
+    border-radius: 999px;
+    background: rgba(20, 26, 44, 0.66);
+    color: var(--text-dim);
+    font-family: var(--font-ui);
+    font-size: 10px;
+    line-height: 1.2;
+    letter-spacing: 0.3px;
+    padding: 3px 9px;
+    cursor: pointer;
+    transition: border-color 0.15s ease, background 0.15s ease, color 0.15s ease;
+}
+
+.turn-flow-banner .flow-action-chip:hover {
+    border-color: rgba(196, 162, 101, 0.58);
+    background: rgba(70, 52, 23, 0.34);
+    color: #f0d9aa;
+}
+
+.turn-flow-banner .flow-action-chip:focus-visible {
+    outline: 1px solid rgba(196, 162, 101, 0.76);
+    outline-offset: 1px;
 }
 
 .turn-flow-banner.is-running {


### PR DESCRIPTION
## Summary\n- split turn-flow banner into stable state/text/actions slots\n- add clickable guidance chips for common recovery/next actions (new game, run round, auto toggle, recovery guide, input focus)\n- keep flow actions updated even when runtime snapshot is unchanged\n- reset flow action state when TRPG DOM is cleared\n\n## Validation\n- cargo test --manifest-path viewer/Cargo.toml turn_runtime -- --nocapture\n- cargo test --manifest-path viewer/Cargo.toml round_runner -- --nocapture\n- cargo check --manifest-path viewer/Cargo.toml --target wasm32-unknown-unknown