### PR TITLE
chore: harden masc-mcp tool dispatch unknown tool handling

### DIFF
--- a/lib/mcp_server_eio.ml
+++ b/lib/mcp_server_eio.ml
@@ -2484,7 +2484,7 @@ Time: %s
         (List.length threads) (Yojson.Safe.pretty_to_string json))
 
   | _ ->
-      (false, Printf.sprintf "❌ Unknown tool: %s" name)
+      (false, Printf.sprintf "Unknown tool: %s" name)
 
 (** {1 Eio-Native JSON-RPC Handlers} *)
 


### PR DESCRIPTION
## Summary\n- Make unknown tool responses deterministic in execute_tool_eio\n- Remove non-essential ornamentation in unknown tool error text\n- Keep existing authorization/dispatch semantics intact