### PR TITLE
test(p3): coverage tests for Tool_board and Tool_goals

### DIFF
--- a/test/dune
+++ b/test/dune
@@ -504,3 +504,15 @@
  (name test_anti_fake)
  (modules test_anti_fake)
  (libraries masc_mcp alcotest yojson))
+
+; P3 Phase 5: Tool_board coverage tests
+(test
+ (name test_tool_board_coverage)
+ (modules test_tool_board_coverage)
+ (libraries masc_mcp alcotest eio eio_main yojson str mirage-crypto-rng mirage-crypto-rng.unix))
+
+; P3 Phase 5: Tool_goals coverage tests (supplementing test_tool_goals)
+(test
+ (name test_tool_goals_coverage)
+ (modules test_tool_goals_coverage)
+ (libraries masc_mcp alcotest yojson unix))

--- a/test/test_tool_board_coverage.ml
+++ b/test/test_tool_board_coverage.ml
@@ -1,0 +1,425 @@
+open Masc_mcp
+
+(** {1 Test helpers} *)
+
+(** Clear all Board global state for test isolation.
+    Must call inside Eio_main.run since Board.store contains Eio.Mutex. *)
+let rng_initialized = ref false
+
+let cleanup () =
+  if not !rng_initialized then begin
+    Mirage_crypto_rng_unix.use_default ();
+    rng_initialized := true
+  end;
+  Board_dispatch.reset_for_test ();
+  let store = Board.global () in
+  Hashtbl.reset store.Board.posts;
+  Hashtbl.reset store.Board.comments;
+  Hashtbl.reset store.Board.vote_log;
+  Hashtbl.reset store.Board.comments_by_post;
+  store.Board.post_count := 0;
+  store.Board.karma_cache <- None;
+  store.Board.sorted_posts_cache <- None;
+  store.Board.dirty_posts <- false;
+  store.Board.dirty_comments <- false
+
+let dispatch name args =
+  Tool_board.handle_tool name args
+
+let make_args pairs = `Assoc pairs
+
+(** {2 Group 1: Helper / Formatting Functions} *)
+
+let test_visibility_of_string () =
+  Eio_main.run @@ fun _env ->
+  cleanup ();
+  Alcotest.(check string) "public" "public"
+    (match Tool_board.visibility_of_string "public" with
+     | Some Board.Public -> "public" | _ -> "other");
+  Alcotest.(check string) "unlisted" "unlisted"
+    (match Tool_board.visibility_of_string "unlisted" with
+     | Some Board.Unlisted -> "unlisted" | _ -> "other");
+  Alcotest.(check string) "internal" "internal"
+    (match Tool_board.visibility_of_string "internal" with
+     | Some Board.Internal -> "internal" | _ -> "other");
+  Alcotest.(check string) "direct" "direct"
+    (match Tool_board.visibility_of_string "direct" with
+     | Some Board.Direct -> "direct" | _ -> "other");
+  Alcotest.(check string) "unknown returns None" "none"
+    (match Tool_board.visibility_of_string "garbage" with
+     | None -> "none" | _ -> "other")
+
+let test_sort_order_of_string () =
+  Eio_main.run @@ fun _env ->
+  cleanup ();
+  Alcotest.(check string) "hot" "hot"
+    (match Tool_board.sort_order_of_string "hot" with
+     | Tool_board.Hot -> "hot" | _ -> "x");
+  Alcotest.(check string) "trending" "trending"
+    (match Tool_board.sort_order_of_string "trending" with
+     | Tool_board.Trending -> "trending" | _ -> "x");
+  Alcotest.(check string) "recent" "recent"
+    (match Tool_board.sort_order_of_string "recent" with
+     | Tool_board.Recent -> "recent" | _ -> "x");
+  Alcotest.(check string) "updated" "updated"
+    (match Tool_board.sort_order_of_string "updated" with
+     | Tool_board.Updated -> "updated" | _ -> "x");
+  Alcotest.(check string) "discussed" "discussed"
+    (match Tool_board.sort_order_of_string "discussed" with
+     | Tool_board.Discussed -> "discussed" | _ -> "x");
+  Alcotest.(check string) "unknown defaults to hot" "hot"
+    (match Tool_board.sort_order_of_string "xyz" with
+     | Tool_board.Hot -> "hot" | _ -> "x")
+
+let test_board_error_to_string () =
+  Eio_main.run @@ fun _env ->
+  cleanup ();
+  let s = Tool_board.board_error_to_string (Board.Post_not_found "test-id") in
+  Alcotest.(check bool) "post_not_found has text" true (String.length s > 0);
+  let s2 = Tool_board.board_error_to_string (Board.Validation_error "bad") in
+  Alcotest.(check bool) "validation_error" true (String.contains s2 'b')
+
+let test_is_lodge_agent () =
+  Eio_main.run @@ fun _env ->
+  cleanup ();
+  Alcotest.(check bool) "lowercase no space = lodge" true
+    (Tool_board.is_lodge_agent "dreamer");
+  Alcotest.(check bool) "with space = not lodge" false
+    (Tool_board.is_lodge_agent "John Smith");
+  Alcotest.(check bool) "uppercase = not lodge" false
+    (Tool_board.is_lodge_agent "Dreamer");
+  Alcotest.(check bool) "empty = not lodge" false
+    (Tool_board.is_lodge_agent "")
+
+let test_format_timestamp_relative () =
+  Eio_main.run @@ fun _env ->
+  cleanup ();
+  let now = Time_compat.now () in
+  let s = Tool_board.format_timestamp_relative now in
+  Alcotest.(check bool) "recent timestamp is 'just now' or contains 's'" true
+    (String.length s > 0);
+  let old = now -. 86400.0 in
+  let s2 = Tool_board.format_timestamp_relative old in
+  Alcotest.(check bool) "1-day old timestamp has content" true (String.length s2 > 0)
+
+(** {2 Group 2: JSON helper functions} *)
+
+let test_get_string () =
+  Eio_main.run @@ fun _env ->
+  cleanup ();
+  let args = make_args [("key", `String "value")] in
+  Alcotest.(check string) "get existing" "value"
+    (Tool_board.get_string args "key" "default");
+  Alcotest.(check string) "get missing" "default"
+    (Tool_board.get_string args "missing" "default")
+
+let test_get_string_opt () =
+  Eio_main.run @@ fun _env ->
+  cleanup ();
+  let args = make_args [("key", `String "value")] in
+  Alcotest.(check (option string)) "get existing" (Some "value")
+    (Tool_board.get_string_opt args "key");
+  Alcotest.(check (option string)) "get missing" None
+    (Tool_board.get_string_opt args "missing")
+
+let test_get_int () =
+  Eio_main.run @@ fun _env ->
+  cleanup ();
+  let args = make_args [("n", `Int 42)] in
+  Alcotest.(check int) "get existing" 42
+    (Tool_board.get_int args "n" 0);
+  Alcotest.(check int) "get missing" 0
+    (Tool_board.get_int args "missing" 0)
+
+let test_get_bool () =
+  Eio_main.run @@ fun _env ->
+  cleanup ();
+  let args = make_args [("flag", `Bool true)] in
+  Alcotest.(check bool) "get existing" true
+    (Tool_board.get_bool args "flag" false);
+  Alcotest.(check bool) "get missing" false
+    (Tool_board.get_bool args "missing" false)
+
+(** {2 Group 3: Post Create / List / Get} *)
+
+let test_post_create_success () =
+  Eio_main.run @@ fun _env ->
+  cleanup ();
+  let ok, body = dispatch "masc_board_post"
+    (make_args [("content", `String "Hello board"); ("author", `String "tester")]) in
+  Alcotest.(check bool) "create ok" true ok;
+  Alcotest.(check bool) "body has post" true (String.length body > 0)
+
+let test_post_create_empty_content () =
+  Eio_main.run @@ fun _env ->
+  cleanup ();
+  let ok, _body = dispatch "masc_board_post"
+    (make_args [("content", `String ""); ("author", `String "tester")]) in
+  (* Board_dispatch.create_post may reject empty content *)
+  ignore ok
+
+let test_post_list_empty () =
+  Eio_main.run @@ fun _env ->
+  cleanup ();
+  let ok, body = dispatch "masc_board_list" (make_args []) in
+  Alcotest.(check bool) "list ok" true ok;
+  Alcotest.(check bool) "no posts msg" true
+    (String.length body > 0)
+
+let test_post_list_with_posts () =
+  Eio_main.run @@ fun _env ->
+  cleanup ();
+  let ok1, _ = dispatch "masc_board_post"
+    (make_args [("content", `String "Post 1"); ("author", `String "a")]) in
+  Alcotest.(check bool) "create 1" true ok1;
+  let ok2, _ = dispatch "masc_board_post"
+    (make_args [("content", `String "Post 2"); ("author", `String "b")]) in
+  Alcotest.(check bool) "create 2" true ok2;
+  let ok, body = dispatch "masc_board_list"
+    (make_args [("limit", `Int 10)]) in
+  Alcotest.(check bool) "list ok" true ok;
+  Alcotest.(check bool) "body has content" true
+    (String.length body > 20)
+
+let test_post_list_limit_clamping () =
+  Eio_main.run @@ fun _env ->
+  cleanup ();
+  (* Create 3 posts *)
+  for _ = 1 to 3 do
+    ignore (dispatch "masc_board_post"
+      (make_args [("content", `String "x"); ("author", `String "a")]))
+  done;
+  let ok, body = dispatch "masc_board_list"
+    (make_args [("limit", `Int 1)]) in
+  Alcotest.(check bool) "list ok" true ok;
+  (* With limit=1, should show only 1 post *)
+  Alcotest.(check bool) "body has posts" true (String.length body > 0)
+
+let test_post_list_sort_orders () =
+  Eio_main.run @@ fun _env ->
+  cleanup ();
+  ignore (dispatch "masc_board_post"
+    (make_args [("content", `String "sort test"); ("author", `String "a")]));
+  let sorts = ["hot"; "trending"; "recent"; "updated"; "discussed"] in
+  List.iter (fun s ->
+    let ok, body = dispatch "masc_board_list"
+      (make_args [("sort_by", `String s)]) in
+    Alcotest.(check bool) (Printf.sprintf "sort %s ok" s) true ok;
+    Alcotest.(check bool) (Printf.sprintf "sort %s has content" s) true (String.length body > 0)
+  ) sorts
+
+let test_post_get_success () =
+  Eio_main.run @@ fun _env ->
+  cleanup ();
+  let ok, body = dispatch "masc_board_post"
+    (make_args [("content", `String "Get me"); ("author", `String "tester")]) in
+  Alcotest.(check bool) "create ok" true ok;
+  (* Extract post_id from the creation response *)
+  let post_id = try
+    let json = Yojson.Safe.from_string body in
+    json |> Yojson.Safe.Util.member "id" |> Yojson.Safe.Util.to_string
+  with _ ->
+    (* Response may be formatted text, not JSON. Find post via list *)
+    let _, list_body = dispatch "masc_board_list" (make_args []) in
+    (* Just try to get the first post *)
+    ignore list_body; ""
+  in
+  if post_id <> "" then begin
+    let ok2, body2 = dispatch "masc_board_get"
+      (make_args [("post_id", `String post_id)]) in
+    Alcotest.(check bool) "get ok" true ok2;
+    Alcotest.(check bool) "get has content" true (String.length body2 > 0)
+  end
+
+let test_post_get_not_found () =
+  Eio_main.run @@ fun _env ->
+  cleanup ();
+  let ok, body = dispatch "masc_board_get"
+    (make_args [("post_id", `String "nonexistent-id")]) in
+  Alcotest.(check bool) "not found fails" false ok;
+  Alcotest.(check bool) "error msg" true (String.length body > 0)
+
+(** {2 Group 4: Voting} *)
+
+let test_vote_not_found () =
+  Eio_main.run @@ fun _env ->
+  cleanup ();
+  let ok, body = dispatch "masc_board_vote"
+    (make_args [("post_id", `String "missing"); ("voter", `String "v"); ("direction", `String "up")]) in
+  Alcotest.(check bool) "vote on missing fails" false ok;
+  Alcotest.(check bool) "has error" true (String.length body > 0)
+
+(** {2 Group 5: Comment} *)
+
+let test_comment_add_missing_post () =
+  Eio_main.run @@ fun _env ->
+  cleanup ();
+  let ok, body = dispatch "masc_board_comment"
+    (make_args [("post_id", `String "missing"); ("content", `String "hi"); ("author", `String "a")]) in
+  Alcotest.(check bool) "comment on missing post fails" false ok;
+  Alcotest.(check bool) "has error" true (String.length body > 0)
+
+let test_comment_vote_missing () =
+  Eio_main.run @@ fun _env ->
+  cleanup ();
+  let ok, body = dispatch "masc_board_comment_vote"
+    (make_args [("comment_id", `String ""); ("voter", `String "v"); ("direction", `String "up")]) in
+  Alcotest.(check bool) "empty comment_id fails" false ok;
+  Alcotest.(check bool) "error msg" true (String.length body > 0)
+
+(** {2 Group 6: Search / Stats / Profile / Hearths} *)
+
+let test_search_empty_query () =
+  Eio_main.run @@ fun _env ->
+  cleanup ();
+  let ok, body = dispatch "masc_board_search"
+    (make_args [("query", `String "")]) in
+  Alcotest.(check bool) "empty query fails" false ok;
+  Alcotest.(check bool) "has error" true (String.length body > 0)
+
+let test_search_no_results () =
+  Eio_main.run @@ fun _env ->
+  cleanup ();
+  let ok, body = dispatch "masc_board_search"
+    (make_args [("query", `String "nonexistent_xyz_123")]) in
+  Alcotest.(check bool) "search ok" true ok;
+  Alcotest.(check bool) "no results msg" true (String.length body > 0)
+
+let test_stats () =
+  Eio_main.run @@ fun _env ->
+  cleanup ();
+  let ok, body = dispatch "masc_board_stats" (make_args []) in
+  Alcotest.(check bool) "stats ok" true ok;
+  Alcotest.(check bool) "stats has content" true (String.length body > 0)
+
+let test_profile_empty_agent () =
+  Eio_main.run @@ fun _env ->
+  cleanup ();
+  let ok, body = dispatch "masc_board_profile"
+    (make_args [("agent", `String "")]) in
+  Alcotest.(check bool) "empty agent fails" false ok;
+  Alcotest.(check bool) "has error" true (String.length body > 0)
+
+let test_profile_with_posts () =
+  Eio_main.run @@ fun _env ->
+  cleanup ();
+  ignore (dispatch "masc_board_post"
+    (make_args [("content", `String "profiled"); ("author", `String "profiler")]));
+  let ok, body = dispatch "masc_board_profile"
+    (make_args [("agent", `String "profiler")]) in
+  Alcotest.(check bool) "profile ok" true ok;
+  Alcotest.(check bool) "has profiler name" true
+    (try ignore (Str.search_forward (Str.regexp_string "profiler") body 0); true
+     with Not_found -> false)
+
+let test_hearth_list_empty () =
+  Eio_main.run @@ fun _env ->
+  cleanup ();
+  let ok, body = dispatch "masc_board_hearths" (make_args []) in
+  Alcotest.(check bool) "hearth list ok" true ok;
+  Alcotest.(check bool) "has content" true (String.length body > 0)
+
+(** {2 Group 7: Dispatch Routing} *)
+
+let test_dispatch_unknown_tool () =
+  Eio_main.run @@ fun _env ->
+  cleanup ();
+  let ok, body = dispatch "masc_board_nonexistent" (make_args []) in
+  Alcotest.(check bool) "unknown tool fails" false ok;
+  Alcotest.(check bool) "has unknown msg" true
+    (try ignore (Str.search_forward (Str.regexp_string "Unknown") body 0); true
+     with Not_found -> false)
+
+let test_dispatch_migrate_without_pg () =
+  Eio_main.run @@ fun _env ->
+  cleanup ();
+  (* Default backend is JSONL, so migrate should fail *)
+  let ok, body = dispatch "masc_board_migrate" (make_args []) in
+  Alcotest.(check bool) "migrate without pg fails" false ok;
+  Alcotest.(check bool) "error mentions pg" true
+    (try ignore (Str.search_forward (Str.regexp_string "PostgreSQL") body 0); true
+     with Not_found -> false)
+
+(** {2 Group 8: Tool Schema Definitions} *)
+
+let test_tools_count () =
+  Eio_main.run @@ fun _env ->
+  cleanup ();
+  Alcotest.(check int) "11 tool schemas" 11 (List.length Tool_board.tools)
+
+let test_tools_names_unique () =
+  Eio_main.run @@ fun _env ->
+  cleanup ();
+  let names = List.map (fun (t : Types.tool_schema) -> t.name) Tool_board.tools in
+  let unique = List.sort_uniq String.compare names in
+  Alcotest.(check int) "all names unique" (List.length names) (List.length unique)
+
+let test_tools_all_have_descriptions () =
+  Eio_main.run @@ fun _env ->
+  cleanup ();
+  List.iter (fun (t : Types.tool_schema) ->
+    Alcotest.(check bool) (Printf.sprintf "%s has description" t.name) true
+      (String.length t.description > 0)
+  ) Tool_board.tools
+
+(** {1 Test Runner} *)
+
+let () =
+  Alcotest.run "Tool_board_coverage"
+    [
+      ( "helpers",
+        [
+          Alcotest.test_case "visibility_of_string" `Quick test_visibility_of_string;
+          Alcotest.test_case "sort_order_of_string" `Quick test_sort_order_of_string;
+          Alcotest.test_case "board_error_to_string" `Quick test_board_error_to_string;
+          Alcotest.test_case "is_lodge_agent" `Quick test_is_lodge_agent;
+          Alcotest.test_case "format_timestamp_relative" `Quick test_format_timestamp_relative;
+        ] );
+      ( "json_helpers",
+        [
+          Alcotest.test_case "get_string" `Quick test_get_string;
+          Alcotest.test_case "get_string_opt" `Quick test_get_string_opt;
+          Alcotest.test_case "get_int" `Quick test_get_int;
+          Alcotest.test_case "get_bool" `Quick test_get_bool;
+        ] );
+      ( "post_crud",
+        [
+          Alcotest.test_case "create success" `Quick test_post_create_success;
+          Alcotest.test_case "create empty content" `Quick test_post_create_empty_content;
+          Alcotest.test_case "list empty" `Quick test_post_list_empty;
+          Alcotest.test_case "list with posts" `Quick test_post_list_with_posts;
+          Alcotest.test_case "list limit clamping" `Quick test_post_list_limit_clamping;
+          Alcotest.test_case "list sort orders" `Quick test_post_list_sort_orders;
+          Alcotest.test_case "get success" `Quick test_post_get_success;
+          Alcotest.test_case "get not found" `Quick test_post_get_not_found;
+        ] );
+      ( "voting",
+        [
+          Alcotest.test_case "vote not found" `Quick test_vote_not_found;
+        ] );
+      ( "comments",
+        [
+          Alcotest.test_case "comment missing post" `Quick test_comment_add_missing_post;
+          Alcotest.test_case "comment vote missing" `Quick test_comment_vote_missing;
+        ] );
+      ( "search_stats",
+        [
+          Alcotest.test_case "search empty query" `Quick test_search_empty_query;
+          Alcotest.test_case "search no results" `Quick test_search_no_results;
+          Alcotest.test_case "stats" `Quick test_stats;
+          Alcotest.test_case "profile empty agent" `Quick test_profile_empty_agent;
+          Alcotest.test_case "profile with posts" `Quick test_profile_with_posts;
+          Alcotest.test_case "hearth list empty" `Quick test_hearth_list_empty;
+        ] );
+      ( "dispatch",
+        [
+          Alcotest.test_case "unknown tool" `Quick test_dispatch_unknown_tool;
+          Alcotest.test_case "migrate without pg" `Quick test_dispatch_migrate_without_pg;
+        ] );
+      ( "schemas",
+        [
+          Alcotest.test_case "tools count" `Quick test_tools_count;
+          Alcotest.test_case "unique names" `Quick test_tools_names_unique;
+          Alcotest.test_case "all have descriptions" `Quick test_tools_all_have_descriptions;
+        ] );
+    ]

--- a/test/test_tool_board_coverage.ml
+++ b/test/test_tool_board_coverage.ml
@@ -96,11 +96,13 @@ let test_format_timestamp_relative () =
   cleanup ();
   let now = Time_compat.now () in
   let s = Tool_board.format_timestamp_relative now in
-  Alcotest.(check bool) "recent timestamp is 'just now' or contains 's'" true
-    (String.length s > 0);
+  Alcotest.(check string) "recent timestamp" "just now" s;
   let old = now -. 86400.0 in
   let s2 = Tool_board.format_timestamp_relative old in
-  Alcotest.(check bool) "1-day old timestamp has content" true (String.length s2 > 0)
+  Alcotest.(check bool) "1-day old has 'd'" true (String.contains s2 'd');
+  let minutes_ago = now -. 120.0 in
+  let s3 = Tool_board.format_timestamp_relative minutes_ago in
+  Alcotest.(check bool) "2min ago has 'm'" true (String.contains s3 'm')
 
 (** {2 Group 2: JSON helper functions} *)
 
@@ -153,10 +155,13 @@ let test_post_create_success () =
 let test_post_create_empty_content () =
   Eio_main.run @@ fun _env ->
   cleanup ();
-  let ok, _body = dispatch "masc_board_post"
+  let ok, body = dispatch "masc_board_post"
     (make_args [("content", `String ""); ("author", `String "tester")]) in
-  (* Board_dispatch.create_post may reject empty content *)
-  ignore ok
+  (* Empty content: either rejected (ok=false) or accepted (ok=true) — verify consistent response *)
+  Alcotest.(check bool) "response has body" true (String.length body > 0);
+  if not ok then
+    Alcotest.(check bool) "error mentions reason" true
+      (String.length body > 0)
 
 let test_post_list_empty () =
   Eio_main.run @@ fun _env ->
@@ -214,22 +219,22 @@ let test_post_get_success () =
   let ok, body = dispatch "masc_board_post"
     (make_args [("content", `String "Get me"); ("author", `String "tester")]) in
   Alcotest.(check bool) "create ok" true ok;
-  (* Extract post_id from the creation response *)
-  let post_id = try
-    let json = Yojson.Safe.from_string body in
-    json |> Yojson.Safe.Util.member "id" |> Yojson.Safe.Util.to_string
-  with _ ->
-    (* Response may be formatted text, not JSON. Find post via list *)
-    let _, list_body = dispatch "masc_board_list" (make_args []) in
-    (* Just try to get the first post *)
-    ignore list_body; ""
+  (* Response is "✅ Post created:\n{json}" — extract JSON after first newline *)
+  let post_id =
+    match String.index_opt body '\n' with
+    | Some idx ->
+      let json_str = String.sub body (idx + 1) (String.length body - idx - 1) in
+      (try
+        let json = Yojson.Safe.from_string json_str in
+        json |> Yojson.Safe.Util.member "id" |> Yojson.Safe.Util.to_string
+      with _ -> Alcotest.fail ("Failed to parse post JSON from: " ^ json_str))
+    | None -> Alcotest.fail ("No newline in create response: " ^ body)
   in
-  if post_id <> "" then begin
-    let ok2, body2 = dispatch "masc_board_get"
-      (make_args [("post_id", `String post_id)]) in
-    Alcotest.(check bool) "get ok" true ok2;
-    Alcotest.(check bool) "get has content" true (String.length body2 > 0)
-  end
+  Alcotest.(check bool) "post_id not empty" true (String.length post_id > 0);
+  let ok2, body2 = dispatch "masc_board_get"
+    (make_args [("post_id", `String post_id)]) in
+  Alcotest.(check bool) "get ok" true ok2;
+  Alcotest.(check bool) "get has content" true (String.length body2 > 0)
 
 let test_post_get_not_found () =
   Eio_main.run @@ fun _env ->

--- a/test/test_tool_goals_coverage.ml
+++ b/test/test_tool_goals_coverage.ml
@@ -263,7 +263,7 @@ let test_review_blocked_outcome () =
   let result_json = parse_json_exn body in
   let status = result_json |> Yojson.Safe.Util.member "goal"
     |> Yojson.Safe.Util.member "status" |> Yojson.Safe.Util.to_string in
-  Alcotest.(check string) "status blocked" "paused" status;
+  Alcotest.(check string) "blocked outcome maps to paused status" "paused" status;
   cleanup_dir base_dir
 
 (** {2 Group 8: Helper Functions} *)

--- a/test/test_tool_goals_coverage.ml
+++ b/test/test_tool_goals_coverage.ml
@@ -1,0 +1,367 @@
+open Masc_mcp
+
+(** {1 Test helpers} *)
+
+let temp_dir () =
+  let dir = Filename.temp_file "test_goals_cov_" "" in
+  Unix.unlink dir;
+  Unix.mkdir dir 0o755;
+  dir
+
+let cleanup_dir dir =
+  let rec rm path =
+    if Sys.file_exists path then
+      if Sys.is_directory path then (
+        Array.iter (fun name -> rm (Filename.concat path name)) (Sys.readdir path);
+        Unix.rmdir path)
+      else Unix.unlink path
+  in
+  try rm dir with _ -> ()
+
+let parse_json_exn s =
+  try Yojson.Safe.from_string s
+  with Yojson.Json_error e -> failwith ("invalid json: " ^ e)
+
+let dispatch_exn ctx ~name ~args =
+  match Tool_goals.dispatch ctx ~name ~args with
+  | Some result -> result
+  | None -> failwith ("dispatch returned None for " ^ name)
+
+let dispatch_opt ctx ~name ~args =
+  Tool_goals.dispatch ctx ~name ~args
+
+let upsert_goal ctx args =
+  dispatch_exn ctx ~name:"masc_goal_upsert" ~args
+
+let make_ctx base_dir =
+  let config = Room.default_config base_dir in
+  ignore (Room.init config ~agent_name:(Some "tester"));
+  let ctx : Tool_goals.context =
+    { config; agent_name = "tester"; call_keeper_msg = None }
+  in
+  (ctx, config)
+
+(** {2 Group 1: Dispatch Routing} *)
+
+let test_dispatch_unknown_returns_none () =
+  let base_dir = temp_dir () in
+  let ctx, _ = make_ctx base_dir in
+  let result = dispatch_opt ctx ~name:"masc_goal_nonexistent" ~args:(`Assoc []) in
+  Alcotest.(check bool) "unknown tool returns None" true (result = None);
+  cleanup_dir base_dir
+
+let test_dispatch_all_tool_names () =
+  let base_dir = temp_dir () in
+  let ctx, _ = make_ctx base_dir in
+  let valid_names = [
+    "masc_goal_upsert"; "masc_goal_list"; "masc_goal_snapshot";
+    "masc_goal_refresh"; "masc_goal_dispatch"; "masc_goal_review"
+  ] in
+  List.iter (fun name ->
+    let result = dispatch_opt ctx ~name ~args:(`Assoc []) in
+    Alcotest.(check bool) (Printf.sprintf "%s dispatches" name) true
+      (result <> None)
+  ) valid_names;
+  cleanup_dir base_dir
+
+(** {2 Group 2: Schema Validation} *)
+
+let test_schemas_count () =
+  Alcotest.(check int) "6 schemas" 6 (List.length Tool_goals.schemas)
+
+let test_schemas_unique_names () =
+  let names = List.map (fun (s : Types.tool_schema) -> s.name) Tool_goals.schemas in
+  let unique = List.sort_uniq String.compare names in
+  Alcotest.(check int) "all unique" (List.length names) (List.length unique)
+
+let test_schemas_have_descriptions () =
+  List.iter (fun (s : Types.tool_schema) ->
+    Alcotest.(check bool) (Printf.sprintf "%s has desc" s.name) true
+      (String.length s.description > 0)
+  ) Tool_goals.schemas
+
+(** {2 Group 3: Goal Snapshot} *)
+
+let test_snapshot_manual_mode () =
+  let base_dir = temp_dir () in
+  let ctx, _ = make_ctx base_dir in
+  (* Create a goal first *)
+  let ok1, _ = upsert_goal ctx
+    (`Assoc [("horizon", `String "short"); ("title", `String "Snap target")]) in
+  Alcotest.(check bool) "upsert ok" true ok1;
+  let ok, body = dispatch_exn ctx ~name:"masc_goal_snapshot"
+    ~args:(`Assoc [("mode", `String "manual")]) in
+  Alcotest.(check bool) "snapshot ok" true ok;
+  let json = parse_json_exn body in
+  let snap = Yojson.Safe.Util.member "snapshot" json in
+  Alcotest.(check bool) "has snapshot field" true (snap <> `Null);
+  cleanup_dir base_dir
+
+let test_snapshot_empty_goals () =
+  let base_dir = temp_dir () in
+  let ctx, _ = make_ctx base_dir in
+  let ok, body = dispatch_exn ctx ~name:"masc_goal_snapshot"
+    ~args:(`Assoc []) in
+  Alcotest.(check bool) "snapshot ok even empty" true ok;
+  let json = parse_json_exn body in
+  Alcotest.(check bool) "has snapshot" true
+    (Yojson.Safe.Util.member "snapshot" json <> `Null);
+  cleanup_dir base_dir
+
+(** {2 Group 4: Horizon / Status Validation} *)
+
+let test_list_invalid_horizon () =
+  let base_dir = temp_dir () in
+  let ctx, _ = make_ctx base_dir in
+  let ok, body = dispatch_exn ctx ~name:"masc_goal_list"
+    ~args:(`Assoc [("horizon", `String "invalid_horizon")]) in
+  Alcotest.(check bool) "invalid horizon fails" false ok;
+  let json = parse_json_exn body in
+  Alcotest.(check string) "error status" "error"
+    (json |> Yojson.Safe.Util.member "status" |> Yojson.Safe.Util.to_string);
+  cleanup_dir base_dir
+
+let test_list_invalid_status () =
+  let base_dir = temp_dir () in
+  let ctx, _ = make_ctx base_dir in
+  let ok, body = dispatch_exn ctx ~name:"masc_goal_list"
+    ~args:(`Assoc [("status", `String "invalid_status")]) in
+  Alcotest.(check bool) "invalid status fails" false ok;
+  let json = parse_json_exn body in
+  Alcotest.(check string) "error status" "error"
+    (json |> Yojson.Safe.Util.member "status" |> Yojson.Safe.Util.to_string);
+  cleanup_dir base_dir
+
+let test_list_valid_horizon_filter () =
+  let base_dir = temp_dir () in
+  let ctx, _ = make_ctx base_dir in
+  let ok1, _ = upsert_goal ctx
+    (`Assoc [("horizon", `String "short"); ("title", `String "Short goal")]) in
+  Alcotest.(check bool) "upsert short" true ok1;
+  let ok2, _ = upsert_goal ctx
+    (`Assoc [("horizon", `String "long"); ("title", `String "Long goal")]) in
+  Alcotest.(check bool) "upsert long" true ok2;
+  let ok, body = dispatch_exn ctx ~name:"masc_goal_list"
+    ~args:(`Assoc [("horizon", `String "short")]) in
+  Alcotest.(check bool) "list short ok" true ok;
+  let json = parse_json_exn body in
+  let count = json |> Yojson.Safe.Util.member "count" |> Yojson.Safe.Util.to_int in
+  Alcotest.(check int) "only short goals" 1 count;
+  cleanup_dir base_dir
+
+let test_list_with_rollup () =
+  let base_dir = temp_dir () in
+  let ctx, _ = make_ctx base_dir in
+  let ok1, _ = upsert_goal ctx
+    (`Assoc [("horizon", `String "short"); ("title", `String "Goal A"); ("priority", `Int 1)]) in
+  Alcotest.(check bool) "upsert A" true ok1;
+  let ok2, _ = upsert_goal ctx
+    (`Assoc [("horizon", `String "mid"); ("title", `String "Goal B"); ("priority", `Int 3)]) in
+  Alcotest.(check bool) "upsert B" true ok2;
+  let ok, body = dispatch_exn ctx ~name:"masc_goal_list" ~args:(`Assoc []) in
+  Alcotest.(check bool) "list ok" true ok;
+  let json = parse_json_exn body in
+  let rollup = Yojson.Safe.Util.member "rollup" json in
+  Alcotest.(check bool) "has rollup" true (rollup <> `Null);
+  cleanup_dir base_dir
+
+(** {2 Group 5: Refresh Edge Cases} *)
+
+let test_refresh_invalid_mode () =
+  let base_dir = temp_dir () in
+  let ctx, _ = make_ctx base_dir in
+  let ok, body = dispatch_exn ctx ~name:"masc_goal_refresh"
+    ~args:(`Assoc [("mode", `String "invalid_mode")]) in
+  Alcotest.(check bool) "invalid mode fails" false ok;
+  let json = parse_json_exn body in
+  Alcotest.(check string) "error status" "error"
+    (json |> Yojson.Safe.Util.member "status" |> Yojson.Safe.Util.to_string);
+  cleanup_dir base_dir
+
+let test_refresh_auto_no_due () =
+  let base_dir = temp_dir () in
+  let ctx, _ = make_ctx base_dir in
+  (* Without force, auto mode may skip if no cadence window is due *)
+  let ok, body = dispatch_exn ctx ~name:"masc_goal_refresh"
+    ~args:(`Assoc [("mode", `String "auto"); ("force", `Bool false)]) in
+  Alcotest.(check bool) "auto no-force ok" true ok;
+  let json = parse_json_exn body in
+  (* May skip or execute depending on scheduler state *)
+  let mode = json |> Yojson.Safe.Util.member "mode" |> Yojson.Safe.Util.to_string in
+  Alcotest.(check string) "mode is auto" "auto" mode;
+  cleanup_dir base_dir
+
+let test_refresh_monthly_force () =
+  let base_dir = temp_dir () in
+  let ctx, _ = make_ctx base_dir in
+  let ok1, _ = upsert_goal ctx
+    (`Assoc [("horizon", `String "long"); ("title", `String "Monthly target")]) in
+  Alcotest.(check bool) "upsert ok" true ok1;
+  let ok, body = dispatch_exn ctx ~name:"masc_goal_refresh"
+    ~args:(`Assoc [("mode", `String "monthly"); ("force", `Bool true)]) in
+  Alcotest.(check bool) "monthly force ok" true ok;
+  let json = parse_json_exn body in
+  let skipped = json |> Yojson.Safe.Util.member "skipped" |> Yojson.Safe.Util.to_bool in
+  Alcotest.(check bool) "not skipped with force" false skipped;
+  cleanup_dir base_dir
+
+(** {2 Group 6: Dispatch (dry-run / execute=false)} *)
+
+let test_dispatch_no_execute () =
+  let base_dir = temp_dir () in
+  let ctx, _ = make_ctx base_dir in
+  let ok1, _ = upsert_goal ctx
+    (`Assoc [("horizon", `String "short"); ("title", `String "Dry run target")]) in
+  Alcotest.(check bool) "upsert ok" true ok1;
+  let ok, body = dispatch_exn ctx ~name:"masc_goal_dispatch"
+    ~args:(`Assoc [("execute", `Bool false)]) in
+  Alcotest.(check bool) "dry run ok" true ok;
+  let json = parse_json_exn body in
+  let executed = json |> Yojson.Safe.Util.member "executed" |> Yojson.Safe.Util.to_bool in
+  Alcotest.(check bool) "not executed" false executed;
+  let plan = Yojson.Safe.Util.member "plan" json in
+  Alcotest.(check bool) "has plan" true (plan <> `Null);
+  cleanup_dir base_dir
+
+(** {2 Group 7: Review Edge Cases} *)
+
+let test_review_missing_fields () =
+  let base_dir = temp_dir () in
+  let ctx, _ = make_ctx base_dir in
+  let ok, body = dispatch_exn ctx ~name:"masc_goal_review"
+    ~args:(`Assoc []) in
+  Alcotest.(check bool) "missing fields fails" false ok;
+  let json = parse_json_exn body in
+  Alcotest.(check string) "error status" "error"
+    (json |> Yojson.Safe.Util.member "status" |> Yojson.Safe.Util.to_string);
+  cleanup_dir base_dir
+
+let test_review_nonexistent_goal () =
+  let base_dir = temp_dir () in
+  let ctx, _ = make_ctx base_dir in
+  let ok, body = dispatch_exn ctx ~name:"masc_goal_review"
+    ~args:(`Assoc [("goal_id", `String "fake-id"); ("outcome", `String "done")]) in
+  Alcotest.(check bool) "nonexistent goal fails" false ok;
+  let json = parse_json_exn body in
+  Alcotest.(check string) "error status" "error"
+    (json |> Yojson.Safe.Util.member "status" |> Yojson.Safe.Util.to_string);
+  cleanup_dir base_dir
+
+let test_review_blocked_outcome () =
+  let base_dir = temp_dir () in
+  let ctx, _ = make_ctx base_dir in
+  let ok1, body1 = upsert_goal ctx
+    (`Assoc [("horizon", `String "short"); ("title", `String "Block me")]) in
+  Alcotest.(check bool) "upsert ok" true ok1;
+  let json = parse_json_exn body1 in
+  let goal_id = json |> Yojson.Safe.Util.member "goal"
+    |> Yojson.Safe.Util.member "id" |> Yojson.Safe.Util.to_string in
+  let ok, body = dispatch_exn ctx ~name:"masc_goal_review"
+    ~args:(`Assoc [("goal_id", `String goal_id); ("outcome", `String "blocked");
+                    ("note", `String "Depends on external team")]) in
+  Alcotest.(check bool) "blocked review ok" true ok;
+  let result_json = parse_json_exn body in
+  let status = result_json |> Yojson.Safe.Util.member "goal"
+    |> Yojson.Safe.Util.member "status" |> Yojson.Safe.Util.to_string in
+  Alcotest.(check string) "status blocked" "paused" status;
+  cleanup_dir base_dir
+
+(** {2 Group 8: Helper Functions} *)
+
+let test_normalize_runtime () =
+  Alcotest.(check (option string)) "task" (Some "task")
+    (Tool_goals.normalize_runtime "task");
+  Alcotest.(check (option string)) "TASK" (Some "task")
+    (Tool_goals.normalize_runtime "TASK");
+  Alcotest.(check (option string)) "keeper" (Some "keeper")
+    (Tool_goals.normalize_runtime "keeper");
+  Alcotest.(check (option string)) "invalid" None
+    (Tool_goals.normalize_runtime "invalid");
+  Alcotest.(check (option string)) "empty" None
+    (Tool_goals.normalize_runtime "")
+
+let test_sanitize_keeper_name () =
+  let name = Tool_goals.sanitize_keeper_name "Goal - Ship MVP" in
+  Alcotest.(check bool) "lowercase" true (name = String.lowercase_ascii name);
+  Alcotest.(check bool) "no spaces" true (not (String.contains name ' '));
+  Alcotest.(check bool) "max 48 chars" true (String.length name <= 48);
+  let empty = Tool_goals.sanitize_keeper_name "" in
+  Alcotest.(check string) "empty defaults to goal-keeper" "goal-keeper" empty;
+  let long = Tool_goals.sanitize_keeper_name (String.make 100 'a') in
+  Alcotest.(check bool) "long truncated to 48" true (String.length long <= 48)
+
+let test_tool_result_json () =
+  let json_str = Tool_goals.tool_result_json [("key", `String "val")] in
+  let json = parse_json_exn json_str in
+  Alcotest.(check string) "status ok" "ok"
+    (json |> Yojson.Safe.Util.member "status" |> Yojson.Safe.Util.to_string);
+  Alcotest.(check string) "key present" "val"
+    (json |> Yojson.Safe.Util.member "key" |> Yojson.Safe.Util.to_string)
+
+let test_error_result_json () =
+  let json_str = Tool_goals.error_result_json "something failed" in
+  let json = parse_json_exn json_str in
+  Alcotest.(check string) "status error" "error"
+    (json |> Yojson.Safe.Util.member "status" |> Yojson.Safe.Util.to_string);
+  let msg = json |> Yojson.Safe.Util.member "message" |> Yojson.Safe.Util.to_string in
+  Alcotest.(check bool) "has error msg" true (String.length msg > 0)
+
+let test_split_csv () =
+  let result = Tool_goals.split_csv "a, b , c" in
+  Alcotest.(check (list string)) "trimmed" ["a"; "b"; "c"] result;
+  let empty = Tool_goals.split_csv "" in
+  Alcotest.(check (list string)) "empty" [] empty
+
+(** {1 Test Runner} *)
+
+let () =
+  Alcotest.run "Tool_goals_coverage"
+    [
+      ( "dispatch_routing",
+        [
+          Alcotest.test_case "unknown returns None" `Quick test_dispatch_unknown_returns_none;
+          Alcotest.test_case "all tools dispatch" `Quick test_dispatch_all_tool_names;
+        ] );
+      ( "schemas",
+        [
+          Alcotest.test_case "schema count" `Quick test_schemas_count;
+          Alcotest.test_case "unique names" `Quick test_schemas_unique_names;
+          Alcotest.test_case "have descriptions" `Quick test_schemas_have_descriptions;
+        ] );
+      ( "snapshot",
+        [
+          Alcotest.test_case "manual mode" `Quick test_snapshot_manual_mode;
+          Alcotest.test_case "empty goals" `Quick test_snapshot_empty_goals;
+        ] );
+      ( "validation",
+        [
+          Alcotest.test_case "invalid horizon" `Quick test_list_invalid_horizon;
+          Alcotest.test_case "invalid status" `Quick test_list_invalid_status;
+          Alcotest.test_case "valid horizon filter" `Quick test_list_valid_horizon_filter;
+          Alcotest.test_case "list with rollup" `Quick test_list_with_rollup;
+        ] );
+      ( "refresh",
+        [
+          Alcotest.test_case "invalid mode" `Quick test_refresh_invalid_mode;
+          Alcotest.test_case "auto no due" `Quick test_refresh_auto_no_due;
+          Alcotest.test_case "monthly force" `Quick test_refresh_monthly_force;
+        ] );
+      ( "dispatch_goals",
+        [
+          Alcotest.test_case "no execute dry run" `Quick test_dispatch_no_execute;
+        ] );
+      ( "review",
+        [
+          Alcotest.test_case "missing fields" `Quick test_review_missing_fields;
+          Alcotest.test_case "nonexistent goal" `Quick test_review_nonexistent_goal;
+          Alcotest.test_case "blocked outcome" `Quick test_review_blocked_outcome;
+        ] );
+      ( "helpers",
+        [
+          Alcotest.test_case "normalize_runtime" `Quick test_normalize_runtime;
+          Alcotest.test_case "sanitize_keeper_name" `Quick test_sanitize_keeper_name;
+          Alcotest.test_case "tool_result_json" `Quick test_tool_result_json;
+          Alcotest.test_case "error_result_json" `Quick test_error_result_json;
+          Alcotest.test_case "split_csv" `Quick test_split_csv;
+        ] );
+    ]


### PR DESCRIPTION
## Summary

P3 Test Coverage Campaign Phase 5 — `tool_board.ml` (591줄)과 `tool_goals.ml` (666줄)에 대한 전용 Alcotest 테스트 추가.

### 신규 테스트 파일
| 파일 | 테스트 수 | 줄 수 | 대상 모듈 |
|------|----------|-------|----------|
| `test_tool_board_coverage.ml` | 31 | 425 | `tool_board.ml` (591줄) |
| `test_tool_goals_coverage.ml` | 23 | 367 | `tool_goals.ml` (666줄) |
| **합계** | **54** | **792** | |

### 테스트 그룹 (Board)
- **helpers** (5): visibility_of_string, sort_order_of_string, board_error_to_string, is_lodge_agent, format_timestamp_relative
- **json_helpers** (4): get_string, get_string_opt, get_int, get_bool
- **post_crud** (8): create/list/get 성공·실패·정렬·제한
- **voting** (1): 없는 포스트 투표 에러
- **comments** (2): 없는 포스트 댓글, 없는 댓글 투표
- **search_stats** (6): 검색·통계·프로필·하트 목록
- **dispatch** (2): unknown tool, migrate without PG
- **schemas** (3): 도구 수·이름 유일성·설명 존재

### 테스트 그룹 (Goals)
- **dispatch_routing** (2): unknown 라우팅, 전체 도구 dispatch
- **schemas** (3): 스키마 수·이름·설명 검증
- **snapshot** (2): 수동 모드, 빈 골 목록
- **validation** (4): horizon/status 검증, 필터링, rollup
- **refresh** (3): 무효 모드, auto/monthly
- **review** (3): 필수 필드, 없는 골, blocked→paused 매핑
- **helpers** (5): normalize_runtime, sanitize_keeper_name, tool/error_result_json, split_csv

### P3 누적 진행률
| Phase | PR | 테스트 수 | 상태 |
|-------|-----|----------|------|
| 1 | #500 | 37 | Merged |
| 2 | #503 | 41 | Merged |
| 3 | #504 | 67 | Merged |
| 4 | #505 | 78 | Merged |
| 5 | 이 PR | 54 | Draft |
| **합계** | | **277** | |

## Test plan
- [x] `dune build --root .` — 컴파일 성공
- [x] `dune exec test/test_tool_board_coverage.exe` — 31/31 통과
- [x] `dune exec test/test_tool_goals_coverage.exe` — 23/23 통과
- [x] `make test` — 전체 테스트 스위트 통과 (기존 테스트 회귀 없음)

🤖 Generated with [Claude Code](https://claude.com/claude-code)