### PR TITLE
fix(command-plane): isolate board state by base path

### DIFF
--- a/bin/main_eio.ml
+++ b/bin/main_eio.ml
@@ -5866,6 +5866,12 @@ let command_plane_help_http_json () =
               ~why:"Strict cross-platoon or disruptive action requires a policy decision."
               ~fix_tool:"masc_policy_approve"
               ~fix_summary:"Review the pending decision and approve/deny it before running tick again.";
+            pitfall ~id:"http-actor-defaults-dashboard"
+              ~title:"HTTP actor defaults to dashboard"
+              ~symptom:"Operation or trace entries show actor=dashboard even though a human or agent initiated the request."
+              ~why:"Mutating HTTP endpoints use dashboard as the fallback actor unless x-masc-agent, x-masc-agent-name, or agent_name is provided."
+              ~fix_tool:"masc_operation_start"
+              ~fix_summary:"Send x-masc-agent-name (or x-masc-agent) on mutating HTTP requests when actor attribution matters.";
           ] );
       ( "examples",
         `List
@@ -5900,6 +5906,7 @@ let command_plane_help_http_json () =
                    [
                      ("method", `String "POST");
                      ("path", `String "/api/v1/command-plane/operations");
+                     ("headers", `Assoc [ ("x-masc-agent-name", `String "codex") ]);
                      ("body",
                       `Assoc
                         [
@@ -5922,7 +5929,10 @@ let command_plane_help_http_json () =
                         ]);
                    ])
               ~notes:
-                [ "Run dispatch/tick after operation start to materialize detachments." ];
+                [
+                  "Run dispatch/tick after operation start to materialize detachments.";
+                  "Without x-masc-agent-name (or x-masc-agent), actor attribution falls back to dashboard.";
+                ];
             example ~id:"approval" ~title:"Approve strict action"
               ~path_id:"cpv2_benchmark" ~transport:"mcp"
               ~request:

--- a/docs/BENCHMARK-RUNBOOK.md
+++ b/docs/BENCHMARK-RUNBOOK.md
@@ -95,8 +95,12 @@
 
 ```json
 {
-  "tool": "masc_operation_start",
-  "arguments": {
+  "method": "POST",
+  "path": "/api/v1/command-plane/operations",
+  "headers": {
+    "x-masc-agent-name": "codex"
+  },
+  "body": {
     "assigned_unit_id": "squad-verify",
     "objective": "Verify and quarantine new research items",
     "autonomy_level": "L4_Autonomous",
@@ -110,6 +114,7 @@
 
 - `masc_observe_operations`에 operation이 보임
 - `trace_id`가 발급됨
+- actor header를 생략하면 operation `created_by`가 `dashboard`로 떨어질 수 있음
 
 ## detachment materialization
 

--- a/docs/COMMAND-PLANE-RUNBOOK.md
+++ b/docs/COMMAND-PLANE-RUNBOOK.md
@@ -107,6 +107,7 @@
 
 ```http
 POST /api/v1/command-plane/operations
+x-masc-agent-name: codex
 Content-Type: application/json
 
 {
@@ -129,6 +130,11 @@ Content-Type: application/json
   }
 }
 ```
+
+주의:
+
+- HTTP mutating call에서 `x-masc-agent` 또는 `x-masc-agent-name`, 혹은 `agent_name` query를 안 주면 actor가 `dashboard`로 기록된다.
+- trace / operation `created_by` attribution이 중요하면 header를 반드시 붙인다.
 
 그 다음 바로:
 

--- a/lib/board.ml
+++ b/lib/board.ml
@@ -285,16 +285,24 @@ let maybe_sweep store =
 
 (** {1 Persistence Paths} *)
 
+let board_base_path () =
+  match Sys.getenv_opt "MASC_BASE_PATH" with
+  | Some p when String.trim p <> "" -> p
+  | _ ->
+      (match Sys.getenv_opt "ME_ROOT" with
+       | Some p -> p
+       | None -> Sys.getcwd ())
+
 let persist_path () =
-  let base = match Sys.getenv_opt "ME_ROOT" with Some p -> p | None -> Sys.getcwd () in
+  let base = board_base_path () in
   Filename.concat base ".masc/board_posts.jsonl"
 
 let comments_path () =
-  let base = match Sys.getenv_opt "ME_ROOT" with Some p -> p | None -> Sys.getcwd () in
+  let base = board_base_path () in
   Filename.concat base ".masc/board_comments.jsonl"
 
 let ensure_masc_dir () =
-  let base = match Sys.getenv_opt "ME_ROOT" with Some p -> p | None -> Sys.getcwd () in
+  let base = board_base_path () in
   let dir = Filename.concat base ".masc" in
   if not (Sys.file_exists dir) then Unix.mkdir dir 0o755
 
@@ -634,7 +642,7 @@ let list_comments store ?(limit=1000) () : comment list =
 let vote_direction_to_string = function Up -> "up" | Down -> "down"
 
 let vote_log_path () =
-  let base = match Sys.getenv_opt "ME_ROOT" with Some p -> p | None -> Sys.getcwd () in
+  let base = board_base_path () in
   Filename.concat base ".masc/board_votes.jsonl"
 
 let append_vote_log ~target ~voter ~direction =

--- a/lib/board.ml
+++ b/lib/board.ml
@@ -301,10 +301,20 @@ let comments_path () =
   let base = board_base_path () in
   Filename.concat base ".masc/board_comments.jsonl"
 
+let rec ensure_dir path =
+  if path = "" || path = "." || path = "/" then ()
+  else if Sys.file_exists path then ()
+  else begin
+    ensure_dir (Filename.dirname path);
+    try Unix.mkdir path 0o755
+    with Unix.Unix_error (Unix.EEXIST, _, _) -> ()
+  end
+
 let ensure_masc_dir () =
   let base = board_base_path () in
   let dir = Filename.concat base ".masc" in
-  if not (Sys.file_exists dir) then Unix.mkdir dir 0o755
+  ensure_dir base;
+  ensure_dir dir
 
 (** {1 JSONL File Rotation} *)
 

--- a/start-masc-mcp.sh
+++ b/start-masc-mcp.sh
@@ -200,6 +200,7 @@ resolve_base_path() {
 }
 
 RESOLVED_BASE_PATH="$(resolve_base_path "$BASE_PATH")"
+export MASC_BASE_PATH="$RESOLVED_BASE_PATH"
 
 # Wait for port to become available.
 # Default behavior is fail-fast on conflict to prevent duplicate server startup.


### PR DESCRIPTION
## Summary
- honor isolated `--base-path` rooms for board persistence by using `MASC_BASE_PATH`
- export the resolved base path from `start-masc-mcp.sh` so local HTTP smokes stop reading global `~/me/.masc` board state
- document the HTTP actor-header pitfall in the CPv2 runbooks and `/api/v1/command-plane/help`

## Validation
- `dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/cpv2-golden-path-smoke`
- isolated CPv2 golden-path smoke on `http://127.0.0.1:8975` with `--base-path /tmp/masc-cpv2-golden-path`
- verified board startup log and dashboard board metrics switched from global `~/me/.masc` to `/tmp/masc-cpv2-golden-path/.masc`
- verified `/api/v1/command-plane/help` now documents `x-masc-agent-name` / `x-masc-agent` actor attribution
