### PR TITLE
refactor(test): migrate Tool_agent and Tool_audit tests to Alcotest

### DIFF
--- a/test/test_tool_agent_coverage.ml
+++ b/test/test_tool_agent_coverage.ml
@@ -1,245 +1,359 @@
-(** Coverage tests for Tool_agent *)
+(** Coverage tests for Tool_agent — Agent management and selection
 
-open Masc_mcp
+    Tests dispatch routing, handler execution, helper functions, and
+    selection strategies for 10 tools: masc_agents, masc_register_capabilities,
+    masc_agent_update, masc_find_by_capability, masc_get_metrics,
+    masc_agent_fitness, masc_select_agent, masc_collaboration_graph,
+    masc_consolidate_learning, masc_agent_card
+*)
 
-let () = Random.self_init ()
+module Tool_agent = Masc_mcp.Tool_agent
+module Room = Masc_mcp.Room
 
-let () = Printf.printf "\n=== Tool_agent Coverage Tests ===\n"
-
-(* Test helper *)
-let test name f =
-  try
-    f ();
-    Printf.printf "✓ %s passed\n" name
-  with e ->
-    Printf.printf "✗ %s FAILED: %s\n" name (Printexc.to_string e);
-    exit 1
-
-(* Create test context *)
 let test_counter = ref 0
-let make_test_ctx () =
+
+let temp_dir () =
   incr test_counter;
-  let tmp = Filename.concat (Filename.get_temp_dir_name ())
-    (Printf.sprintf "masc-agent-test-%d-%d" (int_of_float (Unix.gettimeofday () *. 1000.0)) !test_counter) in
-  Unix.mkdir tmp 0o755;
-  let config = Room.default_config tmp in
-  let _ = Room.init config ~agent_name:(Some "test-agent") in
-  { Tool_agent.config; agent_name = "test-agent" }
+  let dir = Filename.temp_file
+    (Printf.sprintf "test_agent_%d_" !test_counter) "" in
+  Unix.unlink dir;
+  Unix.mkdir dir 0o755;
+  dir
 
-(* Test dispatch returns None for unknown tool *)
-let () = test "dispatch_unknown_tool" (fun () ->
-  let ctx = make_test_ctx () in
-  let args = `Assoc [] in
-  assert (Tool_agent.dispatch ctx ~name:"unknown_tool" ~args = None)
-)
+let cleanup_dir dir =
+  let rec rm path =
+    if Sys.file_exists path then
+      if Sys.is_directory path then (
+        Array.iter (fun name -> rm (Filename.concat path name)) (Sys.readdir path);
+        Unix.rmdir path)
+      else Unix.unlink path
+  in
+  try rm dir with _ -> ()
 
-(* Test masc_agents dispatch *)
-let () = test "dispatch_agents" (fun () ->
-  let ctx = make_test_ctx () in
-  let args = `Assoc [] in
-  match Tool_agent.dispatch ctx ~name:"masc_agents" ~args with
-  | Some (success, _result) -> assert success
-  | None -> failwith "dispatch returned None"
-)
+let make_ctx () =
+  let base_dir = temp_dir () in
+  let config = Room.default_config base_dir in
+  ignore (Room.init config ~agent_name:(Some "test-agent"));
+  let ctx : Tool_agent.context = { config; agent_name = "test-agent" } in
+  (ctx, base_dir)
 
-(* Test handle_agents *)
-let () = test "handle_agents" (fun () ->
-  let ctx = make_test_ctx () in
-  let args = `Assoc [] in
-  let (success, result) = Tool_agent.handle_agents ctx args in
-  assert success;
-  assert (String.length result > 0)
-)
+let dispatch_exn ctx ~name ~args =
+  match Tool_agent.dispatch ctx ~name ~args with
+  | Some result -> result
+  | None -> failwith ("dispatch returned None for " ^ name)
 
-(* Test handle_register_capabilities *)
-let () = test "handle_register_capabilities" (fun () ->
-  let ctx = make_test_ctx () in
+(* ============================================================
+   Dispatch routing tests
+   ============================================================ *)
+
+let test_dispatch_unknown () =
+  let ctx, base_dir = make_ctx () in
+  let result = Tool_agent.dispatch ctx ~name:"unknown_tool" ~args:(`Assoc []) in
+  Alcotest.(check bool) "unknown returns None" true (result = None);
+  cleanup_dir base_dir
+
+let test_dispatch_agents () =
+  let ctx, base_dir = make_ctx () in
+  let result = Tool_agent.dispatch ctx ~name:"masc_agents" ~args:(`Assoc []) in
+  Alcotest.(check bool) "agents dispatches" true (result <> None);
+  cleanup_dir base_dir
+
+let test_dispatch_register_capabilities () =
+  let ctx, base_dir = make_ctx () in
+  let result = Tool_agent.dispatch ctx ~name:"masc_register_capabilities" ~args:(`Assoc []) in
+  Alcotest.(check bool) "register_capabilities dispatches" true (result <> None);
+  cleanup_dir base_dir
+
+let test_dispatch_agent_update () =
+  let ctx, base_dir = make_ctx () in
+  let result = Tool_agent.dispatch ctx ~name:"masc_agent_update" ~args:(`Assoc []) in
+  Alcotest.(check bool) "agent_update dispatches" true (result <> None);
+  cleanup_dir base_dir
+
+let test_dispatch_select_agent () =
+  let ctx, base_dir = make_ctx () in
+  let result = Tool_agent.dispatch ctx ~name:"masc_select_agent" ~args:(`Assoc []) in
+  Alcotest.(check bool) "select_agent dispatches" true (result <> None);
+  cleanup_dir base_dir
+
+(* ============================================================
+   Handler tests — masc_agents
+   ============================================================ *)
+
+let test_handle_agents () =
+  let ctx, base_dir = make_ctx () in
+  let (ok, msg) = Tool_agent.handle_agents ctx (`Assoc []) in
+  Alcotest.(check bool) "agents succeeds" true ok;
+  Alcotest.(check bool) "has response" true (String.length msg > 0);
+  cleanup_dir base_dir
+
+(* ============================================================
+   Handler tests — register_capabilities
+   ============================================================ *)
+
+let test_register_capabilities () =
+  let ctx, base_dir = make_ctx () in
   let args = `Assoc [("capabilities", `List [`String "test"; `String "code"])] in
-  let (success, _result) = Tool_agent.handle_register_capabilities ctx args in
-  assert success
-)
+  let (ok, _msg) = Tool_agent.handle_register_capabilities ctx args in
+  Alcotest.(check bool) "registers capabilities" true ok;
+  cleanup_dir base_dir
 
-(* Test handle_agent_update with status - may fail if agent file doesn't exist *)
-let () = test "handle_agent_update_status" (fun () ->
-  let ctx = make_test_ctx () in
+(* ============================================================
+   Handler tests — agent_update
+   ============================================================ *)
+
+let test_agent_update_status () =
+  let ctx, base_dir = make_ctx () in
   let args = `Assoc [("status", `String "busy")] in
-  let (_success, result) = Tool_agent.handle_agent_update ctx args in
-  (* Success or failure is acceptable - we're testing that handler runs *)
-  assert (String.length result > 0)
-)
+  let (_ok, msg) = Tool_agent.handle_agent_update ctx args in
+  Alcotest.(check bool) "has response" true (String.length msg > 0);
+  cleanup_dir base_dir
 
-(* Test handle_agent_update with capabilities - may fail if agent file doesn't exist *)
-let () = test "handle_agent_update_capabilities" (fun () ->
-  let ctx = make_test_ctx () in
+let test_agent_update_capabilities () =
+  let ctx, base_dir = make_ctx () in
   let args = `Assoc [("capabilities", `List [`String "review"; `String "refactor"])] in
-  let (_success, result) = Tool_agent.handle_agent_update ctx args in
-  assert (String.length result > 0)
-)
+  let (_ok, msg) = Tool_agent.handle_agent_update ctx args in
+  Alcotest.(check bool) "has response" true (String.length msg > 0);
+  cleanup_dir base_dir
 
-(* Test handle_find_by_capability *)
-let () = test "handle_find_by_capability" (fun () ->
-  let ctx = make_test_ctx () in
+(* ============================================================
+   Handler tests — find_by_capability
+   ============================================================ *)
+
+let test_find_by_capability () =
+  let ctx, base_dir = make_ctx () in
   let args = `Assoc [("capability", `String "test")] in
-  let (success, result) = Tool_agent.handle_find_by_capability ctx args in
-  assert success;
-  assert (String.length result > 0)
-)
+  let (ok, msg) = Tool_agent.handle_find_by_capability ctx args in
+  Alcotest.(check bool) "find succeeds" true ok;
+  Alcotest.(check bool) "has response" true (String.length msg > 0);
+  cleanup_dir base_dir
 
-(* Test handle_get_metrics - no metrics case *)
-let () = test "handle_get_metrics_no_data" (fun () ->
-  let ctx = make_test_ctx () in
+(* ============================================================
+   Handler tests — get_metrics
+   ============================================================ *)
+
+let test_get_metrics_no_data () =
+  let ctx, base_dir = make_ctx () in
   let args = `Assoc [("agent_name", `String "nonexistent"); ("days", `Int 7)] in
-  let (success, _result) = Tool_agent.handle_get_metrics ctx args in
-  (* May succeed or fail depending on whether agent has metrics *)
-  assert (success = true || success = false)
-)
+  let (_ok, msg) = dispatch_exn ctx ~name:"masc_get_metrics" ~args in
+  Alcotest.(check bool) "has response" true (String.length msg > 0);
+  cleanup_dir base_dir
 
-(* Test handle_agent_fitness with no agents *)
-let () = test "handle_agent_fitness_no_agents" (fun () ->
-  let ctx = make_test_ctx () in
-  let args = `Assoc [] in
-  let (success, result) = Tool_agent.handle_agent_fitness ctx args in
-  assert success;
-  (* Should return count:0 or some agents *)
-  assert (String.length result > 0)
-)
+(* ============================================================
+   Handler tests — agent_fitness
+   ============================================================ *)
 
-(* Test handle_agent_fitness with specific agent *)
-let () = test "handle_agent_fitness_specific" (fun () ->
-  let ctx = make_test_ctx () in
+let test_agent_fitness_no_agents () =
+  let ctx, base_dir = make_ctx () in
+  let (ok, msg) = Tool_agent.handle_agent_fitness ctx (`Assoc []) in
+  Alcotest.(check bool) "fitness succeeds" true ok;
+  Alcotest.(check bool) "has response" true (String.length msg > 0);
+  cleanup_dir base_dir
+
+let test_agent_fitness_specific () =
+  let ctx, base_dir = make_ctx () in
   let args = `Assoc [("agent_name", `String "test-agent"); ("days", `Int 7)] in
-  let (success, result) = Tool_agent.handle_agent_fitness ctx args in
-  assert success;
-  assert (String.length result > 0)
-)
+  let (ok, msg) = Tool_agent.handle_agent_fitness ctx args in
+  Alcotest.(check bool) "fitness with agent" true ok;
+  Alcotest.(check bool) "has response" true (String.length msg > 0);
+  cleanup_dir base_dir
 
-(* Test handle_select_agent - missing available_agents *)
-let () = test "handle_select_agent_missing_agents" (fun () ->
-  let ctx = make_test_ctx () in
-  let args = `Assoc [] in
-  let (success, _result) = Tool_agent.handle_select_agent ctx args in
-  assert (not success)
-)
+(* ============================================================
+   Handler tests — select_agent (3 strategies)
+   ============================================================ *)
 
-(* Test handle_select_agent - capability_first strategy *)
-let () = test "handle_select_agent_capability_first" (fun () ->
-  let ctx = make_test_ctx () in
+let test_select_agent_missing_agents () =
+  let ctx, base_dir = make_ctx () in
+  let (ok, _msg) = Tool_agent.handle_select_agent ctx (`Assoc []) in
+  Alcotest.(check bool) "missing agents fails" false ok;
+  cleanup_dir base_dir
+
+let test_select_agent_capability_first () =
+  let ctx, base_dir = make_ctx () in
   let args = `Assoc [
     ("available_agents", `List [`String "agent-a"; `String "agent-b"]);
     ("strategy", `String "capability_first");
     ("days", `Int 7);
   ] in
-  let (success, result) = Tool_agent.handle_select_agent ctx args in
-  assert success;
-  assert (String.contains result '{')
-)
+  let (ok, msg) = Tool_agent.handle_select_agent ctx args in
+  Alcotest.(check bool) "capability_first succeeds" true ok;
+  Alcotest.(check bool) "returns JSON" true (String.contains msg '{');
+  cleanup_dir base_dir
 
-(* Test handle_select_agent - random strategy *)
-let () = test "handle_select_agent_random" (fun () ->
-  let ctx = make_test_ctx () in
+let test_select_agent_random () =
+  let ctx, base_dir = make_ctx () in
   let args = `Assoc [
     ("available_agents", `List [`String "agent-x"; `String "agent-y"]);
     ("strategy", `String "random");
   ] in
-  let (success, _result) = Tool_agent.handle_select_agent ctx args in
-  assert success
-)
+  let (ok, _msg) = Tool_agent.handle_select_agent ctx args in
+  Alcotest.(check bool) "random succeeds" true ok;
+  cleanup_dir base_dir
 
-(* Test handle_select_agent - roulette_wheel strategy *)
-let () = test "handle_select_agent_roulette" (fun () ->
-  let ctx = make_test_ctx () in
+let test_select_agent_roulette () =
+  let ctx, base_dir = make_ctx () in
   let args = `Assoc [
-    ("available_agents", `List [`String "agent-1"; `String "agent-2"; `String "agent-3"]);
+    ("available_agents", `List [`String "a-1"; `String "a-2"; `String "a-3"]);
     ("strategy", `String "roulette_wheel");
   ] in
-  let (success, _result) = Tool_agent.handle_select_agent ctx args in
-  assert success
-)
+  let (ok, _msg) = Tool_agent.handle_select_agent ctx args in
+  Alcotest.(check bool) "roulette succeeds" true ok;
+  cleanup_dir base_dir
 
-(* Test handle_collaboration_graph - text format *)
-let () = test "handle_collaboration_graph_text" (fun () ->
-  let ctx = make_test_ctx () in
+(* ============================================================
+   Handler tests — collaboration_graph
+   ============================================================ *)
+
+let test_collaboration_graph_text () =
+  let ctx, base_dir = make_ctx () in
   let args = `Assoc [("format", `String "text")] in
-  let (success, result) = Tool_agent.handle_collaboration_graph ctx args in
-  assert success;
-  assert (String.length result > 0)
-)
+  let (ok, msg) = Tool_agent.handle_collaboration_graph ctx args in
+  Alcotest.(check bool) "text format succeeds" true ok;
+  Alcotest.(check bool) "has response" true (String.length msg > 0);
+  cleanup_dir base_dir
 
-(* Test handle_collaboration_graph - json format *)
-let () = test "handle_collaboration_graph_json" (fun () ->
-  let ctx = make_test_ctx () in
+let test_collaboration_graph_json () =
+  let ctx, base_dir = make_ctx () in
   let args = `Assoc [("format", `String "json")] in
-  let (success, result) = Tool_agent.handle_collaboration_graph ctx args in
-  assert success;
-  assert (String.contains result '{')
-)
+  let (ok, msg) = Tool_agent.handle_collaboration_graph ctx args in
+  Alcotest.(check bool) "json format succeeds" true ok;
+  Alcotest.(check bool) "returns JSON" true (String.contains msg '{');
+  cleanup_dir base_dir
 
-(* Test handle_consolidate_learning *)
-let () = test "handle_consolidate_learning" (fun () ->
-  let ctx = make_test_ctx () in
+(* ============================================================
+   Handler tests — consolidate_learning
+   ============================================================ *)
+
+let test_consolidate_learning () =
+  let ctx, base_dir = make_ctx () in
   let args = `Assoc [("decay_after_days", `Int 30)] in
-  let (success, result) = Tool_agent.handle_consolidate_learning ctx args in
-  assert success;
-  assert (String.length result > 0)
-)
+  let (ok, msg) = Tool_agent.handle_consolidate_learning ctx args in
+  Alcotest.(check bool) "consolidate succeeds" true ok;
+  Alcotest.(check bool) "has response" true (String.length msg > 0);
+  cleanup_dir base_dir
 
-(* Test handle_agent_card - get action *)
-let () = test "handle_agent_card_get" (fun () ->
-  let ctx = make_test_ctx () in
+(* ============================================================
+   Handler tests — agent_card
+   ============================================================ *)
+
+let test_agent_card_get () =
+  let ctx, base_dir = make_ctx () in
   let args = `Assoc [("action", `String "get")] in
-  let (success, result) = Tool_agent.handle_agent_card ctx args in
-  assert success;
-  assert (String.contains result '{')
-)
+  let (ok, msg) = Tool_agent.handle_agent_card ctx args in
+  Alcotest.(check bool) "get succeeds" true ok;
+  Alcotest.(check bool) "returns JSON" true (String.contains msg '{');
+  cleanup_dir base_dir
 
-(* Test handle_agent_card - refresh action *)
-let () = test "handle_agent_card_refresh" (fun () ->
-  let ctx = make_test_ctx () in
+let test_agent_card_refresh () =
+  let ctx, base_dir = make_ctx () in
   let args = `Assoc [("action", `String "refresh")] in
-  let (success, result) = Tool_agent.handle_agent_card ctx args in
-  assert success;
-  assert (String.length result > 0)
-)
+  let (ok, msg) = Tool_agent.handle_agent_card ctx args in
+  Alcotest.(check bool) "refresh succeeds" true ok;
+  Alcotest.(check bool) "has response" true (String.length msg > 0);
+  cleanup_dir base_dir
 
-(* Test helper functions *)
-let () = test "get_string_present" (fun () ->
+(* ============================================================
+   Helper function tests
+   ============================================================ *)
+
+let test_get_string_present () =
   let args = `Assoc [("key", `String "value")] in
-  assert (Tool_agent.get_string args "key" "default" = "value")
-)
+  Alcotest.(check string) "extracts string" "value"
+    (Tool_agent.get_string args "key" "default")
 
-let () = test "get_string_missing" (fun () ->
+let test_get_string_missing () =
   let args = `Assoc [] in
-  assert (Tool_agent.get_string args "key" "default" = "default")
-)
+  Alcotest.(check string) "uses default" "default"
+    (Tool_agent.get_string args "key" "default")
 
-let () = test "get_string_opt_present" (fun () ->
+let test_get_string_opt_present () =
   let args = `Assoc [("key", `String "value")] in
-  assert (Tool_agent.get_string_opt args "key" = Some "value")
-)
+  Alcotest.(check (option string)) "extracts Some" (Some "value")
+    (Tool_agent.get_string_opt args "key")
 
-let () = test "get_string_opt_missing" (fun () ->
+let test_get_string_opt_missing () =
   let args = `Assoc [] in
-  assert (Tool_agent.get_string_opt args "key" = None)
-)
+  Alcotest.(check (option string)) "returns None" None
+    (Tool_agent.get_string_opt args "key")
 
-let () = test "get_int_present" (fun () ->
+let test_get_int_present () =
   let args = `Assoc [("key", `Int 42)] in
-  assert (Tool_agent.get_int args "key" 0 = 42)
-)
+  Alcotest.(check int) "extracts int" 42
+    (Tool_agent.get_int args "key" 0)
 
-let () = test "get_int_missing" (fun () ->
+let test_get_int_missing () =
   let args = `Assoc [] in
-  assert (Tool_agent.get_int args "key" 99 = 99)
-)
+  Alcotest.(check int) "uses default" 99
+    (Tool_agent.get_int args "key" 99)
 
-let () = test "get_string_list_present" (fun () ->
+let test_get_string_list_present () =
   let args = `Assoc [("key", `List [`String "a"; `String "b"])] in
-  assert (Tool_agent.get_string_list args "key" = ["a"; "b"])
-)
+  Alcotest.(check (list string)) "extracts list" ["a"; "b"]
+    (Tool_agent.get_string_list args "key")
 
-let () = test "get_string_list_missing" (fun () ->
+let test_get_string_list_missing () =
   let args = `Assoc [] in
-  assert (Tool_agent.get_string_list args "key" = [])
-)
+  Alcotest.(check (list string)) "empty list" []
+    (Tool_agent.get_string_list args "key")
 
-let () = Printf.printf "\n✅ All Tool_agent tests passed!\n"
+(* ============================================================
+   Test runner
+   ============================================================ *)
+
+let () =
+  Alcotest.run "Tool_agent" [
+    ("dispatch", [
+      Alcotest.test_case "unknown returns None" `Quick test_dispatch_unknown;
+      Alcotest.test_case "agents dispatches" `Quick test_dispatch_agents;
+      Alcotest.test_case "register_capabilities dispatches" `Quick test_dispatch_register_capabilities;
+      Alcotest.test_case "agent_update dispatches" `Quick test_dispatch_agent_update;
+      Alcotest.test_case "select_agent dispatches" `Quick test_dispatch_select_agent;
+    ]);
+    ("agents", [
+      Alcotest.test_case "handle_agents" `Quick test_handle_agents;
+    ]);
+    ("register_capabilities", [
+      Alcotest.test_case "with capabilities" `Quick test_register_capabilities;
+    ]);
+    ("agent_update", [
+      Alcotest.test_case "status update" `Quick test_agent_update_status;
+      Alcotest.test_case "capabilities update" `Quick test_agent_update_capabilities;
+    ]);
+    ("find_by_capability", [
+      Alcotest.test_case "find capability" `Quick test_find_by_capability;
+    ]);
+    ("get_metrics", [
+      Alcotest.test_case "no data" `Quick test_get_metrics_no_data;
+    ]);
+    ("agent_fitness", [
+      Alcotest.test_case "no agents" `Quick test_agent_fitness_no_agents;
+      Alcotest.test_case "specific agent" `Quick test_agent_fitness_specific;
+    ]);
+    ("select_agent", [
+      Alcotest.test_case "missing agents" `Quick test_select_agent_missing_agents;
+      Alcotest.test_case "capability_first" `Quick test_select_agent_capability_first;
+      Alcotest.test_case "random" `Quick test_select_agent_random;
+      Alcotest.test_case "roulette_wheel" `Quick test_select_agent_roulette;
+    ]);
+    ("collaboration_graph", [
+      Alcotest.test_case "text format" `Quick test_collaboration_graph_text;
+      Alcotest.test_case "json format" `Quick test_collaboration_graph_json;
+    ]);
+    ("consolidate_learning", [
+      Alcotest.test_case "with decay" `Quick test_consolidate_learning;
+    ]);
+    ("agent_card", [
+      Alcotest.test_case "get action" `Quick test_agent_card_get;
+      Alcotest.test_case "refresh action" `Quick test_agent_card_refresh;
+    ]);
+    ("helpers", [
+      Alcotest.test_case "get_string present" `Quick test_get_string_present;
+      Alcotest.test_case "get_string missing" `Quick test_get_string_missing;
+      Alcotest.test_case "get_string_opt present" `Quick test_get_string_opt_present;
+      Alcotest.test_case "get_string_opt missing" `Quick test_get_string_opt_missing;
+      Alcotest.test_case "get_int present" `Quick test_get_int_present;
+      Alcotest.test_case "get_int missing" `Quick test_get_int_missing;
+      Alcotest.test_case "get_string_list present" `Quick test_get_string_list_present;
+      Alcotest.test_case "get_string_list missing" `Quick test_get_string_list_missing;
+    ]);
+  ]

--- a/test/test_tool_audit_coverage.ml
+++ b/test/test_tool_audit_coverage.ml
@@ -1,99 +1,110 @@
-(** Coverage tests for Tool_audit *)
+(** Coverage tests for Tool_audit — Audit query, stats, and governance
 
-open Masc_mcp
+    Tests dispatch routing, handler execution, audit_event_to_json,
+    read_audit_events, and helper functions
+    for 3 tools: masc_audit_query, masc_audit_stats, masc_governance_report
+*)
 
-let () = Random.self_init ()
+module Tool_audit = Masc_mcp.Tool_audit
+module Room = Masc_mcp.Room
 
-let () = Printf.printf "\n=== Tool_audit Coverage Tests ===\n"
-
-(* Test helper *)
-let test name f =
-  try
-    f ();
-    Printf.printf "✓ %s passed\n" name
-  with e ->
-    Printf.printf "✗ %s FAILED: %s\n" name (Printexc.to_string e);
-    exit 1
-
-(* Create test context *)
 let test_counter = ref 0
-let make_test_ctx () =
+
+let temp_dir () =
   incr test_counter;
-  let tmp = Filename.concat (Filename.get_temp_dir_name ())
-    (Printf.sprintf "masc-audit-test-%d-%d" (int_of_float (Unix.gettimeofday () *. 1000.0)) !test_counter) in
-  Unix.mkdir tmp 0o755;
-  let config = Room.default_config tmp in
-  { Tool_audit.config }
+  let dir = Filename.temp_file
+    (Printf.sprintf "test_audit_%d_" !test_counter) "" in
+  Unix.unlink dir;
+  Unix.mkdir dir 0o755;
+  dir
 
-(* Test dispatch returns None for unknown tool *)
-let () = test "dispatch_unknown_tool" (fun () ->
-  let ctx = make_test_ctx () in
-  let args = `Assoc [] in
-  assert (Tool_audit.dispatch ctx ~name:"unknown_tool" ~args = None)
-)
+let cleanup_dir dir =
+  let rec rm path =
+    if Sys.file_exists path then
+      if Sys.is_directory path then (
+        Array.iter (fun name -> rm (Filename.concat path name)) (Sys.readdir path);
+        Unix.rmdir path)
+      else Unix.unlink path
+  in
+  try rm dir with _ -> ()
 
-(* Test audit_query dispatch *)
-let () = test "dispatch_audit_query" (fun () ->
-  let ctx = make_test_ctx () in
-  let args = `Assoc [] in
-  match Tool_audit.dispatch ctx ~name:"masc_audit_query" ~args with
-  | Some (success, _result) -> assert success
-  | None -> failwith "dispatch returned None"
-)
+let make_ctx () =
+  let base_dir = temp_dir () in
+  let config = Room.default_config base_dir in
+  ignore (Room.init config ~agent_name:(Some "test-agent"));
+  let ctx = { Tool_audit.config } in
+  (ctx, base_dir)
 
-(* Test handle_audit_query with filters *)
-let () = test "handle_audit_query_with_filters" (fun () ->
-  let ctx = make_test_ctx () in
+(* ============================================================
+   Dispatch routing tests
+   ============================================================ *)
+
+let test_dispatch_unknown () =
+  let ctx, base_dir = make_ctx () in
+  let result = Tool_audit.dispatch ctx ~name:"unknown_tool" ~args:(`Assoc []) in
+  Alcotest.(check bool) "unknown returns None" true (result = None);
+  cleanup_dir base_dir
+
+let test_dispatch_audit_query () =
+  let ctx, base_dir = make_ctx () in
+  let result = Tool_audit.dispatch ctx ~name:"masc_audit_query" ~args:(`Assoc []) in
+  Alcotest.(check bool) "audit_query dispatches" true (result <> None);
+  cleanup_dir base_dir
+
+let test_dispatch_audit_stats () =
+  let ctx, base_dir = make_ctx () in
+  let result = Tool_audit.dispatch ctx ~name:"masc_audit_stats" ~args:(`Assoc []) in
+  Alcotest.(check bool) "audit_stats dispatches" true (result <> None);
+  cleanup_dir base_dir
+
+(* ============================================================
+   Handler tests — audit_query
+   ============================================================ *)
+
+let test_audit_query_empty () =
+  let ctx, base_dir = make_ctx () in
+  let (ok, msg) = Tool_audit.handle_audit_query ctx (`Assoc []) in
+  Alcotest.(check bool) "empty query succeeds" true ok;
+  Alcotest.(check bool) "has response" true (String.length msg > 0);
+  cleanup_dir base_dir
+
+let test_audit_query_with_filters () =
+  let ctx, base_dir = make_ctx () in
   let args = `Assoc [
     ("agent", `String "test-agent");
     ("event_type", `String "tool_call");
     ("limit", `Int 10);
     ("since_hours", `Float 12.0);
   ] in
-  let (success, result) = Tool_audit.handle_audit_query ctx args in
-  assert success;
-  assert (String.length result > 0)
-)
+  let (ok, msg) = Tool_audit.handle_audit_query ctx args in
+  Alcotest.(check bool) "filtered query succeeds" true ok;
+  Alcotest.(check bool) "has response" true (String.length msg > 0);
+  cleanup_dir base_dir
 
-(* Test handle_audit_query empty *)
-let () = test "handle_audit_query_empty" (fun () ->
-  let ctx = make_test_ctx () in
-  let args = `Assoc [] in
-  let (success, result) = Tool_audit.handle_audit_query ctx args in
-  assert success;
-  (* Result should be JSON with empty events *)
-  assert (String.length result > 0)
-)
+(* ============================================================
+   Handler tests — audit_stats
+   ============================================================ *)
 
-(* Test audit_stats dispatch *)
-let () = test "dispatch_audit_stats" (fun () ->
-  let ctx = make_test_ctx () in
-  let args = `Assoc [] in
-  match Tool_audit.dispatch ctx ~name:"masc_audit_stats" ~args with
-  | Some (success, _result) -> assert success
-  | None -> failwith "dispatch returned None"
-)
+let test_audit_stats_empty () =
+  let ctx, base_dir = make_ctx () in
+  let (ok, msg) = Tool_audit.handle_audit_stats ctx (`Assoc []) in
+  Alcotest.(check bool) "empty stats succeeds" true ok;
+  Alcotest.(check bool) "has response" true (String.length msg > 0);
+  cleanup_dir base_dir
 
-(* Test handle_audit_stats *)
-let () = test "handle_audit_stats" (fun () ->
-  let ctx = make_test_ctx () in
-  let args = `Assoc [] in
-  let (success, result) = Tool_audit.handle_audit_stats ctx args in
-  assert success;
-  assert (String.length result > 0)
-)
-
-(* Test handle_audit_stats with agent filter *)
-let () = test "handle_audit_stats_with_agent" (fun () ->
-  let ctx = make_test_ctx () in
+let test_audit_stats_with_agent () =
+  let ctx, base_dir = make_ctx () in
   let args = `Assoc [("agent", `String "test-agent")] in
-  let (success, result) = Tool_audit.handle_audit_stats ctx args in
-  assert success;
-  assert (String.length result > 0)
-)
+  let (ok, msg) = Tool_audit.handle_audit_stats ctx args in
+  Alcotest.(check bool) "agent filter succeeds" true ok;
+  Alcotest.(check bool) "has response" true (String.length msg > 0);
+  cleanup_dir base_dir
 
-(* Test audit_event_to_json *)
-let () = test "audit_event_to_json" (fun () ->
+(* ============================================================
+   audit_event_to_json tests
+   ============================================================ *)
+
+let test_event_to_json_with_detail () =
   let event : Tool_audit.audit_event = {
     timestamp = 1234567890.0;
     agent = "test-agent";
@@ -103,13 +114,14 @@ let () = test "audit_event_to_json" (fun () ->
   } in
   let json = Tool_audit.audit_event_to_json event in
   let open Yojson.Safe.Util in
-  assert (json |> member "agent" |> to_string = "test-agent");
-  assert (json |> member "event_type" |> to_string = "tool_call");
-  assert (json |> member "success" |> to_bool = true)
-)
+  Alcotest.(check string) "agent field" "test-agent"
+    (json |> member "agent" |> to_string);
+  Alcotest.(check string) "event_type field" "tool_call"
+    (json |> member "event_type" |> to_string);
+  Alcotest.(check bool) "success field" true
+    (json |> member "success" |> to_bool)
 
-(* Test audit_event_to_json without detail *)
-let () = test "audit_event_to_json_no_detail" (fun () ->
+let test_event_to_json_no_detail () =
   let event : Tool_audit.audit_event = {
     timestamp = 1234567890.0;
     agent = "test-agent";
@@ -119,60 +131,104 @@ let () = test "audit_event_to_json_no_detail" (fun () ->
   } in
   let json = Tool_audit.audit_event_to_json event in
   let open Yojson.Safe.Util in
-  assert (json |> member "detail" = `Null)
-)
+  Alcotest.(check bool) "detail is null" true
+    (json |> member "detail" = `Null)
 
-(* Test read_audit_events empty *)
-let () = test "read_audit_events_empty" (fun () ->
-  let ctx = make_test_ctx () in
+(* ============================================================
+   read_audit_events tests
+   ============================================================ *)
+
+let test_read_audit_events_empty () =
+  let ctx, base_dir = make_ctx () in
   let events = Tool_audit.read_audit_events ctx.config ~since:0.0 in
-  assert (events = [])
-)
+  Alcotest.(check (list unit)) "empty events" []
+    (List.map (fun _ -> ()) events);
+  cleanup_dir base_dir
 
-(* Test helper functions *)
-let () = test "get_string_present" (fun () ->
+(* ============================================================
+   Helper function tests
+   ============================================================ *)
+
+let test_get_string_present () =
   let args = `Assoc [("key", `String "value")] in
-  assert (Tool_audit.get_string args "key" "default" = "value")
-)
+  Alcotest.(check string) "extracts string" "value"
+    (Tool_audit.get_string args "key" "default")
 
-let () = test "get_string_missing" (fun () ->
+let test_get_string_missing () =
   let args = `Assoc [] in
-  assert (Tool_audit.get_string args "key" "default" = "default")
-)
+  Alcotest.(check string) "uses default" "default"
+    (Tool_audit.get_string args "key" "default")
 
-let () = test "get_string_opt_present" (fun () ->
+let test_get_string_opt_present () =
   let args = `Assoc [("key", `String "value")] in
-  assert (Tool_audit.get_string_opt args "key" = Some "value")
-)
+  Alcotest.(check (option string)) "extracts Some" (Some "value")
+    (Tool_audit.get_string_opt args "key")
 
-let () = test "get_string_opt_missing" (fun () ->
+let test_get_string_opt_missing () =
   let args = `Assoc [] in
-  assert (Tool_audit.get_string_opt args "key" = None)
-)
+  Alcotest.(check (option string)) "returns None" None
+    (Tool_audit.get_string_opt args "key")
 
-let () = test "get_int_present" (fun () ->
+let test_get_int_present () =
   let args = `Assoc [("key", `Int 42)] in
-  assert (Tool_audit.get_int args "key" 0 = 42)
-)
+  Alcotest.(check int) "extracts int" 42
+    (Tool_audit.get_int args "key" 0)
 
-let () = test "get_int_missing" (fun () ->
+let test_get_int_missing () =
   let args = `Assoc [] in
-  assert (Tool_audit.get_int args "key" 99 = 99)
-)
+  Alcotest.(check int) "uses default" 99
+    (Tool_audit.get_int args "key" 99)
 
-let () = test "get_float_present" (fun () ->
+let test_get_float_present () =
   let args = `Assoc [("key", `Float 3.14)] in
-  assert (Tool_audit.get_float args "key" 0.0 = 3.14)
-)
+  Alcotest.(check (float 0.001)) "extracts float" 3.14
+    (Tool_audit.get_float args "key" 0.0)
 
-let () = test "get_float_from_int" (fun () ->
+let test_get_float_from_int () =
   let args = `Assoc [("key", `Int 42)] in
-  assert (Tool_audit.get_float args "key" 0.0 = 42.0)
-)
+  Alcotest.(check (float 0.001)) "int to float" 42.0
+    (Tool_audit.get_float args "key" 0.0)
 
-let () = test "get_float_missing" (fun () ->
+let test_get_float_missing () =
   let args = `Assoc [] in
-  assert (Tool_audit.get_float args "key" 1.5 = 1.5)
-)
+  Alcotest.(check (float 0.001)) "uses default" 1.5
+    (Tool_audit.get_float args "key" 1.5)
 
-let () = Printf.printf "\n✅ All Tool_audit tests passed!\n"
+(* ============================================================
+   Test runner
+   ============================================================ *)
+
+let () =
+  Alcotest.run "Tool_audit" [
+    ("dispatch", [
+      Alcotest.test_case "unknown returns None" `Quick test_dispatch_unknown;
+      Alcotest.test_case "audit_query dispatches" `Quick test_dispatch_audit_query;
+      Alcotest.test_case "audit_stats dispatches" `Quick test_dispatch_audit_stats;
+    ]);
+    ("audit_query", [
+      Alcotest.test_case "empty query" `Quick test_audit_query_empty;
+      Alcotest.test_case "with filters" `Quick test_audit_query_with_filters;
+    ]);
+    ("audit_stats", [
+      Alcotest.test_case "empty stats" `Quick test_audit_stats_empty;
+      Alcotest.test_case "with agent filter" `Quick test_audit_stats_with_agent;
+    ]);
+    ("audit_event_to_json", [
+      Alcotest.test_case "with detail" `Quick test_event_to_json_with_detail;
+      Alcotest.test_case "no detail" `Quick test_event_to_json_no_detail;
+    ]);
+    ("read_audit_events", [
+      Alcotest.test_case "empty log" `Quick test_read_audit_events_empty;
+    ]);
+    ("helpers", [
+      Alcotest.test_case "get_string present" `Quick test_get_string_present;
+      Alcotest.test_case "get_string missing" `Quick test_get_string_missing;
+      Alcotest.test_case "get_string_opt present" `Quick test_get_string_opt_present;
+      Alcotest.test_case "get_string_opt missing" `Quick test_get_string_opt_missing;
+      Alcotest.test_case "get_int present" `Quick test_get_int_present;
+      Alcotest.test_case "get_int missing" `Quick test_get_int_missing;
+      Alcotest.test_case "get_float present" `Quick test_get_float_present;
+      Alcotest.test_case "get_float from int" `Quick test_get_float_from_int;
+      Alcotest.test_case "get_float missing" `Quick test_get_float_missing;
+    ]);
+  ]


### PR DESCRIPTION
## Summary

P3 Phase 3: 기존 커버리지 테스트를 Alcotest 프레임워크로 마이그레이션.

- **Tool_agent**: Printf 기반 커스텀 러너 → Alcotest (30 tests, 12 groups)
- **Tool_audit**: Printf 기반 커스텀 러너 → Alcotest (19 tests, 6 groups)
- **Tool_plan**: 변경 없음 (이미 Alcotest 사용 중)

### 변경 사항
- `Unix.gettimeofday()` 제거 (counter 기반 temp dir 생성)
- 임시 디렉토리 cleanup 추가 (`cleanup_dir`)
- 구조화된 Alcotest 테스트 그룹 (dispatch, handler, helper)
- Phase 1-2 패턴과 일관된 구조

## Test plan
- [x] `dune build` 성공
- [x] `test_tool_plan_coverage` 18 tests 통과
- [x] `test_tool_agent_coverage` 30 tests 통과
- [x] `test_tool_audit_coverage` 19 tests 통과
- [ ] CI green 확인
- [ ] Cross-model 리뷰 (GLM-5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)