### PR TITLE
LLM-native Lodge decisions

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -71,6 +71,7 @@
    log
    lodge_cascade
    lodge_atmosphere
+   lodge_decision
    lodge_heartbeat
    lodge_memory
    lodge_memory_gc

--- a/lib/lodge_decision.ml
+++ b/lib/lodge_decision.ml
@@ -1,0 +1,331 @@
+open Yojson.Safe.Util
+
+type action =
+  | Post
+  | Comment
+  | Upvote
+  | Skip
+
+type reaction = {
+  post_id : string;
+  reaction : Lodge_reaction.reaction_type;
+  confidence : float;
+  reason : string option;
+}
+
+type choice = {
+  action : action;
+  target_post_id : string option;
+  content : string option;
+  reason : string;
+  confidence : float;
+}
+
+type outcome = {
+  reactions : reaction list;
+  choice : choice;
+}
+
+let ( let* ) value f = match value with Ok x -> f x | Error _ as err -> err
+
+let action_to_string = function
+  | Post -> "post"
+  | Comment -> "comment"
+  | Upvote -> "upvote"
+  | Skip -> "skip"
+
+let action_of_string = function
+  | "post" -> Ok Post
+  | "comment" -> Ok Comment
+  | "upvote" -> Ok Upvote
+  | "skip" -> Ok Skip
+  | other -> Error (Printf.sprintf "unsupported action: %s" other)
+
+let trim_opt = function
+  | None -> None
+  | Some text ->
+      let trimmed = String.trim text in
+      if trimmed = "" then None else Some trimmed
+
+let extract_json_object (response : string) : (string, string) result =
+  let trimmed = String.trim response in
+  try
+    let start_idx = String.index trimmed '{' in
+    let end_idx = String.rindex trimmed '}' in
+    if end_idx < start_idx then Error "missing JSON object terminator"
+    else Ok (String.sub trimmed start_idx (end_idx - start_idx + 1))
+  with Not_found -> Error "missing JSON object"
+
+let parse_confidence json =
+  match json with
+  | `Float f -> Ok f
+  | `Int i -> Ok (float_of_int i)
+  | _ -> Error "confidence must be numeric"
+
+let validate_confidence confidence =
+  if confidence < 0.0 || confidence > 1.0 then
+    Error "confidence must be between 0.0 and 1.0"
+  else
+    Ok confidence
+
+let parse_reason json =
+  match json with
+  | `String s ->
+      let trimmed = String.trim s in
+      if trimmed = "" then Error "reason must be non-empty" else Ok trimmed
+  | _ -> Error "reason must be a string"
+
+let parse_reaction json =
+  let post_id =
+    match json |> member "post_id" with
+    | `String s ->
+        let trimmed = String.trim s in
+        if trimmed = "" then Error "reaction.post_id must be non-empty" else Ok trimmed
+    | _ -> Error "reaction.post_id must be a string"
+  in
+  match post_id with
+  | Error _ as err -> err
+  | Ok post_id ->
+      let reaction_str =
+        match json |> member "reaction" with
+        | `String s -> Ok (String.lowercase_ascii (String.trim s))
+        | _ -> Error "reaction.reaction must be a string"
+      in
+      let confidence =
+        match parse_confidence (json |> member "confidence") with
+        | Ok value -> validate_confidence value
+        | Error _ as err -> err
+      in
+      let reason =
+        json |> member "reason" |> to_string_option |> trim_opt
+      in
+      match reaction_str, confidence with
+      | Ok reaction_name, Ok confidence -> (
+          match Lodge_reaction.reaction_type_of_string reaction_name with
+          | Ok reaction -> Ok { post_id; reaction; confidence; reason }
+          | Error err ->
+              Error (Printf.sprintf "invalid reaction for %s: %s" post_id err))
+      | Error err, _ -> Error err
+      | _, Error err -> Error err
+
+let parse_choice json =
+  let action =
+    match json |> member "action" with
+    | `String s -> action_of_string (String.lowercase_ascii (String.trim s))
+    | _ -> Error "decision.action must be a string"
+  in
+  let target_post_id =
+    json |> member "target_post_id" |> to_string_option |> trim_opt
+  in
+  let content =
+    json |> member "content" |> to_string_option |> trim_opt
+  in
+  let reason = parse_reason (json |> member "reason") in
+  let confidence =
+    match parse_confidence (json |> member "confidence") with
+    | Ok value -> validate_confidence value
+    | Error _ as err -> err
+  in
+  match action, reason, confidence with
+  | Ok action, Ok reason, Ok confidence ->
+      Ok { action; target_post_id; content; reason; confidence }
+  | Error err, _, _ -> Error err
+  | _, Error err, _ -> Error err
+  | _, _, Error err -> Error err
+
+let validate_choice ~allowed_post_ids ~allow_post (choice : choice) =
+  let post_id_allowed post_id =
+    List.exists (String.equal post_id) allowed_post_ids
+  in
+  let require_content () =
+    match choice.content with
+    | Some content when String.trim content <> "" -> Ok ()
+    | _ -> Error "content is required for this action"
+  in
+  let require_target () =
+    match choice.target_post_id with
+    | Some post_id when post_id_allowed post_id -> Ok post_id
+    | Some post_id ->
+        Error (Printf.sprintf "target_post_id %s is not in the candidate set" post_id)
+    | None -> Error "target_post_id is required for this action"
+  in
+  match choice.action with
+  | Post ->
+      if not allow_post then Error "post action is not allowed in this context"
+      else
+        let* () = require_content () in
+        Ok { choice with target_post_id = None }
+  | Comment ->
+      let* target_post_id = require_target () in
+      let* () = require_content () in
+      Ok { choice with target_post_id = Some target_post_id }
+  | Upvote ->
+      let* target_post_id = require_target () in
+      Ok { choice with target_post_id = Some target_post_id; content = None }
+  | Skip -> Ok { choice with target_post_id = None; content = None }
+
+let validate_reactions ~allowed_post_ids (reactions : reaction list) =
+  let seen = Hashtbl.create (List.length reactions) in
+  let validate_one (reaction : reaction) =
+    if not (List.exists (String.equal reaction.post_id) allowed_post_ids) then
+      Error
+        (Printf.sprintf "reaction post_id %s is not in the candidate set" reaction.post_id)
+    else if Hashtbl.mem seen reaction.post_id then
+      Error (Printf.sprintf "duplicate reaction for %s" reaction.post_id)
+    else (
+      Hashtbl.add seen reaction.post_id ();
+      Ok ())
+  in
+  let rec loop = function
+    | [] ->
+        let missing =
+          List.filter (fun post_id -> not (Hashtbl.mem seen post_id)) allowed_post_ids
+        in
+        if missing <> [] then
+          Error
+            (Printf.sprintf "missing reactions for: %s"
+               (String.concat ", " missing))
+        else
+          Ok reactions
+    | reaction :: rest ->
+        let* () = validate_one reaction in
+        loop rest
+  in
+  loop reactions
+
+let single_reaction_prompt ~agent_name ~agent_prompt ~interests ~post_id ~content
+    ~language_instruction =
+  let interests_line =
+    match interests with
+    | [] -> ""
+    | items ->
+        Printf.sprintf "\nCurrent interests: %s"
+          (String.concat ", " items)
+  in
+  Printf.sprintf
+    {|You are Lodge agent %s.
+
+Agent identity:
+%s%s
+
+Decide exactly one action for the target post below.
+Allowed actions: "comment", "upvote", "skip"
+Return JSON only. No markdown. No code fences.
+
+Required JSON shape:
+{
+  "action": "comment|upvote|skip",
+  "target_post_id": "%s",
+  "content": "required when action=comment",
+  "reason": "why this action fits your identity and the post",
+  "confidence": 0.0
+}
+
+Rules:
+- target_post_id must stay "%s"
+- If action is comment, content must be concrete and add value in 1-4 sentences
+- If action is upvote or skip, omit content or set it to empty
+- %s
+
+Target post:
+%s|}
+    agent_name agent_prompt interests_line post_id post_id
+    (if String.trim language_instruction = "" then "Write naturally."
+     else language_instruction)
+    content
+
+let batch_decision_prompt ~agent_name ~identity_prompt ~posts ~extra_context ~allow_post
+    =
+  let posts_section =
+    match posts with
+    | [] -> "(no recent posts)"
+    | items ->
+        items
+        |> List.mapi (fun idx (post_id, author, content) ->
+               Printf.sprintf "[Post %d]\nid=%s\nauthor=%s\ncontent=%s" (idx + 1)
+                 post_id author content)
+        |> String.concat "\n\n"
+  in
+  let action_choices =
+    if allow_post then "\"post\", \"comment\", \"upvote\", \"skip\""
+    else "\"comment\", \"upvote\", \"skip\""
+  in
+  let extra_context =
+    match trim_opt extra_context with
+    | Some text -> "\n\nAdditional context:\n" ^ text
+    | None -> ""
+  in
+  Printf.sprintf
+    {|You are Lodge agent %s.
+
+Identity context:
+%s%s
+
+Review the candidate posts and make one final decision.
+Return JSON only. No markdown. No code fences.
+
+Required JSON shape:
+{
+  "reactions": [
+    {
+      "post_id": "candidate post id",
+      "reaction": "upvote|pass|comment_intent|skip",
+      "confidence": 0.0,
+      "reason": "short rationale"
+    }
+  ],
+  "decision": {
+    "action": %s,
+    "target_post_id": "required for comment/upvote",
+    "content": "required for post/comment",
+    "reason": "why this is the best next action",
+    "confidence": 0.0
+  }
+}
+
+Rules:
+- React to every listed post exactly once
+- decision.action must be one of %s
+- If decision.action is comment or upvote, target_post_id must match a listed post
+- If decision.action is comment or post, content must be non-empty and concrete
+- If there are no candidate posts, reactions must be []
+- If nothing is worth doing, choose "skip" with an explicit reason
+
+Candidate posts:
+%s|}
+    agent_name identity_prompt extra_context action_choices action_choices posts_section
+
+let parse_single_choice ~post_id response =
+  let* json_text = extract_json_object response in
+  let* json =
+    try Ok (Yojson.Safe.from_string json_text)
+    with Yojson.Json_error msg -> Error (Printf.sprintf "invalid JSON: %s" msg)
+  in
+  let* choice = parse_choice json in
+  validate_choice ~allowed_post_ids:[ post_id ] ~allow_post:false choice
+
+let parse_batch_outcome ~allowed_post_ids ~allow_post response =
+  let* json_text = extract_json_object response in
+  let* json =
+    try Ok (Yojson.Safe.from_string json_text)
+    with Yojson.Json_error msg -> Error (Printf.sprintf "invalid JSON: %s" msg)
+  in
+  let reactions =
+    match json |> member "reactions" with
+    | `List items ->
+        let rec loop acc = function
+          | [] -> Ok (List.rev acc)
+          | item :: rest ->
+              let* parsed = parse_reaction item in
+              loop (parsed :: acc) rest
+        in
+        loop [] items
+    | _ -> Error "reactions must be an array"
+  in
+  let* reactions = reactions in
+  let* reactions = validate_reactions ~allowed_post_ids reactions in
+  let* choice =
+    json |> member "decision" |> parse_choice
+    |> function Ok choice -> validate_choice ~allowed_post_ids ~allow_post choice | Error _ as err -> err
+  in
+  Ok { reactions; choice }

--- a/lib/lodge_decision.mli
+++ b/lib/lodge_decision.mli
@@ -1,0 +1,54 @@
+(** Structured LLM-native decision contract for Lodge actions. *)
+
+type action =
+  | Post
+  | Comment
+  | Upvote
+  | Skip
+
+type reaction = {
+  post_id : string;
+  reaction : Lodge_reaction.reaction_type;
+  confidence : float;
+  reason : string option;
+}
+
+type choice = {
+  action : action;
+  target_post_id : string option;
+  content : string option;
+  reason : string;
+  confidence : float;
+}
+
+type outcome = {
+  reactions : reaction list;
+  choice : choice;
+}
+
+val single_reaction_prompt :
+  agent_name:string ->
+  agent_prompt:string ->
+  interests:string list ->
+  post_id:string ->
+  content:string ->
+  language_instruction:string ->
+  string
+
+val batch_decision_prompt :
+  agent_name:string ->
+  identity_prompt:string ->
+  posts:(string * string * string) list ->
+  extra_context:string option ->
+  allow_post:bool ->
+  string
+
+val parse_single_choice : post_id:string -> string -> (choice, string) result
+
+val parse_batch_outcome :
+  allowed_post_ids:string list ->
+  allow_post:bool ->
+  string ->
+  (outcome, string) result
+
+val action_to_string : action -> string

--- a/lib/lodge_heartbeat.ml
+++ b/lib/lodge_heartbeat.ml
@@ -701,6 +701,14 @@ and agent_action =
   | ActionUpvote of string         (** post_id *)
   | ActionSkip
 
+type llm_decision_outcome = {
+  action : agent_action;
+  reason : string;
+  confidence : float;
+  llm_used : string option;
+  decision_failure_reason : string option;
+}
+
 type heartbeat_result = {
   timestamp: float;
   current_hour: int;
@@ -2121,45 +2129,20 @@ let run_heartbeat_llm_traced ~agent_name ~phase ~prompt =
     };
   cascade_result
 
-type social_candidate = {
-  post : Board.post;
-  reaction : Lodge_reaction.batch_reaction;
-}
-
-type action_plan =
-  | PlannedAction of agent_action
-  | NoAction of string
-
 let trigger_allows_post = function
   | Scheduled | ManualTrigger -> true
   | ContentAlert _ | Mentioned _ -> false
 
-let candidate_rank (candidate : social_candidate) =
-  let reaction_bias =
-    match candidate.reaction.reaction with
-    | Lodge_reaction.CommentIntent -> 1
-    | Lodge_reaction.Upvote -> 0
-    | Lodge_reaction.Pass | Lodge_reaction.Skip -> -1
-  in
-  (candidate.reaction.confidence, reaction_bias)
-
-let pick_social_candidate ~agent_name ~(candidates : social_candidate list) =
-  let threshold = Lodge_reaction.calibrated_threshold ~agent_name ~base_threshold:0.6 in
-  let sorted =
-    candidates
-    |> List.filter (fun candidate ->
-           match candidate.reaction.reaction with
-           | Lodge_reaction.CommentIntent | Lodge_reaction.Upvote ->
-               candidate.reaction.confidence >= threshold
-           | Lodge_reaction.Pass | Lodge_reaction.Skip -> false)
-    |> List.sort (fun left right ->
-           match Float.compare (fst (candidate_rank right)) (fst (candidate_rank left)) with
-           | 0 -> compare (snd (candidate_rank right)) (snd (candidate_rank left))
-           | order -> order)
-  in
-  match sorted with
-  | candidate :: _ -> Some candidate
-  | [] -> None
+let action_of_choice (choice : Lodge_decision.choice) : (agent_action, string) result =
+  match (choice.action, choice.target_post_id, choice.content) with
+  | Lodge_decision.Post, _, Some content -> Ok (ActionPost content)
+  | Lodge_decision.Comment, Some post_id, Some content ->
+      Ok (ActionComment (post_id, content))
+  | Lodge_decision.Upvote, Some post_id, _ -> Ok (ActionUpvote post_id)
+  | Lodge_decision.Skip, _, _ -> Ok ActionSkip
+  | Lodge_decision.Post, _, _ -> Error "post choice missing content"
+  | Lodge_decision.Comment, _, _ -> Error "comment choice missing target or content"
+  | Lodge_decision.Upvote, _, _ -> Error "upvote choice missing target"
 
 (** Ask LLM to decide what action to take *)
 let decide_agent_action ~agent_name ~trigger ~trigger_reason ~recent_posts =
@@ -2181,75 +2164,82 @@ let decide_agent_action ~agent_name ~trigger ~trigger_reason ~recent_posts =
   in
   let tom_context = tom_context_for_posts ~agent_name sorted_posts in
   let extra_context =
-    if String.trim tom_context = "" then None else Some tom_context
+    let pieces =
+      [ Some ("Trigger: " ^ trigger_reason)
+      ; (if String.trim tom_context = "" then None else Some tom_context)
+      ]
+      |> List.filter_map Fun.id
+    in
+    match pieces with
+    | [] -> None
+    | xs -> Some (String.concat "\n\n" xs)
   in
-  let maybe_post_action ~reason =
-    if trigger_allows_post trigger then
-      match generate_agent_content ~agent_name ~context:trigger_reason ~action_type:(`Post trigger_reason) with
-      | Some content -> PlannedAction (ActionPost content)
-      | None -> NoAction "post_generation_failed"
-    else
-      NoAction reason
+  let prompt =
+    Lodge_decision.batch_decision_prompt
+      ~agent_name
+      ~identity_prompt:
+        (Lodge_reaction.generate_identity_prompt signature ~static_traits)
+      ~posts:prompt_posts
+      ~extra_context
+      ~allow_post:(trigger_allows_post trigger)
   in
-  if prompt_posts = [] then
-    maybe_post_action ~reason:"no_relevant_posts"
-  else
-    let prompt =
-      Lodge_reaction.batch_reaction_prompt
-        ~agent_name ~posts:prompt_posts ~signature ~static_traits ~extra_context
-    in
-    let cascade_result =
-      run_heartbeat_llm_traced ~agent_name ~phase:"reaction_batch" ~prompt
-    in
-    let response = cascade_result.Lodge_cascade.response in
-    let parsed = Lodge_reaction.parse_batch_reactions response in
-    let reactions_by_post = Hashtbl.create (List.length parsed) in
-    List.iter
-      (fun (reaction : Lodge_reaction.batch_reaction) ->
-        Hashtbl.replace reactions_by_post reaction.post_id reaction)
-      parsed;
-    let candidates =
-      sorted_posts
-      |> List.map (fun (post : Board.post) ->
-             let post_id = Board.Post_id.to_string post.id in
-             let reaction =
-               match Hashtbl.find_opt reactions_by_post post_id with
-               | Some reaction -> reaction
-               | None ->
-                   {
-                     Lodge_reaction.post_id;
-                     reaction = Lodge_reaction.Pass;
-                     confidence = 0.0;
-                     reason = Some "unparsed";
-                   }
-             in
-             Lodge_reaction.record_reaction
-               ~agent_name
-               ~post_id
-               ~post_author:(Board.Agent_id.to_string post.author)
-               ~post_content:post.content
-               ~reaction:reaction.reaction
-               ~confidence:reaction.confidence
-               ?reason:reaction.reason
-               ();
-             { post; reaction })
-    in
-    let no_candidate_reason =
-      if parsed = [] then "unparsed_batch" else "below_threshold"
-    in
-    match pick_social_candidate ~agent_name ~candidates with
-    | Some { post; reaction = { reaction = Lodge_reaction.Upvote; _ } } ->
-        PlannedAction (ActionUpvote (Board.Post_id.to_string post.id))
-    | Some { post; reaction = { reaction = Lodge_reaction.CommentIntent; _ } } ->
-        (match
-           generate_agent_content
-             ~agent_name
-             ~context:trigger_reason
-             ~action_type:(`Comment post.content)
-         with
-         | Some content -> PlannedAction (ActionComment (Board.Post_id.to_string post.id, content))
-         | None -> NoAction "comment_generation_failed")
-    | _ -> maybe_post_action ~reason:no_candidate_reason
+  let cascade_result =
+    run_heartbeat_llm_traced ~agent_name ~phase:"lodge_decision" ~prompt
+  in
+  let llm_used = Some cascade_result.Lodge_cascade.llm_used in
+  let response = cascade_result.Lodge_cascade.response in
+  match
+    Lodge_decision.parse_batch_outcome
+      ~allowed_post_ids:(List.map (fun (post_id, _, _) -> post_id) prompt_posts)
+      ~allow_post:(trigger_allows_post trigger)
+      response
+  with
+  | Error reason ->
+      {
+        action = ActionSkip;
+        reason = "decision error: " ^ reason;
+        confidence = 0.0;
+        llm_used;
+        decision_failure_reason = Some reason;
+      }
+  | Ok outcome ->
+      List.iter
+        (fun (reaction : Lodge_decision.reaction) ->
+          match
+            List.find_opt
+              (fun (post : Board.post) ->
+                Board.Post_id.to_string post.id = reaction.post_id)
+              sorted_posts
+          with
+          | Some post ->
+              Lodge_reaction.record_reaction
+                ~agent_name
+                ~post_id:reaction.post_id
+                ~post_author:(Board.Agent_id.to_string post.author)
+                ~post_content:post.content
+                ~reaction:reaction.reaction
+                ~confidence:reaction.confidence
+                ?reason:reaction.reason
+                ()
+          | None -> ())
+        outcome.reactions;
+      (match action_of_choice outcome.choice with
+      | Error reason ->
+          {
+            action = ActionSkip;
+            reason = "decision error: " ^ reason;
+            confidence = 0.0;
+            llm_used;
+            decision_failure_reason = Some reason;
+          }
+      | Ok action ->
+          {
+            action;
+            reason = outcome.choice.reason;
+            confidence = outcome.choice.confidence;
+            llm_used;
+            decision_failure_reason = None;
+          })
 
 (** Execute the decided action *)
 let action_summary = function
@@ -2600,22 +2590,24 @@ let tick ~ignore_quiet_hours ~config ~pending_triggers =
       (name, trigger, Skipped "agent unhealthy (circuit breaker open)")
     else begin
       let trigger_reason = string_of_trigger trigger in
-      let result =
-        match decide_agent_action ~agent_name:name ~trigger ~trigger_reason ~recent_posts with
-        | NoAction reason -> Passed reason
-        | PlannedAction action ->
-            (try
-               let outcome = execute_agent_action ~agent_name:name ~action in
-               (match outcome with
-                | Acted _ -> Agent_health.record_success ~agent_name:name
-                | Passed _ | Skipped _ -> ());
-               outcome
-             with exn ->
-               let err = Printexc.to_string exn in
-               Agent_health.record_failure ~agent_name:name ~reason:err;
-               Printf.printf "[lodge] Agent %s action failed: %s\n%!" name err;
-               Skipped (Printf.sprintf "action_failed:%s" err))
+      let decision =
+        decide_agent_action ~agent_name:name ~trigger ~trigger_reason ~recent_posts
       in
+      let action = decision.action in
+      let result =
+        try
+          let outcome = execute_agent_action ~agent_name:name ~action in
+          (match outcome with
+           | Acted _ -> Agent_health.record_success ~agent_name:name
+           | Passed _ | Skipped _ -> ());
+          outcome
+        with exn ->
+          let err = Printexc.to_string exn in
+          Agent_health.record_failure ~agent_name:name ~reason:err;
+          Printf.printf "[lodge] Agent %s action failed: %s\n%!" name err;
+          Skipped (Printf.sprintf "action_failed:%s" err)
+      in
+      record_checkin ~agent_name:name;
       record_checkin ~agent_name:name;
       (* Record action for Thompson Sampling *)
       (match result with
@@ -2628,8 +2620,29 @@ let tick ~ignore_quiet_hours ~config ~pending_triggers =
            Lodge_selection.record_action ~agent_name:name ~action:`Skip
        | Acted { action = ActionUpvote _; _ }
        | Acted { action = ActionSkip; _ } -> ());
-
-      (name, trigger, result)
+      match result with
+      | Acted { action = ActionPost content; _ } ->
+          let summary =
+            Printf.sprintf "Posted: %s (%s, %.2f)"
+              (utf8_truncate content 40) decision.reason decision.confidence
+          in
+          (name, trigger, Acted { action = ActionPost content; summary })
+      | Acted { action = ActionComment (post_id, content); _ } ->
+          let summary =
+            Printf.sprintf "Commented on %s: %s (%s, %.2f)" post_id
+              (utf8_truncate content 30) decision.reason decision.confidence
+          in
+          (name, trigger, Acted { action = ActionComment (post_id, content); summary })
+      | Acted { action = ActionUpvote post_id; _ } ->
+          let summary =
+            Printf.sprintf "Upvoted %s (%s, %.2f)" post_id decision.reason
+              decision.confidence
+          in
+          (name, trigger, Acted { action = ActionUpvote post_id; summary })
+      | Acted { action = ActionSkip; _ } ->
+          (name, trigger, Passed decision.reason)
+      | Passed reason -> (name, trigger, Passed reason)
+      | Skipped reason -> (name, trigger, Skipped reason)
     end
   ) selected in
 
@@ -2718,20 +2731,15 @@ let make_lodge_tick_consumer ~config ~last_tick_time ~sw ~clock ~room_config
                 Printf.printf "[lodge] Skipping self-heartbeat for %s (unhealthy)\n%!" name
               else begin
                 let trigger_reason = "self-heartbeat continuation" in
-                let planned =
+                let decision =
                   decide_agent_action ~agent_name:name ~trigger:Scheduled ~trigger_reason
                     ~recent_posts
                 in
+                let action = decision.action in
                 (try
-                  let outcome =
-                    match planned with
-                    | NoAction reason -> Passed reason
-                    | PlannedAction action ->
-                        execute_agent_action ~agent_name:name ~action
-                  in
+                  let outcome = execute_agent_action ~agent_name:name ~action in
                   (match outcome with
-                   | Acted _ ->
-                       Agent_health.record_success ~agent_name:name
+                   | Acted _ -> Agent_health.record_success ~agent_name:name
                    | Passed _ | Skipped _ -> ())
                 with exn ->
                   Agent_health.record_failure ~agent_name:name

--- a/lib/masc_mcp.ml
+++ b/lib/masc_mcp.ml
@@ -127,6 +127,7 @@ module Adaptive_thresholds = Adaptive_thresholds
 module Dashboard = Dashboard
 module Tempo = Tempo
 module Federation = Federation
+module Lodge_decision = Lodge_decision
 module Level2_config = Level2_config
 module Level4_config = Level4_config
 module Local_agent_eio = Local_agent_eio

--- a/lib/tool_lodge.ml
+++ b/lib/tool_lodge.ml
@@ -1032,22 +1032,6 @@ let get_agent_prompt name =
     | None ->
       Printf.sprintf "You are %s. (Not found in Neo4j)" name
 
-(** Get interests for agent (from Neo4j cache) *)
-let get_agent_interests_cached name =
-  match get_cached_agent name with
-  | Some c -> c.interests
-  | None -> []
-
-(** Check if content matches agent's interests *)
-let matches_agent_interest agent_name content =
-  let keywords = get_agent_interests_cached agent_name in
-  let content_lower = String.lowercase_ascii content in
-  List.exists (fun kw ->
-    let kw_lower = String.lowercase_ascii kw in
-    try ignore (Str.search_forward (Str.regexp_string kw_lower) content_lower 0); true
-    with Not_found -> false
-  ) keywords
-
 (** Format agent name with emoji badge (from Neo4j cache) *)
 let format_agent_name_dynamic name =
   match get_cached_agent name with
@@ -1097,8 +1081,20 @@ let translate_to_korean ~net text =
     | Ok translated -> String.trim translated
     | Error _ -> text  (* fallback to original *)
 
+type lodge_reaction_outcome =
+  | Delegated
+  | Comment of string
+  | Upvote
+  | Skip of string
+
+let localize_decision_content ~net (choice : Lodge_decision.choice) =
+  match (choice.action, choice.content, lodge_language) with
+  | Lodge_decision.Comment, Some content, "ko" ->
+      { choice with content = Some (translate_to_korean ~net content) }
+  | _ -> choice
+
 (** React to content with a dynamic agent (from Neo4j cache) *)
-let react_to_content ~net ?agent_name:provided_name ?post_id content =
+let react_to_content ~net ?agent_name:provided_name ~post_id content =
   let agent_name = match provided_name with
     | Some n -> n
     | None -> random_agent_name ()
@@ -1108,38 +1104,40 @@ let react_to_content ~net ?agent_name:provided_name ?post_id content =
 
   (* Get agent's existing interests for context *)
   let existing_interests = get_agent_interests ~agent_name in
-  let interests_context = if existing_interests = [] then ""
-    else Printf.sprintf "\nYour interests: %s. Connect these to your response."
-      (String.concat ", " existing_interests)
+  let prompt =
+    Lodge_decision.single_reaction_prompt
+      ~agent_name
+      ~agent_prompt:agent_desc
+      ~interests:existing_interests
+      ~post_id
+      ~content
+      ~language_instruction:(language_instruction ())
   in
-
-  let system = Printf.sprintf "/no_think\n\
-    You are a Lodge participant. %s%s\n\
-    Share your unique perspective. Be thoughtful, specific, and add value. 2-4 sentences only."
-    agent_desc interests_context in
+  let system =
+    "/no_think\nReturn valid JSON only. Do not use markdown fences."
+  in
   (* A2A delegation: emit event for external worker instead of local LLM *)
   if Env_config.LodgeV2.delegate_llm then begin
-    let action_hint = match post_id with
-      | Some pid -> Some ("COMMENT:" ^ pid)
-      | None -> Some "POST"
-    in
     A2a_tools.emit_heartbeat_task ~agent:agent_name ~prompt:system
-      ~context:(Printf.sprintf "React to this Lodge post:\n%s" content)
-      ?action_hint ();
-    Ok ""  (* Empty = delegated; caller skips comment posting *)
+      ~context:prompt ();
+    Ok Delegated
   end else
-  match smart_generate ~net ~temperature:0.8 ~num_predict:250 ~system
-    (Printf.sprintf "React to this Lodge post:\n%s\n\nYour perspective:" content) with
+  match smart_generate ~net ~temperature:0.3 ~num_predict:350 ~system prompt with
   | Error e -> Error e
   | Ok response ->
-    let final_response = match lodge_language with
-      | "ko" -> translate_to_korean ~net response
-      | _ -> response
-    in
-    let new_interests = extract_interests ~net content in
-    let _ = save_interests_to_neo4j ~agent_name new_interests in
-    let display_name = format_agent_name_dynamic agent_name in
-    Ok (Printf.sprintf "%s\n%s" display_name final_response)
+      (match Lodge_decision.parse_single_choice ~post_id response with
+       | Error e -> Error (Printf.sprintf "❌ Lodge decision: %s" e)
+       | Ok choice ->
+           let choice = localize_decision_content ~net choice in
+           let new_interests = extract_interests ~net content in
+           let _ = save_interests_to_neo4j ~agent_name new_interests in
+           match choice.action with
+           | Lodge_decision.Comment ->
+               Ok (Comment (Option.value ~default:"" choice.content))
+           | Lodge_decision.Upvote -> Ok Upvote
+           | Lodge_decision.Skip -> Ok (Skip choice.reason)
+           | Lodge_decision.Post ->
+               Error "❌ Lodge decision: post action is not allowed for reactions")
 
 (** {1 Heartbeat: Full Read → Dig → Share cycle} *)
 
@@ -1187,11 +1185,17 @@ let heartbeat ~net (args : Yojson.Safe.t) =
             List.filter_map (fun agent ->
               match react_to_content ~net ~agent_name:agent ~post_id content with
               | Error _ -> None
-              | Ok "" -> Some (Printf.sprintf "🔮 %s (delegated)" agent)
-              | Ok reaction ->
-                let args = `Assoc [("post_id", `String post_id); ("content", `String reaction); ("author", `String agent)] in
+              | Ok Delegated -> Some (Printf.sprintf "🔮 %s (delegated)" agent)
+              | Ok (Comment reaction) ->
+                let display_name = format_agent_name_dynamic agent in
+                let args = `Assoc [("post_id", `String post_id); ("content", `String (Printf.sprintf "%s\n%s" display_name reaction)); ("author", `String agent)] in
                 let (ok, _) = Tool_board.handle_tool "masc_board_comment" args in
                 if ok then Some (Printf.sprintf "💬 %s" agent) else None
+              | Ok Upvote ->
+                let vote_args = `Assoc [("post_id", `String post_id); ("voter", `String agent); ("direction", `String "up")] in
+                let (ok, _) = Tool_board.handle_tool "masc_board_vote" vote_args in
+                if ok then Some (Printf.sprintf "👍 %s" agent) else None
+              | Ok (Skip _) -> Some (Printf.sprintf "⏭️ %s" agent)
             ) (let names = get_all_agent_names () in
                if List.length names >= 2 then [List.nth names 0; List.nth names 1]
                else names)
@@ -1222,7 +1226,7 @@ let classify ~net (args : Yojson.Safe.t) =
 
     When skip_classify=true, bypasses LLM classification and directly generates
     a reaction. This significantly speeds up the process by avoiding one LLM call. *)
-let react ~net (args : Yojson.Safe.t) =
+let rec react ~net (args : Yojson.Safe.t) =
   let post_id_arg = Safe_ops.json_string ~default:"" "post_id" args in
   let agent_str = Safe_ops.json_string ~default:"random" "agent" args in
   let skip_classify = Safe_ops.json_bool ~default:true "skip_classify" args in
@@ -1251,34 +1255,39 @@ let react ~net (args : Yojson.Safe.t) =
       if skip_classify then
       match react_to_content ~net ~agent_name ~post_id clean_content with
       | Error e -> (false, Printf.sprintf "❌ Lodge: React failed [agent=%s, error=%s]" agent_name e)
-      | Ok "" -> (true, Printf.sprintf "🔮 Lodge reaction delegated for %s [agent=%s]" post_id agent_name)
-      | Ok reaction ->
+      | Ok Delegated -> (true, Printf.sprintf "🔮 Lodge reaction delegated for %s [agent=%s]" post_id agent_name)
+      | Ok (Comment reaction) ->
+        let display_name = format_agent_name_dynamic agent_name in
         let comment_args = `Assoc [
           ("post_id", `String post_id);
-          ("content", `String reaction);
+          ("content", `String (Printf.sprintf "%s\n%s" display_name reaction));
           ("author", `String agent_name);
         ] in
         let (ok, msg) = Tool_board.handle_tool "masc_board_comment" comment_args in
-        if ok then (true, Printf.sprintf "💬 Lodge reaction posted on %s:\n%s" post_id reaction)
+        if ok then (true, Printf.sprintf "💬 Lodge comment posted on %s" post_id)
         else (false, Printf.sprintf "❌ Lodge: Comment failed [post=%s, error=%s]" post_id msg)
+      | Ok Upvote ->
+        let vote_args = `Assoc [
+          ("post_id", `String post_id);
+          ("voter", `String agent_name);
+          ("direction", `String "up");
+        ] in
+        let (ok, msg) = Tool_board.handle_tool "masc_board_vote" vote_args in
+        if ok then (true, Printf.sprintf "👍 Lodge upvoted %s [agent=%s]" post_id agent_name)
+        else (false, Printf.sprintf "❌ Lodge: Upvote failed [post=%s, error=%s]" post_id msg)
+      | Ok (Skip reason) ->
+        (true, Printf.sprintf "⏭️ %s skipped %s (%s)" agent_name post_id reason)
     else
       let cls = classify_content ~net clean_content in
       match cls.category with
       | Noise -> (true, Printf.sprintf "🔇 %s classified as NOISE — no reaction" post_id)
       | Notify -> (true, Printf.sprintf "⚠️ %s classified as NOTIFY — flagged for human" post_id)
       | Review ->
-        match react_to_content ~net ~agent_name ~post_id clean_content with
-        | Error e -> (false, Printf.sprintf "❌ Lodge: React failed [agent=%s, error=%s]" agent_name e)
-        | Ok "" -> (true, Printf.sprintf "🔮 Lodge reaction delegated for %s [agent=%s]" post_id agent_name)
-        | Ok reaction ->
-          let comment_args = `Assoc [
-            ("post_id", `String post_id);
-            ("content", `String reaction);
-            ("author", `String agent_name);
-          ] in
-          let (ok, msg) = Tool_board.handle_tool "masc_board_comment" comment_args in
-          if ok then (true, Printf.sprintf "💬 Lodge reaction posted on %s:\n%s" post_id reaction)
-          else (false, Printf.sprintf "❌ Lodge: Comment failed [post=%s, error=%s]" post_id msg)
+        react ~net (`Assoc [
+          ("post_id", `String post_id);
+          ("agent", `String agent_name);
+          ("skip_classify", `Bool true);
+        ])
 
 (** {1 Full cycle: heartbeat + ONE random agent reacts} *)
 
@@ -1959,25 +1968,12 @@ let agent_patrol ~net (args : Yojson.Safe.t) =
         else
           let target_post = List.hd unreacted in
 
-          let (got_post, post_content) = Tool_board.handle_tool "masc_board_get" (`Assoc [("post_id", `String target_post)]) in
-
-          let upvote_msg =
-            if got_post && matches_agent_interest agent_name post_content then begin
-              let (_vote_ok, vote_result) = Tool_board.handle_tool "masc_board_vote" (`Assoc [
-                ("post_id", `String target_post);
-                ("voter", `String agent_name);
-                ("direction", `String "up");
-              ]) in
-              Printf.sprintf "\n👍 Upvoted (matches %s's interests): %s" agent_name vote_result
-            end else ""
-          in
-
           let (react_ok, react_msg) = react ~net (`Assoc [
             ("post_id", `String target_post);
             ("agent", `String agent_name);
           ]) in
           if react_ok then
-            (true, Printf.sprintf "💬 %s patrolled and reacted to %s:\n%s%s" agent_name target_post react_msg upvote_msg)
+            (true, Printf.sprintf "💬 %s patrolled and reacted to %s:\n%s" agent_name target_post react_msg)
           else
             (false, Printf.sprintf "❌ Lodge: Patrol failed [agent=%s, post=%s, error=%s]" agent_name target_post react_msg)
 

--- a/test/dune
+++ b/test/dune
@@ -139,6 +139,12 @@
  (modules test_lodge_reaction)
  (libraries masc_mcp alcotest str yojson unix))
 
+; Lodge_decision module tests (structured LLM decision contract)
+(test
+ (name test_lodge_decision)
+ (modules test_lodge_decision)
+ (libraries masc_mcp alcotest yojson))
+
 ; Safe_ops module tests (safe exception handling)
 (test
  (name test_safe_ops)
@@ -226,11 +232,6 @@
  (name test_lodge_memory_local)
  (modules test_lodge_memory_local)
  (libraries masc_mcp alcotest unix))
-
-(test
- (name test_lodge_decision)
- (modules test_lodge_decision)
- (libraries masc_mcp alcotest yojson))
 
 (test
  (name test_lodge_heartbeat_cleanup_coverage)

--- a/test/dune
+++ b/test/dune
@@ -228,6 +228,11 @@
  (libraries masc_mcp alcotest unix))
 
 (test
+ (name test_lodge_decision)
+ (modules test_lodge_decision)
+ (libraries masc_mcp alcotest yojson))
+
+(test
  (name test_lodge_heartbeat_cleanup_coverage)
  (modules test_lodge_heartbeat_cleanup_coverage)
  (libraries masc_mcp alcotest unix))

--- a/test/test_lodge_decision.ml
+++ b/test/test_lodge_decision.ml
@@ -1,0 +1,99 @@
+open Alcotest
+open Masc_mcp
+
+let test_parse_single_choice_comment () =
+  let response =
+    {|{"action":"comment","target_post_id":"p-123","content":"이 포스트는 구체적인 운영 팁이 있어서 바로 적용할 수 있겠어요.","reason":"실행 가능한 디테일이 있다","confidence":0.82}|}
+  in
+  match Lodge_decision.parse_single_choice ~post_id:"p-123" response with
+  | Error err -> fail err
+  | Ok choice ->
+      check string "action" "comment"
+        (Lodge_decision.action_to_string choice.action);
+      check (option string) "target" (Some "p-123") choice.target_post_id;
+      check bool "has content" true
+        (match choice.content with Some text -> String.length text > 0 | None -> false)
+
+let test_parse_single_choice_rejects_wrong_target () =
+  let response =
+    {|{"action":"upvote","target_post_id":"p-999","reason":"관심사와 맞다","confidence":0.7}|}
+  in
+  match Lodge_decision.parse_single_choice ~post_id:"p-123" response with
+  | Ok _ -> fail "expected parse failure"
+  | Error err ->
+      check bool "mentions candidate set" true
+        (String.contains err 'c' || String.length err > 0)
+
+let test_parse_batch_outcome_valid () =
+  let response =
+    {|{
+      "reactions": [
+        {"post_id":"p-1","reaction":"upvote","confidence":0.81,"reason":"실용적이다"},
+        {"post_id":"p-2","reaction":"comment_intent","confidence":0.92,"reason":"질문이 있다"}
+      ],
+      "decision": {
+        "action":"comment",
+        "target_post_id":"p-2",
+        "content":"여기서 말한 기준을 실제 운영 지표와 연결하면 더 좋겠습니다.",
+        "reason":"대화를 확장할 가치가 있다",
+        "confidence":0.91
+      }
+    }|}
+  in
+  match Lodge_decision.parse_batch_outcome ~allowed_post_ids:[ "p-1"; "p-2" ] ~allow_post:true response with
+  | Error err -> fail err
+  | Ok outcome ->
+      check int "all reactions recorded" 2 (List.length outcome.reactions);
+      check string "decision action" "comment"
+        (Lodge_decision.action_to_string outcome.choice.action)
+
+let test_parse_batch_outcome_requires_full_coverage () =
+  let response =
+    {|{
+      "reactions": [
+        {"post_id":"p-1","reaction":"upvote","confidence":0.81,"reason":"실용적이다"}
+      ],
+      "decision": {
+        "action":"skip",
+        "reason":"지금은 개입할 필요가 없다",
+        "confidence":0.55
+      }
+    }|}
+  in
+  match Lodge_decision.parse_batch_outcome ~allowed_post_ids:[ "p-1"; "p-2" ] ~allow_post:true response with
+  | Ok _ -> fail "expected coverage validation failure"
+  | Error err ->
+      check bool "mentions missing reactions" true
+        (String.length err > 0)
+
+let test_parse_batch_outcome_rejects_post_when_not_allowed () =
+  let response =
+    {|{
+      "reactions": [],
+      "decision": {
+        "action":"post",
+        "content":"새 글을 쓰자",
+        "reason":"주제를 확장해야 한다",
+        "confidence":0.7
+      }
+    }|}
+  in
+  match Lodge_decision.parse_batch_outcome ~allowed_post_ids:[] ~allow_post:false response with
+  | Ok _ -> fail "expected post disallowed failure"
+  | Error err -> check bool "post disallowed" true (String.length err > 0)
+
+let () =
+  run "Lodge decision"
+    [
+      ( "parse",
+        [
+          test_case "single comment" `Quick test_parse_single_choice_comment;
+          test_case "single rejects wrong target" `Quick
+            test_parse_single_choice_rejects_wrong_target;
+          test_case "batch valid" `Quick test_parse_batch_outcome_valid;
+          test_case "batch full coverage required" `Quick
+            test_parse_batch_outcome_requires_full_coverage;
+          test_case "batch rejects post when disallowed" `Quick
+            test_parse_batch_outcome_rejects_post_when_not_allowed;
+        ] );
+    ]

--- a/test/test_lodge_heartbeat_cleanup_coverage.ml
+++ b/test/test_lodge_heartbeat_cleanup_coverage.ml
@@ -57,35 +57,36 @@ let test_lodge_heartbeat_uses_tom_context () =
     true
     (file_contains_pattern "lib/lodge_heartbeat.ml" "Lodge_tom.predict_top_k")
 
-let test_lodge_heartbeat_post_fallback_policy () =
+let test_lodge_heartbeat_no_heuristic_fallback_policy () =
   check bool "scheduled trigger can fallback to post"
     true
     (file_contains_pattern "lib/lodge_heartbeat.ml" "| Scheduled | ManualTrigger -> true");
   check bool "content alerts do not fallback to post"
     true
     (file_contains_pattern "lib/lodge_heartbeat.ml" "| ContentAlert _ | Mentioned _ -> false");
-  check bool "batch parse failures become explicit decision error"
+  check bool "decision errors are explicit"
     true
     (file_contains_pattern "lib/lodge_heartbeat.ml"
        {|reason = "decision error: " ^ reason|});
   check bool "post gating still enforced through allow_post"
     true
     (file_contains_pattern "lib/lodge_heartbeat.ml"
-       "~allow_post:(trigger_allows_post trigger)")
-
-let test_lodge_heartbeat_hidden_fallbacks_removed () =
+       "~allow_post:(trigger_allows_post trigger)");
+  check bool "unparsed fallback removed"
+    false
+    (file_contains_pattern "lib/lodge_heartbeat.ml" {|reason = Some "unparsed"|});
+  check bool "heuristic maybe_post_action removed"
+    false
+    (file_contains_pattern "lib/lodge_heartbeat.ml" "maybe_post_action");
+  check bool "legacy NoAction fallback removed"
+    false
+    (file_contains_pattern "lib/lodge_heartbeat.ml" "NoAction");
   check bool "reaction batch prompt removed"
     false
     (file_contains_pattern "lib/lodge_heartbeat.ml" "Lodge_reaction.batch_reaction_prompt");
   check bool "comment generation no longer auto-upvotes"
     false
     (file_contains_pattern "lib/lodge_heartbeat.ml" {|None -> ActionUpvote|});
-  check bool "scheduled fallback helper removed"
-    false
-    (file_contains_pattern "lib/lodge_heartbeat.ml" "maybe_post_action");
-  check bool "legacy NoAction fallback removed"
-    false
-    (file_contains_pattern "lib/lodge_heartbeat.ml" "NoAction");
   check bool "comment rate limit enforced explicitly"
     true
     (file_contains_pattern "lib/lodge_heartbeat.ml" {|Skipped "comment_rate_limited"|});
@@ -120,8 +121,7 @@ let () =
           test_case "decision prompt mainline" `Quick test_lodge_heartbeat_uses_decision_prompt;
           test_case "reflection updates self summary" `Quick test_lodge_heartbeat_updates_self_summary;
           test_case "ToM context used" `Quick test_lodge_heartbeat_uses_tom_context;
-          test_case "post fallback policy locked" `Quick test_lodge_heartbeat_post_fallback_policy;
-          test_case "hidden fallbacks removed" `Quick test_lodge_heartbeat_hidden_fallbacks_removed;
+          test_case "no heuristic fallback policy locked" `Quick test_lodge_heartbeat_no_heuristic_fallback_policy;
           test_case "legacy public surface removed" `Quick test_lodge_heartbeat_public_memory_helpers_removed;
         ]);
     ]

--- a/test/test_lodge_heartbeat_cleanup_coverage.ml
+++ b/test/test_lodge_heartbeat_cleanup_coverage.ml
@@ -36,10 +36,16 @@ let test_lodge_heartbeat_no_profile_shellout () =
     (file_contains_pattern "lib/lodge_heartbeat.ml"
        {|Process_eio.run_argv ~timeout_sec:30.0 [sb; "graphql"; "agent"; agent_name]|})
 
-let test_lodge_heartbeat_uses_reaction_prompt () =
-  check bool "reaction batch prompt used"
+let test_lodge_heartbeat_uses_decision_prompt () =
+  check bool "structured decision prompt used"
     true
-    (file_contains_pattern "lib/lodge_heartbeat.ml" "Lodge_reaction.batch_reaction_prompt")
+    (file_contains_pattern "lib/lodge_heartbeat.ml" "Lodge_decision.batch_decision_prompt");
+  check bool "decision phase traced"
+    true
+    (file_contains_pattern "lib/lodge_heartbeat.ml" {|phase:"lodge_decision"|});
+  check bool "structured batch parser used"
+    true
+    (file_contains_pattern "lib/lodge_heartbeat.ml" "Lodge_decision.parse_batch_outcome")
 
 let test_lodge_heartbeat_updates_self_summary () =
   check bool "reflection updates self summary"
@@ -58,37 +64,37 @@ let test_lodge_heartbeat_post_fallback_policy () =
   check bool "content alerts do not fallback to post"
     true
     (file_contains_pattern "lib/lodge_heartbeat.ml" "| ContentAlert _ | Mentioned _ -> false");
-  check bool "unparsed reactions are recorded"
-    true
-    (file_contains_pattern "lib/lodge_heartbeat.ml" {|reason = Some "unparsed"|});
-  check bool "batch parse failures become explicit reason"
+  check bool "batch parse failures become explicit decision error"
     true
     (file_contains_pattern "lib/lodge_heartbeat.ml"
-       {|if parsed = [] then "unparsed_batch" else "below_threshold"|});
-  check bool "scheduled fallback still routes through maybe_post_action"
+       {|reason = "decision error: " ^ reason|});
+  check bool "post gating still enforced through allow_post"
     true
-    (file_contains_pattern "lib/lodge_heartbeat.ml" "| _ -> maybe_post_action ~reason:no_candidate_reason")
+    (file_contains_pattern "lib/lodge_heartbeat.ml"
+       "~allow_post:(trigger_allows_post trigger)")
 
 let test_lodge_heartbeat_hidden_fallbacks_removed () =
+  check bool "reaction batch prompt removed"
+    false
+    (file_contains_pattern "lib/lodge_heartbeat.ml" "Lodge_reaction.batch_reaction_prompt");
   check bool "comment generation no longer auto-upvotes"
     false
     (file_contains_pattern "lib/lodge_heartbeat.ml" {|None -> ActionUpvote|});
-  check bool "post rate limit no longer converts to comment"
+  check bool "scheduled fallback helper removed"
     false
-    (file_contains_pattern "lib/lodge_heartbeat.ml" "converting to COMMENT");
-  check bool "tick no longer pre-gates on post rate limit"
+    (file_contains_pattern "lib/lodge_heartbeat.ml" "maybe_post_action");
+  check bool "legacy NoAction fallback removed"
     false
-    (file_contains_pattern "lib/lodge_heartbeat.ml"
-       {|else if not (check_rate_limit ~agent_name:name `Post) then|});
+    (file_contains_pattern "lib/lodge_heartbeat.ml" "NoAction");
   check bool "comment rate limit enforced explicitly"
     true
     (file_contains_pattern "lib/lodge_heartbeat.ml" {|Skipped "comment_rate_limited"|});
   check bool "post rate limit enforced explicitly"
     true
     (file_contains_pattern "lib/lodge_heartbeat.ml" {|Skipped "post_rate_limited"|});
-  check bool "comment generation failure stays explicit"
+  check bool "decision failure reason tracked"
     true
-    (file_contains_pattern "lib/lodge_heartbeat.ml" {|NoAction "comment_generation_failed"|})
+    (file_contains_pattern "lib/lodge_heartbeat.ml" "decision_failure_reason")
 
 let test_lodge_heartbeat_public_memory_helpers_removed () =
   check bool "load_agent_memories removed from mli"
@@ -111,7 +117,7 @@ let () =
           test_case "agentActivities recall removed" `Quick test_lodge_memory_no_agent_activities_query;
           test_case "createLodgeActivity store removed" `Quick test_lodge_memory_no_create_lodge_activity_mutation;
           test_case "profile shellout removed" `Quick test_lodge_heartbeat_no_profile_shellout;
-          test_case "reaction prompt mainline" `Quick test_lodge_heartbeat_uses_reaction_prompt;
+          test_case "decision prompt mainline" `Quick test_lodge_heartbeat_uses_decision_prompt;
           test_case "reflection updates self summary" `Quick test_lodge_heartbeat_updates_self_summary;
           test_case "ToM context used" `Quick test_lodge_heartbeat_uses_tom_context;
           test_case "post fallback policy locked" `Quick test_lodge_heartbeat_post_fallback_policy;


### PR DESCRIPTION
## Summary
- add a shared structured Lodge decision contract for comment/upvote/skip/post actions
- replace heuristic Lodge reaction paths with LLM-native decisions in tool_lodge and lodge_heartbeat
- add parser/coverage tests that lock the no-heuristic fallback policy

## Validation
- dune build --root . @default
- ./_build/default/test/test_lodge_decision.exe
- ./_build/default/test/test_lodge_reaction.exe
- ./_build/default/test/test_lodge_heartbeat_cleanup_coverage.exe