### PR TITLE
feat(trpg): add ElevenLabs TTS proxy endpoint

### DIFF
--- a/bin/main_eio.ml
+++ b/bin/main_eio.ml
@@ -35,6 +35,7 @@ module Context_manager = Masc_mcp.Context_manager
 module Llm_client = Masc_mcp.Llm_client
 module Tool_perpetual = Masc_mcp.Tool_perpetual
 module Tool_board = Masc_mcp.Tool_board
+module Process_eio = Masc_mcp.Process_eio
 
 (** MCP Protocol Versions *)
 (* ============================================ *)
@@ -1291,6 +1292,83 @@ let auth_token_from_request request =
   match Httpun.Headers.get request.Httpun.Request.headers "authorization" with
   | Some v -> bearer_token_from_header v
   | None -> query_param request "token"
+
+(** TTS proxy — forwards text to ElevenLabs and returns audio/mpeg bytes.
+    Reads ELEVENLABS_API_KEY from environment. *)
+let trpg_tts_proxy ~body_str : (string, [> `Bad_request | `Internal_server_error] * string) result =
+  try
+    let json = Yojson.Safe.from_string body_str in
+    let open Yojson.Safe.Util in
+    let text =
+      match json |> member "text" |> to_string_option with
+      | Some t when String.length (String.trim t) > 0 -> String.trim t
+      | _ -> raise (Yojson.Json_error "missing or empty 'text' field")
+    in
+    let voice_id =
+      match json |> member "voice_id" |> to_string_option with
+      | Some v when String.length v > 0 -> v
+      | _ -> "21m00Tcm4TlvDq8ikWAM"  (* Rachel *)
+    in
+    let model_id =
+      match json |> member "voice_model" |> to_string_option with
+      | Some m when String.length m > 0 -> m
+      | _ -> "eleven_multilingual_v2"
+    in
+    match Sys.getenv_opt "ELEVENLABS_API_KEY" with
+    | None | Some "" ->
+        Error (`Internal_server_error, "ELEVENLABS_API_KEY not configured")
+    | Some api_key ->
+        let url = Printf.sprintf
+          "https://api.elevenlabs.io/v1/text-to-speech/%s" voice_id in
+        let req_body = Yojson.Safe.to_string (`Assoc [
+          ("text", `String text);
+          ("model_id", `String model_id);
+          ("voice_settings", `Assoc [
+            ("stability", `Float 0.5);
+            ("similarity_boost", `Float 0.75);
+            ("style", `Float 0.0);
+          ]);
+        ]) in
+        let headers = [
+          ("xi-api-key", api_key);
+          ("Content-Type", "application/json");
+          ("Accept", "audio/mpeg");
+        ] in
+        let header_args = List.concat_map (fun (k, v) ->
+          ["-H"; Printf.sprintf "%s: %s" k v]
+        ) headers in
+        let argv = ["curl"; "-s"; "--max-time"; "30";
+                    "-X"; "POST"; url] @ header_args @ ["-d"; "@-"] in
+        let (status, raw) = Process_eio.run_argv_with_stdin_and_status
+          ~timeout_sec:35.0
+          ~stdin_content:req_body
+          argv in
+        (match status with
+         | Unix.WEXITED 0 ->
+             if String.length raw < 100 then
+               (* ElevenLabs returns JSON error bodies which are short *)
+               (try
+                 let err_json = Yojson.Safe.from_string raw in
+                 let detail = err_json |> member "detail" |> member "message"
+                   |> to_string_option |> Option.value ~default:raw in
+                 Error (`Internal_server_error,
+                   Printf.sprintf "ElevenLabs error: %s" detail)
+               with _ -> Ok raw)
+             else
+               Ok raw
+         | Unix.WEXITED 28 ->
+             Error (`Internal_server_error, "ElevenLabs request timed out")
+         | Unix.WEXITED code ->
+             Error (`Internal_server_error,
+               Printf.sprintf "curl exit %d calling ElevenLabs" code)
+         | _ ->
+             Error (`Internal_server_error, "ElevenLabs request failed"))
+  with
+  | Yojson.Json_error e ->
+      Error (`Bad_request, Printf.sprintf "invalid json: %s" e)
+  | exn ->
+      Error (`Internal_server_error,
+        Printf.sprintf "TTS proxy error: %s" (Printexc.to_string exn))
 
 let agent_from_request request =
   match Httpun.Headers.get request.Httpun.Request.headers "x-masc-agent" with
@@ -4934,6 +5012,22 @@ let make_routes ~port ~host =
                respond_json_with_cors ~status:`Internal_server_error request reqd
                  (Yojson.Safe.to_string (trpg_error_json msg)))
        ) request reqd)
+  |> Http.Router.post "/api/v1/trpg/tts" (fun request reqd ->
+       Http.Request.read_body_async reqd (fun body_str ->
+         match trpg_tts_proxy ~body_str with
+         | Ok audio_bytes ->
+             let origin = get_origin request in
+             Http.Response.bytes ~content_type:"audio/mpeg"
+               ~headers:(cors_headers origin) audio_bytes reqd
+         | Error (`Bad_request, msg) ->
+             respond_json_with_cors ~status:`Bad_request request reqd
+               (Yojson.Safe.to_string (trpg_error_json msg))
+         | Error (`Internal_server_error, msg) ->
+             respond_json_with_cors ~status:`Internal_server_error request reqd
+               (Yojson.Safe.to_string (trpg_error_json msg))
+         | Error (_, msg) ->
+             respond_json_with_cors ~status:`Internal_server_error request reqd
+               (Yojson.Safe.to_string (trpg_error_json msg))))
   |> Http.Router.post "/api/v1/broadcast" (fun request reqd ->
        (* POST /api/v1/broadcast - HTTP API for external tools like autocov *)
        with_read_auth (fun state _req reqd ->
@@ -5980,6 +6074,25 @@ let run_server ~sw ~env ~port ~base_path =
                   (Yojson.Safe.to_string (trpg_error_json msg))
                   ~status:`Bad_request ~extra_headers:cors
             | Error (`Internal_server_error, msg) ->
+                h2_respond_json h2_reqd
+                  (Yojson.Safe.to_string (trpg_error_json msg))
+                  ~status:`Internal_server_error ~extra_headers:cors)
+
+      | `POST, "/api/v1/trpg/tts" ->
+          h2_read_body h2_reqd (fun body_str ->
+            match trpg_tts_proxy ~body_str with
+            | Ok audio_bytes ->
+                h2_respond_bytes ~content_type:"audio/mpeg"
+                  ~extra_headers:cors h2_reqd audio_bytes
+            | Error (`Bad_request, msg) ->
+                h2_respond_json h2_reqd
+                  (Yojson.Safe.to_string (trpg_error_json msg))
+                  ~status:`Bad_request ~extra_headers:cors
+            | Error (`Internal_server_error, msg) ->
+                h2_respond_json h2_reqd
+                  (Yojson.Safe.to_string (trpg_error_json msg))
+                  ~status:`Internal_server_error ~extra_headers:cors
+            | Error (_, msg) ->
                 h2_respond_json h2_reqd
                   (Yojson.Safe.to_string (trpg_error_json msg))
                   ~status:`Internal_server_error ~extra_headers:cors)


### PR DESCRIPTION
## Summary
- TRPG 대시보드에서 ElevenLabs TTS를 사용하기 위한 프록시 엔드포인트 추가
- `POST /api/v1/trpg/tts` 라우트가 ElevenLabs API로 요청을 프록시하고 `audio/mpeg` 바이너리 반환
- WASM viewer의 DM voice 모듈(`dm_voice.rs`)이 "ElevenLabs Proxy" 프리셋으로 작동 가능

## Changes
- `bin/main_eio.ml`: `trpg_tts_proxy` 헬퍼 함수 + HTTP/1.1 Router route + H2 match case (113 lines)
- `Process_eio.run_argv_with_stdin_and_status`로 curl subprocess 사용 (기존 패턴)
- CORS 헤더 적용 (POST 응답 + OPTIONS preflight)

## 환경변수
- `ELEVENLABS_API_KEY` 필수 (없으면 500 반환)

## Test plan
- [x] 로컬 빌드 성공 (`dune build`)
- [x] 로컬 HTTP 테스트: 200 OK, audio/mpeg 바이너리 반환 (24KB)
- [x] CORS preflight 204 확인 (Origin: localhost:5173)
- [x] Cloudflare 터널 경유 테스트 (`masc.crying.pictures`) 200 OK
- [ ] TRPG 대시보드에서 ElevenLabs 음성 재생 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)