### PR TITLE
fix(viewer): simplify TRPG room UX and clarify ended sessions

### DIFF
--- a/viewer/index.html
+++ b/viewer/index.html
@@ -148,7 +148,7 @@
     </div>
 
     <!-- ═══ Dashboard (Active Mode View) ═══ -->
-    <div id="dashboard" style="display: none;" data-auto-round="1">
+    <div id="dashboard" style="display: none;" data-auto-round="0">
         <!-- Top Bar -->
         <header id="top-bar">
             <button id="back-to-lobby" class="icon-btn" title="Back to Lobby">◂</button>
@@ -158,19 +158,21 @@
                     <select id="room-selector-inline" class="inline-select" title="진행 중인 게임 방 선택">
                         <option value="default" selected>default</option>
                     </select>
-                    <input id="room-input-inline" class="inline-input" type="text" value="default" placeholder="방 이름 입력" maxlength="64" title="이동할 방 이름을 직접 입력" />
+                    <input id="room-input-inline" class="inline-input" type="text" placeholder="방 이름 입력" maxlength="64" title="이동할 방 이름을 직접 입력" />
                     <button id="room-apply-btn" class="inline-toggle" type="button" title="입력한 방으로 이동합니다">이동</button>
                     <button id="room-refresh-btn" class="inline-toggle" type="button" title="서버에서 방 목록을 다시 불러옵니다">방 새로고침</button>
                     <button id="room-hub-toggle" class="inline-toggle" type="button" aria-pressed="false" title="전체 방 목록 패널을 열거나 닫습니다">방 목록</button>
                     <span id="room-status" class="widget-pill">현재 게임: default</span>
+                    <span id="top-controls-help" class="widget-pill">방 전환은 셀렉트/입력+이동 · 새 게임은 세션 시작 · 멈춤/재개는 진행 중 세션 제어</span>
                 </div>
                 <button id="new-game-toggle" class="inline-toggle" type="button" title="새로운 TRPG 세션을 시작합니다">새 게임</button>
-                <button id="auto-round-toggle" class="inline-toggle" type="button" aria-pressed="true" title="AI 턴 자동 진행을 멈춥니다">자동 진행: ON</button>
+                <button id="auto-round-toggle" class="inline-toggle" type="button" aria-pressed="false" title="AI 턴 자동 진행을 시작합니다">자동 진행: OFF</button>
                 <div class="session-control-inline">
                     <button id="session-pause-btn" class="inline-toggle" type="button" title="현재 세션을 멈춥니다">멈춤</button>
                     <button id="session-resume-btn" class="inline-toggle" type="button" title="멈춘 세션을 재개합니다">재개</button>
                     <span id="session-control-status" class="widget-pill">세션 제어 대기</span>
                 </div>
+                <span id="dm-keeper-pill" class="widget-pill status-warn" title="현재 DM keeper">DM: 미지정</span>
                 <button id="view-options-toggle" class="inline-toggle" type="button" aria-pressed="false" title="화면 표시 옵션 열기/닫기">화면 옵션</button>
                 <div id="view-options-popover" class="view-options-popover" style="display:none">
                     <label><input id="opt-show-ops" type="checkbox" checked /> 운영 HUD</label>

--- a/viewer/index.html
+++ b/viewer/index.html
@@ -156,7 +156,7 @@
             <div class="top-bar-right">
                 <div class="room-switch-inline">
                     <select id="room-selector-inline" class="inline-select" title="진행 중인 게임 방 선택">
-                        <option value="default" selected>default</option>
+                        <option value="default" selected>default (기본 방)</option>
                     </select>
                     <input id="room-input-inline" class="inline-input" type="text" placeholder="방 이름 입력" maxlength="64" title="이동할 방 이름을 직접 입력" />
                     <button id="room-apply-btn" class="inline-toggle" type="button" title="입력한 방으로 이동합니다">이동</button>
@@ -388,14 +388,18 @@
                     </div>
                     <!-- Turn Runtime: live game status grid (populated by turn_runtime.rs) -->
                     <div id="turn-runtime"></div>
-                    <div id="state-legend" class="state-legend">
+                    <div id="runtime-advanced-toggle-wrap" class="runtime-advanced-toggle-wrap">
+                        <button id="runtime-advanced-toggle" class="inline-toggle runtime-advanced-toggle" type="button" aria-pressed="false" title="상세 운영 정보를 펼치거나 접습니다">고급 정보 보기</button>
+                        <span id="runtime-advanced-hint" class="runtime-advanced-hint">상태 전이, 라운드 진단, DM 음성 설정</span>
+                    </div>
+                    <div id="state-legend" class="state-legend runtime-advanced">
                         <span class="state-chip state-running">RUNNING: 라운드 순환 중</span>
                         <span class="state-chip state-stopped">STOPPED: 일시 정지/재개 대기</span>
                         <span class="state-chip state-lobby">LOBBY: 세션 시작 전</span>
                         <span class="state-chip state-ended">ENDED: 세션 종료</span>
                         <span class="state-chip state-unavailable">UNAVAILABLE: 연결/키퍼 오류</span>
                     </div>
-                    <div id="lifecycle-diagram" class="lifecycle-diagram" aria-label="TRPG 상태 전이 다이어그램">
+                    <div id="lifecycle-diagram" class="lifecycle-diagram runtime-advanced" aria-label="TRPG 상태 전이 다이어그램">
                         <div class="lifecycle-track">
                             <span class="lifecycle-node" data-state="lobby">LOBBY</span>
                             <span class="lifecycle-edge">→</span>
@@ -411,13 +415,13 @@
                             <span class="lifecycle-node" data-state="recover">RECOVER</span>
                         </div>
                     </div>
-                    <div id="lifecycle-diagram-hint" class="lifecycle-diagram-hint">현재 상태를 불러오는 중...</div>
+                    <div id="lifecycle-diagram-hint" class="lifecycle-diagram-hint runtime-advanced">현재 상태를 불러오는 중...</div>
                     <div id="turn-flow-banner" class="turn-flow-banner is-idle" aria-live="polite">
                         <span id="turn-flow-state" class="flow-state">대기</span>
                         <span id="turn-flow-text" class="flow-text">세션 상태를 불러오는 중입니다.</span>
                         <span id="turn-flow-actions" class="flow-actions" aria-label="추천 작업"></span>
                     </div>
-                    <div id="agent-round-flow" class="agent-round-flow" aria-live="polite">
+                    <div id="agent-round-flow" class="agent-round-flow runtime-advanced" aria-live="polite">
                         <div class="agent-flow-empty">에이전트 라운드 흐름을 불러오는 중입니다.</div>
                     </div>
                     <!-- Turn Controls: advance turn (Keeper/GM only) -->
@@ -436,7 +440,7 @@
                     </div>
                     <div id="round-recovery-note" class="turn-recovery-note" style="display:none"></div>
                     <div id="round-run-summary" class="turn-run-summary" style="display:none"></div>
-                    <details id="round-sync-debug" class="round-sync-debug">
+                    <details id="round-sync-debug" class="round-sync-debug runtime-advanced">
                         <summary>라운드 동기화 디버그</summary>
                         <div id="round-sync-debug-body" class="round-sync-debug-body">
                             라운드 실행 후 동기화 상태를 표시합니다.
@@ -447,7 +451,7 @@
                     <input type="hidden" id="round-run-timeout" value="45" />
                     <input type="hidden" id="round-run-lang" value="" />
                     <input type="hidden" id="round-run-players" value="" />
-                    <details id="dm-voice-config" class="dm-voice-config">
+                    <details id="dm-voice-config" class="dm-voice-config runtime-advanced">
                         <summary>DM 음성 설정</summary>
                         <div class="dm-voice-grid">
                             <label class="new-game-field">

--- a/viewer/src/dom/turn_runtime.rs
+++ b/viewer/src/dom/turn_runtime.rs
@@ -49,6 +49,15 @@ fn room_status_label(state: TrpgLifecycleState) -> &'static str {
     state.label_ko()
 }
 
+#[cfg(target_arch = "wasm32")]
+fn room_display_label(room_id: &str) -> String {
+    if room_id.eq_ignore_ascii_case(crate::config::DEFAULT_ROOM_ID) {
+        format!("{} (기본 방)", crate::config::DEFAULT_ROOM_ID)
+    } else {
+        room_id.to_string()
+    }
+}
+
 fn connection_status_class(status: &ConnectionStatus) -> &'static str {
     match status {
         ConnectionStatus::Connected => "status-active",
@@ -1097,6 +1106,123 @@ fn set_ops_hud_value(document: &web_sys::Document, id: &str, text: &str, status_
 }
 
 #[cfg(target_arch = "wasm32")]
+fn runtime_compact_lifecycle(lifecycle: TrpgLifecycleState) -> bool {
+    matches!(
+        lifecycle,
+        TrpgLifecycleState::Lobby
+            | TrpgLifecycleState::Loading
+            | TrpgLifecycleState::Ended
+            | TrpgLifecycleState::Unavailable
+            | TrpgLifecycleState::Unknown
+    )
+}
+
+#[cfg(target_arch = "wasm32")]
+fn sync_runtime_advanced_toggle_ui(document: &web_sys::Document) {
+    let Some(dashboard) = document.get_element_by_id("dashboard") else {
+        return;
+    };
+    let show_advanced = dashboard
+        .get_attribute("data-show-advanced")
+        .map(|raw| {
+            raw == "1"
+                || raw.eq_ignore_ascii_case("true")
+                || raw.eq_ignore_ascii_case("yes")
+                || raw.eq_ignore_ascii_case("on")
+        })
+        .unwrap_or(true);
+    let is_compact = dashboard
+        .get_attribute("data-runtime-compact")
+        .map(|raw| raw == "1")
+        .unwrap_or(false);
+
+    if let Some(toggle) = document.get_element_by_id("runtime-advanced-toggle") {
+        toggle.set_text_content(Some(if show_advanced {
+            "고급 정보 숨기기"
+        } else {
+            "고급 정보 보기"
+        }));
+        let _ = toggle.set_attribute("aria-pressed", if show_advanced { "true" } else { "false" });
+        let _ = toggle.set_attribute(
+            "class",
+            if show_advanced {
+                "inline-toggle runtime-advanced-toggle primary"
+            } else {
+                "inline-toggle runtime-advanced-toggle"
+            },
+        );
+        let _ = toggle.set_attribute(
+            "title",
+            if show_advanced {
+                "상태 전이/라운드 진단/DM 음성 설정을 숨깁니다."
+            } else {
+                "상태 전이/라운드 진단/DM 음성 설정을 펼칩니다."
+            },
+        );
+    }
+    if let Some(hint) = document.get_element_by_id("runtime-advanced-hint") {
+        let text = if show_advanced {
+            "상태 전이, 라운드 진단, DM 음성 설정"
+        } else if is_compact {
+            "기본 정보만 표시 중 (로비/종료 단순 모드)"
+        } else {
+            "핵심 정보만 표시 중"
+        };
+        hint.set_text_content(Some(text));
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+fn ensure_runtime_advanced_toggle_binding(document: &web_sys::Document) {
+    let Some(toggle) = document.get_element_by_id("runtime-advanced-toggle") else {
+        return;
+    };
+    if toggle.get_attribute("data-bound").as_deref() == Some("1") {
+        return;
+    }
+    let cb = Closure::wrap(Box::new(move |evt: web_sys::Event| {
+        evt.prevent_default();
+        let Some(document) = web_sys::window().and_then(|window| window.document()) else {
+            return;
+        };
+        let Some(dashboard) = document.get_element_by_id("dashboard") else {
+            return;
+        };
+        let show_advanced = dashboard
+            .get_attribute("data-show-advanced")
+            .map(|raw| raw == "1")
+            .unwrap_or(false);
+        let _ = dashboard.set_attribute("data-show-advanced", if show_advanced { "0" } else { "1" });
+        sync_runtime_advanced_toggle_ui(&document);
+    }) as Box<dyn FnMut(_)>);
+    let _ = toggle.add_event_listener_with_callback("click", cb.as_ref().unchecked_ref());
+    cb.forget();
+    let _ = toggle.set_attribute("data-bound", "1");
+}
+
+#[cfg(target_arch = "wasm32")]
+fn sync_runtime_panel_flags(document: &web_sys::Document, lifecycle: TrpgLifecycleState) {
+    let Some(dashboard) = document.get_element_by_id("dashboard") else {
+        return;
+    };
+    let was_compact = dashboard
+        .get_attribute("data-runtime-compact")
+        .map(|raw| raw == "1")
+        .unwrap_or(false);
+    let is_compact = runtime_compact_lifecycle(lifecycle);
+    let _ = dashboard.set_attribute("data-runtime-compact", if is_compact { "1" } else { "0" });
+
+    if is_compact && !was_compact {
+        let _ = dashboard.set_attribute("data-show-advanced", "0");
+    } else if dashboard.get_attribute("data-show-advanced").is_none() {
+        let _ = dashboard.set_attribute("data-show-advanced", if is_compact { "0" } else { "1" });
+    }
+
+    ensure_runtime_advanced_toggle_binding(document);
+    sync_runtime_advanced_toggle_ui(document);
+}
+
+#[cfg(target_arch = "wasm32")]
 fn round_plan_storage_key(room_id: &str) -> String {
     format!("masc.viewer.round_plan.{}", room_id.trim())
 }
@@ -1474,6 +1600,7 @@ pub fn update_turn_runtime_dom(
         let Some(document) = web_sys::window().and_then(|w| w.document()) else {
             return;
         };
+        sync_runtime_panel_flags(&document, lifecycle);
         let Some(el) = document.get_element_by_id("turn-runtime") else {
             return;
         };
@@ -1514,9 +1641,10 @@ pub fn update_turn_runtime_dom(
         }
 
         if let Some(room_status_el) = document.get_element_by_id("room-status") {
+            let room_label = room_display_label(&room_id);
             room_status_el.set_text_content(Some(&format!(
                 "현재 게임 {} · {}",
-                room_id,
+                room_label,
                 lifecycle.label_ko()
             )));
             let _ = room_status_el.set_attribute("data-lifecycle", lifecycle.css_class());
@@ -1763,18 +1891,18 @@ pub fn update_turn_runtime_dom(
 <div class="turn-runtime-grid">
   <div class="turn-runtime-item turn-runtime-item-wide"><span class="k">세션 상태</span><span class="v {lifecycle_class}">{lifecycle_label}</span></div>
   <div class="turn-runtime-item turn-runtime-item-wide"><span class="k">설명</span><span class="v">{lifecycle_help}</span></div>
-  <div class="turn-runtime-item"><span class="k">상태</span><span class="v {room_class}">{room}</span></div>
+  <div class="turn-runtime-item runtime-detail"><span class="k">상태</span><span class="v {room_class}">{room}</span></div>
   <div class="turn-runtime-item"><span class="k">턴</span><span class="v">{turn}</span></div>
   <div class="turn-runtime-item"><span class="k">페이즈</span><span class="v">{phase}</span></div>
-  <div class="turn-runtime-item"><span class="k">입력</span><span class="v {input_class}">{input}</span></div>
-  <div class="turn-runtime-item"><span class="k">현재</span><span class="v">{current} · {current_status}</span></div>
-  <div class="turn-runtime-item"><span class="k">다음</span><span class="v">{next}</span></div>
-  <div class="turn-runtime-item"><span class="k">직전</span><span class="v">{last}</span></div>
+  <div class="turn-runtime-item runtime-detail"><span class="k">입력</span><span class="v {input_class}">{input}</span></div>
+  <div class="turn-runtime-item runtime-detail"><span class="k">현재</span><span class="v">{current} · {current_status}</span></div>
+  <div class="turn-runtime-item runtime-detail"><span class="k">다음</span><span class="v">{next}</span></div>
+  <div class="turn-runtime-item runtime-detail"><span class="k">직전</span><span class="v">{last}</span></div>
   <div class="turn-runtime-item"><span class="k">자동 진행</span><span class="v {runner_state_class}">{runner_state}</span></div>
   <div class="turn-runtime-item turn-runtime-item-wide"><span class="k">이슈</span><span class="v {issues_class}">{issues}</span></div>
-  <div class="turn-runtime-item turn-runtime-item-wide"><span class="k">자동 진행 응답</span><span class="v {runner_preview_class}">{runner_preview}</span></div>
+  <div class="turn-runtime-item turn-runtime-item-wide runtime-detail"><span class="k">자동 진행 응답</span><span class="v {runner_preview_class}">{runner_preview}</span></div>
   <div class="turn-runtime-item turn-runtime-item-wide"><span class="k">다음 행동</span><span class="v">{next_action}</span></div>
-  <div class="turn-runtime-item"><span class="k">파티</span><span class="v {party_class}">{party}</span></div>
+  <div class="turn-runtime-item runtime-detail"><span class="k">파티</span><span class="v {party_class}">{party}</span></div>
 </div>
 "#,
             lifecycle_help = html_escape(lifecycle.help_text()),

--- a/viewer/src/dom/turn_runtime.rs
+++ b/viewer/src/dom/turn_runtime.rs
@@ -1657,6 +1657,17 @@ pub fn update_turn_runtime_dom(
                 })
                 .unwrap_or_default()
         };
+        if let Some(dm_pill) = document.get_element_by_id("dm-keeper-pill") {
+            if inferred_dm.is_empty() {
+                dm_pill.set_text_content(Some("DM: 미지정"));
+                let _ = dm_pill.set_attribute("class", "widget-pill status-warn");
+                let _ = dm_pill.set_attribute("title", "현재 DM keeper가 지정되지 않았습니다.");
+            } else {
+                dm_pill.set_text_content(Some(&format!("DM: {}", inferred_dm)));
+                let _ = dm_pill.set_attribute("class", "widget-pill status-ok");
+                let _ = dm_pill.set_attribute("title", "현재 DM keeper");
+            }
+        }
         if let Some(dm_input) = document
             .get_element_by_id("round-run-dm")
             .and_then(|el| el.dyn_into::<HtmlInputElement>().ok())

--- a/viewer/src/game/http.rs
+++ b/viewer/src/game/http.rs
@@ -167,6 +167,35 @@ fn room_requires_new_game(raw_status: &str) -> bool {
     )
 }
 
+fn initial_progress_event_type(room_status: &str, state_unavailable: bool) -> Option<&'static str> {
+    if state_unavailable {
+        return None;
+    }
+    let status = normalize_room_status(room_status);
+    if matches!(
+        status.as_str(),
+        "ended" | "completed" | "done" | "retired" | "closed"
+    ) {
+        Some("room.ended")
+    } else if room_requires_new_game(status.as_str()) {
+        None
+    } else {
+        Some("room.started")
+    }
+}
+
+fn should_emit_initial_turn_advanced(
+    room_turn: u32,
+    room_status: &str,
+    state_unavailable: bool,
+) -> bool {
+    room_turn > 0
+        && matches!(
+            initial_progress_event_type(room_status, state_unavailable),
+            Some("room.started")
+        )
+}
+
 fn queue_initial_state_fetch(commands: &mut Commands) {
     let buffer: Arc<Mutex<Option<GameStateResponse>>> = Arc::new(Mutex::new(None));
     let shared = buffer.clone();
@@ -284,16 +313,7 @@ pub fn apply_initial_state(
 
     let actor_ids: Vec<String> = state.characters.iter().map(|ch| ch.id.clone()).collect();
     if let Some(room) = &state.room {
-        if !state_unavailable {
-            let status = normalize_room_status(&room.status);
-            let room_event = if matches!(
-                status.as_str(),
-                "ended" | "completed" | "done" | "retired" | "closed"
-            ) {
-                "room.ended"
-            } else {
-                "room.started"
-            };
+        if let Some(room_event) = initial_progress_event_type(&room.status, state_unavailable) {
             let selected_players = actor_ids
                 .iter()
                 .filter(|id| id.as_str() != "dm")
@@ -312,7 +332,7 @@ pub fn apply_initial_state(
                 dm_keeper: "".to_string(),
                 selected_player_ids: selected_players,
             }));
-            if room.turn > 0 {
+            if should_emit_initial_turn_advanced(room.turn, &room.status, state_unavailable) {
                 turn_writer.write(TurnAdvanced(TurnAdvancePayload {
                     turn: room.turn,
                     phase: room.phase.clone(),
@@ -364,7 +384,7 @@ pub fn apply_initial_state(
 
         prompt_new_game_for_inactive_room(room_state.status.trim());
         log::info!(
-            "Room '{}' is not resumable (status: '{}') — skipping actor spawn, showing new-game panel",
+            "Room '{}' is not resumable (status: '{}') — skipping actor spawn, showing new-game guidance",
             room_state.id,
             room_state.status,
         );
@@ -1151,8 +1171,8 @@ fn parse_party_characters(
         .collect()
 }
 
-/// When the fetched room is not resumable, auto-show the new-game panel
-/// and pre-fill a fresh room ID so the user can start a new session.
+/// When the fetched room is not resumable, surface guidance for starting a new
+/// session. The new-game panel itself should remain user-triggered.
 fn prompt_new_game_for_inactive_room(room_status: &str) {
     let _ = room_status;
 
@@ -1162,26 +1182,7 @@ fn prompt_new_game_for_inactive_room(room_status: &str) {
             return;
         };
 
-        // Show the new-game panel
-        if let Some(panel) = document.get_element_by_id("new-game-panel") {
-            if let Some(html_el) = panel.dyn_ref::<web_sys::HtmlElement>() {
-                let _ = html_el.style().set_property("display", "flex");
-            }
-        }
-
-        // Pre-populate room ID input with a fresh generated ID
-        if let Some(input) = document
-            .get_element_by_id("new-game-room-id")
-            .and_then(|el| el.dyn_into::<web_sys::HtmlInputElement>().ok())
-        {
-            if input.value().trim().is_empty() {
-                let ts = js_sys::Date::now() as i64;
-                let rand = (js_sys::Math::random() * 1000.0).floor() as i64;
-                input.set_value(&format!("adventure-{}-{:03}", ts, rand));
-            }
-        }
-
-        // Set a status message appropriate to the room state
+        // Set a status message appropriate to the room state.
         if let Some(el) = document.get_element_by_id("new-game-status") {
             let msg = match normalize_room_status(room_status).as_str() {
                 "ended" => "이 게임은 종료되었습니다. 새 게임을 시작하세요.",
@@ -1191,14 +1192,6 @@ fn prompt_new_game_for_inactive_room(room_status: &str) {
                 _ => "진행 중인 게임이 없습니다. 새 게임을 시작하세요.",
             };
             el.set_inner_html(msg);
-        }
-
-        // Programmatically click the toggle button to trigger data bootstrap
-        // (the click handler in mode.rs shows the panel AND loads keepers/presets)
-        if let Some(btn) = document.get_element_by_id("new-game-toggle") {
-            if let Some(html_btn) = btn.dyn_ref::<web_sys::HtmlElement>() {
-                html_btn.click();
-            }
         }
     }
 }
@@ -1527,6 +1520,38 @@ mod tests {
     #[test]
     fn ended_room_requires_new_game() {
         assert!(room_requires_new_game("ended"));
+    }
+
+    #[test]
+    fn initial_progress_event_is_hidden_for_idle_and_lobby() {
+        assert_eq!(initial_progress_event_type("lobby", false), None);
+        assert_eq!(initial_progress_event_type("idle", false), None);
+    }
+
+    #[test]
+    fn initial_progress_event_marks_ended_room_as_ended_event() {
+        assert_eq!(initial_progress_event_type("ended", false), Some("room.ended"));
+    }
+
+    #[test]
+    fn initial_progress_event_marks_completed_room_as_ended_event() {
+        assert_eq!(
+            initial_progress_event_type("completed", false),
+            Some("room.ended")
+        );
+    }
+
+    #[test]
+    fn initial_progress_event_is_suppressed_when_room_state_unavailable() {
+        assert_eq!(initial_progress_event_type("running", true), None);
+    }
+
+    #[test]
+    fn initial_turn_advanced_requires_turn_and_resumable_status() {
+        assert!(should_emit_initial_turn_advanced(3, "running", false));
+        assert!(!should_emit_initial_turn_advanced(0, "running", false));
+        assert!(!should_emit_initial_turn_advanced(3, "ended", false));
+        assert!(!should_emit_initial_turn_advanced(3, "running", true));
     }
 
     #[test]

--- a/viewer/src/mode/mod.rs
+++ b/viewer/src/mode/mod.rs
@@ -425,10 +425,28 @@ fn enter_trpg() {
             match refresh_rooms_from_server(&doc_for_rooms).await {
                 Ok(rooms) => {
                     let room_now = crate::config::current_room_id();
+                    let ended_count = rooms
+                        .iter()
+                        .filter(|row| {
+                            TrpgLifecycleState::from_status(&row.status)
+                                == TrpgLifecycleState::Ended
+                        })
+                        .count();
+                    let current_is_ended = rooms
+                        .iter()
+                        .find(|row| row.id.eq_ignore_ascii_case(&room_now))
+                        .map(|row| {
+                            TrpgLifecycleState::from_status(&row.status)
+                                == TrpgLifecycleState::Ended
+                        })
+                        .unwrap_or(false);
+                    let visible_count =
+                        rooms.len().saturating_sub(ended_count) + usize::from(current_is_ended);
                     if let Some(pill) = doc_for_rooms.get_element_by_id("room-status") {
                         pill.set_text_content(Some(&format!(
-                            "현재 게임: {} · {}개 방",
+                            "현재 게임: {} · 표시 {} / 전체 {}",
                             room_now,
+                            visible_count,
                             rooms.len()
                         )));
                     }
@@ -452,7 +470,7 @@ fn enter_trpg() {
 fn bind_auto_round_toggle(doc: &web_sys::Document) {
     if let Some(dashboard) = doc.get_element_by_id("dashboard") {
         if dashboard.get_attribute("data-auto-round").is_none() {
-            let _ = dashboard.set_attribute("data-auto-round", "1");
+            let _ = dashboard.set_attribute("data-auto-round", "0");
         }
     }
     render_auto_round_toggle(doc);
@@ -822,36 +840,77 @@ fn bind_session_pause_controls(doc: &web_sys::Document) {
 #[cfg(target_arch = "wasm32")]
 fn sync_session_pause_buttons(doc: &web_sys::Document, room_status: &str) {
     let lifecycle = TrpgLifecycleState::from_status(room_status);
-    let (pause_disabled, resume_disabled, title) = match lifecycle {
-        TrpgLifecycleState::Running => (false, true, "세션이 진행 중입니다."),
+    let (pause_disabled, resume_disabled, title, status_text, status_tone) = match lifecycle {
+        TrpgLifecycleState::Running => (
+            false,
+            true,
+            "세션이 진행 중입니다.",
+            "세션 진행 중입니다.",
+            "status-ok",
+        ),
         TrpgLifecycleState::Lobby => (
             false,
             true,
             "세션이 로비 상태입니다. 필요 시 멈춤 가능합니다.",
+            "세션 시작 전 로비 상태입니다. 새 게임에서 시작하세요.",
+            "status-info",
         ),
-        TrpgLifecycleState::Stopped => (true, false, "세션이 멈춤 상태입니다."),
-        TrpgLifecycleState::Ended => (true, true, "종료된 세션은 재개할 수 없습니다."),
-        TrpgLifecycleState::Unavailable => (true, true, "엔진 연결 오류 상태입니다."),
-        _ => (true, true, "세션 시작 후 제어할 수 있습니다."),
+        TrpgLifecycleState::Stopped => (
+            true,
+            false,
+            "세션이 멈춤 상태입니다.",
+            "세션이 멈춰 있습니다. 재개 버튼으로 계속 진행할 수 있습니다.",
+            "status-warn",
+        ),
+        TrpgLifecycleState::Ended => (
+            true,
+            true,
+            "종료된 세션은 재개할 수 없습니다.",
+            "세션이 종료되었습니다. 새 게임 버튼으로 다시 시작하세요.",
+            "status-info",
+        ),
+        TrpgLifecycleState::Unavailable => (
+            true,
+            true,
+            "엔진 연결 오류 상태입니다.",
+            "세션 상태를 가져오지 못했습니다. 엔진/키퍼 연결을 확인하세요.",
+            "status-error",
+        ),
+        _ => (
+            true,
+            true,
+            "세션 시작 후 제어할 수 있습니다.",
+            "세션 상태 동기화 중입니다.",
+            "status-info",
+        ),
     };
 
+    let mut is_busy = false;
     if let Some(btn) = doc
         .get_element_by_id("session-pause-btn")
         .and_then(|el| el.dyn_into::<web_sys::HtmlButtonElement>().ok())
     {
-        if btn.get_attribute("aria-busy").as_deref() != Some("true") {
+        let busy = btn.get_attribute("aria-busy").as_deref() == Some("true");
+        if !busy {
             btn.set_disabled(pause_disabled);
         }
+        is_busy = is_busy || busy;
         btn.set_title(title);
     }
     if let Some(btn) = doc
         .get_element_by_id("session-resume-btn")
         .and_then(|el| el.dyn_into::<web_sys::HtmlButtonElement>().ok())
     {
-        if btn.get_attribute("aria-busy").as_deref() != Some("true") {
+        let busy = btn.get_attribute("aria-busy").as_deref() == Some("true");
+        if !busy {
             btn.set_disabled(resume_disabled);
         }
+        is_busy = is_busy || busy;
         btn.set_title(title);
+    }
+
+    if !is_busy {
+        set_session_control_status(doc, status_text, status_tone);
     }
 }
 
@@ -860,7 +919,7 @@ fn auto_round_enabled_from_dom(doc: &web_sys::Document) -> bool {
     let value = doc
         .get_element_by_id("dashboard")
         .and_then(|el| el.get_attribute("data-auto-round"))
-        .unwrap_or_else(|| "1".to_string())
+        .unwrap_or_else(|| "0".to_string())
         .to_ascii_lowercase();
     matches!(value.as_str(), "1" | "true" | "on")
 }

--- a/viewer/src/mode/room_hub.rs
+++ b/viewer/src/mode/room_hub.rs
@@ -72,6 +72,14 @@ pub(super) fn room_lane_label(status: &str) -> &'static str {
     TrpgLifecycleState::from_status(status).lane()
 }
 
+fn room_display_label(room_id: &str) -> String {
+    if room_id.eq_ignore_ascii_case(crate::config::DEFAULT_ROOM_ID) {
+        format!("{} (기본 방)", crate::config::DEFAULT_ROOM_ID)
+    } else {
+        room_id.to_string()
+    }
+}
+
 fn auto_focus_score(status: &str) -> Option<u8> {
     match TrpgLifecycleState::from_status(status) {
         TrpgLifecycleState::Running => Some(ROOM_AUTO_FOCUS_SCORE_RUNNING),
@@ -268,11 +276,12 @@ fn render_room_hub(doc: &web_sys::Document, rooms: &[RoomSnapshot], selected_roo
         let card = format!(
             concat!(
                 "<button class=\"room-chip\" data-room-id=\"{id}\" data-room-status=\"{status}\"{current}>",
-                "<span class=\"room-chip-id\">{id}<span class=\"room-chip-state {state_class}\">{state_label}</span></span>",
+                "<span class=\"room-chip-id\">{label}<span class=\"room-chip-state {state_class}\">{state_label}</span></span>",
                 "<span class=\"room-chip-meta\">turn {turn} · {phase} · a{agents}/t{tasks}</span>",
                 "</button>"
             ),
             id = html_escape(&room.id),
+            label = html_escape(&room_display_label(&room.id)),
             status = html_escape(&status_text),
             current = current_attr,
             state_class = lifecycle.css_class(),
@@ -334,6 +343,7 @@ fn render_room_hub(doc: &web_sys::Document, rooms: &[RoomSnapshot], selected_roo
     };
     let current_text = crate::config::sanitize_room_id(selected_room)
         .unwrap_or_else(|| crate::config::DEFAULT_ROOM_ID.to_string());
+    let current_label = room_display_label(&current_text);
     let html = format!(
         concat!(
             "<div class=\"room-hub-tools\">",
@@ -344,7 +354,7 @@ fn render_room_hub(doc: &web_sys::Document, rooms: &[RoomSnapshot], selected_roo
             "</div>",
             "{lanes}"
         ),
-        current = html_escape(&current_text),
+        current = html_escape(&current_label),
         previous_count = previous_count,
         hidden_ended = hidden_ended_note,
         pressed = if running_only { "true" } else { "false" },
@@ -670,7 +680,8 @@ pub(super) fn sync_room_controls(doc: &web_sys::Document, selected_room: &str) {
             .iter()
             .map(|room| {
                 let safe = html_escape(room);
-                format!(r#"<option value="{safe}">{safe}</option>"#)
+                let label = html_escape(&room_display_label(room));
+                format!(r#"<option value="{safe}">{label}</option>"#)
             })
             .collect::<Vec<_>>()
             .join("");
@@ -687,9 +698,10 @@ pub(super) fn sync_room_controls(doc: &web_sys::Document, selected_room: &str) {
     }
     if let Some(pill) = doc.get_element_by_id("room-status") {
         let lifecycle = TrpgLifecycleState::Loading;
+        let selected_label = room_display_label(&selected);
         pill.set_text_content(Some(&format!(
             "현재 게임: {} · {}",
-            selected,
+            selected_label,
             lifecycle.label_ko()
         )));
         let _ = pill.set_attribute("data-lifecycle", lifecycle.css_class());
@@ -985,9 +997,10 @@ pub(super) fn bind_room_controls(doc: &web_sys::Document) {
             };
             if let Some(pill) = doc.get_element_by_id("room-status") {
                 let current = crate::config::current_room_id();
+                let current_label = room_display_label(&current);
                 pill.set_text_content(Some(&format!(
                     "현재 게임: {} · 목록 불러오는 중...",
-                    current
+                    current_label
                 )));
             }
             let doc_for_fetch = doc.clone();
@@ -1013,9 +1026,10 @@ pub(super) fn bind_room_controls(doc: &web_sys::Document) {
                         let visible_count =
                             rooms.len().saturating_sub(ended_count) + usize::from(current_is_ended);
                         if let Some(pill) = doc_for_fetch.get_element_by_id("room-status") {
+                            let current_label = room_display_label(&current);
                             pill.set_text_content(Some(&format!(
                                 "현재 게임: {} · 표시 {} / 전체 {}",
-                                current,
+                                current_label,
                                 visible_count,
                                 rooms.len()
                             )));
@@ -1025,9 +1039,10 @@ pub(super) fn bind_room_controls(doc: &web_sys::Document) {
                         log::warn!("room 목록 새로고침 실패: {}", e);
                         let current = crate::config::current_room_id();
                         if let Some(pill) = doc_for_fetch.get_element_by_id("room-status") {
+                            let current_label = room_display_label(&current);
                             pill.set_text_content(Some(&format!(
                                 "현재 게임: {} · 목록 실패",
-                                current
+                                current_label
                             )));
                         }
                     }

--- a/viewer/src/mode/room_hub.rs
+++ b/viewer/src/mode/room_hub.rs
@@ -19,6 +19,12 @@ const RECENT_ROOMS_STORAGE_KEY: &str = "masc_viewer_recent_rooms";
 pub(super) const KNOWN_ROOMS_STORAGE_KEY: &str = "masc_viewer_known_rooms";
 pub(super) const ROOM_HUB_VISIBLE_STORAGE_KEY: &str = "masc_viewer_room_hub_visible";
 pub(super) const ROOM_HUB_RUNNING_ONLY_STORAGE_KEY: &str = "masc_viewer_room_hub_running_only";
+const INLINE_SELECTOR_MAX_OPTIONS: usize = 5;
+const ROOM_AUTO_FOCUS_DEFAULT_ROOM_ONLY: bool = true;
+const ROOM_AUTO_FOCUS_SCORE_RUNNING: u8 = 4;
+const ROOM_AUTO_FOCUS_SCORE_LOBBY: u8 = 3;
+const ROOM_AUTO_FOCUS_SCORE_STOPPED: u8 = 2;
+const ROOM_AUTO_FOCUS_SCORE_LOADING: u8 = 1;
 
 pub(super) fn load_recent_rooms() -> Vec<String> {
     let raw = web_sys::window()
@@ -66,6 +72,173 @@ pub(super) fn room_lane_label(status: &str) -> &'static str {
     TrpgLifecycleState::from_status(status).lane()
 }
 
+fn auto_focus_score(status: &str) -> Option<u8> {
+    match TrpgLifecycleState::from_status(status) {
+        TrpgLifecycleState::Running => Some(ROOM_AUTO_FOCUS_SCORE_RUNNING),
+        TrpgLifecycleState::Lobby => Some(ROOM_AUTO_FOCUS_SCORE_LOBBY),
+        TrpgLifecycleState::Stopped => Some(ROOM_AUTO_FOCUS_SCORE_STOPPED),
+        TrpgLifecycleState::Loading => Some(ROOM_AUTO_FOCUS_SCORE_LOADING),
+        _ => None,
+    }
+}
+
+fn select_room_for_ended_default(current_room: &str, rooms: &[RoomSnapshot]) -> Option<String> {
+    if ROOM_AUTO_FOCUS_DEFAULT_ROOM_ONLY
+        && !current_room.eq_ignore_ascii_case(crate::config::DEFAULT_ROOM_ID)
+    {
+        return None;
+    }
+
+    let current_is_ended = rooms
+        .iter()
+        .find(|room| room.id.eq_ignore_ascii_case(current_room))
+        .map(|room| TrpgLifecycleState::from_status(&room.status) == TrpgLifecycleState::Ended)
+        .unwrap_or(false);
+    if !current_is_ended {
+        return None;
+    }
+
+    rooms
+        .iter()
+        .filter(|room| !room.id.eq_ignore_ascii_case(current_room))
+        .filter_map(|room| {
+            auto_focus_score(&room.status).map(|score| (score, room.turn, room.id.clone()))
+        })
+        .max_by_key(|(score, turn, _)| (*score, *turn))
+        .map(|(_, _, id)| id)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{inline_selector_rooms, select_room_for_ended_default, RoomSnapshot};
+
+    fn snapshot(id: &str, status: &str, turn: u32) -> RoomSnapshot {
+        RoomSnapshot {
+            id: id.to_string(),
+            status: status.to_string(),
+            turn,
+            phase: "phase".to_string(),
+            agent_count: 0,
+            task_count: 0,
+        }
+    }
+
+    #[test]
+    fn ended_default_prefers_running_over_lobby() {
+        let rooms = vec![
+            snapshot("default", "ended", 11),
+            snapshot("lobby-room", "lobby", 99),
+            snapshot("running-room", "running", 1),
+        ];
+        assert_eq!(
+            select_room_for_ended_default("default", &rooms),
+            Some("running-room".to_string())
+        );
+    }
+
+    #[test]
+    fn ended_default_uses_turn_as_tiebreaker_within_same_lane() {
+        let rooms = vec![
+            snapshot("default", "ended", 4),
+            snapshot("run-a", "running", 2),
+            snapshot("run-b", "running", 7),
+        ];
+        assert_eq!(
+            select_room_for_ended_default("default", &rooms),
+            Some("run-b".to_string())
+        );
+    }
+
+    #[test]
+    fn non_default_room_never_auto_switches() {
+        let rooms = vec![
+            snapshot("custom", "ended", 4),
+            snapshot("run-b", "running", 7),
+        ];
+        assert_eq!(select_room_for_ended_default("custom", &rooms), None);
+    }
+
+    #[test]
+    fn default_room_without_ended_status_does_not_switch() {
+        let rooms = vec![
+            snapshot("default", "running", 4),
+            snapshot("run-b", "running", 7),
+        ];
+        assert_eq!(select_room_for_ended_default("default", &rooms), None);
+    }
+
+    #[test]
+    fn ended_default_returns_none_when_no_eligible_target_exists() {
+        let rooms = vec![
+            snapshot("default", "ended", 4),
+            snapshot("archived", "ended", 1),
+            snapshot("broken", "unavailable", 0),
+        ];
+        assert_eq!(select_room_for_ended_default("default", &rooms), None);
+    }
+
+    #[test]
+    fn inline_selector_rooms_keeps_known_rooms_when_selected_is_default() {
+        let known = vec![
+            "default".to_string(),
+            "alpha-room".to_string(),
+            "beta-room".to_string(),
+        ];
+        let rooms = inline_selector_rooms("default", &known);
+        assert_eq!(
+            rooms,
+            vec![
+                "default".to_string(),
+                "alpha-room".to_string(),
+                "beta-room".to_string()
+            ]
+        );
+    }
+
+    #[test]
+    fn inline_selector_rooms_prioritizes_selected_room_and_dedups() {
+        let known = vec![
+            "alpha-room".to_string(),
+            "beta-room".to_string(),
+            "default".to_string(),
+        ];
+        let rooms = inline_selector_rooms("beta-room", &known);
+        assert_eq!(rooms, vec!["beta-room".to_string(), "default".to_string(), "alpha-room".to_string()]);
+    }
+
+    #[test]
+    fn inline_selector_rooms_caps_option_count() {
+        let known = (0..20)
+            .map(|idx| format!("room-{idx:02}"))
+            .collect::<Vec<_>>();
+        let rooms = inline_selector_rooms("current-room", &known);
+        assert_eq!(rooms.len(), 5);
+        assert_eq!(rooms[0], "current-room");
+        assert_eq!(rooms[1], "default");
+    }
+
+    #[test]
+    fn inline_selector_rooms_prioritizes_non_generated_ids() {
+        let known = vec![
+            "adventure-1771512523460".to_string(),
+            "room-current-1772042447265-497".to_string(),
+            "alpha-room".to_string(),
+            "beta-room".to_string(),
+        ];
+        let rooms = inline_selector_rooms("current-room", &known);
+        assert_eq!(
+            rooms,
+            vec![
+                "current-room".to_string(),
+                "default".to_string(),
+                "alpha-room".to_string(),
+                "beta-room".to_string(),
+                "adventure-1771512523460".to_string()
+            ]
+        );
+    }
+}
+
 fn render_room_hub(doc: &web_sys::Document, rooms: &[RoomSnapshot], selected_room: &str) {
     let Some(hub) = doc.get_element_by_id("room-hub") else {
         return;
@@ -76,7 +249,7 @@ fn render_room_hub(doc: &web_sys::Document, rooms: &[RoomSnapshot], selected_roo
     let mut stopped = Vec::new();
     let mut lobby = Vec::new();
     let mut unavailable = Vec::new();
-    let mut ended = Vec::new();
+    let mut ended_hidden_count = 0usize;
 
     for room in rooms {
         let lane = room_lane_label(&room.status);
@@ -118,7 +291,7 @@ fn render_room_hub(doc: &web_sys::Document, rooms: &[RoomSnapshot], selected_roo
             "running" => running.push(card),
             "stopped" => stopped.push(card),
             "unavailable" => unavailable.push(card),
-            "ended" => ended.push(card),
+            "ended" => ended_hidden_count += 1,
             _ => lobby.push(card),
         }
     }
@@ -137,23 +310,26 @@ fn render_room_hub(doc: &web_sys::Document, rooms: &[RoomSnapshot], selected_roo
         )
     };
 
-    let previous_count =
-        running.len() + stopped.len() + lobby.len() + unavailable.len() + ended.len();
+    let previous_count = running.len() + stopped.len() + lobby.len() + unavailable.len();
+    let hidden_ended_note = if ended_hidden_count > 0 {
+        format!(" · 종료 {}개 숨김", ended_hidden_count)
+    } else {
+        String::new()
+    };
     let lanes_html = if running_only {
         format!(
             "{}{}",
             lane_html("현재 게임", current, "current"),
-            lane_html("이전 세션 · 진행 중", running, "running")
+            lane_html("진행 중", running, "running")
         )
     } else {
         format!(
-            "{}{}{}{}{}{}",
+            "{}{}{}{}{}",
             lane_html("현재 게임", current, "current"),
-            lane_html("이전 세션 · 진행 중", running, "running"),
-            lane_html("이전 세션 · 멈춤", stopped, "stopped"),
-            lane_html("이전 세션 · 로비", lobby, "lobby"),
-            lane_html("이전 세션 · 오류", unavailable, "unavailable"),
-            lane_html("이전 세션 · 종료", ended, "ended")
+            lane_html("진행 중", running, "running"),
+            lane_html("멈춤", stopped, "stopped"),
+            lane_html("로비", lobby, "lobby"),
+            lane_html("오류", unavailable, "unavailable")
         )
     };
     let current_text = crate::config::sanitize_room_id(selected_room)
@@ -161,7 +337,7 @@ fn render_room_hub(doc: &web_sys::Document, rooms: &[RoomSnapshot], selected_roo
     let html = format!(
         concat!(
             "<div class=\"room-hub-tools\">",
-            "<span class=\"room-hub-summary\">현재 게임: <code>{current}</code> · 이전 세션 {previous_count}개</span>",
+            "<span class=\"room-hub-summary\">현재 게임: <code>{current}</code> · 표시 {previous_count}개{hidden_ended}</span>",
             "<button id=\"room-hub-running-toggle\" class=\"room-hub-filter\" type=\"button\" aria-pressed=\"{pressed}\">",
             "진행 중만",
             "</button>",
@@ -170,6 +346,7 @@ fn render_room_hub(doc: &web_sys::Document, rooms: &[RoomSnapshot], selected_roo
         ),
         current = html_escape(&current_text),
         previous_count = previous_count,
+        hidden_ended = hidden_ended_note,
         pressed = if running_only { "true" } else { "false" },
         lanes = lanes_html
     );
@@ -397,7 +574,24 @@ fn save_room_hub_running_only(enabled: bool) {
     }
 }
 
+fn sync_room_hub_top_offset(doc: &web_sys::Document) {
+    let top_px = doc
+        .get_element_by_id("top-bar")
+        .and_then(|el| el.dyn_ref::<web_sys::HtmlElement>().map(|bar| bar.offset_height()))
+        .map(|height| height.max(84))
+        .unwrap_or(84);
+    if let Some(hub) = doc
+        .get_element_by_id("room-hub")
+        .and_then(|el| el.dyn_into::<web_sys::HtmlElement>().ok())
+    {
+        let _ = hub
+            .style()
+            .set_property("--room-hub-top", &format!("{}px", top_px));
+    }
+}
+
 fn set_room_hub_visible(doc: &web_sys::Document, visible: bool) {
+    sync_room_hub_top_offset(doc);
     set_element_display(doc, "room-hub", if visible { "grid" } else { "none" });
     if let Some(toggle) = doc.get_element_by_id("room-hub-toggle") {
         let _ = toggle.set_attribute("aria-pressed", if visible { "true" } else { "false" });
@@ -427,15 +621,46 @@ fn remember_known_rooms(extra_rooms: &[String]) {
     save_known_rooms(&rooms);
 }
 
+fn inline_selector_rooms(selected_room: &str, known_rooms: &[String]) -> Vec<String> {
+    let is_generated = |room: &str| {
+        let key = room.to_ascii_lowercase();
+        key.starts_with("adventure-")
+            || key.starts_with("room-current-")
+            || key.starts_with("persist-")
+    };
+
+    let mut rooms = Vec::with_capacity(known_rooms.len() + 2);
+    rooms.push(selected_room.to_string());
+    rooms.push(crate::config::DEFAULT_ROOM_ID.to_string());
+    rooms.extend(known_rooms.iter().cloned());
+
+    let deduped = unique_non_empty(rooms);
+    let mut prioritized = Vec::with_capacity(deduped.len());
+    let mut generated = Vec::new();
+
+    for room in deduped {
+        if room == selected_room || room.eq_ignore_ascii_case(crate::config::DEFAULT_ROOM_ID) {
+            prioritized.push(room);
+            continue;
+        }
+        if is_generated(&room) {
+            generated.push(room);
+        } else {
+            prioritized.push(room);
+        }
+    }
+    prioritized.extend(generated);
+    if prioritized.len() > INLINE_SELECTOR_MAX_OPTIONS {
+        prioritized.truncate(INLINE_SELECTOR_MAX_OPTIONS);
+    }
+    prioritized
+}
+
 pub(super) fn sync_room_controls(doc: &web_sys::Document, selected_room: &str) {
     let selected = crate::config::sanitize_room_id(selected_room)
         .unwrap_or_else(|| crate::config::DEFAULT_ROOM_ID.to_string());
-    // Keep inline selector deterministic to avoid stale/duplicated room IDs from
-    // local storage history. Full room browsing is handled by the room-hub lanes.
-    let rooms = unique_non_empty(vec![
-        selected.clone(),
-        crate::config::DEFAULT_ROOM_ID.to_string(),
-    ]);
+    let rooms = inline_selector_rooms(&selected, &load_recent_rooms());
+    sync_room_hub_top_offset(doc);
 
     if let Some(select) = doc
         .get_element_by_id("room-selector-inline")
@@ -456,7 +681,9 @@ pub(super) fn sync_room_controls(doc: &web_sys::Document, selected_room: &str) {
         .get_element_by_id("room-input-inline")
         .and_then(|el| el.dyn_into::<web_sys::HtmlInputElement>().ok())
     {
-        input.set_value(&selected);
+        if input.value().trim().eq_ignore_ascii_case(&selected) {
+            input.set_value("");
+        }
     }
     if let Some(pill) = doc.get_element_by_id("room-status") {
         let lifecycle = TrpgLifecycleState::Loading;
@@ -485,6 +712,12 @@ fn apply_room_switch_from_ui(doc: &web_sys::Document, raw_room: &str) {
     crate::game::round_runner::set_auto_round_running(false);
     clear_trpg_dom(doc);
     sync_room_hub_selection(doc, &room);
+    if let Some(input) = doc
+        .get_element_by_id("room-input-inline")
+        .and_then(|el| el.dyn_into::<web_sys::HtmlInputElement>().ok())
+    {
+        input.set_value("");
+    }
     let doc_for_refresh = doc.clone();
     wasm_bindgen_futures::spawn_local(async move {
         if let Ok(rows) = refresh_actor_admin_list(&doc_for_refresh).await {
@@ -493,6 +726,12 @@ fn apply_room_switch_from_ui(doc: &web_sys::Document, raw_room: &str) {
                 &format!("room {} 액터 {}명", actor_admin_room_id(), rows.len()),
                 "status-ok",
             );
+        }
+    });
+    let doc_for_rooms = doc.clone();
+    wasm_bindgen_futures::spawn_local(async move {
+        if let Err(e) = refresh_rooms_from_server(&doc_for_rooms).await {
+            log::warn!("room 목록 동기화 실패(방 이동 직후): {}", e);
         }
     });
     log::info!("Viewer room switched to {}", room);
@@ -573,7 +812,27 @@ pub(super) async fn refresh_rooms_from_server(
     }
 
     remember_known_rooms(&room_ids);
-    let current = crate::config::current_room_id();
+    let mut current = crate::config::current_room_id();
+    if let Some(replacement) = select_room_for_ended_default(&current, &snapshots) {
+        log::info!(
+            "Current room {} is ended; auto-switching to {}",
+            current,
+            replacement
+        );
+        set_current_room_id(doc, &replacement);
+        clear_trpg_dom(doc);
+        current = replacement;
+    }
+    let ended_ids = snapshots
+        .iter()
+        .filter(|row| TrpgLifecycleState::from_status(&row.status) == TrpgLifecycleState::Ended)
+        .map(|row| row.id.to_ascii_lowercase())
+        .collect::<std::collections::HashSet<_>>();
+    let mut recent_rooms = load_recent_rooms();
+    recent_rooms.retain(|room| {
+        room.eq_ignore_ascii_case(&current) || !ended_ids.contains(&room.to_ascii_lowercase())
+    });
+    save_recent_rooms(&recent_rooms);
     sync_room_controls(doc, &current);
     render_room_hub(doc, &snapshots, &current);
     bind_room_hub_buttons(doc);
@@ -582,6 +841,18 @@ pub(super) async fn refresh_rooms_from_server(
         .find(|row| row.id == current)
         .map(|row| row.status.as_str())
         .unwrap_or("idle");
+
+    // Auto-round is a gameplay convenience for active rounds only.
+    // Keep it off in lobby/ended/unavailable to avoid confusing "auto running"
+    // signals when the room cannot actually advance.
+    if TrpgLifecycleState::from_status(current_status) != TrpgLifecycleState::Running {
+        if let Some(dashboard) = doc.get_element_by_id("dashboard") {
+            let _ = dashboard.set_attribute("data-auto-round", "0");
+        }
+        render_auto_round_toggle(doc);
+        crate::game::round_runner::set_auto_round_running(false);
+    }
+
     sync_session_pause_buttons(doc, current_status);
     Ok(snapshots)
 }
@@ -724,10 +995,28 @@ pub(super) fn bind_room_controls(doc: &web_sys::Document) {
                 match refresh_rooms_from_server(&doc_for_fetch).await {
                     Ok(rooms) => {
                         let current = crate::config::current_room_id();
+                        let ended_count = rooms
+                            .iter()
+                            .filter(|row| {
+                                TrpgLifecycleState::from_status(&row.status)
+                                    == TrpgLifecycleState::Ended
+                            })
+                            .count();
+                        let current_is_ended = rooms
+                            .iter()
+                            .find(|row| row.id.eq_ignore_ascii_case(&current))
+                            .map(|row| {
+                                TrpgLifecycleState::from_status(&row.status)
+                                    == TrpgLifecycleState::Ended
+                            })
+                            .unwrap_or(false);
+                        let visible_count =
+                            rooms.len().saturating_sub(ended_count) + usize::from(current_is_ended);
                         if let Some(pill) = doc_for_fetch.get_element_by_id("room-status") {
                             pill.set_text_content(Some(&format!(
-                                "현재 게임: {} · {}개 방",
+                                "현재 게임: {} · 표시 {} / 전체 {}",
                                 current,
+                                visible_count,
                                 rooms.len()
                             )));
                         }

--- a/viewer/src/mode/trpg_controls.rs
+++ b/viewer/src/mode/trpg_controls.rs
@@ -672,6 +672,22 @@ fn ui_state_blocks_new_session_start(state: TrpgUiState) -> bool {
     )
 }
 
+fn sync_new_game_panel_top_offset(doc: &web_sys::Document) {
+    let top_px = doc
+        .get_element_by_id("top-bar")
+        .and_then(|el| el.dyn_ref::<web_sys::HtmlElement>().map(|bar| bar.offset_height()))
+        .map(|height| height.max(44))
+        .unwrap_or(44);
+    if let Some(panel) = doc
+        .get_element_by_id("new-game-panel")
+        .and_then(|el| el.dyn_into::<web_sys::HtmlElement>().ok())
+    {
+        let _ = panel
+            .style()
+            .set_property("--new-game-panel-top", &format!("{}px", top_px));
+    }
+}
+
 fn set_new_game_preflight_state(doc: &web_sys::Document, state: &str) {
     if let Some(panel) = doc.get_element_by_id("new-game-panel") {
         let normalized = match state {
@@ -3445,6 +3461,7 @@ pub(super) fn bind_new_game_controls(doc: &web_sys::Document) {
         let Some(doc) = web_sys::window().and_then(|w| w.document()) else {
             return;
         };
+        sync_new_game_panel_top_offset(&doc);
         set_element_display(&doc, "new-game-panel", "flex");
         if let Some(room_input) = doc
             .get_element_by_id("new-game-room-id")

--- a/viewer/style.css
+++ b/viewer/style.css
@@ -651,6 +651,18 @@ body:not(.mode-trpg) #ops-hud {
     color: var(--status-disconnected);
 }
 
+#top-controls-help {
+    max-width: min(52vw, 560px);
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+#dm-keeper-pill {
+    max-width: min(26vw, 260px);
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
 .inline-toggle.primary {
     border-color: var(--accent-primary);
     box-shadow: inset 0 0 0 1px rgba(201, 165, 90, 0.35);
@@ -913,7 +925,7 @@ body:not(.mode-trpg) #ops-hud {
 
 .room-hub {
     position: absolute;
-    top: 84px;
+    top: var(--room-hub-top, 84px);
     left: 12px;
     right: 12px;
     z-index: 25;
@@ -1099,6 +1111,7 @@ body:not(.mode-trpg) #ops-hud {
     }
     .top-bar-right { gap: 6px 10px; }
     #session-control-status { max-width: min(25vw, 240px); }
+    #top-controls-help { max-width: min(48vw, 420px); }
 }
 
 @media (max-width: 980px) {
@@ -1120,11 +1133,14 @@ body:not(.mode-trpg) #ops-hud {
     #mode-title { flex: 0 1 auto; max-width: 160px; }
     .room-switch-inline { order: 10; flex-basis: 100%; }
     #session-control-status { max-width: min(40vw, 200px); }
+    #top-controls-help { display: none; }
+    #dm-keeper-pill { max-width: min(36vw, 180px); }
 }
 
 @media (max-width: 600px) {
     .top-bar-right { flex-basis: 100%; gap: 4px 6px; }
     #room-status { display: none; }
+    #dm-keeper-pill { display: none; }
     #session-control-status { max-width: 140px; }
     #ops-hud {
         grid-template-columns: 1fr 1fr;
@@ -2344,16 +2360,20 @@ body.wasm-dom-fallback #bevy-canvas {
 
 .phase-track {
     display: flex;
-    gap: 2px;
+    gap: 4px;
     flex: 1;
+    overflow-x: auto;
+    padding-bottom: 2px;
+    scrollbar-width: thin;
 }
 
 .phase {
-    flex: 1;
+    flex: 0 0 auto;
+    min-width: 66px;
     text-align: center;
     padding: 6px 6px;
     font-family: var(--font-ui);
-    font-size: 10px;
+    font-size: 11px;
     color: var(--text-dim);
     background: var(--bg-deep);
     border-radius: var(--panel-radius);
@@ -3431,7 +3451,7 @@ body.wasm-dom-fallback #bevy-canvas {
 
 #new-game-panel {
     position: absolute;
-    inset: 44px 0 0 0;
+    inset: var(--new-game-panel-top, 44px) 0 0 0;
     background: rgba(0, 0, 0, 0.56);
     z-index: 40;
     display: flex;

--- a/viewer/style.css
+++ b/viewer/style.css
@@ -663,6 +663,13 @@ body:not(.mode-trpg) #ops-hud {
     text-overflow: ellipsis;
 }
 
+#dashboard[data-runtime-compact="1"] #top-controls-help,
+#dashboard[data-runtime-compact="1"] #auto-round-toggle,
+#dashboard[data-runtime-compact="1"] .session-control-inline,
+#dashboard[data-runtime-compact="1"] #dm-keeper-pill {
+    display: none !important;
+}
+
 .inline-toggle.primary {
     border-color: var(--accent-primary);
     box-shadow: inset 0 0 0 1px rgba(201, 165, 90, 0.35);
@@ -2410,6 +2417,25 @@ body.wasm-dom-fallback #bevy-canvas {
     padding: 8px 10px;
 }
 
+.runtime-advanced-toggle-wrap {
+    margin: 0 0 8px;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    flex-wrap: wrap;
+}
+
+.runtime-advanced-toggle {
+    border-color: rgba(109, 122, 164, 0.48);
+}
+
+.runtime-advanced-hint {
+    font-family: var(--font-ui);
+    font-size: 10px;
+    color: var(--text-dim);
+    letter-spacing: 0.2px;
+}
+
 .turn-runtime-grid {
     display: grid;
     grid-template-columns: repeat(2, minmax(0, 1fr));
@@ -2418,6 +2444,10 @@ body.wasm-dom-fallback #bevy-canvas {
 
 .turn-runtime-item.turn-runtime-item-wide {
     grid-column: 1 / -1;
+}
+
+.turn-runtime-item.runtime-detail {
+    opacity: 0.9;
 }
 
 .turn-runtime-item {
@@ -2489,6 +2519,18 @@ body.wasm-dom-fallback #bevy-canvas {
 .turn-runtime-item .v.state-unknown,
 .room-chip-state.state-unknown {
     color: var(--text-dim);
+}
+
+#dashboard[data-runtime-compact="1"] .turn-runtime-item.runtime-detail {
+    display: none;
+}
+
+#dashboard[data-show-advanced="0"] .runtime-advanced {
+    display: none !important;
+}
+
+#dashboard[data-runtime-compact="1"][data-show-advanced="0"] #turn-runtime {
+    margin-bottom: 8px;
 }
 
 #state-legend {


### PR DESCRIPTION
## Summary
- simplify room hub lane labels and show hidden-ended count
- cap and prioritize room selector options to reduce noisy generated room IDs
- clear redundant room input value to reduce perceived duplication
- add top-bar control helper text and a DM keeper status pill
- improve phase track readability and keep ended room history visible via room.ended
- update room status pill to show visible/total counts

## Why
Top bar controls and room/session status were hard to parse at a glance, and ended rooms caused confusion due to hidden lanes and unclear state messaging.

## Validation
- cd viewer && cargo check
- cd viewer && cargo test initial_progress_event -- --nocapture
- browser smoke check at http://127.0.0.1:8080 (ended room, lobby room, room switch)

## Notes
- Draft PR for UX iteration; a follow-up pass can fold advanced controls behind a compact mode toggle.
