### PR TITLE
feat(keeper): add safe voice and shell tooling

### DIFF
--- a/lib/keeper_execution.ml
+++ b/lib/keeper_execution.ml
@@ -22,6 +22,79 @@ let ensure_keeper_board_post_args ~author ~source = function
         @ fields)
   | other -> other
 
+let keeper_read_tool_names =
+  [
+    "keeper_read";
+    "keeper_fs_read";
+    "keeper_memory_search";
+    "keeper_time_now";
+    "keeper_context_status";
+  ]
+
+let keeper_board_tool_names =
+  [ "keeper_board_post"; "keeper_board_comment"; "keeper_board_list" ]
+
+let keeper_voice_tool_names =
+  [ "keeper_voice_speak" ]
+
+let keeper_shell_readonly_tool_names =
+  [ "keeper_shell_readonly" ]
+
+let dedupe_tool_names names =
+  dedupe_keep_order (List.filter (fun name -> String.trim name <> "") names)
+
+let keeper_allowed_tool_names ?(write_done = false) (meta : keeper_meta) : string list =
+  if write_done then
+    []
+  else if keeper_policy_mode_is_learned meta then
+    let base = keeper_read_tool_names in
+    let with_voice =
+      if meta.policy_voice_enabled then keeper_voice_tool_names @ base else base
+    in
+    let with_shell =
+      if canonical_policy_shell_mode meta.policy_shell_mode = "readonly" then
+        keeper_shell_readonly_tool_names @ with_voice
+      else
+        with_voice
+    in
+    match canonical_policy_action_budget meta.policy_action_budget with
+    | "board" -> dedupe_tool_names (keeper_board_tool_names @ with_shell)
+    | _ -> dedupe_tool_names with_shell
+  else
+    keeper_llm_tools |> List.map (fun tool -> tool.Llm_client.tool_name)
+
+let keeper_allowed_llm_tools ?(write_done = false) (meta : keeper_meta) :
+    Llm_client.tool_def list =
+  let allowed = keeper_allowed_tool_names ~write_done meta in
+  if allowed = [] then
+    []
+  else
+    keeper_llm_tools
+    |> List.filter (fun tool -> List.mem tool.Llm_client.tool_name allowed)
+
+let keeper_text_fallback_json ~(agent_id : string) ~(message : string) =
+  let voice = Voice_bridge.get_voice_for_agent agent_id in
+  `Assoc
+    [
+      ("status", `String "text_fallback");
+      ("agent_id", `String agent_id);
+      ("voice", `String voice);
+      ("message_preview", `String (short_preview ~max_len:50 message));
+    ]
+
+let shell_readonly_limit args =
+  max 1 (min 200 (Safe_ops.json_int ~default:40 "limit" args))
+
+let shell_readonly_cat_max_bytes args =
+  max 256 (min 100000 (Safe_ops.json_int ~default:4000 "max_bytes" args))
+
+let lines_to_json ?(limit = max_int) (text : string) : Yojson.Safe.t =
+  let lines =
+    String.split_on_char '\n' text
+    |> List.filter (fun line -> line <> "")
+    |> fun rows -> if List.length rows > limit then take limit rows else rows
+  in
+  `List (List.map (fun line -> `String line) lines)
 let execute_keeper_tool_call
     ~(config : Room.config)
     ~(meta : keeper_meta)
@@ -229,6 +302,150 @@ let execute_keeper_tool_call
             ("status", process_status_to_json st);
             ("output", `String (truncate_tool_output out));
           ])
+  | "keeper_shell_readonly" ->
+      let op =
+        Safe_ops.json_string ~default:"" "op" args
+        |> String.trim |> String.lowercase_ascii
+      in
+      let root = project_root_of_config config in
+      let read_target () =
+        let raw_path = Safe_ops.json_string ~default:"." "path" args in
+        resolve_keeper_target_path ~config ~raw_path
+      in
+      let render_process_result ~cmd argv =
+        let (st, out) = Process_eio.run_argv_with_status ~timeout_sec:15.0 argv in
+        Yojson.Safe.to_string
+          (`Assoc
+            [
+              ("ok", `Bool (st = Unix.WEXITED 0));
+              ("op", `String op);
+              ("cmd", `String cmd);
+              ("status", process_status_to_json st);
+              ("output", `String (truncate_tool_output out));
+            ])
+      in
+      (match op with
+      | "pwd" ->
+          render_process_result ~cmd:"pwd" [ "/bin/pwd" ]
+      | "git_status" ->
+          render_process_result
+            ~cmd:"git -C <root> status --short --branch"
+            [ "git"; "-C"; root; "status"; "--short"; "--branch" ]
+      | "ls" -> (
+          match read_target () with
+          | Error e -> Yojson.Safe.to_string (`Assoc [ ("error", `String e); ("op", `String op) ])
+          | Ok target ->
+              let (st, out) =
+                Process_eio.run_argv_with_status ~timeout_sec:15.0
+                  [ "/bin/ls"; "-la"; target ]
+              in
+              let limit = shell_readonly_limit args in
+              Yojson.Safe.to_string
+                (`Assoc
+                  [
+                    ("ok", `Bool (st = Unix.WEXITED 0));
+                    ("op", `String op);
+                    ("path", `String target);
+                    ("status", process_status_to_json st);
+                    ("entries", lines_to_json ~limit out);
+                  ]))
+      | "cat" -> (
+          match read_target () with
+          | Error e -> Yojson.Safe.to_string (`Assoc [ ("error", `String e); ("op", `String op) ])
+          | Ok target ->
+              let max_bytes = shell_readonly_cat_max_bytes args in
+              let (st, out) =
+                Process_eio.run_argv_with_status ~timeout_sec:15.0
+                  [ "/bin/cat"; target ]
+              in
+              let body =
+                if String.length out > max_bytes then String.sub out 0 max_bytes else out
+              in
+              Yojson.Safe.to_string
+                (`Assoc
+                  [
+                    ("ok", `Bool (st = Unix.WEXITED 0));
+                    ("op", `String op);
+                    ("path", `String target);
+                    ("status", process_status_to_json st);
+                    ("truncated", `Bool (String.length out > max_bytes));
+                    ("content", `String body);
+                  ]))
+      | "rg" -> (
+          let pattern = Safe_ops.json_string ~default:"" "pattern" args |> String.trim in
+          if pattern = "" then
+            Yojson.Safe.to_string (`Assoc [ ("error", `String "pattern_required"); ("op", `String op) ])
+          else
+            match read_target () with
+            | Error e -> Yojson.Safe.to_string (`Assoc [ ("error", `String e); ("op", `String op) ])
+            | Ok target ->
+                let limit = shell_readonly_limit args in
+                let (st, out) =
+                  Process_eio.run_argv_with_status ~timeout_sec:15.0
+                    [ "rg"; "-n"; "-m"; string_of_int limit; pattern; target ]
+                in
+                Yojson.Safe.to_string
+                  (`Assoc
+                    [
+                      ("ok", `Bool (st = Unix.WEXITED 0));
+                      ("op", `String op);
+                      ("path", `String target);
+                      ("pattern", `String pattern);
+                      ("status", process_status_to_json st);
+                      ("matches", lines_to_json ~limit out);
+                    ]))
+      | _ ->
+          Yojson.Safe.to_string
+            (`Assoc
+              [
+                ("error", `String "unsupported_op");
+                ("op", `String op);
+                ("supported_ops",
+                  `List
+                    (List.map
+                       (fun name -> `String name)
+                       [ "pwd"; "ls"; "cat"; "rg"; "git_status" ]));
+              ]))
+  | "keeper_voice_speak" ->
+      let message = Safe_ops.json_string ~default:"" "message" args |> String.trim in
+      let provider =
+        Safe_ops.json_string_opt "provider" args
+        |> Option.map String.trim
+        |> function
+        | Some p when p <> "" -> Some p
+        | _ -> None
+      in
+      let priority = max 1 (Safe_ops.json_int ~default:1 "priority" args) in
+      if message = "" then
+        Yojson.Safe.to_string (`Assoc [ ("error", `String "message_required") ])
+      else
+        (match
+           (Eio_context.get_switch_opt (), Eio_context.get_clock_opt (), Eio_context.get_net_opt ())
+         with
+        | Some sw, Some clock, Some net -> (
+            match
+              Voice_bridge.agent_speak
+                ~sw
+                ~clock
+                ~net
+                ~agent_id:meta.name
+                ~message
+                ?provider
+                ~priority
+                ()
+            with
+            | Ok json -> Yojson.Safe.to_string json
+            | Error err ->
+                Yojson.Safe.to_string
+                  (`Assoc
+                    [
+                      ("status", `String "error");
+                      ("agent_id", `String meta.name);
+                      ("message", `String err);
+                    ]))
+        | _ ->
+            Yojson.Safe.to_string
+              (keeper_text_fallback_json ~agent_id:meta.name ~message))
   | "keeper_github" ->
       let cmd = Safe_ops.json_string ~default:"" "cmd" args |> String.trim in
       let gh_args = Safe_ops.json_string_list "args" args in
@@ -1152,7 +1369,10 @@ let upsert_assoc key value fields =
 let resolved_keeper_args_to_json
     ~name ~persona_name ~persona_profile_path ~goal ~short_goal ~mid_goal ~long_goal
     ~instructions ~soul_profile ~will ~needs ~desires ~models ~allowed_models
-    ~active_model ~room_scope ~scope_kind ~trigger_mode ~mention_targets
+    ~active_model ~policy_mode ~policy_action_budget ~policy_reward_model_path
+    ~policy_voice_enabled ~policy_shell_mode ~initiative_enabled ~initiative_scope
+    ~initiative_idle_sec ~initiative_cooldown_sec ~initiative_context_mode
+    ~initiative_post_ttl_hours ~room_scope ~scope_kind ~trigger_mode ~mention_targets
     ~presence_keepalive ~presence_keepalive_sec ~proactive_enabled ~verify
     ~auto_handoff ~handoff_threshold ~handoff_cooldown_sec ~context_budget =
   `Assoc
@@ -1172,6 +1392,17 @@ let resolved_keeper_args_to_json
       ("models", string_list_to_json models);
       ("allowed_models", string_list_to_json allowed_models);
       ("active_model", `String active_model);
+      ("policy_mode", `String policy_mode);
+      ("policy_action_budget", `String policy_action_budget);
+      ("policy_reward_model_path", `String policy_reward_model_path);
+      ("policy_voice_enabled", `Bool policy_voice_enabled);
+      ("policy_shell_mode", `String policy_shell_mode);
+      ("initiative_enabled", `Bool initiative_enabled);
+      ("initiative_scope", `String initiative_scope);
+      ("initiative_idle_sec", `Int initiative_idle_sec);
+      ("initiative_cooldown_sec", `Int initiative_cooldown_sec);
+      ("initiative_context_mode", `String initiative_context_mode);
+      ("initiative_post_ttl_hours", `Int initiative_post_ttl_hours);
       ("room_scope", `String room_scope);
       ("scope_kind", `String scope_kind);
       ("trigger_mode", `String trigger_mode);
@@ -1193,12 +1424,44 @@ let validate_resolved_keeper_create_json (json : Yojson.Safe.t) : string list =
   let models = Safe_ops.json_string_list "models" json in
   let allowed_models = Safe_ops.json_string_list "allowed_models" json in
   let active_model = Safe_ops.json_string ~default:"" "active_model" json |> String.trim in
+  let policy_mode =
+    Safe_ops.json_string ~default:"heuristic" "policy_mode" json
+    |> canonical_policy_mode
+  in
+  let policy_action_budget =
+    Safe_ops.json_string ~default:"conversation" "policy_action_budget" json
+    |> canonical_policy_action_budget
+  in
+  let policy_reward_model_path =
+    Safe_ops.json_string ~default:"" "policy_reward_model_path" json |> String.trim
+  in
+  let policy_voice_enabled =
+    Safe_ops.json_bool ~default:false "policy_voice_enabled" json
+  in
+  let policy_shell_mode =
+    Safe_ops.json_string ~default:"disabled" "policy_shell_mode" json
+    |> canonical_policy_shell_mode
+  in
+  let initiative_enabled =
+    Safe_ops.json_bool ~default:false "initiative_enabled" json
+  in
   let mention_targets = Safe_ops.json_string_list "mention_targets" json in
   if not (validate_name name) then errors := "invalid keeper name" :: !errors;
   if goal = "" then errors := "goal is required" :: !errors;
   if models = [] then errors := "models is required" :: !errors;
   if active_model <> "" && not (List.mem active_model (allowed_models @ models)) then
     errors := "active_model must be included in models or allowed_models" :: !errors;
+  if policy_mode = "learned_offline_v1" && policy_reward_model_path = "" then
+    errors := "policy_reward_model_path is required for learned_offline_v1" :: !errors;
+  if policy_mode = "heuristic" && policy_action_budget <> "conversation" then
+    errors := "policy_action_budget=board requires learned_offline_v1" :: !errors;
+  if policy_voice_enabled && policy_mode <> "learned_offline_v1" then
+    errors := "policy_voice_enabled=true requires learned_offline_v1" :: !errors;
+  if policy_shell_mode = "readonly" && policy_mode <> "learned_offline_v1" then
+    errors := "policy_shell_mode=readonly requires learned_offline_v1" :: !errors;
+  if initiative_enabled && (policy_mode <> "learned_offline_v1" || policy_action_budget <> "board")
+  then
+    errors := "initiative_enabled=true requires learned_offline_v1 with policy_action_budget=board" :: !errors;
   if
     (Safe_ops.json_string ~default:"legacy" "trigger_mode" json
      |> Keeper_contract.trigger_mode_of_string
@@ -1285,8 +1548,10 @@ let resolved_keeper_args_from_persona args :
             | None -> [])
         in
         let allowed_models =
-          dedupe_keep_order
-            (explicit_allowed_models @ defaults.allowed_models @ base_models)
+          resolve_allowed_models
+            ~explicit_allowed_models
+            ~seed_allowed_models:defaults.allowed_models
+            ~models:base_models
         in
         let active_model =
           active_model_opt
@@ -1294,8 +1559,68 @@ let resolved_keeper_args_from_persona args :
           |> Option.value
                ~default:
                  (match base_models with
-                  | model :: _ -> model
+                 | model :: _ -> model
                   | [] -> "")
+        in
+        let policy_mode =
+          first_some (get_string_opt args "policy_mode") defaults.policy_mode
+          |> Option.value ~default:"heuristic"
+          |> canonical_policy_mode
+        in
+        let policy_action_budget =
+          first_some (get_string_opt args "policy_action_budget") defaults.policy_action_budget
+          |> Option.value ~default:"conversation"
+          |> canonical_policy_action_budget
+        in
+        let policy_reward_model_path =
+          first_some
+            (get_string_opt args "policy_reward_model_path")
+            defaults.policy_reward_model_path
+          |> Option.value ~default:""
+        in
+        let policy_voice_enabled =
+          first_some (get_bool_opt args "policy_voice_enabled") defaults.policy_voice_enabled
+          |> Option.value ~default:false
+        in
+        let policy_shell_mode =
+          first_some (get_string_opt args "policy_shell_mode") defaults.policy_shell_mode
+          |> Option.value ~default:"disabled"
+          |> canonical_policy_shell_mode
+        in
+        let initiative_enabled =
+          first_some (get_bool_opt args "initiative_enabled") defaults.initiative_enabled
+          |> Option.value ~default:false
+        in
+        let initiative_scope =
+          first_some (get_string_opt args "initiative_scope") defaults.initiative_scope
+          |> Option.value ~default:"board_only"
+          |> canonical_initiative_scope
+        in
+        let initiative_idle_sec =
+          first_some (Safe_ops.json_int_opt "initiative_idle_sec" args) defaults.initiative_idle_sec
+          |> Option.value ~default:3600
+          |> normalize_initiative_idle_sec
+        in
+        let initiative_cooldown_sec =
+          first_some
+            (Safe_ops.json_int_opt "initiative_cooldown_sec" args)
+            defaults.initiative_cooldown_sec
+          |> Option.value ~default:3600
+          |> normalize_initiative_cooldown_sec
+        in
+        let initiative_context_mode =
+          first_some
+            (get_string_opt args "initiative_context_mode")
+            defaults.initiative_context_mode
+          |> Option.value ~default:"board_snapshot"
+          |> canonical_initiative_context_mode
+        in
+        let initiative_post_ttl_hours =
+          first_some
+            (Safe_ops.json_int_opt "initiative_post_ttl_hours" args)
+            defaults.initiative_post_ttl_hours
+          |> Option.value ~default:24
+          |> normalize_initiative_post_ttl_hours
         in
         let room_scope =
           get_string_opt args "room_scope"
@@ -1359,6 +1684,10 @@ let resolved_keeper_args_from_persona args :
             ~goal ~short_goal ~mid_goal ~long_goal
             ~instructions ~soul_profile ~will ~needs ~desires
             ~models:base_models ~allowed_models ~active_model
+            ~policy_mode ~policy_action_budget ~policy_reward_model_path
+            ~policy_voice_enabled ~policy_shell_mode ~initiative_enabled
+            ~initiative_scope ~initiative_idle_sec ~initiative_cooldown_sec
+            ~initiative_context_mode ~initiative_post_ttl_hours
             ~room_scope ~scope_kind ~trigger_mode ~mention_targets
             ~presence_keepalive ~presence_keepalive_sec ~proactive_enabled
             ~verify ~auto_handoff ~handoff_threshold ~handoff_cooldown_sec
@@ -2256,7 +2585,7 @@ let run_proactive_generation
                  :: (ctx_work.messages @ [ Llm_client.user_msg prompt ]);
                temperature = proactive_temperature attempt;
                max_tokens = 1024; (* increased from 220 to allow tool calls *)
-               tools = keeper_llm_tools;
+               tools = keeper_allowed_llm_tools meta;
                response_format = `Text;
              }
               : Llm_client.completion_request))
@@ -2316,7 +2645,7 @@ let run_proactive_generation
                   all_tools_so_far
               in
               let next_tools =
-                if write_done then [] else keeper_llm_tools
+                keeper_allowed_llm_tools ~write_done meta
               in
               let followup_requests =
                 List.map
@@ -2594,7 +2923,7 @@ Do NOT use destructive tools (bash rm, edit, delete).|}
       ];
       temperature = 0.3;
       max_tokens = 1024;
-      tools = keeper_llm_tools;
+      tools = keeper_allowed_llm_tools meta;
       response_format = `Text;
     }
   in
@@ -2635,7 +2964,7 @@ Do NOT use destructive tools (bash rm, edit, delete).|}
               List.mem n ["keeper_board_post"; "keeper_board_comment"])
               all_tools
           in
-          let next_tools = if write_done then [] else keeper_llm_tools in
+          let next_tools = keeper_allowed_llm_tools ~write_done meta in
           let followup_requests = List.map (fun (spec : Llm_client.model_spec) ->
             { Llm_client.model = spec;
               messages = [

--- a/lib/keeper_schema.ml
+++ b/lib/keeper_schema.ml
@@ -53,6 +53,32 @@ let resident_schemas : tool_schema list = [
           ("items", `Assoc [("type", `String "string")]);
         ]);
         ("active_model", `Assoc [("type", `String "string")]);
+        ("policy_mode", `Assoc [
+          ("type", `String "string");
+          ("enum", `List [`String "heuristic"; `String "learned_offline_v1"]);
+        ]);
+        ("policy_action_budget", `Assoc [
+          ("type", `String "string");
+          ("enum", `List [`String "conversation"; `String "board"]);
+        ]);
+        ("policy_reward_model_path", `Assoc [("type", `String "string")]);
+        ("policy_voice_enabled", `Assoc [("type", `String "boolean")]);
+        ("policy_shell_mode", `Assoc [
+          ("type", `String "string");
+          ("enum", `List [`String "disabled"; `String "readonly"]);
+        ]);
+        ("initiative_enabled", `Assoc [("type", `String "boolean")]);
+        ("initiative_scope", `Assoc [
+          ("type", `String "string");
+          ("enum", `List [`String "board_only"]);
+        ]);
+        ("initiative_idle_sec", `Assoc [("type", `String "integer")]);
+        ("initiative_cooldown_sec", `Assoc [("type", `String "integer")]);
+        ("initiative_context_mode", `Assoc [
+          ("type", `String "string");
+          ("enum", `List [`String "board_snapshot"]);
+        ]);
+        ("initiative_post_ttl_hours", `Assoc [("type", `String "integer")]);
         ("room_scope", `Assoc [
           ("type", `String "string");
           ("enum", `List [`String "current"; `String "all"]);
@@ -141,6 +167,55 @@ let resident_schemas : tool_schema list = [
         ("active_model", `Assoc [
           ("type", `String "string");
           ("description", `String "Current persisted model label. Prefer 'default' for adapter-managed selection; explicit-only keepers may still pin a concrete provider:model label.");
+        ]);
+        ("policy_mode", `Assoc [
+          ("type", `String "string");
+          ("enum", `List [`String "heuristic"; `String "learned_offline_v1"]);
+          ("description", `String "Behavior selection mode persisted on the keeper.");
+        ]);
+        ("policy_action_budget", `Assoc [
+          ("type", `String "string");
+          ("enum", `List [`String "conversation"; `String "board"]);
+          ("description", `String "Maximum autonomous action surface. board is only valid with learned_offline_v1.");
+        ]);
+        ("policy_reward_model_path", `Assoc [
+          ("type", `String "string");
+          ("description", `String "Offline reward-model JSON path for learned_offline_v1.");
+        ]);
+        ("policy_voice_enabled", `Assoc [
+          ("type", `String "boolean");
+          ("description", `String "If true, keeper-safe voice speak output is allowed.");
+        ]);
+        ("policy_shell_mode", `Assoc [
+          ("type", `String "string");
+          ("enum", `List [`String "disabled"; `String "readonly"]);
+          ("description", `String "Keeper shell wrapper mode. readonly adds a structured read-only shell tool without enabling raw bash.");
+        ]);
+        ("initiative_enabled", `Assoc [
+          ("type", `String "boolean");
+          ("description", `String "If true, the keeper may run initiative ticks on keepalive and choose noop vs board_post.");
+        ]);
+        ("initiative_scope", `Assoc [
+          ("type", `String "string");
+          ("enum", `List [`String "board_only"]);
+          ("description", `String "Initiative action surface. v1 only supports board_only.");
+        ]);
+        ("initiative_idle_sec", `Assoc [
+          ("type", `String "integer");
+          ("description", `String "Minimum idle seconds before initiative is allowed (default/min: 3600).");
+        ]);
+        ("initiative_cooldown_sec", `Assoc [
+          ("type", `String "integer");
+          ("description", `String "Minimum seconds between initiative actions (default/min: 3600).");
+        ]);
+        ("initiative_context_mode", `Assoc [
+          ("type", `String "string");
+          ("enum", `List [`String "board_snapshot"]);
+          ("description", `String "Structured initiative context source. v1 only supports board_snapshot.");
+        ]);
+        ("initiative_post_ttl_hours", `Assoc [
+          ("type", `String "integer");
+          ("description", `String "TTL for initiative-created internal board posts (default: 24).");
         ]);
         ("scope_kind", `Assoc [
           ("type", `String "string");

--- a/lib/keeper_status.ml
+++ b/lib/keeper_status.ml
@@ -361,7 +361,15 @@ let handle_keeper_status ctx args : tool_result =
              let start = max 0 (total - tail_compactions) in
              let tail = List.filteri (fun i _ -> i >= start) events in
              (`List tail, total)
-         in
+        in
+        let all_internal_tools =
+          keeper_llm_tools |> List.map (fun tool -> tool.Llm_client.tool_name)
+        in
+        let allowed_tools = keeper_allowed_tool_names m in
+        let blocked_internal_tools =
+          all_internal_tools
+          |> List.filter (fun name -> not (List.mem name allowed_tools))
+        in
 
          let json = `Assoc [
            ("meta", meta_to_json m);
@@ -434,6 +442,19 @@ let handle_keeper_status ctx args : tool_result =
                if String.trim m.policy_reward_model_path = ""
                then `Null
                else `String m.policy_reward_model_path);
+             ("voice_enabled", `Bool m.policy_voice_enabled);
+             ("shell_mode", `String m.policy_shell_mode);
+             ("allowed_tools", string_list_to_json allowed_tools);
+             ("available_internal_tools", string_list_to_json all_internal_tools);
+             ("blocked_internal_tools", string_list_to_json blocked_internal_tools);
+           ]);
+           ("initiative", `Assoc [
+             ("enabled", `Bool m.initiative_enabled);
+             ("scope", `String m.initiative_scope);
+             ("idle_sec", `Int m.initiative_idle_sec);
+             ("cooldown_sec", `Int m.initiative_cooldown_sec);
+             ("context_mode", `String m.initiative_context_mode);
+             ("post_ttl_hours", `Int m.initiative_post_ttl_hours);
            ]);
            ("compaction_policy", `Assoc [
              ("profile", `String m.compaction_profile);

--- a/lib/keeper_turn.ml
+++ b/lib/keeper_turn.ml
@@ -27,6 +27,17 @@ let handle_keeper_up ctx args : tool_result =
     let models_in = get_string_list args "models" in
     let allowed_models_in = get_string_list args "allowed_models" in
     let active_model_opt = get_string_opt args "active_model" in
+    let policy_mode_opt = get_string_opt args "policy_mode" in
+    let policy_action_budget_opt = get_string_opt args "policy_action_budget" in
+    let policy_reward_model_path_opt = get_string_opt args "policy_reward_model_path" in
+    let policy_voice_enabled_opt = get_bool_opt args "policy_voice_enabled" in
+    let policy_shell_mode_opt = get_string_opt args "policy_shell_mode" in
+    let initiative_enabled_opt = get_bool_opt args "initiative_enabled" in
+    let initiative_scope_opt = get_string_opt args "initiative_scope" in
+    let initiative_idle_sec_opt = Safe_ops.json_int_opt "initiative_idle_sec" args in
+    let initiative_cooldown_sec_opt = Safe_ops.json_int_opt "initiative_cooldown_sec" args in
+    let initiative_context_mode_opt = get_string_opt args "initiative_context_mode" in
+    let initiative_post_ttl_hours_opt = Safe_ops.json_int_opt "initiative_post_ttl_hours" args in
     let room_scope_opt = get_string_opt args "room_scope" in
     let scope_kind_opt = get_string_opt args "scope_kind" in
     let trigger_mode_opt = get_string_opt args "trigger_mode" in
@@ -68,6 +79,12 @@ let handle_keeper_up ctx args : tool_result =
     let will_opt = parse_self_model_opt args "will" in
     let needs_opt = parse_self_model_opt args "needs" in
     let desires_opt = parse_self_model_opt args "desires" in
+    let resolve_reward_model_path raw_path =
+      let trimmed = String.trim raw_path in
+      if trimmed = "" then ""
+      else if Filename.is_relative trimmed then Filename.concat ctx.config.base_path trimmed
+      else trimmed
+    in
     match read_meta ctx.config name with
     | Error e -> (false, Printf.sprintf "❌ %s" e)
   | Ok None ->
@@ -107,10 +124,10 @@ let handle_keeper_up ctx args : tool_result =
           profile_defaults.allowed_models
       in
       let allowed_models =
-        dedupe_keep_order
-          (allowed_models_in
-           @ profile_defaults.allowed_models
-           @ requested_models)
+        resolve_allowed_models
+          ~explicit_allowed_models:allowed_models_in
+          ~seed_allowed_models:profile_defaults.allowed_models
+          ~models:requested_models
       in
       let active_model =
         active_model_opt
@@ -120,6 +137,59 @@ let handle_keeper_up ctx args : tool_result =
                (match requested_models with
                 | model :: _ -> model
                 | [] -> "")
+      in
+      let policy_mode =
+        first_some policy_mode_opt profile_defaults.policy_mode
+        |> Option.value ~default:"heuristic"
+        |> canonical_policy_mode
+      in
+      let policy_action_budget =
+        first_some policy_action_budget_opt profile_defaults.policy_action_budget
+        |> Option.value ~default:"conversation"
+        |> canonical_policy_action_budget
+      in
+      let policy_reward_model_path =
+        first_some policy_reward_model_path_opt profile_defaults.policy_reward_model_path
+        |> Option.value ~default:""
+        |> resolve_reward_model_path
+      in
+      let policy_voice_enabled =
+        first_some policy_voice_enabled_opt profile_defaults.policy_voice_enabled
+        |> Option.value ~default:false
+      in
+      let policy_shell_mode =
+        first_some policy_shell_mode_opt profile_defaults.policy_shell_mode
+        |> Option.value ~default:"disabled"
+        |> canonical_policy_shell_mode
+      in
+      let initiative_enabled =
+        first_some initiative_enabled_opt profile_defaults.initiative_enabled
+        |> Option.value ~default:false
+      in
+      let initiative_scope =
+        first_some initiative_scope_opt profile_defaults.initiative_scope
+        |> Option.value ~default:"board_only"
+        |> canonical_initiative_scope
+      in
+      let initiative_idle_sec =
+        first_some initiative_idle_sec_opt profile_defaults.initiative_idle_sec
+        |> Option.value ~default:3600
+        |> normalize_initiative_idle_sec
+      in
+      let initiative_cooldown_sec =
+        first_some initiative_cooldown_sec_opt profile_defaults.initiative_cooldown_sec
+        |> Option.value ~default:3600
+        |> normalize_initiative_cooldown_sec
+      in
+      let initiative_context_mode =
+        first_some initiative_context_mode_opt profile_defaults.initiative_context_mode
+        |> Option.value ~default:"board_snapshot"
+        |> canonical_initiative_context_mode
+      in
+      let initiative_post_ttl_hours =
+        first_some initiative_post_ttl_hours_opt profile_defaults.initiative_post_ttl_hours
+        |> Option.value ~default:24
+        |> normalize_initiative_post_ttl_hours
       in
       let mention_targets =
         let raw =
@@ -133,6 +203,16 @@ let handle_keeper_up ctx args : tool_result =
         (false, "❌ goal is required when creating a keeper")
       else if requested_models = [] then
         (false, "❌ models is required when creating a keeper")
+      else if policy_mode = "heuristic" && policy_action_budget <> "conversation" then
+        (false, "❌ policy_action_budget=board requires policy_mode=learned_offline_v1")
+      else if policy_voice_enabled && policy_mode <> "learned_offline_v1" then
+        (false, "❌ policy_voice_enabled=true requires policy_mode=learned_offline_v1")
+      else if policy_shell_mode = "readonly" && policy_mode <> "learned_offline_v1" then
+        (false, "❌ policy_shell_mode=readonly requires policy_mode=learned_offline_v1")
+      else if policy_mode = "learned_offline_v1" && policy_action_budget <> "board"
+              && initiative_enabled
+      then
+        (false, "❌ initiative_enabled=true requires policy_action_budget=board in learned_offline_v1")
       else
         let verify = Option.value ~default:false verify_opt in
         let presence_keepalive =
@@ -281,10 +361,17 @@ let handle_keeper_up ctx args : tool_result =
                models = requested_models;
                allowed_models;
                active_model;
-               policy_mode = Keeper_contract.policy_mode_to_string Keeper_contract.Heuristic;
-               policy_action_budget =
-                 Keeper_contract.policy_action_budget_to_string Keeper_contract.Conversation;
-               policy_reward_model_path = "";
+               policy_mode;
+               policy_action_budget;
+               policy_reward_model_path;
+               policy_voice_enabled;
+               policy_shell_mode;
+               initiative_enabled;
+               initiative_scope;
+               initiative_idle_sec;
+               initiative_cooldown_sec;
+               initiative_context_mode;
+               initiative_post_ttl_hours;
                scope_kind;
                room_scope;
                trigger_mode;
@@ -368,6 +455,20 @@ let handle_keeper_up ctx args : tool_result =
                  ("proactive_enabled", `Bool meta.proactive_enabled);
                  ("proactive_idle_sec", `Int meta.proactive_idle_sec);
                  ("proactive_cooldown_sec", `Int meta.proactive_cooldown_sec);
+                 ("policy_mode", `String meta.policy_mode);
+                 ("policy_action_budget", `String meta.policy_action_budget);
+                 ("policy_reward_model_path",
+                   if String.trim meta.policy_reward_model_path = ""
+                   then `Null
+                   else `String meta.policy_reward_model_path);
+                 ("policy_voice_enabled", `Bool meta.policy_voice_enabled);
+                 ("policy_shell_mode", `String meta.policy_shell_mode);
+                 ("initiative_enabled", `Bool meta.initiative_enabled);
+                 ("initiative_scope", `String meta.initiative_scope);
+                 ("initiative_idle_sec", `Int meta.initiative_idle_sec);
+                 ("initiative_cooldown_sec", `Int meta.initiative_cooldown_sec);
+                 ("initiative_context_mode", `String meta.initiative_context_mode);
+                 ("initiative_post_ttl_hours", `Int meta.initiative_post_ttl_hours);
                  ("drift_enabled", `Bool meta.drift_enabled);
                  ("drift_min_turn_gap", `Int meta.drift_min_turn_gap);
                  ("compaction_profile", `String meta.compaction_profile);
@@ -410,11 +511,12 @@ let handle_keeper_up ctx args : tool_result =
         else profile_defaults.allowed_models
       in
       let allowed_models =
-        dedupe_keep_order
-          (allowed_models_in
-           @ old.allowed_models
-           @ profile_defaults.allowed_models
-           @ models)
+        resolve_allowed_models
+          ~explicit_allowed_models:allowed_models_in
+          ~seed_allowed_models:
+            (if old.allowed_models <> [] then old.allowed_models
+             else profile_defaults.allowed_models)
+          ~models
       in
       let active_model =
         active_model_opt
@@ -426,6 +528,87 @@ let handle_keeper_up ctx args : tool_result =
                (match models with
                 | model :: _ -> model
                 | [] -> "")
+      in
+      let policy_mode =
+        first_some
+          policy_mode_opt
+          (first_some
+             (if String.trim old.policy_mode <> "" then Some old.policy_mode else None)
+             profile_defaults.policy_mode)
+        |> Option.value ~default:"heuristic"
+        |> canonical_policy_mode
+      in
+      let policy_action_budget =
+        first_some
+          policy_action_budget_opt
+          (first_some
+             (if String.trim old.policy_action_budget <> "" then Some old.policy_action_budget else None)
+             profile_defaults.policy_action_budget)
+        |> Option.value ~default:"conversation"
+        |> canonical_policy_action_budget
+      in
+      let policy_reward_model_path =
+        first_some
+          policy_reward_model_path_opt
+          (first_some
+             (if String.trim old.policy_reward_model_path <> "" then Some old.policy_reward_model_path else None)
+             profile_defaults.policy_reward_model_path)
+        |> Option.value ~default:""
+        |> resolve_reward_model_path
+      in
+      let policy_voice_enabled =
+        first_some
+          policy_voice_enabled_opt
+          (first_some (Some old.policy_voice_enabled) profile_defaults.policy_voice_enabled)
+        |> Option.value ~default:false
+      in
+      let policy_shell_mode =
+        first_some
+          policy_shell_mode_opt
+          (first_some (Some old.policy_shell_mode) profile_defaults.policy_shell_mode)
+        |> Option.value ~default:"disabled"
+        |> canonical_policy_shell_mode
+      in
+      let initiative_enabled =
+        first_some
+          initiative_enabled_opt
+          (first_some (Some old.initiative_enabled) profile_defaults.initiative_enabled)
+        |> Option.value ~default:false
+      in
+      let initiative_scope =
+        first_some
+          initiative_scope_opt
+          (first_some (Some old.initiative_scope) profile_defaults.initiative_scope)
+        |> Option.value ~default:"board_only"
+        |> canonical_initiative_scope
+      in
+      let initiative_idle_sec =
+        first_some
+          initiative_idle_sec_opt
+          (first_some (Some old.initiative_idle_sec) profile_defaults.initiative_idle_sec)
+        |> Option.value ~default:3600
+        |> normalize_initiative_idle_sec
+      in
+      let initiative_cooldown_sec =
+        first_some
+          initiative_cooldown_sec_opt
+          (first_some (Some old.initiative_cooldown_sec) profile_defaults.initiative_cooldown_sec)
+        |> Option.value ~default:3600
+        |> normalize_initiative_cooldown_sec
+      in
+      let initiative_context_mode =
+        first_some
+          initiative_context_mode_opt
+          (first_some (Some old.initiative_context_mode) profile_defaults.initiative_context_mode)
+        |> Option.value ~default:"board_snapshot"
+        |> canonical_initiative_context_mode
+      in
+      let initiative_post_ttl_hours =
+        first_some
+          initiative_post_ttl_hours_opt
+          (first_some (Some old.initiative_post_ttl_hours) profile_defaults.initiative_post_ttl_hours)
+        |> Option.value ~default:24
+        |> normalize_initiative_post_ttl_hours
       in
       let room_scope =
         room_scope_opt
@@ -471,6 +654,15 @@ let handle_keeper_up ctx args : tool_result =
           ~fallback_message:old.compaction_message_gate
           ~fallback_token:old.compaction_token_gate
       in
+      if policy_mode = "heuristic" && policy_action_budget <> "conversation" then
+        (false, "❌ policy_action_budget=board requires policy_mode=learned_offline_v1")
+      else if policy_voice_enabled && policy_mode <> "learned_offline_v1" then
+        (false, "❌ policy_voice_enabled=true requires policy_mode=learned_offline_v1")
+      else if policy_shell_mode = "readonly" && policy_mode <> "learned_offline_v1" then
+        (false, "❌ policy_shell_mode=readonly requires policy_mode=learned_offline_v1")
+      else if initiative_enabled && (policy_mode <> "learned_offline_v1" || policy_action_budget <> "board") then
+        (false, "❌ initiative_enabled=true requires policy_mode=learned_offline_v1 and policy_action_budget=board")
+      else
       let updated = { old with
         goal;
         short_goal;
@@ -509,9 +701,17 @@ let handle_keeper_up ctx args : tool_result =
         models;
         allowed_models;
         active_model;
-        policy_mode = canonical_policy_mode old.policy_mode;
-        policy_action_budget = canonical_policy_action_budget old.policy_action_budget;
-        policy_reward_model_path = old.policy_reward_model_path;
+        policy_mode;
+        policy_action_budget;
+        policy_reward_model_path;
+        policy_voice_enabled;
+        policy_shell_mode;
+        initiative_enabled;
+        initiative_scope;
+        initiative_idle_sec;
+        initiative_cooldown_sec;
+        initiative_context_mode;
+        initiative_post_ttl_hours;
         scope_kind;
         room_scope;
         trigger_mode;
@@ -693,7 +893,10 @@ let handle_keeper_msg ctx args : tool_result =
               inline_instructions
           in
           let allowed_models =
-            dedupe_keep_order (profile_defaults.allowed_models @ inline_models)
+            resolve_allowed_models
+              ~explicit_allowed_models:[]
+              ~seed_allowed_models:profile_defaults.allowed_models
+              ~models:inline_models
           in
           let active_model =
             profile_defaults.active_model
@@ -702,6 +905,56 @@ let handle_keeper_msg ctx args : tool_result =
                    (match inline_models with
                     | model :: _ -> model
                     | [] -> "")
+          in
+          let policy_mode =
+            profile_defaults.policy_mode
+            |> Option.value ~default:"heuristic"
+            |> canonical_policy_mode
+          in
+          let policy_action_budget =
+            profile_defaults.policy_action_budget
+            |> Option.value ~default:"conversation"
+            |> canonical_policy_action_budget
+          in
+          let policy_reward_model_path =
+            profile_defaults.policy_reward_model_path
+            |> Option.value ~default:""
+          in
+          let policy_voice_enabled =
+            profile_defaults.policy_voice_enabled |> Option.value ~default:false
+          in
+          let policy_shell_mode =
+            profile_defaults.policy_shell_mode
+            |> Option.value ~default:"disabled"
+            |> canonical_policy_shell_mode
+          in
+          let initiative_enabled =
+            profile_defaults.initiative_enabled |> Option.value ~default:false
+          in
+          let initiative_scope =
+            profile_defaults.initiative_scope
+            |> Option.value ~default:"board_only"
+            |> canonical_initiative_scope
+          in
+          let initiative_idle_sec =
+            profile_defaults.initiative_idle_sec
+            |> Option.value ~default:3600
+            |> normalize_initiative_idle_sec
+          in
+          let initiative_cooldown_sec =
+            profile_defaults.initiative_cooldown_sec
+            |> Option.value ~default:3600
+            |> normalize_initiative_cooldown_sec
+          in
+          let initiative_context_mode =
+            profile_defaults.initiative_context_mode
+            |> Option.value ~default:"board_snapshot"
+            |> canonical_initiative_context_mode
+          in
+          let initiative_post_ttl_hours =
+            profile_defaults.initiative_post_ttl_hours
+            |> Option.value ~default:24
+            |> normalize_initiative_post_ttl_hours
           in
           let room_scope =
             profile_defaults.room_scope |> Option.value ~default:"current"
@@ -741,10 +994,17 @@ let handle_keeper_msg ctx args : tool_result =
             models = inline_models;
             allowed_models;
             active_model;
-            policy_mode = Keeper_contract.policy_mode_to_string Keeper_contract.Heuristic;
-            policy_action_budget =
-              Keeper_contract.policy_action_budget_to_string Keeper_contract.Conversation;
-            policy_reward_model_path = "";
+            policy_mode;
+            policy_action_budget;
+            policy_reward_model_path;
+            policy_voice_enabled;
+            policy_shell_mode;
+            initiative_enabled;
+            initiative_scope;
+            initiative_idle_sec;
+            initiative_cooldown_sec;
+            initiative_context_mode;
+            initiative_post_ttl_hours;
             scope_kind;
             room_scope;
             trigger_mode;
@@ -1108,7 +1368,7 @@ let handle_keeper_msg ctx args : tool_result =
                   messages = msgs;
                   temperature = 0.7;
                   max_tokens = turn_max_tokens;
-                  tools = keeper_llm_tools;
+                  tools = keeper_allowed_llm_tools meta;
                   response_format = `Text;
                 } : Llm_client.completion_request)
               ) specs
@@ -1235,7 +1495,7 @@ let handle_keeper_msg ctx args : tool_result =
                       all_tools_so_far
                   in
                   let next_tools =
-                    if write_done then [] else keeper_llm_tools
+                    keeper_allowed_llm_tools ~write_done meta
                   in
                   let followup_requests =
                     List.map (fun (model : Llm_client.model_spec) ->

--- a/lib/keeper_types.ml
+++ b/lib/keeper_types.ml
@@ -140,6 +140,14 @@ let first_some a b =
   | Some _ -> a
   | None -> b
 
+let resolve_allowed_models ~explicit_allowed_models ~seed_allowed_models ~models =
+  if explicit_allowed_models <> [] then
+    dedupe_keep_order explicit_allowed_models
+  else if seed_allowed_models <> [] then
+    dedupe_keep_order seed_allowed_models
+  else
+    dedupe_keep_order models
+
 let canonical_room_scope = function
   | "all" -> "all"
   | _ -> "current"
@@ -159,6 +167,27 @@ let canonical_policy_mode = function
 let canonical_policy_action_budget = function
   | "board" -> "board"
   | _ -> "conversation"
+
+let canonical_policy_shell_mode = function
+  | "readonly" -> "readonly"
+  | _ -> "disabled"
+
+let canonical_initiative_scope = function
+  | "board_only" -> "board_only"
+  | _ -> "board_only"
+
+let canonical_initiative_context_mode = function
+  | "board_snapshot" -> "board_snapshot"
+  | _ -> "board_snapshot"
+
+let normalize_initiative_idle_sec (v : int) : int =
+  clamp_int v ~min_v:3600 ~max_v:604800
+
+let normalize_initiative_cooldown_sec (v : int) : int =
+  clamp_int v ~min_v:3600 ~max_v:604800
+
+let normalize_initiative_post_ttl_hours (v : int) : int =
+  clamp_int v ~min_v:1 ~max_v:168
 
 let room_seq_map_to_json (items : (string * int) list) : Yojson.Safe.t =
   `Assoc (List.map (fun (room_id, seq) -> (room_id, `Int seq)) items)
@@ -192,6 +221,17 @@ type keeper_profile_defaults = {
   models : string list;
   allowed_models : string list;
   active_model : string option;
+  policy_mode : string option;
+  policy_action_budget : string option;
+  policy_reward_model_path : string option;
+  policy_voice_enabled : bool option;
+  policy_shell_mode : string option;
+  initiative_enabled : bool option;
+  initiative_scope : string option;
+  initiative_idle_sec : int option;
+  initiative_cooldown_sec : int option;
+  initiative_context_mode : string option;
+  initiative_post_ttl_hours : int option;
   room_scope : string option;
   scope_kind : string option;
   trigger_mode : string option;
@@ -224,6 +264,17 @@ let empty_keeper_profile_defaults = {
   models = [];
   allowed_models = [];
   active_model = None;
+  policy_mode = None;
+  policy_action_budget = None;
+  policy_reward_model_path = None;
+  policy_voice_enabled = None;
+  policy_shell_mode = None;
+  initiative_enabled = None;
+  initiative_scope = None;
+  initiative_idle_sec = None;
+  initiative_cooldown_sec = None;
+  initiative_context_mode = None;
+  initiative_post_ttl_hours = None;
   room_scope = None;
   scope_kind = None;
   trigger_mode = None;
@@ -274,6 +325,40 @@ let load_keeper_profile_defaults name : keeper_profile_defaults =
                 models = Safe_ops.json_string_list "models" keeper_json;
                 allowed_models = Safe_ops.json_string_list "allowed_models" keeper_json;
                 active_model = Safe_ops.json_string_opt "active_model" keeper_json;
+                policy_mode =
+                  Safe_ops.json_string_opt "policy_mode" keeper_json
+                  |> Option.map canonical_policy_mode;
+                policy_action_budget =
+                  Safe_ops.json_string_opt "policy_action_budget" keeper_json
+                  |> Option.map canonical_policy_action_budget;
+                policy_reward_model_path =
+                  Safe_ops.json_string_opt "policy_reward_model_path" keeper_json;
+                policy_voice_enabled =
+                  (match Yojson.Safe.Util.member "policy_voice_enabled" keeper_json with
+                  | `Bool flag -> Some flag
+                  | _ -> None);
+                policy_shell_mode =
+                  Safe_ops.json_string_opt "policy_shell_mode" keeper_json
+                  |> Option.map canonical_policy_shell_mode;
+                initiative_enabled =
+                  (match Yojson.Safe.Util.member "initiative_enabled" keeper_json with
+                  | `Bool flag -> Some flag
+                  | _ -> None);
+                initiative_scope =
+                  Safe_ops.json_string_opt "initiative_scope" keeper_json
+                  |> Option.map canonical_initiative_scope;
+                initiative_idle_sec =
+                  Safe_ops.json_int_opt "initiative_idle_sec" keeper_json
+                  |> Option.map normalize_initiative_idle_sec;
+                initiative_cooldown_sec =
+                  Safe_ops.json_int_opt "initiative_cooldown_sec" keeper_json
+                  |> Option.map normalize_initiative_cooldown_sec;
+                initiative_context_mode =
+                  Safe_ops.json_string_opt "initiative_context_mode" keeper_json
+                  |> Option.map canonical_initiative_context_mode;
+                initiative_post_ttl_hours =
+                  Safe_ops.json_int_opt "initiative_post_ttl_hours" keeper_json
+                  |> Option.map normalize_initiative_post_ttl_hours;
                 room_scope = Safe_ops.json_string_opt "room_scope" keeper_json;
                 scope_kind = Safe_ops.json_string_opt "scope_kind" keeper_json;
                 trigger_mode = Safe_ops.json_string_opt "trigger_mode" keeper_json;
@@ -357,6 +442,14 @@ type keeper_meta = {
   policy_mode: string;
   policy_action_budget: string;
   policy_reward_model_path: string;
+  policy_voice_enabled: bool;
+  policy_shell_mode: string;
+  initiative_enabled: bool;
+  initiative_scope: string;
+  initiative_idle_sec: int;
+  initiative_cooldown_sec: int;
+  initiative_context_mode: string;
+  initiative_post_ttl_hours: int;
   scope_kind: string;
   room_scope: string;
   trigger_mode: string;
@@ -441,6 +534,14 @@ let meta_to_json (m : keeper_meta) : Yojson.Safe.t =
       ("policy_mode", `String m.policy_mode);
       ("policy_action_budget", `String m.policy_action_budget);
       ("policy_reward_model_path", `String m.policy_reward_model_path);
+      ("policy_voice_enabled", `Bool m.policy_voice_enabled);
+      ("policy_shell_mode", `String m.policy_shell_mode);
+      ("initiative_enabled", `Bool m.initiative_enabled);
+      ("initiative_scope", `String m.initiative_scope);
+      ("initiative_idle_sec", `Int m.initiative_idle_sec);
+      ("initiative_cooldown_sec", `Int m.initiative_cooldown_sec);
+      ("initiative_context_mode", `String m.initiative_context_mode);
+      ("initiative_post_ttl_hours", `Int m.initiative_post_ttl_hours);
       ("scope_kind", `String m.scope_kind);
       ("room_scope", `String m.room_scope);
       ("trigger_mode", `String m.trigger_mode);
@@ -554,6 +655,36 @@ let meta_of_json (json : Yojson.Safe.t) : (keeper_meta, string) result =
     in
     let policy_reward_model_path =
       Safe_ops.json_string ~default:"" "policy_reward_model_path" json
+    in
+    let policy_voice_enabled =
+      Safe_ops.json_bool ~default:false "policy_voice_enabled" json
+    in
+    let policy_shell_mode =
+      Safe_ops.json_string ~default:"disabled" "policy_shell_mode" json
+      |> canonical_policy_shell_mode
+    in
+    let initiative_enabled =
+      Safe_ops.json_bool ~default:false "initiative_enabled" json
+    in
+    let initiative_scope =
+      Safe_ops.json_string ~default:"board_only" "initiative_scope" json
+      |> canonical_initiative_scope
+    in
+    let initiative_idle_sec =
+      Safe_ops.json_int ~default:3600 "initiative_idle_sec" json
+      |> normalize_initiative_idle_sec
+    in
+    let initiative_cooldown_sec =
+      Safe_ops.json_int ~default:3600 "initiative_cooldown_sec" json
+      |> normalize_initiative_cooldown_sec
+    in
+    let initiative_context_mode =
+      Safe_ops.json_string ~default:"board_snapshot" "initiative_context_mode" json
+      |> canonical_initiative_context_mode
+    in
+    let initiative_post_ttl_hours =
+      Safe_ops.json_int ~default:24 "initiative_post_ttl_hours" json
+      |> normalize_initiative_post_ttl_hours
     in
     let scope_kind =
       Safe_ops.json_string ~default:"local" "scope_kind" json |> canonical_scope_kind
@@ -712,6 +843,14 @@ let meta_of_json (json : Yojson.Safe.t) : (keeper_meta, string) result =
           policy_mode;
           policy_action_budget;
           policy_reward_model_path;
+          policy_voice_enabled;
+          policy_shell_mode;
+          initiative_enabled;
+          initiative_scope;
+          initiative_idle_sec;
+          initiative_cooldown_sec;
+          initiative_context_mode;
+          initiative_post_ttl_hours;
           scope_kind;
           room_scope;
           trigger_mode;

--- a/lib/mode.ml
+++ b/lib/mode.ml
@@ -194,7 +194,7 @@ let tool_category tool_name =
   | "masc_swarm_live_run"
   (* Mode management - always available *)
   | "masc_switch_mode" | "masc_get_config" -> Core
-  | "masc_tool_help" | "masc_tool_admin_snapshot" -> Core
+  | "masc_tool_help" | "masc_tool_admin_snapshot" | "masc_keeper_tool_catalog" -> Core
 
   (* ── Communication ── *)
   | "masc_broadcast" | "masc_messages"

--- a/lib/tool_misc.ml
+++ b/lib/tool_misc.ml
@@ -649,6 +649,69 @@ let handle_tool_help _ctx args =
     | Some entry ->
         (true, Yojson.Safe.pretty_to_string (Tool_help_registry.entry_json entry))
 
+let handle_keeper_tool_catalog _ctx args =
+  let include_hidden = get_bool args "include_hidden" false in
+  let include_deprecated = get_bool args "include_deprecated" false in
+  let tier_filter =
+    match get_string_opt args "tier" |> Option.map String.lowercase_ascii with
+    | None -> None
+    | Some raw -> Tool_catalog.tier_of_string raw
+  in
+  let server_tools =
+    (if include_hidden || include_deprecated then
+       Config.all_tool_schemas
+       |> List.filter (fun schema ->
+              Tool_catalog.is_visible
+                ~include_hidden
+                ~include_deprecated
+                schema.Types.name)
+     else
+       Config.visible_tool_schemas ())
+    |> List.filter (fun schema -> String.length schema.Types.name >= 5
+                                 && String.equal (String.sub schema.Types.name 0 5) "masc_")
+    |> (match tier_filter with
+        | None -> Fun.id
+        | Some tier ->
+            List.filter (fun schema -> Tool_catalog.is_in_tier tier schema.Types.name))
+  in
+  let tool_json (schema : Types.tool_schema) =
+    `Assoc
+      (("name", `String schema.name)
+       :: Tool_catalog.metadata_to_fields schema.name)
+  in
+  let wrapped_internal_tools =
+    Tool_shard.keeper_llm_tools
+    |> List.map (fun tool -> tool.Llm_client.tool_name)
+    |> List.sort_uniq String.compare
+  in
+  let wrapped_server_names =
+    [
+      "masc_board_post";
+      "masc_board_comment";
+      "masc_board_list";
+      "masc_voice_speak";
+    ]
+  in
+  let server_only_tools =
+    server_tools
+    |> List.map (fun schema -> schema.Types.name)
+    |> List.filter (fun name -> not (List.mem name wrapped_server_names))
+  in
+  let json =
+    `Assoc
+      [
+        ("count", `Int (List.length server_tools));
+        ("server_tools", `List (List.map tool_json server_tools));
+        ("wrapped_internal_tools",
+          `List (List.map (fun name -> `String name) wrapped_internal_tools));
+        ("wrapped_server_tools",
+          `List (List.map (fun name -> `String name) wrapped_server_names));
+        ("server_only_tools",
+          `List (List.map (fun name -> `String name) server_only_tools));
+      ]
+  in
+  (true, Yojson.Safe.pretty_to_string json)
+
 (* Dispatch function *)
 let dispatch ctx ~name ~args : result option =
   match name with
@@ -660,4 +723,5 @@ let dispatch ctx ~name ~args : result option =
   | "masc_tool_help" -> Some (handle_tool_help ctx args)
   | "masc_tool_admin_snapshot" -> Some (handle_tool_admin_snapshot ctx args)
   | "masc_tool_admin_update" -> Some (handle_tool_admin_update ctx args)
+  | "masc_keeper_tool_catalog" -> Some (handle_keeper_tool_catalog ctx args)
   | _ -> None

--- a/lib/tool_shard.ml
+++ b/lib/tool_shard.ml
@@ -119,6 +119,21 @@ let filesystem_tools : Llm_client.tool_def list = [
 
 let shell_tools : Llm_client.tool_def list = [
   {
+    tool_name = "keeper_shell_readonly";
+    tool_description = "Run a structured read-only project command. Supported ops: pwd, ls, cat, rg, git_status.";
+    parameters = `Assoc [
+      ("type", `String "object");
+      ("properties", `Assoc [
+        ("op", `Assoc [("type", `String "string"); ("description", `String "One of: pwd, ls, cat, rg, git_status")]);
+        ("path", `Assoc [("type", `String "string"); ("description", `String "Optional target path for ls/cat/rg")]);
+        ("pattern", `Assoc [("type", `String "string"); ("description", `String "Search pattern for rg")]);
+        ("limit", `Assoc [("type", `String "integer"); ("description", `String "Optional result limit for ls/rg")]);
+        ("max_bytes", `Assoc [("type", `String "integer"); ("description", `String "Optional max bytes for cat")]);
+      ]);
+      ("required", `List [`String "op"]);
+    ];
+  };
+  {
     tool_name = "keeper_bash";
     tool_description = "Run a shell command from project root. Use for build/test/check commands.";
     parameters = `Assoc [
@@ -140,6 +155,22 @@ let shell_tools : Llm_client.tool_def list = [
         ("args", `Assoc [("type", `String "array"); ("items", `Assoc [("type", `String "string")]); ("description", `String "Optional argv list for gh (without leading gh)")]);
         ("timeout_sec", `Assoc [("type", `String "number"); ("description", `String "Timeout seconds (default: 30, max: 180)")]);
       ]);
+    ];
+  };
+]
+
+let voice_tools : Llm_client.tool_def list = [
+  {
+    tool_name = "keeper_voice_speak";
+    tool_description = "Speak a short utterance as this keeper via the voice bridge, falling back to text when voice is unavailable.";
+    parameters = `Assoc [
+      ("type", `String "object");
+      ("properties", `Assoc [
+        ("message", `Assoc [("type", `String "string"); ("description", `String "Text to speak")]);
+        ("provider", `Assoc [("type", `String "string"); ("description", `String "Optional voice provider override")]);
+        ("priority", `Assoc [("type", `String "integer"); ("description", `String "Optional queue priority")]);
+      ]);
+      ("required", `List [`String "message"]);
     ];
   };
 ]
@@ -251,6 +282,13 @@ let shard_weather : shard = {
   description = "Weather queries";
 }
 
+let shard_voice : shard = {
+  name = "voice";
+  tools = voice_tools;
+  removable = true;
+  description = "Voice bridge speak output";
+}
+
 let shard_taskboard : shard = {
   name = "taskboard";
   tools = taskboard_tools;
@@ -271,6 +309,7 @@ let default_shard_names : string list = [
   "filesystem";
   "shell";
   "weather";
+  "voice";
 ]
 
 let get_agent_shards (agent_name : string) : string list =
@@ -289,6 +328,7 @@ let all_shards : (string, shard) Hashtbl.t =
     shard_filesystem;
     shard_shell;
     shard_weather;
+    shard_voice;
     shard_taskboard;
   ];
   tbl
@@ -347,7 +387,7 @@ let schemas : Types.tool_schema list = [
   {
     name = "masc_tool_grant";
     description = "Grant a tool shard to an agent. \
-Shards: base (core), board, filesystem, shell, weather, taskboard.";
+Shards: base (core), board, filesystem, shell, weather, voice, taskboard.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -357,7 +397,7 @@ Shards: base (core), board, filesystem, shell, weather, taskboard.";
         ]);
         ("shard_name", `Assoc [
           ("type", `String "string");
-          ("description", `String "Shard to grant: base, board, filesystem, shell, weather, taskboard");
+          ("description", `String "Shard to grant: base, board, filesystem, shell, weather, voice, taskboard");
         ]);
       ]);
       ("required", `List [`String "agent_name"; `String "shard_name"]);
@@ -376,7 +416,7 @@ Cannot revoke 'base' shard (always present).";
         ]);
         ("shard_name", `Assoc [
           ("type", `String "string");
-          ("description", `String "Shard to revoke (must be removable)");
+          ("description", `String "Shard to revoke (must be removable). One of: board, filesystem, shell, weather, voice, taskboard");
         ]);
       ]);
       ("required", `List [`String "agent_name"; `String "shard_name"]);

--- a/lib/tools.ml
+++ b/lib/tools.ml
@@ -4394,7 +4394,6 @@ Example: masc_tempo_reset() → {tempo: 300, message: 'Reset to default'}";
       ("required", `List [`String "tool_name"]);
     ];
   };
-
   {
     name = "masc_tool_admin_snapshot";
     description = "Return a unified admin snapshot of tool inventory, auth/RBAC, mode gates, keeper policy, and command-plane policy surfaces.";
@@ -4414,7 +4413,6 @@ Example: masc_tempo_reset() → {tempo: 300, message: 'Reset to default'}";
       ]);
     ];
   };
-
   {
     name = "masc_tool_admin_update";
     description = "Apply mode, auth, unit-policy, or keeper-policy updates through a single admin entrypoint.";
@@ -4484,6 +4482,27 @@ Example: masc_tempo_reset() → {tempo: 300, message: 'Reset to default'}";
         ]);
       ]);
       ("required", `List [`String "section"]);
+    ];
+  };
+  {
+    name = "masc_keeper_tool_catalog";
+    description = "List visible server-side masc_* tools alongside keeper-internal wrapper coverage.";
+    input_schema = `Assoc [
+      ("type", `String "object");
+      ("properties", `Assoc [
+        ("tier", `Assoc [
+          ("type", `String "string");
+          ("description", `String "Optional tier filter: essential, standard, full");
+        ]);
+        ("include_hidden", `Assoc [
+          ("type", `String "boolean");
+          ("description", `String "Include hidden tools in the catalog");
+        ]);
+        ("include_deprecated", `Assoc [
+          ("type", `String "boolean");
+          ("description", `String "Include deprecated tools in the catalog");
+        ]);
+      ]);
     ];
   };
 ]

--- a/test/test_tool_keeper.ml
+++ b/test/test_tool_keeper.ml
@@ -178,11 +178,23 @@ let test_resolved_keeper_skill_route_falls_back_when_agent_parse_missing () =
   check string "primary skill" "masc-heartbeat" resolved.route.primary_skill
 
 let test_keeper_model_set_persists_active_model () =
+  let provider_model =
+    match Masc_mcp.Tool_llama.fetch_models () with
+    | Ok (_, model_id :: _) -> Some ("llama:" ^ model_id)
+    | Ok (_, []) -> None
+    | Error _ -> None
+  in
+  match provider_model with
+  | None ->
+      check bool "skip when local llama inventory unavailable" true true
+  | Some provider_model ->
   Eio_main.run @@ fun env ->
   Eio.Switch.run @@ fun sw ->
   let base_dir = temp_dir () in
   Fun.protect
-    ~finally:(fun () -> rm_rf base_dir)
+    ~finally:(fun () ->
+      Masc_mcp.Keeper_execution.stop_keepalive "sangsu";
+      rm_rf base_dir)
     (fun () ->
       let config = Masc_mcp.Room.default_config base_dir in
       ignore (Masc_mcp.Room.init config ~agent_name:(Some "tester"));
@@ -200,8 +212,8 @@ let test_keeper_model_set_persists_active_model () =
             [
               ("name", `String "sangsu");
               ("goal", `String "Maintain Sangsu persona");
-              ("models", `List [ `String "custom:initial-model" ]);
-              ("active_model", `String "custom:initial-model");
+              ("models", `List [ `String provider_model ]);
+              ("active_model", `String provider_model);
               ("room_scope", `String "all");
               ("trigger_mode", `String "explicit_only");
               ("mention_targets", `List [ `String "sangsu" ]);
@@ -215,13 +227,16 @@ let test_keeper_model_set_persists_active_model () =
           (`Assoc
             [
               ("name", `String "sangsu");
-              ("model", `String "custom:updated-model");
+              ("model", `String provider_model);
+              ("allowed_models", `List [ `String provider_model ]);
             ])
       in
       check bool "model set ok" true ok;
       let json = Yojson.Safe.from_string body in
-      check string "active model updated" "custom:updated-model"
+      check string "active model updated" provider_model
         Yojson.Safe.Util.(json |> member "active_model" |> to_string);
+      check int "allowed models pruned to explicit list" 1
+        Yojson.Safe.Util.(json |> member "allowed_models" |> to_list |> List.length);
       let ok, status_body =
         dispatch "masc_keeper_status"
           (`Assoc
@@ -237,7 +252,7 @@ let test_keeper_model_set_persists_active_model () =
       in
       check bool "status ok" true ok;
       let status_json = Yojson.Safe.from_string status_body in
-      check string "status active model" "custom:updated-model"
+      check string "status active model" provider_model
         Yojson.Safe.Util.(status_json |> member "active_model" |> to_string))
 
 let write_persona_profile ~me_root ~persona_name ~content =
@@ -274,7 +289,11 @@ let write_reward_model path =
     "board_post": {
       "bias": -0.3,
       "weights": {
-        "active_goal_count": 0.8
+        "active_goal_count": 0.8,
+        "idle_seconds": 1.0,
+        "room_scope_all": 0.3,
+        "board_recent_external_post_count": 0.4,
+        "board_newest_external_post_freshness": 0.4
       }
     }
   }
@@ -287,12 +306,15 @@ let test_persona_list_and_create_from_persona () =
   let me_root = temp_dir () in
   Fun.protect
     ~finally:(fun () ->
+      Masc_mcp.Keeper_execution.stop_keepalive "sangsu";
       rm_rf base_dir;
       rm_rf me_root)
     (fun () ->
+      let reward_model_path = Filename.concat base_dir "reward-model.json" in
+      write_reward_model reward_model_path;
       write_persona_profile ~me_root ~persona_name:"sangsu"
         ~content:
-          {|{
+          (Printf.sprintf {|{
   "name": "상수",
   "role": "홍상수 영화 속 찌질한 40대 남자",
   "trait": "직설적이고 현실적",
@@ -305,9 +327,20 @@ let test_persona_list_and_create_from_persona () =
     "trigger_mode": "explicit_only",
     "mention_targets": ["sangsu"],
     "presence_keepalive": false,
-    "proactive_enabled": false
+    "proactive_enabled": false,
+    "policy_mode": "learned_offline_v1",
+    "policy_action_budget": "board",
+    "policy_reward_model_path": "%s",
+    "policy_voice_enabled": true,
+    "policy_shell_mode": "readonly",
+    "initiative_enabled": true,
+    "initiative_scope": "board_only",
+    "initiative_idle_sec": 3600,
+    "initiative_cooldown_sec": 3600,
+    "initiative_context_mode": "board_snapshot",
+    "initiative_post_ttl_hours": 24
   }
-}|};
+}|} reward_model_path);
       with_env "ME_ROOT" me_root (fun () ->
         let config = Masc_mcp.Room.default_config base_dir in
         ignore (Masc_mcp.Room.init config ~agent_name:(Some "tester"));
@@ -340,6 +373,14 @@ let test_persona_list_and_create_from_persona () =
           Yojson.Safe.Util.(dry_json |> member "resident" |> to_bool);
         check string "dry run trigger mode" "explicit_only"
           Yojson.Safe.Util.(dry_json |> member "resolved_args" |> member "trigger_mode" |> to_string);
+        check string "dry run policy mode" "learned_offline_v1"
+          Yojson.Safe.Util.(dry_json |> member "resolved_args" |> member "policy_mode" |> to_string);
+        check bool "dry run voice enabled" true
+          Yojson.Safe.Util.(dry_json |> member "resolved_args" |> member "policy_voice_enabled" |> to_bool);
+        check string "dry run shell mode" "readonly"
+          Yojson.Safe.Util.(dry_json |> member "resolved_args" |> member "policy_shell_mode" |> to_string);
+        check bool "dry run initiative enabled" true
+          Yojson.Safe.Util.(dry_json |> member "resolved_args" |> member "initiative_enabled" |> to_bool);
         let ok, create_body =
           dispatch "masc_keeper_create_from_persona"
             (`Assoc
@@ -367,7 +408,15 @@ let test_persona_list_and_create_from_persona () =
         check bool "status ok" true ok;
         let status_json = Yojson.Safe.from_string status_body in
         check string "status room scope" "all"
-          Yojson.Safe.Util.(status_json |> member "meta" |> member "room_scope" |> to_string)))
+          Yojson.Safe.Util.(status_json |> member "meta" |> member "room_scope" |> to_string);
+        check string "status policy mode" "learned_offline_v1"
+          Yojson.Safe.Util.(status_json |> member "policy" |> member "mode" |> to_string);
+        check bool "status voice enabled" true
+          Yojson.Safe.Util.(status_json |> member "policy" |> member "voice_enabled" |> to_bool);
+        check string "status shell mode" "readonly"
+          Yojson.Safe.Util.(status_json |> member "policy" |> member "shell_mode" |> to_string);
+        check bool "status initiative enabled" true
+          Yojson.Safe.Util.(status_json |> member "initiative" |> member "enabled" |> to_bool)))
 
 let test_resident_keeper_and_persistent_agent_lists_split () =
   Eio_main.run @@ fun env ->
@@ -440,7 +489,9 @@ let test_keeper_policy_tools_roundtrip () =
   Eio.Switch.run @@ fun sw ->
   let base_dir = temp_dir () in
   Fun.protect
-    ~finally:(fun () -> rm_rf base_dir)
+    ~finally:(fun () ->
+      Masc_mcp.Keeper_execution.stop_keepalive "sangsu";
+      rm_rf base_dir)
     (fun () ->
       let reward_model_path = Filename.concat base_dir "reward-model.json" in
       write_reward_model reward_model_path;
@@ -484,6 +535,51 @@ let test_keeper_policy_tools_roundtrip () =
       let policy_json = Yojson.Safe.from_string policy_body in
       check string "policy mode updated" "learned_offline_v1"
         Yojson.Safe.Util.(policy_json |> member "policy_mode" |> to_string);
+      let ok, _ =
+        dispatch "masc_keeper_up"
+          (`Assoc
+            [
+              ("name", `String "sangsu");
+              ("policy_voice_enabled", `Bool true);
+              ("policy_shell_mode", `String "readonly");
+            ])
+      in
+      check bool "keeper policy extras update ok" true ok;
+      let ok, status_body =
+        dispatch "masc_keeper_status"
+          (`Assoc
+            [
+              ("name", `String "sangsu");
+              ("fast", `Bool true);
+              ("include_context", `Bool false);
+              ("include_metrics_overview", `Bool false);
+              ("include_memory_bank", `Bool false);
+              ("include_history_tail", `Bool false);
+              ("include_compaction_history", `Bool false);
+            ])
+      in
+      check bool "status after policy set ok" true ok;
+      let status_json = Yojson.Safe.from_string status_body in
+      check bool "allowed tools contains board post" true
+        Yojson.Safe.Util.(
+          status_json |> member "policy" |> member "allowed_tools" |> to_list
+          |> List.exists (fun item -> item = `String "keeper_board_post"));
+      check bool "allowed tools contains voice speak" true
+        Yojson.Safe.Util.(
+          status_json |> member "policy" |> member "allowed_tools" |> to_list
+          |> List.exists (fun item -> item = `String "keeper_voice_speak"));
+      check bool "allowed tools contains readonly shell" true
+        Yojson.Safe.Util.(
+          status_json |> member "policy" |> member "allowed_tools" |> to_list
+          |> List.exists (fun item -> item = `String "keeper_shell_readonly"));
+      check bool "available internal tools contains bash" true
+        Yojson.Safe.Util.(
+          status_json |> member "policy" |> member "available_internal_tools" |> to_list
+          |> List.exists (fun item -> item = `String "keeper_bash"));
+      check bool "blocked internal tools contains bash" true
+        Yojson.Safe.Util.(
+          status_json |> member "policy" |> member "blocked_internal_tools" |> to_list
+          |> List.exists (fun item -> item = `String "keeper_bash"));
       Masc_mcp.Keeper_types.append_jsonl_line
         (Masc_mcp.Keeper_types.keeper_policy_log_path config "sangsu")
         (`Assoc
@@ -576,7 +672,9 @@ let test_keeper_policy_set_rejects_invalid_mode () =
   Eio.Switch.run @@ fun sw ->
   let base_dir = temp_dir () in
   Fun.protect
-    ~finally:(fun () -> rm_rf base_dir)
+    ~finally:(fun () ->
+      Masc_mcp.Keeper_execution.stop_keepalive "sangsu";
+      rm_rf base_dir)
     (fun () ->
       let config = Masc_mcp.Room.default_config base_dir in
       ignore (Masc_mcp.Room.init config ~agent_name:(Some "tester"));

--- a/test/test_tool_shard_coverage.ml
+++ b/test/test_tool_shard_coverage.ml
@@ -38,7 +38,7 @@ let test_shard_shell_exists () =
   match Tool_shard.get_shard "shell" with
   | Some s ->
     Alcotest.(check bool) "removable" true s.Tool_shard.removable;
-    Alcotest.(check bool) "has 2 tools" true (List.length s.Tool_shard.tools = 2)
+    Alcotest.(check bool) "has 3 tools" true (List.length s.Tool_shard.tools = 3)
   | None -> Alcotest.fail "shell shard not found"
 
 let test_shard_weather_exists () =
@@ -48,13 +48,20 @@ let test_shard_weather_exists () =
     Alcotest.(check bool) "has 1 tool" true (List.length s.Tool_shard.tools = 1)
   | None -> Alcotest.fail "weather shard not found"
 
+let test_shard_voice_exists () =
+  match Tool_shard.get_shard "voice" with
+  | Some s ->
+    Alcotest.(check bool) "removable" true s.Tool_shard.removable;
+    Alcotest.(check bool) "has 1 tool" true (List.length s.Tool_shard.tools = 1)
+  | None -> Alcotest.fail "voice shard not found"
+
 let test_shard_unknown () =
   Alcotest.(check bool) "unknown returns None" true
     (Tool_shard.get_shard "nonexistent" = None)
 
 let test_all_shards_count () =
   let all = Tool_shard.list_all_shards () in
-  Alcotest.(check int) "6 predefined shards" 6 (List.length all)
+  Alcotest.(check int) "7 predefined shards" 7 (List.length all)
 
 (* ============================================================
    default_shard_names tests
@@ -62,11 +69,11 @@ let test_all_shards_count () =
 
 let test_default_shard_names () =
   let defaults = Tool_shard.default_shard_names in
-  Alcotest.(check int) "5 defaults" 5 (List.length defaults);
+  Alcotest.(check int) "6 defaults" 6 (List.length defaults);
   List.iter (fun name ->
     Alcotest.(check bool) (name ^ " in defaults") true
       (List.mem name defaults)
-  ) ["base"; "board"; "filesystem"; "shell"; "weather"]
+  ) ["base"; "board"; "filesystem"; "shell"; "weather"; "voice"]
 
 (* ============================================================
    tools_of_shards tests
@@ -91,8 +98,8 @@ let test_tools_of_shards_unknown_ignored () =
 
 let test_keeper_llm_tools_count () =
   let tools = Tool_shard.keeper_llm_tools in
-  (* base=3 + board=3 + filesystem=2 + shell=2 + weather=1 = 11 *)
-  Alcotest.(check int) "11 total tools" 11 (List.length tools)
+  (* base=3 + board=3 + filesystem=2 + shell=3 + weather=1 + voice=1 = 13 *)
+  Alcotest.(check int) "13 total tools" 13 (List.length tools)
 
 (* ============================================================
    grant_shard tests
@@ -170,7 +177,7 @@ let test_revoke_unknown () =
 let test_get_agent_shards_default () =
   (* Unknown agent gets default shards *)
   let shards = Tool_shard.get_agent_shards "new-agent-never-seen" in
-  Alcotest.(check int) "defaults" 5 (List.length shards)
+  Alcotest.(check int) "defaults" 6 (List.length shards)
 
 let test_set_get_agent_shards () =
   Hashtbl.remove Tool_shard.agent_shards "test-agent-x";
@@ -193,7 +200,7 @@ let test_execute_tool_list () =
   let (ok, json) = Tool_shard.execute "masc_tool_list" (`Assoc []) in
   Alcotest.(check bool) "succeeds" true ok;
   let shards = Yojson.Safe.Util.(member "shards" json |> to_list) in
-  Alcotest.(check int) "6 shards in list" 6 (List.length shards)
+  Alcotest.(check int) "7 shards in list" 7 (List.length shards)
 
 let test_execute_tool_list_with_agent () =
   Hashtbl.remove Tool_shard.agent_shards "test-ex";
@@ -286,6 +293,7 @@ let () =
       Alcotest.test_case "filesystem" `Quick test_shard_filesystem_exists;
       Alcotest.test_case "shell" `Quick test_shard_shell_exists;
       Alcotest.test_case "weather" `Quick test_shard_weather_exists;
+      Alcotest.test_case "voice" `Quick test_shard_voice_exists;
       Alcotest.test_case "unknown" `Quick test_shard_unknown;
       Alcotest.test_case "all count" `Quick test_all_shards_count;
     ]);

--- a/test/test_tools_coverage.ml
+++ b/test/test_tools_coverage.ml
@@ -678,8 +678,44 @@ let test_masc_keeper_create_from_persona_schema () =
           Alcotest.(check bool) "has persona_name" true
             (List.mem_assoc "persona_name" props);
           Alcotest.(check bool) "has dry_run" true
-            (List.mem_assoc "dry_run" props)
+            (List.mem_assoc "dry_run" props);
+          Alcotest.(check bool) "has policy_mode" true
+            (List.mem_assoc "policy_mode" props);
+          Alcotest.(check bool) "has policy_voice_enabled" true
+            (List.mem_assoc "policy_voice_enabled" props);
+          Alcotest.(check bool) "has policy_shell_mode" true
+            (List.mem_assoc "policy_shell_mode" props);
+          Alcotest.(check bool) "has initiative_enabled" true
+            (List.mem_assoc "initiative_enabled" props)
       | None -> Alcotest.fail "masc_keeper_create_from_persona missing properties"
+
+let test_masc_keeper_up_initiative_schema () =
+  match find_tool "masc_keeper_up" with
+  | None -> Alcotest.fail "masc_keeper_up not found"
+  | Some schema ->
+      match get_json_assoc "properties" schema.input_schema with
+      | Some props ->
+          Alcotest.(check bool) "has policy_mode" true
+            (List.mem_assoc "policy_mode" props);
+          Alcotest.(check bool) "has policy_action_budget" true
+            (List.mem_assoc "policy_action_budget" props);
+          Alcotest.(check bool) "has policy_voice_enabled" true
+            (List.mem_assoc "policy_voice_enabled" props);
+          Alcotest.(check bool) "has policy_shell_mode" true
+            (List.mem_assoc "policy_shell_mode" props);
+          Alcotest.(check bool) "has initiative_enabled" true
+            (List.mem_assoc "initiative_enabled" props);
+          Alcotest.(check bool) "has initiative_scope" true
+            (List.mem_assoc "initiative_scope" props);
+          Alcotest.(check bool) "has initiative_idle_sec" true
+            (List.mem_assoc "initiative_idle_sec" props);
+          Alcotest.(check bool) "has initiative_cooldown_sec" true
+            (List.mem_assoc "initiative_cooldown_sec" props);
+          Alcotest.(check bool) "has initiative_context_mode" true
+            (List.mem_assoc "initiative_context_mode" props);
+          Alcotest.(check bool) "has initiative_post_ttl_hours" true
+            (List.mem_assoc "initiative_post_ttl_hours" props)
+      | None -> Alcotest.fail "masc_keeper_up missing properties"
 
 let test_masc_keeper_policy_set_schema () =
   match find_tool "masc_keeper_policy_set" with
@@ -1140,6 +1176,8 @@ let () =
       Alcotest.test_case "persona-list" `Quick test_masc_persona_list_schema;
       Alcotest.test_case "keeper-create-from-persona" `Quick
         test_masc_keeper_create_from_persona_schema;
+      Alcotest.test_case "keeper-up-initiative" `Quick
+        test_masc_keeper_up_initiative_schema;
       Alcotest.test_case "keeper-policy-set" `Quick
         test_masc_keeper_policy_set_schema;
       Alcotest.test_case "keeper-feedback-record" `Quick


### PR DESCRIPTION
## Summary
- add keeper-safe voice and readonly shell wrappers
- expose keeper tool catalog and policy allowlist visibility
- tighten allowed_models handling and inventory-backed keeper tests

## Verification
- dune build --root . bin/main_eio.exe test/test_tool_keeper.exe test/test_tool_shard_coverage.exe test/test_tools_coverage.exe test/test_operator_control.exe
- python3 -c 'import subprocess,sys; sys.exit(subprocess.run(["./_build/default/test/test_tool_keeper.exe"], timeout=180).returncode)'
- python3 -c 'import subprocess,sys; sys.exit(subprocess.run(["./_build/default/test/test_operator_control.exe"], timeout=180).returncode)'