### PR TITLE
fix: ignore stale managed trace residue in swarm status

### DIFF
--- a/lib/swarm_status.ml
+++ b/lib/swarm_status.ml
@@ -814,12 +814,20 @@ let slice_by_kind kind classify rows =
 
 let lane_present kind ~operations ~detachments ~alerts ~decisions ~traces ~sessions =
   match kind with
+  | Managed ->
+      (* Managed lanes should reflect live command-plane runtime, not historical
+         trace residue. Old traces/alerts without active operations, detachments,
+         or pending approvals otherwise keep the lane present forever and surface
+         stale_data as if work were still in flight. *)
+      List.exists operation_active operations
+      || List.exists detachment_active detachments
+      || List.exists decision_pending decisions
   | Supervised ->
       (* Supervised traces are historical. Only live session/runtime artifacts should
          make the lane present, otherwise stale operator/team-session traces create a
          phantom supervised lane after the real session has already ended. *)
       operations <> [] || detachments <> [] || decisions <> [] || sessions <> []
-  | Managed | Projected ->
+  | Projected ->
       operations <> [] || detachments <> [] || alerts <> [] || decisions <> [] || traces <> []
       || sessions <> []
 

--- a/test/test_swarm_status.ml
+++ b/test/test_swarm_status.ml
@@ -36,6 +36,34 @@ let test_supervised_trace_only_does_not_make_lane_present () =
     (String.equal "masc_team_session_status"
        (json |> U.member "recommended_next_action" |> U.member "tool" |> U.to_string))
 
+let test_managed_trace_only_does_not_make_lane_present () =
+  let trace : M.Swarm_status.trace_info =
+    {
+      event_id = "trace-managed-1";
+      event_type = "operation_search_scored";
+      source = "control_plane";
+      trace_id = "trace-managed-1";
+      operation_id = Some "op-old";
+      actor = Some "dashboard";
+      timestamp = Some "2026-03-07T18:02:18Z";
+      detail = `Assoc [ ("selected_unit_id", `String "company-runtime") ];
+    }
+  in
+  let json =
+    M.Swarm_status.build_json_from_inputs
+      ~timeline_limit_override:M.Swarm_status.timeline_limit
+      ~now:(M.Time_compat.now ()) ~operations:[] ~detachments:[] ~alerts:[]
+      ~decisions:[] ~traces:[ trace ] ~sessions:[]
+  in
+  let managed = find_lane json "managed" in
+  check bool "managed lane absent" false
+    (managed |> U.member "present" |> U.to_bool);
+  check int "no managed hard flags" 0
+    (managed |> U.member "hard_flags" |> U.to_list |> List.length);
+  check bool "do not recommend dispatch tick from trace residue" false
+    (String.equal "masc_dispatch_tick"
+       (json |> U.member "recommended_next_action" |> U.member "tool" |> U.to_string))
+
 let test_supervised_session_keeps_lane_present () =
   let now = M.Time_compat.now () in
   let now_iso = M.Command_plane_v2.iso_of_unix now in
@@ -165,6 +193,66 @@ let test_terminal_projected_session_artifacts_do_not_keep_supervised_lane_presen
          String.equal "stale_data" (flag |> U.member "code" |> U.to_string))
        (supervised |> U.member "hard_flags" |> U.to_list))
 
+let test_terminal_managed_artifacts_do_not_keep_managed_lane_present () =
+  let now = M.Time_compat.now () in
+  let stale_iso = M.Command_plane_v2.iso_of_unix (now -. 3600.) in
+  let operation : M.Swarm_status.operation_info =
+    {
+      operation_id = "op-old";
+      objective = "Historical managed lane";
+      source = "managed";
+      status = "failed";
+      trace_id = "trace-old";
+      detachment_session_id = None;
+      note = Some "historical failure";
+      updated_at = Some stale_iso;
+    }
+  in
+  let detachment : M.Swarm_status.detachment_info =
+    {
+      detachment_id = "det-op-old";
+      operation_id = "op-old";
+      source = "managed";
+      status = "failed";
+      runtime_kind = Some "managed";
+      session_id = None;
+      roster = [ "worker-a" ];
+      leader_id = Some "worker-a";
+      last_event_at = Some stale_iso;
+      last_progress_at = Some stale_iso;
+      updated_at = Some stale_iso;
+    }
+  in
+  let trace : M.Swarm_status.trace_info =
+    {
+      event_id = "trace-old";
+      event_type = "operation_failed";
+      source = "control_plane";
+      trace_id = "trace-old";
+      operation_id = Some "op-old";
+      actor = Some "dashboard";
+      timestamp = Some stale_iso;
+      detail = `Assoc [ ("status", `String "failed") ];
+    }
+  in
+  let json =
+    M.Swarm_status.build_json_from_inputs
+      ~timeline_limit_override:M.Swarm_status.timeline_limit ~now
+      ~operations:[ operation ] ~detachments:[ detachment ] ~alerts:[]
+      ~decisions:[] ~traces:[ trace ] ~sessions:[]
+  in
+  let managed = find_lane json "managed" in
+  check bool "managed lane absent for terminal-only artifacts" false
+    (managed |> U.member "present" |> U.to_bool);
+  check bool "no stale flag when lane absent" false
+    (List.exists
+       (fun flag ->
+         String.equal "stale_data" (flag |> U.member "code" |> U.to_string))
+       (managed |> U.member "hard_flags" |> U.to_list));
+  check bool "do not recommend dispatch tick from terminal residue" false
+    (String.equal "masc_dispatch_tick"
+       (json |> U.member "recommended_next_action" |> U.member "tool" |> U.to_string))
+
 let () =
   run "Swarm_status"
     [
@@ -172,6 +260,8 @@ let () =
         [
           test_case "trace_only_does_not_activate_supervised_lane" `Quick
             test_supervised_trace_only_does_not_make_lane_present;
+          test_case "trace_only_does_not_activate_managed_lane" `Quick
+            test_managed_trace_only_does_not_make_lane_present;
           test_case "session_keeps_supervised_lane_present" `Quick
             test_supervised_session_keeps_lane_present;
           test_case "stale_session_keeps_stale_flag" `Quick
@@ -179,5 +269,8 @@ let () =
           test_case "terminal_projected_artifacts_do_not_keep_supervised_lane_present"
             `Quick
             test_terminal_projected_session_artifacts_do_not_keep_supervised_lane_present;
+          test_case "terminal_managed_artifacts_do_not_keep_managed_lane_present"
+            `Quick
+            test_terminal_managed_artifacts_do_not_keep_managed_lane_present;
         ] );
     ]


### PR DESCRIPTION
## Summary
- keep the managed swarm-status lane tied to live CPv2 runtime rather than historical trace residue
- stop stale terminal managed artifacts from surfacing `stale_data` and `masc_dispatch_tick` recommendations forever
- add regression coverage for trace-only and terminal-only managed residue

## Verification
- dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix/managed-stale-data-lane
- timeout 60 dune exec --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix/managed-stale-data-lane ./test/test_swarm_status.exe