### PR TITLE
fix(room): server-side join dedup in Room.join

### DIFF
--- a/lib/room.ml
+++ b/lib/room.ml
@@ -316,7 +316,30 @@ and join config ~agent_name ?(agent_type_override=None) ~capabilities
       Nickname.generate agent_type  (* Generate new nickname *)
   in
 
-  (* Collect metadata *)
+  (* Dedup: if agent already joined, update last_seen and return early *)
+  let agent_file_dedup = Filename.concat (agents_dir config) (safe_filename nickname ^ ".json") in
+  let already_joined =
+    if is_pg_backend config then
+      let agent_key = Printf.sprintf "agents:%s" (safe_filename nickname) in
+      backend_exists config ~key:agent_key || Sys.file_exists agent_file_dedup
+    else
+      Sys.file_exists agent_file_dedup
+  in
+  if already_joined then begin
+    let existing_json = read_json config agent_file_dedup in
+    (match agent_of_yojson existing_json with
+     | Ok existing_agent ->
+       let updated = { existing_agent with last_seen = now_iso () } in
+       write_json config agent_file_dedup (agent_to_yojson updated);
+       if is_pg_backend config then begin
+         let agent_key = Printf.sprintf "agents:%s" (safe_filename nickname) in
+         let _ = backend_set config ~key:agent_key
+                   ~value:(Yojson.Safe.to_string (agent_to_yojson updated)) in ()
+       end
+     | Error _ -> ());
+    Printf.sprintf "✅ %s already in room (last_seen updated)" nickname
+  end else begin
+    (* Collect metadata *)
   let session_id = generate_session_id () in
   let meta : agent_meta = {
     session_id;
@@ -391,6 +414,7 @@ and join config ~agent_name ?(agent_type_override=None) ~capabilities
 • "✅ [작업] 완료!"
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 |} nickname nickname agent_type session_id
+  end
 
 (** Leave room *)
 and leave config ~agent_name =


### PR DESCRIPTION
## Summary

- PR #638의 dedup guard가 `room_eio.ml`에 잘못 배치되어, 실제 MCP 호출 경로(`mcp_server_eio.ml` → `Room.join`)에서 실행되지 않던 문제 수정
- `Room.join` 함수에 인라인 dedup guard 추가: 이미 joined된 agent는 `last_seen`만 갱신하고 early return
- broadcast, event log, 새 session_id 생성을 모두 skip하여 중복 `agent_join` 이벤트 방지

## 동작 변경

| 상태 | 변경 전 | 변경 후 |
|------|---------|---------|
| 이미 joined | 새 session_id 생성, 파일 덮어쓰기, broadcast, event log | last_seen 갱신만, 즉시 반환 |
| 새 agent | 정상 join | 정상 join (변경 없음) |

## Test plan

- [x] `dune build` 성공
- [x] `dune test` — Room 테스트 71건 전부 통과 (기존 MDAL 1건 실패는 무관)
- [ ] 서버 재시작 후 동일 agent로 2회 join → events JSONL에 `agent_join` 1건만 기록 확인
- [ ] 2회째 join 응답에 "already in room" 메시지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)