### PR TITLE
fix: keep managed lane visible for live alerts

### DIFF
--- a/lib/swarm_status.ml
+++ b/lib/swarm_status.ml
@@ -816,12 +816,13 @@ let lane_present kind ~operations ~detachments ~alerts ~decisions ~traces ~sessi
   match kind with
   | Managed ->
       (* Managed lanes should reflect live command-plane runtime, not historical
-         trace residue. Old traces/alerts without active operations, detachments,
-         or pending approvals otherwise keep the lane present forever and surface
-         stale_data as if work were still in flight. *)
+         trace residue. Current managed alerts are recomputed from snapshot state
+         and must keep the lane visible, but old traces alone should not keep it
+         present forever and surface stale_data as if work were still in flight. *)
       List.exists operation_active operations
       || List.exists detachment_active detachments
       || List.exists decision_pending decisions
+      || alerts <> []
   | Supervised ->
       (* Supervised traces are historical. Only live session/runtime artifacts should
          make the lane present, otherwise stale operator/team-session traces create a

--- a/test/test_swarm_status.ml
+++ b/test/test_swarm_status.ml
@@ -64,6 +64,55 @@ let test_managed_trace_only_does_not_make_lane_present () =
     (String.equal "masc_dispatch_tick"
        (json |> U.member "recommended_next_action" |> U.member "tool" |> U.to_string))
 
+let test_active_managed_operation_keeps_lane_present () =
+  let now = M.Time_compat.now () in
+  let now_iso = M.Command_plane_v2.iso_of_unix now in
+  let operation : M.Swarm_status.operation_info =
+    {
+      operation_id = "op-running";
+      objective = "Live managed lane";
+      source = "managed";
+      status = "running";
+      trace_id = "trace-running";
+      detachment_session_id = None;
+      note = Some "live operation";
+      updated_at = Some now_iso;
+    }
+  in
+  let json =
+    M.Swarm_status.build_json_from_inputs
+      ~timeline_limit_override:M.Swarm_status.timeline_limit ~now
+      ~operations:[ operation ] ~detachments:[] ~alerts:[] ~decisions:[]
+      ~traces:[] ~sessions:[]
+  in
+  let managed = find_lane json "managed" in
+  check bool "managed lane present for active operation" true
+    (managed |> U.member "present" |> U.to_bool)
+
+let test_managed_alert_only_keeps_lane_present () =
+  let now = M.Time_compat.now () in
+  let now_iso = M.Command_plane_v2.iso_of_unix now in
+  let alert : M.Swarm_status.alert_info =
+    {
+      alert_id = "alert-unit-frozen";
+      severity = "warn";
+      scope_type = Some "unit";
+      scope_id = Some "company-runtime";
+      title = Some "Company runtime is frozen";
+      detail = Some "Dispatch into this unit is blocked until it is unfrozen.";
+      timestamp = Some now_iso;
+    }
+  in
+  let json =
+    M.Swarm_status.build_json_from_inputs
+      ~timeline_limit_override:M.Swarm_status.timeline_limit ~now
+      ~operations:[] ~detachments:[] ~alerts:[ alert ] ~decisions:[]
+      ~traces:[] ~sessions:[]
+  in
+  let managed = find_lane json "managed" in
+  check bool "managed lane present for live alert" true
+    (managed |> U.member "present" |> U.to_bool)
+
 let test_supervised_session_keeps_lane_present () =
   let now = M.Time_compat.now () in
   let now_iso = M.Command_plane_v2.iso_of_unix now in
@@ -262,6 +311,10 @@ let () =
             test_supervised_trace_only_does_not_make_lane_present;
           test_case "trace_only_does_not_activate_managed_lane" `Quick
             test_managed_trace_only_does_not_make_lane_present;
+          test_case "active_managed_operation_keeps_lane_present" `Quick
+            test_active_managed_operation_keeps_lane_present;
+          test_case "managed_alert_only_keeps_lane_present" `Quick
+            test_managed_alert_only_keeps_lane_present;
           test_case "session_keeps_supervised_lane_present" `Quick
             test_supervised_session_keeps_lane_present;
           test_case "stale_session_keeps_stale_flag" `Quick


### PR DESCRIPTION
## Summary
- keep live managed alerts visible in swarm status while still ignoring trace-only residue
- preserve managed lane presence for active operations and alert-only health conditions
- add regression coverage for active managed operations and alert-only managed alerts

## Verification
- dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix/managed-stale-data-lane test/test_swarm_status.exe
- timeout 60 ./_build/default/test/test_swarm_status.exe

## Context
- follow-up to #670 after review flagged alert-only managed state as a real managed signal, not stale residue