### PR TITLE
chore: wrap bare ignore() + convert sprintf JSON to Yojson (P2)

### DIFF
--- a/lib/board.ml
+++ b/lib/board.ml
@@ -278,7 +278,8 @@ let deferred_flush_fn : (store -> unit) ref = ref (fun _ -> ())
 let maybe_sweep store =
   let now = Time_compat.now () in
   if now -. store.last_sweep > float_of_int Limits.sweeper_interval_sec then
-    ignore (sweep store);
+    (try ignore (sweep store)
+     with exn -> Printf.eprintf "[board] sweep failed: %s\n%!" (Printexc.to_string exn));
   if now -. store.last_flush > flush_interval_sec then
     !deferred_flush_fn store
 

--- a/lib/mcp_server_eio.ml
+++ b/lib/mcp_server_eio.ml
@@ -435,7 +435,7 @@ let handle_read_resource_eio state id params =
                     ] in
                     ("application/json", Some (Yojson.Safe.to_string json))
                   end else
-                    ("application/json", Some (Printf.sprintf "{\"error\":\"Library document '%s' not found\"}" topic))
+                    ("application/json", Some (Yojson.Safe.to_string (`Assoc [("error", `String (Printf.sprintf "Library document '%s' not found" topic))])))
                 end else begin
                   (* Markdown single document *)
                   let path = Filename.concat library_dir (topic ^ ".md") in

--- a/lib/notify.ml
+++ b/lib/notify.ml
@@ -26,7 +26,8 @@ let run_argv_line argv =
   | h :: _ -> String.trim h
 
 let run_argv_ignore argv =
-  ignore (Process_eio.run_argv_with_status ~timeout_sec:60.0 argv)
+  (try ignore (Process_eio.run_argv_with_status ~timeout_sec:60.0 argv)
+   with exn -> Printf.eprintf "[notify] run_argv_ignore failed: %s\n%!" (Printexc.to_string exn))
 
 (** Get non-empty environment variable *)
 let getenv_nonempty name =
@@ -188,7 +189,8 @@ let send_notification ?(sound=false) ?focus_cmd ~title ~subtitle ~message () =
     send_via_terminal_notifier ~title ~subtitle ~message ~sound ~focus_cmd
   else begin
     send_via_osascript ~title ~subtitle ~message;
-    ignore (focus_on_osascript ());
+    (try ignore (focus_on_osascript ())
+     with exn -> Printf.eprintf "[notify] focus_on_osascript failed: %s\n%!" (Printexc.to_string exn));
     (* NOTE: For osascript fallback, we intentionally do not execute focus_cmd.
        focus_cmd can contain arbitrary shell snippets (user-configured) and would
        require `sh -c` execution. terminal-notifier handles click actions. *)

--- a/lib/spawn_registry.ml
+++ b/lib/spawn_registry.ml
@@ -167,7 +167,8 @@ let sweep reg =
 let maybe_sweep reg =
   let now = Time_compat.now () in
   if now -. reg.last_sweep > float_of_int Limits.sweeper_interval_sec then
-    ignore (sweep reg)
+    (try ignore (sweep reg)
+     with exn -> Printf.eprintf "[spawn_registry] sweep failed: %s\n%!" (Printexc.to_string exn))
 
 (** {1 Cooldown Management} *)
 


### PR DESCRIPTION
## 요약

P2 Hygiene Sprint: 코드 안전성 개선

### P2-1: Printf.sprintf JSON → Yojson (1건)
- `mcp_server_eio.ml:438`: 수동 JSON 조립을 `Yojson.Safe.to_string`으로 전환
- 원래 34건 추정이었으나, 실제 JSON 수동 조립은 **1건**만 해당
  - 나머지 33건은 OCaml `{| |}` quoted string(프롬프트/HTML/Cypher) 또는 `[log]` 접두사

### P2-4: 잔여 bare ignore() 래핑 (4건)
- PR #488에서 37건 처리 후 잔여 bare ignore() 분석
- 17건 중 래핑 대상 **4건** 식별:
  - `board.ml`: sweep() 에러 로깅
  - `notify.ml`: run_argv_ignore, focus_on_osascript 에러 로깅
  - `spawn_registry.ml`: sweep() 에러 로깅
- 제외 (의도적):
  - `~finally` 블록 (8건) — OCaml 리소스 해제 표준 패턴
  - `Str.search_forward` (8건) — 예외가 정상 제어 흐름 (PR #488 제외 기준)
  - 값 폐기 (4건) — stub, Atomic, Queue.pop 부작용

## 검증

- [x] `dune build` — 0 errors
- [x] `dune runtest` — 전체 통과
- [ ] Cross-model review (GLM-5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)