### PR TITLE
revert: undo #684 (restores #682 CI-green state)

### DIFF
--- a/lib/agent_swarm_runner.ml
+++ b/lib/agent_swarm_runner.ml
@@ -97,7 +97,8 @@ let run_solo ~sw ~net ~clock ~proc_mgr config =
         | _ -> Hooks.Continue) }
   else Hooks.empty in
   let agent = Agent.create ~net ~config:agent_config ~tools:dev_tools
-    ~base_url ~provider:provider_cfg ~hooks () in
+    ~options:{ Agent.default_options with
+               base_url; provider = Some provider_cfg; hooks } () in
   Agent.run ~sw agent config.goal
 
 let run_fleet ~sw ~net ~clock ~proc_mgr config =

--- a/lib/agent_swarm_swarm.ml
+++ b/lib/agent_swarm_swarm.ml
@@ -326,7 +326,8 @@ let run_agent ~sw ~net ~clock ~masc_url ?(extra_tools=[]) spec ~goal =
               } in
               let agent =
                 Agent.create ~net ~config ~tools:all_tools
-                  ~provider:spec.provider ()
+                  ~options:{ Agent.default_options with
+                             provider = Some spec.provider } ()
               in
               Agent.run ~sw:inner_sw agent goal
             )


### PR DESCRIPTION
## Summary
- #684 reversed #682's fix, breaking CI again (Build and Test: fail)
- #682 adapted `Agent.create` calls to `oas#main` options-record API (CI green)
- #684 reverted back to labeled params (codex/provider-ssot API, CI red)
- This revert restores #682 state

## Root cause
Two sessions fixed the same build failure in opposite directions. Both auto-merged.

## Test plan
- [ ] CI Build and Test: green (same state as #682 which passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)