### PR TITLE
feat(trpg): narrative intelligence — inventory, relationships, dedup, JSON recovery

### DIFF
--- a/lib/tool_trpg.ml
+++ b/lib/tool_trpg.ml
@@ -3956,6 +3956,78 @@ let parse_keeper_reply keeper_json =
                    markers"
               else Ok default_fallback_reply))
 
+(** Attempt to recover truncated JSON by closing unclosed braces/brackets.
+    Returns None if the input cannot be recovered. *)
+let recover_truncated_json (raw : string) : Yojson.Safe.t option =
+  let trimmed = String.trim raw in
+  if String.length trimmed = 0 then None
+  else
+    let open_braces = ref 0 in
+    let open_brackets = ref 0 in
+    let in_string = ref false in
+    let escaped = ref false in
+    String.iter
+      (fun c ->
+        if !escaped then escaped := false
+        else
+          match c with
+          | '\\' when !in_string -> escaped := true
+          | '"' -> in_string := not !in_string
+          | '{' when not !in_string -> incr open_braces
+          | '}' when not !in_string -> decr open_braces
+          | '[' when not !in_string -> incr open_brackets
+          | ']' when not !in_string -> decr open_brackets
+          | _ -> ())
+      trimmed;
+    if !in_string then begin
+      (* Close unclosed string *)
+      let buf = Buffer.create (String.length trimmed + 16) in
+      Buffer.add_string buf trimmed;
+      Buffer.add_char buf '"';
+      for _ = 1 to !open_brackets do
+        Buffer.add_char buf ']'
+      done;
+      for _ = 1 to !open_braces do
+        Buffer.add_char buf '}'
+      done;
+      (try Some (Yojson.Safe.from_string (Buffer.contents buf))
+       with Yojson.Json_error _ -> None)
+    end
+    else if !open_braces > 0 || !open_brackets > 0 then begin
+      let buf = Buffer.create (String.length trimmed + 16) in
+      Buffer.add_string buf trimmed;
+      for _ = 1 to !open_brackets do
+        Buffer.add_char buf ']'
+      done;
+      for _ = 1 to !open_braces do
+        Buffer.add_char buf '}'
+      done;
+      (try Some (Yojson.Safe.from_string (Buffer.contents buf))
+       with Yojson.Json_error _ -> None)
+    end
+    else None
+
+(** Parse a raw string as keeper JSON, with truncated JSON recovery.
+    Tries normal Yojson parse first. On failure, attempts to close unclosed
+    braces/brackets and re-parse. Returns the parsed reply or an error. *)
+let parse_keeper_reply_raw (raw : string) =
+  let try_parse s =
+    try Some (Yojson.Safe.from_string s) with Yojson.Json_error _ -> None
+  in
+  match try_parse raw with
+  | Some json -> parse_keeper_reply json
+  | None -> (
+      match recover_truncated_json raw with
+      | Some json ->
+          Printf.eprintf
+            "[WARN] parse_keeper_reply_raw: recovered truncated JSON\n%!";
+          parse_keeper_reply json
+      | None ->
+          (* Not JSON at all — treat the raw text as the reply *)
+          let trimmed = String.trim raw in
+          if trimmed <> "" then Ok trimmed
+          else Error "empty raw keeper response")
+
 type prompt_language = [ `Ko | `En ]
 
 let prompt_language_of_string_opt = function
@@ -4099,10 +4171,13 @@ type prompt_context = {
   actor_archetype : string;
   actor_traits : string list;
   actor_skills : string list;
+  actor_inventory : string list;
+  actor_equipment : (string * string) list;
   scene_description : string;
   scene_mood : string;
   narrative_recent : string list;
   party_summary : string;
+  relationships : (string * string) list;
   world_weather : string;
   world_time : string;
   dm_style : string;
@@ -4118,10 +4193,13 @@ let empty_prompt_context =
     actor_archetype = "";
     actor_traits = [];
     actor_skills = [];
+    actor_inventory = [];
+    actor_equipment = [];
     scene_description = "";
     scene_mood = "";
     narrative_recent = [];
     party_summary = "";
+    relationships = [];
     world_weather = "";
     world_time = "";
     dm_style = "";
@@ -4184,8 +4262,167 @@ let extract_party_summary ~exclude_actor_id (state : Yojson.Safe.t) : string =
       |> String.concat ", "
   | _ -> ""
 
-let extract_prompt_context ~actor_id ~dm_persona_override (state : Yojson.Safe.t) :
-    prompt_context =
+let extract_equipment_fields (actor_json : Yojson.Safe.t) :
+    (string * string) list =
+  match actor_json with
+  | `Null -> []
+  | _ -> (
+      match actor_json |> member "equipment" with
+      | `Assoc pairs ->
+          pairs
+          |> List.filter_map (fun (slot, v) ->
+                 match v with
+                 | `String name when String.trim name <> "" ->
+                     Some (slot, String.trim name)
+                 | _ -> None)
+      | `List items ->
+          items
+          |> List.filter_map (fun item ->
+                 let slot = get_string_field item "slot" in
+                 let name = get_string_field item "name" in
+                 if slot <> "" && name <> "" then Some (slot, name) else None)
+      | _ -> [])
+
+(** Jaccard similarity between two word sets: |A inter B| / |A union B|. *)
+let jaccard_similarity a b =
+  let module SSet = Set.Make (String) in
+  let set_a = SSet.of_list a in
+  let set_b = SSet.of_list b in
+  let inter = SSet.cardinal (SSet.inter set_a set_b) in
+  let union = SSet.cardinal (SSet.union set_a set_b) in
+  if union = 0 then 0.0 else Float.of_int inter /. Float.of_int union
+
+let tokenize_words s =
+  s |> String.lowercase_ascii |> String.split_on_char ' '
+  |> List.concat_map (String.split_on_char '\n')
+  |> List.filter (fun w -> String.length w > 0)
+
+(** Check if a new narration entry is too similar to recent entries.
+    Returns true if the entry should be skipped (>60% Jaccard overlap with
+    any of the last 3 entries). *)
+let is_narration_duplicate ~recent_replies (new_reply : string) : bool =
+  let new_tokens = tokenize_words new_reply in
+  recent_replies
+  |> List.exists (fun prev ->
+         let prev_tokens = tokenize_words prev in
+         jaccard_similarity new_tokens prev_tokens > 0.6)
+
+(** Extract last N reply strings from narration_log. *)
+let extract_recent_replies ?(n = 3) (state : Yojson.Safe.t) : string list =
+  match state |> member "narration_log" with
+  | `List xs ->
+      xs |> take_last n
+      |> List.filter_map (fun entry ->
+             match entry |> member "reply" with
+             | `String s when String.trim s <> "" -> Some (String.trim s)
+             | _ -> None)
+  | _ -> []
+
+(** Deduplicate a narration log list. For each entry, check if its reply
+    is >60% Jaccard-similar to any of the preceding 3 entries. If so, skip. *)
+let deduplicate_narration (entries : Yojson.Safe.t list) :
+    Yojson.Safe.t list =
+  let _recent, kept =
+    List.fold_left
+      (fun (recent, acc) entry ->
+        let reply =
+          match entry |> member "reply" with
+          | `String s -> String.trim s
+          | _ -> ""
+        in
+        if reply = "" then (recent, entry :: acc)
+        else if is_narration_duplicate ~recent_replies:recent reply then
+          (recent, acc)
+        else
+          let recent' = (reply :: recent) |> take_last 3 in
+          (recent', entry :: acc))
+      ([], []) entries
+  in
+  List.rev kept
+
+(** Classify the relationship between actor_id and another actor based on
+    keyword occurrence in narration log entries where both appear.
+    Returns (other_actor_name, relation_type) pairs. *)
+let extract_relationships ~actor_id (state : Yojson.Safe.t) :
+    (string * string) list =
+  let ally_keywords =
+    [ "heal"; "help"; "protect"; "치유"; "도움"; "보호"; "회복" ]
+  in
+  let rival_keywords =
+    [ "attack"; "hit"; "slash"; "strike"; "공격"; "타격"; "베" ]
+  in
+  let party_members =
+    match state |> member "party" with
+    | `Assoc members ->
+        members
+        |> List.filter_map (fun (aid, aj) ->
+               if aid = actor_id then None
+               else
+                 let name = get_string_field aj "name" in
+                 if name = "" then None else Some (aid, name))
+    | _ -> []
+  in
+  let actor_name =
+    match state |> member "party" with
+    | `Assoc members -> (
+        match List.assoc_opt actor_id members with
+        | Some actor_json -> get_string_field actor_json "name"
+        | None -> "")
+    | _ -> ""
+  in
+  let actor_name_l = String.lowercase_ascii actor_name in
+  let entries =
+    match state |> member "narration_log" with
+    | `List xs -> xs
+    | _ -> []
+  in
+  party_members
+  |> List.filter_map (fun (other_id, other_name) ->
+         let ally_score = ref 0 in
+         let rival_score = ref 0 in
+         let co_count = ref 0 in
+         entries
+         |> List.iter (fun entry ->
+                let reply =
+                  match entry |> member "reply" with
+                  | `String s -> String.lowercase_ascii s
+                  | _ -> ""
+                in
+                let entry_actor =
+                  match entry |> member "actor_id" with
+                  | `String a -> a
+                  | _ -> ""
+                in
+                let other_name_l = String.lowercase_ascii other_name in
+                let involves_both =
+                  (entry_actor = actor_id
+                  && find_substring reply other_name_l <> None)
+                  || (entry_actor = other_id && find_substring reply actor_name_l <> None)
+                in
+                if involves_both then begin
+                  incr co_count;
+                  if
+                    List.exists
+                      (fun kw -> find_substring reply kw <> None)
+                      ally_keywords
+                  then incr ally_score;
+                  if
+                    List.exists
+                      (fun kw -> find_substring reply kw <> None)
+                      rival_keywords
+                  then incr rival_score
+                end);
+         if !co_count = 0 then None
+         else
+           let relation =
+             if !ally_score > !rival_score then "ally"
+             else if !rival_score > !ally_score then "rival"
+             else "neutral"
+           in
+           Some (other_name, relation))
+
+let extract_prompt_context ~actor_id ?(dm_persona_override = None)
+    (state : Yojson.Safe.t) : prompt_context =
   let actor_json =
     match state |> member "party" with
     | `Assoc members -> (
@@ -4218,10 +4455,13 @@ let extract_prompt_context ~actor_id ~dm_persona_override (state : Yojson.Safe.t
     actor_archetype = get_string_field actor_json "archetype";
     actor_traits = get_string_list_field actor_json "traits";
     actor_skills = get_string_list_field actor_json "skills";
+    actor_inventory = get_string_list_field actor_json "inventory";
+    actor_equipment = extract_equipment_fields actor_json;
     scene_description = get_string_field world_json "description";
     scene_mood = get_string_field world_json "intro";
     narrative_recent = extract_narrative_recent state;
     party_summary = extract_party_summary ~exclude_actor_id:actor_id state;
+    relationships = extract_relationships ~actor_id state;
     world_weather =
       (let flags = get_string_list_field world_json "story_flags" in
        flags
@@ -4286,6 +4526,17 @@ let build_player_section_ko (ctx : prompt_context) =
       (if ctx.actor_skills <> [] then
          Printf.sprintf "보유 기술: %s." (format_traits ctx.actor_skills)
        else "");
+      (match ctx.actor_equipment with
+      | [] -> ""
+      | eq ->
+          Printf.sprintf "장착 중: %s."
+            (eq
+            |> List.map (fun (slot, name) ->
+                   Printf.sprintf "%s(%s)" name slot)
+            |> String.concat ", "));
+      (if ctx.actor_inventory <> [] then
+         Printf.sprintf "소지품: %s." (String.concat ", " ctx.actor_inventory)
+       else "");
       (if ctx.scene_description <> "" then
          Printf.sprintf "현재 장소: %s" ctx.scene_description
        else "");
@@ -4301,6 +4552,14 @@ let build_player_section_ko (ctx : prompt_context) =
       (if ctx.party_summary <> "" then
          Printf.sprintf "파티 동료: %s." ctx.party_summary
        else "");
+      (match ctx.relationships with
+      | [] -> ""
+      | rels ->
+          rels
+          |> List.map (fun (name, rel) ->
+                 Printf.sprintf "%s와(과)의 관계: %s" name rel)
+          |> String.concat ". "
+          |> Printf.sprintf "관계: %s.");
       (match ctx.narrative_recent with
       | [] -> ""
       | lines ->
@@ -4336,6 +4595,17 @@ let build_player_section_en (ctx : prompt_context) =
       (if ctx.actor_skills <> [] then
          Printf.sprintf "Skills: %s." (format_traits ctx.actor_skills)
        else "");
+      (match ctx.actor_equipment with
+      | [] -> ""
+      | eq ->
+          Printf.sprintf "Equipped: %s."
+            (eq
+            |> List.map (fun (slot, name) ->
+                   Printf.sprintf "%s (%s)" name slot)
+            |> String.concat ", "));
+      (if ctx.actor_inventory <> [] then
+         Printf.sprintf "Carrying: %s." (String.concat ", " ctx.actor_inventory)
+       else "");
       (if ctx.scene_description <> "" then
          Printf.sprintf "Current scene: %s" ctx.scene_description
        else "");
@@ -4351,6 +4621,14 @@ let build_player_section_en (ctx : prompt_context) =
       (if ctx.party_summary <> "" then
          Printf.sprintf "Party members: %s." ctx.party_summary
        else "");
+      (match ctx.relationships with
+      | [] -> ""
+      | rels ->
+          rels
+          |> List.map (fun (name, rel) ->
+                 Printf.sprintf "Relationship with %s: %s" name rel)
+          |> String.concat ". "
+          |> Printf.sprintf "Relationships: %s.");
       (match ctx.narrative_recent with
       | [] -> ""
       | lines ->

--- a/test/dune
+++ b/test/dune
@@ -140,6 +140,12 @@
  (modules test_tool_trpg_coverage)
  (libraries masc_mcp alcotest yojson unix))
 
+; Narrative Intelligence tests (inventory, relationships, dedup, JSON recovery)
+(test
+ (name test_narrative_intelligence)
+ (modules test_narrative_intelligence)
+ (libraries masc_mcp alcotest yojson))
+
 (test
  (name test_tool_goals)
  (modules test_tool_goals)

--- a/test/test_narrative_intelligence.ml
+++ b/test/test_narrative_intelligence.ml
@@ -1,0 +1,490 @@
+(** Tests for narrative intelligence features:
+    - Inventory/equipment extraction and prompt display
+    - Relationship extraction from narration log
+    - Narrative deduplication via Jaccard similarity
+    - Truncated JSON recovery *)
+
+open Masc_mcp
+
+(* ================================================================
+   1. Inventory & Equipment extraction
+   ================================================================ *)
+
+let test_extract_equipment_from_assoc () =
+  let actor =
+    `Assoc
+      [
+        ("name", `String "Thorin");
+        ( "equipment",
+          `Assoc
+            [ ("weapon", `String "battle axe"); ("armor", `String "chainmail") ]
+        );
+      ]
+  in
+  let eq = Tool_trpg.extract_equipment_fields actor in
+  Alcotest.(check int) "2 equipment slots" 2 (List.length eq);
+  Alcotest.(check bool)
+    "weapon slot present" true
+    (List.exists (fun (s, n) -> s = "weapon" && n = "battle axe") eq);
+  Alcotest.(check bool)
+    "armor slot present" true
+    (List.exists (fun (s, n) -> s = "armor" && n = "chainmail") eq)
+
+let test_extract_equipment_from_list () =
+  let actor =
+    `Assoc
+      [
+        ("name", `String "Lina");
+        ( "equipment",
+          `List
+            [
+              `Assoc [ ("slot", `String "weapon"); ("name", `String "staff") ];
+              `Assoc [ ("slot", `String "ring"); ("name", `String "fire ring") ];
+            ] );
+      ]
+  in
+  let eq = Tool_trpg.extract_equipment_fields actor in
+  Alcotest.(check int) "2 equipment items" 2 (List.length eq);
+  Alcotest.(check bool)
+    "weapon present" true
+    (List.exists (fun (s, n) -> s = "weapon" && n = "staff") eq);
+  Alcotest.(check bool)
+    "ring present" true
+    (List.exists (fun (s, n) -> s = "ring" && n = "fire ring") eq)
+
+let test_extract_equipment_null_actor () =
+  let eq = Tool_trpg.extract_equipment_fields `Null in
+  Alcotest.(check int) "empty from null" 0 (List.length eq)
+
+let test_extract_equipment_missing_field () =
+  let actor = `Assoc [ ("name", `String "Nobody") ] in
+  let eq = Tool_trpg.extract_equipment_fields actor in
+  Alcotest.(check int) "empty when no equipment field" 0 (List.length eq)
+
+let test_inventory_in_prompt_context () =
+  let state =
+    `Assoc
+      [
+        ( "party",
+          `Assoc
+            [
+              ( "hero-1",
+                `Assoc
+                  [
+                    ("name", `String "Hero");
+                    ("archetype", `String "warrior");
+                    ("persona", `String "brave");
+                    ("traits", `List [ `String "strong" ]);
+                    ("skills", `List [ `String "swordsmanship" ]);
+                    ( "inventory",
+                      `List
+                        [
+                          `String "health potion";
+                          `String "rope";
+                          `String "torch";
+                        ] );
+                    ( "equipment",
+                      `Assoc
+                        [
+                          ("weapon", `String "longsword");
+                          ("armor", `String "plate");
+                        ] );
+                  ] );
+            ] );
+        ("world", `Assoc [ ("story_flags", `List []) ]);
+        ("narration_log", `List []);
+      ]
+  in
+  let ctx = Tool_trpg.extract_prompt_context ~actor_id:"hero-1" state in
+  Alcotest.(check int) "3 inventory items" 3 (List.length ctx.actor_inventory);
+  Alcotest.(check bool)
+    "has health potion" true
+    (List.mem "health potion" ctx.actor_inventory);
+  Alcotest.(check int) "2 equipment slots" 2 (List.length ctx.actor_equipment);
+  Alcotest.(check bool)
+    "has longsword" true
+    (List.exists (fun (_, n) -> n = "longsword") ctx.actor_equipment)
+
+(* ================================================================
+   2. Relationship extraction
+   ================================================================ *)
+
+let test_extract_relationships_ally () =
+  let state =
+    `Assoc
+      [
+        ( "party",
+          `Assoc
+            [
+              ( "hero-1",
+                `Assoc
+                  [
+                    ("name", `String "Kael");
+                    ("archetype", `String "warrior");
+                  ] );
+              ( "hero-2",
+                `Assoc
+                  [
+                    ("name", `String "Lyra");
+                    ("archetype", `String "healer");
+                  ] );
+            ] );
+        ( "narration_log",
+          `List
+            [
+              `Assoc
+                [
+                  ("actor_id", `String "hero-2");
+                  ("reply", `String "Lyra heals Kael with a gentle touch.");
+                ];
+              `Assoc
+                [
+                  ("actor_id", `String "hero-2");
+                  ("reply", `String "Lyra helps Kael stand up.");
+                ];
+            ] );
+        ("world", `Assoc [ ("story_flags", `List []) ]);
+      ]
+  in
+  let rels = Tool_trpg.extract_relationships ~actor_id:"hero-1" state in
+  Alcotest.(check int) "1 relationship" 1 (List.length rels);
+  match rels with
+  | [ (name, rel) ] ->
+      Alcotest.(check string) "partner name" "Lyra" name;
+      Alcotest.(check string) "ally relation" "ally" rel
+  | _ -> Alcotest.fail "expected exactly one relationship"
+
+let test_extract_relationships_rival () =
+  let state =
+    `Assoc
+      [
+        ( "party",
+          `Assoc
+            [
+              ( "p1",
+                `Assoc
+                  [
+                    ("name", `String "Arin");
+                    ("archetype", `String "rogue");
+                  ] );
+              ( "p2",
+                `Assoc
+                  [
+                    ("name", `String "Bron");
+                    ("archetype", `String "fighter");
+                  ] );
+            ] );
+        ( "narration_log",
+          `List
+            [
+              `Assoc
+                [
+                  ("actor_id", `String "p1");
+                  ("reply", `String "Arin attacks Bron with a dagger slash.");
+                ];
+              `Assoc
+                [
+                  ("actor_id", `String "p1");
+                  ("reply", `String "Arin strikes at Bron again.");
+                ];
+            ] );
+        ("world", `Assoc [ ("story_flags", `List []) ]);
+      ]
+  in
+  let rels = Tool_trpg.extract_relationships ~actor_id:"p1" state in
+  Alcotest.(check int) "1 relationship" 1 (List.length rels);
+  match rels with
+  | [ (name, rel) ] ->
+      Alcotest.(check string) "rival name" "Bron" name;
+      Alcotest.(check string) "rival relation" "rival" rel
+  | _ -> Alcotest.fail "expected exactly one relationship"
+
+let test_extract_relationships_empty_log () =
+  let state =
+    `Assoc
+      [
+        ( "party",
+          `Assoc
+            [
+              ("a", `Assoc [ ("name", `String "A"); ("archetype", `String "x") ]);
+              ("b", `Assoc [ ("name", `String "B"); ("archetype", `String "y") ]);
+            ] );
+        ("narration_log", `List []);
+        ("world", `Assoc [ ("story_flags", `List []) ]);
+      ]
+  in
+  let rels = Tool_trpg.extract_relationships ~actor_id:"a" state in
+  Alcotest.(check int) "no relationships from empty log" 0 (List.length rels)
+
+(* ================================================================
+   3. Narrative deduplication
+   ================================================================ *)
+
+let test_jaccard_identical () =
+  let sim = Tool_trpg.jaccard_similarity [ "a"; "b"; "c" ] [ "a"; "b"; "c" ] in
+  Alcotest.(check bool) "identical = 1.0" true (sim >= 0.99)
+
+let test_jaccard_disjoint () =
+  let sim = Tool_trpg.jaccard_similarity [ "a"; "b" ] [ "c"; "d" ] in
+  Alcotest.(check bool) "disjoint = 0.0" true (sim < 0.01)
+
+let test_jaccard_partial () =
+  let sim =
+    Tool_trpg.jaccard_similarity [ "a"; "b"; "c"; "d" ] [ "a"; "b"; "e"; "f" ]
+  in
+  (* intersection=2, union=6, sim=0.333 *)
+  Alcotest.(check bool) "partial overlap" true (sim > 0.3 && sim < 0.4)
+
+let test_is_narration_duplicate_true () =
+  let recent = [ "the goblin attacks the warrior with a club" ] in
+  let new_reply = "the goblin attacks the warrior with a club fiercely" in
+  Alcotest.(check bool)
+    "similar entry is duplicate" true
+    (Tool_trpg.is_narration_duplicate ~recent_replies:recent new_reply)
+
+let test_is_narration_duplicate_false () =
+  let recent = [ "the goblin attacks the warrior with a club" ] in
+  let new_reply = "the wizard casts a fireball at the dragon" in
+  Alcotest.(check bool)
+    "different entry is not duplicate" false
+    (Tool_trpg.is_narration_duplicate ~recent_replies:recent new_reply)
+
+let make_narration_entry ~actor_id ~reply =
+  `Assoc [ ("actor_id", `String actor_id); ("reply", `String reply) ]
+
+let test_deduplicate_narration_keeps_unique () =
+  let entries =
+    [
+      make_narration_entry ~actor_id:"p1" ~reply:"The hero draws his sword.";
+      make_narration_entry ~actor_id:"p2" ~reply:"The mage casts a spell.";
+      make_narration_entry ~actor_id:"dm" ~reply:"The dragon roars.";
+    ]
+  in
+  let deduped = Tool_trpg.deduplicate_narration entries in
+  Alcotest.(check int) "all 3 kept" 3 (List.length deduped)
+
+let test_deduplicate_narration_removes_duplicate () =
+  let entries =
+    [
+      make_narration_entry ~actor_id:"p1"
+        ~reply:"the hero draws his sword and charges forward";
+      make_narration_entry ~actor_id:"p1"
+        ~reply:"the hero draws his sword and charges forward bravely";
+      make_narration_entry ~actor_id:"p2"
+        ~reply:"the mage casts a powerful fireball at the enemy";
+    ]
+  in
+  let deduped = Tool_trpg.deduplicate_narration entries in
+  (* Second entry is ~89% Jaccard similar to first (8/9 words), exceeds 0.6 *)
+  Alcotest.(check int) "duplicate removed, 2 kept" 2 (List.length deduped)
+
+(* ================================================================
+   4. Truncated JSON recovery
+   ================================================================ *)
+
+let test_recover_truncated_brace () =
+  let raw = {|{"reply": "Hello world"|} in
+  match Tool_trpg.recover_truncated_json raw with
+  | Some json ->
+      let reply =
+        match json |> Yojson.Safe.Util.member "reply" with
+        | `String s -> s
+        | _ -> ""
+      in
+      Alcotest.(check string) "recovered reply" "Hello world" reply
+  | None -> Alcotest.fail "should have recovered truncated JSON"
+
+let test_recover_truncated_string () =
+  let raw = {|{"reply": "Hello|} in
+  match Tool_trpg.recover_truncated_json raw with
+  | Some json ->
+      let reply =
+        match json |> Yojson.Safe.Util.member "reply" with
+        | `String s -> s
+        | _ -> ""
+      in
+      Alcotest.(check string) "recovered truncated string" "Hello" reply
+  | None -> Alcotest.fail "should have recovered truncated string JSON"
+
+let test_recover_valid_json_returns_none () =
+  let raw = {|{"reply": "Hello"}|} in
+  match Tool_trpg.recover_truncated_json raw with
+  | None -> () (* Valid JSON should return None — not truncated *)
+  | Some _ -> Alcotest.fail "valid JSON should not need recovery"
+
+let test_recover_empty_string () =
+  match Tool_trpg.recover_truncated_json "" with
+  | None -> ()
+  | Some _ -> Alcotest.fail "empty string should return None"
+
+let test_parse_keeper_reply_raw_valid_json () =
+  let raw = {|{"reply": "I attack the goblin."}|} in
+  match Tool_trpg.parse_keeper_reply_raw raw with
+  | Ok reply ->
+      Alcotest.(check bool)
+        "contains attack" true
+        (String.length reply > 0)
+  | Error e -> Alcotest.fail ("expected Ok, got Error: " ^ e)
+
+let test_parse_keeper_reply_raw_truncated () =
+  let raw = {|{"reply": "I scout the area|} in
+  match Tool_trpg.parse_keeper_reply_raw raw with
+  | Ok reply ->
+      Alcotest.(check bool)
+        "recovered reply is nonempty" true
+        (String.length reply > 0)
+  | Error e -> Alcotest.fail ("expected recovery, got Error: " ^ e)
+
+let test_parse_keeper_reply_raw_plain_text () =
+  let raw = "I move to the north exit." in
+  match Tool_trpg.parse_keeper_reply_raw raw with
+  | Ok reply ->
+      Alcotest.(check string) "plain text treated as reply" raw reply
+  | Error e -> Alcotest.fail ("expected Ok, got Error: " ^ e)
+
+(* ================================================================
+   5. Prompt section display tests
+   ================================================================ *)
+
+let contains_substring s needle =
+  let s_len = String.length s in
+  let n_len = String.length needle in
+  let rec loop i =
+    if i + n_len > s_len then false
+    else if String.sub s i n_len = needle then true
+    else loop (i + 1)
+  in
+  if n_len = 0 then true else loop 0
+
+let test_build_player_section_ko_inventory () =
+  let ctx =
+    {
+      Tool_trpg.empty_prompt_context with
+      actor_name = "Hero";
+      actor_archetype = "warrior";
+      actor_inventory = [ "potion"; "rope" ];
+      actor_equipment = [ ("weapon", "sword"); ("armor", "plate") ];
+    }
+  in
+  let section = Tool_trpg.build_player_section_ko ctx in
+  Alcotest.(check bool) "contains equipment" true
+    (contains_substring section "sword");
+  Alcotest.(check bool) "contains inventory" true
+    (contains_substring section "potion")
+
+let test_build_player_section_en_inventory () =
+  let ctx =
+    {
+      Tool_trpg.empty_prompt_context with
+      actor_name = "Hero";
+      actor_archetype = "warrior";
+      actor_inventory = [ "potion"; "rope" ];
+      actor_equipment = [ ("weapon", "sword"); ("armor", "plate") ];
+    }
+  in
+  let section = Tool_trpg.build_player_section_en ctx in
+  Alcotest.(check bool) "contains Equipped" true
+    (contains_substring section "Equipped:");
+  Alcotest.(check bool) "contains Carrying" true
+    (contains_substring section "Carrying:")
+
+let test_build_player_section_ko_relationships () =
+  let ctx =
+    {
+      Tool_trpg.empty_prompt_context with
+      actor_name = "Hero";
+      relationships = [ ("Lyra", "ally"); ("Bron", "rival") ];
+    }
+  in
+  let section = Tool_trpg.build_player_section_ko ctx in
+  Alcotest.(check bool) "contains relationship" true
+    (contains_substring section "Lyra");
+  Alcotest.(check bool) "contains ally" true
+    (contains_substring section "ally")
+
+let test_build_player_section_en_relationships () =
+  let ctx =
+    {
+      Tool_trpg.empty_prompt_context with
+      actor_name = "Hero";
+      relationships = [ ("Lyra", "ally") ];
+    }
+  in
+  let section = Tool_trpg.build_player_section_en ctx in
+  Alcotest.(check bool) "contains Relationships" true
+    (contains_substring section "Relationships:");
+  Alcotest.(check bool) "contains ally" true
+    (contains_substring section "ally")
+
+(* ================================================================
+   Runner
+   ================================================================ *)
+
+let () =
+  Alcotest.run "Narrative Intelligence"
+    [
+      ( "equipment",
+        [
+          Alcotest.test_case "extract from assoc" `Quick
+            test_extract_equipment_from_assoc;
+          Alcotest.test_case "extract from list" `Quick
+            test_extract_equipment_from_list;
+          Alcotest.test_case "null actor" `Quick
+            test_extract_equipment_null_actor;
+          Alcotest.test_case "missing field" `Quick
+            test_extract_equipment_missing_field;
+          Alcotest.test_case "inventory in prompt_context" `Quick
+            test_inventory_in_prompt_context;
+        ] );
+      ( "relationships",
+        [
+          Alcotest.test_case "ally detection" `Quick
+            test_extract_relationships_ally;
+          Alcotest.test_case "rival detection" `Quick
+            test_extract_relationships_rival;
+          Alcotest.test_case "empty narration log" `Quick
+            test_extract_relationships_empty_log;
+        ] );
+      ( "deduplication",
+        [
+          Alcotest.test_case "jaccard identical" `Quick test_jaccard_identical;
+          Alcotest.test_case "jaccard disjoint" `Quick test_jaccard_disjoint;
+          Alcotest.test_case "jaccard partial" `Quick test_jaccard_partial;
+          Alcotest.test_case "duplicate detected" `Quick
+            test_is_narration_duplicate_true;
+          Alcotest.test_case "non-duplicate passes" `Quick
+            test_is_narration_duplicate_false;
+          Alcotest.test_case "unique entries kept" `Quick
+            test_deduplicate_narration_keeps_unique;
+          Alcotest.test_case "similar entries removed" `Quick
+            test_deduplicate_narration_removes_duplicate;
+        ] );
+      ( "truncated_json",
+        [
+          Alcotest.test_case "recover unclosed brace" `Quick
+            test_recover_truncated_brace;
+          Alcotest.test_case "recover unclosed string" `Quick
+            test_recover_truncated_string;
+          Alcotest.test_case "valid JSON returns None" `Quick
+            test_recover_valid_json_returns_none;
+          Alcotest.test_case "empty string returns None" `Quick
+            test_recover_empty_string;
+          Alcotest.test_case "parse_keeper_reply_raw valid" `Quick
+            test_parse_keeper_reply_raw_valid_json;
+          Alcotest.test_case "parse_keeper_reply_raw truncated" `Quick
+            test_parse_keeper_reply_raw_truncated;
+          Alcotest.test_case "parse_keeper_reply_raw plain text" `Quick
+            test_parse_keeper_reply_raw_plain_text;
+        ] );
+      ( "prompt_display",
+        [
+          Alcotest.test_case "ko inventory in prompt" `Quick
+            test_build_player_section_ko_inventory;
+          Alcotest.test_case "en inventory in prompt" `Quick
+            test_build_player_section_en_inventory;
+          Alcotest.test_case "ko relationships in prompt" `Quick
+            test_build_player_section_ko_relationships;
+          Alcotest.test_case "en relationships in prompt" `Quick
+            test_build_player_section_en_relationships;
+        ] );
+    ]


### PR DESCRIPTION
## Summary
- **Inventory/Equipment**: `prompt_context`에 `actor_inventory`, `actor_equipment` 필드 추가. Assoc/List 두 가지 JSON 형식 지원. 한/영 프롬프트에 장비 정보 표시.
- **Relationship tracking**: narration_log에서 키워드 기반 ally/rival/neutral 관계 추출. 프롬프트에 관계 정보 포함.
- **Narrative deduplication**: Jaccard similarity (>60% threshold)로 반복 나레이션 필터링. `deduplicate_narration`, `is_narration_duplicate` 함수 추가.
- **Truncated JSON recovery**: `parse_keeper_reply_raw`에서 닫히지 않은 braces/brackets/strings를 자동 복구 후 재파싱.

## Test plan
- [x] 26 new tests in `test/test_narrative_intelligence.ml` (equipment 5, relationships 3, dedup 7, truncated_json 7, prompt_display 4)
- [x] All 37 existing `test_tool_trpg_coverage` tests pass (no regression)
- [x] All 5 `test_trpg_rule_dnd5e_lite` tests pass
- [x] `dune build` clean, `make test` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)