### PR TITLE
fix: short-circuit TRPG rounds after session end

### DIFF
--- a/lib/tool_trpg.ml
+++ b/lib/tool_trpg.ml
@@ -6672,6 +6672,152 @@ let handle_round_run ctx args : result =
           (fun (actor_id, _) -> actor_alive_in_state state actor_id)
           player_keepers
       in
+      let terminal_session = room_already_ended || outcome_already_emitted in
+      if terminal_session then
+        let active_player_count = List.length live_player_keepers in
+        let participant_count = max 1 (1 + active_player_count) in
+        let keeper_timeout_sec =
+          let per_actor_budget =
+            timeout_sec /. float_of_int (max 1 participant_count)
+          in
+          let floor = min 30.0 timeout_sec in
+          max floor per_actor_budget
+        in
+        let player_required_successes =
+          let total = active_player_count in
+          if total <= 0 then 0 else max 1 ((total + 1) / 2)
+        in
+        let terminal_reason =
+          if room_already_ended && outcome_already_emitted then
+            "room already ended and session outcome already emitted"
+          else if room_already_ended then
+            "room already ended"
+          else "session outcome already emitted"
+        in
+        let dead_statuses =
+          dead_player_keepers
+          |> List.map (fun (actor_id, keeper_name) ->
+                 `Assoc
+                   [
+                     ("actor_id", `String actor_id);
+                     ("role", `String "player");
+                     ("keeper", `String keeper_name);
+                     ("status", `String "skipped_dead");
+                     ("reason", `String "actor is not alive at round start");
+                     ("stage", `String "preflight");
+                   ])
+        in
+        let live_statuses =
+          live_player_keepers
+          |> List.map (fun (actor_id, keeper_name) ->
+                 `Assoc
+                   [
+                     ("actor_id", `String actor_id);
+                     ("role", `String "player");
+                     ("keeper", `String keeper_name);
+                     ("status", `String "skipped_session_ended");
+                     ("reason", `String terminal_reason);
+                     ("stage", `String "session_guard");
+                   ])
+        in
+        let dm_status =
+          `Assoc
+            [
+              ("actor_id", `String "dm");
+              ("role", `String "dm");
+              ("keeper", `String dm_keeper);
+              ("status", `String "skipped_session_ended");
+              ("reason", `String terminal_reason);
+              ("stage", `String "session_guard");
+            ]
+        in
+        let statuses = dead_statuses @ live_statuses @ [ dm_status ] in
+        let canon_check =
+          evaluate_canon_check ~base_dir ~state ~events:existing_events_before
+            ~dm_reply:None
+        in
+        let dm_style =
+          match state |> member "config" with
+          | `Assoc fields -> (
+              match List.assoc_opt "dm" fields with
+              | Some dm_json -> get_string_field dm_json "style"
+              | None -> "")
+          | _ -> ""
+        in
+        let dm_persona_used =
+          infer_dm_persona_id
+            ~explicit:(Option.bind dm_persona_override dm_persona_id_of_string)
+            ~dm_style
+        in
+        let room_status =
+          match state |> member "status" with
+          | `String status when String.trim status <> "" -> status
+          | _ -> "ended"
+        in
+        Ok
+          (`Assoc
+            [
+              ("ok", `Bool true);
+              ("room_id", `String room_id);
+              ("phase", `String phase);
+              ("turn_before", `Int turn_before);
+              ("turn_after", `Int turn_before);
+              ("timeout_sec", `Float timeout_sec);
+              ( "preflight_warning",
+                match preflight_warning with
+                | Some warning -> `String warning
+                | None -> `Null );
+              ("statuses", `List statuses);
+              ("interventions_applied", `List []);
+              ( "summary",
+                `Assoc
+                  [
+                    ("participants", `Int participant_count);
+                    ("successes", `Int 0);
+                    ("fallbacks", `Int 0);
+                    ("player_successes", `Int 0);
+                    ("player_fallbacks", `Int 0);
+                    ("player_required_successes", `Int player_required_successes);
+                    ("player_quorum_met", `Bool false);
+                    ("dm_success", `Bool false);
+                    ("advanced", `Bool false);
+                    ("progress_reason", `String "session_ended");
+                    ("progress_detail", `String terminal_reason);
+                    ("recovery_applied", `Bool false);
+                    ( "recovery_mode",
+                      if local_fallback then
+                        `String "local_fallback_enabled"
+                      else `String "none" );
+                    ("effective_timeout_sec", `Float timeout_sec);
+                    ("keeper_timeout_sec", `Float keeper_timeout_sec);
+                    ("timeouts", `Int 0);
+                    ("unavailable", `Int 0);
+                    ("schema_failures", `Int 0);
+                    ("rule_validation_failures", `Int 0);
+                    ("reprompts", `Int 0);
+                    ("dm_persona", `String (string_of_dm_persona_id dm_persona_used));
+                    ("dm_persona_overridden", `Bool (Option.is_some dm_persona_override));
+                    ("npc_spawned", `Int 0);
+                    ("npc_attacks", `Int 0);
+                    ("interventions", `Int 0);
+                    ("canon_status", `String canon_check.status);
+                    ("canon_violation_count", `Int (List.length canon_check.violations));
+                    ("canon_warning_count", `Int (List.length canon_check.warnings));
+                    ("memory_signals", `Int 0);
+                    ("memory_guardrail_escalations", `Int 0);
+                    ("roll_audit_count", `Int 0);
+                    ("roll_audit", `List []);
+                  ] );
+              ("canon_check", canon_check_to_yojson canon_check);
+              ( "outcome",
+                match !latest_outcome_payload with
+                | Some payload -> payload
+                | None -> `Null );
+              ("events", `List []);
+              ("room_status", `String room_status);
+              ("state", state);
+            ])
+      else
       let* join_window_closed_event =
         append_event
           ~base_dir

--- a/test/test_tool_trpg_coverage.ml
+++ b/test/test_tool_trpg_coverage.ml
@@ -1454,6 +1454,74 @@ let test_round_run_skips_dead_player_assignments () =
   | None -> Alcotest.fail "dead actor status is missing");
   cleanup_dir base_dir
 
+let test_round_run_short_circuits_when_session_already_ended () =
+  let base_dir = make_temp_dir () in
+  let config = Room.default_config base_dir in
+  let _ = Room.init config ~agent_name:(Some "tester") in
+  let room_id = "room-round-session-ended" in
+  bootstrap_room_with_actors ~base_dir ~room_id ~actor_ids:["p1"];
+  append_room_event ~base_dir ~room_id
+    ~event_type:Trpg_engine_event.Session_outcome
+    ~payload:
+      (`Assoc
+        [
+          ("outcome", `String "defeat");
+          ("reason", `String "all_players_dead");
+          ("summary", `String "The party has fallen.");
+          ("turn", `Int 1);
+          ("phase", `String "round");
+        ])
+    ();
+  let keeper_called = ref false in
+  let keeper_call ~name:_ ~message:_ ~timeout_sec:_ : Tool_trpg.keeper_call_result =
+    keeper_called := true;
+    `Ok (keeper_payload ~action_type:"explore" "Should not be called.")
+  in
+  let ctx : Tool_trpg.context =
+    { config; agent_name = "tester"; keeper_call = Some keeper_call; keeper_probe = None; dm_voice_emit = None }
+  in
+  let args =
+    `Assoc
+      [
+        ("room_id", `String room_id);
+        ("dm_keeper", `String "dm-keeper");
+        ("player_keepers", `Assoc [ ("p1", `String "pk-1") ]);
+        ("timeout_sec", `Float 0.5);
+      ]
+  in
+  let ok, body = dispatch_exn ctx ~name:"masc_trpg_round_run" ~args in
+  Alcotest.(check bool) "round_run returns payload" true ok;
+  Alcotest.(check bool) "keeper call skipped on ended session" false !keeper_called;
+  let json = parse_json_exn body in
+  let summary = Yojson.Safe.Util.member "summary" json in
+  Alcotest.(check string)
+    "progress reason is session_ended"
+    "session_ended"
+    (Yojson.Safe.Util.member "progress_reason" summary |> Yojson.Safe.Util.to_string);
+  Alcotest.(check bool)
+    "round not advanced"
+    false
+    (Yojson.Safe.Util.member "advanced" summary |> Yojson.Safe.Util.to_bool);
+  Alcotest.(check int)
+    "no emitted events"
+    0
+    (Yojson.Safe.Util.member "events" json |> Yojson.Safe.Util.to_list |> List.length);
+  let statuses = Yojson.Safe.Util.member "statuses" json |> Yojson.Safe.Util.to_list in
+  let dm_status =
+    List.find_opt
+      (fun s ->
+        s |> Yojson.Safe.Util.member "actor_id" |> Yojson.Safe.Util.to_string = "dm")
+      statuses
+  in
+  (match dm_status with
+  | Some status_json ->
+      Alcotest.(check string)
+        "dm status is skipped_session_ended"
+        "skipped_session_ended"
+        (status_json |> Yojson.Safe.Util.member "status" |> Yojson.Safe.Util.to_string)
+  | None -> Alcotest.fail "dm status is missing");
+  cleanup_dir base_dir
+
 let test_round_run_rejects_meta_only_keeper_reply () =
   let base_dir = make_temp_dir () in
   let config = Room.default_config base_dir in
@@ -2968,6 +3036,10 @@ let () =
             "skips dead player assignments and keeps round progression"
             `Quick
             test_round_run_skips_dead_player_assignments;
+          Alcotest.test_case
+            "short-circuits when session is already ended"
+            `Quick
+            test_round_run_short_circuits_when_session_already_ended;
           Alcotest.test_case
             "recovers meta-only keeper replies via synthetic action"
             `Quick


### PR DESCRIPTION
## Summary
- add a terminal-session guard in `masc_trpg_round_run` to short-circuit when room/session is already ended
- skip keeper calls and avoid appending new events for ended sessions
- return explicit `summary.progress_reason = "session_ended"` with detailed status rows (`skipped_session_ended`)
- add regression test for ended-session short-circuit behavior

## Validation
- `dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix-trpg-ended-session-guard`
- `dune exec --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix-trpg-ended-session-guard test/test_tool_trpg_coverage.exe`
- `MCP_URL=http://127.0.0.1:8973/mcp ROUNDS=8 ROUND_TIMEOUT_SEC=45 LOCAL_FALLBACK=true STRICT_ADVANCE=false KEEPER_MODELS='gemini:gemini-2.5-flash' ./scripts/harness/workload/trpg_longplay_liveliness.sh`
