### PR TITLE
feat(viewer): tab-based TRPG control separation + MCP hardening

### DIFF
--- a/lib/mcp_server_eio.ml
+++ b/lib/mcp_server_eio.ml
@@ -764,6 +764,13 @@ let cosine_similarity a b =
 
     All legacy bridges have been removed.
 *)
+let read_only_tools =
+  ["masc_status"; "masc_tasks"; "masc_who"; "masc_agents";
+   "masc_messages"; "masc_task_history"; "masc_votes"; "masc_vote_status";
+   "masc_worktree_list"; "masc_pending_interrupts";
+   "masc_cost_report"; "masc_portal_status";
+   "masc_goal_list"]
+
 let execute_tool_eio ~sw ~clock ?mcp_session_id ?auth_token state ~name ~arguments =
   (* clock parameter used for Session_eio.wait_for_message *)
   (* mcp_session_id: HTTP MCP session ID for agent_name persistence across tool calls *)
@@ -987,11 +994,6 @@ let execute_tool_eio ~sw ~clock ?mcp_session_id ?auth_token state ~name ~argumen
       (false, Printf.sprintf "❌ %s" msg)
   | None ->
 
-  let read_only_tools = ["masc_status"; "masc_tasks"; "masc_who"; "masc_agents";
-                         "masc_messages"; "masc_task_history"; "masc_votes"; "masc_vote_status";
-                         "masc_worktree_list"; "masc_pending_interrupts";
-                         "masc_cost_report"; "masc_portal_status";
-                         "masc_goal_list"] in
   let is_read_only = List.mem name read_only_tools in
 
   let can_auto_join =
@@ -2494,6 +2496,106 @@ let int_of_env_default name ~default ~min_v ~max_v =
       in
       max min_v (min max_v parsed)
 
+let contains_casefold haystack needle =
+  let haystack = String.lowercase_ascii haystack in
+  let needle = String.lowercase_ascii needle in
+  try
+    ignore (Str.search_forward (Str.regexp_string needle) haystack 0);
+    true
+  with Not_found -> false
+
+let parse_status_from_message ~success ~message =
+  if not success then
+    if
+      contains_casefold message "input required"
+      || contains_casefold message "ask agent"
+      || contains_casefold message "ask agent question"
+    then
+      ("ask_agent_question", Some "ask_agent_question")
+    else if
+      contains_casefold message "auth required"
+      || contains_casefold message "authentication required"
+      || contains_casefold message "unauthorized"
+    then
+      ("ask_for_auth", Some "ask_for_auth")
+    else
+      ("error", None)
+  else
+    ("ok", None)
+
+let quality_issue severity code message attempts =
+  `Assoc [
+    ("severity", `String severity);
+    ("code", `String code);
+    ("message", `String message);
+    ("retry_attempts", `Int attempts);
+  ]
+
+let quality_from_result ~success ~message ~attempts =
+  if success then
+    `Assoc [
+      ("passed", `Bool true);
+      ("issues", `List []);
+    ]
+  else
+    let issue =
+      if contains_casefold message "timeout" then
+        quality_issue "warning" "tool_timeout" message attempts
+      else
+        quality_issue "error" "tool_failure" message attempts
+    in
+    `Assoc [
+      ("passed", `Bool false);
+      ("issues", `List [issue]);
+    ]
+
+let read_only_retry_limit () =
+  match Sys.getenv_opt "MASC_TOOL_READONLY_RETRY_LIMIT" with
+  | Some raw ->
+      (try
+         let parsed = int_of_string (String.trim raw) in
+         max 1 (min 5 parsed)
+       with _ -> 2)
+  | None -> 2
+
+let is_retryable_message message =
+  contains_casefold message "timeout" ||
+  contains_casefold message "temporary" ||
+  contains_casefold message "temporarily" ||
+  contains_casefold message "econn" ||
+  contains_casefold message "connection" ||
+  contains_casefold message "unavailable" ||
+  contains_casefold message "rate limit" ||
+  contains_casefold message "502" ||
+  contains_casefold message "503"
+
+let read_only_retry_wait ~attempt =
+  let attempt = float_of_int attempt in
+  min 1.5 (0.2 *. attempt)
+
+let call_tool_with_readonly_retry
+    ~clock
+    ~run_tool
+    ~is_read_only
+    () =
+  let max_attempts = read_only_retry_limit () in
+  let rec loop attempt =
+    let (success, message) =
+      run_tool ()
+    in
+    if
+      success
+      || attempt >= max_attempts
+      || not is_read_only
+      || not (is_retryable_message message)
+    then
+      (success, message, attempt)
+    else (
+      Eio.Time.sleep clock (read_only_retry_wait ~attempt);
+      loop (attempt + 1))
+  in
+  loop 1
+
 (** Optional per-tool timeout to prevent long calls from starving the request loop. *)
 let tool_timeout_sec_opt ~(tool_name : string) : float option =
   match tool_name with
@@ -2512,51 +2614,62 @@ let handle_call_tool_eio ~sw ~clock ?mcp_session_id ?auth_token state id params 
   let module U = Yojson.Safe.Util in
   let name = params |> U.member "name" |> U.to_string in
   let arguments = params |> U.member "arguments" in
+  let is_read_only = List.mem name read_only_tools in
 
   (* Measure execution time for telemetry *)
   let start_time = Eio.Time.now clock in
   let timeout_hit = ref false in
-  let (success, message) =
-    try
-      match tool_timeout_sec_opt ~tool_name:name with
-      | None ->
-          execute_tool_eio ~sw ~clock ?mcp_session_id ?auth_token state ~name ~arguments
-      | Some timeout_sec ->
-          (try
-             Eio.Time.with_timeout_exn
-               clock
-               timeout_sec
-               (fun () ->
-                 execute_tool_eio
-                   ~sw
-                   ~clock
-                   ?mcp_session_id
-                   ?auth_token
-                   state
-                 ~name
-                 ~arguments)
-           with Eio.Time.Timeout ->
-             timeout_hit := true;
-             Log.Mcp.error "tools/call timeout: %s after %.0fs" name timeout_sec;
-             ( false,
-               Printf.sprintf
-                 "❌ Tool timed out after %.0fs: %s (env: MASC_TOOL_TIMEOUT_KEEPER_MSG_SEC)"
+let execute_with_timeout () =
+    let local_timeout_hit = ref false in
+    let result =
+      try
+        match tool_timeout_sec_opt ~tool_name:name with
+        | None ->
+            execute_tool_eio ~sw ~clock ?mcp_session_id ?auth_token state ~name ~arguments
+        | Some timeout_sec ->
+            (try
+               Eio.Time.with_timeout_exn
+                 clock
                  timeout_sec
-                 name ))
-    with exn ->
-      (* Never let a tool exception crash the MCP server. *)
-      let err = Printexc.to_string exn in
-      if String.starts_with ~prefix:"Invalid_argument(\"MASC not initialized." err then
-        let msg =
-          if err = "Invalid_argument(\"MASC not initialized. Use masc_init first.\")" then
-            Types.masc_error_to_string Types.NotInitialized
-          else
-            Printf.sprintf "❌ Invalid argument: %s" err
-        in
-        (false, msg)
-      else
-        (Log.Mcp.error "tools/call crashed: %s" err;
-         false, Printf.sprintf "❌ Internal error: %s" err)
+                 (fun () ->
+                   execute_tool_eio
+                     ~sw
+                     ~clock
+                     ?mcp_session_id
+                     ?auth_token
+                     state
+                     ~name
+                     ~arguments)
+             with Eio.Time.Timeout ->
+               local_timeout_hit := true;
+               Log.Mcp.error "tools/call timeout: %s after %.0fs" name timeout_sec;
+               (false,
+                Printf.sprintf
+                  "❌ Tool timed out after %.0fs: %s (env: MASC_TOOL_TIMEOUT_KEEPER_MSG_SEC)"
+                  timeout_sec
+                  name))
+     with exn ->
+       (* Never let a tool exception crash the MCP server. *)
+       let err = Printexc.to_string exn in
+       if contains_casefold err "Invalid_argument(\"MASC not initialized" then
+         (false, Types.masc_error_to_string Types.NotInitialized)
+       else
+         (Log.Mcp.error "tools/call crashed: %s" err;
+          false, Printf.sprintf "❌ Internal error: %s" err)
+  in
+  if !local_timeout_hit then timeout_hit := true;
+  result
+in
+let (success, message, attempts) =
+  if is_read_only then
+    call_tool_with_readonly_retry
+      ~clock
+      ~run_tool:execute_with_timeout
+      ~is_read_only
+      ()
+  else
+    let (success, message) = execute_with_timeout () in
+    (success, message, 1)
   in
   let end_time = Eio.Time.now clock in
   let duration_ms = int_of_float ((end_time -. start_time) *. 1000.0) in
@@ -2595,7 +2708,32 @@ let handle_call_tool_eio ~sw ~clock ?mcp_session_id ?auth_token state id params 
             Printf.eprintf "[WARN] telemetry tracking failed: %s\n%!" (Printexc.to_string exn))
      | None -> ());
 
+  let trace_id =
+    match id with
+    | `String s -> s
+    | `Int i -> string_of_int i
+    | `Intlit s -> s
+    | `Float f -> Printf.sprintf "%0.0f" f
+    | _ -> "unknown"
+  in
+  let (status, required_follow_up) = parse_status_from_message ~success ~message in
+  let quality = quality_from_result ~success ~message ~attempts in
+  let envelope =
+    `Assoc [
+      ("kind", `String "tool_call");
+      ("summary", `String message);
+      ("status", `String status);
+      ("tool", `String name);
+      ("required_follow_up",
+       (match required_follow_up with
+        | None -> `Null
+        | Some value -> `String value));
+      ("trace_id", `String trace_id);
+      ("quality", quality);
+    ]
+  in
   let result = make_response ~id (`Assoc [
+    ("resultEnvelope", envelope);
     ("content", `List [
       `Assoc [
         ("type", `String "text");
@@ -2695,38 +2833,52 @@ let handle_request ~clock ~sw ?mcp_session_id ?auth_token state request_str =
         else if not (is_jsonrpc_v2 json) then
           make_error ~id:`Null (-32600) "Invalid Request: jsonrpc must be 2.0"
         else
-          match jsonrpc_request_of_yojson json with
-          | Error msg -> make_error ~id:`Null ~data:(`String msg) (-32600) "Invalid Request"
-          | Ok req ->
-              let id = get_id req in
-              if not (is_valid_request_id id) then
-                make_error ~id:`Null (-32600) "Invalid Request: id must be string, number, or null"
-              else if is_notification req then
-                `Null
-              else
-                (match req.method_ with
-                | "initialize" -> handle_initialize_eio id req.params
-                | "initialized"
-                | "notifications/initialized" -> make_response ~id `Null
-                | "resources/list" -> handle_list_resources_eio id
-                | "resources/read" ->
-                    (* Eio native - pure sync resource reading *)
-                    handle_read_resource_eio state id req.params
-                | "resources/templates/list" -> handle_list_resource_templates_eio id
-                | "prompts/list" -> handle_list_prompts_eio id
-                | "tools/list" -> handle_list_tools_eio state id
-                | "tools/call" ->
-                    (match req.params with
-                    | Some params ->
-                        let name = Yojson.Safe.Util.(params |> member "name" |> to_string) in
-                        Printf.eprintf "[MCP] tools/call: %s (id=%s, session=%s)\n%!" name
-                          (match id with `Int i -> string_of_int i | `String s -> s | _ -> "?")
-                          (match mcp_session_id with Some s -> s | None -> "none");
-                        let result = handle_call_tool_eio ~sw ~clock ?mcp_session_id ?auth_token state id params in
-                        Printf.eprintf "[MCP] tools/call done: %s\n%!" name;
-                        result
-                    | None -> make_error ~id (-32602) "Missing params")
-                | method_ -> make_error ~id (-32601) ("Method not found: " ^ method_))
+        match jsonrpc_request_of_yojson json with
+        | Error msg -> make_error ~id:`Null ~data:(`String msg) (-32600) "Invalid Request"
+        | Ok req ->
+            let id = get_id req in
+            if not (is_valid_request_id id) then
+              make_error ~id:`Null (-32600) "Invalid Request: id must be string, number, or null"
+            else if is_notification req then
+              `Null
+            else
+                (try
+                   (match req.method_ with
+                   | "initialize" -> handle_initialize_eio id req.params
+                   | "initialized"
+                   | "notifications/initialized" -> make_response ~id `Null
+                   | "resources/list" -> handle_list_resources_eio id
+                   | "resources/read" ->
+                       (* Eio native - pure sync resource reading *)
+                       handle_read_resource_eio state id req.params
+                   | "resources/templates/list" -> handle_list_resource_templates_eio id
+                   | "prompts/list" -> handle_list_prompts_eio id
+                   | "tools/list" -> handle_list_tools_eio state id
+                   | "tools/call" ->
+                       (match req.params with
+                       | Some params ->
+                           (try
+                             let name = Yojson.Safe.Util.(params |> member "name" |> to_string) in
+                             Printf.eprintf "[MCP] tools/call: %s (id=%s, session=%s)\n%!" name
+                               (match id with `Int i -> string_of_int i | `String s -> s | _ -> "?")
+                               (match mcp_session_id with Some s -> s | None -> "none");
+                             let result =
+                               handle_call_tool_eio ~sw ~clock ?mcp_session_id ?auth_token state id params
+                             in
+                             Printf.eprintf "[MCP] tools/call done: %s\n%!" name;
+                             result
+                           with _ ->
+                             make_error ~id (-32602) "Invalid params: name must be a string")
+                       | None -> make_error ~id (-32602) "Missing params")
+                   | method_ -> make_error ~id (-32601) ("Method not found: " ^ method_))
+                 with
+                 | Invalid_argument msg
+                   when contains_casefold msg "invalid_argument(\"masc not initialized" ->
+                     make_error ~id (-32603) (Types.masc_error_to_string Types.NotInitialized)
+                   | exn ->
+                       let err = Printexc.to_string exn in
+                       Log.Mcp.error "Request handling failed: %s" err;
+                       make_error ~id (-32603) (Printf.sprintf "Internal error: %s" err))
   with exn ->
     make_error ~id:`Null ~data:(`String (Printexc.to_string exn)) (-32603) "Internal error"
 

--- a/test/test_mcp_server_coverage.ml
+++ b/test/test_mcp_server_coverage.ml
@@ -451,6 +451,39 @@ let test_handle_request_missing_params_tools_call () =
 
   cleanup_dir base_path
 
+let test_handle_request_tools_call_invalid_name_type () =
+  Eio_main.run @@ fun env ->
+  let clock = Eio.Stdenv.clock env in
+  Eio.Switch.run @@ fun sw ->
+
+  let base_path = temp_dir () in
+  let state = Mcp_eio.create_state ~test_mode:true ~base_path () in
+
+  let request = Yojson.Safe.to_string (`Assoc [
+    ("jsonrpc", `String "2.0");
+    ("id", `Int 1);
+    ("method", `String "tools/call");
+    ("params", `Assoc [
+      ("name", `Int 1);
+      ("arguments", `Assoc []);
+    ]);
+  ]) in
+
+  let response = Mcp_eio.handle_request ~clock ~sw state request in
+
+  (match response with
+   | `Assoc fields ->
+       Alcotest.(check bool) "has error" true (List.mem_assoc "error" fields);
+       (match List.assoc_opt "error" fields with
+        | Some (`Assoc error_fields) ->
+            (match List.assoc_opt "code" error_fields with
+             | Some (`Int code) -> Alcotest.(check int) "error code -32602" (-32602) code
+             | _ -> Alcotest.fail "error code missing")
+        | _ -> Alcotest.fail "error not an object")
+   | _ -> Alcotest.fail "response not an object");
+
+  cleanup_dir base_path
+
 let test_handle_request_tool_masc_status () =
   Eio_main.run @@ fun env ->
   let clock = Eio.Stdenv.clock env in
@@ -509,6 +542,24 @@ let test_handle_request_tool_not_initialized_error () =
             (match List.assoc_opt "isError" result_fields with
              | Some (`Bool is_error) -> Alcotest.(check bool) "isError true" true is_error
              | _ -> Alcotest.fail "isError missing");
+            (match List.assoc_opt "resultEnvelope" result_fields with
+             | Some (`Assoc envelope) ->
+                 (match List.assoc_opt "kind" envelope with
+                  | Some (`String kind) ->
+                      Alcotest.(check string) "envelope kind" "tool_call" kind
+                  | _ -> Alcotest.fail "resultEnvelope.kind missing");
+                 (match List.assoc_opt "status" envelope with
+                  | Some (`String status) ->
+                      Alcotest.(check string) "envelope status" "error" status
+                  | _ -> Alcotest.fail "resultEnvelope.status missing");
+                 (match List.assoc_opt "quality" envelope with
+                  | Some (`Assoc quality) -> (
+                      (match List.assoc_opt "passed" quality with
+                       | Some (`Bool passed) -> Alcotest.(check bool) "quality passed false" false passed
+                       | _ -> Alcotest.fail "quality.passed missing")
+                    )
+                  | _ -> Alcotest.fail "resultEnvelope.quality missing")
+             | _ -> Alcotest.fail "resultEnvelope missing");
             (match List.assoc_opt "content" result_fields with
              | Some (`List items) ->
                  (match items with
@@ -520,11 +571,10 @@ let test_handle_request_tool_not_initialized_error () =
                        | _ -> Alcotest.fail "missing text")
                   | _ -> Alcotest.fail "content not a list of objects")
              | _ -> Alcotest.fail "content missing")
-        | _ -> Alcotest.fail "result not object")
+             | _ -> Alcotest.fail "result not object")
    | _ -> Alcotest.fail "response not an object");
 
   cleanup_dir base_path
-
 (* ===== 10. Execute Tool Tests ===== *)
 
 let test_execute_tool_masc_set_room () =
@@ -714,6 +764,7 @@ let eio_tests = [
   "handle_notification_initialized", `Quick, test_handle_request_notification_initialized;
   "handle_wrong_jsonrpc_version", `Quick, test_handle_request_wrong_jsonrpc_version;
   "handle_missing_params", `Quick, test_handle_request_missing_params_tools_call;
+  "handle_invalid_tool_name_type", `Quick, test_handle_request_tools_call_invalid_name_type;
   "handle_tool_masc_status", `Quick, test_handle_request_tool_masc_status;
   "handle_tool_not_initialized_error", `Quick, test_handle_request_tool_not_initialized_error;
 ]

--- a/viewer/index.html
+++ b/viewer/index.html
@@ -149,46 +149,12 @@
 
     <!-- ═══ Dashboard (Active Mode View) ═══ -->
     <div id="dashboard" style="display: none;" data-auto-round="1">
-        <!-- Top Bar -->
+        <!-- Top Bar (minimal navigation) -->
         <header id="top-bar">
             <button id="back-to-lobby" class="icon-btn" title="Back to Lobby">◂</button>
             <span id="mode-title">—</span>
             <div class="top-bar-right">
-                <div class="room-switch-inline">
-                    <select id="room-selector-inline" class="inline-select" title="진행 중인 게임 방 선택">
-                        <option value="default" selected>default</option>
-                    </select>
-                    <input id="room-input-inline" class="inline-input" type="text" value="default" placeholder="방 이름 입력" maxlength="64" title="이동할 방 이름을 직접 입력" />
-                    <button id="room-apply-btn" class="inline-toggle" type="button" title="입력한 방으로 이동합니다">이동</button>
-                    <button id="room-refresh-btn" class="inline-toggle" type="button" title="서버에서 방 목록을 다시 불러옵니다">방 새로고침</button>
-                    <button id="room-hub-toggle" class="inline-toggle" type="button" aria-pressed="false" title="전체 방 목록 패널을 열거나 닫습니다">방 목록</button>
-                    <span id="room-status" class="widget-pill">현재 게임: default</span>
-                </div>
-                <button id="new-game-toggle" class="inline-toggle" type="button" title="새로운 TRPG 세션을 시작합니다">새 게임</button>
-                <button id="auto-round-toggle" class="inline-toggle" type="button" aria-pressed="true" title="AI 턴 자동 진행을 멈춥니다">자동 진행: ON</button>
-                <div class="session-control-inline">
-                    <button id="session-pause-btn" class="inline-toggle" type="button" title="현재 세션을 멈춥니다">멈춤</button>
-                    <button id="session-resume-btn" class="inline-toggle" type="button" title="멈춘 세션을 재개합니다">재개</button>
-                    <span id="session-control-status" class="widget-pill">세션 제어 대기</span>
-                </div>
-                <button id="view-options-toggle" class="inline-toggle" type="button" aria-pressed="false" title="화면 표시 옵션 열기/닫기">화면 옵션</button>
-                <div id="view-options-popover" class="view-options-popover" style="display:none">
-                    <label><input id="opt-show-ops" type="checkbox" checked /> 운영 HUD</label>
-                    <label><input id="opt-show-secondary" type="checkbox" checked /> 내러티브 패널</label>
-                    <label><input id="opt-show-tertiary" type="checkbox" checked /> 파티 패널</label>
-                    <label><input id="opt-show-bottom" type="checkbox" checked /> 하단 로그</label>
-                </div>
-                <select id="theme-selector-inline" class="inline-select">
-                    <option value="dark-fantasy">Dark Fantasy</option>
-                    <option value="cyberpunk">Cyberpunk</option>
-                    <option value="terminal">Terminal</option>
-                    <option value="parchment">Parchment</option>
-                </select>
-              <button id="debug-log-toggle" class="inline-toggle debug-only" type="button" aria-pressed="false" title="개발자 디버그 로그 표시/숨김">Debug</button>
-              <span id="debug-log-status" class="widget-pill debug-only" style="display:none">DEBUG</span>
-              <span id="widget-status" class="widget-pill debug-only" style="display:none">Widgets N:0 P:0 H:0</span>
-              <button id="dedup-status" class="widget-pill dedup-pill debug-only" type="button" aria-expanded="false" style="display:none">Dedup S:0 N:0 H:0</button>
-              <div id="dedup-popover" class="dedup-popover" style="display:none"></div>
+                <button id="ops-hud-toggle" class="inline-toggle" type="button" title="운영 상태 패널 열기/닫기">상태</button>
                 <div id="connection-status" class="disconnected">
                     <span class="status-dot"></span>
                     <span class="status-text">Disconnected</span>
@@ -196,7 +162,77 @@
             </div>
         </header>
 
-        <section id="ops-hud" aria-label="TRPG 운영 상태">
+        <!-- Tab Bar (context separation) -->
+        <nav id="control-tab-bar" class="control-tab-bar">
+            <button class="tab-btn active" data-tab="room">방</button>
+            <button class="tab-btn" data-tab="game">게임</button>
+            <button class="tab-btn" data-tab="settings">설정</button>
+        </nav>
+
+        <!-- Tab Panel: 방 -->
+        <div id="tab-panel-room" class="tab-panel active">
+            <div class="room-switch-inline">
+                <select id="room-selector-inline" class="inline-select" title="진행 중인 게임 방 선택">
+                    <option value="default" selected>default</option>
+                </select>
+                <input id="room-input-inline" class="inline-input" type="text" value="default" placeholder="방 이름 입력" maxlength="64" title="이동할 방 이름을 직접 입력" />
+                <button id="room-apply-btn" class="inline-toggle" type="button" title="입력한 방으로 이동합니다">이동</button>
+                <button id="room-refresh-btn" class="inline-toggle" type="button" title="서버에서 방 목록을 다시 불러옵니다">방 새로고침</button>
+                <button id="room-hub-toggle" class="inline-toggle" type="button" aria-pressed="false" title="전체 방 목록 패널을 열거나 닫습니다">방 목록</button>
+                <span id="room-status" class="widget-pill">현재 게임: default</span>
+            </div>
+        </div>
+
+        <!-- Tab Panel: 게임 -->
+        <div id="tab-panel-game" class="tab-panel">
+            <button id="new-game-toggle" class="inline-toggle" type="button" title="새로운 TRPG 세션을 시작합니다">새 게임</button>
+            <button id="auto-round-toggle" class="inline-toggle" type="button" aria-pressed="true" title="AI 턴 자동 진행을 멈춥니다">자동 진행: ON</button>
+            <div class="session-control-inline">
+                <button id="session-pause-btn" class="inline-toggle" type="button" title="현재 세션을 멈춥니다">멈춤</button>
+                <button id="session-resume-btn" class="inline-toggle" type="button" title="멈춘 세션을 재개합니다">재개</button>
+                <span id="session-control-status" class="widget-pill">세션 제어 대기</span>
+            </div>
+        </div>
+
+        <!-- Tab Panel: 설정 -->
+        <div id="tab-panel-settings" class="tab-panel">
+            <button id="view-options-toggle" class="inline-toggle" type="button" aria-pressed="false" aria-expanded="false" aria-haspopup="menu" aria-controls="view-options-popover" title="화면 표시 옵션 열기/닫기">화면 옵션</button>
+            <div id="view-options-popover" class="view-options-popover" role="menu" aria-label="화면 표시 메뉴" aria-labelledby="view-options-title" aria-hidden="true" style="display:none" tabindex="-1">
+                <div class="view-options-header">
+                    <span id="view-options-title" class="view-options-title">화면 표시</span>
+                    <button id="view-options-close" class="view-options-close" type="button" aria-label="화면 옵션 닫기">✕</button>
+                </div>
+                <label class="view-option-item" data-view-option-item="opt-show-ops"><input id="opt-show-ops" type="checkbox" role="menuitemcheckbox" aria-checked="true" checked /> 운영 HUD</label>
+                <label class="view-option-item" data-view-option-item="opt-show-secondary"><input id="opt-show-secondary" type="checkbox" role="menuitemcheckbox" aria-checked="true" checked /> 내러티브 패널</label>
+                <label class="view-option-item" data-view-option-item="opt-show-tertiary"><input id="opt-show-tertiary" type="checkbox" role="menuitemcheckbox" aria-checked="true" checked /> 파티 패널</label>
+                <label class="view-option-item" data-view-option-item="opt-show-bottom"><input id="opt-show-bottom" type="checkbox" role="menuitemcheckbox" aria-checked="true" checked /> 하단 로그</label>
+                <div class="view-options-divider"></div>
+                <label for="opt-log-view-mode" class="view-options-subtitle">로그 모드</label>
+                <label>
+                    <select id="opt-log-view-mode" role="menuitem">
+                        <option value="all" selected>전체</option>
+                        <option value="narrative">내러티브</option>
+                        <option value="action">액션</option>
+                        <option value="system">시스템</option>
+                        <option value="outcome">결과</option>
+                        <option value="debug">디버그</option>
+                    </select>
+                </label>
+            </div>
+            <select id="theme-selector-inline" class="inline-select">
+                <option value="dark-fantasy">Dark Fantasy</option>
+                <option value="cyberpunk">Cyberpunk</option>
+                <option value="terminal">Terminal</option>
+                <option value="parchment">Parchment</option>
+            </select>
+            <button id="debug-log-toggle" class="inline-toggle debug-only" type="button" aria-pressed="false" title="개발자 디버그 로그 표시/숨김">Debug</button>
+            <span id="debug-log-status" class="widget-pill debug-only" style="display:none">DEBUG</span>
+            <span id="widget-status" class="widget-pill debug-only" style="display:none">Widgets N:0 P:0 H:0</span>
+            <button id="dedup-status" class="widget-pill dedup-pill debug-only" type="button" aria-expanded="false" style="display:none">Dedup S:0 N:0 H:0</button>
+            <div id="dedup-popover" class="dedup-popover" style="display:none"></div>
+        </div>
+
+        <section id="ops-hud" class="collapsed" aria-label="TRPG 운영 상태">
             <div class="ops-hud-item">
                 <span class="ops-k">Room</span>
                 <span id="ops-room-id" class="ops-v">default</span>
@@ -220,6 +256,58 @@
             <div class="ops-hud-item">
                 <span class="ops-k">Sync</span>
                 <span id="ops-sync-state" class="ops-v">대기</span>
+            </div>
+        </section>
+
+        <section id="playability-proof" aria-label="TRPG 플레이 증명">
+            <div class="play-proof-card">
+                <div class="play-proof-head">
+                    <strong>플레이 증명</strong>
+                    <div class="play-proof-statuses">
+                        <span class="play-proof-tag">Liveness</span>
+                        <span id="play-proof-liveness-status" class="play-proof-status play-proof-warn">점검 중</span>
+                        <span class="play-proof-tag">Quality</span>
+                        <span id="play-proof-quality-status" class="play-proof-status play-proof-warn">점검 중</span>
+                    </div>
+                </div>
+                <div class="play-proof-grid">
+                    <div class="play-proof-item">
+                        <span class="play-proof-k">턴 진행</span>
+                        <span id="play-proof-turns" class="play-proof-v">turn=0 / started=0</span>
+                    </div>
+                    <div class="play-proof-item">
+                        <span class="play-proof-k">DM 응답</span>
+                        <span id="play-proof-dm" class="play-proof-v">0</span>
+                    </div>
+                    <div class="play-proof-item">
+                        <span class="play-proof-k">플레이어 액션</span>
+                        <span id="play-proof-actions" class="play-proof-v">0</span>
+                    </div>
+                    <div class="play-proof-item">
+                        <span class="play-proof-k">유니크 액터</span>
+                        <span id="play-proof-actors" class="play-proof-v">0</span>
+                    </div>
+                    <div class="play-proof-item">
+                        <span class="play-proof-k">Timeout</span>
+                        <span id="play-proof-timeout" class="play-proof-v">0</span>
+                    </div>
+                    <div class="play-proof-item">
+                        <span class="play-proof-k">Unavailable</span>
+                        <span id="play-proof-unavailable" class="play-proof-v">0</span>
+                    </div>
+                    <div class="play-proof-item">
+                        <span class="play-proof-k">Recovery</span>
+                        <span id="play-proof-recovery" class="play-proof-v">0</span>
+                    </div>
+                    <div class="play-proof-item">
+                        <span class="play-proof-k">Outcome</span>
+                        <span id="play-proof-outcome" class="play-proof-v">진행 중</span>
+                    </div>
+                </div>
+                <div id="play-proof-liveness-reasons" class="play-proof-reasons">Liveness 점검 중...</div>
+                <div id="play-proof-quality-reasons" class="play-proof-reasons">Quality 점검 중...</div>
+                <div id="play-proof-contract-status" class="play-proof-status play-proof-warn" style="display:none">점검 중</div>
+                <div id="play-proof-reasons" class="play-proof-reasons" style="display:none">계약 지표 수집 중...</div>
             </div>
         </section>
 
@@ -292,7 +380,7 @@
 
                     <label class="new-game-field">
                         <span>AI 모델 (쉼표로 구분)</span>
-                        <input id="new-game-models" type="text" value="ollama:glm-4.7-flash" title="AI가 사용할 LLM 모델 지정" />
+                        <input id="new-game-models" type="text" value="glm:glm-5,glm:glm-4.7,glm:glm-4.7-flashx,glm:glm-4.6v,glm:glm-4.5,ollama:glm-4.7-flash" title="AI가 사용할 LLM 모델 지정" />
                     </label>
                 </div>
 
@@ -445,6 +533,7 @@
                     <input type="hidden" id="round-run-timeout" value="45" />
                     <input type="hidden" id="round-run-lang" value="" />
                     <input type="hidden" id="round-run-players" value="" />
+                    <input type="hidden" id="round-run-fallback-mode" value="on" />
                     <details id="dm-voice-config" class="dm-voice-config">
                         <summary>DM 음성 설정</summary>
                         <div class="dm-voice-grid">
@@ -593,6 +682,9 @@
             <aside id="tertiary-zone">
                 <h2 class="panel-title" id="tertiary-title">Party</h2>
                 <div id="tertiary-content" class="scrollable">
+                    <div id="actor-inspector" class="actor-inspector">
+                        <div class="actor-inspector-empty">파티원을 선택하면 상세 정보가 표시됩니다.</div>
+                    </div>
                     <div id="character-panel"></div>
                 </div>
             </aside>
@@ -610,6 +702,33 @@
             </section>
         </footer>
     </div>
+
+    <script>
+    /* Tab switching + Ops HUD toggle */
+    (function () {
+        var tabBar = document.getElementById('control-tab-bar');
+        if (tabBar) {
+            tabBar.addEventListener('click', function (e) {
+                var btn = e.target.closest('.tab-btn');
+                if (!btn) return;
+                var tab = btn.dataset.tab;
+                document.querySelectorAll('.tab-btn').forEach(function (b) {
+                    b.classList.toggle('active', b === btn);
+                });
+                document.querySelectorAll('.tab-panel').forEach(function (p) {
+                    p.classList.toggle('active', p.id === 'tab-panel-' + tab);
+                });
+            });
+        }
+        var hudToggle = document.getElementById('ops-hud-toggle');
+        if (hudToggle) {
+            hudToggle.addEventListener('click', function () {
+                var hud = document.getElementById('ops-hud');
+                if (hud) hud.classList.toggle('collapsed');
+            });
+        }
+    })();
+    </script>
 
     <script>
     (function () {

--- a/viewer/src/dom/actor_lifecycle.rs
+++ b/viewer/src/dom/actor_lifecycle.rs
@@ -30,15 +30,13 @@ pub fn update_actor_lifecycle_dom(
                 .create_element("div")
                 .expect("create div for actor-spawn");
             div.set_class_name("narrative-entry actor-spawn");
-            let name = if p.name.is_empty() {
-                &p.actor_id
-            } else {
-                &p.name
+            let name = match p.name.as_deref() {
+                Some(n) if !n.is_empty() => n,
+                _ => &p.actor_id,
             };
-            let class_info = if p.class.is_empty() {
-                String::new()
-            } else {
-                format!(" ({})", html_escape(&p.class))
+            let class_info = match p.class.as_deref() {
+                Some(c) if !c.is_empty() => format!(" ({})", html_escape(c)),
+                _ => String::new(),
             };
             div.set_inner_html(&format!(
                 "<span class=\"actor-icon\">+</span> <strong>{}</strong>{} joined the adventure",
@@ -53,10 +51,9 @@ pub fn update_actor_lifecycle_dom(
                 .create_element("div")
                 .expect("create div for actor-delete");
             div.set_class_name("narrative-entry actor-delete");
-            let name = if p.name.is_empty() {
-                &p.actor_id
-            } else {
-                &p.name
+            let name = match p.name.as_deref() {
+                Some(n) if !n.is_empty() => n,
+                _ => &p.actor_id,
             };
             div.set_inner_html(&format!(
                 "<span class=\"actor-icon\">-</span> <strong>{}</strong> has left the adventure",
@@ -70,15 +67,13 @@ pub fn update_actor_lifecycle_dom(
                 .create_element("div")
                 .expect("create div for actor-claim");
             div.set_class_name("narrative-entry actor-claim");
-            let name = if p.name.is_empty() {
-                &p.actor_id
-            } else {
-                &p.name
+            let name = match p.name.as_deref() {
+                Some(n) if !n.is_empty() => n,
+                _ => &p.actor_id,
             };
-            let keeper = if p.keeper.is_empty() {
-                "a keeper"
-            } else {
-                &p.keeper
+            let keeper = match p.keeper.as_deref() {
+                Some(k) if !k.is_empty() => k,
+                _ => "a keeper",
             };
             div.set_inner_html(&format!(
                 "<span class=\"actor-icon\">&gt;</span> <strong>{}</strong> is now controlled by {}",
@@ -93,10 +88,9 @@ pub fn update_actor_lifecycle_dom(
                 .create_element("div")
                 .expect("create div for actor-release");
             div.set_class_name("narrative-entry actor-release");
-            let name = if p.name.is_empty() {
-                &p.actor_id
-            } else {
-                &p.name
+            let name = match p.name.as_deref() {
+                Some(n) if !n.is_empty() => n,
+                _ => &p.actor_id,
             };
             div.set_inner_html(&format!(
                 "<span class=\"actor-icon\">&lt;</span> <strong>{}</strong> is now uncontrolled",

--- a/viewer/src/dom/character_panel.rs
+++ b/viewer/src/dom/character_panel.rs
@@ -4,6 +4,8 @@ use crate::assets;
 use crate::dom::escape::html_escape;
 use crate::game::components::{Actor, Skill};
 use crate::game::state::TurnProgressState;
+use wasm_bindgen::closure::Closure;
+use wasm_bindgen::JsCast;
 
 /// Snapshot of actor state used for change detection.
 /// Re-render only fires when this changes.
@@ -11,21 +13,38 @@ use crate::game::state::TurnProgressState;
 pub struct ActorSnapshot {
     id: String,
     hp: i32,
+    hp_known: bool,
+    max_hp_known: bool,
     mp: i32,
+    mp_known: bool,
+    max_mp_known: bool,
     is_dead: bool,
+    atk_known: bool,
+    def_known: bool,
+    int_known: bool,
+    luck_known: bool,
     buff_count: usize,
     debuff_count: usize,
     skill_count: usize,
     condition_count: usize,
     equip_count: usize,
+    relation_count: usize,
+    contribution_score: i32,
+    contribution_last_reason: String,
+    contribution_reasons_fingerprint: String,
+    relationship_fingerprint: String,
 }
 
 /// Tracks the last known state so we only re-render on change.
 #[derive(Resource, Default)]
 pub struct CharacterPanelCache {
-    pub last_snapshot: Vec<(String, i32, bool)>,
+    pub last_snapshot: Vec<(String, i32, bool, bool, bool, bool, bool)>,
     pub last_full: Vec<ActorSnapshot>,
+    pub last_progress_signature: String,
 }
+
+pub(crate) const DEFAULT_ACTOR_INSPECTOR_EMPTY_MESSAGE: &str = "파티원을 선택하면 상세 정보가 표시됩니다.";
+pub(crate) const DEFAULT_ACTOR_INSPECTOR_NO_DIALOGUE_MESSAGE: &str = "최근 대사 없음";
 
 /// Determines HP bar color class based on percentage.
 fn hp_class(hp: i32, max_hp: i32) -> &'static str {
@@ -44,6 +63,45 @@ fn mp_class(mp: i32, max_mp: i32) -> &'static str {
         0..=20 => "mp-depleted",
         21..=50 => "mp-low",
         _ => "mp-full",
+    }
+}
+
+fn parse_bool_attr(value: Option<&str>) -> bool {
+    value
+        .map(|value| value.trim())
+        .filter(|value| !value.is_empty())
+        .is_some_and(|value| matches!(value, "1" | "true" | "on" | "yes"))
+}
+
+fn metric_text(current: i32, current_known: bool, max: i32, max_known: bool) -> String {
+    if current_known {
+        if max_known {
+            format!("{current} / {max}")
+        } else if max > 0 {
+            format!("{} / 미확인 최대", current)
+        } else {
+            current.to_string()
+        }
+    } else {
+        "미확인".to_string()
+    }
+}
+
+fn metric_text_class(current_known: bool, max_known: bool) -> &'static str {
+    if !current_known {
+        "actor-metric-unknown"
+    } else if max_known {
+        "actor-metric-known"
+    } else {
+        "actor-metric-partial"
+    }
+}
+
+fn known_stat_text(value: i32, known: bool) -> String {
+    if known {
+        value.to_string()
+    } else {
+        "-".to_string()
     }
 }
 
@@ -66,6 +124,47 @@ fn class_slug(class: &str) -> String {
     class
         .to_lowercase()
         .replace(|c: char| !c.is_ascii_alphanumeric(), "-")
+}
+
+fn dom_safe_id(value: &str) -> String {
+    let mut out = String::new();
+    let mut prev_hyphen = false;
+    for ch in value.trim().chars() {
+        let ch = ch.to_ascii_lowercase();
+        if ch.is_ascii_alphanumeric() || ch == '_' || ch == '-' {
+            out.push(ch);
+            prev_hyphen = false;
+        } else {
+            if !prev_hyphen && !out.is_empty() {
+                out.push('-');
+                prev_hyphen = true;
+            }
+        }
+    }
+    let collapsed = out.trim_matches('-').to_string();
+    let normalized = if collapsed.is_empty() {
+        "actor".to_string()
+    } else {
+        collapsed
+    };
+    if normalized.chars().next().is_some_and(|ch| ch.is_ascii_digit()) {
+        format!("a-{}", normalized)
+    } else {
+        normalized
+    }
+}
+
+fn ensure_unique_dom_id(base: &str, seen: &mut std::collections::HashSet<String>) -> String {
+    if seen.insert(base.to_string()) {
+        return base.to_string();
+    }
+    for suffix in 2..1000 {
+        let candidate = format!("{base}-{suffix}");
+        if seen.insert(candidate.clone()) {
+            return candidate;
+        }
+    }
+    base.to_string()
 }
 
 /// Icon for a condition name.
@@ -115,6 +214,109 @@ fn fmt_modifier(m: i32) -> String {
 
 fn normalize_lore_key(raw: &str) -> String {
     raw.trim().to_ascii_lowercase().replace(['-', ' '], "_")
+}
+
+fn collect_actor_aliases(actor_id: &str, actor_name: &str, keeper: &str) -> Vec<String> {
+    let mut aliases = Vec::new();
+    let mut seen = std::collections::HashSet::new();
+
+    let push_alias = |raw: &str, aliases: &mut Vec<String>, seen: &mut std::collections::HashSet<String>| {
+        let trimmed = raw.trim().to_ascii_lowercase();
+        if trimmed.is_empty() {
+            return;
+        }
+
+        let compact = trimmed.replace(['_', '-'], "");
+        let plain = trimmed
+            .chars()
+            .filter(|ch| ch.is_ascii_alphanumeric() || *ch == '-' || *ch == '_')
+            .collect::<String>();
+        for candidate in [trimmed.clone(), compact, plain] {
+            if !candidate.is_empty() && seen.insert(candidate.clone()) {
+                aliases.push(candidate);
+            }
+        }
+
+        if let Some((head, _)) = trimmed.split_once('-') {
+            if seen.insert(head.to_string()) {
+                aliases.push(head.to_string());
+            }
+        }
+        if let Some((head, _)) = trimmed.split_once('_') {
+            if seen.insert(head.to_string()) {
+                aliases.push(head.to_string());
+            }
+        }
+
+        if let Some((head, _)) = trimmed.rsplit_once('-') {
+            if seen.insert(head.to_string()) {
+                aliases.push(head.to_string());
+            }
+        }
+
+        if let Some((head, _)) = trimmed.rsplit_once('_') {
+            if seen.insert(head.to_string()) {
+                aliases.push(head.to_string());
+            }
+        }
+    };
+
+    let push_tokens = |raw: &str,
+                       aliases: &mut Vec<String>,
+                       seen: &mut std::collections::HashSet<String>| {
+        let normalized = raw.trim().to_ascii_lowercase();
+        if normalized.is_empty() {
+            return;
+        }
+
+        for token in normalized
+            .split(|ch| matches!(ch, '=' | ';' | ',' | '|' | '/' | '\\' | '(' | ')' | '[' | ']' | '{' | '}'))
+        {
+            let token = token.trim();
+            if token.is_empty() {
+                continue;
+            }
+
+            push_alias(token, aliases, seen);
+            for word in token.split_whitespace() {
+                if !word.trim().is_empty() {
+                    push_alias(word.trim(), aliases, seen);
+                }
+            }
+        }
+    };
+
+    push_tokens(actor_id, &mut aliases, &mut seen);
+    for token in actor_name.split_whitespace().filter(|token| !token.trim().is_empty()) {
+        push_tokens(token, &mut aliases, &mut seen);
+    }
+    push_tokens(keeper, &mut aliases, &mut seen);
+    aliases
+}
+
+fn identity_token(raw: &str) -> String {
+    raw.trim()
+        .to_ascii_lowercase()
+        .chars()
+        .filter(|ch| ch.is_ascii_alphanumeric())
+        .collect()
+}
+
+fn identity_matches(a: &str, b: &str) -> bool {
+    let a = a.trim().to_ascii_lowercase();
+    let b = b.trim().to_ascii_lowercase();
+    if a.is_empty() || b.is_empty() {
+        return false;
+    }
+    let compact_a = identity_token(&a);
+    let compact_b = identity_token(&b);
+
+    a == b
+        || compact_a == compact_b
+        || compact_a == b
+        || a == compact_b
+        || compact_a.ends_with(&compact_b)
+        || compact_b.ends_with(&compact_a)
 }
 
 struct SkillLore {
@@ -258,7 +460,7 @@ fn trait_description(name: &str) -> String {
         "protective" => "아군 대신 맞거나 엄호하는 선택을 우선합니다.".to_string(),
         "honor_bound" => {
             "약속과 규율을 중시해 협상/명예 관련 장면에서 신뢰를 얻습니다.".to_string()
-        }
+        },
         "intense" => "집중력이 높아 짧은 폭발력이나 몰입이 필요한 장면에 강합니다.".to_string(),
         "empathetic" => "상대 감정 신호를 잘 읽어 통찰/중재 상황에서 유리합니다.".to_string(),
         "fatalistic" => "불리한 상황을 감수하고 큰 대가를 선택하는 경향이 있습니다.".to_string(),
@@ -470,6 +672,632 @@ fn read_collapse_state() -> std::collections::HashSet<String> {
     std::collections::HashSet::new()
 }
 
+fn compact_inline(raw: &str) -> String {
+    raw.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
+struct ActorDialogueRow {
+    source: String,
+    text: String,
+}
+
+fn classify_actor_log_source(entry: &web_sys::Element) -> String {
+    let class_name = entry.class_name().to_ascii_lowercase();
+    if class_name.contains("history-event") {
+        let kind = entry.get_attribute("data-kind").unwrap_or_default();
+        let log_kind = entry.get_attribute("data-log-kind").unwrap_or_default();
+        let kind_label = match kind.as_str() {
+            "dice" => "주사위",
+            "turn" => "턴",
+            "progress" => "진행",
+            "system" => "시스템",
+            "narrative" => "내러티브",
+            _ => "이벤트",
+        };
+        let tone = match log_kind.as_str() {
+            "action" => "액션",
+            "outcome" => "결과",
+            "debug" => "디버그",
+            "system" => "시스템",
+            _ => "이벤트",
+        };
+        return format!("{kind_label}({tone})");
+    }
+    if class_name.contains("dice-entry") {
+        return "주사위".to_string();
+    }
+    if class_name.contains("narrative-entry") {
+        let phase = entry.get_attribute("data-phase").unwrap_or_default();
+        return if phase.trim().is_empty() {
+            "내러티브".to_string()
+        } else {
+            format!("내러티브({phase})")
+        };
+    }
+    "로그".to_string()
+}
+
+pub(crate) fn render_actor_inspector_empty(document: &web_sys::Document, message: &str) {
+    if let Some(panel) = document.get_element_by_id("actor-inspector") {
+        panel.set_inner_html(&format!(
+            "<div class=\"actor-inspector-empty\">{}</div>",
+            html_escape(message)
+        ));
+    }
+}
+
+fn collect_recent_actor_dialogues(
+    document: &web_sys::Document,
+    actor_id: &str,
+    actor_name: &str,
+    keeper: &str,
+) -> Vec<ActorDialogueRow> {
+    let Ok(entries) = document.query_selector_all(
+        "#narrative-log .narrative-entry, #session-history .history-event, #dice-log .dice-entry"
+    ) else {
+        return Vec::new();
+    };
+    let actor_id = actor_id.trim().to_ascii_lowercase();
+    let actor_name = actor_name.trim().to_ascii_lowercase();
+    let keeper = keeper.trim().to_ascii_lowercase();
+    let aliases = collect_actor_aliases(&actor_id, &actor_name, &keeper);
+    let mut normalized_identities = Vec::with_capacity(aliases.len() * 2 + 3);
+    for alias in aliases.iter() {
+        let alias = alias.trim();
+        if alias.is_empty() {
+            continue;
+        }
+        let compact = alias.replace(['_', '-'], "");
+        if !compact.is_empty() {
+            normalized_identities.push(compact);
+        }
+        normalized_identities.push(alias.to_string());
+    }
+    normalized_identities.push(actor_id.clone());
+    normalized_identities.push(actor_name.clone());
+    normalized_identities.push(keeper);
+    normalized_identities.push(actor_id.replace('_', ""));
+    normalized_identities.push(actor_name.replace('_', ""));
+    normalized_identities.sort();
+    normalized_identities.dedup();
+    normalized_identities.retain(|item| !item.is_empty());
+
+    let exact_match = |value: &str, identity: &str| {
+        if identity.is_empty() {
+            return false;
+        }
+        let value = value.trim().to_ascii_lowercase();
+        let compact_value = value.replace(['_', '-'], "");
+        value == identity || compact_value == identity || compact_value.ends_with(identity)
+    };
+
+    let mut rows = Vec::new();
+
+    let len = entries.length();
+    for idx in (0..len).rev() {
+        let Some(node) = entries.item(idx) else {
+            continue;
+        };
+        let Some(entry) = node.dyn_ref::<web_sys::Element>() else {
+            continue;
+        };
+
+        let actor_id_candidates = [
+            entry.get_attribute("data-actor-id").unwrap_or_default(),
+            entry
+                .query_selector(".history-actor")
+                .ok()
+                .flatten()
+                .and_then(|actor_el| actor_el.text_content())
+                .unwrap_or_default(),
+        ];
+        let actor_name_candidates = [
+            entry.get_attribute("data-actor-name").unwrap_or_default(),
+            entry
+                .get_attribute("data-speaker")
+                .unwrap_or_default(),
+            entry
+                .query_selector(".history-actor")
+                .ok()
+                .flatten()
+                .and_then(|actor_el| actor_el.text_content())
+                .unwrap_or_default(),
+        ];
+        let text = compact_inline(&entry.text_content().unwrap_or_default());
+        let is_speaker_match = actor_id_candidates
+            .iter()
+            .chain(actor_name_candidates.iter())
+            .any(|candidate| {
+                normalized_identities
+                    .iter()
+                    .any(|identity| exact_match(candidate, identity))
+            });
+
+        if !is_speaker_match {
+            continue;
+        }
+
+        let source = classify_actor_log_source(entry);
+        let clipped = if text.chars().count() > 140 {
+            let mut short = text.chars().take(140).collect::<String>();
+            short.push_str("...");
+            short
+        } else {
+            text
+        };
+        rows.push(ActorDialogueRow {
+            source,
+            text: clipped,
+        });
+        if rows.len() >= 4 {
+            break;
+        }
+    }
+    rows.reverse();
+    rows
+}
+
+fn render_actor_inspector(document: &web_sys::Document, selected: &web_sys::Element) {
+    let Some(panel) = document.get_element_by_id("actor-inspector") else {
+        return;
+    };
+    let actor_id = selected
+        .get_attribute("data-actor-id")
+        .unwrap_or_default()
+        .trim()
+        .to_string();
+    if actor_id.is_empty() {
+        render_actor_inspector_empty(document, DEFAULT_ACTOR_INSPECTOR_EMPTY_MESSAGE);
+        return;
+    }
+
+    let actor_name = selected
+        .get_attribute("data-actor-name")
+        .unwrap_or_default()
+        .trim()
+        .to_string();
+    let actor_class = selected
+        .get_attribute("data-actor-class")
+        .unwrap_or_default()
+        .trim()
+        .to_string();
+    let keeper = selected
+        .get_attribute("data-keeper")
+        .unwrap_or_default()
+        .trim()
+        .to_string();
+    let runtime_state = selected
+        .get_attribute("data-runtime-state")
+        .unwrap_or_default()
+        .trim()
+        .to_string();
+    let runtime_reason = selected
+        .get_attribute("data-runtime-reason")
+        .unwrap_or_default()
+        .trim()
+        .to_string();
+    let archetype = selected
+        .get_attribute("data-archetype")
+        .unwrap_or_default()
+        .trim()
+        .to_string();
+    let persona = selected
+        .get_attribute("data-persona")
+        .unwrap_or_default()
+        .trim()
+        .to_string();
+    let contribution_score = selected
+        .get_attribute("data-contribution-score")
+        .unwrap_or_default()
+        .trim()
+        .to_string();
+    let contribution_reason = selected
+        .get_attribute("data-contribution-reason")
+        .unwrap_or_default()
+        .trim()
+        .to_string();
+    let contribution_score_value = contribution_score
+        .trim()
+        .parse::<i32>()
+        .unwrap_or(0);
+    let contribution_reasons = selected
+        .get_attribute("data-contribution-reasons")
+        .unwrap_or_default()
+        .split('|')
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_string)
+        .collect::<Vec<_>>();
+    let hp = selected
+        .get_attribute("data-hp")
+        .and_then(|value| value.parse::<i32>().ok())
+        .unwrap_or(0);
+    let max_hp = selected
+        .get_attribute("data-max-hp")
+        .and_then(|value| value.parse::<i32>().ok())
+        .unwrap_or(0);
+    let mp = selected
+        .get_attribute("data-mp")
+        .and_then(|value| value.parse::<i32>().ok())
+        .unwrap_or(0);
+    let max_mp = selected
+        .get_attribute("data-max-mp")
+        .and_then(|value| value.parse::<i32>().ok())
+        .unwrap_or(0);
+    let hp_known = parse_bool_attr(selected.get_attribute("data-hp-known").as_deref());
+    let max_hp_known = parse_bool_attr(selected.get_attribute("data-max-hp-known").as_deref());
+    let mp_known = parse_bool_attr(selected.get_attribute("data-mp-known").as_deref());
+    let max_mp_known = parse_bool_attr(selected.get_attribute("data-max-mp-known").as_deref());
+    let atk = selected
+        .get_attribute("data-atk")
+        .and_then(|value| value.parse::<i32>().ok())
+        .unwrap_or(0);
+    let def = selected
+        .get_attribute("data-def")
+        .and_then(|value| value.parse::<i32>().ok())
+        .unwrap_or(0);
+    let int = selected
+        .get_attribute("data-int")
+        .and_then(|value| value.parse::<i32>().ok())
+        .unwrap_or(0);
+    let lck = selected
+        .get_attribute("data-luck")
+        .and_then(|value| value.parse::<i32>().ok())
+        .unwrap_or(0);
+    let atk_known = parse_bool_attr(selected.get_attribute("data-atk-known").as_deref());
+    let def_known = parse_bool_attr(selected.get_attribute("data-def-known").as_deref());
+    let int_known = parse_bool_attr(selected.get_attribute("data-int-known").as_deref());
+    let luck_known = parse_bool_attr(selected.get_attribute("data-luck-known").as_deref());
+    let relationship_rows = selected
+        .get_attribute("data-relationships")
+        .unwrap_or_default()
+        .split('|')
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_string)
+        .collect::<Vec<_>>();
+    let dialogue_rows = collect_recent_actor_dialogues(document, &actor_id, &actor_name, &keeper);
+
+    let dialogue_html = if dialogue_rows.is_empty() {
+        format!(
+            "<div class=\"actor-inspector-empty-sub\">{}</div>",
+            DEFAULT_ACTOR_INSPECTOR_NO_DIALOGUE_MESSAGE
+        )
+    } else {
+        dialogue_rows
+            .iter()
+            .map(|line| {
+                format!(
+                    "<div class=\"actor-inspector-line\"><span class=\"actor-inspector-source\">{}</span><span class=\"actor-inspector-line-text\">{}</span></div>",
+                    html_escape(&line.source),
+                    html_escape(&line.text)
+                )
+            })
+            .collect::<Vec<_>>()
+            .join("")
+    };
+    let relation_html = if relationship_rows.is_empty() {
+        "<span class=\"actor-inspector-muted\">관계 없음</span>".to_string()
+    } else {
+        relationship_rows
+            .iter()
+            .map(|line| format!("<span class=\"actor-rel-chip\">{}</span>", html_escape(line)))
+            .collect::<Vec<_>>()
+            .join("")
+    };
+    let contribution_reason_html = if contribution_reason.is_empty() {
+        "<span class=\"actor-inspector-muted\">기여 사유 없음</span>".to_string()
+    } else {
+        html_escape(&contribution_reason)
+    };
+    let contribution_score_class = if contribution_score_value > 0 {
+        "actor-score-positive"
+    } else if contribution_score_value < 0 {
+        "actor-score-negative"
+    } else {
+        "actor-score-neutral"
+    };
+    let contribution_score_text = if contribution_score_value > 0 {
+        format!("+{}", contribution_score_value)
+    } else {
+        contribution_score_value.to_string()
+    };
+    let contribution_reasons_html = if contribution_reasons.is_empty() {
+        String::new()
+    } else {
+        format!(
+            "<div class=\"actor-inspector-line\">최근 사유: {}</div>",
+            html_escape(&contribution_reasons.join(" · "))
+        )
+    };
+    let hp_display = metric_text(hp, hp_known, max_hp, max_hp_known);
+    let mp_display = metric_text(mp, mp_known, max_mp, max_mp_known);
+    let hp_display_class = metric_text_class(hp_known, max_hp_known);
+    let mp_display_class = metric_text_class(mp_known, max_mp_known);
+    let hp_known_badge = if hp_known {
+        if max_hp_known {
+            "확인됨"
+        } else {
+            "부분 확인"
+        }
+    } else {
+        "미확인"
+    };
+    let mp_known_badge = if mp_known {
+        if max_mp_known {
+            "확인됨"
+        } else {
+            "부분 확인"
+        }
+    } else {
+        "미확인"
+    };
+
+    let atk_text = known_stat_text(atk, atk_known);
+    let def_text = known_stat_text(def, def_known);
+    let int_text = known_stat_text(int, int_known);
+    let luck_text = known_stat_text(lck, luck_known);
+    let atk_class = metric_text_class(atk_known, true);
+    let def_class = metric_text_class(def_known, true);
+    let int_class = metric_text_class(int_known, true);
+    let luck_class = metric_text_class(luck_known, true);
+
+    panel.set_inner_html(&format!(
+        concat!(
+            "<div class=\"actor-inspector-head\">",
+            "<span class=\"actor-inspector-title\">{name}</span>",
+            "<span class=\"actor-inspector-id\">{id}</span>",
+            "</div>",
+            "<div class=\"actor-inspector-chips\">",
+            "<span class=\"actor-inspector-chip\">Class: {class_name}</span>",
+            "<span class=\"actor-inspector-chip\">Keeper: {keeper}</span>",
+            "<span class=\"actor-inspector-chip actor-inspector-chip-score {score_class}\">기여 {score}</span>",
+            "</div>",
+            "<div class=\"actor-inspector-grid\">",
+            "<div><span class=\"k\">HP</span><span class=\"v\"><span class=\"actor-inspector-metric {hp_metric_class}\">{hp}</span> <span class=\"actor-inspector-muted\">({hp_known_hint})</span></span></div>",
+            "<div><span class=\"k\">MP</span><span class=\"v\"><span class=\"actor-inspector-metric {mp_metric_class}\">{mp}</span> <span class=\"actor-inspector-muted\">({mp_known_hint})</span></span></div>",
+            "<div><span class=\"k\">현재 상태</span><span class=\"v\">{runtime}</span></div>",
+            "<div><span class=\"k\">상태 사유</span><span class=\"v\">{reason}</span></div>",
+            "</div>",
+            "<div class=\"actor-inspector-line\">Archetype: {archetype}</div>",
+            "<div class=\"actor-inspector-line\">Persona: {persona}</div>",
+            "<div class=\"actor-inspector-line\">능력치: <span class=\"actor-inspector-metric {atk_class}\">ATK={atk}</span> <span class=\"actor-inspector-metric {def_class}\">DEF={def}</span> <span class=\"actor-inspector-metric {int_class}\">INT={int}</span> <span class=\"actor-inspector-metric {luck_class}\">LCK={luck}</span></div>",
+            "<div class=\"actor-inspector-line\">최근 기여 사유: {contribution_reason}</div>",
+            "{contribution_reasons}",
+            "<div class=\"actor-inspector-section\">",
+            "<div class=\"actor-inspector-section-title\">관계</div>",
+            "<div class=\"actor-rel-list\">{relationships}</div>",
+            "</div>",
+            "<div class=\"actor-inspector-section\">",
+            "<div class=\"actor-inspector-section-title\">최근 대사 / 행동 로그 (선택 액터 관련)</div>",
+            "{dialogues}",
+            "</div>"
+        ),
+        name = html_escape(if actor_name.is_empty() {
+            actor_id.as_str()
+        } else {
+            actor_name.as_str()
+        }),
+        id = html_escape(&actor_id),
+        class_name = html_escape(if actor_class.is_empty() {
+            "-"
+        } else {
+            actor_class.as_str()
+        }),
+        keeper = html_escape(if keeper.is_empty() {
+            "미할당"
+        } else {
+            keeper.as_str()
+        }),
+        runtime = html_escape(if runtime_state.is_empty() {
+            "상태 없음"
+        } else {
+            runtime_state.as_str()
+        }),
+        reason = html_escape(if runtime_reason.is_empty() {
+            "사유 없음"
+        } else {
+            runtime_reason.as_str()
+        }),
+        archetype = html_escape(if archetype.is_empty() {
+            "-"
+        } else {
+            archetype.as_str()
+        }),
+        persona = html_escape(if persona.is_empty() {
+            "-"
+        } else {
+            persona.as_str()
+        }),
+        score = html_escape(&contribution_score_text),
+        score_class = contribution_score_class,
+        contribution_reason = contribution_reason_html,
+        contribution_reasons = contribution_reasons_html,
+        relationships = relation_html,
+        dialogues = dialogue_html,
+        hp = html_escape(&hp_display),
+        hp_metric_class = hp_display_class,
+        hp_known_hint = hp_known_badge,
+        mp = html_escape(&mp_display),
+        mp_metric_class = mp_display_class,
+        mp_known_hint = mp_known_badge,
+        atk_class = atk_class,
+        atk = html_escape(&atk_text),
+        def_class = def_class,
+        def = html_escape(&def_text),
+        int_class = int_class,
+        int = html_escape(&int_text),
+        luck_class = luck_class,
+        luck = html_escape(&luck_text),
+    ));
+}
+
+pub(crate) fn select_character_card(document: &web_sys::Document, actor_id: &str) {
+    let actor_id = actor_id.trim();
+    if actor_id.is_empty() {
+        return;
+    }
+    let actor_id_lower = actor_id.to_ascii_lowercase();
+    let query_aliases = collect_actor_aliases(&actor_id_lower, &actor_id_lower, "");
+
+    let Some(dashboard) = document.get_element_by_id("dashboard") else {
+        return;
+    };
+
+    let Ok(cards) = document.query_selector_all("#character-panel .character-card[data-actor-id]") else {
+        return;
+    };
+
+    let mut selected_card = None::<web_sys::Element>;
+    for idx in 0..cards.length() {
+        let Some(node) = cards.item(idx) else {
+            continue;
+        };
+        let Some(card) = node.dyn_ref::<web_sys::Element>() else {
+            continue;
+        };
+        let card_actor = card
+            .get_attribute("data-actor-id")
+            .unwrap_or_default()
+            .trim()
+            .to_string();
+        let card_name = card
+            .get_attribute("data-actor-name")
+            .unwrap_or_default()
+            .trim()
+            .to_string();
+        let card_keeper = card
+            .get_attribute("data-keeper")
+            .unwrap_or_default()
+            .trim()
+            .to_string();
+        let card_aliases = collect_actor_aliases(&card_actor, &card_name, &card_keeper);
+
+        let matched = card_actor.eq_ignore_ascii_case(actor_id)
+            || query_aliases
+                .iter()
+                .any(|q| card_aliases.iter().any(|alias| identity_matches(q, alias)));
+        if matched {
+            let _ = card.class_list().add_1("join-pick-selected");
+            let _ = card.set_attribute("aria-selected", "true");
+            selected_card = Some(card.clone());
+        } else {
+            let _ = card.class_list().remove_1("join-pick-selected");
+            let _ = card.set_attribute("aria-selected", "false");
+        }
+    }
+
+    let Some(card) = selected_card else {
+        let _ = dashboard.remove_attribute("data-selected-actor");
+        if let Some(input) = document
+            .get_element_by_id("actor-id-input")
+            .and_then(|el| el.dyn_into::<web_sys::HtmlInputElement>().ok())
+        {
+            input.set_value("");
+        }
+        render_actor_inspector_empty(document, DEFAULT_ACTOR_INSPECTOR_EMPTY_MESSAGE);
+        return;
+    };
+
+    let selected_id = card
+        .get_attribute("data-actor-id")
+        .unwrap_or_default()
+        .trim()
+        .to_string();
+    if !selected_id.is_empty() {
+        card.scroll_into_view_with_bool(true);
+        let _ = dashboard.set_attribute("data-selected-actor", &selected_id);
+        if let Some(input) = document
+            .get_element_by_id("actor-id-input")
+            .and_then(|el| el.dyn_into::<web_sys::HtmlInputElement>().ok())
+        {
+            input.set_value(&selected_id);
+        }
+        let _ = card.class_list().add_1("join-pick-selected");
+        let _ = card.set_attribute("aria-selected", "true");
+        render_actor_inspector(document, &card);
+    } else {
+        let _ = dashboard.remove_attribute("data-selected-actor");
+        if let Some(input) = document
+            .get_element_by_id("actor-id-input")
+            .and_then(|el| el.dyn_into::<web_sys::HtmlInputElement>().ok())
+        {
+            input.set_value("");
+        }
+        render_actor_inspector_empty(document, DEFAULT_ACTOR_INSPECTOR_EMPTY_MESSAGE);
+    }
+}
+
+fn resolve_character_card_actor_id(target: web_sys::EventTarget) -> Option<String> {
+    let card = if let Ok(el) = target.clone().dyn_into::<web_sys::Element>() {
+        el.closest(".character-card").ok().flatten()
+    } else {
+        target
+            .clone()
+            .dyn_into::<web_sys::Node>()
+            .ok()
+            .and_then(|node| node.parent_element())
+            .and_then(|el| el.closest(".character-card").ok().flatten())
+    };
+
+    card.and_then(|card| card.get_attribute("data-actor-id").map(|value| value.trim().to_string()))
+}
+
+fn ensure_character_panel_selection_binding(document: &web_sys::Document) {
+    let Some(panel) = document.get_element_by_id("character-panel") else {
+        return;
+    };
+    if panel
+        .get_attribute("data-bound-select")
+        .as_deref()
+        .map(|value| value == "1")
+        .unwrap_or(false)
+    {
+        return;
+    }
+
+    let cb = Closure::wrap(Box::new(move |evt: web_sys::Event| {
+        let Some(target) = evt.target() else {
+            return;
+        };
+        let Some(actor_id) = resolve_character_card_actor_id(target) else {
+            return;
+        };
+        if actor_id.is_empty() {
+            return;
+        }
+        let Some(document) = web_sys::window().and_then(|window| window.document()) else {
+            return;
+        };
+        select_character_card(&document, &actor_id);
+    }) as Box<dyn FnMut(_)>);
+    let _ = panel.add_event_listener_with_callback("click", cb.as_ref().unchecked_ref());
+    cb.forget();
+    let key_cb = Closure::wrap(Box::new(move |evt: web_sys::KeyboardEvent| {
+        if evt.key() != "Enter" && evt.key() != " " && evt.key() != "Spacebar" {
+            return;
+        }
+        let Some(target) = evt.target() else {
+            return;
+        };
+        let Some(actor_id) = resolve_character_card_actor_id(target) else {
+            return;
+        };
+        if actor_id.is_empty() {
+            return;
+        }
+        let Some(document) = web_sys::window().and_then(|window| window.document()) else {
+            return;
+        };
+        select_character_card(&document, &actor_id);
+        evt.prevent_default();
+    }) as Box<dyn FnMut(_)>);
+    let _ = panel
+        .add_event_listener_with_callback("keydown", key_cb.as_ref().unchecked_ref());
+    key_cb.forget();
+    let _ = panel.set_attribute("data-bound-select", "1");
+}
+
 /// Re-renders the #character-panel DOM whenever actor state changes.
 pub fn update_character_panel_dom(
     actors: Query<&Actor>,
@@ -477,9 +1305,19 @@ pub fn update_character_panel_dom(
     progress: Res<TurnProgressState>,
 ) {
     // Build current snapshot for cheap equality check
-    let compat_snapshot: Vec<(String, i32, bool)> = actors
+    let compat_snapshot: Vec<(String, i32, bool, bool, bool, bool, bool)> = actors
         .iter()
-        .map(|a| (a.id.clone(), a.hp, a.is_dead))
+        .map(|a| {
+            (
+                a.id.clone(),
+                a.hp,
+                a.is_dead,
+                a.hp_known,
+                a.max_hp_known,
+                a.mp_known,
+                a.max_mp_known,
+            )
+        })
         .collect();
 
     let full_snapshot: Vec<ActorSnapshot> = actors
@@ -487,22 +1325,65 @@ pub fn update_character_panel_dom(
         .map(|a| ActorSnapshot {
             id: a.id.clone(),
             hp: a.hp,
+            hp_known: a.hp_known,
+            max_hp_known: a.max_hp_known,
             mp: a.mp,
+            mp_known: a.mp_known,
+            max_mp_known: a.max_mp_known,
             is_dead: a.is_dead,
+            atk_known: a.atk_known,
+            def_known: a.def_known,
+            int_known: a.int_known,
+            luck_known: a.luck_known,
             buff_count: a.buffs.len(),
             debuff_count: a.debuffs.len(),
             skill_count: a.skills.len(),
             condition_count: a.conditions.len(),
             equip_count: a.equipment.len(),
+            relation_count: a.relationships.len(),
+            contribution_score: a.contribution_score,
+            contribution_last_reason: a.contribution_last_reason.trim().to_string(),
+            contribution_reasons_fingerprint: a.contribution_reasons.join("|"),
+            relationship_fingerprint: a.relationships.join("|"),
         })
         .collect();
 
+    let mut actor_state_rows = progress
+        .actor_states
+        .iter()
+        .map(|(actor, state)| format!("{}={}", actor.trim(), state.trim()))
+        .collect::<Vec<_>>();
+    actor_state_rows.sort();
+    let mut actor_reason_rows = progress
+        .actor_reasons
+        .iter()
+        .map(|(actor, reason)| format!("{}={}", actor.trim(), reason.trim()))
+        .collect::<Vec<_>>();
+    actor_reason_rows.sort();
+    let narrative_count = web_sys::window()
+        .and_then(|w| w.document())
+        .and_then(|d| d.get_element_by_id("narrative-log"))
+        .map(|el| el.child_element_count())
+        .unwrap_or(0);
+    let progress_signature = format!(
+        "{}|{}|{}|{}|{}",
+        progress.turn,
+        progress.phase.trim(),
+        actor_state_rows.join(","),
+        actor_reason_rows.join(","),
+        narrative_count
+    );
+
     // Skip if nothing changed
-    if compat_snapshot == cache.last_snapshot && full_snapshot == cache.last_full {
+    if compat_snapshot == cache.last_snapshot
+        && full_snapshot == cache.last_full
+        && progress_signature == cache.last_progress_signature
+    {
         return;
     }
     cache.last_snapshot = compat_snapshot;
     cache.last_full = full_snapshot;
+    cache.last_progress_signature = progress_signature;
 
     let Some(document) = web_sys::window().and_then(|w| w.document()) else {
         return;
@@ -524,15 +1405,23 @@ pub fn update_character_panel_dom(
     };
 
     let mut html = String::new();
+    let mut card_ids = std::collections::HashSet::new();
 
     for actor in actors.iter() {
-        let hp_pct = if actor.max_hp > 0 {
-            (actor.hp as f32 / actor.max_hp as f32 * 100.0).max(0.0)
+        let card_id = ensure_unique_dom_id(&format!("actor-{}", dom_safe_id(&actor.id)), &mut card_ids);
+        let escaped_actor_id = html_escape(&actor.id);
+        let data_actor_id = escaped_actor_id.clone();
+        let hp_display = metric_text(actor.hp, actor.hp_known, actor.max_hp, actor.max_hp_known);
+        let mp_display = metric_text(actor.mp, actor.mp_known, actor.max_mp, actor.max_mp_known);
+        let hp_display_class = metric_text_class(actor.hp_known, actor.max_hp_known);
+        let mp_display_class = metric_text_class(actor.mp_known, actor.max_mp_known);
+        let hp_pct = if actor.hp_known && actor.max_hp_known && actor.max_hp > 0 {
+            ((actor.hp.max(0) as f32 / actor.max_hp.max(1) as f32) * 100.0).clamp(0.0, 100.0)
         } else {
             0.0
         };
-        let mp_pct = if actor.max_mp > 0 {
-            (actor.mp as f32 / actor.max_mp as f32 * 100.0).max(0.0)
+        let mp_pct = if actor.mp_known && actor.max_mp_known && actor.max_mp > 0 {
+            ((actor.mp.max(0) as f32 / actor.max_mp.max(1) as f32) * 100.0).clamp(0.0, 100.0)
         } else {
             0.0
         };
@@ -558,7 +1447,7 @@ pub fn update_character_panel_dom(
             .get(&actor.id)
             .map_or(false, |s| s == "thinking");
         let keeper_line = if actor.keeper.trim().is_empty() {
-            "<div class=\"char-owner owner-unassigned\">keeper: (unassigned)</div>".to_string()
+            "<div class=\"char-owner owner-unassigned\">keeper: 미할당</div>".to_string()
         } else {
             let thinking_class = if is_thinking { " keeper-thinking" } else { "" };
             format!(
@@ -593,6 +1482,50 @@ pub fn update_character_panel_dom(
                 archetype_line, persona_line
             )
         };
+        let runtime_state = progress
+            .actor_states
+            .get(&actor.id)
+            .map(|value| value.trim().to_string())
+            .unwrap_or_default();
+        let runtime_reason = progress
+            .actor_reasons
+            .get(&actor.id)
+            .map(|value| value.trim().to_string())
+            .unwrap_or_default();
+        let runtime_line = if runtime_state.is_empty() && runtime_reason.is_empty() {
+            String::new()
+        } else {
+            format!(
+                "<div class=\"char-runtime\">state: {} · reason: {}</div>",
+                html_escape(if runtime_state.is_empty() {
+                    "상태 없음"
+                } else {
+                    runtime_state.as_str()
+                }),
+                html_escape(if runtime_reason.is_empty() {
+                    "사유 없음"
+                } else {
+                    runtime_reason.as_str()
+                })
+            )
+        };
+        let contribution_line = if actor.contribution_score == 0
+            && actor.contribution_last_reason.trim().is_empty()
+        {
+            String::new()
+        } else {
+            format!(
+                "<div class=\"char-contribution\">기여 {} · {}</div>",
+                actor.contribution_score,
+                html_escape(if actor.contribution_last_reason.trim().is_empty() {
+                    "기여 사유 없음"
+                } else {
+                    actor.contribution_last_reason.trim()
+                })
+            )
+        };
+        let relationships_attr = actor.relationships.join(" | ");
+        let contribution_reasons_attr = actor.contribution_reasons.join(" | ");
 
         // Buffs / debuffs
         let buffs_html = actor
@@ -633,9 +1566,9 @@ pub fn update_character_panel_dom(
         };
 
         // Collapsible section IDs
-        let traits_id = format!("toggle-traits-{}", actor.id);
-        let skills_id = format!("toggle-skills-{}", actor.id);
-        let equip_id = format!("toggle-equip-{}", actor.id);
+        let traits_id = format!("{}-traits", card_id);
+        let skills_id = format!("{}-skills", card_id);
+        let equip_id = format!("{}-equip", card_id);
 
         let traits_checked = if expanded.contains(&traits_id) {
             " checked"
@@ -799,26 +1732,79 @@ pub fn update_character_panel_dom(
             )
         };
 
-        // MP bar (only if max_mp > 0)
-        let mp_row = if actor.max_mp > 0 {
+        // Metrics row - hide synthetic bar when max is unknown.
+        let hp_row = if actor.hp_known && actor.max_hp_known && actor.max_hp > 0 {
+            format!(
+                concat!(
+                    "<div class=\"hp-row\">",
+                    "<div class=\"hp-bar-container\">",
+                    "<div class=\"hp-bar-fill {}\" style=\"width: {}%\"></div>",
+                    "</div>",
+                    "<div class=\"hp-text actor-inspector-metric {}\">{}</div>",
+                    "</div>",
+                ),
+                bar_class,
+                hp_pct,
+                hp_display_class,
+                html_escape(&hp_display),
+            )
+        } else {
+            format!(
+                "<div class=\"hp-row\"><div class=\"hp-text actor-inspector-metric {}\">{}</div></div>",
+                hp_display_class,
+                html_escape(&hp_display),
+            )
+        };
+        let mp_row = if actor.mp_known && actor.max_mp_known && actor.max_mp > 0 {
             format!(
                 concat!(
                     "<div class=\"mp-row\">",
                     "<div class=\"mp-bar-container\">",
                     "<div class=\"mp-bar-fill {}\" style=\"width: {}%\"></div>",
                     "</div>",
-                    "<div class=\"mp-text\">{} / {}</div>",
+                    "<div class=\"mp-text actor-inspector-metric {}\">{}</div>",
                     "</div>",
                 ),
-                mp_bar_class, mp_pct, actor.mp, actor.max_mp,
+                mp_bar_class,
+                mp_pct,
+                mp_display_class,
+                html_escape(&mp_display),
             )
         } else {
-            String::new()
+            format!(
+                "<div class=\"mp-row\"><div class=\"mp-text actor-inspector-metric {}\">{}</div></div>",
+                mp_display_class,
+                html_escape(&mp_display),
+            )
         };
+
+        let hp_attr = if actor.hp_known { "1" } else { "0" };
+        let max_hp_attr = if actor.max_hp_known { "1" } else { "0" };
+        let mp_attr = if actor.mp_known { "1" } else { "0" };
+        let max_mp_attr = if actor.max_mp_known { "1" } else { "0" };
+        let display_name = if actor.name.trim().is_empty() {
+            actor.id.clone()
+        } else {
+            actor.name.clone()
+        };
+        let atk_attr = if actor.atk_known { "1" } else { "0" };
+        let def_attr = if actor.def_known { "1" } else { "0" };
+        let int_attr = if actor.int_known { "1" } else { "0" };
+        let luck_attr = if actor.luck_known { "1" } else { "0" };
 
         html.push_str(&format!(
             concat!(
-                "<div class=\"character-card{}\" data-actor-id=\"{}\" data-class=\"{}\">",
+                "<div class=\"character-card{}\" role=\"button\" tabindex=\"0\" aria-label=\"{} 선택\" ",
+                "id=\"{}\" data-card-id=\"{}\" data-actor-id=\"{}\" data-class=\"{}\" ",
+                "data-actor-name=\"{}\" data-actor-class=\"{}\" data-keeper=\"{}\" ",
+                "data-archetype=\"{}\" data-persona=\"{}\" ",
+                "data-runtime-state=\"{}\" data-runtime-reason=\"{}\" ",
+                "data-hp=\"{}\" data-max-hp=\"{}\" data-hp-known=\"{}\" data-max-hp-known=\"{}\" ",
+                "data-mp=\"{}\" data-max-mp=\"{}\" data-mp-known=\"{}\" data-max-mp-known=\"{}\" ",
+                "data-atk=\"{}\" data-atk-known=\"{}\" data-def=\"{}\" data-def-known=\"{}\" ",
+                "data-int=\"{}\" data-int-known=\"{}\" data-luck=\"{}\" data-luck-known=\"{}\" ",
+                "data-contribution-score=\"{}\" data-contribution-reason=\"{}\" data-contribution-reasons=\"{}\" ",
+                "data-relationships=\"{}\" aria-selected=\"false\">",
                 "<div class=\"char-header\">",
                 "{}",
                 "<div class=\"char-identity\">",
@@ -828,44 +1814,74 @@ pub fn update_character_panel_dom(
                 "</div>",
                 "</div>",
                 "{}",
-                "<div class=\"hp-row\">",
-                "<div class=\"hp-bar-container\">",
-                "<div class=\"hp-bar-fill {}\" style=\"width: {}%\"></div>",
-                "</div>",
-                "<div class=\"hp-text\">{} / {}</div>",
-                "</div>",
+                "{}",
+                "{}",
                 "{}",
                 "<div class=\"char-stats\">",
-                "<div class=\"stat\"><div class=\"stat-value\">{}</div><div class=\"stat-label\">ATK</div></div>",
-                "<div class=\"stat\"><div class=\"stat-value\">{}</div><div class=\"stat-label\">DEF</div></div>",
-                "<div class=\"stat\"><div class=\"stat-value\">{}</div><div class=\"stat-label\">INT</div></div>",
-                "<div class=\"stat\"><div class=\"stat-value\">{}</div><div class=\"stat-label\">LCK</div></div>",
+                "<div class=\"stat\"><div class=\"stat-value actor-metric-{}\">{}</div><div class=\"stat-label\">ATK</div></div>",
+                "<div class=\"stat\"><div class=\"stat-value actor-metric-{}\">{}</div><div class=\"stat-label\">DEF</div></div>",
+                "<div class=\"stat\"><div class=\"stat-value actor-metric-{}\">{}</div><div class=\"stat-label\">INT</div></div>",
+                "<div class=\"stat\"><div class=\"stat-value actor-metric-{}\">{}</div><div class=\"stat-label\">LCK</div></div>",
                 "</div>",
                 "{}",
                 "<div class=\"char-effects\">{}{}</div>",
                 "{}",
                 "{}",
                 "{}",
+                "{}",
                 "</div>",
             ),
-            dead_class,
-            actor.id,
-            slug,
+                dead_class,
+                card_id,
+                card_id,
+                html_escape(&display_name),
+                data_actor_id,
+                slug,
+                html_escape(&actor.name),
+            html_escape(&actor.class),
+            html_escape(&actor.keeper),
+            html_escape(actor.archetype.trim()),
+            html_escape(actor.persona.trim()),
+            html_escape(&runtime_state),
+            html_escape(&runtime_reason),
+            actor.hp,
+            actor.max_hp,
+            hp_attr,
+            max_hp_attr,
+            actor.mp,
+            actor.max_mp,
+            mp_attr,
+            max_mp_attr,
+            actor.stats.atk,
+            atk_attr,
+            actor.stats.def,
+            def_attr,
+            actor.stats.int,
+            int_attr,
+            actor.stats.luck,
+            luck_attr,
+            actor.contribution_score,
+            html_escape(actor.contribution_last_reason.trim()),
+            html_escape(&contribution_reasons_attr),
+            html_escape(&relationships_attr),
             portrait_html,
             actor.name,
             icon,
             actor.class,
             lore_line,
             keeper_line,
-            bar_class,
-            hp_pct,
-            actor.hp,
-            actor.max_hp,
+            runtime_line,
+            contribution_line,
+            hp_row,
             mp_row,
-            actor.stats.atk,
-            actor.stats.def,
-            actor.stats.int,
-            actor.stats.luck,
+            metric_text_class(actor.atk_known, true),
+            html_escape(&known_stat_text(actor.stats.atk, actor.atk_known)),
+            metric_text_class(actor.def_known, true),
+            html_escape(&known_stat_text(actor.stats.def, actor.def_known)),
+            metric_text_class(actor.int_known, true),
+            html_escape(&known_stat_text(actor.stats.int, actor.int_known)),
+            metric_text_class(actor.luck_known, true),
+            html_escape(&known_stat_text(actor.stats.luck, actor.luck_known)),
             conditions_html,
             buffs_html,
             debuffs_html,
@@ -876,4 +1892,25 @@ pub fn update_character_panel_dom(
     }
 
     panel.set_inner_html(&html);
+    ensure_character_panel_selection_binding(&document);
+
+    let selected_actor = document
+        .get_element_by_id("dashboard")
+        .and_then(|el| el.get_attribute("data-selected-actor"))
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+        .or_else(|| {
+            document
+                .query_selector("#character-panel .character-card[data-actor-id]")
+                .ok()
+                .flatten()
+                .and_then(|el| el.get_attribute("data-actor-id"))
+                .map(|value| value.trim().to_string())
+                .filter(|value| !value.is_empty())
+        });
+    if let Some(actor_id) = selected_actor {
+        select_character_card(&document, &actor_id);
+    } else {
+        render_actor_inspector_empty(&document, DEFAULT_ACTOR_INSPECTOR_EMPTY_MESSAGE);
+    }
 }

--- a/viewer/src/dom/mod.rs
+++ b/viewer/src/dom/mod.rs
@@ -12,15 +12,21 @@ pub mod gameplay_events;
 pub mod map_canvas;
 pub mod narrative;
 pub mod overlay;
+pub mod playability_proof;
 pub mod session_events;
 pub mod session_history;
 pub mod turn_controls;
 pub mod turn_phase;
 pub mod turn_runtime;
+pub mod panel_visibility;
 
 use bevy::prelude::*;
 
 use crate::mode::ViewerMode;
+#[cfg(target_arch = "wasm32")]
+use crate::dom::panel_visibility::set_panel_visibility;
+#[cfg(target_arch = "wasm32")]
+use crate::dom::character_panel::{render_actor_inspector_empty, DEFAULT_ACTOR_INSPECTOR_EMPTY_MESSAGE};
 
 /// Plugin that bridges Bevy game state changes to HTML DOM updates.
 /// Text-heavy panels are rendered via DOM for scrolling, rich formatting, and CSS.
@@ -41,6 +47,8 @@ impl Plugin for DomBridgePlugin {
             .init_resource::<map_canvas::CanvasMapCache>()
             .init_resource::<overlay::OverlayCache>()
             .init_resource::<endgame::EndgameState>()
+            .init_resource::<crate::game::playability_contract::PlayabilityCounters>()
+            .init_resource::<crate::game::playability_contract::PlayabilityThresholds>()
             .add_systems(OnEnter(ViewerMode::Trpg), reset_trpg_dom_state)
             // TRPG-specific DOM update systems
             .add_systems(
@@ -62,6 +70,7 @@ impl Plugin for DomBridgePlugin {
                     overlay::update_overlay_dom,
                     actor_lifecycle::update_actor_lifecycle_dom,
                     session_events::update_session_events_dom,
+                    playability_proof::update_playability_proof_dom,
                 )
                     .run_if(in_state(ViewerMode::Trpg)),
             )
@@ -103,6 +112,7 @@ fn reset_trpg_dom_state(
 ) {
     character_cache.last_snapshot.clear();
     character_cache.last_full.clear();
+    character_cache.last_progress_signature.clear();
     turn_cache.last_turn = 0;
     turn_cache.last_phase.clear();
     runtime_cache.last_snapshot.clear();
@@ -130,6 +140,10 @@ fn reset_trpg_dom_state(
         if let Some(el) = document.get_element_by_id("character-panel") {
             el.set_inner_html("");
         }
+        if let Some(el) = document.get_element_by_id("dashboard") {
+            let _ = el.remove_attribute("data-selected-actor");
+        }
+        render_actor_inspector_empty(&document, DEFAULT_ACTOR_INSPECTOR_EMPTY_MESSAGE);
         if let Some(el) = document.get_element_by_id("turn-num") {
             el.set_text_content(Some("1"));
         }
@@ -176,6 +190,40 @@ fn reset_trpg_dom_state(
         if let Some(el) = document.get_element_by_id("event-beacon") {
             el.set_inner_html("");
             el.set_class_name("event-beacon");
+        }
+        set_panel_visibility(&document, "action-panel", false);
+        set_panel_visibility(&document, "join-panel", true);
+
+        // Tab reset: activate "방" tab on TRPG entry
+        for tab_id in ["tab-panel-room", "tab-panel-game", "tab-panel-settings"] {
+            if let Some(el) = document.get_element_by_id(tab_id) {
+                if tab_id == "tab-panel-room" {
+                    el.set_class_name("tab-panel active");
+                } else {
+                    el.set_class_name("tab-panel");
+                }
+            }
+        }
+        if let Some(bar) = document.get_element_by_id("control-tab-bar") {
+            if let Ok(buttons) = bar.query_selector_all(".tab-btn") {
+                for i in 0..buttons.length() {
+                    if let Some(node) = buttons.item(i) {
+                        if let Ok(btn) = node.dyn_into::<web_sys::Element>() {
+                            let is_room = btn.get_attribute("data-tab")
+                                .map_or(false, |v| v == "room");
+                            if is_room {
+                                let _ = btn.class_list().add_1("active");
+                            } else {
+                                let _ = btn.class_list().remove_1("active");
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        // Collapse ops-hud on entry
+        if let Some(hud) = document.get_element_by_id("ops-hud") {
+            let _ = hud.class_list().add_1("collapsed");
         }
     }
 }

--- a/viewer/src/dom/panel_visibility.rs
+++ b/viewer/src/dom/panel_visibility.rs
@@ -1,0 +1,46 @@
+#[cfg(target_arch = "wasm32")]
+use web_sys::Document;
+
+/// Show/hide a top-level TRPG panel by toggling CSS visibility signals.
+///
+/// The function writes a minimal inline style and updates aria-hidden
+/// so visibility checks remain consistent across DOM modules.
+#[cfg(target_arch = "wasm32")]
+pub(crate) fn set_panel_visibility(document: &Document, element_id: &str, visible: bool) {
+    let Some(el) = document.get_element_by_id(element_id) else {
+        return;
+    };
+
+    if visible {
+        let _ = el.set_attribute("style", "display: block; pointer-events: auto;");
+        let _ = el.set_attribute("aria-hidden", "false");
+    } else {
+        let _ = el.set_attribute("style", "display: none; pointer-events: none;");
+        let _ = el.set_attribute("aria-hidden", "true");
+    }
+}
+
+/// Best-effort visibility check used by TRPG runtime systems.
+#[cfg(target_arch = "wasm32")]
+pub(crate) fn is_panel_visible(document: &Document, id: &str) -> bool {
+    let Some(el) = document.get_element_by_id(id) else {
+        return false;
+    };
+    if el.has_attribute("hidden") {
+        return false;
+    }
+    if el
+        .get_attribute("aria-hidden")
+        .map(|v| v.trim().eq_ignore_ascii_case("true"))
+        .unwrap_or(false)
+    {
+        return false;
+    }
+    if let Some(style) = el.get_attribute("style") {
+        let style = style.to_ascii_lowercase().replace(' ', "");
+        if style.contains("display:none") || style.contains("visibility:hidden") {
+            return false;
+        }
+    }
+    true
+}

--- a/viewer/style.css
+++ b/viewer/style.css
@@ -6,6 +6,18 @@
 
 @import url('https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700&family=EB+Garamond:ital,wght@0,400;0,600;1,400&family=Noto+Sans+KR:wght@300;400;700&family=Share+Tech+Mono&family=JetBrains+Mono:wght@400;700&display=swap');
 
+:root {
+    --z-overlay-modal: 1200;
+    --z-room-hub: 1150;
+    --z-view-options: 1160;
+    --z-floating-overlay: 40;
+    --z-join-panel: 50;
+    --z-action-panel: 51;
+    --z-actor-inspector: 40;
+    --z-character-list: 35;
+    --z-endgame: 9999;
+}
+
 /* ─── Theme: Dark Fantasy (Default) ────── */
 
 [data-theme="dark-fantasy"] {
@@ -166,6 +178,106 @@ body {
     font-family: var(--font-body);
 }
 
+#playability-proof {
+    margin: 8px 12px 0;
+}
+
+.play-proof-card {
+    border: 1px solid var(--border-main);
+    background: var(--bg-panel);
+    box-shadow: var(--panel-shadow);
+    border-radius: var(--card-radius);
+    padding: 10px 12px;
+}
+
+.play-proof-head {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: 8px;
+    font-family: var(--font-ui);
+    font-size: 13px;
+}
+
+.play-proof-statuses {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    flex-wrap: wrap;
+}
+
+.play-proof-tag {
+    font-size: 10px;
+    color: var(--text-dim);
+    letter-spacing: 0.2px;
+}
+
+.play-proof-status {
+    font-size: 11px;
+    font-weight: 700;
+    padding: 2px 8px;
+    border-radius: 999px;
+    border: 1px solid transparent;
+}
+
+.play-proof-status.play-proof-pass {
+    color: #4ee381;
+    border-color: rgba(78, 227, 129, 0.55);
+    background: rgba(78, 227, 129, 0.08);
+}
+
+.play-proof-status.play-proof-warn {
+    color: #f2c76f;
+    border-color: rgba(242, 199, 111, 0.55);
+    background: rgba(242, 199, 111, 0.08);
+}
+
+.play-proof-status.play-proof-fail {
+    color: #ff7a7a;
+    border-color: rgba(255, 122, 122, 0.55);
+    background: rgba(255, 122, 122, 0.08);
+}
+
+.play-proof-grid {
+    display: grid;
+    grid-template-columns: repeat(4, minmax(120px, 1fr));
+    gap: 6px;
+}
+
+.play-proof-item {
+    padding: 6px 8px;
+    border-radius: 4px;
+    border: 1px solid var(--border-main);
+    background: var(--bg-panel-alt);
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+}
+
+.play-proof-k {
+    font-size: 10px;
+    color: var(--text-dim);
+    letter-spacing: 0.2px;
+    font-family: var(--font-ui);
+}
+
+.play-proof-v {
+    font-size: 12px;
+    color: var(--text-primary);
+    font-family: var(--font-ui);
+}
+
+.play-proof-reasons {
+    margin-top: 8px;
+    padding: 6px 8px;
+    border-radius: 4px;
+    border: 1px dashed var(--border-highlight);
+    background: var(--bg-panel-alt);
+    font-size: 11px;
+    color: var(--text-dim);
+    font-family: var(--font-ui);
+}
+
 /* ═══════════════════════════════════════════
    LOADING SCREEN
    ═══════════════════════════════════════════ */
@@ -173,7 +285,7 @@ body {
 #loading-screen {
   position: fixed;
   inset: 0;
-  z-index: 9999;
+  z-index: var(--z-overlay-modal);
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -417,9 +529,81 @@ body.mode-lobby #dashboard {
     grid-template-columns: 1fr;
 }
 
+#dashboard[data-log-view-mode="narrative"] #narrative-log .narrative-entry:not(.log-kind-narrative):not(.log-kind-outcome),
+#dashboard[data-log-view-mode="narrative"] #session-history .history-event:not([data-log-kind="narrative"]):not([data-log-kind="outcome"]),
+#dashboard[data-log-view-mode="action"] #narrative-log .narrative-entry:not(.log-kind-action),
+#dashboard[data-log-view-mode="action"] #session-history .history-event:not([data-log-kind="action"]),
+#dashboard[data-log-view-mode="system"] #narrative-log .narrative-entry:not(.log-kind-system):not(.log-kind-debug),
+#dashboard[data-log-view-mode="system"] #session-history .history-event:not([data-log-kind="system"]):not([data-log-kind="debug"]),
+#dashboard[data-log-view-mode="outcome"] #narrative-log .narrative-entry:not(.log-kind-outcome),
+#dashboard[data-log-view-mode="outcome"] #session-history .history-event:not([data-log-kind="outcome"]),
+#dashboard[data-log-view-mode="debug"] #narrative-log .narrative-entry:not(.log-kind-debug),
+#dashboard[data-log-view-mode="debug"] #session-history .history-event:not([data-log-kind="debug"]) {
+    display: none;
+}
+
 body:not(.mode-trpg) #ops-hud {
     display: none !important;
 }
+
+#ops-hud.collapsed {
+    display: none;
+}
+
+/* ─── Control Tab Bar ─────────────────── */
+
+.control-tab-bar {
+    display: flex;
+    gap: 0;
+    background: var(--bg-panel);
+    border-bottom: 1px solid var(--border-main);
+    padding: 0 12px;
+    position: relative;
+    z-index: calc(var(--z-floating-overlay) + 5);
+}
+
+.tab-btn {
+    padding: 6px 16px;
+    background: transparent;
+    border: none;
+    color: var(--text-dim);
+    cursor: pointer;
+    border-bottom: 2px solid transparent;
+    font-size: 0.85rem;
+    font-family: var(--font-ui);
+    transition: color 0.2s, border-color 0.2s;
+}
+
+.tab-btn.active {
+    color: var(--accent-primary);
+    border-bottom-color: var(--accent-primary);
+}
+
+.tab-btn:hover {
+    color: var(--text-main);
+}
+
+/* Tab panels */
+.tab-panel {
+    display: none;
+    padding: 6px 12px;
+    gap: 8px;
+    align-items: center;
+    flex-wrap: wrap;
+    background: var(--bg-panel);
+    border-bottom: 1px solid var(--border-main);
+}
+
+.tab-panel.active {
+    display: flex;
+}
+
+body:not(.mode-trpg) .control-tab-bar,
+body:not(.mode-trpg) .tab-panel {
+    display: none !important;
+}
+
+/* ────────────────────────────────────── */
 
 #ops-hud {
     background: var(--bg-panel);
@@ -654,10 +838,11 @@ body:not(.mode-trpg) #ops-hud {
 
 .view-options-popover {
     position: absolute;
-    right: 134px;
+    right: 0;
     top: 30px;
-    z-index: 20;
-    min-width: 170px;
+    z-index: var(--z-view-options);
+    min-width: 190px;
+    max-width: 245px;
     display: grid;
     gap: 6px;
     padding: 8px 10px;
@@ -665,6 +850,50 @@ body:not(.mode-trpg) #ops-hud {
     border-radius: var(--panel-radius);
     background: rgba(11, 15, 30, 0.95);
     box-shadow: 0 8px 24px rgba(0, 0, 0, 0.35);
+    cursor: default;
+}
+
+.view-options-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 8px;
+}
+
+.view-options-title {
+    font-size: 10px;
+    letter-spacing: 0.35px;
+    color: var(--text-dim);
+    text-transform: uppercase;
+}
+
+.view-options-close {
+    appearance: none;
+    -webkit-appearance: none;
+    border: 1px solid var(--border-main);
+    border-radius: 999px;
+    width: 18px;
+    height: 18px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    background: var(--bg-panel-alt);
+    color: var(--text-dim);
+    font-size: 10px;
+    line-height: 1;
+    padding: 0;
+    cursor: pointer;
+}
+
+.view-options-close:hover {
+    color: var(--text-primary);
+    border-color: var(--accent-primary);
+}
+
+.view-options-popover input:focus-visible,
+.view-options-popover select:focus-visible {
+    outline: 1px solid var(--accent-primary);
+    outline-offset: 1px;
 }
 
 .view-options-popover label {
@@ -673,6 +902,33 @@ body:not(.mode-trpg) #ops-hud {
     display: flex;
     align-items: center;
     gap: 6px;
+    cursor: pointer;
+}
+
+.view-options-popover .view-options-subtitle {
+    font-size: 10px;
+    letter-spacing: 0.35px;
+    color: var(--text-dim);
+    text-transform: uppercase;
+    cursor: default;
+    margin-top: 2px;
+}
+
+.view-options-popover .view-options-divider {
+    border-top: 1px solid var(--border-main);
+    margin: 2px 0;
+}
+
+.view-options-popover select {
+    width: 100%;
+    min-width: 0;
+    background: var(--bg-panel-alt);
+    color: var(--text-primary);
+    border: 1px solid var(--border-main);
+    border-radius: 4px;
+    font-family: var(--font-ui);
+    font-size: 11px;
+    padding: 4px 8px;
     cursor: pointer;
 }
 
@@ -912,7 +1168,7 @@ body:not(.mode-trpg) #ops-hud {
     top: 84px;
     left: 12px;
     right: 12px;
-    z-index: 25;
+    z-index: var(--z-room-hub);
     margin: 0;
     padding: 8px;
     border: 1px solid var(--border-main);
@@ -1508,6 +1764,8 @@ body.wasm-dom-fallback #bevy-canvas {
 
 .floating-overlay {
     display: none;
+    position: relative;
+    z-index: var(--z-floating-overlay);
     margin-top: 8px;
     margin-bottom: 8px;
     border: 1px solid var(--border-main);
@@ -1551,6 +1809,7 @@ body.wasm-dom-fallback #bevy-canvas {
 
 /* Character cards */
 .character-card {
+    scroll-margin-top: 8px;
     background: var(--bg-panel-alt);
     border: 1px solid var(--border-main);
     border-left: 3px solid var(--accent-primary-dim);
@@ -1559,6 +1818,13 @@ body.wasm-dom-fallback #bevy-canvas {
     margin-bottom: 6px;
     transition: background 0.2s ease, box-shadow 0.2s ease;
     cursor: pointer;
+    user-select: none;
+    outline: none;
+}
+
+.character-card:focus-visible {
+    outline: 1px solid color-mix(in srgb, var(--accent-primary-dim) 80%, #fff 20%);
+    outline-offset: 2px;
 }
 
 .character-card:hover {
@@ -1568,6 +1834,193 @@ body.wasm-dom-fallback #bevy-canvas {
 
 .character-card.join-pick-selected {
     box-shadow: 0 0 0 1px rgba(196, 162, 101, 0.55), 0 2px 14px rgba(0, 0, 0, 0.32);
+}
+
+.actor-inspector {
+    margin-bottom: 8px;
+    border: 1px solid var(--border-main);
+    background: var(--bg-panel-alt);
+    border-radius: var(--panel-radius);
+    padding: 10px;
+    box-shadow: inset 0 0 0 1px rgba(196, 162, 101, 0.12);
+    position: relative;
+    top: auto;
+    scroll-margin-top: 4px;
+}
+
+#tertiary-content {
+    display: flex;
+    flex-direction: column;
+    min-height: 0;
+    gap: 8px;
+}
+
+.actor-inspector-empty,
+.actor-inspector-empty-sub {
+    color: var(--text-dim);
+    font-size: 12px;
+    line-height: 1.45;
+    padding: 2px 0;
+}
+
+.actor-inspector-head {
+    display: flex;
+    justify-content: space-between;
+    gap: 10px;
+    align-items: flex-start;
+    flex-wrap: wrap;
+    margin-bottom: 8px;
+    border-bottom: 1px dashed rgba(255, 255, 255, 0.15);
+    padding-bottom: 6px;
+}
+
+.actor-inspector-name {
+    color: var(--accent-primary);
+    font-size: 14px;
+    letter-spacing: 0.4px;
+    line-height: 1.25;
+    margin-right: 6px;
+}
+
+.actor-inspector-title {
+    font-family: var(--font-display);
+    color: var(--accent-primary);
+    font-size: 14px;
+    letter-spacing: 0.4px;
+}
+
+.actor-inspector-id {
+    color: var(--text-dim);
+    font-size: 10px;
+    white-space: nowrap;
+    max-width: 200px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.actor-inspector-chips {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+    margin-bottom: 8px;
+}
+
+.actor-inspector-chip {
+    font-size: 10px;
+    padding: 3px 8px;
+    border-radius: 999px;
+    border: 1px solid color-mix(in srgb, var(--accent-primary-dim) 50%, transparent 50%);
+    background: color-mix(in srgb, var(--accent-primary) 8%, transparent);
+    color: var(--text-primary);
+    white-space: nowrap;
+}
+
+.actor-inspector-chip-score.actor-score-positive {
+    border-color: rgba(82, 218, 123, 0.55);
+    background: rgba(82, 218, 123, 0.12);
+    color: #9bffbe;
+}
+
+.actor-inspector-chip-score.actor-score-negative {
+    border-color: rgba(218, 82, 82, 0.55);
+    background: rgba(218, 82, 82, 0.12);
+    color: #ffb7b7;
+}
+
+.actor-inspector-chip-score.actor-score-neutral {
+    border-color: rgba(170, 170, 170, 0.45);
+    background: rgba(170, 170, 170, 0.08);
+    color: var(--text-dim);
+}
+
+.actor-inspector-grid {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 6px 10px;
+    margin-bottom: 8px;
+}
+
+.actor-inspector-grid .k {
+    color: var(--text-dim);
+    font-size: 10px;
+    display: block;
+    margin-bottom: 2px;
+}
+
+.actor-inspector-grid .v {
+    color: var(--text-primary);
+    font-size: 11px;
+}
+
+.actor-inspector-line {
+    margin: 4px 0;
+    color: var(--text-primary);
+    font-size: 11px;
+    line-height: 1.5;
+}
+
+.actor-inspector-source {
+    margin-right: 6px;
+    font-size: 10px;
+    color: var(--text-dim);
+}
+
+.actor-inspector-line-text {
+    color: var(--text-primary);
+}
+
+.actor-inspector-section {
+    margin-top: 10px;
+    padding-top: 8px;
+    border-top: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+.actor-inspector-section-title {
+    font-family: var(--font-display);
+    letter-spacing: 1px;
+    font-size: 10px;
+    color: var(--accent-primary-dim);
+    margin-bottom: 5px;
+}
+
+.actor-rel-list {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 5px;
+}
+
+.actor-rel-chip {
+    font-size: 10px;
+    padding: 2px 7px;
+    border-radius: 999px;
+    border: 1px solid rgba(150, 173, 255, 0.28);
+    background: rgba(140, 170, 255, 0.12);
+    color: #bdd0ff;
+}
+
+.actor-inspector-muted {
+    color: var(--text-dim);
+    font-size: 11px;
+    font-style: italic;
+}
+
+.actor-inspector-metric {
+    font-family: 'JetBrains Mono', var(--font-ui);
+    white-space: nowrap;
+    font-weight: 700;
+}
+
+.actor-metric-known {
+    color: var(--text-primary);
+}
+
+.actor-metric-partial {
+    color: #ccb56b;
+}
+
+.actor-metric-unknown {
+    color: var(--text-dim);
+    font-style: italic;
 }
 
 /* Class-specific left border colors */
@@ -1592,10 +2045,12 @@ body.wasm-dom-fallback #bevy-canvas {
 .character-card[data-class="bard"] { border-left-color: #cc44aa; }
 .character-card[data-class="druid"] { border-left-color: #44cc88; }
 .character-card[data-class="monk"] { border-left-color: #8899bb; }
-
 #character-panel {
     display: flex;
     flex-direction: column;
+    min-height: 0;
+    flex: 1 1 auto;
+    position: relative;
 }
 
 .character-card.dead {
@@ -3063,6 +3518,14 @@ body.wasm-dom-fallback #bevy-canvas {
     padding-top: 4px;
 }
 
+.history-event[data-actor-id] {
+    cursor: pointer;
+}
+
+.history-event[data-actor-id]:hover {
+    background: rgba(255, 255, 255, 0.06);
+}
+
 .history-kind {
     color: var(--accent-primary);
 }
@@ -3407,7 +3870,7 @@ body.wasm-dom-fallback #bevy-canvas {
     position: absolute;
     inset: 44px 0 0 0;
     background: rgba(0, 0, 0, 0.56);
-    z-index: 40;
+    z-index: var(--z-floating-overlay);
     display: flex;
     align-items: flex-start;
     justify-content: center;
@@ -3853,7 +4316,7 @@ body.wasm-dom-fallback #bevy-canvas {
         rgba(0, 0, 0, 0.08) 4px
     );
     pointer-events: none;
-    z-index: 9999;
+    z-index: calc(var(--z-overlay-modal) - 1);
 }
 
 /* ─── Theme-specific cyberpunk chromatic ── */
@@ -3891,7 +4354,7 @@ body.wasm-dom-fallback #bevy-canvas {
     color: var(--text-primary, #e8dcc8);
     overflow-y: auto;
     padding: 24px;
-    z-index: 100;
+    z-index: var(--z-overlay-modal);
 }
 
 .mode-panel.active {
@@ -4396,7 +4859,7 @@ body.wasm-dom-fallback #bevy-canvas {
     border-radius: 0 0 var(--card-radius, 6px) var(--card-radius, 6px);
     position: sticky;
     bottom: 0;
-    z-index: 18;
+    z-index: var(--z-action-panel);
     box-shadow: 0 -10px 20px rgba(0, 0, 0, 0.28);
 }
 
@@ -4656,7 +5119,7 @@ body.wasm-dom-fallback #bevy-canvas {
     background: var(--bg-panel-alt);
     position: sticky;
     bottom: 0;
-    z-index: 18;
+    z-index: var(--z-join-panel);
     box-shadow: 0 -10px 20px rgba(0, 0, 0, 0.28);
 }
 
@@ -4774,7 +5237,7 @@ body.wasm-dom-fallback #bevy-canvas {
 .endgame-overlay {
     position: fixed;
     inset: 0;
-    z-index: 9999;
+    z-index: var(--z-endgame);
     display: flex;
     align-items: center;
     justify-content: center;
@@ -4846,6 +5309,17 @@ body.wasm-dom-fallback #bevy-canvas {
     color: var(--text-dim, #6a5d4d);
     line-height: 1.6;
     margin: 0 auto 1.8em;
+}
+
+.endgame-reason {
+    font-family: var(--font-ui, 'Noto Sans KR', sans-serif);
+    font-size: 0.95em;
+    color: var(--text-primary, #d4c4a8);
+    line-height: 1.5;
+    margin: 0 auto 1.2em;
+    max-width: 560px;
+    white-space: pre-wrap;
+    word-break: keep-all;
 }
 
 .endgame-btn {


### PR DESCRIPTION
## Summary

- **TRPG Viewer UX**: top-bar의 14+ 동시 노출 컨트롤을 3개 탭(방/게임/설정)으로 분리하여 인지 부하 감소
- **MCP 서버**: `tools/call` 파싱 강화 및 미초기화 상태 핸들링 개선

## 변경 사항

### TRPG Tab UI (`e4b81a3`)
- `control-tab-bar` 추가 (방/게임/설정 탭 전환)
- 기존 컨트롤을 탭 패널로 재배치 (DOM ID 보존 → Bevy bridge 호환)
- `ops-hud` 토글 버튼 (상태 배지 접기/펼치기)
- `panel_visibility.rs` 신규 모듈 (DOM show/hide 헬퍼)
- `actor_lifecycle.rs` Option<String> 핸들링 수정
- z-index 스태킹 수정 (탭 바가 new-game-panel 위에 표시)
- TRPG 모드 진입 시 "방" 탭으로 리셋

### MCP Hardening (`831c8ca`)
- `tools/call` JSON-RPC 파싱 강화
- 미초기화 상태 에러 핸들링 개선

## Test plan

- [x] `make test` 통과
- [x] `trunk build` WASM 빌드 성공
- [x] 브라우저에서 탭 전환 (방→게임→설정→방) 정상 확인
- [x] ops-hud 토글 (펼침/접힘) 정상 확인
- [x] 기존 기능 (방 선택, 새 게임, 세션 컨트롤, 테마) 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)