### PR TITLE
feat(viewer): visual depth — conditions, combat fx, area labels, panel

### DIFF
--- a/viewer/src/game/components.rs
+++ b/viewer/src/game/components.rs
@@ -113,3 +113,13 @@ pub struct WeatherOverlay;
 #[cfg(not(target_arch = "wasm32"))]
 #[derive(Component, Debug)]
 pub struct MoodOverlay;
+
+/// Marker for condition indicator dot sprites above map tokens.
+#[cfg(not(target_arch = "wasm32"))]
+#[derive(Component, Debug)]
+pub struct ConditionIndicator;
+
+/// Marker for area name labels on the 2D map.
+#[cfg(not(target_arch = "wasm32"))]
+#[derive(Component, Debug)]
+pub struct AreaLabel;

--- a/viewer/src/render/characters.rs
+++ b/viewer/src/render/characters.rs
@@ -2,7 +2,9 @@ use bevy::prelude::*;
 
 use super::map::{area_to_position, position_to_area};
 use crate::assets;
-use crate::game::components::*;
+use crate::game::components::{
+    Actor, ConditionIndicator, GameCamera, HpBarSprite, MapToken, MpBarSprite,
+};
 
 /// Marker component for entities that can be dragged by the player.
 #[derive(Component)]
@@ -311,6 +313,57 @@ pub fn apply_death_visuals(
     for (actor, mut sprite) in &mut actors {
         if actor.is_dead {
             sprite.color = Color::srgb(0.3, 0.3, 0.3);
+        }
+    }
+}
+
+/// Returns a dot color for a condition name.
+fn condition_dot_color(name: &str) -> Color {
+    match name.to_ascii_lowercase().as_str() {
+        "poisoned" => Color::srgb(0.8, 0.2, 0.3),
+        "stunned" => Color::srgb(0.8, 0.7, 0.2),
+        "frozen" | "cold" => Color::srgb(0.3, 0.5, 0.9),
+        "burning" => Color::srgb(0.9, 0.4, 0.1),
+        "charmed" => Color::srgb(0.7, 0.3, 0.7),
+        "blinded" => Color::srgb(0.4, 0.4, 0.4),
+        _ => Color::srgb(0.8, 0.5, 0.2),
+    }
+}
+
+/// Spawns/updates small colored dots above tokens to indicate active conditions.
+/// Max 3 dots, spaced horizontally at y+24 above the token center.
+pub fn update_condition_indicators(
+    mut commands: Commands,
+    actors: Query<(Entity, &Actor, Option<&Children>), (With<MapToken>, Changed<Actor>)>,
+    indicators: Query<Entity, With<ConditionIndicator>>,
+) {
+    for (actor_entity, actor, children) in &actors {
+        // Despawn existing condition dots for this actor
+        if let Some(children) = children {
+            for child in children.iter() {
+                if indicators.get(child).is_ok() {
+                    commands.entity(child).try_despawn();
+                }
+            }
+        }
+
+        // Spawn new condition dots (max 3)
+        let count = actor.conditions.len().min(3);
+        for (i, condition) in actor.conditions.iter().take(count).enumerate() {
+            let color = condition_dot_color(&condition.name);
+            let x_offset = (i as f32 - (count as f32 - 1.0) / 2.0) * 8.0;
+            let dot = commands
+                .spawn((
+                    Sprite {
+                        color,
+                        custom_size: Some(Vec2::new(6.0, 6.0)),
+                        ..default()
+                    },
+                    Transform::from_xyz(x_offset, 24.0, 0.2),
+                    ConditionIndicator,
+                ))
+                .id();
+            commands.entity(actor_entity).add_child(dot);
         }
     }
 }

--- a/viewer/src/render/fx.rs
+++ b/viewer/src/render/fx.rs
@@ -1,7 +1,7 @@
 use bevy::prelude::*;
 
 use crate::game::components::{Actor, FloatingText, MapToken};
-use crate::game::events::HpChanged;
+use crate::game::events::{CombatAttack, CombatDefense, HpChanged};
 
 /// Spawns a floating damage/heal number above the affected character.
 /// Looks up the actor's current Transform so the text appears on the token,
@@ -67,5 +67,77 @@ pub fn animate_floating_text(
         if floating.timer.just_finished() {
             commands.entity(entity).despawn();
         }
+    }
+}
+
+/// Spawns a floating attack label at the target position on CombatAttack events.
+pub fn spawn_combat_attack_fx(
+    mut commands: Commands,
+    mut events: MessageReader<CombatAttack>,
+    actors: Query<(&Actor, &Transform), With<MapToken>>,
+) {
+    for CombatAttack(payload) in events.read() {
+        // Prefer target position; fall back to attacker position
+        let pos = actors
+            .iter()
+            .find(|(a, _)| a.id == payload.target_id)
+            .or_else(|| actors.iter().find(|(a, _)| a.id == payload.actor_id))
+            .map(|(_, t)| t.translation)
+            .unwrap_or(Vec3::ZERO);
+
+        let label = if payload.action.is_empty() {
+            "Attack".to_string()
+        } else {
+            payload.action.clone()
+        };
+
+        commands.spawn((
+            Text2d::new(format!("\u{2694} {}", label)),
+            TextFont {
+                font_size: 20.0,
+                ..default()
+            },
+            TextColor(Color::srgb(0.9, 0.3, 0.1)),
+            Transform::from_xyz(pos.x, pos.y + 50.0, 10.0),
+            FloatingText {
+                timer: Timer::from_seconds(0.8, TimerMode::Once),
+                velocity: Vec2::new(0.0, 25.0),
+            },
+        ));
+    }
+}
+
+/// Spawns a floating defense label at the defender position on CombatDefense events.
+pub fn spawn_combat_defense_fx(
+    mut commands: Commands,
+    mut events: MessageReader<CombatDefense>,
+    actors: Query<(&Actor, &Transform), With<MapToken>>,
+) {
+    for CombatDefense(payload) in events.read() {
+        let pos = actors
+            .iter()
+            .find(|(a, _)| a.id == payload.actor_id)
+            .map(|(_, t)| t.translation)
+            .unwrap_or(Vec3::ZERO);
+
+        let label = if payload.method.is_empty() {
+            "Defend".to_string()
+        } else {
+            payload.method.clone()
+        };
+
+        commands.spawn((
+            Text2d::new(format!("\u{1F6E1} {}", label)),
+            TextFont {
+                font_size: 20.0,
+                ..default()
+            },
+            TextColor(Color::srgb(0.3, 0.5, 0.9)),
+            Transform::from_xyz(pos.x, pos.y + 50.0, 10.0),
+            FloatingText {
+                timer: Timer::from_seconds(0.8, TimerMode::Once),
+                velocity: Vec2::new(0.0, 25.0),
+            },
+        ));
     }
 }

--- a/viewer/src/render/map.rs
+++ b/viewer/src/render/map.rs
@@ -1,7 +1,7 @@
 use bevy::prelude::*;
 
 use crate::assets;
-use crate::game::components::{GameCamera, MapBackground};
+use crate::game::components::{AreaLabel, GameCamera, MapBackground};
 use crate::game::state::MapState;
 use crate::theme::ViewerTheme;
 
@@ -63,6 +63,22 @@ pub fn setup_map_background(
         Transform::from_xyz(0.0, 0.0, -10.0),
         MapBackground,
     ));
+}
+
+/// Spawns text labels below each named area position on the 2D map.
+pub fn spawn_area_labels(mut commands: Commands) {
+    for &(label, pos) in AREA_POSITIONS {
+        commands.spawn((
+            Text2d::new(label),
+            TextFont {
+                font_size: 14.0,
+                ..default()
+            },
+            TextColor(Color::srgba(1.0, 1.0, 1.0, 0.6)),
+            Transform::from_xyz(pos.x, pos.y - 60.0, 0.5),
+            AreaLabel,
+        ));
+    }
 }
 
 /// Updates the map label overlay when the area changes.

--- a/viewer/src/render/mod.rs
+++ b/viewer/src/render/mod.rs
@@ -8,8 +8,8 @@ pub mod ui;
 use bevy::prelude::*;
 
 use crate::game::components::{
-    FloatingText, GameCamera, HpBarSprite, MapBackground, MapToken, MoodOverlay, MpBarSprite,
-    WeatherOverlay,
+    AreaLabel, ConditionIndicator, FloatingText, GameCamera, HpBarSprite, MapBackground, MapToken,
+    MoodOverlay, MpBarSprite, WeatherOverlay,
 };
 use crate::mode::ViewerMode;
 use crate::render::characters::DragState;
@@ -34,13 +34,14 @@ impl Plugin for MapRenderPlugin {
                 (
                     map::setup_camera,
                     map::setup_map_background,
+                    map::spawn_area_labels,
                     overlay::setup_weather_overlay,
                     overlay::setup_mood_overlay,
                     transition::setup_fade_overlay,
                     ui::setup_ui,
                 ),
             )
-            // Update: character sprites, positions, HP bars, effects, transitions, UI
+            // Update: character sprites, positions, HP bars, drag, map
             .add_systems(
                 Update,
                 (
@@ -49,12 +50,22 @@ impl Plugin for MapRenderPlugin {
                     characters::update_hp_bars,
                     characters::update_mp_bars,
                     characters::apply_death_visuals,
+                    characters::update_condition_indicators,
                     characters::handle_drag_start,
                     characters::handle_drag,
                     characters::handle_drag_end,
                     map::update_map_label,
                     map::update_map_texture,
+                )
+                    .run_if(in_state(ViewerMode::Trpg)),
+            )
+            // Update: effects, overlays, transitions, UI
+            .add_systems(
+                Update,
+                (
                     fx::spawn_damage_text,
+                    fx::spawn_combat_attack_fx,
+                    fx::spawn_combat_defense_fx,
                     fx::animate_floating_text,
                     overlay::update_weather_overlay,
                     overlay::update_mood_overlay,
@@ -103,6 +114,8 @@ fn cleanup_trpg_scene(
             With<WeatherOverlay>,
             With<MoodOverlay>,
             With<UiMarker>,
+            With<ConditionIndicator>,
+            With<AreaLabel>,
         )>,
     >,
     mut scene_transition: ResMut<SceneTransition>,


### PR DESCRIPTION
## Summary
- 맵 토큰 위에 상태 이상 표시 (색깔 점: poison=red, stun=yellow, frozen=blue 등)
- CombatAttack/CombatDefense 이벤트 발생 시 FloatingText 시각 효과
- 맵 영역 라벨 (A-F) 텍스트 표시
- 캐릭터 패널의 스킬, 장비, 버프/디버프는 이전 작업에서 이미 구현 완료 확인

## Changes
- `viewer/src/game/components.rs`: `ConditionIndicator`, `AreaLabel` 마커 컴포넌트 추가
- `viewer/src/render/characters.rs`: `update_condition_indicators` 시스템 (조건별 색상 점 최대 3개)
- `viewer/src/render/fx.rs`: `spawn_combat_attack_fx`, `spawn_combat_defense_fx` 시스템
- `viewer/src/render/map.rs`: `spawn_area_labels` 시스템 (OnEnter에서 6개 영역 라벨 생성)
- `viewer/src/render/mod.rs`: 시스템 등록 + cleanup 쿼리에 새 마커 추가, 튜플 크기 초과 방지를 위해 Update 시스템 그룹 분할

## Test plan
- [x] `cargo build` native build clean (16s)
- [x] `cargo build --target wasm32-unknown-unknown` WASM build clean (4m 53s)
- [ ] Condition dots appear on tokens with conditions
- [ ] Combat events produce floating text effects
- [ ] Area labels visible below tokens on map

🤖 Generated with [Claude Code](https://claude.com/claude-code)