### PR TITLE
fix(council): initialize consensus persistence in tool handlers

### DIFF
--- a/lib/masc_mcp.ml
+++ b/lib/masc_mcp.ml
@@ -178,6 +178,7 @@ module Tool_audit = Tool_audit
 module Tool_suspend = Tool_suspend
 module Tool_shard = Tool_shard
 module Tool_social = Tool_social
+module Tool_council = Tool_council
 module Tool_experiment = Tool_experiment
 module Tool_rate_limit = Tool_rate_limit
 module Tool_cost = Tool_cost

--- a/lib/tool_council.ml
+++ b/lib/tool_council.ml
@@ -34,6 +34,9 @@ type context = {
 
 type result = bool * string
 
+let ensure_consensus ctx =
+  Consensus.init ~base_path:ctx.base_path
+
 (** {1 SSE Event Broadcasting}
 
     Emits decision-model events to connected viewers via the SSE push pipeline.
@@ -195,6 +198,7 @@ let handle_debates ctx _args =
 (** {1 Consensus Handlers} *)
 
 let handle_consensus_start ctx args =
+  ensure_consensus ctx;
   let topic = get_string args "topic" "" in
   let quorum = get_int args "quorum" 2 in
   let threshold = get_float args "threshold" 0.5 in
@@ -228,6 +232,7 @@ let handle_consensus_start ctx args =
       (false, Printf.sprintf "Error: %s" msg)
 
 let handle_consensus_vote ctx args =
+  ensure_consensus ctx;
   let session_id = get_string args "session_id" "" in
   (* Accept both "decision" and "choice" for user convenience *)
   let decision_str = 
@@ -266,7 +271,8 @@ let handle_consensus_vote ctx args =
       in
       (false, Printf.sprintf "Error: %s" msg)
 
-let handle_consensus_close _ctx args =
+let handle_consensus_close ctx args =
+  ensure_consensus ctx;
   let session_id = get_string args "session_id" "" in
   if session_id = "" then
     (false, "Error: session_id is required")
@@ -304,7 +310,8 @@ let handle_consensus_close _ctx args =
       in
       (false, Printf.sprintf "Error: %s" msg)
 
-let handle_consensus_result _ctx args =
+let handle_consensus_result ctx args =
+  ensure_consensus ctx;
   let session_id = get_string args "session_id" "" in
   if session_id = "" then
     (false, "Error: session_id is required")
@@ -323,7 +330,8 @@ let handle_consensus_result _ctx args =
       in
       (false, Printf.sprintf "Error: %s" msg)
 
-let handle_sessions _ctx _args =
+let handle_sessions ctx _args =
+  ensure_consensus ctx;
   let sessions = ConsensusApi.list_active () in
   let items = List.map (fun (s : Consensus.session) ->
     `Assoc [

--- a/test/dune
+++ b/test/dune
@@ -194,7 +194,10 @@
  (name test_tool_keeper)
  (modules test_tool_keeper)
  (libraries masc_mcp alcotest unix))
-
+(test
+ (name test_tool_council)
+ (modules test_tool_council)
+ (libraries masc_mcp alcotest yojson unix))
 ; Dispatch chain evidence test
 (test
  (name test_dispatch_chain_evidence)

--- a/test/test_tool_council.ml
+++ b/test/test_tool_council.ml
@@ -1,0 +1,172 @@
+open Masc_mcp
+open Alcotest
+
+module Consensus = Council.Consensus
+
+let test_counter = ref 0
+
+let temp_dir prefix =
+  incr test_counter;
+  let dir = Filename.temp_file (Printf.sprintf "%s_%d_" prefix !test_counter) "" in
+  Unix.unlink dir;
+  Unix.mkdir dir 0o755;
+  dir
+
+let cleanup_dir dir =
+  let rec rm path =
+    if Sys.file_exists path then
+      if Sys.is_directory path then (
+        Array.iter (fun name -> rm (Filename.concat path name)) (Sys.readdir path);
+        Unix.rmdir path)
+      else
+        Unix.unlink path
+  in
+  try rm dir with _ -> ()
+
+let parse_json_exn s =
+  try Yojson.Safe.from_string s
+  with Yojson.Json_error e -> failwith ("invalid json: " ^ e)
+
+let contains_substring ~needle haystack =
+  let haystack = String.lowercase_ascii haystack in
+  let needle = String.lowercase_ascii needle in
+  let hay_len = String.length haystack in
+  let needle_len = String.length needle in
+  let rec loop idx =
+    idx + needle_len <= hay_len
+    && ((String.sub haystack idx needle_len = needle) || loop (idx + 1))
+  in
+  needle_len = 0 || loop 0
+
+let dispatch_exn ctx ~name ~args =
+  match Tool_council.dispatch ctx ~name ~args with
+  | Some result -> result
+  | None -> failwith ("dispatch returned None for " ^ name)
+
+let make_ctx ~base_path ~agent_name : Tool_council.context =
+  { base_path; agent_name; room_config = None }
+
+let session_file base_path session_id =
+  Filename.concat
+    (Filename.concat (Filename.concat base_path ".masc") "consensus")
+    (session_id ^ ".json")
+
+let with_paths f =
+  let target_base = temp_dir "test_tool_council_target" in
+  let stale_base = temp_dir "test_tool_council_stale" in
+  Fun.protect
+    ~finally:(fun () ->
+      Consensus.clear_sessions ();
+      Consensus.init ~base_path:"/tmp/masc-test-consensus-noop";
+      cleanup_dir target_base;
+      cleanup_dir stale_base)
+    (fun () -> f ~target_base ~stale_base)
+
+let extract_session_id body =
+  parse_json_exn body |> Yojson.Safe.Util.member "id" |> Yojson.Safe.Util.to_string
+
+let test_consensus_start_uses_tool_base_path () =
+  with_paths @@ fun ~target_base ~stale_base ->
+  let ctx = make_ctx ~base_path:target_base ~agent_name:"alice" in
+  Consensus.clear_sessions ();
+  Consensus.init ~base_path:stale_base;
+  let ok, body =
+    dispatch_exn ctx ~name:"masc_consensus_start"
+      ~args:(`Assoc [("topic", `String "Persist via tool"); ("quorum", `Int 2)])
+  in
+  check bool "start ok" true ok;
+  let session_id = extract_session_id body in
+  check bool "persisted to target base" true (Sys.file_exists (session_file target_base session_id));
+  check bool "not persisted to stale base" false (Sys.file_exists (session_file stale_base session_id));
+  Consensus.clear_sessions ();
+  let ok, body = dispatch_exn ctx ~name:"masc_sessions" ~args:(`Assoc []) in
+  check bool "sessions ok" true ok;
+  let sessions = parse_json_exn body |> Yojson.Safe.Util.to_list in
+  let has_session =
+    List.exists
+      (fun json ->
+        Yojson.Safe.Util.member "id" json |> Yojson.Safe.Util.to_string = session_id)
+      sessions
+  in
+  check bool "session restored by tool sessions" true has_session
+
+let test_consensus_vote_reloads_persisted_session () =
+  with_paths @@ fun ~target_base ~stale_base ->
+  let starter = make_ctx ~base_path:target_base ~agent_name:"alice" in
+  let voter = make_ctx ~base_path:target_base ~agent_name:"bob" in
+  Consensus.clear_sessions ();
+  let ok, body =
+    dispatch_exn starter ~name:"masc_consensus_start"
+      ~args:(`Assoc [("topic", `String "Persist vote"); ("quorum", `Int 2)])
+  in
+  check bool "start ok" true ok;
+  let session_id = extract_session_id body in
+  Consensus.clear_sessions ();
+  Consensus.init ~base_path:stale_base;
+  let ok, _body =
+    dispatch_exn voter ~name:"masc_consensus_vote"
+      ~args:
+        (`Assoc
+          [
+            ("session_id", `String session_id);
+            ("decision", `String "approve");
+            ("reason", `String "looks good");
+          ])
+  in
+  check bool "vote ok" true ok;
+  Consensus.clear_sessions ();
+  Consensus.init ~base_path:target_base;
+  match Consensus.get_session ~session_id with
+  | None -> fail "session not restored from target base"
+  | Some restored ->
+      check int "vote count" 1 (List.length restored.Consensus.votes);
+      let vote = List.hd restored.Consensus.votes in
+      check string "vote agent" "bob" vote.Consensus.agent;
+      check bool "decision approve" true (vote.Consensus.decision = Consensus.Approve)
+
+let test_consensus_close_and_result_reload_persisted_session () =
+  with_paths @@ fun ~target_base ~stale_base ->
+  let starter = make_ctx ~base_path:target_base ~agent_name:"alice" in
+  let voter = make_ctx ~base_path:target_base ~agent_name:"bob" in
+  Consensus.clear_sessions ();
+  let ok, body =
+    dispatch_exn starter ~name:"masc_consensus_start"
+      ~args:(`Assoc [("topic", `String "Persist close"); ("quorum", `Int 1)])
+  in
+  check bool "start ok" true ok;
+  let session_id = extract_session_id body in
+  let ok, _body =
+    dispatch_exn voter ~name:"masc_consensus_vote"
+      ~args:
+        (`Assoc
+          [
+            ("session_id", `String session_id);
+            ("decision", `String "approve");
+            ("reason", `String "ship it");
+          ])
+  in
+  check bool "vote ok" true ok;
+  Consensus.clear_sessions ();
+  Consensus.init ~base_path:stale_base;
+  let ok, _body =
+    dispatch_exn starter ~name:"masc_consensus_close"
+      ~args:(`Assoc [("session_id", `String session_id)])
+  in
+  check bool "close ok" true ok;
+  Consensus.clear_sessions ();
+  Consensus.init ~base_path:stale_base;
+  let ok, body =
+    dispatch_exn starter ~name:"masc_consensus_result"
+      ~args:(`Assoc [("session_id", `String session_id)])
+  in
+  check bool "result ok" true ok;
+  check bool "result mentions approved" true (contains_substring ~needle:"approved" body)
+
+let () =
+  run "Tool_council" [
+    ("consensus_persistence", [
+      test_case "start uses tool base path" `Quick test_consensus_start_uses_tool_base_path;
+      test_case "vote reloads persisted session" `Quick test_consensus_vote_reloads_persisted_session;
+      test_case "close and result reload persisted session" `Quick test_consensus_close_and_result_reload_persisted_session;
+    ]);
+  ]


### PR DESCRIPTION
## Summary
- initialize consensus persistence on consensus-only tool paths
- add tool-level regression coverage for persisted start/vote/close/result/session list flows
- close the follow-up gap left after `#550` was merged

## Testing
- `dune build --root . @default`
- `./_build/default/test/test_tool_council.exe`

## Context
- follow-up fix for review thread on `#550` (`discussion_r2899800684`)
