### PR TITLE
feat(llm): Eio.Semaphore concurrency limiter for keeper LLM calls

### DIFF
--- a/lib/llm_client.ml
+++ b/lib/llm_client.ml
@@ -39,6 +39,24 @@ let ollama_timeout_sec () =
     ~min_v:10
     ~max_v:180
 
+(* ================================================================ *)
+(* Concurrency limiter — throttle simultaneous LLM requests          *)
+(* ================================================================ *)
+
+(** Maximum concurrent cascade/LLM calls.
+    Default 2 matches OLLAMA_MAX_LOADED_MODELS on M3 Max 128GB.
+    Prevents keeper stampede from overloading Ollama VRAM. *)
+let max_concurrent_llm =
+  int_of_env_default "MASC_MAX_CONCURRENT_LLM" ~default:2 ~min_v:1 ~max_v:16
+
+let llm_semaphore = Eio.Semaphore.make max_concurrent_llm
+
+let llm_semaphore_available () = Eio.Semaphore.get_value llm_semaphore
+
+let with_llm_permit f =
+  Eio.Semaphore.acquire llm_semaphore;
+  Fun.protect ~finally:(fun () -> Eio.Semaphore.release llm_semaphore) f
+
 let ollama_should_fallback_to_generate (err : string) : bool =
   contains_ci err "404"
   || contains_ci err "not found"
@@ -685,24 +703,28 @@ let complete ?ollama_timeout_sec (req : completion_request) : (completion_respon
 (* ================================================================ *)
 
 let cascade ?ollama_timeout_sec (requests : completion_request list) : (completion_response, string) result =
-  let rec try_next errors = function
-    | [] ->
-      let all_errors = String.concat "; " (List.rev errors) in
-      Error (sprintf "All models failed: %s" all_errors)
-    | req :: rest ->
-      eprintf "[llm_client] cascade: trying %s (%s)\n%!"
-        req.model.model_id (string_of_provider req.model.provider);
-      match complete ?ollama_timeout_sec req with
-      | Ok resp ->
-        eprintf "[llm_client] cascade: success with %s (%dms)\n%!"
-          resp.model_used resp.latency_ms;
-        Ok resp
-      | Error e ->
-        eprintf "[llm_client] cascade: %s failed: %s\n%!"
-          req.model.model_id e;
-        try_next (e :: errors) rest
-  in
-  try_next [] requests
+  with_llm_permit (fun () ->
+    let avail = Eio.Semaphore.get_value llm_semaphore in
+    eprintf "[llm_client] cascade: acquired permit (%d/%d available)\n%!"
+      avail max_concurrent_llm;
+    let rec try_next errors = function
+      | [] ->
+        let all_errors = String.concat "; " (List.rev errors) in
+        Error (sprintf "All models failed: %s" all_errors)
+      | req :: rest ->
+        eprintf "[llm_client] cascade: trying %s (%s)\n%!"
+          req.model.model_id (string_of_provider req.model.provider);
+        match complete ?ollama_timeout_sec req with
+        | Ok resp ->
+          eprintf "[llm_client] cascade: success with %s (%dms)\n%!"
+            resp.model_used resp.latency_ms;
+          Ok resp
+        | Error e ->
+          eprintf "[llm_client] cascade: %s failed: %s\n%!"
+            req.model.model_id e;
+          try_next (e :: errors) rest
+    in
+    try_next [] requests)
 
 (* ================================================================ *)
 (* Model Spec Parser                                                *)

--- a/lib/llm_client.mli
+++ b/lib/llm_client.mli
@@ -109,6 +109,15 @@ val cascade :
   completion_request list ->
   (completion_response, string) result
 
+(** {1 Concurrency Control} *)
+
+(** Maximum concurrent cascade calls (from MASC_MAX_CONCURRENT_LLM env,
+    default 2). *)
+val max_concurrent_llm : int
+
+(** Number of permits currently available (0 = all slots busy). *)
+val llm_semaphore_available : unit -> int
+
 (** {1 Helpers} *)
 
 (** Built-in model specs for common configurations. *)


### PR DESCRIPTION
## Summary

- Add `Eio.Semaphore`-based concurrency limiter to `Llm_client.cascade`
- Default 2 permits matches `OLLAMA_MAX_LOADED_MODELS` on M3 Max 128GB
- Configurable via `MASC_MAX_CONCURRENT_LLM` env var (range: 1-16)
- Prevents keeper stampede: when 29 keepers fire simultaneously, only 2 cascade calls proceed; the rest suspend (Eio fiber-level, not OS-thread blocking)

## Motivation

With 29 perpetual keepers defined and only 2 Ollama model slots (40GB VRAM budget), simultaneous LLM requests cause VRAM thrashing and Ollama OOM. This adds a counting semaphore gate at the `cascade` entry point — the single chokepoint all keeper LLM calls flow through.

## Changes

| File | Change |
|------|--------|
| `lib/llm_client.ml` | `with_llm_permit` wraps `cascade` body; `Eio.Semaphore.acquire`/`release` via `Fun.protect` |
| `lib/llm_client.mli` | Expose `max_concurrent_llm` and `llm_semaphore_available` for monitoring |

## Design decisions

- **Semaphore at `cascade` level, not `complete`**: A cascade call tries N models in sequence — holding one permit for the entire cascade prevents a model swap from consuming another slot
- **`Fun.protect` for release**: Guarantees semaphore release even if cascade throws
- **`Eio.Semaphore` not `Eio.Mutex`**: Counting semaphore (N permits) vs binary mutex (1 permit) — allows configurable parallelism
- **`complete` not wrapped**: `verifier.ml` calls `complete` directly with LFM2.5-1.2B (1.5GB, always in VRAM) — no contention risk

## Test plan

- [x] `dune build` passes (exit 0)
- [x] `dune test --force` passes (4752 tests)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)