### PR TITLE
fix(test): align migration message assertions with production code

### DIFF
--- a/test/test_spawn.ml
+++ b/test/test_spawn.ml
@@ -129,7 +129,7 @@ let test_spawn_bare_ollama_rejected () =
   Alcotest.(check bool) "spawn rejected" false result.Spawn.success;
   Alcotest.(check int) "exit code" 2 result.Spawn.exit_code;
   Alcotest.(check bool) "migration message" true
-    (contains result.Spawn.output "ollama:<model>")
+    (contains result.Spawn.output "llama:<model>")
 
 let tests = [
   Alcotest.test_case "get_config known agents" `Quick test_get_config_known_agents;

--- a/test/test_spawn_coverage.ml
+++ b/test/test_spawn_coverage.ml
@@ -294,7 +294,7 @@ let test_spawn_bare_ollama_rejected () =
     (try
        let _ =
          Str.search_forward
-           (Str.regexp_string "ollama:<model>")
+           (Str.regexp_string "llama:<model>")
            result.Spawn.output 0
        in
        true

--- a/test/test_spawn_eio_coverage.ml
+++ b/test/test_spawn_eio_coverage.ml
@@ -364,7 +364,7 @@ let test_spawn_bare_ollama_rejected () =
     (try
        let _ =
          Str.search_forward
-           (Str.regexp_string "ollama:<model>")
+           (Str.regexp_string "llama:<model>")
            result.output 0
        in
        true

--- a/test/test_tool_mitosis_coverage.ml
+++ b/test/test_tool_mitosis_coverage.ml
@@ -135,7 +135,7 @@ let test_dispatch_mitosis_handoff_rejects_bare_ollama_target () =
         (try
            let _ =
              Str.search_forward
-               (Str.regexp_string "ollama:<model>")
+               (Str.regexp_string "llama:<model>")
                result 0
            in
            true


### PR DESCRIPTION
## Summary

- PR #785 merged `bare_ollama_migration_message()` recommending `llama:<model>` (correct — `ollama` is not a valid provider label)
- 4 test files still asserted against `"ollama:<model>"` causing CI failures on main
- Updated all 4 test assertions to match the actual production message `"llama:<model>"`

## Changed files
- `test/test_spawn.ml`
- `test/test_spawn_coverage.ml`
- `test/test_spawn_eio_coverage.ml`
- `test/test_tool_mitosis_coverage.ml`

## Test plan
- [x] Individual test suites pass (test_spawn, test_spawn_coverage, test_spawn_eio_coverage, test_tool_mitosis_coverage)
- [x] operator:15 test passes
- [ ] Full CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)