### PR TITLE
refactor: replace Unix.gettimeofday with Time_compat.now across lib/

### DIFF
--- a/lib/adaptive_thresholds.ml
+++ b/lib/adaptive_thresholds.ml
@@ -38,7 +38,7 @@ let clamp_thresholds (t : thresholds) : thresholds =
 
 (** Get current ISO 8601 timestamp string *)
 let iso_now () =
-  let t = Unix.gettimeofday () in
+  let t = Time_compat.now () in
   let tm = Unix.gmtime t in
   Printf.sprintf "%04d-%02d-%02dT%02d:%02d:%02dZ"
     (1900 + tm.Unix.tm_year) (1 + tm.Unix.tm_mon) tm.Unix.tm_mday

--- a/lib/ag_ui.ml
+++ b/lib/ag_ui.ml
@@ -93,7 +93,7 @@ let make_event ?(run_id=None) ?(message_id=None) ?(role=None)
     snapshot;
     custom_name;
     custom_value;
-    timestamp = Unix.gettimeofday ();
+    timestamp = Time_compat.now ();
   }
 
 (** Serialize AG-UI event to JSON (spec-compliant field names) *)

--- a/lib/council/balance.ml
+++ b/lib/council/balance.ml
@@ -101,7 +101,7 @@ let record_win ~(stats_table : (string, agent_stats) Hashtbl.t) ~(agent_id : str
   let updated = {
     wins = current.wins + 1;
     participations = current.participations;
-    last_win = Some (Unix.gettimeofday ());
+    last_win = Some (Time_compat.now ());
   } in
   Hashtbl.replace stats_table agent_id updated
 

--- a/lib/council/consensus.ml
+++ b/lib/council/consensus.ml
@@ -86,7 +86,7 @@ let start_voting ~topic ~initiator ?(quorum = 2) ?(threshold = 0.5) () : (sessio
       quorum;
       threshold;
       state = Open;
-      created_at = Unix.gettimeofday ();
+      created_at = Time_compat.now ();
       closed_at = None;
     } in
     Hashtbl.replace sessions session.id session;
@@ -106,7 +106,7 @@ let cast_vote ~session_id ~agent ~decision ~reason ?(archetype=None) ?(weight=1.
         agent;
         decision;
         reason;
-        timestamp = Unix.gettimeofday ();
+        timestamp = Time_compat.now ();
         archetype;
         weight;
       } in
@@ -187,7 +187,7 @@ let close_session ~session_id : (session, error) Result.t =
     let updated = { 
       session with 
       state = Closed;
-      closed_at = Some (Unix.gettimeofday ());
+      closed_at = Some (Time_compat.now ());
     } in
     Hashtbl.replace sessions session_id updated;
     Ok updated
@@ -200,7 +200,7 @@ let cancel_session ~session_id : (session, error) Result.t =
     let updated = { 
       session with 
       state = Cancelled;
-      closed_at = Some (Unix.gettimeofday ());
+      closed_at = Some (Time_compat.now ());
     } in
     Hashtbl.replace sessions session_id updated;
     Ok updated

--- a/lib/council/conversation.ml
+++ b/lib/council/conversation.ml
@@ -106,7 +106,7 @@ let ensure_dirs config =
 let () = Random.self_init ()
 
 let generate_thread_id () =
-  let ts = int_of_float (Unix.gettimeofday () *. 1000.0) in
+  let ts = int_of_float (Time_compat.now () *. 1000.0) in
   let rand = Random.int 1_000_000 in
   Printf.sprintf "thread-%d-%06d" ts rand
 
@@ -303,7 +303,7 @@ let start ~config ~topic ~initiator ?(max_turns = 50) ?(initial_content = "") ?s
     : (thread, string) result =
   ensure_dirs config;
   let id = generate_thread_id () in
-  let now = Unix.gettimeofday () in
+  let now = Time_compat.now () in
 
   (* Create initial turn if content provided *)
   let turns, current_turn =
@@ -365,7 +365,7 @@ let reply ~config ~thread_id ~speaker ~content
         Error (Printf.sprintf "Cannot reply: thread %s is %s (turn %d/%d)"
           thread_id (thread_status_to_string th.status) th.current_turn th.max_turns)
       else begin
-        let now = Unix.gettimeofday () in
+        let now = Time_compat.now () in
         let turn = {
           id = generate_turn_id ~thread_id ~seq:th.current_turn;
           seq = th.current_turn;
@@ -406,7 +406,7 @@ let conclude ~config ~thread_id ~concluder ~conclusion () : (thread, string) res
         Error (Printf.sprintf "Cannot conclude: thread %s is already %s"
           thread_id (thread_status_to_string th.status))
       else begin
-        let now = Unix.gettimeofday () in
+        let now = Time_compat.now () in
 
         (* Add concluding turn *)
         let turn = {

--- a/lib/council/debate.ml
+++ b/lib/council/debate.ml
@@ -53,7 +53,7 @@ let list_dir_safe dir =
 let () = Random.self_init ()
 
 let generate_debate_id () =
-  let ts = int_of_float (Unix.gettimeofday () *. 1000.0) in
+  let ts = int_of_float (Time_compat.now () *. 1000.0) in
   let rand = Random.int 1_000_000 in
   Printf.sprintf "debate-%d-%06d" ts rand
 
@@ -222,7 +222,7 @@ let start_debate config ~topic ?(notify_agents=[]) ~notify_fn () : (debate, stri
     topic;
     status = Open;
     arguments = [];
-    created_at = Unix.gettimeofday ();
+    created_at = Time_compat.now ();
   } in
   let path = debate_path config id in
   try

--- a/lib/council/dune
+++ b/lib/council/dune
@@ -2,5 +2,5 @@
  (name council)
  (public_name masc_mcp.council)
  (modules router debate consensus balance archive executor conversation loop_guard thread_persist council)
- (libraries str yojson base64 unix eio caqti caqti-eio caqti-eio.unix caqti-driver-postgresql cohttp cohttp-eio uuidm)
+ (libraries str yojson base64 unix eio caqti caqti-eio caqti-eio.unix caqti-driver-postgresql cohttp cohttp-eio uuidm time_compat)
  (preprocess (pps ppx_deriving.show ppx_deriving.eq ppx_deriving_yojson)))

--- a/lib/council/executor.ml
+++ b/lib/council/executor.ml
@@ -116,7 +116,7 @@ let combine_output ~stdout ~stderr =
 %s|} s e
 
 let execute_argv argv =
-  let timestamp () = Unix.gettimeofday () in
+  let timestamp () = Time_compat.now () in
   match argv with
   | [] ->
       { success = false;
@@ -178,7 +178,7 @@ let execute_config_change key value =
     ensure_dir config_dir;
     (* Write JSON config *)
     let json = `Assoc [("key", `String key); ("value", `String value); 
-                       ("updated_at", `Float (Unix.gettimeofday ()))] in
+                       ("updated_at", `Float (Time_compat.now ()))] in
     let oc = open_out config_file in
     Fun.protect ~finally:(fun () -> close_out_noerr oc) (fun () ->
       output_string oc (Yojson.Safe.pretty_to_string json));
@@ -187,14 +187,14 @@ let execute_config_change key value =
       stdout = msg;
       stderr = "";
       output = msg;
-      timestamp = Unix.gettimeofday () }
+      timestamp = Time_compat.now () }
   with exn ->
     let msg = Printf.sprintf "Config error: %s" (Printexc.to_string exn) in
     { success = false;
       stdout = "";
       stderr = msg;
       output = msg;
-      timestamp = Unix.gettimeofday () }
+      timestamp = Time_compat.now () }
 
 (** Send notification to target (file-based for now) *)
 let execute_notification target message =
@@ -203,7 +203,7 @@ let execute_notification target message =
     let json = `Assoc [
       ("target", `String target);
       ("message", `String message);
-      ("timestamp", `Float (Unix.gettimeofday ()))
+      ("timestamp", `Float (Time_compat.now ()))
     ] in
     let oc = open_out_gen [Open_append; Open_creat] 0o644 notify_file in
     Fun.protect ~finally:(fun () -> close_out_noerr oc) (fun () ->
@@ -215,14 +215,14 @@ let execute_notification target message =
       stdout = msg;
       stderr = "";
       output = msg;
-      timestamp = Unix.gettimeofday () }
+      timestamp = Time_compat.now () }
   with exn ->
     let msg = Printf.sprintf "Notification error: %s" (Printexc.to_string exn) in
     { success = false;
       stdout = "";
       stderr = msg;
       output = msg;
-      timestamp = Unix.gettimeofday () }
+      timestamp = Time_compat.now () }
 
 let execute_action action =
   match action with
@@ -236,7 +236,7 @@ let execute_action action =
       stdout = "";
       stderr = msg;
       output = msg;
-      timestamp = Unix.gettimeofday () }
+      timestamp = Time_compat.now () }
 
 (** {1 Decision Processing} *)
 

--- a/lib/council/loop_guard.ml
+++ b/lib/council/loop_guard.ml
@@ -81,7 +81,7 @@ let check_identical_pattern ~turns ~speaker ~content ~max_identical =
 
 (** Check for cooldown violation *)
 let check_cooldown ~turns ~speaker ~cooldown_sec =
-  let now = Unix.gettimeofday () in
+  let now = Time_compat.now () in
   let last_turn_from_speaker =
     turns
     |> List.rev

--- a/lib/eval_gate.ml
+++ b/lib/eval_gate.ml
@@ -323,7 +323,7 @@ let guarded_execute
   | Trajectory.Reject _reason ->
       (decision, None, None, 0)
   | Trajectory.Pass ->
-      let t0 = Unix.gettimeofday () in
+      let t0 = Time_compat.now () in
       let result =
         try execute ()
         with exn ->
@@ -332,7 +332,7 @@ let guarded_execute
             ("tool", `String tool_name);
           ])
       in
-      let t1 = Unix.gettimeofday () in
+      let t1 = Time_compat.now () in
       let duration_ms = int_of_float ((t1 -. t0) *. 1000.0) in
 
       let eval = post_eval ~config ~tool_name ~result ~duration_ms

--- a/lib/jiphyeon/consensus.ml
+++ b/lib/jiphyeon/consensus.ml
@@ -74,7 +74,7 @@ let start_voting ~topic ~initiator ?(quorum = 2) ?(threshold = 0.5) () : (sessio
       quorum;
       threshold;
       state = Open;
-      created_at = Unix.gettimeofday ();
+      created_at = Time_compat.now ();
       closed_at = None;
     } in
     Hashtbl.replace sessions session.id session;
@@ -94,7 +94,7 @@ let cast_vote ~session_id ~agent ~decision ~reason : (session, error) Result.t =
         agent;
         decision;
         reason;
-        timestamp = Unix.gettimeofday ();
+        timestamp = Time_compat.now ();
       } in
       let updated = { session with votes = vote :: session.votes } in
       Hashtbl.replace sessions session_id updated;
@@ -160,7 +160,7 @@ let close_session ~session_id : (session, error) Result.t =
     let updated = { 
       session with 
       state = Closed;
-      closed_at = Some (Unix.gettimeofday ());
+      closed_at = Some (Time_compat.now ());
     } in
     Hashtbl.replace sessions session_id updated;
     Ok updated
@@ -173,7 +173,7 @@ let cancel_session ~session_id : (session, error) Result.t =
     let updated = { 
       session with 
       state = Cancelled;
-      closed_at = Some (Unix.gettimeofday ());
+      closed_at = Some (Time_compat.now ());
     } in
     Hashtbl.replace sessions session_id updated;
     Ok updated

--- a/lib/jiphyeon/dune
+++ b/lib/jiphyeon/dune
@@ -16,5 +16,6 @@
    eio
    eio_main
    uuidm
-   unix)
+   unix
+   time_compat)
  (preprocess (pps ppx_deriving_yojson ppx_deriving.show ppx_deriving.eq)))

--- a/lib/library_bridge.ml
+++ b/lib/library_bridge.ml
@@ -34,7 +34,7 @@ let record_to_library
     end else
       library_root ()
   in
-  let now = Unix.localtime (Unix.gettimeofday ()) in
+  let now = Unix.localtime (Time_compat.now ()) in
   let date_str = Printf.sprintf "%04d%02d%02d"
     (now.Unix.tm_year + 1900) (now.Unix.tm_mon + 1) now.Unix.tm_mday in
   let iso_date = Printf.sprintf "%04d-%02d-%02d"

--- a/lib/lodge_cascade.ml
+++ b/lib/lodge_cascade.ml
@@ -205,12 +205,12 @@ let run_cascade_traced
     ~(is_valid : string -> bool)
     ~(agent_name : string)
   : cascade_result =
-  let start_time = Unix.gettimeofday () in
+  let start_time = Time_compat.now () in
   let rotated = rotate_claude_slots slots in
   let rec try_slots = function
     | [] ->
       printf "   ❌ [%s] All LLMs failed, skipping\n%!" agent_name;
-      let duration_ms = int_of_float ((Unix.gettimeofday () -. start_time) *. 1000.0) in
+      let duration_ms = int_of_float ((Time_compat.now () -. start_time) *. 1000.0) in
       { response = ""; llm_used = "none"; duration_ms }
     | slot :: rest ->
       let extra_args =
@@ -236,7 +236,7 @@ let run_cascade_traced
       if is_valid r then begin
         printf "   🧠 [%s] %s: %s\n%!" agent_name label
           (if String.length r > 80 then String.sub r 0 80 ^ "..." else r);
-        let duration_ms = int_of_float ((Unix.gettimeofday () -. start_time) *. 1000.0) in
+        let duration_ms = int_of_float ((Time_compat.now () -. start_time) *. 1000.0) in
         { response = r; llm_used = label; duration_ms }
       end else begin
         printf "   ⚠️ [%s] %s failed (%d chars), next...\n%!" agent_name label (String.length r);

--- a/lib/lodge_heartbeat.ml
+++ b/lib/lodge_heartbeat.ml
@@ -2161,7 +2161,7 @@ let refill () = bucket := min 10 (!bucket + 1)
   (* A2A Delegation: if delegation mode is on, emit heartbeat_task for A2A Worker *)
   if Env_config.LodgeV2.delegate_llm then begin
     let request_id = Printf.sprintf "hb-%s-%d"
-      agent_name (int_of_float (Unix.gettimeofday () *. 1000.0) mod 1000000) in
+      agent_name (int_of_float (Time_compat.now () *. 1000.0) mod 1000000) in
     let board_context = recent_posts
       |> List.filteri (fun i _ -> i < 3)
       |> List.map (fun (p : Board.post) ->
@@ -2204,7 +2204,7 @@ let refill () = bucket := min 10 (!bucket + 1)
 
   (* LLM cascade: config-driven via Lodge_cascade (direct API, no llm-mcp) *)
   let action_slots = Lodge_cascade.get_cascade ~cascade_name:"heartbeat_action" () in
-  let tick_id = Printf.sprintf "%s-%d" agent_name (int_of_float (Unix.gettimeofday () *. 1000.0) mod 1000000) in
+  let tick_id = Printf.sprintf "%s-%d" agent_name (int_of_float (Time_compat.now () *. 1000.0) mod 1000000) in
   let cascade_result =
     if List.length action_slots > 0 then
       Lodge_cascade.run_cascade_traced
@@ -2215,9 +2215,9 @@ let refill () = bucket := min 10 (!bucket + 1)
     else begin
       (* Fallback: no config file, try GLM directly *)
       Printf.printf "   ⚠️ [%s] No cascade config, trying GLM directly...\n%!" agent_name;
-      let start_t = Unix.gettimeofday () in
+      let start_t = Time_compat.now () in
       let r = Llm_direct.call_glm ~model:"glm-4.7" ~prompt ~timeout_sec:60 ~max_chars:4000 () in
-      let duration_ms = int_of_float ((Unix.gettimeofday () -. start_t) *. 1000.0) in
+      let duration_ms = int_of_float ((Time_compat.now () -. start_t) *. 1000.0) in
       Lodge_cascade.{ response = r; llm_used = "glm(glm-4.7)"; duration_ms }
     end
   in
@@ -2257,7 +2257,7 @@ let refill () = bucket := min 10 (!bucket + 1)
     llm_used = cascade_result.Lodge_cascade.llm_used;
     action = action_str;
     duration_ms = cascade_result.Lodge_cascade.duration_ms;
-    timestamp = Unix.gettimeofday ();
+    timestamp = Time_compat.now ();
   };
   (* Convert index to actual post_id for COMMENT action *)
   let action = match action with
@@ -2394,7 +2394,7 @@ let rec execute_agent_action ~agent_name ~action =
       (try Unix.mkdir base_dir 0o755 with Unix.Unix_error (Unix.EEXIST, _, _) -> ());
       (try Unix.mkdir agent_dir 0o755 with Unix.Unix_error (Unix.EEXIST, _, _) -> ());
       (* Generate timestamped filename *)
-      let now = Unix.localtime (Unix.gettimeofday ()) in
+      let now = Unix.localtime (Time_compat.now ()) in
       let timestamp = Printf.sprintf "%04d%02d%02d_%02d%02d"
         (now.Unix.tm_year + 1900) (now.Unix.tm_mon + 1) now.Unix.tm_mday
         now.Unix.tm_hour now.Unix.tm_min in

--- a/lib/tool_council.ml
+++ b/lib/tool_council.ml
@@ -49,7 +49,7 @@ let broadcast_decision_event ~event_type ~agent ?(data=`Null) () =
     ("type", `String event_type);
     ("agent", `String agent);
     ("data", data);
-    ("timestamp", `Float (Unix.gettimeofday ()));
+    ("timestamp", `Float (Time_compat.now ()));
   ] in
   let notification = `Assoc [
     ("jsonrpc", `String "2.0");

--- a/lib/tool_experiment.ml
+++ b/lib/tool_experiment.ml
@@ -224,7 +224,7 @@ let list_experiments config =
 let () = Random.self_init ()
 
 let generate_id () =
-  let ts = int_of_float (Unix.gettimeofday () *. 1000.0) in
+  let ts = int_of_float (Time_compat.now () *. 1000.0) in
   let rand = Random.int 1_000_000 in
   Printf.sprintf "exp-%d-%06d" ts rand
 
@@ -244,7 +244,7 @@ let broadcast_experiment_event ~event_type ~agent ?(data = `Null) () =
         ("type", `String event_type);
         ("agent", `String agent);
         ("data", data);
-        ("timestamp", `Float (Unix.gettimeofday ()));
+        ("timestamp", `Float (Time_compat.now ()));
       ]
   in
   let notification =
@@ -342,7 +342,7 @@ let handle_experiment_start ctx args : result =
         status = Running;
         assignments = [];
         observations = [];
-        created_at = Unix.gettimeofday ();
+        created_at = Time_compat.now ();
       }
     in
     (try
@@ -389,7 +389,7 @@ let handle_experiment_assign ctx args : result =
             if exp.status <> Running then
               (false, Printf.sprintf "Experiment %s is not running" experiment_id)
             else
-              let now = Unix.gettimeofday () in
+              let now = Time_compat.now () in
               let assignment = { subject_id; group; timestamp = now } in
               let updated =
                 { exp with assignments = exp.assignments @ [ assignment ] }
@@ -431,7 +431,7 @@ let handle_experiment_observe ctx args : result =
         if exp.status <> Running then
           (false, Printf.sprintf "Experiment %s is not running" experiment_id)
         else
-          let now = Unix.gettimeofday () in
+          let now = Time_compat.now () in
           let obs = { subject_id; metric_name; value; timestamp = now } in
           let updated =
             { exp with observations = exp.observations @ [ obs ] }
@@ -465,7 +465,7 @@ let handle_experiment_checkpoint ctx args : result =
     match load_experiment ctx.config experiment_id with
     | None -> (false, Printf.sprintf "Experiment not found: %s" experiment_id)
     | Some exp ->
-        let elapsed = Unix.gettimeofday () -. exp.created_at in
+        let elapsed = Time_compat.now () -. exp.created_at in
         let elapsed_pct =
           if exp.window_seconds > 0.0 then
             Float.min 1.0 (elapsed /. exp.window_seconds)
@@ -657,7 +657,7 @@ let handle_experiment_status ctx args : result =
                     ("control", `Int control_count);
                   ] );
               ("total_observations", `Int (List.length exp.observations));
-              ("elapsed_seconds", `Float (Unix.gettimeofday () -. exp.created_at));
+              ("elapsed_seconds", `Float (Time_compat.now () -. exp.created_at));
               ("window_seconds", `Float exp.window_seconds);
             ]
         in

--- a/lib/tool_keeper.ml
+++ b/lib/tool_keeper.ml
@@ -5793,7 +5793,7 @@ Do NOT use destructive tools (bash rm, edit, delete).|}
          (match trajectory_acc with
           | Some acc ->
               Trajectory.record_entry acc {
-                ts = Unix.gettimeofday ();
+                ts = Time_compat.now ();
                 ts_iso = Types.now_iso ();
                 turn = acc.Trajectory.turn;
                 round = 0;
@@ -6050,7 +6050,7 @@ let run_autonomous_goal_turn ~(config : Room.config) ~(meta : keeper_meta)
                    ~generation:meta.generation in
                  (* Record caution warning to trajectory *)
                  Trajectory.record_entry traj_acc {
-                   ts = Unix.gettimeofday ();
+                   ts = Time_compat.now ();
                    ts_iso = Types.now_iso ();
                    turn = traj_acc.Trajectory.turn;
                    round = 0;
@@ -7825,7 +7825,7 @@ let handle_keeper_msg ctx args : tool_result =
                   in
                   (* Record trajectory entry *)
                   let entry : Trajectory.tool_call_entry = {
-                    ts = Unix.gettimeofday ();
+                    ts = Time_compat.now ();
                     ts_iso = Types.now_iso ();
                     turn = trajectory_acc.Trajectory.turn;
                     round = 0;  (* updated by tool_loop caller *)

--- a/lib/tool_library.ml
+++ b/lib/tool_library.ml
@@ -180,7 +180,7 @@ let handle_add ctx args =
     else begin
       (* Determine destination based on confidence *)
       let dest_dir = if confidence < 0.5 then candidates_dir () else library_root () in
-      let date = Unix.gettimeofday () |> Unix.localtime in
+      let date = Time_compat.now () |> Unix.localtime in
       let date_str = sprintf "%04d%02d%02d" (date.tm_year + 1900) (date.tm_mon + 1) date.tm_mday in
       let topic_slug = String.lowercase_ascii title
         |> String.map (fun c -> if c = ' ' then '-' else c)

--- a/lib/tool_lodge.ml
+++ b/lib/tool_lodge.ml
@@ -652,7 +652,7 @@ let save_agents_to_file_cache () =
   if agents = [] then ()
   else begin
     let cache_json = `Assoc [
-      ("updated_at", `Float (Unix.gettimeofday ()));
+      ("updated_at", `Float (Time_compat.now ()));
       ("agents", `List (List.map agent_config_to_yojson agents));
     ] in
     try
@@ -680,7 +680,7 @@ let load_agents_from_file_cache () : bool =
       let json = Yojson.Safe.from_string content in
       let open Yojson.Safe.Util in
       let updated_at = json |> member "updated_at" |> to_float in
-      let age_hours = (Unix.gettimeofday () -. updated_at) /. 3600.0 in
+      let age_hours = (Time_compat.now () -. updated_at) /. 3600.0 in
       let ttl = agent_cache_ttl_hours () in
       if age_hours > ttl then begin
         Printf.eprintf "[Lodge] Cache expired (%.1f hours old, TTL=%.0f)\n%!" age_hours ttl;

--- a/lib/tool_protocol_game_view.ml
+++ b/lib/tool_protocol_game_view.ml
@@ -222,7 +222,7 @@ let broadcast_deprecated_alias ~agent_name ~legacy_tool ~canonical_tool =
               ("canonical_tool", `String canonical_tool);
               ("protocol_version", `String protocol_version);
             ] );
-        ("timestamp", `Float (Unix.gettimeofday ()));
+        ("timestamp", `Float (Time_compat.now ()));
       ]
   in
   let notification =
@@ -242,7 +242,7 @@ let broadcast_masc_event ~event_type ~agent ?(data = `Null) () =
         ("type", `String event_type);
         ("agent", `String agent);
         ("data", data);
-        ("timestamp", `Float (Unix.gettimeofday ()));
+        ("timestamp", `Float (Time_compat.now ()));
       ]
   in
   let notification =

--- a/lib/tool_trpg.ml
+++ b/lib/tool_trpg.ml
@@ -5991,7 +5991,7 @@ let handle_stream ctx args : result =
   match result_json with Ok j -> ok_json j | Error e -> err e
 
 let entropy_seed ~session_id ~salt =
-  let now_ms = int_of_float (Unix.gettimeofday () *. 1000.0) in
+  let now_ms = int_of_float (Time_compat.now () *. 1000.0) in
   Hashtbl.hash (Printf.sprintf "%s|%s|%d" session_id salt now_ms)
 
 let pick_by_seed ~seed xs =
@@ -7418,7 +7418,7 @@ let handle_intervention_submit ctx args : result =
     let* payload_opt = get_optional_object args "payload" in
     let intervention_id =
       Printf.sprintf "intrv-%Ld"
-        (Int64.of_float (Unix.gettimeofday () *. 1000.0))
+        (Int64.of_float (Time_compat.now () *. 1000.0))
     in
     let payload =
       `Assoc

--- a/lib/trajectory.ml
+++ b/lib/trajectory.ml
@@ -210,7 +210,7 @@ let create_accumulator ~masc_root ~keeper_name ~trace_id ~generation : accumulat
     keeper_name;
     trace_id;
     generation;
-    started_at = Unix.gettimeofday ();
+    started_at = Time_compat.now ();
     masc_root;
   }
 
@@ -233,7 +233,7 @@ let finalize (acc : accumulator) (outcome : trajectory_outcome) : trajectory =
     trace_id = acc.trace_id;
     generation = acc.generation;
     started_at = acc.started_at;
-    ended_at = Unix.gettimeofday ();
+    ended_at = Time_compat.now ();
     entries = List.rev acc.entries;
     total_cost_usd = acc.total_cost;
     total_turns = acc.turn;

--- a/lib/trpg_harness.ml
+++ b/lib/trpg_harness.ml
@@ -44,7 +44,7 @@ let truncate ~max_len s =
   else s
 
 let now_iso8601 () =
-  let t = Unix.gettimeofday () in
+  let t = Time_compat.now () in
   let tm = Unix.gmtime t in
   sprintf "%04d-%02d-%02dT%02d:%02d:%02dZ"
     (tm.Unix.tm_year + 1900)

--- a/lib/voice_bridge_eio.ml
+++ b/lib/voice_bridge_eio.ml
@@ -254,7 +254,7 @@ let elevenlabs_direct_tts ~agent_id ~message ~voice =
         ("style", `Float 0.0);
       ]);
     ]) in
-    let timestamp = int_of_float (Unix.gettimeofday ()) in
+    let timestamp = int_of_float (Time_compat.now ()) in
     let safe_agent = String.map (fun c ->
       if (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z')
          || (c >= '0' && c <= '9') || c = '-' || c = '_'
@@ -319,7 +319,7 @@ let elevenlabs_direct_tts ~agent_id ~message ~voice =
         ("model", `String "eleven_multilingual_v2");
         ("response_format", `String "mp3");
       ]) in
-      let timestamp = int_of_float (Unix.gettimeofday ()) in
+      let timestamp = int_of_float (Time_compat.now ()) in
       let safe_agent = String.map (fun c ->
         if (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z')
            || (c >= '0' && c <= '9') || c = '-' || c = '_'
@@ -375,7 +375,7 @@ let elevenlabs_direct_tts ~agent_id ~message ~voice =
 let cleanup_old_audio_files () =
   let dir = ".masc/audio" in
   if Sys.file_exists dir && Sys.is_directory dir then begin
-    let now = Unix.gettimeofday () in
+    let now = Time_compat.now () in
     let cutoff = now -. 3600.0 in
     let entries = Sys.readdir dir in
     let removed = ref 0 in


### PR DESCRIPTION
## 요약

`lib/` 전체에서 `Unix.gettimeofday()` 직접 호출 62건을 `Time_compat.now()`로 마이그레이션.

### 변경 내용
- **23개 .ml 파일**: `Unix.gettimeofday ()` → `Time_compat.now ()` 일괄 치환
- **lib/council/dune**: `time_compat` 의존성 추가 (balance, consensus, conversation, debate, executor, loop_guard)
- **lib/jiphyeon/dune**: `time_compat` 의존성 추가 (consensus.ml)

### 잔여 참조
- `lib/time_compat/time_compat.ml`에만 5건 유지 (canonical fallback 구현)
- `examples/` 내 19건은 대상 외 (예시 코드)

### 동기
- `Time_compat.now()`는 Eio clock이 설정되면 `Eio.Time.now`를 사용하고, 미설정 시 `Unix.gettimeofday()`로 fallback
- Eio fiber 내에서 Unix 시간 함수 직접 사용 시 clock mockability 상실 및 잠재적 불일치 가능
- 향후 테스트에서 clock injection을 통한 시간 제어 기반 마련

### 검증
- `dune build --root .` 통과
- `make test` 전체 통과

## Test plan
- [x] `dune build --root .` 성공
- [x] `make test` 전체 테스트 통과
- [x] `rg 'Unix\.gettimeofday' lib/ --count` → `time_compat.ml:5` only
- [ ] Cross-model review (GLM-5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)