### PR TITLE
fix: harden supervisor session harness and tool surfaces

### DIFF
--- a/lib/auth.ml
+++ b/lib/auth.ml
@@ -295,6 +295,11 @@ let permission_for_tool = function
   | "masc_interrupt" | "masc_branch" -> Some CanInterrupt
   | "masc_approve" | "masc_reject" -> Some CanApprove
   | "masc_cost_log" | "masc_cleanup_zombies" -> Some CanBroadcast (* Worker level *)
+  | "masc_board_list" | "masc_board_get" | "masc_board_hearths"
+  | "masc_board_search" | "masc_board_profile" | "masc_board_stats" ->
+      Some CanReadState
+  | "masc_board_post" | "masc_board_comment" | "masc_board_vote"
+  | "masc_board_comment_vote" -> Some CanBroadcast
   (* Auth tools - special handling *)
   | "masc_auth_enable" | "masc_auth_disable" | "masc_auth_create_token"
   | "masc_auth_revoke" -> Some CanInit  (* Admin only *)

--- a/lib/auth.ml
+++ b/lib/auth.ml
@@ -299,6 +299,9 @@ let permission_for_tool = function
   | "masc_auth_enable" | "masc_auth_disable" | "masc_auth_create_token"
   | "masc_auth_revoke" -> Some CanInit  (* Admin only *)
   | "masc_auth_status" | "masc_auth_refresh" -> Some CanReadState
+  | "masc_tool_stats" | "masc_tool_help" | "masc_keeper_tool_catalog"
+  | "masc_tool_list" -> Some CanReadState
+  | "masc_tool_grant" | "masc_tool_revoke" -> Some CanAdmin
   | "masc_tool_admin_snapshot" -> Some CanReadState
   | "masc_tool_admin_update" -> Some CanAdmin
   | _ -> None

--- a/lib/spawn.ml
+++ b/lib/spawn.ml
@@ -53,6 +53,19 @@ let masc_mcp_tools = [
   "mcp__masc__masc_memento_mori";
   "mcp__masc__masc_relay_status";
   "mcp__masc__masc_relay_checkpoint";
+  (* Board tools *)
+  "mcp__masc__masc_board_list";
+  "mcp__masc__masc_board_post";
+  "mcp__masc__masc_board_comment";
+  "mcp__masc__masc_board_vote";
+  "mcp__masc__masc_board_get";
+  (* Tool management + discovery *)
+  "mcp__masc__masc_tool_help";
+  "mcp__masc__masc_tool_admin_snapshot";
+  "mcp__masc__masc_keeper_tool_catalog";
+  "mcp__masc__masc_tool_list";
+  "mcp__masc__masc_tool_grant";
+  "mcp__masc__masc_tool_revoke";
   (* Team session + communication tools *)
   "mcp__masc__masc_portal_open";
   "mcp__masc__masc_portal_send";
@@ -80,6 +93,8 @@ let masc_mcp_tools = [
   "mcp__masc__masc_run_log";
   "mcp__masc__masc_run_deliverable";
   "mcp__masc__masc_run_get";
+  "mcp__masc__masc_spawn";
+  "mcp__masc__masc_heartbeat_list";
   (* TRPG tools *)
   "mcp__masc__masc_trpg_dice_roll";
   "mcp__masc__masc_trpg_turn_advance";

--- a/lib/spawn.ml
+++ b/lib/spawn.ml
@@ -60,6 +60,7 @@ let masc_mcp_tools = [
   "mcp__masc__masc_board_vote";
   "mcp__masc__masc_board_get";
   (* Tool management + discovery *)
+  "mcp__masc__masc_tool_stats";
   "mcp__masc__masc_tool_help";
   "mcp__masc__masc_tool_admin_snapshot";
   "mcp__masc__masc_keeper_tool_catalog";

--- a/lib/spawn_eio.ml
+++ b/lib/spawn_eio.ml
@@ -60,6 +60,12 @@ let masc_mcp_tools = [
   "mcp__masc__masc_board_comment";
   "mcp__masc__masc_board_vote";
   "mcp__masc__masc_board_get";
+  "mcp__masc__masc_tool_help";
+  "mcp__masc__masc_tool_admin_snapshot";
+  "mcp__masc__masc_keeper_tool_catalog";
+  "mcp__masc__masc_tool_list";
+  "mcp__masc__masc_tool_grant";
+  "mcp__masc__masc_tool_revoke";
   "mcp__masc__masc_portal_open";
   "mcp__masc__masc_portal_send";
   "mcp__masc__masc_portal_status";

--- a/lib/spawn_eio.ml
+++ b/lib/spawn_eio.ml
@@ -60,6 +60,7 @@ let masc_mcp_tools = [
   "mcp__masc__masc_board_comment";
   "mcp__masc__masc_board_vote";
   "mcp__masc__masc_board_get";
+  "mcp__masc__masc_tool_stats";
   "mcp__masc__masc_tool_help";
   "mcp__masc__masc_tool_admin_snapshot";
   "mcp__masc__masc_keeper_tool_catalog";

--- a/scripts/harness/workload/supervisor_team_session.sh
+++ b/scripts/harness/workload/supervisor_team_session.sh
@@ -19,6 +19,7 @@ TEAM_GOAL="${TEAM_GOAL:-Demonstrate a full llama worker team supervised over /mc
 LLAMA_SWARM_MODEL="${LLAMA_SWARM_MODEL:-}"
 SWARM_WORKER_BATCH_JSON="${SWARM_WORKER_BATCH_JSON:-}"
 SWARM_INTERVENTION_MODE="${SWARM_INTERVENTION_MODE:-default}"
+TEAM_SESSION_DURATION_SECONDS="${TEAM_SESSION_DURATION_SECONDS:-180}"
 
 if ! command -v jq >/dev/null 2>&1; then
   echo "jq is required"
@@ -116,6 +117,14 @@ extract_response_error() {
 
 extract_is_error() {
   jq -r 'try (.result.isError) catch "false"'
+}
+
+team_session_status() {
+  local session_id="$1"
+  local status_raw
+  status_raw="$(call_tool "$MCP_URL" "$SUPERVISOR_SESSION_ID" "$SUPERVISOR_TOKEN" 14 "masc_team_session_status" "$(jq -cn --arg s "$session_id" '{session_id:$s}')")"
+  require_tool_success "$status_raw"
+  printf '%s' "$status_raw" | extract_tool_result | jq -r '.session.status // empty'
 }
 
 default_worker_batch_json() {
@@ -336,7 +345,8 @@ printf '[5/10] start supervised team session\n'
 start_payload="$(jq -cn \
   --arg goal "$TEAM_GOAL" \
   --arg supervisor "$SUPERVISOR_NICKNAME" \
-  '{goal:$goal, duration_seconds:180, checkpoint_interval_sec:15, orchestration_mode:"assist", communication_mode:"broadcast", execution_scope:"limited_code_change", fallback_policy:"cascade_then_task", instruction_profile:"strict", min_agents:4, agents:[$supervisor]}')"
+  --argjson duration "$TEAM_SESSION_DURATION_SECONDS" \
+  '{goal:$goal, duration_seconds:$duration, checkpoint_interval_sec:15, orchestration_mode:"assist", communication_mode:"broadcast", execution_scope:"limited_code_change", fallback_policy:"cascade_then_task", instruction_profile:"strict", min_agents:4, agents:[$supervisor]}')"
 start_raw="$(call_tool "$MCP_URL" "$SUPERVISOR_SESSION_ID" "$SUPERVISOR_TOKEN" 3 "masc_team_session_start" "$start_payload")"
 require_tool_success "$start_raw"
 TEAM_SESSION_ID="$(printf '%s' "$start_raw" | extract_tool_result | jq -r '.session_id // empty')"
@@ -374,37 +384,47 @@ printf '%s' "$digest_raw" | extract_tool_result | jq -e '.target_type == "team_s
 
 printf '[8/10] supervisor immediate correction via team_note\n'
 if [ "$SWARM_INTERVENTION_MODE" = "default" ]; then
-  team_note_raw="$(call_tool "$OPERATOR_URL" "$SUPERVISOR_OP_SESSION_ID" "$SUPERVISOR_TOKEN" 6 "masc_operator_action" "$(jq -cn --arg actor "$SUPERVISOR_NICKNAME" --arg s "$TEAM_SESSION_ID" '{actor:$actor,action_type:"team_note",target_id:$s,payload:{message:"[supervisor] keep the proof focused on the MCP loop"}}')")"
-  require_tool_success "$team_note_raw"
-  printf '%s' "$team_note_raw" | extract_tool_text | jq -e '.confirm_required == false' >/dev/null
+  TEAM_SESSION_STATUS="$(team_session_status "$TEAM_SESSION_ID")"
+  if [ "$TEAM_SESSION_STATUS" = "running" ]; then
+    team_note_raw="$(call_tool "$OPERATOR_URL" "$SUPERVISOR_OP_SESSION_ID" "$SUPERVISOR_TOKEN" 6 "masc_operator_action" "$(jq -cn --arg actor "$SUPERVISOR_NICKNAME" --arg s "$TEAM_SESSION_ID" '{actor:$actor,action_type:"team_note",target_id:$s,payload:{message:"[supervisor] keep the proof focused on the MCP loop"}}')")"
+    require_tool_success "$team_note_raw"
+    printf '%s' "$team_note_raw" | extract_tool_text | jq -e '.confirm_required == false' >/dev/null
 
-  printf '[9/10] supervisor disruptive correction via preview + confirm\n'
-  preview_raw="$(call_tool "$OPERATOR_URL" "$SUPERVISOR_OP_SESSION_ID" "$SUPERVISOR_TOKEN" 7 "masc_operator_action" "$(jq -cn --arg actor "$SUPERVISOR_NICKNAME" --arg s "$TEAM_SESSION_ID" '{actor:$actor,action_type:"team_task_inject",target_id:$s,payload:{title:"Capture explicit supervisor proof",description:"Add evidence that preview-confirm changed the session trajectory.",priority:1}}')")"
-  require_tool_success "$preview_raw"
-  CONFIRM_TOKEN="$(printf '%s' "$preview_raw" | extract_tool_text | jq -r '.confirm_token // empty')"
-  if [ -z "$CONFIRM_TOKEN" ]; then
-    echo "FAIL: missing confirm token"
-    printf '%s\n' "$preview_raw"
-    exit 1
+    printf '[9/10] supervisor disruptive correction via preview + confirm\n'
+    preview_raw="$(call_tool "$OPERATOR_URL" "$SUPERVISOR_OP_SESSION_ID" "$SUPERVISOR_TOKEN" 7 "masc_operator_action" "$(jq -cn --arg actor "$SUPERVISOR_NICKNAME" --arg s "$TEAM_SESSION_ID" '{actor:$actor,action_type:"team_task_inject",target_id:$s,payload:{title:"Capture explicit supervisor proof",description:"Add evidence that preview-confirm changed the session trajectory.",priority:1}}')")"
+    require_tool_success "$preview_raw"
+    CONFIRM_TOKEN="$(printf '%s' "$preview_raw" | extract_tool_text | jq -r '.confirm_token // empty')"
+    if [ -z "$CONFIRM_TOKEN" ]; then
+      echo "FAIL: missing confirm token"
+      printf '%s\n' "$preview_raw"
+      exit 1
+    fi
+
+    snapshot_pending_raw="$(call_tool "$OPERATOR_URL" "$SUPERVISOR_OP_SESSION_ID" "$SUPERVISOR_TOKEN" 8 "masc_operator_snapshot" "$(jq -cn --arg actor "$SUPERVISOR_NICKNAME" '{actor:$actor,view:"full"}')")"
+    require_tool_success "$snapshot_pending_raw"
+    printf '%s' "$snapshot_pending_raw" | extract_tool_result | jq -e '.pending_confirms | length == 1' >/dev/null
+
+    confirm_raw="$(call_tool "$OPERATOR_URL" "$SUPERVISOR_OP_SESSION_ID" "$SUPERVISOR_TOKEN" 9 "masc_operator_confirm" "$(jq -cn --arg actor "$SUPERVISOR_NICKNAME" --arg token "$CONFIRM_TOKEN" '{actor:$actor,confirm_token:$token}')")"
+    require_tool_success "$confirm_raw"
+
+    snapshot_after_confirm_raw="$(call_tool "$OPERATOR_URL" "$SUPERVISOR_OP_SESSION_ID" "$SUPERVISOR_TOKEN" 12 "masc_operator_snapshot" "$(jq -cn --arg actor "$SUPERVISOR_NICKNAME" '{actor:$actor,view:"full"}')")"
+    require_tool_success "$snapshot_after_confirm_raw"
+    printf '%s' "$snapshot_after_confirm_raw" | extract_tool_result | jq -e '.pending_confirms | length == 0' >/dev/null
+  else
+    printf '[8/10] skip supervisor correction (session status=%s)\n' "$TEAM_SESSION_STATUS"
   fi
-
-  snapshot_pending_raw="$(call_tool "$OPERATOR_URL" "$SUPERVISOR_OP_SESSION_ID" "$SUPERVISOR_TOKEN" 8 "masc_operator_snapshot" "$(jq -cn --arg actor "$SUPERVISOR_NICKNAME" '{actor:$actor,view:"full"}')")"
-  require_tool_success "$snapshot_pending_raw"
-  printf '%s' "$snapshot_pending_raw" | extract_tool_result | jq -e '.pending_confirms | length == 1' >/dev/null
-
-  confirm_raw="$(call_tool "$OPERATOR_URL" "$SUPERVISOR_OP_SESSION_ID" "$SUPERVISOR_TOKEN" 9 "masc_operator_confirm" "$(jq -cn --arg actor "$SUPERVISOR_NICKNAME" --arg token "$CONFIRM_TOKEN" '{actor:$actor,confirm_token:$token}')")"
-  require_tool_success "$confirm_raw"
-
-  snapshot_after_confirm_raw="$(call_tool "$OPERATOR_URL" "$SUPERVISOR_OP_SESSION_ID" "$SUPERVISOR_TOKEN" 12 "masc_operator_snapshot" "$(jq -cn --arg actor "$SUPERVISOR_NICKNAME" '{actor:$actor,view:"full"}')")"
-  require_tool_success "$snapshot_after_confirm_raw"
-  printf '%s' "$snapshot_after_confirm_raw" | extract_tool_result | jq -e '.pending_confirms | length == 0' >/dev/null
 else
   printf '[9/10] supervisor intervention skipped by policy (%s)\n' "$SWARM_INTERVENTION_MODE"
 fi
 
 printf '[10/10] stop session and prove evidence\n'
-stop_raw="$(call_tool "$MCP_URL" "$SUPERVISOR_SESSION_ID" "$SUPERVISOR_TOKEN" 13 "masc_team_session_stop" "$(jq -cn --arg s "$TEAM_SESSION_ID" '{session_id:$s,reason:"supervisor_harness_complete",generate_report:true}')")"
-require_tool_success "$stop_raw"
+TEAM_SESSION_STATUS="$(team_session_status "$TEAM_SESSION_ID")"
+if [ "$TEAM_SESSION_STATUS" = "running" ]; then
+  stop_raw="$(call_tool "$MCP_URL" "$SUPERVISOR_SESSION_ID" "$SUPERVISOR_TOKEN" 13 "masc_team_session_stop" "$(jq -cn --arg s "$TEAM_SESSION_ID" '{session_id:$s,reason:"supervisor_harness_complete",generate_report:true}')")"
+  require_tool_success "$stop_raw"
+else
+  echo "skip explicit stop; session already in terminal state: $TEAM_SESSION_STATUS"
+fi
 
 deadline=$(( $(date +%s) + STOP_WAIT_SEC ))
 while :; do
@@ -457,7 +477,7 @@ if [ "$unique_spawned_llama_actors" -lt 3 ]; then
   printf '%s\n' "$spawn_events_result"
   exit 1
 fi
-printf '%s' "$spawn_events_result" | jq -e --arg note "$MODEL_SELECTION_NOTE" '[.events[]? | .detail.spawn_selection_note // empty] | all(. == $note)' >/dev/null
+printf '%s' "$spawn_events_result" | jq -e --arg note "$MODEL_SELECTION_NOTE" '[.events[]? | .detail.spawn_selection_note // empty] | all(startswith($note))' >/dev/null
 proof_json_path="$(printf '%s' "$prove_result" | jq -r '.proof_json_path // empty')"
 proof_md_path="$(printf '%s' "$prove_result" | jq -r '.proof_md_path // empty')"
 

--- a/test/test_auth_coverage.ml
+++ b/test/test_auth_coverage.ml
@@ -200,6 +200,16 @@ let test_permission_for_tool_broadcast () =
   | Some Types.CanBroadcast -> ()
   | _ -> fail "expected CanBroadcast"
 
+let test_permission_for_tool_board_list () =
+  match Auth.permission_for_tool "masc_board_list" with
+  | Some Types.CanReadState -> ()
+  | _ -> fail "expected CanReadState"
+
+let test_permission_for_tool_board_post () =
+  match Auth.permission_for_tool "masc_board_post" with
+  | Some Types.CanBroadcast -> ()
+  | _ -> fail "expected CanBroadcast"
+
 let test_permission_for_tool_portal_open () =
   match Auth.permission_for_tool "masc_portal_open" with
   | Some Types.CanOpenPortal -> ()
@@ -420,6 +430,8 @@ let () =
       test_case "claim_next" `Quick test_permission_for_tool_claim_next;
       test_case "done" `Quick test_permission_for_tool_done;
       test_case "broadcast" `Quick test_permission_for_tool_broadcast;
+      test_case "board_list" `Quick test_permission_for_tool_board_list;
+      test_case "board_post" `Quick test_permission_for_tool_board_post;
       test_case "portal_open" `Quick test_permission_for_tool_portal_open;
       test_case "portal_send" `Quick test_permission_for_tool_portal_send;
       test_case "worktree_create" `Quick test_permission_for_tool_worktree_create;

--- a/test/test_auth_coverage.ml
+++ b/test/test_auth_coverage.ml
@@ -245,6 +245,11 @@ let test_permission_for_tool_auth_status () =
   | Some Types.CanReadState -> ()
   | _ -> fail "expected CanReadState"
 
+let test_permission_for_tool_stats () =
+  match Auth.permission_for_tool "masc_tool_stats" with
+  | Some Types.CanReadState -> ()
+  | _ -> fail "expected CanReadState"
+
 let test_permission_for_tool_admin_snapshot () =
   match Auth.permission_for_tool "masc_tool_admin_snapshot" with
   | Some Types.CanReadState -> ()
@@ -252,6 +257,31 @@ let test_permission_for_tool_admin_snapshot () =
 
 let test_permission_for_tool_admin_update () =
   match Auth.permission_for_tool "masc_tool_admin_update" with
+  | Some Types.CanAdmin -> ()
+  | _ -> fail "expected CanAdmin"
+
+let test_permission_for_tool_help () =
+  match Auth.permission_for_tool "masc_tool_help" with
+  | Some Types.CanReadState -> ()
+  | _ -> fail "expected CanReadState"
+
+let test_permission_for_keeper_tool_catalog () =
+  match Auth.permission_for_tool "masc_keeper_tool_catalog" with
+  | Some Types.CanReadState -> ()
+  | _ -> fail "expected CanReadState"
+
+let test_permission_for_tool_list () =
+  match Auth.permission_for_tool "masc_tool_list" with
+  | Some Types.CanReadState -> ()
+  | _ -> fail "expected CanReadState"
+
+let test_permission_for_tool_grant () =
+  match Auth.permission_for_tool "masc_tool_grant" with
+  | Some Types.CanAdmin -> ()
+  | _ -> fail "expected CanAdmin"
+
+let test_permission_for_tool_revoke () =
+  match Auth.permission_for_tool "masc_tool_revoke" with
   | Some Types.CanAdmin -> ()
   | _ -> fail "expected CanAdmin"
 
@@ -399,6 +429,12 @@ let () =
       test_case "approve" `Quick test_permission_for_tool_approve;
       test_case "auth_enable" `Quick test_permission_for_tool_auth_enable;
       test_case "auth_status" `Quick test_permission_for_tool_auth_status;
+      test_case "tool_stats" `Quick test_permission_for_tool_stats;
+      test_case "tool_help" `Quick test_permission_for_tool_help;
+      test_case "keeper_tool_catalog" `Quick test_permission_for_keeper_tool_catalog;
+      test_case "tool_list" `Quick test_permission_for_tool_list;
+      test_case "tool_grant" `Quick test_permission_for_tool_grant;
+      test_case "tool_revoke" `Quick test_permission_for_tool_revoke;
       test_case "tool_admin_snapshot" `Quick test_permission_for_tool_admin_snapshot;
       test_case "tool_admin_update" `Quick test_permission_for_tool_admin_update;
       test_case "llama_models" `Quick test_permission_for_tool_llama_models;

--- a/test/test_spawn.ml
+++ b/test/test_spawn.ml
@@ -124,6 +124,8 @@ let test_masc_mcp_tools () =
     (List.mem "mcp__masc__masc_run_deliverable" Spawn.masc_mcp_tools);
   Alcotest.(check bool) "contains board_post" true
     (List.mem "mcp__masc__masc_board_post" Spawn.masc_mcp_tools);
+  Alcotest.(check bool) "contains tool_stats" true
+    (List.mem "mcp__masc__masc_tool_stats" Spawn.masc_mcp_tools);
   Alcotest.(check bool) "contains tool_help" true
     (List.mem "mcp__masc__masc_tool_help" Spawn.masc_mcp_tools);
   Alcotest.(check bool) "contains tool_admin_snapshot" true

--- a/test/test_spawn.ml
+++ b/test/test_spawn.ml
@@ -122,6 +122,20 @@ let test_masc_mcp_tools () =
     (List.mem "mcp__masc__masc_vote_create" Spawn.masc_mcp_tools);
   Alcotest.(check bool) "contains run_deliverable" true
     (List.mem "mcp__masc__masc_run_deliverable" Spawn.masc_mcp_tools);
+  Alcotest.(check bool) "contains board_post" true
+    (List.mem "mcp__masc__masc_board_post" Spawn.masc_mcp_tools);
+  Alcotest.(check bool) "contains tool_help" true
+    (List.mem "mcp__masc__masc_tool_help" Spawn.masc_mcp_tools);
+  Alcotest.(check bool) "contains tool_admin_snapshot" true
+    (List.mem "mcp__masc__masc_tool_admin_snapshot" Spawn.masc_mcp_tools);
+  Alcotest.(check bool) "contains keeper_tool_catalog" true
+    (List.mem "mcp__masc__masc_keeper_tool_catalog" Spawn.masc_mcp_tools);
+  Alcotest.(check bool) "contains tool_list" true
+    (List.mem "mcp__masc__masc_tool_list" Spawn.masc_mcp_tools);
+  Alcotest.(check bool) "contains tool_grant" true
+    (List.mem "mcp__masc__masc_tool_grant" Spawn.masc_mcp_tools);
+  Alcotest.(check bool) "contains tool_revoke" true
+    (List.mem "mcp__masc__masc_tool_revoke" Spawn.masc_mcp_tools);
   ()
 
 let test_spawn_bare_ollama_rejected () =

--- a/test/test_spawn_coverage.ml
+++ b/test/test_spawn_coverage.ml
@@ -161,6 +161,30 @@ let test_masc_mcp_tools_has_run_deliverable () =
   check bool "has run_deliverable" true
     (List.mem "mcp__masc__masc_run_deliverable" Spawn.masc_mcp_tools)
 
+let test_masc_mcp_tools_has_tool_help () =
+  check bool "has tool_help" true
+    (List.mem "mcp__masc__masc_tool_help" Spawn.masc_mcp_tools)
+
+let test_masc_mcp_tools_has_tool_admin_snapshot () =
+  check bool "has tool_admin_snapshot" true
+    (List.mem "mcp__masc__masc_tool_admin_snapshot" Spawn.masc_mcp_tools)
+
+let test_masc_mcp_tools_has_keeper_tool_catalog () =
+  check bool "has keeper_tool_catalog" true
+    (List.mem "mcp__masc__masc_keeper_tool_catalog" Spawn.masc_mcp_tools)
+
+let test_masc_mcp_tools_has_tool_list () =
+  check bool "has tool_list" true
+    (List.mem "mcp__masc__masc_tool_list" Spawn.masc_mcp_tools)
+
+let test_masc_mcp_tools_has_tool_grant () =
+  check bool "has tool_grant" true
+    (List.mem "mcp__masc__masc_tool_grant" Spawn.masc_mcp_tools)
+
+let test_masc_mcp_tools_has_tool_revoke () =
+  check bool "has tool_revoke" true
+    (List.mem "mcp__masc__masc_tool_revoke" Spawn.masc_mcp_tools)
+
 (* ============================================================
    masc_lifecycle_suffix Tests
    ============================================================ *)
@@ -689,6 +713,12 @@ let () =
       test_case "has a2a_delegate" `Quick test_masc_mcp_tools_has_a2a_delegate;
       test_case "has vote_create" `Quick test_masc_mcp_tools_has_vote_create;
       test_case "has run_deliverable" `Quick test_masc_mcp_tools_has_run_deliverable;
+      test_case "has tool_help" `Quick test_masc_mcp_tools_has_tool_help;
+      test_case "has tool_admin_snapshot" `Quick test_masc_mcp_tools_has_tool_admin_snapshot;
+      test_case "has keeper_tool_catalog" `Quick test_masc_mcp_tools_has_keeper_tool_catalog;
+      test_case "has tool_list" `Quick test_masc_mcp_tools_has_tool_list;
+      test_case "has tool_grant" `Quick test_masc_mcp_tools_has_tool_grant;
+      test_case "has tool_revoke" `Quick test_masc_mcp_tools_has_tool_revoke;
     ];
     "lifecycle_suffix", [
       test_case "not empty" `Quick test_lifecycle_suffix_not_empty;

--- a/test/test_spawn_coverage.ml
+++ b/test/test_spawn_coverage.ml
@@ -165,6 +165,10 @@ let test_masc_mcp_tools_has_tool_help () =
   check bool "has tool_help" true
     (List.mem "mcp__masc__masc_tool_help" Spawn.masc_mcp_tools)
 
+let test_masc_mcp_tools_has_tool_stats () =
+  check bool "has tool_stats" true
+    (List.mem "mcp__masc__masc_tool_stats" Spawn.masc_mcp_tools)
+
 let test_masc_mcp_tools_has_tool_admin_snapshot () =
   check bool "has tool_admin_snapshot" true
     (List.mem "mcp__masc__masc_tool_admin_snapshot" Spawn.masc_mcp_tools)
@@ -713,6 +717,7 @@ let () =
       test_case "has a2a_delegate" `Quick test_masc_mcp_tools_has_a2a_delegate;
       test_case "has vote_create" `Quick test_masc_mcp_tools_has_vote_create;
       test_case "has run_deliverable" `Quick test_masc_mcp_tools_has_run_deliverable;
+      test_case "has tool_stats" `Quick test_masc_mcp_tools_has_tool_stats;
       test_case "has tool_help" `Quick test_masc_mcp_tools_has_tool_help;
       test_case "has tool_admin_snapshot" `Quick test_masc_mcp_tools_has_tool_admin_snapshot;
       test_case "has keeper_tool_catalog" `Quick test_masc_mcp_tools_has_keeper_tool_catalog;

--- a/test/test_spawn_eio_coverage.ml
+++ b/test/test_spawn_eio_coverage.ml
@@ -148,6 +148,30 @@ let test_masc_mcp_tools_contains_run_deliverable () =
   check bool "contains run_deliverable" true
     (List.mem "mcp__masc__masc_run_deliverable" Spawn_eio.masc_mcp_tools)
 
+let test_masc_mcp_tools_contains_tool_help () =
+  check bool "contains tool_help" true
+    (List.mem "mcp__masc__masc_tool_help" Spawn_eio.masc_mcp_tools)
+
+let test_masc_mcp_tools_contains_tool_admin_snapshot () =
+  check bool "contains tool_admin_snapshot" true
+    (List.mem "mcp__masc__masc_tool_admin_snapshot" Spawn_eio.masc_mcp_tools)
+
+let test_masc_mcp_tools_contains_keeper_tool_catalog () =
+  check bool "contains keeper_tool_catalog" true
+    (List.mem "mcp__masc__masc_keeper_tool_catalog" Spawn_eio.masc_mcp_tools)
+
+let test_masc_mcp_tools_contains_tool_list () =
+  check bool "contains tool_list" true
+    (List.mem "mcp__masc__masc_tool_list" Spawn_eio.masc_mcp_tools)
+
+let test_masc_mcp_tools_contains_tool_grant () =
+  check bool "contains tool_grant" true
+    (List.mem "mcp__masc__masc_tool_grant" Spawn_eio.masc_mcp_tools)
+
+let test_masc_mcp_tools_contains_tool_revoke () =
+  check bool "contains tool_revoke" true
+    (List.mem "mcp__masc__masc_tool_revoke" Spawn_eio.masc_mcp_tools)
+
 let test_llama_mcp_tools_curated () =
   check (list string) "llama tools"
     [
@@ -439,6 +463,18 @@ let () =
         test_masc_mcp_tools_contains_vote_create;
       test_case "contains run_deliverable" `Quick
         test_masc_mcp_tools_contains_run_deliverable;
+      test_case "contains tool_help" `Quick
+        test_masc_mcp_tools_contains_tool_help;
+      test_case "contains tool_admin_snapshot" `Quick
+        test_masc_mcp_tools_contains_tool_admin_snapshot;
+      test_case "contains keeper_tool_catalog" `Quick
+        test_masc_mcp_tools_contains_keeper_tool_catalog;
+      test_case "contains tool_list" `Quick
+        test_masc_mcp_tools_contains_tool_list;
+      test_case "contains tool_grant" `Quick
+        test_masc_mcp_tools_contains_tool_grant;
+      test_case "contains tool_revoke" `Quick
+        test_masc_mcp_tools_contains_tool_revoke;
       test_case "llama curated subset" `Quick test_llama_mcp_tools_curated;
     ];
     "masc_lifecycle_suffix", [

--- a/test/test_spawn_eio_coverage.ml
+++ b/test/test_spawn_eio_coverage.ml
@@ -152,6 +152,10 @@ let test_masc_mcp_tools_contains_tool_help () =
   check bool "contains tool_help" true
     (List.mem "mcp__masc__masc_tool_help" Spawn_eio.masc_mcp_tools)
 
+let test_masc_mcp_tools_contains_tool_stats () =
+  check bool "contains tool_stats" true
+    (List.mem "mcp__masc__masc_tool_stats" Spawn_eio.masc_mcp_tools)
+
 let test_masc_mcp_tools_contains_tool_admin_snapshot () =
   check bool "contains tool_admin_snapshot" true
     (List.mem "mcp__masc__masc_tool_admin_snapshot" Spawn_eio.masc_mcp_tools)
@@ -463,6 +467,8 @@ let () =
         test_masc_mcp_tools_contains_vote_create;
       test_case "contains run_deliverable" `Quick
         test_masc_mcp_tools_contains_run_deliverable;
+      test_case "contains tool_stats" `Quick
+        test_masc_mcp_tools_contains_tool_stats;
       test_case "contains tool_help" `Quick
         test_masc_mcp_tools_contains_tool_help;
       test_case "contains tool_admin_snapshot" `Quick


### PR DESCRIPTION
## Summary
- guard supervisor team-session harness against terminal-state races during intervention and stop paths
- make session duration configurable and relax the spawn-note assertion used by the harness
- expose tool-management MCP surfaces to spawned internal agents and add explicit auth coverage for tool shard operations

## Verification
- dune build --root .
- ./_build/default/test/test_spawn.exe
- ./_build/default/test/test_spawn_coverage.exe
- ./_build/default/test/test_spawn_eio_coverage.exe
- ./_build/default/test/test_auth_coverage.exe
- ./scripts/harness_supervisor_team_session.sh
