### PR TITLE
feat(trpg): clarify party-card trait/skill meaning

### DIFF
--- a/viewer/src/dom/character_panel.rs
+++ b/viewer/src/dom/character_panel.rs
@@ -571,13 +571,17 @@ pub fn update_character_panel_dom(actors: Query<&Actor>, mut cache: ResMut<Chara
             format!(
                 concat!(
                     "<input type=\"checkbox\" class=\"section-toggle\" id=\"{}\"{}/>",
-                    "<label class=\"section-header\" for=\"{}\">Traits <span class=\"section-count\">({})</span></label>",
+                    "<label class=\"section-header\" for=\"{}\" title=\"Trait은 캐릭터의 행동 성향입니다.\">Traits (성향) <span class=\"section-count\">({})</span></label>",
                     "<div class=\"section-body traits-list\">{}</div>",
                 ),
                 traits_id, traits_checked,
                 traits_id,
                 actor.traits.len(),
-                rows,
+                format!(
+                    "{}{}",
+                    "<div class=\"section-guide\">행동 선택 방향을 잡는 성향 태그입니다.</div>",
+                    rows
+                ),
             )
         };
 
@@ -593,6 +597,7 @@ pub fn update_character_panel_dom(actors: Query<&Actor>, mut cache: ResMut<Chara
                     let (description, usage_hint) = skill_copy(s, actor);
                     let escaped_name = html_escape(&s.name);
                     let escaped_desc = html_escape(&description);
+                    let escaped_hint = html_escape(&usage_hint);
                     let mod_class = if m > 0 {
                         "mod-positive"
                     } else if m < 0 {
@@ -600,10 +605,10 @@ pub fn update_character_panel_dom(actors: Query<&Actor>, mut cache: ResMut<Chara
                     } else {
                         "mod-neutral"
                     };
-                    let hint_attr = if usage_hint.trim().is_empty() {
+                    let hint_line = if usage_hint.trim().is_empty() {
                         String::new()
                     } else {
-                        format!(" title=\"{}\"", html_escape(&usage_hint))
+                        format!("<div class=\"skill-hint\">Hint: {}</div>", escaped_hint)
                     };
                     format!(
                         concat!(
@@ -613,15 +618,16 @@ pub fn update_character_panel_dom(actors: Query<&Actor>, mut cache: ResMut<Chara
                             "<span class=\"skill-level\">Lv{}</span>",
                             "<span class=\"skill-mod {}\">{}</span>",
                             "</div>",
-                            "<div class=\"skill-desc\"{}>{}</div>",
+                            "<div class=\"skill-desc\">{}</div>",
+                            "{}",
                             "</div>"
                         ),
                         escaped_name,
                         s.level,
                         mod_class,
                         fmt_modifier(m),
-                        hint_attr,
                         escaped_desc,
+                        hint_line,
                     )
                 })
                 .collect::<Vec<_>>()
@@ -630,13 +636,18 @@ pub fn update_character_panel_dom(actors: Query<&Actor>, mut cache: ResMut<Chara
             format!(
                 concat!(
                     "<input type=\"checkbox\" class=\"section-toggle\" id=\"{}\"{}/>",
-                    "<label class=\"section-header\" for=\"{}\">Skills <span class=\"section-count\">({})</span></label>",
+                    "<label class=\"section-header\" for=\"{}\" title=\"Skill 수치는 액션/주사위 판정에 사용됩니다.\">Skills (판정) <span class=\"section-count\">({})</span></label>",
                     "<div class=\"section-body skills-list\">{}</div>",
                 ),
                 skills_id, skills_checked,
                 skills_id,
                 actor.skills.len(),
-                format!("{}{}", head, rows),
+                format!(
+                    "{}{}{}",
+                    "<div class=\"section-guide\">액션/주사위 판정 보정치입니다. 기본 계산: Mod = (Lv-10)/2</div>",
+                    head,
+                    rows
+                ),
             )
         };
 

--- a/viewer/style.css
+++ b/viewer/style.css
@@ -1977,6 +1977,17 @@ body.wasm-dom-fallback #bevy-canvas {
     max-height: 500px;
 }
 
+.section-guide {
+    font-family: var(--font-ui);
+    font-size: 9px;
+    color: var(--text-dim);
+    line-height: 1.35;
+    margin: 2px 4px 6px;
+    padding: 4px 6px;
+    border-left: 2px solid rgba(169, 210, 255, 0.35);
+    background: rgba(255, 255, 255, 0.02);
+}
+
 /* Skills list */
 .skills-list {
     padding: 0 2px;
@@ -2071,6 +2082,14 @@ body.wasm-dom-fallback #bevy-canvas {
     color: var(--text-dim);
     font-size: 9px;
     line-height: 1.35;
+    white-space: normal;
+}
+
+.skill-hint {
+    color: rgba(227, 239, 255, 0.85);
+    font-size: 9px;
+    line-height: 1.35;
+    margin-top: 1px;
     white-space: normal;
 }
 


### PR DESCRIPTION
## Summary
- rename section headers to `Traits (성향)` and `Skills (판정)` for immediate semantics
- add section guide copy inside each collapsible panel
- expose per-skill usage hint as a visible line (`Hint:`) instead of hidden tooltip-only text
- keep existing skill modifier formula presentation (`Mod = (Lv-10)/2`) and make it explicit in guide copy

## Why
- users could see trait/skill values but still not understand what they influence in play
- tooltip-only hint copy was easy to miss on local play/mobile contexts

## Verification
- `cd viewer && cargo check`
