### PR TITLE
fix(team-session): reject empty worker note turns

### DIFF
--- a/docs/SUPERVISOR-MODE.md
+++ b/docs/SUPERVISOR-MODE.md
@@ -223,8 +223,9 @@ What it does:
 6. spawns a full llama worker team (`planner`, `implementer-a`, `implementer-b`)
 7. records the explicit model-selection note in the session
 8. passes the same note into every spawned worker prompt
-9. performs supervisor interventions over `/mcp/operator`
-10. stops the session and generates proof artifacts
+9. requires every worker to leave a non-empty `team_turn` note
+10. performs supervisor interventions over `/mcp/operator`
+11. stops the session and generates proof artifacts
 
 Run it against a real local llama team:
 

--- a/lib/local_agent_eio.ml
+++ b/lib/local_agent_eio.ml
@@ -347,6 +347,8 @@ Keep responses concise and task-focused.
 If a tool schema includes agent_name and you omit it, the runtime will inject %s automatically.
 Do not invent tool names or arguments that are not in schema.
 If you are operating inside a team session, record your own work with masc_team_session_turn as the worker.
+Inside a team session, record at least one note turn with turn_kind="note" and a non-empty message that states your concrete contribution.
+A note turn without a message is invalid and will be rejected.
 When the task is complete, return a short final result summarizing what you changed or learned.|}
     worker_name model_id session_line role_line selection_line worker_name
 

--- a/lib/team_session_engine_eio.ml
+++ b/lib/team_session_engine_eio.ml
@@ -941,35 +941,37 @@ let record_turn ~(config : Room.config) ~(session_id : string) ~(actor : string)
       let task_priority = clamp_int ~min_v:1 ~max_v:5 task_priority in
       let now = Time_compat.now () in
       match turn_kind with
-      | Team_session_types.Turn_note ->
-          let updated =
-            {
-              session with
-              turn_count = session.turn_count + 1;
-              last_turn_at = Some now;
-              last_event_at = Some now;
-              updated_at_iso = now_iso ();
-            }
-          in
-          Team_session_store.save_session config updated;
-          Team_session_store.append_event config session_id ~event_type:"team_turn"
-            ~detail:
-              (`Assoc
-                [
-                  ("turn_no", `Int updated.turn_count);
-                  ("kind", `String "note");
-                  ("actor", `String actor);
-                  ( "message",
-                    Option.fold ~none:`Null ~some:(fun s -> `String s) message );
-                  ("ts_iso", `String (now_iso ()));
-                ]);
-          Ok
-            (`Assoc
-              [
-                ("session_id", `String session_id);
-                ("turn_no", `Int updated.turn_count);
-                ("kind", `String "note");
-              ])
+      | Team_session_types.Turn_note -> (
+          match message with
+          | None -> Error "message is required for note turn"
+          | Some msg ->
+              let updated =
+                {
+                  session with
+                  turn_count = session.turn_count + 1;
+                  last_turn_at = Some now;
+                  last_event_at = Some now;
+                  updated_at_iso = now_iso ();
+                }
+              in
+              Team_session_store.save_session config updated;
+              Team_session_store.append_event config session_id ~event_type:"team_turn"
+                ~detail:
+                  (`Assoc
+                    [
+                      ("turn_no", `Int updated.turn_count);
+                      ("kind", `String "note");
+                      ("actor", `String actor);
+                      ("message", `String msg);
+                      ("ts_iso", `String (now_iso ()));
+                    ]);
+              Ok
+                (`Assoc
+                  [
+                    ("session_id", `String session_id);
+                    ("turn_no", `Int updated.turn_count);
+                    ("kind", `String "note");
+                  ]))
       | Team_session_types.Turn_broadcast -> (
           match message with
           | None -> Error "message is required for broadcast turn"

--- a/lib/team_session_report.ml
+++ b/lib/team_session_report.ml
@@ -170,6 +170,40 @@ let turn_counts_by_agent events =
   Hashtbl.fold (fun agent count acc -> (agent, count) :: acc) tbl []
   |> List.sort (fun (a, _) (b, _) -> compare a b)
 
+let note_message_opt_for_report json =
+  let open Yojson.Safe.Util in
+  match (member "event_type" json, member "detail" json |> member "kind") with
+  | `String "team_turn", `String "note" -> (
+      match member "detail" json |> member "message" with
+      | `String message ->
+          let message = String.trim message in
+          if message = "" then None else Some message
+      | _ -> None)
+  | _ -> None
+
+let empty_note_turn_actor_for_report json =
+  let open Yojson.Safe.Util in
+  match (member "event_type" json, member "detail" json |> member "kind") with
+  | `String "team_turn", `String "note" -> (
+      match (member "detail" json |> member "actor", note_message_opt_for_report json) with
+      | `String actor, None ->
+          let actor = String.trim actor in
+          if actor = "" then None else Some actor
+      | _ -> None)
+  | _ -> None
+
+let count_empty_note_turns_for_report events =
+  List.fold_left
+    (fun acc json ->
+      match empty_note_turn_actor_for_report json with
+      | Some _ -> acc + 1
+      | None -> acc)
+    0 events
+
+let empty_note_turn_actors_for_report events =
+  events |> List.filter_map empty_note_turn_actor_for_report
+  |> Team_session_types.dedup_strings
+
 let mcp_improvements (session : Team_session_types.session) events checkpoints_count
     done_delta_total =
   let base =
@@ -279,6 +313,9 @@ let detached_actor_roster_for_report events =
                    ("ts_iso", member "ts_iso" json);
                  ])
          | _ -> None)
+
+let empty_note_turn_roster_for_report events =
+  empty_note_turn_actors_for_report events |> List.map (fun actor -> `String actor)
 
 let markdown_of_report ~(session : Team_session_types.session)
     ~(summary_json : Yojson.Safe.t) ~(events : Yojson.Safe.t list)
@@ -428,6 +465,21 @@ let markdown_of_report ~(session : Team_session_types.session)
         | _ -> [])
     | _ -> []
   in
+  let empty_note_turn_count =
+    match incidents_json with
+    | `Assoc _ ->
+        incidents_json |> member "empty_note_turn_count" |> to_int_option
+        |> Option.value ~default:0
+    | _ -> 0
+  in
+  let empty_note_turn_actors =
+    match incidents_json with
+    | `Assoc _ -> (
+        match incidents_json |> member "empty_note_turn_actors" with
+        | `List xs -> xs
+        | _ -> [])
+    | _ -> []
+  in
   let failed_spawn_lines =
     failed_spawn_roster
     |> List.map (fun item ->
@@ -458,6 +510,12 @@ let markdown_of_report ~(session : Team_session_types.session)
              |> Option.value ~default:"(not recorded)"
            in
            Printf.sprintf "- %s | reason=%s" actor reason)
+  in
+  let empty_note_turn_lines =
+    empty_note_turn_actors
+    |> List.map (fun item ->
+           item |> to_string_option |> Option.value ~default:"(unknown)")
+    |> List.map (fun actor -> Printf.sprintf "- %s" actor)
   in
   let policy_lines =
     [
@@ -521,6 +579,11 @@ let markdown_of_report ~(session : Team_session_types.session)
       (if detached_actor_lines = [] then "- Detached actor roster: (none)"
        else String.concat "\n" detached_actor_lines);
       "";
+      "## Low-Signal Turn Evidence";
+      Printf.sprintf "- Empty note turns: %d" empty_note_turn_count;
+      (if empty_note_turn_lines = [] then "- Empty note turn actors: (none)"
+       else String.concat "\n" empty_note_turn_lines);
+      "";
       "## Goal vs Outcome";
       Printf.sprintf "- Goal statement: %s" session.goal;
       Printf.sprintf "- Completed task delta: %d" done_total;
@@ -580,8 +643,10 @@ let generate config (session : Team_session_types.session) :
     let violation_count = event_count events "min_agents_violation" in
     let spawn_failure_count = spawn_failure_count_for_report events in
     let detached_agent_count = event_count events "session_agent_detached" in
+    let empty_note_turn_count = count_empty_note_turns_for_report events in
     let failed_spawn_roster = failed_spawn_roster_for_report events in
     let detached_actor_roster = detached_actor_roster_for_report events in
+    let empty_note_turn_actors = empty_note_turn_roster_for_report events in
     let mcp_notes =
       mcp_improvements session events checkpoints_count done_delta_total
     in
@@ -596,6 +661,8 @@ let generate config (session : Team_session_types.session) :
           ("detached_agent_count", `Int detached_agent_count);
           ("failed_spawn_roster", `List failed_spawn_roster);
           ("detached_actor_roster", `List detached_actor_roster);
+          ("empty_note_turn_count", `Int empty_note_turn_count);
+          ("empty_note_turn_actors", `List empty_note_turn_actors);
         ]
     in
     let report_json =
@@ -649,6 +716,7 @@ let generate config (session : Team_session_types.session) :
                 ("active_agents", `List (List.map (fun a -> `String a) active_agents));
                 ("spawn_failure_count", `Int spawn_failure_count);
                 ("detached_agent_count", `Int detached_agent_count);
+                ("empty_note_turn_count", `Int empty_note_turn_count);
               ] );
         ]
     in
@@ -711,6 +779,33 @@ let turn_kind_of_event (json : Yojson.Safe.t) =
     | _ -> None
   else
     None
+
+let turn_message_of_event (json : Yojson.Safe.t) =
+  if has_event_type json "team_turn" then
+    match
+      Yojson.Safe.Util.member "detail" json |> Yojson.Safe.Util.member "message"
+    with
+    | `String message ->
+        let message = String.trim message in
+        if message = "" then None else Some message
+    | _ -> None
+  else
+    None
+
+let empty_note_turn_actor_of_event (json : Yojson.Safe.t) =
+  match (turn_kind_of_event json, turn_actor_of_event json, turn_message_of_event json) with
+  | Some "note", Some actor, None -> Some actor
+  | _ -> None
+
+let count_empty_note_turns events =
+  List.fold_left
+    (fun acc json ->
+      match empty_note_turn_actor_of_event json with Some _ -> acc + 1 | None -> acc)
+    0 events
+
+let empty_note_turn_actors_of_events events =
+  events |> List.filter_map empty_note_turn_actor_of_event
+  |> Team_session_types.dedup_strings
 
 let team_step_spawn_agent (json : Yojson.Safe.t) =
   if has_event_type json "team_step_spawn" then
@@ -821,7 +916,7 @@ let make_standard_criteria ~event_started ~checkpoints_count ~turn_events
 let make_strong_criteria ~required_spawn_agents ~spawn_events
     ~spawn_success_count ~unique_spawn_agents_count ~required_turn_actors
     ~min_turn_events ~turn_events ~min_communication ~communication_total
-    ~vote_events ~run_deliverables =
+    ~vote_events ~run_deliverables ~empty_note_turn_count =
   [
     criterion "spawn_evidence_present" (spawn_events >= required_spawn_agents)
       (Printf.sprintf "spawn_events=%d required_spawn_agents=%d" spawn_events
@@ -845,6 +940,8 @@ let make_strong_criteria ~required_spawn_agents ~spawn_events
       (Printf.sprintf "vote_events=%d required>=1" vote_events);
     criterion "deliverable_evidence_present" (run_deliverables >= 1)
       (Printf.sprintf "run_deliverables=%d required>=1" run_deliverables);
+    criterion "empty_note_turns_absent" (empty_note_turn_count = 0)
+      (Printf.sprintf "empty_note_turn_count=%d" empty_note_turn_count);
   ]
 
 let mandatory_ok_for_level ~proof_level criteria =
@@ -1096,7 +1193,9 @@ let proof_markdown ~(session : Team_session_types.session)
     ~(report_exists : bool) ~(unique_turn_actors_count : int)
     ~(required_turn_actors : int) ~(spawn_models : string list)
     ~(spawn_failure_count : int) ~(detached_agent_count : int)
+    ~(empty_note_turn_count : int)
     ~(failed_spawn_roster : Yojson.Safe.t list)
+    ~(empty_note_turn_actors : string list)
     ~(detached_actor_roster : Yojson.Safe.t list)
     ~(planned_workers : Team_session_types.planned_worker list)
     ~(unique_spawn_runtime_actors_count : int)
@@ -1186,6 +1285,9 @@ let proof_markdown ~(session : Team_session_types.session)
            in
            Printf.sprintf "- %s | reason=%s" actor reason)
   in
+  let empty_note_turn_lines =
+    empty_note_turn_actors |> List.map (fun actor -> Printf.sprintf "- %s" actor)
+  in
   String.concat "\n"
     [
       "# Team Session Proof";
@@ -1209,6 +1311,7 @@ let proof_markdown ~(session : Team_session_types.session)
         unique_spawn_runtime_actors_count;
       Printf.sprintf "- Failed spawn events: %d" spawn_failure_count;
       Printf.sprintf "- Detached failed actors: %d" detached_agent_count;
+      Printf.sprintf "- Empty note turns: %d" empty_note_turn_count;
       Printf.sprintf "- Spawn models: %s"
         (match spawn_models with
         | [] -> "(not recorded)"
@@ -1230,6 +1333,10 @@ let proof_markdown ~(session : Team_session_types.session)
       "## Detached Failed Actors";
       (if detached_actor_lines = [] then "- (none)"
        else String.concat "\n" detached_actor_lines);
+      "";
+      "## Low-Signal Note Turns";
+      (if empty_note_turn_lines = [] then "- (none)"
+       else String.concat "\n" empty_note_turn_lines);
       "";
       "## Criteria";
       (if criteria_lines = [] then "- (no criteria)"
@@ -1318,6 +1425,8 @@ let generate_proof ?(proof_level = default_proof_level) config
       | xs -> Some (String.concat " | " xs)
     in
     let failed_spawn_roster = failed_spawn_roster_of_events events in
+    let empty_note_turn_count = count_empty_note_turns events in
+    let empty_note_turn_actors = empty_note_turn_actors_of_events events in
     let detached_actor_roster = detached_actor_roster_of_events events in
     let detached_agent_count = count_event_type events "session_agent_detached" in
     let min_turn_events = min_turn_events_for_session required_turn_actors in
@@ -1338,7 +1447,7 @@ let generate_proof ?(proof_level = default_proof_level) config
                 (max unique_spawn_agents_count unique_spawn_runtime_actors_count)
               ~required_turn_actors ~min_turn_events ~turn_events
               ~min_communication ~communication_total ~vote_events
-              ~run_deliverables
+              ~run_deliverables ~empty_note_turn_count
     in
     let total = max 1 (List.length criteria) in
     let passed =
@@ -1377,6 +1486,8 @@ let generate_proof ?(proof_level = default_proof_level) config
                 ("spawn_success_count", `Int spawn_success_count);
                 ("spawn_failure_count", `Int spawn_failure_count);
                 ("failed_spawn_roster", `List failed_spawn_roster);
+                ("empty_note_turn_count", `Int empty_note_turn_count);
+                ("empty_note_turn_actors", `List (List.map (fun actor -> `String actor) empty_note_turn_actors));
                 ("unique_spawn_agents", `List (List.map (fun a -> `String a) unique_spawn_agents));
                 ("unique_spawn_agents_count", `Int unique_spawn_agents_count);
                 ( "unique_spawn_runtime_actors",
@@ -1414,8 +1525,8 @@ let generate_proof ?(proof_level = default_proof_level) config
         ~checkpoints_count ~events_count:(List.length events) ~turn_events
         ~report_exists:(report_json_exists && report_md_exists)
         ~unique_turn_actors_count ~required_turn_actors ~spawn_models
-        ~spawn_failure_count ~detached_agent_count
-        ~failed_spawn_roster ~detached_actor_roster
+        ~spawn_failure_count ~detached_agent_count ~empty_note_turn_count
+        ~failed_spawn_roster ~empty_note_turn_actors ~detached_actor_roster
         ~planned_workers:session.planned_workers
         ~unique_spawn_runtime_actors_count
         ~spawn_selection_note_summary

--- a/scripts/harness/workload/supervisor_team_session.sh
+++ b/scripts/harness/workload/supervisor_team_session.sh
@@ -382,6 +382,21 @@ require_tool_success "$prove_raw"
 prove_result="$(printf '%s' "$prove_raw" | extract_tool_result)"
 printf '%s' "$prove_result" | jq -e '.proof.verdict == "proved"' >/dev/null
 printf '%s' "$prove_result" | jq -e '.proof.evidence.unique_turn_actors_count >= 4' >/dev/null
+printf '%s' "$prove_result" | jq -e '.proof.evidence.empty_note_turn_count == 0' >/dev/null
+report_raw="$(call_tool "$MCP_URL" "$SUPERVISOR_SESSION_ID" "$SUPERVISOR_TOKEN" 18 "masc_team_session_report" "$(jq -cn --arg s "$TEAM_SESSION_ID" '{session_id:$s,force_regenerate:false}')")"
+require_tool_success "$report_raw"
+report_result="$(printf '%s' "$report_raw" | extract_tool_result)"
+report_json_path="$(printf '%s' "$report_result" | jq -r '.json_path // empty')"
+if [ -z "$report_json_path" ]; then
+  echo "FAIL: missing report json path"
+  printf '%s\n' "$report_result"
+  exit 1
+fi
+if ! jq -e '.incidents.empty_note_turn_count == 0' "$report_json_path" >/dev/null; then
+  echo "FAIL: report json recorded empty note turns"
+  cat "$report_json_path"
+  exit 1
+fi
 
 printf '[summary]\n'
 events_raw="$(call_tool "$MCP_URL" "$SUPERVISOR_SESSION_ID" "$SUPERVISOR_TOKEN" 16 "masc_team_session_events" "$(jq -cn --arg s "$TEAM_SESSION_ID" '{session_id:$s,event_types:["team_turn"],limit:200}')")"

--- a/scripts/harness/workload/team_session_failed_batch_spawn.sh
+++ b/scripts/harness/workload/team_session_failed_batch_spawn.sh
@@ -409,6 +409,7 @@ require_tool_success "$prove_raw"
 prove_result="$(printf '%s' "$prove_raw" | extract_tool_result)"
 require_json_condition "$prove_result" '.proof.evidence.spawn_failure_count == 2' "proof evidence is missing spawn_failure_count=2"
 require_json_condition "$prove_result" '.proof.evidence.detached_agent_count == 2' "proof evidence is missing detached_agent_count=2"
+require_json_condition "$prove_result" '.proof.evidence.empty_note_turn_count == 0' "proof evidence recorded unexpected empty note turns"
 require_json_condition "$prove_result" '.proof.evidence.failed_spawn_roster | length == 2' "proof evidence is missing failed spawn roster"
 require_json_condition "$prove_result" '.proof.evidence.detached_actor_roster | length == 2' "proof evidence is missing detached actor roster"
 proof_md_path="$(printf '%s' "$prove_result" | jq -r '.proof_md_path')"
@@ -432,6 +433,11 @@ if ! jq -e '.incidents.failed_spawn_roster | length == 2' "$report_json_path" >/
 fi
 if ! jq -e '.incidents.detached_actor_roster | length == 2' "$report_json_path" >/dev/null; then
   echo "FAIL: report json missing detached_actor_roster"
+  cat "$report_json_path"
+  exit 1
+fi
+if ! jq -e '.incidents.empty_note_turn_count == 0' "$report_json_path" >/dev/null; then
+  echo "FAIL: report json recorded unexpected empty note turns"
   cat "$report_json_path"
   exit 1
 fi

--- a/test/test_tool_team_session.ml
+++ b/test/test_tool_team_session.ml
@@ -476,6 +476,16 @@ let test_turn_events_and_prove () =
           ])
   in
   Alcotest.(check bool) "invalid turn kind rejected" false invalid_turn_ok;
+  let empty_note_ok, _ =
+    dispatch_exn ctx ~name:"masc_team_session_turn"
+      ~args:
+        (`Assoc
+          [
+            ("session_id", `String session_id);
+            ("turn_kind", `String "note");
+          ])
+  in
+  Alcotest.(check bool) "empty note rejected" false empty_note_ok;
 
   let engine_intruder_result =
     Team_session_engine_eio.record_turn ~config ~session_id ~actor:"intruder"
@@ -1410,6 +1420,11 @@ let test_proof_exposes_failed_spawn_and_detach_counts () =
     failed_role;
   Alcotest.(check string) "proof detached reason recorded"
     "spawn_failed_without_turn" detached_reason;
+  let empty_note_turn_count =
+    evidence |> Yojson.Safe.Util.member "empty_note_turn_count"
+    |> Yojson.Safe.Util.to_int
+  in
+  Alcotest.(check int) "proof empty note count stays zero" 0 empty_note_turn_count;
   let report_json_path = Team_session_store.report_json_path config session_id in
   let report_doc = Room_utils.read_json config report_json_path in
   let report_failed_roster =
@@ -1422,10 +1437,17 @@ let test_proof_exposes_failed_spawn_and_detach_counts () =
     |> Yojson.Safe.Util.member "detached_actor_roster"
     |> Yojson.Safe.Util.to_list
   in
+  let report_empty_note_count =
+    report_doc |> Yojson.Safe.Util.member "incidents"
+    |> Yojson.Safe.Util.member "empty_note_turn_count"
+    |> Yojson.Safe.Util.to_int
+  in
   Alcotest.(check int) "report failed spawn roster length" 1
     (List.length report_failed_roster);
   Alcotest.(check int) "report detached actor roster length" 1
     (List.length report_detached_roster);
+  Alcotest.(check int) "report empty note count stays zero" 0
+    report_empty_note_count;
   let proof_md_path =
     prove_result |> Yojson.Safe.Util.member "proof_md_path"
     |> Yojson.Safe.Util.to_string
@@ -1456,6 +1478,106 @@ let test_proof_exposes_failed_spawn_and_detach_counts () =
        let _ =
          Str.search_forward (Str.regexp_string "llama-local-failed | reason=spawn_failed_without_turn")
            proof_md 0
+       in
+       true
+     with Not_found -> false);
+  cleanup_dir base_dir
+
+let test_report_and_proof_expose_empty_note_turn_evidence () =
+  Eio_main.run @@ fun env ->
+  Eio.Switch.run @@ fun sw ->
+  let base_dir = temp_dir () in
+  let config = Room.default_config base_dir in
+  ignore (Room.init config ~agent_name:(Some "tester"));
+  ignore (Room.join config ~agent_name:"tester" ~capabilities:[] ());
+  let ctx : _ Tool_team_session.context =
+    { config; agent_name = "tester"; sw; clock = Eio.Stdenv.clock env; proc_mgr = None }
+  in
+  let session_id = start_session_exn ctx ~goal:"empty-note-evidence" |> get_session_id in
+  Team_session_store.append_event config session_id ~event_type:"team_turn"
+    ~detail:
+      (`Assoc
+        [
+          ("turn_no", `Int 1);
+          ("kind", `String "note");
+          ("actor", `String "llama-local-empty");
+          ("message", `Null);
+          ("ts_iso", `String (Types.now_iso ()));
+        ]);
+  ignore
+    (dispatch_exn ctx ~name:"masc_team_session_turn"
+       ~args:
+         (`Assoc
+           [
+             ("session_id", `String session_id);
+             ("turn_kind", `String "note");
+             ("message", `String "supervisor note");
+           ]));
+  ignore
+    (dispatch_exn ctx ~name:"masc_team_session_stop"
+       ~args:
+         (`Assoc
+           [
+             ("session_id", `String session_id);
+             ("reason", `String "empty_note_evidence_done");
+             ("generate_report", `Bool true);
+           ]));
+  ignore (wait_until_terminal ctx session_id);
+  let prove_ok, prove_body =
+    dispatch_exn ctx ~name:"masc_team_session_prove"
+      ~args:(`Assoc [ ("session_id", `String session_id) ])
+  in
+  Alcotest.(check bool) "prove ok for empty note evidence" true prove_ok;
+  let prove_result = parse_json_exn prove_body |> result_field in
+  let evidence =
+    prove_result |> Yojson.Safe.Util.member "proof"
+    |> Yojson.Safe.Util.member "evidence"
+  in
+  let empty_note_turn_count =
+    evidence |> Yojson.Safe.Util.member "empty_note_turn_count"
+    |> Yojson.Safe.Util.to_int
+  in
+  let empty_note_turn_actors =
+    evidence |> Yojson.Safe.Util.member "empty_note_turn_actors"
+    |> Yojson.Safe.Util.to_list
+  in
+  Alcotest.(check int) "proof empty note count" 1 empty_note_turn_count;
+  Alcotest.(check int) "proof empty note actors length" 1
+    (List.length empty_note_turn_actors);
+  Alcotest.(check string) "proof empty note actor recorded"
+    "llama-local-empty"
+    (List.hd empty_note_turn_actors |> Yojson.Safe.Util.to_string);
+  let report_json_path = Team_session_store.report_json_path config session_id in
+  let report_doc = Room_utils.read_json config report_json_path in
+  let report_empty_note_count =
+    report_doc |> Yojson.Safe.Util.member "incidents"
+    |> Yojson.Safe.Util.member "empty_note_turn_count"
+    |> Yojson.Safe.Util.to_int
+  in
+  let report_empty_note_actors =
+    report_doc |> Yojson.Safe.Util.member "incidents"
+    |> Yojson.Safe.Util.member "empty_note_turn_actors"
+    |> Yojson.Safe.Util.to_list
+  in
+  Alcotest.(check int) "report empty note count" 1 report_empty_note_count;
+  Alcotest.(check int) "report empty note actors length" 1
+    (List.length report_empty_note_actors);
+  let proof_md_path =
+    prove_result |> Yojson.Safe.Util.member "proof_md_path"
+    |> Yojson.Safe.Util.to_string
+  in
+  let proof_md = Stdlib.In_channel.with_open_bin proof_md_path Stdlib.In_channel.input_all in
+  Alcotest.(check bool) "proof markdown includes empty note evidence" true
+    (try
+       let _ =
+         Str.search_forward (Str.regexp_string "Empty note turns: 1") proof_md 0
+       in
+       true
+     with Not_found -> false);
+  Alcotest.(check bool) "proof markdown includes empty actor" true
+    (try
+       let _ =
+         Str.search_forward (Str.regexp_string "- llama-local-empty") proof_md 0
        in
        true
      with Not_found -> false);
@@ -1731,6 +1853,8 @@ let () =
             `Quick test_reconcile_failed_spawn_actor_retains_after_turn;
           Alcotest.test_case "proof-exposes-failed-spawn-and-detach-counts"
             `Quick test_proof_exposes_failed_spawn_and_detach_counts;
+          Alcotest.test_case "report-and-proof-expose-empty-note-turn-evidence"
+            `Quick test_report_and_proof_expose_empty_note_turn_evidence;
           Alcotest.test_case "prove-strong-requires-additional-evidence" `Quick
             test_prove_strong_requires_additional_evidence;
           Alcotest.test_case "dispatch-unknown" `Quick test_dispatch_unknown;


### PR DESCRIPTION
## Summary
- reject empty `team_session_turn` note payloads so spawned llama workers cannot leave blank note evidence
- expose empty note turn evidence in report/proof artifacts
- lock both happy-path and failed-spawn harnesses against empty note turns

## Validation
- `dune build --root . @default`
- `./_build/default/test/test_tool_team_session.exe`
- `env LLAMA_SWARM_MODEL=qwen3.5-35b-a3b-ud-q8-xl HTTP_TIMEOUT_SEC=90 ./scripts/harness_supervisor_team_session.sh`
- `env LLAMA_SWARM_MODEL=qwen3.5-35b-a3b-ud-q8-xl ./scripts/harness_team_session_failed_batch_spawn.sh`
