### PR TITLE
test: add hermetic contract harness CI gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,6 +77,67 @@ jobs:
           opam exec -- dune fmt 2>&1 || true
           # Note: dune fmt may not be available, skip if so
 
+      - name: Verification matrix summary
+        run: |
+          echo "::notice::Required CI gates: dune test, test_sse_storm_e2e, contract harness suite"
+          echo "::notice::Optional env-gated suites not run here: PostgreSQL tests, live ICE/STUN, viewer-local-e2e-check, swarm/team-session workload harnesses"
+
+  contract:
+    name: Contract Harness
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup OCaml
+        uses: ocaml/setup-ocaml@v3
+        with:
+          ocaml-compiler: 5.4.x
+          dune-cache: true
+
+      - name: Pin external dependencies
+        run: |
+          chmod +x scripts/opam-pin-external-deps.sh
+          scripts/opam-pin-external-deps.sh
+
+      - name: Refresh system package index
+        run: sudo apt-get update -qq
+
+      - name: Install dependencies
+        run: |
+          for attempt in 1 2 3; do
+            opam install . --deps-only --yes && break
+            if [ "$attempt" -eq 3 ]; then
+              echo "opam install failed after ${attempt} attempts"
+              exit 1
+            fi
+            echo "opam install failed (attempt ${attempt}); retrying in 15s..."
+            sleep 15
+          done
+
+      - name: Build server executable
+        run: |
+          opam exec -- dune build ./bin/main_eio.exe
+
+      - name: Run contract harness suite
+        env:
+          ME_ROOT: /tmp/me
+          CI_TEST_TIMEOUT_SEC: 900
+          CI_TEST_HEARTBEAT_SEC: 15
+        run: |
+          mkdir -p /tmp/me
+          chmod +x scripts/ci-run-tests.sh
+          chmod +x scripts/harness/contract/run_all.sh
+          chmod +x scripts/harness/lib/server_bootstrap.sh
+          scripts/ci-run-tests.sh "scripts/harness/contract/run_all.sh"
+
+      - name: Verification matrix summary
+        run: |
+          echo "::notice::Required CI gates: contract harness suite"
+          echo "::notice::Optional env-gated suites not run here: PostgreSQL tests, live ICE/STUN, viewer-local-e2e-check, swarm/team-session workload harnesses"
+
   lint:
     name: Lint
     runs-on: ubuntu-latest

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -112,6 +112,8 @@ dune clean && dune build      # 클린 빌드 (캐시 문제 시)
 make test                     # 테스트
 ```
 
+검증 계층 구분은 `docs/VERIFICATION-MATRIX.md`를 기준으로 본다.
+
 ### 빌드 주의사항
 - start-masc-mcp.sh가 stale executable 감지 시 자동 rebuild
 - 빌드 캐시 오염 시 `dune clean` 필수

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # masc-mcp Makefile
 # Enterprise-ready development commands
 
-.PHONY: build test test-unit test-contract test-all clean coverage coverage-summary coverage-html doc install-deps dev-setup fmt fmt-check ci viewer-build viewer-serve harness-game-view-contract harness-streamable-http-contract harness-trpg-session-contract harness-trpg-grimland-smoke viewer-local-e2e-check
+.PHONY: build test test-unit test-contract test-contract-live test-all clean coverage coverage-summary coverage-html doc install-deps dev-setup fmt fmt-check ci viewer-build viewer-serve harness-game-view-contract harness-streamable-http-contract harness-trpg-session-contract harness-trpg-grimland-smoke viewer-local-e2e-check
 
 # Default target
 all: build
@@ -18,10 +18,14 @@ test:
 test-unit:
 	dune test --root .
 
-# Contract harness (requires running server on :8935)
+# Contract harness (self-bootstrapping, hermetic local server)
 test-contract:
-	bash scripts/harness/contract/team_session_contract.sh
+	bash scripts/harness/contract/run_all.sh
+
+# Contract harness against an already running server (default :8935)
+test-contract-live:
 	bash scripts/harness/contract/streamable_http_contract.sh
+	bash scripts/harness/contract/team_session_contract.sh
 	bash scripts/harness/contract/game_view_precondition.sh
 	bash scripts/harness/contract/trpg_session_contract.sh
 
@@ -69,7 +73,7 @@ fmt-check:
 	dune fmt --root . --preview || true
 
 # CI target (for GitHub Actions)
-ci: fmt-check test
+ci: fmt-check test test-contract
 	@echo "CI checks passed!"
 
 # Start the MCP server (local development)

--- a/docs/VERIFICATION-MATRIX.md
+++ b/docs/VERIFICATION-MATRIX.md
@@ -1,0 +1,98 @@
+# Verification Matrix
+
+`masc-mcp`의 검증은 한 덩어리가 아니다. 이 문서는 무엇이 기본 게이트이고, 무엇이 환경 의존 검증이며, 무엇이 수동 실험인지 구분하는 SSOT다.
+
+## 1. Hermetic Required
+
+이 계층은 외부 DB, live network, viewer/toolchain, local llama runtime 없이도 재현 가능해야 한다.
+
+이 슬라이스에서 **CI-required**로 보는 항목:
+
+- `dune test --root .`
+  - 기본 단위/통합 테스트 묶음
+- `./_build/default/test/test_sse_storm_e2e.exe`
+  - server executable 기반 SSE reconnect e2e
+- contract harness 4종
+  - `scripts/harness/contract/streamable_http_contract.sh`
+  - `scripts/harness/contract/team_session_contract.sh`
+  - `scripts/harness/contract/game_view_precondition.sh`
+  - `scripts/harness/contract/trpg_session_contract.sh`
+
+로컬 진입점:
+
+```bash
+dune build --root .
+dune test --root .
+make test-contract
+./_build/default/test/test_sse_storm_e2e.exe
+```
+
+의도:
+
+- 기본 브랜치가 초록이면 core MCP/HTTP/team-session/TRPG 계약이 깨지지 않았다고 볼 수 있어야 한다.
+- contract harness는 “서버가 이미 떠 있음”을 전제로 하지 않고 hermetic bootstrap 경로로 실행돼야 한다.
+
+## 2. Optional Env-Gated
+
+이 계층은 특정 환경이 있을 때만 의미가 있다. CI 기본 초록과 동일시하면 안 된다.
+
+대표 항목:
+
+- PostgreSQL 의존
+  - `test/test_board_pg.ml`
+  - `test/test_tool_mdal_pg.ml`
+  - `test/test_pubsub_postgres.ml`
+- live network / realtime 환경 의존
+  - `test/test_ice_eio.ml`
+  - `test/test_stun.ml`
+- local viewer/toolchain 의존
+  - `scripts/viewer-local-e2e-check.sh --build-viewer`
+
+규칙:
+
+- env가 없으면 skip 또는 not run으로 남길 수 있다.
+- CI 로그/문서에는 “왜 안 돌았는지”가 드러나야 한다.
+- 이 계층의 green은 bonus이고, red는 해당 env gate 안에서만 해석한다.
+
+## 3. Manual Experiment
+
+이 계층은 correctness gate가 아니라 orchestration/benchmark/behavior 실험이다. runbook과 함께 다뤄야 한다.
+
+대표 항목:
+
+- benchmark / swarm proof
+  - `scripts/harness_agent_swarm_live.sh`
+  - `docs/BENCHMARK-RUNBOOK.md`
+- supervised delivery / operator path
+  - `scripts/harness_supervisor_team_session.sh`
+  - `docs/SWARM-DELIVERY-RUNBOOK.md`
+  - `docs/SUPERVISOR-MODE.md`
+- TRPG workload / smoke
+  - `scripts/run_trpg_grimland_smoke.sh`
+- local64 / runtime matrix
+  - `scripts/harness_team_session_local64_smoke.sh`
+  - `scripts/harness_local64_model_matrix.sh`
+
+규칙:
+
+- pass/fail만 보지 않는다.
+- proof artifact, report, runtime 전제, 모델 선택 근거를 함께 남긴다.
+- 기본 CI 필수 게이트로 올리지 않는다.
+
+## Current Intent In This Slice
+
+이번 슬라이스의 목적은 다음 두 가지다.
+
+- `Hermetic Required`를 실제 기본 게이트로 올린다.
+- `Optional Env-Gated`와 `Manual Experiment`를 green으로 위장하지 않도록 분리해서 설명한다.
+
+즉, 이번 변경에서 CI 필수로 보려는 것은:
+
+- `dune test --root .`
+- `test_sse_storm_e2e.exe`
+- contract harness 4종
+
+그리고 이번 변경에서 **필수로 올리지 않는 것**은:
+
+- PostgreSQL/live network/viewer/local llama runtime 의존 검증
+- benchmark/swarm/team-session workload 실험

--- a/scripts/harness/contract/run_all.sh
+++ b/scripts/harness/contract/run_all.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
+source "${ROOT_DIR}/scripts/harness/lib/server_bootstrap.sh"
+
+SERVER_EXE="$(harness_find_server_exe "$ROOT_DIR" "${SERVER_EXE:-}")"
+PORT="${PORT:-$(harness_pick_free_port)}"
+BASE_PATH="${BASE_PATH:-$(mktemp -d "${TMPDIR:-/tmp}/masc-contract-room.XXXXXX")}"
+LOG_FILE="${LOG_FILE:-$(mktemp "${TMPDIR:-/tmp}/masc-contract-server.XXXXXX.log")}"
+KEEP_BASE_PATH="${KEEP_BASE_PATH:-0}"
+KEEP_LOG_FILE="${KEEP_LOG_FILE:-0}"
+STOP_WAIT_SEC="${STOP_WAIT_SEC:-10}"
+
+export MCP_URL="${MCP_URL:-http://127.0.0.1:${PORT}/mcp}"
+export CURL_RETRY_COUNT="${CURL_RETRY_COUNT:-12}"
+export CURL_RETRY_DELAY_SEC="${CURL_RETRY_DELAY_SEC:-1}"
+export CURL_TIMEOUT_SEC="${CURL_TIMEOUT_SEC:-25}"
+
+SERVER_PID=""
+
+cleanup() {
+  harness_stop_server "$SERVER_PID" "$STOP_WAIT_SEC"
+  if [[ "$KEEP_BASE_PATH" != "1" ]]; then
+    rm -rf "$BASE_PATH"
+  fi
+  if [[ "$KEEP_LOG_FILE" != "1" ]]; then
+    rm -f "$LOG_FILE"
+  fi
+}
+trap cleanup EXIT
+
+run_contract() {
+  local step="$1"
+  local total="$2"
+  local script_name="$3"
+  echo "[${step}/${total}] ${script_name}"
+  if ! (cd "$ROOT_DIR" && MCP_URL="$MCP_URL" bash "scripts/harness/contract/${script_name}"); then
+    echo "FAIL: ${script_name}" >&2
+    harness_print_log_tail "$LOG_FILE"
+    exit 1
+  fi
+}
+
+echo "[bootstrap] server_exe=${SERVER_EXE}"
+echo "[bootstrap] port=${PORT}"
+echo "[bootstrap] base_path=${BASE_PATH}"
+echo "[bootstrap] log_file=${LOG_FILE}"
+echo "[bootstrap] mcp_url=${MCP_URL}"
+
+SERVER_PID="$(harness_start_server "$SERVER_EXE" "$PORT" "$BASE_PATH" "$LOG_FILE")"
+if ! harness_wait_for_health "$PORT" 25; then
+  echo "FAIL: server did not become healthy on port ${PORT}" >&2
+  harness_print_log_tail "$LOG_FILE"
+  exit 1
+fi
+
+run_contract 1 4 "streamable_http_contract.sh"
+run_contract 2 4 "team_session_contract.sh"
+run_contract 3 4 "game_view_precondition.sh"
+run_contract 4 4 "trpg_session_contract.sh"
+
+echo "PASS: contract harness suite"

--- a/scripts/harness/lib/server_bootstrap.sh
+++ b/scripts/harness/lib/server_bootstrap.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+harness_find_server_exe() {
+  local repo_root="$1"
+  local explicit="${2:-}"
+  if [[ -n "$explicit" && -x "$explicit" ]]; then
+    printf '%s\n' "$explicit"
+    return 0
+  fi
+
+  local -a candidates=(
+    "${repo_root}/_build/default/bin/main_eio.exe"
+    "${repo_root}/bin/main_eio.exe"
+  )
+  local candidate
+  for candidate in "${candidates[@]}"; do
+    if [[ -x "$candidate" ]]; then
+      printf '%s\n' "$candidate"
+      return 0
+    fi
+  done
+
+  echo "server executable not found; build with: dune build --root . ./bin/main_eio.exe" >&2
+  return 1
+}
+
+harness_pick_free_port() {
+  python3 - <<'PY'
+import socket
+s = socket.socket()
+s.bind(("127.0.0.1", 0))
+print(s.getsockname()[1])
+s.close()
+PY
+}
+
+harness_wait_for_health() {
+  local port="$1"
+  local timeout_sec="${2:-20}"
+  local deadline=$(( $(date +%s) + timeout_sec ))
+  while [[ "$(date +%s)" -lt "$deadline" ]]; do
+    if curl -fsS "http://127.0.0.1:${port}/health" >/dev/null 2>&1; then
+      return 0
+    fi
+    sleep 1
+  done
+  return 1
+}
+
+harness_start_server() {
+  local server_exe="$1"
+  local port="$2"
+  local base_path="$3"
+  local log_file="$4"
+
+  (
+    export ME_ROOT="$base_path"
+    export MASC_BASE_PATH="$base_path"
+    export MASC_STORAGE_TYPE="filesystem"
+    export MASC_LODGE_ENABLED="0"
+    export MASC_LODGE_DAEMON_ENABLED="0"
+    export MASC_GUARDIAN_ENABLED="0"
+    export MASC_ORCHESTRATOR_ENABLED="0"
+    export GRAPHQL_API_KEY=""
+    export GRAPHQL_URL="http://127.0.0.1:9/graphql"
+    exec "$server_exe" --port "$port" --base-path "$base_path"
+  ) >"$log_file" 2>&1 &
+  printf '%s\n' "$!"
+}
+
+harness_stop_server() {
+  local pid="${1:-}"
+  local wait_sec="${2:-10}"
+  if [[ -z "$pid" ]]; then
+    return 0
+  fi
+
+  if kill -0 "$pid" >/dev/null 2>&1; then
+    kill "$pid" >/dev/null 2>&1 || true
+    local deadline=$(( $(date +%s) + wait_sec ))
+    while kill -0 "$pid" >/dev/null 2>&1; do
+      if [[ "$(date +%s)" -ge "$deadline" ]]; then
+        kill -9 "$pid" >/dev/null 2>&1 || true
+        break
+      fi
+      sleep 1
+    done
+  fi
+}
+
+harness_print_log_tail() {
+  local log_file="$1"
+  local lines="${2:-120}"
+  if [[ -f "$log_file" ]]; then
+    echo "---- tail -n ${lines} ${log_file} ----" >&2
+    tail -n "$lines" "$log_file" >&2 || true
+  fi
+}

--- a/scripts/harness/lib/test_framework.sh
+++ b/scripts/harness/lib/test_framework.sh
@@ -20,15 +20,19 @@ curl_post_mcp() {
   local body="$1"
   local attempt=1
   local output=""
-  local session_args=()
-  if [ -n "$MCP_SESSION_ID" ]; then
-    session_args=(-H "mcp-session-id: $MCP_SESSION_ID")
-  fi
   while [ "$attempt" -le "$CURL_RETRY_COUNT" ]; do
-    if output="$(curl -sS -m "$CURL_TIMEOUT_SEC" -X POST "$MCP_URL" \
+    if [ -n "$MCP_SESSION_ID" ]; then
+      output="$(curl -sS -m "$CURL_TIMEOUT_SEC" -X POST "$MCP_URL" \
+        -H 'Content-Type: application/json' \
+        -H 'Accept: application/json, text/event-stream' \
+        -H "mcp-session-id: $MCP_SESSION_ID" \
+        -d "$body" 2>/dev/null)" && {
+          printf "%s" "$output"
+          return 0
+        }
+    elif output="$(curl -sS -m "$CURL_TIMEOUT_SEC" -X POST "$MCP_URL" \
       -H 'Content-Type: application/json' \
       -H 'Accept: application/json, text/event-stream' \
-      "${session_args[@]}" \
       -d "$body" 2>/dev/null)"; then
       printf "%s" "$output"
       return 0


### PR DESCRIPTION
## Summary
- add a self-bootstrapping hermetic contract harness runner for MCP/team-session/TRPG contract checks
- wire a dedicated `Contract Harness` job into CI and align `make test-contract` with the same workflow
- document the verification matrix so hermetic required, env-gated, and manual experiment coverage are clearly separated

## Testing
- dune build --root . ./bin/main_eio.exe
- bash scripts/harness/contract/run_all.sh
- scripts/ci-run-tests.sh "scripts/harness/contract/run_all.sh"
- make test-contract

## Notes
- this PR intentionally does not promote PostgreSQL/live ICE-STUN/viewer/local-llama checks into required CI gates
- it fixes a real contract harness bug in `test_framework.sh` under `set -u` while validating the new path