### PR TITLE
chore: fix edge case crashes and unhandled exceptions

### DIFF
--- a/lib/bounded.ml
+++ b/lib/bounded.ml
@@ -498,8 +498,9 @@ let goal_of_json json =
     else if member "gte" cond <> `Null then
       Gte (member "gte" cond |> to_float)
     else if member "between" cond <> `Null then
-      let arr = member "between" cond |> to_list in
-      Between (List.nth arr 0 |> to_float, List.nth arr 1 |> to_float)
+      match member "between" cond |> to_list with
+      | low :: high :: _ -> Between (low |> to_float, high |> to_float)
+      | _ -> invalid_arg "Bounded.rule_of_yojson: 'between' array must have at least 2 elements"
     else if member "in" cond <> `Null then
       In (member "in" cond |> to_list)
     else

--- a/lib/credits_dashboard.ml
+++ b/lib/credits_dashboard.ml
@@ -17,7 +17,9 @@
 let me_root () =
   match Sys.getenv_opt "ME_ROOT" with
   | Some path -> path
-  | None -> Filename.concat (Sys.getenv "HOME") "me"
+  | None ->
+      let home = Option.value ~default:"/tmp" (Sys.getenv_opt "HOME") in
+      Filename.concat home "me"
 
 (** Credits JSON path *)
 let credits_json_path () =

--- a/lib/langfuse.ml
+++ b/lib/langfuse.ml
@@ -210,7 +210,7 @@ let send_to_langfuse ~endpoint ~body () =
       let sockaddr = Unix.ADDR_INET (Unix.inet_addr_of_string
         (try (Unix.gethostbyname host).Unix.h_addr_list.(0)
               |> Unix.string_of_inet_addr
-         with Not_found -> "127.0.0.1"), port) in
+         with _ -> "127.0.0.1"), port) in
       let sock = Unix.socket Unix.PF_INET Unix.SOCK_STREAM 0 in
       (* Use blocking socket for reliable connection *)
       Unix.setsockopt_float sock Unix.SO_SNDTIMEO 2.0;  (* 2 second timeout *)

--- a/lib/mcp_server_eio.ml
+++ b/lib/mcp_server_eio.ml
@@ -783,7 +783,7 @@ let execute_tool_eio ~sw ~clock ?mcp_session_id ?auth_token state ~name ~argumen
           if Option.is_some mcp_session_id then
             generated_fallback_agent_name
           else
-            let term_session_id = try Sys.getenv "TERM_SESSION_ID" with Not_found -> "" in
+            let term_session_id = Option.value ~default:"" (Sys.getenv_opt "TERM_SESSION_ID") in
             let term_file = Printf.sprintf "/tmp/.masc_agent_%s" term_session_id in
             (try
               let ic = open_in term_file in
@@ -1681,9 +1681,9 @@ let execute_tool_eio ~sw ~clock ?mcp_session_id ?auth_token state ~name ~argumen
       let path = arg_get_string "path" "" in
       let expanded =
         if String.length path > 0 && path.[0] = '~' then
-          Filename.concat (Sys.getenv "HOME") (String.sub path 1 (String.length path - 1))
-        else if Filename.is_relative path then
-          Filename.concat (Sys.getcwd ()) path
+          let home = match Sys.getenv_opt "HOME" with Some h -> h | None -> "/tmp" in
+          Filename.concat home (String.sub path 1 (String.length path - 1))
+        else if Filename.is_relative path then          Filename.concat (Sys.getcwd ()) path
         else
           path
       in
@@ -1721,7 +1721,7 @@ let execute_tool_eio ~sw ~clock ?mcp_session_id ?auth_token state ~name ~argumen
       Printf.eprintf "[DEBUG] masc_join: saved nickname=%s to MCP session (original=%s)\n%!" nickname agent_name;
       (* Also save to TERM_SESSION_ID file (terminal persistence) *)
       if Option.is_none mcp_session_id then begin
-        let term_session_id = try Sys.getenv "TERM_SESSION_ID" with Not_found -> "default" in
+        let term_session_id = Option.value ~default:"default" (Sys.getenv_opt "TERM_SESSION_ID") in
         let agent_file = Printf.sprintf "/tmp/.masc_agent_%s" term_session_id in
         (try
           let oc = open_out agent_file in
@@ -1767,7 +1767,7 @@ let execute_tool_eio ~sw ~clock ?mcp_session_id ?auth_token state ~name ~argumen
       unregister_sync registry ~agent_name;
       (* Clean up self-echo filter file *)
       if Option.is_none mcp_session_id then begin
-        let session_id = try Sys.getenv "TERM_SESSION_ID" with Not_found -> "default" in
+        let session_id = Option.value ~default:"default" (Sys.getenv_opt "TERM_SESSION_ID") in
         let agent_file = Printf.sprintf "/tmp/.masc_agent_%s" session_id in
         Safe_ops.remove_file_logged ~context:"masc_leave" agent_file
       end;

--- a/lib/server_mcp_transport_http.ml
+++ b/lib/server_mcp_transport_http.ml
@@ -998,14 +998,16 @@ let handle_ag_ui_events ~deps request reqd =
           Eio.Fiber.fork ~sw (fun () ->
               let rec loop () =
                 if not !(info.stop) then (
-                  (try Eio.Time.sleep clock sse_ping_interval_s with _ -> ());
+                  (try Eio.Time.sleep clock sse_ping_interval_s
+                   with Eio.Cancel.Cancelled _ as exn -> raise exn | _ -> ());
                   (try
                      if info.closed then
                        stop_sse_session info.session_id
                      else if not !(info.stop) then
                        ignore (send_raw info ": ping\n\n")
-                   with _ -> stop_sse_session info.session_id);
+                   with Eio.Cancel.Cancelled _ as exn -> raise exn
+                      | _ -> stop_sse_session info.session_id);
                   loop ())
               in
-              try loop () with _ -> ())
+              try loop () with Eio.Cancel.Cancelled _ as exn -> raise exn | _ -> ())
       | _ -> ())


### PR DESCRIPTION
## Description
Fixes several edge cases where unhandled exceptions could crash components or swallow important cancellation events:

1. **Eio Cancellation swallowed**: In `server_mcp_transport_http.ml`, an empty `with _ -> ()` block was catching `Eio.Cancel.Cancelled`, preventing the fibers from cleanly shutting down. Fixed to properly re-raise it.
2. **List.nth out of bounds**: Replaced `List.nth arr 0` with a safe pattern match in `bounded.ml` to prevent `Failure` on empty or short lists.
3. **Invalid_argument on empty arrays**: Fixed `try (Unix.gethostbyname host).Unix.h_addr_list.(0) with Not_found` in `langfuse.ml` which could throw `Invalid_argument` if the address list was empty. It now safely catches `_` to fallback to localhost.
4. **Sys.getenv "HOME" & "TERM_SESSION_ID" crash**: Replaced naked `Sys.getenv` with `Sys.getenv_opt` to prevent `Not_found` when environmental variables are not defined in `mcp_server_eio.ml` and `credits_dashboard.ml`.