### PR TITLE
feat(tool-registry): in-memory call counters + tools/list mode filter

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -245,6 +245,7 @@
    tool_gardener
    tool_library
    tool_catalog
+   tool_registry
    library_bridge
    tool_council
    tool_code

--- a/lib/masc_mcp.ml
+++ b/lib/masc_mcp.ml
@@ -243,6 +243,7 @@ module Tool_room = Tool_room
 module Tool_control = Tool_control
 module Tool_verification = Tool_verification
 module Tool_misc = Tool_misc
+module Tool_registry = Tool_registry
 module Tool_llama = Tool_llama
 module Tool_board = Tool_board
 module Tool_command_plane = Tool_command_plane

--- a/lib/mcp_server_eio.ml
+++ b/lib/mcp_server_eio.ml
@@ -2968,8 +2968,8 @@ in
             Printf.eprintf "[WARN] telemetry tracking failed: %s\n%!" (Printexc.to_string exn))
      | None -> ());
 
-  (* Track in-memory call counter (hot-path, O(1), survives until restart) *)
-  Tool_registry.record_call ~tool_name:name ~success ~duration_ms;
+  (* Track in-memory call counter only for declared tool names. *)
+  Tool_registry.record_call_if_known ~tool_name:name ~success ~duration_ms;
 
   let trace_id =
     match id with

--- a/lib/mcp_server_eio.ml
+++ b/lib/mcp_server_eio.ml
@@ -2968,6 +2968,9 @@ in
             Printf.eprintf "[WARN] telemetry tracking failed: %s\n%!" (Printexc.to_string exn))
      | None -> ());
 
+  (* Track in-memory call counter (hot-path, O(1), survives until restart) *)
+  Tool_registry.record_call ~tool_name:name ~success ~duration_ms;
+
   let trace_id =
     match id with
     | `String s -> s
@@ -3034,13 +3037,24 @@ Use masc_heartbeat periodically; use @agent mentions in masc_broadcast. \
 Prefer worktrees for parallel work."
 
 let tool_schemas_for_profile ?(include_hidden = false) ?(include_deprecated = false)
-    state profile =
+    ?mode_override state profile =
   match profile with
   | Full ->
-      let room_path = Room.masc_dir state.Mcp_server.room_config in
-      let config = Config.load room_path in
-      Config.enabled_tool_schemas ~include_hidden ~include_deprecated
-        config.enabled_categories
+      let categories =
+        match mode_override with
+        | Some mode_str ->
+            (match Mode.mode_of_string (String.lowercase_ascii mode_str) with
+             | Some mode -> Mode.categories_for_mode mode
+             | None ->
+                 let room_path = Room.masc_dir state.Mcp_server.room_config in
+                 let config = Config.load room_path in
+                 config.Config.enabled_categories)
+        | None ->
+            let room_path = Room.masc_dir state.Mcp_server.room_config in
+            let config = Config.load room_path in
+            config.Config.enabled_categories
+      in
+      Config.enabled_tool_schemas ~include_hidden ~include_deprecated categories
   | Operator_remote -> Tool_operator.remote_schemas
 
 let tool_allowed_in_profile profile tool_name =
@@ -3080,6 +3094,7 @@ type tools_list_params = {
   include_hidden : bool;
   include_deprecated : bool;
   include_usage : bool;
+  mode : string option;
 }
 
 let bool_param payload key =
@@ -3098,6 +3113,7 @@ let requested_tool_list_params params =
         include_hidden = false;
         include_deprecated = false;
         include_usage = false;
+        mode = None;
       }
   | Some (`Assoc _ as payload) -> (
       let names_result =
@@ -3116,9 +3132,18 @@ let requested_tool_list_params params =
             |> Result.map (fun names -> Some (List.rev names))
         | _ -> Error "Invalid params: names must be an array of strings"
       in
+      let mode_result =
+        match payload |> member "mode" with
+        | `Null -> Ok None
+        | `String s -> Ok (Some s)
+        | _ -> Error "Invalid params: mode must be a string"
+      in
       match names_result with
       | Error _ as err -> err
       | Ok names -> (
+          match mode_result with
+          | Error _ as err -> err
+          | Ok mode -> (
           match bool_param payload "include_hidden" with
           | Error _ as err -> err
           | Ok include_hidden -> (
@@ -3133,7 +3158,8 @@ let requested_tool_list_params params =
                         include_hidden;
                         include_deprecated;
                         include_usage;
-                      }))))
+                        mode;
+                      })))))
   | Some _ -> Error "Invalid params: expected object"
 
 let handle_initialize_eio ?(profile = Full) id params =
@@ -3151,7 +3177,7 @@ let handle_initialize_eio ?(profile = Full) id params =
       ])
 
 let handle_list_tools_eio ?(profile = Full) ?names ?(include_hidden = false)
-    ?(include_deprecated = false) ?(include_usage = false) state id =
+    ?(include_deprecated = false) ?(include_usage = false) ?mode state id =
   let usage_summary =
     if include_usage then
       Some (Telemetry_eio.summarize_tool_usage ?fs:state.Mcp_server.fs state.Mcp_server.room_config)
@@ -3159,7 +3185,8 @@ let handle_list_tools_eio ?(profile = Full) ?names ?(include_hidden = false)
       None
   in
   let tools =
-    tool_schemas_for_profile ~include_hidden ~include_deprecated state profile
+    tool_schemas_for_profile ~include_hidden ~include_deprecated
+      ?mode_override:mode state profile
     |> (match names with
        | None -> Fun.id
        | Some wanted ->
@@ -3243,9 +3270,9 @@ let handle_request
                    | "tools/list" -> (
                        match requested_tool_list_params req.params with
                        | Error msg -> make_error ~id (-32602) msg
-                       | Ok { names; include_hidden; include_deprecated; include_usage } ->
+                       | Ok { names; include_hidden; include_deprecated; include_usage; mode } ->
                            handle_list_tools_eio ~profile ?names ~include_hidden
-                             ~include_deprecated ~include_usage state id)
+                             ~include_deprecated ~include_usage ?mode state id)
                    | "tools/call" ->
                        (match req.params with
                        | Some params ->

--- a/lib/tool_misc.ml
+++ b/lib/tool_misc.ml
@@ -45,12 +45,13 @@ let handle_gc ctx args =
 let handle_cleanup_zombies ctx _args =
   (true, Room.cleanup_zombies ctx.config)
 
-let handle_tool_stats _ctx _args =
+let handle_tool_stats _ctx args =
+  let top_n = max 1 (min 100 (get_int args "top_n" 20)) in
   let all_tool_names =
     List.map (fun (s : Types.tool_schema) -> s.name)
       Config.all_tool_schemas
   in
-  let report = Tool_registry.stats_report ~all_tool_names in
+  let report = Tool_registry.stats_report ~top_n ~all_tool_names in
   (true, Yojson.Safe.pretty_to_string report)
 
 (* Dispatch function *)

--- a/lib/tool_misc.ml
+++ b/lib/tool_misc.ml
@@ -45,11 +45,20 @@ let handle_gc ctx args =
 let handle_cleanup_zombies ctx _args =
   (true, Room.cleanup_zombies ctx.config)
 
+let handle_tool_stats _ctx _args =
+  let all_tool_names =
+    List.map (fun (s : Types.tool_schema) -> s.name)
+      Config.all_tool_schemas
+  in
+  let report = Tool_registry.stats_report ~all_tool_names in
+  (true, Yojson.Safe.pretty_to_string report)
+
 (* Dispatch function *)
 let dispatch ctx ~name ~args : result option =
   match name with
   | "masc_dashboard" -> Some (handle_dashboard ctx args)
   | "masc_gc" -> Some (handle_gc ctx args)
   | "masc_cleanup_zombies" -> Some (handle_cleanup_zombies ctx args)
+  | "masc_tool_stats" -> Some (handle_tool_stats ctx args)
   (* Note: verify_handoff needs tokenize/jaccard/cosine - kept in mcp_server_eio.ml *)
   | _ -> None

--- a/lib/tool_registry.ml
+++ b/lib/tool_registry.ml
@@ -1,0 +1,150 @@
+(** Tool Registry - In-memory call counters and usage statistics
+
+    Provides fast O(1) in-memory tracking of tool call frequency.
+    Complements Telemetry_eio's JSONL-based persistence with
+    zero-allocation atomic counters for hot-path performance.
+
+    Usage:
+    - record_call is called on every tools/call dispatch
+    - get_stats / get_top_n / get_unused_since provide reporting
+    - Data resets on server restart (telemetry.jsonl is the durable store)
+*)
+
+(** Per-tool call statistics *)
+type call_stats = {
+  mutable call_count : int;
+  mutable success_count : int;
+  mutable failure_count : int;
+  mutable last_called_at : float;  (** Unix timestamp, 0.0 = never *)
+  mutable total_duration_ms : int;
+}
+
+(** Global registry - process-lifetime, protected by mutex for fiber safety *)
+let registry : (string, call_stats) Hashtbl.t = Hashtbl.create 128
+let registry_mutex = Mutex.create ()
+
+(** Record a tool call. Called from handle_call_tool_eio after execution. *)
+let record_call ~tool_name ~success ~duration_ms =
+  Mutex.lock registry_mutex;
+  Fun.protect
+    ~finally:(fun () -> Mutex.unlock registry_mutex)
+    (fun () ->
+      let stats =
+        match Hashtbl.find_opt registry tool_name with
+        | Some s -> s
+        | None ->
+            let s = {
+              call_count = 0;
+              success_count = 0;
+              failure_count = 0;
+              last_called_at = 0.0;
+              total_duration_ms = 0;
+            } in
+            Hashtbl.replace registry tool_name s;
+            s
+      in
+      stats.call_count <- stats.call_count + 1;
+      if success then
+        stats.success_count <- stats.success_count + 1
+      else
+        stats.failure_count <- stats.failure_count + 1;
+      stats.last_called_at <- Time_compat.now ();
+      stats.total_duration_ms <- stats.total_duration_ms + duration_ms)
+
+(** Get all stats as a sorted list (by call_count descending) *)
+let get_stats () : (string * call_stats) list =
+  Mutex.lock registry_mutex;
+  Fun.protect
+    ~finally:(fun () -> Mutex.unlock registry_mutex)
+    (fun () ->
+      Hashtbl.fold (fun name stats acc -> (name, stats) :: acc) registry []
+      |> List.sort (fun (_, a) (_, b) -> compare b.call_count a.call_count))
+
+(** Get top N tools by call count *)
+let get_top_n n : (string * call_stats) list =
+  let all = get_stats () in
+  let rec take acc n = function
+    | [] -> List.rev acc
+    | _ when n <= 0 -> List.rev acc
+    | x :: xs -> take (x :: acc) (n - 1) xs
+  in
+  take [] n all
+
+(** Get tool names not called since the given Unix timestamp.
+    Only includes tools that are registered (have been called at least once)
+    but not recently. *)
+let get_unused_since (cutoff : float) : string list =
+  Mutex.lock registry_mutex;
+  Fun.protect
+    ~finally:(fun () -> Mutex.unlock registry_mutex)
+    (fun () ->
+      Hashtbl.fold
+        (fun name stats acc ->
+          if stats.last_called_at < cutoff then name :: acc else acc)
+        registry []
+      |> List.sort String.compare)
+
+(** Get tools that have never been called (not in registry at all)
+    compared against a list of all known tool names *)
+let get_never_called (all_tool_names : string list) : string list =
+  Mutex.lock registry_mutex;
+  Fun.protect
+    ~finally:(fun () -> Mutex.unlock registry_mutex)
+    (fun () ->
+      List.filter
+        (fun name -> not (Hashtbl.mem registry name))
+        all_tool_names
+      |> List.sort String.compare)
+
+(** Total calls across all tools *)
+let total_calls () : int =
+  Mutex.lock registry_mutex;
+  Fun.protect
+    ~finally:(fun () -> Mutex.unlock registry_mutex)
+    (fun () ->
+      Hashtbl.fold (fun _ stats acc -> acc + stats.call_count) registry 0)
+
+(** Number of distinct tools that have been called *)
+let distinct_tools_called () : int =
+  Mutex.lock registry_mutex;
+  Fun.protect
+    ~finally:(fun () -> Mutex.unlock registry_mutex)
+    (fun () -> Hashtbl.length registry)
+
+(** Convert call_stats to JSON *)
+let stats_to_json (name, (stats : call_stats)) : Yojson.Safe.t =
+  `Assoc [
+    ("name", `String name);
+    ("call_count", `Int stats.call_count);
+    ("success_count", `Int stats.success_count);
+    ("failure_count", `Int stats.failure_count);
+    ("avg_duration_ms",
+     `Int (if stats.call_count > 0
+           then stats.total_duration_ms / stats.call_count
+           else 0));
+    ("last_called_at", `Float stats.last_called_at);
+  ]
+
+(** Generate a full stats report as JSON *)
+let stats_report ~all_tool_names : Yojson.Safe.t =
+  let top_20 = get_top_n 20 in
+  let cutoff_30d = Time_compat.now () -. (30.0 *. 86400.0) in
+  let unused_30d = get_unused_since cutoff_30d in
+  let never_called = get_never_called all_tool_names in
+  `Assoc [
+    ("total_calls", `Int (total_calls ()));
+    ("distinct_tools_called", `Int (distinct_tools_called ()));
+    ("total_tools_available", `Int (List.length all_tool_names));
+    ("top_20", `List (List.map stats_to_json top_20));
+    ("unused_30d", `List (List.map (fun s -> `String s) unused_30d));
+    ("unused_30d_count", `Int (List.length unused_30d));
+    ("never_called", `List (List.map (fun s -> `String s) never_called));
+    ("never_called_count", `Int (List.length never_called));
+  ]
+
+(** Reset all counters (for testing) *)
+let reset () =
+  Mutex.lock registry_mutex;
+  Fun.protect
+    ~finally:(fun () -> Mutex.unlock registry_mutex)
+    (fun () -> Hashtbl.clear registry)

--- a/lib/tool_registry.ml
+++ b/lib/tool_registry.ml
@@ -23,6 +23,17 @@ type call_stats = {
 let registry : (string, call_stats) Hashtbl.t = Hashtbl.create 128
 let registry_mutex = Mutex.create ()
 
+let known_tool_names : (string, unit) Hashtbl.t Lazy.t =
+  lazy
+    (let tbl = Hashtbl.create 256 in
+     List.iter
+       (fun (schema : Types.tool_schema) -> Hashtbl.replace tbl schema.name ())
+       Config.all_tool_schemas;
+     tbl)
+
+let is_known_tool tool_name =
+  Hashtbl.mem (Lazy.force known_tool_names) tool_name
+
 (** Record a tool call. Called from handle_call_tool_eio after execution. *)
 let record_call ~tool_name ~success ~duration_ms =
   Mutex.lock registry_mutex;
@@ -50,6 +61,10 @@ let record_call ~tool_name ~success ~duration_ms =
         stats.failure_count <- stats.failure_count + 1;
       stats.last_called_at <- Time_compat.now ();
       stats.total_duration_ms <- stats.total_duration_ms + duration_ms)
+
+let record_call_if_known ~tool_name ~success ~duration_ms =
+  if is_known_tool tool_name then
+    record_call ~tool_name ~success ~duration_ms
 
 (** Get all stats as a sorted list (by call_count descending) *)
 let get_stats () : (string * call_stats) list =
@@ -126,8 +141,9 @@ let stats_to_json (name, (stats : call_stats)) : Yojson.Safe.t =
   ]
 
 (** Generate a full stats report as JSON *)
-let stats_report ~all_tool_names : Yojson.Safe.t =
-  let top_20 = get_top_n 20 in
+let stats_report ~top_n ~all_tool_names : Yojson.Safe.t =
+  let bounded_top_n = max 1 (min 100 top_n) in
+  let top_tools = get_top_n bounded_top_n in
   let cutoff_30d = Time_compat.now () -. (30.0 *. 86400.0) in
   let unused_30d = get_unused_since cutoff_30d in
   let never_called = get_never_called all_tool_names in
@@ -135,7 +151,9 @@ let stats_report ~all_tool_names : Yojson.Safe.t =
     ("total_calls", `Int (total_calls ()));
     ("distinct_tools_called", `Int (distinct_tools_called ()));
     ("total_tools_available", `Int (List.length all_tool_names));
-    ("top_20", `List (List.map stats_to_json top_20));
+    ("top_n_requested", `Int bounded_top_n);
+    ("top_tools", `List (List.map stats_to_json top_tools));
+    ("top_20", `List (List.map stats_to_json top_tools));
     ("unused_30d", `List (List.map (fun s -> `String s) unused_30d));
     ("unused_30d_count", `Int (List.length unused_30d));
     ("never_called", `List (List.map (fun s -> `String s) never_called));

--- a/lib/tools.ml
+++ b/lib/tools.ml
@@ -4531,6 +4531,21 @@ Example: masc_swarm_leave({agent_name: 'claude-xyz'})";
       ("required", `List [`String "path"]);
     ];
   };
+
+  {
+    name = "masc_tool_stats";
+    description = "In-memory tool usage statistics for the current server session. Returns top-20 tools by call count, tools unused for 30+ days, and tools never called. Data resets on server restart; telemetry.jsonl is the durable store.";
+    input_schema = `Assoc [
+      ("type", `String "object");
+      ("properties", `Assoc [
+        ("top_n", `Assoc [
+          ("type", `String "integer");
+          ("description", `String "Number of top tools to return (default: 20)");
+          ("default", `Int 20);
+        ]);
+      ]);
+    ];
+  };
 ]
 
 let deprecated_public_tools =

--- a/test/dune
+++ b/test/dune
@@ -746,3 +746,8 @@
  (modules test_context_router_demo)
  (libraries masc_mcp yojson))
 
+; Tool Registry — in-memory call counters (P0: tool profile system)
+(test
+ (name test_tool_registry)
+ (modules test_tool_registry)
+ (libraries masc_mcp alcotest yojson))

--- a/test/test_tool_registry.ml
+++ b/test/test_tool_registry.ml
@@ -1,0 +1,130 @@
+(** Tests for Tool_registry — in-memory call counters *)
+
+module Tool_registry = Masc_mcp.Tool_registry
+
+let () =
+  let open Alcotest in
+  run "Tool_registry"
+    [
+      ( "record_call",
+        [
+          test_case "increments call_count" `Quick (fun () ->
+              Tool_registry.reset ();
+              Tool_registry.record_call ~tool_name:"masc_status" ~success:true
+                ~duration_ms:10;
+              Tool_registry.record_call ~tool_name:"masc_status" ~success:true
+                ~duration_ms:20;
+              let stats = Tool_registry.get_stats () in
+              let count =
+                List.assoc_opt "masc_status" stats
+                |> Option.map (fun s -> s.Tool_registry.call_count)
+                |> Option.value ~default:0
+              in
+              check int "call_count" 2 count);
+          test_case "tracks success and failure separately" `Quick (fun () ->
+              Tool_registry.reset ();
+              Tool_registry.record_call ~tool_name:"masc_join" ~success:true
+                ~duration_ms:5;
+              Tool_registry.record_call ~tool_name:"masc_join" ~success:false
+                ~duration_ms:15;
+              Tool_registry.record_call ~tool_name:"masc_join" ~success:true
+                ~duration_ms:8;
+              let stats = Tool_registry.get_stats () in
+              let s = List.assoc "masc_join" stats in
+              check int "call_count" 3 s.call_count;
+              check int "success_count" 2 s.success_count;
+              check int "failure_count" 1 s.failure_count);
+          test_case "accumulates duration" `Quick (fun () ->
+              Tool_registry.reset ();
+              Tool_registry.record_call ~tool_name:"masc_broadcast" ~success:true
+                ~duration_ms:100;
+              Tool_registry.record_call ~tool_name:"masc_broadcast" ~success:true
+                ~duration_ms:200;
+              let stats = Tool_registry.get_stats () in
+              let s = List.assoc "masc_broadcast" stats in
+              check int "total_duration_ms" 300 s.total_duration_ms);
+        ] );
+      ( "get_top_n",
+        [
+          test_case "returns top N by call count" `Quick (fun () ->
+              Tool_registry.reset ();
+              (* tool_a: 3 calls, tool_b: 1 call, tool_c: 5 calls *)
+              for _ = 1 to 3 do
+                Tool_registry.record_call ~tool_name:"tool_a" ~success:true
+                  ~duration_ms:1
+              done;
+              Tool_registry.record_call ~tool_name:"tool_b" ~success:true
+                ~duration_ms:1;
+              for _ = 1 to 5 do
+                Tool_registry.record_call ~tool_name:"tool_c" ~success:true
+                  ~duration_ms:1
+              done;
+              let top2 = Tool_registry.get_top_n 2 in
+              check int "length" 2 (List.length top2);
+              let names = List.map fst top2 in
+              check (list string) "order" [ "tool_c"; "tool_a" ] names);
+        ] );
+      ( "get_never_called",
+        [
+          test_case "identifies uncalled tools" `Quick (fun () ->
+              Tool_registry.reset ();
+              Tool_registry.record_call ~tool_name:"called_tool" ~success:true
+                ~duration_ms:1;
+              let never =
+                Tool_registry.get_never_called
+                  [ "called_tool"; "uncalled_a"; "uncalled_b" ]
+              in
+              check (list string) "never called"
+                [ "uncalled_a"; "uncalled_b" ]
+                never);
+        ] );
+      ( "totals",
+        [
+          test_case "total_calls sums all" `Quick (fun () ->
+              Tool_registry.reset ();
+              Tool_registry.record_call ~tool_name:"a" ~success:true
+                ~duration_ms:1;
+              Tool_registry.record_call ~tool_name:"b" ~success:true
+                ~duration_ms:1;
+              Tool_registry.record_call ~tool_name:"a" ~success:false
+                ~duration_ms:1;
+              check int "total" 3 (Tool_registry.total_calls ()));
+          test_case "distinct_tools_called" `Quick (fun () ->
+              Tool_registry.reset ();
+              Tool_registry.record_call ~tool_name:"x" ~success:true
+                ~duration_ms:1;
+              Tool_registry.record_call ~tool_name:"y" ~success:true
+                ~duration_ms:1;
+              Tool_registry.record_call ~tool_name:"x" ~success:true
+                ~duration_ms:1;
+              check int "distinct" 2 (Tool_registry.distinct_tools_called ()));
+        ] );
+      ( "stats_report",
+        [
+          test_case "generates valid JSON" `Quick (fun () ->
+              Tool_registry.reset ();
+              Tool_registry.record_call ~tool_name:"masc_status" ~success:true
+                ~duration_ms:42;
+              let json =
+                Tool_registry.stats_report
+                  ~all_tool_names:[ "masc_status"; "masc_join" ]
+              in
+              let s = Yojson.Safe.to_string json in
+              check bool "contains total_calls"
+                (String.length s > 0)
+                true;
+              (* Verify it parses back *)
+              let _ = Yojson.Safe.from_string s in
+              ());
+        ] );
+      ( "reset",
+        [
+          test_case "clears all data" `Quick (fun () ->
+              Tool_registry.reset ();
+              Tool_registry.record_call ~tool_name:"z" ~success:true
+                ~duration_ms:1;
+              check int "before" 1 (Tool_registry.total_calls ());
+              Tool_registry.reset ();
+              check int "after" 0 (Tool_registry.total_calls ()));
+        ] );
+    ]

--- a/test/test_tool_registry.ml
+++ b/test/test_tool_registry.ml
@@ -43,6 +43,11 @@ let () =
               let stats = Tool_registry.get_stats () in
               let s = List.assoc "masc_broadcast" stats in
               check int "total_duration_ms" 300 s.total_duration_ms);
+          test_case "ignores unknown tool names when gated" `Quick (fun () ->
+              Tool_registry.reset ();
+              Tool_registry.record_call_if_known ~tool_name:"totally_unknown_tool"
+                ~success:false ~duration_ms:1;
+              check int "total" 0 (Tool_registry.total_calls ()));
         ] );
       ( "get_top_n",
         [
@@ -107,6 +112,7 @@ let () =
                 ~duration_ms:42;
               let json =
                 Tool_registry.stats_report
+                  ~top_n:20
                   ~all_tool_names:[ "masc_status"; "masc_join" ]
               in
               let s = Yojson.Safe.to_string json in
@@ -116,6 +122,27 @@ let () =
               (* Verify it parses back *)
               let _ = Yojson.Safe.from_string s in
               ());
+          test_case "respects top_n" `Quick (fun () ->
+              Tool_registry.reset ();
+              for _ = 1 to 3 do
+                Tool_registry.record_call ~tool_name:"masc_status" ~success:true
+                  ~duration_ms:1
+              done;
+              for _ = 1 to 2 do
+                Tool_registry.record_call ~tool_name:"masc_join" ~success:true
+                  ~duration_ms:1
+              done;
+              Tool_registry.record_call ~tool_name:"masc_leave" ~success:true
+                ~duration_ms:1;
+              let json =
+                Tool_registry.stats_report ~top_n:2
+                  ~all_tool_names:[ "masc_status"; "masc_join"; "masc_leave" ]
+              in
+              let open Yojson.Safe.Util in
+              check int "top_n_requested" 2
+                (json |> member "top_n_requested" |> to_int);
+              check int "top_tools length" 2
+                (json |> member "top_tools" |> to_list |> List.length));
         ] );
       ( "reset",
         [


### PR DESCRIPTION
## Summary
- P0 of the tool profile system (from the MASC-MCP improvement plan)
- New `Tool_registry` module: Mutex-protected in-memory counters tracking call_count, success/failure, duration per tool
- `tools/list` now accepts optional `mode` parameter for filtering by Mode presets (minimal/standard/full/etc)
- New `masc_tool_stats` MCP tool returning top-N by call count, unused 30d tools, and never-called tools
- Wired `record_call` into `handle_call_tool_eio` hot path (O(1), complements existing Telemetry_eio JSONL persistence)

## Changed files
| File | Change |
|------|--------|
| `lib/tool_registry.ml` | New module: in-memory call stats with Mutex |
| `lib/masc_mcp.ml` | Re-export `Tool_registry` in wrapper module |
| `lib/mcp_server_eio.ml` | Wire `record_call` + `mode` param in `tools/list` |
| `lib/tools.ml` | Add `masc_tool_stats` schema |
| `lib/tool_misc.ml` | Add `handle_tool_stats` handler + dispatch |
| `lib/dune` | Register `tool_registry` module |
| `test/test_tool_registry.ml` | 9 unit tests |
| `test/dune` | Test stanza |

## Test plan
- [x] 9 unit tests pass (record_call, get_top_n, get_never_called, totals, stats_report, reset)
- [x] Full test suite regression check (`dune test` exit 0)
- [ ] Manual validation: `tools/list` with `mode: "minimal"` returns ~20 tools
- [ ] Manual validation: `masc_tool_stats` returns JSON report after server run

🤖 Generated with [Claude Code](https://claude.com/claude-code)