### PR TITLE
refactor(viewer): add PreflightRow::new() constructor

### DIFF
--- a/viewer/src/mode/transport_classify.rs
+++ b/viewer/src/mode/transport_classify.rs
@@ -112,6 +112,8 @@ mod tests {
         let row = PreflightRow::new(true, "test", "detail");
         let cloned = row.clone();
         assert!(cloned.ok);
+        assert_eq!(row.label, "test");
+        assert!(row.hint.is_none());
         assert_eq!(format!("{:?}", row), format!("{:?}", cloned));
     }
 

--- a/viewer/src/mode/transport_classify.rs
+++ b/viewer/src/mode/transport_classify.rs
@@ -11,6 +11,13 @@ pub(super) struct PreflightRow {
     pub hint: Option<String>,
 }
 
+impl PreflightRow {
+    /// Convenience constructor for the common case where `hint` is `None`.
+    pub(super) fn new(ok: bool, label: &str, detail: impl Into<String>) -> Self {
+        Self { ok, label: label.to_string(), detail: detail.into(), hint: None }
+    }
+}
+
 /// Returns `true` when the body looks like an HTML error page (proxy, CDN, etc.).
 pub(super) fn is_html_body(body: &str) -> bool {
     let lower = body.to_ascii_lowercase();
@@ -102,12 +109,7 @@ mod tests {
 
     #[test]
     fn preflight_row_debug_and_clone() {
-        let row = PreflightRow {
-            ok: true,
-            label: "test".to_string(),
-            detail: "detail".to_string(),
-            hint: None,
-        };
+        let row = PreflightRow::new(true, "test", "detail");
         let cloned = row.clone();
         assert!(cloned.ok);
         assert_eq!(format!("{:?}", row), format!("{:?}", cloned));

--- a/viewer/src/mode/trpg_controls.rs
+++ b/viewer/src/mode/trpg_controls.rs
@@ -2183,7 +2183,7 @@ async fn run_new_game_preflight(doc: &web_sys::Document) -> Result<(), String> {
     let health_url = crate::config::build_masc_url("health");
     let server_row = match crate::mode::mcp_rpc::http_get_text(&health_url).await {
         Ok((status, _body)) if (200..300).contains(&status) => {
-            PreflightRow { ok: true, label: "서버 연결".to_string(), detail: "MASC 서버 응답 정상".to_string(), hint: None }
+            PreflightRow::new(true, "서버 연결", "MASC 서버 응답 정상")
         }
         Ok((status, body)) => {
             let hint = if is_html_body(&body) {
@@ -2234,9 +2234,9 @@ async fn run_new_game_preflight(doc: &web_sys::Document) -> Result<(), String> {
                     preset_catalog_keys_preview_from_value(&catalog)
                 )
             };
-            PreflightRow { ok, label: "프리셋".to_string(), detail, hint: None }
+            PreflightRow::new(ok, "프리셋", detail)
         }
-        Err(e) => PreflightRow { ok: false, label: "프리셋".to_string(), detail: format!("조회 실패: {}", e), hint: None },
+        Err(e) => PreflightRow::new(false, "프리셋", format!("조회 실패: {}", e)),
     };
     rows.push(preset_row);
 
@@ -2257,18 +2257,18 @@ async fn run_new_game_preflight(doc: &web_sys::Document) -> Result<(), String> {
                 if count > 0 {
                     (
                         keepers,
-                        PreflightRow { ok: true, label: "키퍼 풀".to_string(), detail: format!("{}명 사용 가능", count), hint: None },
+                        PreflightRow::new(true, "키퍼 풀", format!("{}명 사용 가능", count)),
                     )
                 } else {
                     (
                         Vec::new(),
-                        PreflightRow { ok: false, label: "키퍼 풀".to_string(), detail: "사용 가능한 keeper가 없습니다".to_string(), hint: None },
+                        PreflightRow::new(false, "키퍼 풀", "사용 가능한 keeper가 없습니다"),
                     )
                 }
             }
             Err(e) => (
                 Vec::new(),
-                PreflightRow { ok: false, label: "키퍼 풀".to_string(), detail: format!("조회 실패: {}", e), hint: None },
+                PreflightRow::new(false, "키퍼 풀", format!("조회 실패: {}", e)),
             ),
         };
     rows.push(keeper_pool_row);
@@ -2282,12 +2282,7 @@ async fn run_new_game_preflight(doc: &web_sys::Document) -> Result<(), String> {
     selected_keepers = unique_non_empty(selected_keepers);
 
     let selected_keeper_row = if selected_keepers.is_empty() {
-        PreflightRow {
-            ok: false,
-            label: "선택 키퍼".to_string(),
-            detail: "DM/플레이어 keeper를 선택하세요.".to_string(),
-            hint: None,
-        }
+        PreflightRow::new(false, "선택 키퍼", "DM/플레이어 keeper를 선택하세요.")
     } else {
         let mut blockers = Vec::new();
         let mut warnings = Vec::new();
@@ -2386,24 +2381,14 @@ async fn run_new_game_preflight(doc: &web_sys::Document) -> Result<(), String> {
                 ));
             }
             let detail = detail_parts.join(" · ");
-            PreflightRow {
-                ok: true,
-                label: "선택 키퍼".to_string(),
-                detail,
-                hint: None,
-            }
+            PreflightRow::new(true, "선택 키퍼", detail)
         } else {
-            PreflightRow {
-                ok: false,
-                label: "선택 키퍼".to_string(),
-                detail: format!(
+            PreflightRow::new(false, "선택 키퍼", format!(
                     "준비 실패 {} / {} · {}",
                     blockers.len(),
                     selected_keepers.len(),
                     summarize_preflight_items(&blockers, 3)
-                ),
-                hint: None,
-            }
+                ))
         }
     };
     rows.push(selected_keeper_row);
@@ -2422,27 +2407,12 @@ async fn run_new_game_preflight(doc: &web_sys::Document) -> Result<(), String> {
                 })
                 .collect::<Vec<_>>();
             if conflicts.is_empty() {
-                PreflightRow {
-                    ok: true,
-                    label: "점유 충돌".to_string(),
-                    detail: format!("선택 keeper {}명 모두 비점유", selected_keepers.len()),
-                    hint: None,
-                }
+                PreflightRow::new(true, "점유 충돌", format!("선택 keeper {}명 모두 비점유", selected_keepers.len()))
             } else {
-                PreflightRow {
-                    ok: false,
-                    label: "점유 충돌".to_string(),
-                    detail: format!("이미 점유 중: {}", summarize_preflight_items(&conflicts, 3)),
-                    hint: None,
-                }
+                PreflightRow::new(false, "점유 충돌", format!("이미 점유 중: {}", summarize_preflight_items(&conflicts, 3)))
             }
         }
-        Err(_) => PreflightRow {
-            ok: true,
-            label: "점유 충돌".to_string(),
-            detail: "신규 room으로 판단되어 충돌 검사를 건너뜁니다.".to_string(),
-            hint: None,
-        },
+        Err(_) => PreflightRow::new(true, "점유 충돌", "신규 room으로 판단되어 충돌 검사를 건너뜁니다."),
     };
     rows.push(occupancy_row);
 
@@ -2456,19 +2426,9 @@ async fn run_new_game_preflight(doc: &web_sys::Document) -> Result<(), String> {
                 .unwrap_or("unknown")
                 .trim()
                 .to_string();
-            PreflightRow {
-                ok: true,
-                label: "룸 상태".to_string(),
-                detail: format!("room {} · {}", room_id, status),
-                hint: None,
-            }
+            PreflightRow::new(true, "룸 상태", format!("room {} · {}", room_id, status))
         }
-        Err(_) => PreflightRow {
-            ok: true,
-            label: "룸 상태".to_string(),
-            detail: format!("room {} · 신규 room (아직 초기화 전)", room_id),
-            hint: None,
-        },
+        Err(_) => PreflightRow::new(true, "룸 상태", format!("room {} · 신규 room (아직 초기화 전)", room_id)),
     };
     rows.push(room_row);
 


### PR DESCRIPTION
## 요약

`PreflightRow` 구조체에 `new()` 생성자를 추가하여 `hint: None` 반복을 제거합니다.

- 16개 인스턴스 중 14개(87.5%)가 `hint: None` — 공통 케이스용 생성자 추가
- `hint: Some(...)` 2개는 기존 struct literal 유지
- **-38줄** (61 삭제, 23 추가)

## 변경 파일

| 파일 | 변경 |
|------|------|
| `viewer/src/mode/transport_classify.rs` | `impl PreflightRow` 블록 + `new()` 메서드 추가, 테스트 업데이트 |
| `viewer/src/mode/trpg_controls.rs` | 14개 `hint: None` struct literal → `PreflightRow::new()` 호출로 전환 |

## 테스트

- `cargo test -- transport_classify`: 10/10 통과
- `dune test --root .`: OCaml 테스트 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)