### PR TITLE
fix(room): use native Unix.isatty check to prevent tty command error spam in headless mode

### DIFF
--- a/lib/room.ml
+++ b/lib/room.ml
@@ -233,9 +233,13 @@ let get_tty () =
     | Some tty -> Some tty
     | None ->
         (* Try to read from tty command — argv-based (no shell) *)
-        let output = Process_eio.run_argv ~timeout_sec:5.0 ["tty"] in
-        let trimmed = String.trim output in
-        if String.length trimmed > 0 then Some trimmed else None
+        try
+          if Unix.isatty Unix.stdin then
+            let output = Process_eio.run_argv ~timeout_sec:5.0 ["tty"] in
+            let trimmed = String.trim output in
+            if String.length trimmed > 0 then Some trimmed else None
+          else None
+        with Unix.Unix_error _ -> None
   with e ->
     Printf.eprintf "[WARN] get_tty failed: %s\n%!" (Printexc.to_string e);
     None


### PR DESCRIPTION
## Description
Fixes an issue where `Process_eio.run_argv ~timeout_sec:5.0 ["tty"]` would constantly spam the logs with `Child_error Exited (code 1)` when `masc-mcp` is running in the background or in a non-TTY environment.

## Changes
- Wrapped the `tty` subprocess call with `Unix.isatty Unix.stdin` to prevent execution when no TTY is attached.
- Wrapped in a Unix.Unix_error catch to fail gracefully.