### PR TITLE
feat(dashboard): make masc dashboard all-room by default

### DIFF
--- a/lib/dashboard.ml
+++ b/lib/dashboard.ml
@@ -39,6 +39,19 @@ type section = {
   empty_msg: string;
 }
 
+type scope =
+  | All
+  | Current
+
+type room_snapshot = {
+  room_id: string;
+  is_current: bool;
+  agents: Types.agent list;
+  tasks: Types.task list;
+  messages: Types.message list;
+  locks: int;
+}
+
 (** Format a section *)
 let format_section (s : section) : string =
   let header = Printf.sprintf "== %s ==" s.title in
@@ -76,87 +89,78 @@ let parse_iso_timestamp (s : string) : float option =
     )
   with Scanf.Scan_failure _ | Failure _ | End_of_file -> None
 
-(** Get agents section *)
-let agents_section (config : Room_utils.config) : section =
-  let agents = Room.get_agents_raw config in
-  let now = Time_compat.now () in
-  let content = List.map (fun (a : Types.agent) ->
-    let status_str = Types.agent_status_to_string a.status in
-    let elapsed_str = match parse_iso_timestamp a.last_seen with
-      | Some ts ->
-          let elapsed = now -. ts in
-          if elapsed < 60.0 then Printf.sprintf "%.0fs ago" elapsed
-          else if elapsed < 3600.0 then Printf.sprintf "%.0fm ago" (elapsed /. 60.0)
-          else Printf.sprintf "%.1fh ago" (elapsed /. 3600.0)
-      | None -> a.last_seen
-    in
-    Printf.sprintf "[%s] %s (%s)" status_str a.name elapsed_str
-  ) agents in
-  { title = "Agents"; content; empty_msg = "(no agents)" }
+let format_elapsed now timestamp fallback =
+  match parse_iso_timestamp timestamp with
+  | Some ts ->
+      let elapsed = now -. ts in
+      if elapsed < 60.0 then Printf.sprintf "%.0fs ago" elapsed
+      else if elapsed < 3600.0 then Printf.sprintf "%.0fm ago" (elapsed /. 60.0)
+      else Printf.sprintf "%.1fh ago" (elapsed /. 3600.0)
+  | None -> fallback
 
-(** Get tasks section *)
-let tasks_section (config : Room_utils.config) : section =
-  let tasks = Room.get_tasks_raw config in
-  let in_progress = List.filter (fun t ->
-    match t.Types.task_status with
-    | Types.InProgress _ -> true
-    | Types.Claimed _ -> true
-    | _ -> false
-  ) tasks in
-  let pending = List.filter (fun t ->
-    match t.Types.task_status with
-    | Types.Todo -> true
-    | _ -> false
-  ) tasks in
-  let content =
-    (List.map (fun (t : Types.task) ->
-      let agent = match t.task_status with
-        | Types.InProgress { assignee; _ } -> assignee
-        | Types.Claimed { assignee; _ } -> assignee
-        | _ -> "?"
-      in
-      Printf.sprintf "[P%d] %s (@%s)" t.priority t.title agent
-    ) in_progress) @
-    (List.map (fun (t : Types.task) ->
-      Printf.sprintf "[P%d] %s (pending)" t.priority t.title
-    ) (List.filteri (fun i _ -> i < max_pending_tasks) pending))
-  in
-  let pending_more = List.length pending - max_pending_tasks in
-  let content = if pending_more > 0 then
-    content @ [Printf.sprintf "   ... +%d more pending" pending_more]
-  else content in
-  { title = "Tasks"; content; empty_msg = "(no tasks)" }
-
-(** Truncate path to max_path_length with leading ellipsis *)
 let truncate_path (path : string) : string =
   if String.length path > max_path_length then
-    let suffix_len = max_path_length - 3 in (* 3 for "..." *)
+    let suffix_len = max_path_length - 3 in
     "..." ^ String.sub path (String.length path - suffix_len) suffix_len
   else path
 
-(** Truncate message to max_message_length with trailing ellipsis *)
 let truncate_message (msg : string) : string =
   if String.length msg > max_message_length then
-    let prefix_len = max_message_length - 3 in (* 3 for "..." *)
+    let prefix_len = max_message_length - 3 in
     String.sub msg 0 prefix_len ^ "..."
   else msg
 
-(** Get messages section *)
-let messages_section (config : Room_utils.config) : section =
-  let messages = Room.get_messages_raw config ~limit:max_recent_messages ~since_seq:0 in
-  let content = List.map (fun (m : Types.message) ->
-    Printf.sprintf "%s: %s" m.from_agent (truncate_message m.content)
-  ) messages in
-  { title = "Recent Messages"; content; empty_msg = "(no messages)" }
+let agent_lines now (agents : Types.agent list) =
+  List.map (fun (agent : Types.agent) ->
+    let status_str = Types.agent_status_to_string agent.status in
+    let elapsed_str = format_elapsed now agent.last_seen agent.last_seen in
+    Printf.sprintf "[%s] %s (%s)" status_str agent.name elapsed_str
+  ) agents
 
-(** Get tempo section *)
-let tempo_section (config : Room_utils.config) : section =
-  let state = Tempo.get_tempo config in
-  let content = [Tempo.format_state state] in
-  { title = "Tempo"; content; empty_msg = "" }
+let split_tasks (tasks : Types.task list) =
+  let active =
+    List.filter (fun task ->
+      match task.Types.task_status with
+      | Types.InProgress _ | Types.Claimed _ -> true
+      | Types.Todo | Types.Done _ | Types.Cancelled _ -> false
+    ) tasks
+  in
+  let pending = List.filter (fun task -> task.Types.task_status = Types.Todo) tasks in
+  (active, pending)
 
-(** Parse worktree list JSON to extract worktrees.
-    Tolerant of malformed entries - skips invalid items rather than failing. *)
+let task_lines (tasks : Types.task list) =
+  let (active, pending) = split_tasks tasks in
+  let content =
+    (List.map (fun (task : Types.task) ->
+      let assignee =
+        match task.task_status with
+        | Types.InProgress { assignee; _ } -> assignee
+        | Types.Claimed { assignee; _ } -> assignee
+        | Types.Todo | Types.Done _ | Types.Cancelled _ -> "?"
+      in
+      Printf.sprintf "[P%d] %s (@%s)" task.priority task.title assignee
+    ) active)
+    @ (List.filteri (fun idx _ -> idx < max_pending_tasks) pending
+       |> List.map (fun (task : Types.task) ->
+              Printf.sprintf "[P%d] %s (pending)" task.priority task.title))
+  in
+  let pending_more = List.length pending - max_pending_tasks in
+  if pending_more > 0 then
+    content @ [Printf.sprintf "   ... +%d more pending" pending_more]
+  else
+    content
+
+let message_lines (messages : Types.message list) =
+  List.map (fun (message : Types.message) ->
+    Printf.sprintf "%s: %s" message.from_agent (truncate_message message.content)
+  ) messages
+
+let add_group label lines empty_msg =
+  if lines = [] then
+    [Printf.sprintf "%s: %s" label empty_msg]
+  else
+    (label ^ ":") :: List.map (fun line -> "  " ^ line) lines
+
 let parse_worktrees (json : Yojson.Safe.t) : (string * string) list =
   let module U = Yojson.Safe.Util in
   match json |> U.member "worktrees" with
@@ -165,28 +169,24 @@ let parse_worktrees (json : Yojson.Safe.t) : (string * string) list =
         try
           let worktree = item |> U.member "worktree" |> U.to_string in
           let branch = item |> U.member "branch" |> U.to_string in
-          (* Skip main worktree (usually the repo root) *)
           if String.length branch > 0 && not (String.equal branch "HEAD") then
             Some (branch, worktree)
           else None
         with
-        | Yojson.Safe.Util.Type_error _ -> None  (* JSON field missing or wrong type *)
-        | _ -> None  (* Other unexpected errors *)
+        | Yojson.Safe.Util.Type_error _ -> None
+        | _ -> None
       ) items
-  | `Null -> []  (* No worktrees key - git worktree not used *)
-  | _ -> []  (* Unexpected JSON structure *)
+  | `Null -> []
+  | _ -> []
 
-(** Get worktrees section *)
 let worktrees_section (config : Room_utils.config) : section =
   let json = Room.worktree_list config in
   let worktrees = parse_worktrees json in
-  let content = List.map (fun ((branch, path) : string * string) ->
+  let content = List.map (fun (branch, path) ->
     Printf.sprintf "%s -> %s" branch (truncate_path path)
   ) worktrees in
   { title = "Worktrees"; content; empty_msg = "(no worktrees)" }
 
-(** Count lock files under the locks directory (filesystem backend).
-    Ignores ".flock" metadata files. *)
 let rec count_lock_files path =
   try
     if Sys.file_exists path then
@@ -207,23 +207,123 @@ let rec count_lock_files path =
       0
   with _ -> 0
 
-(** Count active locks across backends *)
-let count_locks (config : Room_utils.config) : int =
+let count_locks_for_dir (config : Room_utils.config) locks_dir =
   match config.backend with
-  | Room_utils.FileSystem _ ->
-      let locks_dir = Filename.concat (Room_utils.masc_dir config) "locks" in
-      count_lock_files locks_dir
-  | Room_utils.Memory _ ->
-      (match Room_utils.backend_list_keys config ~prefix:"locks:" with
-       | Ok keys -> List.length keys
-       | Error _ -> 0)
-  | Room_utils.PostgresNative _ ->
-      (match Room_utils.backend_list_keys config ~prefix:"lock:" with
-       | Ok keys -> List.length keys
-       | Error _ -> 0)
+  | Room_utils.FileSystem _ -> count_lock_files locks_dir
+  | Room_utils.Memory _ | Room_utils.PostgresNative _ ->
+      (match Room_utils.key_of_path config locks_dir with
+       | Some key_prefix ->
+           (match Room_utils.backend_list_keys config ~prefix:(key_prefix ^ ":") with
+            | Ok keys -> List.length keys
+            | Error _ -> 0)
+       | None -> 0)
 
-(** Generate full dashboard *)
-let generate (config : Room_utils.config) : string =
+let count_locks_for_room (config : Room_utils.config) room_id =
+  let locks_dir = Filename.concat (Room.room_path config room_id) "locks" in
+  count_locks_for_dir config locks_dir
+
+let tempo_section (config : Room_utils.config) : section =
+  let state = Tempo.get_tempo config in
+  let content = [Tempo.format_state state] in
+  { title = "Tempo"; content; empty_msg = "" }
+
+let dedupe_keep_order strings =
+  let seen = Hashtbl.create 16 in
+  List.filter (fun value ->
+    if Hashtbl.mem seen value then false
+    else (
+      Hashtbl.add seen value ();
+      true
+    )
+  ) strings
+
+let ordered_room_ids (config : Room_utils.config) =
+  let open Yojson.Safe.Util in
+  let current_room = Room.current_room_id config in
+  let result = Room.rooms_list config in
+  let listed =
+    match result |> member "rooms" with
+    | `List rooms ->
+        List.filter_map (fun room ->
+          match room |> member "id" with
+          | `String id when String.trim id <> "" -> Some id
+          | _ -> None
+        ) rooms
+    | _ -> []
+  in
+  let room_ids =
+    dedupe_keep_order (current_room :: "default" :: listed)
+  in
+  let others = List.filter (fun room_id -> not (String.equal room_id current_room)) room_ids in
+  (current_room, current_room :: List.sort String.compare others)
+
+let room_snapshot (config : Room_utils.config) ~current_room room_id =
+  {
+    room_id;
+    is_current = String.equal room_id current_room;
+    agents = Room.get_agents_raw_in_room config room_id;
+    tasks = Room.get_tasks_raw_in_room config room_id;
+    messages = Room.get_messages_raw_in_room config ~room_id ~since_seq:0 ~limit:max_recent_messages;
+    locks = count_locks_for_room config room_id;
+  }
+
+let room_overview_section (snapshots : room_snapshot list) : section =
+  let content =
+    List.map (fun snapshot ->
+      let (active, pending) = split_tasks snapshot.tasks in
+      Printf.sprintf "%s%s: %d agents | %d active | %d pending | %d locks"
+        snapshot.room_id
+        (if snapshot.is_current then " (current)" else "")
+        (List.length snapshot.agents)
+        (List.length active)
+        (List.length pending)
+        snapshot.locks
+    ) snapshots
+  in
+  { title = "Rooms"; content; empty_msg = "(no rooms)" }
+
+let room_section now (snapshot : room_snapshot) : section =
+  let (active, pending) = split_tasks snapshot.tasks in
+  let content =
+    [Printf.sprintf "Summary: %d agents | %d active | %d pending | %d locks"
+       (List.length snapshot.agents)
+       (List.length active)
+       (List.length pending)
+       snapshot.locks]
+    @ add_group "Agents" (agent_lines now snapshot.agents) "(no agents)"
+    @ add_group "Tasks" (task_lines snapshot.tasks) "(no tasks)"
+    @ add_group "Recent Messages" (message_lines snapshot.messages) "(no messages)"
+  in
+  {
+    title =
+      if snapshot.is_current then
+        Printf.sprintf "Room: %s (current)" snapshot.room_id
+      else
+        Printf.sprintf "Room: %s" snapshot.room_id;
+    content;
+    empty_msg = "";
+  }
+
+let agents_section now (agents : Types.agent list) : section =
+  let content = agent_lines now agents in
+  { title = "Agents"; content; empty_msg = "(no agents)" }
+
+let tasks_section (tasks : Types.task list) : section =
+  let content = task_lines tasks in
+  { title = "Tasks"; content; empty_msg = "(no tasks)" }
+
+let messages_section (messages : Types.message list) : section =
+  let content = message_lines messages in
+  { title = "Recent Messages"; content; empty_msg = "(no messages)" }
+
+let locks_section locks : section =
+  let content = [Printf.sprintf "%d" locks] in
+  { title = "Locks"; content; empty_msg = "0" }
+
+let count_locks (config : Room_utils.config) : int =
+  count_locks_for_room config (Room.current_room_id config)
+
+let generate ?(scope = All) (config : Room_utils.config) : string =
   let now = Time_compat.now () in
   let timestamp =
     let tm = Unix.localtime now in
@@ -231,33 +331,63 @@ let generate (config : Room_utils.config) : string =
       (tm.Unix.tm_year + 1900) (tm.Unix.tm_mon + 1) tm.Unix.tm_mday
       tm.Unix.tm_hour tm.Unix.tm_min tm.Unix.tm_sec
   in
-  let header = Printf.sprintf "========================================\n   MASC Dashboard   %s\n========================================" timestamp in
-  let sections = [
-    agents_section config;
-    tasks_section config;
-    messages_section config;
-    tempo_section config;
-    worktrees_section config;
-  ] in
+  let (current_room, room_ids) = ordered_room_ids config in
+  let snapshots = List.map (room_snapshot config ~current_room) room_ids in
+  let header =
+    Printf.sprintf
+      "========================================\n   MASC Dashboard   %s\n   Scope: %s | Current Room: %s | Rooms: %d\n========================================"
+      timestamp
+      (match scope with All -> "all" | Current -> "current")
+      current_room
+      (List.length room_ids)
+  in
+  let sections =
+    match scope with
+    | All ->
+        [
+          room_overview_section snapshots;
+          tempo_section config;
+          worktrees_section config;
+        ]
+        @ List.map (room_section now) snapshots
+    | Current ->
+        let snapshot = room_snapshot config ~current_room current_room in
+        [
+          agents_section now snapshot.agents;
+          tasks_section snapshot.tasks;
+          messages_section snapshot.messages;
+          locks_section snapshot.locks;
+          tempo_section config;
+          worktrees_section config;
+        ]
+  in
   let section_strs = List.map format_section sections in
   String.concat "\n\n" ([header] @ section_strs @ ["\nRefresh: watch -n 1 masc dashboard"])
 
-(** Compact dashboard (single line per section) *)
-let generate_compact (config : Room_utils.config) : string =
-  let agents = Room.get_agents_raw config in
-  let tasks = Room.get_tasks_raw config in
-  let locks = count_locks config in
+let generate_compact ?(scope = All) (config : Room_utils.config) : string =
   let tempo = Tempo.get_tempo config in
-  let pending = List.filter (fun t -> t.Types.task_status = Types.Todo) tasks in
-  let active = List.filter (fun t ->
-    match t.Types.task_status with
-    | Types.InProgress _ -> true
-    | Types.Claimed _ -> true
-    | _ -> false
-  ) tasks in
-  Printf.sprintf "Agents: %d | Tasks: %d active, %d pending | Locks: %d | Tempo: %.0fs"
-    (List.length agents)
-    (List.length active)
-    (List.length pending)
-    locks
+  let (current_room, room_ids) = ordered_room_ids config in
+  let snapshots =
+    match scope with
+    | All -> List.map (room_snapshot config ~current_room) room_ids
+    | Current -> [room_snapshot config ~current_room current_room]
+  in
+  let (agents_count, active_count, pending_count, locks_count) =
+    List.fold_left (fun (agents_acc, active_acc, pending_acc, locks_acc) snapshot ->
+      let (active, pending) = split_tasks snapshot.tasks in
+      ( agents_acc + List.length snapshot.agents,
+        active_acc + List.length active,
+        pending_acc + List.length pending,
+        locks_acc + snapshot.locks )
+    ) (0, 0, 0, 0) snapshots
+  in
+  Printf.sprintf
+    "Scope: %s | Rooms: %d | Current: %s | Agents: %d | Tasks: %d active, %d pending | Locks: %d | Tempo: %.0fs"
+    (match scope with All -> "all" | Current -> "current")
+    (List.length snapshots)
+    current_room
+    agents_count
+    active_count
+    pending_count
+    locks_count
     tempo.Tempo.current_interval_s

--- a/lib/room.ml
+++ b/lib/room.ml
@@ -82,6 +82,27 @@ let read_backlog config =
 let write_backlog config backlog =
   write_json config (backlog_path config) (backlog_to_yojson backlog)
 
+let current_room_id config =
+  read_current_room config |> Option.value ~default:"default"
+
+let agents_dir_in_room config room_id =
+  Filename.concat (room_dir_for config room_id) "agents"
+
+let tasks_dir_in_room config room_id =
+  Filename.concat (room_dir_for config room_id) "tasks"
+
+let messages_dir_in_room config room_id =
+  Filename.concat (room_dir_for config room_id) "messages"
+
+let backlog_path_in_room config room_id =
+  Filename.concat (tasks_dir_in_room config room_id) "backlog.json"
+
+let read_backlog_in_room config room_id =
+  let json = read_json config (backlog_path_in_room config room_id) in
+  match backlog_of_yojson json with
+  | Ok backlog -> backlog
+  | Error _ -> { tasks = []; last_updated = now_iso (); version = 1 }
+
 (** Parse task id like "task-001" -> 1 *)
 let task_id_to_int id =
   let prefix = "task-" in
@@ -1616,13 +1637,18 @@ let update_priority config ~task_id ~priority =
 (** Get raw task list (for orchestrator) *)
 let get_tasks_raw config =
   ensure_initialized config;
-  let backlog = read_backlog config in
-  backlog.tasks
+  read_backlog_in_room config (current_room_id config) |> fun backlog -> backlog.tasks
+
+let get_tasks_raw_in_room config room_id =
+  if not (root_is_initialized config) then []
+  else
+    let backlog = read_backlog_in_room config room_id in
+    backlog.tasks
 
 (** Get raw agent list (for orchestrator) *)
 let get_agents_raw config =
   ensure_initialized config;
-  let agents_path = agents_dir config in
+  let agents_path = agents_dir_in_room config (current_room_id config) in
   if not (Sys.file_exists agents_path) then []
   else
     Sys.readdir agents_path
@@ -1635,6 +1661,23 @@ let get_agents_raw config =
         | Ok agent -> Some agent
         | Error _ -> None
       )
+
+let get_agents_raw_in_room config room_id =
+  if not (root_is_initialized config) then []
+  else
+    let agents_path = agents_dir_in_room config room_id in
+    if not (Sys.file_exists agents_path) then []
+    else
+      Sys.readdir agents_path
+      |> Array.to_list
+      |> List.filter (fun name -> Filename.check_suffix name ".json")
+      |> List.filter_map (fun name ->
+          let path = Filename.concat agents_path name in
+          let json = read_json config path in
+          match agent_of_yojson json with
+          | Ok agent -> Some agent
+          | Error _ -> None
+        )
 
 (** Check if an agent has joined the room *)
 let is_agent_joined config ~agent_name =
@@ -1680,7 +1723,7 @@ let extract_seq_from_filename name =
 (** Get raw message list (for dashboard) *)
 let get_messages_raw config ~since_seq ~limit =
   ensure_initialized config;
-  let msgs_path = messages_dir config in
+  let msgs_path = messages_dir_in_room config (current_room_id config) in
   if not (Sys.file_exists msgs_path) then []
   else
     Sys.readdir msgs_path
@@ -1699,6 +1742,29 @@ let get_messages_raw config ~since_seq ~limit =
           None
       )
     |> (fun msgs -> List.filteri (fun i _ -> i < limit) msgs)
+
+let get_messages_raw_in_room config ~room_id ~since_seq ~limit =
+  if not (root_is_initialized config) then []
+  else
+    let msgs_path = messages_dir_in_room config room_id in
+    if not (Sys.file_exists msgs_path) then []
+    else
+      Sys.readdir msgs_path
+      |> Array.to_list
+      |> List.filter is_valid_filename
+      |> List.sort (fun a b -> compare (extract_seq_from_filename b) (extract_seq_from_filename a))
+      |> List.filter_map (fun name ->
+          let path = Filename.concat msgs_path name in
+          match read_json config path with
+          | json ->
+            (match message_of_yojson json with
+             | Ok msg when msg.seq > since_seq -> Some msg
+             | _ -> None)
+          | exception e ->
+            Eio.traceln "[WARN] Failed to read room message %s: %s" name (Printexc.to_string e);
+            None
+        )
+      |> (fun msgs -> List.filteri (fun i _ -> i < limit) msgs)
 
 (** List tasks *)
 let list_tasks ?(include_done = false) ?(include_cancelled = false) ?status config =
@@ -2497,21 +2563,16 @@ let room_path config room_id = room_dir_for config room_id
 
 (** Count agents in a room *)
 let count_agents_in_room config room_id =
-  let rpath = room_path config room_id in
-  let agents_path = Filename.concat rpath "agents" in
-  if Sys.file_exists agents_path && Sys.is_directory agents_path then
-    Array.length (Sys.readdir agents_path)
-  else
-    0
+  List.length (get_agents_raw_in_room config room_id)
 
 (** Count tasks in a room *)
 let count_tasks_in_room config room_id =
-  let rpath = room_path config room_id in
-  let tasks_path = Filename.concat rpath "tasks" in
-  if Sys.file_exists tasks_path && Sys.is_directory tasks_path then
-    Array.length (Sys.readdir tasks_path)
-  else
-    0
+  get_tasks_raw_in_room config room_id
+  |> List.fold_left (fun acc (task : Types.task) ->
+         match task.task_status with
+         | Types.Todo | Types.Claimed _ | Types.InProgress _ -> acc + 1
+         | Types.Done _ | Types.Cancelled _ -> acc
+       ) 0
 
 (** Load room registry *)
 let load_registry config : Types.room_registry =

--- a/lib/tool_misc.ml
+++ b/lib/tool_misc.ml
@@ -23,15 +23,31 @@ let get_bool args key default =
   | `Bool b -> b
   | _ -> default
 
+let get_string args key default =
+  match args |> member key with
+  | `String s -> s
+  | _ -> default
+
 (* Handlers *)
 
 let handle_dashboard ctx args =
   let compact = get_bool args "compact" false in
-  let output =
-    if compact then Dashboard.generate_compact ctx.config
-    else Dashboard.generate ctx.config
+  let scope_arg = String.lowercase_ascii (get_string args "scope" "all") in
+  let scope =
+    match scope_arg with
+    | "all" -> Ok Dashboard.All
+    | "current" -> Ok Dashboard.Current
+    | other -> Error other
   in
-  (true, output)
+  match scope with
+  | Error other ->
+      (false, Printf.sprintf "❌ Invalid dashboard scope '%s' (expected: all | current)" other)
+  | Ok scope ->
+      let output =
+        if compact then Dashboard.generate_compact ~scope ctx.config
+        else Dashboard.generate ~scope ctx.config
+      in
+      (true, output)
 
 (* Note: verify_handoff requires tokenize/jaccard/cosine functions from mcp_server_eio.ml
    and is kept there for now. This is a stub. *)

--- a/lib/tools.ml
+++ b/lib/tools.ml
@@ -3266,13 +3266,18 @@ Example: masc_tempo_reset() → {tempo: 300, message: 'Reset to default'}";
   (* ===== Dashboard Tools (Phase 13) ===== *)
   {
     name = "masc_dashboard";
-    description = "Show full MASC dashboard with agents, tasks, locks, messages, tempo, and worktrees. Use with 'watch -n 1' for real-time updates.";
+    description = "Show the MASC dashboard. By default it summarizes all rooms, and you can filter to the current room with scope='current'. Use with 'watch -n 1' for real-time updates.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
         ("compact", `Assoc [
           ("type", `String "boolean");
           ("description", `String "If true, show compact single-line summary instead of full dashboard");
+        ]);
+        ("scope", `Assoc [
+          ("type", `String "string");
+          ("description", `String "Dashboard scope: 'all' (default) or 'current'");
+          ("default", `String "all");
         ]);
       ]);
     ];

--- a/test/test_dashboard.ml
+++ b/test/test_dashboard.ml
@@ -70,9 +70,10 @@ let test_generate_compact () =
   let config = Lib.Room_utils.default_config dir in
   setup_room config;
   let output = Lib.Dashboard.generate_compact config in
-  Alcotest.(check bool) "contains Agents" true (contains output "Agents:");
+  Alcotest.(check bool) "contains Scope" true (contains output "Scope: all");
+  Alcotest.(check bool) "contains Rooms" true (contains output "Rooms:");
   Alcotest.(check bool) "contains Tasks" true (contains output "Tasks:");
-  (* Locks section removed in 132708a - advisory lock deprecation *)
+  Alcotest.(check bool) "contains Current" true (contains output "Current:");
   Alcotest.(check bool) "contains Tempo" true (contains output "Tempo:");
   cleanup_dir dir
 
@@ -82,8 +83,9 @@ let test_generate_full () =
   setup_room config;
   let output = Lib.Dashboard.generate config in
   Alcotest.(check bool) "contains MASC Dashboard" true (contains output "MASC Dashboard");
-  Alcotest.(check bool) "contains Agents section" true (contains output "Agents");
-  Alcotest.(check bool) "contains Tasks section" true (contains output "Tasks");
+  Alcotest.(check bool) "contains Scope" true (contains output "Scope: all");
+  Alcotest.(check bool) "contains Rooms section" true (contains output "Rooms");
+  Alcotest.(check bool) "contains default room" true (contains output "Room: default");
   Alcotest.(check bool) "contains watch hint" true (contains output "watch");
   cleanup_dir dir
 
@@ -93,7 +95,7 @@ let test_agents_section_empty () =
   let dir = test_dir () in
   let config = Lib.Room_utils.default_config dir in
   setup_room config;
-  let section = Lib.Dashboard.agents_section config in
+  let section = Lib.Dashboard.agents_section (Unix.gettimeofday ()) [] in
   Alcotest.(check string) "title" "Agents" section.title;
   Alcotest.(check string) "empty_msg" "(no agents)" section.empty_msg;
   cleanup_dir dir
@@ -102,13 +104,7 @@ let test_tasks_section_empty () =
   let dir = test_dir () in
   let config = Lib.Room_utils.default_config dir in
   setup_room config;
-  let masc_dir = Filename.concat dir ".masc" in
-  let backlog_path = Filename.concat masc_dir "backlog.json" in
-  let backlog_json = `Assoc [("tasks", `List [])] in
-  let oc = open_out backlog_path in
-  output_string oc (Yojson.Safe.to_string backlog_json);
-  close_out oc;
-  let section = Lib.Dashboard.tasks_section config in
+  let section = Lib.Dashboard.tasks_section [] in
   Alcotest.(check string) "title" "Tasks" section.title;
   Alcotest.(check string) "empty_msg" "(no tasks)" section.empty_msg;
   cleanup_dir dir
@@ -117,7 +113,7 @@ let test_messages_section_empty () =
   let dir = test_dir () in
   let config = Lib.Room_utils.default_config dir in
   setup_room config;
-  let section = Lib.Dashboard.messages_section config in
+  let section = Lib.Dashboard.messages_section [] in
   Alcotest.(check string) "title" "Recent Messages" section.title;
   Alcotest.(check string) "empty_msg" "(no messages)" section.empty_msg;
   cleanup_dir dir

--- a/test/test_multi_room.ml
+++ b/test/test_multi_room.ml
@@ -43,6 +43,22 @@ let extract_nickname result =
     String.sub result start_idx (end_idx - start_idx)
   with _ -> "unknown-agent"
 
+let extract_room_task_count json room_id =
+  match json with
+  | `Assoc fields ->
+      (match List.assoc_opt "rooms" fields with
+       | Some (`List rooms) ->
+           List.find_map (fun room ->
+             match room with
+             | `Assoc room_fields ->
+                 (match (List.assoc_opt "id" room_fields, List.assoc_opt "task_count" room_fields) with
+                  | Some (`String id), Some (`Int count) when id = room_id -> Some count
+                  | _ -> None)
+             | _ -> None
+           ) rooms
+       | _ -> None)
+  | _ -> None
+
 (* ============================================ *)
 (* Room Registry Tests                          *)
 (* ============================================ *)
@@ -226,6 +242,28 @@ let test_room_task_isolation () =
     check int "default room remains isolated" 1 (task_count config);
   )
 
+let test_rooms_list_task_count_active_only () =
+  let (config, test_dir) = setup_test_room () in
+  Fun.protect ~finally:(fun () -> cleanup_test_room test_dir) (fun () ->
+    let init_result = Room.init config ~agent_name:(Some "codex") in
+    let nickname = extract_nickname init_result in
+
+    ignore (Room.add_task config ~title:"default-done" ~priority:2 ~description:"");
+    ignore (Room.add_task config ~title:"default-todo" ~priority:2 ~description:"");
+    ignore (Room.claim_task config ~agent_name:nickname ~task_id:"task-001");
+    ignore (Room.complete_task config ~agent_name:nickname ~task_id:"task-001" ~notes:"done");
+
+    ignore (Room.room_create config ~name:"Count Room" ~description:None);
+    ignore (Room.room_enter config ~room_id:"count-room" ~agent_type:"codex" ());
+    ignore (Room.add_task config ~title:"count-room-task" ~priority:3 ~description:"");
+
+    let result = Room.rooms_list config in
+    check (option int) "default counts only active tasks" (Some 1)
+      (extract_room_task_count result "default");
+    check (option int) "count-room active tasks" (Some 1)
+      (extract_room_task_count result "count-room");
+  )
+
 (* ============================================ *)
 (* Backward Compatibility Tests                 *)
 (* ============================================ *)
@@ -277,6 +315,7 @@ let () =
     "room_isolation", [
       test_case "agent moves between rooms" `Quick test_room_enter_moves_agent;
       test_case "tasks are isolated per room" `Quick test_room_task_isolation;
+      test_case "rooms_list task_count uses active tasks" `Quick test_rooms_list_task_count_active_only;
     ];
     "backward_compat", [
       test_case "legacy masc as default" `Quick test_legacy_masc_as_default_room;

--- a/test/test_tool_misc_coverage.ml
+++ b/test/test_tool_misc_coverage.ml
@@ -6,6 +6,18 @@ let () = Random.self_init ()
 
 let () = Printf.printf "\n=== Tool_misc Coverage Tests ===\n"
 
+let str_contains s sub =
+  let len_s = String.length s in
+  let len_sub = String.length sub in
+  if len_sub > len_s then false
+  else
+    let rec loop i =
+      if i > len_s - len_sub then false
+      else if String.sub s i len_sub = sub then true
+      else loop (i + 1)
+    in
+    loop 0
+
 (* Test helper *)
 let test name f =
   try
@@ -36,11 +48,17 @@ let () = test "dispatch_unknown_tool" (fun () ->
 (* Test dispatch dashboard — may require Eio runtime; skip gracefully if unavailable *)
 let () = test "dispatch_dashboard" (fun () ->
   let ctx = make_test_ctx () in
+  ignore (Room.add_task ctx.config ~title:"default task" ~priority:2 ~description:"");
+  ignore (Room.room_create ctx.config ~name:"Second Room" ~description:None);
+  ignore (Room.room_enter ctx.config ~room_id:"second-room" ~agent_type:"claude" ~agent_name:ctx.agent_name ());
+  ignore (Room.add_task ctx.config ~title:"second task" ~priority:1 ~description:"");
   let args = `Assoc [] in
   match Tool_misc.dispatch ctx ~name:"masc_dashboard" ~args with
   | Some (success, result) ->
       assert success;
-      assert (String.length result > 0)
+      assert (str_contains result "Scope: all");
+      assert (str_contains result "Room: default");
+      assert (str_contains result "Room: second-room");
   | None -> failwith "dispatch returned None"
   | exception Effect.Unhandled _ ->
       Printf.printf "  (skipped: Eio runtime not available)\n"
@@ -53,10 +71,38 @@ let () = test "dispatch_dashboard_compact" (fun () ->
   match Tool_misc.dispatch ctx ~name:"masc_dashboard" ~args with
   | Some (success, result) ->
       assert success;
-      assert (String.length result > 0)
+      assert (str_contains result "Scope: all");
+      assert (str_contains result "Current:");
   | None -> failwith "dispatch returned None"
   | exception Effect.Unhandled _ ->
       Printf.printf "  (skipped: Eio runtime not available)\n"
+)
+
+let () = test "dispatch_dashboard_current_scope" (fun () ->
+  let ctx = make_test_ctx () in
+  ignore (Room.room_create ctx.config ~name:"Focus Room" ~description:None);
+  ignore (Room.room_enter ctx.config ~room_id:"focus-room" ~agent_type:"claude" ~agent_name:ctx.agent_name ());
+  ignore (Room.add_task ctx.config ~title:"focus task" ~priority:2 ~description:"");
+  let args = `Assoc [("scope", `String "current")] in
+  match Tool_misc.dispatch ctx ~name:"masc_dashboard" ~args with
+  | Some (success, result) ->
+      assert success;
+      assert (str_contains result "Scope: current");
+      assert (str_contains result "Current Room: focus-room");
+      assert (not (str_contains result "Room: default"))
+  | None -> failwith "dispatch returned None"
+  | exception Effect.Unhandled _ ->
+      Printf.printf "  (skipped: Eio runtime not available)\n"
+)
+
+let () = test "dispatch_dashboard_invalid_scope" (fun () ->
+  let ctx = make_test_ctx () in
+  let args = `Assoc [("scope", `String "everywhere")] in
+  match Tool_misc.dispatch ctx ~name:"masc_dashboard" ~args with
+  | Some (success, result) ->
+      assert (not success);
+      assert (str_contains result "Invalid dashboard scope")
+  | None -> failwith "dispatch returned None"
 )
 
 (* Test dispatch gc *)
@@ -116,6 +162,16 @@ let () = test "get_bool_false" (fun () ->
 let () = test "get_bool_missing" (fun () ->
   let args = `Assoc [] in
   assert (Tool_misc.get_bool args "key" true = true)
+)
+
+let () = test "get_string_present" (fun () ->
+  let args = `Assoc [("key", `String "value")] in
+  assert (Tool_misc.get_string args "key" "default" = "value")
+)
+
+let () = test "get_string_missing" (fun () ->
+  let args = `Assoc [] in
+  assert (Tool_misc.get_string args "key" "default" = "default")
 )
 
 let () = Printf.printf "\n✅ All Tool_misc tests passed!\n"


### PR DESCRIPTION
## Summary
- make `masc_dashboard` default to all-room output with `scope=current` fallback
- add room-scoped dashboard snapshots so room data can be rendered without mutating current room
- fix `rooms_list.task_count` to use active backlog tasks instead of directory entry counts

## Testing
- `dune build --root .`
- `dune exec --root . test/test_dashboard.exe`
- `./_build/default/test/test_multi_room.exe`
- `./_build/default/test/test_tool_misc_coverage.exe`