### PR TITLE
refactor: migrate RAILWAY_PG_URL to SUPABASE_DB_URL

### DIFF
--- a/lib/jiphyeon/archive.ml
+++ b/lib/jiphyeon/archive.ml
@@ -93,12 +93,12 @@ let get_neo4j_url () =
   Sys.getenv_opt "RAILWAY_NEO4J_URL"
 
 let get_postgres_url () =
-  (* Try multiple env vars: DATABASE_URL, RAILWAY_PG_URL, RAILWAY_POSTGRES_URL *)
+  (* Try multiple env vars: DATABASE_URL, SUPABASE_DB_URL, SB_PG_URL *)
   match Sys.getenv_opt "DATABASE_URL" with
   | Some url -> Some url
-  | None -> match Sys.getenv_opt "RAILWAY_PG_URL" with
+  | None -> match Sys.getenv_opt "SUPABASE_DB_URL" with
     | Some url -> Some url
-    | None -> Sys.getenv_opt "RAILWAY_POSTGRES_URL"
+    | None -> Sys.getenv_opt "SB_PG_URL"
 
 (** {1 Neo4j Operations} *)
 

--- a/lib/room_utils.ml
+++ b/lib/room_utils.ml
@@ -149,10 +149,13 @@ let backend_config_for base_path =
     match env_opt "MASC_POSTGRES_URL" with
     | Some _ as url -> url
     | None ->
-        (* Fallback chain: DATABASE_URL -> RAILWAY_PG_URL *)
+        (* Fallback chain: DATABASE_URL -> SUPABASE_DB_URL -> SB_PG_URL *)
         match env_opt "DATABASE_URL" with
         | Some _ as url -> url
-        | None -> env_opt "RAILWAY_PG_URL"
+        | None ->
+            match env_opt "SUPABASE_DB_URL" with
+            | Some _ as url -> url
+            | None -> env_opt "SB_PG_URL"
   in
   let cluster_name =
     match env_opt "MASC_CLUSTER_NAME" with


### PR DESCRIPTION
## 요약

- `RAILWAY_PG_URL` / `RAILWAY_POSTGRES_URL` 환경변수 참조를 `SUPABASE_DB_URL` (primary) → `SB_PG_URL` (fallback)으로 마이그레이션
- Railway PostgreSQL 사용 중단, Supabase PgBouncer (port 6543)로 완전 전환

## 변경 파일 (2개)

- `lib/room_utils.ml` — `MASC_POSTGRES_URL → DATABASE_URL → SUPABASE_DB_URL → SB_PG_URL` 폴백 체인
- `lib/jiphyeon/archive.ml` — `DATABASE_URL → SUPABASE_DB_URL → SB_PG_URL` 폴백 체인

## 참고

- `archive.ml`의 `RAILWAY_NEO4J_URL`은 PG 마이그레이션 범위 밖 (변경하지 않음)

## 테스트 계획

- [ ] `SUPABASE_DB_URL` 설정 시 정상 연결 확인
- [ ] `SB_PG_URL`만 설정 시 fallback 동작 확인
- [ ] 두 변수 모두 미설정 시 에러 메시지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)