### PR TITLE
chore: add missing entries to v2.83.0 CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,11 +24,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Ollama Runtime Removal** — removed Ollama runtime path, LLM calls go through `Lodge_cascade` only (#785)
 - **Dashboard Utils Extraction** — deduplicated 5 utility functions from 12 files into `Dashboard_utils` module (#791)
 - **Transport Deps Injection** — Eio context passed via deps record instead of global singleton (#793)
+- **Keeper Resident Split** — split resident keepers from persistent agents for independent lifecycle (#799)
+- **Dashboard Assets Rebuild** — rebuild stale assets and remove dead batch endpoint code (#798)
 
 ### Fixed
 - Mission briefing async refresh UX with loading states and error recovery (#774)
 - GC archive logic now includes cancelled team-sessions (#777)
 - Team-session `stop_session` directly finalizes instead of deferring to runtime loop (#784, #786)
+- Prevent crash when `LLAMA_DEFAULT_MODEL` unset after Ollama removal (#795)
+- Align migration message test assertions with production code (#794)
 
 ## [2.82.0] - 2026-03-11
 


### PR DESCRIPTION
## Summary
- v2.83.0 CHANGELOG에 누락된 4개 PR 추가
- #794: migration message test 정렬
- #795: LLAMA_DEFAULT_MODEL 미설정 시 crash 방지
- #798: dashboard stale assets 재빌드 + dead code 제거
- #799: resident keeper 분리

## Test plan
- [ ] CHANGELOG 형식 확인
- [ ] 태그 전 머지 필요

🤖 Generated with [Claude Code](https://claude.com/claude-code)