### PR TITLE
Walph 안정화 1차: 에러 격리/상태 가시성/루프 가드

### DIFF
--- a/lib/room.ml
+++ b/lib/room.ml
@@ -1184,8 +1184,7 @@ let claim_next_r config ~agent_name ?(exclude_task_ids=[]) () =
         | Todo -> true
         | _ -> false
       ) sorted in
-      let excluded = List.filter (fun task_id -> task_id <> "") exclude_task_ids in
-      let eligible = List.filter (fun t -> not (List.mem t.id excluded)) unclaimed in
+      let eligible = List.filter (fun t -> not (List.mem t.id exclude_task_ids)) unclaimed in
 
       match unclaimed, eligible with
       | [], _ ->

--- a/lib/room.ml
+++ b/lib/room.ml
@@ -1126,8 +1126,21 @@ let cancel_task_r config ~agent_name ~task_id ~reason : string Types.masc_result
       with e -> Error (Types.IoError (Printexc.to_string e))
     )
 
-(** Claim next highest priority unclaimed task *)
-let claim_next config ~agent_name =
+(** Structured result for claim_next_r (avoids brittle string parsing). *)
+type claim_next_result =
+  | Claim_next_claimed of {
+      task_id : string;
+      title : string;
+      priority : int;
+      message : string;
+    }
+  | Claim_next_no_unclaimed
+  | Claim_next_no_eligible of { excluded_count : int }
+  | Claim_next_error of string
+
+(** Claim next highest priority unclaimed task.
+    Optional [exclude_task_ids] prevents re-claiming known bad tasks in the same loop run. *)
+let claim_next_r config ~agent_name ?(exclude_task_ids=[]) () =
   ensure_initialized config;
 
   let backlog_path = Filename.concat (tasks_dir config) ".backlog" in
@@ -1171,11 +1184,15 @@ let claim_next config ~agent_name =
         | Todo -> true
         | _ -> false
       ) sorted in
+      let excluded = List.filter (fun task_id -> task_id <> "") exclude_task_ids in
+      let eligible = List.filter (fun t -> not (List.mem t.id excluded)) unclaimed in
 
-      match unclaimed with
-      | [] ->
-          "📋 No unclaimed tasks available"
-      | task :: _ ->
+      match unclaimed, eligible with
+      | [], _ ->
+          Claim_next_no_unclaimed
+      | _ :: _, [] ->
+          Claim_next_no_eligible { excluded_count = List.length exclude_task_ids }
+      | _ :: _, task :: _ ->
           (* Claim this task *)
           let new_tasks = List.map (fun t ->
             if t.id = task.id then
@@ -1213,10 +1230,24 @@ let claim_next config ~agent_name =
             "{\"type\":\"task_claim_next\",\"agent\":\"%s\",\"task\":\"%s\",\"priority\":%d,\"ts\":\"%s\"}"
             agent_name task.id task.priority (now_iso ()));
 
-          Printf.sprintf "✅ %s auto-claimed [P%d] %s: %s" agent_name task.priority task.id task.title
+          Claim_next_claimed {
+            task_id = task.id;
+            title = task.title;
+            priority = task.priority;
+            message =
+              Printf.sprintf "✅ %s auto-claimed [P%d] %s: %s" agent_name task.priority task.id task.title;
+          }
     with e ->
-      Printf.sprintf "❌ Error: %s" (Printexc.to_string e)
+      Claim_next_error (Printexc.to_string e)
   )
+
+(** Claim next highest priority unclaimed task (legacy string API). *)
+let claim_next config ~agent_name =
+  match claim_next_r config ~agent_name () with
+  | Claim_next_claimed { message; _ } -> message
+  | Claim_next_no_unclaimed -> "📋 No unclaimed tasks available"
+  | Claim_next_no_eligible _ -> "📋 No unclaimed tasks available"
+  | Claim_next_error e -> Printf.sprintf "❌ Error: %s" e
 
 (* ======== Walph Control System ======== *)
 
@@ -1432,16 +1463,38 @@ let walph_loop config ~agent_name ?(preset="drain") ?(max_iterations=10) ?target
               (match target with Some t -> " --target " ^ t | None -> "")
               max_iterations) in
 
-          (* UTF-8 safe prefix check: 📋=4bytes, ✅=3bytes, ❌=3bytes *)
-          let starts_with prefix s =
-            let plen = String.length prefix in
-            String.length s >= plen && String.sub s 0 plen = prefix
-          in
+	          let failed_task_ids : (string, unit) Hashtbl.t = Hashtbl.create 16 in
+	          let failed_task_id_list () =
+	            Hashtbl.fold (fun task_id () acc -> task_id :: acc) failed_task_ids []
+	          in
+	          let mark_failed task_id =
+	            Hashtbl.replace failed_task_ids task_id ()
+	          in
+	          let release_on_error ~task_id ~error =
+	            let release_result =
+	              transition_task_r config ~agent_name ~task_id ~action:"release" ()
+	            in
+	            let release_status =
+	              match release_result with
+	              | Ok _ -> "ok"
+	              | Error e ->
+	                  Printf.eprintf "[room] walph release failed: %s\n%!"
+	                    (Types.masc_error_to_string e);
+	                  "error"
+	            in
+	            log_event config
+	              (Printf.sprintf
+	                 "{\"type\":\"walph_task_released\",\"agent\":\"%s\",\"task\":\"%s\",\"error\":%s,\"release\":\"%s\",\"ts\":\"%s\"}"
+	                 agent_name task_id
+	                 (Yojson.Safe.to_string (`String error))
+	                 release_status
+	                 (now_iso ()))
+	          in
 
-          (* Run the loop *)
-          let rec loop () =
-            (* Check control state before each iteration *)
-            if not (walph_should_continue config) then begin
+	          (* Run the loop *)
+	          let rec loop () =
+	            (* Check control state before each iteration *)
+	            if not (walph_should_continue config) then begin
               stop_reason := if walph_state.stop_requested then "stop requested" else "paused indefinitely";
               ()
             end else begin
@@ -1454,35 +1507,60 @@ let walph_loop config ~agent_name ?(preset="drain") ?(max_iterations=10) ?target
                   walph_state.iterations <- walph_state.iterations + 1;
                   false
                 end
-              ) in
-              if should_stop then ()
-              else begin
-                (* Try to claim next task *)
-                let claim_result = claim_next config ~agent_name in
-
-                if starts_with "📋" claim_result || starts_with "No unclaimed" claim_result then begin
-                  (* No more unclaimed tasks - drain complete *)
-                  stop_reason := "backlog drained";
-                  ()
-                end else if starts_with "✅" claim_result then begin
-                  with_walph_lock walph_state (fun () ->
-                    walph_state.completed <- walph_state.completed + 1
-                  );
-
-                  (* Broadcast progress *)
-                  let _ = broadcast config ~from_agent:agent_name
-                    ~content:(Printf.sprintf "📊 @walph Iteration %d: %s" walph_state.iterations claim_result) in
-
-                  (* Continue loop *)
-                  loop ()
-                end else begin
-                  (* Error or unexpected result *)
-                  stop_reason := Printf.sprintf "claim error: %s" claim_result;
-                  ()
-                end
-              end
-            end
-          in
+	              ) in
+	              if should_stop then ()
+	              else begin
+	                (* Try to claim next task *)
+	                let claim_result =
+	                  claim_next_r config ~agent_name
+	                    ~exclude_task_ids:(failed_task_id_list ()) ()
+	                in
+	                match claim_result with
+	                | Claim_next_no_unclaimed ->
+	                    stop_reason := "backlog drained"
+	                | Claim_next_no_eligible _ ->
+	                    stop_reason := "no eligible tasks (failed_this_run)"
+	                | Claim_next_error err ->
+	                    stop_reason := Printf.sprintf "claim error: %s" err
+	                | Claim_next_claimed { task_id; message = claim_message; _ } ->
+	                    if preset = "drain" then begin
+	                      let done_result =
+	                        transition_task_r config ~agent_name ~task_id ~action:"done"
+	                          ~notes:"walph drain mode auto-complete" ()
+	                      in
+	                      match done_result with
+	                      | Ok _ ->
+	                          with_walph_lock walph_state (fun () ->
+	                            walph_state.completed <- walph_state.completed + 1
+	                          );
+	                          log_event config
+	                            (Printf.sprintf
+	                               "{\"type\":\"walph_task_done\",\"agent\":\"%s\",\"task\":\"%s\",\"preset\":\"%s\",\"ts\":\"%s\"}"
+	                               agent_name task_id preset (now_iso ()));
+	                          let _ = broadcast config ~from_agent:agent_name
+	                            ~content:(Printf.sprintf "📊 @walph Iteration %d: %s ✅" walph_state.iterations claim_message) in
+	                          loop ()
+	                      | Error err ->
+	                          let err_msg = Types.masc_error_to_string err in
+	                          mark_failed task_id;
+	                          release_on_error ~task_id ~error:err_msg;
+	                          let _ = broadcast config ~from_agent:agent_name
+	                            ~content:(Printf.sprintf "⚠️ @walph done error on %s: %s (released)" task_id err_msg) in
+	                          loop ()
+	                    end else begin
+	                      (* Sync walph does not execute LLM chains; release safely instead of leaving claim stuck. *)
+	                      let err_msg =
+	                        Printf.sprintf "preset %s requires eio walph runner" preset
+	                      in
+	                      mark_failed task_id;
+	                      release_on_error ~task_id ~error:err_msg;
+	                      let _ = broadcast config ~from_agent:agent_name
+	                        ~content:(Printf.sprintf "⚠️ @walph unsupported preset in sync loop for %s: %s (released)" task_id err_msg) in
+	                      loop ()
+	                    end
+	              end
+	            end
+	          in
 
           loop ();
 

--- a/lib/room_walph_eio.ml
+++ b/lib/room_walph_eio.ml
@@ -25,6 +25,16 @@ type walph_state = {
   mutable current_preset : string;
   mutable iterations : int;
   mutable completed : int;
+  mutable claimed : int;
+  mutable released_on_error : int;
+  mutable errors : int;
+  mutable consecutive_errors : int;
+  mutable max_consecutive_errors : int;
+  mutable error_backoff_sec : int;
+  mutable last_error : string option;
+  mutable last_task_id : string option;
+  mutable started_at : string option;
+  mutable last_stop_reason : string option;
   mutex : Eio.Mutex.t;        (** Eio-native mutex (fiber-friendly) *)
   cond : Eio.Condition.t;     (** Eio-native condition variable *)
 }
@@ -68,6 +78,9 @@ let get_walph_state config ~agent_name =
             let s = {
               running = false; paused = false; stop_requested = false;
               current_preset = ""; iterations = 0; completed = 0;
+              claimed = 0; released_on_error = 0; errors = 0; consecutive_errors = 0;
+              max_consecutive_errors = 5; error_backoff_sec = 2;
+              last_error = None; last_task_id = None; started_at = None; last_stop_reason = None;
               mutex = Eio.Mutex.create ();
               cond = Eio.Condition.create ();
             } in
@@ -120,6 +133,39 @@ let list_walph_states config =
 let with_walph_lock state f =
   Eio.Mutex.use_rw ~protect:true state.mutex f
 
+(** JSON status payload for a single walph agent. *)
+let walph_status_json config ~agent_name =
+  match get_walph_state config ~agent_name with
+  | Error msg ->
+      `Assoc [
+        ("ok", `Bool false);
+        ("agent", `String agent_name);
+        ("error", `String msg);
+      ]
+  | Ok state ->
+      with_walph_lock state (fun () ->
+        `Assoc [
+          ("ok", `Bool true);
+          ("agent", `String agent_name);
+          ("running", `Bool state.running);
+          ("paused", `Bool state.paused);
+          ("stop_requested", `Bool state.stop_requested);
+          ("preset", `String state.current_preset);
+          ("iterations", `Int state.iterations);
+          ("claimed", `Int state.claimed);
+          ("completed", `Int state.completed);
+          ("released_on_error", `Int state.released_on_error);
+          ("errors", `Int state.errors);
+          ("consecutive_errors", `Int state.consecutive_errors);
+          ("max_consecutive_errors", `Int state.max_consecutive_errors);
+          ("error_backoff_sec", `Int state.error_backoff_sec);
+          ("last_task_id", Option.fold ~none:`Null ~some:(fun s -> `String s) state.last_task_id);
+          ("last_error", Option.fold ~none:`Null ~some:(fun s -> `String s) state.last_error);
+          ("started_at", Option.fold ~none:`Null ~some:(fun s -> `String s) state.started_at);
+          ("last_stop_reason", Option.fold ~none:`Null ~some:(fun s -> `String s) state.last_stop_reason);
+        ]
+      )
+
 (** {1 Control Commands} *)
 
 (** Handle @walph control command (Eio-native, fiber-safe)
@@ -162,8 +208,10 @@ let walph_control config ~from_agent ~command ~args ?(target_agent=None) () =
           "ℹ️ @walph is not currently running"
     | "STATUS" ->
         if state.running then
-          Printf.sprintf "📊 @walph STATUS: %s (iter: %d, done: %d, paused: %b)"
-            state.current_preset state.iterations state.completed state.paused
+          Printf.sprintf
+            "📊 @walph STATUS: %s (iter: %d, claimed: %d, done: %d, released: %d, errs: %d/%d, paused: %b)"
+            state.current_preset state.iterations state.claimed state.completed
+            state.released_on_error state.consecutive_errors state.max_consecutive_errors state.paused
         else
           "ℹ️ @walph is idle (use @walph START <preset> to begin)"
     | "START" ->
@@ -227,7 +275,9 @@ let get_chain_id_for_preset = function
     @param max_iterations Maximum iterations before forced stop
     @param target Target file/directory for preset
     @return Status string with loop results *)
-let walph_loop config ~net ~clock ~agent_name ?(preset="drain") ?(max_iterations=10) ?target () =
+let walph_loop config ~net ~clock ~agent_name
+    ?(preset="drain") ?(max_iterations=10) ?target
+    ?(max_consecutive_errors=5) ?(error_backoff_sec=2) () =
   Room.ensure_initialized config;
 
   (* Get Walph state for this specific agent *)
@@ -247,6 +297,16 @@ let walph_loop config ~net ~clock ~agent_name ?(preset="drain") ?(max_iterations
       walph_state.current_preset <- preset;
       walph_state.iterations <- 0;
       walph_state.completed <- 0;
+      walph_state.claimed <- 0;
+      walph_state.released_on_error <- 0;
+      walph_state.errors <- 0;
+      walph_state.consecutive_errors <- 0;
+      walph_state.max_consecutive_errors <- max 1 max_consecutive_errors;
+      walph_state.error_backoff_sec <- max 0 error_backoff_sec;
+      walph_state.last_error <- None;
+      walph_state.last_task_id <- None;
+      walph_state.started_at <- Some (Types.now_iso ());
+      walph_state.last_stop_reason <- None;
       Ok ()
     end
   ) in
@@ -255,14 +315,72 @@ let walph_loop config ~net ~clock ~agent_name ?(preset="drain") ?(max_iterations
   | Error msg ->
       let _ = Room.broadcast config ~from_agent:"walph" ~content:msg in
       msg
-  | Ok () ->
-      (* Use Fun.protect to ensure running <- false even on exceptions (zombie prevention) *)
-      let stop_reason = ref "" in
+	  | Ok () ->
+	      (* Use Fun.protect to ensure running <- false even on exceptions (zombie prevention) *)
+	      let stop_reason = ref "" in
+	      let failed_task_ids : (string, unit) Hashtbl.t = Hashtbl.create 32 in
+	      let failed_task_id_list () =
+	        Hashtbl.fold (fun task_id () acc -> task_id :: acc) failed_task_ids []
+	      in
+	      let mark_failed task_id =
+	        if task_id <> "" then Hashtbl.replace failed_task_ids task_id ()
+	      in
+	      let note_claim ~task_id =
+	        with_walph_lock walph_state (fun () ->
+	          walph_state.claimed <- walph_state.claimed + 1;
+	          walph_state.last_task_id <- Some task_id
+	        )
+	      in
+	      let note_success ~task_id =
+	        with_walph_lock walph_state (fun () ->
+	          walph_state.completed <- walph_state.completed + 1;
+	          walph_state.consecutive_errors <- 0;
+	          walph_state.last_task_id <- Some task_id
+	        )
+	      in
+	      let note_error ?task_id err_msg =
+	        with_walph_lock walph_state (fun () ->
+	          walph_state.errors <- walph_state.errors + 1;
+	          walph_state.consecutive_errors <- walph_state.consecutive_errors + 1;
+	          walph_state.last_error <- Some err_msg;
+	          walph_state.last_task_id <- task_id;
+	          walph_state.consecutive_errors >= walph_state.max_consecutive_errors
+	        )
+	      in
+	      let release_claim ~task_id =
+	        match Room.transition_task_r config ~agent_name ~task_id ~action:"release" () with
+	        | Ok _ ->
+	            with_walph_lock walph_state (fun () ->
+	              walph_state.released_on_error <- walph_state.released_on_error + 1
+	            );
+	            "ok"
+	        | Error e ->
+	            let release_err = Types.masc_error_to_string e in
+	            Room.log_event config (Printf.sprintf
+	              "{\"type\":\"walph_release_error\",\"agent\":\"%s\",\"task\":\"%s\",\"error\":%s,\"ts\":\"%s\"}"
+	              agent_name task_id
+	              (Yojson.Safe.to_string (`String release_err))
+	              (Types.now_iso ()));
+	            "error"
+	      in
+	      let log_loop_error ?task_id ~error ~release_status () =
+	        Room.log_event config (Printf.sprintf
+	          "{\"type\":\"walph_loop_error\",\"agent\":\"%s\",\"preset\":\"%s\",\"task\":%s,\"error\":%s,\"release\":\"%s\",\"ts\":\"%s\"}"
+	          agent_name preset
+	          (match task_id with Some tid -> Yojson.Safe.to_string (`String tid) | None -> "null")
+	          (Yojson.Safe.to_string (`String error))
+	          release_status
+	          (Types.now_iso ()))
+	      in
+	      let maybe_backoff () =
+	        if walph_state.error_backoff_sec > 0 then
+	          Eio.Time.sleep clock (float_of_int walph_state.error_backoff_sec)
+	      in
 
-      Common.protect ~module_name:"room_walph_eio" ~finally_label:"finalizer"
-        ~finally:(fun () ->
-          (* Always reset running state, even on exception *)
-          with_walph_lock walph_state (fun () ->
+	      Common.protect ~module_name:"room_walph_eio" ~finally_label:"finalizer"
+	        ~finally:(fun () ->
+	          (* Always reset running state, even on exception *)
+	          with_walph_lock walph_state (fun () ->
             walph_state.running <- false
           ))
         (fun () ->
@@ -272,17 +390,11 @@ let walph_loop config ~net ~clock ~agent_name ?(preset="drain") ?(max_iterations
               (match target with Some t -> " --target " ^ t | None -> "")
               max_iterations) in
 
-          (* UTF-8 safe prefix check: 📋=4bytes, ✅=3bytes, ❌=3bytes *)
-          let starts_with prefix s =
-            let plen = String.length prefix in
-            String.length s >= plen && String.sub s 0 plen = prefix
-          in
-
-          (* Run the loop *)
-          let rec loop () =
-            (* Check control state before each iteration *)
-            if not (walph_should_continue config ~agent_name) then begin
-              stop_reason := if walph_state.stop_requested then "stop requested" else "paused indefinitely";
+	          (* Run the loop *)
+	          let rec loop () =
+	            (* Check control state before each iteration *)
+	            if not (walph_should_continue config ~agent_name) then begin
+	              stop_reason := if walph_state.stop_requested then "stop requested" else "paused indefinitely";
               ()
             end else begin
               (* Check max iterations with lock *)
@@ -294,118 +406,138 @@ let walph_loop config ~net ~clock ~agent_name ?(preset="drain") ?(max_iterations
                   walph_state.iterations <- walph_state.iterations + 1;
                   false
                 end
-              ) in
-              if should_stop then ()
-              else begin
-                (* Try to claim next task *)
-                let claim_result = Room.claim_next config ~agent_name in
+	              ) in
+	              if should_stop then ()
+	              else begin
+	                (* Try to claim next task *)
+	                let claim_result =
+	                  Room.claim_next_r config ~agent_name
+	                    ~exclude_task_ids:(failed_task_id_list ()) ()
+	                in
+	                match claim_result with
+	                | Room.Claim_next_no_unclaimed ->
+	                    stop_reason := "backlog drained"
+	                | Room.Claim_next_no_eligible _ ->
+	                    stop_reason := "no eligible tasks (failed_this_run)"
+	                | Room.Claim_next_error err_msg ->
+	                    let cutoff = note_error err_msg in
+	                    log_loop_error ~error:err_msg ~release_status:"n/a" ();
+	                    let _ = Room.broadcast config ~from_agent:agent_name
+	                      ~content:(Printf.sprintf "⚠️ @walph claim error: %s" err_msg) in
+	                    if cutoff then
+	                      stop_reason := Printf.sprintf "max_consecutive_errors reached (%d)" walph_state.max_consecutive_errors
+	                    else begin
+	                      maybe_backoff ();
+	                      loop ()
+	                    end
+	                | Room.Claim_next_claimed { task_id; message = claim_message; title = task_title; _ } ->
+	                    note_claim ~task_id;
 
-                if starts_with "📋" claim_result || starts_with "No unclaimed" claim_result then begin
-                  (* No more unclaimed tasks - drain complete *)
-                  stop_reason := "backlog drained";
-                  ()
-                end else if starts_with "✅" claim_result then begin
-                  (* Extract task ID from claim result.
-                     Format: "✅ agent auto-claimed [P3] task-XXX: Title" *)
-                  let task_id =
-                    try
-                      let re = Str.regexp {|\(task-[0-9]+\)|} in
-                      if Str.string_match re claim_result 0 then
-                        Some (Str.matched_group 1 claim_result)
-                      else if Str.search_forward re claim_result 0 >= 0 then
-                        Some (Str.matched_group 1 claim_result)
-                      else None
-                    with Not_found | Invalid_argument _ -> None
-                  in
+	                    (* Execute chain if preset has one (not drain) *)
+	                    let chain_id = get_chain_id_for_preset preset in
+	                    let chain_result =
+	                      match chain_id with
+	                      | None ->
+	                        (* Drain mode: no chain, just claim/done *)
+	                        Ok "drain mode - no chain"
+	                      | Some cid ->
+	                        (* Build goal from task info and preset *)
+	                        let task_desc =
+	                          let tasks = Room.get_tasks_raw config in
+	                          match List.find_opt (fun (t : Types.task) -> t.id = task_id) tasks with
+	                          | Some t -> t.description
+	                          | None -> ""
+	                        in
+	                        let goal = match preset with
+	                          | "coverage" ->
+	                              Printf.sprintf "Improve test coverage for: %s. %s. Add comprehensive tests with edge cases." task_title task_desc
+	                          | "refactor" ->
+	                              Printf.sprintf "Refactor the following: %s. %s. Improve code quality, reduce complexity, follow best practices." task_title task_desc
+	                          | "docs" ->
+	                              Printf.sprintf "Create or improve documentation for: %s. %s. Include examples and clear explanations." task_title task_desc
+	                          | "review" ->
+	                              Printf.sprintf "Review PR: %s. %s. Check code quality, security, test coverage." task_title task_desc
+	                          | "figma" ->
+	                              if String.length (String.trim task_desc) > 0 then task_desc
+	                              else
+	                                Printf.sprintf
+	                                  "Vision-first Figma task: %s. Provide figma_dsl JSON in the task description."
+	                                  task_title
+	                          | _ ->
+	                              Printf.sprintf "Complete this task: %s. %s" task_title task_desc
+	                        in
+	                        let _ = Room.broadcast config ~from_agent:agent_name
+	                          ~content:(Printf.sprintf "🔗 @walph executing '%s' for '%s'..." cid task_title) in
+	                        (* Direct LLM call — no llm-mcp dependency *)
+	                        ignore (net, clock);  (* Previously used for llm-mcp HTTP call *)
+	                        try
+	                          let response = Llm_direct.dispatch
+	                            ~tool_name:"glm"
+	                            ~model:Env_config.Llm.default_model
+	                            ~prompt:goal
+	                            ~timeout_sec:60
+	                            ~max_chars:4000
+	                            ()
+	                          in
+	                          if response = "" then Error "Empty LLM response"
+	                          else Ok response
+	                        with exn -> Error (Printexc.to_string exn)
+	                    in
 
-                  (* Execute chain if preset has one (not drain) *)
-                  let chain_id = get_chain_id_for_preset preset in
-                  let chain_result =
-                    match chain_id with
-                    | None ->
-                      (* Drain mode: no chain, just claim/done *)
-                      Ok "drain mode - no chain"
-                    | Some cid ->
-                      (* Build goal from task info and preset *)
-                      let task_title, task_desc = match task_id with
-                        | Some tid ->
-                            let tasks = Room.get_tasks_raw config in
-                            (match List.find_opt (fun (t : Types.task) -> t.id = tid) tasks with
-                             | Some t -> (t.title, t.description)
-                             | None -> (tid, ""))
-                        | None -> ("unknown task", "")
-                      in
-                      let goal = match preset with
-                        | "coverage" ->
-                            Printf.sprintf "Improve test coverage for: %s. %s. Add comprehensive tests with edge cases." task_title task_desc
-                        | "refactor" ->
-                            Printf.sprintf "Refactor the following: %s. %s. Improve code quality, reduce complexity, follow best practices." task_title task_desc
-                        | "docs" ->
-                            Printf.sprintf "Create or improve documentation for: %s. %s. Include examples and clear explanations." task_title task_desc
-                        | "review" ->
-                            Printf.sprintf "Review PR: %s. %s. Check code quality, security, test coverage." task_title task_desc
-                        | "figma" ->
-                            if String.length (String.trim task_desc) > 0 then task_desc
-                            else
-                              Printf.sprintf
-                                "Vision-first Figma task: %s. Provide figma_dsl JSON in the task description."
-                                task_title
-                        | _ ->
-                            Printf.sprintf "Complete this task: %s. %s" task_title task_desc
-                      in
-                      let _ = Room.broadcast config ~from_agent:agent_name
-                        ~content:(Printf.sprintf "🔗 @walph executing '%s' for '%s'..." cid task_title) in
-                      (* Direct LLM call — no llm-mcp dependency *)
-                      ignore (net, clock);  (* Previously used for llm-mcp HTTP call *)
-                      try
-                        let response = Llm_direct.dispatch
-                          ~tool_name:"glm"
-                          ~model:Env_config.Llm.default_model
-                          ~prompt:goal
-                          ~timeout_sec:60
-                          ~max_chars:4000
-                          ()
-                        in
-                        if response = "" then Error "Empty LLM response"
-                        else Ok response
-                      with exn -> Error (Printexc.to_string exn)
-                  in
+	                    (match chain_result with
+	                     | Ok result ->
+	                         let notes_str =
+	                           Printf.sprintf "LLM result: %s"
+	                             (String.sub result 0 (min 100 (String.length result)))
+	                         in
+	                         (match Room.transition_task_r config ~agent_name ~task_id ~action:"done" ~notes:notes_str () with
+	                          | Ok _ ->
+	                              note_success ~task_id;
+	                              Room.log_event config (Printf.sprintf
+	                                "{\"type\":\"walph_task_done\",\"agent\":\"%s\",\"task\":\"%s\",\"preset\":\"%s\",\"ts\":\"%s\"}"
+	                                agent_name task_id preset (Types.now_iso ()));
+	                              let _ = Room.broadcast config ~from_agent:agent_name
+	                                ~content:(Printf.sprintf "📊 @walph Iteration %d: %s ✅" walph_state.iterations claim_message) in
+	                              loop ()
+	                          | Error err ->
+	                              let err_msg = Types.masc_error_to_string err in
+	                              mark_failed task_id;
+	                              let release_status = release_claim ~task_id in
+	                              let cutoff = note_error ~task_id err_msg in
+	                              log_loop_error ~task_id ~error:err_msg ~release_status ();
+	                              let _ = Room.broadcast config ~from_agent:agent_name
+	                                ~content:(Printf.sprintf "⚠️ @walph done error on %s: %s (released)" task_id err_msg) in
+	                              if cutoff then
+	                                stop_reason := Printf.sprintf "max_consecutive_errors reached (%d)" walph_state.max_consecutive_errors
+	                              else begin
+	                                maybe_backoff ();
+	                                loop ()
+	                              end)
+	                     | Error err_msg ->
+	                         mark_failed task_id;
+	                         let release_status = release_claim ~task_id in
+	                         let cutoff = note_error ~task_id err_msg in
+	                         log_loop_error ~task_id ~error:err_msg ~release_status ();
+	                         let _ = Room.broadcast config ~from_agent:agent_name
+	                           ~content:(Printf.sprintf "⚠️ @walph chain error on %s: %s (released)" task_id err_msg) in
+	                         if cutoff then
+	                           stop_reason := Printf.sprintf "max_consecutive_errors reached (%d)" walph_state.max_consecutive_errors
+	                         else begin
+	                           maybe_backoff ();
+	                           loop ()
+	                         end)
+	              end
+	            end
+	          in
 
-                  (match chain_result with
-                   | Ok result ->
-                       with_walph_lock walph_state (fun () ->
-                         walph_state.completed <- walph_state.completed + 1
-                       );
-                       (* Mark task as done *)
-                       (match task_id with
-                        | Some tid ->
-                            let notes_str = Printf.sprintf "LLM result: %s" (String.sub result 0 (min 100 (String.length result))) in
-                            let _ = Room.transition_task_r config ~agent_name ~task_id:tid ~action:"done" ~notes:notes_str () in
-                            ()
-                        | None -> ());
-                       (* Broadcast progress *)
-                       let _ = Room.broadcast config ~from_agent:agent_name
-                         ~content:(Printf.sprintf "📊 @walph Iteration %d: %s ✅" walph_state.iterations claim_result) in
-                       loop ()
-                   | Error err_msg ->
-                       let _ = Room.broadcast config ~from_agent:agent_name
-                         ~content:(Printf.sprintf "⚠️ @walph chain error: %s (continuing...)" err_msg) in
-                       (* Continue even on chain error *)
-                       loop ())
-                end else begin
-                  (* Error or unexpected result *)
-                  stop_reason := Printf.sprintf "claim error: %s" claim_result;
-                  ()
-                end
-              end
-            end
-          in
+	          loop ();
+	          with_walph_lock walph_state (fun () ->
+	            walph_state.last_stop_reason <- Some !stop_reason
+	          );
 
-          loop ();
-
-          (* Final broadcast and log *)
-          let result = Printf.sprintf
-            "🛑 @walph STOPPED. Preset: %s, Iterations: %d, Tasks completed: %d, Reason: %s"
+	          (* Final broadcast and log *)
+	          let result = Printf.sprintf
+	            "🛑 @walph STOPPED. Preset: %s, Iterations: %d, Tasks completed: %d, Reason: %s"
             preset walph_state.iterations walph_state.completed !stop_reason in
 
           let _ = Room.broadcast config ~from_agent:agent_name ~content:result in

--- a/lib/tool_walph.ml
+++ b/lib/tool_walph.ml
@@ -36,8 +36,11 @@ let get_int args key default =
 let handle_walph_loop ctx args =
   let preset = get_string args "preset" "drain" in
   let max_iterations = get_int args "max_iterations" 10 in
+  let max_consecutive_errors = get_int args "max_consecutive_errors" 5 in
+  let error_backoff_sec = get_int args "error_backoff_sec" 2 in
   let target = get_string_opt args "target" in
-  (true, Room_walph_eio.walph_loop ctx.config ~net:ctx.net ~clock:ctx.clock ~agent_name:ctx.agent_name ~preset ~max_iterations ?target ())
+  (true, Room_walph_eio.walph_loop ctx.config ~net:ctx.net ~clock:ctx.clock ~agent_name:ctx.agent_name
+    ~preset ~max_iterations ~max_consecutive_errors ~error_backoff_sec ?target ())
 
 (* Handle masc_walph_control *)
 let handle_walph_control ctx args =
@@ -97,10 +100,16 @@ let handle_walph_natural ctx args =
         (true, Room_walph_eio.walph_loop ctx.config ~net:ctx.net ~clock:ctx.clock ~agent_name:ctx.agent_name ~preset:"drain" ~max_iterations:10 ())
   end
 
+(* Handle masc_walph_status *)
+let handle_walph_status ctx _args =
+  let json = Room_walph_eio.walph_status_json ctx.config ~agent_name:ctx.agent_name in
+  (true, Yojson.Safe.to_string json)
+
 (* Dispatch handler *)
 let dispatch ctx ~name ~args =
   match name with
   | "masc_walph_loop" -> Some (handle_walph_loop ctx args)
   | "masc_walph_control" -> Some (handle_walph_control ctx args)
   | "masc_walph_natural" -> Some (handle_walph_natural ctx args)
+  | "masc_walph_status" -> Some (handle_walph_status ctx args)
   | _ -> None

--- a/lib/tool_walph.mli
+++ b/lib/tool_walph.mli
@@ -19,6 +19,9 @@ val handle_walph_control : ('a, 'b) context -> Yojson.Safe.t -> bool * string
 (** Handle masc_walph_natural *)
 val handle_walph_natural : ('a, 'b) context -> Yojson.Safe.t -> bool * string
 
+(** Handle masc_walph_status *)
+val handle_walph_status : ('a, 'b) context -> Yojson.Safe.t -> bool * string
+
 (** Helper: get string from args *)
 val get_string : Yojson.Safe.t -> string -> string -> string
 

--- a/lib/tools.ml
+++ b/lib/tools.ml
@@ -3748,6 +3748,20 @@ Example: masc_swarm_leave({agent_name: 'claude-xyz'})";
           ("minimum", `Int 1);
           ("maximum", `Int 100);
         ]);
+        ("max_consecutive_errors", `Assoc [
+          ("type", `String "integer");
+          ("description", `String "Stop loop after this many consecutive errors (default: 5)");
+          ("default", `Int 5);
+          ("minimum", `Int 1);
+          ("maximum", `Int 100);
+        ]);
+        ("error_backoff_sec", `Assoc [
+          ("type", `String "integer");
+          ("description", `String "Sleep seconds after an error before retrying (default: 2)");
+          ("default", `Int 2);
+          ("minimum", `Int 0);
+          ("maximum", `Int 300);
+        ]);
         ("target", `Assoc [
           ("type", `String "string");
           ("description", `String "Target file or directory for preset (e.g., src/utils.ts)");
@@ -3795,6 +3809,22 @@ Example: masc_swarm_leave({agent_name: 'claude-xyz'})";
         ]);
       ]);
       ("required", `List [`String "message"; `String "agent_name"]);
+    ];
+  };
+
+  (* Walph status: detailed per-agent runtime counters *)
+  {
+    name = "masc_walph_status";
+    description = "Get detailed status for the current agent's Walph loop, including iterations, claimed/done counts, error counters, backoff settings, and last stop reason.";
+    input_schema = `Assoc [
+      ("type", `String "object");
+      ("properties", `Assoc [
+        ("agent_name", `Assoc [
+          ("type", `String "string");
+          ("description", `String "Agent requesting the status");
+        ]);
+      ]);
+      ("required", `List [`String "agent_name"]);
     ];
   };
 

--- a/test/test_tool_walph_coverage.ml
+++ b/test/test_tool_walph_coverage.ml
@@ -46,6 +46,30 @@ let () = test "dispatch_walph_control" (fun () ->
   | None -> failwith "dispatch returned None"
 )
 
+(* Test walph_status dispatch *)
+let () = test "dispatch_walph_status" (fun () ->
+  Eio_main.run @@ fun env ->
+  let tmp = Filename.concat (Filename.get_temp_dir_name ())
+    (Printf.sprintf "masc-walph-test-status-%d" (int_of_float (Unix.gettimeofday () *. 1000000.0))) in
+  Unix.mkdir tmp 0o755;
+  let config = Room.default_config tmp in
+  let _ = Room.init config ~agent_name:None in
+  let net = Eio.Stdenv.net env in
+  let clock = Eio.Stdenv.clock env in
+  let ctx = { Tool_walph.config; agent_name = "test-agent"; net; clock } in
+  let args = `Assoc [] in
+  match Tool_walph.dispatch ctx ~name:"masc_walph_status" ~args with
+  | Some (success, result) ->
+      assert success;
+      let json = Yojson.Safe.from_string result in
+      (match json with
+       | `Assoc kv ->
+           assert (List.mem_assoc "ok" kv);
+           assert (List.mem_assoc "agent" kv)
+       | _ -> failwith "status result is not JSON object")
+  | None -> failwith "dispatch returned None"
+)
+
 (* Test walph_natural with stop command *)
 let () = test "walph_natural_stop" (fun () ->
   Eio_main.run @@ fun env ->

--- a/test/test_tools_coverage.ml
+++ b/test/test_tools_coverage.ml
@@ -558,7 +558,9 @@ let test_masc_walph_loop_schema () =
       match get_json_assoc "properties" schema.input_schema with
       | Some props ->
           Alcotest.(check bool) "has agent_name" true (List.mem_assoc "agent_name" props);
-          Alcotest.(check bool) "has preset" true (List.mem_assoc "preset" props)
+          Alcotest.(check bool) "has preset" true (List.mem_assoc "preset" props);
+          Alcotest.(check bool) "has max_consecutive_errors" true (List.mem_assoc "max_consecutive_errors" props);
+          Alcotest.(check bool) "has error_backoff_sec" true (List.mem_assoc "error_backoff_sec" props)
       | None -> Alcotest.fail "masc_walph_loop missing properties"
 
 let test_masc_walph_control_schema () =
@@ -578,6 +580,15 @@ let test_masc_walph_natural_schema () =
       | Some props ->
           Alcotest.(check bool) "has message" true (List.mem_assoc "message" props)
       | None -> Alcotest.fail "masc_walph_natural missing properties"
+
+let test_masc_walph_status_schema () =
+  match find_tool "masc_walph_status" with
+  | None -> Alcotest.fail "masc_walph_status not found"
+  | Some schema ->
+      match get_json_assoc "properties" schema.input_schema with
+      | Some props ->
+          Alcotest.(check bool) "has agent_name" true (List.mem_assoc "agent_name" props)
+      | None -> Alcotest.fail "masc_walph_status missing properties"
 
 (* ============================================================ *)
 (* 17. Hat Tool Tests                                            *)
@@ -776,6 +787,7 @@ let () =
       Alcotest.test_case "walph_loop" `Quick test_masc_walph_loop_schema;
       Alcotest.test_case "walph_control" `Quick test_masc_walph_control_schema;
       Alcotest.test_case "walph_natural" `Quick test_masc_walph_natural_schema;
+      Alcotest.test_case "walph_status" `Quick test_masc_walph_status_schema;
     ];
     "hat_tools", [
       Alcotest.test_case "hat_wear" `Quick test_masc_hat_wear_schema;

--- a/test/test_walph_eio.ml
+++ b/test/test_walph_eio.ml
@@ -8,6 +8,7 @@
 *)
 
 open Alcotest
+open Yojson.Safe.Util
 
 let rec rm_rf path =
   if Sys.file_exists path then
@@ -17,6 +18,13 @@ let rec rm_rf path =
       Unix.rmdir path
     end else
       Unix.unlink path
+
+let contains text pattern =
+  try
+    let _ = Str.search_forward (Str.regexp_string pattern) text 0 in
+    true
+  with Not_found ->
+    false
 
 (** Test fixture: Create isolated config with Eio environment *)
 let with_test_config name f =
@@ -238,6 +246,60 @@ let test_eio_list_walph_states () =
   check bool "has agent-b" true (List.mem "agent-b" agent_names);
   check bool "has agent-c" true (List.mem "agent-c" agent_names)
 
+(** Test: walph_status_json exposes extended counters/metadata *)
+let test_eio_status_json_fields () =
+  with_test_config "status_json" @@ fun _env _fs config ->
+  let _state = Masc_mcp.Room_walph_eio.get_walph_state_exn config ~agent_name:"status-agent" in
+  let json = Masc_mcp.Room_walph_eio.walph_status_json config ~agent_name:"status-agent" in
+  check bool "ok=true" true (json |> member "ok" |> to_bool);
+  check string "agent field" "status-agent" (json |> member "agent" |> to_string);
+  ignore (json |> member "claimed" |> to_int);
+  ignore (json |> member "released_on_error" |> to_int);
+  ignore (json |> member "errors" |> to_int);
+  ignore (json |> member "consecutive_errors" |> to_int);
+  ignore (json |> member "max_consecutive_errors" |> to_int);
+  ignore (json |> member "error_backoff_sec" |> to_int);
+  ignore (json |> member "last_error");
+  ignore (json |> member "last_task_id");
+  ignore (json |> member "started_at");
+  ignore (json |> member "last_stop_reason")
+
+(** Test: loop cuts off after max_consecutive_errors on deterministic claim failures *)
+let test_eio_error_cutoff () =
+  with_test_config "error_cutoff" @@ fun env _fs config ->
+  let _ = Masc_mcp.Room.add_task config ~title:"failing task #1" ~description:"llm fail path" ~priority:2 in
+  let _ = Masc_mcp.Room.add_task config ~title:"failing task #2" ~description:"llm fail path" ~priority:2 in
+
+  let prev_zai_api_key = Sys.getenv_opt "ZAI_API_KEY" in
+  let result =
+    Fun.protect
+      ~finally:(fun () ->
+        match prev_zai_api_key with
+        | Some v -> Unix.putenv "ZAI_API_KEY" v
+        | None -> Unix.putenv "ZAI_API_KEY" "")
+      (fun () ->
+        Unix.putenv "ZAI_API_KEY" "";
+        Masc_mcp.Room_walph_eio.walph_loop config
+          ~net:(Eio.Stdenv.net env)
+          ~clock:(Eio.Stdenv.clock env)
+          ~agent_name:"error-agent"
+          ~preset:"coverage"
+          ~max_iterations:10
+          ~max_consecutive_errors:2
+          ~error_backoff_sec:0
+          ())
+  in
+  check bool "stop reason includes cutoff"
+    true (contains result "max_consecutive_errors reached (2)");
+
+  let status = Masc_mcp.Room_walph_eio.walph_status_json config ~agent_name:"error-agent" in
+  check int "errors=2" 2 (status |> member "errors" |> to_int);
+  check int "consecutive_errors=2" 2 (status |> member "consecutive_errors" |> to_int);
+  check int "released_on_error=2" 2 (status |> member "released_on_error" |> to_int);
+  check string "last_stop_reason"
+    "max_consecutive_errors reached (2)"
+    (status |> member "last_stop_reason" |> to_string)
+
 (* ============================================
    Test Registration
    ============================================ *)
@@ -252,6 +314,8 @@ let eio_tests = [
   "preset mapping (incl. review)", `Quick, test_eio_preset_mapping;
   "multi-agent with review preset", `Quick, test_eio_multi_agent_with_review;
   "list walph states", `Quick, test_eio_list_walph_states;
+  "status json fields", `Quick, test_eio_status_json_fields;
+  "error cutoff", `Quick, test_eio_error_cutoff;
 ]
 
 let () =


### PR DESCRIPTION
## Summary
- `Room.claim_next_r` structured API 추가 및 실패 태스크 제외(exclude) 지원
- `Room_walph_eio.walph_loop` 안정화: 실패 시 release, failed-task quarantine, consecutive error cutoff/backoff
- `masc_walph_status` 도구 추가 및 `masc_walph_loop`에 `max_consecutive_errors`/`error_backoff_sec` 인자 노출
- walph 관련 스키마/핸들러/Eio 테스트 보강

## Validation
- `dune build --root .`
- `dune exec --root . test/test_tools_coverage.exe`
- `dune exec --root . test/test_tool_walph_coverage.exe`
- `dune exec --root . test/test_walph_eio.exe`

## Notes
- 기존 `claim_next` 문자열 API는 호환성 유지
- sync walph 경로에서도 claim stuck 방지를 위해 실패 시 release 처리