### PR TITLE
fix(perpetual): add Eio runtime to standalone CLI

### DIFF
--- a/bin/perpetual_cli.ml
+++ b/bin/perpetual_cli.ml
@@ -174,6 +174,15 @@ let () =
     (args.compact_at *. 100.0) (args.handoff_at *. 100.0);
   eprintf "---\n%!";
 
+  (* Run inside Eio runtime — required for Eio.Semaphore (llm_client)
+     and Process_eio subprocess management *)
+  Eio_main.run @@ fun env ->
+  let proc_mgr = Eio.Stdenv.process_mgr env in
+  let clock = Eio.Stdenv.clock env in
+  let fs = Eio.Stdenv.fs env in
+  let cwd = Eio.Path.(fs / Sys.getcwd ()) in
+  Process_eio.init ~cwd_default:cwd ~proc_mgr ~clock;
+
   let state = Perpetual_loop.create_state config in
   Perpetual_loop.run ~config ~state;
 


### PR DESCRIPTION
## Summary

- `perpetual_cli.exe`가 첫 LLM 호출에서 무한 대기하는 버그 수정
- 원인: `llm_client.ml`의 `Eio.Semaphore.acquire`가 Eio 스케줄러 없이 OS 스레드를 블로킹
- `Eio_main.run` 래퍼 + `Process_eio.init` 추가 (`main_eio.ml` 패턴 동일)

## Test plan

- [x] 103/103 unit tests pass (`test_perpetual.exe`)
- [x] CLI E2E: `--goal "Write a haiku" --models "ollama:glm-4.7-flash" --no-verify` — 2 turns, ~3s 완료
- [x] `dune build` clean (exit 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)