### PR TITLE
Fix team session failed batch spawn accounting

### DIFF
--- a/lib/team_session_report.ml
+++ b/lib/team_session_report.ml
@@ -631,6 +631,14 @@ let count_spawn_success events =
       | _ -> acc)
     0 events
 
+let count_spawn_failure events =
+  List.fold_left
+    (fun acc json ->
+      match team_step_spawn_success json with
+      | Some false -> acc + 1
+      | _ -> acc)
+    0 events
+
 let find_criterion criteria name =
   criteria
   |> List.find_opt (fun item ->
@@ -876,6 +884,7 @@ let proof_markdown ~(session : Team_session_types.session)
     ~(checkpoints_count : int) ~(events_count : int) ~(turn_events : int)
     ~(report_exists : bool) ~(unique_turn_actors_count : int)
     ~(required_turn_actors : int) ~(spawn_models : string list)
+    ~(spawn_failure_count : int) ~(detached_agent_count : int)
     ~(planned_workers : Team_session_types.planned_worker list)
     ~(unique_spawn_runtime_actors_count : int)
     ~(spawn_selection_note_summary : string option)
@@ -938,6 +947,8 @@ let proof_markdown ~(session : Team_session_types.session)
       Printf.sprintf "- Planned workers: %d" (List.length planned_workers);
       Printf.sprintf "- Unique spawned runtime actors: %d"
         unique_spawn_runtime_actors_count;
+      Printf.sprintf "- Failed spawn events: %d" spawn_failure_count;
+      Printf.sprintf "- Detached failed actors: %d" detached_agent_count;
       Printf.sprintf "- Spawn models: %s"
         (match spawn_models with
         | [] -> "(not recorded)"
@@ -1019,6 +1030,7 @@ let generate_proof ?(proof_level = default_proof_level) config
     let required_spawn_agents = required_spawn_agents_for_session session in
     let spawn_events = count_event_type events "team_step_spawn" in
     let spawn_success_count = count_spawn_success events in
+    let spawn_failure_count = count_spawn_failure events in
     let unique_spawn_agents =
       collect_spawn_agents events |> Team_session_types.dedup_strings
     in
@@ -1037,6 +1049,7 @@ let generate_proof ?(proof_level = default_proof_level) config
       | [] -> None
       | xs -> Some (String.concat " | " xs)
     in
+    let detached_agent_count = count_event_type events "session_agent_detached" in
     let min_turn_events = min_turn_events_for_session required_turn_actors in
     let min_communication = min_communication_for_session required_turn_actors in
     let vote_events =
@@ -1092,6 +1105,7 @@ let generate_proof ?(proof_level = default_proof_level) config
                 ("required_turn_actors", `Int required_turn_actors);
                 ("spawn_events", `Int spawn_events);
                 ("spawn_success_count", `Int spawn_success_count);
+                ("spawn_failure_count", `Int spawn_failure_count);
                 ("unique_spawn_agents", `List (List.map (fun a -> `String a) unique_spawn_agents));
                 ("unique_spawn_agents_count", `Int unique_spawn_agents_count);
                 ( "unique_spawn_runtime_actors",
@@ -1111,6 +1125,7 @@ let generate_proof ?(proof_level = default_proof_level) config
                 ( "spawn_selection_note_summary",
                   Option.fold ~none:`Null ~some:(fun note -> `String note)
                     spawn_selection_note_summary );
+                ("detached_agent_count", `Int detached_agent_count);
                 ("vote_events", `Int vote_events);
                 ("run_deliverables", `Int run_deliverables);
                 ("broadcast_count", `Int session.broadcast_count);
@@ -1127,6 +1142,7 @@ let generate_proof ?(proof_level = default_proof_level) config
         ~checkpoints_count ~events_count:(List.length events) ~turn_events
         ~report_exists:(report_json_exists && report_md_exists)
         ~unique_turn_actors_count ~required_turn_actors ~spawn_models
+        ~spawn_failure_count ~detached_agent_count
         ~planned_workers:session.planned_workers
         ~unique_spawn_runtime_actors_count
         ~spawn_selection_note_summary

--- a/lib/tool_team_session.ml
+++ b/lib/tool_team_session.ml
@@ -499,6 +499,49 @@ let ensure_session_actor config session_id actor_name =
       Ok ()
   | Error e -> Error e
 
+let detach_session_actor config session_id actor_name ~reason =
+  match Team_session_store.update_session config session_id (fun session ->
+            let agent_names =
+              List.filter
+                (fun existing -> not (String.equal existing actor_name))
+                session.agent_names
+            in
+            { session with agent_names; updated_at_iso = Types.now_iso () })
+  with
+  | Ok updated ->
+      Team_session_store.append_event config session_id
+        ~event_type:"session_agent_detached"
+        ~detail:
+          (`Assoc
+            [
+              ("actor", `String actor_name);
+              ("reason", `String reason);
+              ("agent_count", `Int (List.length updated.agent_names));
+              ("ts_iso", `String (Types.now_iso ()));
+            ]);
+      Ok ()
+  | Error e -> Error e
+
+let session_has_turn_for_actor config session_id actor_name =
+  Team_session_store.read_events config session_id
+  |> List.exists (fun json ->
+         match
+           ( Yojson.Safe.Util.member "event_type" json,
+             Yojson.Safe.Util.member "detail" json
+             |> Yojson.Safe.Util.member "actor" )
+         with
+         | `String "team_turn", `String recorded_actor ->
+             String.equal (String.trim recorded_actor) actor_name
+         | _ -> false)
+
+let reconcile_failed_spawn_actor config session_id actor_name =
+  if session_has_turn_for_actor config session_id actor_name then
+    Ok `Retained
+  else
+    detach_session_actor config session_id actor_name
+      ~reason:"spawn_failed_without_turn"
+    |> Result.map (fun () -> `Detached)
+
 let extract_vote_id (text : string) =
   let re = Str.regexp "vote-[0-9-]+-[0-9]+" in
   try
@@ -741,6 +784,15 @@ let handle_step ctx args : result =
                                           ~exit_code:spawn_result.exit_code
                                           ~elapsed_ms:spawn_result.elapsed_ms
                                           ~output_preview ();
+                                        (match
+                                           (spawn_result.success, prepared.runtime_actor_name)
+                                         with
+                                        | false, Some worker_actor ->
+                                            ignore
+                                              (reconcile_failed_spawn_actor
+                                                 ctx.config session_id
+                                                 worker_actor)
+                                        | _ -> ());
                                         results.(index) <-
                                           Some
                                             (`Assoc

--- a/test/test_tool_team_session.ml
+++ b/test/test_tool_team_session.ml
@@ -1227,6 +1227,178 @@ let test_step_spawn_batch_records_planned_workers () =
     (List.length planned_events);
   cleanup_dir base_dir
 
+let test_reconcile_failed_spawn_actor_detaches_without_turn () =
+  let base_dir = temp_dir () in
+  let config = Room.default_config base_dir in
+  ignore (Room.init config ~agent_name:(Some "owner"));
+  let now = Time_compat.now () in
+  let session =
+    make_manual_session config ~goal:"detach-failed-spawn"
+      ~created_by:"owner" ~agent_names:[ "owner" ] ~min_agents:2
+      ~checkpoint_interval_sec:10 ~started_at:(now -. 10.0)
+      ~planned_end_at:(now +. 120.0)
+      ~fallback_policy:Team_session_types.Fallback_none ~model_cascade:[]
+  in
+  ignore (unwrap_ok (Tool_team_session.ensure_session_actor config session.session_id "llama-local-failed"));
+  let outcome =
+    unwrap_ok
+      (Tool_team_session.reconcile_failed_spawn_actor config session.session_id
+         "llama-local-failed")
+  in
+  Alcotest.(check string) "failed spawn actor detached" "detached"
+    (match outcome with `Detached -> "detached" | `Retained -> "retained");
+  let reloaded = Team_session_store.load_session config session.session_id |> Option.get in
+  Alcotest.(check bool) "actor removed from participants" false
+    (List.mem "llama-local-failed" reloaded.agent_names);
+  let detached_events =
+    Team_session_store.read_events config session.session_id
+    |> List.filter (fun json ->
+           Yojson.Safe.Util.member "event_type" json
+           = `String "session_agent_detached")
+  in
+  Alcotest.(check int) "detached event recorded" 1 (List.length detached_events);
+  cleanup_dir base_dir
+
+let test_reconcile_failed_spawn_actor_retains_after_turn () =
+  Eio_main.run @@ fun env ->
+  Eio.Switch.run @@ fun sw ->
+  let base_dir = temp_dir () in
+  let config = Room.default_config base_dir in
+  ignore (Room.init config ~agent_name:(Some "owner"));
+  ignore (Room.join config ~agent_name:"owner" ~capabilities:[] ());
+  let ctx : _ Tool_team_session.context =
+    { config; agent_name = "owner"; sw; clock = Eio.Stdenv.clock env; proc_mgr = None }
+  in
+  let session_id = start_session_exn ctx ~goal:"retain-failed-spawn-after-turn" |> get_session_id in
+  ignore
+    (unwrap_ok
+       (Tool_team_session.ensure_session_actor config session_id
+          "llama-local-turned"));
+  ignore
+    (unwrap_ok
+       (Team_session_engine_eio.record_turn ~config ~session_id
+          ~actor:"llama-local-turned" ~turn_kind:Team_session_types.Turn_note
+          ~message:(Some "worker left one turn before failing")
+          ~target_agent:None ~task_title:None ~task_description:None
+          ~task_priority:3));
+  let outcome =
+    unwrap_ok
+      (Tool_team_session.reconcile_failed_spawn_actor config session_id
+         "llama-local-turned")
+  in
+  Alcotest.(check string) "actor retained after emitting a turn" "retained"
+    (match outcome with `Detached -> "detached" | `Retained -> "retained");
+  let reloaded = Team_session_store.load_session config session_id |> Option.get in
+  Alcotest.(check bool) "actor still authorized" true
+    (List.mem "llama-local-turned" reloaded.agent_names);
+  let detached_events =
+    Team_session_store.read_events config session_id
+    |> List.filter (fun json ->
+           Yojson.Safe.Util.member "event_type" json
+           = `String "session_agent_detached")
+  in
+  Alcotest.(check int) "no detach event recorded" 0 (List.length detached_events);
+  cleanup_dir base_dir
+
+let test_proof_exposes_failed_spawn_and_detach_counts () =
+  Eio_main.run @@ fun env ->
+  Eio.Switch.run @@ fun sw ->
+  let base_dir = temp_dir () in
+  let config = Room.default_config base_dir in
+  ignore (Room.init config ~agent_name:(Some "tester"));
+  ignore (Room.join config ~agent_name:"tester" ~capabilities:[] ());
+  let ctx : _ Tool_team_session.context =
+    { config; agent_name = "tester"; sw; clock = Eio.Stdenv.clock env; proc_mgr = None }
+  in
+  let start_json =
+    start_session_exn ctx ~goal:"prove failed spawn and detach visibility"
+  in
+  let session_id = get_session_id start_json in
+  Team_session_store.append_event config session_id ~event_type:"team_step_spawn"
+    ~detail:
+      (`Assoc
+        [
+          ("actor", `String "tester");
+          ("spawn_agent", `String "llama");
+          ("runtime_actor", `String "llama-local-failed");
+          ("spawn_role", `String "implementer-a");
+          ("spawn_model", `String "qwen3.5-35b-a3b-ud-q8-xl");
+          ("success", `Bool false);
+          ("exit_code", `Int 1);
+          ("elapsed_ms", `Int 25);
+          ("error", `String "worker exited early");
+          ("ts_iso", `String (Types.now_iso ()));
+        ]);
+  Team_session_store.append_event config session_id
+    ~event_type:"session_agent_detached"
+    ~detail:
+      (`Assoc
+        [
+          ("actor", `String "llama-local-failed");
+          ("reason", `String "spawn_failed_without_turn");
+          ("agent_count", `Int 1);
+          ("ts_iso", `String (Types.now_iso ()));
+        ]);
+  ignore
+    (dispatch_exn ctx ~name:"masc_team_session_turn"
+       ~args:
+         (`Assoc
+           [
+             ("session_id", `String session_id);
+             ("turn_kind", `String "note");
+             ("message", `String "tester turn for failure proof");
+           ]));
+  ignore
+    (dispatch_exn ctx ~name:"masc_team_session_stop"
+       ~args:
+         (`Assoc
+           [
+             ("session_id", `String session_id);
+             ("reason", `String "failed_spawn_done");
+             ("generate_report", `Bool true);
+           ]));
+  ignore (wait_until_terminal ctx session_id);
+  let prove_ok, prove_body =
+    dispatch_exn ctx ~name:"masc_team_session_prove"
+      ~args:
+        (`Assoc
+          [
+            ("session_id", `String session_id);
+            ("generate_report_if_missing", `Bool true);
+          ])
+  in
+  Alcotest.(check bool) "prove ok" true prove_ok;
+  let prove_result = parse_json_exn prove_body |> result_field in
+  let evidence = prove_result |> Yojson.Safe.Util.member "proof" |> Yojson.Safe.Util.member "evidence" in
+  let spawn_failure_count =
+    evidence |> Yojson.Safe.Util.member "spawn_failure_count"
+    |> Yojson.Safe.Util.to_int
+  in
+  let detached_agent_count =
+    evidence |> Yojson.Safe.Util.member "detached_agent_count"
+    |> Yojson.Safe.Util.to_int
+  in
+  Alcotest.(check int) "spawn failure count recorded" 1 spawn_failure_count;
+  Alcotest.(check int) "detached agent count recorded" 1 detached_agent_count;
+  let proof_md_path =
+    prove_result |> Yojson.Safe.Util.member "proof_md_path"
+    |> Yojson.Safe.Util.to_string
+  in
+  let proof_md = Stdlib.In_channel.with_open_bin proof_md_path Stdlib.In_channel.input_all in
+  Alcotest.(check bool) "markdown includes failed spawn count" true
+    (try
+       let _ = Str.search_forward (Str.regexp_string "Failed spawn events: 1") proof_md 0 in
+       true
+     with Not_found -> false);
+  Alcotest.(check bool) "markdown includes detached actor count" true
+    (try
+       let _ =
+         Str.search_forward (Str.regexp_string "Detached failed actors: 1") proof_md 0
+       in
+       true
+     with Not_found -> false);
+  cleanup_dir base_dir
+
 let test_prove_strong_requires_additional_evidence () =
   Eio_main.run @@ fun env ->
   Eio.Switch.run @@ fun sw ->
@@ -1491,6 +1663,12 @@ let () =
             test_step_spawn_llama_requires_spawn_model;
           Alcotest.test_case "step-spawn-batch-records-planned-workers"
             `Quick test_step_spawn_batch_records_planned_workers;
+          Alcotest.test_case "reconcile-failed-spawn-actor-detaches-without-turn"
+            `Quick test_reconcile_failed_spawn_actor_detaches_without_turn;
+          Alcotest.test_case "reconcile-failed-spawn-actor-retains-after-turn"
+            `Quick test_reconcile_failed_spawn_actor_retains_after_turn;
+          Alcotest.test_case "proof-exposes-failed-spawn-and-detach-counts"
+            `Quick test_proof_exposes_failed_spawn_and_detach_counts;
           Alcotest.test_case "prove-strong-requires-additional-evidence" `Quick
             test_prove_strong_requires_additional_evidence;
           Alcotest.test_case "dispatch-unknown" `Quick test_dispatch_unknown;


### PR DESCRIPTION
## Summary
- detach failed batch-spawned runtime actors when they never recorded a team turn
- retain failed actors that already emitted a turn so proof authorization remains stable
- expose failed spawn and detached actor counts in proof/report artifacts

## Verification
- `dune build --root . @default`
- `./_build/default/test/test_tool_team_session.exe test team_session 14-17`
- `env LLAMA_SWARM_MODEL=qwen3.5-35b-a3b-ud-q8-xl HTTP_TIMEOUT_SEC=90 ./scripts/harness_supervisor_team_session.sh`

## Context
- follow-up to #536
- selected by the swarm self-upgrade loop after reviewing batch spawn behavior
