### PR TITLE
fix(trpg): bypass contribution gate during lobby phase in HTTP route

### DIFF
--- a/bin/main_eio.ml
+++ b/bin/main_eio.ml
@@ -898,8 +898,16 @@ let trpg_actor_claim_json ~base_dir ~body_str : trpg_api_result =
       Error (`Bad_request, Printf.sprintf "actor '%s' is not alive" actor_id)
     else
       let actor_role = trpg_actor_role state actor_id in
+      let phase_name =
+        match Yojson.Safe.Util.member "phase" state with
+        | `String phase -> String.lowercase_ascii (String.trim phase)
+        | _ -> "round"
+      in
       let* () =
         if actor_role <> "player" then Ok ()
+        else if phase_name <> "round" then
+          (* Initial party assignment (lobby/briefing) bypasses contribution gate *)
+          Ok ()
         else
           let phase_open = trpg_join_gate_phase_open state in
           let required = trpg_join_gate_min_points state in


### PR DESCRIPTION
## Summary
- HTTP route handler의 actor_claim에서 lobby phase bypass가 누락되어 있었음
- MCP tool handler(`tool_trpg.ml`)에는 이미 수정이 적용되어 있었으나, Bevy UI가 사용하는 HTTP route에는 미적용
- lobby/briefing phase에서 player actor claim 시 contribution gate를 건너뛰도록 수정

## Root Cause
- `bin/main_eio.ml`의 actor_claim handler에서 session phase 확인 없이 항상 contribution gate를 적용
- lobby phase에서는 contribution_ledger가 비어있어 score=0 → min_points=3 조건 불충족
- Chicken-and-egg: 참여 없이 기여 불가, 기여 없이 참여 불가

## Fix
- Session state에서 phase 추출 (`Yojson.Safe.Util.member "phase" state`)
- phase가 "round"가 아닌 경우 (lobby/briefing) contribution gate bypass
- `tool_trpg.ml`의 기존 패턴과 동일한 로직 적용

## Test plan
- [ ] dune build 성공 확인 (완료)
- [ ] Bevy UI에서 lobby phase actor claim 테스트
- [ ] round phase에서 contribution gate 정상 작동 확인

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>