### PR TITLE
fix(lodge): stop lodge.env from overriding GraphQL connection vars

### DIFF
--- a/config/lodge.env
+++ b/config/lodge.env
@@ -2,10 +2,10 @@
 # Loaded by start-masc-mcp.sh at startup
 # All env vars use MASC_LODGE_* prefix (read by Env_config.LodgeV2)
 
-# Local GraphQL (avoid external dependency in local/dev runs)
-GRAPHQL_URL=http://127.0.0.1:8935/graphql
-# Keep empty for local-only mode; external key is not required.
-GRAPHQL_API_KEY=
+# GraphQL connection: inherited from environment (plist / .zshenv).
+# Override here only for isolated local-only dev runs:
+# GRAPHQL_URL=http://127.0.0.1:8935/graphql
+# GRAPHQL_API_KEY=
 
 # Tick interval (seconds) — 2700 = 45 minutes
 MASC_LODGE_TICK_INTERVAL_SEC=2700


### PR DESCRIPTION
## Summary
- `config/lodge.env`가 `GRAPHQL_URL=localhost:8935`와 `GRAPHQL_API_KEY=`(빈 값)을 하드코딩
- `start-masc-mcp.sh`가 `.zshenv` **이후에** lodge.env를 `set -a`로 source → plist/zshenv의 올바른 Railway 값을 덮어씀
- Lodge heartbeat가 자기 자신(`localhost:8935/graphql`)에 GraphQL 요청 → `primaryValue` 필드 없음 → 에이전트 로드 실패

## Fix
- `GRAPHQL_URL`과 `GRAPHQL_API_KEY`를 주석 처리하여 상위 환경(plist/`.zshenv`)에서 상속
- Dev-only override 예시는 주석으로 유지

## Test plan
- [x] launchd 재시작 후 `key=44 chars` + `Loaded 15 agents from Neo4j` 확인
- [x] `/health` endpoint에서 `agent_count: 15` 확인
- [ ] Heartbeat tick에서 에이전트 정상 활성화 확인

Generated with [Claude Code](https://claude.com/claude-code)