### PR TITLE
refactor(llm): add default model alias

### DIFF
--- a/bin/perpetual_cli.ml
+++ b/bin/perpetual_cli.ml
@@ -96,7 +96,7 @@ let rec parse_args args acc =
     eprintf "Usage: perpetual_cli --goal GOAL --models MODEL1,MODEL2 [OPTIONS]\n\n\
 Options:\n\
   --goal GOAL           Goal for the agent\n\
-  --models M1,M2,...    Model cascade (provider:model format)\n\
+  --models M1,M2,...    Model cascade ('default' or provider:model)\n\
   --no-verify           Disable action verification\n\
   --verify-with MODEL   Verifier model (default: provider-aware auto selection)\n\
   --heartbeat SECS      Heartbeat interval (default: 30)\n\

--- a/docs/KEEPER-CONTINUITY-VALIDATION.md
+++ b/docs/KEEPER-CONTINUITY-VALIDATION.md
@@ -58,7 +58,7 @@ Real isolated validation:
 
 ```bash
 cd ~/me/workspace/yousleepwhen/masc-mcp
-KEEPER_MODELS="ollama:glm-4.7-flash" \
+KEEPER_MODELS="default" \
 scripts/harness_keeper_continuity_validation.sh
 ```
 
@@ -68,7 +68,7 @@ Use an existing MCP server instead of starting a temp one:
 cd ~/me/workspace/yousleepwhen/masc-mcp
 START_SERVER=0 \
 MCP_URL="http://127.0.0.1:8935/mcp" \
-KEEPER_MODELS="ollama:glm-4.7-flash" \
+KEEPER_MODELS="default" \
 scripts/harness_keeper_continuity_validation.sh
 ```
 

--- a/docs/TRPG-KEEPER-SPECTATOR-QUICKSTART.md
+++ b/docs/TRPG-KEEPER-SPECTATOR-QUICKSTART.md
@@ -11,7 +11,7 @@ Updated: 2026-03-02
 
 - `masc-mcp` 서버가 HTTP 모드로 실행 중이어야 한다. (`/mcp`, `/health` 접근 가능)
 - Viewer 실행에 `trunk`가 필요하다.
-- 최소 1개 이상의 실행 가능한 모델이 준비되어야 한다. (`new-game-models` 또는 `KEEPER_MODELS`)
+- 최소 1개 이상의 실행 가능한 모델이 준비되어야 한다. (`new-game-models` 또는 `KEEPER_MODELS`, 권장: `default`)
 
 ## 3. 관전 루트 A (Viewer UI 권장)
 
@@ -40,7 +40,7 @@ make viewer-serve
 1. 상단 `새 게임` 클릭
 2. `DM` 1명 선택
 3. 플레이어 keeper 선택 (권장 4명)
-4. `new-game-models` 확인 (예: `glm:glm-4.7`)
+4. `new-game-models` 확인 (권장: `default`)
 5. `세션 시작` 클릭
 
 ### 3.4 관전 시작
@@ -54,7 +54,7 @@ make viewer-serve
 Viewer에서 직접 세션을 만들지 않고, 터미널에서 TRPG 세션 + keeper 배치를 먼저 만든다.
 
 ```bash
-KEEPER_MODELS="glm:glm-4.7" \
+KEEPER_MODELS="default" \
 RUN_ROUND=1 \
 ROUNDS=3 \
 scripts/run_trpg_grimland_smoke.sh

--- a/lib/keeper_schema.ml
+++ b/lib/keeper_schema.ml
@@ -131,7 +131,7 @@ let resident_schemas : tool_schema list = [
         ("models", `Assoc [
           ("type", `String "array");
           ("items", `Assoc [("type", `String "string")]);
-          ("description", `String "Model cascade (provider:model). Examples: 'claude:opus', 'gemini:gemini-3.1-pro-preview', 'glm:glm-4.7', 'openrouter:openai/gpt-4o-mini'.");
+          ("description", `String "Model cascade. Accepts 'default' or 'default:<model>' as the primary public path, plus explicit 'provider:model' overrides when needed.");
         ]);
         ("allowed_models", `Assoc [
           ("type", `String "array");
@@ -140,7 +140,7 @@ let resident_schemas : tool_schema list = [
         ]);
         ("active_model", `Assoc [
           ("type", `String "string");
-          ("description", `String "Current persisted model for the keeper. When set, explicit-only keepers use this exact model instead of fallback selection.");
+          ("description", `String "Current persisted model label. Prefer 'default' for adapter-managed selection; explicit-only keepers may still pin a concrete provider:model label.");
         ]);
         ("scope_kind", `Assoc [
           ("type", `String "string");

--- a/lib/llm_client.ml
+++ b/lib/llm_client.ml
@@ -988,14 +988,37 @@ let cascade ?(accept = fun _ -> true) ?timeout_sec
 (* Model Spec Parser                                                *)
 (* ================================================================ *)
 
-let model_spec_of_string s =
+let rec model_spec_of_string s =
   let s = String.trim s in
+  if String.equal (String.lowercase_ascii s) "default" then
+    match Provider_adapter.default_model_label_result () with
+    | Ok label -> model_spec_of_string label
+    | Error _ as e -> e
+  else if
+    String.length s > 8
+    && String.equal
+         (String.lowercase_ascii (String.sub s 0 8))
+         "default:"
+  then
+    let override_model =
+      String.sub s 8 (String.length s - 8) |> String.trim
+    in
+    (match Provider_adapter.default_model_override_label_result override_model with
+    | Ok label -> model_spec_of_string label
+    | Error _ as e -> e)
+  else
   match String.index_opt s ':' with
   | None ->
-    Error (sprintf "Cannot parse model spec: %s (expected provider:model)" s)
+    Error
+      (sprintf
+         "Cannot parse model spec: %s (expected provider:model or default[:model])"
+         s)
   | Some idx ->
     if idx = 0 || idx >= String.length s - 1 then
-      Error (sprintf "Cannot parse model spec: %s (expected provider:model)" s)
+      Error
+        (sprintf
+           "Cannot parse model spec: %s (expected provider:model or default[:model])"
+           s)
     else
       let provider = String.sub s 0 idx |> String.lowercase_ascii in
       let model_id =
@@ -1003,7 +1026,10 @@ let model_spec_of_string s =
         |> String.trim
       in
       if model_id = "" then
-        Error (sprintf "Cannot parse model spec: %s (expected provider:model)" s)
+        Error
+          (sprintf
+             "Cannot parse model spec: %s (expected provider:model or default[:model])"
+             s)
       else
         match Provider_adapter.resolve_direct_adapter provider with
         | Some adapter when adapter.canonical_name = "llama" ->
@@ -1106,9 +1132,9 @@ let first_available_model_spec labels =
   | spec :: _ -> Ok spec
   | [] ->
       Error
-        "No default model available. Set MASC_DEFAULT_MODEL / MASC_DEFAULT_VERIFIER_MODEL, \
-         configure a supported provider credential (ZAI_API_KEY, GEMINI_API_KEY, \
-         GOOGLE_CLOUD_PROJECT, ANTHROPIC_API_KEY, OPENAI_API_KEY), or pass a model explicitly."
+        "No default model available. Set MASC_DEFAULT_CASCADE, \
+         MASC_DEFAULT_PROVIDER/MASC_DEFAULT_MODEL, or provider credentials for the \
+         preferred fallback chain, or pass an explicit model."
 
 let default_execution_model_spec () =
   first_available_model_spec (default_execution_model_labels ())

--- a/lib/llm_client.mli
+++ b/lib/llm_client.mli
@@ -194,7 +194,7 @@ val run_prompt_cascade :
 val cache_key_of_request : completion_request -> string
 
 (** Parse model spec from string like "glm:glm-4.7",
-    "claude:opus", or "gemini:gemini-3-flash-preview".
+    "claude:opus", "default", or "default:gemini-2.5-flash".
     Splits at the first ':' only, so model IDs may contain additional ':'. *)
 val model_spec_of_string : string -> (model_spec, string) result
 

--- a/lib/provider_adapter.ml
+++ b/lib/provider_adapter.ml
@@ -233,7 +233,7 @@ let dedupe_keep_order items =
     items
 
 let bare_ollama_migration_message () =
-  "Bare `ollama` is no longer supported. Use `ollama:<model>` for provider selection, or use `llama`/`glm` for local execution."
+  "Bare `ollama` is no longer supported. Use `default` for normal selection, or `llama:<model>` / another explicit provider:model label as an override."
 
 let is_bare_ollama_label label =
   String.equal (normalize_label label) "ollama"
@@ -346,6 +346,32 @@ let default_model_label_result () =
   | Ok (first :: _) -> Ok first
   | Ok [] -> Error "No default model configured"
   | Error _ as e -> e
+
+let provider_prefix_of_label_result label =
+  let normalized = String.trim label in
+  match String.index_opt normalized ':' with
+  | Some idx when idx > 0 ->
+      Ok
+        (String.sub normalized 0 idx |> String.trim |> String.lowercase_ascii)
+  | _ ->
+      Error
+        (Printf.sprintf
+           "Default model label must be provider:model, got: %s"
+           normalized)
+
+let default_model_provider_prefix_result () =
+  match default_model_label_result () with
+  | Ok label -> provider_prefix_of_label_result label
+  | Error _ as e -> e
+
+let default_model_override_label_result model_id =
+  let model_id = String.trim model_id in
+  if model_id = "" then
+    Error "default:<model> requires a non-empty model id"
+  else
+    match default_model_provider_prefix_result () with
+    | Ok provider -> Ok (provider ^ ":" ^ model_id)
+    | Error _ as e -> e
 
 let default_local_model_label () =
   match default_model_label_result () with

--- a/lib/tool_perpetual.ml
+++ b/lib/tool_perpetual.ml
@@ -19,7 +19,7 @@ let schemas : Types.tool_schema list = [
 The agent will think → act → observe → verify in a loop, compacting context as needed \
 and handing off to successor agents when context fills up. \
 Requires: goal (what to accomplish), models (LLM cascade in priority order). \
-Example models: 'gemini:gemini-3-flash-preview', 'claude:opus', 'glm:glm-4.7', 'openrouter:openai/gpt-4o-mini'.";
+Example models: 'default', 'default:glm-5', 'gemini:gemini-3-flash-preview', 'claude:opus'.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -31,7 +31,7 @@ Example models: 'gemini:gemini-3-flash-preview', 'claude:opus', 'glm:glm-4.7', '
           ("type", `String "array");
           ("items", `Assoc [("type", `String "string")]);
           ("description", `String "LLM model cascade in priority order. \
-Format: 'provider:model_id'. Examples: 'gemini:gemini-3-flash-preview', 'claude:opus', 'glm:glm-4.7', 'openrouter:openai/gpt-4o-mini'");
+Format: 'provider:model_id' or 'default[:model_id]'. Examples: 'default', 'default:glm-5', 'gemini:gemini-3-flash-preview', 'claude:opus'");
         ]);
         ("verify", `Assoc [
           ("type", `String "boolean");

--- a/lib/tools.ml
+++ b/lib/tools.ml
@@ -2251,7 +2251,7 @@ Embodies proactive mitosis: prepare early at 50%, handoff at 80%.|};
         ]);
         ("target_agent", `Assoc [
           ("type", `String "string");
-          ("description", `String "Agent to spawn: 'claude'|'gemini'|'codex'|'llama' (default: claude). Bare 'ollama' is unsupported; use ollama:<model> only in model fields.");
+          ("description", `String "Agent to spawn: 'claude'|'gemini'|'codex'|'llama' (default: claude). Prefer 'default' in model fields for adapter-managed selection; explicit provider:model labels remain available as overrides.");
         ]);
         ("async", `Assoc [
           ("type", `String "boolean");
@@ -2266,7 +2266,7 @@ Embodies proactive mitosis: prepare early at 50%, handoff at 80%.|};
         ("verifier_models", `Assoc [
           ("type", `String "array");
           ("items", `Assoc [("type", `String "string")]);
-          ("description", `String "Verifier model list (provider:model). Default: provider-aware auto selection from explicit env or available remote credentials.");
+          ("description", `String "Verifier model list. Prefer 'default' or 'default:<model>' for normal use; explicit provider:model labels remain valid as overrides.");
         ]);
         ("verifier_perspectives", `Assoc [
           ("type", `String "array");
@@ -3013,7 +3013,7 @@ Example: masc_a2a_unsubscribe({subscription_id: 'sub-abc123'})";
         ]);
         ("agent_name", `Assoc [
           ("type", `String "string");
-          ("description", `String "Agent to spawn (claude, gemini, codex, llama). Bare 'ollama' is unsupported; use ollama:<model> only in model fields.");
+          ("description", `String "Agent to spawn (claude, gemini, codex, llama). Bare 'ollama' is unsupported; use 'default' in model fields for adapter-managed selection.");
         ]);
         ("additional_instructions", `Assoc [
           ("type", `String "string");

--- a/test/test_llm_client_cascade.ml
+++ b/test/test_llm_client_cascade.ml
@@ -163,6 +163,24 @@ let test_model_spec_of_string_parses_llama_provider () =
       check string "model id" "glm-4.7-flash" spec.model_id
   | Error e -> fail ("expected llama: provider to parse: " ^ e)
 
+let test_model_spec_of_string_resolves_default_label () =
+  with_env "MASC_DEFAULT_PROVIDER" "glm" (fun () ->
+      with_env "MASC_DEFAULT_MODEL" "glm-4.7" (fun () ->
+          match Llm_client.model_spec_of_string "default" with
+          | Ok spec ->
+              check bool "provider" true (spec.provider = Llm_client.Glm_cloud);
+              check string "model id" "glm-4.7" spec.model_id
+          | Error e -> fail ("expected default to resolve: " ^ e)))
+
+let test_model_spec_of_string_resolves_default_override () =
+  with_env "MASC_DEFAULT_PROVIDER" "gemini" (fun () ->
+      with_env "MASC_DEFAULT_MODEL" "gemini-2.5-pro" (fun () ->
+          match Llm_client.model_spec_of_string "default:gemini-2.5-flash" with
+          | Ok spec ->
+              check bool "provider" true (spec.provider = Llm_client.Gemini);
+              check string "model id" "gemini-2.5-flash" spec.model_id
+          | Error e -> fail ("expected default override to resolve: " ^ e)))
+
 let test_run_prompt_cascade_uses_same_request_shape () =
   with_temp_cwd (fun () ->
       Cache.clear_l1 ();
@@ -214,6 +232,10 @@ let () =
             test_model_spec_of_string_rejects_bare_ollama_provider;
           test_case "parses llama provider" `Quick
             test_model_spec_of_string_parses_llama_provider;
+          test_case "resolves default label" `Quick
+            test_model_spec_of_string_resolves_default_label;
+          test_case "resolves default override" `Quick
+            test_model_spec_of_string_resolves_default_override;
           test_case "run_prompt_cascade request shape" `Quick
             test_run_prompt_cascade_uses_same_request_shape;
         ] );

--- a/test/test_provider_adapter.ml
+++ b/test/test_provider_adapter.ml
@@ -70,6 +70,22 @@ let test_default_local_model_label () =
           check string "default local label" "glm:glm-4.7"
             (Adapter.default_local_model_label ())))
 
+let test_default_model_provider_prefix_result () =
+  with_env "MASC_DEFAULT_PROVIDER" (Some "glm") (fun () ->
+      with_env "MASC_DEFAULT_MODEL" (Some "glm-4.7") (fun () ->
+          match Adapter.default_model_provider_prefix_result () with
+          | Ok prefix -> check string "default provider prefix" "glm" prefix
+          | Error msg -> fail msg))
+
+let test_default_model_override_label_result () =
+  with_env "MASC_DEFAULT_PROVIDER" (Some "gemini") (fun () ->
+      with_env "MASC_DEFAULT_MODEL" (Some "gemini-2.5-pro") (fun () ->
+          match Adapter.default_model_override_label_result "gemini-2.5-flash" with
+          | Ok label ->
+              check string "override keeps provider" "gemini:gemini-2.5-flash"
+                label
+          | Error msg -> fail msg))
+
 let () =
   run "Provider Adapter"
     [
@@ -84,5 +100,9 @@ let () =
           test_case "vertex base url" `Quick test_vertex_base_url;
           test_case "default cli agent" `Quick test_default_cli_agent_name;
           test_case "default local model label" `Quick test_default_local_model_label;
+          test_case "default provider prefix" `Quick
+            test_default_model_provider_prefix_result;
+          test_case "default override label" `Quick
+            test_default_model_override_label_result;
         ] );
     ]


### PR DESCRIPTION
## Summary
- add `default` / `default:<model>` as public model aliases resolved through `provider_adapter`
- keep explicit `provider:model` labels as advanced overrides
- update user-facing schemas/help/docs to recommend `default` first

## Validation
- `dune build --root .`
- `_build/default/test/test_provider_adapter.exe`
- `_build/default/test/test_llm_client_cascade.exe`
- `timeout 300 _build/default/test/test_perpetual.exe`

## Notes
- default resolution reuses existing SSOT: `MASC_DEFAULT_CASCADE` or `MASC_DEFAULT_PROVIDER`/`MASC_DEFAULT_MODEL`
- explicit `provider:model` inputs remain supported as overrides