### PR TITLE
fix: tighten TRPG auto-round timeout defaults and single-flight retry pacing

### DIFF
--- a/viewer/index.html
+++ b/viewer/index.html
@@ -442,7 +442,7 @@
                     </details>
                     <input type="hidden" id="round-run-dm" value="" />
                     <input type="hidden" id="round-run-phase" value="" />
-                    <input type="hidden" id="round-run-timeout" value="" />
+                    <input type="hidden" id="round-run-timeout" value="5" />
                     <input type="hidden" id="round-run-lang" value="" />
                     <input type="hidden" id="round-run-players" value="" />
                     <details id="dm-voice-config" class="dm-voice-config">

--- a/viewer/src/dom/turn_controls.rs
+++ b/viewer/src/dom/turn_controls.rs
@@ -1315,7 +1315,7 @@ fn bind_recovery_action_buttons() {
                 let current = read_dom_input(&doc, "round-run-timeout")
                     .and_then(|raw| raw.parse::<f64>().ok())
                     .filter(|value| *value > 0.0)
-                    .unwrap_or(30.0);
+                    .unwrap_or(5.0);
                 let next = (current + 30.0).min(600.0);
                 if let Some(input) = doc
                     .get_element_by_id("round-run-timeout")
@@ -1612,7 +1612,7 @@ fn read_round_run_plan(doc: &web_sys::Document) -> Result<RoundRunPlan, String> 
     let timeout_sec = read_dom_input(doc, "round-run-timeout")
         .and_then(|raw| raw.parse::<f64>().ok())
         .filter(|value| *value > 0.0)
-        .unwrap_or(30.0);
+        .unwrap_or(5.0);
 
     let player_pairs_raw = read_dom_text_value(doc, "round-run-players").unwrap_or_default();
     let mut player_keepers = parse_player_keeper_pairs(&player_pairs_raw);

--- a/viewer/src/game/round_runner.rs
+++ b/viewer/src/game/round_runner.rs
@@ -95,7 +95,7 @@ const STALL_RETRY_MAX_DELAY_MS: i32 = 12000;
 
 /// Retry delay for transient round-run conflicts (ms).
 #[cfg(target_arch = "wasm32")]
-const TRANSIENT_CONFLICT_RETRY_DELAY_MS: i32 = 1200;
+const TRANSIENT_CONFLICT_RETRY_DELAY_MS: i32 = 5000;
 
 #[cfg(any(target_arch = "wasm32", test))]
 fn stall_retry_delay_ms(retry_count: u32) -> i32 {
@@ -486,7 +486,7 @@ fn build_round_body(dm_keeper_fallback: &str) -> Result<String, String> {
     let timeout_sec = read_dom_input("round-run-timeout")
         .and_then(|raw| raw.parse::<f64>().ok())
         .filter(|value| *value > 0.0)
-        .unwrap_or(30.0);
+        .unwrap_or(5.0);
     let lang = read_dom_input("round-run-lang").unwrap_or_else(|| "ko".to_string());
 
     // 2) Player keeper mapping from hidden round plan (`actor=keeper,actor=keeper,...`).

--- a/viewer/src/mode/mod.rs
+++ b/viewer/src/mode/mod.rs
@@ -1479,7 +1479,7 @@ pub(super) fn clear_trpg_dom(doc: &web_sys::Document) {
         .get_element_by_id("round-run-timeout")
         .and_then(|el| el.dyn_into::<web_sys::HtmlInputElement>().ok())
     {
-        input.set_value("30");
+        input.set_value("5");
     }
     if let Some(input) = doc
         .get_element_by_id("round-run-lang")
@@ -1613,7 +1613,7 @@ pub(super) fn set_round_run_fields(
         .get_element_by_id("round-run-timeout")
         .and_then(|el| el.dyn_into::<web_sys::HtmlInputElement>().ok())
     {
-        el.set_value("30");
+        el.set_value("5");
     }
     if let Some(el) = doc
         .get_element_by_id("round-run-lang")


### PR DESCRIPTION
## Summary
- reduce default `round-run-timeout` from 30s to 5s across TRPG round-run field initializers
- keep auto round progression responsive when keeper calls stall/time out
- increase transient single-flight conflict retry delay from 1.2s to 5s to reduce 400 spam while one round is in-flight

## Why
- users observed:
  - turns appearing stuck
  - repeated `round run already in progress` errors
  - fallback progression taking too long when keepers are slow/unavailable

## Validation
- `cargo check` in `viewer/`
- manual browser verification on `http://127.0.0.1:8080/?mode=trpg&room=default` with running MCP backend