### PR TITLE
feat: prove team-session execution via turn/events/proof tools

### DIFF
--- a/docs/TEAM-SESSION.md
+++ b/docs/TEAM-SESSION.md
@@ -8,6 +8,9 @@
 - 보고서 생성: `masc_team_session_report`
 - 세션 목록: `masc_team_session_list`
 - 세션 비교: `masc_team_session_compare`
+- 턴 기록/조작: `masc_team_session_turn`
+- 이벤트 타임라인 조회: `masc_team_session_events`
+- 증명 산출: `masc_team_session_prove`
 
 핵심 동작:
 
@@ -75,6 +78,49 @@
 - `markdown_path`
 - `json_path`
 
+### `masc_team_session_turn`
+
+입력:
+
+- `session_id` (required)
+- `turn_kind` (`note` | `broadcast` | `portal` | `task` | `checkpoint`, default `note`)
+- `message` (broadcast/portal/note에서 사용)
+- `target_agent` (portal에서 사용)
+- `task_title`/`task_description`/`task_priority` (task에서 사용)
+
+출력:
+
+- `turn_no`
+- `kind`
+- 액션 결과(`result`, `broadcast`, `target_agent` 등)
+
+### `masc_team_session_events`
+
+입력:
+
+- `session_id` (required)
+- `event_types` (optional array)
+- `after_ts` (optional unix timestamp)
+- `limit` (default `200`)
+
+출력:
+
+- `count`
+- `events` (필터링된 이벤트 배열)
+
+### `masc_team_session_prove`
+
+입력:
+
+- `session_id` (required)
+- `generate_report_if_missing` (default `true`)
+
+출력:
+
+- `proof` (`verdict`, `score_pct`, `criteria`, `evidence`)
+- `proof_json_path`
+- `proof_md_path`
+
 ## Artifact Layout
 
 기본 경로: `.masc/team-sessions/<session_id>/`
@@ -84,6 +130,8 @@
 - `checkpoints/<timestamp>.json`
 - `report.md`
 - `report.json`
+- `proof.md`
+- `proof.json`
 
 ## Report Structure
 
@@ -115,5 +163,7 @@
 - `start/stop`는 join-required 도구로 동작합니다.
 - `status/report/list/compare`는 read-only 도구로 동작합니다.
 - `status/stop/report/compare`는 세션 참여자(`created_by` 또는 `agent_names`)만 접근할 수 있습니다.
+- `turn/events/prove`도 세션 참여자만 접근할 수 있습니다.
 - `list`는 호출자 기준 접근 가능한 세션만 반환합니다.
 - 종료 직후에도 `force_regenerate=true`로 보고서를 다시 생성할 수 있습니다.
+- `prove`는 보고서가 없을 때 자동 생성 옵션(`generate_report_if_missing`)으로 증명 산출의 일관성을 보장합니다.

--- a/lib/mcp_server_eio.ml
+++ b/lib/mcp_server_eio.ml
@@ -777,7 +777,8 @@ let read_only_tools =
    "masc_worktree_list"; "masc_pending_interrupts";
    "masc_cost_report"; "masc_portal_status";
    "masc_goal_list"; "masc_team_session_status"; "masc_team_session_report";
-   "masc_team_session_list"; "masc_team_session_compare"]
+   "masc_team_session_list"; "masc_team_session_compare";
+   "masc_team_session_events"; "masc_team_session_prove"]
 
 let execute_tool_eio ~sw ~clock ?mcp_session_id ?auth_token state ~name ~arguments =
   (* clock parameter used for Session_eio.wait_for_message *)
@@ -1012,6 +1013,7 @@ let execute_tool_eio ~sw ~clock ?mcp_session_id ?auth_token state ~name ~argumen
     "masc_goal_upsert"; "masc_goal_snapshot"; "masc_goal_refresh";
     "masc_goal_dispatch"; "masc_goal_review";
     "masc_team_session_start"; "masc_team_session_stop";
+    "masc_team_session_turn";
   ] in
 
   (* Auto-init/auto-join for better UX.

--- a/lib/mode.ml
+++ b/lib/mode.ml
@@ -113,7 +113,9 @@ let tool_category tool_name =
   | "masc_task_history"
   | "masc_team_session_start" | "masc_team_session_status"
   | "masc_team_session_stop" | "masc_team_session_report"
-  | "masc_team_session_list" | "masc_team_session_compare" -> Core
+  | "masc_team_session_list" | "masc_team_session_compare"
+  | "masc_team_session_turn" | "masc_team_session_events"
+  | "masc_team_session_prove" -> Core
 
   (* Communication tools *)
   | "masc_broadcast" | "masc_messages"

--- a/lib/team_session_engine_eio.ml
+++ b/lib/team_session_engine_eio.ml
@@ -54,6 +54,10 @@ let session_visible_to_agent ~(agent_name : string)
   String.equal agent_name session.created_by
   || List.exists (String.equal agent_name) session.agent_names
 
+let session_allows_actor ~(actor : string) (session : Team_session_types.session) =
+  String.equal actor session.created_by
+  || List.exists (String.equal actor) session.agent_names
+
 let compute_live_done_delta (config : Room.config)
     (session : Team_session_types.session) =
   let backlog = Room.read_backlog config in
@@ -881,6 +885,8 @@ let record_turn ~(config : Room.config) ~(session_id : string) ~(actor : string)
   | None -> Error (Printf.sprintf "team session not found: %s" session_id)
   | Some session when session.status <> Team_session_types.Running ->
       Error "turn recording is only allowed while session is running"
+  | Some session when not (session_allows_actor ~actor session) ->
+      Error "actor is not authorized for this team session"
   | Some session -> (
       let message = normalize_opt message in
       let target_agent = normalize_opt target_agent in
@@ -1150,7 +1156,7 @@ let prove_session ~(config : Room.config) ~(session_id : string)
         Room_utils.path_exists config
           (Team_session_store.report_md_path config session_id)
       in
-      let ensure_report_result =
+      let ensure_report_result : (Team_session_types.session, string) result =
         if generate_report_if_missing && not (report_json_exists && report_md_exists)
         then
           match Team_session_report.generate config session with
@@ -1161,38 +1167,35 @@ let prove_session ~(config : Room.config) ~(session_id : string)
       in
       match ensure_report_result with
       | Error e -> Error e
-      | Ok _ -> (
-          match Team_session_store.load_session config session_id with
-          | None -> Error (Printf.sprintf "team session not found: %s" session_id)
-          | Some refreshed -> (
-              match Team_session_report.generate_proof config refreshed with
-              | Error e -> Error e
-              | Ok (proof_json, proof_markdown) ->
-                  let proof_json_path =
-                    Team_session_store.proof_json_path config session_id
-                  in
-                  let proof_md_path =
-                    Team_session_store.proof_md_path config session_id
-                  in
-                  Room_utils.write_json config proof_json_path proof_json;
-                  Team_session_store.write_text_file proof_md_path proof_markdown;
-                  Team_session_store.append_event config session_id
-                    ~event_type:"session_proof_generated"
-                    ~detail:
-                      (`Assoc
-                        [
-                          ("proof_json_path", `String proof_json_path);
-                          ("proof_md_path", `String proof_md_path);
-                          ("ts_iso", `String (now_iso ()));
-                        ]);
-                  Ok
-                    (`Assoc
-                      [
-                        ("session_id", `String session_id);
-                        ("proof", proof_json);
-                        ("proof_json_path", `String proof_json_path);
-                        ("proof_md_path", `String proof_md_path);
-                      ])))
+      | Ok refreshed_session -> (
+          match Team_session_report.generate_proof config refreshed_session with
+          | Error e -> Error e
+          | Ok (proof_json, proof_markdown) ->
+              let proof_json_path =
+                Team_session_store.proof_json_path config session_id
+              in
+              let proof_md_path =
+                Team_session_store.proof_md_path config session_id
+              in
+              Room_utils.write_json config proof_json_path proof_json;
+              Team_session_store.write_text_file proof_md_path proof_markdown;
+              Team_session_store.append_event config session_id
+                ~event_type:"session_proof_generated"
+                ~detail:
+                  (`Assoc
+                    [
+                      ("proof_json_path", `String proof_json_path);
+                      ("proof_md_path", `String proof_md_path);
+                      ("ts_iso", `String (now_iso ()));
+                    ]);
+              Ok
+                (`Assoc
+                  [
+                    ("session_id", `String session_id);
+                    ("proof", proof_json);
+                    ("proof_json_path", `String proof_json_path);
+                    ("proof_md_path", `String proof_md_path);
+                  ]))
 
 let list_sessions ~(config : Room.config) ~(requester_agent : string option)
     ~(status_filter : Team_session_types.session_status option) ~(limit : int) :

--- a/lib/team_session_engine_eio.ml
+++ b/lib/team_session_engine_eio.ml
@@ -245,6 +245,10 @@ let session_status_json (config : Room.config) (session : Team_session_types.ses
               `String
                 (Team_session_store.report_md_path config session.session_id) );
             ("json", `String (Team_session_store.report_json_path config session.session_id));
+            ( "proof_markdown",
+              `String
+                (Team_session_store.proof_md_path config session.session_id) );
+            ("proof_json", `String (Team_session_store.proof_json_path config session.session_id));
           ] );
     ]
 
@@ -654,6 +658,7 @@ let start_session ~sw ~(clock : _ Eio.Time.clock) ~(config : Room.config)
           (if report_formats = [] then
              [ Team_session_types.Markdown; Team_session_types.Json ]
            else report_formats);
+        turn_count = 0;
         agent_names = selected_agents;
         broadcast_count = 0;
         portal_count = 0;
@@ -671,6 +676,7 @@ let start_session ~sw ~(clock : _ Eio.Time.clock) ~(config : Room.config)
         stopped_at = None;
         last_checkpoint_at = Some now;
         last_event_at = Some now;
+        last_turn_at = None;
         stop_reason = None;
         generated_report = false;
         artifacts_dir = Team_session_store.session_dir config session_id;
@@ -859,6 +865,334 @@ let generate_report ~(config : Room.config) ~(session_id : string)
                   (Printf.sprintf
                      "report generated but failed to mark generated_report: %s" e)
             )
+
+let record_turn ~(config : Room.config) ~(session_id : string) ~(actor : string)
+    ~(turn_kind : Team_session_types.turn_kind) ~(message : string option)
+    ~(target_agent : string option) ~(task_title : string option)
+    ~(task_description : string option) ~(task_priority : int) :
+    (Yojson.Safe.t, string) result =
+  let normalize_opt = function
+    | Some s ->
+        let t = String.trim s in
+        if t = "" then None else Some t
+    | None -> None
+  in
+  match Team_session_store.load_session config session_id with
+  | None -> Error (Printf.sprintf "team session not found: %s" session_id)
+  | Some session when session.status <> Team_session_types.Running ->
+      Error "turn recording is only allowed while session is running"
+  | Some session -> (
+      let message = normalize_opt message in
+      let target_agent = normalize_opt target_agent in
+      let task_title = normalize_opt task_title in
+      let task_description =
+        match normalize_opt task_description with
+        | Some d -> d
+        | None -> ""
+      in
+      let task_priority = clamp_int ~min_v:1 ~max_v:5 task_priority in
+      let now = Time_compat.now () in
+      match turn_kind with
+      | Team_session_types.Turn_note ->
+          let updated =
+            {
+              session with
+              turn_count = session.turn_count + 1;
+              last_turn_at = Some now;
+              last_event_at = Some now;
+              updated_at_iso = now_iso ();
+            }
+          in
+          Team_session_store.save_session config updated;
+          Team_session_store.append_event config session_id ~event_type:"team_turn"
+            ~detail:
+              (`Assoc
+                [
+                  ("turn_no", `Int updated.turn_count);
+                  ("kind", `String "note");
+                  ("actor", `String actor);
+                  ( "message",
+                    Option.fold ~none:`Null ~some:(fun s -> `String s) message );
+                  ("ts_iso", `String (now_iso ()));
+                ]);
+          Ok
+            (`Assoc
+              [
+                ("session_id", `String session_id);
+                ("turn_no", `Int updated.turn_count);
+                ("kind", `String "note");
+              ])
+      | Team_session_types.Turn_broadcast -> (
+          match message with
+          | None -> Error "message is required for broadcast turn"
+          | Some msg ->
+              ignore (Room.broadcast config ~from_agent:actor ~content:msg);
+              let updated =
+                {
+                  session with
+                  turn_count = session.turn_count + 1;
+                  broadcast_count = session.broadcast_count + 1;
+                  last_turn_at = Some now;
+                  last_event_at = Some now;
+                  updated_at_iso = now_iso ();
+                }
+              in
+              Team_session_store.save_session config updated;
+              Team_session_store.append_event config session_id
+                ~event_type:"team_turn"
+                ~detail:
+                  (`Assoc
+                    [
+                      ("turn_no", `Int updated.turn_count);
+                      ("kind", `String "broadcast");
+                      ("actor", `String actor);
+                      ("message", `String msg);
+                      ("broadcast", `Bool true);
+                      ("ts_iso", `String (now_iso ()));
+                    ]);
+              Ok
+                (`Assoc
+                  [
+                    ("session_id", `String session_id);
+                    ("turn_no", `Int updated.turn_count);
+                    ("kind", `String "broadcast");
+                    ("broadcast", `Bool true);
+                  ]))
+      | Team_session_types.Turn_portal -> (
+          match (target_agent, message) with
+          | Some target, Some msg -> (
+              let send_result =
+                match
+                  Room.portal_open_r config ~agent_name:actor
+                    ~target_agent:target ~initial_message:(Some msg)
+                with
+                | Ok opened -> Ok opened
+                | Error (Types.PortalAlreadyOpen _) ->
+                    Room.portal_send_r config ~agent_name:actor ~message:msg
+                | Error e -> Error e
+              in
+              match send_result with
+              | Error e ->
+                  let err = Types.masc_error_to_string e in
+                  Team_session_store.append_event config session_id
+                    ~event_type:"team_turn_failed"
+                    ~detail:
+                      (`Assoc
+                        [
+                          ("kind", `String "portal");
+                          ("actor", `String actor);
+                          ("target_agent", `String target);
+                          ("error", `String err);
+                          ("ts_iso", `String (now_iso ()));
+                        ]);
+                  Error err
+              | Ok send_msg ->
+                  let updated =
+                    {
+                      session with
+                      turn_count = session.turn_count + 1;
+                      portal_count = session.portal_count + 1;
+                      last_turn_at = Some now;
+                      last_event_at = Some now;
+                      updated_at_iso = now_iso ();
+                    }
+                  in
+                  Team_session_store.save_session config updated;
+                  Team_session_store.append_event config session_id
+                    ~event_type:"team_turn"
+                    ~detail:
+                      (`Assoc
+                        [
+                          ("turn_no", `Int updated.turn_count);
+                          ("kind", `String "portal");
+                          ("actor", `String actor);
+                          ("target_agent", `String target);
+                          ("message", `String msg);
+                          ("result", `String send_msg);
+                          ("ts_iso", `String (now_iso ()));
+                        ]);
+                  Ok
+                    (`Assoc
+                      [
+                        ("session_id", `String session_id);
+                        ("turn_no", `Int updated.turn_count);
+                        ("kind", `String "portal");
+                        ("target_agent", `String target);
+                        ("result", `String send_msg);
+                      ]))
+          | _ -> Error "target_agent and message are required for portal turn")
+      | Team_session_types.Turn_task -> (
+          match task_title with
+          | None -> Error "task_title is required for task turn"
+          | Some title ->
+              let add_result =
+                Room.add_task config ~title ~priority:task_priority
+                  ~description:task_description
+              in
+              let updated =
+                {
+                  session with
+                  turn_count = session.turn_count + 1;
+                  last_turn_at = Some now;
+                  last_event_at = Some now;
+                  updated_at_iso = now_iso ();
+                }
+              in
+              Team_session_store.save_session config updated;
+              Team_session_store.append_event config session_id
+                ~event_type:"team_turn"
+                ~detail:
+                  (`Assoc
+                    [
+                      ("turn_no", `Int updated.turn_count);
+                      ("kind", `String "task");
+                      ("actor", `String actor);
+                      ("task_title", `String title);
+                      ("task_priority", `Int task_priority);
+                      ("result", `String add_result);
+                      ("ts_iso", `String (now_iso ()));
+                    ]);
+              Ok
+                (`Assoc
+                  [
+                    ("session_id", `String session_id);
+                    ("turn_no", `Int updated.turn_count);
+                    ("kind", `String "task");
+                    ("result", `String add_result);
+                  ]))
+      | Team_session_types.Turn_checkpoint ->
+          write_checkpoint config session;
+          let updated =
+            {
+              session with
+              turn_count = session.turn_count + 1;
+              last_turn_at = Some now;
+              last_checkpoint_at = Some now;
+              last_event_at = Some now;
+              updated_at_iso = now_iso ();
+            }
+          in
+          Team_session_store.save_session config updated;
+          Team_session_store.append_event config session_id ~event_type:"team_turn"
+            ~detail:
+              (`Assoc
+                [
+                  ("turn_no", `Int updated.turn_count);
+                  ("kind", `String "checkpoint");
+                  ("actor", `String actor);
+                  ("ts_iso", `String (now_iso ()));
+                ]);
+          Ok
+            (`Assoc
+              [
+                ("session_id", `String session_id);
+                ("turn_no", `Int updated.turn_count);
+                ("kind", `String "checkpoint");
+              ]))
+
+let list_events ~(config : Room.config) ~(session_id : string)
+    ~(event_types : string list) ~(limit : int) ~(after_ts : float option) :
+    (Yojson.Safe.t, string) result =
+  match Team_session_store.load_session config session_id with
+  | None -> Error (Printf.sprintf "team session not found: %s" session_id)
+  | Some _ ->
+      let normalize_types =
+        event_types
+        |> List.map String.trim
+        |> List.filter (fun s -> s <> "")
+        |> Team_session_types.dedup_strings
+      in
+      let max_events = clamp_int ~min_v:1 ~max_v:10000 (max 500 limit) in
+      let limit = clamp_int ~min_v:1 ~max_v:1000 limit in
+      let events = Team_session_store.read_events ~max_events config session_id in
+      let matches_type json =
+        if normalize_types = [] then
+          true
+        else
+          match Yojson.Safe.Util.member "event_type" json with
+          | `String t -> List.mem t normalize_types
+          | _ -> false
+      in
+      let matches_after_ts json =
+        match after_ts with
+        | None -> true
+        | Some ts -> (
+            match Yojson.Safe.Util.member "ts" json with
+            | `Float v -> v > ts
+            | `Int n -> float_of_int n > ts
+            | `Intlit s -> (try float_of_string s > ts with _ -> false)
+            | _ -> false)
+      in
+      let filtered =
+        events
+        |> List.filter matches_type
+        |> List.filter matches_after_ts
+        |> take_last limit
+      in
+      Ok
+        (`Assoc
+          [
+            ("session_id", `String session_id);
+            ("count", `Int (List.length filtered));
+            ("events", `List filtered);
+          ])
+
+let prove_session ~(config : Room.config) ~(session_id : string)
+    ~(generate_report_if_missing : bool) : (Yojson.Safe.t, string) result =
+  match Team_session_store.load_session config session_id with
+  | None -> Error (Printf.sprintf "team session not found: %s" session_id)
+  | Some session ->
+      let report_json_exists =
+        Room_utils.path_exists config
+          (Team_session_store.report_json_path config session_id)
+      in
+      let report_md_exists =
+        Room_utils.path_exists config
+          (Team_session_store.report_md_path config session_id)
+      in
+      let ensure_report_result =
+        if generate_report_if_missing && not (report_json_exists && report_md_exists)
+        then
+          match Team_session_report.generate config session with
+          | Ok (_json, _markdown) ->
+              Team_session_store.mark_report_generated config session_id
+          | Error e -> Error e
+        else Ok session
+      in
+      match ensure_report_result with
+      | Error e -> Error e
+      | Ok _ -> (
+          match Team_session_store.load_session config session_id with
+          | None -> Error (Printf.sprintf "team session not found: %s" session_id)
+          | Some refreshed -> (
+              match Team_session_report.generate_proof config refreshed with
+              | Error e -> Error e
+              | Ok (proof_json, proof_markdown) ->
+                  let proof_json_path =
+                    Team_session_store.proof_json_path config session_id
+                  in
+                  let proof_md_path =
+                    Team_session_store.proof_md_path config session_id
+                  in
+                  Room_utils.write_json config proof_json_path proof_json;
+                  Team_session_store.write_text_file proof_md_path proof_markdown;
+                  Team_session_store.append_event config session_id
+                    ~event_type:"session_proof_generated"
+                    ~detail:
+                      (`Assoc
+                        [
+                          ("proof_json_path", `String proof_json_path);
+                          ("proof_md_path", `String proof_md_path);
+                          ("ts_iso", `String (now_iso ()));
+                        ]);
+                  Ok
+                    (`Assoc
+                      [
+                        ("session_id", `String session_id);
+                        ("proof", proof_json);
+                        ("proof_json_path", `String proof_json_path);
+                        ("proof_md_path", `String proof_md_path);
+                      ])))
 
 let list_sessions ~(config : Room.config) ~(requester_agent : string option)
     ~(status_filter : Team_session_types.session_status option) ~(limit : int) :

--- a/lib/team_session_report.ml
+++ b/lib/team_session_report.ml
@@ -173,6 +173,12 @@ let mcp_improvements (session : Team_session_types.session) events checkpoints_c
       :: with_outcome
     else with_outcome
   in
+  let with_turns =
+    if session.turn_count > 0 then
+      "Turn-level orchestration evidence exists via masc_team_session_turn events."
+      :: with_fallback
+    else with_fallback
+  in
   let recovered_events =
     List.filter
       (fun json ->
@@ -183,8 +189,8 @@ let mcp_improvements (session : Team_session_types.session) events checkpoints_c
   in
   if recovered_events <> [] then
     "Recovery path was exercised (recovered_after_restart event present)."
-    :: with_fallback
-  else with_fallback
+    :: with_turns
+  else with_turns
 
 let markdown_of_report ~(session : Team_session_types.session)
     ~(summary_json : Yojson.Safe.t) ~(events : Yojson.Safe.t list)
@@ -234,6 +240,7 @@ let markdown_of_report ~(session : Team_session_types.session)
     cascade_metrics_json |> member "fallback_task_created" |> to_int_option
     |> Option.value ~default:0
   in
+  let turn_count = session.turn_count in
   let cascade_attempted =
     cascade_metrics_json |> member "attempted" |> to_int_option
     |> Option.value ~default:0
@@ -311,6 +318,7 @@ let markdown_of_report ~(session : Team_session_types.session)
       "## Communication/Cascade Metrics";
       Printf.sprintf "- Broadcast count: %d" broadcast_count;
       Printf.sprintf "- Portal signal count: %d" portal_count;
+      Printf.sprintf "- Recorded turns: %d" turn_count;
       Printf.sprintf "- Alerts emitted: %d" alert_count;
       Printf.sprintf "- Cascade attempted: %d" cascade_attempted;
       Printf.sprintf "- Cascade failed: %d" cascade_failed;
@@ -403,6 +411,7 @@ let generate config (session : Team_session_types.session) :
               [
                 ("events_count", `Int (List.length events));
                 ("checkpoints_count", `Int checkpoints_count);
+                ("turn_count", `Int session.turn_count);
                 ("active_agents", `List (List.map (fun a -> `String a) active_agents));
               ] );
         ]
@@ -423,4 +432,184 @@ let generate config (session : Team_session_types.session) :
     in
     Team_session_store.write_text_file report_md_path markdown;
     Ok (report_json, markdown)
+  with exn -> Error (Printexc.to_string exn)
+
+let bool_of_criterion evidence =
+  match Yojson.Safe.Util.member "passed" evidence with
+  | `Bool b -> b
+  | _ -> false
+
+let proof_markdown ~(session : Team_session_types.session)
+    ~(score_pct : float) ~(verdict : string) ~(criteria : Yojson.Safe.t list)
+    ~(checkpoints_count : int) ~(events_count : int) ~(turn_events : int)
+    ~(report_exists : bool) ~(proof_generated_at_iso : string) =
+  let criteria_lines =
+    criteria
+    |> List.map (fun item ->
+           let open Yojson.Safe.Util in
+           let name =
+             item |> member "name" |> to_string_option
+             |> Option.value ~default:"unknown"
+           in
+           let passed = item |> member "passed" |> to_bool_option |> Option.value ~default:false in
+           let detail =
+             item |> member "detail" |> to_string_option
+             |> Option.value ~default:""
+           in
+           let status = if passed then "PASS" else "FAIL" in
+           Printf.sprintf "- [%s] %s%s" status name
+             (if detail = "" then "" else " - " ^ detail))
+  in
+  String.concat "\n"
+    [
+      "# Team Session Proof";
+      "";
+      "## Verdict";
+      Printf.sprintf "- Session ID: %s" session.session_id;
+      Printf.sprintf "- Verdict: %s" verdict;
+      Printf.sprintf "- Score(%%): %.1f" score_pct;
+      Printf.sprintf "- Generated at: %s" proof_generated_at_iso;
+      "";
+      "## Evidence Summary";
+      Printf.sprintf "- Events count: %d" events_count;
+      Printf.sprintf "- Checkpoints count: %d" checkpoints_count;
+      Printf.sprintf "- Turn events count: %d" turn_events;
+      Printf.sprintf "- Report artifacts exist: %b" report_exists;
+      "";
+      "## Criteria";
+      (if criteria_lines = [] then "- (no criteria)" else String.concat "\n" criteria_lines);
+    ]
+
+let generate_proof config (session : Team_session_types.session) :
+    (Yojson.Safe.t * string, string) result =
+  try
+    let events = Team_session_store.read_events ~max_events:5000 config session.session_id in
+    let checkpoints_count =
+      Team_session_store.list_checkpoint_paths config session.session_id
+      |> List.length
+    in
+    let event_exists event_type =
+      List.exists
+        (fun json ->
+          match Yojson.Safe.Util.member "event_type" json with
+          | `String e when String.equal e event_type -> true
+          | _ -> false)
+        events
+    in
+    let turn_events =
+      List.fold_left
+        (fun acc json ->
+          match Yojson.Safe.Util.member "event_type" json with
+          | `String "team_turn" -> acc + 1
+          | _ -> acc)
+        0 events
+    in
+    let report_json_exists =
+      Room_utils.path_exists config
+        (Team_session_store.report_json_path config session.session_id)
+    in
+    let report_md_exists =
+      Room_utils.path_exists config
+        (Team_session_store.report_md_path config session.session_id)
+    in
+    let report_exists = report_json_exists && report_md_exists in
+    let communication_total = session.broadcast_count + session.portal_count in
+    let done_delta_total =
+      match session.final_done_delta_total with
+      | Some n -> n
+      | None ->
+          let backlog = Room.read_backlog config in
+          let current_done = Team_session_types.done_counts_from_backlog backlog in
+          Team_session_types.done_delta_by_agent ~baseline:session.baseline_done_counts
+            ~current:current_done ~agents:session.agent_names
+          |> List.fold_left (fun acc (_, n) -> acc + n) 0
+    in
+    let criteria =
+      [
+        ( "session_started_event",
+          event_exists "session_started",
+          "session_started 이벤트 존재" );
+        ( "checkpoint_recorded",
+          checkpoints_count > 0,
+          Printf.sprintf "checkpoints=%d" checkpoints_count );
+        ( "turn_or_communication_recorded",
+          turn_events > 0 || communication_total > 0,
+          Printf.sprintf "turn_events=%d communication_total=%d" turn_events
+            communication_total );
+        ( "goal_recorded",
+          String.trim session.goal <> "",
+          "goal 문자열 존재" );
+        ( "participants_recorded",
+          session.agent_names <> [],
+          Printf.sprintf "participants=%d" (List.length session.agent_names) );
+        ( "report_artifacts",
+          report_exists,
+          Printf.sprintf "report_json=%b report_md=%b" report_json_exists
+            report_md_exists );
+        ( "outcome_traceable",
+          done_delta_total >= 0,
+          Printf.sprintf "done_delta_total=%d" done_delta_total );
+      ]
+      |> List.map (fun (name, passed, detail) ->
+             `Assoc
+               [
+                 ("name", `String name);
+                 ("passed", `Bool passed);
+                 ("detail", `String detail);
+               ])
+    in
+    let total = max 1 (List.length criteria) in
+    let passed =
+      List.fold_left (fun acc item -> if bool_of_criterion item then acc + 1 else acc) 0
+        criteria
+    in
+    let score_pct = (100.0 *. float_of_int passed) /. float_of_int total in
+    let mandatory_ok =
+      let find name =
+        criteria
+        |> List.find_opt (fun item ->
+               match Yojson.Safe.Util.member "name" item with
+               | `String n -> String.equal n name
+               | _ -> false)
+        |> Option.value ~default:(`Assoc [ ("passed", `Bool false) ])
+        |> bool_of_criterion
+      in
+      find "session_started_event" && find "checkpoint_recorded"
+      && find "turn_or_communication_recorded" && find "report_artifacts"
+    in
+    let verdict =
+      if mandatory_ok then "proved"
+      else "insufficient_evidence"
+    in
+    let generated_at_iso = Types.now_iso () in
+    let proof_json =
+      `Assoc
+        [
+          ("session_id", `String session.session_id);
+          ("goal", `String session.goal);
+          ("status", `String (Team_session_types.status_to_string session.status));
+          ("verdict", `String verdict);
+          ("score_pct", `Float score_pct);
+          ("criteria", `List criteria);
+          ( "evidence",
+            `Assoc
+              [
+                ("events_count", `Int (List.length events));
+                ("checkpoints_count", `Int checkpoints_count);
+                ("turn_events", `Int turn_events);
+                ("broadcast_count", `Int session.broadcast_count);
+                ("portal_count", `Int session.portal_count);
+                ("done_delta_total", `Int done_delta_total);
+                ("report_json_exists", `Bool report_json_exists);
+                ("report_md_exists", `Bool report_md_exists);
+              ] );
+          ("generated_at_iso", `String generated_at_iso);
+        ]
+    in
+    let markdown =
+      proof_markdown ~session ~score_pct ~verdict ~criteria ~checkpoints_count
+        ~events_count:(List.length events) ~turn_events ~report_exists
+        ~proof_generated_at_iso:generated_at_iso
+    in
+    Ok (proof_json, markdown)
   with exn -> Error (Printexc.to_string exn)

--- a/lib/team_session_store.ml
+++ b/lib/team_session_store.ml
@@ -23,6 +23,12 @@ let report_md_path config session_id =
 let report_json_path config session_id =
   Filename.concat (session_dir config session_id) "report.json"
 
+let proof_md_path config session_id =
+  Filename.concat (session_dir config session_id) "proof.md"
+
+let proof_json_path config session_id =
+  Filename.concat (session_dir config session_id) "proof.json"
+
 let now_iso () = Types.now_iso ()
 
 let ensure_session_dirs config session_id =

--- a/lib/team_session_types.ml
+++ b/lib/team_session_types.ml
@@ -42,6 +42,13 @@ type report_format =
   | Markdown
   | Json
 
+type turn_kind =
+  | Turn_note
+  | Turn_broadcast
+  | Turn_portal
+  | Turn_task
+  | Turn_checkpoint
+
 type session = {
   session_id : string;
   goal : string;
@@ -60,6 +67,7 @@ type session = {
   alert_channel : alert_channel;
   auto_resume : bool;
   report_formats : report_format list;
+  turn_count : int;
   agent_names : string list;
   broadcast_count : int;
   portal_count : int;
@@ -77,6 +85,7 @@ type session = {
   stopped_at : float option;
   last_checkpoint_at : float option;
   last_event_at : float option;
+  last_turn_at : float option;
   stop_reason : string option;
   generated_report : bool;
   artifacts_dir : string;
@@ -195,6 +204,21 @@ let report_formats_of_strings xs =
   |> List.filter_map (fun s -> report_format_of_string (String.lowercase_ascii (String.trim s)))
   |> dedup []
 
+let turn_kind_to_string = function
+  | Turn_note -> "note"
+  | Turn_broadcast -> "broadcast"
+  | Turn_portal -> "portal"
+  | Turn_task -> "task"
+  | Turn_checkpoint -> "checkpoint"
+
+let turn_kind_of_string = function
+  | "broadcast" -> Some Turn_broadcast
+  | "portal" -> Some Turn_portal
+  | "task" -> Some Turn_task
+  | "checkpoint" -> Some Turn_checkpoint
+  | "note" -> Some Turn_note
+  | _ -> None
+
 let dedup_strings xs =
   let rec loop acc = function
     | [] -> List.rev acc
@@ -275,6 +299,7 @@ let session_to_yojson (s : session) =
       ("alert_channel", `String (alert_channel_to_string s.alert_channel));
       ("auto_resume", `Bool s.auto_resume);
       ("report_formats", `List (List.map (fun f -> `String (report_format_to_string f)) s.report_formats));
+      ("turn_count", `Int s.turn_count);
       ("agent_names", `List (List.map (fun a -> `String a) s.agent_names));
       ("broadcast_count", `Int s.broadcast_count);
       ("portal_count", `Int s.portal_count);
@@ -292,6 +317,7 @@ let session_to_yojson (s : session) =
       ("stopped_at", Option.fold ~none:`Null ~some:(fun v -> `Float v) s.stopped_at);
       ("last_checkpoint_at", Option.fold ~none:`Null ~some:(fun v -> `Float v) s.last_checkpoint_at);
       ("last_event_at", Option.fold ~none:`Null ~some:(fun v -> `Float v) s.last_event_at);
+      ("last_turn_at", Option.fold ~none:`Null ~some:(fun v -> `Float v) s.last_turn_at);
       ("stop_reason", Option.fold ~none:`Null ~some:(fun v -> `String v) s.stop_reason);
       ("generated_report", `Bool s.generated_report);
       ("artifacts_dir", `String s.artifacts_dir);
@@ -364,6 +390,7 @@ let session_of_yojson json =
                |> report_formats_of_strings
            | _ -> [])
           |> (fun xs -> if xs = [] then [Markdown; Json] else xs);
+        turn_count = get_int_default "turn_count" 0;
         agent_names =
           (match member "agent_names" json with
            | `List xs -> List.filter_map (function `String s -> Some s | _ -> None) xs
@@ -395,6 +422,7 @@ let session_of_yojson json =
         stopped_at = json |> member "stopped_at" |> to_float_option;
         last_checkpoint_at = json |> member "last_checkpoint_at" |> to_float_option;
         last_event_at = json |> member "last_event_at" |> to_float_option;
+        last_turn_at = json |> member "last_turn_at" |> to_float_option;
         stop_reason = json |> member "stop_reason" |> to_string_option;
         generated_report = json |> member "generated_report" |> to_bool_option |> Option.value ~default:false;
         artifacts_dir = json |> member "artifacts_dir" |> to_string_option |> Option.value ~default:"";

--- a/lib/tool_team_session.ml
+++ b/lib/tool_team_session.ml
@@ -29,6 +29,13 @@ let get_int args key default =
   | `Intlit s -> (try int_of_string s with _ -> default)
   | _ -> default
 
+let get_float_opt args key =
+  match Yojson.Safe.Util.member key args with
+  | `Float v -> Some v
+  | `Int n -> Some (float_of_int n)
+  | `Intlit s -> (try Some (float_of_string s) with _ -> None)
+  | _ -> None
+
 let get_bool args key default =
   match Yojson.Safe.Util.member key args with
   | `Bool b -> b
@@ -92,6 +99,14 @@ let parse_report_formats args =
   let parsed = Team_session_types.report_formats_of_strings raw in
   if parsed = [] then [ Team_session_types.Markdown; Team_session_types.Json ]
   else parsed
+
+let parse_turn_kind args =
+  let raw = get_string args "turn_kind" "note" |> String.trim |> String.lowercase_ascii in
+  match Team_session_types.turn_kind_of_string raw with
+  | Some k -> Ok k
+  | None ->
+      Error
+        "invalid turn_kind (allowed: note|broadcast|portal|task|checkpoint)"
 
 let is_all_digits s =
   let len = String.length s in
@@ -247,6 +262,63 @@ let handle_compare ctx args : result =
   | Error e, _ -> (false, json_error e)
   | _, Error e -> (false, json_error e)
 
+let handle_turn ctx args : result =
+  match get_valid_session_id args with
+  | Error e -> (false, json_error e)
+  | Ok session_id -> (
+      match ensure_session_access ctx session_id with
+      | Error e -> (false, json_error e)
+      | Ok () -> (
+          match parse_turn_kind args with
+          | Error e -> (false, json_error e)
+          | Ok turn_kind ->
+              let message = get_string_opt args "message" in
+              let target_agent = get_string_opt args "target_agent" in
+              let task_title = get_string_opt args "task_title" in
+              let task_description = get_string_opt args "task_description" in
+              let task_priority = get_int args "task_priority" 3 in
+              (match
+                 Team_session_engine_eio.record_turn ~config:ctx.config
+                   ~session_id ~actor:ctx.agent_name ~turn_kind ~message
+                   ~target_agent ~task_title ~task_description ~task_priority
+               with
+              | Ok json -> (true, json_ok [ ("result", json) ])
+              | Error e -> (false, json_error e))))
+
+let handle_events ctx args : result =
+  match get_valid_session_id args with
+  | Error e -> (false, json_error e)
+  | Ok session_id -> (
+      match ensure_session_access ctx session_id with
+      | Error e -> (false, json_error e)
+      | Ok () ->
+          let event_types = get_string_list args "event_types" in
+          let limit = get_int args "limit" 200 in
+          let after_ts = get_float_opt args "after_ts" in
+          (match
+             Team_session_engine_eio.list_events ~config:ctx.config ~session_id
+               ~event_types ~limit ~after_ts
+           with
+          | Ok json -> (true, json_ok [ ("result", json) ])
+          | Error e -> (false, json_error e)))
+
+let handle_prove ctx args : result =
+  match get_valid_session_id args with
+  | Error e -> (false, json_error e)
+  | Ok session_id -> (
+      match ensure_session_access ctx session_id with
+      | Error e -> (false, json_error e)
+      | Ok () ->
+          let generate_report_if_missing =
+            get_bool args "generate_report_if_missing" true
+          in
+          (match
+             Team_session_engine_eio.prove_session ~config:ctx.config ~session_id
+               ~generate_report_if_missing
+           with
+          | Ok json -> (true, json_ok [ ("result", json) ])
+          | Error e -> (false, json_error e)))
+
 let dispatch ctx ~name ~args : result option =
   match name with
   | "masc_team_session_start" -> Some (handle_start ctx args)
@@ -255,6 +327,9 @@ let dispatch ctx ~name ~args : result option =
   | "masc_team_session_report" -> Some (handle_report ctx args)
   | "masc_team_session_list" -> Some (handle_list ctx args)
   | "masc_team_session_compare" -> Some (handle_compare ctx args)
+  | "masc_team_session_turn" -> Some (handle_turn ctx args)
+  | "masc_team_session_events" -> Some (handle_events ctx args)
+  | "masc_team_session_prove" -> Some (handle_prove ctx args)
   | _ -> None
 
 let schemas : tool_schema list =
@@ -474,6 +549,83 @@ let schemas : tool_schema list =
                   ("target_session_id", `Assoc [ ("type", `String "string") ]);
                 ] );
             ("required", `List [ `String "base_session_id"; `String "target_session_id" ]);
+          ];
+    };
+    {
+      name = "masc_team_session_turn";
+      description =
+        "Record a team orchestration turn and optionally execute broadcast/portal/task/checkpoint action.";
+      input_schema =
+        `Assoc
+          [
+            ("type", `String "object");
+            ( "properties",
+              `Assoc
+                [
+                  ("session_id", `Assoc [ ("type", `String "string") ]);
+                  ( "turn_kind",
+                    `Assoc
+                      [
+                        ("type", `String "string");
+                        ( "enum",
+                          `List
+                            [
+                              `String "note";
+                              `String "broadcast";
+                              `String "portal";
+                              `String "task";
+                              `String "checkpoint";
+                            ] );
+                      ] );
+                  ("message", `Assoc [ ("type", `String "string") ]);
+                  ("target_agent", `Assoc [ ("type", `String "string") ]);
+                  ("task_title", `Assoc [ ("type", `String "string") ]);
+                  ("task_description", `Assoc [ ("type", `String "string") ]);
+                  ("task_priority", `Assoc [ ("type", `String "integer") ]);
+                ] );
+            ("required", `List [ `String "session_id" ]);
+          ];
+    };
+    {
+      name = "masc_team_session_events";
+      description =
+        "Read team session event timeline with optional event type and timestamp filters.";
+      input_schema =
+        `Assoc
+          [
+            ("type", `String "object");
+            ( "properties",
+              `Assoc
+                [
+                  ("session_id", `Assoc [ ("type", `String "string") ]);
+                  ( "event_types",
+                    `Assoc
+                      [
+                        ("type", `String "array");
+                        ("items", `Assoc [ ("type", `String "string") ]);
+                      ] );
+                  ("after_ts", `Assoc [ ("type", `String "number") ]);
+                  ("limit", `Assoc [ ("type", `String "integer") ]);
+                ] );
+            ("required", `List [ `String "session_id" ]);
+          ];
+    };
+    {
+      name = "masc_team_session_prove";
+      description =
+        "Generate verifiable proof artifacts (proof.json/proof.md) for a team session based on timeline evidence.";
+      input_schema =
+        `Assoc
+          [
+            ("type", `String "object");
+            ( "properties",
+              `Assoc
+                [
+                  ("session_id", `Assoc [ ("type", `String "string") ]);
+                  ( "generate_report_if_missing",
+                    `Assoc [ ("type", `String "boolean") ] );
+                ] );
+            ("required", `List [ `String "session_id" ]);
           ];
     };
   ]

--- a/scripts/harness/contract/team_session_contract.sh
+++ b/scripts/harness/contract/team_session_contract.sh
@@ -58,15 +58,15 @@ require_ok() {
   fi
 }
 
-echo "[1/9] masc_init"
+echo "[1/12] masc_init"
 r1="$(call_tool 4101 "masc_init" "{\"agent_name\":\"$AGENT_NAME\"}")"
 require_ok "$r1"
 
-echo "[2/9] masc_join"
+echo "[2/12] masc_join"
 r2="$(call_tool 4102 "masc_join" "{\"agent_name\":\"$AGENT_NAME\",\"capabilities\":[\"qa\",\"team-session\"]}")"
 require_ok "$r2"
 
-echo "[3/9] masc_team_session_start (base)"
+echo "[3/12] masc_team_session_start (base)"
 start_args_base="$(jq -cn --arg goal "contract-base" --argjson duration "$DURATION_SEC" '{goal:$goal,duration_seconds:$duration,checkpoint_interval_sec:10,min_agents:1,orchestration_mode:"assist",communication_mode:"hybrid",model_cascade:["glm:glm-5"],fallback_policy:"cascade_then_task",instruction_profile:"strict",alert_channel:"both",report_formats:["markdown","json"]}')"
 r3="$(call_tool 4103 "masc_team_session_start" "$start_args_base")"
 require_ok "$r3"
@@ -77,7 +77,7 @@ if [ -z "$s1" ]; then
   exit 1
 fi
 
-echo "[4/9] masc_team_session_status"
+echo "[4/12] masc_team_session_status"
 r4="$(call_tool 4104 "masc_team_session_status" "{\"session_id\":\"$s1\"}")"
 require_ok "$r4"
 if ! printf "%s" "$r4" | extract_result | jq -e '.team_health and .communication_metrics and .orchestration_state and .cascade_metrics' >/dev/null; then
@@ -86,7 +86,7 @@ if ! printf "%s" "$r4" | extract_result | jq -e '.team_health and .communication
   exit 1
 fi
 
-echo "[5/9] masc_team_session_start (target)"
+echo "[5/12] masc_team_session_start (target)"
 start_args_target="$(jq -cn --arg goal "contract-target" --argjson duration "$DURATION_SEC" '{goal:$goal,duration_seconds:$duration,checkpoint_interval_sec:10,min_agents:1,orchestration_mode:"manual",communication_mode:"broadcast",model_cascade:[],fallback_policy:"task_only",instruction_profile:"standard",alert_channel:"broadcast"}')"
 r5="$(call_tool 4105 "masc_team_session_start" "$start_args_target")"
 require_ok "$r5"
@@ -97,8 +97,19 @@ if [ -z "$s2" ]; then
   exit 1
 fi
 
-echo "[6/9] masc_team_session_list"
-r6="$(call_tool 4106 "masc_team_session_list" "{\"limit\":10}")"
+echo "[6/12] masc_team_session_turn + events"
+r6_turn="$(call_tool 4106 "masc_team_session_turn" "{\"session_id\":\"$s1\",\"turn_kind\":\"broadcast\",\"message\":\"contract turn broadcast\"}")"
+require_ok "$r6_turn"
+r6_events="$(call_tool 4107 "masc_team_session_events" "{\"session_id\":\"$s1\",\"event_types\":[\"team_turn\"],\"limit\":20}")"
+require_ok "$r6_events"
+if ! printf "%s" "$r6_events" | extract_result | jq -e '.count >= 1' >/dev/null; then
+  echo "FAIL: team_turn events not found"
+  printf "%s\n" "$r6_events"
+  exit 1
+fi
+
+echo "[7/12] masc_team_session_list"
+r6="$(call_tool 4108 "masc_team_session_list" "{\"limit\":10}")"
 require_ok "$r6"
 if ! printf "%s" "$r6" | extract_result | jq -e --arg s1 "$s1" --arg s2 "$s2" '.sessions | map(.session_id) | index($s1) != null and index($s2) != null' >/dev/null; then
   echo "FAIL: list does not include both sessions"
@@ -106,8 +117,8 @@ if ! printf "%s" "$r6" | extract_result | jq -e --arg s1 "$s1" --arg s2 "$s2" '.
   exit 1
 fi
 
-echo "[7/9] masc_team_session_compare"
-r7="$(call_tool 4107 "masc_team_session_compare" "{\"base_session_id\":\"$s1\",\"target_session_id\":\"$s2\"}")"
+echo "[8/12] masc_team_session_compare"
+r7="$(call_tool 4109 "masc_team_session_compare" "{\"base_session_id\":\"$s1\",\"target_session_id\":\"$s2\"}")"
 require_ok "$r7"
 if ! printf "%s" "$r7" | extract_result | jq -e --arg s1 "$s1" --arg s2 "$s2" '.base_session_id == $s1 and .target_session_id == $s2 and .summary and .communication and .policy' >/dev/null; then
   echo "FAIL: compare payload invalid"
@@ -115,9 +126,9 @@ if ! printf "%s" "$r7" | extract_result | jq -e --arg s1 "$s1" --arg s2 "$s2" '.
   exit 1
 fi
 
-echo "[8/9] masc_team_session_stop (base) + report"
-_="$(call_tool 4108 "masc_team_session_stop" "{\"session_id\":\"$s1\",\"reason\":\"contract_done\",\"generate_report\":true}")"
-r8_report="$(call_tool 4109 "masc_team_session_report" "{\"session_id\":\"$s1\",\"force_regenerate\":true}")"
+echo "[9/12] masc_team_session_stop (base) + report"
+_="$(call_tool 4110 "masc_team_session_stop" "{\"session_id\":\"$s1\",\"reason\":\"contract_done\",\"generate_report\":true}")"
+r8_report="$(call_tool 4111 "masc_team_session_report" "{\"session_id\":\"$s1\",\"force_regenerate\":true}")"
 require_ok "$r8_report"
 if ! printf "%s" "$r8_report" | extract_result | jq -e '.markdown_path and .json_path' >/dev/null; then
   echo "FAIL: report paths missing"
@@ -125,8 +136,19 @@ if ! printf "%s" "$r8_report" | extract_result | jq -e '.markdown_path and .json
   exit 1
 fi
 
-echo "[9/9] cleanup stop target + leave"
-_="$(call_tool 4110 "masc_team_session_stop" "{\"session_id\":\"$s2\",\"reason\":\"contract_done\",\"generate_report\":false}")"
-_="$(call_tool 4111 "masc_leave" "{\"agent_name\":\"$AGENT_NAME\"}")"
+echo "[10/12] masc_team_session_prove"
+r10_prove="$(call_tool 4112 "masc_team_session_prove" "{\"session_id\":\"$s1\",\"generate_report_if_missing\":true}")"
+require_ok "$r10_prove"
+if ! printf "%s" "$r10_prove" | extract_result | jq -e '.proof.verdict and .proof_json_path and .proof_md_path' >/dev/null; then
+  echo "FAIL: prove payload invalid"
+  printf "%s\n" "$r10_prove"
+  exit 1
+fi
+
+echo "[11/12] cleanup stop target"
+_="$(call_tool 4113 "masc_team_session_stop" "{\"session_id\":\"$s2\",\"reason\":\"contract_done\",\"generate_report\":false}")"
+
+echo "[12/12] leave"
+_="$(call_tool 4114 "masc_leave" "{\"agent_name\":\"$AGENT_NAME\"}")"
 
 echo "PASS: team_session contract harness"

--- a/test/test_mode_coverage.ml
+++ b/test/test_mode_coverage.ml
@@ -156,7 +156,13 @@ let test_tool_category_core () =
   check bool "team_session_list" true
     (Mode.tool_category "masc_team_session_list" = Mode.Core);
   check bool "team_session_compare" true
-    (Mode.tool_category "masc_team_session_compare" = Mode.Core)
+    (Mode.tool_category "masc_team_session_compare" = Mode.Core);
+  check bool "team_session_turn" true
+    (Mode.tool_category "masc_team_session_turn" = Mode.Core);
+  check bool "team_session_events" true
+    (Mode.tool_category "masc_team_session_events" = Mode.Core);
+  check bool "team_session_prove" true
+    (Mode.tool_category "masc_team_session_prove" = Mode.Core)
 
 let test_tool_category_comm () =
   check bool "broadcast" true (Mode.tool_category "masc_broadcast" = Mode.Comm);

--- a/test/test_tool_team_session.ml
+++ b/test/test_tool_team_session.ml
@@ -390,6 +390,27 @@ let test_turn_events_and_prove () =
   in
   let session_id = start_session_exn ctx ~goal:"turn-events-prove" |> get_session_id in
 
+  let invalid_turn_ok, _ =
+    dispatch_exn ctx ~name:"masc_team_session_turn"
+      ~args:
+        (`Assoc
+          [
+            ("session_id", `String session_id);
+            ("turn_kind", `String "invalid-kind");
+          ])
+  in
+  Alcotest.(check bool) "invalid turn kind rejected" false invalid_turn_ok;
+
+  let engine_intruder_result =
+    Team_session_engine_eio.record_turn ~config ~session_id ~actor:"intruder"
+      ~turn_kind:Team_session_types.Turn_note ~message:(Some "unauthorized")
+      ~target_agent:None ~task_title:None ~task_description:None
+      ~task_priority:3
+  in
+  Alcotest.(check bool) "engine actor guard"
+    true
+    (match engine_intruder_result with Error _ -> true | Ok _ -> false);
+
   let check_turn turn_kind extra =
     let ok, _ =
       dispatch_exn ctx ~name:"masc_team_session_turn"

--- a/test/test_tool_team_session.ml
+++ b/test/test_tool_team_session.ml
@@ -48,6 +48,11 @@ let done_delta_total_of_status_body body =
   |> Yojson.Safe.Util.member "done_delta_total"
   |> Yojson.Safe.Util.to_int
 
+let events_count_of_body body =
+  let json = parse_json_exn body in
+  let result = result_field json in
+  result |> Yojson.Safe.Util.member "count" |> Yojson.Safe.Util.to_int
+
 let add_task_id config ~title =
   ignore (Room.add_task config ~title ~priority:1 ~description:"");
   let backlog = Room.read_backlog config in
@@ -236,6 +241,7 @@ let test_recover_elapsed_session () =
       alert_channel = Team_session_types.Alert_both;
       auto_resume = true;
       report_formats = [ Team_session_types.Markdown; Team_session_types.Json ];
+      turn_count = 0;
       agent_names = [ "tester" ];
       broadcast_count = 0;
       portal_count = 0;
@@ -253,6 +259,7 @@ let test_recover_elapsed_session () =
       stopped_at = None;
       last_checkpoint_at = Some (now -. 30.0);
       last_event_at = Some (now -. 30.0);
+      last_turn_at = None;
       stop_reason = None;
       generated_report = false;
       artifacts_dir = Team_session_store.session_dir config session_id;
@@ -371,6 +378,102 @@ let test_list_and_compare () =
            ]));
   cleanup_dir base_dir
 
+let test_turn_events_and_prove () =
+  Eio_main.run @@ fun env ->
+  Eio.Switch.run @@ fun sw ->
+  let base_dir = temp_dir () in
+  let config = Room.default_config base_dir in
+  ignore (Room.init config ~agent_name:(Some "tester"));
+  ignore (Room.join config ~agent_name:"tester" ~capabilities:[] ());
+  let ctx : _ Tool_team_session.context =
+    { config; agent_name = "tester"; sw; clock = Eio.Stdenv.clock env }
+  in
+  let session_id = start_session_exn ctx ~goal:"turn-events-prove" |> get_session_id in
+
+  let check_turn turn_kind extra =
+    let ok, _ =
+      dispatch_exn ctx ~name:"masc_team_session_turn"
+        ~args:
+          (`Assoc
+            ([
+               ("session_id", `String session_id);
+               ("turn_kind", `String turn_kind);
+             ]
+            @ extra))
+    in
+    Alcotest.(check bool) ("turn ok: " ^ turn_kind) true ok
+  in
+  check_turn "note" [ ("message", `String "manual note") ];
+  check_turn "broadcast" [ ("message", `String "broadcast turn message") ];
+  check_turn "portal"
+    [
+      ("target_agent", `String "peer");
+      ("message", `String "portal task payload");
+    ];
+  check_turn "task"
+    [
+      ("task_title", `String "turn-created-task");
+      ("task_description", `String "from turn tool");
+      ("task_priority", `Int 2);
+    ];
+  check_turn "checkpoint" [];
+
+  let events_ok, events_body =
+    dispatch_exn ctx ~name:"masc_team_session_events"
+      ~args:
+        (`Assoc
+          [
+            ("session_id", `String session_id);
+            ("event_types", `List [ `String "team_turn" ]);
+            ("limit", `Int 20);
+          ])
+  in
+  Alcotest.(check bool) "events ok" true events_ok;
+  Alcotest.(check int) "team_turn count" 5 (events_count_of_body events_body);
+
+  let stop_ok, _ =
+    dispatch_exn ctx ~name:"masc_team_session_stop"
+      ~args:
+        (`Assoc
+          [
+            ("session_id", `String session_id);
+            ("reason", `String "prove_ready");
+            ("generate_report", `Bool true);
+          ])
+  in
+  Alcotest.(check bool) "stop accepted" true stop_ok;
+  ignore (wait_until_terminal ctx session_id);
+
+  let prove_ok, prove_body =
+    dispatch_exn ctx ~name:"masc_team_session_prove"
+      ~args:
+        (`Assoc
+          [
+            ("session_id", `String session_id);
+            ("generate_report_if_missing", `Bool true);
+          ])
+  in
+  Alcotest.(check bool) "prove ok" true prove_ok;
+  let prove_result = parse_json_exn prove_body |> result_field in
+  let proof_json_path =
+    prove_result |> Yojson.Safe.Util.member "proof_json_path"
+    |> Yojson.Safe.Util.to_string
+  in
+  let proof_md_path =
+    prove_result |> Yojson.Safe.Util.member "proof_md_path"
+    |> Yojson.Safe.Util.to_string
+  in
+  let verdict =
+    prove_result |> Yojson.Safe.Util.member "proof"
+    |> Yojson.Safe.Util.member "verdict"
+    |> Yojson.Safe.Util.to_string
+  in
+  Alcotest.(check bool) "proof json exists" true
+    (Room_utils.path_exists config proof_json_path);
+  Alcotest.(check bool) "proof md exists" true (Sys.file_exists proof_md_path);
+  Alcotest.(check string) "verdict proved" "proved" verdict;
+  cleanup_dir base_dir
+
 let test_missing_required_args () =
   Eio_main.run @@ fun env ->
   Eio.Switch.run @@ fun sw ->
@@ -404,6 +507,15 @@ let test_missing_required_args () =
     dispatch_exn ctx ~name:"masc_team_session_list"
       ~args:(`Assoc [ ("status", `String "not-a-status") ])
   in
+  let ok10, _ =
+    dispatch_exn ctx ~name:"masc_team_session_turn" ~args:(`Assoc [])
+  in
+  let ok11, _ =
+    dispatch_exn ctx ~name:"masc_team_session_events" ~args:(`Assoc [])
+  in
+  let ok12, _ =
+    dispatch_exn ctx ~name:"masc_team_session_prove" ~args:(`Assoc [])
+  in
   Alcotest.(check bool) "start invalid" false ok1;
   Alcotest.(check bool) "status invalid" false ok2;
   Alcotest.(check bool) "stop invalid" false ok3;
@@ -413,6 +525,9 @@ let test_missing_required_args () =
   Alcotest.(check bool) "report format invalid" false ok7;
   Alcotest.(check bool) "compare invalid" false ok8;
   Alcotest.(check bool) "list invalid status" false ok9;
+  Alcotest.(check bool) "turn invalid" false ok10;
+  Alcotest.(check bool) "events invalid" false ok11;
+  Alcotest.(check bool) "prove invalid" false ok12;
   cleanup_dir base_dir
 
 let test_dispatch_unknown () =
@@ -486,6 +601,30 @@ let test_unauthorized_session_access () =
           ])
   in
   Alcotest.(check bool) "unauthorized compare denied" false compare_ok;
+
+  let turn_ok, _ =
+    dispatch_exn intruder_ctx ~name:"masc_team_session_turn"
+      ~args:
+        (`Assoc
+          [
+            ("session_id", `String session_id);
+            ("turn_kind", `String "note");
+            ("message", `String "intruder");
+          ])
+  in
+  Alcotest.(check bool) "unauthorized turn denied" false turn_ok;
+
+  let events_ok, _ =
+    dispatch_exn intruder_ctx ~name:"masc_team_session_events"
+      ~args:(`Assoc [ ("session_id", `String session_id) ])
+  in
+  Alcotest.(check bool) "unauthorized events denied" false events_ok;
+
+  let prove_ok, _ =
+    dispatch_exn intruder_ctx ~name:"masc_team_session_prove"
+      ~args:(`Assoc [ ("session_id", `String session_id) ])
+  in
+  Alcotest.(check bool) "unauthorized prove denied" false prove_ok;
 
   let owner_stop_ok, _ =
     dispatch_exn owner_ctx ~name:"masc_team_session_stop"
@@ -587,6 +726,8 @@ let () =
           Alcotest.test_case "read-events-limit" `Quick
             test_read_events_limit;
           Alcotest.test_case "list-and-compare" `Quick test_list_and_compare;
+          Alcotest.test_case "turn-events-prove" `Quick
+            test_turn_events_and_prove;
           Alcotest.test_case "missing-required-args" `Quick
             test_missing_required_args;
           Alcotest.test_case "dispatch-unknown" `Quick test_dispatch_unknown;

--- a/test/test_tools_coverage.ml
+++ b/test/test_tools_coverage.ml
@@ -79,7 +79,9 @@ let test_all_names_start_with_masc () =
 let test_find_tool_existing () =
   let tools = ["masc_init"; "masc_join"; "masc_leave"; "masc_status";
                "masc_broadcast"; "masc_claim"; "masc_done";
-               "masc_team_session_list"; "masc_team_session_compare"] in
+               "masc_team_session_list"; "masc_team_session_compare";
+               "masc_team_session_turn"; "masc_team_session_events";
+               "masc_team_session_prove"] in
   List.iter (fun name ->
     match find_tool name with
     | Some schema -> Alcotest.(check string) "found correct tool" name schema.name


### PR DESCRIPTION
## Summary
- add `masc_team_session_turn` to record/drive team-session turns (`note|broadcast|portal|task|checkpoint`)
- add `masc_team_session_events` to query timeline evidence with filters (`event_types`, `after_ts`, `limit`)
- add `masc_team_session_prove` to generate proof artifacts (`proof.json`, `proof.md`) from session evidence
- extend team-session state with `turn_count` / `last_turn_at` and expose proof paths in status
- update mode/server routing, docs, and contract harness for the new proof workflow

## Validation
- `dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/feat-team-session-proof`
- `./_build/default/test/test_tool_team_session.exe`
- `./_build/default/test/test_mode_coverage.exe`
- `./_build/default/test/test_tools_coverage.exe`
- `MCP_URL=http://127.0.0.1:8945/mcp ./scripts/harness/contract/team_session_contract.sh` (PASS)

## Notes
- existing 8935 local server in this environment was an older binary without team-session tools; harness proof used a fresh server built from this branch on 8945.
