### PR TITLE
Harden MCP strict auth and wire viewer auth propagation

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,8 @@ Note: `decision.*`, `experiment.*`, `trpg.*`, `client.*` 네임스페이스는 `
 | `MASC_ORCHESTRATOR_ENABLED` | 0 | Orchestrator 활성화 |
 | `MASC_GUARDIAN_ENABLED` | false | 내부 수호자 루프 활성화 |
 | `MASC_GUARDIAN_MODE` | masc | `masc` / `lodge` / `both` |
+| `MASC_HTTP_AUTH_STRICT` | false | `true`면 public allowlist 외 GET도 read auth 적용 |
+| `MASC_TOOL_AUTH_STRICT` | false | `true`면 unknown non-`masc_*` tool deny, unknown `masc_*`는 worker 권한 기준 검사 |
 | `MASC_GUARDIAN_ZOMBIE_INTERVAL_SEC` | 60 | 좀비 정리 주기 (초) |
 | `MASC_GUARDIAN_GC_INTERVAL_SEC` | 3600 | GC 주기 (초, 0=비활성) |
 | `MASC_GUARDIAN_GC_DAYS` | 7 | GC 기준 일수 |
@@ -243,6 +245,8 @@ Note: `decision.*`, `experiment.*`, `trpg.*`, `client.*` 네임스페이스는 `
 - 자동 시작은 환경별로 선택
 - 로그는 실행 방식에 따라 다름 (stdout/stderr 확인)
 - SSE를 별도 터미널에서 모니터링하면 디버깅이 쉽습니다: `curl -N http://127.0.0.1:8935/sse`
+- Viewer는 URL query의 `token`/`auth_token`/`masc_token`을 초기 읽기 후 주소창에서 제거하고 로컬스토리지에 저장하지 않습니다.
+- auth strict 플래그는 운영 중 동적 토글보다 프로세스 재시작과 함께 고정 적용을 권장합니다.
 
 ## Agent Identity System
 

--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ Note: `decision.*`, `experiment.*`, `trpg.*`, `client.*` 네임스페이스는 `
 | `MASC_GUARDIAN_ENABLED` | false | 내부 수호자 루프 활성화 |
 | `MASC_GUARDIAN_MODE` | masc | `masc` / `lodge` / `both` |
 | `MASC_HTTP_AUTH_STRICT` | false | `true`면 public allowlist 외 GET도 read auth 적용 |
-| `MASC_TOOL_AUTH_STRICT` | false | `true`면 unknown non-`masc_*` tool deny, unknown `masc_*`는 worker 권한 기준 검사 |
+| `MASC_TOOL_AUTH_STRICT` | false | `true`면 unknown external tool deny, unknown internal(`masc_*`/`decision.*`/`experiment.*`/`trpg.*`/`client.*`)는 worker 권한 기준 검사 |
 | `MASC_GUARDIAN_ZOMBIE_INTERVAL_SEC` | 60 | 좀비 정리 주기 (초) |
 | `MASC_GUARDIAN_GC_INTERVAL_SEC` | 3600 | GC 주기 (초, 0=비활성) |
 | `MASC_GUARDIAN_GC_DAYS` | 7 | GC 기준 일수 |

--- a/bin/main_eio.ml
+++ b/bin/main_eio.ml
@@ -1497,6 +1497,20 @@ let auth_token_from_request request =
   | Some v -> bearer_token_from_header v
   | None -> query_param request "token"
 
+let string_starts_with s prefix =
+  let len_s = String.length s in
+  let len_p = String.length prefix in
+  len_s >= len_p && String.sub s 0 len_p = prefix
+
+let env_flag_enabled name =
+  match Sys.getenv_opt name with
+  | None -> false
+  | Some raw ->
+      let v = String.trim raw |> String.lowercase_ascii in
+      v = "1" || v = "true" || v = "yes" || v = "y" || v = "on"
+
+let http_auth_strict_enabled () = env_flag_enabled "MASC_HTTP_AUTH_STRICT"
+
 (** TTS proxy — forwards text to ElevenLabs and returns audio/mpeg bytes.
     Reads ELEVENLABS_API_KEY from environment. *)
 let trpg_tts_proxy ~body_str : (string, [> `Bad_request | `Internal_server_error] * string) result =
@@ -1626,7 +1640,6 @@ let respond_auth_error request reqd err =
   let response = Httpun.Response.create ~headers status in
   Httpun.Reqd.respond_with_string reqd response body
 
-
 (** Admin-only access - requires MASC_ADMIN_TOKEN.
     Uses timing-safe comparison (XOR-based constant-time) to prevent
     timing side-channel attacks that could leak token bytes. *)
@@ -1663,27 +1676,64 @@ let with_admin_auth handler request reqd =
               {|{"error":"Invalid admin token"}|} reqd
 
 (** Public read access - no auth required (dashboard, health) *)
-let with_public_read handler request reqd =
-  match !server_state with
-  | None -> Http.Response.json {|{"error":"not initialized"}|} reqd
-  | Some state -> handler state request reqd
+let is_public_read_path path =
+  String.equal path "/health"
+  || String.equal path "/"
+  || String.equal path "/dashboard"
+  || String.equal path "/dashboard/"
+  || String.equal path "/favicon.ico"
+  || String.equal path "/favicon.svg"
+  || string_starts_with path "/dashboard/"
+  || string_starts_with path "/dashboard/assets/"
+  || string_starts_with path "/static/"
+  || string_starts_with path "/graphiql/"
 
-(** Authenticated read access - requires valid token when auth enabled *)
-let with_read_auth handler request reqd =
+let resolve_agent_name_for_auth ~base_path request ~token :
+    (string option, Types.masc_error) result =
+  match agent_from_request request with
+  | Some raw when String.trim raw <> "" -> Ok (Some (String.trim raw))
+  | _ ->
+      (match token with
+       | None -> Ok None
+       | Some t ->
+           (match Auth.resolve_agent_from_token base_path ~token:t with
+            | Ok agent_name -> Ok (Some agent_name)
+            | Error (Types.InvalidToken _ as e) -> Error e
+            | Error (Types.TokenExpired _ as e) -> Error e
+            | Error _ -> Ok None))
+
+let rec with_public_read handler request reqd =
+  let strict = http_auth_strict_enabled () in
+  let path = Http.Request.path request in
+  if strict && not (is_public_read_path path) then
+    with_read_auth handler request reqd
+  else
+    match !server_state with
+    | None -> Http.Response.json {|{"error":"not initialized"}|} reqd
+    | Some state -> handler state request reqd
+
+and with_read_auth handler request reqd =
   match !server_state with
   | None -> Http.Response.json {|{"error":"not initialized"}|} reqd
   | Some state ->
       let base_path = state.Mcp_server.room_config.base_path in
       let auth_cfg = Auth.load_auth_config base_path in
-      let agent_name_opt = agent_from_request request in
       let token = auth_token_from_request request in
-      let agent_name = Option.value ~default:"dashboard" agent_name_opt in
-      if auth_cfg.enabled && auth_cfg.require_token && agent_name_opt = None then
-        respond_auth_error request reqd (Types.Unauthorized "Agent name required")
-      else
-        match Auth.check_permission base_path ~agent_name ~token ~permission:Types.CanReadState with
-        | Ok () -> handler state request reqd
-        | Error err -> respond_auth_error request reqd err
+      (match resolve_agent_name_for_auth ~base_path request ~token with
+       | Error err -> respond_auth_error request reqd err
+       | Ok agent_name_opt ->
+           let agent_name = Option.value ~default:"dashboard" agent_name_opt in
+           if auth_cfg.enabled && auth_cfg.require_token && token <> None && agent_name_opt = None
+           then
+             respond_auth_error request reqd
+               (Types.Unauthorized "Agent name required (X-MASC-Agent or token-bound credential)")
+           else
+             match
+               Auth.check_permission base_path ~agent_name ~token
+                 ~permission:Types.CanReadState
+             with
+             | Ok () -> handler state request reqd
+             | Error err -> respond_auth_error request reqd err)
 
 (* ================================================================ *)
 (* Dashboard Data (Batch API)                                       *)
@@ -3954,6 +4004,20 @@ let json_headers session_id protocol_version origin =
   @ mcp_headers session_id protocol_version
   @ cors_headers origin
 
+let respond_mcp_auth_error request reqd ~session_id ~protocol_version msg =
+  let origin = get_origin request in
+  let body =
+    Printf.sprintf {|{"jsonrpc":"2.0","error":{"code":-32001,"message":"%s"}}|} msg
+  in
+  let headers =
+    Httpun.Headers.of_list
+      (("content-length", string_of_int (String.length body))
+      :: ("www-authenticate", "Bearer")
+      :: json_headers session_id protocol_version origin)
+  in
+  let response = Httpun.Response.create ~headers `Unauthorized in
+  Httpun.Reqd.respond_with_string reqd response body
+
 (** GraphQL response headers *)
 let graphql_headers origin =
   [("content-type", "application/json")]
@@ -4488,96 +4552,105 @@ let handle_post_mcp request reqd =
     | None -> Mcp_session.generate ()
   in
   let auth_token = auth_token_from_request request in
-
-  Http.Request.read_body_async reqd (fun body_str ->
-    try
-      let state = get_server_state ()
-      in
-      let sw = get_switch ()
-      in
-      let clock = get_clock ()
-      in
-      let response_json =
-        Mcp_eio.handle_request ~clock ~sw ~mcp_session_id:session_id ?auth_token state body_str
-      in
-      (match protocol_version_from_body body_str with
-       | Some v -> remember_protocol_version session_id v
-       | None -> ());
-      let protocol_version = get_protocol_version_for_session ~session_id request in
-      if not (accepts_streamable_mcp request) then
-        let body = json_rpc_error (-32600)
-          "Invalid Accept header: must include application/json and text/event-stream"
-        in
-        let headers = Httpun.Headers.of_list (
-          ("content-length", string_of_int (String.length body))
-          :: json_headers session_id protocol_version origin
-        ) in
-        let response = Httpun.Response.create ~headers `Bad_request in
-        Httpun.Reqd.respond_with_string reqd response body
-      else
-        let wants_sse = accepts_sse request && not force_json_response in
-        if wants_sse then begin
-          match response_json with
-          | `Null ->
-              let headers = Httpun.Headers.of_list (
-                ("content-length", "0")
-                :: mcp_headers session_id protocol_version
-              ) in
-              let response = Httpun.Response.create ~headers `Accepted in
-              Httpun.Reqd.respond_with_string reqd response ""
-          | json when is_http_error_response json ->
-              let body = Yojson.Safe.to_string json in
-              let headers = Httpun.Headers.of_list (
-                ("content-length", string_of_int (String.length body))
-                :: json_headers session_id protocol_version origin
-              ) in
-              let response = Httpun.Response.create ~headers `Bad_request in
-              Httpun.Reqd.respond_with_string reqd response body
-          | json ->
-              let event = Sse.format_event ~event_type:"message" (Yojson.Safe.to_string json) in
-              let body = sse_prime_event () ^ event in
-              let headers = Httpun.Headers.of_list (
-                ("content-length", string_of_int (String.length body))
-                :: sse_headers session_id protocol_version origin
-              ) in
-              let response = Httpun.Response.create ~headers `OK in
-              Httpun.Reqd.respond_with_string reqd response body
-        end else begin
-          match response_json with
-          | `Null ->
-              let headers = Httpun.Headers.of_list (
-                ("content-length", "0")
-                :: mcp_headers session_id protocol_version
-              ) in
-              let response = Httpun.Response.create ~headers `Accepted in
-              Httpun.Reqd.respond_with_string reqd response ""
-          | json when is_http_error_response json ->
-              let body = Yojson.Safe.to_string json in
-              let headers = Httpun.Headers.of_list (
-                ("content-length", string_of_int (String.length body))
-                :: json_headers session_id protocol_version origin
-              ) in
-              let response = Httpun.Response.create ~headers `Bad_request in
-              Httpun.Reqd.respond_with_string reqd response body
-          | json ->
-              let body = Yojson.Safe.to_string json in
-              let headers = Httpun.Headers.of_list (
-                ("content-length", string_of_int (String.length body))
-                :: json_headers session_id protocol_version origin
-              ) in
-              let response = Httpun.Response.create ~headers `OK in
-              Httpun.Reqd.respond_with_string reqd response body
-        end
-    with exn ->
-      let protocol_version = get_protocol_version_for_session ~session_id request in
-      let body = json_rpc_error (-32603) ("Internal error: " ^ Printexc.to_string exn) in
-      let headers = Httpun.Headers.of_list (
-        ("content-length", string_of_int (String.length body))
-        :: json_headers session_id protocol_version origin
-      ) in
-        let response = Httpun.Response.create ~headers `Internal_server_error in
-        Httpun.Reqd.respond_with_string reqd response body
-  )
+  let protocol_version = get_protocol_version_for_session ~session_id request in
+  let base_path =
+    match !server_state with
+    | Some s -> s.Mcp_server.room_config.base_path
+    | None -> default_base_path ()
+  in
+  match verify_mcp_auth ~base_path request with
+  | Error msg ->
+      respond_mcp_auth_error request reqd ~session_id ~protocol_version msg
+  | Ok _cred_opt ->
+      Http.Request.read_body_async reqd (fun body_str ->
+        try
+          let state = get_server_state ()
+          in
+          let sw = get_switch ()
+          in
+          let clock = get_clock ()
+          in
+          let response_json =
+            Mcp_eio.handle_request ~clock ~sw ~mcp_session_id:session_id ?auth_token state body_str
+          in
+          (match protocol_version_from_body body_str with
+           | Some v -> remember_protocol_version session_id v
+           | None -> ());
+          let protocol_version = get_protocol_version_for_session ~session_id request in
+          if not (accepts_streamable_mcp request) then
+            let body = json_rpc_error (-32600)
+              "Invalid Accept header: must include application/json and text/event-stream"
+            in
+            let headers = Httpun.Headers.of_list (
+              ("content-length", string_of_int (String.length body))
+              :: json_headers session_id protocol_version origin
+            ) in
+            let response = Httpun.Response.create ~headers `Bad_request in
+            Httpun.Reqd.respond_with_string reqd response body
+          else
+            let wants_sse = accepts_sse request && not force_json_response in
+            if wants_sse then begin
+              match response_json with
+              | `Null ->
+                  let headers = Httpun.Headers.of_list (
+                    ("content-length", "0")
+                    :: mcp_headers session_id protocol_version
+                  ) in
+                  let response = Httpun.Response.create ~headers `Accepted in
+                  Httpun.Reqd.respond_with_string reqd response ""
+              | json when is_http_error_response json ->
+                  let body = Yojson.Safe.to_string json in
+                  let headers = Httpun.Headers.of_list (
+                    ("content-length", string_of_int (String.length body))
+                    :: json_headers session_id protocol_version origin
+                  ) in
+                  let response = Httpun.Response.create ~headers `Bad_request in
+                  Httpun.Reqd.respond_with_string reqd response body
+              | json ->
+                  let event = Sse.format_event ~event_type:"message" (Yojson.Safe.to_string json) in
+                  let body = sse_prime_event () ^ event in
+                  let headers = Httpun.Headers.of_list (
+                    ("content-length", string_of_int (String.length body))
+                    :: sse_headers session_id protocol_version origin
+                  ) in
+                  let response = Httpun.Response.create ~headers `OK in
+                  Httpun.Reqd.respond_with_string reqd response body
+            end else begin
+              match response_json with
+              | `Null ->
+                  let headers = Httpun.Headers.of_list (
+                    ("content-length", "0")
+                    :: mcp_headers session_id protocol_version
+                  ) in
+                  let response = Httpun.Response.create ~headers `Accepted in
+                  Httpun.Reqd.respond_with_string reqd response ""
+              | json when is_http_error_response json ->
+                  let body = Yojson.Safe.to_string json in
+                  let headers = Httpun.Headers.of_list (
+                    ("content-length", string_of_int (String.length body))
+                    :: json_headers session_id protocol_version origin
+                  ) in
+                  let response = Httpun.Response.create ~headers `Bad_request in
+                  Httpun.Reqd.respond_with_string reqd response body
+              | json ->
+                  let body = Yojson.Safe.to_string json in
+                  let headers = Httpun.Headers.of_list (
+                    ("content-length", string_of_int (String.length body))
+                    :: json_headers session_id protocol_version origin
+                  ) in
+                  let response = Httpun.Response.create ~headers `OK in
+                  Httpun.Reqd.respond_with_string reqd response body
+            end
+        with exn ->
+          let protocol_version = get_protocol_version_for_session ~session_id request in
+          let body = json_rpc_error (-32603) ("Internal error: " ^ Printexc.to_string exn) in
+          let headers = Httpun.Headers.of_list (
+            ("content-length", string_of_int (String.length body))
+            :: json_headers session_id protocol_version origin
+          ) in
+            let response = Httpun.Response.create ~headers `Internal_server_error in
+            Httpun.Reqd.respond_with_string reqd response body
+      )
 
 (** SSE connection tracking (prevents leaks / stale sessions) *)
 type sse_conn_info = {
@@ -4996,26 +5069,35 @@ let handle_post_messages request reqd =
   | Some session_id ->
       let protocol_version = get_protocol_version_for_session ~session_id request in
       let auth_token = auth_token_from_request request in
-      Http.Request.read_body_async reqd (fun body_str ->
-        let state = get_server_state ()
-        in
-        let sw = get_switch ()
-        in
-        let clock = get_clock ()
-        in
-        let response_json =
-          Mcp_eio.handle_request ~clock ~sw ~mcp_session_id:session_id ?auth_token state body_str
-        in
-        (match response_json with
-         | `Null -> ()
-         | json -> Sse.send_to session_id json);
-        let headers = Httpun.Headers.of_list (
-          ("content-length", "0")
-          :: mcp_headers session_id protocol_version
-        ) in
-        let response = Httpun.Response.create ~headers `Accepted in
-        Httpun.Reqd.respond_with_string reqd response ""
-      )
+      let base_path =
+        match !server_state with
+        | Some s -> s.Mcp_server.room_config.base_path
+        | None -> default_base_path ()
+      in
+      (match verify_mcp_auth ~base_path request with
+       | Error msg ->
+           respond_mcp_auth_error request reqd ~session_id ~protocol_version msg
+       | Ok _cred_opt ->
+           Http.Request.read_body_async reqd (fun body_str ->
+             let state = get_server_state ()
+             in
+             let sw = get_switch ()
+             in
+             let clock = get_clock ()
+             in
+             let response_json =
+               Mcp_eio.handle_request ~clock ~sw ~mcp_session_id:session_id ?auth_token state body_str
+             in
+             (match response_json with
+              | `Null -> ()
+              | json -> Sse.send_to session_id json);
+             let headers = Httpun.Headers.of_list (
+               ("content-length", "0")
+               :: mcp_headers session_id protocol_version
+             ) in
+             let response = Httpun.Response.create ~headers `Accepted in
+             Httpun.Reqd.respond_with_string reqd response ""
+           ))
 
 (** DELETE /mcp - Session termination *)
 let handle_delete_mcp request reqd =

--- a/bin/main_eio.ml
+++ b/bin/main_eio.ml
@@ -1614,11 +1614,14 @@ let get_origin (request : Httpun.Request.t) =
   | None -> "*"
 
 (** CORS headers *)
+let cors_allow_headers_value =
+  "Content-Type, Accept, Origin, Authorization, Idempotency-Key, Mcp-Session-Id, \
+   Mcp-Protocol-Version, Last-Event-Id, X-MASC-Agent, X-MASC-Agent-Name"
+
 let cors_headers origin = [
   ("access-control-allow-origin", origin);
   ("access-control-allow-methods", "GET, POST, DELETE, OPTIONS");
-  ("access-control-allow-headers",
-   "Content-Type, Accept, Origin, Authorization, Idempotency-Key, Mcp-Session-Id, Mcp-Protocol-Version, Last-Event-Id");
+  ("access-control-allow-headers", cors_allow_headers_value);
   ("access-control-expose-headers", "Mcp-Session-Id, Mcp-Protocol-Version");
   ("access-control-allow-credentials", "true");
 ]
@@ -1627,12 +1630,14 @@ let respond_json_with_cors ?(status = `OK) request reqd body =
   let origin = get_origin request in
   Http.Response.json ~status ~extra_headers:(cors_headers origin) body reqd
 
+let auth_error_json err =
+  Yojson.Safe.to_string
+    (`Assoc [ ("error", `String (Types.masc_error_to_string err)) ])
+
 let respond_auth_error request reqd err =
   let status = http_status_of_auth_error err in
   let origin = get_origin request in
-  let body = Yojson.Safe.to_string (`Assoc [
-    ("error", `String (Types.masc_error_to_string err));
-  ]) in
+  let body = auth_error_json err in
   let headers = Httpun.Headers.of_list (
     ("content-length", string_of_int (String.length body))
     :: cors_headers origin
@@ -1701,6 +1706,21 @@ let resolve_agent_name_for_auth ~base_path request ~token :
             | Error (Types.TokenExpired _ as e) -> Error e
             | Error _ -> Ok None))
 
+let authorize_read_request ~base_path request : (unit, Types.masc_error) result =
+  let auth_cfg = Auth.load_auth_config base_path in
+  let token = auth_token_from_request request in
+  match resolve_agent_name_for_auth ~base_path request ~token with
+  | Error err -> Error err
+  | Ok agent_name_opt ->
+      let agent_name = Option.value ~default:"dashboard" agent_name_opt in
+      if auth_cfg.enabled && auth_cfg.require_token && token <> None && agent_name_opt = None then
+        Error
+          (Types.Unauthorized
+             "Agent name required (X-MASC-Agent or token-bound credential)")
+      else
+        Auth.check_permission base_path ~agent_name ~token
+          ~permission:Types.CanReadState
+
 let rec with_public_read handler request reqd =
   let strict = http_auth_strict_enabled () in
   let path = Http.Request.path request in
@@ -1716,23 +1736,9 @@ and with_read_auth handler request reqd =
   | None -> Http.Response.json {|{"error":"not initialized"}|} reqd
   | Some state ->
       let base_path = state.Mcp_server.room_config.base_path in
-      let auth_cfg = Auth.load_auth_config base_path in
-      let token = auth_token_from_request request in
-      (match resolve_agent_name_for_auth ~base_path request ~token with
-       | Error err -> respond_auth_error request reqd err
-       | Ok agent_name_opt ->
-           let agent_name = Option.value ~default:"dashboard" agent_name_opt in
-           if auth_cfg.enabled && auth_cfg.require_token && token <> None && agent_name_opt = None
-           then
-             respond_auth_error request reqd
-               (Types.Unauthorized "Agent name required (X-MASC-Agent or token-bound credential)")
-           else
-             match
-               Auth.check_permission base_path ~agent_name ~token
-                 ~permission:Types.CanReadState
-             with
-             | Ok () -> handler state request reqd
-             | Error err -> respond_auth_error request reqd err)
+      match authorize_read_request ~base_path request with
+      | Ok () -> handler state request reqd
+      | Error err -> respond_auth_error request reqd err
 
 (* ================================================================ *)
 (* Dashboard Data (Batch API)                                       *)
@@ -4305,8 +4311,7 @@ let cors_preflight_headers origin =
   [
     ("access-control-allow-origin", origin);
     ("access-control-allow-methods", "GET, POST, DELETE, OPTIONS");
-    ("access-control-allow-headers",
-     "Content-Type, Idempotency-Key, Mcp-Session-Id, Mcp-Protocol-Version, Last-Event-Id, Accept, Origin");
+    ("access-control-allow-headers", cors_allow_headers_value);
     ("access-control-expose-headers", "Mcp-Session-Id, Mcp-Protocol-Version");
   ]
 
@@ -6282,6 +6287,11 @@ let run_server ~sw ~env ~port ~base_path =
       | Some o -> o | None -> "*"
     in
     let cors = cors_headers origin in
+    let base_path =
+      match !server_state with
+      | Some s -> s.Mcp_server.room_config.base_path
+      | None -> default_base_path ()
+    in
     let session_id_opt = get_session_id_any httpun_request in
     let h2_respond_dashboard_index () =
       let index_path = dashboard_index_path () in
@@ -6304,7 +6314,7 @@ let run_server ~sw ~env ~port ~base_path =
           h2_respond_html h2_reqd "<html><body>Dashboard build not found. Run: cd dashboard &amp;&amp; npm run build</body></html>" ~extra_headers:cors
     in
 
-    try
+    let dispatch_h2_route () =
       match httpun_meth, path with
       (* ─────────────────────────────────────────────────────────────────────
          Health & Metrics
@@ -6994,6 +7004,20 @@ let run_server ~sw ~env ~port ~base_path =
       | _ ->
           h2_respond_text h2_reqd (Printf.sprintf "404 Not Found: %s" path) ~status:`Not_found ~extra_headers:cors
 
+    in
+    try
+      if
+        http_auth_strict_enabled ()
+        && httpun_meth <> `OPTIONS
+        && string_starts_with path "/api/v1/trpg/"
+      then
+        match authorize_read_request ~base_path httpun_request with
+        | Ok () -> dispatch_h2_route ()
+        | Error err ->
+            let status = http_status_of_auth_error err in
+            h2_respond_json h2_reqd (auth_error_json err) ~status ~extra_headers:cors
+      else
+        dispatch_h2_route ()
     with exn ->
       let msg = Printexc.to_string exn in
       Printf.eprintf "[H2] Handler error: %s\n%!" msg;

--- a/bin/main_eio.ml
+++ b/bin/main_eio.ml
@@ -1684,7 +1684,6 @@ let is_public_read_path path =
   || String.equal path "/favicon.ico"
   || String.equal path "/favicon.svg"
   || string_starts_with path "/dashboard/"
-  || string_starts_with path "/dashboard/assets/"
   || string_starts_with path "/static/"
   || string_starts_with path "/graphiql/"
 
@@ -4006,9 +4005,13 @@ let json_headers session_id protocol_version origin =
 
 let respond_mcp_auth_error request reqd ~session_id ~protocol_version msg =
   let origin = get_origin request in
-  let body =
-    Printf.sprintf {|{"jsonrpc":"2.0","error":{"code":-32001,"message":"%s"}}|} msg
-  in
+  let body = Yojson.Safe.to_string (`Assoc [
+    ("jsonrpc", `String "2.0");
+    ("error", `Assoc [
+      ("code", `Int (-32001));
+      ("message", `String msg);
+    ]);
+  ]) in
   let headers =
     Httpun.Headers.of_list
       (("content-length", string_of_int (String.length body))

--- a/lib/auth.ml
+++ b/lib/auth.ml
@@ -261,13 +261,24 @@ let is_tool_auth_strict_enabled () =
 let is_masc_tool_name tool_name =
   String.length tool_name >= 5 && String.sub tool_name 0 5 = "masc_"
 
+let string_starts_with s prefix =
+  let len_s = String.length s in
+  let len_p = String.length prefix in
+  len_s >= len_p && String.sub s 0 len_p = prefix
+
+let is_protocol_canonical_tool_name tool_name =
+  string_starts_with tool_name "decision."
+  || string_starts_with tool_name "experiment."
+  || string_starts_with tool_name "trpg."
+  || string_starts_with tool_name "client."
+
 (** Check permission for a tool call *)
 let authorize_tool config ~agent_name ~token ~tool_name : (unit, masc_error) result =
   match permission_for_tool tool_name with
   | None ->
       if not (is_tool_auth_strict_enabled ()) then
         Ok ()  (* Legacy fail-open *)
-      else if is_masc_tool_name tool_name then
+      else if is_masc_tool_name tool_name || is_protocol_canonical_tool_name tool_name then
         (* Conservative default in strict mode for unmapped internal tools. *)
         check_permission config ~agent_name ~token ~permission:CanBroadcast
       else

--- a/lib/auth.ml
+++ b/lib/auth.ml
@@ -110,6 +110,24 @@ let list_credentials config : agent_credential list =
   else
     []
 
+(** Find credential by raw token (hash lookup + expiry check) *)
+let find_credential_by_token config ~token : (agent_credential, masc_error) result =
+  let token_hash = sha256_hash token in
+  match List.find_opt (fun cred -> cred.token = token_hash) (list_credentials config) with
+  | None -> Error (InvalidToken "Token mismatch")
+  | Some cred ->
+      (match cred.expires_at with
+       | None -> Ok cred
+       | Some exp_str ->
+           let now = now_iso () in
+           if now > exp_str then Error (TokenExpired cred.agent_name) else Ok cred)
+
+(** Resolve agent_name from raw token *)
+let resolve_agent_from_token config ~token : (string, masc_error) result =
+  match find_credential_by_token config ~token with
+  | Ok cred -> Ok cred.agent_name
+  | Error e -> Error e
+
 (* ============================================ *)
 (* Token operations                             *)
 (* ============================================ *)
@@ -230,10 +248,30 @@ let permission_for_tool = function
   | "masc_auth_status" | "masc_auth_refresh" -> Some CanReadState
   | _ -> None
 
+(** Strict tool auth mode:
+    - 0/false: legacy fail-open for unknown tools
+    - 1/true: unknown masc_* tools require at least worker-level permission *)
+let is_tool_auth_strict_enabled () =
+  match Sys.getenv_opt "MASC_TOOL_AUTH_STRICT" with
+  | Some raw ->
+      let v = String.trim raw |> String.lowercase_ascii in
+      v = "1" || v = "true" || v = "yes" || v = "y" || v = "on"
+  | None -> false
+
+let is_masc_tool_name tool_name =
+  String.length tool_name >= 5 && String.sub tool_name 0 5 = "masc_"
+
 (** Check permission for a tool call *)
 let authorize_tool config ~agent_name ~token ~tool_name : (unit, masc_error) result =
   match permission_for_tool tool_name with
-  | None -> Ok ()  (* Unknown tool - allow (fail-open for extensibility) *)
+  | None ->
+      if not (is_tool_auth_strict_enabled ()) then
+        Ok ()  (* Legacy fail-open *)
+      else if is_masc_tool_name tool_name then
+        (* Conservative default in strict mode for unmapped internal tools. *)
+        check_permission config ~agent_name ~token ~permission:CanBroadcast
+      else
+        Error (Forbidden { agent = agent_name; action = "use unknown non-masc tool" })
   | Some perm -> check_permission config ~agent_name ~token ~permission:perm
 
 (* ============================================ *)

--- a/lib/mcp_server_eio.ml
+++ b/lib/mcp_server_eio.ml
@@ -915,6 +915,19 @@ let execute_tool_eio ~sw ~clock ?mcp_session_id ?auth_token state ~name ~argumen
     | _ -> agent_name
   in
 
+  let is_ephemeral_agent_name name =
+    String.length name >= 6 && String.sub name 0 6 = "agent-"
+  in
+
+  let agent_name =
+    match token with
+    | Some t when is_ephemeral_agent_name agent_name ->
+        (match Auth.resolve_agent_from_token config.base_path ~token:t with
+         | Ok resolved -> resolved
+         | Error _ -> agent_name)
+    | _ -> agent_name
+  in
+
   (* Enforce tool authorization when enabled *)
   let auth_enabled = Auth.is_auth_enabled config.base_path in
   let auth_result =

--- a/test/test_auth.ml
+++ b/test/test_auth.ml
@@ -300,6 +300,23 @@ let test_authorize_unknown_non_masc_tool_strict_denied () =
   | Error (Types.Forbidden _) -> ()
   | Error e -> fail (Printf.sprintf "wrong error: %s" (Types.masc_error_to_string e))
 
+let test_authorize_unknown_canonical_tool_strict_worker_allowed () =
+  let dir = setup_test_room () in
+  let _ = Auth.enable_auth dir ~require_token:true in
+  let create_result = Auth.create_token dir ~agent_name:"worker_agent" ~role:Types.Worker in
+  let result =
+    match create_result with
+    | Ok (raw_token, _) ->
+        with_env "MASC_TOOL_AUTH_STRICT" "1" (fun () ->
+            Auth.authorize_tool dir ~agent_name:"worker_agent" ~token:(Some raw_token)
+              ~tool_name:"trpg.unlisted_tool")
+    | Error e -> Error e
+  in
+  cleanup_test_room dir;
+  match result with
+  | Ok () -> ()
+  | Error e -> fail (Types.masc_error_to_string e)
+
 (* ============================================ *)
 (* Enable/disable tests                         *)
 (* ============================================ *)
@@ -355,6 +372,8 @@ let () =
         `Quick test_authorize_unknown_masc_tool_strict_reader_denied;
       test_case "strict unknown non-masc tool denied"
         `Quick test_authorize_unknown_non_masc_tool_strict_denied;
+      test_case "strict unknown canonical tool allows worker"
+        `Quick test_authorize_unknown_canonical_tool_strict_worker_allowed;
     ];
     "enable_disable", [
       test_case "enable/disable auth" `Quick test_enable_disable_auth;

--- a/test/test_auth.ml
+++ b/test/test_auth.ml
@@ -28,6 +28,21 @@ let cleanup_test_room dir =
   in
   try rm_rf dir with _ -> ()
 
+let with_env name value f =
+  let previous = Sys.getenv_opt name in
+  Unix.putenv name value;
+  try
+    let result = f () in
+    (match previous with
+     | Some v -> Unix.putenv name v
+     | None -> Unix.putenv name "");
+    result
+  with exn ->
+    (match previous with
+     | Some v -> Unix.putenv name v
+     | None -> Unix.putenv name "");
+    raise exn
+
 (* ============================================ *)
 (* Token generation tests                       *)
 (* ============================================ *)
@@ -119,6 +134,19 @@ let test_verify_wrong_token () =
       fail (Printf.sprintf "wrong error type: %s" (Types.masc_error_to_string e))
   | Error _, _ ->
       fail "create_token should succeed"
+
+let test_resolve_agent_from_token () =
+  let dir = setup_test_room () in
+  let create_result = Auth.create_token dir ~agent_name:"resolver" ~role:Types.Worker in
+  let resolve_result =
+    match create_result with
+    | Ok (raw_token, _) -> Auth.resolve_agent_from_token dir ~token:raw_token
+    | Error e -> Error e
+  in
+  cleanup_test_room dir;
+  match resolve_result with
+  | Ok agent_name -> check string "resolved agent" "resolver" agent_name
+  | Error e -> fail (Types.masc_error_to_string e)
 
 let test_list_credentials () =
   let dir = setup_test_room () in
@@ -219,6 +247,59 @@ let test_permission_denied_for_reader () =
   | Error (Types.Forbidden _) -> ()
   | Error e -> fail (Printf.sprintf "wrong error: %s" (Types.masc_error_to_string e))
 
+let test_authorize_unknown_masc_tool_strict_worker_allowed () =
+  let dir = setup_test_room () in
+  let _ = Auth.enable_auth dir ~require_token:true in
+  let create_result = Auth.create_token dir ~agent_name:"worker_agent" ~role:Types.Worker in
+  let result =
+    match create_result with
+    | Ok (raw_token, _) ->
+        with_env "MASC_TOOL_AUTH_STRICT" "1" (fun () ->
+            Auth.authorize_tool dir ~agent_name:"worker_agent" ~token:(Some raw_token)
+              ~tool_name:"masc_unknown_tool")
+    | Error e -> Error e
+  in
+  cleanup_test_room dir;
+  match result with
+  | Ok () -> ()
+  | Error e -> fail (Types.masc_error_to_string e)
+
+let test_authorize_unknown_masc_tool_strict_reader_denied () =
+  let dir = setup_test_room () in
+  let _ = Auth.enable_auth dir ~require_token:true in
+  let create_result = Auth.create_token dir ~agent_name:"reader_agent" ~role:Types.Reader in
+  let result =
+    match create_result with
+    | Ok (raw_token, _) ->
+        with_env "MASC_TOOL_AUTH_STRICT" "1" (fun () ->
+            Auth.authorize_tool dir ~agent_name:"reader_agent" ~token:(Some raw_token)
+              ~tool_name:"masc_unknown_tool")
+    | Error e -> Error e
+  in
+  cleanup_test_room dir;
+  match result with
+  | Ok () -> fail "reader should be denied in strict mode for unknown masc tool"
+  | Error (Types.Forbidden _) -> ()
+  | Error e -> fail (Printf.sprintf "wrong error: %s" (Types.masc_error_to_string e))
+
+let test_authorize_unknown_non_masc_tool_strict_denied () =
+  let dir = setup_test_room () in
+  let _ = Auth.enable_auth dir ~require_token:true in
+  let create_result = Auth.create_token dir ~agent_name:"worker_agent" ~role:Types.Worker in
+  let result =
+    match create_result with
+    | Ok (raw_token, _) ->
+        with_env "MASC_TOOL_AUTH_STRICT" "1" (fun () ->
+            Auth.authorize_tool dir ~agent_name:"worker_agent" ~token:(Some raw_token)
+              ~tool_name:"external_unknown_tool")
+    | Error e -> Error e
+  in
+  cleanup_test_room dir;
+  match result with
+  | Ok () -> fail "unknown non-masc tool should be denied in strict mode"
+  | Error (Types.Forbidden _) -> ()
+  | Error e -> fail (Printf.sprintf "wrong error: %s" (Types.masc_error_to_string e))
+
 (* ============================================ *)
 (* Enable/disable tests                         *)
 (* ============================================ *)
@@ -254,6 +335,7 @@ let () =
       test_case "create credential" `Quick test_create_credential;
       test_case "verify token" `Quick test_verify_token;
       test_case "verify wrong token" `Quick test_verify_wrong_token;
+      test_case "resolve agent from token" `Quick test_resolve_agent_from_token;
       test_case "list credentials" `Quick test_list_credentials;
       test_case "delete credential" `Quick test_delete_credential;
     ];
@@ -267,6 +349,12 @@ let () =
       test_case "auth enabled requires token" `Quick test_auth_enabled_requires_token;
       test_case "auth enabled with valid token" `Quick test_auth_enabled_with_valid_token;
       test_case "permission denied for reader" `Quick test_permission_denied_for_reader;
+      test_case "strict unknown masc tool allows worker"
+        `Quick test_authorize_unknown_masc_tool_strict_worker_allowed;
+      test_case "strict unknown masc tool denies reader"
+        `Quick test_authorize_unknown_masc_tool_strict_reader_denied;
+      test_case "strict unknown non-masc tool denied"
+        `Quick test_authorize_unknown_non_masc_tool_strict_denied;
     ];
     "enable_disable", [
       test_case "enable/disable auth" `Quick test_enable_disable_auth;

--- a/viewer/src/config.rs
+++ b/viewer/src/config.rs
@@ -236,7 +236,14 @@ fn strip_sensitive_query_params_from_location() {
     };
     let new_url = format!("{pathname}{new_search}{hash}");
     if let Ok(history) = win.history() {
-        let _ = history.replace_state_with_url(&wasm_bindgen::JsValue::NULL, "", Some(&new_url));
+        if let Err(err) =
+            history.replace_state_with_url(&wasm_bindgen::JsValue::NULL, "", Some(&new_url))
+        {
+            log::warn!(
+                "failed to strip sensitive auth query parameters from location: {:?}",
+                err
+            );
+        }
     }
 }
 

--- a/viewer/src/config.rs
+++ b/viewer/src/config.rs
@@ -145,6 +145,10 @@ fn append_query_param(url: &str, key: &str, value: &str) -> String {
     )
 }
 
+fn is_sensitive_auth_key(key: &str) -> bool {
+    matches!(key, "token" | "auth_token" | "masc_token")
+}
+
 #[cfg(target_arch = "wasm32")]
 fn meta_content(name: &str) -> Option<String> {
     let doc = web_sys::window()?.document()?;
@@ -195,6 +199,48 @@ fn runtime_agent_name_override() -> Option<String> {
 }
 
 #[cfg(target_arch = "wasm32")]
+fn strip_sensitive_query_params_from_location() {
+    let Some(win) = web_sys::window() else {
+        return;
+    };
+    let Ok(search) = win.location().search() else {
+        return;
+    };
+    if search.trim().is_empty() {
+        return;
+    }
+
+    let mut changed = false;
+    let mut kept = Vec::new();
+    for pair in search.trim_start_matches('?').split('&') {
+        if pair.trim().is_empty() {
+            continue;
+        }
+        let key = pair.split('=').next().unwrap_or_default();
+        if is_sensitive_auth_key(key) {
+            changed = true;
+            continue;
+        }
+        kept.push(pair.to_string());
+    }
+    if !changed {
+        return;
+    }
+
+    let pathname = win.location().pathname().unwrap_or_default();
+    let hash = win.location().hash().unwrap_or_default();
+    let new_search = if kept.is_empty() {
+        String::new()
+    } else {
+        format!("?{}", kept.join("&"))
+    };
+    let new_url = format!("{pathname}{new_search}{hash}");
+    if let Ok(history) = win.history() {
+        let _ = history.replace_state_with_url(&wasm_bindgen::JsValue::NULL, "", Some(&new_url));
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
 fn runtime_auth_token_override() -> Option<String> {
     let win = web_sys::window()?;
 
@@ -226,17 +272,12 @@ fn runtime_auth_token_override() -> Option<String> {
             .or_else(|| parse_query_param(&search, "token"));
         if let Some(raw) = from_query {
             if let Some(token) = normalize_non_empty(&raw) {
-                if let Ok(Some(storage)) = win.local_storage() {
-                    let _ = storage.set_item("masc_token", &token);
-                }
-                return Some(token);
-            }
-        }
-    }
-
-    if let Ok(Some(storage)) = win.local_storage() {
-        if let Ok(Some(raw)) = storage.get_item("masc_token") {
-            if let Some(token) = normalize_non_empty(&raw) {
+                let _ = js_sys::Reflect::set(
+                    win.as_ref(),
+                    &wasm_bindgen::JsValue::from_str("__MASC_TOKEN"),
+                    &wasm_bindgen::JsValue::from_str(&token),
+                );
+                strip_sensitive_query_params_from_location();
                 return Some(token);
             }
         }
@@ -280,6 +321,31 @@ pub fn attach_auth_query(url: &str) -> String {
         }
     }
     out
+}
+
+pub fn redact_auth_query(url: &str) -> String {
+    let Some((base, query)) = url.split_once('?') else {
+        return url.to_string();
+    };
+
+    let mut parts = Vec::new();
+    for pair in query.split('&') {
+        if pair.is_empty() {
+            continue;
+        }
+        let key = pair.split('=').next().unwrap_or_default();
+        if is_sensitive_auth_key(key) {
+            parts.push(format!("{key}=***"));
+        } else {
+            parts.push(pair.to_string());
+        }
+    }
+
+    if parts.is_empty() {
+        base.to_string()
+    } else {
+        format!("{base}?{}", parts.join("&"))
+    }
 }
 
 pub fn apply_auth_headers(headers: &web_sys::Headers) -> Result<(), wasm_bindgen::JsValue> {
@@ -529,5 +595,20 @@ mod tests {
             sse_endpoint_by_name("Social").as_deref(),
             Some("/sse?room=social")
         );
+    }
+
+    #[test]
+    fn redact_auth_query_masks_sensitive_values() {
+        assert_eq!(
+            redact_auth_query(
+                "/api/v1/trpg/stream/sse?room_id=default&token=abc123&agent=viewer&auth_token=qwe"
+            ),
+            "/api/v1/trpg/stream/sse?room_id=default&token=***&agent=viewer&auth_token=***"
+        );
+    }
+
+    #[test]
+    fn redact_auth_query_keeps_plain_url() {
+        assert_eq!(redact_auth_query("/health"), "/health");
     }
 }

--- a/viewer/src/config.rs
+++ b/viewer/src/config.rs
@@ -106,6 +106,199 @@ pub fn build_masc_url(path: &str) -> String {
     compose_masc_url(&masc_mcp_base_url(), path)
 }
 
+fn normalize_non_empty(raw: &str) -> Option<String> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        None
+    } else {
+        Some(trimmed.to_string())
+    }
+}
+
+fn url_has_query_param(url: &str, key: &str) -> bool {
+    let Some((_, query)) = url.split_once('?') else {
+        return false;
+    };
+    query
+        .split('&')
+        .filter_map(|pair| pair.split_once('=').map(|(k, _)| k).or(Some(pair)))
+        .any(|k| k == key)
+}
+
+#[cfg(target_arch = "wasm32")]
+fn encode_query_component(raw: &str) -> String {
+    js_sys::encode_uri_component(raw)
+        .as_string()
+        .unwrap_or_else(|| raw.to_string())
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn encode_query_component(raw: &str) -> String {
+    raw.to_string()
+}
+
+fn append_query_param(url: &str, key: &str, value: &str) -> String {
+    let sep = if url.contains('?') { '&' } else { '?' };
+    format!(
+        "{url}{sep}{key}={value}",
+        value = encode_query_component(value)
+    )
+}
+
+#[cfg(target_arch = "wasm32")]
+fn meta_content(name: &str) -> Option<String> {
+    let doc = web_sys::window()?.document()?;
+    let selector = format!("meta[name='{}']", name);
+    let node = doc.query_selector(&selector).ok().flatten()?;
+    let content = node.get_attribute("content")?;
+    normalize_non_empty(&content)
+}
+
+#[cfg(target_arch = "wasm32")]
+fn runtime_agent_name_override() -> Option<String> {
+    let win = web_sys::window()?;
+
+    if let Ok(value) = js_sys::Reflect::get(
+        win.as_ref(),
+        &wasm_bindgen::JsValue::from_str("__MASC_AGENT"),
+    ) {
+        if let Some(raw) = value.as_string() {
+            if let Some(agent) = normalize_non_empty(&raw) {
+                return Some(agent);
+            }
+        }
+    }
+
+    if let Ok(search) = win.location().search() {
+        let from_query = parse_query_param(&search, "masc_agent")
+            .or_else(|| parse_query_param(&search, "agent"))
+            .or_else(|| parse_query_param(&search, "agent_name"));
+        if let Some(raw) = from_query {
+            if let Some(agent) = normalize_non_empty(&raw) {
+                if let Ok(Some(storage)) = win.local_storage() {
+                    let _ = storage.set_item("masc_agent", &agent);
+                }
+                return Some(agent);
+            }
+        }
+    }
+
+    if let Ok(Some(storage)) = win.local_storage() {
+        if let Ok(Some(raw)) = storage.get_item("masc_agent") {
+            if let Some(agent) = normalize_non_empty(&raw) {
+                return Some(agent);
+            }
+        }
+    }
+
+    meta_content("masc-agent")
+}
+
+#[cfg(target_arch = "wasm32")]
+fn runtime_auth_token_override() -> Option<String> {
+    let win = web_sys::window()?;
+
+    if let Ok(value) = js_sys::Reflect::get(
+        win.as_ref(),
+        &wasm_bindgen::JsValue::from_str("__MASC_TOKEN"),
+    ) {
+        if let Some(raw) = value.as_string() {
+            if let Some(token) = normalize_non_empty(&raw) {
+                return Some(token);
+            }
+        }
+    }
+
+    if let Ok(value) = js_sys::Reflect::get(
+        win.as_ref(),
+        &wasm_bindgen::JsValue::from_str("__MASC_AUTH_TOKEN"),
+    ) {
+        if let Some(raw) = value.as_string() {
+            if let Some(token) = normalize_non_empty(&raw) {
+                return Some(token);
+            }
+        }
+    }
+
+    if let Ok(search) = win.location().search() {
+        let from_query = parse_query_param(&search, "masc_token")
+            .or_else(|| parse_query_param(&search, "auth_token"))
+            .or_else(|| parse_query_param(&search, "token"));
+        if let Some(raw) = from_query {
+            if let Some(token) = normalize_non_empty(&raw) {
+                if let Ok(Some(storage)) = win.local_storage() {
+                    let _ = storage.set_item("masc_token", &token);
+                }
+                return Some(token);
+            }
+        }
+    }
+
+    if let Ok(Some(storage)) = win.local_storage() {
+        if let Ok(Some(raw)) = storage.get_item("masc_token") {
+            if let Some(token) = normalize_non_empty(&raw) {
+                return Some(token);
+            }
+        }
+    }
+
+    meta_content("masc-token")
+}
+
+pub fn viewer_agent_name() -> Option<String> {
+    #[cfg(target_arch = "wasm32")]
+    {
+        return runtime_agent_name_override();
+    }
+    #[cfg(not(target_arch = "wasm32"))]
+    {
+        None
+    }
+}
+
+pub fn viewer_auth_token() -> Option<String> {
+    #[cfg(target_arch = "wasm32")]
+    {
+        return runtime_auth_token_override();
+    }
+    #[cfg(not(target_arch = "wasm32"))]
+    {
+        None
+    }
+}
+
+pub fn attach_auth_query(url: &str) -> String {
+    let mut out = url.to_string();
+    if let Some(token) = viewer_auth_token() {
+        if !url_has_query_param(&out, "token") {
+            out = append_query_param(&out, "token", &token);
+        }
+    }
+    if let Some(agent) = viewer_agent_name() {
+        if !url_has_query_param(&out, "agent") {
+            out = append_query_param(&out, "agent", &agent);
+        }
+    }
+    out
+}
+
+pub fn apply_auth_headers(headers: &web_sys::Headers) -> Result<(), wasm_bindgen::JsValue> {
+    #[cfg(target_arch = "wasm32")]
+    {
+        if let Some(token) = viewer_auth_token() {
+            headers.set("Authorization", &format!("Bearer {}", token))?;
+        }
+        if let Some(agent) = viewer_agent_name() {
+            headers.set("X-MASC-Agent", &agent)?;
+        }
+    }
+    #[cfg(not(target_arch = "wasm32"))]
+    {
+        let _ = headers;
+    }
+    Ok(())
+}
+
 // ─── Room ID Management ─────────────────────
 
 /// Get current room ID from DOM attribute (set by dashboard/lobby) or URL param.

--- a/viewer/src/dom/actor_join.rs
+++ b/viewer/src/dom/actor_join.rs
@@ -288,6 +288,7 @@ async fn claim_actor(actor_id: &str, keeper_name: &str) -> Result<(), JsValue> {
     opts.set_body(&JsValue::from_str(&body));
 
     let request = web_sys::Request::new_with_str_and_init(&url, &opts)?;
+    config::apply_auth_headers(&request.headers())?;
     request.headers().set("Content-Type", "application/json")?;
 
     let window = web_sys::window().ok_or_else(|| JsValue::from_str("no window"))?;
@@ -340,6 +341,7 @@ async fn release_actor(actor_id: &str) -> Result<(), JsValue> {
     opts.set_body(&JsValue::from_str(&body));
 
     let request = web_sys::Request::new_with_str_and_init(&url, &opts)?;
+    config::apply_auth_headers(&request.headers())?;
     request.headers().set("Content-Type", "application/json")?;
 
     let window = web_sys::window().ok_or_else(|| JsValue::from_str("no window"))?;

--- a/viewer/src/game/http.rs
+++ b/viewer/src/game/http.rs
@@ -516,6 +516,7 @@ async fn fetch_game_state() -> Result<GameStateResponse, JsValue> {
     opts.set_mode(web_sys::RequestMode::Cors);
 
     let request = web_sys::Request::new_with_str_and_init(&url, &opts)?;
+    config::apply_auth_headers(&request.headers())?;
     request.headers().set("Accept", "application/json")?;
 
     let window = web_sys::window().ok_or_else(|| JsValue::from_str("no window"))?;

--- a/viewer/src/mode/mcp_rpc.rs
+++ b/viewer/src/mode/mcp_rpc.rs
@@ -30,6 +30,8 @@ pub(super) async fn mcp_tool_call(tool_name: &str, args: Value) -> Result<Value,
 
     let request = web_sys::Request::new_with_str_and_init(&url, &opts)
         .map_err(|e| format!("request 생성 실패: {:?}", e))?;
+    crate::config::apply_auth_headers(&request.headers())
+        .map_err(|e| format!("auth header 설정 실패: {:?}", e))?;
     request
         .headers()
         .set("Content-Type", "application/json")
@@ -300,6 +302,8 @@ pub(super) async fn http_get_text(url: &str) -> Result<(u16, String), String> {
 
     let request = web_sys::Request::new_with_str_and_init(url, &opts)
         .map_err(|e| format!("request 생성 실패: {:?}", e))?;
+    crate::config::apply_auth_headers(&request.headers())
+        .map_err(|e| format!("auth header 설정 실패: {:?}", e))?;
 
     let window = web_sys::window().ok_or_else(|| "window unavailable".to_string())?;
     let resp_value = JsFuture::from(window.fetch_with_request(&request))

--- a/viewer/src/sse/client.rs
+++ b/viewer/src/sse/client.rs
@@ -1321,6 +1321,7 @@ async fn fetch_text(url: &str) -> Result<String, JsValue> {
     opts.set_mode(web_sys::RequestMode::Cors);
 
     let request = web_sys::Request::new_with_str_and_init(url, &opts)?;
+    config::apply_auth_headers(&request.headers())?;
     request.headers().set("Accept", "application/json")?;
 
     let window = web_sys::window().ok_or_else(|| JsValue::from_str("no window"))?;
@@ -1545,7 +1546,14 @@ fn attempt_trpg_reconnect(
         move || {
             let base_url = config::trpg_stream_poll_url(0);
             let url = reconnect::url_with_last_event_id(&base_url, &last_event_id);
-            create_legacy_event_source(&url, messages, es_handle, reconnect_state, status_proxy);
+            let authed_url = config::attach_auth_query(&url);
+            create_legacy_event_source(
+                &authed_url,
+                messages,
+                es_handle,
+                reconnect_state,
+                status_proxy,
+            );
         },
     );
 }
@@ -1582,7 +1590,7 @@ pub fn setup_sse(
         return;
     }
 
-    let url = config::trpg_stream_poll_url(0);
+    let url = config::attach_auth_query(&config::trpg_stream_poll_url(0));
 
     create_legacy_event_source(
         &url,

--- a/viewer/src/sse/client.rs
+++ b/viewer/src/sse/client.rs
@@ -1428,10 +1428,11 @@ fn create_legacy_event_source(
     reconnect_state: Arc<Mutex<ReconnectState>>,
     status_proxy: Arc<Mutex<ConnectionStatusProxy>>,
 ) {
+    let safe_url = config::redact_auth_query(url);
     let es = match EventSource::new(url) {
         Ok(es) => es,
         Err(e) => {
-            log::warn!("Failed to create EventSource at {}: {:?}", url, e);
+            log::warn!("Failed to create EventSource at {}: {:?}", safe_url, e);
             attempt_trpg_reconnect(messages, es_handle, reconnect_state, status_proxy);
             return;
         }
@@ -1459,7 +1460,7 @@ fn create_legacy_event_source(
     }
 
     {
-        let connected_url = url.to_string();
+        let connected_url = safe_url.clone();
         let rs = reconnect_state.clone();
         let sp = status_proxy.clone();
         let callback = Closure::<dyn FnMut()>::new(move || {

--- a/viewer/src/sse/masc_client.rs
+++ b/viewer/src/sse/masc_client.rs
@@ -255,8 +255,9 @@ fn attempt_reconnect(
             // Compute the URL, attaching lastEventId if we have one
             let base_url = config::sse_endpoint_by_name(&mode_name).unwrap_or_default();
             let url = reconnect::url_with_last_event_id(&base_url, &last_event_id);
+            let authed_url = config::attach_auth_query(&url);
             create_event_source(
-                &url,
+                &authed_url,
                 messages,
                 es_handle,
                 reconnect_state,
@@ -283,6 +284,7 @@ pub fn setup_masc_sse(
             return;
         }
     };
+    let url = config::attach_auth_query(&url);
 
     let messages = Arc::new(Mutex::new(Vec::new()));
     let es_handle: Arc<Mutex<Option<SendEventSource>>> = Arc::new(Mutex::new(None));

--- a/viewer/src/sse/masc_client.rs
+++ b/viewer/src/sse/masc_client.rs
@@ -88,10 +88,11 @@ fn create_event_source(
     status_proxy: Arc<Mutex<ConnectionStatusProxy>>,
     mode_name: String,
 ) {
+    let safe_url = config::redact_auth_query(url);
     let es = match EventSource::new(url) {
         Ok(es) => es,
         Err(e) => {
-            log::warn!("Failed to create MASC EventSource at {}: {:?}", url, e);
+            log::warn!("Failed to create MASC EventSource at {}: {:?}", safe_url, e);
             attempt_reconnect(
                 messages,
                 es_handle,
@@ -149,7 +150,7 @@ fn create_event_source(
 
     // onopen: reset reconnect state, mark connected
     {
-        let connected_url = url.to_string();
+        let connected_url = safe_url.clone();
         let rs = reconnect_state.clone();
         let sp = status_proxy.clone();
         let callback = Closure::<dyn FnMut()>::new(move || {

--- a/viewer/src/sse/social_board.rs
+++ b/viewer/src/sse/social_board.rs
@@ -218,6 +218,7 @@ async fn fetch_board_posts() -> Result<Vec<BoardPost>, JsValue> {
     opts.set_mode(web_sys::RequestMode::Cors);
 
     let request = web_sys::Request::new_with_str_and_init(&url, &opts)?;
+    config::apply_auth_headers(&request.headers())?;
     request.headers().set("Accept", "application/json")?;
 
     let window = web_sys::window().ok_or_else(|| JsValue::from_str("no window"))?;
@@ -253,6 +254,7 @@ async fn submit_vote(post_id: &str, direction: &str) -> Result<(), JsValue> {
     opts.set_body(&JsValue::from_str(&body));
 
     let request = web_sys::Request::new_with_str_and_init(&url, &opts)?;
+    config::apply_auth_headers(&request.headers())?;
     request.headers().set("Content-Type", "application/json")?;
 
     let window = web_sys::window().ok_or_else(|| JsValue::from_str("no window"))?;
@@ -277,6 +279,7 @@ async fn fetch_post_comments(post_id: &str) -> Result<Vec<BoardComment>, JsValue
     opts.set_mode(web_sys::RequestMode::Cors);
 
     let request = web_sys::Request::new_with_str_and_init(&url, &opts)?;
+    config::apply_auth_headers(&request.headers())?;
     request.headers().set("Accept", "application/json")?;
 
     let window = web_sys::window().ok_or_else(|| JsValue::from_str("no window"))?;
@@ -315,6 +318,7 @@ async fn submit_comment(post_id: &str, content: &str) -> Result<(), JsValue> {
     opts.set_body(&JsValue::from_str(&body));
 
     let request = web_sys::Request::new_with_str_and_init(&url, &opts)?;
+    config::apply_auth_headers(&request.headers())?;
     request.headers().set("Content-Type", "application/json")?;
 
     let window = web_sys::window().ok_or_else(|| JsValue::from_str("no window"))?;


### PR DESCRIPTION
## Summary
- harden MCP HTTP auth path with strict-mode aware read/public gating and token-backed agent resolution
- enforce auth checks on MCP POST/message endpoints and add strict unknown-tool policy for authz
- propagate viewer auth (Authorization + X-MASC-Agent and SSE query fallback) across TRPG/social/MCP client calls
- add auth regression tests for token->agent resolution and strict unknown tool behavior

## Scope
- included only implementation files from this task
- excluded unrelated local changes in scripts/harness/workload/trpg_grimland_smoke.sh and scripts/viewer-local-e2e-check.sh

## Verification
- dune build
- dune exec ./test/test_auth.exe
- dune exec ./test/test_auth_coverage.exe
- cd viewer && cargo check
- cd viewer && cargo test config -- --nocapture

## Notes
- new strict flags:
  - MASC_HTTP_AUTH_STRICT
  - MASC_TOOL_AUTH_STRICT