### PR TITLE
fix: harden swarm live proof validation

### DIFF
--- a/lib/agent_swarm_swarm.ml
+++ b/lib/agent_swarm_swarm.ml
@@ -39,13 +39,24 @@ let extract_text (response : Types.api_response) =
   |> List.filter_map (function Types.Text text -> Some text | _ -> None)
   |> String.concat "\n"
 
-let final_marker_line text =
+let trimmed_nonempty_lines text =
   text
   |> String.split_on_char '\n'
   |> List.map String.trim
-  |> List.find_opt (fun line ->
-         String.length line >= 13
-         && String.sub line 0 13 = "FINAL_MARKER[")
+  |> List.filter (fun line -> not (String.equal line ""))
+
+let last_nonempty_line text =
+  match trimmed_nonempty_lines text |> List.rev with
+  | line :: _ -> Some line
+  | [] -> None
+
+let final_marker_line text =
+  match last_nonempty_line text with
+  | Some line
+    when String.length line >= 13
+         && String.sub line 0 13 = "FINAL_MARKER[" ->
+      Some line
+  | _ -> None
 
 let response_has_expected_final_marker (response : Types.api_response)
     ~(expected_final_marker : string option) =
@@ -56,9 +67,9 @@ let response_has_expected_final_marker (response : Types.api_response)
       if String.equal marker "" then
         true
       else
-        String.split_on_char '\n' text
-        |> List.map String.trim
-        |> List.exists (fun line -> String.equal line marker)
+        match last_nonempty_line text with
+        | Some line -> String.equal line marker
+        | None -> false
 
 let validate_expected_final_marker (response : Types.api_response)
     ~(expected_final_marker : string option) =
@@ -67,7 +78,10 @@ let validate_expected_final_marker (response : Types.api_response)
   else
     match expected_final_marker with
     | Some marker ->
-        Error (Printf.sprintf "Missing expected final marker: %s" marker)
+        Error
+          (Printf.sprintf
+             "Missing expected final marker as final non-empty line: %s"
+             marker)
     | None -> Ok response
 
 let contains_substring ~needle haystack =

--- a/lib/command_plane_v2.ml
+++ b/lib/command_plane_v2.ml
@@ -2621,9 +2621,11 @@ let swarm_live_json config ?run_id ?operation_id () =
     |> List.filteri (fun idx _ -> idx < 12)
     |> List.rev
   in
-  let message_contains needle =
+  let message_contains ~from_agent needle =
     List.exists
-      (fun (message : Types.message) -> string_contains ~needle message.content)
+      (fun (message : Types.message) ->
+        String.equal message.from_agent from_agent
+        && string_contains ~needle message.content)
       matching_messages
   in
   let task_by_id =
@@ -2683,9 +2685,15 @@ let swarm_live_json config ?run_id ?operation_id () =
              |> List.find_opt (fun (message : Types.message) ->
                     String.equal message.from_agent plan.name)
            in
-           let claim_marker_seen = message_contains plan.claim_marker in
-           let done_marker_seen = message_contains plan.done_marker in
-           let final_marker_seen = message_contains plan.final_marker in
+           let claim_marker_seen =
+             message_contains ~from_agent:plan.name plan.claim_marker
+           in
+           let done_marker_seen =
+             message_contains ~from_agent:plan.name plan.done_marker
+           in
+           let final_marker_seen =
+             message_contains ~from_agent:plan.name plan.final_marker
+           in
            let joined =
              Option.is_some agent
              || Option.is_some assigned_task

--- a/scripts/harness/workload/agent_swarm_live.sh
+++ b/scripts/harness/workload/agent_swarm_live.sh
@@ -37,6 +37,10 @@ if ! command -v jq >/dev/null 2>&1; then
   exit 1
 fi
 
+urlencode() {
+  jq -rn --arg v "$1" '$v|@uri'
+}
+
 jsonrpc_call() {
   local id="$1"
   local method="$2"
@@ -59,7 +63,9 @@ jsonrpc_call() {
     if [ -n "$response_line" ]; then
       printf "%s" "$response_line"
     else
-      printf "%s\n" "$sse_data" | tail -n1
+      echo "missing matching JSON-RPC response id: $id" >&2
+      printf "%s\n" "$raw" >&2
+      exit 1
     fi
   else
     printf "%s" "$raw"
@@ -420,8 +426,9 @@ start_slot_sampler
 HARNESS_PID="$!"
 
 attempt=0
+RUN_ID_QUERY="$(urlencode "$RUN_ID")"
 while [ "$attempt" -lt 60 ]; do
-  SWARM_LIVE_JSON="$(curl -fsS "${MASC_URL}/api/v1/command-plane/swarm?run_id=${RUN_ID}")"
+  SWARM_LIVE_JSON="$(curl -fsS "${MASC_URL}/api/v1/command-plane/swarm?run_id=${RUN_ID_QUERY}")"
   LIVE_WORKERS="$(printf "%s" "$SWARM_LIVE_JSON" | jq -r '.summary.live_workers // 0')"
   if [ "$LIVE_WORKERS" -ge "$EXPECTED_WORKERS" ]; then
     break
@@ -446,7 +453,8 @@ echo "[10/10] checkpoint + finalize"
 SUCCESSFUL_WORKERS="$(printf "%s" "$HARNESS_RESULT" | jq -r '.summary.successful_workers')"
 call_tool_checked 90130 "masc_operation_checkpoint" "$(jq -cn --arg operation_id "$OPERATION_ID" --arg checkpoint_ref "live-harness-${RUN_ID}" --arg note "successful_workers=${SUCCESSFUL_WORKERS}/${EXPECTED_WORKERS}" '{operation_id:$operation_id,checkpoint_ref:$checkpoint_ref,note:$note}')" >/dev/null
 
-SWARM_JSON="$(curl -fsS "${MASC_URL}/api/v1/command-plane/swarm?run_id=${RUN_ID}&operation_id=${OPERATION_ID}")"
+OPERATION_ID_QUERY="$(urlencode "$OPERATION_ID")"
+SWARM_JSON="$(curl -fsS "${MASC_URL}/api/v1/command-plane/swarm?run_id=${RUN_ID_QUERY}&operation_id=${OPERATION_ID_QUERY}")"
 require_json "$SWARM_JSON"
 PASS="$(printf "%s" "$SWARM_JSON" | jq -r '.summary.pass // false')"
 JOINED="$(printf "%s" "$SWARM_JSON" | jq -r '.summary.joined_workers // 0')"

--- a/test/test_agent_swarm_unit.ml
+++ b/test/test_agent_swarm_unit.ml
@@ -75,6 +75,26 @@ let test_validate_expected_final_marker_accepts_exact_line () =
         (Agent_swarm_swarm.extract_text validated)
   | Error message ->
       Alcotest.failf "expected marker should pass: %s" message
+
+let test_validate_expected_final_marker_requires_final_line_position () =
+  let marker = "FINAL_MARKER[demo:discover:official]" in
+  let response : Agent_sdk.Types.api_response = {
+    id = "resp-3";
+    model = "test-model";
+    stop_reason = Agent_sdk.Types.EndTurn;
+    content = [ Agent_sdk.Types.Text ("summary\n" ^ marker ^ "\ntrailing text") ];
+    usage = None;
+  } in
+  match
+    Agent_swarm_swarm.validate_expected_final_marker response
+      ~expected_final_marker:(Some marker)
+  with
+  | Ok _ -> Alcotest.fail "marker should fail when not last non-empty line"
+  | Error message ->
+      Alcotest.(check string) "position error message"
+        ("Missing expected final marker as final non-empty line: " ^ marker)
+        message
+
 let () =
   Alcotest.run "Swarm Unit" [
     "error_paths", [
@@ -83,5 +103,7 @@ let () =
         test_validate_expected_final_marker_requires_real_output;
       Alcotest.test_case "exact expected final marker passes" `Quick
         test_validate_expected_final_marker_accepts_exact_line;
+      Alcotest.test_case "expected final marker must be last non-empty line" `Quick
+        test_validate_expected_final_marker_requires_final_line_position;
     ];
   ]

--- a/test/test_command_plane_v2.ml
+++ b/test/test_command_plane_v2.ml
@@ -547,6 +547,124 @@ let test_swarm_live_json_ignores_stale_evidence_from_previous_run () =
         (swarm |> member "summary" |> member "final_markers_seen" |> to_int);
       Alcotest.(check bool) "end to end fail" false
         (swarm |> member "summary" |> member "pass_end_to_end" |> to_bool))
+
+let test_swarm_live_json_scopes_markers_to_sender () =
+  let base_dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base_dir)
+    (fun () ->
+      let owner = "owner-root-node" in
+      let run_id = "swarm-live-replica-proof" in
+      let plans =
+        Agent_swarm_live_harness.build_worker_plans ~worker_count:13 run_id
+      in
+      let first_plan = List.hd plans in
+      let replica_plan = List.nth plans 12 in
+      let worker_names =
+        List.map
+          (fun (plan : Agent_swarm_live_harness.worker_plan) -> plan.name)
+          plans
+      in
+      let leader = List.hd worker_names in
+      let config = Room.default_config base_dir in
+      ignore (Room.init config ~agent_name:(Some "owner"));
+      ignore (Room.join config ~agent_name:owner ~capabilities:[] ());
+      List.iter
+        (fun worker -> ignore (Room.join config ~agent_name:worker ~capabilities:[] ()))
+        worker_names;
+      unit_update_exn config ~actor:"owner"
+        (`Assoc
+          [
+            ("unit_id", `String "company-main");
+            ("kind", `String "company");
+            ("label", `String "Main Company");
+            ("leader_id", `String owner);
+            ("roster", `List (List.map (fun name -> `String name) (owner :: worker_names)));
+          ]);
+      unit_update_exn config ~actor:"owner"
+        (`Assoc
+          [
+            ("unit_id", `String "platoon-alpha");
+            ("kind", `String "platoon");
+            ("label", `String "Alpha Platoon");
+            ("parent_unit_id", `String "company-main");
+            ("leader_id", `String leader);
+            ("roster", `List (List.map (fun name -> `String name) worker_names));
+          ]);
+      unit_update_exn config ~actor:"owner"
+        (`Assoc
+          [
+            ("unit_id", `String "squad-alpha-1");
+            ("kind", `String "squad");
+            ("label", `String "Alpha Squad 1");
+            ("parent_unit_id", `String "platoon-alpha");
+            ("leader_id", `String leader);
+            ("roster", `List (List.map (fun name -> `String name) worker_names));
+          ]);
+      let operation =
+        start_operation_exn config ~actor:"owner"
+          (`Assoc
+            [
+              ("assigned_unit_id", `String "squad-alpha-1");
+              ("objective", `String (Printf.sprintf "Run %s live harness" run_id));
+              ("note", `String (Printf.sprintf "run_id=%s" run_id));
+              ("policy_class", `String "guarded");
+              ("budget_class", `String "standard");
+            ])
+      in
+      ignore
+        (unwrap_ok
+           (Command_plane_v2.dispatch_tick_json config ~actor:"owner"
+              (`Assoc [ ("operation_id", `String operation.operation_id) ])));
+      Room_utils.mkdir_p
+        (Filename.concat base_dir ".masc/control-plane/swarm-live/swarm-live-replica-proof");
+      Room_utils.write_json config
+        (Filename.concat base_dir
+           ".masc/control-plane/swarm-live/swarm-live-replica-proof/swarm-live-summary.json")
+        (`Assoc
+          [
+            ("run_id", `String run_id);
+            ("worker_count", `Int 13);
+            ("required_final_markers", `Int 13);
+            ("completed_workers", `Int 1);
+            ("final_markers_seen", `Int 1);
+            ("pass_hot_concurrency", `Bool false);
+            ("pass_end_to_end", `Bool false);
+            ("pass", `Bool false);
+            ("min_hot_slots", `Int 10);
+          ]);
+      ignore
+        (Room.broadcast config ~from_agent:first_plan.name
+           ~content:(Printf.sprintf "%s agent=%s"
+                       first_plan.claim_marker first_plan.name));
+      ignore
+        (Room.broadcast config ~from_agent:first_plan.name
+           ~content:(Printf.sprintf "%s agent=%s"
+                       first_plan.done_marker first_plan.name));
+      ignore
+        (Room.broadcast config ~from_agent:first_plan.name
+           ~content:(Printf.sprintf "%s agent=%s"
+                       first_plan.final_marker first_plan.name));
+      let swarm =
+        Command_plane_v2.swarm_live_json config ~run_id
+          ~operation_id:operation.operation_id ()
+      in
+      let open Yojson.Safe.Util in
+      let workers = swarm |> member "workers" |> to_list in
+      let find_worker name =
+        workers
+        |> List.find (fun row ->
+               String.equal (row |> member "name" |> to_string) name)
+      in
+      let first_row = find_worker first_plan.name in
+      let replica_row = find_worker replica_plan.name in
+      Alcotest.(check bool) "first worker marker seen" true
+        (first_row |> member "final_marker_seen" |> to_bool);
+      Alcotest.(check bool) "replica marker not inherited" false
+        (replica_row |> member "final_marker_seen" |> to_bool);
+      Alcotest.(check bool) "replica claim not inherited" false
+        (replica_row |> member "claim_marker_seen" |> to_bool))
+
 let () =
   Alcotest.run "Command_plane_v2"
     [
@@ -562,5 +680,7 @@ let () =
             test_swarm_live_json_restores_completed_workers_after_leave;
           Alcotest.test_case "swarm live ignores stale previous-run evidence" `Quick
             test_swarm_live_json_ignores_stale_evidence_from_previous_run;
+          Alcotest.test_case "swarm live scopes markers to sender" `Quick
+            test_swarm_live_json_scopes_markers_to_sender;
         ] );
     ]


### PR DESCRIPTION
## Summary
- require the expected final marker to be the last non-empty response line
- scope swarm live proof markers to the emitting worker and add a replica regression test
- fail the harness shell on SSE JSON-RPC id mismatches and URL-encode swarm query params

## Validation
- dune build --root . test/test_agent_swarm_unit.exe test/test_command_plane_v2.exe
- ./_build/default/test/test_agent_swarm_unit.exe
- ./_build/default/test/test_command_plane_v2.exe
- bash -n scripts/harness/workload/agent_swarm_live.sh
- dune build --root . @check