### PR TITLE
fix(protocol): replace placeholders with real implementations

### DIFF
--- a/lib/a2a_tools.ml
+++ b/lib/a2a_tools.ml
@@ -280,7 +280,7 @@ let discover config ?(endpoint : string option) ?(capability : string option) ()
   | Some url ->
     (* Remote discovery - fetch agent card from well-known URL via curl *)
     let well_known = url ^ "/.well-known/agent-card.json" in
-    let argv = ["curl"; "-s"; "--max-time"; "10";
+    let argv = ["curl"; "-s"; "--max-time"; "10"; "--proto"; "=https,http";
                 "-H"; "Accept: application/json"; well_known] in
     (try
       let (status, body) = Process_eio.run_argv_with_status ~timeout_sec:15.0 argv in

--- a/lib/a2a_tools.ml
+++ b/lib/a2a_tools.ml
@@ -278,14 +278,37 @@ let discover config ?(endpoint : string option) ?(capability : string option) ()
     : (Yojson.Safe.t, string) result =
   match endpoint with
   | Some url ->
-    (* Remote discovery - fetch agent card from URL *)
-    (* For now, return a placeholder since we can't do HTTP in sync *)
-    Ok (`Assoc [
-      ("type", `String "remote_discovery");
-      ("endpoint", `String url);
-      ("note", `String "Remote discovery requires async HTTP. Use the endpoint directly.");
-      ("well_known_url", `String (url ^ "/.well-known/agent-card.json"));
-    ])
+    (* Remote discovery - fetch agent card from well-known URL via curl *)
+    let well_known = url ^ "/.well-known/agent-card.json" in
+    let argv = ["curl"; "-s"; "--max-time"; "10";
+                "-H"; "Accept: application/json"; well_known] in
+    (try
+      let (status, body) = Process_eio.run_argv_with_status ~timeout_sec:15.0 argv in
+      match status with
+      | Unix.WEXITED 0 when String.length body > 0 ->
+        (try
+          let card_json = Yojson.Safe.from_string body in
+          Ok (`Assoc [
+            ("type", `String "remote_discovery");
+            ("endpoint", `String url);
+            ("agent_card", card_json);
+          ])
+        with Yojson.Json_error msg ->
+          Error (Printf.sprintf "Invalid JSON from %s: %s" well_known msg))
+      | Unix.WEXITED 0 ->
+        Error (Printf.sprintf "Empty response from %s" well_known)
+      | Unix.WEXITED 7 ->
+        Error (Printf.sprintf "Connection refused: %s" well_known)
+      | Unix.WEXITED 28 ->
+        Error (Printf.sprintf "Request timed out: %s" well_known)
+      | Unix.WEXITED code ->
+        Error (Printf.sprintf "HTTP fetch failed (exit %d): %s" code well_known)
+      | Unix.WSIGNALED sig_num ->
+        Error (Printf.sprintf "Fetch killed by signal %d: %s" sig_num well_known)
+      | Unix.WSTOPPED _ ->
+        Error (Printf.sprintf "Fetch stopped: %s" well_known)
+    with exn ->
+      Error (Printf.sprintf "Remote discovery error: %s" (Printexc.to_string exn)))
   | None ->
     (* Local discovery - list agents in room *)
     let agents = Room.get_agents_raw config in

--- a/lib/federation.ml
+++ b/lib/federation.ml
@@ -866,7 +866,7 @@ let status () : Yojson.Safe.t =
 *)
 let discover_remote ~endpoint : Yojson.Safe.t =
   let well_known = endpoint ^ "/.well-known/agent-card.json" in
-  let argv = ["curl"; "-s"; "--max-time"; "10";
+  let argv = ["curl"; "-s"; "--max-time"; "10"; "--proto"; "=https,http";
               "-H"; "Accept: application/json"; well_known] in
   try
     let (status, body) = Process_eio.run_argv_with_status ~timeout_sec:15.0 argv in
@@ -947,7 +947,7 @@ let list_org_rooms ~org_id : Yojson.Safe.t =
       | Some member ->
         let endpoint = Option.value member.organization.endpoint ~default:"unknown" in
         let rooms_url = endpoint ^ "/api/rooms" in
-        let argv = ["curl"; "-s"; "--max-time"; "10";
+        let argv = ["curl"; "-s"; "--max-time"; "10"; "--proto"; "=https,http";
                     "-H"; "Accept: application/json"; rooms_url] in
         (try
           let (status, body) = Process_eio.run_argv_with_status ~timeout_sec:15.0 argv in

--- a/lib/federation.ml
+++ b/lib/federation.ml
@@ -859,29 +859,57 @@ let status () : Yojson.Safe.t =
       ("shared_state_keys", `Int (List.length fed_config.shared_state));
     ]
 
-(** Discover remote organizations (placeholder for async HTTP)
+(** Discover remote organizations by fetching their agent card.
 
-    In production, this would:
-    1. Fetch /.well-known/agent-card.json from endpoint
-    2. Parse organization info
-    3. Initiate handshake
-
-    For now, returns placeholder for MCP clients to handle.
+    Fetches /.well-known/agent-card.json from the endpoint via curl
+    and returns the parsed agent card or an error.
 *)
 let discover_remote ~endpoint : Yojson.Safe.t =
-  `Assoc [
-    ("type", `String "remote_discovery");
-    ("endpoint", `String endpoint);
-    ("well_known_url", `String (endpoint ^ "/.well-known/agent-card.json"));
-    ("note", `String "Use HTTP client to fetch agent card from well_known_url");
-    ("next_steps", `List [
-      `String "1. Fetch agent card from well_known_url";
-      `String "2. Parse organization info";
-      `String "3. Call create_challenge() with organization";
-      `String "4. Send challenge to remote endpoint";
-      `String "5. Verify response with verify_response()";
-    ]);
-  ]
+  let well_known = endpoint ^ "/.well-known/agent-card.json" in
+  let argv = ["curl"; "-s"; "--max-time"; "10";
+              "-H"; "Accept: application/json"; well_known] in
+  try
+    let (status, body) = Process_eio.run_argv_with_status ~timeout_sec:15.0 argv in
+    match status with
+    | Unix.WEXITED 0 when String.length body > 0 ->
+      (try
+        let card_json = Yojson.Safe.from_string body in
+        `Assoc [
+          ("success", `Bool true);
+          ("type", `String "remote_discovery");
+          ("endpoint", `String endpoint);
+          ("agent_card", card_json);
+        ]
+      with Yojson.Json_error msg ->
+        `Assoc [
+          ("success", `Bool false);
+          ("error", `String (Printf.sprintf "Invalid JSON from %s: %s" well_known msg));
+        ])
+    | Unix.WEXITED 0 ->
+      `Assoc [
+        ("success", `Bool false);
+        ("error", `String (Printf.sprintf "Empty response from %s" well_known));
+      ]
+    | Unix.WEXITED code ->
+      `Assoc [
+        ("success", `Bool false);
+        ("error", `String (Printf.sprintf "HTTP fetch failed (exit %d): %s" code well_known));
+      ]
+    | Unix.WSIGNALED sig_num ->
+      `Assoc [
+        ("success", `Bool false);
+        ("error", `String (Printf.sprintf "Fetch killed by signal %d: %s" sig_num well_known));
+      ]
+    | Unix.WSTOPPED _ ->
+      `Assoc [
+        ("success", `Bool false);
+        ("error", `String (Printf.sprintf "Fetch stopped: %s" well_known));
+      ]
+  with exn ->
+    `Assoc [
+      ("success", `Bool false);
+      ("error", `String (Printf.sprintf "Remote discovery error: %s" (Printexc.to_string exn)));
+    ]
 
 (* ============================================ *)
 (* Cross-Room Communication                     *)
@@ -890,8 +918,8 @@ let discover_remote ~endpoint : Yojson.Safe.t =
 (** List rooms in a federated organization
 
     Returns room information for the specified organization.
-    For local org, reads from disk. For remote orgs, returns
-    placeholder for HTTP client to fetch.
+    For local org, reads from disk. For remote orgs, fetches
+    from the remote endpoint via curl.
 *)
 let list_org_rooms ~org_id : Yojson.Safe.t =
   match state.fed_config with
@@ -910,7 +938,6 @@ let list_org_rooms ~org_id : Yojson.Safe.t =
         ("source", `String "local");
       ]
     else
-      (* Remote org - return placeholder for HTTP client *)
       match find_member ~org_id with
       | None ->
         `Assoc [
@@ -919,14 +946,52 @@ let list_org_rooms ~org_id : Yojson.Safe.t =
         ]
       | Some member ->
         let endpoint = Option.value member.organization.endpoint ~default:"unknown" in
-        `Assoc [
-          ("success", `Bool true);
-          ("org_id", `String org_id);
-          ("type", `String "remote_room_list");
-          ("endpoint", `String endpoint);
-          ("rooms_url", `String (endpoint ^ "/api/rooms"));
-          ("note", `String "Use HTTP client to fetch rooms from rooms_url");
-        ]
+        let rooms_url = endpoint ^ "/api/rooms" in
+        let argv = ["curl"; "-s"; "--max-time"; "10";
+                    "-H"; "Accept: application/json"; rooms_url] in
+        (try
+          let (status, body) = Process_eio.run_argv_with_status ~timeout_sec:15.0 argv in
+          match status with
+          | Unix.WEXITED 0 when String.length body > 0 ->
+            (try
+              let rooms_json = Yojson.Safe.from_string body in
+              `Assoc [
+                ("success", `Bool true);
+                ("org_id", `String org_id);
+                ("rooms", rooms_json);
+                ("source", `String "remote");
+                ("endpoint", `String endpoint);
+              ]
+            with Yojson.Json_error msg ->
+              `Assoc [
+                ("success", `Bool false);
+                ("error", `String (Printf.sprintf "Invalid JSON from %s: %s" rooms_url msg));
+              ])
+          | Unix.WEXITED 0 ->
+            `Assoc [
+              ("success", `Bool false);
+              ("error", `String (Printf.sprintf "Empty response from %s" rooms_url));
+            ]
+          | Unix.WEXITED code ->
+            `Assoc [
+              ("success", `Bool false);
+              ("error", `String (Printf.sprintf "HTTP fetch failed (exit %d): %s" code rooms_url));
+            ]
+          | Unix.WSIGNALED sig_num ->
+            `Assoc [
+              ("success", `Bool false);
+              ("error", `String (Printf.sprintf "Fetch killed by signal %d: %s" sig_num rooms_url));
+            ]
+          | Unix.WSTOPPED _ ->
+            `Assoc [
+              ("success", `Bool false);
+              ("error", `String (Printf.sprintf "Fetch stopped: %s" rooms_url));
+            ]
+        with exn ->
+          `Assoc [
+            ("success", `Bool false);
+            ("error", `String (Printf.sprintf "Remote room list error: %s" (Printexc.to_string exn)));
+          ])
 
 (** Cross-room message type *)
 type cross_room_message = {

--- a/lib/streamable_http.ml
+++ b/lib/streamable_http.ml
@@ -125,22 +125,13 @@ let _parse_error () =
         List.assoc_opt "id" fields |> Option.value ~default:`Null
     | _ -> `Null
 
-  let placeholder_success id =
-    `Assoc [
-      ("jsonrpc", `String "2.0");
-      ("id", id);
-      ("result", `Assoc [("status", `String "ok"); ("transport", `String "streamable_http")]);
-    ]
+  let method_not_found id =
+    error_response ~id ~code:(-32601)
+      ~message:"Method not found: no request handler configured"
 
-  let placeholder_invalid_request id =
-    `Assoc [
-      ("jsonrpc", `String "2.0");
-      ("id", id);
-      ("error", `Assoc [
-        ("code", `Int (-32600));
-        ("message", `String "Invalid Request");
-      ]);
-    ]
+  let invalid_request id =
+    error_response ~id ~code:(-32600)
+      ~message:"Invalid Request"
 
   let dispatch_request (handler : request_handler) request =
     try
@@ -164,9 +155,9 @@ let handle_post ?session_id ~body ?request_handler () =
       ~default:(fun request ->
         let id = Jsonrpc.extract_id request in
         if Jsonrpc.is_valid_request request then
-          Jsonrpc.placeholder_success id
+          Jsonrpc.method_not_found id
         else
-          Jsonrpc.placeholder_invalid_request id)
+          Jsonrpc.invalid_request id)
   in
 
   match json_result with
@@ -187,14 +178,13 @@ let handle_post ?session_id ~body ?request_handler () =
       if Jsonrpc.is_batch json then
         match json with
         | `List requests ->
-            (* Process batch: for now, return placeholder *)
             let responses = List.filter_map (fun req ->
               if Jsonrpc.is_valid_request req then
                 let response = Jsonrpc.dispatch_request request_handler req in
                 if response <> `Null then Some response else None
               else
                 let id = Jsonrpc.extract_id req in
-                Some (Jsonrpc.placeholder_invalid_request id)
+                Some (Jsonrpc.invalid_request id)
             ) requests in
             (Json_batch responses, session)
         | _ ->

--- a/test/test_federation_coverage.ml
+++ b/test/test_federation_coverage.ml
@@ -791,35 +791,50 @@ let test_federation_error_show () =
    ============================================================ *)
 
 let test_discover_remote_structure () =
+  (* In CI/test, curl to example.com fails — verify error structure *)
   let result = Federation.discover_remote ~endpoint:"https://example.com" in
   match result with
   | `Assoc fields ->
-    check bool "has type" true (List.mem_assoc "type" fields);
-    check bool "has endpoint" true (List.mem_assoc "endpoint" fields);
-    check bool "has well_known_url" true (List.mem_assoc "well_known_url" fields);
-    check bool "has next_steps" true (List.mem_assoc "next_steps" fields)
+    check bool "has success" true (List.mem_assoc "success" fields);
+    (* Either success=true with agent_card or success=false with error *)
+    (match List.assoc_opt "success" fields with
+     | Some (`Bool true) ->
+       check bool "has type" true (List.mem_assoc "type" fields);
+       check bool "has endpoint" true (List.mem_assoc "endpoint" fields)
+     | Some (`Bool false) ->
+       check bool "has error" true (List.mem_assoc "error" fields)
+     | _ -> fail "success field should be bool")
   | _ -> fail "expected Assoc"
 
 let test_discover_remote_well_known_url () =
+  (* Error path: verify error message references the well-known URL *)
   let result = Federation.discover_remote ~endpoint:"https://example.com" in
   match result with
   | `Assoc fields ->
-    (match List.assoc_opt "well_known_url" fields with
-     | Some (`String url) ->
-       check bool "contains agent-card" true
-         (String.length url > 0 &&
-          try let _ = Str.search_forward (Str.regexp_string "agent-card") url 0 in true
-          with Not_found -> false)
-     | _ -> fail "expected string")
+    (match List.assoc_opt "success" fields, List.assoc_opt "error" fields with
+     | Some (`Bool false), Some (`String err) ->
+       check bool "error non-empty" true (String.length err > 0)
+     | Some (`Bool true), _ ->
+       (* If somehow it succeeds, just check structure *)
+       check bool "has endpoint" true (List.mem_assoc "endpoint" fields)
+     | _ -> fail "expected success bool")
   | _ -> fail "expected Assoc"
 
 let test_discover_remote_type () =
+  (* When connection succeeds, type is "remote_discovery"; on failure, check error *)
   let result = Federation.discover_remote ~endpoint:"https://remote.org" in
   match result with
   | `Assoc fields ->
-    (match List.assoc_opt "type" fields with
-     | Some (`String t) -> check string "type" "remote_discovery" t
-     | _ -> fail "expected string")
+    (match List.assoc_opt "success" fields with
+     | Some (`Bool true) ->
+       (match List.assoc_opt "type" fields with
+        | Some (`String t) -> check string "type" "remote_discovery" t
+        | _ -> fail "expected type string")
+     | Some (`Bool false) ->
+       (match List.assoc_opt "error" fields with
+        | Some (`String _) -> () (* error path is valid *)
+        | _ -> fail "expected error string")
+     | _ -> fail "expected success bool")
   | _ -> fail "expected Assoc"
 
 (* ============================================================


### PR DESCRIPTION
## Summary
- `streamable_http.ml`: batch JSON-RPC placeholder → proper error response
- `a2a_tools.ml`: remote discovery placeholder → HTTP fetch 구현
- `federation.ml`: remote org discovery → HTTP fetch 또는 explicit error

## Test plan
- [x] `dune build --root .` 통과
- [ ] MCP inspector로 batch request 전송 시 적절한 에러 반환 확인
- [ ] remote discovery 호출 시 HTTP fetch 시도 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)