### PR TITLE
perf: bootstrap existing keepers once per process

### DIFF
--- a/lib/tool_keeper.ml
+++ b/lib/tool_keeper.ml
@@ -8469,8 +8469,23 @@ let bootstrap_existing_keepers ctx : keeper_bootstrap_stats =
         in
         { enabled = true; scanned; started; stale }
 
+let existing_keepalive_bootstrap_done = ref false
+
 let start_existing_keepalives ctx =
-  ignore (bootstrap_existing_keepers ctx)
+  if !existing_keepalive_bootstrap_done then ()
+  else begin
+    existing_keepalive_bootstrap_done := true;
+    try
+      let stats = bootstrap_existing_keepers ctx in
+      if keeper_debug then
+        Printf.eprintf
+          "[KEEPER-DEBUG] bootstrap_existing_keepers enabled=%b scanned=%d started=%d stale=%d\n%!"
+          stats.enabled stats.scanned stats.started stats.stale
+    with exn ->
+      (* Retry bootstrap on next keeper tool call if this attempt failed. *)
+      existing_keepalive_bootstrap_done := false;
+      raise exn
+  end
 
 let dispatch ctx ~name ~args : tool_result option =
   (* Lazy boot: when any keeper tool is used, attach keepalives for existing keepers. *)


### PR DESCRIPTION
## Summary
- run existing keeper bootstrap scan only once per server process
- keep retry behavior: if bootstrap throws, reset guard and retry on next keeper tool call
- add debug summary line under `MASC_KEEPER_DEBUG=1` for bootstrap stats

## Why
- before this change, every keeper tool call (`masc_keeper_list/status/msg/up/down`) re-scanned all keeper meta files
- that repeated scan adds avoidable startup/runtime latency, especially with many keepers

## Verification
- `dune build --root .`
- bootstrap probe (two consecutive `masc_keeper_list` calls in one server process):
  - bootstrap summary log count: `1` (`/tmp/bootstrap_once_8971.log`)
- TRPG smoke regression:
  - `MCP_URL=http://127.0.0.1:8972/mcp KEEPER_MODELS='gemini:gemini-2.5-flash' RUN_ROUND=1 ROUNDS=1 ROUND_TIMEOUT_SEC=45 ROUND_LOCAL_FALLBACK=1 ./scripts/run_trpg_grimland_smoke.sh`
  - `PASS (events=31)`
