### PR TITLE
feat(room): add room strategy and speculation toggles

### DIFF
--- a/lib/command_plane_v2.ml
+++ b/lib/command_plane_v2.ml
@@ -350,6 +350,19 @@ let validate_search_strategy = function
   | "legacy" | "best_first_v1" as value -> Ok value
   | other -> Error (Printf.sprintf "unsupported search_strategy: %s" other)
 
+let room_search_strategy_default config =
+  match (Room.read_state config).search_strategy_default with
+  | Some ("legacy" | "best_first_v1" as value) -> value
+  | _ -> "legacy"
+
+let room_speculation_enabled config =
+  (Room.read_state config).speculation_enabled
+
+let room_speculation_budget config =
+  match (Room.read_state config).speculation_budget with
+  | Some value when value > 0 -> value
+  | _ -> 4
+
 let string_of_unit_kind = function
   | Company -> "company"
   | Platoon -> "platoon"
@@ -4348,6 +4361,64 @@ let operation_search_candidates config units operations
     ~operation:(search_operation_descriptor operation)
     ~candidates:(search_candidates_for_operation config units operations operation)
 
+let take_list n xs =
+  let rec loop acc remaining count =
+    match remaining, count with
+    | _, count when count <= 0 -> List.rev acc
+    | [], _ -> List.rev acc
+    | item :: rest, _ -> loop (item :: acc) rest (count - 1)
+  in
+  loop [] xs n
+
+let speculative_candidates_for_operation (operation : operation_record)
+    (candidates : Cp_search_fabric.scored_candidate list) =
+  List.map
+    (fun (candidate : Cp_search_fabric.scored_candidate) ->
+      {
+        Speculative_engine.label = candidate.unit_id;
+        prompt =
+          Printf.sprintf
+            "Objective: %s\nWorkload: %s\nStage: %s\nCandidate unit: %s\nSearch score: %.1f\nRouting reason: %s\n\nDecide whether this is the best execution target. Keep the answer concise."
+            operation.objective
+            (operation_workload_profile operation)
+            (operation_stage_key operation)
+            candidate.unit_id
+            candidate.breakdown.total
+            candidate.routing_reason;
+        metadata =
+          `Assoc
+            [
+              ("unit_id", `String candidate.unit_id);
+              ("score", `Float candidate.breakdown.total);
+              ("routing_reason", `String candidate.routing_reason);
+            ];
+      })
+    candidates
+
+let speculative_pick_candidate config (operation : operation_record)
+    (candidates : Cp_search_fabric.scored_candidate list) =
+  if
+    not (room_speculation_enabled config)
+    || operation_search_strategy operation <> Cp_search_fabric.Best_first_v1
+    || List.length candidates < 2
+  then
+    None
+  else
+    let budget = min (room_speculation_budget config) (List.length candidates) in
+    let candidates = take_list budget candidates in
+    match
+      Speculative_engine.speculate Tool_risc.global_spec_engine
+        ~goal:(Printf.sprintf "route-%s" operation.operation_id)
+        ~original_query:operation.objective
+        ~candidates:(speculative_candidates_for_operation operation candidates)
+    with
+    | Ok outcome ->
+        List.find_opt
+          (fun (candidate : Cp_search_fabric.scored_candidate) ->
+            String.equal candidate.unit_id outcome.candidate_label)
+          candidates
+    | Error _ -> None
+
 let operation_search_json config units operations (operation : operation_record) =
   let readiness = operation_readiness operations operation in
   let candidates =
@@ -4361,9 +4432,22 @@ let operation_search_json config units operations (operation : operation_record)
     | best :: _ -> Some best.Cp_search_fabric.unit_id
     | [] -> Some operation.assigned_unit_id
   in
-  Cp_search_fabric.summary_json
-    ~strategy:(operation_search_strategy operation)
-    ~readiness ~candidates ~selected_unit_id
+  let base_json =
+    Cp_search_fabric.summary_json
+      ~strategy:(operation_search_strategy operation)
+      ~readiness ~candidates ~selected_unit_id
+  in
+  match base_json with
+  | `Assoc fields ->
+      `Assoc
+        ( ("speculation",
+           `Assoc
+             [
+               ("enabled", `Bool (room_speculation_enabled config));
+               ("budget", `Int (room_speculation_budget config));
+             ] )
+        :: fields )
+  | other -> other
 
 let update_search_stats_for_operation config operation ~outcome =
   let stage = operation_stage_key operation in
@@ -4643,7 +4727,9 @@ let start_operation config ~(actor : string) json =
   | Error message -> Error message
   | Ok _ ->
       let workload_profile_raw = get_string_default json "workload_profile" "generic" in
-      let search_strategy_raw = get_string_default json "search_strategy" "legacy" in
+      let search_strategy_raw =
+        get_string_default json "search_strategy" (room_search_strategy_default config)
+      in
       let* workload_profile = validate_workload_profile workload_profile_raw in
       let* search_strategy = validate_search_strategy search_strategy_raw in
       let chain =
@@ -5488,6 +5574,11 @@ let maybe_apply_best_first_assignment config ~actor units operations
           match candidates with
           | [] -> operation
           | best :: _ ->
+              let best =
+                match speculative_pick_candidate config operation candidates with
+                | Some candidate -> candidate
+                | None -> best
+              in
               let current =
                 candidates
                 |> List.find_opt (fun (candidate : Cp_search_fabric.scored_candidate) ->

--- a/lib/room.ml
+++ b/lib/room.ml
@@ -32,6 +32,9 @@ let read_state config =
       pause_reason = None;
       paused_by = None;
       paused_at = None;
+      search_strategy_default = None;
+      speculation_enabled = false;
+      speculation_budget = None;
     }
 
 (** Write room state — persists to both filesystem and PostgreSQL *)
@@ -239,6 +242,9 @@ let rec init config ~agent_name =
       pause_reason = None;
       paused_by = None;
       paused_at = None;
+      search_strategy_default = None;
+      speculation_enabled = false;
+      speculation_budget = None;
     } in
     write_json_root config (root_state_path config) (room_state_to_yojson root_state)
   end;
@@ -268,6 +274,9 @@ let rec init config ~agent_name =
       pause_reason = None;
       paused_by = None;
       paused_at = None;
+      search_strategy_default = None;
+      speculation_enabled = false;
+      speculation_budget = None;
     } in
     write_state config state;
 

--- a/lib/tool_room.ml
+++ b/lib/tool_room.ml
@@ -16,6 +16,30 @@ type context = {
 
 open Tool_args
 
+let normalize_search_strategy value =
+  match String.trim value with
+  | "" -> Ok None
+  | "legacy" | "best_first_v1" as strategy -> Ok (Some strategy)
+  | other -> Error ("❌ search_strategy_default must be legacy or best_first_v1, got: " ^ other)
+
+let normalize_speculation_budget value =
+  match value with
+  | None -> Ok None
+  | Some v when v <= 0 -> Error "❌ speculation_budget must be > 0"
+  | Some v -> Ok (Some v)
+
+let room_strategy_json config =
+  let state = Room.read_state config in
+  `Assoc
+    [
+      ("room_id", `String (Room.current_room_id config));
+      ("search_strategy_default",
+       match state.search_strategy_default with Some v -> `String v | None -> `Null);
+      ("speculation_enabled", `Bool state.speculation_enabled);
+      ("speculation_budget",
+       match state.speculation_budget with Some v -> `Int v | None -> `Null);
+    ]
+
 (* Handlers *)
 
 let handle_status ctx _args =
@@ -68,6 +92,52 @@ let handle_room_enter ctx args =
     in
     (success, Yojson.Safe.pretty_to_string result)
 
+let handle_room_strategy_get ctx _args =
+  (true, Yojson.Safe.pretty_to_string (room_strategy_json ctx.config))
+
+let handle_room_strategy_set ctx args =
+  let search_strategy_raw = get_string_opt args "search_strategy_default" in
+  let search_strategy_default =
+    match search_strategy_raw with
+    | Some value -> normalize_search_strategy value
+    | None -> Ok None
+  in
+  let speculation_enabled = get_bool_opt args "speculation_enabled" in
+  let speculation_budget =
+    match args |> member "speculation_budget" with
+    | `Int value -> normalize_speculation_budget (Some value)
+    | `Null -> Ok None
+    | _ -> Ok None
+  in
+  match search_strategy_default, speculation_budget with
+  | Error e, _ -> (false, e)
+  | _, Error e -> (false, e)
+  | Ok search_strategy_default, Ok speculation_budget ->
+      let updated =
+        Room.update_state ctx.config (fun state ->
+            {
+              state with
+              search_strategy_default =
+                (match search_strategy_raw with Some _ -> search_strategy_default | None -> state.search_strategy_default);
+              speculation_enabled =
+                Option.value ~default:state.speculation_enabled speculation_enabled;
+              speculation_budget =
+                (match args |> member "speculation_budget" with
+                | `Null -> None
+                | `Int _ -> speculation_budget
+                | _ -> state.speculation_budget);
+            })
+      in
+      ( true,
+        Yojson.Safe.pretty_to_string
+          (`Assoc
+            [
+              ("status", `String "ok");
+              ("room_strategy", room_strategy_json ctx.config);
+              ("updated_at", `String (Types.now_iso ()));
+              ("project", `String updated.project);
+            ]) )
+
 (* Dispatch function *)
 let dispatch ctx ~name ~args : result option =
   match name with
@@ -77,4 +147,6 @@ let dispatch ctx ~name ~args : result option =
   | "masc_rooms_list" -> Some (handle_rooms_list ctx args)
   | "masc_room_create" -> Some (handle_room_create ctx args)
   | "masc_room_enter" -> Some (handle_room_enter ctx args)
+  | "masc_room_strategy_get" -> Some (handle_room_strategy_get ctx args)
+  | "masc_room_strategy_set" -> Some (handle_room_strategy_set ctx args)
   | _ -> None

--- a/lib/tools.ml
+++ b/lib/tools.ml
@@ -3647,6 +3647,38 @@ Example: masc_swarm_leave({agent_name: 'claude-xyz'})";
     ];
   };
 
+  {
+    name = "masc_room_strategy_get";
+    description = "Read the current room-level search and speculation defaults. Use this before changing routing behavior so you know whether best_first_v1 or speculation is already enabled for the room.";
+    input_schema = `Assoc [
+      ("type", `String "object");
+      ("properties", `Assoc []);
+    ];
+  };
+
+  {
+    name = "masc_room_strategy_set";
+    description = "Update room-level search and speculation defaults. Use this to set the default command-plane search strategy and to enable or disable speculative routing for the current room.";
+    input_schema = `Assoc [
+      ("type", `String "object");
+      ("properties", `Assoc [
+        ("search_strategy_default", `Assoc [
+          ("type", `String "string");
+          ("enum", `List [`String "legacy"; `String "best_first_v1"]);
+          ("description", `String "Optional room default for command-plane search strategy.");
+        ]);
+        ("speculation_enabled", `Assoc [
+          ("type", `String "boolean");
+          ("description", `String "Enable or disable room-level speculative routing.");
+        ]);
+        ("speculation_budget", `Assoc [
+          ("type", `String "integer");
+          ("description", `String "Optional max number of candidates to speculate over when speculation is enabled.");
+        ]);
+      ]);
+    ];
+  };
+
   (* ============================================ *)
   (* Audit & Governance Tools (Trust Building)   *)
   (* ============================================ *)

--- a/lib/types.ml
+++ b/lib/types.ml
@@ -390,6 +390,9 @@ type room_state = {
   pause_reason: string option; [@default None]  (** Reason for pause *)
   paused_by: string option; [@default None]  (** Who paused the room *)
   paused_at: string option; [@default None]  (** When paused *)
+  search_strategy_default: string option; [@default None]
+  speculation_enabled: bool; [@default false]
+  speculation_budget: int option; [@default None]
 } [@@deriving yojson { strict = false }, show]
 
 (* ============================================ *)

--- a/test/test_tool_room_coverage.ml
+++ b/test/test_tool_room_coverage.ml
@@ -163,6 +163,44 @@ let () = test "dispatch_room_enter_no_id" (fun () ->
   | None -> failwith "dispatch returned None"
 )
 
+let () = test "dispatch_room_strategy_get" (fun () ->
+  let ctx = make_test_ctx () in
+  let _ = Room.init ctx.config ~agent_name:(Some "test-agent") in
+  match Tool_room.dispatch ctx ~name:"masc_room_strategy_get" ~args:(`Assoc []) with
+  | Some (success, result) ->
+      assert success;
+      assert (str_contains result "\"search_strategy_default\"");
+      assert (str_contains result "\"speculation_enabled\"")
+  | None -> failwith "dispatch returned None"
+)
+
+let () = test "dispatch_room_strategy_set" (fun () ->
+  let ctx = make_test_ctx () in
+  let _ = Room.init ctx.config ~agent_name:(Some "test-agent") in
+  let args =
+    `Assoc
+      [
+        ("search_strategy_default", `String "best_first_v1");
+        ("speculation_enabled", `Bool true);
+        ("speculation_budget", `Int 3);
+      ]
+  in
+  match Tool_room.dispatch ctx ~name:"masc_room_strategy_set" ~args with
+  | Some (success, result) ->
+      assert success;
+      assert (str_contains result "\"best_first_v1\"");
+      assert (str_contains result "\"speculation_enabled\": true")
+  | None -> failwith "dispatch returned None"
+)
+
+let () = test "dispatch_room_strategy_set_bad_strategy" (fun () ->
+  let ctx = make_test_ctx () in
+  let args = `Assoc [ ("search_strategy_default", `String "mcts_everywhere") ] in
+  match Tool_room.dispatch ctx ~name:"masc_room_strategy_set" ~args with
+  | Some (success, _result) -> assert (not success)
+  | None -> failwith "dispatch returned None"
+)
+
 (* Test helper functions *)
 let () = test "get_string_present" (fun () ->
   let args = `Assoc [("key", `String "value")] in

--- a/test/test_tools_coverage.ml
+++ b/test/test_tools_coverage.ml
@@ -338,6 +338,25 @@ let test_masc_operator_confirm_schema () =
             (List.mem (`String "confirm_token") reqs)
       | None -> Alcotest.fail "masc_operator_confirm missing required field"
 
+let test_masc_room_strategy_get_schema () =
+  match find_tool "masc_room_strategy_get" with
+  | None -> Alcotest.fail "masc_room_strategy_get not found"
+  | Some _ -> ()
+
+let test_masc_room_strategy_set_schema () =
+  match find_tool "masc_room_strategy_set" with
+  | None -> Alcotest.fail "masc_room_strategy_set not found"
+  | Some schema ->
+      match get_json_assoc "properties" schema.input_schema with
+      | Some props ->
+          Alcotest.(check bool) "has search_strategy_default" true
+            (List.mem_assoc "search_strategy_default" props);
+          Alcotest.(check bool) "has speculation_enabled" true
+            (List.mem_assoc "speculation_enabled" props);
+          Alcotest.(check bool) "has speculation_budget" true
+            (List.mem_assoc "speculation_budget" props)
+      | None -> Alcotest.fail "masc_room_strategy_set missing properties"
+
 
 
 
@@ -927,6 +946,8 @@ let () =
       Alcotest.test_case "remote_operator_action_strict" `Quick
         test_remote_operator_action_schema_is_strict;
       Alcotest.test_case "masc_operator_confirm" `Quick test_masc_operator_confirm_schema;
+      Alcotest.test_case "masc_room_strategy_get" `Quick test_masc_room_strategy_get_schema;
+      Alcotest.test_case "masc_room_strategy_set" `Quick test_masc_room_strategy_set_schema;
     ];
     "portal_tools", [
       Alcotest.test_case "portal_open" `Quick test_masc_portal_open_schema;


### PR DESCRIPTION
## Summary
- add explicit `masc_room_strategy_get/set` tools
- persist room-level search/speculation defaults in room state
- apply room default search strategy on operation start and add speculative selection as an opt-in best-first tie-breaker

## Validation
- `eval "$(opam env)" && dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/feat/room-strategy-speculation`
- `./_build/default/test/test_tool_room_coverage.exe`
- `./_build/default/test/test_tools_coverage.exe`
- `./_build/default/test/test_command_plane_v2.exe`