### PR TITLE
refactor: silent error cleanup and code hygiene (#796)

### DIFF
--- a/lib/agent_swarm_external_agent.ml
+++ b/lib/agent_swarm_external_agent.ml
@@ -66,7 +66,10 @@ let run_with_masc ~sw ~proc_mgr ~clock ~net ~masc_url config ~goal =
       ~agent_name:config.name ~net in
     let _joined = Agent_swarm_client.join ~sw client in
     Fun.protect ~finally:(fun () ->
-      try ignore (Agent_swarm_client.leave ~sw client) with exn -> ignore exn
+      (try match Agent_swarm_client.leave ~sw client with
+        | Ok _ -> ()
+        | Error msg -> Printf.eprintf "[WARN] [swarm] leave failed: %s\n%!" msg
+      with exn -> Printf.eprintf "[WARN] [swarm] leave error: %s\n%!" (Printexc.to_string exn))
     ) (fun () ->
       let _ = Agent_swarm_client.broadcast ~sw client
         ~message:(Printf.sprintf "Starting: %s" goal) in

--- a/lib/agent_swarm_external_agent.ml
+++ b/lib/agent_swarm_external_agent.ml
@@ -71,8 +71,9 @@ let run_with_masc ~sw ~proc_mgr ~clock ~net ~masc_url config ~goal =
         | Error msg -> Printf.eprintf "[WARN] [swarm] leave failed: %s\n%!" msg
       with exn -> Printf.eprintf "[WARN] [swarm] leave error: %s\n%!" (Printexc.to_string exn))
     ) (fun () ->
-      let _ = Agent_swarm_client.broadcast ~sw client
-        ~message:(Printf.sprintf "Starting: %s" goal) in
+      (match Agent_swarm_client.broadcast ~sw client
+        ~message:(Printf.sprintf "Starting: %s" goal) with
+       | Ok _ -> () | Error msg -> Printf.eprintf "[WARN] [swarm] broadcast failed: %s\n%!" msg);
       let result = run_cli ~sw ~proc_mgr ~clock config ~prompt:goal in
       let summary = match result with
         | Ok out ->
@@ -80,8 +81,9 @@ let run_with_masc ~sw ~proc_mgr ~clock ~net ~masc_url config ~goal =
           else out
         | Error e -> "Error: " ^ e
       in
-      let _ = Agent_swarm_client.broadcast ~sw client
-        ~message:(Printf.sprintf "Done: %s" summary) in
+      (match Agent_swarm_client.broadcast ~sw client
+        ~message:(Printf.sprintf "Done: %s" summary) with
+       | Ok _ -> () | Error msg -> Printf.eprintf "[WARN] [swarm] broadcast failed: %s\n%!" msg);
       result
     )
   with

--- a/lib/agent_swarm_fleet.ml
+++ b/lib/agent_swarm_fleet.ml
@@ -100,9 +100,10 @@ let run ~sw ~net ~clock ~proc_mgr config ~goal =
      | exn -> Printf.eprintf "[WARN] [swarm] leader leave error: %s\n%!" (Printexc.to_string exn))
   ) (fun () ->
     let names = List.map (fun (m, _) -> member_name m) config.members in
-    let _ = Agent_swarm_client.broadcast ~sw leader
+    (match Agent_swarm_client.broadcast ~sw leader
       ~message:(Printf.sprintf "Fleet starting: %s (members: %s)"
-        goal (String.concat ", " names)) in
+        goal (String.concat ", " names)) with
+     | Ok _ -> () | Error msg -> Printf.eprintf "[WARN] [swarm] broadcast failed: %s\n%!" msg);
     let n = List.length config.members in
     let results = Array.make n
       { member_name = ""; capability = General; result = Error "pending" } in
@@ -119,8 +120,9 @@ let run ~sw ~net ~clock ~proc_mgr config ~goal =
       Printf.sprintf "- %s: %s" r.member_name
         (match r.result with Ok _ -> "OK" | Error e -> "Error: " ^ e)
     ) |> String.concat "\n" in
-    let _ = Agent_swarm_client.broadcast ~sw leader
-      ~message:(Printf.sprintf "Fleet done:\n%s" summary) in
+    (match Agent_swarm_client.broadcast ~sw leader
+      ~message:(Printf.sprintf "Fleet done:\n%s" summary) with
+     | Ok _ -> () | Error msg -> Printf.eprintf "[WARN] [swarm] broadcast failed: %s\n%!" msg);
     results_list
   )
 
@@ -139,11 +141,10 @@ let run_full ~sw ~net ~clock ~proc_mgr ~masc_url ~provider
         | Error msg -> Printf.eprintf "[WARN] [swarm] coordinator leave failed: %s\n%!" msg
       with exn -> Printf.eprintf "[WARN] [swarm] coordinator leave error: %s\n%!" (Printexc.to_string exn)))
     (fun () ->
-      let _ =
-        Agent_swarm_client.broadcast ~sw coordinator
+      (match Agent_swarm_client.broadcast ~sw coordinator
           ~message:
-            (Printf.sprintf "Fleet run_full: %s (members: %d)" goal num_members)
-      in
+            (Printf.sprintf "Fleet run_full: %s (members: %d)" goal num_members) with
+       | Ok _ -> () | Error msg -> Printf.eprintf "[WARN] [swarm] broadcast failed: %s\n%!" msg);
       let workdir = match workdir with Some path -> path | None -> Sys.getcwd () in
       let plan =
         build_run_full_plan ~provider ~goal ~num_members ~workdir ~max_turns

--- a/lib/agent_swarm_fleet.ml
+++ b/lib/agent_swarm_fleet.ml
@@ -92,9 +92,12 @@ let run ~sw ~net ~clock ~proc_mgr config ~goal =
     ~agent_name:config.leader_name ~net in
   let _joined = Agent_swarm_client.join ~sw leader in
   Fun.protect ~finally:(fun () ->
-    (try ignore (Agent_swarm_client.leave ~sw leader) with
+    (try match Agent_swarm_client.leave ~sw leader with
+      | Ok _ -> ()
+      | Error msg -> Printf.eprintf "[WARN] [swarm] leader leave failed: %s\n%!" msg
+    with
      | Eio.Cancel.Cancelled _ as ex -> raise ex
-     | _ -> ())
+     | exn -> Printf.eprintf "[WARN] [swarm] leader leave error: %s\n%!" (Printexc.to_string exn))
   ) (fun () ->
     let names = List.map (fun (m, _) -> member_name m) config.members in
     let _ = Agent_swarm_client.broadcast ~sw leader
@@ -131,7 +134,10 @@ let run_full ~sw ~net ~clock ~proc_mgr ~masc_url ~provider
   let _joined = Agent_swarm_client.join ~sw coordinator in
   Fun.protect
     ~finally:(fun () ->
-      try ignore (Agent_swarm_client.leave ~sw coordinator) with exn -> ignore exn)
+      (try match Agent_swarm_client.leave ~sw coordinator with
+        | Ok _ -> ()
+        | Error msg -> Printf.eprintf "[WARN] [swarm] coordinator leave failed: %s\n%!" msg
+      with exn -> Printf.eprintf "[WARN] [swarm] coordinator leave error: %s\n%!" (Printexc.to_string exn)))
     (fun () ->
       let _ =
         Agent_swarm_client.broadcast ~sw coordinator

--- a/lib/auto_recall.ml
+++ b/lib/auto_recall.ml
@@ -134,8 +134,7 @@ let fetch_from_broadcasts (room_config : Room_utils.config) ~(config : recall_co
   ) messages
 
 (** Fetch recently modified files from working directory *)
-let fetch_from_file_context (room_config : Room_utils.config) ~(config : recall_config) ~query =
-  let _ = config in  (* suppress unused warning *)
+let fetch_from_file_context (room_config : Room_utils.config) ~config:(_config : recall_config) ~query =
   let masc_dir = Room_utils.masc_dir room_config in
   let work_dir = Filename.dirname masc_dir in (* Parent of .masc *)
   

--- a/lib/backend.ml
+++ b/lib/backend.ml
@@ -1022,10 +1022,14 @@ end = struct
   let acquire_lock t ~key ~ttl_seconds ~owner =
     let nkey = namespaced_key t.namespace ("lock:" ^ key) in
     (* Clean up expired locks first *)
-    let _ = Caqti_eio.Pool.use (fun conn ->
+    (match Caqti_eio.Pool.use (fun conn ->
       let module C = (val conn : Caqti_eio.CONNECTION) in
       C.exec cleanup_expired_q ()
-    ) t.pool in
+    ) t.pool with
+    | Ok () -> ()
+    | Error err ->
+      Printf.eprintf "[WARN] [backend] expired lock cleanup failed: %s\n%!"
+        (Caqti_error.show err));
     (* Try to acquire lock *)
     match Caqti_eio.Pool.use (fun conn ->
       let module C = (val conn : Caqti_eio.CONNECTION) in

--- a/lib/chain_executor_eio.ml
+++ b/lib/chain_executor_eio.ml
@@ -1853,7 +1853,6 @@ and execute_fanout ctx ~sw ~clock ~exec_fn ~tool_exec (parent : node) (nodes : n
 and execute_quorum ctx ~sw ~clock ~exec_fn ~tool_exec (parent : node) ~consensus ~weights (nodes : node list) : (string, string) result =
   record_start ctx parent.id;
   let start = Time_compat.now () in
-  let _ = (sw, clock, exec_fn, tool_exec) in  (* suppress unused warnings *)
 
   (* Collect results from already-executed nodes or ChainRef lookups *)
   let successes = ref [] in

--- a/lib/debate.ml
+++ b/lib/debate.ml
@@ -146,9 +146,10 @@ let write_json path json =
   let oc = open_out tmp_path in
   let closed = ref false in
   Common.protect ~module_name:"debate" ~finally_label:"finalizer" ~finally:(fun () ->
-    if not !closed then (try close_out oc with exn -> ignore (Printexc.to_string exn));
+    if not !closed then (try close_out oc with exn ->
+      Printf.eprintf "[WARN] [debate] close_out failed: %s\n%!" (Printexc.to_string exn));
     if Sys.file_exists tmp_path then
-      try Sys.remove tmp_path with exn -> ignore (Printexc.to_string exn)
+      Safe_ops.remove_file_logged ~context:"debate" tmp_path
   ) (fun () ->
     output_string oc content;
     flush oc;

--- a/lib/http_server_eio.ml
+++ b/lib/http_server_eio.ml
@@ -269,7 +269,8 @@ module Request = struct
     let stop () =
       if not !stopped then begin
         stopped := true;
-        (try Httpun.Body.Reader.close body with exn -> ignore exn)
+        (try Httpun.Body.Reader.close body with exn ->
+          Printf.eprintf "[WARN] [http] body close failed: %s\n%!" (Printexc.to_string exn))
       end
     in
     (match content_length with

--- a/lib/http_server_h2.ml
+++ b/lib/http_server_h2.ml
@@ -283,7 +283,8 @@ let run ~sw ~net ~clock config request_handler =
         Eio.Fiber.fork ~sw (fun () ->
           Eio.Switch.run (fun conn_sw ->
             Eio.Switch.on_release conn_sw (fun () ->
-              try Eio.Flow.close flow with exn -> ignore exn
+              try Eio.Flow.close flow with exn ->
+                Printf.eprintf "[WARN] [h2] flow close failed: %s\n%!" (Printexc.to_string exn)
             );
             try
               H2_eio.Server.create_connection_handler

--- a/lib/llm_client.ml
+++ b/lib/llm_client.ml
@@ -657,9 +657,9 @@ let parse_openai_response (json_str : string) : (completion_response, string) re
     (* Parse usage *)
     let usage_json = json |> member "usage" in
     let usage = {
-      input_tokens = (try usage_json |> member "prompt_tokens" |> to_int with exn -> Printf.eprintf "[llm] token count parse failed (prompt_tokens): %s\n%!" (Printexc.to_string exn); 0);
-      output_tokens = (try usage_json |> member "completion_tokens" |> to_int with exn -> Printf.eprintf "[llm] token count parse failed (completion_tokens): %s\n%!" (Printexc.to_string exn); 0);
-      total_tokens = (try usage_json |> member "total_tokens" |> to_int with exn -> Printf.eprintf "[llm] token count parse failed (total_tokens): %s\n%!" (Printexc.to_string exn); 0);
+      input_tokens = Safe_ops.json_int "prompt_tokens" usage_json;
+      output_tokens = Safe_ops.json_int "completion_tokens" usage_json;
+      total_tokens = Safe_ops.json_int "total_tokens" usage_json;
       cache_creation_input_tokens = 0;
       cache_read_input_tokens = 0;
     } in
@@ -700,10 +700,10 @@ let parse_claude_response (json_str : string) : (completion_response, string) re
     ) content_blocks in
     (* Parse usage *)
     let usage_json = json |> member "usage" in
-    let input_tokens = try usage_json |> member "input_tokens" |> to_int with exn -> Printf.eprintf "[llm] token count parse failed (input_tokens): %s\n%!" (Printexc.to_string exn); 0 in
-    let output_tokens = try usage_json |> member "output_tokens" |> to_int with exn -> Printf.eprintf "[llm] token count parse failed (output_tokens): %s\n%!" (Printexc.to_string exn); 0 in
-    let cache_creation = try usage_json |> member "cache_creation_input_tokens" |> to_int with exn -> Printf.eprintf "[llm] token count parse failed (cache_creation_input_tokens): %s\n%!" (Printexc.to_string exn); 0 in
-    let cache_read = try usage_json |> member "cache_read_input_tokens" |> to_int with exn -> Printf.eprintf "[llm] token count parse failed (cache_read_input_tokens): %s\n%!" (Printexc.to_string exn); 0 in
+    let input_tokens = Safe_ops.json_int "input_tokens" usage_json in
+    let output_tokens = Safe_ops.json_int "output_tokens" usage_json in
+    let cache_creation = Safe_ops.json_int "cache_creation_input_tokens" usage_json in
+    let cache_read = Safe_ops.json_int "cache_read_input_tokens" usage_json in
     let usage = {
       input_tokens;
       output_tokens;
@@ -723,8 +723,8 @@ let parse_ollama_generate_response (json_str : string) : (completion_response, s
     let json = Yojson.Safe.from_string json_str in
     let open Yojson.Safe.Util in
     let content = json |> member "response" |> to_string in
-    let eval_count = try json |> member "eval_count" |> to_int with exn -> Printf.eprintf "[llm] token count parse failed (eval_count): %s\n%!" (Printexc.to_string exn); 0 in
-    let prompt_eval_count = try json |> member "prompt_eval_count" |> to_int with exn -> Printf.eprintf "[llm] token count parse failed (prompt_eval_count): %s\n%!" (Printexc.to_string exn); 0 in
+    let eval_count = Safe_ops.json_int "eval_count" json in
+    let prompt_eval_count = Safe_ops.json_int "prompt_eval_count" json in
     let model_used = json |> member "model" |> to_string_option
                      |> Option.value ~default:"unknown" in
     let usage = {
@@ -748,8 +748,8 @@ let parse_ollama_chat_response (json_str : string) : (completion_response, strin
     let msg = json |> member "message" in
     let content = msg |> member "content" |> to_string_option
                   |> Option.value ~default:"" in
-    let eval_count = try json |> member "eval_count" |> to_int with exn -> Printf.eprintf "[llm] token count parse failed (eval_count): %s\n%!" (Printexc.to_string exn); 0 in
-    let prompt_eval_count = try json |> member "prompt_eval_count" |> to_int with exn -> Printf.eprintf "[llm] token count parse failed (prompt_eval_count): %s\n%!" (Printexc.to_string exn); 0 in
+    let eval_count = Safe_ops.json_int "eval_count" json in
+    let prompt_eval_count = Safe_ops.json_int "prompt_eval_count" json in
     let model_used = json |> member "model" |> to_string_option
                      |> Option.value ~default:"unknown" in
     let usage = {

--- a/lib/local_agent_eio.ml
+++ b/lib/local_agent_eio.ml
@@ -362,12 +362,10 @@ let local_worker_extra_schemas : Types.tool_schema list =
     };
   ]
 
-let list_masc_tools ~sw ~(auth_token : string option) ~session_id
+let list_masc_tools ~sw:_sw ~(auth_token : string option) ~session_id
     ?(names : string list option = None) () :
     (Types.tool_schema list, string) result =
-  let _ = sw in
-  let _ = auth_token in
-  let _ = session_id in
+  ignore (_sw, auth_token, session_id);
   let all_schemas = local_worker_extra_schemas in
   match names with
   | None -> Ok all_schemas

--- a/lib/lodge_heartbeat.ml
+++ b/lib/lodge_heartbeat.ml
@@ -1250,10 +1250,10 @@ let load_lodge_agents_full () =
                  let name = member "name" node |> to_string in
                  let emoji = (match member "emoji" node with `String s -> s | _ -> "🤖") in
                  let korean_name = (match member "koreanName" node with `String s -> Some s | _ -> None) in
-                 let traits = (try member "traits" node |> to_list |> List.map to_string with exn -> Printf.eprintf "[heartbeat] traits parse: %s\n%!" (Printexc.to_string exn); []) in
-                 let interests = (try member "interests" node |> to_list |> List.map to_string with exn -> Printf.eprintf "[heartbeat] interests parse: %s\n%!" (Printexc.to_string exn); []) in
-                 let activity_level = (match member "activityLevel" node with `Float f -> f | `Int i -> float_of_int i | _ -> 0.5) in
-                 let preferred_hours = (try member "preferredHours" node |> to_list |> List.map to_int with exn -> Printf.eprintf "[heartbeat] preferred_hours parse: %s\n%!" (Printexc.to_string exn); []) in
+                 let traits = Safe_ops.json_string_list "traits" node in
+                 let interests = Safe_ops.json_string_list "interests" node in
+                 let activity_level = Safe_ops.json_float ~default:0.5 "activityLevel" node in
+                 let preferred_hours = (try member "preferredHours" node |> to_list |> List.map to_int with Type_error _ -> []) in
                  let peak_hour = (match member "peakHour" node with `Int i -> Some i | _ -> None) in
                  let model =
                    (match member "model" node with

--- a/lib/neo4j_client_eio.ml
+++ b/lib/neo4j_client_eio.ml
@@ -54,7 +54,8 @@ let get_neo4j_password () =
 let close_connection () =
   match global_state.conn with
   | Some (Box conn) ->
-      (try Bolt.close conn with exn -> let _ = exn in ());
+      (try Bolt.close conn with exn ->
+        Printf.eprintf "[WARN] [neo4j] close failed: %s\n%!" (Printexc.to_string exn));
       global_state.conn <- None
   | None -> ()
 

--- a/lib/room_walph_eio.ml
+++ b/lib/room_walph_eio.ml
@@ -301,7 +301,7 @@ let default_llm_dispatch ~tool_name:_ ~model:_ ~prompt ~timeout_sec ~max_chars (
     @param max_iterations Maximum iterations before forced stop
     @param target Target file/directory for preset
     @return Status string with loop results *)
-let walph_loop config ~net ~clock ~agent_name
+let walph_loop config ~net:_net ~clock ~agent_name
     ?(preset="drain") ?(max_iterations=10) ?target
     ?(max_consecutive_errors=5) ?(error_backoff_sec=2)
     ?(llm_dispatch=default_llm_dispatch) () =
@@ -496,7 +496,6 @@ let walph_loop config ~net ~clock ~agent_name
 	                        let _ = Room.broadcast config ~from_agent:agent_name
 	                          ~content:(Printf.sprintf "🔗 @walph executing '%s' for '%s'..." cid task_title) in
 	                        (* Direct LLM call — no llm-mcp dependency *)
-	                        ignore (net, clock);  (* Previously used for llm-mcp HTTP call *)
 	                        try
 	                          let response = llm_dispatch
 	                            ~tool_name:"glm"


### PR DESCRIPTION
## Summary

- **llm_client.ml / lodge_heartbeat.ml**: 14곳의 반복 `try...with exn -> Printf.eprintf...; 0` 패턴을 `Safe_ops.json_int` / `Safe_ops.json_float` / `Safe_ops.json_string_list`로 교체
- **backend.ml**: expired lock cleanup의 `let _ = Caqti_eio.Pool.use ...` → Result match + WARN 로그
- **6개 파일 shutdown 경로**: `ignore exn` / `let _ = exn in ()` → `Printf.eprintf "[WARN]"` 로그 (neo4j, http, h2, debate, swarm)
- **4개 파일 dead parameter**: `let _ = x in` → OCaml `_` prefix 관용구로 정리
- **broadcast 결과**: `let _ = broadcast ...` → `match Ok/Error` + WARN 로그 (external_agent, fleet)

## Motivation

Silent error swallowing은 디버깅을 불가능하게 만든다. 에러가 발생해도 stderr에 아무것도 나타나지 않으면 문제 추적이 어렵다. 기존 `Safe_ops` 유틸리티를 재활용해 코드 중복도 줄였다.

## Changes (5 commits)

| Commit | Scope | Files |
|--------|-------|-------|
| `refactor(llm)` | band-aid 토큰 파싱 → Safe_ops | llm_client.ml, lodge_heartbeat.ml |
| `fix(backend)` | expired lock cleanup 결과 처리 | backend.ml |
| `refactor(cleanup)` | shutdown 경로 에러 로깅 | neo4j_client_eio.ml, http_server_eio.ml, http_server_h2.ml, debate.ml, agent_swarm_external_agent.ml, agent_swarm_fleet.ml |
| `refactor(params)` | dead parameter suppression | auto_recall.ml, chain_executor_eio.ml, room_walph_eio.ml, local_agent_eio.ml |
| `refactor(broadcast)` | broadcast 결과 match | agent_swarm_external_agent.ml, agent_swarm_fleet.ml |

## Stats

13 files changed, 62 insertions(+), 47 deletions(-)

## Test plan

- [x] `dune build` — 매 커밋 후 빌드 검증
- [x] `make test` — 전체 테스트 스위트 실행
- [x] `grep -rn 'with exn -> ignore exn\|let _ = exn in' lib/*.ml` → 0건 확인
- [x] `grep -rn 'Printf.eprintf.*token count parse failed' lib/llm_client.ml` → 0건 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)