### PR TITLE
fix: address intent forecast review regressions

### DIFF
--- a/lib/command_plane_v2.ml
+++ b/lib/command_plane_v2.ml
@@ -4314,6 +4314,14 @@ let verification_state_of_operation (operation : operation_record) =
   | _, Some "implement" -> Some "implementing"
   | _ -> None
 
+let intent_state_hint_of_operation_status (operation : operation_record) =
+  match operation.status with
+  | Planned | Active -> Active_intent
+  | Paused -> Suspended_intent
+  | Completed -> Completed_intent
+  | Cancelled -> Dropped_intent
+  | Failed -> Blocked_intent
+
 let focus_of_operation (operation : operation_record) =
   {
     stage = operation.stage;
@@ -5173,8 +5181,18 @@ let unresolved_dependencies operations (operation : operation_record) =
 
 let intent_forecast_json config intent_id ?(limit = 3) () =
   with_intent config intent_id (fun _ intent ->
-      let operations = linked_operations_for_intent config intent_id in
-      let latest_operation = List.nth_opt operations 0 in
+      let _, _, units, _ = topology_units config in
+      let all_operations = all_operations config units in
+      let intent_operations =
+        all_operations
+        |> List.filter (fun (operation : operation_record) ->
+               match operation.intent_id with
+               | Some current -> String.equal current intent_id
+               | None -> false)
+        |> List.sort (fun (left : operation_record) (right : operation_record) ->
+               String.compare right.updated_at left.updated_at)
+      in
+      let latest_operation = List.nth_opt intent_operations 0 in
       let base_focus =
         match latest_operation with
         | Some operation -> focus_of_operation operation
@@ -5207,7 +5225,7 @@ let intent_forecast_json config intent_id ?(limit = 3) () =
             if
               match normalize_stage operation.stage with
               | Some ("verify" | "review") ->
-                  unresolved_dependencies operations operation <> []
+                  unresolved_dependencies all_operations operation <> []
               | _ -> false
             then
               flags := "verification_gap" :: !flags);
@@ -5215,7 +5233,7 @@ let intent_forecast_json config intent_id ?(limit = 3) () =
       in
       let blocked_by =
         match latest_operation with
-        | Some operation -> unresolved_dependencies operations operation
+        | Some operation -> unresolved_dependencies all_operations operation
         | None -> []
       in
       let candidate_focuses =
@@ -5836,7 +5854,8 @@ let checkpoint_operation config ~(actor : string) json =
       write_operations config next_operations;
       let _, _, units, _ = topology_units config in
       let _ = sync_managed_detachments config units updated in
-      touch_intent_from_operation config ~actor updated ~state:Active_intent;
+      touch_intent_from_operation config ~actor updated
+        ~state:(intent_state_hint_of_operation_status updated);
       if operation_search_strategy updated = Cp_search_fabric.Best_first_v1 then
         update_search_stats_for_operation config updated ~outcome:`Success;
       append_cp_event config ~trace_id:updated.trace_id ~event_type:"operation_checkpointed"

--- a/test/test_command_plane_v2.ml
+++ b/test/test_command_plane_v2.ml
@@ -353,6 +353,111 @@ let test_intent_state_aggregates_across_parallel_operations () =
        |> Yojson.Safe.Util.member "state"
        |> Yojson.Safe.Util.to_string))
 
+let test_intent_forecast_resolves_dependencies_against_all_operations () =
+  let base_dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base_dir)
+    (fun () ->
+      let owner = "owner-root-node" in
+      let alpha_lead = "alpha-lead-node" in
+      let alpha_two = "alpha-two-node" in
+      let config = Room.default_config base_dir in
+      setup_company_and_platoon config ~owner ~alpha_lead ~alpha_two;
+      let shared_upstream =
+        start_operation_exn config ~actor:"owner"
+          (`Assoc
+            [
+              ("assigned_unit_id", `String "company-main");
+              ("objective", `String "Shared setup");
+              ("workload_profile", `String "coding_task");
+              ("stage", `String "implement");
+            ])
+      in
+      ignore
+        (unwrap_ok
+           (Command_plane_v2.finalize_operation_json config ~actor:"owner"
+              (`Assoc [ ("operation_id", `String shared_upstream.operation_id) ])));
+      let intent =
+        unwrap_ok
+          (Command_plane_v2.create_intent_json config ~actor:"owner"
+             (`Assoc
+               [
+                 ("title", `String "Cross intent dependency forecast");
+                 ("artifact_priors", `List [ `String "lib/command_plane_v2.ml" ]);
+               ]))
+      in
+      ignore
+        (start_operation_exn config ~actor:"owner"
+           (`Assoc
+             [
+               ("assigned_unit_id", `String "company-main");
+               ("objective", `String "Verify after shared setup");
+               ("intent_id", `String intent.intent_id);
+               ("workload_profile", `String "coding_task");
+               ("stage", `String "verify");
+               ("depends_on_operation_ids", `List [ `String shared_upstream.operation_id ]);
+             ]));
+      let forecast =
+        unwrap_ok
+          (Command_plane_v2.intent_forecast_json config intent.intent_id ())
+      in
+      Alcotest.(check (list string)) "blocked_by empty when upstream already completed" []
+        (forecast |> Yojson.Safe.Util.member "blocked_by"
+       |> Yojson.Safe.Util.to_list |> List.map Yojson.Safe.Util.to_string);
+      Alcotest.(check bool) "no verification gap risk" false
+        (forecast |> Yojson.Safe.Util.member "risk_flags"
+       |> Yojson.Safe.Util.to_list
+       |> List.exists (fun value ->
+              String.equal (Yojson.Safe.Util.to_string value) "verification_gap")))
+
+let test_checkpoint_preserves_terminal_intent_state () =
+  let base_dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base_dir)
+    (fun () ->
+      let owner = "owner-root-node" in
+      let alpha_lead = "alpha-lead-node" in
+      let alpha_two = "alpha-two-node" in
+      let config = Room.default_config base_dir in
+      setup_company_and_platoon config ~owner ~alpha_lead ~alpha_two;
+      let intent =
+        unwrap_ok
+          (Command_plane_v2.create_intent_json config ~actor:"owner"
+             (`Assoc [ ("title", `String "Terminal checkpoint preservation") ]))
+      in
+      let operation =
+        start_operation_exn config ~actor:"owner"
+          (`Assoc
+            [
+              ("assigned_unit_id", `String "company-main");
+              ("objective", `String "Complete and checkpoint");
+              ("intent_id", `String intent.intent_id);
+              ("workload_profile", `String "coding_task");
+              ("stage", `String "implement");
+            ])
+      in
+      ignore
+        (unwrap_ok
+           (Command_plane_v2.finalize_operation_json config ~actor:"owner"
+              (`Assoc [ ("operation_id", `String operation.operation_id) ])));
+      ignore
+        (unwrap_ok
+           (Command_plane_v2.checkpoint_operation config ~actor:"owner"
+              (`Assoc
+                [
+                  ("operation_id", `String operation.operation_id);
+                  ("checkpoint_ref", `String "late-terminal-checkpoint");
+                ])));
+      let intent_status =
+        Command_plane_v2.list_intents_json ~intent_id:intent.intent_id config
+      in
+      Alcotest.(check string) "intent remains completed after late checkpoint"
+        "completed"
+        (intent_status |> Yojson.Safe.Util.member "intents"
+       |> Yojson.Safe.Util.index 0
+       |> Yojson.Safe.Util.member "state"
+       |> Yojson.Safe.Util.to_string))
+
 let test_platoon_assignment_expands_detachments_and_tick_runs () =
   let base_dir = temp_dir () in
   Fun.protect
@@ -1517,6 +1622,14 @@ let () =
             "intent state aggregates across parallel operations"
             `Quick
             test_intent_state_aggregates_across_parallel_operations;
+          Alcotest.test_case
+            "intent forecast resolves dependencies against all operations"
+            `Quick
+            test_intent_forecast_resolves_dependencies_against_all_operations;
+          Alcotest.test_case
+            "checkpoint preserves terminal intent state"
+            `Quick
+            test_checkpoint_preserves_terminal_intent_state;
           Alcotest.test_case "invalid search strategy is rejected" `Quick
             test_invalid_search_strategy_is_rejected;
           Alcotest.test_case "best first search blocks and routes research pipeline"

--- a/test/test_command_plane_v2.ml
+++ b/test/test_command_plane_v2.ml
@@ -410,6 +410,124 @@ let test_intent_forecast_resolves_dependencies_against_all_operations () =
        |> List.exists (fun value ->
               String.equal (Yojson.Safe.Util.to_string value) "verification_gap")))
 
+let test_intent_forecast_blocks_on_active_cross_intent_dependency () =
+  let base_dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base_dir)
+    (fun () ->
+      let owner = "owner-root-node" in
+      let alpha_lead = "alpha-lead-node" in
+      let alpha_two = "alpha-two-node" in
+      let config = Room.default_config base_dir in
+      setup_company_and_platoon config ~owner ~alpha_lead ~alpha_two;
+      let shared_upstream =
+        start_operation_exn config ~actor:"owner"
+          (`Assoc
+            [
+              ("assigned_unit_id", `String "company-main");
+              ("objective", `String "Shared setup still running");
+              ("workload_profile", `String "coding_task");
+              ("stage", `String "implement");
+            ])
+      in
+      let intent =
+        unwrap_ok
+          (Command_plane_v2.create_intent_json config ~actor:"owner"
+             (`Assoc
+               [
+                 ("title", `String "Cross intent dependency blocks verify");
+                 ("artifact_priors", `List [ `String "lib/command_plane_v2.ml" ]);
+               ]))
+      in
+      ignore
+        (start_operation_exn config ~actor:"owner"
+           (`Assoc
+             [
+               ("assigned_unit_id", `String "company-main");
+               ("objective", `String "Verify after shared setup");
+               ("intent_id", `String intent.intent_id);
+               ("workload_profile", `String "coding_task");
+               ("stage", `String "verify");
+               ("depends_on_operation_ids", `List [ `String shared_upstream.operation_id ]);
+             ]));
+      let forecast =
+        unwrap_ok
+          (Command_plane_v2.intent_forecast_json config intent.intent_id ())
+      in
+      Alcotest.(check (list string))
+        "blocked_by includes active upstream outside intent"
+        [ shared_upstream.operation_id ]
+        (forecast |> Yojson.Safe.Util.member "blocked_by"
+       |> Yojson.Safe.Util.to_list |> List.map Yojson.Safe.Util.to_string);
+      Alcotest.(check bool) "verification gap risk is raised" true
+        (forecast |> Yojson.Safe.Util.member "risk_flags"
+       |> Yojson.Safe.Util.to_list
+       |> List.exists (fun value ->
+              String.equal (Yojson.Safe.Util.to_string value) "verification_gap")))
+
+let test_intent_forecast_accepts_checkpointed_cross_intent_dependency () =
+  let base_dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base_dir)
+    (fun () ->
+      let owner = "owner-root-node" in
+      let alpha_lead = "alpha-lead-node" in
+      let alpha_two = "alpha-two-node" in
+      let config = Room.default_config base_dir in
+      setup_company_and_platoon config ~owner ~alpha_lead ~alpha_two;
+      let shared_upstream =
+        start_operation_exn config ~actor:"owner"
+          (`Assoc
+            [
+              ("assigned_unit_id", `String "company-main");
+              ("objective", `String "Shared setup checkpointed");
+              ("workload_profile", `String "coding_task");
+              ("stage", `String "implement");
+            ])
+      in
+      ignore
+        (unwrap_ok
+           (Command_plane_v2.checkpoint_operation config ~actor:"owner"
+              (`Assoc
+                [
+                  ("operation_id", `String shared_upstream.operation_id);
+                  ("checkpoint_ref", `String "shared-upstream-checkpoint");
+                ])));
+      let intent =
+        unwrap_ok
+          (Command_plane_v2.create_intent_json config ~actor:"owner"
+             (`Assoc
+               [
+                 ("title", `String "Checkpointed dependency forecast");
+                 ("artifact_priors", `List [ `String "lib/command_plane_v2.ml" ]);
+               ]))
+      in
+      ignore
+        (start_operation_exn config ~actor:"owner"
+           (`Assoc
+             [
+               ("assigned_unit_id", `String "company-main");
+               ("objective", `String "Verify after shared checkpoint");
+               ("intent_id", `String intent.intent_id);
+               ("workload_profile", `String "coding_task");
+               ("stage", `String "verify");
+               ("depends_on_operation_ids", `List [ `String shared_upstream.operation_id ]);
+             ]));
+      let forecast =
+        unwrap_ok
+          (Command_plane_v2.intent_forecast_json config intent.intent_id ())
+      in
+      Alcotest.(check (list string))
+        "blocked_by empty when upstream has checkpoint"
+        []
+        (forecast |> Yojson.Safe.Util.member "blocked_by"
+       |> Yojson.Safe.Util.to_list |> List.map Yojson.Safe.Util.to_string);
+      Alcotest.(check bool) "verification gap risk cleared by checkpoint" false
+        (forecast |> Yojson.Safe.Util.member "risk_flags"
+       |> Yojson.Safe.Util.to_list
+       |> List.exists (fun value ->
+              String.equal (Yojson.Safe.Util.to_string value) "verification_gap")))
+
 let test_checkpoint_preserves_terminal_intent_state () =
   let base_dir = temp_dir () in
   Fun.protect
@@ -1626,6 +1744,14 @@ let () =
             "intent forecast resolves dependencies against all operations"
             `Quick
             test_intent_forecast_resolves_dependencies_against_all_operations;
+          Alcotest.test_case
+            "intent forecast blocks on active cross-intent dependency"
+            `Quick
+            test_intent_forecast_blocks_on_active_cross_intent_dependency;
+          Alcotest.test_case
+            "intent forecast accepts checkpointed cross-intent dependency"
+            `Quick
+            test_intent_forecast_accepts_checkpointed_cross_intent_dependency;
           Alcotest.test_case
             "checkpoint preserves terminal intent state"
             `Quick


### PR DESCRIPTION
## Summary
- resolve intent forecast dependency checks against the full operation set instead of only linked intent operations
- preserve terminal intent state when late checkpoints arrive on completed/cancelled/failed operations
- add regression coverage for cross-intent dependencies and terminal checkpoint preservation

## Context
- follow-up to merged PR #668
- addresses the two unresolved review threads left on #668

## Testing
- `dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix-intent-review-followup`
- `timeout 120 dune exec --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix-intent-review-followup ./test/test_command_plane_v2.exe`