### PR TITLE
feat(viewer): add P3-P7 Bevy viewer improvements

### DIFF
--- a/viewer/Cargo.toml
+++ b/viewer/Cargo.toml
@@ -47,6 +47,7 @@ web-sys = { version = "0.3", features = [
     "HtmlAudioElement",
     "SpeechSynthesis",
     "SpeechSynthesisUtterance",
+    "Performance",
 ] }
 js-sys = "0.3"
 serde = { version = "1", features = ["derive"] }

--- a/viewer/src/dom/character_panel.rs
+++ b/viewer/src/dom/character_panel.rs
@@ -3,6 +3,7 @@ use bevy::prelude::*;
 use crate::assets;
 use crate::dom::escape::html_escape;
 use crate::game::components::{Actor, Skill};
+use crate::game::state::TurnProgressState;
 
 /// Snapshot of actor state used for change detection.
 /// Re-render only fires when this changes.
@@ -370,7 +371,11 @@ fn read_collapse_state() -> std::collections::HashSet<String> {
 }
 
 /// Re-renders the #character-panel DOM whenever actor state changes.
-pub fn update_character_panel_dom(actors: Query<&Actor>, mut cache: ResMut<CharacterPanelCache>) {
+pub fn update_character_panel_dom(
+    actors: Query<&Actor>,
+    mut cache: ResMut<CharacterPanelCache>,
+    progress: Res<TurnProgressState>,
+) {
     // Build current snapshot for cheap equality check
     let compat_snapshot: Vec<(String, i32, bool)> = actors
         .iter()
@@ -448,12 +453,19 @@ pub fn update_character_panel_dom(actors: Query<&Actor>, mut cache: ResMut<Chara
                 html_escape(&actor_initials(&actor.name, &actor.id)),
             )
         };
+        let is_thinking = progress
+            .actor_states
+            .get(&actor.id)
+            .map_or(false, |s| s == "thinking");
         let keeper_line = if actor.keeper.trim().is_empty() {
             "<div class=\"char-owner owner-unassigned\">keeper: (unassigned)</div>".to_string()
         } else {
+            let thinking_class = if is_thinking { " keeper-thinking" } else { "" };
             format!(
-                "<div class=\"char-owner owner-assigned\">keeper: {}</div>",
-                actor.keeper
+                "<div class=\"char-owner owner-assigned{}\">keeper: {}{}</div>",
+                thinking_class,
+                html_escape(&actor.keeper),
+                if is_thinking { " (thinking...)" } else { "" },
             )
         };
         let archetype_line = if actor.archetype.trim().is_empty() {

--- a/viewer/src/dom/narrative.rs
+++ b/viewer/src/dom/narrative.rs
@@ -244,6 +244,54 @@ pub fn update_narrative_dom(
     };
     let debug_enabled = debug_mode_enabled(&document);
 
+    // P5: Manage thinking placeholder divs based on TurnProgressState.
+    // Inject a spinner for each actor currently in "thinking" state,
+    // and remove placeholders for actors that have left that state.
+    {
+        // Collect currently-thinking actor IDs.
+        let thinking_ids: Vec<&String> = progress
+            .actor_states
+            .iter()
+            .filter(|(_, state)| state.as_str() == "thinking")
+            .map(|(id, _)| id)
+            .collect();
+
+        // Remove stale placeholders (actors no longer thinking).
+        let mut to_remove = Vec::new();
+        let children = log_el.children();
+        for i in 0..children.length() {
+            if let Some(child) = children.item(i) {
+                if let Some(id) = child.get_attribute("data-thinking-actor") {
+                    if !thinking_ids.iter().any(|tid| tid.as_str() == id) {
+                        to_remove.push(child);
+                    }
+                }
+            }
+        }
+        for el in to_remove {
+            let _ = log_el.remove_child(&el);
+        }
+
+        // Create placeholders for newly-thinking actors (if not already present).
+        for actor_id in &thinking_ids {
+            let placeholder_id = format!("thinking-{}", actor_id);
+            if document.get_element_by_id(&placeholder_id).is_none() {
+                if let Ok(div) = document.create_element("div") {
+                    div.set_class_name("narrative-entry thinking-placeholder");
+                    let _ = div.set_attribute("id", &placeholder_id);
+                    let _ = div.set_attribute("data-thinking-actor", actor_id);
+                    let label = sanitize_text(actor_id);
+                    div.set_inner_html(&format!(
+                        "<span class=\"thinking-spinner\"></span> <span class=\"thinking-label\">{} thinking…</span>",
+                        label
+                    ));
+                    let _ = log_el.append_child(&div);
+                    scroll_to_bottom(&log_el);
+                }
+            }
+        }
+    }
+
     for NarrativeReceived(payload) in events.read() {
         let Ok(entry) = document.create_element("div") else {
             continue;
@@ -264,6 +312,15 @@ pub fn update_narrative_dom(
             .map(str::trim)
             .filter(|s| !s.is_empty())
             .unwrap_or("system");
+
+        // P5: Remove thinking placeholder for this speaker when their narrative arrives.
+        if speaker_raw != "system" {
+            let placeholder_id = format!("thinking-{}", speaker_raw);
+            if let Some(placeholder) = document.get_element_by_id(&placeholder_id) {
+                let _ = log_el.remove_child(&placeholder);
+            }
+        }
+
         let dedup_key = format!(
             "{}|{}|{}|{}",
             payload.turn,

--- a/viewer/src/dom/overlay.rs
+++ b/viewer/src/dom/overlay.rs
@@ -3,7 +3,7 @@ use bevy::prelude::*;
 #[cfg(target_arch = "wasm32")]
 use wasm_bindgen::JsCast;
 
-use crate::game::state::{ChoiceState, CombatState, OverlayState};
+use crate::game::state::{ChoiceState, CombatState, OverlayState, RoomState};
 
 #[cfg(target_arch = "wasm32")]
 use super::escape::html_escape;
@@ -15,6 +15,8 @@ pub struct OverlayCache {
     pub last_mood: String,
     pub last_choice_active: bool,
     pub last_combat_active: bool,
+    pub last_scenario: String,
+    pub last_node: String,
 }
 
 #[cfg(target_arch = "wasm32")]
@@ -59,19 +61,24 @@ fn mood_icon_path(id: &str) -> Option<&'static str> {
 /// - `#mood-indicator` — mood/atmosphere text
 /// - `#choice-overlay` — choice panel (hidden when inactive)
 /// - `#combat-overlay` — combat indicator (hidden when inactive)
+/// - `#scene-indicator` — current scenario and node display
 #[allow(unused_mut)]
+#[allow(unused_variables)]
 pub fn update_overlay_dom(
     overlay: Res<OverlayState>,
     choice: Res<ChoiceState>,
     combat: Res<CombatState>,
+    room_state: Res<RoomState>,
     mut cache: ResMut<OverlayCache>,
 ) {
     let weather_changed = overlay.weather != cache.last_weather;
     let mood_changed = overlay.mood != cache.last_mood;
     let choice_changed = choice.active != cache.last_choice_active;
     let combat_changed = combat.active != cache.last_combat_active;
+    let scene_changed = room_state.current_scenario != cache.last_scenario
+        || room_state.current_node != cache.last_node;
 
-    if weather_changed || mood_changed || choice_changed || combat_changed {
+    if weather_changed || mood_changed || choice_changed || combat_changed || scene_changed {
         #[cfg(target_arch = "wasm32")]
         {
             let Some(document) = web_sys::window().and_then(|w| w.document()) else {
@@ -177,6 +184,31 @@ pub fn update_overlay_dom(
                     }
                 }
                 cache.last_combat_active = combat.active;
+            }
+
+            if scene_changed {
+                if let Some(el) = document.get_element_by_id("scene-indicator") {
+                    let scenario = room_state.current_scenario.trim();
+                    let node = room_state.current_node.trim();
+                    if scenario.is_empty() && node.is_empty() {
+                        el.set_text_content(None);
+                        if let Some(html_el) = el.dyn_ref::<web_sys::HtmlElement>() {
+                            let _ = html_el.style().set_property("display", "none");
+                        }
+                    } else {
+                        let label = if node.is_empty() {
+                            pretty_label(scenario)
+                        } else {
+                            format!("{} — {}", pretty_label(scenario), pretty_label(node))
+                        };
+                        el.set_text_content(Some(&label));
+                        if let Some(html_el) = el.dyn_ref::<web_sys::HtmlElement>() {
+                            let _ = html_el.style().set_property("display", "block");
+                        }
+                    }
+                }
+                cache.last_scenario = room_state.current_scenario.clone();
+                cache.last_node = room_state.current_node.clone();
             }
         }
     }

--- a/viewer/src/dom/turn_runtime.rs
+++ b/viewer/src/dom/turn_runtime.rs
@@ -327,10 +327,50 @@ fn render_agent_round_flow(document: &web_sys::Document, progress: &TurnProgress
     } else if !quorum_met {
         "플레이어 응답/쿼럼 대기".to_string()
     } else if dm_done {
+        // P7: Clear thinking timer on completion.
+        #[cfg(target_arch = "wasm32")]
+        {
+            if let Some(dash) = document.get_element_by_id("dashboard") {
+                let _ = dash.remove_attribute("data-dm-thinking-start");
+            }
+        }
         format!("DM 처리 완료 ({})", dm_state)
     } else if dm_state == "thinking" {
-        "DM 응답 생성 중 (thinking)".to_string()
+        // P7: Show elapsed seconds during DM thinking via Performance.now().
+        #[cfg(target_arch = "wasm32")]
+        {
+            let now_ms = web_sys::window()
+                .and_then(|w| w.performance())
+                .map(|p: web_sys::Performance| p.now())
+                .unwrap_or(0.0);
+            let start_ms = document
+                .get_element_by_id("dashboard")
+                .and_then(|dash| dash.get_attribute("data-dm-thinking-start"))
+                .and_then(|v| v.parse::<f64>().ok())
+                .unwrap_or_else(|| {
+                    if let Some(dash) = document.get_element_by_id("dashboard") {
+                        let _ = dash.set_attribute(
+                            "data-dm-thinking-start",
+                            &now_ms.to_string(),
+                        );
+                    }
+                    now_ms
+                });
+            let elapsed_sec = (now_ms - start_ms) / 1000.0;
+            format!("DM 응답 생성 중 ({:.1}s)", elapsed_sec)
+        }
+        #[cfg(not(target_arch = "wasm32"))]
+        {
+            "DM 응답 생성 중 (thinking)".to_string()
+        }
     } else {
+        // P7: Clear thinking timer when DM is not thinking.
+        #[cfg(target_arch = "wasm32")]
+        {
+            if let Some(dash) = document.get_element_by_id("dashboard") {
+                let _ = dash.remove_attribute("data-dm-thinking-start");
+            }
+        }
         "DM 실행 대기 (라운드 실행)".to_string()
     };
 

--- a/viewer/src/render/characters.rs
+++ b/viewer/src/render/characters.rs
@@ -15,25 +15,18 @@ pub struct DragState {
     pub drag_offset: Vec2,
 }
 
-/// Character color assignments — each party member gets a distinct color.
+/// Archetype-based color assignments for map tokens.
 /// Used as fallback tint when portrait texture is not yet loaded.
-fn character_color(id: &str) -> Color {
-    match id {
-        // Grimland originals
-        "grimja" => Color::srgb(0.8, 0.3, 0.2), // warrior red
-        "luna" => Color::srgb(0.3, 0.4, 0.8),   // mage blue
-        "songarak" => Color::srgb(0.3, 0.7, 0.3), // rogue green
-        "miso" => Color::srgb(0.8, 0.7, 0.3),   // cleric gold
-        // Identity Erosion
-        "iron" => Color::srgb(0.9, 0.9, 0.85), // ivory white (uncanny saint)
-        "moth" => Color::srgb(0.4, 0.3, 0.5),  // murky purple (J-horror)
-        "bell" => Color::srgb(1.0, 0.85, 0.3), // bright gold (cult leader glow)
-        "dust" => Color::srgb(0.4, 0.4, 0.35), // muted brown-grey (shrinking)
-        // Conformity Pressure
-        "aldric" => Color::srgb(0.6, 0.2, 0.15), // dark crimson (authority)
-        "brenna" => Color::srgb(0.7, 0.55, 0.4), // warm tan (agreeable)
-        "cedric" => Color::srgb(0.5, 0.6, 0.7),  // pale blue (uncertain)
-        "dara" => Color::srgb(0.5, 0.45, 0.55),  // sage purple (observer)
+fn archetype_color(archetype: &str) -> Color {
+    match archetype.to_ascii_lowercase().as_str() {
+        "warrior" | "fighter" | "barbarian" | "knight" => Color::srgb(0.8, 0.3, 0.2),
+        "mage" | "wizard" | "sorcerer" | "warlock" => Color::srgb(0.3, 0.4, 0.8),
+        "rogue" | "thief" | "assassin" | "ranger" => Color::srgb(0.3, 0.7, 0.3),
+        "cleric" | "priest" | "healer" | "paladin" => Color::srgb(0.8, 0.7, 0.3),
+        "bard" | "performer" => Color::srgb(0.7, 0.4, 0.7),
+        "druid" | "shaman" => Color::srgb(0.4, 0.6, 0.3),
+        "monk" | "mystic" => Color::srgb(0.6, 0.5, 0.3),
+        "necromancer" => Color::srgb(0.4, 0.2, 0.5),
         _ => Color::srgb(0.6, 0.6, 0.6),
     }
 }
@@ -57,7 +50,7 @@ pub fn spawn_character_sprites(
             }
         } else {
             Sprite {
-                color: character_color(&actor.id),
+                color: archetype_color(&actor.archetype),
                 custom_size: Some(Vec2::new(40.0, 40.0)),
                 ..default()
             }


### PR DESCRIPTION
## Summary

Bevy viewer enhancements for the TRPG system (P3-P7). P1 (damage text fix) and P2 (MP bars) were merged earlier.

- **P3**: Scene indicator HUD — persistent scene/node display via `OverlayCache` extension
- **P4**: Keeper thinking animation in character panel — pulse CSS class on `actor_states["thinking"]`
- **P5**: Narrative thinking placeholder — spinner `<div>` injected during keeper processing, removed on `NarrativeReceived`
- **P6**: Archetype-driven token colors — generic `archetype_color()` replaces hardcoded per-character IDs. Fixed duplicate `"warlock"` match arm
- **P7**: Keeper latency timer — elapsed seconds during DM thinking via `Performance.now()` + DOM `data-dm-thinking-start` attribute

## Build verification

- Native: `cargo build` — zero errors, zero new warnings
- WASM: `cargo build --target wasm32-unknown-unknown` — zero errors

## Files changed (6)

| File | Change |
|------|--------|
| `viewer/Cargo.toml` | Added `"Performance"` web-sys feature (P7) |
| `viewer/src/dom/character_panel.rs` | Thinking pulse animation (P4) |
| `viewer/src/dom/narrative.rs` | Thinking placeholder management (P5) |
| `viewer/src/dom/overlay.rs` | Scene indicator HUD (P3) |
| `viewer/src/dom/turn_runtime.rs` | Keeper latency timer (P7) |
| `viewer/src/render/characters.rs` | Archetype colors + warlock fix (P6) |

## Test plan

- [ ] Run TRPG session, verify scene indicator updates on scene transitions
- [ ] Verify keeper "thinking" pulse animation in character panel
- [ ] Verify narrative spinner appears during keeper processing
- [ ] Verify archetype colors match class (warrior=red, mage=blue, etc.)
- [ ] Verify DM thinking timer shows elapsed seconds

🤖 Generated with [Claude Code](https://claude.com/claude-code)