### PR TITLE
Add operator worker spawn batch control

### DIFF
--- a/bin/main_eio.ml
+++ b/bin/main_eio.ml
@@ -5396,6 +5396,7 @@ let operator_snapshot_http_json ~state ~sw ~clock request =
       agent_name = Option.value ~default:"dashboard" (operator_actor_hint request);
       sw;
       clock;
+      proc_mgr = state.Mcp_server.proc_mgr;
       mcp_session_id = None;
     }
   in
@@ -5424,6 +5425,7 @@ let operator_action_http_json ~state ~sw ~clock request ~args =
       agent_name = Option.value ~default:"dashboard" (operator_actor_hint request);
       sw;
       clock;
+      proc_mgr = state.Mcp_server.proc_mgr;
       mcp_session_id = None;
     }
   in
@@ -5436,6 +5438,7 @@ let operator_confirm_http_json ~state ~sw ~clock request ~args =
       agent_name = Option.value ~default:"dashboard" (operator_actor_hint request);
       sw;
       clock;
+      proc_mgr = state.Mcp_server.proc_mgr;
       mcp_session_id = None;
     }
   in

--- a/lib/mcp_server_eio.ml
+++ b/lib/mcp_server_eio.ml
@@ -1196,7 +1196,14 @@ let execute_tool_eio ~sw ~clock ?mcp_session_id ?auth_token state ~name ~argumen
     { Tool_team_session.config; agent_name; sw; clock; proc_mgr = state.Mcp_server.proc_mgr }
   in
   let simple_ctx_operator =
-    { Tool_operator.config; agent_name; sw; clock; mcp_session_id }
+    {
+      Tool_operator.config;
+      agent_name;
+      sw;
+      clock;
+      proc_mgr = state.Mcp_server.proc_mgr;
+      mcp_session_id;
+    }
   in
   let simple_ctx_command_plane : Tool_command_plane.context = { config; agent_name } in
   let simple_ctx_cache = { Tool_cache.config } in

--- a/lib/operator_control.ml
+++ b/lib/operator_control.ml
@@ -7,6 +7,7 @@ type 'a context = {
   agent_name : string;
   sw : Eio.Switch.t;
   clock : 'a Eio.Time.clock;
+  proc_mgr : Eio_unix.Process.mgr_ty Eio.Resource.t option;
   mcp_session_id : string option;
 }
 
@@ -393,6 +394,13 @@ let available_actions_json =
         ];
       `Assoc
         [
+          ("action_type", `String "team_worker_spawn_batch");
+          ("target_type", `String "team_session");
+          ("description", `String "Use this when you need to spawn or replace one or more team-session workers through a preview-confirm path.");
+          ("confirm_required", `Bool true);
+        ];
+      `Assoc
+        [
           ("action_type", `String "team_stop");
           ("target_type", `String "team_session");
           ("description", `String "Use this when you need to stop a running team session.");
@@ -608,7 +616,9 @@ let attention_item_to_yojson (item : attention_item) =
     ]
 
 let recommended_confirm_required = function
-  | "room_pause" | "team_stop" | "task_inject" | "team_task_inject" -> true
+  | "room_pause" | "team_stop" | "task_inject" | "team_task_inject"
+  | "team_worker_spawn_batch" ->
+      true
   | _ -> false
 
 let recommended_action_to_yojson ~actor (item : recommended_action) =
@@ -647,6 +657,45 @@ let worker_card_to_yojson (card : worker_card) =
       ("has_turn", `Bool card.has_turn);
       ("last_turn_ts_iso", string_option_to_json card.last_turn_ts_iso);
     ]
+
+let spawn_batch_stub_of_cards (cards : worker_card list) =
+  let items =
+    cards
+    |> List.filter_map (fun (card : worker_card) ->
+           match card.spawn_agent with
+           | None -> None
+           | Some spawn_agent ->
+               let label =
+                 match (card.spawn_role, card.actor) with
+                 | Some role, _ when String.trim role <> "" -> role
+                 | _, Some actor when String.trim actor <> "" -> actor
+                 | _ -> spawn_agent
+               in
+               let fields =
+                 [
+                   ("spawn_agent", `String spawn_agent);
+                   ( "spawn_prompt",
+                     `String
+                       (Printf.sprintf
+                          "REQUIRED: provide explicit spawn_prompt for replacement worker %s"
+                          label) );
+                 ]
+               in
+               let fields =
+                 match card.spawn_role with
+                 | Some role when String.trim role <> "" ->
+                     ("spawn_role", `String role) :: fields
+                 | _ -> fields
+               in
+               let fields =
+                 match card.spawn_model with
+                 | Some model when String.trim model <> "" ->
+                     ("spawn_model", `String model) :: fields
+                 | _ -> fields
+               in
+               Some (`Assoc (List.rev fields)))
+  in
+  `Assoc [ ("spawn_batch", `List items) ]
 
 let session_card_to_yojson ~actor (digest : session_digest) =
   let top_attention =
@@ -992,7 +1041,13 @@ let session_attention_items ~(session : Team_session_types.session)
   List.sort compare_attention base
 
 let session_recommendations ~(session : Team_session_types.session)
-    ~(attentions : attention_item list) =
+    ~(attentions : attention_item list) ~(worker_cards : worker_card list) =
+  let no_turn_worker_cards =
+    worker_cards
+    |> List.filter (fun (card : worker_card) ->
+           String.equal card.status "planned_no_turn"
+           && Option.is_some card.spawn_agent)
+  in
   let suggestions =
     attentions
     |> List.filter_map (fun item ->
@@ -1063,21 +1118,33 @@ let session_recommendations ~(session : Team_session_types.session)
                        ];
                  }
            | "planned_worker_without_turn" ->
-               Some
-                 {
-                   action_type = "team_note";
-                   target_type = "team_session";
-                   target_id = Some session.session_id;
-                   severity = item.severity;
-                   reason = item.summary;
-                   suggested_payload =
-                     `Assoc
-                       [
-                         ( "message",
-                           `String
-                             "[operator] Planned workers have not reported yet. Record a concrete progress note or detach and replace the missing worker." );
-                       ];
-                 }
+               if no_turn_worker_cards = [] then
+                 Some
+                   {
+                     action_type = "team_note";
+                     target_type = "team_session";
+                     target_id = Some session.session_id;
+                     severity = item.severity;
+                     reason = item.summary;
+                     suggested_payload =
+                       `Assoc
+                         [
+                           ( "message",
+                             `String
+                               "[operator] Planned workers have not reported yet. Record a concrete progress note or detach and replace the missing worker." );
+                         ];
+                   }
+               else
+                 Some
+                   {
+                     action_type = "team_worker_spawn_batch";
+                     target_type = "team_session";
+                     target_id = Some session.session_id;
+                     severity = item.severity;
+                     reason = item.summary;
+                     suggested_payload =
+                       spawn_batch_stub_of_cards no_turn_worker_cards;
+                   }
            | _ -> None)
   in
   dedup_recommendations suggestions
@@ -1105,7 +1172,7 @@ let build_session_digest config (session : Team_session_types.session) ~now =
   let worker_cards = build_worker_cards ~session ~events ~now in
   let attention_items = session_attention_items ~session ~events ~worker_cards ~now in
   let recommended_actions =
-    session_recommendations ~session ~attentions:attention_items
+    session_recommendations ~session ~attentions:attention_items ~worker_cards
   in
   let active_agent_count =
     match U.member "active_agents" summary with
@@ -1360,6 +1427,7 @@ let canonical_action_type action_type =
   | "team_note" -> "team_note"
   | "team_broadcast" -> "team_broadcast"
   | "team_task_inject" -> "team_task_inject"
+  | "team_worker_spawn_batch" -> "team_worker_spawn_batch"
   | "keeper_msg" -> "keeper_message"
   | "keeper_message" -> "keeper_message"
   | "keeper_probe" -> "keeper_probe"
@@ -1369,7 +1437,9 @@ let canonical_action_type action_type =
 let default_target_type_for action_type =
   match action_type with
   | "broadcast" | "room_pause" | "room_resume" | "task_inject" | "lodge_tick" -> "room"
-  | "team_turn" | "team_note" | "team_broadcast" | "team_task_inject" | "team_stop" -> "team_session"
+  | "team_turn" | "team_note" | "team_broadcast" | "team_task_inject"
+  | "team_worker_spawn_batch" | "team_stop" ->
+      "team_session"
   | "keeper_message" | "keeper_probe" | "keeper_recover" -> "keeper"
   | _ -> ""
 
@@ -1417,7 +1487,9 @@ let delegated_tool_for action_type =
   | "room_pause" -> "masc_pause"
   | "room_resume" -> "masc_resume"
   | "lodge_tick" -> "lodge_tick"
-  | "team_turn" | "team_note" | "team_broadcast" | "team_task_inject" -> "masc_team_session_turn"
+  | "team_turn" | "team_note" | "team_broadcast" | "team_task_inject" ->
+      "masc_team_session_turn"
+  | "team_worker_spawn_batch" -> "masc_team_session_step"
   | "team_stop" -> "masc_team_session_stop"
   | "keeper_message" -> "masc_keeper_msg"
   | "keeper_probe" -> "masc_keeper_status"
@@ -1426,7 +1498,9 @@ let delegated_tool_for action_type =
   | _ -> "unknown"
 
 let confirm_required = function
-  | "room_pause" | "team_stop" | "task_inject" | "team_task_inject" -> true
+  | "room_pause" | "team_stop" | "task_inject" | "team_task_inject"
+  | "team_worker_spawn_batch" ->
+      true
   | _ -> false
 
 let preview_of_action (request : action_request) =
@@ -1547,6 +1621,33 @@ let tool_keeper_ctx (ctx : 'a context) : _ Tool_keeper.context =
 
 let dispatch_keeper_json (ctx : 'a context) ~tool_name ~args =
   match Tool_keeper.dispatch (tool_keeper_ctx ctx) ~name:tool_name ~args with
+  | Some (true, body) -> Ok (json_of_dispatch_output body)
+  | Some (false, err) -> Error err
+  | None -> Error (Printf.sprintf "%s dispatch unavailable" tool_name)
+
+let dispatch_team_session_json_as (ctx : 'a context) ~session_id ~requested_actor
+    ~tool_name ~args =
+  let* authorized_actor =
+    match Team_session_store.load_session ctx.config session_id with
+    | None -> Error (Printf.sprintf "team session not found: %s" session_id)
+    | Some session ->
+        if String.equal requested_actor session.created_by
+           || List.exists (String.equal requested_actor) session.agent_names
+        then
+          Ok requested_actor
+        else
+          Ok session.created_by
+  in
+  let team_ctx : _ Tool_team_session.context =
+    {
+      config = ctx.config;
+      agent_name = authorized_actor;
+      sw = ctx.sw;
+      clock = ctx.clock;
+      proc_mgr = ctx.proc_mgr;
+    }
+  in
+  match Tool_team_session.dispatch team_ctx ~name:tool_name ~args with
   | Some (true, body) -> Ok (json_of_dispatch_output body)
   | Some (false, err) -> Error err
   | None -> Error (Printf.sprintf "%s dispatch unavailable" tool_name)
@@ -1740,6 +1841,34 @@ let execute_action (ctx : 'a context) (request : action_request) :
         ~message:(get_string_opt request.payload "message")
         ~target_agent:(get_string_opt request.payload "target_agent")
         ~task_title:(Some task_title) ~task_description ~task_priority
+  | "team_worker_spawn_batch" ->
+      let* () = validate_target_type "team_session" request in
+      let* session_id = require_target_id request in
+      let spawn_batch =
+        match U.member "spawn_batch" request.payload with
+        | `List [] -> Error "payload.spawn_batch must contain at least one item"
+        | `List _ as xs -> Ok xs
+        | _ -> Error "payload.spawn_batch is required"
+      in
+      let* spawn_batch = spawn_batch in
+      let args =
+        `Assoc
+          [
+            ("session_id", `String session_id);
+            ("actor", `String request.actor);
+            ("spawn_batch", spawn_batch);
+          ]
+      in
+      let* result_json =
+        dispatch_team_session_json_as ctx ~session_id ~requested_actor:request.actor
+          ~tool_name:"masc_team_session_step" ~args
+      in
+      Ok
+        (`Assoc
+          [
+            ("delegated_tool", `String "masc_team_session_step");
+            ("result", result_json);
+          ])
   | "team_stop" ->
       let* () = validate_target_type "team_session" request in
       let* session_id = require_target_id request in
@@ -1928,7 +2057,8 @@ let validate_request request =
   match request.action_type with
   | "broadcast" | "room_pause" | "room_resume" | "lodge_tick"
   | "team_turn" | "team_note"
-  | "team_broadcast" | "team_task_inject" | "team_stop"
+  | "team_broadcast" | "team_task_inject" | "team_worker_spawn_batch"
+  | "team_stop"
   | "keeper_message" | "keeper_probe" | "keeper_recover" | "task_inject" ->
       Ok ()
   | "" -> Error "action_type is required"

--- a/lib/operator_control.mli
+++ b/lib/operator_control.mli
@@ -3,6 +3,7 @@ type 'a context = {
   agent_name : string;
   sw : Eio.Switch.t;
   clock : 'a Eio.Time.clock;
+  proc_mgr : Eio_unix.Process.mgr_ty Eio.Resource.t option;
   mcp_session_id : string option;
 }
 

--- a/lib/tool_operator.ml
+++ b/lib/tool_operator.ml
@@ -5,6 +5,7 @@ type 'a context = {
   agent_name : string;
   sw : Eio.Switch.t;
   clock : 'a Eio.Time.clock;
+  proc_mgr : Eio_unix.Process.mgr_ty Eio.Resource.t option;
   mcp_session_id : string option;
 }
 
@@ -33,6 +34,7 @@ let strict_action_enums =
     `String "team_note";
     `String "team_broadcast";
     `String "team_task_inject";
+    `String "team_worker_spawn_batch";
     `String "team_stop";
     `String "keeper_message";
     `String "keeper_probe";
@@ -167,6 +169,7 @@ let dispatch (ctx : 'a context) ~name ~args : result option =
       agent_name = ctx.agent_name;
       sw = ctx.sw;
       clock = ctx.clock;
+      proc_mgr = ctx.proc_mgr;
       mcp_session_id = ctx.mcp_session_id;
     }
   in

--- a/test/test_operator_control.ml
+++ b/test/test_operator_control.ml
@@ -27,7 +27,14 @@ let result_field json =
   Yojson.Safe.Util.member "result" json
 
 let operator_ctx ?mcp_session_id env sw config agent_name : _ Operator_control.context =
-  { config; agent_name; sw; clock = Eio.Stdenv.clock env; mcp_session_id }
+  {
+    config;
+    agent_name;
+    sw;
+    clock = Eio.Stdenv.clock env;
+    proc_mgr = Some (Eio.Stdenv.process_mgr env);
+    mcp_session_id;
+  }
 
 let team_ctx env sw config agent_name : _ Tool_team_session.context =
   { config; agent_name; sw; clock = Eio.Stdenv.clock env; proc_mgr = None }
@@ -414,6 +421,147 @@ let test_team_task_inject_requires_confirm_then_executes () =
       in
       Alcotest.(check int) "pending confirm cleared" 0 (List.length pending_confirms))
 
+let test_team_worker_spawn_batch_requires_confirm_then_executes () =
+  Eio_main.run @@ fun env ->
+  Eio.Switch.run @@ fun sw ->
+  let base_dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base_dir)
+    (fun () ->
+      let config = Room.default_config base_dir in
+      ignore (Room.init config ~agent_name:(Some "owner"));
+      ignore (Room.join config ~agent_name:"owner" ~capabilities:[] ());
+      let session_id = start_session_exn (team_ctx env sw config "owner") in
+      let ctx = operator_ctx env sw config "dashboard" in
+      let action_json =
+        Operator_control.action_json ctx
+          (`Assoc
+            [
+              ("actor", `String "dashboard");
+              ("action_type", `String "team_worker_spawn_batch");
+              ("target_id", `String session_id);
+              ( "payload",
+                `Assoc
+                  [
+                    ( "spawn_batch",
+                      `List
+                        [
+                          `Assoc
+                            [
+                              ("spawn_agent", `String "not-a-real-agent");
+                              ("spawn_prompt", `String "record one worker turn");
+                              ("spawn_role", `String "replacement");
+                              ("spawn_timeout_seconds", `Int 1);
+                            ];
+                        ] );
+                  ] );
+            ])
+      in
+      let action_json =
+        match action_json with
+        | Ok json -> json
+        | Error err -> Alcotest.fail err
+      in
+      Alcotest.(check bool) "confirm required" true
+        (action_json |> Yojson.Safe.Util.member "confirm_required"
+         |> Yojson.Safe.Util.to_bool);
+      Alcotest.(check string) "delegated tool" "masc_team_session_step"
+        Yojson.Safe.Util.(action_json |> member "delegated_tool" |> to_string);
+      let confirm_token =
+        action_json |> Yojson.Safe.Util.member "confirm_token"
+        |> Yojson.Safe.Util.to_string
+      in
+      let confirm_json =
+        Operator_control.confirm_json ctx
+          (`Assoc
+            [
+              ("actor", `String "dashboard");
+              ("confirm_token", `String confirm_token);
+            ])
+      in
+      let confirm_json =
+        match confirm_json with
+        | Ok json -> json
+        | Error err -> Alcotest.fail err
+      in
+      let delegated_result =
+        Yojson.Safe.Util.member "delegated_tool_result" confirm_json
+      in
+      Alcotest.(check string) "delegated tool result" "masc_team_session_step"
+        Yojson.Safe.Util.(delegated_result |> member "delegated_tool" |> to_string);
+      let events = Team_session_store.read_events ~max_events:20 config session_id in
+      Alcotest.(check bool) "team_step_spawn recorded" true
+        (List.exists
+           (fun json ->
+             Yojson.Safe.Util.(json |> member "event_type" |> to_string)
+             = "team_step_spawn")
+           events))
+
+let test_digest_recommends_worker_spawn_batch_for_planned_worker_without_turn () =
+  Eio_main.run @@ fun env ->
+  Eio.Switch.run @@ fun sw ->
+  let base_dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base_dir)
+    (fun () ->
+      let config = Room.default_config base_dir in
+      ignore (Room.init config ~agent_name:(Some "owner"));
+      ignore (Room.join config ~agent_name:"owner" ~capabilities:[] ());
+      let session_id = start_session_exn (team_ctx env sw config "owner") in
+      let now = Unix.gettimeofday () in
+      let update_result =
+        Team_session_store.update_session config session_id (fun session ->
+            {
+              session with
+              started_at = now -. 240.0;
+              planned_workers =
+                [
+                  {
+                    Team_session_types.spawn_agent = "llama";
+                    runtime_actor = Some "llama-local-deadbeef";
+                    spawn_role = Some "implementer-a";
+                    spawn_model = Some "qwen3.5";
+                  };
+                ];
+              updated_at_iso = Types.now_iso ();
+            })
+      in
+      (match update_result with Ok _ -> () | Error err -> Alcotest.fail err);
+      let ctx = operator_ctx env sw config "dashboard" in
+      let digest =
+        match
+          Operator_control.digest_json ~actor:"dashboard"
+            ~target_type:"team_session" ~target_id:session_id ctx
+        with
+        | Ok json -> json
+        | Error err -> Alcotest.fail err
+      in
+      let recommendations =
+        Yojson.Safe.Util.(digest |> member "recommended_actions" |> to_list)
+      in
+      let recommendation =
+        match
+          List.find_opt
+            (fun item ->
+              Yojson.Safe.Util.(item |> member "action_type" |> to_string)
+              = "team_worker_spawn_batch")
+            recommendations
+        with
+        | Some item -> item
+        | None -> Alcotest.fail "expected team_worker_spawn_batch recommendation"
+      in
+      let spawn_batch =
+        Yojson.Safe.Util.(
+          recommendation |> member "suggested_payload" |> member "spawn_batch"
+          |> to_list)
+      in
+      Alcotest.(check int) "single worker stub" 1 (List.length spawn_batch);
+      let worker = List.hd spawn_batch in
+      Alcotest.(check string) "spawn_agent" "llama"
+        Yojson.Safe.Util.(worker |> member "spawn_agent" |> to_string);
+      Alcotest.(check string) "spawn_role" "implementer-a"
+        Yojson.Safe.Util.(worker |> member "spawn_role" |> to_string))
+
 let test_confirm_rejects_expired_token () =
   Eio_main.run @@ fun env ->
   Eio.Switch.run @@ fun sw ->
@@ -623,6 +771,10 @@ let () =
             test_team_broadcast_records_event;
           Alcotest.test_case "team task inject confirm flow" `Quick
             test_team_task_inject_requires_confirm_then_executes;
+          Alcotest.test_case "team worker spawn batch confirm flow" `Quick
+            test_team_worker_spawn_batch_requires_confirm_then_executes;
+          Alcotest.test_case "digest recommends worker spawn batch" `Quick
+            test_digest_recommends_worker_spawn_batch_for_planned_worker_without_turn;
           Alcotest.test_case "snapshot exposes keeper and lodge actions" `Quick
             test_snapshot_exposes_keeper_and_lodge_actions;
           Alcotest.test_case "manual selection overrides quiet hours" `Quick

--- a/test/test_tools_coverage.ml
+++ b/test/test_tools_coverage.ml
@@ -278,6 +278,8 @@ let test_masc_operator_action_schema () =
                        (List.mem (`String "team_broadcast") enums);
                      Alcotest.(check bool) "has team_task_inject" true
                        (List.mem (`String "team_task_inject") enums);
+                     Alcotest.(check bool) "has team_worker_spawn_batch" true
+                       (List.mem (`String "team_worker_spawn_batch") enums);
                      Alcotest.(check bool) "has keeper_message" true
                        (List.mem (`String "keeper_message") enums)
                  | _ -> Alcotest.fail "action_type enum missing")
@@ -312,6 +314,8 @@ let test_remote_operator_action_schema_is_strict () =
                   (List.mem (`String "keeper_msg") enums);
                 Alcotest.(check bool) "remote includes team_note" true
                   (List.mem (`String "team_note") enums);
+                Alcotest.(check bool) "remote includes team_worker_spawn_batch" true
+                  (List.mem (`String "team_worker_spawn_batch") enums);
                 Alcotest.(check bool) "remote includes lodge_tick" true
                   (List.mem (`String "lodge_tick") enums);
                 Alcotest.(check bool) "remote includes keeper_probe" true


### PR DESCRIPTION
## Summary
- add `team_worker_spawn_batch` to the operator action surface
- wire operator contexts through `proc_mgr` so operator-triggered team spawns can execute
- recommend worker respawn stubs from operator digest when planned workers never report

## Testing
- dune build --root . @default
- ./_build/default/test/test_operator_control.exe
- ./_build/default/test/test_tools_coverage.exe
- ./_build/default/test/test_mcp_server_eio.exe
- ./_build/default/test/test_operator_mcp_e2e.exe