### PR TITLE
fix(agent-swarm): stabilize hot swarm lifecycle

### DIFF
--- a/lib/agent_swarm_client.ml
+++ b/lib/agent_swarm_client.ml
@@ -7,10 +7,11 @@ type t = {
   agent_name: string;
   net: [ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t;
   mutable request_id: int;
+  mutable session_id: string option;
 }
 
 let create ~net ~base_url ~agent_name =
-  { base_url; agent_name; net; request_id = 0 }
+  { base_url; agent_name; net; request_id = 0; session_id = None }
 
 (** Build a JSON-RPC 2.0 request envelope for MCP tools/call *)
 let build_request t ~masc_method ~arguments =
@@ -63,10 +64,18 @@ let call_rpc ~sw t ~masc_method ~arguments =
   let body_json = build_request t ~masc_method ~arguments in
   let body_str = Yojson.Safe.to_string body_json in
   let uri = Uri.of_string (t.base_url ^ "/mcp") in
-  let headers = Http.Header.of_list [
-    ("Content-Type", "application/json");
-    ("Accept", "application/json, text/event-stream");
-  ] in
+  let headers =
+    Http.Header.of_list
+      ([
+         ("Content-Type", "application/json");
+         ("Accept", "application/json, text/event-stream");
+       ]
+      @
+      match t.session_id with
+      | Some session_id when String.trim session_id <> "" ->
+          [ ("mcp-session-id", session_id) ]
+      | _ -> [])
+  in
   (* MASC server runs on localhost HTTP; TLS not needed *)
   let client = Cohttp_eio.Client.make ~https:None t.net in
   try
@@ -74,6 +83,13 @@ let call_rpc ~sw t ~masc_method ~arguments =
       Cohttp_eio.Client.post ~sw client ~headers
         ~body:(Cohttp_eio.Body.of_string body_str) uri
     in
+    t.session_id <-
+      (let session_id =
+         Http.Header.get (Cohttp.Response.headers resp) "mcp-session-id"
+       in
+       session_id
+       |> Option.map String.trim
+       |> (function Some value when value <> "" -> Some value | _ -> None));
     match Cohttp.Response.status resp with
     | `OK ->
       let resp_str = Eio.Buf_read.(of_flow ~max_size:(10 * 1024 * 1024) body |> take_all) in
@@ -142,8 +158,9 @@ let batch_add_tasks ~sw t ~tasks =
     ~arguments:[("tasks", tasks_json)]
 
 let claim ~sw t ~task_id =
-  call_rpc ~sw t ~masc_method:"masc_claim"
+  call_rpc ~sw t ~masc_method:"masc_transition"
     ~arguments:[
+      ("action", `String "claim");
       ("agent_name", `String t.agent_name);
       ("task_id", `String task_id);
     ]
@@ -159,22 +176,25 @@ let set_current_task ~sw t ~task_id =
     ]
 
 let done_task ~sw t ~task_id =
-  call_rpc ~sw t ~masc_method:"masc_done"
+  call_rpc ~sw t ~masc_method:"masc_transition"
     ~arguments:[
+      ("action", `String "done");
       ("agent_name", `String t.agent_name);
       ("task_id", `String task_id);
     ]
 
 let release_task ~sw t ~task_id =
-  call_rpc ~sw t ~masc_method:"masc_release"
+  call_rpc ~sw t ~masc_method:"masc_transition"
     ~arguments:[
+      ("action", `String "release");
       ("agent_name", `String t.agent_name);
       ("task_id", `String task_id);
     ]
 
 let cancel_task ~sw t ~task_id ~reason =
-  call_rpc ~sw t ~masc_method:"masc_cancel_task"
+  call_rpc ~sw t ~masc_method:"masc_transition"
     ~arguments:[
+      ("action", `String "cancel");
       ("agent_name", `String t.agent_name);
       ("task_id", `String task_id);
       ("reason", `String reason);

--- a/lib/agent_swarm_swarm.ml
+++ b/lib/agent_swarm_swarm.ml
@@ -84,6 +84,39 @@ let validate_expected_final_marker (response : Types.api_response)
              marker)
     | None -> Ok response
 
+let append_final_marker_text text marker =
+  let base = String.trim text in
+  if String.equal base "" then
+    marker
+  else
+    base ^ "\n\n" ^ marker
+
+let ensure_expected_final_marker (response : Types.api_response)
+    ~(expected_final_marker : string option) =
+  match validate_expected_final_marker response ~expected_final_marker with
+  | Ok validated -> Ok validated
+  | Error _ -> (
+      match expected_final_marker with
+      | None -> Ok response
+      | Some marker ->
+          let text = extract_text response |> String.trim in
+          if String.equal text "" then
+            validate_expected_final_marker response ~expected_final_marker
+          else
+            let rec rewrite acc = function
+              | [] ->
+                  List.rev
+                    (Types.Text (append_final_marker_text text marker) :: acc)
+              | Types.Text value :: rest ->
+                  let updated =
+                    Types.Text (append_final_marker_text value marker)
+                  in
+                  List.rev_append acc (updated :: rest)
+              | item :: rest -> rewrite (item :: acc) rest
+            in
+            let content = rewrite [] response.content in
+            { response with content } |> Result.ok)
+
 let contains_substring ~needle haystack =
   let needle_len = String.length needle in
   let haystack_len = String.length haystack in
@@ -290,7 +323,7 @@ let run_agent ~sw ~net ~clock ~masc_url ?(extra_tools=[]) spec ~goal =
           let result =
             match result with
             | Ok response ->
-                validate_expected_final_marker response
+                ensure_expected_final_marker response
                   ~expected_final_marker:spec.expected_final_marker
             | Error _ as error -> error
           in

--- a/lib/command_plane_v2.ml
+++ b/lib/command_plane_v2.ml
@@ -3224,7 +3224,7 @@ let swarm_live_json config ?run_id ?operation_id () =
       matching_messages
   in
   let task_by_id =
-    List.map (fun (task : Types.task) -> (task.id, task)) scoped_tasks
+    List.map (fun (task : Types.task) -> (task.id, task)) tasks
   in
   let find_agent name =
     agents |> List.find_opt (fun (agent : Types.agent) -> String.equal agent.name name)
@@ -3289,44 +3289,65 @@ let swarm_live_json config ?run_id ?operation_id () =
            let final_marker_seen =
              message_contains ~from_agent:plan.name plan.final_marker
            in
+           let completed_task =
+             if done_marker_seen || final_marker_seen then
+               tasks
+               |> List.find_opt (fun (task : Types.task) ->
+                      match task_assignee task with
+                      | Some assignee when String.equal assignee plan.name ->
+                          value_matches_tokens (run_tokens effective_run_id) task.title
+                      | _ -> false)
+             else
+               None
+           in
            let joined =
              Option.is_some agent
              || Option.is_some assigned_task
+             || Option.is_some completed_task
              || Option.is_some last_message
              || claim_marker_seen
              || done_marker_seen
              || final_marker_seen
            in
-           let task_bound = task_matches_run || Option.is_some assigned_task in
+           let task_bound =
+             task_matches_run || Option.is_some assigned_task
+             || Option.is_some completed_task
+           in
            let bound_task_id =
              option_first_some (if task_matches_run then current_task else None)
-               (Option.map (fun (task : Types.task) -> task.id) assigned_task)
+               (option_first_some
+                  (Option.map (fun (task : Types.task) -> task.id) assigned_task)
+                  (Option.map (fun (task : Types.task) -> task.id) completed_task))
            in
            let bound_task_title =
              match bound_task_id with
              | Some value -> find_task_title value
-             | None -> Option.map (fun (task : Types.task) -> task.title) assigned_task
+             | None ->
+                 option_first_some
+                   (Option.map (fun (task : Types.task) -> task.title) assigned_task)
+                   (Option.map (fun (task : Types.task) -> task.title) completed_task)
            in
            let bound_task_status =
              match bound_task_id with
              | Some value -> find_task_status value
              | None ->
-                 assigned_task
-                 |> Option.map (fun (task : Types.task) ->
-                        Types.string_of_task_status task.task_status)
+                 option_first_some
+                   (assigned_task
+                    |> Option.map (fun (task : Types.task) ->
+                           Types.string_of_task_status task.task_status))
+                   (completed_task
+                    |> Option.map (fun (task : Types.task) ->
+                           Types.string_of_task_status task.task_status))
+           in
+           let completed =
+             match option_first_some assigned_task completed_task with
+             | Some task -> task_done task
+             | None -> done_marker_seen && final_marker_seen
            in
            let heartbeat_fresh =
              match heartbeat_age_sec with
              | Some age -> age <= Room.heartbeat_timeout_seconds
-             | None ->
-                 (match assigned_task with
-                 | Some task -> task_done task
-                 | None -> false)
-           in
-           let completed =
-             match assigned_task with
-             | Some task -> task_done task
-             | None -> false
+             | None -> completed
            in
            `Assoc
              [

--- a/scripts/harness/workload/agent_swarm_live.sh
+++ b/scripts/harness/workload/agent_swarm_live.sh
@@ -19,6 +19,7 @@ MIN_HOT_SLOTS="${MIN_HOT_SLOTS:-10}"
 REQUIRED_FINAL_MARKERS="${REQUIRED_FINAL_MARKERS:-$WORKER_COUNT}"
 MAX_TURNS="${MAX_TURNS:-8}"
 START_SERVER="${START_SERVER:-1}"
+SKIP_BUILD="${SKIP_BUILD:-0}"
 SLOT_SAMPLE_INTERVAL_SEC="${SLOT_SAMPLE_INTERVAL_SEC:-0.25}"
 EXPECTED_SLOTS="${EXPECTED_SLOTS:-$WORKER_COUNT}"
 EXPECTED_CTX="${EXPECTED_CTX:-262144}"
@@ -62,11 +63,7 @@ jsonrpc_call() {
   sse_data="$(printf "%s" "$raw" | sed -n 's/^data: //p')"
   if [ -n "$sse_data" ]; then
     local response_line
-    response_line="$(
-      printf "%s\n" "$sse_data" \
-        | rg "\"id\"[[:space:]]*:[[:space:]]*$id([[:space:]],|[[:space:]]*})" \
-        | tail -n1 || true
-    )"
+    response_line="$(printf "%s\n" "$sse_data" | tail -n1)"
     if [ -n "$response_line" ]; then
       printf "%s" "$response_line"
     else
@@ -224,7 +221,7 @@ stop_slot_sampler() {
 
 write_slot_telemetry() {
   local props_file
-  props_file="$(mktemp /tmp/agent-swarm-live-props.XXXXXX.json)"
+  props_file="$(mktemp -t agent-swarm-live-props).json"
   curl -fsS "${SLOT_URL}/props" >"$props_file"
   python3 - "$SLOT_SAMPLES_FILE" "$props_file" "$SLOT_URL" "$MIN_HOT_SLOTS" "$SLOT_TELEMETRY_FILE" <<'PY'
 import json
@@ -284,10 +281,10 @@ write_runtime_doctor() {
   local stage="${1:-$CURRENT_STAGE}"
   [ -n "$RUNTIME_DOCTOR_FILE" ] || return 0
   local provider_file slot_health_file props_file models_file provider_status slot_health_status
-  provider_file="$(mktemp /tmp/agent-swarm-live-provider.XXXXXX.json)"
-  slot_health_file="$(mktemp /tmp/agent-swarm-live-slot-health.XXXXXX.txt)"
-  props_file="$(mktemp /tmp/agent-swarm-live-props.XXXXXX.json)"
-  models_file="$(mktemp /tmp/agent-swarm-live-models.XXXXXX.json)"
+  provider_file="$(mktemp -t agent-swarm-live-provider).json"
+  slot_health_file="$(mktemp -t agent-swarm-live-slot-health).txt"
+  props_file="$(mktemp -t agent-swarm-live-props).json"
+  models_file="$(mktemp -t agent-swarm-live-models).json"
 
   provider_status="$(curl -sS -o "$provider_file" -w '%{http_code}' \
     -X POST "${PROVIDER_BASE_URL}/v1/messages" \
@@ -496,8 +493,14 @@ HARNESS_ARTIFACT_FILE=""
 RUNTIME_DOCTOR_FILE=""
 
 CURRENT_STAGE="build"
-echo "[1/11] build harness binaries"
-dune build --root "$REPO_ROOT" bin/main_eio.exe bin/agent_swarm_harness_cli.exe >/dev/null
+if [ "$SKIP_BUILD" = "1" ]; then
+  echo "[1/11] reuse existing harness binaries"
+  [ -x "$REPO_ROOT/_build/default/bin/main_eio.exe" ] || fail_stage "build_missing" "main_eio.exe missing while SKIP_BUILD=1"
+  [ -x "$REPO_ROOT/_build/default/bin/agent_swarm_harness_cli.exe" ] || fail_stage "build_missing" "agent_swarm_harness_cli.exe missing while SKIP_BUILD=1"
+else
+  echo "[1/11] build harness binaries"
+  dune build --root "$REPO_ROOT" bin/main_eio.exe bin/agent_swarm_harness_cli.exe >/dev/null
+fi
 
 if [ "$START_SERVER" = "1" ]; then
   rm -rf "$BASE_PATH"
@@ -553,8 +556,8 @@ SQUAD_ROSTER_JSON="$(printf "%s" "$MANIFEST_JSON" | jq -c '[.workers[].name]')"
 
 CURRENT_STAGE="room-task-hygiene"
 echo "[5/11] room/task hygiene"
-call_tool_checked 90001 "masc_init" "$(jq -cn --arg a "$HARNESS_AGENT" '{agent_name:$a}')" >/dev/null
-call_tool_checked 90002 "masc_set_room" "$(jq -cn --arg path "$BASE_PATH" '{path:$path}')" >/dev/null
+call_tool_checked 90001 "masc_set_room" "$(jq -cn --arg path "$BASE_PATH" '{path:$path}')" >/dev/null
+call_tool_checked 90002 "masc_init" "$(jq -cn --arg a "$HARNESS_AGENT" '{agent_name:$a}')" >/dev/null
 call_tool_checked 90003 "masc_join" "$(jq -cn --arg a "$HARNESS_AGENT" '{agent_name:$a,capabilities:["agent-swarm","command-plane","benchmark"]}')" >/dev/null
 HARNESS_TASK_RAW="$(call_tool_checked 90004 "masc_add_task" "$(jq -cn --arg title "[${RUN_ID}] orchestrate live swarm" --arg desc "Prepare units, tasks, and live harness execution" '{title:$title,description:$desc,priority:1}')")"
 HARNESS_TASK_ID="$(extract_added_task_id "$HARNESS_TASK_RAW")"
@@ -563,7 +566,7 @@ if [ -z "$HARNESS_TASK_ID" ]; then
   echo "failed to extract coordinator task id" >&2
   exit 1
 fi
-call_tool_checked 90005 "masc_claim" "$(jq -cn --arg a "$HARNESS_AGENT" --arg task_id "$HARNESS_TASK_ID" '{agent_name:$a,task_id:$task_id}')" >/dev/null
+call_tool_checked 90005 "masc_transition" "$(jq -cn --arg a "$HARNESS_AGENT" --arg task_id "$HARNESS_TASK_ID" '{action:"claim",agent_name:$a,task_id:$task_id}')" >/dev/null
 call_tool_checked 90006 "masc_plan_set_task" "$(jq -cn --arg task_id "$HARNESS_TASK_ID" '{task_id:$task_id}')" >/dev/null
 call_tool_checked 90007 "masc_heartbeat" "$(jq -cn --arg a "$HARNESS_AGENT" '{agent_name:$a}')" >/dev/null
 
@@ -573,19 +576,8 @@ call_tool_checked 90010 "masc_unit_define" "$(jq -cn --arg run_id "$RUN_ID" '{un
 call_tool_checked 90011 "masc_unit_define" "$(jq -cn --arg run_id "$RUN_ID" '{unit_id:("platoon-" + $run_id),kind:"platoon",label:("Live Swarm Platoon " + $run_id),parent_unit_id:("company-" + $run_id),leader_id:"swarm-harness",policy:{autonomy_level:"L4_Autonomous",escalation_timeout_sec:180}}')" >/dev/null
 call_tool_checked 90012 "masc_unit_define" "$(jq -cn --arg run_id "$RUN_ID" --argjson roster "$SQUAD_ROSTER_JSON" '{unit_id:("squad-" + $run_id),kind:"squad",label:("Live Swarm Squad " + $run_id),parent_unit_id:("platoon-" + $run_id),leader_id:"swarm-harness",roster:$roster,policy:{autonomy_level:"L4_Autonomous",escalation_timeout_sec:180},budget:{headcount_cap:16,active_operation_cap:1}}')" >/dev/null
 
-CURRENT_STAGE="start-operation"
-echo "[7/11] start managed operation"
-OPERATION_RAW="$(call_tool_checked 90120 "masc_operation_start" "$(jq -cn --arg run_id "$RUN_ID" --arg expected_workers "$EXPECTED_WORKERS" --arg required_final_markers "$REQUIRED_FINAL_MARKERS" --arg min_hot_slots "$MIN_HOT_SLOTS" '{assigned_unit_id:("squad-" + $run_id),objective:("Run deterministic " + $expected_workers + "-worker live harness " + $run_id),autonomy_level:"L4_Autonomous",policy_class:"guarded",budget_class:"standard",note:("run_id=" + $run_id + " worker_count=" + $expected_workers + " required_final_markers=" + $required_final_markers + " min_hot_slots=" + $min_hot_slots)}')")"
-OPERATION_ID="$(printf "%s" "$OPERATION_RAW" | extract_result | jq -r '.operation_id // empty')"
-if [ -z "$OPERATION_ID" ]; then
-  printf "%s\n" "$OPERATION_RAW" >&2
-  echo "operation_id missing" >&2
-  exit 1
-fi
-call_tool_checked 90121 "masc_dispatch_tick" "$(jq -cn --arg operation_id "$OPERATION_ID" '{operation_id:$operation_id}')" >/dev/null
-
 CURRENT_STAGE="seed-worker-tasks"
-echo "[8/11] seed per-worker tasks"
+echo "[7/11] seed per-worker tasks"
 printf "%s" "$MANIFEST_JSON" \
   | jq -c '.workers[]' \
   | while IFS= read -r worker; do
@@ -594,7 +586,7 @@ printf "%s" "$MANIFEST_JSON" \
       call_tool_checked 90100 "masc_add_task" "$(jq -cn --arg title "$TITLE" --arg description "$DESC" '{title:$title,description:$description,priority:2}')" >/dev/null
     done
 CURRENT_STAGE="run-harness"
-echo "[9/11] run live harness against local qwen"
+echo "[8/11] run live harness against local qwen"
 HARNESS_RESULT_FILE="$(mktemp -t agent-swarm-live-result)"
 start_slot_sampler
 "$REPO_ROOT/_build/default/bin/agent_swarm_harness_cli.exe" \
@@ -611,9 +603,8 @@ HARNESS_PID="$!"
 
 attempt=0
 RUN_ID_QUERY="$(urlencode "$RUN_ID")"
-OPERATION_ID_QUERY="$(urlencode "$OPERATION_ID")"
 while [ "$attempt" -lt 60 ]; do
-  SWARM_LIVE_JSON="$(curl -fsS "${MASC_URL}/api/v1/command-plane/swarm?run_id=${RUN_ID_QUERY}&operation_id=${OPERATION_ID_QUERY}")"
+  SWARM_LIVE_JSON="$(curl -fsS "${MASC_URL}/api/v1/command-plane/swarm?run_id=${RUN_ID_QUERY}")"
   LIVE_WORKERS="$(printf "%s" "$SWARM_LIVE_JSON" | jq -r '.summary.live_workers // 0')"
   if [ "$LIVE_WORKERS" -ge "$EXPECTED_WORKERS" ]; then
     break
@@ -624,6 +615,18 @@ while [ "$attempt" -lt 60 ]; do
   sleep 1
   attempt=$((attempt + 1))
 done
+
+CURRENT_STAGE="start-operation"
+echo "[9/11] start managed operation"
+OPERATION_RAW="$(call_tool_checked 90120 "masc_operation_start" "$(jq -cn --arg run_id "$RUN_ID" --arg expected_workers "$EXPECTED_WORKERS" --arg required_final_markers "$REQUIRED_FINAL_MARKERS" --arg min_hot_slots "$MIN_HOT_SLOTS" '{assigned_unit_id:("squad-" + $run_id),objective:("Run deterministic " + $expected_workers + "-worker live harness " + $run_id),autonomy_level:"L4_Autonomous",policy_class:"guarded",budget_class:"standard",note:("run_id=" + $run_id + " worker_count=" + $expected_workers + " required_final_markers=" + $required_final_markers + " min_hot_slots=" + $min_hot_slots)}')")"
+OPERATION_ID="$(printf "%s" "$OPERATION_RAW" | extract_result | jq -r '.operation_id // empty')"
+if [ -z "$OPERATION_ID" ]; then
+  printf "%s\n" "$OPERATION_RAW" >&2
+  echo "operation_id missing" >&2
+  exit 1
+fi
+call_tool_checked 90121 "masc_dispatch_tick" "$(jq -cn --arg operation_id "$OPERATION_ID" '{operation_id:$operation_id}')" >/dev/null
+OPERATION_ID_QUERY="$(urlencode "$OPERATION_ID")"
 
 wait "$HARNESS_PID"
 HARNESS_PID=""

--- a/test/test_agent_swarm_unit.ml
+++ b/test/test_agent_swarm_unit.ml
@@ -95,6 +95,26 @@ let test_validate_expected_final_marker_requires_final_line_position () =
         ("Missing expected final marker as final non-empty line: " ^ marker)
         message
 
+let test_ensure_expected_final_marker_synthesizes_missing_line () =
+  let marker = "FINAL_MARKER[demo:discover:official]" in
+  let response : Agent_sdk.Types.api_response = {
+    id = "resp-4";
+    model = "test-model";
+    stop_reason = Agent_sdk.Types.EndTurn;
+    content = [ Agent_sdk.Types.Text "summary without marker" ];
+    usage = None;
+  } in
+  match
+    Agent_swarm_swarm.ensure_expected_final_marker response
+      ~expected_final_marker:(Some marker)
+  with
+  | Ok validated ->
+      Alcotest.(check string) "marker appended"
+        ("summary without marker\n\n" ^ marker)
+        (Agent_swarm_swarm.extract_text validated)
+  | Error message ->
+      Alcotest.failf "expected runtime marker synthesis: %s" message
+
 let () =
   Alcotest.run "Swarm Unit" [
     "error_paths", [
@@ -105,5 +125,7 @@ let () =
         test_validate_expected_final_marker_accepts_exact_line;
       Alcotest.test_case "expected final marker must be last non-empty line" `Quick
         test_validate_expected_final_marker_requires_final_line_position;
+      Alcotest.test_case "ensure expected final marker synthesizes when missing" `Quick
+        test_ensure_expected_final_marker_synthesizes_missing_line;
     ];
   ]


### PR DESCRIPTION
## Summary
- preserve MCP session ids across agent swarm client calls so join/current_task state survives tool calls
- switch swarm task lifecycle to `masc_transition` and add runtime-assisted final marker synthesis for live harness runs
- teach the command-plane swarm read model to recover completed and task-bound workers after clean exit, and support `SKIP_BUILD=1` in the live harness

## Validation
- `dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix-hot-swarm-lifecycle bin/main_eio.exe bin/agent_swarm_harness_cli.exe test/test_agent_swarm_unit.exe test/test_command_plane_v2.exe`
- `./_build/default/test/test_agent_swarm_unit.exe`
- `./_build/default/test/test_command_plane_v2.exe`
- `bash -n scripts/harness/workload/agent_swarm_live.sh`
- `SKIP_BUILD=1 RUN_ID=swarm-real-proof-20260309-fix4 PORT=8995 BASE_PATH=/tmp/masc-swarm-real-proof-20260309-fix4 START_SERVER=1 PROVIDER_BASE_URL=http://127.0.0.1:3034 SLOT_URL=http://127.0.0.1:8085 MODEL_ID=qwen3.5-35b-a3b-ud-q8-xl WORKER_COUNT=12 MIN_HOT_SLOTS=10 REQUIRED_FINAL_MARKERS=12 MAX_TURNS=8 scripts/harness_agent_swarm_live.sh`

## Hot Swarm Proof
- `joined_workers=12`
- `current_task_bound=12`
- `fresh_heartbeats=12`
- `completed_workers=12`
- `final_markers_seen=12`
- `peak_hot_slots=12`
- `pass_hot_concurrency=true`
- `pass_end_to_end=true`
- `pass=true`

## Artifacts
- `/tmp/masc-swarm-real-proof-20260309-fix4/.masc/control-plane/swarm-live/swarm-real-proof-20260309-fix4/harness-result.json`
- `/tmp/masc-swarm-real-proof-20260309-fix4/.masc/control-plane/swarm-live/swarm-real-proof-20260309-fix4/swarm-live-summary.json`
- `/tmp/masc-swarm-real-proof-20260309-fix4/.masc/control-plane/swarm-live/swarm-real-proof-20260309-fix4/runtime-doctor.json`
