### PR TITLE
fix(ci): rename agent-sdk to oas + private repo auth

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,9 +21,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Configure private repo access
-        run: git config --global url."https://x-access-token:${{ secrets.PRIVATE_REPO_PAT }}@github.com/".insteadOf "https://github.com/"
-
       - name: Setup OCaml
         uses: ocaml/setup-ocaml@v3
         with:
@@ -89,9 +86,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Configure private repo access
-        run: git config --global url."https://x-access-token:${{ secrets.PRIVATE_REPO_PAT }}@github.com/".insteadOf "https://github.com/"
-
       - name: Setup OCaml
         uses: ocaml/setup-ocaml@v3
         with:
@@ -133,9 +127,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-
-      - name: Configure private repo access
-        run: git config --global url."https://x-access-token:${{ secrets.PRIVATE_REPO_PAT }}@github.com/".insteadOf "https://github.com/"
 
       - name: Setup OCaml
         uses: ocaml/setup-ocaml@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Configure private repo access
+        run: git config --global url."https://x-access-token:${{ secrets.PRIVATE_REPO_PAT }}@github.com/".insteadOf "https://github.com/"
+
       - name: Setup OCaml
         uses: ocaml/setup-ocaml@v3
         with:
@@ -86,6 +89,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Configure private repo access
+        run: git config --global url."https://x-access-token:${{ secrets.PRIVATE_REPO_PAT }}@github.com/".insteadOf "https://github.com/"
+
       - name: Setup OCaml
         uses: ocaml/setup-ocaml@v3
         with:
@@ -127,6 +133,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - name: Configure private repo access
+        run: git config --global url."https://x-access-token:${{ secrets.PRIVATE_REPO_PAT }}@github.com/".insteadOf "https://github.com/"
 
       - name: Setup OCaml
         uses: ocaml/setup-ocaml@v3

--- a/scripts/opam-pin-external-deps.sh
+++ b/scripts/opam-pin-external-deps.sh
@@ -24,7 +24,7 @@ if $include_compact_protocol; then
 fi
 
 opam pin add mcp_protocol https://github.com/jeong-sik/mcp-protocol-sdk.git#main -n -y
-opam pin add agent_sdk https://github.com/jeong-sik/agent-sdk.git#main -n -y
+opam pin add agent_sdk https://github.com/jeong-sik/oas.git#main -n -y
 opam pin add ocaml-webrtc https://github.com/jeong-sik/ocaml-webrtc.git#main -n -y
 opam pin add grpc-direct-core https://github.com/jeong-sik/grpc-direct.git#main -n -y
 opam pin add grpc-direct https://github.com/jeong-sik/grpc-direct.git#main -n -y


### PR DESCRIPTION
## Summary
- GitHub repo `agent-sdk` → `oas`로 rename 완료
- opam pin URL 업데이트 (`oas.git`)
- CI 3개 job에 `PRIVATE_REPO_PAT` credential 설정 추가

## CI 실패 원인
`agent-sdk` (현재 `oas`)가 private repo인데 CI에서 인증 없이 `opam pin`으로 fetch 시도 → `fatal: could not read Username`

## TODO
- [ ] GitHub Settings → Fine-grained PAT 생성 (`jeong-sik/oas` Contents Read)
- [ ] `gh secret set PRIVATE_REPO_PAT --repo jeong-sik/masc-mcp` 으로 시크릿 등록
- [ ] CI re-run으로 green 확인

Generated with [Claude Code](https://claude.com/claude-code)