### PR TITLE
fix(swarm): ignore terminal supervised session artifacts

### DIFF
--- a/lib/swarm_status.ml
+++ b/lib/swarm_status.ml
@@ -381,6 +381,19 @@ let operation_active (operation : operation_info) =
 
 let operation_terminal (operation : operation_info) = not (operation_active operation)
 
+let detachment_active (detachment : detachment_info) =
+  match String.lowercase_ascii detachment.status with
+  | "completed" | "cancelled" | "failed" | "stopped" -> false
+  | _ -> true
+
+let decision_pending (decision : decision_info) =
+  String.equal (String.lowercase_ascii decision.status) "pending"
+
+let session_active (session : session_info) =
+  match String.lowercase_ascii session.status with
+  | "running" | "paused" -> true
+  | _ -> false
+
 let classify_operation (operation : operation_info) =
   if String.equal operation.source "managed" then
     Managed
@@ -1023,18 +1036,30 @@ let build_json_from_inputs ~now ~operations ~detachments ~alerts ~decisions
     |> List.map (fun kind ->
            let lane_operations =
              slice_by_kind kind classify_operation operations
+             |> (match kind with
+                | Supervised -> List.filter operation_active
+                | Managed | Projected -> Fun.id)
            in
            let lane_detachments =
              slice_by_kind kind (classify_detachment operation_kinds) detachments
+             |> (match kind with
+                | Supervised -> List.filter detachment_active
+                | Managed | Projected -> Fun.id)
+           in
+           let lane_decisions =
+             decisions_by_kind kind
+             |> (match kind with
+                | Supervised -> List.filter decision_pending
+                | Managed | Projected -> Fun.id)
            in
            let lane_sessions =
              match kind with
-             | Supervised -> sessions
+             | Supervised -> List.filter session_active sessions
              | Managed | Projected -> []
            in
            lane_for_kind kind ~now ~operations:lane_operations
              ~detachments:lane_detachments ~alerts:(alerts_by_kind kind)
-             ~decisions:(decisions_by_kind kind) ~traces:(traces_by_kind kind)
+             ~decisions:lane_decisions ~traces:(traces_by_kind kind)
              ~sessions:lane_sessions ~mixed_runtime_sources)
   in
   let timeline =

--- a/test/test_swarm_status.ml
+++ b/test/test_swarm_status.ml
@@ -93,6 +93,71 @@ let test_stale_supervised_session_keeps_stale_flag () =
   check string "stale supervised recommendation" "masc_team_session_status"
     (json |> U.member "recommended_next_action" |> U.member "tool" |> U.to_string)
 
+let test_terminal_projected_session_artifacts_do_not_keep_supervised_lane_present ()
+    =
+  let now = M.Time_compat.now () in
+  let stale_iso = M.Command_plane_v2.iso_of_unix (now -. 3600.) in
+  let operation : M.Swarm_status.operation_info =
+    {
+      operation_id = "detachment-ts-old";
+      objective = "Historical supervised session";
+      source = "projected";
+      status = "completed";
+      trace_id = "ts-old";
+      detachment_session_id = Some "ts-old";
+      note = Some "duration_reached";
+      updated_at = Some stale_iso;
+    }
+  in
+  let detachment : M.Swarm_status.detachment_info =
+    {
+      detachment_id = "detachment-ts-old";
+      operation_id = "detachment-ts-old";
+      source = "projected";
+      status = "cancelled";
+      runtime_kind = Some "team_session";
+      session_id = Some "ts-old";
+      roster = [ "worker-a"; "worker-b" ];
+      leader_id = Some "worker-a";
+      last_event_at = Some stale_iso;
+      last_progress_at = Some stale_iso;
+      updated_at = Some stale_iso;
+    }
+  in
+  let session : M.Swarm_status.session_info =
+    {
+      session_id = "ts-old";
+      goal = "Historical supervised session";
+      status = "completed";
+      started_at = now -. 7200.;
+      updated_at_iso = stale_iso;
+      last_event_at = Some stale_iso;
+      last_turn_at = Some stale_iso;
+      worker_names = [ "worker-a"; "worker-b" ];
+      min_agents_violation_streak = 0;
+      policy_violation_count = 0;
+    }
+  in
+  let json =
+    M.Swarm_status.build_json_from_inputs ~now ~operations:[ operation ]
+      ~detachments:[ detachment ] ~alerts:[] ~decisions:[] ~traces:[]
+      ~sessions:[ session ]
+  in
+  let supervised = find_lane json "supervised" in
+  check bool "supervised lane absent for terminal-only artifacts" false
+    (supervised |> U.member "present" |> U.to_bool);
+  check int "supervised operations filtered" 0
+    (supervised |> U.member "counts" |> U.member "operations" |> U.to_int);
+  check int "supervised detachments filtered" 0
+    (supervised |> U.member "counts" |> U.member "detachments" |> U.to_int);
+  check int "supervised workers filtered" 0
+    (supervised |> U.member "counts" |> U.member "workers" |> U.to_int);
+  check bool "no stale flag when lane absent" false
+    (List.exists
+       (fun flag ->
+         String.equal "stale_data" (flag |> U.member "code" |> U.to_string))
+       (supervised |> U.member "hard_flags" |> U.to_list))
+
 let () =
   run "Swarm_status"
     [
@@ -104,5 +169,8 @@ let () =
             test_supervised_session_keeps_lane_present;
           test_case "stale_session_keeps_stale_flag" `Quick
             test_stale_supervised_session_keeps_stale_flag;
+          test_case "terminal_projected_artifacts_do_not_keep_supervised_lane_present"
+            `Quick
+            test_terminal_projected_session_artifacts_do_not_keep_supervised_lane_present;
         ] );
     ]


### PR DESCRIPTION
## Summary
- stop completed/cancelled projected team-session artifacts from keeping the supervised lane present
- filter supervised lane inputs to live operations, detachments, sessions, and pending decisions only
- add a regression test for historical projected session remnants

## Testing
- dune build --root . test/test_swarm_status.exe test/test_command_plane_v2.exe test/test_operator_control.exe
- ./_build/default/test/test_swarm_status.exe
- ./_build/default/test/test_command_plane_v2.exe
- ./_build/default/test/test_operator_control.exe