### PR TITLE
fix(sentinel): restore startup prompt bootstrap

### DIFF
--- a/bin/main_eio.ml
+++ b/bin/main_eio.ml
@@ -2547,7 +2547,7 @@ let run_server ~sw ~env ~host ~port ~base_path =
   let state = Mcp_eio.create_state_eio ~sw ~env:caqti_env ~proc_mgr ~fs ~clock ~net ~base_path in
   server_state := Some state;
   ignore (Masc_mcp.Room.init state.room_config ~agent_name:None);
-  Masc_mcp.Chain_native_eio.configure_storage_paths state.room_config;
+  Masc_mcp.Chain_native_eio.ensure_bootstrap state.room_config;
   (try Masc_mcp.Tool_command_plane.backfill_chain_overlays state.room_config
    with exn ->
      Printf.eprintf "[chain-backfill] startup backfill failed: %s\n%!"

--- a/test/dune
+++ b/test/dune
@@ -168,6 +168,11 @@
  (libraries masc_mcp alcotest yojson unix))
 
 (test
+ (name test_chain_native_eio_bootstrap)
+ (modules test_chain_native_eio_bootstrap)
+ (libraries masc_mcp alcotest yojson unix))
+
+(test
  (name test_metrics_store_eio)
  (modules test_metrics_store_eio)
  (libraries masc_mcp alcotest str yojson))

--- a/test/test_chain_native_eio_bootstrap.ml
+++ b/test/test_chain_native_eio_bootstrap.ml
@@ -1,0 +1,56 @@
+module Lib = Masc_mcp
+
+open Alcotest
+
+let test_dir () =
+  let tmp = Filename.temp_file "masc_chain_bootstrap" "" in
+  Sys.remove tmp;
+  Unix.mkdir tmp 0o755;
+  tmp
+
+let cleanup_dir dir =
+  let rec rm path =
+    if Sys.file_exists path then
+      if Sys.is_directory path then begin
+        Sys.readdir path |> Array.iter (fun f -> rm (Filename.concat path f));
+        Unix.rmdir path
+      end else
+        Sys.remove path
+  in
+  rm dir
+
+let test_ensure_bootstrap_loads_sentinel_prompts () =
+  let dir = test_dir () in
+  let previous_source_base = Sys.getenv_opt "MASC_CHAIN_SOURCE_BASE_PATH" in
+  Fun.protect
+    ~finally:(fun () ->
+      (match previous_source_base with
+       | Some value -> Unix.putenv "MASC_CHAIN_SOURCE_BASE_PATH" value
+       | None -> Unix.putenv "MASC_CHAIN_SOURCE_BASE_PATH" "");
+      cleanup_dir dir)
+    (fun () ->
+      let source_root =
+        match Sys.getenv_opt "DUNE_SOURCEROOT" with
+        | Some value -> value
+        | None -> Sys.getcwd ()
+      in
+      Unix.putenv "MASC_CHAIN_SOURCE_BASE_PATH" source_root;
+      let config = Lib.Room.default_config dir in
+      ignore (Lib.Room.init config ~agent_name:(Some "fixture-root"));
+      Lib.Chain_native_eio.ensure_bootstrap config;
+      check bool "sentinel-board-patrol registered" true
+        (Option.is_some (Lib.Prompt_registry.get ~id:"sentinel-board-patrol" ()));
+      check bool "sentinel-task-hygiene registered" true
+        (Option.is_some (Lib.Prompt_registry.get ~id:"sentinel-task-hygiene" ()));
+      check bool "sentinel-keeper-health registered" true
+        (Option.is_some (Lib.Prompt_registry.get ~id:"sentinel-keeper-health" ())))
+
+let () =
+  Alcotest.run "chain_native_eio_bootstrap"
+    [
+      ( "bootstrap",
+        [
+          test_case "loads sentinel prompts from repo data/prompts" `Quick
+            test_ensure_bootstrap_loads_sentinel_prompts;
+        ] );
+    ]


### PR DESCRIPTION
## Summary
- restore startup prompt/bootstrap loading before sentinel starts
- load bundled sentinel prompts at server startup again
- add a regression test that ensure_bootstrap registers sentinel prompts from repo data/prompts

## Verification
- dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix-sentinel-bootstrap-startup ./bin/main_eio.exe ./test/test_chain_native_eio_bootstrap.exe
- env DUNE_SOURCEROOT=/Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix-sentinel-bootstrap-startup timeout 120 /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix-sentinel-bootstrap-startup/_build/default/test/test_chain_native_eio_bootstrap.exe