### PR TITLE
feat(audit): add audit logging for core collaboration events

### DIFF
--- a/lib/mcp_server_eio.ml
+++ b/lib/mcp_server_eio.ml
@@ -1608,6 +1608,9 @@ let execute_tool_eio ~sw ~clock ?mcp_session_id ?auth_token state ~name ~argumen
           ("agent_name", `String nickname);
           ("timestamp", `Float (Time_compat.now ()));
         ]) in
+      (* Audit: log join event *)
+      Audit_log.log_join config ~agent_id:nickname
+        ~room_id:(Filename.basename config.base_path) ();
       (true, final_result)
 
   | "masc_leave" ->
@@ -1626,6 +1629,9 @@ let execute_tool_eio ~sw ~clock ?mcp_session_id ?auth_token state ~name ~argumen
         let agent_file = Printf.sprintf "/tmp/.masc_agent_%s" session_id in
         Safe_ops.remove_file_logged ~context:"masc_leave" agent_file
       end;
+      (* Audit: log leave event *)
+      Audit_log.log_leave config ~agent_id:agent_name
+        ~room_id:(Filename.basename config.base_path) ();
       (true, result)
 
 
@@ -1719,6 +1725,10 @@ let execute_tool_eio ~sw ~clock ?mcp_session_id ?auth_token state ~name ~argumen
         (* Increment broadcast_count in active team sessions *)
         Team_session_engine_eio.increment_broadcast_from_external config
           ~agent_name;
+        (* Audit: log broadcast event *)
+        Audit_log.log_broadcast config ~agent_id:agent_name
+          ~room_id:(Filename.basename config.base_path)
+          ~message_preview:message ();
         (true, result)
       end
 

--- a/lib/tool_task.ml
+++ b/lib/tool_task.ml
@@ -55,7 +55,11 @@ let handle_claim ctx args =
          ("task_id", `String task_id);
          ("agent_name", `String ctx.agent_name);
          ("timestamp", `Float (Time_compat.now ()));
-       ])
+       ]);
+       (* Audit: log claim event *)
+       Audit_log.log_claim_task ctx.config ~agent_id:ctx.agent_name
+         ~room_id:(Filename.basename ctx.config.base_path)
+         ~task_id ()
    | Error _ -> ());
   result_to_response result
 
@@ -127,7 +131,11 @@ let handle_done ctx args =
        (try ignore (Metrics_store_eio.record ctx.config metric)
         with exn -> Printf.eprintf "[task] Metrics_store_eio.record(done) failed: %s\n%!" (Printexc.to_string exn));
        (* Feed success into Thompson Sampling quality signal *)
-       Lodge_selection.record_vote ~agent_name:ctx.agent_name ~direction:`Up
+       Lodge_selection.record_vote ~agent_name:ctx.agent_name ~direction:`Up;
+       (* Audit: log done event *)
+       Audit_log.log_done_task ctx.config ~agent_id:ctx.agent_name
+         ~room_id:(Filename.basename ctx.config.base_path)
+         ~task_id ()
    | Error err ->
        Printf.eprintf "[task] metrics record failed: %s\n%!" (Types.masc_error_to_string err));
   result_to_response result
@@ -173,7 +181,11 @@ let handle_cancel_task ctx args =
          ("agent_name", `String ctx.agent_name);
          ("reason", `String reason);
          ("timestamp", `Float (Time_compat.now ()));
-       ])
+       ]);
+       (* Audit: log cancel event *)
+       Audit_log.log_cancel_task ctx.config ~agent_id:ctx.agent_name
+         ~room_id:(Filename.basename ctx.config.base_path)
+         ~task_id ~reason ()
    | Error err ->
        Printf.eprintf "[task] metrics record failed: %s\n%!" (Types.masc_error_to_string err));
   result_to_response result
@@ -222,7 +234,18 @@ let handle_transition ctx args =
          ("action", `String action);
          ("agent_name", `String ctx.agent_name);
          ("timestamp", `Float (Time_compat.now ()));
-       ])
+       ]);
+       (* Audit: log transition event by action type *)
+       let room_id = Filename.basename ctx.config.base_path in
+       (match action_lc with
+        | "claim" ->
+            Audit_log.log_claim_task ctx.config ~agent_id:ctx.agent_name ~room_id ~task_id ()
+        | "done" ->
+            Audit_log.log_done_task ctx.config ~agent_id:ctx.agent_name ~room_id ~task_id ()
+        | "cancel" ->
+            Audit_log.log_cancel_task ctx.config ~agent_id:ctx.agent_name ~room_id ~task_id
+              ~reason:(if reason = "" then "cancelled" else reason) ()
+        | _ -> ())
    | Error err ->
        Printf.eprintf "[task] task transition failed: %s\n%!" (Types.masc_error_to_string err));
   (* Record metrics *)


### PR DESCRIPTION
## Summary

- Wire `Audit_log.log_*` calls into 6 core MCP event handlers: Join, Leave, Claim, Done, Cancel, Broadcast
- Previously only 2 of 14 defined action types (Suspend, CircuitBreaker) had actual log calls
- Raises audit coverage from **14% to 57%** (8 of 14 action types now logged)
- All logging is on success paths only (no noise from failed attempts)

### Changed files
- `lib/mcp_server_eio.ml` — Join, Leave, Broadcast handlers
- `lib/tool_task.ml` — Claim, Done, Cancel handlers (both direct and via `masc_transition`)

### Remaining (Phase 2)
- ToolCall rich logging (consolidate inline audit in mcp_server_eio.ml)
- AuthSuccess/AuthFailure logging
- SearchRefinement logging

## Test plan
- [x] `dune build` passes
- [ ] `make test` verification
- [ ] Manual: call `masc_join` → `masc_audit_query` to confirm events appear in `audit.jsonl`

Generated with [Claude Code](https://claude.com/claude-code)