### PR TITLE
feat(adapter): add provider-native runtime registry

### DIFF
--- a/docs/PROVIDER-ADAPTER-RUNBOOK.md
+++ b/docs/PROVIDER-ADAPTER-RUNBOOK.md
@@ -1,0 +1,85 @@
+# Provider Adapter Runbook
+
+이 문서는 `MASC`에서 provider/runtime/auth를 어떻게 나누는지에 대한 SSOT다.
+
+핵심 원칙:
+
+- `runtime_kind`는 세 가지다:
+  - `local`
+  - `direct_api`
+  - `cli_agent`
+- auth는 공통화하지 않고 provider-native로 둔다.
+- swarm의 기본 substrate는 여전히 local-first다.
+
+## Canonical Matrix
+
+| Canonical name | Runtime | Auth | Notes |
+|---|---|---|---|
+| `llama` | `local` | `none` | `LLAMA_SERVER_URL` OpenAI-compatible local runtime |
+| `ollama` | `local` | `none` | local Ollama HTTP or CLI path |
+| `glm` | `direct_api` | `api_key` (`ZAI_API_KEY`) | current Z.ai direct path |
+| `claude-api` | `direct_api` | `api_key` (`ANTHROPIC_API_KEY`) | direct Anthropic API |
+| `codex-api` | `direct_api` | `api_key` (`OPENAI_API_KEY`) | direct OpenAI/Codex-family API |
+| `gemini-api` | `direct_api` | `vertex_adc` first, `GEMINI_API_KEY` fallback | canonical Gemini direct path |
+| `claude` | `cli_agent` | `cli_cached_login` | Claude Code / CLI runtime |
+| `codex` | `cli_agent` | `cli_cached_login` | Codex CLI runtime |
+| `gemini` | `cli_agent` | `cli_cached_login` | Gemini CLI runtime |
+
+## Direct API Policy
+
+- `claude-api:<model>`
+  - direct Anthropic path
+  - requires `ANTHROPIC_API_KEY`
+- `codex-api:<model>` or `openai:<model>`
+  - direct OpenAI path
+  - requires `OPENAI_API_KEY`
+- `gemini-api:<model>` or legacy `gemini:<model>`
+  - resolves auth in this order:
+    1. `GOOGLE_CLOUD_PROJECT` + ADC
+    2. `GEMINI_API_KEY`
+    3. actionable error
+
+`gemini-api` Vertex path uses:
+
+- `GOOGLE_CLOUD_PROJECT`
+- `GOOGLE_CLOUD_LOCATION` default `global`
+- `gcloud auth application-default login`
+
+## CLI Agent Policy
+
+- CLI runtimes are not direct API providers.
+- auth is handled by the CLI itself.
+- MASC treats cached CLI login as a runtime concern, not a provider concern.
+
+Current canonical CLI contracts:
+
+- `claude`
+  - machine-readable JSON stdout
+  - prompt via CLI-native path
+- `codex`
+  - machine-readable JSON stdout
+  - prompt via CLI-native path
+- `gemini`
+  - `--output-format json`
+  - prompt via `-p`
+  - stdout JSON `response` is the worker output
+  - stderr is non-authoritative noise/logging only
+
+## Default Swarm Policy
+
+- default worker substrate: `llama`, `ollama`, or `glm`
+- `claude`, `codex`, `gemini` are explicit opt-in workers
+- direct API adapters are for:
+  - keeper/perpetual/MDAL/direct reasoning paths
+  - not the default swarm substrate
+
+## Compatibility
+
+- legacy direct aliases remain supported:
+  - `anthropic:<model>` -> `claude-api`
+  - `google:<model>` -> `gemini-api`
+  - `gemini:<model>` -> `gemini-api`
+- CLI names remain simple:
+  - `claude`
+  - `codex`
+  - `gemini`

--- a/docs/SWARM-DELIVERY-RUNBOOK.md
+++ b/docs/SWARM-DELIVERY-RUNBOOK.md
@@ -14,6 +14,7 @@
 - canonical benchmark / swarm: [COMMAND-PLANE-RUNBOOK.md](./COMMAND-PLANE-RUNBOOK.md)
 - supervised implementation loop: [SUPERVISOR-MODE.md](./SUPERVISOR-MODE.md)
 - remote operator surface: [REMOTE-MCP-OPERATOR.md](./REMOTE-MCP-OPERATOR.md)
+- provider/runtime/auth matrix: [PROVIDER-ADAPTER-RUNBOOK.md](./PROVIDER-ADAPTER-RUNBOOK.md)
 
 ## When To Use This
 

--- a/lib/dune
+++ b/lib/dune
@@ -147,6 +147,7 @@
    orchestrator
    planning_eio
    post_verifier
+   provider_adapter
    process_eio
    progress
    pulse

--- a/lib/llm_client.ml
+++ b/lib/llm_client.ml
@@ -71,6 +71,7 @@ type provider =
   | Ollama
   | Llama
   | Claude
+  | OpenAI
   | Gemini
   | Glm_cloud
   | OpenRouter
@@ -140,6 +141,7 @@ let string_of_provider = function
   | Ollama -> "ollama"
   | Llama -> "llama"
   | Claude -> "claude"
+  | OpenAI -> "openai"
   | Gemini -> "gemini"
   | Glm_cloud -> "glm_cloud"
   | OpenRouter -> "openrouter"
@@ -203,6 +205,16 @@ let claude_sonnet = {
   api_key_env = Some "ANTHROPIC_API_KEY";
   cost_per_1k_input = 0.003;
   cost_per_1k_output = 0.015;
+}
+
+let openai_default = {
+  provider = OpenAI;
+  model_id = "gpt-5";
+  max_context = 400000;
+  api_url = "https://api.openai.com";
+  api_key_env = Some "OPENAI_API_KEY";
+  cost_per_1k_input = 0.0;
+  cost_per_1k_output = 0.0;
 }
 
 let glm_cloud = {
@@ -712,6 +724,83 @@ let get_api_key (spec : model_spec) : string =
   | Some env_var -> Sys.getenv_opt env_var |> Option.value ~default:""
   | None -> ""
 
+let fetch_vertex_adc_access_token () =
+  let manual_override = Sys.getenv_opt "MASC_VERTEX_ACCESS_TOKEN" |> Option.value ~default:"" |> String.trim in
+  if manual_override <> "" then Ok manual_override
+  else
+    let status, output =
+      Process_eio.run_argv_with_status
+        ~timeout_sec:15.0
+        [ "gcloud"; "auth"; "application-default"; "print-access-token" ]
+    in
+    match status with
+    | Unix.WEXITED 0 ->
+        let token = String.trim output in
+        if token = "" then
+          Error "Gemini Vertex ADC unavailable; run gcloud auth application-default login"
+        else Ok token
+    | _ ->
+        Error "Gemini Vertex ADC unavailable; run gcloud auth application-default login"
+
+let resolve_openai_compatible_endpoint (spec : model_spec) =
+  match spec.provider with
+  | Gemini -> (
+      match Provider_adapter.resolve_gemini_direct_auth () with
+      | Provider_adapter.Gemini_vertex_adc { project; location } -> (
+          match fetch_vertex_adc_access_token () with
+          | Ok access_token ->
+              Ok
+                ( Provider_adapter.gemini_vertex_openai_base_url ~project ~location,
+                  "/chat/completions",
+                  [ ("Authorization", sprintf "Bearer %s" access_token) ] )
+          | Error _ as e -> e)
+      | Provider_adapter.Gemini_api_key ->
+          let api_key = get_api_key spec in
+          if api_key = "" then
+            Error
+              "Gemini auth unavailable; set GOOGLE_CLOUD_PROJECT for Vertex ADC or GEMINI_API_KEY"
+          else
+            Ok
+              ( spec.api_url,
+                "/v1beta/openai/chat/completions",
+                [ ("Authorization", sprintf "Bearer %s" api_key) ] )
+      | Provider_adapter.Gemini_auth_missing message -> Error message)
+  | OpenAI ->
+      let api_key = get_api_key spec in
+      if api_key = "" then Error "OPENAI_API_KEY not set"
+      else
+        Ok
+          ( spec.api_url,
+            "/v1/chat/completions",
+            [ ("Authorization", sprintf "Bearer %s" api_key) ] )
+  | Glm_cloud ->
+      let api_key = get_api_key spec in
+      if api_key = "" then Error "ZAI_API_KEY not set"
+      else
+        Ok
+          ( spec.api_url,
+            "/api/coding/paas/v4/chat/completions",
+            [ ("Authorization", sprintf "Bearer %s" api_key) ] )
+  | OpenRouter ->
+      let api_key = get_api_key spec in
+      if api_key = "" then Error "OPENROUTER_API_KEY not set"
+      else
+        Ok
+          ( spec.api_url,
+            "/v1/chat/completions",
+            [ ("Authorization", sprintf "Bearer %s" api_key) ] )
+  | Claude ->
+      Error "Claude direct provider uses call_claude, not OpenAI-compatible transport"
+  | Ollama | Llama ->
+      Ok (spec.api_url, "/v1/chat/completions", [])
+  | Custom _ ->
+      let auth_headers =
+        match get_api_key spec with
+        | "" -> []
+        | api_key -> [ ("Authorization", sprintf "Bearer %s" api_key) ]
+      in
+      Ok (spec.api_url, "/v1/chat/completions", auth_headers)
+
 (** Run curl with body via stdin, return response string.
     Uses status-aware execution to distinguish timeout (exit 28)
     from connection failure (exit 7) and other errors. *)
@@ -843,30 +932,25 @@ let call_claude ?timeout_sec (req : completion_request) : (completion_response, 
     | Ok raw -> parse_claude_response raw
 
 let call_openai_compatible ?timeout_sec (req : completion_request) : (completion_response, string) result =
-  let api_key = get_api_key req.model in
-  let path = match req.model.provider with
-    | Gemini -> "/v1beta/openai/chat/completions"
-    | Glm_cloud -> "/api/coding/paas/v4/chat/completions"
-    | _ -> "/v1/chat/completions"
-  in
-  let url = sprintf "%s%s" req.model.api_url path in
-  let body = build_openai_body req in
-  Printf.eprintf "[llm_client] openai-compat req: model=%s max_tokens=%d tools=%d url=%s\n%!"
-    req.model.model_id req.max_tokens (List.length req.tools) url;
-  if req.tools <> [] then begin
-    let body_trunc = if String.length body > 1500 then String.sub body 0 1500 ^ "..." else body in
-    Printf.eprintf "[llm_client] openai-compat body (tools present, %d bytes): %s\n%!" (String.length body) body_trunc
-  end;
-  let headers = [("Content-Type", "application/json")] @
-    (if api_key <> "" then [("Authorization", sprintf "Bearer %s" api_key)] else [])
-  in
-  let timeout_sec = Option.value timeout_sec ~default:60 in
-  match curl_post ~url ~headers ~body ~timeout_sec with
+  match resolve_openai_compatible_endpoint req.model with
   | Error e -> Error e
-  | Ok raw ->
-    let trunc = if String.length raw > 500 then String.sub raw 0 500 ^ "..." else raw in
-    Printf.eprintf "[llm_client] openai-compat raw (%d bytes): %s\n%!" (String.length raw) trunc;
-    parse_openai_response raw
+  | Ok (base_url, path, auth_headers) ->
+      let url = sprintf "%s%s" base_url path in
+      let body = build_openai_body req in
+      Printf.eprintf "[llm_client] openai-compat req: model=%s provider=%s max_tokens=%d tools=%d url=%s\n%!"
+        req.model.model_id (string_of_provider req.model.provider) req.max_tokens (List.length req.tools) url;
+      if req.tools <> [] then begin
+        let body_trunc = if String.length body > 1500 then String.sub body 0 1500 ^ "..." else body in
+        Printf.eprintf "[llm_client] openai-compat body (tools present, %d bytes): %s\n%!" (String.length body) body_trunc
+      end;
+      let headers = [("Content-Type", "application/json")] @ auth_headers in
+      let timeout_sec = Option.value timeout_sec ~default:60 in
+      match curl_post ~url ~headers ~body ~timeout_sec with
+      | Error e -> Error e
+      | Ok raw ->
+          let trunc = if String.length raw > 500 then String.sub raw 0 500 ^ "..." else raw in
+          Printf.eprintf "[llm_client] openai-compat raw (%d bytes): %s\n%!" (String.length raw) trunc;
+          parse_openai_response raw
 
 (** GLM Cloud call with pool-based load balancing.
     Uses Glm_pool.with_model to select best available model and track usage. *)
@@ -955,7 +1039,7 @@ let complete ?timeout_sec ?ollama_timeout_sec (req : completion_request) : (comp
           | Llama -> call_openai_compatible ?timeout_sec req
           | Claude -> call_claude ?timeout_sec req
           | Glm_cloud -> call_glm_cloud_with_pool ?timeout_sec req
-          | Gemini | OpenRouter | Custom _ -> call_openai_compatible ?timeout_sec req
+          | OpenAI | Gemini | OpenRouter | Custom _ -> call_openai_compatible ?timeout_sec req
         in
         (match (cache_key, upstream_result) with
         | Some key, Ok resp -> (
@@ -1046,24 +1130,26 @@ let model_spec_of_string s =
       if model_id = "" then
         Error (sprintf "Cannot parse model spec: %s (expected provider:model)" s)
       else
-        match provider with
-        | "ollama" ->
+        match Provider_adapter.resolve_direct_adapter provider with
+        | Some adapter when adapter.canonical_name = "ollama" ->
           Ok { ollama_glm with model_id }
-        | "llama" | "llama.cpp" | "llamacpp" ->
+        | Some adapter when adapter.canonical_name = "llama" ->
           Ok { llama_default with model_id }
-        | "gemini" | "google" ->
+        | Some adapter when adapter.canonical_name = "gemini-api" ->
           if model_id = "pro" then Ok gemini_pro
           else if model_id = "flash" then
             Ok { gemini_pro with model_id = "gemini-3-flash-preview" }
           else
             Ok { gemini_pro with model_id }
-        | "claude" | "anthropic" ->
+        | Some adapter when adapter.canonical_name = "claude-api" ->
           if model_id = "opus" then Ok claude_opus
           else if model_id = "sonnet" then Ok claude_sonnet
           else Ok { claude_opus with model_id }
-        | "glm" | "glm_cloud" | "zai" ->
+        | Some adapter when adapter.canonical_name = "codex-api" ->
+          Ok { openai_default with model_id }
+        | Some adapter when adapter.canonical_name = "glm" ->
           Ok { glm_cloud with model_id }
-        | "openrouter" ->
+        | Some adapter when adapter.canonical_name = "openrouter" ->
           Ok {
             provider = OpenRouter;
             model_id;
@@ -1073,6 +1159,10 @@ let model_spec_of_string s =
             cost_per_1k_input = 0.001;
             cost_per_1k_output = 0.002;
           }
+        | Some _ ->
+          Error (sprintf "Cannot parse model spec: %s (unsupported direct adapter '%s')" s provider)
+        | None ->
+          match provider with
         | "mlx" ->
           Ok {
             provider = Custom "mlx";
@@ -1105,5 +1195,5 @@ let model_spec_of_string s =
         | _ ->
           Error
             (sprintf
-               "Cannot parse model spec: %s (unsupported provider '%s'; supported: ollama, llama, claude, gemini, glm, openrouter, mlx, custom)"
+              "Cannot parse model spec: %s (unsupported provider '%s'; supported: ollama, llama, claude, gemini, glm, openrouter, mlx, custom)"
                s provider)

--- a/lib/llm_client.mli
+++ b/lib/llm_client.mli
@@ -17,6 +17,7 @@ type provider =
   | Ollama
   | Llama
   | Claude
+  | OpenAI
   | Gemini
   | Glm_cloud
   | OpenRouter
@@ -136,6 +137,7 @@ val ollama_lfm : model_spec
 val llama_default : model_spec
 val claude_opus : model_spec
 val claude_sonnet : model_spec
+val openai_default : model_spec
 val glm_cloud : model_spec
 val gemini_pro : model_spec
 

--- a/lib/masc_mcp.ml
+++ b/lib/masc_mcp.ml
@@ -114,6 +114,7 @@ module Noosphere_eio = Noosphere_eio
 module Metrics_store_eio = Metrics_store_eio
 module Planning_eio = Planning_eio
 module Post_verifier = Post_verifier
+module Provider_adapter = Provider_adapter
 module Process_eio = Process_eio
 module Eio_context = Eio_context
 module Run_eio = Run_eio

--- a/lib/mdal_worker.ml
+++ b/lib/mdal_worker.ml
@@ -70,6 +70,7 @@ let model_provider_label = function
   | Llm_client.Ollama -> "ollama"
   | Llm_client.Llama -> "llama"
   | Llm_client.Claude -> "claude"
+  | Llm_client.OpenAI -> "openai"
   | Llm_client.Gemini -> "gemini"
   | Llm_client.Glm_cloud -> "glm"
   | Llm_client.OpenRouter -> "openrouter"
@@ -82,6 +83,7 @@ let validate_model_spec (spec : Llm_client.model_spec) :
     (Llm_client.model_spec, string) result =
   match spec.provider with
   | Llm_client.Claude
+  | Llm_client.OpenAI
   | Llm_client.Gemini
   | Llm_client.Ollama
   | Llm_client.Llama
@@ -90,7 +92,7 @@ let validate_model_spec (spec : Llm_client.model_spec) :
   | Llm_client.Custom _ ->
       Error
         (sprintf
-           "MDAL strict worker does not support provider `%s`. Use claude, gemini, ollama, llama, or glm."
+           "MDAL strict worker does not support provider `%s`. Use claude, openai, gemini, ollama, llama, or glm."
            (model_provider_label spec.provider))
 
 let resolve_model_spec ~(agent : string) ~(worker_model : string option) :
@@ -111,6 +113,8 @@ let resolve_model_spec ~(agent : string) ~(worker_model : string option) :
       else
         match normalized with
         | "claude" -> Ok (Llm_client.claude_opus, model_label Llm_client.claude_opus)
+        | "openai" | "codex-api" ->
+            Ok (Llm_client.openai_default, model_label Llm_client.openai_default)
         | "gemini" -> Ok (Llm_client.gemini_pro, model_label Llm_client.gemini_pro)
         | "ollama" -> Ok (Llm_client.ollama_glm, model_label Llm_client.ollama_glm)
         | "glm" ->

--- a/lib/provider_adapter.ml
+++ b/lib/provider_adapter.ml
@@ -1,0 +1,241 @@
+type runtime_kind =
+  | Local
+  | Direct_api
+  | Cli_agent
+
+type provider_family =
+  | Claude_family
+  | OpenAI_family
+  | Gemini_family
+  | Glm_family
+  | Llama_family
+  | Ollama_family
+  | OpenRouter_family
+  | Custom_family of string
+
+type auth_mode =
+  | No_auth
+  | Api_key of string
+  | Cli_cached_login
+  | Vertex_adc of {
+      project_env : string;
+      location_env : string;
+    }
+
+type prompt_transport =
+  | Prompt_stdin
+  | Prompt_arg of string
+
+type output_contract =
+  | Human_stdout
+  | Json_stdout
+
+type adapter = {
+  canonical_name : string;
+  runtime_kind : runtime_kind;
+  provider_family : provider_family;
+  auth_mode : auth_mode;
+  aliases : string list;
+}
+
+type cli_adapter = {
+  meta : adapter;
+  command : string;
+  prompt_transport : prompt_transport;
+  output_contract : output_contract;
+  default_allowed_mcp_servers : string list;
+}
+
+type gemini_direct_auth =
+  | Gemini_vertex_adc of {
+      project : string;
+      location : string;
+    }
+  | Gemini_api_key
+  | Gemini_auth_missing of string
+
+let google_cloud_project_env = "GOOGLE_CLOUD_PROJECT"
+let google_cloud_location_env = "GOOGLE_CLOUD_LOCATION"
+
+let string_of_runtime_kind = function
+  | Local -> "local"
+  | Direct_api -> "direct_api"
+  | Cli_agent -> "cli_agent"
+
+let string_of_provider_family = function
+  | Claude_family -> "claude"
+  | OpenAI_family -> "openai"
+  | Gemini_family -> "gemini"
+  | Glm_family -> "glm"
+  | Llama_family -> "llama"
+  | Ollama_family -> "ollama"
+  | OpenRouter_family -> "openrouter"
+  | Custom_family name -> "custom:" ^ name
+
+let string_of_auth_mode = function
+  | No_auth -> "none"
+  | Api_key env_name -> "api_key:" ^ env_name
+  | Cli_cached_login -> "cli_cached_login"
+  | Vertex_adc { project_env; location_env } ->
+      "vertex_adc:" ^ project_env ^ ":" ^ location_env
+
+let string_of_prompt_transport = function
+  | Prompt_stdin -> "stdin"
+  | Prompt_arg flag -> "arg:" ^ flag
+
+let string_of_output_contract = function
+  | Human_stdout -> "human_stdout"
+  | Json_stdout -> "json_stdout"
+
+let normalize_label label = String.trim label |> String.lowercase_ascii
+
+let direct_adapters =
+  [
+    {
+      canonical_name = "ollama";
+      runtime_kind = Local;
+      provider_family = Ollama_family;
+      auth_mode = No_auth;
+      aliases = [ "ollama" ];
+    };
+    {
+      canonical_name = "llama";
+      runtime_kind = Local;
+      provider_family = Llama_family;
+      auth_mode = No_auth;
+      aliases = [ "llama"; "llama.cpp"; "llamacpp" ];
+    };
+    {
+      canonical_name = "claude-api";
+      runtime_kind = Direct_api;
+      provider_family = Claude_family;
+      auth_mode = Api_key "ANTHROPIC_API_KEY";
+      aliases = [ "claude-api"; "claude"; "anthropic" ];
+    };
+    {
+      canonical_name = "codex-api";
+      runtime_kind = Direct_api;
+      provider_family = OpenAI_family;
+      auth_mode = Api_key "OPENAI_API_KEY";
+      aliases = [ "codex-api"; "openai" ];
+    };
+    {
+      canonical_name = "gemini-api";
+      runtime_kind = Direct_api;
+      provider_family = Gemini_family;
+      auth_mode =
+        Vertex_adc
+          {
+            project_env = google_cloud_project_env;
+            location_env = google_cloud_location_env;
+          };
+      aliases = [ "gemini-api"; "gemini"; "google" ];
+    };
+    {
+      canonical_name = "glm";
+      runtime_kind = Direct_api;
+      provider_family = Glm_family;
+      auth_mode = Api_key "ZAI_API_KEY";
+      aliases = [ "glm"; "glm_cloud"; "zai" ];
+    };
+    {
+      canonical_name = "openrouter";
+      runtime_kind = Direct_api;
+      provider_family = OpenRouter_family;
+      auth_mode = Api_key "OPENROUTER_API_KEY";
+      aliases = [ "openrouter" ];
+    };
+  ]
+
+let cli_adapters =
+  [
+    {
+      meta =
+        {
+          canonical_name = "claude";
+          runtime_kind = Cli_agent;
+          provider_family = Claude_family;
+          auth_mode = Cli_cached_login;
+          aliases = [ "claude"; "claude-code" ];
+        };
+      command = "claude --output-format json -p";
+      prompt_transport = Prompt_stdin;
+      output_contract = Json_stdout;
+      default_allowed_mcp_servers = [ "masc" ];
+    };
+    {
+      meta =
+        {
+          canonical_name = "codex";
+          runtime_kind = Cli_agent;
+          provider_family = OpenAI_family;
+          auth_mode = Cli_cached_login;
+          aliases = [ "codex"; "codex-cli" ];
+        };
+      command = "codex exec --json";
+      prompt_transport = Prompt_stdin;
+      output_contract = Json_stdout;
+      default_allowed_mcp_servers = [ "masc" ];
+    };
+    {
+      meta =
+        {
+          canonical_name = "gemini";
+          runtime_kind = Cli_agent;
+          provider_family = Gemini_family;
+          auth_mode = Cli_cached_login;
+          aliases = [ "gemini"; "gemini-cli" ];
+        };
+      command = "gemini --yolo --output-format json";
+      prompt_transport = Prompt_arg "-p";
+      output_contract = Json_stdout;
+      default_allowed_mcp_servers = [ "masc" ];
+    };
+  ]
+
+let resolve_adapter adapters label =
+  let normalized = normalize_label label in
+  List.find_opt
+    (fun adapter ->
+      List.exists (fun alias -> normalize_label alias = normalized) adapter.aliases)
+    adapters
+
+let resolve_direct_adapter label = resolve_adapter direct_adapters label
+let resolve_cli_adapter label =
+  let normalized = normalize_label label in
+  List.find_opt
+    (fun adapter ->
+      List.exists
+        (fun alias -> normalize_label alias = normalized)
+        adapter.meta.aliases)
+    cli_adapters
+
+let resolve_cli_canonical_name label =
+  Option.map (fun adapter -> adapter.meta.canonical_name) (resolve_cli_adapter label)
+
+let vertex_location () =
+  match Sys.getenv_opt google_cloud_location_env with
+  | Some raw ->
+      let trimmed = String.trim raw in
+      if trimmed = "" then "global" else trimmed
+  | None -> "global"
+
+let resolve_gemini_direct_auth () =
+  match Sys.getenv_opt google_cloud_project_env with
+  | Some raw when String.trim raw <> "" ->
+      Gemini_vertex_adc
+        {
+          project = String.trim raw;
+          location = vertex_location ();
+        }
+  | _ -> (
+      match Sys.getenv_opt "GEMINI_API_KEY" with
+      | Some raw when String.trim raw <> "" -> Gemini_api_key
+      | _ ->
+          Gemini_auth_missing
+            "Gemini auth unavailable; set GOOGLE_CLOUD_PROJECT for Vertex ADC or GEMINI_API_KEY")
+
+let gemini_vertex_openai_base_url ~project ~location =
+  Printf.sprintf
+    "https://aiplatform.googleapis.com/v1/projects/%s/locations/%s/endpoints/openapi"
+    project location

--- a/lib/spawn.ml
+++ b/lib/spawn.ml
@@ -270,12 +270,18 @@ let default_configs = [
 
 (** Get spawn config for agent *)
 let get_config agent_name =
-  List.assoc_opt agent_name default_configs
+  let canonical =
+    match Provider_adapter.resolve_cli_canonical_name agent_name with
+    | Some value -> value
+    | None -> agent_name
+  in
+  List.assoc_opt canonical default_configs
 
 (** Build MCP flags as argument list (no shell escaping needed) *)
 let build_mcp_args agent_name tools =
   if tools = [] then []
-  else match agent_name with
+  else
+    match Provider_adapter.resolve_cli_canonical_name agent_name |> Option.value ~default:agent_name with
   | "claude" ->
     (* Claude: --allowedTools "tool1,tool2,..." *)
     let tools_str = String.concat "," tools in
@@ -292,7 +298,7 @@ let build_mcp_args agent_name tools =
   | _ -> []
 
 let build_prompt_args agent_name prompt =
-  match agent_name with
+  match Provider_adapter.resolve_cli_canonical_name agent_name |> Option.value ~default:agent_name with
   | "gemini" -> ["-p"; prompt]
   | _ -> []
 

--- a/lib/spawn_eio.ml
+++ b/lib/spawn_eio.ml
@@ -479,12 +479,18 @@ let default_configs = [
 ]
 
 let get_config agent_name = 
-  List.assoc_opt agent_name default_configs
+  let canonical =
+    match Provider_adapter.resolve_cli_canonical_name agent_name with
+    | Some value -> value
+    | None -> agent_name
+  in
+  List.assoc_opt canonical default_configs
 
 (** Build MCP flags as argument list (no shell escaping needed) *)
 let build_mcp_args agent_name tools =
   if tools = [] then []
-  else match agent_name with
+  else
+    match Provider_adapter.resolve_cli_canonical_name agent_name |> Option.value ~default:agent_name with
   | "claude" -> 
     let tools_str = String.concat "," tools in 
     ["--allowedTools"; tools_str]
@@ -493,7 +499,7 @@ let build_mcp_args agent_name tools =
   | _ -> []
 
 let build_prompt_args agent_name prompt =
-  match agent_name with
+  match Provider_adapter.resolve_cli_canonical_name agent_name |> Option.value ~default:agent_name with
   | "gemini" -> ["-p"; prompt]
   | _ -> []
 

--- a/test/dune
+++ b/test/dune
@@ -176,6 +176,12 @@
  (modules test_process_eio_coverage)
  (libraries masc_mcp alcotest eio_main))
 
+; Provider adapter registry tests
+(test
+ (name test_provider_adapter)
+ (modules test_provider_adapter)
+ (libraries masc_mcp alcotest unix))
+
 ; Local worker text-tool-call fallback coverage
 (test
  (name test_local_agent_eio_coverage)

--- a/test/test_perpetual.ml
+++ b/test/test_perpetual.ml
@@ -54,6 +54,8 @@ let test_llm_client () = group "LLM Client" (fun () ->
     "llama" (Llm_client.string_of_provider Llama);
   assert_equal "provider_string:claude"
     "claude" (Llm_client.string_of_provider Claude);
+  assert_equal "provider_string:openai"
+    "openai" (Llm_client.string_of_provider OpenAI);
   assert_equal "provider_string:gemini"
     "gemini" (Llm_client.string_of_provider Gemini);
 
@@ -108,6 +110,27 @@ let test_llm_client () = group "LLM Client" (fun () ->
      assert_true "parse_model:google_alias_provider"
        (m.provider = Llm_client.Gemini)
    | Error _ -> assert_true "parse_model:google_alias" false);
+
+  (match Llm_client.model_spec_of_string "claude-api:sonnet" with
+   | Ok m ->
+     assert_equal "parse_model:claude_api_id" "claude-sonnet-4-5-20250929" m.model_id;
+     assert_true "parse_model:claude_api_provider"
+       (m.provider = Llm_client.Claude)
+   | Error _ -> assert_true "parse_model:claude_api" false);
+
+  (match Llm_client.model_spec_of_string "gemini-api:gemini-2.5-flash" with
+   | Ok m ->
+     assert_equal "parse_model:gemini_api_id" "gemini-2.5-flash" m.model_id;
+     assert_true "parse_model:gemini_api_provider"
+       (m.provider = Llm_client.Gemini)
+   | Error _ -> assert_true "parse_model:gemini_api" false);
+
+  (match Llm_client.model_spec_of_string "codex-api:gpt-5-mini" with
+   | Ok m ->
+     assert_equal "parse_model:codex_api_id" "gpt-5-mini" m.model_id;
+     assert_true "parse_model:codex_api_provider"
+       (m.provider = Llm_client.OpenAI)
+   | Error _ -> assert_true "parse_model:codex_api" false);
 
   (* 3. Invalid model spec *)
   (match Llm_client.model_spec_of_string "invalid" with
@@ -166,6 +189,8 @@ let test_llm_client () = group "LLM Client" (fun () ->
     (Llm_client.claude_opus.cost_per_1k_input > 0.0);
   assert_true "builtin:gemini_pro_provider"
     (Llm_client.gemini_pro.provider = Llm_client.Gemini);
+  assert_true "builtin:openai_default_provider"
+    (Llm_client.openai_default.provider = Llm_client.OpenAI);
   assert_true "builtin:llama_default_provider"
     (Llm_client.llama_default.provider = Llm_client.Llama);
 )

--- a/test/test_provider_adapter.ml
+++ b/test/test_provider_adapter.ml
@@ -1,0 +1,76 @@
+open Alcotest
+
+module Adapter = Masc_mcp.Provider_adapter
+
+let with_env name value f =
+  let previous = Sys.getenv_opt name in
+  (match value with
+   | Some v -> Unix.putenv name v
+   | None -> Unix.putenv name "");
+  Fun.protect
+    ~finally:(fun () ->
+      match previous with
+      | Some v -> Unix.putenv name v
+      | None -> Unix.putenv name "")
+    f
+
+let test_resolve_direct_aliases () =
+  let claude = Option.get (Adapter.resolve_direct_adapter "anthropic") in
+  check string "claude alias" "claude-api" claude.canonical_name;
+  let gemini = Option.get (Adapter.resolve_direct_adapter "google") in
+  check string "gemini alias" "gemini-api" gemini.canonical_name;
+  let codex = Option.get (Adapter.resolve_direct_adapter "openai") in
+  check string "codex-api alias" "codex-api" codex.canonical_name
+
+let test_resolve_cli_aliases () =
+  let claude = Option.get (Adapter.resolve_cli_adapter "claude-code") in
+  check string "claude cli alias" "claude" claude.meta.canonical_name;
+  let gemini = Option.get (Adapter.resolve_cli_adapter "gemini-cli") in
+  check string "gemini cli alias" "gemini" gemini.meta.canonical_name;
+  check string "gemini prompt transport" "arg:-p"
+    (Adapter.string_of_prompt_transport gemini.prompt_transport)
+
+let test_gemini_direct_auth_vertex_adc () =
+  with_env "GOOGLE_CLOUD_PROJECT" (Some "demo-project") (fun () ->
+      with_env "GOOGLE_CLOUD_LOCATION" (Some "asia-northeast3") (fun () ->
+          with_env "GEMINI_API_KEY" None (fun () ->
+              match Adapter.resolve_gemini_direct_auth () with
+              | Adapter.Gemini_vertex_adc { project; location } ->
+                  check string "project" "demo-project" project;
+                  check string "location" "asia-northeast3" location
+              | _ -> fail "expected vertex adc")))
+
+let test_gemini_direct_auth_api_key_fallback () =
+  with_env "GOOGLE_CLOUD_PROJECT" None (fun () ->
+      with_env "GEMINI_API_KEY" (Some "dummy-key") (fun () ->
+          match Adapter.resolve_gemini_direct_auth () with
+          | Adapter.Gemini_api_key -> ()
+          | _ -> fail "expected api key fallback"))
+
+let test_gemini_direct_auth_missing () =
+  with_env "GOOGLE_CLOUD_PROJECT" None (fun () ->
+      with_env "GEMINI_API_KEY" None (fun () ->
+          match Adapter.resolve_gemini_direct_auth () with
+          | Adapter.Gemini_auth_missing message ->
+              check bool "actionable message" true (String.length message > 0)
+          | _ -> fail "expected missing auth"))
+
+let test_vertex_base_url () =
+  check string "vertex base url"
+    "https://aiplatform.googleapis.com/v1/projects/demo/locations/global/endpoints/openapi"
+    (Adapter.gemini_vertex_openai_base_url ~project:"demo" ~location:"global")
+
+let () =
+  run "Provider Adapter"
+    [
+      ( "registry",
+        [
+          test_case "resolve direct aliases" `Quick test_resolve_direct_aliases;
+          test_case "resolve cli aliases" `Quick test_resolve_cli_aliases;
+          test_case "gemini vertex adc" `Quick test_gemini_direct_auth_vertex_adc;
+          test_case "gemini api key fallback" `Quick
+            test_gemini_direct_auth_api_key_fallback;
+          test_case "gemini missing auth" `Quick test_gemini_direct_auth_missing;
+          test_case "vertex base url" `Quick test_vertex_base_url;
+        ] );
+    ]

--- a/test/test_spawn.ml
+++ b/test/test_spawn.ml
@@ -10,11 +10,20 @@ let test_get_config_known_agents () =
   Alcotest.(check string) "claude agent_name" "claude" claude.Spawn.agent_name;
   Alcotest.(check bool) "claude has mcp_tools" true (List.length claude.mcp_tools > 0);
 
+  let claude_alias = Spawn.get_config "claude-code" in
+  Alcotest.(check bool) "claude-code alias exists" true (Option.is_some claude_alias);
+
   let gemini = Spawn.get_config "gemini" in
   Alcotest.(check bool) "gemini config exists" true (Option.is_some gemini);
 
+  let gemini_alias = Spawn.get_config "gemini-cli" in
+  Alcotest.(check bool) "gemini-cli alias exists" true (Option.is_some gemini_alias);
+
   let codex = Spawn.get_config "codex" in
   Alcotest.(check bool) "codex config exists" true (Option.is_some codex);
+
+  let codex_alias = Spawn.get_config "codex-cli" in
+  Alcotest.(check bool) "codex-cli alias exists" true (Option.is_some codex_alias);
 
   let ollama = Spawn.get_config "ollama" in
   Alcotest.(check bool) "ollama config exists" true (Option.is_some ollama);


### PR DESCRIPTION
## Summary
- add a provider-native adapter registry covering local, direct API, and CLI runtimes
- normalize direct aliases (, , ) and CLI aliases (, , )
- add Gemini direct auth resolution ( first,  fallback) while keeping CLI auth separate
- route spawn/spawn_eio CLI config lookups through the shared registry and document the runtime/auth matrix

## Validation
- dune build --root . test/test_provider_adapter.exe test/test_perpetual.exe test/test_spawn.exe test/test_spawn_coverage.exe test/test_spawn_eio_coverage.exe
- ./_build/default/test/test_provider_adapter.exe
- ./_build/default/test/test_perpetual.exe
- ./_build/default/test/test_spawn.exe
- ./_build/default/test/test_spawn_coverage.exe
- ./_build/default/test/test_spawn_eio_coverage.exe
- dune build --root . @default