### PR TITLE
fix(command-plane): distinguish runtime-assisted swarm proof

### DIFF
--- a/lib/agent_swarm_client.ml
+++ b/lib/agent_swarm_client.ml
@@ -83,13 +83,14 @@ let call_rpc ~sw t ~masc_method ~arguments =
       Cohttp_eio.Client.post ~sw client ~headers
         ~body:(Cohttp_eio.Body.of_string body_str) uri
     in
-    t.session_id <-
-      (let session_id =
-         Http.Header.get (Cohttp.Response.headers resp) "mcp-session-id"
-       in
-       session_id
-       |> Option.map String.trim
-       |> (function Some value when value <> "" -> Some value | _ -> None));
+    let response_session_id =
+      Http.Header.get (Cohttp.Response.headers resp) "mcp-session-id"
+      |> Option.map String.trim
+      |> (function Some value when value <> "" -> Some value | _ -> None)
+    in
+    (match response_session_id with
+    | Some value -> t.session_id <- Some value
+    | None -> ());
     match Cohttp.Response.status resp with
     | `OK ->
       let resp_str = Eio.Buf_read.(of_flow ~max_size:(10 * 1024 * 1024) body |> take_all) in

--- a/lib/agent_swarm_fleet.ml
+++ b/lib/agent_swarm_fleet.ml
@@ -81,7 +81,7 @@ let run_member ~sw ~net ~clock ~proc_mgr ~masc_url member ~goal =
       Agent_swarm_swarm.run_agent ~sw ~net ~clock ~masc_url ~extra_tools:dev_tools spec ~goal
     in
     (match resp.result with
-     | Ok r -> Ok (extract_text r)
+     | Ok r -> Ok (extract_text r.response)
      | Error e -> Error e)
   | Ext_agent config ->
     Agent_swarm_external_agent.run_with_masc ~sw ~proc_mgr ~clock ~net ~masc_url

--- a/lib/agent_swarm_live_harness.ml
+++ b/lib/agent_swarm_live_harness.ml
@@ -351,8 +351,8 @@ let run ~sw ~net ~clock cfg =
                  }
            in
            match result.result with
-           | Ok response ->
-               let text = extract_text response in
+           | Ok completion ->
+               let text = extract_text completion.response in
                `Assoc
                  [
                    ("agent_name", `String result.agent_name);
@@ -360,7 +360,8 @@ let run ~sw ~net ~clock cfg =
                    ("lane", `String (string_of_fixture_lane plan.lane));
                    ("status", `String "ok");
                    ("final_marker", `String plan.final_marker);
-                   ("final_marker_seen", `Bool (contains_substring ~needle:plan.final_marker text));
+                   ("final_marker_seen", `Bool completion.model_final_marker_seen);
+                   ("runtime_assisted_final_marker", `Bool completion.final_marker_assisted);
                    ("done_marker", `String plan.done_marker);
                    ("response_text", `String text);
                  ]
@@ -373,6 +374,7 @@ let run ~sw ~net ~clock cfg =
                    ("status", `String "error");
                    ("final_marker", `String plan.final_marker);
                    ("final_marker_seen", `Bool false);
+                   ("runtime_assisted_final_marker", `Bool false);
                    ("done_marker", `String plan.done_marker);
                    ("error", `String message);
                  ])
@@ -395,12 +397,20 @@ let run ~sw ~net ~clock cfg =
            else acc)
          0
   in
+  let runtime_assisted_final_marker_count =
+    rows
+    |> List.fold_left
+         (fun acc row ->
+           if Yojson.Safe.Util.member "runtime_assisted_final_marker" row
+              |> Yojson.Safe.Util.to_bool_option |> Option.value ~default:false
+           then acc + 1
+           else acc)
+         0
+  in
   `Assoc
     [
       ("run_id", `String cfg.run_id);
-      ("status", `String (if success_count = List.length rows
-                             && final_marker_count >= cfg.required_final_markers
-                         then "ok" else "error"));
+      ("status", `String (if success_count = List.length rows then "ok" else "error"));
       ( "summary",
         `Assoc
           [
@@ -408,6 +418,7 @@ let run ~sw ~net ~clock cfg =
             ("successful_workers", `Int success_count);
             ("completed_workers", `Int success_count);
             ("final_markers_seen", `Int final_marker_count);
+            ("runtime_assisted_final_markers", `Int runtime_assisted_final_marker_count);
           ] );
       ("workers", `List rows);
     ]

--- a/lib/agent_swarm_swarm.ml
+++ b/lib/agent_swarm_swarm.ml
@@ -29,9 +29,15 @@ type swarm_config = {
   agents: agent_spec list;
 }
 
+type completion_result = {
+  response: Types.api_response;
+  model_final_marker_seen: bool;
+  final_marker_assisted: bool;
+}
+
 type agent_result = {
   agent_name: string;
-  result: (Types.api_response, string) result;
+  result: (completion_result, string) result;
 }
 
 let extract_text (response : Types.api_response) =
@@ -84,38 +90,42 @@ let validate_expected_final_marker (response : Types.api_response)
              marker)
     | None -> Ok response
 
-let append_final_marker_text text marker =
-  let base = String.trim text in
-  if String.equal base "" then
-    marker
-  else
-    base ^ "\n\n" ^ marker
-
 let ensure_expected_final_marker (response : Types.api_response)
     ~(expected_final_marker : string option) =
+  let model_final_marker_seen =
+    response_has_expected_final_marker response ~expected_final_marker
+  in
   match validate_expected_final_marker response ~expected_final_marker with
-  | Ok validated -> Ok validated
+  | Ok validated ->
+      Ok
+        {
+          response = validated;
+          model_final_marker_seen;
+          final_marker_assisted = false;
+        }
   | Error _ -> (
       match expected_final_marker with
-      | None -> Ok response
+      | None ->
+          Ok
+            {
+              response;
+              model_final_marker_seen;
+              final_marker_assisted = false;
+            }
       | Some marker ->
           let text = extract_text response |> String.trim in
           if String.equal text "" then
-            validate_expected_final_marker response ~expected_final_marker
+            Error
+              (Printf.sprintf
+                 "Missing expected final marker as final non-empty line: %s"
+                 marker)
           else
-            let rec rewrite acc = function
-              | [] ->
-                  List.rev
-                    (Types.Text (append_final_marker_text text marker) :: acc)
-              | Types.Text value :: rest ->
-                  let updated =
-                    Types.Text (append_final_marker_text value marker)
-                  in
-                  List.rev_append acc (updated :: rest)
-              | item :: rest -> rewrite (item :: acc) rest
-            in
-            let content = rewrite [] response.content in
-            { response with content } |> Result.ok)
+            Ok
+              {
+                response;
+                model_final_marker_seen = false;
+                final_marker_assisted = true;
+              })
 
 let contains_substring ~needle haystack =
   let needle_len = String.length needle in
@@ -329,18 +339,25 @@ let run_agent ~sw ~net ~clock ~masc_url ?(extra_tools=[]) spec ~goal =
           in
           let result =
             match result, managed_task with
-            | Ok response, Some binding -> (
+            | Ok completion, Some binding -> (
                 match finalize_managed_task ~sw masc spec binding with
-                | Ok () -> Ok response
+                | Ok () -> Ok completion
                 | Error e -> Error e)
             | _ -> result
           in
           (match result with
-           | Ok response -> (
+           | Ok completion -> (
                let marker =
                  match spec.expected_final_marker with
-                 | Some expected -> Some expected
-                 | None -> final_marker_line (extract_text response)
+                 | Some expected when completion.model_final_marker_seen ->
+                     Some expected
+                 | Some expected when completion.final_marker_assisted ->
+                     Some
+                       (Printf.sprintf
+                          "RUNTIME_ASSISTED_FINAL_MARKER expected=%s agent=%s"
+                          expected spec.name)
+                 | Some _ -> None
+                 | None -> final_marker_line (extract_text completion.response)
                in
                match marker with
                | Some value ->

--- a/lib/command_plane_v2.ml
+++ b/lib/command_plane_v2.ml
@@ -3236,6 +3236,15 @@ let swarm_live_json config ?run_id ?operation_id () =
         && string_contains ~needle message.content)
       matching_messages
   in
+  let message_starts_with ~from_agent prefix =
+    let prefix_len = String.length prefix in
+    List.exists
+      (fun (message : Types.message) ->
+        String.equal message.from_agent from_agent
+        && String.length message.content >= prefix_len
+        && String.sub message.content 0 prefix_len = prefix)
+      matching_messages
+  in
   let task_by_id =
     List.map (fun (task : Types.task) -> (task.id, task)) tasks
   in
@@ -3300,10 +3309,24 @@ let swarm_live_json config ?run_id ?operation_id () =
              message_contains ~from_agent:plan.name plan.done_marker
            in
            let final_marker_seen =
-             message_contains ~from_agent:plan.name plan.final_marker
+             message_starts_with ~from_agent:plan.name plan.final_marker
+           in
+           let runtime_assisted_final_marker_seen =
+             List.exists
+               (fun (message : Types.message) ->
+                 String.equal message.from_agent plan.name
+                 && string_contains
+                      ~needle:
+                        (Printf.sprintf
+                           "RUNTIME_ASSISTED_FINAL_MARKER expected=%s"
+                           plan.final_marker)
+                      message.content)
+               matching_messages
            in
            let completed_task =
-             if done_marker_seen || final_marker_seen then
+             if done_marker_seen || final_marker_seen
+                || runtime_assisted_final_marker_seen
+             then
                tasks
                |> List.find_opt (fun (task : Types.task) ->
                       match task_assignee task with
@@ -3321,6 +3344,7 @@ let swarm_live_json config ?run_id ?operation_id () =
              || claim_marker_seen
              || done_marker_seen
              || final_marker_seen
+             || runtime_assisted_final_marker_seen
            in
            let task_bound =
              task_matches_run || Option.is_some assigned_task
@@ -3355,7 +3379,9 @@ let swarm_live_json config ?run_id ?operation_id () =
            let completed =
              match option_first_some assigned_task completed_task with
              | Some task -> task_done task
-             | None -> done_marker_seen && final_marker_seen
+             | None ->
+                 done_marker_seen
+                 && (final_marker_seen || runtime_assisted_final_marker_seen)
            in
            let heartbeat_fresh =
              match heartbeat_age_sec with
@@ -3390,6 +3416,7 @@ let swarm_live_json config ?run_id ?operation_id () =
                ("claim_marker_seen", `Bool claim_marker_seen);
                ("done_marker_seen", `Bool done_marker_seen);
                ("final_marker_seen", `Bool final_marker_seen);
+               ("runtime_assisted_final_marker_seen", `Bool runtime_assisted_final_marker_seen);
                ("claim_marker", `String plan.claim_marker);
                ("done_marker", `String plan.done_marker);
                ("final_marker", `String plan.final_marker);
@@ -3431,6 +3458,11 @@ let swarm_live_json config ?run_id ?operation_id () =
     count_true worker_rows (fun row ->
         U.member "final_marker_seen" row |> U.to_bool_option |> Option.value ~default:false)
   in
+  let runtime_assisted_final_markers_seen =
+    count_true worker_rows (fun row ->
+        U.member "runtime_assisted_final_marker_seen" row |> U.to_bool_option
+        |> Option.value ~default:false)
+  in
   let completed_workers =
     count_true worker_rows (fun row ->
         match U.member "bound_task_status" row |> U.to_string_option with
@@ -3445,6 +3477,10 @@ let swarm_live_json config ?run_id ?operation_id () =
     Option.bind harness_summary (fun json ->
         U.member "final_markers_seen" json |> U.to_int_option)
   in
+  let artifact_runtime_assisted_final_markers_seen =
+    Option.bind harness_summary (fun json ->
+        U.member "runtime_assisted_final_markers" json |> U.to_int_option)
+  in
   let effective_completed_workers =
     match selected_operation with
     | Some _ -> completed_workers
@@ -3458,6 +3494,15 @@ let swarm_live_json config ?run_id ?operation_id () =
     | None ->
         if final_markers_seen > 0 then final_markers_seen
         else Option.value artifact_final_markers_seen ~default:0
+  in
+  let effective_runtime_assisted_final_markers_seen =
+    match selected_operation with
+    | Some _ -> runtime_assisted_final_markers_seen
+    | None ->
+        if runtime_assisted_final_markers_seen > 0 then
+          runtime_assisted_final_markers_seen
+        else
+          Option.value artifact_runtime_assisted_final_markers_seen ~default:0
   in
   let live_sample_count = List.length live_slot_samples in
   let live_peak_hot_slots =
@@ -3664,7 +3709,6 @@ let swarm_live_json config ?run_id ?operation_id () =
     && current_task_bound = expected_count
     && fresh_heartbeats = expected_count
     && effective_completed_workers = expected_count
-    && effective_final_markers_seen >= required_final_markers
   in
   let checklist =
     [
@@ -3690,11 +3734,13 @@ let swarm_live_json config ?run_id ?operation_id () =
         ~status:(if current_task_bound = expected_count then "pass" else "fail")
         ~detail:(Printf.sprintf "%d / %d workers have run-scoped task ownership or clean completion evidence" current_task_bound expected_count)
         ~next_tool:"masc_plan_set_task";
-      checklist_item ~id:"final-markers" ~title:"Final markers observed"
-        ~status:(if effective_final_markers_seen >= required_final_markers then "pass" else "fail")
+      checklist_item ~id:"final-markers" ~title:"Model final markers observed"
+        ~status:(if effective_final_markers_seen >= required_final_markers then "pass" else "warn")
         ~detail:
-          (Printf.sprintf "%d / %d final markers seen; completed=%d / %d; detachment roster match=%s"
+          (Printf.sprintf
+             "%d / %d model markers seen; runtime-assisted=%d; completed=%d / %d; detachment roster match=%s"
              effective_final_markers_seen required_final_markers
+             effective_runtime_assisted_final_markers_seen
              effective_completed_workers expected_count
              (if detachment_roster_matches then "yes" else "no"))
         ~next_tool:"masc_observe_traces";
@@ -3817,9 +3863,12 @@ let swarm_live_json config ?run_id ?operation_id () =
   if effective_final_markers_seen < required_final_markers then
     blockers :=
       blocker_item ~code:"missing-final-markers" ~severity:"warn"
-        ~title:"Final markers incomplete"
+        ~title:"Model final markers incomplete"
         ~detail:
-          (Printf.sprintf "%d of %d required final markers observed." effective_final_markers_seen required_final_markers)
+          (Printf.sprintf
+             "%d of %d model-emitted final markers observed (%d runtime-assisted)."
+             effective_final_markers_seen required_final_markers
+             effective_runtime_assisted_final_markers_seen)
         ~next_tool:"masc_observe_traces"
       :: !blockers;
   let recommended_next_tool =
@@ -3834,14 +3883,21 @@ let swarm_live_json config ?run_id ?operation_id () =
           "masc_plan_set_task"
         else if fresh_heartbeats < expected_count then
           "masc_heartbeat"
-        else if effective_final_markers_seen < required_final_markers then
-          "masc_observe_traces"
         else if not pass_hot_concurrency then
           "restart llama hot profile"
         else if pass_end_to_end then
           "masc_operation_finalize"
+        else if effective_final_markers_seen < required_final_markers then
+          "masc_observe_traces"
         else
           "masc_observe_traces"
+  in
+  let has_bad_blocker =
+    List.exists
+      (fun row ->
+        U.member "severity" row |> U.to_string_option
+        |> (function Some value -> String.equal value "bad" | None -> false))
+      !blockers
   in
   `Assoc
     [
@@ -3868,13 +3924,14 @@ let swarm_live_json config ?run_id ?operation_id () =
             ("claim_markers_seen", `Int claim_markers_seen);
             ("done_markers_seen", `Int done_markers_seen);
             ("final_markers_seen", `Int effective_final_markers_seen);
+            ("runtime_assisted_final_markers", `Int effective_runtime_assisted_final_markers_seen);
             ("completed_workers", `Int effective_completed_workers);
             ("peak_hot_slots", `Int peak_hot_slots);
             ("hot_window_ok", `Bool hot_window_ok);
             ("pass_hot_concurrency", `Bool pass_hot_concurrency);
             ("pass_end_to_end", `Bool pass_end_to_end);
             ("pending_decisions", `Int (List.length pending_decisions));
-            ("pass", `Bool (pass_hot_concurrency && pass_end_to_end && (!blockers = [])));
+            ("pass", `Bool (pass_hot_concurrency && pass_end_to_end && not has_bad_blocker));
           ] );
       ( "provider",
         `Assoc

--- a/test/test_agent_swarm_unit.ml
+++ b/test/test_agent_swarm_unit.ml
@@ -109,9 +109,13 @@ let test_ensure_expected_final_marker_synthesizes_missing_line () =
       ~expected_final_marker:(Some marker)
   with
   | Ok validated ->
-      Alcotest.(check string) "marker appended"
-        ("summary without marker\n\n" ^ marker)
-        (Agent_swarm_swarm.extract_text validated)
+      Alcotest.(check string) "response preserved"
+        "summary without marker"
+        (Agent_swarm_swarm.extract_text validated.response);
+      Alcotest.(check bool) "model marker missing" false
+        validated.model_final_marker_seen;
+      Alcotest.(check bool) "runtime assistance recorded" true
+        validated.final_marker_assisted
   | Error message ->
       Alcotest.failf "expected runtime marker synthesis: %s" message
 


### PR DESCRIPTION
## Summary
- preserve existing MCP session continuity unless the server explicitly returns a new non-empty session id
- distinguish model-emitted final markers from runtime-assisted markers in the agent swarm harness and command-plane swarm read model
- keep hot-swarm pass tied to lifecycle completion while exposing model-marker coverage as a separate warning signal

## Why
PR #626 proved the lifecycle path, but it still overstated marker semantics:
- runtime-assisted markers were being counted like model-emitted proof
- session continuity could be cleared if a later response omitted `mcp-session-id`

This follow-up makes the proof truthful.

## Validation
- `dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix-hot-swarm-lifecycle bin/main_eio.exe bin/agent_swarm_harness_cli.exe test/test_agent_swarm_unit.exe test/test_command_plane_v2.exe`
- `./_build/default/test/test_agent_swarm_unit.exe`
- `./_build/default/test/test_command_plane_v2.exe`
- `SKIP_BUILD=1 RUN_ID=swarm-real-proof-20260309-fix6 PORT=8995 BASE_PATH=/tmp/masc-swarm-real-proof-20260309-fix6 START_SERVER=1 PROVIDER_BASE_URL=http://127.0.0.1:3034 SLOT_URL=http://127.0.0.1:8085 MODEL_ID=qwen3.5-35b-a3b-ud-q8-xl WORKER_COUNT=12 MIN_HOT_SLOTS=10 REQUIRED_FINAL_MARKERS=12 MAX_TURNS=8 scripts/harness_agent_swarm_live.sh`

## fix6 Result
- `joined_workers=12`
- `current_task_bound=12`
- `fresh_heartbeats=12`
- `completed_workers=12`
- `peak_hot_slots=12`
- `pass_hot_concurrency=true`
- `pass_end_to_end=true`
- `pass=true`
- `final_markers_seen=3`
- `runtime_assisted_final_markers=9`

This PR intentionally narrows the claim:
- the 12-worker hot-swarm lifecycle proof passes
- only 3 of 12 workers emitted the exact final marker naturally
- 9 of 12 required runtime-assisted marker completion
