### PR TITLE
fix(test): align CI-failing tests with actual code

### DIFF
--- a/test/test_perpetual.ml
+++ b/test/test_perpetual.ml
@@ -193,11 +193,23 @@ let test_llm_client () = group "LLM Client" (fun () ->
     (Llm_client.openai_default.provider = Llm_client.OpenAI);
   assert_true "builtin:llama_default_provider"
     (Llm_client.llama_default.provider = Llm_client.Llama);
+  (* Set env vars so default_local_model_spec returns Ollama regardless of CI env *)
+  let prev_provider = Sys.getenv_opt "MASC_DEFAULT_PROVIDER" in
+  let prev_model = Sys.getenv_opt "MASC_DEFAULT_MODEL" in
+  Unix.putenv "MASC_DEFAULT_PROVIDER" "ollama";
+  Unix.putenv "MASC_DEFAULT_MODEL" "default-model";
   let default_local = Llm_client.default_local_model_spec () in
   assert_true "builtin:default_local_provider"
     (default_local.provider = Llm_client.Ollama);
   assert_equal "builtin:default_local_model_id"
     "default-model" default_local.model_id;
+  (* Restore env vars *)
+  (match prev_provider with
+   | Some v -> Unix.putenv "MASC_DEFAULT_PROVIDER" v
+   | None -> (try Unix.putenv "MASC_DEFAULT_PROVIDER" "" with _ -> ()));
+  (match prev_model with
+   | Some v -> Unix.putenv "MASC_DEFAULT_MODEL" v
+   | None -> (try Unix.putenv "MASC_DEFAULT_MODEL" "" with _ -> ()));
 )
 
 (* ================================================================ *)

--- a/test/test_silent_failures_p2a.ml
+++ b/test/test_silent_failures_p2a.ml
@@ -145,7 +145,7 @@ let test_source_metrics_fd_unlock () =
 let test_source_llm_token_parse () =
   check bool "llm_client.ml has token count parse logging"
     true (file_contains_pattern "lib/llm_client.ml"
-      {|[llm] token count parse failed|})
+      {|[llm] token field missing or wrong type|})
 
 let test_source_keeper_proactive () =
   check bool "tool_keeper.ml has proactive emission logging"


### PR DESCRIPTION
## Summary
- MA-H3 contract pattern이 PR #707의 `json_int_opt` 변경으로 인한 로그 메시지 변경을 반영하지 못해 실패
- `test_perpetual.ml`의 `default_local_model_spec()` 테스트가 CI 환경(환경변수 미설정)에서 `glm_cloud` fallback으로 인해 실패

## Changes
- `test_silent_failures_p2a.ml`: `[llm] token count parse failed` → `[llm] token field missing or wrong type:` 패턴 업데이트
- `test_perpetual.ml`: `MASC_DEFAULT_PROVIDER=ollama`, `MASC_DEFAULT_MODEL=default-model`을 테스트 내에서 설정하여 CI 환경 독립적으로 동작

## Test plan
- [x] `test_silent_failures_p2a.exe` 로컬 전체 통과 (MA-H3, MA-M4a/b/c 포함)
- [x] `test_perpetual.exe` 로컬 144/144 통과
- [ ] CI Build and Test 통과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)