### PR TITLE
fix(keeper): drop partial tail fragments safely

### DIFF
--- a/lib/tool_keeper.ml
+++ b/lib/tool_keeper.ml
@@ -2408,6 +2408,12 @@ let read_file_tail_lines path ~max_bytes ~max_lines : string list =
       Fun.protect ~finally:(fun () -> close_in_noerr ic) (fun () ->
         let len = in_channel_length ic in
         let start = max 0 (len - max_bytes) in
+        let starts_mid_line =
+          if start <= 0 then false
+          else (
+            seek_in ic (start - 1);
+            input_char ic <> '\n')
+        in
         seek_in ic start;
         let remaining = len - start in
         let buf = Bytes.create remaining in
@@ -2417,6 +2423,11 @@ let read_file_tail_lines path ~max_bytes ~max_lines : string list =
           chunk
           |> String.split_on_char '\n'
           |> List.filter (fun s -> String.trim s <> "")
+        in
+        let lines =
+          match starts_mid_line, lines with
+          | true, _ :: rest -> rest
+          | _ -> lines
         in
         let n = List.length lines in
         let drop = max 0 (n - max_lines) in

--- a/test/dune
+++ b/test/dune
@@ -190,6 +190,11 @@
  (modules test_protocol_game_view)
  (libraries masc_mcp alcotest yojson unix))
 
+(test
+ (name test_tool_keeper)
+ (modules test_tool_keeper)
+ (libraries masc_mcp alcotest unix))
+
 ; Dispatch chain evidence test
 (test
  (name test_dispatch_chain_evidence)

--- a/test/test_tool_keeper.ml
+++ b/test/test_tool_keeper.ml
@@ -1,0 +1,39 @@
+open Alcotest
+
+let with_temp_file contents f =
+  let path = Filename.temp_file "keeper-tail" ".log" in
+  Fun.protect
+    ~finally:(fun () -> if Sys.file_exists path then Sys.remove path)
+    (fun () ->
+      let oc = open_out_bin path in
+      Fun.protect
+        ~finally:(fun () -> close_out_noerr oc)
+        (fun () -> output_string oc contents);
+      f path)
+
+let test_read_file_tail_lines_drops_partial_first_line () =
+  let contents = "AAAAA\nBBBBB\nCCCCC\nDDDDD\n" in
+  let len = String.length contents in
+  let b_index = String.index contents 'B' in
+  let start = b_index + 2 in
+  let max_bytes = len - start in
+  with_temp_file contents (fun path ->
+    let lines = Masc_mcp.Tool_keeper.read_file_tail_lines path ~max_bytes ~max_lines:10 in
+    check (list string) "drops partial fragment" ["CCCCC"; "DDDDD"] lines)
+
+let test_read_file_tail_lines_keeps_line_boundary_start () =
+  let contents = "AAAAA\nBBBBB\nCCCCC\nDDDDD\n" in
+  let len = String.length contents in
+  let b_index = String.index contents 'B' in
+  let max_bytes = len - b_index in
+  with_temp_file contents (fun path ->
+    let lines = Masc_mcp.Tool_keeper.read_file_tail_lines path ~max_bytes ~max_lines:10 in
+    check (list string) "keeps full first line" ["BBBBB"; "CCCCC"; "DDDDD"] lines)
+
+let () =
+  run "Tool_keeper" [
+    ("read_file_tail_lines", [
+         test_case "drops partial first line" `Quick test_read_file_tail_lines_drops_partial_first_line;
+         test_case "keeps line-boundary start" `Quick test_read_file_tail_lines_keeps_line_boundary_start;
+       ]);
+  ]


### PR DESCRIPTION
## Summary
- drop partial first-line fragments when tail reads start mid-line
- preserve the first full line when the read window starts on a line boundary
- add regression coverage for both cases

## Validation
- dune build --root . test/test_tool_keeper.exe
- ./_build/default/test/test_tool_keeper.exe