### PR TITLE
fix(agent-sdk): align with latest pinned SDK

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -35,7 +35,7 @@
   (cmdliner (>= 1.1))
   (cohttp (>= 5.0))
   (cohttp-eio (and (>= 6.0) (< 6.2)))
-  (agent_sdk (>= 0.2.0))
+  (agent_sdk (>= 0.5.0))
   (uri (>= 4.4))
   (tls (>= 0.16))
   (tls-eio (>= 0.16))

--- a/lib/agent_swarm_runner.ml
+++ b/lib/agent_swarm_runner.ml
@@ -78,6 +78,7 @@ let run_solo ~sw ~net ~clock ~proc_mgr config =
   let base_url = match provider_cfg.provider with
     | Provider.Local { base_url } -> base_url
     | Provider.Anthropic -> Api.default_base_url
+    | Provider.Ollama { base_url; _ } -> base_url
     | Provider.OpenAICompat { base_url; _ } -> base_url in
   let dev_tools =
     Agent_swarm_dev_tools.make_tools ~proc_mgr ~clock ~workdir:config.workdir ()

--- a/masc_mcp.opam
+++ b/masc_mcp.opam
@@ -23,7 +23,7 @@ depends: [
   "cmdliner" {>= "1.1"}
   "cohttp" {>= "5.0"}
   "cohttp-eio" {>= "6.0" & < "6.2"}
-  "agent_sdk" {>= "0.2.0"}
+  "agent_sdk" {>= "0.5.0"}
   "uri" {>= "4.4"}
   "tls" {>= "0.16"}
   "tls-eio" {>= "0.16"}

--- a/scripts/opam-pin-external-deps.sh
+++ b/scripts/opam-pin-external-deps.sh
@@ -24,7 +24,7 @@ if $include_compact_protocol; then
 fi
 
 opam pin add mcp_protocol https://github.com/jeong-sik/mcp-protocol-sdk.git#main -n -y
-opam pin add agent_sdk https://github.com/jeong-sik/oas.git#main -n -y
+opam pin add agent_sdk https://github.com/jeong-sik/oas.git#fcf418d6be4b34e23bf76da0c99b798ef7843a41 -n -y
 opam pin add ocaml-webrtc https://github.com/jeong-sik/ocaml-webrtc.git#main -n -y
 opam pin add grpc-direct-core https://github.com/jeong-sik/grpc-direct.git#main -n -y
 opam pin add grpc-direct https://github.com/jeong-sik/grpc-direct.git#main -n -y


### PR DESCRIPTION
## Summary
- align `agent_swarm_runner` with the latest `agent_sdk` provider variants
- pin CI `agent_sdk` installs to the latest known-good `oas` main commit
- raise the declared `agent_sdk` lower bound to `0.5.0`

## Why
- open PR branches broke because CI resolved a newer `agent_sdk` than stale local worktrees had installed
- the moving `#main` pin made builds nondeterministic across time
- `masc-mcp` now explicitly tracks the latest remote `oas/main` commit used for CI

## Verification
- [x] `bash -n scripts/opam-pin-external-deps.sh`
- [x] `dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix-agent-sdk-latest @all`

## Notes
- latest pinned `agent_sdk` commit: `fcf418d6be4b34e23bf76da0c99b798ef7843a41`
