### PR TITLE
fix: honor swarm worker count before artifact write

### DIFF
--- a/lib/command_plane_v2.ml
+++ b/lib/command_plane_v2.ml
@@ -2791,6 +2791,23 @@ let extract_run_id_from_note token =
                 |> String.trim))
          else None)
 
+let extract_int_field_from_note ~field token =
+  let prefix = String.lowercase_ascii field ^ "=" in
+  let prefix_len = String.length prefix in
+  token
+  |> String.split_on_char ' '
+  |> List.find_map (fun part ->
+         let trimmed = String.trim part in
+         if String.length trimmed > prefix_len
+            && String.equal
+                 (String.lowercase_ascii (String.sub trimmed 0 prefix_len))
+                 prefix
+         then
+           int_of_string_opt
+             (String.sub trimmed prefix_len (String.length trimmed - prefix_len)
+             |> String.trim)
+         else None)
+
 let extract_run_id_from_prefixed_token ~prefix token =
   let prefix_len = String.length prefix in
   if String.length token > prefix_len
@@ -2921,18 +2938,38 @@ let swarm_live_json config ?run_id ?operation_id () =
     Option.bind harness_summary (fun json ->
         U.member "worker_count" json |> U.to_int_option)
   in
+  let worker_count_from_operation =
+    Option.bind selected_operation (fun (operation : operation_record) ->
+        Option.bind operation.note
+          (extract_int_field_from_note ~field:"worker_count"))
+  in
   let required_final_markers =
     Option.bind harness_summary (fun json ->
         U.member "required_final_markers" json |> U.to_int_option)
   in
+  let required_final_markers_from_operation =
+    Option.bind selected_operation (fun (operation : operation_record) ->
+        Option.bind operation.note
+          (extract_int_field_from_note ~field:"required_final_markers"))
+  in
   let min_hot_slots =
     Option.bind harness_summary (fun json ->
         U.member "min_hot_slots" json |> U.to_int_option)
-    |> Option.value ~default:10
+  in
+  let min_hot_slots_from_operation =
+    Option.bind selected_operation (fun (operation : operation_record) ->
+        Option.bind operation.note
+          (extract_int_field_from_note ~field:"min_hot_slots"))
+  in
+  let min_hot_slots =
+    Option.value min_hot_slots
+      ~default:(Option.value min_hot_slots_from_operation ~default:10)
   in
   let plans =
     Agent_swarm_live_harness.build_worker_plans
-      ~worker_count:(Option.value worker_count_from_artifact ~default:12)
+      ~worker_count:
+        (Option.value worker_count_from_artifact
+           ~default:(Option.value worker_count_from_operation ~default:12))
       effective_run_id
   in
   let expected_workers = List.map (fun (plan : Agent_swarm_live_harness.worker_plan) -> plan.name) plans in
@@ -3332,7 +3369,10 @@ let swarm_live_json config ?run_id ?operation_id () =
   in
   let expected_count = List.length expected_workers in
   let required_final_markers =
-    Option.value required_final_markers ~default:expected_count
+    Option.value required_final_markers
+      ~default:
+        (Option.value required_final_markers_from_operation
+           ~default:expected_count)
   in
   let pass_hot_concurrency =
     peak_hot_slots >= min_hot_slots

--- a/scripts/harness/workload/agent_swarm_live.sh
+++ b/scripts/harness/workload/agent_swarm_live.sh
@@ -356,7 +356,7 @@ HARNESS_ARTIFACT_FILE="${RUN_ARTIFACT_DIR}/harness-result.json"
 rm -rf "$RUN_ARTIFACT_DIR"
 mkdir -p "$RUN_ARTIFACT_DIR"
 
-echo "[4/10] describe deterministic 12-worker manifest"
+echo "[4/10] describe deterministic swarm manifest"
 MANIFEST_JSON="$("$REPO_ROOT/_build/default/bin/agent_swarm_harness_cli.exe" \
   --describe \
   --run-id "$RUN_ID" \
@@ -393,7 +393,7 @@ call_tool_checked 90011 "masc_unit_define" "$(jq -cn --arg run_id "$RUN_ID" '{un
 call_tool_checked 90012 "masc_unit_define" "$(jq -cn --arg run_id "$RUN_ID" --argjson roster "$SQUAD_ROSTER_JSON" '{unit_id:("squad-" + $run_id),kind:"squad",label:("Live Swarm Squad " + $run_id),parent_unit_id:("platoon-" + $run_id),leader_id:"swarm-harness",roster:$roster,policy:{autonomy_level:"L4_Autonomous",escalation_timeout_sec:180},budget:{headcount_cap:16,active_operation_cap:1}}')" >/dev/null
 
 echo "[7/10] start managed operation"
-OPERATION_RAW="$(call_tool_checked 90120 "masc_operation_start" "$(jq -cn --arg run_id "$RUN_ID" '{assigned_unit_id:("squad-" + $run_id),objective:("Run deterministic 12-worker live harness " + $run_id),autonomy_level:"L4_Autonomous",policy_class:"guarded",budget_class:"standard",note:("run_id=" + $run_id)}')")"
+OPERATION_RAW="$(call_tool_checked 90120 "masc_operation_start" "$(jq -cn --arg run_id "$RUN_ID" --arg expected_workers "$EXPECTED_WORKERS" --arg required_final_markers "$REQUIRED_FINAL_MARKERS" --arg min_hot_slots "$MIN_HOT_SLOTS" '{assigned_unit_id:("squad-" + $run_id),objective:("Run deterministic " + $expected_workers + "-worker live harness " + $run_id),autonomy_level:"L4_Autonomous",policy_class:"guarded",budget_class:"standard",note:("run_id=" + $run_id + " worker_count=" + $expected_workers + " required_final_markers=" + $required_final_markers + " min_hot_slots=" + $min_hot_slots)}')")"
 OPERATION_ID="$(printf "%s" "$OPERATION_RAW" | extract_result | jq -r '.operation_id // empty')"
 if [ -z "$OPERATION_ID" ]; then
   printf "%s\n" "$OPERATION_RAW" >&2
@@ -427,8 +427,9 @@ HARNESS_PID="$!"
 
 attempt=0
 RUN_ID_QUERY="$(urlencode "$RUN_ID")"
+OPERATION_ID_QUERY="$(urlencode "$OPERATION_ID")"
 while [ "$attempt" -lt 60 ]; do
-  SWARM_LIVE_JSON="$(curl -fsS "${MASC_URL}/api/v1/command-plane/swarm?run_id=${RUN_ID_QUERY}")"
+  SWARM_LIVE_JSON="$(curl -fsS "${MASC_URL}/api/v1/command-plane/swarm?run_id=${RUN_ID_QUERY}&operation_id=${OPERATION_ID_QUERY}")"
   LIVE_WORKERS="$(printf "%s" "$SWARM_LIVE_JSON" | jq -r '.summary.live_workers // 0')"
   if [ "$LIVE_WORKERS" -ge "$EXPECTED_WORKERS" ]; then
     break
@@ -453,7 +454,6 @@ echo "[10/10] checkpoint + finalize"
 SUCCESSFUL_WORKERS="$(printf "%s" "$HARNESS_RESULT" | jq -r '.summary.successful_workers')"
 call_tool_checked 90130 "masc_operation_checkpoint" "$(jq -cn --arg operation_id "$OPERATION_ID" --arg checkpoint_ref "live-harness-${RUN_ID}" --arg note "successful_workers=${SUCCESSFUL_WORKERS}/${EXPECTED_WORKERS}" '{operation_id:$operation_id,checkpoint_ref:$checkpoint_ref,note:$note}')" >/dev/null
 
-OPERATION_ID_QUERY="$(urlencode "$OPERATION_ID")"
 SWARM_JSON="$(curl -fsS "${MASC_URL}/api/v1/command-plane/swarm?run_id=${RUN_ID_QUERY}&operation_id=${OPERATION_ID_QUERY}")"
 require_json "$SWARM_JSON"
 PASS="$(printf "%s" "$SWARM_JSON" | jq -r '.summary.pass // false')"
@@ -467,7 +467,7 @@ FINAL_MARKERS_SEEN="$(printf "%s" "$SWARM_JSON" | jq -r '.summary.final_markers_
 PASS_HOT="$(printf "%s" "$SWARM_JSON" | jq -r '.summary.pass_hot_concurrency // false')"
 PASS_E2E="$(printf "%s" "$SWARM_JSON" | jq -r '.summary.pass_end_to_end // false')"
 if [ "$PASS" = "true" ]; then
-  call_tool_checked 90131 "masc_operation_finalize" "$(jq -cn --arg operation_id "$OPERATION_ID" --arg note "12-worker live harness passed" '{operation_id:$operation_id,note:$note}')" >/dev/null
+  call_tool_checked 90131 "masc_operation_finalize" "$(jq -cn --arg operation_id "$OPERATION_ID" --arg note "${EXPECTED_WORKERS}-worker live harness passed" '{operation_id:$operation_id,note:$note}')" >/dev/null
   OPERATION_ID=""
 fi
 

--- a/test/test_command_plane_v2.ml
+++ b/test/test_command_plane_v2.ml
@@ -829,6 +829,94 @@ let test_summary_json_swarm_proof_fallback_and_missing () =
         (missing_proof |> Yojson.Safe.Util.member "source" |> Yojson.Safe.Util.to_string);
       Alcotest.(check bool) "missing reason present" true
         (missing_proof |> Yojson.Safe.Util.member "missing_reason" <> `Null))
+let test_swarm_live_json_reads_custom_worker_count_from_operation_note () =
+  let base_dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base_dir)
+    (fun () ->
+      let owner = "owner-root-node" in
+      let run_id = "swarm-live-custom-count" in
+      let plans =
+        Agent_swarm_live_harness.build_worker_plans ~worker_count:13 run_id
+      in
+      let worker_names =
+        List.map
+          (fun (plan : Agent_swarm_live_harness.worker_plan) -> plan.name)
+          plans
+      in
+      let leader = List.hd worker_names in
+      let config = Room.default_config base_dir in
+      ignore (Room.init config ~agent_name:(Some "owner"));
+      ignore (Room.join config ~agent_name:owner ~capabilities:[] ());
+      List.iter
+        (fun worker ->
+          ignore (Room.join config ~agent_name:worker ~capabilities:[] ()))
+        worker_names;
+      unit_update_exn config ~actor:"owner"
+        (`Assoc
+          [
+            ("unit_id", `String "company-main");
+            ("kind", `String "company");
+            ("label", `String "Main Company");
+            ("leader_id", `String owner);
+            ( "roster",
+              `List
+                (List.map (fun name -> `String name) (owner :: worker_names))
+            );
+          ]);
+      unit_update_exn config ~actor:"owner"
+        (`Assoc
+          [
+            ("unit_id", `String "platoon-alpha");
+            ("kind", `String "platoon");
+            ("label", `String "Alpha Platoon");
+            ("parent_unit_id", `String "company-main");
+            ("leader_id", `String leader);
+            ("roster", `List (List.map (fun name -> `String name) worker_names));
+          ]);
+      unit_update_exn config ~actor:"owner"
+        (`Assoc
+          [
+            ("unit_id", `String "squad-alpha-1");
+            ("kind", `String "squad");
+            ("label", `String "Alpha Squad 1");
+            ("parent_unit_id", `String "platoon-alpha");
+            ("leader_id", `String leader);
+            ("roster", `List (List.map (fun name -> `String name) worker_names));
+          ]);
+      let operation =
+        start_operation_exn config ~actor:"owner"
+          (`Assoc
+            [
+              ("assigned_unit_id", `String "squad-alpha-1");
+              ( "objective",
+                `String
+                  (Printf.sprintf "Run deterministic 13-worker live harness %s"
+                     run_id) );
+              ( "note",
+                `String
+                  (Printf.sprintf
+                     "run_id=%s worker_count=13 required_final_markers=13 min_hot_slots=11"
+                     run_id) );
+              ("policy_class", `String "guarded");
+              ("budget_class", `String "standard");
+            ])
+      in
+      ignore
+        (unwrap_ok
+           (Command_plane_v2.dispatch_tick_json config ~actor:"owner"
+              (`Assoc [ ("operation_id", `String operation.operation_id) ])));
+      let swarm =
+        Command_plane_v2.swarm_live_json config ~run_id
+          ~operation_id:operation.operation_id ()
+      in
+      let open Yojson.Safe.Util in
+      Alcotest.(check int) "expected workers from note" 13
+        (swarm |> member "summary" |> member "expected_workers" |> to_int);
+      Alcotest.(check int) "worker rows from note" 13
+        (swarm |> member "workers" |> to_list |> List.length);
+      Alcotest.(check int) "live workers from joined roster" 13
+        (swarm |> member "summary" |> member "live_workers" |> to_int))
 let () =
   Alcotest.run "Command_plane_v2"
     [
@@ -846,18 +934,8 @@ let () =
             test_swarm_live_json_ignores_stale_evidence_from_previous_run;
           Alcotest.test_case "swarm live scopes markers to sender" `Quick
             test_swarm_live_json_scopes_markers_to_sender;
-          Alcotest.test_case "summary json omits heavy arrays" `Quick
-            test_summary_json_omits_heavy_arrays_and_keeps_summaries;
-          Alcotest.test_case "summary swarm proof prefers artifact" `Quick
-            test_summary_json_swarm_proof_prefers_artifact;
-          Alcotest.test_case "summary swarm proof fallback and missing" `Quick
-            test_summary_json_swarm_proof_fallback_and_missing;
-          Alcotest.test_case "swarm live restores completed workers" `Quick
-            test_swarm_live_json_restores_completed_workers_after_leave;
-          Alcotest.test_case "swarm live ignores stale previous-run evidence" `Quick
-            test_swarm_live_json_ignores_stale_evidence_from_previous_run;
-          Alcotest.test_case "swarm live scopes markers to sender" `Quick
-            test_swarm_live_json_scopes_markers_to_sender;
+          Alcotest.test_case "swarm live reads custom worker count from operation note" `Quick
+            test_swarm_live_json_reads_custom_worker_count_from_operation_note;
           Alcotest.test_case "summary json omits heavy arrays" `Quick
             test_summary_json_omits_heavy_arrays_and_keeps_summaries;
           Alcotest.test_case "summary swarm proof prefers artifact" `Quick

--- a/test/test_swarm_status.ml
+++ b/test/test_swarm_status.ml
@@ -22,8 +22,10 @@ let test_supervised_trace_only_does_not_make_lane_present () =
     }
   in
   let json =
-    M.Swarm_status.build_json_from_inputs ~now:(M.Time_compat.now ()) ~operations:[]
-      ~detachments:[] ~alerts:[] ~decisions:[] ~traces:[ trace ] ~sessions:[]
+    M.Swarm_status.build_json_from_inputs
+      ~timeline_limit_override:M.Swarm_status.timeline_limit
+      ~now:(M.Time_compat.now ()) ~operations:[] ~detachments:[] ~alerts:[]
+      ~decisions:[] ~traces:[ trace ] ~sessions:[]
   in
   let supervised = find_lane json "supervised" in
   check bool "supervised lane absent" false
@@ -52,8 +54,10 @@ let test_supervised_session_keeps_lane_present () =
     }
   in
   let json =
-    M.Swarm_status.build_json_from_inputs ~now:(M.Time_compat.now ()) ~operations:[]
-      ~detachments:[] ~alerts:[] ~decisions:[] ~traces:[] ~sessions:[ session ]
+    M.Swarm_status.build_json_from_inputs
+      ~timeline_limit_override:M.Swarm_status.timeline_limit
+      ~now:(M.Time_compat.now ()) ~operations:[] ~detachments:[] ~alerts:[]
+      ~decisions:[] ~traces:[] ~sessions:[ session ]
   in
   let supervised = find_lane json "supervised" in
   check bool "supervised lane present" true
@@ -78,8 +82,10 @@ let test_stale_supervised_session_keeps_stale_flag () =
     }
   in
   let json =
-    M.Swarm_status.build_json_from_inputs ~now:(M.Time_compat.now ()) ~operations:[]
-      ~detachments:[] ~alerts:[] ~decisions:[] ~traces:[] ~sessions:[ session ]
+    M.Swarm_status.build_json_from_inputs
+      ~timeline_limit_override:M.Swarm_status.timeline_limit
+      ~now:(M.Time_compat.now ()) ~operations:[] ~detachments:[] ~alerts:[]
+      ~decisions:[] ~traces:[] ~sessions:[ session ]
   in
   let supervised = find_lane json "supervised" in
   let hard_flags = supervised |> U.member "hard_flags" |> U.to_list in


### PR DESCRIPTION
## Summary
- carry worker_count, required_final_markers, and min_hot_slots in the managed operation note
- let command_plane_v2 read those values before swarm-live-summary.json exists
- tighten the harness polling query to include operation_id and stop hardcoding 12-worker labels

## Validation
- dune build --root . test/test_command_plane_v2.exe
- ./_build/default/test/test_command_plane_v2.exe
- bash -n scripts/harness/workload/agent_swarm_live.sh
- dune build --root . @check