### PR TITLE
feat(audit): consolidate to canonical Audit_log module (Phase 2)

### DIFF
--- a/lib/mcp_server_eio.ml
+++ b/lib/mcp_server_eio.ml
@@ -1608,6 +1608,9 @@ let execute_tool_eio ~sw ~clock ?mcp_session_id ?auth_token state ~name ~argumen
           ("agent_name", `String nickname);
           ("timestamp", `Float (Time_compat.now ()));
         ]) in
+      (* Audit: log join event *)
+      Audit_log.log_join config ~agent_id:nickname
+        ~room_id:(Filename.basename config.base_path) ();
       (true, final_result)
 
   | "masc_leave" ->
@@ -1626,6 +1629,9 @@ let execute_tool_eio ~sw ~clock ?mcp_session_id ?auth_token state ~name ~argumen
         let agent_file = Printf.sprintf "/tmp/.masc_agent_%s" session_id in
         Safe_ops.remove_file_logged ~context:"masc_leave" agent_file
       end;
+      (* Audit: log leave event *)
+      Audit_log.log_leave config ~agent_id:agent_name
+        ~room_id:(Filename.basename config.base_path) ();
       (true, result)
 
 
@@ -1719,6 +1725,10 @@ let execute_tool_eio ~sw ~clock ?mcp_session_id ?auth_token state ~name ~argumen
         (* Increment broadcast_count in active team sessions *)
         Team_session_engine_eio.increment_broadcast_from_external config
           ~agent_name;
+        (* Audit: log broadcast event *)
+        Audit_log.log_broadcast config ~agent_id:agent_name
+          ~room_id:(Filename.basename config.base_path)
+          ~message_preview:message ();
         (true, result)
       end
 

--- a/lib/mcp_server_eio.ml
+++ b/lib/mcp_server_eio.ml
@@ -582,59 +582,8 @@ let save_governance (config : Room.config) (g : governance_config) =
   ] in
   Room_utils.write_json config (governance_path config) json
 
-type audit_event = {
-  timestamp: float;
-  agent: string;
-  event_type: string;
-  success: bool;
-  detail: string option;
-}
-
-let audit_log_path (config : Room.config) =
-  Filename.concat (Room_utils.masc_dir config) "audit.jsonl"
-
-let audit_event_to_json (e : audit_event) : Yojson.Safe.t =
-  `Assoc [
-    ("timestamp", `Float e.timestamp);
-    ("agent", `String e.agent);
-    ("event_type", `String e.event_type);
-    ("success", `Bool e.success);
-    ("detail", match e.detail with Some d -> `String d | None -> `Null);
-  ]
-
-let append_audit_event (config : Room.config) (e : audit_event) =
-  let g = load_governance config in
-  if g.audit_enabled then begin
-    ensure_masc_dir config;
-    let path = audit_log_path config in
-    let line = Yojson.Safe.to_string (audit_event_to_json e) ^ "\n" in
-    Room_utils.with_file_lock config path (fun () ->
-      let oc = open_out_gen [Open_creat; Open_append; Open_wronly] 0o600 path in
-      Common.protect ~module_name:"mcp_server_eio" ~finally_label:"finalizer" ~finally:(fun () -> close_out_noerr oc) (fun () ->
-        output_string oc line)
-    )
-  end
-
-let read_audit_events (config : Room.config) ~since : audit_event list =
-  let path = audit_log_path config in
-  if not (Sys.file_exists path) then []
-  else
-    let content = In_channel.with_open_text path In_channel.input_all in
-    let lines = String.split_on_char '\n' content |> List.filter (fun s -> String.trim s <> "") in
-    List.filter_map (fun line ->
-      try
-        let json = Yojson.Safe.from_string line in
-        let module U = Yojson.Safe.Util in
-        let timestamp = match Json_util.get_float json "timestamp" with Some v -> v | None -> raise Not_found in
-        if timestamp < since then None
-        else
-          let agent = match Json_util.get_string json "agent" with Some v -> v | None -> raise Not_found in
-          let event_type = match Json_util.get_string json "event_type" with Some v -> v | None -> raise Not_found in
-          let success = match Json_util.get_bool json "success" with Some v -> v | None -> raise Not_found in
-          let detail = Json_util.get_string json "detail" in
-          Some { timestamp; agent; event_type; success; detail }
-      with Yojson.Json_error _ | Yojson.Safe.Util.Type_error _ -> None
-    ) lines
+(* Inline audit system removed in Phase 2 — all audit logging
+   now goes through the canonical Audit_log module. *)
 
 (* ============================================ *)
 (* MCP Session (HTTP Session ID) helpers        *)
@@ -2446,6 +2395,12 @@ Time: %s
              ("message", `String (Printf.sprintf "Found %d relevant items for query: %s"
                (List.length result.items) query));
            ] in
+           (* Audit: log search refinement *)
+           let agent_name = Safe_ops.json_string ~default:"unknown" "agent_name" arguments in
+           Audit_log.log_action config ~agent_id:agent_name ~action:Audit_log.SearchRefinement
+             ~room_id:(Filename.basename config.base_path)
+             ~details:(`Assoc [("query", `String query); ("results", `Int (List.length result.items))])
+             ~outcome:Audit_log.Success ();
            (true, Yojson.Safe.pretty_to_string response))
   (* Board tools delegated to Tool_board module *)
   | "masc_board_post" ->
@@ -2866,20 +2821,10 @@ in
   let agent_name =
     Safe_ops.json_string ~default:"unknown" "agent_name" arguments
   in
-  let audit_detail =
-    Printf.sprintf
-      "%s|timeout=%d|duration_ms=%d"
-      name
-      (if !timeout_hit then 1 else 0)
-      duration_ms
-  in
-  append_audit_event state.Mcp_server.room_config {
-    timestamp = Time_compat.now ();
-    agent = agent_name;
-    event_type = "tool_call";
-    success;
-    detail = Some audit_detail;
-  };
+  (* Audit: log tool_call via canonical Audit_log *)
+  let error_msg = if success then None else Some (Printf.sprintf "timeout=%d|duration_ms=%d" (if !timeout_hit then 1 else 0) duration_ms) in
+  Audit_log.log_tool_call state.Mcp_server.room_config
+    ~agent_id:agent_name ~tool_name:name ~success ~error_msg ();
 
   (* Track tool call in telemetry (controlled by MASC_TELEMETRY_ENABLED) *)
   let telemetry_enabled =

--- a/lib/mcp_server_eio.mli
+++ b/lib/mcp_server_eio.mli
@@ -195,20 +195,6 @@ type governance_config = {
     - "enterprise"/"paranoid": audit=true, anomaly=true *)
 val governance_defaults : string -> governance_config
 
-(** {1 Audit Events} *)
-
-(** Audit event record *)
-type audit_event = {
-  timestamp: float;
-  agent: string;
-  event_type: string;
-  success: bool;
-  detail: string option;
-}
-
-(** Serialize audit event to JSON *)
-val audit_event_to_json : audit_event -> Yojson.Safe.t
-
 (** {1 MCP Sessions} *)
 
 (** MCP session record for HTTP session persistence *)

--- a/lib/tool_audit.ml
+++ b/lib/tool_audit.ml
@@ -28,7 +28,9 @@ let audit_event_to_json (e : audit_event) : Yojson.Safe.t =
     ("detail", match e.detail with Some d -> `String d | None -> `Null);
   ]
 
-(* Read audit events since given timestamp *)
+(* Read audit events since given timestamp.
+   Supports both legacy simple format ("agent"/"event_type"/"success")
+   and canonical Audit_log rich format ("agent_id"/"action"/"outcome"). *)
 let read_audit_events (config : Room.config) ~since : audit_event list =
   let path = audit_log_path config in
   if not (Sys.file_exists path) then []
@@ -42,12 +44,35 @@ let read_audit_events (config : Room.config) ~since : audit_event list =
         let timestamp = json |> U.member "timestamp" |> U.to_float in
         if timestamp < since then None
         else
-          let agent = json |> U.member "agent" |> U.to_string in
-          let event_type = json |> U.member "event_type" |> U.to_string in
-          let success = json |> U.member "success" |> U.to_bool in
-          let detail = json |> U.member "detail" |> U.to_string_option in
+          (* Try rich format first (agent_id/action/outcome), fall back to legacy *)
+          let agent =
+            match U.to_string_option (U.member "agent_id" json) with
+            | Some a -> a
+            | None -> json |> U.member "agent" |> U.to_string
+          in
+          let event_type =
+            match U.to_string_option (U.member "action" json) with
+            | Some a -> a
+            | None -> json |> U.member "event_type" |> U.to_string
+          in
+          let success =
+            match U.member "outcome" json with
+            | `Assoc _ as outcome ->
+                let status = U.to_string_option (U.member "status" outcome) in
+                (match status with Some "success" -> true | _ -> false)
+            | `String "success" -> true
+            | _ ->
+                (match U.to_bool_option (U.member "success" json) with
+                 | Some b -> b
+                 | None -> false)
+          in
+          let detail =
+            match U.to_string_option (U.member "detail" json) with
+            | Some _ as d -> d
+            | None -> U.to_string_option (U.member "details" json)
+          in
           Some { timestamp; agent; event_type; success; detail }
-      with Yojson.Json_error _ | Yojson.Safe.Util.Type_error _ -> None
+      with Yojson.Json_error _ | Yojson.Safe.Util.Type_error _ | Not_found -> None
     ) lines
 
 (* Handle masc_audit_query *)

--- a/lib/tool_task.ml
+++ b/lib/tool_task.ml
@@ -55,7 +55,11 @@ let handle_claim ctx args =
          ("task_id", `String task_id);
          ("agent_name", `String ctx.agent_name);
          ("timestamp", `Float (Time_compat.now ()));
-       ])
+       ]);
+       (* Audit: log claim event *)
+       Audit_log.log_claim_task ctx.config ~agent_id:ctx.agent_name
+         ~room_id:(Filename.basename ctx.config.base_path)
+         ~task_id ()
    | Error _ -> ());
   result_to_response result
 
@@ -127,7 +131,11 @@ let handle_done ctx args =
        (try ignore (Metrics_store_eio.record ctx.config metric)
         with exn -> Printf.eprintf "[task] Metrics_store_eio.record(done) failed: %s\n%!" (Printexc.to_string exn));
        (* Feed success into Thompson Sampling quality signal *)
-       Lodge_selection.record_vote ~agent_name:ctx.agent_name ~direction:`Up
+       Lodge_selection.record_vote ~agent_name:ctx.agent_name ~direction:`Up;
+       (* Audit: log done event *)
+       Audit_log.log_done_task ctx.config ~agent_id:ctx.agent_name
+         ~room_id:(Filename.basename ctx.config.base_path)
+         ~task_id ()
    | Error err ->
        Printf.eprintf "[task] metrics record failed: %s\n%!" (Types.masc_error_to_string err));
   result_to_response result
@@ -173,7 +181,11 @@ let handle_cancel_task ctx args =
          ("agent_name", `String ctx.agent_name);
          ("reason", `String reason);
          ("timestamp", `Float (Time_compat.now ()));
-       ])
+       ]);
+       (* Audit: log cancel event *)
+       Audit_log.log_cancel_task ctx.config ~agent_id:ctx.agent_name
+         ~room_id:(Filename.basename ctx.config.base_path)
+         ~task_id ~reason ()
    | Error err ->
        Printf.eprintf "[task] metrics record failed: %s\n%!" (Types.masc_error_to_string err));
   result_to_response result
@@ -222,7 +234,18 @@ let handle_transition ctx args =
          ("action", `String action);
          ("agent_name", `String ctx.agent_name);
          ("timestamp", `Float (Time_compat.now ()));
-       ])
+       ]);
+       (* Audit: log transition event by action type *)
+       let room_id = Filename.basename ctx.config.base_path in
+       (match action_lc with
+        | "claim" ->
+            Audit_log.log_claim_task ctx.config ~agent_id:ctx.agent_name ~room_id ~task_id ()
+        | "done" ->
+            Audit_log.log_done_task ctx.config ~agent_id:ctx.agent_name ~room_id ~task_id ()
+        | "cancel" ->
+            Audit_log.log_cancel_task ctx.config ~agent_id:ctx.agent_name ~room_id ~task_id
+              ~reason:(if reason = "" then "cancelled" else reason) ()
+        | _ -> ())
    | Error err ->
        Printf.eprintf "[task] task transition failed: %s\n%!" (Types.masc_error_to_string err));
   (* Record metrics *)

--- a/test/test_mcp_server_eio_coverage.ml
+++ b/test/test_mcp_server_eio_coverage.ml
@@ -7,6 +7,7 @@ open Alcotest
 
 module Mcp_server_eio = Masc_mcp.Mcp_server_eio
 module Mcp_server = Masc_mcp.Mcp_server
+module Tool_audit = Masc_mcp.Tool_audit
 
 (* ============================================================
    Type Tests
@@ -377,14 +378,14 @@ let test_governance_defaults_mixed_case () =
    ============================================================ *)
 
 let test_audit_event_to_json_full () =
-  let event : Mcp_server_eio.audit_event = {
+  let event : Tool_audit.audit_event = {
     timestamp = 1706400000.0;
     agent = "claude-test";
     event_type = "tool_call";
     success = true;
     detail = Some "masc_status";
   } in
-  let json = Mcp_server_eio.audit_event_to_json event in
+  let json = Tool_audit.audit_event_to_json event in
   let open Yojson.Safe.Util in
   check (float 0.1) "timestamp" 1706400000.0 (json |> member "timestamp" |> to_float);
   check string "agent" "claude-test" (json |> member "agent" |> to_string);
@@ -393,14 +394,14 @@ let test_audit_event_to_json_full () =
   check string "detail" "masc_status" (json |> member "detail" |> to_string)
 
 let test_audit_event_to_json_no_detail () =
-  let event : Mcp_server_eio.audit_event = {
+  let event : Tool_audit.audit_event = {
     timestamp = 1706400000.0;
     agent = "gemini";
     event_type = "join";
     success = false;
     detail = None;
   } in
-  let json = Mcp_server_eio.audit_event_to_json event in
+  let json = Tool_audit.audit_event_to_json event in
   let open Yojson.Safe.Util in
   check bool "success false" false (json |> member "success" |> to_bool);
   check bool "detail null" true ((json |> member "detail") = `Null)


### PR DESCRIPTION
## Summary
- Remove inline audit system (type, writer, reader) from mcp_server_eio.ml (-51 lines dead code)
- Replace inline ToolCall logging with canonical `Audit_log.log_tool_call`
- Add SearchRefinement logging to `masc_recall_search`
- Make `tool_audit.ml` reader dual-format compatible (legacy + rich format)
- Update .mli and test references

## Coverage
| Phase | Coverage | Actions |
|-------|----------|---------|
| Pre-existing | 2/14 (14%) | Suspend, CircuitOpen/Close |
| Phase 1 (#833) | 8/14 (57%) | +Join, Leave, Claim, Done, Cancel, Broadcast |
| **Phase 2 (this)** | **11/14 (79%)** | **+ToolCall, SearchRefinement** |

Skipped: AuthSuccess/AuthFailure (no auth verification logic exists), Custom (user-defined).

## Review
- llama-server (Qwen3.5 Q8) review: 0 high/critical findings
- GLM-5 review: token exhaustion, reasoning confirmed no blocking issues
- Duplicate logging concern (handle_transition vs direct handlers): **false positive** — separate MCP tool dispatch paths

## Test plan
- [x] `dune build` passes
- [x] `test_mcp_server_eio_coverage` — 60/60 pass
- [x] `test_tool_audit_coverage` — 19/19 pass
- [x] CI Build and Test pass
- [x] CI Contract Harness pass
- [x] CI Lint pass

Generated with [Claude Code](https://claude.com/claude-code)