### PR TITLE
feat(cp): add workload templates and attached sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,23 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [2.81.1] - 2026-03-11
 
+### Added
+- **Workload Templates for CPv2** — `masc_operation_start` now accepts `workload_template` (`coding_team`, `research_team`, `ops_governance_team`) and normalizes default workload/stage pairs.
+- **Attached Team Sessions** — `masc_team_session_start(operation_id=...)` can bind a team session to a managed CPv2 operation and exposes `command_plane.operation_id` / `operation_path` in session status.
+- **AI Front Door Docs** — added `llms.txt` and `llms-full.txt`, and surfaced them from the command-plane help/readme entrypoints.
+
+### Changed
+- `/api/v1/command-plane/help` now includes workload templates and an attached-team-session golden path for the managed execution spine.
+
 ### Fixed
 - Board test isolation: `ref(lazy)` singleton pattern prevents test JSONL data from polluting production board path (#759)
 - Thread-safe resettable singleton via `Lazy.force` atomic CAS + `ref` wrapping for test reset
 - `MASC_BASE_PATH` temp directory isolation in `test_board_dispatch` and `test_tool_board_coverage`
-
-## [2.81.0] - 2026-03-11
-
-### Added
-- **Persona-backed Keeper Creation** — `masc_persona_list` and `masc_keeper_create_from_persona` expose deterministic persona-to-keeper creation for agents and dashboards
-- **Explicit Keeper Model Switching** — `masc_keeper_model_set` persists exact active-model changes without heuristic fallback
-
-### Changed
-- Keeper runtime can now load defaults from `ME_ROOT/personas/<name>/profile.json`
-- Explicit-only keepers can maintain room-aware presence across rooms while reacting only to exact direct mentions
-
-### Fixed
-- Keeper room presence no longer depends on mutating repo-global `current_room`
+- Attached team session validation now rejects duplicate operation attachment based on the nested operation card shape rather than a broken top-level lookup.
 ## [2.80.0] - 2026-03-11
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -268,6 +268,8 @@ Note: `decision.*`, `experiment.*`, `trpg.*`, `client.*` 네임스페이스는 `
 
 | 문서 | 설명 |
 |------|------|
+| `llms.txt` | AI/LLM용 최소 canonical front door |
+| `llms-full.txt` | AI/LLM용 확장 orchestration contract |
 | `docs/QUICKSTART.md` | 빠른 시작 |
 | `docs/SETUP.md` | 설치/실행/백엔드 설정 |
 | `docs/SPEC.md` | 동작 스펙과 데이터 모델 |

--- a/docs/TEAM-SESSION.md
+++ b/docs/TEAM-SESSION.md
@@ -27,6 +27,7 @@
 입력:
 
 - `goal` (required)
+- `operation_id` (optional, managed CPv2 operation attachment)
 - `duration_seconds` (default `3600`)
 - `execution_scope` (`observe_only` | `limited_code_change`, default `observe_only`)
 - `checkpoint_interval_sec` (default `60`)
@@ -38,6 +39,7 @@
 출력:
 
 - `session_id`
+- `operation_id` (if attached)
 - `status` (`running`)
 - `started_at`
 - `planned_end_at`
@@ -53,7 +55,17 @@
 - 런타임 상태(`runtime_running`)
 - 진행 요약(`summary`): elapsed, remaining, progress, done delta
 - LLM 캐시 메트릭(`llm_cache_metrics`): hits/misses/writes/bypass/errors/hit_rate
+- command-plane 링크(`command_plane`): attached operation id/path
 - 보고서 경로(`report_paths`)
+
+### Attached Session Mode
+
+`masc_team_session_start(operation_id="op-...")`를 사용하면 team session이 managed CPv2 operation에 연결됩니다.
+
+- operation의 `detachment_session_id`가 session id로 갱신됩니다.
+- `masc_team_session_status`의 `command_plane.operation_id` / `operation_path`로 연결 상태를 읽을 수 있습니다.
+- 이미 다른 session이 연결된 operation에는 새 session을 attach할 수 없습니다.
+- `operation_id` 없이 시작한 session은 기존처럼 projected session으로 해석됩니다.
 
 ### `masc_team_session_stop`
 

--- a/lib/cp_lifecycle.ml
+++ b/lib/cp_lifecycle.ml
@@ -2410,8 +2410,50 @@ let start_operation config ~(actor : string) json =
   match unit_guard_json config assigned_unit_id with
   | Error message -> Error message
   | Ok _ ->
+      let workload_template =
+        match get_string_opt json "workload_template" with
+        | Some value ->
+            let* validated = validate_workload_template value in
+            Ok (Some validated)
+        | None -> Ok None
+      in
+      let* workload_template = workload_template in
+      let inferred_workload_profile, inferred_stage =
+        match workload_template with
+        | Some template -> (
+            match workload_template_defaults template with
+            | Some defaults -> defaults
+            | None -> ("coding_task", None))
+        | None -> ("coding_task", None)
+      in
+      let explicit_workload_profile = get_string_opt json "workload_profile" in
+      let* () =
+        match workload_template, explicit_workload_profile with
+        | Some template, Some explicit_profile -> (
+            let expected_profile, _ =
+              match workload_template_defaults template with
+              | Some defaults -> defaults
+              | None -> ("coding_task", None)
+            in
+            let* normalized_explicit = validate_workload_profile explicit_profile in
+            if String.equal normalized_explicit expected_profile then
+              Ok ()
+            else
+              Error
+                (Printf.sprintf
+                   "workload_template %s requires workload_profile=%s"
+                   template expected_profile))
+        | _ -> Ok ()
+      in
       let workload_profile_raw =
-        get_string_default json "workload_profile" "coding_task"
+        match explicit_workload_profile with
+        | Some value -> value
+        | None -> inferred_workload_profile
+      in
+      let requested_stage =
+        match get_string_opt json "stage" with
+        | Some value -> Some value
+        | None -> inferred_stage
       in
       let search_strategy_raw =
         get_string_default json "search_strategy" (room_search_strategy_default config)
@@ -2421,7 +2463,7 @@ let start_operation config ~(actor : string) json =
       let raw_artifact_scope = get_string_list json "artifact_scope" in
       let* workload_profile = validate_workload_profile workload_profile_raw in
       let* stage =
-        validate_stage_for_workload ~workload_profile (get_string_opt json "stage")
+        validate_stage_for_workload ~workload_profile requested_stage
       in
       let* search_strategy = validate_search_strategy search_strategy_raw in
       let* intent_binding =
@@ -2494,6 +2536,7 @@ let start_operation config ~(actor : string) json =
           autonomy_level = get_string_default json "autonomy_level" "L4_Autonomous";
           policy_class = get_string_default json "policy_class" "strict";
           budget_class = get_string_default json "budget_class" "standard";
+          workload_template;
           workload_profile;
           stage;
           artifact_scope;
@@ -2536,6 +2579,10 @@ let start_operation config ~(actor : string) json =
             ("intent_id", match operation.intent_id with Some value -> `String value | None -> `Null);
             ("autonomy_level", `String operation.autonomy_level);
             ("policy_class", `String operation.policy_class);
+            ( "workload_template",
+              match operation.workload_template with
+              | Some value -> `String value
+              | None -> `Null );
             ("workload_profile", `String (operation_workload_profile operation));
             ("stage", match operation.stage with Some value -> `String value | None -> `Null);
             ("artifact_scope", json_list_of_strings operation.artifact_scope);

--- a/lib/cp_serde.ml
+++ b/lib/cp_serde.ml
@@ -114,6 +114,26 @@ let validate_workload_profile raw =
   | "coding_task" | "research_pipeline" as value -> Ok value
   | other -> Error (Printf.sprintf "unsupported workload_profile: %s" other)
 
+let normalize_workload_template = function
+  | Some value ->
+      let trimmed = String.trim value |> String.lowercase_ascii in
+      if trimmed = "" then None else Some trimmed
+  | None -> None
+
+let validate_workload_template raw =
+  match normalize_workload_template (Some raw) with
+  | Some ("coding_team" | "research_team" | "ops_governance_team" as value) ->
+      Ok value
+  | Some other ->
+      Error (Printf.sprintf "unsupported workload_template: %s" other)
+  | None -> Error "unsupported workload_template: "
+
+let workload_template_defaults = function
+  | "coding_team" -> Some ("coding_task", Some "decompose")
+  | "research_team" -> Some ("research_pipeline", Some "normalize")
+  | "ops_governance_team" -> Some ("research_pipeline", Some "audit")
+  | _ -> None
+
 let normalize_stage = function
   | Some value ->
       let trimmed = String.trim value |> String.lowercase_ascii in
@@ -422,6 +442,10 @@ let operation_to_json (operation : operation_record) =
       ("autonomy_level", `String operation.autonomy_level);
       ("policy_class", `String operation.policy_class);
       ("budget_class", `String operation.budget_class);
+      ( "workload_template",
+        match operation.workload_template with
+        | Some value -> `String value
+        | None -> `Null );
       ("workload_profile", `String (operation_workload_profile operation));
       ("stage", match operation.stage with Some value -> `String value | None -> `Null);
       ("artifact_scope", json_list_of_strings operation.artifact_scope);
@@ -497,6 +521,8 @@ let operation_of_json json =
             autonomy_level = get_string_default json "autonomy_level" "L4_Autonomous";
             policy_class = get_string_default json "policy_class" "strict";
             budget_class = get_string_default json "budget_class" "standard";
+            workload_template =
+              normalize_workload_template (get_string_opt json "workload_template");
             workload_profile =
               Cp_search_fabric.normalized_workload_profile
                 (get_string_default json "workload_profile" "coding_task");

--- a/lib/cp_types.ml
+++ b/lib/cp_types.ml
@@ -72,6 +72,7 @@ type operation_record = {
   autonomy_level : string;
   policy_class : string;
   budget_class : string;
+  workload_template : string option;
   workload_profile : string;
   stage : string option;
   artifact_scope : string list;

--- a/lib/cp_unit.ml
+++ b/lib/cp_unit.ml
@@ -474,6 +474,7 @@ let projected_team_session_operations config units managed_operations =
              Team_session_types.execution_scope_to_string session.execution_scope;
            budget_class =
              Team_session_types.communication_mode_to_string session.communication_mode;
+           workload_template = None;
            workload_profile = "coding_task";
            stage = Some "implement";
            artifact_scope = [];
@@ -536,6 +537,7 @@ let projected_swarm_operations config units managed_operations =
             autonomy_level = "L5_Independent";
             policy_class = "swarm";
             budget_class = "adaptive";
+            workload_template = None;
             workload_profile = "coding_task";
             stage = None;
             artifact_scope = [];

--- a/lib/server_command_plane_http.ml
+++ b/lib/server_command_plane_http.ml
@@ -703,6 +703,19 @@ let command_plane_help_http_json () =
         ("tools", str_list tools);
       ]
   in
+  let workload_template ~id ~title ~summary ~workload_profile ~default_stage
+      ~autonomy_target ~recommended_tools =
+    `Assoc
+      [
+        ("id", `String id);
+        ("title", `String title);
+        ("summary", `String summary);
+        ("workload_profile", `String workload_profile);
+        ("default_stage", `String default_stage);
+        ("autonomy_target", `String autonomy_target);
+        ("recommended_tools", str_list recommended_tools);
+      ]
+  in
   let pitfall ~id ~title ~symptom ~why ~fix_tool ~fix_summary =
     `Assoc
       [
@@ -752,6 +765,16 @@ let command_plane_help_http_json () =
               [
                 ("title", `String "Swarm Delivery Runbook");
                 ("path", `String "docs/SWARM-DELIVERY-RUNBOOK.md");
+              ];
+            `Assoc
+              [
+                ("title", `String "LLM Front Door");
+                ("path", `String "llms.txt");
+              ];
+            `Assoc
+              [
+                ("title", `String "LLM Front Door Full");
+                ("path", `String "llms-full.txt");
               ];
           ] );
       ( "concepts",
@@ -885,6 +908,63 @@ let command_plane_help_http_json () =
                     ~success_signals:[ "intervention trace appended"; "team-session reflects the change" ]
                     ~pitfalls:[ "do not mix this path with CPv2 benchmark commands in the same explanation" ];
                 ];
+            path ~id:"attached_team_session" ~title:"Attached Team Session"
+              ~summary:
+                "Attach a team session to a managed CPv2 operation so execution and truth stay on the same spine."
+              ~when_to_use:
+                "Use this for hybrid execution where a managed operation owns the objective and a team session materializes the worker team."
+              ~steps:
+                [
+                  step ~id:"start-managed-operation"
+                    ~title:"Start managed operation" ~tool:"masc_operation_start"
+                    ~summary:
+                      "Create the operation first, optionally with workload_template for coding, research, or governance teams."
+                    ~success_signals:
+                      [ "operation_id issued"; "workload_profile/stage normalized"; "trace_id issued" ]
+                    ~pitfalls:
+                      [ "workload_template and workload_profile must stay in the same family" ];
+                  step ~id:"start-attached-session"
+                    ~title:"Start attached team session" ~tool:"masc_team_session_start"
+                    ~summary:
+                      "Start a team session with operation_id so the operation detachment_session_id points back to the session."
+                    ~success_signals:
+                      [ "team session response includes operation_id"; "command-plane operation references session_id" ]
+                    ~pitfalls:
+                      [ "an operation can only be attached to one team session at a time" ];
+                  step ~id:"observe-attached-runtime"
+                    ~title:"Observe hybrid runtime" ~tool:"masc_team_session_status"
+                    ~summary:
+                      "Read team-session status together with command-plane operation state."
+                    ~success_signals:
+                      [ "team session command_plane block returns operation_path"; "operation/detachment visibility is consistent" ]
+                    ~pitfalls:
+                      [ "do not treat projected detached sessions as the same as attached managed sessions" ];
+                ];
+          ] );
+      ( "workload_templates",
+        `List
+          [
+            workload_template ~id:"coding_team" ~title:"Coding Team"
+              ~summary:
+                "Planner -> implementer -> verifier/reviewer style team. Defaults to coding_task/decompose."
+              ~workload_profile:"coding_task" ~default_stage:"decompose"
+              ~autonomy_target:"L3_Guided -> L5_Independent"
+              ~recommended_tools:
+                [ "masc_operation_start"; "masc_team_session_start"; "masc_operator_digest"; "masc_operation_finalize" ];
+            workload_template ~id:"research_team" ~title:"Research Team"
+              ~summary:
+                "Collect -> verify -> curate -> rank -> audit style team. Defaults to research_pipeline/normalize."
+              ~workload_profile:"research_pipeline" ~default_stage:"normalize"
+              ~autonomy_target:"L3_Guided -> L5_Independent"
+              ~recommended_tools:
+                [ "masc_operation_start"; "masc_dispatch_tick"; "masc_observe_operations"; "masc_operation_finalize" ];
+            workload_template ~id:"ops_governance_team" ~title:"Ops / Governance Team"
+              ~summary:
+                "Audit, intervention, approval, and operator-heavy team. Defaults to research_pipeline/audit for decision-heavy work."
+              ~workload_profile:"research_pipeline" ~default_stage:"audit"
+              ~autonomy_target:"L2_Suggestive -> L4_Autonomous"
+              ~recommended_tools:
+                [ "masc_operation_start"; "masc_team_session_start"; "masc_operator_snapshot"; "masc_policy_approve" ];
           ] );
       ( "tool_groups",
         `List

--- a/lib/team_session_engine_eio.ml
+++ b/lib/team_session_engine_eio.ml
@@ -7,6 +7,8 @@ type runtime_state = {
   mutable generate_report_on_finalize : bool;
 }
 
+let ( let* ) = Result.bind
+
 let runtimes : (string, runtime_state) Hashtbl.t = Hashtbl.create 16
 let runtimes_mutex = Eio.Mutex.create ()
 let finalize_mutex = Eio.Mutex.create ()
@@ -249,6 +251,30 @@ let session_has_attached_actor ~(config : Room.config) ~(session_id : string)
              | `String attached -> String.equal attached actor
              | _ -> false)
          | _ -> false)
+
+let validate_operation_attachment ~(config : Room.config) ~(operation_id : string)
+    : (unit, string) result =
+  let open Yojson.Safe.Util in
+  let operations_json = Command_plane_v2.list_operations_json ~operation_id config in
+  match operations_json |> member "operations" with
+  | `List [] ->
+      Error (Printf.sprintf "operation not found: %s" operation_id)
+  | `List ((`Assoc _ as row) :: _) -> (
+      match
+        row |> member "operation" |> member "detachment_session_id"
+        |> to_string_option
+      with
+      | Some session_id when String.trim session_id <> "" ->
+          Error
+            (Printf.sprintf
+               "operation already attached to team session: %s"
+               session_id)
+      | _ -> Ok ())
+  | _ ->
+      Error
+        (Printf.sprintf
+           "operation lookup failed for attachment: %s"
+           operation_id)
 
 let compute_live_done_delta (config : Room.config)
     (session : Team_session_types.session) =
@@ -507,6 +533,20 @@ let session_status_json (config : Room.config) (session : Team_session_types.ses
       ("cascade_metrics", cascade_metrics);
       ("local_runtime", local_runtime);
       ("llm_cache_metrics", llm_cache_metrics);
+      ( "command_plane",
+        `Assoc
+          [
+            ( "operation_id",
+              Option.fold ~none:`Null ~some:(fun value -> `String value)
+                session.operation_id );
+            ( "operation_path",
+              Option.fold ~none:`Null
+                ~some:(fun value ->
+                  `String
+                    (Printf.sprintf "/api/v1/command-plane/operations?operation_id=%s"
+                       value))
+                session.operation_id );
+          ] );
       ( "report_paths",
         `Assoc
           [
@@ -1026,7 +1066,8 @@ let start_session ~sw ~(clock : _ Eio.Time.clock) ~(config : Room.config)
     ~(instruction_profile : Team_session_types.instruction_profile)
     ~(alert_channel : Team_session_types.alert_channel) ~(auto_resume : bool)
     ~(report_formats : Team_session_types.report_format list)
-    ~(agent_names : string list) : (Yojson.Safe.t, string) result =
+    ~(agent_names : string list) ~(operation_id : string option)
+    : (Yojson.Safe.t, string) result =
   try
     Room_utils.ensure_initialized config;
     let duration_seconds = clamp_int ~min_v:60 ~max_v:28800 duration_seconds in
@@ -1037,6 +1078,11 @@ let start_session ~sw ~(clock : _ Eio.Time.clock) ~(config : Room.config)
     let now = Time_compat.now () in
     let session_id = Team_session_store.make_session_id () in
     Team_session_store.ensure_session_dirs config session_id;
+    let* () =
+      match operation_id with
+      | Some value -> validate_operation_attachment ~config ~operation_id:value
+      | None -> Ok ()
+    in
     let room_id =
       Room_utils.read_current_room config |> Option.value ~default:"default"
     in
@@ -1057,6 +1103,7 @@ let start_session ~sw ~(clock : _ Eio.Time.clock) ~(config : Room.config)
         goal;
         created_by;
         room_id;
+        operation_id;
         status = Team_session_types.Running;
         duration_seconds;
         execution_scope;
@@ -1102,6 +1149,31 @@ let start_session ~sw ~(clock : _ Eio.Time.clock) ~(config : Room.config)
         updated_at_iso = now_iso ();
       }
     in
+    let* () =
+      match operation_id with
+      | Some value -> (
+          match
+            Command_plane_v2.update_operation config ~actor:created_by
+              ~operation_id:value ~event_type:"team_session_attached"
+              ~detail:
+                (`Assoc
+                  [
+                    ("session_id", `String session_id);
+                    ("goal", `String goal);
+                  ])
+              (fun current ->
+                { current with
+                  detachment_session_id = Some session_id;
+                  note =
+                    (match current.note with
+                    | Some note when String.trim note <> "" -> Some note
+                    | _ -> Some ("team_session:" ^ session_id))
+                })
+          with
+          | Ok _ -> Ok ()
+          | Error err -> Error err)
+      | None -> Ok ()
+    in
     Team_session_store.save_session config session;
     Team_session_store.append_event config session_id ~event_type:"session_started"
       ~detail:
@@ -1109,6 +1181,7 @@ let start_session ~sw ~(clock : _ Eio.Time.clock) ~(config : Room.config)
           [
             ("goal", `String goal);
             ("created_by", `String created_by);
+            ("operation_id", Option.fold ~none:`Null ~some:(fun value -> `String value) operation_id);
             ("duration_seconds", `Int duration_seconds);
             ("agent_count", `Int (List.length selected_agents));
             ( "scale_profile",
@@ -1162,6 +1235,7 @@ let start_session ~sw ~(clock : _ Eio.Time.clock) ~(config : Room.config)
           ("started_at", `Float now);
           ("planned_end_at", `Float session.planned_end_at);
           ("artifacts_dir", `String session.artifacts_dir);
+          ("operation_id", Option.fold ~none:`Null ~some:(fun value -> `String value) operation_id);
           ( "orchestration_mode",
             `String
               (Team_session_types.orchestration_mode_to_string orchestration_mode)

--- a/lib/team_session_engine_eio.ml
+++ b/lib/team_session_engine_eio.ml
@@ -265,16 +265,40 @@ let validate_operation_attachment ~(config : Room.config) ~(operation_id : strin
         |> to_string_option
       with
       | Some session_id when String.trim session_id <> "" ->
-          Error
-            (Printf.sprintf
-               "operation already attached to team session: %s"
-               session_id)
+          (match Team_session_store.load_session config session_id with
+          | Some session when session.status = Team_session_types.Running ->
+              Error
+                (Printf.sprintf
+                   "operation already attached to team session: %s"
+                   session_id)
+          | _ -> Ok ())
       | _ -> Ok ())
   | _ ->
       Error
         (Printf.sprintf
            "operation lookup failed for attachment: %s"
            operation_id)
+
+let detach_operation_attachment ~(config : Room.config) ~(session : Team_session_types.session) =
+  match session.operation_id with
+  | None -> ()
+  | Some operation_id ->
+      ignore
+        (Command_plane_v2.update_operation config ~actor:session.created_by
+           ~operation_id ~event_type:"team_session_detached"
+           ~detail:
+             (`Assoc
+               [
+                 ("session_id", `String session.session_id);
+                 ("status",
+                   `String
+                     (Team_session_types.status_to_string session.status));
+               ])
+           (fun current ->
+             if current.detachment_session_id = Some session.session_id then
+               { current with detachment_session_id = None }
+             else
+               current))
 
 let compute_live_done_delta (config : Room.config)
     (session : Team_session_types.session) =
@@ -958,6 +982,7 @@ let finalize_session ~(config : Room.config) ~(session_id : string)
               }
             in
             Team_session_store.save_session config updated;
+            detach_operation_attachment ~config ~session:updated;
             Team_session_store.append_event config session_id
               ~event_type:"session_finalized"
               ~detail:
@@ -1149,6 +1174,7 @@ let start_session ~sw ~(clock : _ Eio.Time.clock) ~(config : Room.config)
         updated_at_iso = now_iso ();
       }
     in
+    Team_session_store.save_session config session;
     let* () =
       match operation_id with
       | Some value -> (
@@ -1174,7 +1200,6 @@ let start_session ~sw ~(clock : _ Eio.Time.clock) ~(config : Room.config)
           | Error err -> Error err)
       | None -> Ok ()
     in
-    Team_session_store.save_session config session;
     Team_session_store.append_event config session_id ~event_type:"session_started"
       ~detail:
         (`Assoc

--- a/lib/team_session_types.ml
+++ b/lib/team_session_types.ml
@@ -130,6 +130,7 @@ type session = {
   goal : string;
   created_by : string;
   room_id : string;
+  operation_id : string option;
   status : session_status;
   duration_seconds : int;
   execution_scope : execution_scope;
@@ -790,6 +791,7 @@ let session_to_yojson (s : session) =
       ("goal", `String s.goal);
       ("created_by", `String s.created_by);
       ("room_id", `String s.room_id);
+      ("operation_id", Option.fold ~none:`Null ~some:(fun v -> `String v) s.operation_id);
       ("status", `String (status_to_string s.status));
       ("duration_seconds", `Int s.duration_seconds);
       ("execution_scope", `String (execution_scope_to_string s.execution_scope));
@@ -856,6 +858,7 @@ let session_of_yojson json =
         goal = json |> member "goal" |> to_string;
         created_by = json |> member "created_by" |> to_string_option |> Option.value ~default:"unknown";
         room_id = json |> member "room_id" |> to_string_option |> Option.value ~default:"default";
+        operation_id = json |> member "operation_id" |> to_string_option;
         status = json |> member "status" |> to_string_option |> Option.value ~default:"failed" |> status_of_string;
         duration_seconds;
         execution_scope =

--- a/lib/tool_command_plane.ml
+++ b/lib/tool_command_plane.ml
@@ -1840,6 +1840,7 @@ let schemas : tool_schema list =
             ("autonomy_level", string_prop "Autonomy level such as L3_Guided or L4_Autonomous.");
             ("policy_class", string_prop "Policy class name.");
             ("budget_class", string_prop "Budget class name.");
+            ("workload_template", `Assoc [ ("type", `String "string"); ("enum", `List [ `String "coding_team"; `String "research_team"; `String "ops_governance_team" ]); ("description", `String "Optional high-level team template. Defaults: coding_team -> coding_task/decompose, research_team -> research_pipeline/normalize, ops_governance_team -> research_pipeline/audit. If workload_profile is also provided, it must match the template family.") ]);
             ("workload_profile", `Assoc [ ("type", `String "string"); ("enum", `List [ `String "coding_task"; `String "generic"; `String "research_pipeline" ]); ("description", `String "Workload profile used by CPv2 search fabric. Default: coding_task. generic is a deprecated alias for coding_task.") ]);
             ("stage", string_prop "Optional stage label. coding_task: decompose, inspect, implement, verify, review. research_pipeline: normalize, verify, curate, rank, audit.");
             ("artifact_scope", `Assoc [ ("type", `String "array"); ("items", `Assoc [ ("type", `String "string") ]); ("description", `String "Optional file or directory scope inherited across coding-task stages.") ]);

--- a/lib/tool_team_session.ml
+++ b/lib/tool_team_session.ml
@@ -213,6 +213,7 @@ let handle_start ctx args : result =
     let instruction_profile = parse_instruction_profile args in
     let alert_channel = parse_alert_channel args in
     let agents = get_agent_names args "agents" in
+    let operation_id = get_string_opt args "operation_id" in
     match
       Team_session_engine_eio.start_session ~sw:ctx.sw ~clock:ctx.clock
         ~config:ctx.config ~created_by:ctx.agent_name ~goal ~duration_seconds
@@ -220,7 +221,7 @@ let handle_start ctx args : result =
         ~scale_profile ~control_profile
         ~orchestration_mode ~communication_mode ~model_cascade ~fallback_policy
         ~instruction_profile ~alert_channel ~auto_resume ~report_formats
-        ~agent_names:agents
+        ~agent_names:agents ~operation_id
     with
     | Ok json -> (true, json_ok [ ("result", json) ])
     | Error e -> (false, json_error e)
@@ -2305,6 +2306,14 @@ let schemas : tool_schema list =
                       [
                         ("type", `String "string");
                         ("description", `String "Session goal (required)");
+                      ] );
+                  ( "operation_id",
+                    `Assoc
+                      [
+                        ("type", `String "string");
+                        ( "description",
+                          `String
+                            "Optional managed CPv2 operation id to attach this team session to. When provided, the operation detachment_session_id is updated to this session." );
                       ] );
                   ( "duration_seconds",
                     `Assoc

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -1,0 +1,107 @@
+# MASC-MCP LLM Front Door Full
+
+This file is the AI-friendly narrow waist for `masc-mcp`.
+
+## Goal
+
+Use `CPv2 command plane` as the single source of execution truth. Other orchestration surfaces should attach to it instead of bypassing it.
+
+## Primary entities
+
+- `room`: repo-root coordination scope
+- `task`: backlog work item
+- `operation`: managed execution unit
+- `detachment`: runtime materialization of an operation
+- `team session`: long-running worker capsule that can attach to an operation
+- `policy decision`: approval gate for strict actions
+- `trace`: lineage across operation, dispatch, checkpoint, and policy events
+
+## Canonical golden paths
+
+### 1. Room / task hygiene
+
+Use this before any real work:
+
+1. `masc_set_room`
+2. `masc_join`
+3. `masc_status`
+4. `masc_claim` or `masc_add_task`
+5. `masc_plan_set_task`
+6. `masc_heartbeat`
+
+### 2. Managed large-team orchestration
+
+Use this for benchmark runs or large autonomous teams:
+
+1. `masc_unit_define`
+2. `masc_operation_start`
+3. `masc_dispatch_tick`
+4. `masc_detachment_status`
+5. `masc_observe_topology` / `masc_observe_operations` / `masc_observe_traces`
+6. `masc_policy_approve` or `masc_policy_deny` when blocked
+7. `masc_operation_checkpoint`
+8. `masc_operation_finalize`
+
+### 3. Attached team session
+
+Use this when a managed operation needs a real worker team:
+
+1. Start operation with `masc_operation_start`
+2. Start session with `masc_team_session_start(operation_id="op-...")`
+3. Record work through `masc_team_session_step`
+4. Monitor with `masc_team_session_status`
+5. Use `/mcp/operator` for guided intervention when needed
+6. Finalize operation and session artifacts
+
+## Workload templates
+
+### `coding_team`
+
+- normalized workload profile: `coding_task`
+- default stage: `decompose`
+- intended use: planner / implementer / verifier / reviewer teams
+
+### `research_team`
+
+- normalized workload profile: `research_pipeline`
+- default stage: `normalize`
+- intended use: collect / verify / curate / rank / audit teams
+
+### `ops_governance_team`
+
+- normalized workload profile: `research_pipeline`
+- default stage: `audit`
+- intended use: operator-heavy audit, intervention, approval, and governance flows
+
+## Important constraints
+
+- `workload_template` and explicit `workload_profile` must belong to the same family.
+- An operation can only attach to one team session at a time.
+- `claim` does not set `current_task`; call `masc_plan_set_task`.
+- `dispatch_tick` is required after starting an operation.
+- `team_session` without `operation_id` is valid, but it will be treated as a projected session rather than a managed attached session.
+
+## Operator surface
+
+Use `/mcp/operator` when you want:
+
+- a small tool surface
+- read-first supervision
+- preview/confirm intervention
+- safer human-in-the-loop control
+
+Do not mix operator explanations with benchmark explanations in the same response unless the user explicitly asks for both.
+
+## Secondary surfaces
+
+Treat these as secondary unless the task explicitly calls for them:
+
+- `Lodge`
+- `TRPG`
+- `RISC`
+- concept/vision documents
+
+## Discoverability
+
+- `/api/v1/command-plane/help` exposes current concepts, golden paths, templates, examples, and pitfalls.
+- `tools/list` may hide low-value or deprecated tools; prefer canonical replacements.

--- a/llms.txt
+++ b/llms.txt
@@ -1,0 +1,39 @@
+# MASC-MCP LLM Front Door
+
+`masc-mcp` has many tools. Do not start from the full surface.
+
+## Canonical paths
+
+1. `Room / Task Hygiene`
+   - `masc_set_room`
+   - `masc_join`
+   - `masc_status`
+   - `masc_claim` or `masc_add_task`
+   - `masc_plan_set_task`
+   - `masc_heartbeat`
+
+2. `CPv2 direct`
+   - Use for managed operations, benchmark runs, and large-team orchestration.
+   - Start with `masc_unit_define`, `masc_operation_start`, `masc_dispatch_tick`.
+
+3. `Attached Team Session`
+   - Use when a managed operation needs a worker team.
+   - Start operation first, then call `masc_team_session_start(operation_id=...)`.
+
+4. `Supervisor path`
+   - Use `/mcp/operator` for `masc_operator_snapshot`, `masc_operator_digest`, `masc_operator_action`, `masc_operator_confirm`.
+
+## Workload templates
+
+- `coding_team` -> `coding_task` / default stage `decompose`
+- `research_team` -> `research_pipeline` / default stage `normalize`
+- `ops_governance_team` -> `research_pipeline` / default stage `audit`
+
+## Rules
+
+- Prefer `masc_operation_start` over ad-hoc swarm stories.
+- Prefer `masc_team_session_start(operation_id=...)` over standalone sessions when command-plane truth matters.
+- Treat `Lodge`, `TRPG`, and `RISC` as secondary surfaces unless the task explicitly needs them.
+- Use `/api/v1/command-plane/help` for the current golden paths and pitfalls.
+
+See `llms-full.txt` for the expanded contract.

--- a/test/dune
+++ b/test/dune
@@ -64,6 +64,11 @@
  (libraries masc_mcp alcotest eio eio_main yojson unix))
 
 (test
+ (name test_command_plane_help)
+ (modules test_command_plane_help)
+ (libraries masc_mcp alcotest yojson))
+
+(test
  (name test_dashboard_proof)
  (modules test_dashboard_proof)
  (libraries masc_mcp alcotest yojson unix))

--- a/test/test_command_plane_help.ml
+++ b/test/test_command_plane_help.ml
@@ -1,0 +1,51 @@
+open Masc_mcp
+
+let find_assoc key = function
+  | `Assoc fields -> List.assoc_opt key fields
+  | _ -> None
+
+let string_field key json =
+  match find_assoc key json with
+  | Some (`String value) -> Some value
+  | _ -> None
+
+let list_field key json =
+  match find_assoc key json with
+  | Some (`List rows) -> rows
+  | _ -> []
+
+let test_help_includes_attached_session_and_templates () =
+  let json = Server_command_plane_http.command_plane_help_http_json () in
+  let docs = list_field "docs" json in
+  let doc_paths =
+    docs |> List.filter_map (fun row -> string_field "path" row)
+  in
+  Alcotest.(check bool) "llms.txt listed" true
+    (List.mem "llms.txt" doc_paths);
+  Alcotest.(check bool) "llms-full.txt listed" true
+    (List.mem "llms-full.txt" doc_paths);
+  let golden_paths = list_field "golden_paths" json in
+  let path_ids =
+    golden_paths |> List.filter_map (fun row -> string_field "id" row)
+  in
+  Alcotest.(check bool) "attached team session path present" true
+    (List.mem "attached_team_session" path_ids);
+  let templates = list_field "workload_templates" json in
+  let template_ids =
+    templates |> List.filter_map (fun row -> string_field "id" row)
+  in
+  Alcotest.(check (list string)) "template ids"
+    [ "coding_team"; "research_team"; "ops_governance_team" ]
+    template_ids
+
+let () =
+  Alcotest.run "Command_plane_help"
+    [
+      ( "help",
+        [
+          Alcotest.test_case
+            "includes attached session and workload templates"
+            `Quick
+            test_help_includes_attached_session_and_templates;
+        ] );
+    ]

--- a/test/test_command_plane_v2.ml
+++ b/test/test_command_plane_v2.ml
@@ -131,6 +131,89 @@ let test_generic_alias_normalizes_to_coding_task_and_keeps_artifact_scope () =
         [ "lib/command_plane_v2.ml"; "test/test_command_plane_v2.ml" ]
         operation.artifact_scope)
 
+let test_workload_template_defaults_apply_expected_profile_and_stage () =
+  let base_dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base_dir)
+    (fun () ->
+      let owner = "owner-root-node" in
+      let alpha_lead = "alpha-lead-node" in
+      let alpha_two = "alpha-two-node" in
+      let config = Room.default_config base_dir in
+      setup_company_and_platoon config ~owner ~alpha_lead ~alpha_two;
+      let coding_op =
+        start_operation_exn config ~actor:"owner"
+          (`Assoc
+            [
+              ("assigned_unit_id", `String "company-main");
+              ("objective", `String "Run coding team");
+              ("workload_template", `String "coding_team");
+            ])
+      in
+      Alcotest.(check (option string)) "coding template stored"
+        (Some "coding_team") coding_op.workload_template;
+      Alcotest.(check string) "coding template workload" "coding_task"
+        (Command_plane_v2.operation_workload_profile coding_op);
+      Alcotest.(check (option string)) "coding template stage"
+        (Some "decompose") coding_op.stage;
+      let research_op =
+        start_operation_exn config ~actor:"owner"
+          (`Assoc
+            [
+              ("assigned_unit_id", `String "company-main");
+              ("objective", `String "Run research team");
+              ("workload_template", `String "research_team");
+            ])
+      in
+      Alcotest.(check (option string)) "research template stored"
+        (Some "research_team") research_op.workload_template;
+      Alcotest.(check string) "research template workload" "research_pipeline"
+        (Command_plane_v2.operation_workload_profile research_op);
+      Alcotest.(check (option string)) "research template stage"
+        (Some "normalize") research_op.stage;
+      let ops_op =
+        start_operation_exn config ~actor:"owner"
+          (`Assoc
+            [
+              ("assigned_unit_id", `String "company-main");
+              ("objective", `String "Run ops governance team");
+              ("workload_template", `String "ops_governance_team");
+            ])
+      in
+      Alcotest.(check (option string)) "ops template stored"
+        (Some "ops_governance_team") ops_op.workload_template;
+      Alcotest.(check string) "ops template workload" "research_pipeline"
+        (Command_plane_v2.operation_workload_profile ops_op);
+      Alcotest.(check (option string)) "ops template stage"
+        (Some "audit") ops_op.stage)
+
+let test_workload_template_rejects_mismatched_workload_profile () =
+  let base_dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base_dir)
+    (fun () ->
+      let owner = "owner-root-node" in
+      let alpha_lead = "alpha-lead-node" in
+      let alpha_two = "alpha-two-node" in
+      let config = Room.default_config base_dir in
+      setup_company_and_platoon config ~owner ~alpha_lead ~alpha_two;
+      match
+        Command_plane_v2.start_operation config ~actor:"owner"
+          (`Assoc
+            [
+              ("assigned_unit_id", `String "company-main");
+              ("objective", `String "Mismatch template/profile");
+              ("workload_template", `String "coding_team");
+              ("workload_profile", `String "research_pipeline");
+            ])
+      with
+      | Error message ->
+          Alcotest.(check string)
+            "template/profile mismatch"
+            "workload_template coding_team requires workload_profile=coding_task"
+            message
+      | Ok _ -> Alcotest.fail "expected workload_template mismatch to fail")
+
 let test_coding_verify_and_review_require_expected_dependencies () =
   let base_dir = temp_dir () in
   Fun.protect
@@ -1825,6 +1908,14 @@ let () =
             "generic alias normalizes to coding_task and keeps artifact scope"
             `Quick
             test_generic_alias_normalizes_to_coding_task_and_keeps_artifact_scope;
+          Alcotest.test_case
+            "workload template defaults apply expected profile and stage"
+            `Quick
+            test_workload_template_defaults_apply_expected_profile_and_stage;
+          Alcotest.test_case
+            "workload template rejects mismatched workload profile"
+            `Quick
+            test_workload_template_rejects_mismatched_workload_profile;
           Alcotest.test_case
             "coding verify and review require expected dependencies"
             `Quick

--- a/test/test_dashboard_mission.ml
+++ b/test/test_dashboard_mission.ml
@@ -76,6 +76,7 @@ let seed_room config session_id =
       goal = "Validate local64 swarm role coverage, runtime visibility, and operator census";
       created_by = "fixture-root";
       room_id = "default";
+      operation_id = None;
       status = Interrupted;
       duration_seconds = 2700;
       execution_scope = Observe_only;

--- a/test/test_dashboard_proof.ml
+++ b/test/test_dashboard_proof.ml
@@ -29,6 +29,7 @@ let sample_session now session_id =
     goal = "Prove multi-actor collaboration on MCP help cleanup";
     created_by = "supervisor";
     room_id = "default";
+    operation_id = None;
     status = Running;
     duration_seconds = 600;
     execution_scope = Limited_code_change;

--- a/test/test_tool_team_session.ml
+++ b/test/test_tool_team_session.ml
@@ -411,6 +411,58 @@ let test_start_attached_operation_session () =
     (match Yojson.Safe.Util.member "message" second_json with
     | `String message -> String.starts_with ~prefix:"operation already attached to team session" message
     | _ -> false);
+  let finalize_ok, finalize_body =
+    dispatch_exn ctx ~name:"masc_team_session_finalize"
+      ~args:
+        (`Assoc
+          [
+            ("session_id", `String session_id);
+            ("reason", `String "complete attached session");
+            ("generate_report", `Bool false);
+            ("generate_proof", `Bool false);
+            ("wait_timeout_sec", `Int 5);
+          ])
+  in
+  Alcotest.(check bool) "finalize ok" true finalize_ok;
+  let finalized_status =
+    finalize_body |> parse_json_exn |> result_field
+    |> Yojson.Safe.Util.member "status"
+    |> Yojson.Safe.Util.to_string
+  in
+  Alcotest.(check bool) "terminal status after finalize" true
+    (finalized_status = "completed" || finalized_status = "interrupted");
+  let operation_rows_after_finalize =
+    Command_plane_v2.list_operations_json ~operation_id:operation.operation_id
+      config
+    |> Yojson.Safe.Util.member "operations"
+    |> Yojson.Safe.Util.to_list
+  in
+  let detached_session_id =
+    match operation_rows_after_finalize with
+    | row :: _ ->
+        row |> Yojson.Safe.Util.member "operation"
+        |> Yojson.Safe.Util.member "detachment_session_id"
+        |> Yojson.Safe.Util.to_string_option
+    | [] -> None
+  in
+  Alcotest.(check (option string)) "operation detached after finalize" None
+    detached_session_id;
+  let reattach_ok, reattach_body =
+    dispatch_exn ctx ~name:"masc_team_session_start"
+      ~args:
+        (`Assoc
+          [
+            ("goal", `String "Reattach after finalize");
+            ("duration_seconds", `Int 90);
+            ("checkpoint_interval_sec", `Int 10);
+            ("min_agents", `Int 1);
+            ("operation_id", `String operation.operation_id);
+          ])
+  in
+  Alcotest.(check bool) "reattach succeeds after finalize" true reattach_ok;
+  let reattach_session_id = reattach_body |> parse_json_exn |> get_session_id in
+  Alcotest.(check bool) "reattach gives new session id" true
+    (not (String.equal reattach_session_id session_id));
   cleanup_dir base_dir
 
 let test_duration_reached_path () =

--- a/test/test_tool_team_session.ml
+++ b/test/test_tool_team_session.ml
@@ -82,6 +82,9 @@ let transition_task_ok config ~agent_name ~task_id ~action =
   | Ok _ -> ()
   | Error e -> failwith (Types.masc_error_to_string e)
 
+let unit_update_exn config ~actor args =
+  ignore (unwrap_ok (Command_plane_v2.unit_update_json config ~actor args))
+
 let wait_until_terminal ctx session_id =
   let rec loop attempts =
     if attempts <= 0 then
@@ -104,27 +107,33 @@ let wait_until_terminal ctx session_id =
 
 let rec start_session_exn ctx ~goal =
   start_session_custom_exn ctx ~goal ~min_agents:1 ~agents:[]
+    ~operation_id:None
 
-and start_session_custom_exn ctx ~goal ~min_agents ~agents =
+and start_session_custom_exn ctx ~goal ~min_agents ~agents ~operation_id =
   let agent_json = `List (List.map (fun a -> `String a) agents) in
+  let args =
+    [
+      ("goal", `String goal);
+      ("duration_seconds", `Int 90);
+      ("checkpoint_interval_sec", `Int 10);
+      ("min_agents", `Int min_agents);
+      ("orchestration_mode", `String "assist");
+      ("communication_mode", `String "hybrid");
+      ("model_cascade", `List [ `String "glm:glm-5" ]);
+      ("fallback_policy", `String "cascade_then_task");
+      ("instruction_profile", `String "strict");
+      ("alert_channel", `String "both");
+      ("report_formats", `List [ `String "markdown"; `String "json" ]);
+      ("agents", agent_json);
+    ]
+    @
+    match operation_id with
+    | Some value -> [ ("operation_id", `String value) ]
+    | None -> []
+  in
   let start_ok, start_body =
     dispatch_exn ctx ~name:"masc_team_session_start"
-      ~args:
-        (`Assoc
-          [
-            ("goal", `String goal);
-            ("duration_seconds", `Int 90);
-            ("checkpoint_interval_sec", `Int 10);
-            ("min_agents", `Int min_agents);
-            ("orchestration_mode", `String "assist");
-            ("communication_mode", `String "hybrid");
-            ("model_cascade", `List [ `String "glm:glm-5" ]);
-            ("fallback_policy", `String "cascade_then_task");
-            ("instruction_profile", `String "strict");
-            ("alert_channel", `String "both");
-            ("report_formats", `List [ `String "markdown"; `String "json" ]);
-            ("agents", agent_json);
-          ])
+      ~args:(`Assoc args)
   in
   Alcotest.(check bool) "start ok" true start_ok;
   parse_json_exn start_body
@@ -140,6 +149,7 @@ let make_manual_session config ~goal ~created_by ~agent_names ~min_agents
       goal;
       created_by;
       room_id = "default";
+      operation_id = None;
       status = Team_session_types.Running;
       duration_seconds = int_of_float (max 60.0 (planned_end_at -. started_at));
       execution_scope = Team_session_types.Limited_code_change;
@@ -276,6 +286,133 @@ let test_start_status_report_stop () =
 
   cleanup_dir base_dir
 
+let test_start_attached_operation_session () =
+  Eio_main.run @@ fun env ->
+  Eio.Switch.run @@ fun sw ->
+  let base_dir = temp_dir () in
+  let config = Room.default_config base_dir in
+  ignore (Room.init config ~agent_name:(Some "tester"));
+  ignore (Room.join config ~agent_name:"tester" ~capabilities:[] ());
+  ignore (Room.join config ~agent_name:"ally1" ~capabilities:[] ());
+  ignore (Room.join config ~agent_name:"ally2" ~capabilities:[] ());
+  unit_update_exn config ~actor:"tester"
+    (`Assoc
+      [
+        ("unit_id", `String "company-main");
+        ("kind", `String "company");
+        ("label", `String "Main Company");
+        ("leader_id", `String "tester");
+        ("roster", `List [ `String "tester"; `String "ally1"; `String "ally2" ]);
+      ]);
+  unit_update_exn config ~actor:"tester"
+    (`Assoc
+      [
+        ("unit_id", `String "platoon-main");
+        ("kind", `String "platoon");
+        ("label", `String "Main Platoon");
+        ("parent_unit_id", `String "company-main");
+        ("leader_id", `String "ally1");
+        ("roster", `List [ `String "ally1"; `String "ally2" ]);
+      ]);
+  unit_update_exn config ~actor:"tester"
+    (`Assoc
+      [
+        ("unit_id", `String "squad-main");
+        ("kind", `String "squad");
+        ("label", `String "Main Squad");
+        ("parent_unit_id", `String "platoon-main");
+        ("leader_id", `String "tester");
+        ("roster", `List [ `String "tester" ]);
+      ]);
+  let operation : Command_plane_v2.operation_record =
+    {
+      operation_id = "op-attached-session";
+      objective = "Run attached coding team";
+      intent_id = None;
+      assigned_unit_id = "squad-main";
+      autonomy_level = "L4_Autonomous";
+      policy_class = "guarded";
+      budget_class = "standard";
+      workload_template = Some "coding_team";
+      workload_profile = "coding_task";
+      stage = Some "decompose";
+      artifact_scope = [];
+      depends_on_operation_ids = [];
+      search_strategy = "best_first_v1";
+      detachment_session_id = None;
+      trace_id = "trace-attached-session";
+      checkpoint_ref = None;
+      active_goal_ids = [];
+      note = None;
+      created_by = "tester";
+      source = "managed";
+      status = Command_plane_v2.Active;
+      chain = None;
+      created_at = Types.now_iso ();
+      updated_at = Types.now_iso ();
+    }
+  in
+  Command_plane_v2.write_operations config [ operation ];
+  let ctx : _ Tool_team_session.context =
+    { config; agent_name = "tester"; sw; clock = Eio.Stdenv.clock env; proc_mgr = None }
+  in
+  let start_json =
+    start_session_custom_exn ctx ~goal:"Attach managed session" ~min_agents:1
+      ~agents:[ "tester" ] ~operation_id:(Some operation.operation_id)
+  in
+  let session_id = get_session_id start_json in
+  let start_result = result_field start_json in
+  Alcotest.(check string) "attached operation id in start result"
+    operation.operation_id
+    (start_result |> Yojson.Safe.Util.member "operation_id"
+    |> Yojson.Safe.Util.to_string);
+  let status_ok, status_body =
+    dispatch_exn ctx ~name:"masc_team_session_status"
+      ~args:(`Assoc [ ("session_id", `String session_id) ])
+  in
+  Alcotest.(check bool) "status ok" true status_ok;
+  let status_json = parse_json_exn status_body |> result_field in
+  Alcotest.(check string) "attached operation id in status"
+    operation.operation_id
+    (status_json |> Yojson.Safe.Util.member "command_plane"
+    |> Yojson.Safe.Util.member "operation_id"
+    |> Yojson.Safe.Util.to_string);
+  let operation_rows =
+    Command_plane_v2.list_operations_json ~operation_id:operation.operation_id
+      config
+    |> Yojson.Safe.Util.member "operations"
+    |> Yojson.Safe.Util.to_list
+  in
+  let attached_session_id =
+    match operation_rows with
+    | row :: _ ->
+        row |> Yojson.Safe.Util.member "operation"
+        |> Yojson.Safe.Util.member "detachment_session_id"
+        |> Yojson.Safe.Util.to_string_option
+    | [] -> None
+  in
+  Alcotest.(check (option string)) "operation linked to session"
+    (Some session_id) attached_session_id;
+  let second_ok, second_body =
+    dispatch_exn ctx ~name:"masc_team_session_start"
+      ~args:
+        (`Assoc
+          [
+            ("goal", `String "Duplicate attach should fail");
+            ("duration_seconds", `Int 90);
+            ("checkpoint_interval_sec", `Int 10);
+            ("min_agents", `Int 1);
+            ("operation_id", `String operation.operation_id);
+          ])
+  in
+  Alcotest.(check bool) "second attach rejected" false second_ok;
+  let second_json = parse_json_exn second_body in
+  Alcotest.(check bool) "second attach error mentions existing session" true
+    (match Yojson.Safe.Util.member "message" second_json with
+    | `String message -> String.starts_with ~prefix:"operation already attached to team session" message
+    | _ -> false);
+  cleanup_dir base_dir
+
 let test_duration_reached_path () =
   Eio_main.run @@ fun env ->
   Eio.Switch.run @@ fun sw ->
@@ -317,6 +454,7 @@ let test_recover_elapsed_session () =
       goal = "recover elapsed session";
       created_by = "tester";
       room_id = "default";
+      operation_id = None;
       status = Team_session_types.Running;
       duration_seconds = 60;
       execution_scope = Team_session_types.Observe_only;
@@ -395,6 +533,7 @@ let test_recover_orphan_session () =
       goal = "test orphan cleanup";
       created_by = "tester";
       room_id = "default";
+      operation_id = None;
       status = Team_session_types.Running;
       duration_seconds = 60;
       execution_scope = Team_session_types.Observe_only;
@@ -1059,7 +1198,7 @@ let test_prove_requires_multi_actor_turn_coverage () =
   (* Case 1: single-actor turns should be insufficient when min_agents=3 *)
   let session_single =
     start_session_custom_exn ctx ~goal:"prove-single-actor-insufficient"
-      ~min_agents:3 ~agents:participants
+      ~min_agents:3 ~agents:participants ~operation_id:None
     |> get_session_id
   in
   let single_turn_ok, _ =
@@ -1105,7 +1244,7 @@ let test_prove_requires_multi_actor_turn_coverage () =
   (* Case 2: multi-actor turns satisfy min_agents coverage *)
   let session_multi =
     start_session_custom_exn ctx ~goal:"prove-multi-actor-pass" ~min_agents:3
-      ~agents:participants
+      ~agents:participants ~operation_id:None
     |> get_session_id
   in
   let record_ok actor msg =
@@ -2413,6 +2552,8 @@ let () =
         [
           Alcotest.test_case "start-status-report-stop" `Quick
             test_start_status_report_stop;
+          Alcotest.test_case "start-attached-operation-session" `Quick
+            test_start_attached_operation_session;
           Alcotest.test_case "proof-exposes-spawn-selection-rationale" `Quick
             test_proof_exposes_spawn_selection_rationale;
           Alcotest.test_case "bootstrap-grace-suppresses-min-agents-violation"

--- a/test/test_tools_coverage.ml
+++ b/test/test_tools_coverage.ml
@@ -787,6 +787,28 @@ let test_masc_detachment_status_schema () =
           Alcotest.(check bool) "has detachment_id" true (List.mem_assoc "detachment_id" props)
       | None -> Alcotest.fail "masc_detachment_status missing properties"
 
+let test_masc_operation_start_schema () =
+  match find_tool "masc_operation_start" with
+  | None -> Alcotest.fail "masc_operation_start not found"
+  | Some schema ->
+      match get_json_assoc "properties" schema.input_schema with
+      | Some props ->
+          Alcotest.(check bool) "has workload_template" true
+            (List.mem_assoc "workload_template" props);
+          Alcotest.(check bool) "has workload_profile" true
+            (List.mem_assoc "workload_profile" props)
+      | None -> Alcotest.fail "masc_operation_start missing properties"
+
+let test_masc_team_session_start_schema () =
+  match find_tool "masc_team_session_start" with
+  | None -> Alcotest.fail "masc_team_session_start not found"
+  | Some schema ->
+      match get_json_assoc "properties" schema.input_schema with
+      | Some props ->
+          Alcotest.(check bool) "has operation_id" true
+            (List.mem_assoc "operation_id" props)
+      | None -> Alcotest.fail "masc_team_session_start missing properties"
+
 (* ============================================================ *)
 (* 17. Walph Tool Tests                                          *)
 (* ============================================================ *)
@@ -1038,6 +1060,8 @@ let () =
         test_legacy_swarm_tools_removed;
     ];
     "command_plane_tools", [
+      Alcotest.test_case "operation_start" `Quick test_masc_operation_start_schema;
+      Alcotest.test_case "team_session_start" `Quick test_masc_team_session_start_schema;
       Alcotest.test_case "dispatch_tick" `Quick test_masc_dispatch_tick_schema;
       Alcotest.test_case "detachment_list" `Quick test_masc_detachment_list_schema;
       Alcotest.test_case "detachment_status" `Quick test_masc_detachment_status_schema;


### PR DESCRIPTION
## Summary
- add workload_template to CPv2 operations and normalize template defaults
- allow team sessions to attach to managed operations via operation_id
- extend command-plane help and add llms.txt / llms-full.txt as AI front door docs

## Validation
- dune build --root . @check
- dune exec --root . ./test/test_command_plane_v2.exe
- dune exec --root . ./test/test_tools_coverage.exe
- dune exec --root . ./test/test_tool_team_session.exe -- test team_session 0,1

## Notes
- this is a narrow-waist foundation slice, not the full universal orchestrator end-state
- residual follow-up: clarify attached-session lifecycle semantics beyond initial attach path
