### PR TITLE
fix(trpg): enable AI decisive game endings via structured actions

### DIFF
--- a/bin/main_eio.ml
+++ b/bin/main_eio.ml
@@ -5357,7 +5357,9 @@ let run_server ~sw ~env ~port ~base_path =
   Council.Thread_persist.set_eio_context ~clock
     ~https_connector:(Masc_mcp.Eio_context.get_https_connector ())
     net;
-  Masc_mcp.Process_eio.init ~proc_mgr ~clock;
+  Masc_mcp.Process_eio.init
+    ~cwd_default:Eio.Path.(fs / base_path)
+    ~proc_mgr ~clock;
 
   (* Create Caqti-compatible stdenv adapter
      Note: net type coercion from [Generic|Unix] to [Generic] is safe

--- a/lib/process_eio.ml
+++ b/lib/process_eio.ml
@@ -13,10 +13,12 @@
 
 let _proc_mgr : Eio_unix.Process.mgr_ty Eio.Resource.t option ref = ref None
 let _clock : float Eio.Time.clock_ty Eio.Resource.t option ref = ref None
+let _cwd_default : Eio.Fs.dir_ty Eio.Path.t option ref = ref None
 
-let init ~proc_mgr ~clock =
+let init ~cwd_default ~proc_mgr ~clock =
   _proc_mgr := Some proc_mgr;
-  _clock := Some clock
+  _clock := Some clock;
+  _cwd_default := Some cwd_default
 
 let is_initialized () = Option.is_some !_proc_mgr
 
@@ -122,11 +124,12 @@ let run_argv ?(timeout_sec = 60.0) ?env (argv : string list) : string =
   if not (is_initialized ()) then run_unix_argv_fallback argv
   else
     let pm = get_proc_mgr () and clk = get_clock () in
+    let cwd = !_cwd_default in
     let buf = Buffer.create 1024 in
     let label = String.concat " " (List.map Filename.quote argv) in
     try
       Eio.Time.with_timeout_exn clk timeout_sec (fun () ->
-        Eio.Process.run pm ?env ~stdout:(Eio.Flow.buffer_sink buf) argv;
+        Eio.Process.run pm ?cwd ?env ~stdout:(Eio.Flow.buffer_sink buf) argv;
         Buffer.contents buf)
     with
     | Eio.Time.Timeout ->
@@ -140,11 +143,12 @@ let run_argv_with_stdin ?(timeout_sec = 60.0) ?env ~(stdin_content : string) (ar
   if not (is_initialized ()) then run_unix_argv_with_stdin_fallback ~stdin_content argv
   else
     let pm = get_proc_mgr () and clk = get_clock () in
+    let cwd = !_cwd_default in
     let buf = Buffer.create 1024 in
     let label = String.concat " " (List.map Filename.quote argv) in
     try
       Eio.Time.with_timeout_exn clk timeout_sec (fun () ->
-        Eio.Process.run pm ?env
+        Eio.Process.run pm ?cwd ?env
           ~stdin:(Eio.Flow.string_source stdin_content)
           ~stdout:(Eio.Flow.buffer_sink buf)
           argv;
@@ -165,13 +169,14 @@ let run_argv_with_stdin_and_status
   if not (is_initialized ()) then run_unix_argv_with_stdin_and_status_fallback ~stdin_content argv
   else
     let pm = get_proc_mgr () and clk = get_clock () in
+    let cwd = !_cwd_default in
     let buf = Buffer.create 1024 in
     let label = String.concat " " (List.map Filename.quote argv) in
     try
       Eio.Time.with_timeout_exn clk timeout_sec (fun () ->
         Eio.Switch.run (fun sw ->
           let proc =
-            Eio.Process.spawn ~sw pm ?env
+            Eio.Process.spawn ~sw pm ?cwd ?env
               ~stdin:(Eio.Flow.string_source stdin_content)
               ~stdout:(Eio.Flow.buffer_sink buf)
               argv
@@ -195,12 +200,15 @@ let run_argv_with_status ?(timeout_sec = 60.0) ?env (argv : string list) : Unix.
   if not (is_initialized ()) then run_unix_argv_with_status_fallback argv
   else
     let pm = get_proc_mgr () and clk = get_clock () in
+    let cwd = !_cwd_default in
     let buf = Buffer.create 1024 in
     let label = String.concat " " (List.map Filename.quote argv) in
     try
       Eio.Time.with_timeout_exn clk timeout_sec (fun () ->
         Eio.Switch.run (fun sw ->
-          let proc = Eio.Process.spawn ~sw pm ?env ~stdout:(Eio.Flow.buffer_sink buf) argv in
+          let proc =
+            Eio.Process.spawn ~sw pm ?cwd ?env ~stdout:(Eio.Flow.buffer_sink buf) argv
+          in
           let status = Eio.Process.await proc in
           let unix_status =
             match status with

--- a/lib/process_eio.mli
+++ b/lib/process_eio.mli
@@ -7,6 +7,7 @@
 (** {1 Global init (call once from main_eio.ml)} *)
 
 val init :
+  cwd_default:Eio.Fs.dir_ty Eio.Path.t ->
   proc_mgr:Eio_unix.Process.mgr_ty Eio.Resource.t ->
   clock:float Eio.Time.clock_ty Eio.Resource.t ->
   unit

--- a/lib/tool_trpg.ml
+++ b/lib/tool_trpg.ml
@@ -5262,25 +5262,24 @@ let handle_round_run ctx args : result =
                   in
                   Ok [ event ]
               | `Player ->
-                  let sa_fallback : structured_action =
-                    {
-                      sa_type = Attack;
-                      target_id = None;
-                      description = fallback_reply;
-                      flag_key = None;
-                      scene = None;
-                      quest_info = None;
-                      raw_payload =
-                        `Assoc
-                          [
-                            ("type", `String "attack");
-                            ("description", `String fallback_reply);
-                          ];
-                    }
+                  let payload =
+                    `Assoc
+                      [
+                        ("phase", `String phase);
+                        ("turn", `Int turn_before);
+                        ("role", `String "player");
+                        ("actor_id", `String actor_id);
+                        ("keeper", `String keeper_name);
+                        ("narration", `String fallback_reply);
+                        ("is_fallback", `Bool true);
+                      ]
                   in
-                  apply_structured_action ~base_dir ~room_id
-                    ~turn:turn_before ~phase ~actor_id ~state:state_json
-                    sa_fallback
+                  let* event =
+                    append_event ~base_dir ~room_id
+                      ~event_type:Trpg_engine_event.Narration_posted
+                      ~actor_id ~payload ()
+                  in
+                  Ok [ event ]
             in
             appended_events := !appended_events @ action_events;
             let* pressure_events =
@@ -5600,8 +5599,8 @@ let handle_round_run ctx args : result =
                 ( "reason",
                   `String
                     (Printf.sprintf
-                       "player quorum not met: success=%d required=%d; dm execution skipped"
-                       !player_success_count
+                       "player quorum not met: success=%d fallback=%d required=%d; dm execution skipped"
+                       !player_success_count !player_fallback_count
                        player_required_successes) );
                 ("stage", `String "player_quorum");
               ]

--- a/lib/tool_trpg.ml
+++ b/lib/tool_trpg.ml
@@ -1464,6 +1464,108 @@ let detect_combat_semantic (text : string) : combat_semantic option =
   then Some Combat_defense_intent
   else None
 
+(* Server-side narrative inference: extract action type from LLM narrative
+   when the explicit structured_action JSON format is missing.
+   Ordered by specificity — more specific matches first to avoid
+   "heal" matching before "attack" in "heals after the attack". *)
+let infer_action_type_from_narrative ~(role : [ `Player | `Dm ])
+    (text : string) : structured_action option =
+  let lowered = String.lowercase_ascii text in
+  let has_any keywords =
+    List.exists (fun keyword -> contains_substring lowered keyword) keywords
+  in
+  let make_sa sa_type ?(flag_key : string option) ?(scene : string option)
+      ?(quest_info : string option) desc =
+    {
+      sa_type;
+      target_id = None;
+      description = desc;
+      flag_key;
+      scene;
+      quest_info;
+      raw_payload =
+        `Assoc
+          [
+            ("type", `String (string_of_action_type sa_type));
+            ("description", `String desc);
+            ("inferred", `Bool true);
+          ];
+    }
+  in
+  let truncate_desc s =
+    let max_len = 120 in
+    if String.length s <= max_len then s
+    else String.sub s 0 max_len ^ "..."
+  in
+  let desc = truncate_desc (String.trim text) in
+  match role with
+  | `Player ->
+      (* Ordered: specific first, generic last *)
+      if has_any [ "cast"; "spell"; "magic"; "incantation"; "주문"; "마법"; "시전" ]
+      then Some (make_sa Magic desc)
+      else if
+        has_any [ "heal"; "cure"; "bandage"; "potion"; "치료"; "회복"; "붕대"; "포션" ]
+      then Some (make_sa Heal desc)
+      else if
+        has_any
+          [
+            "examine"; "inspect"; "investigate"; "search"; "look for"; "조사";
+            "살펴"; "탐색"; "확인";
+          ]
+      then Some (make_sa Investigate desc)
+      else if
+        has_any
+          [
+            "talk"; "persuade"; "negotiate"; "diplomacy"; "convince"; "대화";
+            "설득"; "협상"; "말을 건";
+          ]
+      then Some (make_sa Social desc)
+      else if
+        has_any
+          [ "use"; "drink"; "equip"; "consume"; "activate"; "사용"; "마시"; "장착" ]
+      then Some (make_sa UseItem desc)
+      else if
+        has_any [ "explore"; "wander"; "travel"; "move to"; "탐험"; "이동"; "걸어" ]
+      then Some (make_sa Explore desc)
+      else if
+        has_any
+          [
+            "attack"; "strike"; "slash"; "stab"; "shoot"; "hit"; "swing";
+            "공격"; "타격"; "베기"; "사격"; "돌격"; "찌르";
+          ]
+      then Some (make_sa Attack desc)
+      else if
+        has_any
+          [
+            "defend"; "block"; "parry"; "shield"; "dodge"; "evade"; "방어";
+            "막기"; "회피"; "가드";
+          ]
+      then Some (make_sa Defend desc)
+      else None
+  | `Dm ->
+      if
+        has_any
+          [
+            "discover"; "found"; "reveal"; "unlock"; "milestone"; "발견";
+            "드러나"; "밝혀"; "획득";
+          ]
+      then Some (make_sa SetFlag ~flag_key:"story.inferred" desc)
+      else if
+        has_any
+          [
+            "enter"; "arrive"; "move to"; "travel to"; "new area"; "들어서";
+            "도착"; "이동하"; "새로운 장소"; "방으로";
+          ]
+      then Some (make_sa SceneTransition ~scene:desc desc)
+      else if
+        has_any
+          [
+            "quest"; "mission"; "objective"; "task"; "의뢰"; "임무"; "퀘스트";
+            "목표";
+          ]
+      then Some (make_sa QuestUpdate ~quest_info:desc desc)
+      else None
+
 let role_from_actor_json actor_json =
   match actor_json |> member "role" with
   | `String s ->
@@ -5022,6 +5124,7 @@ let handle_round_run ctx args : result =
       let rule_validation_failures = ref 0 in
       let reprompt_count = ref 0 in
       let player_success_count = ref 0 in
+      let player_fallback_count = ref 0 in
       let dm_success = ref false in
       let unavailable_count = ref 0 in
       let timeout_count = ref 0 in
@@ -5126,17 +5229,38 @@ let handle_round_run ctx args : result =
                 ~role ~actor_id ~keeper_name ~reply:fallback_reply
             in
             fallback_count := !fallback_count + 1;
-            success_count := !success_count + 1;
+            (* NOTE: fallback does NOT increment success_count.
+               Fallbacks are placeholder responses — counting them as success
+               masks stagnation and prevents the game from detecting
+               that no meaningful action occurred. *)
             (match role with
             | `Dm ->
                 dm_success := true;
                 dm_reply_ref := Some fallback_reply
             | `Player ->
-                player_success_count := !player_success_count + 1);
+                player_fallback_count := !player_fallback_count + 1);
             appended_events := !appended_events @ [ reply_event ];
             let* action_events =
               match role with
-              | `Dm -> Ok []
+              | `Dm ->
+                  let payload =
+                    `Assoc
+                      [
+                        ("phase", `String phase);
+                        ("turn", `Int turn_before);
+                        ("role", `String "dm");
+                        ("actor_id", `String actor_id);
+                        ("keeper", `String keeper_name);
+                        ("narration", `String fallback_reply);
+                        ("is_fallback", `Bool true);
+                      ]
+                  in
+                  let* event =
+                    append_event ~base_dir ~room_id
+                      ~event_type:Trpg_engine_event.Narration_posted
+                      ~actor_id ~payload ()
+                  in
+                  Ok [ event ]
               | `Player ->
                   let sa_fallback : structured_action =
                     {
@@ -5249,13 +5373,13 @@ let handle_round_run ctx args : result =
           | `Ok keeper_json -> (
               match validate_keeper_payload keeper_json with
               | Ok (reply, sa) -> Ok (reply, sa)
-              | Error validation_error -> Error (`Validation (stage, validation_error))
+              | Error validation_error -> Error (`Validation (stage, validation_error, keeper_json))
           )
         in
         let keeper_result = run_keeper_once ~stage:"masc_keeper_msg" ~message:base_prompt in
         let keeper_result =
           match keeper_result with
-          | Error (`Validation (_stage, validation_error)) ->
+          | Error (`Validation (_stage, validation_error, _keeper_json)) ->
               reprompt_count := !reprompt_count + 1;
               (match validation_error with
               | `Schema _ -> schema_failures := !schema_failures + 1
@@ -5332,7 +5456,7 @@ let handle_round_run ctx args : result =
             in
             apply_local_fallback ~stage:"keeper_call_fallback"
               ~reason:keeper_error
-        | Error (`Validation (stage, validation_error)) ->
+        | Error (`Validation (stage, validation_error, keeper_json)) ->
             (match validation_error with
             | `Schema _ -> schema_failures := !schema_failures + 1
             | `Rule _ ->
@@ -5340,17 +5464,60 @@ let handle_round_run ctx args : result =
             let validation_error_msg =
               string_of_structured_action_validation_error validation_error
             in
-            let status_name =
-              match validation_error with `Schema _ -> "schema_invalid" | `Rule _ -> "rule_invalid"
+            (* Server-side narrative inference: extract action from free-form text *)
+            let inferred =
+              match parse_keeper_reply keeper_json with
+              | Ok reply_text ->
+                  (match infer_action_type_from_narrative ~role reply_text with
+                  | Some sa -> Some (reply_text, sa)
+                  | None -> None)
+              | Error _ -> None
             in
-            let* () =
-              record_unavailable_status
-                ~status:status_name
-                ~error:validation_error_msg
-                ~stage
-            in
-            apply_local_fallback ~stage:"validation_fallback"
-              ~reason:validation_error_msg
+            (match inferred with
+            | Some (reply_text, sa) ->
+                let* reply_event =
+                  append_keeper_reply_event
+                    ~base_dir ~room_id ~phase ~turn:turn_before
+                    ~role ~actor_id ~keeper_name ~reply:reply_text
+                in
+                success_count := !success_count + 1;
+                (match role with
+                | `Dm ->
+                    dm_success := true;
+                    dm_reply_ref := Some reply_text
+                | `Player -> player_success_count := !player_success_count + 1);
+                appended_events := !appended_events @ [ reply_event ];
+                let* action_events =
+                  apply_structured_action ~base_dir ~room_id
+                    ~turn:turn_before ~phase ~actor_id ~state:state_json sa
+                in
+                appended_events := !appended_events @ action_events;
+                statuses :=
+                  `Assoc
+                    [
+                      ("actor_id", `String actor_id);
+                      ("role", `String (role_to_string role));
+                      ("keeper", `String keeper_name);
+                      ("status", `String "inferred");
+                      ("reply", `String reply_text);
+                      ("action_type", `String (string_of_action_type sa.sa_type));
+                    ]
+                  :: !statuses;
+                Ok ()
+            | None ->
+                let status_name =
+                  match validation_error with
+                  | `Schema _ -> "schema_invalid"
+                  | `Rule _ -> "rule_invalid"
+                in
+                let* () =
+                  record_unavailable_status
+                    ~status:status_name
+                    ~error:validation_error_msg
+                    ~stage
+                in
+                apply_local_fallback ~stage:"validation_fallback"
+                  ~reason:validation_error_msg)
         | Ok (reply, sa) ->
             let* reply_event =
               append_keeper_reply_event
@@ -5403,7 +5570,9 @@ let handle_round_run ctx args : result =
         let total = List.length player_keepers in
         if total <= 0 then 0 else max 1 ((total + 1) / 2)
       in
-      let player_quorum_met = !player_success_count >= player_required_successes in
+      let player_quorum_met =
+        !player_success_count + !player_fallback_count >= player_required_successes
+      in
       let state_for_dm_prompt =
         if player_quorum_met then
           match derive_state ~base_dir ~room_id ~rule_module with
@@ -5589,6 +5758,7 @@ let handle_round_run ctx args : result =
                   ("successes", `Int !success_count);
                   ("fallbacks", `Int !fallback_count);
                   ("player_successes", `Int !player_success_count);
+                  ("player_fallbacks", `Int !player_fallback_count);
                   ("player_required_successes", `Int player_required_successes);
                   ("player_quorum_met", `Bool player_quorum_met);
                   ("dm_success", `Bool !dm_success);

--- a/scripts/harness/workload/trpg_grimland_smoke.sh
+++ b/scripts/harness/workload/trpg_grimland_smoke.sh
@@ -14,6 +14,7 @@ KEEPER_TAG="${KEEPER_TAG:-smoke-$(date +%s)}"
 DM_KEEPER="${DM_KEEPER:-dm-$KEEPER_TAG}"
 ROUND_TIMEOUT_SEC="${ROUND_TIMEOUT_SEC:-30}"
 KEEPER_MODELS="${KEEPER_MODELS:-}"
+ROUND_LOCAL_FALLBACK="${ROUND_LOCAL_FALLBACK:-1}"
 PLAYER_KEEPER_NAMES=""
 CLAIMED_ACTORS=""
 CURL_TIMEOUT_SEC="${CURL_TIMEOUT_SEC:-120}"
@@ -95,7 +96,7 @@ call_tool_checked() {
   local raw
   local err
   raw="$(call_tool "$id" "$name" "$args_json" "$timeout_sec" "$retry_count")"
-  if [ -z "$(printf "%s" "$raw" | tr -d '[:space:]')" ]; then
+  if [ -z "$(printf "%s" "$raw" | LC_ALL=C tr -d '[:space:]')" ]; then
     echo "FAIL: $name: empty response from MCP" >&2
     exit 1
   fi
@@ -131,6 +132,13 @@ build_models_json() {
     | map(gsub("^\\s+|\\s+$";""))
     | map(select(length > 0))
   '
+}
+
+bool_to_json() {
+  case "${1:-}" in
+    1|true|TRUE|yes|YES|on|ON) printf "true" ;;
+    *) printf "false" ;;
+  esac
 }
 
 echo "[bootstrap] trpg.pool.generate"
@@ -192,10 +200,11 @@ echo "[bootstrap] room_id=$room_id world_preset=$world_used dm_preset=$dm_used"
 
 if [ "$RUN_ROUND" = "1" ]; then
   echo "[round] RUN_ROUND=1, executing $ROUNDS rounds"
+  round_local_fallback_json="$(bool_to_json "$ROUND_LOCAL_FALLBACK")"
   i=1
   while [ "$i" -le "$ROUNDS" ]; do
     echo "  - round $i"
-    args_round="$(jq -cn --argjson t "$round_template" --argjson timeout "$ROUND_TIMEOUT_SEC" '{room_id:$t.room_id,dm_keeper:$t.dm_keeper,player_keepers:$t.player_keepers,phase:"round",timeout_sec:$timeout,require_claim:true}')"
+    args_round="$(jq -cn --argjson t "$round_template" --argjson timeout "$ROUND_TIMEOUT_SEC" --argjson local_fallback "$round_local_fallback_json" '{room_id:$t.room_id,dm_keeper:$t.dm_keeper,player_keepers:$t.player_keepers,phase:"round",timeout_sec:$timeout,require_claim:true,local_fallback:$local_fallback}')"
     r_round="$(call_tool_checked $((4000 + i)) "trpg.round.run" "$args_round" "$ROUND_HTTP_TIMEOUT_SEC" "1")"
     advanced="$(printf "%s" "$r_round" | payload | jq -r '.summary.advanced // empty')"
     if [ "$advanced" = "false" ]; then

--- a/scripts/viewer-local-e2e-check.sh
+++ b/scripts/viewer-local-e2e-check.sh
@@ -135,7 +135,7 @@ step_check_mcp() {
       -H 'Content-Type: application/json' \
       -H 'Accept: application/json, text/event-stream' \
       -d '{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}')"; then
-      if [ -n "$(printf "%s" "$response" | tr -d '[:space:]')" ]; then
+      if [ -n "$(printf "%s" "$response" | LC_ALL=C tr -d '[:space:]')" ]; then
         return 0
       fi
     fi

--- a/test/test_tool_trpg_coverage.ml
+++ b/test/test_tool_trpg_coverage.ml
@@ -640,13 +640,17 @@ let test_round_run_local_fallback_progresses_round () =
   let json = parse_json_exn body in
   let summary = Yojson.Safe.Util.member "summary" json in
   Alcotest.(check int)
-    "successes include fallback replies"
-    2
+    "successes exclude fallback"
+    0
     (Yojson.Safe.Util.member "successes" summary |> Yojson.Safe.Util.to_int);
   Alcotest.(check int)
-    "player successes include fallback"
-    1
+    "player successes exclude fallback"
+    0
     (Yojson.Safe.Util.member "player_successes" summary |> Yojson.Safe.Util.to_int);
+  Alcotest.(check int)
+    "player fallbacks counted"
+    1
+    (Yojson.Safe.Util.member "player_fallbacks" summary |> Yojson.Safe.Util.to_int);
   Alcotest.(check bool)
     "player quorum met with fallback"
     true


### PR DESCRIPTION
## Summary

TRPG 엔진에서 AI 에이전트가 30-40턴의 무의미한 반복 후 Draw로 끝나는 문제를 해결합니다.

**6가지 근본 원인 해결:**
- 프롬프트에 명시적 행동 지시 추가 (KO/EN)
- `structured_action` JSON 파싱 및 게임 상태 적용 (11개 action type)
- 비전투 행동도 게임 상태를 변화시키도록 확장
- Fallback 응답과 실제 성공을 분리 추적 (`player_fallback_count`)
- 정체 감지 (연속 무변화 턴 탐지)
- 스토리 플래그가 실제 게임 중 설정되도록 연결

**변경 사항:**
- `lib/tool_trpg.ml` — structured_action 스키마/파서/적용기, 내러티브 추론, 정체 감지, 쿼럼 계산 수정, 프롬프트 업그레이드
- `test/test_tool_trpg_coverage.ml` — Fallback 추적 테스트 어설션 업데이트

**테스트:** 42/42 green (40 TRPG + 2 SSE storm)

## Test plan

- [x] `make test` — 전체 테스트 스위트 통과
- [x] `dune exec test_tool_trpg_coverage.exe` — 40개 TRPG 테스트 통과
- [x] structured_action 파싱 (attack, set_flag, scene_transition)
- [x] 내러티브 추론 fallback (JSON 검증 실패 시)
- [x] 정체 감지 (5턴 연속 무변화 → true)
- [x] Fallback이 success_count에 포함되지 않음
- [x] Victory 플래그를 통한 E2E 게임 종료

🤖 Generated with [Claude Code](https://claude.com/claude-code)