### PR TITLE
dashboard: truthfulness fixes for MDAL and agent status

### DIFF
--- a/bin/main_eio.ml
+++ b/bin/main_eio.ml
@@ -5248,7 +5248,6 @@ let mdal_loops_json (request : Httpun.Request.t) : (Yojson.Safe.t, string) resul
 
 let mdal_loops_error_json (msg : string) : Yojson.Safe.t =
   `Assoc [ ("error", `String msg) ]
-
 let dashboard_batch_json ?(compact = false) (config : Room.config) : Yojson.Safe.t =
   let room_state = Room.read_state config in
   let tempo = Tempo.get_tempo config in
@@ -5354,9 +5353,6 @@ let dashboard_batch_json ?(compact = false) (config : Room.config) : Yojson.Safe
         ("current_task", match a.current_task with Some t -> `String t | None -> `Null);
         ("emoji", `String emoji);
         ("koreanName", `String korean_name);
-        ("generation", `Int 0);
-        ("context_ratio", `Float 0.0);
-        ("turn_count", `Int 0);
       ]
     ) agents
   in
@@ -8218,7 +8214,6 @@ let make_routes ~port ~host ~sw ~clock =
                (Yojson.Safe.to_string (operator_error_json ("invalid json: " ^ e)))
          )
        ) request reqd)
-
   |> Http.Router.get "/api/v1/council/debates" (fun request reqd ->
        with_public_read (fun state req reqd ->
          let base_path = state.Mcp_server.room_config.base_path in
@@ -9122,7 +9117,6 @@ let run_server ~sw ~env ~port ~base_path =
           else
             let json = operator_snapshot_http_json ~state ~sw ~clock httpun_request in
             h2_respond_json h2_reqd (Yojson.Safe.to_string json) ~extra_headers:cors
-
       | `GET, "/api/v1/status" ->
           let state = get_server_state () in
           let config = state.Mcp_server.room_config in

--- a/bin/main_eio.ml
+++ b/bin/main_eio.ml
@@ -5353,6 +5353,9 @@ let dashboard_batch_json ?(compact = false) (config : Room.config) : Yojson.Safe
         ("current_task", match a.current_task with Some t -> `String t | None -> `Null);
         ("emoji", `String emoji);
         ("koreanName", `String korean_name);
+        ("generation", `Null);
+        ("context_ratio", `Null);
+        ("turn_count", `Null);
       ]
     ) agents
   in

--- a/dashboard/src/api.ts
+++ b/dashboard/src/api.ts
@@ -336,7 +336,6 @@ export function confirmOperatorAction(actor: string, confirmToken: string): Prom
     confirm_token: confirmToken,
   })
 }
-
 // --- Board ---
 
 const SYSTEM_BOARD_AUTHORS = new Set(['lodge-system', 'team-session'])

--- a/dashboard/src/store.ts
+++ b/dashboard/src/store.ts
@@ -511,7 +511,6 @@ function normalizeMdalLoop(raw: unknown): MdalLoop | null {
     history,
   }
 }
-
 export async function refreshDashboard(mode: DashboardMode = 'full'): Promise<void> {
   const now = Date.now()
   const cached = _dashboardCache[mode]
@@ -610,7 +609,6 @@ export async function refreshMdal(): Promise<void> {
     mdalLoading.value = false
   }
 }
-
 // --- SSE event reaction ---
 // When lastEvent changes, invalidate cache and re-fetch
 

--- a/dashboard/src/store.ts
+++ b/dashboard/src/store.ts
@@ -676,7 +676,13 @@ export function setupSSEReaction(): () => void {
     }
   })
 
-  return unsubscribe
+  return () => {
+    unsubscribe()
+    if (_mdalDebounce) {
+      clearTimeout(_mdalDebounce)
+      _mdalDebounce = null
+    }
+  }
 }
 
 // --- Periodic refresh (for keeper presence heartbeats that don't emit SSE) ---


### PR DESCRIPTION
## Summary
- add /api/v1/mdal/loops snapshot API for dashboard restoration (HTTP + H2)
- remove synthetic agent fields from dashboard batch response (generation/context_ratio/turn_count)
- switch MDAL frontend from SSE synthetic fallback to snapshot-based refresh
- preserve truthful agent statuses (busy, listening) end-to-end

## Validation
- npx tsc --noEmit --pretty (dashboard)
- dune build --root .
- dune exec --root . ./test/test_dashboard.exe
- dune exec --root . ./test/test_dashboard_coverage.exe
- ./_build/default/test/test_web_dashboard_coverage.exe
- ./_build/default/test/test_credits_dashboard_coverage.exe
- dune exec --root . ./test/test_dashboard_resilience_coverage.exe

## Smoke
- local run verified:
  - GET /api/v1/mdal/loops => 200
  - GET /api/v1/mdal/loops?status=foo => 400