### PR TITLE
fix(trpg): bevy portraits + DnD5 trait/skill guidance

### DIFF
--- a/config/trpg/skills/agent_skills.json
+++ b/config/trpg/skills/agent_skills.json
@@ -3,42 +3,126 @@
     "id": "frontline_shield",
     "name": "Frontline Shield",
     "category": "defense",
-    "description": "Absorb incoming threat targeting nearby allies.",
-    "usage_hint": "Use during direct confrontation to prevent party collapse."
+    "description": "Brace the front and absorb incoming threats aimed at nearby allies.",
+    "usage_hint": "Use before enemy burst turns; pairs with STR(Athletics)-style guard checks."
+  },
+  {
+    "id": "oath_intercept",
+    "name": "Oath Intercept",
+    "category": "defense",
+    "description": "Step into a marked ally's danger lane and intercept the blow.",
+    "usage_hint": "Treat as reaction timing; best right after a high-threat target is identified."
+  },
+  {
+    "id": "morale_anchor",
+    "name": "Morale Anchor",
+    "category": "support",
+    "description": "Stabilize shaken allies and recover formation discipline.",
+    "usage_hint": "Strong after consecutive failures; aligns with CHA(Persuasion/Performance) play."
+  },
+  {
+    "id": "deception_feint",
+    "name": "Deception Feint",
+    "category": "social",
+    "description": "Fake intent to misread enemy priorities and open a tactical gap.",
+    "usage_hint": "Run before flanks or disengage; maps cleanly to CHA(Deception)."
   },
   {
     "id": "favor_broker",
     "name": "Favor Broker",
     "category": "social",
-    "description": "Trade concessions for delayed obligations.",
-    "usage_hint": "Useful before scarce-resource negotiations."
+    "description": "Trade obligations and leverage to gain cooperation or intel.",
+    "usage_hint": "Use in negotiation scenes with CHA(Persuasion) + WIS(Insight) framing."
+  },
+  {
+    "id": "shadow_entry",
+    "name": "Shadow Entry",
+    "category": "stealth",
+    "description": "Slip through low-visibility routes with minimal exposure.",
+    "usage_hint": "Use for infiltration/opening position; core check is DEX(Stealth)."
   },
   {
     "id": "supply_scan",
     "name": "Supply Scan",
     "category": "resource",
-    "description": "Estimate resource burn and shortage horizon.",
-    "usage_hint": "Run before committing to long missions."
+    "description": "Forecast burn rate and detect upcoming supply bottlenecks.",
+    "usage_hint": "Run before committing to long routes; resembles INT(Investigation)."
+  },
+  {
+    "id": "ration_shift",
+    "name": "Ration Shift",
+    "category": "resource",
+    "description": "Rebalance rations and loads to extend operational endurance.",
+    "usage_hint": "Use when attrition rises; often resolves through WIS(Survival)."
+  },
+  {
+    "id": "logistics_patch",
+    "name": "Logistics Patch",
+    "category": "resource",
+    "description": "Apply temporary fixes to disrupted supply chains.",
+    "usage_hint": "Best when events stack penalties; combine INT(Investigation) + WIS(Survival)."
   },
   {
     "id": "omen_trace",
     "name": "Omen Trace",
     "category": "arcane",
-    "description": "Infer likely next event from symbolic anomalies.",
-    "usage_hint": "Best in uncertain branching scenes."
+    "description": "Read symbolic anomalies to anticipate near-future threats.",
+    "usage_hint": "Use before branching decisions; align with INT(Arcana/Religion)."
+  },
+  {
+    "id": "arc_flash",
+    "name": "Arc Flash",
+    "category": "arcane",
+    "description": "Release a focused burst of arcane force to disrupt enemy lines.",
+    "usage_hint": "Good as tempo swing; treat as spell attack with Arcana support."
+  },
+  {
+    "id": "ward_bloom",
+    "name": "Ward Bloom",
+    "category": "arcane",
+    "description": "Expand a protective ward that reduces incoming area pressure.",
+    "usage_hint": "Cast before expected AoE windows; supports defensive Abjuration tempo."
   },
   {
     "id": "mark_prey",
     "name": "Mark Prey",
     "category": "combat",
-    "description": "Expose target weakness for coordinated strike.",
-    "usage_hint": "Combine with another actor's attack action."
+    "description": "Tag a target's weakness for coordinated party focus fire.",
+    "usage_hint": "Open with this on priority enemies; maps to WIS(Perception/Survival)."
+  },
+  {
+    "id": "silent_route",
+    "name": "Silent Route",
+    "category": "stealth",
+    "description": "Establish a low-noise approach lane for reposition or ambush.",
+    "usage_hint": "Use pre-engagement to avoid direct trade; DEX(Stealth) focused."
+  },
+  {
+    "id": "finisher_strike",
+    "name": "Finisher Strike",
+    "category": "combat",
+    "description": "Execute weakened enemies with high-conversion closing pressure.",
+    "usage_hint": "Use after ally setup damage; resolves through attack roll timing."
   },
   {
     "id": "field_mend",
     "name": "Field Mend",
     "category": "support",
-    "description": "Emergency stabilization to prevent actor knockout.",
-    "usage_hint": "Use when hp trend is negative for two turns."
+    "description": "Perform emergency stabilization to prevent ally collapse.",
+    "usage_hint": "Prioritize threatened allies; direct fit for WIS(Medicine)."
+  },
+  {
+    "id": "truce_window",
+    "name": "Truce Window",
+    "category": "support",
+    "description": "Open a brief ceasefire window for negotiation or reset.",
+    "usage_hint": "Use when fight EV is poor; CHA(Persuasion) + WIS(Insight) works well."
+  },
+  {
+    "id": "resolve_hymn",
+    "name": "Resolve Hymn",
+    "category": "support",
+    "description": "Reinforce party will and recover momentum under pressure.",
+    "usage_hint": "Great after morale shocks; pairs with CHA(Performance/Persuasion)."
   }
 ]

--- a/config/trpg/skills/agentskills/trpg-dnd5-scene-copilot/SKILL.md
+++ b/config/trpg/skills/agentskills/trpg-dnd5-scene-copilot/SKILL.md
@@ -1,0 +1,54 @@
+---
+name: trpg-dnd5-scene-copilot
+description: "TRPG(DnD5-lite) 턴에서 actor traits/skills를 읽고 액션 3개와 권장 판정(능력치/DC)을 제안하는 코파일럿 스킬. Trigger: trpg skill, dnd5 action, 턴 추천, 전투 선택."
+metadata:
+  short-description: TRPG DnD5 action copilot
+---
+
+# TRPG DnD5 Scene Copilot
+
+## When to use
+- DnD5-lite TRPG 장면에서 플레이어/DM이 다음 액션을 빠르게 고를 때
+- "이 스킬로 지금 뭘 해야 해?" 같은 질문이 나올 때
+- traits/skills를 게임 텍스트로 바로 연결해야 할 때
+
+## Source of truth
+- Skill catalog: `config/trpg/skills/agent_skills.json`
+- Character presets: `config/trpg/presets/character.json`
+
+## Workflow
+1. 현재 actor의 `skills`, `traits`, `hp/mp`, `phase`, `recent outcome`을 먼저 요약한다.
+2. 카탈로그에서 actor가 가진 스킬 1-2개를 우선 선택한다.
+3. 액션 후보 3개를 제시한다:
+- `safe`: 리스크 낮음, 성공 확률 우선
+- `tempo`: 흐름 전환 시도
+- `high-risk`: 고보상, 실패 리스크 큼
+4. 각 후보마다 DnD5-lite 권장 판정을 붙인다:
+- Ability check (예: DEX Stealth, CHA Persuasion)
+- 권장 DC (10/13/15/18 중 하나)
+- 실패 시 비용 한 줄
+5. 출력은 짧고 즉시 실행 가능한 문장으로 마무리한다.
+
+## Output template
+```text
+[TURN PLAN]
+1) SAFE - <action>
+   - Skill: <skill>
+   - Check: <ability/skill>, DC <n>
+   - Cost on fail: <one line>
+
+2) TEMPO - <action>
+   - Skill: <skill>
+   - Check: <ability/skill>, DC <n>
+   - Cost on fail: <one line>
+
+3) HIGH-RISK - <action>
+   - Skill: <skill>
+   - Check: <ability/skill>, DC <n>
+   - Cost on fail: <one line>
+```
+
+## Guardrails
+- meta 설명보다 "지금 행동"을 우선한다.
+- 없는 스킬 이름을 새로 만들지 않는다.
+- 결과가 반복되면 같은 skill이어도 접근(대상/위치/타이밍)을 바꿔 제안한다.

--- a/config/trpg/skills/agentskills/trpg-dnd5-scene-copilot/agents/openai.yaml
+++ b/config/trpg/skills/agentskills/trpg-dnd5-scene-copilot/agents/openai.yaml
@@ -1,0 +1,6 @@
+version: 1
+skill:
+  id: trpg-dnd5-scene-copilot
+  display_name: TRPG DnD5 Scene Copilot
+  short_description: Suggests 3 actionable turn options with DnD5-lite checks.
+  default_prompt: Suggest safe, tempo, and high-risk actions using actor skills and DnD5-lite checks.

--- a/lib/tool_trpg.ml
+++ b/lib/tool_trpg.ml
@@ -1393,8 +1393,37 @@ let non_empty_string_list_field json key =
       xs
       |> List.filter_map (function
            | `String s when String.trim s <> "" -> Some (String.trim s)
+           | `Assoc fields -> (
+               match List.assoc_opt "name" fields with
+               | Some (`String s) when String.trim s <> "" -> Some (String.trim s)
+               | _ -> (
+                   match List.assoc_opt "id" fields with
+                   | Some (`String s) when String.trim s <> "" -> Some (String.trim s)
+                   | _ -> None ) )
            | _ -> None)
   | _ -> []
+
+let last_actor_reply ~state ~actor_id =
+  match state |> member "narration_log" with
+  | `List entries ->
+      entries
+      |> List.rev
+      |> List.find_map (fun entry ->
+             match entry with
+             | `Assoc fields -> (
+                 match List.assoc_opt "actor_id" fields with
+                 | Some (`String aid) when aid = actor_id -> (
+                     match List.assoc_opt "reply" fields with
+                     | Some (`String reply) when String.trim reply <> "" ->
+                         Some (String.trim reply)
+                     | _ -> (
+                         match List.assoc_opt "proposed_action" fields with
+                         | Some (`String reply) when String.trim reply <> "" ->
+                             Some (String.trim reply)
+                         | _ -> None ) )
+                 | _ -> None )
+             | _ -> None)
+  | _ -> None
 
 let pick_deterministic_text ~actor_id ~turn ~salt xs =
   match xs with
@@ -1404,8 +1433,30 @@ let pick_deterministic_text ~actor_id ~turn ~salt xs =
       let idx = (if hash < 0 then -hash else hash) mod List.length xs in
       Some (List.nth xs idx)
 
+let contains_any_substring text keywords =
+  List.exists (fun keyword -> contains_substring text keyword) keywords
+
+let pick_deterministic_text_excluding ~actor_id ~turn ~salt ~exclude xs =
+  let normalized_exclude = String.trim exclude in
+  let rec loop attempt fallback =
+    if attempt > 4 then fallback
+    else
+      let salt' =
+        if attempt = 0 then salt else Printf.sprintf "%s:alt:%d" salt attempt
+      in
+      match pick_deterministic_text ~actor_id ~turn ~salt:salt' xs with
+      | Some candidate when String.trim candidate <> normalized_exclude ->
+          Some candidate
+      | Some candidate ->
+          let next_fallback = if fallback = None then Some candidate else fallback in
+          loop (attempt + 1) next_fallback
+      | None -> fallback
+  in
+  loop 0 None
+
 let fallback_dm_reply ~state =
   let turn = state_turn state in
+  let previous_reply = last_actor_reply ~state ~actor_id:"dm" in
   let live_npcs =
     party_fields_of_state state
     |> List.fold_left
@@ -1463,12 +1514,23 @@ let fallback_dm_reply ~state =
       ]
   in
   let dm_actor_id = "__dm__" in
-  match pick_deterministic_text ~actor_id:dm_actor_id ~turn ~salt:"dm-fallback" templates with
-  | Some template -> template turn live_npcs live_pcs
+  let candidates = List.map (fun template -> template turn live_npcs live_pcs) templates in
+  let selected =
+    match previous_reply with
+    | Some reply ->
+        pick_deterministic_text_excluding ~actor_id:dm_actor_id ~turn
+          ~salt:"dm-fallback" ~exclude:reply candidates
+    | None ->
+        pick_deterministic_text ~actor_id:dm_actor_id ~turn ~salt:"dm-fallback"
+          candidates
+  in
+  match selected with
+  | Some reply -> reply
   | None -> Printf.sprintf "턴 %d, 전장의 상황이 다시 요동치기 시작한다." turn
 
 let fallback_player_reply ~state ~actor_id =
   let turn = state_turn state in
+  let previous_reply = last_actor_reply ~state ~actor_id in
   let skills, traits =
     match actor_json_of_state state actor_id with
     | Some actor_json ->
@@ -1482,33 +1544,111 @@ let fallback_player_reply ~state ~actor_id =
     |> Option.value ~default:""
   in
   match pick_deterministic_text ~actor_id ~turn ~salt:"skill" skills with
-  | Some skill -> (
+  | Some skill ->
+      let key = String.lowercase_ascii (String.trim skill) in
       let templates =
-        [
-          (fun skill trait ->
+        if
+          contains_any_substring key
+            [ "mend"; "heal"; "truce"; "resolve"; "ward"; "anchor" ]
+        then
+          [
+            Printf.sprintf
+              "%s%s로 동료의 호흡을 정비해 붕괴 직전 전열을 안정시킨다."
+              skill trait_hint;
+            Printf.sprintf
+              "%s%s를 사용해 위험한 아군을 먼저 보호하고 회복 시간을 확보한다."
+              skill trait_hint;
+            Printf.sprintf
+              "%s%s로 일행의 흔들린 페이스를 되찾아 다음 턴의 성공 확률을 끌어올린다."
+              skill trait_hint;
+          ]
+        else if
+          contains_any_substring key
+            [ "deception"; "favor"; "broker"; "shadow"; "charm" ]
+        then
+          [
+            Printf.sprintf
+              "%s%s를 활용해 상대의 판단을 흔들고 유리한 협상 구도를 만든다."
+              skill trait_hint;
+            Printf.sprintf
+              "%s%s로 주의를 다른 곳으로 돌린 뒤 핵심 목표에 접근한다."
+              skill trait_hint;
+            Printf.sprintf
+              "%s%s를 통해 정보 우위를 확보하고 다음 행동 선택지를 늘린다."
+              skill trait_hint;
+          ]
+        else if
+          contains_any_substring key
+            [ "supply"; "ration"; "logistics"; "scan"; "omen"; "trace" ]
+        then
+          [
+            Printf.sprintf
+              "%s%s로 변수와 자원 손실을 먼저 점검해 무리한 돌입을 막는다."
+              skill trait_hint;
+            Printf.sprintf
+              "%s%s를 사용해 위험 구간을 표시하고 안전한 진행 루트를 제시한다."
+              skill trait_hint;
+            Printf.sprintf
+              "%s%s로 전장의 흐름을 재평가해 파티 운영 효율을 끌어올린다."
+              skill trait_hint;
+          ]
+        else if
+          contains_any_substring key [ "shield"; "intercept"; "guard"; "defense" ]
+        then
+          [
+            Printf.sprintf
+              "%s%s로 아군 전면을 받치며 적의 강공 타이밍을 흘려낸다."
+              skill trait_hint;
+            Printf.sprintf
+              "%s%s를 통해 적의 집중 화력을 분산시키고 진형 붕괴를 막는다."
+              skill trait_hint;
+            Printf.sprintf
+              "%s%s로 반격 각도를 만들기 전까지 버티는 시간을 번다."
+              skill trait_hint;
+          ]
+        else
+          [
             Printf.sprintf "%s%s로 적 전열의 약한 지점을 파고들어 공격한다." skill
-              trait);
-          (fun skill trait ->
+              trait_hint;
             Printf.sprintf "%s%s를 활용해 측면을 압박하며 핵심 목표를 공격한다." skill
-              trait);
-          (fun skill trait ->
-            Printf.sprintf "%s%s로 빈틈을 열고 전선을 밀어붙인다." skill trait);
-        ]
+              trait_hint;
+            Printf.sprintf "%s%s로 빈틈을 열고 전선을 밀어붙인다." skill trait_hint;
+            Printf.sprintf "%s%s를 연계해 적의 대응 전에 먼저 주도권을 잡는다." skill
+              trait_hint;
+          ]
       in
-      match pick_deterministic_text ~actor_id ~turn ~salt:"skill-template" templates with
-      | Some template -> template skill trait_hint
+      let selected =
+        match previous_reply with
+        | Some reply ->
+            pick_deterministic_text_excluding ~actor_id ~turn
+              ~salt:"skill-template" ~exclude:reply templates
+        | None ->
+            pick_deterministic_text ~actor_id ~turn ~salt:"skill-template"
+              templates
+      in
+      (match selected with
+      | Some reply -> reply
       | None -> Printf.sprintf "%s%s로 적을 공격해 전선을 밀어붙인다." skill trait_hint)
-  | None -> (
+  | None ->
       let templates =
         [
-          (fun trait -> Printf.sprintf "지형을 이용해%s 적의 허점을 노려 공격한다." trait);
-          (fun trait ->
-            Printf.sprintf "호흡을 고르고%s 적의 빈틈을 확인한 뒤 공격한다." trait);
-          (fun trait -> Printf.sprintf "전열을 정비하고%s 확실한 타이밍에 공격한다." trait);
+          Printf.sprintf "지형을 이용해%s 적의 허점을 노려 공격한다." trait_hint;
+          Printf.sprintf "호흡을 고르고%s 적의 빈틈을 확인한 뒤 공격한다." trait_hint;
+          Printf.sprintf "전열을 정비하고%s 확실한 타이밍에 공격한다." trait_hint;
+          Printf.sprintf "교전을 길게 끌지 않기 위해%s 짧고 강한 일격을 노린다." trait_hint;
         ]
       in
-      match pick_deterministic_text ~actor_id ~turn ~salt:"plain-template" templates with
-      | Some template -> template trait_hint
+      let selected =
+        match previous_reply with
+        | Some reply ->
+            pick_deterministic_text_excluding ~actor_id ~turn
+              ~salt:"plain-template" ~exclude:reply templates
+        | None ->
+            pick_deterministic_text ~actor_id ~turn ~salt:"plain-template"
+              templates
+      in
+      (match selected with
+      | Some reply -> reply
       | None -> Printf.sprintf "적의 빈틈을 노려%s 공격한다." trait_hint)
 
 let choose_live_npc_actor_id state =
@@ -3673,7 +3813,7 @@ let handle_round_run ctx args : result =
       let dm_reply_ref : string option ref = ref None in
       let state_for_players_ref = ref base_state_for_prompt in
       let* () =
-        if local_fallback then
+        if phase = "round" then
           let* spawn_event_opt =
             ensure_round_npc_spawn_event ~base_dir ~room_id ~turn:turn_before
               ~state:base_state_for_prompt

--- a/lib/trpg_preset_store.ml
+++ b/lib/trpg_preset_store.ml
@@ -331,43 +331,127 @@ let default_catalog : catalog =
           id = "frontline_shield";
           name = "Frontline Shield";
           category = "defense";
-          description = "Absorb incoming threat targeting nearby allies.";
-          usage_hint = Some "Use during direct confrontation to prevent party collapse.";
+          description = "Brace the front and absorb incoming threats aimed at nearby allies.";
+          usage_hint = Some "Use before enemy burst turns; pairs with STR(Athletics)-style guard checks.";
+        };
+        {
+          id = "oath_intercept";
+          name = "Oath Intercept";
+          category = "defense";
+          description = "Step into a marked ally's danger lane and intercept the blow.";
+          usage_hint = Some "Treat as reaction timing; best right after a high-threat target is identified.";
+        };
+        {
+          id = "morale_anchor";
+          name = "Morale Anchor";
+          category = "support";
+          description = "Stabilize shaken allies and recover formation discipline.";
+          usage_hint = Some "Strong after consecutive failures; aligns with CHA(Persuasion/Performance) play.";
+        };
+        {
+          id = "deception_feint";
+          name = "Deception Feint";
+          category = "social";
+          description = "Fake intent to misread enemy priorities and open a tactical gap.";
+          usage_hint = Some "Run before flanks or disengage; maps cleanly to CHA(Deception).";
         };
         {
           id = "favor_broker";
           name = "Favor Broker";
           category = "social";
-          description = "Trade concessions for delayed obligations.";
-          usage_hint = Some "Useful before scarce-resource negotiations.";
+          description = "Trade obligations and leverage to gain cooperation or intel.";
+          usage_hint = Some "Use in negotiation scenes with CHA(Persuasion) + WIS(Insight) framing.";
+        };
+        {
+          id = "shadow_entry";
+          name = "Shadow Entry";
+          category = "stealth";
+          description = "Slip through low-visibility routes with minimal exposure.";
+          usage_hint = Some "Use for infiltration/opening position; core check is DEX(Stealth).";
         };
         {
           id = "supply_scan";
           name = "Supply Scan";
           category = "resource";
-          description = "Estimate resource burn and shortage horizon.";
-          usage_hint = Some "Run before committing to long missions.";
+          description = "Forecast burn rate and detect upcoming supply bottlenecks.";
+          usage_hint = Some "Run before committing to long routes; resembles INT(Investigation).";
+        };
+        {
+          id = "ration_shift";
+          name = "Ration Shift";
+          category = "resource";
+          description = "Rebalance rations and loads to extend operational endurance.";
+          usage_hint = Some "Use when attrition rises; often resolves through WIS(Survival).";
+        };
+        {
+          id = "logistics_patch";
+          name = "Logistics Patch";
+          category = "resource";
+          description = "Apply temporary fixes to disrupted supply chains.";
+          usage_hint = Some "Best when events stack penalties; combine INT(Investigation) + WIS(Survival).";
         };
         {
           id = "omen_trace";
           name = "Omen Trace";
           category = "arcane";
-          description = "Infer likely next event from symbolic anomalies.";
-          usage_hint = Some "Best in uncertain branching scenes.";
+          description = "Read symbolic anomalies to anticipate near-future threats.";
+          usage_hint = Some "Use before branching decisions; align with INT(Arcana/Religion).";
+        };
+        {
+          id = "arc_flash";
+          name = "Arc Flash";
+          category = "arcane";
+          description = "Release a focused burst of arcane force to disrupt enemy lines.";
+          usage_hint = Some "Good as tempo swing; treat as spell attack with Arcana support.";
+        };
+        {
+          id = "ward_bloom";
+          name = "Ward Bloom";
+          category = "arcane";
+          description = "Expand a protective ward that reduces incoming area pressure.";
+          usage_hint = Some "Cast before expected AoE windows; supports defensive Abjuration tempo.";
         };
         {
           id = "mark_prey";
           name = "Mark Prey";
           category = "combat";
-          description = "Expose target weakness for coordinated strike.";
-          usage_hint = Some "Combine with another actor's attack action.";
+          description = "Tag a target's weakness for coordinated party focus fire.";
+          usage_hint = Some "Open with this on priority enemies; maps to WIS(Perception/Survival).";
+        };
+        {
+          id = "silent_route";
+          name = "Silent Route";
+          category = "stealth";
+          description = "Establish a low-noise approach lane for reposition or ambush.";
+          usage_hint = Some "Use pre-engagement to avoid direct trade; DEX(Stealth) focused.";
+        };
+        {
+          id = "finisher_strike";
+          name = "Finisher Strike";
+          category = "combat";
+          description = "Execute weakened enemies with high-conversion closing pressure.";
+          usage_hint = Some "Use after ally setup damage; resolves through attack roll timing.";
         };
         {
           id = "field_mend";
           name = "Field Mend";
           category = "support";
-          description = "Emergency stabilization to prevent actor knockout.";
-          usage_hint = Some "Use when hp trend is negative for two turns.";
+          description = "Perform emergency stabilization to prevent ally collapse.";
+          usage_hint = Some "Prioritize threatened allies; direct fit for WIS(Medicine).";
+        };
+        {
+          id = "truce_window";
+          name = "Truce Window";
+          category = "support";
+          description = "Open a brief ceasefire window for negotiation or reset.";
+          usage_hint = Some "Use when fight EV is poor; CHA(Persuasion) + WIS(Insight) works well.";
+        };
+        {
+          id = "resolve_hymn";
+          name = "Resolve Hymn";
+          category = "support";
+          description = "Reinforce party will and recover momentum under pressure.";
+          usage_hint = Some "Great after morale shocks; pairs with CHA(Performance/Persuasion).";
         };
       ];
   }

--- a/viewer/src/assets.rs
+++ b/viewer/src/assets.rs
@@ -63,7 +63,34 @@ pub mod paths {
 
 /// Returns the portrait asset path for a given character ID.
 pub fn portrait_for(id: &str) -> Option<&'static str> {
-    match id {
+    let normalized = id.trim().to_ascii_lowercase();
+
+    // Common runtime actor IDs are p01..p08 (and many NPC-* IDs).
+    if let Some(slot) = normalized.strip_prefix('p') {
+        if let Ok(index) = slot.parse::<u8>() {
+            return match index {
+                1 => Some(paths::PORTRAIT_IRON),
+                2 => Some(paths::PORTRAIT_ALDRIC),
+                3 => Some(paths::PORTRAIT_MOTH),
+                4 => Some(paths::PORTRAIT_DUST),
+                5 => Some(paths::PORTRAIT_BELL),
+                6 => Some(paths::PORTRAIT_BRENNA),
+                7 => Some(paths::PORTRAIT_CEDRIC),
+                8 => Some(paths::PORTRAIT_DARA),
+                _ => None,
+            };
+        }
+    }
+
+    let key = normalized.replace(' ', "_");
+    if key.starts_with("npc-") || key.starts_with("npc_") || key == "npc" {
+        return Some(paths::PORTRAIT_CEDRIC);
+    }
+    if key.starts_with("mob-") || key.starts_with("monster-") || key == "enemy" {
+        return Some(paths::PORTRAIT_DARA);
+    }
+
+    match key.as_str() {
         // Grimland originals
         "grimja" => Some(paths::PORTRAIT_GRIMJA),
         "luna" => Some(paths::PORTRAIT_LUNA),
@@ -79,6 +106,13 @@ pub fn portrait_for(id: &str) -> Option<&'static str> {
         "brenna" => Some(paths::PORTRAIT_BRENNA),
         "cedric" => Some(paths::PORTRAIT_CEDRIC),
         "dara" => Some(paths::PORTRAIT_DARA),
+        // Party preset aliases (name + preset id)
+        "brom" | "ironledger" => Some(paths::PORTRAIT_IRON),
+        "kael" | "vowblade" => Some(paths::PORTRAIT_ALDRIC),
+        "ena" | "stormseer" => Some(paths::PORTRAIT_MOTH),
+        "rook" | "gravehound" => Some(paths::PORTRAIT_DUST),
+        "mira" | "silkwhisper" => Some(paths::PORTRAIT_BELL),
+        "sera" | "lumenfriar" => Some(paths::PORTRAIT_BRENNA),
         _ => None,
     }
 }

--- a/viewer/src/dom/character_panel.rs
+++ b/viewer/src/dom/character_panel.rs
@@ -117,56 +117,104 @@ fn normalize_lore_key(raw: &str) -> String {
     raw.trim().to_ascii_lowercase().replace(['-', ' '], "_")
 }
 
-fn known_skill_lore(skill_name: &str) -> Option<(&'static str, &'static str)> {
+struct SkillLore {
+    description: &'static str,
+    hint: &'static str,
+    dnd5_check: &'static str,
+}
+
+fn known_skill_lore(skill_name: &str) -> Option<SkillLore> {
     match normalize_lore_key(skill_name).as_str() {
-        "mark_prey" => Some((
-            "적 한 명을 추적 표식으로 지정해 파티의 집중 화력을 유도합니다.",
-            "라운드 초반에 위협도가 높은 목표를 먼저 지정하면 효율이 큽니다.",
-        )),
-        "silent_route" => Some((
-            "소음과 시야 노출을 줄여 우회/잠입 루트를 확보합니다.",
-            "정면 충돌 전에 위치를 바꾸거나 기습 각도를 만들 때 사용하세요.",
-        )),
-        "finisher_strike" => Some((
-            "체력이 깎인 목표를 마무리하는 처형형 기술입니다.",
-            "아군의 선행 피해 후 연계하면 성공 판정이 잘 나옵니다.",
-        )),
-        "field_mend" => Some((
-            "현장에서 빠르게 상처를 봉합해 전열 붕괴를 막습니다.",
-            "집중 공격받는 아군에게 먼저 써서 다운을 방지하세요.",
-        )),
-        "truce_window" => Some((
-            "짧은 휴전 창을 만들어 협상/재정비 턴을 확보합니다.",
-            "적이 강하거나 정보가 부족할 때 시간을 벌기 좋습니다.",
-        )),
-        "resolve_hymn" => Some((
-            "파티의 동요를 진정시키고 의지를 끌어올리는 결의 기술입니다.",
-            "연속 실패 뒤 사기 회복용으로 쓰면 흐름 복구에 유리합니다.",
-        )),
-        "deception_feint" => Some((
-            "거짓 동작으로 적 판단을 흔들어 빈틈을 만듭니다.",
-            "정면 돌파보다 교란이 필요한 국면에서 효과적입니다.",
-        )),
-        "favor_broker" => Some((
-            "관계/빚을 거래해 협력이나 정보 제공을 이끌어냅니다.",
-            "NPC 또는 파티 설득 상황에서 선택지를 늘릴 때 사용하세요.",
-        )),
-        "shadow_entry" => Some((
-            "그림자 동선을 타고 경계망 안쪽으로 침투합니다.",
-            "탐지 리스크가 높은 구간을 넘어야 할 때 가장 안정적입니다.",
-        )),
-        "supply_scan" => Some((
-            "보급/자원 상태를 점검해 부족 항목을 조기에 찾습니다.",
-            "장기전 직전이나 이벤트 전환 전에 사용하면 손실을 줄입니다.",
-        )),
-        "ration_shift" => Some((
-            "자원 배분을 재조정해 생존 시간을 늘립니다.",
-            "당장 화력보다 지속력이 중요한 턴에 우선 사용하세요.",
-        )),
-        "logistics_patch" => Some((
-            "끊긴 보급 동선을 임시 복구해 팀 운영을 안정화합니다.",
-            "연속 이벤트로 소모가 누적될 때 유지력 확보에 핵심입니다.",
-        )),
+        "frontline_shield" => Some(SkillLore {
+            description: "전열에서 아군을 감싸 피해를 흡수하며 진형 붕괴를 막습니다.",
+            hint: "보스나 집중 사격 타이밍 직전에 선언하면 아군 생존률이 크게 오릅니다.",
+            dnd5_check: "STR(운동) 기반 보호 판정 또는 Protection 반응 운용",
+        }),
+        "oath_intercept" => Some(SkillLore {
+            description: "맹세 대상에게 향한 타격선으로 끼어들어 피해를 가로챕니다.",
+            hint: "직전 턴에 위협을 확정한 적에게 반응형으로 연계하면 효율이 높습니다.",
+            dnd5_check: "반응(Reaction) 기반 차단, STR(운동) 또는 CON 내성 보조",
+        }),
+        "morale_anchor" => Some(SkillLore {
+            description: "동요한 아군의 전의를 묶어 공포/혼란 이후 흐름을 회복합니다.",
+            hint: "연속 실패나 다운 직후 사기 복구용으로 사용하면 턴 손실을 줄입니다.",
+            dnd5_check: "CHA(설득) 또는 공연 계열 보조 체크",
+        }),
+        "deception_feint" => Some(SkillLore {
+            description: "거짓 동작으로 적 판단을 흔들어 빈틈을 만듭니다.",
+            hint: "정면 돌파보다 교란이 필요한 국면에서 효과적입니다.",
+            dnd5_check: "CHA(기만) 체크",
+        }),
+        "favor_broker" => Some(SkillLore {
+            description: "관계/빚을 거래해 협력이나 정보 제공을 이끌어냅니다.",
+            hint: "NPC 또는 파티 설득 상황에서 선택지를 늘릴 때 사용하세요.",
+            dnd5_check: "CHA(설득) + WIS(통찰) 조합 체크",
+        }),
+        "shadow_entry" => Some(SkillLore {
+            description: "그림자 동선을 타고 경계망 안쪽으로 침투합니다.",
+            hint: "탐지 리스크가 높은 구간을 넘어야 할 때 가장 안정적입니다.",
+            dnd5_check: "DEX(은신) 체크",
+        }),
+        "supply_scan" => Some(SkillLore {
+            description: "보급/자원 상태를 점검해 부족 항목을 조기에 찾습니다.",
+            hint: "장기전 직전이나 이벤트 전환 전에 사용하면 손실을 줄입니다.",
+            dnd5_check: "INT(조사) 체크",
+        }),
+        "ration_shift" => Some(SkillLore {
+            description: "자원 배분을 재조정해 생존 시간을 늘립니다.",
+            hint: "당장 화력보다 지속력이 중요한 턴에 우선 사용하세요.",
+            dnd5_check: "WIS(생존) 또는 INT 기반 운영 체크",
+        }),
+        "logistics_patch" => Some(SkillLore {
+            description: "끊긴 보급 동선을 임시 복구해 팀 운영을 안정화합니다.",
+            hint: "연속 이벤트로 소모가 누적될 때 유지력 확보에 핵심입니다.",
+            dnd5_check: "INT(조사) + WIS(생존) 조합 체크",
+        }),
+        "omen_trace" => Some(SkillLore {
+            description: "징조를 해석해 다음 장면의 위험 분기를 예측합니다.",
+            hint: "불확실한 분기에서 먼저 써서 실패 비용이 큰 선택지를 피하세요.",
+            dnd5_check: "INT(비전학) 또는 INT(종교학) 체크",
+        }),
+        "arc_flash" => Some(SkillLore {
+            description: "짧은 비전 폭발로 적 전열을 흔들며 공간을 확보합니다.",
+            hint: "아군이 묶였거나 도주 루트를 열어야 할 때 선행기로 쓰세요.",
+            dnd5_check: "주문 공격(Spell Attack) 또는 INT(비전학) 보조 체크",
+        }),
+        "ward_bloom" => Some(SkillLore {
+            description: "보호 장을 펼쳐 광역 피해를 줄이고 회복 창을 만듭니다.",
+            hint: "광역 피해가 예고된 턴에 선사용하면 파티 안정성이 크게 오릅니다.",
+            dnd5_check: "방호 계열 운용, INT(비전학) + WIS(의학) 보조 체크",
+        }),
+        "mark_prey" => Some(SkillLore {
+            description: "적 한 명을 추적 표식으로 지정해 파티의 집중 화력을 유도합니다.",
+            hint: "라운드 초반에 위협도가 높은 목표를 먼저 지정하면 효율이 큽니다.",
+            dnd5_check: "WIS(지각) 또는 WIS(생존) 체크",
+        }),
+        "silent_route" => Some(SkillLore {
+            description: "소음과 시야 노출을 줄여 우회/잠입 루트를 확보합니다.",
+            hint: "정면 충돌 전에 위치를 바꾸거나 기습 각도를 만들 때 사용하세요.",
+            dnd5_check: "DEX(은신) + WIS(지각) 체크",
+        }),
+        "finisher_strike" => Some(SkillLore {
+            description: "체력이 깎인 목표를 마무리하는 처형형 기술입니다.",
+            hint: "아군의 선행 피해 후 연계하면 성공 판정이 잘 나옵니다.",
+            dnd5_check: "근접/원거리 공격 굴림(STR/DEX) 체크",
+        }),
+        "field_mend" => Some(SkillLore {
+            description: "현장에서 빠르게 상처를 봉합해 전열 붕괴를 막습니다.",
+            hint: "집중 공격받는 아군에게 먼저 써서 다운을 방지하세요.",
+            dnd5_check: "WIS(의학) 체크",
+        }),
+        "truce_window" => Some(SkillLore {
+            description: "짧은 휴전 창을 만들어 협상/재정비 턴을 확보합니다.",
+            hint: "적이 강하거나 정보가 부족할 때 시간을 벌기 좋습니다.",
+            dnd5_check: "CHA(설득) 또는 WIS(통찰) 체크",
+        }),
+        "resolve_hymn" => Some(SkillLore {
+            description: "파티의 동요를 진정시키고 의지를 끌어올리는 결의 기술입니다.",
+            hint: "연속 실패 뒤 사기 회복용으로 쓰면 흐름 복구에 유리합니다.",
+            dnd5_check: "CHA(공연) 또는 CHA(설득) 체크",
+        }),
         _ => None,
     }
 }
@@ -182,6 +230,12 @@ fn trait_icon(name: &str) -> &'static str {
         "calculating" => "\u{1F9E0}",
         "charming" => "\u{1F48E}",
         "risk_seeking" => "\u{1F3B2}",
+        "stubborn" => "\u{1FAA8}",
+        "protective" => "\u{1F6E1}\u{FE0F}",
+        "honor_bound" => "\u{2696}\u{FE0F}",
+        "intense" => "\u{1F525}",
+        "empathetic" => "\u{1FA76}",
+        "fatalistic" => "\u{1F52E}",
         "pragmatic" => "\u{2699}\u{FE0F}",
         "frugal" => "\u{1F4B0}",
         "impatient" => "\u{23F1}\u{FE0F}",
@@ -200,6 +254,14 @@ fn trait_description(name: &str) -> String {
         "calculating" => "확률과 대가를 계산해 손익이 좋은 경로를 찾아냅니다.".to_string(),
         "charming" => "대화 압박을 완화하고 설득/관계 형성 판정에 유리합니다.".to_string(),
         "risk_seeking" => "높은 위험의 대가를 노려 큰 전환점을 만드는 성향입니다.".to_string(),
+        "stubborn" => "의지가 강해 정신 내성/버티기 상황에서 쉽게 물러서지 않습니다.".to_string(),
+        "protective" => "아군 대신 맞거나 엄호하는 선택을 우선합니다.".to_string(),
+        "honor_bound" => {
+            "약속과 규율을 중시해 협상/명예 관련 장면에서 신뢰를 얻습니다.".to_string()
+        }
+        "intense" => "집중력이 높아 짧은 폭발력이나 몰입이 필요한 장면에 강합니다.".to_string(),
+        "empathetic" => "상대 감정 신호를 잘 읽어 통찰/중재 상황에서 유리합니다.".to_string(),
+        "fatalistic" => "불리한 상황을 감수하고 큰 대가를 선택하는 경향이 있습니다.".to_string(),
         "pragmatic" => "당장 생존과 효율을 우선해 자원 운용 판단이 빠릅니다.".to_string(),
         "frugal" => "소모를 줄여 장기전에서 팀 유지력을 끌어올립니다.".to_string(),
         "impatient" => "결단은 빠르지만 장기 설정보다 즉시 행동을 선호합니다.".to_string(),
@@ -208,8 +270,8 @@ fn trait_description(name: &str) -> String {
 }
 
 fn fallback_skill_description(_actor: &Actor, skill_name: &str, modifier: i32) -> String {
-    if let Some((description, _hint)) = known_skill_lore(skill_name) {
-        return description.to_string();
+    if let Some(lore) = known_skill_lore(skill_name) {
+        return lore.description.to_string();
     }
     let key = skill_name.trim().to_ascii_lowercase();
     if key.contains("heal") || key.contains("cure") || key.contains("치유") {
@@ -251,8 +313,8 @@ fn fallback_skill_description(_actor: &Actor, skill_name: &str, modifier: i32) -
 }
 
 fn fallback_skill_hint(actor: &Actor, skill_name: &str) -> String {
-    if let Some((_description, hint)) = known_skill_lore(skill_name) {
-        return hint.to_string();
+    if let Some(lore) = known_skill_lore(skill_name) {
+        return lore.hint.to_string();
     }
     let key = skill_name.trim().to_ascii_lowercase();
     let base = if key.contains("heal") || key.contains("cure") || key.contains("치유") {
@@ -279,7 +341,44 @@ fn fallback_skill_hint(actor: &Actor, skill_name: &str) -> String {
     }
 }
 
-fn skill_copy(skill: &Skill, actor: &Actor) -> (String, String) {
+fn fallback_skill_dnd5(skill_name: &str) -> String {
+    if let Some(lore) = known_skill_lore(skill_name) {
+        return lore.dnd5_check.to_string();
+    }
+    let key = skill_name.trim().to_ascii_lowercase();
+    if key.contains("heal") || key.contains("cure") || key.contains("치유") {
+        "D&D5 권장 체크: WIS(의학)".to_string()
+    } else if key.contains("guard")
+        || key.contains("defend")
+        || key.contains("block")
+        || key.contains("방어")
+    {
+        "D&D5 권장 체크: STR(운동) + 반응(Reaction)".to_string()
+    } else if key.contains("stealth")
+        || key.contains("hide")
+        || key.contains("sneak")
+        || key.contains("은신")
+    {
+        "D&D5 권장 체크: DEX(은신)".to_string()
+    } else if key.contains("charm")
+        || key.contains("deception")
+        || key.contains("persuade")
+        || key.contains("협상")
+    {
+        "D&D5 권장 체크: CHA(기만/설득)".to_string()
+    } else if key.contains("arc")
+        || key.contains("spell")
+        || key.contains("omen")
+        || key.contains("magic")
+        || key.contains("마법")
+    {
+        "D&D5 권장 체크: INT(비전학) 또는 주문 공격".to_string()
+    } else {
+        "D&D5 권장 체크: 관련 능력치 체크(상황 기반)".to_string()
+    }
+}
+
+fn skill_copy(skill: &Skill, actor: &Actor) -> (String, String, String) {
     let modifier = skill.modifier();
     let description = if skill.description.trim().is_empty() {
         fallback_skill_description(actor, &skill.name, modifier)
@@ -291,7 +390,8 @@ fn skill_copy(skill: &Skill, actor: &Actor) -> (String, String) {
     } else {
         skill.usage_hint.trim().to_string()
     };
-    (description, usage_hint)
+    let dnd5_check = fallback_skill_dnd5(&skill.name);
+    (description, usage_hint, dnd5_check)
 }
 
 fn actor_initials(name: &str, id: &str) -> String {
@@ -606,16 +706,22 @@ pub fn update_character_panel_dom(
                 .iter()
                 .map(|s| {
                     let m = s.modifier();
-                    let (description, usage_hint) = skill_copy(s, actor);
+                    let (description, usage_hint, dnd5_check) = skill_copy(s, actor);
                     let escaped_name = html_escape(&s.name);
                     let escaped_desc = html_escape(&description);
                     let escaped_hint = html_escape(&usage_hint);
+                    let escaped_dnd = html_escape(&dnd5_check);
                     let mod_class = if m > 0 {
                         "mod-positive"
                     } else if m < 0 {
                         "mod-negative"
                     } else {
                         "mod-neutral"
+                    };
+                    let dnd_line = if dnd5_check.trim().is_empty() {
+                        String::new()
+                    } else {
+                        format!("<div class=\"skill-dnd\">{}</div>", escaped_dnd)
                     };
                     let hint_line = if usage_hint.trim().is_empty() {
                         String::new()
@@ -632,6 +738,7 @@ pub fn update_character_panel_dom(
                             "</div>",
                             "<div class=\"skill-desc\">{}</div>",
                             "{}",
+                            "{}",
                             "</div>"
                         ),
                         escaped_name,
@@ -639,6 +746,7 @@ pub fn update_character_panel_dom(
                         mod_class,
                         fmt_modifier(m),
                         escaped_desc,
+                        dnd_line,
                         hint_line,
                     )
                 })
@@ -656,7 +764,7 @@ pub fn update_character_panel_dom(
                 actor.skills.len(),
                 format!(
                     "{}{}{}",
-                    "<div class=\"section-guide\">액션/주사위 판정 보정치입니다. 기본 계산: Mod = (Lv-10)/2</div>",
+                    "<div class=\"section-guide\">액션/주사위 판정 보정치입니다. 기본 계산: Mod = (Lv-10)/2, D&D5 권장 체크를 함께 참고하세요.</div>",
                     head,
                     rows
                 ),

--- a/viewer/src/render/characters.rs
+++ b/viewer/src/render/characters.rs
@@ -31,6 +31,24 @@ fn archetype_color(archetype: &str) -> Color {
     }
 }
 
+fn portrait_path_for_actor(actor: &Actor) -> Option<&'static str> {
+    if let Some(path) = assets::portrait_for(&actor.id) {
+        return Some(path);
+    }
+    let name = actor.name.trim().to_ascii_lowercase();
+    if !name.is_empty() {
+        if let Some(path) = assets::portrait_for(&name) {
+            return Some(path);
+        }
+        if let Some(first) = name.split_whitespace().next() {
+            if let Some(path) = assets::portrait_for(first) {
+                return Some(path);
+            }
+        }
+    }
+    None
+}
+
 /// Spawns character token sprites from Actor components that lack MapToken.
 /// Uses AI-generated portrait textures when available, falls back to colored squares.
 pub fn spawn_character_sprites(
@@ -42,7 +60,7 @@ pub fn spawn_character_sprites(
         let pos = area_to_position(&actor.area);
 
         // Use portrait texture if available, fallback to colored square
-        let sprite = if let Some(path) = assets::portrait_for(&actor.id) {
+        let sprite = if let Some(path) = portrait_path_for_actor(actor) {
             Sprite {
                 image: asset_server.load(path),
                 custom_size: Some(Vec2::new(64.0, 64.0)),

--- a/viewer/style.css
+++ b/viewer/style.css
@@ -2085,6 +2085,13 @@ body.wasm-dom-fallback #bevy-canvas {
     white-space: normal;
 }
 
+.skill-dnd {
+    color: #9ab6e6;
+    font-size: 9px;
+    line-height: 1.35;
+    white-space: normal;
+}
+
 .skill-hint {
     color: rgba(227, 239, 255, 0.85);
     font-size: 9px;


### PR DESCRIPTION
## Summary
- fix portrait rendering in Bevy/TRPG viewer by adding alias mapping for runtime actor ids (`p01..`) and preset/name aliases
- add name fallback lookup for map token portrait resolution (`render/characters.rs`)
- expand trait/skill lore in character panel with DnD5-style recommended checks
- add `.skill-dnd` UI line and clarify section guide copy
- expand TRPG skill catalog SSOT to include all preset-referenced skills (18 total)
- add AgentSkills.io-ready TRPG copilot skill package under `config/trpg/skills/agentskills/`

## Verification
- `cargo check` (viewer)
- `dune build @default --root .`

## Notes
- This PR focuses on `rs/bevy` gameplay UX (portrait visibility + actionable skill meaning), not dashboard migration work.