### PR TITLE
feat(voice): expose public voice tools

### DIFF
--- a/lib/auth.ml
+++ b/lib/auth.ml
@@ -235,7 +235,8 @@ let permission_for_tool = function
   | "masc_policy_status" | "masc_dispatch_plan" | "masc_dispatch_route"
   | "masc_observe_topology" | "masc_observe_operations"
   | "masc_observe_capacity" | "masc_observe_alerts"
-  | "masc_observe_traces" ->
+  | "masc_observe_traces"
+  | "masc_voice_sessions" | "masc_voice_agent" | "masc_voice_transcript" ->
       Some CanReadState
   | "masc_add_task" -> Some CanAddTask
   | "masc_claim" | "masc_claim_next" -> Some CanClaimTask
@@ -245,6 +246,9 @@ let permission_for_tool = function
   | "masc_agent_update" | "masc_operator_action"
   | "masc_keeper_create_from_persona"
   | "masc_keeper_model_set"
+  | "masc_voice_speak" | "masc_voice_session_start"
+  | "masc_voice_session_end" | "masc_voice_conference_start"
+  | "masc_voice_conference_end"
   | "masc_operator_confirm" | "masc_unit_define"
   | "masc_unit_update" | "masc_unit_reparent"
   | "masc_unit_reassign" | "masc_operation_start"

--- a/lib/config.ml
+++ b/lib/config.ml
@@ -97,6 +97,7 @@ let raw_all_tool_schemas : Types.tool_schema list =
     @ Tool_command_plane.schemas
     @ Tool_goals.schemas
     @ Tool_team_session.schemas
+    @ Tool_voice.schemas
     @ Tool_protocol_game_view.schemas
     @ Tool_experiment.schemas
     @ Tool_trpg.schemas

--- a/lib/dune
+++ b/lib/dune
@@ -259,6 +259,7 @@
    tool_experiment
    tool_suspend
    tool_notifications
+   tool_voice
    debate
    social
    tool_social

--- a/lib/masc_mcp.ml
+++ b/lib/masc_mcp.ml
@@ -254,6 +254,7 @@ module Tool_command_plane = Tool_command_plane
 module Tool_lodge = Tool_lodge
 module Tool_mdal = Tool_mdal
 module Tool_notifications = Tool_notifications
+module Tool_voice = Tool_voice
 
 (* Lodge subsystem *)
 module Lodge_heartbeat = Lodge_heartbeat

--- a/lib/mcp_server_eio.ml
+++ b/lib/mcp_server_eio.ml
@@ -1211,6 +1211,9 @@ let execute_tool_eio ~sw ~clock ?mcp_session_id ?auth_token state ~name ~argumen
   let simple_ctx_control : Tool_control.context = { config; agent_name } in
   let simple_ctx_misc : Tool_misc.context = { config; agent_name } in
   let simple_ctx_llama : Tool_llama.context = { config; agent_name } in
+  let simple_ctx_voice : _ Tool_voice.context =
+    { agent_name; sw; clock; net = state.Mcp_server.net }
+  in
   let simple_ctx_suspend : Tool_suspend.context = { config; caller_agent = Some agent_name } in
   let simple_ctx_library : Tool_library.context = { agent_name } in
   let simple_ctx_mdal : Tool_mdal.context = {
@@ -1334,6 +1337,9 @@ let execute_tool_eio ~sw ~clock ?mcp_session_id ?auth_token state ~name ~argumen
   | Some result -> result
   | None ->
   match Tool_team_session.dispatch simple_ctx_team_session ~name ~args:arguments with
+  | Some result -> result
+  | None ->
+  match Tool_voice.dispatch simple_ctx_voice ~name ~args:arguments with
   | Some result -> result
   | None ->
   match Tool_cache.dispatch simple_ctx_cache ~name ~args:arguments with

--- a/lib/mode.ml
+++ b/lib/mode.ml
@@ -322,6 +322,10 @@ let tool_category tool_name =
   | "masc_keeper_up" | "masc_keeper_down" | "masc_keeper_status"
   | "masc_keeper_list" | "masc_keeper_msg" | "masc_keeper_eval"
   | "masc_keeper_model_set"
+  | "masc_voice_speak" | "masc_voice_session_start"
+  | "masc_voice_session_end" | "masc_voice_sessions"
+  | "masc_voice_agent" | "masc_voice_transcript"
+  | "masc_voice_conference_start" | "masc_voice_conference_end"
   | "masc_keeper_goals" | "masc_keeper_trajectory"
   | "masc_keeper_autonomy"
   (* Perpetual *)

--- a/lib/tool_voice.ml
+++ b/lib/tool_voice.ml
@@ -10,6 +10,8 @@ type 'a context = {
 
 type result = bool * string
 
+let schema_properties entries = `Assoc entries
+
 let json_string_of_result = function
   | Ok json -> (true, Yojson.Safe.to_string json)
   | Error message ->
@@ -17,14 +19,14 @@ let json_string_of_result = function
         Yojson.Safe.to_string
           (`Assoc [ ("status", `String "error"); ("message", `String message) ]) )
 
-let schema_properties entries = `Assoc entries
+let string_assoc key value = (key, `String value)
 
 let schemas : tool_schema list =
   [
     {
       name = "masc_voice_speak";
       description =
-        "Send text to the voice bridge for an agent. Uses the agent's configured voice and may fall back to text_fallback when voice is unavailable.";
+        "Send text to the voice bridge for an agent. Uses the configured voice and may fall back to text_fallback when voice is unavailable.";
       input_schema =
         `Assoc
           [
@@ -91,7 +93,7 @@ let schemas : tool_schema list =
     };
     {
       name = "masc_voice_transcript";
-      description = "Get the current voice transcript from the voice bridge.";
+      description = "Get the current transcript payload from the voice bridge.";
       input_schema =
         `Assoc [ ("type", `String "object"); ("properties", `Assoc []) ];
     };
@@ -119,7 +121,8 @@ let schemas : tool_schema list =
     };
     {
       name = "masc_voice_conference_end";
-      description = "End a multi-agent voice conference for the given agents.";
+      description =
+        "End a multi-agent voice conference for the given agents.";
       input_schema =
         `Assoc
           [
@@ -144,15 +147,17 @@ let require_net_or_error (ctx : 'a context) =
   | Some net -> Ok net
   | None -> Error "voice bridge requires net (server_state.net is None)"
 
+let message_preview message =
+  String.sub message 0 (min 50 (String.length message))
+
 let text_fallback_json ~agent_id ~message =
   let voice = Voice_bridge.get_voice_for_agent agent_id in
   `Assoc
     [
       ("status", `String "text_fallback");
-      ("agent_id", `String agent_id);
-      ("voice", `String voice);
-      ( "message_preview",
-        `String (String.sub message 0 (min 50 (String.length message))) );
+      string_assoc "agent_id" agent_id;
+      string_assoc "voice" voice;
+      string_assoc "message_preview" (message_preview message);
     ]
 
 let handle_voice_speak (ctx : 'a context) args : result =
@@ -160,7 +165,9 @@ let handle_voice_speak (ctx : 'a context) args : result =
   let message = get_string args "message" "" in
   let provider = get_string_opt args "provider" |> Option.map String.trim in
   let provider =
-    match provider with Some p when p <> "" -> Some p | _ -> None
+    match provider with
+    | Some p when p <> "" -> Some p
+    | _ -> None
   in
   let priority = max 1 (get_int args "priority" 1) in
   if agent_id = "" || String.trim message = "" then
@@ -177,7 +184,9 @@ let handle_voice_session_start (ctx : 'a context) args : result =
   let agent_id = get_string args "agent_id" "" |> String.trim in
   let session_name = get_string_opt args "session_name" |> Option.map String.trim in
   let session_name =
-    match session_name with Some s when s <> "" -> Some s | _ -> None
+    match session_name with
+    | Some name when name <> "" -> Some name
+    | _ -> None
   in
   if agent_id = "" then
     (false, "Error: agent_id is required")
@@ -240,10 +249,16 @@ let handle_voice_transcript (ctx : 'a context) _args : result =
           (`Assoc [ ("transcript", `List []); ("turn_count", `Int 0) ]) )
 
 let handle_voice_conference_start (ctx : 'a context) args : result =
-  let agent_ids = get_string_list args "agent_ids" |> List.map String.trim |> List.filter (( <> ) "") in
+  let agent_ids =
+    get_string_list args "agent_ids"
+    |> List.map String.trim
+    |> List.filter (fun item -> item <> "")
+  in
   let conference_name = get_string_opt args "conference_name" |> Option.map String.trim in
   let conference_name =
-    match conference_name with Some s when s <> "" -> Some s | _ -> None
+    match conference_name with
+    | Some name when name <> "" -> Some name
+    | _ -> None
   in
   if agent_ids = [] then
     (false, "Error: agent_ids must include at least one agent")
@@ -256,7 +271,11 @@ let handle_voice_conference_start (ctx : 'a context) args : result =
              ~agent_ids ?conference_name ())
 
 let handle_voice_conference_end (ctx : 'a context) args : result =
-  let agent_ids = get_string_list args "agent_ids" |> List.map String.trim |> List.filter (( <> ) "") in
+  let agent_ids =
+    get_string_list args "agent_ids"
+    |> List.map String.trim
+    |> List.filter (fun item -> item <> "")
+  in
   if agent_ids = [] then
     (false, "Error: agent_ids must include at least one agent")
   else
@@ -269,7 +288,10 @@ let handle_voice_conference_end (ctx : 'a context) args : result =
         ( true,
           Yojson.Safe.to_string
             (`Assoc
-              [ ("ended", `Int 0); ("total", `Int (List.length agent_ids)) ]) )
+              [
+                ("ended", `Int 0);
+                ("total", `Int (List.length agent_ids));
+              ]) )
 
 let dispatch (ctx : 'a context) ~name ~args : result option =
   match name with

--- a/lib/tool_voice.ml
+++ b/lib/tool_voice.ml
@@ -290,6 +290,8 @@ let handle_voice_conference_end (ctx : 'a context) args : result =
             (`Assoc
               [
                 ("ended", `Int 0);
+                ("skipped", `Int (List.length agent_ids));
+                ("failed", `Int 0);
                 ("total", `Int (List.length agent_ids));
               ]) )
 

--- a/lib/tool_voice.ml
+++ b/lib/tool_voice.ml
@@ -1,0 +1,284 @@
+open Types
+open Tool_args
+
+type 'a context = {
+  agent_name : string;
+  sw : Eio.Switch.t;
+  clock : 'a Eio.Time.clock;
+  net : [ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t option;
+}
+
+type result = bool * string
+
+let json_string_of_result = function
+  | Ok json -> (true, Yojson.Safe.to_string json)
+  | Error message ->
+      ( false,
+        Yojson.Safe.to_string
+          (`Assoc [ ("status", `String "error"); ("message", `String message) ]) )
+
+let schema_properties entries = `Assoc entries
+
+let schemas : tool_schema list =
+  [
+    {
+      name = "masc_voice_speak";
+      description =
+        "Send text to the voice bridge for an agent. Uses the agent's configured voice and may fall back to text_fallback when voice is unavailable.";
+      input_schema =
+        `Assoc
+          [
+            ("type", `String "object");
+            ( "properties",
+              schema_properties
+                [
+                  ("agent_id", `Assoc [ ("type", `String "string") ]);
+                  ("message", `Assoc [ ("type", `String "string") ]);
+                  ("provider", `Assoc [ ("type", `String "string") ]);
+                  ("priority", `Assoc [ ("type", `String "integer") ]);
+                ] );
+            ("required", `List [ `String "agent_id"; `String "message" ]);
+          ];
+    };
+    {
+      name = "masc_voice_session_start";
+      description =
+        "Start a voice session for an agent using the configured voice bridge.";
+      input_schema =
+        `Assoc
+          [
+            ("type", `String "object");
+            ( "properties",
+              schema_properties
+                [
+                  ("agent_id", `Assoc [ ("type", `String "string") ]);
+                  ("session_name", `Assoc [ ("type", `String "string") ]);
+                ] );
+            ("required", `List [ `String "agent_id" ]);
+          ];
+    };
+    {
+      name = "masc_voice_session_end";
+      description = "End the active voice session for an agent.";
+      input_schema =
+        `Assoc
+          [
+            ("type", `String "object");
+            ( "properties",
+              schema_properties
+                [ ("agent_id", `Assoc [ ("type", `String "string") ]) ] );
+            ("required", `List [ `String "agent_id" ]);
+          ];
+    };
+    {
+      name = "masc_voice_sessions";
+      description = "List active voice sessions from the voice bridge.";
+      input_schema =
+        `Assoc [ ("type", `String "object"); ("properties", `Assoc []) ];
+    };
+    {
+      name = "masc_voice_agent";
+      description = "Get the configured voice for an agent.";
+      input_schema =
+        `Assoc
+          [
+            ("type", `String "object");
+            ( "properties",
+              schema_properties
+                [ ("agent_id", `Assoc [ ("type", `String "string") ]) ] );
+            ("required", `List [ `String "agent_id" ]);
+          ];
+    };
+    {
+      name = "masc_voice_transcript";
+      description = "Get the current voice transcript from the voice bridge.";
+      input_schema =
+        `Assoc [ ("type", `String "object"); ("properties", `Assoc []) ];
+    };
+    {
+      name = "masc_voice_conference_start";
+      description =
+        "Start a multi-agent voice conference for the given agents.";
+      input_schema =
+        `Assoc
+          [
+            ("type", `String "object");
+            ( "properties",
+              schema_properties
+                [
+                  ( "agent_ids",
+                    `Assoc
+                      [
+                        ("type", `String "array");
+                        ("items", `Assoc [ ("type", `String "string") ]);
+                      ] );
+                  ("conference_name", `Assoc [ ("type", `String "string") ]);
+                ] );
+            ("required", `List [ `String "agent_ids" ]);
+          ];
+    };
+    {
+      name = "masc_voice_conference_end";
+      description = "End a multi-agent voice conference for the given agents.";
+      input_schema =
+        `Assoc
+          [
+            ("type", `String "object");
+            ( "properties",
+              schema_properties
+                [
+                  ( "agent_ids",
+                    `Assoc
+                      [
+                        ("type", `String "array");
+                        ("items", `Assoc [ ("type", `String "string") ]);
+                      ] );
+                ] );
+            ("required", `List [ `String "agent_ids" ]);
+          ];
+    };
+  ]
+
+let require_net_or_error (ctx : 'a context) =
+  match ctx.net with
+  | Some net -> Ok net
+  | None -> Error "voice bridge requires net (server_state.net is None)"
+
+let text_fallback_json ~agent_id ~message =
+  let voice = Voice_bridge.get_voice_for_agent agent_id in
+  `Assoc
+    [
+      ("status", `String "text_fallback");
+      ("agent_id", `String agent_id);
+      ("voice", `String voice);
+      ( "message_preview",
+        `String (String.sub message 0 (min 50 (String.length message))) );
+    ]
+
+let handle_voice_speak (ctx : 'a context) args : result =
+  let agent_id = get_string args "agent_id" "" |> String.trim in
+  let message = get_string args "message" "" in
+  let provider = get_string_opt args "provider" |> Option.map String.trim in
+  let provider =
+    match provider with Some p when p <> "" -> Some p | _ -> None
+  in
+  let priority = max 1 (get_int args "priority" 1) in
+  if agent_id = "" || String.trim message = "" then
+    (false, "Error: agent_id and message are required")
+  else
+    match ctx.net with
+    | Some net ->
+        json_string_of_result
+          (Voice_bridge.agent_speak ~sw:ctx.sw ~clock:ctx.clock ~net ~agent_id
+             ~message ?provider ~priority ())
+    | None -> (true, Yojson.Safe.to_string (text_fallback_json ~agent_id ~message))
+
+let handle_voice_session_start (ctx : 'a context) args : result =
+  let agent_id = get_string args "agent_id" "" |> String.trim in
+  let session_name = get_string_opt args "session_name" |> Option.map String.trim in
+  let session_name =
+    match session_name with Some s when s <> "" -> Some s | _ -> None
+  in
+  if agent_id = "" then
+    (false, "Error: agent_id is required")
+  else
+    match require_net_or_error ctx with
+    | Error message -> (false, message)
+    | Ok net ->
+        json_string_of_result
+          (Voice_bridge.start_voice_session ~sw:ctx.sw ~clock:ctx.clock ~net
+             ~agent_id ?session_name ())
+
+let handle_voice_session_end (ctx : 'a context) args : result =
+  let agent_id = get_string args "agent_id" "" |> String.trim in
+  if agent_id = "" then
+    (false, "Error: agent_id is required")
+  else
+    match ctx.net with
+    | Some net ->
+        json_string_of_result
+          (Voice_bridge.end_voice_session ~sw:ctx.sw ~clock:ctx.clock ~net
+             ~agent_id)
+    | None ->
+        ( true,
+          Yojson.Safe.to_string
+            (`Assoc
+              [
+                ("status", `String "skipped");
+                ("reason", `String "voice bridge unavailable");
+              ]) )
+
+let handle_voice_sessions (ctx : 'a context) _args : result =
+  match ctx.net with
+  | Some net ->
+      json_string_of_result
+        (Voice_bridge.list_voice_sessions ~sw:ctx.sw ~clock:ctx.clock ~net)
+  | None ->
+      ( true,
+        Yojson.Safe.to_string
+          (`Assoc
+            [
+              ("sessions", `List []);
+              ("status", `String "voice_server_unavailable");
+            ]) )
+
+let handle_voice_agent _ctx args : result =
+  let agent_id = get_string args "agent_id" "" |> String.trim in
+  if agent_id = "" then
+    (false, "Error: agent_id is required")
+  else
+    json_string_of_result (Voice_bridge.get_agent_voice ~agent_id)
+
+let handle_voice_transcript (ctx : 'a context) _args : result =
+  match ctx.net with
+  | Some net ->
+      json_string_of_result
+        (Voice_bridge.get_transcript ~sw:ctx.sw ~clock:ctx.clock ~net ())
+  | None ->
+      ( true,
+        Yojson.Safe.to_string
+          (`Assoc [ ("transcript", `List []); ("turn_count", `Int 0) ]) )
+
+let handle_voice_conference_start (ctx : 'a context) args : result =
+  let agent_ids = get_string_list args "agent_ids" |> List.map String.trim |> List.filter (( <> ) "") in
+  let conference_name = get_string_opt args "conference_name" |> Option.map String.trim in
+  let conference_name =
+    match conference_name with Some s when s <> "" -> Some s | _ -> None
+  in
+  if agent_ids = [] then
+    (false, "Error: agent_ids must include at least one agent")
+  else
+    match require_net_or_error ctx with
+    | Error message -> (false, message)
+    | Ok net ->
+        json_string_of_result
+          (Voice_bridge.start_conference ~sw:ctx.sw ~clock:ctx.clock ~net
+             ~agent_ids ?conference_name ())
+
+let handle_voice_conference_end (ctx : 'a context) args : result =
+  let agent_ids = get_string_list args "agent_ids" |> List.map String.trim |> List.filter (( <> ) "") in
+  if agent_ids = [] then
+    (false, "Error: agent_ids must include at least one agent")
+  else
+    match ctx.net with
+    | Some net ->
+        json_string_of_result
+          (Voice_bridge.end_conference ~sw:ctx.sw ~clock:ctx.clock ~net
+             ~agent_ids ())
+    | None ->
+        ( true,
+          Yojson.Safe.to_string
+            (`Assoc
+              [ ("ended", `Int 0); ("total", `Int (List.length agent_ids)) ]) )
+
+let dispatch (ctx : 'a context) ~name ~args : result option =
+  match name with
+  | "masc_voice_speak" -> Some (handle_voice_speak ctx args)
+  | "masc_voice_session_start" -> Some (handle_voice_session_start ctx args)
+  | "masc_voice_session_end" -> Some (handle_voice_session_end ctx args)
+  | "masc_voice_sessions" -> Some (handle_voice_sessions ctx args)
+  | "masc_voice_agent" -> Some (handle_voice_agent ctx args)
+  | "masc_voice_transcript" -> Some (handle_voice_transcript ctx args)
+  | "masc_voice_conference_start" -> Some (handle_voice_conference_start ctx args)
+  | "masc_voice_conference_end" -> Some (handle_voice_conference_end ctx args)
+  | _ -> None

--- a/lib/tools.ml
+++ b/lib/tools.ml
@@ -4393,7 +4393,7 @@ let all_schemas : tool_schema list = raw_schemas
 let all_schemas_with_perpetual =
   all_schemas @ Tool_perpetual.schemas @ Tool_keeper.schemas
   @ Tool_operator.schemas @ Tool_llama.schemas @ Tool_command_plane.schemas @ Tool_goals.schemas
-  @ Tool_team_session.schemas @ Tool_shard.schemas
+  @ Tool_team_session.schemas @ Tool_voice.schemas @ Tool_shard.schemas
   @ Tool_notifications.schemas
 
 (** Get tool by name *)

--- a/lib/voice_bridge_eio.ml
+++ b/lib/voice_bridge_eio.ml
@@ -795,11 +795,29 @@ let start_conference ~sw ~clock ~net ~agent_ids ?conference_name () =
 
 (** End a multi-agent voice conference *)
 let end_conference ~sw ~clock ~net ~agent_ids () =
-  let results = List.map (fun agent_id ->
-    end_voice_session ~sw ~clock ~net ~agent_id
-  ) agent_ids in
+  let classify_result = function
+    | Ok (`Assoc fields) -> (
+        match List.assoc_opt "status" fields with
+        | Some (`String "ended") -> `Ended
+        | Some (`String "skipped") -> `Skipped
+        | Some (`String _) | Some _ -> `Failed
+        | None -> `Failed)
+    | Ok _ -> `Failed
+    | Error _ -> `Failed
+  in
+  let ended, skipped, failed =
+    List.fold_left
+      (fun (ended, skipped, failed) agent_id ->
+        match classify_result (end_voice_session ~sw ~clock ~net ~agent_id) with
+        | `Ended -> (ended + 1, skipped, failed)
+        | `Skipped -> (ended, skipped + 1, failed)
+        | `Failed -> (ended, skipped, failed + 1))
+      (0, 0, 0) agent_ids
+  in
   Ok (`Assoc [
-    ("ended", `Int (List.length (List.filter Result.is_ok results)));
+    ("ended", `Int ended);
+    ("skipped", `Int skipped);
+    ("failed", `Int failed);
     ("total", `Int (List.length agent_ids));
   ])
 

--- a/test/dune
+++ b/test/dune
@@ -78,6 +78,12 @@
  (name test_dashboard_execution)
  (modules test_dashboard_execution)
  (libraries masc_mcp alcotest eio eio_main yojson unix))
+
+; Voice tool wrapper tests
+(test
+ (name test_tool_voice)
+ (modules test_tool_voice)
+ (libraries masc_mcp alcotest eio eio_main yojson unix))
 ; Board TTL + metadata classification tests
 (test
  (name test_board_ttl)

--- a/test/test_auth_coverage.ml
+++ b/test/test_auth_coverage.ml
@@ -270,6 +270,16 @@ let test_permission_for_tool_persona_list () =
   | Some Types.CanReadState -> ()
   | _ -> fail "expected CanReadState"
 
+let test_permission_for_tool_voice_sessions () =
+  match Auth.permission_for_tool "masc_voice_sessions" with
+  | Some Types.CanReadState -> ()
+  | _ -> fail "expected CanReadState"
+
+let test_permission_for_tool_voice_speak () =
+  match Auth.permission_for_tool "masc_voice_speak" with
+  | Some Types.CanBroadcast -> ()
+  | _ -> fail "expected CanBroadcast"
+
 let test_permission_for_tool_keeper_create_from_persona () =
   match Auth.permission_for_tool "masc_keeper_create_from_persona" with
   | Some Types.CanBroadcast -> ()
@@ -350,6 +360,8 @@ let () =
       test_case "operator_action" `Quick test_permission_for_tool_operator_action;
       test_case "operator_confirm" `Quick test_permission_for_tool_operator_confirm;
       test_case "persona_list" `Quick test_permission_for_tool_persona_list;
+      test_case "voice_sessions" `Quick test_permission_for_tool_voice_sessions;
+      test_case "voice_speak" `Quick test_permission_for_tool_voice_speak;
       test_case "keeper_create_from_persona" `Quick
         test_permission_for_tool_keeper_create_from_persona;
       test_case "unknown" `Quick test_permission_for_tool_unknown;

--- a/test/test_mode_coverage.ml
+++ b/test/test_mode_coverage.ml
@@ -248,6 +248,12 @@ let test_tool_category_code () =
   check bool "code_symbols" true (Mode.tool_category "masc_code_symbols" = Mode.Code);
   check bool "code_read" true (Mode.tool_category "masc_code_read" = Mode.Code)
 
+let test_tool_category_ecosystem_voice () =
+  check bool "voice_speak" true (Mode.tool_category "masc_voice_speak" = Mode.Ecosystem);
+  check bool "voice_sessions" true (Mode.tool_category "masc_voice_sessions" = Mode.Ecosystem);
+  check bool "voice_conference_start" true
+    (Mode.tool_category "masc_voice_conference_start" = Mode.Ecosystem)
+
 let test_tool_category_namespace_mapping () =
   check bool "lodge namespace" true (Mode.tool_category "lodge_heartbeat" = Mode.Comm);
   check bool "trpg namespace" true (Mode.tool_category "trpg.dice.roll" = Mode.TRPG);
@@ -402,6 +408,7 @@ let () =
       test_case "ratelimit tools" `Quick test_tool_category_ratelimit;
       test_case "encryption tools" `Quick test_tool_category_encryption;
       test_case "code tools" `Quick test_tool_category_code;
+      test_case "ecosystem voice tools" `Quick test_tool_category_ecosystem_voice;
       test_case "namespace mappings" `Quick test_tool_category_namespace_mapping;
       test_case "unknown category" `Quick test_tool_category_unknown;
     ];

--- a/test/test_tool_voice.ml
+++ b/test/test_tool_voice.ml
@@ -1,0 +1,139 @@
+(** Coverage tests for Tool_voice *)
+
+open Alcotest
+
+module Tool_voice = Masc_mcp.Tool_voice
+
+let contains haystack needle =
+  let text = String.lowercase_ascii haystack in
+  let sub = String.lowercase_ascii needle in
+  try
+    ignore (Str.search_forward (Str.regexp_string sub) text 0);
+    true
+  with Not_found -> false
+
+let with_ctx_no_net f =
+  Eio_main.run (fun env ->
+      Eio.Switch.run (fun sw ->
+          let ctx : _ Tool_voice.context =
+            {
+              agent_name = "test-agent";
+              sw;
+              clock = Eio.Stdenv.clock env;
+              net = None;
+            }
+          in
+          f ctx))
+
+let dispatch_exn ctx ~name ~args =
+  match Tool_voice.dispatch ctx ~name ~args with
+  | Some result -> result
+  | None -> failwith ("dispatch returned None for " ^ name)
+
+let json_field name json =
+  match Yojson.Safe.from_string json with
+  | `Assoc fields -> List.assoc_opt name fields
+  | _ -> None
+
+let test_dispatch_unknown () =
+  with_ctx_no_net (fun ctx ->
+      check bool "unknown returns None" true
+        (Tool_voice.dispatch ctx ~name:"unknown_tool" ~args:(`Assoc []) = None))
+
+let test_dispatch_known_tools () =
+  with_ctx_no_net (fun ctx ->
+      let tools =
+        [
+          "masc_voice_speak";
+          "masc_voice_session_start";
+          "masc_voice_session_end";
+          "masc_voice_sessions";
+          "masc_voice_agent";
+          "masc_voice_transcript";
+          "masc_voice_conference_start";
+          "masc_voice_conference_end";
+        ]
+      in
+      List.iter
+        (fun name ->
+          check bool (name ^ " dispatches") true
+            (Tool_voice.dispatch ctx ~name ~args:(`Assoc []) <> None))
+        tools)
+
+let test_voice_agent_uses_configured_voice () =
+  with_ctx_no_net (fun ctx ->
+      let ok, body =
+        dispatch_exn ctx ~name:"masc_voice_agent"
+          ~args:(`Assoc [ ("agent_id", `String "claude") ])
+      in
+      check bool "ok" true ok;
+      check (option string) "voice"
+        (Some "Sarah")
+        (match json_field "voice" body with Some (`String s) -> Some s | _ -> None))
+
+let test_voice_speak_without_net_falls_back_to_text () =
+  with_ctx_no_net (fun ctx ->
+      let ok, body =
+        dispatch_exn ctx ~name:"masc_voice_speak"
+          ~args:
+            (`Assoc
+              [
+                ("agent_id", `String "gemini");
+                ("message", `String "hello from voice");
+              ])
+      in
+      check bool "ok" true ok;
+      check (option string) "status"
+        (Some "text_fallback")
+        (match json_field "status" body with Some (`String s) -> Some s | _ -> None);
+      check (option string) "voice"
+        (Some "Roger")
+        (match json_field "voice" body with Some (`String s) -> Some s | _ -> None))
+
+let test_voice_session_start_without_net_errors () =
+  with_ctx_no_net (fun ctx ->
+      let ok, body =
+        dispatch_exn ctx ~name:"masc_voice_session_start"
+          ~args:(`Assoc [ ("agent_id", `String "claude") ])
+      in
+      check bool "fails" false ok;
+      check bool "mentions net" true (contains body "net"))
+
+let test_voice_sessions_without_net_returns_empty_list () =
+  with_ctx_no_net (fun ctx ->
+      let ok, body =
+        dispatch_exn ctx ~name:"masc_voice_sessions" ~args:(`Assoc [])
+      in
+      check bool "ok" true ok;
+      check (option string) "status"
+        (Some "voice_server_unavailable")
+        (match json_field "status" body with Some (`String s) -> Some s | _ -> None))
+
+let test_voice_conference_end_without_net_returns_zero () =
+  with_ctx_no_net (fun ctx ->
+      let ok, body =
+        dispatch_exn ctx ~name:"masc_voice_conference_end"
+          ~args:(`Assoc [ ("agent_ids", `List [ `String "claude"; `String "gemini" ]) ])
+      in
+      check bool "ok" true ok;
+      check (option int) "ended"
+        (Some 0)
+        (match json_field "ended" body with Some (`Int n) -> Some n | _ -> None))
+
+let () =
+  run "Tool_voice"
+    [
+      ( "dispatch",
+        [
+          test_case "unknown" `Quick test_dispatch_unknown;
+          test_case "known tools" `Quick test_dispatch_known_tools;
+        ] );
+      ( "handlers",
+        [
+          test_case "voice agent" `Quick test_voice_agent_uses_configured_voice;
+          test_case "speak fallback" `Quick test_voice_speak_without_net_falls_back_to_text;
+          test_case "session start no net" `Quick test_voice_session_start_without_net_errors;
+          test_case "sessions no net" `Quick test_voice_sessions_without_net_returns_empty_list;
+          test_case "conference end no net" `Quick test_voice_conference_end_without_net_returns_zero;
+        ] );
+    ]

--- a/test/test_tool_voice.ml
+++ b/test/test_tool_voice.ml
@@ -12,6 +12,33 @@ let contains haystack needle =
     true
   with Not_found -> false
 
+let temp_dir () =
+  let dir = Filename.temp_file "masc_tool_voice" "" in
+  Unix.unlink dir;
+  Unix.mkdir dir 0o755;
+  dir
+
+let cleanup_dir dir =
+  let rec rm path =
+    if Sys.file_exists path then
+      if Sys.is_directory path then (
+        Sys.readdir path |> Array.iter (fun name -> rm (Filename.concat path name));
+        Unix.rmdir path)
+      else
+        Sys.remove path
+  in
+  rm dir
+
+let with_env key value f =
+  let old = Sys.getenv_opt key in
+  Unix.putenv key value;
+  Fun.protect
+    ~finally:(fun () ->
+      match old with
+      | Some prev -> Unix.putenv key prev
+      | None -> Unix.putenv key "")
+    f
+
 let with_ctx_no_net f =
   Eio_main.run (fun env ->
       Eio.Switch.run (fun sw ->
@@ -21,6 +48,19 @@ let with_ctx_no_net f =
               sw;
               clock = Eio.Stdenv.clock env;
               net = None;
+            }
+          in
+          f ctx))
+
+let with_ctx_net f =
+  Eio_main.run (fun env ->
+      Eio.Switch.run (fun sw ->
+          let ctx : _ Tool_voice.context =
+            {
+              agent_name = "test-agent";
+              sw;
+              clock = Eio.Stdenv.clock env;
+              net = Some (Eio.Stdenv.net env);
             }
           in
           f ctx))
@@ -118,7 +158,44 @@ let test_voice_conference_end_without_net_returns_zero () =
       check bool "ok" true ok;
       check (option int) "ended"
         (Some 0)
-        (match json_field "ended" body with Some (`Int n) -> Some n | _ -> None))
+        (match json_field "ended" body with Some (`Int n) -> Some n | _ -> None);
+      check (option int) "skipped"
+        (Some 2)
+        (match json_field "skipped" body with Some (`Int n) -> Some n | _ -> None);
+      check (option int) "failed"
+        (Some 0)
+        (match json_field "failed" body with Some (`Int n) -> Some n | _ -> None))
+
+let test_voice_conference_end_with_unavailable_server_counts_skipped () =
+  let root = temp_dir () in
+  let masc_dir = Filename.concat root ".masc" in
+  Unix.mkdir masc_dir 0o755;
+  let config_path = Filename.concat masc_dir "voice_config.json" in
+  let config_json =
+    {|{"server":{"host":"127.0.0.1","port":1},"agent_voices":{"claude":"Sarah","gemini":"Roger"}}|}
+  in
+  let oc = open_out config_path in
+  output_string oc config_json;
+  close_out oc;
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir root)
+    (fun () ->
+      with_env "ME_ROOT" root @@ fun () ->
+      with_ctx_net @@ fun ctx ->
+      let ok, body =
+        dispatch_exn ctx ~name:"masc_voice_conference_end"
+          ~args:(`Assoc [ ("agent_ids", `List [ `String "claude"; `String "gemini" ]) ])
+      in
+      check bool "ok" true ok;
+      check (option int) "ended"
+        (Some 0)
+        (match json_field "ended" body with Some (`Int n) -> Some n | _ -> None);
+      check (option int) "skipped"
+        (Some 2)
+        (match json_field "skipped" body with Some (`Int n) -> Some n | _ -> None);
+      check (option int) "failed"
+        (Some 0)
+        (match json_field "failed" body with Some (`Int n) -> Some n | _ -> None))
 
 let () =
   run "Tool_voice"
@@ -135,5 +212,7 @@ let () =
           test_case "session start no net" `Quick test_voice_session_start_without_net_errors;
           test_case "sessions no net" `Quick test_voice_sessions_without_net_returns_empty_list;
           test_case "conference end no net" `Quick test_voice_conference_end_without_net_returns_zero;
+          test_case "conference end unavailable server counts skipped" `Quick
+            test_voice_conference_end_with_unavailable_server_counts_skipped;
         ] );
     ]

--- a/test/test_tools_coverage.ml
+++ b/test/test_tools_coverage.ml
@@ -84,7 +84,9 @@ let test_find_tool_existing () =
                "masc_team_session_turn"; "masc_team_session_events";
                "masc_team_session_prove"; "masc_llama_models";
                "masc_operator_snapshot"; "masc_operator_digest";
-               "masc_operator_action"; "masc_operator_confirm"] in
+               "masc_operator_action"; "masc_operator_confirm";
+               "masc_voice_speak"; "masc_voice_agent";
+               "masc_voice_sessions"; "masc_voice_conference_start"] in
   List.iter (fun name ->
     match find_tool name with
     | Some schema -> Alcotest.(check string) "found correct tool" name schema.name


### PR DESCRIPTION
## Summary
- add public masc_voice tools on top of the existing voice bridge
- wire voice tools into registry, auth, mode filtering, and server dispatch
- add wrapper and coverage tests for the new public surface

## Verification
- opam exec -- dune build --root . bin/main_eio.exe test/test_tool_voice.exe test/test_tools_coverage.exe test/test_auth_coverage.exe test/test_mode_coverage.exe
- opam exec -- ./_build/default/test/test_tool_voice.exe
- opam exec -- ./_build/default/test/test_tools_coverage.exe
- opam exec -- ./_build/default/test/test_auth_coverage.exe
- opam exec -- ./_build/default/test/test_mode_coverage.exe
