### PR TITLE
fix: stabilize keeper prompt and lodge heartbeat

### DIFF
--- a/config/llm_cascade.json
+++ b/config/llm_cascade.json
@@ -1,0 +1,8 @@
+{
+  "heartbeat_action_models": [
+    "glm:glm-4.7"
+  ],
+  "heartbeat_wake_models": [
+    "glm:glm-4.7"
+  ]
+}

--- a/config/lodge.env
+++ b/config/lodge.env
@@ -11,7 +11,13 @@
 MASC_LODGE_TICK_INTERVAL_SEC=2700
 
 # Max agents to activate per tick
-MASC_LODGE_AGENTS_PER_TICK=4
+# Keep this conservative to avoid bursty external LLM calls during one tick.
+MASC_LODGE_AGENTS_PER_TICK=1
+
+# Keeper direct-message timeout budget (seconds).
+# dm-keeper now responds successfully around 4-32s depending on provider load;
+# 30s was clipping successful replies.
+MASC_TOOL_TIMEOUT_KEEPER_MSG_SEC=60
 
 # Use planner-based selection (true = daily plan priority, false = legacy least-recent)
 MASC_LODGE_USE_PLANNER=true

--- a/lib/context_manager.ml
+++ b/lib/context_manager.ml
@@ -317,6 +317,7 @@ let role_of_string = function
   | "assistant" -> Llm_client.Assistant | _ -> Llm_client.Tool
 
 let message_to_json (m : Llm_client.message) : Yojson.Safe.t =
+  let m = Llm_client.sanitize_message_utf8 m in
   let base = [
     ("role", `String (role_to_string m.role));
     ("content", `String m.content);
@@ -331,14 +332,16 @@ let message_of_json (json : Yojson.Safe.t) : Llm_client.message =
   let open Yojson.Safe.Util in
   {
     role = json |> member "role" |> to_string |> role_of_string;
-    content = json |> member "content" |> to_string;
-    name = json |> member "name" |> to_string_option;
-    tool_call_id = json |> member "tool_call_id" |> to_string_option;
+    content = json |> member "content" |> to_string |> Llm_client.sanitize_text_utf8;
+    name = json |> member "name" |> to_string_option |> Option.map Llm_client.sanitize_text_utf8;
+    tool_call_id =
+      json |> member "tool_call_id" |> to_string_option
+      |> Option.map Llm_client.sanitize_text_utf8;
   }
 
 let serialize_context (ctx : working_context) : string =
   let json = `Assoc [
-    ("system_prompt", `String ctx.system_prompt);
+    ("system_prompt", `String (Llm_client.sanitize_text_utf8 ctx.system_prompt));
     ("messages", `List (List.map message_to_json ctx.messages));
     ("token_count", `Int ctx.token_count);
     ("max_tokens", `Int ctx.max_tokens);
@@ -346,9 +349,11 @@ let serialize_context (ctx : working_context) : string =
   Yojson.Safe.to_string json
 
 let deserialize_context (s : string) ~max_tokens : working_context =
-  let json = Yojson.Safe.from_string s in
+  let json = Yojson.Safe.from_string (Llm_client.sanitize_text_utf8 s) in
   let open Yojson.Safe.Util in
-  let system_prompt = json |> member "system_prompt" |> to_string in
+  let system_prompt =
+    json |> member "system_prompt" |> to_string |> Llm_client.sanitize_text_utf8
+  in
   let messages = json |> member "messages" |> to_list |> List.map message_of_json in
   let token_count = json |> member "token_count" |> to_int in
   { system_prompt; messages; token_count; max_tokens; importance_scores = [] }
@@ -360,7 +365,7 @@ let create_checkpoint ctx ~generation =
     generation;
     message_count = List.length ctx.messages;
     token_count = ctx.token_count;
-    serialized = serialize_context ctx;
+    serialized = serialize_context ctx |> Llm_client.sanitize_text_utf8;
   }
 
 let restore_checkpoint ckpt ~max_tokens =
@@ -385,6 +390,7 @@ let create_session ~session_id ~base_dir =
   { session_id; session_dir; full_history = []; checkpoints = [] }
 
 let persist_message session msg =
+  let msg = Llm_client.sanitize_message_utf8 msg in
   session.full_history <- session.full_history @ [msg];
   let path = Filename.concat session.session_dir "history.jsonl" in
   let now_ts = Time_compat.now () in
@@ -394,13 +400,18 @@ let persist_message session msg =
       `Assoc (("timestamp", `Float now_ts) :: ("ts_unix", `Float now_ts) :: fields)
     | j -> j
   in
-  let line = Yojson.Safe.to_string payload ^ "\n" in
+  let line =
+    (Yojson.Safe.to_string payload |> Llm_client.sanitize_text_utf8) ^ "\n"
+  in
   let fd = Unix.openfile path
     [Unix.O_WRONLY; Unix.O_CREAT; Unix.O_APPEND] 0o644 in
   Fun.protect ~finally:(fun () -> Unix.close fd) (fun () ->
     let _ = Unix.write_substring fd line 0 (String.length line) in ())
 
 let save_checkpoint session ckpt =
+  let ckpt =
+    { ckpt with serialized = Llm_client.sanitize_text_utf8 ckpt.serialized }
+  in
   session.checkpoints <- session.checkpoints @ [ckpt];
   let path = Filename.concat session.session_dir
     (sprintf "%s.json" ckpt.checkpoint_id) in
@@ -412,7 +423,7 @@ let save_checkpoint session ckpt =
     ("token_count", `Int ckpt.token_count);
     ("serialized", `String ckpt.serialized);
   ] in
-  let content = Yojson.Safe.to_string json in
+  let content = Yojson.Safe.to_string json |> Llm_client.sanitize_text_utf8 in
   let fd = Unix.openfile path [Unix.O_WRONLY; Unix.O_CREAT; Unix.O_TRUNC] 0o644 in
   Fun.protect ~finally:(fun () -> Unix.close fd) (fun () ->
     let _ = Unix.write_substring fd content 0 (String.length content) in ())
@@ -436,7 +447,11 @@ let load_latest_checkpoint session =
         let n = in_channel_length ic in
         let buf = Bytes.create n in
         really_input ic buf 0 n;
-        let json = Yojson.Safe.from_string (Bytes.to_string buf) in
+        let json =
+          Bytes.to_string buf
+          |> Llm_client.sanitize_text_utf8
+          |> Yojson.Safe.from_string
+        in
         let open Yojson.Safe.Util in
         Some {
           checkpoint_id = json |> member "checkpoint_id" |> to_string;
@@ -444,5 +459,6 @@ let load_latest_checkpoint session =
           generation = json |> member "generation" |> to_int;
           message_count = json |> member "message_count" |> to_int;
           token_count = json |> member "token_count" |> to_int;
-          serialized = json |> member "serialized" |> to_string;
+          serialized =
+            json |> member "serialized" |> to_string |> Llm_client.sanitize_text_utf8;
         })

--- a/lib/llm_client.ml
+++ b/lib/llm_client.ml
@@ -153,6 +153,35 @@ let string_of_role = function
   | Assistant -> "assistant"
   | Tool -> "tool"
 
+let sanitize_text_utf8 (s : string) : string =
+  let len = String.length s in
+  let buf = Buffer.create len in
+  let rec loop i =
+    if i >= len then ()
+    else
+      let dec = String.get_utf_8_uchar s i in
+      let dlen = Uchar.utf_decode_length dec in
+      if dlen > 0 && Uchar.utf_decode_is_valid dec then (
+        Buffer.add_substring buf s i dlen;
+        loop (i + dlen))
+      else (
+        Buffer.add_string buf "\xEF\xBF\xBD";
+        loop (i + 1))
+  in
+  loop 0;
+  Buffer.contents buf
+
+let sanitize_message_utf8 (m : message) : message =
+  {
+    m with
+    content = sanitize_text_utf8 m.content;
+    name = Option.map sanitize_text_utf8 m.name;
+    tool_call_id = Option.map sanitize_text_utf8 m.tool_call_id;
+  }
+
+let sanitize_messages_utf8 (msgs : message list) : message list =
+  List.map sanitize_message_utf8 msgs
+
 (* ================================================================ *)
 (* Built-in Model Specs                                             *)
 (* ================================================================ *)
@@ -271,6 +300,7 @@ let string_opt_to_json = function
   | None -> `Null
 
 let message_fingerprint_json (m : message) : Yojson.Safe.t =
+  let m = sanitize_message_utf8 m in
   `Assoc
     [
       ("role", `String (string_of_role m.role));
@@ -458,7 +488,9 @@ let tool_def_to_openai_json (td : tool_def) : Yojson.Safe.t =
     Gemini's OpenAI-compat endpoint uses [max_completion_tokens] (thinking models
     consume internal tokens from this budget, so [max_tokens] alone under-allocates). *)
 let build_openai_body (req : completion_request) : string =
-  let messages_json = List.map message_to_openai_json req.messages in
+  let messages_json =
+    req.messages |> sanitize_messages_utf8 |> List.map message_to_openai_json
+  in
   let max_token_fields = match req.model.provider with
     | Gemini ->
       (* Gemini 2.5+ thinking models consume internal thinking tokens from the
@@ -487,11 +519,12 @@ let build_openai_body (req : completion_request) : string =
 
 (** Build Anthropic Messages API request body. *)
 let build_claude_body (req : completion_request) : string =
+  let sanitized_messages = sanitize_messages_utf8 req.messages in
   (* Claude uses separate system parameter *)
   let system_text = List.fold_left (fun acc m ->
     match m.role with System -> acc ^ m.content ^ "\n" | _ -> acc
-  ) "" req.messages |> String.trim in
-  let non_system = List.filter (fun m -> m.role <> System) req.messages in
+  ) "" sanitized_messages |> String.trim in
+  let non_system = List.filter (fun m -> m.role <> System) sanitized_messages in
   let messages_json = List.map (fun m ->
     `Assoc [
       ("role", `String (string_of_role m.role));
@@ -860,7 +893,9 @@ let curl_post ~url ~headers ~body ~timeout_sec : (string, string) result =
     Uses the same message format as OpenAI but adds Ollama-specific fields.
     Includes tools when provided - Ollama supports OpenAI-compatible tool format. *)
 let build_ollama_chat_body (req : completion_request) : string =
-  let messages_json = List.map message_to_openai_json req.messages in
+  let messages_json =
+    req.messages |> sanitize_messages_utf8 |> List.map message_to_openai_json
+  in
   let base = [
     ("model", `String req.model.model_id);
     ("messages", `List messages_json);
@@ -893,6 +928,7 @@ let call_ollama_chat ?timeout_sec (req : completion_request) : (completion_respo
 (** Ollama fallback: /api/generate for models without chat support. *)
 let call_ollama_generate ?timeout_sec (req : completion_request) : (completion_response, string) result =
   let url = sprintf "%s/api/generate" req.model.api_url in
+  let sanitized_messages = sanitize_messages_utf8 req.messages in
   let prompt = List.fold_left (fun acc m ->
     match m.role with
     | System -> sprintf "%s[System] %s\n" acc m.content
@@ -900,7 +936,7 @@ let call_ollama_generate ?timeout_sec (req : completion_request) : (completion_r
     | Assistant -> sprintf "%s[Assistant] %s\n" acc m.content
     | Tool -> sprintf "%s[Tool:%s] %s\n" acc
                 (Option.value ~default:"" m.name) m.content
-  ) "" req.messages in
+  ) "" sanitized_messages in
   let body = Yojson.Safe.to_string (`Assoc [
     ("model", `String req.model.model_id);
     ("prompt", `String prompt);

--- a/lib/llm_client.mli
+++ b/lib/llm_client.mli
@@ -154,6 +154,15 @@ val user_msg : string -> message
 val assistant_msg : string -> message
 val tool_msg : name:string -> call_id:string -> string -> message
 
+(** Repair malformed UTF-8 in arbitrary text. *)
+val sanitize_text_utf8 : string -> string
+
+(** Repair malformed UTF-8 in a single message before request serialization. *)
+val sanitize_message_utf8 : message -> message
+
+(** Repair malformed UTF-8 across a message list before request serialization. *)
+val sanitize_messages_utf8 : message list -> message list
+
 (** Estimate token count for a message list (heuristic: ~4 chars per token). *)
 val estimate_tokens : message list -> int
 

--- a/lib/lodge_cascade.ml
+++ b/lib/lodge_cascade.ml
@@ -41,14 +41,25 @@ let load_json_file path =
   | exn -> Error (Printexc.to_string exn)
 
 let default_config_path () =
-  let me =
-    Sys.getenv_opt "ME_ROOT"
-    |> Option.value
-         ~default:(Sys.getenv_opt "HOME" |> Option.value ~default:"/tmp")
+  let candidates =
+    let cwd_candidate =
+      Filename.concat (Sys.getcwd ()) "config/llm_cascade.json"
+    in
+    let me_root_candidate =
+      let me =
+        Sys.getenv_opt "ME_ROOT"
+        |> Option.value
+             ~default:(Sys.getenv_opt "HOME" |> Option.value ~default:"/tmp")
+      in
+      Filename.concat
+        (Filename.concat me "workspace/yousleepwhen/masc-mcp")
+        "config/llm_cascade.json"
+    in
+    [ cwd_candidate; me_root_candidate ]
   in
-  Filename.concat
-    (Filename.concat me "workspace/yousleepwhen/masc-mcp")
-    "config/llm_cascade.json"
+  match List.find_opt Sys.file_exists candidates with
+  | Some path -> path
+  | None -> List.hd candidates
 
 let default_model_strings ~cascade_name =
   match cascade_name with

--- a/lib/lodge_decision.ml
+++ b/lib/lodge_decision.ml
@@ -62,12 +62,43 @@ let trim_opt = function
 
 let extract_json_object (response : string) : (string, string) result =
   let trimmed = String.trim response in
-  try
-    let start_idx = String.index trimmed '{' in
-    let end_idx = String.rindex trimmed '}' in
-    if end_idx < start_idx then Error "missing JSON object terminator"
-    else Ok (String.sub trimmed start_idx (end_idx - start_idx + 1))
-  with Not_found -> Error "missing JSON object"
+  let len = String.length trimmed in
+  let rec find_start i =
+    if i >= len then None
+    else if trimmed.[i] = '{' then Some i
+    else find_start (i + 1)
+  in
+  let rec find_end i depth in_string escaped =
+    if i >= len then None
+    else
+      let ch = trimmed.[i] in
+      if in_string then
+        if escaped then find_end (i + 1) depth true false
+        else if ch = '\\' then find_end (i + 1) depth true true
+        else if ch = '"' then find_end (i + 1) depth false false
+        else find_end (i + 1) depth true false
+      else
+        match ch with
+        | '"' -> find_end (i + 1) depth true false
+        | '{' -> find_end (i + 1) (depth + 1) false false
+        | '}' ->
+            if depth = 1 then Some i
+            else if depth > 1 then find_end (i + 1) (depth - 1) false false
+            else None
+        | _ -> find_end (i + 1) depth false false
+  in
+  match find_start 0 with
+  | None -> Error "missing JSON object"
+  | Some start_idx -> (
+      match find_end start_idx 0 false false with
+      | None -> Error "missing JSON object terminator"
+      | Some end_idx ->
+          Ok (String.sub trimmed start_idx (end_idx - start_idx + 1)))
+
+let contains_json_object response =
+  match extract_json_object response with
+  | Ok _ -> true
+  | Error _ -> false
 
 let parse_confidence json =
   match json with

--- a/lib/lodge_decision.mli
+++ b/lib/lodge_decision.mli
@@ -67,6 +67,7 @@ val parse_batch_outcome :
 val action_to_string : action -> string
 
 val extract_json_object : string -> (string, string) result
+val contains_json_object : string -> bool
 
 val selection_prompt :
   agent_name:string ->

--- a/lib/lodge_heartbeat.ml
+++ b/lib/lodge_heartbeat.ml
@@ -841,6 +841,10 @@ let load_agents_from_neo4j () =
   let gql_query = "{\"query\": \"{ agents(first: 25) { edges { node { name preferredHours peakHour traits interests activityLevel personalityHint } } } }\"}" in
   let api_key = Sys.getenv_opt "GRAPHQL_API_KEY" |> Option.value ~default:"" in
   Printf.eprintf "[Heartbeat] Loading agents via GraphQL (key=%d chars)...\n%!" (String.length api_key);
+  if String.trim api_key = "" then (
+    Eio.traceln "⚠️ [Heartbeat] GRAPHQL_API_KEY missing; using builtin core agents";
+    builtin_core_agents ())
+  else
   match graphql_request ~timeout_sec:5.0 gql_query with
   | Error err ->
       Eio.traceln "⚠️ [Heartbeat] GraphQL request failed: %s" err;
@@ -2125,21 +2129,27 @@ let tom_context_for_posts ~agent_name (posts : Board.post list) =
              (Lodge_tom.tom_prompt_section predictions)))
   |> String.concat "\n\n"
 
-let heartbeat_response_is_valid s =
+let heartbeat_response_is_valid ?(require_json = false) s =
   let len = String.length s in
   let s_lower = String.lowercase_ascii s in
-  len > 10
+  let base_valid =
+    len > 10
   && not (len >= 5 && String.sub s_lower 0 5 = "error")
   && not (len >= 14 && String.sub s 0 14 = "Empty response")
   && not (len >= 9 && String.sub s 0 9 = "{\"error\":")
   && not (String.length s_lower >= 19 && String.sub s_lower 0 19 = "you've hit your lim")
   && not (String.length s_lower >= 10 && String.sub s_lower 0 10 = "rate limit")
+  in
+  base_valid
+  && ((not require_json) || Lodge_decision.contains_json_object s)
 
-let heartbeat_response_accepted (resp : Llm_client.completion_response) =
-  heartbeat_response_is_valid resp.content
+let heartbeat_response_accepted ?(require_json = false)
+    (resp : Llm_client.completion_response) =
+  heartbeat_response_is_valid ~require_json resp.content
 
-let run_heartbeat_llm_once ~agent_name ~prompt =
+let run_heartbeat_llm_once ?(require_json = false) ~agent_name ~prompt () =
   let models = Lodge_cascade.get_cascade ~cascade_name:"heartbeat_action" () in
+  let heartbeat_max_tokens = 1200 in
   let started_at = Time_compat.now () in
   let result =
     if models = [] then (
@@ -2148,8 +2158,8 @@ let run_heartbeat_llm_once ~agent_name ~prompt =
       Error "no heartbeat model pool available")
     else
       Llm_client.run_prompt_cascade ~timeout_sec:60
-        ~accept:heartbeat_response_accepted ~model_specs:models ~max_tokens:4000
-        ~prompt ()
+        ~accept:(heartbeat_response_accepted ~require_json)
+        ~model_specs:models ~max_tokens:heartbeat_max_tokens ~prompt ()
   in
   let duration_ms =
     int_of_float ((Time_compat.now () -. started_at) *. 1000.0)
@@ -2165,12 +2175,14 @@ let run_heartbeat_llm_once ~agent_name ~prompt =
       Printf.printf "   ❌ [%s] Heartbeat cascade failed: %s\n%!" agent_name err;
       { Lodge_cascade.response = ""; llm_used = "none"; duration_ms }
 
-let run_heartbeat_llm_traced ~agent_name ~phase ~prompt =
+let run_heartbeat_llm_traced ?(require_json = false) ~agent_name ~phase ~prompt () =
   let tick_id =
     Printf.sprintf "%s-%d" agent_name
       (int_of_float (Time_compat.now () *. 1000.0) mod 1000000)
   in
-  let cascade_result = run_heartbeat_llm_once ~agent_name ~prompt in
+  let cascade_result =
+    run_heartbeat_llm_once ~require_json ~agent_name ~prompt ()
+  in
   save_trace
     {
       tick_id;
@@ -2245,6 +2257,29 @@ let checkin_result_of_completion ~agent_name (completion : Lodge_worker.completi
       Skipped
         (Option.value ~default:completion.summary completion.failure_reason)
 
+let fallback_tool_loop_assignment
+    ~agent_name
+    ~trigger_reason
+    ~sorted_posts:(sorted_posts : Board.post list) =
+  let target_post_id =
+    match sorted_posts with
+    | (post : Board.post) :: _ -> Some (Board.Post_id.to_string post.id)
+    | [] -> None
+  in
+  ({ agent_name;
+    target_post_id;
+    goal =
+      (match target_post_id with
+       | Some post_id ->
+           Printf.sprintf
+             "Inspect post %s and decide whether to comment, upvote, or skip using the allowed MCP tools directly."
+             post_id
+       | None ->
+           "No candidate post was selected by the planner. Inspect the current room and decide whether to post, comment, or skip using the allowed MCP tools directly.");
+    reason = "fallback selection after planner parse failure: " ^ trigger_reason;
+    confidence = 0.25;
+  } : Lodge_decision.assignment)
+
 let select_tool_loop_assignment ~agent_name ~trigger ~trigger_reason ~recent_posts =
   let profile = load_agent_profile ~agent_name in
   let signature = Lodge_reaction.get_or_compute_signature ~agent_name in
@@ -2280,7 +2315,8 @@ let select_tool_loop_assignment ~agent_name ~trigger ~trigger_reason ~recent_pos
       ~max_agents:1 ~allow_post:(List.mem "masc_board_post" allowed_tools)
   in
   let cascade_result =
-    run_heartbeat_llm_traced ~agent_name ~phase:"lodge_tool_assignment" ~prompt
+    run_heartbeat_llm_traced
+      ~require_json:true ~agent_name ~phase:"lodge_tool_assignment" ~prompt ()
   in
   match
     Lodge_decision.parse_selection_plan ~allowed_agents:[ agent_name ]
@@ -2291,7 +2327,12 @@ let select_tool_loop_assignment ~agent_name ~trigger ~trigger_reason ~recent_pos
   | Ok { assignments = assignment :: _; _ } ->
       Ok (assignment, identity_prompt, sorted_posts, allowed_tools)
   | Ok _ -> Error "selection returned no assignments"
-  | Error reason -> Error reason
+  | Error _reason ->
+      Ok
+        ( fallback_tool_loop_assignment ~agent_name ~trigger_reason ~sorted_posts,
+          identity_prompt,
+          sorted_posts,
+          allowed_tools )
 
 let run_agent_tool_loop ~agent_name ~trigger ~trigger_reason ~recent_posts =
   match select_tool_loop_assignment ~agent_name ~trigger ~trigger_reason ~recent_posts with
@@ -2363,7 +2404,8 @@ let decide_agent_action ~agent_name ~trigger ~trigger_reason ~recent_posts =
       ~allow_post:(trigger_allows_post trigger)
   in
   let cascade_result =
-    run_heartbeat_llm_traced ~agent_name ~phase:"lodge_decision" ~prompt
+    run_heartbeat_llm_traced
+      ~require_json:true ~agent_name ~phase:"lodge_decision" ~prompt ()
   in
   let llm_used = Some cascade_result.Lodge_cascade.llm_used in
   let response = cascade_result.Lodge_cascade.response in
@@ -2544,7 +2586,7 @@ let execute_agent_action ~agent_name ~action =
     Wraps the LLM cascade in a simple (prompt -> string) signature. *)
 let make_call_llm ~agent_name : (prompt:string -> string) =
   fun ~prompt ->
-    (run_heartbeat_llm_once ~agent_name ~prompt).Lodge_cascade.response
+    (run_heartbeat_llm_once ~agent_name ~prompt ()).Lodge_cascade.response
 
 (** {1 Plan-based Agent Selection} *)
 

--- a/lib/tool_keeper.ml
+++ b/lib/tool_keeper.ml
@@ -1380,6 +1380,57 @@ let model_specs_of_strings (model_strs : string list) : (Llm_client.model_spec l
   in
   go [] model_strs
 
+let env_present name =
+  match Sys.getenv_opt name with
+  | Some value -> String.trim value <> ""
+  | None -> false
+
+let ollama_port_listening () =
+  Sys.command "lsof -iTCP:11434 -sTCP:LISTEN -t >/dev/null 2>&1" = 0
+
+let model_spec_is_local_runtime (model : Llm_client.model_spec) =
+  match model.provider with
+  | Llm_client.Ollama | Llm_client.Llama -> true
+  | _ -> false
+
+let model_spec_is_available (model : Llm_client.model_spec) =
+  match model.provider with
+  | Llm_client.Ollama -> ollama_port_listening ()
+  | Llm_client.Llama -> true
+  | _ -> true
+
+let keeper_fallback_model_labels () =
+  let gemini_available =
+    match Provider_adapter.resolve_gemini_direct_auth () with
+    | Provider_adapter.Gemini_api_key
+    | Provider_adapter.Gemini_vertex_adc _ -> true
+    | Provider_adapter.Gemini_auth_missing _ -> false
+  in
+  let candidates =
+    [
+      (env_present "ZAI_API_KEY", "glm:glm-4.7");
+      (gemini_available, "gemini:gemini-2.5-pro");
+      (env_present "ANTHROPIC_API_KEY", "claude:claude-sonnet-4-5-20250929");
+    ]
+  in
+  candidates
+  |> List.filter_map (fun (enabled, label) -> if enabled then Some label else None)
+
+let maybe_append_keeper_fallback_models (models : string list) =
+  match model_specs_of_strings models with
+  | Error _ -> models
+  | Ok specs ->
+      let all_local = specs <> [] && List.for_all model_spec_is_local_runtime specs in
+      let any_available = List.exists model_spec_is_available specs in
+      if (not all_local) || any_available then
+        models
+      else
+        let extra =
+          keeper_fallback_model_labels ()
+          |> List.filter (fun label -> not (List.mem label models))
+        in
+        if extra = [] then models else models @ extra
+
 let ensure_api_keys (models : Llm_client.model_spec list) : (unit, string) result =
   let missing =
     List.filter_map (fun (m : Llm_client.model_spec) ->
@@ -7965,6 +8016,9 @@ let handle_keeper_msg ctx args : tool_result =
       let gate_config = Eval_gate.default_config in
       let effective_models =
         if inline_models <> [] then inline_models else meta.models
+      in
+      let effective_models =
+        maybe_append_keeper_fallback_models effective_models
       in
       (match model_specs_of_strings effective_models with
        | Error e -> (false, "❌ " ^ e)

--- a/start-masc-mcp.sh
+++ b/start-masc-mcp.sh
@@ -22,9 +22,40 @@ fi
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cd "$SCRIPT_DIR"
 
+resolve_repo_env_root() {
+    if command -v git >/dev/null 2>&1; then
+        local common_dir
+        common_dir="$(git -C "$SCRIPT_DIR" rev-parse --git-common-dir 2>/dev/null || true)"
+        if [ -n "$common_dir" ]; then
+            if [[ "$common_dir" != /* ]]; then
+                common_dir="$SCRIPT_DIR/$common_dir"
+            fi
+            common_dir="$(cd "$(dirname "$common_dir")" && pwd)"
+            echo "$common_dir"
+            return
+        fi
+    fi
+    echo "$SCRIPT_DIR"
+}
+
+load_env_file() {
+    local path="$1"
+    if [ -f "$path" ]; then
+        set -a; source "$path" 2>/dev/null || true; set +a
+    fi
+}
+
+REPO_ENV_ROOT="$(resolve_repo_env_root)"
+
 # Load secrets from the user profile; tracked plist files must not embed them.
-if [ -f "$HOME/.zshenv" ]; then
-    set -a; source "$HOME/.zshenv" 2>/dev/null || true; set +a
+load_env_file "$HOME/.zshenv"
+
+# Load repo-local env for development overrides and secrets kept out of user shell.
+load_env_file "$REPO_ENV_ROOT/.env"
+load_env_file "$REPO_ENV_ROOT/.env.local"
+if [ "$REPO_ENV_ROOT" != "$SCRIPT_DIR" ]; then
+    load_env_file "$SCRIPT_DIR/.env"
+    load_env_file "$SCRIPT_DIR/.env.local"
 fi
 
 # Load Lodge heartbeat configuration (env vars override plist defaults)

--- a/test/test_lodge_decision.ml
+++ b/test/test_lodge_decision.ml
@@ -137,6 +137,20 @@ let test_parse_selection_plan_rejects_duplicate_agents () =
   | Error err ->
       check bool "duplicate error surfaced" true (String.length err > 0)
 
+let test_extract_json_object_from_fenced_block () =
+  let response =
+    "Planner output:\n```json\n{\"assignments\":[{\"agent_name\":\"dreamer\",\"target_post_id\":\"p-1\",\"goal\":\"comment\",\"reason\":\"best match\",\"confidence\":0.8}]}\n```"
+  in
+  match Lodge_decision.extract_json_object response with
+  | Ok json ->
+      check bool "contains assignments"
+        true (String.contains json '{' && String.contains json '}')
+  | Error err -> failf "expected fenced json extraction, got %s" err
+
+let test_contains_json_object_rejects_plain_text () =
+  let response = "dreamer should probably comment on the latest post" in
+  check bool "no json object" false (Lodge_decision.contains_json_object response)
+
 let () =
   run "Lodge decision"
     [
@@ -154,5 +168,9 @@ let () =
             test_parse_selection_plan_valid;
           test_case "selection plan rejects duplicate agents" `Quick
             test_parse_selection_plan_rejects_duplicate_agents;
+          test_case "extract json from fenced block" `Quick
+            test_extract_json_object_from_fenced_block;
+          test_case "reject plain text json extraction" `Quick
+            test_contains_json_object_rejects_plain_text;
         ] );
     ]

--- a/test/test_perpetual.ml
+++ b/test/test_perpetual.ml
@@ -300,6 +300,26 @@ let test_context_manager () = group "Context Manager" (fun () ->
   assert_equal "restore:msg_count" 2 (List.length restored.messages);
   assert_equal "restore:max_tokens" 1000 restored.max_tokens;
 
+  (* 12b. Checkpoint restore repairs malformed UTF-8 from legacy storage *)
+  let dirty_serialized =
+    "{\"system_prompt\":\"test\",\"messages\":[{\"role\":\"user\",\"content\":\"hel\x80lo\"},{\"role\":\"assistant\",\"content\":\"wor\xFFld\"}],\"token_count\":2,\"max_tokens\":1000}"
+  in
+  let dirty_ckpt = { ckpt with serialized = dirty_serialized } in
+  let repaired = Context_manager.restore_checkpoint dirty_ckpt ~max_tokens:1000 in
+  assert_equal "restore:utf8_msg_count" 2 (List.length repaired.messages);
+  assert_true "restore:utf8_content_valid"
+    (List.for_all
+       (fun (msg : Llm_client.message) ->
+         let rec valid_from i =
+           if i >= String.length msg.content then true
+           else
+             let dec = String.get_utf_8_uchar msg.content i in
+             let dlen = Uchar.utf_decode_length dec in
+             dlen > 0 && Uchar.utf_decode_is_valid dec && valid_from (i + dlen)
+         in
+         valid_from 0)
+       repaired.messages);
+
   (* 13. DropLowImportance *)
   let ctx8 = Context_manager.append_many
     (Context_manager.create ~system_prompt:"test" ~max_tokens:10000) [

--- a/test/test_tool_keeper.ml
+++ b/test/test_tool_keeper.ml
@@ -30,10 +30,99 @@ let test_read_file_tail_lines_keeps_line_boundary_start () =
     let lines = Masc_mcp.Tool_keeper.read_file_tail_lines path ~max_bytes ~max_lines:10 in
     check (list string) "keeps full first line" ["BBBBB"; "CCCCC"; "DDDDD"] lines)
 
+let with_env name value f =
+  let original = Sys.getenv_opt name in
+  Fun.protect
+    ~finally:(fun () ->
+      match original with
+      | Some v -> Unix.putenv name v
+      | None -> Unix.putenv name "")
+    (fun () ->
+      Unix.putenv name value;
+      f ())
+
+let string_is_valid_utf8 s =
+  let len = String.length s in
+  let rec loop i =
+    if i >= len then true
+    else
+      let dec = String.get_utf_8_uchar s i in
+      let dlen = Uchar.utf_decode_length dec in
+      dlen > 0 && Uchar.utf_decode_is_valid dec && loop (i + dlen)
+  in
+  loop 0
+
+let test_keeper_fallback_model_labels_prefers_available_remote_models () =
+  with_env "ZAI_API_KEY" "zai-test" (fun () ->
+      with_env "ANTHROPIC_API_KEY" "" (fun () ->
+          with_env "GEMINI_API_KEY" "" (fun () ->
+              let labels = Masc_mcp.Tool_keeper.keeper_fallback_model_labels () in
+              check (list string) "glm fallback only" ["glm:glm-4.7"] labels)))
+
+let test_maybe_append_keeper_fallback_models_adds_glm_when_local_only () =
+  with_env "ZAI_API_KEY" "zai-test" (fun () ->
+      let labels =
+        Masc_mcp.Tool_keeper.maybe_append_keeper_fallback_models
+          ["ollama:glm-4.7-flash"]
+      in
+      let ollama_listening =
+        Sys.command "lsof -iTCP:11434 -sTCP:LISTEN -t >/dev/null 2>&1" = 0
+      in
+      let expected =
+        if ollama_listening then
+          ["ollama:glm-4.7-flash"]
+        else
+          ["ollama:glm-4.7-flash"; "glm:glm-4.7"]
+      in
+      check (list string) "append glm fallback only when local runtime unavailable"
+        expected labels)
+
+let test_llm_client_sanitize_message_utf8_repairs_invalid_fields () =
+  let raw =
+    {
+      Masc_mcp.Llm_client.role = Masc_mcp.Llm_client.User;
+      content = "hello\x80.world";
+      name = Some "to\xFFol";
+      tool_call_id = Some "id\x80";
+    }
+  in
+  let sanitized = Masc_mcp.Llm_client.sanitize_message_utf8 raw in
+  check bool "role preserved" true (sanitized.role = raw.role);
+  check bool "content valid utf8" true (string_is_valid_utf8 sanitized.content);
+  check bool "content changed" true (sanitized.content <> raw.content);
+  check bool "name valid utf8" true
+    (match sanitized.name with Some v -> string_is_valid_utf8 v | None -> false);
+  check bool "tool_call_id valid utf8" true
+    (match sanitized.tool_call_id with Some v -> string_is_valid_utf8 v | None -> false);
+  check bool "name kept present" true (Option.is_some sanitized.name);
+  check bool "tool_call_id kept present" true (Option.is_some sanitized.tool_call_id)
+
+let test_llm_client_sanitize_messages_utf8_preserves_message_count () =
+  let msgs =
+    [
+      Masc_mcp.Llm_client.user_msg "ok\x80";
+      Masc_mcp.Llm_client.assistant_msg "fine\xFF";
+    ]
+  in
+  let sanitized = Masc_mcp.Llm_client.sanitize_messages_utf8 msgs in
+  check int "count preserved" 2 (List.length sanitized);
+  check bool "all valid utf8" true
+    (List.for_all
+       (fun (msg : Masc_mcp.Llm_client.message) -> string_is_valid_utf8 msg.content)
+       sanitized)
+
 let () =
   run "Tool_keeper" [
     ("read_file_tail_lines", [
          test_case "drops partial first line" `Quick test_read_file_tail_lines_drops_partial_first_line;
          test_case "keeps line-boundary start" `Quick test_read_file_tail_lines_keeps_line_boundary_start;
+         test_case "fallback labels prefer available remote models" `Quick
+           test_keeper_fallback_model_labels_prefers_available_remote_models;
+         test_case "append glm fallback for local only model" `Quick
+           test_maybe_append_keeper_fallback_models_adds_glm_when_local_only;
+         test_case "llm client repairs invalid utf8 fields" `Quick
+           test_llm_client_sanitize_message_utf8_repairs_invalid_fields;
+         test_case "llm client preserves message list size" `Quick
+           test_llm_client_sanitize_messages_utf8_preserves_message_count;
        ]);
   ]


### PR DESCRIPTION
## Summary
- repair malformed UTF-8 across keeper prompt serialization and checkpoint/history restore paths
- make lodge planner require JSON and fall back safely when selection parsing fails
- stabilize local startup/runtime by loading repo env files, reducing Lodge fan-out, and honoring worktree llm cascade config

## Verification
- dune build --root "/Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix-keeper-lodge-fallback-v2" --display short
- ./_build/default/test/test_tool_keeper.exe
- ./_build/default/test/test_lodge_decision.exe
- ./_build/default/test/test_perpetual.exe
- live check: masc_keeper_msg on :8935 returned ok with glm-4.7 after restart
