### PR TITLE
feat(operator): surface command-plane signals in operator digest

### DIFF
--- a/bin/main_eio.ml
+++ b/bin/main_eio.ml
@@ -5462,6 +5462,27 @@ let operator_snapshot_http_json ~state ~sw ~clock request =
   Operator_control.snapshot_json ?actor:(operator_actor_hint request)
     ~include_messages ~include_sessions ~include_keepers ctx
 
+let operator_digest_http_json ~state ~sw ~clock request =
+  let ctx : _ Operator_control.context =
+    {
+      config = state.Mcp_server.room_config;
+      agent_name = Option.value ~default:"dashboard" (operator_actor_hint request);
+      sw;
+      clock;
+      proc_mgr = state.Mcp_server.proc_mgr;
+      mcp_session_id = None;
+    }
+  in
+  let target_type = query_param request "target_type" in
+  let target_id = query_param request "target_id" in
+  let include_workers =
+    match query_param request "include_workers" with
+    | Some ("0" | "false" | "no") -> false
+    | _ -> true
+  in
+  Operator_control.digest_json ?actor:(operator_actor_hint request) ?target_type
+    ?target_id ~include_workers ctx
+
 let operator_action_http_json ~state ~sw ~clock request ~args =
   let ctx : _ Operator_control.context =
     {
@@ -9127,6 +9148,17 @@ let make_routes ~port ~host ~sw ~clock =
          Http.Response.json ~compress:true ~request:req (Yojson.Safe.to_string json) reqd
        ) request reqd)
 
+  |> Http.Router.get "/api/v1/operator/digest" (fun request reqd ->
+       with_public_read (fun state req reqd ->
+         match operator_digest_http_json ~state ~sw ~clock req with
+         | Ok json ->
+             Http.Response.json ~compress:true ~request:req
+               (Yojson.Safe.to_string json) reqd
+         | Error message ->
+             respond_json_with_cors ~status:`Bad_request request reqd
+               (Yojson.Safe.to_string (operator_error_json message))
+       ) request reqd)
+
   |> Http.Router.post "/api/v1/operator/action" (fun request reqd ->
        with_permission_auth ~permission:Types.CanBroadcast (fun state req reqd ->
          Http.Request.read_body_async reqd (fun body_str ->
@@ -10120,6 +10152,30 @@ let run_server ~sw ~env ~port ~base_path =
           else
             let json = operator_snapshot_http_json ~state ~sw ~clock httpun_request in
             h2_respond_json h2_reqd (Yojson.Safe.to_string json) ~extra_headers:cors
+      | `GET, "/api/v1/operator/digest" ->
+          let state = get_server_state () in
+          let path = Http.Request.path httpun_request in
+          if http_auth_strict_enabled () && not (is_public_read_path path) then
+            (match authorize_read_request ~base_path:state.Mcp_server.room_config.base_path httpun_request with
+             | Error err ->
+                 let status = http_status_of_auth_error err in
+                 h2_respond_json h2_reqd (auth_error_json err) ~status ~extra_headers:cors
+             | Ok () ->
+                 (match operator_digest_http_json ~state ~sw ~clock httpun_request with
+                  | Ok json ->
+                      h2_respond_json h2_reqd (Yojson.Safe.to_string json) ~extra_headers:cors
+                  | Error message ->
+                      h2_respond_json h2_reqd
+                        (Yojson.Safe.to_string (operator_error_json message))
+                        ~status:`Bad_request ~extra_headers:cors))
+          else
+            (match operator_digest_http_json ~state ~sw ~clock httpun_request with
+             | Ok json ->
+                 h2_respond_json h2_reqd (Yojson.Safe.to_string json) ~extra_headers:cors
+             | Error message ->
+                 h2_respond_json h2_reqd
+                   (Yojson.Safe.to_string (operator_error_json message))
+                   ~status:`Bad_request ~extra_headers:cors)
       | `GET, "/api/v1/status" ->
           let state = get_server_state () in
           let config = state.Mcp_server.room_config in

--- a/dashboard/src/api.ts
+++ b/dashboard/src/api.ts
@@ -18,6 +18,7 @@ import type {
   BoardSortMode,
   OperatorActionRequest,
   OperatorActionResult,
+  OperatorDigest,
   OperatorSnapshot,
   CommandPlaneHelpResponse,
   CommandPlaneChainRunResponse,
@@ -349,6 +350,19 @@ export function fetchMdalLoops(options: FetchMdalLoopsOptions = {}): Promise<Mda
 
 export function fetchOperatorSnapshot(): Promise<OperatorSnapshot> {
   return get('/api/v1/operator')
+}
+
+export function fetchOperatorDigest(
+  targetType: 'room' | 'team_session' = 'room',
+  targetId?: string,
+  includeWorkers = true,
+): Promise<OperatorDigest> {
+  const params = new URLSearchParams()
+  params.set('target_type', targetType)
+  if (targetId) params.set('target_id', targetId)
+  if (!includeWorkers) params.set('include_workers', 'false')
+  const query = params.toString()
+  return get(`/api/v1/operator/digest${query ? `?${query}` : ''}`)
 }
 
 export function fetchCommandPlaneSnapshot(): Promise<CommandPlaneSnapshot> {

--- a/dashboard/src/command-store.ts
+++ b/dashboard/src/command-store.ts
@@ -767,7 +767,7 @@ function normalizeSnapshot(raw: unknown): CommandPlaneSnapshot {
   }
 }
 
-function normalizeSummarySnapshot(raw: unknown): CommandPlaneSummarySnapshot {
+export function normalizeSummarySnapshot(raw: unknown): CommandPlaneSummarySnapshot {
   const root = isRecord(raw) ? raw : {}
   const topology = normalizeTopology(root.topology)
   const operations = normalizeOperations(root.operations)

--- a/dashboard/src/components/ops.ts
+++ b/dashboard/src/components/ops.ts
@@ -6,6 +6,7 @@ import {
   confirmOperatorPendingAction,
   dispatchOperatorAction,
   operatorActionBusy,
+  operatorDigest,
   operatorActionLog,
   operatorError,
   operatorLoading,
@@ -76,6 +77,15 @@ interface OpsPriorityCardData {
 
 function normalizeStatus(value: unknown): string {
   return typeof value === 'string' ? value.trim().toLowerCase() : ''
+}
+
+function signalTone(value?: { tone?: string }): OpsPriorityTone {
+  return value?.tone === 'bad' ? 'bad' : value?.tone === 'warn' ? 'warn' : 'ok'
+}
+
+function metricText(value?: number, suffix = ''): string {
+  if (typeof value !== 'number' || !Number.isFinite(value)) return 'n/a'
+  return `${Math.round(value)}${suffix}`
 }
 
 function sessionPriorityTone(session: OperatorSessionSnapshot): OpsPriorityTone {
@@ -254,6 +264,7 @@ async function confirmPending(confirmToken: string) {
 
 export function Ops() {
   const snapshot = operatorSnapshot.value
+  const digest = operatorDigest.value
   const room = snapshot?.room ?? {}
   const sessions = snapshot?.sessions ?? []
   const keepers = snapshot?.keepers ?? []
@@ -264,6 +275,14 @@ export function Ops() {
   const flaggedSessions = sessions.filter(session => sessionPriorityTone(session) !== 'ok')
   const flaggedKeepers = keepers.filter(keeper => keeperPriorityTone(keeper) !== 'ok')
   const roomFeed = recentMessages.slice(0, 5)
+  const commandPlane = digest?.command_plane
+  const microarch = commandPlane?.operations.microarch
+  const signals = microarch?.signals
+  const issuePressure = signals?.issue_pressure
+  const routingConfidence = signals?.routing_confidence
+  const cacheContention = signals?.cache_contention
+  const speculativePosture = signals?.speculative_posture
+  const digestAttention = digest?.attention_items ?? []
   const priorityCards: OpsPriorityCardData[] = [
     {
       key: 'room',
@@ -300,6 +319,44 @@ export function Ops() {
         ? 'At least one keeper is stale, offline, or running hot'
         : 'Keepers are available for direct intervention',
       tone: flaggedKeepers.some(keeper => keeperPriorityTone(keeper) === 'bad') ? 'bad' : flaggedKeepers.length > 0 ? 'warn' : 'ok',
+    },
+    {
+      key: 'issue-pressure',
+      label: 'Issue Pressure',
+      value: typeof issuePressure?.pending_ops === 'number' && typeof issuePressure?.blocked_ops === 'number'
+        ? issuePressure.pending_ops + issuePressure.blocked_ops
+        : 'n/a',
+      detail: issuePressure
+        ? `${metricText(issuePressure.pending_ops)} pending · ${metricText(issuePressure.blocked_ops)} blocked`
+        : 'Command-plane pressure signal not available',
+      tone: signalTone(issuePressure),
+    },
+    {
+      key: 'routing',
+      label: 'Routing Confidence',
+      value: metricText(routingConfidence?.avg_best_score, '%'),
+      detail: routingConfidence
+        ? `${metricText(routingConfidence.avg_candidate_count)} avg candidates · ${metricText(routingConfidence.best_first_operations)} best-first ops`
+        : 'Routing confidence signal not available',
+      tone: signalTone(routingConfidence),
+    },
+    {
+      key: 'cache',
+      label: 'Cache Contention',
+      value: metricText(cacheContention?.bus_traffic),
+      detail: cacheContention
+        ? `${metricText((cacheContention.l1_hit_rate ?? 0) * 100, '%')} L1 hit · ${metricText(cacheContention.invalidation_count)} invalidations`
+        : 'Cache contention signal not available',
+      tone: signalTone(cacheContention),
+    },
+    {
+      key: 'speculative',
+      label: 'Speculative Posture',
+      value: metricText(speculativePosture?.active_sessions),
+      detail: speculativePosture
+        ? `${metricText((speculativePosture.commit_rate ?? 0) * 100, '%')} commit rate`
+        : 'Speculative posture signal not available',
+      tone: signalTone(speculativePosture),
     },
   ]
 
@@ -347,6 +404,46 @@ export function Ops() {
           `)}
         </div>
       </section>
+
+      ${commandPlane ? html`
+        <section class="card ops-panel">
+          <div class="monitor-section-head">
+            <h2 class="monitor-headline">Command-Plane Readiness</h2>
+            <p class="monitor-subheadline">Operator digest now carries translated search and microarch signals so you can decide whether to intervene without opening the full command-plane surface.</p>
+          </div>
+          <div class="ops-stat-grid">
+            <div class="ops-stat ${signalTone(issuePressure)}">
+              <span>Issue Pressure</span>
+              <strong>${priorityCards.find(card => card.key === 'issue-pressure')?.value ?? 'n/a'}</strong>
+            </div>
+            <div class="ops-stat ${signalTone(routingConfidence)}">
+              <span>Routing</span>
+              <strong>${priorityCards.find(card => card.key === 'routing')?.value ?? 'n/a'}</strong>
+            </div>
+            <div class="ops-stat ${signalTone(cacheContention)}">
+              <span>Cache</span>
+              <strong>${priorityCards.find(card => card.key === 'cache')?.value ?? 'n/a'}</strong>
+            </div>
+            <div class="ops-stat ${signalTone(speculativePosture)}">
+              <span>Speculation</span>
+              <strong>${priorityCards.find(card => card.key === 'speculative')?.value ?? 'n/a'}</strong>
+            </div>
+          </div>
+          ${digestAttention.length > 0 ? html`
+            <div class="ops-feed-list">
+              ${digestAttention.slice(0, 4).map(item => html`
+                <article key=${item.kind} class="ops-feed-item">
+                  <div class="ops-feed-meta">
+                    <strong>${item.kind}</strong>
+                    <span>${item.severity ?? 'ok'}</span>
+                  </div>
+                  <div class="ops-feed-content">${item.summary ?? 'No summary available'}</div>
+                </article>
+              `)}
+            </div>
+          ` : html`<div class="ops-empty">No command-plane attention items right now.</div>`}
+        </section>
+      ` : null}
 
       ${pendingConfirms.length > 0 ? html`
         <section class="card ops-confirmations">

--- a/dashboard/src/operator-store.ts
+++ b/dashboard/src/operator-store.ts
@@ -1,10 +1,14 @@
 import { signal } from '@preact/signals'
-import { confirmOperatorAction, fetchOperatorSnapshot, runOperatorAction } from './api'
+import { confirmOperatorAction, fetchOperatorDigest, fetchOperatorSnapshot, runOperatorAction } from './api'
+import { normalizeSummarySnapshot } from './command-store'
 import type {
+  CommandPlaneSummarySnapshot,
   Message,
   OperatorActionLogEntry,
   OperatorActionRequest,
   OperatorActionResult,
+  OperatorAttentionItem,
+  OperatorDigest,
   OperatorKeeperSnapshot,
   OperatorSessionSnapshot,
   OperatorSnapshot,
@@ -13,6 +17,7 @@ import type {
 } from './types'
 
 export const operatorSnapshot = signal<OperatorSnapshot | null>(null)
+export const operatorDigest = signal<OperatorDigest | null>(null)
 export const operatorLoading = signal(false)
 export const operatorError = signal<string | null>(null)
 export const operatorActionBusy = signal(false)
@@ -186,6 +191,64 @@ function normalizeOperatorSnapshot(raw: unknown): OperatorSnapshot {
   }
 }
 
+function normalizeAttentionItem(raw: unknown): OperatorAttentionItem | null {
+  if (!isRecord(raw)) return null
+  const kind = asString(raw.kind)
+  if (!kind) return null
+  return {
+    kind,
+    severity: asString(raw.severity),
+    summary: asString(raw.summary),
+    target_type: asString(raw.target_type),
+    target_id: asString(raw.target_id) ?? null,
+    actor: asString(raw.actor) ?? null,
+    evidence: raw.evidence,
+  }
+}
+
+function normalizeAttentionSummary(raw: unknown) {
+  if (!isRecord(raw)) return undefined
+  return {
+    count: asNumber(raw.count),
+    bad_count: asNumber(raw.bad_count),
+    warn_count: asNumber(raw.warn_count),
+    top_item: normalizeAttentionItem(raw.top_item),
+  }
+}
+
+function normalizeRecommendationSummary(raw: unknown) {
+  if (!isRecord(raw)) return undefined
+  return {
+    count: asNumber(raw.count),
+    top_action: raw.top_action,
+  }
+}
+
+function normalizeCommandPlaneSummary(raw: unknown): CommandPlaneSummarySnapshot | undefined {
+  if (!isRecord(raw)) return undefined
+  return normalizeSummarySnapshot(raw)
+}
+
+function normalizeOperatorDigest(raw: unknown): OperatorDigest {
+  const root = isRecord(raw) ? raw : {}
+  return {
+    target_type: asString(root.target_type),
+    target_id: asString(root.target_id) ?? null,
+    health: asString(root.health),
+    swarm_status: isRecord(root.swarm_status)
+      ? (root.swarm_status as unknown as OperatorDigest['swarm_status'])
+      : undefined,
+    command_plane: normalizeCommandPlaneSummary(root.command_plane),
+    attention_items: extractArray(root.attention_items).map(normalizeAttentionItem)
+      .filter((item): item is OperatorAttentionItem => item !== null),
+    attention_summary: normalizeAttentionSummary(root.attention_summary),
+    recommended_actions: extractArray(root.recommended_actions),
+    recommendation_summary: normalizeRecommendationSummary(root.recommendation_summary),
+    session_cards: extractArray(root.session_cards).filter(isRecord),
+    worker_cards: extractArray(root.worker_cards).filter(isRecord),
+  }
+}
+
 function stringifyUnknown(value: unknown): string {
   if (typeof value === 'string') return value
   if (value === null || value === undefined) return ''
@@ -225,8 +288,12 @@ export async function refreshOperatorSnapshot(): Promise<void> {
   operatorLoading.value = true
   operatorError.value = null
   try {
-    const raw = await fetchOperatorSnapshot()
-    operatorSnapshot.value = normalizeOperatorSnapshot(raw)
+    const [snapshotRaw, digestRaw] = await Promise.all([
+      fetchOperatorSnapshot(),
+      fetchOperatorDigest(),
+    ])
+    operatorSnapshot.value = normalizeOperatorSnapshot(snapshotRaw)
+    operatorDigest.value = normalizeOperatorDigest(digestRaw)
   } catch (err) {
     operatorError.value = err instanceof Error ? err.message : 'Failed to load operator snapshot'
   } finally {

--- a/dashboard/src/types.ts
+++ b/dashboard/src/types.ts
@@ -689,6 +689,42 @@ export interface OperatorActionDescriptor {
   confirm_required?: boolean
 }
 
+export interface OperatorAttentionItem {
+  kind: string
+  severity?: string
+  summary?: string
+  target_type?: string
+  target_id?: string | null
+  actor?: string | null
+  evidence?: unknown
+}
+
+export interface OperatorRecommendationSummary {
+  count?: number
+  top_action?: unknown
+}
+
+export interface OperatorAttentionSummary {
+  count?: number
+  bad_count?: number
+  warn_count?: number
+  top_item?: OperatorAttentionItem | null
+}
+
+export interface OperatorDigest {
+  target_type?: string
+  target_id?: string | null
+  health?: string
+  swarm_status?: CommandPlaneSwarmStatus
+  command_plane?: CommandPlaneSummarySnapshot
+  attention_items: OperatorAttentionItem[]
+  attention_summary?: OperatorAttentionSummary
+  recommended_actions: unknown[]
+  recommendation_summary?: OperatorRecommendationSummary
+  session_cards: Record<string, unknown>[]
+  worker_cards: Record<string, unknown>[]
+}
+
 export interface KeeperProbeResult {
   status?: unknown
   diagnostic?: KeeperDiagnostic | null

--- a/docs/COMMAND-PLANE-RUNBOOK.md
+++ b/docs/COMMAND-PLANE-RUNBOOK.md
@@ -222,9 +222,12 @@ Content-Type: application/json
 - [SWARM-DELIVERY-RUNBOOK.md](./SWARM-DELIVERY-RUNBOOK.md)
 
 1. `masc_operator_snapshot`
-2. `masc_operator_action`
-3. `masc_operator_confirm`
-4. 필요 시 `masc_team_session_events`
+2. `masc_operator_digest`
+   - room/team-session 상태를 operator-friendly하게 요약한다.
+   - command-plane search/microarch signal은 여기서 먼저 읽고, 더 자세한 정보가 필요할 때만 full command-plane surface로 내려간다.
+3. `masc_operator_action`
+4. `masc_operator_confirm`
+5. 필요 시 `masc_team_session_events`
 
 언제 쓰나:
 

--- a/docs/MERGED-ARCHITECTURE-SSOT.md
+++ b/docs/MERGED-ARCHITECTURE-SSOT.md
@@ -30,6 +30,7 @@
 
 - 대상: planner / implementer / supervisor workflow
 - 핵심 도구: `masc_team_session_*`, `masc_operator_*`
+- operator-facing digest는 command-plane/search/microarch 신호를 번역해 노출하는 canonical intervention surface다.
 - SSOT 문서:
   - [SWARM-DELIVERY-RUNBOOK.md](./SWARM-DELIVERY-RUNBOOK.md)
   - [SUPERVISOR-MODE.md](./SUPERVISOR-MODE.md)

--- a/docs/SEARCH-FABRIC-V1.md
+++ b/docs/SEARCH-FABRIC-V1.md
@@ -59,6 +59,10 @@
 - `search.candidates`
 - `search.dependency_blockers`
 
+Operator-facing 요약은 `masc_operator_digest`와 dashboard `Ops`에서 번역된 signal로 본다.
+기본 surface는 `routing confidence`, `issue pressure`, `scheduler efficiency`, `cache contention` 같은 운영 의미를 사용하고,
+`RISC/MESI/MCTS` raw 용어는 detail/diagnostic에서만 본다.
+
 ## Benchmark
 
 Synthetic comparison executable:

--- a/lib/operator_control.ml
+++ b/lib/operator_control.ml
@@ -1678,24 +1678,120 @@ let build_session_digest config (session : Team_session_types.session) ~now =
   }
 
 let build_room_attention_items config =
-  let pending_confirms = read_pending_confirms config in
-  if pending_confirms = [] then []
-  else
+  let command_plane_summary = Command_plane_v2.summary_json config in
+  let microarch_signals =
+    command_plane_summary
+    |> U.member "operations"
+    |> U.member "microarch"
+    |> U.member "signals"
+  in
+  let signal_items =
     [
-      {
-        kind = "pending_confirm_waiting";
-        severity = "warn";
-        summary =
-          Printf.sprintf "%d pending confirmation(s) are waiting for operator input"
-            (List.length pending_confirms);
-        target_type = "room";
-        target_id = None;
-        actor = None;
-        evidence = `Assoc [ ("count", `Int (List.length pending_confirms)) ];
-      };
+      ( "command_issue_pressure",
+        "command-plane issue pressure is elevated",
+        microarch_signals |> U.member "issue_pressure" );
+      ( "command_cache_contention",
+        "command-plane cache contention is elevated",
+        microarch_signals |> U.member "cache_contention" );
+      ( "command_scheduler_efficiency",
+        "command-plane scheduler efficiency is degraded",
+        microarch_signals |> U.member "scheduler_efficiency" );
+      ( "command_routing_confidence",
+        "command-plane routing confidence is degraded",
+        microarch_signals |> U.member "routing_confidence" );
+      ( "command_speculative_posture",
+        "command-plane speculative posture needs review",
+        microarch_signals |> U.member "speculative_posture" );
     ]
+    |> List.filter_map (fun (kind, summary, signal_json) ->
+           match signal_json |> U.member "tone" with
+           | `String "warn" ->
+               Some
+                 {
+                   kind;
+                   severity = "warn";
+                   summary;
+                   target_type = "room";
+                   target_id = None;
+                   actor = None;
+                   evidence = signal_json;
+                 }
+           | `String "bad" ->
+               Some
+                 {
+                   kind;
+                   severity = "bad";
+                   summary;
+                   target_type = "room";
+                   target_id = None;
+                   actor = None;
+                   evidence = signal_json;
+                 }
+           | _ -> None)
+  in
+  let pending_confirms = read_pending_confirms config in
+  let pending_items =
+    if pending_confirms = [] then []
+    else
+      [
+        {
+          kind = "pending_confirm_waiting";
+          severity = "warn";
+          summary =
+            Printf.sprintf "%d pending confirmation(s) are waiting for operator input"
+              (List.length pending_confirms);
+          target_type = "room";
+          target_id = None;
+          actor = None;
+          evidence = `Assoc [ ("count", `Int (List.length pending_confirms)) ];
+        };
+      ]
+  in
+  List.sort compare_attention (pending_items @ signal_items)
 
-let room_recommendations _config = []
+let room_recommendations config =
+  let command_plane_summary = Command_plane_v2.summary_json config in
+  let microarch_signals =
+    command_plane_summary
+    |> U.member "operations"
+    |> U.member "microarch"
+    |> U.member "signals"
+  in
+  let signal_recommendations =
+    [
+      ( microarch_signals |> U.member "issue_pressure",
+        "broadcast",
+        "command-plane issue pressure is elevated",
+        "[operator] Issue pressure is elevated. Inspect blocked operations, run a dispatch tick, and checkpoint or finalize stale work." );
+      ( microarch_signals |> U.member "routing_confidence",
+        "broadcast",
+        "command-plane routing confidence is degraded",
+        "[operator] Routing confidence is low. Inspect candidate scoring and avoid risky manual rebalance until blockers clear." );
+      ( microarch_signals |> U.member "cache_contention",
+        "broadcast",
+        "command-plane cache contention is elevated",
+        "[operator] Cache contention is elevated. Reduce concurrent hot lanes or rebalance worker placement before scaling further." );
+      ( microarch_signals |> U.member "speculative_posture",
+        "broadcast",
+        "command-plane speculative posture needs review",
+        "[operator] Speculative posture is unstable. Review commit and abort rates before widening speculation." );
+    ]
+    |> List.filter_map
+         (fun (signal_json, action_type, reason, message) ->
+           match signal_json |> U.member "tone" with
+           | `String ("warn" | "bad" as severity) ->
+               Some
+                 {
+                   action_type;
+                   target_type = "room";
+                   target_id = None;
+                   severity;
+                   reason;
+                   suggested_payload = `Assoc [ ("message", `String message) ];
+                 }
+           | _ -> None)
+  in
+  dedup_recommendations signal_recommendations
 
 type snapshot_view =
   | Summary
@@ -1817,9 +1913,12 @@ let digest_json ?actor ?target_type ?target_id ?include_workers (ctx : 'a contex
           ("target_type", `String "room");
           ("target_id", `Null);
           ("health", `String "ok");
+          ("command_plane", `Assoc []);
           ("swarm_status", Swarm_status.empty_json);
           ("attention_items", `List []);
+          ("attention_summary", summary_of_attention_items []);
           ("recommended_actions", `List []);
+          ("recommendation_summary", summary_of_recommendations ~actor:"dashboard" []);
           ("session_cards", `List []);
           ("worker_cards", `List []);
         ])
@@ -1828,9 +1927,10 @@ let digest_json ?actor ?target_type ?target_id ?include_workers (ctx : 'a contex
     let* target_type = normalize_digest_target_type target_type in
     let now = Time_compat.now () in
     let tracked_sessions = Team_session_store.list_sessions config in
-    let command_plane_json = Command_plane_v2.snapshot_json config in
+    let command_plane_snapshot_json = Command_plane_v2.snapshot_json config in
+    let command_plane_digest_json = Command_plane_v2.summary_json config in
     let swarm_status_json =
-      Swarm_status.build_json_from_snapshot config command_plane_json
+      Swarm_status.build_json_from_snapshot config command_plane_snapshot_json
     in
     match target_type with
     | "room" ->
@@ -1860,6 +1960,7 @@ let digest_json ?actor ?target_type ?target_id ?include_workers (ctx : 'a contex
               ("target_type", `String "room");
               ("target_id", `Null);
               ("health", `String (health_from_attention_items attention_items));
+              ("command_plane", command_plane_digest_json);
               ("swarm_status", swarm_status_json);
               ("role_census", aggregate_worker_class_counts tracked_sessions);
               ("runtime_pools", aggregate_runtime_pool_counts tracked_sessions);
@@ -1871,10 +1972,13 @@ let digest_json ?actor ?target_type ?target_id ?include_workers (ctx : 'a contex
               ("escalation_count", `Int (aggregate_escalation_count tracked_sessions));
               ("local_runtime", aggregated_local_runtime_json tracked_sessions);
               ("attention_items", `List (List.map attention_item_to_yojson attention_items));
+              ("attention_summary", summary_of_attention_items attention_items);
               ( "recommended_actions",
                 `List
                   (List.map (recommended_action_to_yojson ~actor:actor_name)
                      recommended_actions) );
+              ( "recommendation_summary",
+                summary_of_recommendations ~actor:actor_name recommended_actions );
               ( "session_cards",
                 `List
                   (List.map (session_card_to_yojson ~actor:actor_name) limited_sessions)
@@ -1905,15 +2009,20 @@ let digest_json ?actor ?target_type ?target_id ?include_workers (ctx : 'a contex
                       ("target_type", `String "team_session");
                       ("target_id", `String session_id);
                       ("health", `String digest.health);
+                      ("command_plane", command_plane_digest_json);
                       ("swarm_status", swarm_status_json);
                       ( "attention_items",
                         `List
                           (List.map attention_item_to_yojson digest.attention_items)
                       );
+                      ("attention_summary", summary_of_attention_items digest.attention_items);
                       ( "recommended_actions",
                         `List
                           (List.map (recommended_action_to_yojson ~actor:actor_name)
                              digest.recommended_actions) );
+                      ( "recommendation_summary",
+                        summary_of_recommendations ~actor:actor_name
+                          digest.recommended_actions );
                       ("session_cards", `List [ session_card_to_yojson ~actor:actor_name digest ]);
                       ("worker_cards", `List (List.map worker_card_to_yojson worker_cards));
                     ])))

--- a/lib/tool_operator.ml
+++ b/lib/tool_operator.ml
@@ -67,9 +67,9 @@ let digest_schema ~remote =
     name = "masc_operator_digest";
     description =
       if remote then
-        "Read an intervention-oriented operator digest. Use this when you need health, attention items, worker summaries, and recommended next actions before deciding how to intervene."
+        "Read an intervention-oriented operator digest. Use this when you need room or team-session health, attention items, command-plane search or microarch signals, worker summaries, and recommended next actions before deciding how to intervene."
       else
-        "Read a high-signal operator digest with intervention recommendations for the room or a specific team session. Use this when raw snapshot data is too low-level for fast supervision.";
+        "Read a high-signal operator digest with intervention recommendations for the room or a specific team session. Use this when raw snapshot data is too low-level for fast supervision and you want translated command-plane search or microarch signals.";
     input_schema =
       `Assoc
         [

--- a/test/test_operator_control.ml
+++ b/test/test_operator_control.ml
@@ -140,8 +140,14 @@ let test_digest_room_exposes_pending_confirm_attention () =
       in
       Alcotest.(check string) "target_type" "room"
         Yojson.Safe.Util.(digest |> member "target_type" |> to_string);
-      Alcotest.(check string) "health" "warn"
+      Alcotest.(check string) "health" "bad"
         Yojson.Safe.Util.(digest |> member "health" |> to_string);
+      Alcotest.(check bool) "command_plane present" true
+        (Yojson.Safe.Util.member "command_plane" digest <> `Null);
+      Alcotest.(check bool) "command_plane microarch present" true
+        (Yojson.Safe.Util.(digest |> member "command_plane" |> member "operations"
+         |> member "microarch")
+         <> `Null);
       Alcotest.(check bool) "swarm_status present" true
         (Yojson.Safe.Util.member "swarm_status" digest <> `Null);
       let attention_items = Yojson.Safe.Util.(digest |> member "attention_items" |> to_list) in
@@ -150,7 +156,15 @@ let test_digest_room_exposes_pending_confirm_attention () =
            (fun item ->
              Yojson.Safe.Util.(item |> member "kind" |> to_string)
              = "pending_confirm_waiting")
-           attention_items))
+           attention_items);
+      Alcotest.(check bool) "command attention present" true
+        (List.exists
+           (fun item ->
+             String.starts_with
+               ~prefix:"command_"
+               Yojson.Safe.Util.(item |> member "kind" |> to_string))
+           attention_items)
+    )
 
 let test_digest_team_session_shape () =
   Eio_main.run @@ fun env ->
@@ -178,6 +192,8 @@ let test_digest_team_session_shape () =
         Yojson.Safe.Util.(digest |> member "target_id" |> to_string);
       Alcotest.(check bool) "swarm_status present" true
         (Yojson.Safe.Util.member "swarm_status" digest <> `Null);
+      Alcotest.(check bool) "command_plane present" true
+        (Yojson.Safe.Util.member "command_plane" digest <> `Null);
       Alcotest.(check int) "single session card" 1
         Yojson.Safe.Util.(digest |> member "session_cards" |> to_list |> List.length);
       Alcotest.(check bool) "worker_cards list" true

--- a/test/test_operator_mcp_e2e.ml
+++ b/test/test_operator_mcp_e2e.ml
@@ -616,6 +616,8 @@ let test_operator_mcp_supervises_team_session () =
     (match digest_result |> U.member "attention_items" with `List _ -> true | _ -> false);
   check bool "digest recommendation array" true
     (match digest_result |> U.member "recommended_actions" with `List _ -> true | _ -> false);
+  check bool "digest command plane" true
+    (digest_result |> U.member "command_plane" <> `Null);
 
   let note_json =
     call_tool ~token:supervisor_token ~path:"/mcp/operator"


### PR DESCRIPTION
## Summary
- add `/api/v1/operator/digest` and include command-plane summary + translated microarch/search signals
- surface the digest in the dashboard Ops view
- tighten tool/docs descriptions around operator digest and command-plane observability

## Validation
- `eval "$(opam env)" && dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/feat-operator-microarch-digest`
- `./_build/default/test/test_operator_control.exe`
- `./_build/default/test/test_tools_coverage.exe`
- `./_build/default/test/test_mcp_server_eio.exe`

## Notes
- `dashboard` TypeScript baseline already has pre-existing `mermaid` typing errors on `main`.
- `test_operator_mcp_e2e.exe` currently fails on `main`-level init preconditions (`masc_join` before `masc_init`), unchanged by this branch.