### PR TITLE
feat(autoresearch): implement real Karpathy loop (Phase 2.5)

### DIFF
--- a/lib/autoresearch.ml
+++ b/lib/autoresearch.ml
@@ -38,6 +38,8 @@ type loop_state = {
   loop_id : string;
   goal : string;
   metric_fn : string;
+  llm_model : string;
+  target_file : string;  (** File the LLM reads and modifies, relative to workdir *)
   mutable status : status;
   mutable error_message : string option;
   mutable current_cycle : int;
@@ -47,6 +49,7 @@ type loop_state = {
   mutable history : cycle_record list;  (** Most recent first *)
   mutable total_keeps : int;
   mutable total_discards : int;
+  mutable insights : string list;  (** Accumulated experiment insights, FIFO max 10 *)
   start_time : float;
   mutable updated_at : float;
   cycle_timeout_s : float;
@@ -126,6 +129,8 @@ let state_to_yojson (s : loop_state) : Yojson.Safe.t =
     ("loop_id", `String s.loop_id);
     ("goal", `String s.goal);
     ("metric_fn", `String s.metric_fn);
+    ("llm_model", `String s.llm_model);
+    ("target_file", `String s.target_file);
     ("status", `String (status_to_string s.status));
     ("current_cycle", `Int s.current_cycle);
     ("baseline", `Float s.baseline);
@@ -138,6 +143,7 @@ let state_to_yojson (s : loop_state) : Yojson.Safe.t =
     ("workdir", `String s.workdir);
     ("elapsed_s", `Float (Time_compat.now () -. s.start_time));
     ("history_count", `Int (List.length s.history));
+    ("insights_count", `Int (List.length s.insights));
     ("error", match s.error_message with
       | Some e -> `String e | None -> `Null);
   ]
@@ -196,7 +202,7 @@ let save_state ~base_path state =
 let measure_metric ~workdir ~timeout_s metric_fn =
   let timeout_flag = Printf.sprintf "timeout %.0f" timeout_s in
   let cmd = Printf.sprintf "cd %s && %s %s 2>/dev/null | tail -1"
-    (Filename.quote workdir) timeout_flag (Filename.quote metric_fn) in
+    (Filename.quote workdir) timeout_flag metric_fn in
   let start = Time_compat.now () in
   let ic = Unix.open_process_in cmd in
   let output = Fun.protect ~finally:(fun () ->
@@ -206,8 +212,39 @@ let measure_metric ~workdir ~timeout_s metric_fn =
   ) in
   let elapsed_ms = int_of_float ((Time_compat.now () -. start) *. 1000.0) in
   match float_of_string_opt (String.trim output) with
-  | Some v -> Ok (v, elapsed_ms)
-  | None -> Error (Printf.sprintf "metric_fn output not a float: %S" output)
+  | Some v -> Result.ok (v, elapsed_ms)
+  | None -> Result.error (Printf.sprintf "metric_fn output not a float: %S" output)
+
+(** Check if [needle] is a substring of [haystack]. *)
+let contains_substring haystack needle =
+  let hlen = String.length haystack in
+  let nlen = String.length needle in
+  if nlen > hlen then false
+  else
+    let found = ref false in
+    for i = 0 to hlen - nlen do
+      if not !found && String.sub haystack i nlen = needle then
+        found := true
+    done;
+    !found
+
+(** Run metric_fn with retry on transient errors (timeout, connection).
+    Returns Ok (score, total_elapsed_ms) or Error on non-transient failure.
+    max_retries=2 means up to 3 total attempts. *)
+let measure_metric_with_retry ~workdir ~timeout_s ?(max_retries = 2) metric_fn =
+  let is_transient err =
+    let lower = String.lowercase_ascii err in
+    contains_substring lower "timeout" || contains_substring lower "connection"
+  in
+  let rec attempt n =
+    match measure_metric ~workdir ~timeout_s metric_fn with
+    | Ok _ as ok -> ok
+    | Error e when n < max_retries && is_transient e ->
+      Unix.sleepf 1.0;
+      attempt (n + 1)
+    | Error _ as err -> err
+  in
+  attempt 0
 
 (* ================================================================ *)
 (* Git Operations                                                   *)
@@ -224,10 +261,13 @@ let git_head_short ~workdir =
     try Some (String.trim (input_line ic)) with End_of_file -> None
   )
 
-(** Commit all changes with a message. Returns commit hash or None on failure. *)
+(** Commit staged/unstaged changes with a message.
+    Returns commit hash or None if nothing to commit.
+    No --allow-empty: real file changes required. *)
 let git_commit ~workdir ~message =
   let cmd = Printf.sprintf
-    "cd %s && git add -A && git commit --allow-empty -m %s 2>/dev/null && git rev-parse --short HEAD"
+    "cd %s && git add -A && git diff --cached --quiet; \
+     if [ $? -ne 0 ]; then git commit -m %s 2>/dev/null && git rev-parse --short HEAD; fi"
     (Filename.quote workdir) (Filename.quote message) in
   let ic = Unix.open_process_in cmd in
   Fun.protect ~finally:(fun () ->
@@ -249,16 +289,186 @@ let git_reset_last ~workdir =
     (Filename.quote workdir) in
   ignore (Sys.command cmd)
 
+(** Commit with autoresearch-formatted message. *)
+let git_commit_cycle ~workdir ~cycle ~hypothesis ~baseline =
+  let message = Printf.sprintf "[autoresearch] cycle %d: %s (baseline=%.4f)"
+    cycle hypothesis baseline in
+  git_commit ~workdir ~message
+
+(** Tag the current HEAD as the best result so far. *)
+let git_tag_best ~workdir ~cycle ~score =
+  let tag = Printf.sprintf "ar-best-c%d-%.4f" cycle score in
+  let cmd = Printf.sprintf "cd %s && git tag -f %s 2>/dev/null"
+    (Filename.quote workdir) (Filename.quote tag) in
+  ignore (Sys.command cmd)
+
+(* ================================================================ *)
+(* LLM Hypothesis Generation                                        *)
+(* ================================================================ *)
+
+(* ================================================================ *)
+(* Target File Validation & I/O                                     *)
+(* ================================================================ *)
+
+(** Validate target_file: must be relative, no path traversal, must exist.
+    Returns Ok absolute_path or Error reason. *)
+let validate_target_file ~workdir target_file =
+  if String.length target_file = 0 then
+    Result.error "target_file is empty"
+  else if contains_substring target_file ".." then
+    Result.error (Printf.sprintf "target_file contains '..': %s" target_file)
+  else if String.get target_file 0 = '/' then
+    Result.error (Printf.sprintf "target_file must be relative: %s" target_file)
+  else
+    let abs = Filename.concat workdir target_file in
+    if Sys.file_exists abs then Result.ok abs
+    else Result.error (Printf.sprintf "target_file not found: %s" abs)
+
+(** Read entire file contents. *)
+let read_file path =
+  let ic = open_in path in
+  Fun.protect ~finally:(fun () -> close_in_noerr ic) (fun () ->
+    let n = in_channel_length ic in
+    let buf = Bytes.create n in
+    really_input ic buf 0 n;
+    Bytes.to_string buf
+  )
+
+(** Apply code change: write new_content to target_file.
+    Returns Ok original_content (for rollback reference) or Error reason. *)
+let apply_code_change ~workdir ~target_file ~new_content =
+  match validate_target_file ~workdir target_file with
+  | (Result.Error _) as e -> e
+  | Result.Ok abs_path ->
+    let original = read_file abs_path in
+    let oc = open_out abs_path in
+    Fun.protect ~finally:(fun () -> close_out_noerr oc) (fun () ->
+      output_string oc new_content
+    );
+    Result.ok original
+
+(* ================================================================ *)
+(* LLM Code Change Generation                                       *)
+(* ================================================================ *)
+
+(** Build prompt for LLM code change. Exported for testing. *)
+let build_code_change_prompt ~goal ~baseline ~history ~insights
+    ~file_content ~target_file =
+  let recent = List.filteri (fun i _ -> i < 5) history in
+  let history_lines = List.map (fun (r : cycle_record) ->
+    Printf.sprintf "  Cycle %d: %s -> delta=%.4f (%s)"
+      r.cycle r.hypothesis r.delta (decision_to_string r.decision)
+  ) recent in
+  let insight_lines = List.map (fun s -> "  - " ^ s) insights in
+  String.concat "\n" ([
+    "You are an autonomous research assistant optimizing code.";
+    Printf.sprintf "Goal: %s" goal;
+    Printf.sprintf "Current baseline score: %.4f (higher is better)" baseline;
+    Printf.sprintf "Target file: %s" target_file;
+  ] @ (if history_lines <> [] then
+    [""; "Recent experiment history:"] @ history_lines
+  else []) @ (if insight_lines <> [] then
+    [""; "Accumulated insights:"] @ insight_lines
+  else []) @ [
+    "";
+    "<current_code>";
+    file_content;
+    "</current_code>";
+    "";
+    "Modify the code to improve the metric score.";
+    "Reply with exactly:";
+    "1. A <hypothesis> tag containing a one-line description of your change";
+    "2. A <modified_code> tag containing the COMPLETE modified file";
+    "";
+    "Example format:";
+    "<hypothesis>Increase batch size from 32 to 64 for better throughput</hypothesis>";
+    "<modified_code>";
+    "... complete file content ...";
+    "</modified_code>";
+  ])
+
+(** Extract text between XML-style tags. *)
+let extract_tag ~tag text =
+  let open_tag = Printf.sprintf "<%s>" tag in
+  let close_tag = Printf.sprintf "</%s>" tag in
+  let open_len = String.length open_tag in
+  let close_len = String.length close_tag in
+  let text_len = String.length text in
+  let rec find_start i =
+    if i + open_len > text_len then None
+    else if String.sub text i open_len = open_tag then
+      let content_start = i + open_len in
+      find_end content_start content_start
+    else find_start (i + 1)
+  and find_end content_start j =
+    if j + close_len > text_len then None
+    else if String.sub text j close_len = close_tag then
+      Some (String.sub text content_start (j - content_start))
+    else find_end content_start (j + 1)
+  in
+  find_start 0
+
+(** Parse LLM response containing <hypothesis> and <modified_code> tags.
+    Returns Ok (hypothesis, modified_code) or Error reason. *)
+let parse_llm_code_response response =
+  if String.trim response = "" then
+    Result.error "LLM returned empty response"
+  else
+    match extract_tag ~tag:"hypothesis" response with
+    | None -> Result.error "Missing <hypothesis> tag in LLM response"
+    | Some h ->
+      let hypothesis = String.trim h in
+      if hypothesis = "" then Result.error "Empty <hypothesis> tag"
+      else
+        match extract_tag ~tag:"modified_code" response with
+        | None -> Result.error "Missing <modified_code> tag in LLM response"
+        | Some code ->
+          if String.trim code = "" then Result.error "Empty <modified_code> tag"
+          else
+            (* Trim leading/trailing newline from code block *)
+            let trimmed =
+              let s = code in
+              let s = if String.length s > 0 && String.get s 0 = '\n'
+                then String.sub s 1 (String.length s - 1) else s in
+              let len = String.length s in
+              if len > 0 && String.get s (len - 1) = '\n'
+              then String.sub s 0 (len - 1) else s
+            in
+            Result.ok (hypothesis, trimmed)
+
+(** Generate code change by calling Llm_client.complete.
+    Returns Ok (hypothesis, new_code) or Error reason. *)
+let generate_code_change ~goal ~baseline ~history ~insights
+    ~target_file ~file_content ~llm_model =
+  let prompt = build_code_change_prompt ~goal ~baseline ~history ~insights
+    ~file_content ~target_file in
+  match Llm_client.model_spec_of_string llm_model with
+  | Result.Error e -> Result.error (Printf.sprintf "Invalid model spec: %s" e)
+  | Result.Ok model ->
+    let req : Llm_client.completion_request = {
+      model;
+      messages = [Llm_client.user_msg prompt];
+      temperature = 0.7;
+      max_tokens = 4096;
+      tools = [];
+      response_format = `Text;
+    } in
+    (match Llm_client.complete ~timeout_sec:120 req with
+    | Result.Error e -> Result.error (Printf.sprintf "LLM call failed: %s" e)
+    | Result.Ok resp -> parse_llm_code_response resp.content)
+
 (* ================================================================ *)
 (* Loop State Management                                            *)
 (* ================================================================ *)
 
-let create_state ~goal ~metric_fn ~cycle_timeout_s ~max_cycles ~workdir () =
+let create_state ~goal ~metric_fn ?(llm_model = "glm") ~target_file ~cycle_timeout_s ~max_cycles ~workdir () =
   let now = Time_compat.now () in
   {
     loop_id = generate_loop_id ();
     goal;
     metric_fn;
+    llm_model;
+    target_file;
     status = Running;
     error_message = None;
     current_cycle = 0;
@@ -268,12 +478,20 @@ let create_state ~goal ~metric_fn ~cycle_timeout_s ~max_cycles ~workdir () =
     history = [];
     total_keeps = 0;
     total_discards = 0;
+    insights = [];
     start_time = now;
     updated_at = now;
     cycle_timeout_s;
     max_cycles;
     workdir;
   }
+
+(** Append an insight, maintaining FIFO max 10 entries. *)
+let add_insight state msg =
+  let max_insights = 10 in
+  state.insights <- msg :: state.insights;
+  if List.length state.insights > max_insights then
+    state.insights <- List.filteri (fun i _ -> i < max_insights) state.insights
 
 (** Record one completed experiment cycle. *)
 let record_cycle state ~hypothesis ~score_before ~score_after
@@ -301,9 +519,13 @@ let record_cycle state ~hypothesis ~score_before ~score_after
      if score_after > state.best_score then begin
        state.best_score <- score_after;
        state.best_cycle <- state.current_cycle
-     end
+     end;
+     add_insight state
+       (Printf.sprintf "Cycle %d: %s improved +%.4f" state.current_cycle hypothesis delta)
    | Discard ->
-     state.total_discards <- state.total_discards + 1);
+     state.total_discards <- state.total_discards + 1;
+     add_insight state
+       (Printf.sprintf "Cycle %d: %s no improvement (%.4f)" state.current_cycle hypothesis delta));
   record
 
 (** Check if the loop should continue. *)

--- a/lib/autoresearch.ml
+++ b/lib/autoresearch.ml
@@ -300,8 +300,14 @@ let git_reset_last ~workdir =
 
 (** Commit with autoresearch-formatted message. *)
 let git_commit_cycle ~workdir ~cycle ~hypothesis ~baseline =
+  (* Sanitize hypothesis: collapse newlines/control chars to single space *)
+  let safe_hyp =
+    String.to_seq hypothesis
+    |> Seq.map (fun c -> if c < ' ' then ' ' else c)
+    |> String.of_seq
+    |> String.trim in
   let message = Printf.sprintf "[autoresearch] cycle %d: %s (baseline=%.4f)"
-    cycle hypothesis baseline in
+    cycle safe_hyp baseline in
   git_commit ~workdir ~message
 
 (** Tag the current HEAD as the best result so far. *)

--- a/lib/autoresearch.ml
+++ b/lib/autoresearch.ml
@@ -264,24 +264,33 @@ let git_head_short ~workdir =
 (** Commit staged/unstaged changes with a message.
     Returns commit hash or None if nothing to commit.
     No --allow-empty: real file changes required. *)
-let git_commit ~workdir ~message =
+(** Git commit result: Ok (Some hash) on success, Ok None when no diff,
+    Error msg when git commit itself fails (e.g. missing identity, hooks). *)
+let git_commit ~workdir ~message
+  : (string option, string) Stdlib.result =
   let cmd = Printf.sprintf
-    "cd %s && git add -A && git diff --cached --quiet; \
-     if [ $? -ne 0 ]; then git commit -m %s 2>/dev/null && git rev-parse --short HEAD; fi"
-    (Filename.quote workdir) (Filename.quote message) in
-  let ic = Unix.open_process_in cmd in
-  Fun.protect ~finally:(fun () ->
-    ignore (Unix.close_process_in ic)
-  ) (fun () ->
-    try
-      let lines = ref [] in
-      (try while true do lines := input_line ic :: !lines done
-       with End_of_file -> ());
-      match !lines with
-      | hash :: _ -> Some (String.trim hash)
-      | [] -> None
-    with _ -> None
-  )
+    "cd %s && git add -A && git diff --cached --quiet"
+    (Filename.quote workdir) in
+  if Sys.command cmd = 0 then
+    (* No staged changes — nothing to commit *)
+    Result.ok None
+  else
+    let commit_cmd = Printf.sprintf
+      "cd %s && git commit -m %s 2>&1 && git rev-parse --short HEAD"
+      (Filename.quote workdir) (Filename.quote message) in
+    let ic = Unix.open_process_in commit_cmd in
+    let lines = ref [] in
+    (try while true do lines := input_line ic :: !lines done
+     with End_of_file -> ());
+    let status = Unix.close_process_in ic in
+    match status with
+    | Unix.WEXITED 0 ->
+      (match !lines with
+       | hash :: _ -> Result.ok (Some (String.trim hash))
+       | [] -> Result.error "git commit succeeded but no hash returned")
+    | _ ->
+      let output = String.concat "\n" (List.rev !lines) in
+      Result.error (Printf.sprintf "git commit failed: %s" output)
 
 (** Reset to HEAD~1, discarding the last commit. *)
 let git_reset_last ~workdir =
@@ -331,6 +340,8 @@ let validate_target_file ~workdir target_file =
     let abs = Filename.concat workdir target_file in
     if not (Sys.file_exists abs) then
       Result.error (Printf.sprintf "target_file not found: %s" abs)
+    else if Sys.is_directory abs then
+      Result.error (Printf.sprintf "target_file is a directory: %s" target_file)
     else
       let real_path = Unix.realpath abs in
       let real_workdir = Unix.realpath workdir in

--- a/lib/autoresearch.ml
+++ b/lib/autoresearch.ml
@@ -310,19 +310,37 @@ let git_tag_best ~workdir ~cycle ~score =
 (* Target File Validation & I/O                                     *)
 (* ================================================================ *)
 
-(** Validate target_file: must be relative, no path traversal, must exist.
+(** Check if path contains traversal components (../ or /.. or bare ..). *)
+let has_path_traversal path =
+  path = ".."
+  || contains_substring path "../"
+  || (let len = String.length path in
+      len >= 3 && String.sub path (len - 3) 3 = "/..")
+
+(** Validate target_file: must be relative, no path traversal, must exist,
+    must not escape workdir via symlink.
     Returns Ok absolute_path or Error reason. *)
 let validate_target_file ~workdir target_file =
   if String.length target_file = 0 then
     Result.error "target_file is empty"
-  else if contains_substring target_file ".." then
-    Result.error (Printf.sprintf "target_file contains '..': %s" target_file)
   else if String.get target_file 0 = '/' then
     Result.error (Printf.sprintf "target_file must be relative: %s" target_file)
+  else if has_path_traversal target_file then
+    Result.error (Printf.sprintf "target_file contains '..': %s" target_file)
   else
     let abs = Filename.concat workdir target_file in
-    if Sys.file_exists abs then Result.ok abs
-    else Result.error (Printf.sprintf "target_file not found: %s" abs)
+    if not (Sys.file_exists abs) then
+      Result.error (Printf.sprintf "target_file not found: %s" abs)
+    else
+      let real_path = Unix.realpath abs in
+      let real_workdir = Unix.realpath workdir in
+      let prefix_len = String.length real_workdir in
+      if String.length real_path >= prefix_len
+         && String.sub real_path 0 prefix_len = real_workdir then
+        Result.ok real_path
+      else
+        Result.error (Printf.sprintf
+          "target_file escapes workdir via symlink: %s" target_file)
 
 (** Read entire file contents. *)
 let read_file path =
@@ -334,18 +352,28 @@ let read_file path =
     Bytes.to_string buf
   )
 
-(** Apply code change: write new_content to target_file.
+(** Apply code change: write new_content to target_file atomically.
+    Writes to a temp file in the same directory, then renames.
     Returns Ok original_content (for rollback reference) or Error reason. *)
 let apply_code_change ~workdir ~target_file ~new_content =
   match validate_target_file ~workdir target_file with
   | (Result.Error _) as e -> e
   | Result.Ok abs_path ->
     let original = read_file abs_path in
-    let oc = open_out abs_path in
-    Fun.protect ~finally:(fun () -> close_out_noerr oc) (fun () ->
-      output_string oc new_content
-    );
-    Result.ok original
+    let dir = Filename.dirname abs_path in
+    let tmp_path = Filename.concat dir
+      (Printf.sprintf ".autoresearch_tmp_%d" (Unix.getpid ())) in
+    (try
+      let oc = open_out tmp_path in
+      Fun.protect ~finally:(fun () -> close_out_noerr oc) (fun () ->
+        output_string oc new_content
+      );
+      Unix.rename tmp_path abs_path;
+      Result.ok original
+    with exn ->
+      (try Sys.remove tmp_path with _ -> ());
+      Result.error (Printf.sprintf "Failed to write %s: %s"
+        target_file (Printexc.to_string exn)))
 
 (* ================================================================ *)
 (* LLM Code Change Generation                                       *)
@@ -425,14 +453,18 @@ let parse_llm_code_response response =
         | Some code ->
           if String.trim code = "" then Result.error "Empty <modified_code> tag"
           else
-            (* Trim leading/trailing newline from code block *)
+            (* Strip all leading/trailing whitespace-only lines *)
             let trimmed =
-              let s = code in
-              let s = if String.length s > 0 && String.get s 0 = '\n'
-                then String.sub s 1 (String.length s - 1) else s in
-              let len = String.length s in
-              if len > 0 && String.get s (len - 1) = '\n'
-              then String.sub s 0 (len - 1) else s
+              let lines = String.split_on_char '\n' code in
+              let rec drop_blank = function
+                | [] -> []
+                | l :: rest ->
+                  if String.trim l = "" then drop_blank rest
+                  else l :: rest
+              in
+              let stripped = drop_blank lines in
+              let stripped = List.rev (drop_blank (List.rev stripped)) in
+              String.concat "\n" stripped
             in
             Result.ok (hypothesis, trimmed)
 

--- a/lib/mode.ml
+++ b/lib/mode.ml
@@ -331,6 +331,7 @@ let tool_category tool_name =
   (* Autoresearch *)
   | "masc_autoresearch_start" | "masc_autoresearch_status"
   | "masc_autoresearch_stop" | "masc_autoresearch_inject"
+  | "masc_autoresearch_cycle"
   (* Handover *)
   | "masc_handover_create" | "masc_handover_get"
   | "masc_handover_list" | "masc_handover_claim"

--- a/lib/tool_autoresearch.ml
+++ b/lib/tool_autoresearch.ml
@@ -363,19 +363,25 @@ let handle_cycle ctx args =
         let file_content = Autoresearch.read_file abs_path in
         (* 2. Generate code change: injected hypothesis > arg > LLM *)
         let code_result =
-          match Hashtbl.find_opt pending_hypotheses id with
-          | Some h ->
-            Hashtbl.remove pending_hypotheses id;
-            (* Injected hypothesis: use it as-is, keep file unchanged *)
-            Ok (h, file_content)
-          | None ->
-            match get_string_opt args "hypothesis" with
-            | Some h -> Ok (h, file_content)
-            | None ->
-              let generate = get_generator id in
-              generate ~goal:state.goal ~baseline:state.baseline
-                ~history:state.history ~insights:state.insights
-                ~target_file ~file_content ~llm_model:state.llm_model
+          let forced_hypothesis =
+            match Hashtbl.find_opt pending_hypotheses id with
+            | Some h -> Hashtbl.remove pending_hypotheses id; Some h
+            | None -> get_string_opt args "hypothesis"
+          in
+          let generate = get_generator id in
+          (match forced_hypothesis with
+           | Some h ->
+             (* Injected/explicit hypothesis: pass it to generator
+                so LLM produces actual code changes for this hypothesis *)
+             generate ~goal:(Printf.sprintf "%s\n\nApply this hypothesis: %s" state.goal h)
+               ~baseline:state.baseline
+               ~history:state.history ~insights:state.insights
+               ~target_file ~file_content ~llm_model:state.llm_model
+             |> Result.map (fun (_generated_hyp, code) -> (h, code))
+           | None ->
+             generate ~goal:state.goal ~baseline:state.baseline
+               ~history:state.history ~insights:state.insights
+               ~target_file ~file_content ~llm_model:state.llm_model)
         in
         match code_result with
         | Error e ->
@@ -406,10 +412,19 @@ let handle_cycle ctx args =
                ]
              | Ok _original ->
                (* 5. Git commit (real changes, no --allow-empty) *)
-               let commit_hash = Autoresearch.git_commit_cycle
+               let commit_result = Autoresearch.git_commit_cycle
                  ~workdir ~cycle:state.current_cycle ~hypothesis ~baseline:score_before in
-               (match commit_hash with
-                | None ->
+               (match commit_result with
+                | Error git_err ->
+                  (* Git commit failed (e.g. missing identity, hooks).
+                     Revert file change to keep working tree clean. *)
+                  Autoresearch.git_reset_last ~workdir;
+                  `Assoc [
+                    ("error", `String (Printf.sprintf "git commit failed: %s" git_err));
+                    ("loop_id", `String id);
+                    ("cycle", `Int state.current_cycle);
+                  ]
+                | Ok None ->
                   (* No diff: LLM produced identical code. Discard. *)
                   let record = Autoresearch.record_cycle state
                     ~hypothesis ~score_before ~score_after:score_before
@@ -426,7 +441,8 @@ let handle_cycle ctx args =
                     ("reason", `String "no diff produced");
                     ("baseline", `Float state.baseline);
                   ]
-                | Some _ ->
+                | Ok (Some _) ->
+                  let commit_hash = (match commit_result with Ok h -> h | _ -> None) in
                   (* 6. Measure score_after *)
                   let after_result = Autoresearch.measure_metric_with_retry
                     ~workdir ~timeout_s state.metric_fn in

--- a/lib/tool_autoresearch.ml
+++ b/lib/tool_autoresearch.ml
@@ -460,13 +460,15 @@ let handle_cycle ctx args =
                        (* Karpathy ratchet: git reset --hard HEAD~1 reverts commit + files *)
                        Autoresearch.git_reset_last ~workdir
                      | Autoresearch.Keep ->
-                       (* Update baseline to new score *)
-                       state.baseline <- score_after;
                        if score_after >= state.best_score then
                          Autoresearch.git_tag_best ~workdir
                            ~cycle:state.current_cycle ~score:score_after);
-                    (* 9. Persist *)
+                    (* 9. Persist cycle record first, then update in-memory state.
+                       Baseline mutation after append_cycle ensures disk has the
+                       decision record even if save_state fails. *)
                     Autoresearch.append_cycle ~base_path:ctx.base_path state.loop_id record;
+                    (if record.decision = Autoresearch.Keep then
+                       state.baseline <- score_after);
                     state.current_cycle <- state.current_cycle + 1;
                     Autoresearch.save_state ~base_path:ctx.base_path state;
                     (* 10. SSE broadcast *)

--- a/lib/tool_autoresearch.ml
+++ b/lib/tool_autoresearch.ml
@@ -3,11 +3,12 @@
     Inspired by Karpathy's autoresearch pattern: autonomous experiment cycles
     that generate hypotheses, measure metrics, and keep/discard changes via git.
 
-    Provides 4 MCP tools:
+    Provides 5 MCP tools:
     - masc_autoresearch_start  — Start an autoresearch loop with goal + metric_fn
     - masc_autoresearch_status — Get current loop state (cycle, baseline, history)
     - masc_autoresearch_stop   — Stop a running loop
     - masc_autoresearch_inject — Inject a hypothesis into a running loop
+    - masc_autoresearch_cycle  — Run one experiment cycle (the Karpathy loop turn)
 
     @since 2.80.0 *)
 
@@ -21,7 +22,7 @@ let schemas : Types.tool_schema list = [
   {
     name = "masc_autoresearch_start";
     description = "Start an autonomous experiment loop (inspired by Karpathy's autoresearch). \
-Each cycle: measure baseline → apply change → measure again → keep if improved, discard if not. \
+Each cycle: measure baseline -> apply change -> measure again -> keep if improved, discard if not. \
 Changes are tracked via git commits. Results are logged to JSONL. \
 Requires: goal (what to optimize), metric_fn (shell command that outputs a float on the last line).";
     input_schema = `Assoc [
@@ -53,8 +54,17 @@ Requires: goal (what to optimize), metric_fn (shell command that outputs a float
           ("type", `String "number");
           ("description", `String "Initial baseline score. If omitted, measured by running metric_fn once.");
         ]);
+        ("llm_model", `Assoc [
+          ("type", `String "string");
+          ("description", `String "LLM model for code change generation (default: 'glm')");
+        ]);
+        ("target_file", `Assoc [
+          ("type", `String "string");
+          ("description", `String "File that the LLM will read and modify (relative to workdir). \
+The LLM receives the full file, generates a modified version, and writes it back.");
+        ]);
       ]);
-      ("required", `List [`String "goal"; `String "metric_fn"]);
+      ("required", `List [`String "goal"; `String "metric_fn"; `String "target_file"]);
     ];
   };
 
@@ -112,6 +122,27 @@ Useful for directing the research based on human insight.";
       ("required", `List [`String "hypothesis"]);
     ];
   };
+
+  {
+    name = "masc_autoresearch_cycle";
+    description = "Run one experiment cycle of a Karpathy-style autoresearch loop. \
+Steps: read target file -> LLM generates modified code -> measure before -> write file -> \
+git commit -> measure after -> keep if improved (update baseline), git reset --hard HEAD~1 if not. \
+Call this repeatedly to drive the autonomous loop.";
+    input_schema = `Assoc [
+      ("type", `String "object");
+      ("properties", `Assoc [
+        ("loop_id", `Assoc [
+          ("type", `String "string");
+          ("description", `String "Loop ID (optional, uses latest)");
+        ]);
+        ("hypothesis", `Assoc [
+          ("type", `String "string");
+          ("description", `String "Hypothesis to test (optional, auto-generates via LLM if omitted)");
+        ]);
+      ]);
+    ];
+  };
 ]
 
 (* ================================================================ *)
@@ -138,6 +169,48 @@ let latest_loop_id : string option ref = ref None
 let pending_hypotheses : (string, string) Hashtbl.t =
   Hashtbl.create 4
 
+(** Code generator type for test injection.
+    Returns Ok (hypothesis, new_code) or Error reason. *)
+type code_generator =
+  goal:string -> baseline:float ->
+  history:Autoresearch.cycle_record list ->
+  insights:string list ->
+  target_file:string -> file_content:string ->
+  llm_model:string ->
+  (string * string, string) Stdlib.result
+
+(** Per-loop code generator override (for tests). *)
+let custom_generators : (string, code_generator) Hashtbl.t =
+  Hashtbl.create 4
+
+(** Set a custom code generator for a loop (used in tests). *)
+let set_generator loop_id gen =
+  Hashtbl.replace custom_generators loop_id gen
+
+(** Get the code generator for a loop. Falls back to Autoresearch.generate_code_change. *)
+let get_generator loop_id =
+  match Hashtbl.find_opt custom_generators loop_id with
+  | Some gen -> gen
+  | None -> Autoresearch.generate_code_change
+
+(* ================================================================ *)
+(* SSE Broadcast                                                    *)
+(* ================================================================ *)
+
+let broadcast_cycle_result (state : Autoresearch.loop_state) (record : Autoresearch.cycle_record) =
+  try Sse.broadcast (`Assoc [
+    ("type", `String "autoresearch_cycle");
+    ("loop_id", `String state.loop_id);
+    ("cycle", `Int record.cycle);
+    ("hypothesis", `String record.hypothesis);
+    ("decision", `String (Autoresearch.decision_to_string record.decision));
+    ("score_before", `Float record.score_before);
+    ("score_after", `Float record.score_after);
+    ("delta", `Float record.delta);
+    ("baseline", `Float state.baseline);
+    ("best_score", `Float state.best_score);
+  ]) with _ -> ()
+
 (* ================================================================ *)
 (* Handlers                                                         *)
 (* ================================================================ *)
@@ -145,14 +218,23 @@ let pending_hypotheses : (string, string) Hashtbl.t =
 let handle_start ctx args =
   let goal = get_string args "goal" "" in
   let metric_fn = get_string args "metric_fn" "" in
+  let target_file = get_string args "target_file" "" in
   let workdir = get_string args "workdir" ctx.base_path in
   let max_cycles = get_int args "max_cycles" 100 in
   let cycle_timeout_s = get_float args "cycle_timeout_s" 300.0 in
+  let llm_model = get_string args "llm_model" "glm" in
   if goal = "" then
     `Assoc [("error", `String "goal is required")]
   else if metric_fn = "" then
     `Assoc [("error", `String "metric_fn is required")]
+  else if target_file = "" then
+    `Assoc [("error", `String "target_file is required")]
   else begin
+    (* Validate target_file exists *)
+    match Autoresearch.validate_target_file ~workdir target_file with
+    | Error e ->
+      `Assoc [("error", `String (Printf.sprintf "Invalid target_file: %s" e))]
+    | Ok _abs_path ->
     (* Measure initial baseline if not provided *)
     let baseline = match get_float_opt args "baseline" with
       | Some b -> Ok b
@@ -166,7 +248,7 @@ let handle_start ctx args =
       `Assoc [("error", `String (Printf.sprintf "Failed to measure baseline: %s" e))]
     | Ok baseline_val ->
       let state = Autoresearch.create_state
-        ~goal ~metric_fn ~cycle_timeout_s ~max_cycles ~workdir () in
+        ~goal ~metric_fn ~llm_model ~target_file ~cycle_timeout_s ~max_cycles ~workdir () in
       state.baseline <- baseline_val;
       state.best_score <- baseline_val;
       Autoresearch.save_state ~base_path:ctx.base_path state;
@@ -177,6 +259,8 @@ let handle_start ctx args =
         ("status", `String "running");
         ("goal", `String goal);
         ("metric_fn", `String metric_fn);
+        ("target_file", `String target_file);
+        ("llm_model", `String llm_model);
         ("baseline", `Float baseline_val);
         ("max_cycles", `Int max_cycles);
         ("cycle_timeout_s", `Float cycle_timeout_s);
@@ -242,6 +326,168 @@ let handle_inject _ctx args =
           ]
         end
 
+(** Run one experiment cycle: the real Karpathy loop turn.
+    Steps: read file -> generate code change -> fresh metric before ->
+    apply change -> git commit -> metric after -> keep/discard -> persist. *)
+let handle_cycle ctx args =
+  match resolve_loop_id args with
+  | None -> `Assoc [("error", `String "No autoresearch loop running")]
+  | Some id ->
+    match Hashtbl.find_opt active_loops id with
+    | None -> `Assoc [("error", `String (Printf.sprintf "Loop %s not found" id))]
+    | Some state ->
+      if state.status <> Autoresearch.Running then
+        `Assoc [("error", `String "Loop is not running")]
+      else if not (Autoresearch.should_continue state) then begin
+        state.status <- Autoresearch.Completed;
+        Autoresearch.save_state ~base_path:ctx.base_path state;
+        `Assoc [
+          ("loop_id", `String id);
+          ("status", `String "completed");
+          ("reason", `String "max_cycles reached");
+          ("best_score", `Float state.best_score);
+          ("best_cycle", `Int state.best_cycle);
+        ]
+      end else begin
+        let workdir = state.workdir in
+        let timeout_s = state.cycle_timeout_s in
+        let target_file = state.target_file in
+        (* 1. Read target file *)
+        match Autoresearch.validate_target_file ~workdir target_file with
+        | Error e ->
+          `Assoc [
+            ("error", `String (Printf.sprintf "target_file invalid: %s" e));
+            ("loop_id", `String id);
+          ]
+        | Ok abs_path ->
+        let file_content = Autoresearch.read_file abs_path in
+        (* 2. Generate code change: injected hypothesis > arg > LLM *)
+        let code_result =
+          match Hashtbl.find_opt pending_hypotheses id with
+          | Some h ->
+            Hashtbl.remove pending_hypotheses id;
+            (* Injected hypothesis: use it as-is, keep file unchanged *)
+            Ok (h, file_content)
+          | None ->
+            match get_string_opt args "hypothesis" with
+            | Some h -> Ok (h, file_content)
+            | None ->
+              let generate = get_generator id in
+              generate ~goal:state.goal ~baseline:state.baseline
+                ~history:state.history ~insights:state.insights
+                ~target_file ~file_content ~llm_model:state.llm_model
+        in
+        match code_result with
+        | Error e ->
+          `Assoc [
+            ("error", `String (Printf.sprintf "Code generation failed: %s" e));
+            ("loop_id", `String id);
+            ("cycle", `Int state.current_cycle);
+          ]
+        | Ok (hypothesis, new_code) ->
+          (* 3. Measure FRESH score_before *)
+          let before_result = Autoresearch.measure_metric_with_retry
+            ~workdir ~timeout_s state.metric_fn in
+          match before_result with
+          | Error e ->
+            `Assoc [
+              ("error", `String (Printf.sprintf "Pre-metric failed: %s" e));
+              ("loop_id", `String id);
+              ("cycle", `Int state.current_cycle);
+            ]
+          | Ok (score_before, _) ->
+            (* 4. Apply code change to disk *)
+            (match Autoresearch.apply_code_change ~workdir ~target_file ~new_content:new_code with
+             | Error e ->
+               `Assoc [
+                 ("error", `String (Printf.sprintf "apply_code_change failed: %s" e));
+                 ("loop_id", `String id);
+                 ("cycle", `Int state.current_cycle);
+               ]
+             | Ok _original ->
+               (* 5. Git commit (real changes, no --allow-empty) *)
+               let commit_hash = Autoresearch.git_commit_cycle
+                 ~workdir ~cycle:state.current_cycle ~hypothesis ~baseline:score_before in
+               (match commit_hash with
+                | None ->
+                  (* No diff: LLM produced identical code. Discard. *)
+                  let record = Autoresearch.record_cycle state
+                    ~hypothesis ~score_before ~score_after:score_before
+                    ~commit_hash:None ~elapsed_ms:0 ~model_used:state.llm_model in
+                  Autoresearch.append_cycle ~base_path:ctx.base_path state.loop_id record;
+                  state.current_cycle <- state.current_cycle + 1;
+                  Autoresearch.save_state ~base_path:ctx.base_path state;
+                  broadcast_cycle_result state record;
+                  `Assoc [
+                    ("loop_id", `String id);
+                    ("cycle", `Int record.cycle);
+                    ("hypothesis", `String hypothesis);
+                    ("decision", `String "discard");
+                    ("reason", `String "no diff produced");
+                    ("baseline", `Float state.baseline);
+                  ]
+                | Some _ ->
+                  (* 6. Measure score_after *)
+                  let after_result = Autoresearch.measure_metric_with_retry
+                    ~workdir ~timeout_s state.metric_fn in
+                  match after_result with
+                  | Error e ->
+                    (* Metric failed: git reset to undo *)
+                    Autoresearch.git_reset_last ~workdir;
+                    let record = Autoresearch.record_cycle state
+                      ~hypothesis ~score_before ~score_after:score_before
+                      ~commit_hash ~elapsed_ms:0 ~model_used:state.llm_model in
+                    Autoresearch.append_cycle ~base_path:ctx.base_path state.loop_id record;
+                    state.current_cycle <- state.current_cycle + 1;
+                    Autoresearch.save_state ~base_path:ctx.base_path state;
+                    broadcast_cycle_result state record;
+                    `Assoc [
+                      ("loop_id", `String id);
+                      ("cycle", `Int record.cycle);
+                      ("hypothesis", `String hypothesis);
+                      ("decision", `String "discard");
+                      ("reason", `String (Printf.sprintf "metric_fn failed: %s" e));
+                      ("baseline", `Float state.baseline);
+                    ]
+                  | Ok (score_after, elapsed_ms) ->
+                    (* 7. Compare and decide *)
+                    let record = Autoresearch.record_cycle state
+                      ~hypothesis ~score_before ~score_after
+                      ~commit_hash ~elapsed_ms ~model_used:state.llm_model in
+                    (* 8. Keep or discard *)
+                    (match record.decision with
+                     | Autoresearch.Discard ->
+                       (* Karpathy ratchet: git reset --hard HEAD~1 reverts commit + files *)
+                       Autoresearch.git_reset_last ~workdir
+                     | Autoresearch.Keep ->
+                       (* Update baseline to new score *)
+                       state.baseline <- score_after;
+                       if score_after >= state.best_score then
+                         Autoresearch.git_tag_best ~workdir
+                           ~cycle:state.current_cycle ~score:score_after);
+                    (* 9. Persist *)
+                    Autoresearch.append_cycle ~base_path:ctx.base_path state.loop_id record;
+                    state.current_cycle <- state.current_cycle + 1;
+                    Autoresearch.save_state ~base_path:ctx.base_path state;
+                    (* 10. SSE broadcast *)
+                    broadcast_cycle_result state record;
+                    (* 11. Return result *)
+                    `Assoc [
+                      ("loop_id", `String id);
+                      ("cycle", `Int record.cycle);
+                      ("hypothesis", `String hypothesis);
+                      ("score_before", `Float score_before);
+                      ("score_after", `Float score_after);
+                      ("delta", `Float record.delta);
+                      ("decision", `String (Autoresearch.decision_to_string record.decision));
+                      ("commit_hash", match record.commit_hash with
+                        | Some h -> `String h | None -> `Null);
+                      ("baseline", `Float state.baseline);
+                      ("best_score", `Float state.best_score);
+                      ("cycles_remaining", `Int (state.max_cycles - state.current_cycle));
+                    ]))
+      end
+
 (* ================================================================ *)
 (* Dispatch                                                         *)
 (* ================================================================ *)
@@ -263,4 +509,5 @@ let dispatch ctx ~name ~args : result option =
   | "masc_autoresearch_status" -> Some (wrap_result (handle_status ctx args))
   | "masc_autoresearch_stop" -> Some (wrap_result (handle_stop ctx args))
   | "masc_autoresearch_inject" -> Some (wrap_result (handle_inject ctx args))
+  | "masc_autoresearch_cycle" -> Some (wrap_result (handle_cycle ctx args))
   | _ -> None

--- a/test/test_autoresearch.ml
+++ b/test/test_autoresearch.ml
@@ -759,6 +759,31 @@ let test_validate_target_file_empty () =
     check bool "mentions empty" true (AR.contains_substring msg "empty")
   | Ok _ -> fail "expected error for empty target_file"
 
+(* ..foo is a legitimate filename, not path traversal *)
+let test_validate_target_file_dotdot_prefix () =
+  with_tmpdir (fun workdir ->
+    let path = Filename.concat workdir "..foo" in
+    let oc = open_out path in
+    output_string oc "ok\n";
+    close_out oc;
+    match AR.validate_target_file ~workdir "..foo" with
+    | Ok abs_path ->
+      check bool "returns absolute" true (String.get abs_path 0 = '/');
+      check bool "ends with ..foo" true (AR.contains_substring abs_path "..foo")
+    | Error e -> fail ("..foo should be allowed: " ^ e)
+  )
+
+(* symlink pointing outside workdir should be rejected *)
+let test_validate_target_file_symlink_escape () =
+  with_tmpdir (fun workdir ->
+    let link = Filename.concat workdir "escape.py" in
+    Unix.symlink "/etc/hosts" link;
+    match AR.validate_target_file ~workdir "escape.py" with
+    | Error msg ->
+      check bool "mentions symlink" true (AR.contains_substring msg "symlink")
+    | Ok _ -> fail "symlink escaping workdir should be rejected"
+  )
+
 (* ============================================ *)
 (* apply_code_change                            *)
 (* ============================================ *)
@@ -1022,6 +1047,8 @@ let () =
       test_case "absolute" `Quick test_validate_target_file_absolute;
       test_case "ok" `Quick test_validate_target_file_ok;
       test_case "empty" `Quick test_validate_target_file_empty;
+      test_case "dotdot prefix" `Quick test_validate_target_file_dotdot_prefix;
+      test_case "symlink escape" `Quick test_validate_target_file_symlink_escape;
     ]);
     ("apply_code_change", [
       test_case "writes file" `Quick test_apply_code_change_writes;

--- a/test/test_autoresearch.ml
+++ b/test/test_autoresearch.ml
@@ -1,7 +1,8 @@
 (** Autoresearch Module Tests
 
     Tests for autonomous experiment loop types, serialization,
-    state management, storage, and MCP tool dispatch. *)
+    state management, storage, MCP tool dispatch, insights,
+    git helpers, retry, and LLM prompt construction. *)
 
 open Alcotest
 module AR = Masc_mcp.Autoresearch
@@ -15,6 +16,8 @@ let make_state
     ?(loop_id = "ar-test0001")
     ?(goal = "Reduce latency")
     ?(metric_fn = "echo 42.0")
+    ?(llm_model = "glm")
+    ?(target_file = "target.py")
     ?(status = AR.Running)
     ?(current_cycle = 0)
     ?(baseline = 1.0)
@@ -23,6 +26,7 @@ let make_state
     ?(history = [])
     ?(total_keeps = 0)
     ?(total_discards = 0)
+    ?(insights = [])
     ?(cycle_timeout_s = 60.0)
     ?(max_cycles = 10)
     ?(workdir = "/tmp/autoresearch-test")
@@ -32,6 +36,8 @@ let make_state
     loop_id;
     goal;
     metric_fn;
+    llm_model;
+    target_file;
     status;
     error_message = None;
     current_cycle;
@@ -41,6 +47,7 @@ let make_state
     history;
     total_keeps;
     total_discards;
+    insights;
     start_time = now;
     updated_at = now;
     cycle_timeout_s;
@@ -143,7 +150,10 @@ let test_state_to_yojson () =
   check string "status" "running" (json |> member "status" |> to_string);
   check int "current_cycle" 0 (json |> member "current_cycle" |> to_int);
   check (float 0.001) "baseline" 1.0 (json |> member "baseline" |> to_float);
-  check int "max_cycles" 10 (json |> member "max_cycles" |> to_int)
+  check int "max_cycles" 10 (json |> member "max_cycles" |> to_int);
+  check string "llm_model" "glm" (json |> member "llm_model" |> to_string);
+  check string "target_file" "target.py" (json |> member "target_file" |> to_string);
+  check int "insights_count" 0 (json |> member "insights_count" |> to_int)
 
 let test_state_with_error () =
   let state = make_state ~status:AR.Error () in
@@ -161,6 +171,7 @@ let test_create_state () =
   let state = AR.create_state
     ~goal:"Optimize throughput"
     ~metric_fn:"echo 99.9"
+    ~target_file:"model.py"
     ~cycle_timeout_s:120.0
     ~max_cycles:50
     ~workdir:"/tmp/test" () in
@@ -169,11 +180,23 @@ let test_create_state () =
      && String.sub state.loop_id 0 3 = "ar-");
   check string "goal" "Optimize throughput" state.goal;
   check string "metric_fn" "echo 99.9" state.metric_fn;
+  check string "llm_model default" "glm" state.llm_model;
+  check string "target_file" "model.py" state.target_file;
   check bool "status running" true (state.status = AR.Running);
   check int "current_cycle" 0 state.current_cycle;
   check (float 0.001) "baseline" 0.0 state.baseline;
   check int "max_cycles" 50 state.max_cycles;
-  check (float 0.001) "cycle_timeout_s" 120.0 state.cycle_timeout_s
+  check (float 0.001) "cycle_timeout_s" 120.0 state.cycle_timeout_s;
+  check (list string) "insights empty" [] state.insights
+
+let test_create_state_custom_llm () =
+  Mirage_crypto_rng_unix.use_default ();
+  let state = AR.create_state
+    ~goal:"test" ~metric_fn:"echo 1.0" ~llm_model:"claude"
+    ~target_file:"main.py"
+    ~cycle_timeout_s:60.0 ~max_cycles:5 ~workdir:"/tmp/test" () in
+  check string "custom llm_model" "claude" state.llm_model;
+  check string "target_file" "main.py" state.target_file
 
 (* ============================================ *)
 (* record_cycle — Keep vs Discard               *)
@@ -211,7 +234,7 @@ let test_record_cycle_discard () =
   check (float 0.001) "best_score unchanged" 2.0 state.best_score
 
 let test_record_cycle_equal_score () =
-  (* Equal score → Discard (strict improvement required) *)
+  (* Equal score -> Discard (strict improvement required) *)
   let state = make_state ~baseline:1.0 ~best_score:1.0 () in
   let record = AR.record_cycle state
     ~hypothesis:"No change"
@@ -245,6 +268,56 @@ let test_record_cycle_best_tracking () =
     ~commit_hash:None ~elapsed_ms:50 ~model_used:"m");
   check (float 0.001) "best unchanged after discard" 3.0 state.best_score;
   check int "best_cycle unchanged" 1 state.best_cycle
+
+(* ============================================ *)
+(* Insights — FIFO + message format             *)
+(* ============================================ *)
+
+let test_insights_keep_message () =
+  let state = make_state ~baseline:1.0 ~best_score:1.0 () in
+  state.current_cycle <- 3;
+  ignore (AR.record_cycle state
+    ~hypothesis:"batch_size=64"
+    ~score_before:1.0 ~score_after:1.5
+    ~commit_hash:None ~elapsed_ms:50 ~model_used:"m");
+  check int "one insight" 1 (List.length state.insights);
+  let msg = List.hd state.insights in
+  check bool "contains cycle" true (Masc_mcp.Autoresearch.contains_substring msg "Cycle 3");
+  check bool "contains improved" true (Masc_mcp.Autoresearch.contains_substring msg "improved")
+
+let test_insights_discard_message () =
+  let state = make_state ~baseline:2.0 ~best_score:2.0 () in
+  state.current_cycle <- 5;
+  ignore (AR.record_cycle state
+    ~hypothesis:"lr=0.01"
+    ~score_before:2.0 ~score_after:1.8
+    ~commit_hash:None ~elapsed_ms:50 ~model_used:"m");
+  let msg = List.hd state.insights in
+  check bool "contains no improvement" true
+    (Masc_mcp.Autoresearch.contains_substring msg "no improvement")
+
+let test_insights_fifo_limit () =
+  let state = make_state ~baseline:1.0 ~best_score:1.0 () in
+  (* Add 12 cycles to generate 12 insights *)
+  for i = 0 to 11 do
+    state.current_cycle <- i;
+    ignore (AR.record_cycle state
+      ~hypothesis:(Printf.sprintf "h%d" i)
+      ~score_before:(float_of_int i) ~score_after:(float_of_int (i + 1))
+      ~commit_hash:None ~elapsed_ms:50 ~model_used:"m")
+  done;
+  check int "insights capped at 10" 10 (List.length state.insights)
+
+(* ============================================ *)
+(* add_insight direct test                      *)
+(* ============================================ *)
+
+let test_add_insight_basic () =
+  let state = make_state () in
+  AR.add_insight state "test insight 1";
+  AR.add_insight state "test insight 2";
+  check int "two insights" 2 (List.length state.insights);
+  check string "most recent first" "test insight 2" (List.hd state.insights)
 
 (* ============================================ *)
 (* should_continue                              *)
@@ -358,6 +431,91 @@ let test_save_state_creates_file () =
   )
 
 (* ============================================ *)
+(* contains_substring                           *)
+(* ============================================ *)
+
+let test_contains_substring () =
+  check bool "found" true (AR.contains_substring "hello world" "world");
+  check bool "not found" false (AR.contains_substring "hello" "xyz");
+  check bool "empty needle" true (AR.contains_substring "hello" "");
+  check bool "needle too long" false (AR.contains_substring "hi" "hello")
+
+(* ============================================ *)
+(* measure_metric_with_retry                    *)
+(* ============================================ *)
+
+let test_retry_parse_failure_no_retry () =
+  (* Parse failure (not a float) should not retry *)
+  with_tmpdir (fun workdir ->
+    match AR.measure_metric_with_retry ~workdir ~timeout_s:5.0 ~max_retries:2 "echo notanumber" with
+    | Error msg ->
+      check bool "parse error" true (AR.contains_substring msg "not a float")
+    | Ok _ -> fail "expected error for non-float output"
+  )
+
+let test_retry_success_no_retry () =
+  with_tmpdir (fun workdir ->
+    match AR.measure_metric_with_retry ~workdir ~timeout_s:5.0 ~max_retries:2 "echo 42.5" with
+    | Ok (v, _ms) ->
+      check (float 0.001) "value" 42.5 v
+    | Error e -> fail ("unexpected error: " ^ e)
+  )
+
+(* ============================================ *)
+(* git_commit_cycle message format              *)
+(* ============================================ *)
+
+let test_git_commit_cycle_format () =
+  (* git_commit no longer uses --allow-empty, so we must create a real file change *)
+  with_tmpdir (fun workdir ->
+    (* Initialize a git repo with an initial commit *)
+    ignore (Sys.command (Printf.sprintf
+      "cd %s && git init -q -b test-branch && git config user.email 'test@test.com' && git config user.name 'Test' && echo 'init' > init.txt && git add init.txt && git commit -m init -q"
+      (Filename.quote workdir)));
+    (* Create a file change so git_commit_cycle has something to commit *)
+    let oc = open_out (Filename.concat workdir "target.py") in
+    output_string oc "print('hello')";
+    close_out oc;
+    match AR.git_commit_cycle ~workdir ~cycle:5 ~hypothesis:"use dropout" ~baseline:0.85 with
+    | Some hash ->
+      check bool "hash non-empty" true (String.length hash > 0);
+      let cmd = Printf.sprintf "cd %s && git log -1 --format=%%s" (Filename.quote workdir) in
+      let ic = Unix.open_process_in cmd in
+      let msg = Fun.protect ~finally:(fun () ->
+        ignore (Unix.close_process_in ic)
+      ) (fun () -> try input_line ic with End_of_file -> "") in
+      check bool "contains [autoresearch]" true (AR.contains_substring msg "[autoresearch]");
+      check bool "contains cycle 5" true (AR.contains_substring msg "cycle 5");
+      check bool "contains hypothesis" true (AR.contains_substring msg "use dropout")
+    | None -> fail "expected commit hash"
+  )
+
+(* ============================================ *)
+(* build_code_change_prompt                     *)
+(* ============================================ *)
+
+let test_build_code_change_prompt_basic () =
+  let prompt = AR.build_code_change_prompt
+    ~goal:"Reduce latency" ~baseline:0.85 ~history:[] ~insights:[]
+    ~file_content:"print('hello')" ~target_file:"target.py" in
+  check bool "contains goal" true (AR.contains_substring prompt "Reduce latency");
+  check bool "contains baseline" true (AR.contains_substring prompt "0.85");
+  check bool "contains target_file" true (AR.contains_substring prompt "target.py");
+  check bool "contains <current_code>" true (AR.contains_substring prompt "<current_code>");
+  check bool "contains file content" true (AR.contains_substring prompt "print('hello')");
+  check bool "contains <modified_code> instruction" true
+    (AR.contains_substring prompt "<modified_code>")
+
+let test_build_code_change_prompt_with_history () =
+  let history = [make_cycle ~cycle:1 ~hypothesis:"batch=32" ()] in
+  let prompt = AR.build_code_change_prompt
+    ~goal:"test" ~baseline:1.0 ~history ~insights:["prev insight"]
+    ~file_content:"x = 1" ~target_file:"t.py" in
+  check bool "contains history" true (AR.contains_substring prompt "batch=32");
+  check bool "contains insight" true (AR.contains_substring prompt "prev insight");
+  check bool "contains code" true (AR.contains_substring prompt "x = 1")
+
+(* ============================================ *)
 (* Tool dispatch                                *)
 (* ============================================ *)
 
@@ -380,7 +538,7 @@ let test_dispatch_start_missing_goal () =
 
 let test_dispatch_start_missing_metric () =
   let ctx : Tool.context = { base_path = "/tmp" } in
-  let args = `Assoc [("goal", `String "optimize")] in
+  let args = `Assoc [("goal", `String "optimize"); ("target_file", `String "t.py")] in
   match Tool.dispatch ctx ~name:"masc_autoresearch_start" ~args with
   | Some (false, json_str) ->
     let json = Yojson.Safe.from_string json_str in
@@ -456,18 +614,312 @@ let test_dispatch_stop_success () =
   )
 
 (* ============================================ *)
+(* Cycle dispatch                               *)
+(* ============================================ *)
+
+let test_dispatch_cycle_no_loop () =
+  let ctx : Tool.context = { base_path = "/tmp" } in
+  Tool.latest_loop_id := None;
+  Hashtbl.clear Tool.active_loops;
+  match Tool.dispatch ctx ~name:"masc_autoresearch_cycle" ~args:(`Assoc []) with
+  | Some (false, json_str) ->
+    let json = Yojson.Safe.from_string json_str in
+    let open Yojson.Safe.Util in
+    check bool "error for no loop" true
+      (String.length (json |> member "error" |> to_string) > 0)
+  | _ -> fail "expected error for no loop"
+
+let test_dispatch_cycle_stopped_loop () =
+  let ctx : Tool.context = { base_path = "/tmp" } in
+  let state = make_state ~loop_id:"ar-stopped" ~status:AR.Stopped () in
+  Hashtbl.replace Tool.active_loops "ar-stopped" state;
+  Tool.latest_loop_id := Some "ar-stopped";
+  match Tool.dispatch ctx ~name:"masc_autoresearch_cycle" ~args:(`Assoc []) with
+  | Some (false, json_str) ->
+    let json = Yojson.Safe.from_string json_str in
+    let open Yojson.Safe.Util in
+    check bool "error for stopped" true
+      (AR.contains_substring (json |> member "error" |> to_string) "not running")
+  | _ -> fail "expected error for stopped loop"
+
+let test_dispatch_cycle_at_max () =
+  with_tmpdir (fun base_path ->
+    let ctx : Tool.context = { base_path } in
+    let state = make_state ~loop_id:"ar-maxed" ~current_cycle:10 ~max_cycles:10 () in
+    Hashtbl.replace Tool.active_loops "ar-maxed" state;
+    Tool.latest_loop_id := Some "ar-maxed";
+    match Tool.dispatch ctx ~name:"masc_autoresearch_cycle" ~args:(`Assoc []) with
+    | Some (true, json_str) ->
+      let json = Yojson.Safe.from_string json_str in
+      let open Yojson.Safe.Util in
+      check string "status completed" "completed"
+        (json |> member "status" |> to_string)
+    | Some (false, s) -> fail ("unexpected error: " ^ s)
+    | None -> fail "expected Some for cycle tool"
+  )
+
+(* ============================================ *)
 (* Schema validation                            *)
 (* ============================================ *)
 
 let test_schemas_count () =
-  check int "4 tool schemas" 4 (List.length Tool.schemas)
+  check int "5 tool schemas" 5 (List.length Tool.schemas)
 
 let test_schemas_names () =
   let names = List.map (fun (s : Masc_mcp.Types.tool_schema) -> s.name) Tool.schemas in
   check bool "start" true (List.mem "masc_autoresearch_start" names);
   check bool "status" true (List.mem "masc_autoresearch_status" names);
   check bool "stop" true (List.mem "masc_autoresearch_stop" names);
-  check bool "inject" true (List.mem "masc_autoresearch_inject" names)
+  check bool "inject" true (List.mem "masc_autoresearch_inject" names);
+  check bool "cycle" true (List.mem "masc_autoresearch_cycle" names)
+
+let test_schemas_cycle_present () =
+  let names = List.map (fun (s : Masc_mcp.Types.tool_schema) -> s.name) Tool.schemas in
+  let has_cycle = List.exists (fun n -> AR.contains_substring n "cycle") names in
+  check bool "has cycle tool" true has_cycle
+
+(* ============================================ *)
+(* parse_llm_code_response                      *)
+(* ============================================ *)
+
+let test_parse_llm_code_response_ok () =
+  let response =
+    "Some preamble text.\n\
+     <hypothesis>Increase batch size to 64</hypothesis>\n\
+     <modified_code>\n\
+     batch_size = 64\n\
+     train(batch_size)\n\
+     </modified_code>\n\
+     Some trailing text." in
+  match AR.parse_llm_code_response response with
+  | Ok (hyp, code) ->
+    check string "hypothesis" "Increase batch size to 64" hyp;
+    check bool "code contains batch_size" true
+      (AR.contains_substring code "batch_size = 64");
+    check bool "code contains train" true
+      (AR.contains_substring code "train(batch_size)")
+  | Error e -> fail ("unexpected error: " ^ e)
+
+let test_parse_llm_code_response_no_tags () =
+  let response = "Just some random text without any tags." in
+  match AR.parse_llm_code_response response with
+  | Error msg ->
+    check bool "mentions hypothesis" true
+      (AR.contains_substring msg "hypothesis")
+  | Ok _ -> fail "expected error for missing tags"
+
+let test_parse_llm_code_response_empty () =
+  match AR.parse_llm_code_response "" with
+  | Error msg ->
+    check bool "mentions empty" true
+      (AR.contains_substring msg "empty")
+  | Ok _ -> fail "expected error for empty response"
+
+let test_parse_llm_code_response_empty_hypothesis () =
+  let response = "<hypothesis>  </hypothesis><modified_code>x=1</modified_code>" in
+  match AR.parse_llm_code_response response with
+  | Error msg ->
+    check bool "mentions empty hypothesis" true
+      (AR.contains_substring msg "Empty")
+  | Ok _ -> fail "expected error for empty hypothesis"
+
+(* ============================================ *)
+(* validate_target_file                         *)
+(* ============================================ *)
+
+let test_validate_target_file_traversal () =
+  match AR.validate_target_file ~workdir:"/tmp" "../secret" with
+  | Error msg ->
+    check bool "mentions .." true (AR.contains_substring msg "..")
+  | Ok _ -> fail "expected error for path traversal"
+
+let test_validate_target_file_absolute () =
+  match AR.validate_target_file ~workdir:"/tmp" "/etc/passwd" with
+  | Error msg ->
+    check bool "mentions relative" true (AR.contains_substring msg "relative")
+  | Ok _ -> fail "expected error for absolute path"
+
+let test_validate_target_file_ok () =
+  with_tmpdir (fun workdir ->
+    let path = Filename.concat workdir "target.py" in
+    let oc = open_out path in
+    output_string oc "x = 1\n";
+    close_out oc;
+    match AR.validate_target_file ~workdir "target.py" with
+    | Ok abs_path ->
+      check bool "returns absolute" true (String.get abs_path 0 = '/');
+      check bool "ends with target.py" true
+        (AR.contains_substring abs_path "target.py")
+    | Error e -> fail ("unexpected error: " ^ e)
+  )
+
+let test_validate_target_file_empty () =
+  match AR.validate_target_file ~workdir:"/tmp" "" with
+  | Error msg ->
+    check bool "mentions empty" true (AR.contains_substring msg "empty")
+  | Ok _ -> fail "expected error for empty target_file"
+
+(* ============================================ *)
+(* apply_code_change                            *)
+(* ============================================ *)
+
+let test_apply_code_change_writes () =
+  with_tmpdir (fun workdir ->
+    let path = Filename.concat workdir "target.py" in
+    let oc = open_out path in
+    output_string oc "original content\n";
+    close_out oc;
+    match AR.apply_code_change ~workdir ~target_file:"target.py"
+            ~new_content:"modified content\n" with
+    | Ok _ ->
+      let actual = AR.read_file path in
+      check string "file overwritten" "modified content\n" actual
+    | Error e -> fail ("unexpected error: " ^ e)
+  )
+
+let test_apply_code_change_returns_original () =
+  with_tmpdir (fun workdir ->
+    let path = Filename.concat workdir "target.py" in
+    let oc = open_out path in
+    output_string oc "original\n";
+    close_out oc;
+    match AR.apply_code_change ~workdir ~target_file:"target.py"
+            ~new_content:"new\n" with
+    | Ok original ->
+      check string "returns original" "original\n" original
+    | Error e -> fail ("unexpected error: " ^ e)
+  )
+
+(* ============================================ *)
+(* extract_tag                                  *)
+(* ============================================ *)
+
+let test_extract_tag_basic () =
+  let text = "before <hypothesis>my idea</hypothesis> after" in
+  match AR.extract_tag ~tag:"hypothesis" text with
+  | Some content -> check string "tag content" "my idea" content
+  | None -> fail "expected Some"
+
+let test_extract_tag_missing () =
+  let text = "no tags here" in
+  check (option string) "missing tag" None (AR.extract_tag ~tag:"hypothesis" text)
+
+(* ============================================ *)
+(* Integration: full cycle keep/discard         *)
+(* ============================================ *)
+
+(** Helper: set up a temp git repo with a target file and metric script.
+    metric.sh counts lines in target.py → score = line count. *)
+let setup_integration_repo () =
+  let workdir = Filename.temp_dir "ar_integ_" "" in
+  (* Initialize git repo *)
+  ignore (Sys.command (Printf.sprintf
+    "cd %s && git init -q -b ar-work && git config user.email 'test@test.com' && git config user.name 'Test'"
+    (Filename.quote workdir)));
+  (* Create target.py with 3 lines *)
+  let target = Filename.concat workdir "target.py" in
+  let oc = open_out target in
+  output_string oc "line1\nline2\nline3\n";
+  close_out oc;
+  (* Create metric.sh: count lines *)
+  let metric = Filename.concat workdir "metric.sh" in
+  let oc = open_out metric in
+  output_string oc "#!/bin/sh\nwc -l < target.py | tr -d ' '\n";
+  close_out oc;
+  ignore (Sys.command (Printf.sprintf "chmod +x %s" (Filename.quote metric)));
+  (* Initial commit *)
+  ignore (Sys.command (Printf.sprintf
+    "cd %s && git add -A && git commit -q -m 'initial'"
+    (Filename.quote workdir)));
+  workdir
+
+let cleanup_integration_repo workdir =
+  ignore (Sys.command (Printf.sprintf "rm -rf %s" (Filename.quote workdir)))
+
+let test_full_cycle_keep () =
+  let workdir = setup_integration_repo () in
+  Fun.protect ~finally:(fun () -> cleanup_integration_repo workdir) (fun () ->
+    (* Set up state *)
+    let state = make_state
+      ~loop_id:"ar-integ-keep"
+      ~goal:"Maximize line count"
+      ~metric_fn:"sh metric.sh"
+      ~target_file:"target.py"
+      ~workdir
+      ~baseline:3.0
+      ~best_score:3.0
+      () in
+    Hashtbl.replace Tool.active_loops "ar-integ-keep" state;
+    Tool.latest_loop_id := Some "ar-integ-keep";
+    (* Register mock generator: adds a line *)
+    Tool.set_generator "ar-integ-keep"
+      (fun ~goal:_ ~baseline:_ ~history:_ ~insights:_
+           ~target_file:_ ~file_content ~llm_model:_ ->
+        Ok ("Add a line", file_content ^ "line4\n"));
+    let ctx : Tool.context = { base_path = workdir } in
+    match Tool.dispatch ctx ~name:"masc_autoresearch_cycle" ~args:(`Assoc []) with
+    | Some (true, json_str) ->
+      let json = Yojson.Safe.from_string json_str in
+      let open Yojson.Safe.Util in
+      let decision = json |> member "decision" |> to_string in
+      check string "decision is keep" "keep" decision;
+      (* Verify baseline updated *)
+      check (float 0.001) "baseline updated to 4" 4.0 state.baseline;
+      (* Verify commit was kept (not reset) *)
+      let ic = Unix.open_process_in
+        (Printf.sprintf "cd %s && git log --oneline | wc -l | tr -d ' '"
+          (Filename.quote workdir)) in
+      let count = Fun.protect ~finally:(fun () ->
+        ignore (Unix.close_process_in ic)
+      ) (fun () -> try int_of_string (String.trim (input_line ic)) with _ -> 0) in
+      check bool "two commits (init + cycle)" true (count >= 2)
+    | Some (false, e) -> fail ("cycle error: " ^ e)
+    | None -> fail "expected Some for cycle"
+  )
+
+let test_full_cycle_discard () =
+  let workdir = setup_integration_repo () in
+  Fun.protect ~finally:(fun () -> cleanup_integration_repo workdir) (fun () ->
+    let state = make_state
+      ~loop_id:"ar-integ-discard"
+      ~goal:"Maximize line count"
+      ~metric_fn:"sh metric.sh"
+      ~target_file:"target.py"
+      ~workdir
+      ~baseline:3.0
+      ~best_score:3.0
+      () in
+    Hashtbl.replace Tool.active_loops "ar-integ-discard" state;
+    Tool.latest_loop_id := Some "ar-integ-discard";
+    (* Register mock generator: removes a line (score decreases) *)
+    Tool.set_generator "ar-integ-discard"
+      (fun ~goal:_ ~baseline:_ ~history:_ ~insights:_
+           ~target_file:_ ~file_content:_ ~llm_model:_ ->
+        Ok ("Remove a line", "line1\nline2\n"));
+    let ctx : Tool.context = { base_path = workdir } in
+    match Tool.dispatch ctx ~name:"masc_autoresearch_cycle" ~args:(`Assoc []) with
+    | Some (true, json_str) ->
+      let json = Yojson.Safe.from_string json_str in
+      let open Yojson.Safe.Util in
+      let decision = json |> member "decision" |> to_string in
+      check string "decision is discard" "discard" decision;
+      (* Verify baseline unchanged *)
+      check (float 0.001) "baseline unchanged" 3.0 state.baseline;
+      (* Verify file was restored by git reset *)
+      let content = AR.read_file (Filename.concat workdir "target.py") in
+      check bool "file restored" true
+        (AR.contains_substring content "line3");
+      (* Verify only initial commit remains *)
+      let ic = Unix.open_process_in
+        (Printf.sprintf "cd %s && git log --oneline | wc -l | tr -d ' '"
+          (Filename.quote workdir)) in
+      let count = Fun.protect ~finally:(fun () ->
+        ignore (Unix.close_process_in ic)
+      ) (fun () -> try int_of_string (String.trim (input_line ic)) with _ -> 0) in
+      check int "only initial commit" 1 count
+    | Some (false, e) -> fail ("cycle error: " ^ e)
+    | None -> fail "expected Some for cycle"
+  )
 
 (* ============================================ *)
 (* Test runner                                  *)
@@ -494,12 +946,19 @@ let () =
     ]);
     ("create_state", [
       test_case "defaults" `Quick test_create_state;
+      test_case "custom llm" `Quick test_create_state_custom_llm;
     ]);
     ("record_cycle", [
       test_case "keep" `Quick test_record_cycle_keep;
       test_case "discard" `Quick test_record_cycle_discard;
       test_case "equal score" `Quick test_record_cycle_equal_score;
       test_case "best tracking" `Quick test_record_cycle_best_tracking;
+    ]);
+    ("insights", [
+      test_case "keep message" `Quick test_insights_keep_message;
+      test_case "discard message" `Quick test_insights_discard_message;
+      test_case "FIFO limit" `Quick test_insights_fifo_limit;
+      test_case "add_insight basic" `Quick test_add_insight_basic;
     ]);
     ("should_continue", [
       test_case "running" `Quick test_should_continue_running;
@@ -519,6 +978,20 @@ let () =
       test_case "append appends" `Quick test_append_cycle_appends;
       test_case "save state" `Quick test_save_state_creates_file;
     ]);
+    ("contains_substring", [
+      test_case "basic" `Quick test_contains_substring;
+    ]);
+    ("retry", [
+      test_case "parse failure no retry" `Quick test_retry_parse_failure_no_retry;
+      test_case "success no retry" `Quick test_retry_success_no_retry;
+    ]);
+    ("git_helpers", [
+      test_case "commit_cycle format" `Quick test_git_commit_cycle_format;
+    ]);
+    ("code_change_prompt", [
+      test_case "basic" `Quick test_build_code_change_prompt_basic;
+      test_case "with history" `Quick test_build_code_change_prompt_with_history;
+    ]);
     ("tool_dispatch", [
       test_case "unknown tool" `Quick test_dispatch_unknown_returns_none;
       test_case "start missing goal" `Quick test_dispatch_start_missing_goal;
@@ -528,8 +1001,38 @@ let () =
       test_case "inject success" `Quick test_dispatch_inject_success;
       test_case "stop success" `Quick test_dispatch_stop_success;
     ]);
+    ("cycle_dispatch", [
+      test_case "no loop" `Quick test_dispatch_cycle_no_loop;
+      test_case "stopped loop" `Quick test_dispatch_cycle_stopped_loop;
+      test_case "at max cycles" `Quick test_dispatch_cycle_at_max;
+    ]);
     ("schemas", [
       test_case "count" `Quick test_schemas_count;
       test_case "names" `Quick test_schemas_names;
+      test_case "cycle present" `Quick test_schemas_cycle_present;
+    ]);
+    ("parse_llm_code_response", [
+      test_case "ok" `Quick test_parse_llm_code_response_ok;
+      test_case "no tags" `Quick test_parse_llm_code_response_no_tags;
+      test_case "empty" `Quick test_parse_llm_code_response_empty;
+      test_case "empty hypothesis" `Quick test_parse_llm_code_response_empty_hypothesis;
+    ]);
+    ("validate_target_file", [
+      test_case "traversal" `Quick test_validate_target_file_traversal;
+      test_case "absolute" `Quick test_validate_target_file_absolute;
+      test_case "ok" `Quick test_validate_target_file_ok;
+      test_case "empty" `Quick test_validate_target_file_empty;
+    ]);
+    ("apply_code_change", [
+      test_case "writes file" `Quick test_apply_code_change_writes;
+      test_case "returns original" `Quick test_apply_code_change_returns_original;
+    ]);
+    ("extract_tag", [
+      test_case "basic" `Quick test_extract_tag_basic;
+      test_case "missing" `Quick test_extract_tag_missing;
+    ]);
+    ("integration", [
+      test_case "full cycle keep" `Quick test_full_cycle_keep;
+      test_case "full cycle discard" `Quick test_full_cycle_discard;
     ]);
   ]

--- a/test/test_autoresearch.ml
+++ b/test/test_autoresearch.ml
@@ -477,7 +477,7 @@ let test_git_commit_cycle_format () =
     output_string oc "print('hello')";
     close_out oc;
     match AR.git_commit_cycle ~workdir ~cycle:5 ~hypothesis:"use dropout" ~baseline:0.85 with
-    | Some hash ->
+    | Ok (Some hash) ->
       check bool "hash non-empty" true (String.length hash > 0);
       let cmd = Printf.sprintf "cd %s && git log -1 --format=%%s" (Filename.quote workdir) in
       let ic = Unix.open_process_in cmd in
@@ -487,7 +487,8 @@ let test_git_commit_cycle_format () =
       check bool "contains [autoresearch]" true (AR.contains_substring msg "[autoresearch]");
       check bool "contains cycle 5" true (AR.contains_substring msg "cycle 5");
       check bool "contains hypothesis" true (AR.contains_substring msg "use dropout")
-    | None -> fail "expected commit hash"
+    | Ok None -> fail "expected commit hash, got Ok None (no diff)"
+    | Error e -> fail (Printf.sprintf "expected commit hash, got Error: %s" e)
   )
 
 (* ============================================ *)
@@ -784,6 +785,17 @@ let test_validate_target_file_symlink_escape () =
     | Ok _ -> fail "symlink escaping workdir should be rejected"
   )
 
+(* A directory path should be rejected — only regular files are valid *)
+let test_validate_target_file_directory () =
+  with_tmpdir (fun workdir ->
+    let dir = Filename.concat workdir "subdir" in
+    Unix.mkdir dir 0o755;
+    match AR.validate_target_file ~workdir "subdir" with
+    | Error msg ->
+      check bool "mentions directory" true (AR.contains_substring msg "directory")
+    | Ok _ -> fail "directory should be rejected as target_file"
+  )
+
 (* ============================================ *)
 (* apply_code_change                            *)
 (* ============================================ *)
@@ -1049,6 +1061,7 @@ let () =
       test_case "empty" `Quick test_validate_target_file_empty;
       test_case "dotdot prefix" `Quick test_validate_target_file_dotdot_prefix;
       test_case "symlink escape" `Quick test_validate_target_file_symlink_escape;
+      test_case "directory" `Quick test_validate_target_file_directory;
     ]);
     ("apply_code_change", [
       test_case "writes file" `Quick test_apply_code_change_writes;


### PR DESCRIPTION
## Summary

- **연극에서 실전으로**: LLM이 target file을 읽고, 수정된 코드를 디스크에 쓰고, git commit → metric 측정 → keep/discard하는 Karpathy-style 루프 구현
- `Llm_client.complete` 사용 (raw curl 대체), `target_file` 필드 추가, `--allow-empty` 제거
- 14개 신규 테스트 (12 unit + 2 integration), 총 61개 통과

## 3가지 치명적 결함 수정

| # | 결함 | Before | After |
|---|------|--------|-------|
| 1 | 코드 미적용 | 가설 텍스트만 생성, `--allow-empty` | LLM이 파일 읽기 → 수정 코드 반환 → 파일 쓰기 |
| 2 | stale score_before | `state.baseline` 사용 | 매 cycle fresh `metric_fn` 측정 |
| 3 | 기존 모듈 재발명 | raw curl | `Llm_client.complete` |

## Test plan

- [x] `dune build` 성공
- [x] `dune exec test/test_autoresearch.exe` — 61 tests pass
- [x] `make test` — full regression pass
- [x] CI checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)