### PR TITLE
feat(trpg): streamline actor creation and add profile fields

### DIFF
--- a/lib/tool_protocol_game_view.ml
+++ b/lib/tool_protocol_game_view.ml
@@ -1471,7 +1471,7 @@ let schemas : Types.tool_schema list =
     schema "trpg.actor.spawn"
       "Canonical alias of masc_trpg_actor_spawn."
       (object_schema
-         ~required:[ "room_id"; "actor_id" ]
+         ~required:[ "room_id" ]
          [
            ("room_id", string_schema);
            ("actor_id", string_schema);
@@ -1479,6 +1479,9 @@ let schemas : Types.tool_schema list =
            ("name", string_schema);
            ("archetype", string_schema);
            ("persona", string_schema);
+           ("portrait", string_schema);
+           ("background", string_schema);
+           ("stats", object_schema []);
            ("hp", int_schema);
            ("max_hp", int_schema);
            ("alive", bool_schema);
@@ -1497,6 +1500,9 @@ let schemas : Types.tool_schema list =
            ("name", string_schema);
            ("archetype", string_schema);
            ("persona", string_schema);
+           ("portrait", string_schema);
+           ("background", string_schema);
+           ("stats", object_schema []);
            ("hp", int_schema);
            ("max_hp", int_schema);
            ("alive", bool_schema);

--- a/lib/tool_trpg.ml
+++ b/lib/tool_trpg.ml
@@ -572,8 +572,8 @@ let schemas : Types.tool_schema list =
       name = "masc_trpg_actor_spawn";
       description =
         "Spawn an actor entity in room state. \
-         Required: room_id, actor_id. \
-         Optional: role(dm|player|npc), name, archetype, persona, hp, max_hp, alive, traits, skills, inventory.";
+         Required: room_id. \
+         Optional: actor_id (auto-generated when omitted), role(dm|player|npc), name, archetype, persona, portrait, background, stats(object), hp, max_hp, alive, traits, skills, inventory.";
       input_schema =
         `Assoc
           [
@@ -587,6 +587,9 @@ let schemas : Types.tool_schema list =
                   ("name", `Assoc [ ("type", `String "string") ]);
                   ("archetype", `Assoc [ ("type", `String "string") ]);
                   ("persona", `Assoc [ ("type", `String "string") ]);
+                  ("portrait", `Assoc [ ("type", `String "string") ]);
+                  ("background", `Assoc [ ("type", `String "string") ]);
+                  ("stats", `Assoc [ ("type", `String "object") ]);
                   ("hp", `Assoc [ ("type", `String "integer") ]);
                   ("max_hp", `Assoc [ ("type", `String "integer") ]);
                   ("alive", `Assoc [ ("type", `String "boolean") ]);
@@ -594,7 +597,7 @@ let schemas : Types.tool_schema list =
                   ("skills", `Assoc [ ("type", `String "array"); ("items", `Assoc [ ("type", `String "string") ]) ]);
                   ("inventory", `Assoc [ ("type", `String "array"); ("items", `Assoc [ ("type", `String "string") ]) ]);
                 ] );
-            ("required", `List [ `String "room_id"; `String "actor_id" ]);
+            ("required", `List [ `String "room_id" ]);
           ];
     };
     {
@@ -602,7 +605,7 @@ let schemas : Types.tool_schema list =
       description =
         "Update an existing actor entity in room state. \
          Required: room_id, actor_id. \
-         Optional: role(dm|player|npc), name, archetype, persona, hp, max_hp, alive, traits, skills, inventory.";
+         Optional: role(dm|player|npc), name, archetype, persona, portrait, background, stats(object), hp, max_hp, alive, traits, skills, inventory.";
       input_schema =
         `Assoc
           [
@@ -616,6 +619,9 @@ let schemas : Types.tool_schema list =
                   ("name", `Assoc [ ("type", `String "string") ]);
                   ("archetype", `Assoc [ ("type", `String "string") ]);
                   ("persona", `Assoc [ ("type", `String "string") ]);
+                  ("portrait", `Assoc [ ("type", `String "string") ]);
+                  ("background", `Assoc [ ("type", `String "string") ]);
+                  ("stats", `Assoc [ ("type", `String "object") ]);
                   ("hp", `Assoc [ ("type", `String "integer") ]);
                   ("max_hp", `Assoc [ ("type", `String "integer") ]);
                   ("alive", `Assoc [ ("type", `String "boolean") ]);
@@ -1015,6 +1021,36 @@ let state_party_fields state =
 
 let actor_exists_in_state state actor_id =
   state_party_fields state |> List.mem_assoc actor_id
+
+let sanitize_actor_id_seed (s : string) =
+  let src = String.lowercase_ascii (String.trim s) in
+  let out = Buffer.create (String.length src) in
+  let prev_dash = ref true in
+  String.iter
+    (fun c ->
+      if (c >= 'a' && c <= 'z') || (c >= '0' && c <= '9') then (
+        Buffer.add_char out c;
+        prev_dash := false)
+      else if not !prev_dash then (
+        Buffer.add_char out '-';
+        prev_dash := true))
+    src;
+  let collapsed = Buffer.contents out in
+  let len = String.length collapsed in
+  if len > 0 && collapsed.[len - 1] = '-' then
+    let trimmed = String.sub collapsed 0 (len - 1) in
+    if trimmed = "" then "actor" else trimmed
+  else if collapsed = "" then "actor"
+  else collapsed
+
+let next_available_actor_id state base_actor_id =
+  if not (actor_exists_in_state state base_actor_id) then base_actor_id
+  else
+    let rec loop n =
+      let candidate = Printf.sprintf "%s-%d" base_actor_id n in
+      if actor_exists_in_state state candidate then loop (n + 1) else candidate
+    in
+    loop 2
 
 let actor_alive_in_state state actor_id =
   match state_party_fields state |> List.assoc_opt actor_id with
@@ -6319,6 +6355,9 @@ let actor_payload_from_spawn_args args ~actor_id =
   let* name_opt = get_optional_string args "name" in
   let* archetype_opt = get_optional_string args "archetype" in
   let* persona_opt = get_optional_string args "persona" in
+  let* portrait_opt = get_optional_string args "portrait" in
+  let* background_opt = get_optional_string args "background" in
+  let* stats_opt = get_optional_object args "stats" in
   let* hp_opt = get_optional_int args "hp" in
   let* max_hp_opt = get_optional_int args "max_hp" in
   let* alive = get_optional_bool args "alive" ~default:true in
@@ -6339,6 +6378,10 @@ let actor_payload_from_spawn_args args ~actor_id =
             ("role", `String role);
             ("archetype", Option.fold ~none:`Null ~some:(fun v -> `String v) archetype_opt);
             ("persona", Option.fold ~none:`Null ~some:(fun v -> `String v) persona_opt);
+            ("portrait", Option.fold ~none:`Null ~some:(fun v -> `String v) portrait_opt);
+            ( "background",
+              Option.fold ~none:`Null ~some:(fun v -> `String v) background_opt );
+            ("stats", Option.value ~default:`Null stats_opt);
             ("hp", `Int hp);
             ("max_hp", `Int max_hp);
             ("alive", `Bool alive);
@@ -6360,6 +6403,9 @@ let actor_patch_from_update_args args =
   let* name_opt = get_optional_string args "name" in
   let* archetype_opt = get_optional_string args "archetype" in
   let* persona_opt = get_optional_string args "persona" in
+  let* portrait_opt = get_optional_string args "portrait" in
+  let* background_opt = get_optional_string args "background" in
+  let* stats_opt = get_optional_object args "stats" in
   let* hp_opt = get_optional_int args "hp" in
   let* max_hp_opt = get_optional_int args "max_hp" in
   let* traits_opt = get_optional_string_list_option args "traits" in
@@ -6405,10 +6451,17 @@ let actor_patch_from_update_args args =
     | Some values -> fields := (key, json_of_strings values) :: !fields
     | None -> ()
   in
+  let add_opt_json key = function
+    | Some value -> fields := (key, value) :: !fields
+    | None -> ()
+  in
   add_opt_string "role" role_opt;
   add_opt_string "name" name_opt;
   add_opt_string "archetype" archetype_opt;
   add_opt_string "persona" persona_opt;
+  add_opt_string "portrait" portrait_opt;
+  add_opt_string "background" background_opt;
+  add_opt_json "stats" stats_opt;
   add_opt_int "hp" hp_opt;
   add_opt_int "max_hp" max_hp_opt;
   add_opt_bool "alive" alive_opt;
@@ -6417,7 +6470,7 @@ let actor_patch_from_update_args args =
   add_opt_strings "inventory" inventory_opt;
   if !fields = [] then
     Error
-      "at least one update field is required: role,name,archetype,persona,hp,max_hp,alive,traits,skills,inventory"
+      "at least one update field is required: role,name,archetype,persona,portrait,background,stats,hp,max_hp,alive,traits,skills,inventory"
   else Ok (`Assoc (List.rev !fields))
 
 let handle_actor_spawn ctx args : result =
@@ -6425,12 +6478,28 @@ let handle_actor_spawn ctx args : result =
   let store = ctx.store in
   let result_json =
     let* room_id = get_required_string args "room_id" in
-    let* actor_id = get_required_string args "actor_id" in
+    let* actor_id_opt = get_optional_string args "actor_id" in
+    let* name_opt = get_optional_string args "name" in
+    let* role_opt = get_optional_string args "role" in
     let* rule_opt = get_optional_string args "rule_module" in
     let rule_module = Option.value ~default:"dnd5e-lite" rule_opt in
     let* () = validate_rule_module rule_module in
     let* derived = derive_state ~store ~room_id ~rule_module in
     let state = state_of_derived derived in
+    let actor_id =
+      match actor_id_opt with
+      | Some explicit -> explicit
+      | None ->
+          let seed =
+            match name_opt with
+            | Some name -> name
+            | None ->
+                role_opt |> Option.value ~default:"player"
+                |> String.lowercase_ascii
+          in
+          let base_actor_id = sanitize_actor_id_seed seed in
+          next_available_actor_id state base_actor_id
+    in
     if actor_exists_in_state state actor_id then
       Error (Printf.sprintf "actor already exists: %s" actor_id)
     else

--- a/test/test_tool_trpg_coverage.ml
+++ b/test/test_tool_trpg_coverage.ml
@@ -2174,6 +2174,133 @@ let test_actor_spawn_claim_release_flow () =
     (count_from_json (parse_json_exn stream_released));
   cleanup_dir base_dir
 
+let test_actor_spawn_auto_generates_actor_id () =
+  let base_dir = make_temp_dir () in
+  let config = Room.default_config base_dir in
+  let _ = Room.init config ~agent_name:(Some "tester") in
+  let store = Trpg_store.make_sqlite ~base_dir in
+  let ctx : Tool_trpg.context =
+    { store; agent_name = "tester"; keeper_call = None; keeper_probe = None; dm_voice_emit = None }
+  in
+  let room_id = "room-actor-auto-id" in
+
+  let ok_spawn1, spawn1_body =
+    dispatch_exn ctx ~name:"masc_trpg_actor_spawn"
+      ~args:
+        (`Assoc
+          [
+            ("room_id", `String room_id);
+            ("name", `String "Night Fox");
+            ("role", `String "npc");
+          ])
+  in
+  Alcotest.(check bool) "auto spawn 1 ok" true ok_spawn1;
+  let spawn1_json = parse_json_exn spawn1_body in
+  let actor_id1 = spawn1_json |> Yojson.Safe.Util.member "actor_id" |> Yojson.Safe.Util.to_string in
+  Alcotest.(check string) "auto actor_id from name" "night-fox" actor_id1;
+  Alcotest.(check bool) "state contains actor_id1" true
+    ((spawn1_json |> Yojson.Safe.Util.member "state" |> Yojson.Safe.Util.member "party"
+    |> Yojson.Safe.Util.member actor_id1)
+    <> `Null);
+
+  let ok_spawn2, spawn2_body =
+    dispatch_exn ctx ~name:"masc_trpg_actor_spawn"
+      ~args:
+        (`Assoc
+          [
+            ("room_id", `String room_id);
+            ("name", `String "Night Fox");
+            ("role", `String "npc");
+          ])
+  in
+  Alcotest.(check bool) "auto spawn 2 ok" true ok_spawn2;
+  let actor_id2 =
+    parse_json_exn spawn2_body |> Yojson.Safe.Util.member "actor_id" |> Yojson.Safe.Util.to_string
+  in
+  Alcotest.(check string) "collision adds suffix" "night-fox-2" actor_id2;
+
+  let ok_spawn3, spawn3_body =
+    dispatch_exn ctx ~name:"masc_trpg_actor_spawn"
+      ~args:(`Assoc [ ("room_id", `String room_id) ])
+  in
+  Alcotest.(check bool) "auto spawn 3 with defaults ok" true ok_spawn3;
+  let actor_id3 =
+    parse_json_exn spawn3_body |> Yojson.Safe.Util.member "actor_id" |> Yojson.Safe.Util.to_string
+  in
+  Alcotest.(check string) "default role seed is player" "player" actor_id3;
+  cleanup_dir base_dir
+
+let test_actor_spawn_profile_fields () =
+  let base_dir = make_temp_dir () in
+  let config = Room.default_config base_dir in
+  let _ = Room.init config ~agent_name:(Some "tester") in
+  let store = Trpg_store.make_sqlite ~base_dir in
+  let ctx : Tool_trpg.context =
+    { store; agent_name = "tester"; keeper_call = None; keeper_probe = None; dm_voice_emit = None }
+  in
+  let room_id = "room-actor-profile-fields" in
+  let actor_id = "pc-luna" in
+
+  let ok_spawn, spawn_body =
+    dispatch_exn ctx ~name:"masc_trpg_actor_spawn"
+      ~args:
+        (`Assoc
+          [
+            ("room_id", `String room_id);
+            ("actor_id", `String actor_id);
+            ("name", `String "Luna");
+            ("portrait", `String "https://example.com/luna.png");
+            ("background", `String "폐허 수색 전문가");
+            ("stats", `Assoc [ ("str", `Int 10); ("dex", `Int 16); ("wis", `Int 14) ]);
+          ])
+  in
+  Alcotest.(check bool) "spawn profile fields ok" true ok_spawn;
+  let spawn_json = parse_json_exn spawn_body in
+  let actor_state =
+    spawn_json |> Yojson.Safe.Util.member "state" |> Yojson.Safe.Util.member "party"
+    |> Yojson.Safe.Util.member actor_id
+  in
+  Alcotest.(check string)
+    "portrait preserved"
+    "https://example.com/luna.png"
+    (actor_state |> Yojson.Safe.Util.member "portrait" |> Yojson.Safe.Util.to_string);
+  Alcotest.(check string)
+    "background preserved"
+    "폐허 수색 전문가"
+    (actor_state |> Yojson.Safe.Util.member "background" |> Yojson.Safe.Util.to_string);
+  Alcotest.(check int)
+    "stats.dex preserved"
+    16
+    (actor_state |> Yojson.Safe.Util.member "stats" |> Yojson.Safe.Util.member "dex"
+   |> Yojson.Safe.Util.to_int);
+
+  let ok_update, update_body =
+    dispatch_exn ctx ~name:"masc_trpg_actor_update"
+      ~args:
+        (`Assoc
+          [
+            ("room_id", `String room_id);
+            ("actor_id", `String actor_id);
+            ("background", `String "폭풍 마법 학파 출신");
+            ("stats", `Assoc [ ("str", `Int 11); ("int", `Int 15) ]);
+          ])
+  in
+  Alcotest.(check bool) "update profile fields ok" true ok_update;
+  let actor_state_after =
+    parse_json_exn update_body |> Yojson.Safe.Util.member "state" |> Yojson.Safe.Util.member "party"
+    |> Yojson.Safe.Util.member actor_id
+  in
+  Alcotest.(check string)
+    "background updated"
+    "폭풍 마법 학파 출신"
+    (actor_state_after |> Yojson.Safe.Util.member "background" |> Yojson.Safe.Util.to_string);
+  Alcotest.(check int)
+    "stats.int updated"
+    15
+    (actor_state_after |> Yojson.Safe.Util.member "stats" |> Yojson.Safe.Util.member "int"
+   |> Yojson.Safe.Util.to_int);
+  cleanup_dir base_dir
+
 let test_actor_update_delete_flow () =
   let base_dir = make_temp_dir () in
   let config = Room.default_config base_dir in
@@ -3129,6 +3256,14 @@ let () =
             "spawn + claim + release flow"
             `Quick
             test_actor_spawn_claim_release_flow;
+          Alcotest.test_case
+            "auto actor_id generation on spawn"
+            `Quick
+            test_actor_spawn_auto_generates_actor_id;
+          Alcotest.test_case
+            "spawn/update profile fields"
+            `Quick
+            test_actor_spawn_profile_fields;
           Alcotest.test_case
             "update + delete flow"
             `Quick

--- a/viewer/index.html
+++ b/viewer/index.html
@@ -313,12 +313,20 @@
                     <div class="actor-admin-head">액터 관리 (현재 room)</div>
                     <div class="actor-admin-grid">
                         <label class="new-game-field">
-                            <span>Actor ID</span>
-                            <input id="actor-admin-id" type="text" maxlength="64" placeholder="warrior-1" />
+                            <span>Actor ID (선택)</span>
+                            <input id="actor-admin-id" type="text" maxlength="64" placeholder="비워두면 자동 생성 (예: night-fox)" />
                         </label>
                         <label class="new-game-field">
                             <span>이름</span>
                             <input id="actor-admin-name" type="text" maxlength="64" placeholder="그림자 전사" />
+                        </label>
+                        <label class="new-game-field">
+                            <span>초상화 URL</span>
+                            <input id="actor-admin-portrait" type="text" maxlength="240" placeholder="https://.../portrait.png" />
+                        </label>
+                        <label class="new-game-field actor-admin-field-wide">
+                            <span>배경</span>
+                            <input id="actor-admin-background" type="text" maxlength="240" placeholder="망명 기사 · 폐허 수색 전문가" />
                         </label>
                         <label class="new-game-field">
                             <span>역할</span>
@@ -327,6 +335,30 @@
                                 <option value="npc">npc</option>
                                 <option value="dm">dm</option>
                             </select>
+                        </label>
+                        <label class="new-game-field">
+                            <span>STR</span>
+                            <input id="actor-admin-str" type="number" min="0" step="1" placeholder="10" />
+                        </label>
+                        <label class="new-game-field">
+                            <span>DEX</span>
+                            <input id="actor-admin-dex" type="number" min="0" step="1" placeholder="10" />
+                        </label>
+                        <label class="new-game-field">
+                            <span>CON</span>
+                            <input id="actor-admin-con" type="number" min="0" step="1" placeholder="10" />
+                        </label>
+                        <label class="new-game-field">
+                            <span>INT</span>
+                            <input id="actor-admin-int" type="number" min="0" step="1" placeholder="10" />
+                        </label>
+                        <label class="new-game-field">
+                            <span>WIS</span>
+                            <input id="actor-admin-wis" type="number" min="0" step="1" placeholder="10" />
+                        </label>
+                        <label class="new-game-field">
+                            <span>CHA</span>
+                            <input id="actor-admin-cha" type="number" min="0" step="1" placeholder="10" />
                         </label>
                         <label class="new-game-field">
                             <span>Keeper</span>

--- a/viewer/src/mode/trpg_controls.rs
+++ b/viewer/src/mode/trpg_controls.rs
@@ -4,7 +4,7 @@
 //! All items are `#[cfg(target_arch = "wasm32")]` gated at the module level
 //! (the parent `mod trpg_controls` declaration carries the gate).
 
-use serde_json::{json, Value};
+use serde_json::{json, Map, Value};
 use std::collections::HashMap;
 use wasm_bindgen::prelude::*;
 use wasm_bindgen::JsCast;
@@ -40,6 +40,14 @@ pub(super) struct ActorAdminRow {
     actor_id: String,
     name: String,
     role: String,
+    portrait: String,
+    background: String,
+    str_score: Option<i32>,
+    dex_score: Option<i32>,
+    con_score: Option<i32>,
+    int_score: Option<i32>,
+    wis_score: Option<i32>,
+    cha_score: Option<i32>,
     hp: i32,
     max_hp: i32,
     keeper: String,
@@ -1740,6 +1748,27 @@ fn actor_admin_input_i64(doc: &web_sys::Document, id: &str) -> Option<i64> {
     }
 }
 
+fn actor_admin_collect_stats(doc: &web_sys::Document) -> Option<Value> {
+    let mut stats = Map::new();
+    for (key, input_id) in [
+        ("str", "actor-admin-str"),
+        ("dex", "actor-admin-dex"),
+        ("con", "actor-admin-con"),
+        ("int", "actor-admin-int"),
+        ("wis", "actor-admin-wis"),
+        ("cha", "actor-admin-cha"),
+    ] {
+        if let Some(v) = actor_admin_input_i64(doc, input_id) {
+            stats.insert(key.to_string(), Value::Number(v.max(0).into()));
+        }
+    }
+    if stats.is_empty() {
+        None
+    } else {
+        Some(Value::Object(stats))
+    }
+}
+
 async fn fetch_room_state_payload(room_id: &str) -> Result<Value, String> {
     let url = crate::config::build_masc_url(&format!("api/v1/trpg/state?room_id={}", room_id));
     let opts = web_sys::RequestInit::new();
@@ -1798,6 +1827,12 @@ fn parse_actor_admin_rows(state_root: &Value) -> Vec<ActorAdminRow> {
     let actor_control = parse_actor_control_map(state_root);
     let control_keeper =
         |actor_id: &str| -> String { actor_control.get(actor_id).cloned().unwrap_or_default() };
+    let read_stat = |stats: Option<&Map<String, Value>>, key: &str| -> Option<i32> {
+        stats
+            .and_then(|obj| obj.get(key))
+            .and_then(Value::as_i64)
+            .map(|v| v as i32)
+    };
 
     let mut rows = Vec::new();
     if let Some(characters) = state.get("characters").and_then(Value::as_array) {
@@ -1826,6 +1861,19 @@ fn parse_actor_admin_rows(state_root: &Value) -> Vec<ActorAdminRow> {
                 .unwrap_or("player")
                 .trim()
                 .to_string();
+            let portrait = ch
+                .get("portrait")
+                .and_then(Value::as_str)
+                .unwrap_or("")
+                .trim()
+                .to_string();
+            let background = ch
+                .get("background")
+                .and_then(Value::as_str)
+                .unwrap_or("")
+                .trim()
+                .to_string();
+            let stats = ch.get("stats").and_then(Value::as_object);
             let hp = ch.get("hp").and_then(Value::as_i64).unwrap_or(0) as i32;
             let max_hp = ch.get("max_hp").and_then(Value::as_i64).unwrap_or(0) as i32;
             let keeper = ch
@@ -1843,6 +1891,14 @@ fn parse_actor_admin_rows(state_root: &Value) -> Vec<ActorAdminRow> {
                 actor_id: actor_id.clone(),
                 name,
                 role,
+                portrait,
+                background,
+                str_score: read_stat(stats, "str"),
+                dex_score: read_stat(stats, "dex"),
+                con_score: read_stat(stats, "con"),
+                int_score: read_stat(stats, "int"),
+                wis_score: read_stat(stats, "wis"),
+                cha_score: read_stat(stats, "cha"),
                 hp,
                 max_hp,
                 keeper: final_keeper.clone(),
@@ -1869,6 +1925,19 @@ fn parse_actor_admin_rows(state_root: &Value) -> Vec<ActorAdminRow> {
                 .unwrap_or("player")
                 .trim()
                 .to_string();
+            let portrait = row
+                .get("portrait")
+                .and_then(Value::as_str)
+                .unwrap_or("")
+                .trim()
+                .to_string();
+            let background = row
+                .get("background")
+                .and_then(Value::as_str)
+                .unwrap_or("")
+                .trim()
+                .to_string();
+            let stats = row.get("stats").and_then(Value::as_object);
             let hp = row.get("hp").and_then(Value::as_i64).unwrap_or(0) as i32;
             let max_hp = row.get("max_hp").and_then(Value::as_i64).unwrap_or(0) as i32;
             let keeper = control_keeper(actor_id);
@@ -1876,6 +1945,14 @@ fn parse_actor_admin_rows(state_root: &Value) -> Vec<ActorAdminRow> {
                 actor_id: actor_id.to_string(),
                 name,
                 role,
+                portrait,
+                background,
+                str_score: read_stat(stats, "str"),
+                dex_score: read_stat(stats, "dex"),
+                con_score: read_stat(stats, "con"),
+                int_score: read_stat(stats, "int"),
+                wis_score: read_stat(stats, "wis"),
+                cha_score: read_stat(stats, "cha"),
                 hp,
                 max_hp,
                 keeper: keeper.clone(),
@@ -1906,10 +1983,19 @@ fn render_actor_admin_rows(doc: &web_sys::Document, rows: &[ActorAdminRow]) {
             } else {
                 "<span class=\"actor-claim-badge is-free\">비점유</span>".to_string()
             };
+            let str_score = row.str_score.map(|v| v.to_string()).unwrap_or_default();
+            let dex_score = row.dex_score.map(|v| v.to_string()).unwrap_or_default();
+            let con_score = row.con_score.map(|v| v.to_string()).unwrap_or_default();
+            let int_score = row.int_score.map(|v| v.to_string()).unwrap_or_default();
+            let wis_score = row.wis_score.map(|v| v.to_string()).unwrap_or_default();
+            let cha_score = row.cha_score.map(|v| v.to_string()).unwrap_or_default();
             format!(
                 concat!(
                     "<button class=\"actor-admin-row\" ",
                     "data-actor-id=\"{id}\" data-name=\"{name}\" data-role=\"{role}\" ",
+                    "data-portrait=\"{portrait}\" data-background=\"{background}\" ",
+                    "data-str=\"{str_score}\" data-dex=\"{dex_score}\" data-con=\"{con_score}\" ",
+                    "data-int=\"{int_score}\" data-wis=\"{wis_score}\" data-cha=\"{cha_score}\" ",
                     "data-keeper=\"{keeper}\" data-hp=\"{hp}\" data-max-hp=\"{max_hp}\" ",
                     "data-claimed=\"{claimed}\">",
                     "{id} · {role} · HP {hp}/{max_hp} {claim_badge}",
@@ -1918,6 +2004,14 @@ fn render_actor_admin_rows(doc: &web_sys::Document, rows: &[ActorAdminRow]) {
                 id = html_escape(&row.actor_id),
                 name = html_escape(&row.name),
                 role = html_escape(&row.role),
+                portrait = html_escape(&row.portrait),
+                background = html_escape(&row.background),
+                str_score = str_score,
+                dex_score = dex_score,
+                con_score = con_score,
+                int_score = int_score,
+                wis_score = wis_score,
+                cha_score = cha_score,
                 keeper = html_escape(&row.keeper),
                 hp = row.hp,
                 max_hp = row.max_hp,
@@ -1946,6 +2040,14 @@ fn bind_actor_admin_row_clicks(doc: &web_sys::Document) {
         let id = el.get_attribute("data-actor-id").unwrap_or_default();
         let name = el.get_attribute("data-name").unwrap_or_default();
         let role = el.get_attribute("data-role").unwrap_or_default();
+        let portrait = el.get_attribute("data-portrait").unwrap_or_default();
+        let background = el.get_attribute("data-background").unwrap_or_default();
+        let str_score = el.get_attribute("data-str").unwrap_or_default();
+        let dex_score = el.get_attribute("data-dex").unwrap_or_default();
+        let con_score = el.get_attribute("data-con").unwrap_or_default();
+        let int_score = el.get_attribute("data-int").unwrap_or_default();
+        let wis_score = el.get_attribute("data-wis").unwrap_or_default();
+        let cha_score = el.get_attribute("data-cha").unwrap_or_default();
         let keeper = el.get_attribute("data-keeper").unwrap_or_default();
         let hp = el.get_attribute("data-hp").unwrap_or_default();
         let max_hp = el.get_attribute("data-max-hp").unwrap_or_default();
@@ -1966,6 +2068,18 @@ fn bind_actor_admin_row_clicks(doc: &web_sys::Document) {
             {
                 input.set_value(&name);
             }
+            if let Some(input) = doc
+                .get_element_by_id("actor-admin-portrait")
+                .and_then(|el| el.dyn_into::<web_sys::HtmlInputElement>().ok())
+            {
+                input.set_value(&portrait);
+            }
+            if let Some(input) = doc
+                .get_element_by_id("actor-admin-background")
+                .and_then(|el| el.dyn_into::<web_sys::HtmlInputElement>().ok())
+            {
+                input.set_value(&background);
+            }
             if let Some(select) = doc
                 .get_element_by_id("actor-admin-role")
                 .and_then(|el| el.dyn_into::<web_sys::HtmlSelectElement>().ok())
@@ -1973,6 +2087,42 @@ fn bind_actor_admin_row_clicks(doc: &web_sys::Document) {
                 if !role.trim().is_empty() {
                     select.set_value(&role);
                 }
+            }
+            if let Some(input) = doc
+                .get_element_by_id("actor-admin-str")
+                .and_then(|el| el.dyn_into::<web_sys::HtmlInputElement>().ok())
+            {
+                input.set_value(&str_score);
+            }
+            if let Some(input) = doc
+                .get_element_by_id("actor-admin-dex")
+                .and_then(|el| el.dyn_into::<web_sys::HtmlInputElement>().ok())
+            {
+                input.set_value(&dex_score);
+            }
+            if let Some(input) = doc
+                .get_element_by_id("actor-admin-con")
+                .and_then(|el| el.dyn_into::<web_sys::HtmlInputElement>().ok())
+            {
+                input.set_value(&con_score);
+            }
+            if let Some(input) = doc
+                .get_element_by_id("actor-admin-int")
+                .and_then(|el| el.dyn_into::<web_sys::HtmlInputElement>().ok())
+            {
+                input.set_value(&int_score);
+            }
+            if let Some(input) = doc
+                .get_element_by_id("actor-admin-wis")
+                .and_then(|el| el.dyn_into::<web_sys::HtmlInputElement>().ok())
+            {
+                input.set_value(&wis_score);
+            }
+            if let Some(input) = doc
+                .get_element_by_id("actor-admin-cha")
+                .and_then(|el| el.dyn_into::<web_sys::HtmlInputElement>().ok())
+            {
+                input.set_value(&cha_score);
             }
             if let Some(input) = doc
                 .get_element_by_id("actor-admin-keeper")
@@ -2298,10 +2448,7 @@ async fn run_new_game_preflight(doc: &web_sys::Document) -> Result<(), String> {
 
 async fn actor_admin_spawn(doc: &web_sys::Document) -> Result<String, String> {
     let room_id = actor_admin_room_id();
-    let actor_id = actor_admin_input_value(doc, "actor-admin-id");
-    if actor_id.is_empty() {
-        return Err("Actor ID를 입력하세요.".to_string());
-    }
+    let actor_id_input = actor_admin_input_value(doc, "actor-admin-id");
     let role = {
         let role_raw = actor_admin_select_value(doc, "actor-admin-role");
         if role_raw.is_empty() {
@@ -2311,22 +2458,61 @@ async fn actor_admin_spawn(doc: &web_sys::Document) -> Result<String, String> {
         }
     };
     let name = actor_admin_input_value(doc, "actor-admin-name");
+    let portrait = actor_admin_input_value(doc, "actor-admin-portrait");
+    let background = actor_admin_input_value(doc, "actor-admin-background");
+    let stats = actor_admin_collect_stats(doc);
     let keeper = actor_admin_input_value(doc, "actor-admin-keeper");
     let max_hp = actor_admin_input_i64(doc, "actor-admin-max-hp").unwrap_or(20);
     let hp = actor_admin_input_i64(doc, "actor-admin-hp").unwrap_or(max_hp);
 
     let mut args = json!({
         "room_id": room_id,
-        "actor_id": actor_id,
         "role": role,
         "hp": hp.max(0),
         "max_hp": max_hp.max(1),
         "alive": hp > 0
     });
+    if !actor_id_input.is_empty() {
+        args["actor_id"] = Value::String(actor_id_input.clone());
+    }
     if !name.is_empty() {
         args["name"] = Value::String(name);
     }
-    mcp_tool_call("trpg.actor.spawn", args).await?;
+    if !portrait.is_empty() {
+        args["portrait"] = Value::String(portrait);
+    }
+    if !background.is_empty() {
+        args["background"] = Value::String(background);
+    }
+    if let Some(stats) = stats {
+        args["stats"] = stats;
+    }
+    let spawn_payload = mcp_tool_call("trpg.actor.spawn", args).await?;
+    let actor_id = spawn_payload
+        .get("actor_id")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|id| !id.is_empty())
+        .map(ToString::to_string)
+        .or_else(|| {
+            if actor_id_input.is_empty() {
+                None
+            } else {
+                Some(actor_id_input.clone())
+            }
+        })
+        .ok_or_else(|| "액터 생성 응답에서 actor_id를 확인하지 못했습니다.".to_string())?;
+    if let Some(input) = doc
+        .get_element_by_id("actor-admin-id")
+        .and_then(|el| el.dyn_into::<web_sys::HtmlInputElement>().ok())
+    {
+        if actor_id_input.is_empty() {
+            // Keep quick-create flow frictionless: don't leave generated IDs in the input.
+            input.set_value("");
+        } else {
+            input.set_value(&actor_id);
+        }
+    }
     if !keeper.is_empty() {
         if let Err(err) = mcp_tool_call(
             "trpg.actor.claim",
@@ -2349,9 +2535,12 @@ async fn actor_admin_update(doc: &web_sys::Document) -> Result<String, String> {
     let room_id = actor_admin_room_id();
     let actor_id = actor_admin_input_value(doc, "actor-admin-id");
     if actor_id.is_empty() {
-        return Err("수정할 Actor ID를 입력하세요.".to_string());
+        return Err("수정할 Actor ID를 입력하세요. 목록에서 액터를 클릭하면 자동 입력됩니다.".to_string());
     }
     let name = actor_admin_input_value(doc, "actor-admin-name");
+    let portrait = actor_admin_input_value(doc, "actor-admin-portrait");
+    let background = actor_admin_input_value(doc, "actor-admin-background");
+    let stats = actor_admin_collect_stats(doc);
     let role = actor_admin_select_value(doc, "actor-admin-role");
     let keeper = actor_admin_input_value(doc, "actor-admin-keeper");
     let hp = actor_admin_input_i64(doc, "actor-admin-hp");
@@ -2368,6 +2557,18 @@ async fn actor_admin_update(doc: &web_sys::Document) -> Result<String, String> {
     }
     if !role.is_empty() {
         args["role"] = Value::String(role);
+        has_patch = true;
+    }
+    if !portrait.is_empty() {
+        args["portrait"] = Value::String(portrait);
+        has_patch = true;
+    }
+    if !background.is_empty() {
+        args["background"] = Value::String(background);
+        has_patch = true;
+    }
+    if let Some(stats) = stats {
+        args["stats"] = stats;
         has_patch = true;
     }
     if let Some(hp) = hp {
@@ -2408,7 +2609,10 @@ async fn actor_admin_release(doc: &web_sys::Document) -> Result<String, String> 
     let room_id = actor_admin_room_id();
     let actor_id = actor_admin_input_value(doc, "actor-admin-id");
     if actor_id.is_empty() {
-        return Err("점유 해제할 Actor ID를 입력하세요.".to_string());
+        return Err(
+            "점유 해제할 Actor ID를 입력하세요. 목록에서 액터를 클릭하면 자동 입력됩니다."
+                .to_string(),
+        );
     }
 
     let keeper = actor_admin_input_value(doc, "actor-admin-keeper");
@@ -2449,7 +2653,7 @@ async fn actor_admin_delete(doc: &web_sys::Document) -> Result<String, String> {
     let room_id = actor_admin_room_id();
     let actor_id = actor_admin_input_value(doc, "actor-admin-id");
     if actor_id.is_empty() {
-        return Err("삭제할 Actor ID를 입력하세요.".to_string());
+        return Err("삭제할 Actor ID를 입력하세요. 목록에서 액터를 클릭하면 자동 입력됩니다.".to_string());
     }
     let reason = actor_admin_input_value(doc, "actor-admin-delete-reason");
     let mut args = json!({


### PR DESCRIPTION
## Summary
- make trpg.actor.spawn accept optional actor_id and auto-generate when omitted
- add profile fields to actor spawn/update: portrait, background, stats(object)
- improve Viewer actor admin UX for quick create/edit (optional actor_id + profile inputs)

## Validation
- dune build --root .
- dune exec --root . ./test/test_tool_trpg_coverage.exe (50 tests)
- cd viewer && cargo check