### PR TITLE
feat(tool): add admin snapshot and update surface

### DIFF
--- a/lib/auth.ml
+++ b/lib/auth.ml
@@ -293,6 +293,8 @@ let permission_for_tool = function
   | "masc_auth_enable" | "masc_auth_disable" | "masc_auth_create_token"
   | "masc_auth_revoke" -> Some CanInit  (* Admin only *)
   | "masc_auth_status" | "masc_auth_refresh" -> Some CanReadState
+  | "masc_tool_admin_snapshot" -> Some CanReadState
+  | "masc_tool_admin_update" -> Some CanAdmin
   | _ -> None
 
 (** Strict tool auth mode:

--- a/lib/mode.ml
+++ b/lib/mode.ml
@@ -193,7 +193,7 @@ let tool_category tool_name =
   | "masc_swarm_live_run"
   (* Mode management - always available *)
   | "masc_switch_mode" | "masc_get_config" -> Core
-  | "masc_tool_help" -> Core
+  | "masc_tool_help" | "masc_tool_admin_snapshot" -> Core
 
   (* ── Communication ── *)
   | "masc_broadcast" | "masc_messages"
@@ -270,7 +270,7 @@ let tool_category tool_name =
   (* ── Authentication & governance ── *)
   | "masc_auth_enable" | "masc_auth_disable" | "masc_auth_status"
   | "masc_auth_create_token" | "masc_auth_refresh" | "masc_auth_revoke"
-  | "masc_auth_list"
+  | "masc_auth_list" | "masc_tool_admin_update"
   | "masc_audit_query" | "masc_audit_stats"
   | "masc_governance_set" | "masc_governance_report"
   | "masc_tool_grant" | "masc_tool_revoke" | "masc_tool_list" -> Auth

--- a/lib/tool_help_registry.ml
+++ b/lib/tool_help_registry.ml
@@ -196,6 +196,56 @@ let manual_help_entry name =
             ];
           prompt_hints = [ "Use prompt 'command_truth' to summarize the resulting proof." ];
         }
+  | "masc_tool_admin_snapshot" ->
+      Some
+        {
+          name;
+          short_description =
+            "Return a unified admin snapshot covering tool inventory, auth, mode, keeper policy, and command-plane policy surfaces.";
+          when_to_use =
+            "Use when you need one truthful view of what tools exist, what is visible, what auth/RBAC applies, and which policy surfaces are enforced versus advisory.";
+          key_constraints =
+            [
+              "Tool catalog visibility metadata is read-only in this snapshot.";
+              "Command-plane tool/model allowlists are reported as advisory until runtime enforcement is wired.";
+            ];
+          details_markdown =
+            "Provides a room-scoped control snapshot: current mode/category gates, auth config and credentials, keeper policy-derived tool gates, command-plane policy topology, and the full tool inventory with metadata and permission hints.";
+          doc_refs =
+            [
+              "docs/COMMAND-PLANE-RUNBOOK.md";
+              "docs/SUPERVISOR-MODE.md";
+            ];
+          prompt_hints =
+            [
+              "Use before changing auth, mode, unit policy, or keeper policy to confirm what is actually enforced.";
+            ];
+        }
+  | "masc_tool_admin_update" ->
+      Some
+        {
+          name;
+          short_description =
+            "Apply mode, auth, unit-policy, or keeper-policy updates through a single admin entrypoint.";
+          when_to_use =
+            "Use when you need to change mode/auth settings, update a unit policy envelope, or adjust keeper policy without bouncing between multiple tools.";
+          key_constraints =
+            [
+              "Section must be one of mode, auth, unit_policy, keeper_policy, persistent_agent_policy.";
+              "Unit tool/model allowlists are stored and surfaced, but remain advisory until runtime enforcement is added.";
+            ];
+          details_markdown =
+            "Delegates to the existing truthful write paths: Config mode updates, Auth config persistence, CPv2 unit policy updates, and keeper meta policy updates. Returns warnings for advisory-only fields.";
+          doc_refs =
+            [
+              "docs/COMMAND-PLANE-RUNBOOK.md";
+              "docs/SUPERVISOR-MODE.md";
+            ];
+          prompt_hints =
+            [
+              "Run masc_tool_admin_snapshot first, then apply the smallest necessary section update.";
+            ];
+        }
   | _ -> None
 
 let derived_short_description name original =

--- a/lib/tool_misc.ml
+++ b/lib/tool_misc.ml
@@ -5,12 +5,553 @@
 
 open Tool_args
 
+module U = Yojson.Safe.Util
+
 type result = bool * string
 
 type context = {
   config: Room.config;
   agent_name: string;
 }
+
+let json_string_option = function
+  | Some value when String.trim value <> "" -> `String (String.trim value)
+  | _ -> `Null
+
+let bool_arg_opt args key =
+  match U.member key args with
+  | `Bool value -> Some value
+  | _ -> None
+
+let int_arg_opt args key =
+  match U.member key args with
+  | `Int value -> Some value
+  | `Intlit raw -> Some (Safe_ops.int_of_string_with_default ~default:0 raw)
+  | _ -> None
+
+let category_list_arg_opt args key =
+  match U.member key args with
+  | `Null -> None
+  | `List items ->
+      let categories =
+        items
+        |> List.filter_map (function
+             | `String raw ->
+                 Mode.category_of_string (String.lowercase_ascii (String.trim raw))
+             | _ -> None)
+      in
+      Some categories
+  | _ -> None
+
+let permission_to_json tool_name =
+  match Auth.permission_for_tool tool_name with
+  | Some permission -> `String (Types.show_permission permission)
+  | None -> `Null
+
+let auth_snapshot_json ctx =
+  let cfg = Auth.load_auth_config ctx.config.base_path in
+  let credentials =
+    Auth.list_credentials ctx.config.base_path
+    |> List.sort (fun (left : Types.agent_credential) right ->
+           String.compare left.agent_name right.agent_name)
+    |> List.map (fun (cred : Types.agent_credential) ->
+           `Assoc
+             [
+               ("agent_name", `String cred.agent_name);
+               ("role", `String (Types.agent_role_to_string cred.role));
+               ("created_at", `String cred.created_at);
+               ("expires_at", json_string_option cred.expires_at);
+             ])
+  in
+  `Assoc
+    [
+      ("enabled", `Bool cfg.enabled);
+      ("require_token", `Bool cfg.require_token);
+      ("default_role", `String (Types.agent_role_to_string cfg.default_role));
+      ("token_expiry_hours", `Int cfg.token_expiry_hours);
+      ("tool_auth_strict", `Bool (Auth.is_tool_auth_strict_enabled ()));
+      ("credential_count", `Int (List.length credentials));
+      ("credentials", `List credentials);
+    ]
+
+let mode_snapshot_json ctx =
+  let room_path = Room.masc_dir ctx.config in
+  let cfg = Config.load room_path in
+  let categories =
+    Mode.all_categories
+    |> List.map (fun category ->
+           let enabled = List.mem category cfg.enabled_categories in
+           `Assoc
+             [
+               ("name", `String (Mode.category_to_string category));
+               ("description", `String (Mode.category_description category));
+               ("enabled", `Bool enabled);
+             ])
+  in
+  `Assoc
+    [
+      ("mode", `String (Mode.mode_to_string cfg.mode));
+      ("mode_description", `String (Mode.mode_description cfg.mode));
+      ("enabled_tool_count", `Int (List.length (Config.enabled_tool_schemas cfg.enabled_categories)));
+      ("categories", `List categories);
+      ("config_summary", Config.get_config_summary room_path);
+    ]
+
+let keeper_tool_policy_json autonomy_level =
+  match Keeper_autonomy.autonomy_level_of_string autonomy_level with
+  | Some level ->
+      let gate = Tool_keeper.autonomous_gate_config ~autonomy_level:level in
+      `Assoc
+        [
+          ("configured_tool_policy", `String (if gate.allowlist_enabled then "allowlist" else "all"));
+          ( "configured_tool_names",
+            `List
+              (if gate.allowlist_enabled
+               then List.map (fun name -> `String name) gate.allowed_tools
+               else []) );
+          ("denied_tool_names", `List (List.map (fun name -> `String name) gate.denied_tools));
+          ("max_tool_calls_per_turn", `Int gate.max_tool_calls_per_turn);
+          ("destructive_check_enabled", `Bool gate.destructive_check_enabled);
+        ]
+  | None ->
+      `Assoc
+        [
+          ("configured_tool_policy", `String "unknown");
+          ("configured_tool_names", `List []);
+          ("denied_tool_names", `List []);
+          ("max_tool_calls_per_turn", `Null);
+          ("destructive_check_enabled", `Null);
+        ]
+
+let keeper_policy_row ctx ~runtime_class (meta : Tool_keeper.keeper_meta) =
+  let status_json = Tool_keeper.parse_agent_status ctx.config ~agent_name:meta.agent_name in
+  let status =
+    match U.member "status" status_json with
+    | `String value -> value
+    | _ -> "unknown"
+  in
+  let policy_json =
+    match keeper_tool_policy_json meta.autonomy_level with
+    | `Assoc fields -> fields
+    | _ -> []
+  in
+  `Assoc
+    ([
+       ("name", `String meta.name);
+       ("runtime_class", `String runtime_class);
+       ("agent_name", `String meta.agent_name);
+       ("status", `String status);
+       ("autonomy_level", `String meta.autonomy_level);
+       ("policy_mode", `String meta.policy_mode);
+       ("action_budget", `String meta.policy_action_budget);
+       ("reward_model_path",
+        if String.trim meta.policy_reward_model_path = "" then `Null
+        else `String meta.policy_reward_model_path);
+       ("active_model", `String (Tool_keeper.active_model_of_meta meta));
+       ("allowed_models", `List (List.map (fun model -> `String model) meta.allowed_models));
+       ("updated_at", `String meta.updated_at);
+     ]
+    @ policy_json)
+
+let keeper_policies_json ctx =
+  let resident_rows =
+    Tool_keeper.resident_keeper_names ctx.config
+    |> List.filter_map (fun name ->
+           match Tool_keeper.read_meta ctx.config name with
+           | Ok (Some meta) -> Some (keeper_policy_row ctx ~runtime_class:"resident_keeper" meta)
+           | Ok None | Error _ -> None)
+  in
+  let persistent_rows =
+    Tool_keeper.persistent_agent_names ctx.config
+    |> List.filter_map (fun name ->
+           match Tool_keeper.read_meta ctx.config name with
+           | Ok (Some meta) -> Some (keeper_policy_row ctx ~runtime_class:"persistent_agent" meta)
+           | Ok None | Error _ -> None)
+  in
+  `Assoc
+    [
+      ("resident_keepers", `List resident_rows);
+      ("persistent_agents", `List persistent_rows);
+    ]
+
+let tool_inventory_json ctx ~include_hidden ~include_deprecated =
+  let room_path = Room.masc_dir ctx.config in
+  let cfg = Config.load room_path in
+  let schemas =
+    Config.raw_all_tool_schemas
+    |> List.filter (fun (schema : Types.tool_schema) ->
+           Tool_catalog.is_visible ~include_hidden ~include_deprecated schema.name)
+    |> List.sort (fun (left : Types.tool_schema) right -> String.compare left.name right.name)
+  in
+  let rows =
+    schemas
+    |> List.map (fun (schema : Types.tool_schema) ->
+           let help_entry = Tool_help_registry.entry_of_schema schema in
+           let category = Mode.tool_category schema.name in
+           `Assoc
+             ([
+                ("name", `String schema.name);
+                ("description", `String help_entry.short_description);
+                ("category", `String (Mode.category_to_string category));
+                ("category_description", `String (Mode.category_description category));
+                ("enabled_in_current_mode", `Bool (Mode.is_tool_enabled cfg.enabled_categories schema.name));
+                ("direct_call_allowed", `Bool (Tool_catalog.allow_direct_call schema.name));
+                ("required_permission", permission_to_json schema.name);
+                ("doc_refs", `List (List.map (fun value -> `String value) help_entry.doc_refs));
+                ("prompt_hints", `List (List.map (fun value -> `String value) help_entry.prompt_hints));
+              ]
+             @ Tool_catalog.metadata_to_fields schema.name))
+  in
+  `Assoc
+    [
+      ("count", `Int (List.length rows));
+      ("tools", `List rows);
+    ]
+
+let enforcement_summary_json () =
+  `List
+    [
+      `Assoc
+        [
+          ("surface", `String "room.mode_categories");
+          ("status", `String "enforced");
+          ("reason",
+           `String
+             "Tool dispatch blocks tools whose category is disabled in the current room mode.");
+        ];
+      `Assoc
+        [
+          ("surface", `String "room.auth.permission_map");
+          ("status", `String "conditional");
+          ("reason",
+           `String
+             "Auth permission checks are enforced only when room auth is enabled.");
+        ];
+      `Assoc
+        [
+          ("surface", `String "tool_catalog.visibility");
+          ("status", `String "enforced");
+          ("reason",
+           `String
+             "Hidden tools are removed from default discovery and may be direct-call blocked.");
+        ];
+      `Assoc
+        [
+          ("surface", `String "keeper.eval_gate.allowed_tools");
+          ("status", `String "enforced");
+          ("reason",
+           `String
+             "Keeper autonomy uses Eval_gate allow/deny lists at tool-call time.");
+        ];
+      `Assoc
+        [
+          ("surface", `String "unit.policy.kill_switch");
+          ("status", `String "enforced");
+          ("reason",
+           `String
+             "Command-plane assignment blocks operations targeting units with kill-switch enabled.");
+        ];
+      `Assoc
+        [
+          ("surface", `String "unit.policy.frozen");
+          ("status", `String "enforced");
+          ("reason",
+           `String
+             "Command-plane assignment blocks operations targeting frozen units.");
+        ];
+      `Assoc
+        [
+          ("surface", `String "unit.policy.tool_allowlist");
+          ("status", `String "advisory_only");
+          ("reason",
+           `String
+             "Stored in CPv2 topology/policy JSON but not wired into runtime tool dispatch on main.");
+        ];
+      `Assoc
+        [
+          ("surface", `String "unit.policy.model_allowlist");
+          ("status", `String "advisory_only");
+          ("reason",
+           `String
+             "Stored in CPv2 topology/policy JSON but not wired into runtime model selection on main.");
+        ];
+    ]
+
+let handle_tool_admin_snapshot ctx args =
+  let include_hidden = get_bool args "include_hidden" true in
+  let include_deprecated = get_bool args "include_deprecated" true in
+  let payload =
+    `Assoc
+      [
+        ("status", `String "ok");
+        ("generated_at", `String (Types.now_iso ()));
+        ("mode", mode_snapshot_json ctx);
+        ("auth", auth_snapshot_json ctx);
+        ( "command_plane",
+          `Assoc
+            [
+              ("policy_status", Command_plane_v2.policy_status_json ctx.config);
+              ("enforcement_summary", enforcement_summary_json ());
+            ] );
+        ("keeper_policies", keeper_policies_json ctx);
+        ( "tool_inventory",
+          tool_inventory_json ctx ~include_hidden ~include_deprecated );
+      ]
+  in
+  (true, Yojson.Safe.pretty_to_string payload)
+
+let apply_keeper_policy_update config ~runtime_class args =
+  let name = get_string args "name" "" |> String.trim in
+  let policy_mode_opt = get_string_opt args "policy_mode" |> Option.map String.trim in
+  let action_budget_opt = get_string_opt args "action_budget" |> Option.map String.trim in
+  let autonomy_level_opt = get_string_opt args "autonomy_level" |> Option.map String.trim in
+  let reward_model_path_opt = get_string_opt args "reward_model_path" |> Option.map String.trim in
+  let membership_ok =
+    match runtime_class with
+    | "resident_keeper" -> List.mem name (Tool_keeper.resident_keeper_names config)
+    | "persistent_agent" -> List.mem name (Tool_keeper.persistent_agent_names config)
+    | _ -> false
+  in
+  if not (Tool_keeper.validate_name name) then
+    Error "invalid keeper name"
+  else if not membership_ok then
+    Error
+      (Printf.sprintf "%s not found in %s set" name runtime_class)
+  else
+    match Tool_keeper.read_meta config name with
+    | Error err -> Error err
+    | Ok None -> Error (Printf.sprintf "keeper not found: %s" name)
+    | Ok (Some meta) ->
+        let policy_mode =
+          match policy_mode_opt with
+          | None -> Ok meta.policy_mode
+          | Some "heuristic" -> Ok "heuristic"
+          | Some "learned_offline_v1" -> Ok "learned_offline_v1"
+          | Some other -> Error (Printf.sprintf "invalid policy_mode: %s" other)
+        in
+        let action_budget =
+          match action_budget_opt with
+          | None -> Ok meta.policy_action_budget
+          | Some "conversation" -> Ok "conversation"
+          | Some "board" -> Ok "board"
+          | Some other -> Error (Printf.sprintf "invalid action_budget: %s" other)
+        in
+        let autonomy_level =
+          match autonomy_level_opt with
+          | None -> Ok meta.autonomy_level
+          | Some raw -> (
+              match Keeper_autonomy.autonomy_level_of_string raw with
+              | Some level ->
+                  Ok
+                    (String.lowercase_ascii
+                       (Keeper_autonomy.autonomy_level_to_string level))
+              | None -> Error (Printf.sprintf "invalid autonomy_level: %s" raw))
+        in
+        (match policy_mode, action_budget, autonomy_level with
+        | Error err, _, _ | _, Error err, _ | _, _, Error err -> Error err
+        | Ok policy_mode, Ok action_budget, Ok autonomy_level ->
+            let reward_model_path_raw =
+              match reward_model_path_opt with
+              | Some value -> value
+              | None -> meta.policy_reward_model_path
+            in
+            let reward_model_path =
+              if reward_model_path_raw <> ""
+                 && Filename.is_relative reward_model_path_raw
+              then
+                Filename.concat config.base_path reward_model_path_raw
+              else
+                reward_model_path_raw
+            in
+            let effective_reward_result =
+              if String.equal policy_mode "learned_offline_v1" then
+                Tool_keeper.load_keeper_reward_model reward_model_path
+                |> Result.map (fun _ -> (reward_model_path, None))
+              else
+                Ok (reward_model_path, None)
+            in
+            match effective_reward_result with
+            | Error err -> Error err
+            | Ok (effective_reward_path, reward_model_version) ->
+                let updated =
+                  {
+                    meta with
+                    policy_mode;
+                    policy_action_budget = action_budget;
+                    policy_reward_model_path = effective_reward_path;
+                    autonomy_level;
+                    updated_at = Types.now_iso ();
+                  }
+                in
+                (match Tool_keeper.write_meta config updated with
+                | Error err -> Error err
+                | Ok () ->
+                    let policy_json =
+                      match keeper_tool_policy_json updated.autonomy_level with
+                      | `Assoc fields -> fields
+                      | _ -> []
+                    in
+                    Ok
+                      (`Assoc
+                        ([
+                           ("status", `String "ok");
+                           ("runtime_class", `String runtime_class);
+                           ("name", `String updated.name);
+                           ("policy_mode", `String updated.policy_mode);
+                           ("action_budget", `String updated.policy_action_budget);
+                           ("autonomy_level", `String updated.autonomy_level);
+                           ("reward_model_path", json_string_option (Some updated.policy_reward_model_path));
+                           ("reward_model_version", json_string_option reward_model_version);
+                         ]
+                        @ policy_json)))
+        )
+
+let handle_tool_admin_update ctx args =
+  let section =
+    get_string args "section" "" |> String.trim |> String.lowercase_ascii
+  in
+  let room_path = Room.masc_dir ctx.config in
+  match section with
+  | "mode" ->
+      let categories_opt = category_list_arg_opt args "enabled_categories" in
+      let mode_opt =
+        get_string_opt args "mode"
+        |> Option.map (fun raw -> String.lowercase_ascii (String.trim raw))
+      in
+      let result =
+        match categories_opt, mode_opt with
+        | Some categories, _ ->
+            let config = Config.set_categories room_path categories in
+            Ok config
+        | None, Some "custom" ->
+            Error "mode=custom requires enabled_categories"
+        | None, Some raw -> (
+            match Mode.mode_of_string raw with
+            | Some mode -> Ok (Config.switch_mode room_path mode)
+            | None -> Error (Printf.sprintf "unknown mode: %s" raw))
+        | None, None -> Error "mode or enabled_categories is required"
+      in
+      (match result with
+      | Error err -> (false, "❌ " ^ err)
+      | Ok _ ->
+          let payload =
+            `Assoc
+              [
+                ("status", `String "ok");
+                ("section", `String "mode");
+                ("result", mode_snapshot_json ctx);
+              ]
+          in
+          (true, Yojson.Safe.pretty_to_string payload))
+  | "auth" ->
+      let current = Auth.load_auth_config ctx.config.base_path in
+      let require_token =
+        match bool_arg_opt args "require_token" with
+        | Some value -> value
+        | None -> current.require_token
+      in
+      let enabled_opt = bool_arg_opt args "enabled" in
+      let room_secret =
+        match enabled_opt with
+        | Some true when not current.enabled ->
+            Some (Auth.enable_auth ctx.config.base_path ~require_token)
+        | Some false when current.enabled ->
+            Auth.disable_auth ctx.config.base_path;
+            None
+        | _ -> None
+      in
+      let refreshed = Auth.load_auth_config ctx.config.base_path in
+      let default_role_result =
+        match get_string_opt args "default_role" with
+        | None -> Ok refreshed.default_role
+        | Some raw -> (
+            match Types.agent_role_of_string (String.lowercase_ascii (String.trim raw)) with
+            | Ok role -> Ok role
+            | Error err -> Error err)
+      in
+      let expiry_hours =
+        match int_arg_opt args "token_expiry_hours" with
+        | Some value when value > 0 -> Ok value
+        | Some _ -> Error "token_expiry_hours must be > 0"
+        | None -> Ok refreshed.token_expiry_hours
+      in
+      (match default_role_result, expiry_hours with
+      | Error err, _ | _, Error err -> (false, "❌ " ^ err)
+      | Ok default_role, Ok token_expiry_hours ->
+          let updated =
+            {
+              refreshed with
+              require_token;
+              default_role;
+              token_expiry_hours;
+              enabled =
+                (match enabled_opt with Some value -> value | None -> refreshed.enabled);
+            }
+          in
+          Auth.save_auth_config ctx.config.base_path updated;
+          let payload =
+            `Assoc
+              [
+                ("status", `String "ok");
+                ("section", `String "auth");
+                ("room_secret", json_string_option room_secret);
+                ("result", auth_snapshot_json ctx);
+              ]
+          in
+          (true, Yojson.Safe.pretty_to_string payload))
+  | "unit_policy" ->
+      (match Command_plane_v2.policy_update_json ctx.config ~actor:ctx.agent_name args with
+      | Error err -> (false, Yojson.Safe.to_string (`Assoc [ ("status", `String "error"); ("message", `String err) ]))
+      | Ok json ->
+          let warnings =
+            let policy_json = U.member "policy" args in
+            let items = ref [] in
+            if U.member "tool_allowlist" policy_json <> `Null then
+              items :=
+                `Assoc
+                  [
+                    ("field", `String "tool_allowlist");
+                    ("status", `String "advisory_only");
+                    ("reason",
+                     `String
+                       "Stored in CPv2 policy but not yet enforced by runtime tool dispatch.");
+                  ]
+                :: !items;
+            if U.member "model_allowlist" policy_json <> `Null then
+              items :=
+                `Assoc
+                  [
+                    ("field", `String "model_allowlist");
+                    ("status", `String "advisory_only");
+                    ("reason",
+                     `String
+                       "Stored in CPv2 policy but not yet enforced by runtime model selection.");
+                  ]
+                :: !items;
+            `List (List.rev !items)
+          in
+          let payload =
+            `Assoc
+              [
+                ("status", `String "ok");
+                ("section", `String "unit_policy");
+                ("warnings", warnings);
+                ("result", json);
+              ]
+          in
+          (true, Yojson.Safe.pretty_to_string payload))
+  | "keeper_policy" ->
+      (match apply_keeper_policy_update ctx.config ~runtime_class:"resident_keeper" args with
+      | Ok json ->
+          (true, Yojson.Safe.pretty_to_string (`Assoc [ ("status", `String "ok"); ("section", `String "keeper_policy"); ("result", json) ]))
+      | Error err -> (false, "❌ " ^ err))
+  | "persistent_agent_policy" ->
+      (match apply_keeper_policy_update ctx.config ~runtime_class:"persistent_agent" args with
+      | Ok json ->
+          (true, Yojson.Safe.pretty_to_string (`Assoc [ ("status", `String "ok"); ("section", `String "persistent_agent_policy"); ("result", json) ]))
+      | Error err -> (false, "❌ " ^ err))
+  | _ ->
+      (false, "❌ section must be one of: mode | auth | unit_policy | keeper_policy | persistent_agent_policy")
 
 (* Handlers *)
 
@@ -83,4 +624,6 @@ let dispatch ctx ~name ~args : result option =
   | "masc_cleanup_zombies" -> Some (handle_cleanup_zombies ctx args)
   | "masc_tool_stats" -> Some (handle_tool_stats ctx args)
   | "masc_tool_help" -> Some (handle_tool_help ctx args)
+  | "masc_tool_admin_snapshot" -> Some (handle_tool_admin_snapshot ctx args)
+  | "masc_tool_admin_update" -> Some (handle_tool_admin_update ctx args)
   | _ -> None

--- a/lib/tools.ml
+++ b/lib/tools.ml
@@ -4385,6 +4385,98 @@ Example: masc_tempo_reset() → {tempo: 300, message: 'Reset to default'}";
       ("required", `List [`String "tool_name"]);
     ];
   };
+
+  {
+    name = "masc_tool_admin_snapshot";
+    description = "Return a unified admin snapshot of tool inventory, auth/RBAC, mode gates, keeper policy, and command-plane policy surfaces.";
+    input_schema = `Assoc [
+      ("type", `String "object");
+      ("properties", `Assoc [
+        ("include_hidden", `Assoc [
+          ("type", `String "boolean");
+          ("description", `String "Include hidden tools in tool_inventory (default: true)");
+          ("default", `Bool true);
+        ]);
+        ("include_deprecated", `Assoc [
+          ("type", `String "boolean");
+          ("description", `String "Include deprecated tools in tool_inventory (default: true)");
+          ("default", `Bool true);
+        ]);
+      ]);
+    ];
+  };
+
+  {
+    name = "masc_tool_admin_update";
+    description = "Apply mode, auth, unit-policy, or keeper-policy updates through a single admin entrypoint.";
+    input_schema = `Assoc [
+      ("type", `String "object");
+      ("properties", `Assoc [
+        ("section", `Assoc [
+          ("type", `String "string");
+          ("description", `String "One of: mode, auth, unit_policy, keeper_policy, persistent_agent_policy");
+        ]);
+        ("mode", `Assoc [
+          ("type", `String "string");
+          ("description", `String "Preset mode to switch to for section=mode");
+        ]);
+        ("enabled_categories", `Assoc [
+          ("type", `String "array");
+          ("items", `Assoc [("type", `String "string")]);
+          ("description", `String "Custom category set for section=mode");
+        ]);
+        ("enabled", `Assoc [
+          ("type", `String "boolean");
+          ("description", `String "Enable or disable auth for section=auth");
+        ]);
+        ("require_token", `Assoc [
+          ("type", `String "boolean");
+          ("description", `String "Require tokens for section=auth");
+        ]);
+        ("default_role", `Assoc [
+          ("type", `String "string");
+          ("description", `String "Default role for unauthenticated agents: reader|worker|admin");
+        ]);
+        ("token_expiry_hours", `Assoc [
+          ("type", `String "integer");
+          ("description", `String "Token expiry in hours for section=auth");
+        ]);
+        ("unit_id", `Assoc [
+          ("type", `String "string");
+          ("description", `String "Managed unit id for section=unit_policy");
+        ]);
+        ("policy", `Assoc [
+          ("type", `String "object");
+          ("description", `String "Unit policy envelope for section=unit_policy");
+        ]);
+        ("budget", `Assoc [
+          ("type", `String "object");
+          ("description", `String "Unit budget envelope for section=unit_policy");
+        ]);
+        ("name", `Assoc [
+          ("type", `String "string");
+          ("description", `String "Keeper or persistent agent name for policy updates");
+        ]);
+        ("policy_mode", `Assoc [
+          ("type", `String "string");
+          ("description", `String "Keeper policy mode: heuristic | learned_offline_v1");
+        ]);
+        ("action_budget", `Assoc [
+          ("type", `String "string");
+          ("description", `String "Keeper action budget: conversation | board");
+        ]);
+        ("autonomy_level", `Assoc [
+          ("type", `String "string");
+          ("description", `String "Keeper autonomy level such as L2_Suggestive or L4_Autonomous");
+        ]);
+        ("reward_model_path", `Assoc [
+          ("type", `String "string");
+          ("description", `String "Reward model path for learned_offline_v1 keeper policy");
+        ]);
+      ]);
+      ("required", `List [`String "section"]);
+    ];
+  };
 ]
 
 let all_schemas : tool_schema list = raw_schemas

--- a/test/test_auth_coverage.ml
+++ b/test/test_auth_coverage.ml
@@ -245,6 +245,16 @@ let test_permission_for_tool_auth_status () =
   | Some Types.CanReadState -> ()
   | _ -> fail "expected CanReadState"
 
+let test_permission_for_tool_admin_snapshot () =
+  match Auth.permission_for_tool "masc_tool_admin_snapshot" with
+  | Some Types.CanReadState -> ()
+  | _ -> fail "expected CanReadState"
+
+let test_permission_for_tool_admin_update () =
+  match Auth.permission_for_tool "masc_tool_admin_update" with
+  | Some Types.CanAdmin -> ()
+  | _ -> fail "expected CanAdmin"
+
 let test_permission_for_tool_operator_snapshot () =
   match Auth.permission_for_tool "masc_operator_snapshot" with
   | Some Types.CanReadState -> ()
@@ -379,6 +389,8 @@ let () =
       test_case "approve" `Quick test_permission_for_tool_approve;
       test_case "auth_enable" `Quick test_permission_for_tool_auth_enable;
       test_case "auth_status" `Quick test_permission_for_tool_auth_status;
+      test_case "tool_admin_snapshot" `Quick test_permission_for_tool_admin_snapshot;
+      test_case "tool_admin_update" `Quick test_permission_for_tool_admin_update;
       test_case "llama_models" `Quick test_permission_for_tool_llama_models;
       test_case "operator_snapshot" `Quick test_permission_for_tool_operator_snapshot;
       test_case "operator_digest" `Quick test_permission_for_tool_operator_digest;

--- a/test/test_mode_coverage.ml
+++ b/test/test_mode_coverage.ml
@@ -233,7 +233,13 @@ let test_tool_category_cost () =
 
 let test_tool_category_auth () =
   check bool "auth_enable" true (Mode.tool_category "masc_auth_enable" = Mode.Auth);
-  check bool "auth_status" true (Mode.tool_category "masc_auth_status" = Mode.Auth)
+  check bool "auth_status" true (Mode.tool_category "masc_auth_status" = Mode.Auth);
+  check bool "tool_admin_update" true
+    (Mode.tool_category "masc_tool_admin_update" = Mode.Auth)
+
+let test_tool_category_core_admin_snapshot () =
+  check bool "tool_admin_snapshot" true
+    (Mode.tool_category "masc_tool_admin_snapshot" = Mode.Core)
 
 let test_tool_category_ratelimit () =
   check bool "rate_limit_status" true (Mode.tool_category "masc_rate_limit_status" = Mode.RateLimit);
@@ -405,6 +411,7 @@ let () =
       test_case "interrupt tools" `Quick test_tool_category_interrupt;
       test_case "cost tools" `Quick test_tool_category_cost;
       test_case "auth tools" `Quick test_tool_category_auth;
+      test_case "core admin snapshot" `Quick test_tool_category_core_admin_snapshot;
       test_case "ratelimit tools" `Quick test_tool_category_ratelimit;
       test_case "encryption tools" `Quick test_tool_category_encryption;
       test_case "code tools" `Quick test_tool_category_code;

--- a/test/test_tool_misc_coverage.ml
+++ b/test/test_tool_misc_coverage.ml
@@ -3,6 +3,7 @@
 open Masc_mcp
 
 let () = Random.self_init ()
+let () = Mirage_crypto_rng_unix.use_default ()
 
 let () = Printf.printf "\n=== Tool_misc Coverage Tests ===\n"
 
@@ -17,6 +18,10 @@ let str_contains s sub =
       else loop (i + 1)
     in
     loop 0
+
+let parse_json s =
+  try Yojson.Safe.from_string s
+  with Yojson.Json_error err -> failwith ("invalid json: " ^ err)
 
 (* Test helper *)
 let test name f =
@@ -136,6 +141,148 @@ let () = test "dispatch_cleanup_zombies" (fun () ->
       assert success;
       assert (String.length result > 0)
   | None -> failwith "dispatch returned None"
+)
+
+let () = test "dispatch_tool_admin_snapshot" (fun () ->
+  let ctx = make_test_ctx () in
+  let args = `Assoc [] in
+  match Tool_misc.dispatch ctx ~name:"masc_tool_admin_snapshot" ~args with
+  | Some (success, result) ->
+      assert success;
+      let json = parse_json result in
+      assert (Yojson.Safe.Util.member "tool_inventory" json <> `Null);
+      assert (Yojson.Safe.Util.member "auth" json <> `Null);
+      assert (Yojson.Safe.Util.member "mode" json <> `Null);
+      assert (Yojson.Safe.Util.member "keeper_policies" json <> `Null);
+      assert (Yojson.Safe.Util.member "command_plane" json <> `Null)
+  | None -> failwith "dispatch returned None"
+)
+
+let () = test "dispatch_tool_admin_update_mode" (fun () ->
+  let ctx = make_test_ctx () in
+  let args =
+    `Assoc
+      [
+        ("section", `String "mode");
+        ("enabled_categories", `List [ `String "core"; `String "auth" ]);
+      ]
+  in
+  match Tool_misc.dispatch ctx ~name:"masc_tool_admin_update" ~args with
+  | Some (success, result) ->
+      assert success;
+      let json = parse_json result in
+      assert (Yojson.Safe.Util.(json |> member "section" |> to_string) = "mode");
+      let cfg = Config.load (Room.masc_dir ctx.config) in
+      assert (cfg.mode = Mode.Custom);
+      assert (List.mem Mode.Core cfg.enabled_categories);
+      assert (List.mem Mode.Auth cfg.enabled_categories)
+  | None -> failwith "dispatch returned None"
+)
+
+let () = test "dispatch_tool_admin_update_auth" (fun () ->
+  let ctx = make_test_ctx () in
+  let args =
+    `Assoc
+      [
+        ("section", `String "auth");
+        ("enabled", `Bool true);
+        ("require_token", `Bool true);
+        ("default_role", `String "reader");
+        ("token_expiry_hours", `Int 12);
+      ]
+  in
+  match Tool_misc.dispatch ctx ~name:"masc_tool_admin_update" ~args with
+  | Some (success, result) ->
+      assert success;
+      let json = parse_json result in
+      assert (Yojson.Safe.Util.(json |> member "section" |> to_string) = "auth");
+      let cfg = Auth.load_auth_config ctx.config.base_path in
+      assert cfg.enabled;
+      assert cfg.require_token;
+      assert (cfg.default_role = Types.Reader);
+      assert (cfg.token_expiry_hours = 12)
+  | None -> failwith "dispatch returned None"
+)
+
+let () = test "dispatch_tool_admin_update_unit_policy" (fun () ->
+  let ctx = make_test_ctx () in
+  let define_args =
+    `Assoc
+      [
+        ("unit_id", `String "squad-admin-test");
+        ("kind", `String "squad");
+        ("label", `String "Admin Test Squad");
+        ("parent_unit_id", `String "company-runtime");
+      ]
+  in
+  ignore (Command_plane_v2.upsert_unit ctx.config ~actor:ctx.agent_name define_args);
+  let args =
+    `Assoc
+      [
+        ("section", `String "unit_policy");
+        ("unit_id", `String "squad-admin-test");
+        ( "policy",
+          `Assoc
+            [
+              ("tool_allowlist", `List [ `String "masc_board_post" ]);
+              ("model_allowlist", `List [ `String "llama:qwen3.5-35b-a3b-ud-q8-xl" ]);
+              ("approval_class", `String "guarded");
+            ] );
+      ]
+  in
+  match Tool_misc.dispatch ctx ~name:"masc_tool_admin_update" ~args with
+  | Some (success, result) ->
+      assert success;
+      let json = parse_json result in
+      assert (Yojson.Safe.Util.(json |> member "section" |> to_string) = "unit_policy");
+      let warnings = Yojson.Safe.Util.(json |> member "warnings" |> to_list) in
+      assert (List.length warnings = 2)
+  | None -> failwith "dispatch returned None"
+)
+
+let () = test "dispatch_tool_admin_update_keeper_policy" (fun () ->
+  Eio_main.run @@ fun env ->
+  Eio.Switch.run @@ fun sw ->
+  let ctx = make_test_ctx () in
+  let keeper_ctx : _ Tool_keeper.context =
+    { config = ctx.config; sw; clock = Eio.Stdenv.clock env }
+  in
+  match
+    Tool_keeper.dispatch keeper_ctx ~name:"masc_keeper_up"
+      ~args:
+        (`Assoc
+          [
+            ("name", `String "admin-keeper");
+            ("goal", `String "Admin tool policy test");
+            ("models", `List [ `String "llama:qwen3.5-35b-a3b-ud-q8-xl" ]);
+            ("presence_keepalive", `Bool false);
+            ("proactive_enabled", `Bool false);
+          ])
+  with
+  | Some (true, _) -> (
+      let args =
+        `Assoc
+          [
+            ("section", `String "keeper_policy");
+            ("name", `String "admin-keeper");
+            ("autonomy_level", `String "L4_Autonomous");
+            ("policy_mode", `String "heuristic");
+            ("action_budget", `String "board");
+          ]
+      in
+      match Tool_misc.dispatch ctx ~name:"masc_tool_admin_update" ~args with
+      | Some (success, result) ->
+          assert success;
+          let json = parse_json result in
+          assert (Yojson.Safe.Util.(json |> member "section" |> to_string) = "keeper_policy");
+          (match Tool_keeper.read_meta ctx.config "admin-keeper" with
+          | Ok (Some meta) ->
+              assert (meta.autonomy_level = "l4_autonomous" || meta.autonomy_level = "L4_Autonomous");
+              assert (meta.policy_action_budget = "board")
+          | _ -> failwith "expected updated keeper meta")
+      | None -> failwith "dispatch returned None")
+  | Some (false, err) -> failwith err
+  | None -> failwith "keeper up dispatch returned None"
 )
 
 (* Test helper functions *)

--- a/test/test_tools_coverage.ml
+++ b/test/test_tools_coverage.ml
@@ -722,6 +722,30 @@ let test_masc_keeper_eval_replay_schema () =
             (List.mem_assoc "limit" props)
       | None -> Alcotest.fail "masc_keeper_eval_replay missing properties"
 
+let test_masc_tool_admin_snapshot_schema () =
+  match find_tool "masc_tool_admin_snapshot" with
+  | None -> Alcotest.fail "masc_tool_admin_snapshot not found"
+  | Some schema ->
+      match get_json_assoc "properties" schema.input_schema with
+      | Some props ->
+          Alcotest.(check bool) "has include_hidden" true
+            (List.mem_assoc "include_hidden" props);
+          Alcotest.(check bool) "has include_deprecated" true
+            (List.mem_assoc "include_deprecated" props)
+      | None -> Alcotest.fail "masc_tool_admin_snapshot missing properties"
+
+let test_masc_tool_admin_update_schema () =
+  match find_tool "masc_tool_admin_update" with
+  | None -> Alcotest.fail "masc_tool_admin_update not found"
+  | Some schema ->
+      match get_json_assoc "properties" schema.input_schema with
+      | Some props ->
+          Alcotest.(check bool) "has section" true (List.mem_assoc "section" props);
+          Alcotest.(check bool) "has policy" true (List.mem_assoc "policy" props);
+          Alcotest.(check bool) "has autonomy_level" true
+            (List.mem_assoc "autonomy_level" props)
+      | None -> Alcotest.fail "masc_tool_admin_update missing properties"
+
 (* ============================================================ *)
 (* 13. Cache Tool Tests                                          *)
 (* ============================================================ *)
@@ -1107,6 +1131,10 @@ let () =
         test_masc_keeper_action_explain_schema;
       Alcotest.test_case "keeper-eval-replay" `Quick
         test_masc_keeper_eval_replay_schema;
+      Alcotest.test_case "tool-admin-snapshot" `Quick
+        test_masc_tool_admin_snapshot_schema;
+      Alcotest.test_case "tool-admin-update" `Quick
+        test_masc_tool_admin_update_schema;
       Alcotest.test_case "llama-models" `Quick test_masc_llama_models_schema;
       Alcotest.test_case "team-session-step-spawn-selection-note" `Quick
         test_masc_team_session_step_spawn_selection_note_schema;


### PR DESCRIPTION
## Summary
- add `masc_tool_admin_snapshot` for unified tool/auth/mode/keeper/policy visibility
- add `masc_tool_admin_update` to route mode/auth/unit policy/keeper policy changes through one surface
- mark CPv2 tool/model allowlists as advisory-only until runtime enforcement exists

## Verification
- dune build --root ./.worktrees/feat-tool-admin ./test/test_tools_coverage.exe ./test/test_auth_coverage.exe ./test/test_mode_coverage.exe ./test/test_tool_misc_coverage.exe
- dune exec --root ./.worktrees/feat-tool-admin ./test/test_auth_coverage.exe
- ./_build/default/test/test_mode_coverage.exe test tool_category 9,10 --color=never
- ./_build/default/test/test_tools_coverage.exe test mitosis_tools 10,11 --color=never
- dune exec --root ./.worktrees/feat-tool-admin ./test/test_tool_misc_coverage.exe
- git diff --check
