### PR TITLE
fix: replace custom string helpers with stdlib, add CanAdmin permission

### DIFF
--- a/bin/main_eio.ml
+++ b/bin/main_eio.ml
@@ -2849,11 +2849,6 @@ let auth_token_from_request request =
   | Some v -> bearer_token_from_header v
   | None -> query_param request "token"
 
-let string_starts_with s prefix =
-  let len_s = String.length s in
-  let len_p = String.length prefix in
-  len_s >= len_p && String.sub s 0 len_p = prefix
-
 let env_flag_enabled name =
   match Sys.getenv_opt name with
   | None -> false
@@ -3040,9 +3035,9 @@ let is_public_read_path path =
   || String.equal path "/dashboard/"
   || String.equal path "/favicon.ico"
   || String.equal path "/favicon.svg"
-  || string_starts_with path "/dashboard/"
-  || string_starts_with path "/static/"
-  || string_starts_with path "/graphiql/"
+  || String.starts_with ~prefix:"/dashboard/" path
+  || String.starts_with ~prefix:"/static/" path
+  || String.starts_with ~prefix:"/graphiql/" path
 
 let resolve_agent_name_for_auth ~base_path request ~token :
     (string option, Types.masc_error) result =
@@ -10387,7 +10382,7 @@ let run_server ~sw ~env ~port ~base_path =
       if
         http_auth_strict_enabled ()
         && httpun_meth <> `OPTIONS
-        && string_starts_with path "/api/v1/trpg/"
+        && String.starts_with ~prefix:"/api/v1/trpg/" path
       then
         match authorize_read_request ~base_path httpun_request with
         | Ok () -> dispatch_h2_route ()

--- a/examples/turn_relay_data_example.ml
+++ b/examples/turn_relay_data_example.ml
@@ -40,15 +40,11 @@ let env_int ?(default=0) name =
   | Some value -> (match int_of_string_opt value with Some v -> v | None -> default)
   | None -> default
 
-let string_starts_with ~prefix s =
-  let prefix_len = String.length prefix in
-  String.length s >= prefix_len && String.sub s 0 prefix_len = prefix
-
 let parse_query_param query key =
   let parts = String.split_on_char '&' query in
   let prefix = key ^ "=" in
   List.find_map (fun part ->
-    if string_starts_with ~prefix part then
+    if String.starts_with ~prefix part then
       Some (String.sub part (String.length prefix) (String.length part - String.length prefix))
     else
       None
@@ -68,9 +64,9 @@ let parse_host_port ~default_port host_port =
 let parse_turn_url url =
   let url = String.trim url in
   let scheme, rest =
-    if string_starts_with ~prefix:"turns:" url then
+    if String.starts_with ~prefix:"turns:" url then
       ("turns", String.sub url 6 (String.length url - 6))
-    else if string_starts_with ~prefix:"turn:" url then
+    else if String.starts_with ~prefix:"turn:" url then
       ("turn", String.sub url 5 (String.length url - 5))
     else
       ("", "")

--- a/examples/turn_tls_example.ml
+++ b/examples/turn_tls_example.ml
@@ -36,15 +36,11 @@ let env_required_credential () =
            Printf.eprintf "Missing TURN_CREDENTIAL (or TURN_PASSWORD)\n";
            exit 1)
 
-let string_starts_with ~prefix s =
-  let prefix_len = String.length prefix in
-  String.length s >= prefix_len && String.sub s 0 prefix_len = prefix
-
 let parse_query_param query key =
   let parts = String.split_on_char '&' query in
   let prefix = key ^ "=" in
   List.find_map (fun part ->
-    if string_starts_with ~prefix part then
+    if String.starts_with ~prefix part then
       Some (String.sub part (String.length prefix) (String.length part - String.length prefix))
     else
       None
@@ -64,9 +60,9 @@ let parse_host_port ~default_port host_port =
 let parse_turn_url url =
   let url = String.trim url in
   let scheme, rest =
-    if string_starts_with ~prefix:"turns:" url then
+    if String.starts_with ~prefix:"turns:" url then
       ("turns", String.sub url 6 (String.length url - 6))
-    else if string_starts_with ~prefix:"turn:" url then
+    else if String.starts_with ~prefix:"turn:" url then
       ("turn", String.sub url 5 (String.length url - 5))
     else
       ("", "")

--- a/lib/auth.ml
+++ b/lib/auth.ml
@@ -248,9 +248,11 @@ let permission_for_tool = function
   | "masc_operation_finalize" | "masc_dispatch_assign"
   | "masc_dispatch_rebalance" | "masc_dispatch_escalate"
   | "masc_dispatch_recall" | "masc_policy_approve"
-  | "masc_policy_deny" | "masc_policy_update"
-  | "masc_policy_freeze_unit" | "masc_policy_kill_switch" ->
+  | "masc_policy_deny" | "masc_policy_update" ->
       Some CanBroadcast
+  (* Command-plane write operations require Admin *)
+  | "masc_policy_freeze_unit" | "masc_policy_kill_switch" ->
+      Some CanAdmin
   | "masc_portal_open" | "masc_portal_close" -> Some CanOpenPortal
   | "masc_portal_send" -> Some CanSendPortal
   | "masc_worktree_create" -> Some CanCreateWorktree
@@ -276,18 +278,13 @@ let is_tool_auth_strict_enabled () =
   | None -> false
 
 let is_masc_tool_name tool_name =
-  String.length tool_name >= 5 && String.sub tool_name 0 5 = "masc_"
-
-let string_starts_with s prefix =
-  let len_s = String.length s in
-  let len_p = String.length prefix in
-  len_s >= len_p && String.sub s 0 len_p = prefix
+  String.starts_with ~prefix:"masc_" tool_name
 
 let is_protocol_canonical_tool_name tool_name =
-  string_starts_with tool_name "decision."
-  || string_starts_with tool_name "experiment."
-  || string_starts_with tool_name "trpg."
-  || string_starts_with tool_name "client."
+  String.starts_with ~prefix:"decision." tool_name
+  || String.starts_with ~prefix:"experiment." tool_name
+  || String.starts_with ~prefix:"trpg." tool_name
+  || String.starts_with ~prefix:"client." tool_name
 
 (** Check permission for a tool call *)
 let authorize_tool config ~agent_name ~token ~tool_name : (unit, masc_error) result =

--- a/lib/auto_recall.ml
+++ b/lib/auto_recall.ml
@@ -24,10 +24,6 @@ let string_contains ~needle haystack =
     in
     check 0
 
-(** Check if str starts with prefix *)
-let string_starts_with ~prefix str =
-  let prefix_len = String.length prefix in
-  String.length str >= prefix_len && String.sub str 0 prefix_len = prefix
 
 (** {1 Types} *)
 
@@ -230,7 +226,7 @@ let fetch_from_file_context (room_config : Room_utils.config) ~(config : recall_
   |> List.mapi (fun i path ->
     let preview = read_preview path in
     let rel_path = 
-      if string_starts_with ~prefix:work_dir path 
+      if String.starts_with ~prefix:work_dir path
       then String.sub path (String.length work_dir + 1) (String.length path - String.length work_dir - 1)
       else path
     in

--- a/lib/command_plane_v2.ml
+++ b/lib/command_plane_v2.ml
@@ -162,34 +162,28 @@ let operator_action_log_path config =
 let swarm_path config =
   Filename.concat config.Room.base_path ".masc/swarm.json"
 
-let string_starts_with s prefix =
-  let len_s = String.length s in
-  let len_p = String.length prefix in
-  len_s >= len_p && String.sub s 0 len_p = prefix
-
-let trim s = String.trim s
+module StringSet = Set.Make (String)
 
 let nonempty_string = function
   | Some raw ->
-      let value = trim raw in
+      let value = String.trim raw in
       if value = "" then None else Some value
   | None -> None
 
 let dedup_strings xs =
-  let rec loop seen acc = function
-    | [] -> List.rev acc
-    | x :: rest ->
-        if List.mem x seen then
-          loop seen acc rest
-        else
-          loop (x :: seen) (x :: acc) rest
+  let _, acc =
+    List.fold_left
+      (fun (seen, acc) x ->
+        if StringSet.mem x seen then (seen, acc)
+        else (StringSet.add x seen, x :: acc))
+      (StringSet.empty, []) xs
   in
-  loop [] [] xs
+  List.rev acc
 
 let filter_nonempty_strings xs =
   xs
   |> List.filter_map (fun raw ->
-         let value = trim raw in
+         let value = String.trim raw in
          if value = "" then None else Some value)
   |> dedup_strings
 
@@ -217,7 +211,7 @@ let safe_slug raw =
     lowered |> String.to_seq |> List.of_seq |> collapse_dash [] |> List.rev
     |> List.to_seq |> String.of_seq
   in
-  let normalized = trim collapsed in
+  let normalized = String.trim collapsed in
   if normalized = "" then "auto" else normalized
 
 let json_list_of_strings xs =
@@ -774,7 +768,7 @@ let read_events config =
         let rec loop acc =
           match input_line ic with
           | line ->
-              let trimmed = trim line in
+              let trimmed = String.trim line in
               let acc' =
                 if trimmed = "" then
                   acc
@@ -2066,7 +2060,7 @@ let recent_operator_trace_events config ?trace_id limit =
         let rec loop acc =
           match input_line ic with
           | line ->
-              let trimmed = trim line in
+              let trimmed = String.trim line in
               let acc' =
                 if trimmed = "" then
                   acc

--- a/lib/types.ml
+++ b/lib/types.ml
@@ -941,6 +941,7 @@ type permission =
   | CanVote
   | CanInterrupt
   | CanApprove
+  | CanAdmin
 [@@deriving show { with_path = false }]
 
 (** Get permissions for a role *)
@@ -962,6 +963,7 @@ let permissions_for_role = function
       CanOpenPortal; CanSendPortal;
       CanCreateWorktree; CanRemoveWorktree;
       CanVote; CanInterrupt; CanApprove;
+      CanAdmin;
     ]
 
 (** Check if role has permission *)


### PR DESCRIPTION
## Summary
- **P2**: 5x `string_starts_with` → `String.starts_with ~prefix` (stdlib 4.13+)
- **P2**: Delete `trim` alias (was literally `String.trim`)
- **P2**: `dedup_strings` O(n^2) → O(n log n) via `StringSet`
- **P1**: New `CanAdmin` permission for destructive command-plane ops (kill_switch, freeze)

## Files changed (7)
- `lib/command_plane_v2.ml` — remove helpers, fix dedup_strings
- `lib/auth.ml` — remove helper, separate CanAdmin ops
- `lib/auto_recall.ml` — remove helper
- `lib/types.ml` — add CanAdmin variant
- `bin/main_eio.ml` — remove helper, update call sites
- `examples/turn_relay_data_example.ml` — remove helper, update call sites
- `examples/turn_tls_example.ml` — remove helper, update call sites

## Test plan
- [x] `dune build` — compiles clean (only pre-existing OCaml 5.0 deprecation alerts)

🤖 Generated with [Claude Code](https://claude.com/claude-code)