### PR TITLE
feat: fix gRPC claim role parity + GeekNews heartbeat source

### DIFF
--- a/lib/masc_pb.ml
+++ b/lib/masc_pb.ml
@@ -538,8 +538,15 @@ module rec Masc : sig
       type t = {
         agent_name:string;
         task_id:string;
+        agent_role:string;
+        (**
+{%html:
+<p>optional: writer/reviewer/admin/unassigned</p>
+%}
+        *)
+
       }
-      val make: ?agent_name:string -> ?task_id:string -> unit -> t
+      val make: ?agent_name:string -> ?task_id:string -> ?agent_role:string -> unit -> t
       (** Helper function to generate a message using default values *)
 
       val to_proto: t -> Runtime'.Writer.t
@@ -558,7 +565,7 @@ module rec Masc : sig
       (** Fully qualified protobuf name of this message *)
 
       (**/**)
-      type make_t = ?agent_name:string -> ?task_id:string -> unit -> t
+      type make_t = ?agent_name:string -> ?task_id:string -> ?agent_role:string -> unit -> t
       val merge: t -> t -> t
       val to_proto': Runtime'.Writer.t -> t -> unit
       val from_proto_exn: Runtime'.Reader.t -> t
@@ -1994,8 +2001,15 @@ end = struct
       type t = {
         agent_name:string;
         task_id:string;
+        agent_role:string;
+        (**
+{%html:
+<p>optional: writer/reviewer/admin/unassigned</p>
+%}
+        *)
+
       }
-      val make: ?agent_name:string -> ?task_id:string -> unit -> t
+      val make: ?agent_name:string -> ?task_id:string -> ?agent_role:string -> unit -> t
       (** Helper function to generate a message using default values *)
 
       val to_proto: t -> Runtime'.Writer.t
@@ -2014,7 +2028,7 @@ end = struct
       (** Fully qualified protobuf name of this message *)
 
       (**/**)
-      type make_t = ?agent_name:string -> ?task_id:string -> unit -> t
+      type make_t = ?agent_name:string -> ?task_id:string -> ?agent_role:string -> unit -> t
       val merge: t -> t -> t
       val to_proto': Runtime'.Writer.t -> t -> unit
       val from_proto_exn: Runtime'.Reader.t -> t
@@ -3945,8 +3959,15 @@ end = struct
       type t = {
         agent_name:string;
         task_id:string;
+        agent_role:string;
+        (**
+{%html:
+<p>optional: writer/reviewer/admin/unassigned</p>
+%}
+        *)
+
       }
-      val make: ?agent_name:string -> ?task_id:string -> unit -> t
+      val make: ?agent_name:string -> ?task_id:string -> ?agent_role:string -> unit -> t
       (** Helper function to generate a message using default values *)
 
       val to_proto: t -> Runtime'.Writer.t
@@ -3965,7 +3986,7 @@ end = struct
       (** Fully qualified protobuf name of this message *)
 
       (**/**)
-      type make_t = ?agent_name:string -> ?task_id:string -> unit -> t
+      type make_t = ?agent_name:string -> ?task_id:string -> ?agent_role:string -> unit -> t
       val merge: t -> t -> t
       val to_proto': Runtime'.Writer.t -> t -> unit
       val from_proto_exn: Runtime'.Reader.t -> t
@@ -3977,31 +3998,34 @@ end = struct
       type t = {
         agent_name:string;
         task_id:string;
+        agent_role:string;
       }
-      type make_t = ?agent_name:string -> ?task_id:string -> unit -> t
-      let make ?(agent_name = {||}) ?(task_id = {||}) () = { agent_name; task_id }
+      type make_t = ?agent_name:string -> ?task_id:string -> ?agent_role:string -> unit -> t
+      let make ?(agent_name = {||}) ?(task_id = {||}) ?(agent_role = {||}) () = { agent_name; task_id; agent_role }
       let merge =
       let merge_agent_name = Runtime'.Merge.merge Runtime'.Spec.( basic ((1, "agent_name", "agentName"), string, ({||})) ) in
       let merge_task_id = Runtime'.Merge.merge Runtime'.Spec.( basic ((2, "task_id", "taskId"), string, ({||})) ) in
+      let merge_agent_role = Runtime'.Merge.merge Runtime'.Spec.( basic ((3, "agent_role", "agentRole"), string, ({||})) ) in
       fun t1 t2 -> {
       	agent_name = (merge_agent_name t1.agent_name t2.agent_name);
       	task_id = (merge_task_id t1.task_id t2.task_id);
+        agent_role = (merge_agent_role t1.agent_role t2.agent_role);
        }
-      let spec () = Runtime'.Spec.( basic ((1, "agent_name", "agentName"), string, ({||})) ^:: basic ((2, "task_id", "taskId"), string, ({||})) ^:: nil )
+      let spec () = Runtime'.Spec.( basic ((1, "agent_name", "agentName"), string, ({||})) ^:: basic ((2, "task_id", "taskId"), string, ({||})) ^:: basic ((3, "agent_role", "agentRole"), string, ({||})) ^:: nil )
       let to_proto' =
         let serialize = Runtime'.apply_lazy (fun () -> Runtime'.Serialize.serialize (spec ())) in
-        fun writer { agent_name; task_id } -> serialize writer agent_name task_id
+        fun writer { agent_name; task_id; agent_role } -> serialize writer agent_name task_id agent_role
 
       let to_proto t = let writer = Runtime'.Writer.init () in to_proto' writer t; writer
       let from_proto_exn =
-        let constructor agent_name task_id = { agent_name; task_id } in
+        let constructor agent_name task_id agent_role = { agent_name; task_id; agent_role } in
         Runtime'.apply_lazy (fun () -> Runtime'.Deserialize.deserialize (spec ()) constructor)
       let from_proto writer = Runtime'.Result.catch (fun () -> from_proto_exn writer)
       let to_json options =
         let serialize = Runtime'.Serialize_json.serialize ~message_name:(name ()) (spec ()) options in
-        fun { agent_name; task_id } -> serialize agent_name task_id
+        fun { agent_name; task_id; agent_role } -> serialize agent_name task_id agent_role
       let from_json_exn =
-        let constructor agent_name task_id = { agent_name; task_id } in
+        let constructor agent_name task_id agent_role = { agent_name; task_id; agent_role } in
         Runtime'.apply_lazy (fun () -> Runtime'.Deserialize_json.deserialize ~message_name:(name ()) (spec ()) constructor)
       let from_json json = Runtime'.Result.catch (fun () -> from_json_exn json)
     end
@@ -5657,4 +5681,3 @@ end = struct
 
   end
 end
-

--- a/lib/tool_lodge.ml
+++ b/lib/tool_lodge.ml
@@ -425,6 +425,58 @@ let fetch_hn_article ~net =
           else Ok { title; url; source = HackerNews }
     with exn -> Error (Printf.sprintf "❌ Parse: HN JSON error [%s]" (Printexc.to_string exn))
 
+let decode_xml_entities s =
+  s
+  |> Str.global_replace (Str.regexp "&amp;") "&"
+  |> Str.global_replace (Str.regexp "&lt;") "<"
+  |> Str.global_replace (Str.regexp "&gt;") ">"
+  |> Str.global_replace (Str.regexp "&quot;") "\""
+  |> Str.global_replace (Str.regexp "&#39;") "'"
+
+let extract_group pattern text =
+  try
+    ignore (Str.search_forward pattern text 0);
+    Some (Str.matched_group 1 text)
+  with Not_found -> None
+
+let parse_geek_entry (entry_xml : string) : article option =
+  let title =
+    match extract_group (Str.regexp "<title><!\\[CDATA\\[\\([^<]+\\)\\]\\]></title>") entry_xml with
+    | Some t -> Some t
+    | None -> extract_group (Str.regexp "<title>\\([^<]+\\)</title>") entry_xml
+  in
+  let url =
+    match extract_group (Str.regexp "<link[^>]*href='\\([^']+\\)'[^>]*/?>") entry_xml with
+    | Some u -> Some u
+    | None -> extract_group (Str.regexp "<link[^>]*href=\"\\([^\"]+\\)\"[^>]*/?>") entry_xml
+  in
+  match title, url with
+  | Some t, Some u ->
+    let t = t |> String.trim |> decode_xml_entities in
+    let u = String.trim u in
+    if t = "" || u = "" then None
+    else Some { title = t; url = u; source = GeekNews }
+  | _ -> None
+
+let fetch_geek_article ~net =
+  match http_get_json ~net "https://news.hada.io/rss/news" with
+  | Error e -> Error (Printf.sprintf "❌ Fetch: GeekNews RSS failed [%s]" e)
+  | Ok body ->
+    try
+      let entries =
+        match Str.split (Str.regexp "<entry>") body with
+        | [] | [_] -> []
+        | _feed :: rows -> rows
+      in
+      let candidates =
+        entries
+        |> List.filter_map parse_geek_entry
+        |> List.filteri (fun i _ -> i < 10)
+      in
+      if candidates = [] then Error "❌ Fetch: GeekNews RSS has no valid entries"
+      else Ok (List.nth candidates (Random.int (List.length candidates)))
+    with exn -> Error (Printf.sprintf "❌ Parse: GeekNews RSS error [%s]" (Printexc.to_string exn))
+
 (** {1 DIG: LLM Analysis} *)
 
 let dig_article ~net article =
@@ -1093,11 +1145,14 @@ let react_to_content ~net ?agent_name:provided_name ?post_id content =
 
 let heartbeat ~net (args : Yojson.Safe.t) =
   let source_str = Safe_ops.json_string ~default:"hn" "source" args in
-  (* GeekNews support: https://github.com/jeong-sik/masc-mcp/issues/490 *)
-  let (_ : source) = source_of_string source_str |> Option.value ~default:HackerNews in
+  let source = source_of_string source_str |> Option.value ~default:HackerNews in
 
   (* READ *)
-  match fetch_hn_article ~net with
+  let read_result = match source with
+    | HackerNews -> fetch_hn_article ~net
+    | GeekNews -> fetch_geek_article ~net
+  in
+  match read_result with
   | Error e -> (false, Printf.sprintf "❌ Lodge: Read failed [%s]" e)
   | Ok article ->
     (* DIG — with Eio timeout *)
@@ -1290,7 +1345,11 @@ let tool_heartbeat : Types.tool_schema = {
   input_schema = `Assoc [
     ("type", `String "object");
     ("properties", `Assoc [
-      ("source", `Assoc [("type", `String "string"); ("description", `String "Content source: hn (default)")]);
+      ("source", `Assoc [
+        ("type", `String "string");
+        ("description", `String "Content source: hn/hackernews (default), geek/geeknews");
+        ("enum", `List [`String "hn"; `String "hackernews"; `String "geek"; `String "geeknews"]);
+      ]);
     ]);
   ];
 }
@@ -1326,7 +1385,11 @@ let tool_cycle : Types.tool_schema = {
   input_schema = `Assoc [
     ("type", `String "object");
     ("properties", `Assoc [
-      ("source", `Assoc [("type", `String "string"); ("description", `String "Content source: hn (default)")]);
+      ("source", `Assoc [
+        ("type", `String "string");
+        ("description", `String "Content source: hn/hackernews (default), geek/geeknews");
+        ("enum", `List [`String "hn"; `String "hackernews"; `String "geek"; `String "geeknews"]);
+      ]);
     ]);
   ];
 }

--- a/lib/transport_grpc_next.ml
+++ b/lib/transport_grpc_next.ml
@@ -267,14 +267,16 @@ let add_task_handler (room_config: Room.config) (data: string) : string =
     let response = Pb.AddTaskResponse.make ~task_id:result ~success () in
     encode_add_task_response response
 
-(** ClaimTask handler - assign task to agent.
-    agent_role defaults to Unassigned because the proto lacks the field.
-    See: https://github.com/jeong-sik/masc-mcp/issues/489 *)
+(** ClaimTask handler - assign task to agent with optional role. *)
 let claim_task_handler (room_config: Room.config) (data: string) : string =
   match decode_claim_task_request data with
   | None -> make_error_response "Invalid ClaimTaskRequest"
   | Some req ->
-    let agent_role = Agent_identity.Unassigned in
+    let agent_role =
+      match String.trim req.agent_role with
+      | "" -> Agent_identity.Unassigned
+      | s -> Agent_identity.role_of_string (String.lowercase_ascii s)
+    in
     let result = Room.claim_task_r room_config ~agent_name:req.agent_name ~task_id:req.task_id ~agent_role () in
     let success, message = match result with
       | Ok msg -> (true, msg)
@@ -665,9 +667,10 @@ module Client = struct
       @param client Connected client
       @param agent_name Agent claiming the task
       @param task_id Task to claim
+      @param agent_role Optional role used for role-gated claiming
       @return Result with response or error *)
-  let claim_task ~sw ~env client ~agent_name ~task_id =
-    let request = Pb.ClaimTaskRequest.make ~agent_name ~task_id () in
+  let claim_task ~sw ~env client ~agent_name ~task_id ?(agent_role = "") () =
+    let request = Pb.ClaimTaskRequest.make ~agent_name ~task_id ~agent_role () in
     let encoded = encode_claim_task_request request in
     call_unary ~sw ~env client ~service:"masc.v1.MASCService" ~method_:"ClaimTask" ~request:encoded
 

--- a/proto/masc.proto
+++ b/proto/masc.proto
@@ -105,6 +105,7 @@ message AddTaskResponse {
 message ClaimTaskRequest {
   string agent_name = 1;
   string task_id = 2;
+  string agent_role = 3;  // optional: writer/reviewer/admin/unassigned
 }
 message ClaimTaskResponse {
   bool success = 1;

--- a/test/test_masc_pb_coverage.ml
+++ b/test/test_masc_pb_coverage.ml
@@ -446,9 +446,10 @@ let test_message_json_roundtrip () =
 
 let test_claim_task_request_make () =
   let r = Masc_pb.Masc.V1.ClaimTaskRequest.make
-    ~agent_name:"claimer" ~task_id:"t-claim" () in
+    ~agent_name:"claimer" ~task_id:"t-claim" ~agent_role:"writer" () in
   check string "agent_name" "claimer" r.agent_name;
-  check string "task_id" "t-claim" r.task_id
+  check string "task_id" "t-claim" r.task_id;
+  check string "agent_role" "writer" r.agent_role
 
 let test_claim_task_response_make () =
   let r = Masc_pb.Masc.V1.ClaimTaskResponse.make
@@ -458,11 +459,13 @@ let test_claim_task_response_make () =
 
 let test_claim_task_proto_roundtrip () =
   let original = Masc_pb.Masc.V1.ClaimTaskRequest.make
-    ~agent_name:"agent-a" ~task_id:"t-100" () in
+    ~agent_name:"agent-a" ~task_id:"t-100" ~agent_role:"reviewer" () in
   let encoded = Masc_pb.Masc.V1.ClaimTaskRequest.to_proto original in
   let reader = Ocaml_protoc_plugin.Reader.create (Ocaml_protoc_plugin.Writer.contents encoded) in
   match Masc_pb.Masc.V1.ClaimTaskRequest.from_proto reader with
-  | Ok decoded -> check string "task_id" "t-100" decoded.task_id
+  | Ok decoded ->
+    check string "task_id" "t-100" decoded.task_id;
+    check string "agent_role" "reviewer" decoded.agent_role
   | Error _ -> fail "claim_task proto decode failed"
 
 let test_claim_task_json_roundtrip () =

--- a/test/test_transport_grpc_next_coverage.ml
+++ b/test/test_transport_grpc_next_coverage.ml
@@ -267,10 +267,12 @@ let test_decode_add_task_request_valid () =
   | None -> fail "expected Some"
 
 let test_decode_claim_task_request_valid () =
-  let request = Pb.ClaimTaskRequest.make ~agent_name:"claude" ~task_id:"task-001" () in
+  let request = Pb.ClaimTaskRequest.make ~agent_name:"claude" ~task_id:"task-001" ~agent_role:"writer" () in
   let encoded = Ocaml_protoc_plugin.Writer.contents (Pb.ClaimTaskRequest.to_proto request) in
   match Transport_grpc_next.decode_claim_task_request encoded with
-  | Some decoded -> check string "task_id" "task-001" decoded.task_id
+  | Some decoded ->
+    check string "task_id" "task-001" decoded.task_id;
+    check string "agent_role" "writer" decoded.agent_role
   | None -> fail "expected Some"
 
 let test_decode_done_task_request_valid () =
@@ -354,7 +356,7 @@ let test_decode_get_plan_request_valid () =
    ============================================================ *)
 
 let test_encode_claim_task_request () =
-  let request = Pb.ClaimTaskRequest.make ~agent_name:"claude" ~task_id:"task-001" () in
+  let request = Pb.ClaimTaskRequest.make ~agent_name:"claude" ~task_id:"task-001" ~agent_role:"reviewer" () in
   let encoded = Transport_grpc_next.encode_claim_task_request request in
   check bool "encoded non-empty" true (String.length encoded > 0)
 
@@ -406,12 +408,13 @@ let test_planning_context_of_json_mixed_notes () =
    ============================================================ *)
 
 let test_roundtrip_claim_task () =
-  let original = Pb.ClaimTaskRequest.make ~agent_name:"claude" ~task_id:"task-123" () in
+  let original = Pb.ClaimTaskRequest.make ~agent_name:"claude" ~task_id:"task-123" ~agent_role:"admin" () in
   let encoded = Transport_grpc_next.encode_claim_task_request original in
   match Transport_grpc_next.decode_claim_task_request encoded with
   | Some decoded ->
     check string "agent_name roundtrip" "claude" decoded.agent_name;
-    check string "task_id roundtrip" "task-123" decoded.task_id
+    check string "task_id roundtrip" "task-123" decoded.task_id;
+    check string "agent_role roundtrip" "admin" decoded.agent_role
   | None -> fail "roundtrip failed"
 
 let test_roundtrip_broadcast () =


### PR DESCRIPTION
## Summary
- fix #489: add agent_role to gRPC ClaimTaskRequest and apply role-gated claim in gRPC handler
- fix #490: implement GeekNews source fetch (https://news.hada.io/rss/news) and wire source branch in lodge_heartbeat/lodge_cycle
- regenerate protobuf bindings and update coverage tests

## Validation
- dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/feat-issue-489-490
- ./_build/default/test/test_masc_pb_coverage.exe
- ./_build/default/test/test_transport_grpc_next_coverage.exe
