### PR TITLE
fix(mode): hidden tools bypass mode filter, fix CI failures

### DIFF
--- a/lib/config.ml
+++ b/lib/config.ml
@@ -118,7 +118,11 @@ let enabled_tool_schemas ?(include_hidden = false) ?(include_deprecated = false)
     Types.tool_schema list =
   visible_tool_schemas ~include_hidden ~include_deprecated ()
   |> List.filter (fun (schema : Types.tool_schema) ->
-         Mode.is_tool_enabled enabled_categories schema.name)
+         if include_hidden then true
+         else
+           let meta = Tool_catalog.metadata schema.name in
+           meta.Tool_catalog.visibility = Tool_catalog.Hidden
+           || Mode.is_tool_enabled enabled_categories schema.name)
 
 (** Switch to a preset mode *)
 let switch_mode room_path mode =

--- a/scripts/harness/contract/game_view_precondition.sh
+++ b/scripts/harness/contract/game_view_precondition.sh
@@ -8,6 +8,9 @@ export CURL_RETRY_COUNT
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "${SCRIPT_DIR}/../lib/test_framework.sh"
 
+echo "[0/5] switch to full mode for harness"
+call_tool 1000 "masc_switch_mode" "{\"mode\":\"full\"}" >/dev/null
+
 echo "[1/5] experiment.start without decision.finalize => expect PRECONDITION_REQUIRED"
 r1="$(call_tool 1001 "experiment.start" "{\"session_id\":\"$SESSION_ID\",\"hypothesis\":\"h\"}")"
 if ! printf "%s" "$r1" | jq -er 'try (.result.content[0].text | fromjson | tostring | contains("PRECONDITION_REQUIRED")) catch false' >/dev/null; then

--- a/test/test_mcp_server_eio.ml
+++ b/test/test_mcp_server_eio.ml
@@ -1212,6 +1212,11 @@ let test_convo_start_uses_current_room () =
   in
   Alcotest.(check bool) "room enter success" true ok_enter;
 
+  (* After entering a new room, its mode defaults to Standard.
+     Convo tools are Consensus category — switch the new room to Full. *)
+  let new_room_path = Masc_mcp.Room.masc_dir state.room_config in
+  let _ = Config.switch_mode new_room_path Mode.Full in
+
   let (ok_start, start_msg) =
     Mcp_eio.execute_tool_eio ~sw ~clock ~mcp_session_id:sid state
       ~name:"masc_convo_start"


### PR DESCRIPTION
## Summary
- Hidden-visibility tools (placeholder, deprecated) now bypass mode filtering — mode is a UX optimization, not a security boundary
- `include_hidden=true` in `tools/list` bypasses mode filtering entirely
- Contract harness (`game_view_precondition.sh`) switches to Full mode before testing Discovery/Consensus/TRPG tools
- Test #22 (`convo start uses current room`) switches new room to Full mode after `masc_room_enter`

## Context
PR #721 was merged before this fix commit landed, causing CI failures on main. This PR cherry-picks the fix.

## Test plan
- [x] 31/31 mcp_server_eio tests pass
- [x] 44/44 mode_coverage tests pass
- [x] Build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)