### PR TITLE
Add operator digest read surface

### DIFF
--- a/bin/main_eio.ml
+++ b/bin/main_eio.ml
@@ -8652,7 +8652,7 @@ let run_server ~sw ~env ~port ~base_path =
     "   GET  /mcp/operator → Remote operator MCP stream (bearer token required)\n\
      %!";
   Printf.printf
-    "   POST /mcp/operator → Remote operator JSON-RPC (3 curated tools only)\n\
+    "   POST /mcp/operator → Remote operator JSON-RPC (4 curated tools only)\n\
      %!";
   Printf.printf
     "   DELETE /mcp/operator → Remote operator session termination\n%!";

--- a/docs/REMOTE-MCP-OPERATOR.md
+++ b/docs/REMOTE-MCP-OPERATOR.md
@@ -12,8 +12,9 @@
 
 - Streamable HTTP / SSE endpoint: `GET|POST|DELETE /mcp/operator`
 - Authentication: bearer token only
-- Tool surface: exactly 3 tools
+- Tool surface: exactly 4 tools
   - `masc_operator_snapshot`
+  - `masc_operator_digest`
   - `masc_operator_action`
   - `masc_operator_confirm`
 
@@ -35,6 +36,15 @@ Read-only room control-plane view.
 
 - Returns room summary, sessions, keepers, recent messages, pending confirmations, available actions, `trace_id`, and server profile metadata.
 - Supports `view` values: `summary`, `sessions`, `keepers`, `messages`, `full`.
+- `view="summary"` and `view="full"` also include lightweight `attention_summary` and `recommendation_summary` counts.
+
+### `masc_operator_digest`
+
+Intervention-oriented read model.
+
+- Use this when raw snapshot data is too low-level and you need actionable supervision hints.
+- Returns `health`, prioritized `attention_items`, advisory `recommended_actions`, and session/worker cards.
+- Supports room-wide digests and session-targeted digests through `target_type` and `target_id`.
 
 ### `masc_operator_action`
 
@@ -89,6 +99,7 @@ url = "https://your-host.example.com/mcp/operator"
 bearer_token_env_var = "MASC_OPERATOR_TOKEN"
 enabled_tools = [
   "masc_operator_snapshot",
+  "masc_operator_digest",
   "masc_operator_action",
   "masc_operator_confirm",
 ]
@@ -100,13 +111,14 @@ Optional static or environment-backed headers can also be used when the client s
 
 ## Claude Code
 
-Claude Code can connect to remote MCP servers. Register the same `/mcp/operator` URL and bearer token in the client's MCP configuration, and keep the exposed tool allowlist restricted to the operator trio.
+Claude Code can connect to remote MCP servers. Register the same `/mcp/operator` URL and bearer token in the client's MCP configuration, and keep the exposed tool allowlist restricted to the operator quartet.
 
 Recommended usage pattern:
 
-1. Call `masc_operator_snapshot`.
-2. Call `masc_operator_action`.
-3. If `confirm_required=true`, inspect the preview and then call `masc_operator_confirm`.
+1. Call `masc_operator_snapshot(view="summary")`.
+2. Call `masc_operator_digest`.
+3. Call `masc_operator_action`.
+4. If `confirm_required=true`, inspect the preview and then call `masc_operator_confirm`.
 
 ## ChatGPT Developer Mode
 

--- a/docs/SUPERVISOR-MODE.md
+++ b/docs/SUPERVISOR-MODE.md
@@ -16,6 +16,7 @@ Supervisor Mode v1 is built on top of the existing operator surface.
 - Worker endpoint: `/mcp`
 - Supervisor tools:
   - `masc_operator_snapshot`
+  - `masc_operator_digest`
   - `masc_operator_action`
   - `masc_operator_confirm`
 - Worker substrate:
@@ -91,16 +92,16 @@ Default policy:
 Recommended loop for Codex or Claude Code in a TUI:
 
 1. Call `masc_operator_snapshot` with `view="summary"` for low-cost polling.
-2. Re-run with `view="full"` when intervention looks necessary.
+2. Call `masc_operator_digest` for the room or a specific team session.
 3. Diagnose using:
-   - active session state
-   - recent messages
-   - pending confirmations
-   - recent operator actions
+   - digest `health`
+   - prioritized `attention_items`
+   - advisory `recommended_actions`
+   - recent messages and pending confirmations from snapshot
 4. Call `masc_operator_action`.
 5. If `confirm_required=true`, inspect `preview` and wait for human approval.
 6. Call `masc_operator_confirm`.
-7. Re-check with `masc_operator_snapshot` and `masc_team_session_events`.
+7. Re-check with `masc_operator_snapshot`, `masc_operator_digest`, and `masc_team_session_events`.
 
 ## Human Confirm Gate
 
@@ -178,6 +179,7 @@ url = "https://your-host.example.com/mcp/operator"
 bearer_token_env_var = "MASC_OPERATOR_TOKEN"
 enabled_tools = [
   "masc_operator_snapshot",
+  "masc_operator_digest",
   "masc_operator_action",
   "masc_operator_confirm",
 ]
@@ -187,23 +189,25 @@ tool_timeout_sec = 60
 
 Typical flow:
 
-1. `masc_operator_snapshot(view="full")`
-2. `masc_operator_action(action_type="team_note", target_id="ts-...", payload={message:"..."})`
-3. `masc_operator_action(action_type="team_task_inject", target_id="ts-...", payload={title:"...", description:"...", priority:1})`
-4. inspect preview
-5. `masc_operator_confirm(confirm_token="...")`
-6. `masc_team_session_events(session_id="ts-...")` via `/mcp`
+1. `masc_operator_snapshot(view="summary")`
+2. `masc_operator_digest(target_type="team_session", target_id="ts-...")`
+3. `masc_operator_action(action_type="team_note", target_id="ts-...", payload={message:"..."})`
+4. `masc_operator_action(action_type="team_task_inject", target_id="ts-...", payload={title:"...", description:"...", priority:1})`
+5. inspect preview
+6. `masc_operator_confirm(confirm_token="...")`
+7. `masc_team_session_events(session_id="ts-...")` via `/mcp`
 
 ## Claude Code Example
 
-Register the same remote MCP server and restrict the exposed tool allowlist to the operator trio.
+Register the same remote MCP server and restrict the exposed tool allowlist to the operator quartet.
 
 Recommended pattern:
 
-1. read snapshot
-2. issue one structured action
-3. wait for confirm when required
-4. re-check team-session evidence through `/mcp`
+1. read summary snapshot
+2. read digest
+3. issue one structured action
+4. wait for confirm when required
+5. re-check team-session evidence through `/mcp`
 
 ## Harness
 

--- a/lib/auth.ml
+++ b/lib/auth.ml
@@ -228,6 +228,7 @@ let permission_for_tool = function
   | "masc_agents" | "masc_portal_status" | "masc_pending_interrupts"
   | "masc_votes" | "masc_vote_status" | "masc_worktree_list"
   | "masc_cost_report" | "masc_task_history" | "masc_operator_snapshot"
+  | "masc_operator_digest"
   | "masc_llama_models" | "masc_unit_list" | "masc_operation_status"
   | "masc_policy_status" | "masc_dispatch_plan" | "masc_dispatch_route"
   | "masc_observe_topology" | "masc_observe_operations"

--- a/lib/mcp_server_eio.ml
+++ b/lib/mcp_server_eio.ml
@@ -782,7 +782,7 @@ let read_only_tools =
    "masc_goal_list"; "masc_team_session_status"; "masc_team_session_report";
    "masc_team_session_list"; "masc_team_session_compare";
    "masc_team_session_events"; "masc_team_session_prove";
-   "masc_operator_snapshot"]
+   "masc_operator_snapshot"; "masc_operator_digest"]
 
 let execute_tool_eio ~sw ~clock ?mcp_session_id ?auth_token state ~name ~arguments =
   (* clock parameter used for Session_eio.wait_for_message *)
@@ -2972,9 +2972,9 @@ in
 
 (** Eio-native handlers for simple methods *)
 let operator_remote_instructions =
-  "MASC remote operator profile exposes only three control-plane tools: \
-masc_operator_snapshot, masc_operator_action, and masc_operator_confirm. \
-Read state with masc_operator_snapshot first. \
+  "MASC remote operator profile exposes only four control-plane tools: \
+masc_operator_snapshot, masc_operator_digest, masc_operator_action, and masc_operator_confirm. \
+Read raw state with masc_operator_snapshot first when needed, and prefer masc_operator_digest for intervention-oriented supervision. \
 Use masc_operator_action for guided actions only. \
 When confirm_required=true, you must call masc_operator_confirm with the returned confirm_token before the action executes. \
 Do not assume access to any other MASC tool from this endpoint."
@@ -3005,6 +3005,8 @@ let tool_allowed_in_profile profile tool_name =
 let tool_annotations_for_profile profile tool_name =
   match profile with
   | Operator_remote when String.equal tool_name "masc_operator_snapshot" ->
+      Some (`Assoc [ ("readOnlyHint", `Bool true) ])
+  | Operator_remote when String.equal tool_name "masc_operator_digest" ->
       Some (`Assoc [ ("readOnlyHint", `Bool true) ])
   | Operator_remote when List.mem tool_name [ "masc_operator_action"; "masc_operator_confirm" ] ->
       Some (`Assoc [ ("readOnlyHint", `Bool false) ])

--- a/lib/mode.ml
+++ b/lib/mode.ml
@@ -135,7 +135,7 @@ let tool_category tool_name =
   | "masc_observe_topology" | "masc_observe_operations"
   | "masc_observe_capacity" | "masc_observe_alerts"
   | "masc_observe_traces"
-  | "masc_operator_snapshot" | "masc_operator_action"
+  | "masc_operator_snapshot" | "masc_operator_digest" | "masc_operator_action"
   | "masc_operator_confirm" -> Core
 
   (* Communication tools *)

--- a/lib/operator_control.ml
+++ b/lib/operator_control.ml
@@ -118,8 +118,56 @@ let operator_server_profile_json =
       ("transport", `String "mcp_streamable_http");
       ("auth", `String "bearer_token");
       ("confirm_ttl_seconds", `Float remote_confirm_ttl_seconds);
-      ("curated_tool_count", `Int 3);
+      ("curated_tool_count", `Int 4);
     ]
+
+type attention_item = {
+  kind : string;
+  severity : string;
+  summary : string;
+  target_type : string;
+  target_id : string option;
+  actor : string option;
+  evidence : Yojson.Safe.t;
+}
+
+type recommended_action = {
+  action_type : string;
+  target_type : string;
+  target_id : string option;
+  severity : string;
+  reason : string;
+  suggested_payload : Yojson.Safe.t;
+}
+
+type worker_card = {
+  actor : string option;
+  spawn_agent : string option;
+  spawn_role : string option;
+  spawn_model : string option;
+  status : string;
+  turn_count : int;
+  empty_note_turn_count : int;
+  has_turn : bool;
+  last_turn_ts_iso : string option;
+}
+
+type session_digest = {
+  session_id : string;
+  goal : string;
+  status : string;
+  health : string;
+  planned_worker_count : int;
+  active_agent_count : int;
+  last_turn_age_sec : int option;
+  attention_items : attention_item list;
+  recommended_actions : recommended_action list;
+  worker_cards : worker_card list;
+}
+
+let stalled_session_threshold_sec = 300.0
+let planned_worker_turn_grace_sec = 180.0
+let room_digest_session_limit = 10
 
 let preview_of_pending_confirm (entry : pending_confirm) =
   `Assoc
@@ -494,6 +542,625 @@ let room_json config =
         ("message_seq", `Int state.message_seq);
       ]
 
+let severity_rank = function
+  | "bad" -> 2
+  | "warn" -> 1
+  | _ -> 0
+
+let compare_attention (a : attention_item) (b : attention_item) =
+  let by_severity = Int.compare (severity_rank b.severity) (severity_rank a.severity) in
+  if by_severity <> 0 then by_severity
+  else
+    match (a.target_id, b.target_id) with
+    | Some x, Some y ->
+        let by_target = String.compare x y in
+        if by_target <> 0 then by_target else String.compare a.kind b.kind
+    | Some _, None -> -1
+    | None, Some _ -> 1
+    | None, None -> String.compare a.kind b.kind
+
+let compare_recommendation (a : recommended_action) (b : recommended_action) =
+  let by_severity = Int.compare (severity_rank b.severity) (severity_rank a.severity) in
+  if by_severity <> 0 then by_severity
+  else
+    match (a.target_id, b.target_id) with
+    | Some x, Some y ->
+        let by_target = String.compare x y in
+        if by_target <> 0 then by_target else String.compare a.action_type b.action_type
+    | Some _, None -> -1
+    | None, Some _ -> 1
+    | None, None -> String.compare a.action_type b.action_type
+
+let compare_worker_card (a : worker_card) (b : worker_card) =
+  let by_status = String.compare a.status b.status in
+  if by_status <> 0 then by_status
+  else
+    let by_turns = Int.compare b.turn_count a.turn_count in
+    if by_turns <> 0 then by_turns
+    else
+      String.compare
+        (Option.value ~default:"" a.actor)
+        (Option.value ~default:"" b.actor)
+
+let compare_session_digest (a : session_digest) (b : session_digest) =
+  let by_health = Int.compare (severity_rank b.health) (severity_rank a.health) in
+  if by_health <> 0 then by_health
+  else
+    let by_status =
+      match (a.status, b.status) with
+      | "running", "running" -> 0
+      | "running", _ -> -1
+      | _, "running" -> 1
+      | _ -> String.compare a.status b.status
+    in
+    if by_status <> 0 then by_status else String.compare a.session_id b.session_id
+
+let attention_item_to_yojson (item : attention_item) =
+  `Assoc
+    [
+      ("kind", `String item.kind);
+      ("severity", `String item.severity);
+      ("summary", `String item.summary);
+      ("target_type", `String item.target_type);
+      ("target_id", string_option_to_json item.target_id);
+      ("actor", string_option_to_json item.actor);
+      ("evidence", item.evidence);
+    ]
+
+let recommended_confirm_required = function
+  | "room_pause" | "team_stop" | "task_inject" | "team_task_inject" -> true
+  | _ -> false
+
+let recommended_action_to_yojson ~actor (item : recommended_action) =
+  let preview =
+    `Assoc
+      [
+        ("actor", `String actor);
+        ("action_type", `String item.action_type);
+        ("target_type", `String item.target_type);
+        ("target_id", string_option_to_json item.target_id);
+        ("payload", item.suggested_payload);
+      ]
+  in
+  `Assoc
+    [
+      ("action_type", `String item.action_type);
+      ("target_type", `String item.target_type);
+      ("target_id", string_option_to_json item.target_id);
+      ("severity", `String item.severity);
+      ("reason", `String item.reason);
+      ("confirm_required", `Bool (recommended_confirm_required item.action_type));
+      ("suggested_payload", item.suggested_payload);
+      ("preview", preview);
+    ]
+
+let worker_card_to_yojson (card : worker_card) =
+  `Assoc
+    [
+      ("actor", string_option_to_json card.actor);
+      ("spawn_agent", string_option_to_json card.spawn_agent);
+      ("spawn_role", string_option_to_json card.spawn_role);
+      ("spawn_model", string_option_to_json card.spawn_model);
+      ("status", `String card.status);
+      ("turn_count", `Int card.turn_count);
+      ("empty_note_turn_count", `Int card.empty_note_turn_count);
+      ("has_turn", `Bool card.has_turn);
+      ("last_turn_ts_iso", string_option_to_json card.last_turn_ts_iso);
+    ]
+
+let session_card_to_yojson ~actor (digest : session_digest) =
+  let top_attention =
+    match digest.attention_items |> List.sort compare_attention with
+    | item :: _ -> Some item
+    | [] -> None
+  in
+  let top_recommendation =
+    match digest.recommended_actions |> List.sort compare_recommendation with
+    | item :: _ -> Some item
+    | [] -> None
+  in
+  `Assoc
+    [
+      ("session_id", `String digest.session_id);
+      ("goal", `String digest.goal);
+      ("status", `String digest.status);
+      ("health", `String digest.health);
+      ("planned_worker_count", `Int digest.planned_worker_count);
+      ("active_agent_count", `Int digest.active_agent_count);
+      ("last_turn_age_sec", option_to_json (fun v -> `Int v) digest.last_turn_age_sec);
+      ("attention_count", `Int (List.length digest.attention_items));
+      ("top_attention", option_to_json attention_item_to_yojson top_attention);
+      ("recommended_action_count", `Int (List.length digest.recommended_actions));
+      ( "top_recommendation",
+        option_to_json (recommended_action_to_yojson ~actor) top_recommendation );
+    ]
+
+let summary_of_attention_items (items : attention_item list) =
+  let sorted = List.sort compare_attention items in
+  let top_item : attention_item option =
+    match sorted with item :: _ -> Some item | [] -> None
+  in
+  let bad_count =
+    List.fold_left
+      (fun acc (item : attention_item) ->
+        if String.equal item.severity "bad" then acc + 1 else acc)
+      0 sorted
+  in
+  let warn_count =
+    List.fold_left
+      (fun acc (item : attention_item) ->
+        if String.equal item.severity "warn" then acc + 1 else acc)
+      0 sorted
+  in
+  `Assoc
+    [
+      ("count", `Int (List.length sorted));
+      ("bad_count", `Int bad_count);
+      ("warn_count", `Int warn_count);
+      ("top_item", option_to_json attention_item_to_yojson top_item);
+    ]
+
+let dedup_recommendations (items : recommended_action list) =
+  let rec loop seen acc = function
+    | [] -> List.rev acc
+    | item :: rest ->
+        let key =
+          String.concat "|"
+            [
+              item.action_type;
+              item.target_type;
+              Option.value ~default:"" item.target_id;
+            ]
+        in
+        if List.mem key seen then loop seen acc rest
+        else loop (key :: seen) (item :: acc) rest
+  in
+  items |> List.sort compare_recommendation |> loop [] []
+
+let summary_of_recommendations ~actor (items : recommended_action list) =
+  let sorted = dedup_recommendations items in
+  let top_item : recommended_action option =
+    match sorted with item :: _ -> Some item | [] -> None
+  in
+  `Assoc
+    [
+      ("count", `Int (List.length sorted));
+      ( "top_action",
+        option_to_json (recommended_action_to_yojson ~actor) top_item );
+    ]
+
+let event_ts_iso json =
+  match U.member "ts_iso" json with `String value -> Some value | _ -> None
+
+let event_type json =
+  match U.member "event_type" json with `String value -> Some value | _ -> None
+
+let event_detail_actor json =
+  match U.member "detail" json |> U.member "actor" with
+  | `String actor ->
+      let trimmed = String.trim actor in
+      if trimmed = "" then None else Some trimmed
+  | _ -> None
+
+let event_detail_kind json =
+  match U.member "detail" json |> U.member "kind" with
+  | `String kind ->
+      let trimmed = String.trim kind in
+      if trimmed = "" then None else Some trimmed
+  | _ -> None
+
+let event_detail_message json =
+  match U.member "detail" json |> U.member "message" with
+  | `String message ->
+      let trimmed = String.trim message in
+      if trimmed = "" then None else Some trimmed
+  | _ -> None
+
+let count_spawn_failures events =
+  List.fold_left
+    (fun acc json ->
+      match (event_type json, U.member "detail" json |> U.member "success") with
+      | Some "team_step_spawn", `Bool false -> acc + 1
+      | _ -> acc)
+    0 events
+
+let count_detached_actors events =
+  List.fold_left
+    (fun acc json ->
+      match event_type json with
+      | Some "session_agent_detached" -> acc + 1
+      | _ -> acc)
+    0 events
+
+let empty_note_turn_actors events =
+  events
+  |> List.filter_map (fun json ->
+         match (event_type json, event_detail_kind json, event_detail_actor json) with
+         | Some "team_turn", Some "note", Some actor -> (
+             match event_detail_message json with None -> Some actor | Some _ -> None)
+         | _ -> None)
+  |> Team_session_types.dedup_strings
+
+let turn_count_by_actor events actor_name =
+  List.fold_left
+    (fun acc json ->
+      match (event_type json, event_detail_actor json) with
+      | Some "team_turn", Some actor when String.equal actor actor_name -> acc + 1
+      | _ -> acc)
+    0 events
+
+let empty_note_turn_count_for_actor events actor_name =
+  List.fold_left
+    (fun acc json ->
+      match (event_type json, event_detail_kind json, event_detail_actor json) with
+      | Some "team_turn", Some "note", Some actor when String.equal actor actor_name -> (
+          match event_detail_message json with None -> acc + 1 | Some _ -> acc)
+      | _ -> acc)
+    0 events
+
+let last_turn_ts_iso_for_actor events actor_name =
+  events
+  |> List.filter_map (fun json ->
+         match (event_type json, event_detail_actor json) with
+         | Some "team_turn", Some actor when String.equal actor actor_name ->
+             event_ts_iso json
+         | _ -> None)
+  |> List.rev |> function value :: _ -> Some value | [] -> None
+
+let normalize_digest_target_type value =
+  match value with
+  | Some raw -> (
+      match String.trim raw |> String.lowercase_ascii with
+      | "room" -> Ok "room"
+      | "team_session" -> Ok "team_session"
+      | _ -> Error "target_type must be one of: room, team_session")
+  | None -> Ok "room"
+
+let build_worker_cards ~(session : Team_session_types.session) ~(events : Yojson.Safe.t list)
+    ~now =
+  let worker_keys =
+    if session.planned_workers <> [] then
+      session.planned_workers
+      |> List.map (fun (worker : Team_session_types.planned_worker) ->
+             ( worker.runtime_actor,
+               Some worker.spawn_agent,
+               worker.spawn_role,
+               worker.spawn_model ))
+    else
+      session.agent_names
+      |> List.map (fun actor -> (Some actor, None, None, None))
+  in
+  worker_keys
+  |> List.map (fun (actor, spawn_agent, spawn_role, spawn_model) ->
+         let turn_count =
+           match actor with
+           | Some value -> turn_count_by_actor events value
+           | None -> 0
+         in
+         let empty_note_turn_count =
+           match actor with
+           | Some value -> empty_note_turn_count_for_actor events value
+           | None -> 0
+         in
+         let has_turn = turn_count > 0 in
+         let last_turn_ts_iso =
+           match actor with
+           | Some value -> last_turn_ts_iso_for_actor events value
+           | None -> None
+        in
+        let status =
+          match actor with
+          | Some _ ->
+              let age_sec = now -. session.started_at in
+              if has_turn then "active"
+               else if age_sec >= planned_worker_turn_grace_sec then "planned_no_turn"
+               else "grace_period"
+           | None -> "planned"
+         in
+         {
+           actor;
+           spawn_agent;
+           spawn_role;
+           spawn_model;
+           status;
+           turn_count;
+           empty_note_turn_count;
+           has_turn;
+           last_turn_ts_iso;
+         })
+  |> List.sort compare_worker_card
+
+let session_attention_items ~(session : Team_session_types.session)
+    ~(events : Yojson.Safe.t list) ~(worker_cards : worker_card list) ~now =
+  let spawn_failure_count = count_spawn_failures events in
+  let detached_actor_count = count_detached_actors events in
+  let empty_note_actors = empty_note_turn_actors events in
+  let base = [] in
+  let base =
+    if spawn_failure_count > 0 then
+      {
+        kind = "spawn_failure_present";
+        severity = "bad";
+        summary =
+          Printf.sprintf "session has %d failed spawn event(s)" spawn_failure_count;
+        target_type = "team_session";
+        target_id = Some session.session_id;
+        actor = None;
+        evidence = `Assoc [ ("count", `Int spawn_failure_count) ];
+      }
+      :: base
+    else base
+  in
+  let base =
+    if detached_actor_count > 0 then
+      {
+        kind = "detached_actor_present";
+        severity = "warn";
+        summary =
+          Printf.sprintf "session detached %d runtime actor(s)"
+            detached_actor_count;
+        target_type = "team_session";
+        target_id = Some session.session_id;
+        actor = None;
+        evidence = `Assoc [ ("count", `Int detached_actor_count) ];
+      }
+      :: base
+    else base
+  in
+  let base =
+    if empty_note_actors <> [] then
+      {
+        kind = "empty_note_turn_present";
+        severity = "warn";
+        summary = "session contains historical empty note turn evidence";
+        target_type = "team_session";
+        target_id = Some session.session_id;
+        actor = None;
+        evidence =
+          `Assoc
+            [
+              ("count", `Int (List.length empty_note_actors));
+              ("actors", `List (List.map (fun actor -> `String actor) empty_note_actors));
+            ];
+      }
+      :: base
+    else base
+  in
+  let age_since_last_turn =
+    now -. Option.value ~default:session.started_at session.last_turn_at
+  in
+  let base =
+    if session.status = Team_session_types.Running
+       && session.planned_workers <> []
+       && age_since_last_turn >= stalled_session_threshold_sec
+    then
+      {
+        kind = "stalled_session";
+        severity = "bad";
+        summary =
+          Printf.sprintf "session has been idle for %d seconds"
+            (int_of_float age_since_last_turn);
+        target_type = "team_session";
+        target_id = Some session.session_id;
+        actor = None;
+        evidence =
+          `Assoc
+            [
+              ("last_turn_age_sec", `Int (int_of_float age_since_last_turn));
+              ( "last_turn_at",
+                option_to_json (fun value -> `Float value) session.last_turn_at );
+            ];
+      }
+      :: base
+    else base
+  in
+  let no_turn_workers =
+    if session.status = Team_session_types.Running
+       && now -. session.started_at >= planned_worker_turn_grace_sec
+    then
+      worker_cards
+      |> List.filter (fun (card : worker_card) ->
+             String.equal card.status "planned_no_turn"
+             && Option.value ~default:"" card.actor <> "")
+    else []
+  in
+  let base =
+    if no_turn_workers <> [] then
+      {
+        kind = "planned_worker_without_turn";
+        severity = "warn";
+        summary =
+          Printf.sprintf "%d planned worker(s) have not recorded a turn"
+            (List.length no_turn_workers);
+        target_type = "team_session";
+        target_id = Some session.session_id;
+        actor = None;
+        evidence =
+          `Assoc
+            [
+              ( "actors",
+                `List
+                  (List.filter_map
+                     (fun (card : worker_card) ->
+                       Option.map (fun actor -> `String actor) card.actor)
+                     no_turn_workers) );
+            ];
+      }
+      :: base
+    else base
+  in
+  List.sort compare_attention base
+
+let session_recommendations ~(session : Team_session_types.session)
+    ~(attentions : attention_item list) =
+  let suggestions =
+    attentions
+    |> List.filter_map (fun item ->
+           match item.kind with
+           | "spawn_failure_present" ->
+               Some
+                 {
+                   action_type = "team_task_inject";
+                   target_type = "team_session";
+                   target_id = Some session.session_id;
+                   severity = item.severity;
+                   reason = item.summary;
+                   suggested_payload =
+                     `Assoc
+                       [
+                         ("title", `String "Recover failed worker coverage");
+                         ( "description",
+                           `String
+                             "Spawn failure evidence is present. Add explicit recovery work or reassign the missing worker contribution." );
+                         ("priority", `Int 1);
+                       ];
+                 }
+           | "detached_actor_present" ->
+               Some
+                 {
+                   action_type = "team_note";
+                   target_type = "team_session";
+                   target_id = Some session.session_id;
+                   severity = item.severity;
+                   reason = item.summary;
+                   suggested_payload =
+                     `Assoc
+                       [
+                         ( "message",
+                           `String
+                             "[operator] A runtime actor detached. Reassign the missing work and record the replacement explicitly." );
+                       ];
+                 }
+           | "empty_note_turn_present" ->
+               Some
+                 {
+                   action_type = "team_note";
+                   target_type = "team_session";
+                   target_id = Some session.session_id;
+                   severity = item.severity;
+                   reason = item.summary;
+                   suggested_payload =
+                     `Assoc
+                       [
+                         ( "message",
+                           `String
+                             "[operator] Record explicit non-empty contribution notes for each worker turn." );
+                       ];
+                 }
+           | "stalled_session" ->
+               Some
+                 {
+                   action_type = "team_stop";
+                   target_type = "team_session";
+                   target_id = Some session.session_id;
+                   severity = item.severity;
+                   reason = item.summary;
+                   suggested_payload =
+                     `Assoc
+                       [
+                         ("reason", `String "stalled_session_detected");
+                         ("generate_report", `Bool true);
+                       ];
+                 }
+           | "planned_worker_without_turn" ->
+               Some
+                 {
+                   action_type = "team_note";
+                   target_type = "team_session";
+                   target_id = Some session.session_id;
+                   severity = item.severity;
+                   reason = item.summary;
+                   suggested_payload =
+                     `Assoc
+                       [
+                         ( "message",
+                           `String
+                             "[operator] Planned workers have not reported yet. Record a concrete progress note or detach and replace the missing worker." );
+                       ];
+                 }
+           | _ -> None)
+  in
+  dedup_recommendations suggestions
+
+let health_from_attention_items (items : attention_item list) =
+  if
+    List.exists
+      (fun (item : attention_item) -> String.equal item.severity "bad")
+      items
+  then "bad"
+  else if items <> [] then "warn"
+  else "ok"
+
+let normalize_team_health = function
+  | "healthy" -> "ok"
+  | "degraded" -> "warn"
+  | "critical" -> "bad"
+  | other -> other
+
+let build_session_digest config (session : Team_session_types.session) ~now =
+  let status_json = Team_session_engine_eio.session_status_json config session in
+  let summary = U.member "summary" status_json in
+  let team_health = U.member "team_health" status_json in
+  let events = Team_session_store.read_events ~max_events:2000 config session.session_id in
+  let worker_cards = build_worker_cards ~session ~events ~now in
+  let attention_items = session_attention_items ~session ~events ~worker_cards ~now in
+  let recommended_actions =
+    session_recommendations ~session ~attentions:attention_items
+  in
+  let active_agent_count =
+    match U.member "active_agents" summary with
+    | `List xs -> List.length xs
+    | _ -> 0
+  in
+  let last_turn_age_sec =
+    match session.last_turn_at with
+    | Some ts -> Some (max 0 (int_of_float (now -. ts)))
+    | None when session.status = Team_session_types.Running ->
+        Some (max 0 (int_of_float (now -. session.started_at)))
+    | None -> None
+  in
+  {
+    session_id = session.session_id;
+    goal = session.goal;
+    status =
+      (match U.member "session" status_json |> U.member "status" with
+      | `String status -> status
+      | _ -> Team_session_types.status_to_string session.status);
+    health =
+      (let attention_health = health_from_attention_items attention_items in
+       if not (String.equal attention_health "ok") then attention_health
+       else
+         match U.member "status" team_health with
+         | `String status -> normalize_team_health status
+         | _ -> attention_health);
+    planned_worker_count = List.length session.planned_workers;
+    active_agent_count;
+    last_turn_age_sec;
+    attention_items;
+    recommended_actions;
+    worker_cards;
+  }
+
+let build_room_attention_items config =
+  let pending_confirms = read_pending_confirms config in
+  if pending_confirms = [] then []
+  else
+    [
+      {
+        kind = "pending_confirm_waiting";
+        severity = "warn";
+        summary =
+          Printf.sprintf "%d pending confirmation(s) are waiting for operator input"
+            (List.length pending_confirms);
+        target_type = "room";
+        target_id = None;
+        actor = None;
+        evidence = `Assoc [ ("count", `Int (List.length pending_confirms)) ];
+      };
+    ]
+
+let room_recommendations _config = []
+
 type snapshot_view =
   | Summary
   | Sessions
@@ -516,6 +1183,7 @@ let snapshot_json ?actor ?view ?(include_messages = true) ?(include_sessions = t
   let config = ctx.config in
   let initialized = Room.is_initialized config in
   let trace_id = trace_id "ops" in
+  let actor_name = normalized_actor ~context_actor:ctx.agent_name actor in
   let view = parse_snapshot_view view in
   let include_sessions =
     include_sessions
@@ -538,23 +1206,143 @@ let snapshot_json ?actor ?view ?(include_messages = true) ?(include_sessions = t
     | Summary | Messages | Full -> true
     | Sessions | Keepers -> false
   in
+  let summary_fields =
+    if initialized && (match view with Summary | Full -> true | _ -> false) then
+      let now = Time_compat.now () in
+      let session_digests =
+        Team_session_store.list_sessions config
+        |> List.map (fun session -> build_session_digest config session ~now)
+      in
+      let room_attention =
+        build_room_attention_items config
+        @ (session_digests |> List.concat_map (fun digest -> digest.attention_items))
+        |> List.sort compare_attention
+      in
+      let room_recommendation_items =
+        room_recommendations config
+        @ (session_digests |> List.concat_map (fun digest -> digest.recommended_actions))
+      in
+      [
+        ("attention_summary", summary_of_attention_items room_attention);
+        ( "recommendation_summary",
+          summary_of_recommendations ~actor:actor_name room_recommendation_items );
+      ]
+    else []
+  in
   `Assoc
-    [
-      ("trace_id", `String trace_id);
-      ("server_profile", operator_server_profile_json);
-      ("room", room_json config);
-      ( "sessions",
-        if initialized && include_sessions then sessions_json config
-        else `Assoc [ ("count", `Int 0); ("items", `List []) ] );
-      ( "keepers",
-        if initialized && include_keepers then keepers_json config
-        else `Assoc [ ("count", `Int 0); ("items", `List []) ] );
-      ("command_plane", if initialized then Command_plane_v2.snapshot_json config else `Assoc []);
-      ("recent_messages", if initialized && include_messages then recent_messages_json config else `List []);
-      ("pending_confirms", pending_confirms_json ?actor config);
-      ("available_actions", available_actions_json);
-      ("recent_actions", recent_actions_json config);
-    ]
+    ([
+       ("trace_id", `String trace_id);
+       ("server_profile", operator_server_profile_json);
+       ("room", room_json config);
+       ( "sessions",
+         if initialized && include_sessions then sessions_json config
+         else `Assoc [ ("count", `Int 0); ("items", `List []) ] );
+       ( "keepers",
+         if initialized && include_keepers then keepers_json config
+         else `Assoc [ ("count", `Int 0); ("items", `List []) ] );
+       ("command_plane", if initialized then Command_plane_v2.snapshot_json config else `Assoc []);
+       ("recent_messages", if initialized && include_messages then recent_messages_json config else `List []);
+       ("pending_confirms", pending_confirms_json ?actor config);
+       ("available_actions", available_actions_json);
+       ("recent_actions", recent_actions_json config);
+     ]
+    @ summary_fields)
+
+let digest_json ?actor ?target_type ?target_id ?include_workers (ctx : 'a context) :
+    (Yojson.Safe.t, string) result =
+  let config = ctx.config in
+  if not (Room.is_initialized config) then
+    Ok
+      (`Assoc
+        [
+          ("trace_id", `String (trace_id "opsd"));
+          ("target_type", `String "room");
+          ("target_id", `Null);
+          ("health", `String "ok");
+          ("attention_items", `List []);
+          ("recommended_actions", `List []);
+          ("session_cards", `List []);
+          ("worker_cards", `List []);
+        ])
+  else
+    let actor_name = normalized_actor ~context_actor:ctx.agent_name actor in
+    let* target_type = normalize_digest_target_type target_type in
+    let now = Time_compat.now () in
+    match target_type with
+    | "room" ->
+        let sessions =
+          Team_session_store.list_sessions config
+          |> List.map (fun session -> build_session_digest config session ~now)
+          |> List.sort compare_session_digest
+        in
+        let limited_sessions =
+          sessions |> List.to_seq |> Seq.take room_digest_session_limit |> List.of_seq
+        in
+        let attention_items =
+          build_room_attention_items config
+          @ (limited_sessions |> List.concat_map (fun digest -> digest.attention_items))
+          |> List.sort compare_attention
+        in
+        let recommended_actions =
+          dedup_recommendations
+            (room_recommendations config
+            @ (limited_sessions
+              |> List.concat_map (fun digest -> digest.recommended_actions)))
+        in
+        Ok
+          (`Assoc
+            [
+              ("trace_id", `String (trace_id "opsd"));
+              ("target_type", `String "room");
+              ("target_id", `Null);
+              ("health", `String (health_from_attention_items attention_items));
+              ("attention_items", `List (List.map attention_item_to_yojson attention_items));
+              ( "recommended_actions",
+                `List
+                  (List.map (recommended_action_to_yojson ~actor:actor_name)
+                     recommended_actions) );
+              ( "session_cards",
+                `List
+                  (List.map (session_card_to_yojson ~actor:actor_name) limited_sessions)
+              );
+              ("worker_cards", `List []);
+            ])
+    | "team_session" -> (
+        match target_id with
+        | None -> Error "target_id is required when target_type=team_session"
+        | Some session_id -> (
+            match Team_session_store.load_session config session_id with
+            | None ->
+                Error (Printf.sprintf "team session not found: %s" session_id)
+            | Some session ->
+                let digest = build_session_digest config session ~now in
+                let worker_cards =
+                  let should_include =
+                    match include_workers with
+                    | Some value -> value
+                    | None -> true
+                  in
+                  if should_include then digest.worker_cards else []
+                in
+                Ok
+                  (`Assoc
+                    [
+                      ("trace_id", `String (trace_id "opsd"));
+                      ("target_type", `String "team_session");
+                      ("target_id", `String session_id);
+                      ("health", `String digest.health);
+                      ( "attention_items",
+                        `List
+                          (List.map attention_item_to_yojson digest.attention_items)
+                      );
+                      ( "recommended_actions",
+                        `List
+                          (List.map (recommended_action_to_yojson ~actor:actor_name)
+                             digest.recommended_actions) );
+                      ("session_cards", `List [ session_card_to_yojson ~actor:actor_name digest ]);
+                      ("worker_cards", `List (List.map worker_card_to_yojson worker_cards));
+                    ])))
+    | _ -> Error "unsupported target_type"
 
 type action_request = {
   actor : string;

--- a/lib/operator_control.mli
+++ b/lib/operator_control.mli
@@ -15,6 +15,14 @@ val snapshot_json :
   'a context ->
   Yojson.Safe.t
 
+val digest_json :
+  ?actor:string ->
+  ?target_type:string ->
+  ?target_id:string ->
+  ?include_workers:bool ->
+  'a context ->
+  (Yojson.Safe.t, string) result
+
 val action_json :
   ?actor_hint:string ->
   'a context ->

--- a/lib/tool_operator.ml
+++ b/lib/tool_operator.ml
@@ -69,6 +69,36 @@ let snapshot_schema ~remote =
         ];
   }
 
+let digest_target_type_enums = [ `String "room"; `String "team_session" ]
+
+let digest_schema ~remote =
+  {
+    name = "masc_operator_digest";
+    description =
+      if remote then
+        "Read an intervention-oriented operator digest. Use this when you need health, attention items, worker summaries, and recommended next actions before deciding how to intervene."
+      else
+        "Read a high-signal operator digest with intervention recommendations for the room or a specific team session. Use this when raw snapshot data is too low-level for fast supervision.";
+    input_schema =
+      `Assoc
+        [
+          ("type", `String "object");
+          ( "properties",
+            schema_properties
+              [
+                ("actor", `Assoc [ ("type", `String "string") ]);
+                ( "target_type",
+                  `Assoc
+                    [
+                      ("type", `String "string");
+                      ("enum", `List digest_target_type_enums);
+                    ] );
+                ("target_id", `Assoc [ ("type", `String "string") ]);
+                ("include_workers", `Assoc [ ("type", `String "boolean") ]);
+              ] );
+        ];
+  }
+
 let action_schema ~remote =
   let enum_values =
     if remote then strict_action_enums else strict_action_enums @ legacy_action_alias_enums
@@ -152,6 +182,15 @@ let dispatch (ctx : 'a context) ~name ~args : result option =
           Yojson.Safe.to_string
             (Operator_control.snapshot_json ?actor ?view ~include_messages ~include_sessions
                ~include_keepers control_ctx) )
+  | "masc_operator_digest" ->
+      let actor = get_string_opt args "actor" in
+      let target_type = get_string_opt args "target_type" in
+      let target_id = get_string_opt args "target_id" in
+      let include_workers = get_bool args "include_workers" true in
+      Some
+        (json_string_of_result
+           (Operator_control.digest_json ?actor ?target_type ?target_id
+              ~include_workers control_ctx))
   | "masc_operator_action" ->
       Some (json_string_of_result (Operator_control.action_json control_ctx args))
   | "masc_operator_confirm" ->
@@ -159,10 +198,20 @@ let dispatch (ctx : 'a context) ~name ~args : result option =
   | _ -> None
 
 let schemas : tool_schema list =
-  [ snapshot_schema ~remote:false; action_schema ~remote:false; confirm_schema ]
+  [
+    snapshot_schema ~remote:false;
+    digest_schema ~remote:false;
+    action_schema ~remote:false;
+    confirm_schema;
+  ]
 
 let remote_schemas : tool_schema list =
-  [ snapshot_schema ~remote:true; action_schema ~remote:true; confirm_schema ]
+  [
+    snapshot_schema ~remote:true;
+    digest_schema ~remote:true;
+    action_schema ~remote:true;
+    confirm_schema;
+  ]
 
 let remote_tool_names : string list =
   List.map (fun (schema : tool_schema) -> schema.name) remote_schemas

--- a/scripts/harness/workload/supervisor_team_session.sh
+++ b/scripts/harness/workload/supervisor_team_session.sh
@@ -320,16 +320,21 @@ printf '[7/10] inspect remote operator surface\n'
 tools_raw="$(jsonrpc_call "$OPERATOR_URL" "$SUPERVISOR_OP_SESSION_ID" "$SUPERVISOR_TOKEN" 4 "tools/list" '{}')"
 require_success_response "$tools_raw"
 tool_count="$(printf '%s' "$tools_raw" | jq -r '.result.tools | length')"
-if [ "$tool_count" -ne 3 ]; then
-  echo "FAIL: expected 3 operator tools, got $tool_count"
+if [ "$tool_count" -ne 4 ]; then
+  echo "FAIL: expected 4 operator tools, got $tool_count"
   printf '%s\n' "$tools_raw"
   exit 1
 fi
-printf '%s' "$tools_raw" | jq -e '.result.tools | map(.name) | sort == ["masc_operator_action","masc_operator_confirm","masc_operator_snapshot"]' >/dev/null
+printf '%s' "$tools_raw" | jq -e '.result.tools | map(.name) | sort == ["masc_operator_action","masc_operator_confirm","masc_operator_digest","masc_operator_snapshot"]' >/dev/null
 
 snapshot_raw="$(call_tool "$OPERATOR_URL" "$SUPERVISOR_OP_SESSION_ID" "$SUPERVISOR_TOKEN" 5 "masc_operator_snapshot" "$(jq -cn --arg actor "$SUPERVISOR_NICKNAME" '{actor:$actor,view:"full"}')")"
 require_tool_success "$snapshot_raw"
 printf '%s' "$snapshot_raw" | extract_tool_result | jq -e '.sessions.items | length >= 1' >/dev/null
+printf '%s' "$snapshot_raw" | extract_tool_result | jq -e '.attention_summary.count >= 0 and .recommendation_summary.count >= 0' >/dev/null
+
+digest_raw="$(call_tool "$OPERATOR_URL" "$SUPERVISOR_OP_SESSION_ID" "$SUPERVISOR_TOKEN" 55 "masc_operator_digest" "$(jq -cn --arg actor "$SUPERVISOR_NICKNAME" --arg s "$TEAM_SESSION_ID" '{actor:$actor,target_type:"team_session",target_id:$s}')")"
+require_tool_success "$digest_raw"
+printf '%s' "$digest_raw" | extract_tool_result | jq -e '.target_type == "team_session" and .target_id == $session and (.health | type == "string") and (.attention_items | type == "array") and (.recommended_actions | type == "array")' --arg session "$TEAM_SESSION_ID" >/dev/null
 
 printf '[8/10] supervisor immediate correction via team_note\n'
 team_note_raw="$(call_tool "$OPERATOR_URL" "$SUPERVISOR_OP_SESSION_ID" "$SUPERVISOR_TOKEN" 6 "masc_operator_action" "$(jq -cn --arg actor "$SUPERVISOR_NICKNAME" --arg s "$TEAM_SESSION_ID" '{actor:$actor,action_type:"team_note",target_id:$s,payload:{message:"[supervisor] keep the proof focused on the MCP loop"}}')")"

--- a/scripts/harness/workload/team_session_failed_batch_spawn.sh
+++ b/scripts/harness/workload/team_session_failed_batch_spawn.sh
@@ -7,6 +7,7 @@ PORT="${PORT:-}"
 BASE_PATH="${BASE_PATH:-}"
 LOG_FILE="${LOG_FILE:-}"
 MCP_URL=""
+OPERATOR_URL=""
 TEAM_SESSION_ID=""
 SUPERVISOR_SESSION_ID="failed-spawn-replay"
 SUPERVISOR_AGENT="failure-replay-supervisor"
@@ -76,6 +77,7 @@ else
 fi
 
 MCP_URL="http://127.0.0.1:${PORT}/mcp"
+OPERATOR_URL="http://127.0.0.1:${PORT}/mcp/operator"
 SERVER_PID=""
 
 read_file() {
@@ -88,10 +90,11 @@ jsonrpc_call() {
   local id="$3"
   local method="$4"
   local params="$5"
+  local endpoint="${6:-$MCP_URL}"
   local body_file
   body_file="$(mktemp "${TMPDIR:-/tmp}/masc-jsonrpc-body.XXXXXX.json")"
   printf '{"jsonrpc":"2.0","id":%s,"method":"%s","params":%s}' "$id" "$method" "$params" >"$body_file"
-  local cmd=(curl -sS --http1.1 --max-time "$HTTP_TIMEOUT_SEC" -X POST "$MCP_URL" \
+  local cmd=(curl -sS --http1.1 --max-time "$HTTP_TIMEOUT_SEC" -X POST "$endpoint" \
     -H 'Content-Type: application/json' \
     -H 'Accept: application/json, text/event-stream' \
     -H "Mcp-Session-Id: $session_id" \
@@ -133,7 +136,8 @@ call_tool() {
   local id="$3"
   local tool_name="$4"
   local args_json="$5"
-  jsonrpc_call "$session_id" "$token" "$id" "tools/call" "{\"name\":\"$tool_name\",\"arguments\":$args_json}"
+  local endpoint="${6:-$MCP_URL}"
+  jsonrpc_call "$session_id" "$token" "$id" "tools/call" "{\"name\":\"$tool_name\",\"arguments\":$args_json}" "$endpoint"
 }
 
 extract_tool_text() {
@@ -304,7 +308,7 @@ if [ "$server_started" != "true" ]; then
   exit 1
 fi
 
-printf '[2/8] bootstrap room and auth\n'
+printf '[2/9] bootstrap room and auth\n'
 init_raw="$(call_tool "$SUPERVISOR_SESSION_ID" "" 1 "masc_init" "$(jq -cn --arg a "$SUPERVISOR_AGENT" '{agent_name:$a}')")"
 require_tool_success "$init_raw"
 switch_mode_raw="$(call_tool "$SUPERVISOR_SESSION_ID" "" 2 "masc_switch_mode" '{"mode":"full"}')"
@@ -316,7 +320,7 @@ enable_auth_raw="$(call_tool "$SUPERVISOR_SESSION_ID" "" 12 "masc_auth_enable" '
 require_tool_success "$enable_auth_raw"
 join_with_token "$SUPERVISOR_SESSION_ID" "$SUPERVISOR_TOKEN" "$SUPERVISOR_NICKNAME" '["supervisor","failure-replay"]'
 
-printf '[3/8] start team session\n'
+printf '[3/9] start team session\n'
 start_payload="$(jq -cn \
   --arg goal "$TEAM_GOAL" \
   --arg supervisor "$SUPERVISOR_NICKNAME" \
@@ -334,7 +338,7 @@ FAILURE_NOTE="[failure-replay] explicit model=${LLAMA_SWARM_MODEL}; llama endpoi
 note_raw="$(call_tool "$SUPERVISOR_SESSION_ID" "$SUPERVISOR_TOKEN" 4 "masc_team_session_turn" "$(jq -cn --arg s "$TEAM_SESSION_ID" --arg msg "$FAILURE_NOTE" '{session_id:$s,turn_kind:"note",message:$msg}')")"
 require_tool_success "$note_raw"
 
-printf '[4/8] replay deterministic failed batch spawn\n'
+printf '[4/9] replay deterministic failed batch spawn\n'
 spawn_batch_raw="$(call_tool "$SUPERVISOR_SESSION_ID" "$SUPERVISOR_TOKEN" 5 "masc_team_session_step" "$(jq -cn \
   --arg s "$TEAM_SESSION_ID" \
   --arg model "$LLAMA_SWARM_MODEL" \
@@ -351,7 +355,7 @@ require_json_condition "$spawn_result" '.spawn.results | all(.runtime_actor != n
 FAILED_RUNTIME_ACTOR_1="$(printf '%s' "$spawn_result" | jq -r '.spawn.results[0].runtime_actor')"
 FAILED_RUNTIME_ACTOR_2="$(printf '%s' "$spawn_result" | jq -r '.spawn.results[1].runtime_actor')"
 
-printf '[5/8] verify detach + participant accounting\n'
+printf '[5/9] verify detach + participant accounting\n'
 spawn_events_raw="$(call_tool "$SUPERVISOR_SESSION_ID" "$SUPERVISOR_TOKEN" 6 "masc_team_session_events" "$(jq -cn --arg s "$TEAM_SESSION_ID" '{session_id:$s,event_types:["team_step_spawn"],limit:100}')")"
 require_tool_success "$spawn_events_raw"
 spawn_events_result="$(printf '%s' "$spawn_events_raw" | extract_tool_result)"
@@ -372,7 +376,15 @@ require_json_condition "$status_result" '.summary.planned_workers | length == 2'
 replay_note_raw="$(call_tool "$SUPERVISOR_SESSION_ID" "$SUPERVISOR_TOKEN" 9 "masc_team_session_turn" "$(jq -cn --arg s "$TEAM_SESSION_ID" --arg msg "[failure-replay] observed 2 failed spawns and 2 detached actors" '{session_id:$s,turn_kind:"note",message:$msg}')")"
 require_tool_success "$replay_note_raw"
 
-printf '[6/8] stop session and generate artifacts\n'
+printf '[6/9] verify operator digest signals\n'
+digest_raw="$(call_tool "$SUPERVISOR_SESSION_ID" "$SUPERVISOR_TOKEN" 92 "masc_operator_digest" "$(jq -cn --arg actor "$SUPERVISOR_NICKNAME" --arg s "$TEAM_SESSION_ID" '{actor:$actor,target_type:"team_session",target_id:$s}')")"
+require_tool_success "$digest_raw"
+digest_result="$(printf '%s' "$digest_raw" | extract_tool_result)"
+require_json_condition "$digest_result" '.target_type == "team_session"' "digest target_type mismatch"
+require_json_condition "$digest_result" '[.attention_items[]?.kind] | index("spawn_failure_present") != null' "digest missing spawn_failure_present"
+require_json_condition "$digest_result" '[.attention_items[]?.kind] | index("detached_actor_present") != null' "digest missing detached_actor_present"
+
+printf '[7/9] stop session and generate artifacts\n'
 stop_raw="$(call_tool "$SUPERVISOR_SESSION_ID" "$SUPERVISOR_TOKEN" 10 "masc_team_session_stop" "$(jq -cn --arg s "$TEAM_SESSION_ID" '{session_id:$s,reason:"failed_batch_spawn_replay_complete",generate_report:true}')")"
 require_tool_success "$stop_raw"
 
@@ -415,7 +427,7 @@ require_json_condition "$prove_result" '.proof.evidence.detached_actor_roster | 
 proof_md_path="$(printf '%s' "$prove_result" | jq -r '.proof_md_path')"
 proof_json_path="$(printf '%s' "$prove_result" | jq -r '.proof_json_path')"
 
-printf '[7/8] verify report/proof text\n'
+printf '[8/9] verify report/proof text\n'
 if ! jq -e '.summary.active_agents | length == 1' "$report_json_path" >/dev/null; then
   echo "FAIL: report json active_agents accounting is wrong"
   cat "$report_json_path"
@@ -472,7 +484,7 @@ if ! rg -q "$FAILED_RUNTIME_ACTOR_2" "$report_md_path"; then
   exit 1
 fi
 
-printf '[8/8] summary\n'
+printf '[9/9] summary\n'
 printf 'session_id=%s\n' "$TEAM_SESSION_ID"
 printf 'llama_swarm_model=%s\n' "$LLAMA_SWARM_MODEL"
 printf 'fail_llama_server_url=%s\n' "$FAIL_LLAMA_SERVER_URL"

--- a/test/test_auth_coverage.ml
+++ b/test/test_auth_coverage.ml
@@ -250,6 +250,11 @@ let test_permission_for_tool_operator_snapshot () =
   | Some Types.CanReadState -> ()
   | _ -> fail "expected CanReadState"
 
+let test_permission_for_tool_operator_digest () =
+  match Auth.permission_for_tool "masc_operator_digest" with
+  | Some Types.CanReadState -> ()
+  | _ -> fail "expected CanReadState"
+
 let test_permission_for_tool_operator_action () =
   match Auth.permission_for_tool "masc_operator_action" with
   | Some Types.CanBroadcast -> ()
@@ -331,6 +336,7 @@ let () =
       test_case "auth_status" `Quick test_permission_for_tool_auth_status;
       test_case "llama_models" `Quick test_permission_for_tool_llama_models;
       test_case "operator_snapshot" `Quick test_permission_for_tool_operator_snapshot;
+      test_case "operator_digest" `Quick test_permission_for_tool_operator_digest;
       test_case "operator_action" `Quick test_permission_for_tool_operator_action;
       test_case "operator_confirm" `Quick test_permission_for_tool_operator_confirm;
       test_case "unknown" `Quick test_permission_for_tool_unknown;

--- a/test/test_mcp_server_eio.ml
+++ b/test/test_mcp_server_eio.ml
@@ -290,7 +290,7 @@ let test_handle_request_initialize_operator_profile () =
               | _ -> ""
             in
             Alcotest.(check bool) "mentions operator profile" true
-              (contains_substring instructions "three control-plane tools");
+              (contains_substring instructions "four control-plane tools");
             Alcotest.(check bool) "mentions confirm workflow" true
               (contains_substring instructions "confirm_required=true")
         | _ -> Alcotest.fail "result not an object")
@@ -326,7 +326,12 @@ let test_handle_request_tools_list_operator_profile () =
                    |> List.filter_map (function `String s -> Some s | _ -> None)
                  in
                  Alcotest.(check (list string)) "operator-only tools"
-                   [ "masc_operator_snapshot"; "masc_operator_action"; "masc_operator_confirm" ]
+                   [
+                     "masc_operator_snapshot";
+                     "masc_operator_digest";
+                     "masc_operator_action";
+                     "masc_operator_confirm";
+                   ]
                    names;
                  let find_tool name =
                    List.find_map
@@ -348,10 +353,19 @@ let test_handle_request_tools_list_operator_profile () =
                    | Some tool -> tool
                    | None -> Alcotest.fail "action tool missing"
                  in
+                 let digest_tool =
+                   match find_tool "masc_operator_digest" with
+                   | Some tool -> tool
+                   | None -> Alcotest.fail "digest tool missing"
+                 in
                  Alcotest.(check bool) "snapshot has annotations" true
                    (Yojson.Safe.Util.member "annotations" snapshot_tool <> `Null);
                  Alcotest.(check bool) "snapshot readonly hint" true
                    (snapshot_tool |> Yojson.Safe.Util.member "annotations"
+                    |> Yojson.Safe.Util.member "readOnlyHint"
+                    |> Yojson.Safe.Util.to_bool);
+                 Alcotest.(check bool) "digest readonly hint" true
+                   (digest_tool |> Yojson.Safe.Util.member "annotations"
                     |> Yojson.Safe.Util.member "readOnlyHint"
                     |> Yojson.Safe.Util.to_bool);
                  Alcotest.(check bool) "action readonly hint" false

--- a/test/test_mode_coverage.ml
+++ b/test/test_mode_coverage.ml
@@ -168,6 +168,8 @@ let test_tool_category_core () =
     (Mode.tool_category "masc_team_session_events" = Mode.Core);
   check bool "operator_snapshot" true
     (Mode.tool_category "masc_operator_snapshot" = Mode.Core);
+  check bool "operator_digest" true
+    (Mode.tool_category "masc_operator_digest" = Mode.Core);
   check bool "llama_models" true
     (Mode.tool_category "masc_llama_models" = Mode.Core);
   check bool "operator_action" true

--- a/test/test_operator_control.ml
+++ b/test/test_operator_control.ml
@@ -88,8 +88,87 @@ let test_snapshot_has_expected_sections () =
         "operator_remote_v1"
         (json |> Yojson.Safe.Util.member "server_profile"
          |> Yojson.Safe.Util.member "name" |> Yojson.Safe.Util.to_string);
+      Alcotest.(check bool) "attention summary present" true
+        (Yojson.Safe.Util.member "attention_summary" json <> `Null);
+      Alcotest.(check bool) "recommendation summary present" true
+        (Yojson.Safe.Util.member "recommendation_summary" json <> `Null);
       Alcotest.(check bool) "recent_actions list present" true
         (match Yojson.Safe.Util.member "recent_actions" json with
+         | `List _ -> true
+         | _ -> false))
+
+let test_digest_room_exposes_pending_confirm_attention () =
+  Eio_main.run @@ fun env ->
+  Eio.Switch.run @@ fun sw ->
+  let base_dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base_dir)
+    (fun () ->
+      let config = Room.default_config base_dir in
+      ignore (Room.init config ~agent_name:(Some "operator"));
+      let ctx = operator_ctx env sw config "operator" in
+      let action_json =
+        Operator_control.action_json ctx
+          (`Assoc
+            [
+              ("actor", `String "operator");
+              ("action_type", `String "task_inject");
+              ("target_type", `String "room");
+              ( "payload",
+                `Assoc
+                  [
+                    ("title", `String "Injected task");
+                    ("description", `String "created by operator");
+                    ("priority", `Int 1);
+                  ] );
+            ])
+      in
+      (match action_json with Ok _ -> () | Error err -> Alcotest.fail err);
+      let digest =
+        match Operator_control.digest_json ~actor:"operator" ctx with
+        | Ok json -> json
+        | Error err -> Alcotest.fail err
+      in
+      Alcotest.(check string) "target_type" "room"
+        Yojson.Safe.Util.(digest |> member "target_type" |> to_string);
+      Alcotest.(check string) "health" "warn"
+        Yojson.Safe.Util.(digest |> member "health" |> to_string);
+      let attention_items = Yojson.Safe.Util.(digest |> member "attention_items" |> to_list) in
+      Alcotest.(check bool) "pending confirm attention present" true
+        (List.exists
+           (fun item ->
+             Yojson.Safe.Util.(item |> member "kind" |> to_string)
+             = "pending_confirm_waiting")
+           attention_items))
+
+let test_digest_team_session_shape () =
+  Eio_main.run @@ fun env ->
+  Eio.Switch.run @@ fun sw ->
+  let base_dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base_dir)
+    (fun () ->
+      let config = Room.default_config base_dir in
+      ignore (Room.init config ~agent_name:(Some "owner"));
+      ignore (Room.join config ~agent_name:"owner" ~capabilities:[] ());
+      let session_id = start_session_exn (team_ctx env sw config "owner") in
+      let ctx = operator_ctx env sw config "dashboard" in
+      let digest =
+        match
+          Operator_control.digest_json ~actor:"dashboard"
+            ~target_type:"team_session" ~target_id:session_id ctx
+        with
+        | Ok json -> json
+        | Error err -> Alcotest.fail err
+      in
+      Alcotest.(check string) "target_type" "team_session"
+        Yojson.Safe.Util.(digest |> member "target_type" |> to_string);
+      Alcotest.(check string) "target_id" session_id
+        Yojson.Safe.Util.(digest |> member "target_id" |> to_string);
+      Alcotest.(check int) "single session card" 1
+        Yojson.Safe.Util.(digest |> member "session_cards" |> to_list |> List.length);
+      Alcotest.(check bool) "worker_cards list" true
+        (match Yojson.Safe.Util.member "worker_cards" digest with
          | `List _ -> true
          | _ -> false))
 
@@ -530,6 +609,10 @@ let () =
         [
           Alcotest.test_case "snapshot sections" `Quick
             test_snapshot_has_expected_sections;
+          Alcotest.test_case "digest room pending confirm attention" `Quick
+            test_digest_room_exposes_pending_confirm_attention;
+          Alcotest.test_case "digest team session shape" `Quick
+            test_digest_team_session_shape;
           Alcotest.test_case "task inject confirm flow" `Quick
             test_task_inject_requires_confirm_then_executes;
           Alcotest.test_case "team turn fallback actor" `Quick

--- a/test/test_operator_mcp_e2e.ml
+++ b/test/test_operator_mcp_e2e.ml
@@ -575,7 +575,12 @@ let test_operator_mcp_supervises_team_session () =
     |> List.sort String.compare
   in
   check (list string) "operator tool names"
-    [ "masc_operator_action"; "masc_operator_confirm"; "masc_operator_snapshot" ]
+    [
+      "masc_operator_action";
+      "masc_operator_confirm";
+      "masc_operator_digest";
+      "masc_operator_snapshot";
+    ]
     tool_names;
 
   let snapshot_json =
@@ -587,6 +592,30 @@ let test_operator_mcp_supervises_team_session () =
   check bool "snapshot has sessions" true
     (snapshot_result |> U.member "sessions" |> U.member "items" |> U.to_list
    |> List.length > 0);
+  check bool "snapshot summary has attention summary" true
+    (snapshot_result |> U.member "attention_summary" <> `Null);
+  check bool "snapshot summary has recommendation summary" true
+    (snapshot_result |> U.member "recommendation_summary" <> `Null);
+
+  let digest_json =
+    call_tool ~token:supervisor_token ~path:"/mcp/operator"
+      ~session_id:"operator-supervisor" ~id:105 ~name:"masc_operator_digest"
+      (`Assoc
+        [
+          ("actor", `String supervisor_nickname);
+          ("target_type", `String "team_session");
+          ("target_id", `String session_id);
+        ])
+  in
+  let digest_result = extract_tool_payload_json "operator_digest" digest_json in
+  check string "digest target type" "team_session"
+    (digest_result |> U.member "target_type" |> U.to_string);
+  check string "digest target id" session_id
+    (digest_result |> U.member "target_id" |> U.to_string);
+  check bool "digest attention array" true
+    (match digest_result |> U.member "attention_items" with `List _ -> true | _ -> false);
+  check bool "digest recommendation array" true
+    (match digest_result |> U.member "recommended_actions" with `List _ -> true | _ -> false);
 
   let note_json =
     call_tool ~token:supervisor_token ~path:"/mcp/operator"

--- a/test/test_tools_coverage.ml
+++ b/test/test_tools_coverage.ml
@@ -83,7 +83,7 @@ let test_find_tool_existing () =
                "masc_team_session_list"; "masc_team_session_compare";
                "masc_team_session_turn"; "masc_team_session_events";
                "masc_team_session_prove"; "masc_llama_models";
-               "masc_operator_snapshot";
+               "masc_operator_snapshot"; "masc_operator_digest";
                "masc_operator_action"; "masc_operator_confirm"] in
   List.iter (fun name ->
     match find_tool name with
@@ -235,6 +235,24 @@ let test_masc_operator_snapshot_schema () =
           Alcotest.(check bool) "has include_sessions" true
             (List.mem_assoc "include_sessions" props)
       | None -> Alcotest.fail "masc_operator_snapshot missing properties"
+
+let test_masc_operator_digest_schema () =
+  match find_tool "masc_operator_digest" with
+  | None -> Alcotest.fail "masc_operator_digest not found"
+  | Some schema ->
+      Alcotest.(check bool) "use-this description" true
+        (String.length schema.description > 20);
+      match get_json_assoc "properties" schema.input_schema with
+      | Some props ->
+          Alcotest.(check bool) "has actor" true
+            (List.mem_assoc "actor" props);
+          Alcotest.(check bool) "has target_type" true
+            (List.mem_assoc "target_type" props);
+          Alcotest.(check bool) "has target_id" true
+            (List.mem_assoc "target_id" props);
+          Alcotest.(check bool) "has include_workers" true
+            (List.mem_assoc "include_workers" props)
+      | None -> Alcotest.fail "masc_operator_digest missing properties"
 
 let test_masc_operator_action_schema () =
   match find_tool "masc_operator_action" with
@@ -882,6 +900,7 @@ let () =
       Alcotest.test_case "masc_add_task" `Quick test_masc_add_task_schema;
       Alcotest.test_case "masc_done" `Quick test_masc_done_schema;
       Alcotest.test_case "masc_operator_snapshot" `Quick test_masc_operator_snapshot_schema;
+      Alcotest.test_case "masc_operator_digest" `Quick test_masc_operator_digest_schema;
       Alcotest.test_case "masc_operator_action" `Quick test_masc_operator_action_schema;
       Alcotest.test_case "remote_operator_action_strict" `Quick
         test_remote_operator_action_schema_is_strict;


### PR DESCRIPTION
## Summary
- add `masc_operator_digest` as an intervention-oriented operator read tool
- extend `masc_operator_snapshot` with lightweight attention and recommendation summaries
- update remote operator profile, tests, and harnesses for digest-first supervision

## Testing
- dune build --root . @default
- ./_build/default/test/test_tools_coverage.exe
- ./_build/default/test/test_auth_coverage.exe
- ./_build/default/test/test_mode_coverage.exe
- ./_build/default/test/test_mcp_server_eio.exe
- ./_build/default/test/test_operator_control.exe
- ./_build/default/test/test_operator_mcp_e2e.exe
- env LLAMA_SWARM_MODEL=qwen3.5-35b-a3b-ud-q8-xl HTTP_TIMEOUT_SEC=90 ./scripts/harness_supervisor_team_session.sh
- env LLAMA_SWARM_MODEL=qwen3.5-35b-a3b-ud-q8-xl ./scripts/harness_team_session_failed_batch_spawn.sh
