### PR TITLE
feat(dashboard): add unified room truth strip

### DIFF
--- a/dashboard/src/api.ts
+++ b/dashboard/src/api.ts
@@ -11,6 +11,7 @@ import type {
   DashboardMissionSessionDetailResponse,
   DashboardProofResponse,
   DashboardPlanningResponse,
+  DashboardRoomTruthResponse,
   DashboardShellResponse,
   BoardPost,
   BoardComment,
@@ -307,6 +308,10 @@ export async function callMcpTool(toolName: string, args: Record<string, unknown
 
 export function fetchDashboardShell(): Promise<DashboardShellResponse> {
   return get('/api/v1/dashboard/shell')
+}
+
+export function fetchDashboardRoomTruth(): Promise<DashboardRoomTruthResponse> {
+  return get('/api/v1/dashboard/room-truth')
 }
 
 export function fetchDashboardExecution(): Promise<DashboardExecutionResponse> {

--- a/dashboard/src/app.ts
+++ b/dashboard/src/app.ts
@@ -10,6 +10,7 @@ import {
   refreshDashboardSemantics,
   refreshShell,
 } from './store'
+import { refreshRoomTruth } from './room-truth-store'
 import { setupSSEReaction, startPeriodicRefresh, stopPeriodicRefresh } from './sse-store'
 import { refreshForTab } from './tab-refresh'
 import {
@@ -32,6 +33,7 @@ export function App() {
     // Connect SSE and start data fetching
     connectSSE()
     refreshShell()
+    refreshRoomTruth()
     refreshExecution()
     refreshDashboardSemantics()
     refreshMissionSnapshot()

--- a/dashboard/src/components/agents.ts
+++ b/dashboard/src/components/agents.ts
@@ -3,6 +3,7 @@
 import { html } from 'htm/preact'
 import { signal } from '@preact/signals'
 import { Card } from './common/card'
+import { RoomTruthStrip } from './common/room-truth-strip'
 import { SurfaceSemanticIntro } from './common/semantic-layer'
 import { StatusBadge } from './common/status-badge'
 import { MitosisRing } from './common/mitosis-ring'
@@ -547,6 +548,7 @@ export function Execution() {
   return html`
     <div class="agents-monitor">
       <${SurfaceSemanticIntro} surfaceId="execution" />
+      <${RoomTruthStrip} />
       <div class="stats-grid">
         <${MonitorStat} label="활성 세션" value=${summary?.active_sessions ?? sessionRowsAll.length} color="#4ade80" caption="실행 관점 세션 수" />
         <${MonitorStat} label="막힌 세션" value=${summary?.blocked_sessions ?? sessionRowsAll.filter(item => toneClass(item.health ?? item.status) !== 'ok').length} color="#fbbf24" caption="개입이 필요한 세션 수" />

--- a/dashboard/src/components/command/index.ts
+++ b/dashboard/src/components/command/index.ts
@@ -15,8 +15,10 @@ import {
   runCommandPlaneDispatchTick,
   setCommandPlaneSurface,
 } from '../../command-store'
+import { refreshRoomTruth } from '../../room-truth-store'
 import { refreshOperatorSnapshot } from '../../operator-store'
 import { navigate, route } from '../../router'
+import { RoomTruthStrip } from '../common/room-truth-strip'
 import { SurfaceSemanticIntro } from '../common/semantic-layer'
 import {
   commandSurfaceForContext,
@@ -233,6 +235,7 @@ export function Command() {
           <button
             class="control-btn ghost"
             onClick=${() => {
+              void refreshRoomTruth()
               void refreshCommandPlaneCurrentSurface()
               void refreshCommandPlaneChainSummary()
               void refreshCommandPlaneSwarm()
@@ -254,6 +257,7 @@ export function Command() {
         ? html`<div class="empty-state error">${commandPlaneActionError.value}</div>`
         : null}
       <${SurfaceSemanticIntro} surfaceId="command" />
+      <${RoomTruthStrip} />
       <${CommandWorkflowBanner} />
       ${commandPlaneSurface.value === 'warroom' ? null : html`<${CommandEntryStrip} />`}
       <${SurfaceTabs} />

--- a/dashboard/src/components/common/room-truth-strip.ts
+++ b/dashboard/src/components/common/room-truth-strip.ts
@@ -1,0 +1,101 @@
+import { html } from 'htm/preact'
+import { navigate } from '../../router'
+import { roomTruth, roomTruthError, roomTruthLoading } from '../../room-truth-store'
+
+function toneClass(value?: string | null): string {
+  const normalized = (value ?? '').trim().toLowerCase()
+  if (normalized === 'bad' || normalized === 'critical' || normalized === 'offline') return 'bad'
+  if (normalized === 'warn' || normalized === 'paused' || normalized === 'blocked') return 'warn'
+  return 'ok'
+}
+
+function openFocus(): void {
+  const focus = roomTruth.value?.focus
+  if (!focus?.suggested_tab) return
+  const params = focus.suggested_params ?? {}
+  if (focus.suggested_tab === 'intervene') {
+    navigate('intervene', params)
+    return
+  }
+  navigate('command', {
+    ...(focus.suggested_surface ? { surface: focus.suggested_surface } : {}),
+    ...params,
+  })
+}
+
+export function RoomTruthStrip() {
+  const snapshot = roomTruth.value
+  if (!snapshot) {
+    if (roomTruthLoading.value) {
+      return html`<section class="room-truth-strip room-truth-strip-loading">room truth 불러오는 중...</section>`
+    }
+    if (roomTruthError.value) {
+      return html`<section class="room-truth-strip room-truth-strip-error">${roomTruthError.value}</section>`
+    }
+    return null
+  }
+
+  const status = snapshot.room.status
+  const counts = snapshot.room.counts
+  const execution = snapshot.execution?.summary
+  const topQueue = snapshot.execution?.top_queue
+  const command = snapshot.command
+  const operator = snapshot.operator
+  const focus = snapshot.focus
+
+  return html`
+    <section class="room-truth-strip">
+      <article class="room-truth-card">
+        <span class="room-truth-label">room truth</span>
+        <strong>${status?.project ?? 'project'} · ${status?.room ?? 'default'}</strong>
+        <p>${counts?.agents ?? 0} agents · ${counts?.tasks ?? 0} tasks · ${counts?.keepers ?? 0} keepers</p>
+        <div class="room-truth-chip-row">
+          <span class="command-chip ${status?.paused ? 'warn' : 'ok'}">${status?.paused ? '일시정지' : '열림'}</span>
+          <span class="command-chip">${status?.cluster ?? 'cluster:unknown'}</span>
+          <span class="command-chip">${snapshot.room.provenance ?? 'truth'}</span>
+        </div>
+      </article>
+
+      <article class="room-truth-card">
+        <span class="room-truth-label">execution</span>
+        <strong>세션 ${execution?.active_sessions ?? 0} · 막힘 ${execution?.blocked_sessions ?? 0}</strong>
+        <p>${topQueue?.summary ?? '지금은 실행 대기열 최상단 항목이 없습니다.'}</p>
+        <div class="room-truth-chip-row">
+          <span class="command-chip ${toneClass((execution?.blocked_sessions ?? 0) > 0 ? 'warn' : 'ok')}">priority ${execution?.priority_items ?? 0}</span>
+          <span class="command-chip">${snapshot.execution?.provenance ?? 'derived'}</span>
+        </div>
+      </article>
+
+      <article class="room-truth-card">
+        <span class="room-truth-label">control</span>
+        <strong>작전 ${command?.active_operations ?? 0} · 승인 ${command?.pending_approvals ?? 0}</strong>
+        <p>alerts bad ${command?.bad_alerts ?? 0} / warn ${command?.warn_alerts ?? 0} · lanes ${command?.moving_lanes ?? 0}/${command?.active_lanes ?? 0}</p>
+        <div class="room-truth-chip-row">
+          <span class="command-chip ${toneClass((command?.bad_alerts ?? 0) > 0 ? 'bad' : (command?.warn_alerts ?? 0) > 0 || (command?.pending_approvals ?? 0) > 0 ? 'warn' : 'ok')}">
+            health ${operator?.health ?? 'ok'}
+          </span>
+          <span class="command-chip">${command?.provenance ?? 'truth'}</span>
+        </div>
+      </article>
+
+      <article class="room-truth-card room-truth-card-focus">
+        <span class="room-truth-label">next focus</span>
+        <strong>${focus?.label ?? '지금은 방 전체가 비교적 안정적입니다'}</strong>
+        <p>${focus?.reason ?? (operator?.attention_summary?.top_item?.summary ?? topQueue?.summary ?? '다음 drill-down 대상이 아직 없습니다.')}</p>
+        <div class="room-truth-chip-row">
+          <span class="command-chip ${toneClass(focus?.provenance === 'fallback' ? 'warn' : 'ok')}">${focus?.source ?? 'steady'}</span>
+          <span class="command-chip">${focus?.provenance ?? operator?.recommendation_summary?.provenance ?? 'derived'}</span>
+        </div>
+        ${focus?.suggested_tab
+          ? html`
+              <div class="room-truth-actions">
+                <button class="control-btn ghost" onClick=${openFocus}>
+                  ${focus.suggested_tab === 'intervene' ? '개입면 열기' : '지휘면 열기'}
+                </button>
+              </div>
+            `
+          : null}
+      </article>
+    </section>
+  `
+}

--- a/dashboard/src/components/mission.ts
+++ b/dashboard/src/components/mission.ts
@@ -1,6 +1,7 @@
 import { html } from 'htm/preact'
 import { useEffect } from 'preact/hooks'
 import { Card } from './common/card'
+import { RoomTruthStrip } from './common/room-truth-strip'
 import { SurfaceSemanticIntro } from './common/semantic-layer'
 import { navigate } from '../router'
 import {
@@ -94,6 +95,8 @@ export function Mission() {
           <span class="command-chip">${mission.generated_at ? relativeTime(mission.generated_at) : '기록 없음'}</span>
         </div>
       </div>
+
+      <${RoomTruthStrip} />
 
       <${MissionContextBar}
         cluster=${mission.summary.cluster}

--- a/dashboard/src/components/ops/index.ts
+++ b/dashboard/src/components/ops/index.ts
@@ -2,6 +2,8 @@
 
 import { html } from 'htm/preact'
 import { useEffect } from 'preact/hooks'
+import { refreshRoomTruth } from '../../room-truth-store'
+import { RoomTruthStrip } from '../common/room-truth-strip'
 import { PanelSemanticDetails, SurfaceSemanticIntro } from '../common/semantic-layer'
 import { route } from '../../router'
 import {
@@ -175,12 +177,13 @@ export function Ops() {
             value=${actorName.value}
             onInput=${(event: Event) => persistActorName((event.target as HTMLInputElement).value)}
           />
-          <button
-            class="control-btn ghost"
-            onClick=${() => {
-              void refreshOperatorSnapshot()
-              void refreshOperatorRoomDigest()
-              void refreshOperatorSessionDigest(selectedSession?.session_id ?? null)
+            <button
+              class="control-btn ghost"
+              onClick=${() => {
+                void refreshRoomTruth()
+                void refreshOperatorSnapshot()
+                void refreshOperatorRoomDigest()
+                void refreshOperatorSessionDigest(selectedSession?.session_id ?? null)
             }}
             disabled=${operatorLoading.value || operatorActionBusy.value}
           >
@@ -191,6 +194,7 @@ export function Ops() {
 
       ${operatorError.value ? html`<section class="ops-banner error">${operatorError.value}</section>` : null}
       ${operatorDigestError.value ? html`<section class="ops-banner error">${operatorDigestError.value}</section>` : null}
+      <${RoomTruthStrip} />
       ${workflowContext ? html`
         <section class="ops-banner ${workflowReady ? 'info' : 'warn'} ops-handoff-banner">
           <div class="ops-handoff-head">

--- a/dashboard/src/room-truth-store.ts
+++ b/dashboard/src/room-truth-store.ts
@@ -1,0 +1,240 @@
+import { signal } from '@preact/signals'
+import { fetchDashboardRoomTruth } from './api'
+import type {
+  DashboardExecutionQueueItem,
+  DashboardExecutionSummary,
+  DashboardRoomTruthAttentionSummary,
+  DashboardRoomTruthFocus,
+  DashboardRoomTruthRecommendationSummary,
+  DashboardRoomTruthResponse,
+  OperatorAttentionItem,
+  OperatorRecommendedAction,
+  PendingConfirmSummary,
+  ServerStatus,
+} from './types'
+import { asBoolean, asNumber, asString, asStringArray, isRecord, extractArray } from './components/common/normalize'
+
+export const roomTruth = signal<DashboardRoomTruthResponse | null>(null)
+export const roomTruthLoading = signal(false)
+export const roomTruthError = signal<string | null>(null)
+
+function normalizeServerStatus(raw: unknown): ServerStatus | null {
+  if (!isRecord(raw)) return null
+  return {
+    room: asString(raw.room) ?? asString(raw.current_room),
+    room_base_path: asString(raw.room_base_path),
+    cluster: asString(raw.cluster),
+    project: asString(raw.project),
+    paused: asBoolean(raw.paused),
+    version: asString(raw.version),
+    generated_at: asString(raw.generated_at),
+    tempo_interval_s: asNumber(raw.tempo_interval_s),
+  }
+}
+
+function normalizeExecutionSummary(raw: unknown): DashboardExecutionSummary | null {
+  if (!isRecord(raw)) return null
+  return {
+    active_sessions: asNumber(raw.active_sessions),
+    blocked_sessions: asNumber(raw.blocked_sessions),
+    active_operations: asNumber(raw.active_operations),
+    blocked_operations: asNumber(raw.blocked_operations),
+    runtime_pressure: asNumber(raw.runtime_pressure),
+    worker_alerts: asNumber(raw.worker_alerts),
+    continuity_alerts: asNumber(raw.continuity_alerts),
+    priority_items: asNumber(raw.priority_items),
+    keepers: asNumber(raw.keepers),
+  }
+}
+
+function normalizeExecutionQueueItem(raw: unknown): DashboardExecutionQueueItem | null {
+  if (!isRecord(raw)) return null
+  const id = asString(raw.id)
+  const kind = asString(raw.kind)
+  const severity = asString(raw.severity)
+  const summary = asString(raw.summary)
+  const targetType = asString(raw.target_type)
+  const targetId = asString(raw.target_id)
+  if (!id || !kind || !severity || !summary || !targetType || !targetId) return null
+  return {
+    id,
+    kind: kind as DashboardExecutionQueueItem['kind'],
+    severity: severity as DashboardExecutionQueueItem['severity'],
+    summary,
+    target_type: targetType,
+    target_id: targetId,
+    status: asString(raw.status),
+    linked_session_id: asString(raw.linked_session_id) ?? null,
+    linked_operation_id: asString(raw.linked_operation_id) ?? null,
+    last_seen_at: asString(raw.last_seen_at) ?? null,
+    top_handoff: isRecord(raw.top_handoff) ? raw.top_handoff as unknown as DashboardExecutionQueueItem['top_handoff'] : null,
+    intervene_handoff: isRecord(raw.intervene_handoff) ? raw.intervene_handoff as unknown as DashboardExecutionQueueItem['intervene_handoff'] : null,
+    command_handoff: isRecord(raw.command_handoff) ? raw.command_handoff as unknown as DashboardExecutionQueueItem['command_handoff'] : null,
+  }
+}
+
+function normalizeAttentionItem(raw: unknown): OperatorAttentionItem | null {
+  if (!isRecord(raw)) return null
+  const kind = asString(raw.kind)
+  const summary = asString(raw.summary)
+  const targetType = asString(raw.target_type)
+  if (!kind || !summary || !targetType) return null
+  return {
+    kind,
+    severity: asString(raw.severity) ?? 'warn',
+    summary,
+    target_type: targetType,
+    target_id: asString(raw.target_id) ?? null,
+    actor: asString(raw.actor) ?? null,
+    evidence: raw.evidence,
+  }
+}
+
+function normalizeRecommendedAction(raw: unknown): OperatorRecommendedAction | null {
+  if (!isRecord(raw)) return null
+  const actionType = asString(raw.action_type)
+  const targetType = asString(raw.target_type)
+  const reason = asString(raw.reason)
+  if (!actionType || !targetType || !reason) return null
+  return {
+    action_type: actionType,
+    target_type: targetType,
+    target_id: asString(raw.target_id) ?? null,
+    severity: asString(raw.severity) ?? 'warn',
+    reason,
+    confirm_required: asBoolean(raw.confirm_required),
+    suggested_payload: isRecord(raw.suggested_payload) ? raw.suggested_payload : undefined,
+    preview: raw.preview,
+  }
+}
+
+function normalizePendingConfirmSummary(raw: unknown): PendingConfirmSummary | null {
+  if (!isRecord(raw)) return null
+  return {
+    actor_filter: asString(raw.actor_filter) ?? null,
+    filter_active: asBoolean(raw.filter_active) ?? false,
+    visible_count: asNumber(raw.visible_count) ?? 0,
+    total_count: asNumber(raw.total_count) ?? 0,
+    hidden_count: asNumber(raw.hidden_count) ?? 0,
+    hidden_actors: asStringArray(raw.hidden_actors),
+    confirm_required_actions: extractArray(raw.confirm_required_actions).flatMap(item => {
+      if (!isRecord(item)) return []
+      const actionType = asString(item.action_type)
+      const targetType = asString(item.target_type)
+      if (!actionType || !targetType) return []
+      return [{
+        action_type: actionType,
+        target_type: targetType,
+        description: asString(item.description),
+        confirm_required: asBoolean(item.confirm_required),
+      }]
+    }),
+  }
+}
+
+function normalizeAttentionSummary(raw: unknown): DashboardRoomTruthAttentionSummary | null {
+  if (!isRecord(raw)) return null
+  return {
+    count: asNumber(raw.count) ?? 0,
+    bad_count: asNumber(raw.bad_count) ?? 0,
+    warn_count: asNumber(raw.warn_count) ?? 0,
+    provenance: asString(raw.provenance) ?? null,
+    top_item: normalizeAttentionItem(raw.top_item),
+  }
+}
+
+function normalizeRecommendationSummary(raw: unknown): DashboardRoomTruthRecommendationSummary | null {
+  if (!isRecord(raw)) return null
+  return {
+    count: asNumber(raw.count) ?? 0,
+    provenance: asString(raw.provenance) ?? null,
+    top_action: normalizeRecommendedAction(raw.top_action),
+  }
+}
+
+function normalizeFocus(raw: unknown): DashboardRoomTruthFocus | null {
+  if (!isRecord(raw)) return null
+  const label = asString(raw.label)
+  const reason = asString(raw.reason)
+  const source = asString(raw.source)
+  const provenance = asString(raw.provenance)
+  if (!label || !reason || !source || !provenance) return null
+  return {
+    label,
+    reason,
+    source,
+    provenance,
+    target_kind: asString(raw.target_kind) ?? null,
+    target_id: asString(raw.target_id) ?? null,
+    suggested_tab: asString(raw.suggested_tab) ?? null,
+    suggested_surface: asString(raw.suggested_surface) ?? null,
+    suggested_params: isRecord(raw.suggested_params)
+      ? Object.fromEntries(
+          Object.entries(raw.suggested_params)
+            .map(([key, value]) => {
+              const text = asString(value)
+              return text ? [key, text] : null
+            })
+            .filter((entry): entry is [string, string] => entry !== null),
+        )
+      : {},
+  }
+}
+
+function normalizeRoomTruth(raw: unknown): DashboardRoomTruthResponse {
+  const root = isRecord(raw) ? raw : {}
+  const roomBlock = isRecord(root.room) ? root.room : {}
+  const executionBlock = isRecord(root.execution) ? root.execution : {}
+  const commandBlock = isRecord(root.command) ? root.command : {}
+  const operatorBlock = isRecord(root.operator) ? root.operator : {}
+  return {
+    generated_at: asString(root.generated_at),
+    room: {
+      status: normalizeServerStatus(roomBlock.status),
+      counts: isRecord(roomBlock.counts)
+        ? {
+            agents: asNumber(roomBlock.counts.agents),
+            tasks: asNumber(roomBlock.counts.tasks),
+            keepers: asNumber(roomBlock.counts.keepers),
+          }
+        : undefined,
+      provenance: asString(roomBlock.provenance) ?? null,
+    },
+    execution: {
+      summary: normalizeExecutionSummary(executionBlock.summary),
+      top_queue: normalizeExecutionQueueItem(executionBlock.top_queue),
+      provenance: asString(executionBlock.provenance) ?? null,
+    },
+    command: {
+      active_operations: asNumber(commandBlock.active_operations),
+      active_detachments: asNumber(commandBlock.active_detachments),
+      pending_approvals: asNumber(commandBlock.pending_approvals),
+      bad_alerts: asNumber(commandBlock.bad_alerts),
+      warn_alerts: asNumber(commandBlock.warn_alerts),
+      moving_lanes: asNumber(commandBlock.moving_lanes),
+      active_lanes: asNumber(commandBlock.active_lanes),
+      provenance: asString(commandBlock.provenance) ?? null,
+    },
+    operator: {
+      health: asString(operatorBlock.health) ?? null,
+      attention_summary: normalizeAttentionSummary(operatorBlock.attention_summary),
+      recommendation_summary: normalizeRecommendationSummary(operatorBlock.recommendation_summary),
+      pending_confirm_summary: normalizePendingConfirmSummary(operatorBlock.pending_confirm_summary),
+      provenance: asString(operatorBlock.provenance) ?? null,
+    },
+    focus: normalizeFocus(root.focus),
+  }
+}
+
+export async function refreshRoomTruth(): Promise<void> {
+  roomTruthLoading.value = true
+  roomTruthError.value = null
+  try {
+    const raw = await fetchDashboardRoomTruth()
+    roomTruth.value = normalizeRoomTruth(raw)
+  } catch (err) {
+    roomTruthError.value = err instanceof Error ? err.message : 'Failed to load room truth'
+  } finally {
+    roomTruthLoading.value = false
+  }
+}

--- a/dashboard/src/styles/ui.css
+++ b/dashboard/src/styles/ui.css
@@ -216,6 +216,71 @@ button.agent-card:hover {
   gap: 2px;
 }
 
+.room-truth-strip {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 12px;
+  margin: 0 0 16px;
+}
+
+.room-truth-strip-loading,
+.room-truth-strip-error {
+  border-radius: 14px;
+  border: 1px solid rgba(138, 163, 211, 0.18);
+  background: rgba(19, 29, 51, 0.72);
+  padding: 12px 14px;
+  color: #9db4de;
+}
+
+.room-truth-strip-error {
+  color: #fecaca;
+  border-color: rgba(248, 113, 113, 0.35);
+}
+
+.room-truth-card {
+  border-radius: 14px;
+  border: 1px solid rgba(138, 163, 211, 0.18);
+  background:
+    linear-gradient(180deg, rgba(40, 56, 92, 0.34), rgba(19, 29, 51, 0.9)),
+    rgba(19, 29, 51, 0.82);
+  padding: 14px 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.room-truth-card strong {
+  color: #edf4ff;
+  font-size: 15px;
+  line-height: 1.35;
+}
+
+.room-truth-card p {
+  margin: 0;
+  color: #96add7;
+  font-size: 12px;
+  line-height: 1.5;
+}
+
+.room-truth-label {
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  font-size: 10px;
+  color: #7fa5d8;
+}
+
+.room-truth-chip-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.room-truth-actions {
+  margin-top: auto;
+  display: flex;
+  justify-content: flex-start;
+}
+
 .agent-card .agent-task {
   margin-top: 10px;
   color: #89a3cf;

--- a/dashboard/src/tab-refresh.ts
+++ b/dashboard/src/tab-refresh.ts
@@ -1,5 +1,6 @@
 import { route } from './router'
 import { refreshExecution, refreshBoard, refreshGoals, refreshTrpg } from './store'
+import { refreshRoomTruth } from './room-truth-store'
 import { refreshOperatorRoomDigest, refreshOperatorSnapshot } from './operator-store'
 import { refreshMissionBriefing, refreshMissionSnapshot } from './mission-store'
 import { refreshProofSnapshot } from './proof-store'
@@ -13,6 +14,7 @@ import {
 
 export function refreshForTab(tab: string) {
   if (tab === 'command') {
+    refreshRoomTruth()
     refreshCommandPlaneCurrentSurface()
     refreshCommandPlaneChainSummary()
     if (
@@ -31,6 +33,7 @@ export function refreshForTab(tab: string) {
   }
 
   if (tab === 'mission') {
+    refreshRoomTruth()
     refreshMissionSnapshot()
     refreshMissionBriefing()
   }
@@ -39,9 +42,13 @@ export function refreshForTab(tab: string) {
     refreshProofSnapshot(route.value.params.session_id, route.value.params.operation_id)
   }
 
-  if (tab === 'execution') refreshExecution()
+  if (tab === 'execution') {
+    refreshRoomTruth()
+    refreshExecution()
+  }
 
   if (tab === 'intervene') {
+    refreshRoomTruth()
     refreshOperatorSnapshot()
     refreshOperatorRoomDigest()
   }

--- a/dashboard/src/types.ts
+++ b/dashboard/src/types.ts
@@ -875,6 +875,64 @@ export interface DashboardShellResponse {
   }
 }
 
+export interface DashboardRoomTruthAttentionSummary {
+  count: number
+  bad_count: number
+  warn_count: number
+  provenance?: string | null
+  top_item?: OperatorAttentionItem | null
+}
+
+export interface DashboardRoomTruthRecommendationSummary {
+  count: number
+  provenance?: string | null
+  top_action?: OperatorRecommendedAction | null
+}
+
+export interface DashboardRoomTruthFocus {
+  label: string
+  reason: string
+  source: string
+  provenance: string
+  target_kind?: string | null
+  target_id?: string | null
+  suggested_tab?: 'command' | 'intervene' | string | null
+  suggested_surface?: CommandPlaneSurface | string | null
+  suggested_params?: Record<string, string>
+}
+
+export interface DashboardRoomTruthResponse {
+  generated_at?: string
+  room: {
+    status?: ServerStatus | null
+    counts?: DashboardShellResponse['counts']
+    provenance?: string | null
+  }
+  execution?: {
+    summary?: DashboardExecutionSummary | null
+    top_queue?: DashboardExecutionQueueItem | null
+    provenance?: string | null
+  }
+  command?: {
+    active_operations?: number
+    active_detachments?: number
+    pending_approvals?: number
+    bad_alerts?: number
+    warn_alerts?: number
+    moving_lanes?: number
+    active_lanes?: number
+    provenance?: string | null
+  }
+  operator?: {
+    health?: string | null
+    attention_summary?: DashboardRoomTruthAttentionSummary | null
+    recommendation_summary?: DashboardRoomTruthRecommendationSummary | null
+    pending_confirm_summary?: PendingConfirmSummary | null
+    provenance?: string | null
+  }
+  focus?: DashboardRoomTruthFocus | null
+}
+
 export interface ServerBuildIdentity {
   release_version: string
   commit?: string | null

--- a/lib/server_dashboard_http.ml
+++ b/lib/server_dashboard_http.ml
@@ -2544,6 +2544,23 @@ let json_int_field key json ~default =
   | `Intlit raw -> (try int_of_string raw with Failure _ -> default)
   | _ -> default
 
+let json_string_field_opt key json =
+  match Yojson.Safe.Util.member key json with
+  | `String value ->
+      let trimmed = String.trim value in
+      if trimmed = "" then None else Some trimmed
+  | _ -> None
+
+let json_assoc_field key json =
+  match Yojson.Safe.Util.member key json with
+  | `Assoc _ as value -> value
+  | _ -> `Assoc []
+
+let json_record_field key json =
+  match Yojson.Safe.Util.member key json with
+  | `Assoc _ as value -> Some value
+  | _ -> None
+
 let dashboard_current_room_id config =
   Room.current_room_id config
 
@@ -2593,6 +2610,197 @@ let dashboard_execution_http_json ~state ~sw ~clock request =
   Dashboard_execution.json ?actor:(operator_actor_hint request) ?fixture
     ~config:state.Mcp_server.room_config ~sw ~clock
     ~proc_mgr:state.Mcp_server.proc_mgr ()
+
+let dashboard_room_truth_http_json ~state ~sw ~clock request =
+  let config = state.Mcp_server.room_config in
+  let actor = operator_actor_hint request in
+  let shell_json = dashboard_shell_http_json config in
+  let execution_json = dashboard_execution_http_json ~state ~sw ~clock request in
+  let command_summary_json =
+    if Room.is_initialized config then
+      try
+        Server_command_plane_http.command_plane_summary_http_json ~state
+      with _ -> `Assoc []
+    else
+      `Assoc []
+  in
+  let operator_ctx : _ Operator_control.context =
+    {
+      config;
+      agent_name = Option.value ~default:"dashboard" actor;
+      sw;
+      clock;
+      proc_mgr = state.Mcp_server.proc_mgr;
+      mcp_session_id = None;
+    }
+  in
+  let operator_digest_json =
+    match Operator_control.digest_json ?actor operator_ctx with
+    | Ok json -> json
+    | Error message ->
+        `Assoc
+          [
+            ("health", `String "warn");
+            ("attention_summary", `Assoc [ ("count", `Int 0); ("provenance", `String "derived") ]);
+            ("recommendation_summary", `Assoc [ ("count", `Int 0); ("provenance", `String "fallback") ]);
+            ("error", `String message);
+          ]
+  in
+  let operator_snapshot_json =
+    Operator_control.snapshot_json ?actor
+      ~include_messages:false ~include_sessions:false ~include_keepers:false
+      operator_ctx
+  in
+  let orchestra_json =
+    if Room.is_initialized config then
+      try Command_plane_orchestra.json operator_ctx with _ -> `Assoc []
+    else
+      `Assoc
+        [
+          ( "focus",
+            `Assoc
+              [
+                ("label", `String "초기 room truth");
+                ("reason", `String "방이 아직 초기화되지 않았습니다. 기본 room 상태부터 확인하세요.");
+                ("source", `String "orchestra");
+                ("provenance", `String "derived");
+                ("target_kind", `String "node");
+                ("target_id", `String "room:default");
+                ("suggested_surface", `String "summary");
+                ("suggested_params", `Assoc []);
+              ] );
+        ]
+  in
+  let execution_queue =
+    match Yojson.Safe.Util.member "execution_queue" execution_json with
+    | `List items -> items
+    | _ -> []
+  in
+  let top_queue =
+    match execution_queue with
+    | head :: _ -> head
+    | [] -> `Null
+  in
+  let command_ops = json_assoc_field "operations" command_summary_json in
+  let command_detachments = json_assoc_field "detachments" command_summary_json in
+  let command_alerts = json_assoc_field "alerts" command_summary_json in
+  let command_decisions = json_assoc_field "decisions" command_summary_json in
+  let swarm_status = json_assoc_field "swarm_status" command_summary_json in
+  let swarm_overview = json_assoc_field "overview" swarm_status in
+  let command_summary =
+    `Assoc
+      [
+        ( "active_operations",
+          `Int
+            (json_int_field "active" (json_assoc_field "summary" command_ops)
+               ~default:0) );
+        ( "active_detachments",
+          `Int
+            (json_int_field "active"
+               (json_assoc_field "summary" command_detachments)
+               ~default:0) );
+        ( "pending_approvals",
+          `Int
+            (json_int_field "pending"
+               (json_assoc_field "summary" command_decisions)
+               ~default:0) );
+        ( "bad_alerts",
+          `Int
+            (json_int_field "bad" (json_assoc_field "summary" command_alerts)
+               ~default:0) );
+        ( "warn_alerts",
+          `Int
+            (json_int_field "warn" (json_assoc_field "summary" command_alerts)
+               ~default:0) );
+        ("moving_lanes", `Int (json_int_field "moving_lanes" swarm_overview ~default:0));
+        ("active_lanes", `Int (json_int_field "active_lanes" swarm_overview ~default:0));
+        ("provenance", `String "truth");
+      ]
+  in
+  let focus_json =
+    match json_record_field "focus" orchestra_json with
+    | Some focus ->
+        let suggested_surface = json_string_field_opt "suggested_surface" focus in
+        let suggested_tab =
+          match suggested_surface with
+          | Some "intervene" -> "intervene"
+          | _ -> "command"
+        in
+        `Assoc
+          [
+            ("label", Yojson.Safe.Util.member "label" focus);
+            ("reason", Yojson.Safe.Util.member "reason" focus);
+            ("source", `String "orchestra");
+            ("provenance", `String "derived");
+            ("target_kind", Yojson.Safe.Util.member "target_kind" focus);
+            ("target_id", Yojson.Safe.Util.member "target_id" focus);
+            ("suggested_tab", `String suggested_tab);
+            ( "suggested_surface",
+              match suggested_surface with
+              | Some value when not (String.equal value "intervene") -> `String value
+              | _ -> `Null );
+            ("suggested_params", json_assoc_field "suggested_params" focus);
+          ]
+    | None -> (
+        let recommendation_summary =
+          json_assoc_field "recommendation_summary" operator_digest_json
+        in
+        match json_record_field "top_action" recommendation_summary with
+        | Some top_action ->
+            `Assoc
+              [
+                ("label", `String "운영 권고");
+                ("reason", Yojson.Safe.Util.member "reason" top_action);
+                ("source", `String "operator");
+                ( "provenance",
+                  match json_string_field_opt "provenance" recommendation_summary with
+                  | Some value -> `String value
+                  | None -> `String "fallback" );
+                ("target_kind", `String "action");
+                ("target_id", Yojson.Safe.Util.member "target_id" top_action);
+                ("suggested_tab", `String "intervene");
+                ("suggested_surface", `Null);
+                ( "suggested_params",
+                  `Assoc
+                    [
+                      ("action_type", Yojson.Safe.Util.member "action_type" top_action);
+                      ("target_type", Yojson.Safe.Util.member "target_type" top_action);
+                      ("target_id", Yojson.Safe.Util.member "target_id" top_action);
+                    ] );
+              ]
+        | None -> `Null)
+  in
+  `Assoc
+    [
+      ("generated_at", `String (Types.now_iso ()));
+      ( "room",
+        `Assoc
+          [
+            ("status", json_assoc_field "status" shell_json);
+            ("counts", json_assoc_field "counts" shell_json);
+            ("provenance", `String "truth");
+          ] );
+      ( "execution",
+        `Assoc
+          [
+            ("summary", json_assoc_field "summary" execution_json);
+            ("top_queue", top_queue);
+            ("provenance", `String "derived");
+          ] );
+      ("command", command_summary);
+      ( "operator",
+        `Assoc
+          [
+            ("health", Yojson.Safe.Util.member "health" operator_digest_json);
+            ("attention_summary", json_assoc_field "attention_summary" operator_digest_json);
+            ( "recommendation_summary",
+              json_assoc_field "recommendation_summary" operator_digest_json );
+            ( "pending_confirm_summary",
+              json_assoc_field "pending_confirm_summary" operator_snapshot_json );
+            ("provenance", `String "derived");
+          ] );
+      ("focus", focus_json);
+    ]
 
 let dashboard_memory_http_json request : Yojson.Safe.t =
   let hearth = query_param request "hearth" in

--- a/lib/server_h2_gateway.ml
+++ b/lib/server_h2_gateway.ml
@@ -398,6 +398,13 @@ let make_request_handler ~sw ~clock ~server_start_time =
           let json = dashboard_shell_http_json state.Mcp_server.room_config in
           h2_respond_json h2_reqd (Yojson.Safe.to_string json) ~extra_headers:cors
 
+      | `GET, "/api/v1/dashboard/room-truth" ->
+          let state = get_server_state () in
+          let json =
+            dashboard_room_truth_http_json ~state ~sw ~clock httpun_request
+          in
+          h2_respond_json h2_reqd (Yojson.Safe.to_string json) ~extra_headers:cors
+
       | `GET, "/api/v1/dashboard/execution" ->
           let state = get_server_state () in
           let json = dashboard_execution_http_json ~state ~sw ~clock httpun_request in

--- a/lib/server_routes_http.ml
+++ b/lib/server_routes_http.ml
@@ -1583,6 +1583,11 @@ let make_routes ~port ~host ~sw ~clock =
          let json = dashboard_shell_http_json state.Mcp_server.room_config in
          Http.Response.json ~compress:true ~request:req (Yojson.Safe.to_string json) reqd
        ) request reqd)
+  |> Http.Router.get "/api/v1/dashboard/room-truth" (fun request reqd ->
+       with_public_read (fun state req reqd ->
+         let json = dashboard_room_truth_http_json ~state ~sw ~clock req in
+         Http.Response.json ~compress:true ~request:req (Yojson.Safe.to_string json) reqd
+       ) request reqd)
   |> Http.Router.get "/api/v1/dashboard/execution" (fun request reqd ->
        with_public_read (fun state req reqd ->
          let json = dashboard_execution_http_json ~state ~sw ~clock request in

--- a/test/dune
+++ b/test/dune
@@ -87,6 +87,11 @@
  (libraries masc_mcp alcotest yojson unix))
 
 (test
+ (name test_dashboard_room_truth)
+ (modules test_dashboard_room_truth)
+ (libraries masc_mcp alcotest eio eio_main yojson unix))
+
+(test
  (name test_local_agent_eio)
  (modules test_local_agent_eio)
  (libraries masc_mcp alcotest eio eio_main yojson unix))

--- a/test/test_dashboard_room_truth.ml
+++ b/test/test_dashboard_room_truth.ml
@@ -1,0 +1,83 @@
+(** Dashboard room truth read-model regression tests. *)
+
+module Lib = Masc_mcp
+
+open Alcotest
+
+let test_dir () =
+  let tmp = Filename.temp_file "masc_dashboard_room_truth" "" in
+  Sys.remove tmp;
+  Unix.mkdir tmp 0o755;
+  tmp
+
+let cleanup_dir dir =
+  let rec rm path =
+    if Sys.file_exists path then
+      if Sys.is_directory path then begin
+        Sys.readdir path |> Array.iter (fun f -> rm (Filename.concat path f));
+        Unix.rmdir path
+      end else
+        Sys.remove path
+  in
+  rm dir
+
+let request target =
+  Httpun.Request.create ~headers:(Httpun.Headers.of_list []) `GET target
+
+let test_dashboard_room_truth_empty_room () =
+  let dir = test_dir () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir dir)
+    (fun () ->
+      let state = Lib.Mcp_server_eio.create_state ~test_mode:true ~base_path:dir () in
+      Eio_main.run @@ fun env ->
+      Eio.Switch.run (fun sw ->
+        let json =
+          Lib.Server_dashboard_http.dashboard_room_truth_http_json
+            ~state ~sw ~clock:(Eio.Stdenv.clock env)
+            (request "/api/v1/dashboard/room-truth")
+        in
+        let open Yojson.Safe.Util in
+        let expected_room = Filename.basename dir in
+        check string "room default"
+          expected_room
+          (json |> member "room" |> member "status" |> member "room" |> to_string);
+        check int "pending confirms zero"
+          0
+          (json |> member "operator" |> member "pending_confirm_summary" |> member "total_count" |> to_int);
+        check string "focus source"
+          "orchestra"
+          (json |> member "focus" |> member "source" |> to_string);
+      ))
+
+let test_dashboard_room_truth_execution_fixture () =
+  let dir = test_dir () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir dir)
+    (fun () ->
+      let state = Lib.Mcp_server_eio.create_state ~test_mode:true ~base_path:dir () in
+      Eio_main.run @@ fun env ->
+      Eio.Switch.run (fun sw ->
+        let json =
+          Lib.Server_dashboard_http.dashboard_room_truth_http_json
+            ~state ~sw ~clock:(Eio.Stdenv.clock env)
+            (request "/api/v1/dashboard/room-truth?fixture=execution_smoke")
+        in
+        let open Yojson.Safe.Util in
+        check int "fixture blocked sessions"
+          1
+          (json |> member "execution" |> member "summary" |> member "blocked_sessions" |> to_int);
+        check string "fixture top queue target"
+          "ts-execution-fixture-001"
+          (json |> member "execution" |> member "top_queue" |> member "target_id" |> to_string);
+      ))
+
+let () =
+  Alcotest.run "Dashboard Room Truth"
+    [
+      ( "read_model",
+        [
+          test_case "empty room shape" `Quick test_dashboard_room_truth_empty_room;
+          test_case "execution fixture surfaces top queue" `Quick test_dashboard_room_truth_execution_fixture;
+        ] );
+    ]


### PR DESCRIPTION
## Summary
- add `/api/v1/dashboard/room-truth` as a unified room-level read model
- add a shared room truth strip to mission, execution, intervene, and command surfaces
- surface one connected view for room state, execution pressure, control pressure, and next focus

## Validation
- dune build --root . bin/main_eio.exe test/test_dashboard_room_truth.exe
- ./_build/default/test/test_dashboard_room_truth.exe
- dune build --root . test/test_dashboard_execution.exe && ./_build/default/test/test_dashboard_execution.exe
- dune build --root . @check
- changed-file TypeScript validation with worktree dashboard node_modules symlinked to the main dashboard install