### PR TITLE
fix(keeper): parameterize direct mention observation

### DIFF
--- a/lib/keeper_execution.ml
+++ b/lib/keeper_execution.ml
@@ -1323,17 +1323,7 @@ let ensure_keeper_room_presence config (meta : keeper_meta) : keeper_meta =
   { meta with joined_room_ids = List.rev successful_rooms }
 
 let exact_direct_mention_present ~(targets : string list) (content : string) : bool =
-  let escaped_targets = targets |> List.map Str.quote |> List.filter (fun s -> String.trim s <> "") in
-  List.exists
-    (fun target ->
-      let pattern =
-        Printf.sprintf "\\(^\\|[^@A-Za-z0-9_-]\\)@%s\\([^A-Za-z0-9_-]\\|$\\)" target
-      in
-      try
-        ignore (Str.search_forward (Str.regexp_case_fold pattern) content 0);
-        true
-      with Not_found -> false)
-    escaped_targets
+  Mention.any_mentioned ~targets content
 
 let persona_summary_to_json (persona : persona_summary) : Yojson.Safe.t =
   `Assoc

--- a/lib/keeper_memory.ml
+++ b/lib/keeper_memory.ml
@@ -177,6 +177,9 @@ let keeper_policy_observation_of_room_message
     ~(room_id : string)
     (msg : Types.message) : keeper_policy_observation =
   let now_ts = Time_compat.now () in
+  let mention_targets =
+    if meta.mention_targets <> [] then meta.mention_targets else [ meta.name ]
+  in
   let last_turn_ago_s =
     if meta.last_turn_ts <= 0.0 then 0.0 else max 0.0 (now_ts -. meta.last_turn_ts)
   in
@@ -185,7 +188,7 @@ let keeper_policy_observation_of_room_message
     room_id = Some room_id;
     from_agent = msg.from_agent;
     message = msg.content;
-    direct_mention = true;
+    direct_mention = Mention.any_mentioned ~targets:mention_targets msg.content;
     has_question = observation_has_question msg.content;
     message_chars = String.length msg.content;
     total_turns = meta.total_turns;

--- a/lib/mention.ml
+++ b/lib/mention.ml
@@ -97,6 +97,25 @@ let resolve_targets mode ~available_agents =
       available_agents
       |> List.filter (fun name -> agent_type_of_mention name = agent_type)
 
+let is_mentioned target content =
+  let target = String.trim target in
+  if target = "" then
+    false
+  else
+    let pattern =
+      Printf.sprintf "\\(^\\|[^@A-Za-z0-9_-]\\)@%s\\([^A-Za-z0-9_-]\\|$\\)"
+        (Str.quote target)
+    in
+    try
+      ignore (Str.search_forward (Str.regexp_case_fold pattern) content 0);
+      true
+    with Not_found -> false
+
+let any_mentioned ~targets content =
+  targets
+  |> List.filter (fun target -> String.trim target <> "")
+  |> List.exists (fun target -> is_mentioned target content)
+
 (** Agent types that can be auto-spawned by Auto-Responder *)
 let spawnable_agents = ["gemini"; "codex"; "claude"; "llama"; "glm"]
 

--- a/lib/mention.mli
+++ b/lib/mention.mli
@@ -32,6 +32,12 @@ val extract : string -> string option
 val resolve_targets : mode -> available_agents:string list -> string list
 (** Get target agents based on mode and available agents *)
 
+val is_mentioned : string -> string -> bool
+(** Check whether content contains an exact direct mention for a target *)
+
+val any_mentioned : targets:string list -> string -> bool
+(** Check whether content contains an exact direct mention for any target *)
+
 val spawnable_agents : string list
 (** List of agent types that can be auto-spawned *)
 

--- a/test/dune
+++ b/test/dune
@@ -24,6 +24,7 @@
         test_swarm test_heartbeat_qw test_sse_qw test_agent_health
         test_post_verifier test_post_verifier_llm test_mdal
         test_swarm_checkpoint test_swarm_goal_loop test_mdal_swarm
+        test_keeper_memory
         test_tool_tier)
  (modules test_room test_types test_checkpoint test_auth test_http_negotiation
           test_sse test_encryption test_backend test_cancellation test_graphql_api
@@ -35,6 +36,7 @@
           test_swarm test_heartbeat_qw test_sse_qw test_agent_health
           test_post_verifier test_post_verifier_llm test_mdal
           test_swarm_checkpoint test_swarm_goal_loop test_mdal_swarm
+          test_keeper_memory
           test_tool_tier)
  (libraries masc_mcp alcotest str yojson mirage-crypto
             mirage-crypto-rng mirage-crypto-rng.unix cohttp cstruct unix))

--- a/test/test_keeper_memory.ml
+++ b/test/test_keeper_memory.ml
@@ -1,0 +1,70 @@
+open Alcotest
+
+module Mention = Masc_mcp.Mention
+module Keeper_memory = Masc_mcp.Keeper_memory
+module Keeper_types = Masc_mcp.Keeper_types
+module Types = Masc_mcp.Types
+
+let keeper_meta ~name ~mention_targets =
+  let json =
+    `Assoc
+      [
+        ("name", `String name);
+        ("trace_id", `String "trace-1");
+        ("goal", `String "keep continuity");
+        ("models", `List [ `String "custom:test-model" ]);
+        ("active_model", `String "custom:test-model");
+        ("mention_targets", `List (List.map (fun target -> `String target) mention_targets));
+      ]
+  in
+  match Keeper_types.meta_of_json json with
+  | Ok meta -> meta
+  | Error err -> fail ("failed to build keeper meta: " ^ err)
+
+let room_message content =
+  {
+    Types.seq = 1;
+    from_agent = "tester";
+    msg_type = "broadcast";
+    content;
+    mention = None;
+    timestamp = "2026-03-12T00:00:00Z";
+  }
+
+let test_any_mentioned_exact_target () =
+  check bool "exact direct mention" true
+    (Mention.any_mentioned ~targets:[ "sangsu" ] "hello @sangsu, are you there?")
+
+let test_any_mentioned_ambient_message () =
+  check bool "ambient message not a direct mention" false
+    (Mention.any_mentioned ~targets:[ "sangsu" ] "hello everyone, just chatting")
+
+let test_keeper_policy_observation_direct_mention () =
+  let meta = keeper_meta ~name:"sangsu" ~mention_targets:[ "sangsu"; "director" ] in
+  let obs =
+    Keeper_memory.keeper_policy_observation_of_room_message
+      ~meta ~room_id:"default" (room_message "@director, what do you think?")
+  in
+  check bool "keeper observation uses mention targets" true obs.direct_mention
+
+let test_keeper_policy_observation_non_mention () =
+  let meta = keeper_meta ~name:"sangsu" ~mention_targets:[ "sangsu"; "director" ] in
+  let obs =
+    Keeper_memory.keeper_policy_observation_of_room_message
+      ~meta ~room_id:"default" (room_message "ambient room chatter")
+  in
+  check bool "keeper observation no longer hardcodes direct mention" false obs.direct_mention
+
+let () =
+  run "Keeper_memory"
+    [
+      ( "mention",
+        [
+          test_case "any_mentioned exact target" `Quick test_any_mentioned_exact_target;
+          test_case "any_mentioned ambient message" `Quick test_any_mentioned_ambient_message;
+          test_case "policy observation direct mention" `Quick
+            test_keeper_policy_observation_direct_mention;
+          test_case "policy observation ambient message" `Quick
+            test_keeper_policy_observation_non_mention;
+        ] );
+    ]


### PR DESCRIPTION
## Summary
- stop hardcoding keeper policy observations as direct mentions
- reuse a shared Mention helper for exact @target detection
- add keeper memory regression coverage for ambient room messages

## Verification
- dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix-issue-803-direct-mention ./test/test_mention_coverage.exe ./test/test_keeper_memory.exe ./test/test_tool_keeper.exe
- timeout 120 /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix-issue-803-direct-mention/_build/default/test/test_mention_coverage.exe
- timeout 120 /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix-issue-803-direct-mention/_build/default/test/test_keeper_memory.exe
- timeout 120 /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix-issue-803-direct-mention/_build/default/test/test_tool_keeper.exe

Closes #803