### PR TITLE
test(ci): follow keeper execution split for logging check

### DIFF
--- a/test/test_silent_failures_p2a.ml
+++ b/test/test_silent_failures_p2a.ml
@@ -148,8 +148,8 @@ let test_source_llm_token_parse () =
       {|[llm] token field missing or wrong type|})
 
 let test_source_keeper_proactive () =
-  check bool "tool_keeper.ml has proactive emission logging"
-    true (file_contains_pattern "lib/tool_keeper.ml"
+  check bool "keeper_execution.ml has proactive emission logging"
+    true (file_contains_pattern "lib/keeper_execution.ml"
       {|[keeper] proactive emission failed:|})
 
 (* MEDIUM priority patterns *)


### PR DESCRIPTION
## Summary
- update the silent failure source assertion to follow the keeper execution split
- point the proactive emission logging check at `lib/keeper_execution.ml`
- keep the CI guardrail intact without depending on the pre-refactor `tool_keeper.ml` layout

## Validation
- `opam exec -- dune build --root . ./test/test_silent_failures_p2a.exe`
- `./_build/default/test/test_silent_failures_p2a.exe`

## Notes
- This fixes the current CI failure in `test_silent_failures_p2a` after keeper internals moved out of `tool_keeper.ml`.
