### PR TITLE
refactor(cascade): migrate distributed-pattern modules to Lodge_cascade.call

### DIFF
--- a/lib/capability_match.ml
+++ b/lib/capability_match.ml
@@ -184,12 +184,6 @@ let agent_profile_of_identity (id : Agent_identity.t) : agent_profile =
 
 (* ---------- LLM Scoring ---------- *)
 
-(** Model specs for capability match LLM scoring.
-    Delegates to Lodge_cascade for hot-reloadable config and built-in defaults.
-    Override via config/llm_cascade.json key "capability_match_models". *)
-let match_model_specs () =
-  Lodge_cascade.get_cascade ~cascade_name:"capability_match" ()
-
 (** Build the LLM prompt for agent-task compatibility scoring. *)
 let build_scoring_prompt (agent : agent_profile) (task : task_profile) : string =
   let traits_str = match agent.traits with
@@ -260,18 +254,14 @@ let score_with_llm (agent : agent_profile) (task : task_profile)
     : (float, string) result =
   let prompt = build_scoring_prompt agent task in
   match
-    Llm_client.run_prompt_cascade
-      ~temperature:0.1
-      ~timeout_sec:15
-      ~accept:llm_score_is_valid
-      ~model_specs:(match_model_specs ())
-      ~max_tokens:20
-      ~prompt ()
+    Lodge_cascade.call ~cascade_name:"capability_match" ~prompt
+      ~temperature:0.1 ~timeout_sec:15 ~max_tokens:20
+      ~accept:llm_score_is_valid ()
   with
-  | Ok resp -> (
-      match parse_llm_score resp.content with
+  | Ok r -> (
+      match parse_llm_score r.response with
       | Some f -> Ok f
-      | None -> Error (Printf.sprintf "unparseable LLM response: %s" resp.content))
+      | None -> Error (Printf.sprintf "unparseable LLM response: %s" r.response))
   | Error err -> Error err
 
 (* ---------- Keyword Scoring ---------- *)

--- a/lib/context_router.ml
+++ b/lib/context_router.ml
@@ -56,12 +56,6 @@ let get_router_mode () : router_mode =
   | Some "hybrid" -> Hybrid_mode
   | _ -> Heuristic
 
-(** Model specs for context router LLM classification.
-    Delegates to Lodge_cascade for hot-reloadable config and built-in defaults.
-    Override via config/llm_cascade.json key "context_router_models". *)
-let router_model_specs () =
-  Lodge_cascade.get_cascade ~cascade_name:"context_router" ()
-
 (* ---------- Intent Classification (Heuristic) ---------- *)
 
 (** Conversational patterns — no retrieval needed *)
@@ -200,16 +194,12 @@ let intent_response_is_valid (resp : Llm_client.completion_response) : bool =
 let classify_intent_llm (query : string) : query_intent * float =
   let prompt = build_intent_prompt query in
   match
-    Llm_client.run_prompt_cascade
-      ~temperature:0.1
-      ~timeout_sec:10
-      ~accept:intent_response_is_valid
-      ~model_specs:(router_model_specs ())
-      ~max_tokens:20
-      ~prompt ()
+    Lodge_cascade.call ~cascade_name:"context_router" ~prompt
+      ~temperature:0.1 ~timeout_sec:10 ~max_tokens:20
+      ~accept:intent_response_is_valid ()
   with
-  | Ok resp -> (
-      match parse_intent_response resp.content with
+  | Ok r -> (
+      match parse_intent_response r.response with
       | Some result -> result
       | None -> (Coordination, 0.3))  (* unparseable → low-confidence fallback *)
   | Error _err -> (Coordination, 0.3)  (* LLM error → low-confidence fallback *)
@@ -218,16 +208,12 @@ let classify_intent_llm (query : string) : query_intent * float =
 let classify_intent_hybrid (query : string) : query_intent * float =
   let prompt = build_intent_prompt query in
   match
-    Llm_client.run_prompt_cascade
-      ~temperature:0.1
-      ~timeout_sec:10
-      ~accept:intent_response_is_valid
-      ~model_specs:(router_model_specs ())
-      ~max_tokens:20
-      ~prompt ()
+    Lodge_cascade.call ~cascade_name:"context_router" ~prompt
+      ~temperature:0.1 ~timeout_sec:10 ~max_tokens:20
+      ~accept:intent_response_is_valid ()
   with
-  | Ok resp -> (
-      match parse_intent_response resp.content with
+  | Ok r -> (
+      match parse_intent_response r.response with
       | Some result -> result
       | None -> classify_intent_heuristic query)
   | Error _err -> classify_intent_heuristic query

--- a/lib/lodge_tom.ml
+++ b/lib/lodge_tom.ml
@@ -64,12 +64,6 @@ let predict_from_signature
 
 (* ── LLM SimToM Prediction ─────────────────────────────────────────── *)
 
-(** Model specs for ToM LLM classification.
-    Delegates to Lodge_cascade for hot-reloadable config and built-in defaults.
-    Override via config/llm_cascade.json key "tom_models". *)
-let tom_model_specs () =
-  Lodge_cascade.get_cascade ~cascade_name:"tom" ()
-
 (** Format agent signature into a concise behavioral profile string. *)
 let format_agent_profile (sig_ : Lodge_reaction.agent_signature) : string =
   let top_topics =
@@ -187,15 +181,11 @@ let predict_with_llm (sig_ : Lodge_reaction.agent_signature)
     : (Lodge_reaction.reaction_type * float * string, string) result =
   let prompt = build_tom_prompt sig_ post_content in
   match
-    Llm_client.run_prompt_cascade
-      ~temperature:0.2
-      ~timeout_sec:15
-      ~accept:tom_response_is_valid
-      ~model_specs:(tom_model_specs ())
-      ~max_tokens:200
-      ~prompt ()
+    Lodge_cascade.call ~cascade_name:"tom" ~prompt
+      ~temperature:0.2 ~timeout_sec:15 ~max_tokens:200
+      ~accept:tom_response_is_valid ()
   with
-  | Ok resp -> parse_tom_response resp.content
+  | Ok r -> parse_tom_response r.response
   | Error err -> Error err
 
 (** {1 Core Functions} *)

--- a/lib/post_verifier_llm.ml
+++ b/lib/post_verifier_llm.ml
@@ -21,12 +21,6 @@ let get_verifier_mode () =
   | Some "hybrid" -> Hybrid
   | _ -> Heuristic
 
-(** Model specs for the verifier LLM cascade.
-    Delegates to Lodge_cascade for hot-reloadable config and built-in defaults.
-    Override via config/llm_cascade.json key "verifier_models". *)
-let verifier_model_specs () =
-  Lodge_cascade.get_cascade ~cascade_name:"verifier" ()
-
 (** G-Eval rubric prompt for post quality assessment. *)
 let build_geval_prompt ~content : string =
   Printf.sprintf
@@ -121,17 +115,13 @@ let geval_response_is_valid (resp : Llm_client.completion_response) : bool =
 let verify_llm ~content : (verification_result, string) result =
   let prompt = build_geval_prompt ~content in
   match
-    Llm_client.run_prompt_cascade
-      ~temperature:0.2
-      ~timeout_sec:15
-      ~accept:geval_response_is_valid
-      ~model_specs:(verifier_model_specs ())
-      ~max_tokens:150
-      ~prompt ()
+    Lodge_cascade.call ~cascade_name:"verifier" ~prompt
+      ~temperature:0.2 ~timeout_sec:15 ~max_tokens:150
+      ~accept:geval_response_is_valid ()
   with
   | Error err -> Error err
-  | Ok resp -> (
-      match parse_geval_response resp.content with
+  | Ok r -> (
+      match parse_geval_response r.response with
       | Error err -> Error err
       | Ok (r, q, s, _reasoning) ->
           let relevance = score_to_verdict ~dim_name:"relevance" r in

--- a/lib/room_walph_eio.ml
+++ b/lib/room_walph_eio.ml
@@ -264,12 +264,6 @@ let get_chain_id_for_preset = function
   | "figma" -> Some "walph-figma"
   | _ -> None
 
-(** Model specs for Walph loop LLM dispatch.
-    Delegates to Lodge_cascade for hot-reloadable config and built-in defaults.
-    Override via config/llm_cascade.json key "walph_models". *)
-let walph_available_model_specs () =
-  Lodge_cascade.get_cascade ~cascade_name:"walph" ()
-
 let walph_response_is_valid (resp : Llm_client.completion_response) =
   let content = String.trim resp.content in
   let lower = String.lowercase_ascii content in
@@ -281,12 +275,10 @@ let walph_response_is_valid (resp : Llm_client.completion_response) =
 
 let default_llm_dispatch ~tool_name:_ ~model:_ ~prompt ~timeout_sec ~max_chars () =
   match
-    Llm_client.run_prompt_cascade ~timeout_sec
-      ~accept:walph_response_is_valid
-      ~model_specs:(walph_available_model_specs ()) ~max_tokens:max_chars
-      ~prompt ()
+    Lodge_cascade.call ~cascade_name:"walph" ~prompt ~timeout_sec
+      ~max_tokens:max_chars ~accept:walph_response_is_valid ()
   with
-  | Ok resp -> resp.content
+  | Ok r -> r.response
   | Error err -> failwith err
 
 (** {1 Main Loop} *)

--- a/lib/trpg_dm_intent.ml
+++ b/lib/trpg_dm_intent.ml
@@ -201,12 +201,6 @@ let extract_keyword (text : string) : dm_intent =
 
 (* ── LLM Classification ────────────────────────────────────────────── *)
 
-(** Model specs for DM intent LLM classification.
-    Delegates to Lodge_cascade for hot-reloadable config and built-in defaults.
-    Override via config/llm_cascade.json key "trpg_intent_models". *)
-let intent_model_specs () =
-  Lodge_cascade.get_cascade ~cascade_name:"trpg_intent" ()
-
 let category_of_string (s : string) : intent_category =
   match String.lowercase_ascii (String.trim s) with
   | "combat_setup" | "combat" -> Combat_setup
@@ -308,15 +302,11 @@ let llm_response_is_valid (resp : Llm_client.completion_response) : bool =
 let extract_with_llm (text : string) : (dm_intent, string) result =
   let prompt = build_classification_prompt text in
   match
-    Llm_client.run_prompt_cascade
-      ~temperature:0.1
-      ~timeout_sec:15
-      ~accept:llm_response_is_valid
-      ~model_specs:(intent_model_specs ())
-      ~max_tokens:200
-      ~prompt ()
+    Lodge_cascade.call ~cascade_name:"trpg_intent" ~prompt
+      ~temperature:0.1 ~timeout_sec:15 ~max_tokens:200
+      ~accept:llm_response_is_valid ()
   with
-  | Ok resp -> parse_llm_intent resp.content
+  | Ok r -> parse_llm_intent r.response
   | Error err -> Error err
 
 (* ── Public API ─────────────────────────────────────────────────────── *)

--- a/test/test_walph_eio.ml
+++ b/test/test_walph_eio.ml
@@ -313,13 +313,13 @@ let test_eio_error_cutoff () =
     (status |> member "last_stop_reason" |> to_string)
 
 let test_eio_default_dispatch_uses_shared_cascade () =
-  check bool "uses Llm_client.run_prompt_cascade" true
-    (file_contains_pattern "lib/room_walph_eio.ml" "Llm_client.run_prompt_cascade");
+  check bool "uses Lodge_cascade.call" true
+    (file_contains_pattern "lib/room_walph_eio.ml"
+       {|Lodge_cascade.call ~cascade_name:"walph"|});
   check bool "legacy direct dispatch removed" false
     (file_contains_pattern "lib/room_walph_eio.ml" "Llm_direct.dispatch");
-  check bool "shared pool uses centralized defaults" true
-    (file_contains_pattern "lib/room_walph_eio.ml"
-       {|Lodge_cascade.get_cascade ~cascade_name:"walph" ()|})
+  check bool "no direct run_prompt_cascade" false
+    (file_contains_pattern "lib/room_walph_eio.ml" "Llm_client.run_prompt_cascade")
 
 (* ============================================
    Test Registration


### PR DESCRIPTION
## Summary

Phase 3 of the unified LLM cascade adapter plan ([Phase 1: #746](https://github.com/jeong-sik/masc-mcp/pull/746), [Phase 2: #766](https://github.com/jeong-sik/masc-mcp/pull/766)).

- Migrate 7 call sites in 6 modules from per-module `*_model_specs()` + `run_prompt_cascade` to centralized `Lodge_cascade.call`
- Remove 6 dead helper functions: `router_model_specs`, `match_model_specs`, `tom_model_specs`, `intent_model_specs`, `verifier_model_specs`, `walph_available_model_specs`
- Net: 32 insertions, 94 deletions (-62 lines)

### Migrated modules

| Module | cascade_name | temp | timeout | max_tokens |
|--------|-------------|------|---------|------------|
| `context_router.ml` | `context_router` | 0.1 | 10s | 20 |
| `capability_match.ml` | `capability_match` | 0.1 | 15s | 20 |
| `lodge_tom.ml` | `tom` | 0.2 | 15s | 200 |
| `trpg_dm_intent.ml` | `trpg_intent` | 0.1 | 15s | 200 |
| `post_verifier_llm.ml` | `verifier` | 0.2 | 15s | 150 |
| `room_walph_eio.ml` | `walph` | 0.3 | param | param |

### Excluded (by plan)
- `auto_responder.ml` — Phase 3.5 (agent_type routing)
- `spawn_eio.ml` — separate refactoring target

## Test plan
- [x] `dune build --root .` compiles cleanly
- [x] All 244 test suites pass (`make test`)
- [ ] CI green
- [ ] External model review (GLM-5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)