### PR TITLE
refactor(cascade): migrate call sites to Lodge_cascade.call (Phase 2)

### DIFF
--- a/lib/gardener.ml
+++ b/lib/gardener.ml
@@ -470,11 +470,10 @@ let decide_spawn_with_llm ~config ~health ~gap : spawn_decision =
     gap.maturity_hours
   in
 
-  let model_specs = Lodge_cascade.get_cascade ~cascade_name:"gardener_spawn" () in
   let response =
-    match Llm_client.run_prompt_cascade ~temperature:0.3 ~timeout_sec:15
-        ~model_specs ~max_tokens:200 ~prompt () with
-    | Ok resp -> resp.content
+    match Lodge_cascade.call ~cascade_name:"gardener_spawn"
+        ~prompt ~temperature:0.3 ~timeout_sec:15 ~max_tokens:200 () with
+    | Ok r -> r.response
     | Error _ -> ""
   in
 

--- a/lib/lodge_cascade.ml
+++ b/lib/lodge_cascade.ml
@@ -173,14 +173,14 @@ let get_cascade ?(config_path = "") ~cascade_name () :
 
 let call ~cascade_name ~prompt
     ?(config_path = "") ?(temperature = 0.3) ?(timeout_sec = 30)
-    ?(max_tokens = 500) ?(accept = fun _ -> true) () =
+    ?(max_tokens = 500) ?(accept = fun _ -> true) ?system () =
   let specs = get_cascade ~config_path ~cascade_name () in
   if specs = [] then
     Error (Printf.sprintf "[cascade] no callable models for %s" cascade_name)
   else
     match
       Llm_client.run_prompt_cascade ~temperature
-        ~timeout_sec ~model_specs:specs ~max_tokens ~accept ~prompt ()
+        ~timeout_sec ~model_specs:specs ~max_tokens ~accept ?system ~prompt ()
     with
     | Ok resp ->
         Ok

--- a/lib/lodge_heartbeat.ml
+++ b/lib/lodge_heartbeat.ml
@@ -660,11 +660,11 @@ let () =
             history
           in
 
-          let model_specs = Lodge_cascade.get_cascade ~cascade_name:"lodge_context_rewrite" () in
           let summary =
-            match Llm_client.run_prompt_cascade ~temperature:0.3 ~timeout_sec:60
-                ~model_specs ~max_tokens:700 ~prompt:summary_prompt () with
-            | Ok resp -> resp.content
+            match Lodge_cascade.call ~cascade_name:"lodge_context_rewrite"
+                ~prompt:summary_prompt ~temperature:0.3 ~timeout_sec:60
+                ~max_tokens:700 () with
+            | Ok r -> r.response
             | Error _ -> ""
           in
 
@@ -1156,11 +1156,10 @@ let generate_agent_traits ~topic ~reason =
 }|}
     topic reason
   in
-  let model_specs = Lodge_cascade.get_cascade ~cascade_name:"lodge_trait_gen" () in
   let response =
-    match Llm_client.run_prompt_cascade ~temperature:0.5 ~timeout_sec:15
-        ~model_specs ~max_tokens:200 ~prompt () with
-    | Ok resp -> resp.content
+    match Lodge_cascade.call ~cascade_name:"lodge_trait_gen"
+        ~prompt ~temperature:0.5 ~timeout_sec:15 ~max_tokens:200 () with
+    | Ok r -> r.response
     | Error _ -> ""
   in
   (* Extract JSON from response *)
@@ -1890,12 +1889,11 @@ let generate_agent_content ~agent_name ~context:_ ~action_type =
   Eio.traceln "   📊 [%s] Context: %d/%d tokens (%d msgs)" agent_name tokens max_tokens msg_count;
 
   (* LLM call via cascade abstraction *)
-  let model_specs = Lodge_cascade.get_cascade ~cascade_name:"lodge_comment" () in
   let response =
-    match Llm_client.run_prompt_cascade ~temperature:0.7 ~timeout_sec:30
-        ~system:system_with_context ~model_specs ~max_tokens:120
-        ~prompt:user_prompt () with
-    | Ok resp -> resp.content
+    match Lodge_cascade.call ~cascade_name:"lodge_comment"
+        ~prompt:user_prompt ~temperature:0.7 ~timeout_sec:30
+        ~max_tokens:120 ~system:system_with_context () with
+    | Ok r -> r.response
     | Error _ -> ""
   in
 
@@ -2170,32 +2168,13 @@ let heartbeat_response_accepted ?(require_json = false)
   heartbeat_response_is_valid ~require_json resp.content
 
 let run_heartbeat_llm_once ?(require_json = false) ~agent_name ~prompt () =
-  let models = Lodge_cascade.get_cascade ~cascade_name:"heartbeat_action" () in
-  let heartbeat_max_tokens = 1200 in
-  let started_at = Time_compat.now () in
-  let result =
-    if models = [] then (
-      Printf.printf
-        "   ⚠️ [%s] No heartbeat model pool available, skipping\n%!" agent_name;
-      Error "no heartbeat model pool available")
-    else
-      Llm_client.run_prompt_cascade ~timeout_sec:60
-        ~accept:(heartbeat_response_accepted ~require_json)
-        ~model_specs:models ~max_tokens:heartbeat_max_tokens ~prompt ()
-  in
-  let duration_ms =
-    int_of_float ((Time_compat.now () -. started_at) *. 1000.0)
-  in
-  match result with
-  | Ok resp ->
-      {
-        Lodge_cascade.response = resp.content;
-        llm_used = resp.model_used;
-        duration_ms;
-      }
+  let accept = heartbeat_response_accepted ~require_json in
+  match Lodge_cascade.call ~cascade_name:"heartbeat_action"
+      ~prompt ~temperature:0.7 ~timeout_sec:60 ~max_tokens:1200 ~accept () with
+  | Ok r -> r
   | Error err ->
       Printf.printf "   ❌ [%s] Heartbeat cascade failed: %s\n%!" agent_name err;
-      { Lodge_cascade.response = ""; llm_used = "none"; duration_ms }
+      { Lodge_cascade.response = ""; llm_used = "none"; duration_ms = 0 }
 
 let run_heartbeat_llm_traced ?(require_json = false) ~agent_name ~phase ~prompt () =
   let tick_id =
@@ -3142,11 +3121,10 @@ let analyze_broadcast_relevance_llm ~content ~available_agents =
      예: dreamer, historian"
     content agents_str
   in
-  let model_specs = Lodge_cascade.get_cascade ~cascade_name:"lodge_agent_match" () in
   let response =
-    match Llm_client.run_prompt_cascade ~temperature:0.1 ~timeout_sec:15
-        ~model_specs ~max_tokens:200 ~prompt () with
-    | Ok resp -> resp.content
+    match Lodge_cascade.call ~cascade_name:"lodge_agent_match"
+        ~prompt ~temperature:0.1 ~timeout_sec:15 ~max_tokens:200 () with
+    | Ok r -> r.response
     | Error _ -> ""
   in
   (* Parse response to get agent names *)

--- a/lib/sentinel.ml
+++ b/lib/sentinel.ml
@@ -48,30 +48,19 @@ let call_sentinel_llm ~cascade_name ~prompt_id ~vars () =
         log (sprintf "prompt %s render failed: %s" prompt_id msg);
         None
     | Ok prompt ->
-        let specs = Lodge_cascade.get_cascade ~cascade_name () in
-        if specs = [] then (
-          log (sprintf "no models available for cascade %s" cascade_name);
-          None)
-        else
-          let timeout = Env_config.Sentinel.llm_timeout_sec in
-          let max_tokens = 800 in
-          match Llm_client.run_prompt_cascade
-                  ~temperature:0.3
-                  ~timeout_sec:timeout
-                  ~model_specs:specs
-                  ~max_tokens
-                  ~prompt () with
-          | Ok resp ->
-              if String.length resp.content > 5 then (
-                log (sprintf "LLM response from %s (%d chars)" resp.model_used
-                       (String.length resp.content));
-                parse_llm_json_safe resp.content)
-              else (
-                log (sprintf "LLM response too short from %s" resp.model_used);
-                None)
-          | Error err ->
-              log (sprintf "LLM cascade %s failed: %s" cascade_name err);
-              None
+        let timeout = Env_config.Sentinel.llm_timeout_sec in
+        (match Lodge_cascade.call ~cascade_name ~prompt
+            ~temperature:0.3 ~timeout_sec:timeout ~max_tokens:800 () with
+        | Ok r when String.length r.response > 5 ->
+            log (sprintf "LLM response from %s (%d chars)" r.llm_used
+                   (String.length r.response));
+            parse_llm_json_safe r.response
+        | Ok r ->
+            log (sprintf "LLM response too short from %s" r.llm_used);
+            None
+        | Error err ->
+            log (sprintf "LLM cascade %s failed: %s" cascade_name err);
+            None)
 
 (* ── Sentinel-specific Pulse Consumers ─────────────────────── *)
 

--- a/lib/tool_lodge.ml
+++ b/lib/tool_lodge.ml
@@ -424,10 +424,9 @@ let llm_generate ~net:_ ?(prefer_fast = true) ~system prompt =
 
 (** Call GLM API via Llm_client cascade — Z.ai cloud API, 200K context, no VRAM. *)
 let glm_direct ~net:_ ?temperature:(_temp = 0.7) ?(max_tokens = 500) ~system prompt =
-  let model_specs = Lodge_cascade.get_cascade ~cascade_name:"lodge_direct" () in
-  match Llm_client.run_prompt_cascade ~temperature:_temp ~timeout_sec:120
-      ~system ~model_specs ~max_tokens ~prompt () with
-  | Ok resp when String.length resp.content > 0 -> Ok resp.content
+  match Lodge_cascade.call ~cascade_name:"lodge_direct"
+      ~prompt ~temperature:_temp ~timeout_sec:120 ~max_tokens ~system () with
+  | Ok r when String.length r.response > 0 -> Ok r.response
   | Ok _ -> Error "LLM: GLM returned empty response"
   | Error e -> Error (Printf.sprintf "LLM: cascade failed [%s]" e)
 

--- a/test/test_lodge_heartbeat_cleanup_coverage.ml
+++ b/test/test_lodge_heartbeat_cleanup_coverage.ml
@@ -99,7 +99,7 @@ let test_lodge_heartbeat_updates_self_summary () =
 let test_lodge_heartbeat_uses_shared_prompt_cascade () =
   check bool "heartbeat uses shared prompt cascade"
     true
-    (file_contains_pattern "lib/lodge_heartbeat.ml" "Llm_client.run_prompt_cascade")
+    (file_contains_pattern "lib/lodge_heartbeat.ml" "Lodge_cascade.call")
 
 let test_lodge_heartbeat_uses_runtime_verifier_mode () =
   check bool "heartbeat uses verifier auto mode for posts"


### PR DESCRIPTION
## Summary

Phase 1 (#746)에서 추가한 `Lodge_cascade.call` 통합 어댑터를 실제 호출처 8곳에 적용.

- `get_cascade` + `run_prompt_cascade` 2단계 패턴을 `Lodge_cascade.call` 1단계로 통합
- `?system` optional parameter 추가 (system prompt가 필요한 호출처 지원)
- 순감 -35줄, 중간 변수(`model_specs`, `started_at`, `duration_ms`) 제거

### 마이그레이션 대상

| 파일 | 호출처 | 특이사항 |
|------|--------|----------|
| `lodge_heartbeat.ml` | context_rewrite, trait_gen, comment, heartbeat_action, agent_match | 5곳, comment는 `~system` 사용 |
| `gardener.ml` | spawn evaluation | 단순 변환 |
| `tool_lodge.ml` | glm_direct | `~system` + 다른 반환 패턴 |
| `sentinel.ml` | sentinel LLM calls | env timeout, JSON 파싱 |

### Phase 3 남은 작업 (별도 PR)

`context_router`, `capability_match`, `lodge_tom`, `trpg_dm_intent`, `post_verifier_llm`, `auto_responder`, `room_walph_eio` — 자체 model_strings를 쓰는 Distributed 패턴.

## Test plan

- [x] `dune build` 성공
- [x] `test_lodge_cascade` 9 tests pass
- [x] `test_gardener` 62 tests pass
- [x] `make test` 전체 통과 (구조 테스트 갱신 포함)
- [ ] CI green 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)