### PR TITLE
feat(trpg): add ops console read models

### DIFF
--- a/bin/main_eio.ml
+++ b/bin/main_eio.ml
@@ -1989,6 +1989,619 @@ let trpg_available_models_json () : Yojson.Safe.t =
       Mutex.unlock trpg_model_catalog_cache.mutex;
       fallback_json
 
+let trpg_json_string_opt_field (json : Yojson.Safe.t) (key : string) : string option =
+  match Yojson.Safe.Util.member key json with
+  | `String value ->
+      let trimmed = String.trim value in
+      if trimmed = "" then None else Some trimmed
+  | _ -> None
+
+let trpg_json_int_field (json : Yojson.Safe.t) (key : string) ~(default : int) : int =
+  match Yojson.Safe.Util.member key json with
+  | `Int value -> value
+  | _ -> default
+
+let trpg_json_bool_field (json : Yojson.Safe.t) (key : string) ~(default : bool) : bool =
+  match Yojson.Safe.Util.member key json with
+  | `Bool value -> value
+  | _ -> default
+
+let trpg_take_right n lst =
+  lst |> List.rev |> take n |> List.rev
+
+let trpg_recent_events ~base_dir ~room_id ~limit =
+  match Masc_mcp.Trpg_engine_store_sqlite.read_events ~base_dir ~room_id with
+  | Ok events -> trpg_take_right limit events
+  | Error _ -> []
+
+let trpg_party_member_rows (state : Yojson.Safe.t) =
+  trpg_state_party_fields state
+  |> List.map (fun (actor_id, row) ->
+         match row with
+         | `Assoc _ ->
+             let name =
+               trpg_json_string_opt_field row "name" |> Option.value ~default:actor_id
+             in
+             let role =
+               trpg_json_string_opt_field row "role" |> Option.value ~default:"player"
+             in
+             let alive = trpg_json_bool_field row "alive" ~default:true in
+             let hp = trpg_json_int_field row "hp" ~default:0 in
+             let max_hp = trpg_json_int_field row "max_hp" ~default:hp in
+             let keeper =
+               trpg_owner_for_actor state actor_id |> Option.value ~default:""
+             in
+             `Assoc
+               [
+                 ("actor_id", `String actor_id);
+                 ("name", `String name);
+                 ("role", `String role);
+                 ("alive", `Bool alive);
+                 ("hp", `Int hp);
+                 ("max_hp", `Int max_hp);
+                 ("keeper", `String keeper);
+                 ("claimed", `Bool (String.trim keeper <> ""));
+               ]
+         | _ ->
+             `Assoc
+               [
+                 ("actor_id", `String actor_id);
+                 ("name", `String actor_id);
+                 ("role", `String "player");
+                 ("alive", `Bool true);
+                 ("hp", `Int 0);
+                 ("max_hp", `Int 0);
+                 ("keeper", `String "");
+                 ("claimed", `Bool false);
+               ])
+
+let trpg_actor_control_rows (state : Yojson.Safe.t) =
+  trpg_party_member_rows state
+  |> List.filter_map (fun row ->
+         let role = trpg_json_string_opt_field row "role" |> Option.value ~default:"player" in
+         let claimed = trpg_json_bool_field row "claimed" ~default:false in
+         if String.equal role "dm" || claimed then Some row else None)
+
+let trpg_keeper_summary_rows (config : Room.config) =
+  let dir = Tool_keeper.keeper_dir config in
+  if not (Sys.file_exists dir) then []
+  else
+    Sys.readdir dir
+    |> Array.to_list
+    |> List.filter (fun f -> Filename.check_suffix f ".json")
+    |> List.map Filename.remove_extension
+    |> List.filter Tool_keeper.validate_name
+    |> List.sort String.compare
+    |> List.filter_map (fun name ->
+           match Tool_keeper.read_meta config name with
+           | Error _ -> None
+           | Ok None -> None
+           | Ok (Some (m : Tool_keeper.keeper_meta)) ->
+               let agent = Tool_keeper.parse_agent_status config ~agent_name:m.agent_name in
+               let agent_exists = trpg_json_bool_field agent "exists" ~default:false in
+               let agent_status =
+                 trpg_json_string_opt_field agent "status"
+                 |> Option.value ~default:"unknown"
+               in
+               let is_zombie = trpg_json_bool_field agent "is_zombie" ~default:false in
+               let keepalive_running = Hashtbl.mem Tool_keeper.keepalives m.name in
+               Some
+                 (`Assoc
+                   [
+                     ("name", `String m.name);
+                     ("agent_name", `String m.agent_name);
+                     ("models", `List (List.map (fun item -> `String item) m.models));
+                     ("goal", `String m.goal);
+                     ("agent_exists", `Bool agent_exists);
+                     ("agent_status", `String agent_status);
+                     ("is_zombie", `Bool is_zombie);
+                     ("keepalive_running", `Bool keepalive_running);
+                   ]))
+
+let trpg_lobby_catalog_json ~base_dir ~(config : Room.config) ~room_id ~rule_module :
+    trpg_api_result =
+  let ( let* ) r f = match r with Ok v -> f v | Error _ as e -> e in
+  let* derived = trpg_derive_state_json ~base_dir ~room_id ~rule_module in
+  let state = trpg_state_from_derived derived in
+  let preset_catalog =
+    match Masc_mcp.Trpg_preset_store.load_catalog ~base_dir with
+    | Ok catalog -> catalog
+    | Error _ -> Masc_mcp.Trpg_preset_store.default_catalog
+  in
+  let keepers = trpg_keeper_summary_rows config in
+  let keeper_names =
+    keepers
+    |> List.filter_map (fun row -> trpg_json_string_opt_field row "name")
+  in
+  let current_status =
+    trpg_json_string_opt_field state "status" |> Option.value ~default:"lobby"
+  in
+  let current_phase =
+    trpg_json_string_opt_field state "phase"
+    |> Option.value ~default:"dm_narration"
+  in
+  let current_turn = trpg_json_int_field state "turn" ~default:0 in
+  Ok
+    (`Assoc
+      [
+        ("ok", `Bool true);
+        ("room_id", `String room_id);
+        ("rule_module", `String rule_module);
+        ("keepers", `List (List.map (fun name -> `String name) keeper_names));
+        ("keeper_rows", `List keepers);
+        ( "world_presets",
+          `List
+            (List.map Masc_mcp.Trpg_preset_store.world_preset_to_yojson
+               preset_catalog.world_presets) );
+        ( "dm_presets",
+          `List
+            (List.map Masc_mcp.Trpg_preset_store.dm_preset_to_yojson
+               preset_catalog.dm_presets) );
+        ("model_catalog", trpg_available_models_json ());
+        ("occupancy", `List (trpg_actor_control_rows state));
+        ( "current_room",
+          `Assoc
+            [
+              ("status", `String current_status);
+              ("phase", `String current_phase);
+              ("turn", `Int current_turn);
+            ] );
+      ])
+
+let trpg_preflight_row ~id ~label ~ok ?hint detail =
+  let status = if ok then "ok" else "fail" in
+  let fields =
+    [
+      ("id", `String id);
+      ("label", `String label);
+      ("ok", `Bool ok);
+      ("status", `String status);
+      ("detail", `String detail);
+    ]
+  in
+  match hint with
+  | Some value when String.trim value <> "" ->
+      `Assoc (fields @ [("hint", `String (String.trim value))])
+  | _ -> `Assoc fields
+
+let trpg_lobby_preflight_json ~base_dir ~(config : Room.config) ~room_id ~rule_module
+    ~(dm_keeper : string option) ~(player_keepers : string list) ~(models : string list) :
+    trpg_api_result =
+  let selected_dm = Option.value ~default:"" dm_keeper |> String.trim in
+  let players = player_keepers |> List.map String.trim |> List.filter (( <> ) "") in
+  let selected_keepers =
+    split_csv_nonempty (String.concat "," (selected_dm :: players))
+  in
+  let keepers = trpg_keeper_summary_rows config in
+  let keeper_names =
+    keepers
+    |> List.filter_map (fun row -> trpg_json_string_opt_field row "name")
+  in
+  let keeper_lookup : (string, Yojson.Safe.t) Hashtbl.t = Hashtbl.create 32 in
+  List.iter
+    (fun row ->
+      match trpg_json_string_opt_field row "name" with
+      | Some name -> Hashtbl.replace keeper_lookup name row
+      | None -> ())
+    keepers;
+  let preset_catalog_result = Masc_mcp.Trpg_preset_store.load_catalog ~base_dir in
+  let preset_ok = Result.is_ok preset_catalog_result in
+  let derived =
+    match trpg_derive_state_json ~base_dir ~room_id ~rule_module with
+    | Ok json -> Some json
+    | Error _ -> None
+  in
+  let state = derived |> Option.map trpg_state_from_derived |> Option.value ~default:(`Assoc []) in
+  let room_status =
+    trpg_json_string_opt_field state "status" |> Option.value ~default:"lobby"
+  in
+  let blocking_rev = ref [] in
+  let warnings_rev = ref [] in
+  let actions_rev = ref [] in
+  let add_blocking message =
+    let trimmed = String.trim message in
+    if trimmed <> "" then blocking_rev := trimmed :: !blocking_rev
+  in
+  let add_warning message =
+    let trimmed = String.trim message in
+    if trimmed <> "" then warnings_rev := trimmed :: !warnings_rev
+  in
+  let add_action message =
+    let trimmed = String.trim message in
+    if trimmed <> "" then actions_rev := trimmed :: !actions_rev
+  in
+  let selection_ok =
+    selected_dm <> "" && players <> [] && not (List.mem selected_dm players)
+  in
+  if selected_dm = "" then add_blocking "DM keeper를 선택하세요.";
+  if players = [] then add_blocking "플레이어 keeper를 1명 이상 선택하세요.";
+  if List.mem selected_dm players then
+    add_blocking "DM keeper와 플레이어 keeper를 중복 선택할 수 없습니다.";
+  if models = [] then add_blocking "AI 모델을 하나 이상 입력하세요.";
+  let missing_keepers =
+    selected_keepers
+    |> List.filter (fun name -> not (List.mem name keeper_names))
+  in
+  if missing_keepers <> [] then
+    add_blocking
+      (Printf.sprintf "keeper pool 없음: %s"
+         (String.concat ", " missing_keepers));
+  let boot_required =
+    selected_keepers
+    |> List.filter_map (fun name ->
+           match Hashtbl.find_opt keeper_lookup name with
+           | None -> None
+           | Some row ->
+               let agent_exists = trpg_json_bool_field row "agent_exists" ~default:false in
+               let agent_status =
+                 trpg_json_string_opt_field row "agent_status"
+                 |> Option.value ~default:"unknown"
+               in
+               let is_zombie = trpg_json_bool_field row "is_zombie" ~default:false in
+               let keepalive_running =
+                 trpg_json_bool_field row "keepalive_running" ~default:false
+               in
+               if (not agent_exists) || is_zombie then Some (Printf.sprintf "%s: boot 필요" name)
+               else if not (List.mem agent_status [ "active"; "busy"; "listening" ]) then
+                 Some (Printf.sprintf "%s: status=%s" name agent_status)
+               else if not keepalive_running then
+                 Some (Printf.sprintf "%s: keepalive off" name)
+               else None)
+  in
+  if boot_required <> [] then
+    add_warning
+      (Printf.sprintf "선택 keeper 준비 필요: %s"
+         (String.concat ", " boot_required));
+  let occupied =
+    trpg_actor_control_rows state
+    |> List.filter_map (fun row ->
+           let keeper = trpg_json_string_opt_field row "keeper" |> Option.value ~default:"" in
+           let actor_id =
+             trpg_json_string_opt_field row "actor_id" |> Option.value ~default:""
+           in
+           if List.mem keeper selected_keepers then
+             Some (Printf.sprintf "%s→%s" keeper actor_id)
+           else None)
+  in
+  if occupied <> [] then (
+    add_blocking
+      (Printf.sprintf "이미 점유 중: %s" (String.concat ", " occupied));
+    add_action "새 room id로 바꾸거나 기존 actor 점유를 해제하세요.");
+  if not preset_ok then add_blocking "프리셋 catalog를 불러오지 못했습니다.";
+  if not selection_ok then add_action "Lobby에서 DM 1명과 플레이어를 다시 선택하세요.";
+  if models = [] then add_action "Lobby에서 AI 모델을 입력하거나 칩에서 선택하세요.";
+  if room_status = "ended" then
+    add_warning "현재 room은 종료 상태입니다. 새 room id 사용을 권장합니다.";
+  let checks =
+    [
+      trpg_preflight_row ~id:"server" ~label:"서버 연결" ~ok:true "MASC 서버 응답 정상";
+      trpg_preflight_row ~id:"presets" ~label:"프리셋" ~ok:preset_ok
+        (if preset_ok then "월드/DM 프리셋 로드 가능" else "프리셋 catalog를 불러오지 못했습니다.");
+      trpg_preflight_row ~id:"keeper-pool" ~label:"키퍼 풀"
+        ~ok:(keeper_names <> [])
+        (Printf.sprintf "%d명 사용 가능" (List.length keeper_names));
+      trpg_preflight_row ~id:"selection" ~label:"선택 키퍼"
+        ~ok:(selected_keepers <> [] && missing_keepers = [] && selection_ok)
+        (if selected_keepers = [] then "DM/플레이어 keeper를 선택하세요."
+         else
+           Printf.sprintf "DM %s · 플레이어 %d명"
+             (if selected_dm = "" then "-" else selected_dm)
+             (List.length players));
+      trpg_preflight_row ~id:"models" ~label:"AI 모델" ~ok:(models <> [])
+        (if models = [] then "입력된 모델이 없습니다."
+         else Printf.sprintf "%d개 선택" (List.length models));
+      trpg_preflight_row ~id:"occupancy" ~label:"점유 충돌" ~ok:(occupied = [])
+        (if occupied = [] then "선택 keeper 모두 비점유"
+         else Printf.sprintf "충돌 %s" (String.concat ", " occupied));
+      trpg_preflight_row ~id:"room" ~label:"룸 상태" ~ok:true
+        (Printf.sprintf "room %s · %s" room_id room_status);
+    ]
+  in
+  let dedupe_list items = String.concat "," items |> split_csv_nonempty in
+  let blocking = List.rev !blocking_rev |> dedupe_list in
+  let warnings = List.rev !warnings_rev |> dedupe_list in
+  let recommended_actions = List.rev !actions_rev |> dedupe_list in
+  Ok
+    (`Assoc
+      [
+        ("ok", `Bool true);
+        ("room_id", `String room_id);
+        ("ready", `Bool (blocking = []));
+        ("checks", `List checks);
+        ("blocking", `List (List.map (fun item -> `String item) blocking));
+        ("warnings", `List (List.map (fun item -> `String item) warnings));
+        ( "recommended_actions",
+          `List (List.map (fun item -> `String item) recommended_actions) );
+      ])
+
+let trpg_build_alarm ~level ~code ~message =
+  `Assoc
+    [
+      ("level", `String level);
+      ("code", `String code);
+      ("message", `String message);
+    ]
+
+let trpg_overview_json ~base_dir ~room_id ~rule_module : trpg_api_result =
+  let ( let* ) r f = match r with Ok v -> f v | Error _ as e -> e in
+  let* derived = trpg_derive_state_json ~base_dir ~room_id ~rule_module in
+  let state = trpg_state_from_derived derived in
+  let recent_events = trpg_recent_events ~base_dir ~room_id ~limit:12 in
+  let party = trpg_party_member_rows state in
+  let players =
+    party
+    |> List.filter (fun row ->
+           trpg_json_string_opt_field row "role" |> Option.value ~default:"player"
+           |> String.lowercase_ascii = "player")
+  in
+  let player_count = List.length players in
+  let alive_players =
+    players |> List.filter (fun row -> trpg_json_bool_field row "alive" ~default:true)
+    |> List.length
+  in
+  let claimed_players =
+    players |> List.filter (fun row -> trpg_json_bool_field row "claimed" ~default:false)
+    |> List.length
+  in
+  let unclaimed_players = max 0 (player_count - claimed_players) in
+  let active_keepers =
+    trpg_state_actor_control_fields state
+    |> List.map snd |> String.concat "," |> split_csv_nonempty |> List.length
+  in
+  let status =
+    trpg_json_string_opt_field state "status" |> Option.value ~default:"lobby"
+  in
+  let phase =
+    trpg_json_string_opt_field state "phase"
+    |> Option.value ~default:"dm_narration"
+  in
+  let scenario =
+    trpg_json_string_fields [ "current_scenario"; "scenario"; "world" ] state
+    |> Option.value ~default:""
+  in
+  let node =
+    trpg_json_string_fields
+      [ "current_node"; "node"; "current_area"; "area"; "scene" ]
+      state
+    |> Option.value ~default:""
+  in
+  let alarms_rev = ref [] in
+  let add_alarm level code message =
+    alarms_rev := trpg_build_alarm ~level ~code ~message :: !alarms_rev
+  in
+  if status = "unavailable" then
+    add_alarm "error" "room_unavailable" "TRPG 엔진 상태를 읽지 못했습니다.";
+  if status = "ended" then
+    add_alarm "warn" "room_ended" "이 room은 종료 상태입니다.";
+  if unclaimed_players > 0 && status <> "lobby" then
+    add_alarm "warn" "unclaimed_players"
+      (Printf.sprintf "player actor %d명이 아직 keeper와 연결되지 않았습니다."
+         unclaimed_players);
+  List.iter
+    (fun ev ->
+      match ev.Masc_mcp.Trpg_engine_event.event_type with
+      | Masc_mcp.Trpg_engine_event.Turn_timeout ->
+          add_alarm "warn" "turn_timeout" "최근 턴 timeout 이벤트가 기록되었습니다."
+      | Masc_mcp.Trpg_engine_event.Keeper_unavailable ->
+          add_alarm "warn" "keeper_unavailable" "최근 keeper unavailable 이벤트가 기록되었습니다."
+      | _ -> ())
+    recent_events;
+  let next_actions =
+    let items = ref [] in
+    let add item =
+      let trimmed = String.trim item in
+      if trimmed <> "" then items := trimmed :: !items
+    in
+    if status = "lobby" then add "Lobby에서 세션을 시작하세요.";
+    if unclaimed_players > 0 then add "Control에서 actor 점유 상태를 확인하세요.";
+    if status = "stopped" then add "세션 재개 또는 라운드 실행 여부를 결정하세요.";
+    if !items = [] then add "Timeline에서 최근 이벤트를 확인하세요.";
+    String.concat "," (List.rev !items) |> split_csv_nonempty
+  in
+  Ok
+    (`Assoc
+      [
+        ("ok", `Bool true);
+        ("room_id", `String room_id);
+        ( "summary",
+          `Assoc
+            [
+              ("status", `String status);
+              ("turn", `Int (trpg_json_int_field state "turn" ~default:0));
+              ("phase", `String phase);
+              ("scenario", `String scenario);
+              ("node", `String node);
+              ("player_count", `Int player_count);
+              ("alive_players", `Int alive_players);
+              ("claimed_players", `Int claimed_players);
+              ("unclaimed_players", `Int unclaimed_players);
+              ("active_keepers", `Int active_keepers);
+            ] );
+        ("alarms", `List (List.rev !alarms_rev));
+        ( "next_actions",
+          `List (List.map (fun item -> `String item) next_actions) );
+        ("party", `List party);
+        ( "recent_events",
+          `List
+            (List.map Masc_mcp.Trpg_engine_event.to_yojson recent_events) );
+      ])
+
+let trpg_control_state_json ~base_dir ~room_id ~rule_module : trpg_api_result =
+  let ( let* ) r f = match r with Ok v -> f v | Error _ as e -> e in
+  let* derived = trpg_derive_state_json ~base_dir ~room_id ~rule_module in
+  let state = trpg_state_from_derived derived in
+  let status =
+    trpg_json_string_opt_field state "status" |> Option.value ~default:"lobby"
+  in
+  let phase =
+    trpg_json_string_opt_field state "phase"
+    |> Option.value ~default:"dm_narration"
+  in
+  let actor_control = trpg_actor_control_rows state in
+  let player_rows =
+    trpg_party_member_rows state
+    |> List.filter (fun row ->
+           trpg_json_string_opt_field row "role" |> Option.value ~default:"player"
+           |> String.lowercase_ascii = "player")
+  in
+  let unclaimed_players =
+    player_rows
+    |> List.filter (fun row -> not (trpg_json_bool_field row "claimed" ~default:false))
+  in
+  let recent_interventions =
+    trpg_recent_events ~base_dir ~room_id ~limit:20
+    |> List.filter (fun ev ->
+           match ev.Masc_mcp.Trpg_engine_event.event_type with
+           | Masc_mcp.Trpg_engine_event.Intervention_submitted
+           | Masc_mcp.Trpg_engine_event.Intervention_applied -> true
+           | _ -> false)
+  in
+  let allowed_actions =
+    [
+      `Assoc
+        [
+          ("id", `String "run-round");
+          ("label", `String "라운드 실행");
+          ("enabled", `Bool (status <> "ended" && status <> "unavailable"));
+          ( "reason",
+            `String
+              (if status = "ended" then "종료된 세션입니다."
+               else if status = "unavailable" then "엔진 상태를 읽지 못했습니다."
+               else "라운드 실행 가능") );
+        ];
+      `Assoc
+        [
+          ("id", `String "pause-session");
+          ("label", `String "세션 멈춤");
+          ("enabled", `Bool (status = "running"));
+          ( "reason",
+            `String (if status = "running" then "진행 중 세션입니다." else "running 상태에서만 사용") );
+        ];
+      `Assoc
+        [
+          ("id", `String "resume-session");
+          ("label", `String "세션 재개");
+          ("enabled", `Bool (status = "stopped"));
+          ( "reason",
+            `String (if status = "stopped" then "중단된 세션입니다." else "stopped 상태에서만 사용") );
+        ];
+    ]
+  in
+  let warnings =
+    [
+      (if unclaimed_players = [] then None
+       else
+         Some
+           (Printf.sprintf "미점유 player actor %d명"
+              (List.length unclaimed_players)));
+      (if recent_interventions = [] then None
+       else Some "최근 intervention 이벤트가 있습니다.");
+    ]
+    |> List.filter_map (fun item -> item)
+  in
+  Ok
+    (`Assoc
+      [
+        ("ok", `Bool true);
+        ("room_id", `String room_id);
+        ( "summary",
+          `Assoc
+            [
+              ("status", `String status);
+              ("turn", `Int (trpg_json_int_field state "turn" ~default:0));
+              ("phase", `String phase);
+              ( "join_window_open",
+                `Bool (trpg_join_gate_phase_open state) );
+              ("join_gate_min_points", `Int (trpg_join_gate_min_points state));
+            ] );
+        ("actor_control", `List actor_control);
+        ("unclaimed_players", `List unclaimed_players);
+        ( "recent_interventions",
+          `List
+            (List.map Masc_mcp.Trpg_engine_event.to_yojson recent_interventions) );
+        ("allowed_actions", `List allowed_actions);
+        ("warnings", `List (List.map (fun item -> `String item) warnings));
+      ])
+
+let trpg_event_phase_matches (phase_filter : string option)
+    (event : Masc_mcp.Trpg_engine_event.t) =
+  match phase_filter with
+  | None -> true
+  | Some phase_filter ->
+      let normalized = String.lowercase_ascii (String.trim phase_filter) in
+      if normalized = "" then true
+      else
+        match
+          trpg_json_string_fields
+            [ "phase"; "phase_name"; "phase_after"; "phase_before" ]
+            event.payload
+        with
+        | Some phase ->
+            String.equal (String.lowercase_ascii (String.trim phase)) normalized
+        | None -> false
+
+let trpg_timeline_json ~base_dir ~room_id ~after_seq ~event_type_filter ~actor_filter
+    ~phase_filter ~limit : trpg_api_result =
+  match trpg_stream_json ~base_dir ~room_id ~after_seq ~event_type_filter with
+  | Error _ as err -> err
+  | Ok raw ->
+      let normalized = trpg_normalize_events_json ~default_room_id:room_id raw in
+      let events =
+        match trpg_json_assoc_find "events" normalized with
+        | Some (`List entries) ->
+            entries
+            |> List.filter_map (fun item ->
+                   match Masc_mcp.Trpg_engine_event.of_yojson item with
+                   | Ok event -> Some event
+                   | Error _ -> None)
+            |> List.filter (fun (event : Masc_mcp.Trpg_engine_event.t) ->
+                   let actor_ok =
+                     match actor_filter with
+                     | Some actor when String.trim actor <> "" -> (
+                         match event.actor_id with
+                         | Some actor_id -> String.equal actor_id (String.trim actor)
+                         | None -> false)
+                     | _ -> true
+                   in
+                   actor_ok && trpg_event_phase_matches phase_filter event)
+            |> take limit
+        | _ -> []
+      in
+      let last_seq =
+        events
+        |> List.rev
+        |> List.find_map (fun event -> Some event.Masc_mcp.Trpg_engine_event.seq)
+        |> Option.value ~default:after_seq
+      in
+      Ok
+        (`Assoc
+          [
+            ("ok", `Bool true);
+            ("room_id", `String room_id);
+            ( "filters",
+              `Assoc
+                [
+                  ("after_seq", `Int after_seq);
+                  ( "event_type",
+                    match event_type_filter with
+                    | Some value -> `String value
+                    | None -> `Null );
+                  ( "actor",
+                    match actor_filter with
+                    | Some value -> `String value
+                    | None -> `Null );
+                  ( "phase",
+                    match phase_filter with
+                    | Some value -> `String value
+                    | None -> `Null );
+                  ("limit", `Int limit);
+                ] );
+            ("count", `Int (List.length events));
+            ("last_seq", `Int last_seq);
+            ( "events",
+              `List (List.map Masc_mcp.Trpg_engine_event.to_yojson events) );
+          ])
+
 let trpg_keeper_call_with_runtime
     ~(config : Room.config)
     ~(sw : Eio.Switch.t)
@@ -6525,6 +7138,87 @@ let make_routes ~port ~host ~sw ~clock =
              respond_json_with_cors ~status:`Internal_server_error request reqd
                (Yojson.Safe.to_string (trpg_error_json msg))
        ) request reqd)
+  |> Http.Router.get "/api/v1/trpg/lobby/catalog" (fun request reqd ->
+       with_public_read (fun state req reqd ->
+         let base_dir = state.Mcp_server.room_config.base_path in
+         let room_id = trpg_resolve_room_id ~config:state.Mcp_server.room_config req in
+         let rule_module =
+           Option.value ~default:"dnd5e-lite" (query_param req "rule_module")
+         in
+         match
+           trpg_lobby_catalog_json ~base_dir ~config:state.Mcp_server.room_config ~room_id
+             ~rule_module
+         with
+         | Ok json ->
+             respond_json_with_cors request reqd (Yojson.Safe.to_string json)
+         | Error (`Bad_request, msg) ->
+             respond_json_with_cors ~status:`Bad_request request reqd
+               (Yojson.Safe.to_string (trpg_error_json msg))
+         | Error (`Internal_server_error, msg) ->
+             respond_json_with_cors ~status:`Internal_server_error request reqd
+               (Yojson.Safe.to_string (trpg_error_json msg))
+       ) request reqd)
+  |> Http.Router.get "/api/v1/trpg/lobby/preflight" (fun request reqd ->
+       with_public_read (fun state req reqd ->
+         let base_dir = state.Mcp_server.room_config.base_path in
+         let room_id = trpg_resolve_room_id ~config:state.Mcp_server.room_config req in
+         let rule_module =
+           Option.value ~default:"dnd5e-lite" (query_param req "rule_module")
+         in
+         let dm_keeper = query_param req "dm" in
+         let player_keepers =
+           query_param req "players" |> Option.value ~default:"" |> split_csv_nonempty
+         in
+         let models =
+           query_param req "models" |> Option.value ~default:"" |> split_csv_nonempty
+         in
+         match
+           trpg_lobby_preflight_json ~base_dir ~config:state.Mcp_server.room_config ~room_id
+             ~rule_module ~dm_keeper ~player_keepers ~models
+         with
+         | Ok json ->
+             respond_json_with_cors request reqd (Yojson.Safe.to_string json)
+         | Error (`Bad_request, msg) ->
+             respond_json_with_cors ~status:`Bad_request request reqd
+               (Yojson.Safe.to_string (trpg_error_json msg))
+         | Error (`Internal_server_error, msg) ->
+             respond_json_with_cors ~status:`Internal_server_error request reqd
+               (Yojson.Safe.to_string (trpg_error_json msg))
+       ) request reqd)
+  |> Http.Router.get "/api/v1/trpg/overview" (fun request reqd ->
+       with_public_read (fun state req reqd ->
+         let base_dir = state.Mcp_server.room_config.base_path in
+         let room_id = trpg_resolve_room_id ~config:state.Mcp_server.room_config req in
+         let rule_module =
+           Option.value ~default:"dnd5e-lite" (query_param req "rule_module")
+         in
+         match trpg_overview_json ~base_dir ~room_id ~rule_module with
+         | Ok json ->
+             respond_json_with_cors request reqd (Yojson.Safe.to_string json)
+         | Error (`Bad_request, msg) ->
+             respond_json_with_cors ~status:`Bad_request request reqd
+               (Yojson.Safe.to_string (trpg_error_json msg))
+         | Error (`Internal_server_error, msg) ->
+             respond_json_with_cors ~status:`Internal_server_error request reqd
+               (Yojson.Safe.to_string (trpg_error_json msg))
+       ) request reqd)
+  |> Http.Router.get "/api/v1/trpg/control/state" (fun request reqd ->
+       with_public_read (fun state req reqd ->
+         let base_dir = state.Mcp_server.room_config.base_path in
+         let room_id = trpg_resolve_room_id ~config:state.Mcp_server.room_config req in
+         let rule_module =
+           Option.value ~default:"dnd5e-lite" (query_param req "rule_module")
+         in
+         match trpg_control_state_json ~base_dir ~room_id ~rule_module with
+         | Ok json ->
+             respond_json_with_cors request reqd (Yojson.Safe.to_string json)
+         | Error (`Bad_request, msg) ->
+             respond_json_with_cors ~status:`Bad_request request reqd
+               (Yojson.Safe.to_string (trpg_error_json msg))
+         | Error (`Internal_server_error, msg) ->
+             respond_json_with_cors ~status:`Internal_server_error request reqd
+               (Yojson.Safe.to_string (trpg_error_json msg))
+       ) request reqd)
   |> Http.Router.get "/api/v1/trpg/models" (fun request reqd ->
        with_public_read (fun _state _req reqd ->
          respond_json_with_cors request reqd
@@ -6603,6 +7297,28 @@ let make_routes ~port ~host ~sw ~clock =
          | Ok json ->
              let normalized = trpg_normalize_events_json ~default_room_id:room_id json in
              respond_json_with_cors request reqd (Yojson.Safe.to_string normalized)
+         | Error (`Bad_request, msg) ->
+             respond_json_with_cors ~status:`Bad_request request reqd
+               (Yojson.Safe.to_string (trpg_error_json msg))
+         | Error (`Internal_server_error, msg) ->
+             respond_json_with_cors ~status:`Internal_server_error request reqd
+               (Yojson.Safe.to_string (trpg_error_json msg))
+       ) request reqd)
+  |> Http.Router.get "/api/v1/trpg/timeline" (fun request reqd ->
+       with_public_read (fun state req reqd ->
+         let base_dir = state.Mcp_server.room_config.base_path in
+         let room_id = trpg_resolve_room_id ~config:state.Mcp_server.room_config req in
+         let after_seq = int_query_param req "after_seq" ~default:0 in
+         let event_type_filter = query_param req "event_type" in
+         let actor_filter = query_param req "actor" in
+         let phase_filter = query_param req "phase" in
+         let limit = int_query_param req "limit" ~default:50 |> clamp ~min_v:1 ~max_v:200 in
+         match
+           trpg_timeline_json ~base_dir ~room_id ~after_seq ~event_type_filter
+             ~actor_filter ~phase_filter ~limit
+         with
+         | Ok json ->
+             respond_json_with_cors request reqd (Yojson.Safe.to_string json)
          | Error (`Bad_request, msg) ->
              respond_json_with_cors ~status:`Bad_request request reqd
                (Yojson.Safe.to_string (trpg_error_json msg))
@@ -7756,6 +8472,97 @@ let run_server ~sw ~env ~port ~base_path =
               h2_respond_json h2_reqd (Yojson.Safe.to_string (trpg_error_json msg))
                 ~status:`Internal_server_error ~extra_headers:cors)
 
+      | `GET, "/api/v1/trpg/lobby/catalog" ->
+          let state = get_server_state () in
+          let base_dir = state.Mcp_server.room_config.base_path in
+          let room_id =
+            trpg_resolve_room_id ~config:state.Mcp_server.room_config httpun_request in
+          let rule_module =
+            Option.value ~default:"dnd5e-lite"
+              (query_param httpun_request "rule_module")
+          in
+          (match
+             trpg_lobby_catalog_json ~base_dir ~config:state.Mcp_server.room_config
+               ~room_id ~rule_module
+           with
+          | Ok json ->
+              h2_respond_json h2_reqd (Yojson.Safe.to_string json) ~extra_headers:cors
+          | Error (`Bad_request, msg) ->
+              h2_respond_json h2_reqd (Yojson.Safe.to_string (trpg_error_json msg))
+                ~status:`Bad_request ~extra_headers:cors
+          | Error (`Internal_server_error, msg) ->
+              h2_respond_json h2_reqd (Yojson.Safe.to_string (trpg_error_json msg))
+                ~status:`Internal_server_error ~extra_headers:cors)
+
+      | `GET, "/api/v1/trpg/lobby/preflight" ->
+          let state = get_server_state () in
+          let base_dir = state.Mcp_server.room_config.base_path in
+          let room_id =
+            trpg_resolve_room_id ~config:state.Mcp_server.room_config httpun_request in
+          let rule_module =
+            Option.value ~default:"dnd5e-lite"
+              (query_param httpun_request "rule_module")
+          in
+          let dm_keeper = query_param httpun_request "dm" in
+          let player_keepers =
+            query_param httpun_request "players" |> Option.value ~default:""
+            |> split_csv_nonempty
+          in
+          let models =
+            query_param httpun_request "models" |> Option.value ~default:""
+            |> split_csv_nonempty
+          in
+          (match
+             trpg_lobby_preflight_json ~base_dir ~config:state.Mcp_server.room_config
+               ~room_id ~rule_module ~dm_keeper ~player_keepers ~models
+           with
+          | Ok json ->
+              h2_respond_json h2_reqd (Yojson.Safe.to_string json) ~extra_headers:cors
+          | Error (`Bad_request, msg) ->
+              h2_respond_json h2_reqd (Yojson.Safe.to_string (trpg_error_json msg))
+                ~status:`Bad_request ~extra_headers:cors
+          | Error (`Internal_server_error, msg) ->
+              h2_respond_json h2_reqd (Yojson.Safe.to_string (trpg_error_json msg))
+                ~status:`Internal_server_error ~extra_headers:cors)
+
+      | `GET, "/api/v1/trpg/overview" ->
+          let state = get_server_state () in
+          let base_dir = state.Mcp_server.room_config.base_path in
+          let room_id =
+            trpg_resolve_room_id ~config:state.Mcp_server.room_config httpun_request in
+          let rule_module =
+            Option.value ~default:"dnd5e-lite"
+              (query_param httpun_request "rule_module")
+          in
+          (match trpg_overview_json ~base_dir ~room_id ~rule_module with
+          | Ok json ->
+              h2_respond_json h2_reqd (Yojson.Safe.to_string json) ~extra_headers:cors
+          | Error (`Bad_request, msg) ->
+              h2_respond_json h2_reqd (Yojson.Safe.to_string (trpg_error_json msg))
+                ~status:`Bad_request ~extra_headers:cors
+          | Error (`Internal_server_error, msg) ->
+              h2_respond_json h2_reqd (Yojson.Safe.to_string (trpg_error_json msg))
+                ~status:`Internal_server_error ~extra_headers:cors)
+
+      | `GET, "/api/v1/trpg/control/state" ->
+          let state = get_server_state () in
+          let base_dir = state.Mcp_server.room_config.base_path in
+          let room_id =
+            trpg_resolve_room_id ~config:state.Mcp_server.room_config httpun_request in
+          let rule_module =
+            Option.value ~default:"dnd5e-lite"
+              (query_param httpun_request "rule_module")
+          in
+          (match trpg_control_state_json ~base_dir ~room_id ~rule_module with
+          | Ok json ->
+              h2_respond_json h2_reqd (Yojson.Safe.to_string json) ~extra_headers:cors
+          | Error (`Bad_request, msg) ->
+              h2_respond_json h2_reqd (Yojson.Safe.to_string (trpg_error_json msg))
+                ~status:`Bad_request ~extra_headers:cors
+          | Error (`Internal_server_error, msg) ->
+              h2_respond_json h2_reqd (Yojson.Safe.to_string (trpg_error_json msg))
+                ~status:`Internal_server_error ~extra_headers:cors)
+
       | `GET, "/api/v1/trpg/models" ->
           h2_respond_json h2_reqd
             (Yojson.Safe.to_string (trpg_available_models_json ()))
@@ -7841,6 +8648,32 @@ let run_server ~sw ~env ~port ~base_path =
           | Ok json ->
               let normalized = trpg_normalize_events_json ~default_room_id:room_id json in
               h2_respond_json h2_reqd (Yojson.Safe.to_string normalized) ~extra_headers:cors
+          | Error (`Bad_request, msg) ->
+              h2_respond_json h2_reqd (Yojson.Safe.to_string (trpg_error_json msg))
+                ~status:`Bad_request ~extra_headers:cors
+          | Error (`Internal_server_error, msg) ->
+              h2_respond_json h2_reqd (Yojson.Safe.to_string (trpg_error_json msg))
+                ~status:`Internal_server_error ~extra_headers:cors)
+
+      | `GET, "/api/v1/trpg/timeline" ->
+          let state = get_server_state () in
+          let base_dir = state.Mcp_server.room_config.base_path in
+          let room_id =
+            trpg_resolve_room_id ~config:state.Mcp_server.room_config httpun_request in
+          let after_seq = int_query_param httpun_request "after_seq" ~default:0 in
+          let event_type_filter = query_param httpun_request "event_type" in
+          let actor_filter = query_param httpun_request "actor" in
+          let phase_filter = query_param httpun_request "phase" in
+          let limit =
+            int_query_param httpun_request "limit" ~default:50
+            |> clamp ~min_v:1 ~max_v:200
+          in
+          (match
+             trpg_timeline_json ~base_dir ~room_id ~after_seq ~event_type_filter
+               ~actor_filter ~phase_filter ~limit
+           with
+          | Ok json ->
+              h2_respond_json h2_reqd (Yojson.Safe.to_string json) ~extra_headers:cors
           | Error (`Bad_request, msg) ->
               h2_respond_json h2_reqd (Yojson.Safe.to_string (trpg_error_json msg))
                 ~status:`Bad_request ~extra_headers:cors

--- a/viewer/index.html
+++ b/viewer/index.html
@@ -312,6 +312,65 @@
                 <div id="new-game-status" class="new-game-status">버튼을 눌러 준비하세요.</div>
                 <div id="new-game-preflight" class="new-game-preflight">사전 점검 대기 중</div>
                 <div id="new-game-assignment" class="new-game-assignment">세션 정보를 준비 중입니다.</div>
+            </div>
+        </section>
+
+        <section id="room-hub" class="room-hub" style="display: none;">
+            <div class="room-hub-placeholder">방 목록을 불러오는 중...</div>
+        </section>
+
+        <section id="trpg-surface-nav" class="trpg-surface-nav" style="display: none;" aria-label="TRPG 운영 콘솔">
+            <button class="trpg-surface-tab" type="button" data-trpg-surface="lobby" aria-pressed="false">Lobby</button>
+            <button class="trpg-surface-tab" type="button" data-trpg-surface="overview" aria-pressed="true">Overview</button>
+            <button class="trpg-surface-tab" type="button" data-trpg-surface="timeline" aria-pressed="false">Timeline</button>
+            <button class="trpg-surface-tab" type="button" data-trpg-surface="control" aria-pressed="false">Control</button>
+            <span id="trpg-surface-status" class="widget-pill">overview</span>
+        </section>
+
+        <section id="trpg-surface-panels" class="trpg-surface-panels" style="display: none;">
+            <div id="trpg-overview-panel" class="trpg-surface-panel">
+                <div class="trpg-surface-head">
+                    <h3>Overview</h3>
+                    <p>현재 room의 핵심 상태, 경고, 다음 액션을 한 번에 봅니다.</p>
+                </div>
+                <div id="trpg-overview-summary" class="trpg-summary-cards">
+                    <div class="trpg-summary-empty">개요를 불러오는 중입니다.</div>
+                </div>
+                <div id="trpg-overview-alarms" class="trpg-alert-list">
+                    <div class="trpg-summary-empty">알림을 불러오는 중입니다.</div>
+                </div>
+                <div id="trpg-overview-actions" class="trpg-action-list">
+                    <div class="trpg-summary-empty">다음 액션을 계산 중입니다.</div>
+                </div>
+            </div>
+
+            <div id="trpg-timeline-panel" class="trpg-surface-panel">
+                <div class="trpg-surface-head">
+                    <h3>Timeline</h3>
+                    <p>최근 이벤트와 필터 상태를 요약합니다. 자세한 흐름은 Narrative / Session History에서 확인합니다.</p>
+                </div>
+                <div id="trpg-timeline-summary" class="trpg-summary-cards">
+                    <div class="trpg-summary-empty">타임라인 요약을 불러오는 중입니다.</div>
+                </div>
+                <div id="trpg-timeline-events" class="trpg-event-list">
+                    <div class="trpg-summary-empty">최근 이벤트를 불러오는 중입니다.</div>
+                </div>
+            </div>
+
+            <div id="trpg-control-panel" class="trpg-surface-panel">
+                <div class="trpg-surface-head">
+                    <h3>Control</h3>
+                    <p>점유 상태, 개입 이벤트, actor 관리 등 운영 전용 도구를 다룹니다.</p>
+                </div>
+                <div id="trpg-control-summary" class="trpg-summary-cards">
+                    <div class="trpg-summary-empty">제어 상태를 불러오는 중입니다.</div>
+                </div>
+                <div id="trpg-control-warnings" class="trpg-alert-list">
+                    <div class="trpg-summary-empty">운영 경고를 불러오는 중입니다.</div>
+                </div>
+                <div id="trpg-control-actions" class="trpg-action-list">
+                    <div class="trpg-summary-empty">허용된 액션을 계산 중입니다.</div>
+                </div>
 
                 <div class="actor-admin">
                     <div class="actor-admin-head">액터 관리 (현재 room)</div>
@@ -401,10 +460,6 @@
                     <div id="actor-admin-list" class="actor-admin-list"></div>
                 </div>
             </div>
-        </section>
-
-        <section id="room-hub" class="room-hub" style="display: none;">
-            <div class="room-hub-placeholder">방 목록을 불러오는 중...</div>
         </section>
 
         <!-- Main Content Grid -->

--- a/viewer/src/mode/mod.rs
+++ b/viewer/src/mode/mod.rs
@@ -1461,6 +1461,7 @@ pub(super) fn set_current_room_id(doc: &web_sys::Document, room_id: &str) {
     }
     remember_recent_room(&room);
     sync_room_controls(doc, &room);
+    refresh_trpg_ops_snapshots(doc);
 }
 
 #[cfg(target_arch = "wasm32")]
@@ -1481,6 +1482,30 @@ pub(super) fn clear_trpg_dom(doc: &web_sys::Document) {
     }
     if let Some(el) = doc.get_element_by_id("character-panel") {
         el.set_inner_html("");
+    }
+    if let Some(el) = doc.get_element_by_id("trpg-overview-summary") {
+        el.set_inner_html("<div class=\"trpg-summary-empty\">개요를 불러오는 중입니다.</div>");
+    }
+    if let Some(el) = doc.get_element_by_id("trpg-overview-alarms") {
+        el.set_inner_html("<div class=\"trpg-summary-empty\">알림을 불러오는 중입니다.</div>");
+    }
+    if let Some(el) = doc.get_element_by_id("trpg-overview-actions") {
+        el.set_inner_html("<div class=\"trpg-summary-empty\">다음 액션을 계산 중입니다.</div>");
+    }
+    if let Some(el) = doc.get_element_by_id("trpg-control-summary") {
+        el.set_inner_html("<div class=\"trpg-summary-empty\">제어 상태를 불러오는 중입니다.</div>");
+    }
+    if let Some(el) = doc.get_element_by_id("trpg-control-warnings") {
+        el.set_inner_html("<div class=\"trpg-summary-empty\">운영 경고를 불러오는 중입니다.</div>");
+    }
+    if let Some(el) = doc.get_element_by_id("trpg-control-actions") {
+        el.set_inner_html("<div class=\"trpg-summary-empty\">허용된 액션을 계산 중입니다.</div>");
+    }
+    if let Some(el) = doc.get_element_by_id("trpg-timeline-summary") {
+        el.set_inner_html("<div class=\"trpg-summary-empty\">타임라인 요약을 불러오는 중입니다.</div>");
+    }
+    if let Some(el) = doc.get_element_by_id("trpg-timeline-events") {
+        el.set_inner_html("<div class=\"trpg-summary-empty\">최근 이벤트를 불러오는 중입니다.</div>");
     }
     if let Some(el) = doc.get_element_by_id("turn-num") {
         el.set_text_content(Some("1"));
@@ -1746,7 +1771,8 @@ use room_hub::{
 mod trpg_controls;
 #[cfg(target_arch = "wasm32")]
 use trpg_controls::{
-    actor_admin_room_id, actor_admin_set_status, bind_new_game_controls, refresh_actor_admin_list,
+    actor_admin_room_id, actor_admin_set_status, bind_new_game_controls,
+    refresh_actor_admin_list, refresh_trpg_ops_snapshots,
 };
 
 /// Refresh TRPG widget status counters (narrative, party, history, dedup).

--- a/viewer/src/mode/trpg_controls.rs
+++ b/viewer/src/mode/trpg_controls.rs
@@ -210,7 +210,93 @@ impl From<&str> for NewGameFlowStage {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum TrpgSurface {
+    Lobby,
+    Overview,
+    Timeline,
+    Control,
+}
+
+impl TrpgSurface {
+    fn code(self) -> &'static str {
+        match self {
+            Self::Lobby => "lobby",
+            Self::Overview => "overview",
+            Self::Timeline => "timeline",
+            Self::Control => "control",
+        }
+    }
+
+    fn label(self) -> &'static str {
+        match self {
+            Self::Lobby => "lobby",
+            Self::Overview => "overview",
+            Self::Timeline => "timeline",
+            Self::Control => "control",
+        }
+    }
+}
+
+impl From<&str> for TrpgSurface {
+    fn from(raw: &str) -> Self {
+        match raw.trim() {
+            "lobby" => Self::Lobby,
+            "timeline" => Self::Timeline,
+            "control" => Self::Control,
+            _ => Self::Overview,
+        }
+    }
+}
+
 // ─── Helpers (moved from mod.rs, only used here) ────────────────
+
+fn encode_query_component(raw: &str) -> String {
+    js_sys::encode_uri_component(raw)
+        .as_string()
+        .unwrap_or_else(|| raw.to_string())
+}
+
+fn append_query_param(url: &str, key: &str, value: &str) -> String {
+    let sep = if url.contains('?') { '&' } else { '?' };
+    format!(
+        "{url}{sep}{key}={value}",
+        value = encode_query_component(value.trim())
+    )
+}
+
+async fn fetch_trpg_http_json(path: &str, params: &[(&str, String)]) -> Result<Value, String> {
+    let mut url = crate::config::build_masc_url(path);
+    for (key, value) in params {
+        if value.trim().is_empty() {
+            continue;
+        }
+        url = append_query_param(&url, key, value);
+    }
+    let (status, body) = crate::mode::mcp_rpc::http_get_text(&url).await?;
+    if !(200..300).contains(&status) {
+        return Err(format!("HTTP {} 응답", status));
+    }
+    if body.trim().is_empty() {
+        return Ok(json!({}));
+    }
+    serde_json::from_str::<Value>(&body).map_err(|e| format!("JSON 파싱 실패: {}", e))
+}
+
+fn parse_string_list_field(payload: &Value, key: &str) -> Vec<String> {
+    payload
+        .get(key)
+        .and_then(Value::as_array)
+        .map(|rows| {
+            rows.iter()
+                .filter_map(Value::as_str)
+                .map(|value| value.trim().to_string())
+                .filter(|value| !value.is_empty())
+                .collect::<Vec<_>>()
+        })
+        .map(unique_non_empty)
+        .unwrap_or_default()
+}
 
 fn parse_keeper_models(raw: &str) -> Vec<String> {
     unique_non_empty(
@@ -469,6 +555,90 @@ async fn refresh_available_model_candidates(
         set_new_game_model_status(doc, &status_message, "ok");
     }
     Ok(rows)
+}
+
+fn apply_keeper_selectors(doc: &web_sys::Document, keepers: &[String]) -> Result<(), String> {
+    if keepers.is_empty() {
+        if let Some(dm_select) = doc.get_element_by_id("new-game-dm-select") {
+            dm_select.set_inner_html(r#"<option value="">(사용 가능한 keeper 없음)</option>"#);
+        }
+        if let Some(player_select) = doc.get_element_by_id("new-game-player-select") {
+            player_select
+                .set_inner_html(r#"<option value="" disabled>(사용 가능한 keeper 없음)</option>"#);
+        }
+        update_new_game_player_hint(doc);
+        return Ok(());
+    }
+
+    let keeper_actor_map = keeper_actor_map_from_actor_admin_dom(doc);
+
+    let option_label = |name: &str| -> String {
+        let suffix = keeper_actor_map
+            .get(name)
+            .map(|actor_id| format!(" · 점유 {}", actor_id))
+            .unwrap_or_default();
+        format!("{}{}", name, suffix)
+    };
+
+    let previous_dm = doc
+        .get_element_by_id("new-game-dm-select")
+        .and_then(|el| {
+            el.dyn_ref::<web_sys::HtmlSelectElement>()
+                .map(|s| s.value())
+        })
+        .map(|v| v.trim().to_string())
+        .filter(|v| !v.is_empty());
+    let previous_players = selected_player_keepers(doc);
+    let dm_default = previous_dm
+        .filter(|prev| keepers.iter().any(|name| name == prev))
+        .or_else(|| keepers.iter().find(|name| name.starts_with("dm")).cloned())
+        .unwrap_or_else(|| keepers[0].clone());
+
+    if let Some(dm_select) = doc.get_element_by_id("new-game-dm-select") {
+        let html = keepers
+            .iter()
+            .map(|name| {
+                let safe = html_escape(name);
+                let label = html_escape(&option_label(name));
+                format!(r#"<option value="{}">{}</option>"#, safe, label)
+            })
+            .collect::<Vec<_>>()
+            .join("");
+        dm_select.set_inner_html(&html);
+        if let Some(select) = dm_select.dyn_ref::<web_sys::HtmlSelectElement>() {
+            select.set_value(&dm_default);
+        }
+    }
+
+    if let Some(player_select) = doc.get_element_by_id("new-game-player-select") {
+        let preserve_existing_selection = !previous_players.is_empty();
+        let mut default_selected = 0_usize;
+        let mut html = String::new();
+        for name in keepers.iter().filter(|name| **name != dm_default) {
+            let safe = html_escape(name);
+            let label = html_escape(&option_label(name));
+            let selected_attr = if preserve_existing_selection
+                && previous_players.iter().any(|picked| picked == name)
+            {
+                " selected"
+            } else if !preserve_existing_selection && default_selected < 4 {
+                default_selected += 1;
+                " selected"
+            } else {
+                ""
+            };
+            html.push_str(&format!(
+                r#"<option value="{value}"{selected}>{label}</option>"#,
+                value = safe,
+                label = label,
+                selected = selected_attr
+            ));
+        }
+        player_select.set_inner_html(&html);
+    }
+
+    update_new_game_player_hint(doc);
+    Ok(())
 }
 
 fn selected_player_keepers(doc: &web_sys::Document) -> Vec<String> {
@@ -1032,6 +1202,87 @@ fn new_game_wizard_busy(doc: &web_sys::Document) -> bool {
     doc.get_element_by_id("new-game-panel")
         .and_then(|panel| panel.get_attribute("data-wizard-busy"))
         .is_some_and(|flag| flag == "1")
+}
+
+fn current_trpg_surface(doc: &web_sys::Document) -> TrpgSurface {
+    doc.get_element_by_id("dashboard")
+        .and_then(|dashboard| dashboard.get_attribute("data-trpg-surface"))
+        .map(|raw| TrpgSurface::from(raw.as_str()))
+        .unwrap_or(TrpgSurface::Overview)
+}
+
+fn sync_trpg_surface_ui(doc: &web_sys::Document) {
+    let surface = current_trpg_surface(doc);
+    set_element_display(doc, "trpg-surface-nav", "flex");
+    set_element_display(doc, "trpg-surface-panels", "grid");
+    set_element_display(
+        doc,
+        "new-game-panel",
+        if surface == TrpgSurface::Lobby { "flex" } else { "none" },
+    );
+    if surface == TrpgSurface::Lobby {
+        sync_new_game_panel_top_offset(doc);
+    }
+    if let Some(status) = doc.get_element_by_id("trpg-surface-status") {
+        status.set_text_content(Some(surface.label()));
+    }
+    if let Ok(nodes) = doc.query_selector_all(".trpg-surface-tab[data-trpg-surface]") {
+        for idx in 0..nodes.length() {
+            let Some(node) = nodes.item(idx) else { continue };
+            let Some(el) = node.dyn_ref::<web_sys::Element>() else {
+                continue;
+            };
+            let pressed = el
+                .get_attribute("data-trpg-surface")
+                .map(|value| value == surface.code())
+                .unwrap_or(false);
+            let _ = el.set_attribute("aria-pressed", if pressed { "true" } else { "false" });
+        }
+    }
+}
+
+fn set_trpg_surface(doc: &web_sys::Document, surface: TrpgSurface) {
+    if let Some(dashboard) = doc.get_element_by_id("dashboard") {
+        let _ = dashboard.set_attribute("data-trpg-surface", surface.code());
+    }
+    sync_trpg_surface_ui(doc);
+    let trpg_mode_active = doc
+        .body()
+        .map(|body| body.class_name().contains("mode-trpg"))
+        .unwrap_or(false);
+    if trpg_mode_active && surface != TrpgSurface::Lobby {
+        refresh_trpg_ops_snapshots(doc);
+    }
+}
+
+fn bind_trpg_surface_tabs(doc: &web_sys::Document) {
+    let Ok(nodes) = doc.query_selector_all(".trpg-surface-tab[data-trpg-surface]") else {
+        return;
+    };
+    for idx in 0..nodes.length() {
+        let Some(node) = nodes.item(idx) else { continue };
+        let Some(el) = node.dyn_ref::<web_sys::Element>() else {
+            continue;
+        };
+        if el.get_attribute("data-bound").as_deref() == Some("1") {
+            continue;
+        }
+        let _ = el.set_attribute("data-bound", "1");
+        let surface = el
+            .get_attribute("data-trpg-surface")
+            .map(|raw| TrpgSurface::from(raw.as_str()))
+            .unwrap_or(TrpgSurface::Overview);
+        let cb = Closure::wrap(Box::new(move |_event: web_sys::Event| {
+            let Some(doc) = web_sys::window().and_then(|w| w.document()) else {
+                return;
+            };
+            set_trpg_surface(&doc, surface);
+        }) as Box<dyn FnMut(_)>);
+        let _ = el.dyn_ref::<web_sys::EventTarget>().map(|target| {
+            target.add_event_listener_with_callback("click", cb.as_ref().unchecked_ref())
+        });
+        cb.forget();
+    }
 }
 
 fn set_step_state(doc: &web_sys::Document, id: &str, state: &str) {
@@ -1891,89 +2142,7 @@ async fn refresh_keeper_selectors(doc: &web_sys::Document) -> Result<Vec<String>
         }
         keepers = unique_non_empty(fallback);
     }
-    if keepers.is_empty() {
-        if let Some(dm_select) = doc.get_element_by_id("new-game-dm-select") {
-            dm_select.set_inner_html(r#"<option value="">(사용 가능한 keeper 없음)</option>"#);
-        }
-        if let Some(player_select) = doc.get_element_by_id("new-game-player-select") {
-            player_select
-                .set_inner_html(r#"<option value="" disabled>(사용 가능한 keeper 없음)</option>"#);
-        }
-        update_new_game_player_hint(doc);
-        return Ok(Vec::new());
-    }
-
-    let keeper_actor_map = match fetch_room_state_payload(&read_new_game_room_id(doc)).await {
-        Ok(state_payload) => parse_keeper_actor_map(&state_payload),
-        Err(_) => HashMap::new(),
-    };
-
-    let option_label = |name: &str| -> String {
-        let suffix = keeper_actor_map
-            .get(name)
-            .map(|actor_id| format!(" · 점유 {}", actor_id))
-            .unwrap_or_default();
-        format!("{}{}", name, suffix)
-    };
-
-    let previous_dm = doc
-        .get_element_by_id("new-game-dm-select")
-        .and_then(|el| {
-            el.dyn_ref::<web_sys::HtmlSelectElement>()
-                .map(|s| s.value())
-        })
-        .map(|v| v.trim().to_string())
-        .filter(|v| !v.is_empty());
-    let previous_players = selected_player_keepers(doc);
-    let dm_default = previous_dm
-        .filter(|prev| keepers.iter().any(|name| name == prev))
-        .or_else(|| keepers.iter().find(|name| name.starts_with("dm")).cloned())
-        .unwrap_or_else(|| keepers[0].clone());
-
-    if let Some(dm_select) = doc.get_element_by_id("new-game-dm-select") {
-        let html = keepers
-            .iter()
-            .map(|name| {
-                let safe = html_escape(name);
-                let label = html_escape(&option_label(name));
-                format!(r#"<option value="{}">{}</option>"#, safe, label)
-            })
-            .collect::<Vec<_>>()
-            .join("");
-        dm_select.set_inner_html(&html);
-        if let Some(select) = dm_select.dyn_ref::<web_sys::HtmlSelectElement>() {
-            select.set_value(&dm_default);
-        }
-    }
-
-    if let Some(player_select) = doc.get_element_by_id("new-game-player-select") {
-        let preserve_existing_selection = !previous_players.is_empty();
-        let mut default_selected = 0_usize;
-        let mut html = String::new();
-        for name in keepers.iter().filter(|name| **name != dm_default) {
-            let safe = html_escape(name);
-            let label = html_escape(&option_label(name));
-            let selected_attr = if preserve_existing_selection
-                && previous_players.iter().any(|picked| picked == name)
-            {
-                " selected"
-            } else if !preserve_existing_selection && default_selected < 4 {
-                default_selected += 1;
-                " selected"
-            } else {
-                ""
-            };
-            html.push_str(&format!(
-                r#"<option value="{value}"{selected}>{label}</option>"#,
-                value = safe,
-                label = label,
-                selected = selected_attr
-            ));
-        }
-        player_select.set_inner_html(&html);
-    }
-
-    update_new_game_player_hint(doc);
+    apply_keeper_selectors(doc, &keepers)?;
     Ok(keepers)
 }
 
@@ -2130,6 +2299,459 @@ async fn fetch_room_state_payload(room_id: &str) -> Result<Value, String> {
         return Ok(json!({}));
     }
     serde_json::from_str::<Value>(&body).map_err(|e| format!("state JSON 파싱 실패: {}", e))
+}
+
+fn truncate_text(raw: &str, limit: usize) -> String {
+    let text = raw.trim();
+    if text.chars().count() <= limit {
+        return text.to_string();
+    }
+    let mut out = text.chars().take(limit.saturating_sub(1)).collect::<String>();
+    out.push('…');
+    out
+}
+
+fn render_summary_cards(
+    doc: &web_sys::Document,
+    element_id: &str,
+    cards: &[(String, String, String)],
+) {
+    let Some(el) = doc.get_element_by_id(element_id) else {
+        return;
+    };
+    if cards.is_empty() {
+        el.set_inner_html("<div class=\"trpg-summary-empty\">표시할 요약이 없습니다.</div>");
+        return;
+    }
+    let html = cards
+        .iter()
+        .map(|(label, value, meta)| {
+            format!(
+                concat!(
+                    "<div class=\"trpg-summary-card\">",
+                    "<div class=\"trpg-summary-card-label\">{label}</div>",
+                    "<div class=\"trpg-summary-card-value\">{value}</div>",
+                    "<div class=\"trpg-summary-card-meta\">{meta}</div>",
+                    "</div>"
+                ),
+                label = html_escape(label),
+                value = html_escape(value),
+                meta = html_escape(meta),
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("");
+    el.set_inner_html(&html);
+}
+
+fn render_text_list(
+    doc: &web_sys::Document,
+    element_id: &str,
+    class_name: &str,
+    rows: &[String],
+) {
+    let Some(el) = doc.get_element_by_id(element_id) else {
+        return;
+    };
+    if rows.is_empty() {
+        el.set_inner_html("<div class=\"trpg-summary-empty\">표시할 항목이 없습니다.</div>");
+        return;
+    }
+    let html = rows
+        .iter()
+        .map(|row| {
+            format!(
+                "<div class=\"{class_name}\">{}</div>",
+                html_escape(row)
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("");
+    el.set_inner_html(&html);
+}
+
+fn render_alert_items(doc: &web_sys::Document, element_id: &str, alarms: &[Value]) {
+    let Some(el) = doc.get_element_by_id(element_id) else {
+        return;
+    };
+    if alarms.is_empty() {
+        el.set_inner_html("<div class=\"trpg-summary-empty\">활성 알림이 없습니다.</div>");
+        return;
+    }
+    let html = alarms
+        .iter()
+        .map(|alarm| {
+            let level = alarm
+                .get("level")
+                .and_then(Value::as_str)
+                .unwrap_or("info")
+                .trim()
+                .to_string();
+            let code = alarm
+                .get("code")
+                .and_then(Value::as_str)
+                .unwrap_or("info")
+                .trim()
+                .to_string();
+            let message = alarm
+                .get("message")
+                .and_then(Value::as_str)
+                .unwrap_or("알림 세부 정보를 읽지 못했습니다.")
+                .trim()
+                .to_string();
+            format!(
+                concat!(
+                    "<div class=\"trpg-alert-item\" data-level=\"{level}\">",
+                    "<div class=\"trpg-alert-code\">{code}</div>",
+                    "<div>{message}</div>",
+                    "</div>"
+                ),
+                level = html_escape(&level),
+                code = html_escape(&code),
+                message = html_escape(&message),
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("");
+    el.set_inner_html(&html);
+}
+
+fn render_event_items(doc: &web_sys::Document, element_id: &str, events: &[Value]) {
+    let Some(el) = doc.get_element_by_id(element_id) else {
+        return;
+    };
+    if events.is_empty() {
+        el.set_inner_html("<div class=\"trpg-summary-empty\">최근 이벤트가 없습니다.</div>");
+        return;
+    }
+    let html = events
+        .iter()
+        .map(|event| {
+            let event_type = event
+                .get("type")
+                .and_then(Value::as_str)
+                .unwrap_or("event")
+                .trim()
+                .to_string();
+            let actor = event
+                .get("actor_id")
+                .and_then(Value::as_str)
+                .unwrap_or("")
+                .trim()
+                .to_string();
+            let seq = event.get("seq").and_then(Value::as_i64).unwrap_or_default();
+            let ts = event
+                .get("ts")
+                .and_then(Value::as_str)
+                .unwrap_or("")
+                .trim()
+                .to_string();
+            let payload_preview = event
+                .get("payload")
+                .map(|payload| truncate_text(&payload.to_string(), 120))
+                .unwrap_or_default();
+            let meta = if actor.is_empty() {
+                format!("#{} · {}", seq, ts)
+            } else {
+                format!("#{} · {} · actor {}", seq, ts, actor)
+            };
+            format!(
+                concat!(
+                    "<div class=\"trpg-event-item\">",
+                    "<div class=\"trpg-event-type\">{event_type}</div>",
+                    "<div class=\"trpg-event-meta\">{meta}</div>",
+                    "<div>{payload}</div>",
+                    "</div>"
+                ),
+                event_type = html_escape(&event_type),
+                meta = html_escape(&meta),
+                payload = html_escape(&payload_preview),
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("");
+    el.set_inner_html(&html);
+}
+
+fn render_trpg_overview_panel(doc: &web_sys::Document, payload: &Value) {
+    let summary = payload.get("summary").unwrap_or(&Value::Null);
+    let cards = vec![
+        (
+            "Status".to_string(),
+            summary
+                .get("status")
+                .and_then(Value::as_str)
+                .unwrap_or("unknown")
+                .to_string(),
+            format!(
+                "turn {} · phase {}",
+                summary.get("turn").and_then(Value::as_i64).unwrap_or_default(),
+                summary
+                    .get("phase")
+                    .and_then(Value::as_str)
+                    .unwrap_or("unknown")
+            ),
+        ),
+        (
+            "Scenario".to_string(),
+            summary
+                .get("scenario")
+                .and_then(Value::as_str)
+                .filter(|value| !value.trim().is_empty())
+                .unwrap_or("미지정")
+                .to_string(),
+            summary
+                .get("node")
+                .and_then(Value::as_str)
+                .filter(|value| !value.trim().is_empty())
+                .unwrap_or("node 정보 없음")
+                .to_string(),
+        ),
+        (
+            "Players".to_string(),
+            summary
+                .get("player_count")
+                .and_then(Value::as_i64)
+                .unwrap_or_default()
+                .to_string(),
+            format!(
+                "alive {} · claimed {}",
+                summary
+                    .get("alive_players")
+                    .and_then(Value::as_i64)
+                    .unwrap_or_default(),
+                summary
+                    .get("claimed_players")
+                    .and_then(Value::as_i64)
+                    .unwrap_or_default()
+            ),
+        ),
+        (
+            "Keepers".to_string(),
+            summary
+                .get("active_keepers")
+                .and_then(Value::as_i64)
+                .unwrap_or_default()
+                .to_string(),
+            format!(
+                "unclaimed {}",
+                summary
+                    .get("unclaimed_players")
+                    .and_then(Value::as_i64)
+                    .unwrap_or_default()
+            ),
+        ),
+    ];
+    render_summary_cards(doc, "trpg-overview-summary", &cards);
+    let alarms = payload
+        .get("alarms")
+        .and_then(Value::as_array)
+        .cloned()
+        .unwrap_or_default();
+    render_alert_items(doc, "trpg-overview-alarms", &alarms);
+    let next_actions = payload
+        .get("next_actions")
+        .and_then(Value::as_array)
+        .map(|rows| {
+            rows.iter()
+                .filter_map(Value::as_str)
+                .map(|item| item.trim().to_string())
+                .filter(|item| !item.is_empty())
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default();
+    render_text_list(doc, "trpg-overview-actions", "trpg-action-item", &next_actions);
+}
+
+fn render_trpg_control_panel(doc: &web_sys::Document, payload: &Value) {
+    let summary = payload.get("summary").unwrap_or(&Value::Null);
+    let actor_control = payload
+        .get("actor_control")
+        .and_then(Value::as_array)
+        .cloned()
+        .unwrap_or_default();
+    let cards = vec![
+        (
+            "State".to_string(),
+            summary
+                .get("status")
+                .and_then(Value::as_str)
+                .unwrap_or("unknown")
+                .to_string(),
+            format!(
+                "turn {} · phase {}",
+                summary.get("turn").and_then(Value::as_i64).unwrap_or_default(),
+                summary
+                    .get("phase")
+                    .and_then(Value::as_str)
+                    .unwrap_or("unknown")
+            ),
+        ),
+        (
+            "Claims".to_string(),
+            actor_control.len().to_string(),
+            "현재 점유 actor 수".to_string(),
+        ),
+        (
+            "Join Gate".to_string(),
+            if summary
+                .get("join_window_open")
+                .and_then(Value::as_bool)
+                .unwrap_or(false)
+            {
+                "open"
+            } else {
+                "closed"
+            }
+            .to_string(),
+            format!(
+                "min points {}",
+                summary
+                    .get("join_gate_min_points")
+                    .and_then(Value::as_i64)
+                    .unwrap_or_default()
+            ),
+        ),
+    ];
+    render_summary_cards(doc, "trpg-control-summary", &cards);
+    let warning_rows = payload
+        .get("warnings")
+        .and_then(Value::as_array)
+        .map(|rows| {
+            rows.iter()
+                .filter_map(Value::as_str)
+                .map(|item| item.trim().to_string())
+                .filter(|item| !item.is_empty())
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default();
+    render_text_list(doc, "trpg-control-warnings", "trpg-alert-item", &warning_rows);
+    let actions = payload
+        .get("allowed_actions")
+        .and_then(Value::as_array)
+        .cloned()
+        .unwrap_or_default();
+    let action_rows = actions
+        .iter()
+        .map(|row| {
+            let label = row
+                .get("label")
+                .and_then(Value::as_str)
+                .unwrap_or("액션")
+                .trim()
+                .to_string();
+            let enabled = row.get("enabled").and_then(Value::as_bool).unwrap_or(false);
+            let reason = row
+                .get("reason")
+                .and_then(Value::as_str)
+                .unwrap_or("")
+                .trim()
+                .to_string();
+            if enabled {
+                format!("{} · 가능 · {}", label, reason)
+            } else {
+                format!("{} · 잠김 · {}", label, reason)
+            }
+        })
+        .collect::<Vec<_>>();
+    render_text_list(doc, "trpg-control-actions", "trpg-action-item", &action_rows);
+}
+
+fn render_trpg_timeline_panel(doc: &web_sys::Document, payload: &Value) {
+    let filters = payload.get("filters").unwrap_or(&Value::Null);
+    let cards = vec![
+        (
+            "Count".to_string(),
+            payload
+                .get("count")
+                .and_then(Value::as_i64)
+                .unwrap_or_default()
+                .to_string(),
+            format!(
+                "last seq {}",
+                payload
+                    .get("last_seq")
+                    .and_then(Value::as_i64)
+                    .unwrap_or_default()
+            ),
+        ),
+        (
+            "Actor Filter".to_string(),
+            filters
+                .get("actor")
+                .and_then(Value::as_str)
+                .filter(|value| !value.trim().is_empty())
+                .unwrap_or("all")
+                .to_string(),
+            "timeline actor filter".to_string(),
+        ),
+        (
+            "Phase Filter".to_string(),
+            filters
+                .get("phase")
+                .and_then(Value::as_str)
+                .filter(|value| !value.trim().is_empty())
+                .unwrap_or("all")
+                .to_string(),
+            "phase slice".to_string(),
+        ),
+    ];
+    render_summary_cards(doc, "trpg-timeline-summary", &cards);
+    let events = payload
+        .get("events")
+        .and_then(Value::as_array)
+        .cloned()
+        .unwrap_or_default();
+    render_event_items(doc, "trpg-timeline-events", &events);
+}
+
+async fn refresh_trpg_ops_snapshots_inner(doc: &web_sys::Document) -> Result<(), String> {
+    let room_id = crate::config::current_room_id();
+    if room_id.trim().is_empty() {
+        return Ok(());
+    }
+    let overview = fetch_trpg_http_json(
+        "api/v1/trpg/overview",
+        &[("room_id", room_id.clone())],
+    )
+    .await?;
+    render_trpg_overview_panel(doc, &overview);
+
+    let control = fetch_trpg_http_json(
+        "api/v1/trpg/control/state",
+        &[("room_id", room_id.clone())],
+    )
+    .await?;
+    render_trpg_control_panel(doc, &control);
+
+    let timeline = fetch_trpg_http_json(
+        "api/v1/trpg/timeline",
+        &[("room_id", room_id), ("limit", "8".to_string())],
+    )
+    .await?;
+    render_trpg_timeline_panel(doc, &timeline);
+    Ok(())
+}
+
+pub(super) fn refresh_trpg_ops_snapshots(doc: &web_sys::Document) {
+    let doc = doc.clone();
+    wasm_bindgen_futures::spawn_local(async move {
+        if let Err(err) = refresh_trpg_ops_snapshots_inner(&doc).await {
+            log::warn!("TRPG ops snapshot refresh failed: {}", err);
+            render_text_list(
+                &doc,
+                "trpg-overview-actions",
+                "trpg-action-item",
+                &[format!("개요 새로고침 실패: {}", err)],
+            );
+            render_text_list(
+                &doc,
+                "trpg-control-warnings",
+                "trpg-alert-item",
+                &[format!("control state 조회 실패: {}", err)],
+            );
+        }
+    });
 }
 
 fn summarize_preflight_items(items: &[String], limit: usize) -> String {
@@ -2493,7 +3115,71 @@ pub(super) async fn refresh_actor_admin_list(
     Ok(rows)
 }
 
+fn preset_options_from_payload_list(payload: &Value, key: &str) -> Vec<PresetOption> {
+    payload
+        .get(key)
+        .and_then(Value::as_array)
+        .map(|rows| {
+            rows.iter()
+                .filter_map(preset_option_from_value)
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default()
+}
+
 async fn refresh_new_game_bootstrap(doc: &web_sys::Document) -> Result<NewGameBootstrap, String> {
+    let room_id = read_new_game_room_id(doc);
+    if let Ok(payload) = fetch_trpg_http_json(
+        "api/v1/trpg/lobby/catalog",
+        &[("room_id", room_id.clone())],
+    )
+    .await
+    {
+        let keepers = parse_string_list_field(&payload, "keepers");
+        let world_presets = preset_options_from_payload_list(&payload, "world_presets");
+        let dm_presets = preset_options_from_payload_list(&payload, "dm_presets");
+        let _ = apply_keeper_selectors(doc, &keepers);
+        if !world_presets.is_empty() {
+            let _ = select_options_set(doc, "new-game-world-select", &world_presets);
+        }
+        if !dm_presets.is_empty() {
+            let _ = select_options_set(doc, "new-game-dm-preset-select", &dm_presets);
+        }
+        let model_payload = payload.get("model_catalog").cloned().unwrap_or_else(|| json!({}));
+        let model_candidates = parse_available_model_candidates(&model_payload);
+        if !model_candidates.is_empty() {
+            render_available_model_candidates(doc, &model_candidates);
+            bind_available_model_chip_clicks(doc);
+            sync_available_model_chip_selection(doc);
+            let effective = parse_effective_model_specs(&model_payload);
+            let warnings = parse_string_list_field(&model_payload, "warnings");
+            let mut status_message = if effective.is_empty() {
+                format!("가용 모델 {}개", model_candidates.len())
+            } else {
+                format!(
+                    "가용 모델 {}개 · runtime {}",
+                    model_candidates.len(),
+                    effective.join(", ")
+                )
+            };
+            if !warnings.is_empty() {
+                status_message.push_str(" · 일부 endpoint 조회 실패");
+                set_new_game_model_status(doc, &status_message, "warn");
+            } else {
+                set_new_game_model_status(doc, &status_message, "ok");
+            }
+        }
+        if let Err(err) = refresh_actor_admin_list(doc).await {
+            actor_admin_set_status(doc, &format!("액터 목록 로드 실패: {}", err), "status-warn");
+        }
+        return Ok(NewGameBootstrap {
+            keepers,
+            world_presets,
+            dm_presets,
+            model_candidates,
+        });
+    }
+
     let keepers = refresh_keeper_selectors(doc).await?;
     let (world_presets, dm_presets) = refresh_preset_selectors(doc).await?;
     let model_candidates = match refresh_available_model_candidates(doc).await {
@@ -2557,6 +3243,91 @@ async fn run_new_game_preflight(doc: &web_sys::Document) -> Result<(), String> {
         );
         sync_new_game_wizard_ui(doc);
         return Err("MASC 서버 연결 실패".to_string());
+    }
+
+    let room_id = read_new_game_room_id(doc);
+    let dm_keeper = selected_dm_keeper(doc);
+    let player_keepers = selected_player_keepers(doc);
+    let models = read_new_game_model_specs(doc);
+    if let Ok(payload) = fetch_trpg_http_json(
+        "api/v1/trpg/lobby/preflight",
+        &[
+            ("room_id", room_id.clone()),
+            ("dm", dm_keeper),
+            ("players", player_keepers.join(",")),
+            ("models", models.join(",")),
+        ],
+    )
+    .await
+    {
+        let endpoint_rows = payload
+            .get("checks")
+            .and_then(Value::as_array)
+            .map(|checks| {
+                checks
+                    .iter()
+                    .map(|row| PreflightRow {
+                        ok: row.get("ok").and_then(Value::as_bool).unwrap_or(false),
+                        label: row
+                            .get("label")
+                            .and_then(Value::as_str)
+                            .unwrap_or("check")
+                            .to_string(),
+                        detail: row
+                            .get("detail")
+                            .and_then(Value::as_str)
+                            .unwrap_or("")
+                            .to_string(),
+                        hint: row
+                            .get("hint")
+                            .and_then(Value::as_str)
+                            .map(|value| value.to_string()),
+                    })
+                    .collect::<Vec<_>>()
+            })
+            .unwrap_or_default();
+        if !endpoint_rows.is_empty() {
+            set_new_game_preflight_rows(doc, &endpoint_rows);
+            let ready = payload.get("ready").and_then(Value::as_bool).unwrap_or(false);
+            let warnings = parse_string_list_field(&payload, "warnings");
+            let blocking = parse_string_list_field(&payload, "blocking");
+            let recommended = parse_string_list_field(&payload, "recommended_actions");
+            let status_parts = [
+                if ready {
+                    Some("사전 점검 통과".to_string())
+                } else {
+                    Some("차단 항목 존재".to_string())
+                },
+                (!warnings.is_empty())
+                    .then(|| format!("경고 {}", summarize_preflight_items(&warnings, 2))),
+                (!blocking.is_empty())
+                    .then(|| format!("차단 {}", summarize_preflight_items(&blocking, 2))),
+                (!recommended.is_empty()).then(|| {
+                    format!("추천 {}", summarize_preflight_items(&recommended, 2))
+                }),
+            ]
+            .into_iter()
+            .flatten()
+            .collect::<Vec<_>>()
+            .join(" · ");
+            set_new_game_preflight_status(doc, &status_parts);
+            set_new_game_preflight_state(doc, if ready { "ok" } else { "fail" });
+            if ready {
+                set_new_game_flow_stage(doc, NewGameFlowStage::Idle, Some("사전 점검 통과"));
+            } else {
+                set_new_game_flow_stage(
+                    doc,
+                    NewGameFlowStage::Failed,
+                    Some("사전 점검 실패 항목 존재"),
+                );
+            }
+            sync_new_game_wizard_ui(doc);
+            return if ready {
+                Ok(())
+            } else {
+                Err("사전 점검 실패 항목이 있습니다.".to_string())
+            };
+        }
     }
 
     let preset_row = match fetch_preset_catalog().await {
@@ -4013,7 +4784,7 @@ pub(super) fn bind_new_game_controls(doc: &web_sys::Document) {
             return;
         };
         sync_new_game_panel_top_offset(&doc);
-        set_element_display(&doc, "new-game-panel", "flex");
+        set_trpg_surface(&doc, TrpgSurface::Lobby);
         if let Some(room_input) = doc
             .get_element_by_id("new-game-room-id")
             .and_then(|el| el.dyn_into::<web_sys::HtmlInputElement>().ok())
@@ -4098,7 +4869,7 @@ pub(super) fn bind_new_game_controls(doc: &web_sys::Document) {
             };
             set_new_game_wizard_busy(&doc, false);
             set_new_game_flow_stage(&doc, NewGameFlowStage::Idle, Some("패널 닫힘"));
-            set_element_display(&doc, "new-game-panel", "none");
+            set_trpg_surface(&doc, TrpgSurface::Overview);
         }) as Box<dyn FnMut()>);
         let _ = close_btn.dyn_ref::<web_sys::EventTarget>().map(|target| {
             target.add_event_listener_with_callback("click", close_cb.as_ref().unchecked_ref())
@@ -4376,7 +5147,7 @@ pub(super) fn bind_new_game_controls(doc: &web_sys::Document) {
                             Some("빠른 시작 완료"),
                         );
                         set_new_game_status(&doc_for_start, &message);
-                        set_element_display(&doc_for_start, "new-game-panel", "none");
+                        set_trpg_surface(&doc_for_start, TrpgSurface::Overview);
                     }
                     Err(e) => {
                         set_new_game_flow_stage(&doc_for_start, NewGameFlowStage::Failed, Some(&e));
@@ -4430,7 +5201,7 @@ pub(super) fn bind_new_game_controls(doc: &web_sys::Document) {
                             Some("세션 시작 완료"),
                         );
                         set_new_game_status(&doc_for_start, &message);
-                        set_element_display(&doc_for_start, "new-game-panel", "none");
+                        set_trpg_surface(&doc_for_start, TrpgSurface::Overview);
                     }
                     Err(e) => {
                         set_new_game_flow_stage(&doc_for_start, NewGameFlowStage::Failed, Some(&e));
@@ -4449,7 +5220,17 @@ pub(super) fn bind_new_game_controls(doc: &web_sys::Document) {
 
     bind_new_game_selection_watchers(doc);
     bind_new_game_model_watchers(doc);
+    bind_trpg_surface_tabs(doc);
     set_new_game_flow_stage(doc, NewGameFlowStage::Idle, Some("대기"));
+    if doc
+        .get_element_by_id("dashboard")
+        .and_then(|dashboard| dashboard.get_attribute("data-trpg-surface"))
+        .is_none()
+    {
+        set_trpg_surface(doc, TrpgSurface::Overview);
+    } else {
+        sync_trpg_surface_ui(doc);
+    }
     sync_new_game_wizard_ui(doc);
     bind_actor_admin_controls(doc);
 }

--- a/viewer/src/mode/trpg_controls.rs
+++ b/viewer/src/mode/trpg_controls.rs
@@ -2715,6 +2715,9 @@ async fn refresh_trpg_ops_snapshots_inner(doc: &web_sys::Document) -> Result<(),
         &[("room_id", room_id.clone())],
     )
     .await?;
+    if crate::config::current_room_id() != room_id {
+        return Ok(());
+    }
     render_trpg_overview_panel(doc, &overview);
 
     let control = fetch_trpg_http_json(
@@ -2722,13 +2725,19 @@ async fn refresh_trpg_ops_snapshots_inner(doc: &web_sys::Document) -> Result<(),
         &[("room_id", room_id.clone())],
     )
     .await?;
+    if crate::config::current_room_id() != room_id {
+        return Ok(());
+    }
     render_trpg_control_panel(doc, &control);
 
     let timeline = fetch_trpg_http_json(
         "api/v1/trpg/timeline",
-        &[("room_id", room_id), ("limit", "8".to_string())],
+        &[("room_id", room_id.clone()), ("limit", "8".to_string())],
     )
     .await?;
+    if crate::config::current_room_id() != room_id {
+        return Ok(());
+    }
     render_trpg_timeline_panel(doc, &timeline);
     Ok(())
 }

--- a/viewer/style.css
+++ b/viewer/style.css
@@ -3514,6 +3514,165 @@ body.wasm-dom-fallback #bevy-canvas {
     min-height: 100%;
 }
 
+.trpg-surface-nav {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 10px 14px 0 14px;
+}
+
+.trpg-surface-tab {
+    border: 1px solid rgba(196, 162, 101, 0.22);
+    border-radius: 999px;
+    background: rgba(10, 16, 22, 0.72);
+    color: var(--text-secondary);
+    cursor: pointer;
+    font-family: var(--font-ui);
+    font-size: 0.72rem;
+    letter-spacing: 0.08em;
+    padding: 6px 12px;
+    text-transform: uppercase;
+}
+
+.trpg-surface-tab[aria-pressed="true"] {
+    border-color: rgba(196, 162, 101, 0.62);
+    background: rgba(196, 162, 101, 0.16);
+    color: var(--accent-primary);
+}
+
+#trpg-surface-status {
+    margin-left: auto;
+}
+
+.trpg-surface-panels {
+    display: grid;
+    gap: 12px;
+    padding: 12px 14px 0 14px;
+}
+
+.trpg-surface-panel {
+    display: none;
+    gap: 12px;
+    padding: 14px;
+    border: 1px solid rgba(196, 162, 101, 0.16);
+    border-radius: 12px;
+    background: linear-gradient(180deg, rgba(7, 12, 17, 0.94), rgba(10, 16, 21, 0.82));
+    box-shadow: 0 12px 32px rgba(0, 0, 0, 0.28);
+}
+
+.trpg-surface-head {
+    display: grid;
+    gap: 4px;
+}
+
+.trpg-surface-head h3 {
+    margin: 0;
+    color: var(--text-bright);
+    font-family: var(--font-display);
+    font-size: 0.98rem;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+}
+
+.trpg-surface-head p {
+    margin: 0;
+    color: var(--text-dim);
+    font-size: 0.78rem;
+    line-height: 1.45;
+}
+
+.trpg-summary-cards {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+    gap: 10px;
+}
+
+.trpg-summary-card {
+    display: grid;
+    gap: 6px;
+    padding: 12px;
+    border: 1px solid rgba(196, 162, 101, 0.12);
+    border-radius: 10px;
+    background: rgba(17, 24, 34, 0.72);
+}
+
+.trpg-summary-card-label {
+    color: var(--text-dim);
+    font-size: 0.68rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+}
+
+.trpg-summary-card-value {
+    color: var(--text-bright);
+    font-size: 1rem;
+    font-weight: 600;
+}
+
+.trpg-summary-card-meta {
+    color: var(--text-secondary);
+    font-size: 0.72rem;
+    line-height: 1.4;
+}
+
+.trpg-summary-empty {
+    padding: 10px 12px;
+    border: 1px dashed rgba(196, 162, 101, 0.18);
+    border-radius: 10px;
+    color: var(--text-dim);
+    font-size: 0.76rem;
+}
+
+.trpg-alert-list,
+.trpg-action-list,
+.trpg-event-list {
+    display: grid;
+    gap: 8px;
+}
+
+.trpg-alert-item,
+.trpg-action-item,
+.trpg-event-item {
+    display: grid;
+    gap: 4px;
+    padding: 10px 12px;
+    border: 1px solid rgba(196, 162, 101, 0.14);
+    border-radius: 10px;
+    background: rgba(14, 20, 29, 0.7);
+    color: var(--text-secondary);
+    font-size: 0.76rem;
+    line-height: 1.45;
+}
+
+.trpg-alert-item[data-level="error"] {
+    border-color: rgba(214, 127, 127, 0.3);
+    background: rgba(74, 24, 24, 0.28);
+}
+
+.trpg-alert-item[data-level="warn"] {
+    border-color: rgba(196, 162, 101, 0.3);
+    background: rgba(79, 58, 22, 0.24);
+}
+
+.trpg-alert-code,
+.trpg-event-type {
+    color: var(--accent-primary);
+    font-size: 0.68rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+}
+
+.trpg-event-meta {
+    color: var(--text-dim);
+    font-size: 0.7rem;
+}
+
+#dashboard[data-trpg-surface="overview"] #trpg-overview-panel,
+#dashboard[data-trpg-surface="timeline"] #trpg-timeline-panel,
+#dashboard[data-trpg-surface="control"] #trpg-control-panel {
+    display: grid;
+}
+
 #new-game-panel {
     position: absolute;
     inset: var(--new-game-panel-top, 44px) 0 0 0;
@@ -3524,6 +3683,10 @@ body.wasm-dom-fallback #bevy-canvas {
     justify-content: center;
     padding: 28px 12px 12px 12px;
     overflow-y: auto;
+}
+
+#dashboard[data-trpg-surface="lobby"] #new-game-panel {
+    display: flex;
 }
 
 .new-game-card {


### PR DESCRIPTION
## Summary
- add TRPG ops read-model endpoints for lobby catalog, preflight, overview, control state, and timeline
- split the viewer into Lobby / Overview / Timeline / Control surfaces and move actor admin into the control surface
- switch the viewer to prefer the new aggregated TRPG endpoints while keeping the existing bootstrap and preflight fallback paths

## Validation
- cargo check
- dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/feat-trpg-ops-console-v1
- local HTTP smoke on port 8945 for /api/v1/trpg/lobby/catalog, /lobby/preflight, /overview, /control/state, and /timeline