### PR TITLE
fix(trpg): improve fallback round liveliness and hp dynamics

### DIFF
--- a/lib/tool_trpg.ml
+++ b/lib/tool_trpg.ml
@@ -1341,22 +1341,148 @@ let ensure_round_npc_spawn_event ~base_dir ~room_id ~turn ~state =
     in
     Ok (Some event)
 
-let fallback_player_reply ~state ~actor_id =
-  let skills =
-    match actor_json_of_state state actor_id with
-    | Some actor_json -> (
-        match actor_json |> member "skills" with
-        | `List xs ->
-            xs
-            |> List.filter_map (function
-                 | `String s when String.trim s <> "" -> Some (String.trim s)
-                 | _ -> None)
-        | _ -> [])
-    | None -> []
+let default_placeholder_reply = "상황을 살피며 다음 행동을 준비합니다."
+
+let state_turn state =
+  match state |> member "turn" with
+  | `Int n when n > 0 -> n
+  | _ -> 1
+
+let non_empty_string_list_field json key =
+  match json |> member key with
+  | `List xs ->
+      xs
+      |> List.filter_map (function
+           | `String s when String.trim s <> "" -> Some (String.trim s)
+           | _ -> None)
+  | _ -> []
+
+let pick_deterministic_text ~actor_id ~turn ~salt xs =
+  match xs with
+  | [] -> None
+  | _ ->
+      let hash = Hashtbl.hash (actor_id ^ ":" ^ string_of_int turn ^ ":" ^ salt) in
+      let idx = (if hash < 0 then -hash else hash) mod List.length xs in
+      Some (List.nth xs idx)
+
+let fallback_dm_reply ~state =
+  let turn = state_turn state in
+  let live_npcs =
+    party_fields_of_state state
+    |> List.fold_left
+         (fun acc (_, actor_json) ->
+           if is_actor_alive actor_json && role_from_actor_json actor_json = "npc" then acc + 1
+           else acc)
+         0
   in
-  match skills with
-  | primary :: _ -> Printf.sprintf "%s로 적을 공격해 전선을 밀어붙인다." primary
-  | [] -> "적의 빈틈을 노려 공격한다."
+  if live_npcs > 0 then
+    Printf.sprintf
+      "턴 %d, 전장의 연기가 걷히자 남은 적들이 전열을 다시 정비하며 반격을 준비한다."
+      turn
+  else
+    Printf.sprintf
+      "턴 %d, 전장의 긴장이 다시 고조되고 어둠 속에서 새로운 위협의 기척이 느껴진다."
+      turn
+
+let fallback_player_reply ~state ~actor_id =
+  let turn = state_turn state in
+  let skills, traits =
+    match actor_json_of_state state actor_id with
+    | Some actor_json ->
+        ( non_empty_string_list_field actor_json "skills",
+          non_empty_string_list_field actor_json "traits" )
+    | None -> ([], [])
+  in
+  let trait_hint =
+    pick_deterministic_text ~actor_id ~turn ~salt:"trait" traits
+    |> Option.map (fun trait -> Printf.sprintf " (%s 성향)" trait)
+    |> Option.value ~default:""
+  in
+  match pick_deterministic_text ~actor_id ~turn ~salt:"skill" skills with
+  | Some skill -> (
+      let templates =
+        [
+          (fun skill trait ->
+            Printf.sprintf "%s%s로 적 전열의 약한 지점을 파고들어 공격한다." skill
+              trait);
+          (fun skill trait ->
+            Printf.sprintf "%s%s를 활용해 측면을 압박하며 핵심 목표를 공격한다." skill
+              trait);
+          (fun skill trait ->
+            Printf.sprintf "%s%s로 빈틈을 열고 전선을 밀어붙인다." skill trait);
+        ]
+      in
+      match pick_deterministic_text ~actor_id ~turn ~salt:"skill-template" templates with
+      | Some template -> template skill trait_hint
+      | None -> Printf.sprintf "%s%s로 적을 공격해 전선을 밀어붙인다." skill trait_hint)
+  | None -> (
+      let templates =
+        [
+          (fun trait -> Printf.sprintf "지형을 이용해%s 적의 허점을 노려 공격한다." trait);
+          (fun trait ->
+            Printf.sprintf "호흡을 고르고%s 적의 빈틈을 확인한 뒤 공격한다." trait);
+          (fun trait -> Printf.sprintf "전열을 정비하고%s 확실한 타이밍에 공격한다." trait);
+        ]
+      in
+      match pick_deterministic_text ~actor_id ~turn ~salt:"plain-template" templates with
+      | Some template -> template trait_hint
+      | None -> Printf.sprintf "적의 빈틈을 노려%s 공격한다." trait_hint)
+
+let choose_live_npc_actor_id state =
+  party_fields_of_state state
+  |> List.find_map (fun (actor_id, actor_json) ->
+         if is_actor_alive actor_json && role_from_actor_json actor_json = "npc" then
+           Some actor_id
+         else None)
+
+let append_npc_counterattack_events ~base_dir ~room_id ~phase ~turn ~state =
+  let ( let* ) = Result.bind in
+  match choose_live_npc_actor_id state with
+  | None -> Ok []
+  | Some npc_actor_id -> (
+      match choose_attack_target_id ~state ~actor_id:npc_actor_id with
+      | None -> Ok []
+      | Some target_actor_id ->
+          let damage = deterministic_damage ~turn ~actor_id:npc_actor_id in
+          let attack_payload =
+            `Assoc
+              [
+                ("turn", `Int turn);
+                ("phase", `String phase);
+                ("actor_id", `String npc_actor_id);
+                ("action", `String "잔존한 적이 반격해 전열을 흔든다.");
+                ("target_id", `String target_actor_id);
+                ("skill", `Null);
+                ("damage", `Int damage);
+              ]
+          in
+          let* attack_event =
+            append_event ~base_dir ~room_id
+              ~event_type:Trpg_engine_event.Combat_attack
+              ~actor_id:npc_actor_id ~payload:attack_payload ()
+          in
+          let hp_payload =
+            `Assoc
+              [
+                ("turn", `Int turn);
+                ("phase", `String phase);
+                ("actor_id", `String target_actor_id);
+                ("delta", `Int (-damage));
+                ("source_actor_id", `String npc_actor_id);
+                ("reason", `String "combat.attack");
+              ]
+          in
+          let* hp_event =
+            append_event ~base_dir ~room_id
+              ~event_type:Trpg_engine_event.Hp_changed
+              ~actor_id:target_actor_id ~payload:hp_payload ()
+          in
+          Ok [ attack_event; hp_event ])
+
+let is_placeholder_reply (raw : string) : bool =
+  let normalized = String.lowercase_ascii (String.trim raw) in
+  normalized = String.lowercase_ascii default_placeholder_reply
+  || normalized = "assess the situation and prepare the next move."
 
 let truncate_before_marker s marker =
   match find_substring s marker with
@@ -1489,7 +1615,7 @@ let fallback_reply_from_keeper_json keeper_json =
   | _ -> None
 
 let parse_keeper_reply keeper_json =
-  let default_fallback_reply = "상황을 살피며 다음 행동을 준비합니다." in
+  let default_fallback_reply = default_placeholder_reply in
   let raw_reply =
     let first_string_field keys =
       keys
@@ -3530,8 +3656,7 @@ let handle_round_run ctx args : result =
             let fallback_reply =
               match role with
               | `Player -> fallback_player_reply ~state:state_json ~actor_id
-              | `Dm ->
-                  "전장의 긴장이 높아지고 어둠 속에서 새로운 위협이 모습을 드러낸다."
+              | `Dm -> fallback_dm_reply ~state:state_json
             in
             let* spawn_event_opt =
               match role with
@@ -3564,6 +3689,14 @@ let handle_round_run ctx args : result =
                     ~state:state_json
             in
             appended_events := !appended_events @ combat_events;
+            let* pressure_events =
+              match role with
+              | `Dm ->
+                  append_npc_counterattack_events ~base_dir ~room_id ~phase
+                    ~turn:turn_before ~state:state_json
+              | `Player -> Ok []
+            in
+            appended_events := !appended_events @ pressure_events;
             statuses :=
               `Assoc
                 [
@@ -3677,6 +3810,13 @@ let handle_round_run ctx args : result =
                 apply_local_fallback ~stage:"parse_reply_fallback"
                   ~reason:parse_error
             | Ok reply ->
+                let reply =
+                  if is_placeholder_reply reply then
+                    match role with
+                    | `Player -> fallback_player_reply ~state:state_json ~actor_id
+                    | `Dm -> fallback_dm_reply ~state:state_json
+                  else reply
+                in
                 let* reply_event =
                   append_keeper_reply_event
                     ~base_dir

--- a/lib/tool_trpg.ml
+++ b/lib/tool_trpg.ml
@@ -1203,24 +1203,44 @@ let choose_attack_target_id ~state ~actor_id =
     | Some actor_json -> role_from_actor_json actor_json
     | None -> "player"
   in
+  let turn =
+    match state |> member "turn" with
+    | `Int n when n > 0 -> n
+    | _ -> 1
+  in
   let live_actors =
     party_fields_of_state state
     |> List.filter (fun (aid, actor_json) ->
            aid <> actor_id && is_actor_alive actor_json)
   in
-  let pick pred =
-    live_actors
-    |> List.find_opt (fun (_, actor_json) -> pred (role_from_actor_json actor_json))
-    |> Option.map fst
+  let choose_from_candidates salt candidates =
+    match candidates with
+    | [] -> None
+    | _ ->
+        let len = List.length candidates in
+        let seed = Hashtbl.hash (actor_id ^ ":" ^ salt) in
+        let offset = (if seed < 0 then -seed else seed) mod len in
+        let idx = ((turn - 1) + offset) mod len in
+        Some (fst (List.nth candidates idx))
+  in
+  let pick pred salt =
+    let candidates =
+      live_actors
+      |> List.filter (fun (_, actor_json) -> pred (role_from_actor_json actor_json))
+    in
+    choose_from_candidates salt candidates
   in
   if attacker_role = "npc" then
-    match pick (fun role -> role <> "npc" && role <> "dm") with
+    match pick (fun role -> role <> "npc" && role <> "dm") "npc-primary" with
     | Some actor -> Some actor
-    | None -> (match pick (fun role -> role <> "npc") with Some actor -> Some actor | None -> None)
+    | None -> (
+        match pick (fun role -> role <> "npc") "npc-fallback" with
+        | Some actor -> Some actor
+        | None -> choose_from_candidates "npc-any" live_actors)
   else
-    match pick (fun role -> role = "npc") with
+    match pick (fun role -> role = "npc") "player-primary" with
     | Some actor -> Some actor
-    | None -> (match live_actors with (aid, _) :: _ -> Some aid | [] -> None)
+    | None -> choose_from_candidates "player-any" live_actors
 
 let deterministic_damage ~turn ~actor_id =
   let hash = Hashtbl.hash (actor_id ^ ":" ^ string_of_int turn) in
@@ -3669,6 +3689,17 @@ let handle_round_run ctx args : result =
             | Some spawn_event ->
                 appended_events := !appended_events @ [ spawn_event ]
             | None -> ());
+            let state_for_pressure =
+              match role with
+              | `Player -> state_json
+              | `Dm -> (
+                  match spawn_event_opt with
+                  | Some _ -> (
+                      match derive_state ~base_dir ~room_id ~rule_module with
+                      | Ok derived_after_spawn -> state_of_derived derived_after_spawn
+                      | Error _ -> state_json )
+                  | None -> state_json )
+            in
             let* reply_event =
               append_keeper_reply_event ~base_dir ~room_id ~phase ~turn:turn_before
                 ~role ~actor_id ~keeper_name ~reply:fallback_reply
@@ -3693,7 +3724,7 @@ let handle_round_run ctx args : result =
               match role with
               | `Dm ->
                   append_npc_counterattack_events ~base_dir ~room_id ~phase
-                    ~turn:turn_before ~state:state_json
+                    ~turn:turn_before ~state:state_for_pressure
               | `Player -> Ok []
             in
             appended_events := !appended_events @ pressure_events;

--- a/scripts/harness/workload/trpg_longplay_liveliness.sh
+++ b/scripts/harness/workload/trpg_longplay_liveliness.sh
@@ -1,0 +1,347 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+MCP_URL="${MCP_URL:-http://127.0.0.1:8935/mcp}"
+SESSION_ID="${SESSION_ID:-longplay-grimland-$(date +%s)}"
+ROOM_ID="${ROOM_ID:-}"
+ROUNDS="${ROUNDS:-20}"
+WORLD_PRESET_ID="${WORLD_PRESET_ID:-}"
+DM_PRESET_ID="${DM_PRESET_ID:-}"
+PARTY_SIZE="${PARTY_SIZE:-4}"
+POOL_SIZE="${POOL_SIZE:-6}"
+KEEPER_TAG="${KEEPER_TAG:-longplay-$(date +%s)}"
+DM_KEEPER="${DM_KEEPER:-dm-$KEEPER_TAG}"
+ROUND_TIMEOUT_SEC="${ROUND_TIMEOUT_SEC:-18}"
+ROUND_HTTP_TIMEOUT_SEC="${ROUND_HTTP_TIMEOUT_SEC:-$((ROUND_TIMEOUT_SEC + 180))}"
+KEEPER_MODELS="${KEEPER_MODELS:-}"
+LOCAL_FALLBACK="${LOCAL_FALLBACK:-false}"
+STRICT_ADVANCE="${STRICT_ADVANCE:-true}"
+ENFORCE_DISTRIBUTION="${ENFORCE_DISTRIBUTION:-false}"
+MIN_UNIQUE_DAMAGED_PLAYERS="${MIN_UNIQUE_DAMAGED_PLAYERS:-2}"
+REPORT_PATH="${REPORT_PATH:-}"
+
+PLAYER_KEEPER_NAMES=""
+CLAIMED_ACTORS=""
+
+CURL_TIMEOUT_SEC="${CURL_TIMEOUT_SEC:-120}"
+CURL_RETRY_COUNT="${CURL_RETRY_COUNT:-12}"
+CURL_RETRY_DELAY_SEC="${CURL_RETRY_DELAY_SEC:-1}"
+
+normalize_bool() {
+  local raw="${1:-false}"
+  local lower
+  lower="$(printf "%s" "$raw" | tr '[:upper:]' '[:lower:]')"
+  case "$lower" in
+    1|true|yes|y|on) printf "true" ;;
+    *) printf "false" ;;
+  esac
+}
+
+cleanup_keepers() {
+  if [ -n "${room_id:-}" ] && [ -n "${CLAIMED_ACTORS:-}" ]; then
+    while IFS='|' read -r actor_id keeper_name; do
+      [ -z "$actor_id" ] && continue
+      [ -z "$keeper_name" ] && continue
+      call_tool 4801 "trpg.actor.release" "$(jq -cn --arg room "$room_id" --arg actor "$actor_id" --arg keeper "$keeper_name" '{room_id:$room,actor_id:$actor,keeper_name:$keeper}')" >/dev/null 2>&1 || true
+    done <<< "$CLAIMED_ACTORS"
+  fi
+  if [ -n "${DM_KEEPER:-}" ]; then
+    call_tool 4802 "masc_keeper_down" "$(jq -cn --arg name "$DM_KEEPER" '{name:$name,remove_meta:true,remove_session:true}')" >/dev/null 2>&1 || true
+  fi
+  if [ -n "${PLAYER_KEEPER_NAMES:-}" ]; then
+    while IFS= read -r keeper_name; do
+      [ -z "$keeper_name" ] && continue
+      call_tool 4803 "masc_keeper_down" "$(jq -cn --arg name "$keeper_name" '{name:$name,remove_meta:true,remove_session:true}')" >/dev/null 2>&1 || true
+    done <<< "$PLAYER_KEEPER_NAMES"
+  fi
+}
+trap cleanup_keepers EXIT
+
+call_tool() {
+  local id="$1"
+  local name="$2"
+  local args_json="$3"
+  local timeout_sec="${4:-$CURL_TIMEOUT_SEC}"
+  local retry_count="${5:-$CURL_RETRY_COUNT}"
+  local raw=""
+  local sse_data
+  local attempt=1
+  while [ "$attempt" -le "$retry_count" ]; do
+    if raw="$(curl -sS -m "$timeout_sec" -X POST "$MCP_URL" \
+      -H 'Content-Type: application/json' \
+      -H 'Accept: application/json, text/event-stream' \
+      -d "{\"jsonrpc\":\"2.0\",\"id\":$id,\"method\":\"tools/call\",\"params\":{\"name\":\"$name\",\"arguments\":$args_json}}")"; then
+      break
+    fi
+    if [ "$attempt" -lt "$retry_count" ]; then
+      sleep "$CURL_RETRY_DELAY_SEC"
+    fi
+    attempt=$((attempt + 1))
+  done
+  if [ -z "$raw" ]; then
+    printf '{"error":{"message":"curl failed after retries: tool=%s timeout_sec=%s retries=%s"}}' "$name" "$timeout_sec" "$retry_count"
+    return 0
+  fi
+  sse_data="$(printf "%s" "$raw" | sed -n 's/^data: //p' | tail -n1)"
+  if [ -n "$sse_data" ]; then
+    printf "%s" "$sse_data"
+  else
+    printf "%s" "$raw"
+  fi
+}
+
+tool_error_message() {
+  local raw="$1"
+  printf "%s" "$raw" | jq -r '
+    if .error?.message then .error.message
+    elif (.result?.isError // false) == true then
+      ([.result.content[]? | select(.type == "text") | .text] | join(" "))
+    else
+      empty
+    end
+  ' 2>/dev/null | awk 'NF { print; exit }'
+}
+
+call_tool_checked() {
+  local id="$1"
+  local name="$2"
+  local args_json="$3"
+  local timeout_sec="${4:-$CURL_TIMEOUT_SEC}"
+  local retry_count="${5:-$CURL_RETRY_COUNT}"
+  local raw
+  local err
+  raw="$(call_tool "$id" "$name" "$args_json" "$timeout_sec" "$retry_count")"
+  if [ -z "$(printf "%s" "$raw" | tr -d '[:space:]')" ]; then
+    echo "FAIL: $name: empty response from MCP" >&2
+    exit 1
+  fi
+  err="$(tool_error_message "$raw")"
+  if [ -n "$err" ]; then
+    echo "FAIL: $name: $err" >&2
+    printf "%s\n" "$raw" >&2
+    exit 1
+  fi
+  printf "%s" "$raw"
+}
+
+payload() {
+  jq -c '
+    if .result? then
+      if .result.structuredContent?.payload? then .result.structuredContent.payload
+      elif .result.payload? then .result.payload
+      elif (.result.content | type) == "array" then
+        ((.result.content[]? | select(.type == "text") | .text) // "{}" | (try fromjson catch {}))
+        | if .payload? then .payload else . end
+      else {}
+      end
+    elif .payload? then .payload
+    else .
+    end
+  '
+}
+
+build_models_json() {
+  jq -cn --arg csv "$KEEPER_MODELS" '
+    $csv
+    | split(",")
+    | map(gsub("^\\s+|\\s+$";""))
+    | map(select(length > 0))
+  '
+}
+
+count_unique_lines() {
+  local raw="$1"
+  printf "%s\n" "$raw" | awk 'NF' | sort -u | wc -l | tr -d ' '
+}
+
+LOCAL_FALLBACK_BOOL="$(normalize_bool "$LOCAL_FALLBACK")"
+STRICT_ADVANCE_BOOL="$(normalize_bool "$STRICT_ADVANCE")"
+ENFORCE_DISTRIBUTION_BOOL="$(normalize_bool "$ENFORCE_DISTRIBUTION")"
+KEEPER_MODELS_JSON="$(build_models_json)"
+
+if [ "$(printf "%s" "$KEEPER_MODELS_JSON" | jq 'length')" -eq 0 ]; then
+  echo "FAIL: KEEPER_MODELS is required (예: KEEPER_MODELS='gemini:gemini-2.5-flash')" >&2
+  exit 1
+fi
+if [ "$POOL_SIZE" -lt "$PARTY_SIZE" ]; then
+  POOL_SIZE="$PARTY_SIZE"
+fi
+if [ "$ROUNDS" -lt 1 ]; then
+  echo "FAIL: ROUNDS must be >= 1" >&2
+  exit 1
+fi
+
+echo "[longplay] trpg.pool.generate"
+args_pool="$(jq -cn --arg sid "$SESSION_ID" --arg world "$WORLD_PRESET_ID" --arg dm "$DM_PRESET_ID" --argjson pool_size "$POOL_SIZE" --argjson party_size "$PARTY_SIZE" '
+  {session_id:$sid,pool_size:$pool_size,party_size:$party_size}
+  | if $world == "" then . else . + {world_preset_id:$world} end
+  | if $dm == "" then . else . + {dm_preset_id:$dm} end
+')"
+r_pool="$(call_tool_checked 4101 "trpg.pool.generate" "$args_pool")"
+pool="$(printf "%s" "$r_pool" | payload | jq -c '.pool')"
+suggested="$(printf "%s" "$r_pool" | payload | jq -c '.suggested_party_ids')"
+
+echo "[longplay] trpg.party.select"
+args_party="$(jq -cn --arg sid "$SESSION_ID" --argjson pool "$pool" --argjson ids "$suggested" '{session_id:$sid,pool:$pool,selected_player_ids:$ids}')"
+r_party="$(call_tool_checked 4102 "trpg.party.select" "$args_party")"
+party="$(printf "%s" "$r_party" | payload | jq -c '.party')"
+
+echo "[longplay] trpg.session.start"
+args_start="$(jq -cn --arg sid "$SESSION_ID" --arg room "$ROOM_ID" --arg world "$WORLD_PRESET_ID" --arg dm "$DM_PRESET_ID" --argjson party "$party" '
+  if $room == "" then
+    {session_id:$sid,party:$party,phase:"briefing"}
+  else
+    {session_id:$sid,room_id:$room,party:$party,phase:"briefing",force:true}
+  end
+  | if $world == "" then . else . + {world_preset_id:$world} end
+  | if $dm == "" then . else . + {dm_preset_id:$dm} end
+  | . + {dm_keeper:$ENV.DM_KEEPER}
+')"
+r_start="$(call_tool_checked 4103 "trpg.session.start" "$args_start")"
+room_id="$(printf "%s" "$r_start" | payload | jq -r '.room_id')"
+world_used="$(printf "%s" "$r_start" | payload | jq -r '.world_preset.id // .world_preset.preset_id // "-"')"
+dm_used="$(printf "%s" "$r_start" | payload | jq -r '.dm_preset.id // .dm_preset.preset_id // "-"')"
+player_keepers="$(printf "%s" "$party" | jq -c --arg tag "$KEEPER_TAG" '
+  reduce .[] as $row ({}; . + {($row.actor_id): ("pk-" + $tag + "-" + $row.actor_id)})
+')"
+PLAYER_KEEPER_NAMES="$(printf "%s" "$player_keepers" | jq -r '.[]' | awk 'NF')"
+
+echo "[longplay] keeper up/claim"
+call_tool_checked 4200 "masc_keeper_up" "$(jq -cn --arg name "$DM_KEEPER" --arg room "$room_id" --argjson models "$KEEPER_MODELS_JSON" '{name:$name,goal:("TRPG room " + $room + " DM keeper"),instructions:"모든 응답은 한국어로 작성하세요.",models:$models,proactive_enabled:false,presence_keepalive:true}')" >/dev/null
+while IFS='|' read -r actor_id keeper_name; do
+  [ -z "$actor_id" ] && continue
+  [ -z "$keeper_name" ] && continue
+  call_tool_checked 4201 "masc_keeper_up" "$(jq -cn --arg name "$keeper_name" --arg room "$room_id" --arg actor "$actor_id" --argjson models "$KEEPER_MODELS_JSON" '{name:$name,goal:("TRPG room " + $room + "에서 " + $actor + " actor를 플레이하세요."),instructions:"모든 응답은 한국어로 작성하세요.",models:$models,proactive_enabled:false,presence_keepalive:true}')" >/dev/null
+  call_tool_checked 4202 "trpg.actor.claim" "$(jq -cn --arg room "$room_id" --arg actor "$actor_id" --arg keeper "$keeper_name" '{room_id:$room,actor_id:$actor,keeper_name:$keeper}')" >/dev/null
+  CLAIMED_ACTORS="${CLAIMED_ACTORS}${CLAIMED_ACTORS:+$'\n'}${actor_id}|${keeper_name}"
+done < <(printf "%s" "$player_keepers" | jq -r 'to_entries[] | "\(.key)|\(.value)"')
+
+echo "[longplay] room_id=$room_id world=$world_used dm_preset=$dm_used rounds=$ROUNDS local_fallback=$LOCAL_FALLBACK_BOOL"
+
+round_failures=0
+timeout_total=0
+unavailable_total=0
+placeholder_total=0
+all_damaged_players=""
+all_targets=""
+all_player_replies=""
+
+i=1
+while [ "$i" -le "$ROUNDS" ]; do
+  args_round="$(jq -cn --arg room "$room_id" --arg dm "$DM_KEEPER" --argjson players "$player_keepers" --argjson timeout "$ROUND_TIMEOUT_SEC" --argjson local_fallback "$LOCAL_FALLBACK_BOOL" '
+    {
+      room_id:$room,
+      dm_keeper:$dm,
+      player_keepers:$players,
+      phase:"round",
+      timeout_sec:$timeout,
+      require_claim:true,
+      local_fallback:$local_fallback
+    }
+  ')"
+  r_round="$(call_tool_checked $((4300 + i)) "trpg.round.run" "$args_round" "$ROUND_HTTP_TIMEOUT_SEC" "1")"
+  p_round="$(printf "%s" "$r_round" | payload)"
+
+  turn_before="$(printf "%s" "$p_round" | jq -r '.turn_before // 0')"
+  turn_after="$(printf "%s" "$p_round" | jq -r '.turn_after // 0')"
+  advanced="$(printf "%s" "$p_round" | jq -r '.summary.advanced // empty')"
+  if [ -z "$advanced" ]; then
+    if [ "$turn_after" -gt "$turn_before" ]; then
+      advanced="true"
+    else
+      advanced="false"
+    fi
+  fi
+  if [ "$advanced" != "true" ]; then
+    round_failures=$((round_failures + 1))
+  fi
+
+  timeouts="$(printf "%s" "$p_round" | jq -r '.summary.timeouts // 0')"
+  unavailable="$(printf "%s" "$p_round" | jq -r '.summary.unavailable // 0')"
+  timeout_total=$((timeout_total + timeouts))
+  unavailable_total=$((unavailable_total + unavailable))
+
+  placeholder_round="$(printf "%s" "$p_round" | jq -r '[.statuses[]? | select((.reply // "") | contains("상황을 살피며 다음 행동을 준비합니다"))] | length')"
+  placeholder_total=$((placeholder_total + placeholder_round))
+
+  damaged_round="$(printf "%s" "$p_round" | jq -r '.state.party | to_entries[] | select(.value.role != "npc" and ((.value.hp // 0) < (.value.max_hp // 0))) | .key')"
+  targets_round="$(printf "%s" "$p_round" | jq -r '.events[]? | select(.type=="combat.attack") | (.payload.target_id // .target_id // empty)')"
+  player_replies_round="$(printf "%s" "$p_round" | jq -r '.statuses[]? | select(.role=="player") | .reply // empty')"
+
+  [ -n "$damaged_round" ] && all_damaged_players="${all_damaged_players}${all_damaged_players:+$'\n'}${damaged_round}"
+  [ -n "$targets_round" ] && all_targets="${all_targets}${all_targets:+$'\n'}${targets_round}"
+  [ -n "$player_replies_round" ] && all_player_replies="${all_player_replies}${all_player_replies:+$'\n'}${player_replies_round}"
+
+  damaged_now="$(printf "%s\n" "$damaged_round" | awk 'NF' | wc -l | tr -d ' ')"
+  echo "[round $i] turn ${turn_before}->${turn_after} advanced=$advanced timeouts=$timeouts unavailable=$unavailable damaged_players_now=$damaged_now placeholder=$placeholder_round"
+
+  i=$((i + 1))
+done
+
+advanced_rounds=$((ROUNDS - round_failures))
+advanced_ratio="$(awk "BEGIN{if ($ROUNDS == 0) {printf \"0.000\"} else {printf \"%.3f\", $advanced_rounds / $ROUNDS}}")"
+
+unique_damaged_count="$(count_unique_lines "$all_damaged_players")"
+unique_target_count="$(count_unique_lines "$all_targets")"
+unique_reply_count="$(count_unique_lines "$all_player_replies")"
+
+summary_json="$(
+  jq -cn \
+    --arg room_id "$room_id" \
+    --arg session_id "$SESSION_ID" \
+    --arg world_preset "$world_used" \
+    --arg dm_preset "$dm_used" \
+    --arg dm_keeper "$DM_KEEPER" \
+    --argjson rounds "$ROUNDS" \
+    --argjson advanced_rounds "$advanced_rounds" \
+    --argjson failed_rounds "$round_failures" \
+    --arg advanced_ratio "$advanced_ratio" \
+    --argjson timeout_total "$timeout_total" \
+    --argjson unavailable_total "$unavailable_total" \
+    --argjson placeholder_total "$placeholder_total" \
+    --argjson unique_damaged_players "$unique_damaged_count" \
+    --argjson unique_targets "$unique_target_count" \
+    --argjson unique_player_replies "$unique_reply_count" \
+    --arg local_fallback "$LOCAL_FALLBACK_BOOL" \
+    '{
+      room_id:$room_id,
+      session_id:$session_id,
+      world_preset:$world_preset,
+      dm_preset:$dm_preset,
+      dm_keeper:$dm_keeper,
+      rounds:$rounds,
+      advanced_rounds:$advanced_rounds,
+      failed_rounds:$failed_rounds,
+      advanced_ratio:$advanced_ratio,
+      timeout_total:$timeout_total,
+      unavailable_total:$unavailable_total,
+      placeholder_total:$placeholder_total,
+      unique_damaged_players:$unique_damaged_players,
+      unique_targets:$unique_targets,
+      unique_player_replies:$unique_player_replies,
+      local_fallback:$local_fallback
+    }'
+)"
+
+echo "[longplay-summary] $summary_json"
+
+if [ -n "$REPORT_PATH" ]; then
+  printf "%s\n" "$summary_json" > "$REPORT_PATH"
+  echo "[longplay] wrote report: $REPORT_PATH"
+fi
+
+exit_code=0
+if [ "$STRICT_ADVANCE_BOOL" = "true" ] && [ "$round_failures" -gt 0 ]; then
+  echo "FAIL: strict advance enabled but failed_rounds=$round_failures" >&2
+  exit_code=1
+fi
+if [ "$ENFORCE_DISTRIBUTION_BOOL" = "true" ] && [ "$unique_damaged_count" -lt "$MIN_UNIQUE_DAMAGED_PLAYERS" ]; then
+  echo "FAIL: distribution gate not met (unique_damaged_players=$unique_damaged_count < min=$MIN_UNIQUE_DAMAGED_PLAYERS)" >&2
+  exit_code=1
+fi
+
+if [ "$exit_code" -eq 0 ]; then
+  echo "PASS: trpg longplay liveliness workload"
+fi
+
+exit "$exit_code"

--- a/scripts/run_trpg_longplay_liveliness.sh
+++ b/scripts/run_trpg_longplay_liveliness.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+exec "$SCRIPT_DIR/harness/workload/trpg_longplay_liveliness.sh" "$@"

--- a/test/test_tool_trpg_coverage.ml
+++ b/test/test_tool_trpg_coverage.ml
@@ -525,6 +525,107 @@ let test_round_run_local_fallback_progresses_round () =
     (List.mem "turn.started" event_types);
   cleanup_dir base_dir
 
+let test_round_run_local_fallback_distributes_team_pressure () =
+  let base_dir = make_temp_dir () in
+  let config = Room.default_config base_dir in
+  let _ = Room.init config ~agent_name:(Some "tester") in
+  bootstrap_room_with_actors ~base_dir
+    ~room_id:"room-round-local-fallback-team"
+    ~actor_ids:["p1"; "p2"; "p3"; "p4"];
+  let keeper_call ~name:_ ~message:_ ~timeout_sec:_ : Tool_trpg.keeper_call_result =
+    `Error "keeper runtime unavailable"
+  in
+  let ctx : Tool_trpg.context =
+    {
+      config;
+      agent_name = "tester";
+      keeper_call = Some keeper_call;
+      keeper_probe = None;
+      dm_voice_emit = None;
+    }
+  in
+  let args =
+    `Assoc
+      [
+        ("room_id", `String "room-round-local-fallback-team");
+        ("dm_keeper", `String "dm-keeper");
+        ( "player_keepers",
+          `Assoc
+            [
+              ("p1", `String "pk-1");
+              ("p2", `String "pk-2");
+              ("p3", `String "pk-3");
+              ("p4", `String "pk-4");
+            ] );
+        ("timeout_sec", `Float 0.2);
+        ("local_fallback", `Bool true);
+      ]
+  in
+  let final_json = ref None in
+  for round_idx = 1 to 4 do
+    let ok, body = dispatch_exn ctx ~name:"masc_trpg_round_run" ~args in
+    Alcotest.(check bool)
+      (Printf.sprintf "round %d executes" round_idx)
+      true ok;
+    let json = parse_json_exn body in
+    final_json := Some json;
+    let turn_before = Yojson.Safe.Util.member "turn_before" json |> Yojson.Safe.Util.to_int in
+    let turn_after = Yojson.Safe.Util.member "turn_after" json |> Yojson.Safe.Util.to_int in
+    Alcotest.(check int)
+      (Printf.sprintf "round %d turn advances" round_idx)
+      (turn_before + 1)
+      turn_after;
+    let has_player_hp_change =
+      json |> Yojson.Safe.Util.member "events" |> Yojson.Safe.Util.to_list
+      |> List.exists (fun event_json ->
+             match
+               ( Yojson.Safe.Util.member "type" event_json,
+                 Yojson.Safe.Util.member "actor_id" event_json )
+             with
+             | `String "hp.changed", `String actor_id ->
+                 String.length actor_id > 0 && actor_id.[0] = 'p'
+             | _ -> false)
+    in
+    Alcotest.(check bool)
+      (Printf.sprintf "round %d emits player hp pressure" round_idx)
+      true has_player_hp_change
+  done;
+  let json =
+    match !final_json with
+    | Some json -> json
+    | None -> failwith "expected final json after fallback loop"
+  in
+  let hp_of actor_id =
+    json |> Yojson.Safe.Util.member "state" |> Yojson.Safe.Util.member "party"
+    |> Yojson.Safe.Util.member actor_id |> Yojson.Safe.Util.member "hp"
+    |> Yojson.Safe.Util.to_int
+  in
+  let damaged_players =
+    [ "p1"; "p2"; "p3"; "p4" ]
+    |> List.filter (fun actor_id -> hp_of actor_id < 10)
+  in
+  Alcotest.(check bool)
+    "team pressure is distributed across multiple players"
+    true
+    (List.length damaged_players >= 2);
+  let dm_fallback_reply =
+    json |> Yojson.Safe.Util.member "statuses" |> Yojson.Safe.Util.to_list
+    |> List.find_map (fun status_json ->
+           match
+             ( Yojson.Safe.Util.member "actor_id" status_json,
+               Yojson.Safe.Util.member "status" status_json,
+               Yojson.Safe.Util.member "reply" status_json )
+           with
+           | `String "dm", `String "fallback", `String reply -> Some reply
+           | _ -> None)
+    |> Option.value ~default:""
+  in
+  Alcotest.(check bool)
+    "dm fallback avoids placeholder text"
+    false
+    (contains_substring dm_fallback_reply "상황을 살피며 다음 행동을 준비합니다");
+  cleanup_dir base_dir
+
 let test_round_run_unavailable_sampling_cap () =
   with_env "MASC_TRPG_KEEPER_UNAVAILABLE_MAX_PER_TURN" "1" (fun () ->
     let base_dir = make_temp_dir () in
@@ -1535,6 +1636,10 @@ let () =
             "local fallback progresses round and emits combat events"
             `Quick
             test_round_run_local_fallback_progresses_round;
+          Alcotest.test_case
+            "local fallback distributes pressure across multi-player team"
+            `Quick
+            test_round_run_local_fallback_distributes_team_pressure;
           Alcotest.test_case
             "samples keeper.unavailable when cap reached"
             `Quick


### PR DESCRIPTION
## Why
Local TRPG play was stalling into repetitive placeholder narration when keeper replies were unavailable or meta-shaped.

## What changed
- Make player fallback replies deterministic but varied using actor skills/traits/turn seed.
- Add DM fallback narration that reflects round pressure (instead of a fixed one-liner).
- Add NPC counterattack events during DM fallback (`combat.attack` + `hp.changed`) so player HP can change even on fallback-only rounds.
- Treat placeholder keeper replies (e.g. `상황을 살피며 다음 행동을 준비합니다.`) as non-playable and replace them with role-specific fallback actions.

## Validation
- `dune build`
- `dune exec ./test/test_tool_trpg_coverage.exe`
- Manual playtest (isolated room): 3 rounds with unavailable keepers + local fallback
  - turn advanced each round
  - fallback replies varied by skill/trait
  - player HP decreased via NPC counterattacks