### PR TITLE
fix(trpg): use origin-relative default TTS proxy URL

### DIFF
--- a/viewer/src/dom/dm_voice.rs
+++ b/viewer/src/dom/dm_voice.rs
@@ -72,8 +72,7 @@ const DM_VOICE_RANDOM_PRESET_VALUE: &str = "random_preset";
 #[cfg(target_arch = "wasm32")]
 const DM_VOICE_RANDOM_PRESET_LABEL: &str = "랜덤 (추천 Voice 중 선택)";
 #[cfg(target_arch = "wasm32")]
-const DM_VOICE_DEFAULT_PROXY_URL: &str =
-    "https://elevenlabs-proxy-production-443b.up.railway.app/v1/audio/speech";
+const DM_VOICE_DEFAULT_PROXY_URL: &str = "/api/v1/trpg/tts";
 #[cfg(target_arch = "wasm32")]
 const DM_VOICE_DEFAULT_MODEL: &str = "eleven_multilingual_v2";
 #[cfg(target_arch = "wasm32")]


### PR DESCRIPTION
## Summary

- DM Voice의 default proxy URL을 Railway 외부 URL에서 origin-relative path (`/api/v1/trpg/tts`)로 변경

## Problem

localStorage가 비어있는 상태(첫 방문)에서 `DM_VOICE_DEFAULT_PROXY_URL`이 Railway 외부 URL로 fallback되면서:
1. **CORS 차단** — 브라우저가 cross-origin 요청 차단 (Railway에 CORS 헤더 없음)
2. **잘못된 body format** — URL에 `/v1/audio/speech`가 포함되어 OpenAI format으로 감지됨
3. **Silent fallback** — `speak_with_proxy`의 catch-all이 에러를 삼키고 Browser TTS로 넘어감

## Fix

```rust
// Before
const DM_VOICE_DEFAULT_PROXY_URL: &str =
    "https://elevenlabs-proxy-production-443b.up.railway.app/v1/audio/speech";

// After
const DM_VOICE_DEFAULT_PROXY_URL: &str = "/api/v1/trpg/tts";
```

Origin-relative path가 3가지를 동시에 해결:
- CORS 문제 제거 (same-origin)
- `is_openai_tts_proxy_url()` → false → custom body format 사용
- Trunk `[[proxy]]` 규칙이 MASC 서버로 자동 전달

## Verification

- Playwright E2E: `fetch("/api/v1/trpg/tts")` → HTTP 200, 20KB `audio/mpeg`
- WASM binary에서 Railway URL 제거 확인 (`strings` 검증)
- Server-side endpoint: PR #387 (이미 merged)

## Test plan

- [ ] `trunk serve`로 Viewer 실행 → DM Voice "ElevenLabs Proxy" 선택 → 음성 재생 확인
- [ ] localStorage 비운 상태에서도 정상 재생 확인
- [ ] Railway proxy option은 UI dropdown에서 여전히 선택 가능 (`viewer/index.html` 미변경)

🤖 Generated with [Claude Code](https://claude.com/claude-code)