### PR TITLE
refactor(team-session): remove unused accepted binding

### DIFF
--- a/lib/team_session_engine_eio.ml
+++ b/lib/team_session_engine_eio.ml
@@ -1288,24 +1288,17 @@ let stop_session ~(config : Room.config) ~(session_id : string) ~(reason : strin
   | None -> Error (Printf.sprintf "team session not found: %s" session_id)
   | Some session ->
       if session.status = Team_session_types.Running then begin
-        let accepted =
-          with_runtimes_lock (fun () ->
-              match Hashtbl.find_opt runtimes session_id with
-              | Some runtime ->
-                  if runtime.finalizing then
-                    false
-                  else (
-                    runtime.stop_requested <- true;
-                    runtime.stop_reason <- Some reason;
-                    runtime.generate_report_on_finalize <- generate_report;
-                    true)
-              | None -> false)
-        in
+        with_runtimes_lock (fun () ->
+            match Hashtbl.find_opt runtimes session_id with
+            | Some runtime when not runtime.finalizing ->
+                runtime.stop_requested <- true;
+                runtime.stop_reason <- Some reason;
+                runtime.generate_report_on_finalize <- generate_report
+            | _ -> ());
         (* Directly finalize rather than deferring to the runtime loop.
            The runtime loop sleeps up to 15s between ticks, so setting a flag
            alone would leave callers waiting. finalize_session is idempotent
            under with_finalize_lock, safe even if the runtime loop also fires. *)
-        ignore accepted;
         let reloaded = Team_session_store.load_session config session_id in
         let updated =
           match reloaded with


### PR DESCRIPTION
## Summary
- `stop_session`의 `let accepted = ... in ignore accepted` 패턴을 `when` guard 사용하는 unit 표현식으로 변경
- side-effect-only 의도를 명확히 표현하여 코드 가독성 개선
- PR #786 `/simplify` 리뷰에서 발견된 유일한 실행 가능 개선 항목

## Changes
- `lib/team_session_engine_eio.ml`: 1파일, -14/+7 줄

## Test plan
- [x] `dune build` 성공
- [x] `test_tool_team_session.exe` 31개 테스트 전부 통과 (316s)

🤖 Generated with [Claude Code](https://claude.com/claude-code)