### PR TITLE
fix(runner): add ollama and openrouter to resolve_provider

### DIFF
--- a/lib/agent_swarm_runner.ml
+++ b/lib/agent_swarm_runner.ml
@@ -37,6 +37,8 @@ let resolve_provider name =
   | "sonnet" -> Some (Provider.anthropic_sonnet ())
   | "haiku" -> Some (Provider.anthropic_haiku ())
   | "opus" -> Some (Provider.anthropic_opus ())
+  | "ollama" -> Some (Provider.ollama ())
+  | "openrouter" -> Some (Provider.openrouter ())
   | _ -> None
 
 let parse_args argv =

--- a/test/test_agent_swarm_runner.ml
+++ b/test/test_agent_swarm_runner.ml
@@ -90,7 +90,7 @@ let test_parse_members_zero () =
     (Error "Invalid --members: 0") (parse_args argv)
 
 let test_provider_resolve () =
-  let known = ["local-qwen"; "local-mlx"; "sonnet"; "haiku"; "opus"] in
+  let known = ["local-qwen"; "local-mlx"; "sonnet"; "haiku"; "opus"; "ollama"; "openrouter"] in
   List.iter (fun name ->
     let result = resolve_provider name in
     Alcotest.(check bool) (Printf.sprintf "%s resolves" name)


### PR DESCRIPTION
## Summary
- `resolve_provider`에 `"ollama"` 및 `"openrouter"` case 추가
- 이전: wildcard `_` fallback으로 `Provider.local_qwen()` 사용 → `run_solo`의 `Provider.Ollama` arm이 dead code
- 이후: `--provider ollama` CLI 인자가 올바른 `Provider.Ollama` config를 반환

## Changed files
| File | Change |
|------|--------|
| `lib/agent_swarm_runner.ml` | `resolve_provider`에 ollama, openrouter case 추가 |
| `test/test_agent_swarm_runner.ml` | known providers 리스트에 ollama, openrouter 추가 |

## Test plan
- [x] `test_agent_swarm_runner.exe` 9/9 통과
- [ ] CI Build and Test
- [ ] CI Contract Harness

🤖 Generated with [Claude Code](https://claude.com/claude-code)