### PR TITLE
refactor: delegate non-tool JSON helpers to Safe_ops

### DIFF
--- a/lib/mind_eio.ml
+++ b/lib/mind_eio.ml
@@ -215,56 +215,13 @@ let mind_to_json (m : mind) : Yojson.Safe.t =
 
 (** {1 Deserialization helpers} *)
 
-let get_string json key =
-  match json with
-  | `Assoc l -> (match List.assoc_opt key l with Some (`String s) -> s | _ -> "")
-  | _ -> ""
-
-let get_float json key =
-  match json with
-  | `Assoc l -> (match List.assoc_opt key l with
-    | Some (`Float f) -> f
-    | Some (`Int i) -> float_of_int i
-    | _ -> 0.0)
-  | _ -> 0.0
-
-let get_int json key =
-  match json with
-  | `Assoc l -> (match List.assoc_opt key l with
-    | Some (`Int i) -> i
-    | Some (`Float f) -> int_of_float f
-    | _ -> 0)
-  | _ -> 0
-
-let get_bool json key =
-  match json with
-  | `Assoc l -> (match List.assoc_opt key l with Some (`Bool b) -> b | _ -> false)
-  | _ -> false
-
-let get_string_list json key =
-  match json with
-  | `Assoc l -> (match List.assoc_opt key l with
-    | Some (`List items) ->
-      List.filter_map (function `String s -> Some s | _ -> None) items
-    | _ -> [])
-  | _ -> []
-
-let get_string_opt json key =
-  match json with
-  | `Assoc l -> (match List.assoc_opt key l with
-    | Some (`String s) -> Some s
-    | Some `Null -> None
-    | _ -> None)
-  | _ -> None
-
-let get_float_opt json key =
-  match json with
-  | `Assoc l -> (match List.assoc_opt key l with
-    | Some (`Float f) -> Some f
-    | Some (`Int i) -> Some (float_of_int i)
-    | Some `Null -> None
-    | _ -> None)
-  | _ -> None
+let get_string json key = Safe_ops.json_string key json
+let get_float json key = Safe_ops.json_float key json
+let get_int json key = Safe_ops.json_int key json
+let get_bool json key = Safe_ops.json_bool key json
+let get_string_list json key = Safe_ops.json_string_list key json
+let get_string_opt json key = Safe_ops.json_string_opt key json
+let get_float_opt json key = Safe_ops.json_float_opt key json
 
 let self_model_of_json json : self_model =
   let state_str = get_string json "current_state" in

--- a/lib/noosphere_eio.ml
+++ b/lib/noosphere_eio.ml
@@ -134,40 +134,11 @@ let noosphere_to_json (n : noosphere) : Yojson.Safe.t =
 
 (** {1 Deserialization helpers} *)
 
-let get_string json key =
-  match json with
-  | `Assoc l -> (match List.assoc_opt key l with Some (`String s) -> s | _ -> "")
-  | _ -> ""
-
-let get_float json key =
-  match json with
-  | `Assoc l -> (match List.assoc_opt key l with
-    | Some (`Float f) -> f
-    | Some (`Int i) -> float_of_int i
-    | _ -> 0.0)
-  | _ -> 0.0
-
-let get_int json key =
-  match json with
-  | `Assoc l -> (match List.assoc_opt key l with
-    | Some (`Int i) -> i
-    | Some (`Float f) -> int_of_float f
-    | _ -> 0)
-  | _ -> 0
-
-let get_string_list json key =
-  match json with
-  | `Assoc l -> (match List.assoc_opt key l with
-    | Some (`List items) -> List.filter_map (function `String s -> Some s | _ -> None) items
-    | _ -> [])
-  | _ -> []
-
-let get_string_opt json key =
-  match json with
-  | `Assoc l -> (match List.assoc_opt key l with
-    | Some (`String s) -> Some s
-    | _ -> None)
-  | _ -> None
+let get_string json key = Safe_ops.json_string key json
+let get_float json key = Safe_ops.json_float key json
+let get_int json key = Safe_ops.json_int key json
+let get_string_list json key = Safe_ops.json_string_list key json
+let get_string_opt json key = Safe_ops.json_string_opt key json
 
 let connection_of_json json : connection = {
   from_mind = get_string json "from_mind";

--- a/lib/safe_ops.ml
+++ b/lib/safe_ops.ml
@@ -128,7 +128,10 @@ let json_string ?(default = "") key json =
 
 let json_int ?(default = 0) key json =
   let open Yojson.Safe.Util in
-  try json |> member key |> to_int
+  try
+    match json |> member key with
+    | `Float f -> int_of_float f
+    | j -> to_int j
   with Type_error _ -> default
 
 let json_float ?(default = 0.0) key json =

--- a/lib/trpg_rule_dnd5e_lite.ml
+++ b/lib/trpg_rule_dnd5e_lite.ml
@@ -72,20 +72,9 @@ let assoc_get key fields = List.assoc_opt key fields
 let assoc_put key value fields =
   (key, value) :: List.remove_assoc key fields
 
-let get_string_opt key json =
-  match json |> member key with
-  | `String s -> Some s
-  | _ -> None
-
-let get_int_opt key json =
-  match json |> member key with
-  | `Int i -> Some i
-  | _ -> None
-
-let get_bool_opt key json =
-  match json |> member key with
-  | `Bool b -> Some b
-  | _ -> None
+let get_string_opt = Safe_ops.json_string_opt
+let get_int_opt = Safe_ops.json_int_opt
+let get_bool_opt = Safe_ops.json_bool_opt
 
 let assoc_fields_or_empty = function
   | `Assoc fields -> fields

--- a/lib/trpg_slot_narrative.ml
+++ b/lib/trpg_slot_narrative.ml
@@ -62,20 +62,9 @@ let assoc_fields_or_empty = function
   | `Assoc fields -> fields
   | _ -> []
 
-let get_string_opt key json =
-  match json |> member key with
-  | `String s -> Some s
-  | _ -> None
-
-let get_int_opt key json =
-  match json |> member key with
-  | `Int i -> Some i
-  | _ -> None
-
-let get_bool_opt key json =
-  match json |> member key with
-  | `Bool b -> Some b
-  | _ -> None
+let get_string_opt = Safe_ops.json_string_opt
+let get_int_opt = Safe_ops.json_int_opt
+let get_bool_opt = Safe_ops.json_bool_opt
 
 let append_to_list key value state =
   match state with

--- a/lib/trpg_slot_world.ml
+++ b/lib/trpg_slot_world.ml
@@ -77,15 +77,8 @@ let assoc_fields_or_empty = function
   | `Assoc fields -> fields
   | _ -> []
 
-let get_string_opt key json =
-  match json |> member key with
-  | `String s -> Some s
-  | _ -> None
-
-let get_int_opt key json =
-  match json |> member key with
-  | `Int i -> Some i
-  | _ -> None
+let get_string_opt = Safe_ops.json_string_opt
+let get_int_opt = Safe_ops.json_int_opt
 
 let append_to_list key value state =
   match state with


### PR DESCRIPTION
## Summary
- PR #621의 후속: non-tool 파일 6개(`noosphere_eio.ml`, `mind_eio.ml`, TRPG 3파일, `safe_ops.ml`)에서 중복 JSON 헬퍼를 Safe_ops로 위임
- `safe_ops.ml`의 `json_int`에 `Float → int_of_float` 변환 추가 (noosphere/mind 로컬 헬퍼와 동작 일치)
- **-98줄** (122 삭제, 24 추가)

## Changes
| 파일 | 변경 |
|------|------|
| `safe_ops.ml` | `json_int`에 `` `Float`` fallback 추가 |
| `noosphere_eio.ml` | 5개 로컬 헬퍼 → Safe_ops 1줄 위임 (-34줄) |
| `mind_eio.ml` | 7개 로컬 헬퍼 → Safe_ops 1줄 위임 (-50줄) |
| `trpg_slot_narrative.ml` | 3개 → point-free alias |
| `trpg_slot_world.ml` | 2개 → point-free alias |
| `trpg_rule_dnd5e_lite.ml` | 3개 → point-free alias |

## Skipped (의도적)
- `command_plane_v2.ml`: `nonempty_string`, `dedup_strings`, `` `Intlit`` 처리 등 도메인 고유 동작
- `swarm_status.ml`: trim+empty check 포함 `get_string_opt` — 도메인 고유

## Test plan
- [x] `dune build` clean compile
- [x] `test_tool_swarm_coverage.exe` (29 tests PASS)
- [x] `test_trpg_engine.exe` (85 tests PASS)
- [x] `test_safe_ops.exe` (9 tests PASS)

🤖 Generated with [Claude Code](https://claude.com/claude-code)