### PR TITLE
fix(viewer): make room switch intent explicit and confirm unknown rooms

### DIFF
--- a/viewer/index.html
+++ b/viewer/index.html
@@ -158,12 +158,12 @@
                     <select id="room-selector-inline" class="inline-select" title="진행 중인 게임 방 선택">
                         <option value="default" selected>default (기본 방)</option>
                     </select>
-                    <input id="room-input-inline" class="inline-input" type="text" placeholder="방 이름 입력" maxlength="64" title="이동할 방 이름을 직접 입력" />
-                    <button id="room-apply-btn" class="inline-toggle" type="button" title="입력한 방으로 이동합니다">이동</button>
+                    <input id="room-input-inline" class="inline-input" type="text" placeholder="방 ID 입력 (없으면 빈 방)" maxlength="64" title="방 ID를 직접 입력해 엽니다. 세션은 자동 시작되지 않습니다." />
+                    <button id="room-apply-btn" class="inline-toggle" type="button" title="입력한 방을 엽니다 (세션 시작 아님)">방 열기</button>
                     <button id="room-refresh-btn" class="inline-toggle" type="button" title="서버에서 방 목록을 다시 불러옵니다">방 새로고침</button>
                     <button id="room-hub-toggle" class="inline-toggle" type="button" aria-pressed="false" title="전체 방 목록 패널을 열거나 닫습니다">방 목록</button>
                     <span id="room-status" class="widget-pill">현재 게임: default</span>
-                    <span id="top-controls-help" class="widget-pill">방 전환은 셀렉트/입력+이동 · 새 게임은 세션 시작 · 멈춤/재개는 진행 중 세션 제어</span>
+                    <span id="top-controls-help" class="widget-pill">방 전환(세션 시작 아님) · 새 게임에서 세션 시작 · 멈춤/재개는 진행 중 세션 제어</span>
                 </div>
                 <button id="new-game-toggle" class="inline-toggle" type="button" title="새로운 TRPG 세션을 시작합니다">새 게임</button>
                 <button id="auto-round-toggle" class="inline-toggle" type="button" aria-pressed="false" title="AI 턴 자동 진행을 시작합니다">자동 진행: OFF</button>

--- a/viewer/src/mode/room_hub.rs
+++ b/viewer/src/mode/room_hub.rs
@@ -383,7 +383,7 @@ fn bind_room_hub_buttons(doc: &web_sys::Document) {
                 let Some(doc) = web_sys::window().and_then(|w| w.document()) else {
                     return;
                 };
-                apply_room_switch_from_ui(&doc, &room_copy);
+                apply_room_switch_from_ui(&doc, &room_copy, false);
             }) as Box<dyn FnMut()>);
             let _ = el.dyn_ref::<web_sys::EventTarget>().map(|target| {
                 target.add_event_listener_with_callback("click", cb.as_ref().unchecked_ref())
@@ -631,6 +631,40 @@ fn remember_known_rooms(extra_rooms: &[String]) {
     save_known_rooms(&rooms);
 }
 
+fn is_known_room_id(room_id: &str) -> bool {
+    let Some(room) = crate::config::sanitize_room_id(room_id) else {
+        return false;
+    };
+    if room.eq_ignore_ascii_case(crate::config::DEFAULT_ROOM_ID) {
+        return true;
+    }
+    let mut known = load_known_rooms();
+    known.extend(load_recent_rooms());
+    known.push(crate::config::current_room_id());
+    known
+        .iter()
+        .any(|existing| existing.eq_ignore_ascii_case(&room))
+}
+
+fn confirm_unknown_room_switch(doc: &web_sys::Document, room_id: &str) -> bool {
+    let room_label = room_display_label(room_id);
+    let message = format!(
+        "'{}' 방은 현재 목록에 없습니다.\n빈 방으로 이동합니다. (세션은 시작되지 않음)\n계속할까요?",
+        room_label
+    );
+    let proceed = web_sys::window()
+        .and_then(|window| window.confirm_with_message(&message).ok())
+        .unwrap_or(true);
+    if !proceed {
+        if let Some(pill) = doc.get_element_by_id("room-status") {
+            let current = crate::config::current_room_id();
+            let current_label = room_display_label(&current);
+            pill.set_text_content(Some(&format!("현재 게임: {} · 이동 취소", current_label)));
+        }
+    }
+    proceed
+}
+
 fn inline_selector_rooms(selected_room: &str, known_rooms: &[String]) -> Vec<String> {
     let is_generated = |room: &str| {
         let key = room.to_ascii_lowercase();
@@ -710,13 +744,32 @@ pub(super) fn sync_room_controls(doc: &web_sys::Document, selected_room: &str) {
     sync_room_hub_selection(doc, &selected);
 }
 
-fn apply_room_switch_from_ui(doc: &web_sys::Document, raw_room: &str) {
+fn apply_room_switch_from_ui(doc: &web_sys::Document, raw_room: &str, manual_input: bool) {
     let Some(room) = crate::config::sanitize_room_id(raw_room) else {
         log::warn!("Ignoring invalid room id from UI: {}", raw_room);
         return;
     };
+    let unknown_room = !is_known_room_id(&room);
+    if manual_input && unknown_room && !confirm_unknown_room_switch(doc, &room) {
+        return;
+    }
+
     remember_known_rooms(std::slice::from_ref(&room));
     set_current_room_id(doc, &room);
+    if unknown_room {
+        if let Some(pill) = doc.get_element_by_id("room-status") {
+            let room_label = room_display_label(&room);
+            pill.set_text_content(Some(&format!(
+                "현재 게임: {} · 빈 방(세션 없음, 새 게임 필요)",
+                room_label
+            )));
+            let _ = pill.set_attribute("data-lifecycle", TrpgLifecycleState::Lobby.css_class());
+            let _ = pill.set_attribute(
+                "title",
+                "해당 방에 세션이 없을 수 있습니다. 새 게임에서 시작할 수 있습니다.",
+            );
+        }
+    }
     if let Some(dashboard) = doc.get_element_by_id("dashboard") {
         let _ = dashboard.set_attribute("data-auto-round", "0");
     }
@@ -946,7 +999,7 @@ pub(super) fn bind_room_controls(doc: &web_sys::Document) {
         if selected.trim().is_empty() {
             return;
         }
-        apply_room_switch_from_ui(&doc, &selected);
+        apply_room_switch_from_ui(&doc, &selected, false);
     }) as Box<dyn FnMut()>);
     let _ = select_el.dyn_ref::<web_sys::EventTarget>().map(|target| {
         target.add_event_listener_with_callback("change", select_cb.as_ref().unchecked_ref())
@@ -962,7 +1015,7 @@ pub(super) fn bind_room_controls(doc: &web_sys::Document) {
                 .get_element_by_id("room-input-inline")
                 .and_then(|el| el.dyn_ref::<web_sys::HtmlInputElement>().map(|i| i.value()))
                 .unwrap_or_default();
-            apply_room_switch_from_ui(&doc, &typed);
+            apply_room_switch_from_ui(&doc, &typed, true);
         }) as Box<dyn FnMut()>);
         let _ = apply_btn.dyn_ref::<web_sys::EventTarget>().map(|target| {
             target.add_event_listener_with_callback("click", apply_cb.as_ref().unchecked_ref())
@@ -982,7 +1035,7 @@ pub(super) fn bind_room_controls(doc: &web_sys::Document) {
                 .get_element_by_id("room-input-inline")
                 .and_then(|el| el.dyn_ref::<web_sys::HtmlInputElement>().map(|i| i.value()))
                 .unwrap_or_default();
-            apply_room_switch_from_ui(&doc, &typed);
+            apply_room_switch_from_ui(&doc, &typed, true);
         }) as Box<dyn FnMut(web_sys::KeyboardEvent)>);
         let _ = input_el.dyn_ref::<web_sys::EventTarget>().map(|target| {
             target.add_event_listener_with_callback("keydown", key_cb.as_ref().unchecked_ref())


### PR DESCRIPTION
## Summary
- rename room input action from `이동` to `방 열기` and clarify "세션 시작 아님" in top helper text
- add unknown-room guard for manual room input: show confirm dialog before opening a non-listed room
- when proceeding to a non-listed room, show explicit status: `빈 방(세션 없음, 새 게임 필요)`

## Why
`방 이동` and `새 게임 시작` looked equivalent in current UX, so entering a new room id felt like it was silently starting a session. This patch keeps the feature but makes intent and result explicit.

## Validation
- `cd viewer && cargo check`
