### PR TITLE
feat(adapter): propagate registry defaults to runtime selection

### DIFF
--- a/lib/llm_client.ml
+++ b/lib/llm_client.ml
@@ -1195,5 +1195,10 @@ let model_spec_of_string s =
         | _ ->
           Error
             (sprintf
-              "Cannot parse model spec: %s (unsupported provider '%s'; supported: ollama, llama, claude, gemini, glm, openrouter, mlx, custom)"
+               "Cannot parse model spec: %s (unsupported provider '%s'; supported: ollama, llama, claude, gemini, glm, openrouter, mlx, custom)"
                s provider)
+
+let default_local_model_spec () =
+  match model_spec_of_string (Provider_adapter.default_local_model_label ()) with
+  | Ok spec -> spec
+  | Error _ -> ollama_glm

--- a/lib/llm_client.mli
+++ b/lib/llm_client.mli
@@ -141,6 +141,10 @@ val openai_default : model_spec
 val glm_cloud : model_spec
 val gemini_pro : model_spec
 
+(** Resolve the canonical default local model through the provider registry.
+    Falls back to [ollama_glm] if parsing fails. *)
+val default_local_model_spec : unit -> model_spec
+
 (** Create a message. *)
 val system_msg : string -> message
 val user_msg : string -> message

--- a/lib/perpetual_loop.ml
+++ b/lib/perpetual_loop.ml
@@ -113,7 +113,7 @@ let default_config ~goal ~models ?verifier ?session_dir () =
     session_base_dir = session_base;
     on_event = (fun _ -> ());  (* No-op default *)
     coding_mode = false;
-    coding_agent = "claude";
+    coding_agent = Provider_adapter.default_cli_agent_name ();
     coding_timeout_s = Env_config.Spawn.coding_timeout_seconds;
     coding_sw = None;
     coding_proc_mgr = None;
@@ -153,7 +153,7 @@ let create_state config =
   in
   let primary_model = match config.model_cascade with
     | m :: _ -> m
-    | [] -> Llm_client.ollama_glm
+    | [] -> Llm_client.default_local_model_spec ()
   in
   let context = Context_manager.create
     ~system_prompt
@@ -380,7 +380,7 @@ let run_coding_turn ~config ~state =
       let next_model = match config.model_cascade with
         | _ :: m :: _ -> m
         | [m] -> m
-        | [] -> Llm_client.ollama_glm
+        | [] -> Llm_client.default_local_model_spec ()
       in
       emit (Handoff {
         to_model = next_model.model_id;
@@ -464,7 +464,7 @@ let run_turn ~config ~state =
       let primary_model =
         match config.model_cascade with
         | m :: _ -> m
-        | [] -> Llm_client.ollama_glm
+        | [] -> Llm_client.default_local_model_spec ()
       in
       let used_model =
         let used =
@@ -573,7 +573,7 @@ let run_turn ~config ~state =
         let next_model = match config.model_cascade with
           | _ :: m :: _ -> m  (* Next model in cascade *)
           | [m] -> m          (* Same model *)
-          | [] -> Llm_client.ollama_glm
+          | [] -> Llm_client.default_local_model_spec ()
         in
         emit (Handoff {
           to_model = next_model.model_id;

--- a/lib/provider_adapter.ml
+++ b/lib/provider_adapter.ml
@@ -213,6 +213,18 @@ let resolve_cli_adapter label =
 let resolve_cli_canonical_name label =
   Option.map (fun adapter -> adapter.meta.canonical_name) (resolve_cli_adapter label)
 
+let default_cli_agent_name () = "claude"
+
+let default_local_model_label () =
+  let model_id =
+    match Sys.getenv_opt "OLLAMA_DEFAULT_MODEL" with
+    | Some raw ->
+        let trimmed = String.trim raw in
+        if trimmed = "" then "glm-4.7-flash" else trimmed
+    | None -> "glm-4.7-flash"
+  in
+  "ollama:" ^ model_id
+
 let vertex_location () =
   match Sys.getenv_opt google_cloud_location_env with
   | Some raw ->

--- a/lib/tool_keeper.ml
+++ b/lib/tool_keeper.ml
@@ -5973,7 +5973,7 @@ let execute_approved_plan
     ~(trajectory_acc : Trajectory.accumulator option)
     : string * float * string list =
   let gate_config = autonomous_gate_config ~autonomy_level in
-  let primary = match specs with p :: _ -> p | [] -> Llm_client.ollama_glm in
+  let primary = match specs with p :: _ -> p | [] -> Llm_client.default_local_model_spec () in
   let system_prompt = Printf.sprintf
 {|You are a keeper agent executing an approved action plan.
 Your name: %s
@@ -6134,7 +6134,7 @@ let run_autonomous_goal_turn ~(config : Room.config) ~(meta : keeper_meta)
     | None -> None
     | Some L1_Reactive -> None
     | Some level ->
-        let primary = match specs with p :: _ -> p | [] -> Llm_client.ollama_glm in
+        let primary = match specs with p :: _ -> p | [] -> Llm_client.default_local_model_spec () in
         let verify_model = Llm_client.ollama_lfm in
         let keeper_context =
           Printf.sprintf "keeper=%s autonomy=%s turns=%d cost=$%.4f"
@@ -6488,7 +6488,7 @@ let maybe_emit_proactive (ctx : _ context) (meta : keeper_meta) : keeper_meta =
                let primary =
                  match specs with
                  | p :: _ -> p
-                 | [] -> Llm_client.ollama_glm
+                 | [] -> Llm_client.default_local_model_spec ()
                in
                let base_dir = session_base_dir ctx.config in
                let (session, ctx_opt) =
@@ -6730,7 +6730,7 @@ let start_keepalive ?(proactive_warmup_sec = 0) (ctx : _ context) (m : keeper_me
                let primary_model =
                  match model_specs_of_strings meta_current.models with
                  | Ok (primary :: _) -> primary
-                 | _ -> Llm_client.ollama_glm
+                 | _ -> Llm_client.default_local_model_spec ()
                in
                let base_dir = session_base_dir ctx.config in
                let (_session, ctx_opt) =
@@ -7006,7 +7006,7 @@ let handle_keeper_up ctx args : tool_result =
              let trace_id = generate_trace_id () in
              let primary = match specs with
                | m :: _ -> m
-               | [] -> Llm_client.ollama_glm
+               | [] -> Llm_client.default_local_model_spec ()
              in
              let base_dir = session_base_dir ctx.config in
              mkdir_p base_dir;
@@ -7236,7 +7236,7 @@ let handle_keeper_status ctx args : tool_result =
       (match model_specs_of_strings models with
        | Error e -> (false, "❌ " ^ e)
        | Ok specs ->
-         let primary = match specs with m0 :: _ -> m0 | [] -> Llm_client.ollama_glm in
+         let primary = match specs with m0 :: _ -> m0 | [] -> Llm_client.default_local_model_spec () in
          let base_dir = session_base_dir ctx.config in
          let ctx_opt =
            if include_context then
@@ -7836,7 +7836,7 @@ let handle_keeper_msg ctx args : tool_result =
              (match ensure_api_keys specs with
               | Error e -> Error e
               | Ok () ->
-                let primary = match specs with m0 :: _ -> m0 | [] -> Llm_client.ollama_glm in
+                let primary = match specs with m0 :: _ -> m0 | [] -> Llm_client.default_local_model_spec () in
                 let session = Context_manager.create_session ~session_id:trace_id ~base_dir in
                 let system_prompt =
                   build_keeper_system_prompt
@@ -7972,7 +7972,7 @@ let handle_keeper_msg ctx args : tool_result =
          (match ensure_api_keys specs with
           | Error e -> (false, "❌ " ^ e)
           | Ok () ->
-            let primary = match specs with m0 :: _ -> m0 | [] -> Llm_client.ollama_glm in
+            let primary = match specs with m0 :: _ -> m0 | [] -> Llm_client.default_local_model_spec () in
             let base_dir = session_base_dir ctx.config in
             mkdir_p base_dir;
             let (session, ctx_opt) = load_context_from_checkpoint

--- a/lib/tool_perpetual.ml
+++ b/lib/tool_perpetual.ml
@@ -152,7 +152,7 @@ let handle_start ctx args =
   let coding_mode = args |> member "coding_mode" |> to_bool_option
                     |> Option.value ~default:false in
   let coding_agent = args |> member "coding_agent" |> to_string_option
-                     |> Option.value ~default:"claude" in
+                     |> Option.value ~default:(Provider_adapter.default_cli_agent_name ()) in
   let coding_timeout = args |> member "coding_timeout_sec" |> to_int_option
                        |> Option.value ~default:Env_config.Spawn.coding_timeout_seconds in
   (* Parse model specs *)

--- a/lib/tool_team_session.ml
+++ b/lib/tool_team_session.ml
@@ -1525,7 +1525,7 @@ let handle_step ctx args : result =
                                 Some assignment.runtime_id )
                         | Error err -> Error err)
                   else
-                    Ok (Llm_client.ollama_glm, None, None)
+                    Ok (Llm_client.default_local_model_spec (), None, None)
                 in
                 match runtime_model with
                 | Error e -> Error (spec, runtime_actor_name, e)

--- a/test/test_perpetual.ml
+++ b/test/test_perpetual.ml
@@ -193,6 +193,11 @@ let test_llm_client () = group "LLM Client" (fun () ->
     (Llm_client.openai_default.provider = Llm_client.OpenAI);
   assert_true "builtin:llama_default_provider"
     (Llm_client.llama_default.provider = Llm_client.Llama);
+  let default_local = Llm_client.default_local_model_spec () in
+  assert_true "builtin:default_local_provider"
+    (default_local.provider = Llm_client.Ollama);
+  assert_equal "builtin:default_local_model_id"
+    Masc_mcp.Env_config.Ollama.default_model default_local.model_id;
 )
 
 (* ================================================================ *)
@@ -524,7 +529,8 @@ let test_perpetual_loop () = group "Perpetual Loop" (fun () ->
   assert_true "config:coding_mode_default" (not config.coding_mode);
 
   (* 12. Default config: coding_agent is "claude" *)
-  assert_equal "config:coding_agent_default" "claude" config.coding_agent;
+  assert_equal "config:coding_agent_default"
+    (Masc_mcp.Provider_adapter.default_cli_agent_name ()) config.coding_agent;
 
   (* 13. Default config: coding_timeout_s uses env default *)
   assert_true "config:coding_timeout_positive" (config.coding_timeout_s > 0);

--- a/test/test_provider_adapter.ml
+++ b/test/test_provider_adapter.ml
@@ -60,6 +60,15 @@ let test_vertex_base_url () =
     "https://aiplatform.googleapis.com/v1/projects/demo/locations/global/endpoints/openapi"
     (Adapter.gemini_vertex_openai_base_url ~project:"demo" ~location:"global")
 
+let test_default_cli_agent_name () =
+  check string "default cli agent" "claude"
+    (Adapter.default_cli_agent_name ())
+
+let test_default_local_model_label () =
+  with_env "OLLAMA_DEFAULT_MODEL" (Some "my-local-model") (fun () ->
+      check string "default local label" "ollama:my-local-model"
+        (Adapter.default_local_model_label ()))
+
 let () =
   run "Provider Adapter"
     [
@@ -72,5 +81,7 @@ let () =
             test_gemini_direct_auth_api_key_fallback;
           test_case "gemini missing auth" `Quick test_gemini_direct_auth_missing;
           test_case "vertex base url" `Quick test_vertex_base_url;
+          test_case "default cli agent" `Quick test_default_cli_agent_name;
+          test_case "default local model label" `Quick test_default_local_model_label;
         ] );
     ]


### PR DESCRIPTION
## Summary
- propagate provider-adapter registry defaults into team-session, keeper, and perpetual selection paths
- remove remaining hardcoded `ollama_glm` / `claude` defaults from runtime selection hot paths
- keep local-first behavior, but resolve it through the shared adapter layer

## Validation
- `dune build --root . test/test_provider_adapter.exe test/test_perpetual.exe test/test_spawn.exe`
- `./_build/default/test/test_provider_adapter.exe`
- `./_build/default/test/test_perpetual.exe`
- `./_build/default/test/test_spawn.exe`
- `dune build --root . @default`
