### PR TITLE
test(gardener): guard empty structured post title

### DIFF
--- a/test/test_gardener.ml
+++ b/test/test_gardener.ml
@@ -402,9 +402,12 @@ let make_mock_post ~id ~author ~content ~created_at =
     | Ok aid -> aid
     | Error _ -> failwith ("Invalid test author: " ^ author)
   in
+  let title =
+    if String.trim content = "" then "test-post" else content
+  in
   { Board.id = post_id;
     author = author_id;
-    title = content;
+    title;
     body = content;
     content;
     post_kind = Board.Human_post;


### PR DESCRIPTION
## Summary
- guard the gardener board-post test fixture so an empty content string still yields a non-empty structured title
- keep the change scoped to `test/test_gardener.ml`

## Validation
- `dune build --root . test/test_gardener.exe`
- `dune exec --root . ./test/test_gardener.exe`
