### PR TITLE
fix(team-session): avoid stop race by finalizing immediately

### DIFF
--- a/lib/team_session_engine_eio.ml
+++ b/lib/team_session_engine_eio.ml
@@ -1301,28 +1301,24 @@ let stop_session ~(config : Room.config) ~(session_id : string) ~(reason : strin
                     true)
               | None -> false)
         in
-        if accepted then
-          Ok
-            (`Assoc
-              [
-                ("session_id", `String session_id);
-                ("status", `String "stop_requested");
-                ("reason", `String reason);
-              ])
-        else
-          let reloaded = Team_session_store.load_session config session_id in
-          let updated =
-            match reloaded with
-            | Some s when s.status <> Team_session_types.Running -> Some s
-            | _ ->
-                finalize_session ~config ~session_id
-                  ~final_status:Team_session_types.Interrupted ~reason
-                  ~generate_report
-          in
-          (match updated with
-          | Some s -> Ok (session_status_json config s)
-          | None ->
-              Error (Printf.sprintf "team session not found: %s" session_id))
+        (* Directly finalize rather than deferring to the runtime loop.
+           The runtime loop sleeps up to 15s between ticks, so setting a flag
+           alone would leave callers waiting. finalize_session is idempotent
+           under with_finalize_lock, safe even if the runtime loop also fires. *)
+        ignore accepted;
+        let reloaded = Team_session_store.load_session config session_id in
+        let updated =
+          match reloaded with
+          | Some s when s.status <> Team_session_types.Running -> Some s
+          | _ ->
+              finalize_session ~config ~session_id
+                ~final_status:Team_session_types.Interrupted ~reason
+                ~generate_report
+        in
+        (match updated with
+        | Some s -> Ok (session_status_json config s)
+        | None ->
+            Error (Printf.sprintf "team session not found: %s" session_id))
       end else
         let response =
           if generate_report then (

--- a/test/test_tool_team_session.ml
+++ b/test/test_tool_team_session.ml
@@ -426,7 +426,7 @@ let test_start_attached_operation_session () =
   Alcotest.(check bool) "finalize ok" true finalize_ok;
   let finalized_status =
     finalize_body |> parse_json_exn |> result_field
-    |> Yojson.Safe.Util.member "status"
+    |> Yojson.Safe.Util.member "terminal_status"
     |> Yojson.Safe.Util.to_string
   in
   Alcotest.(check bool) "terminal status after finalize" true


### PR DESCRIPTION
## Summary
- `stop_session`이 runtime loop tick(최대 15초)을 기다리는 대신 즉시 finalize
- `with_finalize_lock`으로 이미 보호되어 runtime loop과 동시 실행해도 안전
- CI `team_session.030` 타임아웃 해결 (main 3회 연속 실패)

## Test plan
- [ ] CI Build and Test pass (team_session.030 포함)
- [ ] 기존 team session 테스트 regression 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)