### PR TITLE
viewer: clear strict clippy debt in runtime/dom modules

### DIFF
--- a/viewer/src/dom/character_panel.rs
+++ b/viewer/src/dom/character_panel.rs
@@ -113,10 +113,7 @@ fn fmt_modifier(m: i32) -> String {
 }
 
 fn normalize_lore_key(raw: &str) -> String {
-    raw.trim()
-        .to_ascii_lowercase()
-        .replace('-', "_")
-        .replace(' ', "_")
+    raw.trim().to_ascii_lowercase().replace(['-', ' '], "_")
 }
 
 fn known_skill_lore(skill_name: &str) -> Option<(&'static str, &'static str)> {
@@ -479,7 +476,10 @@ pub fn update_character_panel_dom(actors: Query<&Actor>, mut cache: ResMut<Chara
         let lore_line = if archetype_line.is_empty() && persona_line.is_empty() {
             String::new()
         } else {
-            format!("<div class=\"char-lore\">{}{}</div>", archetype_line, persona_line)
+            format!(
+                "<div class=\"char-lore\">{}{}</div>",
+                archetype_line, persona_line
+            )
         };
 
         // Buffs / debuffs

--- a/viewer/src/dom/dm_voice.rs
+++ b/viewer/src/dom/dm_voice.rs
@@ -173,13 +173,11 @@ pub fn maybe_play_dm_voice(
     room_state: &RoomState,
     progress: &TurnProgressState,
 ) {
-    if !should_play_dm_voice(payload, clean_text, room_state, progress) {
-        return;
-    }
-
-    #[cfg(target_arch = "wasm32")]
-    {
-        dispatch_voice(payload, clean_text, room_state);
+    if should_play_dm_voice(payload, clean_text, room_state, progress) {
+        #[cfg(target_arch = "wasm32")]
+        {
+            dispatch_voice(payload, clean_text, room_state);
+        }
     }
 }
 

--- a/viewer/src/dom/endgame.rs
+++ b/viewer/src/dom/endgame.rs
@@ -41,7 +41,7 @@ pub fn detect_endgame(
     }
 
     // Path 0: Canonical session outcome.
-    for SessionOutcome(payload) in outcomes.read() {
+    if let Some(SessionOutcome(payload)) = outcomes.read().next() {
         endgame.triggered = true;
         let tone = match payload.outcome.as_str() {
             "victory" => EndgameTone::Victory,
@@ -58,7 +58,6 @@ pub fn detect_endgame(
             runner.game_ended.store(true, Ordering::SeqCst);
         }
         for _ in narratives.read() {}
-        return;
     }
 
     // Path 1: TPK — all actors dead.

--- a/viewer/src/dom/narrative.rs
+++ b/viewer/src/dom/narrative.rs
@@ -361,7 +361,7 @@ pub fn update_narrative_dom(
         scroll_to_bottom(&log_el);
         trim_log(&log_el, 200);
         if !is_debug_entry {
-            dm_voice::maybe_play_dm_voice(&payload, &clean_text, &room_state, &progress);
+            dm_voice::maybe_play_dm_voice(payload, &clean_text, &room_state, &progress);
         }
     }
 }

--- a/viewer/src/dom/overlay.rs
+++ b/viewer/src/dom/overlay.rs
@@ -71,115 +71,113 @@ pub fn update_overlay_dom(
     let choice_changed = choice.active != cache.last_choice_active;
     let combat_changed = combat.active != cache.last_combat_active;
 
-    if !weather_changed && !mood_changed && !choice_changed && !combat_changed {
-        return;
-    }
+    if weather_changed || mood_changed || choice_changed || combat_changed {
+        #[cfg(target_arch = "wasm32")]
+        {
+            let Some(document) = web_sys::window().and_then(|w| w.document()) else {
+                return;
+            };
 
-    #[cfg(target_arch = "wasm32")]
-    {
-        let Some(document) = web_sys::window().and_then(|w| w.document()) else {
-            return;
-        };
-
-        if weather_changed {
-            if let Some(el) = document.get_element_by_id("weather-indicator") {
-                if overlay.weather.is_empty() {
-                    el.set_text_content(None);
-                } else {
-                    el.set_text_content(Some(&pretty_label(&overlay.weather)));
-                }
-            }
-            if let Some(img) = document
-                .get_element_by_id("weather-icon")
-                .and_then(|el| el.dyn_into::<web_sys::HtmlImageElement>().ok())
-            {
-                if let Some(path) = weather_icon_path(overlay.weather.trim()) {
-                    img.set_src(path);
-                    img.set_alt(&pretty_label(&overlay.weather));
-                    let _ = img.set_attribute("data-empty", "0");
-                } else {
-                    let _ = img.remove_attribute("src");
-                    img.set_alt("");
-                    let _ = img.set_attribute("data-empty", "1");
-                }
-            }
-            cache.last_weather = overlay.weather.clone();
-        }
-
-        if mood_changed {
-            if let Some(el) = document.get_element_by_id("mood-indicator") {
-                if overlay.mood.is_empty() {
-                    el.set_text_content(None);
-                } else {
-                    el.set_text_content(Some(&pretty_label(&overlay.mood)));
-                }
-            }
-            if let Some(img) = document
-                .get_element_by_id("mood-icon")
-                .and_then(|el| el.dyn_into::<web_sys::HtmlImageElement>().ok())
-            {
-                if let Some(path) = mood_icon_path(overlay.mood.trim()) {
-                    img.set_src(path);
-                    img.set_alt(&pretty_label(&overlay.mood));
-                    let _ = img.set_attribute("data-empty", "0");
-                } else {
-                    let _ = img.remove_attribute("src");
-                    img.set_alt("");
-                    let _ = img.set_attribute("data-empty", "1");
-                }
-            }
-            cache.last_mood = overlay.mood.clone();
-        }
-
-        if choice_changed {
-            if let Some(el) = document.get_element_by_id("choice-overlay") {
-                if choice.active {
-                    let html = format!(
-                        "<strong>{}</strong><p>{}</p><ul>{}</ul>",
-                        html_escape(&choice.character),
-                        html_escape(&choice.description),
-                        choice
-                            .options
-                            .iter()
-                            .map(|o| format!("<li>{}</li>", html_escape(o)))
-                            .collect::<Vec<_>>()
-                            .join("")
-                    );
-                    el.set_inner_html(&html);
-                    if let Some(html_el) = el.dyn_ref::<web_sys::HtmlElement>() {
-                        let _ = html_el.style().set_property("display", "block");
-                    }
-                } else {
-                    el.set_inner_html("");
-                    if let Some(html_el) = el.dyn_ref::<web_sys::HtmlElement>() {
-                        let _ = html_el.style().set_property("display", "none");
+            if weather_changed {
+                if let Some(el) = document.get_element_by_id("weather-indicator") {
+                    if overlay.weather.is_empty() {
+                        el.set_text_content(None);
+                    } else {
+                        el.set_text_content(Some(&pretty_label(&overlay.weather)));
                     }
                 }
-            }
-            cache.last_choice_active = choice.active;
-        }
-
-        if combat_changed {
-            if let Some(el) = document.get_element_by_id("combat-overlay") {
-                if combat.active {
-                    let enemies_str = combat.enemies.join(", ");
-                    let html = format!(
-                        "<strong>COMBAT</strong> <span>{}</span><p>{}</p>",
-                        html_escape(&combat.area),
-                        html_escape(&enemies_str)
-                    );
-                    el.set_inner_html(&html);
-                    if let Some(html_el) = el.dyn_ref::<web_sys::HtmlElement>() {
-                        let _ = html_el.style().set_property("display", "block");
-                    }
-                } else {
-                    el.set_inner_html("");
-                    if let Some(html_el) = el.dyn_ref::<web_sys::HtmlElement>() {
-                        let _ = html_el.style().set_property("display", "none");
+                if let Some(img) = document
+                    .get_element_by_id("weather-icon")
+                    .and_then(|el| el.dyn_into::<web_sys::HtmlImageElement>().ok())
+                {
+                    if let Some(path) = weather_icon_path(overlay.weather.trim()) {
+                        img.set_src(path);
+                        img.set_alt(&pretty_label(&overlay.weather));
+                        let _ = img.set_attribute("data-empty", "0");
+                    } else {
+                        let _ = img.remove_attribute("src");
+                        img.set_alt("");
+                        let _ = img.set_attribute("data-empty", "1");
                     }
                 }
+                cache.last_weather = overlay.weather.clone();
             }
-            cache.last_combat_active = combat.active;
+
+            if mood_changed {
+                if let Some(el) = document.get_element_by_id("mood-indicator") {
+                    if overlay.mood.is_empty() {
+                        el.set_text_content(None);
+                    } else {
+                        el.set_text_content(Some(&pretty_label(&overlay.mood)));
+                    }
+                }
+                if let Some(img) = document
+                    .get_element_by_id("mood-icon")
+                    .and_then(|el| el.dyn_into::<web_sys::HtmlImageElement>().ok())
+                {
+                    if let Some(path) = mood_icon_path(overlay.mood.trim()) {
+                        img.set_src(path);
+                        img.set_alt(&pretty_label(&overlay.mood));
+                        let _ = img.set_attribute("data-empty", "0");
+                    } else {
+                        let _ = img.remove_attribute("src");
+                        img.set_alt("");
+                        let _ = img.set_attribute("data-empty", "1");
+                    }
+                }
+                cache.last_mood = overlay.mood.clone();
+            }
+
+            if choice_changed {
+                if let Some(el) = document.get_element_by_id("choice-overlay") {
+                    if choice.active {
+                        let html = format!(
+                            "<strong>{}</strong><p>{}</p><ul>{}</ul>",
+                            html_escape(&choice.character),
+                            html_escape(&choice.description),
+                            choice
+                                .options
+                                .iter()
+                                .map(|o| format!("<li>{}</li>", html_escape(o)))
+                                .collect::<Vec<_>>()
+                                .join("")
+                        );
+                        el.set_inner_html(&html);
+                        if let Some(html_el) = el.dyn_ref::<web_sys::HtmlElement>() {
+                            let _ = html_el.style().set_property("display", "block");
+                        }
+                    } else {
+                        el.set_inner_html("");
+                        if let Some(html_el) = el.dyn_ref::<web_sys::HtmlElement>() {
+                            let _ = html_el.style().set_property("display", "none");
+                        }
+                    }
+                }
+                cache.last_choice_active = choice.active;
+            }
+
+            if combat_changed {
+                if let Some(el) = document.get_element_by_id("combat-overlay") {
+                    if combat.active {
+                        let enemies_str = combat.enemies.join(", ");
+                        let html = format!(
+                            "<strong>COMBAT</strong> <span>{}</span><p>{}</p>",
+                            html_escape(&combat.area),
+                            html_escape(&enemies_str)
+                        );
+                        el.set_inner_html(&html);
+                        if let Some(html_el) = el.dyn_ref::<web_sys::HtmlElement>() {
+                            let _ = html_el.style().set_property("display", "block");
+                        }
+                    } else {
+                        el.set_inner_html("");
+                        if let Some(html_el) = el.dyn_ref::<web_sys::HtmlElement>() {
+                            let _ = html_el.style().set_property("display", "none");
+                        }
+                    }
+                }
+                cache.last_combat_active = combat.active;
+            }
         }
     }
 }

--- a/viewer/src/dom/session_history.rs
+++ b/viewer/src/dom/session_history.rs
@@ -5,6 +5,7 @@
 
 #![allow(dead_code)] // Many helpers used only in wasm32 cfg blocks.
 
+use bevy::ecs::system::SystemParam;
 use bevy::prelude::*;
 use std::cmp::Ordering;
 #[cfg(target_arch = "wasm32")]
@@ -49,6 +50,15 @@ struct RoomHistory {
 #[derive(Resource, Default)]
 pub struct SessionHistoryCache {
     rooms: Vec<RoomHistory>,
+}
+
+#[derive(SystemParam)]
+pub struct SessionHistoryReaders<'w, 's> {
+    narratives: MessageReader<'w, 's, NarrativeReceived>,
+    dice_events: MessageReader<'w, 's, DiceRolled>,
+    turn_events: MessageReader<'w, 's, TurnAdvanced>,
+    progress_events: MessageReader<'w, 's, TurnProgressUpdated>,
+    session_started: MessageReader<'w, 's, SessionStarted>,
 }
 
 #[cfg(target_arch = "wasm32")]
@@ -220,19 +230,21 @@ fn ensure_room_entry(
     (idx, true)
 }
 
-fn append_event(
-    rooms: &mut Vec<RoomHistory>,
-    room_id: &str,
-    room_status: &str,
+struct EventAppendInput<'a> {
+    room_id: &'a str,
+    room_status: &'a str,
     turn: u32,
-    phase: &str,
-    kind: &str,
-    actor: &str,
-    title: &str,
-    detail: &str,
-) -> (bool, bool) {
-    let normalized_turn = turn.max(1);
-    let (room_idx, mut changed) = ensure_room_entry(rooms, room_id, room_status, normalized_turn);
+    phase: &'a str,
+    kind: &'a str,
+    actor: &'a str,
+    title: &'a str,
+    detail: &'a str,
+}
+
+fn append_event(rooms: &mut Vec<RoomHistory>, input: EventAppendInput<'_>) -> (bool, bool) {
+    let normalized_turn = input.turn.max(1);
+    let (room_idx, mut changed) =
+        ensure_room_entry(rooms, input.room_id, input.room_status, normalized_turn);
     let Some(room) = rooms.get_mut(room_idx) else {
         return (false, changed);
     };
@@ -242,17 +254,17 @@ fn append_event(
         changed = true;
     }
 
-    let (turn_idx, turn_changed) = ensure_turn_entry(&mut room.turns, normalized_turn, phase);
+    let (turn_idx, turn_changed) = ensure_turn_entry(&mut room.turns, normalized_turn, input.phase);
     changed = changed || turn_changed;
     let Some(row) = room.turns.get_mut(turn_idx) else {
         return (false, changed);
     };
 
     let candidate = HistoryEvent {
-        kind: kind.to_string(),
-        actor: actor.to_string(),
-        title: title.to_string(),
-        detail: detail.to_string(),
+        kind: input.kind.to_string(),
+        actor: input.actor.to_string(),
+        title: input.title.to_string(),
+        detail: input.detail.to_string(),
     };
 
     if row
@@ -319,10 +331,8 @@ fn label_progress_event(
         "turn"
     } else if matches!(
         payload.event_type.as_str(),
-        "combat.attack" | "combat.defense" | "session.outcome"
+        "combat.attack" | "combat.defense" | "session.outcome" | "room.started" | "room.ended"
     ) {
-        "system"
-    } else if matches!(payload.event_type.as_str(), "room.started" | "room.ended") {
         "system"
     } else {
         "progress"
@@ -1042,13 +1052,17 @@ fn bump_dedup_history(document: &web_sys::Document, sample: &str) {
 pub fn update_session_history_dom(
     room_state: Res<RoomState>,
     progress: Res<TurnProgressState>,
-    mut narratives: MessageReader<NarrativeReceived>,
-    mut dice_events: MessageReader<DiceRolled>,
-    mut turn_events: MessageReader<TurnAdvanced>,
-    mut progress_events: MessageReader<TurnProgressUpdated>,
-    mut session_started: MessageReader<SessionStarted>,
+    mut readers: SessionHistoryReaders,
     mut cache: ResMut<SessionHistoryCache>,
 ) {
+    let SessionHistoryReaders {
+        mut narratives,
+        mut dice_events,
+        mut turn_events,
+        mut progress_events,
+        mut session_started,
+    } = readers;
+
     #[cfg(not(target_arch = "wasm32"))]
     {
         for _ in turn_events.read() {}
@@ -1056,7 +1070,6 @@ pub fn update_session_history_dom(
         for _ in dice_events.read() {}
         for _ in progress_events.read() {}
         for _ in session_started.read() {}
-        return;
     }
 
     #[cfg(target_arch = "wasm32")]
@@ -1158,14 +1171,16 @@ pub fn update_session_history_dom(
             };
             let (appended, updated) = append_event(
                 &mut cache.rooms,
-                &event_room_id,
-                "active",
-                1,
-                &event_phase,
-                "system",
-                "",
-                "세션 시작",
-                &detail,
+                EventAppendInput {
+                    room_id: &event_room_id,
+                    room_status: "active",
+                    turn: 1,
+                    phase: &event_phase,
+                    kind: "system",
+                    actor: "",
+                    title: "세션 시작",
+                    detail: &detail,
+                },
             );
             if !appended {
                 bump_dedup_history(
@@ -1193,24 +1208,27 @@ pub fn update_session_history_dom(
                 normalize_room_id(&event.room_id)
             };
 
+            let turn_detail = format!(
+                "Turn {} ({})",
+                current_turn,
+                if current_phase.is_empty() {
+                    "-"
+                } else {
+                    &current_phase
+                }
+            );
             let (appended, updated) = append_event(
                 &mut cache.rooms,
-                &event_room_id,
-                &base_room_status,
-                current_turn,
-                &current_phase,
-                "turn",
-                "",
-                "턴 진행",
-                &format!(
-                    "Turn {} ({})",
-                    current_turn,
-                    if current_phase.is_empty() {
-                        "-"
-                    } else {
-                        &current_phase
-                    }
-                ),
+                EventAppendInput {
+                    room_id: &event_room_id,
+                    room_status: &base_room_status,
+                    turn: current_turn,
+                    phase: &current_phase,
+                    kind: "turn",
+                    actor: "",
+                    title: "턴 진행",
+                    detail: &turn_detail,
+                },
             );
             if !appended {
                 bump_dedup_history(
@@ -1243,14 +1261,16 @@ pub fn update_session_history_dom(
 
             let (appended, updated) = append_event(
                 &mut cache.rooms,
-                &event_room_id,
-                &base_room_status,
-                event_turn,
-                &event_phase,
-                "narrative",
-                event.speaker.as_deref().unwrap_or(""),
-                "내러티브",
-                &event.text,
+                EventAppendInput {
+                    room_id: &event_room_id,
+                    room_status: &base_room_status,
+                    turn: event_turn,
+                    phase: &event_phase,
+                    kind: "narrative",
+                    actor: event.speaker.as_deref().unwrap_or(""),
+                    title: "내러티브",
+                    detail: &event.text,
+                },
             );
             if !appended {
                 bump_dedup_history(
@@ -1280,24 +1300,27 @@ pub fn update_session_history_dom(
                 normalize_room_id(&payload.room_id)
             };
 
+            let dice_detail = format!(
+                "{} - {} (d20 {} + {} = {}, DC {})",
+                payload.character,
+                payload.action,
+                payload.d20,
+                payload.bonus,
+                payload.total,
+                payload.dc
+            );
             let (appended, updated) = append_event(
                 &mut cache.rooms,
-                &event_room_id,
-                &base_room_status,
-                event_turn,
-                &current_phase,
-                "dice",
-                &payload.character,
-                "주사위",
-                &format!(
-                    "{} - {} (d20 {} + {} = {}, DC {})",
-                    payload.character,
-                    payload.action,
-                    payload.d20,
-                    payload.bonus,
-                    payload.total,
-                    payload.dc
-                ),
+                EventAppendInput {
+                    room_id: &event_room_id,
+                    room_status: &base_room_status,
+                    turn: event_turn,
+                    phase: &current_phase,
+                    kind: "dice",
+                    actor: &payload.character,
+                    title: "주사위",
+                    detail: &dice_detail,
+                },
             );
             if !appended {
                 bump_dedup_history(
@@ -1338,20 +1361,23 @@ pub fn update_session_history_dom(
             };
 
             let (kind, actor, summary) = label_progress_event(event);
+            let title = if summary.is_empty() {
+                "turn progress"
+            } else {
+                &summary
+            };
             let (appended, updated) = append_event(
                 &mut cache.rooms,
-                &event_room_id,
-                &event_status,
-                event_turn,
-                &event_phase,
-                kind,
-                &actor,
-                if summary.is_empty() {
-                    "turn progress"
-                } else {
-                    &summary
+                EventAppendInput {
+                    room_id: &event_room_id,
+                    room_status: &event_status,
+                    turn: event_turn,
+                    phase: &event_phase,
+                    kind,
+                    actor: &actor,
+                    title,
+                    detail: &event.event_type,
                 },
-                &event.event_type,
             );
             if !appended {
                 bump_dedup_history(
@@ -1389,8 +1415,7 @@ pub fn update_session_history_dom(
         history.set_inner_html(&render_session_history_html(&cache.rooms, &current_room_id));
         bind_history_focus_controls(&document);
 
-        let preferred_room = read_focus_room(&document)
-            .or_else(|| Some(base_room_id.clone()));
+        let preferred_room = read_focus_room(&document).or_else(|| Some(base_room_id.clone()));
         let preferred_turn = read_focus_turn(&document).or(Some(current_turn.max(1)));
 
         let focus_room = resolve_focus_room(&cache.rooms, preferred_room.as_deref());

--- a/viewer/src/dom/turn_runtime.rs
+++ b/viewer/src/dom/turn_runtime.rs
@@ -72,15 +72,8 @@ fn normalize_phase_for_sync(phase: &str) -> String {
     let normalized = phase.trim().to_ascii_lowercase().replace('-', "_");
     match normalized.as_str() {
         "briefing" | "dm" | "narration" | "dm_narration" => "dm_narration".to_string(),
-        "discuss"
-        | "discussion"
-        | "player_discuss"
-        | "party_discussion"
-        | "action"
-        | "player_action"
-        | "dice"
-        | "roll"
-        | "dice_resolution" => "round".to_string(),
+        "discuss" | "discussion" | "player_discuss" | "party_discussion" | "action"
+        | "player_action" | "dice" | "roll" | "dice_resolution" => "round".to_string(),
         _ => normalized,
     }
 }
@@ -500,15 +493,19 @@ fn build_next_action_hint(
     }
 }
 
-fn build_flow_banner(
-    lifecycle: TrpgLifecycleState,
-    connection: &ConnectionStatus,
+struct FlowBannerInput<'a> {
     runner_running: bool,
     has_actor_issues: bool,
     has_runner_issue: bool,
-    current_actor: &str,
-    next_action: &str,
-    runner_preview: &str,
+    current_actor: &'a str,
+    next_action: &'a str,
+    runner_preview: &'a str,
+}
+
+fn build_flow_banner(
+    lifecycle: TrpgLifecycleState,
+    connection: &ConnectionStatus,
+    input: FlowBannerInput<'_>,
 ) -> (&'static str, &'static str, String) {
     match connection {
         ConnectionStatus::Failed | ConnectionStatus::Disconnected => (
@@ -548,36 +545,46 @@ fn build_flow_banner(
                 "새 게임을 시작하거나 실행 가능한 방으로 이동하세요.".to_string(),
             ),
             TrpgLifecycleState::Running => {
-                if has_runner_issue {
-                    let detail = if runner_preview.trim().is_empty() || runner_preview == "-" {
-                        format!("자동 진행 이슈 감지 · {}", next_action)
-                    } else {
-                        format!("자동 진행 이슈 감지 ({}) · {}", runner_preview, next_action)
-                    };
+                if input.has_runner_issue {
+                    let detail =
+                        if input.runner_preview.trim().is_empty() || input.runner_preview == "-" {
+                            format!("자동 진행 이슈 감지 · {}", input.next_action)
+                        } else {
+                            format!(
+                                "자동 진행 이슈 감지 ({}) · {}",
+                                input.runner_preview, input.next_action
+                            )
+                        };
                     ("주의", "is-alert", detail)
-                } else if runner_running {
+                } else if input.runner_running {
                     (
                         "자동 진행",
                         "is-running",
-                        format!("AI 라운드 자동 순환 중 · {}", next_action),
+                        format!("AI 라운드 자동 순환 중 · {}", input.next_action),
                     )
-                } else if has_actor_issues {
+                } else if input.has_actor_issues {
                     (
                         "주의",
                         "is-alert",
-                        format!("응답 이슈 감지 · {}", next_action),
+                        format!("응답 이슈 감지 · {}", input.next_action),
                     )
-                } else if !current_actor.trim().is_empty() && current_actor.trim() != "-" {
+                } else if !input.current_actor.trim().is_empty()
+                    && input.current_actor.trim() != "-"
+                {
                     (
                         "진행 중",
                         "is-running",
-                        format!("{} 턴 처리 중 · {}", current_actor.trim(), next_action),
+                        format!(
+                            "{} 턴 처리 중 · {}",
+                            input.current_actor.trim(),
+                            input.next_action
+                        ),
                     )
                 } else {
                     (
                         "대기",
                         "is-waiting",
-                        format!("다음 액션 대기 · {}", next_action),
+                        format!("다음 액션 대기 · {}", input.next_action),
                     )
                 }
             }
@@ -1255,12 +1262,14 @@ pub fn update_turn_runtime_dom(
     let (flow_state, flow_class, flow_detail) = build_flow_banner(
         lifecycle,
         &connection,
-        runner_running,
-        has_actor_issues,
-        has_runner_issue,
-        &current_actor,
-        &next_action,
-        &runner_preview,
+        FlowBannerInput {
+            runner_running,
+            has_actor_issues,
+            has_runner_issue,
+            current_actor: &current_actor,
+            next_action: &next_action,
+            runner_preview: &runner_preview,
+        },
     );
     let flow_action_signature = build_flow_action_signature(
         lifecycle,
@@ -1655,8 +1664,10 @@ mod tests {
 
     #[test]
     fn summarize_actor_issues_respects_actor_order_and_reason() {
-        let mut progress = TurnProgressState::default();
-        progress.actor_order = vec!["dm".to_string(), "p01".to_string(), "p02".to_string()];
+        let mut progress = TurnProgressState {
+            actor_order: vec!["dm".to_string(), "p01".to_string(), "p02".to_string()],
+            ..TurnProgressState::default()
+        };
         progress
             .actor_states
             .insert("p02".to_string(), "unavailable".to_string());
@@ -1701,12 +1712,14 @@ mod tests {
         let (state, class_name, detail) = build_flow_banner(
             TrpgLifecycleState::Running,
             &ConnectionStatus::Failed,
-            false,
-            false,
-            false,
-            "-",
-            "라운드 실행을 누르세요.",
-            "-",
+            FlowBannerInput {
+                runner_running: false,
+                has_actor_issues: false,
+                has_runner_issue: false,
+                current_actor: "-",
+                next_action: "라운드 실행을 누르세요.",
+                runner_preview: "-",
+            },
         );
         assert_eq!(state, "연결 오류");
         assert_eq!(class_name, "is-error");
@@ -1718,12 +1731,14 @@ mod tests {
         let (state, class_name, detail) = build_flow_banner(
             TrpgLifecycleState::Running,
             &ConnectionStatus::Connected,
-            true,
-            false,
-            false,
-            "p01",
-            "자동 진행 중입니다.",
-            "-",
+            FlowBannerInput {
+                runner_running: true,
+                has_actor_issues: false,
+                has_runner_issue: false,
+                current_actor: "p01",
+                next_action: "자동 진행 중입니다.",
+                runner_preview: "-",
+            },
         );
         assert_eq!(state, "자동 진행");
         assert_eq!(class_name, "is-running");
@@ -1735,12 +1750,14 @@ mod tests {
         let (state, class_name, detail) = build_flow_banner(
             TrpgLifecycleState::Running,
             &ConnectionStatus::Connected,
-            true,
-            false,
-            true,
-            "p01",
-            "자동 진행 응답에 이슈가 있습니다.",
-            "keeper busy detected",
+            FlowBannerInput {
+                runner_running: true,
+                has_actor_issues: false,
+                has_runner_issue: true,
+                current_actor: "p01",
+                next_action: "자동 진행 응답에 이슈가 있습니다.",
+                runner_preview: "keeper busy detected",
+            },
         );
         assert_eq!(state, "주의");
         assert_eq!(class_name, "is-alert");

--- a/viewer/src/mode/mod.rs
+++ b/viewer/src/mode/mod.rs
@@ -287,23 +287,12 @@ fn save_view_layout_prefs(prefs: ViewLayoutPrefs) {
 
 /// Holds pending mode transitions from JS click events.
 /// The JS closure writes here; a Bevy Update system drains it.
-#[derive(Resource)]
+#[derive(Resource, Default)]
 pub struct ModeTransitionBuffer {
     #[cfg(target_arch = "wasm32")]
     pending: Arc<Mutex<Option<ViewerMode>>>,
     #[cfg(not(target_arch = "wasm32"))]
     _phantom: (),
-}
-
-impl Default for ModeTransitionBuffer {
-    fn default() -> Self {
-        Self {
-            #[cfg(target_arch = "wasm32")]
-            pending: Arc::new(Mutex::new(None)),
-            #[cfg(not(target_arch = "wasm32"))]
-            _phantom: (),
-        }
-    }
 }
 
 // ─── Plugin ──────────────────────────────────

--- a/viewer/src/sse/masc_bridge.rs
+++ b/viewer/src/sse/masc_bridge.rs
@@ -386,31 +386,6 @@ pub fn poll_masc_events(
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn unwrap_message_event_extracts_inner_type_and_payload() {
-        let raw = r#"{"jsonrpc":"2.0","method":"masc/event","params":{"type":"experiment_created","agent":"tester","data":{"id":"exp-1","hypothesis":"smoke"}}}"#;
-        let (event_type, payload) = unwrap_message_event(raw).expect("envelope should parse");
-
-        assert_eq!(event_type, "experiment_created");
-        assert_eq!(extract_field(&payload, "id"), Some("exp-1"));
-        assert_eq!(extract_field(&payload, "hypothesis"), Some("smoke"));
-    }
-
-    #[test]
-    fn unwrap_message_event_normalizes_masc_broadcast() {
-        let raw = r#"{"jsonrpc":"2.0","method":"masc/event","params":{"type":"masc/broadcast","agent":"tester","data":{"from":"alice","content":"hello"}}}"#;
-        let (event_type, payload) = unwrap_message_event(raw).expect("envelope should parse");
-
-        assert_eq!(event_type, "broadcast");
-        assert_eq!(extract_field(&payload, "from"), Some("alice"));
-        assert_eq!(extract_field(&payload, "content"), Some("hello"));
-    }
-}
-
 // ─── DOM Update Helpers ──────────────────────
 //
 // All DOM access is gated on wasm32. On native, these are no-ops.
@@ -518,5 +493,30 @@ fn update_experiment_dashboard(_summary: &str) {
             let lines: Vec<&str> = updated.lines().take(50).collect();
             el.set_text_content(Some(&lines.join("\n")));
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn unwrap_message_event_extracts_inner_type_and_payload() {
+        let raw = r#"{"jsonrpc":"2.0","method":"masc/event","params":{"type":"experiment_created","agent":"tester","data":{"id":"exp-1","hypothesis":"smoke"}}}"#;
+        let (event_type, payload) = unwrap_message_event(raw).expect("envelope should parse");
+
+        assert_eq!(event_type, "experiment_created");
+        assert_eq!(extract_field(&payload, "id"), Some("exp-1"));
+        assert_eq!(extract_field(&payload, "hypothesis"), Some("smoke"));
+    }
+
+    #[test]
+    fn unwrap_message_event_normalizes_masc_broadcast() {
+        let raw = r#"{"jsonrpc":"2.0","method":"masc/event","params":{"type":"masc/broadcast","agent":"tester","data":{"from":"alice","content":"hello"}}}"#;
+        let (event_type, payload) = unwrap_message_event(raw).expect("envelope should parse");
+
+        assert_eq!(event_type, "broadcast");
+        assert_eq!(extract_field(&payload, "from"), Some("alice"));
+        assert_eq!(extract_field(&payload, "content"), Some("hello"));
     }
 }

--- a/viewer/src/sse/reconnect.rs
+++ b/viewer/src/sse/reconnect.rs
@@ -237,21 +237,21 @@ mod tests {
         let d1 = state
             .next_delay()
             .expect("next_delay should return Some on attempt 1");
-        assert!(d1 >= 750 && d1 <= 1250, "d1={}", d1);
+        assert!((750..=1250).contains(&d1), "d1={}", d1);
         assert_eq!(state.attempt, 1);
 
         // Second delay should be around 2000ms
         let d2 = state
             .next_delay()
             .expect("next_delay should return Some on attempt 2");
-        assert!(d2 >= 1500 && d2 <= 2500, "d2={}", d2);
+        assert!((1500..=2500).contains(&d2), "d2={}", d2);
         assert_eq!(state.attempt, 2);
 
         // Third delay should be around 4000ms
         let d3 = state
             .next_delay()
             .expect("next_delay should return Some on attempt 3");
-        assert!(d3 >= 3000 && d3 <= 5000, "d3={}", d3);
+        assert!((3000..=5000).contains(&d3), "d3={}", d3);
     }
 
     #[test]

--- a/viewer/src/theme.rs
+++ b/viewer/src/theme.rs
@@ -133,23 +133,12 @@ impl ViewerTheme {
 
 /// Holds pending theme transitions from JS change events.
 /// The JS closure writes here; a Bevy Update system drains it.
-#[derive(Resource)]
+#[derive(Resource, Default)]
 pub struct ThemeTransitionBuffer {
     #[cfg(target_arch = "wasm32")]
     pending: Arc<Mutex<Option<ViewerTheme>>>,
     #[cfg(not(target_arch = "wasm32"))]
     _phantom: (),
-}
-
-impl Default for ThemeTransitionBuffer {
-    fn default() -> Self {
-        Self {
-            #[cfg(target_arch = "wasm32")]
-            pending: Arc::new(Mutex::new(None)),
-            #[cfg(not(target_arch = "wasm32"))]
-            _phantom: (),
-        }
-    }
 }
 
 // ─── Plugin ──────────────────────────────────


### PR DESCRIPTION
## Summary
- clear `cargo clippy --all-targets -- -D warnings` failures in `viewer`
- keep behavior intact while reducing lint debt (derive/default, control-flow cleanup, system param factoring)
- fix test-module ordering and range assertions flagged by clippy

## Validation
- `cargo clippy --all-targets -- -D warnings` (in `viewer`) ✅
- `cargo check` (in `viewer`) ✅
- `cargo test` (in `viewer`) ✅ (114 passed)
- `cargo check --target wasm32-unknown-unknown` (in `viewer`) ✅

## Scope
- only `viewer/src/**` touched
- no `qa-hub` changes
