### PR TITLE
feat(team-session): add local64 routing visibility and soak checks

### DIFF
--- a/lib/local_runtime_pool.ml
+++ b/lib/local_runtime_pool.ml
@@ -313,6 +313,15 @@ let preference_matches (runtime : runtime) preferred_pool =
       || String.equal preferred "default"
       || String.equal runtime.id preferred
 
+let runtime_matches_requested_model (runtime : runtime) requested_model =
+  match trim_opt requested_model with
+  | None -> `Any
+  | Some requested -> (
+      match runtime.model with
+      | Some configured when String.equal configured requested -> `Exact
+      | None -> `Generic
+      | Some _ -> `Mismatch)
+
 let runtime_sort_key (runtime : runtime) =
   let overload = max 0 (runtime.active_slots - runtime.max_concurrency) in
   let latency =
@@ -321,7 +330,7 @@ let runtime_sort_key (runtime : runtime) =
   (overload, runtime.active_slots, latency, runtime.failure_streak, runtime.id)
 
 (* Pure selection — no side effects, no Eio calls. *)
-let select_runtime_from (runtimes : runtime list) ?preferred_pool () :
+let select_runtime_from (runtimes : runtime list) ?preferred_pool ?model_name () :
     (runtime, string) result =
   let matching =
     List.filter (fun runtime -> preference_matches runtime preferred_pool) runtimes
@@ -330,6 +339,44 @@ let select_runtime_from (runtimes : runtime list) ?preferred_pool () :
   match matching with
   | [] -> Error "no local llama runtimes configured"
   | runtimes ->
+      let requested_model = trim_opt model_name in
+      let exact_model_matches =
+        List.filter
+          (fun runtime ->
+            match runtime_matches_requested_model runtime requested_model with
+            | `Exact -> true
+            | _ -> false)
+          runtimes
+      in
+      let generic_model_matches =
+        List.filter
+          (fun runtime ->
+            match runtime_matches_requested_model runtime requested_model with
+            | `Generic -> true
+            | _ -> false)
+          runtimes
+      in
+      let candidate_runtimes_result =
+        match requested_model with
+        | None -> Ok runtimes
+        | Some requested -> (
+            match exact_model_matches with
+            | _ :: _ -> Ok exact_model_matches
+            | [] -> (
+                match generic_model_matches with
+                | _ :: _ -> Ok generic_model_matches
+                | [] ->
+                    let scope =
+                      match trim_opt preferred_pool with
+                      | Some pool -> sprintf " in runtime pool %s" pool
+                      | None -> ""
+                    in
+                    Error
+                      (sprintf
+                         "no local llama runtime configured for model %s%s"
+                         requested scope)))
+      in
+      let* runtimes = candidate_runtimes_result in
       let now = Time_compat.now () in
       let healthy =
         List.filter
@@ -340,15 +387,23 @@ let select_runtime_from (runtimes : runtime list) ?preferred_pool () :
           runtimes
       in
       let candidates = if healthy = [] then runtimes else healthy in
-      let sorted = List.sort (fun a b -> compare (runtime_sort_key a) (runtime_sort_key b)) candidates in
+      let sorted =
+        List.sort (fun a b -> compare (runtime_sort_key a) (runtime_sort_key b))
+          candidates
+      in
       match sorted with
       | runtime :: _ -> Ok runtime
-      | [] -> Error "no local llama runtimes configured"
+      | [] -> (
+          match requested_model with
+          | Some requested ->
+              Error
+                (sprintf "no local llama runtime configured for model %s" requested)
+          | None -> Error "no local llama runtimes configured")
 
 (* Backward-compatible wrapper that loads from env first. *)
-let select_runtime ?preferred_pool () =
+let select_runtime ?preferred_pool ?model_name () =
   ensure_loaded ();
-  select_runtime_from (!pool).runtimes ?preferred_pool ()
+  select_runtime_from (!pool).runtimes ?preferred_pool ?model_name ()
 
 (* acquire: ensure_loaded may yield (Eio.traceln inside debug_log).
    After that, reading !pool and swapping pool := are yield-free. *)
@@ -356,7 +411,7 @@ let acquire ?preferred_pool ~model_name () =
   ensure_loaded ();
   (* --- yield-free critical section --- *)
   let state : pool_state = !pool in
-  let* runtime = select_runtime_from state.runtimes ?preferred_pool () in
+  let* runtime = select_runtime_from state.runtimes ?preferred_pool ?model_name () in
   let* model_name = model_name_for_runtime runtime model_name in
   let updated = { runtime with
     active_slots = runtime.active_slots + 1;

--- a/lib/operator_control.ml
+++ b/lib/operator_control.ml
@@ -150,6 +150,11 @@ type worker_card = {
   parent_actor : string option;
   capsule_mode : string option;
   runtime_pool : string option;
+  model_tier : string option;
+  task_profile : string option;
+  risk_level : string option;
+  routing_confidence : float option;
+  routing_reason : string option;
   status : string;
   turn_count : int;
   empty_note_turn_count : int;
@@ -168,6 +173,9 @@ type session_digest = {
   last_turn_age_sec : int option;
   worker_class_counts : Yojson.Safe.t;
   runtime_pool_counts : Yojson.Safe.t;
+  tier_counts : Yojson.Safe.t;
+  task_profile_counts : Yojson.Safe.t;
+  escalation_count : int;
   local_runtime : Yojson.Safe.t;
   attention_items : attention_item list;
   recommended_actions : recommended_action list;
@@ -663,6 +671,12 @@ let worker_card_to_yojson (card : worker_card) =
       ("parent_actor", string_option_to_json card.parent_actor);
       ("capsule_mode", string_option_to_json card.capsule_mode);
       ("runtime_pool", string_option_to_json card.runtime_pool);
+      ("model_tier", string_option_to_json card.model_tier);
+      ("task_profile", string_option_to_json card.task_profile);
+      ("risk_level", string_option_to_json card.risk_level);
+      ( "routing_confidence",
+        option_to_json (fun value -> `Float value) card.routing_confidence );
+      ("routing_reason", string_option_to_json card.routing_reason);
       ("status", `String card.status);
       ("turn_count", `Int card.turn_count);
       ("empty_note_turn_count", `Int card.empty_note_turn_count);
@@ -729,6 +743,24 @@ let spawn_batch_stub_of_cards (cards : worker_card list) =
                      ("runtime_pool", `String runtime_pool) :: fields
                  | _ -> fields
                in
+               let fields =
+                 match card.model_tier with
+                 | Some model_tier when String.trim model_tier <> "" ->
+                     ("model_tier", `String model_tier) :: fields
+                 | _ -> fields
+               in
+               let fields =
+                 match card.task_profile with
+                 | Some task_profile when String.trim task_profile <> "" ->
+                     ("task_profile", `String task_profile) :: fields
+                 | _ -> fields
+               in
+               let fields =
+                 match card.risk_level with
+                 | Some risk_level when String.trim risk_level <> "" ->
+                     ("risk_level", `String risk_level) :: fields
+                 | _ -> fields
+               in
                Some (`Assoc (List.rev fields)))
   in
   `Assoc [ ("spawn_batch", `List items) ]
@@ -744,6 +776,23 @@ let aggregate_runtime_pool_counts (sessions : Team_session_types.session list) =
   |> List.concat_map (fun (session : Team_session_types.session) -> session.planned_workers)
   |> Team_session_types.runtime_pool_counts
   |> Team_session_types.counts_to_json
+
+let aggregate_tier_counts (sessions : Team_session_types.session list) =
+  sessions
+  |> List.concat_map (fun (session : Team_session_types.session) -> session.planned_workers)
+  |> Team_session_types.model_tier_counts
+  |> Team_session_types.counts_to_json
+
+let aggregate_task_profile_counts (sessions : Team_session_types.session list) =
+  sessions
+  |> List.concat_map (fun (session : Team_session_types.session) -> session.planned_workers)
+  |> Team_session_types.task_profile_counts
+  |> Team_session_types.counts_to_json
+
+let aggregate_escalation_count (sessions : Team_session_types.session list) =
+  sessions
+  |> List.concat_map (fun (session : Team_session_types.session) -> session.planned_workers)
+  |> Team_session_types.escalation_count
 
 let aggregated_local_runtime_json (sessions : Team_session_types.session list) =
   if
@@ -777,6 +826,9 @@ let session_card_to_yojson ~actor (digest : session_digest) =
       ("last_turn_age_sec", option_to_json (fun v -> `Int v) digest.last_turn_age_sec);
       ("worker_class_counts", digest.worker_class_counts);
       ("runtime_pool_counts", digest.runtime_pool_counts);
+      ("tier_counts", digest.tier_counts);
+      ("task_profile_counts", digest.task_profile_counts);
+      ("escalation_count", `Int digest.escalation_count);
       ("local_runtime", digest.local_runtime);
       ("attention_count", `Int (List.length digest.attention_items));
       ("top_attention", option_to_json attention_item_to_yojson top_attention);
@@ -941,14 +993,36 @@ let build_worker_cards ~(session : Team_session_types.session) ~(events : Yojson
                worker.parent_actor,
                Option.map Team_session_types.capsule_mode_to_string
                  worker.capsule_mode,
-               worker.runtime_pool ))
+               worker.runtime_pool,
+               Option.map Team_session_types.model_tier_to_string
+                 worker.model_tier,
+               Option.map Team_session_types.task_profile_to_string
+                 worker.task_profile,
+               Option.map Team_session_types.risk_level_to_string
+                 worker.risk_level,
+               worker.routing_confidence,
+               worker.routing_reason ))
     else
       session.agent_names
-      |> List.map (fun actor -> (Some actor, None, None, None, None, None, None, None))
+      |> List.map (fun actor ->
+             (Some actor, None, None, None, None, None, None, None, None, None, None, None, None))
   in
   worker_keys
-  |> List.map (fun (actor, spawn_agent, spawn_role, spawn_model, worker_class,
-                    parent_actor, capsule_mode, runtime_pool) ->
+  |> List.map
+       (fun
+         ( actor,
+           spawn_agent,
+           spawn_role,
+           spawn_model,
+           worker_class,
+           parent_actor,
+           capsule_mode,
+           runtime_pool,
+           model_tier,
+           task_profile,
+           risk_level,
+           routing_confidence,
+           routing_reason ) ->
          let turn_count =
            match actor with
            | Some value -> turn_count_by_actor events value
@@ -983,6 +1057,11 @@ let build_worker_cards ~(session : Team_session_types.session) ~(events : Yojson
            parent_actor;
            capsule_mode;
            runtime_pool;
+           model_tier;
+           task_profile;
+           risk_level;
+           routing_confidence;
+           routing_reason;
            status;
            turn_count;
            empty_note_turn_count;
@@ -1371,6 +1450,23 @@ let build_session_digest config (session : Team_session_types.session) ~now =
       | _ ->
           Team_session_types.runtime_pool_counts session.planned_workers
           |> Team_session_types.counts_to_json);
+    tier_counts =
+      (match U.member "tier_counts" summary with
+      | `Assoc _ as json -> json
+      | _ ->
+          Team_session_types.model_tier_counts session.planned_workers
+          |> Team_session_types.counts_to_json);
+    task_profile_counts =
+      (match U.member "task_profile_counts" summary with
+      | `Assoc _ as json -> json
+      | _ ->
+          Team_session_types.task_profile_counts session.planned_workers
+          |> Team_session_types.counts_to_json);
+    escalation_count =
+      (match U.member "escalation_count" summary with
+      | `Int value -> value
+      | `Intlit raw -> (try int_of_string raw with _ -> 0)
+      | _ -> Team_session_types.escalation_count session.planned_workers);
     local_runtime =
       (match U.member "local_runtime" status_json with
       | `Assoc _ as json -> json
@@ -1496,6 +1592,9 @@ let snapshot_json ?actor ?view ?(include_messages = true) ?(include_sessions = t
        ("swarm_status", swarm_status_json);
        ("role_census", aggregate_worker_class_counts tracked_sessions);
        ("runtime_pools", aggregate_runtime_pool_counts tracked_sessions);
+       ("model_tiers", aggregate_tier_counts tracked_sessions);
+       ("task_profiles", aggregate_task_profile_counts tracked_sessions);
+       ("escalation_count", `Int (aggregate_escalation_count tracked_sessions));
        ("local_runtime", aggregated_local_runtime_json tracked_sessions);
        ("recent_messages", if initialized && include_messages then recent_messages_json config else `List []);
        ("pending_confirms", pending_confirms_json ?actor config);
@@ -1561,6 +1660,9 @@ let digest_json ?actor ?target_type ?target_id ?include_workers (ctx : 'a contex
               ("swarm_status", swarm_status_json);
               ("role_census", aggregate_worker_class_counts tracked_sessions);
               ("runtime_pools", aggregate_runtime_pool_counts tracked_sessions);
+              ("model_tiers", aggregate_tier_counts tracked_sessions);
+              ("task_profiles", aggregate_task_profile_counts tracked_sessions);
+              ("escalation_count", `Int (aggregate_escalation_count tracked_sessions));
               ("local_runtime", aggregated_local_runtime_json tracked_sessions);
               ("attention_items", `List (List.map attention_item_to_yojson attention_items));
               ( "recommended_actions",

--- a/lib/team_session_engine_eio.ml
+++ b/lib/team_session_engine_eio.ml
@@ -229,6 +229,20 @@ let summary_json_of_session (config : Room.config)
     Team_session_types.runtime_pool_counts session.planned_workers
     |> Team_session_types.counts_to_json
   in
+  let tier_counts =
+    Team_session_types.model_tier_counts session.planned_workers
+    |> Team_session_types.counts_to_json
+  in
+  let task_profile_counts =
+    Team_session_types.task_profile_counts session.planned_workers
+    |> Team_session_types.counts_to_json
+  in
+  let escalation_count =
+    Team_session_types.escalation_count session.planned_workers
+  in
+  let routing_reason_summary =
+    Team_session_types.routing_reason_summary session.planned_workers
+  in
   `Assoc
     [
       ("session_id", `String session.session_id);
@@ -251,6 +265,11 @@ let summary_json_of_session (config : Room.config)
         `List (List.map (fun a -> `String a) planned_participants) );
       ("worker_class_counts", worker_class_counts);
       ("runtime_pool_counts", runtime_pool_counts);
+      ("tier_counts", tier_counts);
+      ("task_profile_counts", task_profile_counts);
+      ("escalation_count", `Int escalation_count);
+      ( "routing_reason_summary",
+        `List (List.map (fun reason -> `String reason) routing_reason_summary) );
       ("room_active_agents", `List (List.map (fun a -> `String a) room_active_agents));
       ( "last_checkpoint_at",
         Option.fold ~none:`Null ~some:(fun v -> `Float v)

--- a/lib/team_session_report.ml
+++ b/lib/team_session_report.ml
@@ -152,6 +152,18 @@ let recent_event_lines events limit =
              Some (Printf.sprintf "- %s | %s" ts_iso event_type)
          | _ -> None)
 
+let count_assoc_lines json =
+  match json with
+  | `Assoc fields ->
+      fields
+      |> List.sort (fun (a, _) (b, _) -> String.compare a b)
+      |> List.filter_map (fun (key, value) ->
+             match value with
+             | `Int count -> Some (Printf.sprintf "- %s: %d" key count)
+             | `Intlit raw -> Some (Printf.sprintf "- %s: %s" key raw)
+             | _ -> None)
+  | _ -> []
+
 let turn_counts_by_agent events =
   let tbl = Hashtbl.create 16 in
   List.iter
@@ -367,6 +379,20 @@ let markdown_of_report ~(session : Team_session_types.session)
     | `List xs -> xs
     | _ -> []
   in
+  let tier_counts = summary_json |> member "tier_counts" in
+  let task_profile_counts = summary_json |> member "task_profile_counts" in
+  let escalation_count =
+    summary_json |> member "escalation_count" |> to_int_option
+    |> Option.value ~default:0
+  in
+  let routing_reason_summary =
+    match summary_json |> member "routing_reason_summary" with
+    | `List xs ->
+        xs
+        |> List.filter_map Yojson.Safe.Util.to_string_option
+        |> List.filter (fun value -> String.trim value <> "")
+    | _ -> []
+  in
   let health_required =
     team_health_json |> member "required_agents" |> to_int_option
     |> Option.value ~default:0
@@ -517,6 +543,8 @@ let markdown_of_report ~(session : Team_session_types.session)
            item |> to_string_option |> Option.value ~default:"(unknown)")
     |> List.map (fun actor -> Printf.sprintf "- %s" actor)
   in
+  let tier_count_lines = count_assoc_lines tier_counts in
+  let task_profile_count_lines = count_assoc_lines task_profile_counts in
   let policy_lines =
     [
       Printf.sprintf "- Orchestration mode: %s"
@@ -605,6 +633,19 @@ let markdown_of_report ~(session : Team_session_types.session)
       Printf.sprintf "- LLM cache bypass/errors: %d/%d" llm_cache_bypass
         llm_cache_errors;
       Printf.sprintf "- LLM cache hit rate: %.3f" llm_cache_hit_rate;
+      "";
+      "## Routing Distribution";
+      Printf.sprintf "- Escalation count: %d" escalation_count;
+      (if tier_count_lines = [] then "- Model tiers: (not recorded)"
+       else String.concat "\n" tier_count_lines);
+      (if task_profile_count_lines = [] then "- Task profiles: (not recorded)"
+       else String.concat "\n" task_profile_count_lines);
+      (if routing_reason_summary = [] then "- Routing rationale summary: (not recorded)"
+       else
+         String.concat "\n"
+           (List.map
+              (fun reason -> Printf.sprintf "- %s" reason)
+              routing_reason_summary));
       "";
       "## Team Activity Timeline";
       (if event_lines = [] then
@@ -717,6 +758,22 @@ let generate config (session : Team_session_types.session) :
                 ("spawn_failure_count", `Int spawn_failure_count);
                 ("detached_agent_count", `Int detached_agent_count);
                 ("empty_note_turn_count", `Int empty_note_turn_count);
+                ( "tier_counts",
+                  match Yojson.Safe.Util.member "tier_counts" summary_json with
+                  | `Assoc _ as json -> json
+                  | _ -> `Assoc [] );
+                ( "task_profile_counts",
+                  match Yojson.Safe.Util.member "task_profile_counts" summary_json with
+                  | `Assoc _ as json -> json
+                  | _ -> `Assoc [] );
+                ( "escalation_count",
+                  match Yojson.Safe.Util.member "escalation_count" summary_json with
+                  | `Int _ as json -> json
+                  | _ -> `Int 0 );
+                ( "routing_reason_summary",
+                  match Yojson.Safe.Util.member "routing_reason_summary" summary_json with
+                  | `List _ as json -> json
+                  | _ -> `List [] );
               ] );
         ]
     in
@@ -1235,8 +1292,34 @@ let proof_markdown ~(session : Team_session_types.session)
              Option.value ~default:"(pending)"
                (Option.map String.trim worker.Team_session_types.runtime_actor)
            in
-           Printf.sprintf "- %s | role=%s | model=%s | runtime_actor=%s"
-             worker.Team_session_types.spawn_agent role model actor)
+           let tier =
+             Option.value ~default:"(unspecified)"
+               (Option.map Team_session_types.model_tier_to_string
+                  worker.Team_session_types.model_tier)
+           in
+           let profile =
+             Option.value ~default:"(unspecified)"
+               (Option.map Team_session_types.task_profile_to_string
+                  worker.Team_session_types.task_profile)
+           in
+           let risk =
+             Option.value ~default:"(unspecified)"
+               (Option.map Team_session_types.risk_level_to_string
+                  worker.Team_session_types.risk_level)
+           in
+           let confidence =
+             match worker.Team_session_types.routing_confidence with
+             | Some value -> Printf.sprintf "%.2f" value
+             | None -> "(unspecified)"
+           in
+           let reason =
+             Option.value ~default:"(not recorded)"
+               worker.Team_session_types.routing_reason
+           in
+           Printf.sprintf
+             "- %s | role=%s | model=%s | runtime_actor=%s | tier=%s | profile=%s | risk=%s | confidence=%s | reason=%s"
+             worker.Team_session_types.spawn_agent role model actor tier
+             profile risk confidence reason)
   in
   let failed_spawn_lines =
     failed_spawn_roster
@@ -1312,10 +1395,28 @@ let proof_markdown ~(session : Team_session_types.session)
       Printf.sprintf "- Failed spawn events: %d" spawn_failure_count;
       Printf.sprintf "- Detached failed actors: %d" detached_agent_count;
       Printf.sprintf "- Empty note turns: %d" empty_note_turn_count;
+      Printf.sprintf "- Escalations: %d"
+        (Team_session_types.escalation_count planned_workers);
       Printf.sprintf "- Spawn models: %s"
         (match spawn_models with
         | [] -> "(not recorded)"
-        | xs -> String.concat ", " xs);
+       | xs -> String.concat ", " xs);
+      Printf.sprintf "- Model tier counts: %s"
+        (let pairs = Team_session_types.model_tier_counts planned_workers in
+         if pairs = [] then
+           "(not recorded)"
+         else
+           pairs
+           |> List.map (fun (key, count) -> Printf.sprintf "%s=%d" key count)
+           |> String.concat ", ");
+      Printf.sprintf "- Task profile counts: %s"
+        (let pairs = Team_session_types.task_profile_counts planned_workers in
+         if pairs = [] then
+           "(not recorded)"
+         else
+           pairs
+           |> List.map (fun (key, count) -> Printf.sprintf "%s=%d" key count)
+           |> String.concat ", ");
       Printf.sprintf "- Model selection rationale: %s"
         (match spawn_selection_note_summary with
         | Some note -> note
@@ -1507,6 +1608,21 @@ let generate_proof ?(proof_level = default_proof_level) config
                 ( "spawn_selection_note_summary",
                   Option.fold ~none:`Null ~some:(fun note -> `String note)
                     spawn_selection_note_summary );
+                ( "tier_counts",
+                  Team_session_types.model_tier_counts session.planned_workers
+                  |> Team_session_types.counts_to_json );
+                ( "task_profile_counts",
+                  Team_session_types.task_profile_counts session.planned_workers
+                  |> Team_session_types.counts_to_json );
+                ( "escalation_count",
+                  `Int
+                    (Team_session_types.escalation_count session.planned_workers) );
+                ( "routing_reason_summary",
+                  `List
+                    (List.map
+                       (fun reason -> `String reason)
+                       (Team_session_types.routing_reason_summary
+                          session.planned_workers)) );
                 ("detached_agent_count", `Int detached_agent_count);
                 ("detached_actor_roster", `List detached_actor_roster);
                 ("vote_events", `Int vote_events);

--- a/lib/team_session_types.ml
+++ b/lib/team_session_types.ml
@@ -64,6 +64,23 @@ type worker_class =
   | Worker_librarian
   | Worker_metacog
 
+type model_tier =
+  | Tier_35b
+  | Tier_9b
+
+type task_profile =
+  | Profile_extract
+  | Profile_normalize
+  | Profile_summarize
+  | Profile_verify
+  | Profile_decide
+  | Profile_synthesize
+
+type risk_level =
+  | Risk_low
+  | Risk_medium
+  | Risk_high
+
 type capsule_mode =
   | Capsule_fresh
   | Capsule_inherit
@@ -78,6 +95,12 @@ type planned_worker = {
   parent_actor : string option;
   capsule_mode : capsule_mode option;
   runtime_pool : string option;
+  model_tier : model_tier option;
+  task_profile : task_profile option;
+  risk_level : risk_level option;
+  routing_confidence : float option;
+  routing_reason : string option;
+  routing_escalated : bool;
 }
 
 type session = {
@@ -283,6 +306,43 @@ let worker_class_of_string = function
   | "metacog" -> Some Worker_metacog
   | _ -> None
 
+let model_tier_to_string = function
+  | Tier_35b -> "35b"
+  | Tier_9b -> "9b"
+
+let model_tier_of_string = function
+  | "35b" -> Some Tier_35b
+  | "9b" -> Some Tier_9b
+  | _ -> None
+
+let task_profile_to_string = function
+  | Profile_extract -> "extract"
+  | Profile_normalize -> "normalize"
+  | Profile_summarize -> "summarize"
+  | Profile_verify -> "verify"
+  | Profile_decide -> "decide"
+  | Profile_synthesize -> "synthesize"
+
+let task_profile_of_string = function
+  | "extract" -> Some Profile_extract
+  | "normalize" -> Some Profile_normalize
+  | "summarize" -> Some Profile_summarize
+  | "verify" -> Some Profile_verify
+  | "decide" -> Some Profile_decide
+  | "synthesize" -> Some Profile_synthesize
+  | _ -> None
+
+let risk_level_to_string = function
+  | Risk_low -> "low"
+  | Risk_medium -> "medium"
+  | Risk_high -> "high"
+
+let risk_level_of_string = function
+  | "low" -> Some Risk_low
+  | "medium" -> Some Risk_medium
+  | "high" -> Some Risk_high
+  | _ -> None
+
 let capsule_mode_to_string = function
   | Capsule_fresh -> "fresh"
   | Capsule_inherit -> "inherit"
@@ -318,6 +378,12 @@ let planned_worker_key (w : planned_worker) =
               (Option.map worker_class_to_string w.worker_class);
           "pool:"
           ^ Option.value ~default:"" (Option.map String.trim w.runtime_pool);
+          "tier:"
+          ^ Option.value ~default:""
+              (Option.map model_tier_to_string w.model_tier);
+          "profile:"
+          ^ Option.value ~default:""
+              (Option.map task_profile_to_string w.task_profile);
         ]
 
 let dedup_planned_workers xs =
@@ -431,6 +497,55 @@ let runtime_pool_counts workers =
     workers;
   Hashtbl.fold (fun key count acc -> (key, count) :: acc) tbl []
 
+let model_tier_counts workers =
+  let tbl = Hashtbl.create 4 in
+  List.iter
+    (fun (worker : planned_worker) ->
+      match worker.model_tier with
+      | None -> ()
+      | Some tier ->
+          let key = model_tier_to_string tier in
+          let prev = Option.value ~default:0 (Hashtbl.find_opt tbl key) in
+          Hashtbl.replace tbl key (prev + 1))
+    workers;
+  Hashtbl.fold (fun key count acc -> (key, count) :: acc) tbl []
+
+let task_profile_counts workers =
+  let tbl = Hashtbl.create 8 in
+  List.iter
+    (fun (worker : planned_worker) ->
+      match worker.task_profile with
+      | None -> ()
+      | Some profile ->
+          let key = task_profile_to_string profile in
+          let prev = Option.value ~default:0 (Hashtbl.find_opt tbl key) in
+          Hashtbl.replace tbl key (prev + 1))
+    workers;
+  Hashtbl.fold (fun key count acc -> (key, count) :: acc) tbl []
+
+let escalation_count workers =
+  List.fold_left
+    (fun acc (worker : planned_worker) ->
+      if worker.routing_escalated then acc + 1 else acc)
+    0 workers
+
+let routing_reason_summary ?(max_items = 8) workers =
+  let rec take acc remaining = function
+    | [] -> List.rev acc
+    | _ when remaining <= 0 -> List.rev acc
+    | x :: xs ->
+        if List.mem x acc then take acc remaining xs
+        else take (x :: acc) (remaining - 1) xs
+  in
+  workers
+  |> List.filter_map (fun (worker : planned_worker) ->
+         match worker.routing_reason with
+         | Some reason ->
+             let trimmed = String.trim reason in
+             if trimmed = "" then None else Some trimmed
+         | None -> None)
+  |> take [] max_items
+
 let planned_worker_to_yojson (w : planned_worker) =
   `Assoc
     [
@@ -449,6 +564,21 @@ let planned_worker_to_yojson (w : planned_worker) =
           ~some:(fun mode -> `String (capsule_mode_to_string mode))
           w.capsule_mode );
       ("runtime_pool", Option.fold ~none:`Null ~some:(fun s -> `String s) w.runtime_pool);
+      ( "model_tier",
+        Option.fold ~none:`Null
+          ~some:(fun tier -> `String (model_tier_to_string tier))
+          w.model_tier );
+      ( "task_profile",
+        Option.fold ~none:`Null
+          ~some:(fun profile -> `String (task_profile_to_string profile))
+          w.task_profile );
+      ( "risk_level",
+        Option.fold ~none:`Null
+          ~some:(fun level -> `String (risk_level_to_string level))
+          w.risk_level );
+      ("routing_confidence", Option.fold ~none:`Null ~some:(fun value -> `Float value) w.routing_confidence);
+      ("routing_reason", Option.fold ~none:`Null ~some:(fun s -> `String s) w.routing_reason);
+      ("routing_escalated", `Bool w.routing_escalated);
     ]
 
 let planned_worker_of_yojson (json : Yojson.Safe.t) =
@@ -482,6 +612,35 @@ let planned_worker_of_yojson (json : Yojson.Safe.t) =
                   capsule_mode_of_string
                     (String.lowercase_ascii (String.trim value)));
             runtime_pool = member "runtime_pool" json |> to_string_option;
+            model_tier =
+              Option.bind
+                (member "model_tier" json |> to_string_option)
+                (fun value ->
+                  model_tier_of_string
+                    (String.lowercase_ascii (String.trim value)));
+            task_profile =
+              Option.bind
+                (member "task_profile" json |> to_string_option)
+                (fun value ->
+                  task_profile_of_string
+                    (String.lowercase_ascii (String.trim value)));
+            risk_level =
+              Option.bind
+                (member "risk_level" json |> to_string_option)
+                (fun value ->
+                  risk_level_of_string
+                    (String.lowercase_ascii (String.trim value)));
+            routing_confidence =
+              (match member "routing_confidence" json with
+              | `Float value -> Some value
+              | `Int value -> Some (float_of_int value)
+              | `Intlit raw -> (try Some (float_of_string raw) with _ -> None)
+              | _ -> None);
+            routing_reason = member "routing_reason" json |> to_string_option;
+            routing_escalated =
+              (match member "routing_escalated" json with
+              | `Bool value -> value
+              | _ -> false);
           })
         spawn_agent
   | _ -> None

--- a/lib/tool_team_session.ml
+++ b/lib/tool_team_session.ml
@@ -356,6 +356,17 @@ let derived_llama_runtime_actor ~session_id ~prompt =
   let digest = Digest.string (session_id ^ "\n" ^ prompt) |> Digest.to_hex in
   Printf.sprintf "llama-local-%s" (String.sub digest 0 8)
 
+type routing_decision = {
+  model_tier : Team_session_types.model_tier;
+  task_profile : Team_session_types.task_profile;
+  risk_level : Team_session_types.risk_level;
+  confidence : float option;
+  reason : string;
+  judge_used : bool;
+  escalate_if : string list;
+  escalated : bool;
+}
+
 type spawn_spec = {
   spawn_agent : string;
   spawn_prompt : string;
@@ -365,6 +376,11 @@ type spawn_spec = {
   parent_actor : string option;
   capsule_mode : Team_session_types.capsule_mode option;
   runtime_pool : string option;
+  model_tier : Team_session_types.model_tier option;
+  task_profile : Team_session_types.task_profile option;
+  risk_level : Team_session_types.risk_level option;
+  routing_confidence : float option;
+  routing_reason : string option;
   spawn_selection_note : string option;
   spawn_timeout_seconds : int;
 }
@@ -376,6 +392,510 @@ type prepared_spawn = {
   runtime_lease : Local_runtime_pool.lease option;
   assigned_runtime : string option;
 }
+
+let trim_opt = function
+  | None -> None
+  | Some raw ->
+      let trimmed = String.trim raw in
+      if trimmed = "" then None else Some trimmed
+
+let env_trim_opt name = Sys.getenv_opt name |> trim_opt
+
+let bool_env_default name ~default =
+  match env_trim_opt name with
+  | Some ("1" | "true" | "yes" | "on") -> true
+  | Some ("0" | "false" | "no" | "off") -> false
+  | _ -> default
+
+let float_env_default name ~default =
+  match env_trim_opt name with
+  | Some raw -> (
+      try float_of_string raw with _ -> default)
+  | None -> default
+
+let int_env_default name ~default =
+  match env_trim_opt name with
+  | Some raw -> (
+      try int_of_string raw with _ -> default)
+  | None -> default
+
+let contains_ci haystack needle =
+  let haystack = String.lowercase_ascii haystack in
+  let needle = String.lowercase_ascii needle in
+  let haystack_len = String.length haystack in
+  let needle_len = String.length needle in
+  let rec loop idx =
+    if needle_len = 0 then
+      true
+    else if idx + needle_len > haystack_len then
+      false
+    else if String.sub haystack idx needle_len = needle then
+      true
+    else loop (idx + 1)
+  in
+  loop 0
+
+let contains_any_ci haystack needles =
+  List.exists (fun needle -> contains_ci haystack needle) needles
+
+let runtime_inventory_models () =
+  Local_runtime_pool.snapshots ()
+  |> List.filter_map (fun (runtime : Local_runtime_pool.runtime_snapshot) ->
+         trim_opt runtime.model)
+  |> Team_session_types.dedup_strings
+
+let first_runtime_inventory_model () =
+  match runtime_inventory_models () with
+  | model :: _ -> Some model
+  | [] -> None
+
+let explicit_lead_model () = env_trim_opt "MASC_TEAM_SESSION_MODEL_35B"
+let explicit_worker_model () = env_trim_opt "MASC_TEAM_SESSION_MODEL_9B"
+
+let inferred_lead_model () =
+  match explicit_lead_model () with
+  | Some _ as explicit -> explicit
+  | None -> (
+      match env_trim_opt "LLAMA_SWARM_MODEL" with
+      | Some _ as env_model -> env_model
+      | None ->
+          let inventory = runtime_inventory_models () in
+          match List.find_opt (fun model -> contains_ci model "35b") inventory with
+          | Some _ as matched -> matched
+          | None -> first_runtime_inventory_model ())
+
+let inferred_worker_model () =
+  match explicit_worker_model () with
+  | Some _ as explicit -> explicit
+  | None ->
+      runtime_inventory_models ()
+      |> List.find_opt (fun model -> contains_ci model "9b")
+
+let infer_model_tier_from_model_name model_name =
+  match trim_opt model_name with
+  | None -> None
+  | Some model_name -> (
+      match inferred_worker_model (), inferred_lead_model () with
+      | Some worker_model, _ when String.equal worker_model model_name ->
+          Some Team_session_types.Tier_9b
+      | _, Some lead_model when String.equal lead_model model_name ->
+          Some Team_session_types.Tier_35b
+      | _ when contains_ci model_name "35b" -> Some Team_session_types.Tier_35b
+      | _ when contains_ci model_name "9b" -> Some Team_session_types.Tier_9b
+      | _ -> None)
+
+let default_risk_for_profile = function
+  | Team_session_types.Profile_extract
+  | Team_session_types.Profile_normalize
+  | Team_session_types.Profile_summarize ->
+      Team_session_types.Risk_low
+  | Team_session_types.Profile_verify
+  | Team_session_types.Profile_decide ->
+      Team_session_types.Risk_high
+  | Team_session_types.Profile_synthesize ->
+      Team_session_types.Risk_medium
+
+let min_risk left right =
+  match (left, right) with
+  | Team_session_types.Risk_high, _
+  | _, Team_session_types.Risk_high ->
+      Team_session_types.Risk_high
+  | Team_session_types.Risk_medium, _
+  | _, Team_session_types.Risk_medium ->
+      Team_session_types.Risk_medium
+  | _ -> Team_session_types.Risk_low
+
+let default_tier_for_profile ~risk_level = function
+  | (Team_session_types.Profile_extract
+    | Team_session_types.Profile_normalize
+    | Team_session_types.Profile_summarize)
+    when risk_level <> Team_session_types.Risk_high ->
+      Team_session_types.Tier_9b
+  | _ -> Team_session_types.Tier_35b
+
+let normalized_spawn_text ~spawn_prompt ~spawn_role =
+  String.concat "\n"
+    ([ spawn_prompt ]
+    @
+    match spawn_role with
+    | Some role -> [ role ]
+    | None -> [])
+  |> String.lowercase_ascii
+
+let keyword_matches text =
+  let groups =
+    [
+      ( Team_session_types.Profile_extract,
+        [ "fetch"; "collect"; "gather"; "search"; "find source"; "read docs"; "web"; "official docs"; "article"; "paper"; "source" ] );
+      ( Team_session_types.Profile_normalize,
+        [ "normalize"; "convert"; "transform"; "schema"; "format"; "json"; "label"; "tag"; "dedup" ] );
+      ( Team_session_types.Profile_summarize,
+        [ "summarize"; "summary"; "digest"; "brief"; "recap"; "short answer"; "bullet" ] );
+      ( Team_session_types.Profile_verify,
+        [ "verify"; "validate"; "check"; "review"; "audit"; "judge"; "prove"; "test"; "compare" ] );
+      ( Team_session_types.Profile_decide,
+        [ "decide"; "choose"; "route"; "triage"; "prioritize"; "assign"; "classify" ] );
+      ( Team_session_types.Profile_synthesize,
+        [ "synthesize"; "write"; "draft"; "compose"; "architecture"; "design"; "plan"; "proposal"; "explain" ] );
+    ]
+  in
+  List.filter_map
+    (fun (profile, keywords) ->
+      if contains_any_ci text keywords then Some profile else None)
+    groups
+
+let high_risk_keywords =
+  [ "security"; "policy"; "final"; "merge"; "customer"; "public"; "external"; "production"; "critical"; "architecture"; "decision" ]
+
+let router_judge_enabled () =
+  bool_env_default "MASC_TEAM_SESSION_ROUTER_JUDGE" ~default:true
+
+let router_judge_timeout_sec () =
+  max 5 (int_env_default "MASC_TEAM_SESSION_ROUTER_JUDGE_TIMEOUT_SEC" ~default:15)
+
+let router_judge_confidence_threshold () =
+  let value =
+    float_env_default "MASC_TEAM_SESSION_ROUTER_CONFIDENCE_THRESHOLD"
+      ~default:0.72
+  in
+  if value < 0.0 then 0.0 else if value > 1.0 then 1.0 else value
+
+let router_judge_model () =
+  match env_trim_opt "MASC_TEAM_SESSION_ROUTER_JUDGE_MODEL" with
+  | Some _ as explicit -> explicit
+  | None -> inferred_lead_model ()
+
+let llama_router_model_spec model_id =
+  {
+    Llm_client.provider = Llm_client.Llama;
+    model_id;
+    max_context = 262_144;
+    api_url = Env_config.Llama.server_url;
+    api_key_env = None;
+    cost_per_1k_input = 0.0;
+    cost_per_1k_output = 0.0;
+  }
+
+let classify_risk ~task_profile ~spawn_prompt ~spawn_role =
+  let text = normalized_spawn_text ~spawn_prompt ~spawn_role in
+  let base = default_risk_for_profile task_profile in
+  if contains_any_ci text high_risk_keywords then
+    min_risk base Team_session_types.Risk_high
+  else base
+
+let heuristic_routing ~spawn_prompt ~spawn_role ~worker_class ~task_profile
+    ~risk_level ~model_tier ~routing_confidence ~routing_reason =
+  let resolved_profile =
+    match task_profile with
+    | Some profile -> Some (profile, "explicit_task_profile", 0.99)
+    | None -> (
+        match worker_class with
+        | Some Team_session_types.Worker_manager ->
+            Some (Team_session_types.Profile_decide, "rule:worker_class=manager", 0.97)
+        | Some Team_session_types.Worker_metacog ->
+            Some (Team_session_types.Profile_verify, "rule:worker_class=metacog", 0.97)
+        | Some Team_session_types.Worker_scout ->
+            Some (Team_session_types.Profile_extract, "rule:worker_class=scout", 0.95)
+        | Some Team_session_types.Worker_librarian ->
+            Some (Team_session_types.Profile_summarize, "rule:worker_class=librarian", 0.94)
+        | _ ->
+            let matches =
+              keyword_matches
+                (normalized_spawn_text ~spawn_prompt ~spawn_role)
+            in
+            match matches with
+            | [ profile ] -> Some (profile, "rule:keyword_match", 0.78)
+            | _ -> None)
+  in
+  match resolved_profile with
+  | Some (profile, reason, confidence) ->
+      let resolved_risk =
+        match risk_level with
+        | Some explicit -> explicit
+        | None -> classify_risk ~task_profile:profile ~spawn_prompt ~spawn_role
+      in
+      let resolved_tier =
+        match model_tier with
+        | Some explicit -> explicit
+        | None -> default_tier_for_profile ~risk_level:resolved_risk profile
+      in
+      let confidence =
+        match routing_confidence with
+        | Some value -> Some value
+        | None -> Some confidence
+      in
+      let reason =
+        match routing_reason with
+        | Some explicit -> explicit
+        | None -> reason
+      in
+      Some
+        {
+          model_tier = resolved_tier;
+          task_profile = profile;
+          risk_level = resolved_risk;
+          confidence;
+          reason;
+          judge_used = false;
+          escalate_if =
+            [ "worker failure"; "schema mismatch"; "context pressure"; "evidence conflict" ];
+          escalated = false;
+        }
+  | None -> None
+
+let parse_routing_decision_json (json : Yojson.Safe.t) =
+  let open Yojson.Safe.Util in
+  let model_tier =
+    match member "model_tier" json |> to_string_option with
+    | Some raw ->
+        Team_session_types.model_tier_of_string
+          (String.lowercase_ascii (String.trim raw))
+    | None -> None
+  in
+  let task_profile =
+    match member "task_profile" json |> to_string_option with
+    | Some raw ->
+        Team_session_types.task_profile_of_string
+          (String.lowercase_ascii (String.trim raw))
+    | None -> None
+  in
+  let risk_level =
+    match member "risk_level" json |> to_string_option with
+    | Some raw ->
+        Team_session_types.risk_level_of_string
+          (String.lowercase_ascii (String.trim raw))
+    | None -> None
+  in
+  match (model_tier, task_profile, risk_level) with
+  | Some model_tier, Some task_profile, Some risk_level ->
+      let confidence =
+        match member "confidence" json with
+        | `Float value -> Some value
+        | `Int value -> Some (float_of_int value)
+        | `Intlit raw -> (try Some (float_of_string raw) with _ -> None)
+        | _ -> None
+      in
+      let reason =
+        member "reason" json |> to_string_option
+        |> Option.value ~default:"llm_judge"
+      in
+      let escalate_if =
+        match member "escalate_if" json with
+        | `List xs ->
+            xs
+            |> List.filter_map (function
+                   | `String value ->
+                       let trimmed = String.trim value in
+                       if trimmed = "" then None else Some trimmed
+                   | _ -> None)
+        | _ -> []
+      in
+      Some
+        {
+          model_tier;
+          task_profile;
+          risk_level;
+          confidence;
+          reason;
+          judge_used = true;
+          escalate_if;
+          escalated = false;
+        }
+  | _ -> None
+
+let llm_judge_routing ~spawn_prompt ~spawn_role ~worker_class =
+  match router_judge_model () with
+  | None -> None
+  | Some judge_model ->
+      let worker_class_text =
+        match worker_class with
+        | Some kind -> Team_session_types.worker_class_to_string kind
+        | None -> "unspecified"
+      in
+      let role_text = Option.value ~default:"unspecified" spawn_role in
+      let prompt =
+        Printf.sprintf
+          "Classify the worker task for a quality-first 2-tier swarm router.\n\
+           Return strict JSON only with keys: model_tier, task_profile, risk_level, confidence, reason, escalate_if.\n\
+           model_tier must be one of [\"35b\",\"9b\"].\n\
+           task_profile must be one of [\"extract\",\"normalize\",\"summarize\",\"verify\",\"decide\",\"synthesize\"].\n\
+           risk_level must be one of [\"low\",\"medium\",\"high\"].\n\
+           Use 35b for final judgment, ambiguous work, open-ended synthesis, architecture, or high-risk outputs.\n\
+           Use 9b only for low-risk, machine-checkable, or strict-template subtasks.\n\
+           worker_class=%s\n\
+           spawn_role=%s\n\
+           worker_prompt=%S\n"
+          worker_class_text role_text spawn_prompt
+      in
+      let request : Llm_client.completion_request =
+        {
+          model = llama_router_model_spec judge_model;
+          messages =
+            [
+              {
+                Llm_client.role = Llm_client.System;
+                content =
+                  "You are a routing judge for a hybrid swarm. Output only JSON.";
+                name = None;
+                tool_call_id = None;
+              };
+              {
+                Llm_client.role = Llm_client.User;
+                content = prompt;
+                name = None;
+                tool_call_id = None;
+              };
+            ];
+          temperature = 0.0;
+          max_tokens = 220;
+          tools = [];
+          response_format = `Json;
+        }
+      in
+      match
+        Llm_client.complete ~timeout_sec:(router_judge_timeout_sec ()) request
+      with
+      | Ok response -> (
+          try
+            Yojson.Safe.from_string response.content
+            |> parse_routing_decision_json
+          with _ -> None)
+      | Error _ -> None
+
+let routing_summary_line (decision : routing_decision) =
+  Printf.sprintf
+    "[routing] profile=%s tier=%s risk=%s confidence=%s reason=%s judge=%b escalated=%b"
+    (Team_session_types.task_profile_to_string decision.task_profile)
+    (Team_session_types.model_tier_to_string decision.model_tier)
+    (Team_session_types.risk_level_to_string decision.risk_level)
+    (match decision.confidence with
+    | Some value -> Printf.sprintf "%.2f" value
+    | None -> "n/a")
+    decision.reason decision.judge_used decision.escalated
+
+let merge_selection_note selection_note routing_note =
+  match (trim_opt selection_note, trim_opt (Some routing_note)) with
+  | None, None -> None
+  | Some note, None | None, Some note -> Some note
+  | Some note, Some routing when String.equal note routing -> Some note
+  | Some note, Some routing -> Some (note ^ " | " ^ routing)
+
+let fallback_model_for_tier = function
+  | Some Team_session_types.Tier_9b -> (
+      match inferred_worker_model () with
+      | Some _ as worker -> worker
+      | None -> inferred_lead_model ())
+  | Some Team_session_types.Tier_35b -> inferred_lead_model ()
+  | None -> inferred_lead_model ()
+
+let finalize_routing_decision ~spawn_model ~(decision : routing_decision) =
+  let resolved_model, escalated, reason =
+    match decision.model_tier with
+    | Team_session_types.Tier_35b -> (inferred_lead_model (), decision.escalated, decision.reason)
+    | Team_session_types.Tier_9b -> (
+        match inferred_worker_model () with
+        | Some model -> (Some model, decision.escalated, decision.reason)
+        | None ->
+            ( inferred_lead_model (),
+              true,
+              decision.reason ^ "; fallback:9b_unavailable->35b" ))
+  in
+  let resolved_model =
+    match trim_opt spawn_model with
+    | Some explicit -> Some explicit
+    | None -> resolved_model
+  in
+  let resolved_tier =
+    match trim_opt spawn_model with
+    | Some explicit ->
+        Option.value ~default:decision.model_tier
+          (infer_model_tier_from_model_name (Some explicit))
+    | None ->
+        if escalated then Team_session_types.Tier_35b else decision.model_tier
+  in
+  (resolved_model, resolved_tier, escalated, reason)
+
+let resolve_routing_for_spec (spec : spawn_spec) =
+  if not (String.equal spec.spawn_agent "llama") then
+    spec
+  else
+    let explicit_tier =
+      match spec.model_tier with
+      | Some tier -> Some tier
+      | None -> infer_model_tier_from_model_name spec.spawn_model
+    in
+    let heuristic =
+      heuristic_routing ~spawn_prompt:spec.spawn_prompt ~spawn_role:spec.spawn_role
+        ~worker_class:spec.worker_class ~task_profile:spec.task_profile
+        ~risk_level:spec.risk_level ~model_tier:explicit_tier
+        ~routing_confidence:spec.routing_confidence
+        ~routing_reason:spec.routing_reason
+    in
+    let decision =
+      match heuristic with
+      | Some decision ->
+          let confidence =
+            Option.value ~default:1.0 decision.confidence
+          in
+          if confidence >= router_judge_confidence_threshold ()
+             || Option.is_some spec.task_profile
+             || Option.is_some spec.model_tier
+          then
+            decision
+          else
+            (match llm_judge_routing ~spawn_prompt:spec.spawn_prompt
+                     ~spawn_role:spec.spawn_role ~worker_class:spec.worker_class with
+            | Some llm -> llm
+            | None ->
+                {
+                  decision with
+                  model_tier = Team_session_types.Tier_35b;
+                  risk_level = Team_session_types.Risk_high;
+                  reason = decision.reason ^ "; fallback:uncertain->35b";
+                  escalated = true;
+                })
+      | None -> (
+          match llm_judge_routing ~spawn_prompt:spec.spawn_prompt
+                   ~spawn_role:spec.spawn_role ~worker_class:spec.worker_class with
+          | Some llm -> llm
+          | None ->
+              {
+                model_tier = Option.value ~default:Team_session_types.Tier_35b explicit_tier;
+                task_profile =
+                  Option.value ~default:Team_session_types.Profile_synthesize
+                    spec.task_profile;
+                risk_level =
+                  Option.value ~default:Team_session_types.Risk_high spec.risk_level;
+                confidence = Some 0.0;
+                reason = Option.value ~default:"fallback:ambiguous->35b" spec.routing_reason;
+                judge_used = false;
+                escalate_if =
+                  [ "worker failure"; "schema mismatch"; "context pressure"; "evidence conflict" ];
+                escalated = true;
+              })
+    in
+    let spawn_model, model_tier, routing_escalated, routing_reason =
+      finalize_routing_decision ~spawn_model:spec.spawn_model ~decision
+    in
+    let routing_confidence =
+      match spec.routing_confidence with
+      | Some _ as explicit -> explicit
+      | None -> decision.confidence
+    in
+    let routing_note =
+      routing_summary_line { decision with model_tier; reason = routing_reason; escalated = routing_escalated }
+    in
+    {
+      spec with
+      spawn_model;
+      model_tier = Some model_tier;
+      task_profile = Some decision.task_profile;
+      risk_level = Some decision.risk_level;
+      routing_confidence;
+      routing_reason = Some routing_reason;
+      spawn_selection_note =
+        merge_selection_note spec.spawn_selection_note routing_note;
+    }
 
 let parse_spawn_spec_from_object batch_index json =
   let open Yojson.Safe.Util in
@@ -406,12 +926,40 @@ let parse_spawn_spec_from_object batch_index json =
         Team_session_types.worker_class_of_string
           (String.lowercase_ascii (String.trim raw)))
   in
+  let get_optional_model_tier key =
+    Option.bind
+      (get_optional_string key)
+      (fun raw ->
+        Team_session_types.model_tier_of_string
+          (String.lowercase_ascii (String.trim raw)))
+  in
+  let get_optional_task_profile key =
+    Option.bind
+      (get_optional_string key)
+      (fun raw ->
+        Team_session_types.task_profile_of_string
+          (String.lowercase_ascii (String.trim raw)))
+  in
+  let get_optional_risk_level key =
+    Option.bind
+      (get_optional_string key)
+      (fun raw ->
+        Team_session_types.risk_level_of_string
+          (String.lowercase_ascii (String.trim raw)))
+  in
   let get_optional_capsule_mode key =
     Option.bind
       (get_optional_string key)
       (fun raw ->
         Team_session_types.capsule_mode_of_string
           (String.lowercase_ascii (String.trim raw)))
+  in
+  let get_optional_float key =
+    match member key json with
+    | `Float value -> Some value
+    | `Int value -> Some (float_of_int value)
+    | `Intlit raw -> (try Some (float_of_string raw) with _ -> None)
+    | _ -> None
   in
   let get_timeout key =
     match member key json with
@@ -431,6 +979,11 @@ let parse_spawn_spec_from_object batch_index json =
           parent_actor = get_optional_string "parent_actor";
           capsule_mode = get_optional_capsule_mode "capsule_mode";
           runtime_pool = get_optional_string "runtime_pool";
+          model_tier = get_optional_model_tier "model_tier";
+          task_profile = get_optional_task_profile "task_profile";
+          risk_level = get_optional_risk_level "risk_level";
+          routing_confidence = get_optional_float "routing_confidence";
+          routing_reason = get_optional_string "routing_reason";
           spawn_selection_note = get_optional_string "spawn_selection_note";
           spawn_timeout_seconds = get_timeout "spawn_timeout_seconds";
         }
@@ -457,17 +1010,18 @@ let parse_step_spawn_specs args =
   match batch_specs_result with
   | Error e -> Error e
   | Ok batch_specs ->
+      let route_specs specs = Ok (List.map resolve_routing_for_spec specs) in
       if singular_present && batch_specs <> [] then
         Error "spawn_batch cannot be combined with spawn_agent/spawn_prompt"
       else if batch_specs <> [] then
-        Ok batch_specs
+        route_specs batch_specs
       else
         match (singular_agent, singular_prompt) with
         | None, None -> Ok []
         | Some _, None | None, Some _ ->
             Error "spawn_agent and spawn_prompt must be provided together"
         | Some spawn_agent, Some spawn_prompt ->
-            Ok
+            route_specs
               [
                 {
                   spawn_agent;
@@ -488,6 +1042,26 @@ let parse_step_spawn_specs args =
                         Team_session_types.capsule_mode_of_string
                           (String.lowercase_ascii (String.trim raw)));
                   runtime_pool = get_string_opt args "runtime_pool";
+                  model_tier =
+                    Option.bind
+                      (get_string_opt args "model_tier")
+                      (fun raw ->
+                        Team_session_types.model_tier_of_string
+                          (String.lowercase_ascii (String.trim raw)));
+                  task_profile =
+                    Option.bind
+                      (get_string_opt args "task_profile")
+                      (fun raw ->
+                        Team_session_types.task_profile_of_string
+                          (String.lowercase_ascii (String.trim raw)));
+                  risk_level =
+                    Option.bind
+                      (get_string_opt args "risk_level")
+                      (fun raw ->
+                        Team_session_types.risk_level_of_string
+                          (String.lowercase_ascii (String.trim raw)));
+                  routing_confidence = get_float_opt args "routing_confidence";
+                  routing_reason = get_string_opt args "routing_reason";
                   spawn_selection_note = get_string_opt args "spawn_selection_note";
                   spawn_timeout_seconds = get_int args "spawn_timeout_seconds" 300;
                 };
@@ -504,6 +1078,18 @@ let planned_worker_of_spec ?runtime_actor (spec : spawn_spec) :
     parent_actor = spec.parent_actor;
     capsule_mode = spec.capsule_mode;
     runtime_pool = spec.runtime_pool;
+    model_tier = spec.model_tier;
+    task_profile = spec.task_profile;
+    risk_level = spec.risk_level;
+    routing_confidence = spec.routing_confidence;
+    routing_reason = spec.routing_reason;
+    routing_escalated =
+      (match spec.routing_reason with
+      | Some reason ->
+          contains_ci reason "fallback:"
+          || contains_ci reason "escalate"
+          || contains_ci reason "uncertain->35b"
+      | None -> false);
   }
 
 let register_planned_workers config session_id workers =
@@ -529,6 +1115,16 @@ let register_planned_workers config session_id workers =
               ( "runtime_pool_counts",
                 Team_session_types.runtime_pool_counts updated.planned_workers
                 |> Team_session_types.counts_to_json );
+              ( "tier_counts",
+                Team_session_types.model_tier_counts updated.planned_workers
+                |> Team_session_types.counts_to_json );
+              ( "task_profile_counts",
+                Team_session_types.task_profile_counts updated.planned_workers
+                |> Team_session_types.counts_to_json );
+              ( "escalation_count",
+                `Int
+                  (Team_session_types.escalation_count updated.planned_workers)
+              );
               ( "runtime_actors",
                 `List
                   (workers
@@ -648,7 +1244,9 @@ let handle_step ctx args : result =
               let task_priority = get_int args "task_priority" 3 in
               let append_spawn_event ?spawn_agent ?runtime_actor ?spawn_role
                   ?spawn_model ?worker_class ?parent_actor ?capsule_mode
-                  ?runtime_pool ?assigned_runtime ?spawn_selection_note ~success ?exit_code
+                  ?runtime_pool ?model_tier ?task_profile ?risk_level
+                  ?routing_confidence ?routing_reason ?assigned_runtime
+                  ?spawn_selection_note ~success ?exit_code
                   ?elapsed_ms ?output_preview ?error () =
                 let detail =
                   `Assoc
@@ -684,6 +1282,29 @@ let handle_step ctx args : result =
                       ( "runtime_pool",
                         Option.fold ~none:`Null ~some:(fun s -> `String s)
                           runtime_pool );
+                      ( "model_tier",
+                        Option.fold ~none:`Null
+                          ~some:(fun tier ->
+                            `String
+                              (Team_session_types.model_tier_to_string tier))
+                          model_tier );
+                      ( "task_profile",
+                        Option.fold ~none:`Null
+                          ~some:(fun profile ->
+                            `String
+                              (Team_session_types.task_profile_to_string
+                                 profile))
+                          task_profile );
+                      ( "risk_level",
+                        Option.fold ~none:`Null
+                          ~some:(fun level ->
+                            `String
+                              (Team_session_types.risk_level_to_string level))
+                          risk_level );
+                      ("routing_confidence", float_opt_to_json routing_confidence);
+                      ( "routing_reason",
+                        Option.fold ~none:`Null ~some:(fun s -> `String s)
+                          routing_reason );
                       ( "assigned_runtime",
                         Option.fold ~none:`Null ~some:(fun s -> `String s)
                           assigned_runtime );
@@ -727,7 +1348,12 @@ let handle_step ctx args : result =
                 in
                 let runtime_model =
                   if String.equal spec.spawn_agent "llama" then
-                    match spec.spawn_model with
+                    let resolved_spawn_model =
+                      match spec.spawn_model with
+                      | Some _ as explicit -> explicit
+                      | None -> fallback_model_for_tier spec.model_tier
+                    in
+                    match resolved_spawn_model with
                     | None ->
                         Error
                           "spawn_model is required when spawn_agent=llama"
@@ -739,20 +1365,21 @@ let handle_step ctx args : result =
                         with
                         | Ok assignment ->
                             Ok
-                              ( Local_runtime_pool.model_spec_of_assignment
+                              ( { spec with spawn_model = Some assignment.model_name },
+                                Local_runtime_pool.model_spec_of_assignment
                                   assignment,
                                 Some assignment.lease,
                                 Some assignment.runtime_id )
                         | Error err -> Error err)
                   else
-                    Ok (Llm_client.ollama_glm, None, None)
+                    Ok (spec, Llm_client.ollama_glm, None, None)
                 in
                 match runtime_model with
                 | Error e -> Error (spec, runtime_actor_name, e)
-                | Ok (runtime_model, runtime_lease, assigned_runtime) ->
+                | Ok (resolved_spec, runtime_model, runtime_lease, assigned_runtime) ->
                     Ok
                       {
-                        spec;
+                        spec = resolved_spec;
                         runtime_actor_name;
                         runtime_model;
                         runtime_lease;
@@ -775,6 +1402,11 @@ let handle_step ctx args : result =
                             ?parent_actor:failed_spec.parent_actor
                             ?capsule_mode:failed_spec.capsule_mode
                             ?runtime_pool:failed_spec.runtime_pool
+                            ?model_tier:failed_spec.model_tier
+                            ?task_profile:failed_spec.task_profile
+                            ?risk_level:failed_spec.risk_level
+                            ?routing_confidence:failed_spec.routing_confidence
+                            ?routing_reason:failed_spec.routing_reason
                             ?spawn_selection_note:failed_spec.spawn_selection_note
                             ~success:false ~error:msg ();
                           Error msg)
@@ -817,6 +1449,11 @@ let handle_step ctx args : result =
                               ?parent_actor:prepared.spec.parent_actor
                               ?capsule_mode:prepared.spec.capsule_mode
                               ?runtime_pool:prepared.spec.runtime_pool
+                              ?model_tier:prepared.spec.model_tier
+                              ?task_profile:prepared.spec.task_profile
+                              ?risk_level:prepared.spec.risk_level
+                              ?routing_confidence:prepared.spec.routing_confidence
+                              ?routing_reason:prepared.spec.routing_reason
                               ?assigned_runtime:prepared.assigned_runtime
                               ?spawn_selection_note:
                                 prepared.spec.spawn_selection_note
@@ -842,6 +1479,12 @@ let handle_step ctx args : result =
                                   ?parent_actor:prepared.spec.parent_actor
                                   ?capsule_mode:prepared.spec.capsule_mode
                                   ?runtime_pool:prepared.spec.runtime_pool
+                                  ?model_tier:prepared.spec.model_tier
+                                  ?task_profile:prepared.spec.task_profile
+                                  ?risk_level:prepared.spec.risk_level
+                                  ?routing_confidence:
+                                    prepared.spec.routing_confidence
+                                  ?routing_reason:prepared.spec.routing_reason
                                   ?assigned_runtime:prepared.assigned_runtime
                                   ?spawn_selection_note:
                                     prepared.spec.spawn_selection_note
@@ -877,6 +1520,13 @@ let handle_step ctx args : result =
                                        ?parent_actor:prepared.spec.parent_actor
                                        ?capsule_mode:prepared.spec.capsule_mode
                                        ?runtime_pool:prepared.spec.runtime_pool
+                                       ?model_tier:prepared.spec.model_tier
+                                       ?task_profile:prepared.spec.task_profile
+                                       ?risk_level:prepared.spec.risk_level
+                                       ?routing_confidence:
+                                         prepared.spec.routing_confidence
+                                       ?routing_reason:
+                                         prepared.spec.routing_reason
                                        ?assigned_runtime:prepared.assigned_runtime
                                        ?spawn_selection_note:
                                          prepared.spec.spawn_selection_note
@@ -982,6 +1632,35 @@ let handle_step ctx args : result =
                                                   Option.fold ~none:`Null
                                                     ~some:(fun s -> `String s)
                                                     prepared.spec.runtime_pool );
+                                                ( "model_tier",
+                                                  Option.fold ~none:`Null
+                                                    ~some:(fun tier ->
+                                                      `String
+                                                        (Team_session_types.model_tier_to_string
+                                                           tier))
+                                                    prepared.spec.model_tier );
+                                                ( "task_profile",
+                                                  Option.fold ~none:`Null
+                                                    ~some:(fun profile ->
+                                                      `String
+                                                        (Team_session_types.task_profile_to_string
+                                                           profile))
+                                                    prepared.spec.task_profile );
+                                                ( "risk_level",
+                                                  Option.fold ~none:`Null
+                                                    ~some:(fun level ->
+                                                      `String
+                                                        (Team_session_types.risk_level_to_string
+                                                           level))
+                                                    prepared.spec.risk_level );
+                                                ( "routing_confidence",
+                                                  float_opt_to_json
+                                                    prepared.spec.routing_confidence
+                                                );
+                                                ( "routing_reason",
+                                                  Option.fold ~none:`Null
+                                                    ~some:(fun s -> `String s)
+                                                    prepared.spec.routing_reason );
                                                 ( "assigned_runtime",
                                                   Option.fold ~none:`Null
                                                     ~some:(fun s -> `String s)
@@ -1602,6 +2281,41 @@ let schemas : tool_schema list =
 	                            ] );
 	                      ] );
 	                  ("runtime_pool", `Assoc [ ("type", `String "string") ]);
+	                  ( "model_tier",
+	                    `Assoc
+	                      [
+	                        ("type", `String "string");
+	                        ("enum", `List [ `String "35b"; `String "9b" ]);
+	                      ] );
+	                  ( "task_profile",
+	                    `Assoc
+	                      [
+	                        ("type", `String "string");
+	                        ( "enum",
+	                          `List
+	                            [
+	                              `String "extract";
+	                              `String "normalize";
+	                              `String "summarize";
+	                              `String "verify";
+	                              `String "decide";
+	                              `String "synthesize";
+	                            ] );
+	                      ] );
+	                  ( "risk_level",
+	                    `Assoc
+	                      [
+	                        ("type", `String "string");
+	                        ( "enum",
+	                          `List
+	                            [
+	                              `String "low";
+	                              `String "medium";
+	                              `String "high";
+	                            ] );
+	                      ] );
+	                  ("routing_confidence", `Assoc [ ("type", `String "number") ]);
+	                  ("routing_reason", `Assoc [ ("type", `String "string") ]);
 	                  ("spawn_selection_note", `Assoc [ ("type", `String "string") ]);
 	                  ("spawn_prompt", `Assoc [ ("type", `String "string") ]);
 	                  ("spawn_timeout_seconds", `Assoc [ ("type", `String "integer") ]);
@@ -1647,6 +2361,41 @@ let schemas : tool_schema list =
 	                                              ] );
 	                                        ] );
 	                                    ("runtime_pool", `Assoc [ ("type", `String "string") ]);
+	                                    ( "model_tier",
+	                                      `Assoc
+	                                        [
+	                                          ("type", `String "string");
+	                                          ("enum", `List [ `String "35b"; `String "9b" ]);
+	                                        ] );
+	                                    ( "task_profile",
+	                                      `Assoc
+	                                        [
+	                                          ("type", `String "string");
+	                                          ( "enum",
+	                                            `List
+	                                              [
+	                                                `String "extract";
+	                                                `String "normalize";
+	                                                `String "summarize";
+	                                                `String "verify";
+	                                                `String "decide";
+	                                                `String "synthesize";
+	                                              ] );
+	                                        ] );
+	                                    ( "risk_level",
+	                                      `Assoc
+	                                        [
+	                                          ("type", `String "string");
+	                                          ( "enum",
+	                                            `List
+	                                              [
+	                                                `String "low";
+	                                                `String "medium";
+	                                                `String "high";
+	                                              ] );
+	                                        ] );
+	                                    ("routing_confidence", `Assoc [ ("type", `String "number") ]);
+	                                    ("routing_reason", `Assoc [ ("type", `String "string") ]);
 	                                    ( "spawn_selection_note",
 	                                      `Assoc [ ("type", `String "string") ] );
 	                                    ("spawn_prompt", `Assoc [ ("type", `String "string") ]);

--- a/scripts/harness/workload/team_session_local64_smoke.sh
+++ b/scripts/harness/workload/team_session_local64_smoke.sh
@@ -21,6 +21,7 @@ fi
 HTTP_TIMEOUT_SEC="${HTTP_TIMEOUT_SEC:-$default_http_timeout}"
 WAIT_AFTER_SPAWN_SEC="${WAIT_AFTER_SPAWN_SEC:-3}"
 LLAMA_SWARM_MODEL="${LLAMA_SWARM_MODEL:-}"
+LOCAL64_ROUTER_MODE="${LOCAL64_ROUTER_MODE:-hybrid}"
 MCP_SESSION_ID="${MCP_SESSION_ID:-team-session-local64-$(date +%s)-$RANDOM}"
 GOAL="${GOAL:-Validate local64 swarm role coverage, runtime visibility, and operator census}"
 
@@ -151,16 +152,92 @@ build_spawn_batch() {
     local actor
     actor="$(printf 'local64-smoke-%02d' "$idx")"
     local prompt
-    prompt="$(
-      printf '%s\n' \
-        "너의 에이전트 이름은 ${actor} 이다. 아래를 순서대로 실행해라." \
-        "1) mcp__masc__masc_join(agent_name=\"${actor}\", capabilities=[\"swarm\",\"${role}\"])" \
-        "2) mcp__masc__masc_team_session_turn(session_id=\"${session_id}\", turn_kind=\"note\", message=\"[${actor}] ${role} online for local64 smoke\")" \
-        "3) mcp__masc__masc_leave(agent_name=\"${actor}\")" \
-        "마지막 답변은 한 줄로 \"done:${actor}\"만 출력해라."
-    )"
+    local task_profile=""
+    if [ "$LOCAL64_ROUTER_MODE" = "hybrid" ]; then
+      case "$role" in
+        manager)
+          task_profile="decide"
+          prompt="$(
+            printf '%s\n' \
+              "너의 에이전트 이름은 ${actor} 이다. 아래를 순서대로 실행해라." \
+              "이 작업은 session routing/decide 성격이다." \
+              "1) mcp__masc__masc_join(agent_name=\"${actor}\", capabilities=[\"swarm\",\"manager\"])" \
+              "2) mcp__masc__masc_team_session_turn(session_id=\"${session_id}\", turn_kind=\"note\", message=\"[${actor}] manager decide online for hybrid smoke\")" \
+              "3) mcp__masc__masc_leave(agent_name=\"${actor}\")" \
+              "마지막 답변은 한 줄로 \"done:${actor}\"만 출력해라."
+          )"
+          ;;
+        metacog)
+          task_profile="verify"
+          prompt="$(
+            printf '%s\n' \
+              "너의 에이전트 이름은 ${actor} 이다. 아래를 순서대로 실행해라." \
+              "이 작업은 session verify 성격이다." \
+              "1) mcp__masc__masc_join(agent_name=\"${actor}\", capabilities=[\"swarm\",\"metacog\"])" \
+              "2) mcp__masc__masc_team_session_turn(session_id=\"${session_id}\", turn_kind=\"note\", message=\"[${actor}] metacog verify online for hybrid smoke\")" \
+              "3) mcp__masc__masc_leave(agent_name=\"${actor}\")" \
+              "마지막 답변은 한 줄로 \"done:${actor}\"만 출력해라."
+          )"
+          ;;
+        librarian)
+          task_profile="summarize"
+          prompt="$(
+            printf '%s\n' \
+              "너의 에이전트 이름은 ${actor} 이다. 아래를 순서대로 실행해라." \
+              "이 작업은 short answer summarize 성격이다." \
+              "1) mcp__masc__masc_join(agent_name=\"${actor}\", capabilities=[\"swarm\",\"librarian\"])" \
+              "2) mcp__masc__masc_team_session_turn(session_id=\"${session_id}\", turn_kind=\"note\", message=\"[${actor}] librarian summarize online for hybrid smoke\")" \
+              "3) mcp__masc__masc_leave(agent_name=\"${actor}\")" \
+              "마지막 답변은 한 줄로 \"done:${actor}\"만 출력해라."
+          )"
+          ;;
+        scout)
+          task_profile="extract"
+          prompt="$(
+            printf '%s\n' \
+              "너의 에이전트 이름은 ${actor} 이다. 아래를 순서대로 실행해라." \
+              "이 작업은 fetch and collect source extract 성격이다." \
+              "1) mcp__masc__masc_join(agent_name=\"${actor}\", capabilities=[\"swarm\",\"scout\"])" \
+              "2) mcp__masc__masc_team_session_turn(session_id=\"${session_id}\", turn_kind=\"note\", message=\"[${actor}] scout extract online for hybrid smoke\")" \
+              "3) mcp__masc__masc_leave(agent_name=\"${actor}\")" \
+              "마지막 답변은 한 줄로 \"done:${actor}\"만 출력해라."
+          )"
+          ;;
+        *)
+          task_profile="normalize"
+          prompt="$(
+            printf '%s\n' \
+              "너의 에이전트 이름은 ${actor} 이다. 아래를 순서대로 실행해라." \
+              "이 작업은 normalize evidence into strict JSON schema 성격이다." \
+              "1) mcp__masc__masc_join(agent_name=\"${actor}\", capabilities=[\"swarm\",\"executor\"])" \
+              "2) mcp__masc__masc_team_session_turn(session_id=\"${session_id}\", turn_kind=\"note\", message=\"[${actor}] executor normalize online for hybrid smoke\")" \
+              "3) mcp__masc__masc_leave(agent_name=\"${actor}\")" \
+              "마지막 답변은 한 줄로 \"done:${actor}\"만 출력해라."
+          )"
+          ;;
+      esac
+    else
+      prompt="$(
+        printf '%s\n' \
+          "너의 에이전트 이름은 ${actor} 이다. 아래를 순서대로 실행해라." \
+          "1) mcp__masc__masc_join(agent_name=\"${actor}\", capabilities=[\"swarm\",\"${role}\"])" \
+          "2) mcp__masc__masc_team_session_turn(session_id=\"${session_id}\", turn_kind=\"note\", message=\"[${actor}] ${role} online for local64 smoke\")" \
+          "3) mcp__masc__masc_leave(agent_name=\"${actor}\")" \
+          "마지막 답변은 한 줄로 \"done:${actor}\"만 출력해라."
+      )"
+    fi
 
-    if [ -n "$model" ]; then
+    if [ "$LOCAL64_ROUTER_MODE" = "hybrid" ]; then
+      jq -cn \
+        --arg prompt "$prompt" \
+        --arg role "$spawn_role" \
+        --arg worker_class "$role" \
+        --arg capsule_mode "$capsule_mode" \
+        --arg runtime_pool "local64" \
+        --arg task_profile "$task_profile" \
+        '{spawn_agent:"llama",spawn_prompt:$prompt,spawn_role:$role,worker_class:$worker_class,capsule_mode:$capsule_mode,runtime_pool:$runtime_pool,task_profile:$task_profile}' \
+        >>"$tmp_file"
+    elif [ -n "$model" ]; then
       jq -cn \
         --arg prompt "$prompt" \
         --arg role "$spawn_role" \
@@ -210,6 +287,12 @@ echo "[3/8] inspect local llama runtime"
 runtime_raw="$(call_tool 91004 "masc_llama_runtime_status" '{"include_models":true}')"
 require_tool_success "$runtime_raw"
 require_result_condition "$runtime_raw" '.runtime_count >= 1 and .configured_capacity >= 1' "runtime status missing pool data"
+worker_tier_available="false"
+if [ -n "${MASC_TEAM_SESSION_MODEL_9B:-}" ]; then
+  worker_tier_available="true"
+elif printf '%s' "$runtime_raw" | extract_result | jq -e '[.models[]? | ascii_downcase] | any(contains("9b"))' >/dev/null 2>&1; then
+  worker_tier_available="true"
+fi
 
 echo "[4/8] spawn local64 batch (spawn_timeout=${SPAWN_TIMEOUT_SEC}s http_timeout=${HTTP_TIMEOUT_SEC}s workers=${WORKER_COUNT})"
 spawn_batch_json="$(build_spawn_batch "$SESSION_ID" "$WORKER_COUNT" "$LLAMA_SWARM_MODEL")"
@@ -230,7 +313,7 @@ sleep "$WAIT_AFTER_SPAWN_SEC"
 echo "[6/8] verify team session status visibility"
 status_raw="$(call_tool 91006 "masc_team_session_status" "$(jq -cn --arg s "$SESSION_ID" '{session_id:$s}')")"
 require_tool_success "$status_raw"
-require_result_condition "$status_raw" '
+status_expr='
   .summary.scale_profile == "local64"
   and (.summary.planned_worker_count >= '"$WORKER_COUNT"')
   and ((.summary.worker_class_counts.manager // 0) >= 1)
@@ -239,17 +322,63 @@ require_result_condition "$status_raw" '
   and ((.summary.worker_class_counts.scout // 0) >= 1)
   and ((.summary.runtime_pool_counts.local64 // 0) >= '"$WORKER_COUNT"')
   and (.local_runtime != null)
-' "session status did not expose local64 role/runtime visibility"
+'
+if [ "$LOCAL64_ROUTER_MODE" = "hybrid" ]; then
+  if [ "$worker_tier_available" = "true" ]; then
+    status_expr='
+      '"$status_expr"'
+      and ((.summary.tier_counts["35b"] // 0) >= 2)
+      and ((.summary.tier_counts["9b"] // 0) >= 1)
+      and ((.summary.task_profile_counts.decide // 0) >= 1)
+      and ((.summary.task_profile_counts.verify // 0) >= 1)
+      and ((.summary.task_profile_counts.extract // 0) >= 1)
+      and ((.summary.task_profile_counts.summarize // 0) >= 1)
+      and ((.summary.task_profile_counts.normalize // 0) >= 1)
+    '
+  else
+    status_expr='
+      '"$status_expr"'
+      and ((.summary.tier_counts["35b"] // 0) >= '"$WORKER_COUNT"')
+      and ((.summary.escalation_count // 0) >= 1)
+      and ((.summary.task_profile_counts.decide // 0) >= 1)
+      and ((.summary.task_profile_counts.verify // 0) >= 1)
+      and ((.summary.task_profile_counts.extract // 0) >= 1)
+      and ((.summary.task_profile_counts.summarize // 0) >= 1)
+      and ((.summary.task_profile_counts.normalize // 0) >= 1)
+    '
+  fi
+fi
+require_result_condition "$status_raw" "$status_expr" "session status did not expose local64 role/runtime visibility"
 
 echo "[7/8] verify operator room census"
 digest_raw="$(call_tool 91007 "masc_operator_digest" '{"target_type":"room"}')"
 require_tool_success "$digest_raw"
-require_result_condition "$digest_raw" '
+digest_expr='
   ((.role_census.manager // 0) >= 1)
   and ((.role_census.metacog // 0) >= 1)
   and ((.runtime_pools.local64 // 0) >= '"$WORKER_COUNT"')
   and (.local_runtime != null)
-' "operator digest did not expose local64 census/runtime visibility"
+'
+if [ "$LOCAL64_ROUTER_MODE" = "hybrid" ]; then
+  if [ "$worker_tier_available" = "true" ]; then
+    digest_expr='
+      '"$digest_expr"'
+      and ((.model_tiers["35b"] // 0) >= 2)
+      and ((.model_tiers["9b"] // 0) >= 1)
+      and ((.task_profiles.decide // 0) >= 1)
+      and ((.task_profiles.normalize // 0) >= 1)
+    '
+  else
+    digest_expr='
+      '"$digest_expr"'
+      and ((.model_tiers["35b"] // 0) >= '"$WORKER_COUNT"')
+      and ((.escalation_count // 0) >= 1)
+      and ((.task_profiles.decide // 0) >= 1)
+      and ((.task_profiles.normalize // 0) >= 1)
+    '
+  fi
+fi
+require_result_condition "$digest_raw" "$digest_expr" "operator digest did not expose local64 census/runtime visibility"
 
 echo "[8/8] benchmark runtime pool"
 bench_raw="$(call_tool 91008 "masc_llama_runtime_bench" '{"parallelism":8,"rounds":1,"runtime_pool":"local64"}')"
@@ -257,3 +386,6 @@ require_tool_success "$bench_raw"
 require_result_condition "$bench_raw" '.total_requests >= 1 and .per_runtime_breakdown != null' "runtime bench did not return breakdown"
 
 echo "PASS: local64 smoke session=${SESSION_ID} workers=${WORKER_COUNT}"
+if [ -n "${MASC_LOCAL64_BASE_PATH:-}" ]; then
+  echo "ARTIFACT_DIR=${MASC_LOCAL64_BASE_PATH}/.masc/team-sessions/${SESSION_ID}"
+fi

--- a/scripts/harness/workload/team_session_local64_soak.sh
+++ b/scripts/harness/workload/team_session_local64_soak.sh
@@ -3,20 +3,130 @@ set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
 SMOKE_SCRIPT="$ROOT_DIR/scripts/harness/workload/team_session_local64_smoke.sh"
+source "${ROOT_DIR}/scripts/harness/jsonrpc_sse.sh"
 
 MCP_URL="${MCP_URL:-http://127.0.0.1:8945/mcp}"
 COORD_AGENT="${COORD_AGENT:-team-session-local64-soak}"
-WORKER_COUNT="${WORKER_COUNT:-24}"
-ROUNDS="${ROUNDS:-2}"
-SESSION_DURATION_SEC="${SESSION_DURATION_SEC:-2400}"
+WORKER_COUNT="${WORKER_COUNT:-8}"
+ROUNDS="${ROUNDS:-10}"
+SESSION_DURATION_SEC="${SESSION_DURATION_SEC:-900}"
 SPAWN_TIMEOUT_SEC="${SPAWN_TIMEOUT_SEC:-}"
 WAIT_AFTER_SPAWN_SEC="${WAIT_AFTER_SPAWN_SEC:-3}"
+SETTLE_AFTER_ROUND_SEC="${SETTLE_AFTER_ROUND_SEC:-15}"
+HTTP_TIMEOUT_SEC="${HTTP_TIMEOUT_SEC:-120}"
 LLAMA_SWARM_MODEL="${LLAMA_SWARM_MODEL:-}"
+LOCAL64_ROUTER_MODE="${LOCAL64_ROUTER_MODE:-hybrid}"
+RSS_MAX_DELTA_KB="${LOCAL64_SOAK_RSS_MAX_DELTA_KB:-153600}"
+RSS_MAX_DELTA_RATIO="${LOCAL64_SOAK_RSS_MAX_DELTA_RATIO:-1.2}"
+METRICS_FILE="${LOCAL64_SOAK_METRICS_FILE:-${MASC_LOCAL64_BASE_PATH:-${TMPDIR:-/tmp}}/local64-soak-metrics.jsonl}"
 
 if [ ! -f "$SMOKE_SCRIPT" ]; then
   echo "Missing smoke workload: $SMOKE_SCRIPT" >&2
   exit 1
 fi
+
+mkdir -p "$(dirname "$METRICS_FILE")"
+
+jsonrpc_call() {
+  local id="$1"
+  local method="$2"
+  local params="$3"
+  local raw
+  raw="$(curl -sS --http1.1 --max-time "$HTTP_TIMEOUT_SEC" -X POST "$MCP_URL" \
+    -H 'Content-Type: application/json' \
+    -H 'Accept: application/json, text/event-stream' \
+    -d "{\"jsonrpc\":\"2.0\",\"id\":$id,\"method\":\"$method\",\"params\":$params}")"
+  jsonrpc_normalize_response "$raw" "$id"
+}
+
+call_tool() {
+  local id="$1"
+  local tool_name="$2"
+  local args_json="$3"
+  jsonrpc_call "$id" "tools/call" "{\"name\":\"$tool_name\",\"arguments\":$args_json}"
+}
+
+extract_text() {
+  jq -r 'try (.result.content[0].text) catch empty'
+}
+
+extract_result() {
+  jq -c 'try (.result.content[0].text | fromjson | if has("result") and .result != null then .result else . end) catch empty'
+}
+
+extract_is_error() {
+  jq -r 'try (.result.isError) catch "true"'
+}
+
+require_json() {
+  local payload="$1"
+  if ! printf '%s' "$payload" | jq -e . >/dev/null 2>&1; then
+    echo "FAIL: invalid payload"
+    printf '%s\n' "$payload"
+    exit 1
+  fi
+}
+
+require_tool_success() {
+  local payload="$1"
+  require_json "$payload"
+  local is_error
+  is_error="$(printf '%s' "$payload" | extract_is_error)"
+  if [ "$is_error" = "true" ]; then
+    echo "FAIL: tool returned isError=true"
+    printf '%s\n' "$payload" | extract_text
+    exit 1
+  fi
+}
+
+sample_running_session_count() {
+  local raw
+  raw="$(call_tool 92001 "masc_team_session_list" '{"status":"running","limit":200}')"
+  require_tool_success "$raw"
+  printf '%s' "$raw" | extract_result | jq -r '.count // 0'
+}
+
+sample_allocated_slots() {
+  local raw
+  raw="$(call_tool 92002 "masc_llama_runtime_status" '{"include_models":false}')"
+  require_tool_success "$raw"
+  printf '%s' "$raw" | extract_result | jq -r '.allocated_slots // 0'
+}
+
+sample_zombie_cleanup_text() {
+  local raw
+  raw="$(call_tool 92003 "masc_cleanup_zombies" '{}')"
+  require_tool_success "$raw"
+  printf '%s' "$raw" | extract_text
+}
+
+sample_rss_kb() {
+  local pid="${MASC_LOCAL64_SERVER_PID:-}"
+  if [ -z "$pid" ] || ! command -v ps >/dev/null 2>&1; then
+    return 0
+  fi
+  if ! ps -p "$pid" >/dev/null 2>&1; then
+    return 0
+  fi
+  ps -o rss= -p "$pid" | awk '{print $1}'
+}
+
+record_metric() {
+  local payload="$1"
+  printf '%s\n' "$payload" >>"$METRICS_FILE"
+}
+
+baseline_running_sessions="$(sample_running_session_count)"
+baseline_allocated_slots="$(sample_allocated_slots)"
+baseline_rss_kb="$(sample_rss_kb)"
+peak_rss_kb="${baseline_rss_kb:-0}"
+
+record_metric "$(jq -cn \
+  --arg kind "baseline" \
+  --argjson running "$baseline_running_sessions" \
+  --argjson slots "$baseline_allocated_slots" \
+  --argjson rss "${baseline_rss_kb:-null}" \
+  '{kind:$kind,running_sessions:$running,allocated_slots:$slots,rss_kb:$rss}')"
 
 success=0
 for round in $(seq 1 "$ROUNDS"); do
@@ -30,9 +140,40 @@ for round in $(seq 1 "$ROUNDS"); do
     WAIT_AFTER_SPAWN_SEC="$WAIT_AFTER_SPAWN_SEC" \
     GOAL="Repeated local64 smoke round ${round}/${ROUNDS}" \
     LLAMA_SWARM_MODEL="$LLAMA_SWARM_MODEL" \
+    LOCAL64_ROUTER_MODE="$LOCAL64_ROUTER_MODE" \
     bash "$SMOKE_SCRIPT" >"$round_log" 2>&1; then
     session_id="$(rg -o 'session=[^ ]+' "$round_log" | tail -n1 | cut -d= -f2)"
-    printf '[soak] round=%s pass session=%s\n' "$round" "${session_id:-unknown}"
+    sleep "$SETTLE_AFTER_ROUND_SEC"
+    running_sessions="$(sample_running_session_count)"
+    allocated_slots="$(sample_allocated_slots)"
+    zombie_cleanup_text="$(sample_zombie_cleanup_text)"
+    rss_kb="$(sample_rss_kb)"
+    if [ -n "${rss_kb:-}" ] && [ "$rss_kb" -gt "${peak_rss_kb:-0}" ]; then
+      peak_rss_kb="$rss_kb"
+    fi
+    record_metric "$(jq -cn \
+      --arg kind "round" \
+      --argjson round "$round" \
+      --arg session_id "${session_id:-unknown}" \
+      --argjson running "$running_sessions" \
+      --argjson slots "$allocated_slots" \
+      --arg zombie_cleanup "$zombie_cleanup_text" \
+      --argjson rss "${rss_kb:-null}" \
+      '{kind:$kind,round:$round,session_id:$session_id,running_sessions:$running,allocated_slots:$slots,zombie_cleanup:$zombie_cleanup,rss_kb:$rss}')"
+    if [ "$running_sessions" -ne "$baseline_running_sessions" ]; then
+      echo "FAIL: local64 soak running session count drifted after round $round (baseline=$baseline_running_sessions current=$running_sessions)" >&2
+      exit 1
+    fi
+    if [ "$allocated_slots" -ne "$baseline_allocated_slots" ]; then
+      echo "FAIL: local64 soak allocated_slots drifted after round $round (baseline=$baseline_allocated_slots current=$allocated_slots)" >&2
+      exit 1
+    fi
+    if [[ "$zombie_cleanup_text" != *"No zombie"* ]]; then
+      echo "FAIL: local64 soak found zombie cleanup drift after round $round: $zombie_cleanup_text" >&2
+      exit 1
+    fi
+    printf '[soak] round=%s pass session=%s running=%s slots=%s rss_kb=%s\n' \
+      "$round" "${session_id:-unknown}" "$running_sessions" "$allocated_slots" "${rss_kb:-n/a}"
     success=$((success + 1))
   else
     cat "$round_log" >&2 || true
@@ -41,4 +182,45 @@ for round in $(seq 1 "$ROUNDS"); do
   fi
 done
 
-echo "PASS: local64 soak rounds=${ROUNDS} workers=${WORKER_COUNT} success=${success}"
+final_running_sessions="$(sample_running_session_count)"
+final_allocated_slots="$(sample_allocated_slots)"
+final_zombie_cleanup="$(sample_zombie_cleanup_text)"
+final_rss_kb="$(sample_rss_kb)"
+
+record_metric "$(jq -cn \
+  --arg kind "final" \
+  --argjson rounds "$ROUNDS" \
+  --argjson success "$success" \
+  --argjson baseline_running "$baseline_running_sessions" \
+  --argjson baseline_slots "$baseline_allocated_slots" \
+  --argjson final_running "$final_running_sessions" \
+  --argjson final_slots "$final_allocated_slots" \
+  --arg zombie_cleanup "$final_zombie_cleanup" \
+  --argjson baseline_rss "${baseline_rss_kb:-null}" \
+  --argjson final_rss "${final_rss_kb:-null}" \
+  --argjson peak_rss "${peak_rss_kb:-null}" \
+  '{kind:$kind,rounds:$rounds,success:$success,baseline_running_sessions:$baseline_running,baseline_allocated_slots:$baseline_slots,final_running_sessions:$final_running,final_allocated_slots:$final_slots,zombie_cleanup:$zombie_cleanup,baseline_rss_kb:$baseline_rss,final_rss_kb:$final_rss,peak_rss_kb:$peak_rss}')"
+
+if [ "$final_running_sessions" -ne "$baseline_running_sessions" ]; then
+  echo "FAIL: final running session count drifted (baseline=$baseline_running_sessions current=$final_running_sessions)" >&2
+  exit 1
+fi
+if [ "$final_allocated_slots" -ne "$baseline_allocated_slots" ]; then
+  echo "FAIL: final allocated_slots drifted (baseline=$baseline_allocated_slots current=$final_allocated_slots)" >&2
+  exit 1
+fi
+if [[ "$final_zombie_cleanup" != *"No zombie"* ]]; then
+  echo "FAIL: final zombie cleanup detected drift: $final_zombie_cleanup" >&2
+  exit 1
+fi
+
+if [ -n "${baseline_rss_kb:-}" ] && [ -n "${final_rss_kb:-}" ] && [ "$baseline_rss_kb" -gt 0 ]; then
+  rss_delta_kb=$((final_rss_kb - baseline_rss_kb))
+  rss_limit_kb="$(awk -v base="$baseline_rss_kb" -v ratio="$RSS_MAX_DELTA_RATIO" 'BEGIN { printf "%.0f", base * (ratio - 1.0) }')"
+  if [ "$rss_delta_kb" -gt "$RSS_MAX_DELTA_KB" ] && [ "$rss_delta_kb" -gt "$rss_limit_kb" ]; then
+    echo "FAIL: RSS drift exceeded threshold (baseline=${baseline_rss_kb}KB final=${final_rss_kb}KB delta=${rss_delta_kb}KB)" >&2
+    exit 1
+  fi
+fi
+
+echo "PASS: local64 soak rounds=${ROUNDS} workers=${WORKER_COUNT} success=${success} metrics=${METRICS_FILE}"

--- a/scripts/harness_team_session_local64_smoke.sh
+++ b/scripts/harness_team_session_local64_smoke.sh
@@ -61,6 +61,7 @@ trap cleanup EXIT
 
 resolve_server_exe
 mkdir -p "$BASE_PATH"
+export MASC_LOCAL64_BASE_PATH="$BASE_PATH"
 
 need_pool_start="false"
 if [ "$POOL_SHARDS" -gt 1 ] || [ "$POOL_FORCE_START" = "true" ]; then
@@ -74,6 +75,34 @@ fi
 if [ "$need_pool_start" = "true" ]; then
   export MASC_LLAMA_RUNTIMES_JSON="$("$ROOT_DIR/scripts/llama-runtime-pool.sh" start --target-shards "$POOL_SHARDS" --seed-port "$SEED_PORT")"
   POOL_STARTED="true"
+fi
+
+discovered_models_json=""
+if command -v jq >/dev/null 2>&1; then
+  if [ -n "${MASC_LLAMA_RUNTIMES_JSON:-}" ]; then
+    discovered_models_json="$(printf '%s' "$MASC_LLAMA_RUNTIMES_JSON" | jq -c '[.[] | .model // empty | select(type == "string" and . != "")]')"
+  else
+    model_probe_url="${LLAMA_SERVER_URL:-http://127.0.0.1:${SEED_PORT}}/v1/models"
+    model_probe_raw="$(curl -fsS --max-time 5 "$model_probe_url" 2>/dev/null || true)"
+    if [ -n "${model_probe_raw:-}" ]; then
+      discovered_models_json="$(printf '%s' "$model_probe_raw" | jq -c '[.data[]? | .id // empty | select(type == "string" and . != "")]' 2>/dev/null || true)"
+    fi
+  fi
+fi
+
+if command -v jq >/dev/null 2>&1 && [ -n "${discovered_models_json:-}" ]; then
+  if [ -z "${MASC_TEAM_SESSION_MODEL_35B:-}" ]; then
+    inferred_lead_model="$(printf '%s' "$discovered_models_json" | jq -r '.[0] // empty')"
+    if [ -n "${inferred_lead_model:-}" ]; then
+      export MASC_TEAM_SESSION_MODEL_35B="$inferred_lead_model"
+    fi
+  fi
+  if [ -z "${MASC_TEAM_SESSION_MODEL_9B:-}" ]; then
+    inferred_worker_model="$(printf '%s' "$discovered_models_json" | jq -r '[.[] | select(ascii_downcase | contains("9b"))] | .[0] // empty')"
+    if [ -n "${inferred_worker_model:-}" ]; then
+      export MASC_TEAM_SESSION_MODEL_9B="$inferred_worker_model"
+    fi
+  fi
 fi
 
 MCP_URL="${MCP_URL:-http://127.0.0.1:${PORT}/mcp}"
@@ -90,6 +119,11 @@ if [ "$MCP_URL" = "http://127.0.0.1:${PORT}/mcp" ]; then
     MASC_LLAMA_RUNTIMES_JSON="${MASC_LLAMA_RUNTIMES_JSON:-}" \
     MASC_LLAMA_RUNTIME_COOLDOWN_SEC="${MASC_LLAMA_RUNTIME_COOLDOWN_SEC:-}" \
     MASC_LLAMA_RUNTIME_DEBUG="${MASC_LLAMA_RUNTIME_DEBUG:-}" \
+    MASC_TEAM_SESSION_MODEL_35B="${MASC_TEAM_SESSION_MODEL_35B:-}" \
+    MASC_TEAM_SESSION_MODEL_9B="${MASC_TEAM_SESSION_MODEL_9B:-}" \
+    MASC_TEAM_SESSION_ROUTER_JUDGE="${MASC_TEAM_SESSION_ROUTER_JUDGE:-}" \
+    MASC_TEAM_SESSION_ROUTER_JUDGE_MODEL="${MASC_TEAM_SESSION_ROUTER_JUDGE_MODEL:-}" \
+    MASC_TEAM_SESSION_ROUTER_CONFIDENCE_THRESHOLD="${MASC_TEAM_SESSION_ROUTER_CONFIDENCE_THRESHOLD:-}" \
     MASC_STORAGE_TYPE=filesystem \
     MASC_BASE_PATH="$BASE_PATH" \
     MASC_GUARDIAN_ENABLED=false \
@@ -107,5 +141,7 @@ if [ "$MCP_URL" = "http://127.0.0.1:${PORT}/mcp" ]; then
   fi
 fi
 
+export MASC_LOCAL64_SERVER_PID="${SERVER_PID:-}"
+export MASC_LOCAL64_LOG_FILE="${LOG_FILE:-}"
 export MCP_URL
 exec bash "$WORKLOAD_SCRIPT" "$@"

--- a/test/test_local_runtime_pool.ml
+++ b/test/test_local_runtime_pool.ml
@@ -35,7 +35,7 @@ let test_acquire_and_release () =
   Local_runtime_pool.reset ();
   let json =
     {|[
-      {"id":"local-a","base_url":"http://127.0.0.1:8085","model":"qwen-a","max_concurrency":2},
+      {"id":"local-a","base_url":"http://127.0.0.1:8085","max_concurrency":2},
       {"id":"local-b","base_url":"http://127.0.0.1:8086","model":"qwen-b","max_concurrency":2}
     ]|}
   in
@@ -60,6 +60,45 @@ let test_acquire_and_release () =
   in
   Alcotest.(check int) "active slots released" 0 snapshot.active_slots;
   Alcotest.(check int) "success count recorded" 1 snapshot.total_success
+
+let test_acquire_prefers_exact_model_match () =
+  Local_runtime_pool.reset ();
+  let json =
+    {|[
+      {"id":"generic","base_url":"http://127.0.0.1:8185","max_concurrency":2},
+      {"id":"lead","base_url":"http://127.0.0.1:8186","model":"qwen35-lead","max_concurrency":2},
+      {"id":"worker","base_url":"http://127.0.0.1:8187","model":"qwen9-worker","max_concurrency":2}
+    ]|}
+  in
+  with_env "MASC_LLAMA_RUNTIMES_JSON" (Some json) @@ fun () ->
+  let assignment =
+    match Local_runtime_pool.acquire ~model_name:(Some "qwen9-worker") () with
+    | Ok assignment -> assignment
+    | Error err -> failwith err
+  in
+  Alcotest.(check string) "exact runtime selected" "worker" assignment.runtime_id;
+  Alcotest.(check string) "requested model preserved" "qwen9-worker"
+    assignment.model_name;
+  Local_runtime_pool.release assignment.lease ~success:true ()
+
+let test_acquire_rejects_mismatched_preferred_model_pool () =
+  Local_runtime_pool.reset ();
+  let json =
+    {|[
+      {"id":"lead","base_url":"http://127.0.0.1:8285","model":"qwen35-lead","max_concurrency":2},
+      {"id":"worker","base_url":"http://127.0.0.1:8286","model":"qwen9-worker","max_concurrency":2}
+    ]|}
+  in
+  with_env "MASC_LLAMA_RUNTIMES_JSON" (Some json) @@ fun () ->
+  match
+    Local_runtime_pool.acquire ~preferred_pool:"lead"
+      ~model_name:(Some "qwen9-worker") ()
+  with
+  | Ok _ -> Alcotest.fail "preferred pool with mismatched model should fail"
+  | Error message ->
+      Alcotest.(check string) "mismatch error"
+        "no local llama runtime configured for model qwen9-worker in runtime pool lead"
+        message
 
 let test_select_runtime_from_empty_returns_error () =
   match Local_runtime_pool.select_runtime_from [] () with
@@ -128,6 +167,10 @@ let () =
         [
           Alcotest.test_case "parse runtime env" `Quick test_parse_runtime_env;
           Alcotest.test_case "acquire and release" `Quick test_acquire_and_release;
+          Alcotest.test_case "acquire prefers exact model match" `Quick
+            test_acquire_prefers_exact_model_match;
+          Alcotest.test_case "acquire rejects mismatched preferred model pool"
+            `Quick test_acquire_rejects_mismatched_preferred_model_pool;
           Alcotest.test_case "empty runtime set returns error" `Quick
             test_select_runtime_from_empty_returns_error;
           Alcotest.test_case "acquire requires explicit model when runtime omits it"

--- a/test/test_operator_control.ml
+++ b/test/test_operator_control.ml
@@ -211,6 +211,12 @@ let test_snapshot_and_digest_expose_role_runtime_census () =
                     parent_actor = None;
                     capsule_mode = Some Team_session_types.Capsule_capsule;
                     runtime_pool = Some "local64";
+                    model_tier = Some Team_session_types.Tier_35b;
+                    task_profile = Some Team_session_types.Profile_decide;
+                    risk_level = Some Team_session_types.Risk_high;
+                    routing_confidence = Some 0.94;
+                    routing_reason = Some "explicit:lead_manager";
+                    routing_escalated = false;
                   };
                   {
                     Team_session_types.spawn_agent = "llama";
@@ -221,6 +227,12 @@ let test_snapshot_and_digest_expose_role_runtime_census () =
                     parent_actor = Some "llama-local-manager";
                     capsule_mode = Some Team_session_types.Capsule_capsule;
                     runtime_pool = Some "local64";
+                    model_tier = Some Team_session_types.Tier_35b;
+                    task_profile = Some Team_session_types.Profile_verify;
+                    risk_level = Some Team_session_types.Risk_high;
+                    routing_confidence = Some 0.88;
+                    routing_reason = Some "policy:metacog_guard";
+                    routing_escalated = true;
                   };
                   {
                     Team_session_types.spawn_agent = "llama";
@@ -231,6 +243,12 @@ let test_snapshot_and_digest_expose_role_runtime_census () =
                     parent_actor = Some "llama-local-manager";
                     capsule_mode = Some Team_session_types.Capsule_inherit;
                     runtime_pool = Some "local64";
+                    model_tier = Some Team_session_types.Tier_9b;
+                    task_profile = Some Team_session_types.Profile_normalize;
+                    risk_level = Some Team_session_types.Risk_low;
+                    routing_confidence = Some 0.83;
+                    routing_reason = Some "rule:machine_checkable";
+                    routing_escalated = false;
                   };
                 ];
               updated_at_iso = Types.now_iso ();
@@ -245,6 +263,14 @@ let test_snapshot_and_digest_expose_role_runtime_census () =
         Yojson.Safe.Util.(snapshot |> member "role_census" |> member "metacog" |> to_int);
       Alcotest.(check int) "room runtime pool local64" 3
         Yojson.Safe.Util.(snapshot |> member "runtime_pools" |> member "local64" |> to_int);
+      Alcotest.(check int) "room tier 35b count" 2
+        Yojson.Safe.Util.(snapshot |> member "model_tiers" |> member "35b" |> to_int);
+      Alcotest.(check int) "room tier 9b count" 1
+        Yojson.Safe.Util.(snapshot |> member "model_tiers" |> member "9b" |> to_int);
+      Alcotest.(check int) "room task profile normalize" 1
+        Yojson.Safe.Util.(snapshot |> member "task_profiles" |> member "normalize" |> to_int);
+      Alcotest.(check int) "room escalation count" 1
+        Yojson.Safe.Util.(snapshot |> member "escalation_count" |> to_int);
       let digest =
         match
           Operator_control.digest_json ~actor:"dashboard"
@@ -263,7 +289,35 @@ let test_snapshot_and_digest_expose_role_runtime_census () =
       Alcotest.(check int) "session card metacog count" 1
         Yojson.Safe.Util.(session_card |> member "worker_class_counts" |> member "metacog" |> to_int);
       Alcotest.(check int) "session card runtime pool local64" 3
-        Yojson.Safe.Util.(session_card |> member "runtime_pool_counts" |> member "local64" |> to_int))
+        Yojson.Safe.Util.(session_card |> member "runtime_pool_counts" |> member "local64" |> to_int);
+      Alcotest.(check int) "session card tier 35b count" 2
+        Yojson.Safe.Util.(session_card |> member "tier_counts" |> member "35b" |> to_int);
+      Alcotest.(check int) "session card tier 9b count" 1
+        Yojson.Safe.Util.(session_card |> member "tier_counts" |> member "9b" |> to_int);
+      Alcotest.(check int) "session card profile decide count" 1
+        Yojson.Safe.Util.(session_card |> member "task_profile_counts" |> member "decide" |> to_int);
+      Alcotest.(check int) "session card escalation count" 1
+        Yojson.Safe.Util.(session_card |> member "escalation_count" |> to_int);
+      let worker_cards =
+        Yojson.Safe.Util.(digest |> member "worker_cards" |> to_list)
+      in
+      let manager_card =
+        match
+          List.find_opt
+            (fun card ->
+              Yojson.Safe.Util.(card |> member "actor" |> to_string)
+              = "llama-local-manager")
+            worker_cards
+        with
+        | Some card -> card
+        | None -> Alcotest.fail "expected manager worker card"
+      in
+      Alcotest.(check string) "manager card model tier" "35b"
+        Yojson.Safe.Util.(manager_card |> member "model_tier" |> to_string);
+      Alcotest.(check string) "manager card task profile" "decide"
+        Yojson.Safe.Util.(manager_card |> member "task_profile" |> to_string);
+      Alcotest.(check string) "manager card risk level" "high"
+        Yojson.Safe.Util.(manager_card |> member "risk_level" |> to_string))
 
 let test_task_inject_requires_confirm_then_executes () =
   Eio_main.run @@ fun env ->
@@ -625,6 +679,12 @@ let test_digest_recommends_worker_spawn_batch_for_planned_worker_without_turn ()
 	                    parent_actor = None;
 	                    capsule_mode = None;
 	                    runtime_pool = None;
+	                    model_tier = Some Team_session_types.Tier_9b;
+	                    task_profile = Some Team_session_types.Profile_normalize;
+	                    risk_level = Some Team_session_types.Risk_low;
+	                    routing_confidence = Some 0.82;
+	                    routing_reason = Some "rule:machine_checkable";
+	                    routing_escalated = false;
 	                  };
 	                ];
               updated_at_iso = Types.now_iso ();

--- a/test/test_tool_team_session.ml
+++ b/test/test_tool_team_session.ml
@@ -31,6 +31,18 @@ let unwrap_ok = function
   | Ok v -> v
   | Error e -> failwith e
 
+let with_env name value f =
+  let previous = Sys.getenv_opt name in
+  (match value with
+  | Some v -> Unix.putenv name v
+  | None -> Unix.putenv name "");
+  Fun.protect
+    ~finally:(fun () ->
+      match previous with
+      | Some v -> Unix.putenv name v
+      | None -> Unix.putenv name "")
+    f
+
 let get_session_id response_json =
   response_json |> result_field |> Yojson.Safe.Util.member "session_id"
   |> Yojson.Safe.Util.to_string
@@ -717,6 +729,12 @@ let test_proof_exposes_spawn_selection_rationale () =
                    parent_actor = None;
                    capsule_mode = None;
                    runtime_pool = None;
+                   model_tier = Some Team_session_types.Tier_35b;
+                   task_profile = Some Team_session_types.Profile_decide;
+                   risk_level = Some Team_session_types.Risk_high;
+                   routing_confidence = Some 0.97;
+                   routing_reason = Some "explicit:lead";
+                   routing_escalated = false;
                  };
                ];
            updated_at_iso = Types.now_iso ();
@@ -771,6 +789,14 @@ let test_proof_exposes_spawn_selection_rationale () =
     evidence |> Yojson.Safe.Util.member "unique_spawn_runtime_actors_count"
     |> Yojson.Safe.Util.to_int
   in
+  let tier_35b_count =
+    evidence |> Yojson.Safe.Util.member "tier_counts" |> Yojson.Safe.Util.member "35b"
+    |> Yojson.Safe.Util.to_int
+  in
+  let decide_count =
+    evidence |> Yojson.Safe.Util.member "task_profile_counts"
+    |> Yojson.Safe.Util.member "decide" |> Yojson.Safe.Util.to_int
+  in
   let recorded_models =
     evidence |> Yojson.Safe.Util.member "spawn_models"
     |> Yojson.Safe.Util.to_list |> List.map Yojson.Safe.Util.to_string
@@ -778,6 +804,8 @@ let test_proof_exposes_spawn_selection_rationale () =
   Alcotest.(check string) "selection note summary" selection_note recorded_note;
   Alcotest.(check int) "planned worker count" 1 planned_worker_count;
   Alcotest.(check int) "runtime actor count" 1 runtime_actor_count;
+  Alcotest.(check int) "proof tier count" 1 tier_35b_count;
+  Alcotest.(check int) "proof decide count" 1 decide_count;
   Alcotest.(check bool) "spawn model included" true
     (List.mem spawn_model recorded_models);
   let proof_md_path =
@@ -1239,8 +1267,27 @@ let test_step_spawn_llama_requires_spawn_model () =
     detail |> Yojson.Safe.Util.member "spawn_selection_note"
     |> Yojson.Safe.Util.to_string_option
   in
-  Alcotest.(check (option string)) "selection note recorded in failure event"
-    (Some selection_note) recorded_selection_note;
+  let recorded_selection_note =
+    match recorded_selection_note with
+    | Some value -> value
+    | None -> Alcotest.fail "selection note missing in failure event"
+  in
+  Alcotest.(check bool) "selection note preserved in failure event" true
+    (try
+       let _ =
+         Str.search_forward (Str.regexp_string selection_note)
+           recorded_selection_note 0
+       in
+       true
+     with Not_found -> false);
+  Alcotest.(check bool) "routing summary appended in failure event" true
+    (try
+       let _ =
+         Str.search_forward (Str.regexp_string "[routing]")
+           recorded_selection_note 0
+       in
+       true
+     with Not_found -> false);
   cleanup_dir base_dir
 
 let test_step_spawn_batch_records_planned_workers () =
@@ -1319,6 +1366,242 @@ let test_step_spawn_batch_records_planned_workers () =
   Alcotest.(check int) "planned worker event recorded" 1
     (List.length planned_events);
   cleanup_dir base_dir
+
+let test_step_spawn_batch_applies_hybrid_routing () =
+  Eio_main.run @@ fun env ->
+  Eio.Switch.run @@ fun sw ->
+  let base_dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base_dir)
+    (fun () ->
+      let config = Room.default_config base_dir in
+      ignore (Room.init config ~agent_name:(Some "owner"));
+      ignore (Room.join config ~agent_name:"owner" ~capabilities:[] ());
+      let ctx : _ Tool_team_session.context =
+        {
+          config;
+          agent_name = "owner";
+          sw;
+          clock = Eio.Stdenv.clock env;
+          proc_mgr = None;
+        }
+      in
+      with_env "MASC_TEAM_SESSION_MODEL_35B" (Some "qwen35-lead") @@ fun () ->
+      with_env "MASC_TEAM_SESSION_MODEL_9B" (Some "qwen9-worker") @@ fun () ->
+      with_env "MASC_TEAM_SESSION_ROUTER_JUDGE" (Some "false") @@ fun () ->
+      let session_id =
+        start_session_exn ctx ~goal:"hybrid-router-step" |> get_session_id
+      in
+      let step_ok, step_body =
+        dispatch_exn ctx ~name:"masc_team_session_step"
+          ~args:
+            (`Assoc
+              [
+                ("session_id", `String session_id);
+                ( "spawn_batch",
+                  `List
+                    [
+                      `Assoc
+                        [
+                          ("spawn_agent", `String "llama");
+                          ("spawn_role", `String "normalizer");
+                          ("spawn_prompt", `String "normalize evidence into strict JSON schema");
+                        ];
+                      `Assoc
+                        [
+                          ("spawn_agent", `String "llama");
+                          ("spawn_role", `String "final-writer");
+                          ("spawn_prompt", `String "final architecture decision and synthesize the proposal");
+                        ];
+                    ] );
+              ])
+      in
+      Alcotest.(check bool) "batch step fails without proc manager" false step_ok;
+      let message =
+        parse_json_exn step_body |> Yojson.Safe.Util.member "message"
+        |> Yojson.Safe.Util.to_string
+      in
+      Alcotest.(check bool) "proc manager error surfaced" true
+        (try
+           let _ =
+             Str.search_forward
+               (Str.regexp_string "process manager unavailable")
+               message 0
+           in
+           true
+         with Not_found -> false);
+      let session =
+        Team_session_store.load_session config session_id |> Option.get
+      in
+      Alcotest.(check int) "planned workers recorded" 2
+        (List.length session.planned_workers);
+      let normalizer =
+        List.find
+          (fun worker -> worker.Team_session_types.spawn_role = Some "normalizer")
+          session.planned_workers
+      in
+      Alcotest.(check (option string)) "normalizer model" (Some "qwen9-worker")
+        normalizer.spawn_model;
+      Alcotest.(check (option string)) "normalizer tier" (Some "9b")
+        (Option.map Team_session_types.model_tier_to_string normalizer.model_tier);
+      Alcotest.(check (option string)) "normalizer profile" (Some "normalize")
+        (Option.map Team_session_types.task_profile_to_string
+           normalizer.task_profile);
+      Alcotest.(check (option string)) "normalizer risk" (Some "low")
+        (Option.map Team_session_types.risk_level_to_string normalizer.risk_level);
+      let final_writer =
+        List.find
+          (fun worker -> worker.Team_session_types.spawn_role = Some "final-writer")
+          session.planned_workers
+      in
+      Alcotest.(check (option string)) "final writer model" (Some "qwen35-lead")
+        final_writer.spawn_model;
+      Alcotest.(check (option string)) "final writer tier" (Some "35b")
+        (Option.map Team_session_types.model_tier_to_string
+           final_writer.model_tier);
+      Alcotest.(check (option string)) "final writer profile" (Some "synthesize")
+        (Option.map Team_session_types.task_profile_to_string
+           final_writer.task_profile);
+      Alcotest.(check (option string)) "final writer risk" (Some "high")
+        (Option.map Team_session_types.risk_level_to_string
+           final_writer.risk_level);
+      let status_ok, status_body =
+        dispatch_exn ctx ~name:"masc_team_session_status"
+          ~args:(`Assoc [ ("session_id", `String session_id) ])
+      in
+      Alcotest.(check bool) "status ok" true status_ok;
+      let summary =
+        parse_json_exn status_body |> result_field |> Yojson.Safe.Util.member "summary"
+      in
+      Alcotest.(check int) "summary 35b count" 1
+        Yojson.Safe.Util.(summary |> member "tier_counts" |> member "35b" |> to_int);
+      Alcotest.(check int) "summary 9b count" 1
+        Yojson.Safe.Util.(summary |> member "tier_counts" |> member "9b" |> to_int);
+      Alcotest.(check int) "summary normalize count" 1
+        Yojson.Safe.Util.(summary |> member "task_profile_counts" |> member "normalize" |> to_int);
+      Alcotest.(check int) "summary synthesize count" 1
+        Yojson.Safe.Util.(summary |> member "task_profile_counts" |> member "synthesize" |> to_int))
+
+let test_step_spawn_batch_escalates_to_inventory_lead_model () =
+  Eio_main.run @@ fun env ->
+  Eio.Switch.run @@ fun sw ->
+  let base_dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () ->
+      Local_runtime_pool.reset ();
+      cleanup_dir base_dir)
+    (fun () ->
+      let config = Room.default_config base_dir in
+      ignore (Room.init config ~agent_name:(Some "owner"));
+      ignore (Room.join config ~agent_name:"owner" ~capabilities:[] ());
+      let ctx : _ Tool_team_session.context =
+        {
+          config;
+          agent_name = "owner";
+          sw;
+          clock = Eio.Stdenv.clock env;
+          proc_mgr = None;
+        }
+      in
+      let runtimes_json =
+        {|[
+          {"id":"local64-a","base_url":"http://127.0.0.1:8185","model":"qwen-generic","max_concurrency":8}
+        ]|}
+      in
+      with_env "MASC_LLAMA_RUNTIMES_JSON" (Some runtimes_json) @@ fun () ->
+      with_env "MASC_TEAM_SESSION_MODEL_35B" None @@ fun () ->
+      with_env "MASC_TEAM_SESSION_MODEL_9B" None @@ fun () ->
+      with_env "MASC_TEAM_SESSION_ROUTER_JUDGE" (Some "false") @@ fun () ->
+      Local_runtime_pool.reset ();
+      let session_id =
+        start_session_exn ctx ~goal:"hybrid-router-escalates-to-inventory-lead"
+        |> get_session_id
+      in
+      let step_ok, step_body =
+        dispatch_exn ctx ~name:"masc_team_session_step"
+          ~args:
+            (`Assoc
+              [
+                ("session_id", `String session_id);
+                ( "spawn_batch",
+                  `List
+                    [
+                      `Assoc
+                        [
+                          ("spawn_agent", `String "llama");
+                          ("spawn_role", `String "normalizer");
+                          ("spawn_prompt", `String "normalize evidence into strict JSON schema");
+                        ];
+                      `Assoc
+                        [
+                          ("spawn_agent", `String "llama");
+                          ("spawn_role", `String "final-writer");
+                          ("spawn_prompt", `String "final architecture decision and synthesize the proposal");
+                        ];
+                    ] );
+              ])
+      in
+      Alcotest.(check bool) "batch step fails without proc manager" false step_ok;
+      let message =
+        parse_json_exn step_body |> Yojson.Safe.Util.member "message"
+        |> Yojson.Safe.Util.to_string
+      in
+      Alcotest.(check bool) "proc manager error surfaced" true
+        (try
+           let _ =
+             Str.search_forward
+               (Str.regexp_string "process manager unavailable")
+               message 0
+           in
+           true
+         with Not_found -> false);
+      let session =
+        Team_session_store.load_session config session_id |> Option.get
+      in
+      let normalizer =
+        List.find
+          (fun worker -> worker.Team_session_types.spawn_role = Some "normalizer")
+          session.planned_workers
+      in
+      Alcotest.(check (option string)) "normalizer escalated model"
+        (Some "qwen-generic") normalizer.spawn_model;
+      Alcotest.(check (option string)) "normalizer escalated tier" (Some "35b")
+        (Option.map Team_session_types.model_tier_to_string normalizer.model_tier);
+      Alcotest.(check bool) "normalizer reason records escalation" true
+        (match normalizer.routing_reason with
+        | Some reason -> String.contains reason ';'
+                         && (try
+                               let _ =
+                                 Str.search_forward
+                                   (Str.regexp_string "9b_unavailable->35b")
+                                   reason 0
+                               in
+                               true
+                             with Not_found -> false)
+        | None -> false);
+      let final_writer =
+        List.find
+          (fun worker -> worker.Team_session_types.spawn_role = Some "final-writer")
+          session.planned_workers
+      in
+      Alcotest.(check (option string)) "final writer inventory model"
+        (Some "qwen-generic") final_writer.spawn_model;
+      Alcotest.(check (option string)) "final writer tier remains lead"
+        (Some "35b")
+        (Option.map Team_session_types.model_tier_to_string
+           final_writer.model_tier);
+      let status_ok, status_body =
+        dispatch_exn ctx ~name:"masc_team_session_status"
+          ~args:(`Assoc [ ("session_id", `String session_id) ])
+      in
+      Alcotest.(check bool) "status ok" true status_ok;
+      let summary =
+        parse_json_exn status_body |> result_field |> Yojson.Safe.Util.member "summary"
+      in
+      Alcotest.(check int) "summary escalations recorded" 1
+        Yojson.Safe.Util.(summary |> member "escalation_count" |> to_int);
+      Alcotest.(check int) "summary 35b count after escalation" 2
+        Yojson.Safe.Util.(summary |> member "tier_counts" |> member "35b" |> to_int))
 
 let test_reconcile_failed_spawn_actor_detaches_without_turn () =
   let base_dir = temp_dir () in
@@ -1932,6 +2215,10 @@ let () =
             test_step_spawn_llama_requires_spawn_model;
           Alcotest.test_case "step-spawn-batch-records-planned-workers"
             `Quick test_step_spawn_batch_records_planned_workers;
+          Alcotest.test_case "step-spawn-batch-applies-hybrid-routing"
+            `Quick test_step_spawn_batch_applies_hybrid_routing;
+          Alcotest.test_case "step-spawn-batch-escalates-to-inventory-lead-model"
+            `Quick test_step_spawn_batch_escalates_to_inventory_lead_model;
           Alcotest.test_case "reconcile-failed-spawn-actor-detaches-without-turn"
             `Quick test_reconcile_failed_spawn_actor_detaches_without_turn;
           Alcotest.test_case "reconcile-failed-spawn-actor-retains-after-turn"


### PR DESCRIPTION
## Summary
- add routing metadata and census for local64/team-session workers
- surface model tier/task profile/escalation visibility in session/operator/report outputs
- harden local64 smoke/soak harnesses with hybrid routing defaults and cleanup/RSS checks

## Validation
- dune build --root . ./bin/main_eio.exe test/test_tool_team_session.exe test/test_operator_control.exe
- ./_build/default/test/test_local_runtime_pool.exe
- ./_build/default/test/test_operator_control.exe
- ./_build/default/test/test_tool_team_session.exe
- ROUNDS=1 WORKER_COUNT=8 WAIT_AFTER_SPAWN_SEC=1 SETTLE_AFTER_ROUND_SEC=2 LOCAL64_POOL_TARGET_SHARDS=1 ./scripts/harness_team_session_local64_soak.sh