### PR TITLE
fix(local-worker): include board and lodge schemas

### DIFF
--- a/lib/local_agent_eio.ml
+++ b/lib/local_agent_eio.ml
@@ -362,11 +362,73 @@ let local_worker_extra_schemas : Types.tool_schema list =
     };
   ]
 
+let local_worker_lodge_read_schemas : Types.tool_schema list =
+  [
+    {
+      Types.name = "lodge_research";
+      description = "Research a topic using LLM and share findings with the lodge.";
+      input_schema =
+        `Assoc
+          [
+            ("type", `String "object");
+            ( "properties",
+              `Assoc
+                [
+                  ("topic", `Assoc [ ("type", `String "string") ]);
+                  ("agent_name", `Assoc [ ("type", `String "string") ]);
+                ] );
+            ("required", `List [ `String "topic" ]);
+          ];
+    };
+    {
+      Types.name = "lodge_profile";
+      description = "Get an agent profile with recent lodge activity and stats.";
+      input_schema =
+        `Assoc
+          [
+            ("type", `String "object");
+            ( "properties",
+              `Assoc
+                [
+                  ("agent_name", `Assoc [ ("type", `String "string") ]);
+                ] );
+            ("required", `List [ `String "agent_name" ]);
+          ];
+    };
+    {
+      Types.name = "lodge_search";
+      description = "Search lodge content and agents by keyword.";
+      input_schema =
+        `Assoc
+          [
+            ("type", `String "object");
+            ( "properties",
+              `Assoc
+                [
+                  ("query", `Assoc [ ("type", `String "string") ]);
+                  ("limit", `Assoc [ ("type", `String "integer") ]);
+                ] );
+            ("required", `List [ `String "query" ]);
+          ];
+    };
+  ]
+
+let local_worker_tool_schemas : Types.tool_schema list =
+  let seen = Hashtbl.create 64 in
+  List.filter
+    (fun (schema : Types.tool_schema) ->
+      if Hashtbl.mem seen schema.name then
+        false
+      else (
+        Hashtbl.add seen schema.name ();
+        true))
+    (local_worker_extra_schemas @ Tool_board.tools @ local_worker_lodge_read_schemas)
+
 let list_masc_tools ~sw:_sw ~(auth_token : string option) ~session_id
     ?(names : string list option = None) () :
     (Types.tool_schema list, string) result =
   ignore (_sw, auth_token, session_id);
-  let all_schemas = local_worker_extra_schemas in
+  let all_schemas = local_worker_tool_schemas in
   match names with
   | None -> Ok all_schemas
   | Some values ->

--- a/test/dune
+++ b/test/dune
@@ -81,6 +81,11 @@
  (modules test_dashboard_execution)
  (libraries masc_mcp alcotest eio eio_main yojson unix))
 
+(test
+ (name test_local_agent_eio)
+ (modules test_local_agent_eio)
+ (libraries masc_mcp alcotest eio eio_main yojson unix))
+
 ; Voice tool wrapper tests
 (test
  (name test_tool_voice)

--- a/test/test_local_agent_eio.ml
+++ b/test/test_local_agent_eio.ml
@@ -1,0 +1,39 @@
+module Lib = Masc_mcp
+
+open Alcotest
+
+let test_list_masc_tools_exposes_board_and_lodge_schemas () =
+  Eio_main.run @@ fun _env ->
+    Eio.Switch.run (fun sw ->
+        match
+          Lib.Local_agent_eio.list_masc_tools ~sw ~auth_token:None
+            ~session_id:"worker-test"
+            ~names:
+              (Some
+                 [
+                   "masc_board_post";
+                   "masc_board_list";
+                   "lodge_search";
+                   "lodge_profile";
+                   "lodge_research";
+                 ])
+            ()
+        with
+        | Ok schemas ->
+            let names =
+              List.map (fun (schema : Lib.Types.tool_schema) -> schema.name) schemas
+            in
+            check bool "masc_board_post" true (List.mem "masc_board_post" names);
+            check bool "masc_board_list" true (List.mem "masc_board_list" names);
+            check bool "lodge_search" true (List.mem "lodge_search" names);
+            check bool "lodge_profile" true (List.mem "lodge_profile" names);
+            check bool "lodge_research" true (List.mem "lodge_research" names)
+        | Error err -> failf "expected schema lookup to succeed: %s" err)
+
+let () =
+  Alcotest.run "local_agent_eio"
+    [
+      ( "tool_schemas",
+        [ test_case "includes board and lodge tools for local workers" `Quick
+            test_list_masc_tools_exposes_board_and_lodge_schemas ] );
+    ]


### PR DESCRIPTION
## Summary
- let local workers resolve board and lodge tool schemas used by lodge heartbeat
- keep the scope narrow to canonical board tools plus the lodge read tools heartbeat actually requests
- add a regression test for local worker schema lookup

## Verification
- dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix-local-worker-tool-schema-registry ./test/test_local_agent_eio.exe
- timeout 120 /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix-local-worker-tool-schema-registry/_build/default/test/test_local_agent_eio.exe