### PR TITLE
fix(operator): stop timing out on recent message snapshots

### DIFF
--- a/lib/room.ml
+++ b/lib/room.ml
@@ -1738,51 +1738,45 @@ let extract_seq_from_filename name =
   | None -> 0
   | Some idx -> Safe_ops.int_of_string_with_default ~default:0 (String.sub name 0 idx)
 
+(** Read most-recent messages without parsing the entire history directory. *)
+let collect_recent_messages config ~msgs_path ~since_seq ~limit ~warn_label =
+  let names =
+    Sys.readdir msgs_path
+    |> Array.to_list
+    |> List.filter is_valid_filename
+    |> List.sort (fun a b -> compare (extract_seq_from_filename b) (extract_seq_from_filename a))
+  in
+  let rec loop remaining acc = function
+    | _ when remaining <= 0 -> List.rev acc
+    | [] -> List.rev acc
+    | name :: rest ->
+        if extract_seq_from_filename name <= since_seq then List.rev acc
+        else
+          let path = Filename.concat msgs_path name in
+          match read_json config path with
+          | json ->
+              (match message_of_yojson json with
+               | Ok msg when msg.seq > since_seq -> loop (remaining - 1) (msg :: acc) rest
+               | _ -> loop remaining acc rest)
+          | exception e ->
+              Eio.traceln "[WARN] Failed to read %s %s: %s" warn_label name (Printexc.to_string e);
+              loop remaining acc rest
+  in
+  loop limit [] names
+
 (** Get raw message list (for dashboard) *)
 let get_messages_raw config ~since_seq ~limit =
   ensure_initialized config;
   let msgs_path = messages_dir_in_room config (current_room_id config) in
   if not (Sys.file_exists msgs_path) then []
-  else
-    Sys.readdir msgs_path
-    |> Array.to_list
-    |> List.filter is_valid_filename  (* Skip files with invalid chars *)
-    |> List.sort (fun a b -> compare (extract_seq_from_filename b) (extract_seq_from_filename a))
-    |> List.filter_map (fun name ->
-        let path = Filename.concat msgs_path name in
-        match read_json config path with
-        | json ->
-          (match message_of_yojson json with
-           | Ok msg when msg.seq > since_seq -> Some msg
-           | _ -> None)
-        | exception e ->
-          Eio.traceln "[WARN] Failed to read message %s: %s" name (Printexc.to_string e);
-          None
-      )
-    |> (fun msgs -> List.filteri (fun i _ -> i < limit) msgs)
+  else collect_recent_messages config ~msgs_path ~since_seq ~limit ~warn_label:"message"
 
 let get_messages_raw_in_room config ~room_id ~since_seq ~limit =
   if not (root_is_initialized config) then []
   else
     let msgs_path = messages_dir_in_room config room_id in
     if not (Sys.file_exists msgs_path) then []
-    else
-      Sys.readdir msgs_path
-      |> Array.to_list
-      |> List.filter is_valid_filename
-      |> List.sort (fun a b -> compare (extract_seq_from_filename b) (extract_seq_from_filename a))
-      |> List.filter_map (fun name ->
-          let path = Filename.concat msgs_path name in
-          match read_json config path with
-          | json ->
-            (match message_of_yojson json with
-             | Ok msg when msg.seq > since_seq -> Some msg
-             | _ -> None)
-          | exception e ->
-            Eio.traceln "[WARN] Failed to read room message %s: %s" name (Printexc.to_string e);
-            None
-        )
-      |> (fun msgs -> List.filteri (fun i _ -> i < limit) msgs)
+    else collect_recent_messages config ~msgs_path ~since_seq ~limit ~warn_label:"room message"
 
 (** List tasks *)
 let list_tasks ?(include_done = false) ?(include_cancelled = false) ?status config =

--- a/test/dune
+++ b/test/dune
@@ -188,6 +188,12 @@
  (modules test_common)
  (libraries masc_mcp alcotest))
 
+; Room raw message ordering/limit regression tests
+(test
+ (name test_room_messages_raw)
+ (modules test_room_messages_raw)
+ (libraries masc_mcp alcotest unix))
+
 ; TRPG engine state machine tests
 (test
  (name test_trpg_engine_state_machine)

--- a/test/test_room_messages_raw.ml
+++ b/test/test_room_messages_raw.ml
@@ -1,0 +1,56 @@
+open Masc_mcp
+
+let with_test_env f =
+  let tmp_dir = Filename.concat (Filename.get_temp_dir_name ())
+    (Printf.sprintf "masc_room_messages_%d_%d" (Unix.getpid ())
+       (int_of_float (Unix.gettimeofday () *. 1000.))) in
+  Unix.mkdir tmp_dir 0o755;
+  let config = Room.default_config tmp_dir in
+  let _ = Room.init config ~agent_name:(Some "claude") in
+  try
+    f config;
+    let _ = Room.reset config in
+    Unix.rmdir tmp_dir
+  with e ->
+    let _ = Room.reset config in
+    Unix.rmdir tmp_dir;
+    raise e
+
+let test_get_messages_raw_limit_and_order () =
+  with_test_env (fun config ->
+    let _ = Room.broadcast config ~from_agent:"claude" ~content:"Message 1" in
+    let _ = Room.broadcast config ~from_agent:"claude" ~content:"Message 2" in
+    let _ = Room.broadcast config ~from_agent:"claude" ~content:"Message 3" in
+    let msgs = Room.get_messages_raw config ~since_seq:0 ~limit:2 in
+    let contents = List.map (fun (msg : Types.message) -> msg.content) msgs in
+    Alcotest.(check int) "limit respected" 2 (List.length msgs);
+    Alcotest.(check (list string)) "newest messages first"
+      ["Message 3"; "Message 2"] contents
+  )
+
+let test_get_messages_raw_since_seq_stops_early () =
+  with_test_env (fun config ->
+    let _ = Room.broadcast config ~from_agent:"claude" ~content:"Message 1" in
+    let _ = Room.broadcast config ~from_agent:"claude" ~content:"Message 2" in
+    let _ = Room.broadcast config ~from_agent:"claude" ~content:"Message 3" in
+    let baseline = Room.get_messages_raw config ~since_seq:0 ~limit:10 in
+    let cutoff_seq =
+      match baseline with
+      | _latest :: second :: _ -> second.seq
+      | _ -> Alcotest.fail "expected at least two messages in baseline"
+    in
+    let msgs = Room.get_messages_raw config ~since_seq:cutoff_seq ~limit:10 in
+    let contents = List.map (fun (msg : Types.message) -> msg.content) msgs in
+    Alcotest.(check (list string)) "only newer than since_seq"
+      ["Message 3"] contents
+  )
+
+let () =
+  Alcotest.run "Room raw message regression" [
+    ("messages_raw", [
+      Alcotest.test_case "limit and newest-first ordering" `Quick
+        test_get_messages_raw_limit_and_order;
+      Alcotest.test_case "since_seq filters older history" `Quick
+        test_get_messages_raw_since_seq_stops_early;
+    ]);
+  ]


### PR DESCRIPTION
## Summary
- avoid reading/parsing the full message history when building recent message snapshots
- stop after collecting the requested number of recent messages or reaching `since_seq`
- add a focused regression test for ordering and `since_seq` semantics

## Validation
- `dune build --root . test/test_room_messages_raw.exe`
- `./_build/default/test/test_room_messages_raw.exe`
- reproduced that current main `/api/v1/operator?include_keepers=0&include_sessions=0` still times out, then isolated the bottleneck to `recent_messages`
