### PR TITLE
feat(dashboard): unify nav IA and expose board/council feed health

### DIFF
--- a/dashboard/src/api.ts
+++ b/dashboard/src/api.ts
@@ -80,6 +80,30 @@ async function get<T>(path: string): Promise<T> {
   return res.json() as Promise<T>
 }
 
+function sleep(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms))
+}
+
+async function withRetries<T>(
+  operation: string,
+  run: () => Promise<T>,
+  retries = 2,
+): Promise<T> {
+  let attempt = 0
+
+  while (true) {
+    try {
+      return await run()
+    } catch (err) {
+      if (attempt >= retries) throw err
+      const delayMs = 250 * (attempt + 1)
+      console.warn(`[dashboard/api] ${operation} failed (attempt ${attempt + 1}), retrying in ${delayMs}ms`, err)
+      await sleep(delayMs)
+      attempt += 1
+    }
+  }
+}
+
 async function post<T>(path: string, body: unknown): Promise<T> {
   const res = await fetchWithTimeout(path, {
     method: 'POST',
@@ -237,36 +261,40 @@ function normalizeBoardComment(raw: unknown): BoardComment | null {
 }
 
 export async function fetchBoard(sortBy?: BoardSortMode): Promise<{ posts: BoardPost[] }> {
-  const params = new URLSearchParams()
-  if (sortBy) params.set('sort_by', sortBy)
-  params.set('limit', '100')
-  const qs = params.toString()
-  const raw = await get<{ posts?: unknown[] }>(`/api/v1/board${qs ? `?${qs}` : ''}`)
-  const posts = Array.isArray(raw.posts)
-    ? raw.posts.map(normalizeBoardPost).filter((row): row is BoardPost => row !== null)
-    : []
-  return { posts }
+  return withRetries('fetchBoard', async () => {
+    const params = new URLSearchParams()
+    if (sortBy) params.set('sort_by', sortBy)
+    params.set('limit', '100')
+    const qs = params.toString()
+    const raw = await get<{ posts?: unknown[] }>(`/api/v1/board${qs ? `?${qs}` : ''}`)
+    const posts = Array.isArray(raw.posts)
+      ? raw.posts.map(normalizeBoardPost).filter((row): row is BoardPost => row !== null)
+      : []
+    return { posts }
+  })
 }
 
 export async function fetchBoardPost(postId: string): Promise<BoardPost & { comments: BoardComment[] }> {
-  const raw = await get<Record<string, unknown>>(`/api/v1/board/${postId}?format=flat`)
-  const postRaw = isRecord(raw.post) ? raw.post : raw
-  const post = normalizeBoardPost(postRaw) ?? {
-    id: postId,
-    author: 'unknown',
-    title: 'Post',
-    content: '',
-    tags: [],
-    votes: 0,
-    comment_count: 0,
-    created_at: new Date().toISOString(),
-    updated_at: new Date().toISOString(),
-  }
-  const commentsRaw = Array.isArray(raw.comments) ? raw.comments : []
-  const comments = commentsRaw
-    .map(normalizeBoardComment)
-    .filter((row): row is BoardComment => row !== null)
-  return { ...post, comments }
+  return withRetries('fetchBoardPost', async () => {
+    const raw = await get<Record<string, unknown>>(`/api/v1/board/${postId}?format=flat`)
+    const postRaw = isRecord(raw.post) ? raw.post : raw
+    const post = normalizeBoardPost(postRaw) ?? {
+      id: postId,
+      author: 'unknown',
+      title: 'Post',
+      content: '',
+      tags: [],
+      votes: 0,
+      comment_count: 0,
+      created_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+    }
+    const commentsRaw = Array.isArray(raw.comments) ? raw.comments : []
+    const comments = commentsRaw
+      .map(normalizeBoardComment)
+      .filter((row): row is BoardComment => row !== null)
+    return { ...post, comments }
+  })
 }
 
 export function fetchBoardHearths(): Promise<{ hearths: BoardHearth[] }> {
@@ -1202,45 +1230,49 @@ export async function fetchTaskHistory(taskId: string, limit = 20): Promise<stri
 }
 
 export async function fetchDebates(): Promise<CouncilDebate[]> {
-  const raw = await get<{ debates?: unknown[] }>('/api/v1/council/debates?limit=100')
-  if (!Array.isArray(raw.debates)) return []
-  return raw.debates
-    .map((item): CouncilDebate | null => {
-      if (!isRecord(item)) return null
-      const id = asString(item.id, '').trim()
-      const topic = asString(item.topic, '').trim()
-      if (!id || !topic) return null
-      return {
-        id,
-        topic,
-        status: asString(item.status, 'open'),
-        argument_count: asNumber(item.argument_count, 0),
-        created_at: toIsoTimestamp(item.created_at_iso ?? item.created_at),
-      }
-    })
-    .filter((row): row is CouncilDebate => row !== null)
+  return withRetries('fetchDebates', async () => {
+    const raw = await get<{ debates?: unknown[] }>('/api/v1/council/debates?limit=100')
+    if (!Array.isArray(raw.debates)) return []
+    return raw.debates
+      .map((item): CouncilDebate | null => {
+        if (!isRecord(item)) return null
+        const id = asString(item.id, '').trim()
+        const topic = asString(item.topic, '').trim()
+        if (!id || !topic) return null
+        return {
+          id,
+          topic,
+          status: asString(item.status, 'open'),
+          argument_count: asNumber(item.argument_count, 0),
+          created_at: toIsoTimestamp(item.created_at_iso ?? item.created_at),
+        }
+      })
+      .filter((row): row is CouncilDebate => row !== null)
+  })
 }
 
 export async function fetchCouncilSessions(): Promise<CouncilSession[]> {
-  const raw = await get<{ sessions?: unknown[] }>('/api/v1/council/sessions?limit=100')
-  if (!Array.isArray(raw.sessions)) return []
-  return raw.sessions
-    .map((item): CouncilSession | null => {
-      if (!isRecord(item)) return null
-      const id = asString(item.id, '').trim()
-      const topic = asString(item.topic, '').trim()
-      if (!id || !topic) return null
-      return {
-        id,
-        topic,
-        initiator: asString(item.initiator, 'system'),
-        votes: asNumber(item.votes, 0),
-        quorum: asNumber(item.quorum, 0),
-        state: asString(item.state, 'open'),
-        created_at: toIsoTimestamp(item.created_at_iso ?? item.created_at),
-      }
-    })
-    .filter((row): row is CouncilSession => row !== null)
+  return withRetries('fetchCouncilSessions', async () => {
+    const raw = await get<{ sessions?: unknown[] }>('/api/v1/council/sessions?limit=100')
+    if (!Array.isArray(raw.sessions)) return []
+    return raw.sessions
+      .map((item): CouncilSession | null => {
+        if (!isRecord(item)) return null
+        const id = asString(item.id, '').trim()
+        const topic = asString(item.topic, '').trim()
+        if (!id || !topic) return null
+        return {
+          id,
+          topic,
+          initiator: asString(item.initiator, 'system'),
+          votes: asNumber(item.votes, 0),
+          quorum: asNumber(item.quorum, 0),
+          state: asString(item.state, 'open'),
+          created_at: toIsoTimestamp(item.created_at_iso ?? item.created_at),
+        }
+      })
+      .filter((row): row is CouncilSession => row !== null)
+  })
 }
 
 export async function startDebate(topic: string): Promise<CouncilDebate | null> {
@@ -1253,22 +1285,24 @@ export async function startDebate(topic: string): Promise<CouncilDebate | null> 
 }
 
 export async function fetchDebateStatus(debateId: string): Promise<CouncilDebateSummary | null> {
-  const safeId = encodeURIComponent(debateId)
-  const raw = await get<Record<string, unknown>>(`/api/v1/council/debates/${safeId}/summary`)
-  if (!isRecord(raw)) return null
-  const id = asString(raw.id, '').trim()
-  if (!id) return null
-  return {
-    id,
-    topic: asString(raw.topic, ''),
-    status: asString(raw.status, 'open'),
-    support_count: asNumber(raw.support_count, 0),
-    oppose_count: asNumber(raw.oppose_count, 0),
-    neutral_count: asNumber(raw.neutral_count, 0),
-    total_arguments: asNumber(raw.total_arguments, 0),
-    created_at: toIsoTimestamp(raw.created_at_iso ?? raw.created_at),
-    summary_text: asString(raw.summary_text, ''),
-  }
+  return withRetries('fetchDebateStatus', async () => {
+    const safeId = encodeURIComponent(debateId)
+    const raw = await get<Record<string, unknown>>(`/api/v1/council/debates/${safeId}/summary`)
+    if (!isRecord(raw)) return null
+    const id = asString(raw.id, '').trim()
+    if (!id) return null
+    return {
+      id,
+      topic: asString(raw.topic, ''),
+      status: asString(raw.status, 'open'),
+      support_count: asNumber(raw.support_count, 0),
+      oppose_count: asNumber(raw.oppose_count, 0),
+      neutral_count: asNumber(raw.neutral_count, 0),
+      total_arguments: asNumber(raw.total_arguments, 0),
+      created_at: toIsoTimestamp(raw.created_at_iso ?? raw.created_at),
+      summary_text: asString(raw.summary_text, ''),
+    }
+  })
 }
 
 export function sendKeeperMessage(name: string, message: string, models?: string[]): Promise<string> {

--- a/dashboard/src/api.ts
+++ b/dashboard/src/api.ts
@@ -42,6 +42,37 @@ function jsonHeaders(): Record<string, string> {
 const DEFAULT_GET_TIMEOUT_MS = 15_000
 const DEFAULT_POST_TIMEOUT_MS = 30_000
 const DEFAULT_MCP_TIMEOUT_MS = 60_000
+const RETRYABLE_STATUS_CODES = new Set([408, 425, 429, 500, 502, 503, 504])
+
+class ApiRequestError extends Error {
+  method: string
+  path: string
+  status?: number
+  statusText?: string
+  timeout: boolean
+
+  constructor(opts: {
+    method: string
+    path: string
+    status?: number
+    statusText?: string
+    timeout?: boolean
+    timeoutMs?: number
+  }) {
+    const method = opts.method.toUpperCase()
+    const timeout = opts.timeout === true
+    const message = timeout
+      ? `${method} ${opts.path}: timeout after ${opts.timeoutMs ?? 0}ms`
+      : `${method} ${opts.path}: ${opts.status ?? 'unknown'} ${opts.statusText ?? ''}`.trim()
+    super(message)
+    this.name = 'ApiRequestError'
+    this.method = method
+    this.path = opts.path
+    this.status = opts.status
+    this.statusText = opts.statusText
+    this.timeout = timeout
+  }
+}
 
 async function fetchWithTimeout(path: string, init: RequestInit, timeoutMs: number): Promise<Response> {
   const controller = new AbortController()
@@ -55,7 +86,12 @@ async function fetchWithTimeout(path: string, init: RequestInit, timeoutMs: numb
   } catch (err) {
     if (err instanceof Error && err.name === 'AbortError') {
       const method = typeof init.method === 'string' ? init.method.toUpperCase() : 'GET'
-      throw new Error(`${method} ${path}: timeout after ${timeoutMs}ms`)
+      throw new ApiRequestError({
+        method,
+        path,
+        timeout: true,
+        timeoutMs,
+      })
     }
     throw err
   } finally {
@@ -76,12 +112,39 @@ function defaultBoardVoter(): string {
 
 async function get<T>(path: string): Promise<T> {
   const res = await fetchWithTimeout(path, { headers: authHeaders() }, DEFAULT_GET_TIMEOUT_MS)
-  if (!res.ok) throw new Error(`GET ${path}: ${res.status} ${res.statusText}`)
+  if (!res.ok) {
+    throw new ApiRequestError({
+      method: 'GET',
+      path,
+      status: res.status,
+      statusText: res.statusText,
+    })
+  }
   return res.json() as Promise<T>
 }
 
 function sleep(ms: number): Promise<void> {
   return new Promise(resolve => setTimeout(resolve, ms))
+}
+
+function parseStatusFromMessage(message: string): number | null {
+  const match = message.match(/\b(\d{3})\b/)
+  if (!match) return null
+  const statusToken = match[1]
+  if (!statusToken) return null
+  const status = Number.parseInt(statusToken, 10)
+  return Number.isFinite(status) ? status : null
+}
+
+function isRetryableError(err: unknown): boolean {
+  if (err instanceof ApiRequestError) {
+    return err.timeout || (typeof err.status === 'number' && RETRYABLE_STATUS_CODES.has(err.status))
+  }
+
+  if (!(err instanceof Error)) return false
+  if (/timeout after \d+ms/i.test(err.message)) return true
+  const parsedStatus = parseStatusFromMessage(err.message)
+  return parsedStatus !== null && RETRYABLE_STATUS_CODES.has(parsedStatus)
 }
 
 async function withRetries<T>(
@@ -95,7 +158,7 @@ async function withRetries<T>(
     try {
       return await run()
     } catch (err) {
-      if (attempt >= retries) throw err
+      if (!isRetryableError(err) || attempt >= retries) throw err
       const delayMs = 250 * (attempt + 1)
       console.warn(`[dashboard/api] ${operation} failed (attempt ${attempt + 1}), retrying in ${delayMs}ms`, err)
       await sleep(delayMs)
@@ -110,7 +173,14 @@ async function post<T>(path: string, body: unknown): Promise<T> {
     headers: jsonHeaders(),
     body: JSON.stringify(body),
   }, DEFAULT_POST_TIMEOUT_MS)
-  if (!res.ok) throw new Error(`POST ${path}: ${res.status} ${res.statusText}`)
+  if (!res.ok) {
+    throw new ApiRequestError({
+      method: 'POST',
+      path,
+      status: res.status,
+      statusText: res.statusText,
+    })
+  }
   return res.json() as Promise<T>
 }
 
@@ -128,7 +198,14 @@ async function postRaw(
     },
     body: JSON.stringify(body),
   }, timeoutMs)
-  if (!res.ok) throw new Error(`POST ${path}: ${res.status} ${res.statusText}`)
+  if (!res.ok) {
+    throw new ApiRequestError({
+      method: 'POST',
+      path,
+      status: res.status,
+      statusText: res.statusText,
+    })
+  }
   return res.text()
 }
 

--- a/dashboard/src/app.ts
+++ b/dashboard/src/app.ts
@@ -19,7 +19,6 @@ import {
   tasks,
   keepers,
 } from './store'
-import type { TabId } from './types'
 import { Overview } from './components/overview'
 import { Council } from './components/council'
 import { Board } from './components/board'
@@ -34,6 +33,7 @@ import { ControlDock } from './components/control-dock'
 import { KeeperDetailOverlay } from './components/keeper-detail'
 import { AgentDetailOverlay } from './components/agent-detail'
 import { ToastContainer } from './components/common/toast'
+import { DASHBOARD_NAV_ITEMS } from './config/navigation'
 
 function ConnectionStatus() {
   const isConnected = connected.value
@@ -46,17 +46,6 @@ function ConnectionStatus() {
   `
 }
 
-const RAIL_TABS: { id: TabId; label: string }[] = [
-  { id: 'overview', label: 'Overview' },
-  { id: 'council', label: 'Decisions' },
-  { id: 'board', label: 'Discussions' },
-  { id: 'execution', label: 'Execution' },
-  { id: 'activity', label: 'Activity' },
-  { id: 'goals', label: 'Goals' },
-  { id: 'journal', label: 'Journal' },
-  { id: 'trpg', label: 'TRPG' },
-]
-
 function SideRail() {
   const current = route.value.tab
   const liveConnected = connected.value
@@ -66,12 +55,12 @@ function SideRail() {
       <section class="rail-card">
         <h3>Views</h3>
         <div class="rail-tab-list">
-          ${RAIL_TABS.map(t => html`
+          ${DASHBOARD_NAV_ITEMS.map(t => html`
             <button
               class="rail-tab-btn ${current === t.id ? 'active' : ''}"
               onClick=${() => navigate(t.id)}
             >
-              ${t.label}
+              ${t.icon} ${t.label}
             </button>
           `)}
         </div>

--- a/dashboard/src/components/board.ts
+++ b/dashboard/src/components/board.ts
@@ -7,7 +7,7 @@ import { Card } from './common/card'
 import { TimeAgo } from './common/time-ago'
 import { Markdown } from './common/markdown'
 import { showToast } from './common/toast'
-import { boardPosts, boardSortMode, boardLoading, refreshBoard } from '../store'
+import { boardPosts, boardSortMode, boardLoading, refreshBoard, serverStatus } from '../store'
 import { votePost, fetchBoardPost, commentPost } from '../api'
 import { navigate, navigateToPost, route } from '../router'
 import type { BoardPost, BoardComment, BoardSortMode } from '../types'
@@ -78,6 +78,23 @@ function SortBar() {
           ${m.label}
         </button>
       `)}
+    </div>
+  `
+}
+
+function BoardFeedNotice() {
+  const quality = serverStatus.value?.data_quality
+  if (!quality) return null
+  if (quality.board_contract_ok !== false && !quality.last_sync_at) return null
+
+  return html`
+    <div class="feed-health-banner ${quality.board_contract_ok === false ? 'degraded' : 'ok'}">
+      <span class="feed-health-title">
+        ${quality.board_contract_ok === false ? 'Board feed degraded' : 'Board feed synced'}
+      </span>
+      ${quality.last_sync_at
+        ? html`<span class="feed-health-meta">Last sync: <${TimeAgo} timestamp=${quality.last_sync_at} /></span>`
+        : html`<span class="feed-health-meta">No sync timestamp</span>`}
     </div>
   `
 }
@@ -217,27 +234,41 @@ export function Board() {
   const posts = boardPosts.value
   const loading = boardLoading.value
   const postId = route.value.postId
+  const boardFeedDegraded = serverStatus.value?.data_quality?.board_contract_ok === false
 
   // Detail view: single post
   if (postId) {
     const post = posts.find(p => p.id === postId)
     return post
-      ? html`<${PostDetail} post=${post} />`
+      ? html`
+          <${BoardFeedNotice} />
+          <${PostDetail} post=${post} />
+        `
       : html`
           <div>
+            <${BoardFeedNotice} />
             <button class="back-btn" onClick=${() => navigate('board')}>← Back to Board</button>
-            <div class="empty-state">Post not found</div>
+            <div class="empty-state">
+              ${boardFeedDegraded ? 'Post not available while board feed is degraded' : 'Post not found'}
+            </div>
           </div>
         `
   }
 
   // List view
   return html`
+    <${BoardFeedNotice} />
     <${SortBar} />
     ${loading
       ? html`<div class="loading-indicator">Loading board...</div>`
       : posts.length === 0
-        ? html`<div class="empty-state">No posts yet</div>`
+        ? html`
+            <div class="empty-state">
+              ${boardFeedDegraded
+                ? 'No posts loaded (board feed degraded). Check board contract sync.'
+                : 'No posts yet'}
+            </div>
+          `
         : html`<div class="board-post-list">
             ${posts.map(p => html`<${PostCard} key=${p.id} post=${p} />`)}
           </div>`}

--- a/dashboard/src/components/common/tab-nav.ts
+++ b/dashboard/src/components/common/tab-nav.ts
@@ -1,31 +1,15 @@
 // Tab navigation bar — controls hash-based routing
 
 import { html } from 'htm/preact'
-import type { TabId } from '../../types'
 import { route, navigate } from '../../router'
-
-interface TabDef {
-  id: TabId
-  label: string
-  icon: string
-}
-
-const TABS: TabDef[] = [
-  { id: 'overview', label: 'Overview', icon: '\uD83C\uDFE0' },
-  { id: 'council', label: 'Decisions', icon: '\uD83C\uDFDB\uFE0F' },
-  { id: 'board', label: 'Discussions', icon: '\uD83D\uDCAC' },
-  { id: 'execution', label: 'Execution', icon: '\uD83D\uDEE0\uFE0F' },
-  { id: 'activity', label: 'Activity', icon: '\uD83D\uDCCA' },
-  { id: 'journal', label: 'Journal', icon: '\uD83D\uDCD3' },
-  { id: 'trpg', label: 'TRPG', icon: '\u2694\uFE0F' },
-]
+import { DASHBOARD_NAV_ITEMS } from '../../config/navigation'
 
 export function TabNav() {
   const currentTab = route.value.tab
 
   return html`
     <div class="main-tab-bar">
-      ${TABS.map(t => html`
+      ${DASHBOARD_NAV_ITEMS.map(t => html`
         <button
           class="main-tab-btn ${currentTab === t.id ? 'active' : ''}"
           onClick=${() => navigate(t.id)}

--- a/dashboard/src/components/council.ts
+++ b/dashboard/src/components/council.ts
@@ -4,6 +4,7 @@ import { html } from 'htm/preact'
 import { useEffect } from 'preact/hooks'
 import { signal } from '@preact/signals'
 import { Card } from './common/card'
+import { TimeAgo } from './common/time-ago'
 import { showToast } from './common/toast'
 import {
   fetchCouncilSessions,
@@ -11,6 +12,7 @@ import {
   fetchDebateStatus,
   startDebate,
 } from '../api'
+import { serverStatus } from '../store'
 import type { CouncilDebate, CouncilDebateSummary, CouncilSession } from '../types'
 
 const debates = signal<CouncilDebate[]>([])
@@ -106,13 +108,32 @@ function SessionRow({ session }: { session: CouncilSession }) {
   `
 }
 
+function CouncilFeedNotice() {
+  const quality = serverStatus.value?.data_quality
+  if (!quality) return null
+  if (quality.council_feed_ok !== false && !quality.last_sync_at) return null
+
+  return html`
+    <div class="feed-health-banner ${quality.council_feed_ok === false ? 'degraded' : 'ok'}">
+      <span class="feed-health-title">
+        ${quality.council_feed_ok === false ? 'Council feed degraded' : 'Council feed synced'}
+      </span>
+      ${quality.last_sync_at
+        ? html`<span class="feed-health-meta">Last sync: <${TimeAgo} timestamp=${quality.last_sync_at} /></span>`
+        : html`<span class="feed-health-meta">No sync timestamp</span>`}
+    </div>
+  `
+}
+
 export function Council() {
   useEffect(() => {
     refreshCouncil()
   }, [])
+  const councilFeedDegraded = serverStatus.value?.data_quality?.council_feed_ok === false
 
   return html`
     <div>
+      <${CouncilFeedNotice} />
       <${Card} title="Council Command" class="section">
         <div class="council-create">
           <input
@@ -142,7 +163,13 @@ export function Council() {
         <${Card} title="Debates" class="section">
           <div class="council-list">
             ${debates.value.length === 0
-              ? html`<div class="empty-state">No debates yet</div>`
+              ? html`
+                  <div class="empty-state">
+                    ${councilFeedDegraded
+                      ? 'No debates loaded (council feed degraded).'
+                      : 'No debates yet'}
+                  </div>
+                `
               : debates.value.map(d => html`<${DebateRow} key=${d.id} debate=${d} />`)}
           </div>
         <//>
@@ -150,7 +177,13 @@ export function Council() {
         <${Card} title="Voting Sessions" class="section">
           <div class="council-list">
             ${sessions.value.length === 0
-              ? html`<div class="empty-state">No active sessions</div>`
+              ? html`
+                  <div class="empty-state">
+                    ${councilFeedDegraded
+                      ? 'No sessions loaded (council feed degraded).'
+                      : 'No active sessions'}
+                  </div>
+                `
               : sessions.value.map(s => html`<${SessionRow} key=${s.id} session=${s} />`)}
           </div>
         <//>

--- a/dashboard/src/config/navigation.ts
+++ b/dashboard/src/config/navigation.ts
@@ -1,0 +1,21 @@
+import type { TabId } from '../types'
+
+export interface DashboardNavItem {
+  id: TabId
+  label: string
+  icon: string
+}
+
+// Shared IA order for top nav and side rail.
+export const DASHBOARD_NAV_ITEMS: DashboardNavItem[] = [
+  { id: 'overview', label: 'Overview', icon: '\uD83C\uDFE0' },
+  { id: 'council', label: 'Council', icon: '\uD83C\uDFDB\uFE0F' },
+  { id: 'board', label: 'Board', icon: '\uD83D\uDCAC' },
+  { id: 'activity', label: 'Activity', icon: '\uD83D\uDCCA' },
+  { id: 'agents', label: 'Agents', icon: '\uD83E\uDD16' },
+  { id: 'tasks', label: 'Tasks', icon: '\uD83D\uDCCB' },
+  { id: 'goals', label: 'Goals', icon: '\uD83C\uDFAF' },
+  { id: 'execution', label: 'Execution', icon: '\uD83D\uDEE0\uFE0F' },
+  { id: 'journal', label: 'Journal', icon: '\uD83D\uDCD3' },
+  { id: 'trpg', label: 'TRPG', icon: '\u2694\uFE0F' },
+]

--- a/dashboard/src/styles/components.css
+++ b/dashboard/src/styles/components.css
@@ -456,6 +456,43 @@
 .message-time { font-size: 11px; color: #666; float: right; }
 
 /* ── Board (Posts) ─────────────────────────────────────────── */
+.feed-health-banner {
+  margin-bottom: 12px;
+  padding: 8px 10px;
+  border-radius: 8px;
+  border: 1px solid rgba(138, 163, 211, 0.3);
+  background: rgba(71, 184, 255, 0.12);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.feed-health-banner.degraded {
+  border-color: rgba(251, 191, 36, 0.4);
+  background: rgba(251, 191, 36, 0.12);
+}
+
+.feed-health-title {
+  font-size: 12px;
+  font-weight: 600;
+  color: #d8e8ff;
+}
+
+.feed-health-banner.degraded .feed-health-title {
+  color: #ffe09b;
+}
+
+.feed-health-meta {
+  font-size: 11px;
+  color: #9fb8e1;
+}
+
+.feed-health-banner.degraded .feed-health-meta {
+  color: #fcd985;
+}
+
 .board-controls {
   display: flex;
   gap: 8px;


### PR DESCRIPTION
## Summary
- added shared navigation SSOT (`dashboard/src/config/navigation.ts`)
- wired both top tab bar and side rail to same IA order/labels/icons
- added retry wrapper for board/council API fetch paths
- surfaced board/council feed health banner from `serverStatus.data_quality`
- updated empty states to distinguish true-empty vs degraded-feed cases

## Verification
- `cd dashboard && pnpm install`
- `cd dashboard && pnpm exec tsc --noEmit` (pass)

## Notes
- `pnpm test` is not available in this package (`Missing script: test`)