### PR TITLE
fix(sentinel): bootstrap prompt registry on startup

### DIFF
--- a/bin/main_eio.ml
+++ b/bin/main_eio.ml
@@ -8288,6 +8288,7 @@ let run_server ~sw ~env ~host ~port ~base_path =
   server_state := Some state;
   ignore (Masc_mcp.Room.init state.room_config ~agent_name:None);
   Masc_mcp.Chain_native_eio.configure_storage_paths state.room_config;
+  Masc_mcp.Chain_native_eio.ensure_bootstrap state.room_config;
   (try Masc_mcp.Tool_command_plane.backfill_chain_overlays state.room_config
    with exn ->
      Printf.eprintf "[chain-backfill] startup backfill failed: %s\n%!"


### PR DESCRIPTION
## Summary
- bootstrap prompt and chain registries during server startup
- ensure sentinel can resolve built-in `sentinel-*` prompts before its consumers fire

## Verification
- dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix-sentinel-prompt-bootstrap ./bin/main_eio.exe

Follow-up to runtime truth audit: sentinel was starting, but `sentinel-board-patrol` prompt lookup failed at startup because `Prompt_registry` had not been bootstrapped yet.