### PR TITLE
fix(execution): use passed actor param in dashboard_execution

### DIFF
--- a/lib/dashboard_execution.ml
+++ b/lib/dashboard_execution.ml
@@ -1523,7 +1523,7 @@ let build_continuity_briefs ~(now_ts : float) keepers session_contexts :
          else Float.compare right.last_signal_ts left.last_signal_ts)
 
 let json ?actor ?fixture ~config ~sw ~clock ~proc_mgr () =
-  ignore actor;
+  let effective_actor = Option.value ~default:"dashboard" actor in
   match dashboard_fixture_name ?fixture () with
   | Some "execution_smoke" -> execution_smoke_fixture_json ()
   | _ ->
@@ -1533,7 +1533,7 @@ let json ?actor ?fixture ~config ~sw ~clock ~proc_mgr () =
       let ctx : _ Operator_control.context =
         {
           config;
-          agent_name = "dashboard";
+          agent_name = effective_actor;
           sw;
           clock;
           proc_mgr;
@@ -1542,7 +1542,7 @@ let json ?actor ?fixture ~config ~sw ~clock ~proc_mgr () =
       in
       let snapshot_json =
         Operator_control.snapshot_json
-          ~actor:"dashboard"
+          ~actor:effective_actor
           ~view:"summary"
           ~include_messages:false
           ~include_sessions:true
@@ -1550,7 +1550,7 @@ let json ?actor ?fixture ~config ~sw ~clock ~proc_mgr () =
           ctx
       in
       let digest_json =
-        match Operator_control.digest_json ~actor:"dashboard" ctx with
+        match Operator_control.digest_json ~actor:effective_actor ctx with
         | Ok json -> json
         | Error message ->
             `Assoc


### PR DESCRIPTION
## Summary
- GLM-5 cross-model review finding from PR #757
- `?actor` parameter was accepted but `ignore`d, with `"dashboard"` hardcoded in all `Operator_control` call sites
- Now uses `Option.value ~default:"dashboard" actor` for proper propagation

## Context
PR #757 introduced `dashboard_execution.ml` with a `json` function accepting `?actor`. The parameter was intended to allow caller-specified actor identity but was never wired through. This follow-up fixes the dead parameter.

## Test plan
- [ ] CI Build and Test pass
- [ ] Contract Harness pass
- [ ] Default behavior unchanged (actor defaults to `"dashboard"` when not provided)

🤖 Generated with [Claude Code](https://claude.com/claude-code)