### PR TITLE
refactor: remove implicit ollama fallback bias

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -320,7 +320,7 @@ think → act → observe → verify → compact → heartbeat → loop (or hand
 ```
 # 에이전트 시작
 masc_perpetual_start(goal: "Monitor CI failures and fix them",
-                     models: ["ollama:glm-4.7-flash", "claude:opus"])
+                     models: ["glm:glm-4.7", "claude:opus"])
 
 # 상태 확인
 masc_perpetual_status()
@@ -340,12 +340,12 @@ MCP 서버 없이 독립 실행:
 # 기본 실행
 ./_build/default/bin/perpetual_cli.exe \
   --goal "Write a report on system health" \
-  --models "ollama:glm-4.7-flash"
+  --models "glm:glm-4.7"
 
 # 전체 옵션
 ./_build/default/bin/perpetual_cli.exe \
   --goal "Task description" \
-  --models "ollama:glm-4.7-flash,claude:opus" \
+  --models "glm:glm-4.7,claude:opus" \
   --verify-with "ollama:LFM2.5-1.2B-Instruct" \
   --heartbeat 30 \
   --max-idle 5 \
@@ -373,7 +373,7 @@ MCP 서버 없이 독립 실행:
 
 | Provider | 예시 | API |
 |----------|------|-----|
-| `ollama` | `ollama:glm-4.7-flash` | `http://127.0.0.1:11434/api/chat` |
+| `ollama` | `glm:glm-4.7` | `http://127.0.0.1:11434/api/chat` |
 | `claude` | `claude:opus` | Anthropic Messages API |
 | `gemini` | `gemini:pro` | Google AI GenerateContent |
 | `glm` | `glm:glm-4.7` | Z.ai ChatCompletions |
@@ -403,5 +403,5 @@ Context가 handoff threshold를 초과하면:
 DUNE_SOURCEROOT="$(pwd)" dune exec --root "$(pwd)" test/test_perpetual.exe
 
 # CLI 통합 테스트
-./_build/default/bin/perpetual_cli.exe --goal "Write a haiku" --models "ollama:glm-4.7-flash" --no-verify
+./_build/default/bin/perpetual_cli.exe --goal "Write a haiku" --models "glm:glm-4.7" --no-verify
 ```

--- a/bin/main_eio.ml
+++ b/bin/main_eio.ml
@@ -1557,20 +1557,8 @@ let split_csv_nonempty (raw : string) : string list =
   in
   List.rev out_rev
 
-let has_nonempty_env name =
-  match Sys.getenv_opt name with
-  | Some value -> String.trim value <> ""
-  | None -> false
-
 let trpg_default_fast_keeper_models () : string list =
-  let glm_available = has_nonempty_env "ZAI_API_KEY" in
-  let gemini_available = has_nonempty_env "GEMINI_API_KEY" in
-  match (glm_available, gemini_available) with
-  | true, true ->
-      [ "glm:glm-4.7"; "gemini:gemini-2.5-flash"; "ollama:glm-4.7-flash" ]
-  | true, false -> [ "glm:glm-4.7"; "ollama:glm-4.7-flash" ]
-  | false, true -> [ "gemini:gemini-2.5-flash"; "ollama:glm-4.7-flash" ]
-  | false, false -> [ "ollama:glm-4.7-flash" ]
+  Llm_client.default_execution_model_labels ()
 
 let trpg_keeper_models_override_csv () : string option =
   match Sys.getenv_opt "MASC_TRPG_KEEPER_MODELS" with
@@ -4927,7 +4915,12 @@ let keepers_dashboard_json ?(compact = false) (config : Room.config) : Yojson.Sa
                  | Error _ -> `Assoc [("has_checkpoint", `Bool false)]
                  | Ok specs ->
                      let primary =
-                       match specs with m0 :: _ -> m0 | [] -> Llm_client.ollama_glm
+                       match specs with
+                       | m0 :: _ -> m0
+                       | [] -> (
+                           match Llm_client.default_execution_model_spec () with
+                           | Ok model -> model
+                           | Error _ -> Llm_client.glm_cloud)
                      in
                      let base_dir = Tool_keeper.session_base_dir config in
                      let (_session, ctx_opt) =
@@ -9729,7 +9722,11 @@ let make_routes ~port ~host ~sw ~clock =
                  in
                  let model =
                    match json |> member "model" with
-                   | `String s -> s | _ -> "glm-4.7-flash:latest"
+                   | `String s -> s
+                   | _ -> (
+                       match Provider_adapter.default_model_label_result () with
+                       | Ok label -> label
+                       | Error _ -> "default-model")
                  in
                  let personality_hint =
                    match json |> member "personalityHint" with

--- a/bin/main_eio.ml
+++ b/bin/main_eio.ml
@@ -38,6 +38,7 @@ module Sse = Masc_mcp.Sse
 module Safe_ops = Masc_mcp.Safe_ops
 module Context_manager = Masc_mcp.Context_manager
 module Llm_client = Masc_mcp.Llm_client
+module Provider_adapter = Masc_mcp.Provider_adapter
 module Tool_perpetual = Masc_mcp.Tool_perpetual
 module Tool_mdal = Masc_mcp.Tool_mdal
 module Tool_board = Masc_mcp.Tool_board
@@ -9724,16 +9725,9 @@ let make_routes ~port ~host ~sw ~clock =
                    match json |> member "model" with
                    | `String s -> s
                    | _ -> (
-                       match Sys.getenv_opt "MASC_DEFAULT_CASCADE" with
-                       | Some raw ->
-                           (match raw |> String.split_on_char ',' |> List.map String.trim |> List.filter (fun s -> s <> "") with
-                            | first :: _ -> first
-                            | [] -> "default-model")
-                       | None -> (
-                           match (Sys.getenv_opt "MASC_DEFAULT_PROVIDER", Sys.getenv_opt "MASC_DEFAULT_MODEL") with
-                           | Some provider, Some model_id when String.trim provider <> "" && String.trim model_id <> "" ->
-                               String.trim provider ^ ":" ^ String.trim model_id
-                           | _ -> "default-model"))
+                       match Provider_adapter.default_model_label_result () with
+                       | Ok label -> label
+                       | Error _ -> "")
                  in
                  let personality_hint =
                    match json |> member "personalityHint" with
@@ -9758,6 +9752,9 @@ let make_routes ~port ~host ~sw ~clock =
                  else if preferred_hours = [] then
                    Http.Response.json ~status:`Bad_request
                      {|{"error":"at least one preferredHour"}|} reqd
+                 else if String.trim model = "" then
+                   Http.Response.json ~status:`Bad_request
+                     {|{"error":"model is required (or configure MASC_DEFAULT_CASCADE / MASC_DEFAULT_PROVIDER+MASC_DEFAULT_MODEL)"}|} reqd
                  else if activity_level < 0.1 || activity_level > 1.0 then
                    Http.Response.json ~status:`Bad_request
                      {|{"error":"activityLevel: 0.1-1.0"}|} reqd

--- a/bin/main_eio.ml
+++ b/bin/main_eio.ml
@@ -9724,9 +9724,16 @@ let make_routes ~port ~host ~sw ~clock =
                    match json |> member "model" with
                    | `String s -> s
                    | _ -> (
-                       match Provider_adapter.default_model_label_result () with
-                       | Ok label -> label
-                       | Error _ -> "default-model")
+                       match Sys.getenv_opt "MASC_DEFAULT_CASCADE" with
+                       | Some raw ->
+                           (match raw |> String.split_on_char ',' |> List.map String.trim |> List.filter (fun s -> s <> "") with
+                            | first :: _ -> first
+                            | [] -> "default-model")
+                       | None -> (
+                           match (Sys.getenv_opt "MASC_DEFAULT_PROVIDER", Sys.getenv_opt "MASC_DEFAULT_MODEL") with
+                           | Some provider, Some model_id when String.trim provider <> "" && String.trim model_id <> "" ->
+                               String.trim provider ^ ":" ^ String.trim model_id
+                           | _ -> "default-model"))
                  in
                  let personality_hint =
                    match json |> member "personalityHint" with

--- a/bin/perpetual_cli.ml
+++ b/bin/perpetual_cli.ml
@@ -4,9 +4,9 @@
     Useful for testing and standalone deployment.
 
     Usage:
-      ./perpetual_cli --goal "Task description" --models "ollama:glm-4.7-flash"
+      ./perpetual_cli --goal "Task description" --models "glm:glm-4.7,gemini:gemini-2.5-pro"
       ./perpetual_cli --status
-      ./perpetual_cli --goal "Count to 10" --models "ollama:glm-4.7-flash" --no-verify
+      ./perpetual_cli --goal "Count to 10" --models "glm:glm-4.7" --no-verify
 
     @since 2.61.0 *)
 
@@ -98,7 +98,7 @@ Options:\n\
   --goal GOAL           Goal for the agent\n\
   --models M1,M2,...    Model cascade (provider:model format)\n\
   --no-verify           Disable action verification\n\
-  --verify-with MODEL   Verifier model (default: ollama:LFM2.5-1.2B-Instruct)\n\
+  --verify-with MODEL   Verifier model (default: provider-aware auto selection)\n\
   --heartbeat SECS      Heartbeat interval (default: 30)\n\
   --max-idle N          Max idle turns (default: 5)\n\
   --max-context N       Override max context tokens\n\
@@ -147,15 +147,19 @@ let () =
     exit 1
   end;
 
-  let verifier = match args.verifier_str with
-    | Some s -> (match Llm_client.model_spec_of_string s with
-      | Ok m -> m
-      | Error _ -> Llm_client.ollama_lfm)
-    | None -> Llm_client.ollama_lfm
+  let verifier =
+    match args.verifier_str with
+    | Some s -> (
+        match Llm_client.model_spec_of_string s with
+        | Ok m -> Some m
+        | Error e ->
+            eprintf "Bad verifier spec '%s': %s\n%!" s e;
+            None)
+    | None -> None
   in
 
   let config = Perpetual_loop.default_config ~goal:args.goal ~models
-    ~verifier () in
+    ?verifier () in
   let config = { config with
     feedback_enabled = args.verify;
     heartbeat_interval_s = args.heartbeat;
@@ -171,7 +175,7 @@ let () =
     (List.map (fun (m : Llm_client.model_spec) ->
       sprintf "%s:%s" (Llm_client.string_of_provider m.provider) m.model_id
     ) models));
-  eprintf "Verify: %b (model: %s)\n%!" args.verify verifier.model_id;
+  eprintf "Verify: %b (model: %s)\n%!" args.verify config.verifier_model.model_id;
   eprintf "Thresholds: compact=%.0f%%, handoff=%.0f%%\n%!"
     (args.compact_at *. 100.0) (args.handoff_at *. 100.0);
   eprintf "---\n%!";

--- a/docs/TRPG-KEEPER-SPECTATOR-QUICKSTART.md
+++ b/docs/TRPG-KEEPER-SPECTATOR-QUICKSTART.md
@@ -40,7 +40,7 @@ make viewer-serve
 1. 상단 `새 게임` 클릭
 2. `DM` 1명 선택
 3. 플레이어 keeper 선택 (권장 4명)
-4. `new-game-models` 확인 (예: `ollama:glm-4.7-flash`)
+4. `new-game-models` 확인 (예: `glm:glm-4.7`)
 5. `세션 시작` 클릭
 
 ### 3.4 관전 시작
@@ -54,7 +54,7 @@ make viewer-serve
 Viewer에서 직접 세션을 만들지 않고, 터미널에서 TRPG 세션 + keeper 배치를 먼저 만든다.
 
 ```bash
-KEEPER_MODELS="ollama:glm-4.7-flash" \
+KEEPER_MODELS="glm:glm-4.7" \
 RUN_ROUND=1 \
 ROUNDS=3 \
 scripts/run_trpg_grimland_smoke.sh

--- a/lib/auto_responder.ml
+++ b/lib/auto_responder.ml
@@ -111,17 +111,7 @@ let cli_argv_of_agent_type (agent_type : string) : string list =
   | "claude" -> ["claude"; "-p"; "--allowedTools"; "mcp__masc__*"]
   | "gemini" -> ["gemini"; "--yolo"]
   | "codex" -> ["codex"; "exec"]
-  | "ollama" -> (
-      match Provider_adapter.default_model_label_result () with
-      | Ok label ->
-          let model =
-            match String.index_opt label ':' with
-            | Some idx when idx + 1 < String.length label ->
-                String.sub label (idx + 1) (String.length label - idx - 1)
-            | _ -> label
-          in
-          ["ollama"; "run"; model]
-      | Error msg -> invalid_arg msg)
+  | "ollama" -> ["ollama"; "run"; Provider_adapter.explicit_ollama_model_id ()]
   | other -> [other]
 
 let run_cli_agent ~agent_type ~prompt =

--- a/lib/auto_responder.ml
+++ b/lib/auto_responder.ml
@@ -111,7 +111,17 @@ let cli_argv_of_agent_type (agent_type : string) : string list =
   | "claude" -> ["claude"; "-p"; "--allowedTools"; "mcp__masc__*"]
   | "gemini" -> ["gemini"; "--yolo"]
   | "codex" -> ["codex"; "exec"]
-  | "ollama" -> ["ollama"; "run"; Env_config.Ollama.default_model]
+  | "ollama" -> (
+      match Provider_adapter.default_model_label_result () with
+      | Ok label ->
+          let model =
+            match String.index_opt label ':' with
+            | Some idx when idx + 1 < String.length label ->
+                String.sub label (idx + 1) (String.length label - idx - 1)
+            | _ -> label
+          in
+          ["ollama"; "run"; model]
+      | Error msg -> invalid_arg msg)
   | other -> [other]
 
 let run_cli_agent ~agent_type ~prompt =
@@ -143,11 +153,7 @@ let auto_responder_model_strings ~agent_type =
   | "gemini" ->
       [ "gemini:flash"; Printf.sprintf "glm:%s" Env_config.Llm.default_model ]
   | "glm" -> [ Printf.sprintf "glm:%s" Env_config.Llm.default_model ]
-  | "codex" | "ollama" | _ ->
-      [
-        Printf.sprintf "ollama:%s" Env_config.Ollama.default_model;
-        Printf.sprintf "glm:%s" Env_config.Llm.default_model;
-      ]
+  | "codex" | "ollama" | _ -> Llm_client.default_execution_model_labels ()
 
 let available_model_specs_for_agent_type ~agent_type =
   Llm_client.available_model_specs_of_strings

--- a/lib/capability_match.ml
+++ b/lib/capability_match.ml
@@ -159,11 +159,7 @@ let agent_profile_of_identity (id : Agent_identity.t) : agent_profile =
 let match_model_strings () =
   match Sys.getenv_opt "MASC_CAPABILITY_MATCH_MODELS" with
   | Some s -> String.split_on_char ',' s |> List.map String.trim
-  | None ->
-      [
-        Printf.sprintf "ollama:%s" (Env_config.Ollama.default_model);
-        Printf.sprintf "glm:%s" Env_config.Llm.default_model;
-      ]
+  | None -> Llm_client.default_execution_model_labels ()
 
 let match_model_specs () =
   Llm_client.available_model_specs_of_strings (match_model_strings ())

--- a/lib/chain_native_eio.ml
+++ b/lib/chain_native_eio.ml
@@ -229,10 +229,7 @@ let model_runner_of_string raw =
   | "claude" | "claude-cli" | "opus" | "opus-4" -> direct "claude:opus"
   | "sonnet" -> direct "claude:sonnet"
   | "haiku" | "haiku-4.5" -> direct "claude:haiku"
-  | "ollama" -> (
-      match Provider_adapter.default_model_label_result () with
-      | Ok label -> direct label
-      | Error msg -> Error msg)
+  | "ollama" -> direct (Provider_adapter.explicit_ollama_model_label ())
   | "glm" | "glm-4.7" -> direct "glm:glm-4.7"
   | "stub" | "mock" -> Ok Stub
   | "codex" | "gpt-5.2" -> Ok (Spawn "codex")
@@ -378,10 +375,7 @@ let call_named_tool_model (runtime : runtime) ~tool_name ~(args : Yojson.Safe.t)
         | Some value when starts_with ~prefix:"ollama:" (String.lowercase_ascii value) ->
             value
         | Some value -> "ollama:" ^ value
-        | None -> (
-            match Provider_adapter.default_model_label_result () with
-            | Ok label -> label
-            | Error _ -> "ollama"))
+        | None -> Provider_adapter.explicit_ollama_model_label ())
     | "glm" ->
         let default_model = "glm:glm-4.7" in
         (match assoc_get_string_opt args "model" with

--- a/lib/chain_native_eio.ml
+++ b/lib/chain_native_eio.ml
@@ -229,7 +229,10 @@ let model_runner_of_string raw =
   | "claude" | "claude-cli" | "opus" | "opus-4" -> direct "claude:opus"
   | "sonnet" -> direct "claude:sonnet"
   | "haiku" | "haiku-4.5" -> direct "claude:haiku"
-  | "ollama" -> direct "ollama:glm-4.7-flash"
+  | "ollama" -> (
+      match Provider_adapter.default_model_label_result () with
+      | Ok label -> direct label
+      | Error msg -> Error msg)
   | "glm" | "glm-4.7" -> direct "glm:glm-4.7"
   | "stub" | "mock" -> Ok Stub
   | "codex" | "gpt-5.2" -> Ok (Spawn "codex")
@@ -371,12 +374,14 @@ let call_named_tool_model (runtime : runtime) ~tool_name ~(args : Yojson.Safe.t)
     | "codex" ->
         assoc_get_string_opt args "model" |> Option.value ~default:"codex"
     | "ollama" ->
-        let default_model = "ollama:glm-4.7-flash" in
         (match assoc_get_string_opt args "model" with
         | Some value when starts_with ~prefix:"ollama:" (String.lowercase_ascii value) ->
             value
         | Some value -> "ollama:" ^ value
-        | None -> default_model)
+        | None -> (
+            match Provider_adapter.default_model_label_result () with
+            | Ok label -> label
+            | Error _ -> "ollama"))
     | "glm" ->
         let default_model = "glm:glm-4.7" in
         (match assoc_get_string_opt args "model" with

--- a/lib/council/router.ml
+++ b/lib/council/router.ml
@@ -42,27 +42,56 @@ type route_decision = {
 [@@deriving show]
 
 (** Default agent pool - configurable *)
-let default_agents : agent_spec list = [
-  (* Local tier - always resident in VRAM via OLLAMA_DEFAULT_MODEL *)
-  { name = "glm-flash"; model = (match Sys.getenv_opt "OLLAMA_DEFAULT_MODEL" with Some m -> m | None -> "glm-4.7-flash"); tier = Tiny;
-    strengths = [Factual; Conversation; Code; Analysis; Creative]; cost_per_1k = 0.0 };
-  
-  (* Medium tier - cloud balanced *)
-  { name = "sonnet"; model = "claude-3.5-sonnet"; tier = Medium;
-    strengths = [Code; Analysis; Creative]; cost_per_1k = 0.003 };
-  { name = "gpt-4o-mini"; model = "gpt-4o-mini"; tier = Medium;
-    strengths = [Conversation; Factual; Analysis]; cost_per_1k = 0.00015 };
-  
-  (* Large tier - heavy lifting *)
-  { name = "opus"; model = "claude-opus-4"; tier = Large;
-    strengths = [Complex; Analysis; Creative; Code]; cost_per_1k = 0.015 };
-  { name = "gpt-4o"; model = "gpt-4o"; tier = Large;
-    strengths = [Complex; Analysis; Code]; cost_per_1k = 0.005 };
-  
-  (* Giant tier - deep reasoning *)
-  { name = "o1"; model = "o1"; tier = Giant;
-    strengths = [Complex; Analysis; Code]; cost_per_1k = 0.015 };
-]
+let default_tiny_model_opt () =
+  let split_csv_nonempty raw =
+    raw
+    |> String.split_on_char ','
+    |> List.map String.trim
+    |> List.filter (fun s -> s <> "")
+  in
+  let label_opt =
+    match Sys.getenv_opt "MASC_DEFAULT_CASCADE" with
+    | Some raw -> (
+        match split_csv_nonempty raw with
+        | first :: _ -> Some first
+        | [] -> None)
+    | None -> (
+        match (Sys.getenv_opt "MASC_DEFAULT_PROVIDER", Sys.getenv_opt "MASC_DEFAULT_MODEL") with
+        | Some provider, Some model_id ->
+            let provider = String.trim provider in
+            let model_id = String.trim model_id in
+            if provider = "" || model_id = "" then None else Some (provider ^ ":" ^ model_id)
+        | _ -> None)
+  in
+  match label_opt with
+  | Some label -> (
+      match String.index_opt label ':' with
+      | Some idx when idx + 1 < String.length label ->
+          Some (String.sub label (idx + 1) (String.length label - idx - 1))
+      | _ -> Some label)
+  | None -> None
+
+let default_agents : agent_spec list =
+  let tiny_agents =
+    match default_tiny_model_opt () with
+    | Some model ->
+        [ { name = "default-tiny"; model; tier = Tiny;
+            strengths = [Factual; Conversation; Code; Analysis; Creative];
+            cost_per_1k = 0.0 } ]
+    | None -> []
+  in
+  tiny_agents @ [
+    { name = "sonnet"; model = "claude-3.5-sonnet"; tier = Medium;
+      strengths = [Code; Analysis; Creative]; cost_per_1k = 0.003 };
+    { name = "gpt-4o-mini"; model = "gpt-4o-mini"; tier = Medium;
+      strengths = [Conversation; Factual; Analysis]; cost_per_1k = 0.00015 };
+    { name = "opus"; model = "claude-opus-4"; tier = Large;
+      strengths = [Complex; Analysis; Creative; Code]; cost_per_1k = 0.015 };
+    { name = "gpt-4o"; model = "gpt-4o"; tier = Large;
+      strengths = [Complex; Analysis; Code]; cost_per_1k = 0.005 };
+    { name = "o1"; model = "o1"; tier = Giant;
+      strengths = [Complex; Analysis; Code]; cost_per_1k = 0.015 };
+  ]
 
 (** Feature extraction from query text *)
 module Features = struct

--- a/lib/env_config.ml
+++ b/lib/env_config.ml
@@ -240,12 +240,12 @@ module Spawn = struct
     int_of_float (get_float ~default:60.0 "MASC_SPAWN_GRACE_PERIOD_SEC")
 end
 
-(** {1 Ollama Configuration} *)
+(** {1 Local Runtime Compatibility Configuration} *)
 
 module Ollama = struct
-  (** Default model — always resident in VRAM via launchd preload *)
+  (** Default local runtime model — mirrors the centralized default model. *)
   let default_model =
-    get_string ~default:"glm-4.7-flash" "OLLAMA_DEFAULT_MODEL"
+    get_string ~default:"default-model" "MASC_DEFAULT_MODEL"
 end
 
 (** {1 llama.cpp Server Configuration} *)

--- a/lib/jiphyeon/router.ml
+++ b/lib/jiphyeon/router.ml
@@ -42,27 +42,33 @@ type route_decision = {
 [@@deriving show]
 
 (** Default agent pool - configurable *)
-let default_agents : agent_spec list = [
-  (* Local tier - always resident in VRAM via OLLAMA_DEFAULT_MODEL *)
-  { name = "glm-flash"; model = (match Sys.getenv_opt "OLLAMA_DEFAULT_MODEL" with Some m -> m | None -> "glm-4.7-flash"); tier = Tiny;
-    strengths = [Factual; Conversation; Code; Analysis; Creative]; cost_per_1k = 0.0 };
-  
-  (* Medium tier - cloud balanced *)
-  { name = "sonnet"; model = "claude-3.5-sonnet"; tier = Medium;
-    strengths = [Code; Analysis; Creative]; cost_per_1k = 0.003 };
-  { name = "gpt-4o-mini"; model = "gpt-4o-mini"; tier = Medium;
-    strengths = [Conversation; Factual; Analysis]; cost_per_1k = 0.00015 };
-  
-  (* Large tier - heavy lifting *)
-  { name = "opus"; model = "claude-opus-4"; tier = Large;
-    strengths = [Complex; Analysis; Creative; Code]; cost_per_1k = 0.015 };
-  { name = "gpt-4o"; model = "gpt-4o"; tier = Large;
-    strengths = [Complex; Analysis; Code]; cost_per_1k = 0.005 };
-  
-  (* Giant tier - deep reasoning *)
-  { name = "o1"; model = "o1"; tier = Giant;
-    strengths = [Complex; Analysis; Code]; cost_per_1k = 0.015 };
-]
+let default_agents : agent_spec list =
+  let tiny_agents =
+    match Llm_client.default_execution_model_labels () with
+    | first :: _ ->
+        let model =
+          match String.index_opt first ':' with
+          | Some idx when idx + 1 < String.length first ->
+              String.sub first (idx + 1) (String.length first - idx - 1)
+          | _ -> first
+        in
+        [ { name = "default-tiny"; model; tier = Tiny;
+            strengths = [Factual; Conversation; Code; Analysis; Creative];
+            cost_per_1k = 0.0 } ]
+    | [] -> []
+  in
+  tiny_agents @ [
+    { name = "sonnet"; model = "claude-3.5-sonnet"; tier = Medium;
+      strengths = [Code; Analysis; Creative]; cost_per_1k = 0.003 };
+    { name = "gpt-4o-mini"; model = "gpt-4o-mini"; tier = Medium;
+      strengths = [Conversation; Factual; Analysis]; cost_per_1k = 0.00015 };
+    { name = "opus"; model = "claude-opus-4"; tier = Large;
+      strengths = [Complex; Analysis; Creative; Code]; cost_per_1k = 0.015 };
+    { name = "gpt-4o"; model = "gpt-4o"; tier = Large;
+      strengths = [Complex; Analysis; Code]; cost_per_1k = 0.005 };
+    { name = "o1"; model = "o1"; tier = Giant;
+      strengths = [Complex; Analysis; Code]; cost_per_1k = 0.015 };
+  ]
 
 (** Feature extraction from query text *)
 module Features = struct

--- a/lib/jiphyeon/router.ml
+++ b/lib/jiphyeon/router.ml
@@ -42,20 +42,43 @@ type route_decision = {
 [@@deriving show]
 
 (** Default agent pool - configurable *)
+let default_tiny_model_opt () =
+  let split_csv_nonempty raw =
+    raw
+    |> String.split_on_char ','
+    |> List.map String.trim
+    |> List.filter (fun s -> s <> "")
+  in
+  let label_opt =
+    match Sys.getenv_opt "MASC_DEFAULT_CASCADE" with
+    | Some raw -> (
+        match split_csv_nonempty raw with
+        | first :: _ -> Some first
+        | [] -> None)
+    | None -> (
+        match (Sys.getenv_opt "MASC_DEFAULT_PROVIDER", Sys.getenv_opt "MASC_DEFAULT_MODEL") with
+        | Some provider, Some model_id ->
+            let provider = String.trim provider in
+            let model_id = String.trim model_id in
+            if provider = "" || model_id = "" then None else Some (provider ^ ":" ^ model_id)
+        | _ -> None)
+  in
+  match label_opt with
+  | Some label -> (
+      match String.index_opt label ':' with
+      | Some idx when idx + 1 < String.length label ->
+          Some (String.sub label (idx + 1) (String.length label - idx - 1))
+      | _ -> Some label)
+  | None -> None
+
 let default_agents : agent_spec list =
   let tiny_agents =
-    match Llm_client.default_execution_model_labels () with
-    | first :: _ ->
-        let model =
-          match String.index_opt first ':' with
-          | Some idx when idx + 1 < String.length first ->
-              String.sub first (idx + 1) (String.length first - idx - 1)
-          | _ -> first
-        in
+    match default_tiny_model_opt () with
+    | Some model ->
         [ { name = "default-tiny"; model; tier = Tiny;
             strengths = [Factual; Conversation; Code; Analysis; Creative];
             cost_per_1k = 0.0 } ]
-    | [] -> []
+    | None -> []
   in
   tiny_agents @ [
     { name = "sonnet"; model = "claude-3.5-sonnet"; tier = Medium;

--- a/lib/keeper_autonomy.ml
+++ b/lib/keeper_autonomy.ml
@@ -167,7 +167,7 @@ let evaluate_next_action ~config ~goal_ids ~keeper_name:_ =
           StartPerpetualAgent {
             goal_id = goal.id;
             goal_title = goal.title;
-            models = ["ollama:glm-4.7-flash"; "gemini:gemini-2.5-flash"];
+            models = Llm_client.default_execution_model_labels ();
             coding_mode = true;
             coding_agent = "claude";
           }

--- a/lib/keeper_schema.ml
+++ b/lib/keeper_schema.ml
@@ -53,7 +53,7 @@ Stores context on disk and keeps presence alive. Auto-handoff is enabled by defa
         ("models", `Assoc [
           ("type", `String "array");
           ("items", `Assoc [("type", `String "string")]);
-          ("description", `String "Model cascade (provider:model). Examples: 'claude:opus', 'gemini:gemini-3.1-pro-preview', 'ollama:glm-4.7-flash', 'glm:glm-4.7', 'openrouter:...'.");
+          ("description", `String "Model cascade (provider:model). Examples: 'claude:opus', 'gemini:gemini-3.1-pro-preview', 'glm:glm-4.7', 'openrouter:openai/gpt-4o-mini'.");
         ]);
         ("verify", `Assoc [
           ("type", `String "boolean");

--- a/lib/llm_client.ml
+++ b/lib/llm_client.ml
@@ -182,6 +182,18 @@ let sanitize_message_utf8 (m : message) : message =
 let sanitize_messages_utf8 (msgs : message list) : message list =
   List.map sanitize_message_utf8 msgs
 
+let env_present name =
+  match Sys.getenv_opt name with
+  | Some value -> String.trim value <> ""
+  | None -> false
+
+let nonempty_env name =
+  match Sys.getenv_opt name with
+  | Some value ->
+      let trimmed = String.trim value in
+      if trimmed = "" then None else Some trimmed
+  | None -> None
+
 (* ================================================================ *)
 (* Built-in Model Specs                                             *)
 (* ================================================================ *)
@@ -1245,10 +1257,60 @@ let model_spec_of_string s =
                "Cannot parse model spec: %s (unsupported provider '%s'; supported: ollama, llama, claude, gemini, glm, openrouter, mlx, custom)"
                s provider)
 
-let default_local_model_spec () =
-  match model_spec_of_string (Provider_adapter.default_local_model_label ()) with
-  | Ok spec -> spec
-  | Error _ -> ollama_glm
+let configured_default_model_label () =
+  match Provider_adapter.default_model_label_result () with
+  | Ok label -> Some label
+  | Error _ -> None
+
+let configured_default_verifier_model_label () =
+  match nonempty_env "MASC_DEFAULT_VERIFIER_MODEL" with
+  | Some label -> Some label
+  | None -> configured_default_model_label ()
+
+let gemini_direct_available () =
+  match Provider_adapter.resolve_gemini_direct_auth () with
+  | Provider_adapter.Gemini_api_key
+  | Provider_adapter.Gemini_vertex_adc _ -> true
+  | Provider_adapter.Gemini_auth_missing _ -> false
+
+let dedupe_keep_order items =
+  let seen = Hashtbl.create (List.length items) in
+  List.filter
+    (fun item ->
+      if Hashtbl.mem seen item then
+        false
+      else (
+        Hashtbl.add seen item ();
+        true))
+    items
+
+let default_execution_model_labels () =
+  dedupe_keep_order
+    (List.filter_map
+       Fun.id
+       [
+         configured_default_model_label ();
+         if env_present "ZAI_API_KEY" then Some "glm:glm-4.7" else None;
+         if gemini_direct_available () then Some "gemini:gemini-2.5-pro" else None;
+         if env_present "ANTHROPIC_API_KEY" then
+           Some "claude:claude-sonnet-4-5-20250929"
+         else None;
+         if env_present "OPENAI_API_KEY" then Some "openai:gpt-5" else None;
+       ])
+
+let default_verifier_model_labels () =
+  dedupe_keep_order
+    (List.filter_map
+       Fun.id
+       [
+         configured_default_verifier_model_label ();
+         if env_present "ZAI_API_KEY" then Some "glm:glm-4.7" else None;
+         if gemini_direct_available () then Some "gemini:gemini-2.5-flash" else None;
+         if env_present "ANTHROPIC_API_KEY" then
+           Some "claude:claude-sonnet-4-5-20250929"
+         else None;
+         if env_present "OPENAI_API_KEY" then Some "openai:gpt-5" else None;
+       ])
 
 let available_model_specs_of_strings model_strs =
   model_strs
@@ -1268,6 +1330,35 @@ let available_model_specs_of_strings model_strs =
                    None)
                  else Some spec
              | None -> Some spec))
+
+let first_available_model_spec labels =
+  match available_model_specs_of_strings labels with
+  | spec :: _ -> Ok spec
+  | [] ->
+      Error
+        "No default model available. Set MASC_DEFAULT_MODEL / MASC_DEFAULT_VERIFIER_MODEL, \
+         configure a supported provider credential (ZAI_API_KEY, GEMINI_API_KEY, \
+         GOOGLE_CLOUD_PROJECT, ANTHROPIC_API_KEY, OPENAI_API_KEY), or pass a model explicitly."
+
+let default_execution_model_spec () =
+  first_available_model_spec (default_execution_model_labels ())
+
+let default_verifier_model_spec () =
+  first_available_model_spec (default_verifier_model_labels ())
+
+let default_local_model_spec () =
+  match configured_default_model_label () with
+  | Some label -> (
+      match model_spec_of_string label with
+      | Ok spec -> spec
+      | Error _ -> (
+          match default_execution_model_spec () with
+          | Ok spec -> spec
+          | Error _ -> glm_cloud))
+  | None -> (
+      match default_execution_model_spec () with
+      | Ok spec -> spec
+      | Error _ -> glm_cloud)
 
 let run_prompt_cascade ?(temperature = 0.7) ?timeout_sec ?ollama_timeout_sec
     ?(accept = fun _ -> true) ~model_specs ~max_tokens ~prompt () =

--- a/lib/llm_client.mli
+++ b/lib/llm_client.mli
@@ -202,7 +202,7 @@ val run_prompt_cascade :
     deterministic tests. *)
 val cache_key_of_request : completion_request -> string
 
-(** Parse model spec from string like "ollama:glm-4.7-flash:latest",
+(** Parse model spec from string like "glm:glm-4.7",
     "claude:opus", or "gemini:gemini-3-flash-preview".
     Splits at the first ':' only, so model IDs may contain additional ':'. *)
 val model_spec_of_string : string -> (model_spec, string) result

--- a/lib/llm_client.mli
+++ b/lib/llm_client.mli
@@ -148,6 +148,22 @@ val gemini_pro : model_spec
     Falls back to [ollama_glm] if parsing fails. *)
 val default_local_model_spec : unit -> model_spec
 
+(** Preferred model labels for execution defaults, resolved from explicit env
+    overrides first, then available remote provider credentials, then any
+    explicitly configured local model. *)
+val default_execution_model_labels : unit -> string list
+
+(** Preferred model labels for verifier defaults. *)
+val default_verifier_model_labels : unit -> string list
+
+(** Resolve the first callable execution default.
+    Returns [Error _] instead of silently forcing a local Ollama model. *)
+val default_execution_model_spec : unit -> (model_spec, string) result
+
+(** Resolve the first callable verifier default.
+    Returns [Error _] instead of silently forcing a local Ollama model. *)
+val default_verifier_model_spec : unit -> (model_spec, string) result
+
 (** Create a message. *)
 val system_msg : string -> message
 val user_msg : string -> message

--- a/lib/lodge_daemon.ml
+++ b/lib/lodge_daemon.ml
@@ -63,7 +63,10 @@ let default_config = {
   heartbeat_interval_s = 30.0;
   reflection_interval_s = 3600.0;  (* 1 hour *)
   ollama_url = "http://127.0.0.1:11434";
-  ollama_model = "glm-4.7-flash:latest";  (* 128k context *)
+  ollama_model =
+    (match Sys.getenv_opt "MASC_DEFAULT_MODEL" with
+     | Some value when String.trim value <> "" -> String.trim value
+     | _ -> "default-model");
   neo4j_enabled = true;
 }
 
@@ -86,8 +89,10 @@ let load_config () =
     reflection_interval_s = get_env_float "MASC_LODGE_REFLECTION_INTERVAL" 3600.0;
     ollama_url = Option.value ~default:"http://127.0.0.1:11434"
       (Sys.getenv_opt "OLLAMA_URL");
-    (* Always use long-context model - no env override needed *)
-    ollama_model = "glm-4.7-flash:latest";
+    ollama_model =
+      (match Sys.getenv_opt "MASC_DEFAULT_MODEL" with
+       | Some value when String.trim value <> "" -> String.trim value
+       | _ -> default_config.ollama_model);
     neo4j_enabled = get_env_bool "MASC_LODGE_NEO4J_ENABLED" true;
   }
 

--- a/lib/lodge_heartbeat.ml
+++ b/lib/lodge_heartbeat.ml
@@ -1255,7 +1255,14 @@ let load_lodge_agents_full () =
                  let activity_level = (match member "activityLevel" node with `Float f -> f | `Int i -> float_of_int i | _ -> 0.5) in
                  let preferred_hours = (try member "preferredHours" node |> to_list |> List.map to_int with exn -> Printf.eprintf "[heartbeat] preferred_hours parse: %s\n%!" (Printexc.to_string exn); []) in
                  let peak_hour = (match member "peakHour" node with `Int i -> Some i | _ -> None) in
-                 let model = (match member "model" node with `String s -> s | _ -> "glm-4.7-flash:latest") in
+                 let model =
+                   (match member "model" node with
+                    | `String s -> s
+                    | _ -> (
+                        match Sys.getenv_opt "MASC_DEFAULT_MODEL" with
+                        | Some value when String.trim value <> "" -> String.trim value
+                        | _ -> "default-model"))
+                 in
                  let status = (match member "status" node with `String s -> s | _ -> "active") in
                  let primary_value = (match member "primaryValue" node with `String s -> Some s | _ -> None) in
                  let personality_hint = (match member "personalityHint" node with `String s -> Some s | _ -> None) in

--- a/lib/mcp_server_eio.ml
+++ b/lib/mcp_server_eio.ml
@@ -2062,11 +2062,7 @@ Time: %s
               if String.contains raw ':' then raw else "llama:" ^ raw
             in
             Llm_client.model_spec_of_string spec_name
-        | _, Some raw ->
-            let spec_name =
-              if String.contains raw ':' then raw else raw
-            in
-            Llm_client.model_spec_of_string spec_name
+        | _, Some _ -> Llm_client.default_execution_model_spec ()
         | _, None -> Llm_client.default_execution_model_spec ()
       in
       let module U = Yojson.Safe.Util in

--- a/lib/mcp_server_eio.ml
+++ b/lib/mcp_server_eio.ml
@@ -2062,7 +2062,12 @@ Time: %s
               if String.contains raw ':' then raw else "llama:" ^ raw
             in
             Llm_client.model_spec_of_string spec_name
-        | _, _ -> Ok Llm_client.ollama_glm
+        | _, Some raw ->
+            let spec_name =
+              if String.contains raw ':' then raw else raw
+            in
+            Llm_client.model_spec_of_string spec_name
+        | _, None -> Llm_client.default_execution_model_spec ()
       in
       let module U = Yojson.Safe.Util in
       let working_dir = match arguments |> U.member "working_dir" with

--- a/lib/perpetual_loop.ml
+++ b/lib/perpetual_loop.ml
@@ -89,7 +89,13 @@ let default_config ~goal ~models ?verifier ?session_dir () =
   let me_root = Env_config.me_root () in
   let verifier_model = match verifier with
     | Some v -> v
-    | None -> Llm_client.ollama_lfm  (* Cheapest available *)
+    | None -> (
+        match Llm_client.default_verifier_model_spec () with
+        | Ok model -> model
+        | Error _ -> (
+            match models with
+            | model :: _ -> model
+            | [] -> Llm_client.glm_cloud))
   in
   let session_base = match session_dir with
     | Some d -> d

--- a/lib/provider_adapter.ml
+++ b/lib/provider_adapter.ml
@@ -247,14 +247,9 @@ let default_model_labels_result () =
       | None, Some _ ->
           Error
             "MASC_DEFAULT_PROVIDER is required when MASC_DEFAULT_MODEL is set"
-      | None, None -> (
-          match Sys.getenv_opt "OLLAMA_DEFAULT_MODEL" with
-          | Some raw when String.trim raw <> "" ->
-              Error
-                "OLLAMA_DEFAULT_MODEL is deprecated for default selection; set MASC_DEFAULT_CASCADE or MASC_DEFAULT_PROVIDER/MASC_DEFAULT_MODEL"
-          | _ ->
-              Error
-                "No default model configured; set MASC_DEFAULT_CASCADE or MASC_DEFAULT_PROVIDER/MASC_DEFAULT_MODEL"))
+      | None, None ->
+          Error
+            "No default model configured; set MASC_DEFAULT_CASCADE or MASC_DEFAULT_PROVIDER/MASC_DEFAULT_MODEL")
 
 let default_model_label_result () =
   match default_model_labels_result () with
@@ -266,6 +261,16 @@ let default_local_model_label () =
   match default_model_label_result () with
   | Ok label -> label
   | Error msg -> invalid_arg msg
+
+let explicit_ollama_model_id () =
+  match Sys.getenv_opt "OLLAMA_DEFAULT_MODEL" with
+  | Some raw ->
+      let trimmed = String.trim raw in
+      if trimmed = "" then "glm-4.7-flash" else trimmed
+  | None -> "glm-4.7-flash"
+
+let explicit_ollama_model_label () =
+  "ollama:" ^ explicit_ollama_model_id ()
 
 let vertex_location () =
   match Sys.getenv_opt google_cloud_location_env with

--- a/lib/provider_adapter.ml
+++ b/lib/provider_adapter.ml
@@ -215,15 +215,57 @@ let resolve_cli_canonical_name label =
 
 let default_cli_agent_name () = "claude"
 
+let split_csv_nonempty raw =
+  raw
+  |> String.split_on_char ','
+  |> List.map String.trim
+  |> List.filter (fun s -> s <> "")
+
+let default_model_labels_result () =
+  match Sys.getenv_opt "MASC_DEFAULT_CASCADE" with
+  | Some raw ->
+      let labels = split_csv_nonempty raw in
+      if labels = [] then
+        Error "MASC_DEFAULT_CASCADE is set but empty"
+      else
+        Ok labels
+  | None -> (
+      match
+        (Sys.getenv_opt "MASC_DEFAULT_PROVIDER", Sys.getenv_opt "MASC_DEFAULT_MODEL")
+      with
+      | Some provider, Some model_id ->
+          let provider = String.trim provider in
+          let model_id = String.trim model_id in
+          if provider = "" || model_id = "" then
+            Error
+              "MASC_DEFAULT_PROVIDER/MASC_DEFAULT_MODEL must both be non-empty"
+          else
+            Ok [ provider ^ ":" ^ model_id ]
+      | Some _, None ->
+          Error
+            "MASC_DEFAULT_MODEL is required when MASC_DEFAULT_PROVIDER is set"
+      | None, Some _ ->
+          Error
+            "MASC_DEFAULT_PROVIDER is required when MASC_DEFAULT_MODEL is set"
+      | None, None -> (
+          match Sys.getenv_opt "OLLAMA_DEFAULT_MODEL" with
+          | Some raw when String.trim raw <> "" ->
+              Error
+                "OLLAMA_DEFAULT_MODEL is deprecated for default selection; set MASC_DEFAULT_CASCADE or MASC_DEFAULT_PROVIDER/MASC_DEFAULT_MODEL"
+          | _ ->
+              Error
+                "No default model configured; set MASC_DEFAULT_CASCADE or MASC_DEFAULT_PROVIDER/MASC_DEFAULT_MODEL"))
+
+let default_model_label_result () =
+  match default_model_labels_result () with
+  | Ok (first :: _) -> Ok first
+  | Ok [] -> Error "No default model configured"
+  | Error _ as e -> e
+
 let default_local_model_label () =
-  let model_id =
-    match Sys.getenv_opt "OLLAMA_DEFAULT_MODEL" with
-    | Some raw ->
-        let trimmed = String.trim raw in
-        if trimmed = "" then "glm-4.7-flash" else trimmed
-    | None -> "glm-4.7-flash"
-  in
-  "ollama:" ^ model_id
+  match default_model_label_result () with
+  | Ok label -> label
+  | Error msg -> invalid_arg msg
 
 let vertex_location () =
   match Sys.getenv_opt google_cloud_location_env with

--- a/lib/room_walph_eio.ml
+++ b/lib/room_walph_eio.ml
@@ -266,10 +266,7 @@ let get_chain_id_for_preset = function
 
 (** Default LLM dispatcher for Walph loop. Exposed as overridable parameter for tests. *)
 let walph_default_model_strings () =
-  [
-    Printf.sprintf "ollama:%s" Env_config.Ollama.default_model;
-    Printf.sprintf "glm:%s" Env_config.Llm.default_model;
-  ]
+  Llm_client.default_execution_model_labels ()
 
 let walph_available_model_specs () =
   Llm_client.available_model_specs_of_strings (walph_default_model_strings ())

--- a/lib/spawn.ml
+++ b/lib/spawn.ml
@@ -261,7 +261,7 @@ let default_configs = [
   });
   ("ollama", {
     agent_name = "ollama";
-    command = Printf.sprintf "ollama run %s" Env_config.Ollama.default_model;  (* Direct ollama CLI *)
+    command = "ollama run";  (* Direct ollama CLI; model resolved by adapter policy *)
     timeout_seconds = Env_config.Spawn.timeout_seconds;
     working_dir = None;
     mcp_tools = [];  (* Ollama has no MCP support *)
@@ -307,6 +307,21 @@ let parse_command cmd =
   let parts = String.split_on_char ' ' cmd in
   List.filter (fun s -> String.length s > 0) parts
 
+let add_default_model_arg agent_name argv =
+  match Provider_adapter.resolve_direct_adapter agent_name with
+  | Some adapter when adapter.canonical_name = "ollama" -> (
+      match Provider_adapter.default_model_label_result () with
+      | Ok label ->
+          let model =
+            match String.index_opt label ':' with
+            | Some idx when idx + 1 < String.length label ->
+                String.sub label (idx + 1) (String.length label - idx - 1)
+            | _ -> label
+          in
+          argv @ [ model ]
+      | Error msg -> invalid_arg msg)
+  | _ -> argv
+
 (** Spawn an agent with a prompt/task (direct execution, no shell) *)
 let spawn ~agent_name ~prompt ?timeout_seconds ?working_dir () =
   let start_time = Time_compat.now () in
@@ -330,7 +345,7 @@ let spawn ~agent_name ~prompt ?timeout_seconds ?working_dir () =
   let prompt_args = build_prompt_args agent_name augmented_prompt in
 
   (* Build command args - direct execution without shell *)
-  let base_args = parse_command config.command in
+  let base_args = parse_command config.command |> add_default_model_arg agent_name in
   let cmd_args = ["timeout"; string_of_int timeout] @ base_args @ mcp_args @ prompt_args in
   let cmd_array = Array.of_list cmd_args in
 

--- a/lib/spawn.ml
+++ b/lib/spawn.ml
@@ -310,16 +310,7 @@ let parse_command cmd =
 let add_default_model_arg agent_name argv =
   match Provider_adapter.resolve_direct_adapter agent_name with
   | Some adapter when adapter.canonical_name = "ollama" -> (
-      match Provider_adapter.default_model_label_result () with
-      | Ok label ->
-          let model =
-            match String.index_opt label ':' with
-            | Some idx when idx + 1 < String.length label ->
-                String.sub label (idx + 1) (String.length label - idx - 1)
-            | _ -> label
-          in
-          argv @ [ model ]
-      | Error msg -> invalid_arg msg)
+      argv @ [ Provider_adapter.explicit_ollama_model_id () ])
   | _ -> argv
 
 (** Spawn an agent with a prompt/task (direct execution, no shell) *)

--- a/lib/spawn_eio.ml
+++ b/lib/spawn_eio.ml
@@ -455,7 +455,7 @@ let default_configs = [
   });
   ("ollama", {
     agent_name = "ollama";
-    command = Printf.sprintf "ollama run %s" Env_config.Ollama.default_model;
+    command = "ollama run";
     timeout_seconds = Env_config.Spawn.timeout_seconds;
     working_dir = None;
     mcp_tools = [];
@@ -507,6 +507,21 @@ let build_prompt_args agent_name prompt =
 let parse_command cmd =
   let parts = String.split_on_char ' ' cmd in
   List.filter (fun s -> String.length s > 0) parts
+
+let add_default_model_arg agent_name argv =
+  match Provider_adapter.resolve_direct_adapter agent_name with
+  | Some adapter when adapter.canonical_name = "ollama" -> (
+      match Provider_adapter.default_model_label_result () with
+      | Ok label ->
+          let model =
+            match String.index_opt label ':' with
+            | Some idx when idx + 1 < String.length label ->
+                String.sub label (idx + 1) (String.length label - idx - 1)
+            | _ -> label
+          in
+          argv @ [ model ]
+      | Error msg -> invalid_arg msg)
+  | _ -> argv
 
 type glm_spawn_success = {
   model_used: string;
@@ -910,7 +925,7 @@ let spawn ~sw ~proc_mgr ~agent_name ~prompt ?timeout_seconds ?working_dir
              })
   else
     (* Build command arguments outside the chdir critical section *)
-    let base_args = parse_command config.command in
+    let base_args = parse_command config.command |> add_default_model_arg agent_name in
     let prompt_args = build_prompt_args agent_name augmented_prompt in
     let cmd_args = base_args @ mcp_args @ prompt_args in
     let full_args = ["timeout"; string_of_int timeout] @ cmd_args in

--- a/lib/spawn_eio.ml
+++ b/lib/spawn_eio.ml
@@ -511,16 +511,7 @@ let parse_command cmd =
 let add_default_model_arg agent_name argv =
   match Provider_adapter.resolve_direct_adapter agent_name with
   | Some adapter when adapter.canonical_name = "ollama" -> (
-      match Provider_adapter.default_model_label_result () with
-      | Ok label ->
-          let model =
-            match String.index_opt label ':' with
-            | Some idx when idx + 1 < String.length label ->
-                String.sub label (idx + 1) (String.length label - idx - 1)
-            | _ -> label
-          in
-          argv @ [ model ]
-      | Error msg -> invalid_arg msg)
+      argv @ [ Provider_adapter.explicit_ollama_model_id () ])
   | _ -> argv
 
 type glm_spawn_success = {

--- a/lib/tool_goals.ml
+++ b/lib/tool_goals.ml
@@ -358,7 +358,7 @@ let env_keeper_models () =
 let default_keeper_models () =
   let from_env = env_keeper_models () in
   if from_env <> [] then from_env
-  else [ "ollama:glm-4.7-flash"; "gemini:gemini-3-pro-preview" ]
+  else Llm_client.default_execution_model_labels ()
 
 let sanitize_keeper_name s =
   let buf = Buffer.create (String.length s) in

--- a/lib/tool_keeper.ml
+++ b/lib/tool_keeper.ml
@@ -5412,7 +5412,11 @@ let run_autonomous_goal_turn ~(config : Room.config) ~(meta : keeper_meta)
     | Some L1_Reactive -> None
     | Some level ->
         let primary = match specs with p :: _ -> p | [] -> Llm_client.default_local_model_spec () in
-        let verify_model = Llm_client.ollama_lfm in
+        let verify_model =
+          match Llm_client.default_verifier_model_spec () with
+          | Ok model -> model
+          | Error _ -> primary
+        in
         let keeper_context =
           Printf.sprintf "keeper=%s autonomy=%s turns=%d cost=$%.4f"
             meta.name (Keeper_autonomy.autonomy_level_to_string level)

--- a/lib/tool_lodge.ml
+++ b/lib/tool_lodge.ml
@@ -434,7 +434,15 @@ let glm_direct ~net:_ ?temperature:(_temp = 0.7) ?(max_tokens = 500) ~system pro
   with exn -> Error (Printf.sprintf "❌ LLM: GLM exception [%s]" (Printexc.to_string exn))
 
 (** Call local ollama API — DEPRECATED, use glm_direct instead *)
-let ollama_generate ~net:_ ?(model = Env_config.Ollama.default_model) ?(temperature = 0.7) ?(num_predict = 500) ~system prompt =
+let ollama_generate ~net:_ ?model ?(temperature = 0.7) ?(num_predict = 500) ~system prompt =
+  let model =
+    match model with
+    | Some value -> value
+    | None -> (
+        match Sys.getenv_opt "MASC_DEFAULT_MODEL" with
+        | Some value when String.trim value <> "" -> String.trim value
+        | _ -> "default-model")
+  in
   try
     let body = Yojson.Safe.to_string (`Assoc [
       ("model", `String model);
@@ -729,6 +737,11 @@ type agent_config = {
   interests: string list;
 }
 
+let default_model () =
+  match Sys.getenv_opt "MASC_DEFAULT_MODEL" with
+  | Some value when String.trim value <> "" -> String.trim value
+  | _ -> "default-model"
+
 let builtin_core_agent_configs () =
   [
     {
@@ -740,7 +753,7 @@ let builtin_core_agent_configs () =
       status = "active";
       emoji = "🌙";
       korean_name = "몽상가";
-      model = "glm-4.7-flash:latest";
+      model = default_model ();
       interests = [ "vision"; "future"; "art"; "possibility" ];
     };
     {
@@ -752,7 +765,7 @@ let builtin_core_agent_configs () =
       status = "active";
       emoji = "🧐";
       korean_name = "회의론자";
-      model = "glm-4.7-flash:latest";
+      model = default_model ();
       interests = [ "evidence"; "risk"; "debugging"; "correctness" ];
     };
     {
@@ -764,7 +777,7 @@ let builtin_core_agent_configs () =
       status = "active";
       emoji = "📚";
       korean_name = "역사가";
-      model = "glm-4.7-flash:latest";
+      model = default_model ();
       interests = [ "context"; "history"; "continuity"; "archives" ];
     };
     {
@@ -776,7 +789,7 @@ let builtin_core_agent_configs () =
       status = "active";
       emoji = "🔧";
       korean_name = "실용주의자";
-      model = "glm-4.7-flash:latest";
+      model = default_model ();
       interests = [ "operations"; "execution"; "delivery"; "practicality" ];
     };
     {
@@ -788,7 +801,7 @@ let builtin_core_agent_configs () =
       status = "active";
       emoji = "🕸️";
       korean_name = "연결자";
-      model = "glm-4.7-flash:latest";
+      model = default_model ();
       interests = [ "relationships"; "coordination"; "bridges"; "community" ];
     };
   ]
@@ -841,7 +854,7 @@ let agent_config_of_yojson (json : Yojson.Safe.t) : agent_config option =
       status = json |> member "status" |> to_string_option |> Option.value ~default:"active";
       emoji = json |> member "emoji" |> to_string_option |> Option.value ~default:"🤖";
       korean_name = json |> member "korean_name" |> to_string_option |> Option.value ~default:"";
-      model = json |> member "model" |> to_string_option |> Option.value ~default:"glm-4.7-flash:latest";
+      model = json |> member "model" |> to_string_option |> Option.value ~default:(default_model ());
       interests = json |> member "interests" |> to_list |> List.filter_map to_string_option;
     }
   with Yojson.Safe.Util.Type_error (_, _) -> None
@@ -953,7 +966,7 @@ let load_agents_config () =
                      status = Yojson.Safe.Util.(member "status" node |> to_string_option) |> Option.value ~default:"active";
                      emoji = Yojson.Safe.Util.(member "emoji" node |> to_string_option) |> Option.value ~default:"🤖";
                      korean_name = Yojson.Safe.Util.(member "koreanName" node |> to_string_option) |> Option.value ~default:name;
-                     model = Yojson.Safe.Util.(member "model" node |> to_string_option) |> Option.value ~default:"glm-4.7-flash:latest";
+                     model = Yojson.Safe.Util.(member "model" node |> to_string_option) |> Option.value ~default:(default_model ());
                      interests;
                    } in
                    Mutex.lock agent_cache_mu;
@@ -1166,7 +1179,7 @@ let validate_agent_name name =
 let get_agent_model name =
   match get_cached_agent name with
   | Some c -> c.model
-  | None -> "glm-4.7-flash:latest"
+  | None -> default_model ()
 
 (** Get prompt from Neo4j cache *)
 let get_agent_prompt name =

--- a/lib/tool_mitosis.ml
+++ b/lib/tool_mitosis.ml
@@ -194,11 +194,8 @@ let set_bool_arg args key value =
   | _ ->
       `Assoc [ (key, `Bool value) ]
 
-let default_verifier_models = [
-  "ollama:glm-4.7-flash";
-  "ollama:glm-4.7-flash";
-  "ollama:glm-4.7-flash";
-]
+let default_verifier_models =
+  Llm_client.default_verifier_model_labels ()
 
 let default_verifier_perspectives = [
   "A: continuity archivist (value-neutral)";

--- a/lib/tool_perpetual.ml
+++ b/lib/tool_perpetual.ml
@@ -19,7 +19,7 @@ let schemas : Types.tool_schema list = [
 The agent will think → act → observe → verify in a loop, compacting context as needed \
 and handing off to successor agents when context fills up. \
 Requires: goal (what to accomplish), models (LLM cascade in priority order). \
-Example models: 'gemini:gemini-3-flash-preview', 'ollama:glm-4.7-flash', 'claude:opus', 'glm:glm-4.7'.";
+Example models: 'gemini:gemini-3-flash-preview', 'claude:opus', 'glm:glm-4.7', 'openrouter:openai/gpt-4o-mini'.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -31,7 +31,7 @@ Example models: 'gemini:gemini-3-flash-preview', 'ollama:glm-4.7-flash', 'claude
           ("type", `String "array");
           ("items", `Assoc [("type", `String "string")]);
           ("description", `String "LLM model cascade in priority order. \
-Format: 'provider:model_id'. Examples: 'gemini:gemini-3-flash-preview', 'ollama:glm-4.7-flash', 'claude:opus', 'glm:glm-4.7'");
+Format: 'provider:model_id'. Examples: 'gemini:gemini-3-flash-preview', 'claude:opus', 'glm:glm-4.7', 'openrouter:openai/gpt-4o-mini'");
         ]);
         ("verify", `Assoc [
           ("type", `String "boolean");

--- a/lib/tool_trpg.ml
+++ b/lib/tool_trpg.ml
@@ -7878,7 +7878,10 @@ let handle_round_run ctx args : result =
             let tier1_model =
               match Llm_client.model_spec_of_string tier1_str with
               | Ok m -> m
-              | Error _ -> Llm_client.ollama_lfm
+              | Error _ -> (
+                  match Llm_client.default_verifier_model_spec () with
+                  | Ok model -> model
+                  | Error _ -> Llm_client.glm_cloud)
             in
             let tier2_model =
               match Sys.getenv_opt "TRPG_HARNESS_TIER2_MODEL" with

--- a/lib/tools.ml
+++ b/lib/tools.ml
@@ -2266,7 +2266,7 @@ Embodies proactive mitosis: prepare early at 50%, handoff at 80%.|};
         ("verifier_models", `Assoc [
           ("type", `String "array");
           ("items", `Assoc [("type", `String "string")]);
-          ("description", `String "Verifier model list (provider:model). Default: ['ollama:glm-4.7-flash'].");
+          ("description", `String "Verifier model list (provider:model). Default: provider-aware auto selection from explicit env or available remote credentials.");
         ]);
         ("verifier_perspectives", `Assoc [
           ("type", `String "array");

--- a/lib/verifier.mli
+++ b/lib/verifier.mli
@@ -4,8 +4,8 @@
     whether the action was correct and aligned with the goal.
     This implements the "verify" step of think → act → observe → verify.
 
-    Uses the cheapest available model (LFM2.5 local, or GLM-4.7-flash)
-    with a max 200-token budget per verification.
+    Uses a provider-aware default verifier model when the caller does not
+    specify one, with a max 200-token budget per verification.
 
     Read-only actions (file reads, searches) are skipped.
 

--- a/scripts/harness_mitosis_verifier_continuity_recheck_cmp.sh
+++ b/scripts/harness_mitosis_verifier_continuity_recheck_cmp.sh
@@ -22,7 +22,7 @@ MIN_AGREEMENT="${MIN_AGREEMENT:-0.6666666666666666}"
 JUDGE_TIMEOUT_SEC="${JUDGE_TIMEOUT_SEC:-60}"
 SAGA_TIMEOUT_SEC="${SAGA_TIMEOUT_SEC:-180}"
 PROFILE="${VERIFIER_PROFILE:-abc_neutral}"
-MODELS_JSON="${MODELS_JSON:-[\"gemini:gemini-2.5-flash\",\"ollama:glm-4.7-flash\",\"gemini:gemini-2.5-flash\"]}"
+MODELS_JSON="${MODELS_JSON:-[\"gemini:gemini-2.5-flash\",\"glm:glm-4.7\",\"gemini:gemini-2.5-flash\"]}"
 
 run_case() {
   local label="$1"

--- a/scripts/harness_mitosis_verifier_min_judges_cmp.sh
+++ b/scripts/harness_mitosis_verifier_min_judges_cmp.sh
@@ -7,7 +7,7 @@ RUNS="${RUNS:-10}"
 JUDGE_TIMEOUT_SEC="${JUDGE_TIMEOUT_SEC:-60}"
 SAGA_TIMEOUT_SEC="${SAGA_TIMEOUT_SEC:-180}"
 PROFILE="${VERIFIER_PROFILE:-abc_neutral}"
-MODELS_JSON="${MODELS_JSON:-[\"gemini:gemini-2.5-flash\",\"ollama:glm-4.7-flash\",\"gemini:gemini-2.5-flash\"]}"
+MODELS_JSON="${MODELS_JSON:-[\"gemini:gemini-2.5-flash\",\"glm:glm-4.7\",\"gemini:gemini-2.5-flash\"]}"
 PASS_RATIO="${PASS_RATIO:-0.6666666666666666}"
 MIN_AGREEMENT="${MIN_AGREEMENT:-0.6666666666666666}"
 

--- a/scripts/harness_mitosis_verifier_timeout_cmp.sh
+++ b/scripts/harness_mitosis_verifier_timeout_cmp.sh
@@ -9,7 +9,7 @@ TIMEOUT_B="${TIMEOUT_B:-60}"
 MIN_JUDGES="${MIN_JUDGES:-3}"
 SAGA_TIMEOUT_SEC="${SAGA_TIMEOUT_SEC:-180}"
 PROFILE="${VERIFIER_PROFILE:-abc_neutral}"
-MODELS_JSON="${MODELS_JSON:-[\"gemini:gemini-2.5-flash\",\"ollama:glm-4.7-flash\",\"gemini:gemini-2.5-flash\"]}"
+MODELS_JSON="${MODELS_JSON:-[\"gemini:gemini-2.5-flash\",\"glm:glm-4.7\",\"gemini:gemini-2.5-flash\"]}"
 PASS_RATIO="${PASS_RATIO:-0.6666666666666666}"
 MIN_AGREEMENT="${MIN_AGREEMENT:-0.6666666666666666}"
 

--- a/scripts/run_trpg_with_soul.sh
+++ b/scripts/run_trpg_with_soul.sh
@@ -26,7 +26,7 @@ $DM_SOUL
 $WORLD_INFO
 
 Task: Manage room '$ROOM_ID'." 
-  --models "ollama:glm-4.7-flash" 
+  --models "glm:glm-4.7"
   --heartbeat_sec 10 > logs/dm_soul.log 2>&1 &
 
 # 2. Summon Aragorn
@@ -41,7 +41,7 @@ $ARAGORN_SOUL
 $WORLD_INFO
 
 Task: Play in room '$ROOM_ID' as 'aragorn-1'." 
-  --models "ollama:glm-4.7-flash" 
+  --models "glm:glm-4.7"
   --heartbeat_sec 10 > logs/aragorn_soul.log 2>&1 &
 
 echo "✅ Souls infused. The society is alive."

--- a/scripts/viewer-local-e2e-check.sh
+++ b/scripts/viewer-local-e2e-check.sh
@@ -54,14 +54,14 @@ viewer-local-e2e-check.sh
   --dm-preset-id ID          smoke DM preset
   --party-size N             smoke party size (기본 4)
   --pool-size N              smoke pool size (기본 6)
-  --keeper-models CSV        smoke keeper 모델 (예: ollama:glm-4.7-flash)
+  --keeper-models CSV        smoke keeper 모델 (예: glm:glm-4.7)
   --mcp-url URL              MCP endpoint (기본 http://127.0.0.1:8935/mcp)
   --help                     도움말
 
 예시:
   scripts/viewer-local-e2e-check.sh
   scripts/viewer-local-e2e-check.sh --build-viewer
-  scripts/viewer-local-e2e-check.sh --run-smoke --keeper-models "ollama:glm-4.7-flash"
+  scripts/viewer-local-e2e-check.sh --run-smoke --keeper-models "glm:glm-4.7"
   scripts/viewer-local-e2e-check.sh --run-round --rounds 2 --keeper-models "gemini:gemini-2.5-flash"
 EOF
 }

--- a/test/test_perpetual.ml
+++ b/test/test_perpetual.ml
@@ -197,7 +197,7 @@ let test_llm_client () = group "LLM Client" (fun () ->
   assert_true "builtin:default_local_provider"
     (default_local.provider = Llm_client.Ollama);
   assert_equal "builtin:default_local_model_id"
-    Masc_mcp.Env_config.Ollama.default_model default_local.model_id;
+    "default-model" default_local.model_id;
 )
 
 (* ================================================================ *)

--- a/test/test_provider_adapter.ml
+++ b/test/test_provider_adapter.ml
@@ -65,9 +65,10 @@ let test_default_cli_agent_name () =
     (Adapter.default_cli_agent_name ())
 
 let test_default_local_model_label () =
-  with_env "OLLAMA_DEFAULT_MODEL" (Some "my-local-model") (fun () ->
-      check string "default local label" "ollama:my-local-model"
-        (Adapter.default_local_model_label ()))
+  with_env "MASC_DEFAULT_PROVIDER" (Some "glm") (fun () ->
+      with_env "MASC_DEFAULT_MODEL" (Some "glm-4.7") (fun () ->
+          check string "default local label" "glm:glm-4.7"
+            (Adapter.default_local_model_label ())))
 
 let () =
   run "Provider Adapter"

--- a/test/test_walph_eio.ml
+++ b/test/test_walph_eio.ml
@@ -317,12 +317,9 @@ let test_eio_default_dispatch_uses_shared_cascade () =
     (file_contains_pattern "lib/room_walph_eio.ml" "Llm_client.run_prompt_cascade");
   check bool "legacy direct dispatch removed" false
     (file_contains_pattern "lib/room_walph_eio.ml" "Llm_direct.dispatch");
-  check bool "shared pool starts with ollama" true
+  check bool "shared pool uses centralized defaults" true
     (file_contains_pattern "lib/room_walph_eio.ml"
-       {|Printf.sprintf "ollama:%s" Env_config.Ollama.default_model|});
-  check bool "shared pool falls back to glm" true
-    (file_contains_pattern "lib/room_walph_eio.ml"
-       {|Printf.sprintf "glm:%s" Env_config.Llm.default_model|})
+       {|Llm_client.default_execution_model_labels ()|})
 
 (* ============================================
    Test Registration

--- a/viewer/index.html
+++ b/viewer/index.html
@@ -294,7 +294,7 @@
 
                     <label class="new-game-field new-game-field-wide">
                         <span>AI 모델 (쉼표로 구분)</span>
-                        <input id="new-game-models" type="text" value="ollama:glm-4.7-flash" title="AI가 사용할 LLM 모델 지정" />
+                        <input id="new-game-models" type="text" value="glm:glm-4.7" title="AI가 사용할 LLM 모델 지정" />
                         <div id="new-game-model-status" class="new-game-inline-hint">가용 모델 조회 대기 중</div>
                         <div id="new-game-model-list" class="room-chip-list model-chip-list">
                             <div class="room-chip-empty">가용 모델을 불러오는 중입니다.</div>


### PR DESCRIPTION
## Summary
- remove policy-level implicit ollama defaults from runtime entrypoints and verifier selection
- centralize provider-aware default model selection behind `llm_client` and `provider_adapter`
- update examples and schema/help text so ollama is treated as an optional provider, not the default policy

## What changed
- replace implicit `ollama_glm` / `ollama_lfm` fallbacks in spawn, perpetual, keeper, TRPG, mitosis, walph, auto-responder, capability matching, and route default paths
- add provider-aware default selection helpers using explicit env overrides first, then available remote credentials
- deprecate `OLLAMA_DEFAULT_MODEL` as the source of global default selection; keep it only as an explicit local-model override path
- keep ollama support code paths intact where ollama is explicitly selected as a provider/runtime

## Verification
- `dune build --root .`

## Notes
- This PR removes default-selection bias toward ollama; it does not remove ollama support as a provider.
