### PR TITLE
Fix dashboard MDAL recovery and done-task visibility

### DIFF
--- a/bin/main_eio.ml
+++ b/bin/main_eio.ml
@@ -4110,7 +4110,10 @@ let dashboard_batch_json ?(compact = false) (config : Room.config) : Yojson.Safe
     )
       (List.filter
          (fun (t : Types.task) ->
-           match t.task_status with Types.Done _ | Types.Cancelled _ -> false | _ -> true)
+           match t.task_status with
+           | Types.Cancelled _ -> false
+           | Types.Done _ -> not compact
+           | _ -> true)
          tasks)
   in
   let agents_json =

--- a/dashboard/src/app.ts
+++ b/dashboard/src/app.ts
@@ -101,6 +101,7 @@ function SideRail() {
             refreshDashboard()
             if (current === 'board') refreshBoard()
             if (current === 'trpg') refreshTrpg()
+            if (current === 'goals') refreshGoals()
           }}
         >
           Refresh Now

--- a/dashboard/src/store.ts
+++ b/dashboard/src/store.ts
@@ -452,10 +452,11 @@ export function setupSSEReaction(): () => void {
     if (event.type === 'mdal_started' && event.loop_id) {
       const next = new Map(mdalLoops.value)
       next.set(event.loop_id, {
+        ...(next.get(event.loop_id) ?? {}),
         loop_id: event.loop_id,
         profile: event.profile ?? 'custom',
         status: 'running',
-        current_iteration: 0,
+        current_iteration: event.iteration ?? 0,
         max_iterations: 0,
         baseline_metric: event.baseline ?? 0,
         current_metric: event.baseline ?? 0,
@@ -470,39 +471,65 @@ export function setupSSEReaction(): () => void {
 
     if (event.type === 'mdal_iteration' && event.loop_id) {
       const next = new Map(mdalLoops.value)
-      const existing = next.get(event.loop_id)
-      if (existing) {
-        const record: MdalIterationRecord = {
-          iteration: event.iteration ?? 0,
-          metric_before: event.metric_before ?? 0,
-          metric_after: event.metric_after ?? 0,
-          delta: event.delta ?? 0,
-          changes: '',
-          failed_attempts: '',
-          next_suggestion: '',
-          elapsed_ms: 0,
-          cost_usd: null,
-        }
-        next.set(event.loop_id, {
-          ...existing,
-          current_iteration: event.iteration ?? existing.current_iteration,
-          current_metric: event.metric_after ?? existing.current_metric,
-          history: [record, ...existing.history],
-        })
-        mdalLoops.value = next
+      const metricBefore = event.metric_before ?? event.metric_after ?? 0
+      const metricAfter = event.metric_after ?? metricBefore
+      const existing = next.get(event.loop_id) ?? {
+        loop_id: event.loop_id,
+        profile: event.profile ?? 'unknown',
+        status: 'running',
+        current_iteration: event.iteration ?? 0,
+        max_iterations: 0,
+        baseline_metric: metricBefore,
+        current_metric: metricAfter,
+        target: event.target ?? '',
+        stagnation_streak: 0,
+        stagnation_limit: 0,
+        elapsed_seconds: 0,
+        history: [],
       }
+      const record: MdalIterationRecord = {
+        iteration: event.iteration ?? 0,
+        metric_before: metricBefore,
+        metric_after: metricAfter,
+        delta: event.delta ?? 0,
+        changes: '',
+        failed_attempts: '',
+        next_suggestion: '',
+        elapsed_ms: 0,
+        cost_usd: null,
+      }
+      next.set(event.loop_id, {
+        ...existing,
+        current_iteration: event.iteration ?? existing.current_iteration,
+        current_metric: metricAfter,
+        history: [record, ...existing.history],
+      })
+      mdalLoops.value = next
     }
 
     if ((event.type === 'mdal_completed' || event.type === 'mdal_stopped') && event.loop_id) {
       const next = new Map(mdalLoops.value)
-      const existing = next.get(event.loop_id)
-      if (existing) {
-        next.set(event.loop_id, {
-          ...existing,
-          status: event.type === 'mdal_completed' ? 'completed' : 'stopped',
-        })
-        mdalLoops.value = next
+      const existing = next.get(event.loop_id) ?? {
+        loop_id: event.loop_id,
+        profile: event.profile ?? 'unknown',
+        status: 'running',
+        current_iteration: event.iteration ?? 0,
+        max_iterations: 0,
+        baseline_metric: event.baseline ?? event.metric_before ?? event.metric_after ?? 0,
+        current_metric: event.metric_after ?? event.metric_before ?? event.baseline ?? 0,
+        target: event.target ?? '',
+        stagnation_streak: 0,
+        stagnation_limit: 0,
+        elapsed_seconds: 0,
+        history: [],
       }
+      next.set(event.loop_id, {
+        ...existing,
+        current_iteration: event.iteration ?? existing.current_iteration,
+        current_metric: event.metric_after ?? existing.current_metric,
+        status: event.type === 'mdal_completed' ? 'completed' : 'stopped',
+      })
+      mdalLoops.value = next
     }
   })
 


### PR DESCRIPTION
## Summary
- recover MDAL loops in dashboard state even when mdal_started was missed
- include done tasks in /api/v1/dashboard full mode (keep compact mode filtered)
- refresh goals from side-rail refresh button when the goals tab is active

## Validation
- npx tsc --noEmit --pretty (passed in existing workspace where node deps are installed)
- dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix-dashboard-mdal-done @default
- dune exec --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix-dashboard-mdal-done ./test/test_dashboard.exe
- /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix-dashboard-mdal-done/_build/default/test/test_web_dashboard_coverage.exe
- /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix-dashboard-mdal-done/_build/default/test/test_credits_dashboard_coverage.exe