### PR TITLE
fix: shrink keeper facade follow-up

### DIFF
--- a/lib/keeper_contract.ml
+++ b/lib/keeper_contract.ml
@@ -96,10 +96,8 @@ let trigger_mode_is_explicit_only = function
   | Explicit_only -> true
   | Legacy -> false
 
-let autonomy_level_of_string raw =
-  match Keeper_autonomy.autonomy_level_of_string raw with
-  | Some level -> level
-  | None -> Keeper_autonomy.L1_Reactive
+let parse_autonomy_level raw =
+  Keeper_autonomy.autonomy_level_of_string raw
 
 let autonomy_level_to_storage_string level =
   Keeper_autonomy.autonomy_level_to_string level

--- a/lib/keeper_execution.ml
+++ b/lib/keeper_execution.ml
@@ -2659,10 +2659,10 @@ let run_autonomous_goal_turn ~(config : Room.config) ~(meta : keeper_meta)
   if not (keeper_autonomy_enabled ()) then None
   else if meta.active_goal_ids = [] then None
   else
-    let level = Keeper_contract.autonomy_level_of_string meta.autonomy_level in
-    match level with
-    | L1_Reactive -> None
-    | level ->
+    match Keeper_contract.parse_autonomy_level meta.autonomy_level with
+    | None -> None
+    | Some L1_Reactive -> None
+    | Some level ->
         let primary = match specs with p :: _ -> p | [] -> Llm_client.default_local_model_spec () in
         let verify_model =
           match Llm_client.default_verifier_model_spec () with

--- a/lib/keeper_policy.ml
+++ b/lib/keeper_policy.ml
@@ -425,8 +425,9 @@ let handle_keeper_autonomy ctx args : tool_result =
          let info = Printf.sprintf
            "Keeper: %s\nAutonomy Level: %s\nActive Goals: [%s]\nAutonomous Actions: %d\nLast Autonomous Action: %s"
            m.name
-           (Keeper_contract.autonomy_level_of_string m.autonomy_level
-            |> Keeper_autonomy.autonomy_level_to_string)
+           (match Keeper_contract.parse_autonomy_level m.autonomy_level with
+            | Some level -> Keeper_autonomy.autonomy_level_to_string level
+            | None -> m.autonomy_level)
            (String.concat ", " m.active_goal_ids)
            m.autonomous_action_count
            (if m.last_autonomous_action_at = "" then "never" else m.last_autonomous_action_at)

--- a/lib/tool_misc.ml
+++ b/lib/tool_misc.ml
@@ -383,12 +383,10 @@ let apply_keeper_policy_update config ~runtime_class args =
         in
         let autonomy_level =
           match autonomy_level_opt with
-          | None -> (
-              match Keeper_contract.parse_autonomy_level meta.autonomy_level with
-              | Some level -> Ok level
-              | None ->
-                  Error
-                    (Printf.sprintf "invalid stored autonomy_level: %s" meta.autonomy_level))
+          | None ->
+              Ok
+                (Keeper_contract.parse_autonomy_level meta.autonomy_level
+                 |> Option.value ~default:Keeper_autonomy.L1_Reactive)
           | Some raw -> (
               match Keeper_autonomy.autonomy_level_of_string raw with
               | Some level -> Ok level

--- a/lib/tool_misc.ml
+++ b/lib/tool_misc.ml
@@ -141,20 +141,30 @@ let keeper_gate_config_for_level
       }
 
 let keeper_tool_policy_json autonomy_level =
-  let level = Keeper_contract.autonomy_level_of_string autonomy_level in
-  let gate = keeper_gate_config_for_level ~autonomy_level:level in
-  `Assoc
-    [
-      ("configured_tool_policy", `String (if gate.allowlist_enabled then "allowlist" else "all"));
-      ( "configured_tool_names",
-        `List
-          (if gate.allowlist_enabled
-           then List.map (fun name -> `String name) gate.allowed_tools
-           else []) );
-      ("denied_tool_names", `List (List.map (fun name -> `String name) gate.denied_tools));
-      ("max_tool_calls_per_turn", `Int gate.max_tool_calls_per_turn);
-      ("destructive_check_enabled", `Bool gate.destructive_check_enabled);
-    ]
+  match Keeper_contract.parse_autonomy_level autonomy_level with
+  | Some level ->
+      let gate = keeper_gate_config_for_level ~autonomy_level:level in
+      `Assoc
+        [
+          ("configured_tool_policy", `String (if gate.allowlist_enabled then "allowlist" else "all"));
+          ( "configured_tool_names",
+            `List
+              (if gate.allowlist_enabled
+               then List.map (fun name -> `String name) gate.allowed_tools
+               else []) );
+          ("denied_tool_names", `List (List.map (fun name -> `String name) gate.denied_tools));
+          ("max_tool_calls_per_turn", `Int gate.max_tool_calls_per_turn);
+          ("destructive_check_enabled", `Bool gate.destructive_check_enabled);
+        ]
+  | None ->
+      `Assoc
+        [
+          ("configured_tool_policy", `String "unknown");
+          ("configured_tool_names", `List []);
+          ("denied_tool_names", `List []);
+          ("max_tool_calls_per_turn", `Null);
+          ("destructive_check_enabled", `Null);
+        ]
 
 let keeper_policy_row ctx ~runtime_class (meta : Keeper_types.keeper_meta) =
   let status_json = Keeper_execution.parse_agent_status ctx.config ~agent_name:meta.agent_name in
@@ -373,7 +383,12 @@ let apply_keeper_policy_update config ~runtime_class args =
         in
         let autonomy_level =
           match autonomy_level_opt with
-          | None -> Ok (Keeper_contract.autonomy_level_of_string meta.autonomy_level)
+          | None -> (
+              match Keeper_contract.parse_autonomy_level meta.autonomy_level with
+              | Some level -> Ok level
+              | None ->
+                  Error
+                    (Printf.sprintf "invalid stored autonomy_level: %s" meta.autonomy_level))
           | Some raw -> (
               match Keeper_autonomy.autonomy_level_of_string raw with
               | Some level -> Ok level

--- a/lib/tool_misc.ml
+++ b/lib/tool_misc.ml
@@ -383,13 +383,10 @@ let apply_keeper_policy_update config ~runtime_class args =
         in
         let autonomy_level =
           match autonomy_level_opt with
-          | None ->
-              Ok
-                (Keeper_contract.parse_autonomy_level meta.autonomy_level
-                 |> Option.value ~default:Keeper_autonomy.L1_Reactive)
+          | None -> Ok meta.autonomy_level
           | Some raw -> (
               match Keeper_autonomy.autonomy_level_of_string raw with
-              | Some level -> Ok level
+              | Some level -> Ok (Keeper_contract.autonomy_level_to_storage_string level)
               | None -> Error (Printf.sprintf "invalid autonomy_level: %s" raw))
         in
         (match policy_mode, action_budget, autonomy_level with
@@ -425,8 +422,7 @@ let apply_keeper_policy_update config ~runtime_class args =
                     policy_action_budget =
                       Keeper_contract.policy_action_budget_to_string action_budget;
                     policy_reward_model_path = effective_reward_path;
-                    autonomy_level =
-                      Keeper_contract.autonomy_level_to_storage_string autonomy_level;
+                    autonomy_level;
                     updated_at = Types.now_iso ();
                   }
                 in

--- a/test/test_silent_failures_p2a.ml
+++ b/test/test_silent_failures_p2a.ml
@@ -148,8 +148,8 @@ let test_source_llm_token_parse () =
       {|[llm] token field missing or wrong type|})
 
 let test_source_keeper_proactive () =
-  check bool "tool_keeper.ml has proactive emission logging"
-    true (file_contains_pattern "lib/tool_keeper.ml"
+  check bool "keeper_execution.ml has proactive emission logging"
+    true (file_contains_pattern "lib/keeper_execution.ml"
       {|[keeper] proactive emission failed:|})
 
 (* MEDIUM priority patterns *)


### PR DESCRIPTION
## Summary
- follow-up to merged PR #820 to land the post-merge keeper facade cleanup that was pushed after merge
- keep Tool_keeper wrapper-only, split base handlers into keeper_turn/status/policy/persona
- add Keeper_contract typed helpers for keeper policy/runtime decisions
- update tool_misc to use the new keeper module boundaries and preserve stored autonomy on no-op updates

## Validation
- dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/refactor-keeper-dispatch-typed
- ./_build/default/test/test_tool_keeper.exe
- ./_build/default/test/test_tool_misc_coverage.exe
- ./_build/default/test/test_operator_control.exe
