### PR TITLE
feat(agent-swarm): add planner fleet worker mode

### DIFF
--- a/docs/BENCHMARK-RUNBOOK.md
+++ b/docs/BENCHMARK-RUNBOOK.md
@@ -81,6 +81,21 @@ scripts/harness_agent_swarm_live.sh
 - `hot 10+`는 orchestration proof와 별개다. `llama.cpp /slots` 샘플이 없으면 pass로 보지 않는다.
 - worker가 완료 후 leave해도 completed task ownership과 final marker가 있으면 swarm read model은 복원 가능해야 한다.
 
+## planner -> workers fleet mode
+
+hot-swarm proof와 별도로, `agent_swarm_runner`에는 planner가 tasks를 만들고 workers가 `claim_next`로 병렬 처리하는 2-phase fleet mode가 있다.
+
+이 경로는 다음을 검증할 때 쓴다.
+
+- planner prompt가 `masc_batch_add_tasks`를 제대로 쓰는지
+- worker prompt가 `masc_claim_next -> masc_set_current_task -> masc_complete_task` 순서를 지키는지
+- generic agent-swarm library 경로가 MASC task surface와 계속 맞는지
+
+이 모드는 보조 경로다.
+
+- hot-swarm proof의 pass/fail 기준을 대체하지 않는다
+- CPv2 operation/detachment 진실원천은 여전히 live harness/read model 쪽이다
+
 ## 최소 unit 예시
 
 ```json

--- a/docs/COMMAND-PLANE-RUNBOOK.md
+++ b/docs/COMMAND-PLANE-RUNBOOK.md
@@ -218,6 +218,27 @@ Content-Type: application/json
 - CPv2 benchmark
 - direct swarm orchestration
 
+## Agent Swarm Fleet Mode
+
+`agent_swarm_runner`에는 hot-swarm live harness와 별도로 planner -> workers용 fleet mode가 있다.
+
+핵심 차이:
+
+- hot-swarm harness
+  - deterministic fixture
+  - runtime-assisted claim/current_task/done
+  - CPv2 swarm proof와 dashboard truthfulness 검증이 목적
+- fleet mode
+  - planner가 `masc_batch_add_tasks`로 작업을 쪼갠다
+  - workers는 `masc_claim_next`로 task를 가져가고 `masc_set_current_task`를 직접 맞춘다
+  - 실험용 planner/worker orchestration이 목적
+
+주의:
+
+- fleet mode는 live harness의 대체가 아니다
+- planner가 task를 만들지 못하면 worker phase는 실제 작업을 못 한다
+- `claim_next`를 썼어도 worker가 `masc_set_current_task`를 생략하면 readiness가 어긋난다
+
 ## Which Tool Now?
 
 - room이 안 잡혔다: `masc_set_room`

--- a/lib/agent_swarm_client.ml
+++ b/lib/agent_swarm_client.ml
@@ -129,12 +129,28 @@ let add_task ~sw t ~title ~description =
       ("description", `String description);
     ]
 
+let batch_add_tasks ~sw t ~tasks =
+  let tasks_json =
+    `List
+      (List.map
+         (fun (title, description) ->
+           `Assoc
+             [ ("title", `String title); ("description", `String description) ])
+         tasks)
+  in
+  call_rpc ~sw t ~masc_method:"masc_batch_add_tasks"
+    ~arguments:[("tasks", tasks_json)]
+
 let claim ~sw t ~task_id =
   call_rpc ~sw t ~masc_method:"masc_claim"
     ~arguments:[
       ("agent_name", `String t.agent_name);
       ("task_id", `String task_id);
     ]
+
+let claim_next ~sw t =
+  call_rpc ~sw t ~masc_method:"masc_claim_next"
+    ~arguments:[("agent_name", `String t.agent_name)]
 
 let set_current_task ~sw t ~task_id =
   call_rpc ~sw t ~masc_method:"masc_plan_set_task"
@@ -147,6 +163,21 @@ let done_task ~sw t ~task_id =
     ~arguments:[
       ("agent_name", `String t.agent_name);
       ("task_id", `String task_id);
+    ]
+
+let release_task ~sw t ~task_id =
+  call_rpc ~sw t ~masc_method:"masc_release"
+    ~arguments:[
+      ("agent_name", `String t.agent_name);
+      ("task_id", `String task_id);
+    ]
+
+let cancel_task ~sw t ~task_id ~reason =
+  call_rpc ~sw t ~masc_method:"masc_cancel_task"
+    ~arguments:[
+      ("agent_name", `String t.agent_name);
+      ("task_id", `String task_id);
+      ("reason", `String reason);
     ]
 
 (* --- Communication --- *)

--- a/lib/agent_swarm_fleet.ml
+++ b/lib/agent_swarm_fleet.ml
@@ -21,6 +21,11 @@ type fleet_result = {
   result : (string, string) result;
 }
 
+type run_full_plan = {
+  planner_spec : Agent_swarm_swarm.agent_spec;
+  worker_specs : Agent_swarm_swarm.agent_spec list;
+}
+
 let member_name = function
   | Sdk_agent spec -> spec.Agent_swarm_swarm.name
   | Ext_agent config -> config.Agent_swarm_external_agent.name
@@ -34,6 +39,38 @@ let extract_text (resp : Types.api_response) =
   resp.content
   |> List.filter_map (function Types.Text s -> Some s | _ -> None)
   |> String.concat "\n"
+
+let planner_spec ~provider ~goal =
+  {
+    Agent_swarm_swarm.name = "fleet-planner";
+    provider;
+    system_prompt = Agent_swarm_prompts.fleet_planner ~goal;
+    tools = [];
+    max_tokens = None;
+    max_turns = 10;
+    include_masc_tools = true;
+    managed_task = None;
+    expected_final_marker = None;
+  }
+
+let worker_specs ~provider ~num_members ~workdir ~max_turns =
+  List.init num_members (fun i ->
+      let name = Printf.sprintf "fleet-worker-%d" (i + 1) in
+      {
+        Agent_swarm_swarm.name = name;
+        provider;
+        system_prompt = Agent_swarm_prompts.fleet_worker ~name ~workdir;
+        tools = [];
+        max_tokens = None;
+        max_turns;
+        include_masc_tools = true;
+        managed_task = None;
+        expected_final_marker = None;
+      })
+
+let build_run_full_plan ~provider ~goal ~num_members ~workdir ~max_turns =
+  { planner_spec = planner_spec ~provider ~goal;
+    worker_specs = worker_specs ~provider ~num_members ~workdir ~max_turns }
 
 let run_member ~sw ~net ~clock ~proc_mgr ~masc_url member ~goal =
   match member with
@@ -82,3 +119,72 @@ let run ~sw ~net ~clock ~proc_mgr config ~goal =
       ~message:(Printf.sprintf "Fleet done:\n%s" summary) in
     results_list
   )
+
+let run_full ~sw ~net ~clock ~proc_mgr ~masc_url ~provider
+    ~goal ~num_members ?workdir ~max_turns () =
+  let coordinator =
+    Agent_swarm_client.create ~net ~base_url:masc_url
+      ~agent_name:"fleet-coordinator"
+  in
+  let _joined = Agent_swarm_client.join ~sw coordinator in
+  Fun.protect
+    ~finally:(fun () ->
+      try ignore (Agent_swarm_client.leave ~sw coordinator) with _ -> ())
+    (fun () ->
+      let _ =
+        Agent_swarm_client.broadcast ~sw coordinator
+          ~message:
+            (Printf.sprintf "Fleet run_full: %s (members: %d)" goal num_members)
+      in
+      let workdir = match workdir with Some path -> path | None -> Sys.getcwd () in
+      let plan =
+        build_run_full_plan ~provider ~goal ~num_members ~workdir ~max_turns
+      in
+      let planner_result =
+        Agent_swarm_swarm.run_agent ~sw ~net ~clock ~masc_url plan.planner_spec
+          ~goal:(Printf.sprintf "Decompose this goal into tasks: %s" goal)
+      in
+      match planner_result.result with
+      | Error e ->
+        let _ =
+          Agent_swarm_client.broadcast ~sw coordinator
+            ~message:(Printf.sprintf "Planning failed: %s" e)
+        in
+        [planner_result]
+      | Ok _ ->
+        let _ =
+          Agent_swarm_client.broadcast ~sw coordinator
+            ~message:"Planning complete, launching workers"
+        in
+        let dev_tools =
+          Agent_swarm_dev_tools.make_tools ~proc_mgr ~clock ~workdir ()
+        in
+        let results =
+          Array.make (List.length plan.worker_specs)
+            { Agent_swarm_swarm.agent_name = ""; result = Error "pending" }
+        in
+        Eio.Fiber.all
+          (List.mapi
+             (fun i spec () ->
+               let result =
+                 Agent_swarm_swarm.run_agent ~sw ~net ~clock ~masc_url
+                   ~extra_tools:dev_tools spec
+                   ~goal:"Claim and complete available tasks"
+               in
+               results.(i) <- result)
+             plan.worker_specs);
+        let worker_results = Array.to_list results in
+        let summary =
+          worker_results
+          |> List.map (fun (result : Agent_swarm_swarm.agent_result) ->
+                 Printf.sprintf "- %s: %s" result.agent_name
+                   (match result.result with
+                    | Ok _ -> "OK"
+                    | Error e -> "Error: " ^ e))
+          |> String.concat "\n"
+        in
+        let _ =
+          Agent_swarm_client.broadcast ~sw coordinator
+            ~message:(Printf.sprintf "Fleet done:\n%s" summary)
+        in
+        planner_result :: worker_results)

--- a/lib/agent_swarm_fleet.ml
+++ b/lib/agent_swarm_fleet.ml
@@ -69,6 +69,7 @@ let worker_specs ~provider ~num_members ~workdir ~max_turns =
       })
 
 let build_run_full_plan ~provider ~goal ~num_members ~workdir ~max_turns =
+  if num_members <= 0 then invalid_arg "num_members must be positive";
   { planner_spec = planner_spec ~provider ~goal;
     worker_specs = worker_specs ~provider ~num_members ~workdir ~max_turns }
 
@@ -122,6 +123,7 @@ let run ~sw ~net ~clock ~proc_mgr config ~goal =
 
 let run_full ~sw ~net ~clock ~proc_mgr ~masc_url ~provider
     ~goal ~num_members ?workdir ~max_turns () =
+  if num_members <= 0 then invalid_arg "num_members must be positive";
   let coordinator =
     Agent_swarm_client.create ~net ~base_url:masc_url
       ~agent_name:"fleet-coordinator"
@@ -167,9 +169,16 @@ let run_full ~sw ~net ~clock ~proc_mgr ~masc_url ~provider
           (List.mapi
              (fun i spec () ->
                let result =
-                 Agent_swarm_swarm.run_agent ~sw ~net ~clock ~masc_url
-                   ~extra_tools:dev_tools spec
-                   ~goal:"Claim and complete available tasks"
+                 try
+                   Agent_swarm_swarm.run_agent ~sw ~net ~clock ~masc_url
+                     ~extra_tools:dev_tools spec
+                     ~goal:"Claim and complete available tasks"
+                 with exn ->
+                   { Agent_swarm_swarm.agent_name = spec.name;
+                     result =
+                       Error
+                         (Printf.sprintf "worker exception: %s"
+                            (Printexc.to_string exn)) }
                in
                results.(i) <- result)
              plan.worker_specs);

--- a/lib/agent_swarm_prompts.ml
+++ b/lib/agent_swarm_prompts.ml
@@ -1,19 +1,37 @@
 (** Role-based system prompt templates for swarm agents.
 
-    Each prompt includes MASC tool usage instructions
-    so the LLM knows how to coordinate with other agents. *)
+    These prompts reflect the current agent_swarm tool wrappers:
+    current_task binding and heartbeat remain explicit, while planner/worker
+    prompts can also use batch_add/claim_next/release/cancel flows. *)
 
 let masc_instructions = {|
 You have access to MASC coordination tools:
-- masc_list_tasks: See available tasks
-- masc_claim_task: Claim a task (provide task_id)
-- masc_set_current_task: Bind the claimed task as current planning task
-- masc_broadcast: Send a message to all agents (provide message)
-- masc_complete_task: Mark a task as done (provide task_id)
-- masc_room_status: Check room status
-- masc_heartbeat: Refresh your liveness in the room
 
-Use these tools to coordinate with other agents in the room.|}
+Task discovery and room state:
+- masc_list_tasks
+- masc_room_status
+
+Task creation and decomposition:
+- masc_add_task
+- masc_batch_add_tasks
+
+Task execution:
+- masc_claim_task
+- masc_claim_next
+- masc_set_current_task
+- masc_complete_task
+- masc_release_task
+- masc_cancel_task
+
+Communication and liveness:
+- masc_broadcast
+- masc_send_direct
+- masc_heartbeat
+
+Important semantics:
+- claiming a task does not bind current_task automatically
+- call masc_set_current_task immediately after claiming
+- send masc_heartbeat during longer work so visibility stays fresh|}
 
 let fleet_leader ~goal ~members =
   Printf.sprintf
@@ -26,9 +44,10 @@ Team members:
 %s
 Coordinate by:
 1. Break the goal into sub-tasks for each member
-2. Use MASC tools (masc_broadcast, masc_list_tasks) to communicate and track progress
+2. Use MASC tools to communicate and track progress
 3. Collect and synthesize results from all members
-4. Report the final consolidated outcome|} goal
+4. Report the final consolidated outcome|}
+    goal
     (String.concat "\n" (List.map (fun m -> "- " ^ m) members))
     masc_instructions
 
@@ -41,10 +60,36 @@ Goal: %s
 Instructions:
 1. Use masc_list_tasks to check existing tasks
 2. If no tasks exist, think about what subtasks are needed
-3. Use masc_broadcast to communicate your plan
-4. Monitor progress via masc_room_status
-5. When all tasks are done, summarize the results
-%s|} goal masc_instructions
+3. Use masc_add_task or masc_batch_add_tasks to register work
+4. Use masc_broadcast to communicate your plan
+5. Monitor progress via masc_room_status
+6. When all tasks are done, summarize the results
+%s|}
+    goal masc_instructions
+
+let fleet_planner ~goal =
+  Printf.sprintf
+{|You are the planning phase of a two-phase fleet run.
+
+Goal: %s
+
+Your only job is to decompose the goal into concrete executable tasks.
+
+Rules:
+1. Inspect the room with masc_room_status or masc_list_tasks first.
+2. Register the task set with masc_batch_add_tasks. Prefer one batch call over many single adds.
+3. Broadcast a short execution plan with masc_broadcast after creating tasks.
+4. Do not use development tools or attempt implementation yourself.
+5. Stop after tasks are registered and announced.
+
+Good task sets are:
+- specific
+- independently claimable
+- small enough for a single worker
+- phrased as actionable task titles with short descriptions
+
+%s|}
+    goal masc_instructions
 
 let dev_instructions = {|
 You also have development tools:
@@ -63,15 +108,40 @@ let worker ~specialization =
 {|You are a worker agent specialized in: %s
 
 Instructions:
-1. Use masc_list_tasks to find available tasks
-2. Use masc_claim_task to claim a task you can handle
-3. Immediately call masc_set_current_task for the claimed task id
-4. Send masc_heartbeat during the task so you remain visible
-5. Work on the task using your available tools
-6. Use masc_broadcast to report progress
-7. Use masc_complete_task when done
+1. Use masc_list_tasks to inspect available work.
+2. Claim a task with masc_claim_task when you know the task_id.
+3. Immediately call masc_set_current_task for the claimed task id.
+4. Send masc_heartbeat during the task so you remain visible.
+5. Work on the task using your available tools.
+6. Use masc_broadcast to report progress.
+7. Use masc_complete_task when done.
+8. Use masc_release_task only if you are blocked and another worker should retry.
+9. Use masc_cancel_task only if the task is invalid and you provide a reason.
+
 %s
-%s|} specialization masc_instructions dev_instructions
+%s|}
+    specialization masc_instructions dev_instructions
+
+let fleet_worker ~name ~workdir =
+  Printf.sprintf
+{|You are fleet worker %s in a planner -> workers execution model.
+
+Working directory: %s
+
+Loop:
+1. Use masc_claim_next to get the next unassigned task.
+2. Read the claimed task id from the tool result and call masc_set_current_task.
+3. Send masc_heartbeat before and during longer edits or commands.
+4. Complete the task with development tools.
+5. Report concise progress with masc_broadcast.
+6. Finish with masc_complete_task.
+7. If the task is impossible or invalid, use masc_release_task or masc_cancel_task with a clear reason instead of silently stopping.
+
+Do not create new tasks. The planner already decomposed the goal.
+
+%s
+%s|}
+    name workdir masc_instructions dev_instructions
 
 let solo_developer ~goal =
   Printf.sprintf
@@ -85,4 +155,5 @@ Work step by step:
 4. Verify with shell_exec (run tests, builds)
 5. Iterate until the goal is achieved
 
-Be precise and verify each step before moving on.|} goal dev_instructions
+Be precise and verify each step before moving on.|}
+    goal dev_instructions

--- a/lib/agent_swarm_runner.ml
+++ b/lib/agent_swarm_runner.ml
@@ -11,6 +11,7 @@ type runner_config = {
   workdir : string;
   max_turns : int;
   fleet_mode : bool;
+  num_members : int;
   masc_url : string;
   verbose : bool;
 }
@@ -21,6 +22,7 @@ let default_config = {
   workdir = ".";
   max_turns = 10;
   fleet_mode = false;
+  num_members = 3;
   masc_url = "http://127.0.0.1:8935";
   verbose = false;
 }
@@ -54,6 +56,10 @@ let parse_args argv =
          | _ -> Error (Printf.sprintf "Invalid --max-turns: %s" argv.(i + 1)))
       | "--fleet" ->
         loop (i + 1) { acc with fleet_mode = true }
+      | "--members" when i + 1 < len ->
+        (match int_of_string_opt argv.(i + 1) with
+         | Some n when n > 0 -> loop (i + 2) { acc with num_members = n }
+         | _ -> Error (Printf.sprintf "Invalid --members: %s" argv.(i + 1)))
       | "--masc-url" when i + 1 < len ->
         loop (i + 2) { acc with masc_url = argv.(i + 1) }
       | "--verbose" | "-v" ->
@@ -94,22 +100,12 @@ let run_solo ~sw ~net ~clock ~proc_mgr config =
 let run_fleet ~sw ~net ~clock ~proc_mgr config =
   let provider_cfg = match resolve_provider config.provider_name with
     | Some p -> p | None -> Provider.local_qwen () in
-  let leader_spec : Agent_swarm_fleet.fleet_member =
-    Agent_swarm_fleet.Sdk_agent {
-      Agent_swarm_swarm.name = "fleet-leader";
-      provider = provider_cfg;
-      system_prompt =
-        Agent_swarm_prompts.worker ~specialization:"autonomous development";
-      tools = [];
-      max_tokens = None;
-      max_turns = config.max_turns;
-      include_masc_tools = true;
-      managed_task = None;
-      expected_final_marker = None;
-    } in
-  let fleet_config : Agent_swarm_fleet.fleet_config = {
-    masc_url = config.masc_url;
-    leader_name = "fleet-runner";
-    members = [(leader_spec, [Agent_swarm_fleet.Code; Agent_swarm_fleet.General])];
-  } in
-  Agent_swarm_fleet.run ~sw ~net ~clock ~proc_mgr fleet_config ~goal:config.goal
+  let workdir = if config.workdir = "." then None else Some config.workdir in
+  Agent_swarm_fleet.run_full ~sw ~net ~clock ~proc_mgr
+    ~masc_url:config.masc_url
+    ~provider:provider_cfg
+    ~goal:config.goal
+    ~num_members:config.num_members
+    ?workdir
+    ~max_turns:config.max_turns
+    ()

--- a/lib/agent_swarm_tool_input.ml
+++ b/lib/agent_swarm_tool_input.ml
@@ -12,6 +12,37 @@ let extract_string key json =
      | None -> Error (Printf.sprintf "missing required field: %s" key))
   | _ -> Error "input must be a JSON object"
 
+let extract_optional_string key json =
+  match json with
+  | `Assoc pairs ->
+    (match List.assoc_opt key pairs with
+     | Some (`String s) -> Ok (Some s)
+     | Some `Null | None -> Ok None
+     | Some _ -> Error (Printf.sprintf "%s must be a string" key))
+  | _ -> Error "input must be a JSON object"
+
+let extract_tasks_array json =
+  match json with
+  | `Assoc pairs ->
+    (match List.assoc_opt "tasks" pairs with
+     | Some (`List items) ->
+       let parse_item item =
+         match extract_string "title" item, extract_string "description" item with
+         | Ok title, Ok description -> Ok (title, description)
+         | Error e, _ | _, Error e -> Error e
+       in
+       let rec collect acc = function
+         | [] -> Ok (List.rev acc)
+         | item :: rest -> (
+             match parse_item item with
+             | Ok pair -> collect (pair :: acc) rest
+             | Error e -> Error e)
+       in
+       collect [] items
+     | Some _ -> Error "tasks must be a JSON array"
+     | None -> Error "missing required field: tasks")
+  | _ -> Error "input must be a JSON object"
+
 let extract_float key json =
   match json with
   | `Assoc pairs ->

--- a/lib/agent_swarm_tool_input.ml
+++ b/lib/agent_swarm_tool_input.ml
@@ -25,6 +25,7 @@ let extract_tasks_array json =
   match json with
   | `Assoc pairs ->
     (match List.assoc_opt "tasks" pairs with
+     | Some (`List []) -> Error "tasks must be a non-empty JSON array"
      | Some (`List items) ->
        let parse_item item =
          match extract_string "title" item, extract_string "description" item with

--- a/lib/agent_swarm_tools.ml
+++ b/lib/agent_swarm_tools.ml
@@ -1,25 +1,76 @@
 (** Wrap MASC client operations as Agent SDK tools.
 
     masc_join/masc_leave are lifecycle functions, not exposed as tools.
-    Agents should not arbitrarily leave the room. *)
+    Agents should not arbitrarily leave the room.
 
-(** Create 5 MASC tools that close over the client and switch. *)
+    The tool surface stays close to current MASC task semantics:
+    - claim and current_task binding are distinct
+    - claim_next/batch_add_tasks enable planner->worker fleet flows
+    - release/cancel are explicit escape hatches for blocked tasks *)
+
 let make_tools (client : Agent_swarm_client.t) ~sw : Agent_sdk.Tool.t list =
   let open Agent_sdk.Tool in
 
   let masc_list_tasks = create
     ~name:"masc_list_tasks"
-    ~description:"List all tasks in the MASC room"
+    ~description:"List all tasks in the MASC room."
     ~parameters:[]
     (fun _input ->
-       match Agent_swarm_client.list_tasks ~sw client with
-       | Ok json -> Ok (Agent_swarm_tool_input.json_to_string json)
-       | Error e -> Error e)
+      match Agent_swarm_client.list_tasks ~sw client with
+      | Ok json -> Ok (Agent_swarm_tool_input.json_to_string json)
+      | Error e -> Error e)
+  in
+
+  let masc_room_status = create
+    ~name:"masc_room_status"
+    ~description:"Get the current MASC room status including agents and tasks."
+    ~parameters:[]
+    (fun _input ->
+      match Agent_swarm_client.status ~sw client with
+      | Ok json -> Ok (Agent_swarm_tool_input.json_to_string json)
+      | Error e -> Error e)
+  in
+
+  let masc_add_task = create
+    ~name:"masc_add_task"
+    ~description:"Create a single new task in the MASC room."
+    ~parameters:[
+      { name = "title"; description = "Task title"; param_type = Agent_sdk.Types.String; required = true };
+      { name = "description"; description = "Task description"; param_type = Agent_sdk.Types.String; required = true };
+    ]
+    (fun input ->
+      match
+        ( Agent_swarm_tool_input.extract_string "title" input,
+          Agent_swarm_tool_input.extract_string "description" input )
+      with
+      | Error e, _ | _, Error e -> Error e
+      | Ok title, Ok description ->
+        (match Agent_swarm_client.add_task ~sw client ~title ~description with
+         | Ok json -> Ok (Agent_swarm_tool_input.json_to_string json)
+         | Error e -> Error e))
+  in
+
+  let masc_batch_add_tasks = create
+    ~name:"masc_batch_add_tasks"
+    ~description:"Create multiple tasks at once for planner-driven decomposition."
+    ~parameters:[
+      { name = "tasks";
+        description = "Array of {title, description} task objects";
+        param_type = Agent_sdk.Types.String;
+        required = true };
+    ]
+    (fun input ->
+      match Agent_swarm_tool_input.extract_tasks_array input with
+      | Error e -> Error e
+      | Ok tasks ->
+        (match Agent_swarm_client.batch_add_tasks ~sw client ~tasks with
+         | Ok json -> Ok (Agent_swarm_tool_input.json_to_string json)
+         | Error e -> Error e))
   in
 
   let masc_claim_task = create
     ~name:"masc_claim_task"
-    ~description:"Claim a task by ID so this agent owns it"
+    ~description:"Claim a specific task by task_id."
     ~parameters:[{
       name = "task_id";
       description = "The task ID to claim";
@@ -27,17 +78,27 @@ let make_tools (client : Agent_swarm_client.t) ~sw : Agent_sdk.Tool.t list =
       required = true;
     }]
     (fun input ->
-       match Agent_swarm_tool_input.extract_string "task_id" input with
-       | Error e -> Error e
-       | Ok task_id ->
-         match Agent_swarm_client.claim ~sw client ~task_id with
+      match Agent_swarm_tool_input.extract_string "task_id" input with
+      | Error e -> Error e
+      | Ok task_id ->
+        (match Agent_swarm_client.claim ~sw client ~task_id with
          | Ok json -> Ok (Agent_swarm_tool_input.json_to_string json)
-         | Error e -> Error e)
+         | Error e -> Error e))
+  in
+
+  let masc_claim_next = create
+    ~name:"masc_claim_next"
+    ~description:"Claim the next available task automatically."
+    ~parameters:[]
+    (fun _input ->
+      match Agent_swarm_client.claim_next ~sw client with
+      | Ok json -> Ok (Agent_swarm_tool_input.json_to_string json)
+      | Error e -> Error e)
   in
 
   let masc_set_current_task = create
     ~name:"masc_set_current_task"
-    ~description:"Bind the current planning task for this agent after claiming it. Use immediately after masc_claim_task."
+    ~description:"Bind the claimed task as current_task after a claim step."
     ~parameters:[{
       name = "task_id";
       description = "The claimed task ID to bind as the current planning task";
@@ -45,35 +106,17 @@ let make_tools (client : Agent_swarm_client.t) ~sw : Agent_sdk.Tool.t list =
       required = true;
     }]
     (fun input ->
-       match Agent_swarm_tool_input.extract_string "task_id" input with
-       | Error e -> Error e
-       | Ok task_id ->
-         match Agent_swarm_client.set_current_task ~sw client ~task_id with
+      match Agent_swarm_tool_input.extract_string "task_id" input with
+      | Error e -> Error e
+      | Ok task_id ->
+        (match Agent_swarm_client.set_current_task ~sw client ~task_id with
          | Ok json -> Ok (Agent_swarm_tool_input.json_to_string json)
-         | Error e -> Error e)
-  in
-
-  let masc_broadcast = create
-    ~name:"masc_broadcast"
-    ~description:"Broadcast a message to all agents in the room"
-    ~parameters:[{
-      name = "message";
-      description = "The message to broadcast";
-      param_type = Agent_sdk.Types.String;
-      required = true;
-    }]
-    (fun input ->
-       match Agent_swarm_tool_input.extract_string "message" input with
-       | Error e -> Error e
-       | Ok message ->
-         match Agent_swarm_client.broadcast ~sw client ~message with
-         | Ok json -> Ok (Agent_swarm_tool_input.json_to_string json)
-         | Error e -> Error e)
+         | Error e -> Error e))
   in
 
   let masc_complete_task = create
     ~name:"masc_complete_task"
-    ~description:"Mark a task as done"
+    ~description:"Mark a task as done after finishing the work."
     ~parameters:[{
       name = "task_id";
       description = "The task ID to mark as completed";
@@ -81,76 +124,111 @@ let make_tools (client : Agent_swarm_client.t) ~sw : Agent_sdk.Tool.t list =
       required = true;
     }]
     (fun input ->
-       match Agent_swarm_tool_input.extract_string "task_id" input with
-       | Error e -> Error e
-       | Ok task_id ->
-         match Agent_swarm_client.done_task ~sw client ~task_id with
+      match Agent_swarm_tool_input.extract_string "task_id" input with
+      | Error e -> Error e
+      | Ok task_id ->
+        (match Agent_swarm_client.done_task ~sw client ~task_id with
          | Ok json -> Ok (Agent_swarm_tool_input.json_to_string json)
-         | Error e -> Error e)
+         | Error e -> Error e))
   in
 
-  let masc_room_status = create
-    ~name:"masc_room_status"
-    ~description:"Get the current MASC room status including agents and tasks"
-    ~parameters:[]
-    (fun _input ->
-       match Agent_swarm_client.status ~sw client with
-       | Ok json -> Ok (Agent_swarm_tool_input.json_to_string json)
-       | Error e -> Error e)
+  let masc_release_task = create
+    ~name:"masc_release_task"
+    ~description:"Release a claimed task back to pending for another worker."
+    ~parameters:[{
+      name = "task_id";
+      description = "The task ID to release";
+      param_type = Agent_sdk.Types.String;
+      required = true;
+    }]
+    (fun input ->
+      match Agent_swarm_tool_input.extract_string "task_id" input with
+      | Error e -> Error e
+      | Ok task_id ->
+        (match Agent_swarm_client.release_task ~sw client ~task_id with
+         | Ok json -> Ok (Agent_swarm_tool_input.json_to_string json)
+         | Error e -> Error e))
   in
 
-  let masc_heartbeat = create
-    ~name:"masc_heartbeat"
-    ~description:"Send an immediate heartbeat to keep this agent fresh in MASC visibility."
-    ~parameters:[]
-    (fun _input ->
-       match Agent_swarm_client.heartbeat ~sw client with
-       | Ok json -> Ok (Agent_swarm_tool_input.json_to_string json)
-       | Error e -> Error e)
-  in
-
-  let masc_add_task = create
-    ~name:"masc_add_task"
-    ~description:"Create a new task in the MASC room"
+  let masc_cancel_task = create
+    ~name:"masc_cancel_task"
+    ~description:"Cancel a task permanently when it should not be retried."
     ~parameters:[
-      { name = "title"; description = "Task title"; param_type = Agent_sdk.Types.String; required = true };
-      { name = "description"; description = "Task description"; param_type = Agent_sdk.Types.String; required = true };
+      { name = "task_id"; description = "The task ID to cancel"; param_type = Agent_sdk.Types.String; required = true };
+      { name = "reason"; description = "Optional cancellation reason"; param_type = Agent_sdk.Types.String; required = false };
     ]
     (fun input ->
-       match Agent_swarm_tool_input.extract_string "title" input,
-             Agent_swarm_tool_input.extract_string "description" input with
-       | Error e, _ | _, Error e -> Error e
-       | Ok title, Ok desc ->
-         match Agent_swarm_client.add_task ~sw client ~title ~description:desc with
+      match
+        ( Agent_swarm_tool_input.extract_string "task_id" input,
+          Agent_swarm_tool_input.extract_optional_string "reason" input )
+      with
+      | Error e, _ | _, Error e -> Error e
+      | Ok task_id, Ok reason ->
+        let reason = Option.value ~default:"" reason in
+        (match Agent_swarm_client.cancel_task ~sw client ~task_id ~reason with
          | Ok json -> Ok (Agent_swarm_tool_input.json_to_string json)
-         | Error e -> Error e)
+         | Error e -> Error e))
+  in
+
+  let masc_broadcast = create
+    ~name:"masc_broadcast"
+    ~description:"Broadcast a message to all agents in the room."
+    ~parameters:[{
+      name = "message";
+      description = "The message to broadcast";
+      param_type = Agent_sdk.Types.String;
+      required = true;
+    }]
+    (fun input ->
+      match Agent_swarm_tool_input.extract_string "message" input with
+      | Error e -> Error e
+      | Ok message ->
+        (match Agent_swarm_client.broadcast ~sw client ~message with
+         | Ok json -> Ok (Agent_swarm_tool_input.json_to_string json)
+         | Error e -> Error e))
   in
 
   let masc_send_direct = create
     ~name:"masc_send_direct"
-    ~description:"Send a direct message to a specific agent by name. Unlike masc_broadcast (room-wide), this is private 1:1 delivery. Use when you need to communicate with a single specific agent rather than all agents."
+    ~description:"Send a direct message to a specific agent by name."
     ~parameters:[
-      { name = "target"; description = "Name of the target agent to send the message to"; param_type = Agent_sdk.Types.String; required = true };
-      { name = "message"; description = "The message content to send"; param_type = Agent_sdk.Types.String; required = true };
+      { name = "target"; description = "Name of the target agent"; param_type = Agent_sdk.Types.String; required = true };
+      { name = "message"; description = "The message content"; param_type = Agent_sdk.Types.String; required = true };
     ]
     (fun input ->
-       match Agent_swarm_tool_input.extract_string "target" input,
-             Agent_swarm_tool_input.extract_string "message" input with
-       | Error e, _ | _, Error e -> Error e
-       | Ok target, Ok message ->
-         match Agent_swarm_client.send_direct ~sw client ~target ~message with
+      match
+        ( Agent_swarm_tool_input.extract_string "target" input,
+          Agent_swarm_tool_input.extract_string "message" input )
+      with
+      | Error e, _ | _, Error e -> Error e
+      | Ok target, Ok message ->
+        (match Agent_swarm_client.send_direct ~sw client ~target ~message with
          | Ok json -> Ok (Agent_swarm_tool_input.json_to_string json)
-         | Error e -> Error e)
+         | Error e -> Error e))
+  in
+
+  let masc_heartbeat = create
+    ~name:"masc_heartbeat"
+    ~description:"Send an immediate heartbeat so this agent stays fresh in MASC visibility."
+    ~parameters:[]
+    (fun _input ->
+      match Agent_swarm_client.heartbeat ~sw client with
+      | Ok json -> Ok (Agent_swarm_tool_input.json_to_string json)
+      | Error e -> Error e)
   in
 
   [
     masc_list_tasks;
-    masc_claim_task;
-    masc_set_current_task;
-    masc_add_task;
-    masc_broadcast;
-    masc_complete_task;
     masc_room_status;
+    masc_add_task;
+    masc_batch_add_tasks;
+    masc_claim_task;
+    masc_claim_next;
+    masc_set_current_task;
+    masc_complete_task;
+    masc_release_task;
+    masc_cancel_task;
+    masc_broadcast;
     masc_send_direct;
     masc_heartbeat;
   ]

--- a/test/test_agent_swarm_fleet.ml
+++ b/test/test_agent_swarm_fleet.ml
@@ -83,6 +83,47 @@ let test_fleet_prompt () =
   Alcotest.(check bool) "has bob" true (has_sub prompt "bob");
   Alcotest.(check bool) "has masc" true (has_sub prompt "masc_")
 
+let test_fleet_planner_prompt () =
+  let prompt = Agent_swarm_prompts.fleet_planner ~goal:"Ship the feature" in
+  Alcotest.(check bool) "has goal" true (has_sub prompt "Ship the feature");
+  Alcotest.(check bool) "uses batch add" true
+    (has_sub prompt "masc_batch_add_tasks");
+  Alcotest.(check bool) "planner no dev tools" true
+    (has_sub prompt "Do not use development tools")
+
+let test_fleet_worker_prompt () =
+  let prompt =
+    Agent_swarm_prompts.fleet_worker ~name:"fleet-worker-1" ~workdir:"/tmp/work"
+  in
+  Alcotest.(check bool) "has worker name" true
+    (has_sub prompt "fleet-worker-1");
+  Alcotest.(check bool) "has workdir" true
+    (has_sub prompt "/tmp/work");
+  Alcotest.(check bool) "uses claim_next" true
+    (has_sub prompt "masc_claim_next");
+  Alcotest.(check bool) "uses set current task" true
+    (has_sub prompt "masc_set_current_task")
+
+let test_run_full_plan () =
+  let provider = Provider.local_qwen () in
+  let plan =
+    Agent_swarm_fleet.build_run_full_plan ~provider ~goal:"Fix the bug"
+      ~num_members:3 ~workdir:"/tmp/work" ~max_turns:7
+  in
+  Alcotest.(check string) "planner name" "fleet-planner"
+    plan.planner_spec.Agent_swarm_swarm.name;
+  Alcotest.(check bool) "planner uses masc tools" true
+    plan.planner_spec.Agent_swarm_swarm.include_masc_tools;
+  Alcotest.(check int) "worker count" 3 (List.length plan.worker_specs);
+  Alcotest.(check string) "first worker" "fleet-worker-1"
+    ((List.hd plan.worker_specs).Agent_swarm_swarm.name);
+  Alcotest.(check bool) "worker prompt carries workdir" true
+    (has_sub (List.hd plan.worker_specs).Agent_swarm_swarm.system_prompt "/tmp/work");
+  Alcotest.(check bool) "worker turn budget" true
+    (List.for_all
+       (fun spec -> spec.Agent_swarm_swarm.max_turns = 7)
+       plan.worker_specs)
+
 let () =
   Alcotest.run "Fleet Unit" [
     "external_agent", [
@@ -100,5 +141,11 @@ let () =
     "prompts", [
       Alcotest.test_case "fleet prompt" `Quick
         test_fleet_prompt;
+      Alcotest.test_case "fleet planner prompt" `Quick
+        test_fleet_planner_prompt;
+      Alcotest.test_case "fleet worker prompt" `Quick
+        test_fleet_worker_prompt;
+      Alcotest.test_case "run_full plan" `Quick
+        test_run_full_plan;
     ];
   ]

--- a/test/test_agent_swarm_fleet.ml
+++ b/test/test_agent_swarm_fleet.ml
@@ -124,6 +124,15 @@ let test_run_full_plan () =
        (fun spec -> spec.Agent_swarm_swarm.max_turns = 7)
        plan.worker_specs)
 
+let test_run_full_plan_rejects_zero_members () =
+  Alcotest.check_raises "zero members rejected"
+    (Invalid_argument "num_members must be positive")
+    (fun () ->
+       ignore
+         (Agent_swarm_fleet.build_run_full_plan ~provider:(Provider.local_qwen ())
+            ~goal:"Fix the bug" ~num_members:0 ~workdir:"/tmp/work"
+            ~max_turns:7))
+
 let () =
   Alcotest.run "Fleet Unit" [
     "external_agent", [
@@ -147,5 +156,7 @@ let () =
         test_fleet_worker_prompt;
       Alcotest.test_case "run_full plan" `Quick
         test_run_full_plan;
+      Alcotest.test_case "run_full plan rejects zero members" `Quick
+        test_run_full_plan_rejects_zero_members;
     ];
   ]

--- a/test/test_agent_swarm_masc_tools.ml
+++ b/test/test_agent_swarm_masc_tools.ml
@@ -116,6 +116,24 @@ let test_batch_add_requires_tasks () =
   | Ok _ ->
     Alcotest.fail "should fail without tasks"
 
+let test_batch_add_rejects_empty_tasks () =
+  Eio_main.run @@ fun env ->
+  let net = Eio.Stdenv.net env in
+  Eio.Switch.run @@ fun sw ->
+  let client =
+    Agent_swarm_client.create ~net ~base_url:"http://127.0.0.1:9999" ~agent_name:"test"
+  in
+  let tools = Agent_swarm_tools.make_tools client ~sw in
+  let batch_tool =
+    List.find (fun (t : Tool.t) -> t.schema.name = "masc_batch_add_tasks") tools
+  in
+  let result = Tool.execute batch_tool (`Assoc [("tasks", `List [])]) in
+  match result with
+  | Error msg ->
+    Alcotest.(check bool) "mentions non-empty" true (has_sub msg "non-empty")
+  | Ok _ ->
+    Alcotest.fail "should fail with empty tasks"
+
 let test_claim_next_no_params () =
   Eio_main.run @@ fun env ->
   let net = Eio.Stdenv.net env in
@@ -199,6 +217,7 @@ let () =
       Alcotest.test_case "claim requires task_id" `Quick test_claim_requires_task_id;
       Alcotest.test_case "add_task requires title" `Quick test_add_task_requires_title;
       Alcotest.test_case "batch_add requires tasks" `Quick test_batch_add_requires_tasks;
+      Alcotest.test_case "batch_add rejects empty tasks" `Quick test_batch_add_rejects_empty_tasks;
       Alcotest.test_case "claim_next no params" `Quick test_claim_next_no_params;
       Alcotest.test_case "set current task requires task_id" `Quick
         test_set_current_task_requires_task_id;

--- a/test/test_agent_swarm_masc_tools.ml
+++ b/test/test_agent_swarm_masc_tools.ml
@@ -4,6 +4,16 @@
 open Agent_sdk
 open Masc_mcp
 
+let has_sub s sub =
+  let sn = String.length s and subn = String.length sub in
+  if subn > sn then false
+  else
+    let found = ref false in
+    for i = 0 to sn - subn do
+      if (not !found) && String.sub s i subn = sub then found := true
+    done;
+    !found
+
 let test_tool_count () =
   Eio_main.run @@ fun env ->
   let net = Eio.Stdenv.net env in
@@ -12,7 +22,7 @@ let test_tool_count () =
     Agent_swarm_client.create ~net ~base_url:"http://127.0.0.1:9999" ~agent_name:"test"
   in
   let tools = Agent_swarm_tools.make_tools client ~sw in
-  Alcotest.(check int) "9 MASC tools" 9 (List.length tools)
+  Alcotest.(check int) "13 MASC tools" 13 (List.length tools)
 
 let test_tool_names () =
   Eio_main.run @@ fun env ->
@@ -23,9 +33,14 @@ let test_tool_names () =
   in
   let tools = Agent_swarm_tools.make_tools client ~sw in
   let names = List.map (fun (t : Tool.t) -> t.schema.name) tools in
-  let expected = ["masc_list_tasks"; "masc_claim_task"; "masc_set_current_task";
-                  "masc_add_task"; "masc_broadcast"; "masc_complete_task";
-                  "masc_room_status"; "masc_send_direct"; "masc_heartbeat"] in
+  let expected = [
+    "masc_list_tasks"; "masc_room_status";
+    "masc_add_task"; "masc_batch_add_tasks";
+    "masc_claim_task"; "masc_claim_next";
+    "masc_set_current_task"; "masc_complete_task";
+    "masc_release_task"; "masc_cancel_task";
+    "masc_broadcast"; "masc_send_direct"; "masc_heartbeat"
+  ] in
   Alcotest.(check (list string)) "tool names match" expected names
 
 let test_tool_schema_json () =
@@ -83,6 +98,44 @@ let test_add_task_requires_title () =
   | Ok _ ->
     Alcotest.fail "should fail without title"
 
+let test_batch_add_requires_tasks () =
+  Eio_main.run @@ fun env ->
+  let net = Eio.Stdenv.net env in
+  Eio.Switch.run @@ fun sw ->
+  let client =
+    Agent_swarm_client.create ~net ~base_url:"http://127.0.0.1:9999" ~agent_name:"test"
+  in
+  let tools = Agent_swarm_tools.make_tools client ~sw in
+  let batch_tool =
+    List.find (fun (t : Tool.t) -> t.schema.name = "masc_batch_add_tasks") tools
+  in
+  let result = Tool.execute batch_tool (`Assoc []) in
+  match result with
+  | Error msg ->
+    Alcotest.(check bool) "mentions tasks" true (has_sub msg "tasks")
+  | Ok _ ->
+    Alcotest.fail "should fail without tasks"
+
+let test_claim_next_no_params () =
+  Eio_main.run @@ fun env ->
+  let net = Eio.Stdenv.net env in
+  Eio.Switch.run @@ fun sw ->
+  let client =
+    Agent_swarm_client.create ~net ~base_url:"http://127.0.0.1:9999" ~agent_name:"test"
+  in
+  let tools = Agent_swarm_tools.make_tools client ~sw in
+  let claim_next_tool =
+    List.find (fun (t : Tool.t) -> t.schema.name = "masc_claim_next") tools
+  in
+  let result = Tool.execute claim_next_tool (`Assoc []) in
+  match result with
+  | Error msg ->
+    Alcotest.(check bool) "non-empty rpc error" true (String.length msg > 0);
+    Alcotest.(check bool) "not validation failure" false
+      (has_sub msg "missing required field")
+  | Ok _ ->
+    Alcotest.fail "should fail because no live server is available"
+
 let test_set_current_task_requires_task_id () =
   Eio_main.run @@ fun env ->
   let net = Eio.Stdenv.net env in
@@ -101,6 +154,42 @@ let test_set_current_task_requires_task_id () =
   | Ok _ ->
     Alcotest.fail "should fail without task_id"
 
+let test_release_requires_task_id () =
+  Eio_main.run @@ fun env ->
+  let net = Eio.Stdenv.net env in
+  Eio.Switch.run @@ fun sw ->
+  let client =
+    Agent_swarm_client.create ~net ~base_url:"http://127.0.0.1:9999" ~agent_name:"test"
+  in
+  let tools = Agent_swarm_tools.make_tools client ~sw in
+  let release_tool =
+    List.find (fun (t : Tool.t) -> t.schema.name = "masc_release_task") tools
+  in
+  let result = Tool.execute release_tool (`Assoc []) in
+  match result with
+  | Error msg ->
+    Alcotest.(check bool) "mentions task_id" true (has_sub msg "task_id")
+  | Ok _ ->
+    Alcotest.fail "should fail without task_id"
+
+let test_cancel_requires_task_id () =
+  Eio_main.run @@ fun env ->
+  let net = Eio.Stdenv.net env in
+  Eio.Switch.run @@ fun sw ->
+  let client =
+    Agent_swarm_client.create ~net ~base_url:"http://127.0.0.1:9999" ~agent_name:"test"
+  in
+  let tools = Agent_swarm_tools.make_tools client ~sw in
+  let cancel_tool =
+    List.find (fun (t : Tool.t) -> t.schema.name = "masc_cancel_task") tools
+  in
+  let result = Tool.execute cancel_tool (`Assoc []) in
+  match result with
+  | Error msg ->
+    Alcotest.(check bool) "mentions task_id" true (has_sub msg "task_id")
+  | Ok _ ->
+    Alcotest.fail "should fail without task_id"
+
 let () =
   Alcotest.run "MASC Tools" [
     "structure", [
@@ -109,7 +198,11 @@ let () =
       Alcotest.test_case "schema JSON" `Quick test_tool_schema_json;
       Alcotest.test_case "claim requires task_id" `Quick test_claim_requires_task_id;
       Alcotest.test_case "add_task requires title" `Quick test_add_task_requires_title;
+      Alcotest.test_case "batch_add requires tasks" `Quick test_batch_add_requires_tasks;
+      Alcotest.test_case "claim_next no params" `Quick test_claim_next_no_params;
       Alcotest.test_case "set current task requires task_id" `Quick
         test_set_current_task_requires_task_id;
+      Alcotest.test_case "release requires task_id" `Quick test_release_requires_task_id;
+      Alcotest.test_case "cancel requires task_id" `Quick test_cancel_requires_task_id;
     ];
   ]

--- a/test/test_agent_swarm_runner.ml
+++ b/test/test_agent_swarm_runner.ml
@@ -11,15 +11,16 @@ let runner_config_testable : runner_config Alcotest.testable =
     (fun fmt c ->
       Format.fprintf fmt
         "{goal=%S; provider=%S; workdir=%S; max_turns=%d; \
-         fleet=%b; masc_url=%S; verbose=%b}"
+         fleet=%b; members=%d; masc_url=%S; verbose=%b}"
         c.goal c.provider_name c.workdir c.max_turns
-        c.fleet_mode c.masc_url c.verbose)
+        c.fleet_mode c.num_members c.masc_url c.verbose)
     (fun a b ->
       a.goal = b.goal
       && a.provider_name = b.provider_name
       && a.workdir = b.workdir
       && a.max_turns = b.max_turns
       && a.fleet_mode = b.fleet_mode
+      && a.num_members = b.num_members
       && a.masc_url = b.masc_url
       && a.verbose = b.verbose)
 
@@ -49,6 +50,7 @@ let test_parse_full () =
     workdir = "/tmp/work";
     max_turns = 5;
     fleet_mode = true;
+    num_members = 3;
     masc_url = "http://example.com:9000";
     verbose = true;
   } in
@@ -66,6 +68,26 @@ let test_parse_invalid_max_turns () =
   Alcotest.check result_config "invalid max-turns"
     (Error "Invalid --max-turns: abc")
     (parse_args argv)
+
+let test_parse_members () =
+  let argv = [| "fleet_runner"; "--goal"; "test"; "--fleet"; "--members"; "5" |] in
+  let expected = { default_config with
+    goal = "test";
+    fleet_mode = true;
+    num_members = 5;
+  } in
+  Alcotest.check result_config "members parse"
+    (Ok expected) (parse_args argv)
+
+let test_parse_members_invalid () =
+  let argv = [| "fleet_runner"; "--goal"; "test"; "--members"; "abc" |] in
+  Alcotest.check result_config "invalid members"
+    (Error "Invalid --members: abc") (parse_args argv)
+
+let test_parse_members_zero () =
+  let argv = [| "fleet_runner"; "--goal"; "test"; "--members"; "0" |] in
+  Alcotest.check result_config "zero members"
+    (Error "Invalid --members: 0") (parse_args argv)
 
 let test_provider_resolve () =
   let known = ["local-qwen"; "local-mlx"; "sonnet"; "haiku"; "opus"] in
@@ -87,6 +109,9 @@ let () =
       Alcotest.test_case "full" `Quick test_parse_full;
       Alcotest.test_case "missing goal" `Quick test_parse_missing_goal;
       Alcotest.test_case "invalid max-turns" `Quick test_parse_invalid_max_turns;
+      Alcotest.test_case "members" `Quick test_parse_members;
+      Alcotest.test_case "invalid members" `Quick test_parse_members_invalid;
+      Alcotest.test_case "zero members" `Quick test_parse_members_zero;
     ];
     "resolve_provider", [
       Alcotest.test_case "known providers" `Quick test_provider_resolve;


### PR DESCRIPTION
## Summary
- add agent swarm planner -> workers fleet mode to the main masc-mcp path
- add runner `--members` support and expand MASC tool wrappers for planner/worker workflows
- document fleet planning mode alongside the existing hot-swarm proof flow

## Testing
- dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/extract-fleet-members
- ./_build/default/test/test_agent_swarm_runner.exe
- ./_build/default/test/test_agent_swarm_masc_tools.exe
- ./_build/default/test/test_agent_swarm_fleet.exe
- ./_build/default/test/test_agent_swarm_live_harness.exe
