### PR TITLE
security: remove tracked launchd secrets

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -85,10 +85,13 @@ Heartbeat의 LLM 호출 순서:
 | Cloudflare Tunnel | `com.jeongsik.masc-cloudflared` | — |
 
 ### launchd 환경변수 필수
-plist `EnvironmentVariables`에 반드시 포함:
-- `GRAPHQL_API_KEY` — GraphQL 인증
-- `SSL_CERT_FILE` — TLS 인증서 경로
-- `MASC_ORCHESTRATOR_ENABLED=0` — Orchestrator 비활성화 (EADDRINUSE 방지)
+- 비밀값은 tracked plist에 넣지 않는다.
+- `start-masc-mcp.sh`가 launchd 시작 시 `~/.zshenv`를 읽어서 `GRAPHQL_API_KEY`와 각종 OAuth/API 토큰을 주입한다.
+- plist `EnvironmentVariables`에는 비밀이 아닌 기본값만 둔다.
+- 유지해야 하는 plist 기본값:
+  - `SSL_CERT_FILE` — TLS 인증서 경로
+  - `MASC_ORCHESTRATOR_ENABLED=0` — Orchestrator 비활성화 (EADDRINUSE 방지)
+  - `MASC_MCP_PORT`, `MASC_BASE_PATH`, `PATH` — launchd 런타임 기본값
 
 ### 관리 명령
 ```bash

--- a/infrastructure/launchd/com.jeong-sik.masc-mcp.plist
+++ b/infrastructure/launchd/com.jeong-sik.masc-mcp.plist
@@ -52,20 +52,10 @@
         <string>180</string>
         <key>MASC_ZOMBIE_CLEANUP_INTERVAL_SEC</key>
         <string>30</string>
-        <key>GRAPHQL_API_KEY</key>
-        <string>Cuovi59bsPTt9+J+NCqBM+5Sks9fHuCuVhBhT+oI+2A=</string>
         <key>SSL_CERT_FILE</key>
         <string>/opt/homebrew/etc/ca-certificates/cert.pem</string>
         <key>SSL_CERT_DIR</key>
         <string>/etc/ssl/certs</string>
-        <key>CLAUDE_CODE_OAUTH_TOKEN_anyang</key>
-        <string>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</string>
-        <key>CLAUDE_CODE_OAUTH_TOKEN_for</key>
-        <string>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</string>
-        <key>CLAUDE_CODE_OAUTH_TOKEN_kidsnote</key>
-        <string>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</string>
-        <key>CLAUDE_CODE_OAUTH_TOKEN_yhhjsjmk</key>
-        <string>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</string>
     </dict>
 
     <key>WorkingDirectory</key>

--- a/start-masc-mcp.sh
+++ b/start-masc-mcp.sh
@@ -22,7 +22,7 @@ fi
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cd "$SCRIPT_DIR"
 
-# Load API keys from user profile (launchd doesn't inherit shell env)
+# Load secrets from the user profile; tracked plist files must not embed them.
 if [ -f "$HOME/.zshenv" ]; then
     set -a; source "$HOME/.zshenv" 2>/dev/null || true; set +a
 fi


### PR DESCRIPTION
## Summary
- remove tracked launchd secrets from the plist
- load secrets from ~/.zshenv via start-masc-mcp.sh instead of tracked plist values
- document that tracked plist files must not contain secrets

## Validation
- plutil -lint infrastructure/launchd/com.jeong-sik.masc-mcp.plist
- bash -n start-masc-mcp.sh

## Note
- attempted history rewrite + force-push on main, but GitHub protected branch rules rejected force-push
- remote history still needs an admin-approved rewrite or temporary protection bypass to fully purge old objects