### PR TITLE
fix(ci): update opam pin URL from agent-sdk to oas

### DIFF
--- a/scripts/opam-pin-external-deps.sh
+++ b/scripts/opam-pin-external-deps.sh
@@ -24,7 +24,7 @@ if $include_compact_protocol; then
 fi
 
 opam pin add mcp_protocol https://github.com/jeong-sik/mcp-protocol-sdk.git#main -n -y
-opam pin add agent_sdk https://github.com/jeong-sik/agent-sdk.git#main -n -y
+opam pin add agent_sdk https://github.com/jeong-sik/oas.git#main -n -y
 opam pin add ocaml-webrtc https://github.com/jeong-sik/ocaml-webrtc.git#main -n -y
 opam pin add grpc-direct-core https://github.com/jeong-sik/grpc-direct.git#main -n -y
 opam pin add grpc-direct https://github.com/jeong-sik/grpc-direct.git#main -n -y


### PR DESCRIPTION
## Summary
- `opam-pin-external-deps.sh`의 `agent_sdk` pin URL을 `agent-sdk.git` → `oas.git`으로 변경
- repo가 public으로 재생성되어 PAT credential 불필요

## Test plan
- [ ] CI Build and Test 통과 확인 (opam pin이 public oas repo에서 fetch 성공)
- [ ] CI Lint 통과 확인

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>