### PR TITLE
fix: adapt Agent.create calls to oas#main options-record API

### DIFF
--- a/lib/agent_swarm_runner.ml
+++ b/lib/agent_swarm_runner.ml
@@ -97,7 +97,8 @@ let run_solo ~sw ~net ~clock ~proc_mgr config =
         | _ -> Hooks.Continue) }
   else Hooks.empty in
   let agent = Agent.create ~net ~config:agent_config ~tools:dev_tools
-    ~base_url ~provider:provider_cfg ~hooks () in
+    ~options:{ Agent.default_options with
+               base_url; provider = Some provider_cfg; hooks } () in
   Agent.run ~sw agent config.goal
 
 let run_fleet ~sw ~net ~clock ~proc_mgr config =

--- a/lib/agent_swarm_swarm.ml
+++ b/lib/agent_swarm_swarm.ml
@@ -325,7 +325,9 @@ let run_agent ~sw ~net ~clock ~masc_url ?(extra_tools=[]) spec ~goal =
                 max_turns = spec.max_turns;
               } in
               let agent =
-                Agent.create ~net ~config ~tools:all_tools ~provider:spec.provider ()
+                Agent.create ~net ~config ~tools:all_tools
+                  ~options:{ Agent.default_options with
+                             provider = Some spec.provider } ()
               in
               Agent.run ~sw:inner_sw agent goal
             )


### PR DESCRIPTION
## Summary
- `oas#main` (commit 94d4e36) consolidated `~provider`, `~base_url`, `~hooks` into a single `~options` record parameter on `Agent.create`
- CI pins `agent_sdk` to `oas#main`, causing build failure on `agent_swarm_swarm.ml:328` and `agent_swarm_runner.ml:100`
- Both call sites updated to use `~options:{ Agent.default_options with ... }` pattern

## Files changed
- `lib/agent_swarm_swarm.ml` — wrap `provider` in options record
- `lib/agent_swarm_runner.ml` — wrap `base_url`, `provider`, `hooks` in options record

## Test plan
- [x] `dune build` passes with `oas#main` pin
- [x] `make test` — MDAL test failure is pre-existing (unrelated)
- [ ] CI green after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)