### PR TITLE
Add internal local voice playback orchestration

### DIFF
--- a/lib/voice_bridge_eio.ml
+++ b/lib/voice_bridge_eio.ml
@@ -136,6 +136,84 @@ let log_error msg =
 let log_debug msg =
   Log.debug "%s %s" log_prefix msg
 
+let local_playback_enabled config ~agent_id =
+  config.Voice_config.local_playback.enabled
+  &&
+  (match config.local_playback.agents with
+  | [] -> true
+  | agents -> List.mem agent_id agents)
+
+let split_path_env value =
+  String.split_on_char ':' value
+  |> List.filter (fun entry -> String.trim entry <> "")
+
+let find_executable_in_path ?path_value executable =
+  let path_value =
+    match path_value with
+    | Some value -> value
+    | None -> Option.value (Sys.getenv_opt "PATH") ~default:""
+  in
+  let candidates =
+    split_path_env path_value
+    |> List.map (fun dir -> Filename.concat dir executable)
+  in
+  List.find_opt (fun path -> Sys.file_exists path && not (Sys.is_directory path)) candidates
+
+let local_playback_argv ?path_value ~audio_file () =
+  let commands =
+    [
+      ("ffplay", [ "-nodisp"; "-autoexit"; "-loglevel"; "error" ]);
+      ("mpg123", [ "-q" ]);
+      ("play", [ "-q" ]);
+      ("open", []);
+    ]
+  in
+  let rec pick = function
+    | [] -> None
+    | (executable, args) :: rest -> (
+        match find_executable_in_path ?path_value executable with
+        | Some path -> Some (path :: args @ [ audio_file ])
+        | None -> pick rest)
+  in
+  pick commands
+
+let start_local_playback ~sw ~agent_id ~audio_file =
+  match load_voice_config () with
+  | Error _ -> ()
+  | Ok config ->
+      if not (local_playback_enabled config ~agent_id) then
+        ()
+      else
+        match local_playback_argv ~audio_file () with
+        | None ->
+            log_error
+              "local voice playback unavailable: no ffplay/mpg123/play/open executable found"
+        | Some argv ->
+          Eio.Fiber.fork ~sw (fun () ->
+              match Process_eio.run_argv_with_status ~timeout_sec:180.0 argv with
+              | Unix.WEXITED 0, _ ->
+                  log_info
+                    (Printf.sprintf "local voice playback finished: agent=%s file=%s via=%s"
+                       agent_id audio_file (List.hd argv))
+              | Unix.WEXITED code, output ->
+                  log_error
+                    (Printf.sprintf
+                       "local voice playback failed (exit=%d): %s%s"
+                       code (String.concat " " argv)
+                       (if String.trim output = "" then "" else " :: " ^ String.trim output))
+              | Unix.WSTOPPED signal, output ->
+                  log_error
+                    (Printf.sprintf
+                       "local voice playback stopped (sig=%d): %s%s"
+                       signal (String.concat " " argv)
+                       (if String.trim output = "" then "" else " :: " ^ String.trim output))
+              | Unix.WSIGNALED signal, output ->
+                  log_error
+                    (Printf.sprintf
+                       "local voice playback signaled (sig=%d): %s%s"
+                       signal (String.concat " " argv)
+                       (if String.trim output = "" then "" else " :: " ^ String.trim output)))
+
 (** Get voice for agent, defaults to "Sarah" if config is unavailable *)
 let get_voice_for_agent agent_id =
   let voices = agent_voices () in
@@ -687,6 +765,7 @@ let attempt_tts_endpoint ~sw ~clock ~net ~agent_id ~message ~voice ~model
            ~output_file:audio_file
        with
       | Ok file_size ->
+          start_local_playback ~sw ~agent_id ~audio_file;
           Ok
             (append_provider_metadata
                (`Assoc
@@ -711,6 +790,7 @@ let attempt_tts_endpoint ~sw ~clock ~net ~agent_id ~message ~voice ~model
            ~output_file:audio_file
        with
       | Ok file_size ->
+          start_local_playback ~sw ~agent_id ~audio_file;
           Ok
             (append_provider_metadata
                (`Assoc

--- a/lib/voice_config.ml
+++ b/lib/voice_config.ml
@@ -29,10 +29,16 @@ type stt_config = {
 
 type session_config = { endpoints : endpoint list }
 
+type local_playback_config = {
+  enabled : bool;
+  agents : string list;
+}
+
 type t = {
   tts : tts_config;
   stt : stt_config;
   session : session_config;
+  local_playback : local_playback_config;
 }
 
 let ( let* ) = Result.bind
@@ -48,6 +54,19 @@ let trim_nonempty = function
   | `String value ->
       let trimmed = String.trim value in
       if trimmed = "" then None else Some trimmed
+  | _ -> None
+
+let string_list_opt = function
+  | `List items ->
+      let rec loop acc = function
+        | [] -> Some (List.rev acc)
+        | item :: rest -> (
+            match trim_nonempty item with
+            | Some value -> loop (value :: acc) rest
+            | None -> None)
+      in
+      loop [] items
+  | `Null -> Some []
   | _ -> None
 
 let bool_or_default default = function
@@ -196,6 +215,21 @@ let parse_session json =
   let* endpoints = parse_endpoints ~ctx:"session.endpoints" [] endpoints_json in
   Ok { endpoints }
 
+let parse_local_playback json =
+  match Yojson.Safe.Util.member "local_playback" json with
+  | `Null -> Ok { enabled = false; agents = [] }
+  | `Assoc local_json ->
+      let enabled =
+        Yojson.Safe.Util.member "enabled" (`Assoc local_json) |> bool_or_default false
+      in
+      let agents =
+        match Yojson.Safe.Util.member "agents" (`Assoc local_json) |> string_list_opt with
+        | Some values -> values
+        | None -> []
+      in
+      Ok { enabled; agents }
+  | _ -> Error "root.local_playback must be object"
+
 let load () =
   let path = config_path () in
   if not (Sys.file_exists path) then
@@ -207,16 +241,18 @@ let load () =
       let* tts = parse_tts json in
       let* stt = parse_stt json in
       let* session = parse_session json in
-      Ok { tts; stt; session }
+      let* local_playback = parse_local_playback json in
+      Ok { tts; stt; session; local_playback }
     with
     | Yojson.Json_error error ->
         Error (Printf.sprintf "invalid voice config json: %s" error)
     | Sys_error error ->
         Error (Printf.sprintf "voice config read failed: %s" error)
 
-let enabled_endpoints endpoints = List.filter (fun endpoint -> endpoint.enabled) endpoints
+let enabled_endpoints (endpoints : endpoint list) =
+  List.filter (fun (endpoint : endpoint) -> endpoint.enabled) endpoints
 
-let select_endpoint ?endpoint_id endpoints =
+let select_endpoint ?endpoint_id (endpoints : endpoint list) =
   let endpoints = enabled_endpoints endpoints in
   match endpoint_id with
   | Some id when String.trim id <> "" -> (
@@ -304,4 +340,12 @@ let public_json config =
           ] );
       ( "session",
         `Assoc [ ("active_endpoint", active_endpoint_json config.session.endpoints) ] );
+      ( "local_playback",
+        `Assoc
+          [
+            ("enabled", `Bool config.local_playback.enabled);
+            ( "agents",
+              `List
+                (List.map (fun agent -> `String agent) config.local_playback.agents) );
+          ] );
     ]

--- a/test/test_tool_voice.ml
+++ b/test/test_tool_voice.ml
@@ -3,6 +3,7 @@
 open Alcotest
 
 module Tool_voice = Masc_mcp.Tool_voice
+module Voice_bridge = Masc_mcp.Voice_bridge
 
 let contains haystack needle =
   let text = String.lowercase_ascii haystack in
@@ -218,6 +219,10 @@ let test_voice_conference_end_with_unavailable_server_counts_skipped () =
         "enabled": true
       }
     ]
+  },
+  "local_playback": {
+    "enabled": true,
+    "agents": ["sangsu"]
   }
 }
 |}
@@ -280,6 +285,10 @@ let test_voice_public_config_json () =
         "enabled": true
       }
     ]
+  },
+  "local_playback": {
+    "enabled": true,
+    "agents": ["sangsu"]
   }
 }
 |}
@@ -295,9 +304,51 @@ let test_voice_public_config_json () =
         (json |> member "tts" |> member "preview_url" |> to_string);
       check string "active endpoint id" "railway-proxy"
         (json |> member "tts" |> member "active_endpoint" |> member "id" |> to_string);
+      check bool "local playback enabled" true
+        (json |> member "local_playback" |> member "enabled" |> to_bool);
+      check bool "local playback agent sangsu" true
+        (json |> member "local_playback" |> member "agents" |> to_list
+         |> List.exists (function `String "sangsu" -> true | _ -> false));
       check bool "includes sangsu voice" true
         (json |> member "tts" |> member "available_voices" |> to_list
          |> List.exists (function `String "Josh" -> true | _ -> false))
+
+let touch_executable dir name =
+  let path = Filename.concat dir name in
+  let oc = open_out path in
+  output_string oc "#!/bin/sh\nexit 0\n";
+  close_out oc;
+  Unix.chmod path 0o755;
+  path
+
+let test_local_playback_argv_prefers_ffplay () =
+  let dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir dir)
+    (fun () ->
+      let ffplay = touch_executable dir "ffplay" in
+      ignore (touch_executable dir "mpg123");
+      let argv =
+        Voice_bridge.local_playback_argv ~path_value:dir
+          ~audio_file:"/tmp/sample.mp3" ()
+      in
+      check (option (list string)) "ffplay selected first"
+        (Some [ ffplay; "-nodisp"; "-autoexit"; "-loglevel"; "error"; "/tmp/sample.mp3" ])
+        argv)
+
+let test_local_playback_argv_falls_back_to_open () =
+  let dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir dir)
+    (fun () ->
+      let open_cmd = touch_executable dir "open" in
+      let argv =
+        Voice_bridge.local_playback_argv ~path_value:dir
+          ~audio_file:"/tmp/sample.mp3" ()
+      in
+      check (option (list string)) "open fallback selected"
+        (Some [ open_cmd; "/tmp/sample.mp3" ])
+        argv)
 
 let () =
   run "Tool_voice"
@@ -318,5 +369,9 @@ let () =
             test_voice_conference_end_with_unavailable_server_counts_skipped;
           test_case "voice public config json" `Quick
             test_voice_public_config_json;
+          test_case "local playback argv prefers ffplay" `Quick
+            test_local_playback_argv_prefers_ffplay;
+          test_case "local playback argv falls back to open" `Quick
+            test_local_playback_argv_falls_back_to_open;
         ] );
     ]


### PR DESCRIPTION
## Summary
- add local_playback config support to the public voice config payload
- run local voice playback directly inside masc-mcp instead of delegating to an external helper script
- add deterministic player selection tests for ffplay -> mpg123 -> play -> open

## Verification
- dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/voice-local-playback-hook test/test_tool_voice.exe
- /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/voice-local-playback-hook/_build/default/test/test_tool_voice.exe
