### PR TITLE
fix(zombie): tiered thresholds for keeper zombie detection

### DIFF
--- a/lib/env_config.ml
+++ b/lib/env_config.ml
@@ -40,6 +40,10 @@ module Zombie = struct
   let threshold_seconds =
     get_float ~default:300.0 "MASC_ZOMBIE_THRESHOLD_SEC"
 
+  (** Threshold for keeper agents (longer grace period, default 1 hour) *)
+  let keeper_threshold_seconds =
+    get_float ~default:3600.0 "MASC_KEEPER_ZOMBIE_THRESHOLD_SEC"
+
   (** Cleanup loop interval (seconds) *)
   let cleanup_interval_seconds =
     get_float ~default:60.0 "MASC_ZOMBIE_CLEANUP_INTERVAL_SEC"

--- a/lib/room.ml
+++ b/lib/room.ml
@@ -1732,8 +1732,12 @@ let cleanup_zombies config =
         let json = read_json config path in
         match agent_of_yojson json with
         | Ok agent
-          when is_zombie_agent agent.last_seen
-               && not (is_keeper_runtime_agent_name agent.name) ->
+          when (let threshold =
+                  if is_keeper_runtime_agent_name agent.name
+                  then Env_config.Zombie.keeper_threshold_seconds
+                  else Env_config.Zombie.threshold_seconds
+                in
+                Resilience.Zombie.is_zombie ~threshold agent.last_seen) ->
             zombies := agent.name :: !zombies;
             (* Stop heartbeats owned by this zombie agent *)
             let _stopped = Heartbeat.stop_by_agent ~agent_name:agent.name in

--- a/test/test_room.ml
+++ b/test/test_room.ml
@@ -536,6 +536,54 @@ let test_cleanup_zombies_empty () =
     Alcotest.(check bool) "cleanup result" true (String.length result > 0)
   )
 
+(** Return ISO8601 timestamp offset by seconds from now *)
+let iso_ago seconds =
+  let t = Unix.gettimeofday () -. seconds in
+  let tm = Unix.gmtime t in
+  Printf.sprintf "%04d-%02d-%02dT%02d:%02d:%02dZ"
+    (tm.Unix.tm_year + 1900) (tm.Unix.tm_mon + 1) tm.Unix.tm_mday
+    tm.Unix.tm_hour tm.Unix.tm_min tm.Unix.tm_sec
+
+(** Helper: join an agent then overwrite its last_seen to simulate staleness *)
+let make_stale_agent config ~name ~age_seconds =
+  let _ = Room.join config ~agent_name:name ~capabilities:[] () in
+  (* Overwrite the agent file with a stale last_seen *)
+  let agents_path = Filename.concat (Room.masc_dir config) "agents" in
+  let path = Filename.concat agents_path (Room.safe_filename name ^ ".json") in
+  let stale_ts = iso_ago age_seconds in
+  let agent_json = Printf.sprintf
+    {|{"name":"%s","agent_type":"test","status":"inactive","capabilities":[],"joined_at":"%s","last_seen":"%s"}|}
+    name stale_ts stale_ts
+  in
+  Room.write_json config path (Yojson.Safe.from_string agent_json)
+
+let test_cleanup_zombies_detects_regular () =
+  with_test_env (fun config ->
+    (* Create a regular agent idle for 10 minutes (> 300s threshold) *)
+    make_stale_agent config ~name:"stale-regular-agent" ~age_seconds:700.0;
+    let result = Room.cleanup_zombies config in
+    Alcotest.(check bool) "regular zombie detected"
+      true (str_contains result "stale-regular-agent")
+  )
+
+let test_cleanup_zombies_detects_keeper () =
+  with_test_env (fun config ->
+    (* Create a keeper agent idle for 2 hours (> 3600s keeper threshold) *)
+    make_stale_agent config ~name:"keeper-longplay-agent" ~age_seconds:7200.0;
+    let result = Room.cleanup_zombies config in
+    Alcotest.(check bool) "keeper zombie detected after keeper threshold"
+      true (str_contains result "keeper-longplay-agent")
+  )
+
+let test_cleanup_zombies_spares_recent_keeper () =
+  with_test_env (fun config ->
+    (* Create a keeper agent idle for 10 minutes (< 3600s keeper threshold) *)
+    make_stale_agent config ~name:"keeper-active-agent" ~age_seconds:600.0;
+    let result = Room.cleanup_zombies config in
+    Alcotest.(check bool) "recent keeper spared"
+      true (not (str_contains result "keeper-active-agent"))
+  )
+
 (* ============================================================ *)
 (* Agent Discovery / Capability Tests                           *)
 (* ============================================================ *)
@@ -1081,6 +1129,9 @@ let () =
       Alcotest.test_case "nonexistent agent" `Quick test_heartbeat_nonexistent_agent;
       Alcotest.test_case "get agents status" `Quick test_get_agents_status;
       Alcotest.test_case "cleanup zombies empty" `Quick test_cleanup_zombies_empty;
+      Alcotest.test_case "cleanup detects regular zombie" `Quick test_cleanup_zombies_detects_regular;
+      Alcotest.test_case "cleanup detects keeper zombie" `Quick test_cleanup_zombies_detects_keeper;
+      Alcotest.test_case "cleanup spares recent keeper" `Quick test_cleanup_zombies_spares_recent_keeper;
     ];
 
     (* === Agent Discovery / Capability Tests === *)


### PR DESCRIPTION
## Summary

- `cleanup_zombies`가 `keeper-*-agent` 패턴 에이전트를 완전히 제외하여 좀비가 무한 축적되는 버그 수정
- 기존: keeper 이름 매칭 시 blanket exclusion (`not (is_keeper_runtime_agent_name ...)`)
- 수정: tiered threshold 적용 — 일반 에이전트 300s (5분), keeper 에이전트 3600s (1시간)
- `MASC_KEEPER_ZOMBIE_THRESHOLD_SEC` 환경변수로 keeper threshold 설정 가능

## Background

Production 대시보드에서 248개 좀비 에이전트가 발견됨. 모두 `keeper-*-agent` 패턴으로, `cleanup_zombies`가 이들을 완전히 건너뛰고 있었음.

## Changes

| 파일 | 변경 |
|------|------|
| `lib/env_config.ml` | `keeper_threshold_seconds` 추가 (기본 3600.0) |
| `lib/room.ml` | blanket exclusion → tiered `Resilience.Zombie.is_zombie ~threshold` 호출 |
| `test/test_room.ml` | 3개 테스트 추가 (regular zombie, keeper zombie, recent keeper spared) |

## Test plan

- [x] 기존 68개 테스트 통과
- [x] 신규 3개 테스트 통과 (71개 전체)
  - `cleanup detects regular zombie` — 300s 초과 일반 에이전트 탐지
  - `cleanup detects keeper zombie` — 3600s 초과 keeper 에이전트 탐지
  - `cleanup spares recent keeper` — 3600s 미만 keeper 에이전트 보존

🤖 Generated with [Claude Code](https://claude.com/claude-code)