### PR TITLE
fix: guard Agent_identity session key boundary cases

### DIFF
--- a/lib/agent_identity.ml
+++ b/lib/agent_identity.ml
@@ -87,16 +87,20 @@ let from_mcp_params params =
     try Some (params |> U.member key |> U.to_string)
     with _ -> None
   in
-  let fallback_agent_name session_key =
+  let session_key_prefix session_key =
     let prefix_len = min 8 (String.length session_key) in
-    let prefix =
-      if prefix_len = 0 then "anon"
-      else String.sub session_key 0 prefix_len
-    in
+    if prefix_len = 0 then "unknown"
+    else String.sub session_key 0 prefix_len
+  in
+  let fallback_agent_name session_key =
+    let prefix = session_key_prefix session_key in
+    let prefix = if prefix = "unknown" then "anon" else prefix in
     Printf.sprintf "agent-%s" prefix
   in
   let session_key = match get_opt "_session_key" with
-    | Some k -> k
+    | Some k ->
+        let k = String.trim k in
+        if k = "" then generate_session_key () else k
     | None -> generate_session_key ()
   in
   let agent_name = match get_opt "_agent_name", get_opt "agent_name" with
@@ -249,6 +253,11 @@ let has_capability identity cap =
 
 (** Get display string for logging *)
 let to_display_string identity =
+  let session_key_prefix session_key =
+    let prefix_len = min 8 (String.length session_key) in
+    if prefix_len = 0 then "unknown"
+    else String.sub session_key 0 prefix_len
+  in
   let channel_str = match identity.channel with
     | Some c -> Printf.sprintf " via %s" (string_of_channel c)
     | None -> ""
@@ -259,7 +268,7 @@ let to_display_string identity =
   in
   Printf.sprintf "%s (%s)%s%s"
     identity.agent_name
-    (String.sub identity.session_key 0 8)
+    (session_key_prefix identity.session_key)
     channel_str
     room_str
 

--- a/test/test_agent_identity.ml
+++ b/test/test_agent_identity.ml
@@ -44,8 +44,18 @@ let test_from_mcp_params_minimal () =
 let test_from_mcp_params_empty_session_key () =
   let params = `Assoc [("_session_key", `String "")] in
   let identity = Agent_identity.from_mcp_params params in
-  check string "empty session_key falls back to agent-anon"
-    "agent-anon" identity.agent_name
+  check bool "empty session_key is regenerated" true
+    (String.length identity.session_key > 0);
+  check bool "regenerated session agent_name starts with agent-" true
+    (String.sub identity.agent_name 0 6 = "agent-")
+
+let test_from_mcp_params_blank_session_key () =
+  let params = `Assoc [("_session_key", `String "   ")] in
+  let identity = Agent_identity.from_mcp_params params in
+  check bool "blank session_key is regenerated" true
+    (String.length identity.session_key > 0);
+  check bool "regenerated blank session agent_name starts with agent-" true
+    (String.sub identity.agent_name 0 6 = "agent-")
 
 let test_from_mcp_params_short_session_key () =
   let params = `Assoc [("_session_key", `String "abc")] in
@@ -117,6 +127,23 @@ let test_to_display_string () =
   let display = Agent_identity.to_display_string identity in
   check bool "contains agent_name" true (String.length display > 0);
   check bool "contains channel" true (str_contains (String.lowercase_ascii display) "telegram")
+
+let test_to_display_string_empty_session_key () =
+  let identity = Agent_identity.({
+    uuid = "agent-emptykey";
+    session_key = "";
+    agent_name = "empty-key-agent";
+    channel = Some Api;
+    user_id = None;
+    room_id = None;
+    capabilities = [];
+    registered_at = 0.0;
+    last_seen = 0.0;
+    metadata = [];
+  }) in
+  let display = Agent_identity.to_display_string identity in
+  check bool "empty session key display uses unknown prefix" true
+    (str_contains display "(unknown)")
 
 (** Registry tests *)
 module RegistryTests = struct
@@ -318,12 +345,14 @@ let () =
       test_case "from_mcp_params" `Quick test_from_mcp_params;
       test_case "from_mcp_params_minimal" `Quick test_from_mcp_params_minimal;
       test_case "from_mcp_params_empty_session_key" `Quick test_from_mcp_params_empty_session_key;
+      test_case "from_mcp_params_blank_session_key" `Quick test_from_mcp_params_blank_session_key;
       test_case "from_mcp_params_short_session_key" `Quick test_from_mcp_params_short_session_key;
       test_case "from_mcp_params_long_session_key_prefix" `Quick test_from_mcp_params_long_session_key_prefix;
       test_case "anonymous" `Quick test_anonymous;
       test_case "channel_roundtrip" `Quick test_channel_roundtrip;
       test_case "same_agent" `Quick test_same_agent;
       test_case "to_display_string" `Quick test_to_display_string;
+      test_case "to_display_string_empty_session_key" `Quick test_to_display_string_empty_session_key;
     ];
     "registry", [
       test_case "register_and_find" `Quick RegistryTests.test_register_and_find;


### PR DESCRIPTION
## Summary
- regenerate `_session_key` when param is empty or whitespace-only
- make `to_display_string` robust for empty session keys (no substring crash)
- add regression tests for blank/empty session key paths

## Changes
- `from_mcp_params` now trims `_session_key` and falls back to generated key if blank
- `to_display_string` now uses safe session-key prefix extraction
- tests added:
  - `from_mcp_params_blank_session_key`
  - `to_display_string_empty_session_key`
  - updated empty-session behavior assertions

## Verification
- `dune build --root .`
- `dune exec --root . test/test_agent_identity.exe`
- `dune exec --root . test/test_identity_e2e.exe`