### PR TITLE
Add swarm self-upgrade batch llama roster

### DIFF
--- a/bin/main_eio.ml
+++ b/bin/main_eio.ml
@@ -4744,6 +4744,16 @@ let env_flag name =
       | _ -> false)
   | None -> false
 
+let header_truthy_value value =
+  match String.lowercase_ascii (String.trim value) with
+  | "1" | "true" | "yes" | "on" -> true
+  | _ -> false
+
+let request_force_json_response (request : Httpun.Request.t) =
+  match get_header_any_case request.headers "x-masc-force-json" with
+  | Some value -> header_truthy_value value
+  | None -> false
+
 (** Compatibility mode for legacy Accept headers (default: strict off). *)
 let allow_legacy_accept = env_flag "MASC_ALLOW_LEGACY_ACCEPT"
 
@@ -5482,7 +5492,11 @@ let handle_post_mcp ?(profile = Mcp_eio.Full) request reqd =
                 let protocol_version =
                   get_protocol_version_for_session ~session_id request
                 in
-                let wants_sse = accepts_sse request && not force_json_response in
+                let wants_sse =
+                  accepts_sse request
+                  && not force_json_response
+                  && not (request_force_json_response request)
+                in
                 if wants_sse then begin
                   match response_json with
                   | `Null ->

--- a/lib/local_agent_eio.ml
+++ b/lib/local_agent_eio.ml
@@ -138,6 +138,8 @@ let call_jsonrpc ~sw ~(auth_token : string option) ~session_id ~(method_name : s
       "-H";
       "accept: application/json, text/event-stream";
       "-H";
+      "x-masc-force-json: 1";
+      "-H";
       ("mcp-session-id: " ^ session_id);
     ]
     @
@@ -191,11 +193,22 @@ let call_masc_tool ~sw ~(auth_token : string option) ~session_id ~tool_name
       in
       Ok { text = extract_tool_text json; is_error }
 
-let list_masc_tools ~sw ~(auth_token : string option) ~session_id () :
+let list_masc_tools ~sw ~(auth_token : string option) ~session_id
+    ?(names : string list option = None) () :
     (Types.tool_schema list, string) result =
   let open Yojson.Safe.Util in
+  let params =
+    match names with
+    | None -> `Assoc []
+    | Some values ->
+        `Assoc
+          [
+            ( "names",
+              `List (List.map (fun value -> `String value) values) );
+          ]
+  in
   match call_jsonrpc ~sw ~auth_token ~session_id ~method_name:"tools/list"
-          ~params:(`Assoc [])
+          ~params
   with
   | Error e -> Error e
   | Ok json ->
@@ -373,7 +386,10 @@ let run_worker ~sw ~base_path ~worker_name ~model ~team_session_id ~role
             allowed_tools |> List.map strip_mcp_prefix |> unique_preserve_order
           in
           let listed_schemas =
-            match list_masc_tools ~sw ~auth_token ~session_id:mcp_session_id () with
+            match
+              list_masc_tools ~sw ~auth_token ~session_id:mcp_session_id
+                ~names:(Some allowed_names) ()
+            with
             | Ok schemas -> schemas
             | Error e -> raise (Failure ("tools/list failed: " ^ e))
           in

--- a/lib/mcp_server_eio.ml
+++ b/lib/mcp_server_eio.ml
@@ -3018,6 +3018,27 @@ let tool_json_for_profile profile (schema : Types.tool_schema) =
   | Some annotations -> `Assoc (base @ [ ("annotations", annotations) ])
   | None -> `Assoc base
 
+let requested_tool_names params =
+  let open Yojson.Safe.Util in
+  match params with
+  | None -> Ok None
+  | Some (`Assoc _ as payload) -> (
+      match payload |> member "names" with
+      | `Null -> Ok None
+      | `List items ->
+          items
+          |> List.fold_left
+               (fun acc item ->
+                 match (acc, item) with
+                 | Error _ as err, _ -> err
+                 | Ok names, `String value -> Ok (value :: names)
+                 | Ok _, _ ->
+                     Error "Invalid params: names must be an array of strings")
+               (Ok [])
+          |> Result.map (fun names -> Some (List.rev names))
+      | _ -> Error "Invalid params: names must be an array of strings")
+  | Some _ -> Error "Invalid params: expected object"
+
 let handle_initialize_eio ?(profile = Full) id params =
   match validate_initialize_params params with
   | Error msg -> make_error ~id (-32602) msg
@@ -3032,9 +3053,14 @@ let handle_initialize_eio ?(profile = Full) id params =
         ("instructions", `String (match profile with Full -> default_instructions | Operator_remote -> operator_remote_instructions));
       ])
 
-let handle_list_tools_eio ?(profile = Full) state id =
+let handle_list_tools_eio ?(profile = Full) ?names state id =
   let tools =
     tool_schemas_for_profile state profile
+    |> (match names with
+       | None -> Fun.id
+       | Some wanted ->
+           List.filter (fun (schema : Types.tool_schema) ->
+             List.mem schema.name wanted))
     |> List.map (tool_json_for_profile profile)
   in
   make_response ~id (`Assoc [("tools", `List tools)])
@@ -3091,7 +3117,11 @@ let handle_request ~clock ~sw ?(profile = Full) ?mcp_session_id ?auth_token stat
                        handle_read_resource_eio state id req.params
                    | "resources/templates/list" -> handle_list_resource_templates_eio id
                    | "prompts/list" -> handle_list_prompts_eio id
-                   | "tools/list" -> handle_list_tools_eio ~profile state id
+                   | "tools/list" -> (
+                       match requested_tool_names req.params with
+                       | Error msg -> make_error ~id (-32602) msg
+                       | Ok names ->
+                           handle_list_tools_eio ~profile ?names state id)
                    | "tools/call" ->
                        (match req.params with
                        | Some params ->

--- a/lib/spawn_eio.ml
+++ b/lib/spawn_eio.ml
@@ -91,6 +91,11 @@ let masc_mcp_tools = [
   "mcp__masc__masc_heartbeat_list";
 ]
 
+let llama_mcp_tools = [
+  "mcp__masc__masc_team_session_status";
+  "mcp__masc__masc_team_session_turn";
+]
+
 let masc_lifecycle_suffix = {| 
 --- 
 [MASC LIFECYCLE PROTOCOL - Auto-injected] 
@@ -796,7 +801,7 @@ let spawn ~sw ~proc_mgr ~agent_name ~prompt ?timeout_seconds ?working_dir
            Local_agent_eio.run_worker ~sw ~base_path ~worker_name ~model
              ~team_session_id:runtime_session_id ~role:runtime_role
              ~selection_note:runtime_selection_note
-             ~prompt:augmented_prompt ~allowed_tools:masc_mcp_tools
+             ~prompt:augmented_prompt ~allowed_tools:llama_mcp_tools
              ~timeout_sec:timeout
          with
          | Ok result ->

--- a/lib/team_session_engine_eio.ml
+++ b/lib/team_session_engine_eio.ml
@@ -218,6 +218,8 @@ let summary_json_of_session (config : Room.config)
   in
   let deltas, done_total = done_delta_metrics config session in
   let active_agents = session_active_agent_names session in
+  let planned_runtime_actors = Team_session_types.planned_worker_actor_names session in
+  let planned_participants = Team_session_types.planned_participant_names session in
   let room_active_agents = room_active_agent_names config in
   `Assoc
     [
@@ -229,6 +231,14 @@ let summary_json_of_session (config : Room.config)
       ("done_delta_total", `Int done_total);
       ("done_delta_by_agent", Team_session_types.assoc_int_to_json deltas);
       ("active_agents", `List (List.map (fun a -> `String a) active_agents));
+      ( "planned_workers",
+        `List
+          (List.map Team_session_types.planned_worker_to_yojson
+             session.planned_workers) );
+      ( "planned_runtime_actors",
+        `List (List.map (fun a -> `String a) planned_runtime_actors) );
+      ( "planned_participants",
+        `List (List.map (fun a -> `String a) planned_participants) );
       ("room_active_agents", `List (List.map (fun a -> `String a) room_active_agents));
       ( "last_checkpoint_at",
         Option.fold ~none:`Null ~some:(fun v -> `Float v)
@@ -692,6 +702,7 @@ let start_session ~sw ~(clock : _ Eio.Time.clock) ~(config : Room.config)
            else report_formats);
         turn_count = 0;
         agent_names = selected_agents;
+        planned_workers = [];
         broadcast_count = 0;
         portal_count = 0;
         cascade_attempted = 0;

--- a/lib/team_session_engine_eio.ml
+++ b/lib/team_session_engine_eio.ml
@@ -43,11 +43,17 @@ let take_last max_items xs =
       in
       drop (len - max_items) xs
 
-let active_agent_names (config : Room.config) =
+let room_active_agent_names (config : Room.config) =
   Room.get_agents_raw config
   |> List.map (fun (a : Types.agent) -> a.name)
   |> Team_session_types.dedup_strings
   |> List.sort String.compare
+
+let session_active_agent_names (session : Team_session_types.session) =
+  Team_session_types.participant_names session
+
+let bootstrap_grace_seconds (session : Team_session_types.session) =
+  float_of_int (session.checkpoint_interval_sec * max 1 session.min_agents)
 
 let session_visible_to_agent ~(agent_name : string)
     (session : Team_session_types.session) =
@@ -211,7 +217,8 @@ let summary_json_of_session (config : Room.config)
       min 100.0 (100.0 *. (elapsed /. float_of_int session.duration_seconds))
   in
   let deltas, done_total = done_delta_metrics config session in
-  let active_agents = active_agent_names config in
+  let active_agents = session_active_agent_names session in
+  let room_active_agents = room_active_agent_names config in
   `Assoc
     [
       ("session_id", `String session.session_id);
@@ -222,6 +229,7 @@ let summary_json_of_session (config : Room.config)
       ("done_delta_total", `Int done_total);
       ("done_delta_by_agent", Team_session_types.assoc_int_to_json deltas);
       ("active_agents", `List (List.map (fun a -> `String a) active_agents));
+      ("room_active_agents", `List (List.map (fun a -> `String a) room_active_agents));
       ( "last_checkpoint_at",
         Option.fold ~none:`Null ~some:(fun v -> `Float v)
           session.last_checkpoint_at );
@@ -230,7 +238,7 @@ let summary_json_of_session (config : Room.config)
 
 let status_sections (config : Room.config) (session : Team_session_types.session) =
   let summary = summary_json_of_session config session in
-  let active_agents = active_agent_names config in
+  let active_agents = session_active_agent_names session in
   let team_health = team_health_json session active_agents in
   let communication_metrics = communication_metrics_json session in
   let orchestration_state = orchestration_state_json session in
@@ -287,7 +295,7 @@ let write_checkpoint (config : Room.config) (session : Team_session_types.sessio
     else
       min 100.0 (100.0 *. (elapsed /. float_of_int session.duration_seconds))
   in
-  let active_agents = active_agent_names config in
+  let active_agents = session_active_agent_names session in
   let checkpoint : Team_session_types.checkpoint =
     {
       ts = now;
@@ -404,9 +412,13 @@ let maybe_add_fallback_task ~(config : Room.config)
 
 let apply_runtime_policy ~(config : Room.config)
     (session : Team_session_types.session) : Team_session_types.session =
-  let active_agents = active_agent_names config in
+  let active_agents = session_active_agent_names session in
   let active_count = List.length active_agents in
   let under_min_agents = active_count < session.min_agents in
+  let now = Time_compat.now () in
+  let within_bootstrap_grace =
+    now -. session.started_at < bootstrap_grace_seconds session
+  in
   if not under_min_agents then begin
     if session.min_agents_violation_streak > 0 then
       Team_session_store.append_event config session.session_id
@@ -419,7 +431,9 @@ let apply_runtime_policy ~(config : Room.config)
               ("ts_iso", `String (now_iso ()));
             ]);
     { session with min_agents_violation_streak = 0 }
-  end else
+  end else if within_bootstrap_grace then
+    session
+  else
     let next_streak = session.min_agents_violation_streak + 1 in
     let violation_label =
       Printf.sprintf "active_agents_below_min:%d<%d" active_count session.min_agents
@@ -647,7 +661,7 @@ let start_session ~sw ~(clock : _ Eio.Time.clock) ~(config : Room.config)
       if agent_names <> [] then
         Team_session_types.dedup_strings agent_names
       else
-        let discovered = active_agent_names config in
+        let discovered = room_active_agent_names config in
         if discovered = [] then [ created_by ] else discovered
     in
     let baseline_done_counts =

--- a/lib/team_session_report.ml
+++ b/lib/team_session_report.ml
@@ -86,6 +86,12 @@ let summary_metrics (session : Team_session_types.session) config =
     else min 100.0 (100.0 *. (elapsed /. float_of_int session.duration_seconds))
   in
   let active_agents = Team_session_types.participant_names session in
+  let planned_runtime_actors =
+    Team_session_types.planned_worker_actor_names session
+  in
+  let planned_participants =
+    Team_session_types.planned_participant_names session
+  in
   let room_active_agents =
     Room.get_agents_raw config
     |> List.map (fun (a : Types.agent) -> a.name)
@@ -103,6 +109,14 @@ let summary_metrics (session : Team_session_types.session) config =
         ("done_delta_total", `Int done_delta_total);
         ("done_delta_by_agent", Team_session_types.assoc_int_to_json delta_by_agent);
         ("active_agents", `List (List.map (fun a -> `String a) active_agents));
+        ( "planned_workers",
+          `List
+            (List.map Team_session_types.planned_worker_to_yojson
+               session.planned_workers) );
+        ( "planned_runtime_actors",
+          `List (List.map (fun a -> `String a) planned_runtime_actors) );
+        ( "planned_participants",
+          `List (List.map (fun a -> `String a) planned_participants) );
         ("room_active_agents", `List (List.map (fun a -> `String a) room_active_agents));
       ],
     done_delta_total,
@@ -254,6 +268,16 @@ let markdown_of_report ~(session : Team_session_types.session)
     | `List xs -> List.length xs
     | _ -> 0
   in
+  let planned_participants =
+    match summary_json |> member "planned_participants" with
+    | `List xs -> List.length xs
+    | _ -> health_active
+  in
+  let planned_workers =
+    match summary_json |> member "planned_workers" with
+    | `List xs -> xs
+    | _ -> []
+  in
   let health_required =
     team_health_json |> member "required_agents" |> to_int_option
     |> Option.value ~default:0
@@ -370,6 +394,8 @@ let markdown_of_report ~(session : Team_session_types.session)
       "## Team Health";
       Printf.sprintf "- Health status: %s" health_status;
       Printf.sprintf "- Session participants: %d" health_active;
+      Printf.sprintf "- Planned participants: %d" planned_participants;
+      Printf.sprintf "- Planned workers: %d" (List.length planned_workers);
       Printf.sprintf "- Room active agents: %d" room_active;
       Printf.sprintf "- Required agents(min_agents): %d" health_required;
       Printf.sprintf "- min_agents_violation events: %d" violation_count;
@@ -565,6 +591,19 @@ let team_step_spawn_agent (json : Yojson.Safe.t) =
   else
     None
 
+let team_step_runtime_actor (json : Yojson.Safe.t) =
+  if has_event_type json "team_step_spawn" then
+    match
+      Yojson.Safe.Util.member "detail" json
+      |> Yojson.Safe.Util.member "runtime_actor"
+    with
+    | `String actor ->
+        let actor = String.trim actor in
+        if actor = "" then None else Some actor
+    | _ -> None
+  else
+    None
+
 let team_step_spawn_success (json : Yojson.Safe.t) =
   if has_event_type json "team_step_spawn" then
     match
@@ -695,8 +734,12 @@ let proof_profile_summary ~proof_level ~required_spawn_agents ~min_turn_events
     ]
 
 let required_spawn_agents_for_session (session : Team_session_types.session) =
-  let participants = max 1 (List.length session.agent_names) in
-  max 1 (min 4 participants)
+  let planned_workers = List.length session.planned_workers in
+  if planned_workers > 0 then
+    max 1 (min 4 planned_workers)
+  else
+    let participants = max 1 (List.length session.agent_names) in
+    max 1 (min 4 participants)
 
 let min_turn_events_for_session required_turn_actors =
   max 4 (required_turn_actors * 3)
@@ -762,6 +805,10 @@ let parse_spawn_selection_note json =
 let spawn_agent_of_event json =
   if has_event_type json "team_step_spawn" then parse_spawn_agent json else None
 
+let spawn_runtime_actor_of_event json =
+  if has_event_type json "team_step_spawn" then team_step_runtime_actor json
+  else None
+
 let spawn_success_of_event json =
   if has_event_type json "team_step_spawn" then parse_spawn_success json else None
 
@@ -774,6 +821,10 @@ let spawn_selection_note_of_event json =
 
 let collect_spawn_agents events =
   events |> List.filter_map spawn_agent_of_event |> Team_session_types.dedup_strings
+
+let collect_spawn_runtime_actors events =
+  events |> List.filter_map spawn_runtime_actor_of_event
+  |> Team_session_types.dedup_strings
 
 let collect_spawn_models events =
   events |> List.filter_map spawn_model_of_event |> Team_session_types.dedup_strings
@@ -825,6 +876,8 @@ let proof_markdown ~(session : Team_session_types.session)
     ~(checkpoints_count : int) ~(events_count : int) ~(turn_events : int)
     ~(report_exists : bool) ~(unique_turn_actors_count : int)
     ~(required_turn_actors : int) ~(spawn_models : string list)
+    ~(planned_workers : Team_session_types.planned_worker list)
+    ~(unique_spawn_runtime_actors_count : int)
     ~(spawn_selection_note_summary : string option)
     ~(proof_generated_at_iso : string) =
   let criteria_lines =
@@ -846,6 +899,24 @@ let proof_markdown ~(session : Team_session_types.session)
            Printf.sprintf "- [%s] %s%s" status name
              (if detail = "" then "" else " - " ^ detail))
   in
+  let planned_worker_lines =
+    planned_workers
+    |> List.map (fun worker ->
+           let role =
+             Option.value ~default:"(unspecified)"
+               (Option.map String.trim worker.Team_session_types.spawn_role)
+           in
+           let model =
+             Option.value ~default:"(default)"
+               (Option.map String.trim worker.Team_session_types.spawn_model)
+           in
+           let actor =
+             Option.value ~default:"(pending)"
+               (Option.map String.trim worker.Team_session_types.runtime_actor)
+           in
+           Printf.sprintf "- %s | role=%s | model=%s | runtime_actor=%s"
+             worker.Team_session_types.spawn_agent role model actor)
+  in
   String.concat "\n"
     [
       "# Team Session Proof";
@@ -864,6 +935,9 @@ let proof_markdown ~(session : Team_session_types.session)
       Printf.sprintf "- Turn events count: %d" turn_events;
       Printf.sprintf "- Unique turn actors: %d (required >= %d)"
         unique_turn_actors_count required_turn_actors;
+      Printf.sprintf "- Planned workers: %d" (List.length planned_workers);
+      Printf.sprintf "- Unique spawned runtime actors: %d"
+        unique_spawn_runtime_actors_count;
       Printf.sprintf "- Spawn models: %s"
         (match spawn_models with
         | [] -> "(not recorded)"
@@ -873,6 +947,10 @@ let proof_markdown ~(session : Team_session_types.session)
         | Some note -> note
         | None -> "(not recorded)");
       Printf.sprintf "- Report artifacts exist: %b" report_exists;
+      "";
+      "## Planned Worker Roster";
+      (if planned_worker_lines = [] then "- (not recorded)"
+       else String.concat "\n" planned_worker_lines);
       "";
       "## Criteria";
       (if criteria_lines = [] then "- (no criteria)"
@@ -945,6 +1023,13 @@ let generate_proof ?(proof_level = default_proof_level) config
       collect_spawn_agents events |> Team_session_types.dedup_strings
     in
     let unique_spawn_agents_count = List.length unique_spawn_agents in
+    let unique_spawn_runtime_actors =
+      collect_spawn_runtime_actors events
+      |> Team_session_types.dedup_strings
+    in
+    let unique_spawn_runtime_actors_count =
+      List.length unique_spawn_runtime_actors
+    in
     let spawn_models = collect_spawn_models events in
     let spawn_selection_notes = collect_spawn_selection_notes events in
     let spawn_selection_note_summary =
@@ -965,7 +1050,9 @@ let generate_proof ?(proof_level = default_proof_level) config
       | Team_session_types.Proof_strong ->
           standard_criteria
           @ make_strong_criteria ~required_spawn_agents ~spawn_events
-              ~spawn_success_count ~unique_spawn_agents_count
+              ~spawn_success_count
+              ~unique_spawn_agents_count:
+                (max unique_spawn_agents_count unique_spawn_runtime_actors_count)
               ~required_turn_actors ~min_turn_events ~turn_events
               ~min_communication ~communication_total ~vote_events
               ~run_deliverables
@@ -1007,6 +1094,16 @@ let generate_proof ?(proof_level = default_proof_level) config
                 ("spawn_success_count", `Int spawn_success_count);
                 ("unique_spawn_agents", `List (List.map (fun a -> `String a) unique_spawn_agents));
                 ("unique_spawn_agents_count", `Int unique_spawn_agents_count);
+                ( "unique_spawn_runtime_actors",
+                  `List
+                    (List.map (fun a -> `String a) unique_spawn_runtime_actors) );
+                ( "unique_spawn_runtime_actors_count",
+                  `Int unique_spawn_runtime_actors_count );
+                ( "planned_workers",
+                  `List
+                    (List.map Team_session_types.planned_worker_to_yojson
+                       session.planned_workers) );
+                ("planned_worker_count", `Int (List.length session.planned_workers));
                 ("spawn_models", `List (List.map (fun m -> `String m) spawn_models));
                 ( "spawn_selection_notes",
                   `List (List.map (fun note -> `String note) spawn_selection_notes)
@@ -1030,6 +1127,8 @@ let generate_proof ?(proof_level = default_proof_level) config
         ~checkpoints_count ~events_count:(List.length events) ~turn_events
         ~report_exists:(report_json_exists && report_md_exists)
         ~unique_turn_actors_count ~required_turn_actors ~spawn_models
+        ~planned_workers:session.planned_workers
+        ~unique_spawn_runtime_actors_count
         ~spawn_selection_note_summary
         ~proof_generated_at_iso:generated_at_iso
     in

--- a/lib/team_session_report.ml
+++ b/lib/team_session_report.ml
@@ -85,7 +85,8 @@ let summary_metrics (session : Team_session_types.session) config =
       100.0
     else min 100.0 (100.0 *. (elapsed /. float_of_int session.duration_seconds))
   in
-  let active_agents =
+  let active_agents = Team_session_types.participant_names session in
+  let room_active_agents =
     Room.get_agents_raw config
     |> List.map (fun (a : Types.agent) -> a.name)
     |> Team_session_types.dedup_strings
@@ -102,6 +103,7 @@ let summary_metrics (session : Team_session_types.session) config =
         ("done_delta_total", `Int done_delta_total);
         ("done_delta_by_agent", Team_session_types.assoc_int_to_json delta_by_agent);
         ("active_agents", `List (List.map (fun a -> `String a) active_agents));
+        ("room_active_agents", `List (List.map (fun a -> `String a) room_active_agents));
       ],
     done_delta_total,
     delta_by_agent,
@@ -135,6 +137,24 @@ let recent_event_lines events limit =
          | `String ts_iso, `String event_type ->
              Some (Printf.sprintf "- %s | %s" ts_iso event_type)
          | _ -> None)
+
+let turn_counts_by_agent events =
+  let tbl = Hashtbl.create 16 in
+  List.iter
+    (fun json ->
+      let open Yojson.Safe.Util in
+      match (member "event_type" json, member "detail" json |> member "actor") with
+      | `String "team_turn", `String actor ->
+          let actor = String.trim actor in
+          if actor <> "" then
+            let count =
+              match Hashtbl.find_opt tbl actor with Some n -> n | None -> 0
+            in
+            Hashtbl.replace tbl actor (count + 1)
+      | _ -> ())
+    events;
+  Hashtbl.fold (fun agent count acc -> (agent, count) :: acc) tbl []
+  |> List.sort (fun (a, _) (b, _) -> compare a b)
 
 let mcp_improvements (session : Team_session_types.session) events checkpoints_count
     done_delta_total =
@@ -198,6 +218,7 @@ let mcp_improvements (session : Team_session_types.session) events checkpoints_c
 let markdown_of_report ~(session : Team_session_types.session)
     ~(summary_json : Yojson.Safe.t) ~(events : Yojson.Safe.t list)
     ~(checkpoints_count : int) ~(done_delta_by_agent : (string * int) list)
+    ~(turn_count_by_agent : (string * int) list)
     ~(team_health_json : Yojson.Safe.t)
     ~(communication_metrics_json : Yojson.Safe.t)
     ~(llm_cache_metrics_json : Yojson.Safe.t)
@@ -227,6 +248,11 @@ let markdown_of_report ~(session : Team_session_types.session)
   let health_active =
     team_health_json |> member "active_agents_count" |> to_int_option
     |> Option.value ~default:0
+  in
+  let room_active =
+    match summary_json |> member "room_active_agents" with
+    | `List xs -> List.length xs
+    | _ -> 0
   in
   let health_required =
     team_health_json |> member "required_agents" |> to_int_option
@@ -278,12 +304,23 @@ let markdown_of_report ~(session : Team_session_types.session)
     |> Option.value ~default:0
   in
   let event_lines = recent_event_lines events 12 in
+  let contribution_agents =
+    Team_session_types.dedup_strings
+      (List.map fst done_delta_by_agent @ List.map fst turn_count_by_agent)
+  in
   let contribution_lines =
-    if done_delta_by_agent = [] then [ "- (no tracked contributors)" ]
+    if contribution_agents = [] then [ "- (no tracked contributors)" ]
     else
       List.map
-        (fun (agent, delta) -> Printf.sprintf "- %s: %d" agent delta)
-        done_delta_by_agent
+        (fun agent ->
+          let done_delta =
+            Team_session_types.assoc_find_default agent done_delta_by_agent 0
+          in
+          let turns =
+            Team_session_types.assoc_find_default agent turn_count_by_agent 0
+          in
+          Printf.sprintf "- %s: turns=%d, done_delta=%d" agent turns done_delta)
+        contribution_agents
   in
   let policy_lines =
     [
@@ -332,7 +369,8 @@ let markdown_of_report ~(session : Team_session_types.session)
       "";
       "## Team Health";
       Printf.sprintf "- Health status: %s" health_status;
-      Printf.sprintf "- Active agents: %d" health_active;
+      Printf.sprintf "- Session participants: %d" health_active;
+      Printf.sprintf "- Room active agents: %d" room_active;
       Printf.sprintf "- Required agents(min_agents): %d" health_required;
       Printf.sprintf "- min_agents_violation events: %d" violation_count;
       "";
@@ -390,6 +428,7 @@ let generate config (session : Team_session_types.session) :
         team_health, communication_metrics, cascade_metrics =
       summary_metrics session config
     in
+    let turn_count_by_agent = turn_counts_by_agent events in
     let alert_count = event_count events "alert_emitted" in
     let violation_count = event_count events "min_agents_violation" in
     let mcp_notes =
@@ -427,6 +466,7 @@ let generate config (session : Team_session_types.session) :
               ] );
           ("outcomes", `Assoc [ ("completed_task_delta", `Int done_delta_total) ]);
           ("agent_metrics", Team_session_types.assoc_int_to_json done_delta_by_agent);
+          ("agent_turn_metrics", Team_session_types.assoc_int_to_json turn_count_by_agent);
           ( "goal_metrics",
             `Assoc
               [
@@ -455,7 +495,7 @@ let generate config (session : Team_session_types.session) :
     in
     let markdown =
       markdown_of_report ~session ~summary_json ~events ~checkpoints_count
-        ~done_delta_by_agent ~team_health_json:team_health
+        ~done_delta_by_agent ~turn_count_by_agent ~team_health_json:team_health
         ~communication_metrics_json:communication_metrics
         ~llm_cache_metrics_json:llm_cache_metrics
         ~cascade_metrics_json:cascade_metrics ~alert_count ~violation_count

--- a/lib/team_session_types.ml
+++ b/lib/team_session_types.ml
@@ -53,6 +53,13 @@ type turn_kind =
   | Turn_task
   | Turn_checkpoint
 
+type planned_worker = {
+  spawn_agent : string;
+  runtime_actor : string option;
+  spawn_role : string option;
+  spawn_model : string option;
+}
+
 type session = {
   session_id : string;
   goal : string;
@@ -73,6 +80,7 @@ type session = {
   report_formats : report_format list;
   turn_count : int;
   agent_names : string list;
+  planned_workers : planned_worker list;
   broadcast_count : int;
   portal_count : int;
   cascade_attempted : int;
@@ -239,8 +247,45 @@ let dedup_strings xs =
   in
   loop [] xs
 
+let planned_worker_key (w : planned_worker) =
+  match w.runtime_actor with
+  | Some actor when String.trim actor <> "" -> "actor:" ^ String.trim actor
+  | _ ->
+      String.concat "|"
+        [
+          "agent:" ^ w.spawn_agent;
+          "role:"
+          ^ Option.value ~default:"" (Option.map String.trim w.spawn_role);
+          "model:"
+          ^ Option.value ~default:"" (Option.map String.trim w.spawn_model);
+        ]
+
+let dedup_planned_workers xs =
+  let rec loop seen acc = function
+    | [] -> List.rev acc
+    | x :: rest ->
+        let key = planned_worker_key x in
+        if List.mem key seen then loop seen acc rest
+        else loop (key :: seen) (x :: acc) rest
+  in
+  loop [] [] xs
+
 let participant_names (s : session) =
   dedup_strings (s.created_by :: s.agent_names) |> List.sort String.compare
+
+let planned_worker_actor_names (s : session) =
+  s.planned_workers
+  |> List.filter_map (fun worker ->
+         match worker.runtime_actor with
+         | Some actor ->
+             let trimmed = String.trim actor in
+             if trimmed = "" then None else Some trimmed
+         | None -> None)
+  |> dedup_strings |> List.sort String.compare
+
+let planned_participant_names (s : session) =
+  dedup_strings (participant_names s @ planned_worker_actor_names s)
+  |> List.sort String.compare
 
 let assoc_find_default key pairs default =
   match List.assoc_opt key pairs with Some v -> v | None -> default
@@ -294,6 +339,37 @@ let assoc_int_of_json json =
         fields
   | _ -> []
 
+let planned_worker_to_yojson (w : planned_worker) =
+  `Assoc
+    [
+      ("spawn_agent", `String w.spawn_agent);
+      ( "runtime_actor",
+        Option.fold ~none:`Null ~some:(fun s -> `String s) w.runtime_actor );
+      ("spawn_role", Option.fold ~none:`Null ~some:(fun s -> `String s) w.spawn_role);
+      ("spawn_model", Option.fold ~none:`Null ~some:(fun s -> `String s) w.spawn_model);
+    ]
+
+let planned_worker_of_yojson (json : Yojson.Safe.t) =
+  match json with
+  | `Assoc _ ->
+      let spawn_agent =
+        match member "spawn_agent" json with
+        | `String s ->
+            let trimmed = String.trim s in
+            if trimmed = "" then None else Some trimmed
+        | _ -> None
+      in
+      Option.map
+        (fun spawn_agent ->
+          {
+            spawn_agent;
+            runtime_actor = member "runtime_actor" json |> to_string_option;
+            spawn_role = member "spawn_role" json |> to_string_option;
+            spawn_model = member "spawn_model" json |> to_string_option;
+          })
+        spawn_agent
+  | _ -> None
+
 let session_to_yojson (s : session) =
   `Assoc
     [
@@ -316,6 +392,7 @@ let session_to_yojson (s : session) =
       ("report_formats", `List (List.map (fun f -> `String (report_format_to_string f)) s.report_formats));
       ("turn_count", `Int s.turn_count);
       ("agent_names", `List (List.map (fun a -> `String a) s.agent_names));
+      ("planned_workers", `List (List.map planned_worker_to_yojson s.planned_workers));
       ("broadcast_count", `Int s.broadcast_count);
       ("portal_count", `Int s.portal_count);
       ("cascade_attempted", `Int s.cascade_attempted);
@@ -410,6 +487,11 @@ let session_of_yojson json =
           (match member "agent_names" json with
            | `List xs -> List.filter_map (function `String s -> Some s | _ -> None) xs
            | _ -> []);
+        planned_workers =
+          (match member "planned_workers" json with
+           | `List xs -> List.filter_map planned_worker_of_yojson xs
+           | _ -> [])
+          |> dedup_planned_workers;
         broadcast_count = get_int_default "broadcast_count" 0;
         portal_count = get_int_default "portal_count" 0;
         cascade_attempted = get_int_default "cascade_attempted" 0;

--- a/lib/team_session_types.ml
+++ b/lib/team_session_types.ml
@@ -239,6 +239,9 @@ let dedup_strings xs =
   in
   loop [] xs
 
+let participant_names (s : session) =
+  dedup_strings (s.created_by :: s.agent_names) |> List.sort String.compare
+
 let assoc_find_default key pairs default =
   match List.assoc_opt key pairs with Some v -> v | None -> default
 

--- a/lib/tool_team_session.ml
+++ b/lib/tool_team_session.ml
@@ -343,6 +343,142 @@ let derived_llama_runtime_actor ~session_id ~prompt =
   let digest = Digest.string (session_id ^ "\n" ^ prompt) |> Digest.to_hex in
   Printf.sprintf "llama-local-%s" (String.sub digest 0 8)
 
+type spawn_spec = {
+  spawn_agent : string;
+  spawn_prompt : string;
+  spawn_model : string option;
+  spawn_role : string option;
+  spawn_selection_note : string option;
+  spawn_timeout_seconds : int;
+}
+
+type prepared_spawn = {
+  spec : spawn_spec;
+  runtime_actor_name : string option;
+  runtime_model : Llm_client.model_spec;
+}
+
+let parse_spawn_spec_from_object batch_index json =
+  let open Yojson.Safe.Util in
+  let get_required_string key =
+    match member key json with
+    | `String s ->
+        let trimmed = String.trim s in
+        if trimmed = "" then
+          Error
+            (Printf.sprintf "spawn_batch[%d].%s is required" batch_index key)
+        else
+          Ok trimmed
+    | _ ->
+        Error
+          (Printf.sprintf "spawn_batch[%d].%s is required" batch_index key)
+  in
+  let get_optional_string key =
+    match member key json with
+    | `String s ->
+        let trimmed = String.trim s in
+        if trimmed = "" then None else Some trimmed
+    | _ -> None
+  in
+  let get_timeout key =
+    match member key json with
+    | `Int n -> max 1 n
+    | `Intlit s -> (try max 1 (int_of_string s) with _ -> 300)
+    | _ -> 300
+  in
+  match (get_required_string "spawn_agent", get_required_string "spawn_prompt") with
+  | Ok spawn_agent, Ok spawn_prompt ->
+      Ok
+        {
+          spawn_agent;
+          spawn_prompt;
+          spawn_model = get_optional_string "spawn_model";
+          spawn_role = get_optional_string "spawn_role";
+          spawn_selection_note = get_optional_string "spawn_selection_note";
+          spawn_timeout_seconds = get_timeout "spawn_timeout_seconds";
+        }
+  | Error e, _ | _, Error e -> Error e
+
+let parse_step_spawn_specs args =
+  let singular_agent = get_string_opt args "spawn_agent" in
+  let singular_prompt = get_string_opt args "spawn_prompt" in
+  let singular_present = Option.is_some singular_agent || Option.is_some singular_prompt in
+  let batch_specs_result =
+    match Yojson.Safe.Util.member "spawn_batch" args with
+    | `Null -> Ok []
+    | `List xs ->
+        let rec loop idx acc = function
+          | [] -> Ok (List.rev acc)
+          | json :: rest -> (
+              match parse_spawn_spec_from_object idx json with
+              | Ok spec -> loop (idx + 1) (spec :: acc) rest
+              | Error e -> Error e)
+        in
+        loop 0 [] xs
+    | _ -> Error "spawn_batch must be an array"
+  in
+  match batch_specs_result with
+  | Error e -> Error e
+  | Ok batch_specs ->
+      if singular_present && batch_specs <> [] then
+        Error "spawn_batch cannot be combined with spawn_agent/spawn_prompt"
+      else if batch_specs <> [] then
+        Ok batch_specs
+      else
+        match (singular_agent, singular_prompt) with
+        | None, None -> Ok []
+        | Some _, None | None, Some _ ->
+            Error "spawn_agent and spawn_prompt must be provided together"
+        | Some spawn_agent, Some spawn_prompt ->
+            Ok
+              [
+                {
+                  spawn_agent;
+                  spawn_prompt;
+                  spawn_model = get_string_opt args "spawn_model";
+                  spawn_role = get_string_opt args "spawn_role";
+                  spawn_selection_note = get_string_opt args "spawn_selection_note";
+                  spawn_timeout_seconds = get_int args "spawn_timeout_seconds" 300;
+                };
+              ]
+
+let planned_worker_of_spec ?runtime_actor (spec : spawn_spec) :
+    Team_session_types.planned_worker =
+  {
+    spawn_agent = spec.spawn_agent;
+    runtime_actor;
+    spawn_role = spec.spawn_role;
+    spawn_model = spec.spawn_model;
+  }
+
+let register_planned_workers config session_id workers =
+  match Team_session_store.update_session config session_id (fun session ->
+            {
+              session with
+              planned_workers =
+                Team_session_types.dedup_planned_workers
+                  (session.planned_workers @ workers);
+              updated_at_iso = Types.now_iso ();
+            })
+  with
+  | Ok updated ->
+      Team_session_store.append_event config session_id
+        ~event_type:"session_planned_workers_updated"
+        ~detail:
+          (`Assoc
+            [
+              ("planned_worker_count", `Int (List.length updated.planned_workers));
+              ( "runtime_actors",
+                `List
+                  (workers
+                  |> List.filter_map (fun worker ->
+                         worker.Team_session_types.runtime_actor)
+                  |> List.map (fun actor -> `String actor)) );
+              ("ts_iso", `String (Types.now_iso ()));
+            ]);
+      Ok ()
+  | Error e -> Error e
+
 let ensure_session_actor config session_id actor_name =
   match Team_session_store.update_session config session_id (fun session ->
             let agent_names =
@@ -382,19 +518,20 @@ let handle_step ctx args : result =
       match ensure_session_access ctx session_id with
       | Error e -> (false, json_error e)
       | Ok () ->
-          let spawn_agent_opt = get_string_opt args "spawn_agent" in
-          let spawn_prompt_opt = get_string_opt args "spawn_prompt" in
-          let has_spawn = Option.is_some spawn_agent_opt || Option.is_some spawn_prompt_opt in
-          let turn_kind_result =
-            if has_spawn then parse_turn_kind_opt args
-            else
-              match parse_turn_kind args with
-              | Ok kind -> Ok (Some kind)
-              | Error e -> Error e
-          in
-          match turn_kind_result with
+          let spawn_specs_result = parse_step_spawn_specs args in
+          match spawn_specs_result with
           | Error e -> (false, json_error e)
-          | Ok turn_kind_opt ->
+          | Ok spawn_specs ->
+              let turn_kind_result =
+                if spawn_specs <> [] then parse_turn_kind_opt args
+                else
+                  match parse_turn_kind args with
+                  | Ok kind -> Ok (Some kind)
+                  | Error e -> Error e
+              in
+              match turn_kind_result with
+              | Error e -> (false, json_error e)
+              | Ok turn_kind_opt ->
               let actor =
                 match get_string_opt args "actor" with
                 | Some a -> a
@@ -405,12 +542,6 @@ let handle_step ctx args : result =
               let task_title = get_string_opt args "task_title" in
               let task_description = get_string_opt args "task_description" in
               let task_priority = get_int args "task_priority" 3 in
-              let spawn_model_opt = get_string_opt args "spawn_model" in
-              let spawn_role_opt = get_string_opt args "spawn_role" in
-              let spawn_selection_note_opt =
-                get_string_opt args "spawn_selection_note"
-              in
-              let spawn_timeout_seconds = get_int args "spawn_timeout_seconds" 300 in
               let append_spawn_event ?spawn_agent ?runtime_actor ?spawn_role
                   ?spawn_model ?spawn_selection_note ~success ?exit_code
                   ?elapsed_ms ?output_preview ?error () =
@@ -446,135 +577,228 @@ let handle_step ctx args : result =
                 Team_session_store.append_event ctx.config session_id
                   ~event_type:"team_step_spawn" ~detail
               in
+              let prepare_spawn (spec : spawn_spec) =
+                let runtime_actor_name =
+                  if String.equal spec.spawn_agent "llama" then
+                    Some
+                      (derived_llama_runtime_actor ~session_id
+                         ~prompt:spec.spawn_prompt)
+                  else
+                    None
+                in
+                let runtime_model =
+                  if String.equal spec.spawn_agent "llama" then
+                    match spec.spawn_model with
+                    | None ->
+                        Error
+                          "spawn_model is required when spawn_agent=llama"
+                    | Some model_name -> (
+                        match
+                          Llm_client.model_spec_of_string
+                            ("llama:" ^ model_name)
+                        with
+                        | Ok spec -> Ok spec
+                        | Error err -> Error ("invalid spawn_model: " ^ err))
+                  else
+                    Ok Llm_client.ollama_glm
+                in
+                match runtime_model with
+                | Error e -> Error (spec, runtime_actor_name, e)
+                | Ok runtime_model ->
+                    Ok { spec; runtime_actor_name; runtime_model }
+              in
+              let prepared_spawns_result =
+                let rec loop acc = function
+                  | [] -> Ok (List.rev acc)
+                  | spec :: rest -> (
+                      match prepare_spawn spec with
+                      | Ok prepared -> loop (prepared :: acc) rest
+                      | Error (failed_spec, runtime_actor_name, msg) ->
+                          append_spawn_event ~spawn_agent:failed_spec.spawn_agent
+                            ?runtime_actor:runtime_actor_name
+                            ?spawn_role:failed_spec.spawn_role
+                            ?spawn_model:failed_spec.spawn_model
+                            ?spawn_selection_note:failed_spec.spawn_selection_note
+                            ~success:false ~error:msg ();
+                          Error msg)
+                in
+                loop [] spawn_specs
+              in
               let spawn_result_json =
-                match (spawn_agent_opt, spawn_prompt_opt) with
-                | None, None -> None
-                | Some _, None | None, Some _ ->
-                    let msg =
-                      "spawn_agent and spawn_prompt must be provided together"
+                match prepared_spawns_result with
+                | Error msg -> Some (`Assoc [ ("error", `String msg) ])
+                | Ok [] -> None
+                | Ok prepared_spawns ->
+                    let planned_workers =
+                      List.map
+                        (fun prepared ->
+                          planned_worker_of_spec
+                            ?runtime_actor:prepared.runtime_actor_name
+                            prepared.spec)
+                        prepared_spawns
                     in
-                    append_spawn_event ~success:false ~error:msg ();
-                    Some (`Assoc [ ("error", `String msg) ])
-                | Some spawn_agent, Some spawn_prompt ->
-                    let runtime_agent_name =
-                      if String.equal spawn_agent "llama" then
-                        Some
-                          (derived_llama_runtime_actor ~session_id
-                             ~prompt:spawn_prompt)
-                      else
-                        None
-                    in
-                    let runtime_model =
-                      if String.equal spawn_agent "llama" then
-                        match spawn_model_opt with
-                        | None ->
-                            Error
-                              "spawn_model is required when spawn_agent=llama"
-                        | Some model_name -> (
-                            match
-                              Llm_client.model_spec_of_string
-                                ("llama:" ^ model_name)
-                            with
-                            | Ok spec -> Ok spec
-                            | Error err ->
-                                Error ("invalid spawn_model: " ^ err))
-                      else
-                        Ok (Llm_client.ollama_glm)
-                    in
-                    let prep_error =
-                      match runtime_agent_name with
-                      | Some worker_actor ->
-                          ensure_session_actor ctx.config session_id worker_actor
-                      | None -> Ok ()
-                    in
-                    let spawn_error =
-                      match prep_error with
+                    let planning_error =
+                      match
+                        register_planned_workers ctx.config session_id
+                          planned_workers
+                      with
                       | Error msg -> Some msg
-                      | Ok () -> (
-                          match runtime_model with
-                          | Error msg -> Some msg
-                          | Ok _ -> None)
+                      | Ok () -> None
                     in
-                    (match spawn_error with
-                     | Some msg ->
-                         append_spawn_event ~spawn_agent ?runtime_actor:runtime_agent_name
-                           ?spawn_role:spawn_role_opt ?spawn_model:spawn_model_opt
-                           ?spawn_selection_note:spawn_selection_note_opt
-                           ~success:false ~error:msg ();
-                         Some (`Assoc [ ("error", `String msg) ])
-                     | None -> (
-                         match ctx.proc_mgr with
-                         | None ->
-                             let msg =
-                               "process manager unavailable for team step spawn"
-                             in
-                             append_spawn_event ~spawn_agent
-                               ?runtime_actor:runtime_agent_name
-                               ?spawn_role:spawn_role_opt
-                               ?spawn_model:spawn_model_opt
-                               ?spawn_selection_note:spawn_selection_note_opt
-                               ~success:false ~error:msg ();
-                             Some (`Assoc [ ("error", `String msg) ])
-                         | Some pm ->
-                             let spawn_result =
-                               Spawn_eio.spawn ~sw:ctx.sw ~proc_mgr:pm
-                                 ~agent_name:spawn_agent ~prompt:spawn_prompt
-                                 ~timeout_seconds:spawn_timeout_seconds
-                                 ~room_config:ctx.config
-                                 ?runtime_agent_name
-                                 ~runtime_model:(Result.get_ok runtime_model)
-                                 ?runtime_role:spawn_role_opt
-                                 ?runtime_selection_note:spawn_selection_note_opt
-                                 ~runtime_session_id:session_id ()
-                             in
-                             let output_preview =
-                               truncate_for_event spawn_result.output
-                             in
-                             append_spawn_event ~spawn_agent
-                               ?runtime_actor:runtime_agent_name
-                               ?spawn_role:spawn_role_opt
-                               ?spawn_model:spawn_model_opt
-                               ?spawn_selection_note:spawn_selection_note_opt
-                               ~success:spawn_result.success
-                               ~exit_code:spawn_result.exit_code
-                               ~elapsed_ms:spawn_result.elapsed_ms
-                               ~output_preview ();
-                             Some
-                               (`Assoc
-                                 [
-                                   ("agent", `String spawn_agent);
-                                   ( "runtime_actor",
-                                     Option.fold ~none:`Null
-                                       ~some:(fun s -> `String s)
-                                       runtime_agent_name );
-                                   ( "spawn_role",
-                                     Option.fold ~none:`Null
-                                       ~some:(fun s -> `String s)
-                                       spawn_role_opt );
-                                   ( "spawn_model",
-                                     Option.fold ~none:`Null
-                                       ~some:(fun s -> `String s)
-                                       spawn_model_opt );
-                                   ( "spawn_selection_note",
-                                     Option.fold ~none:`Null
-                                       ~some:(fun s -> `String s)
-                                       spawn_selection_note_opt );
-                                   ("success", `Bool spawn_result.success);
-                                   ("exit_code", `Int spawn_result.exit_code);
-                                   ("elapsed_ms", `Int spawn_result.elapsed_ms);
-                                   ("output_preview", `String output_preview);
-                                   ( "input_tokens",
-                                     int_opt_to_json spawn_result.input_tokens );
-                                   ( "output_tokens",
-                                     int_opt_to_json spawn_result.output_tokens );
-                                   ( "cache_creation_tokens",
-                                     int_opt_to_json
-                                       spawn_result.cache_creation_tokens );
-                                   ( "cache_read_tokens",
-                                     int_opt_to_json
-                                       spawn_result.cache_read_tokens );
-                                   ("cost_usd", float_opt_to_json spawn_result.cost_usd);
-                                 ])))
+                    match planning_error with
+                    | Some msg ->
+                        List.iter
+                          (fun prepared ->
+                            append_spawn_event
+                              ~spawn_agent:prepared.spec.spawn_agent
+                              ?runtime_actor:prepared.runtime_actor_name
+                              ?spawn_role:prepared.spec.spawn_role
+                              ?spawn_model:prepared.spec.spawn_model
+                              ?spawn_selection_note:
+                                prepared.spec.spawn_selection_note
+                              ~success:false ~error:msg ())
+                          prepared_spawns;
+                        Some (`Assoc [ ("error", `String msg) ])
+                    | None ->
+                        match ctx.proc_mgr with
+                        | None ->
+                            let msg =
+                              "process manager unavailable for team step spawn"
+                            in
+                            List.iter
+                              (fun prepared ->
+                                append_spawn_event
+                                  ~spawn_agent:prepared.spec.spawn_agent
+                                  ?runtime_actor:prepared.runtime_actor_name
+                                  ?spawn_role:prepared.spec.spawn_role
+                                  ?spawn_model:prepared.spec.spawn_model
+                                  ?spawn_selection_note:
+                                    prepared.spec.spawn_selection_note
+                                  ~success:false ~error:msg ())
+                              prepared_spawns;
+                            Some (`Assoc [ ("error", `String msg) ])
+                        | Some pm ->
+                            let rec ensure_all = function
+                              | [] -> Ok ()
+                              | prepared :: rest -> (
+                                  match prepared.runtime_actor_name with
+                                  | None -> ensure_all rest
+                                  | Some worker_actor -> (
+                                      match
+                                        ensure_session_actor ctx.config
+                                          session_id worker_actor
+                                      with
+                                      | Ok () -> ensure_all rest
+                                      | Error msg -> Error msg))
+                            in
+                            match ensure_all prepared_spawns with
+                             | Error msg ->
+                                 List.iter
+                                   (fun prepared ->
+                                     append_spawn_event
+                                       ~spawn_agent:prepared.spec.spawn_agent
+                                       ?runtime_actor:prepared.runtime_actor_name
+                                       ?spawn_role:prepared.spec.spawn_role
+                                       ?spawn_model:prepared.spec.spawn_model
+                                       ?spawn_selection_note:
+                                         prepared.spec.spawn_selection_note
+                                       ~success:false ~error:msg ())
+                                   prepared_spawns;
+                                 Some (`Assoc [ ("error", `String msg) ])
+                             | Ok () ->
+                                 let results =
+                                   Array.make (List.length prepared_spawns) None
+                                 in
+                                 Eio.Fiber.all
+                                   (List.mapi
+                                      (fun index prepared () ->
+                                        let spawn_result =
+                                          Spawn_eio.spawn ~sw:ctx.sw ~proc_mgr:pm
+                                            ~agent_name:prepared.spec.spawn_agent
+                                            ~prompt:prepared.spec.spawn_prompt
+                                            ~timeout_seconds:
+                                              prepared.spec.spawn_timeout_seconds
+                                            ~room_config:ctx.config
+                                            ?runtime_agent_name:
+                                              prepared.runtime_actor_name
+                                            ~runtime_model:prepared.runtime_model
+                                            ?runtime_role:prepared.spec.spawn_role
+                                            ?runtime_selection_note:
+                                              prepared.spec.spawn_selection_note
+                                            ~runtime_session_id:session_id ()
+                                        in
+                                        let output_preview =
+                                          truncate_for_event spawn_result.output
+                                        in
+                                        append_spawn_event
+                                          ~spawn_agent:prepared.spec.spawn_agent
+                                          ?runtime_actor:prepared.runtime_actor_name
+                                          ?spawn_role:prepared.spec.spawn_role
+                                          ?spawn_model:prepared.spec.spawn_model
+                                          ?spawn_selection_note:
+                                            prepared.spec.spawn_selection_note
+                                          ~success:spawn_result.success
+                                          ~exit_code:spawn_result.exit_code
+                                          ~elapsed_ms:spawn_result.elapsed_ms
+                                          ~output_preview ();
+                                        results.(index) <-
+                                          Some
+                                            (`Assoc
+                                              [
+                                                ("agent", `String prepared.spec.spawn_agent);
+                                                ( "runtime_actor",
+                                                  Option.fold ~none:`Null
+                                                    ~some:(fun s -> `String s)
+                                                    prepared.runtime_actor_name );
+                                                ( "spawn_role",
+                                                  Option.fold ~none:`Null
+                                                    ~some:(fun s -> `String s)
+                                                    prepared.spec.spawn_role );
+                                                ( "spawn_model",
+                                                  Option.fold ~none:`Null
+                                                    ~some:(fun s -> `String s)
+                                                    prepared.spec.spawn_model );
+                                                ( "spawn_selection_note",
+                                                  Option.fold ~none:`Null
+                                                    ~some:(fun s -> `String s)
+                                                    prepared.spec.spawn_selection_note );
+                                                ("success", `Bool spawn_result.success);
+                                                ("exit_code", `Int spawn_result.exit_code);
+                                                ("elapsed_ms", `Int spawn_result.elapsed_ms);
+                                                ("output_preview", `String output_preview);
+                                                ( "input_tokens",
+                                                  int_opt_to_json
+                                                    spawn_result.input_tokens );
+                                                ( "output_tokens",
+                                                  int_opt_to_json
+                                                    spawn_result.output_tokens );
+                                                ( "cache_creation_tokens",
+                                                  int_opt_to_json
+                                                    spawn_result.cache_creation_tokens
+                                                );
+                                                ( "cache_read_tokens",
+                                                  int_opt_to_json
+                                                    spawn_result.cache_read_tokens );
+                                                ( "cost_usd",
+                                                  float_opt_to_json
+                                                    spawn_result.cost_usd );
+                                              ]))
+                                      prepared_spawns);
+                                 let spawn_results =
+                                   results
+                                   |> Array.to_list
+                                   |> List.filter_map (fun item -> item)
+                                 in
+                                 Some
+                                   (if List.length spawn_results = 1 then
+                                      List.hd spawn_results
+                                    else
+                                      `Assoc
+                                        [
+                                          ("mode", `String "batch");
+                                          ("count", `Int (List.length spawn_results));
+                                          ("results", `List spawn_results);
+                                        ])
               in
               let spawn_error =
                 match spawn_result_json with
@@ -1119,6 +1343,34 @@ let schemas : tool_schema list =
                   ("spawn_selection_note", `Assoc [ ("type", `String "string") ]);
                   ("spawn_prompt", `Assoc [ ("type", `String "string") ]);
                   ("spawn_timeout_seconds", `Assoc [ ("type", `String "integer") ]);
+                  ( "spawn_batch",
+                    `Assoc
+                      [
+                        ("type", `String "array");
+                        ( "items",
+                          `Assoc
+                            [
+                              ("type", `String "object");
+                              ( "properties",
+                                `Assoc
+                                  [
+                                    ("spawn_agent", `Assoc [ ("type", `String "string") ]);
+                                    ("spawn_model", `Assoc [ ("type", `String "string") ]);
+                                    ("spawn_role", `Assoc [ ("type", `String "string") ]);
+                                    ( "spawn_selection_note",
+                                      `Assoc [ ("type", `String "string") ] );
+                                    ("spawn_prompt", `Assoc [ ("type", `String "string") ]);
+                                    ( "spawn_timeout_seconds",
+                                      `Assoc [ ("type", `String "integer") ] );
+                                  ] );
+                              ( "required",
+                                `List
+                                  [
+                                    `String "spawn_agent";
+                                    `String "spawn_prompt";
+                                  ] );
+                            ] );
+                      ] );
                   ("vote_topic", `Assoc [ ("type", `String "string") ]);
                   ( "vote_options",
                     `Assoc

--- a/scripts/harness/workload/supervisor_team_session.sh
+++ b/scripts/harness/workload/supervisor_team_session.sh
@@ -227,19 +227,24 @@ join_with_token() {
   require_tool_success "$join_raw"
 }
 
-spawn_llama_worker() {
-  local role="$1"
-  local prompt="$2"
-  local selection_note="$3"
+spawn_llama_batch() {
+  local selection_note="$1"
+  local planner_prompt="$2"
+  local implementer_a_prompt="$3"
+  local implementer_b_prompt="$4"
   local raw
   raw="$(call_tool "$MCP_URL" "$SUPERVISOR_SESSION_ID" "$SUPERVISOR_TOKEN" 30 "masc_team_session_step" "$(jq -cn \
     --arg s "$TEAM_SESSION_ID" \
-    --arg spawn_agent "llama" \
-    --arg spawn_model "$LLAMA_SWARM_MODEL" \
-    --arg spawn_role "$role" \
-    --arg spawn_selection_note "$selection_note" \
-    --arg spawn_prompt "$prompt" \
-    '{session_id:$s,spawn_agent:$spawn_agent,spawn_model:$spawn_model,spawn_role:$spawn_role,spawn_selection_note:$spawn_selection_note,spawn_prompt:$spawn_prompt,spawn_timeout_seconds:90}')")"
+    --arg model "$LLAMA_SWARM_MODEL" \
+    --arg note "$selection_note" \
+    --arg planner_prompt "$planner_prompt" \
+    --arg implementer_a_prompt "$implementer_a_prompt" \
+    --arg implementer_b_prompt "$implementer_b_prompt" \
+    '{session_id:$s,spawn_batch:[
+      {spawn_agent:"llama",spawn_model:$model,spawn_role:"planner",spawn_selection_note:$note,spawn_prompt:$planner_prompt,spawn_timeout_seconds:90},
+      {spawn_agent:"llama",spawn_model:$model,spawn_role:"implementer-a",spawn_selection_note:$note,spawn_prompt:$implementer_a_prompt,spawn_timeout_seconds:90},
+      {spawn_agent:"llama",spawn_model:$model,spawn_role:"implementer-b",spawn_selection_note:$note,spawn_prompt:$implementer_b_prompt,spawn_timeout_seconds:90}
+    ]}')")"
   require_tool_success "$raw"
   printf '%s' "$raw"
 }
@@ -306,15 +311,10 @@ printf '[6/10] spawn full llama team\n'
 planner_prompt="You are the planner. Inspect the active team session, then record exactly one concise planning turn with masc_team_session_turn describing task decomposition and acceptance criteria."
 implementer_a_prompt="You are implementer-a. Inspect the active team session, then record exactly one concise implementation turn with masc_team_session_turn describing backend/runtime work."
 implementer_b_prompt="You are implementer-b. Inspect the active team session, then record exactly one concise implementation turn with masc_team_session_turn describing docs/tests/harness work."
-planner_spawn_raw="$(spawn_llama_worker "planner" "$planner_prompt" "$MODEL_SELECTION_NOTE")"
-implementer_a_spawn_raw="$(spawn_llama_worker "implementer-a" "$implementer_a_prompt" "$MODEL_SELECTION_NOTE")"
-implementer_b_spawn_raw="$(spawn_llama_worker "implementer-b" "$implementer_b_prompt" "$MODEL_SELECTION_NOTE")"
-printf '%s' "$planner_spawn_raw" | extract_tool_result | jq -e '.spawn.runtime_actor != null and .turn == null' >/dev/null
-printf '%s' "$implementer_a_spawn_raw" | extract_tool_result | jq -e '.spawn.runtime_actor != null and .turn == null' >/dev/null
-printf '%s' "$implementer_b_spawn_raw" | extract_tool_result | jq -e '.spawn.runtime_actor != null and .turn == null' >/dev/null
-printf '%s' "$planner_spawn_raw" | extract_tool_result | jq -e --arg note "$MODEL_SELECTION_NOTE" '.spawn.spawn_selection_note == $note' >/dev/null
-printf '%s' "$implementer_a_spawn_raw" | extract_tool_result | jq -e --arg note "$MODEL_SELECTION_NOTE" '.spawn.spawn_selection_note == $note' >/dev/null
-printf '%s' "$implementer_b_spawn_raw" | extract_tool_result | jq -e --arg note "$MODEL_SELECTION_NOTE" '.spawn.spawn_selection_note == $note' >/dev/null
+spawn_batch_raw="$(spawn_llama_batch "$MODEL_SELECTION_NOTE" "$planner_prompt" "$implementer_a_prompt" "$implementer_b_prompt")"
+printf '%s' "$spawn_batch_raw" | extract_tool_result | jq -e '.spawn.mode == "batch" and .spawn.count == 3 and (.spawn.results | length) == 3 and .turn == null' >/dev/null
+printf '%s' "$spawn_batch_raw" | extract_tool_result | jq -e '.spawn.results | all(.runtime_actor != null)' >/dev/null
+printf '%s' "$spawn_batch_raw" | extract_tool_result | jq -e --arg note "$MODEL_SELECTION_NOTE" '.spawn.results | all(.spawn_selection_note == $note)' >/dev/null
 
 printf '[7/10] inspect remote operator surface\n'
 tools_raw="$(jsonrpc_call "$OPERATOR_URL" "$SUPERVISOR_OP_SESSION_ID" "$SUPERVISOR_TOKEN" 4 "tools/list" '{}')"

--- a/test/test_mcp_server_eio.ml
+++ b/test/test_mcp_server_eio.ml
@@ -394,6 +394,44 @@ let test_handle_request_tools_call_operator_profile_rejects_non_operator () =
    | _ -> Alcotest.fail "response not an object");
   cleanup_dir base_path
 
+let test_handle_request_tools_list_with_names_filter () =
+  Eio_main.run @@ fun env ->
+  let clock = Eio.Stdenv.clock env in
+  Eio.Switch.run @@ fun sw ->
+  let base_path = temp_dir () in
+  let state = Mcp_eio.create_state ~test_mode:true ~base_path () in
+  let request = Yojson.Safe.to_string (`Assoc [
+    ("jsonrpc", `String "2.0");
+    ("id", `Int 120);
+    ("method", `String "tools/list");
+    ("params", `Assoc [
+      ("names", `List [ `String "masc_status"; `String "masc_broadcast" ]);
+    ]);
+  ]) in
+  let response =
+    Mcp_eio.handle_request ~clock ~sw state request
+  in
+  (match response with
+   | `Assoc fields ->
+       (match List.assoc_opt "result" fields with
+        | Some (`Assoc result_fields) ->
+            (match List.assoc_opt "tools" result_fields with
+             | Some (`List tools) ->
+                 let names =
+                   tools
+                   |> List.filter_map (function
+                        | `Assoc tool_fields -> List.assoc_opt "name" tool_fields
+                        | _ -> None)
+                   |> List.filter_map (function `String s -> Some s | _ -> None)
+                 in
+                 Alcotest.(check (list string)) "filtered tool names"
+                   [ "masc_status"; "masc_broadcast" ]
+                   names
+             | _ -> Alcotest.fail "tools not a list")
+        | _ -> Alcotest.fail "result not an object")
+   | _ -> Alcotest.fail "response not an object");
+  cleanup_dir base_path
+
 let test_handle_request_tools_list_with_placeholder_flag () =
   with_env "MASC_PLACEHOLDER_TOOLS_ENABLED" "1" (fun () ->
     Eio_main.run @@ fun env ->
@@ -884,10 +922,12 @@ let response_tests = [
 let eio_tests = [
   "handle initialize", `Quick, test_handle_request_initialize;
   "handle initialize operator profile", `Quick,
-  test_handle_request_initialize_operator_profile;
+    test_handle_request_initialize_operator_profile;
   "handle tools/list", `Quick, test_handle_request_tools_list;
+  "handle tools/list with names filter", `Quick,
+    test_handle_request_tools_list_with_names_filter;
   "handle tools/list operator profile", `Quick,
-  test_handle_request_tools_list_operator_profile;
+    test_handle_request_tools_list_operator_profile;
   "handle tools/list with placeholder flag", `Quick, test_handle_request_tools_list_with_placeholder_flag;
   "reject non-operator tool on operator profile", `Quick,
   test_handle_request_tools_call_operator_profile_rejects_non_operator;

--- a/test/test_spawn_eio_coverage.ml
+++ b/test/test_spawn_eio_coverage.ml
@@ -160,6 +160,14 @@ let test_masc_mcp_tools_contains_run_deliverable () =
   check bool "contains run_deliverable" true
     (List.mem "mcp__masc__masc_run_deliverable" Spawn_eio.masc_mcp_tools)
 
+let test_llama_mcp_tools_curated () =
+  check (list string) "llama tools"
+    [
+      "mcp__masc__masc_team_session_status";
+      "mcp__masc__masc_team_session_turn";
+    ]
+    Spawn_eio.llama_mcp_tools
+
 (* ============================================================
    masc_lifecycle_suffix Tests
    ============================================================ *)
@@ -496,6 +504,7 @@ let () =
         test_masc_mcp_tools_contains_vote_create;
       test_case "contains run_deliverable" `Quick
         test_masc_mcp_tools_contains_run_deliverable;
+      test_case "llama curated subset" `Quick test_llama_mcp_tools_curated;
     ];
     "masc_lifecycle_suffix", [
       test_case "not empty" `Quick test_masc_lifecycle_suffix_not_empty;

--- a/test/test_tool_team_session.ml
+++ b/test/test_tool_team_session.ml
@@ -143,6 +143,7 @@ let make_manual_session config ~goal ~created_by ~agent_names ~min_agents
       report_formats = [ Team_session_types.Markdown; Team_session_types.Json ];
       turn_count = 0;
       agent_names;
+      planned_workers = [];
       broadcast_count = 0;
       portal_count = 0;
       cascade_attempted = 0;
@@ -317,6 +318,7 @@ let test_recover_elapsed_session () =
       report_formats = [ Team_session_types.Markdown; Team_session_types.Json ];
       turn_count = 0;
       agent_names = [ "tester" ];
+      planned_workers = [];
       broadcast_count = 0;
       portal_count = 0;
       cascade_attempted = 0;
@@ -610,6 +612,22 @@ let test_proof_exposes_spawn_selection_rationale () =
           ("output_preview", `String "worker turn recorded");
           ("ts_iso", `String (Types.now_iso ()));
         ]);
+  ignore
+    (Team_session_store.update_session config session_id (fun s ->
+         {
+           s with
+           planned_workers =
+             Team_session_types.dedup_planned_workers
+               [
+                 {
+                   Team_session_types.spawn_agent = "llama";
+                   runtime_actor = Some "llama-local-proof";
+                   spawn_role = Some "planner";
+                   spawn_model = Some spawn_model;
+                 };
+               ];
+           updated_at_iso = Types.now_iso ();
+         }));
   let turn_ok, _ =
     dispatch_exn ctx ~name:"masc_team_session_turn"
       ~args:
@@ -652,11 +670,21 @@ let test_proof_exposes_spawn_selection_rationale () =
     evidence |> Yojson.Safe.Util.member "spawn_selection_note_summary"
     |> Yojson.Safe.Util.to_string
   in
+  let planned_worker_count =
+    evidence |> Yojson.Safe.Util.member "planned_worker_count"
+    |> Yojson.Safe.Util.to_int
+  in
+  let runtime_actor_count =
+    evidence |> Yojson.Safe.Util.member "unique_spawn_runtime_actors_count"
+    |> Yojson.Safe.Util.to_int
+  in
   let recorded_models =
     evidence |> Yojson.Safe.Util.member "spawn_models"
     |> Yojson.Safe.Util.to_list |> List.map Yojson.Safe.Util.to_string
   in
   Alcotest.(check string) "selection note summary" selection_note recorded_note;
+  Alcotest.(check int) "planned worker count" 1 planned_worker_count;
+  Alcotest.(check int) "runtime actor count" 1 runtime_actor_count;
   Alcotest.(check bool) "spawn model included" true
     (List.mem spawn_model recorded_models);
   let proof_md_path =
@@ -1106,12 +1134,97 @@ let test_step_spawn_llama_requires_spawn_model () =
     detail |> Yojson.Safe.Util.member "spawn_model"
   in
   Alcotest.(check bool) "spawn_model absent in failure event" true (spawn_model = `Null);
+  let attached_events =
+    Team_session_store.read_events config session_id
+    |> List.filter (fun json ->
+           Yojson.Safe.Util.member "event_type" json
+           = `String "session_agent_attached")
+  in
+  Alcotest.(check int) "no phantom attachment on validation failure" 0
+    (List.length attached_events);
   let recorded_selection_note =
     detail |> Yojson.Safe.Util.member "spawn_selection_note"
     |> Yojson.Safe.Util.to_string_option
   in
   Alcotest.(check (option string)) "selection note recorded in failure event"
     (Some selection_note) recorded_selection_note;
+  cleanup_dir base_dir
+
+let test_step_spawn_batch_records_planned_workers () =
+  Eio_main.run @@ fun env ->
+  Eio.Switch.run @@ fun sw ->
+  let base_dir = temp_dir () in
+  let config = Room.default_config base_dir in
+  ignore (Room.init config ~agent_name:(Some "owner"));
+  ignore (Room.join config ~agent_name:"owner" ~capabilities:[] ());
+  let ctx : _ Tool_team_session.context =
+    { config; agent_name = "owner"; sw; clock = Eio.Stdenv.clock env; proc_mgr = None }
+  in
+  let session_id = start_session_exn ctx ~goal:"step-spawn-batch-planned-workers" |> get_session_id in
+  let selection_note =
+    "[model-selection] leader selected qwen3.5-35b-a3b-ud-q8-xl from inventory"
+  in
+  let step_ok, step_body =
+    dispatch_exn ctx ~name:"masc_team_session_step"
+      ~args:
+        (`Assoc
+          [
+            ("session_id", `String session_id);
+            ( "spawn_batch",
+              `List
+                [
+                  `Assoc
+                    [
+                      ("spawn_agent", `String "llama");
+                      ("spawn_model", `String "qwen3.5-35b-a3b-ud-q8-xl");
+                      ("spawn_role", `String "planner");
+                      ("spawn_selection_note", `String selection_note);
+                      ("spawn_prompt", `String "planner prompt");
+                    ];
+                  `Assoc
+                    [
+                      ("spawn_agent", `String "llama");
+                      ("spawn_model", `String "qwen3.5-35b-a3b-ud-q8-xl");
+                      ("spawn_role", `String "implementer-a");
+                      ("spawn_selection_note", `String selection_note);
+                      ("spawn_prompt", `String "implementer prompt");
+                    ];
+                ] );
+          ])
+  in
+  Alcotest.(check bool) "batch step fails without proc manager" false step_ok;
+  let body = parse_json_exn step_body in
+  let message = body |> Yojson.Safe.Util.member "message" |> Yojson.Safe.Util.to_string in
+  Alcotest.(check bool) "proc manager error surfaced" true
+    (try
+       let _ =
+         Str.search_forward
+           (Str.regexp_string "process manager unavailable")
+           message 0
+       in
+       true
+     with Not_found -> false);
+  let session =
+    Team_session_store.load_session config session_id |> Option.get
+  in
+  Alcotest.(check int) "planned workers recorded" 2
+    (List.length session.planned_workers);
+  let attached_events =
+    Team_session_store.read_events config session_id
+    |> List.filter (fun json ->
+           Yojson.Safe.Util.member "event_type" json
+           = `String "session_agent_attached")
+  in
+  Alcotest.(check int) "no attachment when proc manager missing" 0
+    (List.length attached_events);
+  let planned_events =
+    Team_session_store.read_events config session_id
+    |> List.filter (fun json ->
+           Yojson.Safe.Util.member "event_type" json
+           = `String "session_planned_workers_updated")
+  in
+  Alcotest.(check int) "planned worker event recorded" 1
+    (List.length planned_events);
   cleanup_dir base_dir
 
 let test_prove_strong_requires_additional_evidence () =
@@ -1376,6 +1489,8 @@ let () =
             test_step_spawn_requires_proc_mgr;
           Alcotest.test_case "step-spawn-llama-requires-spawn-model" `Quick
             test_step_spawn_llama_requires_spawn_model;
+          Alcotest.test_case "step-spawn-batch-records-planned-workers"
+            `Quick test_step_spawn_batch_records_planned_workers;
           Alcotest.test_case "prove-strong-requires-additional-evidence" `Quick
             test_prove_strong_requires_additional_evidence;
           Alcotest.test_case "dispatch-unknown" `Quick test_dispatch_unknown;

--- a/test/test_tool_team_session.ml
+++ b/test/test_tool_team_session.ml
@@ -117,6 +117,59 @@ and start_session_custom_exn ctx ~goal ~min_agents ~agents =
   Alcotest.(check bool) "start ok" true start_ok;
   parse_json_exn start_body
 
+let make_manual_session config ~goal ~created_by ~agent_names ~min_agents
+    ~checkpoint_interval_sec ~started_at ~planned_end_at ~fallback_policy
+    ~model_cascade =
+  let session_id = Team_session_store.make_session_id () in
+  Team_session_store.ensure_session_dirs config session_id;
+  let session : Team_session_types.session =
+    {
+      session_id;
+      goal;
+      created_by;
+      room_id = "default";
+      status = Team_session_types.Running;
+      duration_seconds = int_of_float (max 60.0 (planned_end_at -. started_at));
+      execution_scope = Team_session_types.Limited_code_change;
+      checkpoint_interval_sec;
+      min_agents;
+      orchestration_mode = Team_session_types.Assist;
+      communication_mode = Team_session_types.Comm_broadcast;
+      model_cascade;
+      fallback_policy;
+      instruction_profile = Team_session_types.Profile_strict;
+      alert_channel = Team_session_types.Alert_both;
+      auto_resume = true;
+      report_formats = [ Team_session_types.Markdown; Team_session_types.Json ];
+      turn_count = 0;
+      agent_names;
+      broadcast_count = 0;
+      portal_count = 0;
+      cascade_attempted = 0;
+      cascade_success = 0;
+      cascade_failed = 0;
+      fallback_task_created = 0;
+      min_agents_violation_streak = 0;
+      policy_violations = [];
+      baseline_done_counts = [];
+      final_done_delta_total = None;
+      final_done_delta_by_agent = None;
+      started_at;
+      planned_end_at;
+      stopped_at = None;
+      last_checkpoint_at = Some started_at;
+      last_event_at = Some started_at;
+      last_turn_at = None;
+      stop_reason = None;
+      generated_report = false;
+      artifacts_dir = Team_session_store.session_dir config session_id;
+      created_at_iso = Types.now_iso ();
+      updated_at_iso = Types.now_iso ();
+    }
+  in
+  Team_session_store.save_session config session;
+  session
+
 let test_start_status_report_stop () =
   Eio_main.run @@ fun env ->
   Eio.Switch.run @@ fun sw ->
@@ -623,6 +676,138 @@ let test_proof_exposes_spawn_selection_rationale () =
   Alcotest.(check bool) "markdown includes rationale" true
     (try
        let _ = Str.search_forward (Str.regexp_string selection_note) proof_md 0 in
+       true
+     with Not_found -> false);
+  cleanup_dir base_dir
+
+let test_bootstrap_grace_suppresses_min_agents_violation () =
+  Eio_main.run @@ fun _env ->
+  Eio.Switch.run @@ fun _sw ->
+  let base_dir = temp_dir () in
+  let config = Room.default_config base_dir in
+  ignore (Room.init config ~agent_name:(Some "owner"));
+  let now = Time_compat.now () in
+  let session =
+    make_manual_session config ~goal:"bootstrap-grace"
+      ~created_by:"owner" ~agent_names:[ "owner" ] ~min_agents:4
+      ~checkpoint_interval_sec:10 ~started_at:(now -. 5.0)
+      ~planned_end_at:(now +. 120.0)
+      ~fallback_policy:Team_session_types.Fallback_task_only ~model_cascade:[]
+  in
+  let updated = Team_session_engine_eio.apply_runtime_policy ~config session in
+  Alcotest.(check int) "violation streak suppressed" 0
+    updated.min_agents_violation_streak;
+  Alcotest.(check int) "fallback suppressed" 0 updated.fallback_task_created;
+  let events = Team_session_store.read_events config session.session_id in
+  let violation_events =
+    List.filter
+      (fun json ->
+        Yojson.Safe.Util.member "event_type" json = `String "min_agents_violation")
+      events
+  in
+  Alcotest.(check int) "no violation events during bootstrap" 0
+    (List.length violation_events);
+  cleanup_dir base_dir
+
+let test_min_agents_violation_after_bootstrap_grace () =
+  Eio_main.run @@ fun _env ->
+  Eio.Switch.run @@ fun _sw ->
+  let base_dir = temp_dir () in
+  let config = Room.default_config base_dir in
+  ignore (Room.init config ~agent_name:(Some "owner"));
+  let now = Time_compat.now () in
+  let session =
+    make_manual_session config ~goal:"post-bootstrap-violation"
+      ~created_by:"owner" ~agent_names:[ "owner" ] ~min_agents:4
+      ~checkpoint_interval_sec:10 ~started_at:(now -. 120.0)
+      ~planned_end_at:(now +. 120.0)
+      ~fallback_policy:Team_session_types.Fallback_task_only ~model_cascade:[]
+  in
+  let session = { session with min_agents_violation_streak = 1 } in
+  let updated = Team_session_engine_eio.apply_runtime_policy ~config session in
+  Alcotest.(check int) "violation streak increments after grace" 2
+    updated.min_agents_violation_streak;
+  Alcotest.(check int) "fallback not emitted on non-alert tick" 0
+    updated.fallback_task_created;
+  let events = Team_session_store.read_events config session.session_id in
+  let violation_events =
+    List.filter
+      (fun json ->
+        Yojson.Safe.Util.member "event_type" json = `String "min_agents_violation")
+      events
+  in
+  Alcotest.(check int) "violation event recorded after grace" 1
+    (List.length violation_events);
+  cleanup_dir base_dir
+
+let test_report_uses_participant_and_turn_metrics () =
+  let base_dir = temp_dir () in
+  let config = Room.default_config base_dir in
+  ignore (Room.init config ~agent_name:(Some "owner"));
+  let now = Time_compat.now () in
+  let session =
+    make_manual_session config ~goal:"report-participants-turns"
+      ~created_by:"owner" ~agent_names:[ "owner"; "ally1"; "ally2" ]
+      ~min_agents:3 ~checkpoint_interval_sec:10 ~started_at:(now -. 30.0)
+      ~planned_end_at:(now +. 90.0)
+      ~fallback_policy:Team_session_types.Fallback_none
+      ~model_cascade:[ "llama:qwen3.5-35b-a3b-ud-q8-xl" ]
+  in
+  ignore
+    (unwrap_ok
+       (Team_session_engine_eio.record_turn ~config ~session_id:session.session_id
+          ~actor:"owner" ~turn_kind:Team_session_types.Turn_note
+          ~message:(Some "owner turn") ~target_agent:None ~task_title:None
+          ~task_description:None ~task_priority:3));
+  ignore
+    (unwrap_ok
+       (Team_session_engine_eio.record_turn ~config ~session_id:session.session_id
+          ~actor:"ally1" ~turn_kind:Team_session_types.Turn_note
+          ~message:(Some "ally1 turn") ~target_agent:None ~task_title:None
+          ~task_description:None ~task_priority:3));
+  ignore
+    (unwrap_ok
+       (Team_session_engine_eio.record_turn ~config ~session_id:session.session_id
+          ~actor:"ally2" ~turn_kind:Team_session_types.Turn_task ~message:None
+          ~target_agent:None ~task_title:(Some "task from ally2")
+          ~task_description:(Some "noop task") ~task_priority:2));
+  let reloaded =
+    Team_session_store.load_session config session.session_id
+    |> Option.get
+  in
+  let report_json, markdown =
+    unwrap_ok (Team_session_report.generate config reloaded)
+  in
+  let active_agents_count =
+    report_json |> Yojson.Safe.Util.member "team_health"
+    |> Yojson.Safe.Util.member "active_agents_count"
+    |> Yojson.Safe.Util.to_int
+  in
+  let room_active_agents =
+    report_json |> Yojson.Safe.Util.member "summary"
+    |> Yojson.Safe.Util.member "room_active_agents"
+    |> Yojson.Safe.Util.to_list
+  in
+  let turn_metrics =
+    report_json |> Yojson.Safe.Util.member "agent_turn_metrics"
+    |> Team_session_types.assoc_int_of_json
+  in
+  Alcotest.(check int) "participant count drives team health" 3 active_agents_count;
+  Alcotest.(check bool) "participant count exceeds room active count" true
+    (active_agents_count > List.length room_active_agents);
+  Alcotest.(check int) "owner turn metric" 1
+    (List.assoc "owner" turn_metrics);
+  Alcotest.(check int) "ally1 turn metric" 1
+    (List.assoc "ally1" turn_metrics);
+  Alcotest.(check int) "ally2 turn metric" 1
+    (List.assoc "ally2" turn_metrics);
+  Alcotest.(check bool) "markdown shows turn-based contribution" true
+    (try
+       let _ =
+         Str.search_forward
+           (Str.regexp_string "- ally2: turns=1, done_delta=0")
+           markdown 0
+       in
        true
      with Not_found -> false);
   cleanup_dir base_dir
@@ -1168,6 +1353,12 @@ let () =
             test_start_status_report_stop;
           Alcotest.test_case "proof-exposes-spawn-selection-rationale" `Quick
             test_proof_exposes_spawn_selection_rationale;
+          Alcotest.test_case "bootstrap-grace-suppresses-min-agents-violation"
+            `Quick test_bootstrap_grace_suppresses_min_agents_violation;
+          Alcotest.test_case "min-agents-violation-after-bootstrap-grace"
+            `Quick test_min_agents_violation_after_bootstrap_grace;
+          Alcotest.test_case "report-uses-participant-and-turn-metrics" `Quick
+            test_report_uses_participant_and_turn_metrics;
           Alcotest.test_case "duration-reached-path" `Quick
             test_duration_reached_path;
           Alcotest.test_case "recover-elapsed-session" `Quick

--- a/test/test_tools_coverage.ml
+++ b/test/test_tools_coverage.ml
@@ -564,6 +564,16 @@ let test_masc_team_session_step_spawn_selection_note_schema () =
             (List.mem_assoc "spawn_selection_note" props)
       | None -> Alcotest.fail "masc_team_session_step missing properties"
 
+let test_masc_team_session_step_spawn_batch_schema () =
+  match find_tool "masc_team_session_step" with
+  | None -> Alcotest.fail "masc_team_session_step not found"
+  | Some schema ->
+      match get_json_assoc "properties" schema.input_schema with
+      | Some props ->
+          Alcotest.(check bool) "has spawn_batch" true
+            (List.mem_assoc "spawn_batch" props)
+      | None -> Alcotest.fail "masc_team_session_step missing properties"
+
 (* ============================================================ *)
 (* 13. Cache Tool Tests                                          *)
 (* ============================================================ *)
@@ -886,6 +896,8 @@ let () =
       Alcotest.test_case "llama-models" `Quick test_masc_llama_models_schema;
       Alcotest.test_case "team-session-step-spawn-selection-note" `Quick
         test_masc_team_session_step_spawn_selection_note_schema;
+      Alcotest.test_case "team-session-step-spawn-batch" `Quick
+        test_masc_team_session_step_spawn_batch_schema;
     ];
     "cache_tools", [
       Alcotest.test_case "cache_set" `Quick test_masc_cache_set_schema;


### PR DESCRIPTION
## Summary
- harden spawned swarm health/contribution reporting for llama team sessions
- add planned worker roster and concurrent llama batch spawn support
- shrink local llama worker tool surface and filtered tools/list to unblock live batch spawn

## Verification
- dune build --root . @default
- ./_build/default/test/test_mcp_server_eio.exe
- ./_build/default/test/test_spawn_eio_coverage.exe
- ./_build/default/test/test_tool_team_session.exe
- ./_build/default/test/test_tools_coverage.exe
- env LLAMA_SWARM_MODEL=qwen3.5-35b-a3b-ud-q8-xl HTTP_TIMEOUT_SEC=90 ./scripts/harness_supervisor_team_session.sh