### PR TITLE
feat(mode): default rooms to full

### DIFF
--- a/docs/MODE-SYSTEM.md
+++ b/docs/MODE-SYSTEM.md
@@ -6,6 +6,8 @@
 
 MASC MCP provides 140+ tools across 12 categories. Most agents don't need all of them. The **Mode System** lets you enable only the categories you use, reducing token consumption by narrowing the enabled tool surface.
 
+Default room mode is `full`. Start there for maximum tool visibility, then reduce the surface with `masc_switch_mode` when you want lower token overhead.
+
 ## Why Mode System?
 
 | Problem | Solution |
@@ -201,8 +203,8 @@ Mode configuration is saved to `.masc/config.json`:
 
 ```json
 {
-  "mode": "standard",
-  "enabled_categories": ["core", "comm", "worktree", "health"]
+  "mode": "full",
+  "enabled_categories": ["core", "comm", "portal", "worktree", "code", "health", "discovery", "voting", "interrupt", "cost", "auth", "ratelimit", "encryption", "board", "plan", "consensus", "ecosystem", "trpg", "risc"]
 }
 ```
 
@@ -210,16 +212,16 @@ The configuration persists across server restarts.
 
 ## Best Practices
 
-### 1. Start Minimal, Add as Needed
+### 1. Start Full, Reduce as Needed
 
 ```bash
-# Start with minimal
-masc_switch_mode(mode: "minimal")
+# Default starts at full
+masc_get_config()
 
-# Need worktree? Switch to solo
+# Want a narrower coding surface? Switch to solo or coding
 masc_switch_mode(mode: "solo")
 
-# Need multi-agent? Switch to standard or parallel
+# Need multi-agent but not the whole surface? Switch to standard or parallel
 masc_switch_mode(mode: "standard")
 
 # Heavy parallel work? Switch to parallel

--- a/lib/config.ml
+++ b/lib/config.ml
@@ -13,8 +13,8 @@ type t = {
 
 (** Default configuration *)
 let default = {
-  mode = Standard;
-  enabled_categories = categories_for_mode Standard;
+  mode = Full;
+  enabled_categories = categories_for_mode Full;
 }
 
 (** Config file name *)
@@ -37,12 +37,12 @@ let of_json json =
     let mode_str =
       match Yojson.Safe.Util.member "mode" json with
       | `String s -> s
-      | _ -> "standard"
+      | _ -> "full"
     in
     let mode =
       match mode_of_string mode_str with
       | Some m -> m
-      | None -> Standard
+      | None -> Full
     in
     let enabled_categories =
       match mode with

--- a/test/test_agent_swarm_masc_tools.ml
+++ b/test/test_agent_swarm_masc_tools.ml
@@ -22,7 +22,7 @@ let test_tool_count () =
     Agent_swarm_client.create ~net ~base_url:"http://127.0.0.1:9999" ~agent_name:"test"
   in
   let tools = Agent_swarm_tools.make_tools client ~sw in
-  Alcotest.(check int) "13 MASC tools" 13 (List.length tools)
+  Alcotest.(check int) "14 MASC tools" 14 (List.length tools)
 
 let test_tool_names () =
   Eio_main.run @@ fun env ->
@@ -35,6 +35,7 @@ let test_tool_names () =
   let names = List.map (fun (t : Tool.t) -> t.schema.name) tools in
   let expected = [
     "masc_list_tasks"; "masc_room_status";
+    "masc_autoresearch_swarm_start";
     "masc_add_task"; "masc_batch_add_tasks";
     "masc_claim_task"; "masc_claim_next";
     "masc_set_current_task"; "masc_complete_task";

--- a/test/test_config_coverage.ml
+++ b/test/test_config_coverage.ml
@@ -17,7 +17,7 @@ module Mode = Masc_mcp.Mode
    ============================================================ *)
 
 let test_default_mode () =
-  check bool "default mode is Standard" true (Config.default.mode = Mode.Standard)
+  check bool "default mode is Full" true (Config.default.mode = Mode.Full)
 
 let test_default_has_categories () =
   check bool "has categories" true (List.length Config.default.enabled_categories > 0)
@@ -100,12 +100,12 @@ let test_of_json_solo () =
 let test_of_json_invalid_mode () =
   let json = `Assoc [("mode", `String "invalid")] in
   let config = Config.of_json json in
-  check bool "defaults to Standard" true (config.mode = Mode.Standard)
+  check bool "defaults to Full" true (config.mode = Mode.Full)
 
 let test_of_json_missing_mode () =
   let json = `Assoc [] in
   let config = Config.of_json json in
-  check bool "defaults to Standard" true (config.mode = Mode.Standard)
+  check bool "defaults to Full" true (config.mode = Mode.Full)
 
 let test_of_json_custom_with_categories () =
   let json = `Assoc [
@@ -162,7 +162,7 @@ let test_load_nonexistent () =
   let dir = setup_temp_dir () in
   let config = Config.load dir in
   cleanup_temp_dir dir;
-  check bool "defaults to Standard" true (config.mode = Mode.Standard)
+  check bool "defaults to Full" true (config.mode = Mode.Full)
 
 let test_save_and_load () =
   let dir = setup_temp_dir () in
@@ -319,12 +319,12 @@ let test_get_config_summary_mode_description () =
 let test_of_json_mode_not_string () =
   let json = `Assoc [("mode", `Int 123)] in
   let config = Config.of_json json in
-  check bool "defaults to Standard" true (config.mode = Mode.Standard)
+  check bool "defaults to Full" true (config.mode = Mode.Full)
 
 let test_of_json_completely_invalid () =
   let json = `String "not an object" in
   let config = Config.of_json json in
-  check bool "defaults to Standard" true (config.mode = Mode.Standard)
+  check bool "defaults to Full" true (config.mode = Mode.Full)
 
 (* ============================================================
    Test Runners

--- a/test/test_mcp_server_eio.ml
+++ b/test/test_mcp_server_eio.ml
@@ -1223,10 +1223,11 @@ let test_convo_start_uses_current_room () =
   in
   Alcotest.(check bool) "room enter success" true ok_enter;
 
-  (* After entering a new room, its mode defaults to Standard.
-     Convo tools are Consensus category — switch the new room to Full. *)
+  (* After entering a new room, its mode defaults to Full, so convo tools are
+     immediately available. *)
   let new_room_path = Masc_mcp.Room.masc_dir state.room_config in
-  let _ = Config.switch_mode new_room_path Mode.Full in
+  let mode_config = Config.load new_room_path in
+  Alcotest.(check bool) "new room defaults to full" true (mode_config.mode = Mode.Full);
 
   let (ok_start, start_msg) =
     Mcp_eio.execute_tool_eio ~sw ~clock ~mcp_session_id:sid state

--- a/test/test_mcp_server_eio.ml
+++ b/test/test_mcp_server_eio.ml
@@ -302,21 +302,20 @@ let test_handle_request_tools_list () =
                         | _ -> None)
                    |> List.filter_map (function `String s -> Some s | _ -> None)
                  in
-                 (* TRPG tools are in TRPG category, not in Standard mode *)
+                 (* Full is now the room default, so TRPG tools are available immediately. *)
                  Alcotest.(check bool)
-                   "trpg.dice.roll excluded from standard"
-                   false
+                   "contains trpg.dice.roll in full default"
+                   true
                    (List.mem "trpg.dice.roll" names);
                  Alcotest.(check bool)
-                   "trpg.turn.advance excluded from standard"
-                   false
+                   "contains trpg.turn.advance in full default"
+                   true
                    (List.mem "trpg.turn.advance" names);
-                 (* Plan category IS in Standard mode *)
+                 (* Plan and Board categories remain available. *)
                  Alcotest.(check bool)
                    "contains masc_goal_upsert (Plan category)"
                    true
                    (List.mem "masc_goal_upsert" names);
-                 (* Board category IS in Standard mode *)
                  Alcotest.(check bool)
                    "contains masc_board_post (Board category)"
                    true

--- a/test/test_misc_coverage.ml
+++ b/test/test_misc_coverage.ml
@@ -160,7 +160,7 @@ let test_log_timestamp () =
 
 let test_config_default () =
   let c = Config.default in
-  check bool "mode is Standard" true (c.mode = Mode.Standard)
+  check bool "mode is Full" true (c.mode = Mode.Full)
 
 let test_config_to_json () =
   let c = Config.default in
@@ -190,7 +190,7 @@ let test_config_of_json_invalid () =
   let json = `String "invalid" in
   let c = Config.of_json json in
   (* Should return default on invalid input *)
-  check bool "mode is Standard" true (c.mode = Mode.Standard)
+  check bool "mode is Full" true (c.mode = Mode.Full)
 
 let test_config_filename () =
   check string "config filename" "config.json" Config.config_filename


### PR DESCRIPTION
## Summary
- change the default room mode from standard to full
- make invalid or missing mode config fall back to full
- update mode docs and room-enter regression coverage to match the new default

## Validation
- dune build --root . test/test_config_coverage.exe test/test_mcp_server_eio.exe
- ./_build/default/test/test_config_coverage.exe
- ./_build/default/test/test_mcp_server_eio.exe test eio 28
