### PR TITLE
feat(keeper): restore sangsu explicit voice runtime

### DIFF
--- a/lib/keeper_contract.ml
+++ b/lib/keeper_contract.ml
@@ -4,6 +4,7 @@
 type policy_mode =
   | Heuristic
   | Learned_offline_v1
+  | Explicit_event_v1
 
 type policy_action_budget =
   | Conversation
@@ -25,20 +26,23 @@ type autonomy_level = Keeper_autonomy.autonomy_level
 
 let policy_mode_of_string = function
   | "learned_offline_v1" -> Learned_offline_v1
+  | "explicit_event_v1" -> Explicit_event_v1
   | _ -> Heuristic
 
 let parse_policy_mode = function
   | "heuristic" -> Some Heuristic
   | "learned_offline_v1" -> Some Learned_offline_v1
+  | "explicit_event_v1" -> Some Explicit_event_v1
   | _ -> None
 
 let policy_mode_to_string = function
   | Heuristic -> "heuristic"
   | Learned_offline_v1 -> "learned_offline_v1"
+  | Explicit_event_v1 -> "explicit_event_v1"
 
 let policy_mode_is_learned = function
   | Learned_offline_v1 -> true
-  | Heuristic -> false
+  | Heuristic | Explicit_event_v1 -> false
 
 let policy_action_budget_of_string = function
   | "board" -> Board

--- a/lib/keeper_schema.ml
+++ b/lib/keeper_schema.ml
@@ -142,6 +142,11 @@ let resident_schemas : tool_schema list = [
           ("type", `String "string");
           ("description", `String "Current persisted model label. Prefer 'default' for adapter-managed selection; explicit-only keepers may still pin a concrete provider:model label.");
         ]);
+        ("policy_mode", `Assoc [
+          ("type", `String "string");
+          ("enum", `List [`String "heuristic"; `String "learned_offline_v1"; `String "explicit_event_v1"]);
+          ("description", `String "Behavior selection mode. explicit_event_v1 disables heuristic routing and uses explicit lifecycle/timer events only.");
+        ]);
         ("scope_kind", `Assoc [
           ("type", `String "string");
           ("enum", `List [`String "local"; `String "global"]);
@@ -229,6 +234,19 @@ let resident_schemas : tool_schema list = [
         ("context_budget", `Assoc [
           ("type", `String "number");
           ("description", `String "How much compressed context to transfer to successor (0.0-1.0, default: 0.6).");
+        ]);
+        ("voice_enabled", `Assoc [
+          ("type", `String "boolean");
+          ("description", `String "If true, keeper lifecycle/check-in events may trigger voice output.");
+        ]);
+        ("voice_channel", `Assoc [
+          ("type", `String "string");
+          ("enum", `List [`String "voice_text"; `String "voice_only"; `String "text_only"]);
+          ("description", `String "How keeper event output is surfaced: voice+text, voice only, or text only.");
+        ]);
+        ("voice_agent_id", `Assoc [
+          ("type", `String "string");
+          ("description", `String "Voice bridge agent id to use when emitting keeper voice events.");
         ]);
       ]);
       ("required", `List [`String "name"]);
@@ -454,8 +472,8 @@ let resident_schemas : tool_schema list = [
         ]);
         ("policy_mode", `Assoc [
           ("type", `String "string");
-          ("enum", `List [`String "heuristic"; `String "learned_offline_v1"]);
-          ("description", `String "Behavior selection mode. learned_offline_v1 disables keeper heuristics and uses the reward model scorer.");
+          ("enum", `List [`String "heuristic"; `String "learned_offline_v1"; `String "explicit_event_v1"]);
+          ("description", `String "Behavior selection mode. learned_offline_v1 disables keeper heuristics and uses the reward model scorer. explicit_event_v1 uses explicit lifecycle/timer events only.");
         ]);
         ("action_budget", `Assoc [
           ("type", `String "string");

--- a/lib/keeper_turn.ml
+++ b/lib/keeper_turn.ml
@@ -27,9 +27,13 @@ let handle_keeper_up ctx args : tool_result =
     let models_in = get_string_list args "models" in
     let allowed_models_in = get_string_list args "allowed_models" in
     let active_model_opt = get_string_opt args "active_model" in
+    let policy_mode_opt = get_string_opt args "policy_mode" in
     let room_scope_opt = get_string_opt args "room_scope" in
     let scope_kind_opt = get_string_opt args "scope_kind" in
     let trigger_mode_opt = get_string_opt args "trigger_mode" in
+    let voice_enabled_opt = get_bool_opt args "voice_enabled" in
+    let voice_channel_opt = get_string_opt args "voice_channel" in
+    let voice_agent_id_opt = get_string_opt args "voice_agent_id" in
     let mention_targets_in = get_string_list args "mention_targets" in
     let verify_opt = get_bool_opt args "verify" in
     let presence_keepalive_opt = get_bool_opt args "presence_keepalive" in
@@ -118,8 +122,27 @@ let handle_keeper_up ctx args : tool_result =
         |> Option.value
              ~default:
                (match requested_models with
-                | model :: _ -> model
+               | model :: _ -> model
                 | [] -> "")
+      in
+      let policy_mode =
+        policy_mode_opt
+        |> Option.map canonical_policy_mode
+        |> Option.value
+             ~default:
+               (if default_voice_enabled_for name then "explicit_event_v1"
+                else Keeper_contract.policy_mode_to_string Keeper_contract.Heuristic)
+      in
+      let voice_enabled =
+        Option.value ~default:(default_voice_enabled_for name) voice_enabled_opt
+      in
+      let voice_channel =
+        voice_channel_opt
+        |> Option.map canonical_voice_channel
+        |> Option.value ~default:(default_voice_channel_for name)
+      in
+      let voice_agent_id =
+        Option.value ~default:(default_voice_agent_id_for name) voice_agent_id_opt
       in
       let mention_targets =
         let raw =
@@ -281,13 +304,16 @@ let handle_keeper_up ctx args : tool_result =
                models = requested_models;
                allowed_models;
                active_model;
-               policy_mode = Keeper_contract.policy_mode_to_string Keeper_contract.Heuristic;
+               policy_mode;
                policy_action_budget =
                  Keeper_contract.policy_action_budget_to_string Keeper_contract.Conversation;
                policy_reward_model_path = "";
                scope_kind;
                room_scope;
                trigger_mode;
+               voice_enabled;
+               voice_channel;
+               voice_agent_id;
                mention_targets;
                joined_room_ids = [];
                last_seen_seq_by_room = [];
@@ -363,6 +389,10 @@ let handle_keeper_up ctx args : tool_result =
                  ("desires", `String meta.desires);
                  ("instructions", `String meta.instructions);
                  ("models", `List (List.map (fun s -> `String s) meta.models));
+                 ("policy_mode", `String meta.policy_mode);
+                 ("voice_enabled", `Bool meta.voice_enabled);
+                 ("voice_channel", `String meta.voice_channel);
+                 ("voice_agent_id", `String meta.voice_agent_id);
                  ("presence_keepalive", `Bool meta.presence_keepalive);
                  ("presence_keepalive_sec", `Int meta.presence_keepalive_sec);
                  ("proactive_enabled", `Bool meta.proactive_enabled);
@@ -509,12 +539,23 @@ let handle_keeper_up ctx args : tool_result =
         models;
         allowed_models;
         active_model;
-        policy_mode = canonical_policy_mode old.policy_mode;
+        policy_mode =
+          (policy_mode_opt
+          |> Option.map canonical_policy_mode
+          |> Option.value ~default:(canonical_policy_mode old.policy_mode));
         policy_action_budget = canonical_policy_action_budget old.policy_action_budget;
         policy_reward_model_path = old.policy_reward_model_path;
         scope_kind;
         room_scope;
         trigger_mode;
+        voice_enabled =
+          Option.value ~default:old.voice_enabled voice_enabled_opt;
+        voice_channel =
+          (voice_channel_opt
+          |> Option.map canonical_voice_channel
+          |> Option.value ~default:old.voice_channel);
+        voice_agent_id =
+          Option.value ~default:old.voice_agent_id voice_agent_id_opt;
         mention_targets;
         persona_profile_path =
           if String.trim old.persona_profile_path <> "" then old.persona_profile_path
@@ -723,6 +764,10 @@ let handle_keeper_msg ctx args : tool_result =
             in
             raw |> dedupe_keep_order
           in
+          let policy_mode =
+            if default_voice_enabled_for name then "explicit_event_v1"
+            else Keeper_contract.policy_mode_to_string Keeper_contract.Heuristic
+          in
           let meta = {
             name;
             agent_name = keeper_agent_name name;
@@ -741,13 +786,16 @@ let handle_keeper_msg ctx args : tool_result =
             models = inline_models;
             allowed_models;
             active_model;
-            policy_mode = Keeper_contract.policy_mode_to_string Keeper_contract.Heuristic;
+            policy_mode;
             policy_action_budget =
               Keeper_contract.policy_action_budget_to_string Keeper_contract.Conversation;
             policy_reward_model_path = "";
             scope_kind;
             room_scope;
             trigger_mode;
+            voice_enabled = default_voice_enabled_for name;
+            voice_channel = default_voice_channel_for name;
+            voice_agent_id = default_voice_agent_id_for name;
             mention_targets;
             joined_room_ids = [];
             last_seen_seq_by_room = [];

--- a/lib/keeper_types.ml
+++ b/lib/keeper_types.ml
@@ -154,7 +154,22 @@ let canonical_trigger_mode = function
 
 let canonical_policy_mode = function
   | "learned_offline_v1" -> "learned_offline_v1"
+  | "explicit_event_v1" -> "explicit_event_v1"
   | _ -> "heuristic"
+
+let canonical_voice_channel = function
+  | "voice_only" -> "voice_only"
+  | "text_only" -> "text_only"
+  | _ -> "voice_text"
+
+let default_voice_enabled_for name =
+  String.equal (String.lowercase_ascii (String.trim name)) "sangsu"
+
+let default_voice_channel_for name =
+  if default_voice_enabled_for name then "voice_text" else "text_only"
+
+let default_voice_agent_id_for name =
+  if default_voice_enabled_for name then name else ""
 
 let canonical_policy_action_budget = function
   | "board" -> "board"
@@ -384,6 +399,9 @@ type keeper_meta = {
   handoff_threshold: float;
   handoff_cooldown_sec: int;
   context_budget: float;
+  voice_enabled: bool;
+  voice_channel: string;
+  voice_agent_id: string;
   last_handoff_ts: float;
   created_at: string;
   updated_at: string;
@@ -468,6 +486,9 @@ let meta_to_json (m : keeper_meta) : Yojson.Safe.t =
       ("handoff_threshold", `Float m.handoff_threshold);
       ("handoff_cooldown_sec", `Int m.handoff_cooldown_sec);
       ("context_budget", `Float m.context_budget);
+      ("voice_enabled", `Bool m.voice_enabled);
+      ("voice_channel", `String m.voice_channel);
+      ("voice_agent_id", `String m.voice_agent_id);
       ("last_handoff_ts", `Float m.last_handoff_ts);
       ("created_at", `String m.created_at);
       ("updated_at", `String m.updated_at);
@@ -554,6 +575,16 @@ let meta_of_json (json : Yojson.Safe.t) : (keeper_meta, string) result =
     in
     let policy_reward_model_path =
       Safe_ops.json_string ~default:"" "policy_reward_model_path" json
+    in
+    let voice_enabled =
+      Safe_ops.json_bool ~default:(default_voice_enabled_for name) "voice_enabled" json
+    in
+    let voice_channel =
+      Safe_ops.json_string ~default:(default_voice_channel_for name) "voice_channel" json
+      |> canonical_voice_channel
+    in
+    let voice_agent_id =
+      Safe_ops.json_string ~default:(default_voice_agent_id_for name) "voice_agent_id" json
     in
     let scope_kind =
       Safe_ops.json_string ~default:"local" "scope_kind" json |> canonical_scope_kind
@@ -739,6 +770,9 @@ let meta_of_json (json : Yojson.Safe.t) : (keeper_meta, string) result =
           handoff_threshold;
           handoff_cooldown_sec;
           context_budget;
+          voice_enabled;
+          voice_channel;
+          voice_agent_id;
           last_handoff_ts;
           created_at = if created_at = "" then now_iso () else created_at;
           updated_at = if updated_at = "" then now_iso () else updated_at;
@@ -777,6 +811,9 @@ type resident_keeper_spec = {
   name : string;
   persistent_name : string;
   desired : bool;
+  voice_enabled : bool;
+  voice_channel : string;
+  voice_agent_id : string;
   seed_meta : Yojson.Safe.t;
   created_at : string;
   updated_at : string;
@@ -796,6 +833,9 @@ let resident_keeper_to_json (spec : resident_keeper_spec) =
       ("name", `String spec.name);
       ("persistent_name", `String spec.persistent_name);
       ("desired", `Bool spec.desired);
+      ("voice_enabled", `Bool spec.voice_enabled);
+      ("voice_channel", `String spec.voice_channel);
+      ("voice_agent_id", `String spec.voice_agent_id);
       ("seed_meta", spec.seed_meta);
       ("created_at", `String spec.created_at);
       ("updated_at", `String spec.updated_at);
@@ -816,6 +856,21 @@ let resident_keeper_of_json (json : Yojson.Safe.t) :
       | `Bool value -> value
       | _ -> true
     in
+    let voice_enabled =
+      match json |> member "voice_enabled" with
+      | `Bool value -> value
+      | _ -> default_voice_enabled_for name
+    in
+    let voice_channel =
+      match json |> member "voice_channel" |> to_string_option with
+      | Some value -> canonical_voice_channel value
+      | None -> default_voice_channel_for name
+    in
+    let voice_agent_id =
+      match json |> member "voice_agent_id" |> to_string_option with
+      | Some value -> value
+      | None -> default_voice_agent_id_for name
+    in
     let seed_meta =
       match json |> member "seed_meta" with
       | `Assoc _ as value -> value
@@ -831,7 +886,18 @@ let resident_keeper_of_json (json : Yojson.Safe.t) :
       | Some value -> value
       | None -> created_at
     in
-    Ok { name; persistent_name; desired; seed_meta; created_at; updated_at }
+    Ok
+      {
+        name;
+        persistent_name;
+        desired;
+        voice_enabled;
+        voice_channel;
+        voice_agent_id;
+        seed_meta;
+        created_at;
+        updated_at;
+      }
   with Yojson.Safe.Util.Type_error (msg, _) | Failure msg ->
     Error ("resident keeper parse error: " ^ msg)
 
@@ -906,6 +972,9 @@ let register_resident_keeper_from_meta config (meta : keeper_meta) :
       name = meta.name;
       persistent_name = meta.name;
       desired = true;
+      voice_enabled = meta.voice_enabled;
+      voice_channel = meta.voice_channel;
+      voice_agent_id = meta.voice_agent_id;
       seed_meta = meta_to_json meta;
       created_at;
       updated_at = now_iso ();

--- a/lib/provider_adapter.ml
+++ b/lib/provider_adapter.ml
@@ -29,6 +29,11 @@ type output_contract =
   | Human_stdout
   | Json_stdout
 
+type voice_transport =
+  | Voice_openai_compat
+  | Voice_elevenlabs_direct
+  | Voice_mcp
+
 type adapter = {
   canonical_name : string;
   runtime_kind : runtime_kind;
@@ -43,6 +48,14 @@ type cli_adapter = {
   prompt_transport : prompt_transport;
   output_contract : output_contract;
   default_allowed_mcp_servers : string list;
+}
+
+type voice_adapter = {
+  canonical_name : string;
+  transport : voice_transport;
+  provider_family : provider_family;
+  auth_mode : auth_mode;
+  aliases : string list;
 }
 
 type gemini_direct_auth =
@@ -84,6 +97,11 @@ let string_of_prompt_transport = function
 let string_of_output_contract = function
   | Human_stdout -> "human_stdout"
   | Json_stdout -> "json_stdout"
+
+let string_of_voice_transport = function
+  | Voice_openai_compat -> "openai_compat"
+  | Voice_elevenlabs_direct -> "elevenlabs_direct"
+  | Voice_mcp -> "voice_mcp"
 
 let normalize_label label = String.trim label |> String.lowercase_ascii
 
@@ -184,14 +202,47 @@ let cli_adapters =
     };
   ]
 
-let resolve_adapter adapters label =
+let voice_openai_compat_adapter =
+  {
+    canonical_name = "voice-openai-compat";
+    transport = Voice_openai_compat;
+    provider_family = OpenAI_family;
+    auth_mode = No_auth;
+    aliases =
+      [ "voice-openai-compat"; "openai_compat"; "openai"; "railway-elevenlabs-proxy" ];
+  }
+
+let voice_elevenlabs_direct_adapter =
+  {
+    canonical_name = "elevenlabs-direct";
+    transport = Voice_elevenlabs_direct;
+    provider_family = Custom_family "elevenlabs";
+    auth_mode = Api_key "ELEVENLABS_API_KEY";
+    aliases = [ "elevenlabs-direct"; "elevenlabs"; "tts-elevenlabs" ];
+  }
+
+let voice_mcp_adapter =
+  {
+    canonical_name = "voice-mcp";
+    transport = Voice_mcp;
+    provider_family = Custom_family "voice_mcp";
+    auth_mode = No_auth;
+    aliases = [ "voice-mcp"; "voice_mcp"; "mcp"; "local-voice-mcp" ];
+  }
+
+let voice_adapters =
+  [
+    voice_openai_compat_adapter;
+    voice_elevenlabs_direct_adapter;
+    voice_mcp_adapter;
+  ]
+
+let resolve_direct_adapter label =
   let normalized = normalize_label label in
   List.find_opt
-    (fun adapter ->
+    (fun (adapter : adapter) ->
       List.exists (fun alias -> normalize_label alias = normalized) adapter.aliases)
-    adapters
-
-let resolve_direct_adapter label = resolve_adapter direct_adapters label
+    direct_adapters
 let resolve_cli_adapter label =
   let normalized = normalize_label label in
   List.find_opt
@@ -203,6 +254,37 @@ let resolve_cli_adapter label =
 
 let resolve_cli_canonical_name label =
   Option.map (fun adapter -> adapter.meta.canonical_name) (resolve_cli_adapter label)
+
+let resolve_voice_adapter label =
+  let normalized = normalize_label label in
+  List.find_opt
+    (fun (adapter : voice_adapter) ->
+      List.exists (fun alias -> normalize_label alias = normalized) adapter.aliases)
+    voice_adapters
+
+let voice_adapter_for_endpoint_kind = function
+  | Voice_config.Openai_compat -> voice_openai_compat_adapter
+  | Voice_config.Elevenlabs_direct -> voice_elevenlabs_direct_adapter
+  | Voice_config.Voice_mcp -> voice_mcp_adapter
+
+let voice_adapter_for_endpoint (endpoint : Voice_config.endpoint) =
+  match resolve_voice_adapter endpoint.id with
+  | Some adapter -> adapter
+  | None -> voice_adapter_for_endpoint_kind endpoint.kind
+
+let voice_auth_env_name ?endpoint_api_key_env (adapter : voice_adapter) =
+  match endpoint_api_key_env with
+  | Some raw ->
+      let trimmed = String.trim raw in
+      if trimmed <> "" then Some trimmed
+      else (
+        match adapter.auth_mode with
+        | Api_key env_name -> Some env_name
+        | _ -> None)
+  | None -> (
+      match adapter.auth_mode with
+      | Api_key env_name -> Some env_name
+      | _ -> None)
 
 let default_cli_agent_name () = "claude"
 

--- a/lib/tool_voice.ml
+++ b/lib/tool_voice.ml
@@ -26,7 +26,7 @@ let schemas : tool_schema list =
     {
       name = "masc_voice_speak";
       description =
-        "Send text to the voice bridge for an agent. Uses the configured voice and may fall back to text_fallback when voice is unavailable.";
+        "Send text to the voice bridge for an agent. Returns an error unless a reachable voice backend actually accepts the request.";
       input_schema =
         `Assoc
           [
@@ -147,19 +147,6 @@ let require_net_or_error (ctx : 'a context) =
   | Some net -> Ok net
   | None -> Error "voice bridge requires net (server_state.net is None)"
 
-let message_preview message =
-  String.sub message 0 (min 50 (String.length message))
-
-let text_fallback_json ~agent_id ~message =
-  let voice = Voice_bridge.get_voice_for_agent agent_id in
-  `Assoc
-    [
-      ("status", `String "text_fallback");
-      string_assoc "agent_id" agent_id;
-      string_assoc "voice" voice;
-      string_assoc "message_preview" (message_preview message);
-    ]
-
 let handle_voice_speak (ctx : 'a context) args : result =
   let agent_id = get_string args "agent_id" "" |> String.trim in
   let message = get_string args "message" "" in
@@ -173,12 +160,12 @@ let handle_voice_speak (ctx : 'a context) args : result =
   if agent_id = "" || String.trim message = "" then
     (false, "Error: agent_id and message are required")
   else
-    match ctx.net with
-    | Some net ->
+    match require_net_or_error ctx with
+    | Error message -> (false, message)
+    | Ok net ->
         json_string_of_result
           (Voice_bridge.agent_speak ~sw:ctx.sw ~clock:ctx.clock ~net ~agent_id
              ~message ?provider ~priority ())
-    | None -> (true, Yojson.Safe.to_string (text_fallback_json ~agent_id ~message))
 
 let handle_voice_session_start (ctx : 'a context) args : result =
   let agent_id = get_string args "agent_id" "" |> String.trim in
@@ -203,33 +190,19 @@ let handle_voice_session_end (ctx : 'a context) args : result =
   if agent_id = "" then
     (false, "Error: agent_id is required")
   else
-    match ctx.net with
-    | Some net ->
+    match require_net_or_error ctx with
+    | Error message -> (false, message)
+    | Ok net ->
         json_string_of_result
           (Voice_bridge.end_voice_session ~sw:ctx.sw ~clock:ctx.clock ~net
              ~agent_id)
-    | None ->
-        ( true,
-          Yojson.Safe.to_string
-            (`Assoc
-              [
-                ("status", `String "skipped");
-                ("reason", `String "voice bridge unavailable");
-              ]) )
 
 let handle_voice_sessions (ctx : 'a context) _args : result =
-  match ctx.net with
-  | Some net ->
+  match require_net_or_error ctx with
+  | Error message -> (false, message)
+  | Ok net ->
       json_string_of_result
         (Voice_bridge.list_voice_sessions ~sw:ctx.sw ~clock:ctx.clock ~net)
-  | None ->
-      ( true,
-        Yojson.Safe.to_string
-          (`Assoc
-            [
-              ("sessions", `List []);
-              ("status", `String "voice_server_unavailable");
-            ]) )
 
 let handle_voice_agent _ctx args : result =
   let agent_id = get_string args "agent_id" "" |> String.trim in
@@ -239,14 +212,11 @@ let handle_voice_agent _ctx args : result =
     json_string_of_result (Voice_bridge.get_agent_voice ~agent_id)
 
 let handle_voice_transcript (ctx : 'a context) _args : result =
-  match ctx.net with
-  | Some net ->
+  match require_net_or_error ctx with
+  | Error message -> (false, message)
+  | Ok net ->
       json_string_of_result
         (Voice_bridge.get_transcript ~sw:ctx.sw ~clock:ctx.clock ~net ())
-  | None ->
-      ( true,
-        Yojson.Safe.to_string
-          (`Assoc [ ("transcript", `List []); ("turn_count", `Int 0) ]) )
 
 let handle_voice_conference_start (ctx : 'a context) args : result =
   let agent_ids =
@@ -279,21 +249,12 @@ let handle_voice_conference_end (ctx : 'a context) args : result =
   if agent_ids = [] then
     (false, "Error: agent_ids must include at least one agent")
   else
-    match ctx.net with
-    | Some net ->
+    match require_net_or_error ctx with
+    | Error message -> (false, message)
+    | Ok net ->
         json_string_of_result
           (Voice_bridge.end_conference ~sw:ctx.sw ~clock:ctx.clock ~net
              ~agent_ids ())
-    | None ->
-        ( true,
-          Yojson.Safe.to_string
-            (`Assoc
-              [
-                ("ended", `Int 0);
-                ("skipped", `Int (List.length agent_ids));
-                ("failed", `Int 0);
-                ("total", `Int (List.length agent_ids));
-              ]) )
 
 let dispatch (ctx : 'a context) ~name ~args : result option =
   match name with

--- a/lib/voice_bridge_eio.ml
+++ b/lib/voice_bridge_eio.ml
@@ -46,6 +46,17 @@ let agent_voices () =
   | Ok config -> config.tts.agent_voices
   | Error _ -> default_agent_voices
 
+let tuning_for_agent agent_id =
+  match load_voice_config () with
+  | Ok config -> Voice_config.tuning_for_agent config agent_id
+  | Error _ ->
+      { Voice_config.stability = 0.5; similarity_boost = 0.75; style = 0.0 }
+
+let local_playback_enabled_for_agent agent_id =
+  match load_voice_config () with
+  | Ok config -> Voice_config.local_playback_enabled_for_agent config agent_id
+  | Error _ -> false
+
 let ends_with ~suffix s =
   let slen = String.length s in
   let plen = String.length suffix in
@@ -240,12 +251,17 @@ let voice_name_to_id name =
       if trimmed = "" then "21m00Tcm4TlvDq8ikWAM" else trimmed
 
 (** Ensure .masc/audio/ directory exists *)
+let masc_base_dir () =
+  match Sys.getenv_opt "ME_ROOT" with
+  | Some root when String.trim root <> "" -> Filename.concat root ".masc"
+  | _ -> ".masc"
+
 let ensure_audio_dir () =
-  let dir = ".masc/audio" in
+  let dir = Filename.concat (masc_base_dir ()) "audio" in
   if not (Sys.file_exists dir) then
     Sys.mkdir dir 0o755
   else if not (Sys.is_directory dir) then
-    log_error ".masc/audio exists but is not a directory"
+    log_error "voice audio path exists but is not a directory"
 
 let normalize_base_url value =
   let trimmed = String.trim value in
@@ -269,14 +285,18 @@ let endpoint_url_json endpoint =
   | None -> `Null
 
 let append_provider_metadata json endpoint =
+  let adapter = Provider_adapter.voice_adapter_for_endpoint endpoint in
   match json with
   | `Assoc fields ->
       `Assoc
         (fields
         @ [
+            ("provider_name", `String adapter.canonical_name);
             ( "provider_kind",
-              `String
-                (Voice_config.string_of_endpoint_kind endpoint.Voice_config.kind) );
+              `String (Provider_adapter.string_of_voice_transport adapter.transport) );
+            ( "provider_family",
+              `String (Provider_adapter.string_of_provider_family adapter.provider_family) );
+            ("provider_auth", `String (Provider_adapter.string_of_auth_mode adapter.auth_mode));
             ("endpoint_id", `String endpoint.id);
             ("endpoint_url", endpoint_url_json endpoint);
           ])
@@ -298,7 +318,9 @@ let safe_agent_id value =
 let make_audio_file ~agent_id =
   ensure_audio_dir ();
   let timestamp = int_of_float (Time_compat.now ()) in
-  Printf.sprintf ".masc/audio/%d_%s.mp3" timestamp (safe_agent_id agent_id)
+  Filename.concat
+    (Filename.concat (masc_base_dir ()) "audio")
+    (Printf.sprintf "%d_%s.mp3" timestamp (safe_agent_id agent_id))
 
 let write_text path content =
   let oc = open_out path in
@@ -314,16 +336,94 @@ let read_file path =
       let len = in_channel_length ic in
       really_input_string ic len)
 
+let show_process_status = function
+  | Unix.WEXITED code -> Printf.sprintf "exit %d" code
+  | Unix.WSIGNALED signal -> Printf.sprintf "signal %d" signal
+  | Unix.WSTOPPED signal -> Printf.sprintf "stopped %d" signal
+
+let playback_success_json ~attempted ~succeeded ~method_name ?detail () =
+  `Assoc
+    [
+      ("enabled", `Bool attempted);
+      ("attempted", `Bool attempted);
+      ("succeeded", `Bool succeeded);
+      ("method", `String method_name);
+      ("detail", match detail with Some value -> `String value | None -> `Null);
+    ]
+
+let playback_skipped_json reason =
+  `Assoc
+    [
+      ("enabled", `Bool false);
+      ("attempted", `Bool false);
+      ("succeeded", `Bool false);
+      ("method", `Null);
+      ("detail", `String reason);
+    ]
+
+let play_audio_locally ~agent_id ~audio_file =
+  if not (local_playback_enabled_for_agent agent_id) then
+    Ok (playback_skipped_json "local playback disabled")
+  else
+    let run argv =
+      Process_eio.run_argv_with_status ~timeout_sec:120.0 argv
+    in
+    let run_afplay path =
+      let argv =
+        if Sys.file_exists "/usr/bin/afplay" then [ "/usr/bin/afplay"; path ]
+        else [ "afplay"; path ]
+      in
+      run argv
+    in
+    match run_afplay audio_file with
+    | Unix.WEXITED 0, _ ->
+        Ok (playback_success_json ~attempted:true ~succeeded:true ~method_name:"afplay" ())
+    | status, output ->
+        let wav_file = Filename.temp_file "masc_voice_playback" ".wav" in
+        Fun.protect
+          ~finally:(fun () -> try Sys.remove wav_file with Sys_error _ -> ())
+          (fun () ->
+            let ffmpeg_argv =
+              [ "ffmpeg"; "-y"; "-loglevel"; "error"; "-i"; audio_file; wav_file ]
+            in
+            match run ffmpeg_argv with
+            | Unix.WEXITED 0, _ -> (
+                match run_afplay wav_file with
+                | Unix.WEXITED 0, _ ->
+                    Ok
+                      (playback_success_json ~attempted:true ~succeeded:true
+                         ~method_name:"ffmpeg+afplay"
+                         ~detail:"converted to wav for playback" ())
+                | status2, output2 ->
+                    Error
+                      (Printf.sprintf
+                         "local playback failed after wav conversion: afplay=%s output=%s"
+                         (show_process_status status2)
+                         (String.trim output2)) )
+            | status_ffmpeg, output_ffmpeg ->
+                Error
+                  (Printf.sprintf
+                     "local playback failed: afplay=%s output=%s; ffmpeg=%s output=%s"
+                     (show_process_status status)
+                     (String.trim output)
+                     (show_process_status status_ffmpeg)
+                     (String.trim output_ffmpeg)) )
+
 let resolve_api_key endpoint =
-  match endpoint.Voice_config.api_key_env with
+  let adapter = Provider_adapter.voice_adapter_for_endpoint endpoint in
+  match
+    Provider_adapter.voice_auth_env_name
+      ?endpoint_api_key_env:endpoint.Voice_config.api_key_env
+      adapter
+  with
   | Some env_name -> (
       match Sys.getenv_opt env_name with
       | Some value when String.trim value <> "" -> Ok (String.trim value)
       | _ ->
           Error
             (Printf.sprintf
-               "voice config endpoint %s expects %s to be set"
-               endpoint.id env_name) )
+               "voice provider %s (endpoint %s) expects %s to be set"
+               adapter.canonical_name endpoint.id env_name) )
   | None -> Ok ""
 
 let run_audio_http_request_to_file ~url ~headers ~body_json ~output_file =
@@ -380,7 +480,7 @@ let run_audio_http_request_to_file ~url ~headers ~body_json ~output_file =
       | Unix.WEXITED code -> Error (Printf.sprintf "curl exit %d" code)
       | _ -> Error "curl process failed")
 
-let speak_via_openai_compat_to_file endpoint ~message ~voice ~model ~output_file =
+let speak_via_openai_compat_to_file endpoint ~agent_id ~message ~voice ~model ~output_file =
   let open Result in
   let* api_key = resolve_api_key endpoint in
   let base_url =
@@ -396,6 +496,7 @@ let speak_via_openai_compat_to_file endpoint ~message ~voice ~model ~output_file
     @
     if api_key = "" then [] else [ ("Authorization", "Bearer " ^ api_key) ]
   in
+  let tuning = tuning_for_agent agent_id in
   let body_json =
     `Assoc
       [
@@ -403,13 +504,20 @@ let speak_via_openai_compat_to_file endpoint ~message ~voice ~model ~output_file
         ("voice", `String voice);
         ("model", `String model);
         ("response_format", `String "mp3");
+        ( "voice_settings",
+          `Assoc
+            [
+              ("stability", `Float tuning.stability);
+              ("similarity_boost", `Float tuning.similarity_boost);
+              ("style", `Float tuning.style);
+            ] );
       ]
   in
   run_audio_http_request_to_file
     ~url:(base_url ^ "/audio/speech")
     ~headers ~body_json ~output_file
 
-let speak_via_elevenlabs_to_file endpoint ~message ~voice ~model ~output_file =
+let speak_via_elevenlabs_to_file endpoint ~agent_id ~message ~voice ~model ~output_file =
   let open Result in
   let* api_key = resolve_api_key endpoint in
   let base_url =
@@ -428,6 +536,7 @@ let speak_via_elevenlabs_to_file endpoint ~message ~voice ~model ~output_file =
       ("Accept", "audio/mpeg");
     ]
   in
+  let tuning = tuning_for_agent agent_id in
   let body_json =
     `Assoc
       [
@@ -436,9 +545,9 @@ let speak_via_elevenlabs_to_file endpoint ~message ~voice ~model ~output_file =
         ( "voice_settings",
           `Assoc
             [
-              ("stability", `Float 0.5);
-              ("similarity_boost", `Float 0.75);
-              ("style", `Float 0.0);
+              ("stability", `Float tuning.stability);
+              ("similarity_boost", `Float tuning.similarity_boost);
+              ("style", `Float tuning.style);
             ] );
       ]
   in
@@ -447,21 +556,32 @@ let speak_via_elevenlabs_to_file endpoint ~message ~voice ~model ~output_file =
     ~headers ~body_json ~output_file
 
 let available_tts_endpoints ?provider () =
+  let normalize value = String.lowercase_ascii (String.trim value) in
+  let endpoint_matches_provider label endpoint =
+    let adapter = Provider_adapter.voice_adapter_for_endpoint endpoint in
+    let labels =
+      endpoint.id
+      :: Voice_config.string_of_endpoint_kind endpoint.kind
+      :: Provider_adapter.string_of_voice_transport adapter.transport
+      :: adapter.canonical_name
+      :: adapter.aliases
+    in
+    let target = normalize label in
+    List.exists (fun candidate -> String.equal (normalize candidate) target) labels
+  in
   match load_voice_config () with
   | Error _ -> []
-  | Ok config -> (
-      match Voice_config.select_endpoint ?endpoint_id:provider config.tts.endpoints with
-      | Some endpoint when Option.is_some provider -> [ endpoint ]
-      | _ -> Voice_config.enabled_endpoints config.tts.endpoints)
+  | Ok config ->
+      let endpoints = Voice_config.enabled_endpoints config.tts.endpoints in
+      (match provider with
+      | Some label when String.trim label <> "" ->
+          List.filter (endpoint_matches_provider label) endpoints
+      | _ -> endpoints)
 
 let provider_error_json endpoint message =
-  `Assoc
-    [ ("status", `String "error");
-      ("message", `String message);
-      ( "provider_kind",
-        `String (Voice_config.string_of_endpoint_kind endpoint.Voice_config.kind) );
-      ("endpoint_id", `String endpoint.id);
-      ("endpoint_url", endpoint_url_json endpoint) ]
+  append_provider_metadata
+    (`Assoc [ ("status", `String "error"); ("message", `String message) ])
+    endpoint
 
 let public_config_json () =
   match load_voice_config () with
@@ -530,10 +650,12 @@ let tts_preview_bytes_from_request_json json =
             let result =
               match endpoint.Voice_config.kind with
               | Voice_config.Openai_compat ->
-                  speak_via_openai_compat_to_file endpoint ~message:text ~voice ~model
+                  speak_via_openai_compat_to_file endpoint ~agent_id:"preview"
+                    ~message:text ~voice ~model
                     ~output_file
               | Voice_config.Elevenlabs_direct ->
-                  speak_via_elevenlabs_to_file endpoint ~message:text ~voice ~model
+                  speak_via_elevenlabs_to_file endpoint ~agent_id:"preview"
+                    ~message:text ~voice ~model
                     ~output_file
               | Voice_config.Voice_mcp -> assert false
             in
@@ -550,7 +672,7 @@ let tts_preview_bytes_from_request_json json =
 
 (** Clean up old audio files (>1 hour). Call from heartbeat. *)
 let cleanup_old_audio_files () =
-  let dir = ".masc/audio" in
+  let dir = Filename.concat (masc_base_dir ()) "audio" in
   if Sys.file_exists dir && Sys.is_directory dir then begin
     let now = Time_compat.now () in
     let cutoff = now -. 3600.0 in
@@ -762,7 +884,7 @@ let attempt_tts_endpoint ~sw ~clock ~net ~agent_id ~message ~voice ~model
       let audio_file = make_audio_file ~agent_id in
       (match
          speak_via_openai_compat_to_file endpoint ~message ~voice ~model
-           ~output_file:audio_file
+           ~agent_id ~output_file:audio_file
        with
       | Ok file_size ->
           start_local_playback ~sw ~agent_id ~audio_file;
@@ -787,7 +909,7 @@ let attempt_tts_endpoint ~sw ~clock ~net ~agent_id ~message ~voice ~model
       let audio_file = make_audio_file ~agent_id in
       (match
          speak_via_elevenlabs_to_file endpoint ~message ~voice ~model
-           ~output_file:audio_file
+           ~agent_id ~output_file:audio_file
        with
       | Ok file_size ->
           start_local_playback ~sw ~agent_id ~audio_file;
@@ -980,15 +1102,14 @@ let start_voice_session ~sw ~clock ~net ~agent_id ?session_name () =
 (** End a voice session *)
 let end_voice_session ~sw ~clock ~net ~agent_id =
   if not (is_voice_server_available ~sw ~clock ~net) then
-    Ok
-      (`Assoc
-        [ ("status", `String "skipped"); ("reason", `String "Voice server unavailable") ])
+    Error "Voice server unavailable"
   else
     let args = `Assoc [ ("agent_id", `String agent_id) ] in
     call_session_tool ~sw ~clock ~net ~tool_name:"voice_session_end" ~arguments:args
 
 (** Request speaking turn.
-    Ordered endpoint chain from voice_config.json → text_fallback *)
+    Ordered endpoint chain from voice_config.json. Fails explicitly when no
+    real backend accepts the request. *)
 let agent_speak ~sw ~clock ~net ~agent_id ~message ?provider ?(priority=1) () =
   let voice = get_voice_for_agent agent_id in
   let provider =
@@ -1004,9 +1125,9 @@ let agent_speak ~sw ~clock ~net ~agent_id ~message ?provider ?(priority=1) () =
   in
   let rec try_endpoints attempted = function
     | [] ->
-        text_fallback ~agent_id ~message
-          ~reason:"all configured TTS endpoints failed"
-          ~attempted_endpoints:(List.rev attempted) ()
+        Error
+          (Printf.sprintf "all configured TTS endpoints failed: %s"
+             (String.concat " | " (List.rev attempted)))
     | endpoint :: rest -> (
         match
           attempt_tts_endpoint ~sw ~clock ~net ~agent_id ~message ~voice ~model
@@ -1018,14 +1139,14 @@ let agent_speak ~sw ~clock ~net ~agent_id ~message ?provider ?(priority=1) () =
             try_endpoints (attempt :: attempted) rest)
   in
   if endpoints = [] then
-    text_fallback ~agent_id ~message ~reason:"no configured TTS endpoint" ()
+    Error "no configured TTS endpoint"
   else
     try_endpoints [] endpoints
 
 (** List active voice sessions *)
 let list_voice_sessions ~sw ~clock ~net =
   if not (is_voice_server_available ~sw ~clock ~net) then
-    Ok (`Assoc [ ("sessions", `List []); ("status", `String "voice_server_unavailable") ])
+    Error "Voice server unavailable"
   else
     let args = `Assoc [] in
     call_session_tool ~sw ~clock ~net ~tool_name:"voice_session_list" ~arguments:args
@@ -1102,11 +1223,13 @@ let start_conference ~sw ~clock ~net ~agent_ids ?conference_name () =
 
 (** End a multi-agent voice conference *)
 let end_conference ~sw ~clock ~net ~agent_ids () =
+  if not (is_voice_server_available ~sw ~clock ~net) then
+    Error "Voice server unavailable - cannot end conference"
+  else
   let classify_result = function
     | Ok (`Assoc fields) -> (
         match List.assoc_opt "status" fields with
         | Some (`String "ended") -> `Ended
-        | Some (`String "skipped") -> `Skipped
         | Some (`String _) | Some _ -> `Failed
         | None -> `Failed)
     | Ok _ -> `Failed
@@ -1117,7 +1240,6 @@ let end_conference ~sw ~clock ~net ~agent_ids () =
       (fun (ended, skipped, failed) agent_id ->
         match classify_result (end_voice_session ~sw ~clock ~net ~agent_id) with
         | `Ended -> (ended + 1, skipped, failed)
-        | `Skipped -> (ended, skipped + 1, failed)
         | `Failed -> (ended, skipped, failed + 1))
       (0, 0, 0) agent_ids
   in
@@ -1131,7 +1253,7 @@ let end_conference ~sw ~clock ~net ~agent_ids () =
 (** Get transcript of voice conversation *)
 let get_transcript ~sw ~clock ~net () =
   if not (is_voice_server_available ~sw ~clock ~net) then
-    Ok (`Assoc [ ("transcript", `List []); ("turn_count", `Int 0) ])
+    Error "Voice server unavailable"
   else
     let args = `Assoc [] in
     match
@@ -1139,7 +1261,7 @@ let get_transcript ~sw ~clock ~net () =
         ~arguments:args
     with
     | Ok data -> Ok data
-    | Error _ -> Ok (`Assoc [ ("transcript", `List []); ("turn_count", `Int 0) ])
+    | Error error -> Error error
 
 (** ============================================
     Health Check (Eio-native)

--- a/lib/voice_config.ml
+++ b/lib/voice_config.ml
@@ -15,10 +15,18 @@ type endpoint = {
   max_retries : int option;
 }
 
+type voice_tuning = {
+  stability : float;
+  similarity_boost : float;
+  style : float;
+}
+
 type tts_config = {
   default_model : string;
   default_voice : string;
+  default_voice_settings : voice_tuning;
   agent_voices : (string * string) list;
+  agent_voice_settings : (string * voice_tuning) list;
   endpoints : endpoint list;
 }
 
@@ -81,6 +89,11 @@ let float_opt = function
   | `Float value -> Some value
   | `Int value -> Some (float_of_int value)
   | _ -> None
+
+let float_or_default default = function
+  | `Float value -> value
+  | `Int value -> float_of_int value
+  | _ -> default
 
 let require_string ~ctx ~field json =
   match Yojson.Safe.Util.member field json |> trim_nonempty with
@@ -188,15 +201,60 @@ let parse_agent_voices json =
   | `Null -> Ok []
   | _ -> Error "tts.agent_voices must be an object"
 
+let parse_voice_tuning ~ctx json =
+  match json with
+  | `Assoc _ ->
+      Ok
+        {
+          stability =
+            Yojson.Safe.Util.member "stability" json |> float_or_default 0.5;
+          similarity_boost =
+            Yojson.Safe.Util.member "similarity_boost" json
+            |> float_or_default 0.75;
+          style = Yojson.Safe.Util.member "style" json |> float_or_default 0.0;
+        }
+  | `Null ->
+      Ok { stability = 0.5; similarity_boost = 0.75; style = 0.0 }
+  | _ -> Error (Printf.sprintf "%s must be an object" ctx)
+
+let parse_agent_voice_settings json =
+  match Yojson.Safe.Util.member "agent_voice_settings" json with
+  | `Assoc pairs ->
+      let rec loop acc = function
+        | [] -> Ok (List.rev acc)
+        | (agent_id, tuning_json) :: rest -> (
+            match parse_voice_tuning ~ctx:("tts.agent_voice_settings." ^ agent_id) tuning_json with
+            | Ok tuning -> loop ((String.trim agent_id, tuning) :: acc) rest
+            | Error _ as err -> err)
+      in
+      loop [] pairs
+  | `Null -> Ok []
+  | _ -> Error "tts.agent_voice_settings must be an object"
+
 let parse_tts json =
   let open Result in
   let* tts_json = require_object ~ctx:"root" ~field:"tts" json in
   let* default_model = require_string ~ctx:"tts" ~field:"default_model" tts_json in
   let* default_voice = require_string ~ctx:"tts" ~field:"default_voice" tts_json in
+  let* default_voice_settings =
+    parse_voice_tuning ~ctx:"tts.default_voice_settings"
+      (Yojson.Safe.Util.member "default_voice_settings" tts_json)
+  in
   let* agent_voices = parse_agent_voices tts_json in
+  let* agent_voice_settings =
+    parse_agent_voice_settings tts_json
+  in
   let* endpoints_json = require_list ~ctx:"tts" ~field:"endpoints" tts_json in
   let* endpoints = parse_endpoints ~ctx:"tts.endpoints" [] endpoints_json in
-  Ok { default_model; default_voice; agent_voices; endpoints }
+  Ok
+    {
+      default_model;
+      default_voice;
+      default_voice_settings;
+      agent_voices;
+      agent_voice_settings;
+      endpoints;
+    }
 
 let parse_stt json =
   let open Result in
@@ -217,18 +275,19 @@ let parse_session json =
 
 let parse_local_playback json =
   match Yojson.Safe.Util.member "local_playback" json with
-  | `Null -> Ok { enabled = false; agents = [] }
   | `Assoc local_json ->
+      let local_json = `Assoc local_json in
       let enabled =
-        Yojson.Safe.Util.member "enabled" (`Assoc local_json) |> bool_or_default false
+        Yojson.Safe.Util.member "enabled" local_json |> bool_or_default false
       in
       let agents =
-        match Yojson.Safe.Util.member "agents" (`Assoc local_json) |> string_list_opt with
-        | Some values -> values
-        | None -> []
+        match Yojson.Safe.Util.member "agents" local_json with
+        | `List values -> List.filter_map trim_nonempty values
+        | _ -> []
       in
       Ok { enabled; agents }
-  | _ -> Error "root.local_playback must be object"
+  | `Null -> Ok { enabled = false; agents = [] }
+  | _ -> Error "root.local_playback must be an object"
 
 let load () =
   let path = config_path () in
@@ -258,7 +317,7 @@ let select_endpoint ?endpoint_id (endpoints : endpoint list) =
   | Some id when String.trim id <> "" -> (
       let id = String.trim id in
       List.find_opt
-        (fun endpoint ->
+        (fun (endpoint : endpoint) ->
           endpoint.id = id || string_of_endpoint_kind endpoint.kind = id)
         endpoints )
   | _ -> (
@@ -270,6 +329,18 @@ let voice_for_agent config agent_id =
   match List.assoc_opt agent_id config.tts.agent_voices with
   | Some voice -> voice
   | None -> config.tts.default_voice
+
+let tuning_for_agent config agent_id =
+  match List.assoc_opt agent_id config.tts.agent_voice_settings with
+  | Some tuning -> tuning
+  | None -> config.tts.default_voice_settings
+
+let local_playback_enabled_for_agent config agent_id =
+  config.local_playback.enabled
+  &&
+  match config.local_playback.agents with
+  | [] -> true
+  | agents -> List.mem agent_id agents
 
 let unique_strings values =
   let rec loop seen acc = function
@@ -346,6 +417,6 @@ let public_json config =
             ("enabled", `Bool config.local_playback.enabled);
             ( "agents",
               `List
-                (List.map (fun agent -> `String agent) config.local_playback.agents) );
+                (List.map (fun agent_id -> `String agent_id) config.local_playback.agents) );
           ] );
     ]

--- a/test/test_provider_adapter.ml
+++ b/test/test_provider_adapter.ml
@@ -86,6 +86,22 @@ let test_default_model_override_label_result () =
                 label
           | Error msg -> fail msg))
 
+let test_resolve_voice_aliases () =
+  let elevenlabs = Option.get (Adapter.resolve_voice_adapter "elevenlabs") in
+  check string "elevenlabs alias" "elevenlabs-direct" elevenlabs.canonical_name;
+  let openai_compat = Option.get (Adapter.resolve_voice_adapter "openai_compat") in
+  check string "openai compat alias" "voice-openai-compat"
+    openai_compat.canonical_name
+
+let test_voice_auth_env_resolution () =
+  let elevenlabs = Option.get (Adapter.resolve_voice_adapter "elevenlabs-direct") in
+  check (option string) "elevenlabs auth env"
+    (Some "ELEVENLABS_API_KEY")
+    (Adapter.voice_auth_env_name elevenlabs);
+  let openai_compat = Option.get (Adapter.resolve_voice_adapter "voice-openai-compat") in
+  check (option string) "endpoint override auth env"
+    (Some "VOICE_PROXY_KEY")
+    (Adapter.voice_auth_env_name ~endpoint_api_key_env:"VOICE_PROXY_KEY" openai_compat)
 let () =
   run "Provider Adapter"
     [
@@ -104,5 +120,8 @@ let () =
             test_default_model_provider_prefix_result;
           test_case "default override label" `Quick
             test_default_model_override_label_result;
+          test_case "resolve voice aliases" `Quick test_resolve_voice_aliases;
+          test_case "voice auth env resolution" `Quick
+            test_voice_auth_env_resolution;
         ] );
     ]

--- a/test/test_tool_keeper.ml
+++ b/test/test_tool_keeper.ml
@@ -615,6 +615,167 @@ let test_keeper_policy_set_rejects_invalid_mode () =
            true
          with Not_found -> false))
 
+let test_keeper_up_defaults_sangsu_to_explicit_voice_policy () =
+  Eio_main.run @@ fun env ->
+  Eio.Switch.run @@ fun sw ->
+  let base_dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () -> rm_rf base_dir)
+    (fun () ->
+      let config = Masc_mcp.Room.default_config base_dir in
+      ignore (Masc_mcp.Room.init config ~agent_name:(Some "tester"));
+      let keeper_ctx : _ Masc_mcp.Tool_keeper.context =
+        { config; sw; clock = Eio.Stdenv.clock env }
+      in
+      let dispatch name args =
+        match Masc_mcp.Tool_keeper.dispatch keeper_ctx ~name ~args with
+        | Some result -> result
+        | None -> fail ("missing dispatch for " ^ name)
+      in
+      let ok, body =
+        dispatch "masc_keeper_up"
+          (`Assoc
+            [
+              ("name", `String "sangsu");
+              ("goal", `String "Maintain Sangsu persona");
+              ("models", `List [ `String "llama:qwen3.5-35b-a3b-ud-q8-xl" ]);
+              ("presence_keepalive", `Bool false);
+              ("proactive_enabled", `Bool false);
+            ])
+      in
+      check bool "keeper up ok" true ok;
+      let json = Yojson.Safe.from_string body in
+      check string "policy mode" "explicit_event_v1"
+        Yojson.Safe.Util.(json |> member "policy_mode" |> to_string);
+      check bool "voice enabled" true
+        Yojson.Safe.Util.(json |> member "voice_enabled" |> to_bool);
+      check string "voice channel" "voice_text"
+        Yojson.Safe.Util.(json |> member "voice_channel" |> to_string);
+      check string "voice agent id" "sangsu"
+        Yojson.Safe.Util.(json |> member "voice_agent_id" |> to_string);
+      let resident_path =
+        Filename.concat base_dir ".masc/resident-keepers/sangsu.json"
+      in
+      check bool "resident spec exists" true (Sys.file_exists resident_path);
+      let resident_json = Yojson.Safe.from_file resident_path in
+      check bool "resident voice enabled" true
+        Yojson.Safe.Util.(resident_json |> member "voice_enabled" |> to_bool);
+      check string "resident voice channel" "voice_text"
+        Yojson.Safe.Util.(resident_json |> member "voice_channel" |> to_string))
+
+let test_keeper_policy_set_accepts_explicit_event_v1 () =
+  Eio_main.run @@ fun env ->
+  Eio.Switch.run @@ fun sw ->
+  let base_dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () -> rm_rf base_dir)
+    (fun () ->
+      let config = Masc_mcp.Room.default_config base_dir in
+      ignore (Masc_mcp.Room.init config ~agent_name:(Some "tester"));
+      let keeper_ctx : _ Masc_mcp.Tool_keeper.context =
+        { config; sw; clock = Eio.Stdenv.clock env }
+      in
+      let dispatch name args =
+        match Masc_mcp.Tool_keeper.dispatch keeper_ctx ~name ~args with
+        | Some result -> result
+        | None -> fail ("missing dispatch for " ^ name)
+      in
+      let ok, _ =
+        dispatch "masc_keeper_up"
+          (`Assoc
+            [
+              ("name", `String "buddy");
+              ("goal", `String "Stay resident");
+              ("models", `List [ `String "llama:qwen3.5-35b-a3b-ud-q8-xl" ]);
+              ("presence_keepalive", `Bool false);
+              ("proactive_enabled", `Bool false);
+            ])
+      in
+      check bool "keeper up ok" true ok;
+      let ok, body =
+        dispatch "masc_keeper_policy_set"
+          (`Assoc
+            [
+              ("name", `String "buddy");
+              ("policy_mode", `String "explicit_event_v1");
+            ])
+      in
+      check bool "policy set ok" true ok;
+      let json = Yojson.Safe.from_string body in
+      check string "policy mode updated" "explicit_event_v1"
+        Yojson.Safe.Util.(json |> member "policy_mode" |> to_string))
+
+let test_resident_bootstrap_marks_stale_explicit_keeper () =
+  Eio_main.run @@ fun env ->
+  Eio.Switch.run @@ fun sw ->
+  let base_dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () ->
+      Masc_mcp.Keeper_execution.stop_keepalive "sangsu";
+      rm_rf base_dir)
+    (fun () ->
+      let config = Masc_mcp.Room.default_config base_dir in
+      ignore (Masc_mcp.Room.init config ~agent_name:(Some "tester"));
+      let keeper_ctx : _ Masc_mcp.Tool_keeper.context =
+        { config; sw; clock = Eio.Stdenv.clock env }
+      in
+      let dispatch name args =
+        match Masc_mcp.Tool_keeper.dispatch keeper_ctx ~name ~args with
+        | Some result -> result
+        | None -> fail ("missing dispatch for " ^ name)
+      in
+      let ok, _ =
+        dispatch "masc_keeper_up"
+          (`Assoc
+            [
+              ("name", `String "sangsu");
+              ("goal", `String "Stay resident");
+              ("models", `List [ `String "llama:qwen3.5-35b-a3b-ud-q8-xl" ]);
+              ("presence_keepalive", `Bool true);
+              ("proactive_enabled", `Bool false);
+            ])
+      in
+      check bool "keeper up ok" true ok;
+      Masc_mcp.Keeper_execution.stop_keepalive "sangsu";
+      let meta =
+        match Masc_mcp.Keeper_types.read_meta config "sangsu" with
+        | Ok (Some meta) -> meta
+        | Ok None -> fail "missing keeper meta"
+        | Error e -> fail e
+      in
+      let stale_meta =
+        {
+          meta with
+          policy_mode = "explicit_event_v1";
+          presence_keepalive = true;
+          proactive_enabled = false;
+          last_turn_ts = 0.0;
+        }
+      in
+      (match Masc_mcp.Keeper_types.write_meta config stale_meta with
+      | Ok () -> ()
+      | Error e -> fail e);
+      let stats = Masc_mcp.Keeper_runtime.bootstrap_existing_keepers keeper_ctx in
+      check bool "bootstrap enabled" true stats.enabled;
+      check int "started stale resident" 0 stats.started;
+      check int "stale resident counted" 1 stats.stale;
+      let ok, status_body =
+        dispatch "masc_keeper_status"
+          (`Assoc
+            [
+              ("name", `String "sangsu");
+              ("include_history_tail", `Bool false);
+              ("include_compaction_history", `Bool false);
+              ("include_context", `Bool false);
+              ("include_metrics_overview", `Bool false);
+              ("include_memory_bank", `Bool false);
+            ])
+      in
+      check bool "status ok" true ok;
+      let status_json = Yojson.Safe.from_string status_body in
+      check bool "keepalive running" false
+        Yojson.Safe.Util.(status_json |> member "keepalive_running" |> to_bool))
+
 let () =
   run "Tool_keeper" [
     ("read_file_tail_lines", [
@@ -642,5 +803,11 @@ let () =
            test_keeper_policy_tools_roundtrip;
          test_case "policy set rejects invalid mode" `Quick
            test_keeper_policy_set_rejects_invalid_mode;
+         test_case "sangsu defaults explicit voice policy" `Quick
+           test_keeper_up_defaults_sangsu_to_explicit_voice_policy;
+         test_case "policy set accepts explicit_event_v1" `Quick
+           test_keeper_policy_set_accepts_explicit_event_v1;
+         test_case "resident bootstrap marks stale explicit keeper" `Quick
+           test_resident_bootstrap_marks_stale_explicit_keeper;
        ]);
   ]

--- a/test/test_tool_voice.ml
+++ b/test/test_tool_voice.ml
@@ -124,7 +124,139 @@ let test_voice_agent_uses_configured_voice () =
         (Some "Sarah")
         (match json_field "voice" body with Some (`String s) -> Some s | _ -> None))
 
-let test_voice_speak_without_net_falls_back_to_text () =
+let test_voice_agent_reads_nested_tuning_config () =
+  let config_json =
+    {|
+{
+  "tts": {
+    "default_model": "eleven_multilingual_v2",
+    "default_voice": "Sarah",
+    "default_voice_settings": {
+      "stability": 0.5,
+      "similarity_boost": 0.75,
+      "style": 0.0
+    },
+    "agent_voices": {
+      "sangsu": "Roger"
+    },
+    "agent_voice_settings": {
+      "sangsu": {
+        "stability": 0.28,
+        "similarity_boost": 0.82,
+        "style": 0.45
+      }
+    },
+    "endpoints": [
+      {
+        "id": "test-tts",
+        "kind": "openai_compat",
+        "base_url": "https://example.invalid/v1",
+        "enabled": true
+      }
+    ]
+  },
+  "stt": {
+    "default_model": "whisper-1",
+    "endpoints": [
+      {
+        "id": "test-stt",
+        "kind": "openai_compat",
+        "base_url": "https://api.openai.com/v1",
+        "enabled": true
+      }
+    ]
+  },
+  "session": {
+    "endpoints": [
+      {
+        "id": "test-session",
+        "kind": "voice_mcp",
+        "base_url": "http://127.0.0.1:8936",
+        "enabled": true
+      }
+    ]
+  },
+  "local_playback": {
+    "enabled": true,
+    "agents": ["sangsu"]
+  }
+}
+|}
+  in
+  with_temp_voice_config config_json @@ fun () ->
+      with_ctx_no_net @@ fun ctx ->
+      let ok, body =
+        dispatch_exn ctx ~name:"masc_voice_agent"
+          ~args:(`Assoc [ ("agent_id", `String "sangsu") ])
+      in
+      check bool "ok" true ok;
+      check (option string) "voice"
+        (Some "Roger")
+        (match json_field "voice" body with Some (`String s) -> Some s | _ -> None);
+      let tuning = Masc_mcp.Voice_bridge.tuning_for_agent "sangsu" in
+      check (float 0.001) "stability" 0.28 tuning.stability;
+      check (float 0.001) "similarity_boost" 0.82 tuning.similarity_boost;
+      check (float 0.001) "style" 0.45 tuning.style;
+      check bool "local playback enabled" true
+        (Masc_mcp.Voice_bridge.local_playback_enabled_for_agent "sangsu")
+
+let test_voice_provider_alias_selects_adapter_endpoint () =
+  let config_json =
+    {|
+{
+  "tts": {
+    "default_model": "eleven_multilingual_v2",
+    "default_voice": "Sarah",
+    "agent_voices": {
+      "sangsu": "Roger"
+    },
+    "endpoints": [
+      {
+        "id": "elevenlabs-direct",
+        "kind": "elevenlabs_direct",
+        "base_url": "https://api.elevenlabs.io/v1",
+        "api_key_env": "ELEVENLABS_API_KEY",
+        "enabled": true
+      },
+      {
+        "id": "railway-elevenlabs-proxy",
+        "kind": "openai_compat",
+        "base_url": "https://example.test/v1",
+        "enabled": true
+      }
+    ]
+  },
+  "stt": {
+    "default_model": "whisper-1",
+    "endpoints": [
+      {
+        "id": "openai-stt",
+        "kind": "openai_compat",
+        "base_url": "https://api.openai.com/v1",
+        "enabled": true
+      }
+    ]
+  },
+  "session": {
+    "endpoints": [
+      {
+        "id": "local-session",
+        "kind": "voice_mcp",
+        "base_url": "http://127.0.0.1:8936",
+        "enabled": true
+      }
+    ]
+  }
+}
+|}
+  in
+  with_temp_voice_config config_json @@ fun () ->
+      let endpoints = Masc_mcp.Voice_bridge.available_tts_endpoints ~provider:"elevenlabs" () in
+      check int "one endpoint" 1 (List.length endpoints);
+      let endpoint = List.hd endpoints in
+      check string "selected direct endpoint" "elevenlabs-direct" endpoint.id
+
+let test_voice_speak_without_net_errors () =
   with_ctx_no_net (fun ctx ->
       let ok, body =
         dispatch_exn ctx ~name:"masc_voice_speak"
@@ -135,13 +267,8 @@ let test_voice_speak_without_net_falls_back_to_text () =
                 ("message", `String "hello from voice");
               ])
       in
-      check bool "ok" true ok;
-      check (option string) "status"
-        (Some "text_fallback")
-        (match json_field "status" body with Some (`String s) -> Some s | _ -> None);
-      check (option string) "voice"
-        (Some "Roger")
-        (match json_field "voice" body with Some (`String s) -> Some s | _ -> None))
+      check bool "fails" false ok;
+      check bool "mentions net" true (contains body "net"))
 
 let test_voice_session_start_without_net_errors () =
   with_ctx_no_net (fun ctx ->
@@ -152,34 +279,32 @@ let test_voice_session_start_without_net_errors () =
       check bool "fails" false ok;
       check bool "mentions net" true (contains body "net"))
 
-let test_voice_sessions_without_net_returns_empty_list () =
+let test_voice_sessions_without_net_errors () =
   with_ctx_no_net (fun ctx ->
       let ok, body =
         dispatch_exn ctx ~name:"masc_voice_sessions" ~args:(`Assoc [])
       in
-      check bool "ok" true ok;
-      check (option string) "status"
-        (Some "voice_server_unavailable")
-        (match json_field "status" body with Some (`String s) -> Some s | _ -> None))
+      check bool "fails" false ok;
+      check bool "mentions net" true (contains body "net"))
 
-let test_voice_conference_end_without_net_returns_zero () =
+let test_voice_transcript_without_net_errors () =
+  with_ctx_no_net (fun ctx ->
+      let ok, body =
+        dispatch_exn ctx ~name:"masc_voice_transcript" ~args:(`Assoc [])
+      in
+      check bool "fails" false ok;
+      check bool "mentions net" true (contains body "net"))
+
+let test_voice_conference_end_without_net_errors () =
   with_ctx_no_net (fun ctx ->
       let ok, body =
         dispatch_exn ctx ~name:"masc_voice_conference_end"
           ~args:(`Assoc [ ("agent_ids", `List [ `String "claude"; `String "gemini" ]) ])
       in
-      check bool "ok" true ok;
-      check (option int) "ended"
-        (Some 0)
-        (match json_field "ended" body with Some (`Int n) -> Some n | _ -> None);
-      check (option int) "skipped"
-        (Some 2)
-        (match json_field "skipped" body with Some (`Int n) -> Some n | _ -> None);
-      check (option int) "failed"
-        (Some 0)
-        (match json_field "failed" body with Some (`Int n) -> Some n | _ -> None))
+      check bool "fails" false ok;
+      check bool "mentions net" true (contains body "net"))
 
-let test_voice_conference_end_with_unavailable_server_counts_skipped () =
+let test_voice_conference_end_with_unavailable_server_errors () =
   let config_json =
     {|
 {
@@ -233,16 +358,9 @@ let test_voice_conference_end_with_unavailable_server_counts_skipped () =
         dispatch_exn ctx ~name:"masc_voice_conference_end"
           ~args:(`Assoc [ ("agent_ids", `List [ `String "claude"; `String "gemini" ]) ])
       in
-      check bool "ok" true ok;
-      check (option int) "ended"
-        (Some 0)
-        (match json_field "ended" body with Some (`Int n) -> Some n | _ -> None);
-      check (option int) "skipped"
-        (Some 2)
-        (match json_field "skipped" body with Some (`Int n) -> Some n | _ -> None);
-      check (option int) "failed"
-        (Some 0)
-        (match json_field "failed" body with Some (`Int n) -> Some n | _ -> None)
+      check bool "fails" false ok;
+      check bool "mentions unavailable" true
+        (contains body "unavailable" || contains body "cannot end conference")
 
 let test_voice_public_config_json () =
   let config_json =
@@ -311,7 +429,9 @@ let test_voice_public_config_json () =
          |> List.exists (function `String "sangsu" -> true | _ -> false));
       check bool "includes sangsu voice" true
         (json |> member "tts" |> member "available_voices" |> to_list
-         |> List.exists (function `String "Josh" -> true | _ -> false))
+         |> List.exists (function `String "Roger" -> true | _ -> false));
+      check bool "local playback enabled surfaced" true
+        (json |> member "local_playback" |> member "enabled" |> to_bool)
 
 let touch_executable dir name =
   let path = Filename.concat dir name in
@@ -361,12 +481,21 @@ let () =
       ( "handlers",
         [
           test_case "voice agent" `Quick test_voice_agent_uses_configured_voice;
-          test_case "speak fallback" `Quick test_voice_speak_without_net_falls_back_to_text;
+          test_case "voice agent reads nested config" `Quick
+            test_voice_agent_reads_nested_tuning_config;
+          test_case "voice provider alias selects adapter endpoint" `Quick
+            test_voice_provider_alias_selects_adapter_endpoint;
+          test_case "speak without net errors" `Quick
+            test_voice_speak_without_net_errors;
           test_case "session start no net" `Quick test_voice_session_start_without_net_errors;
-          test_case "sessions no net" `Quick test_voice_sessions_without_net_returns_empty_list;
-          test_case "conference end no net" `Quick test_voice_conference_end_without_net_returns_zero;
-          test_case "conference end unavailable server counts skipped" `Quick
-            test_voice_conference_end_with_unavailable_server_counts_skipped;
+          test_case "sessions no net errors" `Quick
+            test_voice_sessions_without_net_errors;
+          test_case "transcript no net errors" `Quick
+            test_voice_transcript_without_net_errors;
+          test_case "conference end no net errors" `Quick
+            test_voice_conference_end_without_net_errors;
+          test_case "conference end unavailable server errors" `Quick
+            test_voice_conference_end_with_unavailable_server_errors;
           test_case "voice public config json" `Quick
             test_voice_public_config_json;
           test_case "local playback argv prefers ffplay" `Quick


### PR DESCRIPTION
## Summary
- restore Sangsu as an explicit_event_v1 resident keeper with truthful voice policy fields
- make voice transport truthful and adapter-backed, including local playback and direct ElevenLabs endpoint selection
- bootstrap stale resident keepers, emit explicit boot/fixed-idle voice events, and cover regressions with keeper/voice/provider tests

## Verification
- dune build --root . _build/default/test/test_provider_adapter.exe _build/default/test/test_tool_voice.exe _build/default/test/test_tool_keeper.exe _build/default/bin/main_eio.exe
- ./_build/default/test/test_provider_adapter.exe
- ./_build/default/test/test_tool_voice.exe
- ./_build/default/test/test_tool_keeper.exe

## Live Smoke
- temporary worktree server on port 8941 booted Sangsu from resident state
- verified successful `boot` voice event and successful `fixed_idle_checkin` voice event with audio artifacts under `~/.masc/audio`
- smoke server was stopped after verification; persisted Sangsu runtime values were restored to 900s proactive gates