### PR TITLE
fix(trpg): break keeper stall loop caused by missing skill routing

### DIFF
--- a/lib/mcp_server_eio.ml
+++ b/lib/mcp_server_eio.ml
@@ -1180,8 +1180,11 @@ let execute_tool_eio ~sw ~clock ?mcp_session_id ?auth_token state ~name ~argumen
           ("ollama_timeout_sec", `Float timeout_sec);
         ]
     in
+    (* Eio outer timeout includes LLM time + protocol overhead (serialization,
+       network). Add 10s grace to avoid racing the LLM timeout. *)
+    let eio_timeout = timeout_sec +. 10.0 in
     try
-      Eio.Time.with_timeout_exn clock timeout_sec (fun () ->
+      Eio.Time.with_timeout_exn clock eio_timeout (fun () ->
           match
             Tool_keeper.dispatch simple_ctx_keeper ~name:"masc_keeper_msg"
               ~args:keeper_args

--- a/lib/tool_keeper.ml
+++ b/lib/tool_keeper.ml
@@ -2943,6 +2943,7 @@ let keeper_allowed_skills = [
   "masc-heartbeat";
   "lodge-social";
   "masc-keeper-autonomy";
+  "trpg-roleplay";
 ]
 
 let canonical_keeper_skill_token (raw : string) : string option =
@@ -2955,6 +2956,8 @@ let canonical_keeper_skill_token (raw : string) : string option =
   | "keeper"
   | "autonomy" ->
       Some "masc-keeper-autonomy"
+  | "trpg-roleplay" | "trpg_roleplay" | "trpg" | "roleplay" | "rp" ->
+      Some "trpg-roleplay"
   | _ -> None
 
 let unique_skills_preserve_order (xs : string list) : string list =

--- a/lib/tool_trpg.ml
+++ b/lib/tool_trpg.ml
@@ -1316,11 +1316,14 @@ let extract_skill_hint_from_text (raw : string) : string option =
 let fallback_reply_from_keeper_json keeper_json =
   let is_meta_skill_hint skill =
     let lowered = String.lowercase_ascii (String.trim skill) in
-    starts_with lowered "masc-"
-    || starts_with lowered "lodge-"
-    || starts_with lowered "heartbeat"
-    || contains_substring lowered "keeper"
-    || contains_substring lowered "autonomy"
+    (* TRPG skills are never meta-skills — they produce in-game content *)
+    if starts_with lowered "trpg-" then false
+    else
+      starts_with lowered "masc-"
+      || starts_with lowered "lodge-"
+      || starts_with lowered "heartbeat"
+      || contains_substring lowered "keeper"
+      || contains_substring lowered "autonomy"
   in
   let skill_from_meta =
     match keeper_json |> member "skill_primary" with


### PR DESCRIPTION
## Summary

TRPG keepers (p01-p04, DM) entered infinite stall loops producing "상황을 살피며 다음 행동을 준비합니다" for 50+ turns. Root cause: 5-layer failure chain where missing `trpg-roleplay` in `keeper_allowed_skills` forced LLMs to pick `masc-keeper-autonomy`, which `is_meta_skill_hint` flagged as meta → fallback stall text → narration_log poisoning → infinite loop.

### Changes (defense-in-depth at 4 points)

- **`tool_keeper.ml`**: Add `trpg-roleplay` to `keeper_allowed_skills` + canonical mapping for `trpg`/`roleplay`/`rp` aliases
- **`tool_trpg.ml`**: Exclude `trpg-` prefix from `is_meta_skill_hint` (TRPG skills produce in-game content, never meta)
- **`mcp_server_eio.ml`**: Separate Eio outer timeout from LLM timeout (+10s grace) to prevent timeout races

## Test plan

- [x] `dune build` — compiles cleanly
- [x] `make test` — all tests pass (exit code 0)
- [ ] Deploy to local MASC and run a TRPG session — verify keepers produce roleplay actions instead of stall text

🤖 Generated with [Claude Code](https://claude.com/claude-code)