### PR TITLE
feat(viewer): TRPG preflight transport error handling + accessibility

### DIFF
--- a/viewer/src/mode/mcp_rpc.rs
+++ b/viewer/src/mode/mcp_rpc.rs
@@ -8,6 +8,8 @@ use wasm_bindgen::prelude::*;
 use wasm_bindgen::JsCast;
 use wasm_bindgen_futures::JsFuture;
 
+use super::transport_classify::classify_transport_error;
+
 pub(super) async fn mcp_tool_call(tool_name: &str, args: Value) -> Result<Value, String> {
     let url = crate::config::build_masc_url("mcp");
     let body = json!({
@@ -55,6 +57,12 @@ pub(super) async fn mcp_tool_call(tool_name: &str, args: Value) -> Result<Value,
     let body_text = body_js.as_string().unwrap_or_default();
 
     let body_preview = preview_text(&body_text, 240);
+
+    // Early exit on transport-level errors (HTML proxy pages, empty 5xx, etc.)
+    if let Some(transport_err) = classify_transport_error(status, &body_text) {
+        return Err(transport_err);
+    }
+
     let rpc: Value = if body_text.trim().is_empty() {
         json!({})
     } else {
@@ -283,6 +291,36 @@ fn push_candidate(out: &mut Vec<String>, raw: &str) {
     out.push(piece.to_string());
 }
 
+/// Lightweight HTTP GET returning `(status_code, body_text)`.
+/// Used for health checks where no JSON parsing is needed.
+pub(super) async fn http_get_text(url: &str) -> Result<(u16, String), String> {
+    let opts = web_sys::RequestInit::new();
+    opts.set_method("GET");
+    opts.set_mode(web_sys::RequestMode::Cors);
+
+    let request = web_sys::Request::new_with_str_and_init(url, &opts)
+        .map_err(|e| format!("request 생성 실패: {:?}", e))?;
+
+    let window = web_sys::window().ok_or_else(|| "window unavailable".to_string())?;
+    let resp_value = JsFuture::from(window.fetch_with_request(&request))
+        .await
+        .map_err(|e| format!("fetch 실패: {:?}", e))?;
+    let resp: web_sys::Response = resp_value
+        .dyn_into()
+        .map_err(|_| "response 변환 실패".to_string())?;
+    let status = resp.status();
+
+    let body_js = JsFuture::from(
+        resp.text()
+            .map_err(|e| format!("response.text() 실패: {:?}", e))?,
+    )
+    .await
+    .map_err(|e| format!("본문 읽기 실패: {:?}", e))?;
+    let body_text = body_js.as_string().unwrap_or_default();
+
+    Ok((status, body_text))
+}
+
 fn preview_text(raw: &str, max_chars: usize) -> String {
     let trimmed = raw.trim();
     if trimmed.chars().count() <= max_chars {
@@ -499,4 +537,6 @@ INFO warmup done
             Some(1)
         );
     }
+
+    // classify_transport_error tests moved to transport_classify.rs (native-testable)
 }

--- a/viewer/src/mode/mod.rs
+++ b/viewer/src/mode/mod.rs
@@ -1418,24 +1418,32 @@ pub(super) fn set_new_game_preflight_status(doc: &web_sys::Document, message: &s
 #[cfg(target_arch = "wasm32")]
 pub(super) fn set_new_game_preflight_rows(
     doc: &web_sys::Document,
-    rows: &[(bool, String, String)],
+    rows: &[(bool, String, String, Option<String>)],
 ) {
     if let Some(el) = doc.get_element_by_id("new-game-preflight") {
         let html = rows
             .iter()
-            .map(|(ok, label, detail)| {
+            .map(|(ok, label, detail, hint)| {
                 let state_text = if *ok { "OK" } else { "FAIL" };
                 let state_class = if *ok {
                     "preflight-state preflight-ok"
                 } else {
                     "preflight-state preflight-fail"
                 };
+                let hint_html = match hint {
+                    Some(h) if !ok => format!(
+                        "<div class=\"preflight-hint\">{}</div>",
+                        html_escape(h)
+                    ),
+                    _ => String::new(),
+                };
                 format!(
-                    "<div class=\"preflight-row\"><span class=\"{state_class}\">{state_text}</span><span>{label}: {detail}</span></div>",
+                    "<div class=\"preflight-row\"><span class=\"{state_class}\">{state_text}</span><span>{label}: {detail}</span>{hint_html}</div>",
                     state_class = state_class,
                     state_text = state_text,
                     label = html_escape(label),
                     detail = html_escape(detail),
+                    hint_html = hint_html,
                 )
             })
             .collect::<Vec<_>>()
@@ -1719,6 +1727,8 @@ pub(super) fn set_round_run_fields(
         let _ = summary.set_attribute("style", "display:block");
     }
 }
+
+mod transport_classify;
 
 #[cfg(target_arch = "wasm32")]
 mod mcp_rpc;

--- a/viewer/src/mode/transport_classify.rs
+++ b/viewer/src/mode/transport_classify.rs
@@ -1,0 +1,75 @@
+//! Transport-level error classification for MCP HTTP responses.
+//!
+//! Pure-Rust logic with no WASM dependencies, enabling native `cargo test`.
+
+/// Detects non-JSON transport errors (proxy HTML pages, empty 5xx) **before**
+/// JSON-RPC parsing so the caller can short-circuit with a human-readable
+/// Korean error message.
+pub(super) fn classify_transport_error(status: u16, body: &str) -> Option<String> {
+    // 1. HTML error page from proxy / CDN (Cloudflare, nginx, etc.)
+    if (400..=599).contains(&status) {
+        let lower = body.to_ascii_lowercase();
+        if lower.contains("<!doctype") || lower.contains("<html") {
+            let hint = match status {
+                502 => " (게이트웨이 오류)",
+                503 => " (일시적 사용 불가)",
+                504 => " (응답 시간 초과)",
+                _ => "",
+            };
+            return Some(format!(
+                "MASC 서버에 연결할 수 없습니다 (HTTP {}){}. 서버가 실행 중인지 확인하세요.",
+                status, hint
+            ));
+        }
+    }
+
+    // 2. Empty body with server error status
+    if (500..=599).contains(&status) && body.trim().is_empty() {
+        return Some(format!("MASC 서버 응답 없음 (HTTP {})", status));
+    }
+
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn detects_html_502() {
+        let body = "<!DOCTYPE html><html><body><h1>502 Bad Gateway</h1></body></html>";
+        let result = classify_transport_error(502, body);
+        assert!(result.is_some());
+        let msg = result.unwrap();
+        assert!(msg.contains("HTTP 502"), "should mention status: {}", msg);
+        assert!(msg.contains("게이트웨이"), "should have 502 hint: {}", msg);
+    }
+
+    #[test]
+    fn detects_html_503() {
+        let body = "<html><head><title>503</title></head><body>Service Unavailable</body></html>";
+        let result = classify_transport_error(503, body);
+        assert!(result.is_some());
+        assert!(result.unwrap().contains("일시적 사용 불가"));
+    }
+
+    #[test]
+    fn detects_empty_500() {
+        let result = classify_transport_error(500, "  ");
+        assert!(result.is_some());
+        assert!(result.unwrap().contains("응답 없음"));
+    }
+
+    #[test]
+    fn passes_valid_json() {
+        let body = r#"{"jsonrpc":"2.0","id":1,"result":{"payload":{}}}"#;
+        assert!(classify_transport_error(200, body).is_none());
+    }
+
+    #[test]
+    fn passes_400_json_error() {
+        // 400 with JSON body (valid RPC error) should NOT be classified as transport error
+        let body = r#"{"jsonrpc":"2.0","id":1,"error":{"code":-32600,"message":"Invalid Request"}}"#;
+        assert!(classify_transport_error(400, body).is_none());
+    }
+}

--- a/viewer/src/mode/trpg_controls.rs
+++ b/viewer/src/mode/trpg_controls.rs
@@ -2025,7 +2025,42 @@ async fn refresh_new_game_bootstrap(doc: &web_sys::Document) -> Result<NewGameBo
 }
 
 async fn run_new_game_preflight(doc: &web_sys::Document) -> Result<(), String> {
-    let mut rows: Vec<(bool, String, String)> = Vec::new();
+    let mut rows: Vec<(bool, String, String, Option<String>)> = Vec::new();
+
+    // ── Step 0: Server connectivity (early-exit on failure) ──
+    let health_url = crate::config::build_masc_url("health");
+    let server_row = match crate::mode::mcp_rpc::http_get_text(&health_url).await {
+        Ok((status, _body)) if (200..300).contains(&status) => {
+            (true, "서버 연결".to_string(), "MASC 서버 응답 정상".to_string(), None)
+        }
+        Ok((status, body)) => {
+            let hint = if body.to_ascii_lowercase().contains("<html") {
+                Some("프록시/CDN이 에러 페이지를 반환했습니다. 서버 프로세스를 확인하세요.".to_string())
+            } else {
+                Some("서버가 실행 중인지, URL이 올바른지 확인하세요.".to_string())
+            };
+            (false, "서버 연결".to_string(), format!("HTTP {} 응답", status), hint)
+        }
+        Err(e) => {
+            let hint = Some("MASC 서버가 실행 중인지 확인하세요. (로컬: localhost:8935)".to_string());
+            (false, "서버 연결".to_string(), format!("연결 실패: {}", e), hint)
+        }
+    };
+    let server_ok = server_row.0;
+    rows.push(server_row);
+
+    // If server is unreachable, skip all dependent checks (cockpit syndrome prevention).
+    if !server_ok {
+        set_new_game_preflight_rows(doc, &rows);
+        set_new_game_preflight_state(doc, "fail");
+        set_new_game_flow_stage(
+            doc,
+            NewGameFlowStage::Failed,
+            Some("MASC 서버에 연결할 수 없습니다"),
+        );
+        sync_new_game_wizard_ui(doc);
+        return Err("MASC 서버 연결 실패".to_string());
+    }
 
     let preset_row = match fetch_preset_catalog().await {
         Ok(catalog) => {
@@ -2042,9 +2077,9 @@ async fn run_new_game_preflight(doc: &web_sys::Document) -> Result<(), String> {
                     preset_catalog_keys_preview_from_value(&catalog)
                 )
             };
-            (ok, "프리셋".to_string(), detail)
+            (ok, "프리셋".to_string(), detail, None)
         }
-        Err(e) => (false, "프리셋".to_string(), format!("조회 실패: {}", e)),
+        Err(e) => (false, "프리셋".to_string(), format!("조회 실패: {}", e), None),
     };
     rows.push(preset_row);
 
@@ -2069,6 +2104,7 @@ async fn run_new_game_preflight(doc: &web_sys::Document) -> Result<(), String> {
                             true,
                             "키퍼 풀".to_string(),
                             format!("{}명 사용 가능", count),
+                            None,
                         ),
                     )
                 } else {
@@ -2078,13 +2114,14 @@ async fn run_new_game_preflight(doc: &web_sys::Document) -> Result<(), String> {
                             false,
                             "키퍼 풀".to_string(),
                             "사용 가능한 keeper가 없습니다".to_string(),
+                            None,
                         ),
                     )
                 }
             }
             Err(e) => (
                 Vec::new(),
-                (false, "키퍼 풀".to_string(), format!("조회 실패: {}", e)),
+                (false, "키퍼 풀".to_string(), format!("조회 실패: {}", e), None),
             ),
         };
     rows.push(keeper_pool_row);
@@ -2102,6 +2139,7 @@ async fn run_new_game_preflight(doc: &web_sys::Document) -> Result<(), String> {
             false,
             "선택 키퍼".to_string(),
             "DM/플레이어 keeper를 선택하세요.".to_string(),
+            None,
         )
     } else {
         let mut blockers = Vec::new();
@@ -2201,7 +2239,7 @@ async fn run_new_game_preflight(doc: &web_sys::Document) -> Result<(), String> {
                 ));
             }
             let detail = detail_parts.join(" · ");
-            (true, "선택 키퍼".to_string(), detail)
+            (true, "선택 키퍼".to_string(), detail, None)
         } else {
             (
                 false,
@@ -2212,6 +2250,7 @@ async fn run_new_game_preflight(doc: &web_sys::Document) -> Result<(), String> {
                     selected_keepers.len(),
                     summarize_preflight_items(&blockers, 3)
                 ),
+                None,
             )
         }
     };
@@ -2235,12 +2274,14 @@ async fn run_new_game_preflight(doc: &web_sys::Document) -> Result<(), String> {
                     true,
                     "점유 충돌".to_string(),
                     format!("선택 keeper {}명 모두 비점유", selected_keepers.len()),
+                    None,
                 )
             } else {
                 (
                     false,
                     "점유 충돌".to_string(),
                     format!("이미 점유 중: {}", summarize_preflight_items(&conflicts, 3)),
+                    None,
                 )
             }
         }
@@ -2248,6 +2289,7 @@ async fn run_new_game_preflight(doc: &web_sys::Document) -> Result<(), String> {
             true,
             "점유 충돌".to_string(),
             "신규 room으로 판단되어 충돌 검사를 건너뜁니다.".to_string(),
+            None,
         ),
     };
     rows.push(occupancy_row);
@@ -2266,18 +2308,20 @@ async fn run_new_game_preflight(doc: &web_sys::Document) -> Result<(), String> {
                 true,
                 "룸 상태".to_string(),
                 format!("room {} · {}", room_id, status),
+                None,
             )
         }
         Err(_) => (
             true,
             "룸 상태".to_string(),
             format!("room {} · 신규 room (아직 초기화 전)", room_id),
+            None,
         ),
     };
     rows.push(room_row);
 
     set_new_game_preflight_rows(doc, &rows);
-    let all_ok = rows.iter().all(|(ok, _, _)| *ok);
+    let all_ok = rows.iter().all(|(ok, _, _, _)| *ok);
     set_new_game_preflight_state(doc, if all_ok { "ok" } else { "fail" });
     if all_ok {
         set_new_game_flow_stage(doc, NewGameFlowStage::Idle, Some("사전 점검 통과"));

--- a/viewer/style.css
+++ b/viewer/style.css
@@ -3637,6 +3637,13 @@ body.wasm-dom-fallback #bevy-canvas {
     color: var(--text-dim);
 }
 
+.preflight-hint {
+    font-size: 0.8em;
+    color: #9ca3af;
+    margin-left: 1.5em;
+    margin-top: 2px;
+}
+
 .new-game-assignment {
     border: 1px dashed rgba(196, 162, 101, 0.22);
     border-radius: var(--panel-radius);


### PR DESCRIPTION
## 요약

TRPG Pre-check Wizard의 두 가지 문제를 해결합니다:

1. **불투명한 연결 오류**: MCP 호출 실패 시 JSON 파서가 "SSE frame parsing failed" 같은 무의미한 에러를 표시하던 문제 → `classify_transport_error()`로 HTML proxy 에러(502/503/504)와 빈 5xx 응답을 JSON-RPC 파싱 전에 감지하여 한국어 에러 메시지 제공
2. **Cockpit Syndrome**: MASC 서버 다운 시 5개 pre-check 항목이 모두 빨간색으로 표시되던 문제 → 서버 연결 확인을 첫 번째 항목으로 추가하고 early-exit 패턴으로 근본 원인만 표시

## 변경 사항

| 파일 | 변경 내용 |
|------|----------|
| `transport_classify.rs` | 신규. `classify_transport_error()` + 5개 unit test (native cargo test 가능) |
| `mcp_rpc.rs` | `http_get_text()` 헬퍼 추가, transport 에러 분류 통합 |
| `mod.rs` | `transport_classify` 모듈 선언, preflight 4-tuple 시그니처 + hint 렌더링 |
| `trpg_controls.rs` | 서버 health check (첫 번째 항목), early-exit, 모든 tuple 마이그레이션 |
| `style.css` | `.preflight-hint` CSS 규칙 |

## 검증

- WASM 빌드: `cargo check --target wasm32-unknown-unknown` 통과
- Native 테스트: `cargo test -- transport_classify` 5/5 통과
  ```
  test mode::transport_classify::tests::passes_valid_json ... ok
  test mode::transport_classify::tests::passes_400_json_error ... ok
  test mode::transport_classify::tests::detects_empty_500 ... ok
  test mode::transport_classify::tests::detects_html_502 ... ok
  test mode::transport_classify::tests::detects_html_503 ... ok
  ```

## Test plan

- [ ] MASC 서버 정상 상태에서 pre-check 정상 동작 확인
- [ ] MASC 서버 중지 후 pre-check에서 서버 연결 실패만 빨간색으로 표시되는지 확인
- [ ] Cloudflare 502/503 에러 페이지 응답 시 한국어 에러 메시지 표시 확인
- [ ] hint 텍스트가 `.preflight-hint` 스타일로 올바르게 렌더링되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)