### PR TITLE
feat(operator): add swarm run resolution actions

### DIFF
--- a/dashboard/src/api.ts
+++ b/dashboard/src/api.ts
@@ -546,6 +546,12 @@ function operatorActionTimeoutMs(body: OperatorActionRequest): number {
     case 'keeper_message':
     case 'keeper_recover':
       return 90_000
+    case 'swarm_run_continue':
+      return 60_000
+    case 'swarm_run_rerun':
+      return 120_000
+    case 'swarm_run_abandon':
+      return 30_000
     case 'lodge_tick':
       return 45_000
     default:

--- a/dashboard/src/command-store.ts
+++ b/dashboard/src/command-store.ts
@@ -1190,6 +1190,80 @@ function normalizeSwarmProvider(raw: unknown): CommandPlaneSwarmProvider | undef
   }
 }
 
+function normalizeRunResolution(raw: unknown): CommandPlaneSwarmResponse['run_resolution'] {
+  if (!isRecord(raw)) return null
+  const runId = asString(raw.run_id)
+  const status = asString(raw.status) as 'continued' | 'rerun' | 'abandoned' | null
+  const decidedBy = asString(raw.decided_by)
+  const decidedAt = asString(raw.decided_at)
+  const reason = asString(raw.reason)
+  if (!runId || !status || !decidedBy || !decidedAt || !reason) return null
+  const history: NonNullable<CommandPlaneSwarmResponse['run_resolution']>['history'] = []
+  if (Array.isArray(raw.history)) {
+    raw.history.forEach(entry => {
+      if (!isRecord(entry)) return
+      const itemStatus = asString(entry.status) as 'continued' | 'rerun' | 'abandoned' | null
+      const itemActor = asString(entry.decided_by)
+      const itemAt = asString(entry.decided_at)
+      const itemReason = asString(entry.reason)
+      if (!itemStatus || !itemActor || !itemAt || !itemReason) return
+      history.push({
+        status: itemStatus,
+        decided_by: itemActor,
+        decided_at: itemAt,
+        reason: itemReason,
+        operation_id: asString(entry.operation_id) ?? null,
+        detachment_id: asString(entry.detachment_id) ?? null,
+        note: asString(entry.note) ?? null,
+      })
+    })
+  }
+  return {
+    run_id: runId,
+    status,
+    decided_by: decidedBy,
+    decided_at: decidedAt,
+    reason,
+    operation_id: asString(raw.operation_id) ?? null,
+    detachment_id: asString(raw.detachment_id) ?? null,
+    note: asString(raw.note) ?? null,
+    history,
+  }
+}
+
+function normalizeRunResolutionRecommendation(
+  raw: unknown,
+): CommandPlaneSwarmResponse['resolution_recommendation'] {
+  if (!isRecord(raw)) return null
+  const runId = asString(raw.run_id)
+  const recommendedKind = asString(raw.recommended_kind) as 'continue' | 'rerun' | 'abandon' | null
+  const reason = asString(raw.reason)
+  if (!runId || !recommendedKind || !reason) return null
+  return {
+    run_id: runId,
+    recommended_kind: recommendedKind,
+    continue_available: asBoolean(raw.continue_available) ?? false,
+    rerun_available: asBoolean(raw.rerun_available) ?? false,
+    abandon_available: asBoolean(raw.abandon_available) ?? false,
+    reason,
+    evidence: isRecord(raw.evidence)
+      ? {
+          operation_id: asString(raw.evidence.operation_id) ?? null,
+          detachment_id: asString(raw.evidence.detachment_id) ?? null,
+          joined_workers: asNumber(raw.evidence.joined_workers),
+          current_task_bound: asNumber(raw.evidence.current_task_bound),
+          fresh_heartbeats: asNumber(raw.evidence.fresh_heartbeats),
+          trace_events: asNumber(raw.evidence.trace_events),
+          message_events: asNumber(raw.evidence.message_events),
+          runtime_blocker: asString(raw.evidence.runtime_blocker) ?? null,
+        }
+      : undefined,
+    provenance: asString(raw.provenance),
+    decision_engine: asString(raw.decision_engine),
+    authoritative: asBoolean(raw.authoritative),
+  }
+}
+
 function normalizeSwarm(raw: unknown): CommandPlaneSwarmResponse {
   const root = isRecord(raw) ? raw : {}
   const summary = isRecord(root.summary) ? root.summary : undefined
@@ -1199,6 +1273,8 @@ function normalizeSwarm(raw: unknown): CommandPlaneSwarmResponse {
     run_id: asString(root.run_id),
     room_id: asString(root.room_id),
     operation_id: asString(root.operation_id) ?? null,
+    run_resolution: normalizeRunResolution(root.run_resolution),
+    resolution_recommendation: normalizeRunResolutionRecommendation(root.resolution_recommendation),
     recommended_next_tool: asString(root.recommended_next_tool),
     summary: summary
       ? {

--- a/dashboard/src/components/command/swarm.ts
+++ b/dashboard/src/components/command/swarm.ts
@@ -1,11 +1,14 @@
 import { html } from 'htm/preact'
 import type {
+  CommandPlaneRunResolutionRecommendation,
+  CommandPlaneRunResolutionState,
   CommandPlaneSwarmBlocker,
   CommandPlaneSwarmChecklistItem,
   CommandPlaneSwarmFlag,
   CommandPlaneSwarmGap,
   CommandPlaneSwarmLane,
   CommandPlaneSwarmProof,
+  CommandPlaneSwarmResponse,
   CommandPlaneSwarmTimelineEvent,
   CommandPlaneSwarmWorker,
 } from '../../types'
@@ -14,11 +17,18 @@ import {
   commandPlaneSwarmError,
   commandPlaneSwarmLoading,
 } from '../../command-store'
+import {
+  confirmOperatorPendingAction,
+  dispatchOperatorAction,
+  operatorActionBusy,
+  operatorSnapshot,
+} from '../../operator-store'
 import { route } from '../../router'
 import { PanelSemanticDetails } from '../common/semantic-layer'
 import { workflowContextForRoute } from '../../workflow-context'
 import {
   currentCommandPlaneSummary,
+  dashboardActorName,
   dashboardSwarmOperationId,
   dashboardSwarmRunId,
   relativeTime,
@@ -26,6 +36,139 @@ import {
   toneClass,
 } from './helpers'
 import { TraceRow } from './topology'
+
+function previewText(value: unknown): string {
+  if (typeof value === 'string') return value
+  if (value == null) return ''
+  try {
+    return JSON.stringify(value, null, 2)
+  } catch {
+    return String(value)
+  }
+}
+
+function runResolutionTone(
+  recommendation: CommandPlaneRunResolutionRecommendation | null | undefined,
+  resolution: CommandPlaneRunResolutionState | null | undefined,
+): string {
+  if (resolution?.status === 'abandoned') return 'warn'
+  if (recommendation?.recommended_kind === 'continue') return 'warn'
+  if (recommendation?.recommended_kind === 'rerun') return 'bad'
+  return 'ok'
+}
+
+function runResolutionLabel(kind?: string | null): string {
+  switch (kind) {
+    case 'continue':
+    case 'continued':
+      return '계속'
+    case 'rerun':
+      return '재실행'
+    case 'abandon':
+    case 'abandoned':
+      return '포기'
+    default:
+      return kind?.trim() || '결정'
+  }
+}
+
+export function SwarmRunResolutionCard({ swarm }: { swarm: CommandPlaneSwarmResponse }) {
+  const runId = swarm.run_id
+  const recommendation = swarm.resolution_recommendation
+  const resolution = swarm.run_resolution
+  if (!runId || (!recommendation && !resolution)) return null
+
+  const actor = dashboardActorName() ?? 'dashboard'
+  const pendingConfirm =
+    operatorSnapshot.value?.pending_confirms.find(item =>
+      item.target_type === 'swarm_run' && item.target_id === runId,
+    ) ?? null
+  const tone = runResolutionTone(recommendation, resolution)
+  const operationId = swarm.operation?.operation_id ?? swarm.operation_id ?? undefined
+  const basePayload: Record<string, unknown> = {
+    run_id: runId,
+  }
+  if (operationId) basePayload.operation_id = operationId
+  if (recommendation?.reason) basePayload.reason = recommendation.reason
+
+  const previewAction = async (actionType: 'swarm_run_continue' | 'swarm_run_rerun' | 'swarm_run_abandon') => {
+    await dispatchOperatorAction({
+      actor,
+      action_type: actionType,
+      target_type: 'swarm_run',
+      target_id: runId,
+      payload: basePayload,
+    })
+  }
+
+  const confirmPending = async (decision: 'confirm' | 'deny') => {
+    if (!pendingConfirm) return
+    await confirmOperatorPendingAction(actor, pendingConfirm.confirm_token, decision)
+  }
+
+  return html`
+    <article class="command-guide-card ${toneClass(tone)}">
+      <div class="command-guide-head">
+        <strong>Run Resolution</strong>
+        <span class="command-chip ${toneClass(tone)}">
+          ${runResolutionLabel(resolution?.status ?? recommendation?.recommended_kind ?? null)}
+        </span>
+      </div>
+      <p>
+        ${resolution?.status === 'abandoned'
+          ? `이 run은 ${resolution.decided_by}가 ${relativeTime(resolution.decided_at)}에 soft abandon 처리했습니다. ${resolution.reason}`
+          : recommendation?.reason ?? '이 run에 대한 별도 resolution recommendation은 아직 없습니다.'}
+      </p>
+      <div class="command-card-grid">
+        <span>Run</span><span>${runId}</span>
+        <span>Provenance</span><span>${recommendation?.provenance ?? 'recorded'}</span>
+        <span>Engine</span><span>${recommendation?.decision_engine ?? 'operator_record'}</span>
+        <span>Authoritative</span><span>${recommendation?.authoritative ? 'yes' : 'no'}</span>
+      </div>
+      ${recommendation?.evidence
+        ? html`
+            <div class="command-tag-row">
+              <span class="command-tag">joined ${recommendation.evidence.joined_workers ?? 0}</span>
+              <span class="command-tag">trace ${recommendation.evidence.trace_events ?? 0}</span>
+              <span class="command-tag">message ${recommendation.evidence.message_events ?? 0}</span>
+              ${recommendation.evidence.runtime_blocker
+                ? html`<span class="command-tag ${toneClass('bad')}">${recommendation.evidence.runtime_blocker}</span>`
+                : null}
+            </div>
+          `
+        : null}
+      ${pendingConfirm
+        ? html`
+            <div class="command-guide-card warn">
+              <div class="command-guide-head">
+                <strong>확인 대기</strong>
+                <span class="command-chip warn">${pendingConfirm.confirm_token}</span>
+              </div>
+              ${pendingConfirm.preview ? html`<pre class="command-trace-detail">${previewText(pendingConfirm.preview)}</pre>` : null}
+              <div class="command-action-row">
+                <button class="control-btn" onClick=${() => { void confirmPending('confirm') }} disabled=${operatorActionBusy.value}>확인 실행</button>
+                <button class="control-btn ghost" onClick=${() => { void confirmPending('deny') }} disabled=${operatorActionBusy.value}>취소</button>
+              </div>
+            </div>
+          `
+        : recommendation
+          ? html`
+              <div class="command-action-row">
+                ${recommendation.continue_available
+                  ? html`<button class="control-btn ghost" onClick=${() => { void previewAction('swarm_run_continue') }} disabled=${operatorActionBusy.value}>Continue</button>`
+                  : null}
+                ${recommendation.rerun_available
+                  ? html`<button class="control-btn" onClick=${() => { void previewAction('swarm_run_rerun') }} disabled=${operatorActionBusy.value}>Rerun</button>`
+                  : null}
+                ${recommendation.abandon_available
+                  ? html`<button class="control-btn ghost" onClick=${() => { void previewAction('swarm_run_abandon') }} disabled=${operatorActionBusy.value}>Abandon</button>`
+                  : null}
+              </div>
+            `
+          : null}
+    </article>
+  `
+}
 
 function swarmLaneTone(lane: CommandPlaneSwarmLane): string {
   if (lane.motion_state === 'stalled') return 'bad'
@@ -449,6 +592,7 @@ export function SwarmSurface() {
                           ${swarm.truth_notes.map(note => html`<span class="command-tag">${note}</span>`)}
                         </div>`
                       : null}
+                    <${SwarmRunResolutionCard} swarm=${swarm} />
                   `
                 : html`<div class="empty-state">스웜 read-model이 아직 없습니다.</div>`}
         </section>

--- a/dashboard/src/components/command/war-room.ts
+++ b/dashboard/src/components/command/war-room.ts
@@ -37,7 +37,7 @@ import {
   surfaceRouteParams,
   toneClass,
 } from './helpers'
-import { SwarmBlockerCard, SwarmHealthBar, SwarmStoryboard } from './swarm'
+import { SwarmBlockerCard, SwarmHealthBar, SwarmRunResolutionCard, SwarmStoryboard } from './swarm'
 import { TraceRow } from './topology'
 
 type WarRoomWorkerView = {
@@ -425,6 +425,7 @@ export function WarRoomSurface() {
               <${PanelSemanticDetails} panelId="command.warroom" compact=${true} />
             </div>
             <div class="command-card-stack">
+              ${swarm ? html`<${SwarmRunResolutionCard} swarm=${swarm} />` : null}
               ${blockers.length > 0
                 ? blockers.map(blocker => html`<${SwarmBlockerCard} blocker=${blocker} />`)
                 : html`<div class="command-guide-card ok"><p>지금 보이는 blocker는 없습니다.</p></div>`}

--- a/dashboard/src/components/ops/helpers.ts
+++ b/dashboard/src/components/ops/helpers.ts
@@ -135,6 +135,12 @@ export function actionTypeLabel(value?: string | null): string {
       return 'keeper 메시지'
     case 'keeper_msg':
       return 'keeper 메시지'
+    case 'swarm_run_continue':
+      return 'swarm run 계속'
+    case 'swarm_run_rerun':
+      return 'swarm run 재실행'
+    case 'swarm_run_abandon':
+      return 'swarm run 포기'
     default:
       return value?.trim() || '액션'
   }
@@ -148,6 +154,8 @@ export function targetTypeLabel(value?: string | null): string {
       return 'session'
     case 'keeper':
       return 'keeper'
+    case 'swarm_run':
+      return 'swarm run'
     default:
       return value?.trim() || 'target'
   }

--- a/dashboard/src/operator-store.ts
+++ b/dashboard/src/operator-store.ts
@@ -391,14 +391,18 @@ export async function dispatchOperatorAction(request: OperatorActionRequest): Pr
   }
 }
 
-export async function confirmOperatorPendingAction(actor: string, confirmToken: string): Promise<OperatorActionResult> {
+export async function confirmOperatorPendingAction(
+  actor: string,
+  confirmToken: string,
+  decision: 'confirm' | 'deny' = 'confirm',
+): Promise<OperatorActionResult> {
   operatorActionBusy.value = true
   operatorError.value = null
   try {
-    const result = await confirmOperatorAction(actor, confirmToken)
+    const result = await confirmOperatorAction(actor, confirmToken, decision)
     appendLog({
       actor,
-      action_type: 'confirm',
+      action_type: decision,
       target_label: confirmToken,
       outcome: 'confirmed',
       message: logMessageFromResult(result),

--- a/dashboard/src/types.ts
+++ b/dashboard/src/types.ts
@@ -1403,8 +1403,11 @@ export type OperatorActionType =
   | 'keeper_message'
   | 'keeper_probe'
   | 'keeper_recover'
+  | 'swarm_run_continue'
+  | 'swarm_run_rerun'
+  | 'swarm_run_abandon'
 
-export type OperatorTargetType = 'room' | 'team_session' | 'keeper'
+export type OperatorTargetType = 'room' | 'team_session' | 'keeper' | 'swarm_run'
 
 export interface OperatorActionRequest {
   actor: string
@@ -2117,12 +2120,58 @@ export interface CommandPlaneSwarmProvider {
   timeline: CommandPlaneSwarmProviderSample[]
 }
 
+export interface CommandPlaneRunResolutionHistoryEntry {
+  status: 'continued' | 'rerun' | 'abandoned'
+  decided_by: string
+  decided_at: string
+  reason: string
+  operation_id?: string | null
+  detachment_id?: string | null
+  note?: string | null
+}
+
+export interface CommandPlaneRunResolutionState {
+  run_id: string
+  status: 'continued' | 'rerun' | 'abandoned'
+  decided_by: string
+  decided_at: string
+  reason: string
+  operation_id?: string | null
+  detachment_id?: string | null
+  note?: string | null
+  history: CommandPlaneRunResolutionHistoryEntry[]
+}
+
+export interface CommandPlaneRunResolutionRecommendation {
+  run_id: string
+  recommended_kind: 'continue' | 'rerun' | 'abandon'
+  continue_available: boolean
+  rerun_available: boolean
+  abandon_available: boolean
+  reason: string
+  evidence?: {
+    operation_id?: string | null
+    detachment_id?: string | null
+    joined_workers?: number
+    current_task_bound?: number
+    fresh_heartbeats?: number
+    trace_events?: number
+    message_events?: number
+    runtime_blocker?: string | null
+  }
+  provenance?: string
+  decision_engine?: string
+  authoritative?: boolean
+}
+
 export interface CommandPlaneSwarmResponse {
   version?: string
   generated_at?: string
   run_id?: string
   room_id?: string
   operation_id?: string | null
+  run_resolution?: CommandPlaneRunResolutionState | null
+  resolution_recommendation?: CommandPlaneRunResolutionRecommendation | null
   recommended_next_tool?: string
   summary?: {
     expected_workers?: number

--- a/dashboard/src/workflow-context.ts
+++ b/dashboard/src/workflow-context.ts
@@ -387,6 +387,12 @@ export function workflowActionLabel(actionType?: string | null): string {
       return 'keeper probe'
     case 'keeper_recover':
       return 'keeper recover'
+    case 'swarm_run_continue':
+      return 'swarm run 계속'
+    case 'swarm_run_rerun':
+      return 'swarm run 재실행'
+    case 'swarm_run_abandon':
+      return 'swarm run 포기'
     default:
       return actionType?.trim() || '추천 액션'
   }

--- a/lib/cp_lifecycle.ml
+++ b/lib/cp_lifecycle.ml
@@ -1,5 +1,66 @@
 include Cp_snapshot
 
+let option_to_json f = function
+  | Some value -> f value
+  | None -> `Null
+
+let swarm_run_resolution_status_of_json json =
+  match U.member "status" json with
+  | `String ("continued" | "rerun" | "abandoned" as status) -> Some status
+  | _ -> None
+
+let read_swarm_run_resolution_json config run_id =
+  find_swarm_live_artifact_json config run_id "resolution.json"
+
+let swarm_run_resolution_entry_json ~status ~actor ~reason ?operation_id
+    ?detachment_id ?note () =
+  `Assoc
+    [
+      ("status", `String status);
+      ("decided_by", `String actor);
+      ("decided_at", `String (Types.now_iso ()));
+      ("reason", `String reason);
+      ("operation_id", option_to_json (fun value -> `String value) operation_id);
+      ("detachment_id", option_to_json (fun value -> `String value) detachment_id);
+      ("note", option_to_json (fun value -> `String value) note);
+    ]
+
+let record_swarm_run_resolution_json config ~run_id ~status ~actor ~reason
+    ?operation_id ?detachment_id ?note () =
+  let existing =
+    match read_swarm_run_resolution_json config run_id with
+    | Some (`Assoc _ as json) -> json
+    | _ -> `Assoc []
+  in
+  let entry =
+    swarm_run_resolution_entry_json ~status ~actor ~reason ?operation_id
+      ?detachment_id ?note ()
+  in
+  let history =
+    match U.member "history" existing with
+    | `List rows -> rows @ [ entry ]
+    | _ -> [ entry ]
+  in
+  let payload =
+    `Assoc
+      [
+        ("run_id", `String run_id);
+        ("status", `String status);
+        ("decided_by", `String actor);
+        ("decided_at", `String (Types.now_iso ()));
+        ("reason", `String reason);
+        ("operation_id", option_to_json (fun value -> `String value) operation_id);
+        ("detachment_id", option_to_json (fun value -> `String value) detachment_id);
+        ("note", option_to_json (fun value -> `String value) note);
+        ("history", `List history);
+      ]
+  in
+  let run_dir = Cp_paths.primary_swarm_live_run_dir config run_id in
+  Room_utils.mkdir_p run_dir;
+  Room_utils.write_json_local (Cp_paths.swarm_live_resolution_path config run_id)
+    payload;
+  payload
+
 let swarm_live_json config ?run_id ?operation_id () =
   let room_id = Room.current_room_id config in
   let agents = Room.get_agents_raw config in
@@ -864,6 +925,82 @@ let swarm_live_json config ?run_id ?operation_id () =
         |> (function Some value -> String.equal value "bad" | None -> false))
       !blockers
   in
+  let existing_resolution = read_swarm_run_resolution_json config effective_run_id in
+  let existing_resolution_status =
+    Option.bind existing_resolution swarm_run_resolution_status_of_json
+  in
+  let partial_run_evidence =
+    joined_workers > 0
+    || current_task_bound > 0
+    || fresh_heartbeats > 0
+    || recent_messages <> []
+    || relevant_traces <> []
+  in
+  let operation_paused =
+    match selected_operation with
+    | Some operation -> operation.status = Paused
+    | None -> false
+  in
+  let continue_available =
+    pending_decisions = []
+    && (Option.is_some selected_operation || detachment_exists)
+  in
+  let rerun_available = pending_decisions = [] in
+  let abandon_available = true in
+  let resolution_recommendation =
+    if pending_decisions <> [] then
+      None
+    else if existing_resolution_status = Some "abandoned" then
+      None
+    else
+      let recommended_kind, reason =
+        if
+          continue_available
+          && (operation_paused || partial_run_evidence || detachment_exists)
+          && not (Option.is_some runtime_blocker)
+        then
+          ( "continue",
+            if operation_paused then
+              "Matched operation is paused and run-scoped evidence exists. Resume and dispatch before rerunning the harness."
+            else if partial_run_evidence then
+              "Matched operation or detachment still has worker or trace evidence. Try command-plane recovery before a full rerun."
+            else
+              "A matching detachment exists for this run. Dispatch recovery is cheaper than a full rerun." )
+        else
+          ( "rerun",
+            if Option.is_some runtime_blocker then
+              "Runtime verification failed for this run. Clear the runtime blocker, then rerun the harness for the same run_id."
+            else if Option.is_some selected_operation || detachment_exists then
+              "The run still maps to managed state, but resumable evidence is too weak. Rerun the harness and rebuild fresh proof."
+            else
+              "No resumable managed operation or worker evidence remains for this run. Rerun the harness to materialize fresh state." )
+      in
+      Some
+        (`Assoc
+          [
+            ("run_id", `String effective_run_id);
+            ("recommended_kind", `String recommended_kind);
+            ("continue_available", `Bool continue_available);
+            ("rerun_available", `Bool rerun_available);
+            ("abandon_available", `Bool abandon_available);
+            ("reason", `String reason);
+            ( "evidence",
+              `Assoc
+                [
+                  ("operation_id", option_to_json (fun value -> `String value) (Option.map (fun (operation : operation_record) -> operation.operation_id) selected_operation));
+                  ("detachment_id", option_to_json (fun value -> `String value) (Option.map (fun (detachment : detachment_record) -> detachment.detachment_id) matched_detachment));
+                  ("joined_workers", `Int joined_workers);
+                  ("current_task_bound", `Int current_task_bound);
+                  ("fresh_heartbeats", `Int fresh_heartbeats);
+                  ("trace_events", `Int (List.length relevant_traces));
+                  ("message_events", `Int (List.length recent_messages));
+                  ("runtime_blocker", option_to_json (fun value -> `String value) runtime_blocker);
+                ] );
+            ("provenance", `String "derived");
+            ("decision_engine", `String "deterministic_truth_map");
+            ("authoritative", `Bool false);
+          ])
+  in
   `Assoc
     [
       ("version", `String "cp-v2");
@@ -871,6 +1008,8 @@ let swarm_live_json config ?run_id ?operation_id () =
       ("run_id", `String effective_run_id);
       ("room_id", `String room_id);
       ("operation_id", match selected_operation with Some operation -> `String operation.operation_id | None -> `Null);
+      ("run_resolution", option_to_json Fun.id existing_resolution);
+      ("resolution_recommendation", option_to_json Fun.id resolution_recommendation);
       ("recommended_next_tool", `String recommended_next_tool);
       ( "summary",
         `Assoc

--- a/lib/cp_paths.ml
+++ b/lib/cp_paths.ml
@@ -73,11 +73,19 @@ let swarm_live_run_dirs config run_id =
          [ Filename.concat dir normalized; Filename.concat dir run_id ])
   |> List.sort_uniq String.compare
 
+let primary_swarm_live_run_dir config run_id =
+  Filename.concat
+    (Filename.concat (control_plane_root_dir config) "swarm-live")
+    (Room_utils.safe_filename run_id)
+
 let find_swarm_live_artifact_path config run_id filename =
   swarm_live_run_dirs config run_id
   |> List.find_map (fun dir ->
          let path = Filename.concat dir filename in
          if Sys.file_exists path || Room_utils.path_exists config path then Some path else None)
+
+let swarm_live_resolution_path config run_id =
+  Filename.concat (primary_swarm_live_run_dir config run_id) "resolution.json"
 
 let find_swarm_live_artifact_json config run_id filename =
   match find_swarm_live_artifact_path config run_id filename with

--- a/lib/operator_control.ml
+++ b/lib/operator_control.ml
@@ -445,6 +445,27 @@ let available_actions_json =
           ("description", `String "Use this when a keeper is stale, degraded, or offline and you need a safe down/up recovery with before-and-after diagnostics.");
           ("confirm_required", `Bool false);
         ];
+      `Assoc
+        [
+          ("action_type", `String "swarm_run_continue");
+          ("target_type", `String "swarm_run");
+          ("description", `String "Use this when a stalled swarm-live run still has resumable managed state and you want a preview-confirm command-plane recovery chain.");
+          ("confirm_required", `Bool true);
+        ];
+      `Assoc
+        [
+          ("action_type", `String "swarm_run_rerun");
+          ("target_type", `String "swarm_run");
+          ("description", `String "Use this when a swarm-live run has no trustworthy resumable state and you want to rerun the harness for the same run_id.");
+          ("confirm_required", `Bool true);
+        ];
+      `Assoc
+        [
+          ("action_type", `String "swarm_run_abandon");
+          ("target_type", `String "swarm_run");
+          ("description", `String "Use this when you want to soft-abandon a swarm-live run without stopping any matched operation.");
+          ("confirm_required", `Bool true);
+        ];
     ]
 
 let recent_messages_json config =
@@ -638,7 +659,8 @@ let attention_item_to_yojson (item : attention_item) =
 
 let recommended_confirm_required = function
   | "room_pause" | "team_stop" | "task_inject" | "team_task_inject"
-  | "team_worker_spawn_batch" ->
+  | "team_worker_spawn_batch" | "swarm_run_continue"
+  | "swarm_run_rerun" | "swarm_run_abandon" ->
       true
   | _ -> false
 
@@ -1906,7 +1928,75 @@ let room_recommendations config =
                  }
            | _ -> None)
   in
-  dedup_recommendations signal_recommendations
+  let swarm_resolution_recommendation =
+    let swarm = Command_plane_v2.swarm_live_json config () in
+    match U.member "resolution_recommendation" swarm with
+    | `Assoc _ as recommendation -> (
+        match
+          recommendation |> U.member "recommended_kind" |> U.to_string_option,
+          swarm |> U.member "run_id" |> U.to_string_option
+        with
+        | Some recommended_kind, Some run_id -> (
+            let reason =
+              recommendation |> U.member "reason" |> U.to_string_option
+              |> Option.value ~default:"swarm-live run needs operator resolution"
+            in
+            let operation_id =
+              match U.member "operation" swarm with
+              | `Assoc _ as operation ->
+                  operation |> U.member "operation_id" |> U.to_string_option
+              | _ -> None
+            in
+            let payload =
+              `Assoc
+                [
+                  ("run_id", `String run_id);
+                  ("reason", `String reason);
+                  ( "evidence",
+                    match recommendation |> U.member "evidence" with
+                    | `Assoc _ as evidence -> evidence
+                    | _ -> `Assoc [] );
+                ]
+            in
+            let payload =
+              match operation_id with
+              | Some value -> (
+                  match payload with
+                  | `Assoc fields ->
+                      `Assoc (("operation_id", `String value) :: fields)
+                  | other -> other)
+              | None -> payload
+            in
+            let action_type =
+              match recommended_kind with
+              | "continue" -> "swarm_run_continue"
+              | "rerun" -> "swarm_run_rerun"
+              | "abandon" -> "swarm_run_abandon"
+              | _ -> ""
+            in
+            if action_type = "" then None
+            else
+              Some
+                {
+                  action_type;
+                  target_type = "swarm_run";
+                  target_id = Some run_id;
+                  severity =
+                    (match recommendation |> U.member "recommended_kind" |> U.to_string_option with
+                    | Some "continue" -> "warn"
+                    | _ -> "bad");
+                  reason;
+                  suggested_payload = payload;
+                })
+        | _ -> None)
+    | _ -> None
+  in
+  dedup_recommendations
+    (signal_recommendations
+    @
+    match swarm_resolution_recommendation with
+    | Some item -> [ item ]
+    | None -> [])
 
 type snapshot_view =
   | Summary
@@ -2176,6 +2266,9 @@ let canonical_action_type action_type =
   | "keeper_message" -> "keeper_message"
   | "keeper_probe" -> "keeper_probe"
   | "keeper_recover" -> "keeper_recover"
+  | "swarm_run_continue" -> "swarm_run_continue"
+  | "swarm_run_rerun" -> "swarm_run_rerun"
+  | "swarm_run_abandon" -> "swarm_run_abandon"
   | other -> other
 
 let default_target_type_for action_type =
@@ -2185,9 +2278,11 @@ let default_target_type_for action_type =
   | "team_worker_spawn_batch" | "team_stop" ->
       "team_session"
   | "keeper_message" | "keeper_probe" | "keeper_recover" -> "keeper"
+  | "swarm_run_continue" | "swarm_run_rerun" | "swarm_run_abandon" ->
+      "swarm_run"
   | _ -> ""
 
-let generate_confirm_token ~clock config =
+let generate_confirm_token ~(clock : _ Eio.Time.clock) config =
   let max_attempts = 10 in
   let rec loop attempts =
     if attempts >= max_attempts then
@@ -2248,12 +2343,16 @@ let delegated_tool_for action_type =
   | "keeper_message" -> "masc_keeper_msg"
   | "keeper_probe" -> "masc_keeper_status"
   | "keeper_recover" -> "masc_keeper_recover"
+  | "swarm_run_continue" -> "swarm_run_continue_chain"
+  | "swarm_run_rerun" -> "masc_swarm_live_run"
+  | "swarm_run_abandon" -> "swarm_run_resolution"
   | "task_inject" -> "masc_add_task"
   | _ -> "unknown"
 
 let confirm_required = function
   | "room_pause" | "team_stop" | "task_inject" | "team_task_inject"
-  | "team_worker_spawn_batch" ->
+  | "team_worker_spawn_batch" | "swarm_run_continue"
+  | "swarm_run_rerun" | "swarm_run_abandon" ->
       true
   | _ -> false
 
@@ -2300,6 +2399,127 @@ let parse_turn_kind payload =
   | None ->
       Error
         "payload.turn_kind must be one of: note, broadcast, portal, task, checkpoint"
+
+let swarm_run_json_for_request (ctx : 'a context) (request : action_request) =
+  let* run_id = require_target_id request in
+  let operation_id = get_string_opt request.payload "operation_id" in
+  Ok (Command_plane_v2.swarm_live_json ctx.config ~run_id ?operation_id ())
+
+let swarm_run_recommendation_json swarm_json =
+  match U.member "resolution_recommendation" swarm_json with
+  | `Assoc _ as json -> Some json
+  | _ -> None
+
+let swarm_run_operation_id swarm_json =
+  match U.member "operation" swarm_json with
+  | `Assoc _ as operation ->
+      operation |> U.member "operation_id" |> U.to_string_option
+  | _ -> None
+
+let swarm_run_detachment_id swarm_json =
+  match U.member "detachment" swarm_json with
+  | `Assoc _ as detachment ->
+      detachment |> U.member "detachment_id" |> U.to_string_option
+  | _ -> None
+
+let swarm_run_reason swarm_json fallback =
+  match swarm_run_recommendation_json swarm_json with
+  | Some json -> (
+      match U.member "reason" json with
+      | `String reason when String.trim reason <> "" -> reason
+      | _ -> fallback)
+  | None -> fallback
+
+let swarm_run_chain_preview (request : action_request) swarm_json =
+  let run_id =
+    swarm_json |> U.member "run_id" |> U.to_string_option
+    |> Option.value ~default:(Option.value ~default:"swarm-live" request.target_id)
+  in
+  let reason =
+    swarm_run_reason swarm_json "swarm-live run needs operator resolution"
+  in
+  let operation_id = swarm_run_operation_id swarm_json in
+  let detachment_id = swarm_run_detachment_id swarm_json in
+  let base_fields =
+    [
+      ("run_id", `String run_id);
+      ("reason", `String reason);
+      ("provenance", `String "derived");
+      ("decision_engine", `String "deterministic_truth_map");
+      ("authoritative", `Bool false);
+    ]
+  in
+  let evidence =
+    match swarm_run_recommendation_json swarm_json with
+    | Some json -> (
+        match U.member "evidence" json with
+        | `Assoc _ as evidence -> evidence
+        | _ -> `Assoc [])
+    | None -> `Assoc []
+  in
+  match request.action_type with
+  | "swarm_run_continue" ->
+      let steps =
+        (match
+           swarm_json |> U.member "operation" |> U.member "status"
+           |> U.to_string_option
+         with
+        | Some "paused" -> [ `Assoc [ ("tool", `String "masc_operation_resume"); ("args", `Assoc [ ("operation_id", option_to_json (fun value -> `String value) operation_id) ]) ] ]
+        | _ -> [])
+        @
+        (match operation_id, detachment_id with
+        | Some value, _ ->
+            [ `Assoc [ ("tool", `String "masc_dispatch_tick"); ("args", `Assoc [ ("operation_id", `String value) ]) ] ]
+        | None, Some value ->
+            [ `Assoc [ ("tool", `String "masc_dispatch_tick"); ("args", `Assoc [ ("detachment_id", `String value) ]) ] ]
+        | None, None -> [])
+      in
+      `Assoc
+        (base_fields
+        @ [
+            ("resolution_kind", `String "continue");
+            ("delegated_tools", `List (List.map (fun step -> U.member "tool" step) steps));
+            ("tool_chain_preview", `List steps);
+            ("evidence", evidence);
+          ])
+  | "swarm_run_rerun" ->
+      let steps =
+        [
+          `Assoc
+            [
+              ("tool", `String "masc_swarm_live_run");
+              ("args", `Assoc [ ("run_id", `String run_id) ]);
+            ];
+        ]
+      in
+      `Assoc
+        (base_fields
+        @ [
+            ("resolution_kind", `String "rerun");
+            ("delegated_tools", `List (List.map (fun step -> U.member "tool" step) steps));
+            ("tool_chain_preview", `List steps);
+            ("evidence", evidence);
+          ])
+  | "swarm_run_abandon" ->
+      `Assoc
+        (base_fields
+        @ [
+            ("resolution_kind", `String "abandon");
+            ("delegated_tools", `List []);
+            ("tool_chain_preview", `List []);
+            ("operation_id", option_to_json (fun value -> `String value) operation_id);
+            ("detachment_id", option_to_json (fun value -> `String value) detachment_id);
+            ("evidence", evidence);
+          ])
+  | _ ->
+      `Assoc
+        [
+          ("actor", `String request.actor);
+          ("action_type", `String request.action_type);
+          ("target_type", `String request.target_type);
+          ("target_id", string_option_to_json request.target_id);
+          ("payload", request.payload);
+        ]
 
 let json_of_dispatch_output body =
   try Yojson.Safe.from_string body with Yojson.Json_error _ -> `String body
@@ -2384,8 +2604,26 @@ let lodge_tick_ack_json ~mode ~status ~manual_tick_running =
 let tool_keeper_ctx (ctx : 'a context) : _ Tool_keeper.context =
   { config = ctx.config; sw = ctx.sw; clock = ctx.clock }
 
+let tool_command_plane_ctx (ctx : 'a context) : _ Tool_command_plane.context =
+  {
+    config = ctx.config;
+    agent_name = ctx.agent_name;
+    sw = Some ctx.sw;
+    clock = Some ctx.clock;
+    net = None;
+    mcp_state = None;
+    mcp_session_id = ctx.mcp_session_id;
+    auth_token = None;
+  }
+
 let dispatch_keeper_json (ctx : 'a context) ~tool_name ~args =
   match Tool_keeper.dispatch (tool_keeper_ctx ctx) ~name:tool_name ~args with
+  | Some (true, body) -> Ok (json_of_dispatch_output body)
+  | Some (false, err) -> Error err
+  | None -> Error (Printf.sprintf "%s dispatch unavailable" tool_name)
+
+let dispatch_command_plane_json (ctx : 'a context) ~tool_name ~args =
+  match Tool_command_plane.dispatch (tool_command_plane_ctx ctx) ~name:tool_name ~args with
   | Some (true, body) -> Ok (json_of_dispatch_output body)
   | Some (false, err) -> Error err
   | None -> Error (Printf.sprintf "%s dispatch unavailable" tool_name)
@@ -2860,6 +3098,127 @@ let execute_action (ctx : 'a context) (request : action_request) :
             ("delegated_tool", `String "masc_keeper_msg");
             ("result", json_of_dispatch_output body);
           ])
+  | "swarm_run_continue" ->
+      let* () = validate_target_type "swarm_run" request in
+      let swarm_json = swarm_run_json_for_request ctx request in
+      let* swarm_json = swarm_json in
+      let operation_id = swarm_run_operation_id swarm_json in
+      let detachment_id = swarm_run_detachment_id swarm_json in
+      let pending_decisions =
+        swarm_json |> U.member "summary" |> U.member "pending_decisions"
+        |> U.to_int_option |> Option.value ~default:0
+      in
+      if pending_decisions > 0 then
+        Error "swarm run has pending approvals; resolve approvals before continue"
+      else
+        let steps =
+          (match
+             swarm_json |> U.member "operation" |> U.member "status"
+             |> U.to_string_option
+           with
+          | Some "paused" -> [ ("masc_operation_resume", `Assoc [ ("operation_id", option_to_json (fun value -> `String value) operation_id) ]) ]
+          | _ -> [])
+          @
+          (match operation_id, detachment_id with
+          | Some value, _ ->
+              [ ("masc_dispatch_tick", `Assoc [ ("operation_id", `String value) ]) ]
+          | None, Some value ->
+              [ ("masc_dispatch_tick", `Assoc [ ("detachment_id", `String value) ]) ]
+          | None, None -> [])
+        in
+        if steps = [] then
+          Error "swarm run has no resumable managed operation or detachment"
+        else
+          let* results =
+            steps
+            |> List.fold_left
+                 (fun acc (tool_name, args) ->
+                   let* collected = acc in
+                   let* result_json =
+                     dispatch_command_plane_json ctx ~tool_name ~args
+                   in
+                   Ok
+                     (collected
+                     @ [
+                         `Assoc
+                           [
+                             ("tool", `String tool_name);
+                             ("args", args);
+                             ("result", result_json);
+                           ];
+                       ]))
+                 (Ok [])
+          in
+          let run_id = Option.value ~default:"swarm-live" request.target_id in
+          let reason =
+            swarm_run_reason swarm_json
+              "command-plane recovery chain executed for swarm-live run"
+          in
+          let resolution =
+            Command_plane_v2.record_swarm_run_resolution_json ctx.config ~run_id
+              ~status:"continued" ~actor:request.actor ~reason ?operation_id
+              ?detachment_id
+              ?note:(Some "operator continue chain executed") ()
+          in
+          Ok
+            (`Assoc
+              [
+                ("delegated_tool", `String "swarm_run_continue_chain");
+                ("delegated_tools", `List (List.map (fun (tool_name, _) -> `String tool_name) steps));
+                ("result", `List results);
+                ("resolution", resolution);
+              ])
+  | "swarm_run_rerun" ->
+      let* () = validate_target_type "swarm_run" request in
+      let swarm_json = swarm_run_json_for_request ctx request in
+      let* swarm_json = swarm_json in
+      let run_id = Option.value ~default:"swarm-live" request.target_id in
+      let args = `Assoc [ ("run_id", `String run_id) ] in
+      let* rerun_result =
+        dispatch_command_plane_json ctx ~tool_name:"masc_swarm_live_run" ~args
+      in
+      let resolution =
+        Command_plane_v2.record_swarm_run_resolution_json ctx.config ~run_id
+          ~status:"rerun" ~actor:request.actor
+          ~reason:
+            (swarm_run_reason swarm_json
+               "swarm-live harness rerun requested through operator control")
+          ?operation_id:(swarm_run_operation_id swarm_json)
+          ?detachment_id:(swarm_run_detachment_id swarm_json)
+          ?note:(Some "operator rerun executed") ()
+      in
+      Ok
+        (`Assoc
+          [
+            ("delegated_tool", `String "masc_swarm_live_run");
+            ("delegated_tools", `List [ `String "masc_swarm_live_run" ]);
+            ("result", rerun_result);
+            ("resolution", resolution);
+          ])
+  | "swarm_run_abandon" ->
+      let* () = validate_target_type "swarm_run" request in
+      let swarm_json = swarm_run_json_for_request ctx request in
+      let* swarm_json = swarm_json in
+      let run_id = Option.value ~default:"swarm-live" request.target_id in
+      let resolution =
+        Command_plane_v2.record_swarm_run_resolution_json ctx.config ~run_id
+          ~status:"abandoned" ~actor:request.actor
+          ~reason:
+            (get_string request.payload "reason"
+               (swarm_run_reason swarm_json
+                  "swarm-live run was soft-abandoned by operator"))
+          ?operation_id:(swarm_run_operation_id swarm_json)
+          ?detachment_id:(swarm_run_detachment_id swarm_json)
+          ?note:(Some "soft abandon; no operation stop issued") ()
+      in
+      Ok
+        (`Assoc
+          [
+            ("delegated_tool", `String "swarm_run_resolution");
+            ("delegated_tools", `List []);
+            ("result", `Assoc [ ("recorded", `Bool true) ]);
+            ("resolution", resolution);
+          ])
   | "task_inject" ->
       let* () = validate_target_type "room" request in
       let title =
@@ -2888,12 +3247,15 @@ let validate_request request =
   | "team_turn" | "team_note"
   | "team_broadcast" | "team_task_inject" | "team_worker_spawn_batch"
   | "team_stop"
-  | "keeper_message" | "keeper_probe" | "keeper_recover" | "task_inject" ->
+  | "keeper_message" | "keeper_probe" | "keeper_recover"
+  | "swarm_run_continue" | "swarm_run_rerun" | "swarm_run_abandon"
+  | "task_inject" ->
       Ok ()
   | "" -> Error "action_type is required"
   | other -> Error (Printf.sprintf "unsupported action_type: %s" other)
 
-let action_json ?actor_hint (ctx : 'a context) args =
+let action_json ?actor_hint (ctx : _ context) args :
+    (Yojson.Safe.t, string) result =
   let request = action_request_of_args ?actor_hint ctx args in
   let* () = validate_request request in
   let delegated_tool = delegated_tool_for request.action_type in
@@ -2902,6 +3264,14 @@ let action_json ?actor_hint (ctx : 'a context) args =
   if confirm_required request.action_type then (
     let expires_at = iso_of_unix (Unix.gettimeofday () +. remote_confirm_ttl_seconds) in
     let* token = generate_confirm_token ~clock:ctx.clock ctx.config in
+    let preview =
+      match request.action_type with
+      | "swarm_run_continue" | "swarm_run_rerun" | "swarm_run_abandon" -> (
+          match swarm_run_json_for_request ctx request with
+          | Ok swarm_json -> swarm_run_chain_preview request swarm_json
+          | Error _ -> preview_of_action request)
+      | _ -> preview_of_action request
+    in
     let entry =
       {
         token;
@@ -2938,7 +3308,7 @@ let action_json ?actor_hint (ctx : 'a context) args =
            ("trace_id", `String trace_id);
            ("confirm_required", `Bool true);
            ("confirm_token", `String entry.token);
-           ("preview", preview_of_action request);
+           ("preview", preview);
            ("delegated_tool", `String delegated_tool);
            ("expires_at", `String expires_at);
          ]))
@@ -2969,7 +3339,8 @@ let action_json ?actor_hint (ctx : 'a context) args =
            ("result", executed);
          ])
 
-let confirm_json ?actor_hint (ctx : 'a context) args =
+let confirm_json ?actor_hint (ctx : _ context) args :
+    (Yojson.Safe.t, string) result =
   let actor =
     normalized_actor ~context_actor:ctx.agent_name
       (match get_string_opt args "actor" with

--- a/lib/operator_control.mli
+++ b/lib/operator_control.mli
@@ -30,12 +30,12 @@ val digest_json :
 
 val action_json :
   ?actor_hint:string ->
-  'a context ->
+  float Eio.Time.clock_ty context ->
   Yojson.Safe.t ->
   (Yojson.Safe.t, string) result
 
 val confirm_json :
   ?actor_hint:string ->
-  'a context ->
+  float Eio.Time.clock_ty context ->
   Yojson.Safe.t ->
   (Yojson.Safe.t, string) result

--- a/lib/tool_operator.ml
+++ b/lib/tool_operator.ml
@@ -28,13 +28,16 @@ let strict_action_enums =
     `String "keeper_message";
     `String "keeper_probe";
     `String "keeper_recover";
+    `String "swarm_run_continue";
+    `String "swarm_run_rerun";
+    `String "swarm_run_abandon";
   ]
 
 let legacy_action_alias_enums =
   [ `String "team_turn"; `String "keeper_msg"; `String "task_inject" ]
 
 let target_type_enums =
-  [ `String "room"; `String "team_session"; `String "keeper" ]
+  [ `String "room"; `String "team_session"; `String "keeper"; `String "swarm_run" ]
 
 let snapshot_schema ~remote =
   {

--- a/test/test_command_plane_v2.ml
+++ b/test/test_command_plane_v2.ml
@@ -1590,6 +1590,81 @@ let test_swarm_live_json_reads_runtime_doctor_and_blockers () =
                 (row |> member "code" |> to_string)
                 "provider_unreachable")))
 
+let test_swarm_live_json_recommends_rerun_without_resumable_state () =
+  let base_dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base_dir)
+    (fun () ->
+      let config = Room.default_config base_dir in
+      ignore (Room.init config ~agent_name:(Some "owner"));
+      let swarm = Command_plane_v2.swarm_live_json config ~run_id:"empty-swarm-run" () in
+      let open Yojson.Safe.Util in
+      Alcotest.(check string) "rerun recommendation" "rerun"
+        (swarm |> member "resolution_recommendation" |> member "recommended_kind"
+       |> to_string);
+      Alcotest.(check bool) "continue unavailable" false
+        (swarm |> member "resolution_recommendation" |> member "continue_available"
+       |> to_bool);
+      Alcotest.(check bool) "rerun available" true
+        (swarm |> member "resolution_recommendation" |> member "rerun_available"
+       |> to_bool))
+
+let test_swarm_live_json_recommends_continue_for_paused_run_and_hides_after_abandon () =
+  let base_dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base_dir)
+    (fun () ->
+      let owner = "owner-root-node" in
+      let alpha_lead = "alpha-lead-node" in
+      let alpha_two = "alpha-two-node" in
+      let run_id = "paused-swarm-run" in
+      let config = Room.default_config base_dir in
+      setup_company_and_platoon config ~owner ~alpha_lead ~alpha_two;
+      let operation =
+        start_operation_exn config ~actor:"owner"
+          (`Assoc
+            [
+              ("assigned_unit_id", `String "platoon-alpha");
+              ("objective", `String "Paused swarm live harness");
+              ("note", `String (Printf.sprintf "run_id=%s" run_id));
+              ("policy_class", `String "guarded");
+              ("budget_class", `String "standard");
+            ])
+      in
+      ignore
+        (unwrap_ok
+           (Command_plane_v2.dispatch_tick_json config ~actor:"owner"
+              (`Assoc [ ("operation_id", `String operation.operation_id) ])));
+      ignore
+        (unwrap_ok
+           (Command_plane_v2.pause_operation_json config ~actor:"owner"
+              (`Assoc [ ("operation_id", `String operation.operation_id) ])));
+      let before =
+        Command_plane_v2.swarm_live_json config ~run_id
+          ~operation_id:operation.operation_id ()
+      in
+      let open Yojson.Safe.Util in
+      Alcotest.(check string) "continue recommendation" "continue"
+        (before |> member "resolution_recommendation" |> member "recommended_kind"
+       |> to_string);
+      let resolution =
+        Command_plane_v2.record_swarm_run_resolution_json config ~run_id
+          ~status:"abandoned" ~actor:"owner"
+          ~reason:"operator chose soft abandon"
+          ~operation_id:operation.operation_id
+          ?note:(Some "test abandon") ()
+      in
+      Alcotest.(check string) "resolution written" "abandoned"
+        (resolution |> member "status" |> to_string);
+      let after =
+        Command_plane_v2.swarm_live_json config ~run_id
+          ~operation_id:operation.operation_id ()
+      in
+      Alcotest.(check string) "persisted run resolution" "abandoned"
+        (after |> member "run_resolution" |> member "status" |> to_string);
+      Alcotest.(check bool) "recommendation suppressed" true
+        (after |> member "resolution_recommendation" = `Null))
+
 let test_best_first_search_blocks_and_routes_research_pipeline () =
   let base_dir = temp_dir () in
   Fun.protect
@@ -1967,6 +2042,10 @@ let () =
             test_swarm_live_json_reads_custom_worker_count_from_operation_note;
           Alcotest.test_case "swarm live reads runtime doctor and blockers" `Quick
             test_swarm_live_json_reads_runtime_doctor_and_blockers;
+          Alcotest.test_case "swarm live recommends rerun without resumable state" `Quick
+            test_swarm_live_json_recommends_rerun_without_resumable_state;
+          Alcotest.test_case "swarm live recommends continue and hides after abandon" `Quick
+            test_swarm_live_json_recommends_continue_for_paused_run_and_hides_after_abandon;
           Alcotest.test_case "swarm live wrapper persists summary" `Quick
             test_swarm_live_run_with_runner_persists_summary;
           Alcotest.test_case "swarm live wrapper reports runner exceptions" `Quick

--- a/test/test_operator_control.ml
+++ b/test/test_operator_control.ml
@@ -69,6 +69,60 @@ let start_session_exn ctx =
   json |> result_field |> Yojson.Safe.Util.member "session_id"
   |> Yojson.Safe.Util.to_string
 
+let unit_update_exn config ~actor args =
+  match Command_plane_v2.unit_update_json config ~actor args with
+  | Ok _ -> ()
+  | Error message -> failwith message
+
+let start_operation_exn config ~actor args =
+  match Command_plane_v2.start_operation config ~actor args with
+  | Ok operation -> operation
+  | Error message -> failwith message
+
+let setup_swarm_run_env config ~owner ~worker_one ~worker_two ~run_id =
+  ignore (Room.init config ~agent_name:(Some "owner"));
+  ignore (Room.join config ~agent_name:owner ~capabilities:[] ());
+  ignore (Room.join config ~agent_name:worker_one ~capabilities:[] ());
+  ignore (Room.join config ~agent_name:worker_two ~capabilities:[] ());
+  unit_update_exn config ~actor:owner
+    (`Assoc
+      [
+        ("unit_id", `String "company-main");
+        ("kind", `String "company");
+        ("label", `String "Main Company");
+        ("leader_id", `String owner);
+        ("roster", `List [ `String owner; `String worker_one; `String worker_two ]);
+      ]);
+  unit_update_exn config ~actor:owner
+    (`Assoc
+      [
+        ("unit_id", `String "platoon-alpha");
+        ("kind", `String "platoon");
+        ("label", `String "Alpha Platoon");
+        ("parent_unit_id", `String "company-main");
+        ("leader_id", `String worker_one);
+        ("roster", `List [ `String worker_one; `String worker_two ]);
+      ]);
+  let operation =
+    start_operation_exn config ~actor:owner
+      (`Assoc
+        [
+          ("assigned_unit_id", `String "company-main");
+          ("objective", `String "Operator swarm resolution test");
+          ("note", `String (Printf.sprintf "run_id=%s" run_id));
+          ("policy_class", `String "guarded");
+          ("budget_class", `String "standard");
+        ])
+  in
+  ignore
+    (match
+       Command_plane_v2.dispatch_tick_json config ~actor:owner
+         (`Assoc [ ("operation_id", `String operation.operation_id) ])
+     with
+    | Ok _ -> ()
+    | Error message -> failwith message);
+  operation
+
 let test_snapshot_has_expected_sections () =
   Eio_main.run @@ fun env ->
   Eio.Switch.run @@ fun sw ->
@@ -911,6 +965,136 @@ let test_confirm_rejects_expired_token () =
           Alcotest.(check string) "expired error"
             "pending confirmation expired" err)
 
+let test_swarm_run_continue_requires_confirm_then_executes () =
+  Eio_main.run @@ fun env ->
+  Eio.Switch.run @@ fun sw ->
+  let base_dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base_dir)
+    (fun () ->
+      let config = Room.default_config base_dir in
+      let run_id = "operator-swarm-continue" in
+      let operation =
+        setup_swarm_run_env config ~owner:"owner-root-node"
+          ~worker_one:"alpha-lead-node" ~worker_two:"alpha-two-node" ~run_id
+      in
+      ignore
+        (match
+           Command_plane_v2.pause_operation_json config ~actor:"owner"
+             (`Assoc [ ("operation_id", `String operation.operation_id) ])
+         with
+        | Ok _ -> ()
+        | Error message -> failwith message);
+      let ctx = operator_ctx env sw config "dashboard" in
+      let action_json =
+        Operator_control.action_json ctx
+          (`Assoc
+            [
+              ("actor", `String "dashboard");
+              ("action_type", `String "swarm_run_continue");
+              ("target_type", `String "swarm_run");
+              ("target_id", `String run_id);
+              ("payload", `Assoc [ ("operation_id", `String operation.operation_id) ]);
+            ])
+      in
+      let action_json =
+        match action_json with
+        | Ok json -> json
+        | Error err -> Alcotest.fail err
+      in
+      Alcotest.(check bool) "confirm required" true
+        Yojson.Safe.Util.(action_json |> member "confirm_required" |> to_bool);
+      Alcotest.(check string) "delegated tool" "swarm_run_continue_chain"
+        Yojson.Safe.Util.(action_json |> member "delegated_tool" |> to_string);
+      Alcotest.(check string) "preview kind" "continue"
+        Yojson.Safe.Util.(action_json |> member "preview" |> member "resolution_kind" |> to_string);
+      Alcotest.(check int) "preview step count" 2
+        Yojson.Safe.Util.(action_json |> member "preview" |> member "tool_chain_preview" |> to_list |> List.length);
+      let confirm_token =
+        Yojson.Safe.Util.(action_json |> member "confirm_token" |> to_string)
+      in
+      let confirm_json =
+        Operator_control.confirm_json ctx
+          (`Assoc
+            [
+              ("actor", `String "dashboard");
+              ("confirm_token", `String confirm_token);
+            ])
+      in
+      let confirm_json =
+        match confirm_json with
+        | Ok json -> json
+        | Error err -> Alcotest.fail err
+      in
+      let delegated_result = Yojson.Safe.Util.member "delegated_tool_result" confirm_json in
+      Alcotest.(check int) "executed steps" 2
+        Yojson.Safe.Util.(delegated_result |> member "result" |> to_list |> List.length);
+      Alcotest.(check string) "resolution persisted" "continued"
+        Yojson.Safe.Util.(delegated_result |> member "resolution" |> member "status" |> to_string))
+
+let test_swarm_run_abandon_records_soft_resolution () =
+  Eio_main.run @@ fun env ->
+  Eio.Switch.run @@ fun sw ->
+  let base_dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base_dir)
+    (fun () ->
+      let config = Room.default_config base_dir in
+      let run_id = "operator-swarm-abandon" in
+      let operation =
+        setup_swarm_run_env config ~owner:"owner-root-node"
+          ~worker_one:"alpha-lead-node" ~worker_two:"alpha-two-node" ~run_id
+      in
+      let ctx = operator_ctx env sw config "dashboard" in
+      let action_json =
+        Operator_control.action_json ctx
+          (`Assoc
+            [
+              ("actor", `String "dashboard");
+              ("action_type", `String "swarm_run_abandon");
+              ("target_type", `String "swarm_run");
+              ("target_id", `String run_id);
+              ("payload", `Assoc [ ("reason", `String "operator chose to move on") ]);
+            ])
+      in
+      let action_json =
+        match action_json with
+        | Ok json -> json
+        | Error err -> Alcotest.fail err
+      in
+      Alcotest.(check bool) "confirm required" true
+        Yojson.Safe.Util.(action_json |> member "confirm_required" |> to_bool);
+      let confirm_token =
+        Yojson.Safe.Util.(action_json |> member "confirm_token" |> to_string)
+      in
+      let confirm_json =
+        Operator_control.confirm_json ctx
+          (`Assoc
+            [
+              ("actor", `String "dashboard");
+              ("confirm_token", `String confirm_token);
+            ])
+      in
+      let confirm_json =
+        match confirm_json with
+        | Ok json -> json
+        | Error err -> Alcotest.fail err
+      in
+      let delegated_result = Yojson.Safe.Util.member "delegated_tool_result" confirm_json in
+      Alcotest.(check string) "delegated tool" "swarm_run_resolution"
+        Yojson.Safe.Util.(delegated_result |> member "delegated_tool" |> to_string);
+      Alcotest.(check string) "resolution persisted" "abandoned"
+        Yojson.Safe.Util.(delegated_result |> member "resolution" |> member "status" |> to_string);
+      let operation_status =
+        Command_plane_v2.operation_status_json config ~operation_id:operation.operation_id ()
+        |> Yojson.Safe.Util.member "operations"
+        |> Yojson.Safe.Util.index 0
+        |> Yojson.Safe.Util.member "operation"
+        |> Yojson.Safe.Util.member "status"
+        |> Yojson.Safe.Util.to_string
+      in
+      Alcotest.(check string) "operation not stopped" "active" operation_status)
+
 let test_snapshot_exposes_keeper_and_lodge_actions () =
   Eio_main.run @@ fun env ->
   Eio.Switch.run @@ fun sw ->
@@ -956,7 +1140,16 @@ let test_snapshot_exposes_keeper_and_lodge_actions () =
           Alcotest.(check string) "keeper_recover target_type" "keeper"
             Yojson.Safe.Util.(keeper_recover |> member "target_type" |> to_string);
           Alcotest.(check bool) "keeper_recover confirm false" false
-            Yojson.Safe.Util.(keeper_recover |> member "confirm_required" |> to_bool))
+            Yojson.Safe.Util.(keeper_recover |> member "confirm_required" |> to_bool);
+          let swarm_continue =
+            match find_action "swarm_run_continue" with
+            | Some row -> row
+            | None -> Alcotest.fail "expected swarm_run_continue in available_actions"
+          in
+          Alcotest.(check string) "swarm continue target_type" "swarm_run"
+            Yojson.Safe.Util.(swarm_continue |> member "target_type" |> to_string);
+          Alcotest.(check bool) "swarm continue confirm true" true
+            Yojson.Safe.Util.(swarm_continue |> member "confirm_required" |> to_bool))
 
 let test_select_checkin_agents_manual_override_quiet_hours () =
   let current_hour = Lodge_heartbeat.current_hour_kst () in
@@ -1126,5 +1319,9 @@ let () =
             test_manual_lodge_tick_updates_observable_state;
           Alcotest.test_case "expired confirmation rejected" `Quick
             test_confirm_rejects_expired_token;
+          Alcotest.test_case "swarm run continue confirm flow" `Quick
+            test_swarm_run_continue_requires_confirm_then_executes;
+          Alcotest.test_case "swarm run abandon soft resolution" `Quick
+            test_swarm_run_abandon_records_soft_resolution;
         ] );
     ]


### PR DESCRIPTION
## Summary
- add operator-owned swarm-live run resolution recommendations and persisted resolution state
- add preview-confirm operator actions for continue, rerun, and soft abandon
- surface the new resolution card in War Room and Swarm views

## Verification
- dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/feat-swarm-run-resolution
- dune exec --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/feat-swarm-run-resolution ./test/test_command_plane_v2.exe
- dune exec --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/feat-swarm-run-resolution ./test/test_operator_control.exe
- ./node_modules/.bin/tsc --noEmit --pretty false
