### PR TITLE
fix(trpg): use phase as status fallback to unblock DM voice playback

### DIFF
--- a/viewer/src/game/http.rs
+++ b/viewer/src/game/http.rs
@@ -644,8 +644,8 @@ fn parse_masc_state_response(root: &Value) -> GameStateResponse {
                 .get("status")
                 .or_else(|| root.get("status"))
                 .and_then(Value::as_str)
-                .unwrap_or("idle")
-                .to_string(),
+                .map(str::to_string)
+                .unwrap_or_else(|| phase.clone()),
             turn,
             phase,
             current_scenario: state


### PR DESCRIPTION
## Summary

- TRPG DM 음성(ElevenLabs/Browser TTS)이 재생되지 않던 버그 수정
- `parse_masc_state_response()`에서 API 응답에 `status` 필드가 없을 때 `"idle"`로 fallback → `Lobby` 상태 → 음성 차단
- fallback을 이미 추출된 `phase` 값(예: `"round"`, `"dm_narration"`)으로 변경 → `Running` 상태로 정상 매핑 → 음성 재생 허용

## Root Cause

```
API response에 status 필드 부재 →
unwrap_or("idle") →
from_status("idle") → Lobby →
accepts_player_input() = false →
is_room_running() = false →
should_play_dm_voice() = false →
음성 재생 불가
```

## Fix

```rust
// Before: defaults to "idle" → Lobby → voice blocked
.unwrap_or("idle")
.to_string(),

// After: falls back to phase (e.g. "round") → Running → voice allowed
.map(str::to_string)
.unwrap_or_else(|| phase.clone()),
```

## Test plan

- [x] `cargo check` — passed
- [x] `cargo test` — 114 passed, 0 failed
- [ ] Browser E2E: TRPG 세션에서 DM narration 발생 시 ElevenLabs 음성 재생 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)