### PR TITLE
chore: bump version to 2.83.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.83.0] - 2026-03-11
+
+### Added
+- **Gardener Signal Observation** — full signal-based observation with LLM-primary decision making for spawn/retire (#773)
+- **CP Workload Templates** — `masc_operation_start` accepts workload templates and attached team sessions (#769)
+
+### Changed
+- **Cascade Phase 3** — distributed-pattern modules (`auto_chain`, `walph`) migrated to `Lodge_cascade.call` (#772)
+- **WebRTC Deduplication** — removed duplicated WebRTC code in favor of `ocaml-webrtc` library (#778)
+
+### Fixed
+- Mission briefing async refresh UX with loading states and error recovery (#774)
+
 ## [2.82.0] - 2026-03-11
 
 ### Changed

--- a/dune-project
+++ b/dune-project
@@ -1,7 +1,7 @@
 (lang dune 3.13)
 
 (name masc_mcp)
-(version 2.82.0)
+(version 2.83.0)
 
 (generate_opam_files true)
 


### PR DESCRIPTION
## Summary
- Bump `dune-project` version 2.82.0 → 2.83.0
- Add CHANGELOG [2.83.0] section with 5 merged PRs (#769, #772, #773, #774, #778)

## Changes since v2.82.0
- feat(gardener): full signal observation + LLM-primary decisions (#773)
- feat(cp): workload templates and attached sessions (#769)
- refactor(cascade): migrate distributed-pattern modules (#772)
- refactor: remove duplicated WebRTC code (#778)
- fix(mission): async refresh UX (#774)

🤖 Generated with [Claude Code](https://claude.com/claude-code)