### PR TITLE
chore: CHANGELOG for v2.80.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [2.80.0] - 2026-03-11
 
 ### Added
+- **Swarm State Persistence (Gap B+C)** — `checkpoint_of_yojson`, `event_entry_of_yojson`, `load_latest_checkpoint`, `read_recent_events`; recovery events now carry checkpoint state and recent event history (#751)
 - **Karpathy Autoresearch Phase 2.5** — real autonomous experiment loop with expanded runtime control (#736)
 
 ### Changed
-- LLM runtime calls consolidated behind `Llm_client` abstraction (#741)
+- LLM runtime calls consolidated behind `Llm_client` abstraction (#741, #745, #746)
 - Contract truth and shared runtime context restored across dashboard/server flows (#743)
+- `tool_keeper.ml` and `tool_trpg.ml` split into smaller focused modules (#744)
+- Runtime singleton state collapsed into shared context (#749)
+- Dashboard oversized components split (Phase D) (#747)
+- Dashboard Side Rail normalized to Korean with `refreshForTab` helper (#750)
 
 ### Fixed
 - Orphan sessions now transition to `Interrupted` on restart instead of lingering in stale state (#739)


### PR DESCRIPTION
## Summary
- CHANGELOG.md에 v2.80.0 누락 항목 추가 (PRs #744-#751)
- Swarm State Persistence (Gap B+C), LLM cascade 통합, 모듈 분할, dashboard 개선

## Test plan
- [x] CHANGELOG 형식 확인 (Keep a Changelog)
- [x] 모든 PR 번호가 실제 머지된 PR과 일치

🤖 Generated with [Claude Code](https://claude.com/claude-code)