### PR TITLE
refactor(keeper): drop unused recall context arg

### DIFF
--- a/lib/keeper_exec_tools.ml
+++ b/lib/keeper_exec_tools.ml
@@ -857,11 +857,9 @@ let recall_fallback_reply
 
 let deterministic_recall_fallback
     ~(meta : keeper_meta)
-    ~(ctx_work : Context_manager.working_context)
     ~(user_message : string)
     ~(eval : memory_recall_eval)
     ~(candidates : string list) : (string * memory_recall_eval) option =
-  let _ = ctx_work in
   if (not eval.performed) || eval.passed || eval.candidate_count <= 0 then
     None
   else

--- a/lib/keeper_turn.ml
+++ b/lib/keeper_turn.ml
@@ -1763,7 +1763,6 @@ let handle_keeper_msg ctx args : tool_result =
                 match
                   deterministic_recall_fallback
                     ~meta
-                    ~ctx_work
                     ~user_message:message
                     ~eval:eval_after_prompt_fallback
                     ~candidates:recall_candidates


### PR DESCRIPTION
## Summary
- remove the unused  parameter from 
- update the  call site to match the narrowed helper contract
- keep the post-#864 keeper execution split behavior unchanged while trimming the stale interface

## Verification
- dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/refactor-keeper-execution-split-clean
- ./_build/default/test/test_tool_keeper.exe
- ./_build/default/test/test_operator_control.exe
- ./_build/default/test/test_dashboard_execution.exe