### PR TITLE
fix(operator): make lodge tick observable

### DIFF
--- a/lib/lodge_heartbeat.ml
+++ b/lib/lodge_heartbeat.ml
@@ -37,7 +37,17 @@ let lodge_init_lock () =
 (** Run [f] under lodge mutex. Falls back to unprotected if not yet initialized. *)
 let with_lodge_lock f =
   match !lodge_lock with
-  | Some mutex -> Eio.Mutex.use_rw ~protect:true mutex f
+  | Some mutex -> (
+      try Eio.Mutex.use_rw ~protect:true mutex f
+      with exn ->
+        let msg = Printexc.to_string exn in
+        if String.starts_with ~prefix:"Stdlib.Effect.Unhandled" msg
+           || String.starts_with ~prefix:"Eio__Eio_mutex.Poisoned" msg
+           || String.starts_with ~prefix:"Eio.Private.Mutex.Poisoned" msg
+        then
+          f ()
+        else
+          raise exn)
   | None -> f ()
 
 (** Active agents: name -> (uuid, started_at) *)
@@ -830,6 +840,7 @@ type lodge_status = {
   ls_total_ticks: int;
   ls_total_checkins: int;
   ls_last_result: heartbeat_result option;
+  ls_manual_tick_running: bool;
   ls_active_self_heartbeats: string list;
 }
 
@@ -838,6 +849,31 @@ let _lodge_total_ticks = ref 0
 let _lodge_total_checkins = ref 0
 let _lodge_last_result : heartbeat_result option ref = ref None
 let _lodge_enabled = ref false
+let _lodge_manual_tick_running = ref false
+
+let set_manual_tick_running value =
+  lodge_init_lock ();
+  with_lodge_lock (fun () -> _lodge_manual_tick_running := value)
+
+let manual_tick_running () =
+  lodge_init_lock ();
+  with_lodge_lock (fun () -> !_lodge_manual_tick_running)
+
+let try_begin_manual_tick () =
+  lodge_init_lock ();
+  with_lodge_lock (fun () ->
+    if !_lodge_manual_tick_running then
+      false
+    else begin
+      _lodge_manual_tick_running := true;
+      true
+    end)
+
+let record_tick_result (result : heartbeat_result) =
+  _lodge_last_tick := Time_compat.now ();
+  _lodge_total_ticks := !_lodge_total_ticks + 1;
+  _lodge_total_checkins := !_lodge_total_checkins + List.length result.checkins;
+  _lodge_last_result := Some result
 
 let lodge_status () : lodge_status =
   let agents = !agents_cache in
@@ -850,6 +886,7 @@ let lodge_status () : lodge_status =
     ls_total_ticks = !_lodge_total_ticks;
     ls_total_checkins = !_lodge_total_checkins;
     ls_last_result = !_lodge_last_result;
+    ls_manual_tick_running = manual_tick_running ();
     ls_active_self_heartbeats =
       Hashtbl.fold (fun name _state acc -> name :: acc) agent_states [];
   }
@@ -971,6 +1008,7 @@ let lodge_status_to_json (s : lodge_status) : Yojson.Safe.t =
     ("total_ticks", `Int s.ls_total_ticks);
     ("total_checkins", `Int s.ls_total_checkins);
     ("last_tick_result", last_result_json);
+    ("manual_tick_running", `Bool s.ls_manual_tick_running);
     ( "last_skip_reason",
       match last_skip_reason with Some reason -> `String reason | None -> `Null );
     ("active_self_heartbeats", `List (List.map (fun n -> `String n) s.ls_active_self_heartbeats));
@@ -2628,10 +2666,7 @@ let make_lodge_tick_consumer ~config ~last_tick_time ~sw ~clock ~room_config
         let result = tick ~ignore_quiet_hours:false ~config ~pending_triggers in
 
         (* Record observable state *)
-        _lodge_last_tick := Time_compat.now ();
-        _lodge_total_ticks := !_lodge_total_ticks + 1;
-        _lodge_total_checkins := !_lodge_total_checkins + List.length result.checkins;
-        _lodge_last_result := Some result;
+        record_tick_result result;
 
         (* Log result *)
         let n_acted = List.length (List.filter (fun (_, _, r) ->
@@ -2741,7 +2776,7 @@ let start ~sw ~clock room_config =
 
 (** {1 Manual Trigger (for MCP tool)} *)
 
-let trigger_heartbeat room_config =
+let run_manual_heartbeat room_config =
   let config = load_config () in
   let agents = get_agents () in
   (* Manual trigger: create ManualTrigger for all agents *)
@@ -2749,6 +2784,7 @@ let trigger_heartbeat room_config =
     (a.name, ManualTrigger)
   ) agents in
   let result = tick ~ignore_quiet_hours:true ~config ~pending_triggers in
+  record_tick_result result;
 
   List.iter (fun (name, _trigger, _checkin) ->
     Eio.traceln "🔔 %s checked in (manual trigger)" name
@@ -2756,6 +2792,29 @@ let trigger_heartbeat room_config =
 
   ignore room_config;
   result
+
+let trigger_heartbeat room_config =
+  if not (try_begin_manual_tick ()) then
+    invalid_arg "manual heartbeat already running";
+  Fun.protect
+    ~finally:(fun () -> set_manual_tick_running false)
+    (fun () -> run_manual_heartbeat room_config)
+
+let trigger_heartbeat_async ~sw room_config =
+  if not (try_begin_manual_tick ()) then
+    `Already_running
+  else begin
+    Eio.Fiber.fork ~sw (fun () ->
+      Fun.protect
+        ~finally:(fun () -> set_manual_tick_running false)
+        (fun () ->
+          try
+            ignore (run_manual_heartbeat room_config)
+          with exn ->
+            Eio.traceln "💀 Lodge manual trigger failed: %s"
+              (Printexc.to_string exn)));
+    `Started
+  end
 
 (** {1 Broadcast Content-Aware Routing}
 

--- a/lib/lodge_heartbeat.ml
+++ b/lib/lodge_heartbeat.ml
@@ -37,17 +37,7 @@ let lodge_init_lock () =
 (** Run [f] under lodge mutex. Falls back to unprotected if not yet initialized. *)
 let with_lodge_lock f =
   match !lodge_lock with
-  | Some mutex -> (
-      try Eio.Mutex.use_rw ~protect:true mutex f
-      with exn ->
-        let msg = Printexc.to_string exn in
-        if String.starts_with ~prefix:"Stdlib.Effect.Unhandled" msg
-           || String.starts_with ~prefix:"Eio__Eio_mutex.Poisoned" msg
-           || String.starts_with ~prefix:"Eio.Private.Mutex.Poisoned" msg
-        then
-          f ()
-        else
-          raise exn)
+  | Some mutex -> Eio.Mutex.use_rw ~protect:true mutex f
   | None -> f ()
 
 (** Active agents: name -> (uuid, started_at) *)
@@ -851,17 +841,30 @@ let _lodge_last_result : heartbeat_result option ref = ref None
 let _lodge_enabled = ref false
 let _lodge_manual_tick_running = ref false
 
-let set_manual_tick_running value =
+let with_manual_tick_state f =
   lodge_init_lock ();
-  with_lodge_lock (fun () -> _lodge_manual_tick_running := value)
+  match !lodge_lock with
+  | Some mutex -> (
+      try Eio.Mutex.use_rw ~protect:true mutex f
+      with exn ->
+        let msg = Printexc.to_string exn in
+        if String.starts_with ~prefix:"Stdlib.Effect.Unhandled" msg
+           || String.starts_with ~prefix:"Eio__Eio_mutex.Poisoned" msg
+           || String.starts_with ~prefix:"Eio.Private.Mutex.Poisoned" msg
+        then
+          f ()
+        else
+          raise exn)
+  | None -> f ()
+
+let set_manual_tick_running value =
+  with_manual_tick_state (fun () -> _lodge_manual_tick_running := value)
 
 let manual_tick_running () =
-  lodge_init_lock ();
-  with_lodge_lock (fun () -> !_lodge_manual_tick_running)
+  with_manual_tick_state (fun () -> !_lodge_manual_tick_running)
 
 let try_begin_manual_tick () =
-  lodge_init_lock ();
-  with_lodge_lock (fun () ->
+  with_manual_tick_state (fun () ->
     if !_lodge_manual_tick_running then
       false
     else begin

--- a/lib/lodge_heartbeat.mli
+++ b/lib/lodge_heartbeat.mli
@@ -127,11 +127,16 @@ type lodge_status = {
   ls_total_ticks: int;
   ls_total_checkins: int;
   ls_last_result: heartbeat_result option;
+  ls_manual_tick_running: bool;
   ls_active_self_heartbeats: string list;
 }
 
 val lodge_status : unit -> lodge_status
 val lodge_status_to_json : lodge_status -> Yojson.Safe.t
+val record_tick_result : heartbeat_result -> unit
+
+val trigger_heartbeat_async :
+  sw:Eio.Switch.t -> Room.config -> [ `Started | `Already_running ]
 
 [@@@warning "-32"]
 (** {1 REST API — Lodge Agent management} *)

--- a/lib/operator_control.ml
+++ b/lib/operator_control.ml
@@ -1542,13 +1542,13 @@ let lodge_tick_result_json (result : Lodge_heartbeat.heartbeat_result) =
       ("checkins", `List (List.map checkin_json result.checkins));
     ]
 
-let lodge_tick_ack_json ~mode ~status =
+let lodge_tick_ack_json ~mode ~status ~manual_tick_running =
   `Assoc
     [
       ("status", `String status);
       ("mode", `String mode);
       ("quiet_hours_overridden", `Bool true);
-      ("manual_tick_running", `Bool true);
+      ("manual_tick_running", `Bool manual_tick_running);
     ]
 
 let tool_keeper_ctx (ctx : 'a context) : _ Tool_keeper.context =
@@ -1690,7 +1690,9 @@ let execute_action (ctx : 'a context) (request : action_request) :
               (`Assoc
                 [
                   ("delegated_tool", `String "lodge_tick");
-                  ("result", lodge_tick_ack_json ~mode:"sync" ~status:"already_running");
+                  ( "result",
+                    lodge_tick_ack_json ~mode:"sync" ~status:"already_running"
+                      ~manual_tick_running:true );
                 ])
           else
             let result = Lodge_heartbeat.trigger_heartbeat ctx.config in
@@ -1710,7 +1712,9 @@ let execute_action (ctx : 'a context) (request : action_request) :
             (`Assoc
               [
                 ("delegated_tool", `String "lodge_tick");
-                ("result", lodge_tick_ack_json ~mode:"async" ~status);
+                ( "result",
+                  lodge_tick_ack_json ~mode:"async" ~status
+                    ~manual_tick_running:(status = "accepted" || status = "already_running") );
               ])
   | "team_turn" ->
       let* () = validate_target_type "team_session" request in

--- a/lib/operator_control.ml
+++ b/lib/operator_control.ml
@@ -1542,6 +1542,15 @@ let lodge_tick_result_json (result : Lodge_heartbeat.heartbeat_result) =
       ("checkins", `List (List.map checkin_json result.checkins));
     ]
 
+let lodge_tick_ack_json ~mode ~status =
+  `Assoc
+    [
+      ("status", `String status);
+      ("mode", `String mode);
+      ("quiet_hours_overridden", `Bool true);
+      ("manual_tick_running", `Bool true);
+    ]
+
 let tool_keeper_ctx (ctx : 'a context) : _ Tool_keeper.context =
   { config = ctx.config; sw = ctx.sw; clock = ctx.clock }
 
@@ -1674,13 +1683,35 @@ let execute_action (ctx : 'a context) (request : action_request) :
                   ] );
             ])
       else
-        let result = Lodge_heartbeat.trigger_heartbeat ctx.config in
-        Ok
-          (`Assoc
-            [
-              ("delegated_tool", `String "lodge_tick");
-              ("result", lodge_tick_result_json result);
-            ])
+        let wait_for_result = get_bool request.payload "wait" false in
+        if wait_for_result then
+          if (Lodge_heartbeat.lodge_status ()).ls_manual_tick_running then
+            Ok
+              (`Assoc
+                [
+                  ("delegated_tool", `String "lodge_tick");
+                  ("result", lodge_tick_ack_json ~mode:"sync" ~status:"already_running");
+                ])
+          else
+            let result = Lodge_heartbeat.trigger_heartbeat ctx.config in
+            Ok
+              (`Assoc
+                [
+                  ("delegated_tool", `String "lodge_tick");
+                  ("result", lodge_tick_result_json result);
+                ])
+        else
+          let status =
+            match Lodge_heartbeat.trigger_heartbeat_async ~sw:ctx.sw ctx.config with
+            | `Started -> "accepted"
+            | `Already_running -> "already_running"
+          in
+          Ok
+            (`Assoc
+              [
+                ("delegated_tool", `String "lodge_tick");
+                ("result", lodge_tick_ack_json ~mode:"async" ~status);
+              ])
   | "team_turn" ->
       let* () = validate_target_type "team_session" request in
       let* session_id = require_target_id request in

--- a/lib/tool_operator.ml
+++ b/lib/tool_operator.ml
@@ -107,9 +107,9 @@ let action_schema ~remote =
     name = "masc_operator_action";
     description =
       if remote then
-        "Preview or run a structured operator action. Use this when you need to broadcast, steer a team session, pause a room, or message a keeper through the remote operator surface."
+        "Preview or run a structured operator action. Use this when you need to broadcast, steer a team session, pause a room, or message a keeper through the remote operator surface. For lodge_tick, the default is async accepted; set payload.wait=true to block for the full result."
       else
-        "Run a structured operator action against the room, a team session, or a keeper. Use this when you need guided control with preview-confirm safety for disruptive actions.";
+        "Run a structured operator action against the room, a team session, or a keeper. Use this when you need guided control with preview-confirm safety for disruptive actions. For lodge_tick, the default is async accepted; set payload.wait=true to block for the full result.";
     input_schema =
       `Assoc
         [

--- a/test/test_dashboard.ml
+++ b/test/test_dashboard.ml
@@ -142,6 +142,7 @@ let test_lodge_status_json_has_runtime_fields () =
   Alcotest.(check bool) "quiet_active present" true (has_key "quiet_active");
   Alcotest.(check bool) "last_tick_ago_s present" true (has_key "last_tick_ago_s");
   Alcotest.(check bool) "last_tick_result present" true (has_key "last_tick_result");
+  Alcotest.(check bool) "manual_tick_running present" true (has_key "manual_tick_running");
   Alcotest.(check bool) "last_skip_reason present" true (has_key "last_skip_reason");
   Alcotest.(check bool) "last_tick_ago string" true (member "last_tick_ago" json <> `Null)
 

--- a/test/test_operator_control.ml
+++ b/test/test_operator_control.ml
@@ -602,6 +602,40 @@ let test_keeper_status_exposes_summary_and_recoverable () =
       Alcotest.(check bool) "summary present" true
         (String.length Yojson.Safe.Util.(diagnostic |> member "summary" |> to_string) > 0))
 
+let test_manual_lodge_tick_updates_observable_state () =
+  let base_dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base_dir)
+    (fun () ->
+      let before = Lodge_heartbeat.lodge_status () in
+      let result : Lodge_heartbeat.heartbeat_result =
+        {
+          timestamp = Unix.gettimeofday ();
+          current_hour = 11;
+          agents_checked = 2;
+          checkins =
+            [
+              ( "historian",
+                Lodge_heartbeat.ManualTrigger,
+                Lodge_heartbeat.Passed "no valuable contribution" );
+            ];
+          agents_woken = [];
+          encounter_rolled = None;
+          activity_report = "manual test tick";
+        }
+      in
+      Lodge_heartbeat.record_tick_result result;
+      let after = Lodge_heartbeat.lodge_status () in
+      Alcotest.(check int) "manual tick increments total ticks"
+        (before.ls_total_ticks + 1) after.ls_total_ticks;
+      Alcotest.(check int) "manual tick increments total checkins"
+        (before.ls_total_checkins + List.length result.Lodge_heartbeat.checkins)
+        after.ls_total_checkins;
+      Alcotest.(check bool) "manual tick stores last result" true
+        (Option.is_some after.ls_last_result);
+      Alcotest.(check bool) "manual tick running cleared" false
+        after.ls_manual_tick_running)
+
 let () =
   Alcotest.run "Operator_control"
     [
@@ -629,6 +663,8 @@ let () =
             test_select_checkin_agents_manual_override_quiet_hours;
           Alcotest.test_case "keeper status exposes summary and recoverable" `Quick
             test_keeper_status_exposes_summary_and_recoverable;
+          Alcotest.test_case "manual lodge tick updates observable state" `Quick
+            test_manual_lodge_tick_updates_observable_state;
           Alcotest.test_case "expired confirmation rejected" `Quick
             test_confirm_rejects_expired_token;
         ] );


### PR DESCRIPTION
## Summary
- update manual lodge ticks to write observable heartbeat state just like scheduled ticks
- expose `manual_tick_running` in lodge status so `/health` can show in-flight manual ticks
- make operator `lodge_tick` return async accepted by default, with `payload.wait=true` for blocking results

## Testing
- `dune build --root . test/test_operator_control.exe test/test_dashboard.exe`
- `./_build/default/test/test_operator_control.exe`
- `./_build/default/test/test_dashboard.exe`
