### PR TITLE
fix(trpg): stabilize flow, resume boundaries, and endgame timing

### DIFF
--- a/lib/tool_trpg.ml
+++ b/lib/tool_trpg.ml
@@ -1303,6 +1303,14 @@ type session_outcome =
   | Defeat
   | Draw
 
+type outcome_source =
+  | Outcome_source_flag
+  | Outcome_source_dm_signal
+  | Outcome_source_all_players_dead
+  | Outcome_source_max_turn
+  | Outcome_source_stagnation
+  | Outcome_source_unknown
+
 let string_of_session_outcome = function
   | Victory -> "victory"
   | Defeat -> "defeat"
@@ -1312,6 +1320,55 @@ let summary_of_session_outcome = function
   | Victory -> "Victory condition met."
   | Defeat -> "Defeat condition met."
   | Draw -> "Draw condition met."
+
+let string_of_outcome_source = function
+  | Outcome_source_flag -> "flag"
+  | Outcome_source_dm_signal -> "dm_signal"
+  | Outcome_source_all_players_dead -> "all_players_dead"
+  | Outcome_source_max_turn -> "max_turn"
+  | Outcome_source_stagnation -> "stagnation"
+  | Outcome_source_unknown -> "unknown"
+
+let outcome_source_of_reason reason =
+  let trimmed = String.trim reason in
+  if starts_with trimmed "flag:" then Outcome_source_flag
+  else if starts_with trimmed "dm_signal:" then Outcome_source_dm_signal
+  else if trimmed = "all_players_dead" then Outcome_source_all_players_dead
+  else if trimmed = "max_turn_reached" then Outcome_source_max_turn
+  else if trimmed = "stagnation" then Outcome_source_stagnation
+  else Outcome_source_unknown
+
+let outcome_source_from_payload_opt (payload : Yojson.Safe.t) : string option =
+  match payload |> member "outcome_source" with
+  | `String raw ->
+      let source = String.trim raw in
+      if source = "" then None else Some source
+  | _ -> None
+
+let outcome_source_from_payload (payload : Yojson.Safe.t) : string =
+  match outcome_source_from_payload_opt payload with
+  | Some source -> source
+  | None ->
+      let reason =
+        match payload |> member "reason" with
+        | `String raw -> raw
+        | _ -> ""
+      in
+      string_of_outcome_source (outcome_source_of_reason reason)
+
+let ensure_outcome_payload_source (payload : Yojson.Safe.t) : Yojson.Safe.t =
+  let source = outcome_source_from_payload payload in
+  match payload with
+  | `Assoc fields ->
+      `Assoc
+        (("outcome_source", `String source)
+        :: List.remove_assoc "outcome_source" fields)
+  | _ -> payload
+
+let stagnation_level_from_payload (payload : Yojson.Safe.t) : int =
+  match payload |> member "stagnation_level" with
+  | `Int n when n > 0 -> n
+  | _ -> 0
 
 let default_end_rules_local : Trpg_preset_store.end_rules =
   {
@@ -2037,6 +2094,44 @@ let detect_stagnation ~(events : Trpg_engine_event.t list) ~threshold =
     not (List.exists (fun (ev : Trpg_engine_event.t) ->
              is_meaningful_event_type ev.event_type) recent_events)
 
+let stagnation_detection_turn_threshold = 5
+let stagnation_escalation_threshold = 3
+
+let latest_stagnation_pressure_level ~(events : Trpg_engine_event.t list) : int =
+  let latest_meaningful_seq =
+    events
+    |> List.fold_left
+         (fun acc (ev : Trpg_engine_event.t) ->
+           if is_meaningful_event_type ev.event_type then max acc ev.seq else acc)
+         0
+  in
+  let latest_pressure_seq, latest_pressure_level =
+    events
+    |> List.fold_left
+         (fun (best_seq, best_level) (ev : Trpg_engine_event.t) ->
+           if ev.event_type <> Trpg_engine_event.World_event then
+             (best_seq, best_level)
+           else
+             let event_type =
+               match ev.payload |> member "event_type" with
+               | `String raw -> String.lowercase_ascii (String.trim raw)
+               | _ -> ""
+             in
+             if event_type <> "stagnation_pressure" then
+               (best_seq, best_level)
+             else
+               let level =
+                 match ev.payload |> member "stagnation_level" with
+                 | `Int n when n > 0 -> n
+                 | _ -> 1
+               in
+               if ev.seq >= best_seq then (ev.seq, level)
+               else (best_seq, best_level))
+         (0, 0)
+  in
+  if latest_pressure_seq = 0 || latest_meaningful_seq > latest_pressure_seq then 0
+  else latest_pressure_level
+
 let has_event_type (events : Trpg_engine_event.t list) event_type =
   List.exists
     (fun (ev : Trpg_engine_event.t) -> ev.event_type = event_type)
@@ -2064,7 +2159,8 @@ let latest_session_outcome_payload (events : Trpg_engine_event.t list) :
   events
   |> List.fold_left
        (fun acc (ev : Trpg_engine_event.t) ->
-         if ev.event_type = Trpg_engine_event.Session_outcome then Some ev.payload
+         if ev.event_type = Trpg_engine_event.Session_outcome then
+           Some (ensure_outcome_payload_source ev.payload)
          else acc)
        None
 
@@ -7442,6 +7538,18 @@ let handle_round_run ctx args : result =
       let latest_outcome_payload =
         ref (latest_session_outcome_payload session_events_before)
       in
+      let response_outcome_source =
+        ref
+          (match !latest_outcome_payload with
+          | Some payload -> outcome_source_from_payload payload
+          | None -> "none")
+      in
+      let response_stagnation_level =
+        ref
+          (match !latest_outcome_payload with
+          | Some payload -> stagnation_level_from_payload payload
+          | None -> 0)
+      in
       let* turn_before = read_state_turn derived in
       let unavailable_sampling =
         make_unavailable_sampling_state ~events:existing_events_before
@@ -7604,6 +7712,11 @@ let handle_round_run ctx args : result =
                     ("canon_warning_count", `Int (List.length canon_check.warnings));
                     ("memory_signals", `Int 0);
                     ("memory_guardrail_escalations", `Int 0);
+                    ("stagnation_level", `Int !response_stagnation_level);
+                    ("stagnation_turn_threshold", `Int stagnation_detection_turn_threshold);
+                    ( "stagnation_escalation_threshold",
+                      `Int stagnation_escalation_threshold );
+                    ("outcome_source", `String !response_outcome_source);
                     ("roll_audit_count", `Int 0);
                     ("roll_audit", `List []);
                   ] );
@@ -7612,6 +7725,8 @@ let handle_round_run ctx args : result =
                 match !latest_outcome_payload with
                 | Some payload -> payload
                 | None -> `Null );
+              ("outcome_source", `String !response_outcome_source);
+              ("stagnation_level", `Int !response_stagnation_level);
               ("events", `List []);
               ("room_status", `String room_status);
               ("state", state);
@@ -7652,6 +7767,9 @@ let handle_round_run ctx args : result =
         ref (join_window_closed_event :: phase_event :: intervention_events)
       in
       let statuses = ref [] in
+      let outcome_source_ref = ref "none" in
+      let stagnation_level_ref = ref 0 in
+      let stagnation_pressure_emitted = ref false in
       let success_count = ref 0 in
       let fallback_count = ref 0 in
       let schema_failures = ref 0 in
@@ -8629,17 +8747,23 @@ let handle_round_run ctx args : result =
       in
       let* next_derived = derive_state ~store ~room_id ~rule_module in
       let next_state = state_of_derived next_derived in
-      let computed_outcome =
-        if outcome_already_emitted then None
+      let* computed_outcome =
+        if outcome_already_emitted then (
+          outcome_source_ref := !response_outcome_source;
+          stagnation_level_ref := !response_stagnation_level;
+          Ok None )
         else
           match
             evaluate_session_outcome ~end_rules
               ~max_turn_override:outcome_max_turn_override ~state:next_state
               ~dm_reply:!dm_reply_ref
           with
-          | Some _ as outcome -> outcome
+          | Some ((_, reason) as outcome) ->
+              outcome_source_ref :=
+                string_of_outcome_source (outcome_source_of_reason reason);
+              stagnation_level_ref := 0;
+              Ok (Some outcome)
           | None ->
-              let stagnation_threshold = 5 in
               let all_events =
                 match
                   store.read_events ~room_id
@@ -8648,22 +8772,83 @@ let handle_round_run ctx args : result =
                 | Error _ -> []
               in
               let all_events = all_events @ !appended_events in
-              if detect_stagnation ~events:all_events ~threshold:stagnation_threshold
-              then Some (Draw, "stagnation")
-              else None
+              if
+                detect_stagnation ~events:all_events
+                  ~threshold:stagnation_detection_turn_threshold
+              then
+                let prior_level =
+                  latest_stagnation_pressure_level ~events:all_events
+                in
+                let next_level = prior_level + 1 in
+                stagnation_level_ref := next_level;
+                if next_level >= stagnation_escalation_threshold then (
+                  outcome_source_ref := "stagnation";
+                  Ok (Some (Draw, "stagnation")) )
+                else
+                  let pressure_payload =
+                    `Assoc
+                      [
+                        ("event_type", `String "stagnation_pressure");
+                        ("severity", `String "major");
+                        ( "description",
+                          `String
+                            (Printf.sprintf
+                               "Stagnation guard triggered (%d/%d): forcing higher stakes choices."
+                               next_level stagnation_escalation_threshold) );
+                        ("phase", `String phase);
+                        ("turn", `Int turn_after);
+                        ("stagnation_level", `Int next_level);
+                        ( "stagnation_turn_threshold",
+                          `Int stagnation_detection_turn_threshold );
+                        ( "stagnation_escalation_threshold",
+                          `Int stagnation_escalation_threshold );
+                      ]
+                  in
+                  let* pressure_event =
+                    append_event ~store ~room_id
+                      ~event_type:Trpg_engine_event.World_event
+                      ~payload:pressure_payload ()
+                  in
+                  stagnation_pressure_emitted := true;
+                  appended_events := !appended_events @ [ pressure_event ];
+                  statuses :=
+                    `Assoc
+                      [
+                        ("actor_id", `String "system");
+                        ("role", `String "system");
+                        ("keeper", `String "system");
+                        ("status", `String "stagnation_pressure");
+                        ("reason", `String "stagnation_guard");
+                        ("stage", `String "stagnation_guard");
+                        ("stagnation_level", `Int next_level);
+                      ]
+                    :: !statuses;
+                  Ok None
+              else (
+                stagnation_level_ref := 0;
+                Ok None )
       in
       let* final_derived =
         match computed_outcome with
-        | None -> Ok next_derived
+        | None ->
+            if !stagnation_pressure_emitted then
+              derive_state ~store ~room_id ~rule_module
+            else Ok next_derived
         | Some (outcome, reason) ->
             let outcome_str = string_of_session_outcome outcome in
             let summary = summary_of_session_outcome outcome in
+            let outcome_source =
+              if !outcome_source_ref = "none" then
+                string_of_outcome_source (outcome_source_of_reason reason)
+              else !outcome_source_ref
+            in
             let room_end_payload =
               `Assoc
                 [
                   ("room_id", `String room_id);
                   ("reason", `String reason);
                   ("outcome", `String outcome_str);
+                  ("outcome_source", `String outcome_source);
                 ]
             in
             let outcome_payload =
@@ -8674,6 +8859,8 @@ let handle_round_run ctx args : result =
                   ("summary", `String summary);
                   ("turn", `Int turn_after);
                   ("phase", `String phase);
+                  ("outcome_source", `String outcome_source);
+                  ("stagnation_level", `Int !stagnation_level_ref);
                 ]
             in
             let* room_end_event_opt =
@@ -8715,7 +8902,9 @@ let handle_round_run ctx args : result =
                   ]
             in
             appended_events := !appended_events @ [ memory_event ];
-            latest_outcome_payload := Some outcome_payload;
+            response_outcome_source := outcome_source;
+            response_stagnation_level := !stagnation_level_ref;
+            latest_outcome_payload := Some (ensure_outcome_payload_source outcome_payload);
             derive_state ~store ~room_id ~rule_module
       in
       let* _final_derived, final_state =
@@ -8797,6 +8986,20 @@ let handle_round_run ctx args : result =
           ~explicit:(Option.bind dm_persona_override dm_persona_id_of_string)
           ~dm_style
       in
+      let resolved_outcome_source =
+        match !latest_outcome_payload with
+        | Some payload -> outcome_source_from_payload payload
+        | None ->
+            if !outcome_source_ref <> "none" then !outcome_source_ref
+            else !response_outcome_source
+      in
+      let resolved_stagnation_level =
+        match !latest_outcome_payload with
+        | Some payload -> stagnation_level_from_payload payload
+        | None -> !stagnation_level_ref
+      in
+      response_outcome_source := resolved_outcome_source;
+      response_stagnation_level := resolved_stagnation_level;
       let events_json = List.map Trpg_engine_event.to_yojson !appended_events in
       Ok
         (`Assoc
@@ -8850,6 +9053,11 @@ let handle_round_run ctx args : result =
                   ("canon_warning_count", `Int (List.length canon_check.warnings));
                   ("memory_signals", `Int memory_signal_count);
                   ("memory_guardrail_escalations", `Int memory_guardrail_escalations);
+                  ("stagnation_level", `Int resolved_stagnation_level);
+                  ("stagnation_turn_threshold", `Int stagnation_detection_turn_threshold);
+                  ( "stagnation_escalation_threshold",
+                    `Int stagnation_escalation_threshold );
+                  ("outcome_source", `String resolved_outcome_source);
                   ("roll_audit_count", `Int roll_audit_count);
                   ("roll_audit", `List roll_audit);
                 ] );
@@ -8858,6 +9066,8 @@ let handle_round_run ctx args : result =
               match !latest_outcome_payload with
               | Some payload -> payload
               | None -> `Null );
+            ("outcome_source", `String resolved_outcome_source);
+            ("stagnation_level", `Int resolved_stagnation_level);
             ("events", `List events_json);
             ( "room_status",
               match final_state |> member "status" with

--- a/viewer/src/dom/endgame.rs
+++ b/viewer/src/dom/endgame.rs
@@ -1,15 +1,12 @@
 //! Endgame detection and overlay rendering.
 //!
-//! Three detection paths:
-//! 1. **TPK** — all `Actor` entities have `is_dead = true`
-//! 2. **Quest complete** — `NarrativeReceived` with `phase == "endgame"`
-//! 3. **Round runner signal** — `RoundRunner.game_ended` atomic flag
+//! Canonical detection path:
+//! 1. **Session outcome** — `session.outcome` SSE event
 
 use bevy::prelude::*;
 use std::sync::atomic::Ordering;
 
-use crate::game::components::Actor;
-use crate::game::events::{NarrativeReceived, SessionOutcome};
+use crate::game::events::SessionOutcome;
 use crate::game::round_runner::RoundRunner;
 
 /// Tracks whether the endgame overlay has been shown (prevents re-trigger).
@@ -25,22 +22,19 @@ enum EndgameTone {
     Draw,
 }
 
-/// Monitors multiple signals and triggers the endgame overlay once.
+/// Monitors canonical session outcome and triggers the endgame overlay once.
 pub fn detect_endgame(
-    actors: Query<&Actor>,
     runner: Option<Res<RoundRunner>>,
-    mut narratives: MessageReader<NarrativeReceived>,
     mut outcomes: MessageReader<SessionOutcome>,
     mut endgame: ResMut<EndgameState>,
 ) {
     if endgame.triggered {
         // Drain the reader even when already triggered to avoid stale buffers.
-        for _ in narratives.read() {}
         for _ in outcomes.read() {}
         return;
     }
 
-    // Path 0: Canonical session outcome.
+    // Canonical session outcome.
     if let Some(SessionOutcome(payload)) = outcomes.read().next() {
         endgame.triggered = true;
         let tone = match payload.outcome.as_str() {
@@ -56,41 +50,6 @@ pub fn detect_endgame(
         show_endgame_overlay(message, tone);
         if let Some(runner) = &runner {
             runner.game_ended.store(true, Ordering::SeqCst);
-        }
-        for _ in narratives.read() {}
-    }
-
-    // Path 1: TPK — all actors dead.
-    let actor_count = actors.iter().count();
-    if actor_count > 0 {
-        let dead_count = actors.iter().filter(|a| a.is_dead).count();
-        if dead_count == actor_count {
-            endgame.triggered = true;
-            show_endgame_overlay("파티가 전멸했습니다.", EndgameTone::Defeat);
-            if let Some(runner) = &runner {
-                runner.game_ended.store(true, Ordering::SeqCst);
-            }
-            // Drain remaining narratives.
-            for _ in narratives.read() {}
-            for _ in outcomes.read() {}
-            return;
-        }
-    }
-
-    // Path 2: Quest complete — endgame narrative phase.
-    for NarrativeReceived(payload) in narratives.read() {
-        if payload.phase == "endgame" {
-            endgame.triggered = true;
-            show_endgame_overlay(&payload.text, EndgameTone::Victory);
-            return;
-        }
-    }
-
-    // Path 3: Round runner detected game ended via response JSON.
-    if let Some(runner) = &runner {
-        if runner.game_ended.load(Ordering::SeqCst) {
-            endgame.triggered = true;
-            show_endgame_overlay("모험이 끝났습니다.", EndgameTone::Victory);
         }
     }
 }

--- a/viewer/src/game/events.rs
+++ b/viewer/src/game/events.rs
@@ -360,6 +360,8 @@ pub struct SessionOutcomePayload {
     #[serde(default)]
     pub reason: String,
     #[serde(default)]
+    pub outcome_source: String,
+    #[serde(default)]
     pub summary: String,
     #[serde(default)]
     pub turn: u32,

--- a/viewer/src/game/http.rs
+++ b/viewer/src/game/http.rs
@@ -163,7 +163,8 @@ fn normalize_room_status(raw: &str) -> String {
 fn room_requires_new_game(raw_status: &str) -> bool {
     matches!(
         normalize_room_status(raw_status).as_str(),
-        "" | "idle" | "lobby" | "ended" | "unavailable"
+        "" | "idle" | "lobby" | "ended" | "completed" | "done" | "retired" | "closed"
+            | "unavailable"
     )
 }
 
@@ -1192,6 +1193,7 @@ fn parse_party_characters(
 /// When the fetched room is not resumable, surface guidance for starting a new
 /// session. The new-game panel itself should remain user-triggered.
 fn prompt_new_game_for_inactive_room(room_status: &str) {
+    #[cfg(not(target_arch = "wasm32"))]
     let _ = room_status;
 
     #[cfg(target_arch = "wasm32")]
@@ -1200,7 +1202,40 @@ fn prompt_new_game_for_inactive_room(room_status: &str) {
             return;
         };
 
-        // Set a status message appropriate to the room state.
+        let mut should_bootstrap = false;
+        // Show the new-game panel
+        if let Some(panel) = document.get_element_by_id("new-game-panel") {
+            let was_visible = panel
+                .dyn_ref::<web_sys::HtmlElement>()
+                .and_then(|html_el| html_el.style().get_property_value("display").ok())
+                .map(|display| {
+                    matches!(
+                        display.trim().to_ascii_lowercase().as_str(),
+                        "flex" | "block" | "grid" | "inline-flex"
+                    )
+                })
+                .unwrap_or(false);
+            if let Some(html_el) = panel.dyn_ref::<web_sys::HtmlElement>() {
+                let _ = html_el.style().set_property("display", "flex");
+            }
+            if !was_visible {
+                should_bootstrap = true;
+            }
+        }
+
+        // Pre-populate room ID input with a fresh generated ID
+        if let Some(input) = document
+            .get_element_by_id("new-game-room-id")
+            .and_then(|el| el.dyn_into::<web_sys::HtmlInputElement>().ok())
+        {
+            if input.value().trim().is_empty() {
+                let ts = js_sys::Date::now() as i64;
+                let rand = (js_sys::Math::random() * 1000.0).floor() as i64;
+                input.set_value(&format!("adventure-{}-{:03}", ts, rand));
+            }
+        }
+
+        // Set a status message appropriate to the room state
         if let Some(el) = document.get_element_by_id("new-game-status") {
             let msg = match normalize_room_status(room_status).as_str() {
                 "ended" => "이 게임은 종료되었습니다. 새 게임을 시작하세요.",
@@ -1210,6 +1245,15 @@ fn prompt_new_game_for_inactive_room(room_status: &str) {
                 _ => "진행 중인 게임이 없습니다. 새 게임을 시작하세요.",
             };
             el.set_inner_html(msg);
+        }
+
+        // Trigger bootstrap once when auto-opening the panel for an inactive room.
+        if should_bootstrap {
+            if let Some(btn) = document.get_element_by_id("new-game-toggle") {
+                if let Some(html_btn) = btn.dyn_ref::<web_sys::HtmlElement>() {
+                    html_btn.click();
+                }
+            }
         }
     }
 }
@@ -1538,6 +1582,9 @@ mod tests {
     #[test]
     fn ended_room_requires_new_game() {
         assert!(room_requires_new_game("ended"));
+        assert!(room_requires_new_game("completed"));
+        assert!(room_requires_new_game("done"));
+        assert!(room_requires_new_game("closed"));
     }
 
     #[test]

--- a/viewer/src/game/systems.rs
+++ b/viewer/src/game/systems.rs
@@ -671,10 +671,18 @@ pub fn apply_session_outcome(
         }
         progress.room_status = "ended".to_string();
         let reason = payload.reason.trim();
-        progress.last_result = if reason.is_empty() {
+        let source = payload.outcome_source.trim();
+        let detail = if reason.is_empty() {
+            source.to_string()
+        } else if source.is_empty() {
+            reason.to_string()
+        } else {
+            format!("{reason} · source={source}")
+        };
+        progress.last_result = if detail.is_empty() {
             payload.outcome.clone()
         } else {
-            format!("{} ({})", payload.outcome, reason)
+            format!("{} ({})", payload.outcome, detail)
         };
 
         // Reset combat state when session ends

--- a/viewer/src/mode/mod.rs
+++ b/viewer/src/mode/mod.rs
@@ -604,6 +604,12 @@ fn set_session_control_status(doc: &web_sys::Document, text: &str, tone: &str) {
     } else {
         format!("widget-pill {}", tone.trim())
     };
+    let unchanged = el.text_content().as_deref() == Some(display_text.as_str())
+        && el.get_attribute("class").as_deref() == Some(class_name.as_str())
+        && el.get_attribute("title").as_deref() == Some(full_text.as_str());
+    if unchanged {
+        return;
+    }
     el.set_text_content(Some(&display_text));
     let _ = el.set_attribute("class", &class_name);
     let _ = el.set_attribute("title", &full_text);
@@ -1391,7 +1397,11 @@ pub(super) fn generate_room_id() -> String {
 #[cfg(target_arch = "wasm32")]
 pub(super) fn set_new_game_status(doc: &web_sys::Document, message: &str) {
     if let Some(el) = doc.get_element_by_id("new-game-status") {
-        el.set_inner_html(&html_escape(message));
+        let escaped = html_escape(message);
+        if el.inner_html() == escaped {
+            return;
+        }
+        el.set_inner_html(&escaped);
     }
 }
 

--- a/viewer/src/mode/trpg_controls.rs
+++ b/viewer/src/mode/trpg_controls.rs
@@ -2845,8 +2845,7 @@ async fn start_new_game_flow(doc: &web_sys::Document) -> Result<String, String> 
             "dm_preset_id": dm_preset_id,
             "world_preset_id": world_preset_id,
             "party": party,
-            "phase": "briefing",
-            "force": true
+            "phase": "briefing"
         }),
     )
     .await?;

--- a/viewer/src/sse/client.rs
+++ b/viewer/src/sse/client.rs
@@ -144,6 +144,24 @@ fn value_to_string_vec(v: Option<&Value>) -> Vec<String> {
 }
 
 #[cfg(any(target_arch = "wasm32", test))]
+fn infer_outcome_source_from_reason(reason: &str) -> &'static str {
+    let normalized = reason.trim().to_ascii_lowercase();
+    if normalized.starts_with("flag:") {
+        "flag"
+    } else if normalized.starts_with("dm_signal:") {
+        "dm_signal"
+    } else if normalized == "all_players_dead" {
+        "all_players_dead"
+    } else if normalized == "max_turn_reached" {
+        "max_turn"
+    } else if normalized == "stagnation" {
+        "stagnation"
+    } else {
+        "unknown"
+    }
+}
+
+#[cfg(any(target_arch = "wasm32", test))]
 fn canonical_weather_id(raw: &str) -> Option<&'static str> {
     let key = raw.trim().to_ascii_lowercase();
     if key.is_empty() {
@@ -896,6 +914,12 @@ fn map_trpg_event(
                 .unwrap_or("draw");
             let summary = payload.get("summary").and_then(Value::as_str).unwrap_or("");
             let reason = payload.get("reason").and_then(Value::as_str).unwrap_or("");
+            let outcome_source = payload
+                .get("outcome_source")
+                .and_then(Value::as_str)
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
+                .unwrap_or_else(|| infer_outcome_source_from_reason(reason));
             let turn = value_to_u32(payload.get("turn"), state.last_turn);
             if turn > 0 {
                 state.last_turn = turn;
@@ -904,6 +928,7 @@ fn map_trpg_event(
                 json!({
                     "outcome": outcome,
                     "reason": reason,
+                    "outcome_source": outcome_source,
                     "summary": summary,
                     "turn": turn
                 }),
@@ -1821,7 +1846,7 @@ mod tests {
     fn decode_stream_maps_session_outcome_event() {
         let body = r#"{
             "events": [
-                {"seq": 7, "type": "session.outcome", "payload": {"outcome": "victory", "reason": "objective_complete", "summary": "Relic recovered and party extracted.", "turn": 9}}
+                {"seq": 7, "type": "session.outcome", "payload": {"outcome": "victory", "reason": "flag:objective_complete", "outcome_source": "flag", "summary": "Relic recovered and party extracted.", "turn": 9}}
             ]
         }"#;
 
@@ -1835,6 +1860,7 @@ mod tests {
         let payload: Value =
             serde_json::from_str(&outcome.1).expect("session.outcome payload json");
         assert_eq!(payload["outcome"], "victory");
+        assert_eq!(payload["outcome_source"], "flag");
         assert_eq!(payload["turn"], 9);
 
         let narrative = mapped


### PR DESCRIPTION
## Summary
- canonicalized TRPG endgame trigger to `session.outcome` in viewer overlay path
- removed forced session restart behavior from new game flow (`force=true` dropped)
- tightened non-resumable room status handling and reduced repeated new-game/status re-rendering
- added `outcome_source` and staged stagnation pressure/escalation in round-run outcome pipeline

## Details
- Server (`lib/tool_trpg.ml`)
  - add `outcome_source` derivation + propagation in outcome payload/response
  - add staged stagnation handling (`stagnation_pressure` event first, draw only after escalation threshold)
  - expose `stagnation_level` and thresholds in summary/response
- Viewer
  - `viewer/src/dom/endgame.rs`: overlay now reacts only to `SessionOutcome`
  - `viewer/src/game/http.rs`: stronger `room_requires_new_game` and idempotent inactive-room bootstrap
  - `viewer/src/mode/mod.rs`: dedup repeated session/new-game status DOM updates
  - `viewer/src/mode/trpg_controls.rs`: remove `force=true` from `trpg.session.start`
  - `viewer/src/game/events.rs`, `viewer/src/game/systems.rs`, `viewer/src/sse/client.rs`: carry and render `outcome_source`

## Validation
- `dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix-trpg-flow-stability`
- `cd viewer && cargo check`
- `cd viewer && cargo test decode_stream_maps_session_outcome_event -- --nocapture`
- `cd viewer && cargo test ended_room_requires_new_game -- --nocapture`

## Notes
- `cargo fmt --check` reports pre-existing formatting diffs in unrelated viewer files; not auto-applied in this PR.
