### PR TITLE
refactor(cascade): migrate auto_responder to Lodge_cascade.call

### DIFF
--- a/lib/auto_responder.ml
+++ b/lib/auto_responder.ml
@@ -137,17 +137,8 @@ let run_cli_agent ~agent_type ~prompt =
 
 (* --- LLM mode: shared cascade + in-process MASC HTTP tools/call --- *)
 
-let auto_responder_model_strings ~agent_type =
-  match agent_type with
-  | "claude" -> [ "claude:sonnet"; Printf.sprintf "glm:%s" Env_config.Llm.default_model ]
-  | "gemini" ->
-      [ "gemini:flash"; Printf.sprintf "glm:%s" Env_config.Llm.default_model ]
-  | "glm" -> [ Printf.sprintf "glm:%s" Env_config.Llm.default_model ]
-  | "codex" | "ollama" | _ -> Llm_client.default_execution_model_labels ()
-
-let available_model_specs_for_agent_type ~agent_type =
-  Llm_client.available_model_specs_of_strings
-    (auto_responder_model_strings ~agent_type)
+let cascade_name_for_agent_type agent_type =
+  Printf.sprintf "auto_responder_%s" agent_type
 
 let llm_response_is_valid (resp : Llm_client.completion_response) =
   let s = String.trim resp.content in
@@ -159,18 +150,17 @@ let llm_response_is_valid (resp : Llm_client.completion_response) =
   && not (len >= 9 && String.sub s 0 9 = "{\"error\":")
 
 let call_llm_direct_sync ~agent_type ~prompt =
+  let cascade_name = cascade_name_for_agent_type agent_type in
   try
     match
-      Llm_client.run_prompt_cascade ~timeout_sec:30
-        ~accept:llm_response_is_valid
-        ~model_specs:(available_model_specs_for_agent_type ~agent_type)
-        ~max_tokens:500 ~prompt ()
+      Lodge_cascade.call ~cascade_name ~prompt
+        ~accept:llm_response_is_valid ~timeout_sec:30 ~max_tokens:500 ()
     with
-    | Ok resp ->
+    | Ok result ->
         debug_log
-          (Printf.sprintf "LLM_MODEL_USED %s for agent_type=%s" resp.model_used
+          (Printf.sprintf "LLM_MODEL_USED %s for agent_type=%s" result.llm_used
              agent_type);
-        if String.trim resp.content = "" then "no response" else resp.content
+        if String.trim result.response = "" then "no response" else result.response
     | Error err ->
         Printf.eprintf "[auto_responder] LLM cascade failed: %s\n%!" err;
         "no response"

--- a/lib/lodge_cascade.ml
+++ b/lib/lodge_cascade.ml
@@ -104,6 +104,14 @@ let default_model_strings ~cascade_name =
   | "governance_judge" -> llama_glm
   (* walph — default execution models *)
   | "walph" -> llama_glm
+  (* auto_responder — agent_type-specific cascades *)
+  | "auto_responder_claude" ->
+      [ "claude:sonnet"; Printf.sprintf "glm:%s" Env_config.Llm.default_model ]
+  | "auto_responder_gemini" ->
+      [ "gemini:flash"; Printf.sprintf "glm:%s" Env_config.Llm.default_model ]
+  | "auto_responder_glm" ->
+      [ Printf.sprintf "glm:%s" Env_config.Llm.default_model ]
+  | "auto_responder" -> llama_glm
   (* spawn glm — cloud cascade for spawn_eio direct client path *)
   | "spawn_glm" ->
       [ "glm:glm-4.7"; "glm:glm-4.7-flash"; "glm:glm-5"; "glm:glm-5-code" ]

--- a/test/test_auto_responder_coverage.ml
+++ b/test/test_auto_responder_coverage.ml
@@ -209,8 +209,10 @@ let test_build_response_prompt_long_content () =
   check bool "handles long content" true (String.length prompt > 1000)
 
 let test_auto_responder_uses_shared_llm_client () =
-  check bool "uses Llm_client.run_prompt_cascade"
-    true
+  check bool "uses Lodge_cascade.call" true
+    (file_contains_pattern "lib/auto_responder.ml"
+       {|Lodge_cascade.call ~cascade_name|});
+  check bool "no direct run_prompt_cascade" false
     (file_contains_pattern "lib/auto_responder.ml" "Llm_client.run_prompt_cascade");
   check bool "legacy Llm_direct dispatch removed"
     false


### PR DESCRIPTION
## Summary
- auto_responder의 자체 model routing 함수들(`auto_responder_model_strings`, `available_model_specs_for_agent_type`)을 삭제하고 `Lodge_cascade.call`로 전환
- agent_type별 cascade 기본값을 `lodge_cascade.ml`에 등록 (`auto_responder_claude`, `auto_responder_gemini`, `auto_responder_glm`, `auto_responder`)
- structural test를 `Lodge_cascade.call ~cascade_name` 패턴 검증으로 업데이트

Phase 3.5 of the [Unified LLM Cascade Adapter plan](https://github.com/jeong-sik/masc-mcp/pull/772).

## Changes
| File | Change |
|------|--------|
| `lib/lodge_cascade.ml` | 4개 auto_responder cascade 기본값 추가 |
| `lib/auto_responder.ml` | 자체 model routing 삭제, `Lodge_cascade.call` 사용 |
| `test/test_auto_responder_coverage.ml` | structural test 업데이트 |

## Test plan
- [x] `dune build --root .` green
- [x] `test_auto_responder_coverage.exe` 29/29 pass
- [ ] CI green
- [ ] GLM-5 cross-model review

🤖 Generated with [Claude Code](https://claude.com/claude-code)