### PR TITLE
Add swarm delivery runbook and harness

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ CI_TEST_TIMEOUT_SEC=1200 CI_TEST_HEARTBEAT_SEC=30 \
 - `POST /mcp`는 기본적으로 `Accept: application/json, text/event-stream`를 요구합니다.
 - 구형 클라이언트 호환이 필요할 때만 `MASC_ALLOW_LEGACY_ACCEPT=1`을 설정하세요.
 - 레거시 `/sse`, `/messages` endpoint는 deprecated 상태이며 `/mcp`로 전환이 권장됩니다.
-- 원격 감독관 표면은 `/mcp/operator`를 사용하세요. 운영 루프와 confirm 정책은 `docs/REMOTE-MCP-OPERATOR.md`, `docs/SUPERVISOR-MODE.md`에 정리돼 있습니다.
+- 원격 감독관 표면은 `/mcp/operator`를 사용하세요. 운영 루프와 confirm 정책은 `docs/REMOTE-MCP-OPERATOR.md`, `docs/SUPERVISOR-MODE.md`에, swarm-driven 구현 표준은 `docs/SWARM-DELIVERY-RUNBOOK.md`에 정리돼 있습니다.
 
 ## 기본 사용 흐름
 

--- a/bin/main_eio.ml
+++ b/bin/main_eio.ml
@@ -5689,6 +5689,11 @@ let command_plane_help_http_json () =
                 ("title", `String "Supervisor Mode");
                 ("path", `String "docs/SUPERVISOR-MODE.md");
               ];
+            `Assoc
+              [
+                ("title", `String "Swarm Delivery Runbook");
+                ("path", `String "docs/SWARM-DELIVERY-RUNBOOK.md");
+              ];
           ] );
       ( "concepts",
         `List

--- a/docs/COMMAND-PLANE-RUNBOOK.md
+++ b/docs/COMMAND-PLANE-RUNBOOK.md
@@ -156,6 +156,10 @@ Content-Type: application/json
 
 이건 benchmark canonical path가 아니다. supervised implementation path다.
 
+실제 기능 개발을 `MASC` swarm으로 굴릴 때의 delivery 표준은 별도 문서를 본다:
+
+- [SWARM-DELIVERY-RUNBOOK.md](./SWARM-DELIVERY-RUNBOOK.md)
+
 1. `masc_operator_snapshot`
 2. `masc_operator_action`
 3. `masc_operator_confirm`

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -7,6 +7,7 @@
 - CPv2 benchmark / swarm: [COMMAND-PLANE-RUNBOOK.md](./COMMAND-PLANE-RUNBOOK.md)
 - benchmark 비교 실험: [BENCHMARK-RUNBOOK.md](./BENCHMARK-RUNBOOK.md)
 - supervised team-session: [SUPERVISOR-MODE.md](./SUPERVISOR-MODE.md)
+- swarm-driven implementation delivery: [SWARM-DELIVERY-RUNBOOK.md](./SWARM-DELIVERY-RUNBOOK.md)
 
 ## 1. 서버 시작
 
@@ -66,4 +67,5 @@ curl -s http://127.0.0.1:8935/api/v1/command-plane | jq '.operations.summary'
 - [COMMAND-PLANE-RUNBOOK.md](./COMMAND-PLANE-RUNBOOK.md)
 - [BENCHMARK-RUNBOOK.md](./BENCHMARK-RUNBOOK.md)
 - [SUPERVISOR-MODE.md](./SUPERVISOR-MODE.md)
+- [SWARM-DELIVERY-RUNBOOK.md](./SWARM-DELIVERY-RUNBOOK.md)
 - [README.md](../README.md)

--- a/docs/SUPERVISOR-MODE.md
+++ b/docs/SUPERVISOR-MODE.md
@@ -6,6 +6,7 @@ Canonical benchmark / swarm path는 이 문서가 아니다.
 
 - CPv2 benchmark / swarm: [COMMAND-PLANE-RUNBOOK.md](./COMMAND-PLANE-RUNBOOK.md)
 - benchmark compare recipe: [BENCHMARK-RUNBOOK.md](./BENCHMARK-RUNBOOK.md)
+- swarm-driven implementation delivery: [SWARM-DELIVERY-RUNBOOK.md](./SWARM-DELIVERY-RUNBOOK.md)
 
 The goal is not a new autonomous control plane. The goal is a small, explicit loop that Codex or Claude Code can run safely:
 
@@ -262,6 +263,7 @@ two-worker llama batch spawn, and verifies:
 
 ## Related Docs
 
+- `docs/SWARM-DELIVERY-RUNBOOK.md`
 - `docs/REMOTE-MCP-OPERATOR.md`
 - `docs/TEAM-SESSION.md`
 - `scripts/harness_supervisor_team_session.sh`

--- a/docs/SWARM-DELIVERY-RUNBOOK.md
+++ b/docs/SWARM-DELIVERY-RUNBOOK.md
@@ -1,0 +1,150 @@
+# Swarm Delivery Runbook
+
+이 문서는 `MASC` 자체를 구현 substrate로 써서 기능 슬라이스를 계획하고 구현할 때의 표준 순서를 정리한다.
+
+핵심 원칙:
+
+- 구현 swarm의 SSOT는 `Team Session + Supervisor Mode`
+- canonical benchmark/swarm path는 여전히 `CPv2 direct`
+- model 선택은 항상 explicit
+- 기본 운영 형태는 supervised swarm
+
+관련 문서:
+
+- canonical benchmark / swarm: [COMMAND-PLANE-RUNBOOK.md](./COMMAND-PLANE-RUNBOOK.md)
+- supervised implementation loop: [SUPERVISOR-MODE.md](./SUPERVISOR-MODE.md)
+- remote operator surface: [REMOTE-MCP-OPERATOR.md](./REMOTE-MCP-OPERATOR.md)
+
+## When To Use This
+
+이 경로를 기본으로 잡는다:
+
+- 새 기능 슬라이스를 `MASC` swarm으로 실제 구현할 때
+- planner / implementer / supervisor를 분리해서 운영할 때
+- report / proof / review evidence까지 남겨야 할 때
+
+이 경로를 기본으로 잡지 않는다:
+
+- canonical CPv2 benchmark 자체를 실험할 때
+- 완전 무인 autonomous swarm을 바로 검증할 때
+
+## Default Delivery Topology
+
+기본 역할:
+
+- `supervisor`
+  - `/mcp/operator`
+  - 상태 읽기, 개입, confirm만 담당
+- `planner`
+  - `/mcp`
+  - 작업 분해와 acceptance criteria 작성
+- `implementer-a`
+  - `/mcp`
+  - runtime / backend / API
+- `implementer-b`
+  - `/mcp`
+  - docs / tests / harness
+
+기본 model policy:
+
+1. `masc_llama_models`
+2. explicit model 선택
+3. session note에 선택 근거 기록
+4. 같은 note를 `spawn_selection_note`로 각 worker에 전달
+
+## Golden Path
+
+1. `masc_set_room`
+   - repo-root room semantics를 먼저 맞춘다.
+2. `masc_join`
+   - supervisor identity를 room에 등록한다.
+3. `masc_llama_models`
+   - local `llama.cpp` inventory를 읽는다.
+4. explicit model 선택
+   - `LLAMA_SWARM_MODEL=<exact-id>`
+5. `masc_team_session_start`
+   - 목표와 orchestration policy를 가진 session을 시작한다.
+6. `masc_team_session_turn`
+   - model selection rationale을 note로 남긴다.
+7. `masc_team_session_step(spawn_batch=...)`
+   - planner / implementers를 한 번에 기동한다.
+8. `masc_operator_snapshot(view="summary")`
+9. `masc_operator_digest`
+   - health, attention, recommended actions를 읽는다.
+10. `masc_operator_action`
+    - 필요한 개입을 preview 또는 immediate로 넣는다.
+11. `masc_operator_confirm`
+    - disruptive action이면 confirm으로 실행한다.
+12. `masc_team_session_report`
+13. `masc_team_session_prove`
+14. draft PR + cross-model review evidence
+
+## Harness
+
+기본 bootstrap harness:
+
+```bash
+LLAMA_SERVER_URL=http://127.0.0.1:8085 \
+LLAMA_SWARM_MODEL=<exact-model-id-from-masc_llama_models> \
+HTTP_TIMEOUT_SEC=120 \
+./scripts/harness_swarm_delivery.sh
+```
+
+기본 출력:
+
+- `session_id`
+- `llama_swarm_model`
+- `swarm_intervention_mode`
+- `spawned_worker_roles`
+- `spawned_runtime_actors`
+- `proof_json_path`
+- `proof_md_path`
+
+### Optional Inputs
+
+- `SWARM_SESSION_GOAL`
+  - 기본 `TEAM_GOAL` override
+- `SWARM_INTERVENTION_MODE`
+  - `default` | `none`
+- `SWARM_WORKER_BATCH_JSON`
+  - worker batch를 JSON으로 직접 넘긴다
+- `SWARM_WORKER_BATCH_FILE`
+  - JSON 파일 경로로 worker batch를 넘긴다
+
+`SWARM_WORKER_BATCH_JSON` / `SWARM_WORKER_BATCH_FILE` shape:
+
+```json
+[
+  {
+    "spawn_role": "planner",
+    "spawn_prompt": "Inspect the session and leave one planning turn."
+  },
+  {
+    "spawn_role": "implementer-a",
+    "spawn_prompt": "Inspect the session and leave one implementation turn.",
+    "spawn_timeout_seconds": 120
+  }
+]
+```
+
+harness는 각 item에 다음을 자동으로 덧붙인다:
+
+- `spawn_agent="llama"`
+- `spawn_model=LLAMA_SWARM_MODEL`
+- `spawn_selection_note=<leader note>`
+
+## Acceptance
+
+이 경로를 성공으로 보는 최소 기준:
+
+- spawned worker가 own `team_turn`을 남긴다
+- `masc_operator_digest`가 session health를 읽는다
+- supervisor action이 기록되거나, no-intervention policy가 출력에 명시된다
+- `masc_team_session_report` / `masc_team_session_prove` artifact가 생성된다
+- draft PR과 cross-model review evidence가 남는다
+
+## Notes
+
+- 이 문서는 implementation substrate SSOT다.
+- benchmark canonical path는 여전히 `CPv2 direct`다.
+- worker 품질은 orchestration뿐 아니라 model/runtime 상태에도 크게 좌우된다.

--- a/scripts/harness/workload/supervisor_team_session.sh
+++ b/scripts/harness/workload/supervisor_team_session.sh
@@ -16,6 +16,8 @@ HTTP_TIMEOUT_SEC="${HTTP_TIMEOUT_SEC:-60}"
 STOP_WAIT_SEC="${STOP_WAIT_SEC:-30}"
 TEAM_GOAL="${TEAM_GOAL:-Demonstrate a full llama worker team supervised over /mcp and /mcp/operator}"
 LLAMA_SWARM_MODEL="${LLAMA_SWARM_MODEL:-}"
+SWARM_WORKER_BATCH_JSON="${SWARM_WORKER_BATCH_JSON:-}"
+SWARM_INTERVENTION_MODE="${SWARM_INTERVENTION_MODE:-default}"
 
 if ! command -v jq >/dev/null 2>&1; then
   echo "jq is required"
@@ -119,6 +121,47 @@ extract_response_error() {
 
 extract_is_error() {
   jq -r 'try (.result.isError) catch "false"'
+}
+
+default_worker_batch_json() {
+  jq -cn \
+    --arg planner_prompt "You are the planner. Inspect the active team session, then record exactly one concise planning turn with masc_team_session_turn describing task decomposition and acceptance criteria." \
+    --arg implementer_a_prompt "You are implementer-a. Inspect the active team session, then record exactly one concise implementation turn with masc_team_session_turn describing backend/runtime work." \
+    --arg implementer_b_prompt "You are implementer-b. Inspect the active team session, then record exactly one concise implementation turn with masc_team_session_turn describing docs/tests/harness work." \
+    '[
+      {spawn_role:"planner",spawn_prompt:$planner_prompt},
+      {spawn_role:"implementer-a",spawn_prompt:$implementer_a_prompt},
+      {spawn_role:"implementer-b",spawn_prompt:$implementer_b_prompt}
+    ]'
+}
+
+normalized_worker_batch_json() {
+  local batch_json="$1"
+  printf '%s' "$batch_json" | jq -c \
+    --arg model "$LLAMA_SWARM_MODEL" \
+    --arg note "$MODEL_SELECTION_NOTE" \
+    '
+      if type != "array" or length == 0 then
+        error("worker batch must be a non-empty JSON array")
+      else
+        map(
+          if (.spawn_role | type) != "string" or (.spawn_role | gsub("^\\s+|\\s+$";"")) == "" then
+            error("each worker batch item must include a non-empty spawn_role")
+          elif (.spawn_prompt | type) != "string" or (.spawn_prompt | gsub("^\\s+|\\s+$";"")) == "" then
+            error("each worker batch item must include a non-empty spawn_prompt")
+          else
+            {
+              spawn_agent: "llama",
+              spawn_model: $model,
+              spawn_role: .spawn_role,
+              spawn_selection_note: $note,
+              spawn_prompt: .spawn_prompt,
+              spawn_timeout_seconds: (.spawn_timeout_seconds // 90)
+            }
+          end
+        )
+      end
+    '
 }
 
 require_json() {
@@ -229,23 +272,14 @@ join_with_token() {
 
 spawn_llama_batch() {
   local selection_note="$1"
-  local planner_prompt="$2"
-  local implementer_a_prompt="$3"
-  local implementer_b_prompt="$4"
+  local batch_json="$2"
   local raw
   raw="$(call_tool "$MCP_URL" "$SUPERVISOR_SESSION_ID" "$SUPERVISOR_TOKEN" 30 "masc_team_session_step" "$(jq -cn \
     --arg s "$TEAM_SESSION_ID" \
-    --arg model "$LLAMA_SWARM_MODEL" \
-    --arg note "$selection_note" \
-    --arg planner_prompt "$planner_prompt" \
-    --arg implementer_a_prompt "$implementer_a_prompt" \
-    --arg implementer_b_prompt "$implementer_b_prompt" \
-    '{session_id:$s,spawn_batch:[
-      {spawn_agent:"llama",spawn_model:$model,spawn_role:"planner",spawn_selection_note:$note,spawn_prompt:$planner_prompt,spawn_timeout_seconds:90},
-      {spawn_agent:"llama",spawn_model:$model,spawn_role:"implementer-a",spawn_selection_note:$note,spawn_prompt:$implementer_a_prompt,spawn_timeout_seconds:90},
-      {spawn_agent:"llama",spawn_model:$model,spawn_role:"implementer-b",spawn_selection_note:$note,spawn_prompt:$implementer_b_prompt,spawn_timeout_seconds:90}
-    ]}')")"
+    --argjson batch "$batch_json" \
+    '{session_id:$s,spawn_batch:$batch}')")"
   require_tool_success "$raw"
+  printf '%s' "$raw" | extract_tool_result | jq -e --arg note "$selection_note" '.spawn.mode == "batch" and .spawn.count == ($expected | length) and (.spawn.results | length) == ($expected | length) and .turn == null and (.spawn.results | all(.runtime_actor != null and .spawn_selection_note == $note))' --argjson expected "$batch_json" >/dev/null
   printf '%s' "$raw"
 }
 
@@ -289,6 +323,19 @@ if ! printf '%s' "$llama_models_result" | jq -e --arg model "$LLAMA_SWARM_MODEL"
   exit 1
 fi
 MODEL_SELECTION_NOTE="[model-selection] leader selected $LLAMA_SWARM_MODEL from masc_llama_models inventory for the supervised llama worker team"
+case "$SWARM_INTERVENTION_MODE" in
+  default|none) ;;
+  *)
+    echo "FAIL: unsupported SWARM_INTERVENTION_MODE: $SWARM_INTERVENTION_MODE"
+    echo "expected one of: default, none"
+    exit 1
+    ;;
+esac
+
+if [ -z "$SWARM_WORKER_BATCH_JSON" ]; then
+  SWARM_WORKER_BATCH_JSON="$(default_worker_batch_json)"
+fi
+NORMALIZED_SWARM_BATCH_JSON="$(normalized_worker_batch_json "$SWARM_WORKER_BATCH_JSON")"
 
 printf '[5/10] start supervised team session\n'
 start_payload="$(jq -cn \
@@ -308,13 +355,7 @@ model_selection_turn_raw="$(call_tool "$MCP_URL" "$SUPERVISOR_SESSION_ID" "$SUPE
 require_tool_success "$model_selection_turn_raw"
 
 printf '[6/10] spawn full llama team\n'
-planner_prompt="You are the planner. Inspect the active team session, then record exactly one concise planning turn with masc_team_session_turn describing task decomposition and acceptance criteria."
-implementer_a_prompt="You are implementer-a. Inspect the active team session, then record exactly one concise implementation turn with masc_team_session_turn describing backend/runtime work."
-implementer_b_prompt="You are implementer-b. Inspect the active team session, then record exactly one concise implementation turn with masc_team_session_turn describing docs/tests/harness work."
-spawn_batch_raw="$(spawn_llama_batch "$MODEL_SELECTION_NOTE" "$planner_prompt" "$implementer_a_prompt" "$implementer_b_prompt")"
-printf '%s' "$spawn_batch_raw" | extract_tool_result | jq -e '.spawn.mode == "batch" and .spawn.count == 3 and (.spawn.results | length) == 3 and .turn == null' >/dev/null
-printf '%s' "$spawn_batch_raw" | extract_tool_result | jq -e '.spawn.results | all(.runtime_actor != null)' >/dev/null
-printf '%s' "$spawn_batch_raw" | extract_tool_result | jq -e --arg note "$MODEL_SELECTION_NOTE" '.spawn.results | all(.spawn_selection_note == $note)' >/dev/null
+spawn_batch_raw="$(spawn_llama_batch "$MODEL_SELECTION_NOTE" "$NORMALIZED_SWARM_BATCH_JSON")"
 
 printf '[7/10] inspect remote operator surface\n'
 tools_raw="$(jsonrpc_call "$OPERATOR_URL" "$SUPERVISOR_OP_SESSION_ID" "$SUPERVISOR_TOKEN" 4 "tools/list" '{}')"
@@ -337,30 +378,34 @@ require_tool_success "$digest_raw"
 printf '%s' "$digest_raw" | extract_tool_result | jq -e '.target_type == "team_session" and .target_id == $session and (.health | type == "string") and (.attention_items | type == "array") and (.recommended_actions | type == "array")' --arg session "$TEAM_SESSION_ID" >/dev/null
 
 printf '[8/10] supervisor immediate correction via team_note\n'
-team_note_raw="$(call_tool "$OPERATOR_URL" "$SUPERVISOR_OP_SESSION_ID" "$SUPERVISOR_TOKEN" 6 "masc_operator_action" "$(jq -cn --arg actor "$SUPERVISOR_NICKNAME" --arg s "$TEAM_SESSION_ID" '{actor:$actor,action_type:"team_note",target_id:$s,payload:{message:"[supervisor] keep the proof focused on the MCP loop"}}')")"
-require_tool_success "$team_note_raw"
-printf '%s' "$team_note_raw" | extract_tool_text | jq -e '.confirm_required == false' >/dev/null
+if [ "$SWARM_INTERVENTION_MODE" = "default" ]; then
+  team_note_raw="$(call_tool "$OPERATOR_URL" "$SUPERVISOR_OP_SESSION_ID" "$SUPERVISOR_TOKEN" 6 "masc_operator_action" "$(jq -cn --arg actor "$SUPERVISOR_NICKNAME" --arg s "$TEAM_SESSION_ID" '{actor:$actor,action_type:"team_note",target_id:$s,payload:{message:"[supervisor] keep the proof focused on the MCP loop"}}')")"
+  require_tool_success "$team_note_raw"
+  printf '%s' "$team_note_raw" | extract_tool_text | jq -e '.confirm_required == false' >/dev/null
 
-printf '[9/10] supervisor disruptive correction via preview + confirm\n'
-preview_raw="$(call_tool "$OPERATOR_URL" "$SUPERVISOR_OP_SESSION_ID" "$SUPERVISOR_TOKEN" 7 "masc_operator_action" "$(jq -cn --arg actor "$SUPERVISOR_NICKNAME" --arg s "$TEAM_SESSION_ID" '{actor:$actor,action_type:"team_task_inject",target_id:$s,payload:{title:"Capture explicit supervisor proof",description:"Add evidence that preview-confirm changed the session trajectory.",priority:1}}')")"
-require_tool_success "$preview_raw"
-CONFIRM_TOKEN="$(printf '%s' "$preview_raw" | extract_tool_text | jq -r '.confirm_token // empty')"
-if [ -z "$CONFIRM_TOKEN" ]; then
-  echo "FAIL: missing confirm token"
-  printf '%s\n' "$preview_raw"
-  exit 1
+  printf '[9/10] supervisor disruptive correction via preview + confirm\n'
+  preview_raw="$(call_tool "$OPERATOR_URL" "$SUPERVISOR_OP_SESSION_ID" "$SUPERVISOR_TOKEN" 7 "masc_operator_action" "$(jq -cn --arg actor "$SUPERVISOR_NICKNAME" --arg s "$TEAM_SESSION_ID" '{actor:$actor,action_type:"team_task_inject",target_id:$s,payload:{title:"Capture explicit supervisor proof",description:"Add evidence that preview-confirm changed the session trajectory.",priority:1}}')")"
+  require_tool_success "$preview_raw"
+  CONFIRM_TOKEN="$(printf '%s' "$preview_raw" | extract_tool_text | jq -r '.confirm_token // empty')"
+  if [ -z "$CONFIRM_TOKEN" ]; then
+    echo "FAIL: missing confirm token"
+    printf '%s\n' "$preview_raw"
+    exit 1
+  fi
+
+  snapshot_pending_raw="$(call_tool "$OPERATOR_URL" "$SUPERVISOR_OP_SESSION_ID" "$SUPERVISOR_TOKEN" 8 "masc_operator_snapshot" "$(jq -cn --arg actor "$SUPERVISOR_NICKNAME" '{actor:$actor,view:"full"}')")"
+  require_tool_success "$snapshot_pending_raw"
+  printf '%s' "$snapshot_pending_raw" | extract_tool_result | jq -e '.pending_confirms | length == 1' >/dev/null
+
+  confirm_raw="$(call_tool "$OPERATOR_URL" "$SUPERVISOR_OP_SESSION_ID" "$SUPERVISOR_TOKEN" 9 "masc_operator_confirm" "$(jq -cn --arg actor "$SUPERVISOR_NICKNAME" --arg token "$CONFIRM_TOKEN" '{actor:$actor,confirm_token:$token}')")"
+  require_tool_success "$confirm_raw"
+
+  snapshot_after_confirm_raw="$(call_tool "$OPERATOR_URL" "$SUPERVISOR_OP_SESSION_ID" "$SUPERVISOR_TOKEN" 12 "masc_operator_snapshot" "$(jq -cn --arg actor "$SUPERVISOR_NICKNAME" '{actor:$actor,view:"full"}')")"
+  require_tool_success "$snapshot_after_confirm_raw"
+  printf '%s' "$snapshot_after_confirm_raw" | extract_tool_result | jq -e '.pending_confirms | length == 0' >/dev/null
+else
+  printf '[9/10] supervisor intervention skipped by policy (%s)\n' "$SWARM_INTERVENTION_MODE"
 fi
-
-snapshot_pending_raw="$(call_tool "$OPERATOR_URL" "$SUPERVISOR_OP_SESSION_ID" "$SUPERVISOR_TOKEN" 8 "masc_operator_snapshot" "$(jq -cn --arg actor "$SUPERVISOR_NICKNAME" '{actor:$actor,view:"full"}')")"
-require_tool_success "$snapshot_pending_raw"
-printf '%s' "$snapshot_pending_raw" | extract_tool_result | jq -e '.pending_confirms | length == 1' >/dev/null
-
-confirm_raw="$(call_tool "$OPERATOR_URL" "$SUPERVISOR_OP_SESSION_ID" "$SUPERVISOR_TOKEN" 9 "masc_operator_confirm" "$(jq -cn --arg actor "$SUPERVISOR_NICKNAME" --arg token "$CONFIRM_TOKEN" '{actor:$actor,confirm_token:$token}')")"
-require_tool_success "$confirm_raw"
-
-snapshot_after_confirm_raw="$(call_tool "$OPERATOR_URL" "$SUPERVISOR_OP_SESSION_ID" "$SUPERVISOR_TOKEN" 12 "masc_operator_snapshot" "$(jq -cn --arg actor "$SUPERVISOR_NICKNAME" '{actor:$actor,view:"full"}')")"
-require_tool_success "$snapshot_after_confirm_raw"
-printf '%s' "$snapshot_after_confirm_raw" | extract_tool_result | jq -e '.pending_confirms | length == 0' >/dev/null
 
 printf '[10/10] stop session and prove evidence\n'
 stop_raw="$(call_tool "$MCP_URL" "$SUPERVISOR_SESSION_ID" "$SUPERVISOR_TOKEN" 13 "masc_team_session_stop" "$(jq -cn --arg s "$TEAM_SESSION_ID" '{session_id:$s,reason:"supervisor_harness_complete",generate_report:true}')")"
@@ -423,6 +468,9 @@ proof_md_path="$(printf '%s' "$prove_result" | jq -r '.proof_md_path // empty')"
 
 printf 'session_id=%s\n' "$TEAM_SESSION_ID"
 printf 'llama_swarm_model=%s\n' "$LLAMA_SWARM_MODEL"
+printf 'swarm_intervention_mode=%s\n' "$SWARM_INTERVENTION_MODE"
+printf 'spawned_worker_roles=%s\n' "$(printf '%s' "$spawn_batch_raw" | extract_tool_result | jq -c '[.spawn.results[] | .spawn_role]')"
+printf 'spawned_runtime_actors=%s\n' "$(printf '%s' "$spawn_batch_raw" | extract_tool_result | jq -c '[.spawn.results[] | .runtime_actor]')"
 printf 'unique_turn_actors=%s\n' "$unique_turn_actors"
 printf 'unique_spawned_llama_actors=%s\n' "$unique_spawned_llama_actors"
 printf 'proof_json_path=%s\n' "$proof_json_path"

--- a/scripts/harness/workload/swarm_delivery.sh
+++ b/scripts/harness/workload/swarm_delivery.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+export HTTP_TIMEOUT_SEC="${HTTP_TIMEOUT_SEC:-120}"
+export STOP_WAIT_SEC="${STOP_WAIT_SEC:-45}"
+
+if [ -n "${SWARM_SESSION_GOAL:-}" ]; then
+  export TEAM_GOAL="$SWARM_SESSION_GOAL"
+fi
+
+if [ -n "${SWARM_WORKER_BATCH_FILE:-}" ] && [ -z "${SWARM_WORKER_BATCH_JSON:-}" ]; then
+  if [ ! -f "$SWARM_WORKER_BATCH_FILE" ]; then
+    echo "FAIL: SWARM_WORKER_BATCH_FILE not found: $SWARM_WORKER_BATCH_FILE"
+    exit 1
+  fi
+  export SWARM_WORKER_BATCH_JSON
+  SWARM_WORKER_BATCH_JSON="$(cat "$SWARM_WORKER_BATCH_FILE")"
+fi
+
+exec "${SCRIPT_DIR}/supervisor_team_session.sh" "$@"

--- a/scripts/harness_swarm_delivery.sh
+++ b/scripts/harness_swarm_delivery.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+exec "${SCRIPT_DIR}/harness/workload/swarm_delivery.sh" "$@"


### PR DESCRIPTION
## Summary
- add a swarm delivery runbook that standardizes MASC team-session + supervisor mode as the implementation substrate
- add a dedicated `harness_swarm_delivery.sh` entrypoint with explicit model, worker batch, and intervention-mode inputs
- wire the new runbook into discovery surfaces so users can find the delivery path from README, Quick Start, supervisor docs, and command-plane help

## Validation
- `bash -n scripts/harness_swarm_delivery.sh scripts/harness/workload/swarm_delivery.sh scripts/harness/workload/supervisor_team_session.sh`
- `dune build --root . @default`
- `env LLAMA_SERVER_URL=http://127.0.0.1:8085 LLAMA_SWARM_MODEL=qwen3.5-35b-a3b-ud-q8-xl ./scripts/harness_swarm_delivery.sh`
- `env LLAMA_SERVER_URL=http://127.0.0.1:8085 LLAMA_SWARM_MODEL=qwen3.5-35b-a3b-ud-q8-xl SWARM_INTERVENTION_MODE=none SWARM_WORKER_BATCH_FILE=/tmp/swarm-batch.json ./scripts/harness_swarm_delivery.sh`
