### PR TITLE
fix(keeper): skip stale keepers during bootstrap

### DIFF
--- a/lib/tool_keeper.ml
+++ b/lib/tool_keeper.ml
@@ -8436,15 +8436,16 @@ let bootstrap_existing_keepers ctx : keeper_bootstrap_stats =
               let name = Filename.remove_extension f in
               match read_meta ctx.config name with
               | Ok (Some m) ->
-                  let already_running = Hashtbl.mem keepalives m.name in
-                  start_keepalive ctx m;
                   let stale_now =
                     stale_turn_sec > 0.0
                     && (m.last_turn_ts <= 0.0
                         || now_ts -. m.last_turn_ts >= stale_turn_sec)
                   in
+                  let already_running = Hashtbl.mem keepalives m.name in
+                  if not stale_now then start_keepalive ctx m;
                   ( scanned_acc + 1,
-                    started_acc + (if already_running then 0 else 1),
+                    started_acc
+                    + (if stale_now || already_running then 0 else 1),
                     stale_acc + (if stale_now then 1 else 0) )
               | _ -> (scanned_acc, started_acc, stale_acc))
             (0, 0, 0)


### PR DESCRIPTION
## Summary
- fix keeper bootstrap logic to avoid starting keepalive fibers for stale keepers
- keep stale counting intact while only incrementing `started` for non-stale keepers actually started
- reduce startup contention from old keepers that trigger unnecessary LLM cascades and slow TRPG round latency

## Root Cause
`bootstrap_existing_keepers` called `start_keepalive` before stale filtering, so stale keepers were always revived.
This made startup logs show patterns like `scanned=47 started=47 stale=31`, meaning stale=31 still got started.

## Validation
- Build:
  - `dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix-trpg-turn-stall bin/main_eio.exe`
- Bootstrap probe (default bootstrap enabled):
  - startup log now reports `scanned=47 started=16 stale=31` (stale keepers no longer revived)
- TRPG smoke regression:
  - `MASC_KEEPER_BOOTSTRAP_ENABLED=0 ... scripts/run_trpg_grimland_smoke.sh` with `RUN_ROUND=1 ROUNDS=1`
  - result: `PASS: trpg smoke`
