### PR TITLE
feat(agent): enforce truth provenance on public surfaces

### DIFF
--- a/docs/AGENT-TRUTH-AUDIT.md
+++ b/docs/AGENT-TRUTH-AUDIT.md
@@ -1,0 +1,71 @@
+# Agent Truth Audit
+
+Status: active contract on `main`
+Date: 2026-03-11
+
+## Purpose
+
+`masc-mcp`에서 agent처럼 보이는 surface는 다음 중 하나로 명시되어야 한다.
+
+- `truth`: 원천 상태. 읽기 모델이 아니라 사실 기록이다.
+- `judgment`: LLM + prompt + runtime/tool path로 생성된 판단이다.
+- `derived`: truth를 결정적으로 압축하거나 번역한 읽기 모델이다.
+- `fallback`: primary judgment가 없거나 실패했을 때 쓰는 결정적 대체 경로다.
+- `narrative`: 사람을 위한 LLM 서술 계층이다. 제어면의 canonical judgment가 아니다.
+- `simulation`: 의도적으로 비실런타임인 compatibility/test surface다.
+- `placeholder`: 미완성 또는 기본 노출 금지 surface다.
+
+이 구분이 없는 public surface는 설계 버그로 본다.
+
+## Current Main Contract
+
+### Tool catalog
+
+- `implementationStatus`가 tool truth의 기본 계약이다.
+- default-visible tool은 `real` 또는 `adapter`만 허용한다.
+- `simulation`과 `placeholder`는 기본 노출 금지다.
+
+### Operator / Swarm / Mission
+
+- `command_plane`은 `truth`
+- `swarm_status`는 `derived`
+- `attention_items`는 `derived`
+- `recommended_actions`와 `recommended_next_action`은 `fallback`
+- `Mission briefing`은 `narrative`
+
+`operator_control`과 `swarm_status`는 resident judge가 없으므로 현재 canonical judgment owner가 아니다. 둘 다 fallback read-model 계층으로 노출한다.
+
+### Keeper / classifier-style surfaces
+
+- `keeper` skill selection 기본값은 `agent` 경로다.
+- `capability_match` 기본값은 `hybrid`다.
+- `trpg_dm_intent` 기본값은 `hybrid`다.
+
+즉 primary path는 LLM judgment를 먼저 시도하고, 실패 시에만 fallback을 쓴다.
+
+## Validation
+
+최소 검증 명령:
+
+```bash
+dune build ./_build/default/test/test_tool_contract_truth.exe \
+  ./_build/default/test/test_operator_control.exe \
+  ./_build/default/test/test_swarm_status.exe \
+  ./_build/default/test/test_dashboard_mission_briefing.exe \
+  ./_build/default/test/test_capability_match_coverage.exe \
+  ./_build/default/test/test_trpg_dm_intent.exe
+
+./_build/default/test/test_tool_contract_truth.exe
+./_build/default/test/test_operator_control.exe
+./_build/default/test/test_swarm_status.exe
+./_build/default/test/test_dashboard_mission_briefing.exe
+./_build/default/test/test_capability_match_coverage.exe
+./_build/default/test/test_trpg_dm_intent.exe
+```
+
+이 검증의 목적은 품질 점수보다 truthfulness다.
+
+- public JSON에 provenance가 있는가
+- heuristic surface가 fallback/derived로 격하되어 있는가
+- model-first path가 기본값으로 설정되어 있는가
+- placeholder/simulation이 truth surface로 위장하지 않는가

--- a/lib/capability_match.ml
+++ b/lib/capability_match.ml
@@ -14,9 +14,9 @@
     (e.g. "security" ↔ "cybersecurity", "frontend" ↔ "UI").
 
     Mode selection via MASC_CAPABILITY_MATCH_MODE:
-      - keyword (default): existing heuristic, 0-latency
+      - keyword: existing heuristic, 0-latency
       - llm: LLM-only scoring
-      - hybrid: LLM with keyword fallback on failure
+      - hybrid (default): LLM with keyword fallback on failure
 
     @see "Orchestrating Human-AI Teams" — capability-based assignment
     @see arXiv 2601.04748 — semantic confusability in agent routing
@@ -53,6 +53,8 @@ type match_score = {
   interest_score: float;    (** 0.0-1.0: how well interests match *)
   capability_score: float;  (** 0.0-1.0: direct capability match *)
   total_score: float;       (** Weighted combination *)
+  mode: string;             (** Active scoring mode *)
+  provenance: string;       (** judgment | derived | fallback *)
 } [@@deriving show, eq]
 
 (* ---------- Match Mode ---------- *)
@@ -63,8 +65,36 @@ type match_mode = Keyword | Llm | Hybrid
 let get_match_mode () : match_mode =
   match Sys.getenv_opt "MASC_CAPABILITY_MATCH_MODE" with
   | Some "llm" -> Llm
-  | Some "hybrid" -> Hybrid
-  | _ -> Keyword
+  | Some "keyword" -> Keyword
+  | _ -> Hybrid
+
+let match_mode_to_string = function
+  | Keyword -> "keyword"
+  | Llm -> "llm"
+  | Hybrid -> "hybrid"
+
+type score_provenance =
+  | Judgment
+  | Derived
+  | Fallback
+
+let score_provenance_to_string = function
+  | Judgment -> "judgment"
+  | Derived -> "derived"
+  | Fallback -> "fallback"
+
+let make_match_score ~mode ~provenance ~agent_name ~task_id
+    ~trait_score ~interest_score ~capability_score ~total_score =
+  {
+    agent_name;
+    task_id;
+    trait_score;
+    interest_score;
+    capability_score;
+    total_score;
+    mode = match_mode_to_string mode;
+    provenance = score_provenance_to_string provenance;
+  }
 
 (* ---------- Keyword Extraction ---------- *)
 
@@ -288,52 +318,53 @@ let score_keyword (agent : agent_profile) (task : task_profile) : match_score =
     +. capability_score *. 0.2
   in
   let total_score = if role_ok then base_score else 0.0 in
-  {
-    agent_name = agent.name;
-    task_id = task.task_id;
-    trait_score;
-    interest_score;
-    capability_score;
-    total_score;
-  }
+  make_match_score ~mode:Keyword ~provenance:Derived
+    ~agent_name:agent.name ~task_id:task.task_id
+    ~trait_score ~interest_score ~capability_score ~total_score
 
 (** Compute LLM-based match score. Falls back to keyword on parse failure. *)
 let score_llm (agent : agent_profile) (task : task_profile) : match_score =
   let role_ok = Agent_identity.role_satisfies
     ~required:task.required_role ~agent_role:agent.role in
   if not role_ok then
-    { agent_name = agent.name; task_id = task.task_id;
-      trait_score = 0.0; interest_score = 0.0;
-      capability_score = 0.0; total_score = 0.0 }
+    make_match_score ~mode:Llm ~provenance:Judgment
+      ~agent_name:agent.name ~task_id:task.task_id
+      ~trait_score:0.0 ~interest_score:0.0
+      ~capability_score:0.0 ~total_score:0.0
   else
     match score_with_llm agent task with
     | Ok llm_score ->
-        { agent_name = agent.name; task_id = task.task_id;
-          trait_score = llm_score; interest_score = llm_score;
-          capability_score = llm_score; total_score = llm_score }
+        make_match_score ~mode:Llm ~provenance:Judgment
+          ~agent_name:agent.name ~task_id:task.task_id
+          ~trait_score:llm_score ~interest_score:llm_score
+          ~capability_score:llm_score ~total_score:llm_score
     | Error _err ->
         (* LLM failed — return zero rather than silently falling back *)
-        { agent_name = agent.name; task_id = task.task_id;
-          trait_score = 0.0; interest_score = 0.0;
-          capability_score = 0.0; total_score = 0.0 }
+        make_match_score ~mode:Llm ~provenance:Judgment
+          ~agent_name:agent.name ~task_id:task.task_id
+          ~trait_score:0.0 ~interest_score:0.0
+          ~capability_score:0.0 ~total_score:0.0
 
 (** Compute hybrid match score: LLM first, keyword fallback on failure. *)
 let score_hybrid (agent : agent_profile) (task : task_profile) : match_score =
   let role_ok = Agent_identity.role_satisfies
     ~required:task.required_role ~agent_role:agent.role in
   if not role_ok then
-    { agent_name = agent.name; task_id = task.task_id;
-      trait_score = 0.0; interest_score = 0.0;
-      capability_score = 0.0; total_score = 0.0 }
+    make_match_score ~mode:Hybrid ~provenance:Fallback
+      ~agent_name:agent.name ~task_id:task.task_id
+      ~trait_score:0.0 ~interest_score:0.0
+      ~capability_score:0.0 ~total_score:0.0
   else
     match score_with_llm agent task with
     | Ok llm_score ->
-        { agent_name = agent.name; task_id = task.task_id;
-          trait_score = llm_score; interest_score = llm_score;
-          capability_score = llm_score; total_score = llm_score }
+        make_match_score ~mode:Hybrid ~provenance:Judgment
+          ~agent_name:agent.name ~task_id:task.task_id
+          ~trait_score:llm_score ~interest_score:llm_score
+          ~capability_score:llm_score ~total_score:llm_score
     | Error _err ->
         (* LLM unavailable — fall back to keyword heuristic *)
-        score_keyword agent task
+        let keyword = score_keyword agent task in
+        { keyword with mode = match_mode_to_string Hybrid; provenance = "fallback" }
 
 (** Compute match score using the active mode (env var dispatch). *)
 let score (agent : agent_profile) (task : task_profile) : match_score =
@@ -381,6 +412,8 @@ let match_score_to_json (m : match_score) : Yojson.Safe.t =
     ("interestScore", `Float m.interest_score);
     ("capabilityScore", `Float m.capability_score);
     ("totalScore", `Float m.total_score);
+    ("mode", `String m.mode);
+    ("provenance", `String m.provenance);
   ]
 
 let ranking_to_json (scores : match_score list) : Yojson.Safe.t =

--- a/lib/dashboard_mission_briefing.ml
+++ b/lib/dashboard_mission_briefing.ml
@@ -3,6 +3,14 @@ let cache_ttl_sec = 300.0
 let no_model_reason =
   "No dashboard briefing model is available in the current environment."
 
+let mission_briefing_surface_contract_json =
+  `Assoc
+    [
+      ("summary", `String "narrative");
+      ("sections", `String "narrative");
+      ("basis", `String "truth");
+    ]
+
 let briefing_timeout_sec () =
   match Sys.getenv_opt "MASC_DASHBOARD_BRIEFING_TIMEOUT_SEC" with
   | Some raw -> (
@@ -471,6 +479,8 @@ let annotate_section ~section_id ~status ~summary ~evidence ~metadata_gaps
       ("evidence", `List (List.map (fun item -> `String item) evidence));
       ("signal_class", `String signal_class);
       ("evidence_quality", `String evidence_quality);
+      ("provenance", `String "narrative");
+      ("authoritative", `Bool false);
     ]
 
 module For_test = struct
@@ -490,6 +500,9 @@ let unavailable_json ~now ~reason =
       ("refreshing", `Bool false);
       ("status", `String "unavailable");
       ("summary", `String reason);
+      ("provenance", `String "narrative");
+      ("authoritative", `Bool false);
+      ("provenance_summary", mission_briefing_surface_contract_json);
       ("model", `Null);
       ("ttl_sec", `Int (int_of_float cache_ttl_sec));
       ("criteria", criteria_json ());
@@ -507,6 +520,9 @@ let error_json ~now ~reason =
       ("refreshing", `Bool false);
       ("status", `String "error");
       ("summary", `String "Mission briefing refresh failed. Retry to request a fresh judgment.");
+      ("provenance", `String "narrative");
+      ("authoritative", `Bool false);
+      ("provenance_summary", mission_briefing_surface_contract_json);
       ("model", `Null);
       ("ttl_sec", `Int (int_of_float cache_ttl_sec));
       ("criteria", criteria_json ());
@@ -524,6 +540,9 @@ let pending_json ~now ~last_error =
       ("refreshing", `Bool true);
       ("status", `String "pending");
       ("summary", `String "Generating mission briefing from the latest snapshot.");
+      ("provenance", `String "narrative");
+      ("authoritative", `Bool false);
+      ("provenance_summary", mission_briefing_surface_contract_json);
       ("model", `Null);
       ("ttl_sec", `Int (int_of_float cache_ttl_sec));
       ("criteria", criteria_json ());
@@ -719,6 +738,9 @@ let compute_briefing_json ~actor_name ~models ~config ~sw ~clock ~proc_mgr () =
                 ("refreshing", `Bool false);
                 ("status", `String "ok");
                 ("summary", `String watch_summary);
+                ("provenance", `String "narrative");
+                ("authoritative", `Bool false);
+                ("provenance_summary", mission_briefing_surface_contract_json);
                 ("model", `String response.model_used);
                 ("ttl_sec", `Int (int_of_float cache_ttl_sec));
                 ("criteria", criteria_json ());

--- a/lib/operator_control.ml
+++ b/lib/operator_control.ml
@@ -100,6 +100,17 @@ let operator_server_profile_json =
       ("curated_tool_count", `Int 4);
     ]
 
+let operator_surface_contract_json =
+  `Assoc
+    [
+      ("command_plane", `String "truth");
+      ("swarm_status", `String "derived");
+      ("attention_items", `String "derived");
+      ("recommended_actions", `String "fallback");
+      ("session_cards", `String "derived");
+      ("worker_cards", `String "truth");
+    ]
+
 type attention_item = {
   kind : string;
   severity : string;
@@ -620,6 +631,9 @@ let attention_item_to_yojson (item : attention_item) =
       ("target_id", string_option_to_json item.target_id);
       ("actor", string_option_to_json item.actor);
       ("evidence", item.evidence);
+      ("provenance", `String "derived");
+      ("decision_engine", `String "deterministic_translation");
+      ("authoritative", `Bool false);
     ]
 
 let recommended_confirm_required = function
@@ -649,6 +663,9 @@ let recommended_action_to_yojson ~actor (item : recommended_action) =
       ("confirm_required", `Bool (recommended_confirm_required item.action_type));
       ("suggested_payload", item.suggested_payload);
       ("preview", preview);
+      ("provenance", `String "fallback");
+      ("decision_engine", `String "deterministic_rules");
+      ("authoritative", `Bool false);
     ]
 
 let worker_card_to_yojson (card : worker_card) =
@@ -677,6 +694,8 @@ let worker_card_to_yojson (card : worker_card) =
       ("empty_note_turn_count", `Int card.empty_note_turn_count);
       ("has_turn", `Bool card.has_turn);
       ("last_turn_ts_iso", string_option_to_json card.last_turn_ts_iso);
+      ("provenance", `String "truth");
+      ("authoritative", `Bool true);
     ]
 
 let spawn_batch_stub_of_cards (cards : worker_card list) =
@@ -875,6 +894,8 @@ let session_card_to_yojson ~actor (digest : session_digest) =
       ("recommended_action_count", `Int (List.length digest.recommended_actions));
       ( "top_recommendation",
         option_to_json (recommended_action_to_yojson ~actor) top_recommendation );
+      ("provenance", `String "derived");
+      ("authoritative", `Bool false);
     ]
 
 let summary_of_attention_items (items : attention_item list) =
@@ -900,6 +921,8 @@ let summary_of_attention_items (items : attention_item list) =
       ("bad_count", `Int bad_count);
       ("warn_count", `Int warn_count);
       ("top_item", option_to_json attention_item_to_yojson top_item);
+      ("provenance", `String "derived");
+      ("authoritative", `Bool false);
     ]
 
 let dedup_recommendations (items : recommended_action list) =
@@ -930,6 +953,8 @@ let summary_of_recommendations ~actor (items : recommended_action list) =
       ("count", `Int (List.length sorted));
       ( "top_action",
         option_to_json (recommended_action_to_yojson ~actor) top_item );
+      ("provenance", `String "fallback");
+      ("authoritative", `Bool false);
     ]
 
 let event_ts_iso json =
@@ -1967,6 +1992,9 @@ let snapshot_json ?actor ?view ?(include_messages = true) ?(include_sessions = t
     ([
        ("trace_id", `String trace_id);
        ("server_profile", operator_server_profile_json);
+       ("judgment_owner", `String "fallback_read_model");
+       ("authoritative_judgment_available", `Bool false);
+       ("provenance_summary", operator_surface_contract_json);
        ("room", room_json config);
        ( "sessions",
          if initialized && include_sessions then sessions_json config
@@ -2003,6 +2031,9 @@ let digest_json ?actor ?target_type ?target_id ?include_workers (ctx : 'a contex
           ("target_type", `String "room");
           ("target_id", `Null);
           ("health", `String "ok");
+          ("judgment_owner", `String "fallback_read_model");
+          ("authoritative_judgment_available", `Bool false);
+          ("provenance_summary", operator_surface_contract_json);
           ("command_plane", `Assoc []);
           ("swarm_status", Swarm_status.empty_json);
           ("attention_items", `List []);
@@ -2050,6 +2081,9 @@ let digest_json ?actor ?target_type ?target_id ?include_workers (ctx : 'a contex
               ("target_type", `String "room");
               ("target_id", `Null);
               ("health", `String (health_from_attention_items attention_items));
+              ("judgment_owner", `String "fallback_read_model");
+              ("authoritative_judgment_available", `Bool false);
+              ("provenance_summary", operator_surface_contract_json);
               ("command_plane", command_plane_digest_json);
               ("swarm_status", swarm_status_json);
               ("role_census", aggregate_worker_class_counts tracked_sessions);
@@ -2099,6 +2133,9 @@ let digest_json ?actor ?target_type ?target_id ?include_workers (ctx : 'a contex
                       ("target_type", `String "team_session");
                       ("target_id", `String session_id);
                       ("health", `String digest.health);
+                      ("judgment_owner", `String "fallback_read_model");
+                      ("authoritative_judgment_available", `Bool false);
+                      ("provenance_summary", operator_surface_contract_json);
                       ("command_plane", command_plane_digest_json);
                       ("swarm_status", swarm_status_json);
                       ( "attention_items",

--- a/lib/swarm_status.ml
+++ b/lib/swarm_status.ml
@@ -148,6 +148,16 @@ let source_of_truth = function
   | Projected -> "projected_swarm_json"
   | Supervised -> "team_session_operator"
 
+let swarm_surface_contract_json =
+  `Assoc
+    [
+      ("overview", `String "derived");
+      ("lanes", `String "derived");
+      ("timeline", `String "truth");
+      ("gaps", `String "derived");
+      ("recommended_next_action", `String "fallback");
+    ]
+
 let option_map_to_json f = function
   | Some value -> f value
   | None -> `Null
@@ -160,6 +170,7 @@ let flag_to_json (flag : flag) =
       ("code", `String flag.code);
       ("severity", `String flag.severity);
       ("summary", `String flag.summary);
+      ("provenance", `String "derived");
     ]
 
 let timeline_event_to_json (event : timeline_event) =
@@ -173,6 +184,7 @@ let timeline_event_to_json (event : timeline_event) =
       ("detail", `String event.detail);
       ("tone", `String event.tone);
       ("source", `String event.source);
+      ("provenance", `String "truth");
     ]
 
 let lane_to_json (lane : lane) =
@@ -199,6 +211,8 @@ let lane_to_json (lane : lane) =
             ("alerts", `Int lane.alerts);
           ] );
       ("hard_flags", `List (List.map flag_to_json lane.hard_flags));
+      ("provenance", `String "derived");
+      ("authoritative", `Bool false);
     ]
 
 let recommendation_to_json (item : recommendation) =
@@ -208,6 +222,9 @@ let recommendation_to_json (item : recommendation) =
       ("label", `String item.label);
       ("reason", `String item.reason);
       ("lane_id", string_option_to_json item.lane_id);
+      ("provenance", `String "fallback");
+      ("decision_engine", `String "deterministic_lane_rules");
+      ("authoritative", `Bool false);
     ]
 
 let get_string_opt json key =
@@ -1144,6 +1161,7 @@ let build_json_from_inputs ~timeline_limit_override ~now
                ("summary", `String flag.summary);
                ("lane_ids", `List (List.map (fun lane_id -> `String lane_id) lane_ids));
                ("count", `Int (List.length lane_ids));
+               ("provenance", `String "derived");
              ])
     |> List.sort (fun left right ->
            let left_severity = left |> U.member "severity" |> U.to_string in
@@ -1181,6 +1199,9 @@ let build_json_from_inputs ~timeline_limit_override ~now
   `Assoc
     [
       ("generated_at", `String (Types.now_iso ()));
+      ("judgment_owner", `String "fallback_read_model");
+      ("authoritative_judgment_available", `Bool false);
+      ("provenance_summary", swarm_surface_contract_json);
       ( "overview",
         `Assoc
           [
@@ -1189,6 +1210,7 @@ let build_json_from_inputs ~timeline_limit_override ~now
             ("stalled_lanes", `Int stalled_lanes);
             ("projected_lanes", `Int projected_lanes);
             ("last_movement_at", string_option_to_json last_movement_at);
+            ("provenance", `String "derived");
           ] );
       ("lanes", `List (List.map lane_to_json lanes));
       ("timeline", `List (List.map timeline_event_to_json timeline));
@@ -1251,6 +1273,9 @@ let empty_json =
   `Assoc
     [
       ("generated_at", `String (Types.now_iso ()));
+      ("judgment_owner", `String "fallback_read_model");
+      ("authoritative_judgment_available", `Bool false);
+      ("provenance_summary", swarm_surface_contract_json);
       ( "overview",
         `Assoc
           [
@@ -1259,6 +1284,7 @@ let empty_json =
             ("stalled_lanes", `Int 0);
             ("projected_lanes", `Int 0);
             ("last_movement_at", `Null);
+            ("provenance", `String "derived");
           ] );
       ("lanes", `List (List.map lane_to_json [ lane Managed; lane Supervised; lane Projected ]));
       ("timeline", `List []);

--- a/lib/tool_gardener.ml
+++ b/lib/tool_gardener.ml
@@ -12,6 +12,15 @@ open Tool_args
 
 type result = bool * string
 
+let spawn_decision_provenance ~(use_llm_decision : bool)
+    (decision : spawn_decision) =
+  match decision with
+  | SpawnApproved _ when use_llm_decision -> "judgment"
+  | SpawnApproved _ | SpawnDeferred _ | SpawnRejected _ -> "fallback"
+
+let retirement_decision_provenance (_decision : retirement_decision) =
+  "fallback"
+
 (** {1 Tool Handlers} *)
 
 (** Handle masc_gardener_health tool call.
@@ -70,7 +79,9 @@ let handle_propose_spawn _ctx args : result =
 
       let decision = Gardener.propose_spawn ~topic ~reason ~urgency in
       let decision_provenance =
-        if (Gardener.get_config ()).use_llm_decision then "judgment" else "fallback"
+        spawn_decision_provenance
+          ~use_llm_decision:(Gardener.get_config ()).use_llm_decision
+          decision
       in
 
       let json = `Assoc [
@@ -100,9 +111,7 @@ let handle_retire_agent _ctx args : result =
       (false, "Missing required parameter: agent_name")
     else begin
       let decision = Gardener.propose_retire ~agent_name in
-      let decision_provenance =
-        if (Gardener.get_config ()).use_llm_decision then "judgment" else "fallback"
-      in
+      let decision_provenance = retirement_decision_provenance decision in
 
       let json = `Assoc [
         ("status", `String "ok");

--- a/lib/tool_gardener.ml
+++ b/lib/tool_gardener.ml
@@ -28,6 +28,8 @@ let handle_health _ctx _args : result =
 
     let json = `Assoc [
       ("status", `String "ok");
+      ("provenance", `String "derived");
+      ("authoritative", `Bool false);
       ("health", ecosystem_health_to_yojson health);
       ("config_summary", `Assoc [
         ("enabled", `Bool config.enabled);
@@ -67,9 +69,14 @@ let handle_propose_spawn _ctx args : result =
       let urgency = urgency_of_string urgency_str in
 
       let decision = Gardener.propose_spawn ~topic ~reason ~urgency in
+      let decision_provenance =
+        if (Gardener.get_config ()).use_llm_decision then "judgment" else "fallback"
+      in
 
       let json = `Assoc [
         ("status", `String "ok");
+        ("provenance", `String decision_provenance);
+        ("authoritative", `Bool false);
         ("decision", spawn_decision_to_yojson decision);
         ("topic", `String topic);
         ("can_execute", `Bool (match decision with SpawnApproved _ -> true | _ -> false));
@@ -93,9 +100,14 @@ let handle_retire_agent _ctx args : result =
       (false, "Missing required parameter: agent_name")
     else begin
       let decision = Gardener.propose_retire ~agent_name in
+      let decision_provenance =
+        if (Gardener.get_config ()).use_llm_decision then "judgment" else "fallback"
+      in
 
       let json = `Assoc [
         ("status", `String "ok");
+        ("provenance", `String decision_provenance);
+        ("authoritative", `Bool false);
         ("decision", retirement_decision_to_yojson decision);
         ("agent_name", `String agent_name);
         ("can_execute", `Bool (match decision with RetireApproved _ -> true | _ -> false));
@@ -113,6 +125,8 @@ let handle_config _ctx _args : result =
     let config = Gardener.get_config () in
     let json = `Assoc [
       ("status", `String "ok");
+      ("provenance", `String "truth");
+      ("authoritative", `Bool true);
       ("config", gardener_config_to_yojson config);
       ("circuit_breaker", `Assoc [
         ("is_open", `Bool (Gardener.is_circuit_open ()));

--- a/lib/tool_keeper.ml
+++ b/lib/tool_keeper.ml
@@ -9734,6 +9734,12 @@ let handle_keeper_list ctx args : tool_result =
 	            in
 	            let skill_route_json =
 	              let open Yojson.Safe.Util in
+                  let selection_mode = keeper_skill_selection_mode () in
+                  let selection_mode_string, selection_provenance =
+                    match selection_mode with
+                    | SkillSelectAgent -> ("agent", "judgment")
+                    | SkillSelectHeuristic -> ("heuristic", "fallback")
+                  in
 	              match last_skill_metrics with
 	              | None -> `Null
 	              | Some metrics ->
@@ -9751,6 +9757,9 @@ let handle_keeper_list ctx args : tool_result =
 	                    ("primary", match primary with Some s -> `String s | None -> `Null);
 	                    ("secondary", `List (List.map (fun s -> `String s) secondary));
 	                    ("reason", match reason with Some s -> `String s | None -> `Null);
+                        ("selection_mode", `String selection_mode_string);
+                        ("provenance", `String selection_provenance);
+                        ("authoritative", `Bool false);
 	                  ]
 	            in
 	            Some (`Assoc [

--- a/lib/trpg_dm_intent.ml
+++ b/lib/trpg_dm_intent.ml
@@ -2,9 +2,9 @@
 
     Extracts DM's narrative intent from their action text.
     Supports three modes via MASC_TRPG_DM_INTENT_MODE:
-    - keyword (default): Pure keyword matching, zero latency
+    - keyword: Pure keyword matching, zero latency
     - llm: LLM structured classification via Llm_client cascade
-    - hybrid: LLM with keyword fallback on failure
+    - hybrid (default): LLM with keyword fallback on failure
 
     @since 2.70.0 *)
 
@@ -24,6 +24,8 @@ type dm_intent = {
   secondary : intent_category option;
   confidence : float;
   keywords_matched : string list;
+  mode : string;
+  provenance : string;
 }
 
 (* ── Match Mode ─────────────────────────────────────────────────────── *)
@@ -33,8 +35,33 @@ type match_mode = Keyword | Llm | Hybrid
 let get_match_mode () : match_mode =
   match Sys.getenv_opt "MASC_TRPG_DM_INTENT_MODE" with
   | Some "llm" -> Llm
-  | Some "hybrid" -> Hybrid
-  | _ -> Keyword
+  | Some "keyword" -> Keyword
+  | _ -> Hybrid
+
+let match_mode_to_string = function
+  | Keyword -> "keyword"
+  | Llm -> "llm"
+  | Hybrid -> "hybrid"
+
+type intent_provenance =
+  | Judgment
+  | Derived
+  | Fallback
+
+let intent_provenance_to_string = function
+  | Judgment -> "judgment"
+  | Derived -> "derived"
+  | Fallback -> "fallback"
+
+let make_intent ~mode ~provenance ~primary ~secondary ~confidence ~keywords_matched =
+  {
+    primary;
+    secondary;
+    confidence;
+    keywords_matched;
+    mode = match_mode_to_string mode;
+    provenance = intent_provenance_to_string provenance;
+  }
 
 (* ── Keyword tables ─────────────────────────────────────────────────── *)
 
@@ -151,15 +178,14 @@ let extract_keyword (text : string) : dm_intent =
         secondary = None;
         confidence = 0.0;
         keywords_matched = [];
+        mode = match_mode_to_string Keyword;
+        provenance = intent_provenance_to_string Derived;
       }
   | best :: rest ->
       if best.confidence < primary_threshold then
-        {
-          primary = Unknown;
-          secondary = None;
-          confidence = 0.0;
-          keywords_matched = [];
-        }
+        make_intent ~mode:Keyword ~provenance:Derived
+          ~primary:Unknown ~secondary:None ~confidence:0.0
+          ~keywords_matched:[]
       else
         let secondary =
           match rest with
@@ -169,12 +195,9 @@ let extract_keyword (text : string) : dm_intent =
               Some second.category
           | _ -> None
         in
-        {
-          primary = best.category;
-          secondary;
-          confidence = best.confidence;
-          keywords_matched = best.matched;
-        }
+        make_intent ~mode:Keyword ~provenance:Derived
+          ~primary:best.category ~secondary ~confidence:best.confidence
+          ~keywords_matched:best.matched
 
 (* ── LLM Classification ────────────────────────────────────────────── *)
 
@@ -246,7 +269,9 @@ let intent_of_json (json : Yojson.Safe.t) : (dm_intent, string) result =
             List.filter_map (function `String s -> Some s | _ -> None) items
         | _ -> []
       in
-      Ok { primary; secondary; confidence; keywords_matched }
+      Ok
+        (make_intent ~mode:Llm ~provenance:Judgment
+           ~primary ~secondary ~confidence ~keywords_matched)
   | _ -> Error "LLM response is not a JSON object"
 
 (** Parse dm_intent from LLM text response.
@@ -304,12 +329,17 @@ let extract (text : string) : dm_intent =
        | Ok intent -> intent
        | Error _ ->
            (* LLM-only mode still returns Unknown on failure *)
-           { primary = Unknown; secondary = None;
-             confidence = 0.0; keywords_matched = [] })
+           make_intent ~mode:Llm ~provenance:Judgment
+             ~primary:Unknown ~secondary:None ~confidence:0.0
+             ~keywords_matched:[] )
   | Hybrid ->
       (match extract_with_llm text with
        | Ok intent -> intent
-       | Error _ -> extract_keyword text)
+       | Error _ ->
+           let keyword_intent = extract_keyword text in
+           { keyword_intent with
+             mode = match_mode_to_string Hybrid;
+             provenance = intent_provenance_to_string Fallback })
 
 let string_of_category = function
   | Combat_setup -> "combat_setup"
@@ -359,4 +389,6 @@ let to_yojson (intent : dm_intent) : Yojson.Safe.t =
       ("secondary", secondary_json);
       ("confidence", `Float intent.confidence);
       ("keywords_matched", keywords_json);
+      ("mode", `String intent.mode);
+      ("provenance", `String intent.provenance);
     ]

--- a/lib/trpg_dm_intent.mli
+++ b/lib/trpg_dm_intent.mli
@@ -2,9 +2,9 @@
 
     Extracts DM's narrative intent from their action text.
     Mode selection via MASC_TRPG_DM_INTENT_MODE:
-    - keyword (default): Pure keyword matching, zero latency
+    - keyword: Pure keyword matching, zero latency
     - llm: LLM structured classification via Llm_client cascade
-    - hybrid: LLM with keyword fallback on failure
+    - hybrid (default): LLM with keyword fallback on failure
 
     @since 2.70.0 *)
 
@@ -25,6 +25,8 @@ type dm_intent = {
   secondary : intent_category option;  (** Second strongest signal, if any *)
   confidence : float;                  (** 0.0-1.0 *)
   keywords_matched : string list;      (** Which keywords triggered the match *)
+  mode : string;                       (** keyword | llm | hybrid *)
+  provenance : string;                 (** judgment | derived | fallback *)
 }
 
 (** Extract DM intent from action text.

--- a/test/test_capability_match_coverage.ml
+++ b/test/test_capability_match_coverage.ml
@@ -4,6 +4,19 @@ open Masc_mcp.Capability_match
 
 let () = Printexc.record_backtrace true
 
+let with_env key value f =
+  let old = Sys.getenv_opt key in
+  Unix.putenv key value;
+  Fun.protect
+    ~finally:(fun () ->
+      match old with
+      | Some prev -> Unix.putenv key prev
+      | None -> Unix.putenv key "")
+    f
+
+let with_keyword_mode f =
+  with_env "MASC_CAPABILITY_MATCH_MODE" "keyword" f
+
 (* ---------- Test Agents ---------- *)
 
 let security_agent = {
@@ -133,86 +146,100 @@ let test_overlap_substring () =
 (* ---------- Scoring Tests ---------- *)
 
 let test_score_perfect_match () =
-  let m = score security_agent security_task in
-  assert (m.total_score > 0.0);
-  assert (m.agent_name = "claude-security");
-  assert (m.task_id = "task-sec-001")
+  with_keyword_mode (fun () ->
+      let m = score security_agent security_task in
+      assert (m.total_score > 0.0);
+      assert (m.agent_name = "claude-security");
+      assert (m.task_id = "task-sec-001"))
 
 let test_score_no_match () =
-  let m = score generalist_agent security_task in
-  assert (m.total_score < 0.01)
+  with_keyword_mode (fun () ->
+      let m = score generalist_agent security_task in
+      assert (m.total_score < 0.01))
 
 let test_score_cross_domain () =
-  let m = score security_agent frontend_task in
-  let m2 = score frontend_agent frontend_task in
-  (* Frontend agent should score higher on frontend task *)
-  assert (m2.total_score > m.total_score)
+  with_keyword_mode (fun () ->
+      let m = score security_agent frontend_task in
+      let m2 = score frontend_agent frontend_task in
+      (* Frontend agent should score higher on frontend task *)
+      assert (m2.total_score > m.total_score))
 
 (* ---------- Ranking Tests ---------- *)
 
 let test_rank_agents_for_task () =
-  let agents = [generalist_agent; frontend_agent; security_agent; devops_agent] in
-  let ranked = rank_agents_for_task agents security_task in
-  assert (List.length ranked = 4);
-  (* Security agent should be first *)
-  assert ((List.hd ranked).agent_name = "claude-security")
+  with_keyword_mode (fun () ->
+      let agents = [generalist_agent; frontend_agent; security_agent; devops_agent] in
+      let ranked = rank_agents_for_task agents security_task in
+      assert (List.length ranked = 4);
+      (* Security agent should be first *)
+      assert ((List.hd ranked).agent_name = "claude-security"))
 
 let test_rank_tasks_for_agent () =
-  let tasks = [frontend_task; devops_task; security_task] in
-  let ranked = rank_tasks_for_agent security_agent tasks in
-  assert (List.length ranked = 3);
-  (* Security task should be first *)
-  assert ((List.hd ranked).task_id = "task-sec-001")
+  with_keyword_mode (fun () ->
+      let tasks = [frontend_task; devops_task; security_task] in
+      let ranked = rank_tasks_for_agent security_agent tasks in
+      assert (List.length ranked = 3);
+      (* Security task should be first *)
+      assert ((List.hd ranked).task_id = "task-sec-001"))
 
 let test_rank_devops_task () =
-  let agents = [security_agent; frontend_agent; devops_agent] in
-  let ranked = rank_agents_for_task agents devops_task in
-  (* DevOps agent should rank first *)
-  assert ((List.hd ranked).agent_name = "claude-devops")
+  with_keyword_mode (fun () ->
+      let agents = [security_agent; frontend_agent; devops_agent] in
+      let ranked = rank_agents_for_task agents devops_task in
+      (* DevOps agent should rank first *)
+      assert ((List.hd ranked).agent_name = "claude-devops"))
 
 let test_rank_frontend_task () =
-  let agents = [security_agent; frontend_agent; devops_agent] in
-  let ranked = rank_agents_for_task agents frontend_task in
-  (* Frontend agent should rank first *)
-  assert ((List.hd ranked).agent_name = "claude-frontend")
+  with_keyword_mode (fun () ->
+      let agents = [security_agent; frontend_agent; devops_agent] in
+      let ranked = rank_agents_for_task agents frontend_task in
+      (* Frontend agent should rank first *)
+      assert ((List.hd ranked).agent_name = "claude-frontend"))
 
 (* ---------- Best Agent / Suggest Task ---------- *)
 
 let test_best_agent () =
-  let agents = [generalist_agent; security_agent] in
-  let best = best_agent_for_task agents security_task in
-  assert (best <> None);
-  assert ((Option.get best).agent_name = "claude-security")
+  with_keyword_mode (fun () ->
+      let agents = [generalist_agent; security_agent] in
+      let best = best_agent_for_task agents security_task in
+      assert (best <> None);
+      assert ((Option.get best).agent_name = "claude-security"))
 
 let test_best_agent_min_score () =
-  let agents = [generalist_agent] in
-  let best = best_agent_for_task ~min_score:0.5 agents security_task in
-  (* Generalist has 0.0 score, should return None *)
-  assert (best = None)
+  with_keyword_mode (fun () ->
+      let agents = [generalist_agent] in
+      let best = best_agent_for_task ~min_score:0.5 agents security_task in
+      (* Generalist has 0.0 score, should return None *)
+      assert (best = None))
 
 let test_suggest_task () =
-  let tasks = [frontend_task; devops_task; security_task] in
-  let suggested = suggest_task_for_agent security_agent tasks in
-  assert (suggested <> None);
-  assert ((Option.get suggested).task_id = "task-sec-001")
+  with_keyword_mode (fun () ->
+      let tasks = [frontend_task; devops_task; security_task] in
+      let suggested = suggest_task_for_agent security_agent tasks in
+      assert (suggested <> None);
+      assert ((Option.get suggested).task_id = "task-sec-001"))
 
 (* ---------- JSON Serialization ---------- *)
 
 let test_match_score_to_json () =
-  let m = score security_agent security_task in
-  let json = match_score_to_json m in
-  let open Yojson.Safe.Util in
-  assert (json |> member "agentName" |> to_string = "claude-security");
-  assert (json |> member "taskId" |> to_string = "task-sec-001");
-  assert (json |> member "totalScore" |> to_float >= 0.0)
+  with_keyword_mode (fun () ->
+      let m = score security_agent security_task in
+      let json = match_score_to_json m in
+      let open Yojson.Safe.Util in
+      assert (json |> member "agentName" |> to_string = "claude-security");
+      assert (json |> member "taskId" |> to_string = "task-sec-001");
+      assert (json |> member "totalScore" |> to_float >= 0.0);
+      assert (json |> member "mode" |> to_string <> "");
+      assert (json |> member "provenance" |> to_string <> ""))
 
 let test_ranking_to_json () =
-  let agents = [security_agent; frontend_agent] in
-  let ranked = rank_agents_for_task agents security_task in
-  let json = ranking_to_json ranked in
-  match json with
-  | `List items -> assert (List.length items = 2)
-  | _ -> failwith "Expected JSON list"
+  with_keyword_mode (fun () ->
+      let agents = [security_agent; frontend_agent] in
+      let ranked = rank_agents_for_task agents security_task in
+      let json = ranking_to_json ranked in
+      match json with
+      | `List items -> assert (List.length items = 2)
+      | _ -> failwith "Expected JSON list")
 
 (* ---------- Agent Profile from JSON ---------- *)
 
@@ -302,8 +329,8 @@ let test_match_mode_dispatch () =
   let mode = get_match_mode () in
   match Sys.getenv_opt "MASC_CAPABILITY_MATCH_MODE" with
   | Some "llm" -> assert (mode = Llm)
-  | Some "hybrid" -> assert (mode = Hybrid)
-  | _ -> assert (mode = Keyword)
+  | Some "keyword" -> assert (mode = Keyword)
+  | _ -> assert (mode = Hybrid)
 
 let test_score_keyword_direct () =
   (* score_keyword should behave identically to old score *)

--- a/test/test_dashboard_mission_briefing.ml
+++ b/test/test_dashboard_mission_briefing.ml
@@ -87,6 +87,10 @@ let test_disabled_override_returns_unavailable () =
           (json |> member "status" |> to_string);
         check bool "refreshing false" false
           (json |> member "refreshing" |> to_bool);
+        check string "provenance" "narrative"
+          (json |> member "provenance" |> to_string);
+        check bool "not authoritative" false
+          (json |> member "authoritative" |> to_bool);
         check string "error reason"
           "No dashboard briefing model is available in the current environment."
           (json |> member "error" |> to_string)))

--- a/test/test_operator_control.ml
+++ b/test/test_operator_control.ml
@@ -99,6 +99,12 @@ let test_snapshot_has_expected_sections () =
         (Yojson.Safe.Util.member "attention_summary" json <> `Null);
       Alcotest.(check bool) "recommendation summary present" true
         (Yojson.Safe.Util.member "recommendation_summary" json <> `Null);
+      Alcotest.(check string) "judgment owner" "fallback_read_model"
+        Yojson.Safe.Util.(json |> member "judgment_owner" |> to_string);
+      Alcotest.(check bool) "no authoritative judgment" false
+        Yojson.Safe.Util.(json |> member "authoritative_judgment_available" |> to_bool);
+      Alcotest.(check string) "command plane provenance" "truth"
+        Yojson.Safe.Util.(json |> member "provenance_summary" |> member "command_plane" |> to_string);
       Alcotest.(check bool) "recent_actions list present" true
         (match Yojson.Safe.Util.member "recent_actions" json with
          | `List _ -> true
@@ -157,6 +163,12 @@ let test_digest_room_exposes_pending_confirm_attention () =
              Yojson.Safe.Util.(item |> member "kind" |> to_string)
              = "pending_confirm_waiting")
            attention_items);
+      Alcotest.(check bool) "attention provenance present" true
+        (List.for_all
+           (fun item ->
+             String.equal "derived"
+               Yojson.Safe.Util.(item |> member "provenance" |> to_string))
+           attention_items);
       Alcotest.(check bool) "command attention present" true
         (List.exists
            (fun item ->
@@ -190,6 +202,8 @@ let test_digest_team_session_shape () =
         Yojson.Safe.Util.(digest |> member "target_type" |> to_string);
       Alcotest.(check string) "target_id" session_id
         Yojson.Safe.Util.(digest |> member "target_id" |> to_string);
+      Alcotest.(check string) "recommendation provenance summary" "fallback"
+        Yojson.Safe.Util.(digest |> member "provenance_summary" |> member "recommended_actions" |> to_string);
       Alcotest.(check bool) "swarm_status present" true
         (Yojson.Safe.Util.member "swarm_status" digest <> `Null);
       Alcotest.(check bool) "command_plane present" true
@@ -794,7 +808,9 @@ let test_digest_recommends_worker_spawn_batch_for_planned_worker_without_turn ()
       Alcotest.(check string) "spawn_agent" "llama"
         Yojson.Safe.Util.(worker |> member "spawn_agent" |> to_string);
       Alcotest.(check string) "spawn_role" "implementer-a"
-        Yojson.Safe.Util.(worker |> member "spawn_role" |> to_string))
+        Yojson.Safe.Util.(worker |> member "spawn_role" |> to_string);
+      Alcotest.(check string) "recommendation provenance" "fallback"
+        Yojson.Safe.Util.(recommendation |> member "provenance" |> to_string))
 
 let test_confirm_rejects_expired_token () =
   Eio_main.run @@ fun env ->

--- a/test/test_swarm_status.ml
+++ b/test/test_swarm_status.ml
@@ -30,8 +30,14 @@ let test_supervised_trace_only_does_not_make_lane_present () =
   let supervised = find_lane json "supervised" in
   check bool "supervised lane absent" false
     (supervised |> U.member "present" |> U.to_bool);
+  check string "lane provenance" "derived"
+    (supervised |> U.member "provenance" |> U.to_string);
   check int "no supervised hard flags" 0
     (supervised |> U.member "hard_flags" |> U.to_list |> List.length);
+  check string "root recommendation provenance" "fallback"
+    (json |> U.member "recommended_next_action" |> U.member "provenance" |> U.to_string);
+  check string "timeline provenance contract" "truth"
+    (json |> U.member "provenance_summary" |> U.member "timeline" |> U.to_string);
   check bool "do not recommend team session inspection" false
     (String.equal "masc_team_session_status"
        (json |> U.member "recommended_next_action" |> U.member "tool" |> U.to_string))
@@ -87,7 +93,9 @@ let test_active_managed_operation_keeps_lane_present () =
   in
   let managed = find_lane json "managed" in
   check bool "managed lane present for active operation" true
-    (managed |> U.member "present" |> U.to_bool)
+    (managed |> U.member "present" |> U.to_bool);
+  check string "overview provenance" "derived"
+    (json |> U.member "overview" |> U.member "provenance" |> U.to_string)
 
 let test_managed_alert_only_keeps_lane_present () =
   let now = M.Time_compat.now () in

--- a/test/test_tool_gardener_coverage.ml
+++ b/test/test_tool_gardener_coverage.ml
@@ -71,6 +71,8 @@ let test_config_returns_json () =
   let json = Yojson.Safe.from_string msg in
   let status = json |> Yojson.Safe.Util.member "status" |> Yojson.Safe.Util.to_string in
   Alcotest.(check string) "status ok" "ok" status;
+  let provenance = json |> Yojson.Safe.Util.member "provenance" |> Yojson.Safe.Util.to_string in
+  Alcotest.(check string) "config provenance truth" "truth" provenance;
   let cb = json |> Yojson.Safe.Util.member "circuit_breaker" in
   let is_open = cb |> Yojson.Safe.Util.member "is_open" |> Yojson.Safe.Util.to_bool in
   Alcotest.(check bool) "circuit_breaker.is_open is bool" true (is_open || not is_open);
@@ -78,6 +80,54 @@ let test_config_returns_json () =
   Alcotest.(check bool) "can_spawn is bool" true (can_spawn || not can_spawn);
   let can_retire = json |> Yojson.Safe.Util.member "can_retire" |> Yojson.Safe.Util.to_bool in
   Alcotest.(check bool) "can_retire is bool" true (can_retire || not can_retire)
+
+let test_spawn_decision_provenance_uses_decision_path () =
+  let approved =
+    Masc_mcp.Gardener_types.SpawnApproved
+      {
+        topic = "security";
+        urgency = Masc_mcp.Gardener_types.Medium;
+        proposed_traits = [];
+        proposed_hours = [];
+        reason = "approved";
+      }
+  in
+  let deferred =
+    Masc_mcp.Gardener_types.SpawnDeferred
+      { topic = "security"; retry_after_sec = 60.0; reason = "cooldown"; }
+  in
+  let rejected =
+    Masc_mcp.Gardener_types.SpawnRejected
+      { topic = "security"; reason = "population cap"; }
+  in
+  Alcotest.(check string) "approved with llm uses judgment" "judgment"
+    (Tool_gardener.spawn_decision_provenance ~use_llm_decision:true approved);
+  Alcotest.(check string) "approved without llm uses fallback" "fallback"
+    (Tool_gardener.spawn_decision_provenance ~use_llm_decision:false approved);
+  Alcotest.(check string) "deferred stays fallback" "fallback"
+    (Tool_gardener.spawn_decision_provenance ~use_llm_decision:true deferred);
+  Alcotest.(check string) "rejected stays fallback" "fallback"
+    (Tool_gardener.spawn_decision_provenance ~use_llm_decision:true rejected)
+
+let test_retirement_decision_provenance_always_fallback () =
+  let approved =
+    Masc_mcp.Gardener_types.RetireApproved
+      { agent_name = "agent-x"; reason = "idle"; grace_period_sec = 30.0; }
+  in
+  let deferred =
+    Masc_mcp.Gardener_types.RetireDeferred
+      { agent_name = "agent-x"; retry_after_sec = 60.0; reason = "cooldown"; }
+  in
+  let rejected =
+    Masc_mcp.Gardener_types.RetireRejected
+      { agent_name = "agent-x"; reason = "active"; }
+  in
+  Alcotest.(check string) "approved retirement fallback" "fallback"
+    (Tool_gardener.retirement_decision_provenance approved);
+  Alcotest.(check string) "deferred retirement fallback" "fallback"
+    (Tool_gardener.retirement_decision_provenance deferred);
+  Alcotest.(check string) "rejected retirement fallback" "fallback"
+    (Tool_gardener.retirement_decision_provenance rejected)
 
 (* ============================================================
    Input validation tests (early return, no network)
@@ -137,6 +187,8 @@ let () =
     ]);
     ("config", [
       Alcotest.test_case "returns json" `Quick test_config_returns_json;
+      Alcotest.test_case "spawn provenance path" `Quick test_spawn_decision_provenance_uses_decision_path;
+      Alcotest.test_case "retirement provenance path" `Quick test_retirement_decision_provenance_always_fallback;
     ]);
     ("validation", [
       Alcotest.test_case "propose_spawn missing topic" `Quick test_propose_spawn_missing_topic;

--- a/test/test_trpg_dm_intent.ml
+++ b/test/test_trpg_dm_intent.ml
@@ -1,82 +1,111 @@
 open Masc_mcp
 
+let with_env key value f =
+  let old = Sys.getenv_opt key in
+  Unix.putenv key value;
+  Fun.protect
+    ~finally:(fun () ->
+      match old with
+      | Some prev -> Unix.putenv key prev
+      | None -> Unix.putenv key "")
+    f
+
+let with_keyword_mode f =
+  with_env "MASC_TRPG_DM_INTENT_MODE" "keyword" f
+
 (* ==== Keyword extraction tests (default mode) ============================ *)
 
 let test_combat () =
-  let intent =
-    Trpg_dm_intent.extract
-      "The goblins draw their swords and charge! A battle begins as the monsters attack."
-  in
-  let cat = Trpg_dm_intent.string_of_category intent.primary in
-  Alcotest.(check string) "combat detected" "combat_setup" cat;
-  Alcotest.(check bool) "confidence > 0" true (intent.confidence > 0.0);
-  Alcotest.(check bool) "keywords non-empty" true
-    (List.length intent.keywords_matched > 0)
+  with_keyword_mode (fun () ->
+      let intent =
+        Trpg_dm_intent.extract
+          "The goblins draw their swords and charge! A battle begins as the monsters attack."
+      in
+      let cat = Trpg_dm_intent.string_of_category intent.primary in
+      Alcotest.(check string) "combat detected" "combat_setup" cat;
+      Alcotest.(check bool) "confidence > 0" true (intent.confidence > 0.0);
+      Alcotest.(check bool) "keywords non-empty" true
+        (List.length intent.keywords_matched > 0);
+      Alcotest.(check bool) "mode set" true (String.length intent.mode > 0);
+      Alcotest.(check bool) "provenance set" true
+        (String.length intent.provenance > 0))
 
 let test_social () =
-  let intent =
-    Trpg_dm_intent.extract
-      "The merchant greets you at the tavern and says: I have an offer for a trade."
-  in
-  let cat = Trpg_dm_intent.string_of_category intent.primary in
-  Alcotest.(check string) "social detected" "social_encounter" cat
+  with_keyword_mode (fun () ->
+      let intent =
+        Trpg_dm_intent.extract
+          "The merchant greets you at the tavern and says: I have an offer for a trade."
+      in
+      let cat = Trpg_dm_intent.string_of_category intent.primary in
+      Alcotest.(check string) "social detected" "social_encounter" cat)
 
 let test_puzzle () =
-  let intent =
-    Trpg_dm_intent.extract
-      "You find a locked chest with strange runes. A riddle is inscribed."
-  in
-  let cat = Trpg_dm_intent.string_of_category intent.primary in
-  Alcotest.(check string) "puzzle detected" "puzzle_challenge" cat
+  with_keyword_mode (fun () ->
+      let intent =
+        Trpg_dm_intent.extract
+          "You find a locked chest with strange runes. A riddle is inscribed."
+      in
+      let cat = Trpg_dm_intent.string_of_category intent.primary in
+      Alcotest.(check string) "puzzle detected" "puzzle_challenge" cat)
 
 let test_exploration () =
-  let intent =
-    Trpg_dm_intent.extract
-      "You travel through the dense forest, discovering ancient ruins ahead."
-  in
-  let cat = Trpg_dm_intent.string_of_category intent.primary in
-  Alcotest.(check string) "exploration detected" "exploration" cat
+  with_keyword_mode (fun () ->
+      let intent =
+        Trpg_dm_intent.extract
+          "You travel through the dense forest, discovering ancient ruins ahead."
+      in
+      let cat = Trpg_dm_intent.string_of_category intent.primary in
+      Alcotest.(check string) "exploration detected" "exploration" cat)
 
 let test_rest () =
-  let intent =
-    Trpg_dm_intent.extract "The party sets up camp for the night to rest and heal."
-  in
-  let cat = Trpg_dm_intent.string_of_category intent.primary in
-  Alcotest.(check string) "rest detected" "rest_downtime" cat
+  with_keyword_mode (fun () ->
+      let intent =
+        Trpg_dm_intent.extract "The party sets up camp for the night to rest and heal."
+      in
+      let cat = Trpg_dm_intent.string_of_category intent.primary in
+      Alcotest.(check string) "rest detected" "rest_downtime" cat)
 
 let test_tension () =
-  let intent =
-    Trpg_dm_intent.extract
-      "An ominous shadow looms overhead. Something watches from the darkness."
-  in
-  let cat = Trpg_dm_intent.string_of_category intent.primary in
-  Alcotest.(check string) "tension detected" "tension_building" cat
+  with_keyword_mode (fun () ->
+      let intent =
+        Trpg_dm_intent.extract
+          "An ominous shadow looms overhead. Something watches from the darkness."
+      in
+      let cat = Trpg_dm_intent.string_of_category intent.primary in
+      Alcotest.(check string) "tension detected" "tension_building" cat)
 
 let test_unknown () =
-  let intent = Trpg_dm_intent.extract "Hello world, nothing specific here." in
-  let cat = Trpg_dm_intent.string_of_category intent.primary in
-  (* Could be unknown or low-confidence match *)
-  Alcotest.(check bool) "some category returned" true (String.length cat > 0)
+  with_keyword_mode (fun () ->
+      let intent = Trpg_dm_intent.extract "Hello world, nothing specific here." in
+      let cat = Trpg_dm_intent.string_of_category intent.primary in
+      (* Could be unknown or low-confidence match *)
+      Alcotest.(check bool) "some category returned" true (String.length cat > 0))
 
 (* ==== Serialization tests ================================================ *)
 
 let test_to_hint () =
-  let intent = Trpg_dm_intent.extract "Monsters appear! Roll initiative!" in
-  let hint = Trpg_dm_intent.to_hint intent in
-  Alcotest.(check bool) "hint non-empty" true (String.length hint > 0)
+  with_keyword_mode (fun () ->
+      let intent = Trpg_dm_intent.extract "Monsters appear! Roll initiative!" in
+      let hint = Trpg_dm_intent.to_hint intent in
+      Alcotest.(check bool) "hint non-empty" true (String.length hint > 0))
 
 let test_to_yojson () =
-  let intent = Trpg_dm_intent.extract "The king reveals the secret prophecy." in
-  let json = Trpg_dm_intent.to_yojson intent in
-  match json with
-  | `Assoc fields ->
-    Alcotest.(check bool) "has primary field" true
-      (List.mem_assoc "primary" fields);
-    Alcotest.(check bool) "has confidence field" true
-      (List.mem_assoc "confidence" fields);
-    Alcotest.(check bool) "has keywords_matched field" true
-      (List.mem_assoc "keywords_matched" fields)
-  | _ -> Alcotest.fail "to_yojson should return Assoc"
+  with_keyword_mode (fun () ->
+      let intent = Trpg_dm_intent.extract "The king reveals the secret prophecy." in
+      let json = Trpg_dm_intent.to_yojson intent in
+      match json with
+      | `Assoc fields ->
+        Alcotest.(check bool) "has primary field" true
+          (List.mem_assoc "primary" fields);
+        Alcotest.(check bool) "has confidence field" true
+          (List.mem_assoc "confidence" fields);
+        Alcotest.(check bool) "has keywords_matched field" true
+          (List.mem_assoc "keywords_matched" fields);
+        Alcotest.(check bool) "has mode field" true
+          (List.mem_assoc "mode" fields);
+        Alcotest.(check bool) "has provenance field" true
+          (List.mem_assoc "provenance" fields)
+      | _ -> Alcotest.fail "to_yojson should return Assoc")
 
 (* ==== category_of_string tests =========================================== *)
 


### PR DESCRIPTION
## Summary
- add explicit truth/provenance contracts to operator, swarm, mission, keeper, and gardener public surfaces
- switch capability_match and trpg_dm_intent defaults to hybrid and expose mode/provenance in their JSON outputs
- add agent truth audit documentation and coverage for the new contracts

## Verification
- git diff --check
- dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/agent-truth-main-pass test/test_operator_control.exe test/test_swarm_status.exe test/test_dashboard_mission_briefing.exe test/test_capability_match_coverage.exe test/test_trpg_dm_intent.exe test/test_tool_contract_truth.exe
- ./_build/default/test/test_operator_control.exe
- ./_build/default/test/test_swarm_status.exe
- ./_build/default/test/test_dashboard_mission_briefing.exe
- ./_build/default/test/test_tool_contract_truth.exe
- ./_build/default/test/test_capability_match_coverage.exe
- ./_build/default/test/test_trpg_dm_intent.exe