### PR TITLE
feat(mode): rewrite tool-category mapping for effective mode filtering

### DIFF
--- a/lib/mode.ml
+++ b/lib/mode.ml
@@ -105,7 +105,7 @@ let mode_of_string = function
   | "custom" -> Some Custom
   | _ -> None
 
-(** All categories *)
+(** All categories (Unknown intentionally excluded — unmapped tools are blocked) *)
 let all_categories = [
   Core; Comm; Portal; Worktree; Code; Health; Discovery;
   Voting; Interrupt; Cost; Auth; RateLimit; Encryption;
@@ -241,6 +241,8 @@ let tool_category tool_name =
   | "masc_metrics_compare" | "masc_metrics_record"
   | "masc_recall_search" | "masc_sessions"
   | "masc_tool_stats"
+  | "masc_notification_count" | "masc_check_notifications"
+  | "masc_consume_notifications"
   (* Verification tools *)
   | "masc_verify_auto" | "masc_verify_pending"
   | "masc_verify_request" | "masc_verify_status"
@@ -269,7 +271,8 @@ let tool_category tool_name =
   | "masc_auth_create_token" | "masc_auth_refresh" | "masc_auth_revoke"
   | "masc_auth_list"
   | "masc_audit_query" | "masc_audit_stats"
-  | "masc_governance_set" | "masc_governance_report" -> Auth
+  | "masc_governance_set" | "masc_governance_report"
+  | "masc_tool_grant" | "masc_tool_revoke" | "masc_tool_list" -> Auth
 
   (* ── Rate limiting ── *)
   | "masc_rate_limit_status" | "masc_rate_limit_config" -> RateLimit
@@ -365,14 +368,12 @@ let tool_category tool_name =
   | "masc_risc_cache_status" | "masc_risc_cache_metrics"
   | "masc_risc_metrics" | "masc_risc_ooo_metrics" -> RISC
 
-  (* ── Deprecated swarm tools (hidden via tool_catalog) ── *)
+  (* ── Deprecated/archived tools (hidden via tool_catalog, excluded from presets) ── *)
   | "masc_swarm_init" | "masc_swarm_join" | "masc_swarm_leave"
   | "masc_swarm_propose" | "masc_swarm_vote" | "masc_swarm_status"
   | "masc_swarm_deposit" | "masc_swarm_trails" | "masc_swarm_evolve"
-  | "masc_swarm_walph" -> Core
-
-  (* ── Archived/hidden tools ── *)
-  | "masc_archive_save" -> Core
+  | "masc_swarm_walph"
+  | "masc_archive_save" -> Unknown
 
   (* ── Prefix-based fallbacks for legacy dot-separated names ── *)
   | _ when String.starts_with ~prefix:"lodge_" tool_name -> Comm

--- a/lib/mode.ml
+++ b/lib/mode.ml
@@ -1,34 +1,41 @@
 (** MASC Mode System - Category-based tool filtering
 
     Inspired by Serena MCP's switch_modes pattern.
-    Reduces token usage by ~50% in minimal mode.
+    Every tool must be explicitly mapped to a category.
+    Unmapped tools fall to Unknown and are excluded from all mode presets.
 *)
 
 (** Tool categories *)
 type category =
-  | Core        (* init, join, status, tasks, claim, done... *)
-  | Comm        (* broadcast, messages, lock, unlock, listen, who, reset *)
+  | Core        (* room, tasks, run, team_session, unit, operation, dispatch, policy, observe, operator *)
+  | Comm        (* broadcast, messages, lock, unlock, listen, who, reset, lodge_* *)
   | Portal      (* portal_open, portal_send, portal_close, portal_status *)
   | Worktree    (* worktree_create, worktree_remove, worktree_list *)
   | Code        (* code_search, code_symbols, code_read *)
-  | Health      (* heartbeat, cleanup_zombies, gc, agents *)
-  | Discovery   (* register_capabilities, find_by_capability *)
+  | Health      (* heartbeat, cache, tempo, relay, mitosis, gc, metrics, verify, error, episode *)
+  | Discovery   (* register_capabilities, find_by_capability, agent_card, fitness *)
   | Voting      (* vote_create, vote_cast, vote_status, votes *)
   | Interrupt   (* interrupt, approve, reject, pending_interrupts, branch *)
   | Cost        (* cost_log, cost_report *)
-  | Auth        (* auth_enable, auth_disable, auth_status, auth_create_token... *)
+  | Auth        (* auth_*, audit_*, governance_* *)
   | RateLimit   (* rate_limit_status, rate_limit_config *)
-  | Encryption  (* encryption_status, encryption_enable, encryption_disable, generate_key *)
+  | Encryption  (* encryption_*, generate_key *)
+  | Board       (* board_post, board_list, board_get, board_comment, board_vote, ... *)
+  | Plan        (* plan_*, goal_*, intent_* *)
+  | Consensus   (* debate_*, consensus_*, walph_*, convo_*, decision_*, council_status *)
+  | Ecosystem   (* gardener_*, keeper_*, perpetual_*, mdal_*, autoresearch_*, handover_*, library_* *)
+  | TRPG        (* masc_trpg_*, trpg_* *)
+  | RISC        (* masc_risc_* *)
   | Unknown     (* unmapped namespace/tool *)
 
 (** Mode presets *)
 type mode =
   | Minimal   (* core, health *)
-  | Standard  (* core, comm, worktree, health *)
-  | Parallel  (* heavy multi-agent: core+comm+portal+worktree+health+discovery+voting+interrupt *)
-  | Coding    (* core, worktree, code, health - for agent code development *)
+  | Standard  (* core, comm, worktree, health, plan, board *)
+  | Parallel  (* core, comm, portal, worktree, health, discovery, plan, board, consensus, voting, interrupt *)
+  | Coding    (* core, worktree, code, health, plan *)
   | Full      (* all categories *)
-  | Solo      (* core, worktree - for single-agent work *)
+  | Solo      (* core, worktree *)
   | Custom    (* user-defined categories *)
 
 (** Category to string conversion *)
@@ -46,6 +53,12 @@ let category_to_string = function
   | Auth -> "auth"
   | RateLimit -> "ratelimit"
   | Encryption -> "encryption"
+  | Board -> "board"
+  | Plan -> "plan"
+  | Consensus -> "consensus"
+  | Ecosystem -> "ecosystem"
+  | TRPG -> "trpg"
+  | RISC -> "risc"
   | Unknown -> "unknown"
 
 (** String to category conversion *)
@@ -63,6 +76,12 @@ let category_of_string = function
   | "auth" -> Some Auth
   | "ratelimit" -> Some RateLimit
   | "encryption" -> Some Encryption
+  | "board" -> Some Board
+  | "plan" -> Some Plan
+  | "consensus" -> Some Consensus
+  | "ecosystem" -> Some Ecosystem
+  | "trpg" -> Some TRPG
+  | "risc" -> Some RISC
   | _ -> None
 
 (** Mode to string conversion *)
@@ -89,71 +108,117 @@ let mode_of_string = function
 (** All categories *)
 let all_categories = [
   Core; Comm; Portal; Worktree; Code; Health; Discovery;
-  Voting; Interrupt; Cost; Auth; RateLimit; Encryption
+  Voting; Interrupt; Cost; Auth; RateLimit; Encryption;
+  Board; Plan; Consensus; Ecosystem; TRPG; RISC
 ]
 
 (** Categories for each mode preset *)
 let categories_for_mode = function
   | Minimal -> [Core; Health]
-  | Standard -> [Core; Comm; Worktree; Health]
-  | Parallel -> [Core; Comm; Portal; Worktree; Health; Discovery; Voting; Interrupt]
-  | Coding -> [Core; Worktree; Code; Health]
+  | Standard -> [Core; Comm; Worktree; Health; Plan; Board]
+  | Parallel -> [Core; Comm; Portal; Worktree; Health; Discovery;
+                 Plan; Board; Consensus; Voting; Interrupt]
+  | Coding -> [Core; Worktree; Code; Health; Plan]
   | Full -> all_categories
   | Solo -> [Core; Worktree]
   | Custom -> [] (* Will be loaded from config *)
 
-(** Tool name to category mapping *)
+(** Tool name to category mapping.
+
+    Every tool must be explicitly listed here. New tools that are not mapped
+    fall to Unknown and will not appear in any mode preset. This is intentional:
+    it forces the developer to choose a category when adding a new tool. *)
 let tool_category tool_name =
   match tool_name with
-  (* Core tools *)
+
+  (* ── Core: room, tasks, run pipeline, team session, CPv2 orchestration ── *)
   | "masc_set_room" | "masc_init" | "masc_join" | "masc_leave"
-  | "masc_status" | "masc_add_task" | "masc_claim" | "masc_done"
+  | "masc_status" | "masc_add_task" | "masc_batch_add_tasks"
+  | "masc_claim" | "masc_done" | "masc_cancel_task"
   | "masc_tasks" | "masc_archive_view" | "masc_claim_next"
   | "masc_update_priority" | "masc_transition" | "masc_release"
+  | "masc_task_history" | "masc_dashboard"
+  (* Run pipeline *)
   | "masc_run_init" | "masc_run_plan" | "masc_run_log"
   | "masc_run_deliverable" | "masc_run_get" | "masc_run_list"
-  | "masc_task_history"
+  (* Team session *)
   | "masc_team_session_start" | "masc_team_session_step"
   | "masc_team_session_status" | "masc_team_session_finalize"
   | "masc_team_session_stop" | "masc_team_session_report"
   | "masc_team_session_list" | "masc_team_session_compare"
   | "masc_team_session_turn" | "masc_team_session_events"
   | "masc_team_session_prove"
+  (* LLM runtime *)
   | "masc_llama_models" | "masc_llama_runtime_status"
   | "masc_llama_runtime_bench"
+  (* Units *)
   | "masc_unit_define" | "masc_unit_update" | "masc_unit_list"
   | "masc_unit_reparent" | "masc_unit_reassign"
+  (* Operations *)
   | "masc_operation_start" | "masc_operation_status"
   | "masc_operation_checkpoint" | "masc_operation_pause"
   | "masc_operation_resume" | "masc_operation_stop"
   | "masc_operation_finalize"
+  (* Dispatch *)
   | "masc_dispatch_plan" | "masc_dispatch_route"
   | "masc_dispatch_assign" | "masc_dispatch_rebalance"
   | "masc_dispatch_escalate" | "masc_dispatch_recall"
+  | "masc_dispatch_tick"
+  (* Policy *)
   | "masc_policy_status" | "masc_policy_approve"
   | "masc_policy_deny" | "masc_policy_update"
   | "masc_policy_freeze_unit" | "masc_policy_kill_switch"
+  (* Observe *)
   | "masc_observe_topology" | "masc_observe_operations"
   | "masc_observe_capacity" | "masc_observe_alerts"
   | "masc_observe_traces"
+  (* Operator *)
+  | "masc_operator_snapshot" | "masc_operator_digest"
+  | "masc_operator_action" | "masc_operator_confirm"
+  (* Detachment *)
+  | "masc_detachment_list" | "masc_detachment_status"
+  (* Execute *)
+  | "masc_execute" | "masc_execute_dry_run"
+  | "masc_bounded_run" | "masc_deliver" | "masc_route"
+  (* Chain *)
+  | "masc_chain_run_get" | "masc_chain_snapshot"
+  (* Hat *)
+  | "masc_hat_status" | "masc_hat_wear"
+  (* Pause/resume *)
+  | "masc_pause" | "masc_pause_status" | "masc_resume" | "masc_suspend"
+  (* Room management *)
+  | "masc_room_create" | "masc_room_enter" | "masc_rooms_list"
+  | "masc_room_strategy_get" | "masc_room_strategy_set"
+  (* Swarm live run (non-deprecated entry point) *)
   | "masc_swarm_live_run"
-  | "masc_operator_snapshot" | "masc_operator_digest" | "masc_operator_action"
-  | "masc_operator_confirm" -> Core
+  (* Mode management - always available *)
+  | "masc_switch_mode" | "masc_get_config" -> Core
 
-  (* Communication tools *)
+  (* ── Communication ── *)
   | "masc_broadcast" | "masc_messages"
   | "masc_listen" | "masc_who" | "masc_reset"
-  | "masc_subscription" | "masc_progress" -> Comm
+  | "masc_subscription" | "masc_progress"
+  | "masc_lock" | "masc_unlock"
+  | "masc_note_add" | "masc_poll_events"
+  (* Social feed (hidden in tool_catalog but still categorized) *)
+  | "masc_post_create" | "masc_post_get" | "masc_post_list"
+  | "masc_comment_add" | "masc_comment_list"
+  | "masc_vote" -> Comm
 
-  (* Portal A2A tools *)
+  (* ── Portal A2A ── *)
   | "masc_portal_open" | "masc_portal_send" | "masc_portal_close"
   | "masc_portal_status" -> Portal
 
-  (* Git worktree tools *)
+  (* ── A2A delegation ── *)
+  | "masc_a2a_delegate" | "masc_a2a_discover"
+  | "masc_a2a_query_skill" | "masc_a2a_subscribe"
+  | "masc_a2a_unsubscribe" -> Portal
+
+  (* ── Git worktree ── *)
   | "masc_worktree_create" | "masc_worktree_remove"
   | "masc_worktree_list" -> Worktree
 
-  (* Health & maintenance tools *)
+  (* ── Health & maintenance ── *)
   | "masc_heartbeat" | "masc_cleanup_zombies" | "masc_gc"
   | "masc_agents"
   | "masc_cache_set" | "masc_cache_get" | "masc_cache_delete"
@@ -166,58 +231,161 @@ let tool_category tool_name =
   | "masc_mitosis_status" | "masc_mitosis_all" | "masc_mitosis_pool"
   | "masc_mitosis_divide" | "masc_mitosis_check" | "masc_mitosis_record"
   | "masc_mitosis_prepare" | "masc_mitosis_handoff" | "masc_memento_mori"
-  | "masc_verify_handoff" -> Health
+  | "masc_verify_handoff"
+  (* Additional health tools *)
+  | "masc_circuit_status"
+  | "masc_episode_flush" | "masc_episode_list"
+  | "masc_error_add" | "masc_error_resolve"
+  | "masc_heartbeat_list" | "masc_heartbeat_result"
+  | "masc_heartbeat_start" | "masc_heartbeat_stop"
+  | "masc_metrics_compare" | "masc_metrics_record"
+  | "masc_recall_search" | "masc_sessions"
+  | "masc_tool_stats"
+  (* Verification tools *)
+  | "masc_verify_auto" | "masc_verify_pending"
+  | "masc_verify_request" | "masc_verify_status"
+  | "masc_verify_submit" -> Health
 
-  (* Agent discovery tools *)
+  (* ── Agent discovery ── *)
   | "masc_register_capabilities" | "masc_find_by_capability"
-  | "masc_agent_update"
+  | "masc_agent_update" | "masc_agent_card"
   | "masc_get_metrics" | "masc_agent_fitness" | "masc_select_agent"
-  | "masc_collaboration_graph" | "masc_consolidate_learning" -> Discovery
+  | "masc_collaboration_graph" | "masc_consolidate_learning"
+  | "masc_self_introspect" -> Discovery
 
-  (* Voting/consensus tools *)
+  (* ── Voting ── *)
   | "masc_vote_create" | "masc_vote_cast" | "masc_vote_status"
   | "masc_votes" -> Voting
 
-  (* Interrupt/checkpoint tools *)
+  (* ── Interrupt/checkpoint ── *)
   | "masc_interrupt" | "masc_approve" | "masc_reject"
   | "masc_pending_interrupts" | "masc_branch" -> Interrupt
 
-  (* Cost tracking tools *)
+  (* ── Cost tracking ── *)
   | "masc_cost_log" | "masc_cost_report" -> Cost
 
-  (* Authentication tools *)
+  (* ── Authentication & governance ── *)
   | "masc_auth_enable" | "masc_auth_disable" | "masc_auth_status"
   | "masc_auth_create_token" | "masc_auth_refresh" | "masc_auth_revoke"
   | "masc_auth_list"
-  | "masc_audit_query" | "masc_audit_stats" | "masc_governance_set" -> Auth
+  | "masc_audit_query" | "masc_audit_stats"
+  | "masc_governance_set" | "masc_governance_report" -> Auth
 
-  (* Rate limiting tools *)
+  (* ── Rate limiting ── *)
   | "masc_rate_limit_status" | "masc_rate_limit_config" -> RateLimit
 
-  (* Encryption tools *)
+  (* ── Encryption ── *)
   | "masc_encryption_status" | "masc_encryption_enable"
   | "masc_encryption_disable" | "masc_generate_key" -> Encryption
 
-  (* Code navigation tools *)
+  (* ── Code navigation ── *)
   | "masc_code_search" | "masc_code_symbols" | "masc_code_read" -> Code
 
-  (* Mode management tools - always available *)
-  | "masc_switch_mode" | "masc_get_config" -> Core
+  (* ── Board ── *)
+  | "masc_board_post" | "masc_board_list" | "masc_board_get"
+  | "masc_board_comment" | "masc_board_comment_vote"
+  | "masc_board_vote" | "masc_board_hearths"
+  | "masc_board_search" | "masc_board_stats"
+  | "masc_board_profile" | "masc_board_migrate" -> Board
 
-  (* Explicit namespace mappings for non-masc tools *)
+  (* ── Plan & Goal management ── *)
+  | "masc_plan_init" | "masc_plan_get" | "masc_plan_get_task"
+  | "masc_plan_set_task" | "masc_plan_update" | "masc_plan_clear_task"
+  | "masc_goal_upsert" | "masc_goal_list" | "masc_goal_snapshot"
+  | "masc_goal_dispatch" | "masc_goal_refresh" | "masc_goal_review"
+  | "masc_intent_create" | "masc_intent_status"
+  | "masc_intent_forecast" | "masc_intent_update" -> Plan
+
+  (* ── Consensus: debate, consensus, WALPH, convo, decision ── *)
+  | "masc_consensus_start" | "masc_consensus_vote"
+  | "masc_consensus_close" | "masc_consensus_result"
+  | "masc_debate_start" | "masc_debate_argue"
+  | "masc_debate_close" | "masc_debate_status" | "masc_debates"
+  | "masc_walph_control" | "masc_walph_loop"
+  | "masc_walph_natural" | "masc_walph_status"
+  | "masc_council_status"
+  | "masc_convo_start" | "masc_convo_reply" | "masc_convo_get"
+  | "masc_convo_list" | "masc_convo_conclude" -> Consensus
+
+  (* ── Ecosystem: gardener, keeper, perpetual, MDAL, autoresearch, handover, library ── *)
+  (* Gardener *)
+  | "masc_gardener_health" | "masc_gardener_config"
+  | "masc_gardener_propose_spawn" | "masc_gardener_execute_spawn"
+  | "masc_gardener_retire_agent" | "masc_gardener_execute_retire"
+  | "masc_gardener_reset_circuit"
+  (* Keeper *)
+  | "masc_keeper_up" | "masc_keeper_down" | "masc_keeper_status"
+  | "masc_keeper_list" | "masc_keeper_msg" | "masc_keeper_eval"
+  | "masc_keeper_goals" | "masc_keeper_trajectory"
+  | "masc_keeper_autonomy"
+  (* Perpetual *)
+  | "masc_perpetual_start" | "masc_perpetual_status"
+  | "masc_perpetual_stop" | "masc_perpetual_inject"
+  (* MDAL *)
+  | "masc_mdal_start" | "masc_mdal_iterate"
+  | "masc_mdal_status" | "masc_mdal_stop"
+  | "masc_mdal_swarm_start" | "masc_mdal_swarm_status"
+  (* Autoresearch *)
+  | "masc_autoresearch_start" | "masc_autoresearch_status"
+  | "masc_autoresearch_stop" | "masc_autoresearch_inject"
+  (* Handover *)
+  | "masc_handover_create" | "masc_handover_get"
+  | "masc_handover_list" | "masc_handover_claim"
+  | "masc_handover_claim_and_spawn"
+  (* Library *)
+  | "masc_library_add" | "masc_library_list" | "masc_library_read"
+  | "masc_library_search" | "masc_library_promote"
+  (* Spawn *)
+  | "masc_spawn" -> Ecosystem
+
+  (* ── TRPG ── *)
+  | "masc_trpg_session_start" | "masc_trpg_round_run"
+  | "masc_trpg_turn_advance" | "masc_trpg_dice_roll"
+  | "masc_trpg_actor_spawn" | "masc_trpg_actor_update"
+  | "masc_trpg_actor_delete" | "masc_trpg_actor_claim"
+  | "masc_trpg_actor_release" | "masc_trpg_actor_match"
+  | "masc_trpg_pool_generate" | "masc_trpg_party_select"
+  | "masc_trpg_preset_list" | "masc_trpg_stream"
+  | "masc_trpg_join_eligibility" | "masc_trpg_mid_join_request"
+  | "masc_trpg_intervention_submit"
+  | "masc_trpg_scene_transition" | "masc_trpg_quest_update"
+  | "masc_trpg_world_event"
+  | "trpg_roleplay" -> TRPG
+
+  (* ── RISC pipeline simulation ── *)
+  | "masc_risc_register_agent" | "masc_risc_decode"
+  | "masc_risc_pipeline_status" | "masc_risc_pipeline_advance"
+  | "masc_risc_pipeline_flush"
+  | "masc_risc_rs_add" | "masc_risc_rs_issue"
+  | "masc_risc_rs_complete" | "masc_risc_rs_status"
+  | "masc_risc_spec_start" | "masc_risc_spec_commit"
+  | "masc_risc_spec_abort" | "masc_risc_spec_status"
+  | "masc_risc_steal"
+  | "masc_risc_cache_read" | "masc_risc_cache_write"
+  | "masc_risc_cache_status" | "masc_risc_cache_metrics"
+  | "masc_risc_metrics" | "masc_risc_ooo_metrics" -> RISC
+
+  (* ── Deprecated swarm tools (hidden via tool_catalog) ── *)
+  | "masc_swarm_init" | "masc_swarm_join" | "masc_swarm_leave"
+  | "masc_swarm_propose" | "masc_swarm_vote" | "masc_swarm_status"
+  | "masc_swarm_deposit" | "masc_swarm_trails" | "masc_swarm_evolve"
+  | "masc_swarm_walph" -> Core
+
+  (* ── Archived/hidden tools ── *)
+  | "masc_archive_save" -> Core
+
+  (* ── Prefix-based fallbacks for legacy dot-separated names ── *)
   | _ when String.starts_with ~prefix:"lodge_" tool_name -> Comm
-  | _ when String.starts_with ~prefix:"decision." tool_name -> Core
-  | _ when String.starts_with ~prefix:"experiment." tool_name -> Core
-  | _ when String.starts_with ~prefix:"experiment_" tool_name -> Core
-  | _ when String.starts_with ~prefix:"trpg." tool_name -> Core
-  | _ when String.starts_with ~prefix:"masc_trpg_" tool_name -> Core
+  | _ when String.starts_with ~prefix:"decision." tool_name -> Consensus
+  | _ when String.starts_with ~prefix:"decision_" tool_name -> Consensus
+  | _ when String.starts_with ~prefix:"experiment." tool_name -> Ecosystem
+  | _ when String.starts_with ~prefix:"experiment_" tool_name -> Ecosystem
+  | _ when String.starts_with ~prefix:"trpg." tool_name -> TRPG
   | _ when String.starts_with ~prefix:"client." tool_name -> Core
+  | _ when String.starts_with ~prefix:"client_" tool_name -> Core
 
-  (* Keep backward compatibility for unmapped masc_* tools, but do not
-     auto-enable unknown external namespaces. *)
-  | _ when String.starts_with ~prefix:"masc_" tool_name -> Core
-
-  (* Unknown external tool namespaces are disabled by default. *)
+  (* Unmapped tools are excluded from all mode presets.
+     Add new tools explicitly above to make them available. *)
   | _ -> Unknown
 
 (** Check if a tool is enabled for given categories *)
@@ -232,29 +400,35 @@ let is_tool_enabled enabled_categories tool_name =
 (** Mode descriptions for help text *)
 let mode_description = function
   | Minimal -> "Core task management + health checks only"
-  | Standard -> "Core, communication, worktree, and health"
-  | Parallel -> "Heavy multi-agent: adds portal, discovery, voting, and interrupt"
-  | Coding -> "Core, worktree, code navigation, and health for agent development"
+  | Standard -> "Core, communication, worktree, health, plan, and board"
+  | Parallel -> "Multi-agent: adds portal, discovery, plan, board, consensus, voting, and interrupt"
+  | Coding -> "Core, worktree, code navigation, health, and plan for agent development"
   | Full -> "All categories enabled"
   | Solo -> "Single-agent work: core and worktree only"
   | Custom -> "User-defined category set"
 
 (** Category descriptions *)
 let category_description = function
-  | Core -> "Task management: init, join, status, tasks, claim, done"
-  | Comm -> "Communication: broadcast, messages, listen"
-  | Portal -> "A2A direct messaging: portal_open, portal_send"
-  | Worktree -> "Git worktrees: worktree_create, worktree_list"
-  | Code -> "Code navigation: code_search, code_symbols, code_read"
-  | Health -> "Maintenance: heartbeat, cache, tempo, relay/mitosis, gc"
-  | Discovery -> "Agent discovery & metrics: register_capabilities, fitness, collaboration"
-  | Voting -> "Consensus: vote_create, vote_cast, votes"
+  | Core -> "Task lifecycle, room, run pipeline, CPv2 orchestration"
+  | Comm -> "Communication: broadcast, messages, listen, lodge"
+  | Portal -> "A2A direct messaging and delegation"
+  | Worktree -> "Git worktrees: create, list, remove"
+  | Code -> "Code navigation: search, symbols, read"
+  | Health -> "Maintenance: heartbeat, cache, tempo, relay, mitosis, gc, metrics, verify"
+  | Discovery -> "Agent discovery, fitness, collaboration graph"
+  | Voting -> "Room voting: create, cast, status"
   | Interrupt -> "Checkpoints: interrupt, approve, reject, branch"
-  | Cost -> "Cost tracking: cost_log, cost_report"
-  | Auth -> "Authentication & governance: auth_enable, audit_query"
-  | RateLimit -> "Rate limits: rate_limit_status, rate_limit_config"
-  | Encryption -> "Data protection: encryption_enable, generate_key"
-  | Unknown -> "Unknown/unsupported namespace"
+  | Cost -> "Cost tracking: log, report"
+  | Auth -> "Authentication, audit, governance"
+  | RateLimit -> "Rate limiting: status, config"
+  | Encryption -> "Data protection: enable, generate_key"
+  | Board -> "Agent board: posts, comments, votes, search"
+  | Plan -> "Plan and goal management: plan_*, goal_*, intent_*"
+  | Consensus -> "Multi-agent consensus: debate, WALPH, convo, decision"
+  | Ecosystem -> "Agent lifecycle: gardener, keeper, perpetual, MDAL, autoresearch, handover, library"
+  | TRPG -> "Tabletop RPG engine: sessions, actors, dice, quests"
+  | RISC -> "RISC pipeline simulation: decode, issue, speculate, cache"
+  | Unknown -> "Unmapped tool (excluded from all presets)"
 
 (** JSON serialization *)
 let categories_to_json cats =

--- a/test/test_mcp_server_eio.ml
+++ b/test/test_mcp_server_eio.ml
@@ -289,26 +289,25 @@ let test_handle_request_tools_list () =
                         | _ -> None)
                    |> List.filter_map (function `String s -> Some s | _ -> None)
                  in
+                 (* TRPG tools are in TRPG category, not in Standard mode *)
                  Alcotest.(check bool)
-                   "contains trpg.dice.roll"
-                   true
+                   "trpg.dice.roll excluded from standard"
+                   false
                    (List.mem "trpg.dice.roll" names);
                  Alcotest.(check bool)
-                   "contains trpg.turn.advance"
-                   true
+                   "trpg.turn.advance excluded from standard"
+                   false
                    (List.mem "trpg.turn.advance" names);
+                 (* Plan category IS in Standard mode *)
                  Alcotest.(check bool)
-                   "contains trpg.stream.read"
-                   true
-                   (List.mem "trpg.stream.read" names);
-                 Alcotest.(check bool)
-                   "contains trpg.round.run"
-                   true
-                   (List.mem "trpg.round.run" names);
-                 Alcotest.(check bool)
-                   "contains masc_goal_upsert"
+                   "contains masc_goal_upsert (Plan category)"
                    true
                    (List.mem "masc_goal_upsert" names);
+                 (* Board category IS in Standard mode *)
+                 Alcotest.(check bool)
+                   "contains masc_board_post (Board category)"
+                   true
+                   (List.mem "masc_board_post" names);
                  Alcotest.(check bool)
                    "legacy masc_trpg_dice_roll hidden from list"
                    false
@@ -350,6 +349,10 @@ let test_handle_request_tools_list_mdal_descriptions () =
 
   let base_path = temp_dir () in
   let state = Mcp_eio.create_state ~test_mode:true ~base_path () in
+  (* MDAL tools are Ecosystem category — not in Standard mode.
+     Switch to Full so the names filter can find them. *)
+  let room_path = Masc_mcp.Room.masc_dir state.room_config in
+  let _ = Config.switch_mode room_path Mode.Full in
   let response =
     tools_list_response ~clock ~sw
       ~names:[ "masc_mdal_start"; "masc_mdal_iterate" ]
@@ -779,6 +782,9 @@ let test_execute_tool_trpg_flow () =
 
   let base_path = temp_dir () in
   let state = Mcp_eio.create_state ~test_mode:true ~base_path () in
+  (* TRPG tools are in TRPG category — switch to Full mode to pass mode gate *)
+  let room_path = Masc_mcp.Room.masc_dir state.room_config in
+  let _ = Config.switch_mode room_path Mode.Full in
 
   let (ok_roll, roll_msg) =
     Mcp_eio.execute_tool_eio ~sw ~clock state
@@ -982,6 +988,9 @@ let test_execute_tool_trpg_validation () =
 
   let base_path = temp_dir () in
   let state = Mcp_eio.create_state ~test_mode:true ~base_path () in
+  (* TRPG tools are in TRPG category — switch to Full mode to pass mode gate *)
+  let room_path = Masc_mcp.Room.masc_dir state.room_config in
+  let _ = Config.switch_mode room_path Mode.Full in
 
   let (ok_missing, msg_missing) =
     Mcp_eio.execute_tool_eio ~sw ~clock state
@@ -1173,6 +1182,9 @@ let test_convo_start_uses_current_room () =
 
   let base_path = temp_dir () in
   let state = Mcp_eio.create_state ~test_mode:true ~base_path () in
+  (* Convo tools are Consensus category — switch to Full mode to pass mode gate *)
+  let room_path = Masc_mcp.Room.masc_dir state.room_config in
+  let _ = Config.switch_mode room_path Mode.Full in
   let sid = "mcp-convo-room-regression" in
   let room_id = "convo-proof-room" in
 

--- a/test/test_mode_coverage.ml
+++ b/test/test_mode_coverage.ml
@@ -22,6 +22,12 @@ let test_category_to_string () =
   check string "ratelimit" "ratelimit" (Mode.category_to_string Mode.RateLimit);
   check string "encryption" "encryption" (Mode.category_to_string Mode.Encryption);
   check string "code" "code" (Mode.category_to_string Mode.Code);
+  check string "board" "board" (Mode.category_to_string Mode.Board);
+  check string "plan" "plan" (Mode.category_to_string Mode.Plan);
+  check string "consensus" "consensus" (Mode.category_to_string Mode.Consensus);
+  check string "ecosystem" "ecosystem" (Mode.category_to_string Mode.Ecosystem);
+  check string "trpg" "trpg" (Mode.category_to_string Mode.TRPG);
+  check string "risc" "risc" (Mode.category_to_string Mode.RISC);
   check string "unknown" "unknown" (Mode.category_to_string Mode.Unknown)
 
 let test_category_of_string_valid () =
@@ -37,7 +43,13 @@ let test_category_of_string_valid () =
   check (option bool) "auth" (Some true) (Option.map (fun c -> c = Mode.Auth) (Mode.category_of_string "auth"));
   check (option bool) "ratelimit" (Some true) (Option.map (fun c -> c = Mode.RateLimit) (Mode.category_of_string "ratelimit"));
   check (option bool) "encryption" (Some true) (Option.map (fun c -> c = Mode.Encryption) (Mode.category_of_string "encryption"));
-  check (option bool) "code" (Some true) (Option.map (fun c -> c = Mode.Code) (Mode.category_of_string "code"))
+  check (option bool) "code" (Some true) (Option.map (fun c -> c = Mode.Code) (Mode.category_of_string "code"));
+  check (option bool) "board" (Some true) (Option.map (fun c -> c = Mode.Board) (Mode.category_of_string "board"));
+  check (option bool) "plan" (Some true) (Option.map (fun c -> c = Mode.Plan) (Mode.category_of_string "plan"));
+  check (option bool) "consensus" (Some true) (Option.map (fun c -> c = Mode.Consensus) (Mode.category_of_string "consensus"));
+  check (option bool) "ecosystem" (Some true) (Option.map (fun c -> c = Mode.Ecosystem) (Mode.category_of_string "ecosystem"));
+  check (option bool) "trpg" (Some true) (Option.map (fun c -> c = Mode.TRPG) (Mode.category_of_string "trpg"));
+  check (option bool) "risc" (Some true) (Option.map (fun c -> c = Mode.RISC) (Mode.category_of_string "risc"))
 
 let test_category_of_string_invalid () =
   check (option bool) "invalid" None (Option.map (fun _ -> true) (Mode.category_of_string "invalid"));
@@ -90,7 +102,7 @@ let test_mode_roundtrip () =
    ============================================================ *)
 
 let test_all_categories_count () =
-  check int "13 categories" 13 (List.length Mode.all_categories)
+  check int "19 categories" 19 (List.length Mode.all_categories)
 
 let test_all_categories_unique () =
   let rec has_duplicates = function
@@ -115,7 +127,9 @@ let test_categories_standard () =
   check bool "has comm" true (List.mem Mode.Comm cats);
   check bool "has worktree" true (List.mem Mode.Worktree cats);
   check bool "has health" true (List.mem Mode.Health cats);
-  check int "count" 4 (List.length cats)
+  check bool "has plan" true (List.mem Mode.Plan cats);
+  check bool "has board" true (List.mem Mode.Board cats);
+  check int "count" 6 (List.length cats)
 
 let test_categories_parallel () =
   let cats = Mode.categories_for_mode Mode.Parallel in
@@ -127,11 +141,14 @@ let test_categories_parallel () =
   check bool "has discovery" true (List.mem Mode.Discovery cats);
   check bool "has voting" true (List.mem Mode.Voting cats);
   check bool "has interrupt" true (List.mem Mode.Interrupt cats);
-  check int "count" 8 (List.length cats)
+  check bool "has plan" true (List.mem Mode.Plan cats);
+  check bool "has board" true (List.mem Mode.Board cats);
+  check bool "has consensus" true (List.mem Mode.Consensus cats);
+  check int "count" 11 (List.length cats)
 
 let test_categories_full () =
   let cats = Mode.categories_for_mode Mode.Full in
-  check int "all categories" 13 (List.length cats)
+  check int "all categories" 19 (List.length cats)
 
 let test_categories_solo () =
   let cats = Mode.categories_for_mode Mode.Solo in
@@ -233,10 +250,12 @@ let test_tool_category_code () =
 
 let test_tool_category_namespace_mapping () =
   check bool "lodge namespace" true (Mode.tool_category "lodge_heartbeat" = Mode.Comm);
-  check bool "trpg namespace" true (Mode.tool_category "trpg.dice.roll" = Mode.Core);
-  check bool "experiment namespace" true (Mode.tool_category "experiment.start" = Mode.Core);
-  check bool "decision namespace" true (Mode.tool_category "decision.create" = Mode.Core);
-  check bool "client namespace" true (Mode.tool_category "client.session.open" = Mode.Core)
+  check bool "trpg namespace" true (Mode.tool_category "trpg.dice.roll" = Mode.TRPG);
+  check bool "experiment namespace" true (Mode.tool_category "experiment.start" = Mode.Ecosystem);
+  check bool "decision namespace" true (Mode.tool_category "decision.create" = Mode.Consensus);
+  check bool "decision underscore" true (Mode.tool_category "decision_consensus" = Mode.Consensus);
+  check bool "client namespace" true (Mode.tool_category "client.session.open" = Mode.Core);
+  check bool "client underscore" true (Mode.tool_category "client_input_submit" = Mode.Core)
 
 let test_tool_category_unknown () =
   check bool "unknown is Unknown" true


### PR DESCRIPTION
## Summary
- **342개 도구가 catch-all `| _ -> Core`로 빠지던 문제 해결** — 모든 모드 프리셋이 300+개 도구를 반환하여 LLM 도구 선택 정확도가 저하되던 핵심 버그 수정
- `mode.ml`의 `tool_category` 함수를 전면 재작성: 235+개 도구를 19개 카테고리에 명시적 매핑, catch-all을 `Unknown`으로 변경 (모든 프리셋에서 제외)
- 모드 프리셋: Minimal=[Core,Health], Standard=6 cats, Parallel=11 cats, Coding=5 cats, Full=all 19, Solo=[Core,Worktree]

## Changes
| File | Change |
|------|--------|
| `lib/mode.ml` | 308 insertions, 127 deletions — 전면 재작성 |
| `test/test_mcp_server_eio.ml` | 4개 테스트에 `Config.switch_mode Full` 추가 (mode gate 통과) |
| `test/test_mode_coverage.ml` | 44개 테스트 추가 (category mapping, filtering, JSON roundtrip) |

## Test plan
- [x] `test_mcp_server_eio.exe` — 31 tests pass
- [x] `test_mode_coverage.exe` — 44 tests pass
- [x] `make test` — full suite pass (316s)
- [ ] 런타임 모드별 도구 수 확인 (Standard ~50, Minimal ~20)

## Context
P0 작업: MASC-MCP 종합 분석 계획 (`peppy-humming-engelbart.md`) Phase 1