### PR TITLE
fix(core): harden unsafe list access paths

### DIFF
--- a/lib/lodge_heartbeat.ml
+++ b/lib/lodge_heartbeat.ml
@@ -3043,20 +3043,25 @@ let load_agent_specialties_from_neo4j () =
         match arr with
         | inner_node :: _ ->
           let inner = Yojson.Safe.Util.to_list inner_node in
-          let name = Yojson.Safe.Util.to_string (List.nth inner 0) in
-          let traits = Yojson.Safe.Util.(List.nth inner 1 |> to_list |> List.map to_string) in
-          let description =
-            match List.nth inner 2 with
-            | `Null -> ""
-            | `String s -> s
-            | _ -> ""
-          in
-          (* Combine traits + words from description as keywords *)
-          let desc_words = description
-            |> String.split_on_char ' '
-            |> List.filter (fun w -> String.length w > 3)
-          in
-          Some (name, traits @ desc_words)
+          (match inner with
+           | name_json :: traits_json :: description_json :: _ ->
+             let name = Yojson.Safe.Util.to_string name_json in
+             let traits =
+               Yojson.Safe.Util.(traits_json |> to_list |> List.map to_string)
+             in
+             let description =
+               match description_json with
+               | `Null -> ""
+               | `String s -> s
+               | _ -> ""
+             in
+             (* Combine traits + words from description as keywords *)
+             let desc_words = description
+               |> String.split_on_char ' '
+               |> List.filter (fun w -> String.length w > 3)
+             in
+             Some (name, traits @ desc_words)
+           | _ -> None)
         | [] -> None
       with Yojson.Safe.Util.Type_error _ | Failure _ -> None
     ) records

--- a/lib/mcp_session.ml
+++ b/lib/mcp_session.ml
@@ -14,7 +14,9 @@ let encode_base62 n =
     else aux (base62_chars.[n mod 62] :: acc) (n / 62)
   in
   if n = 0 then "0"
-  else String.init (List.length (aux [] n)) (fun i -> List.nth (aux [] n) i)
+  else
+    let chars = aux [] n |> Array.of_list in
+    String.init (Array.length chars) (fun i -> chars.(i))
 
 (** Validate session ID per MCP spec: visible ASCII only (0x21-0x7E) *)
 let is_valid id =

--- a/lib/spawn.ml
+++ b/lib/spawn.ml
@@ -368,71 +368,102 @@ let spawn ~agent_name ~prompt ?timeout_seconds ?working_dir () =
 
   (* Build command args - direct execution without shell *)
   let base_args = parse_command config.command |> add_default_model_arg agent_name in
-  let cmd_args = ["timeout"; string_of_int timeout] @ base_args @ mcp_args @ prompt_args in
-  let cmd_array = Array.of_list cmd_args in
+  if base_args = [] then
+    {
+      success = false;
+      output =
+        Printf.sprintf "spawn command is empty for agent '%s'" agent_name;
+      exit_code = 2;
+      elapsed_ms = int_of_float ((Time_compat.now () -. start_time) *. 1000.0);
+      input_tokens = None;
+      output_tokens = None;
+      cache_creation_tokens = None;
+      cache_read_tokens = None;
+      cost_usd = None;
+    }
+  else (
+    let cmd_args =
+      [ "timeout"; string_of_int timeout ] @ base_args @ mcp_args @ prompt_args
+    in
+    let cmd_array = Array.of_list cmd_args in
 
-  (* Change to working dir if specified *)
-  let original_dir = Sys.getcwd () in
-  let () = match working_dir with
-    | Some dir -> Sys.chdir dir
-    | None -> match config.working_dir with
+    (* Change to working dir if specified *)
+    let original_dir = Sys.getcwd () in
+    let () =
+      match working_dir with
       | Some dir -> Sys.chdir dir
-      | None -> ()
-  in
-
-  try
-    (* Create pipes for stdin and stdout *)
-    let (stdout_read, stdout_write) = Unix.pipe () in
-    let (stdin_read, stdin_write) = Unix.pipe () in
-    
-    (* Spawn process directly without shell *)
-    let executable =
-      match cmd_args with
-      | executable :: _ -> executable
-      | [] -> invalid_arg "spawn_with_direct_exec: empty command args"
-    in
-    let pid = Unix.create_process
-      executable cmd_array
-      stdin_read stdout_write Unix.stderr in
-    
-    (* Close unused ends *)
-    Unix.close stdout_write;
-    Unix.close stdin_read;
-    
-    (* Gemini CLI expects prompt via -p; other CLIs still read stdin. *)
-    let stdin_content = if agent_name = "gemini" then "" else augmented_prompt in
-    let _ = Unix.write_substring stdin_write stdin_content 0 (String.length stdin_content) in
-    Unix.close stdin_write;
-    
-    (* Read output *)
-    let ic = Unix.in_channel_of_descr stdout_read in
-    let raw_output = In_channel.input_all ic in
-    In_channel.close ic;
-    
-    (* Wait for process *)
-    let (_, status) = Unix.waitpid [] pid in
-
-    (* Restore directory *)
-    Sys.chdir original_dir;
-
-    let elapsed_ms = int_of_float ((Time_compat.now () -. start_time) *. 1000.0) in
-    let exit_code = match status with
-      | Unix.WEXITED code -> code
-      | Unix.WSIGNALED _ -> -1
-      | Unix.WSTOPPED _ -> -2
+      | None -> (
+          match config.working_dir with
+          | Some dir -> Sys.chdir dir
+          | None -> ())
     in
 
-    (* Extract token usage for Claude (JSON output) *)
-    let (output, input_tokens, output_tokens, cache_creation, cache_read, cost_usd) =
-      if agent_name = "claude" then
-        let (result_opt, inp, out, cache_c, cache_r, cost) = parse_claude_json raw_output in
-        (Option.value result_opt ~default:raw_output, inp, out, cache_c, cache_r, cost)
-      else if agent_name = "gemini" then
-        let inp, out, cached, cost = parse_gemini_output raw_output in
-        let result_text = Option.value (extract_gemini_response_text raw_output) ~default:raw_output in
-        (result_text, inp, out, None, cached, cost)
-      else
-        (raw_output, None, None, None, None, None)
+    try
+      (* Create pipes for stdin and stdout *)
+      let (stdout_read, stdout_write) = Unix.pipe () in
+      let (stdin_read, stdin_write) = Unix.pipe () in
+
+      (* Spawn process directly without shell *)
+      let pid =
+        Unix.create_process (Array.get cmd_array 0) cmd_array stdin_read
+          stdout_write Unix.stderr
+      in
+
+      (* Close unused ends *)
+      Unix.close stdout_write;
+      Unix.close stdin_read;
+
+      (* Gemini CLI expects prompt via -p; other CLIs still read stdin. *)
+      let stdin_content = if agent_name = "gemini" then "" else augmented_prompt in
+      let _ =
+        Unix.write_substring stdin_write stdin_content 0
+          (String.length stdin_content)
+      in
+      Unix.close stdin_write;
+
+      (* Read output *)
+      let ic = Unix.in_channel_of_descr stdout_read in
+      let raw_output = In_channel.input_all ic in
+      In_channel.close ic;
+
+      (* Wait for process *)
+      let (_, status) = Unix.waitpid [] pid in
+
+      (* Restore directory *)
+      Sys.chdir original_dir;
+
+      let elapsed_ms =
+        int_of_float ((Time_compat.now () -. start_time) *. 1000.0)
+      in
+      let exit_code =
+        match status with
+        | Unix.WEXITED code -> code
+        | Unix.WSIGNALED _ -> -1
+        | Unix.WSTOPPED _ -> -2
+      in
+
+      (* Extract token usage for Claude (JSON output) *)
+      let (output, input_tokens, output_tokens, cache_creation, cache_read, cost_usd)
+          =
+        if agent_name = "claude" then
+          let (result_opt, inp, out, cache_c, cache_r, cost) =
+            parse_claude_json raw_output
+          in
+          ( Option.value result_opt ~default:raw_output,
+            inp,
+            out,
+            cache_c,
+            cache_r,
+            cost )
+        else if agent_name = "gemini" then
+          let inp, out, cached, cost = parse_gemini_output raw_output in
+          let result_text =
+            Option.value (extract_gemini_response_text raw_output)
+              ~default:raw_output
+          in
+          (result_text, inp, out, None, cached, cost)
+        else
+          (raw_output, None, None, None, None, None)
     in
 
     {
@@ -458,7 +489,7 @@ let spawn ~agent_name ~prompt ?timeout_seconds ?working_dir () =
       cache_creation_tokens = None;
       cache_read_tokens = None;
       cost_usd = None;
-    }
+    })
 
 (** Spawn and wait for result (synchronous) *)
 let spawn_sync = spawn

--- a/test/test_spawn_coverage.ml
+++ b/test/test_spawn_coverage.ml
@@ -328,6 +328,20 @@ let test_spawn_bare_ollama_rejected () =
        true
      with Not_found -> false)
 
+let test_spawn_empty_command_rejected () =
+  let result = Spawn.spawn ~agent_name:"   " ~prompt:"test" () in
+  check bool "spawn rejected" false result.Spawn.success;
+  check int "exit code" 2 result.Spawn.exit_code;
+  check bool "mentions empty command" true
+    (try
+       let _ =
+         Str.search_forward
+           (Str.regexp_string "spawn command is empty")
+           result.Spawn.output 0
+       in
+       true
+     with Not_found -> false)
+
 (* ============================================================
    build_mcp_args Tests
    ============================================================ *)
@@ -754,6 +768,7 @@ let () =
       test_case "ollama removed" `Quick test_get_config_ollama_removed;
       test_case "unknown" `Quick test_get_config_unknown;
       test_case "bare ollama rejected" `Quick test_spawn_bare_ollama_rejected;
+      test_case "empty command rejected" `Quick test_spawn_empty_command_rejected;
     ];
     "build_mcp_args", [
       test_case "empty" `Quick test_build_mcp_args_empty;


### PR DESCRIPTION
## Summary
- reject empty spawn commands before process creation instead of crashing on List.hd
- make MCP session base62 encoding linear and avoid repeated List.nth traversal
- remove unsafe Neo4j specialty parsing in lodge_heartbeat by pattern matching the row shape

## Validation
- DUNE_BUILD_DIR=_build_unsafe_guard dune build --root . test/test_spawn_coverage.exe test/test_mcp_session_coverage.exe test/test_lodge_graphql_failure_coverage.exe
- ./_build_unsafe_guard/default/test/test_spawn_coverage.exe
- ./_build_unsafe_guard/default/test/test_mcp_session_coverage.exe
- ./_build_unsafe_guard/default/test/test_lodge_graphql_failure_coverage.exe