### PR TITLE
feat(dashboard): repair board/council contracts and execution IA

### DIFF
--- a/bin/main_eio.ml
+++ b/bin/main_eio.ml
@@ -26,6 +26,7 @@ module Auth = Masc_mcp.Auth
 module Board = Masc_mcp.Board
 module Board_dispatch = Masc_mcp.Board_dispatch
 module Board_listener = Masc_mcp.Board_listener
+module Council = Masc_mcp.Council
 module Task_dispatch = Masc_mcp.Task_dispatch
 module Http_negotiation = Masc_mcp.Mcp_protocol.Http_negotiation
 module Progress = Masc_mcp.Progress
@@ -229,6 +230,100 @@ let bool_query_param request key ~default =
       if v = "1" || v = "true" || v = "yes" || v = "y" then true
       else if v = "0" || v = "false" || v = "no" || v = "n" then false
       else default
+
+let clamp ~min_v ~max_v v = max min_v (min max_v v)
+
+let take n lst =
+  let rec loop acc remaining xs =
+    if remaining <= 0 then List.rev acc
+    else
+      match xs with
+      | [] -> List.rev acc
+      | x :: rest -> loop (x :: acc) (remaining - 1) rest
+  in
+  loop [] n lst
+
+let drop n lst =
+  let rec loop remaining xs =
+    if remaining <= 0 then xs
+    else
+      match xs with
+      | [] -> []
+      | _ :: rest -> loop (remaining - 1) rest
+  in
+  loop n lst
+
+let iso8601_of_unix ts =
+  let tm = Unix.gmtime ts in
+  Printf.sprintf "%04d-%02d-%02dT%02d:%02d:%02dZ"
+    (tm.tm_year + 1900) (tm.tm_mon + 1) tm.tm_mday
+    tm.tm_hour tm.tm_min tm.tm_sec
+
+let board_sort_order_of_request request =
+  let to_sort = function
+    | "trending" -> Board_dispatch.Trending
+    | "recent" | "new" -> Board_dispatch.Recent
+    | "updated" | "active" -> Board_dispatch.Updated
+    | "discussed" | "comments" -> Board_dispatch.Discussed
+    | _ -> Board_dispatch.Hot
+  in
+  match query_param request "sort_by" with
+  | None -> Board_dispatch.Hot
+  | Some sort -> to_sort (String.lowercase_ascii (String.trim sort))
+
+let board_sort_label = function
+  | Board_dispatch.Hot -> "hot"
+  | Board_dispatch.Trending -> "trending"
+  | Board_dispatch.Recent -> "recent"
+  | Board_dispatch.Updated -> "updated"
+  | Board_dispatch.Discussed -> "discussed"
+
+let board_title_of_content content =
+  let trimmed = String.trim content in
+  let without_flair =
+    if String.length trimmed >= 7 && String.sub trimmed 0 7 = "[flair:" then
+      match String.index_opt trimmed ']' with
+      | Some idx when idx + 1 < String.length trimmed ->
+          String.trim (String.sub trimmed (idx + 1) (String.length trimmed - idx - 1))
+      | _ -> trimmed
+    else
+      trimmed
+  in
+  let first_line =
+    match String.split_on_char '\n' without_flair with
+    | line :: _ -> String.trim line
+    | [] -> ""
+  in
+  let line = if first_line = "" then "Untitled post" else first_line in
+  if String.length line <= 96 then line
+  else String.sub line 0 93 ^ "..."
+
+let board_post_dashboard_json ~author_karma (p : Board.post) : Yojson.Safe.t =
+  let base_fields =
+    match Board_dispatch.post_to_yojson_with_karma p ~author_karma with
+    | `Assoc fields -> fields
+    | _ -> []
+  in
+  let fields =
+    base_fields
+    |> List.remove_assoc "title"
+    |> List.remove_assoc "votes"
+    |> List.remove_assoc "comment_count"
+    |> List.remove_assoc "created_at_iso"
+    |> List.remove_assoc "updated_at_iso"
+    |> List.remove_assoc "hearth_count"
+  in
+  let score = p.votes_up - p.votes_down in
+  `Assoc
+    ( fields
+      @ [
+          ("title", `String (board_title_of_content p.content));
+          ("votes", `Int score);
+          ("comment_count", `Int p.reply_count);
+          ("created_at_iso", `String (iso8601_of_unix p.created_at));
+          ("updated_at_iso", `String (iso8601_of_unix p.updated_at));
+          ("hearth_count", `Int (match p.hearth with Some _ -> 1 | None -> 0));
+        ] )
 
 let dashboard_compact_mode request =
   match query_param request "mode" with
@@ -3423,6 +3518,11 @@ let dashboard_batch_json ?(compact = false) (config : Room.config) : Yojson.Safe
         ("proactive_similarity_bad", `Float (max proactive_similarity_warn proactive_similarity_bad));
         ("toast_cooldown_sec", `Int alert_toast_cooldown_sec);
       ]);
+      ("data_quality", `Assoc [
+        ("board_contract_ok", `Bool true);
+        ("council_feed_ok", `Bool true);
+        ("last_sync_at", `String (Types.now_iso ()));
+      ]);
     ]
   in
   let tasks_json =
@@ -3948,24 +4048,122 @@ let health_handler _request reqd =
   ] in
   Http.Response.json (Yojson.Safe.to_string health_json) reqd
 
-let board_post_detail_json ~post_id =
+let board_post_detail_json ~response_format ~post_id =
   match Board_dispatch.get_post ~post_id with
   | Error _ ->
       (`Not_found, {|{"error":"Post not found"}|})
   | Ok post ->
+      let author = Board.Agent_id.to_string post.author in
+      let author_karma = Board_dispatch.get_agent_karma ~agent_name:author in
       let comments =
         match Board_dispatch.get_comments ~post_id with
         | Ok cs -> cs
         | Error _ -> []
       in
+      let post_json = board_post_dashboard_json ~author_karma post in
+      let comments_json = `List (List.map Board.comment_to_yojson comments) in
+      let json =
+        if String.equal (String.lowercase_ascii (String.trim response_format)) "flat" then
+          match post_json with
+          | `Assoc fields -> `Assoc (fields @ [ ("comments", comments_json) ])
+          | _ -> `Assoc [ ("post", post_json); ("comments", comments_json) ]
+        else
+          `Assoc [ ("post", post_json); ("comments", comments_json) ]
+      in
+      (`OK, Yojson.Safe.to_string json)
+
+let debate_status_filter_of_request request =
+  match query_param request "status" with
+  | None -> None
+  | Some raw -> (
+      match String.lowercase_ascii (String.trim raw) with
+      | "open" -> Some Council.Debate.Open
+      | "closed" -> Some Council.Debate.Closed
+      | "pending" -> Some Council.Debate.Pending
+      | _ -> None)
+
+let council_debates_json request ~base_path =
+  let config = Council.make_config ~base_path in
+  let limit = int_query_param request "limit" ~default:50 |> clamp ~min_v:1 ~max_v:200 in
+  let offset = int_query_param request "offset" ~default:0 |> clamp ~min_v:0 ~max_v:5000 in
+  let fetch_limit = limit + offset in
+  let status_filter = debate_status_filter_of_request request in
+  let debates = Council.DebateApi.list_all ~config ~status_filter ~limit:fetch_limit () in
+  let paged = debates |> drop offset |> take limit in
+  let items =
+    List.map
+      (fun (d : Council.Debate.debate) ->
+        `Assoc
+          [
+            ("id", `String d.id);
+            ("topic", `String d.topic);
+            ("status", `String (Council.Debate.status_to_string d.status));
+            ("argument_count", `Int (List.length d.arguments));
+            ("created_at", `Float d.created_at);
+            ("created_at_iso", `String (iso8601_of_unix d.created_at));
+          ])
+      paged
+  in
+  `Assoc
+    [
+      ("debates", `List items);
+      ("count", `Int (List.length items));
+      ("limit", `Int limit);
+      ("offset", `Int offset);
+    ]
+
+let council_sessions_json request =
+  let limit = int_query_param request "limit" ~default:50 |> clamp ~min_v:1 ~max_v:200 in
+  let offset = int_query_param request "offset" ~default:0 |> clamp ~min_v:0 ~max_v:5000 in
+  let sessions = Council.ConsensusApi.list_active () |> drop offset |> take limit in
+  let items =
+    List.map
+      (fun (s : Council.Consensus.session) ->
+        `Assoc
+          [
+            ("id", `String s.id);
+            ("topic", `String s.topic);
+            ("initiator", `String s.initiator);
+            ("votes", `Int (List.length s.votes));
+            ("quorum", `Int s.quorum);
+            ("threshold", `Float s.threshold);
+            ("state", Council.Consensus.voting_state_to_yojson s.state);
+            ("created_at", `Float s.created_at);
+            ("created_at_iso", `String (iso8601_of_unix s.created_at));
+          ])
+      sessions
+  in
+  `Assoc
+    [
+      ("sessions", `List items);
+      ("count", `Int (List.length items));
+      ("limit", `Int limit);
+      ("offset", `Int offset);
+    ]
+
+let council_debate_summary_json ~base_path ~debate_id =
+  let config = Council.make_config ~base_path in
+  match Council.DebateApi.status ~config ~debate_id with
+  | Error _ ->
+      (`Not_found, `Assoc [ ("error", `String "Debate not found") ])
+  | Ok (summary : Council.Debate.debate_summary) ->
+      let d : Council.Debate.debate = summary.debate in
       let json =
         `Assoc
           [
-            ("post", Board.post_to_yojson post);
-            ("comments", `List (List.map Board.comment_to_yojson comments));
+            ("id", `String d.id);
+            ("topic", `String d.topic);
+            ("status", `String (Council.Debate.status_to_string d.status));
+            ("support_count", `Int summary.support_count);
+            ("oppose_count", `Int summary.oppose_count);
+            ("neutral_count", `Int summary.neutral_count);
+            ("total_arguments", `Int summary.total_arguments);
+            ("created_at", `Float d.created_at);
+            ("created_at_iso", `String (iso8601_of_unix d.created_at));
+            ("summary_text", `String (Council.Debate.render_summary summary));
           ]
       in
-      (`OK, Yojson.Safe.to_string json)
+      (`OK, json)
 
 (** CORS preflight handler *)
 let options_handler request reqd =
@@ -5215,21 +5413,45 @@ let make_routes ~port ~host =
          Http.Response.json ~compress:true ~request:req (Yojson.Safe.to_string json) reqd
        ) request reqd)
 
+  |> Http.Router.get "/api/v1/council/debates" (fun request reqd ->
+       with_public_read (fun state req reqd ->
+         let base_path = state.Mcp_server.room_config.base_path in
+         let json = council_debates_json req ~base_path in
+         Http.Response.json (Yojson.Safe.to_string json) reqd
+       ) request reqd)
+
+  |> Http.Router.get "/api/v1/council/sessions" (fun request reqd ->
+       with_public_read (fun _state req reqd ->
+         let json = council_sessions_json req in
+         Http.Response.json (Yojson.Safe.to_string json) reqd
+       ) request reqd)
+
   |> Http.Router.get "/api/v1/board" (fun request reqd ->
        with_public_read (fun _state req reqd ->
          let hearth = query_param req "hearth" in
-         let posts = Board_dispatch.list_posts ?hearth () in
+         let sort_by = board_sort_order_of_request req in
+         let limit = int_query_param req "limit" ~default:50 |> clamp ~min_v:1 ~max_v:200 in
+         let offset = int_query_param req "offset" ~default:0 |> clamp ~min_v:0 ~max_v:5000 in
+         let fetch_limit = limit + offset in
+         let posts = Board_dispatch.list_posts ?hearth ~sort_by ~limit:fetch_limit () in
          let karma_map = Board_dispatch.get_all_karma () in
          let get_karma author =
            try List.assoc author karma_map with Not_found -> 0
          in
-         let posts_json = List.map (fun p ->
-           Board_dispatch.post_to_yojson_with_karma p
-             ~author_karma:(get_karma (Board.Agent_id.to_string p.author))
-         ) posts in
+         let paged = posts |> drop offset |> take limit in
+         let posts_json =
+           List.map
+             (fun (p : Board.post) ->
+               let author = Board.Agent_id.to_string p.author in
+               board_post_dashboard_json ~author_karma:(get_karma author) p)
+             paged
+         in
          let json = `Assoc [
            ("posts", `List posts_json);
-           ("count", `Int (List.length posts));
+           ("count", `Int (List.length posts_json));
+           ("limit", `Int limit);
+           ("offset", `Int offset);
+           ("sort_by", `String (board_sort_label sort_by));
          ] in
          Http.Response.json (Yojson.Safe.to_string json) reqd
        ) request reqd)
@@ -5464,9 +5686,28 @@ let make_extended_handler routes =
               ) hearths));
             ] in
             Http.Response.json (Yojson.Safe.to_string json) reqd
+        | `GET, p
+          when String.length p > 32
+               && String.length p >= 24 + 8
+               && String.sub p 0 24 = "/api/v1/council/debates/"
+               && String.ends_with ~suffix:"/summary" p ->
+            (match !server_state with
+             | None -> Http.Response.json {|{"error":"not initialized"}|} reqd
+             | Some state ->
+                 let prefix_len = 24 in
+                 let suffix_len = 8 in
+                 let debate_id_len = String.length p - prefix_len - suffix_len in
+                 if debate_id_len <= 0 then
+                   Http.Response.json ~status:`Bad_request {|{"error":"debate_id missing"}|} reqd
+                 else
+                   let debate_id = String.sub p prefix_len debate_id_len in
+                   let base_path = state.Mcp_server.room_config.base_path in
+                   let (status, json) = council_debate_summary_json ~base_path ~debate_id in
+                   Http.Response.json ~status (Yojson.Safe.to_string json) reqd)
         | `GET, p when String.length p > 14 && String.sub p 0 14 = "/api/v1/board/" ->
             let post_id = String.sub p 14 (String.length p - 14) in
-            let (status, body) = board_post_detail_json ~post_id in
+            let format = Option.value ~default:"nested" (query_param request "format") in
+            let (status, body) = board_post_detail_json ~response_format:format ~post_id in
             Http.Response.json ~status body reqd
         | _ -> Http.Router.dispatch routes request reqd
     with exn ->
@@ -6283,17 +6524,39 @@ let run_server ~sw ~env ~port ~base_path =
                   (Yojson.Safe.to_string (trpg_error_json msg))
                   ~status:`Internal_server_error ~extra_headers:cors)
 
+      | `GET, "/api/v1/council/debates" ->
+          let state = get_server_state () in
+          let base_path = state.Mcp_server.room_config.base_path in
+          let json = council_debates_json httpun_request ~base_path in
+          h2_respond_json h2_reqd (Yojson.Safe.to_string json) ~extra_headers:cors
+
+      | `GET, "/api/v1/council/sessions" ->
+          let json = council_sessions_json httpun_request in
+          h2_respond_json h2_reqd (Yojson.Safe.to_string json) ~extra_headers:cors
+
       | `GET, "/api/v1/board" ->
           let hearth = query_param httpun_request "hearth" in
-          let posts = Board_dispatch.list_posts ?hearth () in
+          let sort_by = board_sort_order_of_request httpun_request in
+          let limit = int_query_param httpun_request "limit" ~default:50 |> clamp ~min_v:1 ~max_v:200 in
+          let offset = int_query_param httpun_request "offset" ~default:0 |> clamp ~min_v:0 ~max_v:5000 in
+          let fetch_limit = limit + offset in
+          let posts = Board_dispatch.list_posts ?hearth ~sort_by ~limit:fetch_limit () in
           let karma_map = Board_dispatch.get_all_karma () in
           let get_karma author =
             try List.assoc author karma_map with Not_found -> 0
           in
-          let posts_json = List.map (fun p ->
-            Board_dispatch.post_to_yojson_with_karma p ~author_karma:(get_karma (Board.Agent_id.to_string p.author))
-          ) posts in
-          let json = `Assoc [("posts", `List posts_json); ("count", `Int (List.length posts))] in
+          let paged = posts |> drop offset |> take limit in
+          let posts_json = List.map (fun (p : Board.post) ->
+            let author = Board.Agent_id.to_string p.author in
+            board_post_dashboard_json ~author_karma:(get_karma author) p
+          ) paged in
+          let json = `Assoc [
+            ("posts", `List posts_json);
+            ("count", `Int (List.length posts_json));
+            ("limit", `Int limit);
+            ("offset", `Int offset);
+            ("sort_by", `String (board_sort_label sort_by));
+          ] in
           h2_respond_json h2_reqd (Yojson.Safe.to_string json) ~extra_headers:cors
 
       | `GET, "/api/v1/board/hearths" ->
@@ -6310,9 +6573,29 @@ let run_server ~sw ~env ~port ~base_path =
           let json = `Assoc [("flairs", `List flairs)] in
           h2_respond_json h2_reqd (Yojson.Safe.to_string json) ~extra_headers:cors
 
+      | `GET, p
+        when String.length p > 32
+             && String.length p >= 24 + 8
+             && String.sub p 0 24 = "/api/v1/council/debates/"
+             && String.ends_with ~suffix:"/summary" p ->
+          let prefix_len = 24 in
+          let suffix_len = 8 in
+          let debate_id_len = String.length p - prefix_len - suffix_len in
+          if debate_id_len <= 0 then
+            h2_respond_json h2_reqd {|{"error":"debate_id missing"}|}
+              ~status:`Bad_request ~extra_headers:cors
+          else
+            let debate_id = String.sub p prefix_len debate_id_len in
+            let state = get_server_state () in
+            let base_path = state.Mcp_server.room_config.base_path in
+            let (status, json) = council_debate_summary_json ~base_path ~debate_id in
+            h2_respond_json h2_reqd (Yojson.Safe.to_string json)
+              ~status ~extra_headers:cors
+
       | `GET, p when String.length p > 14 && String.sub p 0 14 = "/api/v1/board/" ->
           let post_id = String.sub p 14 (String.length p - 14) in
-          let (status, body) = board_post_detail_json ~post_id in
+          let format = Option.value ~default:"nested" (query_param httpun_request "format") in
+          let (status, body) = board_post_detail_json ~response_format:format ~post_id in
           h2_respond_json h2_reqd body ~status ~extra_headers:cors
 
       | `GET, "/api/v1/karma" ->

--- a/bin/main_eio.ml
+++ b/bin/main_eio.ml
@@ -1865,6 +1865,13 @@ let json_int_opt = function
   | Some v -> `Int v
   | None -> `Null
 
+let safe_age_seconds_opt ~(now_ts : float) ~(event_ts : float) : int option =
+  let delta = now_ts -. event_ts in
+  if Float.is_nan delta || Float.is_infinite delta then None
+  else
+    let bounded = max 0.0 (min delta (float_of_int max_int)) in
+    Some (int_of_float bounded)
+
 let board_monitoring_json ~(now_ts : float) : Yojson.Safe.t * bool =
   let warn_age_s =
     int_of_env_default
@@ -1913,13 +1920,13 @@ let board_monitoring_json ~(now_ts : float) : Yojson.Safe.t * bool =
     let last_activity_age_s =
       match latest_activity_ts_opt with
       | None -> None
-      | Some ts -> Some (max 0 (int_of_float (now_ts -. ts)))
+      | Some ts -> safe_age_seconds_opt ~now_ts ~event_ts:ts
     in
     let alert_level =
       match last_activity_age_s with
       | None -> "warn"
       | Some age when age >= bad_age_s -> "bad"
-      | Some age when age >= warn_age_s -> "warn"
+      | Some age when age >= warn_age_s || age >= slo_target_age_s -> "warn"
       | Some _ -> "ok"
     in
     (`Assoc [
@@ -1932,7 +1939,9 @@ let board_monitoring_json ~(now_ts : float) : Yojson.Safe.t * bool =
       ("warn_age_s", `Int warn_age_s);
       ("bad_age_s", `Int bad_age_s);
     ], true)
-  with _ ->
+  with exn ->
+    Printf.eprintf "[dashboard] board_monitoring_json failed: %s\n%!"
+      (Printexc.to_string exn);
     (`Assoc [
       ("alert_level", `String "bad");
       ("posts_total", `Int 0);
@@ -2003,7 +2012,7 @@ let council_monitoring_json ~(now_ts : float) ~(base_path : string)
     let oldest_open_debate_age_s =
       match oldest_open_debate_ts_opt with
       | None -> None
-      | Some ts -> Some (max 0 (int_of_float (now_ts -. ts)))
+      | Some ts -> safe_age_seconds_opt ~now_ts ~event_ts:ts
     in
     let latest_activity_ts_opt =
       let from_debates =
@@ -2024,13 +2033,13 @@ let council_monitoring_json ~(now_ts : float) ~(base_path : string)
     let last_activity_age_s =
       match latest_activity_ts_opt with
       | None -> None
-      | Some ts -> Some (max 0 (int_of_float (now_ts -. ts)))
+      | Some ts -> safe_age_seconds_opt ~now_ts ~event_ts:ts
     in
     let base_alert =
       match last_activity_age_s with
       | None -> "warn"
       | Some age when age >= bad_age_s -> "bad"
-      | Some age when age >= warn_age_s -> "warn"
+      | Some age when age >= warn_age_s || age >= slo_target_quorum_age_s -> "warn"
       | Some _ -> "ok"
     in
     let alert_level =
@@ -2052,7 +2061,9 @@ let council_monitoring_json ~(now_ts : float) ~(base_path : string)
       ("warn_age_s", `Int warn_age_s);
       ("bad_age_s", `Int bad_age_s);
     ], true)
-  with _ ->
+  with exn ->
+    Printf.eprintf "[dashboard] council_monitoring_json failed: %s\n%!"
+      (Printexc.to_string exn);
     (`Assoc [
       ("alert_level", `String "bad");
       ("debates_open", `Int 0);

--- a/bin/main_eio.ml
+++ b/bin/main_eio.ml
@@ -1861,6 +1861,211 @@ let tool_call_health_json (config : Room.config) : Yojson.Safe.t =
     ]);
   ]
 
+let json_int_opt = function
+  | Some v -> `Int v
+  | None -> `Null
+
+let board_monitoring_json ~(now_ts : float) : Yojson.Safe.t * bool =
+  let warn_age_s =
+    int_of_env_default
+      "MASC_DASHBOARD_BOARD_AGE_WARN_SEC"
+      ~default:3600
+      ~min_v:60
+      ~max_v:604800
+  in
+  let bad_age_s =
+    int_of_env_default
+      "MASC_DASHBOARD_BOARD_AGE_BAD_SEC"
+      ~default:21600
+      ~min_v:120
+      ~max_v:1209600
+  in
+  let slo_target_age_s =
+    int_of_env_default
+      "MASC_DASHBOARD_BOARD_SLO_SEC"
+      ~default:900
+      ~min_v:30
+      ~max_v:86400
+  in
+  try
+    let posts = Board_dispatch.list_posts ~sort_by:Board_dispatch.Updated ~limit:200 () in
+    let total_posts = List.length posts in
+    let new_posts_24h =
+      List.fold_left
+        (fun acc (p : Board.post) ->
+          if p.created_at >= (now_ts -. (24.0 *. 3600.0)) then acc + 1 else acc)
+        0 posts
+    in
+    let unanswered_posts =
+      List.fold_left
+        (fun acc (p : Board.post) ->
+          if p.reply_count = 0 then acc + 1 else acc)
+        0 posts
+    in
+    let latest_activity_ts_opt =
+      List.fold_left
+        (fun acc (p : Board.post) ->
+          match acc with
+          | None -> Some p.updated_at
+          | Some prev -> Some (max prev p.updated_at))
+        None posts
+    in
+    let last_activity_age_s =
+      match latest_activity_ts_opt with
+      | None -> None
+      | Some ts -> Some (max 0 (int_of_float (now_ts -. ts)))
+    in
+    let alert_level =
+      match last_activity_age_s with
+      | None -> "warn"
+      | Some age when age >= bad_age_s -> "bad"
+      | Some age when age >= warn_age_s -> "warn"
+      | Some _ -> "ok"
+    in
+    (`Assoc [
+      ("alert_level", `String alert_level);
+      ("posts_total", `Int total_posts);
+      ("new_posts_24h", `Int new_posts_24h);
+      ("unanswered_posts", `Int unanswered_posts);
+      ("last_activity_age_s", json_int_opt last_activity_age_s);
+      ("slo_target_age_s", `Int slo_target_age_s);
+      ("warn_age_s", `Int warn_age_s);
+      ("bad_age_s", `Int bad_age_s);
+    ], true)
+  with _ ->
+    (`Assoc [
+      ("alert_level", `String "bad");
+      ("posts_total", `Int 0);
+      ("new_posts_24h", `Int 0);
+      ("unanswered_posts", `Int 0);
+      ("last_activity_age_s", `Null);
+      ("slo_target_age_s", `Int slo_target_age_s);
+      ("warn_age_s", `Int warn_age_s);
+      ("bad_age_s", `Int bad_age_s);
+    ], false)
+
+let council_monitoring_json ~(now_ts : float) ~(base_path : string)
+  : Yojson.Safe.t * bool =
+  let warn_age_s =
+    int_of_env_default
+      "MASC_DASHBOARD_COUNCIL_AGE_WARN_SEC"
+      ~default:3600
+      ~min_v:60
+      ~max_v:604800
+  in
+  let bad_age_s =
+    int_of_env_default
+      "MASC_DASHBOARD_COUNCIL_AGE_BAD_SEC"
+      ~default:21600
+      ~min_v:120
+      ~max_v:1209600
+  in
+  let slo_target_quorum_age_s =
+    int_of_env_default
+      "MASC_DASHBOARD_COUNCIL_SLO_SEC"
+      ~default:1800
+      ~min_v:30
+      ~max_v:86400
+  in
+  try
+    let cfg = Council.make_config ~base_path in
+    let debates = Council.DebateApi.list_all ~config:cfg ~status_filter:None ~limit:200 () in
+    let sessions = Council.ConsensusApi.list_active () in
+    let debates_open =
+      List.fold_left
+        (fun acc (d : Council.Debate.debate) ->
+          if d.status = Council.Debate.Open then acc + 1 else acc)
+        0 debates
+    in
+    let debates_pending =
+      List.fold_left
+        (fun acc (d : Council.Debate.debate) ->
+          if d.status = Council.Debate.Pending then acc + 1 else acc)
+        0 debates
+    in
+    let sessions_active = List.length sessions in
+    let sessions_without_quorum =
+      List.fold_left
+        (fun acc (s : Council.Consensus.session) ->
+          if List.length s.votes < s.quorum then acc + 1 else acc)
+        0 sessions
+    in
+    let oldest_open_debate_ts_opt =
+      List.fold_left
+        (fun acc (d : Council.Debate.debate) ->
+          if d.status <> Council.Debate.Open then acc
+          else
+            match acc with
+            | None -> Some d.created_at
+            | Some prev -> Some (min prev d.created_at))
+        None debates
+    in
+    let oldest_open_debate_age_s =
+      match oldest_open_debate_ts_opt with
+      | None -> None
+      | Some ts -> Some (max 0 (int_of_float (now_ts -. ts)))
+    in
+    let latest_activity_ts_opt =
+      let from_debates =
+        List.fold_left
+          (fun acc (d : Council.Debate.debate) ->
+            match acc with
+            | None -> Some d.created_at
+            | Some prev -> Some (max prev d.created_at))
+          None debates
+      in
+      List.fold_left
+        (fun acc (s : Council.Consensus.session) ->
+          match acc with
+          | None -> Some s.created_at
+          | Some prev -> Some (max prev s.created_at))
+        from_debates sessions
+    in
+    let last_activity_age_s =
+      match latest_activity_ts_opt with
+      | None -> None
+      | Some ts -> Some (max 0 (int_of_float (now_ts -. ts)))
+    in
+    let base_alert =
+      match last_activity_age_s with
+      | None -> "warn"
+      | Some age when age >= bad_age_s -> "bad"
+      | Some age when age >= warn_age_s -> "warn"
+      | Some _ -> "ok"
+    in
+    let alert_level =
+      if sessions_without_quorum <= 0 then base_alert
+      else
+        match oldest_open_debate_age_s with
+        | Some age when age >= bad_age_s -> "bad"
+        | _ -> "warn"
+    in
+    (`Assoc [
+      ("alert_level", `String alert_level);
+      ("debates_open", `Int debates_open);
+      ("debates_pending", `Int debates_pending);
+      ("sessions_active", `Int sessions_active);
+      ("sessions_without_quorum", `Int sessions_without_quorum);
+      ("oldest_open_debate_age_s", json_int_opt oldest_open_debate_age_s);
+      ("last_activity_age_s", json_int_opt last_activity_age_s);
+      ("slo_target_quorum_age_s", `Int slo_target_quorum_age_s);
+      ("warn_age_s", `Int warn_age_s);
+      ("bad_age_s", `Int bad_age_s);
+    ], true)
+  with _ ->
+    (`Assoc [
+      ("alert_level", `String "bad");
+      ("debates_open", `Int 0);
+      ("debates_pending", `Int 0);
+      ("sessions_active", `Int 0);
+      ("sessions_without_quorum", `Int 0);
+      ("oldest_open_debate_age_s", `Null);
+      ("last_activity_age_s", `Null);
+      ("slo_target_quorum_age_s", `Int slo_target_quorum_age_s);
+      ("warn_age_s", `Int warn_age_s);
+      ("bad_age_s", `Int bad_age_s);
+    ], false)
+
 type keeper_gen_window_stats = {
   mutable turns: int;
   mutable input_tokens: int;
@@ -3468,6 +3673,11 @@ let dashboard_batch_json ?(compact = false) (config : Room.config) : Yojson.Safe
   let tasks = Room.get_tasks_raw config in
   let agents = Room.get_agents_raw config in
   let msgs = Room.get_messages_raw config ~since_seq:0 ~limit:20 in
+  let now_ts = Masc_mcp.Time_compat.now () in
+  let (board_monitor_json, board_contract_ok) = board_monitoring_json ~now_ts in
+  let (council_monitor_json, council_feed_ok) =
+    council_monitoring_json ~now_ts ~base_path:config.base_path
+  in
 
   let proactive_fallback_warn =
     float_of_env_default
@@ -3518,9 +3728,13 @@ let dashboard_batch_json ?(compact = false) (config : Room.config) : Yojson.Safe
         ("proactive_similarity_bad", `Float (max proactive_similarity_warn proactive_similarity_bad));
         ("toast_cooldown_sec", `Int alert_toast_cooldown_sec);
       ]);
+      ("monitoring", `Assoc [
+        ("board", board_monitor_json);
+        ("council", council_monitor_json);
+      ]);
       ("data_quality", `Assoc [
-        ("board_contract_ok", `Bool true);
-        ("council_feed_ok", `Bool true);
+        ("board_contract_ok", `Bool board_contract_ok);
+        ("council_feed_ok", `Bool council_feed_ok);
         ("last_sync_at", `String (Types.now_iso ()));
       ]);
     ]

--- a/bin/main_eio.ml
+++ b/bin/main_eio.ml
@@ -1926,8 +1926,13 @@ let board_monitoring_json ~(now_ts : float) : Yojson.Safe.t * bool =
       match last_activity_age_s with
       | None -> "warn"
       | Some age when age >= bad_age_s -> "bad"
-      | Some age when age >= warn_age_s || age >= slo_target_age_s -> "warn"
+      | Some age when age >= warn_age_s -> "warn"
       | Some _ -> "ok"
+    in
+    let slo_breached =
+      match last_activity_age_s with
+      | Some age -> age >= slo_target_age_s
+      | None -> false
     in
     (`Assoc [
       ("alert_level", `String alert_level);
@@ -1936,6 +1941,7 @@ let board_monitoring_json ~(now_ts : float) : Yojson.Safe.t * bool =
       ("unanswered_posts", `Int unanswered_posts);
       ("last_activity_age_s", json_int_opt last_activity_age_s);
       ("slo_target_age_s", `Int slo_target_age_s);
+      ("slo_breached", `Bool slo_breached);
       ("warn_age_s", `Int warn_age_s);
       ("bad_age_s", `Int bad_age_s);
     ], true)
@@ -1949,6 +1955,7 @@ let board_monitoring_json ~(now_ts : float) : Yojson.Safe.t * bool =
       ("unanswered_posts", `Int 0);
       ("last_activity_age_s", `Null);
       ("slo_target_age_s", `Int slo_target_age_s);
+      ("slo_breached", `Bool false);
       ("warn_age_s", `Int warn_age_s);
       ("bad_age_s", `Int bad_age_s);
     ], false)
@@ -2039,8 +2046,18 @@ let council_monitoring_json ~(now_ts : float) ~(base_path : string)
       match last_activity_age_s with
       | None -> "warn"
       | Some age when age >= bad_age_s -> "bad"
-      | Some age when age >= warn_age_s || age >= slo_target_quorum_age_s -> "warn"
+      | Some age when age >= warn_age_s -> "warn"
       | Some _ -> "ok"
+    in
+    let slo_breached =
+      if sessions_without_quorum > 0 then
+        match oldest_open_debate_age_s with
+        | Some age -> age >= slo_target_quorum_age_s
+        | None -> false
+      else
+        match last_activity_age_s with
+        | Some age -> age >= slo_target_quorum_age_s
+        | None -> false
     in
     let alert_level =
       if sessions_without_quorum <= 0 then base_alert
@@ -2058,6 +2075,7 @@ let council_monitoring_json ~(now_ts : float) ~(base_path : string)
       ("oldest_open_debate_age_s", json_int_opt oldest_open_debate_age_s);
       ("last_activity_age_s", json_int_opt last_activity_age_s);
       ("slo_target_quorum_age_s", `Int slo_target_quorum_age_s);
+      ("slo_breached", `Bool slo_breached);
       ("warn_age_s", `Int warn_age_s);
       ("bad_age_s", `Int bad_age_s);
     ], true)
@@ -2073,6 +2091,7 @@ let council_monitoring_json ~(now_ts : float) ~(base_path : string)
       ("oldest_open_debate_age_s", `Null);
       ("last_activity_age_s", `Null);
       ("slo_target_quorum_age_s", `Int slo_target_quorum_age_s);
+      ("slo_breached", `Bool false);
       ("warn_age_s", `Int warn_age_s);
       ("bad_age_s", `Int bad_age_s);
     ], false)

--- a/dashboard/src/api.ts
+++ b/dashboard/src/api.ts
@@ -11,6 +11,7 @@ import type {
   TrpgEvent,
   Agent,
   CouncilDebate,
+  CouncilDebateSummary,
   CouncilSession,
   BoardSortMode,
 } from './types'
@@ -149,13 +150,6 @@ export async function callMcpTool(toolName: string, args: Record<string, unknown
   return extractMcpText(parsed)
 }
 
-function parseJsonList<T>(text: string): T[] {
-  const trimmed = text.trim()
-  if (!trimmed) return []
-  const parsed = JSON.parse(trimmed) as unknown
-  return Array.isArray(parsed) ? (parsed as T[]) : []
-}
-
 // --- Dashboard (batch) ---
 
 export type DashboardMode = 'compact' | 'full'
@@ -166,15 +160,113 @@ export function fetchDashboard(mode: DashboardMode = 'compact'): Promise<Dashboa
 
 // --- Board ---
 
-export function fetchBoard(sortBy?: BoardSortMode): Promise<{ posts: BoardPost[] }> {
-  const params = new URLSearchParams()
-  if (sortBy) params.set('sort_by', sortBy)
-  const qs = params.toString()
-  return get(`/api/v1/board${qs ? `?${qs}` : ''}`)
+function toIsoTimestamp(value: unknown): string {
+  if (typeof value === 'string' && value.trim()) return value
+  if (typeof value !== 'number' || Number.isNaN(value)) return new Date().toISOString()
+  const ms = value < 1_000_000_000_000 ? value * 1000 : value
+  return new Date(ms).toISOString()
 }
 
-export function fetchBoardPost(postId: string): Promise<BoardPost & { comments: BoardComment[] }> {
-  return get(`/api/v1/board/${postId}`)
+function derivePostTitle(content: string): string {
+  const trimmed = content.trim()
+  const withoutFlair = trimmed.startsWith('[flair:') ? trimmed.replace(/^\[flair:[^\]]+\]\s*/i, '') : trimmed
+  const firstLine = withoutFlair.split('\n')[0]?.trim() || 'Untitled post'
+  if (firstLine.length <= 96) return firstLine
+  return `${firstLine.slice(0, 93)}...`
+}
+
+function normalizeBoardPost(raw: unknown): BoardPost | null {
+  if (!isRecord(raw)) return null
+  const id = asString(raw.id, '').trim()
+  const author = asString(raw.author, '').trim()
+  const content = asString(raw.content, '').trim()
+  if (!id || !author) return null
+
+  const score = asNumber(raw.score, 0)
+  const votesUp = asNumber(raw.votes_up, 0)
+  const votesDown = asNumber(raw.votes_down, 0)
+  const votes = asNumber(raw.votes, score || (votesUp - votesDown))
+  const commentCount = asNumber(raw.comment_count, asNumber(raw.reply_count, 0))
+  const flairValue = (() => {
+    const flair = raw.flair
+    if (typeof flair === 'string' && flair.trim()) return flair.trim()
+    if (isRecord(flair)) {
+      const name = asString(flair.name, '').trim()
+      if (name) return name
+    }
+    const fallback = asString(raw.flair_name, '').trim()
+    return fallback || undefined
+  })()
+  const createdAt =
+    asString(raw.created_at_iso, '').trim() || toIsoTimestamp(raw.created_at)
+  const updatedAt =
+    asString(raw.updated_at_iso, '').trim()
+    || (raw.updated_at !== undefined ? toIsoTimestamp(raw.updated_at) : createdAt)
+  const titleRaw = asString(raw.title, '').trim()
+  const title = titleRaw || derivePostTitle(content)
+
+  return {
+    id,
+    author,
+    title,
+    content,
+    tags: [],
+    votes,
+    vote_balance: score,
+    comment_count: commentCount,
+    created_at: createdAt,
+    updated_at: updatedAt,
+    flair: flairValue,
+    hearth_count: asNumber(raw.hearth_count, 0),
+  }
+}
+
+function normalizeBoardComment(raw: unknown): BoardComment | null {
+  if (!isRecord(raw)) return null
+  const id = asString(raw.id, '').trim()
+  const postId = asString(raw.post_id, '').trim()
+  const author = asString(raw.author, '').trim()
+  if (!id || !author) return null
+  return {
+    id,
+    post_id: postId,
+    author,
+    content: asString(raw.content, ''),
+    created_at: toIsoTimestamp(raw.created_at),
+  }
+}
+
+export async function fetchBoard(sortBy?: BoardSortMode): Promise<{ posts: BoardPost[] }> {
+  const params = new URLSearchParams()
+  if (sortBy) params.set('sort_by', sortBy)
+  params.set('limit', '100')
+  const qs = params.toString()
+  const raw = await get<{ posts?: unknown[] }>(`/api/v1/board${qs ? `?${qs}` : ''}`)
+  const posts = Array.isArray(raw.posts)
+    ? raw.posts.map(normalizeBoardPost).filter((row): row is BoardPost => row !== null)
+    : []
+  return { posts }
+}
+
+export async function fetchBoardPost(postId: string): Promise<BoardPost & { comments: BoardComment[] }> {
+  const raw = await get<Record<string, unknown>>(`/api/v1/board/${postId}?format=flat`)
+  const postRaw = isRecord(raw.post) ? raw.post : raw
+  const post = normalizeBoardPost(postRaw) ?? {
+    id: postId,
+    author: 'unknown',
+    title: 'Post',
+    content: '',
+    tags: [],
+    votes: 0,
+    comment_count: 0,
+    created_at: new Date().toISOString(),
+    updated_at: new Date().toISOString(),
+  }
+  const commentsRaw = Array.isArray(raw.comments) ? raw.comments : []
+  const comments = commentsRaw
+    .map(normalizeBoardComment)
+    .filter((row): row is BoardComment => row !== null)
+  return { ...post, comments }
 }
 
 export function fetchBoardHearths(): Promise<{ hearths: BoardHearth[] }> {
@@ -188,6 +280,7 @@ export function fetchBoardFlairs(): Promise<{ flairs: BoardFlair[] }> {
 export function votePost(postId: string, direction: 'up' | 'down'): Promise<unknown> {
   return post('/api/v1/tools/masc_board_vote', {
     post_id: postId,
+    direction,
     vote: direction,
     voter: defaultBoardVoter(),
   })
@@ -196,6 +289,7 @@ export function votePost(postId: string, direction: 'up' | 'down'): Promise<unkn
 export function voteBoardTool(postId: string, vote: 'up' | 'down', voter: string): Promise<unknown> {
   return post('/api/v1/tools/masc_board_vote', {
     post_id: postId,
+    direction: vote,
     vote,
     voter,
   })
@@ -1108,13 +1202,45 @@ export async function fetchTaskHistory(taskId: string, limit = 20): Promise<stri
 }
 
 export async function fetchDebates(): Promise<CouncilDebate[]> {
-  const text = await callMcpTool('masc_debates', {})
-  return parseJsonList<CouncilDebate>(text)
+  const raw = await get<{ debates?: unknown[] }>('/api/v1/council/debates?limit=100')
+  if (!Array.isArray(raw.debates)) return []
+  return raw.debates
+    .map((item): CouncilDebate | null => {
+      if (!isRecord(item)) return null
+      const id = asString(item.id, '').trim()
+      const topic = asString(item.topic, '').trim()
+      if (!id || !topic) return null
+      return {
+        id,
+        topic,
+        status: asString(item.status, 'open'),
+        argument_count: asNumber(item.argument_count, 0),
+        created_at: toIsoTimestamp(item.created_at_iso ?? item.created_at),
+      }
+    })
+    .filter((row): row is CouncilDebate => row !== null)
 }
 
 export async function fetchCouncilSessions(): Promise<CouncilSession[]> {
-  const text = await callMcpTool('masc_sessions', {})
-  return parseJsonList<CouncilSession>(text)
+  const raw = await get<{ sessions?: unknown[] }>('/api/v1/council/sessions?limit=100')
+  if (!Array.isArray(raw.sessions)) return []
+  return raw.sessions
+    .map((item): CouncilSession | null => {
+      if (!isRecord(item)) return null
+      const id = asString(item.id, '').trim()
+      const topic = asString(item.topic, '').trim()
+      if (!id || !topic) return null
+      return {
+        id,
+        topic,
+        initiator: asString(item.initiator, 'system'),
+        votes: asNumber(item.votes, 0),
+        quorum: asNumber(item.quorum, 0),
+        state: asString(item.state, 'open'),
+        created_at: toIsoTimestamp(item.created_at_iso ?? item.created_at),
+      }
+    })
+    .filter((row): row is CouncilSession => row !== null)
 }
 
 export async function startDebate(topic: string): Promise<CouncilDebate | null> {
@@ -1126,8 +1252,23 @@ export async function startDebate(topic: string): Promise<CouncilDebate | null> 
   }
 }
 
-export function fetchDebateStatus(debateId: string): Promise<string> {
-  return callMcpTool('masc_debate_status', { debate_id: debateId })
+export async function fetchDebateStatus(debateId: string): Promise<CouncilDebateSummary | null> {
+  const safeId = encodeURIComponent(debateId)
+  const raw = await get<Record<string, unknown>>(`/api/v1/council/debates/${safeId}/summary`)
+  if (!isRecord(raw)) return null
+  const id = asString(raw.id, '').trim()
+  if (!id) return null
+  return {
+    id,
+    topic: asString(raw.topic, ''),
+    status: asString(raw.status, 'open'),
+    support_count: asNumber(raw.support_count, 0),
+    oppose_count: asNumber(raw.oppose_count, 0),
+    neutral_count: asNumber(raw.neutral_count, 0),
+    total_arguments: asNumber(raw.total_arguments, 0),
+    created_at: toIsoTimestamp(raw.created_at_iso ?? raw.created_at),
+    summary_text: asString(raw.summary_text, ''),
+  }
 }
 
 export function sendKeeperMessage(name: string, message: string, models?: string[]): Promise<string> {

--- a/dashboard/src/app.ts
+++ b/dashboard/src/app.ts
@@ -26,6 +26,7 @@ import { Board } from './components/board'
 import { Activity } from './components/activity'
 import { Agents } from './components/agents'
 import { Tasks } from './components/tasks'
+import { Execution } from './components/execution'
 import { Journal } from './components/journal'
 import { Goals } from './components/goals'
 import { Trpg } from './components/trpg'
@@ -47,11 +48,10 @@ function ConnectionStatus() {
 
 const RAIL_TABS: { id: TabId; label: string }[] = [
   { id: 'overview', label: 'Overview' },
-  { id: 'council', label: 'Council' },
-  { id: 'board', label: 'Board' },
+  { id: 'council', label: 'Decisions' },
+  { id: 'board', label: 'Discussions' },
+  { id: 'execution', label: 'Execution' },
   { id: 'activity', label: 'Activity' },
-  { id: 'agents', label: 'Agents' },
-  { id: 'tasks', label: 'Tasks' },
   { id: 'goals', label: 'Goals' },
   { id: 'journal', label: 'Journal' },
   { id: 'trpg', label: 'TRPG' },
@@ -132,6 +132,8 @@ function TabContent() {
       return html`<${Council} />`
     case 'board':
       return html`<${Board} />`
+    case 'execution':
+      return html`<${Execution} />`
     case 'activity':
       return html`<${Activity} />`
     case 'agents':
@@ -187,7 +189,7 @@ export function App() {
             MASC Dashboard
             <span class="version-badge">SPA</span>
           </h1>
-          <p class="header-subtitle">Real-time multi-agent operations console</p>
+          <p class="header-subtitle">Decision and execution operations console</p>
         </div>
         <div class="header-right">
           <${ConnectionStatus} />

--- a/dashboard/src/components/board.ts
+++ b/dashboard/src/components/board.ts
@@ -24,11 +24,13 @@ const SORT_MODES: { id: BoardSortMode; label: string }[] = [
 
 const detailComments = signal<BoardComment[]>([])
 const detailLoading = signal(false)
+const detailPostId = signal<string | null>(null)
 const commentText = signal('')
 const commentAuthor = signal('dashboard-user')
 const commentSubmitting = signal(false)
 
 async function loadPostDetail(postId: string) {
+  detailPostId.value = postId
   detailLoading.value = true
   detailComments.value = []
   try {
@@ -164,7 +166,7 @@ function CommentForm({ postId }: { postId: string }) {
 
 function PostDetail({ post }: { post: BoardPost }) {
   // Load comments on first render
-  if (detailComments.value.length === 0 && !detailLoading.value) {
+  if (detailPostId.value !== post.id && !detailLoading.value) {
     loadPostDetail(post.id)
   }
 

--- a/dashboard/src/components/common/tab-nav.ts
+++ b/dashboard/src/components/common/tab-nav.ts
@@ -12,11 +12,10 @@ interface TabDef {
 
 const TABS: TabDef[] = [
   { id: 'overview', label: 'Overview', icon: '\uD83C\uDFE0' },
-  { id: 'council', label: 'Council', icon: '\uD83C\uDFDB\uFE0F' },
-  { id: 'board', label: 'Board', icon: '\uD83D\uDCAC' },
+  { id: 'council', label: 'Decisions', icon: '\uD83C\uDFDB\uFE0F' },
+  { id: 'board', label: 'Discussions', icon: '\uD83D\uDCAC' },
+  { id: 'execution', label: 'Execution', icon: '\uD83D\uDEE0\uFE0F' },
   { id: 'activity', label: 'Activity', icon: '\uD83D\uDCCA' },
-  { id: 'agents', label: 'Agents', icon: '\uD83E\uDD16' },
-  { id: 'tasks', label: 'Tasks', icon: '\uD83D\uDCCB' },
   { id: 'journal', label: 'Journal', icon: '\uD83D\uDCD3' },
   { id: 'trpg', label: 'TRPG', icon: '\u2694\uFE0F' },
 ]

--- a/dashboard/src/components/common/time-ago.ts
+++ b/dashboard/src/components/common/time-ago.ts
@@ -8,7 +8,10 @@ interface TimeAgoProps {
 
 function formatTimeAgo(ts: string | number): string {
   const now = Date.now()
-  const then = typeof ts === 'number' ? ts : new Date(ts).getTime()
+  const then =
+    typeof ts === 'number'
+      ? (ts < 1_000_000_000_000 ? ts * 1000 : ts)
+      : new Date(ts).getTime()
   const diffSec = Math.floor((now - then) / 1000)
 
   if (diffSec < 60) return `${diffSec}s ago`
@@ -22,7 +25,11 @@ function formatTimeAgo(ts: string | number): string {
 
 export function TimeAgo({ timestamp }: TimeAgoProps) {
   const text = formatTimeAgo(timestamp)
-  return html`<span class="time-ago" title=${typeof timestamp === 'string' ? timestamp : new Date(timestamp).toISOString()}>${text}</span>`
+  const title =
+    typeof timestamp === 'string'
+      ? timestamp
+      : new Date(timestamp < 1_000_000_000_000 ? timestamp * 1000 : timestamp).toISOString()
+  return html`<span class="time-ago" title=${title}>${text}</span>`
 }
 
 export { formatTimeAgo }

--- a/dashboard/src/components/council.ts
+++ b/dashboard/src/components/council.ts
@@ -11,7 +11,7 @@ import {
   fetchDebateStatus,
   startDebate,
 } from '../api'
-import type { CouncilDebate, CouncilSession } from '../types'
+import type { CouncilDebate, CouncilDebateSummary, CouncilSession } from '../types'
 
 const debates = signal<CouncilDebate[]>([])
 const sessions = signal<CouncilSession[]>([])
@@ -20,7 +20,7 @@ const loading = signal(false)
 const starting = signal(false)
 const errorText = signal('')
 const selectedDebateId = signal<string | null>(null)
-const selectedDebateDetail = signal('')
+const selectedDebateDetail = signal<CouncilDebateSummary | null>(null)
 const detailLoading = signal(false)
 
 async function refreshCouncil() {
@@ -60,11 +60,12 @@ async function submitDebate() {
 async function loadDebateDetail(debateId: string) {
   selectedDebateId.value = debateId
   detailLoading.value = true
-  selectedDebateDetail.value = ''
+  selectedDebateDetail.value = null
   try {
     selectedDebateDetail.value = await fetchDebateStatus(debateId)
   } catch (err) {
-    selectedDebateDetail.value = err instanceof Error ? err.message : 'Failed to load debate status'
+    errorText.value = err instanceof Error ? err.message : 'Failed to load debate status'
+    selectedDebateDetail.value = null
   } finally {
     detailLoading.value = false
   }
@@ -97,6 +98,7 @@ function SessionRow({ session }: { session: CouncilSession }) {
         <div class="council-sub">
           <span>ID: ${session.id.slice(0, 10)}</span>
           <span>Initiator: ${session.initiator}</span>
+          ${session.state ? html`<span>State: ${session.state}</span>` : null}
         </div>
       </div>
       <span class="council-state vote">${session.votes}/${session.quorum}</span>
@@ -158,7 +160,20 @@ export function Council() {
         ${detailLoading.value
           ? html`<div class="loading-indicator">Loading debate detail...</div>`
           : selectedDebateDetail.value
-            ? html`<pre class="council-detail">${selectedDebateDetail.value}</pre>`
+            ? html`
+                <div class="council-sub" style="margin-bottom: 8px;">
+                  <span>Status: ${selectedDebateDetail.value.status}</span>
+                  <span>Total arguments: ${selectedDebateDetail.value.total_arguments}</span>
+                </div>
+                <div class="council-sub" style="margin-bottom: 8px;">
+                  <span>Support: ${selectedDebateDetail.value.support_count}</span>
+                  <span>Oppose: ${selectedDebateDetail.value.oppose_count}</span>
+                  <span>Neutral: ${selectedDebateDetail.value.neutral_count}</span>
+                </div>
+                ${selectedDebateDetail.value.summary_text
+                  ? html`<pre class="council-detail">${selectedDebateDetail.value.summary_text}</pre>`
+                  : null}
+              `
             : html`<div class="empty-state">Select a debate to view summary</div>`}
       <//>
     </div>

--- a/dashboard/src/components/execution.ts
+++ b/dashboard/src/components/execution.ts
@@ -1,0 +1,109 @@
+// Execution tab — Product-owner oriented work queue and assignee visibility
+
+import { html } from 'htm/preact'
+import { Card } from './common/card'
+import { StatusBadge } from './common/status-badge'
+import { TimeAgo } from './common/time-ago'
+import { activeAgents, tasksByStatus } from '../store'
+import type { Task } from '../types'
+
+function taskPriorityLabel(priority?: number): string {
+  if (priority == null) return 'P3'
+  if (priority <= 1) return 'P1'
+  if (priority === 2) return 'P2'
+  if (priority >= 4) return 'P4+'
+  return 'P3'
+}
+
+function ExecutionTaskRow({ task }: { task: Task }) {
+  return html`
+    <div class="council-row session">
+      <div class="council-row-main">
+        <div class="council-topic">${task.title}</div>
+        <div class="council-sub">
+          <span>${taskPriorityLabel(task.priority)}</span>
+          ${task.assignee ? html`<span>Assignee: ${task.assignee}</span>` : html`<span>Unassigned</span>`}
+          ${task.created_at ? html`<span><${TimeAgo} timestamp=${task.created_at} /></span>` : null}
+        </div>
+      </div>
+      <span class="council-state ${task.status}">${task.status}</span>
+    </div>
+  `
+}
+
+export function Execution() {
+  const grouped = tasksByStatus.value
+  const inProgress = grouped.inProgress
+  const todo = grouped.todo
+  const done = grouped.done
+  const agents = activeAgents.value
+  const urgentTodo = todo.filter(t => (t.priority ?? 3) <= 2)
+  const unassigned = todo.filter(t => !t.assignee)
+
+  return html`
+    <div class="stats-grid">
+      <div class="stat-card">
+        <div class="stat-label">In Progress</div>
+        <div class="stat-value" style="color:#fbbf24">${inProgress.length}</div>
+      </div>
+      <div class="stat-card">
+        <div class="stat-label">Ready Queue</div>
+        <div class="stat-value">${todo.length}</div>
+      </div>
+      <div class="stat-card">
+        <div class="stat-label">Urgent Ready</div>
+        <div class="stat-value" style="color:#fb7185">${urgentTodo.length}</div>
+      </div>
+      <div class="stat-card">
+        <div class="stat-label">Done (Visible)</div>
+        <div class="stat-value" style="color:#4ade80">${done.length}</div>
+      </div>
+    </div>
+
+    <div class="council-grid">
+      <${Card} title="Execution Queue" class="section">
+        <div class="council-list">
+          ${inProgress.length === 0
+            ? html`<div class="empty-state">No active execution tasks</div>`
+            : inProgress.slice(0, 20).map(task => html`<${ExecutionTaskRow} key=${task.id} task=${task} />`)}
+        </div>
+      <//>
+
+      <${Card} title="Ready Queue" class="section">
+        <div class="council-list">
+          ${todo.length === 0
+            ? html`<div class="empty-state">No ready tasks</div>`
+            : todo.slice(0, 20).map(task => html`<${ExecutionTaskRow} key=${task.id} task=${task} />`)}
+        </div>
+      <//>
+    </div>
+
+    <div class="grid-2col">
+      <${Card} title="Assignee Coverage" class="section">
+        <div class="council-list">
+          ${agents.length === 0
+            ? html`<div class="empty-state">No active agents</div>`
+            : agents.map(agent => html`
+                <div class="council-row session">
+                  <div class="council-row-main">
+                    <div class="council-topic">${agent.name}</div>
+                    <div class="council-sub">
+                      ${agent.current_task ? html`<span>${agent.current_task}</span>` : html`<span>Idle</span>`}
+                    </div>
+                  </div>
+                  <${StatusBadge} status=${agent.status} />
+                </div>
+              `)}
+        </div>
+      <//>
+
+      <${Card} title="Attention Needed" class="section">
+        <div class="council-list">
+          ${unassigned.length === 0
+            ? html`<div class="empty-state">No unassigned tasks</div>`
+            : unassigned.slice(0, 20).map(task => html`<${ExecutionTaskRow} key=${task.id} task=${task} />`)}
+        </div>
+      <//>
+    </div>
+  `
+}

--- a/dashboard/src/components/overview.ts
+++ b/dashboard/src/components/overview.ts
@@ -138,6 +138,8 @@ export function Overview() {
   const agentList = agents.value
   const keeperList = keepers.value
   const byStatus = tasksByStatus.value
+  const boardMonitor = status?.monitoring?.board
+  const councilMonitor = status?.monitoring?.council
 
   return html`
     <div class="stats-grid">
@@ -148,6 +150,41 @@ export function Overview() {
       <${StatCard} label="In Progress" value=${byStatus.inProgress.length} color="#fbbf24" />
       <${StatCard} label="Done" value=${byStatus.done.length} color="#4ade80" />
     </div>
+
+    ${boardMonitor || councilMonitor
+      ? html`
+        <${Card} title="Operations SLO" class="section">
+          <div class="grid-2col">
+            <div class="stat-card">
+              <div class="stat-label">Board Feed</div>
+              <div class="stat-value" style=${`color: ${monitorLevelColor(boardMonitor?.alert_level)}`}>
+                ${monitorLevelLabel(boardMonitor?.alert_level)}
+              </div>
+              <div class="council-sub">
+                <span>Freshness: ${formatDuration(boardMonitor?.last_activity_age_s)}</span>
+                <span>SLO: ≤ ${formatDuration(boardMonitor?.slo_target_age_s)}</span>
+                <span>Posts (24h): ${boardMonitor?.new_posts_24h ?? 0}</span>
+                <span>Unanswered: ${boardMonitor?.unanswered_posts ?? 0}</span>
+              </div>
+            </div>
+
+            <div class="stat-card">
+              <div class="stat-label">Council Feed</div>
+              <div class="stat-value" style=${`color: ${monitorLevelColor(councilMonitor?.alert_level)}`}>
+                ${monitorLevelLabel(councilMonitor?.alert_level)}
+              </div>
+              <div class="council-sub">
+                <span>Freshness: ${formatDuration(councilMonitor?.last_activity_age_s)}</span>
+                <span>Open Debates: ${councilMonitor?.debates_open ?? 0}</span>
+                <span>Pending Debates: ${councilMonitor?.debates_pending ?? 0}</span>
+                <span>Quorum Risk: ${councilMonitor?.sessions_without_quorum ?? 0}</span>
+                <span>SLO: ≤ ${formatDuration(councilMonitor?.slo_target_quorum_age_s)}</span>
+              </div>
+            </div>
+          </div>
+        <//>
+      `
+      : null}
 
     <div class="grid-2col">
       <${Card} title="Agents" class="section">
@@ -207,4 +244,30 @@ function formatUptime(seconds: number): string {
   const h = Math.floor(seconds / 3600)
   const m = Math.floor((seconds % 3600) / 60)
   return h > 0 ? `${h}h ${m}m` : `${m}m`
+}
+
+function formatDuration(seconds?: number | null): string {
+  if (seconds == null || !Number.isFinite(seconds)) return 'No data'
+  if (seconds < 60) return `${Math.max(0, Math.round(seconds))}s`
+  const m = Math.floor(seconds / 60)
+  if (m < 60) return `${m}m`
+  const h = Math.floor(m / 60)
+  const remM = m % 60
+  return remM > 0 ? `${h}h ${remM}m` : `${h}h`
+}
+
+function monitorLevelLabel(level?: string): string {
+  const v = (level ?? '').toLowerCase()
+  if (v === 'ok') return 'Healthy'
+  if (v === 'warn') return 'Warning'
+  if (v === 'bad') return 'Degraded'
+  return 'Unknown'
+}
+
+function monitorLevelColor(level?: string): string {
+  const v = (level ?? '').toLowerCase()
+  if (v === 'ok') return '#4ade80'
+  if (v === 'warn') return '#fbbf24'
+  if (v === 'bad') return '#fb7185'
+  return '#94a3b8'
 }

--- a/dashboard/src/components/overview.ts
+++ b/dashboard/src/components/overview.ts
@@ -192,6 +192,9 @@ export function Overview() {
             ${status.paused ? html`<span class="pill pill-stale">Paused</span>` : null}
             ${status.tempo ? html`<span>Tempo: ${status.tempo}</span>` : null}
             ${status.tempo_interval_s != null ? html`<span>Interval: ${status.tempo_interval_s}s</span>` : null}
+            ${status.data_quality?.board_contract_ok === false ? html`<span class="pill pill-stale">Board Contract: Degraded</span>` : null}
+            ${status.data_quality?.council_feed_ok === false ? html`<span class="pill pill-stale">Council Feed: Degraded</span>` : null}
+            ${status.data_quality?.last_sync_at ? html`<span>Data Sync: <${TimeAgo} timestamp=${status.data_quality.last_sync_at} /></span>` : null}
           </div>
         <//>
       `

--- a/dashboard/src/components/overview.ts
+++ b/dashboard/src/components/overview.ts
@@ -163,6 +163,7 @@ export function Overview() {
               <div class="council-sub">
                 <span>Freshness: ${formatDuration(boardMonitor?.last_activity_age_s)}</span>
                 <span>SLO: ≤ ${formatDuration(boardMonitor?.slo_target_age_s)}</span>
+                <span>SLO Breach: ${boardMonitor?.slo_breached ? 'Yes' : 'No'}</span>
                 <span>Posts (24h): ${boardMonitor?.new_posts_24h ?? 0}</span>
                 <span>Unanswered: ${boardMonitor?.unanswered_posts ?? 0}</span>
               </div>
@@ -179,6 +180,7 @@ export function Overview() {
                 <span>Pending Debates: ${councilMonitor?.debates_pending ?? 0}</span>
                 <span>Quorum Risk: ${councilMonitor?.sessions_without_quorum ?? 0}</span>
                 <span>SLO: ≤ ${formatDuration(councilMonitor?.slo_target_quorum_age_s)}</span>
+                <span>SLO Breach: ${councilMonitor?.slo_breached ? 'Yes' : 'No'}</span>
               </div>
             </div>
           </div>

--- a/dashboard/src/store.ts
+++ b/dashboard/src/store.ts
@@ -362,7 +362,7 @@ export async function refreshDashboard(mode: DashboardMode = 'full'): Promise<vo
 export async function refreshBoard(): Promise<void> {
   boardLoading.value = true
   try {
-    const data = await fetchBoard()
+    const data = await fetchBoard(boardSortMode.value)
     boardPosts.value = data.posts ?? []
   } catch (err) {
     console.error('Board fetch error:', err)

--- a/dashboard/src/types.ts
+++ b/dashboard/src/types.ts
@@ -408,6 +408,30 @@ export interface CouncilDebateSummary {
   summary_text?: string
 }
 
+export interface BoardMonitoring {
+  alert_level?: 'ok' | 'warn' | 'bad' | string
+  posts_total?: number
+  new_posts_24h?: number
+  unanswered_posts?: number
+  last_activity_age_s?: number | null
+  slo_target_age_s?: number
+  warn_age_s?: number
+  bad_age_s?: number
+}
+
+export interface CouncilMonitoring {
+  alert_level?: 'ok' | 'warn' | 'bad' | string
+  debates_open?: number
+  debates_pending?: number
+  sessions_active?: number
+  sessions_without_quorum?: number
+  oldest_open_debate_age_s?: number | null
+  last_activity_age_s?: number | null
+  slo_target_quorum_age_s?: number
+  warn_age_s?: number
+  bad_age_s?: number
+}
+
 // --- Dashboard batch response ---
 
 export interface DashboardData {
@@ -439,6 +463,10 @@ export interface ServerStatus {
     proactive_similarity_warn: number
     proactive_similarity_bad: number
     toast_cooldown_sec: number
+  }
+  monitoring?: {
+    board?: BoardMonitoring
+    council?: CouncilMonitoring
   }
   data_quality?: {
     board_contract_ok?: boolean

--- a/dashboard/src/types.ts
+++ b/dashboard/src/types.ts
@@ -382,6 +382,7 @@ export interface CouncilDebate {
   topic: string
   status: string
   argument_count: number
+  created_at?: string
 }
 
 export interface CouncilSession {
@@ -390,6 +391,21 @@ export interface CouncilSession {
   initiator: string
   votes: number
   quorum: number
+  threshold?: number
+  state?: string
+  created_at?: string
+}
+
+export interface CouncilDebateSummary {
+  id: string
+  topic: string
+  status: string
+  support_count: number
+  oppose_count: number
+  neutral_count: number
+  total_arguments: number
+  created_at?: string
+  summary_text?: string
 }
 
 // --- Dashboard batch response ---
@@ -423,6 +439,11 @@ export interface ServerStatus {
     proactive_similarity_warn: number
     proactive_similarity_bad: number
     toast_cooldown_sec: number
+  }
+  data_quality?: {
+    board_contract_ok?: boolean
+    council_feed_ok?: boolean
+    last_sync_at?: string
   }
 }
 
@@ -489,6 +510,7 @@ export interface RouteState {
 
 export type TabId =
   | 'overview'
+  | 'execution'
   | 'board'
   | 'activity'
   | 'agents'
@@ -500,6 +522,7 @@ export type TabId =
 
 export const VALID_TABS: TabId[] = [
   'overview',
+  'execution',
   'board',
   'activity',
   'agents',

--- a/dashboard/src/types.ts
+++ b/dashboard/src/types.ts
@@ -415,6 +415,7 @@ export interface BoardMonitoring {
   unanswered_posts?: number
   last_activity_age_s?: number | null
   slo_target_age_s?: number
+  slo_breached?: boolean
   warn_age_s?: number
   bad_age_s?: number
 }
@@ -428,6 +429,7 @@ export interface CouncilMonitoring {
   oldest_open_debate_age_s?: number | null
   last_activity_age_s?: number | null
   slo_target_quorum_age_s?: number
+  slo_breached?: boolean
   warn_age_s?: number
   bad_age_s?: number
 }

--- a/lib/board.ml
+++ b/lib/board.ml
@@ -1061,6 +1061,7 @@ let post_to_yojson_with_karma (p : post) ~author_karma : Yojson.Safe.t =
     ("flair", flair_json);
     ("visibility", `String (visibility_to_string p.visibility));
     ("created_at", `Float p.created_at);
+    ("updated_at", `Float p.updated_at);
     ("expires_at", `Float p.expires_at);
     ("votes_up", `Int p.votes_up);
     ("votes_down", `Int p.votes_down);

--- a/lib/masc_mcp.ml
+++ b/lib/masc_mcp.ml
@@ -50,6 +50,7 @@ module Board = Board
 module Board_pg = Board_pg
 module Board_dispatch = Board_dispatch
 module Board_listener = Board_listener
+module Council = Council
 module Social = Social
 module Task_pg = Task_pg
 module Task_dispatch = Task_dispatch

--- a/lib/tool_board.ml
+++ b/lib/tool_board.ml
@@ -295,7 +295,10 @@ let register_evolution_callback cb =
 let handle_vote args =
   let post_id = get_string args "post_id" "" in
   let voter = get_string args "voter" "anonymous" in
-  let direction_str = get_string args "direction" "up" in
+  let direction_str =
+    let from_direction = get_string args "direction" "" in
+    if from_direction <> "" then from_direction else get_string args "vote" "up"
+  in
 
   let direction = if direction_str = "down" then Board.Down else Board.Up in
 


### PR DESCRIPTION
## Summary
- repair Board API contract for dashboard (sorting/paging compatibility fields, detail flat format)
- add structured Council REST endpoints for debates/sessions/summary
- add dashboard data-quality status signals and frontend normalization
- add Execution tab + main IA relabeling (Decisions/Discussions)
- fix board detail refetch loop and timestamp second/ms handling

## Validation
- dune build --root .
- ./dashboard/node_modules/.bin/tsc --noEmit --pretty -p dashboard/tsconfig.json

## Notes
- dashboard typecheck in worktree used temporary node_modules link from repo root dashboard; link removed after check