### PR TITLE
feat(tools): add 3-tier tool filtering (Essential/Standard/Full)

### DIFF
--- a/lib/masc_mcp.ml
+++ b/lib/masc_mcp.ml
@@ -248,6 +248,7 @@ module Tool_control = Tool_control
 module Tool_verification = Tool_verification
 module Tool_misc = Tool_misc
 module Tool_registry = Tool_registry
+module Tool_catalog = Tool_catalog
 module Tool_llama = Tool_llama
 module Tool_board = Tool_board
 module Tool_command_plane = Tool_command_plane

--- a/lib/mcp_server_eio.ml
+++ b/lib/mcp_server_eio.ml
@@ -2983,6 +2983,7 @@ type tools_list_params = {
   include_deprecated : bool;
   include_usage : bool;
   mode : string option;
+  tier : string option;
 }
 
 let bool_param payload key =
@@ -3002,6 +3003,7 @@ let requested_tool_list_params params =
         include_deprecated = false;
         include_usage = false;
         mode = None;
+        tier = None;
       }
   | Some (`Assoc _ as payload) -> (
       let names_result =
@@ -3026,12 +3028,24 @@ let requested_tool_list_params params =
         | `String s -> Ok (Some s)
         | _ -> Error "Invalid params: mode must be a string"
       in
+      let tier_result =
+        match payload |> member "tier" with
+        | `Null -> Ok None
+        | `String s -> (
+            match Tool_catalog.tier_of_string (String.lowercase_ascii s) with
+            | Some _ -> Ok (Some s)
+            | None -> Error "Invalid params: tier must be one of: essential, standard, full")
+        | _ -> Error "Invalid params: tier must be a string"
+      in
       match names_result with
       | Error _ as err -> err
       | Ok names -> (
           match mode_result with
           | Error _ as err -> err
           | Ok mode -> (
+          match tier_result with
+          | Error _ as err -> err
+          | Ok tier -> (
           match bool_param payload "include_hidden" with
           | Error _ as err -> err
           | Ok include_hidden -> (
@@ -3047,7 +3061,8 @@ let requested_tool_list_params params =
                         include_deprecated;
                         include_usage;
                         mode;
-                      })))))
+                        tier;
+                      }))))))
   | Some _ -> Error "Invalid params: expected object"
 
 let handle_initialize_eio ?(profile = Full) id params =
@@ -3065,12 +3080,17 @@ let handle_initialize_eio ?(profile = Full) id params =
       ])
 
 let handle_list_tools_eio ?(profile = Full) ?names ?(include_hidden = false)
-    ?(include_deprecated = false) ?(include_usage = false) ?mode state id =
+    ?(include_deprecated = false) ?(include_usage = false) ?mode ?tier state id =
   let usage_summary =
     if include_usage then
       Some (Telemetry_eio.summarize_tool_usage ?fs:state.Mcp_server.fs state.Mcp_server.room_config)
     else
       None
+  in
+  let tier_filter =
+    match tier with
+    | None -> None
+    | Some s -> Tool_catalog.tier_of_string (String.lowercase_ascii s)
   in
   let tools =
     tool_schemas_for_profile ~include_hidden ~include_deprecated
@@ -3080,6 +3100,11 @@ let handle_list_tools_eio ?(profile = Full) ?names ?(include_hidden = false)
        | Some wanted ->
            List.filter (fun (schema : Types.tool_schema) ->
              List.mem schema.name wanted))
+    |> (match tier_filter with
+       | None -> Fun.id
+       | Some t ->
+           List.filter (fun (schema : Types.tool_schema) ->
+             Tool_catalog.is_in_tier t schema.name))
     |> List.map (tool_json_for_profile ?usage_summary profile)
   in
   let result_fields =
@@ -3158,9 +3183,9 @@ let handle_request
                    | "tools/list" -> (
                        match requested_tool_list_params req.params with
                        | Error msg -> make_error ~id (-32602) msg
-                       | Ok { names; include_hidden; include_deprecated; include_usage; mode } ->
+                       | Ok { names; include_hidden; include_deprecated; include_usage; mode; tier } ->
                            handle_list_tools_eio ~profile ?names ~include_hidden
-                             ~include_deprecated ~include_usage ?mode state id)
+                             ~include_deprecated ~include_usage ?mode ?tier state id)
                    | "tools/call" ->
                        (match req.params with
                        | Some params ->

--- a/lib/tool_catalog.ml
+++ b/lib/tool_catalog.ml
@@ -12,6 +12,11 @@ type implementation_status =
   | Simulation
   | Placeholder
 
+type tier =
+  | Essential
+  | Standard
+  | Full
+
 type metadata = {
   visibility : visibility;
   lifecycle : lifecycle;
@@ -182,6 +187,74 @@ let lifecycle_to_string = function
   | Active -> "active"
   | Deprecated -> "deprecated"
 
+(** {1 Tool Tier System}
+
+    3-tier tool filtering to reduce the number of tools presented to LLMs.
+    Essential (~20) < Standard (~50) < Full (all).
+    Tier is an additive overlay on the existing mode/category system. *)
+
+let essential_tools =
+  [
+    "masc_join"; "masc_leave"; "masc_status"; "masc_set_room";
+    "masc_add_task"; "masc_claim_next"; "masc_transition"; "masc_tasks";
+    "masc_broadcast"; "masc_heartbeat"; "masc_messages";
+    "masc_worktree_create"; "masc_worktree_list"; "masc_worktree_remove";
+    "masc_plan_init"; "masc_plan_get"; "masc_plan_set_task"; "masc_plan_update";
+    "masc_who"; "masc_dashboard";
+  ]
+
+let standard_tools =
+  essential_tools
+  @ [
+    (* Board *)
+    "masc_board_post"; "masc_board_get"; "masc_board_list";
+    "masc_board_vote"; "masc_board_comment"; "masc_board_comment_vote";
+    "masc_board_search"; "masc_board_stats"; "masc_board_profile";
+    "masc_board_hearths";
+    (* Team Session *)
+    "masc_team_session_start"; "masc_team_session_step";
+    "masc_team_session_status"; "masc_team_session_stop";
+    "masc_team_session_list"; "masc_team_session_events";
+    (* Consensus *)
+    "masc_consensus_start"; "masc_consensus_vote";
+    "masc_consensus_result"; "masc_consensus_close";
+    (* Decision *)
+    "decision_create"; "decision_finalize"; "decision_status";
+    (* Handover *)
+    "masc_handover_create"; "masc_handover_claim";
+    "masc_handover_get"; "masc_handover_list";
+    (* Misc *)
+    "masc_spawn"; "masc_agents"; "masc_progress";
+    "masc_note_add"; "masc_batch_add_tasks"; "masc_stats";
+  ]
+
+let tier_to_string = function
+  | Essential -> "essential"
+  | Standard -> "standard"
+  | Full -> "full"
+
+let tier_of_string = function
+  | "essential" -> Some Essential
+  | "standard" -> Some Standard
+  | "full" -> Some Full
+  | _ -> None
+
+let tool_tier name =
+  if List.mem name essential_tools then Essential
+  else if List.mem name standard_tools then Standard
+  else Full
+
+let is_in_tier tier name =
+  match tier with
+  | Full -> true
+  | Standard -> List.mem name standard_tools
+  | Essential -> List.mem name essential_tools
+
+let tier_tool_count = function
+  | Essential -> List.length essential_tools
+  | Standard -> List.length standard_tools
+  | Full -> -1  (* unknown until schemas are enumerated *)
+
 let metadata_to_fields name =
   let meta = metadata name in
   let base =
@@ -189,6 +262,7 @@ let metadata_to_fields name =
       ("visibility", `String (visibility_to_string meta.visibility));
       ("lifecycle", `String (lifecycle_to_string meta.lifecycle));
       ("implementationStatus", `String (implementation_status_to_string meta.implementation_status));
+      ("tier", `String (tier_to_string (tool_tier name)));
     ]
   in
   let with_canonical =

--- a/test/dune
+++ b/test/dune
@@ -23,7 +23,8 @@
         test_multi_room test_worktree_detection test_bounded test_mention test_hat
         test_swarm test_heartbeat_qw test_sse_qw test_agent_health
         test_post_verifier test_post_verifier_llm test_mdal
-        test_swarm_checkpoint test_swarm_goal_loop test_mdal_swarm)
+        test_swarm_checkpoint test_swarm_goal_loop test_mdal_swarm
+        test_tool_tier)
  (modules test_room test_types test_checkpoint test_auth test_http_negotiation
           test_sse test_encryption test_backend test_cancellation test_graphql_api
           test_graphql_endpoint
@@ -33,7 +34,8 @@
           test_multi_room test_worktree_detection test_bounded test_mention test_hat
           test_swarm test_heartbeat_qw test_sse_qw test_agent_health
           test_post_verifier test_post_verifier_llm test_mdal
-          test_swarm_checkpoint test_swarm_goal_loop test_mdal_swarm)
+          test_swarm_checkpoint test_swarm_goal_loop test_mdal_swarm
+          test_tool_tier)
  (libraries masc_mcp alcotest str yojson mirage-crypto
             mirage-crypto-rng mirage-crypto-rng.unix cohttp cstruct unix))
 

--- a/test/test_tool_tier.ml
+++ b/test/test_tool_tier.ml
@@ -1,0 +1,156 @@
+(** Tests for Tool_catalog tier system — 3-tier tool filtering *)
+
+module Tool_catalog = Masc_mcp.Tool_catalog
+
+let () =
+  let open Alcotest in
+  run "Tool_tier"
+    [
+      ( "essential_tools",
+        [
+          test_case "contains expected core tools" `Quick (fun () ->
+              let essential =
+                [
+                  "masc_join"; "masc_leave"; "masc_status"; "masc_set_room";
+                  "masc_add_task"; "masc_claim_next"; "masc_transition";
+                  "masc_tasks"; "masc_broadcast"; "masc_heartbeat";
+                  "masc_messages"; "masc_worktree_create";
+                  "masc_worktree_list"; "masc_worktree_remove";
+                  "masc_plan_init"; "masc_plan_get"; "masc_plan_set_task";
+                  "masc_plan_update"; "masc_who"; "masc_dashboard";
+                ]
+              in
+              List.iter
+                (fun name ->
+                  check bool (name ^ " is essential") true
+                    (Tool_catalog.tool_tier name = Tool_catalog.Essential))
+                essential);
+          test_case "count is 20" `Quick (fun () ->
+              check int "essential count" 20
+                (Tool_catalog.tier_tool_count Tool_catalog.Essential));
+        ] );
+      ( "standard_tools",
+        [
+          test_case "includes all essential tools" `Quick (fun () ->
+              check bool "masc_join in standard" true
+                (Tool_catalog.is_in_tier Tool_catalog.Standard "masc_join");
+              check bool "masc_dashboard in standard" true
+                (Tool_catalog.is_in_tier Tool_catalog.Standard "masc_dashboard"));
+          test_case "includes board tools" `Quick (fun () ->
+              check bool "masc_board_post" true
+                (Tool_catalog.is_in_tier Tool_catalog.Standard "masc_board_post");
+              check bool "masc_board_search" true
+                (Tool_catalog.is_in_tier Tool_catalog.Standard
+                   "masc_board_search"));
+          test_case "includes team session tools" `Quick (fun () ->
+              check bool "masc_team_session_start" true
+                (Tool_catalog.is_in_tier Tool_catalog.Standard
+                   "masc_team_session_start");
+              check bool "masc_team_session_step" true
+                (Tool_catalog.is_in_tier Tool_catalog.Standard
+                   "masc_team_session_step"));
+          test_case "includes consensus tools" `Quick (fun () ->
+              check bool "masc_consensus_start" true
+                (Tool_catalog.is_in_tier Tool_catalog.Standard
+                   "masc_consensus_start");
+              check bool "masc_consensus_vote" true
+                (Tool_catalog.is_in_tier Tool_catalog.Standard
+                   "masc_consensus_vote"));
+          test_case "includes decision tools" `Quick (fun () ->
+              check bool "decision_create" true
+                (Tool_catalog.is_in_tier Tool_catalog.Standard "decision_create");
+              check bool "decision_status" true
+                (Tool_catalog.is_in_tier Tool_catalog.Standard "decision_status"));
+          test_case "count is reasonable (40-60)" `Quick (fun () ->
+              let n = Tool_catalog.tier_tool_count Tool_catalog.Standard in
+              check bool "between 40 and 60" true (n >= 40 && n <= 60));
+        ] );
+      ( "full_tier",
+        [
+          test_case "is_in_tier Full always returns true" `Quick (fun () ->
+              check bool "arbitrary tool" true
+                (Tool_catalog.is_in_tier Tool_catalog.Full
+                   "masc_some_unknown_tool_xyz");
+              check bool "essential tool" true
+                (Tool_catalog.is_in_tier Tool_catalog.Full "masc_join"));
+          test_case "tier_tool_count returns -1 for Full" `Quick (fun () ->
+              check int "unknown count" (-1)
+                (Tool_catalog.tier_tool_count Tool_catalog.Full));
+        ] );
+      ( "tool_tier",
+        [
+          test_case "essential tool returns Essential" `Quick (fun () ->
+              check string "tier" "essential"
+                (Tool_catalog.tier_to_string
+                   (Tool_catalog.tool_tier "masc_join")));
+          test_case "standard-only tool returns Standard" `Quick (fun () ->
+              check string "tier" "standard"
+                (Tool_catalog.tier_to_string
+                   (Tool_catalog.tool_tier "masc_board_post")));
+          test_case "unknown tool returns Full" `Quick (fun () ->
+              check string "tier" "full"
+                (Tool_catalog.tier_to_string
+                   (Tool_catalog.tool_tier "masc_risc_pipeline_status")));
+        ] );
+      ( "tier_of_string",
+        [
+          test_case "parses valid tier names" `Quick (fun () ->
+              check bool "essential" true
+                (Tool_catalog.tier_of_string "essential"
+                = Some Tool_catalog.Essential);
+              check bool "standard" true
+                (Tool_catalog.tier_of_string "standard"
+                = Some Tool_catalog.Standard);
+              check bool "full" true
+                (Tool_catalog.tier_of_string "full" = Some Tool_catalog.Full));
+          test_case "rejects invalid names" `Quick (fun () ->
+              check bool "bogus" true
+                (Tool_catalog.tier_of_string "bogus" = None);
+              check bool "empty" true
+                (Tool_catalog.tier_of_string "" = None));
+        ] );
+      ( "is_in_tier_filtering",
+        [
+          test_case "Essential excludes standard-only tools" `Quick (fun () ->
+              check bool "board_post not essential" false
+                (Tool_catalog.is_in_tier Tool_catalog.Essential
+                   "masc_board_post"));
+          test_case "Standard excludes full-only tools" `Quick (fun () ->
+              check bool "risc tool not standard" false
+                (Tool_catalog.is_in_tier Tool_catalog.Standard
+                   "masc_risc_pipeline_status"));
+          test_case "Essential subset property" `Quick (fun () ->
+              let essentials =
+                [
+                  "masc_join"; "masc_leave"; "masc_status"; "masc_add_task";
+                  "masc_transition"; "masc_broadcast"; "masc_heartbeat";
+                ]
+              in
+              List.iter
+                (fun name ->
+                  check bool (name ^ " also in standard") true
+                    (Tool_catalog.is_in_tier Tool_catalog.Standard name))
+                essentials);
+        ] );
+      ( "metadata_to_fields",
+        [
+          test_case "includes tier in output" `Quick (fun () ->
+              let fields = Tool_catalog.metadata_to_fields "masc_join" in
+              let tier_val =
+                List.assoc_opt "tier" fields
+                |> Option.map (function `String s -> s | _ -> "")
+                |> Option.value ~default:""
+              in
+              check string "tier field" "essential" tier_val);
+          test_case "full-tier tool has tier=full" `Quick (fun () ->
+              let fields =
+                Tool_catalog.metadata_to_fields "masc_risc_pipeline_status"
+              in
+              let tier_val =
+                List.assoc_opt "tier" fields
+                |> Option.map (function `String s -> s | _ -> "")
+                |> Option.value ~default:""
+              in
+              check string "tier field" "full" tier_val);
+        ] );
+    ]


### PR DESCRIPTION
## Summary
- MCP `tools/list` 엔드포인트에 3-tier 필터링 추가 (Essential 20개 / Standard ~53개 / Full 전체)
- LLM이 360+ 도구 중 올바른 도구를 선택하는 정확도 개선이 목적
- `tools/list` 요청 시 `"tier": "essential"` 파라미터로 노출 도구 수 제어 가능
- 기존 동작(파라미터 없이 호출)은 Full tier로 하위호환 유지

## Changes
| File | Change |
|------|--------|
| `lib/tool_catalog.ml` | `tier` type, Essential/Standard 화이트리스트, 헬퍼 함수 |
| `lib/mcp_server_eio.ml` | `tools_list_params`에 tier 필드 + 파싱 + `List.filter` |
| `lib/masc_mcp.ml` | `Tool_catalog` 모듈 re-export |
| `test/test_tool_tier.ml` | 7개 그룹 20개 테스트 케이스 |
| `test/dune` | `test_tool_tier` 추가 |

## Test plan
- [x] `dune test --root .` 전체 통과 (exit 0)
- [x] `test_tool_tier.exe` 20개 테스트 0.002s 통과
- [ ] 서버 기동 후 `tools/list` tier 파라미터 수동 검증
- [ ] Claude Code `.mcp.json`에 `profile: "standard"` 설정 후 체감 테스트

🤖 Generated with [Claude Code](https://claude.com/claude-code)