### PR TITLE
fix(runtime): stabilize subprocess cwd and smoke harness round progression

### DIFF
--- a/bin/main_eio.ml
+++ b/bin/main_eio.ml
@@ -5357,7 +5357,9 @@ let run_server ~sw ~env ~port ~base_path =
   Council.Thread_persist.set_eio_context ~clock
     ~https_connector:(Masc_mcp.Eio_context.get_https_connector ())
     net;
-  Masc_mcp.Process_eio.init ~proc_mgr ~clock;
+  Masc_mcp.Process_eio.init
+    ~cwd_default:Eio.Path.(fs / base_path)
+    ~proc_mgr ~clock;
 
   (* Create Caqti-compatible stdenv adapter
      Note: net type coercion from [Generic|Unix] to [Generic] is safe

--- a/lib/process_eio.ml
+++ b/lib/process_eio.ml
@@ -13,10 +13,12 @@
 
 let _proc_mgr : Eio_unix.Process.mgr_ty Eio.Resource.t option ref = ref None
 let _clock : float Eio.Time.clock_ty Eio.Resource.t option ref = ref None
+let _cwd_default : Eio.Fs.dir_ty Eio.Path.t option ref = ref None
 
-let init ~proc_mgr ~clock =
+let init ~cwd_default ~proc_mgr ~clock =
   _proc_mgr := Some proc_mgr;
-  _clock := Some clock
+  _clock := Some clock;
+  _cwd_default := Some cwd_default
 
 let is_initialized () = Option.is_some !_proc_mgr
 
@@ -122,11 +124,12 @@ let run_argv ?(timeout_sec = 60.0) ?env (argv : string list) : string =
   if not (is_initialized ()) then run_unix_argv_fallback argv
   else
     let pm = get_proc_mgr () and clk = get_clock () in
+    let cwd = !_cwd_default in
     let buf = Buffer.create 1024 in
     let label = String.concat " " (List.map Filename.quote argv) in
     try
       Eio.Time.with_timeout_exn clk timeout_sec (fun () ->
-        Eio.Process.run pm ?env ~stdout:(Eio.Flow.buffer_sink buf) argv;
+        Eio.Process.run pm ?cwd ?env ~stdout:(Eio.Flow.buffer_sink buf) argv;
         Buffer.contents buf)
     with
     | Eio.Time.Timeout ->
@@ -140,11 +143,12 @@ let run_argv_with_stdin ?(timeout_sec = 60.0) ?env ~(stdin_content : string) (ar
   if not (is_initialized ()) then run_unix_argv_with_stdin_fallback ~stdin_content argv
   else
     let pm = get_proc_mgr () and clk = get_clock () in
+    let cwd = !_cwd_default in
     let buf = Buffer.create 1024 in
     let label = String.concat " " (List.map Filename.quote argv) in
     try
       Eio.Time.with_timeout_exn clk timeout_sec (fun () ->
-        Eio.Process.run pm ?env
+        Eio.Process.run pm ?cwd ?env
           ~stdin:(Eio.Flow.string_source stdin_content)
           ~stdout:(Eio.Flow.buffer_sink buf)
           argv;
@@ -165,13 +169,14 @@ let run_argv_with_stdin_and_status
   if not (is_initialized ()) then run_unix_argv_with_stdin_and_status_fallback ~stdin_content argv
   else
     let pm = get_proc_mgr () and clk = get_clock () in
+    let cwd = !_cwd_default in
     let buf = Buffer.create 1024 in
     let label = String.concat " " (List.map Filename.quote argv) in
     try
       Eio.Time.with_timeout_exn clk timeout_sec (fun () ->
         Eio.Switch.run (fun sw ->
           let proc =
-            Eio.Process.spawn ~sw pm ?env
+            Eio.Process.spawn ~sw pm ?cwd ?env
               ~stdin:(Eio.Flow.string_source stdin_content)
               ~stdout:(Eio.Flow.buffer_sink buf)
               argv
@@ -195,12 +200,15 @@ let run_argv_with_status ?(timeout_sec = 60.0) ?env (argv : string list) : Unix.
   if not (is_initialized ()) then run_unix_argv_with_status_fallback argv
   else
     let pm = get_proc_mgr () and clk = get_clock () in
+    let cwd = !_cwd_default in
     let buf = Buffer.create 1024 in
     let label = String.concat " " (List.map Filename.quote argv) in
     try
       Eio.Time.with_timeout_exn clk timeout_sec (fun () ->
         Eio.Switch.run (fun sw ->
-          let proc = Eio.Process.spawn ~sw pm ?env ~stdout:(Eio.Flow.buffer_sink buf) argv in
+          let proc =
+            Eio.Process.spawn ~sw pm ?cwd ?env ~stdout:(Eio.Flow.buffer_sink buf) argv
+          in
           let status = Eio.Process.await proc in
           let unix_status =
             match status with

--- a/lib/process_eio.mli
+++ b/lib/process_eio.mli
@@ -7,6 +7,7 @@
 (** {1 Global init (call once from main_eio.ml)} *)
 
 val init :
+  cwd_default:Eio.Fs.dir_ty Eio.Path.t ->
   proc_mgr:Eio_unix.Process.mgr_ty Eio.Resource.t ->
   clock:float Eio.Time.clock_ty Eio.Resource.t ->
   unit

--- a/scripts/harness/workload/trpg_grimland_smoke.sh
+++ b/scripts/harness/workload/trpg_grimland_smoke.sh
@@ -14,6 +14,7 @@ KEEPER_TAG="${KEEPER_TAG:-smoke-$(date +%s)}"
 DM_KEEPER="${DM_KEEPER:-dm-$KEEPER_TAG}"
 ROUND_TIMEOUT_SEC="${ROUND_TIMEOUT_SEC:-30}"
 KEEPER_MODELS="${KEEPER_MODELS:-}"
+ROUND_LOCAL_FALLBACK="${ROUND_LOCAL_FALLBACK:-1}"
 PLAYER_KEEPER_NAMES=""
 CLAIMED_ACTORS=""
 CURL_TIMEOUT_SEC="${CURL_TIMEOUT_SEC:-120}"
@@ -95,7 +96,7 @@ call_tool_checked() {
   local raw
   local err
   raw="$(call_tool "$id" "$name" "$args_json" "$timeout_sec" "$retry_count")"
-  if [ -z "$(printf "%s" "$raw" | tr -d '[:space:]')" ]; then
+  if [ -z "$(printf "%s" "$raw" | LC_ALL=C tr -d '[:space:]')" ]; then
     echo "FAIL: $name: empty response from MCP" >&2
     exit 1
   fi
@@ -131,6 +132,13 @@ build_models_json() {
     | map(gsub("^\\s+|\\s+$";""))
     | map(select(length > 0))
   '
+}
+
+bool_to_json() {
+  case "${1:-}" in
+    1|true|TRUE|yes|YES|on|ON) printf "true" ;;
+    *) printf "false" ;;
+  esac
 }
 
 echo "[bootstrap] trpg.pool.generate"
@@ -192,10 +200,11 @@ echo "[bootstrap] room_id=$room_id world_preset=$world_used dm_preset=$dm_used"
 
 if [ "$RUN_ROUND" = "1" ]; then
   echo "[round] RUN_ROUND=1, executing $ROUNDS rounds"
+  round_local_fallback_json="$(bool_to_json "$ROUND_LOCAL_FALLBACK")"
   i=1
   while [ "$i" -le "$ROUNDS" ]; do
     echo "  - round $i"
-    args_round="$(jq -cn --argjson t "$round_template" --argjson timeout "$ROUND_TIMEOUT_SEC" '{room_id:$t.room_id,dm_keeper:$t.dm_keeper,player_keepers:$t.player_keepers,phase:"round",timeout_sec:$timeout,require_claim:true}')"
+    args_round="$(jq -cn --argjson t "$round_template" --argjson timeout "$ROUND_TIMEOUT_SEC" --argjson local_fallback "$round_local_fallback_json" '{room_id:$t.room_id,dm_keeper:$t.dm_keeper,player_keepers:$t.player_keepers,phase:"round",timeout_sec:$timeout,require_claim:true,local_fallback:$local_fallback}')"
     r_round="$(call_tool_checked $((4000 + i)) "trpg.round.run" "$args_round" "$ROUND_HTTP_TIMEOUT_SEC" "1")"
     advanced="$(printf "%s" "$r_round" | payload | jq -r '.summary.advanced // empty')"
     if [ "$advanced" = "false" ]; then

--- a/scripts/viewer-local-e2e-check.sh
+++ b/scripts/viewer-local-e2e-check.sh
@@ -135,7 +135,7 @@ step_check_mcp() {
       -H 'Content-Type: application/json' \
       -H 'Accept: application/json, text/event-stream' \
       -d '{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}')"; then
-      if [ -n "$(printf "%s" "$response" | tr -d '[:space:]')" ]; then
+      if [ -n "$(printf "%s" "$response" | LC_ALL=C tr -d '[:space:]')" ]; then
         return 0
       fi
     fi


### PR DESCRIPTION
## Summary
- pin Eio subprocess cwd to `base_path` via `Process_eio.init ~cwd_default` to avoid CLI failures when original working directory disappears
- pass default cwd through all Process_eio run/spawn helpers
- harden smoke harness round path by enabling configurable `ROUND_LOCAL_FALLBACK` (default on) for `trpg.round.run`
- make harness whitespace checks locale-safe (`LC_ALL=C tr`) to avoid illegal byte sequence errors

## Validation
- `dune build --root . @default`
- `dune exec --root . test/test_tool_trpg_coverage.exe`
- `dune exec --root . test/test_protocol_game_view.exe`
- `MCP_URL=http://127.0.0.1:8940/mcp scripts/viewer-local-e2e-check.sh`
- `MCP_URL=http://127.0.0.1:8940/mcp scripts/viewer-local-e2e-check.sh --run-smoke --keeper-models "ollama:glm-4.7-flash"`
- `MCP_URL=http://127.0.0.1:8940/mcp scripts/viewer-local-e2e-check.sh --run-round --rounds 1 --round-timeout-sec 20 --party-size 1 --pool-size 1 --keeper-models "ollama:glm-4.7-flash"`

## Notes
- full 4-player round smoke can still be latency-heavy depending on keeper model responsiveness; harness now has fallback safety for round progression.
