### PR TITLE
feat(gardener): add truth-only runtime status surface

### DIFF
--- a/bin/main_eio.ml
+++ b/bin/main_eio.ml
@@ -5492,6 +5492,7 @@ let dashboard_shell_status_json (config : Room.config) : Yojson.Safe.t =
   let room_state = Room.read_state config in
   let tempo = Tempo.get_tempo config in
   let lodge_json = Masc_mcp.Lodge_heartbeat.(lodge_status () |> lodge_status_to_json) in
+  let gardener_json = Masc_mcp.Gardener.status_json () in
   let build = Build_identity.current () in
   `Assoc
     [
@@ -5504,6 +5505,7 @@ let dashboard_shell_status_json (config : Room.config) : Yojson.Safe.t =
       ("tempo_interval_s", `Float tempo.current_interval_s);
       ("paused", `Bool room_state.paused);
       ("lodge", lodge_json);
+      ("gardener", gardener_json);
       ("version", `String build.release_version);
       ("build", Build_identity.to_yojson build);
     ]
@@ -6300,6 +6302,7 @@ let health_handler _request reqd =
   in
   let build = Build_identity.current () in
   let lodge_json = Masc_mcp.Lodge_heartbeat.(lodge_status () |> lodge_status_to_json) in
+  let gardener_json = Masc_mcp.Gardener.status_json () in
   let guardian_json = Masc_mcp.Guardian.status_json () in
   let sentinel_json = Masc_mcp.Sentinel.status_json () in
   let health_json = `Assoc [
@@ -6325,6 +6328,7 @@ let health_handler _request reqd =
     ("uptime", `String uptime_str);
     ("sse_clients", `Int (Masc_mcp.Sse.client_count ()));
     ("lodge", lodge_json);
+    ("gardener", gardener_json);
     ("guardian", guardian_json);
     ("sentinel", sentinel_json);
   ] in
@@ -8576,6 +8580,7 @@ let run_server ~sw ~env ~host ~port ~base_path =
           in
           let build = Build_identity.current () in
           let lodge_json = Masc_mcp.Lodge_heartbeat.(lodge_status () |> lodge_status_to_json) in
+          let gardener_json = Masc_mcp.Gardener.status_json () in
           let guardian_json = Masc_mcp.Guardian.status_json () in
           let sentinel_json = Masc_mcp.Sentinel.status_json () in
           let health_json = `Assoc [
@@ -8588,6 +8593,7 @@ let run_server ~sw ~env ~host ~port ~base_path =
             ("uptime", `String uptime_str);
             ("sse_clients", `Int (Sse.client_count ()));
             ("lodge", lodge_json);
+            ("gardener", gardener_json);
             ("guardian", guardian_json);
             ("sentinel", sentinel_json);
           ] in

--- a/dashboard/src/app.ts
+++ b/dashboard/src/app.ts
@@ -147,6 +147,7 @@ function refreshForTab(tab: string) {
 function SnapshotCard({ currentTab }: { currentTab: string }) {
   const liveConnected = connected.value
   const build = serverStatus.value?.build
+  const gardener = serverStatus.value?.gardener
   return html`
     <section class="rail-card">
       <div class="rail-card-head">
@@ -190,6 +191,38 @@ function SnapshotCard({ currentTab }: { currentTab: string }) {
       ${build
         ? html`<div class="rail-build-hint">Server Build · v${build.release_version} · ${shortCommit(build.commit)}</div>`
         : null}
+      ${gardener ? html`
+        <div style="margin-top:12px; padding-top:12px; border-top:1px solid rgba(255,255,255,0.08); display:flex; flex-direction:column; gap:6px;">
+          <div class="rail-card-head" style="margin:0;">
+            <h3 style="font-size:12px;">Gardener</h3>
+            <span class="rail-section-chip ${gardener.alive ? 'ok' : gardener.enabled ? 'warn' : 'bad'}">
+              ${gardener.alive ? 'Live' : gardener.enabled ? 'Starting' : 'Disabled'}
+            </span>
+          </div>
+          <div class="build-badge-row">
+            <span>Last tick</span>
+            <strong>${gardener.last_tick_completed_at ? html`<${TimeAgo} timestamp=${gardener.last_tick_completed_at} />` : 'never'}</strong>
+          </div>
+          <div class="build-badge-row">
+            <span>Decision</span>
+            <strong>${gardener.last_intervention ?? 'none'} · ${gardener.last_decision_source ?? 'none'}</strong>
+          </div>
+          <div class="build-badge-row">
+            <span>Action</span>
+            <strong>${gardener.last_action ?? 'none'}</strong>
+          </div>
+          <div class="build-badge-row">
+            <span>Backlog</span>
+            <strong>${gardener.health_summary?.todo_count ?? 0} todo · P1/2 ${gardener.health_summary?.high_priority_todo ?? 0}</strong>
+          </div>
+          ${gardener.last_reason
+            ? html`<div class="rail-build-hint">Reason · ${gardener.last_reason}</div>`
+            : null}
+          ${gardener.last_error
+            ? html`<div class="rail-build-hint" style="color:#fca5a5;">Error · ${gardener.last_error}</div>`
+            : null}
+        </div>
+      ` : null}
     </section>
   `
 }

--- a/dashboard/src/store.ts
+++ b/dashboard/src/store.ts
@@ -730,6 +730,51 @@ function normalizeBuildIdentity(raw: unknown): ServerStatus['build'] | undefined
   }
 }
 
+function normalizeGardenerRuntimeStatus(raw: unknown): ServerStatus['gardener'] | undefined {
+  if (!isRecord(raw)) return undefined
+  return {
+    enabled: raw.enabled === true,
+    alive: raw.alive === true,
+    status: asString(raw.status) ?? undefined,
+    tick_in_progress: typeof raw.tick_in_progress === 'boolean' ? raw.tick_in_progress : undefined,
+    tick_count: asNumber(raw.tick_count) ?? undefined,
+    check_interval_sec: asNumber(raw.check_interval_sec) ?? undefined,
+    last_tick_started_at: toIsoTimestamp(raw.last_tick_started_at) ?? asString(raw.last_tick_started_at) ?? null,
+    last_tick_completed_at: toIsoTimestamp(raw.last_tick_completed_at) ?? asString(raw.last_tick_completed_at) ?? null,
+    next_tick_due_at: toIsoTimestamp(raw.next_tick_due_at) ?? asString(raw.next_tick_due_at) ?? null,
+    last_health_check_at: toIsoTimestamp(raw.last_health_check_at) ?? asString(raw.last_health_check_at) ?? null,
+    last_intervention: asString(raw.last_intervention) ?? undefined,
+    last_decision_source: asString(raw.last_decision_source) ?? undefined,
+    last_action: asString(raw.last_action) ?? undefined,
+    last_target: asString(raw.last_target) ?? null,
+    last_reason: asString(raw.last_reason) ?? null,
+    last_error: asString(raw.last_error) ?? null,
+    circuit_open: typeof raw.circuit_open === 'boolean' ? raw.circuit_open : undefined,
+    circuit_open_until: toIsoTimestamp(raw.circuit_open_until) ?? asString(raw.circuit_open_until) ?? null,
+    can_spawn: typeof raw.can_spawn === 'boolean' ? raw.can_spawn : undefined,
+    can_retire: typeof raw.can_retire === 'boolean' ? raw.can_retire : undefined,
+    last_spawn_attempt_at: toIsoTimestamp(raw.last_spawn_attempt_at) ?? asString(raw.last_spawn_attempt_at) ?? null,
+    last_retirement_attempt_at: toIsoTimestamp(raw.last_retirement_attempt_at) ?? asString(raw.last_retirement_attempt_at) ?? null,
+    spawns_today: asNumber(raw.spawns_today) ?? undefined,
+    retirements_today: asNumber(raw.retirements_today) ?? undefined,
+    health_summary: isRecord(raw.health_summary)
+      ? {
+          total_agents: asNumber(raw.health_summary.total_agents) ?? undefined,
+          active_agents: asNumber(raw.health_summary.active_agents) ?? undefined,
+          idle_agents: asNumber(raw.health_summary.idle_agents) ?? undefined,
+          todo_count: asNumber(raw.health_summary.todo_count) ?? undefined,
+          high_priority_todo: asNumber(raw.health_summary.high_priority_todo) ?? undefined,
+          orphan_count: asNumber(raw.health_summary.orphan_count) ?? undefined,
+          homeostatic_score: asNumber(raw.health_summary.homeostatic_score) ?? undefined,
+          needs_workers:
+            typeof raw.health_summary.needs_workers === 'boolean'
+              ? raw.health_summary.needs_workers
+              : undefined,
+        }
+      : undefined,
+  }
+}
+
 function normalizeServerStatus(raw: unknown, generatedAt?: string): ServerStatus | null {
   if (!isRecord(raw)) return null
   return {
@@ -737,6 +782,7 @@ function normalizeServerStatus(raw: unknown, generatedAt?: string): ServerStatus
     generated_at: generatedAt ?? toIsoTimestamp(raw.generated_at) ?? undefined,
     build: normalizeBuildIdentity(raw.build),
     lodge: normalizeLodgeRuntimeStatus(raw.lodge) ?? undefined,
+    gardener: normalizeGardenerRuntimeStatus(raw.gardener) ?? undefined,
   }
 }
 

--- a/dashboard/src/types.ts
+++ b/dashboard/src/types.ts
@@ -783,6 +783,43 @@ export interface LodgeRuntimeStatus {
   active_self_heartbeats?: string[]
 }
 
+export interface GardenerRuntimeStatus {
+  enabled: boolean
+  alive: boolean
+  status?: string
+  tick_in_progress?: boolean
+  tick_count?: number
+  check_interval_sec?: number
+  last_tick_started_at?: string | null
+  last_tick_completed_at?: string | null
+  next_tick_due_at?: string | null
+  last_health_check_at?: string | null
+  last_intervention?: string
+  last_decision_source?: string
+  last_action?: string
+  last_target?: string | null
+  last_reason?: string | null
+  last_error?: string | null
+  circuit_open?: boolean
+  circuit_open_until?: string | null
+  can_spawn?: boolean
+  can_retire?: boolean
+  last_spawn_attempt_at?: string | null
+  last_retirement_attempt_at?: string | null
+  spawns_today?: number
+  retirements_today?: number
+  health_summary?: {
+    total_agents?: number
+    active_agents?: number
+    idle_agents?: number
+    todo_count?: number
+    high_priority_todo?: number
+    orphan_count?: number
+    homeostatic_score?: number
+    needs_workers?: boolean
+  }
+}
+
 // --- Dashboard projection responses ---
 
 export interface DashboardShellResponse {
@@ -2385,6 +2422,7 @@ export interface ServerStatus {
     council?: CouncilMonitoring
   }
   lodge?: LodgeRuntimeStatus
+  gardener?: GardenerRuntimeStatus
   data_quality?: {
     board_contract_ok?: boolean
     council_feed_ok?: boolean

--- a/lib/auth.ml
+++ b/lib/auth.ml
@@ -243,6 +243,9 @@ let permission_for_tool = function
   | "masc_observe_traces"
   | "masc_voice_sessions" | "masc_voice_agent" | "masc_voice_transcript" ->
       Some CanReadState
+  | "masc_gardener_health" | "masc_gardener_config" | "masc_gardener_status"
+  | "masc_gardener_propose_spawn" | "masc_gardener_retire_agent" ->
+      Some CanReadState
   | "masc_add_task" -> Some CanAddTask
   | "masc_claim" | "masc_claim_next" -> Some CanClaimTask
   | "masc_done" | "masc_update_priority" | "masc_transition" | "masc_release" -> Some CanCompleteTask
@@ -280,6 +283,9 @@ let permission_for_tool = function
       Some CanBroadcast
   (* Command-plane write operations require Admin *)
   | "masc_policy_freeze_unit" | "masc_policy_kill_switch" ->
+      Some CanAdmin
+  | "masc_gardener_execute_spawn" | "masc_gardener_execute_retire"
+  | "masc_gardener_reset_circuit" ->
       Some CanAdmin
   | "masc_portal_open" | "masc_portal_close" -> Some CanOpenPortal
   | "masc_portal_send" -> Some CanSendPortal

--- a/lib/gardener.ml
+++ b/lib/gardener.ml
@@ -67,6 +67,92 @@ let get_state () =
       gardener_state_ref := Some s;
       s
 
+let iso_of_unix ts =
+  let tm = Unix.gmtime ts in
+  Printf.sprintf "%04d-%02d-%02dT%02d:%02d:%02dZ"
+    (tm.Unix.tm_year + 1900) (tm.Unix.tm_mon + 1) tm.Unix.tm_mday
+    tm.Unix.tm_hour tm.Unix.tm_min tm.Unix.tm_sec
+
+let json_string_of_float_ts ts =
+  if ts > 0.0 then `String (iso_of_unix ts) else `Null
+
+let json_string_of_opt_ts = function
+  | Some ts when ts > 0.0 -> `String (iso_of_unix ts)
+  | _ -> `Null
+
+let json_string_of_nonempty value =
+  let trimmed = String.trim value in
+  if trimmed = "" then `Null else `String trimmed
+
+type decision_snapshot = {
+  intervention : intervention;
+  source : string;
+  reason : string;
+  target : string;
+  error : string;
+}
+
+let intervention_name = function
+  | NeedSpawn _ -> "need_spawn"
+  | NeedWorker _ -> "need_worker"
+  | NeedRetirement _ -> "need_retirement"
+  | Balanced -> "balanced"
+
+let intervention_target = function
+  | NeedSpawn gap -> gap.topic
+  | NeedRetirement stats -> stats.name
+  | NeedWorker _ | Balanced -> ""
+
+let mark_tick_start () =
+  let now = Time_compat.now () in
+  with_lock (fun () ->
+      let state = get_state () in
+      state.tick_count <- state.tick_count + 1;
+      state.last_tick_started_at <- now;
+      state.last_error <- "";
+      state.last_action <- "none";
+      state.last_target <- "";
+      state.last_reason <- "";
+      state.last_intervention <- "none";
+      state.last_decision_source <- "none");
+  now
+
+let record_health_summary ~(at : float) (health : ecosystem_health) =
+  with_lock (fun () ->
+      let state = get_state () in
+      state.last_health_check <- at;
+      state.last_total_agents <- health.total_agents;
+      state.last_active_agents <- health.active_agents;
+      state.last_idle_agents <- health.idle_agents;
+      state.last_todo_count <- health.task_backlog.todo_count;
+      state.last_high_priority_todo <- health.task_backlog.high_priority_todo;
+      state.last_orphan_count <- health.task_backlog.orphan_count;
+      state.last_homeostatic_score <- health.homeostatic_score;
+      state.last_needs_workers <- health.needs_workers)
+
+let record_decision (decision : decision_snapshot) =
+  with_lock (fun () ->
+      let state = get_state () in
+      state.last_intervention <- intervention_name decision.intervention;
+      state.last_decision_source <- decision.source;
+      state.last_reason <- decision.reason;
+      state.last_target <- decision.target;
+      if String.trim decision.error <> "" then state.last_error <- decision.error)
+
+let record_action ?target ?reason ?error action =
+  with_lock (fun () ->
+      let state = get_state () in
+      state.last_action <- action;
+      (match target with Some value when String.trim value <> "" -> state.last_target <- value | _ -> ());
+      (match reason with Some value when String.trim value <> "" -> state.last_reason <- value | _ -> ());
+      (match error with Some value when String.trim value <> "" -> state.last_error <- value | _ -> ()))
+
+let record_tick_complete () =
+  let now = Time_compat.now () in
+  with_lock (fun () ->
+      let state = get_state () in
+      state.last_tick_completed_at <- now)
+
 (** {1 Circuit Breaker} *)
 
 let is_circuit_open () =
@@ -754,14 +840,26 @@ let execute_retire ~(decision : retirement_decision) : (string, string) result =
 (** {1 Intervention Detection} *)
 
 (** Rule-based intervention detection (task-aware fallback) *)
-let detect_intervention_rule_based ~config ~health : intervention =
+let detect_intervention_rule_based ~config ~health : decision_snapshot =
   let backlog = health.task_backlog in
 
   (* Task pressure takes priority over Board gaps *)
   if backlog.todo_count > 0 && backlog.high_priority_todo > 0 && health.active_agents < 2 then
-    NeedWorker backlog
+    {
+      intervention = NeedWorker backlog;
+      source = "fallback";
+      reason = "high-priority backlog exceeds active worker capacity";
+      target = "";
+      error = "";
+    }
   else if backlog.orphan_count > 0 then
-    NeedWorker backlog
+    {
+      intervention = NeedWorker backlog;
+      source = "fallback";
+      reason = "orphan tasks detected in backlog";
+      target = "";
+      error = "";
+    }
   else begin
     (* Board gap detection — existing logic *)
     let mature_gaps = Lodge_heartbeat.check_gap_threshold () in
@@ -772,9 +870,25 @@ let detect_intervention_rule_based ~config ~health : intervention =
         let signals = Lodge_heartbeat.get_signals_for_topic ~topic in
         let gap = enrich_gap ~topic ~signals ~agents in
         if gap.maturity_hours >= config.gap_maturity_hours then
-          NeedSpawn gap
+          {
+            intervention = NeedSpawn gap;
+            source = "fallback";
+            reason =
+              Printf.sprintf "mature gap '%s' reached %.1fh with %d signals"
+                gap.topic gap.maturity_hours gap.signal_count;
+            target = gap.topic;
+            error = "";
+          }
         else
-          Balanced
+          {
+            intervention = Balanced;
+            source = "fallback";
+            reason =
+              Printf.sprintf "gap '%s' not mature enough yet (%.1fh < %.1fh)"
+                gap.topic gap.maturity_hours config.gap_maturity_hours;
+            target = gap.topic;
+            error = "";
+          }
     | _ ->
         (* Check for retirement candidates — inline condition, no pre-computed boolean *)
         if health.total_agents > config.target_agents && health.idle_agents > 0 then begin
@@ -786,14 +900,37 @@ let detect_intervention_rule_based ~config ~health : intervention =
             |> List.sort (fun a b ->
                 compare b.Lodge_selection.last_selected_at a.Lodge_selection.last_selected_at) in
           match idle_candidates with
-          | candidate :: _ -> NeedRetirement (convert_stats candidate)
-          | [] -> Balanced
+          | candidate :: _ ->
+              let stats = convert_stats candidate in
+              {
+                intervention = NeedRetirement stats;
+                source = "fallback";
+                reason =
+                  Printf.sprintf "agent '%s' idle for %.1fh over threshold"
+                    stats.name stats.idle_hours;
+                target = stats.name;
+                error = "";
+              }
+          | [] ->
+              {
+                intervention = Balanced;
+                source = "fallback";
+                reason = "no retirement candidate exceeded idle threshold";
+                target = "";
+                error = "";
+              }
         end else
-          Balanced
+          {
+            intervention = Balanced;
+            source = "fallback";
+            reason = "no worker pressure, no mature gap, no retirement candidate";
+            target = "";
+            error = "";
+          }
   end
 
 (** Use LLM to decide ecosystem intervention (primary decision path) *)
-let decide_intervention_with_llm ~config ~health : intervention =
+let decide_intervention_with_llm ~config ~health : decision_snapshot =
   let backlog = health.task_backlog in
   let prompt = Printf.sprintf
     {|에이전트 생태계 관리자로서 모든 시그널을 종합 분석하고 개입 여부를 판단해줘.
@@ -826,56 +963,196 @@ let decide_intervention_with_llm ~config ~health : intervention =
   let response =
     match Llm_client.run_prompt_cascade ~temperature:0.3 ~timeout_sec:20
         ~model_specs ~max_tokens:300 ~prompt () with
-    | Ok resp -> resp.content
-    | Error _ -> ""
+    | Ok resp -> Ok resp.content
+    | Error err -> Error ("llm intervention failed: " ^ err)
   in
 
   (* Parse LLM response *)
-  let action =
-    try
-      let start = String.index response '{' in
-      let end_pos = String.rindex response '}' in
-      let json_str = String.sub response start (end_pos - start + 1) in
-      let json = Yojson.Safe.from_string json_str in
-      let module U = Yojson.Safe.Util in
-      json |> U.member "action" |> U.to_string
-    with exn ->
-      Eio.traceln "[Gardener] LLM intervention JSON parse failed: %s" (Printexc.to_string exn);
-      "none"
+  let parsed_response =
+    match response with
+    | Error err -> Error err
+    | Ok body ->
+        try
+          let start = String.index body '{' in
+          let end_pos = String.rindex body '}' in
+          let json_str = String.sub body start (end_pos - start + 1) in
+          let json = Yojson.Safe.from_string json_str in
+          let module U = Yojson.Safe.Util in
+          let action = json |> U.member "action" |> U.to_string in
+          let reason =
+            match json |> U.member "reason" with
+            | `String value -> String.trim value
+            | _ -> ""
+          in
+          Ok (action, reason)
+        with exn ->
+          let message =
+            Printf.sprintf "llm intervention JSON parse failed: %s"
+              (Printexc.to_string exn)
+          in
+          Eio.traceln "[Gardener] %s" message;
+          Error message
   in
+  match parsed_response with
+  | Error err ->
+      let fallback = detect_intervention_rule_based ~config ~health in
+      { fallback with source = "fallback"; error = err }
+  | Ok (action, llm_reason) ->
+      (match action with
+       | "spawn_worker" when backlog.todo_count > 0 ->
+           {
+             intervention = NeedWorker backlog;
+             source = "llm";
+             reason =
+               if llm_reason <> "" then llm_reason
+               else "llm requested worker allocation";
+             target = "";
+             error = "";
+           }
+       | "spawn_worker" | "spawn_agent" ->
+           let mature_gaps = Lodge_heartbeat.check_gap_threshold () in
+           let agents = Lodge_heartbeat.get_agents () in
+           (match mature_gaps with
+            | (topic, _) :: _ ->
+                let signals = Lodge_heartbeat.get_signals_for_topic ~topic in
+                let gap = enrich_gap ~topic ~signals ~agents in
+                {
+                  intervention = NeedSpawn gap;
+                  source = "llm";
+                  reason =
+                    if llm_reason <> "" then llm_reason
+                    else Printf.sprintf "llm selected spawn for gap '%s'" gap.topic;
+                  target = gap.topic;
+                  error = "";
+                }
+            | [] ->
+                {
+                  intervention = Balanced;
+                  source = "llm";
+                  reason =
+                    if llm_reason <> "" then llm_reason
+                    else "llm requested spawn but no mature gap was available";
+                  target = "";
+                  error = "";
+                })
+       | "retire" ->
+           let all_stats = Lodge_selection.get_all_stats () in
+           let idle_candidates =
+             all_stats
+             |> List.filter (fun s ->
+                    let idle_hours =
+                      (Time_compat.now () -. s.Lodge_selection.last_selected_at) /. 3600.0
+                    in
+                    idle_hours > config.idle_threshold_hours)
+             |> List.sort (fun a b ->
+                    compare b.Lodge_selection.last_selected_at
+                      a.Lodge_selection.last_selected_at)
+           in
+           (match idle_candidates with
+            | candidate :: _ ->
+                let stats = convert_stats candidate in
+                {
+                  intervention = NeedRetirement stats;
+                  source = "llm";
+                  reason =
+                    if llm_reason <> "" then llm_reason
+                    else Printf.sprintf "llm selected retirement for '%s'" stats.name;
+                  target = stats.name;
+                  error = "";
+                }
+            | [] ->
+                {
+                  intervention = Balanced;
+                  source = "llm";
+                  reason =
+                    if llm_reason <> "" then llm_reason
+                    else "llm requested retirement but no idle candidate was available";
+                  target = "";
+                  error = "";
+                })
+       | _ ->
+           {
+             intervention = Balanced;
+             source = "llm";
+             reason = if llm_reason <> "" then llm_reason else "llm returned no intervention";
+             target = "";
+             error = "";
+           })
 
-  match action with
-  | "spawn_worker" when backlog.todo_count > 0 -> NeedWorker backlog
-  | "spawn_worker" | "spawn_agent" ->
-      (* LLM decided to spawn — find appropriate gap signal *)
-      let mature_gaps = Lodge_heartbeat.check_gap_threshold () in
-      let agents = Lodge_heartbeat.get_agents () in
-      (match mature_gaps with
-       | (topic, _) :: _ ->
-           let signals = Lodge_heartbeat.get_signals_for_topic ~topic in
-           let gap = enrich_gap ~topic ~signals ~agents in
-           NeedSpawn gap
-       | [] -> Balanced)
-  | "retire" ->
-      (* LLM decided to retire — find most idle agent *)
-      let all_stats = Lodge_selection.get_all_stats () in
-      let idle_candidates = all_stats
-        |> List.filter (fun s ->
-            let idle_hours = (Time_compat.now () -. s.Lodge_selection.last_selected_at) /. 3600.0 in
-            idle_hours > config.idle_threshold_hours)
-        |> List.sort (fun a b ->
-            compare b.Lodge_selection.last_selected_at a.Lodge_selection.last_selected_at) in
-      (match idle_candidates with
-       | candidate :: _ -> NeedRetirement (convert_stats candidate)
-       | [] -> Balanced)
-  | _ -> Balanced
-
-(** Detect what intervention is needed *)
-let detect_intervention ~config ~health : intervention =
+(** Detect what intervention is needed with internal decision metadata. *)
+let detect_intervention_detail ~config ~health : decision_snapshot =
   if config.use_llm_decision then
     decide_intervention_with_llm ~config ~health
   else
     detect_intervention_rule_based ~config ~health
+
+(** Detect what intervention is needed *)
+let detect_intervention ~config ~health : intervention =
+  (detect_intervention_detail ~config ~health).intervention
+
+let status_json () : Yojson.Safe.t =
+  let config = load_config () in
+  with_lock (fun () ->
+      let state = get_state () in
+      let tick_in_progress =
+        state.last_tick_started_at > 0.0
+        && state.last_tick_started_at > state.last_tick_completed_at
+      in
+      let alive =
+        config.enabled
+        && (state.last_tick_started_at > 0.0 || state.last_tick_completed_at > 0.0)
+      in
+      let next_tick_due_at =
+        if state.last_tick_completed_at > 0.0 && config.check_interval_sec > 0.0 then
+          `String (iso_of_unix (state.last_tick_completed_at +. config.check_interval_sec))
+        else
+          `Null
+      in
+      let status =
+        if not config.enabled then "disabled"
+        else if tick_in_progress then "running"
+        else if alive then "idle"
+        else "starting"
+      in
+      `Assoc
+        [
+          ("enabled", `Bool config.enabled);
+          ("alive", `Bool alive);
+          ("status", `String status);
+          ("tick_in_progress", `Bool tick_in_progress);
+          ("tick_count", `Int state.tick_count);
+          ("check_interval_sec", `Float config.check_interval_sec);
+          ("last_tick_started_at", json_string_of_float_ts state.last_tick_started_at);
+          ("last_tick_completed_at", json_string_of_float_ts state.last_tick_completed_at);
+          ("next_tick_due_at", next_tick_due_at);
+          ("last_health_check_at", json_string_of_float_ts state.last_health_check);
+          ("last_intervention", `String state.last_intervention);
+          ("last_decision_source", `String state.last_decision_source);
+          ("last_action", `String state.last_action);
+          ("last_target", json_string_of_nonempty state.last_target);
+          ("last_reason", json_string_of_nonempty state.last_reason);
+          ("last_error", json_string_of_nonempty state.last_error);
+          ("circuit_open", `Bool (is_circuit_open ()));
+          ("circuit_open_until", json_string_of_opt_ts state.circuit_open_until);
+          ("can_spawn", `Bool (can_spawn ~config));
+          ("can_retire", `Bool (can_retire ~config));
+          ("last_spawn_attempt_at", json_string_of_float_ts state.last_spawn_attempt);
+          ("last_retirement_attempt_at", json_string_of_float_ts state.last_retirement_attempt);
+          ("spawns_today", `Int state.spawns_today);
+          ("retirements_today", `Int state.retirements_today);
+          ( "health_summary",
+            `Assoc
+              [
+                ("total_agents", `Int state.last_total_agents);
+                ("active_agents", `Int state.last_active_agents);
+                ("idle_agents", `Int state.last_idle_agents);
+                ("todo_count", `Int state.last_todo_count);
+                ("high_priority_todo", `Int state.last_high_priority_todo);
+                ("orphan_count", `Int state.last_orphan_count);
+                ("homeostatic_score", `Float state.last_homeostatic_score);
+                ("needs_workers", `Bool state.last_needs_workers);
+              ] );
+        ])
 
 let backlog_goal_prefix = "[Gardener] Backlog triage"
 
@@ -1062,10 +1339,21 @@ let start_backlog_triage_session ~sw ~clock ~(room_config : Room_utils.config)
 
 (** Main gardener loop iteration *)
 let tick ~sw ~clock ~config ~room_config : unit =
-  if is_circuit_open () then
+  let tick_started_at = mark_tick_start () in
+  if is_circuit_open () then begin
+    record_decision
+      {
+        intervention = Balanced;
+        source = "none";
+        reason = "circuit open; tick skipped";
+        target = "";
+        error = "";
+      };
+    record_tick_complete ();
     Eio.traceln "[Gardener] Circuit open, skipping tick"
-  else begin
+  end else begin
     let health = calculate_health ~config ~room_config:(Some room_config) in
+    record_health_summary ~at:tick_started_at health;
     let backlog = health.task_backlog in
     Eio.traceln
       "[Gardener] Health: agents=%d/%d active=%d idle=%d score=%.2f task_backlog: todo=%d high_pri=%d orphans=%d"
@@ -1073,18 +1361,29 @@ let tick ~sw ~clock ~config ~room_config : unit =
       health.idle_agents health.homeostatic_score backlog.todo_count
       backlog.high_priority_todo backlog.orphan_count;
 
-    match detect_intervention ~config ~health with
+    let decision = detect_intervention_detail ~config ~health in
+    record_decision decision;
+    match decision.intervention with
     | NeedSpawn gap ->
         Eio.traceln "[Gardener] Intervention needed: spawn %s" gap.topic;
-        let decision = decide_spawn ~config ~health ~gap in
-        (match execute_spawn ~decision with
-         | Ok name -> Eio.traceln "[Gardener] Spawned: %s" name
-         | Error e -> Eio.traceln "[Gardener] Spawn failed: %s" e)
+        let spawn_decision = decide_spawn ~config ~health ~gap in
+        (match execute_spawn ~decision:spawn_decision with
+         | Ok name ->
+             record_action "spawned" ~target:name
+               ~reason:(Printf.sprintf "spawned from gap '%s'" gap.topic);
+             Eio.traceln "[Gardener] Spawned: %s" name
+         | Error e ->
+             record_action "none" ~target:gap.topic
+               ~reason:"spawn decision did not execute"
+               ~error:e;
+             Eio.traceln "[Gardener] Spawn failed: %s" e)
     | NeedWorker backlog ->
         Eio.traceln "[Gardener] Task pressure: %d TODO, %d high-pri, %d orphans"
           backlog.todo_count backlog.high_priority_todo backlog.orphan_count;
         (match start_backlog_triage_session ~sw ~clock ~room_config ~backlog with
          | Ok session_id ->
+             record_action "worker_session_started" ~target:session_id
+               ~reason:"started backlog triage session";
              Eio.traceln "[Gardener] Started backlog triage session: %s" session_id;
              Sse.broadcast
                (`Assoc
@@ -1096,6 +1395,9 @@ let tick ~sw ~clock ~config ~room_config : unit =
                    ("orphan_count", `Int backlog.orphan_count);
                  ])
          | Error err ->
+             record_action "worker_request_posted"
+               ~reason:"backlog triage session failed; posted worker request"
+               ~error:err;
              Eio.traceln "[Gardener] Backlog triage start failed: %s" err;
              let store = Board.global () in
              let msg =
@@ -1122,11 +1424,21 @@ let tick ~sw ~clock ~config ~room_config : unit =
                  ]))
     | NeedRetirement stats ->
         Eio.traceln "[Gardener] Intervention needed: retire %s" stats.name;
-        let decision = decide_retire ~config ~health ~agent_stats:stats in
-        (match execute_retire ~decision with
-         | Ok name -> Eio.traceln "[Gardener] Retirement initiated: %s" name
-         | Error e -> Eio.traceln "[Gardener] Retirement failed: %s" e)
-    | Balanced -> Eio.traceln "[Gardener] Ecosystem balanced"
+        let retirement_decision = decide_retire ~config ~health ~agent_stats:stats in
+        (match execute_retire ~decision:retirement_decision with
+         | Ok name ->
+             record_action "retirement_initiated" ~target:name
+               ~reason:"retirement grace period initiated";
+             Eio.traceln "[Gardener] Retirement initiated: %s" name
+         | Error e ->
+             record_action "none" ~target:stats.name
+               ~reason:"retirement decision did not execute"
+               ~error:e;
+             Eio.traceln "[Gardener] Retirement failed: %s" e)
+    | Balanced ->
+        record_action "none" ~reason:decision.reason;
+        Eio.traceln "[Gardener] Ecosystem balanced";
+    record_tick_complete ()
   end
 
 (** Run the gardener background loop (no switch needed — loop is self-contained) *)

--- a/lib/gardener.mli
+++ b/lib/gardener.mli
@@ -66,6 +66,9 @@ val calculate_health : config:gardener_config -> room_config:Room_utils.config o
 (** Convenience function for MCP tools — uses default config *)
 val get_health : unit -> ecosystem_health
 
+(** Truth-only runtime status for the active gardener loop. *)
+val status_json : unit -> Yojson.Safe.t
+
 (** {1 Decision Making} *)
 
 (** Decide whether to spawn a new agent for a gap.

--- a/lib/gardener_types.ml
+++ b/lib/gardener_types.ml
@@ -271,23 +271,57 @@ let retirement_decision_to_yojson = function
 (** Persistent state for the Gardener Agent *)
 type gardener_state = {
   mutable last_health_check: float;
+  mutable last_tick_started_at: float;
+  mutable last_tick_completed_at: float;
   mutable last_spawn_attempt: float;
   mutable last_retirement_attempt: float;
   mutable consecutive_failures: int;
   mutable circuit_open_until: float option;
   mutable spawns_today: int;
   mutable retirements_today: int;
+  mutable last_intervention: string;
+  mutable last_decision_source: string;
+  mutable last_action: string;
+  mutable last_target: string;
+  mutable last_reason: string;
+  mutable last_error: string;
+  mutable tick_count: int;
+  mutable last_total_agents: int;
+  mutable last_active_agents: int;
+  mutable last_idle_agents: int;
+  mutable last_todo_count: int;
+  mutable last_high_priority_todo: int;
+  mutable last_orphan_count: int;
+  mutable last_homeostatic_score: float;
+  mutable last_needs_workers: bool;
   mutable day_start: float;  (** Start of current "day" for budget tracking *)
 } [@@deriving show]
 
 let make_gardener_state () = {
   last_health_check = 0.0;
+  last_tick_started_at = 0.0;
+  last_tick_completed_at = 0.0;
   last_spawn_attempt = 0.0;
   last_retirement_attempt = 0.0;
   consecutive_failures = 0;
   circuit_open_until = None;
   spawns_today = 0;
   retirements_today = 0;
+  last_intervention = "none";
+  last_decision_source = "none";
+  last_action = "none";
+  last_target = "";
+  last_reason = "";
+  last_error = "";
+  tick_count = 0;
+  last_total_agents = 0;
+  last_active_agents = 0;
+  last_idle_agents = 0;
+  last_todo_count = 0;
+  last_high_priority_todo = 0;
+  last_orphan_count = 0;
+  last_homeostatic_score = 0.0;
+  last_needs_workers = false;
   day_start = Time_compat.now ();
 }
 

--- a/lib/gardener_types.mli
+++ b/lib/gardener_types.mli
@@ -201,12 +201,29 @@ val show_retirement_decision : retirement_decision -> string
 *)
 type gardener_state = {
   mutable last_health_check: float;
+  mutable last_tick_started_at: float;
+  mutable last_tick_completed_at: float;
   mutable last_spawn_attempt: float;
   mutable last_retirement_attempt: float;
   mutable consecutive_failures: int;
   mutable circuit_open_until: float option;
   mutable spawns_today: int;
   mutable retirements_today: int;
+  mutable last_intervention: string;
+  mutable last_decision_source: string;
+  mutable last_action: string;
+  mutable last_target: string;
+  mutable last_reason: string;
+  mutable last_error: string;
+  mutable tick_count: int;
+  mutable last_total_agents: int;
+  mutable last_active_agents: int;
+  mutable last_idle_agents: int;
+  mutable last_todo_count: int;
+  mutable last_high_priority_todo: int;
+  mutable last_orphan_count: int;
+  mutable last_homeostatic_score: float;
+  mutable last_needs_workers: bool;
   mutable day_start: float;  (** Start of current "day" for budget tracking *)
 }
 

--- a/lib/mode.ml
+++ b/lib/mode.ml
@@ -315,6 +315,7 @@ let tool_category tool_name =
   (* ── Ecosystem: gardener, keeper, perpetual, MDAL, autoresearch, handover, library ── *)
   (* Gardener *)
   | "masc_gardener_health" | "masc_gardener_config"
+  | "masc_gardener_status"
   | "masc_gardener_propose_spawn" | "masc_gardener_execute_spawn"
   | "masc_gardener_retire_agent" | "masc_gardener_execute_retire"
   | "masc_gardener_reset_circuit"

--- a/lib/tool_gardener.ml
+++ b/lib/tool_gardener.ml
@@ -39,6 +39,8 @@ let handle_health _ctx _args : result =
       ("status", `String "ok");
       ("provenance", `String "derived");
       ("authoritative", `Bool false);
+      ("health_kind", `String "derived_snapshot");
+      ("informational_only_fields", `List [`String "needs_spawn"; `String "needs_retirement"]);
       ("health", ecosystem_health_to_yojson health);
       ("config_summary", `Assoc [
         ("enabled", `Bool config.enabled);
@@ -58,6 +60,21 @@ let handle_health _ctx _args : result =
     (true, Yojson.Safe.to_string json)
   with exn ->
     (false, Printf.sprintf "Error getting health: %s" (Printexc.to_string exn))
+
+(** Handle masc_gardener_status tool call.
+
+    Returns truth-only runtime state for the current gardener loop. *)
+let handle_status _ctx _args : result =
+  try
+    let json = `Assoc [
+      ("status", `String "ok");
+      ("provenance", `String "truth");
+      ("authoritative", `Bool true);
+      ("runtime", Gardener.status_json ());
+    ] in
+    (true, Yojson.Safe.to_string json)
+  with exn ->
+    (false, Printf.sprintf "Error getting gardener status: %s" (Printexc.to_string exn))
 
 (** Handle masc_gardener_propose_spawn tool call.
 
@@ -262,6 +279,7 @@ let handle_reset_circuit _ctx _args : result =
 let dispatch ctx tool_name args : result =
   match tool_name with
   | "masc_gardener_health" -> handle_health ctx args
+  | "masc_gardener_status" -> handle_status ctx args
   | "masc_gardener_propose_spawn" -> handle_propose_spawn ctx args
   | "masc_gardener_retire_agent" -> handle_retire_agent ctx args
   | "masc_gardener_config" -> handle_config ctx args

--- a/lib/tools.ml
+++ b/lib/tools.ml
@@ -3994,6 +3994,15 @@ Example: masc_tempo_reset() → {tempo: 300, message: 'Reset to default'}";
   };
 
   {
+    name = "masc_gardener_status";
+    description = "Get truth-only gardener loop runtime status. Returns liveness, last tick timestamps, last decision source, last action, last error, cooldown/circuit state, and the last observed health summary.";
+    input_schema = `Assoc [
+      ("type", `String "object");
+      ("properties", `Assoc []);
+    ];
+  };
+
+  {
     name = "masc_gardener_propose_spawn";
     description = "Evaluate whether a new agent should be spawned for a given topic. Uses LLM decision (if enabled) or rule-based logic. Returns approval/deferral/rejection with reasons. Does NOT actually create the agent — use masc_gardener_execute_spawn for that.";
     input_schema = `Assoc [

--- a/test/test_auth_coverage.ml
+++ b/test/test_auth_coverage.ml
@@ -320,6 +320,16 @@ let test_permission_for_tool_keeper_eval_replay () =
   | Some Types.CanReadState -> ()
   | _ -> fail "expected CanReadState"
 
+let test_permission_for_tool_gardener_status () =
+  match Auth.permission_for_tool "masc_gardener_status" with
+  | Some Types.CanReadState -> ()
+  | _ -> fail "expected CanReadState"
+
+let test_permission_for_tool_gardener_execute_spawn () =
+  match Auth.permission_for_tool "masc_gardener_execute_spawn" with
+  | Some Types.CanAdmin -> ()
+  | _ -> fail "expected CanAdmin"
+
 let test_permission_for_tool_unknown () =
   match Auth.permission_for_tool "unknown_tool_xyz" with
   | None -> ()
@@ -411,6 +421,10 @@ let () =
         test_permission_for_tool_keeper_action_explain;
       test_case "keeper_eval_replay" `Quick
         test_permission_for_tool_keeper_eval_replay;
+      test_case "gardener_status" `Quick
+        test_permission_for_tool_gardener_status;
+      test_case "gardener_execute_spawn" `Quick
+        test_permission_for_tool_gardener_execute_spawn;
       test_case "unknown" `Quick test_permission_for_tool_unknown;
       test_case "empty" `Quick test_permission_for_tool_empty;
     ];

--- a/test/test_mode_coverage.ml
+++ b/test/test_mode_coverage.ml
@@ -255,6 +255,7 @@ let test_tool_category_code () =
   check bool "code_read" true (Mode.tool_category "masc_code_read" = Mode.Code)
 
 let test_tool_category_ecosystem_voice () =
+  check bool "gardener_status" true (Mode.tool_category "masc_gardener_status" = Mode.Ecosystem);
   check bool "voice_speak" true (Mode.tool_category "masc_voice_speak" = Mode.Ecosystem);
   check bool "voice_sessions" true (Mode.tool_category "masc_voice_sessions" = Mode.Ecosystem);
   check bool "voice_conference_start" true

--- a/test/test_tool_gardener_coverage.ml
+++ b/test/test_tool_gardener_coverage.ml
@@ -36,6 +36,7 @@ let test_dispatch_unknown_tool () =
 let test_dispatch_safe_tools () =
   let safe_tools = [
     "masc_gardener_config";
+    "masc_gardener_status";
     "masc_gardener_reset_circuit";
   ] in
   List.iter (fun name ->
@@ -50,6 +51,7 @@ let test_dispatch_safe_tools () =
 let test_dispatch_recognizes_validatable_tools () =
   let tools_with_validation = [
     "masc_gardener_config";
+    "masc_gardener_status";
     "masc_gardener_propose_spawn";
     "masc_gardener_retire_agent";
     "masc_gardener_execute_spawn";
@@ -80,6 +82,23 @@ let test_config_returns_json () =
   Alcotest.(check bool) "can_spawn is bool" true (can_spawn || not can_spawn);
   let can_retire = json |> Yojson.Safe.Util.member "can_retire" |> Yojson.Safe.Util.to_bool in
   Alcotest.(check bool) "can_retire is bool" true (can_retire || not can_retire)
+
+let test_status_returns_truth_runtime_json () =
+  let (ok, msg) = Tool_gardener.dispatch () "masc_gardener_status" (`Assoc []) in
+  Alcotest.(check bool) "status ok" true ok;
+  let json = Yojson.Safe.from_string msg in
+  let provenance = json |> Yojson.Safe.Util.member "provenance" |> Yojson.Safe.Util.to_string in
+  Alcotest.(check string) "status provenance truth" "truth" provenance;
+  let authoritative = json |> Yojson.Safe.Util.member "authoritative" |> Yojson.Safe.Util.to_bool in
+  Alcotest.(check bool) "status authoritative" true authoritative;
+  let runtime = json |> Yojson.Safe.Util.member "runtime" in
+  Alcotest.(check bool) "runtime present" true (runtime <> `Null);
+  let tick_count = runtime |> Yojson.Safe.Util.member "tick_count" |> Yojson.Safe.Util.to_int in
+  Alcotest.(check bool) "tick_count nonnegative" true (tick_count >= 0);
+  let alive = runtime |> Yojson.Safe.Util.member "alive" |> Yojson.Safe.Util.to_bool in
+  Alcotest.(check bool) "alive is bool" true (alive || not alive);
+  let health_summary = runtime |> Yojson.Safe.Util.member "health_summary" in
+  Alcotest.(check bool) "health_summary present" true (health_summary <> `Null)
 
 let test_spawn_decision_provenance_uses_decision_path () =
   let approved =
@@ -187,6 +206,7 @@ let () =
     ]);
     ("config", [
       Alcotest.test_case "returns json" `Quick test_config_returns_json;
+      Alcotest.test_case "status returns runtime json" `Quick test_status_returns_truth_runtime_json;
       Alcotest.test_case "spawn provenance path" `Quick test_spawn_decision_provenance_uses_decision_path;
       Alcotest.test_case "retirement provenance path" `Quick test_retirement_decision_provenance_always_fallback;
     ]);


### PR DESCRIPTION
## Summary
- add truth-only gardener runtime status with liveness, last tick, last decision source, last action, and last error
- expose gardener status in MCP (`masc_gardener_status`), `/health`, and dashboard shell status
- add a lightweight dashboard monitor so gardener state is visible without reading logs

## Motivation
- gardener loop can be enabled and running while operators still cannot tell if it is alive or what it last decided
- existing `masc_gardener_health` is a derived ecosystem snapshot, not a truthful loop monitor

## Verification
- dune build --root ./.worktrees/feat-gardener-status ./test/test_tool_gardener_coverage.exe ./test/test_auth_coverage.exe ./test/test_mode_coverage.exe
- dune exec --root ./.worktrees/feat-gardener-status ./test/test_tool_gardener_coverage.exe
- dune exec --root ./.worktrees/feat-gardener-status ./test/test_auth_coverage.exe
- ./_build/default/test/test_mode_coverage.exe test tool_category 9,14 --color=never
- cd ./.worktrees/feat-gardener-status/dashboard && npm ci
- cd ./.worktrees/feat-gardener-status/dashboard && npx tsc --noEmit --pretty false
- git diff --check
