### PR TITLE
fix(test): update MA-H4 source path after keeper facade split

### DIFF
--- a/test/test_silent_failures_p2a.ml
+++ b/test/test_silent_failures_p2a.ml
@@ -148,8 +148,8 @@ let test_source_llm_token_parse () =
       {|[llm] token field missing or wrong type|})
 
 let test_source_keeper_proactive () =
-  check bool "tool_keeper.ml has proactive emission logging"
-    true (file_contains_pattern "lib/tool_keeper.ml"
+  check bool "keeper_execution.ml has proactive emission logging"
+    true (file_contains_pattern "lib/keeper_execution.ml"
       {|[keeper] proactive emission failed:|})
 
 (* MEDIUM priority patterns *)


### PR DESCRIPTION
## Summary
- PR #820이 `tool_keeper.ml`에서 `keeper_execution.ml`로 proactive emission logging을 이동
- `test_silent_failures_p2a.ml`의 MA-H4 소스 검증 테스트가 이전 파일 경로를 참조하여 실패
- `file_contains_pattern` 경로를 `lib/keeper_execution.ml`로 수정

## Test plan
- [x] `dune exec test/test_silent_failures_p2a.exe` — 15/15 통과
- [ ] CI green 확인

Generated with [Claude Code](https://claude.com/claude-code)