### PR TITLE
refactor(viewer): GLM-5 review follow-up for preflight wizard

### DIFF
--- a/viewer/src/mode/mod.rs
+++ b/viewer/src/mode/mod.rs
@@ -1418,20 +1418,20 @@ pub(super) fn set_new_game_preflight_status(doc: &web_sys::Document, message: &s
 #[cfg(target_arch = "wasm32")]
 pub(super) fn set_new_game_preflight_rows(
     doc: &web_sys::Document,
-    rows: &[(bool, String, String, Option<String>)],
+    rows: &[super::transport_classify::PreflightRow],
 ) {
     if let Some(el) = doc.get_element_by_id("new-game-preflight") {
         let html = rows
             .iter()
-            .map(|(ok, label, detail, hint)| {
-                let state_text = if *ok { "OK" } else { "FAIL" };
-                let state_class = if *ok {
+            .map(|row| {
+                let state_text = if row.ok { "OK" } else { "FAIL" };
+                let state_class = if row.ok {
                     "preflight-state preflight-ok"
                 } else {
                     "preflight-state preflight-fail"
                 };
-                let hint_html = match hint {
-                    Some(h) if !ok => format!(
+                let hint_html = match &row.hint {
+                    Some(h) if !row.ok => format!(
                         "<div class=\"preflight-hint\">{}</div>",
                         html_escape(h)
                     ),
@@ -1441,8 +1441,8 @@ pub(super) fn set_new_game_preflight_rows(
                     "<div class=\"preflight-row\"><span class=\"{state_class}\">{state_text}</span><span>{label}: {detail}</span>{hint_html}</div>",
                     state_class = state_class,
                     state_text = state_text,
-                    label = html_escape(label),
-                    detail = html_escape(detail),
+                    label = html_escape(&row.label),
+                    detail = html_escape(&row.detail),
                     hint_html = hint_html,
                 )
             })

--- a/viewer/src/mode/transport_classify.rs
+++ b/viewer/src/mode/transport_classify.rs
@@ -2,25 +2,37 @@
 //!
 //! Pure-Rust logic with no WASM dependencies, enabling native `cargo test`.
 
+/// A single row in the preflight checklist.
+#[derive(Debug, Clone)]
+pub(super) struct PreflightRow {
+    pub ok: bool,
+    pub label: String,
+    pub detail: String,
+    pub hint: Option<String>,
+}
+
+/// Returns `true` when the body looks like an HTML error page (proxy, CDN, etc.).
+pub(super) fn is_html_body(body: &str) -> bool {
+    let lower = body.to_ascii_lowercase();
+    lower.contains("<!doctype") || lower.contains("<html")
+}
+
 /// Detects non-JSON transport errors (proxy HTML pages, empty 5xx) **before**
 /// JSON-RPC parsing so the caller can short-circuit with a human-readable
 /// Korean error message.
 pub(super) fn classify_transport_error(status: u16, body: &str) -> Option<String> {
     // 1. HTML error page from proxy / CDN (Cloudflare, nginx, etc.)
-    if (400..=599).contains(&status) {
-        let lower = body.to_ascii_lowercase();
-        if lower.contains("<!doctype") || lower.contains("<html") {
-            let hint = match status {
-                502 => " (게이트웨이 오류)",
-                503 => " (일시적 사용 불가)",
-                504 => " (응답 시간 초과)",
-                _ => "",
-            };
-            return Some(format!(
-                "MASC 서버에 연결할 수 없습니다 (HTTP {}){}. 서버가 실행 중인지 확인하세요.",
-                status, hint
-            ));
-        }
+    if (400..=599).contains(&status) && is_html_body(body) {
+        let hint = match status {
+            502 => " (게이트웨이 오류)",
+            503 => " (일시적 사용 불가)",
+            504 => " (응답 시간 초과)",
+            _ => "",
+        };
+        return Some(format!(
+            "MASC 서버에 연결할 수 없습니다 (HTTP {}){}. 서버가 실행 중인지 확인하세요.",
+            status, hint
+        ));
     }
 
     // 2. Empty body with server error status
@@ -71,5 +83,33 @@ mod tests {
         // 400 with JSON body (valid RPC error) should NOT be classified as transport error
         let body = r#"{"jsonrpc":"2.0","id":1,"error":{"code":-32600,"message":"Invalid Request"}}"#;
         assert!(classify_transport_error(400, body).is_none());
+    }
+
+    #[test]
+    fn is_html_body_detects_doctype() {
+        assert!(is_html_body("<!DOCTYPE html><html><body>502</body></html>"));
+    }
+
+    #[test]
+    fn is_html_body_detects_html_tag() {
+        assert!(is_html_body("<HTML><BODY>Error</BODY></HTML>"));
+    }
+
+    #[test]
+    fn is_html_body_rejects_json() {
+        assert!(!is_html_body(r#"{"error":"bad"}"#));
+    }
+
+    #[test]
+    fn preflight_row_debug_and_clone() {
+        let row = PreflightRow {
+            ok: true,
+            label: "test".to_string(),
+            detail: "detail".to_string(),
+            hint: None,
+        };
+        let cloned = row.clone();
+        assert!(cloned.ok);
+        assert_eq!(format!("{:?}", row), format!("{:?}", cloned));
     }
 }

--- a/viewer/src/mode/transport_classify.rs
+++ b/viewer/src/mode/transport_classify.rs
@@ -112,4 +112,18 @@ mod tests {
         assert!(cloned.ok);
         assert_eq!(format!("{:?}", row), format!("{:?}", cloned));
     }
+
+    #[test]
+    fn preflight_row_with_hint() {
+        let row = PreflightRow {
+            ok: false,
+            label: "서버 연결".to_string(),
+            detail: "HTTP 502 응답".to_string(),
+            hint: Some("프록시 확인".to_string()),
+        };
+        assert!(!row.ok);
+        assert_eq!(row.hint.as_deref(), Some("프록시 확인"));
+        let cloned = row.clone();
+        assert_eq!(cloned.hint, row.hint);
+    }
 }

--- a/viewer/src/mode/trpg_controls.rs
+++ b/viewer/src/mode/trpg_controls.rs
@@ -2025,28 +2025,35 @@ async fn refresh_new_game_bootstrap(doc: &web_sys::Document) -> Result<NewGameBo
 }
 
 async fn run_new_game_preflight(doc: &web_sys::Document) -> Result<(), String> {
-    let mut rows: Vec<(bool, String, String, Option<String>)> = Vec::new();
+    use super::transport_classify::{is_html_body, PreflightRow};
+
+    let mut rows: Vec<PreflightRow> = Vec::new();
 
     // ── Step 0: Server connectivity (early-exit on failure) ──
     let health_url = crate::config::build_masc_url("health");
     let server_row = match crate::mode::mcp_rpc::http_get_text(&health_url).await {
         Ok((status, _body)) if (200..300).contains(&status) => {
-            (true, "서버 연결".to_string(), "MASC 서버 응답 정상".to_string(), None)
+            PreflightRow { ok: true, label: "서버 연결".to_string(), detail: "MASC 서버 응답 정상".to_string(), hint: None }
         }
         Ok((status, body)) => {
-            let hint = if body.to_ascii_lowercase().contains("<html") {
-                Some("프록시/CDN이 에러 페이지를 반환했습니다. 서버 프로세스를 확인하세요.".to_string())
+            let hint = if is_html_body(&body) {
+                "프록시/CDN이 에러 페이지를 반환했습니다. 서버 프로세스를 확인하세요.".to_string()
             } else {
-                Some("서버가 실행 중인지, URL이 올바른지 확인하세요.".to_string())
+                "서버가 실행 중인지, URL이 올바른지 확인하세요.".to_string()
             };
-            (false, "서버 연결".to_string(), format!("HTTP {} 응답", status), hint)
+            PreflightRow { ok: false, label: "서버 연결".to_string(), detail: format!("HTTP {} 응답", status), hint: Some(hint) }
         }
         Err(e) => {
-            let hint = Some("MASC 서버가 실행 중인지 확인하세요. (로컬: localhost:8935)".to_string());
-            (false, "서버 연결".to_string(), format!("연결 실패: {}", e), hint)
+            let base = crate::config::masc_mcp_base_url();
+            let hint = if base.is_empty() {
+                "MASC 서버가 실행 중인지 확인하세요.".to_string()
+            } else {
+                format!("MASC 서버가 실행 중인지 확인하세요. ({})", base)
+            };
+            PreflightRow { ok: false, label: "서버 연결".to_string(), detail: format!("연결 실패: {}", e), hint: Some(hint) }
         }
     };
-    let server_ok = server_row.0;
+    let server_ok = server_row.ok;
     rows.push(server_row);
 
     // If server is unreachable, skip all dependent checks (cockpit syndrome prevention).
@@ -2077,9 +2084,9 @@ async fn run_new_game_preflight(doc: &web_sys::Document) -> Result<(), String> {
                     preset_catalog_keys_preview_from_value(&catalog)
                 )
             };
-            (ok, "프리셋".to_string(), detail, None)
+            PreflightRow { ok, label: "프리셋".to_string(), detail, hint: None }
         }
-        Err(e) => (false, "프리셋".to_string(), format!("조회 실패: {}", e), None),
+        Err(e) => PreflightRow { ok: false, label: "프리셋".to_string(), detail: format!("조회 실패: {}", e), hint: None },
     };
     rows.push(preset_row);
 
@@ -2100,28 +2107,18 @@ async fn run_new_game_preflight(doc: &web_sys::Document) -> Result<(), String> {
                 if count > 0 {
                     (
                         keepers,
-                        (
-                            true,
-                            "키퍼 풀".to_string(),
-                            format!("{}명 사용 가능", count),
-                            None,
-                        ),
+                        PreflightRow { ok: true, label: "키퍼 풀".to_string(), detail: format!("{}명 사용 가능", count), hint: None },
                     )
                 } else {
                     (
                         Vec::new(),
-                        (
-                            false,
-                            "키퍼 풀".to_string(),
-                            "사용 가능한 keeper가 없습니다".to_string(),
-                            None,
-                        ),
+                        PreflightRow { ok: false, label: "키퍼 풀".to_string(), detail: "사용 가능한 keeper가 없습니다".to_string(), hint: None },
                     )
                 }
             }
             Err(e) => (
                 Vec::new(),
-                (false, "키퍼 풀".to_string(), format!("조회 실패: {}", e), None),
+                PreflightRow { ok: false, label: "키퍼 풀".to_string(), detail: format!("조회 실패: {}", e), hint: None },
             ),
         };
     rows.push(keeper_pool_row);


### PR DESCRIPTION
## 요약

PR #473 (Transport 에러 처리 + 접근성 개선)에 대한 GLM-5 외부 리뷰 지적사항 3건 수정.

### 변경사항

- **DRY 위반 해소** (리뷰 #2): `is_html_body()` 헬퍼를 `transport_classify.rs`에 추출하고, `trpg_controls.rs`에서 인라인 HTML 감지 로직을 제거
- **PreflightRow struct 도입** (리뷰 #4): 가독성이 낮은 4-tuple `(bool, String, String, Option<String>)`을 명시적 필드명을 가진 `PreflightRow` 구조체로 교체
- **포트 하드코딩 제거** (리뷰 #8): 에러 힌트에서 `localhost:8935`를 `crate::config::masc_mcp_base_url()`로 대체

### 영향 범위

| 파일 | 변경 내용 |
|------|----------|
| `viewer/src/mode/transport_classify.rs` | `PreflightRow` struct 추가, `is_html_body()` 공개, 테스트 4건 추가 |
| `viewer/src/mode/trpg_controls.rs` | struct 리터럴 사용, DRY 헬퍼 호출, config 기반 URL |
| `viewer/src/mode/mod.rs` | `set_new_game_preflight_rows` 파라미터/접근 패턴 변경 |

## 테스트

```
cargo test --bin masc-viewer -- transport_classify
# 9 passed; 0 failed
```

## 관련 이슈

- MASC task-012
- 원본 PR: #473

🤖 Generated with [Claude Code](https://claude.com/claude-code)