### PR TITLE
TRPG actor spawn idempotency + single-flight hardening

### DIFF
--- a/bin/main_eio.ml
+++ b/bin/main_eio.ml
@@ -753,22 +753,35 @@ let trpg_read_state_int derived_json field =
 
 (* ─── Actor state query helpers ─────────────────────────────── *)
 
+type trpg_actor_spawn_cached = {
+  fingerprint : string;
+  response_json : Yojson.Safe.t;
+}
+
 type trpg_actor_spawn_guard_state = {
   mutex : Mutex.t;
   room_mutexes : (string, Mutex.t) Hashtbl.t;
+  idempotency_cache : (string, trpg_actor_spawn_cached) Hashtbl.t;
+  mutable cache_writes : int;
 }
 
 let trpg_actor_spawn_guard : trpg_actor_spawn_guard_state =
-  { mutex = Mutex.create (); room_mutexes = Hashtbl.create 64 }
+  {
+    mutex = Mutex.create ();
+    room_mutexes = Hashtbl.create 64;
+    idempotency_cache = Hashtbl.create 2048;
+    cache_writes = 0;
+  }
+
+let trpg_with_actor_spawn_guard_lock f =
+  Mutex.lock trpg_actor_spawn_guard.mutex;
+  Fun.protect ~finally:(fun () -> Mutex.unlock trpg_actor_spawn_guard.mutex) f
 
 let trpg_with_actor_spawn_room_lock ~room_id f =
   let room_key = String.trim room_id in
   let room_key = if room_key = "" then "default" else room_key in
   let room_mutex =
-    Mutex.lock trpg_actor_spawn_guard.mutex;
-    Fun.protect
-      ~finally:(fun () -> Mutex.unlock trpg_actor_spawn_guard.mutex)
-      (fun () ->
+    trpg_with_actor_spawn_guard_lock (fun () ->
         match Hashtbl.find_opt trpg_actor_spawn_guard.room_mutexes room_key with
         | Some m -> m
         | None ->
@@ -778,6 +791,28 @@ let trpg_with_actor_spawn_room_lock ~room_id f =
   in
   Mutex.lock room_mutex;
   Fun.protect ~finally:(fun () -> Mutex.unlock room_mutex) f
+
+let trpg_actor_spawn_cache_key ~room_id ~idempotency_key =
+  room_id ^ "\x1f" ^ idempotency_key
+
+let trpg_actor_spawn_cache_lookup ~room_id ~idempotency_key =
+  let key = trpg_actor_spawn_cache_key ~room_id ~idempotency_key in
+  trpg_with_actor_spawn_guard_lock (fun () ->
+      Hashtbl.find_opt trpg_actor_spawn_guard.idempotency_cache key)
+
+let trpg_actor_spawn_cache_store ~room_id ~idempotency_key ~fingerprint
+    ~response_json =
+  let key = trpg_actor_spawn_cache_key ~room_id ~idempotency_key in
+  trpg_with_actor_spawn_guard_lock (fun () ->
+      Hashtbl.replace trpg_actor_spawn_guard.idempotency_cache key
+        { fingerprint; response_json };
+      trpg_actor_spawn_guard.cache_writes <-
+        trpg_actor_spawn_guard.cache_writes + 1;
+      if trpg_actor_spawn_guard.cache_writes >= 1024
+         && Hashtbl.length trpg_actor_spawn_guard.idempotency_cache > 4096
+      then (
+        Hashtbl.reset trpg_actor_spawn_guard.idempotency_cache;
+        trpg_actor_spawn_guard.cache_writes <- 0))
 
 let trpg_normalize_keeper_name s = s |> String.trim |> String.lowercase_ascii
 
@@ -837,6 +872,16 @@ let trpg_state_actor_control_fields state =
           | _ -> None)
         fields
   | _ -> []
+
+let rec trpg_canonicalize_json (value : Yojson.Safe.t) : Yojson.Safe.t =
+  match value with
+  | `Assoc fields ->
+      `Assoc
+        (fields
+        |> List.map (fun (k, v) -> (k, trpg_canonicalize_json v))
+        |> List.sort (fun (a, _) (b, _) -> String.compare a b))
+  | `List items -> `List (List.map trpg_canonicalize_json items)
+  | other -> other
 
 let trpg_owner_for_actor state actor_id =
   trpg_state_actor_control_fields state |> List.assoc_opt actor_id
@@ -980,7 +1025,55 @@ let trpg_dice_roll_json ~base_dir ~body_str : trpg_api_result =
 
 (* ─── Actor REST wrappers ───────────────────────────────────── *)
 
-let trpg_actor_spawn_json ~base_dir ~body_str : trpg_api_result =
+let trpg_actor_spawn_extract_idempotency_key ~(header_key : string option)
+    (json : Yojson.Safe.t) : string option =
+  let normalize = function
+    | None -> None
+    | Some raw ->
+        let trimmed = String.trim raw in
+        if trimmed = "" then None else Some trimmed
+  in
+  match normalize header_key with
+  | Some _ as key -> key
+  | None -> (
+      match Yojson.Safe.Util.member "idempotency_key" json with
+      | `String raw -> normalize (Some raw)
+      | _ -> None)
+
+let trpg_actor_spawn_request_fingerprint ~room_id ~rule_module ~actor_id_opt
+    ~name_opt ~role ~archetype ~persona ~portrait ~background ~stats_opt ~hp
+    ~max_hp ~alive ~traits ~skills ~inventory =
+  let fields =
+    ref
+      [
+        ("room_id", `String room_id);
+        ("rule_module", `String rule_module);
+        ("role", `String role);
+        ("hp", `Int hp);
+        ("max_hp", `Int max_hp);
+        ("alive", `Bool alive);
+        ("traits", `List (List.map (fun s -> `String s) traits));
+        ("skills", `List (List.map (fun s -> `String s) skills));
+        ("inventory", `List (List.map (fun s -> `String s) inventory));
+      ]
+  in
+  let add_opt_string key = function
+    | Some value -> fields := (key, `String value) :: !fields
+    | None -> ()
+  in
+  add_opt_string "actor_id" actor_id_opt;
+  add_opt_string "name" name_opt;
+  add_opt_string "archetype" archetype;
+  add_opt_string "persona" persona;
+  add_opt_string "portrait" portrait;
+  add_opt_string "background" background;
+  (match stats_opt with
+  | Some stats -> fields := ("stats", trpg_canonicalize_json stats) :: !fields
+  | None -> ());
+  `Assoc !fields |> trpg_canonicalize_json |> Yojson.Safe.to_string
+
+let trpg_actor_spawn_json ~base_dir ~(idempotency_key : string option) ~body_str
+    : trpg_api_result =
   try
     let json = Yojson.Safe.from_string body_str in
     let ( let* ) r f = match r with Ok v -> f v | Error _ as e -> e in
@@ -1022,80 +1115,124 @@ let trpg_actor_spawn_json ~base_dir ~body_str : trpg_api_result =
     let* traits = trpg_parse_optional_string_list "traits" json in
     let* skills = trpg_parse_optional_string_list "skills" json in
     let* inventory = trpg_parse_optional_string_list "inventory" json in
+    let idempotency_key =
+      trpg_actor_spawn_extract_idempotency_key ~header_key:idempotency_key json
+    in
+    let request_fingerprint =
+      trpg_actor_spawn_request_fingerprint ~room_id ~rule_module ~actor_id_opt
+        ~name_opt ~role ~archetype ~persona ~portrait ~background ~stats_opt ~hp
+        ~max_hp ~alive ~traits ~skills ~inventory
+    in
     trpg_with_actor_spawn_room_lock ~room_id (fun () ->
-      let* derived = trpg_derive_state_json ~base_dir ~room_id ~rule_module in
-      let state = trpg_state_from_derived derived in
-      let actor_id =
-        match actor_id_opt with
-        | Some explicit -> explicit
-        | None ->
-            let seed = name_opt |> Option.value ~default:role in
-            let base_actor_id = trpg_sanitize_actor_id_seed seed in
-            trpg_next_available_actor_id state base_actor_id
-      in
-      let name = Option.value ~default:actor_id name_opt in
-      if trpg_actor_exists state actor_id then
-        Error (`Bad_request, Printf.sprintf "actor '%s' already exists" actor_id)
-      else
-        let actor_fields = ref [] in
-        let add_field key value = actor_fields := (key, value) :: !actor_fields in
-        let add_opt_string key = function
-          | Some value -> add_field key (`String value)
-          | None -> ()
+      let run_spawn_once () =
+        let* derived = trpg_derive_state_json ~base_dir ~room_id ~rule_module in
+        let state = trpg_state_from_derived derived in
+        let actor_id =
+          match actor_id_opt with
+          | Some explicit -> explicit
+          | None ->
+              let seed = name_opt |> Option.value ~default:role in
+              let base_actor_id = trpg_sanitize_actor_id_seed seed in
+              trpg_next_available_actor_id state base_actor_id
         in
-        let add_opt_json key = function
-          | Some value -> add_field key value
-          | None -> ()
-        in
-        add_field "inventory" (`List (List.map (fun s -> `String s) inventory));
-        add_field "skills" (`List (List.map (fun s -> `String s) skills));
-        add_field "traits" (`List (List.map (fun s -> `String s) traits));
-        add_field "alive" (`Bool alive);
-        add_field "max_hp" (`Int max_hp);
-        add_field "hp" (`Int hp);
-        add_opt_json "stats" stats_opt;
-        add_opt_string "background" background;
-        add_opt_string "portrait" portrait;
-        add_opt_string "persona" persona;
-        add_opt_string "archetype" archetype;
-        add_field "role" (`String role);
-        add_field "name" (`String name);
-        let actor_json = `Assoc (List.rev !actor_fields) in
-        let payload_fields =
-          [
-            ("actor_id", `String actor_id);
-            ("name", `String name);
-            ("role", `String role);
-            ("hp", `Int hp);
-            ("max_hp", `Int max_hp);
-            ("alive", `Bool alive);
-            ("traits", `List (List.map (fun s -> `String s) traits));
-            ("skills", `List (List.map (fun s -> `String s) skills));
-            ("inventory", `List (List.map (fun s -> `String s) inventory));
-            ("actor", actor_json);
-          ]
-        in
-        let payload_fields =
-          payload_fields
-          @ (match archetype with Some v -> [ ("archetype", `String v) ] | None -> [])
-          @ (match persona with Some v -> [ ("persona", `String v) ] | None -> [])
-          @ (match portrait with Some v -> [ ("portrait", `String v) ] | None -> [])
-          @ (match background with Some v -> [ ("background", `String v) ] | None -> [])
-          @ (match stats_opt with Some stats -> [ ("stats", stats) ] | None -> [])
-        in
-        let payload = `Assoc payload_fields in
-        let* _event =
-          trpg_append_event ~base_dir ~room_id
-            ~event_type:Masc_mcp.Trpg_engine_event.Actor_spawned ~actor_id ~payload ()
-        in
-        let* derived2 = trpg_derive_state_json ~base_dir ~room_id ~rule_module in
-        Ok
-          (`Assoc
+        let name = Option.value ~default:actor_id name_opt in
+        if trpg_actor_exists state actor_id then
+          Error (`Bad_request, Printf.sprintf "actor '%s' already exists" actor_id)
+        else
+          let actor_fields = ref [] in
+          let add_field key value = actor_fields := (key, value) :: !actor_fields in
+          let add_opt_string key = function
+            | Some value -> add_field key (`String value)
+            | None -> ()
+          in
+          let add_opt_json key = function
+            | Some value -> add_field key value
+            | None -> ()
+          in
+          add_field "inventory" (`List (List.map (fun s -> `String s) inventory));
+          add_field "skills" (`List (List.map (fun s -> `String s) skills));
+          add_field "traits" (`List (List.map (fun s -> `String s) traits));
+          add_field "alive" (`Bool alive);
+          add_field "max_hp" (`Int max_hp);
+          add_field "hp" (`Int hp);
+          add_opt_json "stats" stats_opt;
+          add_opt_string "background" background;
+          add_opt_string "portrait" portrait;
+          add_opt_string "persona" persona;
+          add_opt_string "archetype" archetype;
+          add_field "role" (`String role);
+          add_field "name" (`String name);
+          let actor_json = `Assoc (List.rev !actor_fields) in
+          let payload_fields =
             [
-              ("ok", `Bool true);
               ("actor_id", `String actor_id);
-              ("state", trpg_state_from_derived derived2);
-            ]))
+              ("name", `String name);
+              ("role", `String role);
+              ("hp", `Int hp);
+              ("max_hp", `Int max_hp);
+              ("alive", `Bool alive);
+              ("traits", `List (List.map (fun s -> `String s) traits));
+              ("skills", `List (List.map (fun s -> `String s) skills));
+              ("inventory", `List (List.map (fun s -> `String s) inventory));
+              ("actor", actor_json);
+            ]
+          in
+          let payload_fields =
+            payload_fields
+            @
+            (match archetype with
+            | Some v -> [ ("archetype", `String v) ]
+            | None -> [])
+            @
+            (match persona with
+            | Some v -> [ ("persona", `String v) ]
+            | None -> [])
+            @
+            (match portrait with
+            | Some v -> [ ("portrait", `String v) ]
+            | None -> [])
+            @
+            (match background with
+            | Some v -> [ ("background", `String v) ]
+            | None -> [])
+            @ (match stats_opt with Some stats -> [ ("stats", stats) ] | None -> [])
+          in
+          let payload = `Assoc payload_fields in
+          let* _event =
+            trpg_append_event ~base_dir ~room_id
+              ~event_type:Masc_mcp.Trpg_engine_event.Actor_spawned ~actor_id
+              ~payload ()
+          in
+          let* derived2 = trpg_derive_state_json ~base_dir ~room_id ~rule_module in
+          Ok
+            (`Assoc
+              [
+                ("ok", `Bool true);
+                ("actor_id", `String actor_id);
+                ("state", trpg_state_from_derived derived2);
+              ])
+      in
+      let run_and_maybe_store () =
+        let result = run_spawn_once () in
+        (match (result, idempotency_key) with
+        | Ok response_json, Some key ->
+            trpg_actor_spawn_cache_store ~room_id ~idempotency_key:key
+              ~fingerprint:request_fingerprint ~response_json
+        | _ -> ());
+        result
+      in
+      match idempotency_key with
+      | Some key -> (
+          match trpg_actor_spawn_cache_lookup ~room_id ~idempotency_key:key with
+          | Some cached when String.equal cached.fingerprint request_fingerprint ->
+              Ok cached.response_json
+          | Some _ ->
+              Error
+                ( `Bad_request,
+                  "idempotency key reused with different payload: code=idempotency_payload_mismatch"
+                )
+          | None -> run_and_maybe_store ())
+      | None -> run_spawn_once ())
   with Yojson.Json_error e ->
     Error (`Bad_request, Printf.sprintf "invalid json: %s" e)
 
@@ -5766,10 +5903,15 @@ let make_routes ~port ~host =
          handle_trpg_sse ~base_dir ~room_id ~event_type_filter request reqd
        ) request reqd)
   |> Http.Router.post "/api/v1/trpg/actors/spawn" (fun request reqd ->
-       with_public_read (fun state _req reqd ->
+       with_public_read (fun state req reqd ->
          let base_dir = state.Mcp_server.room_config.base_path in
          Http.Request.read_body_async reqd (fun body_str ->
-           match trpg_actor_spawn_json ~base_dir ~body_str with
+           match
+             trpg_actor_spawn_json ~base_dir
+               ~idempotency_key:
+                 (get_header_any_case req.Httpun.Request.headers "idempotency-key")
+               ~body_str
+           with
            | Ok json ->
                respond_json_with_cors ~status:`Created request reqd
                  (Yojson.Safe.to_string json)
@@ -6920,7 +7062,12 @@ let run_server ~sw ~env ~port ~base_path =
           let state = get_server_state () in
           let base_dir = state.Mcp_server.room_config.base_path in
           h2_read_body h2_reqd (fun body_str ->
-            match trpg_actor_spawn_json ~base_dir ~body_str with
+            match
+              trpg_actor_spawn_json ~base_dir
+                ~idempotency_key:
+                  (get_header_any_case httpun_request.headers "idempotency-key")
+                ~body_str
+            with
             | Ok json ->
                 h2_respond_json h2_reqd (Yojson.Safe.to_string json)
                   ~status:`Created ~extra_headers:cors

--- a/bin/main_eio.ml
+++ b/bin/main_eio.ml
@@ -756,13 +756,14 @@ let trpg_read_state_int derived_json field =
 type trpg_actor_spawn_cached = {
   fingerprint : string;
   response_json : Yojson.Safe.t;
+  seq : int;
 }
 
 type trpg_actor_spawn_guard_state = {
   mutex : Mutex.t;
   room_mutexes : (string, Mutex.t) Hashtbl.t;
   idempotency_cache : (string, trpg_actor_spawn_cached) Hashtbl.t;
-  mutable cache_writes : int;
+  mutable next_seq : int;
 }
 
 let trpg_actor_spawn_guard : trpg_actor_spawn_guard_state =
@@ -770,7 +771,7 @@ let trpg_actor_spawn_guard : trpg_actor_spawn_guard_state =
     mutex = Mutex.create ();
     room_mutexes = Hashtbl.create 64;
     idempotency_cache = Hashtbl.create 2048;
-    cache_writes = 0;
+    next_seq = 0;
   }
 
 let trpg_with_actor_spawn_guard_lock f =
@@ -802,17 +803,30 @@ let trpg_actor_spawn_cache_lookup ~room_id ~idempotency_key =
 
 let trpg_actor_spawn_cache_store ~room_id ~idempotency_key ~fingerprint
     ~response_json =
+  let max_cache_entries = 4096 in
   let key = trpg_actor_spawn_cache_key ~room_id ~idempotency_key in
   trpg_with_actor_spawn_guard_lock (fun () ->
+      trpg_actor_spawn_guard.next_seq <- trpg_actor_spawn_guard.next_seq + 1;
       Hashtbl.replace trpg_actor_spawn_guard.idempotency_cache key
-        { fingerprint; response_json };
-      trpg_actor_spawn_guard.cache_writes <-
-        trpg_actor_spawn_guard.cache_writes + 1;
-      if trpg_actor_spawn_guard.cache_writes >= 1024
-         && Hashtbl.length trpg_actor_spawn_guard.idempotency_cache > 4096
-      then (
-        Hashtbl.reset trpg_actor_spawn_guard.idempotency_cache;
-        trpg_actor_spawn_guard.cache_writes <- 0))
+        { fingerprint; response_json; seq = trpg_actor_spawn_guard.next_seq };
+      while Hashtbl.length trpg_actor_spawn_guard.idempotency_cache
+            > max_cache_entries
+      do
+        let oldest =
+          Hashtbl.to_seq trpg_actor_spawn_guard.idempotency_cache
+          |> Seq.fold_left
+               (fun acc (k, v) ->
+                 match acc with
+                 | None -> Some (k, v.seq)
+                 | Some (_old_key, old_seq) ->
+                     if v.seq < old_seq then Some (k, v.seq) else acc)
+               None
+        in
+        match oldest with
+        | Some (old_key, _) ->
+            Hashtbl.remove trpg_actor_spawn_guard.idempotency_cache old_key
+        | None -> ()
+      done)
 
 let trpg_normalize_keeper_name s = s |> String.trim |> String.lowercase_ascii
 

--- a/dashboard/src/api.ts
+++ b/dashboard/src/api.ts
@@ -167,10 +167,17 @@ async function withRetries<T>(
   }
 }
 
-async function post<T>(path: string, body: unknown): Promise<T> {
+async function post<T>(
+  path: string,
+  body: unknown,
+  extraHeaders?: Record<string, string>,
+): Promise<T> {
   const res = await fetchWithTimeout(path, {
     method: 'POST',
-    headers: jsonHeaders(),
+    headers: {
+      ...jsonHeaders(),
+      ...(extraHeaders ?? {}),
+    },
     body: JSON.stringify(body),
   }, DEFAULT_POST_TIMEOUT_MS)
   if (!res.ok) {
@@ -1203,6 +1210,7 @@ export interface TrpgSpawnActorRequest {
   actor_id?: string
   name?: string
   role?: 'dm' | 'player' | 'npc'
+  idempotencyKey?: string
   keeper_name?: string
   archetype?: string
   persona?: string
@@ -1228,6 +1236,7 @@ export function spawnTrpgActor(
   room: string,
   actor: TrpgSpawnActorRequest,
 ): Promise<TrpgSpawnActorResponse> {
+  const idempotencyKey = actor.idempotencyKey?.trim()
   const body: Record<string, unknown> = {
     room_id: room,
   }
@@ -1245,7 +1254,8 @@ export function spawnTrpgActor(
   if (Array.isArray(actor.skills) && actor.skills.length > 0) body.skills = actor.skills
   if (Array.isArray(actor.inventory) && actor.inventory.length > 0) body.inventory = actor.inventory
   if (actor.stats && Object.keys(actor.stats).length > 0) body.stats = actor.stats
-  return post('/api/v1/trpg/actors/spawn', body)
+  if (idempotencyKey) body.idempotency_key = idempotencyKey
+  return post('/api/v1/trpg/actors/spawn', body, idempotencyKey ? { 'Idempotency-Key': idempotencyKey } : undefined)
 }
 
 export function claimTrpgActor(room: string, actorId: string, keeper: string): Promise<unknown> {

--- a/dashboard/src/components/trpg.ts
+++ b/dashboard/src/components/trpg.ts
@@ -792,10 +792,15 @@ function ActorSpawnPanel({ state }: { state: TrpgState }) {
 
     spawnStatus.value = 'spawning'
     try {
+      const idempotencyKey =
+        typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function'
+          ? `trpg_spawn_${crypto.randomUUID()}`
+          : `trpg_spawn_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 10)}`
       const spawnRes = await spawnTrpgActor(room, {
         actor_id: actorIdInput || undefined,
         name: name || undefined,
         role: spawnRole.value,
+        idempotencyKey,
         portrait: spawnPortrait.value.trim() || undefined,
         background: spawnBackground.value.trim() || undefined,
         hp,

--- a/scripts/harness/workload/trpg_actor_spawn_idempotency_stress.sh
+++ b/scripts/harness/workload/trpg_actor_spawn_idempotency_stress.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "jq is required" >&2
+  exit 1
+fi
+
+BASE_URL="${BASE_URL:-http://127.0.0.1:8080}"
+ROOM_ID="${ROOM_ID:-room-idem-stress-$(date +%s)}"
+REQUESTS="${REQUESTS:-20}"
+CONCURRENCY="${CONCURRENCY:-8}"
+TIMEOUT_SEC="${TIMEOUT_SEC:-5}"
+IDEMPOTENCY_KEY="${IDEMPOTENCY_KEY:-spawn-idem-stress-$(date +%s)}"
+
+TMP_DIR="$(mktemp -d /tmp/trpg-spawn-idem-stress.XXXXXX)"
+cleanup() {
+  rm -rf "$TMP_DIR"
+}
+trap cleanup EXIT
+
+PAYLOAD="$(jq -cn \
+  --arg room "$ROOM_ID" \
+  '{room_id:$room,name:"Stress Echo",role:"player",max_hp:22,stats:{dex:13,luck:7}}')"
+
+export BASE_URL IDEMPOTENCY_KEY PAYLOAD TIMEOUT_SEC TMP_DIR
+
+seq 1 "$REQUESTS" | xargs -I{} -P "$CONCURRENCY" bash -c '
+  idx="$1"
+  body_file="$TMP_DIR/body.$idx.json"
+  head_file="$TMP_DIR/head.$idx.txt"
+  if ! curl -sS --http1.1 --max-time "$TIMEOUT_SEC" \
+    -X POST "$BASE_URL/api/v1/trpg/actors/spawn" \
+    -H "Content-Type: application/json" \
+    -H "Idempotency-Key: $IDEMPOTENCY_KEY" \
+    --data "$PAYLOAD" \
+    -o "$body_file" \
+    -D "$head_file"; then
+    echo "curl_failed $idx" > "$TMP_DIR/fail.$idx.txt"
+  fi
+' _ {}
+
+if ls "$TMP_DIR"/fail.*.txt >/dev/null 2>&1; then
+  echo "FAIL: at least one curl call failed" >&2
+  cat "$TMP_DIR"/fail.*.txt >&2 || true
+  exit 1
+fi
+
+status_ok=0
+status_fail=0
+for head in "$TMP_DIR"/head.*.txt; do
+  status="$(awk '/^HTTP\// {code=$2} END {print code+0}' "$head")"
+  if [ "$status" -eq 201 ]; then
+    status_ok=$((status_ok + 1))
+  else
+    status_fail=$((status_fail + 1))
+  fi
+done
+
+actor_ids_file="$TMP_DIR/actor_ids.txt"
+for body in "$TMP_DIR"/body.*.json; do
+  jq -r '.actor_id // empty' "$body"
+done | sed '/^$/d' > "$actor_ids_file"
+
+unique_actor_ids="$(sort -u "$actor_ids_file" | wc -l | tr -d ' ')"
+
+echo "requests=$REQUESTS ok=$status_ok fail=$status_fail unique_actor_ids=$unique_actor_ids room=$ROOM_ID key=$IDEMPOTENCY_KEY"
+
+if [ "$status_fail" -ne 0 ]; then
+  echo "FAIL: non-201 responses detected" >&2
+  exit 1
+fi
+
+if [ "$unique_actor_ids" -ne 1 ]; then
+  echo "FAIL: expected exactly one unique actor_id for same key" >&2
+  sort -u "$actor_ids_file" >&2
+  exit 1
+fi
+
+MISMATCH_PAYLOAD="$(jq -cn \
+  --arg room "$ROOM_ID" \
+  '{room_id:$room,name:"Different Payload",role:"player"}')"
+mismatch_body="$TMP_DIR/mismatch_body.json"
+mismatch_head="$TMP_DIR/mismatch_head.txt"
+curl -sS --http1.1 --max-time "$TIMEOUT_SEC" \
+  -X POST "$BASE_URL/api/v1/trpg/actors/spawn" \
+  -H "Content-Type: application/json" \
+  -H "Idempotency-Key: $IDEMPOTENCY_KEY" \
+  --data "$MISMATCH_PAYLOAD" \
+  -o "$mismatch_body" \
+  -D "$mismatch_head"
+
+mismatch_status="$(awk '/^HTTP\// {code=$2} END {print code+0}' "$mismatch_head")"
+if [ "$mismatch_status" -ne 400 ]; then
+  echo "FAIL: expected mismatch status 400, got $mismatch_status" >&2
+  cat "$mismatch_body" >&2 || true
+  exit 1
+fi
+
+if ! grep -q "idempotency_payload_mismatch" "$mismatch_body"; then
+  echo "FAIL: mismatch response missing idempotency_payload_mismatch marker" >&2
+  cat "$mismatch_body" >&2 || true
+  exit 1
+fi
+
+echo "PASS: trpg actor spawn idempotency stress"

--- a/scripts/run_trpg_actor_spawn_idempotency_stress.sh
+++ b/scripts/run_trpg_actor_spawn_idempotency_stress.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+exec "$SCRIPT_DIR/harness/workload/trpg_actor_spawn_idempotency_stress.sh" "$@"

--- a/test/test_trpg_actor_api_e2e.ml
+++ b/test/test_trpg_actor_api_e2e.ml
@@ -42,10 +42,15 @@ let parse_status header_raw =
   in
   find_http lines
 
-let run_curl ~port ~path ?body ~method_name () =
+let run_curl ~port ~path ?body ?(headers = []) ~method_name () =
   let header_file = Filename.temp_file "trpg-actor-api-header-" ".txt" in
   let body_file = Filename.temp_file "trpg-actor-api-body-" ".txt" in
   let url = Printf.sprintf "http://127.0.0.1:%d%s" port path in
+  let header_args =
+    headers
+    |> List.concat_map (fun (name, value) ->
+           [ "-H"; Printf.sprintf "%s: %s" name value ])
+  in
   let args =
     [
       "curl";
@@ -61,10 +66,12 @@ let run_curl ~port ~path ?body ~method_name () =
       header_file;
     ]
     @
+    (header_args
+    @
     ((match body with
      | Some payload -> [ "-H"; "Content-Type: application/json"; "--data"; payload ]
      | None -> [])
-    @ [ url ])
+    @ [ url ]))
   in
   let (ic, oc, ec) =
     Unix.open_process_args_full "curl" (Array.of_list args) (Unix.environment ())
@@ -227,6 +234,84 @@ let expect_status expected res label =
            "missing HTTP status (curl_exit=%d, stderr=%s)"
            res.curl_exit res.stderr)
 
+let actor_id_of_response_body body =
+  Yojson.Safe.from_string body
+  |> Yojson.Safe.Util.member "actor_id"
+  |> Yojson.Safe.Util.to_string
+
+let write_http_result path (res : http_result) =
+  let status_json = match res.status with Some code -> `Int code | None -> `Null in
+  let json =
+    `Assoc
+      [
+        ("status", status_json);
+        ("body", `String res.body);
+        ("curl_exit", `Int res.curl_exit);
+        ("stderr", `String res.stderr);
+      ]
+  in
+  let oc = open_out_bin path in
+  Fun.protect
+    ~finally:(fun () -> close_out_noerr oc)
+    (fun () -> output_string oc (Yojson.Safe.to_string json))
+
+let read_http_result path : http_result =
+  let json = Yojson.Safe.from_string (read_file path) in
+  {
+    status =
+      (match Yojson.Safe.Util.member "status" json with
+      | `Int code -> Some code
+      | _ -> None);
+    body = Yojson.Safe.Util.member "body" json |> Yojson.Safe.Util.to_string;
+    curl_exit = Yojson.Safe.Util.member "curl_exit" json |> Yojson.Safe.Util.to_int;
+    stderr = Yojson.Safe.Util.member "stderr" json |> Yojson.Safe.Util.to_string;
+  }
+
+let run_parallel_spawn_pair ~port ~body ~headers =
+  let gate_r, gate_w = Unix.pipe () in
+  let out_a = Filename.temp_file "trpg-actor-par-a-" ".json" in
+  let out_b = Filename.temp_file "trpg-actor-par-b-" ".json" in
+  let spawn_child out_file =
+    match Unix.fork () with
+    | 0 ->
+        let exit_code =
+          try
+            Unix.close gate_w;
+            let gate_buf = Bytes.create 1 in
+            let _ = Unix.read gate_r gate_buf 0 1 in
+            let res =
+              run_curl ~port ~path:"/api/v1/trpg/actors/spawn" ~method_name:"POST"
+                ~headers ~body ()
+            in
+            write_http_result out_file res;
+            0
+          with exn ->
+            write_http_result out_file
+              {
+                status = None;
+                body = "";
+                curl_exit = 255;
+                stderr = Printexc.to_string exn;
+              };
+            1
+        in
+        Unix.close gate_r;
+        exit exit_code
+    | pid -> pid
+  in
+  let pid_a = spawn_child out_a in
+  let pid_b = spawn_child out_b in
+  Unix.close gate_r;
+  let _ = Unix.write_substring gate_w "AB" 0 2 in
+  Unix.close gate_w;
+  let _ = Unix.waitpid [] pid_a in
+  let _ = Unix.waitpid [] pid_b in
+  let res_a = read_http_result out_a in
+  let res_b = read_http_result out_b in
+  (try Sys.remove out_a with _ -> ());
+  (try Sys.remove out_b with _ -> ());
+  (res_a, res_b)
+
 let test_spawn_auto_actor_id_and_profile_fields () =
   with_server @@ fun ~port ->
   let spawn_auto =
@@ -343,6 +428,85 @@ let test_spawn_validation_errors () =
   check bool "zero max_hp message" true
     (contains_substr "max_hp must be > 0" bad_max_hp.body)
 
+let test_spawn_idempotency_replay_and_mismatch () =
+  with_server @@ fun ~port ->
+  let idem_key = "spawn-idem-e2e-replay" in
+  let replay_body =
+    Yojson.Safe.to_string
+      (`Assoc
+        [
+          ("room_id", `String "room-api-idem");
+          ("name", `String "Idem Runner");
+          ("role", `String "player");
+          ("max_hp", `Int 17);
+          ("stats", `Assoc [ ("dex", `Int 14); ("luck", `Int 9) ]);
+        ])
+  in
+  let replay_1 =
+    run_curl ~port ~path:"/api/v1/trpg/actors/spawn" ~method_name:"POST"
+      ~headers:[ ("Idempotency-Key", idem_key) ] ~body:replay_body ()
+  in
+  expect_status 201 replay_1 "idempotent replay first call returns 201";
+  let actor_id_1 = actor_id_of_response_body replay_1.body in
+  let replay_2 =
+    run_curl ~port ~path:"/api/v1/trpg/actors/spawn" ~method_name:"POST"
+      ~headers:[ ("Idempotency-Key", idem_key) ] ~body:replay_body ()
+  in
+  expect_status 201 replay_2 "idempotent replay second call returns 201";
+  let actor_id_2 = actor_id_of_response_body replay_2.body in
+  check string "idempotent replay keeps actor_id stable" actor_id_1 actor_id_2;
+
+  let mismatch_key = "spawn-idem-e2e-mismatch" in
+  let mismatch_body_a =
+    Yojson.Safe.to_string
+      (`Assoc
+        [
+          ("room_id", `String "room-api-idem-mismatch");
+          ("name", `String "One");
+          ("role", `String "npc");
+        ])
+  in
+  let mismatch_body_b =
+    Yojson.Safe.to_string
+      (`Assoc
+        [
+          ("room_id", `String "room-api-idem-mismatch");
+          ("name", `String "Two");
+          ("role", `String "npc");
+        ])
+  in
+  let mismatch_1 =
+    run_curl ~port ~path:"/api/v1/trpg/actors/spawn" ~method_name:"POST"
+      ~headers:[ ("Idempotency-Key", mismatch_key) ] ~body:mismatch_body_a ()
+  in
+  expect_status 201 mismatch_1 "idempotent mismatch seed call returns 201";
+  let mismatch_2 =
+    run_curl ~port ~path:"/api/v1/trpg/actors/spawn" ~method_name:"POST"
+      ~headers:[ ("Idempotency-Key", mismatch_key) ] ~body:mismatch_body_b ()
+  in
+  expect_status 400 mismatch_2 "same key with different payload returns 400";
+  check bool "idempotency mismatch error code exposed" true
+    (contains_substr "idempotency_payload_mismatch" mismatch_2.body)
+
+let test_spawn_idempotency_parallel_replay () =
+  with_server @@ fun ~port ->
+  let body =
+    Yojson.Safe.to_string
+      (`Assoc
+        [
+          ("room_id", `String "room-api-idem-parallel");
+          ("name", `String "Parallel Echo");
+          ("role", `String "player");
+        ])
+  in
+  let headers = [ ("Idempotency-Key", "spawn-idem-e2e-parallel") ] in
+  let res_a, res_b = run_parallel_spawn_pair ~port ~body ~headers in
+  expect_status 201 res_a "parallel replay request A returns 201";
+  expect_status 201 res_b "parallel replay request B returns 201";
+  let actor_a = actor_id_of_response_body res_a.body in
+  let actor_b = actor_id_of_response_body res_b.body in
+  check string "parallel replay keeps actor_id stable" actor_a actor_b
+
 let () =
   run "trpg_actor_api_e2e"
     [
@@ -353,5 +517,9 @@ let () =
             `Slow
             test_spawn_auto_actor_id_and_profile_fields;
           test_case "spawn validation errors" `Slow test_spawn_validation_errors;
+          test_case "spawn idempotency replay and mismatch" `Slow
+            test_spawn_idempotency_replay_and_mismatch;
+          test_case "spawn idempotency parallel replay" `Slow
+            test_spawn_idempotency_parallel_replay;
         ] );
     ]


### PR DESCRIPTION
## Summary
- add idempotency handling for `/api/v1/trpg/actors/spawn` (header/body key normalization)
- enforce payload consistency for reused key (`idempotency_payload_mismatch` on mismatch)
- cache successful spawn response by `room_id + idempotency_key` under room lock
- wire idempotency header pass-through in both HTTP/1 and H2 spawn routes
- add dashboard-side idempotency key generation and header/body propagation on spawn
- extend TRPG actor API e2e coverage for replay/mismatch/parallel replay
- add workload harness for spawn idempotency stress checks

## Why
Actor creation retries and concurrent duplicate requests could produce multiple actors. This change makes spawn replay-safe and deterministic per idempotency key while preserving existing behavior without key.

## Validation
- `dune build --root . @runtest`
- `npm run build` (dashboard)
- `./_build/default/test/test_trpg_actor_api_e2e.exe` (environment-bound: skipped in this run)
- `bash -n scripts/harness/workload/trpg_actor_spawn_idempotency_stress.sh scripts/run_trpg_actor_spawn_idempotency_stress.sh`

## Notes
- No behavior change for requests without idempotency key.
- mismatch error code text: `idempotency_payload_mismatch`.
