### PR TITLE
fix: stop infinite TRPG round loop after session restart

### DIFF
--- a/lib/tool_trpg.ml
+++ b/lib/tool_trpg.ml
@@ -997,8 +997,10 @@ let resolve_end_rules_for_room ~base_dir ~(events : Trpg_engine_event.t list) :
     Trpg_preset_store.end_rules =
   match
     events
-    |> List.find_opt (fun (ev : Trpg_engine_event.t) ->
-           ev.event_type = Trpg_engine_event.Room_created)
+    |> List.fold_left
+         (fun acc (ev : Trpg_engine_event.t) ->
+           if ev.event_type = Trpg_engine_event.Room_created then Some ev else acc)
+         None
   with
   | None -> default_end_rules_local
   | Some room_created -> (
@@ -1120,6 +1122,23 @@ let has_event_type (events : Trpg_engine_event.t list) event_type =
   List.exists
     (fun (ev : Trpg_engine_event.t) -> ev.event_type = event_type)
     events
+
+let is_session_marker_event = function
+  | Trpg_engine_event.Room_started
+  | Trpg_engine_event.Session_started
+  | Trpg_engine_event.Room_created ->
+      true
+  | _ -> false
+
+let events_since_last_session_marker (events : Trpg_engine_event.t list) :
+    Trpg_engine_event.t list =
+  let rec collect acc = function
+    | [] -> acc
+    | (ev : Trpg_engine_event.t) :: tl ->
+        let acc' = ev :: acc in
+        if is_session_marker_event ev.event_type then acc' else collect acc' tl
+  in
+  collect [] (List.rev events)
 
 let latest_session_outcome_payload (events : Trpg_engine_event.t list) :
     Yojson.Safe.t option =
@@ -1395,14 +1414,49 @@ let fallback_dm_reply ~state =
            else acc)
          0
   in
-  if live_npcs > 0 then
-    Printf.sprintf
-      "턴 %d, 전장의 연기가 걷히자 남은 적들이 전열을 다시 정비하며 반격을 준비한다."
-      turn
-  else
-    Printf.sprintf
-      "턴 %d, 전장의 긴장이 다시 고조되고 어둠 속에서 새로운 위협의 기척이 느껴진다."
-      turn
+  let templates =
+    if live_npcs > 0 then
+      [
+        (fun turn ->
+          Printf.sprintf
+            "턴 %d, 전장의 연기가 걷히자 남은 적들이 전열을 다시 정비하며 반격을 준비한다."
+            turn);
+        (fun turn ->
+          Printf.sprintf
+            "턴 %d, 금속이 맞부딪히는 소리 속에 적 진형이 재편되며 역습의 각을 만든다."
+            turn);
+        (fun turn ->
+          Printf.sprintf
+            "턴 %d, 파편과 먼지 사이로 적의 지휘 신호가 번쩍이며 전선이 다시 밀려온다."
+            turn);
+        (fun turn ->
+          Printf.sprintf
+            "턴 %d, 균열 난 방패 틈으로 적 선봉이 고개를 들고 압박 수위를 끌어올린다."
+            turn);
+      ]
+    else
+      [
+        (fun turn ->
+          Printf.sprintf
+            "턴 %d, 전장의 긴장이 다시 고조되고 어둠 속에서 새로운 위협의 기척이 느껴진다."
+            turn);
+        (fun turn ->
+          Printf.sprintf
+            "턴 %d, 잠시 정적이 흐른 뒤 먼 거리에서 불길한 발소리와 함께 그림자가 다가온다."
+            turn);
+        (fun turn ->
+          Printf.sprintf
+            "턴 %d, 전장 가장자리의 안개가 걷히며 아직 드러나지 않은 적의 존재가 감지된다."
+            turn);
+        (fun turn ->
+          Printf.sprintf
+            "턴 %d, 바람이 꺼진 횃불을 흔들고 다음 국면을 예고하는 불길한 조짐이 스며든다."
+            turn);
+      ]
+  in
+  match pick_deterministic_text ~actor_id:"dm" ~turn ~salt:"fallback-dm" templates with
+  | Some template -> template turn
+  | None -> Printf.sprintf "턴 %d, 상황이 급변하며 다음 국면이 시작된다." turn
 
 let fallback_player_reply ~state ~actor_id =
   let turn = state_turn state in
@@ -3527,18 +3581,21 @@ let handle_round_run ctx args : result =
       let* existing_events_before =
         Trpg_engine_store_sqlite.read_events ~base_dir ~room_id
       in
+      let session_events_before =
+        events_since_last_session_marker existing_events_before
+      in
       let state = state_of_derived derived in
       let room_already_ended =
-        has_event_type existing_events_before Trpg_engine_event.Room_ended
+        has_event_type session_events_before Trpg_engine_event.Room_ended
       in
       let outcome_already_emitted =
-        has_event_type existing_events_before Trpg_engine_event.Session_outcome
+        has_event_type session_events_before Trpg_engine_event.Session_outcome
       in
       let end_rules =
         resolve_end_rules_for_room ~base_dir ~events:existing_events_before
       in
       let latest_outcome_payload =
-        ref (latest_session_outcome_payload existing_events_before)
+        ref (latest_session_outcome_payload session_events_before)
       in
       let* turn_before = read_state_turn derived in
       let unavailable_sampling =

--- a/test/test_tool_trpg_coverage.ml
+++ b/test/test_tool_trpg_coverage.ml
@@ -288,6 +288,116 @@ let test_round_run_emits_session_outcome_event () =
     (count_from_json (parse_json_exn stream_outcome));
   cleanup_dir base_dir
 
+let test_round_run_uses_current_session_for_outcome_gate () =
+  let base_dir = make_temp_dir () in
+  let config = Room.default_config base_dir in
+  let _ = Room.init config ~agent_name:(Some "tester") in
+  bootstrap_room_with_actors ~base_dir ~room_id:"room-round-restart-outcome" ~actor_ids:["p1"];
+  let old_room_end =
+    Trpg_engine_event.make ~seq:3 ~room_id:"room-round-restart-outcome" ~ts:(Types.now_iso ())
+      ~event_type:Trpg_engine_event.Room_ended
+      ~payload:(`Assoc [ ("reason", `String "old_session_done") ])
+      ()
+  in
+  append_event_exn ~base_dir ~event:old_room_end;
+  let old_outcome =
+    Trpg_engine_event.make ~seq:4 ~room_id:"room-round-restart-outcome" ~ts:(Types.now_iso ())
+      ~event_type:Trpg_engine_event.Session_outcome
+      ~payload:
+        (`Assoc
+          [
+            ("outcome", `String "victory");
+            ("reason", `String "flag:outcome.victory");
+            ("summary", `String "Victory condition met.");
+            ("turn", `Int 2);
+            ("phase", `String "round");
+          ])
+      ()
+  in
+  append_event_exn ~base_dir ~event:old_outcome;
+  let restarted =
+    Trpg_engine_event.make ~seq:5 ~room_id:"room-round-restart-outcome" ~ts:(Types.now_iso ())
+      ~event_type:Trpg_engine_event.Room_started
+      ~payload:(`Assoc [ ("phase", `String "round") ])
+      ()
+  in
+  append_event_exn ~base_dir ~event:restarted;
+  let turn_40 =
+    Trpg_engine_event.make ~seq:6 ~room_id:"room-round-restart-outcome" ~ts:(Types.now_iso ())
+      ~event_type:Trpg_engine_event.Turn_started
+      ~payload:(`Assoc [ ("turn", `Int 40) ])
+      ()
+  in
+  append_event_exn ~base_dir ~event:turn_40;
+
+  let keeper_call ~name ~message:_ ~timeout_sec:_ : Tool_trpg.keeper_call_result =
+    match name with
+    | "dm-keeper" -> `Ok (`Assoc [ ("reply", `String "The chapter closes.") ])
+    | "pk-1" -> `Ok (`Assoc [ ("reply", `String "I secure the gate.") ])
+    | other -> `Error ("unknown keeper: " ^ other)
+  in
+  let ctx : Tool_trpg.context =
+    { config; agent_name = "tester"; keeper_call = Some keeper_call; keeper_probe = None; dm_voice_emit = None }
+  in
+  let args =
+    `Assoc
+      [
+        ("room_id", `String "room-round-restart-outcome");
+        ("dm_keeper", `String "dm-keeper");
+        ("player_keepers", `Assoc [ ("p1", `String "pk-1") ]);
+        ("phase", `String "round");
+        ("timeout_sec", `Float 1.0);
+      ]
+  in
+  let ok, body = dispatch_exn ctx ~name:"masc_trpg_round_run" ~args in
+  Alcotest.(check bool) "round_run success" true ok;
+  let json = parse_json_exn body in
+  Alcotest.(check string)
+    "current session reaches draw at max turn"
+    "draw"
+    (json |> Yojson.Safe.Util.member "outcome"
+    |> Yojson.Safe.Util.member "outcome"
+    |> Yojson.Safe.Util.to_string);
+  Alcotest.(check string)
+    "reason is max_turn_reached"
+    "max_turn_reached"
+    (json |> Yojson.Safe.Util.member "outcome"
+    |> Yojson.Safe.Util.member "reason"
+    |> Yojson.Safe.Util.to_string);
+  Alcotest.(check string)
+    "room_status ended"
+    "ended"
+    (json |> Yojson.Safe.Util.member "room_status" |> Yojson.Safe.Util.to_string);
+
+  let _, stream_outcome =
+    dispatch_exn ctx ~name:"masc_trpg_stream"
+      ~args:
+        (`Assoc
+          [
+            ("room_id", `String "room-round-restart-outcome");
+            ("event_type", `String "session.outcome");
+          ])
+  in
+  Alcotest.(check int)
+    "session.outcome includes old + current session"
+    2
+    (count_from_json (parse_json_exn stream_outcome));
+
+  let _, stream_room_end =
+    dispatch_exn ctx ~name:"masc_trpg_stream"
+      ~args:
+        (`Assoc
+          [
+            ("room_id", `String "room-round-restart-outcome");
+            ("event_type", `String "room.ended");
+          ])
+  in
+  Alcotest.(check int)
+    "room.ended includes old + current session"
+    2
+    (count_from_json (parse_json_exn stream_room_end));
+  cleanup_dir base_dir
+
 let test_round_run_timeout_policy () =
   let base_dir = make_temp_dir () in
   let config = Room.default_config base_dir in
@@ -1676,6 +1786,10 @@ let () =
             "emits session outcome event"
             `Quick
             test_round_run_emits_session_outcome_event;
+          Alcotest.test_case
+            "current session outcome gate ignores past session outcome"
+            `Quick
+            test_round_run_uses_current_session_for_outcome_gate;
           Alcotest.test_case
             "rejects non-unique keepers"
             `Quick


### PR DESCRIPTION
## Summary\n- scope TRPG outcome/end dedupe checks to current session window (since last session marker)\n- resolve end rules from the latest room.created event instead of the oldest one\n- diversify local DM fallback narration templates to reduce repetitive lines\n- add regression test for restart scenario where old session.outcome must not block new max_turn termination\n\n## Validation\n- dune exec --root . ./test/test_tool_trpg_coverage.exe\n- dune build --root . test/test_tool_trpg_coverage.exe\n\n## User-visible impact\n- rooms that were force-restarted no longer keep running forever past max_turn because of stale old session outcome\n- DM fallback narration has more variation instead of repeating the same sentence pattern each turn\n