### PR TITLE
fix(test): remove runtime dependencies from keeper tests

### DIFF
--- a/test/test_tool_keeper.ml
+++ b/test/test_tool_keeper.ml
@@ -178,20 +178,6 @@ let test_resolved_keeper_skill_route_falls_back_when_agent_parse_missing () =
   check string "primary skill" "masc-heartbeat" resolved.route.primary_skill
 
 let test_keeper_model_set_persists_active_model () =
-  let local_llama_available =
-    try
-      let sock = Unix.socket Unix.PF_INET Unix.SOCK_STREAM 0 in
-      Fun.protect
-        ~finally:(fun () ->
-          try Unix.close sock with Unix.Unix_error _ -> ())
-        (fun () ->
-          Unix.connect sock (Unix.ADDR_INET (Unix.inet_addr_loopback, 8085));
-          true)
-    with Unix.Unix_error _ -> false
-  in
-  if not local_llama_available then
-    check bool "skip when local llama unavailable" true true
-  else
   Eio_main.run @@ fun env ->
   Eio.Switch.run @@ fun sw ->
   let base_dir = temp_dir () in
@@ -214,8 +200,8 @@ let test_keeper_model_set_persists_active_model () =
             [
               ("name", `String "sangsu");
               ("goal", `String "Maintain Sangsu persona");
-              ("models", `List [ `String "llama:qwen3.5-35b-a3b-ud-q8-xl" ]);
-              ("active_model", `String "llama:qwen3.5-35b-a3b-ud-q8-xl");
+              ("models", `List [ `String "custom:initial-model" ]);
+              ("active_model", `String "custom:initial-model");
               ("room_scope", `String "all");
               ("trigger_mode", `String "explicit_only");
               ("mention_targets", `List [ `String "sangsu" ]);
@@ -229,12 +215,12 @@ let test_keeper_model_set_persists_active_model () =
           (`Assoc
             [
               ("name", `String "sangsu");
-              ("model", `String "llama:qwen3.5:35b-a3b");
+              ("model", `String "custom:updated-model");
             ])
       in
       check bool "model set ok" true ok;
       let json = Yojson.Safe.from_string body in
-      check string "active model updated" "llama:qwen3.5:35b-a3b"
+      check string "active model updated" "custom:updated-model"
         Yojson.Safe.Util.(json |> member "active_model" |> to_string);
       let ok, status_body =
         dispatch "masc_keeper_status"
@@ -251,7 +237,7 @@ let test_keeper_model_set_persists_active_model () =
       in
       check bool "status ok" true ok;
       let status_json = Yojson.Safe.from_string status_body in
-      check string "status active model" "llama:qwen3.5:35b-a3b"
+      check string "status active model" "custom:updated-model"
         Yojson.Safe.Util.(status_json |> member "active_model" |> to_string))
 
 let write_persona_profile ~me_root ~persona_name ~content =
@@ -406,7 +392,7 @@ let test_resident_keeper_and_persistent_agent_lists_split () =
             [
               ("name", `String "resident-demo");
               ("goal", `String "Stay resident");
-              ("models", `List [ `String "ollama:glm-4.7-flash" ]);
+              ("models", `List [ `String "custom:test-model" ]);
               ("presence_keepalive", `Bool false);
               ("proactive_enabled", `Bool false);
             ])
@@ -418,7 +404,7 @@ let test_resident_keeper_and_persistent_agent_lists_split () =
             [
               ("name", `String "persistent-demo");
               ("goal", `String "Stay on demand");
-              ("models", `List [ `String "ollama:glm-4.7-flash" ]);
+              ("models", `List [ `String "custom:test-model" ]);
               ("presence_keepalive", `Bool false);
               ("proactive_enabled", `Bool false);
             ])


### PR DESCRIPTION
## Summary

- Test 8 (`keeper_model_set_persists_active_model`): `"llama:..."` → `"custom:..."` — `handle_keeper_model_set`이 Llama provider에 대해 `Tool_llama.fetch_models()`로 런타임 검증을 수행하므로 llama-server 없는 CI에서 실패
- Test 10 (`resident_and_persistent_lists_split`): `"ollama:glm-4.7-flash"` → `"custom:test-model"` — `ollama`는 미등록 provider (ollama != llama.cpp), `model_spec_of_string`이 Error 반환
- Test 8의 llama 포트 8085 TCP guard 제거 (custom provider는 외부 의존성 없음)

## Root Cause

PR #799에서 resident keeper와 persistent agent를 분리하면서 추가된 테스트가 외부 런타임(llama-server, ollama)에 의존하는 모델 스펙을 사용. CI 환경에서는 이 런타임이 없어 실패.

## Test plan

- [x] `dune exec test/test_tool_keeper.exe` — 13/13 통과
- [ ] CI green 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)