### PR TITLE
fix(audit): align audit file path from audit.log to audit.jsonl

### DIFF
--- a/lib/mcp_server_eio.ml
+++ b/lib/mcp_server_eio.ml
@@ -591,7 +591,7 @@ type audit_event = {
 }
 
 let audit_log_path (config : Room.config) =
-  Filename.concat (Room_utils.masc_dir config) "audit.log"
+  Filename.concat (Room_utils.masc_dir config) "audit.jsonl"
 
 let audit_event_to_json (e : audit_event) : Yojson.Safe.t =
   `Assoc [

--- a/lib/tool_audit.ml
+++ b/lib/tool_audit.ml
@@ -16,7 +16,7 @@ type audit_event = {
 
 (* Audit log path *)
 let audit_log_path (config : Room.config) =
-  Filename.concat (Room_utils.masc_dir config) "audit.log"
+  Filename.concat (Room_utils.masc_dir config) "audit.jsonl"
 
 (* Convert audit event to JSON *)
 let audit_event_to_json (e : audit_event) : Yojson.Safe.t =


### PR DESCRIPTION
## Summary
- `audit_log.ml`은 `.masc/audit.jsonl`에 기록하지만, `tool_audit.ml`과 `mcp_server_eio.ml`은 `.masc/audit.log`에서 읽으려 했음
- 파일이 존재하지 않아 `read_audit_events`가 항상 빈 배열 반환 → `masc_audit_query`/`masc_audit_stats`가 0 actor traces 보고
- 2개 파일에서 `"audit.log"` → `"audit.jsonl"`로 경로 통일

## Test plan
- [x] `dune build` 통과
- [ ] `make test` 통과 (실행 중)
- [ ] 서버 재시작 후 `masc_audit_query` 호출 시 실제 이벤트 반환 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)