### PR TITLE
feat(audit): add governance report with cost/token tracking

### DIFF
--- a/lib/audit_log.ml
+++ b/lib/audit_log.ml
@@ -31,6 +31,7 @@ type action =
   | AuthFailure
   | CircuitOpen
   | CircuitClose
+  | SearchRefinement
   | Custom of string
 
 type audit_entry = {
@@ -40,6 +41,8 @@ type audit_entry = {
   room_id: string option;
   details: Yojson.Safe.t;
   outcome: outcome;
+  cost_estimate: float option;
+  token_count: int option;
 }
 
 (** {1 Serialization} *)
@@ -57,7 +60,27 @@ let action_to_string = function
   | AuthFailure -> "auth_failure"
   | CircuitOpen -> "circuit_open"
   | CircuitClose -> "circuit_close"
+  | SearchRefinement -> "search_refinement"
   | Custom name -> "custom:" ^ name
+
+let string_to_action = function
+  | "join" -> Join
+  | "leave" -> Leave
+  | "claim_task" -> ClaimTask
+  | "done_task" -> DoneTask
+  | "cancel_task" -> CancelTask
+  | "broadcast" -> Broadcast
+  | "suspend" -> Suspend
+  | "auth_success" -> AuthSuccess
+  | "auth_failure" -> AuthFailure
+  | "circuit_open" -> CircuitOpen
+  | "circuit_close" -> CircuitClose
+  | "search_refinement" -> SearchRefinement
+  | s when String.length s > 10 && String.sub s 0 10 = "tool_call:" ->
+      ToolCall (String.sub s 10 (String.length s - 10))
+  | s when String.length s > 7 && String.sub s 0 7 = "custom:" ->
+      Custom (String.sub s 7 (String.length s - 7))
+  | s -> Custom s
 
 let outcome_to_json = function
   | Success -> `Assoc [("status", `String "success")]
@@ -67,14 +90,61 @@ let outcome_to_json = function
     ]
 
 let entry_to_json (e : audit_entry) : Yojson.Safe.t =
-  `Assoc [
+  let base = [
     ("timestamp", `Float e.timestamp);
     ("agent_id", `String e.agent_id);
     ("action", `String (action_to_string e.action));
     ("room_id", match e.room_id with Some r -> `String r | None -> `Null);
     ("details", e.details);
     ("outcome", outcome_to_json e.outcome);
-  ]
+  ] in
+  let with_cost = match e.cost_estimate with
+    | Some c -> base @ [("cost_estimate", `Float c)]
+    | None -> base
+  in
+  let with_tokens = match e.token_count with
+    | Some t -> with_cost @ [("token_count", `Int t)]
+    | None -> with_cost
+  in
+  `Assoc with_tokens
+
+(** Parse a JSON object back into an audit_entry *)
+let entry_of_json (json : Yojson.Safe.t) : audit_entry option =
+  try
+    let module U = Yojson.Safe.Util in
+    let timestamp = json |> U.member "timestamp" |> U.to_float in
+    let agent_id = json |> U.member "agent_id" |> U.to_string in
+    let action = json |> U.member "action" |> U.to_string |> string_to_action in
+    let room_id = json |> U.member "room_id" |> U.to_string_option in
+    let details =
+      try json |> U.member "details"
+      with _ -> `Null
+    in
+    let outcome =
+      let o = json |> U.member "outcome" in
+      let status = o |> U.member "status" |> U.to_string in
+      if status = "success" then Success
+      else
+        let reason = try o |> U.member "reason" |> U.to_string with _ -> "unknown" in
+        Failure reason
+    in
+    let cost_estimate =
+      try
+        match json |> U.member "cost_estimate" with
+        | `Float f -> Some f
+        | `Int i -> Some (float_of_int i)
+        | _ -> None
+      with _ -> None
+    in
+    let token_count =
+      try
+        match json |> U.member "token_count" with
+        | `Int i -> Some i
+        | _ -> None
+      with _ -> None
+    in
+    Some { timestamp; agent_id; action; room_id; details; outcome; cost_estimate; token_count }
+  with _ -> None
 
 (** {1 File Operations} *)
 
@@ -83,6 +153,25 @@ let mutex = Mutex.create ()
 let get_audit_path (config : Room.config) =
   let masc_dir = Room_utils.masc_dir config in
   Filename.concat masc_dir "audit.jsonl"
+
+(** Read all audit entries from the JSONL file *)
+let read_entries (config : Room.config) : audit_entry list =
+  let path = get_audit_path config in
+  if not (Sys.file_exists path) then []
+  else
+    let ic = open_in path in
+    let entries = ref [] in
+    (try
+      while true do
+        let line = input_line ic in
+        if String.trim line <> "" then
+          match entry_of_json (Yojson.Safe.from_string line) with
+          | Some e -> entries := e :: !entries
+          | None -> ()
+      done
+    with End_of_file -> ());
+    close_in ic;
+    List.rev !entries
 
 (** Recursively create directory (no shell, safe) *)
 let rec ensure_dir_safe dir =
@@ -123,6 +212,8 @@ let log_action
     ~action
     ?(room_id : string option)
     ?(details : Yojson.Safe.t = `Null)
+    ?(cost_estimate : float option)
+    ?(token_count : int option)
     ~outcome
     () =
   let entry = {
@@ -132,70 +223,73 @@ let log_action
     room_id;
     details;
     outcome;
+    cost_estimate;
+    token_count;
   } in
   append_entry config entry
 
 (** Convenience functions for common events *)
 
-let log_join config ~agent_id ~room_id =
+let log_join config ~agent_id ~room_id ?cost_estimate ?token_count () =
   log_action config ~agent_id ~action:Join ~room_id
-    ~outcome:Success ()
+    ?cost_estimate ?token_count ~outcome:Success ()
 
-let log_leave config ~agent_id ~room_id =
+let log_leave config ~agent_id ~room_id ?cost_estimate ?token_count () =
   log_action config ~agent_id ~action:Leave ~room_id
-    ~outcome:Success ()
+    ?cost_estimate ?token_count ~outcome:Success ()
 
-let log_claim_task config ~agent_id ~room_id ~task_id =
+let log_claim_task config ~agent_id ~room_id ~task_id ?cost_estimate ?token_count () =
   log_action config ~agent_id ~action:ClaimTask ~room_id
     ~details:(`Assoc [("task_id", `String task_id)])
-    ~outcome:Success ()
+    ?cost_estimate ?token_count ~outcome:Success ()
 
-let log_done_task config ~agent_id ~room_id ~task_id =
+let log_done_task config ~agent_id ~room_id ~task_id ?cost_estimate ?token_count () =
   log_action config ~agent_id ~action:DoneTask ~room_id
     ~details:(`Assoc [("task_id", `String task_id)])
-    ~outcome:Success ()
+    ?cost_estimate ?token_count ~outcome:Success ()
 
-let log_cancel_task config ~agent_id ~room_id ~task_id ~reason =
+let log_cancel_task config ~agent_id ~room_id ~task_id ~reason ?cost_estimate ?token_count () =
   log_action config ~agent_id ~action:CancelTask ~room_id
     ~details:(`Assoc [
       ("task_id", `String task_id);
       ("reason", `String reason);
     ])
-    ~outcome:Success ()
+    ?cost_estimate ?token_count ~outcome:Success ()
 
-let log_broadcast config ~agent_id ~room_id ~message_preview =
+let log_broadcast config ~agent_id ~room_id ~message_preview ?cost_estimate ?token_count () =
   (* Truncate message for privacy/size *)
   let preview = if String.length message_preview > 100
     then String.sub message_preview 0 100 ^ "..."
     else message_preview in
   log_action config ~agent_id ~action:Broadcast ~room_id
     ~details:(`Assoc [("preview", `String preview)])
-    ~outcome:Success ()
+    ?cost_estimate ?token_count ~outcome:Success ()
 
-let log_suspend config ~agent_id ~target_agent ~reason ~rooms_affected =
+let log_suspend config ~agent_id ~target_agent ~reason ~rooms_affected ?cost_estimate ?token_count () =
   log_action config ~agent_id ~action:Suspend
     ~details:(`Assoc [
       ("target_agent", `String target_agent);
       ("reason", `String reason);
       ("rooms_affected", `Int rooms_affected);
     ])
-    ~outcome:Success ()
+    ?cost_estimate ?token_count ~outcome:Success ()
 
-let log_tool_call config ~agent_id ~tool_name ~success ~error_msg =
+let log_tool_call config ~agent_id ~tool_name ~success ~error_msg ?cost_estimate ?token_count () =
   let outcome = if success then Success else Failure (Option.value error_msg ~default:"unknown") in
-  log_action config ~agent_id ~action:(ToolCall tool_name) ~outcome ()
+  log_action config ~agent_id ~action:(ToolCall tool_name) ?cost_estimate ?token_count ~outcome ()
 
-let log_auth_attempt config ~agent_id ~success ~method_name =
+let log_auth_attempt config ~agent_id ~success ~method_name ?cost_estimate ?token_count () =
   let action = if success then AuthSuccess else AuthFailure in
   log_action config ~agent_id ~action
     ~details:(`Assoc [("method", `String method_name)])
+    ?cost_estimate ?token_count
     ~outcome:(if success then Success else Failure "auth_failed") ()
 
-let log_circuit_breaker config ~agent_id ~opened ~reason =
+let log_circuit_breaker config ~agent_id ~opened ~reason ?cost_estimate ?token_count () =
   let action = if opened then CircuitOpen else CircuitClose in
   log_action config ~agent_id ~action
     ~details:(`Assoc [("reason", `String reason)])
-    ~outcome:Success ()
+    ?cost_estimate ?token_count ~outcome:Success ()
 
 (** {1 Rotation & Cleanup} *)
 

--- a/lib/tool_audit.ml
+++ b/lib/tool_audit.ml
@@ -167,9 +167,136 @@ let handle_audit_stats ctx args =
   ] in
   (true, Yojson.Safe.pretty_to_string json)
 
+(** {1 Governance Report} *)
+
+type agent_summary = {
+  agent_id : string;
+  action_count : int;
+  action_types : (string * int) list;
+  total_cost : float;
+  total_tokens : int;
+  failure_rate : float;
+}
+
+type governance_report = {
+  period_start : string;
+  period_end : string;
+  agents : agent_summary list;
+  total_actions : int;
+  total_cost : float;
+  total_tokens : int;
+  overall_failure_rate : float;
+}
+
+let governance_summary ?(since="") ?(until_time="") (entries : Audit_log.audit_entry list) : governance_report =
+  (* Filter by time range if provided *)
+  let since_ts = if since = "" then 0.0
+    else (try float_of_string since with _ -> 0.0)
+  in
+  let until_ts = if until_time = "" then infinity
+    else (try float_of_string until_time with _ -> infinity)
+  in
+  let filtered = List.filter (fun (e : Audit_log.audit_entry) ->
+    e.timestamp >= since_ts && e.timestamp <= until_ts
+  ) entries in
+  (* Group by agent_id *)
+  let agent_ids =
+    List.map (fun (e : Audit_log.audit_entry) -> e.agent_id) filtered
+    |> List.sort_uniq String.compare
+  in
+  let summarize_agent agent_id =
+    let agent_entries = List.filter (fun (e : Audit_log.audit_entry) ->
+      e.agent_id = agent_id
+    ) filtered in
+    let action_count = List.length agent_entries in
+    (* Count actions by type *)
+    let type_counts = Hashtbl.create 16 in
+    List.iter (fun (e : Audit_log.audit_entry) ->
+      let key = Audit_log.action_to_string e.action in
+      let cur = try Hashtbl.find type_counts key with Not_found -> 0 in
+      Hashtbl.replace type_counts key (cur + 1)
+    ) agent_entries;
+    let action_types = Hashtbl.fold (fun k v acc -> (k, v) :: acc) type_counts [] in
+    let action_types = List.sort (fun (a, _) (b, _) -> String.compare a b) action_types in
+    (* Sum costs *)
+    let total_cost = List.fold_left (fun acc (e : Audit_log.audit_entry) ->
+      acc +. (Option.value e.cost_estimate ~default:0.0)
+    ) 0.0 agent_entries in
+    (* Sum tokens *)
+    let total_tokens = List.fold_left (fun acc (e : Audit_log.audit_entry) ->
+      acc + (Option.value e.token_count ~default:0)
+    ) 0 agent_entries in
+    (* Calculate failure rate *)
+    let failure_count = List.fold_left (fun acc (e : Audit_log.audit_entry) ->
+      match e.outcome with
+      | Audit_log.Failure _ -> acc + 1
+      | Audit_log.Success -> acc
+    ) 0 agent_entries in
+    let failure_rate =
+      if action_count = 0 then 0.0
+      else float_of_int failure_count /. float_of_int action_count
+    in
+    { agent_id; action_count; action_types; total_cost; total_tokens; failure_rate }
+  in
+  let agents = List.map summarize_agent agent_ids in
+  let total_actions = List.fold_left (fun acc (a : agent_summary) -> acc + a.action_count) 0 agents in
+  let total_cost = List.fold_left (fun acc (a : agent_summary) -> acc +. a.total_cost) 0.0 agents in
+  let total_tokens = List.fold_left (fun acc (a : agent_summary) -> acc + a.total_tokens) 0 agents in
+  let total_failures = List.fold_left (fun acc (e : Audit_log.audit_entry) ->
+    match e.outcome with
+    | Audit_log.Failure _ -> acc + 1
+    | Audit_log.Success -> acc
+  ) 0 filtered in
+  let overall_failure_rate =
+    if total_actions = 0 then 0.0
+    else float_of_int total_failures /. float_of_int total_actions
+  in
+  let period_start = if since <> "" then since
+    else match filtered with
+      | [] -> ""
+      | first :: _ -> Printf.sprintf "%.0f" first.timestamp
+  in
+  let period_end = if until_time <> "" then until_time
+    else match List.rev filtered with
+      | [] -> ""
+      | last :: _ -> Printf.sprintf "%.0f" last.timestamp
+  in
+  { period_start; period_end; agents; total_actions; total_cost; total_tokens; overall_failure_rate }
+
+let agent_summary_to_json (a : agent_summary) : Yojson.Safe.t =
+  `Assoc [
+    ("agent_id", `String a.agent_id);
+    ("action_count", `Int a.action_count);
+    ("action_types", `Assoc (List.map (fun (k, v) -> (k, `Int v)) a.action_types));
+    ("total_cost", `Float a.total_cost);
+    ("total_tokens", `Int a.total_tokens);
+    ("failure_rate", `Float a.failure_rate);
+  ]
+
+let report_to_json (report : governance_report) : Yojson.Safe.t =
+  `Assoc [
+    ("period_start", `String report.period_start);
+    ("period_end", `String report.period_end);
+    ("agents", `List (List.map agent_summary_to_json report.agents));
+    ("total_actions", `Int report.total_actions);
+    ("total_cost", `Float report.total_cost);
+    ("total_tokens", `Int report.total_tokens);
+    ("overall_failure_rate", `Float report.overall_failure_rate);
+  ]
+
+(* Handle masc_governance_report *)
+let handle_governance_report ctx args =
+  let since = get_string args "since" "" in
+  let until_time = get_string args "until" "" in
+  let entries = Audit_log.read_entries ctx.config in
+  let report = governance_summary ~since ~until_time entries in
+  let json = report_to_json report in
+  (true, Yojson.Safe.pretty_to_string json)
+
 (* Dispatch handler *)
 let dispatch ctx ~name ~args =
   match name with
   | "masc_audit_query" -> Some (handle_audit_query ctx args)
   | "masc_audit_stats" -> Some (handle_audit_stats ctx args)
+  | "masc_governance_report" -> Some (handle_governance_report ctx args)
   | _ -> None

--- a/lib/tool_audit.mli
+++ b/lib/tool_audit.mli
@@ -1,4 +1,4 @@
-(** Tool_audit - Audit query and statistics handlers *)
+(** Tool_audit - Audit query, statistics, and governance report handlers *)
 
 type context = {
   config: Room.config;
@@ -11,6 +11,27 @@ type audit_event = {
   event_type: string;
   success: bool;
   detail: string option;
+}
+
+(** {1 Governance Report Types} *)
+
+type agent_summary = {
+  agent_id : string;
+  action_count : int;
+  action_types : (string * int) list;
+  total_cost : float;
+  total_tokens : int;
+  failure_rate : float;
+}
+
+type governance_report = {
+  period_start : string;
+  period_end : string;
+  agents : agent_summary list;
+  total_actions : int;
+  total_cost : float;
+  total_tokens : int;
+  overall_failure_rate : float;
 }
 
 (** Dispatch handler. Returns Some (success, result) if handled, None otherwise *)
@@ -27,6 +48,12 @@ val handle_audit_query : context -> Yojson.Safe.t -> bool * string
 
 (** Handle masc_audit_stats *)
 val handle_audit_stats : context -> Yojson.Safe.t -> bool * string
+
+(** Generate governance summary from audit trail entries *)
+val governance_summary : ?since:string -> ?until_time:string -> Audit_log.audit_entry list -> governance_report
+
+(** Convert governance report to JSON *)
+val report_to_json : governance_report -> Yojson.Safe.t
 
 (** Helper: get string from args *)
 val get_string : Yojson.Safe.t -> string -> string -> string

--- a/lib/tool_suspend.ml
+++ b/lib/tool_suspend.ml
@@ -140,13 +140,13 @@ let handle_suspend ctx args =
       ~agent_id:caller
       ~target_agent
       ~reason
-      ~rooms_affected;
+      ~rooms_affected ();
 
     (* Log circuit breaker event *)
     Audit_log.log_circuit_breaker ctx.config
       ~agent_id:target_agent
       ~opened:true
-      ~reason:("Suspended by " ^ caller);
+      ~reason:("Suspended by " ^ caller) ();
 
     Log.Session.warn "[Suspend] Agent '%s' suspended by '%s': %s (%.1fh, %d rooms)"
       target_agent caller reason duration_hours rooms_affected;

--- a/lib/tools.ml
+++ b/lib/tools.ml
@@ -3663,6 +3663,24 @@ Example: masc_swarm_leave({agent_name: 'claude-xyz'})";
   };
 
   {
+    name = "masc_governance_report";
+    description = "Generate a governance summary report from the audit trail. Aggregates per-agent action counts, cost estimates, token usage, and failure rates over a time period. Use for periodic governance review and cost tracking.";
+    input_schema = `Assoc [
+      ("type", `String "object");
+      ("properties", `Assoc [
+        ("since", `Assoc [
+          ("type", `String "string");
+          ("description", `String "Start of period as Unix timestamp string (optional, defaults to all time)");
+        ]);
+        ("until", `Assoc [
+          ("type", `String "string");
+          ("description", `String "End of period as Unix timestamp string (optional, defaults to now)");
+        ]);
+      ]);
+    ];
+  };
+
+  {
     name = "masc_governance_set";
     description = "Configure governance policies for the room. Enables audit logging, anomaly detection, and agent isolation. Enterprise security for production use.";
     input_schema = `Assoc [


### PR DESCRIPTION
## Summary
- `Audit_log`에 `cost_estimate`, `token_count` optional 필드 추가
- `tool_audit.ml`에 `governance_summary` 함수: 시간 범위별 에이전트 활동 집계
- `masc_governance_report` MCP 도구 등록 (since/until 파라미터)
- `SearchRefinement` action variant 추가

## Changed Files
- `lib/audit_log.ml`: cost/token 필드 + read_entries/entry_of_json 함수 (+136 lines)
- `lib/tool_audit.ml`: governance report 생성 로직 + MCP handler (+127 lines)
- `lib/tool_audit.mli`: 타입/함수 시그니처 노출 (+29 lines)
- `lib/tool_suspend.ml`: trailing unit param 적용 (+4 lines)
- `lib/tools.ml`: MCP 도구 스키마 등록 (+18 lines)

## Design Decisions
- `agent_summary`/`governance_report` record field 이름 충돌 → 명시적 타입 annotation 사용
- audit.jsonl 파싱: `string_to_action`으로 variant 복원, unknown은 `Other` 폴백
- 시간 범위 필터링: Unix timestamp 문자열 비교 (ISO8601 정규화는 후속 작업)

## Verification
- `dune build` clean
- `dune runtest` 통과 (22 eval_harness + 1 board_api_e2e)

## Test plan
- [ ] `masc_governance_report` MCP 호출 시 JSON 응답 확인
- [ ] since/until 파라미터 필터링 동작 확인
- [ ] cost_estimate/token_count 기록 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)