### PR TITLE
fix(task): clarify masc_done rejection reasons

### DIFF
--- a/lib/room.ml
+++ b/lib/room.ml
@@ -1059,12 +1059,30 @@ let complete_task_r config ~agent_name ~task_id ~notes : string Types.masc_resul
         match task_opt with
         | None -> Error (Types.TaskNotFound task_id)
         | Some task ->
-            let can_complete = match task.task_status with
-              | Claimed { assignee; _ } | InProgress { assignee; _ } -> assignee = agent_name
-              | Todo | Done _ | Cancelled _ -> false
+            let completion_error =
+              match task.task_status with
+              | Claimed { assignee; _ } | InProgress { assignee; _ } ->
+                  if assignee = agent_name then
+                    None
+                  else
+                    Some (Types.TaskAlreadyClaimed { task_id; by = assignee })
+              | Todo -> Some (Types.TaskNotClaimed task_id)
+              | Done { assignee; _ } ->
+                  Some
+                    (Types.TaskInvalidState
+                       (Printf.sprintf
+                          "task %s is already done by %s; inspect task history instead of calling masc_done again"
+                          task_id assignee))
+              | Cancelled { cancelled_by; _ } ->
+                  Some
+                    (Types.TaskInvalidState
+                       (Printf.sprintf
+                          "task %s was cancelled by %s; reopen or create a new task instead of calling masc_done"
+                          task_id cancelled_by))
             in
-            if not can_complete then Error (Types.TaskNotClaimed task_id)
-            else begin
+            match completion_error with
+            | Some err -> Error err
+            | None -> begin
               let new_tasks = List.map (fun t ->
                 if t.id = task_id then
                   { t with task_status = Done { assignee = agent_name; completed_at = now_iso (); notes = if notes = "" then None else Some notes } }

--- a/lib/types.ml
+++ b/lib/types.ml
@@ -784,8 +784,14 @@ let rec masc_error_to_string = function
   | AgentNotFound name -> Printf.sprintf "❌ Agent not found: %s" name
   | AgentAlreadyJoined name -> Printf.sprintf "⚠ %s is already in the room" name
   | TaskNotFound id -> Printf.sprintf "❌ Task not found: %s" id
-  | TaskAlreadyClaimed { task_id; by } -> Printf.sprintf "❌ Task %s already claimed by %s" task_id by
-  | TaskNotClaimed id -> Printf.sprintf "❌ Task %s is not claimed" id
+  | TaskAlreadyClaimed { task_id; by } ->
+      Printf.sprintf
+        "❌ Task %s is currently owned by %s. Ask that agent to finish it, or claim a different task."
+        task_id by
+  | TaskNotClaimed id ->
+      Printf.sprintf
+        "❌ Task %s is still todo. Claim/start it first, then mark it done."
+        id
   | TaskInvalidState msg -> Printf.sprintf "❌ Invalid task state: %s" msg
   | TaskRoleMismatch { task_id; required; actual } ->
       Printf.sprintf "❌ Role mismatch for %s: requires %s, agent has %s" task_id required actual

--- a/test/test_tool_task_coverage.ml
+++ b/test/test_tool_task_coverage.ml
@@ -26,6 +26,18 @@ let make_test_ctx () =
   let _ = Room.init config ~agent_name:(Some "test-agent") in
   { Tool_task.config; agent_name = "test-agent" }
 
+let str_contains s substring =
+  let len_s = String.length s in
+  let len_sub = String.length substring in
+  if len_sub > len_s then false
+  else
+    let rec loop i =
+      if i > len_s - len_sub then false
+      else if String.sub s i len_sub = substring then true
+      else loop (i + 1)
+    in
+    loop 0
+
 (* Test dispatch returns None for unknown tool *)
 let () = test "dispatch_unknown_tool" (fun () ->
   let ctx = make_test_ctx () in
@@ -69,6 +81,54 @@ let () = test "dispatch_claim_next" (fun () ->
   match Tool_task.dispatch ctx ~name:"masc_claim_next" ~args with
   | Some (_success, _result) -> ()
   | None -> failwith "dispatch returned None"
+)
+
+(* Test handle_done returns owner guidance when another agent owns the task *)
+let () = test "handle_done_owned_by_other_guidance" (fun () ->
+  let ctx = make_test_ctx () in
+  let _ = Tool_task.handle_add_task ctx (`Assoc [("title", `String "Done test")]) in
+  let _ = Room.claim_task ctx.config ~agent_name:"other-agent" ~task_id:"task-001" in
+  let success, result =
+    Tool_task.handle_done ctx (`Assoc [("task_id", `String "task-001"); ("notes", `String "")])
+  in
+  assert (not success);
+  assert (str_contains result "currently owned by other-agent")
+)
+
+(* Test handle_done on todo task recommends claim/start first *)
+let () = test "handle_done_todo_guidance" (fun () ->
+  let ctx = make_test_ctx () in
+  let _ = Tool_task.handle_add_task ctx (`Assoc [("title", `String "Todo test")]) in
+  let success, result =
+    Tool_task.handle_done ctx (`Assoc [("task_id", `String "task-001"); ("notes", `String "")])
+  in
+  assert (not success);
+  assert (str_contains result "Claim/start it first")
+)
+
+(* Test handle_done reports already-done guidance instead of generic not-claimed *)
+let () = test "handle_done_already_done_guidance" (fun () ->
+  let ctx = make_test_ctx () in
+  let _ = Tool_task.handle_add_task ctx (`Assoc [("title", `String "Done test")]) in
+  let _ = Room.claim_task ctx.config ~agent_name:"other-agent" ~task_id:"task-001" in
+  let _ = Room.complete_task_r ctx.config ~agent_name:"other-agent" ~task_id:"task-001" ~notes:"done" in
+  let success, result =
+    Tool_task.handle_done ctx (`Assoc [("task_id", `String "task-001"); ("notes", `String "")])
+  in
+  assert (not success);
+  assert (str_contains result "already done by other-agent")
+)
+
+(* Test handle_done reports cancelled-task guidance instead of generic not-claimed *)
+let () = test "handle_done_cancelled_guidance" (fun () ->
+  let ctx = make_test_ctx () in
+  let _ = Tool_task.handle_add_task ctx (`Assoc [("title", `String "Cancelled test")]) in
+  let _ = Room.cancel_task_r ctx.config ~agent_name:"test-agent" ~task_id:"task-001" ~reason:"stop" in
+  let success, result =
+    Tool_task.handle_done ctx (`Assoc [("task_id", `String "task-001"); ("notes", `String "")])
+  in
+  assert (not success);
+  assert (str_contains result "was cancelled by test-agent")
 )
 
 (* Test dispatch release *)

--- a/test/test_types_coverage.ml
+++ b/test/test_types_coverage.ml
@@ -751,7 +751,9 @@ let test_masc_error_task_not_found () =
 
 let test_masc_error_task_already_claimed () =
   let s = Types.masc_error_to_string (Types.TaskAlreadyClaimed { task_id = "t1"; by = "agent" }) in
-  check bool "contains both" true (String.length s > 0)
+  check bool "contains owner guidance" true
+    (try let _ = Str.search_forward (Str.regexp "currently owned by agent") s 0 in true
+     with Not_found -> false)
 
 let test_masc_error_rate_limit () =
   let s = Types.masc_error_to_string
@@ -1026,7 +1028,9 @@ let test_masc_error_agent_already_joined () =
 
 let test_masc_error_task_not_claimed () =
   let s = Types.masc_error_to_string (Types.TaskNotClaimed "t1") in
-  check bool "nonempty" true (String.length s > 0)
+  check bool "contains claim guidance" true
+    (try let _ = Str.search_forward (Str.regexp "Claim/start it first") s 0 in true
+     with Not_found -> false)
 
 let test_masc_error_task_invalid_state () =
   let s = Types.masc_error_to_string (Types.TaskInvalidState "cancelled") in


### PR DESCRIPTION
## Summary
- return precise masc_done errors for todo, owned-by-other, already-done, and cancelled tasks
- improve task error strings so agents can self-correct instead of retrying blindly
- add tool/types regression coverage for the new guidance paths

## Validation
- dune build --root . test/test_tool_task_coverage.exe test/test_types_coverage.exe
- ./_build/default/test/test_tool_task_coverage.exe
- ./_build/default/test/test_types_coverage.exe