### PR TITLE
feat(llama): enforce global local output budget

### DIFF
--- a/lib/env_config.ml
+++ b/lib/env_config.ml
@@ -250,6 +250,10 @@ module Llama = struct
   (** Default local runtime model id for llama.cpp/OpenAI-compatible servers. *)
   let default_model =
     get_string ~default:"explicit-model-required" "LLAMA_DEFAULT_MODEL"
+
+  (** Global output budget for all local llama-provider requests. *)
+  let max_tokens =
+    get_int ~default:32768 "MASC_LLAMA_MAX_TOKENS"
 end
 
 (** {1 Federation Configuration} *)

--- a/lib/llm_client.ml
+++ b/lib/llm_client.ml
@@ -264,6 +264,11 @@ let message_fingerprint_json (m : message) : Yojson.Safe.t =
     ]
 
 let completion_request_fingerprint_json (req : completion_request) : Yojson.Safe.t =
+  let req =
+    if req.model.provider = Llama && req.max_tokens <> Env_config.Llama.max_tokens
+    then { req with max_tokens = Env_config.Llama.max_tokens }
+    else req
+  in
   `Assoc
     [
       ("schema_version", `String completion_cache_schema_version);
@@ -442,6 +447,11 @@ let tool_def_to_openai_json (td : tool_def) : Yojson.Safe.t =
     Gemini's OpenAI-compat endpoint uses [max_completion_tokens] (thinking models
     consume internal tokens from this budget, so [max_tokens] alone under-allocates). *)
 let build_openai_body (req : completion_request) : string =
+  let req =
+    if req.model.provider = Llama && req.max_tokens <> Env_config.Llama.max_tokens
+    then { req with max_tokens = Env_config.Llama.max_tokens }
+    else req
+  in
   let messages_json =
     req.messages |> sanitize_messages_utf8 |> List.map message_to_openai_json
   in
@@ -473,6 +483,11 @@ let build_openai_body (req : completion_request) : string =
 
 (** Build Anthropic Messages API request body. *)
 let build_claude_body (req : completion_request) : string =
+  let req =
+    if req.model.provider = Llama && req.max_tokens <> Env_config.Llama.max_tokens
+    then { req with max_tokens = Env_config.Llama.max_tokens }
+    else req
+  in
   let sanitized_messages = sanitize_messages_utf8 req.messages in
   (* Claude uses separate system parameter *)
   let system_text = List.fold_left (fun acc m ->
@@ -819,13 +834,20 @@ let call_claude ?timeout_sec (req : completion_request) : (completion_response, 
     | Ok raw -> parse_claude_response raw
 
 let call_openai_compatible ?timeout_sec (req : completion_request) : (completion_response, string) result =
+  let effective_req =
+    if req.model.provider = Llama && req.max_tokens <> Env_config.Llama.max_tokens
+    then { req with max_tokens = Env_config.Llama.max_tokens }
+    else req
+  in
   match resolve_openai_compatible_endpoint req.model with
   | Error e -> Error e
   | Ok (base_url, path, auth_headers) ->
       let url = sprintf "%s%s" base_url path in
-      let body = build_openai_body req in
-      Printf.eprintf "[llm_client] openai-compat req: model=%s provider=%s max_tokens=%d tools=%d url=%s\n%!"
-        req.model.model_id (string_of_provider req.model.provider) req.max_tokens (List.length req.tools) url;
+      let body = build_openai_body effective_req in
+      Printf.eprintf
+        "[llm_client] openai-compat req: model=%s provider=%s requested_max_tokens=%d effective_max_tokens=%d tools=%d url=%s\n%!"
+        req.model.model_id (string_of_provider req.model.provider) req.max_tokens
+        effective_req.max_tokens (List.length req.tools) url;
       if req.tools <> [] then begin
         let body_trunc = if String.length body > 1500 then String.sub body 0 1500 ^ "..." else body in
         Printf.eprintf "[llm_client] openai-compat body (tools present, %d bytes): %s\n%!" (String.length body) body_trunc
@@ -868,6 +890,11 @@ let call_glm_cloud_with_pool ?timeout_sec (req : completion_request) : (completi
 
 let complete ?timeout_sec (req : completion_request) : (completion_response, string) result =
   let t0 = Time_compat.now () in
+  let req =
+    if req.model.provider = Llama && req.max_tokens <> Env_config.Llama.max_tokens
+    then { req with max_tokens = Env_config.Llama.max_tokens }
+    else req
+  in
   let cache_key =
     match cache_bypass_reason req with
     | Some reason ->

--- a/test/test_llm_client_cascade.ml
+++ b/test/test_llm_client_cascade.ml
@@ -214,6 +214,43 @@ let test_run_prompt_cascade_uses_same_request_shape () =
           check string "winner" "run-prompt-2" resp.model_used
       | Error e -> fail ("unexpected run_prompt_cascade error: " ^ e))
 
+let test_llama_cache_key_uses_global_output_budget () =
+  let llama_model =
+    { Llm_client.llama_default with model_id = "qwen3.5-35b-a3b-ud-q8-xl" }
+  in
+  let req_short =
+    make_request_for_model ~model:llama_model ~prompt:"same prompt" ~max_tokens:32 ()
+  in
+  let req_long =
+    make_request_for_model ~model:llama_model ~prompt:"same prompt" ~max_tokens:8192 ()
+  in
+  check string "same cache key"
+    (Llm_client.cache_key_of_request req_short)
+    (Llm_client.cache_key_of_request req_long)
+
+let test_non_llama_cache_key_preserves_requested_budget () =
+  let model : Llm_client.model_spec =
+    {
+      provider = Llm_client.Custom "cached";
+      model_id = "shape-check";
+      max_context = 4096;
+      api_url = "http://127.0.0.1:1";
+      api_key_env = None;
+      cost_per_1k_input = 0.0;
+      cost_per_1k_output = 0.0;
+    }
+  in
+  let req_short =
+    make_request_for_model ~model ~prompt:"same prompt" ~max_tokens:32 ()
+  in
+  let req_long =
+    make_request_for_model ~model ~prompt:"same prompt" ~max_tokens:8192 ()
+  in
+  check bool "different cache key"
+    true
+    (Llm_client.cache_key_of_request req_short
+     <> Llm_client.cache_key_of_request req_long)
+
 let () =
   run "llm_client_cascade"
     [
@@ -238,5 +275,9 @@ let () =
             test_model_spec_of_string_resolves_default_override;
           test_case "run_prompt_cascade request shape" `Quick
             test_run_prompt_cascade_uses_same_request_shape;
+          test_case "llama cache key uses global output budget" `Quick
+            test_llama_cache_key_uses_global_output_budget;
+          test_case "non-llama cache key preserves requested budget" `Quick
+            test_non_llama_cache_key_preserves_requested_budget;
         ] );
     ]


### PR DESCRIPTION
## Summary
- enforce one global local-llama output budget in llm_client instead of scattered per-call heuristics
- add MASC_LLAMA_MAX_TOKENS with default 32768 and normalize all Llama provider requests to that value
- add regression coverage proving llama cache keys ignore requested max_tokens while non-llama providers still preserve it

## Verification
- dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/feat-local-qwen-output-budget ./test/test_llm_client_cascade.exe
- timeout 120 /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/feat-local-qwen-output-budget/_build/default/test/test_llm_client_cascade.exe

## Note
- latest origin/main currently has an unrelated full-build blocker at lib/tool_misc.ml -> Tool_keeper.autonomous_gate_config. This branch is scoped to env_config/llm_client/test_llm_client_cascade only, so full dune build may stay red until that blocker is fixed on main.