### PR TITLE
fix(team-session): tighten planning and swarm contracts

### DIFF
--- a/lib/operator_control.ml
+++ b/lib/operator_control.ml
@@ -2365,6 +2365,13 @@ let dispatch_team_session_json_as (ctx : 'a context) ~session_id ~requested_acto
         else
           Ok session.created_by
   in
+  let args =
+    match args with
+    | `Assoc fields ->
+        `Assoc
+          (("actor", `String authorized_actor) :: List.remove_assoc "actor" fields)
+    | other -> other
+  in
   let team_ctx : _ Tool_team_session.context =
     {
       config = ctx.config;

--- a/lib/tool_command_plane.ml
+++ b/lib/tool_command_plane.ml
@@ -1433,6 +1433,44 @@ let handle_observe_traces (ctx : (_, _) context) args : result =
     Yojson.Safe.to_string
       (Command_plane_v2.list_traces_json ctx.config ?operation_id ~limit ()))
 
+let swarm_live_run_id_of_args args =
+  match get_string_opt args "run_id" with
+  | Some value -> value
+  | None -> "swarm-live"
+
+let swarm_live_worker_count_of_args args =
+  match Yojson.Safe.Util.member "worker_count" args with
+  | `Int value when value > 0 && value <= 100 -> value
+  | `Int _ -> Agent_swarm_live_harness.default_config.worker_count
+  | _ -> Agent_swarm_live_harness.default_config.worker_count
+
+let persist_swarm_live_summary config ~run_id result_json =
+  let run_dir =
+    Filename.concat
+      (Filename.concat (Cp_paths.control_plane_root_dir config) "swarm-live")
+      (Agent_swarm_live_harness.safe_run_id run_id)
+  in
+  Room_utils.mkdir_p run_dir;
+  Room_utils.write_json_local
+    (Filename.concat run_dir "swarm-live-summary.json")
+    result_json
+
+let handle_swarm_live_run_with_runner config args ~runner : result =
+  let run_id = swarm_live_run_id_of_args args in
+  let worker_count = swarm_live_worker_count_of_args args in
+  let cfg =
+    { Agent_swarm_live_harness.default_config with run_id; worker_count }
+  in
+  try
+    let result_json = runner cfg in
+    persist_swarm_live_summary config ~run_id result_json;
+    (true, Yojson.Safe.to_string result_json)
+  with exn ->
+    ( false,
+      json_error
+        (Printf.sprintf "swarm-live harness failed: %s"
+           (Printexc.to_string exn)) )
+
 let handle_swarm_live_run (ctx : (_, _) context) args : result =
   let run_id =
     match get_string_opt args "run_id" with

--- a/lib/tool_goals.ml
+++ b/lib/tool_goals.ml
@@ -134,7 +134,7 @@ let schemas : tool_schema list =
     {
       name = "masc_goal_dispatch";
       description =
-        "Build or execute hierarchical dispatch plan (child/grandchild). Uses approval gate when enabled.";
+        "Build or execute hierarchical dispatch plan (child/grandchild). Task runtime creates backlog tasks only; callers must still claim one and call masc_plan_set_task. Uses approval gate when enabled.";
       input_schema =
         `Assoc
           [
@@ -322,6 +322,12 @@ let handle_goal_refresh ctx args =
 let filter_goal_ids goals ids =
   if ids = [] then goals
   else List.filter (fun g -> List.mem g.Goal_store.id ids) goals
+
+let unknown_goal_ids goals ids =
+  if ids = [] then []
+  else
+    let known_ids = List.map (fun g -> g.Goal_store.id) goals in
+    List.filter (fun goal_id -> not (List.mem goal_id known_ids)) ids
 
 type keeper_call_outcome = {
   node_id : string;
@@ -537,13 +543,17 @@ let handle_goal_dispatch ctx args =
   in
   let fallback_to_task = get_bool args "fallback_to_task" true in
   let keeper_prefix = get_string args "keeper_prefix" "goal" in
-  let goals =
-    Goal_store.active_goals ctx.config
-    |> fun goals -> filter_goal_ids goals goal_ids
-  in
+  let active_goals = Goal_store.active_goals ctx.config in
+  let missing_goal_ids = unknown_goal_ids active_goals goal_ids in
   match runtime_opt with
   | None -> (false, error_result_json "runtime must be task|keeper")
+  | Some _ when missing_goal_ids <> [] ->
+      ( false,
+        error_result_json
+          (Printf.sprintf "unknown goal_ids: %s"
+             (String.concat ", " missing_goal_ids)) )
   | Some runtime ->
+  let goals = filter_goal_ids active_goals goal_ids in
   let plan =
     Goal_orchestrator.build_plan ~goals
       {
@@ -585,6 +595,10 @@ let handle_goal_dispatch ctx args =
         [
           ("runtime", `String runtime);
           ("approval_required", `Bool false);
+          ("current_task_bound", `Bool false);
+          ( "message",
+            `String
+              "dispatch created backlog tasks only; claim one and call masc_plan_set_task to bind current_task" );
           ("plan", Goal_orchestrator.dispatch_plan_to_yojson plan);
           ("execution", Goal_orchestrator.execution_summary_to_yojson summary);
         ] )

--- a/lib/tool_team_session.ml
+++ b/lib/tool_team_session.ml
@@ -1388,11 +1388,19 @@ let handle_step ctx args : result =
               match turn_kind_result with
               | Error e -> (false, json_error e)
               | Ok turn_kind_opt ->
-              let actor =
+              let actor_result =
                 match get_string_opt args "actor" with
-                | Some a -> a
-                | None -> ctx.agent_name
+                | None -> Ok ctx.agent_name
+                | Some actor_name
+                  when String.equal (String.trim actor_name) ctx.agent_name ->
+                    Ok ctx.agent_name
+                | Some _ ->
+                    Error
+                      "actor must match the authenticated caller; omit actor to use the current agent"
               in
+              match actor_result with
+              | Error e -> (false, json_error e)
+              | Ok actor ->
               let base_message = get_string_opt args "message" in
               let target_agent = get_string_opt args "target_agent" in
               let task_title = get_string_opt args "task_title" in
@@ -2492,7 +2500,14 @@ let schemas : tool_schema list =
                               `String "checkpoint";
                             ] );
                       ] );
-                  ("actor", `Assoc [ ("type", `String "string") ]);
+                  ( "actor",
+                    `Assoc
+                      [
+                        ("type", `String "string");
+                        ( "description",
+                          `String
+                            "Optional explicit actor. If provided, it must match the authenticated caller." );
+                      ] );
                   ("message", `Assoc [ ("type", `String "string") ]);
                   ("target_agent", `Assoc [ ("type", `String "string") ]);
                   ("task_title", `Assoc [ ("type", `String "string") ]);

--- a/test/test_command_plane_v2.ml
+++ b/test/test_command_plane_v2.ml
@@ -1726,6 +1726,92 @@ let test_invalid_search_strategy_is_rejected () =
           Alcotest.(check string) "validation error"
             "unsupported search_strategy: made_up_strategy" message)
 
+let test_swarm_live_run_with_runner_persists_summary () =
+  let base_dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base_dir)
+    (fun () ->
+      let config = Room.default_config base_dir in
+      let ok, body =
+        Tool_command_plane.handle_swarm_live_run_with_runner config
+          (`Assoc
+            [
+              ("run_id", `String "swarm-live-wrapper");
+              ("worker_count", `Int 3);
+            ])
+          ~runner:(fun cfg ->
+            `Assoc
+              [
+                ("run_id", `String cfg.Agent_swarm_live_harness.run_id);
+                ("worker_count", `Int cfg.worker_count);
+              ])
+      in
+      Alcotest.(check bool) "wrapper success" true ok;
+      let json = Yojson.Safe.from_string body in
+      Alcotest.(check string) "run_id preserved" "swarm-live-wrapper"
+        Yojson.Safe.Util.(json |> member "run_id" |> to_string);
+      Alcotest.(check int) "worker_count preserved" 3
+        Yojson.Safe.Util.(json |> member "worker_count" |> to_int);
+      let summary_path =
+        Filename.concat
+          (Filename.concat
+             (Filename.concat base_dir ".masc/control-plane/swarm-live")
+             (Agent_swarm_live_harness.safe_run_id "swarm-live-wrapper"))
+          "swarm-live-summary.json"
+      in
+      Alcotest.(check bool) "summary persisted" true (Sys.file_exists summary_path);
+      let persisted = Yojson.Safe.from_file summary_path in
+      Alcotest.(check string) "persisted run_id" "swarm-live-wrapper"
+        Yojson.Safe.Util.(persisted |> member "run_id" |> to_string))
+
+let test_swarm_live_run_with_runner_returns_error_on_exception () =
+  let base_dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base_dir)
+    (fun () ->
+      let config = Room.default_config base_dir in
+      let ok, body =
+        Tool_command_plane.handle_swarm_live_run_with_runner config
+          (`Assoc [ ("run_id", `String "failing-run") ])
+          ~runner:(fun _ -> failwith "runner exploded")
+      in
+      Alcotest.(check bool) "wrapper failure" false ok;
+      let json = Yojson.Safe.from_string body in
+      Alcotest.(check string) "status error" "error"
+        Yojson.Safe.Util.(json |> member "status" |> to_string);
+      Alcotest.(check bool) "error mentions runner" true
+        (String.length Yojson.Safe.Util.(json |> member "message" |> to_string) > 0))
+
+let test_swarm_live_run_rejects_invalid_run_id () =
+  let base_dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base_dir)
+    (fun () ->
+      let config = Room.default_config base_dir in
+      let ctx : _ Tool_command_plane.context =
+        {
+          config;
+          agent_name = "tester";
+          sw = None;
+          clock = None;
+          net = None;
+          mcp_state = None;
+          mcp_session_id = None;
+          auth_token = None;
+        }
+      in
+      let ok, body =
+        Tool_command_plane.handle_swarm_live_run ctx
+          (`Assoc [ ("run_id", `String "bad run id") ])
+      in
+      Alcotest.(check bool) "invalid run id fails" false ok;
+      let json = Yojson.Safe.from_string body in
+      Alcotest.(check string) "status error" "error"
+        Yojson.Safe.Util.(json |> member "status" |> to_string);
+      Alcotest.(check string) "invalid run id message"
+        "invalid chain run_id: only [A-Za-z0-9_-] are allowed"
+        Yojson.Safe.Util.(json |> member "message" |> to_string))
+
 let () =
   Alcotest.run "Command_plane_v2"
     [
@@ -1790,6 +1876,12 @@ let () =
             test_swarm_live_json_reads_custom_worker_count_from_operation_note;
           Alcotest.test_case "swarm live reads runtime doctor and blockers" `Quick
             test_swarm_live_json_reads_runtime_doctor_and_blockers;
+          Alcotest.test_case "swarm live wrapper persists summary" `Quick
+            test_swarm_live_run_with_runner_persists_summary;
+          Alcotest.test_case "swarm live wrapper reports runner exceptions" `Quick
+            test_swarm_live_run_with_runner_returns_error_on_exception;
+          Alcotest.test_case "swarm live wrapper rejects invalid run_id" `Quick
+            test_swarm_live_run_rejects_invalid_run_id;
           Alcotest.test_case "summary json omits heavy arrays" `Quick
             test_summary_json_omits_heavy_arrays_and_keeps_summaries;
           Alcotest.test_case "summary swarm proof prefers artifact" `Quick

--- a/test/test_operator_control.ml
+++ b/test/test_operator_control.ml
@@ -700,7 +700,22 @@ let test_team_worker_spawn_batch_requires_confirm_then_executes () =
            (fun json ->
              Yojson.Safe.Util.(json |> member "event_type" |> to_string)
              = "team_step_spawn")
-           events))
+           events);
+      let spawn_event =
+        match
+          List.find_opt
+            (fun json ->
+              Yojson.Safe.Util.(json |> member "event_type" |> to_string)
+              = "team_step_spawn")
+            events
+        with
+        | Some json -> json
+        | None -> Alcotest.fail "expected team_step_spawn event"
+      in
+      Alcotest.(check string) "spawn actor falls back to owner" "owner"
+        Yojson.Safe.Util.(
+          spawn_event |> member "detail" |> member "actor" |> to_string)
+    )
 
 let test_digest_recommends_worker_spawn_batch_for_planned_worker_without_turn () =
   Eio_main.run @@ fun env ->

--- a/test/test_operator_mcp_e2e.ml
+++ b/test/test_operator_mcp_e2e.ml
@@ -82,7 +82,7 @@ let parse_headers raw =
       (status, headers)
   | Some [] -> (None, [])
 
-let run_curl_json ?token ~port ~path ~session_id ~payload () =
+let run_curl_json ?token ?(max_time_sec = 5) ~port ~path ~session_id ~payload () =
   let header_file = Filename.temp_file "operator-mcp-header-" ".txt" in
   let body_file = Filename.temp_file "operator-mcp-body-" ".txt" in
   let data_file = Filename.temp_file "operator-mcp-request-" ".json" in
@@ -97,7 +97,7 @@ let run_curl_json ?token ~port ~path ~session_id ~payload () =
       "-sS";
       "--http1.1";
       "--max-time";
-      "5";
+      string_of_int max_time_sec;
       "-X";
       "POST";
       "-H";
@@ -474,9 +474,9 @@ let test_operator_mcp_supervises_team_session () =
                          ~implementer_b_token ~supervisor_nickname
                          ~planner_nickname ~implementer_a_nickname
                          ~implementer_b_nickname ->
-  let call_tool ?token ~path ~session_id ~id ~name arguments =
+  let call_tool ?token ?max_time_sec ~path ~session_id ~id ~name arguments =
     let res =
-      run_curl_json ?token ~port ~path ~session_id
+      run_curl_json ?token ?max_time_sec ~port ~path ~session_id
         ~payload:(tool_payload ~id ~name ~arguments) ()
     in
     let json = parse_json_body name res in
@@ -545,10 +545,22 @@ let test_operator_mcp_supervises_team_session () =
     |> U.member "session_id" |> U.to_string
   in
 
-  let worker_turn token session_id_header id message =
+  ignore
+    (call_tool ~token:supervisor_token ~path:"/mcp" ~session_id:"supervisor-root"
+       ~id:6 ~name:"masc_team_session_step"
+       (`Assoc
+         [
+           ("session_id", `String session_id);
+           ("turn_kind", `String "note");
+           ( "message",
+             `String
+               "[supervisor] explicit model selection is recorded before worker execution" );
+         ]));
+
+  let worker_step token session_id_header id message =
     ignore
       (call_tool ~token ~path:"/mcp" ~session_id:session_id_header ~id
-         ~name:"masc_team_session_turn"
+         ~name:"masc_team_session_step"
          (`Assoc
            [
              ("session_id", `String session_id);
@@ -556,16 +568,16 @@ let test_operator_mcp_supervises_team_session () =
              ("message", `String message);
            ]))
   in
-  worker_turn planner_token "planner" 6
+  worker_step planner_token "planner" 7
     "[planner] decomposition is docs + harness + endpoint proof";
-  worker_turn implementer_a_token "implementer-a" 7
+  worker_step implementer_a_token "implementer-a" 8
     "[implementer-a] backend path uses /mcp plus /mcp/operator";
-  worker_turn implementer_b_token "implementer-b" 8
+  worker_step implementer_b_token "implementer-b" 9
     "[implementer-b] docs will explain preview-confirm supervision";
 
   let tools_list_res =
     run_curl_json ~token:supervisor_token ~port ~path:"/mcp/operator"
-      ~session_id:"operator-supervisor" ~payload:(tools_list_payload ~id:9) ()
+      ~session_id:"operator-supervisor" ~payload:(tools_list_payload ~id:10) ()
   in
   let tools_list_json = parse_json_body "operator tools/list" tools_list_res in
   require_jsonrpc_ok "operator tools/list" tools_list_json;
@@ -585,7 +597,7 @@ let test_operator_mcp_supervises_team_session () =
 
   let snapshot_json =
     call_tool ~token:supervisor_token ~path:"/mcp/operator"
-      ~session_id:"operator-supervisor" ~id:10 ~name:"masc_operator_snapshot"
+      ~session_id:"operator-supervisor" ~id:11 ~name:"masc_operator_snapshot"
       (`Assoc [ ("actor", `String supervisor_nickname); ("view", `String "full") ])
   in
   let snapshot_result = extract_tool_payload_json "operator_snapshot" snapshot_json in
@@ -621,7 +633,7 @@ let test_operator_mcp_supervises_team_session () =
 
   let note_json =
     call_tool ~token:supervisor_token ~path:"/mcp/operator"
-      ~session_id:"operator-supervisor" ~id:11 ~name:"masc_operator_action"
+      ~session_id:"operator-supervisor" ~id:12 ~name:"masc_operator_action"
       (`Assoc
         [
           ("actor", `String supervisor_nickname);
@@ -640,7 +652,7 @@ let test_operator_mcp_supervises_team_session () =
 
   let preview_json =
     call_tool ~token:supervisor_token ~path:"/mcp/operator"
-      ~session_id:"operator-supervisor" ~id:12 ~name:"masc_operator_action"
+      ~session_id:"operator-supervisor" ~id:13 ~name:"masc_operator_action"
       (`Assoc
         [
           ("actor", `String supervisor_nickname);
@@ -662,7 +674,7 @@ let test_operator_mcp_supervises_team_session () =
 
   let confirm_json =
     call_tool ~token:supervisor_token ~path:"/mcp/operator"
-      ~session_id:"operator-supervisor" ~id:13 ~name:"masc_operator_confirm"
+      ~session_id:"operator-supervisor" ~id:14 ~name:"masc_operator_confirm"
       (`Assoc
         [
           ("actor", `String supervisor_nickname);
@@ -674,7 +686,7 @@ let test_operator_mcp_supervises_team_session () =
     (confirm_result |> U.member "delegated_tool_result" <> `Null);
 
   let events_json =
-    call_tool ~token:supervisor_token ~path:"/mcp" ~session_id:"supervisor-root" ~id:14
+    call_tool ~token:supervisor_token ~path:"/mcp" ~session_id:"supervisor-root" ~id:15
       ~name:"masc_team_session_events"
       (`Assoc
         [
@@ -691,10 +703,67 @@ let test_operator_mcp_supervises_team_session () =
     (contains_substr "implementer-a" events_text);
   check bool "implementer-b event present" true
     (contains_substr "implementer-b" events_text);
+  check bool "selection note present" true
+    (contains_substr
+       "[supervisor] explicit model selection is recorded before worker execution"
+       events_text);
   check bool "supervisor note present" true
     (contains_substr "[supervisor] keep the session focused on MCP proof" events_text);
   check bool "injected task present" true
-    (contains_substr "Capture supervisor evidence" events_text)
+    (contains_substr "Capture supervisor evidence" events_text);
+
+  let finalize_json =
+    call_tool ~token:supervisor_token ~max_time_sec:35 ~path:"/mcp"
+      ~session_id:"supervisor-root"
+      ~id:16 ~name:"masc_team_session_finalize"
+      (`Assoc
+        [
+          ("session_id", `String session_id);
+          ("reason", `String "operator_e2e_finalize");
+          ("generate_report", `Bool true);
+          ("generate_proof", `Bool true);
+          ("wait_timeout_sec", `Int 25);
+        ])
+  in
+  let finalize_result =
+    extract_tool_result_json "team_session_finalize" finalize_json
+  in
+  check string "finalize terminal status" "interrupted"
+    (finalize_result |> U.member "terminal_status" |> U.to_string);
+  check bool "finalize report present" true
+    (finalize_result |> U.member "report" <> `Null);
+  check bool "finalize proof present" true
+    (finalize_result |> U.member "proof" <> `Null);
+
+  let report_json =
+    call_tool ~token:supervisor_token ~path:"/mcp" ~session_id:"supervisor-root"
+      ~id:17 ~name:"masc_team_session_report"
+      (`Assoc
+        [
+          ("session_id", `String session_id);
+          ("force_regenerate", `Bool false);
+        ])
+  in
+  let report_result = extract_tool_result_json "team_session_report" report_json in
+  check bool "report json path present" true
+    (report_result |> U.member "json_path" <> `Null);
+  check bool "report markdown path present" true
+    (report_result |> U.member "markdown_path" <> `Null);
+
+  let prove_json =
+    call_tool ~token:supervisor_token ~path:"/mcp" ~session_id:"supervisor-root"
+      ~id:18 ~name:"masc_team_session_prove"
+      (`Assoc
+        [
+          ("session_id", `String session_id);
+          ("generate_report_if_missing", `Bool false);
+        ])
+  in
+  let prove_result = extract_tool_result_json "team_session_prove" prove_json in
+  check bool "prove json path present" true
+    (prove_result |> U.member "proof_json_path" <> `Null);
+  check bool "prove markdown path present" true
+    (prove_result |> U.member "proof_md_path" <> `Null)
 
 let () =
   run "operator_mcp_e2e"

--- a/test/test_tool_goals.ml
+++ b/test/test_tool_goals.ml
@@ -199,6 +199,68 @@ let test_goal_dispatch_runtime_validation () =
     (json |> Yojson.Safe.Util.member "status" |> Yojson.Safe.Util.to_string);
   cleanup_dir base_dir
 
+let test_goal_dispatch_task_runtime_requires_manual_current_task_binding () =
+  let base_dir = temp_dir () in
+  let config = Room.default_config base_dir in
+  ignore (Room.init config ~agent_name:(Some "tester"));
+  let ctx : Tool_goals.context =
+    { config; agent_name = "tester"; call_keeper_msg = None }
+  in
+  ignore
+    (upsert_goal_exn ctx
+       (`Assoc
+         [ ("horizon", `String "short"); ("title", `String "Dispatch task hygiene") ]));
+  let ok, body =
+    dispatch_exn ctx ~name:"masc_goal_dispatch"
+      ~args:
+        (`Assoc
+          [
+            ("runtime", `String "task");
+            ("execute", `Bool true);
+            ("approved", `Bool true);
+          ])
+  in
+  Alcotest.(check bool) "task runtime dispatch ok" true ok;
+  let json = parse_json_exn body in
+  Alcotest.(check bool) "current task not bound" false
+    (json |> Yojson.Safe.Util.member "current_task_bound"
+   |> Yojson.Safe.Util.to_bool);
+  Alcotest.(check string) "task hygiene message"
+    "dispatch created backlog tasks only; claim one and call masc_plan_set_task to bind current_task"
+    (json |> Yojson.Safe.Util.member "message" |> Yojson.Safe.Util.to_string);
+  Alcotest.(check (option string)) "planning current_task still unset" None
+    (Planning_eio.get_current_task config);
+  cleanup_dir base_dir
+
+let test_goal_dispatch_unknown_goal_ids_fail () =
+  let base_dir = temp_dir () in
+  let config = Room.default_config base_dir in
+  ignore (Room.init config ~agent_name:(Some "tester"));
+  let ctx : Tool_goals.context =
+    { config; agent_name = "tester"; call_keeper_msg = None }
+  in
+  ignore
+    (upsert_goal_exn ctx
+       (`Assoc [ ("horizon", `String "short"); ("title", `String "Known goal") ]));
+  let ok, body =
+    dispatch_exn ctx ~name:"masc_goal_dispatch"
+      ~args:
+        (`Assoc
+          [
+            ("goal_ids", `List [ `String "goal-missing" ]);
+            ("execute", `Bool true);
+            ("approved", `Bool true);
+          ])
+  in
+  Alcotest.(check bool) "unknown goal ids fail" false ok;
+  let json = parse_json_exn body in
+  Alcotest.(check string) "status error" "error"
+    (json |> Yojson.Safe.Util.member "status" |> Yojson.Safe.Util.to_string);
+  Alcotest.(check string) "unknown goal ids message"
+    "unknown goal_ids: goal-missing"
+    (json |> Yojson.Safe.Util.member "message" |> Yojson.Safe.Util.to_string);
+  cleanup_dir base_dir
+
 let () =
   Alcotest.run "Tool_goals"
     [
@@ -213,5 +275,10 @@ let () =
             test_goal_review_done_and_promote;
           Alcotest.test_case "dispatch runtime validation" `Quick
             test_goal_dispatch_runtime_validation;
+          Alcotest.test_case
+            "dispatch task runtime requires manual current_task binding" `Quick
+            test_goal_dispatch_task_runtime_requires_manual_current_task_binding;
+          Alcotest.test_case "dispatch unknown goal_ids fail" `Quick
+            test_goal_dispatch_unknown_goal_ids_fail;
         ] );
     ]

--- a/test/test_tool_team_session.ml
+++ b/test/test_tool_team_session.ml
@@ -1153,6 +1153,39 @@ let test_missing_required_args () =
   Alcotest.(check bool) "finalize invalid" false ok14;
   cleanup_dir base_dir
 
+let test_step_actor_must_match_caller () =
+  Eio_main.run @@ fun env ->
+  Eio.Switch.run @@ fun sw ->
+  let base_dir = temp_dir () in
+  let config = Room.default_config base_dir in
+  ignore (Room.init config ~agent_name:(Some "owner"));
+  ignore (Room.join config ~agent_name:"owner" ~capabilities:[] ());
+  let ctx : _ Tool_team_session.context =
+    { config; agent_name = "owner"; sw; clock = Eio.Stdenv.clock env; proc_mgr = None }
+  in
+  let session_id =
+    start_session_exn ctx ~goal:"step-actor-must-match-caller" |> get_session_id
+  in
+  let ok, body =
+    dispatch_exn ctx ~name:"masc_team_session_step"
+      ~args:
+        (`Assoc
+          [
+            ("session_id", `String session_id);
+            ("turn_kind", `String "note");
+            ("actor", `String "planner");
+            ("message", `String "spoofed note");
+          ])
+  in
+  Alcotest.(check bool) "step rejects actor mismatch" false ok;
+  let json = parse_json_exn body in
+  Alcotest.(check string) "status error" "error"
+    (json |> Yojson.Safe.Util.member "status" |> Yojson.Safe.Util.to_string);
+  Alcotest.(check string) "actor mismatch message"
+    "actor must match the authenticated caller; omit actor to use the current agent"
+    (json |> Yojson.Safe.Util.member "message" |> Yojson.Safe.Util.to_string);
+  cleanup_dir base_dir
+
 let test_step_spawn_requires_proc_mgr () =
   Eio_main.run @@ fun env ->
   Eio.Switch.run @@ fun sw ->
@@ -2326,6 +2359,8 @@ let () =
             test_prove_requires_multi_actor_turn_coverage;
           Alcotest.test_case "missing-required-args" `Quick
             test_missing_required_args;
+          Alcotest.test_case "step-actor-must-match-caller" `Quick
+            test_step_actor_must_match_caller;
           Alcotest.test_case "step-spawn-requires-proc-mgr" `Quick
             test_step_spawn_requires_proc_mgr;
           Alcotest.test_case "step-spawn-llama-requires-spawn-model" `Quick


### PR DESCRIPTION
## Summary
- enforce caller-matched actor attribution on `masc_team_session_step`
- align canonical operator E2E with `masc_team_session_step` plus finalize/report/prove coverage
- make `masc_goal_dispatch` explicit about manual `current_task` binding and reject unknown `goal_ids`
- factor `masc_swarm_live_run` wrapper persistence/error paths into focused tests

## Testing
- `dune build --root . test/test_operator_mcp_e2e.exe test/test_tool_goals.exe test/test_tool_team_session.exe test/test_command_plane_v2.exe`
- `./_build/default/test/test_tool_goals.exe`
- `./_build/default/test/test_command_plane_v2.exe`
- `./_build/default/test/test_operator_mcp_e2e.exe`
- `./_build/default/test/test_tool_team_session.exe`