### PR TITLE
refactor: extract command plane http routes

### DIFF
--- a/bin/main_eio.ml
+++ b/bin/main_eio.ml
@@ -44,6 +44,7 @@ module Tool_mdal = Masc_mcp.Tool_mdal
 module Tool_board = Masc_mcp.Tool_board
 module Process_eio = Masc_mcp.Process_eio
 module Mdal = Masc_mcp.Mdal
+module Server_command_plane_http = Masc_mcp.Server_command_plane_http
 
 (** MCP Protocol Versions *)
 (* ============================================ *)
@@ -5855,86 +5856,6 @@ let operator_confirm_http_json ~state ~sw ~clock request ~args =
 let operator_error_json message =
   `Assoc [ ("status", `String "error"); ("message", `String message) ]
 
-let assoc_add key value = function
-  | `Assoc fields -> `Assoc ((key, value) :: List.remove_assoc key fields)
-  | json -> `Assoc [ ("payload", json); (key, value) ]
-
-let command_plane_summary_http_json ~state =
-  let config = state.Mcp_server.room_config in
-  let summary = Command_plane_v2.summary_json config in
-  let swarm_status =
-    if Room.is_initialized config then
-      Masc_mcp.Swarm_status.build_json ~timeline_limit_override:6 config
-    else
-      Masc_mcp.Swarm_status.empty_json
-  in
-  summary
-  |> assoc_add "swarm_status" swarm_status
-
-let command_plane_snapshot_http_json ~state =
-  let config = state.Mcp_server.room_config in
-  let snapshot = Command_plane_v2.snapshot_json config in
-  let swarm_status =
-    if Room.is_initialized config then
-      Masc_mcp.Swarm_status.build_json_from_snapshot config snapshot
-    else
-      Masc_mcp.Swarm_status.empty_json
-  in
-  snapshot
-  |> assoc_add "swarm_status" swarm_status
-
-let command_plane_topology_http_json ~state =
-  Command_plane_v2.topology_json state.Mcp_server.room_config
-
-let command_plane_units_http_json ~state =
-  Command_plane_v2.list_units_json state.Mcp_server.room_config
-
-let command_plane_operations_http_json ~state request =
-  let operation_id = query_param request "operation_id" in
-  Command_plane_v2.operation_status_json state.Mcp_server.room_config ?operation_id ()
-
-let command_plane_detachments_http_json ~state request =
-  let operation_id = query_param request "operation_id" in
-  let detachment_id = query_param request "detachment_id" in
-  Command_plane_v2.list_detachments_json state.Mcp_server.room_config ?operation_id
-    ?detachment_id
-
-let command_plane_detachment_status_http_json ~state request =
-  let args =
-    `Assoc
-      [
-        ( "detachment_id",
-          match query_param request "detachment_id" with
-          | Some value -> `String value
-          | None -> `Null );
-      ]
-  in
-  Command_plane_v2.detachment_status_json state.Mcp_server.room_config args
-
-let command_plane_decisions_http_json ~state request =
-  let decision_id = query_param request "decision_id" in
-  Command_plane_v2.list_policy_decisions_json state.Mcp_server.room_config ?decision_id
-
-let command_plane_capacity_http_json ~state =
-  Command_plane_v2.capacity_json state.Mcp_server.room_config
-
-let command_plane_alerts_http_json ~state =
-  Command_plane_v2.list_alerts_json state.Mcp_server.room_config
-
-let command_plane_traces_http_json ~state request =
-  let operation_id = query_param request "operation_id" in
-  let limit = int_query_param request "limit" ~default:25 |> clamp ~min_v:1 ~max_v:200 in
-  Command_plane_v2.list_traces_json state.Mcp_server.room_config ?operation_id ~limit ()
-
-let command_plane_swarm_http_json ~state request =
-  let run_id = query_param request "run_id" in
-  let operation_id = query_param request "operation_id" in
-  Command_plane_v2.swarm_live_json state.Mcp_server.room_config ?run_id
-    ?operation_id ()
-
-let command_plane_actor request =
-  Option.value ~default:"dashboard" (operator_actor_hint request)
-
 (** Shared runtime access for MCP handlers.
     main_eio delegates to the shared Eio_context instead of storing another
     copy of switch/clock/net state. *)
@@ -5942,925 +5863,169 @@ let get_switch () = Masc_mcp.Eio_context.get_switch ()
 let get_clock () = Masc_mcp.Eio_context.get_clock ()
 let get_net () = Masc_mcp.Eio_context.get_net ()
 
-let command_plane_tool_ctx ~state request : (_, _) Masc_mcp.Tool_command_plane.context =
+let command_plane_http_deps : Server_command_plane_http.deps =
   {
-    config = state.Mcp_server.room_config;
-    agent_name = command_plane_actor request;
-    sw = Some (get_switch ());
-    clock = Some (get_clock ());
-    net = Some (get_net ());
-    mcp_state = Some state;
-    mcp_session_id = get_session_id_any request;
-    auth_token = auth_token_from_request request;
+    query_param;
+    int_query_param;
+    operator_actor_hint;
+    get_session_id_any;
+    auth_token_from_request;
+    get_switch;
+    get_clock;
+    get_net;
+    get_origin;
+    cors_headers;
   }
 
-let tool_command_plane_http_json ~state request ~name ~args =
-  match Masc_mcp.Tool_command_plane.dispatch (command_plane_tool_ctx ~state request) ~name ~args with
-  | Some (true, payload) -> (
-      try Ok (Yojson.Safe.from_string payload)
-      with Yojson.Json_error message -> Error ("invalid tool json: " ^ message))
-  | Some (false, payload) -> (
-      try
-        match Yojson.Safe.from_string payload with
-        | `Assoc fields -> (
-            match List.assoc_opt "message" fields with
-            | Some (`String message) -> Error message
-            | _ -> Error payload)
-        | _ -> Error payload
-      with Yojson.Json_error _ -> Error payload)
-  | None -> Error ("unsupported command-plane tool: " ^ name)
+let command_plane_summary_http_json ~state =
+  Server_command_plane_http.command_plane_summary_http_json ~state
+
+let command_plane_snapshot_http_json ~state =
+  Server_command_plane_http.command_plane_snapshot_http_json ~state
+
+let command_plane_topology_http_json ~state =
+  Server_command_plane_http.command_plane_topology_http_json ~state
+
+let command_plane_units_http_json ~state =
+  Server_command_plane_http.command_plane_units_http_json ~state
+
+let command_plane_operations_http_json ~state request =
+  Server_command_plane_http.command_plane_operations_http_json
+    ~deps:command_plane_http_deps ~state request
+
+let command_plane_detachments_http_json ~state request =
+  Server_command_plane_http.command_plane_detachments_http_json
+    ~deps:command_plane_http_deps ~state request
+
+let command_plane_detachment_status_http_json ~state request =
+  Server_command_plane_http.command_plane_detachment_status_http_json
+    ~deps:command_plane_http_deps ~state request
+
+let command_plane_decisions_http_json ~state request =
+  Server_command_plane_http.command_plane_decisions_http_json
+    ~deps:command_plane_http_deps ~state request
+
+let command_plane_capacity_http_json ~state =
+  Server_command_plane_http.command_plane_capacity_http_json ~state
+
+let command_plane_alerts_http_json ~state =
+  Server_command_plane_http.command_plane_alerts_http_json ~state
+
+let command_plane_traces_http_json ~state request =
+  Server_command_plane_http.command_plane_traces_http_json
+    ~deps:command_plane_http_deps ~state request
+
+let command_plane_swarm_http_json ~state request =
+  Server_command_plane_http.command_plane_swarm_http_json
+    ~deps:command_plane_http_deps ~state request
 
 let command_plane_unit_define_http_json ~state request ~args =
-  Command_plane_v2.unit_update_json state.Mcp_server.room_config
-    ~actor:(command_plane_actor request) args
+  Server_command_plane_http.command_plane_unit_define_http_json
+    ~deps:command_plane_http_deps ~state request ~args
 
 let command_plane_operation_start_http_json ~state request ~args =
-  tool_command_plane_http_json ~state request ~name:"masc_operation_start" ~args
+  Server_command_plane_http.command_plane_operation_start_http_json
+    ~deps:command_plane_http_deps ~state request ~args
 
 let command_plane_chain_summary_http_json ~state request =
-  tool_command_plane_http_json ~state request ~name:"masc_chain_snapshot"
-    ~args:(`Assoc [])
+  Server_command_plane_http.command_plane_chain_summary_http_json
+    ~deps:command_plane_http_deps ~state request
 
 let command_plane_chain_run_http_json ~state request run_id =
-  tool_command_plane_http_json ~state request ~name:"masc_chain_run_get"
-    ~args:(`Assoc [ ("run_id", `String run_id) ])
+  Server_command_plane_http.command_plane_chain_run_http_json
+    ~deps:command_plane_http_deps ~state request run_id
 
 let chain_http_error_status message =
-  let starts_with ~prefix value =
-    let prefix_len = String.length prefix in
-    String.length value >= prefix_len
-    && String.equal (String.sub value 0 prefix_len) prefix
-  in
-  if starts_with ~prefix:"invalid chain run_id:" message then
-    `Bad_request
-  else if starts_with ~prefix:"chain run not found:" message then
-    `Not_found
-  else
-    `Bad_gateway
-
-let stream_native_chain_events_http ~request reqd =
-  let origin = get_origin request in
-  let headers =
-    Httpun.Headers.of_list
-      ([
-         ("content-type", "text/event-stream");
-         ("cache-control", "no-cache");
-         ("connection", "keep-alive");
-         ("x-accel-buffering", "no");
-       ]
-      @ cors_headers origin)
-  in
-  let response = Httpun.Response.create ~headers `OK in
-  let writer = Httpun.Reqd.respond_with_streaming reqd response in
-  let mutex = Eio.Mutex.create () in
-  let closed = ref false in
-  let sub_ref : Masc_mcp.Chain_telemetry.subscription option ref = ref None in
-  let log_chain_sse message =
-    Printf.eprintf "[chain-sse] %s\n%!" message
-  in
-  let close_stream ?reason () =
-    let sub_to_remove, should_close =
-      Eio.Mutex.use_rw ~protect:true mutex (fun () ->
-          let sub = !sub_ref in
-          sub_ref := None;
-          if !closed then
-            (sub, false)
-          else (
-            closed := true;
-            (sub, true)))
-    in
-    Option.iter Masc_mcp.Chain_telemetry.unsubscribe sub_to_remove;
-    if should_close then (
-      Option.iter log_chain_sse reason;
-      try
-        if not (Httpun.Body.Writer.is_closed writer) then Httpun.Body.Writer.close writer
-      with Invalid_argument _ -> ())
-  in
-  let send_raw frame =
-    let write_result =
-      Eio.Mutex.use_rw ~protect:true mutex (fun () ->
-          if !closed || Httpun.Body.Writer.is_closed writer then
-            `Closed
-          else
-            try
-              Httpun.Body.Writer.write_string writer frame;
-              Httpun.Body.Writer.flush writer (fun _ -> ());
-              `Sent
-            with exn -> `Error exn)
-    in
-    match write_result with
-    | `Sent -> true
-    | `Closed ->
-        close_stream ();
-        false
-    | `Error exn ->
-        close_stream ~reason:(Printf.sprintf "stream write failed: %s" (Printexc.to_string exn)) ();
-        false
-  in
-  (try
-     let sub =
-       Masc_mcp.Chain_telemetry.subscribe (fun event ->
-           let payload =
-             Masc_mcp.Chain_native_eio.chain_event_json event
-             |> Yojson.Safe.to_string
-           in
-           let frame =
-             Masc_mcp.Sse.format_event
-               ~event_type:(Masc_mcp.Chain_native_eio.chain_event_name event)
-               payload
-           in
-           ignore (send_raw frame))
-     in
-     Eio.Mutex.use_rw ~protect:true mutex (fun () -> sub_ref := Some sub);
-     if send_raw ": native chain stream\nretry: 3000\n\n" then
-       Eio.Fiber.fork ~sw:(get_switch ()) (fun () ->
-           try
-             while not !closed do
-               Eio.Time.sleep (get_clock ()) 30.0;
-               if not (send_raw ": keepalive\n\n") then close_stream ()
-             done
-           with exn ->
-             close_stream
-               ~reason:
-                 (Printf.sprintf "keepalive loop failed: %s"
-                    (Printexc.to_string exn))
-               ())
-     else
-       close_stream ~reason:"initial stream write failed" ()
-   with exn ->
-     close_stream
-       ~reason:
-         (Printf.sprintf "subscription setup failed: %s" (Printexc.to_string exn))
-       ())
-
-let proxy_chain_events_http ~request reqd =
-  let endpoint = Masc_mcp.Llm_client_eio.resolve_endpoint () in
-  let path = Masc_mcp.Llm_client_eio.endpoint_path endpoint "/chain/events" in
-  let origin = get_origin request in
-  let headers =
-    Httpun.Headers.of_list
-      ([
-         ("content-type", "text/event-stream");
-         ("cache-control", "no-cache");
-         ("connection", "keep-alive");
-         ("x-accel-buffering", "no");
-       ]
-      @ cors_headers origin)
-  in
-  let response = Httpun.Response.create ~headers `OK in
-  let writer = Httpun.Reqd.respond_with_streaming reqd response in
-  let upstream_request =
-    let auth_header =
-      match endpoint.api_key with
-      | Some value -> [ Printf.sprintf "Authorization: Bearer %s" value ]
-      | None -> []
-    in
-    Printf.sprintf "GET %s HTTP/1.1\r\nHost: %s:%d\r\nAccept: text/event-stream\r\nCache-Control: no-cache\r\nConnection: close\r\n%s\r\n\r\n"
-      path endpoint.host endpoint.port
-      (String.concat "\r\n" auth_header)
-  in
-  Eio.Fiber.fork ~sw:(get_switch ()) (fun () ->
-      let safe_close () =
-        try Httpun.Body.Writer.close writer with Invalid_argument _ -> ()
-      in
-      let send_error message =
-        (try
-           let payload =
-             Printf.sprintf "event: error\ndata: {\"message\":%s}\n\n"
-               (Yojson.Safe.to_string (`String message))
-           in
-           Httpun.Body.Writer.write_string writer payload;
-           Httpun.Body.Writer.flush writer ignore
-         with _ -> ());
-        safe_close ()
-      in
-      try
-        Eio.Net.with_tcp_connect ~host:endpoint.host
-          ~service:(string_of_int endpoint.port) (get_net ())
-        @@ fun flow ->
-        Eio.Flow.copy_string upstream_request flow;
-        let header_buf = Buffer.create 4096 in
-        let rec read_headers () =
-          let chunk = Cstruct.create 2048 in
-          match Eio.Flow.single_read flow chunk with
-          | n ->
-              Buffer.add_string header_buf (Cstruct.to_string ~len:n chunk);
-              let current = Buffer.contents header_buf in
-              (try
-                 let idx = Str.search_forward (Str.regexp "\r\n\r\n") current 0 in
-                 let headers_part = String.sub current 0 idx in
-                 let body_start = idx + 4 in
-                 let body_rest =
-                   if body_start >= String.length current then ""
-                   else
-                     String.sub current body_start (String.length current - body_start)
-                 in
-                 Ok (headers_part, body_rest)
-               with Not_found -> read_headers ())
-          | exception End_of_file ->
-              Error "llm-mcp closed chain/events stream before headers were received"
-        in
-        match read_headers () with
-        | Error message -> send_error message
-        | Ok (headers_part, body_rest) ->
-            let status_line =
-              match String.split_on_char '\n' headers_part with
-              | line :: _ -> String.trim line
-              | [] -> "HTTP/1.1 502 Bad Gateway"
-            in
-            let status_code =
-              match String.split_on_char ' ' status_line with
-              | _http :: code :: _ -> (try int_of_string code with _ -> 502)
-              | _ -> 502
-            in
-            if status_code < 200 || status_code >= 300 then
-              send_error
-                (Printf.sprintf "llm-mcp /chain/events upstream returned %d"
-                   status_code)
-            else (
-              if body_rest <> "" then (
-                Httpun.Body.Writer.write_string writer body_rest;
-                Httpun.Body.Writer.flush writer ignore);
-              let rec pump () =
-                let chunk = Cstruct.create 4096 in
-                match Eio.Flow.single_read flow chunk with
-                | n ->
-                    Httpun.Body.Writer.write_string writer
-                      (Cstruct.to_string ~len:n chunk);
-                    Httpun.Body.Writer.flush writer ignore;
-                    pump ()
-                | exception End_of_file -> safe_close ()
-                | exception exn -> send_error (Printexc.to_string exn)
-              in
-              pump ())
-      with exn -> send_error (Printexc.to_string exn))
+  Server_command_plane_http.chain_http_error_status message
 
 let command_plane_chain_events_http ~request reqd =
-  match Masc_mcp.Tool_command_plane.chain_backend () with
-  | Masc_mcp.Tool_command_plane.Native -> stream_native_chain_events_http ~request reqd
-  | Masc_mcp.Tool_command_plane.Compat_llm_mcp ->
-      proxy_chain_events_http ~request reqd
-
-let stream_native_chain_events_h2 ~request h2_reqd =
-  let origin = get_origin request in
-  let headers =
-    H2.Headers.of_list
-      ([
-         ("content-type", "text/event-stream");
-         ("cache-control", "no-cache");
-         ("x-accel-buffering", "no");
-       ]
-      @ cors_headers origin)
-  in
-  let response = H2.Response.create ~headers `OK in
-  let writer =
-    H2.Reqd.respond_with_streaming ~flush_headers_immediately:true h2_reqd response
-  in
-  let mutex = Eio.Mutex.create () in
-  let closed = ref false in
-  let sub_ref : Masc_mcp.Chain_telemetry.subscription option ref = ref None in
-  let log_chain_sse message =
-    Printf.eprintf "[chain-sse/h2] %s\n%!" message
-  in
-  let close_stream ?reason () =
-    let sub_to_remove, should_close =
-      Eio.Mutex.use_rw ~protect:true mutex (fun () ->
-          let sub = !sub_ref in
-          sub_ref := None;
-          if !closed then
-            (sub, false)
-          else (
-            closed := true;
-            (sub, true)))
-    in
-    Option.iter Masc_mcp.Chain_telemetry.unsubscribe sub_to_remove;
-    if should_close then (
-      Option.iter log_chain_sse reason;
-      try
-        if not (H2.Body.Writer.is_closed writer) then H2.Body.Writer.close writer
-      with Invalid_argument _ -> ())
-  in
-  let send_raw frame =
-    let write_result =
-      Eio.Mutex.use_rw ~protect:true mutex (fun () ->
-          if !closed || H2.Body.Writer.is_closed writer then
-            `Closed
-          else
-            try
-              H2.Body.Writer.write_string writer frame;
-              H2.Body.Writer.flush writer (fun _ -> ());
-              `Sent
-            with exn -> `Error exn)
-    in
-    match write_result with
-    | `Sent -> true
-    | `Closed ->
-        close_stream ();
-        false
-    | `Error exn ->
-        close_stream
-          ~reason:
-            (Printf.sprintf "stream write failed: %s" (Printexc.to_string exn))
-          ();
-        false
-  in
-  (try
-     let sub =
-       Masc_mcp.Chain_telemetry.subscribe (fun event ->
-           let payload =
-             Masc_mcp.Chain_native_eio.chain_event_json event
-             |> Yojson.Safe.to_string
-           in
-           let frame =
-             Masc_mcp.Sse.format_event
-               ~event_type:(Masc_mcp.Chain_native_eio.chain_event_name event)
-               payload
-           in
-           ignore (send_raw frame))
-     in
-     Eio.Mutex.use_rw ~protect:true mutex (fun () -> sub_ref := Some sub);
-     if send_raw ": native chain stream\nretry: 3000\n\n" then
-       Eio.Fiber.fork ~sw:(get_switch ()) (fun () ->
-           try
-             while not !closed do
-               Eio.Time.sleep (get_clock ()) 30.0;
-               if not (send_raw ": keepalive\n\n") then close_stream ()
-             done
-           with exn ->
-             close_stream
-               ~reason:
-                 (Printf.sprintf "keepalive loop failed: %s"
-                    (Printexc.to_string exn))
-               ())
-     else
-       close_stream ~reason:"initial stream write failed" ()
-   with exn ->
-     close_stream
-       ~reason:
-         (Printf.sprintf "subscription setup failed: %s" (Printexc.to_string exn))
-       ())
-
-let proxy_chain_events_h2 ~request h2_reqd =
-  let endpoint = Masc_mcp.Llm_client_eio.resolve_endpoint () in
-  let path = Masc_mcp.Llm_client_eio.endpoint_path endpoint "/chain/events" in
-  let origin = get_origin request in
-  let headers =
-    H2.Headers.of_list
-      ([
-         ("content-type", "text/event-stream");
-         ("cache-control", "no-cache");
-         ("x-accel-buffering", "no");
-       ]
-      @ cors_headers origin)
-  in
-  let response = H2.Response.create ~headers `OK in
-  let writer =
-    H2.Reqd.respond_with_streaming ~flush_headers_immediately:true h2_reqd response
-  in
-  let upstream_request =
-    let auth_header =
-      match endpoint.api_key with
-      | Some value -> [ Printf.sprintf "Authorization: Bearer %s" value ]
-      | None -> []
-    in
-    Printf.sprintf
-      "GET %s HTTP/1.1\r\nHost: %s:%d\r\nAccept: text/event-stream\r\nCache-Control: no-cache\r\nConnection: close\r\n%s\r\n\r\n"
-      path endpoint.host endpoint.port
-      (String.concat "\r\n" auth_header)
-  in
-  Eio.Fiber.fork ~sw:(get_switch ()) (fun () ->
-      let safe_close () =
-        try H2.Body.Writer.close writer with Invalid_argument _ -> ()
-      in
-      let send_error message =
-        (try
-           let payload =
-             Printf.sprintf "event: error\ndata: {\"message\":%s}\n\n"
-               (Yojson.Safe.to_string (`String message))
-           in
-           H2.Body.Writer.write_string writer payload;
-           H2.Body.Writer.flush writer ignore
-         with _ -> ());
-        safe_close ()
-      in
-      try
-        Eio.Net.with_tcp_connect ~host:endpoint.host
-          ~service:(string_of_int endpoint.port) (get_net ())
-        @@ fun flow ->
-        Eio.Flow.copy_string upstream_request flow;
-        let header_buf = Buffer.create 4096 in
-        let rec read_headers () =
-          let chunk = Cstruct.create 2048 in
-          match Eio.Flow.single_read flow chunk with
-          | n ->
-              Buffer.add_string header_buf (Cstruct.to_string ~len:n chunk);
-              let current = Buffer.contents header_buf in
-              (try
-                 let idx = Str.search_forward (Str.regexp "\r\n\r\n") current 0 in
-                 let headers_part = String.sub current 0 idx in
-                 let body_start = idx + 4 in
-                 let body_rest =
-                   if body_start >= String.length current then ""
-                   else
-                     String.sub current body_start
-                       (String.length current - body_start)
-                 in
-                 Ok (headers_part, body_rest)
-               with Not_found -> read_headers ())
-          | exception End_of_file ->
-              Error "llm-mcp closed chain/events stream before headers were received"
-        in
-        match read_headers () with
-        | Error message -> send_error message
-        | Ok (headers_part, body_rest) ->
-            let status_line =
-              match String.split_on_char '\n' headers_part with
-              | line :: _ -> String.trim line
-              | [] -> "HTTP/1.1 502 Bad Gateway"
-            in
-            let status_code =
-              match String.split_on_char ' ' status_line with
-              | _http :: code :: _ -> (try int_of_string code with _ -> 502)
-              | _ -> 502
-            in
-            if status_code < 200 || status_code >= 300 then
-              send_error
-                (Printf.sprintf "llm-mcp /chain/events upstream returned %d"
-                   status_code)
-            else (
-              if String.length body_rest > 0 then (
-                H2.Body.Writer.write_string writer body_rest;
-                H2.Body.Writer.flush writer ignore);
-              let rec pump () =
-                let chunk = Cstruct.create 4096 in
-                match Eio.Flow.single_read flow chunk with
-                | n when n > 0 ->
-                    H2.Body.Writer.write_bigstring writer
-                      ~off:0 ~len:n
-                      (Cstruct.to_bigarray chunk);
-                    H2.Body.Writer.flush writer ignore;
-                    pump ()
-                | _ -> safe_close ()
-                | exception End_of_file -> safe_close ()
-                | exception exn -> send_error (Printexc.to_string exn)
-              in
-              pump ())
-      with exn -> send_error (Printexc.to_string exn))
+  Server_command_plane_http.command_plane_chain_events_http
+    ~deps:command_plane_http_deps ~request reqd
 
 let command_plane_chain_events_h2 ~request h2_reqd =
-  match Masc_mcp.Tool_command_plane.chain_backend () with
-  | Masc_mcp.Tool_command_plane.Native -> stream_native_chain_events_h2 ~request h2_reqd
-  | Masc_mcp.Tool_command_plane.Compat_llm_mcp ->
-      proxy_chain_events_h2 ~request h2_reqd
+  Server_command_plane_http.command_plane_chain_events_h2
+    ~deps:command_plane_http_deps ~request h2_reqd
 
 let command_plane_operation_checkpoint_http_json ~state request ~args =
-  match
-    Command_plane_v2.checkpoint_operation state.Mcp_server.room_config
-      ~actor:(command_plane_actor request) args
-  with
-  | Ok operation ->
-      Ok
-        (`Assoc
-          [
-            ("status", `String "ok");
-            ("result", Command_plane_v2.operation_to_json operation);
-            ( "traces",
-              Command_plane_v2.list_traces_json state.Mcp_server.room_config
-                ~operation_id:operation.operation_id () );
-          ])
-  | Error message -> Error message
-  | exception Invalid_argument message -> Error message
+  Server_command_plane_http.command_plane_operation_checkpoint_http_json
+    ~deps:command_plane_http_deps ~state request ~args
 
 let command_plane_unit_reparent_http_json ~state request ~args =
-  Command_plane_v2.unit_reparent_json state.Mcp_server.room_config
-    ~actor:(command_plane_actor request) args
+  Server_command_plane_http.command_plane_unit_reparent_http_json
+    ~deps:command_plane_http_deps ~state request ~args
 
 let command_plane_unit_reassign_http_json ~state request ~args =
-  Command_plane_v2.unit_reassign_json state.Mcp_server.room_config
-    ~actor:(command_plane_actor request) args
+  Server_command_plane_http.command_plane_unit_reassign_http_json
+    ~deps:command_plane_http_deps ~state request ~args
 
 let command_plane_operation_pause_http_json ~state request ~args =
-  Command_plane_v2.pause_operation_json state.Mcp_server.room_config
-    ~actor:(command_plane_actor request) args
+  Server_command_plane_http.command_plane_operation_pause_http_json
+    ~deps:command_plane_http_deps ~state request ~args
 
 let command_plane_operation_resume_http_json ~state request ~args =
-  Command_plane_v2.resume_operation_json state.Mcp_server.room_config
-    ~actor:(command_plane_actor request) args
+  Server_command_plane_http.command_plane_operation_resume_http_json
+    ~deps:command_plane_http_deps ~state request ~args
 
 let command_plane_operation_stop_http_json ~state request ~args =
-  Command_plane_v2.stop_operation_json state.Mcp_server.room_config
-    ~actor:(command_plane_actor request) args
+  Server_command_plane_http.command_plane_operation_stop_http_json
+    ~deps:command_plane_http_deps ~state request ~args
 
 let command_plane_operation_finalize_http_json ~state request ~args =
-  Command_plane_v2.finalize_operation_json state.Mcp_server.room_config
-    ~actor:(command_plane_actor request) args
+  Server_command_plane_http.command_plane_operation_finalize_http_json
+    ~deps:command_plane_http_deps ~state request ~args
 
-let command_plane_dispatch_plan_http_json ~state _request ~args =
-  Ok (Command_plane_v2.dispatch_plan_json state.Mcp_server.room_config args)
+let command_plane_dispatch_plan_http_json ~state request ~args =
+  Server_command_plane_http.command_plane_dispatch_plan_http_json ~state request
+    ~args
 
 let command_plane_dispatch_assign_http_json ~state request ~args =
-  Command_plane_v2.dispatch_assign_json state.Mcp_server.room_config
-    ~actor:(command_plane_actor request) args
+  Server_command_plane_http.command_plane_dispatch_assign_http_json
+    ~deps:command_plane_http_deps ~state request ~args
 
 let command_plane_dispatch_rebalance_http_json ~state request ~args =
-  Command_plane_v2.dispatch_rebalance_json state.Mcp_server.room_config
-    ~actor:(command_plane_actor request) args
+  Server_command_plane_http.command_plane_dispatch_rebalance_http_json
+    ~deps:command_plane_http_deps ~state request ~args
 
 let command_plane_dispatch_escalate_http_json ~state request ~args =
-  Command_plane_v2.dispatch_escalate_json state.Mcp_server.room_config
-    ~actor:(command_plane_actor request) args
+  Server_command_plane_http.command_plane_dispatch_escalate_http_json
+    ~deps:command_plane_http_deps ~state request ~args
 
 let command_plane_dispatch_recall_http_json ~state request ~args =
-  Command_plane_v2.dispatch_recall_json state.Mcp_server.room_config
-    ~actor:(command_plane_actor request) args
+  Server_command_plane_http.command_plane_dispatch_recall_http_json
+    ~deps:command_plane_http_deps ~state request ~args
 
 let command_plane_dispatch_tick_http_json ~state request ~args =
-  Command_plane_v2.dispatch_tick_json state.Mcp_server.room_config
-    ~actor:(command_plane_actor request) args
+  Server_command_plane_http.command_plane_dispatch_tick_http_json
+    ~deps:command_plane_http_deps ~state request ~args
 
 let command_plane_policy_status_http_json ~state =
-  Command_plane_v2.policy_status_json state.Mcp_server.room_config
+  Server_command_plane_http.command_plane_policy_status_http_json ~state
 
 let command_plane_policy_approve_http_json ~state request ~args =
-  Command_plane_v2.policy_approve_json state.Mcp_server.room_config
-    ~actor:(command_plane_actor request) args
+  Server_command_plane_http.command_plane_policy_approve_http_json
+    ~deps:command_plane_http_deps ~state request ~args
 
 let command_plane_policy_deny_http_json ~state request ~args =
-  Command_plane_v2.policy_deny_json state.Mcp_server.room_config
-    ~actor:(command_plane_actor request) args
+  Server_command_plane_http.command_plane_policy_deny_http_json
+    ~deps:command_plane_http_deps ~state request ~args
 
 let command_plane_policy_update_http_json ~state request ~args =
-  Command_plane_v2.policy_update_json state.Mcp_server.room_config
-    ~actor:(command_plane_actor request) args
+  Server_command_plane_http.command_plane_policy_update_http_json
+    ~deps:command_plane_http_deps ~state request ~args
 
 let command_plane_policy_freeze_http_json ~state request ~args =
-  Command_plane_v2.policy_freeze_unit_json state.Mcp_server.room_config
-    ~actor:(command_plane_actor request) args
+  Server_command_plane_http.command_plane_policy_freeze_http_json
+    ~deps:command_plane_http_deps ~state request ~args
 
 let command_plane_policy_kill_switch_http_json ~state request ~args =
-  Command_plane_v2.policy_kill_switch_json state.Mcp_server.room_config
-    ~actor:(command_plane_actor request) args
+  Server_command_plane_http.command_plane_policy_kill_switch_http_json
+    ~deps:command_plane_http_deps ~state request ~args
 
 let command_plane_help_http_json () =
-  let str_list values = `List (List.map (fun value -> `String value) values) in
-  let concept ~id ~title ~summary =
-    `Assoc
-      [
-        ("id", `String id);
-        ("title", `String title);
-        ("summary", `String summary);
-      ]
-  in
-  let step ~id ~title ~tool ~summary ~success_signals ~pitfalls =
-    `Assoc
-      [
-        ("id", `String id);
-        ("title", `String title);
-        ("tool", `String tool);
-        ("summary", `String summary);
-        ("success_signals", str_list success_signals);
-        ("pitfalls", str_list pitfalls);
-      ]
-  in
-  let path ~id ~title ~summary ~when_to_use ~steps =
-    `Assoc
-      [
-        ("id", `String id);
-        ("title", `String title);
-        ("summary", `String summary);
-        ("when_to_use", `String when_to_use);
-        ("steps", `List steps);
-      ]
-  in
-  let tool_group ~id ~title ~description ~tools =
-    `Assoc
-      [
-        ("id", `String id);
-        ("title", `String title);
-        ("description", `String description);
-        ("tools", str_list tools);
-      ]
-  in
-  let pitfall ~id ~title ~symptom ~why ~fix_tool ~fix_summary =
-    `Assoc
-      [
-        ("id", `String id);
-        ("title", `String title);
-        ("symptom", `String symptom);
-        ("why", `String why);
-        ("fix_tool", `String fix_tool);
-        ("fix_summary", `String fix_summary);
-      ]
-  in
-  let example ~id ~title ~path_id ~transport ~request ~response ~notes =
-    `Assoc
-      [
-        ("id", `String id);
-        ("title", `String title);
-        ("path_id", `String path_id);
-        ("transport", `String transport);
-        ("request", request);
-        ("response", response);
-        ("notes", str_list notes);
-      ]
-  in
-  `Assoc
-    [
-      ("version", `String "1");
-      ("generated_at", `String (Types.now_iso ()));
-      ( "docs",
-        `List
-          [
-            `Assoc
-              [
-                ("title", `String "Command Plane Runbook");
-                ("path", `String "docs/COMMAND-PLANE-RUNBOOK.md");
-              ];
-            `Assoc
-              [
-                ("title", `String "Benchmark Runbook");
-                ("path", `String "docs/BENCHMARK-RUNBOOK.md");
-              ];
-            `Assoc
-              [
-                ("title", `String "Supervisor Mode");
-                ("path", `String "docs/SUPERVISOR-MODE.md");
-              ];
-            `Assoc
-              [
-                ("title", `String "Swarm Delivery Runbook");
-                ("path", `String "docs/SWARM-DELIVERY-RUNBOOK.md");
-              ];
-          ] );
-      ( "concepts",
-        `List
-          [
-            concept ~id:"room" ~title:"Room"
-              ~summary:
-                "The coordination scope. In practice masc_set_room resolves to the repo-root room, not an arbitrary nested worktree.";
-            concept ~id:"task" ~title:"Task"
-              ~summary:
-                "Backlog work item. Claiming a task does not automatically set the session current_task pointer.";
-            concept ~id:"operation" ~title:"Operation"
-              ~summary:
-                "Managed CPv2 execution unit owned by company/platoon/squad hierarchy.";
-            concept ~id:"detachment" ~title:"Detachment"
-              ~summary:
-                "Scheduler/runtime view of active work under an operation. Use it to inspect progress, liveness, and runtime binding.";
-            concept ~id:"policy_decision" ~title:"Policy Decision"
-              ~summary:
-                "Pending approval item. Cross-platoon moves and disruptive actions stop here until approved or denied.";
-            concept ~id:"trace" ~title:"Trace"
-              ~summary:
-                "End-to-end lineage of operation, checkpoint, dispatch, and policy events.";
-          ] );
-      ( "golden_paths",
-        `List
-          [
-            path ~id:"room_task_hygiene" ~title:"Room / Task Hygiene"
-              ~summary:
-                "Minimal MCP sequence before doing any real work in a room."
-              ~when_to_use:
-                "Use this before benchmark runs, CPv2 experiments, or ordinary implementation work."
-              ~steps:
-                [
-                  step ~id:"join" ~title:"Join the room" ~tool:"masc_join"
-                    ~summary:
-                      "Register agent identity and capabilities in the repo-root room."
-                    ~success_signals:
-                      [ "agent visible in masc_status"; "room agent roster includes your agent" ]
-                    ~pitfalls:
-                      [ "masc_set_room points at repo root semantics"; "without join you are invisible to scheduling" ];
-                  step ~id:"claim" ~title:"Claim or create work" ~tool:"masc_claim"
-                    ~summary:
-                      "Claim an existing task or create one first with masc_add_task when the backlog is empty."
-                    ~success_signals:
-                      [ "task assignee is your agent"; "task status becomes claimed/in_progress" ]
-                    ~pitfalls:
-                      [ "claiming alone does not set current_task" ];
-                  step ~id:"set-task" ~title:"Bind current task" ~tool:"masc_plan_set_task"
-                    ~summary:
-                      "Set the current session task pointer so later planning and logs target the correct task."
-                    ~success_signals:
-                      [ "masc_plan_get_task returns the claimed task id" ]
-                    ~pitfalls:
-                      [ "dashboard can show claimed task and missing current_task at the same time" ];
-                  step ~id:"heartbeat" ~title:"Refresh presence" ~tool:"masc_heartbeat"
-                    ~summary:
-                      "Update liveness before or during long-running work."
-                    ~success_signals:
-                      [ "agent status stays active/busy"; "last_seen remains fresh" ]
-                    ~pitfalls:
-                      [ "without heartbeat an otherwise healthy agent looks zombie/stale" ];
-                ];
-            path ~id:"cpv2_benchmark" ~title:"CPv2 Benchmark / Swarm"
-              ~summary:
-                "Canonical benchmark path for company → platoon → squad → agent orchestration."
-              ~when_to_use:
-                "Use this for real swarm experiments, benchmarking, long-running command-plane work, and 4→16→64 agent rehearsals."
-              ~steps:
-                [
-                  step ~id:"define-units" ~title:"Define hierarchy" ~tool:"masc_unit_define"
-                    ~summary:
-                      "Create managed company/platoon/squad/agent units with policy and budget envelopes."
-                    ~success_signals:
-                      [ "masc_observe_topology shows managed units"; "capacity rows appear for units" ]
-                    ~pitfalls:
-                      [ "missing leaders or empty live rosters block operation start" ];
-                  step ~id:"start-operation" ~title:"Start operation" ~tool:"masc_operation_start"
-                    ~summary:
-                      "Create the managed benchmark operation and bind it to the target unit."
-                    ~success_signals:
-                      [ "operation appears in masc_observe_operations"; "trace_id is issued" ]
-                    ~pitfalls:
-                      [ "starting directly on a frozen or killed unit fails" ];
-                  step ~id:"dispatch" ~title:"Materialize detachments" ~tool:"masc_dispatch_tick"
-                    ~summary:
-                      "Run the scheduler/reconciler to create or update detachments."
-                    ~success_signals:
-                      [ "masc_detachment_list returns active detachments"; "operation moves from planned to active runtime" ]
-                    ~pitfalls:
-                      [ "active op with zero detachments usually means tick has not been run yet" ];
-                  step ~id:"observe" ~title:"Observe runtime" ~tool:"masc_detachment_status"
-                    ~summary:
-                      "Inspect detachments, topology, alerts, and trace events while the operation runs."
-                    ~success_signals:
-                      [ "heartbeat_deadline and last_progress_at advance"; "alerts/traces explain stalls or approvals" ]
-                    ~pitfalls:
-                      [ "pending approvals stop cross-platoon movement until policy action happens" ];
-                  step ~id:"approve" ~title:"Handle approval queue" ~tool:"masc_policy_approve"
-                    ~summary:
-                      "Approve or deny pending policy decisions for strict actions."
-                    ~success_signals:
-                      [ "decision leaves pending state"; "next tick applies the move or leaves a denial trace" ]
-                    ~pitfalls:
-                      [ "dispatch_rebalance can legitimately return pending_approval" ];
-                  step ~id:"checkpoint" ~title:"Checkpoint and finalize" ~tool:"masc_operation_checkpoint"
-                    ~summary:
-                      "Record durable state, then finish with masc_operation_finalize when done."
-                    ~success_signals:
-                      [ "checkpoint_ref stored on operation"; "finalized operation is completed in operations view" ]
-                    ~pitfalls:
-                      [ "stop/finalize without checkpoint loses resume breadcrumbs" ];
-                ];
-            path ~id:"supervisor_session" ~title:"Supervisor / Team Session"
-              ~summary:
-                "Guided intervention loop for supervised implementation sessions."
-              ~when_to_use:
-                "Use this when a human or supervisor agent steers a team session instead of running direct CPv2 benchmark orchestration."
-              ~steps:
-                [
-                  step ~id:"snapshot" ~title:"Read operator snapshot" ~tool:"masc_operator_snapshot"
-                    ~summary:"Read state first from the small operator surface."
-                    ~success_signals:[ "summary/full snapshot available" ]
-                    ~pitfalls:[ "this is not the benchmark canonical path" ];
-                  step ~id:"intervene" ~title:"Preview intervention" ~tool:"masc_operator_action"
-                    ~summary:"Prepare a small intervention such as team_note or team_task_inject."
-                    ~success_signals:[ "preview token or immediate action result returned" ]
-                    ~pitfalls:[ "disruptive actions require confirm" ];
-                  step ~id:"confirm" ~title:"Confirm disruptive action" ~tool:"masc_operator_confirm"
-                    ~summary:"Execute the previewed intervention once a human approves it."
-                    ~success_signals:[ "intervention trace appended"; "team-session reflects the change" ]
-                    ~pitfalls:[ "do not mix this path with CPv2 benchmark commands in the same explanation" ];
-                ];
-          ] );
-      ( "tool_groups",
-        `List
-          [
-            tool_group ~id:"room-task" ~title:"Room / Task Hygiene"
-              ~description:
-                "Core room/task tools every session should use before higher-level workflows."
-              ~tools:
-                [ "masc_set_room"; "masc_join"; "masc_status"; "masc_claim"; "masc_plan_set_task"; "masc_heartbeat" ];
-            tool_group ~id:"cpv2-core" ~title:"CPv2 Benchmark Core"
-              ~description:
-                "Canonical swarm/benchmark tool family."
-              ~tools:
-                [ "masc_unit_define"; "masc_operation_start"; "masc_dispatch_tick"; "masc_detachment_list"; "masc_detachment_status"; "masc_observe_topology"; "masc_observe_operations"; "masc_observe_alerts"; "masc_observe_traces"; "masc_policy_status"; "masc_policy_approve"; "masc_policy_deny"; "masc_operation_checkpoint"; "masc_operation_finalize" ];
-            tool_group ~id:"supervisor" ~title:"Supervisor Session"
-              ~description:
-                "Small operator loop for intervention-oriented sessions."
-              ~tools:
-                [ "masc_operator_snapshot"; "masc_operator_action"; "masc_operator_confirm"; "masc_team_session_events" ];
-          ] );
-      ( "pitfalls",
-        `List
-          [
-            pitfall ~id:"repo-root-room" ~title:"Room path resolves to repo root"
-              ~symptom:"You point masc_set_room at a worktree but the room still behaves like the repo root."
-              ~why:"Room semantics are repo-root scoped; worktrees share the same room substrate."
-              ~fix_tool:"masc_join"
-              ~fix_summary:"Treat worktrees as code-isolation only. Join the repo-root room and reason about shared room state.";
-            pitfall ~id:"claimed-not-current" ~title:"Claimed task is not current task"
-              ~symptom:"Task is claimed, but planning/log tools still act like no current task is selected."
-              ~why:"Claim mutates backlog ownership; it does not set the session current_task pointer."
-              ~fix_tool:"masc_plan_set_task"
-              ~fix_summary:"Call masc_plan_set_task immediately after claiming the task.";
-            pitfall ~id:"heartbeat-stale" ~title:"Agent looks stale"
-              ~symptom:"Your agent appears inactive/zombie during long work even though the process is alive."
-              ~why:"Heartbeat/liveness was not refreshed recently."
-              ~fix_tool:"masc_heartbeat"
-              ~fix_summary:"Call masc_heartbeat periodically during long operations or before observing state.";
-            pitfall ~id:"no-detachments" ~title:"Operation exists but no detachments"
-              ~symptom:"Operation is visible, but detachments list is empty."
-              ~why:"The scheduler has not reconciled yet, or the target unit is blocked."
-              ~fix_tool:"masc_dispatch_tick"
-              ~fix_summary:"Run masc_dispatch_tick, then inspect topology/capacity or policy queue if detachments still do not appear.";
-            pitfall ~id:"pending-approval" ~title:"Dispatch is blocked by approval"
-              ~symptom:"dispatch_rebalance or related control action returns pending_approval."
-              ~why:"Strict cross-platoon or disruptive action requires a policy decision."
-              ~fix_tool:"masc_policy_approve"
-              ~fix_summary:"Review the pending decision and approve/deny it before running tick again.";
-            pitfall ~id:"http-actor-defaults-dashboard"
-              ~title:"HTTP actor defaults to dashboard"
-              ~symptom:"Operation or trace entries show actor=dashboard even though a human or agent initiated the request."
-              ~why:"Mutating HTTP endpoints use dashboard as the fallback actor unless x-masc-agent, x-masc-agent-name, or agent_name is provided."
-              ~fix_tool:"masc_operation_start"
-              ~fix_summary:"Send x-masc-agent-name (or x-masc-agent) on mutating HTTP requests when actor attribution matters.";
-          ] );
-      ( "examples",
-        `List
-          [
-            example ~id:"join-room" ~title:"Join room for task hygiene"
-              ~path_id:"room_task_hygiene" ~transport:"mcp"
-              ~request:
-                (`Assoc
-                   [
-                     ("tool", `String "masc_join");
-                     ("arguments",
-                      `Assoc
-                        [
-                          ("agent_name", `String "codex");
-                          ("capabilities",
-                           `List [ `String "ocaml"; `String "dashboard"; `String "documentation" ]);
-                        ]);
-                   ])
-              ~response:
-                (`Assoc
-                   [
-                     ("agent", `String "codex-...");
-                     ("status", `String "joined");
-                     ("room", `String "repo-root room");
-                   ])
-              ~notes:
-                [ "Response is trimmed to canonical fields."; "Use masc_status next to confirm visibility." ];
-            example ~id:"start-op" ~title:"Start benchmark operation"
-              ~path_id:"cpv2_benchmark" ~transport:"http"
-              ~request:
-                (`Assoc
-                   [
-                     ("method", `String "POST");
-                     ("path", `String "/api/v1/command-plane/operations");
-                     ("headers", `Assoc [ ("x-masc-agent-name", `String "codex") ]);
-                     ("body",
-                      `Assoc
-                        [
-                          ("assigned_unit_id", `String "squad-research-normalize");
-                          ("objective", `String "Normalize and verify latest AI research items");
-                          ("autonomy_level", `String "L4_Autonomous");
-                          ("policy_class", `String "guarded");
-                        ]);
-                   ])
-              ~response:
-                (`Assoc
-                   [
-                     ("status", `String "ok");
-                     ("result",
-                      `Assoc
-                        [
-                          ("operation_id", `String "op-...");
-                          ("trace_id", `String "trace-...");
-                          ("status", `String "active");
-                        ]);
-                   ])
-              ~notes:
-                [
-                  "Run dispatch/tick after operation start to materialize detachments.";
-                  "Without x-masc-agent-name (or x-masc-agent), actor attribution falls back to dashboard.";
-                ];
-            example ~id:"approval" ~title:"Approve strict action"
-              ~path_id:"cpv2_benchmark" ~transport:"mcp"
-              ~request:
-                (`Assoc
-                   [
-                     ("tool", `String "masc_policy_approve");
-                     ("arguments",
-                      `Assoc [ ("decision_id", `String "decision-...") ]);
-                   ])
-              ~response:
-                (`Assoc
-                   [
-                     ("status", `String "ok");
-                     ("decision_id", `String "decision-...");
-                     ("approval_state", `String "approved");
-                   ])
-              ~notes:
-                [ "Follow with masc_dispatch_tick to apply the approved move." ];
-          ] );
-    ]
+  Server_command_plane_http.command_plane_help_http_json ()
 
 let command_plane_error_json message =
-  `Assoc [ ("status", `String "error"); ("message", `String message) ]
+  Server_command_plane_http.command_plane_error_json message
 let parse_host_port host_header default_host default_port =
   match host_header with
   | None -> (default_host, default_port)

--- a/bin/main_eio.ml
+++ b/bin/main_eio.ml
@@ -45,6 +45,7 @@ module Tool_board = Masc_mcp.Tool_board
 module Process_eio = Masc_mcp.Process_eio
 module Mdal = Masc_mcp.Mdal
 module Server_command_plane_http = Masc_mcp.Server_command_plane_http
+module Server_mcp_transport_http = Masc_mcp.Server_mcp_transport_http
 
 (** MCP Protocol Versions *)
 (* ============================================ *)
@@ -105,168 +106,47 @@ let verify_operator_mcp_auth ~base_path request =
         | Ok cred -> Ok (Some cred)
         | Error err -> Error (Types.masc_error_to_string err))
 
-let mcp_protocol_versions = Mcp_server.supported_protocol_versions
+let mcp_protocol_versions = Server_mcp_transport_http.mcp_protocol_versions
 
-let mcp_protocol_version_default = Mcp_server.default_protocol_version
+let mcp_protocol_version_default =
+  Server_mcp_transport_http.mcp_protocol_version_default
 
-let protocol_version_by_session : (string, string) Hashtbl.t = Hashtbl.create 128
-let mcp_profile_by_session : (string, Mcp_eio.tool_profile) Hashtbl.t = Hashtbl.create 128
+let default_base_path = Server_mcp_transport_http.default_base_path
 
-(** Get default base path from ME_ROOT or current directory *)
-let default_base_path () =
-  match Sys.getenv_opt "ME_ROOT" with
-  | Some path -> path
-  | None -> Sys.getcwd ()
+let is_valid_protocol_version =
+  Server_mcp_transport_http.is_valid_protocol_version
 
-(** Validate MCP-Protocol-Version *)
-let is_valid_protocol_version version =
-  List.mem version mcp_protocol_versions
+let remember_protocol_version =
+  Server_mcp_transport_http.remember_protocol_version
 
-let remember_protocol_version session_id version =
-  if is_valid_protocol_version version then
-    Hashtbl.replace protocol_version_by_session session_id version
+let remember_mcp_profile = Server_mcp_transport_http.remember_mcp_profile
 
-let remember_mcp_profile session_id profile =
-  Hashtbl.replace mcp_profile_by_session session_id profile
+let forget_mcp_session = Server_mcp_transport_http.forget_mcp_session
 
-let forget_mcp_session session_id =
-  Hashtbl.remove protocol_version_by_session session_id;
-  Hashtbl.remove mcp_profile_by_session session_id
+let validate_mcp_session_profile =
+  Server_mcp_transport_http.validate_mcp_session_profile
 
-let profile_label = function
-  | Mcp_eio.Full -> "/mcp"
-  | Mcp_eio.Operator_remote -> "/mcp/operator"
+let validate_mcp_session_delete_profile =
+  Server_mcp_transport_http.validate_mcp_session_delete_profile
 
-let validate_mcp_session_profile ~profile session_id =
-  match Hashtbl.find_opt mcp_profile_by_session session_id with
-  | None -> Ok ()
-  | Some existing when existing = profile -> Ok ()
-  | Some existing ->
-      Error
-        (Printf.sprintf "Session %s belongs to %s, not %s." session_id
-           (profile_label existing) (profile_label profile))
+let protocol_version_from_body =
+  Server_mcp_transport_http.protocol_version_from_body
 
-let validate_mcp_session_delete_profile ~profile session_id =
-  match profile with
-  | Mcp_eio.Operator_remote -> (
-      match Hashtbl.find_opt mcp_profile_by_session session_id with
-      | Some Mcp_eio.Operator_remote -> Ok ()
-      | Some existing ->
-          Error
-            (Printf.sprintf "Session %s belongs to %s, not %s." session_id
-               (profile_label existing) (profile_label profile))
-      | None ->
-          Error
-            (Printf.sprintf
-               "Session %s is not registered on %s." session_id
-               (profile_label profile)))
-  | Mcp_eio.Full -> validate_mcp_session_profile ~profile session_id
+let get_session_id_query = Server_mcp_transport_http.get_session_id_query
 
-(** Extract protocol version from initialize request body *)
-let protocol_version_from_body body_str =
-  try
-    let json = Yojson.Safe.from_string body_str in
-    match Mcp_server.jsonrpc_request_of_yojson json with
-    | Ok req when String.equal req.method_ "initialize" ->
-        let version =
-          Mcp_server.protocol_version_from_params req.params
-          |> Mcp_server.normalize_protocol_version
-        in
-        Some version
-    | _ -> None
-  with Yojson.Json_error _ | Yojson.Safe.Util.Type_error _ -> None
+let get_header_any_case = Server_mcp_transport_http.get_header_any_case
 
-(** Get session_id from query string *)
-let get_session_id_query target =
-  match String.split_on_char '?' target with
-  | [_; query] ->
-      query
-      |> String.split_on_char '&'
-      |> List.find_map (fun param ->
-          match String.split_on_char '=' param with
-          | ["session_id"; v] | ["sessionId"; v] -> Some v
-          | _ -> None)
-  | _ -> None
+let get_cookie_value = Server_mcp_transport_http.get_cookie_value
 
-let capitalize_ascii (s : string) =
-  if s = "" then s
-  else
-    let first = Char.uppercase_ascii s.[0] |> String.make 1 in
-    let rest =
-      if String.length s > 1 then
-        String.sub s 1 (String.length s - 1) |> String.lowercase_ascii
-      else
-        ""
-    in
-    first ^ rest
+let get_session_id_any = Server_mcp_transport_http.get_session_id_any
 
-let title_case_header_name (header_name : string) =
-  header_name
-  |> String.split_on_char '-'
-  |> List.map capitalize_ascii
-  |> String.concat "-"
+let legacy_messages_endpoint_url =
+  Server_mcp_transport_http.legacy_messages_endpoint_url
 
-let get_header_any_case (headers : Httpun.Headers.t) (name : string) =
-  match Httpun.Headers.get headers name with
-  | Some _ as value -> value
-  | None ->
-      let title_case = title_case_header_name name in
-      (match Httpun.Headers.get headers title_case with
-       | Some _ as value -> value
-       | None -> Httpun.Headers.get headers (String.uppercase_ascii name))
+let get_protocol_version = Server_mcp_transport_http.get_protocol_version
 
-let get_cookie_value (request : Httpun.Request.t) cookie_name =
-  match get_header_any_case request.headers "cookie" with
-  | None -> None
-  | Some raw ->
-      raw
-      |> String.split_on_char ';'
-      |> List.find_map (fun part ->
-           match String.split_on_char '=' (String.trim part) with
-           | key :: value_parts
-             when String.lowercase_ascii (String.trim key)
-                  = String.lowercase_ascii cookie_name ->
-               let value = String.concat "=" value_parts |> String.trim in
-               if value = "" then None else Some value
-           | _ -> None)
-
-(** Get session_id from either query param or header *)
-let get_session_id_any (request : Httpun.Request.t) =
-  match get_session_id_query request.target with
-  | Some _ as id -> id
-  | None ->
-      (match get_header_any_case request.headers "mcp-session-id" with
-       | Some _ as id -> id
-       | None -> get_cookie_value request "mcp-session-id")
-
-(** Build legacy SSE messages endpoint URL (event: endpoint) *)
-let legacy_messages_endpoint_url (request : Httpun.Request.t) session_id =
-  match Httpun.Headers.get request.headers "host" with
-  | Some host ->
-      let proto =
-        match Httpun.Headers.get request.headers "x-forwarded-proto" with
-        | Some p -> p
-        | None ->
-            (* Cloudflare tunnel domains are always HTTPS *)
-            if String.length host >= 17 && String.sub host 0 17 = "masc.crying.pict" then "https"
-            else "http"
-      in
-      Printf.sprintf "%s://%s/messages?session_id=%s" proto host session_id
-  | None -> Printf.sprintf "/messages?session_id=%s" session_id
-
-(** Get protocol version from headers *)
-let get_protocol_version (request : Httpun.Request.t) =
-  match Httpun.Headers.get request.headers "mcp-protocol-version" with
-  | Some v -> v
-  | None -> mcp_protocol_version_default
-
-let get_protocol_version_for_session ?session_id request =
-  match session_id with
-  | Some id ->
-      (match Hashtbl.find_opt protocol_version_by_session id with
-      | Some v -> v
-      | None -> get_protocol_version request)
-  | None -> get_protocol_version request
+let get_protocol_version_for_session =
+  Server_mcp_transport_http.get_protocol_version_for_session
 
 (** Parse query param from request target *)
 let query_param request key =
@@ -6069,152 +5949,44 @@ let accepts_streamable_mcp (request : Httpun.Request.t) =
   Http_negotiation.accepts_streamable_mcp
     (Httpun.Headers.get request.headers "accept")
 
-let env_flag name =
-  match Sys.getenv_opt name with
-  | Some raw -> (
-      match String.lowercase_ascii (String.trim raw) with
-      | "1" | "true" | "yes" | "on" -> true
-      | _ -> false)
-  | None -> false
+let request_force_json_response =
+  Server_mcp_transport_http.request_force_json_response
 
-let header_truthy_value value =
-  match String.lowercase_ascii (String.trim value) with
-  | "1" | "true" | "yes" | "on" -> true
-  | _ -> false
+let allow_legacy_accept = Server_mcp_transport_http.allow_legacy_accept
 
-let request_force_json_response (request : Httpun.Request.t) =
-  match get_header_any_case request.headers "x-masc-force-json" with
-  | Some value -> header_truthy_value value
-  | None -> false
+let classify_mcp_accept = Server_mcp_transport_http.classify_mcp_accept
 
-(** Compatibility mode for legacy Accept headers (default: strict off). *)
-let allow_legacy_accept = env_flag "MASC_ALLOW_LEGACY_ACCEPT"
+let legacy_accept_warning_headers =
+  Server_mcp_transport_http.legacy_accept_warning_headers
 
-let classify_mcp_accept (request : Httpun.Request.t) =
-  Http_negotiation.classify_mcp_accept ~allow_legacy:allow_legacy_accept
-    (Httpun.Headers.get request.headers "accept")
-
-(** Warning headers when a non-streamable Accept header is temporarily accepted. *)
-let legacy_accept_warning_headers = function
-  | Http_negotiation.Legacy_accepted ->
-      [
-        ( "warning",
-          "299 - \"Legacy Accept is deprecated; use 'application/json, text/event-stream'\"" );
-        ("x-masc-legacy-accept", "1");
-      ]
-  | Http_negotiation.Streamable | Http_negotiation.Rejected -> []
-
-(** Deprecation headers for legacy SSE endpoints (/sse, /messages). *)
 let legacy_transport_deprecation_headers =
-  [
-    ("deprecation", "true");
-    ( "warning",
-      "299 - \"Legacy SSE endpoints (/sse,/messages) are deprecated; use /mcp\"" );
-    ("link", "</mcp>; rel=\"successor-version\"");
-  ]
+  Server_mcp_transport_http.legacy_transport_deprecation_headers
 
-(** Force JSON responses for POST /mcp (compatibility fallback). *)
-let force_json_response =
-  env_flag "MASC_FORCE_JSON_RESPONSE" || env_flag "MCP_FORCE_JSON_RESPONSE"
+let force_json_response = Server_mcp_transport_http.force_json_response
 
-(** SSE retry interval in milliseconds (for connection closure) *)
-let sse_retry_ms = 3000
+let get_last_event_id = Server_mcp_transport_http.get_last_event_id
 
-(** Format SSE priming event (id + retry, no data payload). *)
-let sse_prime_event () =
-  let id = Sse.next_id () in
-  Printf.sprintf "retry: %d\nid: %d\n\n" sse_retry_ms id
+let mcp_transport_json_headers session_id protocol_version origin =
+  Server_mcp_transport_http.json_headers
+    ~deps:
+      {
+        get_origin = get_origin;
+        cors_headers = cors_headers;
+        auth_token_from_request = auth_token_from_request;
+        get_server_state_opt = (fun () -> !server_state);
+        verify_mcp_auth =
+          (fun ~base_path request ->
+            Result.map (fun _ -> ()) (verify_mcp_auth ~base_path request));
+        verify_operator_mcp_auth =
+          (fun ~base_path request ->
+            Result.map (fun _ -> ())
+              (verify_operator_mcp_auth ~base_path request));
+      }
+    session_id protocol_version origin
 
-(** SSE keep-alive ping interval in seconds *)
-let sse_ping_interval_s = 30.0
+let mcp_headers = Server_mcp_transport_http.mcp_headers
 
-let env_float_or ~name ~default =
-  match Sys.getenv_opt name with
-  | None -> default
-  | Some raw ->
-      (try float_of_string raw with _ -> default)
-
-let env_int_or ~name ~default =
-  match Sys.getenv_opt name with
-  | None -> default
-  | Some raw ->
-      (try int_of_string raw with _ -> default)
-
-(** SSE reconnect guard (disabled by default unless env is set). *)
-let sse_reconnect_min_interval_s =
-  env_float_or ~name:"MASC_SSE_RECONNECT_MIN_INTERVAL_S" ~default:0.0
-  |> Float.max 0.0
-
-let sse_connect_window_s =
-  env_float_or ~name:"MASC_SSE_CONNECT_WINDOW_S" ~default:0.0
-  |> Float.max 0.0
-
-let sse_connect_max_in_window =
-  env_int_or ~name:"MASC_SSE_CONNECT_MAX_IN_WINDOW" ~default:0
-  |> max 0
-
-(** Get Last-Event-ID from headers for resumability *)
-let get_last_event_id (request : Httpun.Request.t) =
-  match Httpun.Headers.get request.headers "last-event-id" with
-  | Some id -> (try Some (int_of_string id) with Failure _ -> None)
-  | None -> None
-
-
-(** Common MCP headers *)
-let mcp_headers session_id protocol_version = [
-  ("mcp-session-id", session_id);
-  ("mcp-protocol-version", protocol_version);
-]
-
-let session_cookie_header session_id =
-  ("set-cookie",
-   Printf.sprintf "mcp-session-id=%s; Path=/; Max-Age=86400; SameSite=Lax" session_id)
-
-(** SSE response headers *)
-let sse_headers session_id protocol_version origin =
-  [
-    ("content-type", Http_negotiation.sse_content_type);
-    session_cookie_header session_id;
-  ]
-  @ mcp_headers session_id protocol_version
-  @ cors_headers origin
-
-(** SSE stream headers (with keep-alive) *)
-let sse_stream_headers session_id protocol_version origin =
-  [
-    ("content-type", Http_negotiation.sse_content_type);
-    ("cache-control", "no-cache");
-    ("connection", "keep-alive");
-    session_cookie_header session_id;
-  ]
-  @ mcp_headers session_id protocol_version
-  @ cors_headers origin
-
-(** JSON response headers *)
-let json_headers session_id protocol_version origin =
-  [("content-type", "application/json")]
-  @ mcp_headers session_id protocol_version
-  @ cors_headers origin
-
-let respond_mcp_auth_error ?(extra_headers = []) request reqd ~session_id
-    ~protocol_version msg =
-  let origin = get_origin request in
-  let body = Yojson.Safe.to_string (`Assoc [
-    ("jsonrpc", `String "2.0");
-    ("error", `Assoc [
-      ("code", `Int (-32001));
-      ("message", `String msg);
-    ]);
-  ]) in
-  let headers =
-    Httpun.Headers.of_list
-      ((("content-length", string_of_int (String.length body))
-       :: ("www-authenticate", "Bearer")
-       :: extra_headers)
-      @ json_headers session_id protocol_version origin)
-  in
-  let response = Httpun.Response.create ~headers `Unauthorized in
-  Httpun.Reqd.respond_with_string reqd response body
+let json_headers = mcp_transport_json_headers
 
 (** GraphQL response headers *)
 let graphql_headers origin =
@@ -6741,436 +6513,34 @@ let handle_graphql request reqd =
   | `POST -> handle_post_graphql request reqd
   | _ -> Http.Response.method_not_allowed reqd
 
-(** MCP POST handler - async body reading with callback-based response *)
-let handle_post_mcp ?(profile = Mcp_eio.Full) request reqd =
-  let origin = get_origin request in
-  let session_id =
-    match get_session_id_any request with
-    | Some id -> id
-    | None -> Mcp_session.generate ()
-  in
-  let auth_token = auth_token_from_request request in
-  let protocol_version = get_protocol_version_for_session ~session_id request in
-  let base_path =
-    match !server_state with
-    | Some s -> s.Mcp_server.room_config.base_path
-    | None -> default_base_path ()
-  in
-  let auth_result =
-    match profile with
-    | Mcp_eio.Full -> verify_mcp_auth ~base_path request
-    | Mcp_eio.Operator_remote -> verify_operator_mcp_auth ~base_path request
-  in
-  match validate_mcp_session_profile ~profile session_id with
-  | Error msg ->
-      let body = json_rpc_error (-32600) msg in
-      let headers =
-        Httpun.Headers.of_list
-          ( ("content-length", string_of_int (String.length body))
-          :: json_headers session_id protocol_version origin )
-      in
-      let response = Httpun.Response.create ~headers `Conflict in
-      Httpun.Reqd.respond_with_string reqd response body
-  | Ok () ->
-      remember_mcp_profile session_id profile;
-      (match auth_result with
-  | Error msg ->
-      respond_mcp_auth_error request reqd ~session_id ~protocol_version msg
-  | Ok _cred_opt -> (
-      match classify_mcp_accept request with
-      | Http_negotiation.Rejected ->
-          let body =
-            json_rpc_error (-32600)
-              "Invalid Accept header: must include application/json and text/event-stream. \
-               Set MASC_ALLOW_LEGACY_ACCEPT=1 for temporary compatibility."
-          in
-          let headers =
-            Httpun.Headers.of_list
-              ( ("content-length", string_of_int (String.length body))
-              :: json_headers session_id protocol_version origin )
-          in
-          let response = Httpun.Response.create ~headers `Bad_request in
-          Httpun.Reqd.respond_with_string reqd response body
-      | accept_mode ->
-          let accept_warn_headers = legacy_accept_warning_headers accept_mode in
-          Http.Request.read_body_async reqd (fun body_str ->
-              try
-                let state = get_server_state ()
-                in
-                let sw = get_switch ()
-                in
-                let clock = get_clock ()
-                in
-                let response_json =
-                  Mcp_eio.handle_request ~clock ~sw ~profile ~mcp_session_id:session_id
-                    ?auth_token state body_str
-                in
-                (match protocol_version_from_body body_str with
-                | Some v -> remember_protocol_version session_id v
-                | None -> ());
-                let protocol_version =
-                  get_protocol_version_for_session ~session_id request
-                in
-                let wants_sse =
-                  accepts_sse request
-                  && not force_json_response
-                  && not (request_force_json_response request)
-                in
-                if wants_sse then begin
-                  match response_json with
-                  | `Null ->
-                      let headers =
-                        Httpun.Headers.of_list
-                          ( ("content-length", "0")
-                          :: accept_warn_headers
-                          @ mcp_headers session_id protocol_version )
-                      in
-                      let response = Httpun.Response.create ~headers `Accepted in
-                      Httpun.Reqd.respond_with_string reqd response ""
-                  | json when is_http_error_response json ->
-                      let body = Yojson.Safe.to_string json in
-                      let headers =
-                        Httpun.Headers.of_list
-                          ( ("content-length", string_of_int (String.length body))
-                          :: accept_warn_headers
-                          @ json_headers session_id protocol_version origin )
-                      in
-                      let response = Httpun.Response.create ~headers `Bad_request in
-                      Httpun.Reqd.respond_with_string reqd response body
-                  | json ->
-                      let event =
-                        Sse.format_event ~event_type:"message"
-                          (Yojson.Safe.to_string json)
-                      in
-                      let body = sse_prime_event () ^ event in
-                      let headers =
-                        Httpun.Headers.of_list
-                          ( ("content-length", string_of_int (String.length body))
-                          :: accept_warn_headers
-                          @ sse_headers session_id protocol_version origin )
-                      in
-                      let response = Httpun.Response.create ~headers `OK in
-                      Httpun.Reqd.respond_with_string reqd response body
-                end else begin
-                  match response_json with
-                  | `Null ->
-                      let headers =
-                        Httpun.Headers.of_list
-                          ( ("content-length", "0")
-                          :: accept_warn_headers
-                          @ mcp_headers session_id protocol_version )
-                      in
-                      let response = Httpun.Response.create ~headers `Accepted in
-                      Httpun.Reqd.respond_with_string reqd response ""
-                  | json when is_http_error_response json ->
-                      let body = Yojson.Safe.to_string json in
-                      let headers =
-                        Httpun.Headers.of_list
-                          ( ("content-length", string_of_int (String.length body))
-                          :: accept_warn_headers
-                          @ json_headers session_id protocol_version origin )
-                      in
-                      let response = Httpun.Response.create ~headers `Bad_request in
-                      Httpun.Reqd.respond_with_string reqd response body
-                  | json ->
-                      let body = Yojson.Safe.to_string json in
-                      let headers =
-                        Httpun.Headers.of_list
-                          ( ("content-length", string_of_int (String.length body))
-                          :: accept_warn_headers
-                          @ json_headers session_id protocol_version origin )
-                      in
-                      let response = Httpun.Response.create ~headers `OK in
-                      Httpun.Reqd.respond_with_string reqd response body
-                end
-              with exn ->
-                let protocol_version =
-                  get_protocol_version_for_session ~session_id request
-                in
-                let body =
-                  json_rpc_error (-32603)
-                    ("Internal error: " ^ Printexc.to_string exn)
-                in
-                let headers =
-                  Httpun.Headers.of_list
-                    ( ("content-length", string_of_int (String.length body))
-                    :: json_headers session_id protocol_version origin )
-                in
-                let response =
-                  Httpun.Response.create ~headers `Internal_server_error
-                in
-                Httpun.Reqd.respond_with_string reqd response body)))
+let mcp_transport_http_deps : Server_mcp_transport_http.deps =
+  {
+    get_origin;
+    cors_headers;
+    auth_token_from_request;
+    get_server_state_opt = (fun () -> !server_state);
+    verify_mcp_auth =
+      (fun ~base_path request ->
+        Result.map (fun _ -> ()) (verify_mcp_auth ~base_path request));
+    verify_operator_mcp_auth =
+      (fun ~base_path request ->
+        Result.map (fun _ -> ()) (verify_operator_mcp_auth ~base_path request));
+  }
 
-(** SSE connection tracking (prevents leaks / stale sessions) *)
-type sse_conn_info = {
-  session_id: string;
-  client_id: int;
-  writer: Httpun.Body.Writer.t;
-  mutex: Eio.Mutex.t;
-  stop: bool ref;
-  mutable closed: bool;
-}
+let check_sse_connect_guard = Server_mcp_transport_http.check_sse_connect_guard
 
-let sse_conn_by_session : (string, sse_conn_info) Hashtbl.t = Hashtbl.create 128
+let stop_sse_session = Server_mcp_transport_http.stop_sse_session
 
-type sse_connect_guard_state = {
-  mutable last_connect_at: float;
-  mutable connect_times: float list;  (* newest first *)
-}
-
-let sse_connect_guard_by_session : (string, sse_connect_guard_state) Hashtbl.t =
-  Hashtbl.create 256
-
-let prune_connect_times ~now times =
-  if sse_connect_window_s <= 0.0 then times
-  else List.filter (fun ts -> now -. ts <= sse_connect_window_s) times
-
-let check_sse_connect_guard session_id =
-  let now = Time_compat.now () in
-  let state =
-    match Hashtbl.find_opt sse_connect_guard_by_session session_id with
-    | Some v -> v
-    | None -> { last_connect_at = -.1.0; connect_times = [] }
-  in
-  let recent = prune_connect_times ~now state.connect_times in
-  state.connect_times <- recent;
-  let session_wait_s =
-    if sse_reconnect_min_interval_s <= 0.0 then
-      0.0
-    else
-      sse_reconnect_min_interval_s -. (now -. state.last_connect_at)
-  in
-  if session_wait_s > 0.0 then
-    Error ("session_cooldown", session_wait_s)
-  else
-    let window_wait_s =
-      if sse_connect_window_s <= 0.0 || sse_connect_max_in_window <= 0 then
-        0.0
-      else if List.length recent >= sse_connect_max_in_window then
-        match List.rev recent with
-        | oldest :: _ -> sse_connect_window_s -. (now -. oldest)
-        | [] -> 0.0
-      else
-        0.0
-    in
-    if window_wait_s > 0.0 then
-      Error ("window_limit", window_wait_s)
-    else begin
-      state.last_connect_at <- now;
-      state.connect_times <- now :: recent;
-      Hashtbl.replace sse_connect_guard_by_session session_id state;
-      Ok ()
-    end
-
-let respond_sse_rate_limited ~origin ~session_id ~protocol_version ~reason ~retry_after_s reqd =
-  let retry_after_s = Float.max retry_after_s 0.001 in
-  let retry_after_header =
-    retry_after_s
-    |> Float.ceil
-    |> int_of_float
-    |> max 1
-    |> string_of_int
-  in
-  let body =
-    `Assoc [
-      ("error", `String "sse_connection_rate_limited");
-      ("reason", `String reason);
-      ("retry_after_seconds", `Float retry_after_s);
-    ]
-    |> Yojson.Safe.to_string
-  in
-  let headers = Httpun.Headers.of_list (
-    ("content-length", string_of_int (String.length body))
-    :: ("retry-after", retry_after_header)
-    :: json_headers session_id protocol_version origin
-  ) in
-  let response = Httpun.Response.create ~headers `Too_many_requests in
-  Httpun.Reqd.respond_with_string reqd response body
-
-let close_sse_conn info =
-  if not info.closed then begin
-    info.closed <- true;
-    info.stop := true;
-    (try Httpun.Body.Writer.close info.writer with
-     | exn ->
-         (* Expected during client disconnect - log for debugging *)
-         Printf.eprintf "[DEBUG] close_sse_conn: %s\n%!" (Printexc.to_string exn));
-    (* Critical: unregister from Sse module to prevent client count leak.
-       unregister_if_current is idempotent (checks client_id match). *)
-    Sse.unregister_if_current info.session_id info.client_id
-  end
-
-let stop_sse_session session_id =
-  match Hashtbl.find_opt sse_conn_by_session session_id with
-  | None -> ()
-  | Some info ->
-      Hashtbl.remove sse_conn_by_session session_id;
-      close_sse_conn info
-      (* Note: Sse.unregister_if_current already called in close_sse_conn *)
-
-(** Close all SSE connections gracefully - for shutdown *)
-let close_all_sse_connections () =
-  let sessions = Hashtbl.fold (fun k _ acc -> k :: acc) sse_conn_by_session [] in
-  List.iter (fun session_id ->
-    stop_sse_session session_id
-  ) sessions;
-  Printf.eprintf "🚀 MASC MCP: Closed %d SSE connections\n%!" (List.length sessions)
-
-let send_raw info data =
-  if info.closed || !(info.stop) || Httpun.Body.Writer.is_closed info.writer then
-    (close_sse_conn info; false)
-  else
-    try
-      Eio.Mutex.use_rw ~protect:true info.mutex (fun () ->
-        Httpun.Body.Writer.write_string info.writer data;
-        Httpun.Body.Writer.flush info.writer (fun _ -> ())
-      );
-      Sse.touch info.session_id;
-      true
-    with _exn ->
-      (* Expected during client disconnect - silent close *)
-      close_sse_conn info;
-      false
+let close_all_sse_connections =
+  Server_mcp_transport_http.close_all_sse_connections
 
 let handle_get_mcp ?legacy_messages_endpoint ?(profile = Mcp_eio.Full) request reqd =
-  let origin = get_origin request in
-  let session_id = Mcp_session.get_or_generate (get_session_id_any request) in
-  let protocol_version = get_protocol_version_for_session ~session_id request in
-  let legacy_headers =
-    match legacy_messages_endpoint with
-    | Some _ -> legacy_transport_deprecation_headers
-    | None -> []
-  in
-  let last_event_id = get_last_event_id request in
-  match validate_mcp_session_profile ~profile session_id with
-  | Error msg ->
-      let headers =
-        Httpun.Headers.of_list
-          ( ("content-length", string_of_int (String.length msg))
-          :: json_headers session_id protocol_version origin )
-      in
-      let response = Httpun.Response.create ~headers `Conflict in
-      Httpun.Reqd.respond_with_string reqd response msg
-  | Ok () ->
-      remember_mcp_profile session_id profile;
-      (match check_sse_connect_guard session_id with
-  | Error (reason, retry_after_s) ->
-      respond_sse_rate_limited
-        ~origin
-        ~session_id
-        ~protocol_version
-        ~reason
-        ~retry_after_s
-        reqd
-  | Ok () ->
-      (* Replace existing connection for session_id *)
-      stop_sse_session session_id;
+  Server_mcp_transport_http.handle_get_mcp ~deps:mcp_transport_http_deps
+    ?legacy_messages_endpoint ~profile request reqd
 
-      let headers =
-        Httpun.Headers.of_list
-          (legacy_headers @ sse_stream_headers session_id protocol_version origin)
-      in
-      let response = Httpun.Response.create ~headers `OK in
-      let writer = Httpun.Reqd.respond_with_streaming reqd response in
-      let mutex = Eio.Mutex.create () in
-      let info_ref : sse_conn_info option ref = ref None in
-      let push event =
-        match !info_ref with
-        | None -> ()
-        | Some info -> ignore (send_raw info event)
-      in
-      let (client_id, evicted) =
-        Sse.register session_id ~push
-          ~last_event_id:(Option.value ~default:0 last_event_id)
-      in
-      (* Clean up writer for evicted session *)
-      (match evicted with
-       | Some evicted_sid -> stop_sse_session evicted_sid
-       | None -> ());
-      let info = {
-        session_id;
-        client_id;
-        writer;
-        mutex;
-        stop = ref false;
-        closed = false;
-      } in
-      info_ref := Some info;
-      Hashtbl.replace sse_conn_by_session session_id info;
-
-      (* Send priming event first *)
-      ignore (send_raw info (sse_prime_event ()));
-
-      (* Legacy SSE transport: provide messages endpoint (event: endpoint) *)
-      (match legacy_messages_endpoint with
-       | None -> ()
-       | Some f ->
-           let endpoint_url = f session_id in
-           ignore (send_raw info (Sse.format_event ~event_type:"endpoint" endpoint_url)));
-
-      (* Replay missed events if Last-Event-ID provided (MCP spec MUST) *)
-      (match last_event_id with
-       | Some last_id ->
-           let missed = Sse.get_events_after last_id in
-           List.iter (fun ev -> ignore (send_raw info ev)) missed
-       | None -> ());
-
-      (* Keep-alive ping loop *)
-      (match Masc_mcp.Eio_context.get_switch_opt (), Masc_mcp.Eio_context.get_clock_opt () with
-       | Some sw, Some clock ->
-           Eio.Fiber.fork ~sw (fun () ->
-             let is_cancelled exn =
-               match exn with
-              | Eio.Cancel.Cancelled _ -> true
-               | _ -> false
-             in
-             let rec loop () =
-               if not !(info.stop) then begin
-                 (try
-                    Eio.Time.sleep clock sse_ping_interval_s
-                  with exn ->
-                    if is_cancelled exn then raise exn;
-                    Printf.eprintf "[SSE] ping sleep error: %s\n%!" (Printexc.to_string exn));
-                 (try
-                    if info.closed then
-                      stop_sse_session info.session_id
-                    else if not !(info.stop) then
-                      ignore (send_raw info ": ping\n\n")
-                  with exn ->
-                    if is_cancelled exn then raise exn;
-                    Printf.eprintf "[SSE] ping send error: %s\n%!" (Printexc.to_string exn);
-                    stop_sse_session info.session_id);
-                 loop ()
-               end
-             in
-             try loop () with exn ->
-               if is_cancelled exn then ()
-               else Printf.eprintf "[SSE] ping loop error: %s\n%!" (Printexc.to_string exn))
-       | _ -> ());
-
-      (* Only log when approaching capacity or in debug mode *)
-      let client_count = Sse.client_count () in
-      if client_count > Sse.max_clients / 2 then
-        Printf.eprintf "📡 SSE connected: %s (active: %d/%d)\n%!"
-          session_id client_count Sse.max_clients)
-
-(** SSE simple handler - for compatibility, returns single event *)
 let sse_simple_handler request reqd =
-  let origin = get_origin request in
-  let session_id = Mcp_session.get_or_generate (get_session_id_any request) in
-  let protocol_version = get_protocol_version_for_session ~session_id request in
-  let event = sse_prime_event ()
-              ^ Sse.format_event ~event_type:"connected"
-                  (Printf.sprintf {|{"session_id":"%s"}|} session_id)
-  in
-  let headers =
-    Httpun.Headers.of_list
-      ( ("content-length", string_of_int (String.length event))
-      :: legacy_transport_deprecation_headers
-      @ sse_headers session_id protocol_version origin )
-  in
-  let response = Httpun.Response.create ~headers `OK in
-  Httpun.Reqd.respond_with_string reqd response event
+  Server_mcp_transport_http.sse_simple_handler ~deps:mcp_transport_http_deps
+    request reqd
 
 (** TRPG SSE poll interval in seconds *)
 let trpg_sse_poll_interval_s = 2.0
@@ -7317,118 +6687,24 @@ let handle_trpg_sse ~base_dir ~room_id ~event_type_filter request reqd =
                "event: error\ndata: {\"error\":\"server not ready\"}\n\n"))
 
 let handle_get_operator_mcp request reqd =
-  let session_id = Mcp_session.get_or_generate (get_session_id_any request) in
-  let protocol_version = get_protocol_version_for_session ~session_id request in
-  let base_path =
-    match !server_state with
-    | Some s -> s.Mcp_server.room_config.base_path
-    | None -> default_base_path ()
-  in
-  match verify_operator_mcp_auth ~base_path request with
-  | Error msg ->
-      respond_mcp_auth_error request reqd ~session_id ~protocol_version msg
-  | Ok _ -> handle_get_mcp ~profile:Mcp_eio.Operator_remote request reqd
+  Server_mcp_transport_http.handle_get_operator_mcp
+    ~deps:mcp_transport_http_deps request reqd
 
-(** POST /messages - Legacy SSE transport (client->server messages) *)
 let handle_post_messages request reqd =
-  let origin = get_origin request in
-  let legacy_headers = legacy_transport_deprecation_headers in
-  match get_session_id_any request with
-  | None ->
-      let body = "session_id required" in
-      let headers = Httpun.Headers.of_list (
-        ("content-length", string_of_int (String.length body))
-        :: (legacy_headers @ cors_headers origin)
-      ) in
-      let response = Httpun.Response.create ~headers `Bad_request in
-      Httpun.Reqd.respond_with_string reqd response body
-  | Some session_id when not (Mcp_session.is_valid session_id) ->
-      let body = "invalid session_id" in
-      let headers = Httpun.Headers.of_list (
-        ("content-length", string_of_int (String.length body))
-        :: (legacy_headers @ cors_headers origin)
-      ) in
-      let response = Httpun.Response.create ~headers `Bad_request in
-      Httpun.Reqd.respond_with_string reqd response body
-  | Some session_id ->
-      let protocol_version = get_protocol_version_for_session ~session_id request in
-      let auth_token = auth_token_from_request request in
-      let base_path =
-        match !server_state with
-        | Some s -> s.Mcp_server.room_config.base_path
-        | None -> default_base_path ()
-      in
-      (match verify_mcp_auth ~base_path request with
-       | Error msg ->
-           respond_mcp_auth_error request reqd ~session_id ~protocol_version
-             ~extra_headers:legacy_headers msg
-       | Ok _cred_opt ->
-           Http.Request.read_body_async reqd (fun body_str ->
-             let state = get_server_state ()
-             in
-             let sw = get_switch ()
-             in
-             let clock = get_clock ()
-             in
-             let response_json =
-               Mcp_eio.handle_request ~clock ~sw ~mcp_session_id:session_id ?auth_token state body_str
-             in
-             (match response_json with
-             | `Null -> ()
-             | json -> Sse.send_to session_id json);
-             let headers = Httpun.Headers.of_list (
-               ("content-length", "0")
-               :: (legacy_headers @ mcp_headers session_id protocol_version)
-             ) in
-             let response = Httpun.Response.create ~headers `Accepted in
-             Httpun.Reqd.respond_with_string reqd response ""
-           ))
+  Server_mcp_transport_http.handle_post_messages ~deps:mcp_transport_http_deps
+    request reqd
 
-(** DELETE /mcp - Session termination *)
+let handle_post_mcp ?(profile = Mcp_eio.Full) request reqd =
+  Server_mcp_transport_http.handle_post_mcp ~deps:mcp_transport_http_deps
+    ~profile request reqd
+
 let handle_delete_mcp ?(profile = Mcp_eio.Full) request reqd =
-  let base_path =
-    match !server_state with
-    | Some s -> s.Mcp_server.room_config.base_path
-    | None -> default_base_path ()
-  in
-  let auth_result =
-    match profile with
-    | Mcp_eio.Full -> Ok None
-    | Mcp_eio.Operator_remote -> verify_operator_mcp_auth ~base_path request
-  in
-  match auth_result with
-  | Error msg ->
-      let session_id = Mcp_session.get_or_generate (get_session_id_any request) in
-      let protocol_version = get_protocol_version_for_session ~session_id request in
-      respond_mcp_auth_error request reqd ~session_id ~protocol_version msg
-  | Ok _ ->
-      (match get_session_id_any request with
-      | Some session_id -> (
-          match validate_mcp_session_delete_profile ~profile session_id with
-          | Error msg ->
-              let headers = Httpun.Headers.of_list [
-                ("content-length", string_of_int (String.length msg));
-              ] in
-              let response = Httpun.Response.create ~headers `Conflict in
-              Httpun.Reqd.respond_with_string reqd response msg
-          | Ok () ->
-              stop_sse_session session_id;
-              Sse.unregister session_id;
-              forget_mcp_session session_id;
-              Printf.printf "🔚 Session terminated: %s\n%!" session_id;
-              let headers = Httpun.Headers.of_list (
-                ("content-length", "0")
-                :: mcp_headers session_id (get_protocol_version request)
-              ) in
-              let response = Httpun.Response.create ~headers `No_content in
-              Httpun.Reqd.respond_with_string reqd response "")
-      | None ->
-          let body = "Mcp-Session-Id required" in
-          let headers = Httpun.Headers.of_list [
-            ("content-length", string_of_int (String.length body));
-          ] in
-          let response = Httpun.Response.create ~headers `Bad_request in
-          Httpun.Reqd.respond_with_string reqd response body)
+  Server_mcp_transport_http.handle_delete_mcp ~deps:mcp_transport_http_deps
+    ~profile request reqd
+
+let handle_ag_ui_events request reqd =
+  Server_mcp_transport_http.handle_ag_ui_events ~deps:mcp_transport_http_deps
+    request reqd
 
 (** Build routes for MCP server *)
 let make_routes ~port ~host ~sw ~clock =
@@ -7448,108 +6724,7 @@ let make_routes ~port ~host ~sw ~clock =
          let a2a_version = Masc_mcp.A2a_tools.default_a2a_version in
          Http.Response.json ~extra_headers:[("A2A-Version", a2a_version)] json reqd
        ) request reqd)
-  |> Http.Router.get "/ag-ui/events" (fun request reqd ->
-       (* AG-UI Protocol SSE endpoint — translates MASC events to AG-UI format.
-          Clients connect here to receive real-time AG-UI events. *)
-       let origin = get_origin request in
-       let session_id = Mcp_session.get_or_generate (get_session_id_any request) in
-       let protocol_version = get_protocol_version_for_session ~session_id request in
-       let room_id = Option.value ~default:"default" (query_param request "room") in
-       let last_event_id = get_last_event_id request in
-       match check_sse_connect_guard session_id with
-       | Error (reason, retry_after_s) ->
-           respond_sse_rate_limited
-             ~origin
-             ~session_id
-             ~protocol_version
-             ~reason
-             ~retry_after_s
-             reqd
-       | Ok () ->
-           stop_sse_session session_id;
-
-           let headers = Httpun.Headers.of_list (sse_stream_headers session_id protocol_version origin) in
-           let response = Httpun.Response.create ~headers `OK in
-           let writer = Httpun.Reqd.respond_with_streaming reqd response in
-           let mutex = Eio.Mutex.create () in
-           let info_ref : sse_conn_info option ref = ref None in
-           let push event =
-             match !info_ref with
-             | None -> ()
-             | Some info ->
-               (* Translate MASC SSE data to AG-UI event format.
-                  Parse the JSON from the SSE data line and re-emit as AG-UI CUSTOM. *)
-               let ag_ui_event =
-                 try
-                   (* Extract JSON from SSE format: "id: N\nevent: type\ndata: {...}\n\n" *)
-                   let lines = String.split_on_char '\n' event in
-                   let data_line = List.find_opt (fun l ->
-                     String.length l > 6 && String.sub l 0 6 = "data: "
-                   ) lines in
-                   match data_line with
-                   | Some dl ->
-                     let json_str = String.sub dl 6 (String.length dl - 6) in
-                     let json = Yojson.Safe.from_string json_str in
-                     let ag_event = Masc_mcp.Ag_ui.of_custom ~room_id
-                       ~name:"MASC_EVENT" json in
-                     Masc_mcp.Ag_ui.event_to_sse ag_event
-                   | None -> event  (* Pass through if no data line *)
-                 with _ -> event  (* Pass through on parse error *)
-               in
-               ignore (send_raw info ag_ui_event)
-           in
-           let (client_id, evicted) =
-             Sse.register session_id ~push
-               ~last_event_id:(Option.value ~default:0 last_event_id)
-           in
-           (match evicted with
-            | Some evicted_sid -> stop_sse_session evicted_sid
-            | None -> ());
-           let info = {
-             session_id;
-             client_id;
-             writer;
-             mutex;
-             stop = ref false;
-             closed = false;
-           } in
-           info_ref := Some info;
-           Hashtbl.replace sse_conn_by_session session_id info;
-
-           (* Send AG-UI priming: RUN_STARTED event *)
-           let prime = Masc_mcp.Ag_ui.(
-             make_event ~thread_id:room_id
-               ~run_id:(Some session_id)
-               Run_started
-             |> event_to_sse
-           ) in
-           ignore (send_raw info prime);
-
-           (* Replay missed events *)
-           (match last_event_id with
-            | Some last_id ->
-              let missed = Sse.get_events_after last_id in
-              List.iter (fun ev -> ignore (send_raw info ev)) missed
-            | None -> ());
-
-           (* Keep-alive ping *)
-           (match Masc_mcp.Eio_context.get_switch_opt (), Masc_mcp.Eio_context.get_clock_opt () with
-            | Some sw, Some clock ->
-              Eio.Fiber.fork ~sw (fun () ->
-                let rec loop () =
-                  if not !(info.stop) then begin
-                    (try Eio.Time.sleep clock sse_ping_interval_s
-                     with _ -> ());
-                    (try
-                       if info.closed then stop_sse_session info.session_id
-                       else if not !(info.stop) then
-                         ignore (send_raw info ": ping\n\n")
-                     with _ -> stop_sse_session info.session_id);
-                    loop ()
-                  end
-                in
-                try loop () with _ -> ())
-            | _ -> ()))
+  |> Http.Router.get "/ag-ui/events" handle_ag_ui_events
   (* Dashboard sub-routes: credits and lodge must come before the SPA catchall *)
   |> Http.Router.get "/dashboard/credits" (fun request reqd ->
        with_public_read (fun _state _req reqd ->

--- a/lib/dune
+++ b/lib/dune
@@ -44,6 +44,7 @@
    dashboard_mission_briefing
    drift_guard
    server_command_plane_http
+   server_mcp_transport_http
    web_dashboard
    credits_dashboard
    cp_microarch_summary

--- a/lib/dune
+++ b/lib/dune
@@ -43,6 +43,7 @@
    dashboard_mission
    dashboard_mission_briefing
    drift_guard
+   server_command_plane_http
    web_dashboard
    credits_dashboard
    cp_microarch_summary

--- a/lib/masc_mcp.ml
+++ b/lib/masc_mcp.ml
@@ -166,6 +166,7 @@ module Dashboard = Dashboard
 module Dashboard_semantics = Dashboard_semantics
 module Dashboard_mission = Dashboard_mission
 module Dashboard_mission_briefing = Dashboard_mission_briefing
+module Server_command_plane_http = Server_command_plane_http
 module Swarm_status = Swarm_status
 module Tempo = Tempo
 module Federation = Federation

--- a/lib/masc_mcp.ml
+++ b/lib/masc_mcp.ml
@@ -167,6 +167,7 @@ module Dashboard_semantics = Dashboard_semantics
 module Dashboard_mission = Dashboard_mission
 module Dashboard_mission_briefing = Dashboard_mission_briefing
 module Server_command_plane_http = Server_command_plane_http
+module Server_mcp_transport_http = Server_mcp_transport_http
 module Swarm_status = Swarm_status
 module Tempo = Tempo
 module Federation = Federation

--- a/lib/server_command_plane_http.ml
+++ b/lib/server_command_plane_http.ml
@@ -1,0 +1,1025 @@
+type deps = {
+  query_param : Httpun.Request.t -> string -> string option;
+  int_query_param : Httpun.Request.t -> string -> default:int -> int;
+  operator_actor_hint : Httpun.Request.t -> string option;
+  get_session_id_any : Httpun.Request.t -> string option;
+  auth_token_from_request : Httpun.Request.t -> string option;
+  get_switch : unit -> Eio.Switch.t;
+  get_clock : unit -> float Eio.Time.clock_ty Eio.Resource.t;
+  get_net : unit -> [ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t;
+  get_origin : Httpun.Request.t -> string;
+  cors_headers : string -> (string * string) list;
+}
+
+let assoc_add key value = function
+  | `Assoc fields -> `Assoc ((key, value) :: List.remove_assoc key fields)
+  | json -> `Assoc [ ("payload", json); (key, value) ]
+
+let command_plane_actor deps request =
+  Option.value ~default:"dashboard" (deps.operator_actor_hint request)
+
+let command_plane_tool_ctx ~deps ~state request :
+    (_, _) Tool_command_plane.context =
+  {
+    config = state.Mcp_server.room_config;
+    agent_name = command_plane_actor deps request;
+    sw = Some (deps.get_switch ());
+    clock = Some (deps.get_clock ());
+    net = Some (deps.get_net ());
+    mcp_state = Some state;
+    mcp_session_id = deps.get_session_id_any request;
+    auth_token = deps.auth_token_from_request request;
+  }
+
+let tool_command_plane_http_json ~deps ~state request ~name ~args =
+  match
+    Tool_command_plane.dispatch
+      (command_plane_tool_ctx ~deps ~state request)
+      ~name ~args
+  with
+  | Some (true, payload) -> (
+      try Ok (Yojson.Safe.from_string payload)
+      with Yojson.Json_error message -> Error ("invalid tool json: " ^ message))
+  | Some (false, payload) -> (
+      try
+        match Yojson.Safe.from_string payload with
+        | `Assoc fields -> (
+            match List.assoc_opt "message" fields with
+            | Some (`String message) -> Error message
+            | _ -> Error payload)
+        | _ -> Error payload
+      with Yojson.Json_error _ -> Error payload)
+  | None -> Error ("unsupported command-plane tool: " ^ name)
+
+let command_plane_summary_http_json ~state =
+  let config = state.Mcp_server.room_config in
+  let summary = Command_plane_v2.summary_json config in
+  let swarm_status =
+    if Room.is_initialized config then
+      Swarm_status.build_json ~timeline_limit_override:6 config
+    else Swarm_status.empty_json
+  in
+  assoc_add "swarm_status" swarm_status summary
+
+let command_plane_snapshot_http_json ~state =
+  let config = state.Mcp_server.room_config in
+  let snapshot = Command_plane_v2.snapshot_json config in
+  let swarm_status =
+    if Room.is_initialized config then
+      Swarm_status.build_json_from_snapshot config snapshot
+    else Swarm_status.empty_json
+  in
+  assoc_add "swarm_status" swarm_status snapshot
+
+let command_plane_topology_http_json ~state =
+  Command_plane_v2.topology_json state.Mcp_server.room_config
+
+let command_plane_units_http_json ~state =
+  Command_plane_v2.list_units_json state.Mcp_server.room_config
+
+let command_plane_operations_http_json ~deps ~state request =
+  let operation_id = deps.query_param request "operation_id" in
+  Command_plane_v2.operation_status_json state.Mcp_server.room_config ?operation_id ()
+
+let command_plane_detachments_http_json ~deps ~state request =
+  let operation_id = deps.query_param request "operation_id" in
+  let detachment_id = deps.query_param request "detachment_id" in
+  Command_plane_v2.list_detachments_json state.Mcp_server.room_config ?operation_id
+    ?detachment_id
+
+let command_plane_detachment_status_http_json ~deps ~state request =
+  let args =
+    `Assoc
+      [
+        ( "detachment_id",
+          match deps.query_param request "detachment_id" with
+          | Some value -> `String value
+          | None -> `Null );
+      ]
+  in
+  Command_plane_v2.detachment_status_json state.Mcp_server.room_config args
+
+let command_plane_decisions_http_json ~deps ~state request =
+  let decision_id = deps.query_param request "decision_id" in
+  Command_plane_v2.list_policy_decisions_json state.Mcp_server.room_config
+    ?decision_id
+
+let command_plane_capacity_http_json ~state =
+  Command_plane_v2.capacity_json state.Mcp_server.room_config
+
+let command_plane_alerts_http_json ~state =
+  Command_plane_v2.list_alerts_json state.Mcp_server.room_config
+
+let command_plane_traces_http_json ~deps ~state request =
+  let operation_id = deps.query_param request "operation_id" in
+  let limit =
+    deps.int_query_param request "limit" ~default:25 |> fun v -> max 1 (min 200 v)
+  in
+  Command_plane_v2.list_traces_json state.Mcp_server.room_config ?operation_id
+    ~limit ()
+
+let command_plane_swarm_http_json ~deps ~state request =
+  let run_id = deps.query_param request "run_id" in
+  let operation_id = deps.query_param request "operation_id" in
+  Command_plane_v2.swarm_live_json state.Mcp_server.room_config ?run_id
+    ?operation_id ()
+
+let command_plane_unit_define_http_json ~deps ~state request ~args =
+  Command_plane_v2.unit_update_json state.Mcp_server.room_config
+    ~actor:(command_plane_actor deps request) args
+
+let command_plane_operation_start_http_json ~deps ~state request ~args =
+  tool_command_plane_http_json ~deps ~state request ~name:"masc_operation_start"
+    ~args
+
+let command_plane_chain_summary_http_json ~deps ~state request =
+  tool_command_plane_http_json ~deps ~state request ~name:"masc_chain_snapshot"
+    ~args:(`Assoc [])
+
+let command_plane_chain_run_http_json ~deps ~state request run_id =
+  tool_command_plane_http_json ~deps ~state request ~name:"masc_chain_run_get"
+    ~args:(`Assoc [ ("run_id", `String run_id) ])
+
+let chain_http_error_status message =
+  let starts_with ~prefix value =
+    let prefix_len = String.length prefix in
+    String.length value >= prefix_len
+    && String.equal (String.sub value 0 prefix_len) prefix
+  in
+  if starts_with ~prefix:"invalid chain run_id:" message then
+    `Bad_request
+  else if starts_with ~prefix:"chain run not found:" message then
+    `Not_found
+  else
+    `Bad_gateway
+
+let stream_native_chain_events_http ~deps ~request reqd =
+  let origin = deps.get_origin request in
+  let headers =
+    Httpun.Headers.of_list
+      ([
+         ("content-type", "text/event-stream");
+         ("cache-control", "no-cache");
+         ("connection", "keep-alive");
+         ("x-accel-buffering", "no");
+       ]
+      @ deps.cors_headers origin)
+  in
+  let response = Httpun.Response.create ~headers `OK in
+  let writer = Httpun.Reqd.respond_with_streaming reqd response in
+  let mutex = Eio.Mutex.create () in
+  let closed = ref false in
+  let sub_ref : Chain_telemetry.subscription option ref = ref None in
+  let log_chain_sse message =
+    Printf.eprintf "[chain-sse] %s\n%!" message
+  in
+  let close_stream ?reason () =
+    let sub_to_remove, should_close =
+      Eio.Mutex.use_rw ~protect:true mutex (fun () ->
+          let sub = !sub_ref in
+          sub_ref := None;
+          if !closed then
+            (sub, false)
+          else (
+            closed := true;
+            (sub, true)))
+    in
+    Option.iter Chain_telemetry.unsubscribe sub_to_remove;
+    if should_close then (
+      Option.iter log_chain_sse reason;
+      try
+        if not (Httpun.Body.Writer.is_closed writer) then
+          Httpun.Body.Writer.close writer
+      with Invalid_argument _ -> ())
+  in
+  let send_raw frame =
+    let write_result =
+      Eio.Mutex.use_rw ~protect:true mutex (fun () ->
+          if !closed || Httpun.Body.Writer.is_closed writer then
+            `Closed
+          else
+            try
+              Httpun.Body.Writer.write_string writer frame;
+              Httpun.Body.Writer.flush writer (fun _ -> ());
+              `Sent
+            with exn -> `Error exn)
+    in
+    match write_result with
+    | `Sent -> true
+    | `Closed ->
+        close_stream ();
+        false
+    | `Error exn ->
+        close_stream
+          ~reason:
+            (Printf.sprintf "stream write failed: %s" (Printexc.to_string exn))
+          ();
+        false
+  in
+  (try
+     let sub =
+       Chain_telemetry.subscribe (fun event ->
+           let payload = Chain_native_eio.chain_event_json event |> Yojson.Safe.to_string in
+           let frame =
+             Sse.format_event
+               ~event_type:(Chain_native_eio.chain_event_name event)
+               payload
+           in
+           ignore (send_raw frame))
+     in
+     Eio.Mutex.use_rw ~protect:true mutex (fun () -> sub_ref := Some sub);
+     if send_raw ": native chain stream\nretry: 3000\n\n" then
+       Eio.Fiber.fork ~sw:(deps.get_switch ()) (fun () ->
+           try
+             while not !closed do
+               Eio.Time.sleep (deps.get_clock ()) 30.0;
+               if not (send_raw ": keepalive\n\n") then close_stream ()
+             done
+           with exn ->
+             close_stream
+               ~reason:
+                 (Printf.sprintf "keepalive loop failed: %s"
+                    (Printexc.to_string exn))
+               ())
+     else
+       close_stream ~reason:"initial stream write failed" ()
+   with exn ->
+     close_stream
+       ~reason:
+         (Printf.sprintf "subscription setup failed: %s"
+            (Printexc.to_string exn))
+       ())
+
+let proxy_chain_events_http ~deps ~request reqd =
+  let endpoint = Llm_client_eio.resolve_endpoint () in
+  let path = Llm_client_eio.endpoint_path endpoint "/chain/events" in
+  let origin = deps.get_origin request in
+  let headers =
+    Httpun.Headers.of_list
+      ([
+         ("content-type", "text/event-stream");
+         ("cache-control", "no-cache");
+         ("connection", "keep-alive");
+         ("x-accel-buffering", "no");
+       ]
+      @ deps.cors_headers origin)
+  in
+  let response = Httpun.Response.create ~headers `OK in
+  let writer = Httpun.Reqd.respond_with_streaming reqd response in
+  let upstream_request =
+    let auth_header =
+      match endpoint.api_key with
+      | Some value -> [ Printf.sprintf "Authorization: Bearer %s" value ]
+      | None -> []
+    in
+    Printf.sprintf
+      "GET %s HTTP/1.1\r\nHost: %s:%d\r\nAccept: text/event-stream\r\nCache-Control: no-cache\r\nConnection: close\r\n%s\r\n\r\n"
+      path endpoint.host endpoint.port
+      (String.concat "\r\n" auth_header)
+  in
+  Eio.Fiber.fork ~sw:(deps.get_switch ()) (fun () ->
+      let safe_close () =
+        try Httpun.Body.Writer.close writer with Invalid_argument _ -> ()
+      in
+      let send_error message =
+        (try
+           let payload =
+             Printf.sprintf "event: error\ndata: {\"message\":%s}\n\n"
+               (Yojson.Safe.to_string (`String message))
+           in
+           Httpun.Body.Writer.write_string writer payload;
+           Httpun.Body.Writer.flush writer ignore
+         with _ -> ());
+        safe_close ()
+      in
+      try
+        Eio.Net.with_tcp_connect ~host:endpoint.host
+          ~service:(string_of_int endpoint.port) (deps.get_net ())
+        @@ fun flow ->
+        Eio.Flow.copy_string upstream_request flow;
+        let header_buf = Buffer.create 4096 in
+        let rec read_headers () =
+          let chunk = Cstruct.create 2048 in
+          match Eio.Flow.single_read flow chunk with
+          | n ->
+              Buffer.add_string header_buf (Cstruct.to_string ~len:n chunk);
+              let current = Buffer.contents header_buf in
+              (try
+                 let idx = Str.search_forward (Str.regexp "\r\n\r\n") current 0 in
+                 let headers_part = String.sub current 0 idx in
+                 let body_start = idx + 4 in
+                 let body_rest =
+                   if body_start >= String.length current then ""
+                   else
+                     String.sub current body_start
+                       (String.length current - body_start)
+                 in
+                 Ok (headers_part, body_rest)
+               with Not_found -> read_headers ())
+          | exception End_of_file ->
+              Error
+                "llm-mcp closed chain/events stream before headers were received"
+        in
+        match read_headers () with
+        | Error message -> send_error message
+        | Ok (headers_part, body_rest) ->
+            let status_line =
+              match String.split_on_char '\n' headers_part with
+              | line :: _ -> String.trim line
+              | [] -> "HTTP/1.1 502 Bad Gateway"
+            in
+            let status_code =
+              match String.split_on_char ' ' status_line with
+              | _http :: code :: _ -> (try int_of_string code with _ -> 502)
+              | _ -> 502
+            in
+            if status_code < 200 || status_code >= 300 then
+              send_error
+                (Printf.sprintf "llm-mcp /chain/events upstream returned %d"
+                   status_code)
+            else (
+              if body_rest <> "" then (
+                Httpun.Body.Writer.write_string writer body_rest;
+                Httpun.Body.Writer.flush writer ignore);
+              let rec pump () =
+                let chunk = Cstruct.create 4096 in
+                match Eio.Flow.single_read flow chunk with
+                | n ->
+                    Httpun.Body.Writer.write_string writer
+                      (Cstruct.to_string ~len:n chunk);
+                    Httpun.Body.Writer.flush writer ignore;
+                    pump ()
+                | exception End_of_file -> safe_close ()
+                | exception exn -> send_error (Printexc.to_string exn)
+              in
+              pump ())
+      with exn -> send_error (Printexc.to_string exn))
+
+let command_plane_chain_events_http ~deps ~request reqd =
+  match Tool_command_plane.chain_backend () with
+  | Tool_command_plane.Native ->
+      stream_native_chain_events_http ~deps ~request reqd
+  | Tool_command_plane.Compat_llm_mcp ->
+      proxy_chain_events_http ~deps ~request reqd
+
+let stream_native_chain_events_h2 ~deps ~request h2_reqd =
+  let origin = deps.get_origin request in
+  let headers =
+    H2.Headers.of_list
+      ([
+         ("content-type", "text/event-stream");
+         ("cache-control", "no-cache");
+         ("x-accel-buffering", "no");
+       ]
+      @ deps.cors_headers origin)
+  in
+  let response = H2.Response.create ~headers `OK in
+  let writer =
+    H2.Reqd.respond_with_streaming ~flush_headers_immediately:true h2_reqd
+      response
+  in
+  let mutex = Eio.Mutex.create () in
+  let closed = ref false in
+  let sub_ref : Chain_telemetry.subscription option ref = ref None in
+  let log_chain_sse message =
+    Printf.eprintf "[chain-sse/h2] %s\n%!" message
+  in
+  let close_stream ?reason () =
+    let sub_to_remove, should_close =
+      Eio.Mutex.use_rw ~protect:true mutex (fun () ->
+          let sub = !sub_ref in
+          sub_ref := None;
+          if !closed then
+            (sub, false)
+          else (
+            closed := true;
+            (sub, true)))
+    in
+    Option.iter Chain_telemetry.unsubscribe sub_to_remove;
+    if should_close then (
+      Option.iter log_chain_sse reason;
+      try
+        if not (H2.Body.Writer.is_closed writer) then H2.Body.Writer.close writer
+      with Invalid_argument _ -> ())
+  in
+  let send_raw frame =
+    let write_result =
+      Eio.Mutex.use_rw ~protect:true mutex (fun () ->
+          if !closed || H2.Body.Writer.is_closed writer then
+            `Closed
+          else
+            try
+              H2.Body.Writer.write_string writer frame;
+              H2.Body.Writer.flush writer (fun _ -> ());
+              `Sent
+            with exn -> `Error exn)
+    in
+    match write_result with
+    | `Sent -> true
+    | `Closed ->
+        close_stream ();
+        false
+    | `Error exn ->
+        close_stream
+          ~reason:
+            (Printf.sprintf "stream write failed: %s" (Printexc.to_string exn))
+          ();
+        false
+  in
+  (try
+     let sub =
+       Chain_telemetry.subscribe (fun event ->
+           let payload = Chain_native_eio.chain_event_json event |> Yojson.Safe.to_string in
+           let frame =
+             Sse.format_event
+               ~event_type:(Chain_native_eio.chain_event_name event)
+               payload
+           in
+           ignore (send_raw frame))
+     in
+     Eio.Mutex.use_rw ~protect:true mutex (fun () -> sub_ref := Some sub);
+     if send_raw ": native chain stream\nretry: 3000\n\n" then
+       Eio.Fiber.fork ~sw:(deps.get_switch ()) (fun () ->
+           try
+             while not !closed do
+               Eio.Time.sleep (deps.get_clock ()) 30.0;
+               if not (send_raw ": keepalive\n\n") then close_stream ()
+             done
+           with exn ->
+             close_stream
+               ~reason:
+                 (Printf.sprintf "keepalive loop failed: %s"
+                    (Printexc.to_string exn))
+               ())
+     else
+       close_stream ~reason:"initial stream write failed" ()
+   with exn ->
+     close_stream
+       ~reason:
+         (Printf.sprintf "subscription setup failed: %s"
+            (Printexc.to_string exn))
+       ())
+
+let proxy_chain_events_h2 ~deps ~request h2_reqd =
+  let endpoint = Llm_client_eio.resolve_endpoint () in
+  let path = Llm_client_eio.endpoint_path endpoint "/chain/events" in
+  let origin = deps.get_origin request in
+  let headers =
+    H2.Headers.of_list
+      ([
+         ("content-type", "text/event-stream");
+         ("cache-control", "no-cache");
+         ("x-accel-buffering", "no");
+       ]
+      @ deps.cors_headers origin)
+  in
+  let response = H2.Response.create ~headers `OK in
+  let writer =
+    H2.Reqd.respond_with_streaming ~flush_headers_immediately:true h2_reqd
+      response
+  in
+  let upstream_request =
+    let auth_header =
+      match endpoint.api_key with
+      | Some value -> [ Printf.sprintf "Authorization: Bearer %s" value ]
+      | None -> []
+    in
+    Printf.sprintf
+      "GET %s HTTP/1.1\r\nHost: %s:%d\r\nAccept: text/event-stream\r\nCache-Control: no-cache\r\nConnection: close\r\n%s\r\n\r\n"
+      path endpoint.host endpoint.port
+      (String.concat "\r\n" auth_header)
+  in
+  Eio.Fiber.fork ~sw:(deps.get_switch ()) (fun () ->
+      let safe_close () =
+        try H2.Body.Writer.close writer with Invalid_argument _ -> ()
+      in
+      let send_error message =
+        (try
+           let payload =
+             Printf.sprintf "event: error\ndata: {\"message\":%s}\n\n"
+               (Yojson.Safe.to_string (`String message))
+           in
+           H2.Body.Writer.write_string writer payload;
+           H2.Body.Writer.flush writer ignore
+         with _ -> ());
+        safe_close ()
+      in
+      try
+        Eio.Net.with_tcp_connect ~host:endpoint.host
+          ~service:(string_of_int endpoint.port) (deps.get_net ())
+        @@ fun flow ->
+        Eio.Flow.copy_string upstream_request flow;
+        let header_buf = Buffer.create 4096 in
+        let rec read_headers () =
+          let chunk = Cstruct.create 2048 in
+          match Eio.Flow.single_read flow chunk with
+          | n ->
+              Buffer.add_string header_buf (Cstruct.to_string ~len:n chunk);
+              let current = Buffer.contents header_buf in
+              (try
+                 let idx = Str.search_forward (Str.regexp "\r\n\r\n") current 0 in
+                 let headers_part = String.sub current 0 idx in
+                 let body_start = idx + 4 in
+                 let body_rest =
+                   if body_start >= String.length current then ""
+                   else
+                     String.sub current body_start
+                       (String.length current - body_start)
+                 in
+                 Ok (headers_part, body_rest)
+               with Not_found -> read_headers ())
+          | exception End_of_file ->
+              Error
+                "llm-mcp closed chain/events stream before headers were received"
+        in
+        match read_headers () with
+        | Error message -> send_error message
+        | Ok (headers_part, body_rest) ->
+            let status_line =
+              match String.split_on_char '\n' headers_part with
+              | line :: _ -> String.trim line
+              | [] -> "HTTP/1.1 502 Bad Gateway"
+            in
+            let status_code =
+              match String.split_on_char ' ' status_line with
+              | _http :: code :: _ -> (try int_of_string code with _ -> 502)
+              | _ -> 502
+            in
+            if status_code < 200 || status_code >= 300 then
+              send_error
+                (Printf.sprintf "llm-mcp /chain/events upstream returned %d"
+                   status_code)
+            else (
+              if String.length body_rest > 0 then (
+                H2.Body.Writer.write_string writer body_rest;
+                H2.Body.Writer.flush writer ignore);
+              let rec pump () =
+                let chunk = Cstruct.create 4096 in
+                match Eio.Flow.single_read flow chunk with
+                | n when n > 0 ->
+                    H2.Body.Writer.write_bigstring writer ~off:0 ~len:n
+                      (Cstruct.to_bigarray chunk);
+                    H2.Body.Writer.flush writer ignore;
+                    pump ()
+                | _ -> safe_close ()
+                | exception End_of_file -> safe_close ()
+                | exception exn -> send_error (Printexc.to_string exn)
+              in
+              pump ())
+      with exn -> send_error (Printexc.to_string exn))
+
+let command_plane_chain_events_h2 ~deps ~request h2_reqd =
+  match Tool_command_plane.chain_backend () with
+  | Tool_command_plane.Native ->
+      stream_native_chain_events_h2 ~deps ~request h2_reqd
+  | Tool_command_plane.Compat_llm_mcp ->
+      proxy_chain_events_h2 ~deps ~request h2_reqd
+
+let command_plane_operation_checkpoint_http_json ~deps ~state request ~args =
+  match
+    Command_plane_v2.checkpoint_operation state.Mcp_server.room_config
+      ~actor:(command_plane_actor deps request) args
+  with
+  | Ok operation ->
+      Ok
+        (`Assoc
+          [
+            ("status", `String "ok");
+            ("result", Command_plane_v2.operation_to_json operation);
+            ( "traces",
+              Command_plane_v2.list_traces_json state.Mcp_server.room_config
+                ~operation_id:operation.operation_id () );
+          ])
+  | Error message -> Error message
+  | exception Invalid_argument message -> Error message
+
+let command_plane_unit_reparent_http_json ~deps ~state request ~args =
+  Command_plane_v2.unit_reparent_json state.Mcp_server.room_config
+    ~actor:(command_plane_actor deps request) args
+
+let command_plane_unit_reassign_http_json ~deps ~state request ~args =
+  Command_plane_v2.unit_reassign_json state.Mcp_server.room_config
+    ~actor:(command_plane_actor deps request) args
+
+let command_plane_operation_pause_http_json ~deps ~state request ~args =
+  Command_plane_v2.pause_operation_json state.Mcp_server.room_config
+    ~actor:(command_plane_actor deps request) args
+
+let command_plane_operation_resume_http_json ~deps ~state request ~args =
+  Command_plane_v2.resume_operation_json state.Mcp_server.room_config
+    ~actor:(command_plane_actor deps request) args
+
+let command_plane_operation_stop_http_json ~deps ~state request ~args =
+  Command_plane_v2.stop_operation_json state.Mcp_server.room_config
+    ~actor:(command_plane_actor deps request) args
+
+let command_plane_operation_finalize_http_json ~deps ~state request ~args =
+  Command_plane_v2.finalize_operation_json state.Mcp_server.room_config
+    ~actor:(command_plane_actor deps request) args
+
+let command_plane_dispatch_plan_http_json ~state _request ~args =
+  Ok (Command_plane_v2.dispatch_plan_json state.Mcp_server.room_config args)
+
+let command_plane_dispatch_assign_http_json ~deps ~state request ~args =
+  Command_plane_v2.dispatch_assign_json state.Mcp_server.room_config
+    ~actor:(command_plane_actor deps request) args
+
+let command_plane_dispatch_rebalance_http_json ~deps ~state request ~args =
+  Command_plane_v2.dispatch_rebalance_json state.Mcp_server.room_config
+    ~actor:(command_plane_actor deps request) args
+
+let command_plane_dispatch_escalate_http_json ~deps ~state request ~args =
+  Command_plane_v2.dispatch_escalate_json state.Mcp_server.room_config
+    ~actor:(command_plane_actor deps request) args
+
+let command_plane_dispatch_recall_http_json ~deps ~state request ~args =
+  Command_plane_v2.dispatch_recall_json state.Mcp_server.room_config
+    ~actor:(command_plane_actor deps request) args
+
+let command_plane_dispatch_tick_http_json ~deps ~state request ~args =
+  Command_plane_v2.dispatch_tick_json state.Mcp_server.room_config
+    ~actor:(command_plane_actor deps request) args
+
+let command_plane_policy_status_http_json ~state =
+  Command_plane_v2.policy_status_json state.Mcp_server.room_config
+
+let command_plane_policy_approve_http_json ~deps ~state request ~args =
+  Command_plane_v2.policy_approve_json state.Mcp_server.room_config
+    ~actor:(command_plane_actor deps request) args
+
+let command_plane_policy_deny_http_json ~deps ~state request ~args =
+  Command_plane_v2.policy_deny_json state.Mcp_server.room_config
+    ~actor:(command_plane_actor deps request) args
+
+let command_plane_policy_update_http_json ~deps ~state request ~args =
+  Command_plane_v2.policy_update_json state.Mcp_server.room_config
+    ~actor:(command_plane_actor deps request) args
+
+let command_plane_policy_freeze_http_json ~deps ~state request ~args =
+  Command_plane_v2.policy_freeze_unit_json state.Mcp_server.room_config
+    ~actor:(command_plane_actor deps request) args
+
+let command_plane_policy_kill_switch_http_json ~deps ~state request ~args =
+  Command_plane_v2.policy_kill_switch_json state.Mcp_server.room_config
+    ~actor:(command_plane_actor deps request) args
+
+let command_plane_help_http_json () =
+  let str_list values = `List (List.map (fun value -> `String value) values) in
+  let concept ~id ~title ~summary =
+    `Assoc
+      [
+        ("id", `String id);
+        ("title", `String title);
+        ("summary", `String summary);
+      ]
+  in
+  let step ~id ~title ~tool ~summary ~success_signals ~pitfalls =
+    `Assoc
+      [
+        ("id", `String id);
+        ("title", `String title);
+        ("tool", `String tool);
+        ("summary", `String summary);
+        ("success_signals", str_list success_signals);
+        ("pitfalls", str_list pitfalls);
+      ]
+  in
+  let path ~id ~title ~summary ~when_to_use ~steps =
+    `Assoc
+      [
+        ("id", `String id);
+        ("title", `String title);
+        ("summary", `String summary);
+        ("when_to_use", `String when_to_use);
+        ("steps", `List steps);
+      ]
+  in
+  let tool_group ~id ~title ~description ~tools =
+    `Assoc
+      [
+        ("id", `String id);
+        ("title", `String title);
+        ("description", `String description);
+        ("tools", str_list tools);
+      ]
+  in
+  let pitfall ~id ~title ~symptom ~why ~fix_tool ~fix_summary =
+    `Assoc
+      [
+        ("id", `String id);
+        ("title", `String title);
+        ("symptom", `String symptom);
+        ("why", `String why);
+        ("fix_tool", `String fix_tool);
+        ("fix_summary", `String fix_summary);
+      ]
+  in
+  let example ~id ~title ~path_id ~transport ~request ~response ~notes =
+    `Assoc
+      [
+        ("id", `String id);
+        ("title", `String title);
+        ("path_id", `String path_id);
+        ("transport", `String transport);
+        ("request", request);
+        ("response", response);
+        ("notes", str_list notes);
+      ]
+  in
+  `Assoc
+    [
+      ("version", `String "1");
+      ("generated_at", `String (Types.now_iso ()));
+      ( "docs",
+        `List
+          [
+            `Assoc
+              [
+                ("title", `String "Command Plane Runbook");
+                ("path", `String "docs/COMMAND-PLANE-RUNBOOK.md");
+              ];
+            `Assoc
+              [
+                ("title", `String "Benchmark Runbook");
+                ("path", `String "docs/BENCHMARK-RUNBOOK.md");
+              ];
+            `Assoc
+              [
+                ("title", `String "Supervisor Mode");
+                ("path", `String "docs/SUPERVISOR-MODE.md");
+              ];
+            `Assoc
+              [
+                ("title", `String "Swarm Delivery Runbook");
+                ("path", `String "docs/SWARM-DELIVERY-RUNBOOK.md");
+              ];
+          ] );
+      ( "concepts",
+        `List
+          [
+            concept ~id:"room" ~title:"Room"
+              ~summary:
+                "The coordination scope. In practice masc_set_room resolves to the repo-root room, not an arbitrary nested worktree.";
+            concept ~id:"task" ~title:"Task"
+              ~summary:
+                "Backlog work item. Claiming a task does not automatically set the session current_task pointer.";
+            concept ~id:"operation" ~title:"Operation"
+              ~summary:
+                "Managed CPv2 execution unit owned by company/platoon/squad hierarchy.";
+            concept ~id:"detachment" ~title:"Detachment"
+              ~summary:
+                "Scheduler/runtime view of active work under an operation. Use it to inspect progress, liveness, and runtime binding.";
+            concept ~id:"policy_decision" ~title:"Policy Decision"
+              ~summary:
+                "Pending approval item. Cross-platoon moves and disruptive actions stop here until approved or denied.";
+            concept ~id:"trace" ~title:"Trace"
+              ~summary:
+                "End-to-end lineage of operation, checkpoint, dispatch, and policy events.";
+          ] );
+      ( "golden_paths",
+        `List
+          [
+            path ~id:"room_task_hygiene" ~title:"Room / Task Hygiene"
+              ~summary:
+                "Minimal MCP sequence before doing any real work in a room."
+              ~when_to_use:
+                "Use this before benchmark runs, CPv2 experiments, or ordinary implementation work."
+              ~steps:
+                [
+                  step ~id:"join" ~title:"Join the room" ~tool:"masc_join"
+                    ~summary:
+                      "Register agent identity and capabilities in the repo-root room."
+                    ~success_signals:
+                      [ "agent visible in masc_status"; "room agent roster includes your agent" ]
+                    ~pitfalls:
+                      [ "masc_set_room points at repo root semantics"; "without join you are invisible to scheduling" ];
+                  step ~id:"claim" ~title:"Claim or create work" ~tool:"masc_claim"
+                    ~summary:
+                      "Claim an existing task or create one first with masc_add_task when the backlog is empty."
+                    ~success_signals:
+                      [ "task assignee is your agent"; "task status becomes claimed/in_progress" ]
+                    ~pitfalls:
+                      [ "claiming alone does not set current_task" ];
+                  step ~id:"set-task" ~title:"Bind current task" ~tool:"masc_plan_set_task"
+                    ~summary:
+                      "Set the current session task pointer so later planning and logs target the correct task."
+                    ~success_signals:
+                      [ "masc_plan_get_task returns the claimed task id" ]
+                    ~pitfalls:
+                      [ "dashboard can show claimed task and missing current_task at the same time" ];
+                  step ~id:"heartbeat" ~title:"Refresh presence" ~tool:"masc_heartbeat"
+                    ~summary:
+                      "Update liveness before or during long-running work."
+                    ~success_signals:
+                      [ "agent status stays active/busy"; "last_seen remains fresh" ]
+                    ~pitfalls:
+                      [ "without heartbeat an otherwise healthy agent looks zombie/stale" ];
+                ];
+            path ~id:"cpv2_benchmark" ~title:"CPv2 Benchmark / Swarm"
+              ~summary:
+                "Canonical benchmark path for company → platoon → squad → agent orchestration."
+              ~when_to_use:
+                "Use this for real swarm experiments, benchmarking, long-running command-plane work, and 4→16→64 agent rehearsals."
+              ~steps:
+                [
+                  step ~id:"define-units" ~title:"Define hierarchy" ~tool:"masc_unit_define"
+                    ~summary:
+                      "Create managed company/platoon/squad/agent units with policy and budget envelopes."
+                    ~success_signals:
+                      [ "masc_observe_topology shows managed units"; "capacity rows appear for units" ]
+                    ~pitfalls:
+                      [ "missing leaders or empty live rosters block operation start" ];
+                  step ~id:"start-operation" ~title:"Start operation" ~tool:"masc_operation_start"
+                    ~summary:
+                      "Create the managed benchmark operation and bind it to the target unit."
+                    ~success_signals:
+                      [ "operation appears in masc_observe_operations"; "trace_id is issued" ]
+                    ~pitfalls:
+                      [ "starting directly on a frozen or killed unit fails" ];
+                  step ~id:"dispatch" ~title:"Materialize detachments" ~tool:"masc_dispatch_tick"
+                    ~summary:
+                      "Run the scheduler/reconciler to create or update detachments."
+                    ~success_signals:
+                      [ "masc_detachment_list returns active detachments"; "operation moves from planned to active runtime" ]
+                    ~pitfalls:
+                      [ "active op with zero detachments usually means tick has not been run yet" ];
+                  step ~id:"observe" ~title:"Observe runtime" ~tool:"masc_detachment_status"
+                    ~summary:
+                      "Inspect detachments, topology, alerts, and trace events while the operation runs."
+                    ~success_signals:
+                      [ "heartbeat_deadline and last_progress_at advance"; "alerts/traces explain stalls or approvals" ]
+                    ~pitfalls:
+                      [ "pending approvals stop cross-platoon movement until policy action happens" ];
+                  step ~id:"approve" ~title:"Handle approval queue" ~tool:"masc_policy_approve"
+                    ~summary:
+                      "Approve or deny pending policy decisions for strict actions."
+                    ~success_signals:
+                      [ "decision leaves pending state"; "next tick applies the move or leaves a denial trace" ]
+                    ~pitfalls:
+                      [ "dispatch_rebalance can legitimately return pending_approval" ];
+                  step ~id:"checkpoint" ~title:"Checkpoint and finalize" ~tool:"masc_operation_checkpoint"
+                    ~summary:
+                      "Record durable state, then finish with masc_operation_finalize when done."
+                    ~success_signals:
+                      [ "checkpoint_ref stored on operation"; "finalized operation is completed in operations view" ]
+                    ~pitfalls:
+                      [ "stop/finalize without checkpoint loses resume breadcrumbs" ];
+                ];
+            path ~id:"supervisor_session" ~title:"Supervisor / Team Session"
+              ~summary:
+                "Guided intervention loop for supervised implementation sessions."
+              ~when_to_use:
+                "Use this when a human or supervisor agent steers a team session instead of running direct CPv2 benchmark orchestration."
+              ~steps:
+                [
+                  step ~id:"snapshot" ~title:"Read operator snapshot" ~tool:"masc_operator_snapshot"
+                    ~summary:"Read state first from the small operator surface."
+                    ~success_signals:[ "summary/full snapshot available" ]
+                    ~pitfalls:[ "this is not the benchmark canonical path" ];
+                  step ~id:"intervene" ~title:"Preview intervention" ~tool:"masc_operator_action"
+                    ~summary:"Prepare a small intervention such as team_note or team_task_inject."
+                    ~success_signals:[ "preview token or immediate action result returned" ]
+                    ~pitfalls:[ "disruptive actions require confirm" ];
+                  step ~id:"confirm" ~title:"Confirm disruptive action" ~tool:"masc_operator_confirm"
+                    ~summary:"Execute the previewed intervention once a human approves it."
+                    ~success_signals:[ "intervention trace appended"; "team-session reflects the change" ]
+                    ~pitfalls:[ "do not mix this path with CPv2 benchmark commands in the same explanation" ];
+                ];
+          ] );
+      ( "tool_groups",
+        `List
+          [
+            tool_group ~id:"room-task" ~title:"Room / Task Hygiene"
+              ~description:
+                "Core room/task tools every session should use before higher-level workflows."
+              ~tools:
+                [ "masc_set_room"; "masc_join"; "masc_status"; "masc_claim"; "masc_plan_set_task"; "masc_heartbeat" ];
+            tool_group ~id:"cpv2-core" ~title:"CPv2 Benchmark Core"
+              ~description:
+                "Canonical swarm/benchmark tool family."
+              ~tools:
+                [ "masc_unit_define"; "masc_operation_start"; "masc_dispatch_tick"; "masc_detachment_list"; "masc_detachment_status"; "masc_observe_topology"; "masc_observe_operations"; "masc_observe_alerts"; "masc_observe_traces"; "masc_policy_status"; "masc_policy_approve"; "masc_policy_deny"; "masc_operation_checkpoint"; "masc_operation_finalize" ];
+            tool_group ~id:"supervisor" ~title:"Supervisor Session"
+              ~description:
+                "Small operator loop for intervention-oriented sessions."
+              ~tools:
+                [ "masc_operator_snapshot"; "masc_operator_action"; "masc_operator_confirm"; "masc_team_session_events" ];
+          ] );
+      ( "pitfalls",
+        `List
+          [
+            pitfall ~id:"repo-root-room" ~title:"Room path resolves to repo root"
+              ~symptom:"You point masc_set_room at a worktree but the room still behaves like the repo root."
+              ~why:"Room semantics are repo-root scoped; worktrees share the same room substrate."
+              ~fix_tool:"masc_join"
+              ~fix_summary:"Treat worktrees as code-isolation only. Join the repo-root room and reason about shared room state.";
+            pitfall ~id:"claimed-not-current" ~title:"Claimed task is not current task"
+              ~symptom:"Task is claimed, but planning/log tools still act like no current task is selected."
+              ~why:"Claim mutates backlog ownership; it does not set the session current_task pointer."
+              ~fix_tool:"masc_plan_set_task"
+              ~fix_summary:"Call masc_plan_set_task immediately after claiming the task.";
+            pitfall ~id:"heartbeat-stale" ~title:"Agent looks stale"
+              ~symptom:"Your agent appears inactive/zombie during long work even though the process is alive."
+              ~why:"Heartbeat/liveness was not refreshed recently."
+              ~fix_tool:"masc_heartbeat"
+              ~fix_summary:"Call masc_heartbeat periodically during long operations or before observing state.";
+            pitfall ~id:"no-detachments" ~title:"Operation exists but no detachments"
+              ~symptom:"Operation is visible, but detachments list is empty."
+              ~why:"The scheduler has not reconciled yet, or the target unit is blocked."
+              ~fix_tool:"masc_dispatch_tick"
+              ~fix_summary:"Run masc_dispatch_tick, then inspect topology/capacity or policy queue if detachments still do not appear.";
+            pitfall ~id:"pending-approval" ~title:"Dispatch is blocked by approval"
+              ~symptom:"dispatch_rebalance or related control action returns pending_approval."
+              ~why:"Strict cross-platoon or disruptive action requires a policy decision."
+              ~fix_tool:"masc_policy_approve"
+              ~fix_summary:"Review the pending decision and approve/deny it before running tick again.";
+            pitfall ~id:"http-actor-defaults-dashboard"
+              ~title:"HTTP actor defaults to dashboard"
+              ~symptom:"Operation or trace entries show actor=dashboard even though a human or agent initiated the request."
+              ~why:"Mutating HTTP endpoints use dashboard as the fallback actor unless x-masc-agent, x-masc-agent-name, or agent_name is provided."
+              ~fix_tool:"masc_operation_start"
+              ~fix_summary:"Send x-masc-agent-name (or x-masc-agent) on mutating HTTP requests when actor attribution matters.";
+          ] );
+      ( "examples",
+        `List
+          [
+            example ~id:"join-room" ~title:"Join room for task hygiene"
+              ~path_id:"room_task_hygiene" ~transport:"mcp"
+              ~request:
+                (`Assoc
+                   [
+                     ("tool", `String "masc_join");
+                     ("arguments",
+                      `Assoc
+                        [
+                          ("agent_name", `String "codex");
+                          ("capabilities",
+                           `List [ `String "ocaml"; `String "dashboard"; `String "documentation" ]);
+                        ]);
+                   ])
+              ~response:
+                (`Assoc
+                   [
+                     ("agent", `String "codex-...");
+                     ("status", `String "joined");
+                     ("room", `String "repo-root room");
+                   ])
+              ~notes:
+                [ "Response is trimmed to canonical fields."; "Use masc_status next to confirm visibility." ];
+            example ~id:"start-op" ~title:"Start benchmark operation"
+              ~path_id:"cpv2_benchmark" ~transport:"http"
+              ~request:
+                (`Assoc
+                   [
+                     ("method", `String "POST");
+                     ("path", `String "/api/v1/command-plane/operations");
+                     ("headers", `Assoc [ ("x-masc-agent-name", `String "codex") ]);
+                     ("body",
+                      `Assoc
+                        [
+                          ("assigned_unit_id", `String "squad-research-normalize");
+                          ("objective", `String "Normalize and verify latest AI research items");
+                          ("autonomy_level", `String "L4_Autonomous");
+                          ("policy_class", `String "guarded");
+                        ]);
+                   ])
+              ~response:
+                (`Assoc
+                   [
+                     ("status", `String "ok");
+                     ("result",
+                      `Assoc
+                        [
+                          ("operation_id", `String "op-...");
+                          ("trace_id", `String "trace-...");
+                          ("status", `String "active");
+                        ]);
+                   ])
+              ~notes:
+                [
+                  "Run dispatch/tick after operation start to materialize detachments.";
+                  "Without x-masc-agent-name (or x-masc-agent), actor attribution falls back to dashboard.";
+                ];
+            example ~id:"approval" ~title:"Approve strict action"
+              ~path_id:"cpv2_benchmark" ~transport:"mcp"
+              ~request:
+                (`Assoc
+                   [
+                     ("tool", `String "masc_policy_approve");
+                     ("arguments",
+                      `Assoc [ ("decision_id", `String "decision-...") ]);
+                   ])
+              ~response:
+                (`Assoc
+                   [
+                     ("status", `String "ok");
+                     ("decision_id", `String "decision-...");
+                     ("approval_state", `String "approved");
+                   ])
+              ~notes:
+                [ "Follow with masc_dispatch_tick to apply the approved move." ];
+          ] );
+    ]
+
+let command_plane_error_json message =
+  `Assoc [ ("status", `String "error"); ("message", `String message) ]

--- a/lib/server_mcp_transport_http.ml
+++ b/lib/server_mcp_transport_http.ml
@@ -1,0 +1,992 @@
+module Http = Http_server_eio
+module Mcp_eio = Mcp_server_eio
+module Http_negotiation = Mcp_protocol.Http_negotiation
+
+type deps = {
+  get_origin : Httpun.Request.t -> string;
+  cors_headers : string -> (string * string) list;
+  auth_token_from_request : Httpun.Request.t -> string option;
+  get_server_state_opt : unit -> Mcp_server.server_state option;
+  verify_mcp_auth : base_path:string -> Httpun.Request.t -> (unit, string) result;
+  verify_operator_mcp_auth :
+    base_path:string -> Httpun.Request.t -> (unit, string) result;
+}
+
+let mcp_protocol_versions = Mcp_server.supported_protocol_versions
+
+let mcp_protocol_version_default = Mcp_server.default_protocol_version
+
+let protocol_version_by_session : (string, string) Hashtbl.t =
+  Hashtbl.create 128
+
+let mcp_profile_by_session : (string, Mcp_eio.tool_profile) Hashtbl.t =
+  Hashtbl.create 128
+
+let default_base_path () =
+  match Sys.getenv_opt "ME_ROOT" with
+  | Some path -> path
+  | None -> Sys.getcwd ()
+
+let is_valid_protocol_version version =
+  List.mem version mcp_protocol_versions
+
+let remember_protocol_version session_id version =
+  if is_valid_protocol_version version then
+    Hashtbl.replace protocol_version_by_session session_id version
+
+let remember_mcp_profile session_id profile =
+  Hashtbl.replace mcp_profile_by_session session_id profile
+
+let forget_mcp_session session_id =
+  Hashtbl.remove protocol_version_by_session session_id;
+  Hashtbl.remove mcp_profile_by_session session_id
+
+let profile_label = function
+  | Mcp_eio.Full -> "/mcp"
+  | Mcp_eio.Operator_remote -> "/mcp/operator"
+
+let validate_mcp_session_profile ~profile session_id =
+  match Hashtbl.find_opt mcp_profile_by_session session_id with
+  | None -> Ok ()
+  | Some existing when existing = profile -> Ok ()
+  | Some existing ->
+      Error
+        (Printf.sprintf "Session %s belongs to %s, not %s." session_id
+           (profile_label existing) (profile_label profile))
+
+let validate_mcp_session_delete_profile ~profile session_id =
+  match profile with
+  | Mcp_eio.Operator_remote -> (
+      match Hashtbl.find_opt mcp_profile_by_session session_id with
+      | Some Mcp_eio.Operator_remote -> Ok ()
+      | Some existing ->
+          Error
+            (Printf.sprintf "Session %s belongs to %s, not %s." session_id
+               (profile_label existing) (profile_label profile))
+      | None ->
+          Error
+            (Printf.sprintf "Session %s is not registered on %s." session_id
+               (profile_label profile)))
+  | Mcp_eio.Full -> validate_mcp_session_profile ~profile session_id
+
+let protocol_version_from_body body_str =
+  try
+    let json = Yojson.Safe.from_string body_str in
+    match Mcp_server.jsonrpc_request_of_yojson json with
+    | Ok req when String.equal req.method_ "initialize" ->
+        let version =
+          Mcp_server.protocol_version_from_params req.params
+          |> Mcp_server.normalize_protocol_version
+        in
+        Some version
+    | _ -> None
+  with Yojson.Json_error _ | Yojson.Safe.Util.Type_error _ -> None
+
+let get_session_id_query target =
+  match String.split_on_char '?' target with
+  | [ _; query ] ->
+      query
+      |> String.split_on_char '&'
+      |> List.find_map (fun param ->
+             match String.split_on_char '=' param with
+             | [ "session_id"; v ] | [ "sessionId"; v ] -> Some v
+             | _ -> None)
+  | _ -> None
+
+let capitalize_ascii (s : string) =
+  if s = "" then
+    s
+  else
+    let first = Char.uppercase_ascii s.[0] |> String.make 1 in
+    let rest =
+      if String.length s > 1 then
+        String.sub s 1 (String.length s - 1) |> String.lowercase_ascii
+      else
+        ""
+    in
+    first ^ rest
+
+let title_case_header_name (header_name : string) =
+  header_name |> String.split_on_char '-' |> List.map capitalize_ascii
+  |> String.concat "-"
+
+let get_header_any_case (headers : Httpun.Headers.t) (name : string) =
+  match Httpun.Headers.get headers name with
+  | Some _ as value -> value
+  | None ->
+      let title_case = title_case_header_name name in
+      (match Httpun.Headers.get headers title_case with
+      | Some _ as value -> value
+      | None -> Httpun.Headers.get headers (String.uppercase_ascii name))
+
+let get_cookie_value (request : Httpun.Request.t) cookie_name =
+  match get_header_any_case request.headers "cookie" with
+  | None -> None
+  | Some raw ->
+      raw
+      |> String.split_on_char ';'
+      |> List.find_map (fun part ->
+             match String.split_on_char '=' (String.trim part) with
+             | key :: value_parts
+               when String.lowercase_ascii (String.trim key)
+                    = String.lowercase_ascii cookie_name ->
+                 let value = String.concat "=" value_parts |> String.trim in
+                 if value = "" then None else Some value
+             | _ -> None)
+
+let get_session_id_any (request : Httpun.Request.t) =
+  match get_session_id_query request.target with
+  | Some _ as id -> id
+  | None -> (
+      match get_header_any_case request.headers "mcp-session-id" with
+      | Some _ as id -> id
+      | None -> get_cookie_value request "mcp-session-id")
+
+let legacy_messages_endpoint_url (request : Httpun.Request.t) session_id =
+  match Httpun.Headers.get request.headers "host" with
+  | Some host ->
+      let proto =
+        match Httpun.Headers.get request.headers "x-forwarded-proto" with
+        | Some p -> p
+        | None ->
+            if
+              String.length host >= 17
+              && String.sub host 0 17 = "masc.crying.pict"
+            then "https"
+            else "http"
+      in
+      Printf.sprintf "%s://%s/messages?session_id=%s" proto host session_id
+  | None -> Printf.sprintf "/messages?session_id=%s" session_id
+
+let get_protocol_version (request : Httpun.Request.t) =
+  match Httpun.Headers.get request.headers "mcp-protocol-version" with
+  | Some v -> v
+  | None -> mcp_protocol_version_default
+
+let get_protocol_version_for_session ?session_id request =
+  match session_id with
+  | Some id -> (
+      match Hashtbl.find_opt protocol_version_by_session id with
+      | Some v -> v
+      | None -> get_protocol_version request)
+  | None -> get_protocol_version request
+
+let query_param request key =
+  let uri = Uri.of_string request.Httpun.Request.target in
+  Uri.get_query_param uri key
+
+let is_http_error_response = function
+  | `Assoc fields ->
+      let id_is_null =
+        match List.assoc_opt "id" fields with
+        | Some `Null -> true
+        | _ -> false
+      in
+      let code =
+        match List.assoc_opt "error" fields with
+        | Some (`Assoc err_fields) -> (
+            match List.assoc_opt "code" err_fields with
+            | Some (`Int c) -> Some c
+            | _ -> None)
+        | _ -> None
+      in
+      id_is_null && (code = Some (-32700) || code = Some (-32600))
+  | _ -> false
+
+let get_server_state deps =
+  match deps.get_server_state_opt () with
+  | Some state -> state
+  | None -> failwith "Server state not initialized"
+
+let env_flag name =
+  match Sys.getenv_opt name with
+  | Some raw -> (
+      match String.lowercase_ascii (String.trim raw) with
+      | "1" | "true" | "yes" | "on" -> true
+      | _ -> false)
+  | None -> false
+
+let header_truthy_value value =
+  match String.lowercase_ascii (String.trim value) with
+  | "1" | "true" | "yes" | "on" -> true
+  | _ -> false
+
+let request_force_json_response (request : Httpun.Request.t) =
+  match get_header_any_case request.headers "x-masc-force-json" with
+  | Some value -> header_truthy_value value
+  | None -> false
+
+let allow_legacy_accept = env_flag "MASC_ALLOW_LEGACY_ACCEPT"
+
+let classify_mcp_accept (request : Httpun.Request.t) =
+  Http_negotiation.classify_mcp_accept ~allow_legacy:allow_legacy_accept
+    (Httpun.Headers.get request.headers "accept")
+
+let legacy_accept_warning_headers = function
+  | Http_negotiation.Legacy_accepted ->
+      [
+        ( "warning",
+          "299 - \"Legacy Accept is deprecated; use 'application/json, text/event-stream'\"" );
+        ("x-masc-legacy-accept", "1");
+      ]
+  | Http_negotiation.Streamable | Http_negotiation.Rejected -> []
+
+let legacy_transport_deprecation_headers =
+  [
+    ("deprecation", "true");
+    ( "warning",
+      "299 - \"Legacy SSE endpoints (/sse,/messages) are deprecated; use /mcp\"" );
+    ("link", "</mcp>; rel=\"successor-version\"");
+  ]
+
+let force_json_response =
+  env_flag "MASC_FORCE_JSON_RESPONSE" || env_flag "MCP_FORCE_JSON_RESPONSE"
+
+let sse_retry_ms = 3000
+
+let sse_prime_event () =
+  let id = Sse.next_id () in
+  Printf.sprintf "retry: %d\nid: %d\n\n" sse_retry_ms id
+
+let sse_ping_interval_s = 30.0
+
+let env_float_or ~name ~default =
+  match Sys.getenv_opt name with
+  | None -> default
+  | Some raw -> (
+      try float_of_string raw with _ -> default)
+
+let env_int_or ~name ~default =
+  match Sys.getenv_opt name with
+  | None -> default
+  | Some raw -> (
+      try int_of_string raw with _ -> default)
+
+let sse_reconnect_min_interval_s =
+  env_float_or ~name:"MASC_SSE_RECONNECT_MIN_INTERVAL_S" ~default:0.0
+  |> Float.max 0.0
+
+let sse_connect_window_s =
+  env_float_or ~name:"MASC_SSE_CONNECT_WINDOW_S" ~default:0.0 |> Float.max 0.0
+
+let sse_connect_max_in_window =
+  env_int_or ~name:"MASC_SSE_CONNECT_MAX_IN_WINDOW" ~default:0 |> max 0
+
+let get_last_event_id (request : Httpun.Request.t) =
+  match Httpun.Headers.get request.headers "last-event-id" with
+  | Some id -> (
+      try Some (int_of_string id) with Failure _ -> None)
+  | None -> None
+
+let mcp_headers session_id protocol_version =
+  [ ("mcp-session-id", session_id); ("mcp-protocol-version", protocol_version) ]
+
+let session_cookie_header session_id =
+  ( "set-cookie",
+    Printf.sprintf
+      "mcp-session-id=%s; Path=/; Max-Age=86400; SameSite=Lax"
+      session_id )
+
+let sse_headers ~deps session_id protocol_version origin =
+  [
+    ("content-type", Http_negotiation.sse_content_type);
+    session_cookie_header session_id;
+  ]
+  @ mcp_headers session_id protocol_version
+  @ deps.cors_headers origin
+
+let sse_stream_headers ~deps session_id protocol_version origin =
+  [
+    ("content-type", Http_negotiation.sse_content_type);
+    ("cache-control", "no-cache");
+    ("connection", "keep-alive");
+    session_cookie_header session_id;
+  ]
+  @ mcp_headers session_id protocol_version
+  @ deps.cors_headers origin
+
+let json_headers ~deps session_id protocol_version origin =
+  [ ("content-type", "application/json") ]
+  @ mcp_headers session_id protocol_version
+  @ deps.cors_headers origin
+
+let respond_mcp_auth_error ?(extra_headers = []) ~deps request reqd ~session_id
+    ~protocol_version msg =
+  let origin = deps.get_origin request in
+  let body =
+    Yojson.Safe.to_string
+      (`Assoc
+        [
+          ("jsonrpc", `String "2.0");
+          ( "error",
+            `Assoc
+              [ ("code", `Int (-32001)); ("message", `String msg) ] );
+        ])
+  in
+  let headers =
+    Httpun.Headers.of_list
+      ((("content-length", string_of_int (String.length body))
+       :: ("www-authenticate", "Bearer")
+       :: extra_headers)
+      @ json_headers ~deps session_id protocol_version origin)
+  in
+  let response = Httpun.Response.create ~headers `Unauthorized in
+  Httpun.Reqd.respond_with_string reqd response body
+
+type sse_conn_info = {
+  session_id : string;
+  client_id : int;
+  writer : Httpun.Body.Writer.t;
+  mutex : Eio.Mutex.t;
+  stop : bool ref;
+  mutable closed : bool;
+}
+
+let sse_conn_by_session : (string, sse_conn_info) Hashtbl.t = Hashtbl.create 128
+
+type sse_connect_guard_state = {
+  mutable last_connect_at : float;
+  mutable connect_times : float list;
+}
+
+let sse_connect_guard_by_session :
+    (string, sse_connect_guard_state) Hashtbl.t =
+  Hashtbl.create 256
+
+let prune_connect_times ~now times =
+  if sse_connect_window_s <= 0.0 then times
+  else List.filter (fun ts -> now -. ts <= sse_connect_window_s) times
+
+let check_sse_connect_guard session_id =
+  let now = Time_compat.now () in
+  let state =
+    match Hashtbl.find_opt sse_connect_guard_by_session session_id with
+    | Some v -> v
+    | None -> { last_connect_at = -.1.0; connect_times = [] }
+  in
+  let recent = prune_connect_times ~now state.connect_times in
+  state.connect_times <- recent;
+  let session_wait_s =
+    if sse_reconnect_min_interval_s <= 0.0 then
+      0.0
+    else
+      sse_reconnect_min_interval_s -. (now -. state.last_connect_at)
+  in
+  if session_wait_s > 0.0 then
+    Error ("session_cooldown", session_wait_s)
+  else
+    let window_wait_s =
+      if sse_connect_window_s <= 0.0 || sse_connect_max_in_window <= 0 then
+        0.0
+      else if List.length recent >= sse_connect_max_in_window then
+        match List.rev recent with
+        | oldest :: _ -> sse_connect_window_s -. (now -. oldest)
+        | [] -> 0.0
+      else
+        0.0
+    in
+    if window_wait_s > 0.0 then
+      Error ("window_limit", window_wait_s)
+    else (
+      state.last_connect_at <- now;
+      state.connect_times <- now :: recent;
+      Hashtbl.replace sse_connect_guard_by_session session_id state;
+      Ok ())
+
+let respond_sse_rate_limited ~deps ~origin ~session_id ~protocol_version
+    ~reason ~retry_after_s reqd =
+  let retry_after_s = Float.max retry_after_s 0.001 in
+  let retry_after_header =
+    retry_after_s |> Float.ceil |> int_of_float |> max 1 |> string_of_int
+  in
+  let body =
+    `Assoc
+      [
+        ("error", `String "sse_connection_rate_limited");
+        ("reason", `String reason);
+        ("retry_after_seconds", `Float retry_after_s);
+      ]
+    |> Yojson.Safe.to_string
+  in
+  let headers =
+    Httpun.Headers.of_list
+      (("content-length", string_of_int (String.length body))
+      :: ("retry-after", retry_after_header)
+      :: json_headers ~deps session_id protocol_version origin)
+  in
+  let response = Httpun.Response.create ~headers `Too_many_requests in
+  Httpun.Reqd.respond_with_string reqd response body
+
+let close_sse_conn info =
+  if not info.closed then (
+    info.closed <- true;
+    info.stop := true;
+    (try Httpun.Body.Writer.close info.writer
+     with exn ->
+       Printf.eprintf "[DEBUG] close_sse_conn: %s\n%!"
+         (Printexc.to_string exn));
+    Sse.unregister_if_current info.session_id info.client_id)
+
+let stop_sse_session session_id =
+  match Hashtbl.find_opt sse_conn_by_session session_id with
+  | None -> ()
+  | Some info ->
+      Hashtbl.remove sse_conn_by_session session_id;
+      close_sse_conn info
+
+let close_all_sse_connections () =
+  let sessions = Hashtbl.fold (fun k _ acc -> k :: acc) sse_conn_by_session [] in
+  List.iter stop_sse_session sessions;
+  Printf.eprintf "🚀 MASC MCP: Closed %d SSE connections\n%!"
+    (List.length sessions)
+
+let send_raw info data =
+  if info.closed || !(info.stop) || Httpun.Body.Writer.is_closed info.writer then (
+    close_sse_conn info;
+    false)
+  else
+    try
+      Eio.Mutex.use_rw ~protect:true info.mutex (fun () ->
+          Httpun.Body.Writer.write_string info.writer data;
+          Httpun.Body.Writer.flush info.writer (fun _ -> ()));
+      Sse.touch info.session_id;
+      true
+    with _exn ->
+      close_sse_conn info;
+      false
+
+let handle_post_mcp ~deps ?(profile = Mcp_eio.Full) request reqd =
+  let session_id =
+    match get_session_id_any request with
+    | Some sid -> sid
+    | None -> Mcp_session.generate ()
+  in
+  let auth_token = deps.auth_token_from_request request in
+  let protocol_version = get_protocol_version_for_session ~session_id request in
+  let origin = deps.get_origin request in
+  let base_path =
+    match deps.get_server_state_opt () with
+    | Some s -> s.Mcp_server.room_config.base_path
+    | None -> default_base_path ()
+  in
+  let auth_result =
+    match profile with
+    | Mcp_eio.Full -> deps.verify_mcp_auth ~base_path request
+    | Mcp_eio.Operator_remote ->
+        deps.verify_operator_mcp_auth ~base_path request
+  in
+  match validate_mcp_session_profile ~profile session_id with
+  | Error msg ->
+      let body =
+        Printf.sprintf
+          {|{"jsonrpc":"2.0","error":{"code":-32600,"message":%s},"id":null}|}
+          (Yojson.Safe.to_string (`String msg))
+      in
+      let headers =
+        Httpun.Headers.of_list
+          (("content-length", string_of_int (String.length body))
+          :: json_headers ~deps session_id protocol_version origin)
+      in
+      let response = Httpun.Response.create ~headers `Conflict in
+      Httpun.Reqd.respond_with_string reqd response body
+  | Ok () ->
+      remember_mcp_profile session_id profile;
+      (match auth_result with
+      | Error msg ->
+          respond_mcp_auth_error ~deps request reqd ~session_id
+            ~protocol_version msg
+      | Ok () -> (
+          match classify_mcp_accept request with
+          | Http_negotiation.Rejected ->
+              let body =
+                Yojson.Safe.to_string
+                  (`Assoc
+                    [
+                      ("jsonrpc", `String "2.0");
+                      ( "error",
+                        `Assoc
+                          [
+                            ("code", `Int (-32600));
+                            ( "message",
+                              `String
+                                "Invalid Accept header: must include application/json and text/event-stream. Set MASC_ALLOW_LEGACY_ACCEPT=1 for temporary compatibility." );
+                          ] );
+                    ])
+              in
+              let headers =
+                Httpun.Headers.of_list
+                  (("content-length", string_of_int (String.length body))
+                  :: json_headers ~deps session_id protocol_version origin)
+              in
+              let response = Httpun.Response.create ~headers `Bad_request in
+              Httpun.Reqd.respond_with_string reqd response body
+          | accept_mode ->
+              let accept_warn_headers =
+                legacy_accept_warning_headers accept_mode
+              in
+              Http.Request.read_body_async reqd (fun body_str ->
+                  try
+                    let state = get_server_state deps in
+                    let sw = Eio_context.get_switch () in
+                    let clock = Eio_context.get_clock () in
+                    let response_json =
+                      Mcp_eio.handle_request ~clock ~sw ~profile
+                        ~mcp_session_id:session_id ?auth_token state body_str
+                    in
+                    (match protocol_version_from_body body_str with
+                    | Some v -> remember_protocol_version session_id v
+                    | None -> ());
+                    let protocol_version =
+                      get_protocol_version_for_session ~session_id request
+                    in
+                    let wants_sse =
+                      Http_negotiation.accepts_sse_header
+                        (Httpun.Headers.get request.headers "accept")
+                      && not force_json_response
+                      && not (request_force_json_response request)
+                    in
+                    if wants_sse then
+                      match response_json with
+                      | `Null ->
+                          let headers =
+                            Httpun.Headers.of_list
+                              ( ("content-length", "0")
+                              :: accept_warn_headers
+                              @ mcp_headers session_id protocol_version )
+                          in
+                          let response =
+                            Httpun.Response.create ~headers `Accepted
+                          in
+                          Httpun.Reqd.respond_with_string reqd response ""
+                      | json when is_http_error_response json ->
+                          let body = Yojson.Safe.to_string json in
+                          let headers =
+                            Httpun.Headers.of_list
+                              ( ("content-length", string_of_int (String.length body))
+                              :: accept_warn_headers
+                              @ json_headers ~deps session_id protocol_version
+                                  origin )
+                          in
+                          let response =
+                            Httpun.Response.create ~headers `Bad_request
+                          in
+                          Httpun.Reqd.respond_with_string reqd response body
+                      | json ->
+                          let event =
+                            Sse.format_event ~event_type:"message"
+                              (Yojson.Safe.to_string json)
+                          in
+                          let body = sse_prime_event () ^ event in
+                          let headers =
+                            Httpun.Headers.of_list
+                              ( ("content-length", string_of_int (String.length body))
+                              :: accept_warn_headers
+                              @ sse_headers ~deps session_id protocol_version
+                                  origin )
+                          in
+                          let response =
+                            Httpun.Response.create ~headers `OK
+                          in
+                          Httpun.Reqd.respond_with_string reqd response body
+                    else
+                      match response_json with
+                      | `Null ->
+                          let headers =
+                            Httpun.Headers.of_list
+                              ( ("content-length", "0")
+                              :: accept_warn_headers
+                              @ mcp_headers session_id protocol_version )
+                          in
+                          let response =
+                            Httpun.Response.create ~headers `Accepted
+                          in
+                          Httpun.Reqd.respond_with_string reqd response ""
+                      | json when is_http_error_response json ->
+                          let body = Yojson.Safe.to_string json in
+                          let headers =
+                            Httpun.Headers.of_list
+                              ( ("content-length", string_of_int (String.length body))
+                              :: accept_warn_headers
+                              @ json_headers ~deps session_id protocol_version
+                                  origin )
+                          in
+                          let response =
+                            Httpun.Response.create ~headers `Bad_request
+                          in
+                          Httpun.Reqd.respond_with_string reqd response body
+                      | json ->
+                          let body = Yojson.Safe.to_string json in
+                          let headers =
+                            Httpun.Headers.of_list
+                              ( ("content-length", string_of_int (String.length body))
+                              :: accept_warn_headers
+                              @ json_headers ~deps session_id protocol_version
+                                  origin )
+                          in
+                          let response =
+                            Httpun.Response.create ~headers `OK
+                          in
+                          Httpun.Reqd.respond_with_string reqd response body
+                  with exn ->
+                    let protocol_version =
+                      get_protocol_version_for_session ~session_id request
+                    in
+                    let body =
+                      Printf.sprintf
+                        {|{"jsonrpc":"2.0","error":{"code":-32603,"message":%s},"id":null}|}
+                        (Yojson.Safe.to_string
+                           (`String
+                             ("Internal error: " ^ Printexc.to_string exn)))
+                    in
+                    let headers =
+                      Httpun.Headers.of_list
+                        ( ("content-length", string_of_int (String.length body))
+                        :: json_headers ~deps session_id protocol_version origin
+                        )
+                    in
+                    let response =
+                      Httpun.Response.create ~headers `Internal_server_error
+                    in
+                    Httpun.Reqd.respond_with_string reqd response body)))
+
+let handle_get_mcp ~deps ?legacy_messages_endpoint ?(profile = Mcp_eio.Full)
+    request reqd =
+  let origin = deps.get_origin request in
+  let session_id = Mcp_session.get_or_generate (get_session_id_any request) in
+  let protocol_version = get_protocol_version_for_session ~session_id request in
+  let legacy_headers =
+    match legacy_messages_endpoint with
+    | Some _ -> legacy_transport_deprecation_headers
+    | None -> []
+  in
+  let last_event_id = get_last_event_id request in
+  match validate_mcp_session_profile ~profile session_id with
+  | Error msg ->
+      let headers =
+        Httpun.Headers.of_list
+          (("content-length", string_of_int (String.length msg))
+          :: json_headers ~deps session_id protocol_version origin)
+      in
+      let response = Httpun.Response.create ~headers `Conflict in
+      Httpun.Reqd.respond_with_string reqd response msg
+  | Ok () ->
+      remember_mcp_profile session_id profile;
+      (match check_sse_connect_guard session_id with
+      | Error (reason, retry_after_s) ->
+          respond_sse_rate_limited ~deps ~origin ~session_id ~protocol_version
+            ~reason ~retry_after_s reqd
+      | Ok () ->
+          stop_sse_session session_id;
+          let headers =
+            Httpun.Headers.of_list
+              (legacy_headers
+              @ sse_stream_headers ~deps session_id protocol_version origin)
+          in
+          let response = Httpun.Response.create ~headers `OK in
+          let writer = Httpun.Reqd.respond_with_streaming reqd response in
+          let mutex = Eio.Mutex.create () in
+          let info_ref : sse_conn_info option ref = ref None in
+          let push event =
+            match !info_ref with
+            | None -> ()
+            | Some info -> ignore (send_raw info event)
+          in
+          let client_id, evicted =
+            Sse.register session_id ~push
+              ~last_event_id:(Option.value ~default:0 last_event_id)
+          in
+          (match evicted with
+          | Some evicted_sid -> stop_sse_session evicted_sid
+          | None -> ());
+          let info =
+            {
+              session_id;
+              client_id;
+              writer;
+              mutex;
+              stop = ref false;
+              closed = false;
+            }
+          in
+          info_ref := Some info;
+          Hashtbl.replace sse_conn_by_session session_id info;
+          ignore (send_raw info (sse_prime_event ()));
+          (match legacy_messages_endpoint with
+          | None -> ()
+          | Some f ->
+              let endpoint_url = f session_id in
+              ignore
+                (send_raw info
+                   (Sse.format_event ~event_type:"endpoint" endpoint_url)));
+          (match last_event_id with
+          | Some last_id ->
+              let missed = Sse.get_events_after last_id in
+              List.iter (fun ev -> ignore (send_raw info ev)) missed
+          | None -> ());
+          (match
+             (Eio_context.get_switch_opt (), Eio_context.get_clock_opt ())
+           with
+          | Some sw, Some clock ->
+              Eio.Fiber.fork ~sw (fun () ->
+                  let is_cancelled exn =
+                    match exn with
+                    | Eio.Cancel.Cancelled _ -> true
+                    | _ -> false
+                  in
+                  let rec loop () =
+                    if not !(info.stop) then (
+                      (try Eio.Time.sleep clock sse_ping_interval_s
+                       with exn ->
+                         if is_cancelled exn then raise exn;
+                         Printf.eprintf "[SSE] ping sleep error: %s\n%!"
+                           (Printexc.to_string exn));
+                      (try
+                         if info.closed then
+                           stop_sse_session info.session_id
+                         else if not !(info.stop) then
+                           ignore (send_raw info ": ping\n\n")
+                       with exn ->
+                         if is_cancelled exn then raise exn;
+                         Printf.eprintf "[SSE] ping send error: %s\n%!"
+                           (Printexc.to_string exn);
+                         stop_sse_session info.session_id);
+                      loop ())
+                  in
+                  try loop () with exn ->
+                    if is_cancelled exn then ()
+                    else
+                      Printf.eprintf "[SSE] ping loop error: %s\n%!"
+                        (Printexc.to_string exn))
+          | _ -> ());
+          let client_count = Sse.client_count () in
+          if client_count > Sse.max_clients / 2 then
+            Printf.eprintf "📡 SSE connected: %s (active: %d/%d)\n%!"
+              session_id client_count Sse.max_clients)
+
+let sse_simple_handler ~deps request reqd =
+  let origin = deps.get_origin request in
+  let session_id = Mcp_session.get_or_generate (get_session_id_any request) in
+  let protocol_version = get_protocol_version_for_session ~session_id request in
+  let event =
+    sse_prime_event ()
+    ^ Sse.format_event ~event_type:"connected"
+        (Printf.sprintf {|{"session_id":"%s"}|} session_id)
+  in
+  let headers =
+    Httpun.Headers.of_list
+      (("content-length", string_of_int (String.length event))
+      :: legacy_transport_deprecation_headers
+      @ sse_headers ~deps session_id protocol_version origin)
+  in
+  let response = Httpun.Response.create ~headers `OK in
+  Httpun.Reqd.respond_with_string reqd response event
+
+let handle_get_operator_mcp ~deps request reqd =
+  let session_id = Mcp_session.get_or_generate (get_session_id_any request) in
+  let protocol_version = get_protocol_version_for_session ~session_id request in
+  let base_path =
+    match deps.get_server_state_opt () with
+    | Some s -> s.Mcp_server.room_config.base_path
+    | None -> default_base_path ()
+  in
+  match deps.verify_operator_mcp_auth ~base_path request with
+  | Error msg ->
+      respond_mcp_auth_error ~deps request reqd ~session_id ~protocol_version
+        msg
+  | Ok () ->
+      handle_get_mcp ~deps ~profile:Mcp_eio.Operator_remote request reqd
+
+let handle_post_messages ~deps request reqd =
+  let origin = deps.get_origin request in
+  let legacy_headers = legacy_transport_deprecation_headers in
+  match get_session_id_any request with
+  | None ->
+      let body = "session_id required" in
+      let headers =
+        Httpun.Headers.of_list
+          (("content-length", string_of_int (String.length body))
+          :: (legacy_headers @ deps.cors_headers origin))
+      in
+      let response = Httpun.Response.create ~headers `Bad_request in
+      Httpun.Reqd.respond_with_string reqd response body
+  | Some session_id when not (Mcp_session.is_valid session_id) ->
+      let body = "invalid session_id" in
+      let headers =
+        Httpun.Headers.of_list
+          (("content-length", string_of_int (String.length body))
+          :: (legacy_headers @ deps.cors_headers origin))
+      in
+      let response = Httpun.Response.create ~headers `Bad_request in
+      Httpun.Reqd.respond_with_string reqd response body
+  | Some session_id ->
+      let protocol_version = get_protocol_version_for_session ~session_id request in
+      let auth_token = deps.auth_token_from_request request in
+      let base_path =
+        match deps.get_server_state_opt () with
+        | Some s -> s.Mcp_server.room_config.base_path
+        | None -> default_base_path ()
+      in
+      (match deps.verify_mcp_auth ~base_path request with
+      | Error msg ->
+          respond_mcp_auth_error ~deps request reqd ~session_id
+            ~protocol_version ~extra_headers:legacy_headers msg
+      | Ok () ->
+          Http.Request.read_body_async reqd (fun body_str ->
+              let state = get_server_state deps in
+              let sw = Eio_context.get_switch () in
+              let clock = Eio_context.get_clock () in
+              let response_json =
+                Mcp_eio.handle_request ~clock ~sw ~mcp_session_id:session_id
+                  ?auth_token state body_str
+              in
+              (match response_json with
+              | `Null -> ()
+              | json -> Sse.send_to session_id json);
+              let headers =
+                Httpun.Headers.of_list
+                  (("content-length", "0")
+                  :: (legacy_headers @ mcp_headers session_id protocol_version))
+              in
+              let response = Httpun.Response.create ~headers `Accepted in
+              Httpun.Reqd.respond_with_string reqd response ""))
+
+let handle_delete_mcp ~deps ?(profile = Mcp_eio.Full) request reqd =
+  let base_path =
+    match deps.get_server_state_opt () with
+    | Some s -> s.Mcp_server.room_config.base_path
+    | None -> default_base_path ()
+  in
+  let auth_result =
+    match profile with
+    | Mcp_eio.Full -> Ok ()
+    | Mcp_eio.Operator_remote ->
+        deps.verify_operator_mcp_auth ~base_path request
+  in
+  match auth_result with
+  | Error msg ->
+      let session_id = Mcp_session.get_or_generate (get_session_id_any request) in
+      let protocol_version = get_protocol_version_for_session ~session_id request in
+      respond_mcp_auth_error ~deps request reqd ~session_id ~protocol_version
+        msg
+  | Ok () -> (
+      match get_session_id_any request with
+      | Some session_id -> (
+          match validate_mcp_session_delete_profile ~profile session_id with
+          | Error msg ->
+              let headers =
+                Httpun.Headers.of_list
+                  [ ("content-length", string_of_int (String.length msg)) ]
+              in
+              let response = Httpun.Response.create ~headers `Conflict in
+              Httpun.Reqd.respond_with_string reqd response msg
+          | Ok () ->
+              stop_sse_session session_id;
+              Sse.unregister session_id;
+              forget_mcp_session session_id;
+              Printf.printf "🔚 Session terminated: %s\n%!" session_id;
+              let headers =
+                Httpun.Headers.of_list
+                  (("content-length", "0")
+                  :: mcp_headers session_id (get_protocol_version request))
+              in
+              let response = Httpun.Response.create ~headers `No_content in
+              Httpun.Reqd.respond_with_string reqd response "")
+      | None ->
+          let body = "Mcp-Session-Id required" in
+          let headers =
+            Httpun.Headers.of_list
+              [ ("content-length", string_of_int (String.length body)) ]
+          in
+          let response = Httpun.Response.create ~headers `Bad_request in
+          Httpun.Reqd.respond_with_string reqd response body)
+
+let ag_ui_event_of_masc_event ~room_id event =
+  try
+    let lines = String.split_on_char '\n' event in
+    let data_line =
+      List.find_opt
+        (fun l -> String.length l > 6 && String.sub l 0 6 = "data: ")
+        lines
+    in
+    match data_line with
+    | Some dl ->
+        let json_str = String.sub dl 6 (String.length dl - 6) in
+        let json = Yojson.Safe.from_string json_str in
+        let ag_event = Ag_ui.of_custom ~room_id ~name:"MASC_EVENT" json in
+        Ag_ui.event_to_sse ag_event
+    | None -> event
+  with _ -> event
+
+let handle_ag_ui_events ~deps request reqd =
+  let origin = deps.get_origin request in
+  let session_id = Mcp_session.get_or_generate (get_session_id_any request) in
+  let protocol_version = get_protocol_version_for_session ~session_id request in
+  let room_id = Option.value ~default:"default" (query_param request "room") in
+  let last_event_id = get_last_event_id request in
+  match check_sse_connect_guard session_id with
+  | Error (reason, retry_after_s) ->
+      respond_sse_rate_limited ~deps ~origin ~session_id ~protocol_version
+        ~reason ~retry_after_s reqd
+  | Ok () ->
+      stop_sse_session session_id;
+      let headers =
+        Httpun.Headers.of_list
+          (sse_stream_headers ~deps session_id protocol_version origin)
+      in
+      let response = Httpun.Response.create ~headers `OK in
+      let writer = Httpun.Reqd.respond_with_streaming reqd response in
+      let mutex = Eio.Mutex.create () in
+      let info_ref : sse_conn_info option ref = ref None in
+      let push event =
+        match !info_ref with
+        | None -> ()
+        | Some info -> ignore (send_raw info (ag_ui_event_of_masc_event ~room_id event))
+      in
+      let client_id, evicted =
+        Sse.register session_id ~push
+          ~last_event_id:(Option.value ~default:0 last_event_id)
+      in
+      (match evicted with
+      | Some evicted_sid -> stop_sse_session evicted_sid
+      | None -> ());
+      let info =
+        {
+          session_id;
+          client_id;
+          writer;
+          mutex;
+          stop = ref false;
+          closed = false;
+        }
+      in
+      info_ref := Some info;
+      Hashtbl.replace sse_conn_by_session session_id info;
+      let prime =
+        Ag_ui.(
+          make_event ~thread_id:room_id ~run_id:(Some session_id) Run_started
+          |> event_to_sse)
+      in
+      ignore (send_raw info prime);
+      (match last_event_id with
+      | Some last_id ->
+          let missed = Sse.get_events_after last_id in
+          List.iter (fun ev -> ignore (send_raw info ev)) missed
+      | None -> ());
+      (match
+         (Eio_context.get_switch_opt (), Eio_context.get_clock_opt ())
+       with
+      | Some sw, Some clock ->
+          Eio.Fiber.fork ~sw (fun () ->
+              let rec loop () =
+                if not !(info.stop) then (
+                  (try Eio.Time.sleep clock sse_ping_interval_s with _ -> ());
+                  (try
+                     if info.closed then
+                       stop_sse_session info.session_id
+                     else if not !(info.stop) then
+                       ignore (send_raw info ": ping\n\n")
+                   with _ -> stop_sse_session info.session_id);
+                  loop ())
+              in
+              try loop () with _ -> ())
+      | _ -> ())


### PR DESCRIPTION
## Summary
- extract the command-plane HTTP/H2 route family from `bin/main_eio.ml` into `lib/server_command_plane_http.ml`
- keep route wiring and response semantics intact by replacing the old in-file implementations with thin wrappers
- start the planned `main_eio` god-module split with the most self-contained route family first

## Verification
- `dune build --root . _build/default/bin/main_eio.exe`
- `_build/default/bin/main_eio.exe --help`
- `_build/default/test/test_mcp_server_eio.exe`
- `_build/default/test/test_http_server_eio_coverage.exe`

## Follow-up
- next slices: MCP transport handlers, GraphQL/TRPG SSE handlers, then final route/bootstrap thinning