### PR TITLE
fix: prefer repo dashboard assets over cwd assets

### DIFF
--- a/bin/main_eio.ml
+++ b/bin/main_eio.ml
@@ -7219,9 +7219,9 @@ let assets_root () =
   in
   match env_assets with
   | Some path when is_dir path -> path
+  | _ when is_dir exe_assets -> exe_assets
   | _ when is_dir (Filename.concat (Sys.getcwd ()) "assets") ->
       Filename.concat (Sys.getcwd ()) "assets"
-  | _ when is_dir exe_assets -> exe_assets
   | _ -> Filename.concat (Sys.getcwd ()) "assets"
 
 (** Local GraphiQL assets *)

--- a/lib/web_dashboard.ml
+++ b/lib/web_dashboard.ml
@@ -20,11 +20,12 @@ let assets_root () =
   match env_assets with
   | Some d -> d
   | None ->
+      let exe_dir = Filename.dirname Sys.executable_name in
+      let exe_assets = Filename.concat exe_dir "assets" in
       let cwd_assets = Filename.concat (Sys.getcwd ()) "assets" in
-      if Sys.file_exists cwd_assets then cwd_assets
-      else
-        let exe_dir = Filename.dirname Sys.executable_name in
-        Filename.concat exe_dir "assets"
+      if Sys.file_exists exe_assets then exe_assets
+      else if Sys.file_exists cwd_assets then cwd_assets
+      else exe_assets
 
 let index_path () =
   Filename.concat (Filename.concat (assets_root ()) "dashboard") "index.html"


### PR DESCRIPTION
## Summary
- prefer repo-local `assets/` resolved from the executable before `cwd/assets`
- fix false "Dashboard build not found" responses when the process is started from a directory that has an unrelated `assets/` folder
- keep explicit `MASC_ASSETS_ROOT` / `MASC_ASSETS_DIR` overrides intact

## Validation
- `dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix-dashboard-assets-root bin/main_eio.exe test/test_web_dashboard_coverage.exe`
- launched `/Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix-dashboard-assets-root/_build/default/bin/main_eio.exe --port=8946 --base-path=/Users/dancer/me`
- verified `http://127.0.0.1:8946/dashboard` returns the built SPA instead of the fallback error page
