### PR TITLE
fix(team-session): stop_session directly finalizes instead of deferring to runtime loop

### DIFF
--- a/lib/team_session_engine_eio.ml
+++ b/lib/team_session_engine_eio.ml
@@ -1301,28 +1301,24 @@ let stop_session ~(config : Room.config) ~(session_id : string) ~(reason : strin
                     true)
               | None -> false)
         in
-        if accepted then
-          Ok
-            (`Assoc
-              [
-                ("session_id", `String session_id);
-                ("status", `String "stop_requested");
-                ("reason", `String reason);
-              ])
-        else
-          let reloaded = Team_session_store.load_session config session_id in
-          let updated =
-            match reloaded with
-            | Some s when s.status <> Team_session_types.Running -> Some s
-            | _ ->
-                finalize_session ~config ~session_id
-                  ~final_status:Team_session_types.Interrupted ~reason
-                  ~generate_report
-          in
-          (match updated with
-          | Some s -> Ok (session_status_json config s)
-          | None ->
-              Error (Printf.sprintf "team session not found: %s" session_id))
+        (* Directly finalize rather than deferring to the runtime loop.
+           The runtime loop sleeps up to 15s between ticks, so setting a flag
+           alone would leave callers waiting. finalize_session is idempotent
+           under with_finalize_lock, safe even if the runtime loop also fires. *)
+        ignore accepted;
+        let reloaded = Team_session_store.load_session config session_id in
+        let updated =
+          match reloaded with
+          | Some s when s.status <> Team_session_types.Running -> Some s
+          | _ ->
+              finalize_session ~config ~session_id
+                ~final_status:Team_session_types.Interrupted ~reason
+                ~generate_report
+        in
+        (match updated with
+        | Some s -> Ok (session_status_json config s)
+        | None ->
+            Error (Printf.sprintf "team session not found: %s" session_id))
       end else
         let response =
           if generate_report then (

--- a/test/test_tool_team_session.ml
+++ b/test/test_tool_team_session.ml
@@ -426,7 +426,7 @@ let test_start_attached_operation_session () =
   Alcotest.(check bool) "finalize ok" true finalize_ok;
   let finalized_status =
     finalize_body |> parse_json_exn |> result_field
-    |> Yojson.Safe.Util.member "status"
+    |> Yojson.Safe.Util.member "terminal_status"
     |> Yojson.Safe.Util.to_string
   in
   Alcotest.(check bool) "terminal status after finalize" true


### PR DESCRIPTION
## Summary
- `stop_session`이 runtime loop에 플래그만 설정하고 대기하는 대신, `finalize_session`을 직접 호출하도록 변경
- runtime loop이 최대 15초 sleep하므로, `handle_finalize`의 5초 wait timeout 내에 터미널 상태에 도달하지 못하는 타이밍 버그 수정
- 테스트에서 `"status"` (전체 객체) 대신 `"terminal_status"` (문자열)를 읽도록 수정

## Root Cause
`start_runtime_loop`의 fiber가 `Eio.Time.sleep clock (min 15.0 ...)` 으로 최대 15초 sleep. `stop_session`이 `stop_requested` 플래그만 설정하면, `handle_finalize`의 `wait_terminal` (25 polls × 0.2s = 5s)이 타임아웃.

## Fix
`finalize_session`은 `with_finalize_lock`으로 보호되고, status 체크로 idempotent. runtime loop이 나중에 같은 호출을 해도 안전.

## Test plan
- [x] `team_session.001` (start-attached-operation-session) 통과
- [x] 전체 31개 team_session 테스트 통과 (regression 없음)
- [ ] CI green 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)