### PR TITLE
refactor: unify runtime llm cascade helpers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,7 +19,7 @@ Thumbs.db
 .masc/
 .worktrees/
 
-# LLM cascade config (contains env var names for API keys)
+# Local heartbeat model-pool override
 config/llm_cascade.json
 
 # Database files

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,7 +46,7 @@ lib/                    # Core library (~200 .ml files)
   env_config.ml         # Centralized env var management (12-Factor)
 bin/                    # Executable entry points
 config/
-  llm_cascade.json      # LLM cascade slot config (hot-reload every 60s)
+  llm_cascade.json      # Local heartbeat model-pool config (provider:model, hot-reload)
   lodge.env             # Heartbeat config (tick interval, quiet hours)
 test/                   # Test suite
 ```
@@ -88,12 +88,11 @@ let with_lodge_lock f =
   | Some mutex -> Eio.Mutex.use_rw ~protect:true mutex f
   | None -> f ()
 
-(* Correct: cascade slot config *)
-type cascade_slot = {
-  tool_name : string;
-  model : string;
-  key_env : string option;
-}
+(* Correct: local heartbeat model-pool config *)
+let heartbeat_action_models = [
+  "llama:qwen3.5-35b-a3b-ud-q8-xl";
+  "glm:glm-4.7";
+]
 ```
 
 ### Naming
@@ -167,7 +166,7 @@ dune build @check
 - Changes to `room.ml` state machine (affects all coordination)
 - Changes to `lodge_heartbeat.ml` tick logic (affects autonomous agents)
 - Adding new MCP tool registrations in `tools.ml`
-- Modifying `config/llm_cascade.json` slot ordering
+- Modifying `config/llm_cascade.json` model ordering
 - Changes to `board.ml` post ID generation (cryptographic)
 
 ### Never Do

--- a/lib/auto_responder.ml
+++ b/lib/auto_responder.ml
@@ -135,29 +135,49 @@ let run_cli_agent ~agent_type ~prompt =
   in
   debug_log (Printf.sprintf "SPAWN_DONE %s output=%s" status_s preview)
 
-(* --- LLM mode: direct call + in-process MASC HTTP tools/call --- *)
+(* --- LLM mode: shared cascade + in-process MASC HTTP tools/call --- *)
+
+let auto_responder_model_strings ~agent_type =
+  match agent_type with
+  | "claude" -> [ "claude:sonnet"; Printf.sprintf "glm:%s" Env_config.Llm.default_model ]
+  | "gemini" ->
+      [ "gemini:flash"; Printf.sprintf "glm:%s" Env_config.Llm.default_model ]
+  | "glm" -> [ Printf.sprintf "glm:%s" Env_config.Llm.default_model ]
+  | "codex" | "ollama" | _ ->
+      [
+        Printf.sprintf "ollama:%s" Env_config.Ollama.default_model;
+        Printf.sprintf "glm:%s" Env_config.Llm.default_model;
+      ]
+
+let available_model_specs_for_agent_type ~agent_type =
+  Llm_client.available_model_specs_of_strings
+    (auto_responder_model_strings ~agent_type)
+
+let llm_response_is_valid (resp : Llm_client.completion_response) =
+  let s = String.trim resp.content in
+  let s_lower = String.lowercase_ascii s in
+  let len = String.length s in
+  len > 0
+  && not (len >= 5 && String.sub s_lower 0 5 = "error")
+  && not (len >= 14 && String.sub s 0 14 = "Empty response")
+  && not (len >= 9 && String.sub s 0 9 = "{\"error\":")
 
 let call_llm_direct_sync ~agent_type ~prompt =
-  let tool_name =
-    match agent_type with
-    | "gemini" -> "glm" (* Gemini not directly supported, use GLM *)
-    | "claude" -> "claude-cli"
-    | "codex" -> "ollama" (* Codex not directly supported, use Ollama *)
-    | "glm" -> "glm"
-    | _ -> "ollama"
-  in
-  let model =
-    match tool_name with
-    | "glm" -> "glm-4.7"
-    | "ollama" -> Env_config.Ollama.default_model
-    | "claude-cli" -> "claude-sonnet-4-20250514"
-    | _ -> "glm-4-flash"
-  in
   try
-    let response =
-      Llm_direct.dispatch ~tool_name ~model ~prompt ~timeout_sec:30 ~max_chars:500 ()
-    in
-    if response = "" then "no response" else response
+    match
+      Llm_client.run_prompt_cascade ~timeout_sec:30
+        ~accept:llm_response_is_valid
+        ~model_specs:(available_model_specs_for_agent_type ~agent_type)
+        ~max_tokens:500 ~prompt ()
+    with
+    | Ok resp ->
+        debug_log
+          (Printf.sprintf "LLM_MODEL_USED %s for agent_type=%s" resp.model_used
+             agent_type);
+        if String.trim resp.content = "" then "no response" else resp.content
+    | Error err ->
+        Printf.eprintf "[auto_responder] LLM cascade failed: %s\n%!" err;
+        "no response"
   with exn ->
     Printf.eprintf "[auto_responder] LLM call failed: %s\n%!" (Printexc.to_string exn);
     "no response"
@@ -207,12 +227,19 @@ let masc_call ~sw ~tool_name ~(args : Yojson.Safe.t) : (string, string) result =
         Error (Printexc.to_string exn)
 
 let extract_nickname (response_text : string) : string option =
+  let prefix = "Nickname:" in
   let lines = String.split_on_char '\n' response_text in
   let rec find = function
     | [] -> None
     | line :: rest ->
-        if String.length line > 12 && String.sub line 0 10 = "  Nickname:" then
-          Some (String.trim (String.sub line 10 (String.length line - 10)))
+        let trimmed = String.trim line in
+        if String.length trimmed >= String.length prefix
+           && String.sub trimmed 0 (String.length prefix) = prefix
+        then
+          Some
+            (String.trim
+               (String.sub trimmed (String.length prefix)
+                  (String.length trimmed - String.length prefix)))
         else find rest
   in
   find lines
@@ -320,4 +347,3 @@ let maybe_respond ~sw ~base_path:_ ~from_agent ~content ~mention =
         );
         Some task_id
       )
-

--- a/lib/llm_client.ml
+++ b/lib/llm_client.ml
@@ -295,6 +295,8 @@ let completion_cache_key (req : completion_request) =
   let canonical = Yojson.Safe.to_string (completion_request_fingerprint_json req) in
   Llm_response_cache.make_key ~namespace:"llmresp" ~content:canonical
 
+let cache_key_of_request = completion_cache_key
+
 let token_usage_to_json (u : token_usage) : Yojson.Safe.t =
   `Assoc
     [
@@ -1063,7 +1065,8 @@ let complete ?timeout_sec ?ollama_timeout_sec (req : completion_request) : (comp
 (* Cascade: try models in order                                     *)
 (* ================================================================ *)
 
-let cascade ?timeout_sec ?ollama_timeout_sec (requests : completion_request list) : (completion_response, string) result =
+let cascade ?(accept = fun _ -> true) ?timeout_sec ?ollama_timeout_sec
+    (requests : completion_request list) : (completion_response, string) result =
   with_llm_permit (fun () ->
     let avail = Eio.Semaphore.get_value llm_semaphore in
     eprintf "[llm_client] cascade: acquired permit (%d/%d available)\n%!"
@@ -1099,9 +1102,15 @@ let cascade ?timeout_sec ?ollama_timeout_sec (requests : completion_request list
         in
         match attempt_result with
         | Ok resp ->
-          eprintf "[llm_client] cascade: success with %s (%dms)\n%!"
-            resp.model_used resp.latency_ms;
-          Ok resp
+          if accept resp then (
+            eprintf "[llm_client] cascade: success with %s (%dms)\n%!"
+              resp.model_used resp.latency_ms;
+            Ok resp)
+          else (
+            eprintf
+              "[llm_client] cascade: %s rejected by validator, continuing\n%!"
+              resp.model_used;
+            try_next ("response rejected by validator" :: errors) rest)
         | Error e ->
           eprintf "[llm_client] cascade: %s failed: %s\n%!"
             req.model.model_id e;
@@ -1202,3 +1211,40 @@ let default_local_model_spec () =
   match model_spec_of_string (Provider_adapter.default_local_model_label ()) with
   | Ok spec -> spec
   | Error _ -> ollama_glm
+
+let available_model_specs_of_strings model_strs =
+  model_strs
+  |> List.filter_map (fun model_str ->
+         match model_spec_of_string model_str with
+         | Error err ->
+             eprintf "[llm_client] ignoring invalid model spec %s: %s\n%!"
+               model_str err;
+             None
+         | Ok spec -> (
+             match spec.api_key_env with
+             | Some env_name ->
+                 let value = Sys.getenv_opt env_name |> Option.value ~default:"" in
+                 if String.trim value = "" then (
+                   eprintf "[llm_client] skipping %s: %s not set\n%!"
+                     model_str env_name;
+                   None)
+                 else Some spec
+             | None -> Some spec))
+
+let run_prompt_cascade ?(temperature = 0.7) ?timeout_sec ?ollama_timeout_sec
+    ?(accept = fun _ -> true) ~model_specs ~max_tokens ~prompt () =
+  let requests =
+    List.map
+      (fun (model : model_spec) ->
+        ({
+           model;
+           messages = [ user_msg prompt ];
+           temperature;
+           max_tokens;
+           tools = [];
+           response_format = `Text;
+         }
+          : completion_request))
+      model_specs
+  in
+  cascade ?timeout_sec ?ollama_timeout_sec ~accept requests

--- a/lib/llm_client.mli
+++ b/lib/llm_client.mli
@@ -109,12 +109,15 @@ val complete :
 
 (** Cascade — try models in order until one succeeds.
     Each request targets a different model. First success wins.
+    Optional [accept] can reject a syntactically successful response and force
+    the cascade to continue with the next model.
     Optional [timeout_sec] sets an overall wall-clock budget (seconds) for the
     full cascade. Remaining budget is applied per-attempt.
     Optional [ollama_timeout_sec] overrides Ollama request timeout (seconds)
     for all tries in this cascade.
     @return Ok response from first successful model, Error if all fail. *)
 val cascade :
+  ?accept:(completion_response -> bool) ->
   ?timeout_sec:int ->
   ?ollama_timeout_sec:int ->
   completion_request list ->
@@ -153,6 +156,26 @@ val tool_msg : name:string -> call_id:string -> string -> message
 
 (** Estimate token count for a message list (heuristic: ~4 chars per token). *)
 val estimate_tokens : message list -> int
+
+(** Parse model strings and keep only models that are callable in the current
+    environment. Invalid specs and specs with missing API keys are skipped. *)
+val available_model_specs_of_strings : string list -> model_spec list
+
+(** Run a text-only single-prompt cascade over an ordered model list. *)
+val run_prompt_cascade :
+  ?temperature:float ->
+  ?timeout_sec:int ->
+  ?ollama_timeout_sec:int ->
+  ?accept:(completion_response -> bool) ->
+  model_specs:model_spec list ->
+  max_tokens:int ->
+  prompt:string ->
+  unit ->
+  (completion_response, string) result
+
+(** Stable cache key for a completion request. Useful for cache inspection and
+    deterministic tests. *)
+val cache_key_of_request : completion_request -> string
 
 (** Parse model spec from string like "ollama:glm-4.7-flash:latest",
     "claude:opus", or "gemini:gemini-3-flash-preview".

--- a/lib/lodge_cascade.ml
+++ b/lib/lodge_cascade.ml
@@ -1,277 +1,118 @@
-(** Lodge Cascade — JSON-driven LLM cascade with strategy-aware routing.
+(** Lodge Cascade — local heartbeat model-pool loader.
 
-    Reads slot arrays from config/llm_cascade.json.
-    Each slot = (tool_name, model, api_key_env).
-    Claude slots are rotated round-robin across heartbeat ticks.
-    Config file is hot-reloaded by checking mtime every 60s.
+    Reads provider:model arrays from config/llm_cascade.json.
+    Entries requiring API keys are skipped when the key is not set.
+    Invalid entries are ignored with a warning.
 
-    Strategies:
-    - sequential: try slots in config order (default, current behavior)
-    - cost_optimized: reorder by cost tier ascending (cheapest first)
-    - quality_first: reorder by cost tier descending (strongest first) *)
+    The file is hot-reloaded via a simple mtime cache.
+    When the file or requested key is missing, built-in defaults are used. *)
 
 open Printf
 
-(* ---------- Types ---------- *)
-
-type cascade_slot = {
-  tool_name : string;    (* "glm", "ollama", "llama", "claude-cli" *)
-  model : string;        (* "glm-4.7", "glm-4.7-flash", "claude-sonnet-4-20250514" *)
-  key_env : string option; (* env var name for api_key, e.g. "CLAUDE_CODE_OAUTH_TOKEN_anyang" *)
-}
-
-(** Routing strategy for slot ordering *)
-type strategy =
-  | Sequential       (** Config order, Claude round-robin (default) *)
-  | Cost_optimized   (** Cheapest first: ollama(0) → glm(1) → claude(3) *)
-  | Quality_first    (** Strongest first: claude(3) → glm(1) → ollama(0) *)
-
-let strategy_of_string = function
-  | "cost_optimized" -> Cost_optimized
-  | "quality_first" -> Quality_first
-  | _ -> Sequential
-
-let string_of_strategy = function
-  | Sequential -> "sequential"
-  | Cost_optimized -> "cost_optimized"
-  | Quality_first -> "quality_first"
-
-(** Result of a cascade call, including which LLM was used *)
 type cascade_result = {
-  response : string;     (* LLM response text *)
-  llm_used : string;     (* e.g. "glm(glm-4.7)", "claude-cli(NG_TOKEN)" *)
-  duration_ms : int;     (* Time taken in milliseconds *)
+  response : string;
+  llm_used : string;
+  duration_ms : int;
 }
 
-(* ---------- Config Cache ---------- *)
-
-(* mtime-based cache: (path -> (mtime, parsed_json)) *)
 let config_cache : (string, float * Yojson.Safe.t) Hashtbl.t = Hashtbl.create 4
 
-(* Claude round-robin counter — persists for process lifetime (lock-free) *)
-let claude_rr_counter = Atomic.make 0
-
 let load_json_file path =
-  let st = Unix.stat path in
-  let mtime = st.Unix.st_mtime in
-  match Hashtbl.find_opt config_cache path with
-  | Some (cached_mtime, json) when Float.equal cached_mtime mtime -> json
-  | _ ->
-    let ic = open_in path in
-    Fun.protect ~finally:(fun () -> close_in_noerr ic) (fun () ->
-      let n = in_channel_length ic in
-      let buf = Bytes.create n in
-      really_input ic buf 0 n;
-      buf)
-    |> fun buf ->
-    let json = Yojson.Safe.from_string (Bytes.to_string buf) in
-    Hashtbl.replace config_cache path (mtime, json);
-    json
-
-(* ---------- Config Parsing ---------- *)
-
-let parse_slot (json : Yojson.Safe.t) : cascade_slot =
-  let open Yojson.Safe.Util in
-  let tool_name = json |> member "tool" |> to_string in
-  let model = json |> member "model" |> to_string in
-  let key_env = json |> member "key_env" |> to_string_option in
-  { tool_name; model; key_env }
-
-(** Parse cost_tiers from config: tool_name -> int cost tier *)
-let parse_cost_tiers (json : Yojson.Safe.t) : (string * int) list =
-  let open Yojson.Safe.Util in
-  match json |> member "cost_tiers" with
-  | `Assoc pairs ->
-    List.filter_map (fun (k, v) ->
-      match v with `Int n -> Some (k, n) | _ -> None
-    ) pairs
-  | _ -> [("ollama", 0); ("llama", 0); ("glm", 1); ("claude-cli", 3)]
-
-(** Parse per-cascade strategy from config *)
-let parse_strategy (json : Yojson.Safe.t) ~cascade_name : strategy =
-  let open Yojson.Safe.Util in
-  match json |> member "strategy" with
-  | `Assoc _ as strat ->
-    (match strat |> member cascade_name |> to_string_option with
-     | Some s -> strategy_of_string s
-     | None -> Sequential)
-  | `String s -> strategy_of_string s
-  | _ -> Sequential
-
-(** Reorder slots based on strategy and cost tiers *)
-let apply_strategy ~(strategy : strategy) ~(cost_tiers : (string * int) list)
-    (slots : cascade_slot list) : cascade_slot list =
-  match strategy with
-  | Sequential -> slots  (* Config order, unchanged *)
-  | Cost_optimized ->
-    let cost_of s =
-      List.assoc_opt s.tool_name cost_tiers |> Option.value ~default:1
-    in
-    List.stable_sort (fun a b -> compare (cost_of a) (cost_of b)) slots
-  | Quality_first ->
-    let cost_of s =
-      List.assoc_opt s.tool_name cost_tiers |> Option.value ~default:1
-    in
-    List.stable_sort (fun a b -> compare (cost_of b) (cost_of a)) slots
-
-let load_cascade ~config_path ~cascade_name : cascade_slot list =
   try
-    let json = load_json_file config_path in
-    let open Yojson.Safe.Util in
-    let arr = json |> member cascade_name |> to_list in
-    List.map parse_slot arr
+    let st = Unix.stat path in
+    let mtime = st.Unix.st_mtime in
+    match Hashtbl.find_opt config_cache path with
+    | Some (cached_mtime, json) when Float.equal cached_mtime mtime -> Ok json
+    | _ ->
+        let ic = open_in path in
+        Fun.protect
+          ~finally:(fun () -> close_in_noerr ic)
+          (fun () ->
+            let n = in_channel_length ic in
+            let buf = Bytes.create n in
+            really_input ic buf 0 n;
+            let json = Yojson.Safe.from_string (Bytes.to_string buf) in
+            Hashtbl.replace config_cache path (mtime, json);
+            Ok json)
   with
-  | Sys_error msg ->
-    eprintf "[cascade] config load failed: %s — using empty cascade\n%!" msg;
-    []
-  | exn ->
-    eprintf "[cascade] config parse error: %s — using empty cascade\n%!" (Printexc.to_string exn);
-    []
-
-(** Load cascade with strategy applied *)
-let load_cascade_with_strategy ~config_path ~cascade_name : cascade_slot list =
-  try
-    let json = load_json_file config_path in
-    let open Yojson.Safe.Util in
-    let arr = json |> member cascade_name |> to_list in
-    let slots = List.map parse_slot arr in
-    let strategy = parse_strategy json ~cascade_name in
-    let cost_tiers = parse_cost_tiers json in
-    let reordered = apply_strategy ~strategy ~cost_tiers slots in
-    if strategy <> Sequential then
-      printf "[cascade] %s: strategy=%s, %d slots reordered\n%!"
-        cascade_name (string_of_strategy strategy) (List.length reordered);
-    reordered
-  with
-  | Sys_error msg ->
-    eprintf "[cascade] config load failed: %s — using empty cascade\n%!" msg;
-    []
-  | exn ->
-    eprintf "[cascade] config parse error: %s — using empty cascade\n%!" (Printexc.to_string exn);
-    []
-
-(* ---------- Slot Reordering (Claude Rotation) ---------- *)
-
-(** Partition slots into non-claude prefix, claude group, non-claude suffix.
-    Then rotate the claude group by the round-robin counter. *)
-let rotate_claude_slots (slots : cascade_slot list) : cascade_slot list =
-  (* Split into three groups: prefix (before first claude), claudes, suffix (after last claude) *)
-  let rec split_prefix acc = function
-    | [] -> (List.rev acc, [], [])
-    | s :: rest when s.tool_name = "claude-cli" ->
-      let claudes, suffix = split_claudes [s] rest in
-      (List.rev acc, claudes, suffix)
-    | s :: rest -> split_prefix (s :: acc) rest
-  and split_claudes acc = function
-    | [] -> (List.rev acc, [])
-    | s :: rest when s.tool_name = "claude-cli" ->
-      split_claudes (s :: acc) rest
-    | rest -> (List.rev acc, rest)
-  in
-  let prefix, claudes, suffix = split_prefix [] slots in
-  if List.length claudes <= 1 then slots  (* Nothing to rotate *)
-  else begin
-    let n = List.length claudes in
-    let offset = Atomic.fetch_and_add claude_rr_counter 1 mod n in
-    (* Rotate: drop first `offset` elements, append them at end *)
-    let arr = Array.of_list claudes in
-    let rotated = Array.init n (fun i -> arr.((i + offset) mod n)) in
-    prefix @ Array.to_list rotated @ suffix
-  end
-
-(* ---------- Cascade Execution ---------- *)
-
-(** Resolve env var name to its value at runtime. *)
-let resolve_key (key_env : string option) : string option =
-  match key_env with
-  | None -> None
-  | Some env_name -> Sys.getenv_opt env_name
-
-(** Run cascade with tracing: try each slot in order until one succeeds.
-    Returns cascade_result with response, LLM used, and duration.
-    @param slots Ordered list of cascade slots
-    @param prompt Prompt to send to LLM
-    @param timeout_sec Curl --max-time
-    @param max_chars Max response chars to keep
-    @param call_llm Function that actually invokes llm-mcp
-    @param is_valid Predicate to check if response is usable
-    @param agent_name For logging *)
-let run_cascade_traced
-    ~(slots : cascade_slot list)
-    ~(prompt : string)
-    ~(timeout_sec : int)
-    ~(max_chars : int)
-    ~(call_llm : tool_name:string -> extra_args:(string * Yojson.Safe.t) list -> prompt:string -> timeout_sec:int -> max_chars:int -> string)
-    ~(is_valid : string -> bool)
-    ~(agent_name : string)
-  : cascade_result =
-  let start_time = Time_compat.now () in
-  let rotated = rotate_claude_slots slots in
-  let rec try_slots = function
-    | [] ->
-      printf "   ❌ [%s] All LLMs failed, skipping\n%!" agent_name;
-      let duration_ms = int_of_float ((Time_compat.now () -. start_time) *. 1000.0) in
-      { response = ""; llm_used = "none"; duration_ms }
-    | slot :: rest ->
-      let extra_args =
-        let base = [("model", `String slot.model)] in
-        match resolve_key slot.key_env with
-        | Some k ->
-          printf "   🔑 [%s] api_key resolved for %s (%d chars)\n%!" agent_name
-            (Option.value ~default:"?" slot.key_env) (String.length k);
-          ("api_key", `String k) :: base
-        | None ->
-          (match slot.key_env with
-           | Some env -> printf "   ⚠️ [%s] env var %s NOT FOUND\n%!" agent_name env
-           | None -> ());
-          base
-      in
-      let label = match slot.key_env with
-        | Some env -> sprintf "%s(%s)" slot.tool_name (String.sub env (max 0 (String.length env - 8)) (min 8 (String.length env)))
-        | None -> slot.tool_name
-      in
-      printf "   🔍 [%s] trying %s...\n%!" agent_name label;
-      let r = call_llm ~tool_name:slot.tool_name ~extra_args ~prompt ~timeout_sec ~max_chars in
-      printf "   🔍 [%s] %s returned (%d chars)\n%!" agent_name label (String.length r);
-      if is_valid r then begin
-        printf "   🧠 [%s] %s: %s\n%!" agent_name label
-          (if String.length r > 80 then String.sub r 0 80 ^ "..." else r);
-        let duration_ms = int_of_float ((Time_compat.now () -. start_time) *. 1000.0) in
-        { response = r; llm_used = label; duration_ms }
-      end else begin
-        printf "   ⚠️ [%s] %s failed (%d chars), next...\n%!" agent_name label (String.length r);
-        try_slots rest
-      end
-  in
-  try_slots rotated
-
-(** Run cascade: try each slot in order until one succeeds.
-    Backward-compatible wrapper that returns only the response string.
-    @param slots Ordered list of cascade slots
-    @param prompt Prompt to send to LLM
-    @param timeout_sec Curl --max-time
-    @param max_chars Max response chars to keep
-    @param call_llm Function that actually invokes llm-mcp
-    @param is_valid Predicate to check if response is usable
-    @param agent_name For logging *)
-let run_cascade
-    ~(slots : cascade_slot list)
-    ~(prompt : string)
-    ~(timeout_sec : int)
-    ~(max_chars : int)
-    ~(call_llm : tool_name:string -> extra_args:(string * Yojson.Safe.t) list -> prompt:string -> timeout_sec:int -> max_chars:int -> string)
-    ~(is_valid : string -> bool)
-    ~(agent_name : string)
-  : string =
-  let result = run_cascade_traced ~slots ~prompt ~timeout_sec ~max_chars ~call_llm ~is_valid ~agent_name in
-  result.response
-
-(* ---------- Convenience: get_cascade (cached load + rotate) ---------- *)
+  | Sys_error msg -> Error msg
+  | Unix.Unix_error (err, fn, arg) ->
+      Error (Printf.sprintf "%s(%s): %s" fn arg (Unix.error_message err))
+  | exn -> Error (Printexc.to_string exn)
 
 let default_config_path () =
-  let me = Sys.getenv_opt "ME_ROOT" |> Option.value ~default:(Sys.getenv_opt "HOME" |> Option.value ~default:"/tmp") in
-  Filename.concat (Filename.concat me "workspace/yousleepwhen/masc-mcp") "config/llm_cascade.json"
+  let me =
+    Sys.getenv_opt "ME_ROOT"
+    |> Option.value
+         ~default:(Sys.getenv_opt "HOME" |> Option.value ~default:"/tmp")
+  in
+  Filename.concat
+    (Filename.concat me "workspace/yousleepwhen/masc-mcp")
+    "config/llm_cascade.json"
 
-let get_cascade ?(config_path = "") ~cascade_name () : cascade_slot list =
-  let path = if String.length config_path > 0 then config_path else default_config_path () in
-  load_cascade_with_strategy ~config_path:path ~cascade_name
+let default_model_strings ~cascade_name =
+  match cascade_name with
+  | "heartbeat_action" | "heartbeat_wake" ->
+      [
+        "llama:qwen3.5-35b-a3b-ud-q8-xl";
+        Printf.sprintf "glm:%s" Env_config.Llm.default_model;
+      ]
+  | _ -> []
+
+let model_key_of_cascade cascade_name = cascade_name ^ "_models"
+
+let read_model_strings ~config_path ~cascade_name =
+  let key = model_key_of_cascade cascade_name in
+  match load_json_file config_path with
+  | Error msg ->
+      eprintf
+        "[cascade] config load failed for %s: %s — using built-in defaults\n%!"
+        key msg;
+      default_model_strings ~cascade_name
+  | Ok json -> (
+      let open Yojson.Safe.Util in
+      match json |> member key with
+      | `List items ->
+          let parsed =
+            List.filter_map
+              (function
+                | `String s -> Some (String.trim s)
+                | other ->
+                    eprintf
+                      "[cascade] %s: ignoring non-string entry %s\n%!"
+                      key (Yojson.Safe.to_string other);
+                    None)
+              items
+          in
+          if parsed = [] then (
+            eprintf
+              "[cascade] %s: empty model list — using built-in defaults\n%!" key;
+            default_model_strings ~cascade_name)
+          else parsed
+      | `Null ->
+          eprintf
+            "[cascade] %s not found in %s — using built-in defaults\n%!" key
+            config_path;
+          default_model_strings ~cascade_name
+      | other ->
+          eprintf
+            "[cascade] %s must be a string list, got %s — using built-in defaults\n%!"
+            key (Yojson.Safe.to_string other);
+          default_model_strings ~cascade_name)
+
+let get_cascade ?(config_path = "") ~cascade_name () :
+    Llm_client.model_spec list =
+  let path =
+    if String.length config_path > 0 then config_path else default_config_path ()
+  in
+  let configured = read_model_strings ~config_path:path ~cascade_name in
+  let specs = Llm_client.available_model_specs_of_strings configured in
+  if specs <> [] then specs
+  else
+    let defaults = default_model_strings ~cascade_name in
+    if configured = defaults then []
+    else (
+      eprintf
+        "[cascade] %s: configured models unavailable — retrying built-in defaults\n%!"
+        cascade_name;
+      Llm_client.available_model_specs_of_strings defaults)

--- a/lib/lodge_heartbeat.ml
+++ b/lib/lodge_heartbeat.ml
@@ -2125,54 +2125,52 @@ let tom_context_for_posts ~agent_name (posts : Board.post list) =
              (Lodge_tom.tom_prompt_section predictions)))
   |> String.concat "\n\n"
 
+let heartbeat_response_is_valid s =
+  let len = String.length s in
+  let s_lower = String.lowercase_ascii s in
+  len > 10
+  && not (len >= 5 && String.sub s_lower 0 5 = "error")
+  && not (len >= 14 && String.sub s 0 14 = "Empty response")
+  && not (len >= 9 && String.sub s 0 9 = "{\"error\":")
+  && not (String.length s_lower >= 19 && String.sub s_lower 0 19 = "you've hit your lim")
+  && not (String.length s_lower >= 10 && String.sub s_lower 0 10 = "rate limit")
+
+let heartbeat_response_accepted (resp : Llm_client.completion_response) =
+  heartbeat_response_is_valid resp.content
+
+let run_heartbeat_llm_once ~agent_name ~prompt =
+  let models = Lodge_cascade.get_cascade ~cascade_name:"heartbeat_action" () in
+  let started_at = Time_compat.now () in
+  let result =
+    if models = [] then (
+      Printf.printf
+        "   ⚠️ [%s] No heartbeat model pool available, skipping\n%!" agent_name;
+      Error "no heartbeat model pool available")
+    else
+      Llm_client.run_prompt_cascade ~timeout_sec:60
+        ~accept:heartbeat_response_accepted ~model_specs:models ~max_tokens:4000
+        ~prompt ()
+  in
+  let duration_ms =
+    int_of_float ((Time_compat.now () -. started_at) *. 1000.0)
+  in
+  match result with
+  | Ok resp ->
+      {
+        Lodge_cascade.response = resp.content;
+        llm_used = resp.model_used;
+        duration_ms;
+      }
+  | Error err ->
+      Printf.printf "   ❌ [%s] Heartbeat cascade failed: %s\n%!" agent_name err;
+      { Lodge_cascade.response = ""; llm_used = "none"; duration_ms }
+
 let run_heartbeat_llm_traced ~agent_name ~phase ~prompt =
-  let is_valid_response s =
-    let len = String.length s in
-    let s_lower = String.lowercase_ascii s in
-    len > 10
-    && not (len >= 5 && String.sub s_lower 0 5 = "error")
-    && not (len >= 14 && String.sub s 0 14 = "Empty response")
-    && not (len >= 9 && String.sub s 0 9 = "{\"error\":")
-    && not (String.length s_lower >= 19 && String.sub s_lower 0 19 = "you've hit your lim")
-    && not (String.length s_lower >= 10 && String.sub s_lower 0 10 = "rate limit")
-  in
-  let cascade_call_llm ~tool_name ~extra_args ~prompt:p ~timeout_sec ~max_chars =
-    let model =
-      List.assoc_opt "model" extra_args
-      |> Option.map Yojson.Safe.Util.to_string
-      |> Option.value ~default:"glm-4.7"
-    in
-    let api_key =
-      List.assoc_opt "api_key" extra_args
-      |> Option.map Yojson.Safe.Util.to_string
-      |> Option.value ~default:""
-    in
-    Llm_direct.dispatch ~tool_name ~api_key ~model ~prompt:p ~timeout_sec ~max_chars ()
-  in
-  let slots = Lodge_cascade.get_cascade ~cascade_name:"heartbeat_action" () in
   let tick_id =
     Printf.sprintf "%s-%d" agent_name
       (int_of_float (Time_compat.now () *. 1000.0) mod 1000000)
   in
-  let cascade_result =
-    if List.length slots > 0 then
-      Lodge_cascade.run_cascade_traced
-        ~slots ~prompt ~timeout_sec:60 ~max_chars:4000
-        ~call_llm:cascade_call_llm
-        ~is_valid:is_valid_response
-        ~agent_name
-    else begin
-      Printf.printf "   ⚠️ [%s] No cascade config, trying GLM directly...\n%!" agent_name;
-      let started_at = Time_compat.now () in
-      let response =
-        Llm_direct.call_glm ~model:"glm-4.7" ~prompt ~timeout_sec:60 ~max_chars:4000 ()
-      in
-      let duration_ms =
-        int_of_float ((Time_compat.now () -. started_at) *. 1000.0)
-      in
-      Lodge_cascade.{ response; llm_used = "glm(glm-4.7)"; duration_ms }
-    end
-  in
+  let cascade_result = run_heartbeat_llm_once ~agent_name ~prompt in
   save_trace
     {
       tick_id;
@@ -2546,37 +2544,7 @@ let execute_agent_action ~agent_name ~action =
     Wraps the LLM cascade in a simple (prompt -> string) signature. *)
 let make_call_llm ~agent_name : (prompt:string -> string) =
   fun ~prompt ->
-    let is_valid_response s =
-      let len = String.length s in
-      let s_lower = String.lowercase_ascii s in
-      len > 10 &&
-      not (len >= 5 && String.sub s_lower 0 5 = "error") &&
-      not (len >= 14 && String.sub s 0 14 = "Empty response") &&
-      not (len >= 9 && String.sub s 0 9 = "{\"error\":") &&
-      (* Rate limit / quota messages from Claude CLI *)
-      not (len >= 19 && String.sub s_lower 0 19 = "you've hit your lim") &&
-      not (len >= 10 && String.sub s_lower 0 10 = "rate limit")
-    in
-    let cascade_call_llm ~tool_name ~extra_args ~prompt:p ~timeout_sec ~max_chars =
-      let model = List.assoc_opt "model" extra_args
-        |> Option.map Yojson.Safe.Util.to_string
-        |> Option.value ~default:"glm-4.7" in
-      let api_key = List.assoc_opt "api_key" extra_args
-        |> Option.map Yojson.Safe.Util.to_string
-        |> Option.value ~default:"" in
-      Llm_direct.dispatch ~tool_name ~api_key ~model ~prompt:p ~timeout_sec ~max_chars ()
-    in
-    let slots = Lodge_cascade.get_cascade ~cascade_name:"heartbeat_action" () in
-    if List.length slots > 0 then
-      Lodge_cascade.run_cascade
-        ~slots ~prompt ~timeout_sec:60 ~max_chars:4000
-        ~call_llm:cascade_call_llm
-        ~is_valid:is_valid_response
-        ~agent_name
-    else begin
-      Printf.printf "   ⚠️ [%s] No cascade config, trying GLM directly...\n%!" agent_name;
-      Llm_direct.call_glm ~model:"glm-4.7" ~prompt ~timeout_sec:60 ~max_chars:4000 ()
-    end
+    (run_heartbeat_llm_once ~agent_name ~prompt).Lodge_cascade.response
 
 (** {1 Plan-based Agent Selection} *)
 

--- a/lib/masc_mcp.ml
+++ b/lib/masc_mcp.ml
@@ -106,6 +106,7 @@ module Backend = Backend
 module Backend_eio = Backend_eio
 module Cache_eio = Cache_eio
 module Llm_response_cache = Llm_response_cache
+module Lodge_cascade = Lodge_cascade
 module Prometheus = Prometheus
 module Rate_limit = Rate_limit
 module Circuit_breaker = Circuit_breaker

--- a/lib/room_walph_eio.ml
+++ b/lib/room_walph_eio.ml
@@ -265,8 +265,33 @@ let get_chain_id_for_preset = function
   | _ -> None
 
 (** Default LLM dispatcher for Walph loop. Exposed as overridable parameter for tests. *)
-let default_llm_dispatch ~tool_name ~model ~prompt ~timeout_sec ~max_chars () =
-  Llm_direct.dispatch ~tool_name ~model ~prompt ~timeout_sec ~max_chars ()
+let walph_default_model_strings () =
+  [
+    Printf.sprintf "ollama:%s" Env_config.Ollama.default_model;
+    Printf.sprintf "glm:%s" Env_config.Llm.default_model;
+  ]
+
+let walph_available_model_specs () =
+  Llm_client.available_model_specs_of_strings (walph_default_model_strings ())
+
+let walph_response_is_valid (resp : Llm_client.completion_response) =
+  let content = String.trim resp.content in
+  let lower = String.lowercase_ascii content in
+  let len = String.length content in
+  len > 0
+  && not (len >= 5 && String.sub lower 0 5 = "error")
+  && not (len >= 14 && String.sub content 0 14 = "Empty response")
+  && not (len >= 9 && String.sub content 0 9 = "{\"error\":")
+
+let default_llm_dispatch ~tool_name:_ ~model:_ ~prompt ~timeout_sec ~max_chars () =
+  match
+    Llm_client.run_prompt_cascade ~timeout_sec
+      ~accept:walph_response_is_valid
+      ~model_specs:(walph_available_model_specs ()) ~max_tokens:max_chars
+      ~prompt ()
+  with
+  | Ok resp -> resp.content
+  | Error err -> failwith err
 
 (** {1 Main Loop} *)
 

--- a/test/dune
+++ b/test/dune
@@ -108,6 +108,16 @@
  (libraries masc_mcp alcotest yojson unix))
 
 (test
+ (name test_lodge_cascade)
+ (modules test_lodge_cascade)
+ (libraries masc_mcp alcotest unix))
+
+(test
+ (name test_llm_client_cascade)
+ (modules test_llm_client_cascade)
+ (libraries masc_mcp alcotest yojson unix))
+
+(test
  (name test_metrics_store_eio)
  (modules test_metrics_store_eio)
  (libraries masc_mcp alcotest str yojson))

--- a/test/test_auto_responder_coverage.ml
+++ b/test/test_auto_responder_coverage.ml
@@ -12,6 +12,28 @@ open Alcotest
 
 module Auto_responder = Masc_mcp.Auto_responder
 
+let file_contains_pattern file_rel pattern =
+  let source_root =
+    match Sys.getenv_opt "DUNE_SOURCEROOT" with
+    | Some root -> root
+    | None -> Sys.getcwd ()
+  in
+  let path = Filename.concat source_root file_rel in
+  if not (Sys.file_exists path) then false
+  else
+    let ic = open_in path in
+    Fun.protect
+      ~finally:(fun () -> close_in_noerr ic)
+      (fun () ->
+        let content = In_channel.input_all ic in
+        let rec loop idx =
+          let remaining = String.length content - idx in
+          let plen = String.length pattern in
+          remaining >= plen
+          && (String.sub content idx plen = pattern || loop (idx + 1))
+        in
+        if String.length pattern = 0 then true else loop 0)
+
 (* ============================================================
    mode Type Tests
    ============================================================ *)
@@ -94,16 +116,13 @@ let test_build_response_prompt_contains_leave () =
 
 (* ============================================================
    extract_nickname Tests
-   NOTE: Current implementation has a bug where String.sub 0 10 is compared
-   to "  Nickname:" (11 chars), so it always returns None.
-   Tests match actual behavior.
    ============================================================ *)
 
 let test_extract_nickname_returns_option () =
   let response = "Some text\n  Nickname: claude-rare-beaver\nMore text" in
   let nick = Auto_responder.extract_nickname response in
-  (* Implementation bug: comparison always fails, returns None *)
-  check (option string) "returns option type" None nick
+  check (option string) "returns parsed nickname"
+    (Some "claude-rare-beaver") nick
 
 let test_extract_nickname_empty () =
   let nick = Auto_responder.extract_nickname "" in
@@ -117,7 +136,7 @@ let test_extract_nickname_no_match () =
 let test_extract_nickname_wrong_format () =
   let response = "Nickname: test" in  (* Missing leading spaces *)
   let nick = Auto_responder.extract_nickname response in
-  check (option string) "wrong format" None nick
+  check (option string) "wrong format still accepted" (Some "test") nick
 
 let test_extract_nickname_multiline () =
   let response = "Line1\nLine2\nLine3" in
@@ -189,6 +208,14 @@ let test_build_response_prompt_long_content () =
   let prompt = Auto_responder.build_response_prompt ~from_agent:"a" ~content:long_content ~mention:"b" in
   check bool "handles long content" true (String.length prompt > 1000)
 
+let test_auto_responder_uses_shared_llm_client () =
+  check bool "uses Llm_client.run_prompt_cascade"
+    true
+    (file_contains_pattern "lib/auto_responder.ml" "Llm_client.run_prompt_cascade");
+  check bool "legacy Llm_direct dispatch removed"
+    false
+    (file_contains_pattern "lib/auto_responder.ml" "Llm_direct.dispatch")
+
 (* ============================================================
    Test Runners
    ============================================================ *)
@@ -240,5 +267,8 @@ let () =
     ];
     "edge_cases", [
       test_case "long content" `Quick test_build_response_prompt_long_content;
+    ];
+    "source", [
+      test_case "shared llm client" `Quick test_auto_responder_uses_shared_llm_client;
     ];
   ]

--- a/test/test_llm_client_cascade.ml
+++ b/test/test_llm_client_cascade.ml
@@ -1,0 +1,204 @@
+open Alcotest
+
+module Cache = Masc_mcp.Llm_response_cache
+module Llm_client = Masc_mcp.Llm_client
+
+let rec rm_rf path =
+  if Sys.file_exists path then
+    if Sys.is_directory path then (
+      Array.iter (fun name -> rm_rf (Filename.concat path name)) (Sys.readdir path);
+      Unix.rmdir path)
+    else
+      Unix.unlink path
+
+let with_temp_cwd f =
+  let original = Sys.getcwd () in
+  let dir = Filename.temp_file "test_llm_client_cascade_" "" in
+  Unix.unlink dir;
+  Unix.mkdir dir 0o755;
+  Unix.chdir dir;
+  Fun.protect
+    ~finally:(fun () ->
+      Unix.chdir original;
+      rm_rf dir)
+    f
+
+let with_env name value f =
+  let previous = Sys.getenv_opt name in
+  Unix.putenv name value;
+  Fun.protect
+    ~finally:(fun () ->
+      match previous with
+      | Some v -> Unix.putenv name v
+      | None -> Unix.putenv name "")
+    f
+
+let cache_response (req : Llm_client.completion_request) ~content ~model_used =
+  let key = Llm_client.cache_key_of_request req in
+  let payload =
+    `Assoc
+      [
+        ("schema_version", `String "1.0.0");
+        ("kind", `String "completion_response");
+        ( "response",
+          `Assoc
+            [
+              ("content", `String content);
+              ("tool_calls", `List []);
+              ( "usage",
+                `Assoc
+                  [
+                    ("input_tokens", `Int 1);
+                    ("output_tokens", `Int 1);
+                    ("total_tokens", `Int 2);
+                    ("cache_creation_input_tokens", `Int 0);
+                    ("cache_read_input_tokens", `Int 0);
+                  ] );
+              ("model_used", `String model_used);
+            ] );
+      ]
+  in
+  match Cache.set_json ~key ~ttl_seconds:30 payload with
+  | Ok () -> ()
+  | Error e -> fail ("set_json failed: " ^ e)
+
+let make_request model_id =
+  let model : Llm_client.model_spec =
+    {
+      provider = Llm_client.Custom "cached";
+      model_id;
+      max_context = 4096;
+      api_url = "http://127.0.0.1:1";
+      api_key_env = None;
+      cost_per_1k_input = 0.0;
+      cost_per_1k_output = 0.0;
+    }
+  in
+  ({
+     model;
+     messages = [ Llm_client.user_msg ("prompt:" ^ model_id) ];
+     temperature = 0.0;
+     max_tokens = 64;
+     tools = [];
+     response_format = `Text;
+   }
+    : Llm_client.completion_request)
+
+let make_request_for_model ?(temperature = 0.0) ~model ~prompt ~max_tokens () =
+  ({
+     model;
+     messages = [ Llm_client.user_msg prompt ];
+     temperature;
+     max_tokens;
+     tools = [];
+     response_format = `Text;
+   }
+    : Llm_client.completion_request)
+
+let contains_substring haystack needle =
+  let h_len = String.length haystack in
+  let n_len = String.length needle in
+  let rec loop idx =
+    idx + n_len <= h_len
+    && (String.sub haystack idx n_len = needle || loop (idx + 1))
+  in
+  if n_len = 0 then true else loop 0
+
+let test_cascade_uses_next_cached_response_when_validator_rejects () =
+  with_temp_cwd (fun () ->
+      Cache.clear_l1 ();
+      let first = make_request "cached-1" in
+      let second = make_request "cached-2" in
+      cache_response first ~content:"reject me" ~model_used:"cached-1";
+      cache_response second ~content:"accept me" ~model_used:"cached-2";
+      match
+        Llm_client.cascade
+          ~accept:(fun (resp : Llm_client.completion_response) ->
+            not (String.equal resp.content "reject me"))
+          [ first; second ]
+      with
+      | Ok resp ->
+          check string "content" "accept me" resp.content;
+          check string "winner" "cached-2" resp.model_used
+      | Error e -> fail ("unexpected cascade error: " ^ e))
+
+let test_cascade_returns_error_when_all_responses_rejected () =
+  with_temp_cwd (fun () ->
+      Cache.clear_l1 ();
+      let first = make_request "cached-only" in
+      cache_response first ~content:"reject me" ~model_used:"cached-only";
+      match
+        Llm_client.cascade
+          ~accept:(fun (resp : Llm_client.completion_response) ->
+            not (String.equal resp.content "reject me"))
+          [ first ]
+      with
+      | Ok _ -> fail "expected rejection error"
+      | Error e ->
+          check bool "validator rejection in error" true
+            (contains_substring e "response rejected by validator"))
+
+let test_available_model_specs_filters_invalid_and_missing_keys () =
+  with_env "GEMINI_API_KEY" "" (fun () ->
+      let specs =
+        Llm_client.available_model_specs_of_strings
+          [ "invalid"; "gemini:gemini-2.5-pro"; "ollama:glm-4.7-flash" ]
+      in
+      check int "only ollama survives" 1 (List.length specs);
+      match specs with
+      | [ only ] ->
+          check bool "provider" true (only.provider = Llm_client.Ollama);
+          check string "model id" "glm-4.7-flash" only.model_id
+      | _ -> fail "expected one filtered model")
+
+let test_run_prompt_cascade_uses_same_request_shape () =
+  with_temp_cwd (fun () ->
+      Cache.clear_l1 ();
+      let model1 : Llm_client.model_spec =
+        {
+          provider = Llm_client.Custom "cached";
+          model_id = "run-prompt-1";
+          max_context = 4096;
+          api_url = "http://127.0.0.1:1";
+          api_key_env = None;
+          cost_per_1k_input = 0.0;
+          cost_per_1k_output = 0.0;
+        }
+      in
+      let model2 = { model1 with model_id = "run-prompt-2" } in
+      let prompt = "shared helper prompt" in
+      cache_response
+        (make_request_for_model ~model:model1 ~prompt ~max_tokens:32 ())
+        ~content:"reject me" ~model_used:"run-prompt-1";
+      cache_response
+        (make_request_for_model ~model:model2 ~prompt ~max_tokens:32 ())
+        ~content:"accept me" ~model_used:"run-prompt-2";
+      match
+        Llm_client.run_prompt_cascade ~temperature:0.0 ~timeout_sec:30
+          ~accept:(fun (resp : Llm_client.completion_response) ->
+            not (String.equal resp.content "reject me"))
+          ~model_specs:[ model1; model2 ] ~max_tokens:32 ~prompt ()
+      with
+      | Ok resp ->
+          check string "content" "accept me" resp.content;
+          check string "winner" "run-prompt-2" resp.model_used
+      | Error e -> fail ("unexpected run_prompt_cascade error: " ^ e))
+
+let () =
+  run "llm_client_cascade"
+    [
+      ( "accept",
+        [
+          test_case "uses next cached response after rejection" `Quick
+            test_cascade_uses_next_cached_response_when_validator_rejects;
+          test_case "all rejected returns error" `Quick
+            test_cascade_returns_error_when_all_responses_rejected;
+        ] );
+      ( "helpers",
+        [
+          test_case "filters invalid and missing keys" `Quick
+            test_available_model_specs_filters_invalid_and_missing_keys;
+          test_case "run_prompt_cascade request shape" `Quick
+            test_run_prompt_cascade_uses_same_request_shape;
+        ] );
+    ]

--- a/test/test_lodge_cascade.ml
+++ b/test/test_lodge_cascade.ml
@@ -1,0 +1,80 @@
+open Alcotest
+
+module Lodge_cascade = Masc_mcp.Lodge_cascade
+module Llm_client = Masc_mcp.Llm_client
+
+let with_temp_json contents f =
+  let path = Filename.temp_file "lodge_cascade_" ".json" in
+  let oc = open_out path in
+  Fun.protect
+    ~finally:(fun () ->
+      close_out_noerr oc;
+      if Sys.file_exists path then Sys.remove path)
+    (fun () ->
+      output_string oc contents;
+      close_out oc;
+      f path)
+
+let with_env name value f =
+  let previous = Sys.getenv_opt name in
+  Unix.putenv name value;
+  Fun.protect
+    ~finally:(fun () ->
+      match previous with
+      | Some v -> Unix.putenv name v
+      | None -> Unix.putenv name "")
+    f
+
+let test_load_models_from_config () =
+  with_temp_json
+    {|{"heartbeat_action_models":["llama:qwen-local","ollama:glm-4.7-flash"]}|}
+    (fun path ->
+      let specs = Lodge_cascade.get_cascade ~config_path:path ~cascade_name:"heartbeat_action" () in
+      check int "spec count" 2 (List.length specs);
+      match specs with
+      | [ first; second ] ->
+          check bool "first is llama" true (first.provider = Llm_client.Llama);
+          check string "first model" "qwen-local" first.model_id;
+          check bool "second is ollama" true (second.provider = Llm_client.Ollama);
+          check string "second model" "glm-4.7-flash" second.model_id
+      | _ -> fail "expected two specs")
+
+let test_skips_invalid_and_missing_api_key () =
+  with_env "GEMINI_API_KEY" "" (fun () ->
+      with_temp_json
+        {|{"heartbeat_action_models":["invalid","gemini:gemini-2.5-pro","llama:qwen-live"]}|}
+        (fun path ->
+          let specs = Lodge_cascade.get_cascade ~config_path:path ~cascade_name:"heartbeat_action" () in
+          check int "only llama survives" 1 (List.length specs);
+          match specs with
+          | [ only ] ->
+              check bool "llama provider" true
+                (only.provider = Llm_client.Llama);
+              check string "llama model" "qwen-live" only.model_id
+          | _ -> fail "expected one surviving spec"))
+
+let test_missing_config_uses_defaults () =
+  let path = Filename.concat (Filename.get_temp_dir_name ()) "missing-llm-cascade.json" in
+  let specs = Lodge_cascade.get_cascade ~config_path:path ~cascade_name:"heartbeat_action" () in
+  check bool "defaults available" true (List.length specs >= 1);
+  match specs with
+  | first :: _ ->
+      check bool "default starts with llama" true
+        (first.provider = Llm_client.Llama);
+      check string "default llama model" "qwen3.5-35b-a3b-ud-q8-xl"
+        first.model_id
+  | [] -> fail "expected default fallback models"
+
+let () =
+  run "lodge_cascade"
+    [
+      ( "loader",
+        [
+          test_case "loads provider:model order" `Quick
+            test_load_models_from_config;
+          test_case "skips invalid and missing api key" `Quick
+            test_skips_invalid_and_missing_api_key;
+          test_case "missing config uses defaults" `Quick
+            test_missing_config_uses_defaults;
+        ] );
+    ]

--- a/test/test_lodge_heartbeat_cleanup_coverage.ml
+++ b/test/test_lodge_heartbeat_cleanup_coverage.ml
@@ -96,6 +96,11 @@ let test_lodge_heartbeat_updates_self_summary () =
     true
     (file_contains_pattern "lib/lodge_heartbeat.ml" "Lodge_reaction.update_self_summary")
 
+let test_lodge_heartbeat_uses_shared_prompt_cascade () =
+  check bool "heartbeat uses shared prompt cascade"
+    true
+    (file_contains_pattern "lib/lodge_heartbeat.ml" "Llm_client.run_prompt_cascade")
+
 let test_lodge_heartbeat_uses_tom_context () =
   check bool "ToM context used"
     true
@@ -160,6 +165,7 @@ let () =
           test_case "profile shellout removed" `Quick test_lodge_heartbeat_no_profile_shellout;
           test_case "tool assignment prompt mainline" `Quick test_lodge_heartbeat_uses_tool_assignment_prompt;
           test_case "graphql defaults and guards" `Quick test_lodge_graphql_defaults_and_guards;
+          test_case "shared prompt cascade helper" `Quick test_lodge_heartbeat_uses_shared_prompt_cascade;
           test_case "reflection updates self summary" `Quick test_lodge_heartbeat_updates_self_summary;
           test_case "ToM context used" `Quick test_lodge_heartbeat_uses_tom_context;
           test_case "no heuristic fallback policy locked" `Quick test_lodge_heartbeat_no_heuristic_fallback_policy;

--- a/test/test_walph_eio.ml
+++ b/test/test_walph_eio.ml
@@ -26,6 +26,22 @@ let contains text pattern =
   with Not_found ->
     false
 
+let file_contains_pattern file_rel pattern =
+  let source_root =
+    match Sys.getenv_opt "DUNE_SOURCEROOT" with
+    | Some root -> root
+    | None -> Sys.getcwd ()
+  in
+  let path = Filename.concat source_root file_rel in
+  if not (Sys.file_exists path) then false
+  else
+    let ic = open_in path in
+    Fun.protect
+      ~finally:(fun () -> close_in_noerr ic)
+      (fun () ->
+        let content = In_channel.input_all ic in
+        contains content pattern)
+
 (** Test fixture: Create isolated config with Eio environment *)
 let with_test_config name f =
   Eio_main.run @@ fun env ->
@@ -296,6 +312,18 @@ let test_eio_error_cutoff () =
     "max_consecutive_errors reached (2)"
     (status |> member "last_stop_reason" |> to_string)
 
+let test_eio_default_dispatch_uses_shared_cascade () =
+  check bool "uses Llm_client.run_prompt_cascade" true
+    (file_contains_pattern "lib/room_walph_eio.ml" "Llm_client.run_prompt_cascade");
+  check bool "legacy direct dispatch removed" false
+    (file_contains_pattern "lib/room_walph_eio.ml" "Llm_direct.dispatch");
+  check bool "shared pool starts with ollama" true
+    (file_contains_pattern "lib/room_walph_eio.ml"
+       {|Printf.sprintf "ollama:%s" Env_config.Ollama.default_model|});
+  check bool "shared pool falls back to glm" true
+    (file_contains_pattern "lib/room_walph_eio.ml"
+       {|Printf.sprintf "glm:%s" Env_config.Llm.default_model|})
+
 (* ============================================
    Test Registration
    ============================================ *)
@@ -312,6 +340,8 @@ let eio_tests = [
   "list walph states", `Quick, test_eio_list_walph_states;
   "status json fields", `Quick, test_eio_status_json_fields;
   "error cutoff", `Quick, test_eio_error_cutoff;
+  "default dispatch uses shared cascade", `Quick,
+  test_eio_default_dispatch_uses_shared_cascade;
 ]
 
 let () =


### PR DESCRIPTION
## Summary
- move heartbeat from legacy slot execution to shared provider:model cascade
- migrate auto_responder and walph default runtime paths onto shared Llm_client prompt cascade helpers
- add regression coverage for shared model filtering and prompt-cascade request shaping

## Notes
- local config/llm_cascade.json remains ignored and is not included in this PR
- heartbeat still falls back to built-in defaults when that local file is absent

## Verification
- dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix-heartbeat-llm-pool
- _build/default/test/test_lodge_cascade.exe
- _build/default/test/test_llm_client_cascade.exe
- _build/default/test/test_lodge_heartbeat_cleanup_coverage.exe
- _build/default/test/test_auto_responder_coverage.exe
- _build/default/test/test_walph_eio.exe