### PR TITLE
refactor: add result-based env and HTTPS helpers

### DIFF
--- a/lib/env_config.ml
+++ b/lib/env_config.ml
@@ -64,10 +64,17 @@ let me_root_opt () =
       | Some path -> Some path
       | None -> Sys.getenv_opt "DUNE_SOURCEROOT" |> trim_opt)
 
-let me_root () =
+let me_root_result () =
   match me_root_opt () with
-  | Some path -> path
-  | None -> failwith "MASC_WORKSPACE_ROOT or ME_ROOT is required (tests may use DUNE_SOURCEROOT)"
+  | Some path -> Ok path
+  | None ->
+      Error
+        "MASC_WORKSPACE_ROOT or ME_ROOT is required (tests may use DUNE_SOURCEROOT)"
+
+let me_root () =
+  match me_root_result () with
+  | Ok path -> path
+  | Error msg -> failwith msg
 
 let sb_path_opt () =
   match Sys.getenv_opt "MASC_SB_PATH" |> trim_opt with
@@ -79,10 +86,17 @@ let sb_path_opt () =
           if existing_file path then Some path else None
       | None -> None)
 
-let sb_path () =
+let sb_path_result () =
   match sb_path_opt () with
-  | Some path -> path
-  | None -> failwith "Unable to resolve scripts/sb. Set MASC_SB_PATH or MASC_WORKSPACE_ROOT."
+  | Some path -> Ok path
+  | None ->
+      Error
+        "Unable to resolve scripts/sb. Set MASC_SB_PATH or MASC_WORKSPACE_ROOT."
+
+let sb_path () =
+  match sb_path_result () with
+  | Ok path -> path
+  | Error msg -> failwith msg
 
 let masc_http_port () =
   match Sys.getenv_opt "MASC_HTTP_PORT" |> trim_opt with
@@ -92,16 +106,25 @@ let masc_http_port () =
       | Some port -> port
       | None -> "8935")
 
-let masc_http_base_url () =
+let rec masc_http_base_url () =
+  match masc_http_base_url_result () with
+  | Ok base -> base
+  | Error msg -> failwith msg
+
+and masc_http_base_url_result () =
   match Sys.getenv_opt "MASC_HTTP_BASE_URL" |> trim_opt with
-  | Some base -> strip_trailing_slashes base
+  | Some base -> Ok (strip_trailing_slashes base)
   | None ->
       let host =
         match Sys.getenv_opt "MASC_HOST" |> trim_opt with
-        | Some value -> value
-        | None -> failwith "MASC_HTTP_BASE_URL is required (or set MASC_HOST with MASC_HTTP_PORT/MASC_PORT)"
+        | Some value -> Ok value
+        | None ->
+            Error
+              "MASC_HTTP_BASE_URL is required (or set MASC_HOST with MASC_HTTP_PORT/MASC_PORT)"
       in
-      Printf.sprintf "http://%s:%s" host (masc_http_port ())
+      Result.map
+        (fun host -> Printf.sprintf "http://%s:%s" host (masc_http_port ()))
+        host
 
 let libdatachannel_path_candidates () =
   let env_path =
@@ -497,25 +520,40 @@ module Endpoints = struct
   let llm_mcp_url =
     get_string ~default:"" "LLM_MCP_URL"  (* Default empty - not used *)
 
+  let masc_host_result () =
+    match Uri.host (Uri.of_string (masc_http_base_url ())) with
+    | Some host -> Ok host
+    | None -> Error "MASC_HTTP_BASE_URL must include a host"
+
   (** MASC server host *)
   let masc_host () =
-    match Uri.host (Uri.of_string (masc_http_base_url ())) with
-    | Some host -> host
-    | None -> failwith "MASC_HTTP_BASE_URL must include a host"
+    match masc_host_result () with
+    | Ok host -> host
+    | Error msg -> failwith msg
+
+  let masc_port_result () =
+    match Uri.port (Uri.of_string (masc_http_base_url ())) with
+    | Some port -> Ok port
+    | None -> (
+        match Uri.scheme (Uri.of_string (masc_http_base_url ())) with
+        | Some "https" -> Ok 443
+        | Some "http" -> Ok 80
+        | _ -> Error "MASC_HTTP_BASE_URL must include a port or scheme")
 
   (** MASC server port *)
   let masc_port () =
-    match Uri.port (Uri.of_string (masc_http_base_url ())) with
-    | Some port -> port
-    | None -> (
-        match Uri.scheme (Uri.of_string (masc_http_base_url ())) with
-        | Some "https" -> 443
-        | Some "http" -> 80
-        | _ -> failwith "MASC_HTTP_BASE_URL must include a port or scheme")
+    match masc_port_result () with
+    | Ok port -> port
+    | Error msg -> failwith msg
+
+  let masc_sse_url_result () =
+    Result.map (fun base -> Printf.sprintf "%s/sse" base) (masc_http_base_url_result ())
 
   (** MASC SSE URL (derived) *)
   let masc_sse_url () =
-    Printf.sprintf "%s/sse" (masc_http_base_url ())
+    match masc_sse_url_result () with
+    | Ok url -> url
+    | Error msg -> failwith msg
 end
 
 (** {1 Gardener — Self-Organizing Agent Ecosystem} *)

--- a/lib/voice_bridge_eio.ml
+++ b/lib/voice_bridge_eio.ml
@@ -94,6 +94,11 @@ let client_for_uri ~net uri =
   else
     Cohttp_eio.Client.make ~https:None net
 
+let client_for_uri_result ~net uri =
+  try Ok (client_for_uri ~net uri)
+  with exn ->
+    Error (Printf.sprintf "HTTPS client init error: %s" (Printexc.to_string exn))
+
 (** ============================================
     Structured Logging
     ============================================ *)
@@ -659,21 +664,25 @@ let call_voice_mcp ~sw ~clock ~net ~tool_name ~arguments =
     ("Content-Type", "application/json");
     ("Accept", "application/json");
   ] in
-  let client = client_for_uri ~net uri in
-  let operation () =
-    with_timeout ~clock (fun () ->
-      single_voice_mcp_call ~sw ~client ~uri ~headers ~body_str)
-  in
-  let result = retry_with_backoff ~clock
-    ~attempt:1
-    ~max_attempts:(max_retries ())
-    ~backoff_sec:(initial_backoff_seconds ())
-    operation
-  in
-  (match result with
-  | Ok _ -> log_debug (Printf.sprintf "Tool %s succeeded" tool_name)
-  | Error e -> log_error (Printf.sprintf "Tool %s failed: %s" tool_name e));
-  result
+  match client_for_uri_result ~net uri with
+  | Error error ->
+      log_error (Printf.sprintf "Tool %s failed: %s" tool_name error);
+      Error error
+  | Ok client ->
+      let operation () =
+        with_timeout ~clock (fun () ->
+          single_voice_mcp_call ~sw ~client ~uri ~headers ~body_str)
+      in
+      let result = retry_with_backoff ~clock
+        ~attempt:1
+        ~max_attempts:(max_retries ())
+        ~backoff_sec:(initial_backoff_seconds ())
+        operation
+      in
+      (match result with
+      | Ok _ -> log_debug (Printf.sprintf "Tool %s succeeded" tool_name)
+      | Error e -> log_error (Printf.sprintf "Tool %s failed: %s" tool_name e));
+      result
 
 (** Extract result from MCP response *)
 let extract_mcp_result json =
@@ -718,17 +727,19 @@ let call_voice_mcp_endpoint ~sw ~clock ~net ~endpoint ~tool_name ~arguments =
     Cohttp.Header.of_list
       [ ("Content-Type", "application/json"); ("Accept", "application/json") ]
   in
-  let client = client_for_uri ~net uri in
-  let operation () =
-    let timeout =
-      Option.value endpoint.timeout_seconds ~default:(request_timeout_seconds ())
-    in
-    with_timeout ~clock ~timeout (fun () ->
-        single_voice_mcp_call ~sw ~client ~uri ~headers ~body_str)
-  in
-  retry_with_backoff ~clock ~attempt:1
-    ~max_attempts:(Option.value endpoint.max_retries ~default:(max_retries ()))
-    ~backoff_sec:(initial_backoff_seconds ()) operation
+  match client_for_uri_result ~net uri with
+  | Error error -> Error error
+  | Ok client ->
+      let operation () =
+        let timeout =
+          Option.value endpoint.timeout_seconds ~default:(request_timeout_seconds ())
+        in
+        with_timeout ~clock ~timeout (fun () ->
+            single_voice_mcp_call ~sw ~client ~uri ~headers ~body_str)
+      in
+      retry_with_backoff ~clock ~attempt:1
+        ~max_attempts:(Option.value endpoint.max_retries ~default:(max_retries ()))
+        ~backoff_sec:(initial_backoff_seconds ()) operation
 
 let attempt_tts_endpoint ~sw ~clock ~net ~agent_id ~message ~voice ~model
     ~priority endpoint =
@@ -829,14 +840,16 @@ let is_voice_server_available ~sw ~clock ~net =
               | Ok url -> Uri.of_string url
               | Error _ -> voice_health_uri ()
             in
-            let client = client_for_uri ~net uri in
-            let resp, _ = Cohttp_eio.Client.get ~sw client uri in
-            let status = Cohttp.Response.status resp in
-            let available =
-              Cohttp.Code.is_success (Cohttp.Code.code_of_status status)
-            in
-            voice_server_available := Some available;
-            Ok available
+            match client_for_uri_result ~net uri with
+            | Error error -> Error error
+            | Ok client ->
+                let resp, _ = Cohttp_eio.Client.get ~sw client uri in
+                let status = Cohttp.Response.status resp in
+                let available =
+                  Cohttp.Code.is_success (Cohttp.Code.code_of_status status)
+                in
+                voice_server_available := Some available;
+                Ok available
           with exn ->
             Eio.traceln "[WARN] voice server check failed: %s"
               (Printexc.to_string exn);

--- a/test/test_env_config_coverage.ml
+++ b/test/test_env_config_coverage.ml
@@ -79,28 +79,55 @@ let test_get_bool_default_false () =
 let test_me_root_prefers_env () =
   with_env "ME_ROOT" "/tmp/masc-custom-root" (fun () ->
     check (option string) "me_root_opt" (Some "/tmp/masc-custom-root") (Env_config.me_root_opt ());
+    check (result string string) "me_root_result" (Ok "/tmp/masc-custom-root")
+      (Env_config.me_root_result ());
     check string "me_root" "/tmp/masc-custom-root" (Env_config.me_root ()))
 
 let test_me_root_prefers_explicit_workspace_root () =
   with_env "MASC_WORKSPACE_ROOT" "/tmp/masc-workspace-root" (fun () ->
     with_env "ME_ROOT" "" (fun () ->
       check (option string) "me_root_opt explicit" (Some "/tmp/masc-workspace-root") (Env_config.me_root_opt ());
+      check (result string string) "me_root_result explicit"
+        (Ok "/tmp/masc-workspace-root") (Env_config.me_root_result ());
       check string "me_root explicit" "/tmp/masc-workspace-root" (Env_config.me_root ())))
 
 let test_masc_http_base_url_prefers_env_and_trims () =
   with_env "MASC_HTTP_BASE_URL" "http://example.test:9911/" (fun () ->
+    check (result string string) "base url result trimmed"
+      (Ok "http://example.test:9911")
+      (Env_config.masc_http_base_url_result ());
     check string "base url trimmed" "http://example.test:9911" (Env_config.masc_http_base_url ()))
 
 let test_masc_http_base_url_uses_explicit_host_and_port () =
   with_env "MASC_HTTP_BASE_URL" "" (fun () ->
     with_env "MASC_HOST" "masc.example.test" (fun () ->
       with_env "MASC_HTTP_PORT" "7777" (fun () ->
+        check (result string string) "base url result from host+port"
+          (Ok "http://masc.example.test:7777")
+          (Env_config.masc_http_base_url_result ());
         check string "base url from host+port" "http://masc.example.test:7777" (Env_config.masc_http_base_url ()))))
+
+let test_sb_path_result_missing_is_error () =
+  with_env "MASC_SB_PATH" "" (fun () ->
+    with_env "MASC_WORKSPACE_ROOT" "" (fun () ->
+      with_env "ME_ROOT" "" (fun () ->
+        check bool "sb path result is error" true
+          (match Env_config.sb_path_result () with Error _ -> true | Ok _ -> false))))
 
 let test_libdatachannel_candidates_include_env_override () =
   with_env "LIBDATACHANNEL_PATH" "/tmp/libdatachannel-custom.dylib" (fun () ->
     check bool "env path present" true
       (List.mem "/tmp/libdatachannel-custom.dylib" (Env_config.libdatachannel_path_candidates ())))
+
+let test_endpoints_result_helpers () =
+  with_env "MASC_HTTP_BASE_URL" "https://masc.example.test" (fun () ->
+    check (result string string) "masc_host_result"
+      (Ok "masc.example.test") (Env_config.Endpoints.masc_host_result ());
+    check (result int string) "masc_port_result"
+      (Ok 443) (Env_config.Endpoints.masc_port_result ());
+    check (result string string) "masc_sse_url_result"
+      (Ok "https://masc.example.test/sse")
+      (Env_config.Endpoints.masc_sse_url_result ()))
 
 (* ============================================================
    print_summary Tests
@@ -316,6 +343,8 @@ let () =
       test_case "me_root prefers explicit workspace root" `Quick test_me_root_prefers_explicit_workspace_root;
       test_case "base url prefers env and trims" `Quick test_masc_http_base_url_prefers_env_and_trims;
       test_case "base url uses explicit host+port" `Quick test_masc_http_base_url_uses_explicit_host_and_port;
+      test_case "sb_path_result missing is error" `Quick test_sb_path_result_missing_is_error;
+      test_case "endpoint result helpers" `Quick test_endpoints_result_helpers;
       test_case "libdatachannel candidates include env override" `Quick test_libdatachannel_candidates_include_env_override;
     ];
     "print_summary", [


### PR DESCRIPTION
## Summary
- add result-returning env/endpoint helpers to `Env_config` while preserving existing fail-fast wrappers
- harden `voice_bridge_eio` HTTPS client initialization so connector failures return explicit errors instead of raising
- extend env config coverage tests for the new result helpers

## Validation
- `_build/default/test/test_provider_adapter.exe`
- `_build/default/test/test_lodge_cascade.exe`
- `_build/default/test/test_env_config_coverage.exe`
- `dune build --root . @check`

## Notes
- This PR is stacked on top of #876 and should merge after that PR.