### PR TITLE
fix(init): replace Unix.select with Eio.Time.sleep

### DIFF
--- a/lib/operator_control.ml
+++ b/lib/operator_control.ml
@@ -2060,7 +2060,7 @@ let default_target_type_for action_type =
   | "keeper_message" | "keeper_probe" | "keeper_recover" -> "keeper"
   | _ -> ""
 
-let generate_confirm_token config =
+let generate_confirm_token ~clock config =
   let max_attempts = 10 in
   let rec loop attempts =
     if attempts >= max_attempts then
@@ -2077,8 +2077,8 @@ let generate_confirm_token config =
       in
       if exists then begin
         (* Exponential backoff: 1ms, 2ms, 4ms, ... up to ~512ms *)
-        let backoff_us = 1000 * (1 lsl (min attempts 9)) in
-        ignore (Unix.select [] [] [] (float_of_int backoff_us /. 1_000_000.0));
+        let backoff_s = float_of_int (1000 * (1 lsl (min attempts 9))) /. 1_000_000.0 in
+        Eio.Time.sleep clock backoff_s;
         loop (attempts + 1)
       end else Ok token
   in
@@ -2767,7 +2767,7 @@ let action_json ?actor_hint (ctx : 'a context) args =
   let started_at = Unix.gettimeofday () in
   if confirm_required request.action_type then (
     let expires_at = iso_of_unix (Unix.gettimeofday () +. remote_confirm_ttl_seconds) in
-    let* token = generate_confirm_token ctx.config in
+    let* token = generate_confirm_token ~clock:ctx.clock ctx.config in
     let entry =
       {
         token;


### PR DESCRIPTION
## Summary
- `operator_control.ml`의 `generate_confirm_token`에서 exponential backoff에 사용되던 `Unix.select`를 `Eio.Time.sleep`으로 교체
- `Unix.select`는 OS 스레드를 블로킹하여 Eio의 cooperative scheduler를 우회함
- `ctx.clock`이 이미 사용 가능하므로 labeled argument로 전달

## Changes
- `generate_confirm_token config` → `generate_confirm_token ~clock config`
- `Unix.select [] [] [] delay` → `Eio.Time.sleep clock delay`
- 호출자(L2770)에서 `~clock:ctx.clock` 전달

## Context
GLM-5 cross-model review에서 MEDIUM으로 지적된 항목 (PR #645 리뷰 시 발견)

## Test plan
- [x] `dune build` 통과
- [ ] `dune runtest` 통과 (CI 확인)