### PR TITLE
feat(lodge): run agents through MCP tool loop

### DIFF
--- a/lib/a2a_tools.ml
+++ b/lib/a2a_tools.ml
@@ -605,125 +605,112 @@ let notify_event ~(event_type : event_type) ~(agent : string) ~(data : Yojson.Sa
     end
   ) subscriptions
 
-(** {1 Heartbeat Task Events — Soul + Body Pattern}
+(** {1 Heartbeat Task Events — Soul + Tool Loop Pattern}
 
-    MASC server emits heartbeat_task events when an agent should "speak".
-    Workers subscribe to these events and invoke LLM to generate responses.
-    This enables local LLM (Ollama) to power remote agent activity.
-
-    Flow:
-    1. MASC heartbeat tick → Thompson Sampling → agent selected
-    2. emit_heartbeat_task ~agent ~prompt ~context
-    3. Worker receives event via poll_events or SSE
-    4. Worker invokes local LLM with agent's prompt
-    5. Worker broadcasts result back to MASC
+    MASC emits heartbeat_task events when an external worker should act as a Lodge
+    agent through the MCP tool loop. The payload carries the goal, context, and
+    allowed tools. The worker performs tools directly, then reports completion
+    evidence back to MASC.
 *)
 
 (** Emit a heartbeat_task event for Worker to process.
     @param agent Agent name (soul to embody)
-    @param prompt The prompt for LLM (includes agent personality)
+    @param goal Concrete goal for the worker
     @param context Board state, recent posts, etc.
+    @param allowed_tools Curated MCP tool allowlist for the worker
     @param board_id Optional target board ID *)
 let emit_heartbeat_task
     ~agent
-    ~prompt
+    ~goal
     ~context
+    ~allowed_tools
     ?(board_id : string option)
-    ?(action_hint : string option)
+    ?(worker_mode = "mcp_tool_loop")
+    ?(mcp_base_url : string option)
+    ?(session_id : string option)
+    ?(decision_reason : string option)
+    ?(decision_confidence : float option)
+    ?(auth_token : string option)
     () : unit =
   let data = `Assoc ([
     ("agent", `String agent);
-    ("prompt", `String prompt);
+    ("goal", `String goal);
     ("context", `String context);
+    ("worker_mode", `String worker_mode);
+    ("allowed_tools", `List (List.map (fun name -> `String name) allowed_tools));
   ] @ (match board_id with
     | Some bid -> [("board_id", `String bid)]
     | None -> [])
-  @ (match action_hint with
-    | Some hint -> [("action_hint", `String hint)]
+  @ (match mcp_base_url with
+    | Some url -> [("mcp_base_url", `String url)]
+    | None -> [])
+  @ (match session_id with
+    | Some id -> [("session_id", `String id)]
+    | None -> [])
+  @ (match decision_reason with
+    | Some reason -> [("decision_reason", `String reason)]
+    | None -> [])
+  @ (match decision_confidence with
+    | Some confidence -> [("decision_confidence", `Float confidence)]
+    | None -> [])
+  @ (match auth_token with
+    | Some token -> [("auth_token", `String token)]
     | None -> []))
   in
   notify_event ~event_type:HeartbeatTask ~agent ~data;
-  Log.info ~ctx:"heartbeat" "💓 HeartbeatTask emitted for %s (prompt: %d chars, hint: %s)"
-    agent (String.length prompt) (Option.value ~default:"none" action_hint)
+  Log.info ~ctx:"heartbeat"
+    "💓 HeartbeatTask emitted for %s (goal: %d chars, tools: %d, worker_mode: %s)"
+    agent (String.length goal) (List.length allowed_tools) worker_mode
 
-(** {1 A2A Worker Response — Complete the delegation cycle}
+(** {1 A2A Worker Response — Completion Evidence}
 
-    Worker processes heartbeat_task and submits result.
-    The result is then posted to Board on behalf of the original agent.
+    Worker processes heartbeat_task, performs MCP tools directly, and submits a
+    completion/evidence record. MASC no longer proxies the board write.
 *)
 
 (** Submit heartbeat task result from A2A Worker.
     @param worker_name Worker agent name (e.g., "llm-worker-local")
     @param agent Original agent name (soul owner)
-    @param action_type "POST" | "COMMENT:post_id" | "UPVOTE:post_id" | "SKIP"
-    @param content Generated content
+    @param status "acted" | "skipped" | "failed"
+    @param summary Short completion summary
+    @param tool_call_count Number of MCP tool calls the worker made
+    @param tool_names Executed MCP tool names
+    @param decision_reason Why the worker chose this outcome
+    @param decision_confidence Confidence score (0.0-1.0)
+    @param failure_reason Optional explicit error reason
     @return Success/error *)
 let submit_heartbeat_result
     ~worker_name
     ~agent
-    ~action_type
-    ~content
+    ~status
+    ~summary
+    ~tool_call_count
+    ~tool_names
+    ~decision_reason
+    ~decision_confidence
+    ?failure_reason
     () : (Yojson.Safe.t, string) result =
-  Log.info ~ctx:"a2a" "📥 Worker %s submitting result for %s: %s"
-    worker_name agent action_type;
-
-  let store = Board.global () in
-
-  (* Parse action type and execute *)
+  let normalized_status = String.lowercase_ascii (String.trim status) in
   let result =
-    if action_type = "POST" then begin
-      match Board.create_post store ~author:agent ~content ~ttl_hours:168 () with
-      | Ok post ->
-          let post_id = Board.Post_id.to_string post.id in
-          Ok (`Assoc [
-            ("success", `Bool true);
-            ("action", `String "post");
-            ("post_id", `String post_id);
-            ("agent", `String agent);
-            ("worker", `String worker_name);
-          ])
-      | Error e ->
-          Error (Printf.sprintf "Board post failed: %s" (Board.show_board_error e))
-    end
-    else if String.length action_type > 8 && String.sub action_type 0 8 = "COMMENT:" then begin
-      let post_id = String.sub action_type 8 (String.length action_type - 8) in
-      match Board.add_comment store ~post_id ~author:agent ~content () with
-      | Ok comment ->
-          let comment_id = Board.Comment_id.to_string comment.id in
-          Ok (`Assoc [
-            ("success", `Bool true);
-            ("action", `String "comment");
-            ("post_id", `String post_id);
-            ("comment_id", `String comment_id);
-            ("agent", `String agent);
-            ("worker", `String worker_name);
-          ])
-      | Error e ->
-          Error (Printf.sprintf "Board comment failed: %s" (Board.show_board_error e))
-    end
-    else if String.length action_type > 7 && String.sub action_type 0 7 = "UPVOTE:" then begin
-      let post_id = String.sub action_type 7 (String.length action_type - 7) in
-      match Board.vote store ~voter:agent ~post_id ~direction:Board.Up with
-      | Ok _ ->
-          Ok (`Assoc [
-            ("success", `Bool true);
-            ("action", `String "upvote");
-            ("post_id", `String post_id);
-            ("agent", `String agent);
-            ("worker", `String worker_name);
-          ])
-      | Error e ->
-          Error (Printf.sprintf "Board vote failed: %s" (Board.show_board_error e))
-    end
-    else if action_type = "SKIP" then
-      Ok (`Assoc [
-        ("success", `Bool true);
-        ("action", `String "skip");
-        ("agent", `String agent);
-        ("worker", `String worker_name);
-      ])
-    else
-      Error (Printf.sprintf "Unknown action type: %s" action_type)
+    match normalized_status with
+    | "acted" | "skipped" | "failed" ->
+        Ok (`Assoc [
+          ("success", `Bool true);
+          ("status", `String normalized_status);
+          ("agent", `String agent);
+          ("worker", `String worker_name);
+          ("summary", `String summary);
+          ("tool_call_count", `Int tool_call_count);
+          ("tool_names", `List (List.map (fun name -> `String name) tool_names));
+          ("decision_reason", `String decision_reason);
+          ("decision_confidence", `Float decision_confidence);
+          ("failure_reason",
+            match failure_reason with
+            | Some reason -> `String reason
+            | None -> `Null);
+        ])
+    | other ->
+        Error (Printf.sprintf "Unknown worker status: %s" other)
   in
 
   (* Broadcast completion event *)
@@ -732,9 +719,18 @@ let submit_heartbeat_result
        notify_event ~event_type:Completion ~agent
          ~data:(`Assoc [
            ("worker", `String worker_name);
-           ("action", `String action_type);
+           ("status", `String normalized_status);
+           ("summary", `String summary);
+           ("tool_call_count", `Int tool_call_count);
+           ("tool_names", `List (List.map (fun name -> `String name) tool_names));
+           ("decision_reason", `String decision_reason);
+           ("decision_confidence", `Float decision_confidence);
+           ("failure_reason",
+           match failure_reason with
+            | Some reason -> `String reason
+            | None -> `Null);
          ])
    | Error msg ->
-       Printf.eprintf "[a2a] notification failed: %s\n%!" msg);
+       Printf.eprintf "[a2a] heartbeat result rejected: %s\n%!" msg);
 
   result

--- a/lib/dune
+++ b/lib/dune
@@ -72,6 +72,7 @@
    lodge_cascade
    lodge_atmosphere
    lodge_decision
+   lodge_worker
    lodge_heartbeat
    lodge_memory
    lodge_memory_gc

--- a/lib/lodge_decision.ml
+++ b/lib/lodge_decision.ml
@@ -26,6 +26,19 @@ type outcome = {
   choice : choice;
 }
 
+type assignment = {
+  agent_name : string;
+  target_post_id : string option;
+  goal : string;
+  reason : string;
+  confidence : float;
+}
+
+type selection_plan = {
+  assignments : assignment list;
+  plan_reason : string option;
+}
+
 let ( let* ) value f = match value with Ok x -> f x | Error _ as err -> err
 
 let action_to_string = function
@@ -133,6 +146,39 @@ let parse_choice json =
   | _, Error err, _ -> Error err
   | _, _, Error err -> Error err
 
+let parse_assignment json =
+  let agent_name =
+    match json |> member "agent_name" with
+    | `String s ->
+        let trimmed = String.trim s in
+        if trimmed = "" then Error "assignment.agent_name must be non-empty"
+        else Ok trimmed
+    | _ -> Error "assignment.agent_name must be a string"
+  in
+  let goal =
+    match json |> member "goal" with
+    | `String s ->
+        let trimmed = String.trim s in
+        if trimmed = "" then Error "assignment.goal must be non-empty" else Ok trimmed
+    | _ -> Error "assignment.goal must be a string"
+  in
+  let reason = parse_reason (json |> member "reason") in
+  let confidence =
+    match parse_confidence (json |> member "confidence") with
+    | Ok value -> validate_confidence value
+    | Error _ as err -> err
+  in
+  let target_post_id =
+    json |> member "target_post_id" |> to_string_option |> trim_opt
+  in
+  match agent_name, goal, reason, confidence with
+  | Ok agent_name, Ok goal, Ok reason, Ok confidence ->
+      Ok { agent_name; target_post_id; goal; reason; confidence }
+  | Error err, _, _, _ -> Error err
+  | _, Error err, _, _ -> Error err
+  | _, _, Error err, _ -> Error err
+  | _, _, _, Error err -> Error err
+
 let validate_choice ~allowed_post_ids ~allow_post (choice : choice) =
   let post_id_allowed post_id =
     List.exists (String.equal post_id) allowed_post_ids
@@ -192,6 +238,37 @@ let validate_reactions ~allowed_post_ids (reactions : reaction list) =
         loop rest
   in
   loop reactions
+
+let validate_assignments ~allowed_agents ~allowed_post_ids ~max_agents assignments =
+  if List.length assignments > max_agents then
+    Error
+      (Printf.sprintf "selection exceeds max_agents (%d > %d)"
+         (List.length assignments) max_agents)
+  else
+    let seen = Hashtbl.create (List.length assignments) in
+    let validate_one assignment =
+      if not (List.mem assignment.agent_name allowed_agents) then
+        Error
+          (Printf.sprintf "assignment agent_name %s is not in the candidate set"
+             assignment.agent_name)
+      else if Hashtbl.mem seen assignment.agent_name then
+        Error (Printf.sprintf "duplicate assignment for %s" assignment.agent_name)
+      else
+        let () = Hashtbl.add seen assignment.agent_name () in
+        match assignment.target_post_id with
+        | Some post_id when not (List.mem post_id allowed_post_ids) ->
+            Error
+              (Printf.sprintf "assignment target_post_id %s is not in the candidate set"
+                 post_id)
+        | _ -> Ok ()
+    in
+    let rec loop acc = function
+      | [] -> Ok (List.rev acc)
+      | assignment :: rest ->
+          let* () = validate_one assignment in
+          loop (assignment :: acc) rest
+    in
+    loop [] assignments
 
 let single_reaction_prompt ~agent_name ~agent_prompt ~interests ~post_id ~content
     ~language_instruction =
@@ -295,6 +372,73 @@ Candidate posts:
 %s|}
     agent_name identity_prompt extra_context action_choices action_choices posts_section
 
+let selection_prompt ~agent_name ~candidate_agents ~posts ~extra_context ~max_agents
+    ~allow_post =
+  let agents_section =
+    match candidate_agents with
+    | [] -> "(no candidate agents)"
+    | items ->
+        items
+        |> List.map (fun (name, identity) ->
+               Printf.sprintf "agent=%s\nidentity=%s" name identity)
+        |> String.concat "\n\n"
+  in
+  let posts_section =
+    match posts with
+    | [] -> "(no candidate posts)"
+    | items ->
+        items
+        |> List.mapi (fun idx (post_id, author, content) ->
+               Printf.sprintf "[Post %d]\nid=%s\nauthor=%s\ncontent=%s" (idx + 1)
+                 post_id author content)
+        |> String.concat "\n\n"
+  in
+  let extra_context =
+    match trim_opt extra_context with
+    | Some text -> "\n\nAdditional context:\n" ^ text
+    | None -> ""
+  in
+  let post_rule =
+    if allow_post then
+      "If posting is warranted, you may omit target_post_id and set a goal that writes a new board post."
+    else
+      "Do not plan new top-level posts. Use existing posts or choose goals that lead to skipping."
+  in
+  Printf.sprintf
+    {|You are the Lodge orchestrator for %s.
+
+Select up to %d agents and assign each a concrete MCP tool-loop goal.
+Return JSON only. No markdown. No code fences.
+
+Required JSON shape:
+{
+  "assignments": [
+    {
+      "agent_name": "candidate agent name",
+      "target_post_id": "optional candidate post id",
+      "goal": "concrete MCP-worker goal",
+      "reason": "why this agent should act",
+      "confidence": 0.0
+    }
+  ],
+  "plan_reason": "optional room-level rationale"
+}
+
+Rules:
+- assignments length must be <= %d
+- agent_name must come from the listed candidate agents
+- If target_post_id is present, it must come from the listed candidate posts
+- goal and reason must be non-empty
+- %s
+
+Candidate agents:
+%s
+%s
+
+Candidate posts:
+%s|}
+    agent_name max_agents max_agents post_rule agents_section extra_context posts_section
+
 let parse_single_choice ~post_id response =
   let* json_text = extract_json_object response in
   let* json =
@@ -329,3 +473,28 @@ let parse_batch_outcome ~allowed_post_ids ~allow_post response =
     |> function Ok choice -> validate_choice ~allowed_post_ids ~allow_post choice | Error _ as err -> err
   in
   Ok { reactions; choice }
+
+let parse_selection_plan ~allowed_agents ~allowed_post_ids ~max_agents response =
+  let* json_text = extract_json_object response in
+  let* json =
+    try Ok (Yojson.Safe.from_string json_text)
+    with Yojson.Json_error msg -> Error (Printf.sprintf "invalid JSON: %s" msg)
+  in
+  let assignments =
+    match json |> member "assignments" with
+    | `List items ->
+        let rec loop acc = function
+          | [] -> Ok (List.rev acc)
+          | item :: rest ->
+              let* parsed = parse_assignment item in
+              loop (parsed :: acc) rest
+        in
+        loop [] items
+    | _ -> Error "assignments must be an array"
+  in
+  let* assignments = assignments in
+  let* assignments =
+    validate_assignments ~allowed_agents ~allowed_post_ids ~max_agents assignments
+  in
+  let plan_reason = json |> member "plan_reason" |> to_string_option |> trim_opt in
+  Ok { assignments; plan_reason }

--- a/lib/lodge_decision.mli
+++ b/lib/lodge_decision.mli
@@ -26,6 +26,19 @@ type outcome = {
   choice : choice;
 }
 
+type assignment = {
+  agent_name : string;
+  target_post_id : string option;
+  goal : string;
+  reason : string;
+  confidence : float;
+}
+
+type selection_plan = {
+  assignments : assignment list;
+  plan_reason : string option;
+}
+
 val single_reaction_prompt :
   agent_name:string ->
   agent_prompt:string ->
@@ -52,3 +65,21 @@ val parse_batch_outcome :
   (outcome, string) result
 
 val action_to_string : action -> string
+
+val extract_json_object : string -> (string, string) result
+
+val selection_prompt :
+  agent_name:string ->
+  candidate_agents:(string * string) list ->
+  posts:(string * string * string) list ->
+  extra_context:string option ->
+  max_agents:int ->
+  allow_post:bool ->
+  string
+
+val parse_selection_plan :
+  allowed_agents:string list ->
+  allowed_post_ids:string list ->
+  max_agents:int ->
+  string ->
+  (selection_plan, string) result

--- a/lib/lodge_heartbeat.ml
+++ b/lib/lodge_heartbeat.ml
@@ -422,9 +422,62 @@ let sb_path () =
 
 (** Use local GraphQL by default for local MCP runs.
     Set GRAPHQL_URL explicitly to force remote endpoint. *)
+let trim_trailing_slash s =
+  let trimmed = String.trim s in
+  let len = String.length trimmed in
+  if len > 0 && trimmed.[len - 1] = '/' then
+    String.sub trimmed 0 (len - 1)
+  else
+    trimmed
+
 let default_graphql_url () =
-  let port = Sys.getenv_opt "MASC_MCP_PORT" |> Option.value ~default:"8935" in
-  Printf.sprintf "http://127.0.0.1:%s/graphql" port
+  match Sys.getenv_opt "MASC_HTTP_BASE_URL" with
+  | Some raw when String.trim raw <> "" ->
+      trim_trailing_slash raw ^ "/graphql"
+  | _ ->
+      let port = Sys.getenv_opt "MASC_HTTP_PORT" |> Option.value ~default:"8935" in
+      Printf.sprintf "http://127.0.0.1:%s/graphql" port
+
+let graphql_url () =
+  match Sys.getenv_opt "GRAPHQL_URL" with
+  | Some raw when String.trim raw <> "" -> String.trim raw
+  | _ -> default_graphql_url ()
+
+let looks_like_html_response body =
+  let trimmed = String.lowercase_ascii (String.trim body) in
+  trimmed <> "" && trimmed.[0] = '<'
+
+let ensure_graphql_json_response body =
+  if String.length body = 0 then
+    Error "empty response"
+  else if looks_like_html_response body then
+    Error "endpoint returned HTML instead of JSON"
+  else
+    Ok body
+
+let graphql_error_message json =
+  match Yojson.Safe.Util.member "errors" json with
+  | `List (first :: _) ->
+      first |> Yojson.Safe.Util.member "message" |> Yojson.Safe.Util.to_string_option
+  | _ -> None
+
+let graphql_agents_edges json =
+  match graphql_error_message json with
+  | Some msg -> Error ("GraphQL error: " ^ msg)
+  | None ->
+      let open Yojson.Safe.Util in
+      let data = member "data" json in
+      if data = `Null then
+        Error "GraphQL data is null"
+      else
+        let agents = member "agents" data in
+        if agents = `Null then
+          Error "GraphQL agents is null"
+        else
+          match member "edges" agents with
+          | `List edges -> Ok edges
+          | `Null -> Ok []
+          | _ -> Error "GraphQL agents.edges is not a list"
 
 (** Keep auth token out of argv so process errors don't leak secrets. *)
 let with_auth_header_file api_key f =
@@ -442,12 +495,13 @@ let with_auth_header_file api_key f =
 
 (** curl-based GraphQL request — reliable DNS resolution in Railway containers *)
 let graphql_request_curl body : (string, string) Stdlib.result =
-  let url = Sys.getenv_opt "GRAPHQL_URL" |> Option.value ~default:(default_graphql_url ()) in
+  let url = graphql_url () in
   let api_key = Sys.getenv_opt "GRAPHQL_API_KEY" |> Option.value ~default:"" in
   with_auth_header_file api_key (fun auth_header_file ->
       let argv =
-        [ "curl"; "-s"; "-m"; "10"; url;
-          "-H"; "Content-Type: application/json"
+        [ "curl"; "-s"; "-m"; "10"; "-X"; "POST"; url;
+          "-H"; "Content-Type: application/json";
+          "-H"; "Accept: application/json"
         ]
         |> fun base ->
         match auth_header_file with
@@ -461,13 +515,13 @@ let graphql_request_curl body : (string, string) Stdlib.result =
         let output =
           Process_eio.run_argv_with_stdin ~timeout_sec:15.0 ~stdin_content:body argv
         in
-        if String.length output = 0 then Error "curl: empty response" else Ok output
+        ensure_graphql_json_response output
       with exn -> Error (Printf.sprintf "curl: %s" (Printexc.to_string exn)))
 
 (** GraphQL request via Cohttp_eio with curl fallback.
     Falls back to curl if Cohttp fails (Railway DNS issues). *)
 let graphql_request ?(timeout_sec=5.0) body : (string, string) Stdlib.result =
-  let url = Sys.getenv_opt "GRAPHQL_URL" |> Option.value ~default:(default_graphql_url ()) in
+  let url = graphql_url () in
   let api_key = Sys.getenv_opt "GRAPHQL_API_KEY" |> Option.value ~default:"" in
   let max_response_bytes = 1_000_000 in
   let suppress_body _s = "body suppressed" in
@@ -501,12 +555,10 @@ let graphql_request ?(timeout_sec=5.0) body : (string, string) Stdlib.result =
           let body_str =
             Eio.Buf_read.(parse_exn take_all) resp_body ~max_size:max_response_bytes
           in
-          if String.length body_str = 0 then
-            Error "empty response"
-          else if Cohttp.Code.is_success status then
-            Ok body_str
-          else
+          if not (Cohttp.Code.is_success status) then
             Error (Printf.sprintf "HTTP %d (%s)" status (suppress_body body_str))
+          else
+            ensure_graphql_json_response body_str
         )
       in
       match Eio_context.get_clock_opt () with
@@ -758,67 +810,56 @@ let load_agents_from_neo4j () =
   match graphql_request ~timeout_sec:5.0 gql_query with
   | Error err ->
       Eio.traceln "⚠️ [Heartbeat] GraphQL request failed: %s" err;
-      []
+      builtin_core_agents ()
   | Ok json_str ->
       Printf.eprintf "[Heartbeat] GraphQL response: %d bytes\n%!" (String.length json_str);
       try
         let json = Yojson.Safe.from_string json_str in
-        (* Check for GraphQL errors before parsing data *)
-        (match Yojson.Safe.Util.member "errors" json with
-         | `List errors when errors <> [] ->
-           let msg = try
-             List.hd errors |> Yojson.Safe.Util.member "message" |> Yojson.Safe.Util.to_string
-           with Yojson.Safe.Util.Type_error _ | Failure _ -> "unknown error" in
-           Eio.traceln "⚠️ GraphQL error loading agents: %s" msg;
-           []
-         | _ ->
-        let edges = json
-          |> Yojson.Safe.Util.member "data"
-          |> Yojson.Safe.Util.member "agents"
-          |> Yojson.Safe.Util.member "edges"
-          |> Yojson.Safe.Util.to_list
-        in
-        let parsed =
-          List.filter_map (fun edge ->
-            try
-              let node = Yojson.Safe.Util.member "node" edge in
-              let name = Yojson.Safe.Util.(member "name" node |> to_string) in
-              let preferred_hours = Yojson.Safe.Util.(member "preferredHours" node |> to_list |> List.map to_int) in
-              let peak_hour = Yojson.Safe.Util.(member "peakHour" node |> to_int_option) in
-              let traits = Yojson.Safe.Util.(member "traits" node |> to_list |> List.map to_string) in
-              let activity_level =
-                match Yojson.Safe.Util.(member "activityLevel" node) with
-                | `Null -> 0.5
-                | v -> Yojson.Safe.Util.to_float v
-              in
-              (* Client-side filter: only agents with preferredHours *)
-              let interests =
-                try Yojson.Safe.Util.(member "interests" node |> to_list |> List.map to_string)
-                with Yojson.Safe.Util.Type_error _ | Failure _ -> []
-              in
-              let personality_hint =
-                match Yojson.Safe.Util.(member "personalityHint" node) with
-                | `String s -> Some s
-                | _ -> None
-              in
-              if preferred_hours <> [] then
-                Some { name; preferred_hours; peak_hour; traits; interests;
-                       personality_hint; activity_level }
-              else
-                None
-            with Yojson.Safe.Util.Type_error (msg, _) ->
-              Eio.traceln "⚠️ Agent parse error: %s" msg;
-              None
-          ) edges
-        in
-        if parsed <> [] then parsed
-        else begin
-          Eio.traceln "⚠️ GraphQL agents empty, using builtin core agents fallback";
-          builtin_core_agents ()
-        end)
+        (match graphql_agents_edges json with
+         | Error msg ->
+             Eio.traceln "⚠️ GraphQL error loading agents: %s" msg;
+             builtin_core_agents ()
+         | Ok edges ->
+             let parsed =
+               List.filter_map (fun edge ->
+                 try
+                   let node = Yojson.Safe.Util.member "node" edge in
+                   let name = Yojson.Safe.Util.(member "name" node |> to_string) in
+                   let preferred_hours = Yojson.Safe.Util.(member "preferredHours" node |> to_list |> List.map to_int) in
+                   let peak_hour = Yojson.Safe.Util.(member "peakHour" node |> to_int_option) in
+                   let traits = Yojson.Safe.Util.(member "traits" node |> to_list |> List.map to_string) in
+                   let activity_level =
+                     match Yojson.Safe.Util.(member "activityLevel" node) with
+                     | `Null -> 0.5
+                     | v -> Yojson.Safe.Util.to_float v
+                   in
+                   let interests =
+                     try Yojson.Safe.Util.(member "interests" node |> to_list |> List.map to_string)
+                     with Yojson.Safe.Util.Type_error _ | Failure _ -> []
+                   in
+                   let personality_hint =
+                     match Yojson.Safe.Util.(member "personalityHint" node) with
+                     | `String s -> Some s
+                     | _ -> None
+                   in
+                   if preferred_hours <> [] then
+                     Some { name; preferred_hours; peak_hour; traits; interests;
+                            personality_hint; activity_level }
+                   else
+                     None
+                 with Yojson.Safe.Util.Type_error (msg, _) ->
+                   Eio.traceln "⚠️ Agent parse error: %s" msg;
+                   None
+               ) edges
+             in
+             if parsed <> [] then parsed
+             else begin
+               Eio.traceln "⚠️ GraphQL agents empty, using builtin core agents fallback";
+               builtin_core_agents ()
+             end)
       with e ->
         Eio.traceln "⚠️ Failed to load agents from GraphQL: %s" (Printexc.to_string e);
-        []
+        builtin_core_agents ()
 
 (** Cached agents - loaded once at startup, refreshed periodically *)
 let agents_cache = ref []
@@ -1161,52 +1202,42 @@ let load_lodge_agents_full () =
   | Ok json_str ->
       try
         let json = Yojson.Safe.from_string json_str in
-        (match Yojson.Safe.Util.member "errors" json with
-         | `List errors when errors <> [] ->
-           let msg = try
-             List.hd errors |> Yojson.Safe.Util.member "message" |> Yojson.Safe.Util.to_string
-           with _ -> "unknown error" in
-           Error (Printf.sprintf "GraphQL error: %s" msg)
-         | _ ->
-        let edges = json
-          |> Yojson.Safe.Util.member "data"
-          |> Yojson.Safe.Util.member "agents"
-          |> Yojson.Safe.Util.member "edges"
-          |> Yojson.Safe.Util.to_list
-        in
-        let agents = List.filter_map (fun edge ->
-          try
-            let node = Yojson.Safe.Util.member "node" edge in
-            let open Yojson.Safe.Util in
-            let name = member "name" node |> to_string in
-            let emoji = (match member "emoji" node with `String s -> s | _ -> "🤖") in
-            let korean_name = (match member "koreanName" node with `String s -> Some s | _ -> None) in
-            let traits = (try member "traits" node |> to_list |> List.map to_string with exn -> Printf.eprintf "[heartbeat] traits parse: %s\n%!" (Printexc.to_string exn); []) in
-            let interests = (try member "interests" node |> to_list |> List.map to_string with exn -> Printf.eprintf "[heartbeat] interests parse: %s\n%!" (Printexc.to_string exn); []) in
-            let activity_level = (match member "activityLevel" node with `Float f -> f | `Int i -> float_of_int i | _ -> 0.5) in
-            let preferred_hours = (try member "preferredHours" node |> to_list |> List.map to_int with exn -> Printf.eprintf "[heartbeat] preferred_hours parse: %s\n%!" (Printexc.to_string exn); []) in
-            let peak_hour = (match member "peakHour" node with `Int i -> Some i | _ -> None) in
-            let model = (match member "model" node with `String s -> s | _ -> "glm-4.7-flash:latest") in
-            let status = (match member "status" node with `String s -> s | _ -> "active") in
-            let primary_value = (match member "primaryValue" node with `String s -> Some s | _ -> None) in
-            let personality_hint = (match member "personalityHint" node with `String s -> Some s | _ -> None) in
-            Some (`Assoc [
-              ("name", `String name);
-              ("emoji", `String emoji);
-              ("koreanName", match korean_name with Some s -> `String s | None -> `Null);
-              ("traits", `List (List.map (fun s -> `String s) traits));
-              ("interests", `List (List.map (fun s -> `String s) interests));
-              ("activityLevel", `Float activity_level);
-              ("preferredHours", `List (List.map (fun i -> `Int i) preferred_hours));
-              ("peakHour", match peak_hour with Some i -> `Int i | None -> `Null);
-              ("model", `String model);
-              ("status", `String status);
-              ("primaryValue", match primary_value with Some s -> `String s | None -> `Null);
-              ("personalityHint", match personality_hint with Some s -> `String s | None -> `Null);
-            ])
-          with _ -> None
-        ) edges in
-        Ok (`Assoc [("agents", `List agents)]))
+        (match graphql_agents_edges json with
+         | Error msg -> Error msg
+         | Ok edges ->
+             let agents = List.filter_map (fun edge ->
+               try
+                 let node = Yojson.Safe.Util.member "node" edge in
+                 let open Yojson.Safe.Util in
+                 let name = member "name" node |> to_string in
+                 let emoji = (match member "emoji" node with `String s -> s | _ -> "🤖") in
+                 let korean_name = (match member "koreanName" node with `String s -> Some s | _ -> None) in
+                 let traits = (try member "traits" node |> to_list |> List.map to_string with exn -> Printf.eprintf "[heartbeat] traits parse: %s\n%!" (Printexc.to_string exn); []) in
+                 let interests = (try member "interests" node |> to_list |> List.map to_string with exn -> Printf.eprintf "[heartbeat] interests parse: %s\n%!" (Printexc.to_string exn); []) in
+                 let activity_level = (match member "activityLevel" node with `Float f -> f | `Int i -> float_of_int i | _ -> 0.5) in
+                 let preferred_hours = (try member "preferredHours" node |> to_list |> List.map to_int with exn -> Printf.eprintf "[heartbeat] preferred_hours parse: %s\n%!" (Printexc.to_string exn); []) in
+                 let peak_hour = (match member "peakHour" node with `Int i -> Some i | _ -> None) in
+                 let model = (match member "model" node with `String s -> s | _ -> "glm-4.7-flash:latest") in
+                 let status = (match member "status" node with `String s -> s | _ -> "active") in
+                 let primary_value = (match member "primaryValue" node with `String s -> Some s | _ -> None) in
+                 let personality_hint = (match member "personalityHint" node with `String s -> Some s | _ -> None) in
+                 Some (`Assoc [
+                   ("name", `String name);
+                   ("emoji", `String emoji);
+                   ("koreanName", match korean_name with Some s -> `String s | None -> `Null);
+                   ("traits", `List (List.map (fun s -> `String s) traits));
+                   ("interests", `List (List.map (fun s -> `String s) interests));
+                   ("activityLevel", `Float activity_level);
+                   ("preferredHours", `List (List.map (fun i -> `Int i) preferred_hours));
+                   ("peakHour", match peak_hour with Some i -> `Int i | None -> `Null);
+                   ("model", `String model);
+                   ("status", `String status);
+                   ("primaryValue", match primary_value with Some s -> `String s | None -> `Null);
+                   ("personalityHint", match personality_hint with Some s -> `String s | None -> `Null);
+                 ])
+               with _ -> None
+             ) edges in
+             Ok (`Assoc [("agents", `List agents)]))
       with e ->
         Error (Printf.sprintf "Failed to load agents: %s" (Printexc.to_string e))
 
@@ -1516,17 +1547,10 @@ let load_agent_profiles_from_graphql () : agent_profile list =
   | Ok json_str ->
       try
         let json = Yojson.Safe.from_string json_str in
-        match Yojson.Safe.Util.member "errors" json with
-        | `List errors when errors <> [] -> []
-        | _ ->
+        match graphql_agents_edges json with
+        | Error _ -> []
+        | Ok edges ->
             let open Yojson.Safe.Util in
-            let edges =
-              json
-              |> member "data"
-              |> member "agents"
-              |> member "edges"
-              |> to_list
-            in
             List.filter_map
               (fun edge ->
                 try
@@ -2133,6 +2157,129 @@ let trigger_allows_post = function
   | Scheduled | ManualTrigger -> true
   | ContentAlert _ | Mentioned _ -> false
 
+let heartbeat_tool_context (posts : Board.post list) =
+  posts
+  |> List.map (fun (post : Board.post) ->
+         Printf.sprintf "[target_post_id=%s]\nauthor=%s\n%s"
+           (Board.Post_id.to_string post.id)
+           (Board.Agent_id.to_string post.author)
+           (utf8_truncate post.content 300))
+  |> String.concat "\n\n"
+
+let heartbeat_read_tools =
+  [
+    "masc_board_get";
+    "masc_board_list";
+    "masc_board_search";
+    "lodge_search";
+    "lodge_profile";
+    "lodge_research";
+  ]
+
+let heartbeat_allowed_tools ~agent_name ~trigger ~recent_posts =
+  let tools = ref heartbeat_read_tools in
+  if recent_posts <> [] then tools := !tools @ [ "masc_board_vote" ];
+  if recent_posts <> [] && check_rate_limit ~agent_name `Comment then
+    tools := !tools @ [ "masc_board_comment" ];
+  if trigger_allows_post trigger && check_rate_limit ~agent_name `Post then
+    tools := !tools @ [ "masc_board_post" ];
+  List.sort_uniq String.compare !tools
+
+let classify_completion_action (completion : Lodge_worker.completion) =
+  if List.mem "masc_board_post" completion.tool_names then `Post
+  else if List.mem "masc_board_comment" completion.tool_names then `Comment
+  else if List.mem "masc_board_vote" completion.tool_names then `Vote
+  else `Skip
+
+let checkin_result_of_completion ~agent_name (completion : Lodge_worker.completion) =
+  (match classify_completion_action completion with
+   | `Post -> record_rate_action ~agent_name `Post
+   | `Comment -> record_rate_action ~agent_name `Comment
+   | `Vote -> record_rate_action ~agent_name `Vote
+   | `Skip -> ());
+  record_agent_activity ~name:agent_name;
+  match completion.status with
+  | Lodge_worker.Acted ->
+      let action =
+        match classify_completion_action completion with
+        | `Post -> ActionPost completion.summary
+        | `Comment -> ActionComment ("tool-loop", completion.summary)
+        | `Vote -> ActionUpvote "tool-loop"
+        | `Skip -> ActionSkip
+      in
+      Acted { action; summary = completion.summary }
+  | Lodge_worker.Skipped -> Passed completion.decision_reason
+  | Lodge_worker.Failed ->
+      Skipped
+        (Option.value ~default:completion.summary completion.failure_reason)
+
+let select_tool_loop_assignment ~agent_name ~trigger ~trigger_reason ~recent_posts =
+  let profile = load_agent_profile ~agent_name in
+  let signature = Lodge_reaction.get_or_compute_signature ~agent_name in
+  let all_keywords = reaction_keywords ~signature ~profile in
+  let sorted_posts =
+    sort_posts_for_agent ~agent_name ~agent_traits:all_keywords recent_posts
+    |> take_list 5
+  in
+  let identity_prompt =
+    let static_traits =
+      if signature.total_reactions < 5 then profile.traits @ profile.interests else []
+    in
+    if signature.total_reactions > 0 || static_traits <> [] then
+      Lodge_reaction.generate_identity_prompt signature ~static_traits
+    else load_agent_identity ~agent_name
+  in
+  let allowed_tools = heartbeat_allowed_tools ~agent_name ~trigger ~recent_posts:sorted_posts in
+  let prompt =
+    Lodge_decision.selection_prompt ~agent_name
+      ~candidate_agents:[ (agent_name, identity_prompt) ]
+      ~posts:
+        (List.map
+           (fun (post : Board.post) ->
+             ( Board.Post_id.to_string post.id,
+               Board.Agent_id.to_string post.author,
+               utf8_truncate post.content 300 ))
+           sorted_posts)
+      ~extra_context:
+        (Some
+           (Printf.sprintf
+              "Trigger: %s\nAllowed MCP tools for this run: %s\nSelect exactly one assignment for this agent. The worker will use tools directly."
+              trigger_reason (String.concat ", " allowed_tools)))
+      ~max_agents:1 ~allow_post:(List.mem "masc_board_post" allowed_tools)
+  in
+  let cascade_result =
+    run_heartbeat_llm_traced ~agent_name ~phase:"lodge_tool_assignment" ~prompt
+  in
+  match
+    Lodge_decision.parse_selection_plan ~allowed_agents:[ agent_name ]
+      ~allowed_post_ids:
+        (List.map (fun (post : Board.post) -> Board.Post_id.to_string post.id) sorted_posts)
+      ~max_agents:1 cascade_result.Lodge_cascade.response
+  with
+  | Ok { assignments = assignment :: _; _ } ->
+      Ok (assignment, identity_prompt, sorted_posts, allowed_tools)
+  | Ok _ -> Error "selection returned no assignments"
+  | Error reason -> Error reason
+
+let run_agent_tool_loop ~agent_name ~trigger ~trigger_reason ~recent_posts =
+  match select_tool_loop_assignment ~agent_name ~trigger ~trigger_reason ~recent_posts with
+  | Error reason -> Skipped ("tool_loop_selection_failed:" ^ reason)
+  | Ok (assignment, identity_prompt, sorted_posts, allowed_tools) ->
+      let context = heartbeat_tool_context sorted_posts in
+      if Env_config.LodgeV2.delegate_llm then begin
+        A2a_tools.emit_heartbeat_task ~agent:agent_name ~goal:assignment.goal ~context
+          ~allowed_tools ~decision_reason:assignment.reason
+          ~decision_confidence:assignment.confidence ();
+        Passed ("delegated_tool_loop:" ^ assignment.reason)
+      end else
+        match
+          Lodge_worker.run_local ~agent_name ~identity_prompt ~goal:assignment.goal
+            ~context ~allow_post:(List.mem "masc_board_post" allowed_tools)
+            ~allowed_tools_override:allowed_tools ()
+        with
+        | Error err -> Skipped ("tool_loop_failed:" ^ err)
+        | Ok completion -> checkin_result_of_completion ~agent_name completion
+
 let action_of_choice (choice : Lodge_decision.choice) : (agent_action, string) result =
   match (choice.action, choice.target_post_id, choice.content) with
   | Lodge_decision.Post, _, Some content -> Ok (ActionPost content)
@@ -2590,13 +2737,11 @@ let tick ~ignore_quiet_hours ~config ~pending_triggers =
       (name, trigger, Skipped "agent unhealthy (circuit breaker open)")
     else begin
       let trigger_reason = string_of_trigger trigger in
-      let decision =
-        decide_agent_action ~agent_name:name ~trigger ~trigger_reason ~recent_posts
-      in
-      let action = decision.action in
       let result =
         try
-          let outcome = execute_agent_action ~agent_name:name ~action in
+          let outcome =
+            run_agent_tool_loop ~agent_name:name ~trigger ~trigger_reason ~recent_posts
+          in
           (match outcome with
            | Acted _ -> Agent_health.record_success ~agent_name:name
            | Passed _ | Skipped _ -> ());
@@ -2615,34 +2760,11 @@ let tick ~ignore_quiet_hours ~config ~pending_triggers =
            Lodge_selection.record_action ~agent_name:name ~action:`Post
        | Acted { action = ActionComment _; _ } ->
            Lodge_selection.record_action ~agent_name:name ~action:`Comment
-       | Passed _
-       | Skipped _ ->
-           Lodge_selection.record_action ~agent_name:name ~action:`Skip
        | Acted { action = ActionUpvote _; _ }
-       | Acted { action = ActionSkip; _ } -> ());
-      match result with
-      | Acted { action = ActionPost content; _ } ->
-          let summary =
-            Printf.sprintf "Posted: %s (%s, %.2f)"
-              (utf8_truncate content 40) decision.reason decision.confidence
-          in
-          (name, trigger, Acted { action = ActionPost content; summary })
-      | Acted { action = ActionComment (post_id, content); _ } ->
-          let summary =
-            Printf.sprintf "Commented on %s: %s (%s, %.2f)" post_id
-              (utf8_truncate content 30) decision.reason decision.confidence
-          in
-          (name, trigger, Acted { action = ActionComment (post_id, content); summary })
-      | Acted { action = ActionUpvote post_id; _ } ->
-          let summary =
-            Printf.sprintf "Upvoted %s (%s, %.2f)" post_id decision.reason
-              decision.confidence
-          in
-          (name, trigger, Acted { action = ActionUpvote post_id; summary })
-      | Acted { action = ActionSkip; _ } ->
-          (name, trigger, Passed decision.reason)
-      | Passed reason -> (name, trigger, Passed reason)
-      | Skipped reason -> (name, trigger, Skipped reason)
+       | Acted { action = ActionSkip; _ }
+       | Passed _ | Skipped _ ->
+           Lodge_selection.record_action ~agent_name:name ~action:`Skip);
+      (name, trigger, result)
     end
   ) selected in
 
@@ -2731,13 +2853,11 @@ let make_lodge_tick_consumer ~config ~last_tick_time ~sw ~clock ~room_config
                 Printf.printf "[lodge] Skipping self-heartbeat for %s (unhealthy)\n%!" name
               else begin
                 let trigger_reason = "self-heartbeat continuation" in
-                let decision =
-                  decide_agent_action ~agent_name:name ~trigger:Scheduled ~trigger_reason
-                    ~recent_posts
-                in
-                let action = decision.action in
                 (try
-                  let outcome = execute_agent_action ~agent_name:name ~action in
+                  let outcome =
+                    run_agent_tool_loop ~agent_name:name ~trigger:Scheduled
+                      ~trigger_reason ~recent_posts
+                  in
                   (match outcome with
                    | Acted _ -> Agent_health.record_success ~agent_name:name
                    | Passed _ | Skipped _ -> ())

--- a/lib/lodge_worker.ml
+++ b/lib/lodge_worker.ml
@@ -1,0 +1,277 @@
+open Printf
+
+let ( let* ) value f = match value with Ok x -> f x | Error _ as err -> err
+
+type status =
+  | Acted
+  | Skipped
+  | Failed
+
+type completion = {
+  status : status;
+  summary : string;
+  decision_reason : string;
+  decision_confidence : float;
+  tool_call_count : int;
+  tool_names : string list;
+  worker_name : string;
+  model_used : string;
+  output : string;
+  failure_reason : string option;
+}
+
+let status_to_string = function
+  | Acted -> "acted"
+  | Skipped -> "skipped"
+  | Failed -> "failed"
+
+let status_of_string = function
+  | "acted" -> Ok Acted
+  | "skipped" -> Ok Skipped
+  | "failed" -> Ok Failed
+  | other -> Error (sprintf "unsupported worker status: %s" other)
+
+let trim_opt = function
+  | None -> None
+  | Some text ->
+      let trimmed = String.trim text in
+      if trimmed = "" then None else Some trimmed
+
+let default_allowed_tools ~allow_post =
+  let base =
+    [
+      "masc_board_get";
+      "masc_board_list";
+      "masc_board_search";
+      "masc_board_comment";
+      "masc_board_vote";
+      "lodge_search";
+      "lodge_profile";
+      "lodge_research";
+    ]
+  in
+  if allow_post then "masc_board_post" :: base else base
+
+let uniq items =
+  let rec loop seen = function
+    | [] -> List.rev seen
+    | x :: xs ->
+        if List.mem x seen then loop seen xs else loop (x :: seen) xs
+  in
+  loop [] items
+
+let allowed_tools ~allow_post ?(extra = []) () =
+  uniq (default_allowed_tools ~allow_post @ extra)
+
+let mcp_base_url () =
+  match Sys.getenv_opt "MASC_HTTP_BASE_URL" with
+  | Some raw when String.trim raw <> "" -> String.trim raw
+  | _ ->
+      let port =
+        match Sys.getenv_opt "MASC_HTTP_PORT" with
+        | Some raw when String.trim raw <> "" -> String.trim raw
+        | _ -> "8935"
+      in
+      sprintf "http://127.0.0.1:%s" port
+
+let worker_model_spec () =
+  let explicit =
+    match Sys.getenv_opt "MASC_LODGE_WORKER_MODEL" with
+    | Some raw when String.trim raw <> "" -> Some (String.trim raw)
+    | _ -> None
+  in
+  match explicit with
+  | Some spec -> Llm_client.model_spec_of_string spec
+  | None -> (
+      match Sys.getenv_opt "LLAMA_SWARM_MODEL" with
+      | Some raw when String.trim raw <> "" ->
+          Llm_client.model_spec_of_string ("llama:" ^ String.trim raw)
+      | _ ->
+          Error
+            "MASC_LODGE_WORKER_MODEL (provider:model) or LLAMA_SWARM_MODEL is required for Lodge MCP workers")
+
+let base_path () =
+  Room_utils.resolve_masc_base_path (Sys.getcwd ())
+
+let extract_json_object = Lodge_decision.extract_json_object
+
+let parse_confidence = function
+  | `Float f -> Ok f
+  | `Int i -> Ok (float_of_int i)
+  | _ -> Error "decision_confidence must be numeric"
+
+let parse_completion_json (text : string) : (completion, string) result =
+  let open Yojson.Safe.Util in
+  let* json_text = extract_json_object text in
+  let* json =
+    try Ok (Yojson.Safe.from_string json_text)
+    with Yojson.Json_error msg -> Error (sprintf "invalid worker JSON: %s" msg)
+  in
+  let* status =
+    match json |> member "status" with
+    | `String s -> status_of_string (String.lowercase_ascii (String.trim s))
+    | _ -> Error "status must be a string"
+  in
+  let* summary =
+    match json |> member "summary" with
+    | `String s ->
+        let trimmed = String.trim s in
+        if trimmed = "" then Error "summary must be non-empty" else Ok trimmed
+    | _ -> Error "summary must be a string"
+  in
+  let* decision_reason =
+    match json |> member "decision_reason" with
+    | `String s ->
+        let trimmed = String.trim s in
+        if trimmed = "" then Error "decision_reason must be non-empty" else Ok trimmed
+    | _ -> Error "decision_reason must be a string"
+  in
+  let* decision_confidence =
+    match parse_confidence (json |> member "decision_confidence") with
+    | Ok value when value >= 0.0 && value <= 1.0 -> Ok value
+    | Ok _ -> Error "decision_confidence must be between 0.0 and 1.0"
+    | Error _ as err -> err
+  in
+  let failure_reason =
+    json |> member "failure_reason" |> to_string_option |> trim_opt
+  in
+  Ok
+    {
+      status;
+      summary;
+      decision_reason;
+      decision_confidence;
+      tool_call_count = 0;
+      tool_names = [];
+      worker_name = "";
+      model_used = "";
+      output = text;
+      failure_reason;
+    }
+
+let action_tool_names =
+  [ "masc_board_post"; "masc_board_comment"; "masc_board_vote"; "masc_board_comment_vote" ]
+
+let acted_by_tools tool_names =
+  List.exists (fun name -> List.mem name action_tool_names) tool_names
+
+let default_summary tool_names =
+  if tool_names = [] then "No tools executed."
+  else sprintf "Executed tools: %s" (String.concat ", " tool_names)
+
+let default_reason tool_names =
+  if acted_by_tools tool_names then "worker acted via MCP tools"
+  else "worker inspected context and chose not to act"
+
+let build_prompt ~agent_name ~identity_prompt ~goal ~context =
+  sprintf
+    {|You are Lodge agent %s.
+
+Identity context:
+%s
+
+Goal:
+%s
+
+Operational context:
+%s
+
+Use the provided MASC MCP tools directly.
+Decide for yourself which tools to call, in what order, and whether to act or skip.
+If you act, the action must happen via tools, not prose.
+If you skip, explain why.
+
+When you are done, return JSON only:
+{
+  "status": "acted|skipped|failed",
+  "summary": "what you actually did, or why you skipped",
+  "decision_reason": "why this choice fit your identity and the context",
+  "decision_confidence": 0.0,
+  "failure_reason": "optional"
+}
+
+Rules:
+- Do not invent tools or arguments.
+- Prefer the minimal number of tools that yields a defensible action.
+- If you use no write tools, status should be "skipped" unless execution failed.
+- decision_confidence must be between 0.0 and 1.0.
+- summary and decision_reason must be non-empty.|}
+    agent_name identity_prompt goal context
+
+let run_local ~agent_name ~identity_prompt ~goal ~context ~allow_post
+    ?allowed_tools_override ?(allowed_tools_extra = []) () :
+    (completion, string) result =
+  let* model = worker_model_spec () in
+  let prompt = build_prompt ~agent_name ~identity_prompt ~goal ~context in
+  let worker_name =
+    let digest =
+      Digest.string (agent_name ^ goal ^ string_of_float (Time_compat.now ()))
+      |> Digest.to_hex
+    in
+    sprintf "lodge-worker-%s-%s" agent_name (String.sub digest 0 8)
+  in
+  let allowed_tools =
+    match allowed_tools_override with
+    | Some names -> uniq names
+    | None -> allowed_tools ~allow_post ~extra:allowed_tools_extra ()
+  in
+  Eio.Switch.run (fun sw ->
+      match
+        Local_agent_eio.run_worker ~sw ~base_path:(base_path ()) ~worker_name ~model
+          ~team_session_id:None ~role:(Some "lodge-worker") ~selection_note:None
+          ~prompt ~allowed_tools ~timeout_sec:90
+      with
+      | Error e -> Error e
+      | Ok run_result ->
+          let parsed = parse_completion_json run_result.output in
+          let tool_names = run_result.tool_names in
+          let tool_call_count = run_result.tool_call_count in
+          let model_used = run_result.model_used in
+          let output = run_result.output in
+          let acted = acted_by_tools tool_names in
+          let completion =
+            match parsed with
+            | Ok parsed ->
+                {
+                  parsed with
+                  status =
+                    (match parsed.status with
+                    | Failed -> Failed
+                    | Acted when acted -> Acted
+                    | Acted -> Failed
+                    | Skipped when acted -> Acted
+                    | Skipped -> Skipped);
+                  summary =
+                    (match trim_opt (Some parsed.summary) with
+                    | Some value -> value
+                    | None -> default_summary tool_names);
+                  decision_reason =
+                    (match trim_opt (Some parsed.decision_reason) with
+                    | Some value -> value
+                    | None -> default_reason tool_names);
+                  tool_call_count;
+                  tool_names;
+                  worker_name;
+                  model_used;
+                  output;
+                  failure_reason =
+                    (match parsed.status with
+                    | Acted when not acted ->
+                        Some "worker reported acted without any board write tool"
+                    | _ -> parsed.failure_reason);
+                }
+            | Error parse_error ->
+                {
+                  status = if acted then Acted else Failed;
+                  summary = default_summary tool_names;
+                  decision_reason = default_reason tool_names;
+                  decision_confidence = 0.0;
+                  tool_call_count;
+                  tool_names;
+                  worker_name;
+                  model_used;
+                  output;
+                  failure_reason = Some parse_error;
+                }
+          in
+          Ok completion)

--- a/lib/masc_mcp.ml
+++ b/lib/masc_mcp.ml
@@ -128,6 +128,7 @@ module Dashboard = Dashboard
 module Tempo = Tempo
 module Federation = Federation
 module Lodge_decision = Lodge_decision
+module Lodge_worker = Lodge_worker
 module Level2_config = Level2_config
 module Level4_config = Level4_config
 module Local_agent_eio = Local_agent_eio

--- a/lib/tool_a2a.ml
+++ b/lib/tool_a2a.ml
@@ -94,12 +94,32 @@ let handle_poll_events _ctx args =
 let handle_heartbeat_result _ctx args =
   let worker_name = get_string args "worker_name" "" in
   let agent = get_string args "agent" "" in
-  let action_type = get_string args "action_type" "" in
-  let content = get_string args "content" "" in
-  if worker_name = "" || agent = "" || action_type = "" then
-    (false, "❌ worker_name, agent, and action_type are required")
+  let status = get_string args "status" "" in
+  let summary = get_string args "summary" "" in
+  let tool_call_count = get_int args "tool_call_count" 0 in
+  let tool_names =
+    match Yojson.Safe.Util.member "tool_names" args with
+    | `List items -> List.filter_map (function `String s -> Some s | _ -> None) items
+    | _ -> []
+  in
+  let decision_reason = get_string args "decision_reason" "" in
+  let decision_confidence =
+    match Yojson.Safe.Util.member "decision_confidence" args with
+    | `Float f -> f
+    | `Int n -> float_of_int n
+    | _ -> -1.0
+  in
+  let failure_reason = get_string_opt args "failure_reason" in
+  if worker_name = "" || agent = "" || status = "" || summary = "" || decision_reason = "" then
+    (false, "❌ worker_name, agent, status, summary, and decision_reason are required")
+  else if decision_confidence < 0.0 || decision_confidence > 1.0 then
+    (false, "❌ decision_confidence must be between 0.0 and 1.0")
   else
-    match A2a_tools.submit_heartbeat_result ~worker_name ~agent ~action_type ~content () with
+    match
+      A2a_tools.submit_heartbeat_result ~worker_name ~agent ~status ~summary
+        ~tool_call_count ~tool_names ~decision_reason ~decision_confidence
+        ?failure_reason ()
+    with
     | Ok json -> (true, Yojson.Safe.pretty_to_string json)
     | Error e -> (false, Printf.sprintf "❌ Submit result failed: %s" e)
 

--- a/lib/tool_lodge.ml
+++ b/lib/tool_lodge.ml
@@ -141,11 +141,63 @@ let http_get_json ~net:_ url =
 
 (* NOTE: http_get_local removed — using curl subprocess for all HTTP *)
 
+let trim_trailing_slash s =
+  let trimmed = String.trim s in
+  let len = String.length trimmed in
+  if len > 0 && trimmed.[len - 1] = '/' then
+    String.sub trimmed 0 (len - 1)
+  else
+    trimmed
+
 (** Use local GraphQL by default for local MCP runs.
     Set GRAPHQL_URL explicitly to force remote endpoint. *)
 let default_graphql_url () =
-  let port = Sys.getenv_opt "MASC_MCP_PORT" |> Option.value ~default:"8935" in
-  Printf.sprintf "http://127.0.0.1:%s/graphql" port
+  match Sys.getenv_opt "MASC_HTTP_BASE_URL" with
+  | Some raw when String.trim raw <> "" ->
+      trim_trailing_slash raw ^ "/graphql"
+  | _ ->
+      let port = Sys.getenv_opt "MASC_HTTP_PORT" |> Option.value ~default:"8935" in
+      Printf.sprintf "http://127.0.0.1:%s/graphql" port
+
+let graphql_url () =
+  match Sys.getenv_opt "GRAPHQL_URL" with
+  | Some raw when String.trim raw <> "" -> String.trim raw
+  | _ -> default_graphql_url ()
+
+let looks_like_html_response body =
+  let trimmed = String.lowercase_ascii (String.trim body) in
+  trimmed <> "" && trimmed.[0] = '<'
+
+let ensure_graphql_json_response body =
+  if String.length body = 0 then
+    Error "❌ GraphQL: empty response"
+  else if looks_like_html_response body then
+    Error "❌ GraphQL: endpoint returned HTML instead of JSON"
+  else
+    Ok body
+
+let graphql_error_message json =
+  match Yojson.Safe.Util.member "errors" json with
+  | `List (first :: _) ->
+      first |> Yojson.Safe.Util.member "message" |> Yojson.Safe.Util.to_string_option
+  | _ -> None
+
+let graphql_agents_edges json =
+  match graphql_error_message json with
+  | Some msg -> Error ("GraphQL error: " ^ msg)
+  | None ->
+      let data = Yojson.Safe.Util.member "data" json in
+      if data = `Null then
+        Error "GraphQL data is null"
+      else
+        let agents = Yojson.Safe.Util.member "agents" data in
+        if agents = `Null then
+          Error "GraphQL agents is null"
+        else
+          match Yojson.Safe.Util.member "edges" agents with
+          | `List edges -> Ok edges
+          | `Null -> Ok []
+          | _ -> Error "GraphQL agents.edges is not a list"
 
 (** Keep auth token out of argv so process errors don't leak secrets. *)
 let with_auth_header_file api_key f =
@@ -163,13 +215,14 @@ let with_auth_header_file api_key f =
 
 (** curl-based GraphQL request — reliable DNS resolution in Railway containers *)
 let graphql_request_curl body : (string, string) Stdlib.result =
-  let url = Sys.getenv_opt "GRAPHQL_URL" |> Option.value ~default:(default_graphql_url ()) in
+  let url = graphql_url () in
   let api_key = Sys.getenv_opt "GRAPHQL_API_KEY" |> Option.value ~default:"" in
   with_auth_header_file api_key (fun auth_header_file ->
       try
         let argv =
-          [ "curl"; "-s"; "-m"; "10"; "-f"; url;
+          [ "curl"; "-s"; "-m"; "10"; "-f"; "-X"; "POST"; url;
             "-H"; "Content-Type: application/json"
+            ; "-H"; "Accept: application/json"
           ]
           |> fun base ->
           match auth_header_file with
@@ -180,14 +233,14 @@ let graphql_request_curl body : (string, string) Stdlib.result =
           with_auth @ [ "-d"; "@-" ]
         in
         let output = Process_eio.run_argv_with_stdin ~timeout_sec:15.0 ~stdin_content:body argv in
-        if String.length output = 0 then Error "❌ GraphQL curl: empty response" else Ok output
+        ensure_graphql_json_response output
       with exn -> Error (Printf.sprintf "❌ GraphQL curl: %s" (Printexc.to_string exn)))
 
 (** GraphQL request via Cohttp_eio with curl fallback.
     Falls back to curl if Cohttp fails (Railway DNS issues).
     URL configurable via GRAPHQL_URL env var for Railway internal networking. *)
 let graphql_request ?(timeout_sec=5.0) body : (string, string) Stdlib.result =
-  let url = Sys.getenv_opt "GRAPHQL_URL" |> Option.value ~default:(default_graphql_url ()) in
+  let url = graphql_url () in
   let api_key = Sys.getenv_opt "GRAPHQL_API_KEY" |> Option.value ~default:"" in
   let max_response_bytes = 1_000_000 in
   let cohttp_result = match Eio_context.get_net_opt () with
@@ -220,12 +273,10 @@ let graphql_request ?(timeout_sec=5.0) body : (string, string) Stdlib.result =
           let body_str =
             Eio.Buf_read.(parse_exn take_all) resp_body ~max_size:max_response_bytes
           in
-          if String.length body_str = 0 then
-            Error "❌ GraphQL: empty response"
-          else if Cohttp.Code.is_success status then
-            Ok body_str
-          else
+          if not (Cohttp.Code.is_success status) then
             Error (Printf.sprintf "❌ GraphQL: HTTP %d" status)
+          else
+            ensure_graphql_json_response body_str
         )
       in
       match Eio_context.get_clock_opt () with
@@ -637,6 +688,70 @@ type agent_config = {
   interests: string list;
 }
 
+let builtin_core_agent_configs () =
+  [
+    {
+      name = "dreamer";
+      primary_value = Some "imagination";
+      value_weights = None;
+      prompt_template = None;
+      generation = 0;
+      status = "active";
+      emoji = "🌙";
+      korean_name = "몽상가";
+      model = "glm-4.7-flash:latest";
+      interests = [ "vision"; "future"; "art"; "possibility" ];
+    };
+    {
+      name = "skeptic";
+      primary_value = Some "verification";
+      value_weights = None;
+      prompt_template = None;
+      generation = 0;
+      status = "active";
+      emoji = "🧐";
+      korean_name = "회의론자";
+      model = "glm-4.7-flash:latest";
+      interests = [ "evidence"; "risk"; "debugging"; "correctness" ];
+    };
+    {
+      name = "historian";
+      primary_value = Some "memory";
+      value_weights = None;
+      prompt_template = None;
+      generation = 0;
+      status = "active";
+      emoji = "📚";
+      korean_name = "역사가";
+      model = "glm-4.7-flash:latest";
+      interests = [ "context"; "history"; "continuity"; "archives" ];
+    };
+    {
+      name = "pragmatist";
+      primary_value = Some "utility";
+      value_weights = None;
+      prompt_template = None;
+      generation = 0;
+      status = "active";
+      emoji = "🔧";
+      korean_name = "실용주의자";
+      model = "glm-4.7-flash:latest";
+      interests = [ "operations"; "execution"; "delivery"; "practicality" ];
+    };
+    {
+      name = "connector";
+      primary_value = Some "synthesis";
+      value_weights = None;
+      prompt_template = None;
+      generation = 0;
+      status = "active";
+      emoji = "🕸️";
+      korean_name = "연결자";
+      model = "glm-4.7-flash:latest";
+      interests = [ "relationships"; "coordination"; "bridges"; "community" ];
+    };
+  ]
+
 (** In-memory cache for dynamic agents (protected by mutex for concurrent access) *)
 let agent_cache : (string, agent_config) Hashtbl.t = Hashtbl.create 10
 let agent_cache_mu = Mutex.create ()
@@ -781,54 +896,57 @@ let load_agents_config () =
           Printf.eprintf "[Lodge] GraphQL response: %d bytes\n%!" (String.length json_str);
           (* Parse JSON response *)
           let json = Yojson.Safe.from_string json_str in
-          let edges = json
-            |> Yojson.Safe.Util.member "data"
-            |> Yojson.Safe.Util.member "agents"
-            |> Yojson.Safe.Util.member "edges"
-            |> Yojson.Safe.Util.to_list
-          in
-          List.iter (fun edge ->
-            try
-              let node = Yojson.Safe.Util.member "node" edge in
-              let name = Yojson.Safe.Util.(member "name" node |> to_string) in
-              let interests_json = Yojson.Safe.Util.(member "interests" node) in
-              let interests = match interests_json with
-                | `List items -> List.filter_map (fun i -> Yojson.Safe.Util.to_string_option i) items
-                | _ -> []
-              in
-              let config = {
-                name;
-                primary_value = Yojson.Safe.Util.(member "primaryValue" node |> to_string_option);
-                value_weights = Yojson.Safe.Util.(member "valueWeights" node |> to_string_option);
-                prompt_template = Yojson.Safe.Util.(member "promptTemplate" node |> to_string_option);
-                generation = Yojson.Safe.Util.(member "generation" node |> to_int_option) |> Option.value ~default:0;
-                status = Yojson.Safe.Util.(member "status" node |> to_string_option) |> Option.value ~default:"active";
-                emoji = Yojson.Safe.Util.(member "emoji" node |> to_string_option) |> Option.value ~default:"🤖";
-                korean_name = Yojson.Safe.Util.(member "koreanName" node |> to_string_option) |> Option.value ~default:name;
-                model = Yojson.Safe.Util.(member "model" node |> to_string_option) |> Option.value ~default:"glm-4.7-flash:latest";
-                interests;
-              } in
-              Mutex.lock agent_cache_mu;
-              Hashtbl.replace agent_cache config.name config;
-              Mutex.unlock agent_cache_mu
-            with Yojson.Safe.Util.Type_error _ | Yojson.Json_error _ -> ()
-          ) edges;
-          Mutex.lock agent_cache_mu;
-          let n = Hashtbl.length agent_cache in
-          Mutex.unlock agent_cache_mu;
-          if n > 0 then begin
-            graphql_success := true;
-            Printf.eprintf "[Lodge] ✅ Loaded %d SOUL agents from Neo4j\n%!" n;
-            (* Save to file cache for offline fallback *)
-            save_agents_to_file_cache ()
-          end
+          (match graphql_agents_edges json with
+           | Error msg ->
+               Printf.eprintf "[Lodge] GraphQL agent parse failed: %s\n%!" msg
+           | Ok edges ->
+               List.iter (fun edge ->
+                 try
+                   let node = Yojson.Safe.Util.member "node" edge in
+                   let name = Yojson.Safe.Util.(member "name" node |> to_string) in
+                   let interests_json = Yojson.Safe.Util.(member "interests" node) in
+                   let interests = match interests_json with
+                     | `List items -> List.filter_map (fun i -> Yojson.Safe.Util.to_string_option i) items
+                     | _ -> []
+                   in
+                   let config = {
+                     name;
+                     primary_value = Yojson.Safe.Util.(member "primaryValue" node |> to_string_option);
+                     value_weights = Yojson.Safe.Util.(member "valueWeights" node |> to_string_option);
+                     prompt_template = Yojson.Safe.Util.(member "promptTemplate" node |> to_string_option);
+                     generation = Yojson.Safe.Util.(member "generation" node |> to_int_option) |> Option.value ~default:0;
+                     status = Yojson.Safe.Util.(member "status" node |> to_string_option) |> Option.value ~default:"active";
+                     emoji = Yojson.Safe.Util.(member "emoji" node |> to_string_option) |> Option.value ~default:"🤖";
+                     korean_name = Yojson.Safe.Util.(member "koreanName" node |> to_string_option) |> Option.value ~default:name;
+                     model = Yojson.Safe.Util.(member "model" node |> to_string_option) |> Option.value ~default:"glm-4.7-flash:latest";
+                     interests;
+                   } in
+                   Mutex.lock agent_cache_mu;
+                   Hashtbl.replace agent_cache config.name config;
+                   Mutex.unlock agent_cache_mu
+                 with Yojson.Safe.Util.Type_error _ | Yojson.Json_error _ -> ()
+               ) edges;
+               Mutex.lock agent_cache_mu;
+               let n = Hashtbl.length agent_cache in
+               Mutex.unlock agent_cache_mu;
+               if n > 0 then begin
+                 graphql_success := true;
+                 Printf.eprintf "[Lodge] ✅ Loaded %d SOUL agents from Neo4j\n%!" n;
+                 save_agents_to_file_cache ()
+               end)
     with e ->
       Printf.eprintf "[Lodge] ❌ GraphQL failed: %s\n%!" (Printexc.to_string e)
     end;
     (* Fallback to file cache if GraphQL failed *)
     if not !graphql_success then begin
       Printf.eprintf "[Lodge] Trying file cache fallback...\n%!";
-      if not (load_agents_from_file_cache ()) then
+      if not (load_agents_from_file_cache ()) then begin
+        Printf.eprintf "[Lodge] Falling back to builtin core identities\n%!";
+        Mutex.lock agent_cache_mu;
+        List.iter (fun cfg -> Hashtbl.replace agent_cache cfg.name cfg) (builtin_core_agent_configs ());
+        Mutex.unlock agent_cache_mu;
+      end;
+      if not (has_cached_agents_in_memory ()) then
         Printf.eprintf "[Lodge] ⚠ No agents available (GraphQL failed, no valid cache)\n%!"
     end
   end
@@ -996,7 +1114,7 @@ let random_agent_name () =
 
 (** Validate agent name exists in cache (replaces validate_agent_name) *)
 let validate_agent_name name =
-  if name = "random" || name = "랜덤" then Some (random_agent_name ())
+  if name = "random" || name = "랜덤" then None
   else match get_cached_agent name with
     | Some _ -> Some name
     | None ->
@@ -1082,62 +1200,113 @@ let translate_to_korean ~net text =
     | Error _ -> text  (* fallback to original *)
 
 type lodge_reaction_outcome =
-  | Delegated
-  | Comment of string
-  | Upvote
-  | Skip of string
+  | Delegated of string
+  | Completed of Lodge_worker.completion
 
-let localize_decision_content ~net (choice : Lodge_decision.choice) =
-  match (choice.action, choice.content, lodge_language) with
-  | Lodge_decision.Comment, Some content, "ko" ->
-      { choice with content = Some (translate_to_korean ~net content) }
-  | _ -> choice
+let default_reaction_goal ?target_post_id ~allow_post () =
+  match target_post_id, allow_post with
+  | Some post_id, _ ->
+      Printf.sprintf
+        "Inspect board post %s, decide whether to comment, upvote, or skip, and use MASC tools directly to carry out the decision. Do not create a new top-level post."
+        post_id
+  | None, true ->
+      "Inspect the provided board context and decide whether to write a new top-level post, comment on an existing post, upvote, or skip. Use MASC tools directly to carry out the decision."
+  | None, false ->
+      "Inspect the provided board context and decide whether to comment, upvote, or skip using MASC tools directly. Do not create a new top-level post."
+
+let reaction_context posts =
+  posts
+  |> List.map (fun (post_id, content) ->
+         Printf.sprintf "[target_post_id=%s]\n%s" post_id content)
+  |> String.concat "\n\n"
+
+let select_reaction_assignments ~net ~agent_name_opt ~posts ~max_agents ~allow_post
+    : (Lodge_decision.assignment list, string) Stdlib.result =
+  let candidate_post_ids = List.map fst posts in
+  let explicit_agent =
+    match agent_name_opt with
+    | Some name -> validate_agent_name name
+    | None -> None
+  in
+  match explicit_agent with
+  | Some agent_name ->
+      Ok
+        [
+          {
+            Lodge_decision.agent_name;
+            target_post_id =
+              (match posts with
+              | (post_id, _) :: _ -> Some post_id
+              | [] -> None);
+            goal =
+              default_reaction_goal
+                ?target_post_id:
+                  (match posts with
+                  | (post_id, _) :: _ -> Some post_id
+                  | [] -> None)
+                ~allow_post ();
+            reason = "explicitly requested agent";
+            confidence = 1.0;
+          };
+        ]
+  | None ->
+      let candidate_agents =
+        get_all_agent_names ()
+        |> List.map (fun name -> (name, get_agent_prompt name))
+      in
+      let prompt =
+        Lodge_decision.selection_prompt ~agent_name:"lodge-orchestrator"
+          ~candidate_agents
+          ~posts:(List.map (fun (post_id, content) -> (post_id, "unknown", content)) posts)
+          ~extra_context:
+            (Some
+               "Choose the best reacting agents for this board context. They should inspect the posts and use Lodge-safe MCP tools directly.")
+          ~max_agents ~allow_post
+      in
+      let system =
+        "/no_think\nReturn valid JSON only. Do not use markdown fences."
+      in
+      match smart_generate ~net ~temperature:0.2 ~num_predict:500 ~system prompt with
+      | Error e -> Error e
+      | Ok response -> (
+          match
+            Lodge_decision.parse_selection_plan
+              ~allowed_agents:(List.map fst candidate_agents)
+              ~allowed_post_ids:candidate_post_ids ~max_agents response
+          with
+          | Ok plan when plan.assignments <> [] -> Ok plan.assignments
+          | Ok _ -> Error "selection returned no assignments"
+          | Error e -> Error (Printf.sprintf "❌ Lodge selection: %s" e))
 
 (** React to content with a dynamic agent (from Neo4j cache) *)
-let react_to_content ~net ?agent_name:provided_name ~post_id content =
-  let agent_name = match provided_name with
-    | Some n -> n
-    | None -> random_agent_name ()
-  in
-  (* Get prompt from Neo4j cache *)
-  let agent_desc = get_agent_prompt agent_name in
-
-  (* Get agent's existing interests for context *)
-  let existing_interests = get_agent_interests ~agent_name in
-  let prompt =
-    Lodge_decision.single_reaction_prompt
-      ~agent_name
-      ~agent_prompt:agent_desc
-      ~interests:existing_interests
-      ~post_id
-      ~content
-      ~language_instruction:(language_instruction ())
-  in
-  let system =
-    "/no_think\nReturn valid JSON only. Do not use markdown fences."
-  in
-  (* A2A delegation: emit event for external worker instead of local LLM *)
-  if Env_config.LodgeV2.delegate_llm then begin
-    A2a_tools.emit_heartbeat_task ~agent:agent_name ~prompt:system
-      ~context:prompt ();
-    Ok Delegated
-  end else
-  match smart_generate ~net ~temperature:0.3 ~num_predict:350 ~system prompt with
+let react_to_content ~net ~agent_name_opt ~post_id content =
+  match
+    select_reaction_assignments ~net ~agent_name_opt
+      ~posts:[ (post_id, content) ] ~max_agents:1 ~allow_post:false
+  with
   | Error e -> Error e
-  | Ok response ->
-      (match Lodge_decision.parse_single_choice ~post_id response with
-       | Error e -> Error (Printf.sprintf "❌ Lodge decision: %s" e)
-       | Ok choice ->
-           let choice = localize_decision_content ~net choice in
-           let new_interests = extract_interests ~net content in
-           let _ = save_interests_to_neo4j ~agent_name new_interests in
-           match choice.action with
-           | Lodge_decision.Comment ->
-               Ok (Comment (Option.value ~default:"" choice.content))
-           | Lodge_decision.Upvote -> Ok Upvote
-           | Lodge_decision.Skip -> Ok (Skip choice.reason)
-           | Lodge_decision.Post ->
-               Error "❌ Lodge decision: post action is not allowed for reactions")
+  | Ok (assignment :: _) ->
+      let agent_name = assignment.agent_name in
+      let agent_desc = get_agent_prompt agent_name in
+      let reaction_context = reaction_context [ (post_id, content) ] in
+      let allowed_tools = Lodge_worker.allowed_tools ~allow_post:false () in
+      if Env_config.LodgeV2.delegate_llm then begin
+        A2a_tools.emit_heartbeat_task ~agent:agent_name ~goal:assignment.goal
+          ~context:reaction_context ~allowed_tools
+          ~decision_reason:assignment.reason
+          ~decision_confidence:assignment.confidence ();
+        Ok (Delegated agent_name)
+      end else (
+        match
+          Lodge_worker.run_local ~agent_name ~identity_prompt:agent_desc
+            ~goal:assignment.goal ~context:reaction_context ~allow_post:false ()
+        with
+        | Error e -> Error e
+        | Ok completion ->
+            let new_interests = extract_interests ~net content in
+            let _ = save_interests_to_neo4j ~agent_name new_interests in
+            Ok (Completed completion))
+  | Ok [] -> Error "reaction selection returned no assignments"
 
 (** {1 Heartbeat: Full Read → Dig → Share cycle} *)
 
@@ -1182,23 +1351,30 @@ let heartbeat ~net (args : Yojson.Safe.t) =
           with Not_found -> "" in
           (* Auto-trigger reactions from agents *)
           let reactions = if post_id <> "" then
-            List.filter_map (fun agent ->
-              match react_to_content ~net ~agent_name:agent ~post_id content with
-              | Error _ -> None
-              | Ok Delegated -> Some (Printf.sprintf "🔮 %s (delegated)" agent)
-              | Ok (Comment reaction) ->
-                let display_name = format_agent_name_dynamic agent in
-                let args = `Assoc [("post_id", `String post_id); ("content", `String (Printf.sprintf "%s\n%s" display_name reaction)); ("author", `String agent)] in
-                let (ok, _) = Tool_board.handle_tool "masc_board_comment" args in
-                if ok then Some (Printf.sprintf "💬 %s" agent) else None
-              | Ok Upvote ->
-                let vote_args = `Assoc [("post_id", `String post_id); ("voter", `String agent); ("direction", `String "up")] in
-                let (ok, _) = Tool_board.handle_tool "masc_board_vote" vote_args in
-                if ok then Some (Printf.sprintf "👍 %s" agent) else None
-              | Ok (Skip _) -> Some (Printf.sprintf "⏭️ %s" agent)
-            ) (let names = get_all_agent_names () in
-               if List.length names >= 2 then [List.nth names 0; List.nth names 1]
-               else names)
+            match
+              select_reaction_assignments ~net ~agent_name_opt:None
+                ~posts:[ (post_id, content) ] ~max_agents:2 ~allow_post:false
+            with
+            | Error _ -> []
+            | Ok assignments ->
+                List.filter_map
+                  (fun (assignment : Lodge_decision.assignment) ->
+                    match
+                      react_to_content ~net ~agent_name_opt:(Some assignment.agent_name)
+                        ~post_id content
+                    with
+                    | Error _ -> None
+                    | Ok (Delegated agent) ->
+                        Some (Printf.sprintf "🔮 %s (delegated)" agent)
+                    | Ok (Completed completion) ->
+                        Some
+                          (Printf.sprintf "%s %s"
+                             (match completion.status with
+                             | Lodge_worker.Acted -> "🛠️"
+                             | Lodge_worker.Skipped -> "⏭️"
+                             | Lodge_worker.Failed -> "❌")
+                             assignment.agent_name))
+                  assignments
           else [] in
           match reactions with [] -> "" | rs -> "\n🎭 " ^ String.concat ", " rs
         end else "" in
@@ -1230,10 +1406,7 @@ let rec react ~net (args : Yojson.Safe.t) =
   let post_id_arg = Safe_ops.json_string ~default:"" "post_id" args in
   let agent_str = Safe_ops.json_string ~default:"random" "agent" args in
   let skip_classify = Safe_ops.json_bool ~default:true "skip_classify" args in
-  let agent_name = match validate_agent_name agent_str with
-    | Some n -> n
-    | None -> random_agent_name ()
-  in
+  let agent_name = validate_agent_name agent_str in
   if post_id_arg = "" then (false, "❌ Lodge: post_id required")
   else
     let post_id =
@@ -1253,30 +1426,31 @@ let rec react ~net (args : Yojson.Safe.t) =
     else
       let clean_content = extract_post_content detail in
       if skip_classify then
-      match react_to_content ~net ~agent_name ~post_id clean_content with
-      | Error e -> (false, Printf.sprintf "❌ Lodge: React failed [agent=%s, error=%s]" agent_name e)
-      | Ok Delegated -> (true, Printf.sprintf "🔮 Lodge reaction delegated for %s [agent=%s]" post_id agent_name)
-      | Ok (Comment reaction) ->
-        let display_name = format_agent_name_dynamic agent_name in
-        let comment_args = `Assoc [
-          ("post_id", `String post_id);
-          ("content", `String (Printf.sprintf "%s\n%s" display_name reaction));
-          ("author", `String agent_name);
-        ] in
-        let (ok, msg) = Tool_board.handle_tool "masc_board_comment" comment_args in
-        if ok then (true, Printf.sprintf "💬 Lodge comment posted on %s" post_id)
-        else (false, Printf.sprintf "❌ Lodge: Comment failed [post=%s, error=%s]" post_id msg)
-      | Ok Upvote ->
-        let vote_args = `Assoc [
-          ("post_id", `String post_id);
-          ("voter", `String agent_name);
-          ("direction", `String "up");
-        ] in
-        let (ok, msg) = Tool_board.handle_tool "masc_board_vote" vote_args in
-        if ok then (true, Printf.sprintf "👍 Lodge upvoted %s [agent=%s]" post_id agent_name)
-        else (false, Printf.sprintf "❌ Lodge: Upvote failed [post=%s, error=%s]" post_id msg)
-      | Ok (Skip reason) ->
-        (true, Printf.sprintf "⏭️ %s skipped %s (%s)" agent_name post_id reason)
+      match react_to_content ~net ~agent_name_opt:agent_name ~post_id clean_content with
+      | Error e ->
+          (false,
+           Printf.sprintf "❌ Lodge: React failed [agent=%s, error=%s]"
+             (Option.value ~default:"auto" agent_name) e)
+      | Ok (Delegated agent) ->
+          (true, Printf.sprintf "🔮 Lodge reaction delegated for %s [agent=%s]" post_id agent)
+      | Ok (Completed completion) -> (
+          match completion.status with
+          | Lodge_worker.Acted ->
+              (true,
+               Printf.sprintf "🛠️ Lodge worker acted on %s [agent=%s, tools=%s]"
+                 post_id completion.worker_name
+                 (if completion.tool_names = [] then "none"
+                  else String.concat ", " completion.tool_names))
+          | Lodge_worker.Skipped ->
+              (true,
+               Printf.sprintf "⏭️ %s skipped %s (%s)"
+                 completion.worker_name post_id
+                 completion.decision_reason)
+          | Lodge_worker.Failed ->
+              (false,
+               Printf.sprintf "❌ Lodge worker failed [agent=%s, error=%s]"
+                 completion.worker_name
+                 (Option.value ~default:completion.summary completion.failure_reason)))
     else
       let cls = classify_content ~net clean_content in
       match cls.category with
@@ -1285,7 +1459,7 @@ let rec react ~net (args : Yojson.Safe.t) =
       | Review ->
         react ~net (`Assoc [
           ("post_id", `String post_id);
-          ("agent", `String agent_name);
+          ("agent", `String (Option.value ~default:"random" agent_name));
           ("skip_classify", `Bool true);
         ])
 
@@ -1306,21 +1480,16 @@ let full_cycle ~net (args : Yojson.Safe.t) =
     in
     if post_id = "" then (true, Printf.sprintf "%s\n(no post_id found for reaction)" msg)
     else
-      (* Step 2: ONE random agent reacts *)
-      let agent = random_agent_name () in
       let (ok2, result) = react ~net (`Assoc [
         ("post_id", `String post_id);
-        ("agent", `String agent);
+        ("agent", `String "random");
       ]) in
-      let model = get_agent_model agent in
-      (true, Printf.sprintf "%s\n\n💬 %s [%s] reacted:\n%s"
-        msg agent model (if ok2 then result else "❌ " ^ result))
+      (true, Printf.sprintf "%s\n\n💬 Lodge reacted:\n%s"
+        msg (if ok2 then result else "❌ " ^ result))
 
 (** {1 Discussion: agents read and react to EACH OTHER's posts} *)
 
 let lodge_discussion ~net (_args : Yojson.Safe.t) =
-  let agent = random_agent_name () in
-
   let (ok, posts_result) = Tool_board.handle_tool "masc_board_list" (`Assoc [("limit", `Int 10)]) in
   if not ok then (false, Printf.sprintf "❌ Lodge: Failed to list posts [%s]" posts_result)
   else
@@ -1335,16 +1504,36 @@ let lodge_discussion ~net (_args : Yojson.Safe.t) =
       find_all 0 []
     in
 
-    if post_ids = [] then (true, Printf.sprintf "📭 %s: 게시판이 비어있어요" agent)
+    if post_ids = [] then (true, "📭 게시판이 비어있어요")
     else
-      let target = List.nth post_ids (Random.int (List.length post_ids)) in
-      let (ok2, result) = react ~net (`Assoc [
-        ("post_id", `String target);
-        ("agent", `String agent);
-      ]) in
-      let model = get_agent_model agent in
-      (true, Printf.sprintf "💬 %s [%s] joined discussion on %s:\n%s"
-        agent model target (if ok2 then result else "❌ " ^ result))
+      let posts =
+        List.filter_map
+          (fun post_id ->
+            let (ok_post, detail) =
+              Tool_board.handle_tool "masc_board_get"
+                (`Assoc [ ("post_id", `String post_id) ])
+            in
+            if ok_post then Some (post_id, extract_post_content detail) else None)
+          post_ids
+      in
+      match
+        select_reaction_assignments ~net ~agent_name_opt:None ~posts ~max_agents:1
+          ~allow_post:false
+      with
+      | Error e -> (false, Printf.sprintf "❌ Lodge discussion selection failed [%s]" e)
+      | Ok [] -> (true, "⏭️ Lodge discussion skipped: no assignments")
+      | Ok ((assignment : Lodge_decision.assignment) :: _) -> (
+          match assignment.target_post_id with
+          | None ->
+              (true,
+               Printf.sprintf "⏭️ Lodge discussion skipped: %s" assignment.reason)
+          | Some target ->
+              let (ok2, result) = react ~net (`Assoc [
+                ("post_id", `String target);
+                ("agent", `String assignment.agent_name);
+              ]) in
+              (true, Printf.sprintf "💬 Lodge joined discussion on %s:\n%s"
+                 target (if ok2 then result else "❌ " ^ result)))
 
 (** {1 Tool Definitions} *)
 
@@ -1637,20 +1826,23 @@ let get_all_agents () =
     | Ok output ->
         try
           let json = Yojson.Safe.from_string output in
-          let edges = json |> member "data" |> member "agents" |> member "edges" |> to_list in
-          List.filter_map (fun edge ->
-            try
-              let node = edge |> member "node" in
-              let name = node |> member "name" |> to_string in
-              (* Trust GraphQL results — no cache filter (fixes chicken-egg bug) *)
-              let primary_value = (try node |> member "primaryValue" |> to_string with Yojson.Safe.Util.Type_error _ -> "unknown") in
-              let prompt = (try node |> member "promptTemplate" |> to_string with Yojson.Safe.Util.Type_error _ -> "") in
-              let status = (try node |> member "status" |> to_string with Yojson.Safe.Util.Type_error _ -> "active") in
-              if status = "active" then
-                Some (name, primary_value, prompt, "system", 0)
-              else None
-            with Yojson.Safe.Util.Type_error _ -> None
-          ) edges
+          (match graphql_agents_edges json with
+           | Error err ->
+               Printf.eprintf "[Lodge] GraphQL agent parse failed: %s\n%!" err;
+               []
+           | Ok edges ->
+               List.filter_map (fun edge ->
+                 try
+                   let node = edge |> member "node" in
+                   let name = node |> member "name" |> to_string in
+                   let primary_value = (try node |> member "primaryValue" |> to_string with Yojson.Safe.Util.Type_error _ -> "unknown") in
+                   let prompt = (try node |> member "promptTemplate" |> to_string with Yojson.Safe.Util.Type_error _ -> "") in
+                   let status = (try node |> member "status" |> to_string with Yojson.Safe.Util.Type_error _ -> "active") in
+                   if status = "active" then
+                     Some (name, primary_value, prompt, "system", 0)
+                   else None
+                 with Yojson.Safe.Util.Type_error _ -> None
+               ) edges)
         with Yojson.Safe.Util.Type_error _ | Yojson.Json_error _ -> []
   with Unix.Unix_error _ | Sys_error _ ->
     let cached = get_cached_agents_tuple () in
@@ -1715,8 +1907,7 @@ let spawn_agent ~net:_ ~parent_name ~child_name ~child_role ~child_prompt =
     (false, Printf.sprintf "❌ Lodge: 에이전트 '%s'가 이미 존재합니다" agent_name)
   else
     (* Create via GraphQL mutation *)
-    let graphql_url = Sys.getenv_opt "GRAPHQL_URL"
-      |> Option.value ~default:(default_graphql_url ()) in
+    let graphql_url = graphql_url () in
     let api_key = Sys.getenv_opt "GRAPHQL_API_KEY" |> Option.value ~default:"" in
     if api_key = "" then
       (false, "❌ Lodge: GRAPHQL_API_KEY not configured")

--- a/lib/tools.ml
+++ b/lib/tools.ml
@@ -2671,9 +2671,7 @@ Example: masc_a2a_unsubscribe({subscription_id: 'sub-abc123'})";
 
   {
     name = "masc_heartbeat_result";
-    description = "A2A Worker submits heartbeat task result. Worker receives heartbeat_task event, generates content with local LLM, then submits result. MASC posts to Board on behalf of the original agent. \
-action_type: POST | COMMENT:post_id | UPVOTE:post_id | SKIP. \
-Example workflow: 1) subscribe(['heartbeat_task']), 2) poll_events → get agent+prompt, 3) call LLM, 4) parse response for action, 5) masc_heartbeat_result(worker, agent, action, content).";
+    description = "A2A Worker submits heartbeat completion evidence. Worker receives heartbeat_task, runs an MCP tool loop directly, then reports status, tool usage, and decision metadata. MASC no longer proxies the board write.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -2685,16 +2683,49 @@ Example workflow: 1) subscribe(['heartbeat_task']), 2) poll_events → get agent
           ("type", `String "string");
           ("description", `String "Original Lodge agent name (e.g., 'dreamer')");
         ]);
-        ("action_type", `Assoc [
+        ("status", `Assoc [
           ("type", `String "string");
-          ("description", `String "Action: POST | COMMENT:post_id | UPVOTE:post_id | SKIP");
+          ("description", `String "Completion status: acted | skipped | failed");
+          ("enum", `List [`String "acted"; `String "skipped"; `String "failed"]);
         ]);
-        ("content", `Assoc [
+        ("summary", `Assoc [
           ("type", `String "string");
-          ("description", `String "Generated content (for POST/COMMENT)");
+          ("description", `String "Short completion summary");
+        ]);
+        ("tool_call_count", `Assoc [
+          ("type", `String "integer");
+          ("description", `String "Number of MCP tool calls executed by the worker");
+        ]);
+        ("tool_names", `Assoc [
+          ("type", `String "array");
+          ("description", `String "Executed MCP tool names");
+          ("items", `Assoc [("type", `String "string")]);
+        ]);
+        ("decision_reason", `Assoc [
+          ("type", `String "string");
+          ("description", `String "Why the worker chose this outcome");
+        ]);
+        ("decision_confidence", `Assoc [
+          ("type", `String "number");
+          ("description", `String "Confidence score between 0.0 and 1.0");
+        ]);
+        ("failure_reason", `Assoc [
+          ("type", `String "string");
+          ("description", `String "Optional explicit failure reason");
         ]);
       ]);
-      ("required", `List [`String "worker_name"; `String "agent"; `String "action_type"]);
+      ("required",
+        `List
+          [
+            `String "worker_name";
+            `String "agent";
+            `String "status";
+            `String "summary";
+            `String "tool_call_count";
+            `String "tool_names";
+            `String "decision_reason";
+            `String "decision_confidence";
+          ]);
     ];
   };
 

--- a/test/test_error_logging_coverage.ml
+++ b/test/test_error_logging_coverage.ml
@@ -6,7 +6,7 @@
     Coverage:
     - spawn_registry: Agent_name.of_string failure → "[spawn_registry]" prefix
     - tool_task: complete_task on nonexistent task → "[task]" prefix
-    - a2a_tools: submit_heartbeat_result with unknown action → "[a2a]" prefix
+    - a2a_tools: submit_heartbeat_result with unknown status → "[a2a]" prefix
 
     Stderr capture approach: Unix.pipe + Unix.dup2 redirect.
     The pipe is set non-blocking to avoid blocking on empty read.
@@ -169,22 +169,26 @@ let test_tool_task_cancel_nonexistent_logs () =
     true (str_contains output "[task]")
 
 (* ============================================================
-   a2a_tools: submit_heartbeat_result unknown action → "[a2a]" on stderr
+   a2a_tools: submit_heartbeat_result unknown status → "[a2a]" on stderr
    ============================================================ *)
 
-(** submit_heartbeat_result with an action_type that is not "POST",
-    "COMMENT:...", "UPVOTE:...", or "SKIP".
-    result becomes Error "Unknown action type: ..." and the [a2a] eprintf fires. *)
-let test_a2a_submit_unknown_action_logs () =
+(** submit_heartbeat_result with a status that is not "acted", "skipped",
+    or "failed". result becomes Error "Unknown worker status: ..." and the
+    [a2a] eprintf fires. *)
+let test_a2a_submit_unknown_status_logs () =
   let output = capture_stderr (fun () ->
     ignore (A2a_tools.submit_heartbeat_result
       ~worker_name:"test-worker"
       ~agent:"test-agent"
-      ~action_type:"INVALID_ACTION_XYZ"
-      ~content:"test content"
+      ~status:"INVALID_STATUS_XYZ"
+      ~summary:"test summary"
+      ~tool_call_count:0
+      ~tool_names:[]
+      ~decision_reason:"invalid test"
+      ~decision_confidence:0.0
       ())
   ) in
-  check bool "stderr contains [a2a] prefix for unknown action"
+  check bool "stderr contains [a2a] prefix for unknown status"
     true (str_contains output "[a2a]")
 
 (* ============================================================
@@ -208,7 +212,7 @@ let () =
         `Quick test_tool_task_cancel_nonexistent_logs;
     ];
     "a2a_tools", [
-      test_case "submit_heartbeat unknown action logs [a2a]"
-        `Quick test_a2a_submit_unknown_action_logs;
+      test_case "submit_heartbeat unknown status logs [a2a]"
+        `Quick test_a2a_submit_unknown_status_logs;
     ];
   ]

--- a/test/test_lodge_decision.ml
+++ b/test/test_lodge_decision.ml
@@ -82,6 +82,61 @@ let test_parse_batch_outcome_rejects_post_when_not_allowed () =
   | Ok _ -> fail "expected post disallowed failure"
   | Error err -> check bool "post disallowed" true (String.length err > 0)
 
+let test_parse_selection_plan_valid () =
+  let response =
+    {|{
+      "assignments": [
+        {
+          "agent_name":"dreamer",
+          "target_post_id":"p-2",
+          "goal":"Inspect p-2 and decide whether to comment, upvote, or skip using MCP tools directly.",
+          "reason":"dreamer can extend the discussion constructively",
+          "confidence":0.88
+        }
+      ],
+      "plan_reason":"dreamer fits this discussion best"
+    }|}
+  in
+  match
+    Lodge_decision.parse_selection_plan ~allowed_agents:[ "dreamer"; "skeptic" ]
+      ~allowed_post_ids:[ "p-1"; "p-2" ] ~max_agents:1 response
+  with
+  | Error err -> fail err
+  | Ok plan ->
+      check int "one assignment" 1 (List.length plan.assignments);
+      let assignment = List.hd plan.assignments in
+      check string "agent" "dreamer" assignment.agent_name;
+      check (option string) "target" (Some "p-2") assignment.target_post_id
+
+let test_parse_selection_plan_rejects_duplicate_agents () =
+  let response =
+    {|{
+      "assignments": [
+        {
+          "agent_name":"dreamer",
+          "target_post_id":"p-1",
+          "goal":"Inspect p-1 and decide via tools.",
+          "reason":"first choice",
+          "confidence":0.71
+        },
+        {
+          "agent_name":"dreamer",
+          "target_post_id":"p-2",
+          "goal":"Inspect p-2 and decide via tools.",
+          "reason":"duplicate should fail",
+          "confidence":0.69
+        }
+      ]
+    }|}
+  in
+  match
+    Lodge_decision.parse_selection_plan ~allowed_agents:[ "dreamer"; "skeptic" ]
+      ~allowed_post_ids:[ "p-1"; "p-2" ] ~max_agents:2 response
+  with
+  | Ok _ -> fail "expected duplicate assignment failure"
+  | Error err ->
+      check bool "duplicate error surfaced" true (String.length err > 0)
+
 let () =
   run "Lodge decision"
     [
@@ -95,5 +150,9 @@ let () =
             test_parse_batch_outcome_requires_full_coverage;
           test_case "batch rejects post when disallowed" `Quick
             test_parse_batch_outcome_rejects_post_when_not_allowed;
+          test_case "selection plan valid" `Quick
+            test_parse_selection_plan_valid;
+          test_case "selection plan rejects duplicate agents" `Quick
+            test_parse_selection_plan_rejects_duplicate_agents;
         ] );
     ]

--- a/test/test_lodge_graphql_failure_coverage.ml
+++ b/test/test_lodge_graphql_failure_coverage.ml
@@ -7,6 +7,18 @@ open Masc_mcp
 
 let () = Printf.printf "\n=== Lodge GraphQL Fallback Coverage Tests ===\n"
 
+let with_env key value f =
+  let prev = Sys.getenv_opt key in
+  (match value with
+   | Some v -> Unix.putenv key v
+   | None -> Unix.putenv key "");
+  Fun.protect
+    ~finally:(fun () ->
+      match prev with
+      | Some v -> Unix.putenv key v
+      | None -> Unix.putenv key "")
+    f
+
 let test name f =
   try
     f ();
@@ -18,45 +30,29 @@ let test name f =
 (* Test: curl fallback works when Eio net not initialized *)
 let () = test "load_agents_from_neo4j_curl_fallback" (fun () ->
   (* When Eio net is not initialized, Cohttp fails but curl fallback succeeds.
-     If GRAPHQL_API_KEY is set and network is available, agents are returned. *)
-  let has_api_key =
-    match Sys.getenv_opt "GRAPHQL_API_KEY" with
-    | Some s when String.length s > 0 -> true
-    | _ -> false
-  in
+     On invalid/empty GraphQL payloads, Lodge now falls back to builtin agents. *)
   let agents = Lodge_heartbeat.load_agents_from_neo4j () in
-  if has_api_key then
-    (* With API key, curl fallback should return agents (or [] if network down) *)
-    Printf.printf "  (curl fallback returned %d agents)\n" (List.length agents)
-  else
-    (* Without API key, expect empty list *)
-    assert (agents = [])
+  assert (List.length agents >= 5);
+  Printf.printf "  (fallback returned %d agents)\n" (List.length agents)
 )
 
-(* Test: load_lodge_agents_full also uses curl fallback *)
-let () = test "load_lodge_agents_full_curl_fallback" (fun () ->
-  let has_api_key =
-    match Sys.getenv_opt "GRAPHQL_API_KEY" with
-    | Some s when String.length s > 0 -> true
-    | _ -> false
-  in
-  match Lodge_heartbeat.load_lodge_agents_full () with
-  | Ok json ->
-      if has_api_key then begin
-        (* Try to count agents from JSON response, handle different structures *)
-        try
-          let open Yojson.Safe.Util in
-          let edges = json |> member "data" |> member "agents" |> member "edges" |> to_list in
-          Printf.printf "  (curl fallback returned %d full agents)\n" (List.length edges)
-        with Yojson.Safe.Util.Type_error _ ->
-          (* Different JSON structure - just verify we got valid JSON *)
-          Printf.printf "  (curl fallback returned valid JSON response)\n"
-      end else
-        Printf.printf "  (returned response without API key)\n"
-  | Error msg ->
-      (* Error is acceptable if network is truly unavailable *)
-      let short_msg = if String.length msg > 50 then String.sub msg 0 50 else msg in
-      Printf.printf "  (GraphQL error as expected: %s...)\n" short_msg
-)
+let () = test "load_agents_from_neo4j_invalid_endpoint_uses_builtin_fallback" (fun () ->
+  with_env "GRAPHQL_URL" (Some "http://127.0.0.1:9/graphql") (fun () ->
+      let agents = Lodge_heartbeat.load_agents_from_neo4j () in
+      assert (List.length agents >= 5)))
+
+let () = test "load_lodge_agents_full_invalid_endpoint_errors_cleanly" (fun () ->
+  with_env "GRAPHQL_URL" (Some "http://127.0.0.1:9/graphql") (fun () ->
+      match Lodge_heartbeat.load_lodge_agents_full () with
+      | Ok (`Assoc fields) ->
+          ignore (List.assoc "agents" fields)
+      | Ok _ -> failwith "expected agents payload"
+      | Error msg -> assert (String.length msg > 0)))
+
+let () = test "tool_lodge_invalid_endpoint_uses_builtin_cache_fallback" (fun () ->
+  with_env "GRAPHQL_URL" (Some "http://127.0.0.1:9/graphql") (fun () ->
+      Tool_lodge.load_agents_config ();
+      let agents = Tool_lodge.get_all_agents () in
+      assert (List.length agents >= 5)))
 
 let () = Printf.printf "\n✅ All Lodge GraphQL fallback tests passed!\n"

--- a/test/test_lodge_heartbeat_cleanup_coverage.ml
+++ b/test/test_lodge_heartbeat_cleanup_coverage.ml
@@ -36,16 +36,48 @@ let test_lodge_heartbeat_no_profile_shellout () =
     (file_contains_pattern "lib/lodge_heartbeat.ml"
        {|Process_eio.run_argv ~timeout_sec:30.0 [sb; "graphql"; "agent"; agent_name]|})
 
-let test_lodge_heartbeat_uses_decision_prompt () =
-  check bool "structured decision prompt used"
+let test_lodge_heartbeat_uses_tool_assignment_prompt () =
+  check bool "structured selection prompt used"
     true
-    (file_contains_pattern "lib/lodge_heartbeat.ml" "Lodge_decision.batch_decision_prompt");
-  check bool "decision phase traced"
+    (file_contains_pattern "lib/lodge_heartbeat.ml" "Lodge_decision.selection_prompt");
+  check bool "tool assignment phase traced"
     true
-    (file_contains_pattern "lib/lodge_heartbeat.ml" {|phase:"lodge_decision"|});
-  check bool "structured batch parser used"
+    (file_contains_pattern "lib/lodge_heartbeat.ml" {|phase:"lodge_tool_assignment"|});
+  check bool "structured selection parser used"
     true
-    (file_contains_pattern "lib/lodge_heartbeat.ml" "Lodge_decision.parse_batch_outcome")
+    (file_contains_pattern "lib/lodge_heartbeat.ml" "Lodge_decision.parse_selection_plan");
+  check bool "tool loop worker used"
+    true
+    (file_contains_pattern "lib/lodge_heartbeat.ml" "Lodge_worker.run_local");
+  check bool "heartbeat delegation emits task payload"
+    true
+    (file_contains_pattern "lib/lodge_heartbeat.ml" "A2a_tools.emit_heartbeat_task")
+
+let test_lodge_graphql_defaults_and_guards () =
+  check bool "heartbeat GraphQL defaults to HTTP port"
+    true
+    (file_contains_pattern "lib/lodge_heartbeat.ml" {|Sys.getenv_opt "MASC_HTTP_PORT"|});
+  check bool "heartbeat GraphQL no longer defaults to MCP port"
+    false
+    (file_contains_pattern "lib/lodge_heartbeat.ml" {|Sys.getenv_opt "MASC_MCP_PORT"|});
+  check bool "tool_lodge GraphQL defaults to HTTP port"
+    true
+    (file_contains_pattern "lib/tool_lodge.ml" {|Sys.getenv_opt "MASC_HTTP_PORT"|});
+  check bool "tool_lodge GraphQL no longer defaults to MCP port"
+    false
+    (file_contains_pattern "lib/tool_lodge.ml" {|Sys.getenv_opt "MASC_MCP_PORT"|});
+  check bool "HTML GraphQL guard present in heartbeat"
+    true
+    (file_contains_pattern "lib/lodge_heartbeat.ml" "endpoint returned HTML instead of JSON");
+  check bool "HTML GraphQL guard present in tool_lodge"
+    true
+    (file_contains_pattern "lib/tool_lodge.ml" "endpoint returned HTML instead of JSON");
+  check bool "null agents guard present in heartbeat"
+    true
+    (file_contains_pattern "lib/lodge_heartbeat.ml" "GraphQL agents is null");
+  check bool "null agents guard present in tool_lodge"
+    true
+    (file_contains_pattern "lib/tool_lodge.ml" "GraphQL agents is null")
 
 let test_lodge_heartbeat_updates_self_summary () =
   check bool "reflection updates self summary"
@@ -58,44 +90,40 @@ let test_lodge_heartbeat_uses_tom_context () =
     (file_contains_pattern "lib/lodge_heartbeat.ml" "Lodge_tom.predict_top_k")
 
 let test_lodge_heartbeat_no_heuristic_fallback_policy () =
-  check bool "scheduled trigger can fallback to post"
+  check bool "scheduled trigger can request post tool"
     true
     (file_contains_pattern "lib/lodge_heartbeat.ml" "| Scheduled | ManualTrigger -> true");
-  check bool "content alerts do not fallback to post"
+  check bool "content alerts cannot request post tool"
     true
     (file_contains_pattern "lib/lodge_heartbeat.ml" "| ContentAlert _ | Mentioned _ -> false");
-  check bool "decision errors are explicit"
+  check bool "selection failures are explicit"
     true
     (file_contains_pattern "lib/lodge_heartbeat.ml"
-       {|reason = "decision error: " ^ reason|});
-  check bool "post gating still enforced through allow_post"
+       {|Skipped ("tool_loop_selection_failed:" ^ reason)|});
+  check bool "post gating enforced through allowed tools"
     true
     (file_contains_pattern "lib/lodge_heartbeat.ml"
-       "~allow_post:(trigger_allows_post trigger)");
-  check bool "unparsed fallback removed"
+       {|List.mem "masc_board_post" allowed_tools|});
+  check bool "legacy action_hint payload removed"
     false
-    (file_contains_pattern "lib/lodge_heartbeat.ml" {|reason = Some "unparsed"|});
-  check bool "heuristic maybe_post_action removed"
+    (file_contains_pattern "lib/a2a_tools.ml" "action_hint");
+  check bool "legacy prompt payload removed"
     false
-    (file_contains_pattern "lib/lodge_heartbeat.ml" "maybe_post_action");
-  check bool "legacy NoAction fallback removed"
+    (file_contains_pattern "lib/a2a_tools.ml" {|("prompt", `String prompt)|});
+  check bool "legacy proxied board write removed"
     false
-    (file_contains_pattern "lib/lodge_heartbeat.ml" "NoAction");
-  check bool "reaction batch prompt removed"
-    false
-    (file_contains_pattern "lib/lodge_heartbeat.ml" "Lodge_reaction.batch_reaction_prompt");
-  check bool "comment generation no longer auto-upvotes"
-    false
-    (file_contains_pattern "lib/lodge_heartbeat.ml" {|None -> ActionUpvote|});
+    (file_contains_pattern "lib/a2a_tools.ml" "Board.create_post store");
   check bool "comment rate limit enforced explicitly"
     true
-    (file_contains_pattern "lib/lodge_heartbeat.ml" {|Skipped "comment_rate_limited"|});
+    (file_contains_pattern "lib/lodge_heartbeat.ml"
+       {|check_rate_limit ~agent_name `Comment|});
   check bool "post rate limit enforced explicitly"
     true
-    (file_contains_pattern "lib/lodge_heartbeat.ml" {|Skipped "post_rate_limited"|});
-  check bool "decision failure reason tracked"
+    (file_contains_pattern "lib/lodge_heartbeat.ml"
+       {|check_rate_limit ~agent_name `Post|});
+  check bool "worker failure reason tracked"
     true
-    (file_contains_pattern "lib/lodge_heartbeat.ml" "decision_failure_reason")
+    (file_contains_pattern "lib/lodge_worker.ml" "failure_reason")
 
 let test_lodge_heartbeat_public_memory_helpers_removed () =
   check bool "load_agent_memories removed from mli"
@@ -118,7 +146,8 @@ let () =
           test_case "agentActivities recall removed" `Quick test_lodge_memory_no_agent_activities_query;
           test_case "createLodgeActivity store removed" `Quick test_lodge_memory_no_create_lodge_activity_mutation;
           test_case "profile shellout removed" `Quick test_lodge_heartbeat_no_profile_shellout;
-          test_case "decision prompt mainline" `Quick test_lodge_heartbeat_uses_decision_prompt;
+          test_case "tool assignment prompt mainline" `Quick test_lodge_heartbeat_uses_tool_assignment_prompt;
+          test_case "graphql defaults and guards" `Quick test_lodge_graphql_defaults_and_guards;
           test_case "reflection updates self summary" `Quick test_lodge_heartbeat_updates_self_summary;
           test_case "ToM context used" `Quick test_lodge_heartbeat_uses_tom_context;
           test_case "no heuristic fallback policy locked" `Quick test_lodge_heartbeat_no_heuristic_fallback_policy;

--- a/test/test_tools_coverage.ml
+++ b/test/test_tools_coverage.ml
@@ -548,6 +548,24 @@ let test_masc_poll_events_schema () =
           Alcotest.(check bool) "has subscription_id" true (List.mem_assoc "subscription_id" props)
       | None -> Alcotest.fail "masc_poll_events missing properties"
 
+let test_masc_heartbeat_result_schema () =
+  match find_tool "masc_heartbeat_result" with
+  | None -> Alcotest.fail "masc_heartbeat_result not found"
+  | Some schema ->
+      match get_json_assoc "properties" schema.input_schema with
+      | Some props ->
+          Alcotest.(check bool) "has status" true (List.mem_assoc "status" props);
+          Alcotest.(check bool) "has summary" true (List.mem_assoc "summary" props);
+          Alcotest.(check bool) "has tool_call_count" true
+            (List.mem_assoc "tool_call_count" props);
+          Alcotest.(check bool) "has tool_names" true
+            (List.mem_assoc "tool_names" props);
+          Alcotest.(check bool) "has decision_reason" true
+            (List.mem_assoc "decision_reason" props);
+          Alcotest.(check bool) "has decision_confidence" true
+            (List.mem_assoc "decision_confidence" props)
+      | None -> Alcotest.fail "masc_heartbeat_result missing properties"
+
 (* ============================================================ *)
 (* 12. Mitosis Tool Tests                                        *)
 (* ============================================================ *)
@@ -948,6 +966,7 @@ let () =
       Alcotest.test_case "a2a_delegate" `Quick test_masc_a2a_delegate_schema;
       Alcotest.test_case "a2a_subscribe" `Quick test_masc_a2a_subscribe_schema;
       Alcotest.test_case "poll_events" `Quick test_masc_poll_events_schema;
+      Alcotest.test_case "heartbeat_result" `Quick test_masc_heartbeat_result_schema;
     ];
     "mitosis_tools", [
       Alcotest.test_case "mitosis_status" `Quick test_masc_mitosis_status_schema;


### PR DESCRIPTION
## Summary
- run Lodge reactions and heartbeat actions through MCP tool-calling workers
- harden Lodge GraphQL bootstrap against wrong-port HTML/null responses
- remove legacy action_hint/action_type heartbeat result flow and record worker execution evidence

## Validation
- dune build --root . @default
- env GRAPHQL_API_KEY='' ./_build/default/test/test_lodge_graphql_failure_coverage.exe
- ./_build/default/test/test_lodge_heartbeat_cleanup_coverage.exe
- ./_build/default/test/test_lodge_decision.exe
- ./_build/default/test/test_lodge_reaction.exe
- ./_build/default/test/test_tool_a2a_coverage.exe
- ./_build/default/test/test_a2a_tools_coverage.exe
- ./_build/default/test/test_tools_coverage.exe