### PR TITLE
fix(lodge): fall back to LLAMA_DEFAULT_MODEL when worker model unset

### DIFF
--- a/lib/lodge_worker.ml
+++ b/lib/lodge_worker.ml
@@ -79,8 +79,8 @@ let worker_model_spec () =
       | Some raw when String.trim raw <> "" ->
           Llm_client.model_spec_of_string ("llama:" ^ String.trim raw)
       | _ ->
-          Error
-            "MASC_LODGE_WORKER_MODEL (provider:model) or LLAMA_SWARM_MODEL is required for Lodge MCP workers")
+          Llm_client.model_spec_of_string
+            ("llama:" ^ Env_config.Llama.default_model))
 
 let base_path () =
   Room_utils.resolve_masc_base_path (Sys.getcwd ())


### PR DESCRIPTION
## Summary
- Ollama 제거 후 `MASC_LODGE_WORKER_MODEL` / `LLAMA_SWARM_MODEL` 미설정 시 Lodge 에이전트 전원 스킵되던 문제 수정
- 기존: Error 반환 → 모든 에이전트 `tool_loop_failed`
- 수정: `llama:<LLAMA_DEFAULT_MODEL>` fallback으로 기본 llama-server 모델 사용

## Changes
- `lib/lodge_worker.ml`: Error → `Env_config.Llama.default_model` fallback (2줄)

## Fallback chain (수정 후)
1. `MASC_LODGE_WORKER_MODEL` (명시 지정)
2. `LLAMA_SWARM_MODEL` (swarm 전용)
3. `llama:<LLAMA_DEFAULT_MODEL>` (기본 llama-server 모델)

## Test plan
- [x] `dune build` 성공
- [ ] MASC 서버 재시작 후 Lodge heartbeat tick에서 에이전트 활동 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)