### PR TITLE
refactor: replace Printf.sprintf JSON with Yojson.Safe across lib/

### DIFF
--- a/lib/backend_eio.ml
+++ b/lib/backend_eio.ml
@@ -364,8 +364,11 @@ module FileSystem = struct
   }
 
   let lock_info_to_json info =
-    Printf.sprintf {|{"owner":"%s","acquired_at":%f,"expires_at":%f}|}
-      info.owner info.acquired_at info.expires_at
+    Yojson.Safe.to_string (`Assoc [
+      ("owner", `String info.owner);
+      ("acquired_at", `Float info.acquired_at);
+      ("expires_at", `Float info.expires_at);
+    ])
 
   let lock_info_of_json json =
     try

--- a/lib/bridge/dune
+++ b/lib/bridge/dune
@@ -2,4 +2,5 @@
 (library
  (name event_bridge)
  (public_name masc_mcp.bridge)
+ (libraries yojson)
  (modules event_bus))

--- a/lib/bridge/event_bus.ml
+++ b/lib/bridge/event_bus.ml
@@ -7,15 +7,31 @@ type event_type =
   | DialogueSpoken of { agent: string; text: string }
 
 let to_json = function
-  | TurnStarted name -> 
-      Printf.sprintf "{\"type\": \"TurnStarted\", \"agent\": \"%s\"}" name
+  | TurnStarted name ->
+      Yojson.Safe.to_string (`Assoc [
+        ("type", `String "TurnStarted");
+        ("agent", `String name);
+      ])
   | ActionPerformed { agent; action; target } ->
-      let target_str = match target with Some t -> t | None -> "null" in
-      Printf.sprintf "{\"type\": \"ActionPerformed\", \"agent\": \"%s\", \"action\": \"%s\", \"target\": \"%s\"}" agent action target_str
+      let target_val = match target with Some t -> `String t | None -> `Null in
+      Yojson.Safe.to_string (`Assoc [
+        ("type", `String "ActionPerformed");
+        ("agent", `String agent);
+        ("action", `String action);
+        ("target", target_val);
+      ])
   | JudgmentMade { agent; result } ->
-      Printf.sprintf "{\"type\": \"JudgmentMade\", \"agent\": \"%s\", \"result\": \"%s\"}" agent result
+      Yojson.Safe.to_string (`Assoc [
+        ("type", `String "JudgmentMade");
+        ("agent", `String agent);
+        ("result", `String result);
+      ])
   | DialogueSpoken { agent; text } ->
-      Printf.sprintf "{\"type\": \"DialogueSpoken\", \"agent\": \"%s\", \"text\": \"%s\"}" agent text
+      Yojson.Safe.to_string (`Assoc [
+        ("type", `String "DialogueSpoken");
+        ("agent", `String agent);
+        ("text", `String text);
+      ])
 
 let broadcast event =
   let json = to_json event in

--- a/lib/http_server_eio.ml
+++ b/lib/http_server_eio.ml
@@ -432,7 +432,7 @@ end
 
 (** Health check endpoint - JSON response *)
 let health_handler _request reqd =
-  let json = Printf.sprintf {|{"status":"ok","server":"masc-mcp","version":"%s"}|} Version.version in
+  let json = Yojson.Safe.to_string (`Assoc [("status", `String "ok"); ("server", `String "masc-mcp"); ("version", `String Version.version)]) in
   Response.json json reqd
 
 (** Readiness probe - Kubernetes *)
@@ -511,7 +511,7 @@ let mcp_get_handler request reqd =
   match Streamable_http.handle_get ?session_id () with
   | Ok session ->
       (* Return session info, actual SSE handled elsewhere *)
-      let json = Printf.sprintf {|{"session_id":"%s","transport":"streamable_http"}|} session.id in
+      let json = Yojson.Safe.to_string (`Assoc [("session_id", `String session.id); ("transport", `String "streamable_http")]) in
       Response.json json reqd
   | Error msg ->
       Response.text ~status:`Bad_request msg reqd

--- a/lib/llm_client_eio.ml
+++ b/lib/llm_client_eio.ml
@@ -54,18 +54,18 @@ let model_to_string = function
 (** Build MCP JSON-RPC request for LLM call *)
 let build_request ~model ~prompt =
   let model_str = model_to_string model in
-  Printf.sprintf {|{
-  "jsonrpc": "2.0",
-  "id": 1,
-  "method": "tools/call",
-  "params": {
-    "name": "%s",
-    "arguments": {
-      "prompt": %s,
-      "response_format": "verbose"
-    }
-  }
-}|} model_str (Yojson.Safe.to_string (`String prompt))
+  Yojson.Safe.to_string (`Assoc [
+    ("jsonrpc", `String "2.0");
+    ("id", `Int 1);
+    ("method", `String "tools/call");
+    ("params", `Assoc [
+      ("name", `String model_str);
+      ("arguments", `Assoc [
+        ("prompt", `String prompt);
+        ("response_format", `String "verbose");
+      ]);
+    ]);
+  ])
 
 (** Parse LLM response from MCP JSON-RPC response *)
 let parse_response json_str =
@@ -280,26 +280,25 @@ Output JSON only (no markdown):
     @param timeout Timeout in seconds (default: 120)
     @param max_replans Maximum re-planning attempts (default: 2) *)
 let build_chain_request ~goal ?chain_id ?(timeout=120) ?(max_replans=2) () =
-  let chain_id_field = match chain_id with
-    | Some id -> Printf.sprintf {|"chain_id": %s,
-      |} (Yojson.Safe.to_string (`String id))
-    | None -> ""
+  let chain_id_fields = match chain_id with
+    | Some id -> [("chain_id", `String id)]
+    | None -> []
   in
-  Printf.sprintf {|{
-  "jsonrpc": "2.0",
-  "id": 1,
-  "method": "tools/call",
-  "params": {
-    "name": "chain.orchestrate",
-    "arguments": {
-      %s"goal": %s,
-      "timeout": %d,
-      "max_replans": %d,
-      "trace": false,
-      "verify_on_complete": true
-    }
-  }
-}|} chain_id_field (Yojson.Safe.to_string (`String goal)) timeout max_replans
+  Yojson.Safe.to_string (`Assoc [
+    ("jsonrpc", `String "2.0");
+    ("id", `Int 1);
+    ("method", `String "tools/call");
+    ("params", `Assoc [
+      ("name", `String "chain.orchestrate");
+      ("arguments", `Assoc (chain_id_fields @ [
+        ("goal", `String goal);
+        ("timeout", `Int timeout);
+        ("max_replans", `Int max_replans);
+        ("trace", `Bool false);
+        ("verify_on_complete", `Bool true);
+      ]));
+    ]);
+  ])
 
 (** Call chain.orchestrate on llm-mcp server
     @param net Eio network capability

--- a/lib/lodge_heartbeat.ml
+++ b/lib/lodge_heartbeat.ml
@@ -1103,7 +1103,7 @@ let create_agent_graphql ~name ~emoji ~korean_name ~traits ~interests
     (opt_str "personalityHint" personality_hint)
     (opt_str "primaryValue" primary_value)
   in
-  let gql_body = Printf.sprintf {|{"query": "%s"}|} (esc mutation) in
+  let gql_body = Yojson.Safe.to_string (`Assoc [("query", `String mutation)]) in
   Printf.eprintf "[Admin] Creating agent '%s' via GraphQL...\n%!" name;
   match graphql_request ~timeout_sec:10.0 gql_body with
   | Error err ->
@@ -1304,7 +1304,7 @@ let record_to_neo4j ~agent_name ~action_type ~content ~target_id =
     (String.escaped (utf8_truncate content 100))
     target_id timestamp
   in
-  let json_payload = Printf.sprintf {|{"query": "%s"}|} (String.escaped mutation) in
+  let json_payload = Yojson.Safe.to_string (`Assoc [("query", `String mutation)]) in
   (* Fire and forget - don't block the main loop, but log failures *)
   match graphql_request ~timeout_sec:3.0 json_payload with
   | Error err ->

--- a/lib/room.ml
+++ b/lib/room.ml
@@ -850,7 +850,7 @@ let claim_task_r config ~agent_name ~task_id
                         Printf.eprintf "[room] agent state write failed: %s\n%!" msg
                   end;
                   let _ = broadcast config ~from_agent:agent_name ~content:(Printf.sprintf "📋 Claimed %s" task_id) in
-                  log_event config (Printf.sprintf "{\"type\":\"task_claim\",\"agent\":\"%s\",\"task\":\"%s\",\"ts\":\"%s\"}" agent_name task_id (now_iso ()));
+                  log_event config (Yojson.Safe.to_string (`Assoc [("type", `String "task_claim"); ("agent", `String agent_name); ("task", `String task_id); ("ts", `String (now_iso ()))]));
                   Ok (Printf.sprintf "✅ %s claimed %s" agent_name task_id)
           end)
       with e -> Error (Types.IoError (Printexc.to_string e))
@@ -1065,7 +1065,7 @@ let complete_task_r config ~agent_name ~task_id ~notes : string Types.masc_resul
               end;
               let msg = if notes = "" then Printf.sprintf "✅ Completed %s" task_id else Printf.sprintf "✅ Completed %s - %s" task_id notes in
               let _ = broadcast config ~from_agent:agent_name ~content:msg in
-              log_event config (Printf.sprintf "{\"type\":\"task_done\",\"agent\":\"%s\",\"task\":\"%s\",\"notes\":%s,\"ts\":\"%s\"}" agent_name task_id (if notes = "" then "null" else Printf.sprintf "\"%s\"" notes) (now_iso ()));
+              log_event config (Yojson.Safe.to_string (`Assoc [("type", `String "task_done"); ("agent", `String agent_name); ("task", `String task_id); ("notes", if notes = "" then `Null else `String notes); ("ts", `String (now_iso ()))]));
               Ok (Printf.sprintf "✅ %s completed %s" agent_name task_id)
             end
       with e -> Error (Types.IoError (Printexc.to_string e))
@@ -1119,8 +1119,7 @@ let cancel_task_r config ~agent_name ~task_id ~reason : string Types.masc_result
               end;
               let msg = if reason = "" then Printf.sprintf "🚫 Cancelled %s" task_id else Printf.sprintf "🚫 Cancelled %s - %s" task_id reason in
               let _ = broadcast config ~from_agent:agent_name ~content:msg in
-              log_event config (Printf.sprintf "{\"type\":\"task_cancelled\",\"agent\":\"%s\",\"task\":\"%s\",\"reason\":%s,\"ts\":\"%s\"}"
-                agent_name task_id (if reason = "" then "null" else Printf.sprintf "\"%s\"" reason) (now_iso ()));
+              log_event config (Yojson.Safe.to_string (`Assoc [("type", `String "task_cancelled"); ("agent", `String agent_name); ("task", `String task_id); ("reason", if reason = "" then `Null else `String reason); ("ts", `String (now_iso ()))]));
               Ok (Printf.sprintf "🚫 %s cancelled %s" agent_name task_id)
             end
       with e -> Error (Types.IoError (Printexc.to_string e))

--- a/lib/tool_keeper.ml
+++ b/lib/tool_keeper.ml
@@ -5784,8 +5784,7 @@ Do NOT use destructive tools (bash rm, edit, delete).|}
            | Trajectory.Reject reason, _ ->
                Printf.eprintf "[keeper-autonomy] GATE BLOCKED %s: %s\n%!"
                  tc.call_name reason;
-               Printf.sprintf "{\"gate_blocked\":\"%s\",\"reason\":\"%s\"}"
-                 tc.call_name reason
+               Yojson.Safe.to_string (`Assoc [("gate_blocked", `String tc.call_name); ("reason", `String reason)])
            | _, Some r -> r
            | _, None -> "{\"error\":\"no result\"}"
          in
@@ -6055,7 +6054,7 @@ let run_autonomous_goal_turn ~(config : Room.config) ~(meta : keeper_meta)
                    turn = traj_acc.Trajectory.turn;
                    round = 0;
                    tool_name = "_caution_warning";
-                   args_json = Printf.sprintf "{\"warning\":\"%s\"}" (String.escaped warning);
+                   args_json = Yojson.Safe.to_string (`Assoc [("warning", `String warning)]);
                    gate_decision = Trajectory.Pass;
                    result = Some warning;
                    duration_ms = 0;

--- a/lib/transport_grpc_next.ml
+++ b/lib/transport_grpc_next.ml
@@ -220,7 +220,7 @@ let encode_broadcast_request (msg : Pb.BroadcastRequest.t) : string =
 
 (** Helper: Create error response *)
 let make_error_response msg =
-  Printf.sprintf "{\"success\":false,\"message\":\"%s\"}" msg
+  Yojson.Safe.to_string (`Assoc [("success", `Bool false); ("message", `String msg)])
 
 (** GetStatus handler - returns room status with agent/task counts. *)
 let get_status_handler (room_config: Room.config) (request_data: string) : string =


### PR DESCRIPTION
## Summary

- `Printf.sprintf`로 수동 JSON 조립하던 ~20개 패턴을 `Yojson.Safe.to_string`으로 전환
- 이스케이핑 누락, null/string 혼동, 타입 불일치 버그를 구조적으로 제거
- 9개 파일 변경: event_bus, transport_grpc_next, http_server_eio, backend_eio, tool_keeper, room, lodge_heartbeat, llm_client_eio + bridge/dune (yojson dep 추가)

## Key Changes

| 패턴 | Before | After |
|------|--------|-------|
| 일반 필드 | `Printf.sprintf "{\"k\":\"%s\"}" v` | `` `Assoc [("k", `String v)] `` |
| Nullable | `if x="" then "null" else sprintf "\"%s\"" x` | `` if x="" then `Null else `String x `` |
| Optional 필드 | 조건부 `%s` 문자열 삽입 | `list concat @ [...]` |
| 이스케이핑 | `String.escaped` / `esc` 수동 호출 | Yojson 자동 처리 |

## Motivation

Plan P2-1에 해당. Printf.sprintf로 JSON을 조립하면:
1. 특수문자(`"`, `\`, 줄바꿈)가 포함된 문자열에서 파싱 에러 발생
2. null과 `"null"` 문자열을 혼동
3. 타입 안전성 없음 (int를 `%s`로 넣어도 컴파일 통과)

## Test plan

- [x] `dune build --root .` — 빌드 성공 (기존 unix deprecated 경고만)
- [x] `make test` — 전체 테스트 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)