### PR TITLE
Encapsulate dashboard and workspace runtime config

### DIFF
--- a/dashboard/vite.config.ts
+++ b/dashboard/vite.config.ts
@@ -1,29 +1,35 @@
 import { defineConfig } from 'vite'
 import preact from '@preact/preset-vite'
 
-const proxyTarget = process.env.MASC_DASHBOARD_PROXY_TARGET || 'http://localhost:8935'
+export default defineConfig(({ command }) => {
+  const proxyTarget = process.env.MASC_DASHBOARD_PROXY_TARGET
+  if (command === 'serve' && !proxyTarget) {
+    throw new Error('MASC_DASHBOARD_PROXY_TARGET is required for `vite serve`.')
+  }
 
-export default defineConfig({
-  plugins: [preact()],
-  base: '/dashboard/',
-  build: {
-    outDir: '../assets/dashboard',
-    emptyOutDir: true,
-    rollupOptions: {
-      output: {
-        manualChunks: {
-          vendor: ['preact', 'preact/hooks', 'htm', '@preact/signals'],
+  return {
+    plugins: [preact()],
+    base: '/dashboard/',
+    build: {
+      outDir: '../assets/dashboard',
+      emptyOutDir: true,
+      rollupOptions: {
+        output: {
+          manualChunks: {
+            vendor: ['preact', 'preact/hooks', 'htm', '@preact/signals'],
+          },
         },
       },
     },
-  },
-  server: {
-    proxy: {
-      '/api': proxyTarget,
-      '/sse': {
-        target: proxyTarget,
-        // SSE needs no WebSocket upgrade
-      },
-    },
-  },
+    server: proxyTarget
+      ? {
+          proxy: {
+            '/api': proxyTarget,
+            '/sse': {
+              target: proxyTarget,
+            },
+          },
+        }
+      : undefined,
+  }
 })

--- a/lib/agent_swarm_runner.ml
+++ b/lib/agent_swarm_runner.ml
@@ -23,7 +23,10 @@ let default_config = {
   max_turns = 10;
   fleet_mode = false;
   num_members = 3;
-  masc_url = "http://127.0.0.1:8935";
+  masc_url =
+    (match Sys.getenv_opt "MASC_HTTP_BASE_URL" with
+     | Some value when String.trim value <> "" -> String.trim value
+     | _ -> "");
   verbose = false;
 }
 

--- a/lib/env_config.ml
+++ b/lib/env_config.ml
@@ -459,9 +459,6 @@ end
 (** {1 Endpoint Configuration} *)
 
 module Endpoints = struct
-  let masc_base_url_opt =
-    Sys.getenv_opt "MASC_HTTP_BASE_URL" |> trim_opt |> Option.map strip_trailing_slashes
-
   (** @deprecated LLM-MCP server URL - no longer used.
       Use {!Llm_direct.dispatch} for direct API calls instead.
       Kept for backward compatibility; will be removed in v3.0. *)
@@ -469,35 +466,24 @@ module Endpoints = struct
     get_string ~default:"" "LLM_MCP_URL"  (* Default empty - not used *)
 
   (** MASC server host *)
-  let masc_host =
-    match masc_base_url_opt with
-    | Some base -> (
-        match Uri.host (Uri.of_string base) with
-        | Some host -> host
-        | None -> "")
-    | None -> Sys.getenv_opt "MASC_HOST" |> trim_opt |> Option.value ~default:""
+  let masc_host () =
+    match Uri.host (Uri.of_string (masc_http_base_url ())) with
+    | Some host -> host
+    | None -> failwith "MASC_HTTP_BASE_URL must include a host"
 
   (** MASC server port *)
-  let masc_port =
-    match masc_base_url_opt with
-    | Some base -> (
-        match Uri.port (Uri.of_string base) with
-        | Some port -> port
-        | None -> (
-            match Uri.scheme (Uri.of_string base) with
-            | Some "https" -> 443
-            | Some "http" -> 80
-            | _ -> 0))
-    | None ->
-        (match Sys.getenv_opt "MASC_MCP_PORT" |> trim_opt with
-         | Some value -> Safe_ops.int_of_string_with_default ~default:0 value
-         | None -> 0)
+  let masc_port () =
+    match Uri.port (Uri.of_string (masc_http_base_url ())) with
+    | Some port -> port
+    | None -> (
+        match Uri.scheme (Uri.of_string (masc_http_base_url ())) with
+        | Some "https" -> 443
+        | Some "http" -> 80
+        | _ -> failwith "MASC_HTTP_BASE_URL must include a port or scheme")
 
   (** MASC SSE URL (derived) *)
-  let masc_sse_url =
-    match masc_base_url_opt with
-    | Some base -> Printf.sprintf "%s/sse" base
-    | None -> ""
+  let masc_sse_url () =
+    Printf.sprintf "%s/sse" (masc_http_base_url ())
 end
 
 (** {1 Gardener — Self-Organizing Agent Ecosystem} *)

--- a/lib/env_config.ml
+++ b/lib/env_config.ml
@@ -56,34 +56,33 @@ let existing_file path =
 let home_dir_opt () =
   Sys.getenv_opt "HOME" |> trim_opt
 
-let home_me_root_opt () =
-  match home_dir_opt () with
-  | Some home ->
-      let candidate = Filename.concat home "me" in
-      if existing_dir candidate then Some candidate else None
-  | None -> None
-
 let me_root_opt () =
-  match Sys.getenv_opt "ME_ROOT" |> trim_opt with
+  match Sys.getenv_opt "MASC_WORKSPACE_ROOT" |> trim_opt with
   | Some path -> Some path
-  | None -> home_me_root_opt ()
+  | None -> (
+      match Sys.getenv_opt "ME_ROOT" |> trim_opt with
+      | Some path -> Some path
+      | None -> Sys.getenv_opt "DUNE_SOURCEROOT" |> trim_opt)
 
 let me_root () =
   match me_root_opt () with
   | Some path -> path
-  | None -> failwith "ME_ROOT is not set and $HOME/me does not exist"
+  | None -> failwith "MASC_WORKSPACE_ROOT or ME_ROOT is required (tests may use DUNE_SOURCEROOT)"
 
 let sb_path_opt () =
-  match me_root_opt () with
-  | Some root ->
-      let path = Filename.concat root "scripts/sb" in
-      if existing_file path then Some path else None
-  | None -> None
+  match Sys.getenv_opt "MASC_SB_PATH" |> trim_opt with
+  | Some path -> Some path
+  | None -> (
+      match me_root_opt () with
+      | Some root ->
+          let path = Filename.concat root "scripts/sb" in
+          if existing_file path then Some path else None
+      | None -> None)
 
 let sb_path () =
   match sb_path_opt () with
   | Some path -> path
-  | None -> failwith "Unable to resolve scripts/sb. Set ME_ROOT or create $HOME/me/scripts/sb."
+  | None -> failwith "Unable to resolve scripts/sb. Set MASC_SB_PATH or MASC_WORKSPACE_ROOT."
 
 let masc_http_port () =
   match Sys.getenv_opt "MASC_HTTP_PORT" |> trim_opt with
@@ -96,7 +95,13 @@ let masc_http_port () =
 let masc_http_base_url () =
   match Sys.getenv_opt "MASC_HTTP_BASE_URL" |> trim_opt with
   | Some base -> strip_trailing_slashes base
-  | None -> Printf.sprintf "http://127.0.0.1:%s" (masc_http_port ())
+  | None ->
+      let host =
+        match Sys.getenv_opt "MASC_HOST" |> trim_opt with
+        | Some value -> value
+        | None -> failwith "MASC_HTTP_BASE_URL is required (or set MASC_HOST with MASC_HTTP_PORT/MASC_PORT)"
+      in
+      Printf.sprintf "http://%s:%s" host (masc_http_port ())
 
 let libdatachannel_path_candidates () =
   let env_path =
@@ -454,6 +459,9 @@ end
 (** {1 Endpoint Configuration} *)
 
 module Endpoints = struct
+  let masc_base_url_opt =
+    Sys.getenv_opt "MASC_HTTP_BASE_URL" |> trim_opt |> Option.map strip_trailing_slashes
+
   (** @deprecated LLM-MCP server URL - no longer used.
       Use {!Llm_direct.dispatch} for direct API calls instead.
       Kept for backward compatibility; will be removed in v3.0. *)
@@ -462,15 +470,34 @@ module Endpoints = struct
 
   (** MASC server host *)
   let masc_host =
-    get_string ~default:"127.0.0.1" "MASC_HOST"
+    match masc_base_url_opt with
+    | Some base -> (
+        match Uri.host (Uri.of_string base) with
+        | Some host -> host
+        | None -> "")
+    | None -> Sys.getenv_opt "MASC_HOST" |> trim_opt |> Option.value ~default:""
 
   (** MASC server port *)
   let masc_port =
-    get_int ~default:8935 "MASC_MCP_PORT"
+    match masc_base_url_opt with
+    | Some base -> (
+        match Uri.port (Uri.of_string base) with
+        | Some port -> port
+        | None -> (
+            match Uri.scheme (Uri.of_string base) with
+            | Some "https" -> 443
+            | Some "http" -> 80
+            | _ -> 0))
+    | None ->
+        (match Sys.getenv_opt "MASC_MCP_PORT" |> trim_opt with
+         | Some value -> Safe_ops.int_of_string_with_default ~default:0 value
+         | None -> 0)
 
   (** MASC SSE URL (derived) *)
   let masc_sse_url =
-    Printf.sprintf "http://%s:%d/sse" masc_host masc_port
+    match masc_base_url_opt with
+    | Some base -> Printf.sprintf "%s/sse" base
+    | None -> ""
 end
 
 (** {1 Gardener — Self-Organizing Agent Ecosystem} *)

--- a/start-masc-mcp.sh
+++ b/start-masc-mcp.sh
@@ -12,13 +12,6 @@ fi
 
 # Storage backends are opt-in. Use MASC_STORAGE_TYPE + MASC_REDIS_URL/MASC_POSTGRES_URL explicitly.
 
-# Room/namespace: derive from ME_ROOT directory name if not set
-# e.g., ME_ROOT=/Users/dancer/me → cluster "me"
-# e.g., ME_ROOT=/Users/dancer/workspace/my-project → cluster "my-project"
-if [ -z "$MASC_CLUSTER_NAME" ] && [ -n "$ME_ROOT" ]; then
-    export MASC_CLUSTER_NAME="$(basename "$ME_ROOT")"
-fi
-
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cd "$SCRIPT_DIR"
 
@@ -72,7 +65,7 @@ fi
 # Default arguments
 PORT="${MASC_MCP_PORT:-8935}"
 HTTP_MODE="${MASC_MCP_HTTP:-true}"
-BASE_PATH="${MASC_BASE_PATH:-${ME_ROOT:-$(pwd -P)}}"
+BASE_PATH="${MASC_BASE_PATH:-$SCRIPT_DIR}"
 # NOTE: Eio is now the default runtime (Lwt deprecated since 2026-01)
 EIO_MODE="true"
 
@@ -300,10 +293,14 @@ if [ "$EIO_MODE" = "true" ]; then
     echo "  Port: $PORT" >&2
     echo "  Base path: $RESOLVED_BASE_PATH" >&2
     if [ "$RESOLVED_BASE_PATH" != "$BASE_PATH" ]; then
-    echo "  Base path (input): $BASE_PATH" >&2
+        echo "  Base path (input): $BASE_PATH" >&2
     fi
     echo "  MASC dir: $RESOLVED_BASE_PATH/.masc" >&2
-    echo "  MCP endpoint: http://127.0.0.1:$PORT/mcp" >&2
+    if [ -n "${MASC_HTTP_BASE_URL:-}" ]; then
+        echo "  MCP endpoint: ${MASC_HTTP_BASE_URL%/}/mcp" >&2
+    else
+        echo "  MCP endpoint: /mcp (set MASC_HTTP_BASE_URL for an absolute origin)" >&2
+    fi
     echo "  MCP Accept: application/json, text/event-stream" >&2
     echo "  Legacy Accept fallback: MASC_ALLOW_LEGACY_ACCEPT=1" >&2
     exec "$SELECTED_EXE" --port="$PORT" --base-path="$BASE_PATH"
@@ -312,10 +309,14 @@ elif [ "$HTTP_MODE" = "true" ]; then
     echo "  Port: $PORT" >&2
     echo "  Base path: $RESOLVED_BASE_PATH" >&2
     if [ "$RESOLVED_BASE_PATH" != "$BASE_PATH" ]; then
-    echo "  Base path (input): $BASE_PATH" >&2
+        echo "  Base path (input): $BASE_PATH" >&2
     fi
     echo "  MASC dir: $RESOLVED_BASE_PATH/.masc" >&2
-    echo "  MCP endpoint: http://127.0.0.1:$PORT/mcp" >&2
+    if [ -n "${MASC_HTTP_BASE_URL:-}" ]; then
+        echo "  MCP endpoint: ${MASC_HTTP_BASE_URL%/}/mcp" >&2
+    else
+        echo "  MCP endpoint: /mcp (set MASC_HTTP_BASE_URL for an absolute origin)" >&2
+    fi
     echo "  MCP Accept: application/json, text/event-stream" >&2
     echo "  Legacy Accept fallback: MASC_ALLOW_LEGACY_ACCEPT=1" >&2
     exec "$SELECTED_EXE" --http --port "$PORT" --path "$BASE_PATH"

--- a/test/test_env_config_coverage.ml
+++ b/test/test_env_config_coverage.ml
@@ -20,12 +20,6 @@ let with_env name value fn =
       Unix.putenv name value;
       fn ())
 
-let make_temp_dir prefix =
-  let path = Filename.temp_file prefix "" in
-  Sys.remove path;
-  Unix.mkdir path 0o755;
-  path
-
 (* ============================================================
    get_string Tests
    ============================================================ *)
@@ -87,28 +81,21 @@ let test_me_root_prefers_env () =
     check (option string) "me_root_opt" (Some "/tmp/masc-custom-root") (Env_config.me_root_opt ());
     check string "me_root" "/tmp/masc-custom-root" (Env_config.me_root ()))
 
-let test_me_root_falls_back_to_home_me () =
-  let home = make_temp_dir "env-config-home-" in
-  let me_dir = Filename.concat home "me" in
-  Fun.protect
-    ~finally:(fun () ->
-      Unix.rmdir me_dir;
-      Unix.rmdir home)
-    (fun () ->
-      Unix.mkdir me_dir 0o755;
-      with_env "ME_ROOT" "" (fun () ->
-        with_env "HOME" home (fun () ->
-          check (option string) "me_root_opt fallback" (Some me_dir) (Env_config.me_root_opt ());
-          check string "me_root fallback" me_dir (Env_config.me_root ()))))
+let test_me_root_prefers_explicit_workspace_root () =
+  with_env "MASC_WORKSPACE_ROOT" "/tmp/masc-workspace-root" (fun () ->
+    with_env "ME_ROOT" "" (fun () ->
+      check (option string) "me_root_opt explicit" (Some "/tmp/masc-workspace-root") (Env_config.me_root_opt ());
+      check string "me_root explicit" "/tmp/masc-workspace-root" (Env_config.me_root ())))
 
 let test_masc_http_base_url_prefers_env_and_trims () =
   with_env "MASC_HTTP_BASE_URL" "http://example.test:9911/" (fun () ->
     check string "base url trimmed" "http://example.test:9911" (Env_config.masc_http_base_url ()))
 
-let test_masc_http_base_url_falls_back_to_port () =
+let test_masc_http_base_url_uses_explicit_host_and_port () =
   with_env "MASC_HTTP_BASE_URL" "" (fun () ->
-    with_env "MASC_HTTP_PORT" "7777" (fun () ->
-      check string "base url from port" "http://127.0.0.1:7777" (Env_config.masc_http_base_url ())))
+    with_env "MASC_HOST" "masc.example.test" (fun () ->
+      with_env "MASC_HTTP_PORT" "7777" (fun () ->
+        check string "base url from host+port" "http://masc.example.test:7777" (Env_config.masc_http_base_url ()))))
 
 let test_libdatachannel_candidates_include_env_override () =
   with_env "LIBDATACHANNEL_PATH" "/tmp/libdatachannel-custom.dylib" (fun () ->
@@ -326,9 +313,9 @@ let () =
     ];
     "path_helpers", [
       test_case "me_root prefers env" `Quick test_me_root_prefers_env;
-      test_case "me_root falls back to home/me" `Quick test_me_root_falls_back_to_home_me;
+      test_case "me_root prefers explicit workspace root" `Quick test_me_root_prefers_explicit_workspace_root;
       test_case "base url prefers env and trims" `Quick test_masc_http_base_url_prefers_env_and_trims;
-      test_case "base url falls back to port" `Quick test_masc_http_base_url_falls_back_to_port;
+      test_case "base url uses explicit host+port" `Quick test_masc_http_base_url_uses_explicit_host_and_port;
       test_case "libdatachannel candidates include env override" `Quick test_libdatachannel_candidates_include_env_override;
     ];
     "print_summary", [

--- a/web/index.html
+++ b/web/index.html
@@ -218,7 +218,7 @@
   <div class="lobby">
     <header>
       <h1>🏛️ MASC LOBBY</h1>
-      <span class="room">[me]</span>
+      <span class="room" id="roomLabel">[default]</span>
       <div class="status">
         <div class="dot"></div>
         <span>Connected</span>
@@ -291,9 +291,14 @@
   </div>
 
   <script>
-    const MCP_URL = 'http://127.0.0.1:8935/mcp';
+    const roomParams = new URLSearchParams(window.location.search);
+    const ROOM_ID = roomParams.get('room') || 'default';
+    const BASE_URL = window.location.origin;
+    const MCP_URL = new URL('/mcp', BASE_URL).toString();
     const MAX_EVENTS = 50;  // 이벤트 스트림 최대 개수
     let requestId = 1;
+    const roomLabel = document.getElementById('roomLabel');
+    if (roomLabel) roomLabel.textContent = `[${ROOM_ID}]`;
 
     // Debounce helper - 연속 호출 방지
     function debounce(fn, delay) {
@@ -585,7 +590,7 @@
 
       updateSSEStatus('🟡');  // connecting
       const sid = encodeURIComponent(getOrCreateLobbySseSessionId());
-      evtSource = new EventSource(`http://127.0.0.1:8935/sse?room=me&session_id=${sid}`);
+      evtSource = new EventSource(`${BASE_URL}/sse?room=${encodeURIComponent(ROOM_ID)}&session_id=${sid}`);
 
       evtSource.onopen = () => {
         reconnectAttempts = 0;

--- a/web/proxy_server.py
+++ b/web/proxy_server.py
@@ -1,12 +1,13 @@
 #!/usr/bin/env python3
 from http.server import HTTPServer, SimpleHTTPRequestHandler
+import os
 import sys
 import urllib.error
 import urllib.request
 
 
 class ProxyHandler(SimpleHTTPRequestHandler):
-    BACKEND = "http://127.0.0.1:8935"
+    BACKEND = ""
 
     def _cors_origin(self):
         origin = self.headers.get("Origin")
@@ -104,6 +105,10 @@ class ProxyHandler(SimpleHTTPRequestHandler):
 
 if __name__ == "__main__":
     port = int(sys.argv[1]) if len(sys.argv) > 1 else 8080
+    backend = (sys.argv[2] if len(sys.argv) > 2 else os.getenv("MASC_WEB_BACKEND_URL", "")).rstrip("/")
+    if not backend:
+        raise SystemExit("MASC_WEB_BACKEND_URL or <backend-url> is required")
+    ProxyHandler.BACKEND = backend
     print(f"Proxy server on http://localhost:{port}")
-    print("Proxying /api, /sse, /mcp to http://127.0.0.1:8935")
+    print(f"Proxying /api, /sse, /mcp to {backend}")
     HTTPServer(("", port), ProxyHandler).serve_forever()

--- a/web/server.py
+++ b/web/server.py
@@ -7,7 +7,7 @@ import urllib.request
 
 
 class Handler(SimpleHTTPRequestHandler):
-    BACKEND = "http://127.0.0.1:8935"
+    BACKEND = ""
 
     def _cors_origin(self):
         origin = self.headers.get("Origin")
@@ -102,5 +102,9 @@ class Handler(SimpleHTTPRequestHandler):
 
 if __name__ == "__main__":
     port = int(sys.argv[1]) if len(sys.argv) > 1 else 8080
+    backend = (sys.argv[2] if len(sys.argv) > 2 else os.getenv("MASC_WEB_BACKEND_URL", "")).rstrip("/")
+    if not backend:
+        raise SystemExit("MASC_WEB_BACKEND_URL or <backend-url> is required")
+    Handler.BACKEND = backend
     os.chdir(os.path.dirname(os.path.realpath(__file__)))
     HTTPServer(("", port), Handler).serve_forever()


### PR DESCRIPTION
## Summary
- remove home/workspace fallback logic from dashboard/web/runtime config boundaries
- require explicit dashboard proxy and web backend targets instead of hardcoded localhost defaults
- move browser surfaces to same-origin paths and explicit workspace/base-url inputs

## Validation
- dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/codex-runtime-boundary-pass1 bin/main_eio.exe test/test_env_config_coverage.exe
- dune exec --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/codex-runtime-boundary-pass1 ./test/test_env_config_coverage.exe
- cd dashboard && npm ci && npm run build