### PR TITLE
chore(gitignore): ignore local dotenv files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,8 @@ viewer/dist-build/
 
 # Local Claude session scratch
 .claude/
+
+# Local environment files
+.env
+.env.*
+!.env.example


### PR DESCRIPTION
## Summary
- ignore local  files at repo root
- keep tracked config files like  untouched

## Validation
- .gitignore:60:.env	.env
.gitignore:61:.env.*	.env.local
.gitignore:61:.env.*	.env.production
- verified  is still not ignored