### PR TITLE
chore: bump version to 2.78.0

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -1,7 +1,7 @@
 (lang dune 3.13)
 
 (name masc_mcp)
-(version 2.77.0)
+(version 2.78.0)
 
 (generate_opam_files true)
 


### PR DESCRIPTION
## Summary
- Bump version from 2.77.0 to 2.78.0
- 1065 commits since v2.77.0 tag
- Covers 5-stream code quality fixes (PRs #643-#647) and Unix.select → Eio.Time.sleep migration (PR #650)

## Test plan
- [ ] `dune build` passes
- [ ] Version string updated in dune-project

🤖 Generated with [Claude Code](https://claude.com/claude-code)