### PR TITLE
fix(keeper): change remove_meta default to false in keeper_down

### DIFF
--- a/lib/tool_keeper.ml
+++ b/lib/tool_keeper.ml
@@ -344,7 +344,7 @@ Persists context + checkpoints. Auto-handoff is applied when needed.";
         ]);
         ("remove_meta", `Assoc [
           ("type", `String "boolean");
-          ("description", `String "Delete .masc/perpetual-keepers/<name>.json (default: true).");
+          ("description", `String "Delete .masc/perpetual-keepers/<name>.json (default: false). Set true only for permanent removal.");
         ]);
         ("remove_session", `Assoc [
           ("type", `String "boolean");
@@ -8137,7 +8137,7 @@ let handle_keeper_down ctx args : tool_result =
   if not (validate_name name) then
     (false, "❌ invalid keeper name")
   else
-    let remove_meta = get_bool args "remove_meta" true in
+    let remove_meta = get_bool args "remove_meta" false in
     let remove_session = get_bool args "remove_session" false in
     stop_keepalive name;
     match read_meta ctx.config name with


### PR DESCRIPTION
## 요약

`keeper_down` 호출 시 `remove_meta` 기본값이 `true`여서, 키퍼를 중지할 때마다 설정 JSON이 삭제되는 버그 수정.

## 문제

- `keeper_down`의 `remove_meta` 파라미터 기본값이 `true`
- 키퍼 중지 시 `.masc/perpetual-keepers/<name>.json` 설정 파일이 삭제됨
- 재시작 후 키퍼가 목록에서 "사라지는" 현상 발생
- 301개의 orphan metrics 파일이 설정 없이 남아있는 상태 확인

## 변경 내용

- `get_bool args "remove_meta" true` → `get_bool args "remove_meta" false` (기본값 변경)
- 도구 스키마 description 업데이트: 기본값 `false`, 영구 삭제 시에만 `true` 전달

## 테스트

- `dune build` 통과
- `make test` 전체 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)