### PR TITLE
fix(runtime): make sentinel the housekeeping ssot

### DIFF
--- a/bin/main_eio.ml
+++ b/bin/main_eio.ml
@@ -8192,6 +8192,7 @@ let run_server ~sw ~env ~port ~base_path =
   (* Initialize server state with Eio context *)
   let state = Mcp_eio.create_state_eio ~sw ~env:caqti_env ~proc_mgr ~fs ~clock ~net ~base_path in
   server_state := Some state;
+  ignore (Masc_mcp.Room.init state.room_config ~agent_name:None);
   Masc_mcp.Chain_native_eio.configure_storage_paths state.room_config;
   (try Masc_mcp.Tool_command_plane.backfill_chain_overlays state.room_config
    with exn ->

--- a/bin/main_eio.ml
+++ b/bin/main_eio.ml
@@ -8225,8 +8225,15 @@ let run_server ~sw ~env ~port ~base_path =
   Masc_mcp.Lodge_heartbeat.start ~sw ~clock state.room_config;
   (* Gardener — self-organizing agent ecosystem (task-aware, LLM-primary) *)
   Masc_mcp.Gardener.start ~sw ~clock ~room_config:state.room_config;
-  (* Internal guardian loops (no external watchdog dependency) *)
-  Masc_mcp.Guardian.start ~sw ~clock ~net state.room_config;
+  if Masc_mcp.Env_config.Sentinel.enabled then begin
+    (* Sentinel is the SSOT for housekeeping. It embeds zombie/gc loops itself. *)
+    Masc_mcp.Sentinel.start ~sw ~clock ~net state.room_config;
+    (* Lodge patrol remains a Guardian concern and can still be enabled explicitly. *)
+    if Masc_mcp.Env_config.Guardian.enabled then
+      Masc_mcp.Guardian.start_lodge_loop ~sw ~clock ~net
+  end else
+    (* Fallback runtime when sentinel is disabled. *)
+    Masc_mcp.Guardian.start ~sw ~clock ~net state.room_config;
   Masc_mcp.Dashboard_governance_judge.start ~sw ~clock
     ~base_path:state.room_config.base_path
     ~build_facts:(fun () ->

--- a/lib/guardian.ml
+++ b/lib/guardian.ml
@@ -46,6 +46,15 @@ let last_zombie_result : string option ref = ref None
 let last_gc_result : string option ref = ref None
 let last_lodge_result : (bool * string) option ref = ref None
 let lodge_running = ref false
+let zombie_loop_started = ref false
+let gc_loop_started = ref false
+let lodge_loop_started = ref false
+
+type masc_runtime_owner =
+  | Guardian_runtime
+  | Sentinel_runtime
+
+let masc_loops_owner : masc_runtime_owner option ref = ref None
 
 (* Pulse instances — stored for nudge/shutdown/stats access. *)
 let zombie_pulse : Pulse.t option ref = ref None
@@ -72,6 +81,39 @@ let is_quiet_hours () =
 (** Fixed-interval rhythm with no quiet hours. *)
 let fixed_rhythm base_s =
   { Pulse.base_s; min_s = base_s; max_s = base_s; quiet = (0, 0) }
+
+let runtime_owner_to_string = function
+  | Guardian_runtime -> "guardian"
+  | Sentinel_runtime -> "sentinel"
+
+let masc_runtime_owner_label () =
+  match !masc_loops_owner with
+  | None -> "none"
+  | Some owner -> runtime_owner_to_string owner
+
+let masc_loops_running () =
+  !zombie_loop_started || !gc_loop_started
+
+let note_embedded_masc_loops_started_for_tests () =
+  zombie_loop_started := true;
+  gc_loop_started := true;
+  masc_loops_owner := Some Sentinel_runtime
+
+let reset_runtime_state_for_tests () =
+  masc_loops_owner := None;
+  zombie_pulse := None;
+  gc_pulse := None;
+  lodge_pulse_inst := None;
+  lodge_running := false;
+  zombie_loop_started := false;
+  gc_loop_started := false;
+  lodge_loop_started := false;
+  last_zombie_cleanup := None;
+  last_gc := None;
+  last_lodge := None;
+  last_zombie_result := None;
+  last_gc_result := None;
+  last_lodge_result := None
 
 (* ── Pulse Consumer Factories ──────────────────────────────── *)
 
@@ -147,7 +189,12 @@ let status_json () : Yojson.Safe.t =
     ("enabled", `Bool enabled);
     ("mode", `String (Mode.to_string mode));
     ("masc_enabled", `Bool masc_enabled);
+    ("masc_loops_running", `Bool (masc_loops_running ()));
+    ("runtime_owner", `String (masc_runtime_owner_label ()));
+    ("zombie_loop_running", `Bool !zombie_loop_started);
+    ("gc_loop_running", `Bool !gc_loop_started);
     ("lodge_enabled", `Bool lodge_enabled);
+    ("lodge_loop_started", `Bool !lodge_loop_started);
     ("zombie_interval_s", `Float zombie_interval_s);
     ("gc_interval_s", `Float gc_interval_s);
     ("gc_days", `Int gc_days);
@@ -182,11 +229,17 @@ let status_json () : Yojson.Safe.t =
 
 (* ── Start ─────────────────────────────────────────────────── *)
 
-let start_masc_loops ~sw ~clock config =
-  if not masc_enabled then begin
+let start_masc_loops_internal ~owner ~respect_guardian_toggle ~sw ~clock config =
+  let can_start = if respect_guardian_toggle then masc_enabled else true in
+  if not can_start then begin
     log "masc guardian disabled";
     ()
+  end else if masc_loops_running () then begin
+    log
+      (sprintf "masc guardian loops already running (owner=%s)"
+         (masc_runtime_owner_label ()))
   end else begin
+    let started_any = ref false in
     if zombie_interval_s > 0.0 then begin
       let p = Pulse.create
         ~clock
@@ -195,7 +248,9 @@ let start_masc_loops ~sw ~clock config =
         ~consumers:[make_zombie_consumer config]
       in
       zombie_pulse := Some p;
-      Pulse.run ~sw p
+      Pulse.run ~sw p;
+      zombie_loop_started := true;
+      started_any := true
     end;
     if gc_interval_s > 0.0 then begin
       let p = Pulse.create
@@ -205,13 +260,30 @@ let start_masc_loops ~sw ~clock config =
         ~consumers:[make_gc_consumer config]
       in
       gc_pulse := Some p;
-      Pulse.run ~sw p
-    end
+      Pulse.run ~sw p;
+      gc_loop_started := true;
+      started_any := true
+    end;
+    if !started_any then
+      masc_loops_owner := Some owner
+    else
+      log "masc guardian loops disabled by interval configuration"
   end
+
+let start_masc_loops ~sw ~clock config =
+  start_masc_loops_internal ~owner:Guardian_runtime ~respect_guardian_toggle:true
+    ~sw ~clock config
+
+let start_embedded_masc_loops ~sw ~clock config =
+  start_masc_loops_internal ~owner:Sentinel_runtime ~respect_guardian_toggle:false
+    ~sw ~clock config
 
 let start_lodge_loop ~sw ~clock ~net =
   if not lodge_enabled then begin
     log "lodge guardian disabled";
+    ()
+  end else if Option.is_some !lodge_pulse_inst then begin
+    log "guardian lodge loop already running";
     ()
   end else if lodge_interval_s <= 0.0 || lodge_iterations <= 0 then begin
     log "lodge guardian disabled by interval/iterations";
@@ -224,6 +296,7 @@ let start_lodge_loop ~sw ~clock ~net =
       ~consumers:[make_lodge_consumer ~net]
     in
     lodge_pulse_inst := Some p;
+    lodge_loop_started := true;
     Pulse.run ~sw p
   end
 

--- a/lib/sentinel.ml
+++ b/lib/sentinel.ml
@@ -310,6 +310,10 @@ let mark_started_for_tests () =
   started := true;
   start_ts := Time_compat.now ()
 
+let ensure_room_initialized_for_start config =
+  if not (Room.is_initialized config) then
+    ignore (Room.init config ~agent_name:None)
+
 let status_json () : Yojson.Safe.t =
   let embedded_guardian_loops_running = Guardian.masc_loops_running () in
   let consumers =
@@ -344,6 +348,7 @@ let start ~sw ~clock ~net config =
   if not Env_config.Sentinel.enabled then
     log "disabled (set MASC_SENTINEL_ENABLED=true)"
   else begin
+    ensure_room_initialized_for_start config;
     (* 1. Join room as sentinel agent *)
     let join_result = Room.join config ~agent_name ~capabilities:["sentinel"; "housekeeping"] () in
     log (sprintf "join: %s" (String.sub join_result 0 (min 80 (String.length join_result))));

--- a/lib/sentinel.ml
+++ b/lib/sentinel.ml
@@ -302,21 +302,40 @@ let make_keeper_health_consumer _config : (module Pulse.Consumer) =
 let started = ref false
 let start_ts : float ref = ref 0.0
 
+let reset_runtime_state_for_tests () =
+  started := false;
+  start_ts := 0.0
+
+let mark_started_for_tests () =
+  started := true;
+  start_ts := Time_compat.now ()
+
 let status_json () : Yojson.Safe.t =
+  let embedded_guardian_loops_running = Guardian.masc_loops_running () in
+  let consumers =
+    [
+      `String "sentinel-heartbeat";
+    ]
+    @
+    (if embedded_guardian_loops_running then
+       [ `String "guardian-zombie"; `String "guardian-gc" ]
+     else [])
+    @
+    [
+      `String "sentinel-board-patrol";
+      `String "sentinel-task-hygiene";
+      `String "sentinel-keeper-health";
+    ]
+  in
   `Assoc [
     ("enabled", `Bool Env_config.Sentinel.enabled);
     ("started", `Bool !started);
     ("agent_name", `String agent_name);
     ("llm_enabled", `Bool Env_config.Sentinel.llm_enabled);
     ("uptime_s", `Float (if !started then Time_compat.now () -. !start_ts else 0.0));
-    ("consumers", `List [
-      `String "sentinel-heartbeat";
-      `String "guardian-zombie";
-      `String "guardian-gc";
-      `String "sentinel-board-patrol";
-      `String "sentinel-task-hygiene";
-      `String "sentinel-keeper-health";
-    ]);
+    ("embedded_guardian_loops_running", `Bool embedded_guardian_loops_running);
+    ("guardian_runtime_owner", `String (Guardian.masc_runtime_owner_label ()));
+    ("consumers", `List consumers);
   ]
 
 (* ── Start ─────────────────────────────────────────────────── *)
@@ -338,8 +357,8 @@ let start ~sw ~clock ~net config =
     in
     Pulse.run ~sw p_hb;
 
-    (* 3. Guardian consumers: zombie + gc (reuse existing factories) *)
-    Guardian.start_masc_loops ~sw ~clock config;
+    (* 3. Embedded guardian masc loops: zombie + gc stay under sentinel ownership. *)
+    Guardian.start_embedded_masc_loops ~sw ~clock config;
 
     (* 4. Board patrol (10min) *)
     let p_board = Pulse.create
@@ -365,5 +384,5 @@ let start ~sw ~clock ~net config =
     started := true;
     start_ts := Time_compat.now ();
     ignore net;  (* net reserved for future HTTP-based health checks *)
-    log "started (6 consumers: heartbeat, zombie, gc, board-patrol, task-hygiene, keeper-health)"
+    log "started (heartbeat, embedded zombie/gc, board-patrol, task-hygiene, keeper-health)"
   end

--- a/lib/sentinel.mli
+++ b/lib/sentinel.mli
@@ -20,5 +20,11 @@ val start :
   Room_utils.config ->
   unit
 
+(** Test helper: clears in-memory sentinel runtime markers. *)
+val reset_runtime_state_for_tests : unit -> unit
+
+(** Test helper: marks sentinel as started without spawning runtime fibers. *)
+val mark_started_for_tests : unit -> unit
+
 (** JSON status for /health and dashboard. *)
 val status_json : unit -> Yojson.Safe.t

--- a/lib/sentinel.mli
+++ b/lib/sentinel.mli
@@ -26,5 +26,8 @@ val reset_runtime_state_for_tests : unit -> unit
 (** Test helper: marks sentinel as started without spawning runtime fibers. *)
 val mark_started_for_tests : unit -> unit
 
+(** Ensures the room root/current room state exists before sentinel joins. *)
+val ensure_room_initialized_for_start : Room_utils.config -> unit
+
 (** JSON status for /health and dashboard. *)
 val status_json : unit -> Yojson.Safe.t

--- a/test/dune
+++ b/test/dune
@@ -193,6 +193,11 @@
  (modules test_gardener)
  (libraries masc_mcp alcotest eio eio_main str yojson))
 
+(test
+ (name test_guardian_sentinel)
+ (modules test_guardian_sentinel)
+ (libraries masc_mcp alcotest yojson unix))
+
 ; Lodge_reaction module tests (Emergent Identity System)
 (test
  (name test_lodge_reaction)

--- a/test/test_guardian_sentinel.ml
+++ b/test/test_guardian_sentinel.ml
@@ -3,9 +3,24 @@ open Masc_mcp
 
 module U = Yojson.Safe.Util
 
+let with_temp_room_root f =
+  let dir = Filename.temp_dir "guardian-sentinel-" "" in
+  let config = Room.default_config dir in
+  Fun.protect
+    ~finally:(fun () ->
+      if Room.is_initialized config then ignore (Room.reset config);
+      Unix.rmdir dir)
+    (fun () -> f config)
+
 let reset_runtime_state () =
   Guardian.reset_runtime_state_for_tests ();
   Sentinel.reset_runtime_state_for_tests ()
+
+let test_sentinel_ensures_room_initialized () =
+  with_temp_room_root (fun config ->
+    check bool "room starts uninitialized" false (Room.is_initialized config);
+    Sentinel.ensure_room_initialized_for_start config;
+    check bool "room initialized by sentinel helper" true (Room.is_initialized config))
 
 let test_guardian_status_defaults () =
   reset_runtime_state ();
@@ -43,6 +58,7 @@ let () =
   run "Guardian/Sentinel"
     [
       ("runtime", [
+        test_case "sentinel ensures room initialized" `Quick test_sentinel_ensures_room_initialized;
         test_case "guardian status defaults" `Quick test_guardian_status_defaults;
         test_case "guardian embedded loops ignore master switch" `Quick test_guardian_embedded_loops_ignore_master_switch;
         test_case "sentinel reports embedded guardian runtime" `Quick test_sentinel_status_reports_embedded_guardian_runtime;

--- a/test/test_guardian_sentinel.ml
+++ b/test/test_guardian_sentinel.ml
@@ -1,0 +1,50 @@
+open Alcotest
+open Masc_mcp
+
+module U = Yojson.Safe.Util
+
+let reset_runtime_state () =
+  Guardian.reset_runtime_state_for_tests ();
+  Sentinel.reset_runtime_state_for_tests ()
+
+let test_guardian_status_defaults () =
+  reset_runtime_state ();
+  let json = Guardian.status_json () in
+  check bool "guardian enabled default false" false (json |> U.member "enabled" |> U.to_bool);
+  check bool "masc loops not running" false (json |> U.member "masc_loops_running" |> U.to_bool);
+  check string "runtime owner none" "none" (json |> U.member "runtime_owner" |> U.to_string)
+
+let test_guardian_embedded_loops_ignore_master_switch () =
+  reset_runtime_state ();
+  Guardian.note_embedded_masc_loops_started_for_tests ();
+  let json = Guardian.status_json () in
+  check bool "guardian configured disabled" false (json |> U.member "enabled" |> U.to_bool);
+  check bool "embedded loops running" true (json |> U.member "masc_loops_running" |> U.to_bool);
+  check string "owner is sentinel" "sentinel" (json |> U.member "runtime_owner" |> U.to_string)
+
+let test_sentinel_status_reports_embedded_guardian_runtime () =
+  reset_runtime_state ();
+  Sentinel.mark_started_for_tests ();
+  Guardian.note_embedded_masc_loops_started_for_tests ();
+  let sentinel = Sentinel.status_json () in
+  let consumers = sentinel |> U.member "consumers" |> U.to_list |> List.map U.to_string in
+  check bool "sentinel started" true (sentinel |> U.member "started" |> U.to_bool);
+  check bool "embedded guardian loops running" true
+    (sentinel |> U.member "embedded_guardian_loops_running" |> U.to_bool);
+  check string "guardian runtime owner" "sentinel"
+    (sentinel |> U.member "guardian_runtime_owner" |> U.to_string);
+  check bool "consumer includes guardian-zombie" true (List.mem "guardian-zombie" consumers);
+  check bool "consumer includes guardian-gc" true (List.mem "guardian-gc" consumers);
+  let guardian = Guardian.status_json () in
+  check string "guardian status owner follows sentinel" "sentinel"
+    (guardian |> U.member "runtime_owner" |> U.to_string)
+
+let () =
+  run "Guardian/Sentinel"
+    [
+      ("runtime", [
+        test_case "guardian status defaults" `Quick test_guardian_status_defaults;
+        test_case "guardian embedded loops ignore master switch" `Quick test_guardian_embedded_loops_ignore_master_switch;
+        test_case "sentinel reports embedded guardian runtime" `Quick test_sentinel_status_reports_embedded_guardian_runtime;
+      ]);
+    ]


### PR DESCRIPTION
## Summary
- make `Sentinel` the canonical housekeeping runtime instead of leaving it unwired
- keep `Gardener` scoped to ecosystem population management
- keep `Guardian` as the embedded/fallback maintenance runtime and expose truthful ownership in `/health`

## Changes
- start `Sentinel` from `main_eio` when enabled and avoid double-starting guardian masc loops
- add embedded guardian masc-loop startup so sentinel can run zombie/gc even when `MASC_GUARDIAN_ENABLED=false`
- make `guardian` and `sentinel` health/status payloads reflect actual runtime ownership and started state
- add regression coverage for guardian/sentinel runtime status

## Verification
- `dune build @check`
- `dune exec test/test_guardian_sentinel.exe`
- `dune exec test/test_operator_control.exe`
- smoke on `/health` with `MASC_LODGE_ENABLED=false MASC_SENTINEL_LLM_ENABLED=false` confirmed:
  - `guardian.runtime_owner = "sentinel"`
  - `guardian.masc_loops_running = true`
  - `sentinel.started = true`
  - `sentinel.embedded_guardian_loops_running = true`
