### PR TITLE
feat(swarm): add masc_swarm_live_run MCP tool

### DIFF
--- a/lib/mcp_server_eio.ml
+++ b/lib/mcp_server_eio.ml
@@ -20,7 +20,7 @@ type tool_profile =
 (** {1 Network Context for LLM Chain Calls} *)
 
 (** Type alias for generic Eio network capability *)
-type eio_net = [`Generic] Eio.Net.ty Eio.Resource.t
+type eio_net = [`Generic | `Unix] Eio.Net.ty Eio.Resource.t
 
 (** Global Eio network reference for Walph chain execution.
     Set by main_eio.ml during server initialization.

--- a/lib/mcp_server_eio.mli
+++ b/lib/mcp_server_eio.mli
@@ -51,14 +51,14 @@ val get_field : string -> Yojson.Safe.t -> Yojson.Safe.t option
 
 (** {1 Network Context} *)
 
-(** Type alias for generic Eio network capability *)
-type eio_net = [`Generic] Eio.Net.ty Eio.Resource.t
+(** Type alias for Eio network capability (Generic + Unix for Agent SDK) *)
+type eio_net = [`Generic | `Unix] Eio.Net.ty Eio.Resource.t
 
-(** Set the Eio network reference for Walph chain execution.
+(** Set the Eio network reference for server-side network calls.
     Must be called from main_eio.ml during server initialization.
-    Accepts any Eio.Net.t (Unix, Generic, etc.) and stores as generic.
+    Requires Generic + Unix capabilities for Agent SDK compatibility.
     @param net Eio network capability *)
-val set_net : _ Eio.Net.t -> unit
+val set_net : [> `Generic | `Unix] Eio.Net.ty Eio.Resource.t -> unit
 
 (** Set the Eio clock reference for async sleep. *)
 val set_clock : float Eio.Time.clock_ty Eio.Resource.t -> unit

--- a/lib/tool_command_plane.ml
+++ b/lib/tool_command_plane.ml
@@ -1334,6 +1334,40 @@ let handle_observe_traces (ctx : (_, _) context) args : result =
     Yojson.Safe.to_string
       (Command_plane_v2.list_traces_json ctx.config ?operation_id ~limit ()))
 
+let handle_swarm_live_run (ctx : (_, _) context) args : result =
+  match ctx.sw, ctx.clock, ctx.net with
+  | Some sw, Some clock, Some net ->
+      let run_id =
+        match get_string_opt args "run_id" with
+        | Some value -> value
+        | None -> "swarm-live"
+      in
+      let worker_count =
+        match Yojson.Safe.Util.member "worker_count" args with
+        | `Int value -> value
+        | _ -> Agent_swarm_live_harness.default_config.worker_count
+      in
+      let cfg =
+        { Agent_swarm_live_harness.default_config with run_id; worker_count }
+      in
+      let result_json = Agent_swarm_live_harness.run ~sw ~net ~clock cfg in
+      let run_dir =
+        Filename.concat
+          (Filename.concat
+             (Cp_paths.control_plane_root_dir ctx.config)
+             "swarm-live")
+          (Agent_swarm_live_harness.safe_run_id run_id)
+      in
+      Room_utils.mkdir_p run_dir;
+      Room_utils.write_json_local
+        (Filename.concat run_dir "swarm-live-summary.json")
+        result_json;
+      (true, Yojson.Safe.to_string result_json)
+  | _ ->
+      ( false,
+        json_error
+          "swarm-live harness requires server runtime context (sw, clock, net)" )
+
 let handle_unit_update (ctx : (_, _) context) args : result =
   json_result (Command_plane_v2.unit_update_json ctx.config ~actor:ctx.agent_name args)
 
@@ -1449,6 +1483,7 @@ let dispatch (ctx : (_, _) context) ~name ~args : result option =
   | "masc_observe_operations" -> Some (handle_observe_operations ctx)
   | "masc_observe_capacity" -> Some (handle_observe_capacity ctx)
   | "masc_observe_traces" -> Some (handle_observe_traces ctx args)
+  | "masc_swarm_live_run" -> Some (handle_swarm_live_run ctx args)
   | _ -> None
 
 let object_schema ?(required = []) properties =
@@ -1919,6 +1954,19 @@ let schemas : tool_schema list =
           [
             ("operation_id", string_prop "Operation id.");
             ("limit", integer_prop ~default:25 "Maximum events to return.");
+          ];
+    };
+    {
+      name = "masc_swarm_live_run";
+      description =
+        "Execute the deterministic swarm-live harness. Spawns workers against a synthetic fixture, runs them through the Agent SDK, and persists the summary artifact to .masc/control-plane/swarm-live/<run_id>/. Results are then visible via masc_observe_traces.";
+      input_schema =
+        object_schema
+          [
+            ("run_id", string_prop "Run identifier (default: swarm-live).");
+            ( "worker_count",
+              integer_prop ~default:12
+                "Number of swarm workers to spawn (default: 12)." );
           ];
     };
   ]

--- a/lib/tool_command_plane.ml
+++ b/lib/tool_command_plane.ml
@@ -1344,25 +1344,30 @@ let handle_swarm_live_run (ctx : (_, _) context) args : result =
       in
       let worker_count =
         match Yojson.Safe.Util.member "worker_count" args with
-        | `Int value -> value
+        | `Int value when value > 0 && value <= 100 -> value
+        | `Int _ -> Agent_swarm_live_harness.default_config.worker_count
         | _ -> Agent_swarm_live_harness.default_config.worker_count
       in
       let cfg =
         { Agent_swarm_live_harness.default_config with run_id; worker_count }
       in
-      let result_json = Agent_swarm_live_harness.run ~sw ~net ~clock cfg in
-      let run_dir =
-        Filename.concat
-          (Filename.concat
-             (Cp_paths.control_plane_root_dir ctx.config)
-             "swarm-live")
-          (Agent_swarm_live_harness.safe_run_id run_id)
-      in
-      Room_utils.mkdir_p run_dir;
-      Room_utils.write_json_local
-        (Filename.concat run_dir "swarm-live-summary.json")
-        result_json;
-      (true, Yojson.Safe.to_string result_json)
+      (try
+        let result_json = Agent_swarm_live_harness.run ~sw ~net ~clock cfg in
+        let run_dir =
+          Filename.concat
+            (Filename.concat
+               (Cp_paths.control_plane_root_dir ctx.config)
+               "swarm-live")
+            (Agent_swarm_live_harness.safe_run_id run_id)
+        in
+        Room_utils.mkdir_p run_dir;
+        Room_utils.write_json_local
+          (Filename.concat run_dir "swarm-live-summary.json")
+          result_json;
+        (true, Yojson.Safe.to_string result_json)
+      with exn ->
+        (false, json_error (Printf.sprintf "swarm-live harness failed: %s"
+          (Printexc.to_string exn))))
   | _ ->
       ( false,
         json_error


### PR DESCRIPTION
## Summary
- `masc_swarm_live_run` MCP tool 추가 — 에이전트가 shell 없이 MCP로 직접 swarm-live harness를 실행
- 결과 artifact를 `.masc/control-plane/swarm-live/<run_id>/`에 자동 저장하여 `masc_observe_traces`로 조회 가능
- `eio_net` 타입을 `[`Generic | `Unix]`로 확장하여 Agent SDK 호환성 확보

## Changes
| File | Change |
|------|--------|
| `lib/tool_command_plane.ml` | `handle_swarm_live_run` handler + dispatch + schema 추가 (+48) |
| `lib/mcp_server_eio.ml` | `eio_net` 타입 `[`Generic]` → `[`Generic | `Unix]` |
| `lib/mcp_server_eio.mli` | interface 동기화 (`eio_net`, `set_net` 시그니처) |

## Context
기존에 `masc_observe_traces`는 swarm-live artifact를 읽을 수 있었지만, artifact를 생성하는 MCP tool이 없었다 (observe만 있고 execute가 없는 비대칭). 이 PR로 에이전트가 MCP tool을 통해 직접 harness를 트리거하고 결과를 조회할 수 있다.

## Test plan
- [x] `dune build --root .` 통과
- [x] `make test` 4/4 통과
- [ ] CI (Build and Test, Contract Harness, Lint)

🤖 Generated with [Claude Code](https://claude.com/claude-code)