### PR TITLE
test(command-plane): lock operator snapshot alerts coverage

### DIFF
--- a/test/test_command_plane_v2.ml
+++ b/test/test_command_plane_v2.ml
@@ -244,6 +244,11 @@ let test_snapshot_json_reports_consistent_sections () =
        |> Yojson.Safe.Util.member "summary"
        |> Yojson.Safe.Util.member "total"
        |> Yojson.Safe.Util.to_int);
+      Alcotest.(check int) "alerts total" 0
+        (snapshot |> Yojson.Safe.Util.member "alerts"
+       |> Yojson.Safe.Util.member "summary"
+       |> Yojson.Safe.Util.member "total"
+       |> Yojson.Safe.Util.to_int);
       Alcotest.(check string) "operation objective retained" "Run snapshot drill"
         (snapshot |> Yojson.Safe.Util.member "operations"
        |> Yojson.Safe.Util.member "operations"


### PR DESCRIPTION
## Summary
- add follow-up regression coverage for command-plane snapshot alerts summary
- keep the recently merged operator snapshot performance fix honest with an end-to-end snapshot consistency test

## Validation
- dune build --root . @default
- ./_build/default/test/test_command_plane_v2.exe
