### PR TITLE
feat(lodge): add llama-server (Qwen3.5) to LLM cascade

### DIFF
--- a/lib/llm_direct.ml
+++ b/lib/llm_direct.ml
@@ -1,6 +1,7 @@
 (** Llm_direct — Direct LLM API calls without llm-mcp dependency.
 
-    Provides call_glm, call_claude_cli, call_ollama, and a unified dispatch.
+    Provides call_glm, call_claude_cli, call_ollama, call_llama,
+    and a unified dispatch.
     Removes the SPOF on llm-mcp (port 8932) for Lodge heartbeat. *)
 
 open Printf
@@ -133,6 +134,39 @@ let call_ollama ~model ~prompt ~timeout_sec ~max_chars () =
     then String.sub result 0 max_chars else result in
   strip_extra truncated
 
+(* ---------- Llama (llama.cpp / llama-server) ---------- *)
+
+(** Call llama-server via OpenAI-compatible API.
+    Endpoint: LLAMA_SERVER_URL/v1/chat/completions (default http://127.0.0.1:8085) *)
+let call_llama ~model ~prompt ~timeout_sec ~max_chars () =
+  let url = Env_config.Llama.server_url in
+  let body = Yojson.Safe.to_string (`Assoc [
+    ("model", `String model);
+    ("messages", `List [
+      `Assoc [("role", `String "user"); ("content", `String prompt)]
+    ]);
+    ("max_tokens", `Int max_chars);
+    ("temperature", `Float 0.7);
+  ]) in
+  let raw = Process_eio.run_argv_with_stdin
+    ~timeout_sec:(Float.of_int timeout_sec +. 5.0)
+    ~stdin_content:body
+    ["curl"; "-s"; "--max-time"; string_of_int timeout_sec;
+     "-X"; "POST"; url ^ "/v1/chat/completions";
+     "-H"; "Content-Type: application/json";
+     "-d"; "@-"] in
+  let result = try
+    let json = Yojson.Safe.from_string raw in
+    json |> Yojson.Safe.Util.member "choices"
+         |> Yojson.Safe.Util.index 0
+         |> Yojson.Safe.Util.member "message"
+         |> Yojson.Safe.Util.member "content"
+         |> Yojson.Safe.Util.to_string
+  with _ -> raw in
+  let truncated = if String.length result > max_chars
+    then String.sub result 0 max_chars else result in
+  strip_extra truncated
+
 (* ---------- Dispatch ---------- *)
 
 (** Unified dispatcher: routes by tool_name to the appropriate backend.
@@ -146,6 +180,8 @@ let dispatch ~tool_name ?(api_key="") ~model ~prompt ~timeout_sec ~max_chars () 
       call_claude_cli ~api_key ~model ~prompt ~timeout_sec ~max_chars ()
   | "ollama" ->
       call_ollama ~model ~prompt ~timeout_sec ~max_chars ()
+  | "llama" | "llama.cpp" | "llamacpp" ->
+      call_llama ~model ~prompt ~timeout_sec ~max_chars ()
   | other ->
       eprintf "[llm_direct] unknown tool_name: %s, trying GLM fallback\n%!" other;
       call_glm ~api_key ~model ~prompt ~timeout_sec ~max_chars ()

--- a/lib/lodge_cascade.ml
+++ b/lib/lodge_cascade.ml
@@ -15,7 +15,7 @@ open Printf
 (* ---------- Types ---------- *)
 
 type cascade_slot = {
-  tool_name : string;    (* "glm", "ollama", "claude-cli" *)
+  tool_name : string;    (* "glm", "ollama", "llama", "claude-cli" *)
   model : string;        (* "glm-4.7", "glm-4.7-flash", "claude-sonnet-4-20250514" *)
   key_env : string option; (* env var name for api_key, e.g. "CLAUDE_CODE_OAUTH_TOKEN_anyang" *)
 }
@@ -85,7 +85,7 @@ let parse_cost_tiers (json : Yojson.Safe.t) : (string * int) list =
     List.filter_map (fun (k, v) ->
       match v with `Int n -> Some (k, n) | _ -> None
     ) pairs
-  | _ -> [("ollama", 0); ("glm", 1); ("claude-cli", 3)]
+  | _ -> [("ollama", 0); ("llama", 0); ("glm", 1); ("claude-cli", 3)]
 
 (** Parse per-cascade strategy from config *)
 let parse_strategy (json : Yojson.Safe.t) ~cascade_name : strategy =


### PR DESCRIPTION
## Summary

- `Llm_direct.dispatch`에 `call_llama` 함수 추가 — OpenAI-compatible `/v1/chat/completions` 호출
- `config/llm_cascade.json`에 llama 슬롯 삽입 (ollama 앞, cost tier 0)
- `Lodge_cascade.parse_cost_tiers` 기본값에 `("llama", 0)` 추가

llama-server가 꺼져 있으면 curl `Connection refused`로 즉시 실패 → 다음 슬롯(ollama)으로 자연스럽게 fallback.

## Changes

| File | Change |
|------|--------|
| `lib/llm_direct.ml` | `call_llama` 함수 + dispatch `"llama"` 분기 (+35 lines) |
| `lib/lodge_cascade.ml` | cost_tiers 기본값에 llama 추가, type 주석 업데이트 |
| `config/llm_cascade.json` | llama 슬롯 2개 + cost_tiers 항목 (untracked, runtime config) |

## Test plan

- [x] `dune build --root .` 성공
- [x] llama-server `:8085` 응답 확인 (`/v1/models`)
- [ ] `launchctl kickstart` 후 heartbeat 로그에서 llama dispatch 확인
- [ ] llama-server 중지 후 ollama fallback 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)