### PR TITLE
Walph 안정화 2차: 테스트용 LLM 디스패처 주입

### DIFF
--- a/lib/room_walph_eio.ml
+++ b/lib/room_walph_eio.ml
@@ -264,6 +264,10 @@ let get_chain_id_for_preset = function
   | "figma" -> Some "walph-figma"
   | _ -> None
 
+(** Default LLM dispatcher for Walph loop. Exposed as overridable parameter for tests. *)
+let default_llm_dispatch ~tool_name ~model ~prompt ~timeout_sec ~max_chars () =
+  Llm_direct.dispatch ~tool_name ~model ~prompt ~timeout_sec ~max_chars ()
+
 (** {1 Main Loop} *)
 
 (** Walph (Walph Wiggum variant) pattern: Keep claiming tasks until stop condition
@@ -277,7 +281,8 @@ let get_chain_id_for_preset = function
     @return Status string with loop results *)
 let walph_loop config ~net ~clock ~agent_name
     ?(preset="drain") ?(max_iterations=10) ?target
-    ?(max_consecutive_errors=5) ?(error_backoff_sec=2) () =
+    ?(max_consecutive_errors=5) ?(error_backoff_sec=2)
+    ?(llm_dispatch=default_llm_dispatch) () =
   Room.ensure_initialized config;
 
   (* Get Walph state for this specific agent *)
@@ -471,7 +476,7 @@ let walph_loop config ~net ~clock ~agent_name
 	                        (* Direct LLM call — no llm-mcp dependency *)
 	                        ignore (net, clock);  (* Previously used for llm-mcp HTTP call *)
 	                        try
-	                          let response = Llm_direct.dispatch
+	                          let response = llm_dispatch
 	                            ~tool_name:"glm"
 	                            ~model:Env_config.Llm.default_model
 	                            ~prompt:goal

--- a/test/test_walph_eio.ml
+++ b/test/test_walph_eio.ml
@@ -270,24 +270,20 @@ let test_eio_error_cutoff () =
   let _ = Masc_mcp.Room.add_task config ~title:"failing task #1" ~description:"llm fail path" ~priority:2 in
   let _ = Masc_mcp.Room.add_task config ~title:"failing task #2" ~description:"llm fail path" ~priority:2 in
 
-  let prev_zai_api_key = Sys.getenv_opt "ZAI_API_KEY" in
+  let failing_dispatch ~tool_name:_ ~model:_ ~prompt:_ ~timeout_sec:_ ~max_chars:_ () =
+    ""  (* Forces deterministic "Empty LLM response" error path *)
+  in
   let result =
-    Fun.protect
-      ~finally:(fun () ->
-        match prev_zai_api_key with
-        | Some v -> Unix.putenv "ZAI_API_KEY" v
-        | None -> Unix.putenv "ZAI_API_KEY" "")
-      (fun () ->
-        Unix.putenv "ZAI_API_KEY" "";
-        Masc_mcp.Room_walph_eio.walph_loop config
-          ~net:(Eio.Stdenv.net env)
-          ~clock:(Eio.Stdenv.clock env)
-          ~agent_name:"error-agent"
-          ~preset:"coverage"
-          ~max_iterations:10
-          ~max_consecutive_errors:2
-          ~error_backoff_sec:0
-          ())
+    Masc_mcp.Room_walph_eio.walph_loop config
+      ~net:(Eio.Stdenv.net env)
+      ~clock:(Eio.Stdenv.clock env)
+      ~agent_name:"error-agent"
+      ~preset:"coverage"
+      ~max_iterations:10
+      ~max_consecutive_errors:2
+      ~error_backoff_sec:0
+      ~llm_dispatch:failing_dispatch
+      ()
   in
   check bool "stop reason includes cutoff"
     true (contains result "max_consecutive_errors reached (2)");


### PR DESCRIPTION
## Summary
- Add overridable `llm_dispatch` parameter to `Room_walph_eio.walph_loop`
- Keep default behavior via `default_llm_dispatch` wrapper to preserve runtime behavior
- Remove test-time global env mutation (`ZAI_API_KEY`) from `test_eio_error_cutoff`
- Make cutoff path deterministic using injected failing dispatcher

## Why
- Avoid process-global side effects in tests
- Improve long-run loop test stability for repeated walph runs
- Keep production path unchanged while making tests deterministic

## Validation
- `dune build --root .`
- `dune exec --root . test/test_walph_eio.exe`
- `dune exec --root . test/test_tool_walph_coverage.exe`
