### PR TITLE
fix: surface keeper tool audit fallbacks

### DIFF
--- a/lib/dashboard_mission.ml
+++ b/lib/dashboard_mission.ml
@@ -177,6 +177,58 @@ let tool_audit_json_fields agent_name =
     ("tool_audit_at", json_string_option tool_audit_at);
   ]
 
+let keeper_tool_audit_json_fields keeper agent_name =
+  let fallback_allowed =
+    Dashboard_utils.string_list_of_json (member_assoc "allowed_tool_names" keeper)
+  in
+  let fallback_latest =
+    Dashboard_utils.string_list_of_json (member_assoc "latest_tool_names" keeper)
+  in
+  let fallback_count =
+    match member_assoc "latest_tool_call_count" keeper with
+    | `Int value -> Some value
+    | `Intlit raw -> (try Some (int_of_string raw) with Failure _ -> None)
+    | _ -> if fallback_latest = [] then None else Some (List.length fallback_latest)
+  in
+  let fallback_source =
+    trim_to_option (string_field "tool_audit_source" keeper)
+  in
+  let fallback_at =
+    trim_to_option (string_field "tool_audit_at" keeper)
+  in
+  let allowed_tool_names, latest_tool_names, latest_tool_call_count,
+      tool_audit_source, tool_audit_at =
+    match A2a_tools.latest_heartbeat_task agent_name,
+          A2a_tools.latest_heartbeat_result agent_name with
+    | Some task, Some result ->
+        if task.seq > result.seq then
+          (task.allowed_tools, [], None, Some "heartbeat_task", Some task.created_at)
+        else
+          ( task.allowed_tools,
+            result.tool_names,
+            Some result.tool_call_count,
+            Some "heartbeat_result",
+            Some result.updated_at )
+    | Some task, None ->
+        (task.allowed_tools, [], None, Some "heartbeat_task", Some task.created_at)
+    | None, Some result ->
+        ( fallback_allowed,
+          result.tool_names,
+          Some result.tool_call_count,
+          Some "heartbeat_result",
+          Some result.updated_at )
+    | None, None ->
+        (fallback_allowed, fallback_latest, fallback_count, fallback_source, fallback_at)
+  in
+  [
+    ("allowed_tool_names", string_list_json allowed_tool_names);
+    ("latest_tool_names", string_list_json latest_tool_names);
+    ( "latest_tool_call_count",
+      option_to_json (fun value -> `Int value) latest_tool_call_count );
+    ("tool_audit_source", json_string_option tool_audit_source);
+    ("tool_audit_at", json_string_option tool_audit_at);
+  ]
+
 let recent_tool_names_for_agent agent_name =
   match A2a_tools.latest_heartbeat_result agent_name with
   | Some snapshot -> snapshot.tool_names
@@ -908,7 +960,7 @@ let build_keeper_briefs snapshot_json =
                            | None -> trim_to_option (string_field "goal" keeper)) );
                       ("last_autonomous_action_at", member_assoc "last_autonomous_action_at" keeper);
                     ]
-                    @ tool_audit_json_fields
+                    @ keeper_tool_audit_json_fields keeper
                         (match trim_to_option (string_field "agent_name" keeper) with
                          | Some agent_name -> agent_name
                          | None -> name));

--- a/lib/operator_control.ml
+++ b/lib/operator_control.ml
@@ -541,6 +541,64 @@ let recent_messages_json config =
   |> List.map Types.message_to_yojson
   |> fun rows -> `List rows
 
+let latest_keeper_tools_from_metrics config keeper_name =
+  let metrics_path = Keeper_types.keeper_metrics_path config keeper_name in
+  Keeper_memory.read_file_tail_lines metrics_path ~max_bytes:40000 ~max_lines:8
+  |> List.rev
+  |> List.find_map (fun line ->
+         try
+           let json = Yojson.Safe.from_string line in
+           let tools =
+             match Yojson.Safe.Util.member "tools_used" json with
+             | `List items ->
+                 items
+                 |> List.filter_map (function
+                        | `String tool ->
+                            let trimmed = String.trim tool in
+                            if trimmed = "" then None else Some trimmed
+                        | _ -> None)
+             | _ -> []
+           in
+           if tools = [] then None else Some (List.sort_uniq String.compare tools)
+         with Yojson.Json_error _ -> None)
+  |> Option.value ~default:[]
+
+let keeper_tool_audit_fields config (meta : Keeper_types.keeper_meta) =
+  let fallback_allowed = Keeper_execution.keeper_allowed_tool_names meta in
+  let fallback_latest = latest_keeper_tools_from_metrics config meta.name in
+  let fallback_count =
+    if fallback_latest = [] then None else Some (List.length fallback_latest)
+  in
+  let fallback_source =
+    if fallback_latest <> [] then Some "keeper_metrics" else Some "keeper_policy"
+  in
+  let fallback_at =
+    let last_autonomous = String.trim meta.last_autonomous_action_at in
+    if last_autonomous <> "" then Some last_autonomous
+    else Some meta.updated_at
+  in
+  match A2a_tools.latest_heartbeat_task meta.agent_name,
+        A2a_tools.latest_heartbeat_result meta.agent_name with
+  | Some task, Some result ->
+      if task.seq > result.seq then
+        (task.allowed_tools, [], None, Some "heartbeat_task", Some task.created_at)
+      else
+        ( task.allowed_tools,
+          result.tool_names,
+          Some result.tool_call_count,
+          Some "heartbeat_result",
+          Some result.updated_at )
+  | Some task, None ->
+      (task.allowed_tools, [], None, Some "heartbeat_task", Some task.created_at)
+  | None, Some result ->
+      ( fallback_allowed,
+        result.tool_names,
+        Some result.tool_call_count,
+        Some "heartbeat_result",
+        Some result.updated_at )
+  | None, None ->
+      (fallback_allowed, fallback_latest, fallback_count, fallback_source, fallback_at)
+
 let keepers_json config =
   let names = Keeper_types.resident_keeper_names config in
   let rows =
@@ -552,10 +610,29 @@ let keepers_json config =
             let agent_json =
               Keeper_execution.parse_agent_status config ~agent_name:meta.agent_name
             in
+            let keepalive_running =
+              Keeper_execution.keeper_keepalive_running meta.name
+            in
+            let agent_exists =
+              match agent_json |> U.member "exists" with
+              | `Bool value -> value
+              | _ -> false
+            in
+            let diagnostic =
+              Keeper_execution.keeper_diagnostic_json ~meta
+                ~agent_status:agent_json ~keepalive_running ~history_items:[]
+                ~now_ts:(Time_compat.now ())
+            in
+            let allowed_tool_names, latest_tool_names, latest_tool_call_count,
+                tool_audit_source, tool_audit_at =
+              keeper_tool_audit_fields config meta
+            in
             let agent_status =
-              match agent_json |> U.member "status" with
-              | `String status -> status
-              | _ -> "unknown"
+              if not agent_exists then "offline"
+              else
+                match agent_json |> U.member "status" with
+                | `String status -> status
+                | _ -> "unknown"
             in
             Some
               (`Assoc
@@ -571,12 +648,15 @@ let keepers_json config =
                   ("mid_goal", `String meta.mid_goal);
                   ("long_goal", `String meta.long_goal);
                   ("status", `String agent_status);
+                  ("agent", agent_json);
+                  ("diagnostic", diagnostic);
                   ("generation", `Int meta.generation);
                   ("turn_count", `Int meta.total_turns);
                   ("context_ratio", `Null);
                   ("context_tokens", `Int meta.last_total_tokens);
                   ("last_model_used", `String meta.last_model_used);
                   ("active_model", `String (Keeper_execution.active_model_of_meta meta));
+                  ("keepalive_running", `Bool keepalive_running);
                   ( "next_model_hint",
                     string_option_to_json (Keeper_execution.next_model_hint_of_meta meta)
                   );
@@ -588,6 +668,12 @@ let keepers_json config =
                     if String.trim meta.last_autonomous_action_at = "" then `Null
                     else `String meta.last_autonomous_action_at );
                   ("autonomous_action_count", `Int meta.autonomous_action_count);
+                  ("allowed_tool_names", `List (List.map (fun value -> `String value) allowed_tool_names));
+                  ("latest_tool_names", `List (List.map (fun value -> `String value) latest_tool_names));
+                  ("recent_tool_names", `List (List.map (fun value -> `String value) latest_tool_names));
+                  ("latest_tool_call_count", option_to_json (fun value -> `Int value) latest_tool_call_count);
+                  ("tool_audit_source", string_option_to_json tool_audit_source);
+                  ("tool_audit_at", string_option_to_json tool_audit_at);
                   ("updated_at", `String meta.updated_at);
                   ("created_at", `String meta.created_at);
                 ]))

--- a/test/test_dashboard_mission.ml
+++ b/test/test_dashboard_mission.ml
@@ -21,6 +21,11 @@ let cleanup_dir dir =
   in
   rm dir
 
+let dispatch_keeper_exn ctx ~name ~args =
+  match Lib.Tool_keeper.dispatch ctx ~name ~args with
+  | Some result -> result
+  | None -> failwith ("keeper dispatch missing: " ^ name)
+
 let contains str substr =
   try
     ignore (Str.search_forward (Str.regexp_string substr) str 0);
@@ -416,10 +421,62 @@ let test_dashboard_mission_projection () =
           ((session_detail |> member "operations" |> to_list) <> []);
       ))
 
+let test_dashboard_mission_keeper_tool_audit_fallback () =
+  let dir = test_dir () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir dir)
+    (fun () ->
+      let config = Lib.Room_utils.default_config dir in
+      ignore (Lib.Room.init config ~agent_name:(Some "fixture-root"));
+      Eio_main.run @@ fun env ->
+      Eio.Switch.run (fun sw ->
+        let keeper_ctx : _ Lib.Tool_keeper.context =
+          { config; sw; clock = Eio.Stdenv.clock env }
+        in
+        let keeper_name = "audit-keeper" in
+        let ok, _ =
+          dispatch_keeper_exn keeper_ctx ~name:"masc_keeper_up"
+            ~args:
+              (`Assoc
+                [
+                  ("name", `String keeper_name);
+                  ("goal", `String "Dashboard mission keeper fallback");
+                  ("models", `List [ `String "llama:qwen3.5-35b-a3b-ud-q8-xl" ]);
+                  ("presence_keepalive", `Bool false);
+                  ("proactive_enabled", `Bool false);
+                ])
+        in
+        check bool "keeper up ok" true ok;
+        let json =
+          Lib.Dashboard_mission.json
+            ~actor:"test-dashboard"
+            ~config
+            ~sw
+            ~clock:(Eio.Stdenv.clock env)
+            ~proc_mgr:None
+            ()
+        in
+        let open Yojson.Safe.Util in
+        let brief =
+          json |> member "keeper_briefs" |> to_list
+          |> List.find (fun row -> row |> member "name" |> to_string = keeper_name)
+        in
+        check bool "fallback allowed tools present" true
+          ((brief |> member "allowed_tool_names" |> to_list) <> []);
+        check string "fallback source" "keeper_policy"
+          (brief |> member "tool_audit_source" |> to_string);
+        check bool "no observed tools without evidence" true
+          ((brief |> member "latest_tool_names" |> to_list) = []);
+      ))
+
 let () =
   Alcotest.run "Dashboard Mission"
     [
       ( "read_model",
-        [ Alcotest.test_case "projection groups root-cause lanes" `Quick
-            test_dashboard_mission_projection ] );
+        [
+          Alcotest.test_case "projection groups root-cause lanes" `Quick
+            test_dashboard_mission_projection;
+          Alcotest.test_case "keeper tool audit fallback" `Quick
+            test_dashboard_mission_keeper_tool_audit_fallback;
+        ] );
     ]

--- a/test/test_operator_control.ml
+++ b/test/test_operator_control.ml
@@ -1593,6 +1593,53 @@ let test_keeper_status_exposes_summary_and_recoverable () =
       Alcotest.(check bool) "summary present" true
         (String.length Yojson.Safe.Util.(diagnostic |> member "summary" |> to_string) > 0))
 
+let test_snapshot_keeper_tool_audit_fallback () =
+  Eio_main.run @@ fun env ->
+  Eio.Switch.run @@ fun sw ->
+  let base_dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base_dir)
+    (fun () ->
+      let config = Room.default_config base_dir in
+      ignore (Room.init config ~agent_name:(Some "operator"));
+      let keeper_ctx : _ Tool_keeper.context =
+        { config; sw; clock = Eio.Stdenv.clock env }
+      in
+      let keeper_name = "audit-keeper" in
+      let ok, _ =
+        dispatch_keeper_exn keeper_ctx ~name:"masc_keeper_up"
+          ~args:
+            (`Assoc
+              [
+                ("name", `String keeper_name);
+                ("goal", `String "Expose dashboard fallback keeper audit");
+                ("models", `List [ `String "llama:qwen3.5-35b-a3b-ud-q8-xl" ]);
+                ("presence_keepalive", `Bool false);
+                ("proactive_enabled", `Bool false);
+              ])
+      in
+      Alcotest.(check bool) "keeper up ok" true ok;
+      let snapshot =
+        Operator_control.snapshot_json ~include_messages:false ~include_sessions:false
+          ~include_keepers:true (operator_ctx env sw config "operator")
+      in
+      let open Yojson.Safe.Util in
+      let keeper =
+        snapshot
+        |> member "keepers" |> member "items" |> to_list
+        |> List.find (fun row -> row |> member "name" |> to_string = keeper_name)
+      in
+      Alcotest.(check string) "offline when no agent runtime" "offline"
+        (keeper |> member "status" |> to_string);
+      Alcotest.(check bool) "allowed tool fallback present" true
+        ((keeper |> member "allowed_tool_names" |> to_list) <> []);
+      Alcotest.(check string) "tool audit source fallback" "keeper_policy"
+        (keeper |> member "tool_audit_source" |> to_string);
+      Alcotest.(check bool) "diagnostic present" true
+        (keeper |> member "diagnostic" <> `Null);
+      Alcotest.(check string) "diagnostic health offline" "offline"
+        (keeper |> member "diagnostic" |> member "health_state" |> to_string))
+
 let test_manual_lodge_tick_updates_observable_state () =
   let base_dir = temp_dir () in
   Fun.protect
@@ -1678,6 +1725,8 @@ let () =
             test_select_checkin_agents_manual_override_quiet_hours;
           Alcotest.test_case "keeper status exposes summary and recoverable" `Quick
             test_keeper_status_exposes_summary_and_recoverable;
+          Alcotest.test_case "snapshot keeper tool audit fallback" `Quick
+            test_snapshot_keeper_tool_audit_fallback;
           Alcotest.test_case "manual lodge tick updates observable state" `Quick
             test_manual_lodge_tick_updates_observable_state;
           Alcotest.test_case "expired confirmation rejected" `Quick


### PR DESCRIPTION
## Summary
- keep resident keeper snapshot rows from collapsing to empty tool-audit fields when no heartbeat_task/result evidence exists
- fall back to keeper policy and metrics-tail data for allowed/latest tool names in operator/dashboard mission projections
- mark keepers without a live agent runtime as `offline` instead of generic `unknown`

## Validation
- `dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix-keeper-dashboard-tool-audit`
- `dune exec --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix-keeper-dashboard-tool-audit ./test/test_operator_control.exe -- test operator 23`
- `dune exec --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix-keeper-dashboard-tool-audit ./test/test_dashboard_mission.exe -- test read_model 1`

## Follow-up
- keeper runtime를 truly always-on / auto-recover 상태로 만드는 작업은 별도 PR로 분리합니다. This PR only fixes the dashboard/read-model truthfulness gap.