### PR TITLE
fix: use labeled params for Agent.create (agent_sdk 0.5.0)

### DIFF
--- a/lib/agent_swarm_runner.ml
+++ b/lib/agent_swarm_runner.ml
@@ -97,8 +97,7 @@ let run_solo ~sw ~net ~clock ~proc_mgr config =
         | _ -> Hooks.Continue) }
   else Hooks.empty in
   let agent = Agent.create ~net ~config:agent_config ~tools:dev_tools
-    ~options:{ Agent.default_options with
-               base_url; provider = Some provider_cfg; hooks } () in
+    ~base_url ~provider:provider_cfg ~hooks () in
   Agent.run ~sw agent config.goal
 
 let run_fleet ~sw ~net ~clock ~proc_mgr config =

--- a/lib/agent_swarm_swarm.ml
+++ b/lib/agent_swarm_swarm.ml
@@ -326,8 +326,7 @@ let run_agent ~sw ~net ~clock ~masc_url ?(extra_tools=[]) spec ~goal =
               } in
               let agent =
                 Agent.create ~net ~config ~tools:all_tools
-                  ~options:{ Agent.default_options with
-                             provider = Some spec.provider } ()
+                  ~provider:spec.provider ()
               in
               Agent.run ~sw:inner_sw agent goal
             )


### PR DESCRIPTION
## Summary
- `agent_sdk 0.5.0`에서 `Agent.create`의 `~options` record parameter가 삭제되고 개별 labeled optional parameter로 변경됨
- `agent_swarm_swarm.ml`, `agent_swarm_runner.ml` 2곳의 호출부를 새 시그니처에 맞게 수정

## Changes
| File | Before | After |
|------|--------|-------|
| `agent_swarm_swarm.ml` | `~options:{ Agent.default_options with provider = Some spec.provider }` | `~provider:spec.provider` |
| `agent_swarm_runner.ml` | `~options:{ Agent.default_options with base_url; provider = Some provider_cfg; hooks }` | `~base_url ~provider:provider_cfg ~hooks` |

## Test plan
- [x] `dune build` 성공 확인 (worktree)
- [ ] `make test` 실행

🤖 Generated with [Claude Code](https://claude.com/claude-code)