### PR TITLE
feat(harness): add anti-fake test quality scoring (P2)

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -1,7 +1,7 @@
 (lang dune 3.13)
 
 (name masc_mcp)
-(version 2.74.0)
+(version 2.74.1)
 
 (generate_opam_files true)
 

--- a/lib/anti_fake.ml
+++ b/lib/anti_fake.ml
@@ -1,0 +1,234 @@
+(** Anti-Fake Test Quality Scoring — Pure heuristic analysis.
+
+    Detects common patterns of low-quality ("fake") tests:
+    - [assert true] (vacuous assertion)
+    - [let _ = expr] (discarding results)
+    - TODO / FIXME comments (incomplete tests)
+    - [skip] / [ignore] (disabled tests)
+
+    And rewards quality indicators:
+    - [Alcotest.check] / [assert_equal] (real assertions)
+    - [roundtrip] (encoding/decoding verification)
+    - [property] / [quickcheck] / [QCheck] (property-based testing)
+
+    @since 2.75.0 *)
+
+type severity =
+  | Info
+  | Warning
+  | Critical
+
+type finding = {
+  line_number : int;
+  pattern : string;
+  severity : severity;
+  penalty : float;
+  context : string;
+}
+
+type score_result = {
+  file_path : string;
+  raw_score : float;
+  final_score : float;
+  findings : finding list;
+  total_lines : int;
+  test_lines : int;
+  quality_tier : string;
+}
+
+type audit_summary = {
+  total_files : int;
+  avg_score : float;
+  min_score : float;
+  max_score : float;
+  fake_count : int;
+  suspect_count : int;
+  results : score_result list;
+}
+
+(** Penalty patterns: (substring, weight, severity).
+    Weights are negative — they reduce the score. *)
+let penalties : (string * float * severity) list = [
+  ("assert true", -0.3, Critical);
+  ("assert_bool \"\" true", -0.3, Critical);
+  ("let _ =", -0.2, Warning);
+  ("(* TODO", -0.15, Warning);
+  ("(* FIXME", -0.15, Warning);
+  ("skip", -0.1, Info);
+  ("ignore", -0.1, Info);
+  ("fun _ ->", -0.05, Info);
+]
+
+(** Bonus patterns: (substring, weight).
+    Weights are positive — each distinct occurrence (capped at 3)
+    adds [weight * min(count, 3)] to the score. *)
+let bonuses : (string * float) list = [
+  ("Alcotest.(check", 0.15);
+  ("Alcotest.check", 0.15);
+  ("assert_equal", 0.1);
+  ("check_raises", 0.1);
+  ("expect", 0.1);
+  ("roundtrip", 0.15);
+  ("property", 0.1);
+  ("quickcheck", 0.1);
+  ("QCheck", 0.1);
+  ("Crowbar", 0.1);
+]
+
+let base_score = 0.5
+
+let clamp v ~lo ~hi = Float.max lo (Float.min hi v)
+
+(** Return ["excellent"], ["good"], ["suspect"], or ["fake"]. *)
+let quality_tier (score : float) : string =
+  if score >= 0.8 then "excellent"
+  else if score >= 0.5 then "good"
+  else if score >= 0.3 then "suspect"
+  else "fake"
+
+(** True when [needle] is a substring of [haystack]. *)
+let contains_substring haystack needle =
+  let nlen = String.length needle in
+  let hlen = String.length haystack in
+  if nlen > hlen then false
+  else begin
+    let found = ref false in
+    let i = ref 0 in
+    while !i <= hlen - nlen && not !found do
+      if String.sub haystack !i nlen = needle then found := true
+      else incr i
+    done;
+    !found
+  end
+
+(** Truncate [s] to at most [max_len] characters, appending ["..."]
+    when truncated. *)
+let truncate_line s max_len =
+  if String.length s > max_len then String.sub s 0 max_len ^ "..."
+  else s
+
+(** Score the content of a single test file.
+    Pure function — no I/O. *)
+let score_content ~(file_path : string) (content : string) : score_result =
+  let lines = String.split_on_char '\n' content in
+  let total_lines = List.length lines in
+  let findings = ref [] in
+  let bonus_total = ref 0.0 in
+
+  (* Scan each line for penalty patterns *)
+  List.iteri (fun i line ->
+    let trimmed = String.trim line in
+    if String.length trimmed > 0 then
+      List.iter (fun (pattern, penalty, sev) ->
+        if contains_substring trimmed pattern then
+          findings := {
+            line_number = i + 1;
+            pattern;
+            severity = sev;
+            penalty;
+            context = truncate_line trimmed 80;
+          } :: !findings
+      ) penalties
+  ) lines;
+
+  (* Scan all lines for bonus patterns, count occurrences (capped at 3) *)
+  List.iter (fun (pattern, bonus) ->
+    let count = List.fold_left (fun acc line ->
+      if contains_substring line pattern then acc + 1 else acc
+    ) 0 lines in
+    if count > 0 then
+      bonus_total := !bonus_total +. (bonus *. Float.of_int (min count 3))
+  ) bonuses;
+
+  (* Count lines that contain any test-related pattern *)
+  let test_lines = List.length (List.filter (fun line ->
+    let t = String.trim line in
+    List.exists (fun (p, _) -> contains_substring t p) bonuses
+    || List.exists (fun (p, _, _) -> contains_substring t p) penalties
+  ) lines) in
+
+  let penalty_total =
+    List.fold_left (fun acc f -> acc +. f.penalty) 0.0 !findings
+  in
+  let raw_score = base_score +. penalty_total +. !bonus_total in
+  let final_score = clamp raw_score ~lo:0.0 ~hi:1.0 in
+
+  {
+    file_path;
+    raw_score;
+    final_score;
+    findings = List.rev !findings;
+    total_lines;
+    test_lines;
+    quality_tier = quality_tier final_score;
+  }
+
+(** Score a test file by reading it from disk. *)
+let score_file (file_path : string) : score_result =
+  let ic = open_in file_path in
+  Fun.protect ~finally:(fun () -> close_in ic) (fun () ->
+    let content = In_channel.input_all ic in
+    score_content ~file_path content)
+
+(** Aggregate multiple [score_result]s into a summary. *)
+let summarize (results : score_result list) : audit_summary =
+  let n = List.length results in
+  if n = 0 then {
+    total_files = 0; avg_score = 0.0; min_score = 0.0;
+    max_score = 0.0; fake_count = 0; suspect_count = 0; results = [];
+  }
+  else
+    let scores = List.map (fun r -> r.final_score) results in
+    let sum = List.fold_left ( +. ) 0.0 scores in
+    let min_s = List.fold_left Float.min 1.0 scores in
+    let max_s = List.fold_left Float.max 0.0 scores in
+    {
+      total_files = n;
+      avg_score = sum /. Float.of_int n;
+      min_score = min_s;
+      max_score = max_s;
+      fake_count =
+        List.length (List.filter (fun r -> r.final_score < 0.3) results);
+      suspect_count =
+        List.length (List.filter (fun r ->
+          r.final_score >= 0.3 && r.final_score < 0.5) results);
+      results;
+    }
+
+(* ── JSON serialization ─────────────────────────────────────── *)
+
+let severity_to_string = function
+  | Info -> "info"
+  | Warning -> "warning"
+  | Critical -> "critical"
+
+let finding_to_json (f : finding) : Yojson.Safe.t =
+  `Assoc [
+    ("line", `Int f.line_number);
+    ("pattern", `String f.pattern);
+    ("severity", `String (severity_to_string f.severity));
+    ("penalty", `Float f.penalty);
+    ("context", `String f.context);
+  ]
+
+let result_to_json (r : score_result) : Yojson.Safe.t =
+  `Assoc [
+    ("file", `String r.file_path);
+    ("raw_score", `Float r.raw_score);
+    ("final_score", `Float r.final_score);
+    ("quality_tier", `String r.quality_tier);
+    ("total_lines", `Int r.total_lines);
+    ("test_lines", `Int r.test_lines);
+    ("findings", `List (List.map finding_to_json r.findings));
+  ]
+
+let summary_to_json (s : audit_summary) : Yojson.Safe.t =
+  `Assoc [
+    ("total_files", `Int s.total_files);
+    ("avg_score", `Float s.avg_score);
+    ("min_score", `Float s.min_score);
+    ("max_score", `Float s.max_score);
+    ("fake_count", `Int s.fake_count);
+    ("suspect_count", `Int s.suspect_count);
+    ("results", `List (List.map result_to_json s.results));
+  ]

--- a/lib/anti_fake.mli
+++ b/lib/anti_fake.mli
@@ -1,0 +1,76 @@
+(** Anti-Fake Test Quality Scoring — Pure heuristic analysis.
+
+    Scores test files based on pattern detection to identify
+    vacuous ("fake") tests and reward genuine quality indicators.
+
+    @since 2.75.0 *)
+
+(** Severity classification for a detected pattern. *)
+type severity =
+  | Info
+  | Warning
+  | Critical
+
+(** A single pattern match found in the source. *)
+type finding = {
+  line_number : int;
+  pattern : string;
+  severity : severity;
+  penalty : float;
+  context : string;
+}
+
+(** Scoring result for one test file. *)
+type score_result = {
+  file_path : string;
+  raw_score : float;       (** Before clamping to [0.0, 1.0]. *)
+  final_score : float;     (** Clamped to [0.0, 1.0]. *)
+  findings : finding list;
+  total_lines : int;
+  test_lines : int;        (** Lines containing test-related patterns. *)
+  quality_tier : string;   (** One of "excellent", "good", "suspect", "fake". *)
+}
+
+(** Aggregate statistics across multiple files. *)
+type audit_summary = {
+  total_files : int;
+  avg_score : float;
+  min_score : float;
+  max_score : float;
+  fake_count : int;        (** Files with [final_score < 0.3]. *)
+  suspect_count : int;     (** Files with [0.3 <= final_score < 0.5]. *)
+  results : score_result list;
+}
+
+(** Penalty patterns with their weights and severities. *)
+val penalties : (string * float * severity) list
+
+(** Bonus patterns with their weights. *)
+val bonuses : (string * float) list
+
+(** The base score before penalties and bonuses: [0.5]. *)
+val base_score : float
+
+(** [clamp v ~lo ~hi] constrains [v] to [[lo, hi]]. *)
+val clamp : float -> lo:float -> hi:float -> float
+
+(** Map a numeric score to a quality tier label. *)
+val quality_tier : float -> string
+
+(** [score_content ~file_path content] scores the given string
+    as though it were the contents of [file_path].
+    Pure — performs no I/O. *)
+val score_content : file_path:string -> string -> score_result
+
+(** [score_file path] reads [path] and scores its contents. *)
+val score_file : string -> score_result
+
+(** Aggregate a list of results into a summary. *)
+val summarize : score_result list -> audit_summary
+
+(** {2 JSON serialization} *)
+
+val severity_to_string : severity -> string
+val finding_to_json : finding -> Yojson.Safe.t
+val result_to_json : score_result -> Yojson.Safe.t
+val summary_to_json : audit_summary -> Yojson.Safe.t

--- a/lib/dune
+++ b/lib/dune
@@ -232,7 +232,9 @@
    trpg_bdi
    trpg_harness
    trpg_actor_match
-   json_util)
+   json_util
+   ;; Anti-Fake Test Quality Scoring (harness P2)
+   anti_fake)
  (libraries
    yojson
    base64

--- a/lib/masc_mcp.ml
+++ b/lib/masc_mcp.ml
@@ -201,6 +201,7 @@ module Tool_keeper = Tool_keeper
 module Trajectory = Trajectory
 module Eval_gate = Eval_gate
 module Eval_harness = Eval_harness
+module Anti_fake = Anti_fake
 
 module Tool_goals = Tool_goals
 module Tool_trpg = Tool_trpg

--- a/scripts/anti-fake-audit.sh
+++ b/scripts/anti-fake-audit.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# Anti-Fake Test Audit — scan test files for vacuous / fake test patterns.
+# Uses shell heuristics (no OCaml build required).
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$REPO_ROOT"
+
+echo "=== Anti-Fake Test Audit ==="
+echo ""
+
+# Collect test files
+mapfile -t TEST_FILES < <(find test -name "test_*.ml" -type f | sort)
+FILE_COUNT=${#TEST_FILES[@]}
+
+echo "Found $FILE_COUNT test files"
+echo ""
+
+FAKE=0
+SUSPECT=0
+GOOD=0
+
+for f in "${TEST_FILES[@]}"; do
+  # Count penalty patterns
+  ASSERT_TRUE=$(rg -c "assert true|assert_bool.*true" "$f" 2>/dev/null || echo 0)
+  LET_IGNORE=$(rg -c "let _ =" "$f" 2>/dev/null || echo 0)
+  TODO_COUNT=$(rg -c '\(\* TODO|\(\* FIXME' "$f" 2>/dev/null || echo 0)
+
+  # Count bonus patterns
+  REAL_ASSERT=$(rg -c 'Alcotest\.|assert_equal|check_raises' "$f" 2>/dev/null || echo 0)
+  PROP_TEST=$(rg -c 'QCheck|quickcheck|Crowbar|property' "$f" 2>/dev/null || echo 0)
+  ROUNDTRIP=$(rg -c 'roundtrip' "$f" 2>/dev/null || echo 0)
+
+  # Compute a simplified score
+  # base 0.5, penalties (capped contribution), bonuses (capped contribution)
+  PENALTY=$(echo "scale=2; $ASSERT_TRUE * 0.3 + $LET_IGNORE * 0.2 + $TODO_COUNT * 0.15" | bc)
+  BONUS=$(echo "scale=2; $REAL_ASSERT * 0.05 + $PROP_TEST * 0.05 + $ROUNDTRIP * 0.1" | bc)
+  # Cap bonus at 0.5
+  BONUS=$(echo "scale=2; if ($BONUS > 0.5) 0.5 else $BONUS" | bc)
+  SCORE=$(echo "scale=2; s = 0.5 - $PENALTY + $BONUS; if (s < 0) 0 else if (s > 1) 1 else s" | bc)
+
+  # Classify
+  TIER="good"
+  if (( $(echo "$SCORE < 0.3" | bc -l) )); then
+    TIER="FAKE"
+    FAKE=$((FAKE + 1))
+  elif (( $(echo "$SCORE < 0.5" | bc -l) )); then
+    TIER="SUSPECT"
+    SUSPECT=$((SUSPECT + 1))
+  else
+    GOOD=$((GOOD + 1))
+  fi
+
+  printf "  %-55s  score=%-5s  [%s]\n" "$f" "$SCORE" "$TIER"
+done
+
+echo ""
+echo "=== Summary ==="
+echo "  Good:    $GOOD"
+echo "  Suspect: $SUSPECT"
+echo "  Fake:    $FAKE"
+echo "  Total:   $FILE_COUNT"
+
+if [ "$FAKE" -gt 0 ]; then
+  echo ""
+  echo "WARNING: $FAKE fake test file(s) detected."
+  exit 1
+fi
+
+exit 0

--- a/test/dune
+++ b/test/dune
@@ -472,3 +472,9 @@
  (name test_eval_harness)
  (modules test_eval_harness)
  (libraries masc_mcp alcotest str yojson unix))
+
+; Anti-Fake Test Quality Scoring (harness P2)
+(test
+ (name test_anti_fake)
+ (modules test_anti_fake)
+ (libraries masc_mcp alcotest yojson))

--- a/test/test_anti_fake.ml
+++ b/test/test_anti_fake.ml
@@ -1,0 +1,251 @@
+(** Tests for Anti_fake — anti-fake test quality scoring. *)
+
+module AF = Masc_mcp.Anti_fake
+
+(* ── Helpers ────────────────────────────────────────────────── *)
+
+let float_eps = Alcotest.testable
+  (fun ppf v -> Fmt.pf ppf "%.4f" v)
+  (fun a b -> Float.abs (a -. b) < 0.001)
+
+let score content =
+  AF.score_content ~file_path:"<test>" content
+
+(* ── Test: vacuous assert true → fake ──────────────────────── *)
+
+let test_assert_true_is_fake () =
+  let content =
+    {|let test_a () = assert true
+let test_b () = assert true
+let test_c () = assert true|}
+  in
+  let r = score content in
+  Alcotest.(check string) "quality_tier" "fake" r.quality_tier;
+  Alcotest.(check bool) "score < 0.3" true (r.final_score < 0.3);
+  (* 3 findings for "assert true" *)
+  Alcotest.(check int) "findings count" 3 (List.length r.findings);
+  List.iter (fun f ->
+    Alcotest.(check string) "pattern" "assert true" f.AF.pattern;
+    match f.AF.severity with
+    | AF.Critical -> ()
+    | _ -> Alcotest.fail "expected Critical severity"
+  ) r.findings
+
+(* ── Test: proper Alcotest assertions → good ───────────────── *)
+
+let test_alcotest_check_is_good () =
+  let content =
+    {|let test_create () =
+  let v = create () in
+  Alcotest.(check int) "initial" 0 v
+
+let test_tick () =
+  let v = tick () in
+  Alcotest.(check int) "ticked" 1 v|}
+  in
+  let r = score content in
+  Alcotest.(check bool) "score >= 0.5" true (r.final_score >= 0.5);
+  Alcotest.(check string) "tier is good or excellent"
+    (if r.final_score >= 0.8 then "excellent" else "good")
+    r.quality_tier;
+  (* No findings — no penalty patterns present *)
+  Alcotest.(check int) "no penalties" 0 (List.length r.findings)
+
+(* ── Test: mixed good and bad → intermediate ───────────────── *)
+
+let test_mixed_score () =
+  let content =
+    {|let test_a () = assert true
+let test_b () =
+  Alcotest.(check int) "val" 42 (compute ())
+let test_c () =
+  let _ = ignored_result () in
+  ()|}
+  in
+  let r = score content in
+  (* Has both penalties and bonuses; score should be moderate *)
+  Alcotest.(check bool) "has findings" true (List.length r.findings > 0);
+  (* Not purely fake — the Alcotest.check rescues it somewhat *)
+  Alcotest.(check bool) "score > 0.0" true (r.final_score > 0.0)
+
+(* ── Test: empty file → base score 0.5 ────────────────────── *)
+
+let test_empty_file () =
+  let r = score "" in
+  Alcotest.(check (float_eps)) "base score" 0.5 r.final_score;
+  Alcotest.(check string) "tier" "good" r.quality_tier;
+  Alcotest.(check int) "no findings" 0 (List.length r.findings);
+  Alcotest.(check int) "total_lines" 1 r.total_lines;
+  Alcotest.(check int) "test_lines" 0 r.test_lines
+
+(* ── Test: quality tier boundaries ─────────────────────────── *)
+
+let test_quality_tier_excellent () =
+  Alcotest.(check string) "0.8" "excellent" (AF.quality_tier 0.8);
+  Alcotest.(check string) "1.0" "excellent" (AF.quality_tier 1.0);
+  Alcotest.(check string) "0.95" "excellent" (AF.quality_tier 0.95)
+
+let test_quality_tier_good () =
+  Alcotest.(check string) "0.5" "good" (AF.quality_tier 0.5);
+  Alcotest.(check string) "0.79" "good" (AF.quality_tier 0.79)
+
+let test_quality_tier_suspect () =
+  Alcotest.(check string) "0.3" "suspect" (AF.quality_tier 0.3);
+  Alcotest.(check string) "0.49" "suspect" (AF.quality_tier 0.49)
+
+let test_quality_tier_fake () =
+  Alcotest.(check string) "0.0" "fake" (AF.quality_tier 0.0);
+  Alcotest.(check string) "0.29" "fake" (AF.quality_tier 0.29)
+
+(* ── Test: roundtrip bonus ─────────────────────────────────── *)
+
+let test_roundtrip_bonus () =
+  let content =
+    {|let test_roundtrip () =
+  let encoded = encode value in
+  let decoded = decode encoded in
+  Alcotest.(check int) "roundtrip" value decoded|}
+  in
+  let r = score content in
+  (* roundtrip (+0.15) + Alcotest.check (+0.15) on base 0.5 = 0.8 *)
+  Alcotest.(check bool) "score >= 0.8" true (r.final_score >= 0.8);
+  Alcotest.(check string) "tier" "excellent" r.quality_tier
+
+(* ── Test: multiple penalties accumulate ────────────────────── *)
+
+let test_penalties_accumulate () =
+  let content =
+    {|let test_a () = assert true
+let test_b () = assert true
+let _ = something ()
+(* TODO: fix this test *)
+(* FIXME: broken *)|}
+  in
+  let r = score content in
+  (* 2 * (-0.3) + 1 * (-0.2) + 1 * (-0.15) + 1 * (-0.15) = -1.1 *)
+  (* raw = 0.5 + (-1.1) = -0.6 → clamped to 0.0 *)
+  Alcotest.(check (float_eps)) "clamped to 0.0" 0.0 r.final_score;
+  Alcotest.(check string) "tier" "fake" r.quality_tier
+
+(* ── Test: clamp ───────────────────────────────────────────── *)
+
+let test_clamp () =
+  Alcotest.(check (float_eps)) "within" 0.5 (AF.clamp 0.5 ~lo:0.0 ~hi:1.0);
+  Alcotest.(check (float_eps)) "below" 0.0 (AF.clamp (-1.0) ~lo:0.0 ~hi:1.0);
+  Alcotest.(check (float_eps)) "above" 1.0 (AF.clamp 2.0 ~lo:0.0 ~hi:1.0)
+
+(* ── Test: bonus cap at 3 occurrences ──────────────────────── *)
+
+let test_bonus_capped_at_3 () =
+  let lines = List.init 5 (fun _ -> "Alcotest.(check int) \"v\" 1 1") in
+  let content = String.concat "\n" lines in
+  let r = score content in
+  (* 5 occurrences but capped at 3: bonus = 0.15 * 3 = 0.45 *)
+  (* base 0.5 + 0.45 = 0.95 *)
+  Alcotest.(check (float_eps)) "capped bonus" 0.95 r.final_score
+
+(* ── Test: summarize ───────────────────────────────────────── *)
+
+let test_summarize_empty () =
+  let s = AF.summarize [] in
+  Alcotest.(check int) "total" 0 s.total_files;
+  Alcotest.(check (float_eps)) "avg" 0.0 s.avg_score
+
+let test_summarize_mixed () =
+  let r1 = score "assert true\nassert true\nassert true" in
+  let r2 = score "Alcotest.(check int) \"x\" 1 1" in
+  let s = AF.summarize [r1; r2] in
+  Alcotest.(check int) "total" 2 s.total_files;
+  Alcotest.(check bool) "min <= max" true (s.min_score <= s.max_score);
+  (* r1 is fake (score < 0.3) *)
+  Alcotest.(check int) "fake_count" 1 s.fake_count
+
+(* ── Test: JSON serialization round-trips key fields ────────── *)
+
+let test_result_to_json () =
+  let r = score "Alcotest.(check int) \"val\" 1 1" in
+  let json = AF.result_to_json r in
+  let open Yojson.Safe.Util in
+  let file = json |> member "file" |> to_string in
+  let tier = json |> member "quality_tier" |> to_string in
+  let fs = json |> member "final_score" |> to_float in
+  Alcotest.(check string) "file" "<test>" file;
+  Alcotest.(check string) "tier" r.quality_tier tier;
+  Alcotest.(check (float_eps)) "final_score" r.final_score fs
+
+let test_summary_to_json () =
+  let r = score "" in
+  let s = AF.summarize [r] in
+  let json = AF.summary_to_json s in
+  let open Yojson.Safe.Util in
+  let total = json |> member "total_files" |> to_int in
+  Alcotest.(check int) "total_files" 1 total
+
+(* ── Test: severity_to_string ──────────────────────────────── *)
+
+let test_severity_to_string () =
+  Alcotest.(check string) "info" "info" (AF.severity_to_string Info);
+  Alcotest.(check string) "warning" "warning" (AF.severity_to_string Warning);
+  Alcotest.(check string) "critical" "critical" (AF.severity_to_string Critical)
+
+(* ── Test: test_lines count ────────────────────────────────── *)
+
+let test_test_lines_count () =
+  let content =
+    {|let x = 1
+Alcotest.(check int) "a" 1 1
+let y = 2
+assert true
+let z = 3|}
+  in
+  let r = score content in
+  (* line 2: Alcotest.check, line 4: assert true → 2 test lines *)
+  Alcotest.(check int) "test_lines" 2 r.test_lines
+
+(* ── Test: property-based testing patterns ─────────────────── *)
+
+let test_property_bonus () =
+  let content =
+    {|let test_prop () =
+  QCheck.Test.make ~count:100
+    QCheck.int (fun n -> property_holds n)|}
+  in
+  let r = score content in
+  (* QCheck appears twice (+0.1*2) + property (+0.1) on base 0.5 = 0.8 *)
+  Alcotest.(check bool) "score >= 0.7" true (r.final_score >= 0.7);
+  Alcotest.(check string) "tier" "excellent" r.quality_tier
+
+(* ── Runner ─────────────────────────────────────────────────── *)
+
+let () =
+  Alcotest.run "Anti_fake" [
+    "scoring", [
+      Alcotest.test_case "assert true is fake" `Quick test_assert_true_is_fake;
+      Alcotest.test_case "Alcotest.check is good" `Quick test_alcotest_check_is_good;
+      Alcotest.test_case "mixed score" `Quick test_mixed_score;
+      Alcotest.test_case "empty file" `Quick test_empty_file;
+      Alcotest.test_case "roundtrip bonus" `Quick test_roundtrip_bonus;
+      Alcotest.test_case "penalties accumulate" `Quick test_penalties_accumulate;
+      Alcotest.test_case "bonus capped at 3" `Quick test_bonus_capped_at_3;
+      Alcotest.test_case "property bonus" `Quick test_property_bonus;
+      Alcotest.test_case "test_lines count" `Quick test_test_lines_count;
+    ];
+    "quality_tier", [
+      Alcotest.test_case "excellent" `Quick test_quality_tier_excellent;
+      Alcotest.test_case "good" `Quick test_quality_tier_good;
+      Alcotest.test_case "suspect" `Quick test_quality_tier_suspect;
+      Alcotest.test_case "fake" `Quick test_quality_tier_fake;
+    ];
+    "clamp", [
+      Alcotest.test_case "clamp" `Quick test_clamp;
+    ];
+    "summarize", [
+      Alcotest.test_case "empty" `Quick test_summarize_empty;
+      Alcotest.test_case "mixed" `Quick test_summarize_mixed;
+    ];
+    "json", [
+      Alcotest.test_case "result_to_json" `Quick test_result_to_json;
+      Alcotest.test_case "summary_to_json" `Quick test_summary_to_json;
+      Alcotest.test_case "severity_to_string" `Quick test_severity_to_string;
+    ];
+  ]


### PR DESCRIPTION
## Summary
- `lib/anti_fake.ml` 휴리스틱 테스트 품질 스코어링 엔진 추가 (패널티/보너스 기반)
- `test/test_anti_fake.ml` 19개 Alcotest 테스트 추가
- `scripts/anti-fake-audit.sh` 기존 테스트 파일 품질 감사 스크립트 추가
- llm-mcp의 anti_fake 구현 패턴을 참조하되 masc-mcp 도메인에 맞게 적응

## Test plan
- [ ] `assert true`만 있는 테스트 → score < 0.5
- [ ] roundtrip + assert_equal 테스트 → score > 0.7
- [ ] `dune test` 전체 패스 확인
- [ ] `scripts/anti-fake-audit.sh` 실행 가능 확인

Generated with [Claude Code](https://claude.com/claude-code)
