### PR TITLE
fix(sse): Eio.Mutex concurrency protection for SSE client registry

### DIFF
--- a/lib/sse.ml
+++ b/lib/sse.ml
@@ -1,5 +1,14 @@
 (** SSE (Server-Sent Events) module for MCP Streamable HTTP Transport
-    MCP Spec 2025-03-26 compliant *)
+    MCP Spec 2025-03-26 compliant
+
+    Concurrency: All access to [clients] Hashtbl is protected by
+    [registry_mutex] (Eio.Mutex).  [client_count_atomic] mirrors
+    Hashtbl.length for signal-handler-safe reads.
+
+    Signal handler safety: [broadcast] and [close_all_clients] use
+    try/with around mutex acquisition; if the mutex cannot be acquired
+    (e.g. signal interrupted a fiber holding it), they fall back to
+    best-effort lock-free execution since the process is shutting down. *)
 
 (** Maximum concurrent SSE clients — prevents connection storm on restart.
     Increased from 50 to 200 to handle Claude.ai MCP client reconnections. *)
@@ -16,6 +25,31 @@ type client = {
 
 (** Client registry - maps session_id to client *)
 let clients : (string, client) Hashtbl.t = Hashtbl.create 16
+
+(** Registry mutex — protects all [clients] Hashtbl access.
+    Pattern: mcp_agent_queue.ml, agent_identity.ml *)
+let registry_mutex = Eio.Mutex.create ()
+
+(** Atomic client count — mirrors Hashtbl.length for signal-handler-safe reads.
+    Kept in sync inside [registry_mutex] critical sections. *)
+let client_count_atomic = Atomic.make 0
+
+(** Run [f] inside the registry mutex.
+    Falls back to lock-free [f ()] when Eio effects are unavailable
+    (e.g. POSIX signal handler context, module init, or test harness
+    running outside [Eio_main.run]).
+
+    Two exception classes to handle:
+    - [Effect.Unhandled _]: no Eio scheduler installed at all.
+    - [Eio.Mutex.Poisoned _]: mutex created but scheduler not running
+      (e.g. Alcotest without [Eio_main.run] wrapper). *)
+let with_registry_rw f =
+  try Eio.Mutex.use_rw ~protect:true registry_mutex f
+  with Effect.Unhandled _ | Eio.Mutex.Poisoned _ -> f ()
+
+let with_registry_ro f =
+  try Eio.Mutex.use_ro registry_mutex f
+  with Effect.Unhandled _ | Eio.Mutex.Poisoned _ -> f ()
 
 let mark_seen (client : client) =
   client.last_seen_at <- Time_compat.now ()
@@ -65,68 +99,89 @@ let next_id () =
 
 (** Register a new SSE client.
     Returns (client_id, evicted_session_id option).
-    Evicts the oldest client when at capacity. *)
+    Evicts the oldest client when at capacity.
+    ID generation + collision check + add are atomic under [registry_mutex]. *)
 let register session_id ~push ~last_event_id =
-  (* Evict oldest if at capacity *)
-  let evicted =
-    if Hashtbl.length clients >= max_clients then
-      let oldest = Hashtbl.fold (fun sid c acc ->
-        match acc with
-        | None -> Some (sid, c)
-        | Some (_, c2) -> if c.created_at < c2.created_at then Some (sid, c) else acc
-      ) clients None in
-      match oldest with
-      | Some (sid, _) ->
-          Printf.eprintf "[SSE] Evicting oldest client %s (at cap %d)\n%!" sid max_clients;
-          Hashtbl.remove clients sid; Some sid
-      | None -> None
-    else None
-  in
-  let now = Time_compat.now () in
-  let new_id = Atomic.fetch_and_add client_id_counter 1 + 1 in
-  let client = { id = new_id; push; last_event_id; created_at = now; last_seen_at = now } in
-  Hashtbl.replace clients session_id client;
-  (client.id, evicted)
+  with_registry_rw (fun () ->
+    (* Evict oldest if at capacity *)
+    let evicted =
+      if Hashtbl.length clients >= max_clients then
+        let oldest = Hashtbl.fold (fun sid c acc ->
+          match acc with
+          | None -> Some (sid, c)
+          | Some (_, c2) -> if c.created_at < c2.created_at then Some (sid, c) else acc
+        ) clients None in
+        match oldest with
+        | Some (sid, _) ->
+            Printf.eprintf "[SSE] Evicting oldest client %s (at cap %d)\n%!" sid max_clients;
+            Hashtbl.remove clients sid;
+            Atomic.decr client_count_atomic;
+            Some sid
+        | None -> None
+      else None
+    in
+    let now = Time_compat.now () in
+    let new_id = Atomic.fetch_and_add client_id_counter 1 + 1 in
+    let client = { id = new_id; push; last_event_id; created_at = now; last_seen_at = now } in
+    (* If session_id already exists, replace does not change count *)
+    let was_present = Hashtbl.mem clients session_id in
+    Hashtbl.replace clients session_id client;
+    if not was_present then Atomic.incr client_count_atomic;
+    (client.id, evicted))
 
 (** Unregister an SSE client *)
 let unregister session_id =
-  Hashtbl.remove clients session_id
+  with_registry_rw (fun () ->
+    if Hashtbl.mem clients session_id then begin
+      Hashtbl.remove clients session_id;
+      Atomic.decr client_count_atomic
+    end)
 
 (** Unregister only if the current client matches the given client_id.
     Prevents an old connection's cleanup from unregistering a newer connection
     that re-used the same session_id. *)
 let unregister_if_current session_id client_id =
-  match Hashtbl.find_opt clients session_id with
-  | Some client when client.id = client_id -> Hashtbl.remove clients session_id
-  | _ -> ()
+  with_registry_rw (fun () ->
+    match Hashtbl.find_opt clients session_id with
+    | Some client when client.id = client_id ->
+        Hashtbl.remove clients session_id;
+        Atomic.decr client_count_atomic
+    | _ -> ())
 
 (** Check if client exists *)
 let exists session_id =
-  Hashtbl.mem clients session_id
+  with_registry_ro (fun () ->
+    Hashtbl.mem clients session_id)
 
 (** Mark a client as recently active *)
 let touch session_id =
-  match Hashtbl.find_opt clients session_id with
-  | Some client -> mark_seen client
-  | None -> ()
+  with_registry_rw (fun () ->
+    match Hashtbl.find_opt clients session_id with
+    | Some client -> mark_seen client
+    | None -> ())
 
 (** Update client's last event ID *)
 let update_last_event_id session_id event_id =
-  match Hashtbl.find_opt clients session_id with
-  | Some client ->
-      client.last_event_id <- event_id;
-      mark_seen client
-  | None -> ()
+  with_registry_rw (fun () ->
+    match Hashtbl.find_opt clients session_id with
+    | Some client ->
+        client.last_event_id <- event_id;
+        mark_seen client
+    | None -> ())
 
-(** Broadcast event to all connected clients
-    Uses snapshot-based iteration to safely remove failed connections *)
+(** Broadcast event to all connected clients.
+    Uses snapshot-then-act: take snapshot under lock, push outside lock.
+    Failed clients are unregistered individually afterwards. *)
 let broadcast json =
   let data = Yojson.Safe.to_string json in
   let current_event_id = Atomic.get event_counter + 1 in
   let event = format_event ~id:current_event_id ~event_type:"message" data in
   buffer_event current_event_id event;
-  (* Take snapshot first to avoid modifying Hashtbl during iteration *)
-  let clients_snapshot = Hashtbl.fold (fun k v acc -> (k, v) :: acc) clients [] in
+  (* Snapshot under lock *)
+  let clients_snapshot =
+    with_registry_ro (fun () ->
+      Hashtbl.fold (fun k v acc -> (k, v) :: acc) clients [])
+  in
   let failed = ref [] in
   List.iter (fun (session_id, client) ->
     if current_event_id > client.last_event_id then begin
@@ -137,8 +192,8 @@ let broadcast json =
         failed := session_id :: !failed
     end
   ) clients_snapshot;
-  (* Remove failed connections after iteration *)
-  List.iter (Hashtbl.remove clients) !failed
+  (* Remove failed connections *)
+  List.iter (fun sid -> unregister sid) !failed
 
 (** Send a JSON-RPC message to a specific session (legacy SSE transport) *)
 let send_to session_id json =
@@ -146,7 +201,11 @@ let send_to session_id json =
   let current_event_id = Atomic.get event_counter + 1 in
   let event = format_event ~id:current_event_id ~event_type:"message" data in
   buffer_event current_event_id event;
-  match Hashtbl.find_opt clients session_id with
+  let client_opt =
+    with_registry_ro (fun () ->
+      Hashtbl.find_opt clients session_id)
+  in
+  match client_opt with
   | None -> ()
   | Some client ->
       (match client.push event with
@@ -154,27 +213,38 @@ let send_to session_id json =
        | exception e ->
          Printf.eprintf "[SSE] Push to %s failed: %s\n%!" session_id (Printexc.to_string e))
 
-(** Get client count *)
+(** Get client count.
+    Uses [Atomic.get] so it is safe to call from signal handlers. *)
 let client_count () =
-  Hashtbl.length clients
+  Atomic.get client_count_atomic
 
-(** Close all SSE clients - for graceful shutdown
-    Returns the number of clients that were closed *)
+(** Close all SSE clients - for graceful shutdown.
+    Returns the number of clients that were closed.
+    Signal-handler safe via [with_registry_rw] fallback. *)
 let close_all_clients () =
-  let sessions = Hashtbl.fold (fun sid _ acc -> sid :: acc) clients [] in
-  List.iter (Hashtbl.remove clients) sessions;
+  let sessions =
+    with_registry_rw (fun () ->
+      let ss = Hashtbl.fold (fun sid _ acc -> sid :: acc) clients [] in
+      Hashtbl.clear clients;
+      Atomic.set client_count_atomic 0;
+      ss)
+  in
   List.length sessions
 
 (** Remove clients idle longer than max_age_s (default 30 min).
     Returns list of evicted session_ids so caller can clean up writers. *)
 let cleanup_stale ?(max_age_s=1800.0) () =
   let now = Time_compat.now () in
-  let stale = Hashtbl.fold (fun sid c acc ->
-    if now -. c.last_seen_at > max_age_s then sid :: acc else acc
-  ) clients [] in
-  List.iter (fun sid ->
-    Printf.eprintf "[SSE] idle evict: %s (idle %.0fs)\n%!"
-      sid (now -. (Hashtbl.find clients sid).last_seen_at);
-    Hashtbl.remove clients sid
+  (* Snapshot stale candidates under lock *)
+  let stale =
+    with_registry_ro (fun () ->
+      Hashtbl.fold (fun sid c acc ->
+        if now -. c.last_seen_at > max_age_s then (sid, c.last_seen_at) :: acc else acc
+      ) clients [])
+  in
+  (* Remove under lock, one by one *)
+  List.iter (fun (sid, last_seen) ->
+    Printf.eprintf "[SSE] idle evict: %s (idle %.0fs)\n%!" sid (now -. last_seen);
+    unregister sid
   ) stale;
-  stale
+  List.map fst stale

--- a/test/test_sse.ml
+++ b/test/test_sse.ml
@@ -39,9 +39,31 @@ let test_cleanup_stale_respects_touch () =
 
   unregister alive_sid
 
+let test_concurrent_register_unregister () =
+  Eio_main.run @@ fun _env ->
+  let open Masc_mcp.Sse in
+  let n = 50 in
+  let prefix = "conc_" ^ string_of_int (Random.int 1000000) ^ "_" in
+  let noop _ = () in
+  let count_before = client_count () in
+  (* N fibers register, then unregister concurrently.
+     Switch.run waits for all forked fibers before returning. *)
+  Eio.Switch.run (fun sw ->
+    for i = 0 to n - 1 do
+      Eio.Fiber.fork ~sw (fun () ->
+        let sid = prefix ^ string_of_int i in
+        let (_id, _) = register sid ~push:noop ~last_event_id:0 in
+        Eio.Fiber.yield ();
+        unregister sid)
+    done);
+  (* All fibers have completed — count should be restored *)
+  let count_after = client_count () in
+  check int "count restored" count_before count_after
+
 let () =
   run "sse"
     [
       ("unregister_if_current", [test_case "guards reconnect" `Quick test_unregister_if_current]);
       ("cleanup_stale", [test_case "uses idle time" `Quick test_cleanup_stale_respects_touch]);
+      ("concurrency", [test_case "concurrent register/unregister" `Quick test_concurrent_register_unregister]);
     ]


### PR DESCRIPTION
## Summary
- SSE `clients` Hashtbl을 `Eio.Mutex`로 보호하여 fiber-safe 동시 접근 보장
- `Atomic.t` 기반 `client_count`로 signal handler에서도 안전한 카운트 읽기
- TOCTOU race condition 제거 (ID 생성 + 등록을 단일 critical section에서 수행)
- Snapshot-then-act 패턴으로 broadcast/cleanup 시 deadlock 방지
- `Effect.Unhandled` + `Eio.Mutex.Poisoned` fallback으로 signal handler/test 컨텍스트 호환
- agent_swarm 파일들은 agent_sdk v0.5.0 API 호환성 수정 (pre-existing)

## Changes
| File | Change |
|------|--------|
| `lib/sse.ml` | Eio.Mutex + Atomic.t + snapshot-then-act 패턴 적용 |
| `test/test_sse.ml` | 50-fiber 동시 register/unregister 테스트 추가 |
| `lib/agent_swarm_runner.ml` | Agent.create 호출을 v0.5.0 API에 맞춤 |
| `lib/agent_swarm_swarm.ml` | Agent.create 호출을 v0.5.0 API에 맞춤 |

## Design
기존 `mcp_agent_queue.ml`의 `Eio.Mutex` 패턴을 따름:
- `with_registry_rw`: 쓰기 작업 (register, unregister, touch, update)
- `with_registry_ro`: 읽기 작업 (exists, snapshot for broadcast)
- Signal handler fallback: `try Eio.Mutex.use_rw ... with Effect.Unhandled _ | Eio.Mutex.Poisoned _ -> f ()`

## Test plan
- [x] `test_sse.exe` 3/3 통과 (unregister_if_current, cleanup_stale, concurrent)
- [x] `test_sse_coverage.exe` 29/29 통과
- [ ] `dune build --root .` 전체 빌드 확인
- [ ] `bin/main_eio.ml` signal handler의 `client_count()` / `close_all_clients()` 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)