### PR TITLE
fix: align ollama migration messages to llama:<model>

### DIFF
--- a/lib/provider_adapter.ml
+++ b/lib/provider_adapter.ml
@@ -233,7 +233,7 @@ let dedupe_keep_order items =
     items
 
 let bare_ollama_migration_message () =
-  "Bare `ollama` is no longer supported. Use `ollama:<model>` for provider selection, or use `llama`/`glm` for local execution."
+  "Bare `ollama` is no longer supported. Use `llama:<model>` for local execution, or choose another supported provider label explicitly."
 
 let is_bare_ollama_label label =
   String.equal (normalize_label label) "ollama"

--- a/lib/tools.ml
+++ b/lib/tools.ml
@@ -2251,7 +2251,7 @@ Embodies proactive mitosis: prepare early at 50%, handoff at 80%.|};
         ]);
         ("target_agent", `Assoc [
           ("type", `String "string");
-          ("description", `String "Agent to spawn: 'claude'|'gemini'|'codex'|'llama' (default: claude). Bare 'ollama' is unsupported; use ollama:<model> only in model fields.");
+          ("description", `String "Agent to spawn: 'claude'|'gemini'|'codex'|'llama' (default: claude). Bare 'ollama' is unsupported; use 'llama:<model>' for local execution.");
         ]);
         ("async", `Assoc [
           ("type", `String "boolean");
@@ -3013,7 +3013,7 @@ Example: masc_a2a_unsubscribe({subscription_id: 'sub-abc123'})";
         ]);
         ("agent_name", `Assoc [
           ("type", `String "string");
-          ("description", `String "Agent to spawn (claude, gemini, codex, llama). Bare 'ollama' is unsupported; use ollama:<model> only in model fields.");
+          ("description", `String "Agent to spawn (claude, gemini, codex, llama). Bare 'ollama' is unsupported; use 'llama:<model>' for local execution.");
         ]);
         ("additional_instructions", `Assoc [
           ("type", `String "string");


### PR DESCRIPTION
## Summary

- `provider_adapter.ml:bare_ollama_migration_message`: `ollama:<model>` → `llama:<model>`
- `tools.ml` (mitosis handover + claim_and_spawn descriptions): same fix, 2 locations

`model_spec_of_string` rejects `ollama:` prefix — so user-facing guidance must point to `llama:<model>`.

Tests on main already assert `"llama:<model>"` and pass only by coincidence (substring match). This PR makes the message text actually correct.

## Test plan

- [x] `test_spawn.exe` — 8/8 pass (includes `bare ollama rejected`)
- [x] `test_spawn_coverage.exe` — 80/80 pass
- [x] `test_tool_mitosis_coverage.exe` — 74/74 pass
- [x] `test_spawn_eio_coverage.exe` — 51/51 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)