### PR TITLE
fix(lodge): default GraphQL lookups to Railway

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -44,6 +44,7 @@
    federation
    gcm_compat
    glm_pool
+   graphql_endpoint
    graphql_api
    handover_eio
    hat

--- a/lib/graphql_endpoint.ml
+++ b/lib/graphql_endpoint.ml
@@ -1,0 +1,50 @@
+let trim_trailing_slash s =
+  let trimmed = String.trim s in
+  let len = String.length trimmed in
+  if len > 0 && trimmed.[len - 1] = '/' then
+    String.sub trimmed 0 (len - 1)
+  else
+    trimmed
+
+let starts_with s prefix =
+  let s_len = String.length s in
+  let prefix_len = String.length prefix in
+  s_len >= prefix_len && String.sub s 0 prefix_len = prefix
+
+let ends_with s suffix =
+  let s_len = String.length s in
+  let suffix_len = String.length suffix in
+  s_len >= suffix_len
+  && String.sub s (s_len - suffix_len) suffix_len = suffix
+
+let normalize_railway_url raw =
+  let trimmed = String.trim raw in
+  if trimmed = "" then
+    ""
+  else
+    let with_scheme =
+      if starts_with trimmed "http://" || starts_with trimmed "https://" then
+        trimmed
+      else
+        "https://" ^ trimmed
+    in
+    let without_trailing = trim_trailing_slash with_scheme in
+    if ends_with without_trailing "/graphql" then
+      without_trailing
+    else
+      without_trailing ^ "/graphql"
+
+let default_railway_url =
+  "https://second-brain-graphql-production.up.railway.app/graphql"
+
+let railway_graphql_url () =
+  match Sys.getenv_opt "RAILWAY_GRAPHQL_URL" with
+  | Some raw ->
+      let normalized = normalize_railway_url raw in
+      if normalized = "" then default_railway_url else normalized
+  | None -> default_railway_url
+
+let graphql_url () =
+  match Sys.getenv_opt "GRAPHQL_URL" with
+  | Some raw when String.trim raw <> "" -> String.trim raw
+  | _ -> railway_graphql_url ()

--- a/lib/graphql_endpoint.ml
+++ b/lib/graphql_endpoint.ml
@@ -17,7 +17,7 @@ let ends_with s suffix =
   s_len >= suffix_len
   && String.sub s (s_len - suffix_len) suffix_len = suffix
 
-let normalize_railway_url raw =
+let normalize_graphql_url ~default_scheme raw =
   let trimmed = String.trim raw in
   if trimmed = "" then
     ""
@@ -26,7 +26,7 @@ let normalize_railway_url raw =
       if starts_with trimmed "http://" || starts_with trimmed "https://" then
         trimmed
       else
-        "https://" ^ trimmed
+        default_scheme ^ trimmed
     in
     let without_trailing = trim_trailing_slash with_scheme in
     if ends_with without_trailing "/graphql" then
@@ -40,11 +40,26 @@ let default_railway_url =
 let railway_graphql_url () =
   match Sys.getenv_opt "RAILWAY_GRAPHQL_URL" with
   | Some raw ->
-      let normalized = normalize_railway_url raw in
+      let normalized = normalize_graphql_url ~default_scheme:"https://" raw in
       if normalized = "" then default_railway_url else normalized
   | None -> default_railway_url
 
+let default_scheme_for_override raw =
+  let trimmed = String.trim raw in
+  if starts_with trimmed "localhost"
+     || starts_with trimmed "127.0.0.1"
+     || starts_with trimmed "0.0.0.0"
+     || starts_with trimmed "[::1]"
+  then
+    "http://"
+  else
+    "https://"
+
 let graphql_url () =
   match Sys.getenv_opt "GRAPHQL_URL" with
-  | Some raw when String.trim raw <> "" -> String.trim raw
+  | Some raw ->
+      let normalized =
+        normalize_graphql_url ~default_scheme:(default_scheme_for_override raw) raw
+      in
+      if normalized = "" then railway_graphql_url () else normalized
   | _ -> railway_graphql_url ()

--- a/lib/lodge_heartbeat.ml
+++ b/lib/lodge_heartbeat.ml
@@ -422,26 +422,9 @@ let sb_path () =
 
 (** Use local GraphQL by default for local MCP runs.
     Set GRAPHQL_URL explicitly to force remote endpoint. *)
-let trim_trailing_slash s =
-  let trimmed = String.trim s in
-  let len = String.length trimmed in
-  if len > 0 && trimmed.[len - 1] = '/' then
-    String.sub trimmed 0 (len - 1)
-  else
-    trimmed
-
-let default_graphql_url () =
-  match Sys.getenv_opt "MASC_HTTP_BASE_URL" with
-  | Some raw when String.trim raw <> "" ->
-      trim_trailing_slash raw ^ "/graphql"
-  | _ ->
-      let port = Sys.getenv_opt "MASC_HTTP_PORT" |> Option.value ~default:"8935" in
-      Printf.sprintf "http://127.0.0.1:%s/graphql" port
-
-let graphql_url () =
-  match Sys.getenv_opt "GRAPHQL_URL" with
-  | Some raw when String.trim raw <> "" -> String.trim raw
-  | _ -> default_graphql_url ()
+(** Use Railway GraphQL by default.
+    Set GRAPHQL_URL explicitly for local dev or alternate endpoints. *)
+let graphql_url () = Graphql_endpoint.graphql_url ()
 
 let looks_like_html_response body =
   let trimmed = String.lowercase_ascii (String.trim body) in

--- a/lib/masc_mcp.ml
+++ b/lib/masc_mcp.ml
@@ -43,6 +43,7 @@ module Mcp_server_eio = Mcp_server_eio
 module Mcp_session = Mcp_session
 module Http_server_eio = Http_server_eio
 module Http_server_h2 = Http_server_h2
+module Graphql_endpoint = Graphql_endpoint
 module Graphql_api = Graphql_api
 module Safe_ops = Safe_ops
 module Sse = Sse

--- a/lib/tool_lodge.ml
+++ b/lib/tool_lodge.ml
@@ -141,28 +141,9 @@ let http_get_json ~net:_ url =
 
 (* NOTE: http_get_local removed — using curl subprocess for all HTTP *)
 
-let trim_trailing_slash s =
-  let trimmed = String.trim s in
-  let len = String.length trimmed in
-  if len > 0 && trimmed.[len - 1] = '/' then
-    String.sub trimmed 0 (len - 1)
-  else
-    trimmed
-
-(** Use local GraphQL by default for local MCP runs.
-    Set GRAPHQL_URL explicitly to force remote endpoint. *)
-let default_graphql_url () =
-  match Sys.getenv_opt "MASC_HTTP_BASE_URL" with
-  | Some raw when String.trim raw <> "" ->
-      trim_trailing_slash raw ^ "/graphql"
-  | _ ->
-      let port = Sys.getenv_opt "MASC_HTTP_PORT" |> Option.value ~default:"8935" in
-      Printf.sprintf "http://127.0.0.1:%s/graphql" port
-
-let graphql_url () =
-  match Sys.getenv_opt "GRAPHQL_URL" with
-  | Some raw when String.trim raw <> "" -> String.trim raw
-  | _ -> default_graphql_url ()
+(** Use Railway GraphQL by default.
+    Set GRAPHQL_URL explicitly for local dev or alternate endpoints. *)
+let graphql_url () = Graphql_endpoint.graphql_url ()
 
 let looks_like_html_response body =
   let trimmed = String.lowercase_ascii (String.trim body) in

--- a/test/dune
+++ b/test/dune
@@ -16,6 +16,7 @@
 (tests
  (names test_room test_types test_checkpoint test_auth test_http_negotiation
         test_sse test_encryption test_backend test_cancellation test_graphql_api
+        test_graphql_endpoint
         test_subscriptions test_session test_progress test_mitosis test_spawn
         test_validation test_response test_voice_stream test_sctp
         test_datachannel_rfc test_dtls_crypto test_dashboard
@@ -24,6 +25,7 @@
         test_post_verifier test_mdal)
  (modules test_room test_types test_checkpoint test_auth test_http_negotiation
           test_sse test_encryption test_backend test_cancellation test_graphql_api
+          test_graphql_endpoint
           test_subscriptions test_session test_progress test_mitosis test_spawn
           test_validation test_response test_voice_stream test_sctp
           test_datachannel_rfc test_dtls_crypto test_dashboard

--- a/test/test_graphql_endpoint.ml
+++ b/test/test_graphql_endpoint.ml
@@ -24,6 +24,14 @@ let test_explicit_graphql_url_takes_priority () =
         "http://127.0.0.1:8935/graphql"
         (Graphql_endpoint.graphql_url ()))
 
+let test_explicit_graphql_host_normalizes_for_local_dev () =
+  with_graphql_env ~graphql_url:"127.0.0.1:8935"
+    ~railway_url:"second-brain-graphql-production.up.railway.app" (fun () ->
+      Alcotest.(check string)
+        "graphql_url"
+        "http://127.0.0.1:8935/graphql"
+        (Graphql_endpoint.graphql_url ()))
+
 let test_railway_url_without_scheme_is_normalized () =
   with_graphql_env ?graphql_url:None
     ~railway_url:"second-brain-graphql-production.up.railway.app" (fun () ->
@@ -46,6 +54,8 @@ let () =
         [
           Alcotest.test_case "explicit GRAPHQL_URL wins" `Quick
             test_explicit_graphql_url_takes_priority;
+          Alcotest.test_case "explicit GRAPHQL_URL host normalizes" `Quick
+            test_explicit_graphql_host_normalizes_for_local_dev;
           Alcotest.test_case "RAILWAY_GRAPHQL_URL host normalizes" `Quick
             test_railway_url_without_scheme_is_normalized;
           Alcotest.test_case "default uses Railway production" `Quick

--- a/test/test_graphql_endpoint.ml
+++ b/test/test_graphql_endpoint.ml
@@ -1,0 +1,54 @@
+open Masc_mcp
+
+let with_env key value f =
+  let prev = Sys.getenv_opt key in
+  (match value with
+   | Some v -> Unix.putenv key v
+   | None -> Unix.putenv key "");
+  Fun.protect
+    ~finally:(fun () ->
+      match prev with
+      | Some v -> Unix.putenv key v
+      | None -> Unix.putenv key "")
+    f
+
+let with_graphql_env ?graphql_url ?railway_url f =
+  with_env "GRAPHQL_URL" graphql_url (fun () ->
+      with_env "RAILWAY_GRAPHQL_URL" railway_url f)
+
+let test_explicit_graphql_url_takes_priority () =
+  with_graphql_env ~graphql_url:"http://127.0.0.1:8935/graphql"
+    ~railway_url:"second-brain-graphql-production.up.railway.app" (fun () ->
+      Alcotest.(check string)
+        "graphql_url"
+        "http://127.0.0.1:8935/graphql"
+        (Graphql_endpoint.graphql_url ()))
+
+let test_railway_url_without_scheme_is_normalized () =
+  with_graphql_env ?graphql_url:None
+    ~railway_url:"second-brain-graphql-production.up.railway.app" (fun () ->
+      Alcotest.(check string)
+        "graphql_url"
+        "https://second-brain-graphql-production.up.railway.app/graphql"
+        (Graphql_endpoint.graphql_url ()))
+
+let test_default_falls_back_to_railway_production () =
+  with_graphql_env ?graphql_url:None ?railway_url:None (fun () ->
+      Alcotest.(check string)
+        "graphql_url"
+        "https://second-brain-graphql-production.up.railway.app/graphql"
+        (Graphql_endpoint.graphql_url ()))
+
+let () =
+  Alcotest.run "Graphql_endpoint"
+    [
+      ( "resolution",
+        [
+          Alcotest.test_case "explicit GRAPHQL_URL wins" `Quick
+            test_explicit_graphql_url_takes_priority;
+          Alcotest.test_case "RAILWAY_GRAPHQL_URL host normalizes" `Quick
+            test_railway_url_without_scheme_is_normalized;
+          Alcotest.test_case "default uses Railway production" `Quick
+            test_default_falls_back_to_railway_production;
+        ] );
+    ]

--- a/test/test_lodge_heartbeat_cleanup_coverage.ml
+++ b/test/test_lodge_heartbeat_cleanup_coverage.ml
@@ -54,18 +54,22 @@ let test_lodge_heartbeat_uses_tool_assignment_prompt () =
     (file_contains_pattern "lib/lodge_heartbeat.ml" "A2a_tools.emit_heartbeat_task")
 
 let test_lodge_graphql_defaults_and_guards () =
-  check bool "heartbeat GraphQL defaults to HTTP port"
+  check bool "heartbeat GraphQL uses shared endpoint helper"
     true
-    (file_contains_pattern "lib/lodge_heartbeat.ml" {|Sys.getenv_opt "MASC_HTTP_PORT"|});
-  check bool "heartbeat GraphQL no longer defaults to MCP port"
-    false
-    (file_contains_pattern "lib/lodge_heartbeat.ml" {|Sys.getenv_opt "MASC_MCP_PORT"|});
-  check bool "tool_lodge GraphQL defaults to HTTP port"
+    (file_contains_pattern "lib/lodge_heartbeat.ml" "Graphql_endpoint.graphql_url ()");
+  check bool "tool_lodge GraphQL uses shared endpoint helper"
     true
-    (file_contains_pattern "lib/tool_lodge.ml" {|Sys.getenv_opt "MASC_HTTP_PORT"|});
-  check bool "tool_lodge GraphQL no longer defaults to MCP port"
+    (file_contains_pattern "lib/tool_lodge.ml" "Graphql_endpoint.graphql_url ()");
+  check bool "shared helper normalizes Railway env"
     false
-    (file_contains_pattern "lib/tool_lodge.ml" {|Sys.getenv_opt "MASC_MCP_PORT"|});
+    (file_contains_pattern "lib/graphql_endpoint.ml" {|Sys.getenv_opt "MASC_HTTP_PORT"|});
+  check bool "shared helper supports Railway env"
+    true
+    (file_contains_pattern "lib/graphql_endpoint.ml" {|Sys.getenv_opt "RAILWAY_GRAPHQL_URL"|});
+  check bool "shared helper has production Railway fallback"
+    true
+    (file_contains_pattern "lib/graphql_endpoint.ml"
+       "https://second-brain-graphql-production.up.railway.app/graphql");
   check bool "HTML GraphQL guard present in heartbeat"
     true
     (file_contains_pattern "lib/lodge_heartbeat.ml" "endpoint returned HTML instead of JSON");


### PR DESCRIPTION
## Summary
- default Lodge GraphQL endpoint resolution to Railway production when `GRAPHQL_URL` is unset
- share endpoint resolution in a single helper used by `lodge_heartbeat` and `tool_lodge`
- add coverage for Railway default and endpoint normalization

## Verification
- `env DUNE_BUILD_DIR=_build_gql_default dune build --root . test/test_graphql_endpoint.exe test/test_lodge_heartbeat_cleanup_coverage.exe`
- `./_build_gql_default/default/test/test_graphql_endpoint.exe`
- `./_build_gql_default/default/test/test_lodge_heartbeat_cleanup_coverage.exe`