### PR TITLE
chore: replace unsafe Yojson and List access with safe option parsing

### DIFF
--- a/lib/auto_responder.ml
+++ b/lib/auto_responder.ml
@@ -204,8 +204,9 @@ let masc_call ~sw ~tool_name ~(args : Yojson.Safe.t) : (string, string) result =
           try
             let json = Yojson.Safe.from_string body_str in
             let txt =
-              json |> member "result" |> member "content" |> to_list |> List.hd
-                  |> member "text" |> to_string
+              match json |> member "result" |> member "content" |> to_list with
+              | item :: _ -> item |> member "text" |> to_string
+              | [] -> raise (Failure "empty content list")
             in
             Ok txt
           with exn ->

--- a/lib/lodge_heartbeat.ml
+++ b/lib/lodge_heartbeat.ml
@@ -3041,21 +3041,24 @@ let load_agent_specialties_from_neo4j () =
     List.filter_map (fun record ->
       try
         let arr = Yojson.Safe.Util.to_list record in
-        let inner = Yojson.Safe.Util.to_list (List.hd arr) in
-        let name = Yojson.Safe.Util.to_string (List.nth inner 0) in
-        let traits = Yojson.Safe.Util.(List.nth inner 1 |> to_list |> List.map to_string) in
-        let description =
-          match List.nth inner 2 with
-          | `Null -> ""
-          | `String s -> s
-          | _ -> ""
-        in
-        (* Combine traits + words from description as keywords *)
-        let desc_words = description
-          |> String.split_on_char ' '
-          |> List.filter (fun w -> String.length w > 3)
-        in
-        Some (name, traits @ desc_words)
+        match arr with
+        | inner_node :: _ ->
+          let inner = Yojson.Safe.Util.to_list inner_node in
+          let name = Yojson.Safe.Util.to_string (List.nth inner 0) in
+          let traits = Yojson.Safe.Util.(List.nth inner 1 |> to_list |> List.map to_string) in
+          let description =
+            match List.nth inner 2 with
+            | `Null -> ""
+            | `String s -> s
+            | _ -> ""
+          in
+          (* Combine traits + words from description as keywords *)
+          let desc_words = description
+            |> String.split_on_char ' '
+            |> List.filter (fun w -> String.length w > 3)
+          in
+          Some (name, traits @ desc_words)
+        | [] -> None
       with Yojson.Safe.Util.Type_error _ | Failure _ -> None
     ) records
   with

--- a/lib/tool_llama.ml
+++ b/lib/tool_llama.ml
@@ -286,10 +286,11 @@ let raw_completion_at ~server_url ~model_id ~prompt ~max_tokens ~timeout_sec () 
                   { success = false; latency_ms; error = Some "llama returned error" })
           | _ ->
               ignore
-                (json |> member "choices" |> to_list |> List.hd
-                |> member "message" |> member "content" |> to_string_option);
+                (match json |> member "choices" |> to_list with
+                 | choice :: _ -> choice |> member "message" |> member "content" |> to_string_option
+                 | [] -> None);
               { success = true; latency_ms; error = None }
-        with Yojson.Json_error _ | Yojson.Safe.Util.Type_error _ ->
+        with Yojson.Json_error _ | Yojson.Safe.Util.Type_error _ | Failure _ ->
           { success = false; latency_ms; error = Some "invalid llama response json" })
     | Unix.WEXITED code ->
         {

--- a/lib/tool_perpetual.ml
+++ b/lib/tool_perpetual.ml
@@ -140,21 +140,16 @@ let active_agents : (string, Perpetual_loop.loop_state * Perpetual_loop.loop_con
 let latest_trace_id : string option ref = ref None
 
 let handle_start ctx args =
-  let open Yojson.Safe.Util in
-  let goal = args |> member "goal" |> to_string in
-  let model_strs = args |> member "models" |> to_list |> List.map to_string in
-  let verify = args |> member "verify" |> to_bool_option
-               |> Option.value ~default:true in
-  let heartbeat = args |> member "heartbeat_sec" |> to_number_option
-                  |> Option.value ~default:30.0 in
-  let max_idle = args |> member "max_idle" |> to_int_option
-                 |> Option.value ~default:5 in
-  let coding_mode = args |> member "coding_mode" |> to_bool_option
-                    |> Option.value ~default:false in
-  let coding_agent = args |> member "coding_agent" |> to_string_option
-                     |> Option.value ~default:(Provider_adapter.default_cli_agent_name ()) in
-  let coding_timeout = args |> member "coding_timeout_sec" |> to_int_option
-                       |> Option.value ~default:Env_config.Spawn.coding_timeout_seconds in
+  let goal = Safe_ops.json_string "goal" args in
+  let model_strs = Safe_ops.json_string_list "models" args in
+  let verify = Safe_ops.json_bool ~default:true "verify" args in
+  let heartbeat = Safe_ops.json_float ~default:30.0 "heartbeat_sec" args in
+  let max_idle = Safe_ops.json_int ~default:5 "max_idle" args in
+  let coding_mode = Safe_ops.json_bool ~default:false "coding_mode" args in
+  let coding_agent = match Safe_ops.json_string_opt "coding_agent" args with
+                     | Some s -> s
+                     | None -> Provider_adapter.default_cli_agent_name () in
+  let coding_timeout = Safe_ops.json_int ~default:Env_config.Spawn.coding_timeout_seconds "coding_timeout_sec" args in
   (* Parse model specs *)
   let models = List.filter_map (fun s ->
     match Llm_client.model_spec_of_string s with


### PR DESCRIPTION
## Description
Fixes potential uncaught `Type_error` and `Failure "hd"` exceptions when parsing JSON or dealing with empty arrays in several modules.
- Replaced `List.hd` usages with pattern matching to handle empty lists gracefully in `auto_responder`, `lodge_heartbeat`, and `tool_llama`.
- Adopted `Safe_ops` parsers in `tool_perpetual` to replace raw `Yojson.Safe.Util` accesses.

This prevents silent tool-call failures and provides safer defaults.