### PR TITLE
fix(masc): harden tool call parsing, retries, and not-initialized error handling

### DIFF
--- a/lib/mcp_server_eio.ml
+++ b/lib/mcp_server_eio.ml
@@ -764,6 +764,13 @@ let cosine_similarity a b =
 
     All legacy bridges have been removed.
 *)
+let read_only_tools =
+  ["masc_status"; "masc_tasks"; "masc_who"; "masc_agents";
+   "masc_messages"; "masc_task_history"; "masc_votes"; "masc_vote_status";
+   "masc_worktree_list"; "masc_pending_interrupts";
+   "masc_cost_report"; "masc_portal_status";
+   "masc_goal_list"]
+
 let execute_tool_eio ~sw ~clock ?mcp_session_id ?auth_token state ~name ~arguments =
   (* clock parameter used for Session_eio.wait_for_message *)
   (* mcp_session_id: HTTP MCP session ID for agent_name persistence across tool calls *)
@@ -987,11 +994,6 @@ let execute_tool_eio ~sw ~clock ?mcp_session_id ?auth_token state ~name ~argumen
       (false, Printf.sprintf "❌ %s" msg)
   | None ->
 
-  let read_only_tools = ["masc_status"; "masc_tasks"; "masc_who"; "masc_agents";
-                         "masc_messages"; "masc_task_history"; "masc_votes"; "masc_vote_status";
-                         "masc_worktree_list"; "masc_pending_interrupts";
-                         "masc_cost_report"; "masc_portal_status";
-                         "masc_goal_list"] in
   let is_read_only = List.mem name read_only_tools in
 
   let can_auto_join =
@@ -2494,6 +2496,106 @@ let int_of_env_default name ~default ~min_v ~max_v =
       in
       max min_v (min max_v parsed)
 
+let contains_casefold haystack needle =
+  let haystack = String.lowercase_ascii haystack in
+  let needle = String.lowercase_ascii needle in
+  try
+    ignore (Str.search_forward (Str.regexp_string needle) haystack 0);
+    true
+  with Not_found -> false
+
+let parse_status_from_message ~success ~message =
+  if not success then
+    if
+      contains_casefold message "input required"
+      || contains_casefold message "ask agent"
+      || contains_casefold message "ask agent question"
+    then
+      ("ask_agent_question", Some "ask_agent_question")
+    else if
+      contains_casefold message "auth required"
+      || contains_casefold message "authentication required"
+      || contains_casefold message "unauthorized"
+    then
+      ("ask_for_auth", Some "ask_for_auth")
+    else
+      ("error", None)
+  else
+    ("ok", None)
+
+let quality_issue severity code message attempts =
+  `Assoc [
+    ("severity", `String severity);
+    ("code", `String code);
+    ("message", `String message);
+    ("retry_attempts", `Int attempts);
+  ]
+
+let quality_from_result ~success ~message ~attempts =
+  if success then
+    `Assoc [
+      ("passed", `Bool true);
+      ("issues", `List []);
+    ]
+  else
+    let issue =
+      if contains_casefold message "timeout" then
+        quality_issue "warning" "tool_timeout" message attempts
+      else
+        quality_issue "error" "tool_failure" message attempts
+    in
+    `Assoc [
+      ("passed", `Bool false);
+      ("issues", `List [issue]);
+    ]
+
+let read_only_retry_limit () =
+  match Sys.getenv_opt "MASC_TOOL_READONLY_RETRY_LIMIT" with
+  | Some raw ->
+      (try
+         let parsed = int_of_string (String.trim raw) in
+         max 1 (min 5 parsed)
+       with _ -> 2)
+  | None -> 2
+
+let is_retryable_message message =
+  contains_casefold message "timeout" ||
+  contains_casefold message "temporary" ||
+  contains_casefold message "temporarily" ||
+  contains_casefold message "econn" ||
+  contains_casefold message "connection" ||
+  contains_casefold message "unavailable" ||
+  contains_casefold message "rate limit" ||
+  contains_casefold message "502" ||
+  contains_casefold message "503"
+
+let read_only_retry_wait ~attempt =
+  let attempt = float_of_int attempt in
+  min 1.5 (0.2 *. attempt)
+
+let call_tool_with_readonly_retry
+    ~clock
+    ~run_tool
+    ~is_read_only
+    () =
+  let max_attempts = read_only_retry_limit () in
+  let rec loop attempt =
+    let (success, message) =
+      run_tool ()
+    in
+    if
+      success
+      || attempt >= max_attempts
+      || not is_read_only
+      || not (is_retryable_message message)
+    then
+      (success, message, attempt)
+    else (
+      Eio.Time.sleep clock (read_only_retry_wait ~attempt);
+      loop (attempt + 1))
+  in
+  loop 1
+
 (** Optional per-tool timeout to prevent long calls from starving the request loop. *)
 let tool_timeout_sec_opt ~(tool_name : string) : float option =
   match tool_name with
@@ -2512,51 +2614,62 @@ let handle_call_tool_eio ~sw ~clock ?mcp_session_id ?auth_token state id params 
   let module U = Yojson.Safe.Util in
   let name = params |> U.member "name" |> U.to_string in
   let arguments = params |> U.member "arguments" in
+  let is_read_only = List.mem name read_only_tools in
 
   (* Measure execution time for telemetry *)
   let start_time = Eio.Time.now clock in
   let timeout_hit = ref false in
-  let (success, message) =
-    try
-      match tool_timeout_sec_opt ~tool_name:name with
-      | None ->
-          execute_tool_eio ~sw ~clock ?mcp_session_id ?auth_token state ~name ~arguments
-      | Some timeout_sec ->
-          (try
-             Eio.Time.with_timeout_exn
-               clock
-               timeout_sec
-               (fun () ->
-                 execute_tool_eio
-                   ~sw
-                   ~clock
-                   ?mcp_session_id
-                   ?auth_token
-                   state
-                 ~name
-                 ~arguments)
-           with Eio.Time.Timeout ->
-             timeout_hit := true;
-             Log.Mcp.error "tools/call timeout: %s after %.0fs" name timeout_sec;
-             ( false,
-               Printf.sprintf
-                 "❌ Tool timed out after %.0fs: %s (env: MASC_TOOL_TIMEOUT_KEEPER_MSG_SEC)"
+let execute_with_timeout () =
+    let local_timeout_hit = ref false in
+    let result =
+      try
+        match tool_timeout_sec_opt ~tool_name:name with
+        | None ->
+            execute_tool_eio ~sw ~clock ?mcp_session_id ?auth_token state ~name ~arguments
+        | Some timeout_sec ->
+            (try
+               Eio.Time.with_timeout_exn
+                 clock
                  timeout_sec
-                 name ))
-    with exn ->
-      (* Never let a tool exception crash the MCP server. *)
-      let err = Printexc.to_string exn in
-      if String.starts_with ~prefix:"Invalid_argument(\"MASC not initialized." err then
-        let msg =
-          if err = "Invalid_argument(\"MASC not initialized. Use masc_init first.\")" then
-            Types.masc_error_to_string Types.NotInitialized
-          else
-            Printf.sprintf "❌ Invalid argument: %s" err
-        in
-        (false, msg)
-      else
-        (Log.Mcp.error "tools/call crashed: %s" err;
-         false, Printf.sprintf "❌ Internal error: %s" err)
+                 (fun () ->
+                   execute_tool_eio
+                     ~sw
+                     ~clock
+                     ?mcp_session_id
+                     ?auth_token
+                     state
+                     ~name
+                     ~arguments)
+             with Eio.Time.Timeout ->
+               local_timeout_hit := true;
+               Log.Mcp.error "tools/call timeout: %s after %.0fs" name timeout_sec;
+               (false,
+                Printf.sprintf
+                  "❌ Tool timed out after %.0fs: %s (env: MASC_TOOL_TIMEOUT_KEEPER_MSG_SEC)"
+                  timeout_sec
+                  name))
+     with exn ->
+       (* Never let a tool exception crash the MCP server. *)
+       let err = Printexc.to_string exn in
+       if contains_casefold err "Invalid_argument(\"MASC not initialized" then
+         (false, Types.masc_error_to_string Types.NotInitialized)
+       else
+         (Log.Mcp.error "tools/call crashed: %s" err;
+          false, Printf.sprintf "❌ Internal error: %s" err)
+  in
+  if !local_timeout_hit then timeout_hit := true;
+  result
+in
+let (success, message, attempts) =
+  if is_read_only then
+    call_tool_with_readonly_retry
+      ~clock
+      ~run_tool:execute_with_timeout
+      ~is_read_only
+      ()
+  else
+    let (success, message) = execute_with_timeout () in
+    (success, message, 1)
   in
   let end_time = Eio.Time.now clock in
   let duration_ms = int_of_float ((end_time -. start_time) *. 1000.0) in
@@ -2595,7 +2708,32 @@ let handle_call_tool_eio ~sw ~clock ?mcp_session_id ?auth_token state id params 
             Printf.eprintf "[WARN] telemetry tracking failed: %s\n%!" (Printexc.to_string exn))
      | None -> ());
 
+  let trace_id =
+    match id with
+    | `String s -> s
+    | `Int i -> string_of_int i
+    | `Intlit s -> s
+    | `Float f -> Printf.sprintf "%0.0f" f
+    | _ -> "unknown"
+  in
+  let (status, required_follow_up) = parse_status_from_message ~success ~message in
+  let quality = quality_from_result ~success ~message ~attempts in
+  let envelope =
+    `Assoc [
+      ("kind", `String "tool_call");
+      ("summary", `String message);
+      ("status", `String status);
+      ("tool", `String name);
+      ("required_follow_up",
+       (match required_follow_up with
+        | None -> `Null
+        | Some value -> `String value));
+      ("trace_id", `String trace_id);
+      ("quality", quality);
+    ]
+  in
   let result = make_response ~id (`Assoc [
+    ("resultEnvelope", envelope);
     ("content", `List [
       `Assoc [
         ("type", `String "text");
@@ -2695,38 +2833,52 @@ let handle_request ~clock ~sw ?mcp_session_id ?auth_token state request_str =
         else if not (is_jsonrpc_v2 json) then
           make_error ~id:`Null (-32600) "Invalid Request: jsonrpc must be 2.0"
         else
-          match jsonrpc_request_of_yojson json with
-          | Error msg -> make_error ~id:`Null ~data:(`String msg) (-32600) "Invalid Request"
-          | Ok req ->
-              let id = get_id req in
-              if not (is_valid_request_id id) then
-                make_error ~id:`Null (-32600) "Invalid Request: id must be string, number, or null"
-              else if is_notification req then
-                `Null
-              else
-                (match req.method_ with
-                | "initialize" -> handle_initialize_eio id req.params
-                | "initialized"
-                | "notifications/initialized" -> make_response ~id `Null
-                | "resources/list" -> handle_list_resources_eio id
-                | "resources/read" ->
-                    (* Eio native - pure sync resource reading *)
-                    handle_read_resource_eio state id req.params
-                | "resources/templates/list" -> handle_list_resource_templates_eio id
-                | "prompts/list" -> handle_list_prompts_eio id
-                | "tools/list" -> handle_list_tools_eio state id
-                | "tools/call" ->
-                    (match req.params with
-                    | Some params ->
-                        let name = Yojson.Safe.Util.(params |> member "name" |> to_string) in
-                        Printf.eprintf "[MCP] tools/call: %s (id=%s, session=%s)\n%!" name
-                          (match id with `Int i -> string_of_int i | `String s -> s | _ -> "?")
-                          (match mcp_session_id with Some s -> s | None -> "none");
-                        let result = handle_call_tool_eio ~sw ~clock ?mcp_session_id ?auth_token state id params in
-                        Printf.eprintf "[MCP] tools/call done: %s\n%!" name;
-                        result
-                    | None -> make_error ~id (-32602) "Missing params")
-                | method_ -> make_error ~id (-32601) ("Method not found: " ^ method_))
+        match jsonrpc_request_of_yojson json with
+        | Error msg -> make_error ~id:`Null ~data:(`String msg) (-32600) "Invalid Request"
+        | Ok req ->
+            let id = get_id req in
+            if not (is_valid_request_id id) then
+              make_error ~id:`Null (-32600) "Invalid Request: id must be string, number, or null"
+            else if is_notification req then
+              `Null
+            else
+                (try
+                   (match req.method_ with
+                   | "initialize" -> handle_initialize_eio id req.params
+                   | "initialized"
+                   | "notifications/initialized" -> make_response ~id `Null
+                   | "resources/list" -> handle_list_resources_eio id
+                   | "resources/read" ->
+                       (* Eio native - pure sync resource reading *)
+                       handle_read_resource_eio state id req.params
+                   | "resources/templates/list" -> handle_list_resource_templates_eio id
+                   | "prompts/list" -> handle_list_prompts_eio id
+                   | "tools/list" -> handle_list_tools_eio state id
+                   | "tools/call" ->
+                       (match req.params with
+                       | Some params ->
+                           (try
+                             let name = Yojson.Safe.Util.(params |> member "name" |> to_string) in
+                             Printf.eprintf "[MCP] tools/call: %s (id=%s, session=%s)\n%!" name
+                               (match id with `Int i -> string_of_int i | `String s -> s | _ -> "?")
+                               (match mcp_session_id with Some s -> s | None -> "none");
+                             let result =
+                               handle_call_tool_eio ~sw ~clock ?mcp_session_id ?auth_token state id params
+                             in
+                             Printf.eprintf "[MCP] tools/call done: %s\n%!" name;
+                             result
+                           with _ ->
+                             make_error ~id (-32602) "Invalid params: name must be a string")
+                       | None -> make_error ~id (-32602) "Missing params")
+                   | method_ -> make_error ~id (-32601) ("Method not found: " ^ method_))
+                 with
+                 | Invalid_argument msg
+                   when contains_casefold msg "invalid_argument(\"masc not initialized" ->
+                     make_error ~id (-32603) (Types.masc_error_to_string Types.NotInitialized)
+                   | exn ->
+                       let err = Printexc.to_string exn in
+                       Log.Mcp.error "Request handling failed: %s" err;
+                       make_error ~id (-32603) (Printf.sprintf "Internal error: %s" err))
   with exn ->
     make_error ~id:`Null ~data:(`String (Printexc.to_string exn)) (-32603) "Internal error"
 

--- a/test/test_mcp_server_coverage.ml
+++ b/test/test_mcp_server_coverage.ml
@@ -451,6 +451,39 @@ let test_handle_request_missing_params_tools_call () =
 
   cleanup_dir base_path
 
+let test_handle_request_tools_call_invalid_name_type () =
+  Eio_main.run @@ fun env ->
+  let clock = Eio.Stdenv.clock env in
+  Eio.Switch.run @@ fun sw ->
+
+  let base_path = temp_dir () in
+  let state = Mcp_eio.create_state ~test_mode:true ~base_path () in
+
+  let request = Yojson.Safe.to_string (`Assoc [
+    ("jsonrpc", `String "2.0");
+    ("id", `Int 1);
+    ("method", `String "tools/call");
+    ("params", `Assoc [
+      ("name", `Int 1);
+      ("arguments", `Assoc []);
+    ]);
+  ]) in
+
+  let response = Mcp_eio.handle_request ~clock ~sw state request in
+
+  (match response with
+   | `Assoc fields ->
+       Alcotest.(check bool) "has error" true (List.mem_assoc "error" fields);
+       (match List.assoc_opt "error" fields with
+        | Some (`Assoc error_fields) ->
+            (match List.assoc_opt "code" error_fields with
+             | Some (`Int code) -> Alcotest.(check int) "error code -32602" (-32602) code
+             | _ -> Alcotest.fail "error code missing")
+        | _ -> Alcotest.fail "error not an object")
+   | _ -> Alcotest.fail "response not an object");
+
+  cleanup_dir base_path
+
 let test_handle_request_tool_masc_status () =
   Eio_main.run @@ fun env ->
   let clock = Eio.Stdenv.clock env in
@@ -509,6 +542,24 @@ let test_handle_request_tool_not_initialized_error () =
             (match List.assoc_opt "isError" result_fields with
              | Some (`Bool is_error) -> Alcotest.(check bool) "isError true" true is_error
              | _ -> Alcotest.fail "isError missing");
+            (match List.assoc_opt "resultEnvelope" result_fields with
+             | Some (`Assoc envelope) ->
+                 (match List.assoc_opt "kind" envelope with
+                  | Some (`String kind) ->
+                      Alcotest.(check string) "envelope kind" "tool_call" kind
+                  | _ -> Alcotest.fail "resultEnvelope.kind missing");
+                 (match List.assoc_opt "status" envelope with
+                  | Some (`String status) ->
+                      Alcotest.(check string) "envelope status" "error" status
+                  | _ -> Alcotest.fail "resultEnvelope.status missing");
+                 (match List.assoc_opt "quality" envelope with
+                  | Some (`Assoc quality) -> (
+                      (match List.assoc_opt "passed" quality with
+                       | Some (`Bool passed) -> Alcotest.(check bool) "quality passed false" false passed
+                       | _ -> Alcotest.fail "quality.passed missing")
+                    )
+                  | _ -> Alcotest.fail "resultEnvelope.quality missing")
+             | _ -> Alcotest.fail "resultEnvelope missing");
             (match List.assoc_opt "content" result_fields with
              | Some (`List items) ->
                  (match items with
@@ -520,11 +571,10 @@ let test_handle_request_tool_not_initialized_error () =
                        | _ -> Alcotest.fail "missing text")
                   | _ -> Alcotest.fail "content not a list of objects")
              | _ -> Alcotest.fail "content missing")
-        | _ -> Alcotest.fail "result not object")
+             | _ -> Alcotest.fail "result not object")
    | _ -> Alcotest.fail "response not an object");
 
   cleanup_dir base_path
-
 (* ===== 10. Execute Tool Tests ===== *)
 
 let test_execute_tool_masc_set_room () =
@@ -714,6 +764,7 @@ let eio_tests = [
   "handle_notification_initialized", `Quick, test_handle_request_notification_initialized;
   "handle_wrong_jsonrpc_version", `Quick, test_handle_request_wrong_jsonrpc_version;
   "handle_missing_params", `Quick, test_handle_request_missing_params_tools_call;
+  "handle_invalid_tool_name_type", `Quick, test_handle_request_tools_call_invalid_name_type;
   "handle_tool_masc_status", `Quick, test_handle_request_tool_masc_status;
   "handle_tool_not_initialized_error", `Quick, test_handle_request_tool_not_initialized_error;
 ]


### PR DESCRIPTION
## Summary
- `tools/call` 요청의 파싱/검증을 강화해 잘못된 파라미터를 명확히 거부합니다.
- `MASC not initialized` 내부 예외를 `NotInitialized`로 구조화된 오류 응답에 매핑합니다.
- read-only 툴에 대해 실패 시 재시도 정책을 적용하고, 재시도 횟수/품질을 응답 메타로 반영합니다.
- 툴 호출 응답에 resultEnvelope를 추가해 상태/품질/후속 필요성 정보를 제공합니다.

## Motivation
- 현재 `MASC not initialized` 오류가 내부 에러로 흘러가거나 무의미한 결과를 반환해 UI/클라이언트 체감 오류를 일으키는 문제가 있어
  - 사용자에게 일관된 구조화된 실패 신호를 제공하고
  - read-only 툴의 일시적 실패에 대한 내성을 높이기 위해 수정했습니다.

## Changes
- `lib/mcp_server_eio.ml`
  - `tools/call` 파싱 강화
    - `params` 누락 시 Invalid params 처리
    - `name` 타입 검증(문자열 강제)
    - `Invalid_argument("MASC not initialized...")` 패턴 매칭 처리
  - read-only 툴 리스트 모듈 상수화 및 재시도 래퍼 적용
  - 툴 실행 결과 응답에 resultEnvelope 추가 (kind/summary/status/tool/required_follow_up/trace_id/quality)
- `test/test_mcp_server_coverage.ml`
  - `tools/call`에서 `name` 타입 오염 케이스 테스트 추가
  - MASC not initialized 케이스에서 resultEnvelope 유효성 검증 추가

## Testing
- `dune test` 통과 확인

## Files
- `lib/mcp_server_eio.ml`
- `test/test_mcp_server_coverage.ml`

## Notes
- 기존 동작(성공 응답)은 유지했고, 에러 파이프라인만 강화했습니다.