### PR TITLE
feat(dashboard): add room-wide orchestra map

### DIFF
--- a/bin/main_eio.ml
+++ b/bin/main_eio.ml
@@ -5684,6 +5684,10 @@ let command_plane_swarm_http_json ~state request =
   Server_command_plane_http.command_plane_swarm_http_json
     ~deps:command_plane_http_deps ~state request
 
+let command_plane_orchestra_http_json ~state request =
+  Server_command_plane_http.command_plane_orchestra_http_json
+    ~deps:command_plane_http_deps ~state request
+
 let command_plane_unit_define_http_json ~state request ~args =
   Server_command_plane_http.command_plane_unit_define_http_json
     ~deps:command_plane_http_deps ~state request ~args
@@ -7396,6 +7400,12 @@ let make_routes ~port ~host ~sw ~clock =
          Http.Response.json ~compress:true ~request:req (Yojson.Safe.to_string json) reqd
        ) request reqd)
 
+  |> Http.Router.get "/api/v1/command-plane/orchestra" (fun request reqd ->
+       with_public_read (fun state req reqd ->
+         let json = command_plane_orchestra_http_json ~state req in
+         Http.Response.json ~compress:true ~request:req (Yojson.Safe.to_string json) reqd
+       ) request reqd)
+
   |> Http.Router.get "/api/v1/chains/summary" (fun request reqd ->
        with_public_read (fun state req reqd ->
          match command_plane_chain_summary_http_json ~state req with
@@ -8828,6 +8838,11 @@ let run_server ~sw ~env ~port ~base_path =
       | `GET, "/api/v1/command-plane/swarm" ->
           let state = get_server_state () in
           let json = command_plane_swarm_http_json ~state httpun_request in
+          h2_respond_json h2_reqd (Yojson.Safe.to_string json) ~extra_headers:cors
+
+      | `GET, "/api/v1/command-plane/orchestra" ->
+          let state = get_server_state () in
+          let json = command_plane_orchestra_http_json ~state httpun_request in
           h2_respond_json h2_reqd (Yojson.Safe.to_string json) ~extra_headers:cors
 
       | `GET, "/api/v1/chains/summary" ->

--- a/dashboard/src/api.ts
+++ b/dashboard/src/api.ts
@@ -45,6 +45,7 @@ import type {
   CommandPlaneChainSummary,
   CommandPlaneSnapshot,
   CommandPlaneSwarmResponse,
+  CommandPlaneOrchestraResponse,
   CommandPlaneSummarySnapshot,
 } from './types'
 
@@ -531,6 +532,17 @@ export function fetchCommandPlaneSwarm(
   if (operationId) params.set('operation_id', operationId)
   const query = params.toString()
   return get(`/api/v1/command-plane/swarm${query ? `?${query}` : ''}`)
+}
+
+export function fetchCommandPlaneOrchestra(
+  runId?: string,
+  operationId?: string,
+): Promise<CommandPlaneOrchestraResponse> {
+  const params = new URLSearchParams()
+  if (runId) params.set('run_id', runId)
+  if (operationId) params.set('operation_id', operationId)
+  const query = params.toString()
+  return get(`/api/v1/command-plane/orchestra${query ? `?${query}` : ''}`)
 }
 
 export function runCommandPlaneAction(

--- a/dashboard/src/app.ts
+++ b/dashboard/src/app.ts
@@ -44,6 +44,7 @@ import {
   commandPlaneSurface,
   refreshCommandPlaneChainSummary,
   refreshCommandPlaneCurrentSurface,
+  refreshCommandPlaneOrchestra,
   refreshCommandPlaneSwarm,
 } from './command-store'
 
@@ -120,8 +121,11 @@ function refreshForTab(tab: string) {
   if (tab === 'command') {
     refreshCommandPlaneCurrentSurface()
     refreshCommandPlaneChainSummary()
-    if (commandPlaneSurface.value === 'swarm' || commandPlaneSurface.value === 'warroom') {
+    if (commandPlaneSurface.value === 'swarm' || commandPlaneSurface.value === 'warroom' || commandPlaneSurface.value === 'orchestra') {
       refreshCommandPlaneSwarm()
+    }
+    if (commandPlaneSurface.value === 'orchestra') {
+      refreshCommandPlaneOrchestra()
     }
     if (commandPlaneSurface.value === 'warroom') {
       refreshOperatorSnapshot()

--- a/dashboard/src/command-store.ts
+++ b/dashboard/src/command-store.ts
@@ -3,6 +3,7 @@ import {
   fetchChainRun,
   fetchChainSummary,
   fetchCommandPlaneHelp,
+  fetchCommandPlaneOrchestra,
   fetchCommandPlaneSnapshot,
   fetchCommandPlaneSummary,
   fetchCommandPlaneSwarm,
@@ -45,6 +46,12 @@ import type {
   CommandPlaneSnapshot,
   CommandPlaneSummarySnapshot,
   CommandPlaneSwarmFlag,
+  CommandPlaneOrchestraEdge,
+  CommandPlaneOrchestraFact,
+  CommandPlaneOrchestraFocus,
+  CommandPlaneOrchestraNode,
+  CommandPlaneOrchestraResponse,
+  CommandPlaneOrchestraSignal,
   CommandPlaneSwarmGap,
   CommandPlaneSwarmLane,
   CommandPlaneSwarmProof,
@@ -84,6 +91,9 @@ export const commandPlaneHelpError = signal<string | null>(null)
 export const commandPlaneSwarm = signal<CommandPlaneSwarmResponse | null>(null)
 export const commandPlaneSwarmLoading = signal(false)
 export const commandPlaneSwarmError = signal<string | null>(null)
+export const commandPlaneOrchestra = signal<CommandPlaneOrchestraResponse | null>(null)
+export const commandPlaneOrchestraLoading = signal(false)
+export const commandPlaneOrchestraError = signal<string | null>(null)
 export const commandPlaneChainSummary = signal<CommandPlaneChainSummary | null>(null)
 export const commandPlaneChainLoading = signal(false)
 export const commandPlaneChainError = signal<string | null>(null)
@@ -94,7 +104,7 @@ export const commandPlaneChainFocusOperationId = signal<string | null>(null)
 let activeChainRunRequestId: string | null = null
 
 function surfaceNeedsDetail(surface: CommandPlaneSurface): boolean {
-  return surface !== 'summary' && surface !== 'swarm' && surface !== 'warroom'
+  return surface !== 'summary' && surface !== 'swarm' && surface !== 'warroom' && surface !== 'orchestra'
 }
 
 function currentLocationParams(): URLSearchParams {
@@ -1330,6 +1340,184 @@ function normalizeSwarm(raw: unknown): CommandPlaneSwarmResponse {
   }
 }
 
+function normalizeOrchestraFact(raw: unknown): CommandPlaneOrchestraFact | null {
+  if (!isRecord(raw)) return null
+  const label = asString(raw.label)
+  const value = asString(raw.value)
+  if (!label || !value) return null
+  return { label, value }
+}
+
+function normalizeOrchestraNode(raw: unknown): CommandPlaneOrchestraNode | null {
+  if (!isRecord(raw)) return null
+  const id = asString(raw.id)
+  const kind = asString(raw.kind)
+  const label = asString(raw.label)
+  const tone = asString(raw.tone)
+  const provenance = asString(raw.provenance)
+  if (!id || !kind || !label || !tone || !provenance) return null
+  return {
+    id,
+    kind,
+    label,
+    subtitle: asString(raw.subtitle) ?? null,
+    status: asString(raw.status) ?? null,
+    tone,
+    pulse: asString(raw.pulse) ?? null,
+    provenance,
+    visual_class: asString(raw.visual_class) ?? undefined,
+    glyph: asString(raw.glyph) ?? undefined,
+    parent_id: asString(raw.parent_id) ?? null,
+    lane_id: asString(raw.lane_id) ?? null,
+    link_tab: asString(raw.link_tab) ?? null,
+    link_surface: asString(raw.link_surface) ?? null,
+    link_params: isRecord(raw.link_params)
+      ? Object.fromEntries(
+          Object.entries(raw.link_params)
+            .map(([key, value]) => {
+              const text = asString(value)
+              return text ? [key, text] : null
+            })
+            .filter((entry): entry is [string, string] => entry !== null),
+        )
+      : {},
+    facts: Array.isArray(raw.facts)
+      ? raw.facts
+          .map(normalizeOrchestraFact)
+          .filter((item): item is CommandPlaneOrchestraFact => item !== null)
+      : [],
+  }
+}
+
+function normalizeOrchestraEdge(raw: unknown): CommandPlaneOrchestraEdge | null {
+  if (!isRecord(raw)) return null
+  const id = asString(raw.id)
+  const source = asString(raw.source)
+  const target = asString(raw.target)
+  const kind = asString(raw.kind)
+  const tone = asString(raw.tone)
+  const provenance = asString(raw.provenance)
+  if (!id || !source || !target || !kind || !tone || !provenance) return null
+  return {
+    id,
+    source,
+    target,
+    kind,
+    label: asString(raw.label) ?? null,
+    tone,
+    provenance,
+    animated: asBoolean(raw.animated),
+  }
+}
+
+function normalizeOrchestraSignal(raw: unknown): CommandPlaneOrchestraSignal | null {
+  if (!isRecord(raw)) return null
+  const id = asString(raw.id)
+  const kind = asString(raw.kind)
+  const label = asString(raw.label)
+  const tone = asString(raw.tone)
+  const provenance = asString(raw.provenance)
+  if (!id || !kind || !label || !tone || !provenance) return null
+  return {
+    id,
+    kind,
+    label,
+    detail: asString(raw.detail) ?? null,
+    tone,
+    provenance,
+    source_id: asString(raw.source_id) ?? null,
+    target_id: asString(raw.target_id) ?? null,
+    suggested_surface: asString(raw.suggested_surface) ?? null,
+    suggested_params: isRecord(raw.suggested_params)
+      ? Object.fromEntries(
+          Object.entries(raw.suggested_params)
+            .map(([key, value]) => {
+              const text = asString(value)
+              return text ? [key, text] : null
+            })
+            .filter((entry): entry is [string, string] => entry !== null),
+        )
+      : {},
+  }
+}
+
+function normalizeOrchestraFocus(raw: unknown): CommandPlaneOrchestraFocus | null {
+  if (!isRecord(raw)) return null
+  const targetKind = asString(raw.target_kind)
+  const targetId = asString(raw.target_id)
+  const label = asString(raw.label)
+  const reason = asString(raw.reason)
+  if (!targetKind || !targetId || !label || !reason) return null
+  return {
+    target_kind: targetKind,
+    target_id: targetId,
+    label,
+    reason,
+    suggested_surface: asString(raw.suggested_surface) ?? null,
+    suggested_params: isRecord(raw.suggested_params)
+      ? Object.fromEntries(
+          Object.entries(raw.suggested_params)
+            .map(([key, value]) => {
+              const text = asString(value)
+              return text ? [key, text] : null
+            })
+            .filter((entry): entry is [string, string] => entry !== null),
+        )
+      : {},
+  }
+}
+
+function normalizeOrchestra(raw: unknown): CommandPlaneOrchestraResponse {
+  const root = isRecord(raw) ? raw : {}
+  const room = isRecord(root.room) ? root.room : {}
+  const summary = isRecord(root.summary) ? root.summary : undefined
+  return {
+    version: asString(root.version),
+    generated_at: asString(root.generated_at),
+    room: {
+      room_id: asString(room.room_id),
+      project: asString(room.project),
+      cluster: asString(room.cluster),
+      paused: asBoolean(room.paused),
+      pause_reason: asString(room.pause_reason) ?? null,
+      agent_count: asNumber(room.agent_count),
+      task_count: asNumber(room.task_count),
+      message_count: asNumber(room.message_count),
+    },
+    summary: summary
+      ? {
+          session_count: asNumber(summary.session_count),
+          operation_count: asNumber(summary.operation_count),
+          detachment_count: asNumber(summary.detachment_count),
+          lane_count: asNumber(summary.lane_count),
+          worker_count: asNumber(summary.worker_count),
+          keeper_count: asNumber(summary.keeper_count),
+          signal_count: asNumber(summary.signal_count),
+          alert_count: asNumber(summary.alert_count),
+        }
+      : undefined,
+    nodes: Array.isArray(root.nodes)
+      ? root.nodes
+          .map(normalizeOrchestraNode)
+          .filter((item): item is CommandPlaneOrchestraNode => item !== null)
+      : [],
+    edges: Array.isArray(root.edges)
+      ? root.edges
+          .map(normalizeOrchestraEdge)
+          .filter((item): item is CommandPlaneOrchestraEdge => item !== null)
+      : [],
+    signals: Array.isArray(root.signals)
+      ? root.signals
+          .map(normalizeOrchestraSignal)
+          .filter((item): item is CommandPlaneOrchestraSignal => item !== null)
+      : [],
+    focus: normalizeOrchestraFocus(root.focus),
+    swarm_status: normalizeSwarmStatus(root.swarm_status),
+    swarm_proof: normalizeSwarmProof(root.swarm_proof),
+    truth_notes: asStringArray(root.truth_notes),
+  }
+}
+
 export function setCommandPlaneSurface(surface: CommandPlaneSurface): void {
   commandPlaneSurface.value = surface
   if (surfaceNeedsDetail(surface)) {
@@ -1460,6 +1648,23 @@ export async function refreshCommandPlaneSwarm(
   }
 }
 
+export async function refreshCommandPlaneOrchestra(
+  runId = currentSwarmRunId(),
+  operationId = currentSwarmOperationId(),
+): Promise<void> {
+  commandPlaneOrchestraLoading.value = true
+  commandPlaneOrchestraError.value = null
+  try {
+    const raw = await fetchCommandPlaneOrchestra(runId, operationId)
+    commandPlaneOrchestra.value = normalizeOrchestra(raw)
+  } catch (err) {
+    commandPlaneOrchestraError.value =
+      err instanceof Error ? err.message : 'Failed to load orchestra map'
+  } finally {
+    commandPlaneOrchestraLoading.value = false
+  }
+}
+
 async function runAction(key: string, path: string, body: Record<string, unknown>): Promise<void> {
   commandPlaneActionBusy.value = key
   commandPlaneActionError.value = null
@@ -1470,6 +1675,7 @@ async function runAction(key: string, path: string, body: Record<string, unknown
       await refreshCommandPlaneSnapshot()
     }
     await refreshCommandPlaneSwarm()
+    await refreshCommandPlaneOrchestra()
     await refreshCommandPlaneChainSummary()
   } catch (err) {
     commandPlaneActionError.value =
@@ -1539,9 +1745,13 @@ registerCommandPlaneRefresh(() => {
   if (
     commandPlaneSurface.value === 'swarm'
     || commandPlaneSurface.value === 'warroom'
+    || commandPlaneSurface.value === 'orchestra'
     || commandPlaneSwarm.value !== null
   ) {
     void refreshCommandPlaneSwarm()
+  }
+  if (commandPlaneSurface.value === 'orchestra' || commandPlaneOrchestra.value !== null) {
+    void refreshCommandPlaneOrchestra()
   }
   if (commandPlaneSurface.value === 'warroom') {
     void refreshOperatorSnapshot()

--- a/dashboard/src/components/command/helpers.ts
+++ b/dashboard/src/components/command/helpers.ts
@@ -174,6 +174,7 @@ export const COMMAND_SURFACE_META: Array<{ id: CommandPlaneSurface; label: strin
   { id: 'warroom', label: '워룸', group: 'status' },
   { id: 'summary', label: '요약', group: 'status' },
   { id: 'topology', label: '토폴로지', group: 'status' },
+  { id: 'orchestra', label: '오케스트라', group: 'status' },
   { id: 'swarm', label: '스웜', group: 'status' },
   { id: 'operations', label: '작전', group: 'history' },
   { id: 'trace', label: '트레이스', group: 'history' },
@@ -192,6 +193,10 @@ export const COMMAND_SURFACE_GUIDE: Record<CommandPlaneSurface, { title: string;
   operations: {
     title: '현재 작전 상세',
     description: '활성 operation, detachment, dependency를 먼저 읽는 기본 진입 표면입니다.',
+  },
+  orchestra: {
+    title: '룸 오케스트라 맵',
+    description: 'room, session, lane, worker, keeper를 한 장의 작전판으로 읽는 시각화 표면입니다.',
   },
   swarm: {
     title: '스웜 실행 흐름',
@@ -244,10 +249,20 @@ function inheritedWorkflowRouteParams(): Record<string, string> {
 
 export function surfaceRouteParams(surface: CommandPlaneSurface): Record<string, string> {
   const inherited = inheritedWorkflowRouteParams()
+  const swarmRunId = dashboardSwarmRunId()
+  const swarmOperationId = dashboardSwarmOperationId()
   if (surface === 'operations') return inherited
   if (surface === 'chains') {
     const operationId = commandPlaneChainFocusOperationId.value
     return operationId ? { ...inherited, surface, operation: operationId } : { ...inherited, surface }
+  }
+  if (surface === 'swarm' || surface === 'warroom' || surface === 'orchestra') {
+    return {
+      ...inherited,
+      surface,
+      ...(swarmRunId ? { run_id: swarmRunId } : {}),
+      ...(swarmOperationId ? { operation_id: swarmOperationId } : {}),
+    }
   }
   return { ...inherited, surface }
 }
@@ -308,6 +323,11 @@ export function currentSurfaceRecommendation(surface: CommandPlaneSurface): {
       return {
         tool: swarm?.recommended_next_tool ?? summary?.swarm_status?.recommended_next_action?.tool ?? 'masc_observe_traces',
         reason: summary?.swarm_status?.recommended_next_action?.reason ?? 'lane 이동과 blocker를 보고 다음 probe 도구를 고릅니다.',
+      }
+    case 'orchestra':
+      return {
+        tool: 'masc_operator_snapshot',
+        reason: 'room, session, lane, worker, keeper를 한 장에서 훑은 뒤 drill-down 대상을 고릅니다.',
       }
     case 'chains':
       return {

--- a/dashboard/src/components/command/index.ts
+++ b/dashboard/src/components/command/index.ts
@@ -10,6 +10,7 @@ import {
   refreshCommandPlaneChainSummary,
   refreshCommandPlaneCurrentSurface,
   refreshCommandPlaneHelp,
+  refreshCommandPlaneOrchestra,
   refreshCommandPlaneSwarm,
   runCommandPlaneDispatchTick,
   setCommandPlaneSurface,
@@ -33,6 +34,7 @@ import {
 } from './helpers'
 import { CommandEntryStrip, CommandWorkflowBanner } from './summary-hero'
 import { DetailLoadingState, SummarySurface } from './guided-panel'
+import { OrchestraSurface } from './orchestra'
 import { WarRoomSurface } from './war-room'
 import { SwarmSurface } from './swarm'
 import { ChainsSurface, OperationsSurface } from './operations'
@@ -73,6 +75,9 @@ function SurfaceBody() {
   if (commandPlaneSurface.value === 'summary') {
     return html`<${SummarySurface} />`
   }
+  if (commandPlaneSurface.value === 'orchestra') {
+    return html`<${OrchestraSurface} />`
+  }
   if (commandPlaneSurface.value === 'swarm') {
     return html`<${SwarmSurface} />`
   }
@@ -102,6 +107,7 @@ export function Command() {
     void refreshCommandPlaneChainSummary()
     void refreshCommandPlaneHelp()
     void refreshCommandPlaneSwarm()
+    void refreshCommandPlaneOrchestra()
   }, [])
 
   useEffect(() => {
@@ -124,8 +130,11 @@ export function Command() {
     if (requestedOperation) {
       focusCommandPlaneChainOperation(requestedOperation)
     }
-    if (requestedSurface === 'swarm' || requestedSurface === 'warroom' || commandPlaneSurface.value === 'warroom') {
+    if (requestedSurface === 'swarm' || requestedSurface === 'warroom' || requestedSurface === 'orchestra' || commandPlaneSurface.value === 'warroom' || commandPlaneSurface.value === 'orchestra') {
       void refreshCommandPlaneSwarm()
+    }
+    if (requestedSurface === 'orchestra' || commandPlaneSurface.value === 'orchestra') {
+      void refreshCommandPlaneOrchestra()
     }
     if (requestedSurface === 'warroom' || commandPlaneSurface.value === 'warroom') {
       void refreshOperatorSnapshot()
@@ -151,8 +160,11 @@ export function Command() {
         refreshTimer = null
         void refreshCommandPlaneCurrentSurface()
         void refreshCommandPlaneChainSummary()
-        if (commandPlaneSurface.value === 'swarm' || commandPlaneSurface.value === 'warroom') {
+        if (commandPlaneSurface.value === 'swarm' || commandPlaneSurface.value === 'warroom' || commandPlaneSurface.value === 'orchestra') {
           void refreshCommandPlaneSwarm()
+        }
+        if (commandPlaneSurface.value === 'orchestra') {
+          void refreshCommandPlaneOrchestra()
         }
         if (commandPlaneSurface.value === 'warroom') {
           void refreshOperatorSnapshot()
@@ -185,9 +197,12 @@ export function Command() {
     const interval = window.setInterval(() => {
       if (document.visibilityState === 'hidden') return
       const surface = commandPlaneSurface.value
-      if (surface !== 'swarm' && surface !== 'warroom') return
+      if (surface !== 'swarm' && surface !== 'warroom' && surface !== 'orchestra') return
       void refreshCommandPlaneCurrentSurface()
       void refreshCommandPlaneSwarm()
+      if (surface === 'orchestra') {
+        void refreshCommandPlaneOrchestra()
+      }
       if (surface === 'warroom') {
         void refreshOperatorSnapshot()
       }

--- a/dashboard/src/components/command/orchestra.ts
+++ b/dashboard/src/components/command/orchestra.ts
@@ -1,0 +1,434 @@
+import { html } from 'htm/preact'
+import { signal } from '@preact/signals'
+import type {
+  CommandPlaneOrchestraEdge,
+  CommandPlaneOrchestraNode,
+  CommandPlaneOrchestraResponse,
+  CommandPlaneOrchestraSignal,
+  CommandPlaneSurface,
+} from '../../types'
+import {
+  commandPlaneOrchestra,
+  commandPlaneOrchestraError,
+  commandPlaneOrchestraLoading,
+  setCommandPlaneSurface,
+} from '../../command-store'
+import { navigate } from '../../router'
+import { PanelSemanticDetails } from '../common/semantic-layer'
+import {
+  relativeTime,
+  surfaceRouteParams,
+  toneClass,
+} from './helpers'
+
+const orchestraSelection = signal<string | null>(null)
+
+type Point = { x: number; y: number }
+
+const SVG_WIDTH = 1280
+const SVG_HEIGHT = 760
+
+function spreadX(count: number, min: number, max: number): number[] {
+  if (count <= 0) return []
+  if (count === 1) return [Math.round((min + max) / 2)]
+  const step = (max - min) / (count - 1)
+  return Array.from({ length: count }, (_, idx) => Math.round(min + idx * step))
+}
+
+function groupBy<T>(items: T[], getKey: (item: T) => string): Map<string, T[]> {
+  const out = new Map<string, T[]>()
+  for (const item of items) {
+    const key = getKey(item)
+    const bucket = out.get(key) ?? []
+    bucket.push(item)
+    out.set(key, bucket)
+  }
+  return out
+}
+
+function nodeMap(orchestra: CommandPlaneOrchestraResponse): Map<string, CommandPlaneOrchestraNode> {
+  return new Map(orchestra.nodes.map(node => [node.id, node]))
+}
+
+function layout(orchestra: CommandPlaneOrchestraResponse): Map<string, Point> {
+  const positions = new Map<string, Point>()
+  const nodes = orchestra.nodes
+  const roomNode = nodes.find(node => node.kind === 'room') ?? null
+  const sessions = nodes.filter(node => node.kind === 'session')
+  const operations = nodes.filter(node => node.kind === 'operation')
+  const detachments = nodes.filter(node => node.kind === 'detachment')
+  const lanes = nodes.filter(node => node.kind === 'lane')
+  const workers = nodes.filter(node => node.kind === 'worker')
+  const keepers = nodes.filter(node => node.kind === 'keeper')
+
+  if (roomNode) positions.set(roomNode.id, { x: 640, y: 96 })
+
+  spreadX(sessions.length, 170, 1110).forEach((x, idx) => {
+    const node = sessions[idx]
+    if (node) positions.set(node.id, { x, y: 220 })
+  })
+
+  spreadX(operations.length, 240, 1040).forEach((x, idx) => {
+    const node = operations[idx]
+    if (node) positions.set(node.id, { x, y: 330 })
+  })
+
+  spreadX(detachments.length, 300, 980).forEach((x, idx) => {
+    const node = detachments[idx]
+    if (node) positions.set(node.id, { x, y: 420 })
+  })
+
+  spreadX(lanes.length, 170, 1110).forEach((x, idx) => {
+    const node = lanes[idx]
+    if (node) positions.set(node.id, { x, y: 530 })
+  })
+
+  const laneCenters = new Map(
+    lanes
+      .map(node => {
+        const point = positions.get(node.id)
+        return point ? [node.id, point.x] as const : null
+      })
+      .filter((entry): entry is readonly [string, number] => entry !== null),
+  )
+
+  const workerBuckets = groupBy(workers, worker => {
+    if (worker.lane_id) return `lane:${worker.lane_id}`
+    if (worker.parent_id) return worker.parent_id
+    return 'free'
+  })
+
+  let freeWorkerRow = 0
+  for (const [bucketId, bucket] of workerBuckets) {
+    let xCenter = laneCenters.get(bucketId)
+    if (xCenter == null) {
+      const parent = positions.get(bucketId)
+      xCenter = parent?.x
+    }
+    if (xCenter == null) {
+      xCenter = 180 + (freeWorkerRow % 5) * 200
+      freeWorkerRow += 1
+    }
+    const xs = spreadX(bucket.length, xCenter - 90, xCenter + 90)
+    xs.forEach((x, idx) => {
+      const worker = bucket[idx]
+      if (!worker) return
+      const row = idx > 5 ? Math.floor(idx / 6) : 0
+      positions.set(worker.id, {
+        x,
+        y: 635 + row * 62,
+      })
+    })
+  }
+
+  const keeperXs = keepers.length > 3 ? [1120, 1180] : [1140]
+  keepers.forEach((keeper, idx) => {
+    const col = idx % keeperXs.length
+    const row = Math.floor(idx / keeperXs.length)
+    positions.set(keeper.id, {
+      x: keeperXs[col] ?? 1140,
+      y: 190 + row * 108,
+    })
+  })
+
+  return positions
+}
+
+function edgePath(source: Point, target: Point): string {
+  const midX = (source.x + target.x) / 2
+  const curve = target.y >= source.y ? 32 : -32
+  return `M ${source.x} ${source.y} C ${midX} ${source.y + curve}, ${midX} ${target.y - curve}, ${target.x} ${target.y}`
+}
+
+function jumpTo(tab: string, surface: CommandPlaneSurface | string | null | undefined, params: Record<string, string>): void {
+  if (tab === 'command') {
+    if (surface) {
+      setCommandPlaneSurface(surface as CommandPlaneSurface)
+      navigate('command', { ...surfaceRouteParams(surface as CommandPlaneSurface), ...params })
+      return
+    }
+    navigate('command', params)
+    return
+  }
+  if (tab === 'intervene') {
+    navigate('intervene', params)
+    return
+  }
+  navigate('command', params)
+}
+
+function nodeSize(node: CommandPlaneOrchestraNode): { width: number; height: number; radius: number } {
+  switch (node.kind) {
+    case 'room':
+      return { width: 150, height: 150, radius: 74 }
+    case 'worker':
+      return { width: 78, height: 42, radius: 22 }
+    case 'lane':
+      return { width: 170, height: 54, radius: 16 }
+    case 'keeper':
+      return { width: 120, height: 56, radius: 24 }
+    default:
+      return { width: 188, height: 64, radius: 18 }
+  }
+}
+
+function OrchestraSignals({
+  orchestra,
+  roomPoint,
+  onSelect,
+}: {
+  orchestra: CommandPlaneOrchestraResponse
+  roomPoint: Point | null
+  onSelect: (id: string) => void
+}) {
+  if (!roomPoint || orchestra.signals.length === 0) return null
+  const radius = 108
+  return html`
+    ${orchestra.signals.slice(0, 6).map((signalNode, idx) => {
+      const angle = (-120 + idx * 38) * (Math.PI / 180)
+      const x = Math.round(roomPoint.x + Math.cos(angle) * radius)
+      const y = Math.round(roomPoint.y + Math.sin(angle) * radius)
+      return html`
+        <g
+          key=${signalNode.id}
+          class=${`orchestra-signal-node ${toneClass(signalNode.tone)}`}
+          onClick=${() => onSelect(signalNode.id)}
+        >
+          <line x1=${roomPoint.x} y1=${roomPoint.y} x2=${x} y2=${y} class="orchestra-signal-link" />
+          <circle cx=${x} cy=${y} r="16" class="orchestra-signal-dot" />
+          <text x=${x} y=${y + 4} text-anchor="middle" class="orchestra-signal-glyph">!</text>
+        </g>
+      `
+    })}
+  `
+}
+
+function OrchestraEdgeLayer({
+  edges,
+  positions,
+  selectedId,
+}: {
+  edges: CommandPlaneOrchestraEdge[]
+  positions: Map<string, Point>
+  selectedId: string | null
+}) {
+  return html`
+    ${edges.map(edge => {
+      const source = positions.get(edge.source)
+      const target = positions.get(edge.target)
+      if (!source || !target) return null
+      const active = selectedId != null && (edge.source === selectedId || edge.target === selectedId)
+      return html`
+        <path
+          key=${edge.id}
+          d=${edgePath(source, target)}
+          class=${`orchestra-edge ${toneClass(edge.tone)} ${edge.animated ? 'animated' : ''} ${active ? 'active' : ''}`}
+        />
+      `
+    })}
+  `
+}
+
+function OrchestraNodeLayer({
+  orchestra,
+  positions,
+  selectedId,
+  onSelect,
+}: {
+  orchestra: CommandPlaneOrchestraResponse
+  positions: Map<string, Point>
+  selectedId: string | null
+  onSelect: (id: string) => void
+}) {
+  const focusId = orchestra.focus?.target_kind === 'node' ? orchestra.focus.target_id : null
+  return html`
+    ${orchestra.nodes.map(node => {
+      const point = positions.get(node.id)
+      if (!point) return null
+      const size = nodeSize(node)
+      const selected = node.id === selectedId
+      const focused = node.id === focusId
+      if (node.kind === 'room') {
+        return html`
+          <g
+            key=${node.id}
+            class=${`orchestra-node room ${toneClass(node.tone)} ${selected ? 'selected' : ''} ${focused ? 'focused' : ''}`}
+            onClick=${() => onSelect(node.id)}
+          >
+            <circle cx=${point.x} cy=${point.y} r=${size.radius} class="orchestra-room-ring outer" />
+            <circle cx=${point.x} cy=${point.y} r=${size.radius - 16} class="orchestra-room-ring inner" />
+            <text x=${point.x} y=${point.y - 10} text-anchor="middle" class="orchestra-room-glyph">${node.glyph ?? '◎'}</text>
+            <text x=${point.x} y=${point.y + 22} text-anchor="middle" class="orchestra-room-label">${node.label}</text>
+          </g>
+        `
+      }
+      const x = point.x - size.width / 2
+      const y = point.y - size.height / 2
+      return html`
+        <g
+          key=${node.id}
+          class=${`orchestra-node ${node.kind} ${toneClass(node.tone)} ${selected ? 'selected' : ''} ${focused ? 'focused' : ''}`}
+          onClick=${() => onSelect(node.id)}
+        >
+          <rect x=${x} y=${y} width=${size.width} height=${size.height} rx=${size.radius} class="orchestra-node-body" />
+          <text x=${x + 16} y=${y + 24} class="orchestra-node-glyph">${node.glyph ?? '•'}</text>
+          <text x=${x + 38} y=${y + 24} class="orchestra-node-label">${node.label}</text>
+          ${node.subtitle ? html`<text x=${x + 38} y=${y + 42} class="orchestra-node-subtitle">${node.subtitle}</text>` : null}
+          ${node.status ? html`<text x=${x + size.width - 10} y=${y + 18} text-anchor="end" class="orchestra-node-status">${node.status}</text>` : null}
+        </g>
+      `
+    })}
+  `
+}
+
+function selectedTarget(
+  orchestra: CommandPlaneOrchestraResponse,
+): { type: 'node'; value: CommandPlaneOrchestraNode } | { type: 'signal'; value: CommandPlaneOrchestraSignal } | null {
+  const current = orchestraSelection.value
+  if (current) {
+    const foundNode = orchestra.nodes.find(node => node.id === current)
+    if (foundNode) return { type: 'node', value: foundNode }
+    const foundSignal = orchestra.signals.find(signalNode => signalNode.id === current)
+    if (foundSignal) return { type: 'signal', value: foundSignal }
+  }
+  if (orchestra.focus?.target_kind === 'node') {
+    const found = orchestra.nodes.find(node => node.id === orchestra.focus?.target_id)
+    if (found) return { type: 'node', value: found }
+  }
+  if (orchestra.focus?.target_kind === 'signal') {
+    const found = orchestra.signals.find(signalNode => signalNode.id === orchestra.focus?.target_id)
+    if (found) return { type: 'signal', value: found }
+  }
+  const firstNode = orchestra.nodes[0]
+  return firstNode ? { type: 'node', value: firstNode } : null
+}
+
+function OrchestraDetailDrawer({ orchestra }: { orchestra: CommandPlaneOrchestraResponse }) {
+  const selected = selectedTarget(orchestra)
+  if (!selected) return html`<aside class="orchestra-drawer card"><div class="empty-state">선택 가능한 대상이 아직 없습니다.</div></aside>`
+  if (selected.type === 'signal') {
+    const signalNode = selected.value
+    return html`
+      <aside class="orchestra-drawer card ${toneClass(signalNode.tone)}">
+        <div class="card-title-row">
+          <div class="card-title">${signalNode.label}</div>
+          <span class="command-chip ${toneClass(signalNode.tone)}">${signalNode.kind}</span>
+        </div>
+        <p>${signalNode.detail ?? '세부 설명이 없습니다.'}</p>
+        ${signalNode.suggested_surface
+          ? html`
+              <div class="command-action-row">
+                <button
+                  class="control-btn"
+                  onClick=${() => jumpTo('command', signalNode.suggested_surface, signalNode.suggested_params ?? {})}
+                >
+                  ${signalNode.suggested_surface} 열기
+                </button>
+              </div>
+            `
+          : null}
+      </aside>
+    `
+  }
+
+  const node = selected.value
+  const relatedSignals = orchestra.signals.filter(signalNode => signalNode.source_id === node.id || signalNode.target_id === node.id)
+  const relatedEdges = orchestra.edges.filter(edge => edge.source === node.id || edge.target === node.id)
+  return html`
+    <aside class="orchestra-drawer card ${toneClass(node.tone)}">
+      <div class="card-title-row">
+        <div class="card-title">${node.label}</div>
+        <span class="command-chip ${toneClass(node.tone)}">${node.kind}</span>
+      </div>
+      ${node.subtitle ? html`<p class="command-card-sub">${node.subtitle}</p>` : null}
+      <div class="orchestra-fact-list">
+        ${node.facts.map(factRow => html`
+          <div class="orchestra-fact-row">
+            <span>${factRow.label}</span>
+            <strong>${factRow.value}</strong>
+          </div>
+        `)}
+      </div>
+      ${relatedSignals.length > 0 ? html`
+        <div class="command-tag-row">
+          ${relatedSignals.map(signalNode => html`<span class="command-chip ${toneClass(signalNode.tone)}">${signalNode.label}</span>`)}
+        </div>
+      ` : null}
+      <div class="command-card-sub">연결 ${relatedEdges.length}개 · provenance ${node.provenance}</div>
+      ${(node.link_tab && (node.link_surface || Object.keys(node.link_params ?? {}).length > 0))
+        ? html`
+            <div class="command-action-row">
+              <button
+                class="control-btn"
+                onClick=${() => jumpTo(node.link_tab ?? 'command', node.link_surface, node.link_params ?? {})}
+              >
+                열기
+              </button>
+            </div>
+          `
+        : null}
+    </aside>
+  `
+}
+
+export function OrchestraSurface() {
+  const orchestra = commandPlaneOrchestra.value
+  if (commandPlaneOrchestraLoading.value && !orchestra) {
+    return html`<section class="card command-section"><div class="empty-state">오케스트라 맵 불러오는 중…</div></section>`
+  }
+  if (commandPlaneOrchestraError.value) {
+    return html`<section class="card command-section"><div class="empty-state error">${commandPlaneOrchestraError.value}</div></section>`
+  }
+  if (!orchestra) {
+    return html`<section class="card command-section"><div class="empty-state">오케스트라 맵 데이터가 아직 없습니다.</div></section>`
+  }
+
+  const positions = layout(orchestra)
+  const selected = selectedTarget(orchestra)
+  const selectedId = selected?.value.id ?? null
+  const roomPoint = orchestra.nodes.find(node => node.kind === 'room')
+    ? positions.get(orchestra.nodes.find(node => node.kind === 'room')!.id) ?? null
+    : null
+
+  return html`
+    <section class="card command-section orchestra-surface">
+      <div class="card-title-row">
+        <div class="card-title">오케스트라</div>
+        <${PanelSemanticDetails} panelId="command.orchestra" compact=${true} />
+      </div>
+      <p class="command-card-sub">room 전체를 한 장의 작전판으로 읽는 시각화입니다. 클릭하면 drill-down 대상과 관련 신호를 바로 볼 수 있습니다.</p>
+
+      <div class="orchestra-shell">
+        <div class="orchestra-canvas-wrap">
+          <svg class="orchestra-canvas" viewBox=${`0 0 ${SVG_WIDTH} ${SVG_HEIGHT}`}>
+            <defs>
+              <pattern id="orchestra-grid" width="32" height="32" patternUnits="userSpaceOnUse">
+                <path d="M 32 0 L 0 0 0 32" fill="none" class="orchestra-grid-line"></path>
+              </pattern>
+            </defs>
+            <rect width=${SVG_WIDTH} height=${SVG_HEIGHT} fill="url(#orchestra-grid)" class="orchestra-grid"></rect>
+            <${OrchestraEdgeLayer} edges=${orchestra.edges} positions=${positions} selectedId=${selectedId} />
+            <${OrchestraSignals} orchestra=${orchestra} roomPoint=${roomPoint} onSelect=${(id: string) => { orchestraSelection.value = id }} />
+            <${OrchestraNodeLayer}
+              orchestra=${orchestra}
+              positions=${positions}
+              selectedId=${selectedId}
+              onSelect=${(id: string) => { orchestraSelection.value = id }}
+            />
+          </svg>
+          <div class="orchestra-summary-strip">
+            <span class="command-chip">sessions ${orchestra.summary?.session_count ?? 0}</span>
+            <span class="command-chip">workers ${orchestra.summary?.worker_count ?? 0}</span>
+            <span class="command-chip">keepers ${orchestra.summary?.keeper_count ?? 0}</span>
+            <span class="command-chip ${toneClass(orchestra.signals.some(signalNode => signalNode.tone === 'bad') ? 'bad' : orchestra.signals.length > 0 ? 'warn' : 'ok')}">
+              signals ${orchestra.summary?.signal_count ?? orchestra.signals.length}
+            </span>
+            <span class="command-chip">${relativeTime(orchestra.generated_at)}</span>
+          </div>
+        </div>
+
+        <${OrchestraDetailDrawer} orchestra=${orchestra} />
+      </div>
+    </section>
+  `
+}

--- a/dashboard/src/styles/command.css
+++ b/dashboard/src/styles/command.css
@@ -439,6 +439,240 @@
   grid-template-columns: minmax(0, 1fr);
 }
 
+.orchestra-surface {
+  overflow: hidden;
+}
+
+.orchestra-shell {
+  display: grid;
+  grid-template-columns: minmax(0, 1.35fr) minmax(320px, 0.65fr);
+  gap: 16px;
+  margin-top: 16px;
+}
+
+.orchestra-canvas-wrap {
+  position: relative;
+  border-radius: 18px;
+  overflow: hidden;
+  border: 1px solid rgba(125,211,252,0.12);
+  background:
+    radial-gradient(circle at top, rgba(34,211,238,0.12), transparent 42%),
+    radial-gradient(circle at 20% 80%, rgba(96,165,250,0.08), transparent 35%),
+    linear-gradient(180deg, rgba(15,23,42,0.98), rgba(2,6,23,0.98));
+}
+
+.orchestra-canvas-wrap::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(180deg, rgba(255,255,255,0.02), transparent 18%, transparent 82%, rgba(255,255,255,0.02));
+  pointer-events: none;
+}
+
+.orchestra-canvas {
+  display: block;
+  width: 100%;
+  height: auto;
+  min-height: 720px;
+}
+
+.orchestra-grid {
+  fill: rgba(255,255,255,0.015);
+}
+
+.orchestra-grid-line {
+  stroke: rgba(125,211,252,0.06);
+  stroke-width: 1;
+}
+
+.orchestra-edge {
+  fill: none;
+  stroke: rgba(148,163,184,0.28);
+  stroke-width: 2;
+  transition: stroke-width 0.2s ease, opacity 0.2s ease;
+  opacity: 0.62;
+}
+
+.orchestra-edge.ok { stroke: rgba(74,222,128,0.35); }
+.orchestra-edge.warn { stroke: rgba(251,191,36,0.42); }
+.orchestra-edge.bad { stroke: rgba(248,113,113,0.5); }
+.orchestra-edge.active {
+  stroke-width: 3;
+  opacity: 0.96;
+}
+
+.orchestra-edge.animated {
+  stroke-dasharray: 10 10;
+  animation: orchestraFlow 3.2s linear infinite;
+}
+
+.orchestra-node {
+  cursor: pointer;
+}
+
+.orchestra-node-body,
+.orchestra-room-ring {
+  fill: rgba(15,23,42,0.88);
+  stroke: rgba(148,163,184,0.26);
+  stroke-width: 1.5;
+}
+
+.orchestra-node.ok .orchestra-node-body,
+.orchestra-node.ok .orchestra-room-ring { stroke: rgba(74,222,128,0.45); }
+.orchestra-node.warn .orchestra-node-body,
+.orchestra-node.warn .orchestra-room-ring { stroke: rgba(251,191,36,0.48); }
+.orchestra-node.bad .orchestra-node-body,
+.orchestra-node.bad .orchestra-room-ring { stroke: rgba(248,113,113,0.56); }
+
+.orchestra-node.focused .orchestra-node-body,
+.orchestra-node.focused .orchestra-room-ring,
+.orchestra-node.selected .orchestra-node-body,
+.orchestra-node.selected .orchestra-room-ring {
+  stroke-width: 2.6;
+  filter: drop-shadow(0 0 10px rgba(34,211,238,0.25));
+}
+
+.orchestra-room-ring.outer {
+  fill: rgba(15,23,42,0.9);
+}
+
+.orchestra-room-ring.inner {
+  fill: rgba(14,116,144,0.12);
+}
+
+.orchestra-room-glyph {
+  font-size: 30px;
+  fill: #67e8f9;
+  font-weight: 700;
+}
+
+.orchestra-room-label,
+.orchestra-node-label {
+  fill: #f8fafc;
+  font-size: 13px;
+  font-weight: 600;
+}
+
+.orchestra-node-subtitle,
+.orchestra-node-status {
+  fill: rgba(226,232,240,0.62);
+  font-size: 10px;
+}
+
+.orchestra-node-glyph {
+  fill: #7dd3fc;
+  font-size: 15px;
+}
+
+.orchestra-node.worker .orchestra-node-body,
+.orchestra-node.worker-ghost .orchestra-node-body {
+  rx: 20px;
+}
+
+.orchestra-node.worker-ghost .orchestra-node-body {
+  fill: rgba(51,65,85,0.7);
+  stroke-dasharray: 5 4;
+}
+
+.orchestra-node.session .orchestra-node-body {
+  fill: rgba(15,23,42,0.88);
+}
+
+.orchestra-node.lane .orchestra-node-body {
+  fill: rgba(8,47,73,0.72);
+}
+
+.orchestra-node.keeper .orchestra-node-body {
+  fill: rgba(48,16,96,0.34);
+}
+
+.orchestra-signal-link {
+  stroke: rgba(251,191,36,0.2);
+  stroke-dasharray: 5 5;
+}
+
+.orchestra-signal-dot {
+  fill: rgba(15,23,42,0.94);
+  stroke: rgba(251,191,36,0.42);
+  stroke-width: 2;
+}
+
+.orchestra-signal-node.bad .orchestra-signal-dot {
+  stroke: rgba(248,113,113,0.6);
+  animation: warnBlink 1s ease-in-out infinite;
+}
+
+.orchestra-signal-node.warn .orchestra-signal-dot {
+  animation: orchestraPulse 1.4s ease-in-out infinite;
+}
+
+.orchestra-signal-glyph {
+  fill: #f8fafc;
+  font-size: 11px;
+  font-weight: 700;
+}
+
+.orchestra-summary-strip {
+  position: absolute;
+  left: 14px;
+  right: 14px;
+  bottom: 12px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  pointer-events: none;
+}
+
+.orchestra-summary-strip .command-chip {
+  pointer-events: auto;
+  background: rgba(15,23,42,0.8);
+}
+
+.orchestra-drawer {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  min-height: 720px;
+}
+
+.orchestra-fact-list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.orchestra-fact-row {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 8px 10px;
+  border-radius: 10px;
+  background: rgba(255,255,255,0.03);
+  border: 1px solid rgba(255,255,255,0.06);
+}
+
+.orchestra-fact-row span {
+  color: rgba(226,232,240,0.64);
+  font-size: 0.82rem;
+}
+
+.orchestra-fact-row strong {
+  color: #f8fafc;
+  font-size: 0.84rem;
+  text-align: right;
+}
+
+@keyframes orchestraFlow {
+  to {
+    stroke-dashoffset: -40;
+  }
+}
+
+@keyframes orchestraPulse {
+  0%, 100% { transform: scale(1); opacity: 0.92; }
+  50% { transform: scale(1.06); opacity: 1; }
+}
+
 /* ── SwarmHealthBar ────────────────────────────── */
 .swarm-health-bar {
   display: flex;
@@ -1248,4 +1482,3 @@
   overflow-wrap: anywhere;
   word-break: break-word;
 }
-

--- a/dashboard/src/types.ts
+++ b/dashboard/src/types.ts
@@ -2278,9 +2278,99 @@ export interface CommandPlaneSwarmResponse {
   truth_notes: string[]
 }
 
+export interface CommandPlaneOrchestraFact {
+  label: string
+  value: string
+}
+
+export interface CommandPlaneOrchestraNode {
+  id: string
+  kind: 'room' | 'session' | 'operation' | 'detachment' | 'lane' | 'worker' | 'keeper' | string
+  label: string
+  subtitle?: string | null
+  status?: string | null
+  tone: 'ok' | 'warn' | 'bad' | string
+  pulse?: string | null
+  provenance: 'truth' | 'derived' | 'fallback' | string
+  visual_class?: string
+  glyph?: string
+  parent_id?: string | null
+  lane_id?: string | null
+  link_tab?: 'command' | 'intervene' | string | null
+  link_surface?: CommandPlaneSurface | string | null
+  link_params?: Record<string, string>
+  facts: CommandPlaneOrchestraFact[]
+}
+
+export interface CommandPlaneOrchestraEdge {
+  id: string
+  source: string
+  target: string
+  kind: string
+  label?: string | null
+  tone: 'ok' | 'warn' | 'bad' | string
+  provenance: 'truth' | 'derived' | 'fallback' | string
+  animated?: boolean
+}
+
+export interface CommandPlaneOrchestraSignal {
+  id: string
+  kind: string
+  label: string
+  detail?: string | null
+  tone: 'ok' | 'warn' | 'bad' | string
+  provenance: 'truth' | 'derived' | 'fallback' | string
+  source_id?: string | null
+  target_id?: string | null
+  suggested_surface?: CommandPlaneSurface | string | null
+  suggested_params?: Record<string, string>
+}
+
+export interface CommandPlaneOrchestraFocus {
+  target_kind: 'node' | 'signal' | string
+  target_id: string
+  label: string
+  reason: string
+  suggested_surface?: CommandPlaneSurface | string | null
+  suggested_params?: Record<string, string>
+}
+
+export interface CommandPlaneOrchestraResponse {
+  version?: string
+  generated_at?: string
+  room: {
+    room_id?: string
+    project?: string
+    cluster?: string
+    paused?: boolean
+    pause_reason?: string | null
+    agent_count?: number
+    task_count?: number
+    message_count?: number
+  }
+  summary?: {
+    session_count?: number
+    operation_count?: number
+    detachment_count?: number
+    lane_count?: number
+    worker_count?: number
+    keeper_count?: number
+    signal_count?: number
+    alert_count?: number
+  }
+  nodes: CommandPlaneOrchestraNode[]
+  edges: CommandPlaneOrchestraEdge[]
+  signals: CommandPlaneOrchestraSignal[]
+  focus?: CommandPlaneOrchestraFocus | null
+  swarm_status?: CommandPlaneSwarmStatus
+  swarm_proof?: CommandPlaneSwarmProof
+  truth_notes?: string[]
+}
+
 export type CommandPlaneSurface =
   | 'warroom'
   | 'summary'
+  | 'orchestra'
   | 'swarm'
   | 'operations'
   | 'topology'

--- a/dashboard/src/workflow-context.ts
+++ b/dashboard/src/workflow-context.ts
@@ -332,7 +332,7 @@ export function commandSurfaceForContext(context: DashboardWorkflowContext): str
     return 'swarm'
   }
   if (context.focus_kind === 'operation' || context.target_type === 'operation') return 'operations'
-  return context.target_type === 'room' ? 'summary' : 'swarm'
+  return context.target_type === 'room' ? 'orchestra' : 'swarm'
 }
 
 export function workflowCommandParams(context: DashboardWorkflowContext): Record<string, string> {
@@ -404,6 +404,8 @@ export function workflowCommandSurfaceLabel(surface?: string | null): string {
       return '워룸'
     case 'summary':
       return '요약'
+    case 'orchestra':
+      return '오케스트라'
     case 'swarm':
       return '스웜'
     case 'chains':

--- a/lib/command_plane_orchestra.ml
+++ b/lib/command_plane_orchestra.ml
@@ -1,0 +1,806 @@
+module U = Yojson.Safe.Util
+
+let trim_to_option = Dashboard_utils.trim_to_option
+
+let first_some left right =
+  match left with
+  | Some _ -> left
+  | None -> right
+
+let string_opt json key =
+  match U.member key json with
+  | `String value -> trim_to_option value
+  | _ -> None
+
+let int_opt json key =
+  match U.member key json with
+  | `Int value -> Some value
+  | `Intlit value -> (try Some (int_of_string value) with _ -> None)
+  | `Float value -> Some (int_of_float value)
+  | _ -> None
+
+let float_opt json key =
+  match U.member key json with
+  | `Float value -> Some value
+  | `Int value -> Some (float_of_int value)
+  | `Intlit value -> (try Some (float_of_string value) with _ -> None)
+  | _ -> None
+
+let bool_opt json key =
+  match U.member key json with
+  | `Bool value -> Some value
+  | _ -> None
+
+let list_member json key =
+  match U.member key json with
+  | `List rows -> rows
+  | _ -> []
+
+let assoc_or_empty json key =
+  match U.member key json with
+  | `Assoc _ as value -> value
+  | _ -> `Assoc []
+
+let json_string_option = function
+  | Some value -> `String value
+  | None -> `Null
+
+let json_int_option = function
+  | Some value -> `Int value
+  | None -> `Null
+
+let json_float_option = function
+  | Some value -> `Float value
+  | None -> `Null
+
+let json_params fields = `Assoc fields
+
+let fact label value =
+  `Assoc [ ("label", `String label); ("value", `String value) ]
+
+let node ?subtitle ?status ?pulse ?parent_id ?lane_id ?link_tab ?link_surface
+    ?(link_params = `Assoc []) ~id ~kind ~label ~tone ~provenance ~visual_class
+    ~glyph ~facts () =
+  `Assoc
+    [
+      ("id", `String id);
+      ("kind", `String kind);
+      ("label", `String label);
+      ("subtitle", json_string_option subtitle);
+      ("status", json_string_option status);
+      ("tone", `String tone);
+      ("pulse", json_string_option pulse);
+      ("provenance", `String provenance);
+      ("visual_class", `String visual_class);
+      ("glyph", `String glyph);
+      ("parent_id", json_string_option parent_id);
+      ("lane_id", json_string_option lane_id);
+      ("link_tab", json_string_option link_tab);
+      ("link_surface", json_string_option link_surface);
+      ("link_params", link_params);
+      ("facts", `List facts);
+    ]
+
+let edge ?label ?(tone = "ok") ?(provenance = "derived") ?(animated = false)
+    ~id ~source ~target ~kind () =
+  `Assoc
+    [
+      ("id", `String id);
+      ("source", `String source);
+      ("target", `String target);
+      ("kind", `String kind);
+      ("label", json_string_option label);
+      ("tone", `String tone);
+      ("provenance", `String provenance);
+      ("animated", `Bool animated);
+    ]
+
+let signal ?detail ?source_id ?target_id ?suggested_surface
+    ?(suggested_params = `Assoc []) ?(provenance = "derived") ~id ~kind ~label
+    ~tone () =
+  `Assoc
+    [
+      ("id", `String id);
+      ("kind", `String kind);
+      ("label", `String label);
+      ("detail", json_string_option detail);
+      ("tone", `String tone);
+      ("provenance", `String provenance);
+      ("source_id", json_string_option source_id);
+      ("target_id", json_string_option target_id);
+      ("suggested_surface", json_string_option suggested_surface);
+      ("suggested_params", suggested_params);
+    ]
+
+let status_tone = function
+  | "failed" | "error" | "cancelled" | "offline" | "stalled" | "bad" -> "bad"
+  | "paused" | "interrupted" | "warn" | "waiting" | "degraded" -> "warn"
+  | _ -> "ok"
+
+let pulse_of_tone = function
+  | "bad" -> Some "blink"
+  | "warn" -> Some "pulse"
+  | _ -> Some "steady"
+
+let room_json config =
+  if not (Room.is_initialized config) then
+    `Assoc
+      [
+        ("room_id", `String "default");
+        ("project", `String (Filename.basename config.base_path));
+        ("cluster", `String (Option.value ~default:"default" (Sys.getenv_opt "MASC_CLUSTER_NAME")));
+        ("paused", `Bool false);
+        ("pause_reason", `Null);
+        ("agent_count", `Int 0);
+        ("task_count", `Int 0);
+        ("message_count", `Int 0);
+      ]
+  else
+    let state = Room.read_state config in
+    let agents = Room.get_agents_raw config in
+    let tasks = Room.get_tasks_raw config in
+    `Assoc
+      [
+        ("room_id", `String (Option.value ~default:"default" (Room.read_current_room config)));
+        ("project", `String state.project);
+        ("cluster", `String (Option.value ~default:"default" (Sys.getenv_opt "MASC_CLUSTER_NAME")));
+        ("paused", `Bool state.paused);
+        ("pause_reason", json_string_option state.pause_reason);
+        ("agent_count", `Int (List.length agents));
+        ("task_count", `Int (List.length tasks));
+        ("message_count", `Int state.message_seq);
+      ]
+
+let room_node room_json session_count operation_count worker_count keeper_count
+    alert_count pending_confirm_count =
+  let room_id = string_opt room_json "room_id" |> Option.value ~default:"default" in
+  let paused = bool_opt room_json "paused" |> Option.value ~default:false in
+  let tone = if paused || pending_confirm_count > 0 || alert_count > 0 then "warn" else "ok" in
+  node ~id:("room:" ^ room_id) ~kind:"room" ~label:room_id
+    ?subtitle:(string_opt room_json "project")
+    ~tone ~provenance:"truth" ~visual_class:"room-core" ~glyph:"◎"
+    ?pulse:(pulse_of_tone tone)
+    ~facts:
+      [
+        fact "project"
+          (string_opt room_json "project" |> Option.value ~default:"n/a");
+        fact "cluster"
+          (string_opt room_json "cluster" |> Option.value ~default:"default");
+        fact "sessions" (string_of_int session_count);
+        fact "operations" (string_of_int operation_count);
+        fact "workers" (string_of_int worker_count);
+        fact "keepers" (string_of_int keeper_count);
+        fact "alerts" (string_of_int alert_count);
+        fact "pending confirms" (string_of_int pending_confirm_count);
+      ]
+    ~link_tab:"command" ~link_surface:"summary" ()
+
+let session_tone (session : Team_session_types.session) status_json =
+  let status = Team_session_types.status_to_string session.status in
+  match status with
+  | "failed" | "cancelled" -> "bad"
+  | "paused" | "interrupted" -> "warn"
+  | _ ->
+      let team_health = assoc_or_empty status_json "team_health" in
+      let health_status = string_opt team_health "status" |> Option.value ~default:"ok" in
+      if session.min_agents_violation_streak > 0 || session.policy_violations <> [] then "warn"
+      else status_tone health_status
+
+let session_node config (session : Team_session_types.session) =
+  let status_json = Team_session_engine_eio.session_status_json config session in
+  let summary = assoc_or_empty status_json "summary" in
+  let command_plane = assoc_or_empty status_json "command_plane" in
+  let tone = session_tone session status_json in
+  let progress =
+    float_opt summary "progress_pct"
+    |> Option.map (fun value -> Printf.sprintf "%.0f%%" value)
+    |> Option.value ~default:"n/a"
+  in
+  let active_agents =
+    int_opt summary "active_agent_count"
+    |> Option.map string_of_int
+    |> Option.value ~default:(string_of_int (List.length session.agent_names))
+  in
+  node ~id:("session:" ^ session.session_id) ~kind:"session"
+    ~label:session.session_id ~subtitle:session.goal
+    ~status:(Team_session_types.status_to_string session.status)
+    ~tone ~provenance:"truth" ~visual_class:"session-island" ~glyph:"◈"
+    ?pulse:(pulse_of_tone tone)
+    ~facts:
+      [
+        fact "goal" session.goal;
+        fact "progress" progress;
+        fact "agents" active_agents;
+        fact "mode"
+          (Team_session_types.orchestration_mode_to_string
+             session.orchestration_mode);
+        fact "scale"
+          (Team_session_types.scale_profile_to_string session.scale_profile);
+        fact "operation"
+          (string_opt command_plane "operation_id" |> Option.value ~default:"none");
+      ]
+    ~link_tab:"intervene"
+    ~link_params:
+      (json_params
+         [
+           ("target_type", `String "team_session");
+           ("target_id", `String session.session_id);
+         ])
+    ()
+
+let operation_node op_json =
+  let operation_id = string_opt op_json "operation_id" |> Option.value ~default:"operation" in
+  let status = string_opt op_json "status" |> Option.value ~default:"unknown" in
+  let tone = status_tone status in
+  node ~id:("operation:" ^ operation_id) ~kind:"operation"
+    ~label:operation_id
+    ?subtitle:(string_opt op_json "objective")
+    ~status ~tone ~provenance:"truth" ~visual_class:"operation-core" ~glyph:"▣"
+    ?pulse:(pulse_of_tone tone)
+    ~facts:
+      [
+        fact "unit"
+          (string_opt op_json "assigned_unit_id" |> Option.value ~default:"n/a");
+        fact "autonomy"
+          (string_opt op_json "autonomy_level" |> Option.value ~default:"n/a");
+        fact "source"
+          (string_opt op_json "source" |> Option.value ~default:"managed");
+        fact "trace"
+          (string_opt op_json "trace_id" |> Option.value ~default:"n/a");
+      ]
+    ~link_tab:"command" ~link_surface:"operations"
+    ~link_params:(json_params [ ("operation_id", `String operation_id) ]) ()
+
+let detachment_node det_json =
+  let detachment_id = string_opt det_json "detachment_id" |> Option.value ~default:"detachment" in
+  let status = string_opt det_json "status" |> Option.value ~default:"unknown" in
+  let tone = status_tone status in
+  let roster_count = list_member det_json "roster" |> List.length in
+  node ~id:("detachment:" ^ detachment_id) ~kind:"detachment"
+    ~label:detachment_id
+    ?subtitle:(string_opt det_json "runtime_kind")
+    ~status ~tone ~provenance:"truth" ~visual_class:"detachment-shell" ~glyph:"◇"
+    ?pulse:(pulse_of_tone tone)
+    ~facts:
+      [
+        fact "operation"
+          (string_opt det_json "operation_id" |> Option.value ~default:"n/a");
+        fact "session"
+          (string_opt det_json "session_id" |> Option.value ~default:"none");
+        fact "runtime"
+          (string_opt det_json "runtime_kind" |> Option.value ~default:"n/a");
+        fact "roster" (string_of_int roster_count);
+      ]
+    ~link_tab:"command" ~link_surface:"operations"
+    ~link_params:(json_params [ ("detachment_id", `String detachment_id) ]) ()
+
+let lane_group_tone workers =
+  let joined = ref false in
+  let stale = ref false in
+  let live = ref false in
+  List.iter
+    (fun worker_json ->
+      if bool_opt worker_json "joined" |> Option.value ~default:false then joined := true;
+      if bool_opt worker_json "live_presence" |> Option.value ~default:false then live := true;
+      if not (bool_opt worker_json "heartbeat_fresh" |> Option.value ~default:false)
+         && not (bool_opt worker_json "completed" |> Option.value ~default:false)
+      then stale := true)
+    workers;
+  if !stale then "warn" else if !joined || !live then "ok" else "warn"
+
+let lane_group_node lane_name workers =
+  let tone = lane_group_tone workers in
+  let completed =
+    List.fold_left
+      (fun acc worker_json ->
+        if bool_opt worker_json "completed" |> Option.value ~default:false then acc + 1
+        else acc)
+      0 workers
+  in
+  node ~id:("lane:" ^ lane_name) ~kind:"lane" ~label:lane_name
+    ~subtitle:(Printf.sprintf "%d worker(s)" (List.length workers))
+    ~status:"live" ~tone ~provenance:"truth" ~visual_class:"worker-lane"
+    ~glyph:"═"
+    ?pulse:(Some (if tone = "warn" then "pulse" else "flow"))
+    ~facts:
+      [
+        fact "workers" (string_of_int (List.length workers));
+        fact "completed" (string_of_int completed);
+      ]
+    ~link_tab:"command" ~link_surface:"swarm" ()
+
+let control_lane_node lane_json =
+  let lane_id = string_opt lane_json "lane_id" |> Option.value ~default:"lane" in
+  let label = string_opt lane_json "label" |> Option.value ~default:lane_id in
+  let motion_state = string_opt lane_json "motion_state" |> Option.value ~default:"waiting" in
+  let tone =
+    if motion_state = "stalled" then "bad"
+    else if motion_state = "waiting" then "warn"
+    else "ok"
+  in
+  let counts = assoc_or_empty lane_json "counts" in
+  node ~id:("lane:" ^ lane_id) ~kind:"lane" ~label
+    ?subtitle:(string_opt lane_json "phase")
+    ~status:motion_state ~tone ~provenance:"derived"
+    ~visual_class:"control-lane" ~glyph:"═"
+    ?pulse:(Some
+              (match motion_state with
+              | "moving" -> "flow"
+              | "stalled" -> "blink"
+              | _ -> "pulse"))
+    ~facts:
+      [
+        fact "step"
+          (string_opt lane_json "current_step" |> Option.value ~default:"n/a");
+        fact "source"
+          (string_opt lane_json "source_of_truth" |> Option.value ~default:"derived");
+        fact "workers"
+          (int_opt counts "workers" |> Option.value ~default:0 |> string_of_int);
+        fact "operations"
+          (int_opt counts "operations" |> Option.value ~default:0 |> string_of_int);
+      ]
+    ~link_tab:"command" ~link_surface:"swarm" ()
+
+let actual_worker_node worker_json =
+  let name = string_opt worker_json "name" |> Option.value ~default:"worker" in
+  let status = string_opt worker_json "status" |> Option.value ~default:"unknown" in
+  let tone =
+    if not (bool_opt worker_json "joined" |> Option.value ~default:false) then "bad"
+    else if not (bool_opt worker_json "heartbeat_fresh" |> Option.value ~default:false)
+            && not (bool_opt worker_json "completed" |> Option.value ~default:false)
+    then "warn"
+    else "ok"
+  in
+  let lane = string_opt worker_json "lane" in
+  node ~id:("worker:" ^ name) ~kind:"worker" ~label:name
+    ?subtitle:(string_opt worker_json "role")
+    ~status ~tone ~provenance:"truth" ~visual_class:"worker-unit" ~glyph:"●"
+    ?pulse:(Some
+              (match tone with
+              | "bad" -> "blink"
+              | "warn" -> "pulse"
+              | _ -> "steady"))
+    ?lane_id:lane
+    ~facts:
+      [
+        fact "lane" (Option.value ~default:"n/a" lane);
+        fact "task"
+          (string_opt worker_json "current_task"
+           |> first_some (string_opt worker_json "bound_task_title")
+           |> first_some (string_opt worker_json "bound_task_id")
+           |> Option.value ~default:"none");
+        fact "heartbeat"
+          (match float_opt worker_json "heartbeat_age_sec" with
+          | Some value -> Printf.sprintf "%.0fs" value
+          | None ->
+              if bool_opt worker_json "heartbeat_fresh" |> Option.value ~default:false then
+                "fresh"
+              else
+                "n/a");
+        fact "markers"
+          (String.concat "/"
+             [
+               (if bool_opt worker_json "claim_marker_seen" |> Option.value ~default:false then "claim" else "no-claim");
+               (if bool_opt worker_json "done_marker_seen" |> Option.value ~default:false then "done" else "no-done");
+               (if bool_opt worker_json "final_marker_seen" |> Option.value ~default:false then "final" else "no-final");
+             ]);
+      ]
+    ~link_tab:"command" ~link_surface:"swarm" ()
+
+let ghost_worker_id session_id label =
+  let digest = Digestif.SHA1.(to_hex (digest_string label)) in
+  "ghost:" ^ session_id ^ ":" ^ String.sub digest 0 (min 40 (String.length digest))
+
+let ghost_worker_node ~session_id ~label ~subtitle ?lane_id () =
+  node ~id:(ghost_worker_id session_id label) ~kind:"worker" ~label
+    ~subtitle ~status:"planned" ~tone:"warn" ~provenance:"derived"
+    ~visual_class:"worker-ghost" ~glyph:"◌" ?lane_id
+    ~parent_id:("session:" ^ session_id)
+    ?pulse:(Some "pulse")
+    ~facts:[ fact "session" session_id; fact "state" "planned" ]
+    ~link_tab:"intervene"
+    ~link_params:
+      (json_params
+         [ ("target_type", `String "team_session"); ("target_id", `String session_id) ])
+    ()
+
+let keeper_node row =
+  let name = string_opt row "name" |> Option.value ~default:"keeper" in
+  let runtime_class = string_opt row "runtime_class" in
+  let status = string_opt row "status" |> Option.value ~default:"unknown" in
+  let tone =
+    if status = "offline" || status = "inactive" || status = "error" then "bad"
+    else
+      match float_opt row "context_ratio" with
+      | Some ratio when ratio >= 0.8 -> "warn"
+      | _ -> status_tone status
+  in
+  node ~id:("keeper:" ^ name) ~kind:"keeper" ~label:name
+    ?subtitle:runtime_class ~status ~tone ~provenance:"truth"
+    ~visual_class:"continuity-keeper" ~glyph:"✦"
+    ?pulse:(pulse_of_tone tone)
+    ~facts:
+      [
+        fact "agent"
+          (string_opt row "agent_name" |> Option.value ~default:"n/a");
+        fact "autonomy"
+          (string_opt row "autonomy_level" |> Option.value ~default:"n/a");
+        fact "context"
+          (match float_opt row "context_ratio" with
+          | Some value -> Printf.sprintf "%.0f%%" (value *. 100.)
+          | None -> "n/a");
+      ]
+    ~link_tab:"intervene"
+    ~link_params:
+      (json_params [ ("target_type", `String "keeper"); ("target_id", `String name) ])
+    ()
+
+let signal_for_pending_confirms summary room_id =
+  let total = int_opt summary "total_count" |> Option.value ~default:0 in
+  if total <= 0 then
+    None
+  else
+    let visible = int_opt summary "visible_count" |> Option.value ~default:total in
+    let hidden = int_opt summary "hidden_count" |> Option.value ~default:0 in
+    let detail =
+      if hidden > 0 then
+        Printf.sprintf "%d visible / %d total pending confirms" visible total
+      else
+        Printf.sprintf "%d pending confirms require operator action" total
+    in
+    Some
+      (signal ~id:"signal:pending-confirms" ~kind:"pending_confirm"
+         ~label:"승인 대기" ~detail ~tone:"warn" ~source_id:room_id
+         ~suggested_surface:"intervene" ())
+
+let signal_for_runtime_blocker swarm_json room_id =
+  let provider = assoc_or_empty swarm_json "provider" in
+  match string_opt provider "runtime_blocker" with
+  | Some blocker ->
+      Some
+        (signal ~id:"signal:runtime-blocker" ~kind:"runtime_blocker"
+           ~label:"런타임 막힘" ~detail:blocker ~tone:"bad" ~source_id:room_id
+           ~suggested_surface:"swarm" ())
+  | None -> None
+
+let signal_for_hot_proof summary_json room_id =
+  let proof = assoc_or_empty summary_json "swarm_proof" in
+  match string_opt proof "status" with
+  | Some "present" when bool_opt proof "pass" = Some true -> None
+  | Some status ->
+      let tone =
+        match bool_opt proof "pass" with
+        | Some false -> "bad"
+        | _ -> if status = "missing" then "warn" else "warn"
+      in
+      let detail =
+        string_opt proof "missing_reason"
+        |> Option.value ~default:
+             (Printf.sprintf "proof status=%s" status)
+      in
+      Some
+        (signal ~id:"signal:hot-proof" ~kind:"hot_proof" ~label:"Hot proof"
+           ~detail ~tone ~source_id:room_id ~suggested_surface:"swarm" ())
+  | None -> None
+
+let signals_for_alerts alerts room_id =
+  alerts
+  |> List.filter_map (fun row ->
+         let severity = string_opt row "severity" |> Option.value ~default:"warn" in
+         let title = string_opt row "title" |> Option.value ~default:"Alert" in
+         let detail = string_opt row "detail" in
+         let alert_id = string_opt row "alert_id" |> Option.value ~default:title in
+         Some
+           (signal ~id:("signal:alert:" ^ alert_id) ~kind:"alert" ~label:title
+              ?detail ~tone:(status_tone severity) ~source_id:room_id
+              ~suggested_surface:"alerts" ()))
+
+let string_assoc_list json =
+  match json with
+  | `Assoc fields -> fields
+  | _ -> []
+
+let json_assoc_of_fields fields = `Assoc fields
+
+let by_id rows key_field =
+  rows
+  |> List.filter_map (fun row ->
+         match string_opt row key_field with
+         | Some key -> Some (key, row)
+         | None -> None)
+
+let json ?run_id ?operation_id (ctx : _ Operator_control.context) =
+  let config = ctx.config in
+  let actor = ctx.agent_name in
+  let room = room_json config in
+  let room_id = "room:" ^ (string_opt room "room_id" |> Option.value ~default:"default") in
+  let operator_snapshot = Operator_control.snapshot_json ~actor ctx in
+  let pending_summary =
+    assoc_or_empty operator_snapshot "pending_confirm_summary"
+  in
+  let keepers =
+    list_member (assoc_or_empty operator_snapshot "keepers") "items"
+    @ list_member (assoc_or_empty operator_snapshot "persistent_agents") "items"
+  in
+  let sessions = Team_session_store.list_sessions config in
+  let summary_json = Command_plane_v2.summary_json config in
+  let alerts_json = Command_plane_v2.list_alerts_json config in
+  let alerts = list_member alerts_json "alerts" in
+  let swarm_status_json =
+    if Room.is_initialized config then
+      Swarm_status.build_json config
+    else
+      Swarm_status.empty_json
+  in
+  let swarm_json =
+    if Room.is_initialized config then
+      Command_plane_v2.swarm_live_json config ?run_id ?operation_id ()
+    else
+      `Assoc []
+  in
+  let operations_json = Command_plane_v2.operation_status_json config () in
+  let operation_rows =
+    list_member operations_json "operations"
+    |> List.filter_map (fun row ->
+           match U.member "operation" row with
+           | `Assoc _ as op -> Some op
+           | _ -> None)
+  in
+  let active_operation_rows =
+    operation_rows
+    |> List.filter (fun op ->
+           let status = string_opt op "status" |> Option.value ~default:"active" in
+           not (List.mem status [ "completed"; "cancelled"; "failed" ]))
+  in
+  let detachments_json = Command_plane_v2.list_detachments_json config in
+  let detachment_rows =
+    list_member detachments_json "detachments"
+    |> List.filter_map (fun row ->
+           match U.member "detachment" row with
+           | `Assoc _ as det -> Some det
+           | _ -> None)
+  in
+  let active_detachment_rows =
+    detachment_rows
+    |> List.filter (fun det ->
+           let status = string_opt det "status" |> Option.value ~default:"active" in
+           not (List.mem status [ "completed"; "cancelled"; "failed"; "stopped" ]))
+  in
+  let swarm_workers = list_member swarm_json "workers" in
+  let actual_worker_names =
+    swarm_workers
+    |> List.filter_map (fun row -> string_opt row "name")
+  in
+  let actual_worker_name_set = actual_worker_names |> List.sort_uniq String.compare in
+  let worker_lanes =
+    swarm_workers
+    |> List.fold_left
+         (fun acc row ->
+           let lane = string_opt row "lane" |> Option.value ~default:"swarm" in
+           let existing = List.assoc_opt lane acc |> Option.value ~default:[] in
+           (lane, row :: existing) :: List.remove_assoc lane acc)
+         []
+    |> List.map (fun (lane, rows) -> (lane, List.rev rows))
+    |> List.sort (fun (left, _) (right, _) -> String.compare left right)
+  in
+  let session_nodes = List.map (session_node config) sessions in
+  let operation_nodes = List.map operation_node active_operation_rows in
+  let detachment_nodes = List.map detachment_node active_detachment_rows in
+  let lane_nodes =
+    if worker_lanes <> [] then
+      List.map (fun (lane_name, rows) -> lane_group_node lane_name rows) worker_lanes
+    else
+      list_member swarm_status_json "lanes"
+      |> List.filter (fun row -> bool_opt row "present" |> Option.value ~default:false)
+      |> List.map control_lane_node
+  in
+  let actual_worker_nodes = List.map actual_worker_node swarm_workers in
+  let ghost_worker_nodes =
+    sessions
+    |> List.concat_map (fun (session : Team_session_types.session) ->
+           let planned =
+             if session.planned_workers <> [] then
+               session.planned_workers
+               |> List.map (fun (worker : Team_session_types.planned_worker) ->
+                      let label =
+                        match worker.runtime_actor, worker.spawn_role with
+                        | Some actor, _ when String.trim actor <> "" -> String.trim actor
+                        | _, Some role when String.trim role <> "" -> String.trim role
+                        | _ -> worker.spawn_agent
+                      in
+                      ( label,
+                        Option.value ~default:"planned" worker.spawn_role,
+                        worker.lane_id ) )
+             else
+               session.agent_names
+               |> List.map (fun name -> (name, "participant", None))
+           in
+           planned
+           |> List.filter (fun (label, _, _) -> not (List.mem label actual_worker_name_set))
+           |> List.map (fun (label, subtitle, lane_id) ->
+                  ghost_worker_node ~session_id:session.session_id ~label
+                    ~subtitle ?lane_id ()))
+  in
+  let keeper_nodes = List.map keeper_node keepers in
+  let nodes =
+    room_node room (List.length sessions) (List.length active_operation_rows)
+      (List.length actual_worker_nodes + List.length ghost_worker_nodes)
+      (List.length keeper_nodes) (List.length alerts)
+      (int_opt pending_summary "total_count" |> Option.value ~default:0)
+    :: session_nodes @ operation_nodes @ detachment_nodes @ lane_nodes
+       @ actual_worker_nodes @ ghost_worker_nodes @ keeper_nodes
+  in
+  let operation_rows_by_id = by_id active_operation_rows "operation_id" in
+  let detachment_rows_by_id = by_id active_detachment_rows "detachment_id" in
+  let edges =
+    (sessions
+    |> List.map (fun (session : Team_session_types.session) ->
+           edge ~id:("edge:room-session:" ^ session.session_id) ~source:room_id
+             ~target:("session:" ^ session.session_id) ~kind:"contains"
+             ~label:"session" ~provenance:"truth" ())
+    )
+    @ (sessions
+      |> List.filter_map (fun (session : Team_session_types.session) ->
+             match session.operation_id with
+             | Some operation_id
+               when List.mem_assoc operation_id operation_rows_by_id ->
+                 Some
+                   (edge
+                      ~id:("edge:session-operation:" ^ session.session_id ^ ":" ^ operation_id)
+                      ~source:("session:" ^ session.session_id)
+                      ~target:("operation:" ^ operation_id) ~kind:"attached"
+                      ~label:"operation" ~provenance:"truth" ())
+             | _ -> None))
+    @ (active_detachment_rows
+      |> List.filter_map (fun det ->
+             match string_opt det "operation_id" with
+             | Some operation_id
+               when List.mem_assoc operation_id operation_rows_by_id ->
+                 let detachment_id =
+                   string_opt det "detachment_id" |> Option.value ~default:"detachment"
+                 in
+                 Some
+                   (edge
+                      ~id:("edge:operation-detachment:" ^ operation_id ^ ":" ^ detachment_id)
+                      ~source:("operation:" ^ operation_id)
+                      ~target:("detachment:" ^ detachment_id) ~kind:"materializes"
+                      ~label:"detachment" ~provenance:"truth" ())
+             | _ -> None))
+    @ (if worker_lanes <> [] then
+         let lane_parent =
+           match string_opt (assoc_or_empty swarm_json "detachment") "detachment_id" with
+           | Some detachment_id when List.mem_assoc detachment_id detachment_rows_by_id ->
+               "detachment:" ^ detachment_id
+           | _ -> (
+               match string_opt (assoc_or_empty swarm_json "operation") "operation_id" with
+               | Some operation_id when List.mem_assoc operation_id operation_rows_by_id ->
+                   "operation:" ^ operation_id
+               | _ -> room_id)
+         in
+         (worker_lanes
+         |> List.map (fun (lane_name, _rows) ->
+                edge ~id:("edge:parent-lane:" ^ lane_name) ~source:lane_parent
+                  ~target:("lane:" ^ lane_name) ~kind:"routes"
+                  ~label:"lane" ~tone:"ok" ~animated:true ~provenance:"truth"
+                  ()))
+         @ (worker_lanes
+           |> List.concat_map (fun (lane_name, rows) ->
+                  rows
+                  |> List.filter_map (fun row ->
+                         match string_opt row "name" with
+                         | Some name ->
+                             Some
+                               (edge
+                                  ~id:("edge:lane-worker:" ^ lane_name ^ ":" ^ name)
+                                  ~source:("lane:" ^ lane_name)
+                                  ~target:("worker:" ^ name) ~kind:"feeds"
+                                  ~label:"worker" ~animated:true
+                                  ~provenance:"truth" ())
+                         | None -> None)))
+       else
+         [])
+    @ (ghost_worker_nodes
+      |> List.filter_map (fun node_json ->
+             match string_opt node_json "id", string_opt node_json "parent_id" with
+             | Some worker_id, Some parent_id ->
+                 Some
+                   (edge ~id:("edge:session-ghost:" ^ worker_id) ~source:parent_id
+                      ~target:worker_id ~kind:"planned" ~label:"planned worker"
+                      ~tone:"warn" ~animated:false ~provenance:"derived" ())
+             | _ -> None))
+    @ (keeper_nodes
+      |> List.filter_map (fun keeper_json ->
+             match string_opt keeper_json "id" with
+             | Some keeper_id ->
+                 Some
+                   (edge ~id:("edge:room-keeper:" ^ keeper_id) ~source:room_id
+                      ~target:keeper_id ~kind:"continuity" ~label:"keeper"
+                      ~provenance:"truth" ())
+             | None -> None))
+  in
+  let signals =
+    List.filter_map Fun.id
+      [
+        signal_for_pending_confirms pending_summary room_id;
+        signal_for_runtime_blocker swarm_json room_id;
+        signal_for_hot_proof summary_json room_id;
+      ]
+    @ signals_for_alerts alerts room_id
+  in
+  let focus =
+    match List.find_opt (fun signal_json -> string_opt signal_json "tone" = Some "bad") signals with
+    | Some signal_json ->
+        `Assoc
+          [
+            ("target_kind", `String "signal");
+            ( "target_id",
+              `String
+                (string_opt signal_json "id"
+                |> Option.value ~default:"signal:unknown") );
+            ( "label",
+              `String
+                (string_opt signal_json "label"
+                |> Option.value ~default:"Signal") );
+            ( "reason",
+              `String
+                (string_opt signal_json "detail"
+                |> Option.value ~default:"Critical orchestra signal") );
+            ( "suggested_surface",
+              json_string_option (string_opt signal_json "suggested_surface") );
+            ("suggested_params", assoc_or_empty signal_json "suggested_params");
+          ]
+    | None -> (
+        match
+          List.find_opt
+            (fun node_json ->
+              string_opt node_json "kind" = Some "session"
+              && string_opt node_json "tone" <> Some "ok")
+            nodes
+        with
+        | Some node_json ->
+            `Assoc
+              [
+                ("target_kind", `String "node");
+                ("target_id", `String (string_opt node_json "id" |> Option.value ~default:room_id));
+                ("label", `String (string_opt node_json "label" |> Option.value ~default:"session"));
+                ("reason", `String "A session needs supervision or is not fully healthy.");
+                ("suggested_surface", `String "intervene");
+                ("suggested_params", assoc_or_empty node_json "link_params");
+              ]
+        | None ->
+            `Assoc
+              [
+                ("target_kind", `String "node");
+                ("target_id", `String room_id);
+                ("label", `String (string_opt room "room_id" |> Option.value ~default:"default"));
+                ("reason", `String "Room-wide view is healthy enough; start from the command overview.");
+                ("suggested_surface", `String "summary");
+                ("suggested_params", `Assoc []);
+              ])
+  in
+  `Assoc
+    [
+      ("version", `String "orchestra.v1");
+      ("generated_at", `String (Types.now_iso ()));
+      ("room", room);
+      ( "summary",
+        `Assoc
+          [
+            ("session_count", `Int (List.length sessions));
+            ("operation_count", `Int (List.length active_operation_rows));
+            ("detachment_count", `Int (List.length active_detachment_rows));
+            ("lane_count", `Int (List.length lane_nodes));
+            ( "worker_count",
+              `Int (List.length actual_worker_nodes + List.length ghost_worker_nodes) );
+            ("keeper_count", `Int (List.length keeper_nodes));
+            ("signal_count", `Int (List.length signals));
+            ("alert_count", `Int (List.length alerts));
+          ] );
+      ("nodes", `List nodes);
+      ("edges", `List edges);
+      ("signals", `List signals);
+      ("focus", focus);
+      ("swarm_status", swarm_status_json);
+      ("swarm_proof", assoc_or_empty summary_json "swarm_proof");
+      ("truth_notes", `List [ `String "room-wide orchestra map is composed from command-plane truth, swarm live state, and operator read models."; `String "provenance marks whether a node or signal is truth, derived, or fallback."; ]);
+    ]

--- a/lib/dashboard_semantics.ml
+++ b/lib/dashboard_semantics.ml
@@ -329,6 +329,13 @@ let json () =
                       ~bad_smell:"The system explains failure but leaves the operator directionless."
                       ~next_action:"Follow the recommended tool unless a stronger blocker is visible."
                   ];
+                panel ~id:"command.orchestra" ~title:"Orchestra Map"
+                  ~purpose:"Shows the full room as a single tactical map across sessions, lanes, workers, keepers, and hot signals."
+                  ~problem_solved:"Prevents operators from having to mentally merge swarm, war-room, intervene, and continuity views."
+                  ~when_active:"Orchestra surface."
+                  ~agent_role:"Agents should start here for room-wide orientation, then drill down into swarm, war-room, or intervene."
+                  ~ecosystem_function:"Creates a room-scale visual control room over orchestration state."
+                  [];
                 panel ~id:"command.operations" ~title:"Operations / Detachments"
                   ~purpose:"Shows managed intent and materialized execution bodies together."
                   ~problem_solved:"Prevents confusion between assigned work and instantiated runtime work."

--- a/lib/dune
+++ b/lib/dune
@@ -28,6 +28,7 @@
    checkpoint_types
    common
    command_plane_v2
+   command_plane_orchestra
    cp_types
    cp_paths
    cp_serde

--- a/lib/masc_mcp.ml
+++ b/lib/masc_mcp.ml
@@ -14,6 +14,7 @@ module Response = Response
 module Error = Error
 module Validation = Validation
 module Command_plane_v2 = Command_plane_v2
+module Command_plane_orchestra = Command_plane_orchestra
 module Cp_search_fabric = Cp_search_fabric
 module Config = Config
 module Env_config = Env_config

--- a/lib/server_command_plane_http.ml
+++ b/lib/server_command_plane_http.ml
@@ -124,6 +124,22 @@ let command_plane_swarm_http_json ~deps ~state request =
   Command_plane_v2.swarm_live_json state.Mcp_server.room_config ?run_id
     ?operation_id ()
 
+let command_plane_orchestra_http_json ~deps ~state request =
+  let actor = command_plane_actor deps request in
+  let run_id = deps.query_param request "run_id" in
+  let operation_id = deps.query_param request "operation_id" in
+  let ctx : _ Operator_control.context =
+    {
+      config = state.Mcp_server.room_config;
+      agent_name = actor;
+      sw = deps.get_switch ();
+      clock = deps.get_clock ();
+      proc_mgr = state.Mcp_server.proc_mgr;
+      mcp_session_id = deps.get_session_id_any request;
+    }
+  in
+  Command_plane_orchestra.json ?run_id ?operation_id ctx
+
 let command_plane_unit_define_http_json ~deps ~state request ~args =
   Command_plane_v2.unit_update_json state.Mcp_server.room_config
     ~actor:(command_plane_actor deps request) args


### PR DESCRIPTION
## Summary
- add a room-wide `orchestra` command-plane surface for visual swarm/session/worker/keeper monitoring
- expose a new `/api/v1/command-plane/orchestra` read model for the dashboard
- keep existing `swarm` and `warroom` surfaces intact while adding a new overview-first visualizer

## Testing
- dune build --root .
- file-scoped TypeScript validation for changed command/dashboard files

## Notes
- dedicated orchestra smoke test is not included in this slice because the initial Eio/Alcotest version hung and needs separate follow-up
