### PR TITLE
refactor(voice): route transport through provider adapter

### DIFF
--- a/lib/provider_adapter.ml
+++ b/lib/provider_adapter.ml
@@ -320,6 +320,70 @@ let voice_endpoint_auth_env_name (endpoint : Voice_config.endpoint) =
   let adapter = voice_adapter_for_endpoint endpoint in
   voice_auth_env_name ?endpoint_api_key_env:endpoint.api_key_env adapter
 
+let ends_with ~suffix s =
+  let slen = String.length s in
+  let plen = String.length suffix in
+  slen >= plen && String.sub s (slen - plen) plen = suffix
+
+let compose_voice_endpoint_url ~base_url ~path =
+  let base_uri = Uri.of_string base_url in
+  let base_path = Uri.path base_uri in
+  let base_path =
+    if base_path = "" then "/"
+    else if ends_with ~suffix:"/" base_path && String.length base_path > 1 then
+      String.sub base_path 0 (String.length base_path - 1)
+    else base_path
+  in
+  let final_path =
+    if path = "/mcp" then
+      if ends_with ~suffix:"/mcp" base_path then base_path
+      else if base_path = "/" then "/mcp"
+      else base_path ^ "/mcp"
+    else if path = "/health" then
+      if ends_with ~suffix:"/health" base_path then base_path
+      else if ends_with ~suffix:"/mcp" base_path then
+        String.sub base_path 0 (String.length base_path - 4) ^ "/health"
+      else if base_path = "/" then "/health"
+      else base_path ^ "/health"
+    else if base_path = "/" then path
+    else base_path ^ path
+  in
+  Uri.with_path base_uri final_path |> Uri.to_string
+
+let voice_session_endpoint_result (config : Voice_config.t) =
+  match Voice_config.select_endpoint config.session.endpoints with
+  | Some endpoint ->
+      let adapter = voice_adapter_for_endpoint endpoint in
+      if adapter.transport = Voice_mcp then Ok endpoint
+      else
+        Error
+          (Printf.sprintf "session endpoint %s must use kind=voice_mcp" endpoint.id)
+  | None -> Error "no configured session endpoint"
+
+let voice_session_mcp_url_of_endpoint (endpoint : Voice_config.endpoint) =
+  let adapter = voice_adapter_for_endpoint endpoint in
+  if adapter.transport <> Voice_mcp then
+    Error (Printf.sprintf "session endpoint %s must use voice_mcp transport" endpoint.id)
+  else
+    match endpoint.mcp_url with
+    | Some url -> Ok url
+    | None -> (
+        match endpoint.base_url with
+        | Some base_url -> Ok (compose_voice_endpoint_url ~base_url ~path:"/mcp")
+        | None -> Ok "http://127.0.0.1:8936/mcp")
+
+let voice_session_health_url_of_endpoint (endpoint : Voice_config.endpoint) =
+  let adapter = voice_adapter_for_endpoint endpoint in
+  if adapter.transport <> Voice_mcp then
+    Error (Printf.sprintf "session endpoint %s must use voice_mcp transport" endpoint.id)
+  else
+    match endpoint.health_url with
+    | Some url -> Ok url
+    | None -> (
+        match endpoint.base_url with
+        | Some base_url -> Ok (compose_voice_endpoint_url ~base_url ~path:"/health")
+        | None -> Ok "http://127.0.0.1:8936/health")
+
 let voice_transport_supports_http_tts (adapter : voice_adapter) =
   match adapter.transport with
   | Voice_openai_compat | Voice_elevenlabs_direct -> true

--- a/lib/provider_adapter.ml
+++ b/lib/provider_adapter.ml
@@ -262,6 +262,11 @@ let resolve_voice_adapter label =
       List.exists (fun alias -> normalize_label alias = normalized) adapter.aliases)
     voice_adapters
 
+let voice_adapter_labels (adapter : voice_adapter) =
+  adapter.canonical_name
+  :: string_of_voice_transport adapter.transport
+  :: adapter.aliases
+
 let voice_adapter_for_endpoint_kind = function
   | Voice_config.Openai_compat -> voice_openai_compat_adapter
   | Voice_config.Elevenlabs_direct -> voice_elevenlabs_direct_adapter
@@ -271,6 +276,25 @@ let voice_adapter_for_endpoint (endpoint : Voice_config.endpoint) =
   match resolve_voice_adapter endpoint.id with
   | Some adapter -> adapter
   | None -> voice_adapter_for_endpoint_kind endpoint.kind
+
+let voice_endpoint_matches_provider_label label (endpoint : Voice_config.endpoint) =
+  let normalized = normalize_label label in
+  let adapter = voice_adapter_for_endpoint endpoint in
+  let candidates =
+    endpoint.id
+    :: Voice_config.string_of_endpoint_kind endpoint.kind
+    :: voice_adapter_labels adapter
+  in
+  List.exists (fun candidate -> String.equal (normalize_label candidate) normalized) candidates
+
+let select_voice_endpoints ?provider (endpoints : Voice_config.endpoint list) =
+  let endpoints =
+    List.filter (fun (endpoint : Voice_config.endpoint) -> endpoint.enabled) endpoints
+  in
+  match provider with
+  | Some label when String.trim label <> "" ->
+      List.filter (voice_endpoint_matches_provider_label label) endpoints
+  | _ -> endpoints
 
 let voice_auth_env_name ?endpoint_api_key_env (adapter : voice_adapter) =
   match endpoint_api_key_env with
@@ -285,6 +309,10 @@ let voice_auth_env_name ?endpoint_api_key_env (adapter : voice_adapter) =
       match adapter.auth_mode with
       | Api_key env_name -> Some env_name
       | _ -> None)
+
+let voice_endpoint_auth_env_name (endpoint : Voice_config.endpoint) =
+  let adapter = voice_adapter_for_endpoint endpoint in
+  voice_auth_env_name ?endpoint_api_key_env:endpoint.api_key_env adapter
 
 let default_cli_agent_name () = "claude"
 

--- a/lib/provider_adapter.ml
+++ b/lib/provider_adapter.ml
@@ -58,6 +58,12 @@ type voice_adapter = {
   aliases : string list;
 }
 
+type voice_http_request = {
+  url : string;
+  headers : (string * string) list;
+  body_json : Yojson.Safe.t;
+}
+
 type gemini_direct_auth =
   | Gemini_vertex_adc of {
       project : string;
@@ -313,6 +319,107 @@ let voice_auth_env_name ?endpoint_api_key_env (adapter : voice_adapter) =
 let voice_endpoint_auth_env_name (endpoint : Voice_config.endpoint) =
   let adapter = voice_adapter_for_endpoint endpoint in
   voice_auth_env_name ?endpoint_api_key_env:endpoint.api_key_env adapter
+
+let voice_transport_supports_http_tts (adapter : voice_adapter) =
+  match adapter.transport with
+  | Voice_openai_compat | Voice_elevenlabs_direct -> true
+  | Voice_mcp -> false
+
+let voice_endpoint_supports_http_tts (endpoint : Voice_config.endpoint) =
+  voice_adapter_for_endpoint endpoint
+  |> voice_transport_supports_http_tts
+
+let default_elevenlabs_base_url = "https://api.elevenlabs.io/v1"
+
+let normalize_base_url value =
+  let trimmed = String.trim value in
+  if String.length trimmed > 1 && trimmed.[String.length trimmed - 1] = '/' then
+    String.sub trimmed 0 (String.length trimmed - 1)
+  else
+    trimmed
+
+let voice_endpoint_base_url (endpoint : Voice_config.endpoint) =
+  match voice_adapter_for_endpoint endpoint with
+  | { transport = Voice_elevenlabs_direct; _ } -> (
+      match endpoint.base_url with
+      | Some value -> Some (normalize_base_url value)
+      | None -> Some default_elevenlabs_base_url)
+  | _ -> Option.map normalize_base_url endpoint.base_url
+
+let elevenlabs_voice_id voice =
+  match String.trim voice with
+  | "Sarah" -> "EXAVITQu4vr4xnSDxMaL"
+  | "Roger" -> "CwhRBWXzGAHq8TQ4Fs17"
+  | "George" -> "JBFqnCBsd6RMkjVDRZzb"
+  | "Laura" -> "FGY2WhTYpPnrIDTdsKH5"
+  | "" -> "21m00Tcm4TlvDq8ikWAM"
+  | value -> value
+
+let voice_http_request_for_tts (endpoint : Voice_config.endpoint) ~api_key
+    ~message ~voice ~model ~(tuning : Voice_config.voice_tuning) =
+  let adapter = voice_adapter_for_endpoint endpoint in
+  match voice_endpoint_base_url endpoint, adapter.transport with
+  | None, _ ->
+      Error
+        (Printf.sprintf "voice config endpoint %s missing base_url" endpoint.id)
+  | Some _, Voice_mcp ->
+      Error
+        (Printf.sprintf
+           "voice config endpoint %s uses voice_mcp and cannot build HTTP TTS request"
+           endpoint.id)
+  | Some base_url, Voice_openai_compat ->
+      let headers =
+        [ ("Content-Type", "application/json"); ("Accept", "audio/mpeg") ]
+        @
+        if api_key = "" then [] else [ ("Authorization", "Bearer " ^ api_key) ]
+      in
+      let body_json =
+        `Assoc
+          [
+            ("input", `String message);
+            ("voice", `String voice);
+            ("model", `String model);
+            ("response_format", `String "mp3");
+            ( "voice_settings",
+              `Assoc
+                [
+                  ("stability", `Float tuning.stability);
+                  ("similarity_boost", `Float tuning.similarity_boost);
+                  ("style", `Float tuning.style);
+                ] );
+          ]
+      in
+      Ok { url = base_url ^ "/audio/speech"; headers; body_json }
+  | Some base_url, Voice_elevenlabs_direct ->
+      let headers =
+        [
+          ("xi-api-key", api_key);
+          ("Content-Type", "application/json");
+          ("Accept", "audio/mpeg");
+        ]
+      in
+      let body_json =
+        `Assoc
+          [
+            ("text", `String message);
+            ("model_id", `String model);
+            ( "voice_settings",
+              `Assoc
+                [
+                  ("stability", `Float tuning.stability);
+                  ("similarity_boost", `Float tuning.similarity_boost);
+                  ("style", `Float tuning.style);
+                ] );
+          ]
+      in
+      Ok
+        {
+          url =
+            Printf.sprintf "%s/text-to-speech/%s" base_url
+              (elevenlabs_voice_id voice);
+          headers;
+          body_json;
+        }
 
 let default_cli_agent_name () = "claude"
 

--- a/lib/voice_bridge_eio.ml
+++ b/lib/voice_bridge_eio.ml
@@ -57,67 +57,29 @@ let local_playback_enabled_for_agent agent_id =
   | Ok config -> Voice_config.local_playback_enabled_for_agent config agent_id
   | Error _ -> false
 
-let ends_with ~suffix s =
-  let slen = String.length s in
-  let plen = String.length suffix in
-  slen >= plen && String.sub s (slen - plen) plen = suffix
-
-let compose_endpoint_from_base ~base_url ~path =
-  let base_uri = Uri.of_string base_url in
-  let base_path = Uri.path base_uri in
-  let base_path =
-    if base_path = "" then "/"
-    else if ends_with ~suffix:"/" base_path && String.length base_path > 1 then
-      String.sub base_path 0 (String.length base_path - 1)
-    else base_path
-  in
-  let final_path =
-    if path = "/mcp" then
-      if ends_with ~suffix:"/mcp" base_path then base_path
-      else if base_path = "/" then "/mcp"
-      else base_path ^ "/mcp"
-    else if path = "/health" then
-      if ends_with ~suffix:"/health" base_path then base_path
-      else if ends_with ~suffix:"/mcp" base_path then
-        String.sub base_path 0 (String.length base_path - 4) ^ "/health"
-      else if base_path = "/" then "/health"
-      else base_path ^ "/health"
-    else if base_path = "/" then path
-    else base_path ^ path
-  in
-  Uri.with_path base_uri final_path
-
-let active_session_endpoint () =
-  match load_voice_config () with
-  | Ok config -> Voice_config.select_endpoint config.session.endpoints
-  | Error _ -> None
-
-let session_mcp_uri endpoint =
-  match endpoint.Voice_config.mcp_url with
-  | Some url -> Uri.of_string url
-  | None -> (
-      match endpoint.base_url with
-      | Some base_url -> compose_endpoint_from_base ~base_url ~path:"/mcp"
-      | None -> Uri.make ~scheme:"http" ~host:"127.0.0.1" ~port:8936 ~path:"/mcp" ())
-
-let session_health_uri endpoint =
-  match endpoint.Voice_config.health_url with
-  | Some url -> Uri.of_string url
-  | None -> (
-      match endpoint.base_url with
-      | Some base_url -> compose_endpoint_from_base ~base_url ~path:"/health"
-      | None ->
-          Uri.make ~scheme:"http" ~host:"127.0.0.1" ~port:8936 ~path:"/health" ())
-
 let voice_mcp_uri () =
-  match active_session_endpoint () with
-  | Some endpoint -> session_mcp_uri endpoint
-  | None -> Uri.make ~scheme:"http" ~host:"127.0.0.1" ~port:8936 ~path:"/mcp" ()
+  match load_voice_config () with
+  | Ok config -> (
+      match Provider_adapter.voice_session_endpoint_result config with
+      | Ok endpoint -> (
+          match Provider_adapter.voice_session_mcp_url_of_endpoint endpoint with
+          | Ok url -> Uri.of_string url
+          | Error _ -> Uri.make ~scheme:"http" ~host:"127.0.0.1" ~port:8936 ~path:"/mcp" () )
+      | Error _ -> Uri.make ~scheme:"http" ~host:"127.0.0.1" ~port:8936 ~path:"/mcp" ())
+  | Error _ -> Uri.make ~scheme:"http" ~host:"127.0.0.1" ~port:8936 ~path:"/mcp" ()
 
 let voice_health_uri () =
-  match active_session_endpoint () with
-  | Some endpoint -> session_health_uri endpoint
-  | None ->
+  match load_voice_config () with
+  | Ok config -> (
+      match Provider_adapter.voice_session_endpoint_result config with
+      | Ok endpoint -> (
+          match Provider_adapter.voice_session_health_url_of_endpoint endpoint with
+          | Ok url -> Uri.of_string url
+          | Error _ ->
+              Uri.make ~scheme:"http" ~host:"127.0.0.1" ~port:8936 ~path:"/health" () )
+      | Error _ ->
+          Uri.make ~scheme:"http" ~host:"127.0.0.1" ~port:8936 ~path:"/health" ())
+  | Error _ ->
       Uri.make ~scheme:"http" ~host:"127.0.0.1" ~port:8936 ~path:"/health" ()
 
 let voice_mcp_host () =
@@ -737,7 +699,11 @@ let extract_mcp_result json =
     Error (Printf.sprintf "Parse error: %s" (Printexc.to_string e))
 
 let call_voice_mcp_endpoint ~sw ~clock ~net ~endpoint ~tool_name ~arguments =
-  let uri = session_mcp_uri endpoint in
+  let uri =
+    match Provider_adapter.voice_session_mcp_url_of_endpoint endpoint with
+    | Ok url -> Uri.of_string url
+    | Error _ -> voice_mcp_uri ()
+  in
   let request_body =
     `Assoc
       [
@@ -834,16 +800,7 @@ let cache_duration () =
 let session_endpoint_result () =
   match load_voice_config () with
   | Error message -> Error message
-  | Ok config -> (
-      match Voice_config.select_endpoint config.session.endpoints with
-      | Some endpoint -> (
-          match endpoint.Voice_config.kind with
-          | Voice_config.Voice_mcp -> Ok endpoint
-          | _ ->
-              Error
-                (Printf.sprintf
-                   "session endpoint %s must use kind=voice_mcp" endpoint.id) )
-      | None -> Error "no configured session endpoint")
+  | Ok config -> Provider_adapter.voice_session_endpoint_result config
 
 let is_voice_server_available ~sw ~clock ~net =
   match session_endpoint_result () with
@@ -851,7 +808,11 @@ let is_voice_server_available ~sw ~clock ~net =
       voice_server_available := Some false;
       false
   | Ok endpoint ->
-      let health_target = Uri.to_string (session_health_uri endpoint) in
+      let health_target =
+        match Provider_adapter.voice_session_health_url_of_endpoint endpoint with
+        | Ok url -> url
+        | Error _ -> Uri.to_string (voice_health_uri ())
+      in
       if !voice_server_health_target <> Some health_target then (
         voice_server_health_target := Some health_target;
         voice_server_available := None;
@@ -863,7 +824,11 @@ let is_voice_server_available ~sw ~clock ~net =
         voice_server_check_time := now;
         let check () =
           try
-            let uri = session_health_uri endpoint in
+            let uri =
+              match Provider_adapter.voice_session_health_url_of_endpoint endpoint with
+              | Ok url -> Uri.of_string url
+              | Error _ -> voice_health_uri ()
+            in
             let client = client_for_uri ~net uri in
             let resp, _ = Cohttp_eio.Client.get ~sw client uri in
             let status = Cohttp.Response.status resp in
@@ -1136,7 +1101,11 @@ let health_check ~sw ~clock:_ ~net () =
   match session_endpoint_result () with
   | Error error -> Error error
   | Ok endpoint ->
-      let uri = session_health_uri endpoint in
+      let uri =
+        match Provider_adapter.voice_session_health_url_of_endpoint endpoint with
+        | Ok url -> Uri.of_string url
+        | Error _ -> voice_health_uri ()
+      in
       try
         let client = client_for_uri ~net uri in
         let resp, body = Cohttp_eio.Client.get ~sw client uri in

--- a/lib/voice_bridge_eio.ml
+++ b/lib/voice_bridge_eio.ml
@@ -850,32 +850,6 @@ let is_voice_server_available ~sw ~clock ~net =
             false
       end
 
-(** Text-only fallback for when voice is unavailable *)
-let text_fallback ?reason ?(attempted_endpoints = []) ~agent_id ~message () =
-  let voice = get_voice_for_agent agent_id in
-  log_info (Printf.sprintf "[Text fallback] %s (%s): %s"
-    agent_id voice
-    (String.sub message 0 (min 50 (String.length message))));
-  let fields =
-    [
-      ("status", `String "text_fallback");
-      ("agent_id", `String agent_id);
-      ("voice", `String voice);
-      ( "message_preview",
-        `String (String.sub message 0 (min 50 (String.length message))) );
-    ]
-    @
-    (match reason with Some value -> [ ("reason", `String value) ] | None -> [])
-    @
-    if attempted_endpoints = [] then []
-    else
-      [
-        ( "attempted_endpoints",
-          `List (List.map (fun value -> `String value) attempted_endpoints) );
-      ]
-  in
-  Ok (`Assoc fields)
-
 let call_session_tool ~sw ~clock ~net ~tool_name ~arguments =
   match session_endpoint_result () with
   | Error message -> Error message

--- a/lib/voice_bridge_eio.ml
+++ b/lib/voice_bridge_eio.ml
@@ -147,13 +147,6 @@ let log_error msg =
 let log_debug msg =
   Log.debug "%s %s" log_prefix msg
 
-let local_playback_enabled config ~agent_id =
-  config.Voice_config.local_playback.enabled
-  &&
-  (match config.local_playback.agents with
-  | [] -> true
-  | agents -> List.mem agent_id agents)
-
 let split_path_env value =
   String.split_on_char ':' value
   |> List.filter (fun entry -> String.trim entry <> "")
@@ -192,7 +185,7 @@ let start_local_playback ~sw ~agent_id ~audio_file =
   match load_voice_config () with
   | Error _ -> ()
   | Ok config ->
-      if not (local_playback_enabled config ~agent_id) then
+      if not (Voice_config.local_playback_enabled_for_agent config agent_id) then
         ()
       else
         match local_playback_argv ~audio_file () with
@@ -411,11 +404,7 @@ let play_audio_locally ~agent_id ~audio_file =
 
 let resolve_api_key endpoint =
   let adapter = Provider_adapter.voice_adapter_for_endpoint endpoint in
-  match
-    Provider_adapter.voice_auth_env_name
-      ?endpoint_api_key_env:endpoint.Voice_config.api_key_env
-      adapter
-  with
+  match Provider_adapter.voice_endpoint_auth_env_name endpoint with
   | Some env_name -> (
       match Sys.getenv_opt env_name with
       | Some value when String.trim value <> "" -> Ok (String.trim value)
@@ -556,27 +545,9 @@ let speak_via_elevenlabs_to_file endpoint ~agent_id ~message ~voice ~model ~outp
     ~headers ~body_json ~output_file
 
 let available_tts_endpoints ?provider () =
-  let normalize value = String.lowercase_ascii (String.trim value) in
-  let endpoint_matches_provider label endpoint =
-    let adapter = Provider_adapter.voice_adapter_for_endpoint endpoint in
-    let labels =
-      endpoint.id
-      :: Voice_config.string_of_endpoint_kind endpoint.kind
-      :: Provider_adapter.string_of_voice_transport adapter.transport
-      :: adapter.canonical_name
-      :: adapter.aliases
-    in
-    let target = normalize label in
-    List.exists (fun candidate -> String.equal (normalize candidate) target) labels
-  in
   match load_voice_config () with
   | Error _ -> []
-  | Ok config ->
-      let endpoints = Voice_config.enabled_endpoints config.tts.endpoints in
-      (match provider with
-      | Some label when String.trim label <> "" ->
-          List.filter (endpoint_matches_provider label) endpoints
-      | _ -> endpoints)
+  | Ok config -> Provider_adapter.select_voice_endpoints ?provider config.tts.endpoints
 
 let provider_error_json endpoint message =
   append_provider_metadata

--- a/lib/voice_bridge_eio.ml
+++ b/lib/voice_bridge_eio.ml
@@ -236,13 +236,6 @@ let elevenlabs_voice_ids = [
   ("Laura",  "FGY2WhTYpPnrIDTdsKH5");
 ]
 
-let voice_name_to_id name =
-  match List.assoc_opt name elevenlabs_voice_ids with
-  | Some id -> id
-  | None ->
-      let trimmed = String.trim name in
-      if trimmed = "" then "21m00Tcm4TlvDq8ikWAM" else trimmed
-
 (** Ensure .masc/audio/ directory exists *)
 let masc_base_dir () =
   match Sys.getenv_opt "ME_ROOT" with
@@ -256,21 +249,17 @@ let ensure_audio_dir () =
   else if not (Sys.is_directory dir) then
     log_error "voice audio path exists but is not a directory"
 
-let normalize_base_url value =
-  let trimmed = String.trim value in
-  if ends_with ~suffix:"/" trimmed && String.length trimmed > 1 then
-    String.sub trimmed 0 (String.length trimmed - 1)
-  else
-    trimmed
-
 let endpoint_url endpoint =
-  match endpoint.Voice_config.kind with
-  | Voice_config.Openai_compat | Voice_config.Elevenlabs_direct ->
-      endpoint.base_url
-  | Voice_config.Voice_mcp -> (
-      match endpoint.mcp_url with
-      | Some _ as url -> url
-      | None -> endpoint.base_url)
+  if Provider_adapter.voice_endpoint_supports_http_tts endpoint then
+    Provider_adapter.voice_endpoint_base_url endpoint
+  else
+    match endpoint.Voice_config.kind with
+    | Voice_config.Voice_mcp -> (
+        match endpoint.mcp_url with
+        | Some _ as url -> url
+        | None -> endpoint.base_url)
+    | Voice_config.Openai_compat | Voice_config.Elevenlabs_direct ->
+        Provider_adapter.voice_endpoint_base_url endpoint
 
 let endpoint_url_json endpoint =
   match endpoint_url endpoint with
@@ -469,80 +458,15 @@ let run_audio_http_request_to_file ~url ~headers ~body_json ~output_file =
       | Unix.WEXITED code -> Error (Printf.sprintf "curl exit %d" code)
       | _ -> Error "curl process failed")
 
-let speak_via_openai_compat_to_file endpoint ~agent_id ~message ~voice ~model ~output_file =
-  let open Result in
+let speak_via_http_tts_to_file endpoint ~agent_id ~message ~voice ~model ~output_file =
   let* api_key = resolve_api_key endpoint in
-  let base_url =
-    match endpoint.base_url with
-    | Some value -> Ok (normalize_base_url value)
-    | None ->
-        Error
-          (Printf.sprintf "voice config endpoint %s missing base_url" endpoint.id)
-  in
-  let* base_url = base_url in
-  let headers =
-    [ ("Content-Type", "application/json"); ("Accept", "audio/mpeg") ]
-    @
-    if api_key = "" then [] else [ ("Authorization", "Bearer " ^ api_key) ]
-  in
   let tuning = tuning_for_agent agent_id in
-  let body_json =
-    `Assoc
-      [
-        ("input", `String message);
-        ("voice", `String voice);
-        ("model", `String model);
-        ("response_format", `String "mp3");
-        ( "voice_settings",
-          `Assoc
-            [
-              ("stability", `Float tuning.stability);
-              ("similarity_boost", `Float tuning.similarity_boost);
-              ("style", `Float tuning.style);
-            ] );
-      ]
+  let* request =
+    Provider_adapter.voice_http_request_for_tts endpoint ~api_key ~message ~voice
+      ~model ~tuning
   in
-  run_audio_http_request_to_file
-    ~url:(base_url ^ "/audio/speech")
-    ~headers ~body_json ~output_file
-
-let speak_via_elevenlabs_to_file endpoint ~agent_id ~message ~voice ~model ~output_file =
-  let open Result in
-  let* api_key = resolve_api_key endpoint in
-  let base_url =
-    match endpoint.base_url with
-    | Some value -> Ok (normalize_base_url value)
-    | None ->
-        Error
-          (Printf.sprintf "voice config endpoint %s missing base_url" endpoint.id)
-  in
-  let* base_url = base_url in
-  let voice_id = voice_name_to_id voice in
-  let headers =
-    [
-      ("xi-api-key", api_key);
-      ("Content-Type", "application/json");
-      ("Accept", "audio/mpeg");
-    ]
-  in
-  let tuning = tuning_for_agent agent_id in
-  let body_json =
-    `Assoc
-      [
-        ("text", `String message);
-        ("model_id", `String model);
-        ( "voice_settings",
-          `Assoc
-            [
-              ("stability", `Float tuning.stability);
-              ("similarity_boost", `Float tuning.similarity_boost);
-              ("style", `Float tuning.style);
-            ] );
-      ]
-  in
-  run_audio_http_request_to_file
-    ~url:(Printf.sprintf "%s/text-to-speech/%s" base_url voice_id)
-    ~headers ~body_json ~output_file
+  run_audio_http_request_to_file ~url:request.url ~headers:request.headers
+    ~body_json:request.body_json ~output_file
 
 let available_tts_endpoints ?provider () =
   match load_voice_config () with
@@ -610,25 +534,17 @@ let tts_preview_bytes_from_request_json json =
         in
         Error detail
     | endpoint :: rest -> (
-        match endpoint.Voice_config.kind with
-        | Voice_config.Voice_mcp ->
+        let adapter = Provider_adapter.voice_adapter_for_endpoint endpoint in
+        if not (Provider_adapter.voice_transport_supports_http_tts adapter) then
             let note =
               Printf.sprintf "%s: preview unsupported for voice_mcp" endpoint.id
             in
             try_endpoints (note :: attempted) rest
-        | Voice_config.Openai_compat | Voice_config.Elevenlabs_direct ->
+        else
             let output_file = Filename.temp_file "masc_voice_preview" ".mp3" in
             let result =
-              match endpoint.Voice_config.kind with
-              | Voice_config.Openai_compat ->
-                  speak_via_openai_compat_to_file endpoint ~agent_id:"preview"
-                    ~message:text ~voice ~model
-                    ~output_file
-              | Voice_config.Elevenlabs_direct ->
-                  speak_via_elevenlabs_to_file endpoint ~agent_id:"preview"
-                    ~message:text ~voice ~model
-                    ~output_file
-              | Voice_config.Voice_mcp -> assert false
+              speak_via_http_tts_to_file endpoint ~agent_id:"preview" ~message:text
+                ~voice ~model ~output_file
             in
             Fun.protect
               ~finally:(fun () -> (try Sys.remove output_file with Sys_error _ -> ()))
@@ -850,11 +766,13 @@ let call_voice_mcp_endpoint ~sw ~clock ~net ~endpoint ~tool_name ~arguments =
 
 let attempt_tts_endpoint ~sw ~clock ~net ~agent_id ~message ~voice ~model
     ~priority endpoint =
-  match endpoint.Voice_config.kind with
-  | Voice_config.Openai_compat ->
+  let adapter = Provider_adapter.voice_adapter_for_endpoint endpoint in
+  match adapter.transport with
+  | Provider_adapter.Voice_openai_compat
+  | Provider_adapter.Voice_elevenlabs_direct ->
       let audio_file = make_audio_file ~agent_id in
       (match
-         speak_via_openai_compat_to_file endpoint ~message ~voice ~model
+         speak_via_http_tts_to_file endpoint ~message ~voice ~model
            ~agent_id ~output_file:audio_file
        with
       | Ok file_size ->
@@ -876,32 +794,7 @@ let attempt_tts_endpoint ~sw ~clock ~net ~agent_id ~message ~voice ~model
       | Error error ->
           (try Sys.remove audio_file with Sys_error _ -> ());
           Error error)
-  | Voice_config.Elevenlabs_direct ->
-      let audio_file = make_audio_file ~agent_id in
-      (match
-         speak_via_elevenlabs_to_file endpoint ~message ~voice ~model
-           ~agent_id ~output_file:audio_file
-       with
-      | Ok file_size ->
-          start_local_playback ~sw ~agent_id ~audio_file;
-          Ok
-            (append_provider_metadata
-               (`Assoc
-                 [
-                   ("status", `String "spoken");
-                   ("agent_id", `String agent_id);
-                   ("voice", `String voice);
-                   ("audio_file", `String audio_file);
-                   ("audio_size", `Int file_size);
-                   ( "message_preview",
-                     `String
-                       (String.sub message 0 (min 50 (String.length message))) );
-                 ])
-               endpoint)
-      | Error error ->
-          (try Sys.remove audio_file with Sys_error _ -> ());
-          Error error)
-  | Voice_config.Voice_mcp ->
+  | Provider_adapter.Voice_mcp ->
       let args =
         `Assoc
           [

--- a/test/test_provider_adapter.ml
+++ b/test/test_provider_adapter.ml
@@ -102,6 +102,66 @@ let test_voice_auth_env_resolution () =
   check (option string) "endpoint override auth env"
     (Some "VOICE_PROXY_KEY")
     (Adapter.voice_auth_env_name ~endpoint_api_key_env:"VOICE_PROXY_KEY" openai_compat)
+
+let test_voice_http_request_openai_compat () =
+  let endpoint : Masc_mcp.Voice_config.endpoint =
+    {
+      id = "railway-elevenlabs-proxy";
+      kind = Openai_compat;
+      base_url = Some "https://example.test/v1/";
+      mcp_url = None;
+      health_url = None;
+      api_key_env = None;
+      enabled = true;
+      timeout_seconds = None;
+      max_retries = None;
+    }
+  in
+  let tuning : Masc_mcp.Voice_config.voice_tuning =
+    { stability = 0.28; similarity_boost = 0.82; style = 0.45 }
+  in
+  match
+    Adapter.voice_http_request_for_tts endpoint ~api_key:"" ~message:"hello"
+      ~voice:"Roger" ~model:"eleven_multilingual_v2" ~tuning
+  with
+  | Error msg -> fail msg
+  | Ok request ->
+      check string "openai compat url" "https://example.test/v1/audio/speech"
+        request.url;
+      check bool "has content-type" true
+        (List.mem ("Content-Type", "application/json") request.headers);
+      check string "body input" "hello"
+        Yojson.Safe.Util.(request.body_json |> member "input" |> to_string)
+
+let test_voice_http_request_elevenlabs_direct () =
+  let endpoint : Masc_mcp.Voice_config.endpoint =
+    {
+      id = "elevenlabs-direct";
+      kind = Elevenlabs_direct;
+      base_url = Some "https://api.elevenlabs.io/v1/";
+      mcp_url = None;
+      health_url = None;
+      api_key_env = Some "ELEVENLABS_API_KEY";
+      enabled = true;
+      timeout_seconds = None;
+      max_retries = None;
+    }
+  in
+  let tuning : Masc_mcp.Voice_config.voice_tuning =
+    { stability = 0.28; similarity_boost = 0.82; style = 0.45 }
+  in
+  match
+    Adapter.voice_http_request_for_tts endpoint ~api_key:"secret" ~message:"hello"
+      ~voice:"Roger" ~model:"eleven_multilingual_v2" ~tuning
+  with
+  | Error msg -> fail msg
+  | Ok request ->
+      check bool "uses elevenlabs path" true
+        (String.ends_with ~suffix:"/text-to-speech/CwhRBWXzGAHq8TQ4Fs17" request.url);
+      check bool "has xi-api-key" true
+        (List.mem ("xi-api-key", "secret") request.headers);
+      check string "body text" "hello"
+        Yojson.Safe.Util.(request.body_json |> member "text" |> to_string)
 let () =
   run "Provider Adapter"
     [
@@ -123,5 +183,9 @@ let () =
           test_case "resolve voice aliases" `Quick test_resolve_voice_aliases;
           test_case "voice auth env resolution" `Quick
             test_voice_auth_env_resolution;
+          test_case "voice http request openai compat" `Quick
+            test_voice_http_request_openai_compat;
+          test_case "voice http request elevenlabs direct" `Quick
+            test_voice_http_request_elevenlabs_direct;
         ] );
     ]

--- a/test/test_provider_adapter.ml
+++ b/test/test_provider_adapter.ml
@@ -103,65 +103,6 @@ let test_voice_auth_env_resolution () =
     (Some "VOICE_PROXY_KEY")
     (Adapter.voice_auth_env_name ~endpoint_api_key_env:"VOICE_PROXY_KEY" openai_compat)
 
-let test_voice_http_request_openai_compat () =
-  let endpoint : Masc_mcp.Voice_config.endpoint =
-    {
-      id = "railway-elevenlabs-proxy";
-      kind = Openai_compat;
-      base_url = Some "https://example.test/v1/";
-      mcp_url = None;
-      health_url = None;
-      api_key_env = None;
-      enabled = true;
-      timeout_seconds = None;
-      max_retries = None;
-    }
-  in
-  let tuning : Masc_mcp.Voice_config.voice_tuning =
-    { stability = 0.28; similarity_boost = 0.82; style = 0.45 }
-  in
-  match
-    Adapter.voice_http_request_for_tts endpoint ~api_key:"" ~message:"hello"
-      ~voice:"Roger" ~model:"eleven_multilingual_v2" ~tuning
-  with
-  | Error msg -> fail msg
-  | Ok request ->
-      check string "openai compat url" "https://example.test/v1/audio/speech"
-        request.url;
-      check bool "has content-type" true
-        (List.mem ("Content-Type", "application/json") request.headers);
-      check string "body input" "hello"
-        Yojson.Safe.Util.(request.body_json |> member "input" |> to_string)
-
-let test_voice_http_request_elevenlabs_direct () =
-  let endpoint : Masc_mcp.Voice_config.endpoint =
-    {
-      id = "elevenlabs-direct";
-      kind = Elevenlabs_direct;
-      base_url = Some "https://api.elevenlabs.io/v1/";
-      mcp_url = None;
-      health_url = None;
-      api_key_env = Some "ELEVENLABS_API_KEY";
-      enabled = true;
-      timeout_seconds = None;
-      max_retries = None;
-    }
-  in
-  let tuning : Masc_mcp.Voice_config.voice_tuning =
-    { stability = 0.28; similarity_boost = 0.82; style = 0.45 }
-  in
-  match
-    Adapter.voice_http_request_for_tts endpoint ~api_key:"secret" ~message:"hello"
-      ~voice:"Roger" ~model:"eleven_multilingual_v2" ~tuning
-  with
-  | Error msg -> fail msg
-  | Ok request ->
-      check bool "uses elevenlabs path" true
-        (String.ends_with ~suffix:"/text-to-speech/CwhRBWXzGAHq8TQ4Fs17" request.url);
-      check bool "has xi-api-key" true
-        (List.mem ("xi-api-key", "secret") request.headers);
-      check string "body text" "hello"
-        Yojson.Safe.Util.(request.body_json |> member "text" |> to_string)
 let () =
   run "Provider Adapter"
     [
@@ -183,9 +124,5 @@ let () =
           test_case "resolve voice aliases" `Quick test_resolve_voice_aliases;
           test_case "voice auth env resolution" `Quick
             test_voice_auth_env_resolution;
-          test_case "voice http request openai compat" `Quick
-            test_voice_http_request_openai_compat;
-          test_case "voice http request elevenlabs direct" `Quick
-            test_voice_http_request_elevenlabs_direct;
         ] );
     ]

--- a/test/test_tool_voice.ml
+++ b/test/test_tool_voice.ml
@@ -256,6 +256,112 @@ let test_voice_provider_alias_selects_adapter_endpoint () =
       let endpoint = List.hd endpoints in
       check string "selected direct endpoint" "elevenlabs-direct" endpoint.id
 
+let test_voice_request_builder_follows_adapter_contract () =
+  let config_json =
+    {|
+{
+  "tts": {
+    "default_model": "eleven_multilingual_v2",
+    "default_voice": "Roger",
+    "default_voice_settings": {
+      "stability": 0.28,
+      "similarity_boost": 0.82,
+      "style": 0.45
+    },
+    "endpoints": [
+      {
+        "id": "elevenlabs-direct",
+        "kind": "elevenlabs_direct",
+        "base_url": "https://api.elevenlabs.io/v1/",
+        "api_key_env": "ELEVENLABS_API_KEY",
+        "enabled": true
+      }
+    ]
+  },
+  "stt": {
+    "default_model": "whisper-1",
+    "endpoints": [
+      {
+        "id": "openai-stt",
+        "kind": "openai_compat",
+        "base_url": "https://api.openai.com/v1",
+        "enabled": true
+      }
+    ]
+  },
+  "session": {
+    "endpoints": [
+      {
+        "id": "local-session",
+        "kind": "voice_mcp",
+        "base_url": "http://127.0.0.1:8936",
+        "enabled": true
+      }
+    ]
+  }
+}
+|}
+  in
+  with_temp_voice_config config_json @@ fun () ->
+      let endpoint = List.hd (Masc_mcp.Voice_bridge.available_tts_endpoints ~provider:"elevenlabs" ()) in
+      let tuning = Masc_mcp.Voice_bridge.tuning_for_agent "sangsu" in
+      match
+        Masc_mcp.Provider_adapter.voice_http_request_for_tts endpoint ~api_key:"secret"
+          ~message:"hello" ~voice:"Roger" ~model:"eleven_multilingual_v2" ~tuning
+      with
+      | Error msg -> failf "request build failed: %s" msg
+      | Ok request ->
+          check bool "elevenlabs path" true
+            (String.ends_with ~suffix:"/text-to-speech/CwhRBWXzGAHq8TQ4Fs17" request.url);
+          check bool "has xi-api-key" true
+            (List.mem ("xi-api-key", "secret") request.headers)
+
+let test_voice_session_urls_follow_adapter_contract () =
+  let config_json =
+    {|
+{
+  "tts": {
+    "default_model": "eleven_multilingual_v2",
+    "default_voice": "Roger",
+    "endpoints": [
+      {
+        "id": "elevenlabs-direct",
+        "kind": "elevenlabs_direct",
+        "base_url": "https://api.elevenlabs.io/v1",
+        "enabled": true
+      }
+    ]
+  },
+  "stt": {
+    "default_model": "whisper-1",
+    "endpoints": [
+      {
+        "id": "openai-stt",
+        "kind": "openai_compat",
+        "base_url": "https://api.openai.com/v1",
+        "enabled": true
+      }
+    ]
+  },
+  "session": {
+    "endpoints": [
+      {
+        "id": "local-voice-mcp",
+        "kind": "voice_mcp",
+        "base_url": "https://voice.example/base",
+        "enabled": true
+      }
+    ]
+  }
+}
+|}
+  in
+  with_temp_voice_config config_json @@ fun () ->
+      check string "mcp uri" "https://voice.example/base/mcp"
+        (Uri.to_string (Masc_mcp.Voice_bridge.voice_mcp_uri ()));
+      check string "health uri" "https://voice.example/base/health"
+        (Uri.to_string (Masc_mcp.Voice_bridge.voice_health_uri ()))
+
 let test_voice_speak_without_net_errors () =
   with_ctx_no_net (fun ctx ->
       let ok, body =
@@ -485,6 +591,10 @@ let () =
             test_voice_agent_reads_nested_tuning_config;
           test_case "voice provider alias selects adapter endpoint" `Quick
             test_voice_provider_alias_selects_adapter_endpoint;
+          test_case "voice request builder follows adapter contract" `Quick
+            test_voice_request_builder_follows_adapter_contract;
+          test_case "voice session urls follow adapter contract" `Quick
+            test_voice_session_urls_follow_adapter_contract;
           test_case "speak without net errors" `Quick
             test_voice_speak_without_net_errors;
           test_case "session start no net" `Quick test_voice_session_start_without_net_errors;


### PR DESCRIPTION
## Summary
- move voice endpoint selection and auth resolution into Provider_adapter
- move HTTP TTS request shaping and voice_mcp session URL construction into Provider_adapter
- keep Voice_bridge as the execution shell with the same outward behavior

## Verification
- dune build --root . _build/default/test/test_provider_adapter.exe _build/default/test/test_tool_voice.exe _build/default/bin/main_eio.exe
- ./_build/default/test/test_provider_adapter.exe
- ./_build/default/test/test_tool_voice.exe