### PR TITLE
feat(keeper): emit SSE events for real-time dashboard monitoring

### DIFF
--- a/lib/tool_keeper.ml
+++ b/lib/tool_keeper.ml
@@ -5410,7 +5410,15 @@ let start_keepalive (ctx : _ context) (m : keeper_meta) : unit =
                         | None -> `Null);
 	                      ("handoff", `Assoc [("performed", `Bool false)]);
 	                    ] in
-                    append_jsonl_line metrics_path snapshot)
+                    append_jsonl_line metrics_path snapshot;
+                    (* SSE: keeper_heartbeat — dashboard real-time monitoring *)
+                    (try Sse.broadcast (`Assoc [
+                      ("type", `String "keeper_heartbeat");
+                      ("name", `String meta_current.name);
+                      ("generation", `Int meta_current.generation);
+                      ("context_ratio", `Float (Context_manager.context_ratio c));
+                      ("ts_unix", `Float now_ts);
+                    ]) with _ -> ()))
              with _ -> ());
             last_snapshot_ts := now_ts
           end;
@@ -7041,7 +7049,14 @@ let handle_keeper_msg ctx args : tool_result =
                                 (Option.value
                                    ~default:"policy threshold exceeded"
                                    auto_rules.guardrail_reason)))
-                    with _ -> ()));
+                    with _ -> ());
+                   (* SSE: keeper_guardrail — dashboard real-time alert *)
+                   (try Sse.broadcast (`Assoc [
+                     ("type", `String "keeper_guardrail");
+                     ("name", `String meta_turn.name);
+                     ("reason", `String (Option.value ~default:"policy threshold exceeded"
+                        auto_rules.guardrail_reason));
+                   ]) with _ -> ()));
                 let do_handoff =
                   auto_rules.handoff &&
 		                (now_ts -. meta_turn.last_handoff_ts >= float_of_int meta_turn.handoff_cooldown_sec)
@@ -7146,6 +7161,15 @@ let handle_keeper_msg ctx args : tool_result =
                    ] in
                    append_jsonl_line metrics_path metrics_json
                  with _ -> ());
+                (* SSE: keeper_compaction — emitted only when compaction occurred *)
+                (if compacted then
+                  (try Sse.broadcast (`Assoc [
+                    ("type", `String "keeper_compaction");
+                    ("name", `String meta_turn.name);
+                    ("saved_tokens", `Int (before_compact_tokens - after_compact_tokens));
+                    ("trigger", match compaction_trigger with
+                      | Some r -> `String r | None -> `Null);
+                  ]) with _ -> ()));
 
                 let json = `Assoc [
                   ("name", `String meta_turn.name);
@@ -7369,6 +7393,14 @@ let handle_keeper_msg ctx args : tool_result =
                    ] in
                    append_jsonl_line metrics_path metrics_json
                  with _ -> ());
+                (* SSE: keeper_handoff — generation succession event *)
+                (try Sse.broadcast (`Assoc [
+                  ("type", `String "keeper_handoff");
+                  ("name", `String meta_turn.name);
+                  ("from_generation", `Int meta_turn.generation);
+                  ("to_generation", `Int next_generation);
+                  ("to_model", `String next_model.model_id);
+                ]) with _ -> ());
 
                 let json = `Assoc [
                   ("name", `String meta'.name);


### PR DESCRIPTION
## Summary

- **keeper_heartbeat**: keepalive loop에서 매 스냅샷마다 `context_ratio`, `generation`, `ts_unix` 포함하여 SSE 전송
- **keeper_guardrail**: safety policy 발동 시 `reason` 포함 SSE 전송
- **keeper_compaction**: context 압축 완료 시 `saved_tokens`, `trigger` 포함 SSE 전송
- **keeper_handoff**: 세대 교체 시 `from_generation`, `to_generation`, `to_model` 포함 SSE 전송

모든 broadcast는 `(try ... with _ -> ())` 패턴으로 keeper 루프 안정성 보장.

Frontend SSE handler는 PR #378에서 이미 구현 완료 (`dashboard/src/sse.ts`, `store.ts`).

## Changed files

- `lib/tool_keeper.ml` (+34/-2) — 4개 SSE broadcast 삽입

## Test plan

- [ ] `dune build` 성공 확인
- [ ] 로컬 서버 실행 후 keeper 활성화 → `/sse` 스트림에서 `keeper_heartbeat` 이벤트 수신 확인
- [ ] Dashboard keeper 카드에서 heartbeat dot 실시간 업데이트 확인
- [ ] Compaction/handoff 발생 시 SSE 이벤트 정상 전송 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)