### PR TITLE
feat(swarm-risc): Phase 4 Speculative Execution + MCTS

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -310,7 +310,10 @@
    cache_coherence
    ;; SWARM-RISC Phase 3: OoO (Tomasulo) + Work-Stealing
    reservation_station
-   work_stealing)
+   work_stealing
+   ;; SWARM-RISC Phase 4: Speculative Execution + MCTS
+   mcts_tree
+   speculative_engine)
  (libraries
    yojson
    base64

--- a/lib/masc_mcp.ml
+++ b/lib/masc_mcp.ml
@@ -312,3 +312,7 @@ module Cache_coherence = Cache_coherence
 (* SWARM-RISC Phase 3: OoO + Work-Stealing *)
 module Reservation_station = Reservation_station
 module Work_stealing = Work_stealing
+
+(* SWARM-RISC Phase 4: Speculative Execution + MCTS *)
+module Mcts_tree = Mcts_tree
+module Speculative_engine = Speculative_engine

--- a/lib/mcts_tree.ml
+++ b/lib/mcts_tree.ml
@@ -1,0 +1,407 @@
+(** MCTS Tree — Monte Carlo Tree Search for speculative execution paths.
+
+    Implements UCB1-based tree search (Kocsis & Szepesvári, 2006) adapted
+    for agent task-path selection.  Each node represents a decision point
+    (BRANCH instruction), edges are candidate approaches, and leaf values
+    come from fast-LLM simulation + verifier verdict.
+
+    Key adaptation from game-playing MCTS:
+    - No adversarial opponent → single-player optimisation
+    - Simulation = fast LLM call (not random rollout)
+    - Reward = verifier verdict (PASS=1.0, WARN=0.5, FAIL=0.0)
+    - Persistent tree across task executions (learning transfers)
+
+    @since 2.80.0 *)
+
+(* ================================================================ *)
+(* Types                                                            *)
+(* ================================================================ *)
+
+(** Unique identifier for tree nodes. *)
+type node_id = string
+
+(** Verifier verdict mapped to numeric reward. *)
+type verdict_reward =
+  | Pass    (** 1.0 *)
+  | Warn    (** 0.5 *)
+  | Fail    (** 0.0 *)
+
+let reward_of_verdict = function
+  | Pass -> 1.0
+  | Warn -> 0.5
+  | Fail -> 0.0
+
+let verdict_of_float f =
+  if f >= 0.9 then Pass
+  else if f >= 0.4 then Warn
+  else Fail
+
+let verdict_to_string = function
+  | Pass -> "PASS" | Warn -> "WARN" | Fail -> "FAIL"
+
+let verdict_to_yojson v = `String (verdict_to_string v)
+
+let verdict_of_yojson = function
+  | `String "PASS" -> Ok Pass
+  | `String "WARN" -> Ok Warn
+  | `String "FAIL" -> Ok Fail
+  | _ -> Error "verdict_reward: expected PASS, WARN, or FAIL"
+
+(** Simulation result from a fast LLM call. *)
+type simulation_result = {
+  output : string;           (** Raw LLM output *)
+  verdict : verdict_reward;  (** Verifier assessment *)
+  latency_ms : float;        (** Round-trip time *)
+  model_used : string;       (** Which fast model was used *)
+}
+
+let simulation_result_to_yojson s =
+  `Assoc [
+    ("output", `String s.output);
+    ("verdict", verdict_to_yojson s.verdict);
+    ("latency_ms", `Float s.latency_ms);
+    ("model_used", `String s.model_used);
+  ]
+
+(** A node in the MCTS tree.
+
+    Invariants:
+    - [visit_count >= 0]
+    - [total_reward >= 0.0]
+    - If [visit_count = 0] then [total_reward = 0.0] (unexplored)
+    - [children] can be empty (leaf or unexpanded) *)
+type node = {
+  id : node_id;
+  label : string;               (** Human-readable description of this path *)
+  parent_id : node_id option;   (** None for root *)
+  mutable children : node list;
+  mutable visit_count : int;
+  mutable total_reward : float;
+  mutable last_simulation : simulation_result option;
+  created_at : float;
+}
+
+(** The MCTS tree container with configuration and metrics. *)
+type t = {
+  root : node;
+  mutable node_count : int;
+  exploration_constant : float;  (** C in UCB1, default sqrt(2) *)
+  (* Metrics *)
+  mutable total_simulations : int;
+  mutable total_selections : int;
+  mutable total_expansions : int;
+  mutable total_backpropagations : int;
+}
+
+(* ================================================================ *)
+(* Construction                                                     *)
+(* ================================================================ *)
+
+let _node_counter = ref 0
+
+let gen_node_id () =
+  let n = !_node_counter in
+  _node_counter := n + 1;
+  Printf.sprintf "mcts-%d-%d"
+    (int_of_float (Time_compat.now () *. 1000.0)) n
+
+let make_node ?(parent_id = None) label =
+  {
+    id = gen_node_id ();
+    label;
+    parent_id;
+    children = [];
+    visit_count = 0;
+    total_reward = 0.0;
+    last_simulation = None;
+    created_at = Time_compat.now ();
+  }
+
+let create ?(exploration_constant = sqrt 2.0) ~root_label () =
+  let root = make_node root_label in
+  {
+    root;
+    node_count = 1;
+    exploration_constant;
+    total_simulations = 0;
+    total_selections = 0;
+    total_expansions = 0;
+    total_backpropagations = 0;
+  }
+
+(* ================================================================ *)
+(* Tree Navigation                                                  *)
+(* ================================================================ *)
+
+(** Find a node by ID via DFS. Returns None if not found. *)
+let find_node t node_id =
+  let rec dfs node =
+    if node.id = node_id then Some node
+    else List.fold_left (fun acc child ->
+      match acc with
+      | Some _ -> acc
+      | None -> dfs child
+    ) None node.children
+  in
+  dfs t.root
+
+(** Collect all leaf nodes (nodes with no children). *)
+let leaves t =
+  let rec collect acc node =
+    if node.children = [] then node :: acc
+    else List.fold_left collect acc node.children
+  in
+  collect [] t.root
+
+(** Depth of a node (root = 0). *)
+let depth t node_id =
+  let rec trace id d =
+    match find_node t id with
+    | None -> d
+    | Some n ->
+      match n.parent_id with
+      | None -> d
+      | Some pid -> trace pid (d + 1)
+  in
+  trace node_id 0
+
+(* ================================================================ *)
+(* UCB1 Selection                                                   *)
+(* ================================================================ *)
+
+(** UCB1 score for a child node given parent visit count.
+
+    UCB1(n) = Q(n)/N(n) + C * sqrt(ln(N_parent) / N(n))
+
+    Unvisited nodes get +infinity to ensure they are tried first. *)
+let ucb1 ~exploration_constant ~parent_visits child =
+  if child.visit_count = 0 then infinity
+  else
+    let exploitation =
+      child.total_reward /. float_of_int child.visit_count
+    in
+    let exploration =
+      exploration_constant
+      *. sqrt (log (float_of_int parent_visits)
+               /. float_of_int child.visit_count)
+    in
+    exploitation +. exploration
+
+(** Select the best child of a node using UCB1.
+
+    Returns None if the node has no children.
+    When multiple children have equal UCB1 scores (e.g., all unvisited),
+    the first one is chosen deterministically for reproducibility. *)
+let select_child t node =
+  match node.children with
+  | [] -> None
+  | children ->
+    t.total_selections <- t.total_selections + 1;
+    let parent_visits = max 1 node.visit_count in
+    let scored = List.map (fun c ->
+      (c, ucb1 ~exploration_constant:t.exploration_constant
+              ~parent_visits c)
+    ) children in
+    let best = List.fold_left (fun (best_node, best_score) (n, s) ->
+      if s > best_score then (n, s) else (best_node, best_score)
+    ) (List.hd children, neg_infinity) scored in
+    Some (fst best)
+
+(** Select a path from root to a leaf using UCB1 at each level.
+
+    This is the "Selection" phase of MCTS: repeatedly pick the
+    best child until reaching a leaf or unexpanded node. *)
+let select_path t =
+  let rec descend node path =
+    match select_child t node with
+    | None -> List.rev (node :: path)
+    | Some child -> descend child (node :: path)
+  in
+  descend t.root []
+
+(* ================================================================ *)
+(* Expansion                                                        *)
+(* ================================================================ *)
+
+(** Expand a node by adding candidate children.
+
+    Each label represents a candidate approach for the task.
+    Returns the list of newly created child nodes. *)
+let expand t parent_id ~labels =
+  match find_node t parent_id with
+  | None -> Error (Printf.sprintf "Node %s not found" parent_id)
+  | Some parent ->
+    if parent.children <> [] then
+      Error (Printf.sprintf "Node %s already expanded" parent_id)
+    else begin
+      let children = List.map (fun label ->
+        make_node ~parent_id:(Some parent_id) label
+      ) labels in
+      parent.children <- children;
+      let n = List.length children in
+      t.node_count <- t.node_count + n;
+      t.total_expansions <- t.total_expansions + 1;
+      Ok children
+    end
+
+(** Add a single child to an existing node.  Unlike [expand], this
+    does not require the parent to be childless — useful for
+    incremental expansion (progressive widening). *)
+let add_child t parent_id ~label =
+  match find_node t parent_id with
+  | None -> Error (Printf.sprintf "Node %s not found" parent_id)
+  | Some parent ->
+    let child = make_node ~parent_id:(Some parent_id) label in
+    parent.children <- child :: parent.children;
+    t.node_count <- t.node_count + 1;
+    Ok child
+
+(* ================================================================ *)
+(* Simulation Recording                                             *)
+(* ================================================================ *)
+
+(** Record a simulation result on a leaf node.
+
+    This is the "Simulation" phase: the actual fast-LLM call happens
+    externally, and we record its result here.  The verdict is
+    converted to a numeric reward for backpropagation. *)
+let record_simulation t node_id result =
+  match find_node t node_id with
+  | None -> Error (Printf.sprintf "Node %s not found" node_id)
+  | Some node ->
+    node.last_simulation <- Some result;
+    t.total_simulations <- t.total_simulations + 1;
+    Ok (reward_of_verdict result.verdict)
+
+(* ================================================================ *)
+(* Backpropagation                                                  *)
+(* ================================================================ *)
+
+(** Backpropagate a reward from a leaf up to the root.
+
+    Each ancestor node's visit_count and total_reward are updated.
+    This is what makes UCB1 converge: good paths accumulate
+    higher average reward, so they get selected more often. *)
+let backpropagate t node_id reward =
+  let rec propagate id =
+    match find_node t id with
+    | None -> ()
+    | Some node ->
+      node.visit_count <- node.visit_count + 1;
+      node.total_reward <- node.total_reward +. reward;
+      t.total_backpropagations <- t.total_backpropagations + 1;
+      match node.parent_id with
+      | None -> ()
+      | Some pid -> propagate pid
+  in
+  propagate node_id
+
+(* ================================================================ *)
+(* Best Path Extraction                                             *)
+(* ================================================================ *)
+
+(** Select the best child by average reward (exploitation only).
+
+    Used after all simulations are done to pick the final answer.
+    Unlike UCB1 selection during search, this ignores exploration. *)
+let best_child_by_reward node =
+  match node.children with
+  | [] -> None
+  | children ->
+    let best = List.fold_left (fun best c ->
+      let avg = if c.visit_count = 0 then 0.0
+        else c.total_reward /. float_of_int c.visit_count in
+      let best_avg = if (fst best).visit_count = 0 then 0.0
+        else (fst best).total_reward /. float_of_int (fst best).visit_count in
+      if avg > best_avg then (c, avg) else best
+    ) (List.hd children, 0.0) children in
+    Some (fst best)
+
+(** Extract the best path from root to leaf by following highest
+    average-reward children at each level. *)
+let best_path t =
+  let rec descend node acc =
+    match best_child_by_reward node with
+    | None -> List.rev (node :: acc)
+    | Some child -> descend child (node :: acc)
+  in
+  descend t.root []
+
+(* ================================================================ *)
+(* Pruning                                                          *)
+(* ================================================================ *)
+
+(** Prune children of a node whose average reward is below threshold.
+
+    Returns the number of pruned subtrees.  Useful for focusing
+    the tree after initial exploration. *)
+let prune t parent_id ~min_avg_reward =
+  match find_node t parent_id with
+  | None -> Error (Printf.sprintf "Node %s not found" parent_id)
+  | Some parent ->
+    let rec count_subtree node =
+      1 + List.fold_left (fun acc c -> acc + count_subtree c) 0 node.children
+    in
+    let kept, pruned_count = List.fold_left (fun (kept, pruned) child ->
+      let avg = if child.visit_count = 0 then 0.0
+        else child.total_reward /. float_of_int child.visit_count in
+      if avg >= min_avg_reward then (child :: kept, pruned)
+      else (kept, pruned + count_subtree child)
+    ) ([], 0) parent.children in
+    parent.children <- List.rev kept;
+    t.node_count <- t.node_count - pruned_count;
+    Ok pruned_count
+
+(* ================================================================ *)
+(* Serialization                                                    *)
+(* ================================================================ *)
+
+let rec node_to_yojson node =
+  let avg_reward =
+    if node.visit_count = 0 then 0.0
+    else node.total_reward /. float_of_int node.visit_count
+  in
+  `Assoc [
+    ("id", `String node.id);
+    ("label", `String node.label);
+    ("parent_id", match node.parent_id with
+      | None -> `Null | Some p -> `String p);
+    ("visit_count", `Int node.visit_count);
+    ("total_reward", `Float node.total_reward);
+    ("avg_reward", `Float avg_reward);
+    ("last_simulation", match node.last_simulation with
+      | None -> `Null | Some s -> simulation_result_to_yojson s);
+    ("children_count", `Int (List.length node.children));
+    ("children", `List (List.map node_to_yojson node.children));
+  ]
+
+let to_yojson t =
+  `Assoc [
+    ("root", node_to_yojson t.root);
+    ("node_count", `Int t.node_count);
+    ("exploration_constant", `Float t.exploration_constant);
+    ("metrics", `Assoc [
+      ("total_simulations", `Int t.total_simulations);
+      ("total_selections", `Int t.total_selections);
+      ("total_expansions", `Int t.total_expansions);
+      ("total_backpropagations", `Int t.total_backpropagations);
+    ]);
+  ]
+
+(** Compact summary (no recursive children) for dashboard/status. *)
+let summary_to_yojson t =
+  let best = best_path t in
+  let best_labels = List.map (fun n -> `String n.label) best in
+  let leaf_count = List.length (leaves t) in
+  `Assoc [
+    ("node_count", `Int t.node_count);
+    ("leaf_count", `Int leaf_count);
+    ("exploration_constant", `Float t.exploration_constant);
+    ("best_path", `List best_labels);
+    ("root_visits", `Int t.root.visit_count);
+    ("root_avg_reward",
+      `Float (if t.root.visit_count = 0 then 0.0
+              else t.root.total_reward /. float_of_int t.root.visit_count));
+    ("simulations", `Int t.total_simulations);
+    ("selections", `Int t.total_selections);
+  ]

--- a/lib/speculative_engine.ml
+++ b/lib/speculative_engine.ml
@@ -1,0 +1,598 @@
+(** Speculative Engine — Fast/Slow LLM pairing with MCTS-guided path selection.
+
+    Coordinates speculative execution: multiple candidate approaches are
+    evaluated with a fast (cheap) LLM, scored by the verifier, and the best
+    path is committed using the slow (expensive) LLM.
+
+    Architecture (from ICLR 2026 "Speculative Actions"):
+    1. BRANCH — create MCTS branch point with N candidates
+    2. SPEC   — fast LLM evaluates each candidate (simulation)
+    3. VERIFY — verifier scores each simulation result
+    4. COMMIT — best path accepted, slow LLM executes
+    5. ABORT  — discard speculative results, rollback
+
+    Semantic Guard checks (3 criteria):
+    - Intent alignment: does output match original query's purpose?
+    - Format compliance: does output match expected schema/format?
+    - Side-effect safety: no new side-effects beyond original path?
+
+    @since 2.80.0 *)
+
+open Printf
+
+(* ================================================================ *)
+(* Types                                                            *)
+(* ================================================================ *)
+
+(** A candidate approach for speculative evaluation. *)
+type candidate = {
+  label : string;           (** Human-readable description *)
+  prompt : string;          (** Prompt to send to fast LLM *)
+  metadata : Yojson.Safe.t; (** Arbitrary metadata for tracking *)
+}
+
+(** Result of a single speculative simulation. *)
+type simulation_outcome = {
+  candidate_label : string;
+  fast_response : string;       (** Raw fast LLM output *)
+  verdict : Mcts_tree.verdict_reward;
+  verdict_reason : string;
+  latency_ms : int;
+  cost_estimate : float;        (** Estimated cost in USD *)
+}
+
+(** Semantic guard check result. *)
+type guard_result = {
+  intent_aligned : bool;
+  format_compliant : bool;
+  side_effect_safe : bool;
+  reason : string;
+}
+
+(** Speculation state machine. *)
+type spec_state =
+  | Idle
+  | Branching       (** Creating MCTS branch point *)
+  | Simulating      (** Running fast LLM on candidates *)
+  | Verifying       (** Verifier scoring results *)
+  | Ready_to_commit (** Best path selected, awaiting commit *)
+  | Committed       (** Accepted and applied *)
+  | Aborted of string (** Discarded with reason *)
+
+(** A speculative execution session. *)
+type spec_session = {
+  spec_id : string;
+  goal : string;
+  original_query : string;
+  candidates : candidate list;
+  outcomes : simulation_outcome list;
+  best_candidate : string option;
+  state : spec_state;
+  tree_node_id : string;    (** MCTS node_id where branching occurred *)
+  created_at : float;
+  completed_at : float option;
+}
+
+(** Engine configuration. *)
+type config = {
+  max_candidates : int;          (** Max branches per speculation (default: 4) *)
+  fast_model : Llm_client.model_spec;
+  verify_model : Llm_client.model_spec option;  (** None = use fast_model *)
+  max_simulations : int;         (** MCTS simulation budget (default: 8) *)
+  semantic_guard_enabled : bool;
+  min_confidence : float;        (** Min avg reward to commit (default: 0.6) *)
+}
+
+(** Engine state. *)
+type t = {
+  mutable sessions : spec_session list;
+  mutable session_counter : int;
+  tree : Mcts_tree.t;
+  config : config;
+  (* Metrics *)
+  mutable total_speculations : int;
+  mutable total_commits : int;
+  mutable total_aborts : int;
+  mutable total_fast_calls : int;
+  mutable total_cost : float;
+}
+
+(* ================================================================ *)
+(* Construction                                                     *)
+(* ================================================================ *)
+
+let create ?(max_candidates = 4)
+           ?(max_simulations = 8)
+           ?(semantic_guard_enabled = true)
+           ?(min_confidence = 0.6)
+           ?verify_model
+           ~fast_model () : t =
+  let tree = Mcts_tree.create
+    ~root_label:"spec-root"
+    ~exploration_constant:(sqrt 2.0) () in
+  {
+    sessions = [];
+    session_counter = 0;
+    tree;
+    config = {
+      max_candidates;
+      fast_model;
+      verify_model;
+      max_simulations;
+      semantic_guard_enabled;
+      min_confidence;
+    };
+    total_speculations = 0;
+    total_commits = 0;
+    total_aborts = 0;
+    total_fast_calls = 0;
+    total_cost = 0.0;
+  }
+
+(* ================================================================ *)
+(* Helpers                                                          *)
+(* ================================================================ *)
+
+let generate_spec_id (engine : t) : string =
+  engine.session_counter <- engine.session_counter + 1;
+  sprintf "spec-%04d" engine.session_counter
+
+let find_session (engine : t) (spec_id : string) : spec_session option =
+  List.find_opt (fun s -> s.spec_id = spec_id) engine.sessions
+
+let update_session (engine : t) (session : spec_session) : unit =
+  engine.sessions <- List.map (fun s ->
+    if s.spec_id = session.spec_id then session else s
+  ) engine.sessions
+
+(* ================================================================ *)
+(* Semantic Guard                                                   *)
+(* ================================================================ *)
+
+(** Build semantic guard prompt. *)
+let build_guard_prompt ~original_query ~candidate_label ~fast_response : string =
+  sprintf
+{|You are a semantic guard. Check if this speculative result is safe to commit.
+
+Original query: %s
+Candidate approach: %s
+Fast LLM response: %s
+
+Check these 3 criteria:
+1. INTENT: Does the response address the original query's purpose?
+2. FORMAT: Is the response in an expected format (not garbled/truncated)?
+3. SAFETY: Does the response introduce unexpected side-effects?
+
+Respond in exactly this format:
+INTENT: YES or NO
+FORMAT: YES or NO
+SAFETY: YES or NO
+REASON: <one line explanation>|}
+    (if String.length original_query > 200
+     then String.sub original_query 0 200 ^ "..."
+     else original_query)
+    candidate_label
+    (if String.length fast_response > 500
+     then String.sub fast_response 0 500 ^ "..."
+     else fast_response)
+
+let parse_guard_response (text : string) : guard_result =
+  let lines = String.split_on_char '\n' text in
+  let find_yes key =
+    List.exists (fun line ->
+      let upper = String.uppercase_ascii (String.trim line) in
+      let prefix = key ^ ":" in
+      String.length upper >= String.length prefix
+      && String.sub upper 0 (String.length prefix) = prefix
+      && (let rest = String.trim (
+            String.sub upper (String.length prefix)
+              (String.length upper - String.length prefix)) in
+          String.length rest >= 3
+          && String.sub rest 0 3 = "YES")
+    ) lines
+  in
+  let reason =
+    let reason_line = List.find_opt (fun line ->
+      let upper = String.uppercase_ascii (String.trim line) in
+      String.length upper >= 7 && String.sub upper 0 7 = "REASON:"
+    ) lines in
+    match reason_line with
+    | Some line ->
+      let trimmed = String.trim line in
+      if String.length trimmed > 8 then
+        String.trim (String.sub trimmed 8 (String.length trimmed - 8))
+      else "no reason given"
+    | None -> "guard response unparseable"
+  in
+  {
+    intent_aligned = find_yes "INTENT";
+    format_compliant = find_yes "FORMAT";
+    side_effect_safe = find_yes "SAFETY";
+    reason;
+  }
+
+(** Run semantic guard check on a speculative result.
+    Returns Ok guard_result or Error string. *)
+let check_semantic_guard
+    ~(model : Llm_client.model_spec)
+    ~original_query
+    ~candidate_label
+    ~fast_response
+    : (guard_result, string) result =
+  let prompt = build_guard_prompt ~original_query ~candidate_label ~fast_response in
+  let req : Llm_client.completion_request = {
+    model;
+    messages = [Llm_client.user_msg prompt];
+    temperature = 0.0;
+    max_tokens = 150;
+    tools = [];
+    response_format = `Text;
+  } in
+  match Llm_client.complete req with
+  | Ok resp -> Ok (parse_guard_response resp.content)
+  | Error e -> Error (sprintf "semantic guard LLM failed: %s" e)
+
+(* ================================================================ *)
+(* Core: Branch                                                     *)
+(* ================================================================ *)
+
+(** Create a speculation branch point.
+    Registers candidates as MCTS children and returns a session. *)
+let branch (engine : t)
+           ~goal ~original_query
+           ~(candidates : candidate list)
+    : (spec_session, string) result =
+  if List.length candidates = 0 then
+    Error "no candidates provided"
+  else if List.length candidates > engine.config.max_candidates then
+    Error (sprintf "too many candidates: %d > %d"
+      (List.length candidates) engine.config.max_candidates)
+  else begin
+    let spec_id = generate_spec_id engine in
+    let root_id = engine.tree.root.id in
+    let labels = List.map (fun c -> c.label) candidates in
+    (* expand mutates the tree in-place *)
+    ignore (Mcts_tree.expand engine.tree root_id ~labels);
+    let session = {
+      spec_id;
+      goal;
+      original_query;
+      candidates;
+      outcomes = [];
+      best_candidate = None;
+      state = Branching;
+      tree_node_id = root_id;
+      created_at = Time_compat.now ();
+      completed_at = None;
+    } in
+    engine.sessions <- session :: engine.sessions;
+    engine.total_speculations <- engine.total_speculations + 1;
+    Ok session
+  end
+
+(* ================================================================ *)
+(* Core: Simulate                                                   *)
+(* ================================================================ *)
+
+(** Run fast LLM simulation on a single candidate.
+    Returns simulation_outcome. *)
+let simulate_candidate
+    (engine : t) ~goal ~(candidate : candidate)
+    : simulation_outcome =
+  let start_time = Time_compat.now () in
+  let fast_model = engine.config.fast_model in
+  let prompt = sprintf
+    "Goal: %s\n\nApproach: %s\n\n%s\n\nProvide a concise response."
+    goal candidate.label candidate.prompt in
+  let req : Llm_client.completion_request = {
+    model = fast_model;
+    messages = [Llm_client.user_msg prompt];
+    temperature = 0.3;  (* Slight diversity for exploration *)
+    max_tokens = 500;
+    tools = [];
+    response_format = `Text;
+  } in
+  engine.total_fast_calls <- engine.total_fast_calls + 1;
+  match Llm_client.complete req with
+  | Ok resp ->
+    let latency_ms = int_of_float ((Time_compat.now () -. start_time) *. 1000.0) in
+    let cost = float_of_int resp.usage.total_tokens
+               *. fast_model.cost_per_1k_input /. 1000.0 in
+    engine.total_cost <- engine.total_cost +. cost;
+    (* Use verifier to score *)
+    let verify_model = match engine.config.verify_model with
+      | Some m -> m
+      | None -> fast_model
+    in
+    let v_req : Verifier.verification_request = {
+      action_description = sprintf "Speculative: %s" candidate.label;
+      action_result = resp.content;
+      goal;
+      context_summary = candidate.prompt;
+    } in
+    let verdict_v = Verifier.verify ~model:verify_model v_req in
+    let (verdict, verdict_reason) = match verdict_v with
+      | Verifier.Pass -> (Mcts_tree.Pass, "passed verification")
+      | Verifier.Warn reason -> (Mcts_tree.Warn, reason)
+      | Verifier.Fail reason -> (Mcts_tree.Fail, reason)
+    in
+    {
+      candidate_label = candidate.label;
+      fast_response = resp.content;
+      verdict;
+      verdict_reason;
+      latency_ms;
+      cost_estimate = cost;
+    }
+  | Error e ->
+    let latency_ms = int_of_float ((Time_compat.now () -. start_time) *. 1000.0) in
+    {
+      candidate_label = candidate.label;
+      fast_response = "";
+      verdict = Mcts_tree.Fail;
+      verdict_reason = sprintf "fast LLM failed: %s" e;
+      latency_ms;
+      cost_estimate = 0.0;
+    }
+
+(** Run simulations for all candidates in a session.
+    Updates MCTS tree with results. Returns updated session. *)
+let simulate_all (engine : t) (spec_id : string)
+    : (spec_session, string) result =
+  match find_session engine spec_id with
+  | None -> Error (sprintf "session %s not found" spec_id)
+  | Some session when session.state <> Branching ->
+    Error (sprintf "session %s not in Branching state" spec_id)
+  | Some session ->
+    let session = { session with state = Simulating } in
+    update_session engine session;
+    (* Simulate each candidate *)
+    let outcomes = List.map (fun candidate ->
+      simulate_candidate engine ~goal:session.goal ~candidate
+    ) session.candidates in
+    (* Record simulations in MCTS tree *)
+    let children = engine.tree.root.children in
+    List.iter2 (fun (child : Mcts_tree.node) outcome ->
+      let sim : Mcts_tree.simulation_result = {
+        model_used = engine.config.fast_model.model_id;
+        output =
+          (if String.length outcome.fast_response > 100
+           then String.sub outcome.fast_response 0 100 ^ "..."
+           else outcome.fast_response);
+        verdict = outcome.verdict;
+        latency_ms = float_of_int outcome.latency_ms;
+      } in
+      let reward = Mcts_tree.reward_of_verdict outcome.verdict in
+      ignore (Mcts_tree.record_simulation engine.tree child.id sim);
+      Mcts_tree.backpropagate engine.tree child.id reward
+    ) children outcomes;
+    let session = { session with
+      state = Verifying;
+      outcomes;
+    } in
+    update_session engine session;
+    Ok session
+
+(* ================================================================ *)
+(* Core: Select Best + Semantic Guard                               *)
+(* ================================================================ *)
+
+(** Select best candidate from simulation outcomes.
+    If semantic guard is enabled, verify the best candidate.
+    Returns updated session in Ready_to_commit or Aborted state. *)
+let select_best (engine : t) (spec_id : string)
+    : (spec_session, string) result =
+  match find_session engine spec_id with
+  | None -> Error (sprintf "session %s not found" spec_id)
+  | Some session when session.state <> Verifying ->
+    Error (sprintf "session %s not in Verifying state" spec_id)
+  | Some session ->
+    (* Find best by MCTS best_path *)
+    let best = Mcts_tree.best_path engine.tree in
+    let best_label = match best with
+      | _ :: child :: _ -> Some child.Mcts_tree.label
+      | _ -> None
+    in
+    (* Check if best exceeds min_confidence *)
+    let best_outcome = match best_label with
+      | Some lbl ->
+        List.find_opt (fun o -> o.candidate_label = lbl) session.outcomes
+      | None -> None
+    in
+    let avg_reward = match best_outcome with
+      | Some o -> Mcts_tree.reward_of_verdict o.verdict
+      | None -> 0.0
+    in
+    if avg_reward < engine.config.min_confidence then begin
+      let reason = sprintf
+        "best candidate '%s' reward %.2f < min_confidence %.2f"
+        (Option.value best_label ~default:"none")
+        avg_reward engine.config.min_confidence in
+      let session = { session with
+        state = Aborted reason;
+        completed_at = Some (Time_compat.now ());
+      } in
+      update_session engine session;
+      engine.total_aborts <- engine.total_aborts + 1;
+      Ok session
+    end
+    else begin
+      (* Semantic guard check *)
+      let guard_ok =
+        if not engine.config.semantic_guard_enabled then true
+        else match best_outcome with
+          | None -> false
+          | Some outcome ->
+            let model = match engine.config.verify_model with
+              | Some m -> m | None -> engine.config.fast_model in
+            match check_semantic_guard
+              ~model
+              ~original_query:session.original_query
+              ~candidate_label:outcome.candidate_label
+              ~fast_response:outcome.fast_response with
+            | Ok guard ->
+              guard.intent_aligned && guard.format_compliant && guard.side_effect_safe
+            | Error _e -> true  (* Guard failure = allow *)
+      in
+      if not guard_ok then begin
+        let reason = "semantic guard rejected best candidate" in
+        let session = { session with
+          state = Aborted reason;
+          completed_at = Some (Time_compat.now ());
+        } in
+        update_session engine session;
+        engine.total_aborts <- engine.total_aborts + 1;
+        Ok session
+      end
+      else begin
+        let session = { session with
+          state = Ready_to_commit;
+          best_candidate = best_label;
+        } in
+        update_session engine session;
+        Ok session
+      end
+    end
+
+(* ================================================================ *)
+(* Core: Commit / Abort                                             *)
+(* ================================================================ *)
+
+(** Commit the best speculative result.
+    Returns the best candidate's fast_response for the caller to apply. *)
+let commit (engine : t) (spec_id : string)
+    : (simulation_outcome, string) result =
+  match find_session engine spec_id with
+  | None -> Error (sprintf "session %s not found" spec_id)
+  | Some session when session.state <> Ready_to_commit ->
+    Error (sprintf "session %s not in Ready_to_commit state" spec_id)
+  | Some session ->
+    let best_label = match session.best_candidate with
+      | Some l -> l
+      | None -> ""
+    in
+    let best_outcome = List.find_opt
+      (fun o -> o.candidate_label = best_label) session.outcomes in
+    match best_outcome with
+    | None -> Error "best candidate outcome not found"
+    | Some outcome ->
+      let session = { session with
+        state = Committed;
+        completed_at = Some (Time_compat.now ());
+      } in
+      update_session engine session;
+      engine.total_commits <- engine.total_commits + 1;
+      Ok outcome
+
+(** Abort a speculation session, discarding all results. *)
+let abort (engine : t) (spec_id : string) ~reason
+    : (spec_session, string) result =
+  match find_session engine spec_id with
+  | None -> Error (sprintf "session %s not found" spec_id)
+  | Some session ->
+    (match session.state with
+     | Committed -> Error "cannot abort committed session"
+     | Aborted _ -> Error "session already aborted"
+     | _ ->
+       let session = { session with
+         state = Aborted reason;
+         completed_at = Some (Time_compat.now ());
+       } in
+       update_session engine session;
+       engine.total_aborts <- engine.total_aborts + 1;
+       Ok session)
+
+(* ================================================================ *)
+(* Convenience: Full Pipeline                                       *)
+(* ================================================================ *)
+
+(** Run the full speculative pipeline: branch → simulate → select → commit/abort.
+    Returns Ok (committed_outcome) or Error. *)
+let speculate (engine : t)
+              ~goal ~original_query
+              ~(candidates : candidate list)
+    : (simulation_outcome, string) result =
+  match branch engine ~goal ~original_query ~candidates with
+  | Error e -> Error e
+  | Ok session ->
+    match simulate_all engine session.spec_id with
+    | Error e -> Error e
+    | Ok _session ->
+      match select_best engine session.spec_id with
+      | Error e -> Error e
+      | Ok session ->
+        match session.state with
+        | Ready_to_commit -> commit engine session.spec_id
+        | Aborted reason -> Error (sprintf "speculation aborted: %s" reason)
+        | _ -> Error "unexpected state after select_best"
+
+(* ================================================================ *)
+(* Queries                                                          *)
+(* ================================================================ *)
+
+let state_to_string = function
+  | Idle -> "idle"
+  | Branching -> "branching"
+  | Simulating -> "simulating"
+  | Verifying -> "verifying"
+  | Ready_to_commit -> "ready_to_commit"
+  | Committed -> "committed"
+  | Aborted reason -> sprintf "aborted: %s" reason
+
+let session_to_yojson (s : spec_session) : Yojson.Safe.t =
+  `Assoc [
+    "spec_id", `String s.spec_id;
+    "goal", `String s.goal;
+    "state", `String (state_to_string s.state);
+    "num_candidates", `Int (List.length s.candidates);
+    "num_outcomes", `Int (List.length s.outcomes);
+    "best_candidate", (match s.best_candidate with
+      | Some l -> `String l | None -> `Null);
+    "created_at", `Float s.created_at;
+    "completed_at", (match s.completed_at with
+      | Some t -> `Float t | None -> `Null);
+  ]
+
+let outcome_to_yojson (o : simulation_outcome) : Yojson.Safe.t =
+  `Assoc [
+    "candidate", `String o.candidate_label;
+    "verdict", `String (Mcts_tree.verdict_to_string o.verdict);
+    "verdict_reason", `String o.verdict_reason;
+    "latency_ms", `Int o.latency_ms;
+    "cost_estimate", `Float o.cost_estimate;
+    "response_preview",
+      `String (if String.length o.fast_response > 100
+               then String.sub o.fast_response 0 100 ^ "..."
+               else o.fast_response);
+  ]
+
+let metrics_to_yojson (engine : t) : Yojson.Safe.t =
+  let tree_summary = Mcts_tree.summary_to_yojson engine.tree in
+  `Assoc [
+    "total_speculations", `Int engine.total_speculations;
+    "total_commits", `Int engine.total_commits;
+    "total_aborts", `Int engine.total_aborts;
+    "commit_rate",
+      `Float (if engine.total_speculations > 0
+              then float_of_int engine.total_commits /.
+                   float_of_int engine.total_speculations
+              else 0.0);
+    "total_fast_calls", `Int engine.total_fast_calls;
+    "total_cost_usd", `Float engine.total_cost;
+    "active_sessions", `Int (List.length (List.filter (fun s ->
+      match s.state with Committed | Aborted _ -> false | _ -> true
+    ) engine.sessions));
+    "mcts_tree", tree_summary;
+  ]
+
+let status (engine : t) : Yojson.Safe.t =
+  `Assoc [
+    "metrics", metrics_to_yojson engine;
+    "recent_sessions",
+      `List (List.map session_to_yojson
+        (List.filteri (fun i _ -> i < 5) engine.sessions));
+    "tree_summary", Mcts_tree.summary_to_yojson engine.tree;
+  ]
+
+(** Get the MCTS tree for direct inspection. *)
+let tree (engine : t) : Mcts_tree.t = engine.tree

--- a/lib/speculative_engine.ml
+++ b/lib/speculative_engine.ml
@@ -146,6 +146,26 @@ let update_session (engine : t) (session : spec_session) : unit =
     if s.spec_id = session.spec_id then session else s
   ) engine.sessions
 
+let avg_reward_of_node (node : Mcts_tree.node) : float =
+  if node.visit_count = 0 then 0.0
+  else node.total_reward /. float_of_int node.visit_count
+
+let best_session_label (engine : t) (session : spec_session) : string option =
+  session.child_node_ids
+  |> List.filter_map (fun child_id ->
+         Mcts_tree.find_node engine.tree child_id
+         |> Option.map (fun node -> (node.Mcts_tree.label, avg_reward_of_node node)))
+  |> function
+  | [] -> None
+  | (label, reward) :: rest ->
+      let best_label, _ =
+        List.fold_left
+          (fun ((_, best_reward) as best) (label, reward) ->
+            if reward > best_reward then (label, reward) else best)
+          (label, reward) rest
+      in
+      Some best_label
+
 (* ================================================================ *)
 (* Semantic Guard                                                   *)
 (* ================================================================ *)
@@ -401,12 +421,10 @@ let select_best (engine : t) (spec_id : string)
   | Some session when session.state <> Verifying ->
     Error (sprintf "session %s not in Verifying state" spec_id)
   | Some session ->
-    (* Find best by MCTS best_path *)
-    let best = Mcts_tree.best_path engine.tree in
-    let best_label = match best with
-      | _ :: child :: _ -> Some child.Mcts_tree.label
-      | _ -> None
-    in
+    (* Choose only among this session's child nodes. The engine tree is
+       shared across sessions, so a global best-path lookup can leak a
+       previous session's label into the current selection. *)
+    let best_label = best_session_label engine session in
     (* Check if best exceeds min_confidence *)
     let best_outcome = match best_label with
       | Some lbl ->

--- a/lib/speculative_engine.ml
+++ b/lib/speculative_engine.ml
@@ -68,7 +68,8 @@ type spec_session = {
   outcomes : simulation_outcome list;
   best_candidate : string option;
   state : spec_state;
-  tree_node_id : string;    (** MCTS node_id where branching occurred *)
+  tree_node_id : string;       (** MCTS node_id where branching occurred *)
+  child_node_ids : string list; (** MCTS node_ids for this session's candidates *)
   created_at : float;
   completed_at : float option;
 }
@@ -251,8 +252,20 @@ let branch (engine : t)
     let spec_id = generate_spec_id engine in
     let root_id = engine.tree.root.id in
     let labels = List.map (fun c -> c.label) candidates in
-    (* expand mutates the tree in-place *)
-    ignore (Mcts_tree.expand engine.tree root_id ~labels);
+    (* Try expand first (works if root has no children).
+       If root already expanded (prior session), use add_child for
+       progressive widening — each candidate becomes a new child.
+       This makes multi-session operation safe. *)
+    let child_ids = match Mcts_tree.expand engine.tree root_id ~labels with
+      | Ok children -> List.map (fun (c : Mcts_tree.node) -> c.id) children
+      | Error _ ->
+        (* Root already expanded: add each candidate individually *)
+        List.filter_map (fun label ->
+          match Mcts_tree.add_child engine.tree root_id ~label with
+          | Ok child -> Some child.id
+          | Error _ -> None
+        ) labels
+    in
     let session = {
       spec_id;
       goal;
@@ -262,6 +275,7 @@ let branch (engine : t)
       best_candidate = None;
       state = Branching;
       tree_node_id = root_id;
+      child_node_ids = child_ids;
       created_at = Time_compat.now ();
       completed_at = None;
     } in
@@ -350,9 +364,9 @@ let simulate_all (engine : t) (spec_id : string)
     let outcomes = List.map (fun candidate ->
       simulate_candidate engine ~goal:session.goal ~candidate
     ) session.candidates in
-    (* Record simulations in MCTS tree *)
-    let children = engine.tree.root.children in
-    List.iter2 (fun (child : Mcts_tree.node) outcome ->
+    (* Record simulations in MCTS tree using session-specific child IDs.
+       This is safe for multi-session: each session tracks its own children. *)
+    List.iter2 (fun child_id outcome ->
       let sim : Mcts_tree.simulation_result = {
         model_used = engine.config.fast_model.model_id;
         output =
@@ -363,9 +377,9 @@ let simulate_all (engine : t) (spec_id : string)
         latency_ms = float_of_int outcome.latency_ms;
       } in
       let reward = Mcts_tree.reward_of_verdict outcome.verdict in
-      ignore (Mcts_tree.record_simulation engine.tree child.id sim);
-      Mcts_tree.backpropagate engine.tree child.id reward
-    ) children outcomes;
+      ignore (Mcts_tree.record_simulation engine.tree child_id sim);
+      Mcts_tree.backpropagate engine.tree child_id reward
+    ) session.child_node_ids outcomes;
     let session = { session with
       state = Verifying;
       outcomes;
@@ -432,7 +446,15 @@ let select_best (engine : t) (spec_id : string)
               ~fast_response:outcome.fast_response with
             | Ok guard ->
               guard.intent_aligned && guard.format_compliant && guard.side_effect_safe
-            | Error _e -> true  (* Guard failure = allow *)
+            | Error _e ->
+              (* Fail-open by design: if the guard LLM itself errors (network,
+                 timeout, model unavailable), we allow the candidate through
+                 rather than blocking the entire speculative pipeline.
+                 Rationale: the guard is a secondary quality check — the primary
+                 signal is the verifier verdict (which already passed to reach
+                 this point).  Blocking here would make speculation fragile
+                 under transient LLM failures. *)
+              true
       in
       if not guard_ok then begin
         let reason = "semantic guard rejected best candidate" in

--- a/lib/tool_risc.ml
+++ b/lib/tool_risc.ml
@@ -674,7 +674,8 @@ let handle_spec_commit args : result =
 (* ================================================================ *)
 
 (** Abort a speculative session — discard results and rollback.
-    Backpropagates failure reward (0.0) into MCTS tree. *)
+    Note: MCTS tree is not updated on abort — the simulation outcomes
+    already recorded during simulate_all remain for future UCB1 selection. *)
 let handle_spec_abort args : result =
   let spec_id = get_string args "spec_id" "" in
   let reason = get_string args "reason" "user_abort" in

--- a/lib/tool_risc.ml
+++ b/lib/tool_risc.ml
@@ -1,10 +1,11 @@
-(** Tool_risc -- MCP Tool Handlers for SWARM-RISC Pipeline + Cache + OoO
+(** Tool_risc -- MCP Tool Handlers for SWARM-RISC Pipeline + Cache + OoO + Speculative
 
-    Exposes pipeline operations, cache coherence, and OoO scheduling
-    as MCP tools.
+    Exposes pipeline operations, cache coherence, OoO scheduling,
+    and speculative execution as MCP tools.
     Phase 1 tools: pipeline_status, decode, pipeline_flush.
     Phase 2 tools: cache_status, cache_read, cache_write, cache_metrics.
     Phase 3 tools: rs_status, rs_add, rs_issue, rs_cdb, steal, ooo_metrics.
+    Phase 4 tools: spec_start, spec_status, spec_commit, spec_abort.
 
     Tool dispatch follows the project convention: match-based routing,
     no dict/map lookup.
@@ -38,6 +39,27 @@ let global_coherence = Cache_coherence.create_controller ()
 
 (** Singleton Tomasulo RS scheduler. Same thread-safety note above. *)
 let global_scheduler = Reservation_station.create_scheduler ()
+
+(* ================================================================ *)
+(* Global Speculative Engine (Phase 4)                              *)
+(* ================================================================ *)
+
+(** Default fast model for speculative execution.
+    Uses Ollama glm-4.7-flash (local, cheap).
+    Overridable via tool args at runtime. *)
+let default_fast_model : Llm_client.model_spec = {
+  provider = Ollama;
+  model_id = "glm-4.7-flash";
+  max_context = 202000;
+  api_url = "http://127.0.0.1:11434";
+  api_key_env = None;
+  cost_per_1k_input = 0.0;
+  cost_per_1k_output = 0.0;
+}
+
+(** Singleton speculative engine. Same thread-safety note above. *)
+let global_spec_engine =
+  Speculative_engine.create ~fast_model:default_fast_model ()
 
 (* ================================================================ *)
 (* Argument Helpers (consistent with tool_cache.ml pattern)         *)
@@ -596,10 +618,78 @@ let handle_ooo_metrics _args : result =
   ]))
 
 (* ================================================================ *)
+(* Tool: masc_risc_spec_start (Phase 4)                             *)
+(* ================================================================ *)
+
+(** Start speculative execution: branch into N candidates for MCTS
+    evaluation via fast LLM. *)
+let handle_spec_start args : result =
+  let goal = get_string args "goal" "" in
+  let query = get_string args "original_query" "" in
+  let labels = get_string_list args "candidate_labels" in
+  if goal = "" then (false, "goal is required")
+  else if labels = [] then (false, "candidate_labels is required (string list)")
+  else begin
+    let candidates = List.map (fun label ->
+      { Speculative_engine.label;
+        prompt = label;
+        metadata = `Null }
+    ) labels in
+    match Speculative_engine.branch global_spec_engine
+      ~goal ~original_query:query ~candidates with
+    | Ok session ->
+        (true, Yojson.Safe.pretty_to_string
+          (Speculative_engine.session_to_yojson session))
+    | Error msg -> (false, msg)
+  end
+
+(* ================================================================ *)
+(* Tool: masc_risc_spec_status (Phase 4)                            *)
+(* ================================================================ *)
+
+(** Query speculative engine status: active sessions, metrics, MCTS tree. *)
+let handle_spec_status _args : result =
+  (true, Yojson.Safe.pretty_to_string (Speculative_engine.status global_spec_engine))
+
+(* ================================================================ *)
+(* Tool: masc_risc_spec_commit (Phase 4)                            *)
+(* ================================================================ *)
+
+(** Commit a speculative session — accept the best candidate.
+    Only valid when session is in Ready_to_commit state. *)
+let handle_spec_commit args : result =
+  let spec_id = get_string args "spec_id" "" in
+  if spec_id = "" then (false, "spec_id is required")
+  else match Speculative_engine.commit global_spec_engine spec_id with
+    | Ok outcome ->
+        (true, Yojson.Safe.pretty_to_string (`Assoc [
+          ("committed", `Bool true);
+          ("spec_id", `String spec_id);
+          ("outcome", Speculative_engine.outcome_to_yojson outcome);
+        ]))
+    | Error msg -> (false, msg)
+
+(* ================================================================ *)
+(* Tool: masc_risc_spec_abort (Phase 4)                             *)
+(* ================================================================ *)
+
+(** Abort a speculative session — discard results and rollback.
+    Backpropagates failure reward (0.0) into MCTS tree. *)
+let handle_spec_abort args : result =
+  let spec_id = get_string args "spec_id" "" in
+  let reason = get_string args "reason" "user_abort" in
+  if spec_id = "" then (false, "spec_id is required")
+  else match Speculative_engine.abort global_spec_engine spec_id ~reason with
+    | Ok session ->
+        (true, Yojson.Safe.pretty_to_string
+          (Speculative_engine.session_to_yojson session))
+    | Error msg -> (false, msg)
+
+(* ================================================================ *)
 (* Tool Definitions (for MCP registration)                          *)
 (* ================================================================ *)
 
-(** MCP tool definitions for SWARM-RISC Phase 1 + Phase 2 + Phase 3.
+(** MCP tool definitions for SWARM-RISC Phase 1-4.
     To be registered in mcp_server_eio.ml dispatch. *)
 let tool_definitions : (string * Yojson.Safe.t) list = [
   ("masc_risc_pipeline_status", `Assoc [
@@ -880,6 +970,74 @@ let tool_definitions : (string * Yojson.Safe.t) list = [
       ("properties", `Assoc []);
     ]);
   ]);
+
+  (* Phase 4: Speculative Execution *)
+  ("masc_risc_spec_start", `Assoc [
+    ("name", `String "masc_risc_spec_start");
+    ("description", `String "Start speculative execution: branch into N candidates for MCTS evaluation via fast LLM.");
+    ("inputSchema", `Assoc [
+      ("type", `String "object");
+      ("properties", `Assoc [
+        ("goal", `Assoc [
+          ("type", `String "string");
+          ("description", `String "The goal to accomplish speculatively.");
+        ]);
+        ("original_query", `Assoc [
+          ("type", `String "string");
+          ("description", `String "The original user query to preserve intent alignment.");
+        ]);
+        ("candidate_labels", `Assoc [
+          ("type", `String "array");
+          ("items", `Assoc [("type", `String "string")]);
+          ("description", `String "Labels for candidate approaches (e.g. ['schema_first', 'regex', 'llm_parse']).");
+        ]);
+      ]);
+      ("required", `List [`String "goal"; `String "candidate_labels"]);
+    ]);
+  ]);
+
+  ("masc_risc_spec_status", `Assoc [
+    ("name", `String "masc_risc_spec_status");
+    ("description", `String "Query speculative engine status: active sessions, metrics, MCTS tree summary.");
+    ("inputSchema", `Assoc [
+      ("type", `String "object");
+      ("properties", `Assoc []);
+    ]);
+  ]);
+
+  ("masc_risc_spec_commit", `Assoc [
+    ("name", `String "masc_risc_spec_commit");
+    ("description", `String "Commit a speculative session — accept the best candidate result.");
+    ("inputSchema", `Assoc [
+      ("type", `String "object");
+      ("properties", `Assoc [
+        ("spec_id", `Assoc [
+          ("type", `String "string");
+          ("description", `String "Speculative session ID (e.g. spec-0001).");
+        ]);
+      ]);
+      ("required", `List [`String "spec_id"]);
+    ]);
+  ]);
+
+  ("masc_risc_spec_abort", `Assoc [
+    ("name", `String "masc_risc_spec_abort");
+    ("description", `String "Abort a speculative session — discard results and rollback. Backpropagates failure reward.");
+    ("inputSchema", `Assoc [
+      ("type", `String "object");
+      ("properties", `Assoc [
+        ("spec_id", `Assoc [
+          ("type", `String "string");
+          ("description", `String "Speculative session ID to abort.");
+        ]);
+        ("reason", `Assoc [
+          ("type", `String "string");
+          ("description", `String "Reason for aborting (default: user_abort).");
+        ]);
+      ]);
+      ("required", `List [`String "spec_id"]);
+    ]);
+  ]);
 ]
 
 (** Tool schemas in Types.tool_schema format for config.ml registration. *)
@@ -914,6 +1072,11 @@ let dispatch tool_name args : result =
   | "masc_risc_rs_complete" -> handle_rs_complete args
   | "masc_risc_steal" -> handle_steal args
   | "masc_risc_ooo_metrics" -> handle_ooo_metrics args
+  (* Phase 4: Speculative Execution *)
+  | "masc_risc_spec_start" -> handle_spec_start args
+  | "masc_risc_spec_status" -> handle_spec_status args
+  | "masc_risc_spec_commit" -> handle_spec_commit args
+  | "masc_risc_spec_abort" -> handle_spec_abort args
   | _ -> (false, Printf.sprintf "Unknown RISC tool: %s" tool_name)
 
 (** Check if a tool name is a RISC tool. *)

--- a/lib/tool_risc.ml
+++ b/lib/tool_risc.ml
@@ -623,6 +623,20 @@ let handle_ooo_metrics _args : result =
 
 (** Start speculative execution: branch into N candidates for MCTS
     evaluation via fast LLM. *)
+let advance_spec_start
+    ~simulate
+    ~select
+    (engine : Speculative_engine.t)
+    (session : Speculative_engine.spec_session) : result =
+  match simulate engine session.spec_id with
+  | Error msg -> (false, msg)
+  | Ok _ -> (
+      match select engine session.spec_id with
+      | Error msg -> (false, msg)
+      | Ok final_session ->
+          (true, Yojson.Safe.pretty_to_string
+             (Speculative_engine.session_to_yojson final_session)) )
+
 let handle_spec_start args : result =
   let goal = get_string args "goal" "" in
   let query = get_string args "original_query" "" in
@@ -638,8 +652,10 @@ let handle_spec_start args : result =
     match Speculative_engine.branch global_spec_engine
       ~goal ~original_query:query ~candidates with
     | Ok session ->
-        (true, Yojson.Safe.pretty_to_string
-          (Speculative_engine.session_to_yojson session))
+        advance_spec_start
+          ~simulate:Speculative_engine.simulate_all
+          ~select:Speculative_engine.select_best
+          global_spec_engine session
     | Error msg -> (false, msg)
   end
 

--- a/test/dune
+++ b/test/dune
@@ -685,3 +685,15 @@
  (name test_reservation_station)
  (modules test_reservation_station)
  (libraries masc_mcp yojson unix))
+
+; SWARM-RISC Phase 4: MCTS tree (UCB1 selection + backpropagation)
+(test
+ (name test_mcts)
+ (modules test_mcts)
+ (libraries masc_mcp yojson unix))
+
+; SWARM-RISC Phase 4: Speculative engine (fast/slow LLM + semantic guard)
+(test
+ (name test_speculative)
+ (modules test_speculative)
+ (libraries masc_mcp yojson unix str))

--- a/test/test_mcts.ml
+++ b/test/test_mcts.ml
@@ -1,0 +1,428 @@
+(** Tests for Mcts_tree — UCB1 tree search for speculative execution.
+
+    Covers: construction, expansion, UCB1 selection, simulation recording,
+    backpropagation, best-path extraction, pruning, and serialization.
+
+    @since 2.80.0 *)
+
+open Masc_mcp.Mcts_tree
+
+(* ================================================================ *)
+(* Test Helpers                                                     *)
+(* ================================================================ *)
+
+let pass_count = ref 0
+let fail_count = ref 0
+
+let check label cond =
+  if cond then begin
+    incr pass_count;
+    Printf.printf "  ✓ %s\n%!" label
+  end else begin
+    incr fail_count;
+    Printf.printf "  ✗ %s\n%!" label
+  end
+
+let run_test name f =
+  Printf.printf "\n─── %s ───\n%!" name;
+  (try f () with exn ->
+    incr fail_count;
+    Printf.printf "  ✗ EXCEPTION: %s\n%!" (Printexc.to_string exn))
+
+let make_sim ?(output = "test output") ?(latency = 10.0)
+    ?(model = "test-model") verdict =
+  { output; verdict; latency_ms = latency; model_used = model }
+
+(* ================================================================ *)
+(* Tests: Construction                                              *)
+(* ================================================================ *)
+
+let test_create () =
+  let t = create ~root_label:"root task" () in
+  check "root label" (t.root.label = "root task");
+  check "node_count = 1" (t.node_count = 1);
+  check "exploration_constant = sqrt(2)" (abs_float (t.exploration_constant -. sqrt 2.0) < 0.001);
+  check "root has no children" (t.root.children = []);
+  check "root visit_count = 0" (t.root.visit_count = 0);
+  check "root parent_id = None" (t.root.parent_id = None);
+  check "metrics zeroed" (t.total_simulations = 0 && t.total_selections = 0)
+
+let test_create_custom_c () =
+  let t = create ~exploration_constant:1.0 ~root_label:"custom" () in
+  check "custom C = 1.0" (abs_float (t.exploration_constant -. 1.0) < 0.001)
+
+(* ================================================================ *)
+(* Tests: Expansion                                                 *)
+(* ================================================================ *)
+
+let test_expand () =
+  let t = create ~root_label:"task" () in
+  match expand t t.root.id ~labels:["approach A"; "approach B"; "approach C"] with
+  | Error msg -> failwith msg
+  | Ok children ->
+    check "3 children created" (List.length children = 3);
+    check "node_count = 4" (t.node_count = 4);
+    check "root has 3 children" (List.length t.root.children = 3);
+    check "children have parent_id" (
+      List.for_all (fun c -> c.parent_id = Some t.root.id) children);
+    check "total_expansions = 1" (t.total_expansions = 1)
+
+let test_expand_already_expanded () =
+  let t = create ~root_label:"task" () in
+  let _ = expand t t.root.id ~labels:["A"; "B"] in
+  match expand t t.root.id ~labels:["C"] with
+  | Error msg -> check "double expand rejected" (String.length msg > 0)
+  | Ok _ -> check "should have failed" false
+
+let test_expand_not_found () =
+  let t = create ~root_label:"task" () in
+  match expand t "nonexistent" ~labels:["A"] with
+  | Error _ -> check "not found error" true
+  | Ok _ -> check "should have failed" false
+
+let test_add_child () =
+  let t = create ~root_label:"task" () in
+  let _ = expand t t.root.id ~labels:["A"] in
+  match add_child t t.root.id ~label:"B (progressive)" with
+  | Error msg -> failwith msg
+  | Ok child ->
+    check "child added" (child.label = "B (progressive)");
+    check "root now has 2 children" (List.length t.root.children = 2);
+    check "node_count = 3" (t.node_count = 3)
+
+(* ================================================================ *)
+(* Tests: UCB1 Selection                                            *)
+(* ================================================================ *)
+
+let test_ucb1_unvisited_first () =
+  let t = create ~root_label:"task" () in
+  let _ = expand t t.root.id ~labels:["A"; "B"; "C"] in
+  (* All unvisited → UCB1 = infinity, first child selected *)
+  match select_child t t.root with
+  | None -> check "should have children" false
+  | Some child ->
+    check "unvisited child selected" (child.visit_count = 0);
+    check "total_selections = 1" (t.total_selections = 1)
+
+let test_ucb1_exploitation () =
+  let t = create ~exploration_constant:0.0 ~root_label:"task" () in
+  let _ = expand t t.root.id ~labels:["A"; "B"; "C"] in
+  (* Give B higher reward *)
+  let children = t.root.children in
+  let b = List.nth children 1 in
+  b.visit_count <- 10;
+  b.total_reward <- 9.0;  (* avg = 0.9 *)
+  let a = List.nth children 0 in
+  a.visit_count <- 10;
+  a.total_reward <- 3.0;  (* avg = 0.3 *)
+  let c = List.nth children 2 in
+  c.visit_count <- 10;
+  c.total_reward <- 5.0;  (* avg = 0.5 *)
+  t.root.visit_count <- 30;
+  match select_child t t.root with
+  | None -> check "should select" false
+  | Some child ->
+    check "B selected (highest avg)" (child.id = b.id)
+
+let test_select_path () =
+  let t = create ~root_label:"root" () in
+  let _ = expand t t.root.id ~labels:["L1-A"; "L1-B"] in
+  let path = select_path t in
+  check "path has 2 nodes" (List.length path = 2);
+  check "path starts at root" ((List.hd path).label = "root")
+
+(* ================================================================ *)
+(* Tests: Simulation Recording                                      *)
+(* ================================================================ *)
+
+let test_record_simulation () =
+  let t = create ~root_label:"task" () in
+  let _ = expand t t.root.id ~labels:["A"] in
+  let a = List.hd t.root.children in
+  let sim = make_sim Pass in
+  match record_simulation t a.id sim with
+  | Error msg -> failwith msg
+  | Ok reward ->
+    check "pass reward = 1.0" (abs_float (reward -. 1.0) < 0.001);
+    check "simulation recorded" (Option.is_some a.last_simulation);
+    check "total_simulations = 1" (t.total_simulations = 1)
+
+let test_record_warn_fail () =
+  let t = create ~root_label:"task" () in
+  let _ = expand t t.root.id ~labels:["A"; "B"] in
+  let a = List.hd t.root.children in
+  let b = List.nth t.root.children 1 in
+  let _ = record_simulation t a.id (make_sim Warn) in
+  let _ = record_simulation t b.id (make_sim Fail) in
+  check "warn reward" (reward_of_verdict Warn = 0.5);
+  check "fail reward" (reward_of_verdict Fail = 0.0);
+  check "total_simulations = 2" (t.total_simulations = 2)
+
+let test_record_not_found () =
+  let t = create ~root_label:"task" () in
+  match record_simulation t "ghost" (make_sim Pass) with
+  | Error _ -> check "not found error" true
+  | Ok _ -> check "should fail" false
+
+(* ================================================================ *)
+(* Tests: Backpropagation                                           *)
+(* ================================================================ *)
+
+let test_backpropagate () =
+  let t = create ~root_label:"task" () in
+  let _ = expand t t.root.id ~labels:["A"] in
+  let a = List.hd t.root.children in
+  backpropagate t a.id 1.0;
+  check "leaf visit_count = 1" (a.visit_count = 1);
+  check "leaf total_reward = 1.0" (abs_float (a.total_reward -. 1.0) < 0.001);
+  check "root visit_count = 1" (t.root.visit_count = 1);
+  check "root total_reward = 1.0" (abs_float (t.root.total_reward -. 1.0) < 0.001);
+  check "backpropagations = 2" (t.total_backpropagations = 2)
+
+let test_backpropagate_two_levels () =
+  let t = create ~root_label:"root" () in
+  let _ = expand t t.root.id ~labels:["L1"] in
+  let l1 = List.hd t.root.children in
+  let _ = expand t l1.id ~labels:["L2-A"; "L2-B"] in
+  let l2a = List.hd l1.children in
+  backpropagate t l2a.id 0.5;
+  check "L2-A visits = 1" (l2a.visit_count = 1);
+  check "L1 visits = 1" (l1.visit_count = 1);
+  check "root visits = 1" (t.root.visit_count = 1);
+  check "all rewards = 0.5" (
+    abs_float (l2a.total_reward -. 0.5) < 0.001
+    && abs_float (l1.total_reward -. 0.5) < 0.001
+    && abs_float (t.root.total_reward -. 0.5) < 0.001)
+
+(* ================================================================ *)
+(* Tests: Best Path                                                 *)
+(* ================================================================ *)
+
+let test_best_path () =
+  let t = create ~root_label:"root" () in
+  let _ = expand t t.root.id ~labels:["A"; "B"] in
+  let a = List.hd t.root.children in
+  let b = List.nth t.root.children 1 in
+  (* A: avg 0.9, B: avg 0.3 *)
+  a.visit_count <- 10; a.total_reward <- 9.0;
+  b.visit_count <- 10; b.total_reward <- 3.0;
+  let path = best_path t in
+  check "path length = 2" (List.length path = 2);
+  check "best path goes through A" ((List.nth path 1).id = a.id)
+
+let test_best_child_empty () =
+  let t = create ~root_label:"leaf" () in
+  match best_child_by_reward t.root with
+  | None -> check "no children = None" true
+  | Some _ -> check "should be None" false
+
+(* ================================================================ *)
+(* Tests: Pruning                                                   *)
+(* ================================================================ *)
+
+let test_prune () =
+  let t = create ~root_label:"root" () in
+  let _ = expand t t.root.id ~labels:["good"; "bad"; "ok"] in
+  let children = t.root.children in
+  let good = List.nth children 0 in
+  let bad = List.nth children 1 in
+  let ok = List.nth children 2 in
+  good.visit_count <- 10; good.total_reward <- 8.0;  (* avg 0.8 *)
+  bad.visit_count <- 10; bad.total_reward <- 1.0;     (* avg 0.1 *)
+  ok.visit_count <- 10; ok.total_reward <- 6.0;       (* avg 0.6 *)
+  match prune t t.root.id ~min_avg_reward:0.5 with
+  | Error msg -> failwith msg
+  | Ok pruned ->
+    check "1 subtree pruned" (pruned = 1);
+    check "2 children remain" (List.length t.root.children = 2);
+    check "node_count updated" (t.node_count = 3);
+    let ids = List.map (fun c -> c.label) t.root.children in
+    check "bad removed" (not (List.mem "bad" ids));
+    check "good kept" (List.mem "good" ids);
+    check "ok kept" (List.mem "ok" ids)
+
+let test_prune_deep_subtree () =
+  let t = create ~root_label:"root" () in
+  let _ = expand t t.root.id ~labels:["branch"] in
+  let branch = List.hd t.root.children in
+  let _ = expand t branch.id ~labels:["sub1"; "sub2"] in
+  branch.visit_count <- 5; branch.total_reward <- 0.5;  (* avg 0.1 *)
+  check "node_count before = 4" (t.node_count = 4);
+  match prune t t.root.id ~min_avg_reward:0.5 with
+  | Error msg -> failwith msg
+  | Ok pruned ->
+    check "3 nodes pruned (branch + 2 subs)" (pruned = 3);
+    check "node_count = 1 (root only)" (t.node_count = 1);
+    check "root has no children" (t.root.children = [])
+
+(* ================================================================ *)
+(* Tests: Tree Navigation                                           *)
+(* ================================================================ *)
+
+let test_find_node () =
+  let t = create ~root_label:"root" () in
+  let _ = expand t t.root.id ~labels:["A"; "B"] in
+  let a = List.hd t.root.children in
+  match find_node t a.id with
+  | Some found -> check "found node A" (found.label = "A")
+  | None -> check "should find A" false
+
+let test_find_node_missing () =
+  let t = create ~root_label:"root" () in
+  match find_node t "nonexistent" with
+  | None -> check "not found returns None" true
+  | Some _ -> check "should not find" false
+
+let test_leaves () =
+  let t = create ~root_label:"root" () in
+  let _ = expand t t.root.id ~labels:["A"; "B"] in
+  let ls = leaves t in
+  check "2 leaves (A, B)" (List.length ls = 2)
+
+let test_leaves_root_only () =
+  let t = create ~root_label:"root" () in
+  let ls = leaves t in
+  check "root is leaf" (List.length ls = 1);
+  check "leaf is root" ((List.hd ls).label = "root")
+
+let test_depth () =
+  let t = create ~root_label:"root" () in
+  let _ = expand t t.root.id ~labels:["L1"] in
+  let l1 = List.hd t.root.children in
+  let _ = expand t l1.id ~labels:["L2"] in
+  let l2 = List.hd l1.children in
+  check "root depth = 0" (depth t t.root.id = 0);
+  check "L1 depth = 1" (depth t l1.id = 1);
+  check "L2 depth = 2" (depth t l2.id = 2)
+
+(* ================================================================ *)
+(* Tests: Verdict helpers                                           *)
+(* ================================================================ *)
+
+let test_verdict_helpers () =
+  check "verdict_of_float 1.0 = Pass" (verdict_of_float 1.0 = Pass);
+  check "verdict_of_float 0.5 = Warn" (verdict_of_float 0.5 = Warn);
+  check "verdict_of_float 0.0 = Fail" (verdict_of_float 0.0 = Fail);
+  check "verdict_of_float 0.95 = Pass" (verdict_of_float 0.95 = Pass);
+  check "verdict_of_float 0.3 = Fail" (verdict_of_float 0.3 = Fail);
+  check "verdict_to_string Pass" (verdict_to_string Pass = "PASS");
+  check "verdict_to_string Warn" (verdict_to_string Warn = "WARN");
+  check "verdict_to_string Fail" (verdict_to_string Fail = "FAIL")
+
+let test_verdict_yojson_roundtrip () =
+  let check_rt v =
+    match verdict_of_yojson (verdict_to_yojson v) with
+    | Ok v2 -> v = v2
+    | Error _ -> false
+  in
+  check "Pass roundtrip" (check_rt Pass);
+  check "Warn roundtrip" (check_rt Warn);
+  check "Fail roundtrip" (check_rt Fail)
+
+(* ================================================================ *)
+(* Tests: Serialization                                             *)
+(* ================================================================ *)
+
+let test_to_yojson () =
+  let t = create ~root_label:"root" () in
+  let _ = expand t t.root.id ~labels:["A"] in
+  let json = to_yojson t in
+  match json with
+  | `Assoc fields ->
+    check "has root field" (List.mem_assoc "root" fields);
+    check "has node_count" (List.mem_assoc "node_count" fields);
+    check "has metrics" (List.mem_assoc "metrics" fields)
+  | _ -> check "should be Assoc" false
+
+let test_summary_yojson () =
+  let t = create ~root_label:"root" () in
+  let _ = expand t t.root.id ~labels:["A"; "B"] in
+  let a = List.hd t.root.children in
+  a.visit_count <- 5; a.total_reward <- 4.0;
+  let json = summary_to_yojson t in
+  match json with
+  | `Assoc fields ->
+    check "has best_path" (List.mem_assoc "best_path" fields);
+    check "has node_count" (List.mem_assoc "node_count" fields);
+    check "has leaf_count" (List.mem_assoc "leaf_count" fields)
+  | _ -> check "should be Assoc" false
+
+(* ================================================================ *)
+(* Tests: Full MCTS Cycle                                           *)
+(* ================================================================ *)
+
+let test_full_mcts_cycle () =
+  let t = create ~root_label:"Fix login bug" () in
+  (* Expand: 3 candidate approaches *)
+  let _ = expand t t.root.id
+    ~labels:["Regex validation"; "Schema parse"; "Token refresh"] in
+  (* Simulate each *)
+  let children = t.root.children in
+  let regex = List.nth children 0 in
+  let schema = List.nth children 1 in
+  let token = List.nth children 2 in
+  (* Regex: FAIL *)
+  let r1 = record_simulation t regex.id (make_sim Fail) in
+  (match r1 with Ok r -> backpropagate t regex.id r | _ -> ());
+  (* Schema: PASS *)
+  let r2 = record_simulation t schema.id (make_sim Pass) in
+  (match r2 with Ok r -> backpropagate t schema.id r | _ -> ());
+  (* Token: WARN *)
+  let r3 = record_simulation t token.id (make_sim Warn) in
+  (match r3 with Ok r -> backpropagate t token.id r | _ -> ());
+  (* Best path should go through schema (highest reward) *)
+  let path = best_path t in
+  check "best path length = 2" (List.length path = 2);
+  let best_leaf = List.nth path 1 in
+  check "best approach = Schema parse" (best_leaf.label = "Schema parse");
+  check "root visited 3 times" (t.root.visit_count = 3);
+  check "total_simulations = 3" (t.total_simulations = 3)
+
+(* ================================================================ *)
+(* Runner                                                           *)
+(* ================================================================ *)
+
+let () =
+  Printf.printf "=== MCTS Tree Tests ===\n%!";
+
+  run_test "create" test_create;
+  run_test "create custom C" test_create_custom_c;
+
+  run_test "expand" test_expand;
+  run_test "expand already expanded" test_expand_already_expanded;
+  run_test "expand not found" test_expand_not_found;
+  run_test "add_child (progressive widening)" test_add_child;
+
+  run_test "UCB1 unvisited first" test_ucb1_unvisited_first;
+  run_test "UCB1 exploitation (C=0)" test_ucb1_exploitation;
+  run_test "select_path" test_select_path;
+
+  run_test "record simulation" test_record_simulation;
+  run_test "record warn/fail" test_record_warn_fail;
+  run_test "record not found" test_record_not_found;
+
+  run_test "backpropagate" test_backpropagate;
+  run_test "backpropagate two levels" test_backpropagate_two_levels;
+
+  run_test "best path" test_best_path;
+  run_test "best child empty" test_best_child_empty;
+
+  run_test "prune" test_prune;
+  run_test "prune deep subtree" test_prune_deep_subtree;
+
+  run_test "find node" test_find_node;
+  run_test "find node missing" test_find_node_missing;
+  run_test "leaves" test_leaves;
+  run_test "leaves root only" test_leaves_root_only;
+  run_test "depth" test_depth;
+
+  run_test "verdict helpers" test_verdict_helpers;
+  run_test "verdict yojson roundtrip" test_verdict_yojson_roundtrip;
+
+  run_test "to_yojson" test_to_yojson;
+  run_test "summary_yojson" test_summary_yojson;
+
+  run_test "full MCTS cycle" test_full_mcts_cycle;
+
+  Printf.printf "\n=== Results: %d passed, %d failed ===\n%!" !pass_count !fail_count;
+  if !fail_count > 0 then exit 1

--- a/test/test_risc.ml
+++ b/test/test_risc.ml
@@ -15,6 +15,16 @@ open Masc_mcp
 let pass name = Printf.printf "  PASS %s\n%!" name
 let fail name msg = Printf.printf "  FAIL %s: %s\n%!" name msg; exit 1
 
+let dummy_model : Llm_client.model_spec = {
+  provider = Ollama;
+  model_id = "test-fast-model";
+  max_context = 4096;
+  api_url = "http://localhost:11434";
+  api_key_env = None;
+  cost_per_1k_input = 0.0;
+  cost_per_1k_output = 0.0;
+}
+
 (* ================================================================ *)
 (* risc_types.ml tests                                              *)
 (* ================================================================ *)
@@ -482,6 +492,73 @@ let test_tool_dispatch_unknown () =
   if ok then fail name "unknown tool should fail"
   else pass name
 
+let test_spec_start_advances_session () =
+  let name = "tool_spec_start_progression" in
+  let engine = Speculative_engine.create ~fast_model:dummy_model () in
+  let session = Result.get_ok
+    (Speculative_engine.branch engine
+       ~goal:"g" ~original_query:"q"
+       ~candidates:
+         [
+           Speculative_engine.{ label = "alpha"; prompt = "alpha"; metadata = `Null };
+           { label = "beta"; prompt = "beta"; metadata = `Null };
+         ]) in
+  let simulated = ref false in
+  let selected = ref false in
+  let ok, output =
+    Tool_risc.advance_spec_start
+      ~simulate:(fun engine spec_id ->
+        simulated := true;
+        match Speculative_engine.find_session engine spec_id with
+        | None -> Error "missing session"
+        | Some current ->
+          let outcomes = [
+            Speculative_engine.{
+              candidate_label = "alpha";
+              fast_response = "ok";
+              verdict = Mcts_tree.Pass;
+              verdict_reason = "ok";
+              latency_ms = 1;
+              cost_estimate = 0.0;
+            };
+            {
+              candidate_label = "beta";
+              fast_response = "no";
+              verdict = Mcts_tree.Fail;
+              verdict_reason = "bad";
+              latency_ms = 1;
+              cost_estimate = 0.0;
+            };
+          ] in
+          let updated = { current with state = Verifying; outcomes } in
+          Speculative_engine.update_session engine updated;
+          Ok updated)
+      ~select:(fun engine spec_id ->
+        selected := true;
+        match Speculative_engine.find_session engine spec_id with
+        | None -> Error "missing session"
+        | Some current ->
+          let updated =
+            { current with
+              state = Ready_to_commit;
+              best_candidate = Some "alpha";
+            }
+          in
+          Speculative_engine.update_session engine updated;
+          Ok updated)
+      engine session
+  in
+  if not ok then fail name ("advance_spec_start failed: " ^ output)
+  else if not !simulated then fail name "simulate stage not called"
+  else if not !selected then fail name "select stage not called"
+  else
+    let json = Yojson.Safe.from_string output in
+    let state = Yojson.Safe.Util.(json |> member "state" |> to_string) in
+    let best = Yojson.Safe.Util.(json |> member "best_candidate" |> to_string) in
+    if state <> "ready_to_commit" then fail name ("unexpected state: " ^ state)
+    else if best <> "alpha" then fail name ("unexpected best candidate: " ^ best)
+    else pass name
+
 let test_is_risc_tool () =
   let name = "is_risc_tool" in
   if not (Tool_risc.is_risc_tool "masc_risc_decode") then
@@ -600,6 +677,7 @@ let () =
   test_tool_dispatch_register ();
   test_tool_dispatch_decode ();
   test_tool_dispatch_unknown ();
+  test_spec_start_advances_session ();
   test_is_risc_tool ();
   test_tool_definitions_count ();
 
@@ -612,4 +690,4 @@ let () =
   test_hazard_to_string ();
   test_hazard_to_yojson ();
 
-  Printf.printf "\n=== All 35 SWARM-RISC tests passed ===\n"
+  Printf.printf "\n=== All 36 SWARM-RISC tests passed ===\n"

--- a/test/test_risc.ml
+++ b/test/test_risc.ml
@@ -493,8 +493,8 @@ let test_is_risc_tool () =
 let test_tool_definitions_count () =
   let name = "tool_definitions_count" in
   let count = List.length Tool_risc.tool_definitions in
-  if count <> 16 then
-    fail name (Printf.sprintf "expected 16 tool definitions, got %d" count)
+  if count <> 20 then
+    fail name (Printf.sprintf "expected 20 tool definitions, got %d" count)
   else pass name
 
 (* ================================================================ *)

--- a/test/test_speculative.ml
+++ b/test/test_speculative.ml
@@ -453,6 +453,87 @@ let () = run_test "select_best: wrong state" (fun () ->
   check "select_best on Branching state fails" (Result.is_error result);
 )
 
+let () = run_test "select_best: session-scoped MCTS choice" (fun () ->
+  let engine = make_engine ~min_confidence:0.4 () in
+  let global_session = Result.get_ok
+    (Speculative_engine.branch engine
+       ~goal:"g1" ~original_query:"q1"
+       ~candidates:(make_candidates ["global-best"; "global-bad"])) in
+  let global_outcomes = [
+    Speculative_engine.{
+      candidate_label = "global-best";
+      fast_response = "global";
+      verdict = Mcts_tree.Pass;
+      verdict_reason = "ok";
+      latency_ms = 1;
+      cost_estimate = 0.0;
+    };
+    {
+      candidate_label = "global-bad";
+      fast_response = "bad";
+      verdict = Mcts_tree.Fail;
+      verdict_reason = "bad";
+      latency_ms = 1;
+      cost_estimate = 0.0;
+    };
+  ] in
+  List.iter2 (fun child_id (outcome : Speculative_engine.simulation_outcome) ->
+    let sim : Mcts_tree.simulation_result = {
+      model_used = "test";
+      output = outcome.fast_response;
+      verdict = outcome.verdict;
+      latency_ms = float_of_int outcome.latency_ms;
+    } in
+    ignore (Mcts_tree.record_simulation engine.tree child_id sim);
+    Mcts_tree.backpropagate engine.tree child_id
+      (Mcts_tree.reward_of_verdict outcome.verdict)
+  ) global_session.child_node_ids global_outcomes;
+  Speculative_engine.update_session engine
+    { global_session with state = Verifying; outcomes = global_outcomes };
+  let local_session = Result.get_ok
+    (Speculative_engine.branch engine
+       ~goal:"g2" ~original_query:"q2"
+       ~candidates:(make_candidates ["local-best"; "local-bad"])) in
+  let local_outcomes = [
+    Speculative_engine.{
+      candidate_label = "local-best";
+      fast_response = "local";
+      verdict = Mcts_tree.Warn;
+      verdict_reason = "warn";
+      latency_ms = 1;
+      cost_estimate = 0.0;
+    };
+    {
+      candidate_label = "local-bad";
+      fast_response = "bad";
+      verdict = Mcts_tree.Fail;
+      verdict_reason = "bad";
+      latency_ms = 1;
+      cost_estimate = 0.0;
+    };
+  ] in
+  List.iter2 (fun child_id (outcome : Speculative_engine.simulation_outcome) ->
+    let sim : Mcts_tree.simulation_result = {
+      model_used = "test";
+      output = outcome.fast_response;
+      verdict = outcome.verdict;
+      latency_ms = float_of_int outcome.latency_ms;
+    } in
+    ignore (Mcts_tree.record_simulation engine.tree child_id sim);
+    Mcts_tree.backpropagate engine.tree child_id
+      (Mcts_tree.reward_of_verdict outcome.verdict)
+  ) local_session.child_node_ids local_outcomes;
+  Speculative_engine.update_session engine
+    { local_session with state = Verifying; outcomes = local_outcomes };
+  let selected =
+    Result.get_ok (Speculative_engine.select_best engine local_session.spec_id)
+  in
+  check "local session reaches Ready_to_commit"
+    (selected.state = Ready_to_commit);
+  check "best candidate stays local"
+    (selected.best_candidate = Some "local-best");
+)
+
 (* ================================================================ *)
 (* Tests: commit state check                                        *)
 (* ================================================================ *)

--- a/test/test_speculative.ml
+++ b/test/test_speculative.ml
@@ -350,28 +350,24 @@ let () = run_test "status: includes metrics and sessions" (fun () ->
 (* Tests: Session management                                        *)
 (* ================================================================ *)
 
-let () = run_test "multiple sessions tracked" (fun () ->
+let () = run_test "multiple sessions on same engine (progressive widening)" (fun () ->
   let engine = make_engine () in
-  (* Need separate engines since expand on root fails when root already has children *)
-  let engine1 = make_engine () in
-  let engine2 = make_engine () in
-  let c1 = make_candidates ["a1"] in
+  let c1 = make_candidates ["a1"; "a2"] in
   let c2 = make_candidates ["b1"] in
-  let s1 = Result.get_ok (Speculative_engine.branch engine1
+  let s1 = Result.get_ok (Speculative_engine.branch engine
     ~goal:"goal1" ~original_query:"q1" ~candidates:c1) in
-  let s2 = Result.get_ok (Speculative_engine.branch engine2
+  let s2 = Result.get_ok (Speculative_engine.branch engine
     ~goal:"goal2" ~original_query:"q2" ~candidates:c2) in
   check "session 1 exists" (s1.spec_id <> "");
   check "session 2 exists" (s2.spec_id <> "");
-  (* Different engines share counter namespace, so IDs may collide.
-     Just check both are valid spec-NNNN format. *)
-  check "spec_id format valid" (String.length s1.spec_id > 0 &&
-    String.length s2.spec_id > 0);
-
-  (* Also test on same engine — will fail because root already expanded *)
-  let _s_first = Result.get_ok (Speculative_engine.branch engine
-    ~goal:"g1" ~original_query:"q1" ~candidates:(make_candidates ["x"])) in
-  check "engine has 1 session" (List.length engine.sessions = 1);
+  check "different spec_ids" (s1.spec_id <> s2.spec_id);
+  check "engine has 2 sessions" (List.length engine.sessions = 2);
+  check "session 1 has 2 child_node_ids" (List.length s1.child_node_ids = 2);
+  check "session 2 has 1 child_node_id" (List.length s2.child_node_ids = 1);
+  (* Tree should have root + 2 (expand) + 1 (add_child) = 4 nodes *)
+  check "tree has 4 nodes" (engine.tree.node_count = 4);
+  check "root has 3 children total" (List.length engine.tree.root.children = 3);
+  check "total_speculations = 2" (engine.total_speculations = 2);
 )
 
 let () = run_test "tree accessor" (fun () ->
@@ -388,7 +384,7 @@ let () = run_test "tree accessor" (fun () ->
 let () = run_test "branch creates MCTS children" (fun () ->
   let engine = make_engine () in
   let candidates = make_candidates ["opt-1"; "opt-2"; "opt-3"] in
-  let _session = Result.get_ok (Speculative_engine.branch engine
+  let session = Result.get_ok (Speculative_engine.branch engine
     ~goal:"test" ~original_query:"q" ~candidates) in
   let tree = Speculative_engine.tree engine in
   check "tree has 4 nodes" (tree.node_count = 4);
@@ -399,6 +395,8 @@ let () = run_test "branch creates MCTS children" (fun () ->
     (List.mem "opt-1" child_labels
      && List.mem "opt-2" child_labels
      && List.mem "opt-3" child_labels);
+  (* child_node_ids should match tree children *)
+  check "3 child_node_ids" (List.length session.child_node_ids = 3);
 )
 
 (* ================================================================ *)

--- a/test/test_speculative.ml
+++ b/test/test_speculative.ml
@@ -1,0 +1,519 @@
+(** Test suite for Speculative_engine.
+
+    Tests pure functions (parse, serialize, state machine, branch/abort)
+    without requiring actual LLM calls.
+
+    @since 2.80.0 *)
+
+open Masc_mcp
+
+(* ================================================================ *)
+(* Test harness (same as test_mcts.ml)                              *)
+(* ================================================================ *)
+
+let passed = ref 0
+let failed = ref 0
+
+let check desc cond =
+  if cond then begin
+    incr passed;
+    Printf.printf "  \xE2\x9C\x93 %s\n" desc
+  end else begin
+    incr failed;
+    Printf.printf "  \xE2\x9C\x97 FAIL: %s\n" desc
+  end
+
+let run_test name f =
+  Printf.printf "\n\xE2\x94\x80\xE2\x94\x80\xE2\x94\x80 %s \xE2\x94\x80\xE2\x94\x80\xE2\x94\x80\n" name;
+  f ()
+
+(* ================================================================ *)
+(* Helpers                                                          *)
+(* ================================================================ *)
+
+(** Dummy model_spec for testing (no real LLM calls). *)
+let dummy_model : Llm_client.model_spec = {
+  provider = Ollama;
+  model_id = "test-fast-model";
+  max_context = 4096;
+  api_url = "http://localhost:11434";
+  api_key_env = None;
+  cost_per_1k_input = 0.001;
+  cost_per_1k_output = 0.002;
+}
+
+let make_engine ?(max_candidates = 4)
+                ?(semantic_guard_enabled = false)
+                ?(min_confidence = 0.6)
+                () =
+  Speculative_engine.create
+    ~fast_model:dummy_model
+    ~max_candidates
+    ~semantic_guard_enabled
+    ~min_confidence
+    ()
+
+let make_candidates labels =
+  List.map (fun label ->
+    Speculative_engine.{ label; prompt = "test prompt for " ^ label; metadata = `Null }
+  ) labels
+
+(* ================================================================ *)
+(* Tests: Engine creation                                           *)
+(* ================================================================ *)
+
+let () = run_test "engine creation" (fun () ->
+  let engine = make_engine () in
+  check "total_speculations = 0" (engine.total_speculations = 0);
+  check "total_commits = 0" (engine.total_commits = 0);
+  check "total_aborts = 0" (engine.total_aborts = 0);
+  check "total_fast_calls = 0" (engine.total_fast_calls = 0);
+  check "total_cost = 0.0" (engine.total_cost = 0.0);
+  check "sessions empty" (engine.sessions = []);
+  check "tree node_count = 1" (engine.tree.node_count = 1);
+)
+
+(* ================================================================ *)
+(* Tests: Branch                                                    *)
+(* ================================================================ *)
+
+let () = run_test "branch: valid candidates" (fun () ->
+  let engine = make_engine () in
+  let candidates = make_candidates ["approach-A"; "approach-B"; "approach-C"] in
+  let result = Speculative_engine.branch engine
+    ~goal:"test goal"
+    ~original_query:"test query"
+    ~candidates in
+  check "branch returns Ok" (Result.is_ok result);
+  let session = Result.get_ok result in
+  check "spec_id starts with spec-" (String.length session.spec_id >= 5
+    && String.sub session.spec_id 0 5 = "spec-");
+  check "state = Branching" (session.state = Branching);
+  check "3 candidates stored" (List.length session.candidates = 3);
+  check "no outcomes yet" (session.outcomes = []);
+  check "best_candidate is None" (session.best_candidate = None);
+  check "total_speculations incremented" (engine.total_speculations = 1);
+  check "tree has 4 nodes (root + 3)" (engine.tree.node_count = 4);
+)
+
+let () = run_test "branch: empty candidates" (fun () ->
+  let engine = make_engine () in
+  let result = Speculative_engine.branch engine
+    ~goal:"g" ~original_query:"q" ~candidates:[] in
+  check "returns Error" (Result.is_error result);
+  let err = Result.get_error result in
+  check "error mentions 'no candidates'" (String.length err > 0
+    && try ignore (Str.search_forward (Str.regexp "no candidates") err 0); true
+    with Not_found -> false);
+)
+
+let () = run_test "branch: too many candidates" (fun () ->
+  let engine = make_engine ~max_candidates:2 () in
+  let candidates = make_candidates ["a"; "b"; "c"] in
+  let result = Speculative_engine.branch engine
+    ~goal:"g" ~original_query:"q" ~candidates in
+  check "returns Error" (Result.is_error result);
+  let err = Result.get_error result in
+  check "error mentions 'too many'" (String.length err > 0
+    && try ignore (Str.search_forward (Str.regexp "too many") err 0); true
+    with Not_found -> false);
+)
+
+(* ================================================================ *)
+(* Tests: Abort                                                     *)
+(* ================================================================ *)
+
+let () = run_test "abort: from Branching state" (fun () ->
+  let engine = make_engine () in
+  let candidates = make_candidates ["x"; "y"] in
+  let session = Result.get_ok (Speculative_engine.branch engine
+    ~goal:"g" ~original_query:"q" ~candidates) in
+  let result = Speculative_engine.abort engine session.spec_id
+    ~reason:"user cancelled" in
+  check "abort returns Ok" (Result.is_ok result);
+  let aborted = Result.get_ok result in
+  (match aborted.state with
+   | Aborted reason ->
+     check "abort reason preserved" (reason = "user cancelled")
+   | _ -> check "state is Aborted" false);
+  check "completed_at is set" (aborted.completed_at <> None);
+  check "total_aborts incremented" (engine.total_aborts = 1);
+)
+
+let () = run_test "abort: already aborted" (fun () ->
+  let engine = make_engine () in
+  let candidates = make_candidates ["x"] in
+  let session = Result.get_ok (Speculative_engine.branch engine
+    ~goal:"g" ~original_query:"q" ~candidates) in
+  ignore (Speculative_engine.abort engine session.spec_id ~reason:"r1");
+  let result = Speculative_engine.abort engine session.spec_id ~reason:"r2" in
+  check "double abort returns Error" (Result.is_error result);
+)
+
+let () = run_test "abort: nonexistent session" (fun () ->
+  let engine = make_engine () in
+  let result = Speculative_engine.abort engine "spec-9999" ~reason:"r" in
+  check "returns Error" (Result.is_error result);
+)
+
+(* ================================================================ *)
+(* Tests: State machine                                             *)
+(* ================================================================ *)
+
+let () = run_test "state_to_string" (fun () ->
+  check "Idle" (Speculative_engine.state_to_string Idle = "idle");
+  check "Branching" (Speculative_engine.state_to_string Branching = "branching");
+  check "Simulating" (Speculative_engine.state_to_string Simulating = "simulating");
+  check "Verifying" (Speculative_engine.state_to_string Verifying = "verifying");
+  check "Ready_to_commit"
+    (Speculative_engine.state_to_string Ready_to_commit = "ready_to_commit");
+  check "Committed" (Speculative_engine.state_to_string Committed = "committed");
+  check "Aborted"
+    (Speculative_engine.state_to_string (Aborted "test") = "aborted: test");
+)
+
+(* ================================================================ *)
+(* Tests: Guard prompt building                                     *)
+(* ================================================================ *)
+
+let () = run_test "build_guard_prompt: short inputs" (fun () ->
+  let prompt = Speculative_engine.build_guard_prompt
+    ~original_query:"What is 2+2?"
+    ~candidate_label:"arithmetic"
+    ~fast_response:"The answer is 4." in
+  check "contains original query" (try
+    ignore (Str.search_forward (Str.regexp "What is 2") prompt 0); true
+  with Not_found -> false);
+  check "contains candidate label" (try
+    ignore (Str.search_forward (Str.regexp "arithmetic") prompt 0); true
+  with Not_found -> false);
+  check "contains INTENT criterion" (try
+    ignore (Str.search_forward (Str.regexp "INTENT") prompt 0); true
+  with Not_found -> false);
+  check "contains FORMAT criterion" (try
+    ignore (Str.search_forward (Str.regexp "FORMAT") prompt 0); true
+  with Not_found -> false);
+  check "contains SAFETY criterion" (try
+    ignore (Str.search_forward (Str.regexp "SAFETY") prompt 0); true
+  with Not_found -> false);
+)
+
+let () = run_test "build_guard_prompt: long inputs truncated" (fun () ->
+  let long_query = String.make 300 'x' in
+  let long_response = String.make 600 'y' in
+  let prompt = Speculative_engine.build_guard_prompt
+    ~original_query:long_query
+    ~candidate_label:"test"
+    ~fast_response:long_response in
+  check "query truncated (has ...)" (try
+    ignore (Str.search_forward (Str.regexp "\\.\\.\\.") prompt 0); true
+  with Not_found -> false);
+  (* Truncation happened — the 300-char query is not fully embedded verbatim *)
+  check "query not embedded verbatim" (not (try
+    ignore (Str.search_forward (Str.regexp (String.make 300 'x')) prompt 0); true
+  with Not_found -> false));
+)
+
+(* ================================================================ *)
+(* Tests: Guard response parsing                                    *)
+(* ================================================================ *)
+
+let () = run_test "parse_guard_response: all YES" (fun () ->
+  let text = "INTENT: YES\nFORMAT: YES\nSAFETY: YES\nREASON: looks good" in
+  let guard = Speculative_engine.parse_guard_response text in
+  check "intent_aligned" guard.intent_aligned;
+  check "format_compliant" guard.format_compliant;
+  check "side_effect_safe" guard.side_effect_safe;
+  check "reason parsed" (guard.reason = "looks good");
+)
+
+let () = run_test "parse_guard_response: mixed results" (fun () ->
+  let text = "INTENT: YES\nFORMAT: NO\nSAFETY: YES\nREASON: format wrong" in
+  let guard = Speculative_engine.parse_guard_response text in
+  check "intent_aligned" guard.intent_aligned;
+  check "format NOT compliant" (not guard.format_compliant);
+  check "side_effect_safe" guard.side_effect_safe;
+  check "reason parsed" (guard.reason = "format wrong");
+)
+
+let () = run_test "parse_guard_response: all NO" (fun () ->
+  let text = "INTENT: NO\nFORMAT: NO\nSAFETY: NO\nREASON: everything wrong" in
+  let guard = Speculative_engine.parse_guard_response text in
+  check "intent NOT aligned" (not guard.intent_aligned);
+  check "format NOT compliant" (not guard.format_compliant);
+  check "side_effect NOT safe" (not guard.side_effect_safe);
+)
+
+let () = run_test "parse_guard_response: missing REASON line" (fun () ->
+  let text = "INTENT: YES\nFORMAT: YES\nSAFETY: YES" in
+  let guard = Speculative_engine.parse_guard_response text in
+  check "intent_aligned" guard.intent_aligned;
+  check "reason is unparseable fallback" (guard.reason = "guard response unparseable");
+)
+
+let () = run_test "parse_guard_response: case insensitive" (fun () ->
+  let text = "  intent: YES  \n  format: yes  \n  safety: Yes\nreason: ok" in
+  let guard = Speculative_engine.parse_guard_response text in
+  check "intent_aligned" guard.intent_aligned;
+  check "format_compliant" guard.format_compliant;
+  check "side_effect_safe" guard.side_effect_safe;
+)
+
+let () = run_test "parse_guard_response: garbage input" (fun () ->
+  let text = "I don't understand the question." in
+  let guard = Speculative_engine.parse_guard_response text in
+  check "intent NOT aligned" (not guard.intent_aligned);
+  check "format NOT compliant" (not guard.format_compliant);
+  check "side_effect NOT safe" (not guard.side_effect_safe);
+)
+
+(* ================================================================ *)
+(* Tests: Serialization                                             *)
+(* ================================================================ *)
+
+let () = run_test "session_to_yojson" (fun () ->
+  let engine = make_engine () in
+  let candidates = make_candidates ["alpha"; "beta"] in
+  let session = Result.get_ok (Speculative_engine.branch engine
+    ~goal:"serialize test" ~original_query:"q" ~candidates) in
+  let json = Speculative_engine.session_to_yojson session in
+  let json_str = Yojson.Safe.to_string json in
+  check "contains spec_id" (try
+    ignore (Str.search_forward (Str.regexp "spec_id") json_str 0); true
+  with Not_found -> false);
+  check "contains goal" (try
+    ignore (Str.search_forward (Str.regexp "serialize test") json_str 0); true
+  with Not_found -> false);
+  check "state is branching" (try
+    ignore (Str.search_forward (Str.regexp "branching") json_str 0); true
+  with Not_found -> false);
+  check "num_candidates = 2" (try
+    ignore (Str.search_forward (Str.regexp "num_candidates") json_str 0); true
+  with Not_found -> false);
+)
+
+let () = run_test "outcome_to_yojson" (fun () ->
+  let outcome : Speculative_engine.simulation_outcome = {
+    candidate_label = "test-approach";
+    fast_response = "The result is 42.";
+    verdict = Mcts_tree.Pass;
+    verdict_reason = "correct answer";
+    latency_ms = 150;
+    cost_estimate = 0.0005;
+  } in
+  let json = Speculative_engine.outcome_to_yojson outcome in
+  let json_str = Yojson.Safe.to_string json in
+  check "contains candidate" (try
+    ignore (Str.search_forward (Str.regexp "test-approach") json_str 0); true
+  with Not_found -> false);
+  check "contains PASS verdict" (try
+    ignore (Str.search_forward (Str.regexp "PASS") json_str 0); true
+  with Not_found -> false);
+  check "contains latency_ms" (try
+    ignore (Str.search_forward (Str.regexp "150") json_str 0); true
+  with Not_found -> false);
+)
+
+let () = run_test "metrics_to_yojson: initial state" (fun () ->
+  let engine = make_engine () in
+  let json = Speculative_engine.metrics_to_yojson engine in
+  let json_str = Yojson.Safe.to_string json in
+  check "total_speculations present" (try
+    ignore (Str.search_forward (Str.regexp "total_speculations") json_str 0); true
+  with Not_found -> false);
+  check "commit_rate present" (try
+    ignore (Str.search_forward (Str.regexp "commit_rate") json_str 0); true
+  with Not_found -> false);
+  check "mcts_tree present" (try
+    ignore (Str.search_forward (Str.regexp "mcts_tree") json_str 0); true
+  with Not_found -> false);
+)
+
+let () = run_test "status: includes metrics and sessions" (fun () ->
+  let engine = make_engine () in
+  let candidates = make_candidates ["s1"; "s2"] in
+  ignore (Speculative_engine.branch engine ~goal:"g" ~original_query:"q" ~candidates);
+  let json = Speculative_engine.status engine in
+  let json_str = Yojson.Safe.to_string json in
+  check "has metrics key" (try
+    ignore (Str.search_forward (Str.regexp "metrics") json_str 0); true
+  with Not_found -> false);
+  check "has recent_sessions key" (try
+    ignore (Str.search_forward (Str.regexp "recent_sessions") json_str 0); true
+  with Not_found -> false);
+  check "has tree_summary key" (try
+    ignore (Str.search_forward (Str.regexp "tree_summary") json_str 0); true
+  with Not_found -> false);
+)
+
+(* ================================================================ *)
+(* Tests: Session management                                        *)
+(* ================================================================ *)
+
+let () = run_test "multiple sessions tracked" (fun () ->
+  let engine = make_engine () in
+  (* Need separate engines since expand on root fails when root already has children *)
+  let engine1 = make_engine () in
+  let engine2 = make_engine () in
+  let c1 = make_candidates ["a1"] in
+  let c2 = make_candidates ["b1"] in
+  let s1 = Result.get_ok (Speculative_engine.branch engine1
+    ~goal:"goal1" ~original_query:"q1" ~candidates:c1) in
+  let s2 = Result.get_ok (Speculative_engine.branch engine2
+    ~goal:"goal2" ~original_query:"q2" ~candidates:c2) in
+  check "session 1 exists" (s1.spec_id <> "");
+  check "session 2 exists" (s2.spec_id <> "");
+  (* Different engines share counter namespace, so IDs may collide.
+     Just check both are valid spec-NNNN format. *)
+  check "spec_id format valid" (String.length s1.spec_id > 0 &&
+    String.length s2.spec_id > 0);
+
+  (* Also test on same engine — will fail because root already expanded *)
+  let _s_first = Result.get_ok (Speculative_engine.branch engine
+    ~goal:"g1" ~original_query:"q1" ~candidates:(make_candidates ["x"])) in
+  check "engine has 1 session" (List.length engine.sessions = 1);
+)
+
+let () = run_test "tree accessor" (fun () ->
+  let engine = make_engine () in
+  let tree = Speculative_engine.tree engine in
+  check "tree is the engine's tree" (tree.node_count = 1);
+  check "tree root label is spec-root" (tree.root.label = "spec-root");
+)
+
+(* ================================================================ *)
+(* Tests: MCTS tree integration after branch                        *)
+(* ================================================================ *)
+
+let () = run_test "branch creates MCTS children" (fun () ->
+  let engine = make_engine () in
+  let candidates = make_candidates ["opt-1"; "opt-2"; "opt-3"] in
+  let _session = Result.get_ok (Speculative_engine.branch engine
+    ~goal:"test" ~original_query:"q" ~candidates) in
+  let tree = Speculative_engine.tree engine in
+  check "tree has 4 nodes" (tree.node_count = 4);
+  check "root has 3 children" (List.length tree.root.children = 3);
+  (* Children labels match candidate labels *)
+  let child_labels = List.map (fun (c : Mcts_tree.node) -> c.label) tree.root.children in
+  check "child labels match candidates"
+    (List.mem "opt-1" child_labels
+     && List.mem "opt-2" child_labels
+     && List.mem "opt-3" child_labels);
+)
+
+(* ================================================================ *)
+(* Tests: Config variations                                         *)
+(* ================================================================ *)
+
+let () = run_test "custom config" (fun () ->
+  let engine = Speculative_engine.create
+    ~fast_model:dummy_model
+    ~max_candidates:2
+    ~max_simulations:4
+    ~semantic_guard_enabled:true
+    ~min_confidence:0.8
+    ~verify_model:dummy_model
+    () in
+  check "config max_candidates = 2" (engine.config.max_candidates = 2);
+  check "config max_simulations = 4" (engine.config.max_simulations = 4);
+  check "config semantic_guard_enabled" engine.config.semantic_guard_enabled;
+  check "config min_confidence = 0.8" (engine.config.min_confidence = 0.8);
+  check "config verify_model is Some" (engine.config.verify_model <> None);
+)
+
+(* ================================================================ *)
+(* Tests: simulate_all state check                                  *)
+(* ================================================================ *)
+
+let () = run_test "simulate_all: wrong state" (fun () ->
+  let engine = make_engine () in
+  let candidates = make_candidates ["a"; "b"] in
+  let session = Result.get_ok (Speculative_engine.branch engine
+    ~goal:"g" ~original_query:"q" ~candidates) in
+  (* Abort it first, then try simulate *)
+  ignore (Speculative_engine.abort engine session.spec_id ~reason:"test");
+  let result = Speculative_engine.simulate_all engine session.spec_id in
+  check "simulate on aborted session fails" (Result.is_error result);
+)
+
+let () = run_test "simulate_all: nonexistent session" (fun () ->
+  let engine = make_engine () in
+  let result = Speculative_engine.simulate_all engine "spec-9999" in
+  check "returns Error" (Result.is_error result);
+)
+
+(* ================================================================ *)
+(* Tests: select_best state check                                   *)
+(* ================================================================ *)
+
+let () = run_test "select_best: wrong state" (fun () ->
+  let engine = make_engine () in
+  let candidates = make_candidates ["a"] in
+  let session = Result.get_ok (Speculative_engine.branch engine
+    ~goal:"g" ~original_query:"q" ~candidates) in
+  let result = Speculative_engine.select_best engine session.spec_id in
+  check "select_best on Branching state fails" (Result.is_error result);
+)
+
+(* ================================================================ *)
+(* Tests: commit state check                                        *)
+(* ================================================================ *)
+
+let () = run_test "commit: wrong state" (fun () ->
+  let engine = make_engine () in
+  let candidates = make_candidates ["a"] in
+  let session = Result.get_ok (Speculative_engine.branch engine
+    ~goal:"g" ~original_query:"q" ~candidates) in
+  let result = Speculative_engine.commit engine session.spec_id in
+  check "commit on Branching state fails" (Result.is_error result);
+)
+
+let () = run_test "commit: nonexistent session" (fun () ->
+  let engine = make_engine () in
+  let result = Speculative_engine.commit engine "spec-9999" in
+  check "returns Error" (Result.is_error result);
+)
+
+(* ================================================================ *)
+(* Tests: abort on committed (should fail)                          *)
+(* ================================================================ *)
+
+(* Cannot test commit→abort without LLM, but we can test double-abort *)
+let () = run_test "abort: double abort idempotency" (fun () ->
+  let engine = make_engine () in
+  let candidates = make_candidates ["a"] in
+  let session = Result.get_ok (Speculative_engine.branch engine
+    ~goal:"g" ~original_query:"q" ~candidates) in
+  let _first = Speculative_engine.abort engine session.spec_id ~reason:"r1" in
+  let second = Speculative_engine.abort engine session.spec_id ~reason:"r2" in
+  check "second abort returns Error" (Result.is_error second);
+  check "total_aborts = 1 (not 2)" (engine.total_aborts = 1);
+)
+
+(* ================================================================ *)
+(* Tests: Metrics after operations                                  *)
+(* ================================================================ *)
+
+let () = run_test "metrics after branch + abort" (fun () ->
+  let engine = make_engine () in
+  let candidates = make_candidates ["a"; "b"] in
+  let session = Result.get_ok (Speculative_engine.branch engine
+    ~goal:"g" ~original_query:"q" ~candidates) in
+  ignore (Speculative_engine.abort engine session.spec_id ~reason:"test");
+  check "total_speculations = 1" (engine.total_speculations = 1);
+  check "total_aborts = 1" (engine.total_aborts = 1);
+  check "total_commits = 0" (engine.total_commits = 0);
+  let json = Speculative_engine.metrics_to_yojson engine in
+  let json_str = Yojson.Safe.to_string json in
+  check "commit_rate = 0" (try
+    ignore (Str.search_forward (Str.regexp "commit_rate.*0") json_str 0); true
+  with Not_found -> false);
+)
+
+(* ================================================================ *)
+(* Report                                                           *)
+(* ================================================================ *)
+
+let () =
+  Printf.printf "\n=== Results: %d passed, %d failed ===\n" !passed !failed;
+  if !failed > 0 then exit 1


### PR DESCRIPTION
## Summary

SWARM-RISC Phase 4: CPU 아키텍처의 투기적 실행(Speculative Execution) 원리를 에이전트 조율에 적용.

- **mcts_tree.ml** (408 lines): UCB1 선택, 확장, 시뮬레이션 기록, 역전파를 지원하는 persistent MCTS 트리
- **speculative_engine.ml** (599 lines): branch → simulate → verify → commit/abort 상태 머신 + semantic guard (intent/format/side-effect 3축 검증)
- **tool_risc.ml**: 4개 MCP tool 추가 (`spec_start`, `spec_status`, `spec_commit`, `spec_abort`)

### Architecture

```
              MCTS Controller
              (UCB1 selection)
                    │
        ┌───────────┼───────────┐
        │           │           │
   Branch A    Branch B    Branch C
   fast LLM    fast LLM    fast LLM
        │           │           │
   Verify      Verify      Verify
   (guard)     (guard)     (guard)
        └─────┬─────┘───────────┘
              ▼
       Best path COMMIT or ABORT
```

### Key Design Decisions

- **Semantic Guard**: 3-criteria check (intent alignment, format compliance, side-effect safety) before committing speculative results
- **MCTS + UCB1**: `C = √2` exploration constant, verdict-based rewards (Pass=1.0, Warn=0.5, Fail=0.0)
- **State Machine**: `Idle → Branching → Simulating → Verifying → Ready_to_commit → Committed/Aborted`
- **Global singleton**: Same pattern as Phase 1-3 (pipeline registry, coherence controller, scheduler)

## Test plan

- [x] mcts_tree: 81 assertions (tree operations, UCB1 selection, backpropagation, serialization)
- [x] speculative_engine: 96 assertions (state machine, branch/abort, guard prompt/response parsing, serialization)
- [x] test_risc: tool_definitions_count updated 16 → 20
- [x] No regression on existing SWARM-RISC tests (Phase 1-3)
- [ ] MDAL test failures are pre-existing on main (unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)