### PR TITLE
feat(team-session): swarm state persistence — Gap B + Gap C

### DIFF
--- a/lib/team_session_engine_eio.ml
+++ b/lib/team_session_engine_eio.ml
@@ -1843,16 +1843,46 @@ let recover_running_sessions ~sw ~(clock : _ Eio.Time.clock)
                     true))
             in
             if should_start then begin
+              let checkpoint_detail =
+                match
+                  Team_session_store.load_latest_checkpoint config
+                    session.session_id
+                with
+                | None -> [ ("last_checkpoint", `Null) ]
+                | Some cp ->
+                    [
+                      ( "last_checkpoint",
+                        Team_session_types.checkpoint_to_yojson cp );
+                      ("progress_at_restart", `Float cp.progress_pct);
+                      ("done_at_restart", `Int cp.done_delta_total);
+                    ]
+              in
+              let recent_events =
+                Team_session_store.read_recent_events config
+                  session.session_id ~max_count:10
+              in
+              let event_context =
+                [
+                  ( "recent_events_before_restart",
+                    `List
+                      (List.map Team_session_types.event_entry_to_yojson
+                         recent_events) );
+                  ( "event_count_before_restart",
+                    `Int (List.length recent_events) );
+                ]
+              in
               Team_session_store.append_event config session.session_id
                 ~event_type:"recovered_after_restart"
                 ~detail:
                   (`Assoc
-                    [
-                      ( "remaining_sec",
-                        `Int
-                          (int_of_float (session.planned_end_at -. now)) );
-                      ("ts_iso", `String (now_iso ()));
-                    ]);
+                    ([
+                       ( "remaining_sec",
+                         `Int
+                           (int_of_float (session.planned_end_at -. now))
+                       );
+                       ("ts_iso", `String (now_iso ()));
+                     ]
+                    @ checkpoint_detail @ event_context));
               start_runtime_loop ~sw ~clock ~config
                 ~session_id:session.session_id
             end

--- a/lib/team_session_store.ml
+++ b/lib/team_session_store.ml
@@ -145,6 +145,27 @@ let list_checkpoint_paths config session_id =
     |> List.sort String.compare
     |> List.map (Filename.concat dir)
 
+let load_latest_checkpoint config session_id : Team_session_types.checkpoint option =
+  match List.rev (list_checkpoint_paths config session_id) with
+  | [] -> None
+  | latest :: _ -> (
+      try
+        let json = read_json config latest in
+        match Team_session_types.checkpoint_of_yojson json with
+        | Ok cp -> Some cp
+        | Error _ -> None
+      with _ -> None)
+
+let read_recent_events config session_id ~max_count :
+    Team_session_types.event_entry list =
+  let raw = read_events ~max_events:max_count config session_id in
+  List.filter_map
+    (fun json ->
+      match Team_session_types.event_entry_of_yojson json with
+      | Ok e -> Some e
+      | Error _ -> None)
+    raw
+
 let list_sessions config : Team_session_types.session list =
   let root = sessions_root config in
   if not (path_exists config root) then

--- a/lib/team_session_store.ml
+++ b/lib/team_session_store.ml
@@ -153,18 +153,28 @@ let load_latest_checkpoint config session_id : Team_session_types.checkpoint opt
         let json = read_json config latest in
         match Team_session_types.checkpoint_of_yojson json with
         | Ok cp -> Some cp
-        | Error _ -> None
-      with _ -> None)
+        | Error e ->
+            Printf.eprintf "[team_session] checkpoint parse error (%s): %s\n%!" latest e;
+            None
+      with exn ->
+        Printf.eprintf "[team_session] checkpoint load error (%s): %s\n%!" latest
+          (Printexc.to_string exn);
+        None)
 
 let read_recent_events config session_id ~max_count :
     Team_session_types.event_entry list =
-  let raw = read_events ~max_events:max_count config session_id in
-  List.filter_map
-    (fun json ->
-      match Team_session_types.event_entry_of_yojson json with
-      | Ok e -> Some e
-      | Error _ -> None)
-    raw
+  try
+    let raw = read_events ~max_events:max_count config session_id in
+    List.filter_map
+      (fun json ->
+        match Team_session_types.event_entry_of_yojson json with
+        | Ok e -> Some e
+        | Error _ -> None)
+      raw
+  with exn ->
+    Printf.eprintf "[team_session] read_recent_events error (%s): %s\n%!"
+      session_id (Printexc.to_string exn);
+    []
 
 let list_sessions config : Team_session_types.session list =
   let root = sessions_root config in

--- a/lib/team_session_types.ml
+++ b/lib/team_session_types.ml
@@ -963,6 +963,36 @@ let event_entry_to_yojson (e : event_entry) =
       ("detail", e.detail);
     ]
 
+let checkpoint_of_yojson (json : Yojson.Safe.t) : (checkpoint, string) result =
+  try
+    Ok
+      {
+        ts = json |> member "ts" |> to_float;
+        ts_iso = json |> member "ts_iso" |> to_string;
+        status =
+          json |> member "status" |> to_string |> status_of_string;
+        elapsed_sec = json |> member "elapsed_sec" |> to_int;
+        remaining_sec = json |> member "remaining_sec" |> to_int;
+        progress_pct = json |> member "progress_pct" |> to_float;
+        done_delta_total = json |> member "done_delta_total" |> to_int;
+        done_delta_by_agent =
+          assoc_int_of_json (json |> member "done_delta_by_agent");
+        active_agents =
+          json |> member "active_agents" |> to_list |> List.map to_string;
+      }
+  with exn -> Error (Printexc.to_string exn)
+
+let event_entry_of_yojson (json : Yojson.Safe.t) : (event_entry, string) result =
+  try
+    Ok
+      {
+        ts = json |> member "ts" |> to_float;
+        ts_iso = json |> member "ts_iso" |> to_string;
+        event_type = json |> member "event_type" |> to_string;
+        detail = json |> member "detail";
+      }
+  with exn -> Error (Printexc.to_string exn)
+
 let checkpoint_to_yojson (c : checkpoint) =
   `Assoc
     [

--- a/test/dune
+++ b/test/dune
@@ -306,6 +306,11 @@
  (libraries masc_mcp alcotest str yojson unix))
 
 (test
+ (name test_swarm_persistence)
+ (modules test_swarm_persistence)
+ (libraries masc_mcp alcotest yojson unix))
+
+(test
  (name test_tool_team_session)
  (modules test_tool_team_session)
  (libraries masc_mcp alcotest yojson unix eio eio_main))

--- a/test/test_swarm_persistence.ml
+++ b/test/test_swarm_persistence.ml
@@ -1,0 +1,179 @@
+(** Swarm State Persistence tests (Gap B + Gap C).
+
+    - checkpoint_of_yojson roundtrip
+    - load_latest_checkpoint (empty / populated)
+    - event_entry_of_yojson roundtrip
+    - read_recent_events (empty / max_count cap)
+*)
+
+open Masc_mcp
+
+let temp_dir () =
+  let dir = Filename.temp_file "test_swarm_persist_" "" in
+  Unix.unlink dir;
+  Unix.mkdir dir 0o755;
+  dir
+
+let cleanup_dir dir =
+  let rec rm path =
+    if Sys.file_exists path then
+      if Sys.is_directory path then (
+        Array.iter (fun name -> rm (Filename.concat path name)) (Sys.readdir path);
+        Unix.rmdir path)
+      else Unix.unlink path
+  in
+  try rm dir with _ -> ()
+
+(* ── Gap B: checkpoint roundtrip ─────────────────────────────── *)
+
+let sample_checkpoint : Team_session_types.checkpoint =
+  {
+    ts = 1700000000.0;
+    ts_iso = "2023-11-14T22:13:20.000Z";
+    status = Team_session_types.Running;
+    elapsed_sec = 120;
+    remaining_sec = 480;
+    progress_pct = 25.0;
+    done_delta_total = 3;
+    done_delta_by_agent = [ ("alice", 2); ("bob", 1) ];
+    active_agents = [ "alice"; "bob" ];
+  }
+
+let test_checkpoint_roundtrip () =
+  let json = Team_session_types.checkpoint_to_yojson sample_checkpoint in
+  match Team_session_types.checkpoint_of_yojson json with
+  | Error e -> Alcotest.fail ("roundtrip failed: " ^ e)
+  | Ok cp ->
+      Alcotest.(check (float 0.01)) "ts" sample_checkpoint.ts cp.ts;
+      Alcotest.(check string) "ts_iso" sample_checkpoint.ts_iso cp.ts_iso;
+      Alcotest.(check string) "status" "running"
+        (Team_session_types.status_to_string cp.status);
+      Alcotest.(check int) "elapsed_sec" 120 cp.elapsed_sec;
+      Alcotest.(check int) "remaining_sec" 480 cp.remaining_sec;
+      Alcotest.(check (float 0.01)) "progress_pct" 25.0 cp.progress_pct;
+      Alcotest.(check int) "done_delta_total" 3 cp.done_delta_total;
+      Alcotest.(check int) "agent count" 2 (List.length cp.done_delta_by_agent);
+      Alcotest.(check int) "active count" 2 (List.length cp.active_agents)
+
+let test_checkpoint_of_invalid_json () =
+  match Team_session_types.checkpoint_of_yojson (`String "garbage") with
+  | Error _ -> ()
+  | Ok _ -> Alcotest.fail "should fail on invalid json"
+
+(* ── Gap B: load_latest_checkpoint ───────────────────────────── *)
+
+let test_load_latest_checkpoint_empty () =
+  let base = temp_dir () in
+  Fun.protect ~finally:(fun () -> cleanup_dir base) (fun () ->
+      let config = Room.default_config base in
+      let sid = "test-sess-empty" in
+      Team_session_store.ensure_session_dirs config sid;
+      match Team_session_store.load_latest_checkpoint config sid with
+      | None -> ()
+      | Some _ -> Alcotest.fail "expected None for empty checkpoints dir")
+
+let test_load_latest_checkpoint_returns_latest () =
+  let base = temp_dir () in
+  Fun.protect ~finally:(fun () -> cleanup_dir base) (fun () ->
+      let config = Room.default_config base in
+      let sid = "test-sess-ckpt" in
+      Team_session_store.ensure_session_dirs config sid;
+      (* Write two checkpoints with different timestamps *)
+      let cp1 = { sample_checkpoint with ts = 1700000001.0; progress_pct = 10.0 } in
+      let cp2 = { sample_checkpoint with ts = 1700000002.0; progress_pct = 75.0 } in
+      Team_session_store.write_checkpoint config sid cp1;
+      Team_session_store.write_checkpoint config sid cp2;
+      match Team_session_store.load_latest_checkpoint config sid with
+      | None -> Alcotest.fail "expected Some for populated checkpoints dir"
+      | Some cp ->
+          (* cp2 has higher timestamp → last in sorted order *)
+          Alcotest.(check (float 0.01)) "latest progress_pct" 75.0 cp.progress_pct)
+
+(* ── Gap C: event_entry roundtrip ────────────────────────────── *)
+
+let test_event_entry_roundtrip () =
+  let entry : Team_session_types.event_entry =
+    {
+      ts = 1700000000.0;
+      ts_iso = "2023-11-14T22:13:20.000Z";
+      event_type = "test_event";
+      detail = `Assoc [ ("key", `String "value") ];
+    }
+  in
+  let json = Team_session_types.event_entry_to_yojson entry in
+  match Team_session_types.event_entry_of_yojson json with
+  | Error e -> Alcotest.fail ("event roundtrip failed: " ^ e)
+  | Ok e ->
+      Alcotest.(check (float 0.01)) "ts" entry.ts e.ts;
+      Alcotest.(check string) "event_type" "test_event" e.event_type;
+      Alcotest.(check string) "ts_iso" entry.ts_iso e.ts_iso
+
+let test_event_entry_of_invalid_json () =
+  match Team_session_types.event_entry_of_yojson (`Int 42) with
+  | Error _ -> ()
+  | Ok _ -> Alcotest.fail "should fail on invalid json"
+
+(* ── Gap C: read_recent_events ───────────────────────────────── *)
+
+let test_read_recent_events_empty () =
+  let base = temp_dir () in
+  Fun.protect ~finally:(fun () -> cleanup_dir base) (fun () ->
+      let config = Room.default_config base in
+      let sid = "test-sess-no-events" in
+      Team_session_store.ensure_session_dirs config sid;
+      let events =
+        Team_session_store.read_recent_events config sid ~max_count:5
+      in
+      Alcotest.(check int) "empty events" 0 (List.length events))
+
+let test_read_recent_events_capped () =
+  let base = temp_dir () in
+  Fun.protect ~finally:(fun () -> cleanup_dir base) (fun () ->
+      let config = Room.default_config base in
+      let sid = "test-sess-events" in
+      Team_session_store.ensure_session_dirs config sid;
+      (* Write 10 events *)
+      for i = 1 to 10 do
+        Team_session_store.append_event config sid
+          ~event_type:(Printf.sprintf "evt_%d" i)
+          ~detail:(`Assoc [ ("i", `Int i) ])
+      done;
+      let events =
+        Team_session_store.read_recent_events config sid ~max_count:5
+      in
+      Alcotest.(check int) "capped at 5" 5 (List.length events);
+      (* Should be the last 5 events (evt_6..evt_10) *)
+      let first = List.hd events in
+      Alcotest.(check string) "first is evt_6" "evt_6" first.event_type;
+      let last = List.nth events 4 in
+      Alcotest.(check string) "last is evt_10" "evt_10" last.event_type)
+
+(* ── Runner ──────────────────────────────────────────────────── *)
+
+let () =
+  Alcotest.run "Swarm Persistence (Gap B+C)"
+    [
+      ( "checkpoint_roundtrip",
+        [
+          Alcotest.test_case "to/of_yojson" `Quick test_checkpoint_roundtrip;
+          Alcotest.test_case "invalid json" `Quick test_checkpoint_of_invalid_json;
+        ] );
+      ( "load_latest_checkpoint",
+        [
+          Alcotest.test_case "empty dir → None" `Quick
+            test_load_latest_checkpoint_empty;
+          Alcotest.test_case "returns latest" `Quick
+            test_load_latest_checkpoint_returns_latest;
+        ] );
+      ( "event_entry_roundtrip",
+        [
+          Alcotest.test_case "to/of_yojson" `Quick test_event_entry_roundtrip;
+          Alcotest.test_case "invalid json" `Quick test_event_entry_of_invalid_json;
+        ] );
+      ( "read_recent_events",
+        [
+          Alcotest.test_case "empty → []" `Quick test_read_recent_events_empty;
+          Alcotest.test_case "capped at max_count" `Quick
+            test_read_recent_events_capped;
+        ] );
+    ]


### PR DESCRIPTION
## Summary

Dashboard Ops 진단 시리즈의 연장. Gap A (#739) 이후 남은 두 가지 Gap을 구현합니다.

### Gap B: Checkpoint 읽기 + Recovery Event 보강
- `checkpoint_of_yojson` 추가 — checkpoint 파일이 write-only에서 read/write로 전환
- `load_latest_checkpoint` — 가장 최근 checkpoint를 로드
- recovery event에 `last_checkpoint`, `progress_at_restart`, `done_at_restart` 필드 추가

### Gap C: Event Replay로 세션 연속성 확보
- `event_entry_of_yojson` 추가 — events.jsonl 역직렬화
- `read_recent_events` — 최근 N개 이벤트를 파싱된 구조체로 반환
- recovery event에 `recent_events_before_restart`, `event_count_before_restart` 추가

### 변경 파일
- `lib/team_session_types.ml` — `checkpoint_of_yojson`, `event_entry_of_yojson`
- `lib/team_session_store.ml` — `load_latest_checkpoint`, `read_recent_events`
- `lib/team_session_engine_eio.ml` — recovery event detail 보강
- `test/test_swarm_persistence.ml` — 8개 테스트 (새 파일)

## Test plan

- [x] `test_checkpoint_roundtrip` — to/of_yojson 왕복 검증
- [x] `test_checkpoint_of_invalid_json` — 잘못된 JSON 에러 처리
- [x] `test_load_latest_checkpoint_empty` — 빈 디렉토리 → None
- [x] `test_load_latest_checkpoint_returns_latest` — 최신 checkpoint 반환
- [x] `test_event_entry_roundtrip` — event entry 왕복 검증
- [x] `test_event_entry_of_invalid_json` — 잘못된 JSON 에러 처리
- [x] `test_read_recent_events_empty` — 빈 이벤트 → []
- [x] `test_read_recent_events_capped` — max_count 제한 검증
- [x] 기존 30개 team session 테스트 통과 (331s)
- [x] 기존 54개 checkpoint types 테스트 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)