### PR TITLE
fix(operator): make pending confirmations actor-aware

### DIFF
--- a/dashboard/src/api.ts
+++ b/dashboard/src/api.ts
@@ -56,11 +56,19 @@ function getQueryParams(): URLSearchParams {
 
 const DASHBOARD_AGENT_NAME_KEY = 'masc_dashboard_agent_name'
 
+function readStoredAgentName(): string | null {
+  try {
+    return localStorage.getItem(DASHBOARD_AGENT_NAME_KEY)?.trim() || null
+  } catch {
+    return null
+  }
+}
+
 function authHeaders(): Record<string, string> {
   const params = getQueryParams()
   const headers: Record<string, string> = {}
   const token = params.get('token')
-  const storedAgent = localStorage.getItem(DASHBOARD_AGENT_NAME_KEY)?.trim()
+  const storedAgent = readStoredAgentName()
   const agent = params.get('agent') ?? params.get('agent_name') ?? storedAgent
   if (token) headers['Authorization'] = `Bearer ${token}`
   if (agent) headers['X-MASC-Agent'] = agent

--- a/dashboard/src/api.ts
+++ b/dashboard/src/api.ts
@@ -54,11 +54,14 @@ function getQueryParams(): URLSearchParams {
   return new URLSearchParams(window.location.search)
 }
 
+const DASHBOARD_AGENT_NAME_KEY = 'masc_dashboard_agent_name'
+
 function authHeaders(): Record<string, string> {
   const params = getQueryParams()
   const headers: Record<string, string> = {}
   const token = params.get('token')
-  const agent = params.get('agent') ?? params.get('agent_name')
+  const storedAgent = localStorage.getItem(DASHBOARD_AGENT_NAME_KEY)?.trim()
+  const agent = params.get('agent') ?? params.get('agent_name') ?? storedAgent
   if (token) headers['Authorization'] = `Bearer ${token}`
   if (agent) headers['X-MASC-Agent'] = agent
   return headers

--- a/dashboard/src/components/ops/helpers.ts
+++ b/dashboard/src/components/ops/helpers.ts
@@ -2,7 +2,12 @@
 
 import { signal } from '@preact/signals'
 import { showToast } from '../common/toast'
-import type { OperatorAttentionItem, OperatorKeeperSnapshot, OperatorSessionSnapshot } from '../../types'
+import type {
+  OperatorAttentionItem,
+  OperatorKeeperSnapshot,
+  OperatorRecommendedAction,
+  OperatorSessionSnapshot,
+} from '../../types'
 import {
   confirmOperatorPendingAction,
   dispatchOperatorAction,
@@ -29,11 +34,12 @@ export const taskTitle = signal('')
 export const taskDescription = signal('')
 export const taskPriority = signal('2')
 export const selectedSessionId = signal('')
-export const teamTurnKind = signal<'note' | 'broadcast' | 'task'>('note')
+export const teamTurnKind = signal<'note' | 'broadcast' | 'task' | 'worker_spawn_batch'>('note')
 export const teamMessage = signal('')
 export const teamTaskTitle = signal('')
 export const teamTaskDescription = signal('')
 export const teamTaskPriority = signal('2')
+export const teamSpawnBatchJson = signal('')
 export const teamStopReason = signal('운영자 중지 요청')
 export const selectedKeeperName = signal('')
 export const keeperMessage = signal('')
@@ -198,6 +204,8 @@ export function sessionActionLabel(value: typeof teamTurnKind.value): string {
       return '방송'
     case 'task':
       return '작업'
+    case 'worker_spawn_batch':
+      return 'worker 교체'
     default:
       return value
   }
@@ -214,53 +222,96 @@ function workflowPayloadString(
   return null
 }
 
-function workflowTeamTurnKind(context: DashboardWorkflowContext): typeof teamTurnKind.value {
-  if (context.action_type === 'team_task_inject') return 'task'
-  if (context.action_type === 'team_broadcast') return 'broadcast'
-  if (context.action_type === 'team_note') return 'note'
-  if (context.action_type === 'team_turn') {
-    const requested = workflowPayloadString(context.suggested_payload, 'turn_kind')
-    if (requested === 'broadcast' || requested === 'task') return requested
-  }
-  return 'note'
+function payloadRecord(payload: unknown): Record<string, unknown> | null {
+  if (!payload || typeof payload !== 'object' || Array.isArray(payload)) return null
+  return payload as Record<string, unknown>
 }
 
-export function hydrateOpsWorkflow(context: DashboardWorkflowContext): void {
-  const payload = context.suggested_payload
-  if (context.target_type === 'room') {
-    if (context.action_type === 'broadcast') {
-      broadcastMessage.value = workflowPayloadString(payload, 'message') ?? context.summary
+function spawnBatchJsonString(payload: Record<string, unknown> | null): string {
+  if (!payload) return ''
+  const direct = payload.spawn_batch
+  if (direct !== undefined) return prettyJson(direct)
+  return prettyJson(payload)
+}
+
+function hydrateActionForm(input: {
+  action_type?: string | null
+  target_type?: string | null
+  target_id?: string | null
+  payload?: unknown
+  summary: string
+}): void {
+  const payload = payloadRecord(input.payload)
+  if (input.target_type === 'room') {
+    if (input.action_type === 'broadcast') {
+      broadcastMessage.value = workflowPayloadString(payload, 'message') ?? input.summary
       return
     }
-    if (context.action_type === 'task_inject') {
+    if (input.action_type === 'task_inject') {
       taskTitle.value = workflowPayloadString(payload, 'title') ?? '운영자 주입 작업'
-      taskDescription.value = workflowPayloadString(payload, 'description') ?? context.summary
+      taskDescription.value = workflowPayloadString(payload, 'description') ?? input.summary
       taskPriority.value = workflowPayloadString(payload, 'priority') ?? taskPriority.value
+      return
+    }
+    if (input.action_type === 'room_pause') {
+      pauseReason.value = workflowPayloadString(payload, 'reason') ?? input.summary
     }
     return
   }
 
-  if (context.target_type === 'team_session') {
-    if (context.target_id) selectedSessionId.value = context.target_id
-    if (context.action_type === 'team_stop') {
-      teamStopReason.value = workflowPayloadString(payload, 'reason') ?? context.summary
+  if (input.target_type === 'team_session') {
+    if (input.target_id) selectedSessionId.value = input.target_id
+    if (input.action_type === 'team_stop') {
+      teamStopReason.value = workflowPayloadString(payload, 'reason') ?? input.summary
       return
     }
-    teamTurnKind.value = workflowTeamTurnKind(context)
+    teamTurnKind.value =
+      input.action_type === 'team_worker_spawn_batch'
+        ? 'worker_spawn_batch'
+        : input.action_type === 'team_task_inject'
+          ? 'task'
+          : input.action_type === 'team_broadcast'
+            ? 'broadcast'
+            : 'note'
     const message = workflowPayloadString(payload, 'message')
     if (message) teamMessage.value = message
+    if (teamTurnKind.value === 'worker_spawn_batch') {
+      teamSpawnBatchJson.value = spawnBatchJsonString(payload)
+      return
+    }
     if (teamTurnKind.value === 'task') {
       teamTaskTitle.value = workflowPayloadString(payload, 'task_title') ?? workflowPayloadString(payload, 'title') ?? '운영자 주입 작업'
-      teamTaskDescription.value = workflowPayloadString(payload, 'task_description') ?? workflowPayloadString(payload, 'description') ?? context.summary
+      teamTaskDescription.value = workflowPayloadString(payload, 'task_description') ?? workflowPayloadString(payload, 'description') ?? input.summary
       teamTaskPriority.value = workflowPayloadString(payload, 'task_priority') ?? workflowPayloadString(payload, 'priority') ?? teamTaskPriority.value
     }
     return
   }
 
-  if (context.target_type === 'keeper') {
-    if (context.target_id) selectedKeeperName.value = context.target_id
-    keeperMessage.value = workflowPayloadString(payload, 'message') ?? context.summary
+  if (input.target_type === 'keeper') {
+    if (input.target_id) selectedKeeperName.value = input.target_id
+    keeperMessage.value = workflowPayloadString(payload, 'message') ?? input.summary
   }
+}
+
+export function hydrateOpsWorkflow(context: DashboardWorkflowContext): void {
+  hydrateActionForm({
+    action_type: context.action_type,
+    target_type: context.target_type,
+    target_id: context.target_id,
+    payload: context.suggested_payload,
+    summary: context.summary,
+  })
+}
+
+export function hydrateRecommendedAction(item: OperatorRecommendedAction): void {
+  hydrateActionForm({
+    action_type: item.action_type,
+    target_type: item.target_type,
+    target_id: item.target_id ?? null,
+    payload: item.suggested_payload,
+    summary: item.reason,
+  })
+  showToast('추천 액션 payload를 폼에 채웠습니다', 'success')
 }
 
 export function workflowTargetReady(
@@ -280,7 +331,7 @@ export function workflowTargetReady(
 }
 
 async function executeAction(input: {
-  action_type: 'broadcast' | 'room_pause' | 'room_resume' | 'task_inject' | 'team_note' | 'team_broadcast' | 'team_task_inject' | 'team_stop' | 'keeper_message'
+  action_type: 'broadcast' | 'room_pause' | 'room_resume' | 'task_inject' | 'team_note' | 'team_broadcast' | 'team_task_inject' | 'team_worker_spawn_batch' | 'team_stop' | 'keeper_message'
   target_type: 'room' | 'team_session' | 'keeper'
   target_id?: string
   payload: Record<string, unknown>
@@ -365,6 +416,37 @@ export async function submitTeamTurn() {
     return
   }
   const payload: Record<string, unknown> = {}
+  if (teamTurnKind.value === 'worker_spawn_batch') {
+    const raw = teamSpawnBatchJson.value.trim()
+    if (!raw) {
+      showToast('spawn_batch JSON을 먼저 채우세요', 'warning')
+      return
+    }
+    try {
+      const parsed = JSON.parse(raw) as unknown
+      if (Array.isArray(parsed)) {
+        payload.spawn_batch = parsed
+      } else if (parsed && typeof parsed === 'object' && Array.isArray((parsed as Record<string, unknown>).spawn_batch)) {
+        payload.spawn_batch = (parsed as Record<string, unknown>).spawn_batch
+      } else {
+        showToast('spawn_batch는 배열 또는 { spawn_batch: [...] } 형태여야 합니다', 'warning')
+        return
+      }
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'spawn_batch JSON 파싱에 실패했습니다'
+      showToast(message, 'error')
+      return
+    }
+    const result = await executeAction({
+      action_type: 'team_worker_spawn_batch',
+      target_type: 'team_session',
+      target_id: sessionId,
+      payload,
+      successMessage: 'worker 교체 요청을 적용했습니다',
+    })
+    if (result) teamSpawnBatchJson.value = ''
+    return
+  }
   const message = teamMessage.value.trim()
   if (message) payload.message = message
   let actionType: 'team_note' | 'team_broadcast' | 'team_task_inject' = 'team_note'

--- a/dashboard/src/components/ops/helpers.ts
+++ b/dashboard/src/components/ops/helpers.ts
@@ -127,6 +127,8 @@ export function actionTypeLabel(value?: string | null): string {
       return '세션 방송'
     case 'team_task_inject':
       return '세션 작업 주입'
+    case 'team_worker_spawn_batch':
+      return '세션 worker 교체'
     case 'task_inject':
       return '작업 주입'
     case 'team_stop':
@@ -427,13 +429,20 @@ export async function submitKeeperMessage() {
   if (result) keeperMessage.value = ''
 }
 
-export async function confirmPending(confirmToken: string) {
+export async function confirmPending(
+  confirmToken: string,
+  decision: 'confirm' | 'deny' = 'confirm',
+) {
   const actor = actorName.value.trim() || 'dashboard'
   try {
-    await confirmOperatorPendingAction(actor, confirmToken)
-    showToast('확인 실행을 완료했습니다', 'success')
+    await confirmOperatorPendingAction(actor, confirmToken, decision)
+    showToast(decision === 'deny' ? '승인 대기를 거부했습니다' : '확인 실행을 완료했습니다', 'success')
   } catch (err) {
-    const message = err instanceof Error ? err.message : '확인 실행에 실패했습니다'
+    const message = err instanceof Error
+      ? err.message
+      : decision === 'deny'
+        ? '승인 대기 거부에 실패했습니다'
+        : '확인 실행에 실패했습니다'
     showToast(message, 'error')
   }
 }

--- a/dashboard/src/components/ops/index.ts
+++ b/dashboard/src/components/ops/index.ts
@@ -49,6 +49,11 @@ export function Ops() {
   const sessions = snapshot?.sessions ?? []
   const keepers = snapshot?.keepers ?? []
   const pendingConfirms = snapshot?.pending_confirms ?? []
+  const pendingSummary = snapshot?.pending_confirm_summary
+  const visiblePendingCount = pendingSummary?.visible_count ?? pendingConfirms.length
+  const totalPendingCount = pendingSummary?.total_count ?? pendingConfirms.length
+  const hiddenPendingCount = pendingSummary?.hidden_count ?? 0
+  const pendingActorFilter = pendingSummary?.actor_filter?.trim() || null
   const selectedSession = sessions.find(session => session.session_id === selectedSessionId.value) ?? sessions[0] ?? null
   const roomAttention = roomDigest?.attention_items ?? []
   const sessionAttention = roomAttention.filter(isSessionAttention)
@@ -101,11 +106,13 @@ export function Ops() {
     {
       key: 'confirm',
       label: '확인 대기',
-      value: pendingConfirms.length,
-      detail: pendingConfirms.length > 0
+      value: hiddenPendingCount > 0 ? `${visiblePendingCount}/${totalPendingCount}` : visiblePendingCount,
+      detail: visiblePendingCount > 0
         ? '미리보기만 된 개입이 아직 사람 확인을 기다리고 있습니다'
-        : '지금 막혀 있는 확인 대기는 없습니다',
-      tone: pendingConfirms.length > 0 ? 'warn' : 'ok',
+        : hiddenPendingCount > 0 && pendingActorFilter
+          ? `현재 actor(${pendingActorFilter}) 기준으로는 비어 있고, 다른 actor 대기 ${hiddenPendingCount}건이 있습니다`
+          : '지금 막혀 있는 확인 대기는 없습니다',
+      tone: totalPendingCount > 0 ? 'warn' : 'ok',
     },
     {
       key: 'session',
@@ -203,11 +210,15 @@ export function Ops() {
 
       ${(() => {
         const actions: Array<{ label: string; desc: string; tone: OpsPriorityTone; onClick: () => void }> = []
-        if (pendingConfirms.length > 0) {
+        if (visiblePendingCount > 0 || hiddenPendingCount > 0) {
           actions.push({
-            label: `확인 대기 ${pendingConfirms.length}건 처리`,
-            desc: '승인 또는 거부가 필요한 개입이 대기 중입니다',
-            tone: 'bad',
+            label: hiddenPendingCount > 0
+              ? `확인 대기 ${visiblePendingCount}/${totalPendingCount}건 확인`
+              : `확인 대기 ${visiblePendingCount}건 처리`,
+            desc: hiddenPendingCount > 0 && pendingActorFilter
+              ? `현재 actor(${pendingActorFilter}) 기준으로 보이는 queue를 먼저 확인합니다`
+              : '승인 또는 거부가 필요한 개입이 대기 중입니다',
+            tone: visiblePendingCount > 0 ? 'bad' : 'warn',
             onClick: () => {
               const el = document.querySelector('.ops-pending-section')
               el?.scrollIntoView({ behavior: 'smooth' })

--- a/dashboard/src/components/ops/ops-room-column.ts
+++ b/dashboard/src/components/ops/ops-room-column.ts
@@ -33,7 +33,7 @@ export function OpsRoomColumn() {
   const pendingConfirms = snapshot?.pending_confirms ?? []
   const pendingSummary = snapshot?.pending_confirm_summary
   const confirmRequiredActions =
-    pendingSummary?.confirm_required_actions.length
+    pendingSummary
       ? pendingSummary.confirm_required_actions
       : (snapshot?.available_actions ?? []).filter(action => action.confirm_required)
   const actorFilter = pendingSummary?.actor_filter?.trim() || null

--- a/dashboard/src/components/ops/ops-room-column.ts
+++ b/dashboard/src/components/ops/ops-room-column.ts
@@ -13,6 +13,7 @@ import {
   broadcastMessage,
   confirmPending,
   deliveryModeLabel,
+  hydrateRecommendedAction,
   pauseReason,
   prettyJson,
   submitBroadcast,
@@ -159,6 +160,13 @@ export function OpsRoomColumn() {
                   <span>${deliveryModeLabel(item.confirm_required)}</span>
                 </div>
                 <div class="ops-log-body">${item.reason}</div>
+                ${item.suggested_payload ? html`
+                  <div class="ops-confirmation-actions">
+                    <button class="control-btn ghost" onClick=${() => { hydrateRecommendedAction(item) }} disabled=${operatorActionBusy.value}>
+                      폼에 채우기
+                    </button>
+                  </div>
+                ` : null}
               </article>
             `)}
           </div>

--- a/dashboard/src/components/ops/ops-room-column.ts
+++ b/dashboard/src/components/ops/ops-room-column.ts
@@ -30,6 +30,14 @@ export function OpsRoomColumn() {
   const roomDigest = operatorRoomDigest.value
   const room = snapshot?.room ?? {}
   const pendingConfirms = snapshot?.pending_confirms ?? []
+  const pendingSummary = snapshot?.pending_confirm_summary
+  const confirmRequiredActions =
+    pendingSummary?.confirm_required_actions.length
+      ? pendingSummary.confirm_required_actions
+      : (snapshot?.available_actions ?? []).filter(action => action.confirm_required)
+  const actorFilter = pendingSummary?.actor_filter?.trim() || null
+  const hiddenCount = pendingSummary?.hidden_count ?? 0
+  const hiddenActors = pendingSummary?.hidden_actors ?? []
   const recentMessages = snapshot?.recent_messages ?? []
   const recommendedActions = roomDigest?.recommended_actions ?? []
   const roomFeed = recentMessages.slice(0, 5)
@@ -164,7 +172,25 @@ export function OpsRoomColumn() {
           <div class="card-title">승인 대기</div>
           <${PanelSemanticDetails} panelId="intervene.pending_confirmations" compact=${true} />
         </div>
-        <p class="ops-context-note">미리보기만 끝났고 아직 사람이 눌러줘야 하는 액션만 남깁니다.</p>
+        <p class="ops-context-note">
+          ${actorFilter
+            ? `현재 actor ${actorFilter} 기준 queue를 읽습니다. 승인 대기는 즉시 실행이 아니라 preview-confirm 경로를 타는 액션만 쌓입니다.`
+            : '승인 대기는 즉시 실행이 아니라 preview-confirm 경로를 타는 액션만 쌓입니다.'}
+        </p>
+        ${confirmRequiredActions.length > 0 ? html`
+          <div class="ops-log-list">
+            ${confirmRequiredActions.map(item => html`
+              <article key=${`${item.action_type}:${item.target_type}`} class="ops-log-entry">
+                <div class="ops-log-head">
+                  <strong>${actionTypeLabel(item.action_type)}</strong>
+                  <span>${targetTypeLabel(item.target_type)}</span>
+                  <span>${deliveryModeLabel(item.confirm_required)}</span>
+                </div>
+                <div class="ops-log-body">${item.description ?? '설명 확인 필요'}</div>
+              </article>
+            `)}
+          </div>
+        ` : null}
         ${pendingConfirms.length > 0 ? html`
           <div class="ops-confirmation-list">
             ${pendingConfirms.map(item => html`
@@ -179,12 +205,21 @@ export function OpsRoomColumn() {
                   <button class="control-btn" onClick=${() => { void confirmPending(item.confirm_token) }} disabled=${operatorActionBusy.value}>
                     실행
                   </button>
+                  <button class="control-btn ghost" onClick=${() => { void confirmPending(item.confirm_token, 'deny') }} disabled=${operatorActionBusy.value}>
+                    거부
+                  </button>
                   <span class="ops-token">${item.confirm_token}</span>
                 </div>
               </article>
             `)}
           </div>
-        ` : html`<div class="ops-empty">지금 승인 대기는 없습니다.</div>`}
+        ` : html`
+          <div class="ops-empty">
+            ${hiddenCount > 0 && actorFilter
+              ? `현재 선택한 actor(${actorFilter}) 기준 승인 대기는 0건입니다. 다른 actor 대기 ${hiddenCount}건${hiddenActors.length > 0 ? ` · ${hiddenActors.join(', ')}` : ''}`
+              : '지금 승인 대기는 없습니다. 위 목록의 preview-confirm 액션을 먼저 만들어야 여기에 쌓입니다.'}
+          </div>
+        `}
       </section>
 
       <section class="card ops-panel">

--- a/dashboard/src/components/ops/ops-session-column.ts
+++ b/dashboard/src/components/ops/ops-session-column.ts
@@ -8,7 +8,9 @@ import {
   operatorSnapshot,
 } from '../../operator-store'
 import {
+  actionTypeLabel,
   displayStatus,
+  deliveryModeLabel,
   prettyJson,
   selectedSessionId,
   sessionActionLabel,
@@ -16,6 +18,7 @@ import {
   submitTeamTurn,
   targetTypeLabel,
   teamMessage,
+  teamSpawnBatchJson,
   teamStopReason,
   teamTaskDescription,
   teamTaskPriority,
@@ -27,6 +30,7 @@ export function OpsSessionColumn() {
   const snapshot = operatorSnapshot.value
   const sessionDigest = operatorSessionDigest.value
   const sessions = snapshot?.sessions ?? []
+  const availableSessionActions = (snapshot?.available_actions ?? []).filter(action => action.target_type === 'team_session')
   const selectedSession = sessions.find(session => session.session_id === selectedSessionId.value) ?? sessions[0] ?? null
 
   return html`
@@ -100,6 +104,19 @@ export function OpsSessionColumn() {
           <${PanelSemanticDetails} panelId="intervene.action_studio" compact=${true} />
         </div>
         <p class="ops-context-note">선택한 세션에만 메모, 작업, 체크포인트, 중지 요청을 보냅니다.</p>
+        ${availableSessionActions.length > 0 ? html`
+          <div class="ops-log-list">
+            ${availableSessionActions.map(action => html`
+              <article key=${action.action_type} class="ops-log-entry">
+                <div class="ops-log-head">
+                  <strong>${actionTypeLabel(action.action_type)}</strong>
+                  <span>${deliveryModeLabel(action.confirm_required)}</span>
+                </div>
+                <div class="ops-log-body">${action.description ?? '설명 확인 필요'}</div>
+              </article>
+            `)}
+          </div>
+        ` : null}
 
         ${selectedSession ? html`
           <div class="ops-detail-card">
@@ -127,6 +144,7 @@ export function OpsSessionColumn() {
             <option value="note">노트</option>
             <option value="broadcast">방송</option>
             <option value="task">작업</option>
+            <option value="worker_spawn_batch">worker 교체</option>
           </select>
           <button class="control-btn" onClick=${() => { void submitTeamTurn() }} disabled=${operatorActionBusy.value || !selectedSession}>
             적용
@@ -172,6 +190,15 @@ export function OpsSessionColumn() {
             <option value="4">P4</option>
             <option value="5">P5</option>
           </select>
+        ` : teamTurnKind.value === 'worker_spawn_batch' ? html`
+          <textarea
+            class="control-textarea"
+            rows=${6}
+            placeholder='spawn_batch JSON, 예: [{"spawn_agent":"llama","spawn_prompt":"...", "spawn_role":"replacement"}]'
+            value=${teamSpawnBatchJson.value}
+            onInput=${(event: Event) => { teamSpawnBatchJson.value = (event.target as HTMLTextAreaElement).value }}
+            disabled=${operatorActionBusy.value || !selectedSession}
+          ></textarea>
         ` : null}
 
         <div class="control-row ops-split-row">

--- a/dashboard/src/operator-store.ts
+++ b/dashboard/src/operator-store.ts
@@ -3,6 +3,7 @@ import { confirmOperatorAction, fetchOperatorDigest, fetchOperatorSnapshot, runO
 import type {
   Message,
   OperatorActionLogEntry,
+  OperatorActionDescriptor,
   OperatorActionRequest,
   OperatorActionResult,
   OperatorAttentionItem,
@@ -13,6 +14,7 @@ import type {
   OperatorSessionCard,
   OperatorSnapshot,
   OperatorRoomSnapshot,
+  PendingConfirmSummary,
   PendingConfirmation,
   OperatorWorkerCard,
 } from './types'
@@ -250,6 +252,34 @@ function normalizePendingConfirm(raw: unknown): PendingConfirmation | null {
   }
 }
 
+function normalizeActionDescriptor(raw: unknown): OperatorActionDescriptor | null {
+  if (!isRecord(raw)) return null
+  const actionType = asString(raw.action_type)
+  const targetType = asString(raw.target_type)
+  if (!actionType || !targetType) return null
+  return {
+    action_type: actionType,
+    target_type: targetType,
+    description: asString(raw.description),
+    confirm_required: asBoolean(raw.confirm_required),
+  }
+}
+
+function normalizePendingConfirmSummary(raw: unknown): PendingConfirmSummary | null {
+  if (!isRecord(raw)) return null
+  return {
+    actor_filter: asString(raw.actor_filter) ?? null,
+    filter_active: asBoolean(raw.filter_active) ?? false,
+    visible_count: asNumber(raw.visible_count) ?? 0,
+    total_count: asNumber(raw.total_count) ?? 0,
+    hidden_count: asNumber(raw.hidden_count) ?? 0,
+    hidden_actors: asStringArray(raw.hidden_actors),
+    confirm_required_actions: extractArray(raw.confirm_required_actions)
+      .map(normalizeActionDescriptor)
+      .filter((item): item is OperatorActionDescriptor => item !== null),
+  }
+}
+
 function normalizeOperatorSnapshot(raw: unknown): OperatorSnapshot {
   const root = isRecord(raw) ? raw : {}
   return {
@@ -269,14 +299,10 @@ function normalizeOperatorSnapshot(raw: unknown): OperatorSnapshot {
     pending_confirms: extractArray(root.pending_confirms, ['items', 'confirms'])
       .map(normalizePendingConfirm)
       .filter((item): item is PendingConfirmation => item !== null),
+    pending_confirm_summary: normalizePendingConfirmSummary(root.pending_confirm_summary) ?? undefined,
     available_actions: extractArray(root.available_actions, ['actions'])
-      .filter(isRecord)
-      .map(item => ({
-        action_type: asString(item.action_type) ?? 'unknown',
-        target_type: asString(item.target_type) ?? 'unknown',
-        description: asString(item.description),
-        confirm_required: asBoolean(item.confirm_required),
-      })),
+      .map(normalizeActionDescriptor)
+      .filter((item): item is OperatorActionDescriptor => item !== null),
   }
 }
 

--- a/dashboard/src/types.ts
+++ b/dashboard/src/types.ts
@@ -1363,6 +1363,16 @@ export interface OperatorActionDescriptor {
   confirm_required?: boolean
 }
 
+export interface PendingConfirmSummary {
+  actor_filter?: string | null
+  filter_active: boolean
+  visible_count: number
+  total_count: number
+  hidden_count: number
+  hidden_actors: string[]
+  confirm_required_actions: OperatorActionDescriptor[]
+}
+
 export interface OperatorAttentionItem {
   kind: string
   severity: string
@@ -1460,6 +1470,7 @@ export interface OperatorSnapshot {
   swarm_status?: CommandPlaneSwarmStatus
   recent_messages: Message[]
   pending_confirms: PendingConfirmation[]
+  pending_confirm_summary?: PendingConfirmSummary
   available_actions: OperatorActionDescriptor[]
 }
 

--- a/lib/dashboard_semantics.ml
+++ b/lib/dashboard_semantics.ml
@@ -190,10 +190,10 @@ let json () =
                   ~ecosystem_function:"Encourages minimal, reversible supervision."
                   [];
                 panel ~id:"intervene.pending_confirmations" ~title:"Pending Confirmations"
-                  ~purpose:"Makes the confirm gate explicit for disruptive actions."
-                  ~problem_solved:"Prevents previewed interventions from being mistaken as executed."
-                  ~when_active:"Only when there are preview tokens."
-                  ~agent_role:"Agents should explain these as governance debt, not completed work."
+                  ~purpose:"Shows the actor-scoped preview queue for confirm-required operator actions."
+                  ~problem_solved:"Prevents previewed interventions from being mistaken as executed and explains when the queue is empty only because another actor owns the token."
+                  ~when_active:"When confirm-required actions exist or when the operator needs to know which actions enter the preview-confirm path."
+                  ~agent_role:"Agents should explain these as incomplete work, call out actor filtering, and distinguish visible from hidden pending tokens."
                   ~ecosystem_function:"Maintains human-in-the-loop control."
                   [];
                 panel ~id:"intervene.session_queue" ~title:"Session Queue"

--- a/lib/operator_control.ml
+++ b/lib/operator_control.ml
@@ -354,114 +354,170 @@ let recent_actions_json config =
     in
     `List items
 
-let available_actions_json =
-  `List
+type available_action = {
+  action_type : string;
+  target_type : string;
+  description : string;
+  confirm_required : bool;
+}
+
+let available_actions : available_action list =
+  [
+    {
+      action_type = "broadcast";
+      target_type = "room";
+      description = "Use this when you need a room-wide operator broadcast.";
+      confirm_required = false;
+    };
+    {
+      action_type = "room_pause";
+      target_type = "room";
+      description = "Use this when you need to pause room automation or spawning.";
+      confirm_required = true;
+    };
+    {
+      action_type = "room_resume";
+      target_type = "room";
+      description = "Use this when you need to resume a paused room.";
+      confirm_required = false;
+    };
+    {
+      action_type = "lodge_tick";
+      target_type = "room";
+      description = "Use this when you need to run one immediate Lodge tick and inspect which agents acted or were skipped.";
+      confirm_required = false;
+    };
+    {
+      action_type = "task_inject";
+      target_type = "room";
+      description = "Use this when you need to inject a new backlog task into the room through a preview-confirm path.";
+      confirm_required = true;
+    };
+    {
+      action_type = "team_note";
+      target_type = "team_session";
+      description = "Use this when you need to append a non-broadcast operator note to a team session.";
+      confirm_required = false;
+    };
+    {
+      action_type = "team_broadcast";
+      target_type = "team_session";
+      description = "Use this when you need a broadcast-style orchestration turn in a team session.";
+      confirm_required = false;
+    };
+    {
+      action_type = "team_task_inject";
+      target_type = "team_session";
+      description = "Use this when you need to inject a new task into a running team session.";
+      confirm_required = true;
+    };
+    {
+      action_type = "team_worker_spawn_batch";
+      target_type = "team_session";
+      description = "Use this when you need to spawn or replace one or more team-session workers through a preview-confirm path.";
+      confirm_required = true;
+    };
+    {
+      action_type = "team_stop";
+      target_type = "team_session";
+      description = "Use this when you need to stop a running team session.";
+      confirm_required = true;
+    };
+    {
+      action_type = "keeper_message";
+      target_type = "keeper";
+      description = "Use this when you need to send a direct operator message to a keeper.";
+      confirm_required = false;
+    };
+    {
+      action_type = "keeper_probe";
+      target_type = "keeper";
+      description = "Use this when you need an immediate keeper diagnostic snapshot with health, silence reason, and next suggested action.";
+      confirm_required = false;
+    };
+    {
+      action_type = "keeper_recover";
+      target_type = "keeper";
+      description = "Use this when a keeper is stale, degraded, or offline and you need a safe down/up recovery with before-and-after diagnostics.";
+      confirm_required = false;
+    };
+    {
+      action_type = "swarm_run_continue";
+      target_type = "swarm_run";
+      description = "Use this when a stalled swarm-live run still has resumable managed state and you want a preview-confirm command-plane recovery chain.";
+      confirm_required = true;
+    };
+    {
+      action_type = "swarm_run_rerun";
+      target_type = "swarm_run";
+      description = "Use this when a swarm-live run has no trustworthy resumable state and you want to rerun the harness for the same run_id.";
+      confirm_required = true;
+    };
+    {
+      action_type = "swarm_run_abandon";
+      target_type = "swarm_run";
+      description = "Use this when you want to soft-abandon a swarm-live run without stopping any matched operation.";
+      confirm_required = true;
+    };
+  ]
+
+let available_action_to_yojson (entry : available_action) =
+  `Assoc
     [
-      `Assoc
-        [
-          ("action_type", `String "broadcast");
-          ("target_type", `String "room");
-          ("description", `String "Use this when you need a room-wide operator broadcast.");
-          ("confirm_required", `Bool false);
-        ];
-      `Assoc
-        [
-          ("action_type", `String "room_pause");
-          ("target_type", `String "room");
-          ("description", `String "Use this when you need to pause room automation or spawning.");
-          ("confirm_required", `Bool true);
-        ];
-      `Assoc
-        [
-          ("action_type", `String "room_resume");
-          ("target_type", `String "room");
-          ("description", `String "Use this when you need to resume a paused room.");
-          ("confirm_required", `Bool false);
-        ];
-      `Assoc
-        [
-          ("action_type", `String "lodge_tick");
-          ("target_type", `String "room");
-          ("description", `String "Use this when you need to run one immediate Lodge tick and inspect which agents acted or were skipped.");
-          ("confirm_required", `Bool false);
-        ];
-      `Assoc
-        [
-          ("action_type", `String "team_note");
-          ("target_type", `String "team_session");
-          ("description", `String "Use this when you need to append a non-broadcast operator note to a team session.");
-          ("confirm_required", `Bool false);
-        ];
-      `Assoc
-        [
-          ("action_type", `String "team_broadcast");
-          ("target_type", `String "team_session");
-          ("description", `String "Use this when you need a broadcast-style orchestration turn in a team session.");
-          ("confirm_required", `Bool false);
-        ];
-      `Assoc
-        [
-          ("action_type", `String "team_task_inject");
-          ("target_type", `String "team_session");
-          ("description", `String "Use this when you need to inject a new task into a running team session.");
-          ("confirm_required", `Bool true);
-        ];
-      `Assoc
-        [
-          ("action_type", `String "team_worker_spawn_batch");
-          ("target_type", `String "team_session");
-          ("description", `String "Use this when you need to spawn or replace one or more team-session workers through a preview-confirm path.");
-          ("confirm_required", `Bool true);
-        ];
-      `Assoc
-        [
-          ("action_type", `String "team_stop");
-          ("target_type", `String "team_session");
-          ("description", `String "Use this when you need to stop a running team session.");
-          ("confirm_required", `Bool true);
-        ];
-      `Assoc
-        [
-          ("action_type", `String "keeper_message");
-          ("target_type", `String "keeper");
-          ("description", `String "Use this when you need to send a direct operator message to a keeper.");
-          ("confirm_required", `Bool false);
-        ];
-      `Assoc
-        [
-          ("action_type", `String "keeper_probe");
-          ("target_type", `String "keeper");
-          ("description", `String "Use this when you need an immediate keeper diagnostic snapshot with health, silence reason, and next suggested action.");
-          ("confirm_required", `Bool false);
-        ];
-      `Assoc
-        [
-          ("action_type", `String "keeper_recover");
-          ("target_type", `String "keeper");
-          ("description", `String "Use this when a keeper is stale, degraded, or offline and you need a safe down/up recovery with before-and-after diagnostics.");
-          ("confirm_required", `Bool false);
-        ];
-      `Assoc
-        [
-          ("action_type", `String "swarm_run_continue");
-          ("target_type", `String "swarm_run");
-          ("description", `String "Use this when a stalled swarm-live run still has resumable managed state and you want a preview-confirm command-plane recovery chain.");
-          ("confirm_required", `Bool true);
-        ];
-      `Assoc
-        [
-          ("action_type", `String "swarm_run_rerun");
-          ("target_type", `String "swarm_run");
-          ("description", `String "Use this when a swarm-live run has no trustworthy resumable state and you want to rerun the harness for the same run_id.");
-          ("confirm_required", `Bool true);
-        ];
-      `Assoc
-        [
-          ("action_type", `String "swarm_run_abandon");
-          ("target_type", `String "swarm_run");
-          ("description", `String "Use this when you want to soft-abandon a swarm-live run without stopping any matched operation.");
-          ("confirm_required", `Bool true);
-        ];
+      ("action_type", `String entry.action_type);
+      ("target_type", `String entry.target_type);
+      ("description", `String entry.description);
+      ("confirm_required", `Bool entry.confirm_required);
+    ]
+
+let available_actions_json =
+  `List (List.map available_action_to_yojson available_actions)
+
+let pending_confirm_summary_json ?actor config =
+  let actor_filter =
+    match actor with
+    | Some raw ->
+        let trimmed = String.trim raw in
+        if trimmed = "" then None else Some trimmed
+    | None -> None
+  in
+  let all_entries =
+    read_pending_confirms config
+    |> List.sort (fun (a : pending_confirm) (b : pending_confirm) ->
+           String.compare b.created_at a.created_at)
+  in
+  let visible_entries =
+    match actor_filter with
+    | None -> all_entries
+    | Some value ->
+        List.filter (fun (entry : pending_confirm) -> String.equal value entry.actor) all_entries
+  in
+  let hidden_entries =
+    match actor_filter with
+    | None -> []
+    | Some value ->
+        List.filter (fun (entry : pending_confirm) -> not (String.equal value entry.actor)) all_entries
+  in
+  let hidden_actors =
+    hidden_entries
+    |> List.map (fun (entry : pending_confirm) -> entry.actor)
+    |> List.sort_uniq String.compare
+    |> List.map (fun value -> `String value)
+  in
+  let confirm_required_actions =
+    available_actions
+    |> List.filter (fun (entry : available_action) -> entry.confirm_required)
+    |> List.map available_action_to_yojson
+  in
+  `Assoc
+    [
+      ("actor_filter", string_option_to_json actor_filter);
+      ("filter_active", `Bool (Option.is_some actor_filter));
+      ("visible_count", `Int (List.length visible_entries));
+      ("total_count", `Int (List.length all_entries));
+      ("hidden_count", `Int (List.length hidden_entries));
+      ("hidden_actors", `List hidden_actors);
+      ("confirm_required_actions", `List confirm_required_actions);
     ]
 
 let recent_messages_json config =
@@ -987,7 +1043,7 @@ let summary_of_attention_items (items : attention_item list) =
 let dedup_recommendations (items : recommended_action list) =
   let rec loop seen acc = function
     | [] -> List.rev acc
-    | item :: rest ->
+    | (item : recommended_action) :: rest ->
         let key =
           String.concat "|"
             [
@@ -2145,6 +2201,7 @@ let snapshot_json ?actor ?view ?(include_messages = true) ?(include_sessions = t
        ("local_runtime", aggregated_local_runtime_json tracked_sessions);
        ("recent_messages", if initialized && include_messages then recent_messages_json config else `List []);
        ("pending_confirms", pending_confirms_json ?actor config);
+       ("pending_confirm_summary", pending_confirm_summary_json ?actor config);
        ("available_actions", available_actions_json);
        ("recent_actions", recent_actions_json config);
      ]

--- a/test/test_operator_control.ml
+++ b/test/test_operator_control.ml
@@ -166,6 +166,63 @@ let test_snapshot_has_expected_sections () =
       Alcotest.(check bool) "swarm_status present" true
         (Yojson.Safe.Util.member "swarm_status" json <> `Null))
 
+let test_snapshot_pending_confirm_summary_tracks_actor_scope () =
+  Eio_main.run @@ fun env ->
+  Eio.Switch.run @@ fun sw ->
+  let base_dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base_dir)
+    (fun () ->
+      let config = Room.default_config base_dir in
+      ignore (Room.init config ~agent_name:(Some "owner"));
+      let ctx = operator_ctx env sw config "owner" in
+      let inject_task actor title =
+        match
+          Operator_control.action_json ctx
+            (`Assoc
+              [
+                ("actor", `String actor);
+                ("action_type", `String "task_inject");
+                ("target_type", `String "room");
+                ( "payload",
+                  `Assoc
+                    [
+                      ("title", `String title);
+                      ("description", `String "created by operator");
+                      ("priority", `Int 2);
+                    ] );
+              ])
+        with
+        | Ok _ -> ()
+        | Error err -> Alcotest.fail err
+      in
+      inject_task "operator-a" "alpha preview";
+      inject_task "operator-b" "beta preview";
+      let snapshot = Operator_control.snapshot_json ~actor:"operator-a" ctx in
+      let summary = Yojson.Safe.Util.(snapshot |> member "pending_confirm_summary") in
+      Alcotest.(check string) "actor filter" "operator-a"
+        Yojson.Safe.Util.(summary |> member "actor_filter" |> to_string);
+      Alcotest.(check bool) "filter active" true
+        Yojson.Safe.Util.(summary |> member "filter_active" |> to_bool);
+      Alcotest.(check int) "visible count" 1
+        Yojson.Safe.Util.(summary |> member "visible_count" |> to_int);
+      Alcotest.(check int) "total count" 2
+        Yojson.Safe.Util.(summary |> member "total_count" |> to_int);
+      Alcotest.(check int) "hidden count" 1
+        Yojson.Safe.Util.(summary |> member "hidden_count" |> to_int);
+      Alcotest.(check bool) "hidden actor listed" true
+        (List.mem (`String "operator-b")
+           Yojson.Safe.Util.(summary |> member "hidden_actors" |> to_list));
+      let confirm_required_actions =
+        Yojson.Safe.Util.(summary |> member "confirm_required_actions" |> to_list)
+      in
+      Alcotest.(check bool) "task inject listed" true
+        (List.exists
+           (fun row ->
+             Yojson.Safe.Util.(row |> member "action_type" |> to_string)
+             = "task_inject")
+           confirm_required_actions))
+
 let test_digest_room_exposes_pending_confirm_attention () =
   Eio_main.run @@ fun env ->
   Eio.Switch.run @@ fun sw ->
@@ -1295,6 +1352,8 @@ let () =
         [
           Alcotest.test_case "snapshot sections" `Quick
             test_snapshot_has_expected_sections;
+          Alcotest.test_case "snapshot pending confirm summary tracks actor scope" `Quick
+            test_snapshot_pending_confirm_summary_tracks_actor_scope;
           Alcotest.test_case "digest room pending confirm attention" `Quick
             test_digest_room_exposes_pending_confirm_attention;
           Alcotest.test_case "digest team session shape" `Quick


### PR DESCRIPTION
## Summary
- ground pending confirmations in the operator contract instead of UI heuristics
- expose actor-scoped pending confirmation summary and visible/hidden counts
- wire recommended actions into the action studio, including team worker spawn batch

## Testing
- dune build --root .
- dune exec --root . ./test/test_operator_control.exe
- node /Users/dancer/me/workspace/yousleepwhen/masc-mcp/dashboard/node_modules/typescript/bin/tsc --noEmit --pretty --target ES2020 --module ESNext --lib ES2020,DOM,DOM.Iterable,ESNext.Disposable --moduleResolution bundler --jsx react-jsx --jsxImportSource preact --strict src/components/ops/helpers.ts src/components/ops/ops-room-column.ts src/components/ops/ops-session-column.ts src/operator-store.ts src/api.ts src/types.ts
