### PR TITLE
fix: return friendly error when MASC not initialized

### DIFF
--- a/lib/mcp_server_eio.ml
+++ b/lib/mcp_server_eio.ml
@@ -2546,8 +2546,17 @@ let handle_call_tool_eio ~sw ~clock ?mcp_session_id ?auth_token state id params 
     with exn ->
       (* Never let a tool exception crash the MCP server. *)
       let err = Printexc.to_string exn in
-      Log.Mcp.error "tools/call crashed: %s" err;
-      (false, Printf.sprintf "❌ Internal error: %s" err)
+      if String.starts_with ~prefix:"Invalid_argument(\"MASC not initialized." err then
+        let msg =
+          if err = "Invalid_argument(\"MASC not initialized. Use masc_init first.\")" then
+            Types.masc_error_to_string Types.NotInitialized
+          else
+            Printf.sprintf "❌ Invalid argument: %s" err
+        in
+        (false, msg)
+      else
+        (Log.Mcp.error "tools/call crashed: %s" err;
+         false, Printf.sprintf "❌ Internal error: %s" err)
   in
   let end_time = Eio.Time.now clock in
   let duration_ms = int_of_float ((end_time -. start_time) *. 1000.0) in


### PR DESCRIPTION
## Summary
- Map `Invalid_argument("MASC not initialized")` to a user-facing error message instead of wrapping as `Internal error`.
- Keep non-initialization `Invalid_argument` in the same explicit error path so diagnostics remain transparent.

## Repro steps
- Start MASC MCP server in a fresh context without running `masc_init`.
- Invoke any tool that requires room initialization (for example a tool with `room_initialized` dependency).
- Verify the response is `❌ MASC not initialized. Use masc_init first.` instead of `❌ Internal error:`.

## Regression test checklist
- `dune build`
- Manual call path that triggers `Invalid_argument("MASC not initialized. Use masc_init first.")`
  - Expect `Tools` response: `❌ MASC not initialized. Use masc_init first.`
- Manual call path that triggers a different `Invalid_argument(...)` message
  - Expect response is still user-facing and does not appear as generic `Internal error`.
- Existing generic exception paths
  - Expect unchanged `❌ Internal error: ...` behavior for non-`Invalid_argument` failures.