### PR TITLE
feat(dashboard): surface resident runtimes

### DIFF
--- a/bin/main_eio.ml
+++ b/bin/main_eio.ml
@@ -5476,6 +5476,8 @@ let dashboard_shell_status_json (config : Room.config) : Yojson.Safe.t =
   let tempo = Tempo.get_tempo config in
   let lodge_json = Masc_mcp.Lodge_heartbeat.(lodge_status () |> lodge_status_to_json) in
   let gardener_json = Masc_mcp.Gardener.status_json () in
+  let guardian_json = Masc_mcp.Guardian.status_json () in
+  let sentinel_json = Masc_mcp.Sentinel.status_json () in
   let build = Build_identity.current () in
   `Assoc
     [
@@ -5489,6 +5491,8 @@ let dashboard_shell_status_json (config : Room.config) : Yojson.Safe.t =
       ("paused", `Bool room_state.paused);
       ("lodge", lodge_json);
       ("gardener", gardener_json);
+      ("guardian", guardian_json);
+      ("sentinel", sentinel_json);
       ("version", `String build.release_version);
       ("build", Build_identity.to_yojson build);
     ]

--- a/dashboard/src/app.ts
+++ b/dashboard/src/app.ts
@@ -3,6 +3,7 @@
 
 import { html } from 'htm/preact'
 import { useEffect } from 'preact/hooks'
+import type { ComponentChildren } from 'preact'
 import { signal } from '@preact/signals'
 import { route, initRouter, navigate } from './router'
 import { connected, eventCount, connectSSE, disconnectSSE } from './sse'
@@ -148,10 +149,140 @@ function refreshForTab(tab: string) {
   if (tab === 'lab') refreshTrpg()
 }
 
+function renderRuntimeStat(label: string, value: ComponentChildren) {
+  return html`
+    <div class="build-badge-row">
+      <span>${label}</span>
+      <strong>${value}</strong>
+    </div>
+  `
+}
+
+function renderResidentRuntimeCard(
+  title: string,
+  statusLabel: string,
+  tone: 'ok' | 'warn' | 'bad',
+  rows: ComponentChildren[],
+  hint?: ComponentChildren,
+) {
+  return html`
+    <div style="padding-top:12px; border-top:1px solid rgba(255,255,255,0.08); display:flex; flex-direction:column; gap:6px;">
+      <div class="rail-card-head" style="margin:0;">
+        <h3 style="font-size:12px;">${title}</h3>
+        <span class="rail-section-chip ${tone}">${statusLabel}</span>
+      </div>
+      ${rows}
+      ${hint ? html`<div class="rail-build-hint">${hint}</div>` : null}
+    </div>
+  `
+}
+
 function SnapshotCard({ currentTab }: { currentTab: string }) {
   const liveConnected = connected.value
   const build = serverStatus.value?.build
+  const lodge = serverStatus.value?.lodge
   const gardener = serverStatus.value?.gardener
+  const guardian = serverStatus.value?.guardian
+  const sentinel = serverStatus.value?.sentinel
+  const residentCards: ComponentChildren[] = []
+
+  if (lodge) {
+    residentCards.push(
+      renderResidentRuntimeCard(
+        'Lodge',
+        lodge.enabled ? (lodge.quiet_active ? 'Quiet' : 'Live') : 'Disabled',
+        lodge.enabled ? (lodge.quiet_active ? 'warn' : 'ok') : 'bad',
+        [
+          renderRuntimeStat('Ticks', lodge.total_ticks ?? 0),
+          renderRuntimeStat('Checkins', lodge.total_checkins ?? 0),
+          renderRuntimeStat(
+            'Last result',
+            lodge.last_tick_result?.activity_report
+              ?? lodge.last_skip_reason
+              ?? 'none',
+          ),
+        ],
+      ),
+    )
+  }
+
+  if (gardener) {
+    residentCards.push(
+      renderResidentRuntimeCard(
+        'Gardener',
+        gardener.alive ? 'Live' : gardener.enabled ? 'Starting' : 'Disabled',
+        gardener.alive ? 'ok' : gardener.enabled ? 'warn' : 'bad',
+        [
+          renderRuntimeStat(
+            'Last tick',
+            gardener.last_tick_completed_at
+              ? html`<${TimeAgo} timestamp=${gardener.last_tick_completed_at} />`
+              : 'never',
+          ),
+          renderRuntimeStat(
+            'Decision',
+            `${gardener.last_intervention ?? 'none'} · ${gardener.last_decision_source ?? 'none'}`,
+          ),
+          renderRuntimeStat(
+            'Backlog',
+            `${gardener.health_summary?.todo_count ?? 0} todo · P1/2 ${gardener.health_summary?.high_priority_todo ?? 0}`,
+          ),
+        ],
+        gardener.last_reason ?? gardener.last_error ?? undefined,
+      ),
+    )
+  }
+
+  if (guardian) {
+    const guardianLive = guardian.masc_loops_running || guardian.lodge_loop_started || guardian.lodge_running
+    residentCards.push(
+      renderResidentRuntimeCard(
+        'Guardian',
+        guardianLive ? 'Live' : guardian.enabled ? 'Idle' : 'Disabled',
+        guardianLive ? 'ok' : guardian.enabled ? 'warn' : 'bad',
+        [
+          renderRuntimeStat('Mode', guardian.mode ?? 'unknown'),
+          renderRuntimeStat(
+            'Loops',
+            `zombie ${guardian.zombie_loop_running ? 'on' : 'off'} · gc ${guardian.gc_loop_running ? 'on' : 'off'}`,
+          ),
+          renderRuntimeStat(
+            'Owner',
+            guardian.runtime_owner ?? 'none',
+          ),
+        ],
+        guardian.last_lodge_result?.message
+          ?? guardian.last_gc_result
+          ?? guardian.last_zombie_result
+          ?? undefined,
+      ),
+    )
+  }
+
+  if (sentinel) {
+    residentCards.push(
+      renderResidentRuntimeCard(
+        'Sentinel',
+        sentinel.started ? 'Live' : sentinel.enabled ? 'Starting' : 'Disabled',
+        sentinel.started ? 'ok' : sentinel.enabled ? 'warn' : 'bad',
+        [
+          renderRuntimeStat('Agent', sentinel.agent_name ?? 'sentinel'),
+          renderRuntimeStat(
+            'Consumers',
+            sentinel.consumers?.length ?? 0,
+          ),
+          renderRuntimeStat(
+            'Guardian owner',
+            sentinel.guardian_runtime_owner ?? 'none',
+          ),
+        ],
+        sentinel.llm_enabled === true
+          ? 'LLM-enabled housekeeping resident'
+          : undefined,
+      ),
+    )
+  }
+
   return html`
     <section class="rail-card">
       <div class="rail-card-head">
@@ -195,38 +326,13 @@ function SnapshotCard({ currentTab }: { currentTab: string }) {
       ${build
         ? html`<div class="rail-build-hint">Server Build · v${build.release_version} · ${shortCommit(build.commit)}</div>`
         : null}
-      ${gardener ? html`
-        <div style="margin-top:12px; padding-top:12px; border-top:1px solid rgba(255,255,255,0.08); display:flex; flex-direction:column; gap:6px;">
-          <div class="rail-card-head" style="margin:0;">
-            <h3 style="font-size:12px;">Gardener</h3>
-            <span class="rail-section-chip ${gardener.alive ? 'ok' : gardener.enabled ? 'warn' : 'bad'}">
-              ${gardener.alive ? 'Live' : gardener.enabled ? 'Starting' : 'Disabled'}
-            </span>
-          </div>
-          <div class="build-badge-row">
-            <span>Last tick</span>
-            <strong>${gardener.last_tick_completed_at ? html`<${TimeAgo} timestamp=${gardener.last_tick_completed_at} />` : 'never'}</strong>
-          </div>
-          <div class="build-badge-row">
-            <span>Decision</span>
-            <strong>${gardener.last_intervention ?? 'none'} · ${gardener.last_decision_source ?? 'none'}</strong>
-          </div>
-          <div class="build-badge-row">
-            <span>Action</span>
-            <strong>${gardener.last_action ?? 'none'}</strong>
-          </div>
-          <div class="build-badge-row">
-            <span>Backlog</span>
-            <strong>${gardener.health_summary?.todo_count ?? 0} todo · P1/2 ${gardener.health_summary?.high_priority_todo ?? 0}</strong>
-          </div>
-          ${gardener.last_reason
-            ? html`<div class="rail-build-hint">Reason · ${gardener.last_reason}</div>`
-            : null}
-          ${gardener.last_error
-            ? html`<div class="rail-build-hint" style="color:#fca5a5;">Error · ${gardener.last_error}</div>`
-            : null}
-        </div>
-      ` : null}
+      ${residentCards.length > 0
+        ? html`
+            <div style="margin-top:12px; display:flex; flex-direction:column; gap:10px;">
+              ${residentCards}
+            </div>
+          `
+        : null}
     </section>
   `
 }

--- a/dashboard/src/store.ts
+++ b/dashboard/src/store.ts
@@ -775,6 +775,50 @@ function normalizeGardenerRuntimeStatus(raw: unknown): ServerStatus['gardener'] 
   }
 }
 
+function normalizeGuardianRuntimeStatus(raw: unknown): ServerStatus['guardian'] | undefined {
+  if (!isRecord(raw)) return undefined
+  return {
+    enabled: raw.enabled === true,
+    mode: asString(raw.mode) ?? undefined,
+    masc_enabled: typeof raw.masc_enabled === 'boolean' ? raw.masc_enabled : undefined,
+    masc_loops_running: typeof raw.masc_loops_running === 'boolean' ? raw.masc_loops_running : undefined,
+    runtime_owner: asString(raw.runtime_owner) ?? null,
+    zombie_loop_running: typeof raw.zombie_loop_running === 'boolean' ? raw.zombie_loop_running : undefined,
+    gc_loop_running: typeof raw.gc_loop_running === 'boolean' ? raw.gc_loop_running : undefined,
+    lodge_enabled: typeof raw.lodge_enabled === 'boolean' ? raw.lodge_enabled : undefined,
+    lodge_loop_started: typeof raw.lodge_loop_started === 'boolean' ? raw.lodge_loop_started : undefined,
+    lodge_running: typeof raw.lodge_running === 'boolean' ? raw.lodge_running : undefined,
+    last_zombie_cleanup: toIsoTimestamp(raw.last_zombie_cleanup) ?? asString(raw.last_zombie_cleanup) ?? null,
+    last_gc: toIsoTimestamp(raw.last_gc) ?? asString(raw.last_gc) ?? null,
+    last_lodge: toIsoTimestamp(raw.last_lodge) ?? asString(raw.last_lodge) ?? null,
+    last_zombie_result: asString(raw.last_zombie_result) ?? null,
+    last_gc_result: asString(raw.last_gc_result) ?? null,
+    last_lodge_result: isRecord(raw.last_lodge_result)
+      ? {
+          ok: typeof raw.last_lodge_result.ok === 'boolean' ? raw.last_lodge_result.ok : undefined,
+          message: asString(raw.last_lodge_result.message) ?? undefined,
+        }
+      : null,
+  }
+}
+
+function normalizeSentinelRuntimeStatus(raw: unknown): ServerStatus['sentinel'] | undefined {
+  if (!isRecord(raw)) return undefined
+  return {
+    enabled: raw.enabled === true,
+    started: raw.started === true,
+    agent_name: asString(raw.agent_name) ?? null,
+    llm_enabled: typeof raw.llm_enabled === 'boolean' ? raw.llm_enabled : undefined,
+    uptime_s: asNumber(raw.uptime_s) ?? undefined,
+    embedded_guardian_loops_running:
+      typeof raw.embedded_guardian_loops_running === 'boolean'
+        ? raw.embedded_guardian_loops_running
+        : undefined,
+    guardian_runtime_owner: asString(raw.guardian_runtime_owner) ?? null,
+    consumers: asStringArray(raw.consumers),
+  }
+}
+
 function normalizeServerStatus(raw: unknown, generatedAt?: string): ServerStatus | null {
   if (!isRecord(raw)) return null
   return {
@@ -783,6 +827,8 @@ function normalizeServerStatus(raw: unknown, generatedAt?: string): ServerStatus
     build: normalizeBuildIdentity(raw.build),
     lodge: normalizeLodgeRuntimeStatus(raw.lodge) ?? undefined,
     gardener: normalizeGardenerRuntimeStatus(raw.gardener) ?? undefined,
+    guardian: normalizeGuardianRuntimeStatus(raw.guardian) ?? undefined,
+    sentinel: normalizeSentinelRuntimeStatus(raw.sentinel) ?? undefined,
   }
 }
 

--- a/dashboard/src/types.ts
+++ b/dashboard/src/types.ts
@@ -825,6 +825,39 @@ export interface GardenerRuntimeStatus {
   }
 }
 
+export interface GuardianRuntimeStatus {
+  enabled: boolean
+  mode?: string
+  masc_enabled?: boolean
+  masc_loops_running?: boolean
+  runtime_owner?: string | null
+  zombie_loop_running?: boolean
+  gc_loop_running?: boolean
+  lodge_enabled?: boolean
+  lodge_loop_started?: boolean
+  lodge_running?: boolean
+  last_zombie_cleanup?: string | null
+  last_gc?: string | null
+  last_lodge?: string | null
+  last_zombie_result?: string | null
+  last_gc_result?: string | null
+  last_lodge_result?: {
+    ok?: boolean
+    message?: string
+  } | null
+}
+
+export interface SentinelRuntimeStatus {
+  enabled: boolean
+  started: boolean
+  agent_name?: string | null
+  llm_enabled?: boolean
+  uptime_s?: number
+  embedded_guardian_loops_running?: boolean
+  guardian_runtime_owner?: string | null
+  consumers?: string[]
+}
+
 // --- Dashboard projection responses ---
 
 export interface DashboardShellResponse {
@@ -2518,6 +2551,8 @@ export interface ServerStatus {
   }
   lodge?: LodgeRuntimeStatus
   gardener?: GardenerRuntimeStatus
+  guardian?: GuardianRuntimeStatus
+  sentinel?: SentinelRuntimeStatus
   data_quality?: {
     board_contract_ok?: boolean
     council_feed_ok?: boolean


### PR DESCRIPTION
## Summary
- include guardian and sentinel in the dashboard shell status payload
- normalize guardian and sentinel runtime state in the dashboard store
- render lodge, gardener, guardian, and sentinel together in the side rail resident runtime section

## Validation
- dune build --root . bin/main_eio.exe
- node /Users/dancer/me/workspace/yousleepwhen/masc-mcp/dashboard/node_modules/typescript/bin/tsc --noEmit --skipLibCheck --pretty --target ES2020 --module ESNext --lib ES2020,DOM,DOM.Iterable,ESNext.Disposable --moduleResolution bundler --jsx react-jsx --jsxImportSource preact --strict dashboard/src/app.ts dashboard/src/store.ts dashboard/src/types.ts
