### PR TITLE
feat(dashboard): reorder briefing LLM cascade — llama-server first

### DIFF
--- a/lib/dashboard_mission_briefing.ml
+++ b/lib/dashboard_mission_briefing.ml
@@ -89,12 +89,11 @@ let mission_briefing_models () =
     | None ->
         let glm = has_nonempty_env "ZAI_API_KEY" in
         let gemini = has_nonempty_env "GEMINI_API_KEY" in
-        match (glm, gemini) with
-        | true, true ->
-            [ "ollama:glm-4.7-flash"; "glm:glm-4.7-flash"; "gemini:gemini-2.5-flash" ]
-        | true, false -> [ "ollama:glm-4.7-flash"; "glm:glm-4.7-flash" ]
-        | false, true -> [ "ollama:glm-4.7-flash"; "gemini:gemini-2.5-flash" ]
-        | false, false -> [ "ollama:glm-4.7-flash" ]
+        let cloud =
+          (if glm then [ "glm:glm-4.7-flash" ] else [])
+          @ (if gemini then [ "gemini:gemini-2.5-flash" ] else [])
+        in
+        [ "llama:qwen3.5-35b-a3b" ] @ cloud @ [ "ollama:glm-4.7-flash" ]
   in
   Llm_client.available_model_specs_of_strings defaults
 


### PR DESCRIPTION
## 변경 내용

Dashboard mission briefing LLM cascade 순서 재배치:

| 순서 | 모델 | 비고 |
|------|------|------|
| 1 | llama:qwen3.5-35b-a3b | 콜드 스타트 없음 (프로세스 시작 시 모델 로드) |
| 2 | glm:glm-4.7-flash | ZAI_API_KEY 필요 |
| 3 | gemini:gemini-2.5-flash | GEMINI_API_KEY 필요 |
| 4 | ollama:glm-4.7-flash | 최후 수단 (콜드 스타트 시 8s 타임아웃 초과 가능) |

## 배경

Ollama 모델이 VRAM에서 언로드된 상태에서 19GB glm-4.7-flash 로드에 10s+ 소요. Dashboard 브리핑 타임아웃(8s) 초과로 cascade 전체 실패.

llama-server는 프로세스 시작 시 모델을 미리 로드하므로 콜드 스타트 문제 없음.

## 코드 변경

- 4-way boolean match를 리스트 결합으로 단순화 (cloud provider 추가 시 분기 폭발 방지)
- 1 file, +5/-6 lines
