### PR TITLE
fix(session): transition orphan sessions to Interrupted on restart

### DIFF
--- a/lib/team_session_engine_eio.ml
+++ b/lib/team_session_engine_eio.ml
@@ -1820,39 +1820,51 @@ let recover_running_sessions ~sw ~(clock : _ Eio.Time.clock)
   let now = Time_compat.now () in
   List.iter
     (fun (session : Team_session_types.session) ->
-      if session.status = Team_session_types.Running && session.auto_resume then
-        if now >= session.planned_end_at then
+      if session.status = Team_session_types.Running then begin
+        if session.auto_resume then begin
+          if now >= session.planned_end_at then
+            ignore
+              (finalize_session ~config ~session_id:session.session_id
+                 ~final_status:Team_session_types.Completed
+                 ~reason:"duration_elapsed_during_restart" ~generate_report:true)
+          else
+            let should_start =
+              with_runtimes_lock (fun () ->
+                  if Hashtbl.mem runtimes session.session_id then
+                    false
+                  else (
+                    Hashtbl.replace runtimes session.session_id
+                      {
+                        stop_requested = false;
+                        stop_reason = None;
+                        finalizing = false;
+                        generate_report_on_finalize = true;
+                      };
+                    true))
+            in
+            if should_start then begin
+              Team_session_store.append_event config session.session_id
+                ~event_type:"recovered_after_restart"
+                ~detail:
+                  (`Assoc
+                    [
+                      ( "remaining_sec",
+                        `Int
+                          (int_of_float (session.planned_end_at -. now)) );
+                      ("ts_iso", `String (now_iso ()));
+                    ]);
+              start_runtime_loop ~sw ~clock ~config
+                ~session_id:session.session_id
+            end
+        end else begin
+          Printf.eprintf
+            "[team_session] orphan session %s (auto_resume=false): \
+             transitioning to Interrupted\n%!"
+            session.session_id;
           ignore
             (finalize_session ~config ~session_id:session.session_id
-               ~final_status:Team_session_types.Completed
-               ~reason:"duration_elapsed_during_restart" ~generate_report:true)
-        else
-          let should_start =
-            with_runtimes_lock (fun () ->
-                if Hashtbl.mem runtimes session.session_id then
-                  false
-                else (
-                  Hashtbl.replace runtimes session.session_id
-                    {
-                      stop_requested = false;
-                      stop_reason = None;
-                      finalizing = false;
-                      generate_report_on_finalize = true;
-                    };
-                  true))
-          in
-          if should_start then begin
-            Team_session_store.append_event config session.session_id
-              ~event_type:"recovered_after_restart"
-              ~detail:
-                (`Assoc
-                  [
-                    ( "remaining_sec",
-                      `Int
-                        (int_of_float (session.planned_end_at -. now)) );
-                    ("ts_iso", `String (now_iso ()));
-                  ]);
-            start_runtime_loop ~sw ~clock ~config
-              ~session_id:session.session_id
-          end)
+               ~final_status:Team_session_types.Interrupted
+               ~reason:"no_auto_resume_on_restart" ~generate_report:true)
+        end
+      end)
     sessions

--- a/test/test_tool_team_session.ml
+++ b/test/test_tool_team_session.ml
@@ -380,6 +380,83 @@ let test_recover_elapsed_session () =
        (Team_session_store.report_json_path config session_id));
   cleanup_dir base_dir
 
+let test_recover_orphan_session () =
+  Eio_main.run @@ fun env ->
+  Eio.Switch.run @@ fun sw ->
+  let base_dir = temp_dir () in
+  let config = Room.default_config base_dir in
+  ignore (Room.init config ~agent_name:(Some "tester"));
+  let session_id = Team_session_store.make_session_id () in
+  let now = Time_compat.now () in
+  Team_session_store.ensure_session_dirs config session_id;
+  let session : Team_session_types.session =
+    {
+      session_id;
+      goal = "test orphan cleanup";
+      created_by = "tester";
+      room_id = "default";
+      status = Team_session_types.Running;
+      duration_seconds = 60;
+      execution_scope = Team_session_types.Observe_only;
+      checkpoint_interval_sec = 10;
+      min_agents = 1;
+      orchestration_mode = Team_session_types.Assist;
+      communication_mode = Team_session_types.Comm_broadcast;
+      scale_profile = Team_session_types.Scale_standard;
+      control_profile = Team_session_types.Control_flat;
+      model_cascade = [ "glm:glm-5" ];
+      fallback_policy = Team_session_types.Fallback_cascade_then_task;
+      instruction_profile = Team_session_types.Profile_standard;
+      alert_channel = Team_session_types.Alert_both;
+      auto_resume = false;
+      report_formats = [ Team_session_types.Markdown; Team_session_types.Json ];
+      turn_count = 0;
+      agent_names = [ "tester" ];
+      planned_workers = [];
+      broadcast_count = 0;
+      portal_count = 0;
+      cascade_attempted = 0;
+      cascade_success = 0;
+      cascade_failed = 0;
+      fallback_task_created = 0;
+      min_agents_violation_streak = 0;
+      policy_violations = [];
+      baseline_done_counts = [];
+      final_done_delta_total = None;
+      final_done_delta_by_agent = None;
+      started_at = now -. 120.0;
+      planned_end_at = now +. 3600.0;
+      stopped_at = None;
+      last_checkpoint_at = Some (now -. 30.0);
+      last_event_at = Some (now -. 30.0);
+      last_turn_at = None;
+      stop_reason = None;
+      generated_report = false;
+      artifacts_dir = Team_session_store.session_dir config session_id;
+      created_at_iso = Types.now_iso ();
+      updated_at_iso = Types.now_iso ();
+    }
+  in
+  Team_session_store.save_session config session;
+  Team_session_engine_eio.recover_running_sessions ~sw
+    ~clock:(Eio.Stdenv.clock env) ~config;
+  let rec wait_loaded attempts =
+    if attempts <= 0 then
+      failwith "orphan session not transitioned after recover"
+    else
+      match Team_session_store.load_session config session_id with
+      | Some s -> s
+      | None ->
+          Eio.Time.sleep (Eio.Stdenv.clock env) 0.05;
+          wait_loaded (attempts - 1)
+  in
+  let reloaded = wait_loaded 100 in
+  Alcotest.(check string) "orphan becomes interrupted" "interrupted"
+    (Team_session_types.status_to_string reloaded.status);
+  Alcotest.(check string) "stop reason" "no_auto_resume_on_restart"
+    (Option.value ~default:"" reloaded.stop_reason);
+  cleanup_dir base_dir
+
 let test_read_events_limit () =
   let base_dir = temp_dir () in
   let config = Room.default_config base_dir in
@@ -2348,6 +2425,8 @@ let () =
             test_duration_reached_path;
           Alcotest.test_case "recover-elapsed-session" `Quick
             test_recover_elapsed_session;
+          Alcotest.test_case "recover-orphan-session" `Quick
+            test_recover_orphan_session;
           Alcotest.test_case "read-events-limit" `Quick
             test_read_events_limit;
           Alcotest.test_case "list-and-compare" `Quick test_list_and_compare;


### PR DESCRIPTION
## Summary
- `recover_running_sessions`에서 `auto_resume=false && status=Running` 세션을 `Interrupted`로 전이
- 서버 재시작 후 phantom Running 세션이 대시보드에 잔류하는 문제 해결 (Gap A from swarm-64 plan)
- `finalize_session`은 runtimes 해시테이블 항목 없이도 안전하게 동작

## Changes
- `lib/team_session_engine_eio.ml`: `recover_running_sessions`에 `auto_resume=false` 분기 추가 (~10줄)
- `test/test_tool_team_session.ml`: `test_recover_orphan_session` 테스트 추가 (auto_resume=false → Interrupted 전이 검증)

## Test plan
- [x] `test_recover_orphan_session` 통과 (auto_resume=false → Interrupted, stop_reason="no_auto_resume_on_restart")
- [x] `test_recover_elapsed_session` 기존 테스트 통과 (auto_resume=true, 만료 → Completed)
- [x] `dune build` 성공

🤖 Generated with [Claude Code](https://claude.com/claude-code)