### PR TITLE
fix(trpg): add idle gate to auto-round loop and disable local_fallback

### DIFF
--- a/viewer/src/dom/action_panel.rs
+++ b/viewer/src/dom/action_panel.rs
@@ -327,6 +327,9 @@ fn bind_dice_roll_button() {
 
 #[cfg(target_arch = "wasm32")]
 fn submit_intervention_from_input() {
+    // Submitting an intervention is explicit user activity.
+    crate::game::round_runner::record_user_activity();
+
     let Some(doc) = web_sys::window().and_then(|w| w.document()) else {
         return;
     };

--- a/viewer/src/dom/turn_controls.rs
+++ b/viewer/src/dom/turn_controls.rs
@@ -536,6 +536,9 @@ fn bind_advance_button() {
 
 #[cfg(target_arch = "wasm32")]
 fn on_advance_click() {
+    // Any click on the advance button counts as user activity for idle detection.
+    crate::game::round_runner::record_user_activity();
+
     let Some(doc) = web_sys::window().and_then(|w| w.document()) else {
         return;
     };

--- a/viewer/src/game/round_runner.rs
+++ b/viewer/src/game/round_runner.rs
@@ -17,6 +17,10 @@ use crate::game::state::TurnProgressState;
 #[cfg(target_arch = "wasm32")]
 use std::cell::RefCell;
 
+/// User idle timeout (ms) — pause auto-round if no interaction for this long.
+#[cfg(target_arch = "wasm32")]
+const USER_IDLE_TIMEOUT_MS: f64 = 120_000.0; // 2 minutes
+
 // ─── Resource ──────────────────────────────────
 
 /// Shared state between the Bevy ECS world and the async WASM loop.
@@ -46,6 +50,9 @@ struct RoundRunnerControl {
 #[cfg(target_arch = "wasm32")]
 thread_local! {
     static ROUND_RUNNER_CONTROL: RefCell<Option<RoundRunnerControl>> = const { RefCell::new(None) };
+    /// Timestamp (ms since epoch) of the last user interaction.
+    /// Updated by `record_user_activity()`, checked by the auto-round loop.
+    static LAST_USER_ACTIVITY: RefCell<f64> = RefCell::new(0.0);
 }
 
 impl Default for RoundRunner {
@@ -105,6 +112,9 @@ pub fn start_round_loop(mut commands: Commands, progress: Res<TurnProgressState>
 
     #[cfg(target_arch = "wasm32")]
     {
+        // Mark game entry as user activity so idle gate doesn't fire immediately.
+        record_user_activity();
+
         let auto_enabled = auto_round_enabled();
         runner.running.store(auto_enabled, Ordering::SeqCst);
         if !auto_enabled {
@@ -181,6 +191,33 @@ pub fn set_auto_round_running(enabled: bool) {
 #[allow(dead_code)]
 pub fn set_auto_round_running(_enabled: bool) {}
 
+/// Record that the user interacted (click, key press, manual round trigger).
+/// The auto-round loop checks this to pause when the user is absent.
+#[cfg(target_arch = "wasm32")]
+pub fn record_user_activity() {
+    let now = js_sys::Date::now();
+    LAST_USER_ACTIVITY.with(|cell| {
+        *cell.borrow_mut() = now;
+    });
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+#[allow(dead_code)]
+pub fn record_user_activity() {}
+
+/// Returns `true` if no user activity has been recorded for `USER_IDLE_TIMEOUT_MS`.
+#[cfg(target_arch = "wasm32")]
+fn is_user_idle() -> bool {
+    let last = LAST_USER_ACTIVITY.with(|cell| *cell.borrow());
+    if last == 0.0 {
+        // Never recorded — treat first few rounds as active (activity gets
+        // recorded on game entry via start_round_loop).
+        return false;
+    }
+    let elapsed = js_sys::Date::now() - last;
+    elapsed > USER_IDLE_TIMEOUT_MS
+}
+
 #[cfg(target_arch = "wasm32")]
 fn spawn_round_loop(control: RoundRunnerControl) {
     let running = control.running.clone();
@@ -200,6 +237,19 @@ fn spawn_round_loop(control: RoundRunnerControl) {
             && !game_ended.load(Ordering::SeqCst)
             && round_num < MAX_ROUNDS
         {
+            // ── Idle gate: pause when user is absent ──
+            if is_user_idle() {
+                log::info!(
+                    "RoundRunner: user idle for >{}s — pausing auto round. \
+                     Interact to resume.",
+                    (USER_IDLE_TIMEOUT_MS / 1000.0) as u32
+                );
+                running.store(false, Ordering::SeqCst);
+                set_dom_runner_active(false);
+                sync_auto_round_ui(false);
+                break;
+            }
+
             let body = match build_round_body(&dm_keeper_snapshot) {
                 Ok(body) => body,
                 Err(reason) => {
@@ -460,7 +510,7 @@ fn build_round_body(dm_keeper_fallback: &str) -> Result<String, String> {
         "timeout_sec": timeout_sec,
         "lang": lang,
         "require_claim": false,
-        "local_fallback": true
+        "local_fallback": false
     });
 
     Ok(body.to_string())

--- a/viewer/src/mode/mod.rs
+++ b/viewer/src/mode/mod.rs
@@ -467,6 +467,9 @@ fn bind_auto_round_toggle(doc: &web_sys::Document) {
 
     let doc_clone = doc.clone();
     let cb = Closure::wrap(Box::new(move || {
+        // Toggling auto-round is explicit user activity.
+        crate::game::round_runner::record_user_activity();
+
         let next = !auto_round_enabled_from_dom(&doc_clone);
         if let Some(dashboard) = doc_clone.get_element_by_id("dashboard") {
             let _ = dashboard.set_attribute("data-auto-round", if next { "1" } else { "0" });


### PR DESCRIPTION
## 요약

DM이 혼자서 무한 대화하는 버그 수정.

**원인 2가지:**
1. `local_fallback: true` — 서버가 DM 응답뿐 아니라 **플레이어 행동까지** 자체 생성
2. auto-round 루프에 유저 존재 확인 없음 — 50라운드까지 무조건 실행

**수정 내용:**
- `local_fallback: false`로 변경 → 서버는 DM 턴만 생성, 플레이어 행동은 실제 유저 입력 필요
- 2분 idle timeout gate 추가 → 유저 상호작용 없으면 auto-round 일시정지
- `record_user_activity()` 를 advance 버튼, auto-round 토글, intervention 제출에 연결

## 변경 파일

| 파일 | 변경 |
|------|------|
| `viewer/src/game/round_runner.rs` | idle timeout 상수, 타임스탬프 추적, idle gate 체크, local_fallback=false |
| `viewer/src/dom/turn_controls.rs` | advance 버튼 클릭 시 activity 기록 |
| `viewer/src/dom/action_panel.rs` | intervention 제출 시 activity 기록 |
| `viewer/src/mode/mod.rs` | auto-round 토글 시 activity 기록 |

## 테스트 계획

- [ ] WASM 빌드 성공 확인 (`cargo build --target wasm32-unknown-unknown`)
- [ ] auto-round 시작 후 2분 방치 → 자동 일시정지 확인
- [ ] advance 버튼 클릭 후 idle 타이머 리셋 확인
- [ ] local_fallback=false 상태에서 DM만 응답하는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)