### PR TITLE
fix(trpg): prevent stale round-runner DOM state from locking UI

### DIFF
--- a/viewer/src/dom/turn_controls.rs
+++ b/viewer/src/dom/turn_controls.rs
@@ -228,7 +228,18 @@ fn derive_trpg_ui_state(
     if !connection_ok || matches!(lifecycle, TrpgLifecycleState::Unavailable) {
         return TrpgUiState::Error;
     }
-    if round_running {
+    // Only honour round_running when the session is actually active.
+    // Stale DOM attributes (data-round-runner-active) can persist after a
+    // session ends abnormally, locking the UI in RoundRunning even though
+    // the lifecycle has returned to Lobby/Ended.
+    if round_running
+        && !matches!(
+            lifecycle,
+            TrpgLifecycleState::Lobby
+                | TrpgLifecycleState::Ended
+                | TrpgLifecycleState::Unknown
+        )
+    {
         return TrpgUiState::RoundRunning;
     }
     if wizard_busy || matches!(lifecycle, TrpgLifecycleState::Loading) {
@@ -409,6 +420,22 @@ pub fn sync_turn_controls_visibility(
         let (mut can_run, mut reason, mut reason_class) =
             derive_round_control_state(lifecycle, connection_ok, plan_error.as_deref());
         let lock_owner = current_round_flight_owner(&doc);
+
+        // ── Stale DOM cleanup ──────────────────────────────────────────
+        // When the lifecycle has returned to a terminal state (Lobby or
+        // Ended), any lingering round-runner / flight-owner DOM flags are
+        // stale leftovers from a previous session that ended abnormally.
+        // Force-clear them so the UI is not permanently locked.
+        if matches!(
+            lifecycle,
+            TrpgLifecycleState::Lobby | TrpgLifecycleState::Ended
+        ) {
+            if let Some(dashboard) = doc.get_element_by_id("dashboard") {
+                let _ = dashboard.set_attribute("data-round-runner-active", "0");
+                let _ = dashboard.remove_attribute("data-round-flight-owner");
+            }
+        }
+
         let runner_active = auto_round_runner_active(&doc);
         if runner_active {
             can_run = false;
@@ -2021,6 +2048,48 @@ mod tests {
         let state =
             derive_trpg_ui_state(TrpgLifecycleState::Lobby, true, false, false, true, false);
         assert_eq!(state, TrpgUiState::Lobby);
+    }
+
+    /// Stale `data-round-runner-active` DOM attribute must NOT lock the UI
+    /// when lifecycle has returned to Lobby (e.g. after abnormal session end).
+    #[test]
+    fn derive_trpg_ui_state_ignores_stale_round_running_in_lobby() {
+        // round_running=true but lifecycle=Lobby → should NOT be RoundRunning
+        let state =
+            derive_trpg_ui_state(TrpgLifecycleState::Lobby, true, false, true, true, true);
+        assert_ne!(state, TrpgUiState::RoundRunning);
+        // With preflight+wizard ready, it should be ConfigReady
+        assert_eq!(state, TrpgUiState::ConfigReady);
+    }
+
+    /// Same stale-state protection for Ended lifecycle.
+    #[test]
+    fn derive_trpg_ui_state_ignores_stale_round_running_in_ended() {
+        let state =
+            derive_trpg_ui_state(TrpgLifecycleState::Ended, true, false, true, true, true);
+        assert_ne!(state, TrpgUiState::RoundRunning);
+        assert_eq!(state, TrpgUiState::Ended);
+    }
+
+    /// round_running in Unknown lifecycle should also be ignored.
+    #[test]
+    fn derive_trpg_ui_state_ignores_stale_round_running_in_unknown() {
+        let state =
+            derive_trpg_ui_state(TrpgLifecycleState::Unknown, true, false, false, false, true);
+        assert_ne!(state, TrpgUiState::RoundRunning);
+        assert_eq!(state, TrpgUiState::Lobby);
+    }
+
+    /// round_running in Running lifecycle should still be honoured.
+    #[test]
+    fn derive_trpg_ui_state_honours_round_running_when_active() {
+        let state =
+            derive_trpg_ui_state(TrpgLifecycleState::Running, true, false, true, true, true);
+        assert_eq!(state, TrpgUiState::RoundRunning);
+
+        let state =
+            derive_trpg_ui_state(TrpgLifecycleState::Stopped, true, false, true, true, true);
+        assert_eq!(state, TrpgUiState::RoundRunning);
     }
 
     #[test]


### PR DESCRIPTION
## 요약

TRPG 세션이 비정상 종료된 후 UI가 "시작 대기: 현재 라운드 실행 중 상태입니다"로 잠기는 버그를 수정합니다.

### 근본 원인

- `room.ended` 이후 도착하는 orphan 이벤트가 `set_dom_runner_active(true)`를 호출
- `data-round-runner-active="1"` DOM 속성이 영구적으로 남음
- `derive_trpg_ui_state()`가 lifecycle 상태와 무관하게 `RoundRunning`을 반환
- 모든 UI 버튼이 비활성화되어 새 세션 시작 불가

### 수정 내용

1. **`derive_trpg_ui_state()`**: lifecycle이 Lobby/Ended/Unknown일 때 `round_running` 플래그를 무시 (출력 방어)
2. **`sync_turn_controls_visibility()`**: lifecycle이 Lobby/Ended일 때 stale DOM 속성(`data-round-runner-active`, `data-round-flight-owner`)을 자동 클리어 (입력 정화)

### 테스트

- 4개 신규 unit test 추가 (stale state 시나리오 + active session 보존 확인)
- `cargo test` 123 passed; 0 failed

## Test plan
- [ ] `cargo test` 통과 확인
- [ ] 로컬에서 TRPG 세션 시작 → 비정상 종료 → Lobby 복귀 시 UI 정상 동작 확인
- [ ] 정상 세션 중 round_running이 올바르게 RoundRunning 상태를 반환하는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)