### PR TITLE
fix(swarm): ignore phantom supervised lane traces

### DIFF
--- a/lib/swarm_status.ml
+++ b/lib/swarm_status.ml
@@ -620,7 +620,7 @@ let lane_flags kind ~present ~approvals ~workers ~trace_count ~last_movement_at
   in
   let flags =
     match parse_timestamp last_movement_at with
-    | Some ts when Time_compat.now () -. ts > stale_window_sec ->
+    | Some ts when present && Time_compat.now () -. ts > stale_window_sec ->
         append_flag flags "stale_data" "warn"
           "The most recent movement is older than the freshness window."
     | _ -> flags
@@ -799,6 +799,17 @@ let trace_infos_of_snapshot snapshot =
 let slice_by_kind kind classify rows =
   List.filter (fun row -> classify row = kind) rows
 
+let lane_present kind ~operations ~detachments ~alerts ~decisions ~traces ~sessions =
+  match kind with
+  | Supervised ->
+      (* Supervised traces are historical. Only live session/runtime artifacts should
+         make the lane present, otherwise stale operator/team-session traces create a
+         phantom supervised lane after the real session has already ended. *)
+      operations <> [] || detachments <> [] || decisions <> [] || sessions <> []
+  | Managed | Projected ->
+      operations <> [] || detachments <> [] || alerts <> [] || decisions <> [] || traces <> []
+      || sessions <> []
+
 let lane_for_kind kind ~now ~operations ~detachments ~alerts ~decisions ~traces
     ~sessions ~mixed_runtime_sources =
   let workers =
@@ -809,10 +820,7 @@ let lane_for_kind kind ~now ~operations ~detachments ~alerts ~decisions ~traces
     | Managed | Projected ->
         worker_names_from_detachments detachments |> List.length
   in
-  let present =
-    operations <> [] || detachments <> [] || alerts <> [] || decisions <> [] || traces <> []
-    || sessions <> []
-  in
+  let present = lane_present kind ~operations ~detachments ~alerts ~decisions ~traces ~sessions in
   let approvals =
     decisions
     |> List.filter (fun (decision : decision_info) -> String.equal decision.status "pending")

--- a/test/dune
+++ b/test/dune
@@ -164,6 +164,12 @@
  (modules test_json_util)
  (libraries masc_mcp alcotest yojson))
 
+; Swarm_status regression tests (lane presence / recommendation logic)
+(test
+ (name test_swarm_status)
+ (modules test_swarm_status)
+ (libraries masc_mcp alcotest yojson))
+
 ; Resilience module tests (Time, Zombie, ZeroZombie pure functions)
 (test
  (name test_resilience)

--- a/test/test_swarm_status.ml
+++ b/test/test_swarm_status.ml
@@ -1,0 +1,108 @@
+open Alcotest
+
+module U = Yojson.Safe.Util
+module M = Masc_mcp
+
+let find_lane json lane_id =
+  json |> U.member "lanes" |> U.to_list
+  |> List.find (fun lane ->
+         String.equal (lane |> U.member "lane_id" |> U.to_string) lane_id)
+
+let test_supervised_trace_only_does_not_make_lane_present () =
+  let trace : M.Swarm_status.trace_info =
+    {
+      event_id = "trace-1";
+      event_type = "lodge_tick";
+      source = "operator";
+      trace_id = "ops_1";
+      operation_id = None;
+      actor = Some "dashboard-kind-crane";
+      timestamp = Some "2026-03-07T18:02:18Z";
+      detail = `Assoc [ ("action_type", `String "lodge_tick") ];
+    }
+  in
+  let json =
+    M.Swarm_status.build_json_from_inputs ~now:(M.Time_compat.now ()) ~operations:[]
+      ~detachments:[] ~alerts:[] ~decisions:[] ~traces:[ trace ] ~sessions:[]
+  in
+  let supervised = find_lane json "supervised" in
+  check bool "supervised lane absent" false
+    (supervised |> U.member "present" |> U.to_bool);
+  check int "no supervised hard flags" 0
+    (supervised |> U.member "hard_flags" |> U.to_list |> List.length);
+  check bool "do not recommend team session inspection" false
+    (String.equal "masc_team_session_status"
+       (json |> U.member "recommended_next_action" |> U.member "tool" |> U.to_string))
+
+let test_supervised_session_keeps_lane_present () =
+  let now = M.Time_compat.now () in
+  let now_iso = M.Command_plane_v2.iso_of_unix now in
+  let session : M.Swarm_status.session_info =
+    {
+      session_id = "sess-1";
+      goal = "Exercise supervised lane";
+      status = "running";
+      started_at = 0.0;
+      updated_at_iso = now_iso;
+      last_event_at = Some now_iso;
+      last_turn_at = Some now_iso;
+      worker_names = [ "worker-a" ];
+      min_agents_violation_streak = 0;
+      policy_violation_count = 0;
+    }
+  in
+  let json =
+    M.Swarm_status.build_json_from_inputs ~now:(M.Time_compat.now ()) ~operations:[]
+      ~detachments:[] ~alerts:[] ~decisions:[] ~traces:[] ~sessions:[ session ]
+  in
+  let supervised = find_lane json "supervised" in
+  check bool "supervised lane present" true
+    (supervised |> U.member "present" |> U.to_bool);
+  check string "next action" "masc_observe_traces"
+    (json |> U.member "recommended_next_action" |> U.member "tool" |> U.to_string)
+
+let test_stale_supervised_session_keeps_stale_flag () =
+  let stale_iso = M.Command_plane_v2.iso_of_unix (M.Time_compat.now () -. 1200.) in
+  let session : M.Swarm_status.session_info =
+    {
+      session_id = "sess-stale";
+      goal = "Exercise stale supervised lane";
+      status = "running";
+      started_at = 0.0;
+      updated_at_iso = stale_iso;
+      last_event_at = Some stale_iso;
+      last_turn_at = Some stale_iso;
+      worker_names = [ "worker-a" ];
+      min_agents_violation_streak = 0;
+      policy_violation_count = 0;
+    }
+  in
+  let json =
+    M.Swarm_status.build_json_from_inputs ~now:(M.Time_compat.now ()) ~operations:[]
+      ~detachments:[] ~alerts:[] ~decisions:[] ~traces:[] ~sessions:[ session ]
+  in
+  let supervised = find_lane json "supervised" in
+  let hard_flags = supervised |> U.member "hard_flags" |> U.to_list in
+  check bool "supervised lane still present" true
+    (supervised |> U.member "present" |> U.to_bool);
+  check bool "stale_data flag present" true
+    (List.exists
+       (fun flag ->
+         String.equal "stale_data" (flag |> U.member "code" |> U.to_string))
+       hard_flags);
+  check string "stale supervised recommendation" "masc_team_session_status"
+    (json |> U.member "recommended_next_action" |> U.member "tool" |> U.to_string)
+
+let () =
+  run "Swarm_status"
+    [
+      ( "lane_presence",
+        [
+          test_case "trace_only_does_not_activate_supervised_lane" `Quick
+            test_supervised_trace_only_does_not_make_lane_present;
+          test_case "session_keeps_supervised_lane_present" `Quick
+            test_supervised_session_keeps_lane_present;
+          test_case "stale_session_keeps_stale_flag" `Quick
+            test_stale_supervised_session_keeps_stale_flag;
+        ] );
+    ]


### PR DESCRIPTION
## Summary
- stop marking the supervised lane present from stale operator traces alone
- avoid emitting stale-data flags for lanes that are not actually present
- add swarm-status regression coverage for trace-only and real-session supervised lanes

## Validation
- dune build --root . @default
- ./_build/default/test/test_swarm_status.exe
- ./_build/default/test/test_command_plane_v2.exe
- ./_build/default/test/test_operator_control.exe