### PR TITLE
fix(ci): add apt-get update before opam install

### DIFF
--- a/.github/workflows/deploy-railway.yml
+++ b/.github/workflows/deploy-railway.yml
@@ -32,6 +32,9 @@ jobs:
           opam pin add neo4j_packstream https://github.com/jeong-sik/ocaml-neo4j-bolt.git#main -n -y
           opam pin add neo4j_bolt_eio https://github.com/jeong-sik/ocaml-neo4j-bolt.git#main -n -y
 
+      - name: Refresh apt index
+        run: sudo apt-get update
+
       - name: Install dependencies
         run: |
           for attempt in 1 2 3; do

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,6 +52,10 @@ jobs:
           echo "$(brew --prefix libpq)/bin" >> "$GITHUB_PATH"
           echo "PKG_CONFIG_PATH=$(brew --prefix libpq)/lib/pkgconfig" >> "$GITHUB_ENV"
 
+      - name: Refresh apt index
+        if: runner.os == 'Linux'
+        run: sudo apt-get update -qq
+
       - name: Install dependencies
         run: |
           for attempt in 1 2 3; do


### PR DESCRIPTION
## Summary
- `deploy-railway.yml`과 `release.yml`에서 `opam install` 전에 `apt-get update`를 추가
- GitHub Actions `ubuntu-latest` 러너의 stale apt index로 인해 `libprotobuf-dev` 등 시스템 패키지 설치 시 404 발생하는 문제 수정
- `ci.yml`에는 이미 `apt-get update -qq`가 포함되어 있어 영향 없었음

## Root Cause
`opam install . --deps-only`는 내부적으로 `opam-depext`를 통해 `apt-get install`로 시스템 의존성을 설치합니다. Ubuntu 미러에서 패키지 버전이 갱신/제거되면 pre-baked apt index와 불일치가 발생하여 404 에러로 설치가 실패합니다.

## Changes
| File | Change |
|------|--------|
| `deploy-railway.yml` | `sudo apt-get update` 스텝 추가 |
| `release.yml` | `sudo apt-get update -qq` 스텝 추가 (Linux only) |

## Test plan
- [ ] PR 병합 후 `deploy-railway` workflow 성공 확인
- [ ] `release.yml`은 tag push 시 동작하므로 다음 릴리즈에서 검증

🤖 Generated with [Claude Code](https://claude.com/claude-code)