### PR TITLE
test: add proof criteria unit tests and shared harness framework

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # masc-mcp Makefile
 # Enterprise-ready development commands
 
-.PHONY: build test clean coverage coverage-summary coverage-html doc install-deps dev-setup fmt fmt-check ci viewer-build viewer-serve harness-game-view-contract harness-streamable-http-contract harness-trpg-session-contract harness-trpg-grimland-smoke viewer-local-e2e-check
+.PHONY: build test test-unit test-contract test-all clean coverage coverage-summary coverage-html doc install-deps dev-setup fmt fmt-check ci viewer-build viewer-serve harness-game-view-contract harness-streamable-http-contract harness-trpg-session-contract harness-trpg-grimland-smoke viewer-local-e2e-check
 
 # Default target
 all: build
@@ -10,9 +10,23 @@ all: build
 build:
 	dune build --root .
 
-# Run tests
+# Run tests (alias for test-unit)
 test:
 	dune test --root .
+
+# Unit tests only (no server required)
+test-unit:
+	dune test --root .
+
+# Contract harness (requires running server on :8935)
+test-contract:
+	bash scripts/harness/contract/team_session_contract.sh
+	bash scripts/harness/contract/streamable_http_contract.sh
+	bash scripts/harness/contract/game_view_precondition.sh
+	bash scripts/harness/contract/trpg_session_contract.sh
+
+# All tests: unit + contract
+test-all: test-unit test-contract
 
 # Clean build artifacts
 clean:

--- a/scripts/harness/contract/game_view_precondition.sh
+++ b/scripts/harness/contract/game_view_precondition.sh
@@ -1,46 +1,12 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-MCP_URL="${MCP_URL:-http://127.0.0.1:8935/mcp}"
 SESSION_ID="${SESSION_ID:-harness-gv-$(date +%s)-$$}"
 CURL_RETRY_COUNT="${CURL_RETRY_COUNT:-12}"
-CURL_RETRY_DELAY_SEC="${CURL_RETRY_DELAY_SEC:-1}"
+export CURL_RETRY_COUNT
 
-curl_post_mcp() {
-  local body="$1"
-  local attempt=1
-  while [ "$attempt" -le "$CURL_RETRY_COUNT" ]; do
-    local raw
-    if raw="$(curl -sS -m 20 -X POST "$MCP_URL" \
-      -H 'Content-Type: application/json' \
-      -H 'Accept: application/json, text/event-stream' \
-      -d "$body")"; then
-      printf "%s" "$raw"
-      return 0
-    fi
-    if [ "$attempt" -lt "$CURL_RETRY_COUNT" ]; then
-      sleep "$CURL_RETRY_DELAY_SEC"
-    fi
-    attempt=$((attempt + 1))
-  done
-  return 1
-}
-
-call_tool() {
-  local id="$1"
-  local name="$2"
-  local args_json="$3"
-  local raw
-  local sse_data
-  raw="$(curl_post_mcp "{\"jsonrpc\":\"2.0\",\"id\":$id,\"method\":\"tools/call\",\"params\":{\"name\":\"$name\",\"arguments\":$args_json}}")"
-
-  sse_data="$(printf "%s" "$raw" | sed -n 's/^data: //p' | tail -n1)"
-  if [ -n "$sse_data" ]; then
-    printf "%s" "$sse_data"
-  else
-    printf "%s" "$raw"
-  fi
-}
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/../lib/test_framework.sh"
 
 echo "[1/5] experiment.start without decision.finalize => expect PRECONDITION_REQUIRED"
 r1="$(call_tool 1001 "experiment.start" "{\"session_id\":\"$SESSION_ID\",\"hypothesis\":\"h\"}")"

--- a/scripts/harness/contract/team_session_contract.sh
+++ b/scripts/harness/contract/team_session_contract.sh
@@ -1,60 +1,13 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
-source "${ROOT_DIR}/scripts/harness/jsonrpc_sse.sh"
-
-MCP_URL="${MCP_URL:-http://127.0.0.1:8935/mcp}"
 AGENT_NAME="${AGENT_NAME:-team-session-harness}"
 DURATION_SEC="${DURATION_SEC:-120}"
 MCP_SESSION_ID="${MCP_SESSION_ID:-team-session-contract-$(date +%s)-$RANDOM}"
+export MCP_SESSION_ID
 
-curl_post_mcp() {
-  local body="$1"
-  local attempts=0
-  local max_attempts=4
-  local output=""
-  while [ "$attempts" -lt "$max_attempts" ]; do
-    if output="$(curl -sS -m 25 -X POST "$MCP_URL" \
-      -H 'Content-Type: application/json' \
-      -H 'Accept: application/json, text/event-stream' \
-      -H "mcp-session-id: $MCP_SESSION_ID" \
-      -d "$body" 2>/dev/null)"; then
-      printf "%s" "$output"
-      return 0
-    fi
-    attempts=$((attempts + 1))
-    sleep 1
-  done
-  return 1
-}
-
-call_tool() {
-  local id="$1"
-  local name="$2"
-  local args_json="$3"
-  local raw
-
-  raw="$(curl_post_mcp "{\"jsonrpc\":\"2.0\",\"id\":$id,\"method\":\"tools/call\",\"params\":{\"name\":\"$name\",\"arguments\":$args_json}}")"
-  jsonrpc_normalize_response "$raw" "$id"
-}
-
-extract_result() {
-  jq -c 'try (.result.content[0].text | fromjson | .result) catch empty'
-}
-
-extract_error() {
-  jq -r 'try (.result.content[0].text | fromjson | .message) catch (.error.message // "")'
-}
-
-require_ok() {
-  local payload="$1"
-  if ! printf "%s" "$payload" | jq -e . >/dev/null 2>&1; then
-    echo "FAIL: invalid json payload"
-    printf "%s\n" "$payload"
-    exit 1
-  fi
-}
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/../lib/test_framework.sh"
 
 echo "[1/12] masc_init"
 r1="$(call_tool 4101 "masc_init" "{\"agent_name\":\"$AGENT_NAME\"}")"

--- a/scripts/harness/contract/trpg_session_contract.sh
+++ b/scripts/harness/contract/trpg_session_contract.sh
@@ -1,52 +1,13 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-MCP_URL="${MCP_URL:-http://127.0.0.1:8935/mcp}"
 SESSION_ID="${SESSION_ID:-harness-trpg-session-$(date +%s)-$$}"
 ROOM_ID="${ROOM_ID:-}"
 CURL_RETRY_COUNT="${CURL_RETRY_COUNT:-12}"
-CURL_RETRY_DELAY_SEC="${CURL_RETRY_DELAY_SEC:-1}"
+export CURL_RETRY_COUNT
 
-curl_post_mcp() {
-  local body="$1"
-  local attempt=1
-  while [ "$attempt" -le "$CURL_RETRY_COUNT" ]; do
-    local raw
-    if raw="$(curl -sS -m 25 -X POST "$MCP_URL" \
-      -H 'Content-Type: application/json' \
-      -H 'Accept: application/json, text/event-stream' \
-      -d "$body")"; then
-      printf "%s" "$raw"
-      return 0
-    fi
-    if [ "$attempt" -lt "$CURL_RETRY_COUNT" ]; then
-      sleep "$CURL_RETRY_DELAY_SEC"
-    fi
-    attempt=$((attempt + 1))
-  done
-  return 1
-}
-
-call_tool() {
-  local id="$1"
-  local name="$2"
-  local args_json="$3"
-  local raw
-  local sse_data
-
-  raw="$(curl_post_mcp "{\"jsonrpc\":\"2.0\",\"id\":$id,\"method\":\"tools/call\",\"params\":{\"name\":\"$name\",\"arguments\":$args_json}}")"
-
-  sse_data="$(printf "%s" "$raw" | sed -n 's/^data: //p' | tail -n1)"
-  if [ -n "$sse_data" ]; then
-    printf "%s" "$sse_data"
-  else
-    printf "%s" "$raw"
-  fi
-}
-
-extract_payload() {
-  jq -c 'try (.result.content[0].text | fromjson | .payload) catch empty'
-}
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/../lib/test_framework.sh"
 
 echo "[1/6] trpg.preset.list"
 r1="$(call_tool 2001 "trpg.preset.list" "{}")"

--- a/scripts/harness/lib/test_framework.sh
+++ b/scripts/harness/lib/test_framework.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# Shared test framework for MCP contract harness scripts.
+#
+# Source this file after setting MCP_URL and other env vars.
+# Depends on: jsonrpc_sse.sh (auto-sourced)
+
+: "${MCP_URL:=http://127.0.0.1:8935/mcp}"
+: "${CURL_RETRY_COUNT:=4}"
+: "${CURL_RETRY_DELAY_SEC:=1}"
+: "${CURL_TIMEOUT_SEC:=25}"
+: "${MCP_SESSION_ID:=}"
+
+_HARNESS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+source "${_HARNESS_DIR}/jsonrpc_sse.sh"
+
+# POST a JSON body to the MCP endpoint with retry logic.
+# Includes mcp-session-id header when MCP_SESSION_ID is set.
+# Usage: curl_post_mcp '{"jsonrpc":"2.0",...}'
+curl_post_mcp() {
+  local body="$1"
+  local attempt=1
+  local output=""
+  local session_args=()
+  if [ -n "$MCP_SESSION_ID" ]; then
+    session_args=(-H "mcp-session-id: $MCP_SESSION_ID")
+  fi
+  while [ "$attempt" -le "$CURL_RETRY_COUNT" ]; do
+    if output="$(curl -sS -m "$CURL_TIMEOUT_SEC" -X POST "$MCP_URL" \
+      -H 'Content-Type: application/json' \
+      -H 'Accept: application/json, text/event-stream' \
+      "${session_args[@]}" \
+      -d "$body" 2>/dev/null)"; then
+      printf "%s" "$output"
+      return 0
+    fi
+    if [ "$attempt" -lt "$CURL_RETRY_COUNT" ]; then
+      sleep "$CURL_RETRY_DELAY_SEC"
+    fi
+    attempt=$((attempt + 1))
+  done
+  return 1
+}
+
+# Call an MCP tool and normalize SSE/JSON response.
+# Usage: call_tool <jsonrpc_id> <tool_name> <args_json>
+call_tool() {
+  local id="$1"
+  local name="$2"
+  local args_json="$3"
+  local raw
+  raw="$(curl_post_mcp "{\"jsonrpc\":\"2.0\",\"id\":$id,\"method\":\"tools/call\",\"params\":{\"name\":\"$name\",\"arguments\":$args_json}}")"
+  jsonrpc_normalize_response "$raw" "$id"
+}
+
+# Extract .result from MCP tool response content.
+# Usage: echo "$response" | extract_result
+extract_result() {
+  jq -c 'try (.result.content[0].text | fromjson | .result) catch empty'
+}
+
+# Extract .payload from MCP tool response content.
+# Usage: echo "$response" | extract_payload
+extract_payload() {
+  jq -c 'try (.result.content[0].text | fromjson | .payload) catch empty'
+}
+
+# Extract error message from MCP tool response.
+# Usage: echo "$response" | extract_error
+extract_error() {
+  jq -r 'try (.result.content[0].text | fromjson | .message) catch (.error.message // "")'
+}
+
+# Assert that a payload is valid JSON. Exits 1 on failure.
+# Usage: require_ok "$response"
+require_ok() {
+  local payload="$1"
+  if ! printf "%s" "$payload" | jq -e . >/dev/null 2>&1; then
+    echo "FAIL: invalid json payload"
+    printf "%s\n" "$payload"
+    exit 1
+  fi
+}
+
+# Print pass/fail summary line.
+# Usage: test_summary <harness_name> <pass_count> <total_count>
+test_summary() {
+  local name="$1"
+  local passed="$2"
+  local total="$3"
+  if [ "$passed" -eq "$total" ]; then
+    echo "PASS: $name ($passed/$total)"
+  else
+    echo "FAIL: $name ($passed/$total)"
+    return 1
+  fi
+}

--- a/test/dune
+++ b/test/dune
@@ -719,3 +719,9 @@
  (name test_speculative)
  (modules test_speculative)
  (libraries masc_mcp yojson unix str))
+
+; Proof criteria pure-function unit tests (no server required)
+(test
+ (name test_proof_criteria)
+ (modules test_proof_criteria)
+ (libraries masc_mcp alcotest yojson))

--- a/test/test_proof_criteria.ml
+++ b/test/test_proof_criteria.ml
@@ -1,0 +1,357 @@
+(** Unit tests for Team_session_report proof criteria pure functions.
+
+    These tests exercise make_standard_criteria, make_strong_criteria,
+    find_criterion, all_criteria_pass, and mandatory_ok_for_level
+    without requiring a running server. *)
+
+open Masc_mcp
+
+let check_bool msg expected actual =
+  Alcotest.(check bool) msg expected actual
+
+(* ------------------------------------------------------------ *)
+(* make_standard_criteria tests                                  *)
+(* ------------------------------------------------------------ *)
+
+let test_standard_all_pass () =
+  let criteria =
+    Team_session_report.make_standard_criteria ~event_started:true
+      ~checkpoints_count:1 ~turn_events:2 ~communication_total:3
+      ~goal_recorded:true ~participants_count:2
+      ~unique_turn_actors_count:2 ~required_turn_actors:2
+      ~unauthorized_turn_actors:[] ~report_json_exists:true
+      ~report_md_exists:true ~done_delta_total:5
+  in
+  check_bool "all_criteria_pass (happy path)" true
+    (Team_session_report.all_criteria_pass criteria);
+  check_bool "session_started_event" true
+    (Team_session_report.find_criterion criteria "session_started_event");
+  check_bool "checkpoint_recorded" true
+    (Team_session_report.find_criterion criteria "checkpoint_recorded");
+  check_bool "turn_or_communication_recorded" true
+    (Team_session_report.find_criterion criteria "turn_or_communication_recorded");
+  check_bool "goal_recorded" true
+    (Team_session_report.find_criterion criteria "goal_recorded");
+  check_bool "participants_recorded" true
+    (Team_session_report.find_criterion criteria "participants_recorded");
+  check_bool "multi_actor_turn_coverage" true
+    (Team_session_report.find_criterion criteria "multi_actor_turn_coverage");
+  check_bool "turn_actor_authorized" true
+    (Team_session_report.find_criterion criteria "turn_actor_authorized");
+  check_bool "report_artifacts" true
+    (Team_session_report.find_criterion criteria "report_artifacts");
+  check_bool "outcome_traceable" true
+    (Team_session_report.find_criterion criteria "outcome_traceable")
+
+let test_standard_all_fail () =
+  let criteria =
+    Team_session_report.make_standard_criteria ~event_started:false
+      ~checkpoints_count:0 ~turn_events:0 ~communication_total:0
+      ~goal_recorded:false ~participants_count:0
+      ~unique_turn_actors_count:0 ~required_turn_actors:2
+      ~unauthorized_turn_actors:["intruder"]
+      ~report_json_exists:false ~report_md_exists:false
+      ~done_delta_total:(-1)
+  in
+  check_bool "all_criteria_pass (all fail)" false
+    (Team_session_report.all_criteria_pass criteria);
+  check_bool "session_started_event fails" false
+    (Team_session_report.find_criterion criteria "session_started_event");
+  check_bool "checkpoint fails" false
+    (Team_session_report.find_criterion criteria "checkpoint_recorded");
+  check_bool "turn_or_communication fails" false
+    (Team_session_report.find_criterion criteria "turn_or_communication_recorded");
+  check_bool "unauthorized actors fail" false
+    (Team_session_report.find_criterion criteria "turn_actor_authorized");
+  check_bool "outcome_traceable fails (negative delta)" false
+    (Team_session_report.find_criterion criteria "outcome_traceable")
+
+(* ------------------------------------------------------------ *)
+(* Edge cases: boundary values                                   *)
+(* ------------------------------------------------------------ *)
+
+let test_checkpoint_boundary () =
+  let c0 =
+    Team_session_report.make_standard_criteria ~event_started:true
+      ~checkpoints_count:0 ~turn_events:1 ~communication_total:0
+      ~goal_recorded:true ~participants_count:1
+      ~unique_turn_actors_count:1 ~required_turn_actors:1
+      ~unauthorized_turn_actors:[] ~report_json_exists:true
+      ~report_md_exists:true ~done_delta_total:0
+  in
+  check_bool "checkpoint=0 fails" false
+    (Team_session_report.find_criterion c0 "checkpoint_recorded");
+  let c1 =
+    Team_session_report.make_standard_criteria ~event_started:true
+      ~checkpoints_count:1 ~turn_events:1 ~communication_total:0
+      ~goal_recorded:true ~participants_count:1
+      ~unique_turn_actors_count:1 ~required_turn_actors:1
+      ~unauthorized_turn_actors:[] ~report_json_exists:true
+      ~report_md_exists:true ~done_delta_total:0
+  in
+  check_bool "checkpoint=1 passes" true
+    (Team_session_report.find_criterion c1 "checkpoint_recorded")
+
+let test_turn_or_communication_edge () =
+  (* turn=0, communication=0 -> fail *)
+  let c_none =
+    Team_session_report.make_standard_criteria ~event_started:true
+      ~checkpoints_count:1 ~turn_events:0 ~communication_total:0
+      ~goal_recorded:true ~participants_count:1
+      ~unique_turn_actors_count:1 ~required_turn_actors:1
+      ~unauthorized_turn_actors:[] ~report_json_exists:true
+      ~report_md_exists:true ~done_delta_total:0
+  in
+  check_bool "turn=0,comm=0 fails" false
+    (Team_session_report.find_criterion c_none "turn_or_communication_recorded");
+  (* turn=0, communication=1 -> pass (OR logic) *)
+  let c_comm =
+    Team_session_report.make_standard_criteria ~event_started:true
+      ~checkpoints_count:1 ~turn_events:0 ~communication_total:1
+      ~goal_recorded:true ~participants_count:1
+      ~unique_turn_actors_count:1 ~required_turn_actors:1
+      ~unauthorized_turn_actors:[] ~report_json_exists:true
+      ~report_md_exists:true ~done_delta_total:0
+  in
+  check_bool "turn=0,comm=1 passes (OR)" true
+    (Team_session_report.find_criterion c_comm "turn_or_communication_recorded");
+  (* turn=1, communication=0 -> pass (OR logic) *)
+  let c_turn =
+    Team_session_report.make_standard_criteria ~event_started:true
+      ~checkpoints_count:1 ~turn_events:1 ~communication_total:0
+      ~goal_recorded:true ~participants_count:1
+      ~unique_turn_actors_count:1 ~required_turn_actors:1
+      ~unauthorized_turn_actors:[] ~report_json_exists:true
+      ~report_md_exists:true ~done_delta_total:0
+  in
+  check_bool "turn=1,comm=0 passes (OR)" true
+    (Team_session_report.find_criterion c_turn "turn_or_communication_recorded")
+
+let test_unauthorized_actors () =
+  let c_one =
+    Team_session_report.make_standard_criteria ~event_started:true
+      ~checkpoints_count:1 ~turn_events:1 ~communication_total:0
+      ~goal_recorded:true ~participants_count:1
+      ~unique_turn_actors_count:1 ~required_turn_actors:1
+      ~unauthorized_turn_actors:["x"]
+      ~report_json_exists:true ~report_md_exists:true ~done_delta_total:0
+  in
+  check_bool "one unauthorized actor fails" false
+    (Team_session_report.find_criterion c_one "turn_actor_authorized")
+
+let test_report_artifacts_partial () =
+  let c_json_only =
+    Team_session_report.make_standard_criteria ~event_started:true
+      ~checkpoints_count:1 ~turn_events:1 ~communication_total:0
+      ~goal_recorded:true ~participants_count:1
+      ~unique_turn_actors_count:1 ~required_turn_actors:1
+      ~unauthorized_turn_actors:[]
+      ~report_json_exists:true ~report_md_exists:false ~done_delta_total:0
+  in
+  check_bool "json only -> report_artifacts fails" false
+    (Team_session_report.find_criterion c_json_only "report_artifacts");
+  let c_md_only =
+    Team_session_report.make_standard_criteria ~event_started:true
+      ~checkpoints_count:1 ~turn_events:1 ~communication_total:0
+      ~goal_recorded:true ~participants_count:1
+      ~unique_turn_actors_count:1 ~required_turn_actors:1
+      ~unauthorized_turn_actors:[]
+      ~report_json_exists:false ~report_md_exists:true ~done_delta_total:0
+  in
+  check_bool "md only -> report_artifacts fails" false
+    (Team_session_report.find_criterion c_md_only "report_artifacts")
+
+let test_done_delta_boundary () =
+  let c_neg =
+    Team_session_report.make_standard_criteria ~event_started:true
+      ~checkpoints_count:1 ~turn_events:1 ~communication_total:0
+      ~goal_recorded:true ~participants_count:1
+      ~unique_turn_actors_count:1 ~required_turn_actors:1
+      ~unauthorized_turn_actors:[]
+      ~report_json_exists:true ~report_md_exists:true ~done_delta_total:(-1)
+  in
+  check_bool "done_delta=-1 fails" false
+    (Team_session_report.find_criterion c_neg "outcome_traceable");
+  let c_zero =
+    Team_session_report.make_standard_criteria ~event_started:true
+      ~checkpoints_count:1 ~turn_events:1 ~communication_total:0
+      ~goal_recorded:true ~participants_count:1
+      ~unique_turn_actors_count:1 ~required_turn_actors:1
+      ~unauthorized_turn_actors:[]
+      ~report_json_exists:true ~report_md_exists:true ~done_delta_total:0
+  in
+  check_bool "done_delta=0 passes" true
+    (Team_session_report.find_criterion c_zero "outcome_traceable")
+
+(* ------------------------------------------------------------ *)
+(* find_criterion: missing name returns false                    *)
+(* ------------------------------------------------------------ *)
+
+let test_find_criterion_missing () =
+  let criteria =
+    Team_session_report.make_standard_criteria ~event_started:true
+      ~checkpoints_count:1 ~turn_events:1 ~communication_total:0
+      ~goal_recorded:true ~participants_count:1
+      ~unique_turn_actors_count:1 ~required_turn_actors:1
+      ~unauthorized_turn_actors:[]
+      ~report_json_exists:true ~report_md_exists:true ~done_delta_total:0
+  in
+  check_bool "nonexistent criterion returns false" false
+    (Team_session_report.find_criterion criteria "nonexistent_criterion_xyz")
+
+(* ------------------------------------------------------------ *)
+(* mandatory_ok_for_level                                        *)
+(* ------------------------------------------------------------ *)
+
+let test_mandatory_standard_pass () =
+  let criteria =
+    Team_session_report.make_standard_criteria ~event_started:true
+      ~checkpoints_count:1 ~turn_events:1 ~communication_total:0
+      ~goal_recorded:true ~participants_count:1
+      ~unique_turn_actors_count:1 ~required_turn_actors:1
+      ~unauthorized_turn_actors:[]
+      ~report_json_exists:true ~report_md_exists:true ~done_delta_total:0
+  in
+  check_bool "standard mandatory ok" true
+    (Team_session_report.mandatory_ok_for_level
+       ~proof_level:Team_session_types.Proof_standard criteria)
+
+let test_mandatory_standard_fail_no_checkpoint () =
+  let criteria =
+    Team_session_report.make_standard_criteria ~event_started:true
+      ~checkpoints_count:0 ~turn_events:1 ~communication_total:0
+      ~goal_recorded:true ~participants_count:1
+      ~unique_turn_actors_count:1 ~required_turn_actors:1
+      ~unauthorized_turn_actors:[]
+      ~report_json_exists:true ~report_md_exists:true ~done_delta_total:0
+  in
+  check_bool "standard fails without checkpoint" false
+    (Team_session_report.mandatory_ok_for_level
+       ~proof_level:Team_session_types.Proof_standard criteria)
+
+let test_mandatory_strong_requires_all () =
+  (* Strong level: even a non-mandatory criterion failing should cause failure *)
+  let criteria =
+    Team_session_report.make_standard_criteria ~event_started:true
+      ~checkpoints_count:1 ~turn_events:1 ~communication_total:0
+      ~goal_recorded:false (* non-mandatory for standard, but strong requires all *)
+      ~participants_count:1
+      ~unique_turn_actors_count:1 ~required_turn_actors:1
+      ~unauthorized_turn_actors:[]
+      ~report_json_exists:true ~report_md_exists:true ~done_delta_total:0
+  in
+  check_bool "strong fails when goal missing" false
+    (Team_session_report.mandatory_ok_for_level
+       ~proof_level:Team_session_types.Proof_strong criteria)
+
+(* ------------------------------------------------------------ *)
+(* verdict_for_level                                             *)
+(* ------------------------------------------------------------ *)
+
+let test_verdict_standard_proved () =
+  Alcotest.(check string) "standard proved"
+    "proved"
+    (Team_session_report.verdict_for_level
+       ~proof_level:Team_session_types.Proof_standard ~mandatory_ok:true)
+
+let test_verdict_standard_insufficient () =
+  Alcotest.(check string) "standard insufficient"
+    "insufficient_evidence"
+    (Team_session_report.verdict_for_level
+       ~proof_level:Team_session_types.Proof_standard ~mandatory_ok:false)
+
+let test_verdict_strong_proved () =
+  Alcotest.(check string) "strong proved"
+    "proved_strong"
+    (Team_session_report.verdict_for_level
+       ~proof_level:Team_session_types.Proof_strong ~mandatory_ok:true)
+
+let test_verdict_strong_insufficient () =
+  Alcotest.(check string) "strong insufficient"
+    "insufficient_evidence_strong"
+    (Team_session_report.verdict_for_level
+       ~proof_level:Team_session_types.Proof_strong ~mandatory_ok:false)
+
+(* ------------------------------------------------------------ *)
+(* make_strong_criteria                                          *)
+(* ------------------------------------------------------------ *)
+
+let test_strong_criteria_all_pass () =
+  let criteria =
+    Team_session_report.make_strong_criteria ~required_spawn_agents:2
+      ~spawn_events:3 ~spawn_success_count:2 ~unique_spawn_agents_count:2
+      ~required_turn_actors:2 ~min_turn_events:5 ~turn_events:10
+      ~min_communication:3 ~communication_total:5 ~vote_events:2
+      ~run_deliverables:1 ~empty_note_turn_count:0
+  in
+  check_bool "strong all pass" true
+    (Team_session_report.all_criteria_pass criteria)
+
+let test_strong_criteria_empty_notes_fail () =
+  let criteria =
+    Team_session_report.make_strong_criteria ~required_spawn_agents:1
+      ~spawn_events:1 ~spawn_success_count:1 ~unique_spawn_agents_count:1
+      ~required_turn_actors:1 ~min_turn_events:1 ~turn_events:1
+      ~min_communication:1 ~communication_total:1 ~vote_events:1
+      ~run_deliverables:1 ~empty_note_turn_count:1
+  in
+  check_bool "empty_note_turns_absent fails" false
+    (Team_session_report.find_criterion criteria "empty_note_turns_absent")
+
+let test_strong_criteria_no_votes () =
+  let criteria =
+    Team_session_report.make_strong_criteria ~required_spawn_agents:1
+      ~spawn_events:1 ~spawn_success_count:1 ~unique_spawn_agents_count:1
+      ~required_turn_actors:1 ~min_turn_events:1 ~turn_events:1
+      ~min_communication:1 ~communication_total:1 ~vote_events:0
+      ~run_deliverables:1 ~empty_note_turn_count:0
+  in
+  check_bool "vote_evidence fails with 0 votes" false
+    (Team_session_report.find_criterion criteria "vote_evidence_present")
+
+(* ------------------------------------------------------------ *)
+(* Test runner                                                   *)
+(* ------------------------------------------------------------ *)
+
+let () =
+  Alcotest.run "proof_criteria"
+    [
+      ( "standard_criteria",
+        [
+          Alcotest.test_case "all pass" `Quick test_standard_all_pass;
+          Alcotest.test_case "all fail" `Quick test_standard_all_fail;
+          Alcotest.test_case "checkpoint boundary" `Quick test_checkpoint_boundary;
+          Alcotest.test_case "turn or communication edge" `Quick
+            test_turn_or_communication_edge;
+          Alcotest.test_case "unauthorized actors" `Quick test_unauthorized_actors;
+          Alcotest.test_case "report artifacts partial" `Quick
+            test_report_artifacts_partial;
+          Alcotest.test_case "done_delta boundary" `Quick test_done_delta_boundary;
+          Alcotest.test_case "find missing criterion" `Quick
+            test_find_criterion_missing;
+        ] );
+      ( "mandatory_ok",
+        [
+          Alcotest.test_case "standard pass" `Quick test_mandatory_standard_pass;
+          Alcotest.test_case "standard fail (no checkpoint)" `Quick
+            test_mandatory_standard_fail_no_checkpoint;
+          Alcotest.test_case "strong requires all" `Quick
+            test_mandatory_strong_requires_all;
+        ] );
+      ( "verdict",
+        [
+          Alcotest.test_case "standard proved" `Quick test_verdict_standard_proved;
+          Alcotest.test_case "standard insufficient" `Quick
+            test_verdict_standard_insufficient;
+          Alcotest.test_case "strong proved" `Quick test_verdict_strong_proved;
+          Alcotest.test_case "strong insufficient" `Quick
+            test_verdict_strong_insufficient;
+        ] );
+      ( "strong_criteria",
+        [
+          Alcotest.test_case "all pass" `Quick test_strong_criteria_all_pass;
+          Alcotest.test_case "empty notes fail" `Quick
+            test_strong_criteria_empty_notes_fail;
+          Alcotest.test_case "no votes fail" `Quick test_strong_criteria_no_votes;
+        ] );
+    ]


### PR DESCRIPTION
## Summary
- Add 18 Alcotest unit tests for `Team_session_report` proof criteria pure functions (no server required)
- Extract shared test framework (`scripts/harness/lib/test_framework.sh`) from 3 duplicated contract scripts (-100 lines)
- Add `test-unit`, `test-contract`, `test-all` Makefile targets to separate server-dependent tests

## Test plan
- [x] `dune exec test/test_proof_criteria.exe` — 18/18 PASS
- [x] `bash -n` syntax check on all 4 harness scripts
- [x] `dune build` — clean build
- [ ] `make test-contract` with running server (requires live :8935)

🤖 Generated with [Claude Code](https://claude.com/claude-code)