### PR TITLE
Tighten dashboard typing for context ratio and input events

### DIFF
--- a/dashboard/src/components/agents.ts
+++ b/dashboard/src/components/agents.ts
@@ -21,7 +21,7 @@ function AgentCard({ agent }: { agent: Agent }) {
             ? html`<span class="agent-korean">${agent.koreanName}</span>`
             : null}
         </div>
-        <${MitosisRing} ratio=${(agent as any).context_ratio} />
+        <${MitosisRing} ratio=${agent.context_ratio} />
         <${StatusBadge} status=${agent.status} />
       </div>
       ${agent.current_task
@@ -74,7 +74,7 @@ function KeeperCard({ keeper }: { keeper: Keeper }) {
       <div class="live-agent-main">
         <div class="live-agent-title">
           <span class="live-agent-name">${keeper.emoji ?? ''} ${keeper.name}</span>
-          <${MitosisRing} ratio=${(keeper as any).context_ratio} />
+          <${MitosisRing} ratio=${keeper.context_ratio} />
         <${StatusBadge} status=${keeper.status} />
           ${keeper.model ? html`<span class="pill">${keeper.model}</span>` : null}
         </div>

--- a/dashboard/src/components/keeper-detail.ts
+++ b/dashboard/src/components/keeper-detail.ts
@@ -439,7 +439,7 @@ function KeeperMonologue({ keeperName }: { keeperName: string }) {
             <input 
               type="text" 
               value=${chatInput} 
-              onInput=${(e: any) => setChatInput(e.target.value)} 
+              onInput=${(e: Event) => setChatInput((e.currentTarget as HTMLInputElement).value)} 
               onKeyDown=${(e: KeyboardEvent) => e.key === "Enter" && !e.shiftKey && sendPing()}
               placeholder="Ping the agent..."
               disabled=${isSending}

--- a/dashboard/src/types.ts
+++ b/dashboard/src/types.ts
@@ -7,6 +7,7 @@ export interface Agent {
   name: string
   status: 'active' | 'idle' | 'inactive' | 'offline'
   current_task: string | null
+  context_ratio?: number
   last_seen?: string
   emoji?: string
   koreanName?: string


### PR DESCRIPTION
## Summary
- remove unsafe dashboard casts for `context_ratio` by adding a typed optional field to shared `Agent` type
- replace event handler `any` typing in keeper detail input with explicit DOM event typing
- keep runtime behavior unchanged while tightening compile-time guarantees

## Validation
- dune build --root .

## Notes
- dashboard TypeScript check could not be fully validated in this environment because npm registry access failed (`ENOTFOUND registry.npmjs.org`).
