### PR TITLE
refactor(tools): extract Tool_args, eliminate 120 duplicate arg helpers

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -190,6 +190,7 @@
    telemetry_eio
    tempo
    tools
+   tool_args
    tool_swarm
    tool_plan
    tool_run

--- a/lib/masc_mcp.ml
+++ b/lib/masc_mcp.ml
@@ -60,6 +60,7 @@ module Llm_client_eio = Llm_client_eio
 module Room_git = Room_git
 module Room_portal = Room_portal
 module Room_worktree = Room_worktree
+module Tool_args = Tool_args
 module Tool_code = Tool_code
 module Room_eio = Room_eio
 

--- a/lib/operator_control.ml
+++ b/lib/operator_control.ml
@@ -1,4 +1,5 @@
 module U = Yojson.Safe.Util
+open Tool_args
 
 let ( let* ) = Result.bind
 
@@ -41,29 +42,6 @@ type action_log_entry = {
 
 let json_ok fields =
   `Assoc (("status", `String "ok") :: fields)
-
-let get_string args key default =
-  match U.member key args with
-  | `String s -> s
-  | _ -> default
-
-let get_string_opt args key =
-  match U.member key args with
-  | `String s ->
-      let trimmed = String.trim s in
-      if trimmed = "" then None else Some trimmed
-  | _ -> None
-
-let get_int args key default =
-  match U.member key args with
-  | `Int n -> n
-  | `Intlit s -> (try int_of_string s with _ -> default)
-  | _ -> default
-
-let get_bool args key default =
-  match U.member key args with
-  | `Bool b -> b
-  | _ -> default
 
 let get_payload args =
   match U.member "payload" args with

--- a/lib/safe_ops.ml
+++ b/lib/safe_ops.ml
@@ -133,7 +133,10 @@ let json_int ?(default = 0) key json =
 
 let json_float ?(default = 0.0) key json =
   let open Yojson.Safe.Util in
-  try json |> member key |> to_float
+  try
+    match json |> member key with
+    | `Int i -> float_of_int i
+    | j -> to_float j
   with Type_error _ -> default
 
 let json_bool ?(default = false) key json =
@@ -143,7 +146,9 @@ let json_bool ?(default = false) key json =
 
 let json_string_list key json =
   let open Yojson.Safe.Util in
-  try json |> member key |> to_list |> List.map to_string
+  try
+    json |> member key |> to_list |> List.filter_map (fun v ->
+      try Some (to_string v) with Type_error _ -> None)
   with Type_error _ -> []
 
 let json_string_opt key json =

--- a/lib/safe_ops.ml
+++ b/lib/safe_ops.ml
@@ -171,6 +171,14 @@ let json_float_opt key json =
     | j -> Some (to_float j)
   with Type_error _ -> None
 
+let json_bool_opt key json =
+  let open Yojson.Safe.Util in
+  try
+    match json |> member key with
+    | `Null -> None
+    | j -> Some (to_bool j)
+  with Type_error _ -> None
+
 (** {1 Safe Process Execution} *)
 
 (* Intentionally empty: process execution lives in Process_eio (argv-only). *)

--- a/lib/tool_a2a.ml
+++ b/lib/tool_a2a.ml
@@ -1,25 +1,6 @@
 (** A2A tools - Agent-to-Agent protocol *)
 
-(* Argument helpers *)
-let get_string args key default =
-  match Yojson.Safe.Util.member key args with
-  | `String s -> s
-  | _ -> default
-
-let get_string_opt args key =
-  match Yojson.Safe.Util.member key args with
-  | `String s when s <> "" -> Some s
-  | _ -> None
-
-let get_int args key default =
-  match Yojson.Safe.Util.member key args with
-  | `Int n -> n
-  | _ -> default
-
-let get_bool args key default =
-  match Yojson.Safe.Util.member key args with
-  | `Bool b -> b
-  | _ -> default
+open Tool_args
 
 (* Context required by a2a tools *)
 type context = {

--- a/lib/tool_a2a.mli
+++ b/lib/tool_a2a.mli
@@ -1,10 +1,5 @@
 (** A2A tools - Agent-to-Agent protocol *)
 
-val get_string : Yojson.Safe.t -> string -> string -> string
-val get_string_opt : Yojson.Safe.t -> string -> string option
-val get_int : Yojson.Safe.t -> string -> int -> int
-val get_bool : Yojson.Safe.t -> string -> bool -> bool
-
 type context = {
   config: Room.config;
   agent_name: string;

--- a/lib/tool_agent.ml
+++ b/lib/tool_agent.ml
@@ -1,34 +1,11 @@
 (** Tool_agent - Agent management, metrics, and capability discovery handlers *)
 
+open Tool_args
+
 type context = {
   config: Room.config;
   agent_name: string;
 }
-
-(** Helper: get string from args *)
-let get_string args key default =
-  match Yojson.Safe.Util.member key args with
-  | `String s -> s
-  | _ -> default
-
-(** Helper: get string option from args *)
-let get_string_opt args key =
-  match Yojson.Safe.Util.member key args with
-  | `String s -> Some s
-  | _ -> None
-
-(** Helper: get int from args *)
-let get_int args key default =
-  match Yojson.Safe.Util.member key args with
-  | `Int i -> i
-  | _ -> default
-
-(** Helper: get string list from args *)
-let get_string_list args key =
-  match Yojson.Safe.Util.member key args with
-  | `List items ->
-      List.filter_map (function `String s -> Some s | _ -> None) items
-  | _ -> []
 
 (** Helper: result to response *)
 let result_to_response = function

--- a/lib/tool_agent.mli
+++ b/lib/tool_agent.mli
@@ -37,15 +37,3 @@ val handle_consolidate_learning : context -> Yojson.Safe.t -> bool * string
 
 (** Handle masc_agent_card *)
 val handle_agent_card : context -> Yojson.Safe.t -> bool * string
-
-(** Helper: get string from args *)
-val get_string : Yojson.Safe.t -> string -> string -> string
-
-(** Helper: get string option from args *)
-val get_string_opt : Yojson.Safe.t -> string -> string option
-
-(** Helper: get int from args *)
-val get_int : Yojson.Safe.t -> string -> int -> int
-
-(** Helper: get string list from args *)
-val get_string_list : Yojson.Safe.t -> string -> string list

--- a/lib/tool_args.ml
+++ b/lib/tool_args.ml
@@ -1,0 +1,26 @@
+(** Tool_args -- Tool-convention argument extraction wrappers over Safe_ops.
+
+    All tool_*.ml files should [open Tool_args] instead of defining local helpers.
+
+    Signature convention: [get_TYPE args key default] (positional, args first).
+    This bridges the tool-file convention to Safe_ops labeled API:
+    [Safe_ops.json_TYPE ~default key args] (labeled, key first).
+
+    {b Empty-string filtering}: [get_string_opt] treats [""] as [None],
+    matching the majority tool convention ([when s <> ""] guard).
+*)
+
+let get_string args key default = Safe_ops.json_string ~default key args
+let get_int args key default = Safe_ops.json_int ~default key args
+let get_float args key default = Safe_ops.json_float ~default key args
+let get_bool args key default = Safe_ops.json_bool ~default key args
+
+let get_string_opt args key =
+  match Safe_ops.json_string_opt key args with
+  | Some "" -> None
+  | other -> other
+
+let get_int_opt args key = Safe_ops.json_int_opt key args
+let get_float_opt args key = Safe_ops.json_float_opt key args
+let get_bool_opt args key = Safe_ops.json_bool_opt key args
+let get_string_list args key = Safe_ops.json_string_list key args

--- a/lib/tool_audit.ml
+++ b/lib/tool_audit.ml
@@ -1,5 +1,7 @@
 (** Tool_audit - Audit query and statistics handlers *)
 
+open Tool_args
+
 type context = {
   config: Room.config;
 }
@@ -11,40 +13,6 @@ type audit_event = {
   success: bool;
   detail: string option;
 }
-
-(* Helper functions *)
-let get_string args key default =
-  match args with
-  | `Assoc l ->
-      (match List.assoc_opt key l with
-       | Some (`String s) -> s
-       | _ -> default)
-  | _ -> default
-
-let get_string_opt args key =
-  match args with
-  | `Assoc l ->
-      (match List.assoc_opt key l with
-       | Some (`String s) when s <> "" -> Some s
-       | _ -> None)
-  | _ -> None
-
-let get_int args key default =
-  match args with
-  | `Assoc l ->
-      (match List.assoc_opt key l with
-       | Some (`Int i) -> i
-       | _ -> default)
-  | _ -> default
-
-let get_float args key default =
-  match args with
-  | `Assoc l ->
-      (match List.assoc_opt key l with
-       | Some (`Float f) -> f
-       | Some (`Int i) -> float_of_int i
-       | _ -> default)
-  | _ -> default
 
 (* Audit log path *)
 let audit_log_path (config : Room.config) =

--- a/lib/tool_audit.mli
+++ b/lib/tool_audit.mli
@@ -55,14 +55,3 @@ val governance_summary : ?since:string -> ?until_time:string -> Audit_log.audit_
 (** Convert governance report to JSON *)
 val report_to_json : governance_report -> Yojson.Safe.t
 
-(** Helper: get string from args *)
-val get_string : Yojson.Safe.t -> string -> string -> string
-
-(** Helper: get string option from args *)
-val get_string_opt : Yojson.Safe.t -> string -> string option
-
-(** Helper: get int from args *)
-val get_int : Yojson.Safe.t -> string -> int -> int
-
-(** Helper: get float from args *)
-val get_float : Yojson.Safe.t -> string -> float -> float

--- a/lib/tool_auth.ml
+++ b/lib/tool_auth.ml
@@ -1,14 +1,6 @@
 (** Auth tools - Authentication and authorization *)
 
-let get_string args key default =
-  match Yojson.Safe.Util.member key args with
-  | `String s -> s
-  | _ -> default
-
-let get_bool args key default =
-  match Yojson.Safe.Util.member key args with
-  | `Bool b -> b
-  | _ -> default
+open Tool_args
 
 type context = {
   config: Room.config;

--- a/lib/tool_auth.mli
+++ b/lib/tool_auth.mli
@@ -1,8 +1,5 @@
 (** Auth tools - Authentication and authorization *)
 
-val get_string : Yojson.Safe.t -> string -> string -> string
-val get_bool : Yojson.Safe.t -> string -> bool -> bool
-
 type context = {
   config: Room.config;
   agent_name: string;

--- a/lib/tool_board.ml
+++ b/lib/tool_board.ml
@@ -9,7 +9,7 @@
     Replaces tool_social.ml for new installations.
 *)
 
-open Yojson.Safe.Util
+open Tool_args
 
 type result = bool * string
 
@@ -46,34 +46,6 @@ let visibility_of_string = function
   | "unlisted" -> Some Board.Unlisted
   | "internal" -> Some Board.Internal
   | "direct" -> Some Board.Direct
-  | _ -> None
-
-(** {1 JSON Helpers} *)
-
-let get_string args key default =
-  match args |> member key with
-  | `String s -> s
-  | _ -> default
-
-let get_string_opt args key =
-  match args |> member key with
-  | `String s -> Some s
-  | _ -> None
-
-let get_int args key default =
-  match args |> member key with
-  | `Int i -> i
-  | _ -> default
-
-let get_bool args key default =
-  match args |> member key with
-  | `Bool b -> b
-  | _ -> default
-
-let get_float_opt args key =
-  match args |> member key with
-  | `Float f -> Some f
-  | `Int i -> Some (float_of_int i)
   | _ -> None
 
 (** {1 Formatters} *)

--- a/lib/tool_cache.ml
+++ b/lib/tool_cache.ml
@@ -4,6 +4,8 @@
     6 tools: cache_set, cache_get, cache_delete, cache_list, cache_clear, cache_stats
 *)
 
+open Tool_args
+
 (** Tool handler context *)
 type context = {
   config: Room.config;
@@ -11,41 +13,6 @@ type context = {
 
 (** Tool result type *)
 type result = bool * string
-
-(** {1 Argument Helpers} *)
-
-let get_string args key default =
-  match args with
-  | `Assoc fields ->
-      (match List.assoc_opt key fields with
-       | Some (`String s) -> s
-       | _ -> default)
-  | _ -> default
-
-let get_string_opt args key =
-  match args with
-  | `Assoc fields ->
-      (match List.assoc_opt key fields with
-       | Some (`String s) when s <> "" -> Some s
-       | _ -> None)
-  | _ -> None
-
-let get_int_opt args key =
-  match args with
-  | `Assoc fields ->
-      (match List.assoc_opt key fields with
-       | Some (`Int i) -> Some i
-       | _ -> None)
-  | _ -> None
-
-let get_string_list args key =
-  match args with
-  | `Assoc fields ->
-      (match List.assoc_opt key fields with
-       | Some (`List lst) ->
-           List.filter_map (function `String s -> Some s | _ -> None) lst
-       | _ -> [])
-  | _ -> []
 
 (** {1 Individual Handlers} *)
 

--- a/lib/tool_cache.mli
+++ b/lib/tool_cache.mli
@@ -12,13 +12,6 @@ type context = {
 (** Tool result type *)
 type result = bool * string
 
-(** {1 Argument Helpers} *)
-
-val get_string : Yojson.Safe.t -> string -> string -> string
-val get_string_opt : Yojson.Safe.t -> string -> string option
-val get_int_opt : Yojson.Safe.t -> string -> int option
-val get_string_list : Yojson.Safe.t -> string -> string list
-
 (** {1 Individual Handlers} *)
 
 val handle_cache_set : context -> Yojson.Safe.t -> result

--- a/lib/tool_code.ml
+++ b/lib/tool_code.ml
@@ -10,22 +10,7 @@
 *)
 
 open Types
-
-(* Argument helpers *)
-let get_string args key default =
-  match Yojson.Safe.Util.member key args with
-  | `String s -> s
-  | _ -> default
-
-let get_int args key default =
-  match Yojson.Safe.Util.member key args with
-  | `Int i -> i
-  | _ -> default
-
-let get_bool args key default =
-  match Yojson.Safe.Util.member key args with
-  | `Bool b -> b
-  | _ -> default
+open Tool_args
 
 (* Context required by code tools *)
 type context = {

--- a/lib/tool_command_plane.ml
+++ b/lib/tool_command_plane.ml
@@ -1,4 +1,5 @@
 open Types
+open Tool_args
 
 module U = Yojson.Safe.Util
 
@@ -14,18 +15,6 @@ type ('clock, 'net) context = {
 }
 
 type result = bool * string
-
-let get_string_opt args key =
-  match U.member key args with
-  | `String s ->
-      let trimmed = String.trim s in
-      if trimmed = "" then None else Some trimmed
-  | _ -> None
-
-let get_bool_default args key default =
-  match U.member key args with
-  | `Bool value -> value
-  | _ -> default
 
 let get_json_opt args key =
   match U.member key args with
@@ -171,7 +160,7 @@ let parse_chain_launch args =
                     chain_id = value;
                     input_json = get_json_opt args "chain_input";
                     checkpoint_enabled =
-                      get_bool_default args "chain_checkpoint_enabled" true;
+                      get_bool args "chain_checkpoint_enabled" true;
                   }))
       | None, Some goal -> Ok (Some (Chain_orchestrate { goal })))
   | other ->

--- a/lib/tool_control.ml
+++ b/lib/tool_control.ml
@@ -3,7 +3,7 @@
     Handles: pause, pause_status, resume, switch_mode, get_config
 *)
 
-open Yojson.Safe.Util
+open Tool_args
 
 type result = bool * string
 
@@ -11,24 +11,6 @@ type context = {
   config: Room.config;
   agent_name: string;
 }
-
-(* JSON helpers *)
-let get_string args key default =
-  match args |> member key with
-  | `String s -> s
-  | _ -> default
-
-let get_string_list args key =
-  match args |> member key with
-  | `List values ->
-      List.filter_map
-        (function
-          | `String s ->
-              let trimmed = String.trim s in
-              if trimmed = "" then None else Some trimmed
-          | _ -> None)
-        values
-  | _ -> []
 
 (* Handlers *)
 

--- a/lib/tool_cost.ml
+++ b/lib/tool_cost.ml
@@ -1,34 +1,10 @@
 (** Tool_cost - Cost tracking and reporting handlers *)
 
+open Tool_args
+
 type context = {
   agent_name: string;
 }
-
-(* Helper functions *)
-let get_string args key default =
-  match args with
-  | `Assoc l ->
-      (match List.assoc_opt key l with
-       | Some (`String s) -> s
-       | _ -> default)
-  | _ -> default
-
-let get_int args key default =
-  match args with
-  | `Assoc l ->
-      (match List.assoc_opt key l with
-       | Some (`Int i) -> i
-       | _ -> default)
-  | _ -> default
-
-let get_float args key default =
-  match args with
-  | `Assoc l ->
-      (match List.assoc_opt key l with
-       | Some (`Float f) -> f
-       | Some (`Int i) -> float_of_int i
-       | _ -> default)
-  | _ -> default
 
 (* Safe exec helper - runs CLI command and returns result (Eio-native) *)
 let safe_exec args =

--- a/lib/tool_cost.mli
+++ b/lib/tool_cost.mli
@@ -12,12 +12,3 @@ val handle_cost_log : context -> Yojson.Safe.t -> bool * string
 
 (** Handle masc_cost_report *)
 val handle_cost_report : context -> Yojson.Safe.t -> bool * string
-
-(** Helper: get string from args *)
-val get_string : Yojson.Safe.t -> string -> string -> string
-
-(** Helper: get int from args *)
-val get_int : Yojson.Safe.t -> string -> int -> int
-
-(** Helper: get float from args *)
-val get_float : Yojson.Safe.t -> string -> float -> float

--- a/lib/tool_council.ml
+++ b/lib/tool_council.ml
@@ -1,29 +1,7 @@
 (** Council tools - Multi-agent debate and consensus system *)
 
 open Council
-
-(* Argument helpers *)
-let get_string args key default =
-  match Yojson.Safe.Util.member key args with
-  | `String s -> s
-  | _ -> default
-
-let get_int args key default =
-  match Yojson.Safe.Util.member key args with
-  | `Int n -> n
-  | _ -> default
-
-let get_float args key default =
-  match Yojson.Safe.Util.member key args with
-  | `Float f -> f
-  | `Int n -> Float.of_int n
-  | _ -> default
-
-let get_string_list args key =
-  match Yojson.Safe.Util.member key args with
-  | `List items ->
-      List.filter_map (function `String s -> Some s | _ -> None) items
-  | _ -> []
+open Tool_args
 
 (* Context required by council tools *)
 type context = {

--- a/lib/tool_encryption.ml
+++ b/lib/tool_encryption.ml
@@ -1,9 +1,6 @@
 (** Encryption tools - Data encryption management *)
 
-let get_string args key default =
-  match Yojson.Safe.Util.member key args with
-  | `String s -> s
-  | _ -> default
+open Tool_args
 
 type context = {
   state: Mcp_server.server_state;

--- a/lib/tool_encryption.mli
+++ b/lib/tool_encryption.mli
@@ -1,7 +1,5 @@
 (** Encryption tools - Data encryption management *)
 
-val get_string : Yojson.Safe.t -> string -> string -> string
-
 type context = {
   state: Mcp_server.server_state;
 }

--- a/lib/tool_experiment.ml
+++ b/lib/tool_experiment.ml
@@ -6,29 +6,7 @@
 
     Storage: file-based under .masc/experiments/ (one JSON per experiment). *)
 
-(* {1 Argument Helpers} *)
-
-let get_string args key default =
-  match Yojson.Safe.Util.member key args with
-  | `String s -> s
-  | _ -> default
-
-let get_float args key default =
-  match Yojson.Safe.Util.member key args with
-  | `Float f -> f
-  | `Int n -> Float.of_int n
-  | _ -> default
-
-let get_int args key default =
-  match Yojson.Safe.Util.member key args with
-  | `Int n -> n
-  | _ -> default
-
-let get_string_list args key =
-  match Yojson.Safe.Util.member key args with
-  | `List items ->
-      List.filter_map (function `String s -> Some s | _ -> None) items
-  | _ -> []
+open Tool_args
 
 (* {1 Types} *)
 

--- a/lib/tool_gardener.ml
+++ b/lib/tool_gardener.ml
@@ -7,20 +7,10 @@
     - [masc_gardener_config]: Get current configuration
 *)
 
-open Yojson.Safe.Util
 open Gardener_types
+open Tool_args
 
 type result = bool * string
-
-(** {1 Helper Functions} *)
-
-let get_string args key default =
-  try args |> member key |> to_string
-  with _ -> default
-
-let get_string_opt args key =
-  try Some (args |> member key |> to_string)
-  with _ -> None
 
 (** {1 Tool Handlers} *)
 

--- a/lib/tool_goals.ml
+++ b/lib/tool_goals.ml
@@ -1,50 +1,11 @@
 open Types
+open Tool_args
 
 type context = {
   config : Room.config;
   agent_name : string;
   call_keeper_msg : (Yojson.Safe.t -> (bool * string)) option;
 }
-
-let get_string_opt args key =
-  match Yojson.Safe.Util.member key args with
-  | `String s ->
-      let trimmed = String.trim s in
-      if trimmed = "" then None else Some trimmed
-  | _ -> None
-
-let get_string args key default =
-  match get_string_opt args key with
-  | Some s -> s
-  | None -> default
-
-let get_int_opt args key =
-  match Yojson.Safe.Util.member key args with
-  | `Int i -> Some i
-  | `Intlit s -> (
-      try Some (int_of_string s) with _ -> None)
-  | _ -> None
-
-let get_int args key default =
-  match get_int_opt args key with
-  | Some i -> i
-  | None -> default
-
-let get_bool args key default =
-  match Yojson.Safe.Util.member key args with
-  | `Bool b -> b
-  | _ -> default
-
-let get_string_list args key =
-  match Yojson.Safe.Util.member key args with
-  | `List xs ->
-      xs
-      |> List.filter_map (function
-             | `String s ->
-                 let t = String.trim s in
-                 if t = "" then None else Some t
-             | _ -> None)
-  | _ -> []
 
 let split_csv raw =
   raw

--- a/lib/tool_handover.ml
+++ b/lib/tool_handover.ml
@@ -1,36 +1,6 @@
 (** Handover tools - Cellular agent handover DNA *)
 
-(* Argument helpers *)
-let get_string args key default =
-  match Yojson.Safe.Util.member key args with
-  | `String s -> s
-  | _ -> default
-
-let get_string_opt args key =
-  match Yojson.Safe.Util.member key args with
-  | `String s when s <> "" -> Some s
-  | _ -> None
-
-let get_int args key default =
-  match Yojson.Safe.Util.member key args with
-  | `Int n -> n
-  | _ -> default
-
-let _get_int_opt args key =
-  match Yojson.Safe.Util.member key args with
-  | `Int n -> Some n
-  | _ -> None
-
-let get_bool args key default =
-  match Yojson.Safe.Util.member key args with
-  | `Bool b -> b
-  | _ -> default
-
-let get_string_list args key =
-  match Yojson.Safe.Util.member key args with
-  | `List items ->
-      List.filter_map (function `String s -> Some s | _ -> None) items
-  | _ -> []
+open Tool_args
 
 (* Context required by handover tools - needs Eio filesystem *)
 type context = {
@@ -99,7 +69,7 @@ let handle_handover_claim ctx args =
 let handle_handover_claim_and_spawn ctx args =
   let handover_id = get_string args "handover_id" "" in
   let additional_instructions = get_string_opt args "additional_instructions" in
-  let timeout_seconds = _get_int_opt args "timeout_seconds" in
+  let timeout_seconds = get_int_opt args "timeout_seconds" in
   match ctx.fs, ctx.proc_mgr, ctx.sw with
   | Some fs, Some pm, Some sw ->
       (match Handover_eio.claim_and_spawn ~sw ~fs ~proc_mgr:pm ctx.config

--- a/lib/tool_handover.mli
+++ b/lib/tool_handover.mli
@@ -1,11 +1,5 @@
 (** Handover tools - Cellular agent handover DNA *)
 
-val get_string : Yojson.Safe.t -> string -> string -> string
-val get_string_opt : Yojson.Safe.t -> string -> string option
-val get_int : Yojson.Safe.t -> string -> int -> int
-val get_bool : Yojson.Safe.t -> string -> bool -> bool
-val get_string_list : Yojson.Safe.t -> string -> string list
-
 type context = {
   config: Room.config;
   agent_name: string;

--- a/lib/tool_hat.ml
+++ b/lib/tool_hat.ml
@@ -1,9 +1,6 @@
 (** Hat tools - Agent role management *)
 
-let get_string args key default =
-  match Yojson.Safe.Util.member key args with
-  | `String s -> s
-  | _ -> default
+open Tool_args
 
 type context = {
   config: Room.config;

--- a/lib/tool_hat.mli
+++ b/lib/tool_hat.mli
@@ -1,7 +1,5 @@
 (** Hat tools - Agent role management *)
 
-val get_string : Yojson.Safe.t -> string -> string -> string
-
 type context = {
   config: Room.config;
   agent_name: string;

--- a/lib/tool_heartbeat.ml
+++ b/lib/tool_heartbeat.ml
@@ -1,19 +1,6 @@
 (** Heartbeat tools - Agent health monitoring *)
 
-let get_string args key default =
-  match Yojson.Safe.Util.member key args with
-  | `String s -> s
-  | _ -> default
-
-let get_int args key default =
-  match Yojson.Safe.Util.member key args with
-  | `Int n -> n
-  | _ -> default
-
-let get_bool args key default =
-  match Yojson.Safe.Util.member key args with
-  | `Bool b -> b
-  | _ -> default
+open Tool_args
 
 type 'a context = {
   config: Room.config;

--- a/lib/tool_heartbeat.mli
+++ b/lib/tool_heartbeat.mli
@@ -1,8 +1,5 @@
 (** Heartbeat tools - Agent health monitoring *)
 
-val get_string : Yojson.Safe.t -> string -> string -> string
-val get_int : Yojson.Safe.t -> string -> int -> int
-
 type 'a context = {
   config: Room.config;
   agent_name: string;

--- a/lib/tool_keeper.ml
+++ b/lib/tool_keeper.ml
@@ -18,6 +18,7 @@
 *)
 
 open Types
+open Tool_args
 
 let keeper_debug =
   try Sys.getenv "MASC_KEEPER_DEBUG" = "1" with Not_found -> false
@@ -476,38 +477,6 @@ Persists context + checkpoints. Auto-handoff is applied when needed.";
     ];
   };
 ]
-
-(* --------------------------------------------------------------- *)
-(* Helpers                                                          *)
-(* --------------------------------------------------------------- *)
-
-let get_string args key default =
-  Safe_ops.json_string ~default key args
-
-let get_string_opt args key =
-  match Safe_ops.json_string_opt key args with
-  | Some "" -> None
-  | other -> other
-
-let get_bool args key default =
-  Safe_ops.json_bool ~default key args
-
-let get_bool_opt args key =
-  let open Yojson.Safe.Util in
-  try
-    match args |> member key with
-    | `Null -> None
-    | j -> Some (to_bool j)
-  with Type_error _ -> None
-
-let get_int args key default =
-  Safe_ops.json_int ~default key args
-
-let get_float args key default =
-  Safe_ops.json_float ~default key args
-
-let get_string_list args key =
-  Safe_ops.json_string_list key args
 
 let bool_default_true_of_env name =
   match Sys.getenv_opt name with

--- a/lib/tool_misc.ml
+++ b/lib/tool_misc.ml
@@ -3,7 +3,7 @@
     Handles: dashboard, verify_handoff, gc, cleanup_zombies
 *)
 
-open Yojson.Safe.Util
+open Tool_args
 
 type result = bool * string
 
@@ -11,22 +11,6 @@ type context = {
   config: Room.config;
   agent_name: string;
 }
-
-(* JSON helpers *)
-let get_int args key default =
-  match args |> member key with
-  | `Int i -> i
-  | _ -> default
-
-let get_bool args key default =
-  match args |> member key with
-  | `Bool b -> b
-  | _ -> default
-
-let get_string args key default =
-  match args |> member key with
-  | `String s -> s
-  | _ -> default
 
 (* Handlers *)
 

--- a/lib/tool_mitosis.ml
+++ b/lib/tool_mitosis.ml
@@ -173,35 +173,7 @@ let get_session_id () =
     | Some sid when sid <> "" -> sid
     | _ -> Printf.sprintf "session-%d" (int_of_float (Time_compat.now () *. 1000.0) mod 1000000)
 
-(** {1 Argument Helpers} *)
-
-let get_string args key default =
-  match args with
-  | `Assoc fields ->
-      (match List.assoc_opt key fields with
-       | Some (`String s) -> s
-       | Some _ -> Printf.eprintf "[MITOSIS/WARN] %s: type mismatch\n%!" key; default
-       | None -> default)
-  | _ -> default
-
-let get_float args key default =
-  match args with
-  | `Assoc fields ->
-      (match List.assoc_opt key fields with
-       | Some (`Float f) -> f
-       | Some (`Int i) -> Float.of_int i
-       | Some _ -> Printf.eprintf "[MITOSIS/WARN] %s: type mismatch\n%!" key; default
-       | None -> default)
-  | _ -> default
-
-let get_bool args key default =
-  match args with
-  | `Assoc fields ->
-      (match List.assoc_opt key fields with
-       | Some (`Bool b) -> b
-       | Some _ -> Printf.eprintf "[MITOSIS/WARN] %s: type mismatch\n%!" key; default
-       | None -> default)
-  | _ -> default
+open Tool_args
 
 (** Clamp context_ratio to valid range with warning - BALTHASAR feedback *)
 let validate_context_ratio ratio =
@@ -221,26 +193,6 @@ let set_bool_arg args key value =
       `Assoc ((key, `Bool value) :: fields')
   | _ ->
       `Assoc [ (key, `Bool value) ]
-
-let get_string_list args key default =
-  match args with
-  | `Assoc fields ->
-      (match List.assoc_opt key fields with
-       | Some (`List xs) ->
-           let vals =
-             List.filter_map (function
-               | `String s ->
-                   let v = String.trim s in
-                   if v = "" then None else Some v
-               | _ -> None
-             ) xs
-           in
-           if vals = [] then default else vals
-       | Some _ ->
-           Printf.eprintf "[MITOSIS/WARN] %s: type mismatch\n%!" key;
-           default
-       | None -> default)
-  | _ -> default
 
 let default_verifier_models = [
   "ollama:glm-4.7-flash";
@@ -277,7 +229,7 @@ let perspectives_for_profile profile =
   | _ -> default_verifier_perspectives
 
 let resolve_verifier_perspectives args =
-  let explicit = get_string_list args "verifier_perspectives" [] in
+  let explicit = get_string_list args "verifier_perspectives" in
   if explicit <> [] then
     ("custom", explicit)
   else
@@ -446,7 +398,7 @@ let run_handoff_verifier ~ctx ~args ~(parsed_result : Yojson.Safe.t) : (Yojson.S
   if not verify_enabled then
     (None, true)
   else
-    let model_strs = get_string_list args "verifier_models" default_verifier_models in
+    let model_strs = match get_string_list args "verifier_models" with [] -> default_verifier_models | xs -> xs in
     let (perspective_profile, perspectives) = resolve_verifier_perspectives args in
     let goal =
       get_string args "verifier_goal"

--- a/lib/tool_mitosis.mli
+++ b/lib/tool_mitosis.mli
@@ -92,22 +92,6 @@ val reset_handoff_cooldown : unit -> unit
     [success] is [true] when the tool executed without errors. *)
 type result = bool * string
 
-(** {1 Argument Helpers} *)
-
-(** [get_string args key default] extracts a string value from the
-    JSON [args] object at [key], returning [default] if absent or
-    not a string. *)
-val get_string : Yojson.Safe.t -> string -> string -> string
-
-(** [get_float args key default] extracts a float value from the
-    JSON [args] object at [key], returning [default] if absent.
-    Accepts both JSON floats and integers. *)
-val get_float : Yojson.Safe.t -> string -> float -> float
-
-(** [get_bool args key default] extracts a boolean value from the
-    JSON [args] object at [key], returning [default] if absent. *)
-val get_bool : Yojson.Safe.t -> string -> bool -> bool
-
 (** {1 DNA Validation} *)
 
 (** [validate_dna dna] checks DNA quality before handoff.

--- a/lib/tool_notifications.ml
+++ b/lib/tool_notifications.ml
@@ -56,17 +56,7 @@ Use masc_check_notifications first if you want to preview before consuming.";
   };
 ]
 
-(* ================================================================ *)
-(* Argument Helpers                                                 *)
-(* ================================================================ *)
-
-let get_int args key default =
-  match args with
-  | `Assoc fields ->
-      (match List.assoc_opt key fields with
-       | Some (`Int i) -> i
-       | _ -> default)
-  | _ -> default
+open Tool_args
 
 (* ================================================================ *)
 (* Handlers                                                         *)

--- a/lib/tool_operator.ml
+++ b/lib/tool_operator.ml
@@ -1,4 +1,5 @@
 open Types
+open Tool_args
 
 type 'a context = {
   config : Room.config;
@@ -10,18 +11,6 @@ type 'a context = {
 }
 
 type result = bool * string
-
-let get_string_opt args key =
-  match Yojson.Safe.Util.member key args with
-  | `String s ->
-      let trimmed = String.trim s in
-      if trimmed = "" then None else Some trimmed
-  | _ -> None
-
-let get_bool args key default =
-  match Yojson.Safe.Util.member key args with
-  | `Bool value -> value
-  | _ -> default
 
 let schema_properties entries = `Assoc entries
 

--- a/lib/tool_plan.ml
+++ b/lib/tool_plan.ml
@@ -13,23 +13,7 @@ type context = {
 (** Tool result type *)
 type result = bool * string
 
-(** {1 Argument Helpers} *)
-
-let get_string args key default =
-  match args with
-  | `Assoc fields ->
-      (match List.assoc_opt key fields with
-       | Some (`String s) -> s
-       | _ -> default)
-  | _ -> default
-
-let get_int args key default =
-  match args with
-  | `Assoc fields ->
-      (match List.assoc_opt key fields with
-       | Some (`Int i) -> i
-       | _ -> default)
-  | _ -> default
+open Tool_args
 
 (** {1 Individual Handlers} *)
 

--- a/lib/tool_plan.mli
+++ b/lib/tool_plan.mli
@@ -13,11 +13,6 @@ type context = {
 (** Tool result type *)
 type result = bool * string
 
-(** {1 Argument Helpers} *)
-
-val get_string : Yojson.Safe.t -> string -> string -> string
-val get_int : Yojson.Safe.t -> string -> int -> int
-
 (** {1 Individual Handlers} *)
 
 val handle_plan_init : context -> Yojson.Safe.t -> result

--- a/lib/tool_portal.ml
+++ b/lib/tool_portal.ml
@@ -1,15 +1,6 @@
 (** Portal tools - Agent-to-agent direct messaging *)
 
-(* Argument helpers *)
-let get_string args key default =
-  match Yojson.Safe.Util.member key args with
-  | `String s -> s
-  | _ -> default
-
-let get_string_opt args key =
-  match Yojson.Safe.Util.member key args with
-  | `String s when s <> "" -> Some s
-  | _ -> None
+open Tool_args
 
 (* Context required by portal tools *)
 type context = {

--- a/lib/tool_portal.mli
+++ b/lib/tool_portal.mli
@@ -1,8 +1,5 @@
 (** Portal tools - Agent-to-agent direct messaging *)
 
-val get_string : Yojson.Safe.t -> string -> string -> string
-val get_string_opt : Yojson.Safe.t -> string -> string option
-
 type context = {
   config: Room.config;
   agent_name: string;

--- a/lib/tool_protocol_game_view.ml
+++ b/lib/tool_protocol_game_view.ml
@@ -36,36 +36,7 @@ let ( let* ) = Result.bind
 
 let protocol_version = "masc.game-view/0.1"
 
-let get_string args key default =
-  match args |> member key with
-  | `String s -> s
-  | _ -> default
-
-let get_string_opt args key =
-  match args |> member key with
-  | `String s when String.trim s <> "" -> Some s
-  | _ -> None
-
-let get_float_opt args key =
-  match args |> member key with
-  | `Float f -> Some f
-  | `Int n -> Some (Float.of_int n)
-  | _ -> None
-
-let get_int args key default =
-  match args |> member key with
-  | `Int n -> n
-  | `Intlit s -> (
-      try int_of_string s with _ -> default)
-  | _ -> default
-
-let get_string_list args key =
-  match args |> member key with
-  | `List xs ->
-      List.filter_map
-        (function `String s when String.trim s <> "" -> Some s | _ -> None)
-        xs
-  | _ -> []
+open Tool_args
 
 let get_object_opt args key =
   match args |> member key with

--- a/lib/tool_relay.ml
+++ b/lib/tool_relay.ml
@@ -1,24 +1,6 @@
 (** Relay tools - Infinite context via handoff *)
 
-let get_string args key default =
-  match Yojson.Safe.Util.member key args with
-  | `String s -> s
-  | _ -> default
-
-let get_string_opt args key =
-  match Yojson.Safe.Util.member key args with
-  | `String s when s <> "" -> Some s
-  | _ -> None
-
-let get_int args key default =
-  match Yojson.Safe.Util.member key args with
-  | `Int n -> n
-  | _ -> default
-
-let get_string_list args key =
-  match Yojson.Safe.Util.member key args with
-  | `List items -> List.filter_map (function `String s -> Some s | _ -> None) items
-  | _ -> []
+open Tool_args
 
 type context = {
   config: Room.config;

--- a/lib/tool_relay.mli
+++ b/lib/tool_relay.mli
@@ -1,10 +1,5 @@
 (** Relay tools - Infinite context via handoff *)
 
-val get_string : Yojson.Safe.t -> string -> string -> string
-val get_string_opt : Yojson.Safe.t -> string -> string option
-val get_int : Yojson.Safe.t -> string -> int -> int
-val get_string_list : Yojson.Safe.t -> string -> string list
-
 type context = {
   config: Room.config;
   agent_name: string;

--- a/lib/tool_risc.ml
+++ b/lib/tool_risc.ml
@@ -61,42 +61,7 @@ let default_fast_model : Llm_client.model_spec = {
 let global_spec_engine =
   Speculative_engine.create ~fast_model:default_fast_model ()
 
-(* ================================================================ *)
-(* Argument Helpers (consistent with tool_cache.ml pattern)         *)
-(* ================================================================ *)
-
-let get_string args key default =
-  match args with
-  | `Assoc fields ->
-      (match List.assoc_opt key fields with
-       | Some (`String s) -> s
-       | _ -> default)
-  | _ -> default
-
-let get_string_opt args key =
-  match args with
-  | `Assoc fields ->
-      (match List.assoc_opt key fields with
-       | Some (`String s) when s <> "" -> Some s
-       | _ -> None)
-  | _ -> None
-
-let get_string_list args key =
-  match args with
-  | `Assoc fields ->
-      (match List.assoc_opt key fields with
-       | Some (`List lst) ->
-           List.filter_map (function `String s -> Some s | _ -> None) lst
-       | _ -> [])
-  | _ -> []
-
-let get_int args key default =
-  match args with
-  | `Assoc fields ->
-      (match List.assoc_opt key fields with
-       | Some (`Int i) -> i
-       | _ -> default)
-  | _ -> default
+open Tool_args
 
 (* ================================================================ *)
 (* Tool Result Type                                                 *)

--- a/lib/tool_room.ml
+++ b/lib/tool_room.ml
@@ -14,16 +14,7 @@ type context = {
   agent_name: string;
 }
 
-(* JSON helpers *)
-let get_string args key default =
-  match args |> member key with
-  | `String s -> s
-  | _ -> default
-
-let get_bool args key default =
-  match args |> member key with
-  | `Bool b -> b
-  | _ -> default
+open Tool_args
 
 (* Handlers *)
 

--- a/lib/tool_run.ml
+++ b/lib/tool_run.ml
@@ -12,23 +12,7 @@ type context = {
 (** Tool result type *)
 type result = bool * string
 
-(** {1 Argument Helpers} *)
-
-let get_string args key default =
-  match args with
-  | `Assoc fields ->
-      (match List.assoc_opt key fields with
-       | Some (`String s) -> s
-       | _ -> default)
-  | _ -> default
-
-let get_string_opt args key =
-  match args with
-  | `Assoc fields ->
-      (match List.assoc_opt key fields with
-       | Some (`String s) when s <> "" -> Some s
-       | _ -> None)
-  | _ -> None
+open Tool_args
 
 (** {1 Individual Handlers} *)
 

--- a/lib/tool_run.mli
+++ b/lib/tool_run.mli
@@ -12,11 +12,6 @@ type context = {
 (** Tool result type *)
 type result = bool * string
 
-(** {1 Argument Helpers} *)
-
-val get_string : Yojson.Safe.t -> string -> string -> string
-val get_string_opt : Yojson.Safe.t -> string -> string option
-
 (** {1 Individual Handlers} *)
 
 val handle_run_init : context -> Yojson.Safe.t -> result

--- a/lib/tool_social.ml
+++ b/lib/tool_social.ml
@@ -3,8 +3,6 @@
     Handles: masc_post_create, masc_post_list, masc_comment_add, masc_vote
 *)
 
-open Yojson.Safe.Util
-
 type result = bool * string
 
 (* Input validation *)
@@ -46,21 +44,7 @@ type context = {
   agent_name: string;
 }
 
-(* JSON helpers *)
-let get_string args key default =
-  match args |> member key with
-  | `String s -> s
-  | _ -> default
-
-let get_string_opt args key =
-  match args |> member key with
-  | `String s -> Some s
-  | _ -> None
-
-let get_int args key default =
-  match args |> member key with
-  | `Int i -> i
-  | _ -> default
+open Tool_args
 
 (* Format timestamp as relative time *)
 let format_timestamp_relative ts =

--- a/lib/tool_social.mli
+++ b/lib/tool_social.mli
@@ -1,9 +1,5 @@
 (** Tool_social - MCP tool handlers for social features *)
 
-val get_string : Yojson.Safe.t -> string -> string -> string
-val get_string_opt : Yojson.Safe.t -> string -> string option
-val get_int : Yojson.Safe.t -> string -> int -> int
-
 type context = {
   config: Room_utils.config;
   agent_name: string;

--- a/lib/tool_suspend.ml
+++ b/lib/tool_suspend.ml
@@ -13,32 +13,7 @@ type context = {
   caller_agent: string option;  (** Who is calling the tool *)
 }
 
-(** {1 Helpers} *)
-
-let get_string args key default =
-  match args with
-  | `Assoc l ->
-      (match List.assoc_opt key l with
-       | Some (`String s) -> s
-       | _ -> default)
-  | _ -> default
-
-let get_string_opt args key =
-  match args with
-  | `Assoc l ->
-      (match List.assoc_opt key l with
-       | Some (`String s) when s <> "" -> Some s
-       | _ -> None)
-  | _ -> None
-
-let get_float args key default =
-  match args with
-  | `Assoc l ->
-      (match List.assoc_opt key l with
-       | Some (`Float f) -> f
-       | Some (`Int i) -> float_of_int i
-       | _ -> default)
-  | _ -> default
+open Tool_args
 
 (** {1 Blacklist Management} *)
 

--- a/lib/tool_swarm.ml
+++ b/lib/tool_swarm.ml
@@ -5,6 +5,7 @@
 *)
 
 open Yojson.Safe.Util
+open Tool_args
 
 (** Tool handler context - shared dependencies *)
 type context = {
@@ -12,12 +13,6 @@ type context = {
   fs: Eio.Fs.dir_ty Eio.Path.t option;
   agent_name: string;
 }
-
-(** Argument extraction helpers *)
-let get_string args key default = Safe_ops.json_string ~default key args
-let get_float args key default = Safe_ops.json_float ~default key args
-let get_int args key default = Safe_ops.json_int ~default key args
-let get_bool args key default = Safe_ops.json_bool ~default key args
 
 (** Tool result type *)
 type result = bool * string

--- a/lib/tool_swarm.mli
+++ b/lib/tool_swarm.mli
@@ -14,13 +14,6 @@ type context = {
 (** Tool result type: (success, message) *)
 type result = bool * string
 
-(** {1 Argument Helpers} *)
-
-val get_string : Yojson.Safe.t -> string -> string -> string
-val get_float : Yojson.Safe.t -> string -> float -> float
-val get_int : Yojson.Safe.t -> string -> int -> int
-val get_bool : Yojson.Safe.t -> string -> bool -> bool
-
 (** {1 Individual Handlers} *)
 
 val handle_init : context -> Yojson.Safe.t -> result

--- a/lib/tool_task.ml
+++ b/lib/tool_task.ml
@@ -13,26 +13,7 @@ type context = {
   agent_name: string;
 }
 
-(* JSON helpers *)
-let get_string args key default =
-  match args |> member key with
-  | `String s -> s
-  | _ -> default
-
-let get_int args key default =
-  match args |> member key with
-  | `Int i -> i
-  | _ -> default
-
-let get_bool args key default =
-  match args |> member key with
-  | `Bool b -> b
-  | _ -> default
-
-let get_int_opt args key =
-  match args |> member key with
-  | `Int i -> Some i
-  | _ -> None
+open Tool_args
 
 let result_to_response = function
   | Ok msg -> (true, msg)

--- a/lib/tool_task.mli
+++ b/lib/tool_task.mli
@@ -7,10 +7,6 @@ type context = {
   agent_name: string;
 }
 
-val get_string : Yojson.Safe.t -> string -> string -> string
-val get_int : Yojson.Safe.t -> string -> int -> int
-val get_int_opt : Yojson.Safe.t -> string -> int option
-
 val handle_add_task : context -> Yojson.Safe.t -> result
 val handle_batch_add_tasks : context -> Yojson.Safe.t -> result
 val handle_claim : context -> Yojson.Safe.t -> result

--- a/lib/tool_team_session.ml
+++ b/lib/tool_team_session.ml
@@ -1,6 +1,7 @@
 (** MCP tools for long-running team sessions (1h orchestration). *)
 
 open Types
+open Tool_args
 
 type 'a context = {
   config : Room.config;
@@ -11,47 +12,6 @@ type 'a context = {
 }
 
 type result = bool * string
-
-let get_string args key default =
-  match Yojson.Safe.Util.member key args with
-  | `String s -> s
-  | _ -> default
-
-let get_string_opt args key =
-  match Yojson.Safe.Util.member key args with
-  | `String s ->
-      let t = String.trim s in
-      if t = "" then None else Some t
-  | _ -> None
-
-let get_int args key default =
-  match Yojson.Safe.Util.member key args with
-  | `Int n -> n
-  | `Intlit s -> (try int_of_string s with _ -> default)
-  | _ -> default
-
-let get_float_opt args key =
-  match Yojson.Safe.Util.member key args with
-  | `Float v -> Some v
-  | `Int n -> Some (float_of_int n)
-  | `Intlit s -> (try Some (float_of_string s) with _ -> None)
-  | _ -> None
-
-let get_bool args key default =
-  match Yojson.Safe.Util.member key args with
-  | `Bool b -> b
-  | _ -> default
-
-let get_string_list args key =
-  match Yojson.Safe.Util.member key args with
-  | `List xs ->
-      xs
-      |> List.filter_map (function
-             | `String s ->
-                 let t = String.trim s in
-                 if t = "" then None else Some t
-             | _ -> None)
-  | _ -> []
 
 let json_error message =
   Yojson.Safe.to_string

--- a/lib/tool_tempo.ml
+++ b/lib/tool_tempo.ml
@@ -4,6 +4,8 @@
     5 tools: tempo, tempo_get, tempo_set, tempo_adjust, tempo_reset
 *)
 
+open Tool_args
+
 (** Tool handler context *)
 type context = {
   config: Room.config;
@@ -12,33 +14,6 @@ type context = {
 
 (** Tool result type *)
 type result = bool * string
-
-(** {1 Argument Helpers} *)
-
-let get_string args key default =
-  match args with
-  | `Assoc fields ->
-      (match List.assoc_opt key fields with
-       | Some (`String s) -> s
-       | _ -> default)
-  | _ -> default
-
-let get_string_opt args key =
-  match args with
-  | `Assoc fields ->
-      (match List.assoc_opt key fields with
-       | Some (`String s) when s <> "" -> Some s
-       | _ -> None)
-  | _ -> None
-
-let get_float args key default =
-  match args with
-  | `Assoc fields ->
-      (match List.assoc_opt key fields with
-       | Some (`Float f) -> f
-       | Some (`Int i) -> Float.of_int i
-       | _ -> default)
-  | _ -> default
 
 (** {1 Individual Handlers} *)
 

--- a/lib/tool_tempo.mli
+++ b/lib/tool_tempo.mli
@@ -13,12 +13,6 @@ type context = {
 (** Tool result type *)
 type result = bool * string
 
-(** {1 Argument Helpers} *)
-
-val get_string : Yojson.Safe.t -> string -> string -> string
-val get_string_opt : Yojson.Safe.t -> string -> string option
-val get_float : Yojson.Safe.t -> string -> float -> float
-
 (** {1 Individual Handlers} *)
 
 val handle_tempo_get : context -> Yojson.Safe.t -> result

--- a/lib/tool_verification.ml
+++ b/lib/tool_verification.ml
@@ -10,13 +10,9 @@
 *)
 
 open Yojson.Safe.Util
+open Tool_args
 
 type result = bool * string
-
-let get_string args key default =
-  match args |> member key with
-  | `String s -> s
-  | _ -> default
 
 (** masc_verify_request: Create a verification request *)
 let handle_request config agent_name args =

--- a/lib/tool_vote.ml
+++ b/lib/tool_vote.ml
@@ -1,21 +1,6 @@
 (** Vote tools - Consensus voting system *)
 
-(* Argument helpers *)
-let get_string args key default =
-  match Yojson.Safe.Util.member key args with
-  | `String s -> s
-  | _ -> default
-
-let get_int args key default =
-  match Yojson.Safe.Util.member key args with
-  | `Int n -> n
-  | _ -> default
-
-let get_string_list args key =
-  match Yojson.Safe.Util.member key args with
-  | `List items ->
-      List.filter_map (function `String s -> Some s | _ -> None) items
-  | _ -> []
+open Tool_args
 
 (* Context required by vote tools *)
 type context = {

--- a/lib/tool_vote.mli
+++ b/lib/tool_vote.mli
@@ -1,9 +1,5 @@
 (** Vote tools - Consensus voting system *)
 
-val get_string : Yojson.Safe.t -> string -> string -> string
-val get_int : Yojson.Safe.t -> string -> int -> int
-val get_string_list : Yojson.Safe.t -> string -> string list
-
 type context = {
   config: Room.config;
   agent_name: string;

--- a/lib/tool_walph.ml
+++ b/lib/tool_walph.ml
@@ -1,36 +1,13 @@
 (** Tool_walph - Walph loop control handlers *)
 
+open Tool_args
+
 type ('a, 'b) context = {
   config: Room.config;
   agent_name: string;
   net: 'a Eio.Net.t;
   clock: 'b Eio.Time.clock;
 }
-
-(* Helper functions *)
-let get_string args key default =
-  match args with
-  | `Assoc l ->
-      (match List.assoc_opt key l with
-       | Some (`String s) -> s
-       | _ -> default)
-  | _ -> default
-
-let get_string_opt args key =
-  match args with
-  | `Assoc l ->
-      (match List.assoc_opt key l with
-       | Some (`String s) when s <> "" -> Some s
-       | _ -> None)
-  | _ -> None
-
-let get_int args key default =
-  match args with
-  | `Assoc l ->
-      (match List.assoc_opt key l with
-       | Some (`Int i) -> i
-       | _ -> default)
-  | _ -> default
 
 (* Handle masc_walph_loop *)
 let handle_walph_loop ctx args =

--- a/lib/tool_walph.mli
+++ b/lib/tool_walph.mli
@@ -22,11 +22,3 @@ val handle_walph_natural : ('a, 'b) context -> Yojson.Safe.t -> bool * string
 (** Handle masc_walph_status *)
 val handle_walph_status : ('a, 'b) context -> Yojson.Safe.t -> bool * string
 
-(** Helper: get string from args *)
-val get_string : Yojson.Safe.t -> string -> string -> string
-
-(** Helper: get string option from args *)
-val get_string_opt : Yojson.Safe.t -> string -> string option
-
-(** Helper: get int from args *)
-val get_int : Yojson.Safe.t -> string -> int -> int

--- a/lib/tool_worktree.ml
+++ b/lib/tool_worktree.ml
@@ -1,10 +1,6 @@
 (** Worktree tools - Git worktree management for task isolation *)
 
-(* Argument helpers *)
-let get_string args key default =
-  match Yojson.Safe.Util.member key args with
-  | `String s -> s
-  | _ -> default
+open Tool_args
 
 (* Context required by worktree tools *)
 type context = {

--- a/lib/tool_worktree.mli
+++ b/lib/tool_worktree.mli
@@ -1,7 +1,5 @@
 (** Worktree tools - Git worktree management for task isolation *)
 
-val get_string : Yojson.Safe.t -> string -> string -> string
-
 type context = {
   config: Room.config;
   agent_name: string;

--- a/test/test_tool_a2a_coverage.ml
+++ b/test/test_tool_a2a_coverage.ml
@@ -1,5 +1,6 @@
 (** Tool_a2a Module Coverage Tests *)
 
+module Tool_args = Masc_mcp.Tool_args
 open Alcotest
 
 let () = Random.self_init ()
@@ -12,35 +13,35 @@ module Tool_a2a = Masc_mcp.Tool_a2a
 
 let test_get_string_exists () =
   let args = `Assoc [("target_agent", `String "codex-001")] in
-  check string "extracts string" "codex-001" (Tool_a2a.get_string args "target_agent" "default")
+  check string "extracts string" "codex-001" (Tool_args.get_string args "target_agent" "default")
 
 let test_get_string_missing () =
   let args = `Assoc [] in
-  check string "uses default" "default" (Tool_a2a.get_string args "target_agent" "default")
+  check string "uses default" "default" (Tool_args.get_string args "target_agent" "default")
 
 let test_get_string_opt_exists () =
   let args = `Assoc [("endpoint", `String "https://example.com")] in
-  check (option string) "extracts option" (Some "https://example.com") (Tool_a2a.get_string_opt args "endpoint")
+  check (option string) "extracts option" (Some "https://example.com") (Tool_args.get_string_opt args "endpoint")
 
 let test_get_string_opt_missing () =
   let args = `Assoc [] in
-  check (option string) "returns None" None (Tool_a2a.get_string_opt args "endpoint")
+  check (option string) "returns None" None (Tool_args.get_string_opt args "endpoint")
 
 let test_get_int_exists () =
   let args = `Assoc [("timeout", `Int 600)] in
-  check int "extracts int" 600 (Tool_a2a.get_int args "timeout" 300)
+  check int "extracts int" 600 (Tool_args.get_int args "timeout" 300)
 
 let test_get_int_missing () =
   let args = `Assoc [] in
-  check int "uses default" 300 (Tool_a2a.get_int args "timeout" 300)
+  check int "uses default" 300 (Tool_args.get_int args "timeout" 300)
 
 let test_get_bool_exists () =
   let args = `Assoc [("clear", `Bool false)] in
-  check bool "extracts bool" false (Tool_a2a.get_bool args "clear" true)
+  check bool "extracts bool" false (Tool_args.get_bool args "clear" true)
 
 let test_get_bool_missing () =
   let args = `Assoc [] in
-  check bool "uses default" true (Tool_a2a.get_bool args "clear" true)
+  check bool "uses default" true (Tool_args.get_bool args "clear" true)
 
 (* ============================================================
    Context Creation Tests

--- a/test/test_tool_agent_coverage.ml
+++ b/test/test_tool_agent_coverage.ml
@@ -6,6 +6,7 @@
     masc_agent_fitness, masc_select_agent, masc_collaboration_graph,
     masc_consolidate_learning, masc_agent_card
 *)
+module Tool_args = Masc_mcp.Tool_args
 
 module Tool_agent = Masc_mcp.Tool_agent
 module Room = Masc_mcp.Room
@@ -259,42 +260,42 @@ let test_agent_card_refresh () =
 let test_get_string_present () =
   let args = `Assoc [("key", `String "value")] in
   Alcotest.(check string) "extracts string" "value"
-    (Tool_agent.get_string args "key" "default")
+    (Tool_args.get_string args "key" "default")
 
 let test_get_string_missing () =
   let args = `Assoc [] in
   Alcotest.(check string) "uses default" "default"
-    (Tool_agent.get_string args "key" "default")
+    (Tool_args.get_string args "key" "default")
 
 let test_get_string_opt_present () =
   let args = `Assoc [("key", `String "value")] in
   Alcotest.(check (option string)) "extracts Some" (Some "value")
-    (Tool_agent.get_string_opt args "key")
+    (Tool_args.get_string_opt args "key")
 
 let test_get_string_opt_missing () =
   let args = `Assoc [] in
   Alcotest.(check (option string)) "returns None" None
-    (Tool_agent.get_string_opt args "key")
+    (Tool_args.get_string_opt args "key")
 
 let test_get_int_present () =
   let args = `Assoc [("key", `Int 42)] in
   Alcotest.(check int) "extracts int" 42
-    (Tool_agent.get_int args "key" 0)
+    (Tool_args.get_int args "key" 0)
 
 let test_get_int_missing () =
   let args = `Assoc [] in
   Alcotest.(check int) "uses default" 99
-    (Tool_agent.get_int args "key" 99)
+    (Tool_args.get_int args "key" 99)
 
 let test_get_string_list_present () =
   let args = `Assoc [("key", `List [`String "a"; `String "b"])] in
   Alcotest.(check (list string)) "extracts list" ["a"; "b"]
-    (Tool_agent.get_string_list args "key")
+    (Tool_args.get_string_list args "key")
 
 let test_get_string_list_missing () =
   let args = `Assoc [] in
   Alcotest.(check (list string)) "empty list" []
-    (Tool_agent.get_string_list args "key")
+    (Tool_args.get_string_list args "key")
 
 (* ============================================================
    Test runner

--- a/test/test_tool_audit_coverage.ml
+++ b/test/test_tool_audit_coverage.ml
@@ -4,6 +4,7 @@
     read_audit_events, and helper functions
     for 3 tools: masc_audit_query, masc_audit_stats, masc_governance_report
 *)
+module Tool_args = Masc_mcp.Tool_args
 
 module Tool_audit = Masc_mcp.Tool_audit
 module Room = Masc_mcp.Room
@@ -152,47 +153,47 @@ let test_read_audit_events_empty () =
 let test_get_string_present () =
   let args = `Assoc [("key", `String "value")] in
   Alcotest.(check string) "extracts string" "value"
-    (Tool_audit.get_string args "key" "default")
+    (Tool_args.get_string args "key" "default")
 
 let test_get_string_missing () =
   let args = `Assoc [] in
   Alcotest.(check string) "uses default" "default"
-    (Tool_audit.get_string args "key" "default")
+    (Tool_args.get_string args "key" "default")
 
 let test_get_string_opt_present () =
   let args = `Assoc [("key", `String "value")] in
   Alcotest.(check (option string)) "extracts Some" (Some "value")
-    (Tool_audit.get_string_opt args "key")
+    (Tool_args.get_string_opt args "key")
 
 let test_get_string_opt_missing () =
   let args = `Assoc [] in
   Alcotest.(check (option string)) "returns None" None
-    (Tool_audit.get_string_opt args "key")
+    (Tool_args.get_string_opt args "key")
 
 let test_get_int_present () =
   let args = `Assoc [("key", `Int 42)] in
   Alcotest.(check int) "extracts int" 42
-    (Tool_audit.get_int args "key" 0)
+    (Tool_args.get_int args "key" 0)
 
 let test_get_int_missing () =
   let args = `Assoc [] in
   Alcotest.(check int) "uses default" 99
-    (Tool_audit.get_int args "key" 99)
+    (Tool_args.get_int args "key" 99)
 
 let test_get_float_present () =
   let args = `Assoc [("key", `Float 3.14)] in
   Alcotest.(check (float 0.001)) "extracts float" 3.14
-    (Tool_audit.get_float args "key" 0.0)
+    (Tool_args.get_float args "key" 0.0)
 
 let test_get_float_from_int () =
   let args = `Assoc [("key", `Int 42)] in
   Alcotest.(check (float 0.001)) "int to float" 42.0
-    (Tool_audit.get_float args "key" 0.0)
+    (Tool_args.get_float args "key" 0.0)
 
 let test_get_float_missing () =
   let args = `Assoc [] in
   Alcotest.(check (float 0.001)) "uses default" 1.5
-    (Tool_audit.get_float args "key" 1.5)
+    (Tool_args.get_float args "key" 1.5)
 
 (* ============================================================
    Test runner

--- a/test/test_tool_auth_coverage.ml
+++ b/test/test_tool_auth_coverage.ml
@@ -117,28 +117,28 @@ let () = test "dispatch_auth_revoke" (fun () ->
 (* Test get_string helper *)
 let () = test "get_string_present" (fun () ->
   let args = `Assoc [("key", `String "value")] in
-  assert (Tool_auth.get_string args "key" "default" = "value")
+  assert (Tool_args.get_string args "key" "default" = "value")
 )
 
 let () = test "get_string_missing" (fun () ->
   let args = `Assoc [] in
-  assert (Tool_auth.get_string args "key" "default" = "default")
+  assert (Tool_args.get_string args "key" "default" = "default")
 )
 
 (* Test get_bool helper *)
 let () = test "get_bool_true" (fun () ->
   let args = `Assoc [("key", `Bool true)] in
-  assert (Tool_auth.get_bool args "key" false = true)
+  assert (Tool_args.get_bool args "key" false = true)
 )
 
 let () = test "get_bool_false" (fun () ->
   let args = `Assoc [("key", `Bool false)] in
-  assert (Tool_auth.get_bool args "key" true = false)
+  assert (Tool_args.get_bool args "key" true = false)
 )
 
 let () = test "get_bool_missing" (fun () ->
   let args = `Assoc [] in
-  assert (Tool_auth.get_bool args "key" true = true)
+  assert (Tool_args.get_bool args "key" true = true)
 )
 
 let () = Printf.printf "\n✅ All Tool_auth tests passed!\n"

--- a/test/test_tool_board_coverage.ml
+++ b/test/test_tool_board_coverage.ml
@@ -111,36 +111,36 @@ let test_get_string () =
   cleanup ();
   let args = make_args [("key", `String "value")] in
   Alcotest.(check string) "get existing" "value"
-    (Tool_board.get_string args "key" "default");
+    (Tool_args.get_string args "key" "default");
   Alcotest.(check string) "get missing" "default"
-    (Tool_board.get_string args "missing" "default")
+    (Tool_args.get_string args "missing" "default")
 
 let test_get_string_opt () =
   Eio_main.run @@ fun _env ->
   cleanup ();
   let args = make_args [("key", `String "value")] in
   Alcotest.(check (option string)) "get existing" (Some "value")
-    (Tool_board.get_string_opt args "key");
+    (Tool_args.get_string_opt args "key");
   Alcotest.(check (option string)) "get missing" None
-    (Tool_board.get_string_opt args "missing")
+    (Tool_args.get_string_opt args "missing")
 
 let test_get_int () =
   Eio_main.run @@ fun _env ->
   cleanup ();
   let args = make_args [("n", `Int 42)] in
   Alcotest.(check int) "get existing" 42
-    (Tool_board.get_int args "n" 0);
+    (Tool_args.get_int args "n" 0);
   Alcotest.(check int) "get missing" 0
-    (Tool_board.get_int args "missing" 0)
+    (Tool_args.get_int args "missing" 0)
 
 let test_get_bool () =
   Eio_main.run @@ fun _env ->
   cleanup ();
   let args = make_args [("flag", `Bool true)] in
   Alcotest.(check bool) "get existing" true
-    (Tool_board.get_bool args "flag" false);
+    (Tool_args.get_bool args "flag" false);
   Alcotest.(check bool) "get missing" false
-    (Tool_board.get_bool args "missing" false)
+    (Tool_args.get_bool args "missing" false)
 
 (** {2 Group 3: Post Create / List / Get} *)
 

--- a/test/test_tool_cache_coverage.ml
+++ b/test/test_tool_cache_coverage.ml
@@ -1,5 +1,6 @@
 (** Tool_cache Module Coverage Tests *)
 
+module Tool_args = Masc_mcp.Tool_args
 open Alcotest
 
 let () = Random.self_init ()
@@ -12,39 +13,39 @@ module Tool_cache = Masc_mcp.Tool_cache
 
 let test_get_string_exists () =
   let args = `Assoc [("key", `String "mykey")] in
-  check string "extracts string" "mykey" (Tool_cache.get_string args "key" "default")
+  check string "extracts string" "mykey" (Tool_args.get_string args "key" "default")
 
 let test_get_string_missing () =
   let args = `Assoc [] in
-  check string "uses default" "default" (Tool_cache.get_string args "key" "default")
+  check string "uses default" "default" (Tool_args.get_string args "key" "default")
 
 let test_get_string_opt_exists () =
   let args = `Assoc [("tag", `String "important")] in
-  check (option string) "extracts option" (Some "important") (Tool_cache.get_string_opt args "tag")
+  check (option string) "extracts option" (Some "important") (Tool_args.get_string_opt args "tag")
 
 let test_get_string_opt_missing () =
   let args = `Assoc [] in
-  check (option string) "returns None" None (Tool_cache.get_string_opt args "tag")
+  check (option string) "returns None" None (Tool_args.get_string_opt args "tag")
 
 let test_get_int_opt_exists () =
   let args = `Assoc [("ttl_seconds", `Int 3600)] in
-  check (option int) "extracts option" (Some 3600) (Tool_cache.get_int_opt args "ttl_seconds")
+  check (option int) "extracts option" (Some 3600) (Tool_args.get_int_opt args "ttl_seconds")
 
 let test_get_int_opt_missing () =
   let args = `Assoc [] in
-  check (option int) "returns None" None (Tool_cache.get_int_opt args "ttl_seconds")
+  check (option int) "returns None" None (Tool_args.get_int_opt args "ttl_seconds")
 
 let test_get_string_list_exists () =
   let args = `Assoc [("tags", `List [`String "a"; `String "b"])] in
-  check (list string) "extracts list" ["a"; "b"] (Tool_cache.get_string_list args "tags")
+  check (list string) "extracts list" ["a"; "b"] (Tool_args.get_string_list args "tags")
 
 let test_get_string_list_missing () =
   let args = `Assoc [] in
-  check (list string) "returns empty" [] (Tool_cache.get_string_list args "tags")
+  check (list string) "returns empty" [] (Tool_args.get_string_list args "tags")
 
 let test_get_string_list_mixed () =
   let args = `Assoc [("tags", `List [`String "a"; `Int 1; `String "b"])] in
-  check (list string) "filters non-strings" ["a"; "b"] (Tool_cache.get_string_list args "tags")
+  check (list string) "filters non-strings" ["a"; "b"] (Tool_args.get_string_list args "tags")
 
 (* ============================================================
    Context Creation Tests

--- a/test/test_tool_control_coverage.ml
+++ b/test/test_tool_control_coverage.ml
@@ -121,12 +121,12 @@ let () = test "dispatch_get_config" (fun () ->
 (* Test helper functions *)
 let () = test "get_string_present" (fun () ->
   let args = `Assoc [("key", `String "value")] in
-  assert (Tool_control.get_string args "key" "default" = "value")
+  assert (Tool_args.get_string args "key" "default" = "value")
 )
 
 let () = test "get_string_missing" (fun () ->
   let args = `Assoc [] in
-  assert (Tool_control.get_string args "key" "default" = "default")
+  assert (Tool_args.get_string args "key" "default" = "default")
 )
 
 let () = Printf.printf "\n✅ All Tool_control tests passed!\n"

--- a/test/test_tool_cost_coverage.ml
+++ b/test/test_tool_cost_coverage.ml
@@ -80,37 +80,37 @@ let () = test "handle_cost_report_with_filters" (fun () ->
 (* Test helper functions *)
 let () = test "get_string_present" (fun () ->
   let args = `Assoc [("key", `String "value")] in
-  assert (Tool_cost.get_string args "key" "default" = "value")
+  assert (Tool_args.get_string args "key" "default" = "value")
 )
 
 let () = test "get_string_missing" (fun () ->
   let args = `Assoc [] in
-  assert (Tool_cost.get_string args "key" "default" = "default")
+  assert (Tool_args.get_string args "key" "default" = "default")
 )
 
 let () = test "get_int_present" (fun () ->
   let args = `Assoc [("key", `Int 42)] in
-  assert (Tool_cost.get_int args "key" 0 = 42)
+  assert (Tool_args.get_int args "key" 0 = 42)
 )
 
 let () = test "get_int_missing" (fun () ->
   let args = `Assoc [] in
-  assert (Tool_cost.get_int args "key" 99 = 99)
+  assert (Tool_args.get_int args "key" 99 = 99)
 )
 
 let () = test "get_float_present" (fun () ->
   let args = `Assoc [("key", `Float 3.14)] in
-  assert (Tool_cost.get_float args "key" 0.0 = 3.14)
+  assert (Tool_args.get_float args "key" 0.0 = 3.14)
 )
 
 let () = test "get_float_from_int" (fun () ->
   let args = `Assoc [("key", `Int 42)] in
-  assert (Tool_cost.get_float args "key" 0.0 = 42.0)
+  assert (Tool_args.get_float args "key" 0.0 = 42.0)
 )
 
 let () = test "get_float_missing" (fun () ->
   let args = `Assoc [] in
-  assert (Tool_cost.get_float args "key" 1.5 = 1.5)
+  assert (Tool_args.get_float args "key" 1.5 = 1.5)
 )
 
 let () = Printf.printf "\n✅ All Tool_cost tests passed!\n"

--- a/test/test_tool_encryption_coverage.ml
+++ b/test/test_tool_encryption_coverage.ml
@@ -98,17 +98,17 @@ let () = test "handle_encryption_disable" (fun () ->
 (* Test get_string helper *)
 let () = test "get_string_present" (fun () ->
   let args = `Assoc [("key", `String "value")] in
-  assert (Tool_encryption.get_string args "key" "default" = "value")
+  assert (Tool_args.get_string args "key" "default" = "value")
 )
 
 let () = test "get_string_missing" (fun () ->
   let args = `Assoc [] in
-  assert (Tool_encryption.get_string args "key" "default" = "default")
+  assert (Tool_args.get_string args "key" "default" = "default")
 )
 
 let () = test "get_string_wrong_type" (fun () ->
   let args = `Assoc [("key", `Int 42)] in
-  assert (Tool_encryption.get_string args "key" "default" = "default")
+  assert (Tool_args.get_string args "key" "default" = "default")
 )
 
 let () = Printf.printf "\n✅ All Tool_encryption tests passed!\n"

--- a/test/test_tool_handover_coverage.ml
+++ b/test/test_tool_handover_coverage.ml
@@ -5,6 +5,7 @@ open Alcotest
 let () = Random.self_init ()
 
 module Tool_handover = Masc_mcp.Tool_handover
+module Tool_args = Masc_mcp.Tool_args
 
 (* ============================================================
    Argument Helper Tests
@@ -12,43 +13,43 @@ module Tool_handover = Masc_mcp.Tool_handover
 
 let test_get_string_exists () =
   let args = `Assoc [("task_id", `String "task-001")] in
-  check string "extracts string" "task-001" (Tool_handover.get_string args "task_id" "default")
+  check string "extracts string" "task-001" (Tool_args.get_string args "task_id" "default")
 
 let test_get_string_missing () =
   let args = `Assoc [] in
-  check string "uses default" "default" (Tool_handover.get_string args "task_id" "default")
+  check string "uses default" "default" (Tool_args.get_string args "task_id" "default")
 
 let test_get_string_opt_exists () =
   let args = `Assoc [("additional_instructions", `String "Be careful")] in
-  check (option string) "extracts option" (Some "Be careful") (Tool_handover.get_string_opt args "additional_instructions")
+  check (option string) "extracts option" (Some "Be careful") (Tool_args.get_string_opt args "additional_instructions")
 
 let test_get_string_opt_missing () =
   let args = `Assoc [] in
-  check (option string) "returns None" None (Tool_handover.get_string_opt args "additional_instructions")
+  check (option string) "returns None" None (Tool_args.get_string_opt args "additional_instructions")
 
 let test_get_int_exists () =
   let args = `Assoc [("context_pct", `Int 85)] in
-  check int "extracts int" 85 (Tool_handover.get_int args "context_pct" 0)
+  check int "extracts int" 85 (Tool_args.get_int args "context_pct" 0)
 
 let test_get_int_missing () =
   let args = `Assoc [] in
-  check int "uses default" 0 (Tool_handover.get_int args "context_pct" 0)
+  check int "uses default" 0 (Tool_args.get_int args "context_pct" 0)
 
 let test_get_bool_exists () =
   let args = `Assoc [("pending_only", `Bool true)] in
-  check bool "extracts bool" true (Tool_handover.get_bool args "pending_only" false)
+  check bool "extracts bool" true (Tool_args.get_bool args "pending_only" false)
 
 let test_get_bool_missing () =
   let args = `Assoc [] in
-  check bool "uses default" false (Tool_handover.get_bool args "pending_only" false)
+  check bool "uses default" false (Tool_args.get_bool args "pending_only" false)
 
 let test_get_string_list_exists () =
   let args = `Assoc [("completed_steps", `List [`String "step1"; `String "step2"])] in
-  check (list string) "extracts list" ["step1"; "step2"] (Tool_handover.get_string_list args "completed_steps")
+  check (list string) "extracts list" ["step1"; "step2"] (Tool_args.get_string_list args "completed_steps")
 
 let test_get_string_list_missing () =
   let args = `Assoc [] in
-  check (list string) "returns empty" [] (Tool_handover.get_string_list args "completed_steps")
+  check (list string) "returns empty" [] (Tool_args.get_string_list args "completed_steps")
 
 (* ============================================================
    Context Creation Tests

--- a/test/test_tool_hat_coverage.ml
+++ b/test/test_tool_hat_coverage.ml
@@ -138,17 +138,17 @@ let () = test "handle_hat_status_with_agents" (fun () ->
 (* Test get_string helper *)
 let () = test "get_string_present" (fun () ->
   let args = `Assoc [("key", `String "value")] in
-  assert (Tool_hat.get_string args "key" "default" = "value")
+  assert (Tool_args.get_string args "key" "default" = "value")
 )
 
 let () = test "get_string_missing" (fun () ->
   let args = `Assoc [] in
-  assert (Tool_hat.get_string args "key" "default" = "default")
+  assert (Tool_args.get_string args "key" "default" = "default")
 )
 
 let () = test "get_string_wrong_type" (fun () ->
   let args = `Assoc [("key", `Int 42)] in
-  assert (Tool_hat.get_string args "key" "default" = "default")
+  assert (Tool_args.get_string args "key" "default" = "default")
 )
 
 let () = Printf.printf "\n✅ All Tool_hat tests passed!\n"

--- a/test/test_tool_heartbeat_coverage.ml
+++ b/test/test_tool_heartbeat_coverage.ml
@@ -73,22 +73,22 @@ let () = test "heartbeat_list_multiple" (fun () ->
 (* Tool_heartbeat tests *)
 let () = test "get_string_present" (fun () ->
   let args = `Assoc [("key", `String "value")] in
-  assert (Tool_heartbeat.get_string args "key" "default" = "value")
+  assert (Tool_args.get_string args "key" "default" = "value")
 )
 
 let () = test "get_string_missing" (fun () ->
   let args = `Assoc [] in
-  assert (Tool_heartbeat.get_string args "key" "default" = "default")
+  assert (Tool_args.get_string args "key" "default" = "default")
 )
 
 let () = test "get_int_present" (fun () ->
   let args = `Assoc [("key", `Int 42)] in
-  assert (Tool_heartbeat.get_int args "key" 0 = 42)
+  assert (Tool_args.get_int args "key" 0 = 42)
 )
 
 let () = test "get_int_missing" (fun () ->
   let args = `Assoc [] in
-  assert (Tool_heartbeat.get_int args "key" 99 = 99)
+  assert (Tool_args.get_int args "key" 99 = 99)
 )
 
 let () = test "dispatch_unknown_tool" (fun () ->

--- a/test/test_tool_misc_coverage.ml
+++ b/test/test_tool_misc_coverage.ml
@@ -141,37 +141,37 @@ let () = test "dispatch_cleanup_zombies" (fun () ->
 (* Test helper functions *)
 let () = test "get_int_present" (fun () ->
   let args = `Assoc [("key", `Int 42)] in
-  assert (Tool_misc.get_int args "key" 0 = 42)
+  assert (Tool_args.get_int args "key" 0 = 42)
 )
 
 let () = test "get_int_missing" (fun () ->
   let args = `Assoc [] in
-  assert (Tool_misc.get_int args "key" 99 = 99)
+  assert (Tool_args.get_int args "key" 99 = 99)
 )
 
 let () = test "get_bool_true" (fun () ->
   let args = `Assoc [("key", `Bool true)] in
-  assert (Tool_misc.get_bool args "key" false = true)
+  assert (Tool_args.get_bool args "key" false = true)
 )
 
 let () = test "get_bool_false" (fun () ->
   let args = `Assoc [("key", `Bool false)] in
-  assert (Tool_misc.get_bool args "key" true = false)
+  assert (Tool_args.get_bool args "key" true = false)
 )
 
 let () = test "get_bool_missing" (fun () ->
   let args = `Assoc [] in
-  assert (Tool_misc.get_bool args "key" true = true)
+  assert (Tool_args.get_bool args "key" true = true)
 )
 
 let () = test "get_string_present" (fun () ->
   let args = `Assoc [("key", `String "value")] in
-  assert (Tool_misc.get_string args "key" "default" = "value")
+  assert (Tool_args.get_string args "key" "default" = "value")
 )
 
 let () = test "get_string_missing" (fun () ->
   let args = `Assoc [] in
-  assert (Tool_misc.get_string args "key" "default" = "default")
+  assert (Tool_args.get_string args "key" "default" = "default")
 )
 
 let () = Printf.printf "\n✅ All Tool_misc tests passed!\n"

--- a/test/test_tool_mitosis_coverage.ml
+++ b/test/test_tool_mitosis_coverage.ml
@@ -5,6 +5,7 @@ open Alcotest
 let () = Random.self_init ()
 
 module Tool_mitosis = Masc_mcp.Tool_mitosis
+module Tool_args = Masc_mcp.Tool_args
 
 (* ============================================================
    Argument Helper Tests
@@ -12,35 +13,35 @@ module Tool_mitosis = Masc_mcp.Tool_mitosis
 
 let test_get_string_exists () =
   let args = `Assoc [("summary", `String "test summary")] in
-  check string "extracts string" "test summary" (Tool_mitosis.get_string args "summary" "default")
+  check string "extracts string" "test summary" (Tool_args.get_string args "summary" "default")
 
 let test_get_string_missing () =
   let args = `Assoc [] in
-  check string "uses default" "default" (Tool_mitosis.get_string args "summary" "default")
+  check string "uses default" "default" (Tool_args.get_string args "summary" "default")
 
 let test_get_float_exists () =
   let args = `Assoc [("context_ratio", `Float 0.75)] in
-  check (float 0.001) "extracts float" 0.75 (Tool_mitosis.get_float args "context_ratio" 0.0)
+  check (float 0.001) "extracts float" 0.75 (Tool_args.get_float args "context_ratio" 0.0)
 
 let test_get_float_from_int () =
   let args = `Assoc [("context_ratio", `Int 1)] in
-  check (float 0.001) "converts int" 1.0 (Tool_mitosis.get_float args "context_ratio" 0.0)
+  check (float 0.001) "converts int" 1.0 (Tool_args.get_float args "context_ratio" 0.0)
 
 let test_get_float_missing () =
   let args = `Assoc [] in
-  check (float 0.001) "uses default" 0.5 (Tool_mitosis.get_float args "context_ratio" 0.5)
+  check (float 0.001) "uses default" 0.5 (Tool_args.get_float args "context_ratio" 0.5)
 
 let test_get_bool_exists_true () =
   let args = `Assoc [("task_done", `Bool true)] in
-  check bool "extracts true" true (Tool_mitosis.get_bool args "task_done" false)
+  check bool "extracts true" true (Tool_args.get_bool args "task_done" false)
 
 let test_get_bool_exists_false () =
   let args = `Assoc [("task_done", `Bool false)] in
-  check bool "extracts false" false (Tool_mitosis.get_bool args "task_done" true)
+  check bool "extracts false" false (Tool_args.get_bool args "task_done" true)
 
 let test_get_bool_missing () =
   let args = `Assoc [] in
-  check bool "uses default" true (Tool_mitosis.get_bool args "task_done" true)
+  check bool "uses default" true (Tool_args.get_bool args "task_done" true)
 
 (* ============================================================
    Context Creation Tests

--- a/test/test_tool_notifications_coverage.ml
+++ b/test/test_tool_notifications_coverage.ml
@@ -7,6 +7,7 @@
     handlers, limit boundary, empty queue, queue mutation (consume). *)
 
 module Tool_notifications = Masc_mcp.Tool_notifications
+module Tool_args = Masc_mcp.Tool_args
 module Session = Masc_mcp.Session
 
 (* ============================================================
@@ -36,22 +37,22 @@ let json_to_int json = Yojson.Safe.Util.to_int json
 let test_get_int_present () =
   let args = `Assoc [("limit", `Int 5)] in
   Alcotest.(check int) "extracts int" 5
-    (Tool_notifications.get_int args "limit" 10)
+    (Tool_args.get_int args "limit" 10)
 
 let test_get_int_missing () =
   let args = `Assoc [] in
   Alcotest.(check int) "returns default" 10
-    (Tool_notifications.get_int args "limit" 10)
+    (Tool_args.get_int args "limit" 10)
 
 let test_get_int_wrong_type () =
   let args = `Assoc [("limit", `String "five")] in
   Alcotest.(check int) "returns default on wrong type" 10
-    (Tool_notifications.get_int args "limit" 10)
+    (Tool_args.get_int args "limit" 10)
 
 let test_get_int_non_assoc () =
   let args = `Null in
   Alcotest.(check int) "returns default on non-assoc" 10
-    (Tool_notifications.get_int args "limit" 10)
+    (Tool_args.get_int args "limit" 10)
 
 (* ============================================================
    Dispatch routing tests

--- a/test/test_tool_plan_coverage.ml
+++ b/test/test_tool_plan_coverage.ml
@@ -1,5 +1,6 @@
 (** Tool_plan Module Coverage Tests *)
 
+module Tool_args = Masc_mcp.Tool_args
 open Alcotest
 
 let () = Random.self_init ()
@@ -12,23 +13,23 @@ module Tool_plan = Masc_mcp.Tool_plan
 
 let test_get_string_exists () =
   let args = `Assoc [("task_id", `String "task-123")] in
-  check string "extracts string" "task-123" (Tool_plan.get_string args "task_id" "default")
+  check string "extracts string" "task-123" (Tool_args.get_string args "task_id" "default")
 
 let test_get_string_missing () =
   let args = `Assoc [] in
-  check string "uses default" "default" (Tool_plan.get_string args "task_id" "default")
+  check string "uses default" "default" (Tool_args.get_string args "task_id" "default")
 
 let test_get_string_wrong_type () =
   let args = `Assoc [("task_id", `Int 42)] in
-  check string "uses default on type mismatch" "default" (Tool_plan.get_string args "task_id" "default")
+  check string "uses default on type mismatch" "default" (Tool_args.get_string args "task_id" "default")
 
 let test_get_int_exists () =
   let args = `Assoc [("index", `Int 5)] in
-  check int "extracts int" 5 (Tool_plan.get_int args "index" 0)
+  check int "extracts int" 5 (Tool_args.get_int args "index" 0)
 
 let test_get_int_missing () =
   let args = `Assoc [] in
-  check int "uses default" 0 (Tool_plan.get_int args "index" 0)
+  check int "uses default" 0 (Tool_args.get_int args "index" 0)
 
 (* ============================================================
    Context Creation Tests

--- a/test/test_tool_portal_coverage.ml
+++ b/test/test_tool_portal_coverage.ml
@@ -1,5 +1,6 @@
 (** Tool_portal Module Coverage Tests *)
 
+module Tool_args = Masc_mcp.Tool_args
 open Alcotest
 
 let () = Random.self_init ()
@@ -12,23 +13,23 @@ module Tool_portal = Masc_mcp.Tool_portal
 
 let test_get_string_exists () =
   let args = `Assoc [("target_agent", `String "claude-001")] in
-  check string "extracts string" "claude-001" (Tool_portal.get_string args "target_agent" "default")
+  check string "extracts string" "claude-001" (Tool_args.get_string args "target_agent" "default")
 
 let test_get_string_missing () =
   let args = `Assoc [] in
-  check string "uses default" "default" (Tool_portal.get_string args "target_agent" "default")
+  check string "uses default" "default" (Tool_args.get_string args "target_agent" "default")
 
 let test_get_string_opt_exists () =
   let args = `Assoc [("initial_message", `String "hello")] in
-  check (option string) "extracts option" (Some "hello") (Tool_portal.get_string_opt args "initial_message")
+  check (option string) "extracts option" (Some "hello") (Tool_args.get_string_opt args "initial_message")
 
 let test_get_string_opt_missing () =
   let args = `Assoc [] in
-  check (option string) "returns None" None (Tool_portal.get_string_opt args "initial_message")
+  check (option string) "returns None" None (Tool_args.get_string_opt args "initial_message")
 
 let test_get_string_opt_empty () =
   let args = `Assoc [("initial_message", `String "")] in
-  check (option string) "empty is None" None (Tool_portal.get_string_opt args "initial_message")
+  check (option string) "empty is None" None (Tool_args.get_string_opt args "initial_message")
 
 (* ============================================================
    Context Creation Tests

--- a/test/test_tool_relay_coverage.ml
+++ b/test/test_tool_relay_coverage.ml
@@ -162,50 +162,50 @@ let run ~sw ~proc_mgr =
   (* Test get_string helper *)
   test "get_string_present" (fun () ->
     let args = `Assoc [("key", `String "value")] in
-    assert (Tool_relay.get_string args "key" "default" = "value")
+    assert (Tool_args.get_string args "key" "default" = "value")
   );
 
   test "get_string_missing" (fun () ->
     let args = `Assoc [] in
-    assert (Tool_relay.get_string args "key" "default" = "default")
+    assert (Tool_args.get_string args "key" "default" = "default")
   );
 
   (* Test get_int helper *)
   test "get_int_present" (fun () ->
     let args = `Assoc [("key", `Int 42)] in
-    assert (Tool_relay.get_int args "key" 0 = 42)
+    assert (Tool_args.get_int args "key" 0 = 42)
   );
 
   test "get_int_missing" (fun () ->
     let args = `Assoc [] in
-    assert (Tool_relay.get_int args "key" 99 = 99)
+    assert (Tool_args.get_int args "key" 99 = 99)
   );
 
   (* Test get_string_opt helper *)
   test "get_string_opt_present" (fun () ->
     let args = `Assoc [("key", `String "value")] in
-    assert (Tool_relay.get_string_opt args "key" = Some "value")
+    assert (Tool_args.get_string_opt args "key" = Some "value")
   );
 
   test "get_string_opt_missing" (fun () ->
     let args = `Assoc [] in
-    assert (Tool_relay.get_string_opt args "key" = None)
+    assert (Tool_args.get_string_opt args "key" = None)
   );
 
   test "get_string_opt_empty" (fun () ->
     let args = `Assoc [("key", `String "")] in
-    assert (Tool_relay.get_string_opt args "key" = None)
+    assert (Tool_args.get_string_opt args "key" = None)
   );
 
   (* Test get_string_list helper *)
   test "get_string_list_present" (fun () ->
     let args = `Assoc [("key", `List [`String "a"; `String "b"])] in
-    assert (Tool_relay.get_string_list args "key" = ["a"; "b"])
+    assert (Tool_args.get_string_list args "key" = ["a"; "b"])
   );
 
   test "get_string_list_missing" (fun () ->
     let args = `Assoc [] in
-    assert (Tool_relay.get_string_list args "key" = [])
+    assert (Tool_args.get_string_list args "key" = [])
   );
 
   Printf.printf "\n✅ All Tool_relay tests passed!\n"

--- a/test/test_tool_room_coverage.ml
+++ b/test/test_tool_room_coverage.ml
@@ -166,27 +166,27 @@ let () = test "dispatch_room_enter_no_id" (fun () ->
 (* Test helper functions *)
 let () = test "get_string_present" (fun () ->
   let args = `Assoc [("key", `String "value")] in
-  assert (Tool_room.get_string args "key" "default" = "value")
+  assert (Tool_args.get_string args "key" "default" = "value")
 )
 
 let () = test "get_string_missing" (fun () ->
   let args = `Assoc [] in
-  assert (Tool_room.get_string args "key" "default" = "default")
+  assert (Tool_args.get_string args "key" "default" = "default")
 )
 
 let () = test "get_bool_true" (fun () ->
   let args = `Assoc [("key", `Bool true)] in
-  assert (Tool_room.get_bool args "key" false = true)
+  assert (Tool_args.get_bool args "key" false = true)
 )
 
 let () = test "get_bool_false" (fun () ->
   let args = `Assoc [("key", `Bool false)] in
-  assert (Tool_room.get_bool args "key" true = false)
+  assert (Tool_args.get_bool args "key" true = false)
 )
 
 let () = test "get_bool_missing" (fun () ->
   let args = `Assoc [] in
-  assert (Tool_room.get_bool args "key" true = true)
+  assert (Tool_args.get_bool args "key" true = true)
 )
 
 let () = Printf.printf "\n✅ All Tool_room tests passed!\n"

--- a/test/test_tool_run_coverage.ml
+++ b/test/test_tool_run_coverage.ml
@@ -1,5 +1,6 @@
 (** Tool_run Module Coverage Tests *)
 
+module Tool_args = Masc_mcp.Tool_args
 open Alcotest
 
 let () = Random.self_init ()
@@ -12,23 +13,23 @@ module Tool_run = Masc_mcp.Tool_run
 
 let test_get_string_exists () =
   let args = `Assoc [("task_id", `String "run-123")] in
-  check string "extracts string" "run-123" (Tool_run.get_string args "task_id" "default")
+  check string "extracts string" "run-123" (Tool_args.get_string args "task_id" "default")
 
 let test_get_string_missing () =
   let args = `Assoc [] in
-  check string "uses default" "default" (Tool_run.get_string args "task_id" "default")
+  check string "uses default" "default" (Tool_args.get_string args "task_id" "default")
 
 let test_get_string_opt_exists () =
   let args = `Assoc [("agent_name", `String "claude")] in
-  check (option string) "extracts option" (Some "claude") (Tool_run.get_string_opt args "agent_name")
+  check (option string) "extracts option" (Some "claude") (Tool_args.get_string_opt args "agent_name")
 
 let test_get_string_opt_missing () =
   let args = `Assoc [] in
-  check (option string) "returns None" None (Tool_run.get_string_opt args "agent_name")
+  check (option string) "returns None" None (Tool_args.get_string_opt args "agent_name")
 
 let test_get_string_opt_empty () =
   let args = `Assoc [("agent_name", `String "")] in
-  check (option string) "empty is None" None (Tool_run.get_string_opt args "agent_name")
+  check (option string) "empty is None" None (Tool_args.get_string_opt args "agent_name")
 
 (* ============================================================
    Context Creation Tests

--- a/test/test_tool_suspend_coverage.ml
+++ b/test/test_tool_suspend_coverage.ml
@@ -10,6 +10,7 @@
 
     @since 2.76.0
 *)
+module Tool_args = Masc_mcp.Tool_args
 
 open Alcotest
 
@@ -47,22 +48,22 @@ let cleanup_blacklist agent_id =
 let test_get_string_exists () =
   let args = `Assoc [("target_agent", `String "agent-1")] in
   check string "extracts string" "agent-1"
-    (Tool_suspend.get_string args "target_agent" "default")
+    (Tool_args.get_string args "target_agent" "default")
 
 let test_get_string_missing () =
   let args = `Assoc [] in
   check string "uses default" "default"
-    (Tool_suspend.get_string args "target_agent" "default")
+    (Tool_args.get_string args "target_agent" "default")
 
 let test_get_string_wrong_type () =
   let args = `Assoc [("target_agent", `Int 42)] in
   check string "uses default on type mismatch" "default"
-    (Tool_suspend.get_string args "target_agent" "default")
+    (Tool_args.get_string args "target_agent" "default")
 
 let test_get_string_non_assoc () =
   let args = `List [`String "a"] in
   check string "uses default on non-assoc" "default"
-    (Tool_suspend.get_string args "target_agent" "default")
+    (Tool_args.get_string args "target_agent" "default")
 
 (* ============================================================
    get_string_opt Tests
@@ -71,27 +72,27 @@ let test_get_string_non_assoc () =
 let test_get_string_opt_exists () =
   let args = `Assoc [("agent_id", `String "agent-1")] in
   check (option string) "returns Some" (Some "agent-1")
-    (Tool_suspend.get_string_opt args "agent_id")
+    (Tool_args.get_string_opt args "agent_id")
 
 let test_get_string_opt_missing () =
   let args = `Assoc [] in
   check (option string) "returns None" None
-    (Tool_suspend.get_string_opt args "agent_id")
+    (Tool_args.get_string_opt args "agent_id")
 
 let test_get_string_opt_empty_string () =
   let args = `Assoc [("agent_id", `String "")] in
   check (option string) "empty string returns None" None
-    (Tool_suspend.get_string_opt args "agent_id")
+    (Tool_args.get_string_opt args "agent_id")
 
 let test_get_string_opt_wrong_type () =
   let args = `Assoc [("agent_id", `Int 42)] in
   check (option string) "wrong type returns None" None
-    (Tool_suspend.get_string_opt args "agent_id")
+    (Tool_args.get_string_opt args "agent_id")
 
 let test_get_string_opt_non_assoc () =
   let args = `Null in
   check (option string) "non-assoc returns None" None
-    (Tool_suspend.get_string_opt args "agent_id")
+    (Tool_args.get_string_opt args "agent_id")
 
 (* ============================================================
    get_float Tests
@@ -100,27 +101,27 @@ let test_get_string_opt_non_assoc () =
 let test_get_float_from_float () =
   let args = `Assoc [("duration", `Float 2.5)] in
   check (float 0.001) "extracts float" 2.5
-    (Tool_suspend.get_float args "duration" 1.0)
+    (Tool_args.get_float args "duration" 1.0)
 
 let test_get_float_from_int () =
   let args = `Assoc [("duration", `Int 3)] in
   check (float 0.001) "converts int to float" 3.0
-    (Tool_suspend.get_float args "duration" 1.0)
+    (Tool_args.get_float args "duration" 1.0)
 
 let test_get_float_missing () =
   let args = `Assoc [] in
   check (float 0.001) "uses default" 1.0
-    (Tool_suspend.get_float args "duration" 1.0)
+    (Tool_args.get_float args "duration" 1.0)
 
 let test_get_float_wrong_type () =
   let args = `Assoc [("duration", `String "2.5")] in
   check (float 0.001) "uses default on string" 1.0
-    (Tool_suspend.get_float args "duration" 1.0)
+    (Tool_args.get_float args "duration" 1.0)
 
 let test_get_float_non_assoc () =
   let args = `Bool true in
   check (float 0.001) "uses default on non-assoc" 1.0
-    (Tool_suspend.get_float args "duration" 1.0)
+    (Tool_args.get_float args "duration" 1.0)
 
 (* ============================================================
    Blacklist Management Tests

--- a/test/test_tool_swarm_coverage.ml
+++ b/test/test_tool_swarm_coverage.ml
@@ -3,6 +3,7 @@
     Tests for swarm tool handlers - argument extraction, dispatch logic.
     Integration tests require Eio runtime and filesystem.
 *)
+module Tool_args = Masc_mcp.Tool_args
 
 open Alcotest
 
@@ -16,48 +17,48 @@ module Tool_swarm = Masc_mcp.Tool_swarm
 
 let test_get_string_exists () =
   let args = `Assoc [("name", `String "claude")] in
-  check string "extracts string" "claude" (Tool_swarm.get_string args "name" "default")
+  check string "extracts string" "claude" (Tool_args.get_string args "name" "default")
 
 let test_get_string_missing () =
   let args = `Assoc [] in
-  check string "uses default" "default" (Tool_swarm.get_string args "name" "default")
+  check string "uses default" "default" (Tool_args.get_string args "name" "default")
 
 let test_get_string_wrong_type () =
   let args = `Assoc [("name", `Int 42)] in
-  check string "uses default on type mismatch" "default" (Tool_swarm.get_string args "name" "default")
+  check string "uses default on type mismatch" "default" (Tool_args.get_string args "name" "default")
 
 let test_get_float_exists () =
   let args = `Assoc [("rate", `Float 0.5)] in
-  check (float 0.001) "extracts float" 0.5 (Tool_swarm.get_float args "rate" 0.0)
+  check (float 0.001) "extracts float" 0.5 (Tool_args.get_float args "rate" 0.0)
 
 let test_get_float_missing () =
   let args = `Assoc [] in
-  check (float 0.001) "uses default" 0.3 (Tool_swarm.get_float args "rate" 0.3)
+  check (float 0.001) "uses default" 0.3 (Tool_args.get_float args "rate" 0.3)
 
 let test_get_float_from_int () =
   (* JSON often has ints where floats are expected *)
   let args = `Assoc [("rate", `Int 1)] in
-  check (float 0.001) "int fallback to default" 0.5 (Tool_swarm.get_float args "rate" 0.5)
+  check (float 0.001) "int fallback to default" 0.5 (Tool_args.get_float args "rate" 0.5)
 
 let test_get_int_exists () =
   let args = `Assoc [("limit", `Int 10)] in
-  check int "extracts int" 10 (Tool_swarm.get_int args "limit" 5)
+  check int "extracts int" 10 (Tool_args.get_int args "limit" 5)
 
 let test_get_int_missing () =
   let args = `Assoc [] in
-  check int "uses default" 5 (Tool_swarm.get_int args "limit" 5)
+  check int "uses default" 5 (Tool_args.get_int args "limit" 5)
 
 let test_get_bool_exists_true () =
   let args = `Assoc [("enabled", `Bool true)] in
-  check bool "extracts true" true (Tool_swarm.get_bool args "enabled" false)
+  check bool "extracts true" true (Tool_args.get_bool args "enabled" false)
 
 let test_get_bool_exists_false () =
   let args = `Assoc [("enabled", `Bool false)] in
-  check bool "extracts false" false (Tool_swarm.get_bool args "enabled" true)
+  check bool "extracts false" false (Tool_args.get_bool args "enabled" true)
 
 let test_get_bool_missing () =
   let args = `Assoc [] in
-  check bool "uses default" true (Tool_swarm.get_bool args "enabled" true)
+  check bool "uses default" true (Tool_args.get_bool args "enabled" true)
 
 (* ============================================================
    Context Creation Tests

--- a/test/test_tool_swarm_coverage.ml
+++ b/test/test_tool_swarm_coverage.ml
@@ -36,9 +36,9 @@ let test_get_float_missing () =
   check (float 0.001) "uses default" 0.3 (Tool_args.get_float args "rate" 0.3)
 
 let test_get_float_from_int () =
-  (* JSON often has ints where floats are expected *)
+  (* JSON often has ints where floats are expected — should convert *)
   let args = `Assoc [("rate", `Int 1)] in
-  check (float 0.001) "int fallback to default" 0.5 (Tool_args.get_float args "rate" 0.5)
+  check (float 0.001) "int converts to float" 1.0 (Tool_args.get_float args "rate" 0.5)
 
 let test_get_int_exists () =
   let args = `Assoc [("limit", `Int 10)] in

--- a/test/test_tool_task_coverage.ml
+++ b/test/test_tool_task_coverage.ml
@@ -192,32 +192,32 @@ let () = test "handle_batch_add_tasks" (fun () ->
 (* Test helper functions *)
 let () = test "get_string_present" (fun () ->
   let args = `Assoc [("key", `String "value")] in
-  assert (Tool_task.get_string args "key" "default" = "value")
+  assert (Tool_args.get_string args "key" "default" = "value")
 )
 
 let () = test "get_string_missing" (fun () ->
   let args = `Assoc [] in
-  assert (Tool_task.get_string args "key" "default" = "default")
+  assert (Tool_args.get_string args "key" "default" = "default")
 )
 
 let () = test "get_int_present" (fun () ->
   let args = `Assoc [("key", `Int 42)] in
-  assert (Tool_task.get_int args "key" 0 = 42)
+  assert (Tool_args.get_int args "key" 0 = 42)
 )
 
 let () = test "get_int_missing" (fun () ->
   let args = `Assoc [] in
-  assert (Tool_task.get_int args "key" 99 = 99)
+  assert (Tool_args.get_int args "key" 99 = 99)
 )
 
 let () = test "get_int_opt_present" (fun () ->
   let args = `Assoc [("key", `Int 42)] in
-  assert (Tool_task.get_int_opt args "key" = Some 42)
+  assert (Tool_args.get_int_opt args "key" = Some 42)
 )
 
 let () = test "get_int_opt_missing" (fun () ->
   let args = `Assoc [] in
-  assert (Tool_task.get_int_opt args "key" = None)
+  assert (Tool_args.get_int_opt args "key" = None)
 )
 
 let () = Printf.printf "\n✅ All Tool_task tests passed!\n"

--- a/test/test_tool_tempo_coverage.ml
+++ b/test/test_tool_tempo_coverage.ml
@@ -1,5 +1,6 @@
 (** Tool_tempo Module Coverage Tests *)
 
+module Tool_args = Masc_mcp.Tool_args
 open Alcotest
 
 let () = Random.self_init ()
@@ -12,31 +13,31 @@ module Tool_tempo = Masc_mcp.Tool_tempo
 
 let test_get_string_exists () =
   let args = `Assoc [("action", `String "get")] in
-  check string "extracts string" "get" (Tool_tempo.get_string args "action" "default")
+  check string "extracts string" "get" (Tool_args.get_string args "action" "default")
 
 let test_get_string_missing () =
   let args = `Assoc [] in
-  check string "uses default" "default" (Tool_tempo.get_string args "action" "default")
+  check string "uses default" "default" (Tool_args.get_string args "action" "default")
 
 let test_get_string_opt_exists () =
   let args = `Assoc [("reason", `String "manual")] in
-  check (option string) "extracts option" (Some "manual") (Tool_tempo.get_string_opt args "reason")
+  check (option string) "extracts option" (Some "manual") (Tool_args.get_string_opt args "reason")
 
 let test_get_string_opt_missing () =
   let args = `Assoc [] in
-  check (option string) "returns None" None (Tool_tempo.get_string_opt args "reason")
+  check (option string) "returns None" None (Tool_args.get_string_opt args "reason")
 
 let test_get_float_exists () =
   let args = `Assoc [("interval", `Float 30.0)] in
-  check (float 0.001) "extracts float" 30.0 (Tool_tempo.get_float args "interval" 0.0)
+  check (float 0.001) "extracts float" 30.0 (Tool_args.get_float args "interval" 0.0)
 
 let test_get_float_from_int () =
   let args = `Assoc [("interval", `Int 30)] in
-  check (float 0.001) "converts int" 30.0 (Tool_tempo.get_float args "interval" 0.0)
+  check (float 0.001) "converts int" 30.0 (Tool_args.get_float args "interval" 0.0)
 
 let test_get_float_missing () =
   let args = `Assoc [] in
-  check (float 0.001) "uses default" 10.0 (Tool_tempo.get_float args "interval" 10.0)
+  check (float 0.001) "uses default" 10.0 (Tool_args.get_float args "interval" 10.0)
 
 (* ============================================================
    Context Creation Tests

--- a/test/test_tool_vote_coverage.ml
+++ b/test/test_tool_vote_coverage.ml
@@ -1,5 +1,6 @@
 (** Tool_vote Module Coverage Tests *)
 
+module Tool_args = Masc_mcp.Tool_args
 open Alcotest
 
 let () = Random.self_init ()
@@ -12,31 +13,31 @@ module Tool_vote = Masc_mcp.Tool_vote
 
 let test_get_string_exists () =
   let args = `Assoc [("topic", `String "Should we merge?")] in
-  check string "extracts string" "Should we merge?" (Tool_vote.get_string args "topic" "default")
+  check string "extracts string" "Should we merge?" (Tool_args.get_string args "topic" "default")
 
 let test_get_string_missing () =
   let args = `Assoc [] in
-  check string "uses default" "default" (Tool_vote.get_string args "topic" "default")
+  check string "uses default" "default" (Tool_args.get_string args "topic" "default")
 
 let test_get_int_exists () =
   let args = `Assoc [("required_votes", `Int 3)] in
-  check int "extracts int" 3 (Tool_vote.get_int args "required_votes" 2)
+  check int "extracts int" 3 (Tool_args.get_int args "required_votes" 2)
 
 let test_get_int_missing () =
   let args = `Assoc [] in
-  check int "uses default" 2 (Tool_vote.get_int args "required_votes" 2)
+  check int "uses default" 2 (Tool_args.get_int args "required_votes" 2)
 
 let test_get_string_list_exists () =
   let args = `Assoc [("options", `List [`String "yes"; `String "no"; `String "abstain"])] in
-  check (list string) "extracts list" ["yes"; "no"; "abstain"] (Tool_vote.get_string_list args "options")
+  check (list string) "extracts list" ["yes"; "no"; "abstain"] (Tool_args.get_string_list args "options")
 
 let test_get_string_list_missing () =
   let args = `Assoc [] in
-  check (list string) "returns empty" [] (Tool_vote.get_string_list args "options")
+  check (list string) "returns empty" [] (Tool_args.get_string_list args "options")
 
 let test_get_string_list_mixed () =
   let args = `Assoc [("options", `List [`String "yes"; `Int 1; `String "no"])] in
-  check (list string) "filters non-strings" ["yes"; "no"] (Tool_vote.get_string_list args "options")
+  check (list string) "filters non-strings" ["yes"; "no"] (Tool_args.get_string_list args "options")
 
 (* ============================================================
    Context Creation Tests

--- a/test/test_tool_walph_coverage.ml
+++ b/test/test_tool_walph_coverage.ml
@@ -171,32 +171,32 @@ let () = test "walph_natural_empty" (fun () ->
 (* Test helper functions *)
 let () = test "get_string_present" (fun () ->
   let args = `Assoc [("key", `String "value")] in
-  assert (Tool_walph.get_string args "key" "default" = "value")
+  assert (Tool_args.get_string args "key" "default" = "value")
 )
 
 let () = test "get_string_missing" (fun () ->
   let args = `Assoc [] in
-  assert (Tool_walph.get_string args "key" "default" = "default")
+  assert (Tool_args.get_string args "key" "default" = "default")
 )
 
 let () = test "get_string_opt_present" (fun () ->
   let args = `Assoc [("key", `String "value")] in
-  assert (Tool_walph.get_string_opt args "key" = Some "value")
+  assert (Tool_args.get_string_opt args "key" = Some "value")
 )
 
 let () = test "get_string_opt_missing" (fun () ->
   let args = `Assoc [] in
-  assert (Tool_walph.get_string_opt args "key" = None)
+  assert (Tool_args.get_string_opt args "key" = None)
 )
 
 let () = test "get_int_present" (fun () ->
   let args = `Assoc [("key", `Int 42)] in
-  assert (Tool_walph.get_int args "key" 0 = 42)
+  assert (Tool_args.get_int args "key" 0 = 42)
 )
 
 let () = test "get_int_missing" (fun () ->
   let args = `Assoc [] in
-  assert (Tool_walph.get_int args "key" 99 = 99)
+  assert (Tool_args.get_int args "key" 99 = 99)
 )
 
 let () = Printf.printf "\n✅ All Tool_walph tests passed!\n"

--- a/test/test_tool_worktree_coverage.ml
+++ b/test/test_tool_worktree_coverage.ml
@@ -1,5 +1,6 @@
 (** Tool_worktree Module Coverage Tests *)
 
+module Tool_args = Masc_mcp.Tool_args
 open Alcotest
 
 let () = Random.self_init ()
@@ -12,19 +13,19 @@ module Tool_worktree = Masc_mcp.Tool_worktree
 
 let test_get_string_exists () =
   let args = `Assoc [("task_id", `String "task-001")] in
-  check string "extracts string" "task-001" (Tool_worktree.get_string args "task_id" "default")
+  check string "extracts string" "task-001" (Tool_args.get_string args "task_id" "default")
 
 let test_get_string_missing () =
   let args = `Assoc [] in
-  check string "uses default" "default" (Tool_worktree.get_string args "task_id" "default")
+  check string "uses default" "default" (Tool_args.get_string args "task_id" "default")
 
 let test_get_string_base_branch () =
   let args = `Assoc [("base_branch", `String "main")] in
-  check string "extracts branch" "main" (Tool_worktree.get_string args "base_branch" "develop")
+  check string "extracts branch" "main" (Tool_args.get_string args "base_branch" "develop")
 
 let test_get_string_base_branch_default () =
   let args = `Assoc [] in
-  check string "uses develop default" "develop" (Tool_worktree.get_string args "base_branch" "develop")
+  check string "uses develop default" "develop" (Tool_args.get_string args "base_branch" "develop")
 
 (* ============================================================
    Context Creation Tests


### PR DESCRIPTION
## Summary

- 40+ tool_*.ml 파일에 중복 정의된 120개 JSON arg parser helper를 Tool_args 모듈로 통합
- Safe_ops.json_* 위에 tool-convention positional signature wrapper 제공
- Safe_ops.json_bool_opt 추가
- Safe_ops.json_float: Int to float 변환 추가 (json_float_opt와 일관성 확보)
- Safe_ops.json_string_list: mixed-type array에서 문자열만 필터 (List.filter_map)

## Changes

| Category | Count |
|----------|-------|
| New module | lib/tool_args.ml (9 functions, 15 lines) |
| Modified lib files | 41 .ml + 22 .mli |
| Modified test files | 27 |
| Net reduction | ~870 lines |

## Test plan

- [x] dune build clean compile
- [x] dune runtest all tests pass (286s)
- [ ] CI green
- [ ] GLM-5 external review