### PR TITLE
feat(swarm): role-based temperature and max_tokens for Planner/Worker

### DIFF
--- a/lib/agent_swarm_fleet.ml
+++ b/lib/agent_swarm_fleet.ml
@@ -46,8 +46,9 @@ let planner_spec ~provider ~goal =
     provider;
     system_prompt = Agent_swarm_prompts.fleet_planner ~goal;
     tools = [];
-    max_tokens = None;
+    max_tokens = Some 16384;
     max_turns = 10;
+    temperature = Some 1.0;
     include_masc_tools = true;
     managed_task = None;
     expected_final_marker = None;
@@ -61,8 +62,9 @@ let worker_specs ~provider ~num_members ~workdir ~max_turns =
         provider;
         system_prompt = Agent_swarm_prompts.fleet_worker ~name ~workdir;
         tools = [];
-        max_tokens = None;
+        max_tokens = Some 8192;
         max_turns;
+        temperature = Some 0.6;
         include_masc_tools = true;
         managed_task = None;
         expected_final_marker = None;

--- a/lib/agent_swarm_live_harness.ml
+++ b/lib/agent_swarm_live_harness.ml
@@ -244,6 +244,7 @@ let worker_spec cfg plan : Agent_swarm_swarm.agent_spec =
     tools = [];
     max_tokens = Some 256;
     max_turns = cfg.max_turns;
+    temperature = None;
     include_masc_tools = false;
     managed_task =
       Some

--- a/lib/agent_swarm_swarm.ml
+++ b/lib/agent_swarm_swarm.ml
@@ -19,6 +19,7 @@ type agent_spec = {
   tools: Tool.t list;
   max_tokens: int option;
   max_turns: int;
+  temperature: float option;
   include_masc_tools: bool;
   managed_task: managed_task option;
   expected_final_marker: string option;
@@ -343,6 +344,7 @@ let run_agent ~sw ~net ~clock ~masc_url ?(extra_tools=[]) spec ~goal =
                   Option.value spec.max_tokens
                     ~default:Types.default_config.max_tokens;
                 max_turns = spec.max_turns;
+                temperature = spec.temperature;
               } in
               let agent =
                 Agent.create ~net ~config ~tools:all_tools

--- a/test/test_agent_swarm_fleet.ml
+++ b/test/test_agent_swarm_fleet.ml
@@ -36,6 +36,7 @@ let test_fleet_member_variant () =
     tools = [];
     max_tokens = None;
     max_turns = 5;
+    temperature = None;
     include_masc_tools = true;
     managed_task = None;
     expected_final_marker = None;
@@ -122,7 +123,15 @@ let test_run_full_plan () =
   Alcotest.(check bool) "worker turn budget" true
     (List.for_all
        (fun spec -> spec.Agent_swarm_swarm.max_turns = 7)
-       plan.worker_specs)
+       plan.worker_specs);
+  Alcotest.(check (option (float 0.01))) "planner temperature" (Some 1.0)
+    plan.planner_spec.Agent_swarm_swarm.temperature;
+  Alcotest.(check (option (float 0.01))) "worker temperature" (Some 0.6)
+    (List.hd plan.worker_specs).Agent_swarm_swarm.temperature;
+  Alcotest.(check (option int)) "planner max_tokens" (Some 16384)
+    plan.planner_spec.Agent_swarm_swarm.max_tokens;
+  Alcotest.(check (option int)) "worker max_tokens" (Some 8192)
+    (List.hd plan.worker_specs).Agent_swarm_swarm.max_tokens
 
 let test_run_full_plan_rejects_zero_members () =
   Alcotest.check_raises "zero members rejected"

--- a/test/test_agent_swarm_unit.ml
+++ b/test/test_agent_swarm_unit.ml
@@ -21,6 +21,7 @@ let test_join_failure_returns_error () =
     tools = [];
     max_tokens = None;
     max_turns = 1;
+    temperature = None;
     include_masc_tools = true;
     managed_task = None;
     expected_final_marker = None;


### PR DESCRIPTION
## Summary
Qwen3.5 로컬 실행 가이드(Unsloth) 인사이트를 적용해 swarm agent의 역할별 LLM 파라미터를 분리.

## Changes
- `agent_spec`에 `temperature: float option` 필드 추가
- `run_agent`에서 Agent SDK config에 temperature 전달
- Fleet Planner: temperature=1.0, max_tokens=16384 (넓은 탐색 공간)
- Fleet Worker: temperature=0.6, max_tokens=8192 (결정론적 실행)

## Rationale
- 코딩 작업에는 temperature=0.6이 최적 (아티클 근거)
- Planner의 태스크 분해는 높은 온도에서 다양한 분해 전략을 탐색
- max_tokens 제한으로 불필요한 토큰 생성 방지, 응답 시간 예측 가능

## Test
- Fleet Unit: 9/9 pass (temperature, max_tokens 검증 포함)
- Swarm Unit: 5/5 pass
