### PR TITLE
refactor(state): thread net through server_state record (P3a)

### DIFF
--- a/bin/main_eio.ml
+++ b/bin/main_eio.ml
@@ -8253,7 +8253,7 @@ let run_server ~sw ~env ~port ~base_path =
   Unix.putenv "MASC_BASE_PATH_INPUT" base_path;
 
   (* Initialize server state with Eio context *)
-  let state = Mcp_eio.create_state_eio ~sw ~env:caqti_env ~proc_mgr ~fs ~clock ~base_path in
+  let state = Mcp_eio.create_state_eio ~sw ~env:caqti_env ~proc_mgr ~fs ~clock ~net ~base_path in
   server_state := Some state;
   Masc_mcp.Chain_native_eio.configure_storage_paths state.room_config;
   (try Masc_mcp.Tool_command_plane.backfill_chain_overlays state.room_config

--- a/lib/mcp_server.ml
+++ b/lib/mcp_server.ml
@@ -461,6 +461,7 @@ type server_state = {
   fs: Eio.Fs.dir_ty Eio.Path.t option; (* For filesystem access *)
   clock: float Eio.Time.clock_ty Eio.Resource.t option; (* For timestamps/sleep *)
   env: Caqti_eio.stdenv option; (* For DB/HTTP access - Agent Being Protocol *)
+  net: Eio_context.eio_net option; (* For network calls - P3a: replaces global ref *)
 }
 
 let create_state ~base_path =
@@ -482,10 +483,11 @@ let create_state ~base_path =
     fs = None;
     clock = None;
     env = None;
+    net = None;
   }
 
 (** Create state with Eio context - required for PostgresNative backend *)
-let create_state_eio ~sw ~env ~proc_mgr ~fs ~clock ~base_path =
+let create_state_eio ~sw ~env ~proc_mgr ~fs ~clock ~net ~base_path =
   let config = Room.default_config_eio ~sw ~env base_path in
   let registry = Session.create () in
   let agents_path = Filename.concat config.base_path ".masc/agents" in
@@ -503,6 +505,7 @@ let create_state_eio ~sw ~env ~proc_mgr ~fs ~clock ~base_path =
     fs = Some fs;
     clock = Some clock;
     env = Some env;
+    net = Some net;
   }
 
 (** Register SSE broadcast callback *)

--- a/lib/mcp_server_eio.ml
+++ b/lib/mcp_server_eio.ml
@@ -37,8 +37,8 @@ let create_state ?test_mode:_ ~base_path () =
   Mcp_server.create_state ~base_path
 
 (** Create state with Eio context - required for PostgresNative backend *)
-let create_state_eio ~sw ~env ~proc_mgr ~fs ~clock ~base_path =
-  let state = Mcp_server.create_state_eio ~sw ~env ~proc_mgr ~fs ~clock ~base_path in
+let create_state_eio ~sw ~env ~proc_mgr ~fs ~clock ~net ~base_path =
+  let state = Mcp_server.create_state_eio ~sw ~env ~proc_mgr ~fs ~clock ~net:(net :> Eio_context.eio_net) ~base_path in
   (* Recover any previously running team sessions after server restart. *)
   (try Team_session_engine_eio.recover_running_sessions ~sw ~clock ~config:state.Mcp_server.room_config
    with exn ->
@@ -1125,7 +1125,7 @@ let execute_tool_eio ~sw ~clock ?mcp_session_id ?auth_token state ~name ~argumen
       agent_name;
       sw = Some sw;
       clock = Some clock;
-      net = get_net_opt ();
+      net = state.Mcp_server.net;
       mcp_state = Some state;
       mcp_session_id;
       auth_token;
@@ -1182,7 +1182,11 @@ let execute_tool_eio ~sw ~clock ?mcp_session_id ?auth_token state ~name ~argumen
   let simple_ctx_audit : Tool_audit.context = { config } in
   let simple_ctx_rate_limit : Tool_rate_limit.context = { config; agent_name; registry } in
   let simple_ctx_cost : Tool_cost.context = { agent_name } in
-  let simple_ctx_walph = lazy ({ config; agent_name; net = get_net (); clock } : _ Tool_walph.context) in
+  let simple_ctx_walph = lazy (
+    match state.Mcp_server.net with
+    | Some net -> ({ config; agent_name; net; clock } : _ Tool_walph.context)
+    | None -> failwith "walph requires net (server_state.net is None)"
+  ) in
   let simple_ctx_agent : Tool_agent.context = { config; agent_name } in
   let simple_ctx_task : Tool_task.context = { config; agent_name } in
   let simple_ctx_room : Tool_room.context = { config; agent_name } in
@@ -1263,7 +1267,9 @@ let execute_tool_eio ~sw ~clock ?mcp_session_id ?auth_token state ~name ~argumen
     | exn -> `Error (Printexc.to_string exn)
   in
   let trpg_dm_voice_emit ~agent_id ~message ~provider : Tool_trpg.dm_voice_emit_result =
-    let net = get_net () in
+    match state.Mcp_server.net with
+    | None -> Error "trpg voice requires net (server_state.net is None)"
+    | Some net ->
     let provider =
       match provider |> Option.map String.trim with
       | Some p when p <> "" && not (String.equal (String.lowercase_ascii p) "auto") ->
@@ -2483,8 +2489,9 @@ Time: %s
   | "lodge_research" | "lodge_profile"
   (* New: Search, Like, Progress *)
   | "lodge_search" | "lodge_comment_like" | "lodge_progress" ->
-      let net = get_net () in
-      Tool_lodge.handle_tool ~net name arguments
+      (match state.Mcp_server.net with
+       | Some net -> Tool_lodge.handle_tool ~net name arguments
+       | None -> (false, "lodge tools require net (server_state.net is None)"))
 
   (* ============================================ *)
   (* Conversation Tools - Persistent Agent Dialogue *)

--- a/lib/mcp_server_eio.mli
+++ b/lib/mcp_server_eio.mli
@@ -86,6 +86,7 @@ val create_state : ?test_mode:bool -> base_path:string -> unit -> server_state
     @param proc_mgr Eio process manager for agent spawning
     @param fs Eio filesystem for file operations
     @param clock Eio time clock for timestamps/sleep
+    @param net Eio network capability for HTTP/TLS calls
     @param base_path Base path for MASC data directory *)
 val create_state_eio :
   sw:Eio.Switch.t ->
@@ -93,6 +94,7 @@ val create_state_eio :
   proc_mgr:Eio_unix.Process.mgr_ty Eio.Resource.t ->
   fs:Eio.Fs.dir_ty Eio.Path.t ->
   clock:float Eio.Time.clock_ty Eio.Resource.t ->
+  net:[> `Generic | `Unix] Eio.Net.ty Eio.Resource.t ->
   base_path:string ->
   server_state
 


### PR DESCRIPTION
## Summary
- `server_state` 레코드에 `net: Eio_context.eio_net option` 필드 추가
- lib/ 레이어의 `Eio_context.get_net()` 글로벌 ref 호출 3곳을 `state.Mcp_server.net` option 패턴매칭으로 교체
- `create_state_eio`에 `~net` 파라미터 추가 (open variant 수용 + coercion)
- bin/ 레이어의 `get_net()` 호출은 application code이므로 별도 PR로 처리 예정

## Motivation
글로벌 가변 ref(`Eio_context.current_net`)는 타입 시스템을 우회한다. `Option.get` 스타일의 throwing getter는 초기화 순서에 의존하며, 컴파일러가 보호하지 못하는 런타임 크래시를 유발할 수 있다. `server_state` 레코드를 통해 전달하면 타입 수준에서 존재 여부를 강제할 수 있다.

## Changes (4 files, +21/-9)
| File | Change |
|------|--------|
| `lib/mcp_server.ml` | `server_state`에 `net` 필드 추가, `create_state_eio`에 `~net` 파라미터 |
| `lib/mcp_server_eio.ml` | 3곳 `get_net()` → option 패턴매칭 (walph=failwith, trpg=Result, lodge=tuple) |
| `lib/mcp_server_eio.mli` | `create_state_eio` 시그니처에 `~net` 추가 |
| `bin/main_eio.ml` | `create_state_eio` 호출에 `~net` 전달 |

## Test plan
- [x] `dune build --root .` 성공
- [x] `make test` 전체 통과 (97 tests, exit 0)
- [ ] 테스트 호출부 변경 제로 확인 (net이 state 레코드에 있으므로)

🤖 Generated with [Claude Code](https://claude.com/claude-code)