### PR TITLE
feat(llm): add mlx and custom provider support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -364,6 +364,8 @@ MCP 서버 없이 독립 실행:
 | `gemini` | `gemini:pro` | Google AI GenerateContent |
 | `glm` | `glm:glm-4.7` | Z.ai ChatCompletions |
 | `openrouter` | `openrouter:meta-llama/llama-3` | OpenRouter API |
+| `mlx` | `mlx:qwen3.5-35b` | `http://127.0.0.1:8091/v1/chat/completions` |
+| `custom` | `custom:model@http://host:port` | User-specified OpenAI-compatible endpoint |
 
 ### Succession (세대 교체)
 

--- a/lib/llm_client.ml
+++ b/lib/llm_client.ml
@@ -824,8 +824,37 @@ let model_spec_of_string s =
             cost_per_1k_input = 0.001;
             cost_per_1k_output = 0.002;
           }
+        | "mlx" ->
+          Ok {
+            provider = Custom "mlx";
+            model_id;
+            max_context = 128000;
+            api_url = "http://127.0.0.1:8091";
+            api_key_env = None;
+            cost_per_1k_input = 0.0;
+            cost_per_1k_output = 0.0;
+          }
+        | "custom" ->
+          (* Format: custom:model@http://host:port or custom:model *)
+          let actual_model, url =
+            match String.index_opt model_id '@' with
+            | Some at_idx ->
+              ( String.sub model_id 0 at_idx,
+                String.sub model_id (at_idx + 1)
+                  (String.length model_id - at_idx - 1) )
+            | None -> (model_id, "http://127.0.0.1:8080")
+          in
+          Ok {
+            provider = Custom actual_model;
+            model_id = actual_model;
+            max_context = 128000;
+            api_url = url;
+            api_key_env = None;
+            cost_per_1k_input = 0.0;
+            cost_per_1k_output = 0.0;
+          }
         | _ ->
           Error
             (sprintf
-               "Cannot parse model spec: %s (unsupported provider '%s'; supported: ollama, claude, gemini, glm, openrouter)"
+               "Cannot parse model spec: %s (unsupported provider '%s'; supported: ollama, claude, gemini, glm, openrouter, mlx, custom)"
                s provider)

--- a/test/test_perpetual.ml
+++ b/test/test_perpetual.ml
@@ -107,6 +107,31 @@ let test_llm_client () = group "LLM Client" (fun () ->
    | Error _ -> assert_true "parse_model:empty_model_rejected" true
    | Ok _ -> assert_true "parse_model:empty_model_should_fail" false);
 
+  (* 3b. MLX and Custom provider parsing *)
+  (match Llm_client.model_spec_of_string "mlx:qwen3.5-35b" with
+   | Ok m ->
+     assert_equal "parse_model:mlx_id" "qwen3.5-35b" m.model_id;
+     assert_true "parse_model:mlx_provider"
+       (m.provider = Llm_client.Custom "mlx");
+     assert_equal "parse_model:mlx_url" "http://127.0.0.1:8091" m.api_url
+   | Error e -> assert_true ("parse_model:mlx_failed: " ^ e) false);
+
+  (match Llm_client.model_spec_of_string "custom:mymodel@http://localhost:9999" with
+   | Ok m ->
+     assert_equal "parse_model:custom_with_url_id" "mymodel" m.model_id;
+     assert_true "parse_model:custom_with_url_provider"
+       (m.provider = Llm_client.Custom "mymodel");
+     assert_equal "parse_model:custom_with_url_url" "http://localhost:9999" m.api_url
+   | Error e -> assert_true ("parse_model:custom_url_failed: " ^ e) false);
+
+  (match Llm_client.model_spec_of_string "custom:bare-model" with
+   | Ok m ->
+     assert_equal "parse_model:custom_bare_id" "bare-model" m.model_id;
+     assert_true "parse_model:custom_bare_provider"
+       (m.provider = Llm_client.Custom "bare-model");
+     assert_equal "parse_model:custom_bare_url" "http://127.0.0.1:8080" m.api_url
+   | Error e -> assert_true ("parse_model:custom_bare_failed: " ^ e) false);
+
   (* 4. Message constructors *)
   let msg = Llm_client.system_msg "hello" in
   assert_true "msg:system_role" (msg.role = Llm_client.System);


### PR DESCRIPTION
## 요약

- `model_spec_of_string`에 `mlx`와 `custom` provider 파싱 추가
- MLX 서버(Apple Silicon Metal GPU)를 Perpetual Agent Runtime의 LLM 백엔드로 사용 가능
- 임의의 OpenAI-compatible 서버를 `custom:model@url` 포맷으로 연결 가능

## 배경

Qwen3.5-35B-A3B 모델은 Gated DeltaNet 아키텍처(75% 레이어)를 사용하며, llama.cpp(Ollama)에서 Metal GPU 커널이 미구현되어 1-4 tok/s 수준. MLX에서는 43-50 tok/s로 동작하므로 MLX 서버를 LLM 백엔드로 지원.

## 변경 사항

| 파일 | 변경 |
|------|------|
| `lib/llm_client.ml` | `mlx`, `custom` 파서 브랜치 추가 |
| `test/test_perpetual.ml` | 3개 테스트 케이스 추가 (mlx, custom+url, custom bare) |

## 사용법

```bash
# MLX 백엔드
perpetual_cli.exe --models "mlx:qwen3.5-35b"

# 임의 OpenAI-compatible 서버
perpetual_cli.exe --models "custom:mymodel@http://localhost:9999"
```

## 테스트

- 112/112 passed (기존 103 + 신규 포함)

🤖 Generated with [Claude Code](https://claude.com/claude-code)