### PR TITLE
test: quick-win coverage for Heartbeat and SSE modules

### DIFF
--- a/test/dune
+++ b/test/dune
@@ -20,14 +20,14 @@
         test_validation test_response test_voice_stream test_sctp
         test_datachannel_rfc test_dtls_crypto test_dashboard
         test_multi_room test_worktree_detection test_bounded test_mention test_hat
-        test_swarm)
+        test_swarm test_heartbeat_qw test_sse_qw)
  (modules test_room test_types test_checkpoint test_auth test_http_negotiation
           test_sse test_encryption test_backend test_cancellation test_graphql_api
           test_subscriptions test_session test_progress test_mitosis test_spawn
           test_validation test_response test_voice_stream test_sctp
           test_datachannel_rfc test_dtls_crypto test_dashboard
           test_multi_room test_worktree_detection test_bounded test_mention test_hat
-          test_swarm)
+          test_swarm test_heartbeat_qw test_sse_qw)
  (libraries masc_mcp mcp_protocol alcotest str yojson mirage-crypto
             mirage-crypto-rng mirage-crypto-rng.unix cohttp cstruct unix))
 

--- a/test/test_heartbeat_qw.ml
+++ b/test/test_heartbeat_qw.ml
@@ -1,0 +1,143 @@
+(** Quick-win tests for Heartbeat module.
+    Covers: generate_id, start, stop, list, get, stop_by_agent. *)
+
+open Masc_mcp
+
+let () =
+  (* Clear state before each test group *)
+  let reset () =
+    List.iter (fun (hb : Heartbeat.t) -> ignore (Heartbeat.stop hb.id))
+      (Heartbeat.list ())
+  in
+
+  Alcotest.run "heartbeat-qw"
+    [
+      ( "generate_id",
+        [
+          Alcotest.test_case "non-empty" `Quick (fun () ->
+              let id = Heartbeat.generate_id () in
+              Alcotest.(check bool) "non-empty" true (String.length id > 0));
+          Alcotest.test_case "has hb- prefix" `Quick (fun () ->
+              let id = Heartbeat.generate_id () in
+              let prefix = String.sub id 0 3 in
+              Alcotest.(check string) "prefix" "hb-" prefix);
+          Alcotest.test_case "unique" `Quick (fun () ->
+              let a = Heartbeat.generate_id () in
+              let b = Heartbeat.generate_id () in
+              Alcotest.(check bool) "different" true (a <> b));
+        ] );
+      ( "start",
+        [
+          Alcotest.test_case "returns id" `Quick (fun () ->
+              reset ();
+              let id =
+                Heartbeat.start ~agent_name:"test-a" ~interval:60
+                  ~message:"ping"
+              in
+              Alcotest.(check bool) "non-empty id" true (String.length id > 0);
+              ignore (Heartbeat.stop id));
+          Alcotest.test_case "registers in table" `Quick (fun () ->
+              reset ();
+              let id =
+                Heartbeat.start ~agent_name:"test-b" ~interval:30
+                  ~message:"hello"
+              in
+              let found = Heartbeat.get id in
+              Alcotest.(check bool) "found" true (Option.is_some found);
+              ignore (Heartbeat.stop id));
+        ] );
+      ( "stop",
+        [
+          Alcotest.test_case "existing returns true" `Quick (fun () ->
+              reset ();
+              let id =
+                Heartbeat.start ~agent_name:"test-c" ~interval:10
+                  ~message:"msg"
+              in
+              let removed = Heartbeat.stop id in
+              Alcotest.(check bool) "removed" true removed);
+          Alcotest.test_case "missing returns false" `Quick (fun () ->
+              let removed = Heartbeat.stop "nonexistent-id" in
+              Alcotest.(check bool) "not found" false removed);
+          Alcotest.test_case "removes from table" `Quick (fun () ->
+              reset ();
+              let id =
+                Heartbeat.start ~agent_name:"test-d" ~interval:10
+                  ~message:"msg"
+              in
+              ignore (Heartbeat.stop id);
+              let found = Heartbeat.get id in
+              Alcotest.(check bool) "gone" true (Option.is_none found));
+        ] );
+      ( "list",
+        [
+          Alcotest.test_case "includes started" `Quick (fun () ->
+              reset ();
+              let id =
+                Heartbeat.start ~agent_name:"test-e" ~interval:10
+                  ~message:"msg"
+              in
+              let items = Heartbeat.list () in
+              let ids =
+                List.map (fun (hb : Heartbeat.t) -> hb.id) items
+              in
+              Alcotest.(check bool) "contains id" true (List.mem id ids);
+              ignore (Heartbeat.stop id));
+        ] );
+      ( "get",
+        [
+          Alcotest.test_case "found" `Quick (fun () ->
+              reset ();
+              let id =
+                Heartbeat.start ~agent_name:"test-f" ~interval:10
+                  ~message:"msg"
+              in
+              let hb = Heartbeat.get id in
+              Alcotest.(check bool) "some" true (Option.is_some hb);
+              ignore (Heartbeat.stop id));
+          Alcotest.test_case "not found" `Quick (fun () ->
+              let hb = Heartbeat.get "bogus" in
+              Alcotest.(check bool) "none" true (Option.is_none hb));
+        ] );
+      ( "stop_by_agent",
+        [
+          Alcotest.test_case "removes all for agent" `Quick (fun () ->
+              reset ();
+              let _a =
+                Heartbeat.start ~agent_name:"alice" ~interval:10
+                  ~message:"m1"
+              in
+              let _b =
+                Heartbeat.start ~agent_name:"alice" ~interval:20
+                  ~message:"m2"
+              in
+              let _c =
+                Heartbeat.start ~agent_name:"bob" ~interval:10
+                  ~message:"m3"
+              in
+              let removed = Heartbeat.stop_by_agent ~agent_name:"alice" in
+              Alcotest.(check int) "removed 2" 2 removed;
+              ignore (Heartbeat.stop _c));
+          Alcotest.test_case "no match returns 0" `Quick (fun () ->
+              reset ();
+              let removed =
+                Heartbeat.stop_by_agent ~agent_name:"nobody"
+              in
+              Alcotest.(check int) "removed 0" 0 removed);
+          Alcotest.test_case "leaves others" `Quick (fun () ->
+              reset ();
+              let _a =
+                Heartbeat.start ~agent_name:"alice" ~interval:10
+                  ~message:"m1"
+              in
+              let b =
+                Heartbeat.start ~agent_name:"bob" ~interval:10
+                  ~message:"m2"
+              in
+              ignore (Heartbeat.stop_by_agent ~agent_name:"alice");
+              let bob = Heartbeat.get b in
+              Alcotest.(check bool) "bob still here" true
+                (Option.is_some bob);
+              ignore (Heartbeat.stop b));
+        ] );
+    ]

--- a/test/test_sse_qw.ml
+++ b/test/test_sse_qw.ml
@@ -1,0 +1,90 @@
+(** Quick-win tests for Sse module.
+    Covers: max_clients, touch, close_all_clients, cleanup_stale, register/unregister. *)
+
+open Masc_mcp
+
+let () =
+  let reset () = ignore (Sse.close_all_clients ()) in
+  let dummy_push _s = () in
+
+  Alcotest.run "sse-qw"
+    [
+      ( "max_clients",
+        [
+          Alcotest.test_case "positive" `Quick (fun () ->
+              Alcotest.(check bool) "positive" true (Sse.max_clients > 0));
+          Alcotest.test_case "value is 200" `Quick (fun () ->
+              Alcotest.(check int) "200" 200 Sse.max_clients);
+        ] );
+      ( "register_unregister",
+        [
+          Alcotest.test_case "register adds client" `Quick (fun () ->
+              reset ();
+              ignore (Sse.register "sess-1" ~push:dummy_push ~last_event_id:0);
+              Alcotest.(check bool) "exists" true (Sse.exists "sess-1");
+              Sse.unregister "sess-1");
+          Alcotest.test_case "unregister removes client" `Quick (fun () ->
+              reset ();
+              ignore (Sse.register "sess-2" ~push:dummy_push ~last_event_id:0);
+              Sse.unregister "sess-2";
+              Alcotest.(check bool) "gone" false (Sse.exists "sess-2"));
+          Alcotest.test_case "client_count" `Quick (fun () ->
+              reset ();
+              ignore (Sse.register "s-a" ~push:dummy_push ~last_event_id:0);
+              ignore (Sse.register "s-b" ~push:dummy_push ~last_event_id:0);
+              Alcotest.(check int) "count" 2 (Sse.client_count ());
+              Sse.unregister "s-a";
+              Sse.unregister "s-b");
+        ] );
+      ( "touch",
+        [
+          Alcotest.test_case "existing client" `Quick (fun () ->
+              reset ();
+              ignore (Sse.register "sess-3" ~push:dummy_push ~last_event_id:0);
+              Unix.sleepf 0.05;
+              Sse.touch "sess-3";
+              (* No exception = pass *)
+              Alcotest.(check bool) "touched" true true;
+              Sse.unregister "sess-3");
+          Alcotest.test_case "nonexistent no error" `Quick (fun () ->
+              Sse.touch "nonexistent";
+              Alcotest.(check bool) "no crash" true true);
+        ] );
+      ( "close_all_clients",
+        [
+          Alcotest.test_case "with clients" `Quick (fun () ->
+              reset ();
+              ignore (Sse.register "c-1" ~push:dummy_push ~last_event_id:0);
+              ignore (Sse.register "c-2" ~push:dummy_push ~last_event_id:0);
+              ignore (Sse.register "c-3" ~push:dummy_push ~last_event_id:0);
+              let closed = Sse.close_all_clients () in
+              Alcotest.(check int) "closed 3" 3 closed;
+              Alcotest.(check int) "now empty" 0 (Sse.client_count ()));
+          Alcotest.test_case "empty" `Quick (fun () ->
+              reset ();
+              let closed = Sse.close_all_clients () in
+              Alcotest.(check int) "closed 0" 0 closed);
+        ] );
+      ( "cleanup_stale",
+        [
+          Alcotest.test_case "fresh clients survive" `Quick (fun () ->
+              reset ();
+              ignore (Sse.register "fresh" ~push:dummy_push ~last_event_id:0);
+              let evicted = Sse.cleanup_stale () in
+              Alcotest.(check int) "none evicted" 0 (List.length evicted);
+              Sse.unregister "fresh");
+          Alcotest.test_case "zero threshold evicts all" `Quick (fun () ->
+              reset ();
+              ignore (Sse.register "old" ~push:dummy_push ~last_event_id:0);
+              Unix.sleepf 0.05;
+              let evicted = Sse.cleanup_stale ~max_age_s:0.0 () in
+              Alcotest.(check bool) "evicted" true (List.length evicted > 0));
+          Alcotest.test_case "returns evicted ids" `Quick (fun () ->
+              reset ();
+              ignore (Sse.register "target" ~push:dummy_push ~last_event_id:0);
+              Unix.sleepf 0.05;
+              let evicted = Sse.cleanup_stale ~max_age_s:0.0 () in
+              Alcotest.(check bool) "contains target" true
+                (List.mem "target" evicted));
+        ] );
+    ]


### PR DESCRIPTION
## Summary
- **fix(trpg)**: `deterministic_damage` 부분 적용 버그 수정 (PR #402에서 유입)
- **test**: Heartbeat 모듈 14개 + SSE 모듈 12개 = **26개 테스트** 추가
- 커버리지: **44.20%** (44% CI 임계값 통과)

## 테스트 상세

### test_heartbeat_qw (14 tests)
- `generate_id`: non-empty, hb- prefix, unique
- `start`: returns id, registers in table
- `stop`: existing true, missing false, removes from table
- `list`: includes started
- `get`: found, not found
- `stop_by_agent`: removes all for agent, no match returns 0, leaves others

### test_sse_qw (12 tests)
- `max_clients`: positive, value=200
- `register_unregister`: adds client, removes, client_count
- `touch`: existing client, nonexistent no error
- `close_all_clients`: with clients, empty
- `cleanup_stale`: fresh survive, zero threshold evicts, returns evicted ids

## Test plan
- [x] `dune build` — 빌드 성공
- [x] `dune exec test/test_heartbeat_qw.exe` — 14/14 pass
- [x] `dune exec test/test_sse_qw.exe` — 12/12 pass
- [x] Full suite with `bisect_ppx` instrumentation — all pass
- [x] Coverage report: 44.20% >= 44% threshold

🤖 Generated with [Claude Code](https://claude.com/claude-code)