### PR TITLE
feat(trpg): surface available model list in new game

### DIFF
--- a/bin/main_eio.ml
+++ b/bin/main_eio.ml
@@ -1593,6 +1593,315 @@ let trpg_keeper_models_for_round () : string list =
         Printf.eprintf "[trpg] invalid keeper model override ignored: %s\n%!" e;
       []
 
+let trim_trailing_slashes (raw : string) : string =
+  let rec loop value =
+    let len = String.length value in
+    if len > 0 && value.[len - 1] = '/' then
+      loop (String.sub value 0 (len - 1))
+    else
+      value
+  in
+  loop (String.trim raw)
+
+let trpg_json_assoc_find (key : string) = function
+  | `Assoc fields -> List.assoc_opt key fields
+  | _ -> None
+
+let trpg_json_string_fields (keys : string list) (json : Yojson.Safe.t) : string option =
+  let rec pick = function
+    | [] -> None
+    | key :: rest -> (
+        match trpg_json_assoc_find key json with
+        | Some (`String value) ->
+            let trimmed = String.trim value in
+            if trimmed = "" then pick rest else Some trimmed
+        | _ -> pick rest)
+  in
+  pick keys
+
+let trpg_json_string_list_field (key : string) = function
+  | `Assoc fields -> (
+      match List.assoc_opt key fields with
+      | Some (`List rows) ->
+          rows
+          |> List.filter_map (function
+               | `String value ->
+                   let trimmed = String.trim value in
+                   if trimmed = "" then None else Some trimmed
+               | _ -> None)
+      | _ -> [])
+  | _ -> []
+
+let trpg_http_get_json_via_curl ?(timeout_sec = 2) (url : string) :
+    (Yojson.Safe.t, string) result =
+  let argv = ["curl"; "-sS"; "--max-time"; string_of_int timeout_sec; url] in
+  try
+    let status, raw =
+      Process_eio.run_argv_with_status
+        ~timeout_sec:(Float.of_int timeout_sec +. 1.0)
+        argv
+    in
+    match status with
+    | Unix.WEXITED 0 -> (
+        if String.trim raw = "" then Error "empty response"
+        else
+          try Ok (Yojson.Safe.from_string raw)
+          with Yojson.Json_error msg ->
+            Error (Printf.sprintf "invalid json: %s" msg))
+    | Unix.WEXITED 7 -> Error "connection refused"
+    | Unix.WEXITED 28 -> Error "request timed out"
+    | Unix.WEXITED code -> Error (Printf.sprintf "curl exit %d" code)
+    | Unix.WSIGNALED sig_num ->
+        Error (Printf.sprintf "curl killed by signal %d" sig_num)
+    | Unix.WSTOPPED _ -> Error "curl stopped unexpectedly"
+  with exn ->
+    Error (Printf.sprintf "http error: %s" (Printexc.to_string exn))
+
+let trpg_custom_endpoint_urls_from_specs (specs : string list) : string list =
+  specs
+  |> List.filter_map (fun spec ->
+         let spec = String.trim spec in
+         if not (String.starts_with ~prefix:"custom:" spec) then None
+         else
+           match String.index_opt spec '@' with
+           | Some at_idx when at_idx + 1 < String.length spec ->
+               let url =
+                 String.sub spec (at_idx + 1) (String.length spec - at_idx - 1)
+                 |> trim_trailing_slashes
+               in
+               if url = "" then None else Some url
+           | _ -> None)
+  |> String.concat ","
+  |> split_csv_nonempty
+
+let trpg_string_contains ~(needle : string) (haystack : string) : bool =
+  let needle_len = String.length needle in
+  let haystack_len = String.length haystack in
+  let rec loop idx =
+    if needle_len = 0 then true
+    else if idx + needle_len > haystack_len then false
+    else if String.sub haystack idx needle_len = needle then true
+    else loop (idx + 1)
+  in
+  loop 0
+
+let trpg_parse_flag_value ~(flag : string) (command : string) : string option =
+  let trimmed = String.trim command in
+  let with_equals = flag ^ "=" in
+  let len = String.length trimmed in
+  let rec find_equals idx =
+    if idx >= len then None
+    else if
+      idx + String.length with_equals <= len
+      && String.sub trimmed idx (String.length with_equals) = with_equals
+    then
+      let start = idx + String.length with_equals in
+      let rec stop j =
+        if j >= len then j
+        else
+          match trimmed.[j] with
+          | ' ' | '\t' | '\n' | '\r' -> j
+          | _ -> stop (j + 1)
+      in
+      let value = String.sub trimmed start (stop start - start) |> String.trim in
+      if value = "" then None else Some value
+    else find_equals (idx + 1)
+  in
+  match find_equals 0 with
+  | Some _ as value -> value
+  | None ->
+      let with_space = flag ^ " " in
+      let rec find_space idx =
+        if idx >= len then None
+        else if
+          idx + String.length with_space <= len
+          && String.sub trimmed idx (String.length with_space) = with_space
+        then
+          let start = idx + String.length with_space in
+          let rec skip_spaces j =
+            if j < len && (trimmed.[j] = ' ' || trimmed.[j] = '\t') then
+              skip_spaces (j + 1)
+            else
+              j
+          in
+          let start = skip_spaces start in
+          let rec stop j =
+            if j >= len then j
+            else
+              match trimmed.[j] with
+              | ' ' | '\t' | '\n' | '\r' -> j
+              | _ -> stop (j + 1)
+          in
+          let value = String.sub trimmed start (stop start - start) |> String.trim in
+          if value = "" then None else Some value
+        else find_space (idx + 1)
+      in
+      find_space 0
+
+let trpg_running_llama_cpp_urls () : string list =
+  try
+    let status, raw =
+      Process_eio.run_argv_with_status ~timeout_sec:2.5 ["ps"; "ax"; "-o"; "command="]
+    in
+    match status with
+    | Unix.WEXITED 0 ->
+        raw
+        |> String.split_on_char '\n'
+        |> List.filter_map (fun line ->
+               let trimmed = String.trim line in
+               if trimmed = "" || not (trpg_string_contains ~needle:"llama-server" trimmed)
+               then None
+               else
+                 match trpg_parse_flag_value ~flag:"--port" trimmed with
+                 | Some port when String.for_all (function '0' .. '9' -> true | _ -> false) port
+                   ->
+                     Some (Printf.sprintf "http://127.0.0.1:%s" port)
+                 | _ -> None
+               )
+        |> String.concat ","
+        |> split_csv_nonempty
+    | _ -> []
+  with _ -> []
+
+let trpg_openai_compatible_urls () : string list =
+  let env_urls =
+    match Sys.getenv_opt "MASC_TRPG_CUSTOM_MODEL_ENDPOINTS" with
+    | Some raw -> split_csv_nonempty raw |> List.map trim_trailing_slashes
+    | None -> []
+  in
+  let spec_urls =
+    trpg_keeper_models_for_round () |> trpg_custom_endpoint_urls_from_specs
+  in
+  let llama_cpp_urls = trpg_running_llama_cpp_urls () in
+  env_urls @ spec_urls @ llama_cpp_urls
+  |> List.map trim_trailing_slashes
+  |> String.concat ","
+  |> split_csv_nonempty
+
+let trpg_discover_openai_compatible_models (base_url : string) :
+    (string list, string) result =
+  let base_url = trim_trailing_slashes base_url in
+  let url = base_url ^ "/v1/models" in
+  match trpg_http_get_json_via_curl url with
+  | Error err -> Error err
+  | Ok json ->
+      let named_rows =
+        let gather key =
+          match trpg_json_assoc_find key json with
+          | Some (`List entries) ->
+              entries
+              |> List.filter_map (fun entry ->
+                     trpg_json_string_fields ["id"; "name"; "model"] entry)
+          | _ -> []
+        in
+        gather "data" @ gather "models"
+      in
+      let names = split_csv_nonempty (String.concat "," named_rows) in
+      if names = [] then Error "model ids not found in /v1/models"
+      else
+        Ok
+          (List.map
+             (fun model_id -> Printf.sprintf "custom:%s@%s" model_id base_url)
+             names)
+
+let trpg_discover_ollama_models () : (string list, string) result =
+  let base_url = trim_trailing_slashes Llm_client.ollama_glm.api_url in
+  let url = base_url ^ "/api/tags" in
+  match trpg_http_get_json_via_curl url with
+  | Error err -> Error err
+  | Ok json -> (
+      match trpg_json_assoc_find "models" json with
+      | Some (`List entries) ->
+          let names =
+            entries
+            |> List.filter_map (fun entry ->
+                   trpg_json_string_fields ["name"; "model"] entry)
+            |> List.map (fun model_id -> Printf.sprintf "ollama:%s" model_id)
+            |> String.concat ","
+            |> split_csv_nonempty
+          in
+          if names = [] then Error "no ollama models found"
+          else Ok names
+      | _ -> Error "ollama tag list missing models array")
+
+let trpg_available_models_json () : Yojson.Safe.t =
+  let seen : (string, bool) Hashtbl.t = Hashtbl.create 64 in
+  let models_rev = ref [] in
+  let warnings_rev = ref [] in
+  let add_warning message =
+    let trimmed = String.trim message in
+    if trimmed <> "" then warnings_rev := trimmed :: !warnings_rev
+  in
+  let add_model ~spec ~source ~status ?detail () =
+    let spec = String.trim spec in
+    if spec = "" || Hashtbl.mem seen spec then ()
+    else (
+      Hashtbl.replace seen spec true;
+      let fields =
+        [
+          ("spec", `String spec);
+          ("source", `String source);
+          ("status", `String status);
+        ]
+      in
+      let fields =
+        match detail with
+        | Some detail when String.trim detail <> "" ->
+            ("detail", `String (String.trim detail)) :: fields
+        | _ -> fields
+      in
+      models_rev := `Assoc (List.rev fields) :: !models_rev)
+  in
+  let configured_override =
+    match trpg_keeper_models_override_csv () with
+    | Some raw -> split_csv_nonempty raw
+    | None -> []
+  in
+  let default_models = trpg_default_fast_keeper_models () in
+  let effective_models = trpg_keeper_models_for_round () in
+  List.iter
+    (fun spec -> add_model ~spec ~source:"runtime-default" ~status:"default" ())
+    default_models;
+  List.iter
+    (fun spec -> add_model ~spec ~source:"env-override" ~status:"override" ())
+    configured_override;
+  List.iter
+    (fun spec -> add_model ~spec ~source:"runtime-effective" ~status:"selected" ())
+    effective_models;
+  List.iter
+    (fun base_url ->
+      match trpg_discover_openai_compatible_models base_url with
+      | Ok specs ->
+          List.iter
+            (fun spec ->
+              add_model ~spec ~source:"openai-compatible" ~status:"live"
+                ~detail:base_url ())
+            specs
+      | Error err ->
+          add_warning
+            (Printf.sprintf "openai-compatible %s 조회 실패: %s" base_url err))
+    (trpg_openai_compatible_urls ());
+  (match trpg_discover_ollama_models () with
+  | Ok specs ->
+      List.iter
+        (fun spec ->
+          add_model ~spec ~source:"ollama" ~status:"live"
+            ~detail:Llm_client.ollama_glm.api_url ())
+        specs
+  | Error err ->
+      add_warning
+        (Printf.sprintf "ollama %s 조회 실패: %s" Llm_client.ollama_glm.api_url err));
+  `Assoc
+    [
+      ("ok", `Bool true);
+      ( "effective_models",
+        `List (List.map (fun spec -> `String spec) effective_models) );
+      ( "configured_override",
+        `List (List.map (fun spec -> `String spec) configured_override) );
+      ("models", `List (List.rev !models_rev));
+      ("warnings", `List (List.rev_map (fun item -> `String item) !warnings_rev));
+    ]
+
 let trpg_keeper_call_with_runtime
     ~(config : Room.config)
     ~(sw : Eio.Switch.t)
@@ -6127,6 +6436,11 @@ let make_routes ~port ~host ~sw ~clock =
              respond_json_with_cors ~status:`Internal_server_error request reqd
                (Yojson.Safe.to_string (trpg_error_json msg))
        ) request reqd)
+  |> Http.Router.get "/api/v1/trpg/models" (fun request reqd ->
+       with_public_read (fun _state _req reqd ->
+         respond_json_with_cors request reqd
+           (Yojson.Safe.to_string (trpg_available_models_json ()))
+       ) request reqd)
   |> Http.Router.post "/api/v1/trpg/dice/roll" (fun request reqd ->
        with_public_read (fun state _req reqd ->
          let base_dir = state.Mcp_server.room_config.base_path in
@@ -7352,6 +7666,11 @@ let run_server ~sw ~env ~port ~base_path =
           | Error (`Internal_server_error, msg) ->
               h2_respond_json h2_reqd (Yojson.Safe.to_string (trpg_error_json msg))
                 ~status:`Internal_server_error ~extra_headers:cors)
+
+      | `GET, "/api/v1/trpg/models" ->
+          h2_respond_json h2_reqd
+            (Yojson.Safe.to_string (trpg_available_models_json ()))
+            ~extra_headers:cors
 
       | `POST, "/api/v1/trpg/dice/roll" ->
           let state = get_server_state () in

--- a/bin/main_eio.ml
+++ b/bin/main_eio.ml
@@ -1824,7 +1824,7 @@ let trpg_discover_ollama_models () : (string list, string) result =
           else Ok names
       | _ -> Error "ollama tag list missing models array")
 
-let trpg_available_models_json () : Yojson.Safe.t =
+let trpg_available_models_json_uncached () : Yojson.Safe.t =
   let seen : (string, bool) Hashtbl.t = Hashtbl.create 64 in
   let models_rev = ref [] in
   let warnings_rev = ref [] in
@@ -1901,6 +1901,46 @@ let trpg_available_models_json () : Yojson.Safe.t =
       ("models", `List (List.rev !models_rev));
       ("warnings", `List (List.rev_map (fun item -> `String item) !warnings_rev));
     ]
+
+type trpg_model_catalog_cache = {
+  mutex : Mutex.t;
+  mutable cached_at : float;
+  mutable cached_json : Yojson.Safe.t option;
+}
+
+let trpg_model_catalog_cache_ttl_sec = 15.0
+
+let trpg_model_catalog_cache : trpg_model_catalog_cache =
+  {
+    mutex = Mutex.create ();
+    cached_at = 0.0;
+    cached_json = None;
+  }
+
+let trpg_available_models_json () : Yojson.Safe.t =
+  let now = Unix.gettimeofday () in
+  let cached =
+    Mutex.lock trpg_model_catalog_cache.mutex;
+    let snapshot =
+      match trpg_model_catalog_cache.cached_json with
+      | Some json
+        when now -. trpg_model_catalog_cache.cached_at
+             < trpg_model_catalog_cache_ttl_sec ->
+          Some json
+      | _ -> None
+    in
+    Mutex.unlock trpg_model_catalog_cache.mutex;
+    snapshot
+  in
+  match cached with
+  | Some json -> json
+  | None ->
+      let fresh = trpg_available_models_json_uncached () in
+      Mutex.lock trpg_model_catalog_cache.mutex;
+      trpg_model_catalog_cache.cached_json <- Some fresh;
+      trpg_model_catalog_cache.cached_at <- Unix.gettimeofday ();
+      Mutex.unlock trpg_model_catalog_cache.mutex;
+      fresh
 
 let trpg_keeper_call_with_runtime
     ~(config : Room.config)

--- a/viewer/index.html
+++ b/viewer/index.html
@@ -292,9 +292,13 @@
                         </div>
                     </div>
 
-                    <label class="new-game-field">
+                    <label class="new-game-field new-game-field-wide">
                         <span>AI 모델 (쉼표로 구분)</span>
                         <input id="new-game-models" type="text" value="ollama:glm-4.7-flash" title="AI가 사용할 LLM 모델 지정" />
+                        <div id="new-game-model-status" class="new-game-inline-hint">가용 모델 조회 대기 중</div>
+                        <div id="new-game-model-list" class="room-chip-list model-chip-list">
+                            <div class="room-chip-empty">가용 모델을 불러오는 중입니다.</div>
+                        </div>
                     </label>
                 </div>
 

--- a/viewer/src/mode/trpg_controls.rs
+++ b/viewer/src/mode/trpg_controls.rs
@@ -33,6 +33,15 @@ struct NewGameBootstrap {
     keepers: Vec<String>,
     world_presets: Vec<PresetOption>,
     dm_presets: Vec<PresetOption>,
+    model_candidates: Vec<AvailableModelCandidate>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct AvailableModelCandidate {
+    spec: String,
+    source: String,
+    status: String,
+    detail: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -209,6 +218,257 @@ fn parse_keeper_models(raw: &str) -> Vec<String> {
             .map(|part| part.trim().to_string())
             .collect::<Vec<_>>(),
     )
+}
+
+fn read_new_game_model_specs(doc: &web_sys::Document) -> Vec<String> {
+    doc.get_element_by_id("new-game-models")
+        .and_then(|el| el.dyn_into::<web_sys::HtmlInputElement>().ok())
+        .map(|input| parse_keeper_models(&input.value()))
+        .unwrap_or_default()
+}
+
+fn write_new_game_model_specs(doc: &web_sys::Document, specs: &[String]) {
+    if let Some(input) = doc
+        .get_element_by_id("new-game-models")
+        .and_then(|el| el.dyn_into::<web_sys::HtmlInputElement>().ok())
+    {
+        input.set_value(&specs.join(","));
+    }
+}
+
+fn set_new_game_model_status(doc: &web_sys::Document, message: &str, tone: &str) {
+    let Some(el) = doc.get_element_by_id("new-game-model-status") else {
+        return;
+    };
+    el.set_text_content(Some(message));
+    let classes = el.class_list();
+    let _ = classes.remove_3("is-ok", "is-warn", "is-error");
+    let class_name = match tone {
+        "ok" => Some("is-ok"),
+        "warn" => Some("is-warn"),
+        "error" => Some("is-error"),
+        _ => None,
+    };
+    if let Some(class_name) = class_name {
+        let _ = classes.add_1(class_name);
+    }
+}
+
+fn parse_available_model_candidates(payload: &Value) -> Vec<AvailableModelCandidate> {
+    let mut rows = payload
+        .get("models")
+        .and_then(Value::as_array)
+        .map(|entries| {
+            entries
+                .iter()
+                .filter_map(|entry| {
+                    let spec = entry.get("spec").and_then(Value::as_str)?.trim().to_string();
+                    if spec.is_empty() {
+                        return None;
+                    }
+                    Some(AvailableModelCandidate {
+                        spec,
+                        source: entry
+                            .get("source")
+                            .and_then(Value::as_str)
+                            .unwrap_or("")
+                            .trim()
+                            .to_string(),
+                        status: entry
+                            .get("status")
+                            .and_then(Value::as_str)
+                            .unwrap_or("")
+                            .trim()
+                            .to_string(),
+                        detail: entry
+                            .get("detail")
+                            .and_then(Value::as_str)
+                            .unwrap_or("")
+                            .trim()
+                            .to_string(),
+                    })
+                })
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default();
+    rows.sort_by(|a, b| a.spec.cmp(&b.spec));
+    rows
+}
+
+fn parse_effective_model_specs(payload: &Value) -> Vec<String> {
+    payload
+        .get("effective_models")
+        .and_then(Value::as_array)
+        .map(|entries| {
+            entries
+                .iter()
+                .filter_map(Value::as_str)
+                .map(|value| value.trim().to_string())
+                .filter(|value| !value.is_empty())
+                .collect::<Vec<_>>()
+        })
+        .map(|items| unique_non_empty(items))
+        .unwrap_or_default()
+}
+
+fn model_status_badge_label(raw: &str) -> &'static str {
+    match raw.trim() {
+        "selected" => "RUNTIME",
+        "override" => "OVERRIDE",
+        "live" => "LIVE",
+        "default" => "DEFAULT",
+        _ => "MODEL",
+    }
+}
+
+fn sync_available_model_chip_selection(doc: &web_sys::Document) {
+    let selected = read_new_game_model_specs(doc);
+    let Ok(nodes) = doc.query_selector_all("#new-game-model-list .model-chip") else {
+        return;
+    };
+    for idx in 0..nodes.length() {
+        let Some(node) = nodes.item(idx) else { continue };
+        let Some(el) = node.dyn_ref::<web_sys::Element>() else {
+            continue;
+        };
+        let spec = el
+            .get_attribute("data-model-spec")
+            .unwrap_or_default()
+            .trim()
+            .to_string();
+        let is_selected = !spec.is_empty() && selected.iter().any(|item| item == &spec);
+        let _ = el.set_attribute("data-current", if is_selected { "1" } else { "0" });
+    }
+}
+
+fn toggle_new_game_model_spec(doc: &web_sys::Document, spec: &str) {
+    let spec = spec.trim();
+    if spec.is_empty() {
+        return;
+    }
+    let mut selected = read_new_game_model_specs(doc);
+    if let Some(idx) = selected.iter().position(|item| item == spec) {
+        selected.remove(idx);
+    } else {
+        selected.push(spec.to_string());
+    }
+    write_new_game_model_specs(doc, &unique_non_empty(selected));
+    sync_available_model_chip_selection(doc);
+}
+
+fn render_available_model_candidates(
+    doc: &web_sys::Document,
+    rows: &[AvailableModelCandidate],
+) {
+    let Some(list) = doc.get_element_by_id("new-game-model-list") else {
+        return;
+    };
+    if rows.is_empty() {
+        list.set_inner_html("<div class=\"room-chip-empty\">표시할 가용 모델이 없습니다.</div>");
+        return;
+    }
+    let selected = read_new_game_model_specs(doc);
+    let html = rows
+        .iter()
+        .map(|row| {
+            let selected_now = selected.iter().any(|item| item == &row.spec);
+            let meta = if row.detail.is_empty() {
+                row.source.clone()
+            } else if row.source.is_empty() {
+                row.detail.clone()
+            } else {
+                format!("{} · {}", row.source, row.detail)
+            };
+            format!(
+                concat!(
+                    "<button type=\"button\" class=\"room-chip model-chip\" ",
+                    "data-model-spec=\"{spec}\" data-current=\"{selected}\">",
+                    "<span class=\"room-chip-id\">{spec}<span class=\"room-chip-state\">{status}</span></span>",
+                    "<span class=\"room-chip-meta\">{meta}</span>",
+                    "</button>"
+                ),
+                spec = html_escape(&row.spec),
+                selected = if selected_now { "1" } else { "0" },
+                status = html_escape(model_status_badge_label(&row.status)),
+                meta = html_escape(&meta),
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("");
+    list.set_inner_html(&html);
+}
+
+fn bind_available_model_chip_clicks(doc: &web_sys::Document) {
+    let Ok(nodes) = doc.query_selector_all("#new-game-model-list .model-chip") else {
+        return;
+    };
+    for idx in 0..nodes.length() {
+        let Some(node) = nodes.item(idx) else { continue };
+        let Some(el) = node.dyn_ref::<web_sys::Element>() else {
+            continue;
+        };
+        if el.get_attribute("data-bound").as_deref() == Some("1") {
+            continue;
+        }
+        let _ = el.set_attribute("data-bound", "1");
+        let spec = el
+            .get_attribute("data-model-spec")
+            .unwrap_or_default()
+            .trim()
+            .to_string();
+        let cb = Closure::wrap(Box::new(move |_event: web_sys::Event| {
+            let Some(doc) = web_sys::window().and_then(|w| w.document()) else {
+                return;
+            };
+            toggle_new_game_model_spec(&doc, &spec);
+        }) as Box<dyn FnMut(_)>);
+        let _ = el.dyn_ref::<web_sys::EventTarget>().map(|target| {
+            target.add_event_listener_with_callback("click", cb.as_ref().unchecked_ref())
+        });
+        cb.forget();
+    }
+}
+
+async fn refresh_available_model_candidates(
+    doc: &web_sys::Document,
+) -> Result<Vec<AvailableModelCandidate>, String> {
+    set_new_game_model_status(doc, "가용 모델 조회 중...", "warn");
+    let url = crate::config::build_masc_url("api/v1/trpg/models");
+    let (status, body) = crate::mode::mcp_rpc::http_get_text(&url).await?;
+    if !(200..300).contains(&status) {
+        return Err(format!("HTTP {} 응답", status));
+    }
+    let payload: Value =
+        serde_json::from_str(&body).map_err(|e| format!("JSON 파싱 실패: {}", e))?;
+    let rows = parse_available_model_candidates(&payload);
+    let effective = parse_effective_model_specs(&payload);
+    let warnings = payload
+        .get("warnings")
+        .and_then(Value::as_array)
+        .map(|entries| {
+            entries
+                .iter()
+                .filter_map(Value::as_str)
+                .map(|value| value.trim().to_string())
+                .filter(|value| !value.is_empty())
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default();
+    render_available_model_candidates(doc, &rows);
+    bind_available_model_chip_clicks(doc);
+    sync_available_model_chip_selection(doc);
+    let mut status_message = if effective.is_empty() {
+        format!("가용 모델 {}개", rows.len())
+    } else {
+        format!("가용 모델 {}개 · runtime {}", rows.len(), effective.join(", "))
+    };
+    if !warnings.is_empty() {
+        status_message.push_str(" · 일부 로컬 엔드포인트 조회 실패");
+        set_new_game_model_status(doc, &status_message, "warn");
+    } else {
+        set_new_game_model_status(doc, &status_message, "ok");
+    }
+    Ok(rows)
 }
 
 fn selected_player_keepers(doc: &web_sys::Document) -> Vec<String> {
@@ -1415,6 +1675,33 @@ fn bind_new_game_selection_watchers(doc: &web_sys::Document) {
     update_new_game_player_hint(doc);
 }
 
+fn bind_new_game_model_watchers(doc: &web_sys::Document) {
+    let Some(model_input) = doc
+        .get_element_by_id("new-game-models")
+        .and_then(|el| el.dyn_into::<web_sys::HtmlInputElement>().ok())
+    else {
+        return;
+    };
+    if model_input.get_attribute("data-bound").as_deref() == Some("1") {
+        sync_available_model_chip_selection(doc);
+        return;
+    }
+    let _ = model_input.set_attribute("data-bound", "1");
+    let input_cb = Closure::wrap(Box::new(move |_event: web_sys::Event| {
+        let Some(doc) = web_sys::window().and_then(|w| w.document()) else {
+            return;
+        };
+        sync_available_model_chip_selection(&doc);
+    }) as Box<dyn FnMut(_)>);
+    let _ = model_input
+        .dyn_ref::<web_sys::EventTarget>()
+        .map(|target| {
+            target.add_event_listener_with_callback("input", input_cb.as_ref().unchecked_ref())
+        });
+    input_cb.forget();
+    sync_available_model_chip_selection(doc);
+}
+
 fn available_player_keepers(doc: &web_sys::Document) -> Vec<String> {
     let Ok(nodes) = doc.query_selector_all("#new-game-player-select option") else {
         return Vec::new();
@@ -2209,6 +2496,13 @@ pub(super) async fn refresh_actor_admin_list(
 async fn refresh_new_game_bootstrap(doc: &web_sys::Document) -> Result<NewGameBootstrap, String> {
     let keepers = refresh_keeper_selectors(doc).await?;
     let (world_presets, dm_presets) = refresh_preset_selectors(doc).await?;
+    let model_candidates = match refresh_available_model_candidates(doc).await {
+        Ok(rows) => rows,
+        Err(err) => {
+            set_new_game_model_status(doc, &format!("가용 모델 조회 실패: {}", err), "warn");
+            Vec::new()
+        }
+    };
     if let Err(err) = refresh_actor_admin_list(doc).await {
         actor_admin_set_status(doc, &format!("액터 목록 로드 실패: {}", err), "status-warn");
     }
@@ -2216,6 +2510,7 @@ async fn refresh_new_game_bootstrap(doc: &web_sys::Document) -> Result<NewGameBo
         keepers,
         world_presets,
         dm_presets,
+        model_candidates,
     })
 }
 
@@ -2758,16 +3053,18 @@ async fn run_new_game_quick_start(doc: &web_sys::Document) -> Result<String, Str
         NewGameFlowStage::Bootstrap,
         &if bootstrap.keepers.is_empty() {
             format!(
-                "빠른 시작: Keeper 없음 · 월드 {}개 · DM 프리셋 {}개",
+                "빠른 시작: Keeper 없음 · 월드 {}개 · DM 프리셋 {}개 · 모델 {}개",
                 bootstrap.world_presets.len(),
-                bootstrap.dm_presets.len()
+                bootstrap.dm_presets.len(),
+                bootstrap.model_candidates.len()
             )
         } else {
             format!(
-                "빠른 시작: Keeper {}개 · 월드 {}개 · DM 프리셋 {}개 로드됨",
+                "빠른 시작: Keeper {}개 · 월드 {}개 · DM 프리셋 {}개 · 모델 {}개 로드됨",
                 bootstrap.keepers.len(),
                 bootstrap.world_presets.len(),
-                bootstrap.dm_presets.len()
+                bootstrap.dm_presets.len(),
+                bootstrap.model_candidates.len()
             )
         },
     );
@@ -3744,16 +4041,18 @@ pub(super) fn bind_new_game_controls(doc: &web_sys::Document) {
                         &doc_for_fetch,
                         &if bootstrap.keepers.is_empty() {
                             format!(
-                                "Keeper 없음 · 월드 {}개 · DM 프리셋 {}개 (새 게임 전 keeper 실행 필요)",
+                                "Keeper 없음 · 월드 {}개 · DM 프리셋 {}개 · 모델 {}개 (새 게임 전 keeper 실행 필요)",
                                 bootstrap.world_presets.len(),
-                                bootstrap.dm_presets.len()
+                                bootstrap.dm_presets.len(),
+                                bootstrap.model_candidates.len()
                             )
                         } else {
                             format!(
-                                "Keeper {}개 · 월드 {}개 · DM 프리셋 {}개 로드됨",
+                                "Keeper {}개 · 월드 {}개 · DM 프리셋 {}개 · 모델 {}개 로드됨",
                                 bootstrap.keepers.len(),
                                 bootstrap.world_presets.len(),
-                                bootstrap.dm_presets.len()
+                                bootstrap.dm_presets.len(),
+                                bootstrap.model_candidates.len()
                             )
                         },
                     );
@@ -3969,16 +4268,18 @@ pub(super) fn bind_new_game_controls(doc: &web_sys::Document) {
                             &doc_for_fetch,
                             &if bootstrap.keepers.is_empty() {
                                 format!(
-                                    "Keeper 없음 · 월드 {}개 · DM 프리셋 {}개 (새 게임 전 keeper 실행 필요)",
+                                    "Keeper 없음 · 월드 {}개 · DM 프리셋 {}개 · 모델 {}개 (새 게임 전 keeper 실행 필요)",
                                     bootstrap.world_presets.len(),
-                                    bootstrap.dm_presets.len()
+                                    bootstrap.dm_presets.len(),
+                                    bootstrap.model_candidates.len(),
                                 )
                             } else {
                                 format!(
-                                    "Keeper {}개 · 월드 {}개 · DM 프리셋 {}개 새로고침 완료",
+                                    "Keeper {}개 · 월드 {}개 · DM 프리셋 {}개 · 모델 {}개 새로고침 완료",
                                     bootstrap.keepers.len(),
                                     bootstrap.world_presets.len(),
-                                    bootstrap.dm_presets.len()
+                                    bootstrap.dm_presets.len(),
+                                    bootstrap.model_candidates.len(),
                                 )
                             },
                         );
@@ -4147,6 +4448,7 @@ pub(super) fn bind_new_game_controls(doc: &web_sys::Document) {
     }
 
     bind_new_game_selection_watchers(doc);
+    bind_new_game_model_watchers(doc);
     set_new_game_flow_stage(doc, NewGameFlowStage::Idle, Some("대기"));
     sync_new_game_wizard_ui(doc);
     bind_actor_admin_controls(doc);

--- a/viewer/style.css
+++ b/viewer/style.css
@@ -875,6 +875,29 @@ body:not(.mode-trpg) #ops-hud {
     background: rgba(14, 20, 36, 0.58);
 }
 
+.model-chip-list {
+    margin-top: 4px;
+    max-height: 168px;
+}
+
+.model-chip {
+    gap: 4px;
+}
+
+.model-chip[data-current="1"] {
+    border-color: var(--accent-primary);
+    box-shadow: inset 0 0 0 1px rgba(201, 165, 90, 0.35);
+}
+
+.model-chip .room-chip-id {
+    text-transform: none;
+    align-items: flex-start;
+}
+
+.model-chip .room-chip-meta {
+    line-height: 1.35;
+}
+
 .manual-map-actions {
     display: flex;
     justify-content: flex-end;


### PR DESCRIPTION
## Summary
- add  to aggregate runtime defaults and live local model discovery
- show clickable available model chips under the new game model input
- discover local llama.cpp endpoints from env, custom specs, and running llama-server wrapper - M3 Max optimized

Usage: llama-server.sh COMMAND

Commands:
  start     Start llama-server
  stop      Stop llama-server
  restart   Restart llama-server
  status    Show server status
  logs      Show recent logs (last 100 lines)
  test      Test API endpoint (thinking OFF check)

Presets (LLAMA_PRESET env var):
  qwen35      Qwen3.5-35B-A3B Q8 (port 8085, ctx 262k, thinking OFF)
  qwen3next   Qwen3-Next-80B-A3B Q4_K_M (port 8090, ctx 262k)

Environment Variables:
  LLAMA_BIN             Binary path (default: ~/.local/bin/llama-server in me/)
  LLAMA_PRESET          Model preset (qwen35, qwen3next)
  LLAMA_MODEL           Model path
  LLAMA_ALIAS           Model alias for API
  LLAMA_PORT            Server port (default: 8085)
  LLAMA_HOST            Server host (default: 127.0.0.1)
  LLAMA_CTX             Context size (default: 262144)
  LLAMA_NGL             GPU layers (default: 999 = all)
  LLAMA_TEMPLATE_KWARGS JSON for --chat-template-kwargs

Examples:
  llama-server.sh start                              # Start with defaults (Qwen3.5)
  LLAMA_PRESET=qwen35 llama-server.sh start          # Explicit preset
  LLAMA_PRESET=qwen3next llama-server.sh start       # Qwen3-Next-80B
  llama-server.sh status                             # Check status
  llama-server.sh test                               # Test API + thinking check

Thinking mode control (Qwen3.5):
  Server default: thinking OFF (no <think> tags in response)
  API override: pass chat_template_kwargs in request body
    curl http://127.0.0.1:8085/v1/chat/completions \
      -d '{"messages":[...],"chat_template_kwargs":{"enable_thinking":true}}' processes instead of probing hardcoded fallback ports

## Validation
-  (viewer)
- 

## Notes
- live discovery currently reports  as unavailable when the local server is not running, but keeps runtime default specs visible