### PR TITLE
fix(gemini): force json cli output for spawned workers

### DIFF
--- a/lib/spawn.ml
+++ b/lib/spawn.ml
@@ -136,6 +136,106 @@ let parse_claude_json output =
     (* If JSON parsing fails, return raw output with no token info *)
     (Some output, None, None, None, None, None)
 
+(** Extract Gemini CLI response text from JSON output. *)
+let extract_gemini_response_text output =
+  try
+    let json = Yojson.Safe.from_string output in
+    let module U = Yojson.Safe.Util in
+    json |> U.member "response" |> U.to_string_option
+  with Yojson.Json_error _ | Yojson.Safe.Util.Type_error _ ->
+    None
+
+(** Parse Gemini output for token tracking.
+    Supports both Gemini API usageMetadata and Gemini CLI JSON stats. *)
+let parse_gemini_output output =
+  try
+    let json = Yojson.Safe.from_string output in
+    let module U = Yojson.Safe.Util in
+    let usage_opt =
+      match json |> U.member "usageMetadata" with
+      | `Assoc _ as usage -> Some usage
+      | _ -> None
+    in
+    let stats_models_opt =
+      match json |> U.member "stats" with
+      | `Assoc _ as stats ->
+          (match stats |> U.member "models" with
+           | `Assoc entries -> Some entries
+           | _ -> None)
+      | _ -> None
+    in
+    let input_tokens =
+      match Option.bind usage_opt (fun usage -> usage |> U.member "promptTokenCount" |> U.to_int_option) with
+      | Some _ as value -> value
+      | None ->
+          (match stats_models_opt with
+           | None -> None
+           | Some entries ->
+               let sum_field field =
+                 entries
+                 |> List.fold_left (fun acc (_name, item) ->
+                        acc
+                        + (item |> U.member "tokens" |> U.member field |> U.to_int_option
+                          |> Option.value ~default:0))
+                      0
+               in
+               let input = sum_field "input" in
+               let prompt = sum_field "prompt" in
+               let chosen = if input > 0 then input else prompt in
+               if chosen > 0 then Some chosen else None)
+    in
+    let output_tokens =
+      match Option.bind usage_opt (fun usage -> usage |> U.member "candidatesTokenCount" |> U.to_int_option) with
+      | Some _ as value -> value
+      | None ->
+          (match stats_models_opt with
+           | None -> None
+           | Some entries ->
+               let total =
+                 entries
+                 |> List.fold_left (fun acc (_name, item) ->
+                        acc
+                        + (item |> U.member "tokens" |> U.member "candidates" |> U.to_int_option
+                          |> Option.value ~default:0))
+                      0
+               in
+               if total > 0 then Some total else None)
+    in
+    let cached_tokens =
+      match Option.bind usage_opt (fun usage -> usage |> U.member "cachedContentTokenCount" |> U.to_int_option) with
+      | Some _ as value -> value
+      | None ->
+          (match stats_models_opt with
+           | None -> None
+           | Some entries ->
+               let total =
+                 entries
+                 |> List.fold_left (fun acc (_name, item) ->
+                        acc
+                        + (item |> U.member "tokens" |> U.member "cached" |> U.to_int_option
+                          |> Option.value ~default:0))
+                      0
+               in
+               if total > 0 then Some total else None)
+    in
+    let cost =
+      match input_tokens, output_tokens, cached_tokens with
+      | Some inp, Some out, Some cached ->
+          let uncached = inp - cached in
+          Some
+            (float_of_int uncached *. 0.00015 /. 1000.0
+           +. float_of_int cached *. 0.000015 /. 1000.0
+           +. float_of_int out *. 0.0006 /. 1000.0)
+      | Some inp, Some out, None ->
+          Some
+            (float_of_int inp *. 0.00015 /. 1000.0
+           +. float_of_int out *. 0.0006 /. 1000.0)
+      | _ -> None
+    in
+    (input_tokens, output_tokens, cached_tokens, cost)
+  with Yojson.Json_error _ | Yojson.Safe.Util.Type_error _ ->
+    (None, None, None, None)
+
 (** Default spawn configs for known agents *)
 let default_configs = [
   ("claude", {
@@ -147,7 +247,7 @@ let default_configs = [
   });
   ("gemini", {
     agent_name = "gemini";
-    command = "gemini --yolo";  (* Auto-approve tools for non-interactive *)
+    command = "gemini --yolo --output-format json";
     timeout_seconds = Env_config.Spawn.timeout_seconds;
     working_dir = None;
     mcp_tools = masc_mcp_tools;  (* Gemini: --allowed-mcp-server-names flag *)
@@ -191,6 +291,11 @@ let build_mcp_args agent_name tools =
     []
   | _ -> []
 
+let build_prompt_args agent_name prompt =
+  match agent_name with
+  | "gemini" -> ["-p"; prompt]
+  | _ -> []
+
 (** Parse command string into executable and arguments *)
 let parse_command cmd =
   let parts = String.split_on_char ' ' cmd in
@@ -216,10 +321,11 @@ let spawn ~agent_name ~prompt ?timeout_seconds ?working_dir () =
   let mcp_args = build_mcp_args agent_name config.mcp_tools in
   (* Auto-append MASC lifecycle protocol to prompt *)
   let augmented_prompt = prompt ^ masc_lifecycle_suffix in
+  let prompt_args = build_prompt_args agent_name augmented_prompt in
 
   (* Build command args - direct execution without shell *)
   let base_args = parse_command config.command in
-  let cmd_args = ["timeout"; string_of_int timeout] @ base_args @ mcp_args in
+  let cmd_args = ["timeout"; string_of_int timeout] @ base_args @ mcp_args @ prompt_args in
   let cmd_array = Array.of_list cmd_args in
 
   (* Change to working dir if specified *)
@@ -245,8 +351,9 @@ let spawn ~agent_name ~prompt ?timeout_seconds ?working_dir () =
     Unix.close stdout_write;
     Unix.close stdin_read;
     
-    (* Write prompt to stdin and close *)
-    let _ = Unix.write_substring stdin_write augmented_prompt 0 (String.length augmented_prompt) in
+    (* Gemini CLI expects prompt via -p; other CLIs still read stdin. *)
+    let stdin_content = if agent_name = "gemini" then "" else augmented_prompt in
+    let _ = Unix.write_substring stdin_write stdin_content 0 (String.length stdin_content) in
     Unix.close stdin_write;
     
     (* Read output *)
@@ -272,6 +379,10 @@ let spawn ~agent_name ~prompt ?timeout_seconds ?working_dir () =
       if agent_name = "claude" then
         let (result_opt, inp, out, cache_c, cache_r, cost) = parse_claude_json raw_output in
         (Option.value result_opt ~default:raw_output, inp, out, cache_c, cache_r, cost)
+      else if agent_name = "gemini" then
+        let inp, out, cached, cost = parse_gemini_output raw_output in
+        let result_text = Option.value (extract_gemini_response_text raw_output) ~default:raw_output in
+        (result_text, inp, out, None, cached, cost)
       else
         (raw_output, None, None, None, None, None)
     in

--- a/lib/spawn_eio.ml
+++ b/lib/spawn_eio.ml
@@ -131,16 +131,84 @@ let parse_claude_json output =
   | Yojson.Json_error _ | Yojson.Safe.Util.Type_error _ ->
     (Some output, None, None, None, None, None)
 
+(** Extract Gemini CLI response text from JSON output. *)
+let extract_gemini_response_text output =
+  try
+    let json = Yojson.Safe.from_string output in
+    let open Yojson.Safe.Util in
+    json |> member "response" |> to_string_option
+  with Yojson.Json_error _ | Yojson.Safe.Util.Type_error _ ->
+    None
+
 (** Parse Gemini output for token tracking
-    Format: {"usageMetadata": {"promptTokenCount": N, "candidatesTokenCount": M, "cachedContentTokenCount": C}} *)
+    Supports both:
+    - Gemini API style: {"usageMetadata": {"promptTokenCount": N, "candidatesTokenCount": M, "cachedContentTokenCount": C}}
+    - Gemini CLI JSON: {"response": "...", "stats": {"models": {"...": {"tokens": {...}}}}} *)
 let parse_gemini_output output =
   try
     let json = Yojson.Safe.from_string output in
     let open Yojson.Safe.Util in
-    let usage = json |> member "usageMetadata" in
-    let input_tokens = usage |> member "promptTokenCount" |> to_int_option in
-    let output_tokens = usage |> member "candidatesTokenCount" |> to_int_option in
-    let cached_tokens = usage |> member "cachedContentTokenCount" |> to_int_option in
+    let usage_opt =
+      match json |> member "usageMetadata" with
+      | `Assoc _ as usage -> Some usage
+      | _ -> None
+    in
+    let stats_models_opt =
+      match json |> member "stats" with
+      | `Assoc _ as stats ->
+          (match stats |> member "models" with
+           | `Assoc entries -> Some entries
+           | _ -> None)
+      | _ -> None
+    in
+    let input_tokens =
+      match Option.bind usage_opt (fun usage -> usage |> member "promptTokenCount" |> to_int_option) with
+      | Some _ as value -> value
+      | None ->
+          (match stats_models_opt with
+           | None -> None
+           | Some entries ->
+               let sum_field field =
+                 entries
+                 |> List.fold_left (fun acc (_name, item) ->
+                     acc + (item |> member "tokens" |> member field |> to_int_option |> Option.value ~default:0)
+                   ) 0
+               in
+               let input = sum_field "input" in
+               let prompt = sum_field "prompt" in
+               let chosen = if input > 0 then input else prompt in
+               if chosen > 0 then Some chosen else None)
+    in
+    let output_tokens =
+      match Option.bind usage_opt (fun usage -> usage |> member "candidatesTokenCount" |> to_int_option) with
+      | Some _ as value -> value
+      | None ->
+          (match stats_models_opt with
+           | None -> None
+           | Some entries ->
+               let total =
+                 entries
+                 |> List.fold_left (fun acc (_name, item) ->
+                     acc + (item |> member "tokens" |> member "candidates" |> to_int_option |> Option.value ~default:0)
+                   ) 0
+               in
+               if total > 0 then Some total else None)
+    in
+    let cached_tokens =
+      match Option.bind usage_opt (fun usage -> usage |> member "cachedContentTokenCount" |> to_int_option) with
+      | Some _ as value -> value
+      | None ->
+          (match stats_models_opt with
+           | None -> None
+           | Some entries ->
+               let total =
+                 entries
+                 |> List.fold_left (fun acc (_name, item) ->
+                     acc + (item |> member "tokens" |> member "cached" |> to_int_option |> Option.value ~default:0)
+                   ) 0
+               in
+               if total > 0 then Some total else None)
+    in
     (* Gemini 2.5: cached tokens are 90% cheaper *)
     let cost = match input_tokens, output_tokens, cached_tokens with
       | Some inp, Some out, Some cached ->
@@ -372,7 +440,7 @@ let default_configs = [
   });
   ("gemini", {
     agent_name = "gemini";
-    command = "gemini --yolo";
+    command = "gemini --yolo --output-format json";
     timeout_seconds = Env_config.Spawn.timeout_seconds;
     working_dir = None;
     mcp_tools = masc_mcp_tools;
@@ -413,14 +481,19 @@ let get_config agent_name =
   List.assoc_opt agent_name default_configs
 
 (** Build MCP flags as argument list (no shell escaping needed) *)
-let build_mcp_args agent_name tools = 
+let build_mcp_args agent_name tools =
   if tools = [] then []
-  else match agent_name with 
+  else match agent_name with
   | "claude" -> 
     let tools_str = String.concat "," tools in 
     ["--allowedTools"; tools_str]
   | "gemini" -> 
     ["--allowed-mcp-server-names"; "masc"; "--allowed-tools"] @ tools
+  | _ -> []
+
+let build_prompt_args agent_name prompt =
+  match agent_name with
+  | "gemini" -> ["-p"; prompt]
   | _ -> []
 
 (** Parse command string into executable and arguments *)
@@ -831,8 +904,10 @@ let spawn ~sw ~proc_mgr ~agent_name ~prompt ?timeout_seconds ?working_dir
   else
     (* Build command arguments outside the chdir critical section *)
     let base_args = parse_command config.command in
-    let cmd_args = base_args @ mcp_args in
+    let prompt_args = build_prompt_args agent_name augmented_prompt in
+    let cmd_args = base_args @ mcp_args @ prompt_args in
     let full_args = ["timeout"; string_of_int timeout] @ cmd_args in
+    let stdin_content = if agent_name = "gemini" then "" else augmented_prompt in
 
     (* Serialize chdir + fork under mutex. Sys.chdir is process-global;
        without this, concurrent Eio fibers would race on the CWD. *)
@@ -844,7 +919,7 @@ let spawn ~sw ~proc_mgr ~agent_name ~prompt ?timeout_seconds ?working_dir
           let buf = Buffer.create 4096 in
           let proc =
             Eio.Process.spawn ~sw proc_mgr
-              ~stdin:(Eio.Flow.string_source augmented_prompt)
+              ~stdin:(Eio.Flow.string_source stdin_content)
               ~stdout:(Eio.Flow.buffer_sink buf)
               full_args
           in
@@ -870,7 +945,8 @@ let spawn ~sw ~proc_mgr ~agent_name ~prompt ?timeout_seconds ?working_dir
               (Option.value result_opt ~default:raw_output, inp, out, cache_c, cache_r, cost)
           | "gemini" ->
               let inp, out, cached, cost = parse_gemini_output raw_output in
-              (raw_output, inp, out, cached, None, cost)
+              let result_text = Option.value (extract_gemini_response_text raw_output) ~default:raw_output in
+              (result_text, inp, out, cached, None, cost)
           | "ollama" ->
               let inp, out, cost = parse_ollama_output raw_output in
               (raw_output, inp, out, None, None, cost)

--- a/test/test_spawn_coverage.ml
+++ b/test/test_spawn_coverage.ml
@@ -239,6 +239,16 @@ let test_default_configs_gemini_command () =
        with Not_found -> false)
   | None -> fail "no gemini config"
 
+let test_default_configs_gemini_json_output () =
+  match List.assoc_opt "gemini" Spawn.default_configs with
+  | Some cfg ->
+      check bool "has json output" true
+        (try
+           let _ = Str.search_forward (Str.regexp_string "--output-format json") cfg.command 0 in
+           true
+         with Not_found -> false)
+  | None -> fail "no gemini config"
+
 (* ============================================================
    get_config Tests
    ============================================================ *)
@@ -309,6 +319,14 @@ let test_build_mcp_args_unknown () =
   let flags = Spawn.build_mcp_args "unknown" ["tool1"] in
   check (list string) "unknown empty" [] flags
 
+let test_build_prompt_args_gemini () =
+  let flags = Spawn.build_prompt_args "gemini" "hello" in
+  check (list string) "gemini prompt args" ["-p"; "hello"] flags
+
+let test_build_prompt_args_other () =
+  let flags = Spawn.build_prompt_args "claude" "hello" in
+  check (list string) "other prompt args" [] flags
+
 (* ============================================================
    parse_claude_json Tests
    ============================================================ *)
@@ -343,6 +361,56 @@ let test_parse_claude_json_missing_fields () =
   let (_result, input, output, _cache_c, _cache_r, _cost) = Spawn.parse_claude_json json_str in
   check (option int) "no input" None input;
   check (option int) "no output" None output
+
+(* ============================================================
+   parse_gemini_output Tests
+   ============================================================ *)
+
+let test_extract_gemini_response_text_cli_json () =
+  let json = {|{"response":"hello from gemini","session_id":"sess-1","stats":{"models":{}}}|} in
+  check (option string) "response field"
+    (Some "hello from gemini")
+    (Spawn.extract_gemini_response_text json)
+
+let test_parse_gemini_output_success () =
+  let json = {|{"usageMetadata": {"promptTokenCount": 50, "candidatesTokenCount": 100}}|} in
+  let (input, output, cached, _) = Spawn.parse_gemini_output json in
+  check (option int) "input" (Some 50) input;
+  check (option int) "output" (Some 100) output;
+  check (option int) "cached" None cached
+
+let test_parse_gemini_output_with_cache () =
+  let json = {|{"usageMetadata": {"promptTokenCount": 100, "candidatesTokenCount": 50, "cachedContentTokenCount": 80}}|} in
+  let (input, output, cached, cost) = Spawn.parse_gemini_output json in
+  check (option int) "input" (Some 100) input;
+  check (option int) "output" (Some 50) output;
+  check (option int) "cached" (Some 80) cached;
+  check bool "has cost" true (Option.is_some cost)
+
+let test_parse_gemini_output_cli_json () =
+  let json = {|
+    {
+      "response":"hello",
+      "stats":{
+        "models":{
+          "gemini-2.5-flash-lite":{"tokens":{"input":1001,"prompt":1001,"candidates":50,"cached":0}},
+          "gemini-3-flash-preview":{"tokens":{"input":14768,"prompt":14768,"candidates":35,"cached":0}}
+        }
+      }
+    }
+  |} in
+  let (input, output, cached, cost) = Spawn.parse_gemini_output json in
+  check (option int) "input" (Some 15769) input;
+  check (option int) "output" (Some 85) output;
+  check (option int) "cached" None cached;
+  check bool "has cost" true (Option.is_some cost)
+
+let test_parse_gemini_output_invalid () =
+  let (input, output, cached, cost) = Spawn.parse_gemini_output "invalid" in
+  check (option int) "input None" None input;
+  check (option int) "output None" None output;
+  check (option int) "cached None" None cached;
+  check (option (float 0.01)) "cost None" None cost
 
 (* ============================================================
    int_opt_to_json / float_opt_to_json Tests
@@ -616,6 +684,7 @@ let () =
       test_case "has ollama" `Quick test_default_configs_has_ollama;
       test_case "claude command" `Quick test_default_configs_claude_command;
       test_case "gemini command" `Quick test_default_configs_gemini_command;
+      test_case "gemini json output" `Quick test_default_configs_gemini_json_output;
       test_case "timeout from env_config" `Quick test_default_configs_timeout_from_env_config;
       test_case "timeout is 600" `Quick test_default_configs_timeout_is_600;
     ];
@@ -631,6 +700,8 @@ let () =
       test_case "claude" `Quick test_build_mcp_args_claude;
       test_case "gemini" `Quick test_build_mcp_args_gemini;
       test_case "gemini allowed tools" `Quick test_build_mcp_args_gemini_allowed_tools;
+      test_case "gemini prompt args" `Quick test_build_prompt_args_gemini;
+      test_case "other prompt args" `Quick test_build_prompt_args_other;
       test_case "codex" `Quick test_build_mcp_args_codex;
       test_case "ollama" `Quick test_build_mcp_args_ollama;
       test_case "unknown" `Quick test_build_mcp_args_unknown;
@@ -640,6 +711,13 @@ let () =
       test_case "with cache" `Quick test_parse_claude_json_with_cache;
       test_case "invalid" `Quick test_parse_claude_json_invalid;
       test_case "missing fields" `Quick test_parse_claude_json_missing_fields;
+    ];
+    "parse_gemini_output", [
+      test_case "extract response from cli json" `Quick test_extract_gemini_response_text_cli_json;
+      test_case "success" `Quick test_parse_gemini_output_success;
+      test_case "with cache" `Quick test_parse_gemini_output_with_cache;
+      test_case "cli json stats" `Quick test_parse_gemini_output_cli_json;
+      test_case "invalid" `Quick test_parse_gemini_output_invalid;
     ];
     "int_opt_to_json", [
       test_case "some" `Quick test_int_opt_to_json_some;

--- a/test/test_spawn_eio_coverage.ml
+++ b/test/test_spawn_eio_coverage.ml
@@ -228,6 +228,30 @@ let test_parse_gemini_output_invalid () =
   check (option int) "cached None" None cached;
   check (option (float 0.01)) "cost None" None cost
 
+let test_extract_gemini_response_text_cli_json () =
+  let json = {|{"response":"hello from gemini","session_id":"sess-1","stats":{"models":{}}}|} in
+  check (option string) "response field"
+    (Some "hello from gemini")
+    (Spawn_eio.extract_gemini_response_text json)
+
+let test_parse_gemini_output_cli_json () =
+  let json = {|
+    {
+      "response":"hello",
+      "stats":{
+        "models":{
+          "gemini-2.5-flash-lite":{"tokens":{"input":1001,"prompt":1001,"candidates":50,"cached":0}},
+          "gemini-3-flash-preview":{"tokens":{"input":14768,"prompt":14768,"candidates":35,"cached":0}}
+        }
+      }
+    }
+  |} in
+  let (input, output, cached, cost) = Spawn_eio.parse_gemini_output json in
+  check (option int) "input" (Some 15769) input;
+  check (option int) "output" (Some 85) output;
+  check (option int) "cached" None cached;
+  check bool "has cost" true (Option.is_some cost)
+
 (* ============================================================
    parse_ollama_output Tests
    ============================================================ *)
@@ -413,6 +437,17 @@ let test_default_configs_has_codex () =
 let test_default_configs_has_llama () =
   check bool "has llama" true (List.mem_assoc "llama" Spawn_eio.default_configs)
 
+let test_default_configs_gemini_json_output () =
+  match Spawn_eio.get_config "gemini" with
+  | Some cfg ->
+      check bool "includes json output" true
+        (String.contains cfg.command '-' &&
+         try
+           let _ = Str.search_forward (Str.regexp_string "--output-format json") cfg.command 0 in
+           true
+         with Not_found -> false)
+  | None -> fail "expected gemini config"
+
 (* ============================================================
    get_config Tests
    ============================================================ *)
@@ -471,6 +506,14 @@ let test_build_mcp_args_other () =
   let flags = Spawn_eio.build_mcp_args "codex" ["tool1"] in
   check (list string) "empty for other" [] flags
 
+let test_build_prompt_args_gemini () =
+  let flags = Spawn_eio.build_prompt_args "gemini" "hello" in
+  check (list string) "gemini prompt args" ["-p"; "hello"] flags
+
+let test_build_prompt_args_other () =
+  let flags = Spawn_eio.build_prompt_args "claude" "hello" in
+  check (list string) "other prompt args" [] flags
+
 (* ============================================================
    Test Runners
    ============================================================ *)
@@ -519,6 +562,8 @@ let () =
     "parse_gemini_output", [
       test_case "success" `Quick test_parse_gemini_output_success;
       test_case "with cache" `Quick test_parse_gemini_output_with_cache;
+      test_case "extract response from cli json" `Quick test_extract_gemini_response_text_cli_json;
+      test_case "cli json stats" `Quick test_parse_gemini_output_cli_json;
       test_case "invalid" `Quick test_parse_gemini_output_invalid;
     ];
     "parse_ollama_output", [
@@ -553,6 +598,7 @@ let () =
       test_case "not empty" `Quick test_default_configs_not_empty;
       test_case "has claude" `Quick test_default_configs_has_claude;
       test_case "has gemini" `Quick test_default_configs_has_gemini;
+      test_case "gemini json output" `Quick test_default_configs_gemini_json_output;
       test_case "has codex" `Quick test_default_configs_has_codex;
       test_case "has llama" `Quick test_default_configs_has_llama;
     ];
@@ -567,6 +613,8 @@ let () =
       test_case "empty" `Quick test_build_mcp_args_empty;
       test_case "claude" `Quick test_build_mcp_args_claude;
       test_case "gemini" `Quick test_build_mcp_args_gemini;
+      test_case "gemini prompt args" `Quick test_build_prompt_args_gemini;
+      test_case "other prompt args" `Quick test_build_prompt_args_other;
       test_case "other" `Quick test_build_mcp_args_other;
     ];
   ]


### PR DESCRIPTION
## Summary
- force spawned Gemini workers onto JSON stdout and pass prompts via `-p`
- parse Gemini CLI `response` text and `stats.models.*.tokens` usage in both sync and Eio spawn paths
- add coverage for Gemini CLI JSON extraction, prompt args, and config defaults

## Validation
- dune build --root . @default
- dune build --root . test/test_spawn_eio_coverage.exe test/test_spawn_coverage.exe
- ./_build/default/test/test_spawn_eio_coverage.exe
- ./_build/default/test/test_spawn_coverage.exe