### PR TITLE
ci(opam): pin neo4j_bolt_common in shared setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,15 +29,8 @@ jobs:
 
       - name: Pin external dependencies
         run: |
-          opam pin add mcp_protocol https://github.com/jeong-sik/mcp-protocol-sdk.git#main -n -y
-          # bisect_ppx opam constraints lag newer compilers; keep CI solvable under OCaml 5.4 by pinning.
-          opam pin add bisect_ppx git+https://github.com/patricoferris/bisect_ppx.git#5.2 -n -y
-          opam pin add ocaml-webrtc https://github.com/jeong-sik/ocaml-webrtc.git#main -n -y
-          opam pin add grpc-direct-core https://github.com/jeong-sik/grpc-direct.git#main -n -y
-          opam pin add grpc-direct https://github.com/jeong-sik/grpc-direct.git#main -n -y
-          opam pin add neo4j_packstream https://github.com/jeong-sik/ocaml-neo4j-bolt.git#main -n -y
-          opam pin add neo4j_bolt https://github.com/jeong-sik/ocaml-neo4j-bolt.git#main -n -y
-          opam pin add neo4j_bolt_eio https://github.com/jeong-sik/ocaml-neo4j-bolt.git#main -n -y
+          chmod +x scripts/opam-pin-external-deps.sh
+          scripts/opam-pin-external-deps.sh --with-bisect
 
       - name: Refresh system package index
         run: sudo apt-get update -qq
@@ -101,13 +94,8 @@ jobs:
 
       - name: Pin external dependencies
         run: |
-          opam pin add mcp_protocol https://github.com/jeong-sik/mcp-protocol-sdk.git#main -n -y
-          opam pin add ocaml-webrtc https://github.com/jeong-sik/ocaml-webrtc.git#main -n -y
-          opam pin add grpc-direct-core https://github.com/jeong-sik/grpc-direct.git#main -n -y
-          opam pin add grpc-direct https://github.com/jeong-sik/grpc-direct.git#main -n -y
-          opam pin add neo4j_packstream https://github.com/jeong-sik/ocaml-neo4j-bolt.git#main -n -y
-          opam pin add neo4j_bolt https://github.com/jeong-sik/ocaml-neo4j-bolt.git#main -n -y
-          opam pin add neo4j_bolt_eio https://github.com/jeong-sik/ocaml-neo4j-bolt.git#main -n -y
+          chmod +x scripts/opam-pin-external-deps.sh
+          scripts/opam-pin-external-deps.sh
 
       - name: Refresh system package index
         run: sudo apt-get update -qq
@@ -148,13 +136,8 @@ jobs:
 
       - name: Pin external dependencies
         run: |
-          opam pin add mcp_protocol https://github.com/jeong-sik/mcp-protocol-sdk.git#main -n -y
-          opam pin add ocaml-webrtc https://github.com/jeong-sik/ocaml-webrtc.git#main -n -y
-          opam pin add grpc-direct-core https://github.com/jeong-sik/grpc-direct.git#main -n -y
-          opam pin add grpc-direct https://github.com/jeong-sik/grpc-direct.git#main -n -y
-          opam pin add neo4j_packstream https://github.com/jeong-sik/ocaml-neo4j-bolt.git#main -n -y
-          opam pin add neo4j_bolt https://github.com/jeong-sik/ocaml-neo4j-bolt.git#main -n -y
-          opam pin add neo4j_bolt_eio https://github.com/jeong-sik/ocaml-neo4j-bolt.git#main -n -y
+          chmod +x scripts/opam-pin-external-deps.sh
+          scripts/opam-pin-external-deps.sh
 
       - name: Refresh system package index
         run: sudo apt-get update -qq

--- a/.github/workflows/deploy-railway.yml
+++ b/.github/workflows/deploy-railway.yml
@@ -24,13 +24,8 @@ jobs:
 
       - name: Pin private dependencies
         run: |
-          opam pin add compact-protocol https://github.com/jeong-sik/compact-protocol.git#main -n -y
-          opam pin add mcp_protocol https://github.com/jeong-sik/mcp-protocol-sdk.git#main -n -y
-          opam pin add ocaml-webrtc https://github.com/jeong-sik/ocaml-webrtc.git#main -n -y
-          opam pin add grpc-direct-core https://github.com/jeong-sik/grpc-direct.git#main -n -y
-          opam pin add grpc-direct https://github.com/jeong-sik/grpc-direct.git#main -n -y
-          opam pin add neo4j_packstream https://github.com/jeong-sik/ocaml-neo4j-bolt.git#main -n -y
-          opam pin add neo4j_bolt_eio https://github.com/jeong-sik/ocaml-neo4j-bolt.git#main -n -y
+          chmod +x scripts/opam-pin-external-deps.sh
+          scripts/opam-pin-external-deps.sh --with-compact-protocol
 
       - name: Refresh apt index
         run: sudo apt-get update

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,14 +36,8 @@ jobs:
 
       - name: Pin private dependencies
         run: |
-          opam pin add compact-protocol https://github.com/jeong-sik/compact-protocol.git#main -n -y
-          opam pin add mcp_protocol https://github.com/jeong-sik/mcp-protocol-sdk.git#main -n -y
-          opam pin add ocaml-webrtc https://github.com/jeong-sik/ocaml-webrtc.git#main -n -y
-          opam pin add grpc-direct-core https://github.com/jeong-sik/grpc-direct.git#main -n -y
-          opam pin add grpc-direct https://github.com/jeong-sik/grpc-direct.git#main -n -y
-          opam pin add neo4j_packstream https://github.com/jeong-sik/ocaml-neo4j-bolt.git#main -n -y
-          opam pin add neo4j_bolt https://github.com/jeong-sik/ocaml-neo4j-bolt.git#main -n -y
-          opam pin add neo4j_bolt_eio https://github.com/jeong-sik/ocaml-neo4j-bolt.git#main -n -y
+          chmod +x scripts/opam-pin-external-deps.sh
+          scripts/opam-pin-external-deps.sh --with-compact-protocol
 
       - name: Install libpq (macOS)
         if: runner.os == 'macOS'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,16 +9,20 @@ MASC (Multi-Agent Streaming Coordination) — OCaml 5.x MCP server for AI agent 
 git clone https://github.com/jeong-sik/masc-mcp.git
 cd masc-mcp
 
-# 2. Install OCaml dependencies
+# 2. Pin external OCaml dependencies
+chmod +x scripts/opam-pin-external-deps.sh
+scripts/opam-pin-external-deps.sh
+
+# 3. Install OCaml dependencies
 opam install . --deps-only
 
-# 3. Build
+# 4. Build
 dune build
 
-# 4. Run tests
+# 5. Run tests
 make test
 
-# 5. Start server (HTTP mode)
+# 6. Start server (HTTP mode)
 ./start-masc-mcp.sh --http --port 8935
 ```
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,12 @@ OCaml 5.x + Eio로 만든 개인용 MCP 서버입니다.
 ## 빠른 시작
 
 ```bash
+# external pins for fresh switches / CI parity
+chmod +x scripts/opam-pin-external-deps.sh
+scripts/opam-pin-external-deps.sh
+
 # 빌드
+opam install . --deps-only
 dune build
 
 # 실행

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -13,9 +13,9 @@
 git clone https://github.com/jeong-sik/masc-mcp.git
 cd masc-mcp
 
-# 외부 의존성 pin (opam에 없음)
-opam pin add mcp_protocol https://github.com/jeong-sik/mcp-protocol-sdk.git -y
-opam pin add ocaml-webrtc https://github.com/jeong-sik/ocaml-webrtc.git -y
+# 외부 의존성 pin (fresh switch / CI와 동일)
+chmod +x scripts/opam-pin-external-deps.sh
+scripts/opam-pin-external-deps.sh
 
 # 의존성 설치
 opam install . --deps-only

--- a/scripts/opam-pin-external-deps.sh
+++ b/scripts/opam-pin-external-deps.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+include_bisect=false
+include_compact_protocol=false
+
+for arg in "$@"; do
+  case "$arg" in
+    --with-bisect)
+      include_bisect=true
+      ;;
+    --with-compact-protocol)
+      include_compact_protocol=true
+      ;;
+    *)
+      echo "unknown argument: $arg" >&2
+      exit 2
+      ;;
+  esac
+done
+
+if $include_compact_protocol; then
+  opam pin add compact-protocol https://github.com/jeong-sik/compact-protocol.git#main -n -y
+fi
+
+opam pin add mcp_protocol https://github.com/jeong-sik/mcp-protocol-sdk.git#main -n -y
+opam pin add ocaml-webrtc https://github.com/jeong-sik/ocaml-webrtc.git#main -n -y
+opam pin add grpc-direct-core https://github.com/jeong-sik/grpc-direct.git#main -n -y
+opam pin add grpc-direct https://github.com/jeong-sik/grpc-direct.git#main -n -y
+opam pin add neo4j_packstream https://github.com/jeong-sik/ocaml-neo4j-bolt.git#main -n -y
+opam pin add neo4j_bolt_common https://github.com/jeong-sik/ocaml-neo4j-bolt.git#main -n -y
+opam pin add neo4j_bolt https://github.com/jeong-sik/ocaml-neo4j-bolt.git#main -n -y
+opam pin add neo4j_bolt_eio https://github.com/jeong-sik/ocaml-neo4j-bolt.git#main -n -y
+
+if $include_bisect; then
+  # bisect_ppx opam constraints lag newer compilers; keep CI solvable under OCaml 5.4 by pinning.
+  opam pin add bisect_ppx git+https://github.com/patricoferris/bisect_ppx.git#5.2 -n -y
+fi


### PR DESCRIPTION
## Summary
- add a shared opam pin script for external dependencies used by CI and release workflows
- include the newly split `neo4j_bolt_common` package so `neo4j_bolt_eio` resolves again in fresh CI switches
- point setup docs and contributor quick starts at the shared pin script for CI parity

## Validation
- bash -n scripts/opam-pin-external-deps.sh
- ruby -e "require "yaml"; ..." to parse ci.yml, deploy-railway.yml, and release.yml
- git diff --check

## Context
- unblocks repo-wide CI failures currently affecting main and PR #549 during `opam install`