### PR TITLE
chore: resolve 3 TODO/FIXME in lib/ (P2-3)

### DIFF
--- a/lib/mcp_server_eio.ml
+++ b/lib/mcp_server_eio.ml
@@ -1051,7 +1051,7 @@ let execute_tool_eio ~sw ~clock ?mcp_session_id ?auth_token state ~name ~argumen
   (* Log tool call *)
   Log.Mcp.debug "[%s] %s" agent_name name;
 
-  (* Update activity for any tool call - TODO: migrate to Session_eio when ready *)
+  (* Update activity for any tool call *)
   if agent_name <> "unknown" then begin
     Session.update_activity registry ~agent_name ();
     (* Keep read-only/fast tools non-blocking; heartbeat is best-effort. *)

--- a/lib/tool_lodge.ml
+++ b/lib/tool_lodge.ml
@@ -1093,7 +1093,7 @@ let react_to_content ~net ?agent_name:provided_name ?post_id content =
 
 let heartbeat ~net (args : Yojson.Safe.t) =
   let source_str = Safe_ops.json_string ~default:"hn" "source" args in
-  (* TODO: GeekNews support — for now only HN is implemented *)
+  (* GeekNews support: https://github.com/jeong-sik/masc-mcp/issues/490 *)
   let (_ : source) = source_of_string source_str |> Option.value ~default:HackerNews in
 
   (* READ *)

--- a/lib/transport_grpc_next.ml
+++ b/lib/transport_grpc_next.ml
@@ -268,10 +268,8 @@ let add_task_handler (room_config: Room.config) (data: string) : string =
     encode_add_task_response response
 
 (** ClaimTask handler - assign task to agent.
-    TODO(A-3): ClaimTaskRequest proto lacks an agent_role field.
-    Add `string agent_role = 3` to proto/masc.proto and regenerate
-    to enable role-based claim filtering over gRPC. Until then the
-    call defaults to Unassigned, so role-gated tasks will be rejected. *)
+    agent_role defaults to Unassigned because the proto lacks the field.
+    See: https://github.com/jeong-sik/masc-mcp/issues/489 *)
 let claim_task_handler (room_config: Room.config) (data: string) : string =
   match decode_claim_task_request data with
   | None -> make_error_response "Invalid ClaimTaskRequest"


### PR DESCRIPTION
## Summary

로드맵 P2-3 항목: `lib/` 내 TODO/FIXME 3건 트리아지 완료.

| 파일 | TODO 내용 | 처리 |
|------|----------|------|
| `transport_grpc_next.ml:271` | `TODO(A-3)` ClaimTaskRequest proto에 agent_role 필드 없음 | 이슈 전환 → #489 |
| `tool_lodge.ml:1096` | GeekNews heartbeat 미지원 | 이슈 전환 → #490 |
| `mcp_server_eio.ml:1054` | Session_eio 마이그레이션 | 삭제 (모듈 미존재, premature) |

## Changes

- Comment-only 변경 (3파일, +4/-6)
- TODO → 이슈 링크 참조 교체 (2건)
- premature TODO 삭제 (1건)

## Test plan

- [x] `dune build` 성공
- [x] `test_tools_coverage.exe` 73 tests passed