### PR TITLE
refactor(dashboard): prune low-value core surfaces

### DIFF
--- a/dashboard/src/components/agent-detail.ts
+++ b/dashboard/src/components/agent-detail.ts
@@ -7,19 +7,9 @@ import { StatusBadge } from './common/status-badge'
 import { TimeAgo } from './common/time-ago'
 import { showToast } from './common/toast'
 import {
-  allowlistEmptyState,
-  auditMetadataState,
-  linkedRecentToolsEmptyState,
-  observedToolsEmptyState,
-  openToolsInventory,
-  toolAuditStateLabel,
-} from './common/tool-audit'
-import {
   agents,
   executionContinuityBriefs,
-  executionLodgeCheckins,
   keepers,
-  serverStatus,
   tasks,
 } from '../store'
 import { fetchRoomMessages, fetchTaskHistory, sendBroadcast } from '../api'
@@ -27,7 +17,6 @@ import { missionSnapshot } from '../mission-store'
 import type {
   Agent,
   DashboardExecutionContinuityBrief,
-  DashboardExecutionLodgeCheckin,
   DashboardMissionAgentBrief,
   Keeper,
   Task,
@@ -84,39 +73,10 @@ function missionAgentBrief(agentName: string | null): DashboardMissionAgentBrief
   return mission.agent_briefs.find(brief => brief.agent_name === agentName) ?? null
 }
 
-function windowTopTools(keeper: Keeper | null): string[] {
-  if (!keeper) return []
-  const metrics = keeper.metrics_window
-  const topTools = Array.isArray(metrics?.top_tools) ? metrics.top_tools : []
-  return topTools
-    .map(item => (typeof item === 'object' && item !== null && 'tool' in item && typeof item.tool === 'string' ? item.tool : null))
-    .filter((item): item is string => item !== null)
-}
-
-function recentToolsForAgent(agentName: string | null): string[] {
-  const keeper = keeperForAgent(agentName)
-  if (!keeper) return []
-  return keeper.recent_tool_names && keeper.recent_tool_names.length > 0 ? keeper.recent_tool_names : []
-}
-
-function firstNonEmptyToolList(...candidates: Array<string[] | null | undefined>): string[] {
-  for (const candidate of candidates) {
-    if (candidate && candidate.length > 0) return candidate
-  }
-  return []
-}
-
 function continuityBriefForAgent(agentName: string | null): DashboardExecutionContinuityBrief | null {
   if (!agentName) return null
   return executionContinuityBriefs.value.find(
     brief => brief.agent_name === agentName || brief.name === agentName,
-  ) ?? null
-}
-
-function latestLodgeCheckinForAgent(agentName: string | null): DashboardExecutionLodgeCheckin | null {
-  if (!agentName) return null
-  return executionLodgeCheckins.value.find(
-    row => row.agent_name === agentName || row.worker_name === agentName,
   ) ?? null
 }
 
@@ -199,6 +159,12 @@ function TaskHistoryPanel({ row }: { row: TaskHistoryRow }) {
   `
 }
 
+function compactCopy(value: string | null | undefined, max = 160): string | null {
+  const text = (value ?? '').replace(/\s+/g, ' ').trim()
+  if (!text) return null
+  return text.length > max ? `${text.slice(0, max - 1)}…` : text
+}
+
 export function AgentDetailOverlay() {
   const agentName = selectedAgentName.value
   if (!agentName) return null
@@ -206,50 +172,23 @@ export function AgentDetailOverlay() {
   const agent = selectedAgent()
   const keeper = keeperForAgent(agentName)
   const continuityBrief = continuityBriefForAgent(agentName)
-  const lodgeCheckin = latestLodgeCheckinForAgent(agentName)
   const missionBrief = missionAgentBrief(agentName)
   const ownedTasks = assignedTasks(agentName)
   const lines = roomActivity.value
-  const recentTools = recentToolsForAgent(agentName)
-  const topTools = windowTopTools(keeper)
-  const allowedTools =
-    firstNonEmptyToolList(
-      continuityBrief?.allowed_tool_names,
-      missionBrief?.allowed_tool_names,
-      lodgeCheckin?.allowed_tool_names,
-      keeper?.allowed_tool_names,
-    )
-  const observedTools =
-    firstNonEmptyToolList(
-      continuityBrief?.latest_tool_names,
-      missionBrief?.latest_tool_names,
-      lodgeCheckin?.used_tool_names,
-      keeper?.latest_tool_names,
-    )
-  const toolCallCount =
-    continuityBrief?.latest_tool_call_count
-    ?? missionBrief?.latest_tool_call_count
-    ?? lodgeCheckin?.used_tool_call_count
-    ?? keeper?.latest_tool_call_count
-  const auditSource =
-    continuityBrief?.tool_audit_source
-    ?? missionBrief?.tool_audit_source
-    ?? lodgeCheckin?.tool_audit_source
-    ?? keeper?.tool_audit_source
-  const auditAt =
-    continuityBrief?.tool_audit_at
-    ?? missionBrief?.tool_audit_at
-    ?? lodgeCheckin?.tool_audit_at
-    ?? keeper?.tool_audit_at
-  const capabilities = agent?.capabilities ?? []
-  const room = serverStatus.value?.room ?? 'default'
-  const project = serverStatus.value?.project ?? '확인 없음'
-  const cluster = serverStatus.value?.cluster ?? '확인 없음'
-  const allowlistFallback = toolAuditStateLabel(allowlistEmptyState(keeper))
-  const observedFallback = toolAuditStateLabel(observedToolsEmptyState(keeper, auditSource))
-  const metadataFallback = toolAuditStateLabel(auditMetadataState(keeper, auditSource))
-  const linkedRecentFallback = toolAuditStateLabel(linkedRecentToolsEmptyState(keeper))
-  const openToolsQuery = allowedTools[0] ?? observedTools[0] ?? recentTools[0] ?? null
+  const displayName = missionBrief?.display_name ?? keeper?.name ?? agentName
+  const secondaryLabel = displayName !== agentName ? agentName : null
+  const headerStatus = agent?.status ?? missionBrief?.status ?? 'unknown'
+  const isArchivedParticipant = !agent && missionBrief?.is_live === false
+  const lastSeenAt =
+    agent?.last_seen
+    ?? missionBrief?.last_activity_at
+    ?? null
+  const agentEmoji = agent?.emoji ?? keeper?.emoji
+  const koreanName = agent?.koreanName ?? keeper?.koreanName
+  const continuitySummary =
+    compactCopy(continuityBrief?.continuity_summary)
+    ?? compactCopy(continuityBrief?.skill_route_summary)
+    ?? null
 
   return html`
     <div
@@ -263,58 +202,38 @@ export function AgentDetailOverlay() {
         <div class="agent-detail-header">
           <div style="display:flex;flex-direction:column;gap:8px;flex:1">
             <div style="display:flex;align-items:center;gap:12px">
-              ${agent?.emoji ? html`<span style="font-size:2rem">${agent.emoji}</span>` : ''}
+              ${agentEmoji ? html`<span style="font-size:2rem">${agentEmoji}</span>` : ''}
               <div>
                 <h2 style="margin:0;display:flex;align-items:baseline;gap:8px">
-                  ${agentName}
-                  ${agent?.koreanName ? html`<span style="font-size:0.75em;color:#888">(${agent.koreanName})</span>` : ''}
+                  ${displayName}
+                  ${koreanName ? html`<span style="font-size:0.75em;color:#888">(${koreanName})</span>` : ''}
+                  ${secondaryLabel ? html`<span class="mono" style="font-size:0.75em;color:#888">${secondaryLabel}</span>` : ''}
                 </h2>
                 <div style="display:flex;align-items:center;gap:8px;margin-top:4px;flex-wrap:wrap">
-                  ${agent
-                    ? html`
-                        <${StatusBadge} status=${agent.status} />
-                        ${agent.model ? html`<span class="mono" style="font-size:0.75rem;background:#2a2a4a;padding:2px 6px;border-radius:4px">${agent.model}</span>` : ''}
-                        ${agent.primaryValue ? html`<span style="font-size:0.75rem;color:#a78bfa">${agent.primaryValue}</span>` : ''}
-                      `
-                    : html`<span>Agent snapshot not found in current state</span>`}
+                  <${StatusBadge} status=${headerStatus} />
+                  ${isArchivedParticipant ? html`<span class="pill">archived session participant</span>` : null}
+                  ${agent?.model ? html`<span class="mono" style="font-size:0.75rem;background:#2a2a4a;padding:2px 6px;border-radius:4px">${agent.model}</span>` : ''}
+                  ${!agent && missionBrief?.archived_reason
+                    ? html`<span style="font-size:0.75rem;color:#888">${missionBrief.archived_reason}</span>`
+                    : null}
                 </div>
               </div>
             </div>
-            ${agent?.activityLevel != null ? html`
-              <div style="display:flex;align-items:center;gap:8px;font-size:0.8rem">
-                <span style="color:#888">Activity</span>
-                <div style="flex:1;max-width:120px;height:6px;background:#1a1a2e;border-radius:3px;overflow:hidden">
-                  <div style="width:${Math.min(agent.activityLevel * 10, 100)}%;height:100%;background:${agent.activityLevel >= 8 ? '#22c55e' : agent.activityLevel >= 5 ? '#f59e0b' : '#666'};border-radius:3px"></div>
-                </div>
-                <span style="color:#888">${agent.activityLevel}/10</span>
-              </div>
-            ` : ''}
-            ${(agent?.traits?.length ?? 0) > 0 ? html`
-              <div style="display:flex;flex-wrap:wrap;gap:4px">
-                ${agent?.traits?.map((t: string) => html`<span style="font-size:0.7rem;background:#1e3a5f;color:#60a5fa;padding:2px 8px;border-radius:10px">${t}</span>`)}
-              </div>
-            ` : ''}
-            ${(agent?.interests?.length ?? 0) > 0 ? html`
-              <div style="display:flex;flex-wrap:wrap;gap:4px">
-                ${agent?.interests?.map((t: string) => html`<span style="font-size:0.7rem;background:#3b1f4e;color:#c084fc;padding:2px 8px;border-radius:10px">${t}</span>`)}
-              </div>
-            ` : ''}
-            ${capabilities.length > 0 ? html`
-              <div style="display:flex;flex-wrap:wrap;gap:4px">
-                ${capabilities.map((capability: string) => html`<span style="font-size:0.7rem;background:#183153;color:#7dd3fc;padding:2px 8px;border-radius:10px">${capability}</span>`)}
-              </div>
-            ` : ''}
             <div class="agent-detail-sub">
-              ${agent
-                ? html`
-                    ${agent.current_task ? html`<span>Task: ${agent.current_task}</span>` : null}
-                    ${agent.last_seen ? html`<span>Last seen: <${TimeAgo} timestamp=${agent.last_seen} /></span>` : null}
-                    <span>Room: ${room}</span>
-                    <span>Project: ${project}</span>
-                    <span>Cluster: ${cluster}</span>
-                  `
+              ${agent?.current_task || missionBrief?.current_work
+                ? html`<span>Task: ${agent?.current_task ?? missionBrief?.current_work}</span>`
                 : null}
+              ${lastSeenAt ? html`<span>Last seen: <${TimeAgo} timestamp=${lastSeenAt} /></span>` : null}
             </div>
+            ${keeper || continuitySummary || missionBrief?.related_session_id
+              ? html`
+                  <div class="agent-detail-sub">
+                    ${keeper ? html`<span>Linked keeper: ${keeper.name}</span>` : null}
+                    ${missionBrief?.related_session_id ? html`<span>Session: ${missionBrief.related_session_id}</span>` : null}
+                    ${continuitySummary ? html`<span>${continuitySummary}</span>` : null}
+                  </div>
+                `
+              : null}
           </div>
           <div class="agent-detail-actions">
             <button class="control-btn ghost" onClick=${() => { void refreshAgentDetail() }} disabled=${loading.value}>
@@ -339,106 +258,6 @@ export function AgentDetailOverlay() {
               : html`<div class="agent-activity-list">${lines.map((line, idx) => html`<div key=${idx} class="agent-activity-line">${line}</div>`)}</div>`}
           <//>
         </div>
-
-        <${Card} title="Capabilities & Tool Audit">
-          <div style="display:flex; flex-direction:column; gap:12px;">
-            <div>
-              <div style="font-size:12px; color:#888; margin-bottom:6px;">Capabilities</div>
-              <div style="display:flex; flex-wrap:wrap; gap:6px;">
-                ${capabilities.length > 0
-                  ? capabilities.map((capability: string) => html`<span class="pill">${capability}</span>`)
-                  : html`<span class="empty-state" style="font-size:12px;">No capability metadata</span>`}
-              </div>
-            </div>
-            <div style="display:flex; justify-content:flex-end;">
-              <button class="control-btn ghost" onClick=${() => { openToolsInventory(openToolsQuery) }}>
-                Open tools panel
-              </button>
-            </div>
-            <div>
-              <div style="font-size:12px; color:#888; margin-bottom:6px;">Allowed tools</div>
-              <div style="font-size:11px; color:#64748b; margin-bottom:6px;">Currently permitted tools for this runtime, not the full system inventory.</div>
-              <div style="display:flex; flex-wrap:wrap; gap:6px;">
-                ${allowedTools.length > 0
-                  ? allowedTools.map((tool: string) => html`<span class="pill">${tool}</span>`)
-                  : html`<span class="empty-state" style="font-size:12px;">${allowlistFallback}</span>`}
-              </div>
-            </div>
-            <div>
-              <div style="font-size:12px; color:#888; margin-bottom:6px;">Observed tools</div>
-              <div style="font-size:11px; color:#64748b; margin-bottom:6px;">Recent execution evidence, not policy allowlist.</div>
-              <div style="display:flex; flex-wrap:wrap; gap:6px;">
-                ${observedTools.length > 0
-                  ? observedTools.map((tool: string) => html`<span class="pill">${tool}</span>`)
-                  : html`<span class="empty-state" style="font-size:12px;">${observedFallback}</span>`}
-              </div>
-            </div>
-            <div class="agent-detail-sub">
-              <span>Tool calls: ${typeof toolCallCount === 'number' ? toolCallCount : observedFallback === 'none_recent' ? 0 : metadataFallback}</span>
-              <span>Evidence source: ${auditSource ?? metadataFallback}</span>
-              <span>
-                Observed at:
-                ${auditAt ? html` <${TimeAgo} timestamp=${auditAt} />` : ` ${metadataFallback}`}
-              </span>
-            </div>
-            <div>
-              <div style="font-size:12px; color:#888; margin-bottom:6px;">Linked keeper recent tools</div>
-              <div style="display:flex; flex-wrap:wrap; gap:6px;">
-                ${recentTools.length > 0
-                  ? recentTools.map((tool: string) => html`<span class="pill">${tool}</span>`)
-                  : html`<span class="empty-state" style="font-size:12px;">${linkedRecentFallback}</span>`}
-              </div>
-            </div>
-            ${topTools.length > 0
-              ? html`
-                  <div>
-                    <div style="font-size:12px; color:#888; margin-bottom:6px;">Keeper window top tools</div>
-                    <div style="display:flex; flex-wrap:wrap; gap:6px;">
-                      ${topTools.map((tool: string) => html`<span class="pill">${tool}</span>`)}
-                    </div>
-                  </div>
-                `
-              : null}
-            ${keeper
-              ? html`
-                  <div style="font-size:12px; color:#888;">
-                    Linked keeper: <span style="color:#4ade80;">${keeper.name}</span>
-                    ${keeper.skill_primary ? html` · route <span style="color:#22d3ee;">${keeper.skill_primary}</span>` : null}
-                  </div>
-                `
-              : null}
-            ${continuityBrief?.continuity_summary || continuityBrief?.skill_route_summary
-              ? html`
-                  <div class="agent-detail-sub">
-                    ${continuityBrief?.continuity_summary ? html`<span>${continuityBrief.continuity_summary}</span>` : null}
-                    ${continuityBrief?.skill_route_summary ? html`<span>Route: ${continuityBrief.skill_route_summary}</span>` : null}
-                  </div>
-                `
-              : null}
-          </div>
-        <//>
-
-        ${lodgeCheckin
-          ? html`
-              <${Card} title="Latest Lodge Check-in">
-                <div class="agent-detail-sub">
-                  <span>Outcome: ${lodgeCheckin.outcome}</span>
-                  <span>Trigger: ${lodgeCheckin.trigger ?? 'unknown'}</span>
-                  <span>Action: ${lodgeCheckin.action_kind ?? 'none'}</span>
-                  ${lodgeCheckin.checked_at ? html`<span>Checked: <${TimeAgo} timestamp=${lodgeCheckin.checked_at} /></span>` : null}
-                </div>
-                ${lodgeCheckin.reason ? html`<div class="monitor-footnote">${lodgeCheckin.reason}</div>` : null}
-                ${lodgeCheckin.summary && lodgeCheckin.summary !== lodgeCheckin.reason
-                  ? html`<div class="monitor-footnote">${lodgeCheckin.summary}</div>`
-                  : null}
-                ${lodgeCheckin.failure_reason
-                  ? html`<div class="monitor-footnote">Failure: ${lodgeCheckin.failure_reason}</div>`
-                  : lodgeCheckin.decision_reason
-                    ? html`<div class="monitor-footnote">Decision: ${lodgeCheckin.decision_reason}</div>`
-                    : null}
-              <//>
-            `
-          : null}
 
         <${Card} title="Task History">
           ${taskHistories.value.length === 0

--- a/dashboard/src/components/agents.ts
+++ b/dashboard/src/components/agents.ts
@@ -12,7 +12,6 @@ import { openKeeperDetail } from './keeper-detail'
 import { openAgentDetail } from './agent-detail'
 import { navigate } from '../router'
 import {
-  executionSummary,
   executionQueue,
   executionSessionBriefs,
   executionOperationBriefs,
@@ -138,13 +137,6 @@ function lodgeActionKindLabel(value?: DashboardExecutionLodgeCheckin['action_kin
     default:
       return value
   }
-}
-
-function renderToolSummary(tools: string[] | undefined, empty = '없음') {
-  const rows = tools ?? []
-  if (rows.length === 0) return empty
-  if (rows.length <= 3) return rows.join(', ')
-  return `${rows.slice(0, 3).join(', ')} +${rows.length - 3}`
 }
 
 function openHandoff(handoff: DashboardExecutionHandoff | null | undefined): void {
@@ -361,15 +353,10 @@ function LodgeCheckinRow({ row }: { row: DashboardExecutionLodgeCheckin }) {
         <span>trigger · ${row.trigger ?? 'unknown'}</span>
         ${row.checked_at ? html`<span><${TimeAgo} timestamp=${row.checked_at} /></span>` : null}
         <span>action · ${lodgeActionKindLabel(row.action_kind)}</span>
-        <span>allow ${row.allowed_tool_names.length}</span>
-        <span>used ${row.used_tool_names.length}</span>
       </div>
       ${row.summary && row.summary !== row.reason
         ? html`<div class="monitor-focus">${row.summary}</div>`
         : null}
-      <div class="monitor-footnote">
-        허용 도구: ${renderToolSummary(row.allowed_tool_names)} · 사용 도구: ${renderToolSummary(row.used_tool_names)}
-      </div>
       ${row.failure_reason || row.decision_reason
         ? html`<div class="monitor-footnote">
             ${row.failure_reason ? `실패 이유: ${row.failure_reason}` : `판단 이유: ${row.decision_reason}`}
@@ -450,24 +437,11 @@ function ContinuityRow({ row }: { row: DashboardExecutionContinuityBrief }) {
       ${row.recent_output_preview || row.continuity_summary
         ? html`<div class="monitor-footnote">${row.recent_output_preview ?? row.continuity_summary}</div>`
         : null}
-      ${row.skill_route_summary || row.tool_audit_source
-        ? html`<div class="monitor-footnote">
-            ${row.skill_route_summary ? `route · ${row.skill_route_summary}` : ''}
-            ${row.tool_audit_source ? `${row.skill_route_summary ? ' · ' : ''}audit · ${row.tool_audit_source}` : ''}
-            ${row.tool_audit_at ? html` · <${TimeAgo} timestamp=${row.tool_audit_at} />` : null}
-          </div>`
-        : null}
-      ${(row.recent_tool_names?.length ?? 0) > 0 || (row.allowed_tool_names?.length ?? 0) > 0
-        ? html`<div class="monitor-footnote">
-            recent tools: ${renderToolSummary(row.recent_tool_names)} · allowed: ${renderToolSummary(row.allowed_tool_names)}
-          </div>`
-        : null}
     </button>
   `
 }
 
 export function Execution() {
-  const summary = executionSummary.value
   const queueRows = executionQueue.value
   const sessionRowsAll = executionSessionBriefs.value
   const operationRowsAll = executionOperationBriefs.value
@@ -549,15 +523,6 @@ export function Execution() {
     <div class="agents-monitor">
       <${SurfaceSemanticIntro} surfaceId="execution" />
       <${RoomTruthStrip} />
-      <div class="stats-grid">
-        <${MonitorStat} label="활성 세션" value=${summary?.active_sessions ?? sessionRowsAll.length} color="#4ade80" caption="실행 관점 세션 수" />
-        <${MonitorStat} label="막힌 세션" value=${summary?.blocked_sessions ?? sessionRowsAll.filter(item => toneClass(item.health ?? item.status) !== 'ok').length} color="#fbbf24" caption="개입이 필요한 세션 수" />
-        <${MonitorStat} label="활성 작전" value=${summary?.active_operations ?? operationRowsAll.length} color="#22d3ee" caption="지휘 평면 작전 수" />
-        <${MonitorStat} label="막힌 작전" value=${summary?.blocked_operations ?? operationRowsAll.filter(item => item.blocker_summary).length} color="#fb7185" caption="원인 확인이 필요한 작전 수" />
-        <${MonitorStat} label="인력 경고" value=${summary?.worker_alerts ?? workerSupportAll.filter(item => item.tone !== 'ok').length} color="#fb7185" caption="지원 인력 압박" />
-        <${MonitorStat} label="연속성 경고" value=${summary?.continuity_alerts ?? continuityAll.filter(item => item.tone !== 'ok').length} color="#fb7185" caption="키퍼 연속성 압박" />
-      </div>
-
       <${Card}
         title="실행 대기열"
         class="section"

--- a/dashboard/src/components/keeper-detail.ts
+++ b/dashboard/src/components/keeper-detail.ts
@@ -1,17 +1,13 @@
-// Keeper detail overlay — full keeper info with KPIs, field dictionary,
-// memory, conversations, equipment, relationships, handoff timeline
-// CSS classes: .keeper-kpis, .keeper-field-dict, .keeper-memory-list, etc. (components.css)
+// Keeper detail overlay — focused keeper profile, continuity, and direct comms.
 
 import { html } from 'htm/preact'
 import { signal } from '@preact/signals'
-import { runOperatorAction } from '../api'
+import { currentDashboardActor, runOperatorAction } from '../api'
 import { Card } from './common/card'
 import { StatusBadge } from './common/status-badge'
 import { TimeAgo } from './common/time-ago'
-import { missionSnapshot } from '../mission-store'
-import type { DashboardMissionKeeperBrief, Keeper, KeeperMetricPoint, TrpgCharacterStats, AutonomyLevel } from '../types'
-import { invalidateDashboardCache, refreshDashboard, serverStatus } from '../store'
-import { operatorSnapshot } from '../operator-store'
+import type { Keeper, KeeperMetricPoint, TrpgCharacterStats } from '../types'
+import { invalidateDashboardCache, refreshDashboard } from '../store'
 import { normalizeLodgeTickResult, selectKeeper } from '../keeper-runtime'
 import {
   KeeperConversationPanel,
@@ -19,17 +15,6 @@ import {
   KeeperRuntimeActions,
 } from './keeper-shared'
 import { showToast } from './common/toast'
-import {
-  allowlistEmptyState,
-  auditMetadataState,
-  linkedRecentToolsEmptyState,
-  linkedRuntimeState,
-  observedToolsEmptyState,
-  openToolsInventory,
-  toolAuditStateLabel,
-} from './common/tool-audit'
-
-// ── Global overlay state ──────────────────────────────────
 
 export const selectedKeeper = signal<Keeper | null>(null)
 
@@ -42,186 +27,17 @@ export function closeKeeperDetail() {
   selectedKeeper.value = null
 }
 
-// ── Autonomy helpers ─────────────────────────────────────
-
-const AUTONOMY_LEVELS: { level: AutonomyLevel; label: string; color: string }[] = [
-  { level: 'L1_Reactive', label: 'L1 Reactive', color: '#6b7280' },
-  { level: 'L2_Suggestive', label: 'L2 Suggestive', color: '#3b82f6' },
-  { level: 'L3_Guided', label: 'L3 Guided', color: '#f59e0b' },
-  { level: 'L4_Autonomous', label: 'L4 Autonomous', color: '#f97316' },
-  { level: 'L5_Independent', label: 'L5 Independent', color: '#ef4444' },
-]
-
-function autonomyIndex(level: AutonomyLevel | undefined): number {
-  if (!level) return 0
-  const idx = AUTONOMY_LEVELS.findIndex(a => a.level === level)
-  return idx >= 0 ? idx : 0
-}
-
-function AutonomyMeter({ keeper }: { keeper: Keeper }) {
-  const idx = autonomyIndex(keeper.autonomy_level)
-  const info = AUTONOMY_LEVELS[idx] ?? AUTONOMY_LEVELS[0]
-  if (!info) return null
-  const pct = ((idx + 1) / AUTONOMY_LEVELS.length) * 100
-
-  return html`
-    <div class="keeper-signal-list">
-      <div style="margin-bottom:8px;">
-        <div style="display:flex; justify-content:space-between; align-items:center; margin-bottom:4px;">
-          <span style="font-size:13px; font-weight:600; color:${info.color};">${info.label}</span>
-          <span style="font-size:11px; color:#888;">${idx + 1} / ${AUTONOMY_LEVELS.length}</span>
-        </div>
-        <div style="width:100%; height:6px; background:#1a1a2e; border-radius:3px; overflow:hidden;">
-          <div style="width:${pct}%; height:100%; background:${info.color}; border-radius:3px; transition:width 0.3s;"></div>
-        </div>
-        <div style="display:flex; justify-content:space-between; margin-top:2px;">
-          ${AUTONOMY_LEVELS.map((a, i) => html`
-            <span style="width:8px; height:8px; border-radius:50%; background:${i <= idx ? a.color : '#333'}; display:inline-block;"></span>
-          `)}
-        </div>
-      </div>
-      <div class="keeper-signal-row">
-        <span>Autonomous actions</span>
-        <strong>${keeper.autonomous_action_count ?? 0}</strong>
-      </div>
-      ${keeper.last_autonomous_action_at
-        ? html`<div class="keeper-signal-row">
-            <span>Last autonomous action</span>
-            <strong><${TimeAgo} timestamp=${keeper.last_autonomous_action_at} /></strong>
-          </div>`
-        : null}
-      ${keeper.active_goal_ids && keeper.active_goal_ids.length > 0
-        ? html`<div class="keeper-signal-row">
-            <span>Active goals</span>
-            <strong>${keeper.active_goal_ids.length}</strong>
-          </div>`
-        : null}
-    </div>
-  `
-}
-
-// ── Sub-components ────────────────────────────────────────
-
-function formatTokens(n: number | undefined): string {
-  if (!n) return '—'
-  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`
-  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}K`
-  return String(n)
-}
-
-function actionDescriptorLabel(actionType?: string): string {
-  switch (actionType) {
-    case 'keeper_message':
-      return 'message'
-    case 'keeper_probe':
-      return 'probe'
-    case 'keeper_recover':
-      return 'recover'
-    case 'broadcast':
-      return 'broadcast'
-    case 'room_pause':
-      return 'pause'
-    case 'room_resume':
-      return 'resume'
-    case 'lodge_tick':
-      return 'lodge'
-    default:
-      return actionType?.trim() || 'action'
-  }
-}
-
-function keeperRecentTools(keeper: Keeper): string[] {
-  if (keeper.recent_tool_names && keeper.recent_tool_names.length > 0) {
-    return keeper.recent_tool_names
-  }
-  return []
-}
-
-function keeperTopTools(keeper: Keeper): string[] {
-  const metrics = keeper.metrics_window
-  const topTools = Array.isArray(metrics?.top_tools) ? metrics.top_tools : []
-  return topTools
-    .map(item => (typeof item === 'object' && item !== null && 'tool' in item && typeof item.tool === 'string' ? item.tool : null))
-    .filter((item): item is string => item !== null)
-}
-
-function missionKeeperBrief(keeper: Keeper): DashboardMissionKeeperBrief | null {
-  const mission = missionSnapshot.value
-  if (!mission) return null
-  return mission.keeper_briefs.find(brief =>
-    brief.name === keeper.name
-      || (brief.agent_name && keeper.agent_name && brief.agent_name === keeper.agent_name))
-    ?? null
-}
-
-function KpiGrid({ keeper }: { keeper: Keeper }) {
-  const series = keeper.metrics_series ?? []
-  const lastPt = series[series.length - 1] as KeeperMetricPoint | undefined
-  const latestCost =
-    lastPt && Number.isFinite(lastPt.cost_usd)
-      ? `$${lastPt.cost_usd.toFixed(4)}`
-      : null
-
-  const items: { label: string; value: string | number; hint?: string }[] = [
-    {
-      label: 'Generation',
-      value: keeper.generation ?? '-',
-      hint: 'Succession count',
-    },
-    {
-      label: 'Turns',
-      value: keeper.turn_count ?? '-',
-      hint: 'Total loop turns',
-    },
-    {
-      label: 'Context',
-      value: keeper.context_ratio != null ? `${Math.round(keeper.context_ratio * 100)}%` : '-',
-      hint: keeper.context_ratio != null && keeper.context_ratio > 0.8 ? 'Near limit' : undefined,
-    },
-    {
-      label: 'Activity',
-      value: keeper.activityLevel ?? '-',
-      hint: 'Level 0–5',
-    },
-  ]
-
-  return html`
-    <div class="keeper-kpis">
-      ${items.map(i => html`
-        <div class="keeper-kpi">
-          <div class="keeper-kpi-label">${i.label}</div>
-          <div class="keeper-kpi-value">${i.value}</div>
-          ${i.hint ? html`<div class="keeper-kpi-hint">${i.hint}</div>` : null}
-        </div>
-      `)}
-      <div class="kpi-tile">
-        <div class="kpi-value">${formatTokens(keeper.context_tokens)}</div>
-        <div class="kpi-label">Tokens</div>
-      </div>
-      <div class="kpi-tile">
-        <div class="kpi-value">${keeper.handoff_count_total ?? '—'}</div>
-        <div class="kpi-label">Handoffs</div>
-      </div>
-      <div class="kpi-tile">
-        <div class="kpi-value">${keeper.compaction_count ?? '—'}</div>
-        <div class="kpi-label">Compactions</div>
-      </div>
-      ${latestCost
-        ? html`
-            <div class="kpi-tile">
-              <div class="kpi-value">${latestCost}</div>
-              <div class="kpi-label">Cost (USD)</div>
-            </div>
-          `
-        : null}
-    </div>
-  `
+function contextPressureLabel(value?: number | null): string {
+  if (typeof value !== 'number' || Number.isNaN(value)) return '확인 필요'
+  if (value >= 0.85) return '높음'
+  if (value >= 0.7) return '상승 중'
+  return '안정'
 }
 
 function ContextChart({ keeper }: { keeper: Keeper }) {
   const series = keeper.metrics_series ?? []
   if (series.length < 2) {
-    const pct = ((keeper.context?.context_ratio ?? 0) * 100)
+    const pct = ((keeper.context?.context_ratio ?? keeper.context_ratio ?? 0) * 100)
     const color = pct > 85 ? '#ef4444' : pct > 70 ? '#f59e0b' : '#22c55e'
     return html`
       <div class="context-chart">
@@ -232,7 +48,9 @@ function ContextChart({ keeper }: { keeper: Keeper }) {
       </div>`
   }
 
-  const W = 200, H = 60, pad = 2
+  const W = 200
+  const H = 60
+  const pad = 2
   const n = series.length
   const pts = series.map((p: KeeperMetricPoint, i: number) => {
     const x = pad + (i / (n - 1)) * (W - 2 * pad)
@@ -246,84 +64,15 @@ function ContextChart({ keeper }: { keeper: Keeper }) {
   return html`
     <div class="context-chart" style="display:flex;align-items:center;gap:8px">
       <svg viewBox="0 0 ${W} ${H}" width="${W}" height="${H}" style="background:#1a1a2e;border-radius:4px">
-        <line x1="${pad}" y1="${(H - pad - 0.5 * (H - 2 * pad)).toFixed(1)}" x2="${W - pad}" y2="${(H - pad - 0.5 * (H - 2 * pad)).toFixed(1)}" stroke="#666" stroke-dasharray="3,3" stroke-width="0.5"/>
         <line x1="${pad}" y1="${(H - pad - 0.7 * (H - 2 * pad)).toFixed(1)}" x2="${W - pad}" y2="${(H - pad - 0.7 * (H - 2 * pad)).toFixed(1)}" stroke="#666" stroke-dasharray="3,3" stroke-width="0.5"/>
         <line x1="${pad}" y1="${(H - pad - 0.85 * (H - 2 * pad)).toFixed(1)}" x2="${W - pad}" y2="${(H - pad - 0.85 * (H - 2 * pad)).toFixed(1)}" stroke="#f59e0b" stroke-dasharray="3,3" stroke-width="0.5"/>
         ${pts.filter(({ p }) => p.is_handoff).map(({ x }) => html`
           <line x1="${x.toFixed(1)}" y1="${pad}" x2="${x.toFixed(1)}" y2="${H - pad}" stroke="#ef4444" stroke-width="1.5" opacity="0.7"/>
         `)}
         <polyline points="${polyline}" fill="none" stroke="${lineColor}" stroke-width="1.5"/>
-        ${pts.filter(({ p }) => p.is_compaction).map(({ x, y }) => html`
-          <circle cx="${x.toFixed(1)}" cy="${y.toFixed(1)}" r="2.5" fill="#a855f7"/>
-        `)}
       </svg>
       <span class="chart-pct">${lastRatio.toFixed(1)}%</span>
     </div>`
-}
-
-// Searchable field dictionary — shows all keeper properties
-const fieldSearch = signal('')
-
-function FieldDictionary({ keeper }: { keeper: Keeper }) {
-  const filter = fieldSearch.value.toLowerCase()
-
-  const fields: { title: string; key: string; value: string }[] = [
-    { title: 'Name', key: 'name', value: keeper.name },
-    { title: 'Emoji', key: 'emoji', value: keeper.emoji ?? '-' },
-    { title: 'Korean', key: 'koreanName', value: keeper.koreanName ?? '-' },
-    { title: 'Model', key: 'model', value: keeper.model ?? '-' },
-    { title: 'Status', key: 'status', value: keeper.status },
-    { title: 'Primary', key: 'primaryValue', value: keeper.primaryValue ?? '-' },
-    { title: 'Activity', key: 'activityLevel', value: String(keeper.activityLevel ?? '-') },
-    { title: 'Gen', key: 'generation', value: String(keeper.generation ?? '-') },
-    { title: 'Turns', key: 'turn_count', value: String(keeper.turn_count ?? '-') },
-    { title: 'Context', key: 'context_ratio', value: keeper.context_ratio != null ? `${Math.round(keeper.context_ratio * 100)}%` : '-' },
-    { title: 'Heartbeat', key: 'last_heartbeat', value: keeper.last_heartbeat ?? '-' },
-    { title: 'Traits', key: 'traits', value: keeper.traits?.join(', ') || '-' },
-    { title: 'Interests', key: 'interests', value: keeper.interests?.join(', ') || '-' },
-  ]
-
-  const filtered = filter
-    ? fields.filter(f => f.title.toLowerCase().includes(filter) || f.key.includes(filter) || f.value.toLowerCase().includes(filter))
-    : fields
-
-  return html`
-    <div class="keeper-field-dict">
-      <input
-        class="keeper-field-search"
-        type="text"
-        placeholder="Search fields..."
-        value=${fieldSearch.value}
-        onInput=${(e: Event) => { fieldSearch.value = (e.target as HTMLInputElement).value }}
-      />
-      ${filtered.map(f => html`
-        <div class="keeper-field-row">
-          <span class="keeper-field-title">${f.title}</span>
-          <span class="keeper-field-key">${f.key}</span>
-          <span style="flex:1; text-align:right; color:#ccc;">${f.value}</span>
-        </div>
-      `)}
-      ${keeper.trace_id ? html`<div class="keeper-field-row"><span class="keeper-field-title">Trace ID</span><span class="keeper-field-key mono">${keeper.trace_id}</span></div>` : ''}
-      ${keeper.agent_name ? html`<div class="keeper-field-row"><span class="keeper-field-title">Agent</span><span style="flex:1; text-align:right; color:#ccc;">${keeper.agent_name}</span></div>` : ''}
-      ${keeper.primary_model ? html`<div class="keeper-field-row"><span class="keeper-field-title">Primary Model</span><span class="mono" style="flex:1; text-align:right; color:#ccc;">${keeper.primary_model}</span></div>` : ''}
-      ${keeper.active_model ? html`<div class="keeper-field-row"><span class="keeper-field-title">Active Model</span><span class="mono" style="flex:1; text-align:right; color:#ccc;">${keeper.active_model}</span></div>` : ''}
-      ${keeper.next_model_hint ? html`<div class="keeper-field-row"><span class="keeper-field-title">Next Model Hint</span><span class="mono" style="flex:1; text-align:right; color:#ccc;">${keeper.next_model_hint}</span></div>` : ''}
-      ${keeper.skill_primary ? html`<div class="keeper-field-row"><span class="keeper-field-title">Skill (Primary)</span><span style="flex:1; text-align:right; color:#ccc;">${keeper.skill_primary}</span></div>` : ''}
-      ${keeper.skill_secondary ? html`<div class="keeper-field-row"><span class="keeper-field-title">Skill (Secondary)</span><span style="flex:1; text-align:right; color:#ccc;">${keeper.skill_secondary}</span></div>` : ''}
-      ${keeper.skill_reason ? html`<div class="keeper-field-row"><span class="keeper-field-title">Skill Reason</span><span style="flex:1; text-align:right; color:#ccc;">${keeper.skill_reason}</span></div>` : ''}
-      ${keeper.context_source ? html`<div class="keeper-field-row"><span class="keeper-field-title">Context Source</span><span style="flex:1; text-align:right; color:#ccc;">${keeper.context_source}</span></div>` : ''}
-      ${keeper.context_tokens != null ? html`<div class="keeper-field-row"><span class="keeper-field-title">Context Tokens</span><span style="flex:1; text-align:right; color:#ccc;">${formatTokens(keeper.context_tokens)}</span></div>` : ''}
-      ${keeper.context_max != null ? html`<div class="keeper-field-row"><span class="keeper-field-title">Context Max</span><span style="flex:1; text-align:right; color:#ccc;">${formatTokens(keeper.context_max)}</span></div>` : ''}
-      ${keeper.memory_recent_note ? html`<div class="keeper-field-row"><span class="keeper-field-title">Memory Note</span><span style="flex:1; text-align:right; color:#ccc;">${keeper.memory_recent_note}</span></div>` : ''}
-      ${keeper.k2k_count != null ? html`<div class="keeper-field-row"><span class="keeper-field-title">K2K Count</span><span style="flex:1; text-align:right; color:#ccc;">${keeper.k2k_count}</span></div>` : ''}
-      ${keeper.conversation_tail_count != null ? html`<div class="keeper-field-row"><span class="keeper-field-title">Conv Tail</span><span style="flex:1; text-align:right; color:#ccc;">${keeper.conversation_tail_count}</span></div>` : ''}
-      ${keeper.handoff_count_total != null ? html`<div class="keeper-field-row"><span class="keeper-field-title">Total Handoffs</span><span style="flex:1; text-align:right; color:#ccc;">${keeper.handoff_count_total}</span></div>` : ''}
-      ${keeper.compaction_count != null ? html`<div class="keeper-field-row"><span class="keeper-field-title">Compactions</span><span style="flex:1; text-align:right; color:#ccc;">${keeper.compaction_count}</span></div>` : ''}
-      ${keeper.last_compaction_saved_tokens != null ? html`<div class="keeper-field-row"><span class="keeper-field-title">Last Compact Saved</span><span style="flex:1; text-align:right; color:#ccc;">${formatTokens(keeper.last_compaction_saved_tokens)}</span></div>` : ''}
-      ${keeper.context?.message_count != null ? html`<div class="keeper-field-row"><span class="keeper-field-title">Message Count</span><span style="flex:1; text-align:right; color:#ccc;">${keeper.context.message_count}</span></div>` : ''}
-      ${keeper.context?.has_checkpoint != null ? html`<div class="keeper-field-row"><span class="keeper-field-title">Has Checkpoint</span><span style="flex:1; text-align:right; color:#ccc;">${keeper.context.has_checkpoint ? 'Yes' : 'No'}</span></div>` : ''}
-    </div>
-  `
 }
 
 function TrpgStats({ stats }: { stats: TrpgCharacterStats }) {
@@ -332,7 +81,7 @@ function TrpgStats({ stats }: { stats: TrpgCharacterStats }) {
 
   return html`
     <div>
-      <div style="display: flex; gap: 12px; margin-bottom: 10px;">
+      <div style="display:flex; gap:12px; margin-bottom:10px;">
         <div style="flex:1;">
           <div style="font-size:11px; color:#888;">HP ${stats.hp}/${stats.max_hp}</div>
           <div style="height:6px; background:rgba(255,255,255,0.06); border-radius:3px; overflow:hidden;">
@@ -362,14 +111,14 @@ function TrpgStats({ stats }: { stats: TrpgCharacterStats }) {
         `)}
       </div>
       <div style="margin-top:8px; font-size:12px; color:#888;">
-        Level ${stats.level} — XP ${stats.xp}
+        Level ${stats.level} · XP ${stats.xp}
       </div>
     </div>
   `
 }
 
 function EquipmentList({ items }: { items: string[] }) {
-  if (items.length === 0) return html`<div class="empty-state" style="font-size:13px">No equipment</div>`
+  if (items.length === 0) return html`<div class="empty-state" style="font-size:13px;">No equipment</div>`
 
   return html`
     <div class="keeper-equipment-list">
@@ -385,7 +134,7 @@ function EquipmentList({ items }: { items: string[] }) {
 
 function RelationshipList({ rels }: { rels: Record<string, string> }) {
   const entries = Object.entries(rels)
-  if (entries.length === 0) return html`<div class="empty-state" style="font-size:13px">No relationships</div>`
+  if (entries.length === 0) return html`<div class="empty-state" style="font-size:13px;">No relationships</div>`
 
   return html`
     <div class="keeper-k2k-list">
@@ -403,7 +152,7 @@ function TraitsList({ traits, label }: { traits: string[]; label: string }) {
   if (traits.length === 0) return null
 
   return html`
-    <div style="margin-bottom: 12px;">
+    <div style="margin-bottom:12px;">
       <div style="font-size:11px; color:#888; text-transform:uppercase; letter-spacing:1px; margin-bottom:6px;">${label}</div>
       <div style="display:flex; flex-wrap:wrap; gap:6px;">
         ${traits.map(t => html`<span class="keeper-mention-chip">${t}</span>`)}
@@ -412,195 +161,10 @@ function TraitsList({ traits, label }: { traits: string[]; label: string }) {
   `
 }
 
-function formatPct(value: number | undefined): string {
-  if (value == null || Number.isNaN(value)) return '-'
-  return `${Math.round(value * 100)}%`
-}
-
-function RuntimeSignals({ keeper }: { keeper: Keeper }) {
-  const mw = keeper.metrics_window
-
-  const rows: Array<{ label: string; value: string | number }> = [
-    { label: 'Model fallback', value: formatPct(typeof mw?.model_fallback_rate === 'number' ? mw.model_fallback_rate : undefined) },
-    { label: 'Proactive fallback', value: formatPct(typeof mw?.proactive_fallback_rate === 'number' ? mw.proactive_fallback_rate : undefined) },
-    { label: 'Memory pass rate', value: formatPct(typeof mw?.memory_pass_rate === 'number' ? mw.memory_pass_rate : undefined) },
-    { label: 'Handoffs', value: typeof mw?.handoff_count === 'number' ? mw.handoff_count : keeper.handoff_count_total ?? '-' },
-    { label: 'Compactions', value: typeof mw?.compaction_events === 'number' ? mw.compaction_events : keeper.compaction_count ?? '-' },
-    { label: 'Saved tokens', value: typeof mw?.compaction_saved_tokens === 'number' ? mw.compaction_saved_tokens : keeper.last_compaction_saved_tokens ?? '-' },
-    { label: 'K2K events', value: keeper.k2k_count ?? '-' },
-    { label: 'Conversation tail', value: keeper.conversation_tail_count ?? '-' },
-    { label: 'Tool Calls', value: typeof mw?.tool_call_count === 'number' ? mw.tool_call_count : '-' },
-    { label: 'Preview Similarity', value: typeof mw?.proactive_preview_similarity_avg === 'number' ? `${(mw.proactive_preview_similarity_avg * 100).toFixed(1)}%` : '-' },
-    { label: 'Memory Avg Score', value: typeof mw?.memory_avg_score === 'number' ? mw.memory_avg_score.toFixed(3) : '-' },
-    { label: 'Fallback Rate', value: typeof mw?.fallback_rate === 'number' ? `${(mw.fallback_rate * 100).toFixed(1)}%` : '-' },
-  ]
-
-  const visibleRows = rows.filter(row =>
-    !(
-      row.value === '-'
-      || row.value === '—'
-      || row.value === ''
-    ))
-
-  if (visibleRows.length === 0) return null
-
-  return html`
-    <div class="keeper-signal-list">
-      ${visibleRows.map(r => html`
-        <div class="keeper-signal-row">
-          <span>${r.label}</span>
-          <strong>${r.value}</strong>
-        </div>
-      `)}
-    </div>
-  `
-}
-
-function KeeperNeighborhood({ keeper }: { keeper: Keeper }) {
-  const room = operatorSnapshot.value?.room ?? {}
-  const actions = (operatorSnapshot.value?.available_actions ?? [])
-    .filter(action => action.target_type === 'keeper' || action.target_type === 'room')
-    .slice(0, 8)
-  const recentTools = keeperRecentTools(keeper)
-  const topTools = keeperTopTools(keeper)
-  const missionBrief = missionKeeperBrief(keeper)
-  const allowedTools =
-    missionBrief?.allowed_tool_names && missionBrief.allowed_tool_names.length > 0
-      ? missionBrief.allowed_tool_names
-      : keeper.allowed_tool_names ?? []
-  const observedTools =
-    missionBrief?.latest_tool_names && missionBrief.latest_tool_names.length > 0
-      ? missionBrief.latest_tool_names
-      : keeper.latest_tool_names ?? []
-  const toolCallCount = missionBrief?.latest_tool_call_count ?? keeper.latest_tool_call_count
-  const auditSource = missionBrief?.tool_audit_source ?? keeper.tool_audit_source
-  const auditAt = missionBrief?.tool_audit_at ?? keeper.tool_audit_at
-  const capabilities = keeper.agent?.capabilities ?? []
-  const roomName = room.current_room ?? room.room_id ?? serverStatus.value?.room ?? 'default'
-  const project = room.project ?? serverStatus.value?.project ?? '확인 없음'
-  const cluster = room.cluster ?? serverStatus.value?.cluster ?? '확인 없음'
-  const allowlistFallback = toolAuditStateLabel(allowlistEmptyState(keeper))
-  const observedFallback = toolAuditStateLabel(observedToolsEmptyState(keeper, auditSource))
-  const metadataFallback = toolAuditStateLabel(auditMetadataState(keeper, auditSource))
-  const linkedRecentFallback = toolAuditStateLabel(linkedRecentToolsEmptyState(keeper))
-  const runtimeState = linkedRuntimeState(keeper)
-  const currentTaskLabel =
-    keeper.agent?.current_task
-    ?? (runtimeState === 'offline' ? 'offline' : 'not_collected')
-  const skillRouteLabel =
-    keeper.skill_primary
-    ?? (runtimeState === 'offline' ? 'offline' : 'not_collected')
-  const openToolsQuery = allowedTools[0] ?? observedTools[0] ?? recentTools[0] ?? null
-
-  return html`
-    <div class="keeper-signal-list">
-      <div class="keeper-signal-row">
-        <span>Room</span>
-        <strong>${roomName}</strong>
-      </div>
-      <div class="keeper-signal-row">
-        <span>Project</span>
-        <strong>${project}</strong>
-      </div>
-      <div class="keeper-signal-row">
-        <span>Cluster</span>
-        <strong>${cluster}</strong>
-      </div>
-      <div class="keeper-signal-row">
-        <span>Current task</span>
-        <strong>${currentTaskLabel}</strong>
-      </div>
-      <div class="keeper-signal-row">
-        <span>Skill route</span>
-        <strong>${skillRouteLabel}</strong>
-      </div>
-      <div style="display:flex; justify-content:flex-end; margin-top:4px;">
-        <button class="control-btn ghost" onClick=${() => { openToolsInventory(openToolsQuery) }}>
-          Open tools panel
-        </button>
-      </div>
-      <div style="display:flex; flex-direction:column; gap:8px; margin-top:8px;">
-        <span style="font-size:12px; color:#888;">Allowed tools</span>
-        <span style="font-size:11px; color:#64748b;">Currently permitted tools for this keeper runtime.</span>
-        <div style="display:flex; flex-wrap:wrap; gap:6px;">
-          ${allowedTools.length > 0
-            ? allowedTools.map(tool => html`<span class="pill">${tool}</span>`)
-            : html`<span style="font-size:12px; color:#888;">${allowlistFallback}</span>`}
-        </div>
-      </div>
-      <div style="display:flex; flex-direction:column; gap:8px; margin-top:8px;">
-        <span style="font-size:12px; color:#888;">Observed tools</span>
-        <span style="font-size:11px; color:#64748b;">Recent execution evidence from heartbeat or runtime telemetry.</span>
-        <div style="display:flex; flex-wrap:wrap; gap:6px;">
-          ${observedTools.length > 0
-            ? observedTools.map(tool => html`<span class="pill">${tool}</span>`)
-            : html`<span style="font-size:12px; color:#888;">${observedFallback}</span>`}
-        </div>
-      </div>
-      <div class="keeper-signal-row">
-        <span>Tool calls</span>
-        <strong>${typeof toolCallCount === 'number' ? toolCallCount : observedFallback === 'none_recent' ? 0 : metadataFallback}</strong>
-      </div>
-      <div class="keeper-signal-row">
-        <span>Evidence source</span>
-        <strong>${auditSource ?? metadataFallback}</strong>
-      </div>
-      <div class="keeper-signal-row">
-        <span>Observed at</span>
-        <strong>${auditAt ? html`<${TimeAgo} timestamp=${auditAt} />` : metadataFallback}</strong>
-      </div>
-      <div style="display:flex; flex-direction:column; gap:8px; margin-top:8px;">
-        <span style="font-size:12px; color:#888;">Keeper recent tools</span>
-        <div style="display:flex; flex-wrap:wrap; gap:6px;">
-          ${recentTools.length > 0
-            ? recentTools.map(tool => html`<span class="pill">${tool}</span>`)
-            : html`<span style="font-size:12px; color:#888;">${linkedRecentFallback}</span>`}
-        </div>
-      </div>
-      ${topTools.length > 0
-        ? html`
-            <div style="display:flex; flex-direction:column; gap:8px; margin-top:8px;">
-              <span style="font-size:12px; color:#888;">Window top tools</span>
-              <div style="display:flex; flex-wrap:wrap; gap:6px;">
-                ${topTools.map(tool => html`<span class="pill">${tool}</span>`)}
-              </div>
-            </div>
-          `
-        : null}
-      <div style="display:flex; flex-direction:column; gap:8px; margin-top:8px;">
-        <span style="font-size:12px; color:#888;">Capabilities</span>
-        <div style="display:flex; flex-wrap:wrap; gap:6px;">
-          ${capabilities.length > 0
-            ? capabilities.map(capability => html`<span class="pill">${capability}</span>`)
-            : html`<span style="font-size:12px; color:#888;">등록된 capability 없음</span>`}
-        </div>
-      </div>
-      <div style="display:flex; flex-direction:column; gap:8px; margin-top:8px;">
-        <span style="font-size:12px; color:#888;">Available actions nearby</span>
-        <div style="display:flex; flex-wrap:wrap; gap:6px;">
-          ${actions.length > 0
-            ? actions.map(action => html`<span class="pill">${actionDescriptorLabel(action.action_type)}</span>`)
-            : html`<span style="font-size:12px; color:#888;">operator action 광고 없음</span>`}
-        </div>
-      </div>
-    </div>
-  `
-}
-
-// ── Main Detail Overlay ───────────────────────────────────
-
-function currentOperatorActor(): string {
-  const q = new URLSearchParams(window.location.search)
-  const queryActor = q.get('agent') ?? q.get('agent_name')
-  const storedActor = localStorage.getItem('masc_dashboard_agent_name')
-  const actor = (queryActor ?? storedActor ?? 'dashboard').trim()
-  return actor || 'dashboard'
-}
-
 async function pokeLodgeNow(): Promise<void> {
   try {
     const response = await runOperatorAction({
-      actor: currentOperatorActor(),
+      actor: currentDashboardActor(),
       action_type: 'lodge_tick',
       target_type: 'room',
       payload: {},
@@ -624,20 +188,20 @@ async function pokeLodgeNow(): Promise<void> {
 
 function KeeperCommsPanel({ keeper }: { keeper: Keeper }) {
   return html`
-    <div style="margin-top: 24px; border-top: 1px solid rgba(255,255,255,0.1); padding-top: 24px;">
-      <h3 style="margin: 0 0 16px; color: var(--accent-cyan); font-family: var(--font-display);">Direct Comms & Runtime Diagnostics</h3>
+    <div style="margin-top:24px; border-top:1px solid rgba(255,255,255,0.1); padding-top:24px;">
+      <h3 style="margin:0 0 16px; color: var(--accent-cyan); font-family: var(--font-display);">Direct Comms & Runtime Diagnostics</h3>
 
-      <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 20px;">
-        <div style="display: flex; flex-direction: column; gap: 12px;">
+      <div style="display:grid; grid-template-columns:1fr 1fr; gap:20px;">
+        <div style="display:flex; flex-direction:column; gap:12px;">
           <${KeeperDiagnosticSummary} keeper=${keeper} />
           <${KeeperRuntimeActions}
-            actor=${currentOperatorActor()}
+            actor=${currentDashboardActor()}
             keeper=${keeper}
             onPokeLodge=${() => { void pokeLodgeNow() }}
           />
         </div>
 
-        <div style="min-height: 345px;">
+        <div style="min-height:345px;">
           <${KeeperConversationPanel}
             keeperName=${keeper.name}
             placeholder="Direct prompt for this keeper"
@@ -652,6 +216,8 @@ export function KeeperDetailOverlay() {
   const keeper = selectedKeeper.value
   if (!keeper) return null
 
+  const profileItems = (keeper.traits?.length ?? 0) > 0 || (keeper.interests?.length ?? 0) > 0 || Boolean(keeper.skill_primary) || Boolean(keeper.last_heartbeat)
+
   return html`
     <div
       class="keeper-detail-overlay"
@@ -664,7 +230,6 @@ export function KeeperDetailOverlay() {
       }}
     >
       <div style="max-width:780px; width:100%; max-height:90vh; overflow-y:auto; background:#1a1a2e; border-radius:16px; border:1px solid rgba(255,255,255,0.08); padding:24px;">
-        ${'' /* Header */}
         <div style="display:flex; align-items:center; justify-content:space-between; margin-bottom:20px;">
           <div style="display:flex; align-items:center; gap:12px;">
             <span style="font-size:32px;">${keeper.emoji}</span>
@@ -673,7 +238,6 @@ export function KeeperDetailOverlay() {
               ${keeper.koreanName ? html`<div style="font-size:13px; color:#888;">${keeper.koreanName}</div>` : null}
             </div>
             <${StatusBadge} status=${keeper.status} />
-            ${keeper.model ? html`<span class="pill">${keeper.model}</span>` : null}
           </div>
           <button
             onClick=${() => closeKeeperDetail()}
@@ -681,110 +245,69 @@ export function KeeperDetailOverlay() {
           >✕</button>
         </div>
 
-        ${'' /* KPIs */}
-        <${KpiGrid} keeper=${keeper} />
-
-        ${'' /* Context chart */}
         <${ContextChart} keeper=${keeper} />
 
-        ${'' /* Two-column grid for sections */}
         <div style="display:grid; grid-template-columns:1fr 1fr; gap:16px; margin-top:16px;">
-
-          ${'' /* Left: Field Dictionary */}
-          <${Card} title="Field Dictionary">
-            <${FieldDictionary} keeper=${keeper} />
-          <//>
-
-          ${'' /* Right: Traits + Interests */}
-          <${Card} title="Profile">
-            <${TraitsList} traits=${keeper.traits ?? []} label="Traits" />
-            <${TraitsList} traits=${keeper.interests ?? []} label="Interests" />
-            ${keeper.primaryValue
-              ? html`<div style="font-size:12px; color:#888;">Primary value: <span style="color:#4ade80;">${keeper.primaryValue}</span></div>`
-              : null}
-            ${keeper.skill_primary
-              ? html`<div style="font-size:12px; color:#888; margin-top:6px;">
-                  Skill route: <span style="color:#22d3ee;">${keeper.skill_primary}</span>
-                </div>`
-              : null}
-            ${keeper.skill_reason
-              ? html`<div style="font-size:12px; color:#888; margin-top:4px;">${keeper.skill_reason}</div>`
-              : null}
-            ${keeper.last_heartbeat
-              ? html`<div style="font-size:12px; color:#888; margin-top:6px;">
-                  Last heartbeat: <${TimeAgo} timestamp=${keeper.last_heartbeat} />
-                </div>`
-              : null}
-          <//>
-
-          ${'' /* Autonomy Level (if available) */}
-          ${keeper.autonomy_level
+          ${profileItems
             ? html`
-              <${Card} title="Autonomy">
-                <${AutonomyMeter} keeper=${keeper} />
-              <//>
-            `
+                <${Card} title="Profile">
+                  <${TraitsList} traits=${keeper.traits ?? []} label="Traits" />
+                  <${TraitsList} traits=${keeper.interests ?? []} label="Interests" />
+                  ${keeper.skill_primary
+                    ? html`<div style="font-size:12px; color:#888; margin-top:6px;">Skill route: <span style="color:#22d3ee;">${keeper.skill_primary}</span></div>`
+                    : null}
+                  ${keeper.last_heartbeat
+                    ? html`<div style="font-size:12px; color:#888; margin-top:6px;">Last heartbeat: <${TimeAgo} timestamp=${keeper.last_heartbeat} /></div>`
+                    : null}
+                <//>
+              `
             : null}
 
-          ${'' /* TRPG Stats (if available) */}
           ${keeper.trpg_stats
             ? html`
-              <${Card} title="TRPG Stats">
-                <${TrpgStats} stats=${keeper.trpg_stats} />
-              <//>
-            `
+                <${Card} title="TRPG Stats">
+                  <${TrpgStats} stats=${keeper.trpg_stats} />
+                <//>
+              `
             : null}
 
-          ${'' /* Equipment */}
           ${keeper.inventory && keeper.inventory.length > 0
             ? html`
-              <${Card} title="Equipment (${keeper.inventory.length})">
-                <${EquipmentList} items=${keeper.inventory} />
-              <//>
-            `
+                <${Card} title="Equipment (${keeper.inventory.length})">
+                  <${EquipmentList} items=${keeper.inventory} />
+                <//>
+              `
             : null}
 
-          ${'' /* Relationships */}
           ${keeper.relationships && Object.keys(keeper.relationships).length > 0
             ? html`
-              <${Card} title="Relationships (${Object.keys(keeper.relationships).length})">
-                <${RelationshipList} rels=${keeper.relationships} />
-              <//>
-            `
+                <${Card} title="Relationships (${Object.keys(keeper.relationships).length})">
+                  <${RelationshipList} rels=${keeper.relationships} />
+                <//>
+              `
             : null}
-
-          <${Card} title="Runtime Signals">
-            <${RuntimeSignals} keeper=${keeper} />
-          <//>
-
-          <${Card} title="Neighborhood & Tool Audit">
-            <${KeeperNeighborhood} keeper=${keeper} />
-          <//>
 
           <${Card} title="Memory & Context">
             <div class="keeper-signal-list">
               <div class="keeper-signal-row">
-                <span>Context source</span>
-                <strong>${keeper.context_source ?? keeper.context?.source ?? '-'}</strong>
+                <span>Context pressure</span>
+                <strong>${contextPressureLabel(keeper.context?.context_ratio ?? keeper.context_ratio ?? null)}</strong>
               </div>
               <div class="keeper-signal-row">
-                <span>Context tokens</span>
+                <span>Current ratio</span>
                 <strong>
-                  ${keeper.context_tokens ?? keeper.context?.context_tokens ?? '-'}
-                  /
-                  ${keeper.context_max ?? keeper.context?.context_max ?? '-'}
+                  ${typeof (keeper.context?.context_ratio ?? keeper.context_ratio) === 'number'
+                    ? `${Math.round((keeper.context?.context_ratio ?? keeper.context_ratio ?? 0) * 100)}%`
+                    : '-'}
                 </strong>
               </div>
               ${keeper.memory_recent_note
-                ? html`
-                  <div class="keeper-memory-note">
-                    ${keeper.memory_recent_note}
-                  </div>
-                `
+                ? html`<div class="keeper-memory-note">${keeper.memory_recent_note}</div>`
                 : html`<div class="empty-state" style="font-size:12px;">No recent memory note</div>`}
             </div>
           <//>
         </div>
+
         <${KeeperCommsPanel} keeper=${keeper} />
       </div>
     </div>

--- a/dashboard/src/components/mission-cards.ts
+++ b/dashboard/src/components/mission-cards.ts
@@ -1,7 +1,5 @@
 import { html } from 'htm/preact'
 import { Card } from './common/card'
-import { extractAgentInfo } from './common/agent-info'
-import { linkedRecentToolsEmptyState, observedToolsEmptyState, toolAuditStateLabel } from './common/tool-audit'
 import { openAgentDetail } from './agent-detail'
 import { openKeeperDetail } from './keeper-detail'
 import {
@@ -19,7 +17,6 @@ import type {
   DashboardMissionSessionDetailResponse,
 } from '../types'
 import {
-  type EnrichedAgentRow,
   type EnrichedKeeperRow,
   toneClass,
   relativeTime,
@@ -70,26 +67,6 @@ export function MissionContextBar({
         <strong>${generatedAt ? relativeTime(generatedAt) : '기록 없음'}</strong>
       </div>
     </div>
-  `
-}
-
-export function SummaryStat({
-  label,
-  value,
-  detail,
-  tone,
-}: {
-  label: string
-  value: string | number
-  detail: string
-  tone?: string | null
-}) {
-  return html`
-    <article class="mission-stat-card ${toneClass(tone)}">
-      <span class="mission-stat-label">${label}</span>
-      <strong class="mission-stat-value">${value}</strong>
-      <small class="mission-stat-detail">${detail}</small>
-    </article>
   `
 }
 
@@ -315,6 +292,7 @@ export function SessionBriefCard({
   const members = brief.member_previews.slice(0, 4)
   const action = brief.top_recommendation ?? null
   const incident = brief.top_attention ?? null
+  const memberPreviewLabels = members.map(member => member.display_name ?? member.agent_name)
 
   return html`
     <article class="mission-crew-card ${toneClass(brief.top_attention?.severity ?? brief.health ?? brief.status)} ${selected ? 'is-selected' : ''}">
@@ -331,7 +309,7 @@ export function SessionBriefCard({
           <div class="mission-fact-tile">
             <span>멤버</span>
             <strong>${brief.member_names.length}</strong>
-            <small>${brief.member_names.slice(0, 3).join(', ') || '없음'}</small>
+            <small>${memberPreviewLabels.slice(0, 3).join(', ') || brief.member_names.slice(0, 3).join(', ') || '없음'}</small>
           </div>
           <div class="mission-fact-tile">
             <span>가동 시간</span>
@@ -376,9 +354,12 @@ export function SessionBriefCard({
             <div class="mission-member-preview-grid">
               ${members.map(member => html`
                 <button class="mission-member-preview" onClick=${() => openAgentDetail(member.agent_name)}>
-                  <strong>${member.agent_name}</strong>
+                  <strong>${member.display_name ?? member.agent_name}</strong>
                   <span>${member.current_work ?? '현재 작업 없음'}</span>
-                  <small>${member.recent_output_preview ?? member.recent_input_preview ?? '최근 입출력 없음'}</small>
+                  <small>
+                    ${member.recent_output_preview ?? member.recent_input_preview ?? '최근 입출력 없음'}
+                    ${member.is_live === false ? ' · archived participant' : ''}
+                  </small>
                 </button>
               `)}
             </div>
@@ -465,10 +446,11 @@ export function SessionDetailCard({
             ${detail.participants.length > 0
               ? detail.participants.map(participant => html`
                   <button class="mission-member-preview" onClick=${() => openAgentDetail(participant.agent_name)}>
-                    <strong>${participant.agent_name}</strong>
+                    <strong>${participant.display_name ?? participant.agent_name}</strong>
                     <span>${participant.current_work ?? '현재 작업 없음'}</span>
                     <small>
                       ${participant.recent_output_preview ?? participant.recent_input_preview ?? '최근 입출력 없음'}
+                      ${participant.is_live === false ? ' · archived participant' : ''}
                       ${participant.last_activity_at ? ` · ${relativeTime(participant.last_activity_at)}` : ''}
                     </small>
                   </button>
@@ -519,68 +501,6 @@ export function SessionDetailCard({
   `
 }
 
-export function AgentBriefCard({ row }: { row: EnrichedAgentRow }) {
-  const info = extractAgentInfo(row.brief.agent_name)
-  const who = row.withWhom.length > 0 ? row.withWhom.slice(0, 3).join(', ') : '단독 또는 방 단위'
-  const recentToolsLabel =
-    row.recentTools.length > 0
-      ? row.recentTools.join(', ')
-      : toolAuditStateLabel(observedToolsEmptyState(row.keeper, row.brief.tool_audit_source))
-  return html`
-    <article class="mission-activity-card ${toneClass(row.brief.status ?? row.agent?.status)}">
-      <button class="mission-card-select" onClick=${() => openAgentDetail(row.brief.agent_name)}>
-        <div class="mission-activity-head">
-          <div class="mission-activity-title">
-            <span class="agent-emoji">${row.agent?.emoji ?? row.keeper?.emoji ?? ''}</span>
-            <div>
-              <strong>${row.brief.agent_name}</strong>
-              <span>${info.model !== info.nickname ? `${info.model} · ` : ''}${info.nickname}</span>
-            </div>
-          </div>
-          <span class="command-chip ${toneClass(row.brief.status ?? row.agent?.status)}">${statusLabel(row.brief.status ?? row.agent?.status)}</span>
-        </div>
-
-        <div class="mission-activity-meta">
-          <span>어디서 · ${row.where}</span>
-          <span>누구와 · ${who}</span>
-          <span>주의 신호 · ${row.brief.related_attention_count}</span>
-        </div>
-
-        <div class="mission-activity-focus">
-          <span>무엇을</span>
-          <strong>${row.currentWork}</strong>
-          ${row.how ? html`<small>어떻게 · ${row.how}</small>` : null}
-        </div>
-      </button>
-
-      <details class="mission-card-disclosure">
-        <summary>최근 흐름</summary>
-        <div class="mission-activity-foot">
-          ${row.recentEvent ? html`<span>최근 일 · ${row.recentEvent}</span>` : html`<span>최근 사건 요약 없음</span>`}
-          <span>관련 세션 · ${row.brief.related_session_id ?? '없음'}</span>
-        </div>
-
-        <details class="mission-card-disclosure compact">
-          <summary>입력 · 응답 · 도구</summary>
-          <div class="mission-io-stack">
-            <div class="mission-io-item">
-              <span>최근 입력</span>
-              <strong>${row.recentInput ?? '표시 가능한 최근 입력이 없습니다'}</strong>
-            </div>
-            <div class="mission-io-item">
-              <span>최근 응답</span>
-              <strong>${row.recentOutput ?? '표시 가능한 최근 응답이 없습니다'}</strong>
-            </div>
-          </div>
-          <div class="mission-activity-foot">
-            <span>최근 도구 · ${recentToolsLabel}</span>
-          </div>
-        </details>
-      </details>
-    </article>
-  `
-}
-
 export function KeeperBriefCard({ row }: { row: EnrichedKeeperRow }) {
   const continuity = [
     `세대 ${row.brief.generation ?? row.keeper?.generation ?? 0}`,
@@ -591,10 +511,6 @@ export function KeeperBriefCard({ row }: { row: EnrichedKeeperRow }) {
   ]
     .filter((value): value is string => value !== null)
     .join(' · ')
-  const recentToolsLabel =
-    row.recentTools.length > 0
-      ? row.recentTools.join(', ')
-      : toolAuditStateLabel(linkedRecentToolsEmptyState(row.keeper))
 
   return html`
     <article class="mission-activity-card ${toneClass(row.brief.status ?? row.keeper?.status)}">
@@ -641,7 +557,7 @@ export function KeeperBriefCard({ row }: { row: EnrichedKeeperRow }) {
             </div>
           </div>
           <div class="mission-activity-foot">
-            <span>최근 도구 · ${recentToolsLabel}</span>
+            <span>최근 도구 · ${row.recentTools.length > 0 ? row.recentTools.join(', ') : '도구 사용 없음'}</span>
           </div>
         </details>
       </details>

--- a/dashboard/src/components/mission-utils.ts
+++ b/dashboard/src/components/mission-utils.ts
@@ -1,19 +1,14 @@
 import { signal } from '@preact/signals'
-import { extractAgentInfo } from './common/agent-info'
 import { navigate } from '../router'
 import { missionSnapshot } from '../mission-store'
-import { agents, keepers, messages, tasks } from '../store'
+import { keepers } from '../store'
 import type {
-  Agent,
-  DashboardMissionAgentBrief,
   DashboardMissionAttentionQueueItem,
   DashboardMissionKeeperBrief,
   DashboardMissionSessionBrief,
   Keeper,
-  Message,
   OperatorAttentionItem,
   OperatorRecommendedAction,
-  Task,
 } from '../types'
 import {
   createMissionWorkflowContext,
@@ -22,20 +17,6 @@ import {
   persistWorkflowContext,
   workflowTargetLabel,
 } from '../workflow-context'
-
-export type EnrichedAgentRow = {
-  brief: DashboardMissionAgentBrief
-  agent: Agent | null
-  keeper: Keeper | null
-  where: string
-  withWhom: string[]
-  currentWork: string
-  how: string | null
-  recentInput: string | null
-  recentOutput: string | null
-  recentEvent: string | null
-  recentTools: string[]
-}
 
 export type EnrichedKeeperRow = {
   brief: DashboardMissionKeeperBrief
@@ -229,102 +210,6 @@ export function attentionAsIncident(item: DashboardMissionAttentionQueueItem): O
   }
 }
 
-function latestMessageFrom(agentName: string, rows: Message[]): Message | null {
-  const key = agentName.trim().toLowerCase()
-  return [...rows]
-    .filter(item => (item.from ?? '').trim().toLowerCase() === key)
-    .sort((a, b) => Date.parse(b.timestamp) - Date.parse(a.timestamp))[0] ?? null
-}
-
-function escapeRegex(value: string): string {
-  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
-}
-
-function containsDirectMention(content: string, agentName: string): boolean {
-  if (!agentName) return false
-  const escaped = escapeRegex(agentName)
-  const pattern = new RegExp(`(?:^|[^a-z0-9_])@${escaped}(?![a-z0-9_-])`, 'i')
-  return pattern.test(content)
-}
-
-function latestMessageTo(agentName: string, rows: Message[]): Message | null {
-  const key = agentName.trim().toLowerCase()
-  return [...rows]
-    .filter(item => {
-      const from = (item.from ?? '').trim().toLowerCase()
-      if (from === key) return false
-      const content = (item.content ?? '').trim().toLowerCase()
-      return containsDirectMention(content, key)
-    })
-    .sort((a, b) => Date.parse(b.timestamp) - Date.parse(a.timestamp))[0] ?? null
-}
-
-function keeperForAgent(agentName: string): Keeper | null {
-  return keepers.value.find(keeper =>
-    keeper.agent_name === agentName || keeper.name === agentName,
-  ) ?? null
-}
-
-function agentByName(name: string): Agent | null {
-  return agents.value.find(agent => agent.name === name) ?? null
-}
-
-function taskLabel(taskId: string | null | undefined, taskList: Task[]): string | null {
-  const current = trimText(taskId, 100)
-  if (!current) return null
-  const byId = taskList.find(task => task.id === current)
-  if (byId) return `${byId.id} · ${trimText(byId.title, 92)}`
-  const byTitle = taskList.find(task => task.title === current)
-  if (byTitle) return `${byTitle.id} · ${trimText(byTitle.title, 92)}`
-  return current
-}
-
-export function enrichedAgentRow(brief: DashboardMissionAgentBrief): EnrichedAgentRow {
-  const agent = agentByName(brief.agent_name)
-  const keeper = keeperForAgent(brief.agent_name)
-  const latestOut = latestMessageFrom(brief.agent_name, messages.value)
-  const latestIn = latestMessageTo(brief.agent_name, messages.value)
-  const info = extractAgentInfo(brief.agent_name)
-  const how =
-    keeper?.skill_primary
-    ?? (agent?.capabilities && agent.capabilities.length > 0 ? agent.capabilities.slice(0, 3).join(', ') : null)
-    ?? info.model
-    ?? agent?.agent_type
-    ?? null
-
-  return {
-    brief,
-    agent,
-    keeper,
-    where: brief.where ?? '방 정보 없음',
-    withWhom: brief.with_whom,
-    currentWork:
-      brief.current_work
-      ?? taskLabel(agent?.current_task ?? null, tasks.value)
-      ?? '명시된 current task 없음',
-    how,
-    recentInput:
-      trimText(brief.recent_input_preview, 120)
-      ?? trimText(latestIn?.content, 120)
-      ?? trimText(keeper?.recent_input_preview, 120)
-      ?? null,
-    recentOutput:
-      trimText(brief.recent_output_preview, 120)
-      ?? trimText(latestOut?.content, 120)
-      ?? trimText(keeper?.recent_output_preview, 120)
-      ?? trimText(keeper?.diagnostic?.last_reply_preview, 120)
-      ?? null,
-    recentEvent:
-      trimText(brief.recent_event, 120)
-      ?? trimText(keeper?.diagnostic?.summary, 120)
-      ?? null,
-    recentTools:
-      brief.recent_tool_names.length > 0
-        ? brief.recent_tool_names
-        : keeper?.recent_tool_names ?? [],
-  }
-}
-
 export function enrichedKeeperRow(brief: DashboardMissionKeeperBrief): EnrichedKeeperRow {
   const keeper =
     keepers.value.find(item => item.name === brief.name || item.agent_name === brief.agent_name) ?? null
@@ -356,19 +241,6 @@ export function sessionLookupById() {
   if (!mission) return new Map<string, DashboardMissionSessionBrief>()
   const rows = mission.sessions.length > 0 ? mission.sessions : mission.session_briefs
   return new Map(rows.map(item => [item.session_id, item]))
-}
-
-export function memberPreview(name: string) {
-  const agent = agentByName(name)
-  const latestOut = latestMessageFrom(name, messages.value)
-  const info = extractAgentInfo(name)
-  return {
-    name,
-    model: info.model,
-    nickname: info.nickname,
-    currentTask: taskLabel(agent?.current_task ?? null, tasks.value) ?? 'agent snapshot 없음',
-    output: trimText(latestOut?.content, 96),
-  }
 }
 
 export function toggleAttention(id: string): void {

--- a/dashboard/src/components/mission.ts
+++ b/dashboard/src/components/mission.ts
@@ -25,7 +25,6 @@ import {
 } from './mission-utils'
 import {
   MissionContextBar,
-  SummaryStat,
   MissionBriefingCard,
   AttentionCard,
   SessionBriefCard,
@@ -66,16 +65,6 @@ export function Mission() {
     .filter(item => item.related_session_ids.length > 0)
     .slice(0, 6)
   const internalSignals = mission.internal_signals.slice(0, 3)
-  const blockedSessions = sessionRows.filter(row => {
-    const tone = row.top_attention?.severity ?? row.health ?? row.status
-    return toneClass(tone) !== 'ok' || Boolean(row.blocker_summary)
-  }).length
-  const activeParticipants = new Set(
-    sessionRows.flatMap(row => row.member_names),
-  ).size
-  const liveOutputs =
-    sessionRows.flatMap(row => row.member_previews ?? []).filter(row => row.recent_output_preview).length
-    + keeperRows.filter(row => row.recentOutput).length
 
   useEffect(() => {
     void refreshMissionSessionDetail(activeSessionId)
@@ -106,15 +95,6 @@ export function Mission() {
       />
 
       <${MissionBriefingCard} />
-
-      <div class="mission-stat-grid">
-        <${SummaryStat} label="활성 세션" value=${sessionRows.length} detail="지금 진행중인 협업 단위" tone=${focusSession?.top_attention?.severity ?? focusSession?.health ?? 'ok'} />
-        <${SummaryStat} label="막힌 세션" value=${blockedSessions} detail="주의가 필요한 흐름" tone=${blockedSessions > 0 ? 'warn' : 'ok'} />
-        <${SummaryStat} label="참여자" value=${activeParticipants} detail="현재 세션에 연결된 주체" tone=${activeParticipants > 0 ? 'ok' : 'warn'} />
-        <${SummaryStat} label="키퍼 관찰" value=${keeperRows.length} detail="연속성 확인 대상" tone=${keeperRows[0]?.brief.status ?? 'ok'} />
-        <${SummaryStat} label="최근 응답" value=${liveOutputs} detail="메인에서 바로 읽을 수 있는 응답 수" tone=${liveOutputs > 0 ? 'ok' : 'warn'} />
-        <${SummaryStat} label="내부 신호" value=${internalSignals.length} detail="시스템 진단은 보조 면에만 유지" tone=${internalSignals[0]?.severity ?? 'ok'} />
-      </div>
 
       ${activeSessionId
         ? html`

--- a/dashboard/src/keeper-runtime.ts
+++ b/dashboard/src/keeper-runtime.ts
@@ -1,5 +1,5 @@
 import { signal } from '@preact/signals'
-import { callMcpTool, runOperatorAction, sendKeeperMessage } from './api'
+import { callMcpTool, currentDashboardActor, runOperatorAction } from './api'
 import type {
   Keeper,
   KeeperConversationDelivery,
@@ -139,9 +139,6 @@ export function normalizeKeeperDiagnostic(raw: unknown): KeeperDiagnostic | null
     recoverable: diagnosticRecoverable(raw.recoverable, nextActionPath as KeeperDiagnostic['next_action_path']),
     summary: diagnosticSummary(raw.summary, healthState as KeeperDiagnostic['health_state'], (asString(raw.quiet_reason) ?? null) as KeeperDiagnostic['quiet_reason']),
     keepalive_running: typeof raw.keepalive_running === 'boolean' ? raw.keepalive_running : undefined,
-    continuity_state:
-      (asString(raw.continuity_state) ?? null) as KeeperDiagnostic['continuity_state'],
-    continuity_summary: asString(raw.continuity_summary) ?? null,
   }
 }
 
@@ -321,6 +318,28 @@ function normalizeStatusDetail(name: string, text: string, rawStatus: unknown): 
   }
 }
 
+function keeperReplyTextFromOperatorResult(raw: unknown): string {
+  if (typeof raw === 'string') return raw.trim()
+  if (!isRecord(raw)) return ''
+  const direct =
+    asString(raw.reply)
+    ?? asString(raw.content)
+    ?? asString(raw.text)
+    ?? asString(raw.message)
+  if (direct && direct.trim()) return direct.trim()
+  const nested = raw.result
+  if (typeof nested === 'string') return nested.trim()
+  if (isRecord(nested)) {
+    const nestedText =
+      asString(nested.reply)
+      ?? asString(nested.content)
+      ?? asString(nested.text)
+      ?? asString(nested.message)
+    return nestedText?.trim() ?? ''
+  }
+  return ''
+}
+
 function appendThreadEntry(name: string, entry: KeeperConversationEntry): void {
   const existing = keeperThreads.value[name] ?? []
   keeperThreads.value = {
@@ -429,6 +448,7 @@ export async function sendKeeperThreadMessage(name: string, prompt: string): Pro
   const keeperName = name.trim()
   const message = prompt.trim()
   if (!keeperName || !message) return
+  const actor = currentDashboardActor()
   const localId = `local-${Date.now()}`
   appendThreadEntry(keeperName, {
     id: localId,
@@ -441,7 +461,14 @@ export async function sendKeeperThreadMessage(name: string, prompt: string): Pro
   setRecordValue(keeperSending, keeperName, true)
   setRecordValue(keeperActionErrors, keeperName, null)
   try {
-    const reply = await sendKeeperMessage(keeperName, message)
+    const response = await runOperatorAction({
+      actor,
+      action_type: 'keeper_message',
+      target_type: 'keeper',
+      target_id: keeperName,
+      payload: { message },
+    })
+    const reply = keeperReplyTextFromOperatorResult(response.result)
     keeperThreads.value = {
       ...keeperThreads.value,
       [keeperName]: (keeperThreads.value[keeperName] ?? []).map(entry =>

--- a/dashboard/src/mission-store.ts
+++ b/dashboard/src/mission-store.ts
@@ -254,16 +254,6 @@ function normalizeSummary(raw: unknown): DashboardMissionSummary {
     cluster: asString(root.cluster),
     project: asString(root.project),
     current_room: asString(root.current_room) ?? null,
-    paused: asBoolean(root.paused),
-    tempo_interval_s: asNumber(root.tempo_interval_s),
-    active_agents: asNumber(root.active_agents),
-    keeper_pressure: asNumber(root.keeper_pressure),
-    active_operations: asNumber(root.active_operations),
-    pending_approvals: asNumber(root.pending_approvals),
-    incident_count: asNumber(root.incident_count),
-    recommended_action_count: asNumber(root.recommended_action_count),
-    top_attention: normalizeAttentionItem(root.top_attention),
-    top_action: normalizeRecommendedAction(root.top_action),
   }
 }
 
@@ -370,13 +360,11 @@ function normalizeParticipantPreview(raw: unknown): DashboardMissionParticipantP
   if (!agentName) return null
   return {
     agent_name: agentName,
-    status: asString(raw.status),
+    display_name: asString(raw.display_name) ?? null,
+    is_live: typeof raw.is_live === 'boolean' ? raw.is_live : undefined,
     current_work: asString(raw.current_work) ?? null,
     recent_input_preview: asString(raw.recent_input_preview) ?? null,
     recent_output_preview: asString(raw.recent_output_preview) ?? null,
-    recent_tool_names: extractArray(raw.recent_tool_names)
-      .map(item => (typeof item === 'string' ? item.trim() : ''))
-      .filter(Boolean),
     last_activity_at: asString(raw.last_activity_at) ?? null,
   }
 }
@@ -433,30 +421,15 @@ function normalizeAgentBrief(raw: unknown): DashboardMissionAgentBrief | null {
   if (!agentName) return null
   return {
     agent_name: agentName,
+    display_name: asString(raw.display_name) ?? null,
+    is_live: typeof raw.is_live === 'boolean' ? raw.is_live : undefined,
+    archived_reason: asString(raw.archived_reason) ?? null,
     status: asString(raw.status),
-    where: asString(raw.where) ?? null,
-    with_whom: extractArray(raw.with_whom)
-      .map(item => (typeof item === 'string' ? item.trim() : ''))
-      .filter(Boolean),
     current_work: asString(raw.current_work) ?? null,
     related_session_id: asString(raw.related_session_id) ?? null,
-    related_attention_count: asNumber(raw.related_attention_count) ?? 0,
     last_activity_at: asString(raw.last_activity_at) ?? null,
     recent_output_preview: asString(raw.recent_output_preview) ?? null,
     recent_input_preview: asString(raw.recent_input_preview) ?? null,
-    recent_event: asString(raw.recent_event) ?? null,
-    recent_tool_names: extractArray(raw.recent_tool_names)
-      .map(item => (typeof item === 'string' ? item.trim() : ''))
-      .filter(Boolean),
-    allowed_tool_names: extractArray(raw.allowed_tool_names)
-      .map(item => (typeof item === 'string' ? item.trim() : ''))
-      .filter(Boolean),
-    latest_tool_names: extractArray(raw.latest_tool_names)
-      .map(item => (typeof item === 'string' ? item.trim() : ''))
-      .filter(Boolean),
-    latest_tool_call_count: asNumber(raw.latest_tool_call_count) ?? null,
-    tool_audit_source: asString(raw.tool_audit_source) ?? null,
-    tool_audit_at: asString(raw.tool_audit_at) ?? null,
   }
 }
 

--- a/dashboard/src/store.ts
+++ b/dashboard/src/store.ts
@@ -8,6 +8,8 @@ import type {
   Task,
   Message,
   Keeper,
+  KeeperMetricPoint,
+  KeeperDiagnostic,
   BoardPost,
   ServerStatus,
   PerpetualStatus,
@@ -22,7 +24,6 @@ import type {
   DashboardSemanticPanel,
   DashboardSemanticSurfaceId,
   DashboardExecutionHandoff,
-  DashboardExecutionSummary,
   DashboardExecutionQueueItem,
   DashboardExecutionSessionBrief,
   DashboardExecutionOperationBrief,
@@ -41,12 +42,7 @@ import {
   fetchTrpgState,
 } from './api'
 import { journal } from './sse'
-import { normalizeLodgeRuntimeStatus } from './keeper-runtime'
-import {
-  deriveLifecycleState,
-  keeperFreshnessTs,
-  normalizeKeepers,
-} from './keeper-store-normalize'
+import { deriveKeeperDiagnostic, normalizeLodgeRuntimeStatus } from './keeper-runtime'
 import { buildAgentMotion, type AgentMotionSnapshot } from './components/common/agent-motion'
 import { isRecord, asString, asNumber, asStringArray, toIsoTimestamp } from './components/common/normalize'
 
@@ -58,7 +54,6 @@ export const messages = signal<Message[]>([])
 export const keepers = signal<Keeper[]>([])
 export const serverStatus = signal<ServerStatus | null>(null)
 export const perpetualStatus = signal<PerpetualStatus | null>(null)
-export const executionSummary = signal<DashboardExecutionSummary | null>(null)
 export const executionQueue = signal<DashboardExecutionQueueItem[]>([])
 export const executionSessionBriefs = signal<DashboardExecutionSessionBrief[]>([])
 export const executionOperationBriefs = signal<DashboardExecutionOperationBrief[]>([])
@@ -154,15 +149,30 @@ export const agentMotionMap: ReadonlySignal<Map<string, AgentMotionSnapshot>> = 
   return map
 })
 
+// --- Keeper lifecycle derivation ---
+
+export function deriveLifecycleState(keeper: Keeper): KeeperLifecycleState {
+  const status = keeper.status?.toLowerCase() ?? ''
+  if (status === 'offline' || status === 'inactive') return 'offline'
+
+  const series = keeper.metrics_series
+  if (!series || series.length === 0) {
+    return 'idle'
+  }
+  const latest = series[series.length - 1]
+  if (!latest) return 'idle'
+  if (latest.is_handoff) return 'handoff-imminent'
+  if (latest.is_compaction) return 'compacting'
+  const ratio = latest.context_ratio
+  if (ratio > 0.85) return 'handoff-imminent'
+  if (ratio > 0.70) return 'preparing'
+  if (ratio > 0.50) return 'compacting'
+  return 'active'
+}
+
 export const keeperLifecycles: ReadonlySignal<Map<string, KeeperLifecycleState>> = computed(() => {
   const map = new Map<string, KeeperLifecycleState>()
   for (const k of keepers.value) {
-    const status = k.status?.toLowerCase() ?? ''
-    if (status === 'offline' || status === 'inactive') {
-      map.set(k.name, 'offline')
-      continue
-    }
-    if (!k.metrics_series || k.metrics_series.length === 0) continue
     map.set(k.name, deriveLifecycleState(k))
   }
   return map
@@ -170,6 +180,25 @@ export const keeperLifecycles: ReadonlySignal<Map<string, KeeperLifecycleState>>
 
 // Heartbeat staleness threshold (120 seconds)
 const HEARTBEAT_STALE_MS = 120_000
+
+function keeperFreshnessTs(keeper: Keeper, heartbeats: Map<string, number>): number | null {
+  const mapped = heartbeats.get(keeper.name)
+  if (mapped != null) return mapped
+
+  const direct = keeper.last_heartbeat ? Date.parse(keeper.last_heartbeat) : Number.NaN
+  if (!Number.isNaN(direct)) return direct
+
+  const ageSeconds = [
+    keeper.last_turn_ago_s,
+    keeper.last_proactive_ago_s,
+    keeper.last_handoff_ago_s,
+    keeper.last_compaction_ago_s,
+  ].find(value => typeof value === 'number' && Number.isFinite(value) && value >= 0)
+
+  return typeof ageSeconds === 'number'
+    ? Date.now() - (ageSeconds * 1000)
+    : null
+}
 
 export const staleKeepers: ReadonlySignal<Set<string>> = computed(() => {
   const now = Date.now()
@@ -291,26 +320,6 @@ function normalizeExecutionTone(value: unknown): DashboardExecutionQueueItem['se
   const raw = typeof value === 'string' ? value.toLowerCase() : ''
   if (raw === 'ok' || raw === 'warn' || raw === 'bad') return raw
   return 'ok'
-}
-
-function normalizeExecutionSummary(raw: unknown): DashboardExecutionSummary | null {
-  if (!isRecord(raw)) return null
-  return {
-    active_sessions: asNumber(raw.active_sessions),
-    blocked_sessions: asNumber(raw.blocked_sessions),
-    active_operations: asNumber(raw.active_operations),
-    blocked_operations: asNumber(raw.blocked_operations),
-    runtime_pressure: asNumber(raw.runtime_pressure),
-    worker_alerts: asNumber(raw.worker_alerts),
-    continuity_alerts: asNumber(raw.continuity_alerts),
-    priority_items: asNumber(raw.priority_items),
-    todo_tasks: asNumber(raw.todo_tasks),
-    claimed_tasks: asNumber(raw.claimed_tasks),
-    running_tasks: asNumber(raw.running_tasks),
-    done_tasks: asNumber(raw.done_tasks),
-    cancelled_tasks: asNumber(raw.cancelled_tasks),
-    keepers: asNumber(raw.keepers),
-  }
 }
 
 function normalizeExecutionHandoff(raw: unknown): DashboardExecutionHandoff | null {
@@ -544,6 +553,205 @@ function mergeMessages(current: Message[], incoming: Message[]): Message[] {
     .sort((a, b) => messageSortKey(a) - messageSortKey(b))
     .slice(-500)
 }
+
+function normalizeMetricsSeries(raw: unknown): KeeperMetricPoint[] {
+  if (!Array.isArray(raw)) return []
+  return raw
+    .map((item): KeeperMetricPoint | null => {
+      if (!isRecord(item)) return null
+      const ts = asNumber(item.ts_unix)
+      if (ts == null) return null
+      const handoffObj = isRecord(item.handoff) ? item.handoff : null
+      return {
+        ts,
+        context_ratio: asNumber(item.context_ratio) ?? 0,
+        context_tokens: asNumber(item.context_tokens) ?? 0,
+        context_max: asNumber(item.context_max) ?? 0,
+        latency_ms: asNumber(item.latency_ms) ?? 0,
+        generation: asNumber(item.generation) ?? 0,
+        channel: typeof item.channel === 'string' ? item.channel : 'turn',
+        is_handoff: handoffObj != null && item.handoff_performed === true,
+        is_compaction: item.compacted === true,
+        compaction_saved_tokens: asNumber(item.compaction_saved_tokens) ?? 0,
+        compaction_trigger: typeof item.compaction_trigger === 'string' ? item.compaction_trigger : null,
+        model_used: typeof item.model_used === 'string' ? item.model_used : '',
+        cost_usd: asNumber(item.cost_usd) ?? 0,
+        handoff_to_model: handoffObj ? (typeof handoffObj.to_model === 'string' ? handoffObj.to_model : null) : null,
+        handoff_new_generation: handoffObj ? (asNumber(handoffObj.new_generation) ?? null) : null,
+      }
+    })
+    .filter((item): item is KeeperMetricPoint => item !== null)
+}
+
+function normalizeKeeperDiagnostic(raw: unknown): KeeperDiagnostic | null {
+  if (!isRecord(raw)) return null
+  const healthState = asString(raw.health_state)
+  const nextActionPath = asString(raw.next_action_path)
+  const lastReplyStatus = asString(raw.last_reply_status)
+  if (!healthState || !nextActionPath || !lastReplyStatus) return null
+  const quietReason = (asString(raw.quiet_reason) ?? null) as KeeperDiagnostic['quiet_reason']
+  const summary =
+    asString(raw.summary)
+    ?? (
+      healthState === 'offline' || healthState === 'degraded' || healthState === 'stale'
+        ? 'Keeper is not in a healthy reply state. Probe or recover before relying on automation.'
+        : quietReason === 'quiet_hours'
+          ? 'Lodge quiet hours are active. Direct messages still work, but scheduled social ticks may look asleep.'
+          : quietReason === 'min_gap'
+            ? 'Keeper is inside its proactive cooldown window. Direct messages work now; autonomous check-ins will wait.'
+            : quietReason === 'never_started'
+              ? 'Keeper metadata exists but no reply turn has been recorded yet.'
+              : 'Keeper is reachable. Send a direct message for an immediate response.'
+    )
+  return {
+    health_state: healthState as KeeperDiagnostic['health_state'],
+    quiet_reason: quietReason,
+    next_action_path: nextActionPath as KeeperDiagnostic['next_action_path'],
+    last_reply_status: lastReplyStatus as KeeperDiagnostic['last_reply_status'],
+    last_reply_at: toIsoTimestamp(raw.last_reply_at) ?? asString(raw.last_reply_at) ?? null,
+    last_reply_preview: asString(raw.last_reply_preview) ?? null,
+    last_error: asString(raw.last_error) ?? null,
+    next_eligible_at_s: asNumber(raw.next_eligible_at_s) ?? null,
+    recoverable:
+      typeof raw.recoverable === 'boolean'
+        ? raw.recoverable
+        : nextActionPath === 'recover',
+    summary,
+    keepalive_running:
+      typeof raw.keepalive_running === 'boolean' ? raw.keepalive_running : undefined,
+  }
+}
+
+function normalizeKeepers(raw: unknown, serverStatusValue?: ServerStatus | null): Keeper[] {
+  const rows =
+    Array.isArray(raw)
+      ? raw
+      : isRecord(raw) && Array.isArray(raw.keepers)
+        ? raw.keepers
+        : []
+
+  return rows
+    .map((row): Keeper | null => {
+      if (!isRecord(row)) return null
+      const agentRaw = isRecord(row.agent) ? row.agent : null
+      const contextRaw = isRecord(row.context) ? row.context : null
+      const metricsWindowRaw = isRecord(row.metrics_window) ? row.metrics_window : undefined
+
+      const name = asString(row.name)
+      if (!name) return null
+
+      const contextRatio = asNumber(row.context_ratio) ?? asNumber(contextRaw?.context_ratio)
+      const statusRaw = asString(row.status) ?? asString(agentRaw?.status) ?? 'offline'
+      const status = normalizeAgentStatus(statusRaw)
+      const model = asString(row.model) ?? asString(row.active_model) ?? asString(row.primary_model)
+      const skillSecondary = asStringArray(row.skill_secondary)
+
+      const normalizedContext =
+        contextRaw
+          ? {
+              source: asString(contextRaw.source),
+              context_ratio: asNumber(contextRaw.context_ratio),
+              context_tokens: asNumber(contextRaw.context_tokens),
+              context_max: asNumber(contextRaw.context_max),
+              message_count: asNumber(contextRaw.message_count),
+              has_checkpoint: typeof contextRaw.has_checkpoint === 'boolean' ? contextRaw.has_checkpoint : undefined,
+            }
+          : undefined
+
+      const normalizedAgent =
+        agentRaw
+          ? {
+              name: asString(agentRaw.name),
+              exists: typeof agentRaw.exists === 'boolean' ? agentRaw.exists : undefined,
+              error: asString(agentRaw.error),
+              agent_type: asString(agentRaw.agent_type),
+              status: asString(agentRaw.status),
+              current_task: asString(agentRaw.current_task) ?? null,
+              joined_at: asString(agentRaw.joined_at),
+              last_seen: asString(agentRaw.last_seen),
+              last_seen_ago_s: asNumber(agentRaw.last_seen_ago_s),
+              capabilities: asStringArray(agentRaw.capabilities),
+              is_zombie: typeof agentRaw.is_zombie === 'boolean' ? agentRaw.is_zombie : undefined,
+            }
+          : undefined
+
+      const metricsSeries = normalizeMetricsSeries(row.metrics_series)
+
+      const keeper: Keeper = {
+        name,
+        runtime_class:
+          row.runtime_class === 'persistent_agent' ? 'persistent_agent' : 'resident_keeper',
+        desired:
+          typeof row.desired === 'boolean' ? row.desired : undefined,
+        resident_registered:
+          typeof row.resident_registered === 'boolean' ? row.resident_registered : undefined,
+        reconcile_status: asString(row.reconcile_status) ?? null,
+        emoji: asString(row.emoji),
+        koreanName: asString(row.koreanName) ?? asString(row.korean_name),
+        agent_name: asString(row.agent_name),
+        trace_id: asString(row.trace_id),
+        model,
+        primary_model: asString(row.primary_model),
+        active_model: asString(row.active_model),
+        next_model_hint: asString(row.next_model_hint) ?? null,
+        status,
+        presence_keepalive:
+          typeof row.presence_keepalive === 'boolean' ? row.presence_keepalive : undefined,
+        presence_keepalive_sec: asNumber(row.presence_keepalive_sec),
+        keepalive_running:
+          typeof row.keepalive_running === 'boolean' ? row.keepalive_running : undefined,
+        proactive_enabled:
+          typeof row.proactive_enabled === 'boolean' ? row.proactive_enabled : undefined,
+        proactive_idle_sec: asNumber(row.proactive_idle_sec),
+        proactive_cooldown_sec: asNumber(row.proactive_cooldown_sec),
+        last_heartbeat: asString(row.last_heartbeat) ?? asString(agentRaw?.last_seen),
+        generation: asNumber(row.generation),
+        turn_count: asNumber(row.turn_count) ?? asNumber(row.total_turns),
+        keeper_age_s: asNumber(row.keeper_age_s),
+        last_turn_ago_s: asNumber(row.last_turn_ago_s),
+        last_handoff_ago_s: asNumber(row.last_handoff_ago_s),
+        last_compaction_ago_s: asNumber(row.last_compaction_ago_s),
+        last_proactive_ago_s: asNumber(row.last_proactive_ago_s),
+        last_proactive_preview: asString(row.last_proactive_preview) ?? null,
+        context_ratio: contextRatio,
+        context_tokens: asNumber(row.context_tokens) ?? asNumber(contextRaw?.context_tokens),
+        context_max: asNumber(row.context_max) ?? asNumber(contextRaw?.context_max),
+        context_source: asString(row.context_source) ?? asString(contextRaw?.source),
+        context: normalizedContext,
+        traits: asStringArray(row.traits),
+        interests: asStringArray(row.interests),
+        primaryValue: asString(row.primaryValue) ?? asString(row.primary_value),
+        activityLevel: asNumber(row.activityLevel) ?? asNumber(row.activity_level),
+        memory_recent_note: asString(row.memory_recent_note) ?? null,
+        recent_input_preview: asString(row.recent_input_preview) ?? null,
+        recent_output_preview: asString(row.recent_output_preview) ?? null,
+        recent_tool_names: asStringArray(row.recent_tool_names) ?? [],
+        allowed_tool_names: asStringArray(row.allowed_tool_names) ?? [],
+        latest_tool_names: asStringArray(row.latest_tool_names) ?? [],
+        latest_tool_call_count: asNumber(row.latest_tool_call_count) ?? null,
+        tool_audit_source: asString(row.tool_audit_source) ?? null,
+        tool_audit_at: toIsoTimestamp(row.tool_audit_at) ?? asString(row.tool_audit_at) ?? null,
+        conversation_tail_count: asNumber(row.conversation_tail_count),
+        k2k_count: asNumber(row.k2k_count),
+        handoff_count_total: asNumber(row.handoff_count_total) ?? asNumber(row.trace_history_count),
+        compaction_count: asNumber(row.compaction_count),
+        last_compaction_saved_tokens: asNumber(row.last_compaction_saved_tokens),
+        diagnostic: normalizeKeeperDiagnostic(row.diagnostic),
+        skill_primary: asString(row.skill_primary) ?? null,
+        skill_secondary: skillSecondary,
+        skill_reason: asString(row.skill_reason) ?? null,
+        metrics_series: metricsSeries.length > 0 ? metricsSeries : undefined,
+        metrics_window: metricsWindowRaw as Keeper['metrics_window'],
+        agent: normalizedAgent,
+      }
+      keeper.diagnostic =
+        normalizeKeeperDiagnostic(row.diagnostic)
+        ?? deriveKeeperDiagnostic(keeper, serverStatusValue?.lodge ?? null)
+      return keeper
+    })
+    .filter((row): row is Keeper => row !== null)
+}
+
 function normalizeBuildIdentity(raw: unknown): ServerStatus['build'] | undefined {
   if (!isRecord(raw)) return undefined
   const releaseVersion = asString(raw.release_version)
@@ -895,8 +1103,7 @@ export async function refreshExecution(): Promise<void> {
       .map(normalizeMessage)
       .filter((row): row is Message => row !== null)
     messages.value = roomChanged ? executionMessages : mergeMessages(messages.value, executionMessages)
-    keepers.value = normalizeKeepers(data.keepers)
-    executionSummary.value = normalizeExecutionSummary(data.summary)
+    keepers.value = normalizeKeepers(data.keepers, normalizedStatus ?? serverStatus.value)
     executionLodgeTick.value = normalizeExecutionLodgeTick(data.lodge_tick)
     executionLodgeCheckins.value = (Array.isArray(data.lodge_checkins) ? data.lodge_checkins : [])
       .map(normalizeExecutionLodgeCheckin)

--- a/dashboard/src/types.ts
+++ b/dashboard/src/types.ts
@@ -214,12 +214,6 @@ export type KeeperReplyStatus =
   | 'error'
   | 'unknown'
 
-export type KeeperContinuityState =
-  | 'desired_offline'
-  | 'recovering'
-  | 'healthy'
-  | 'offline'
-
 export interface KeeperDiagnostic {
   health_state: KeeperHealthState
   quiet_reason?: KeeperQuietReason | null
@@ -232,8 +226,6 @@ export interface KeeperDiagnostic {
   recoverable?: boolean
   summary?: string
   keepalive_running?: boolean
-  continuity_state?: KeeperContinuityState | null
-  continuity_summary?: string | null
 }
 
 export type KeeperConversationRole = 'user' | 'assistant' | 'system' | 'tool' | 'other'
@@ -962,11 +954,6 @@ export interface DashboardExecutionSummary {
   worker_alerts?: number
   continuity_alerts?: number
   priority_items?: number
-  todo_tasks?: number
-  claimed_tasks?: number
-  running_tasks?: number
-  done_tasks?: number
-  cancelled_tasks?: number
   keepers?: number
 }
 
@@ -1118,7 +1105,6 @@ export interface DashboardExecutionContinuityBrief {
 export interface DashboardExecutionResponse {
   generated_at?: string
   status?: ServerStatus
-  summary?: DashboardExecutionSummary
   lodge_tick?: DashboardExecutionLodgeTick | null
   lodge_checkins?: unknown[]
   execution_queue?: unknown[]
@@ -1193,16 +1179,6 @@ export interface DashboardMissionSummary {
   cluster?: string
   project?: string
   current_room?: string | null
-  paused?: boolean
-  tempo_interval_s?: number
-  active_agents?: number
-  keeper_pressure?: number
-  active_operations?: number
-  pending_approvals?: number
-  incident_count?: number
-  recommended_action_count?: number
-  top_attention?: OperatorAttentionItem | null
-  top_action?: OperatorRecommendedAction | null
 }
 
 export interface DashboardMissionCommandFocus {
@@ -1259,11 +1235,11 @@ export interface DashboardMissionSessionBrief {
 
 export interface DashboardMissionParticipantPreview {
   agent_name: string
-  status?: string
+  display_name?: string | null
+  is_live?: boolean
   current_work?: string | null
   recent_input_preview?: string | null
   recent_output_preview?: string | null
-  recent_tool_names: string[]
   last_activity_at?: string | null
 }
 
@@ -1294,22 +1270,15 @@ export interface DashboardMissionSessionCard extends DashboardMissionSessionBrie
 
 export interface DashboardMissionAgentBrief {
   agent_name: string
+  display_name?: string | null
+  is_live?: boolean
+  archived_reason?: string | null
   status?: string
-  where?: string | null
-  with_whom: string[]
   current_work?: string | null
   related_session_id?: string | null
-  related_attention_count: number
   last_activity_at?: string | null
   recent_output_preview?: string | null
   recent_input_preview?: string | null
-  recent_event?: string | null
-  recent_tool_names: string[]
-  allowed_tool_names?: string[]
-  latest_tool_names?: string[]
-  latest_tool_call_count?: number | null
-  tool_audit_source?: string | null
-  tool_audit_at?: string | null
 }
 
 export interface DashboardMissionKeeperBrief {

--- a/lib/dashboard_execution.ml
+++ b/lib/dashboard_execution.ml
@@ -382,24 +382,6 @@ let execution_smoke_fixture_json () =
             ("lodge", `Assoc []);
             ("version", `String Version.version);
           ] );
-      ( "summary",
-        `Assoc
-          [
-            ("active_sessions", `Int 2);
-            ("blocked_sessions", `Int 1);
-            ("active_operations", `Int 2);
-            ("blocked_operations", `Int 2);
-            ("runtime_pressure", `Int 3);
-            ("worker_alerts", `Int 2);
-            ("continuity_alerts", `Int 1);
-            ("priority_items", `Int 2);
-            ("todo_tasks", `Int 1);
-            ("claimed_tasks", `Int 1);
-            ("running_tasks", `Int 1);
-            ("done_tasks", `Int 0);
-            ("cancelled_tasks", `Int 0);
-            ("keepers", `Int 1);
-          ] );
       ( "lodge_tick",
         `Assoc
           [
@@ -1965,76 +1947,10 @@ let json ?actor ?fixture ~config ~sw ~clock ~proc_mgr () =
       let lodge_tick_summary, lodge_checkins =
         build_lodge_checkins (Lodge_heartbeat.lodge_status ())
       in
-      let blocked_sessions =
-        session_contexts
-        |> List.fold_left
-             (fun acc (session : session_context) ->
-               if session.severity <> "ok" then acc + 1 else acc)
-             0
-      in
-      let active_operations =
-        operation_contexts
-        |> List.fold_left
-             (fun acc (operation : operation_context) ->
-               let status = string_field "status" operation.json in
-               if List.mem status [ "active"; "paused" ] then acc + 1 else acc)
-             0
-      in
-      let blocked_operations =
-        operation_contexts
-        |> List.fold_left
-             (fun acc (operation : operation_context) ->
-               if operation.severity <> "ok" then acc + 1 else acc)
-             0
-      in
-      let worker_alerts =
-        worker_rows
-        |> List.fold_left
-             (fun acc (row : worker_context) ->
-               if string_field "tone" row.json <> "ok" then acc + 1 else acc)
-             0
-      in
-      let continuity_alerts =
-        continuity_rows
-        |> List.fold_left
-             (fun acc (row : continuity_context) ->
-               if string_field "tone" row.json <> "ok" then acc + 1 else acc)
-             0
-      in
-      let (todo_count, claimed_count, running_count, done_count, cancelled_count) =
-        List.fold_left
-          (fun (todo, claimed, running, done_items, cancelled) (task : Types.task) ->
-            match task.task_status with
-            | Todo -> (todo + 1, claimed, running, done_items, cancelled)
-            | Claimed _ -> (todo, claimed + 1, running, done_items, cancelled)
-            | InProgress _ -> (todo, claimed, running + 1, done_items, cancelled)
-            | Done _ -> (todo, claimed, running, done_items + 1, cancelled)
-            | Cancelled _ -> (todo, claimed, running, done_items, cancelled + 1))
-          (0, 0, 0, 0, 0)
-          tasks
-      in
       `Assoc
         [
           ("generated_at", `String (Types.now_iso ()));
           ("status", room_status_json config);
-          ( "summary",
-            `Assoc
-              [
-                ("active_sessions", `Int (List.length session_contexts));
-                ("blocked_sessions", `Int blocked_sessions);
-                ("active_operations", `Int active_operations);
-                ("blocked_operations", `Int blocked_operations);
-                ("runtime_pressure", `Int (List.length execution_queue));
-                ("worker_alerts", `Int worker_alerts);
-                ("continuity_alerts", `Int continuity_alerts);
-                ("priority_items", `Int (List.length execution_queue));
-                ("todo_tasks", `Int todo_count);
-                ("claimed_tasks", `Int claimed_count);
-                ("running_tasks", `Int running_count);
-                ("done_tasks", `Int done_count);
-                ("cancelled_tasks", `Int cancelled_count);
-                ("keepers", `Int (List.length continuity_rows));
-              ] );
           ("lodge_tick", option_to_json (fun value -> value) lodge_tick_summary);
           ("lodge_checkins", `List (List.map (fun (row : lodge_checkin_context) -> row.json) lodge_checkins));
           ("execution_queue", `List (List.map (fun (row : queue_context) -> row.json) execution_queue));

--- a/lib/dashboard_mission.ml
+++ b/lib/dashboard_mission.ml
@@ -53,6 +53,10 @@ type operation_context = {
   updated_at : string option;
 }
 
+type archived_agent_meta = {
+  last_event_at : string option;
+}
+
 let json_string_option value =
   match value with
   | Some text when String.trim text <> "" -> `String (String.trim text)
@@ -72,18 +76,6 @@ let int_field ?(default = 0) key json =
   | `Int value -> value
   | `Intlit raw -> (try int_of_string raw with Failure _ -> default)
   | `Float value -> int_of_float value
-  | _ -> default
-
-let float_field ?(default = 0.0) key json =
-  match member_assoc key json with
-  | `Float value -> value
-  | `Int value -> float_of_int value
-  | `Intlit raw -> (try float_of_string raw with Failure _ -> default)
-  | _ -> default
-
-let bool_field ?(default = false) key json =
-  match member_assoc key json with
-  | `Bool value -> value
   | _ -> default
 
 let string_field ?(default = "") key json =
@@ -133,50 +125,6 @@ let compact_text ?(max_len = 160) raw =
 let string_list_json values =
   `List (List.map (fun value -> `String value) values)
 
-let tool_audit_json_fields agent_name =
-  let task_snapshot = A2a_tools.latest_heartbeat_task agent_name in
-  let result_snapshot = A2a_tools.latest_heartbeat_result agent_name in
-  let allowed_tool_names, latest_tool_names, latest_tool_call_count,
-      tool_audit_source, tool_audit_at =
-    match task_snapshot, result_snapshot with
-    | Some task, Some result ->
-        if task.seq > result.seq
-        then
-          ( task.allowed_tools,
-            result.tool_names,
-            Some result.tool_call_count,
-            Some "heartbeat_task_pending_result",
-            Some task.created_at )
-        else
-          ( task.allowed_tools,
-            result.tool_names,
-            Some result.tool_call_count,
-            Some "heartbeat_result",
-            Some result.updated_at )
-    | Some task, None ->
-        ( task.allowed_tools,
-          [],
-          None,
-          Some "heartbeat_task",
-          Some task.created_at )
-    | None, Some result ->
-        ( [],
-          result.tool_names,
-          Some result.tool_call_count,
-          Some "heartbeat_result",
-          Some result.updated_at )
-    | None, None ->
-        ([], [], None, None, None)
-  in
-  [
-    ("allowed_tool_names", string_list_json allowed_tool_names);
-    ("latest_tool_names", string_list_json latest_tool_names);
-    ( "latest_tool_call_count",
-      option_to_json (fun value -> `Int value) latest_tool_call_count );
-    ("tool_audit_source", json_string_option tool_audit_source);
-    ("tool_audit_at", json_string_option tool_audit_at);
-  ]
-
 let keeper_tool_audit_json_fields keeper agent_name =
   let fallback_allowed =
     Dashboard_utils.string_list_of_json (member_assoc "allowed_tool_names" keeper)
@@ -191,7 +139,10 @@ let keeper_tool_audit_json_fields keeper agent_name =
     | _ -> None
   in
   let fallback_source =
-    trim_to_option (string_field "tool_audit_source" keeper)
+    match trim_to_option (string_field "tool_audit_source" keeper) with
+    | Some _ as value -> value
+    | None when fallback_allowed <> [] -> Some "keeper_policy"
+    | None -> None
   in
   let fallback_at =
     trim_to_option (string_field "tool_audit_at" keeper)
@@ -233,11 +184,6 @@ let keeper_tool_audit_json_fields keeper agent_name =
     ("tool_audit_at", json_string_option tool_audit_at);
   ]
 
-let recent_tool_names_for_agent agent_name =
-  match A2a_tools.latest_heartbeat_result agent_name with
-  | Some snapshot -> snapshot.tool_names
-  | None -> []
-
 let parse_iso_opt = Dashboard_utils.parse_iso_opt
 let string_list_of_json = Dashboard_utils.string_list_of_json
 
@@ -252,35 +198,6 @@ let top_item items =
   match items with
   | item :: _ -> item
   | [] -> `Null
-
-let keeper_pressure_count snapshot_json =
-  let keepers = member_assoc "keepers" snapshot_json |> member_assoc "items" |> function
-    | `List items -> items
-    | _ -> []
-  in
-  List.fold_left
-    (fun acc keeper ->
-      let status = string_field ~default:"unknown" "status" keeper in
-      let context_ratio = float_field "context_ratio" keeper in
-      let last_turn_ago_s = float_field "last_turn_ago_s" keeper in
-      if List.mem status [ "offline"; "inactive"; "error" ]
-         || context_ratio >= 0.80
-         || last_turn_ago_s >= 3600.0
-      then acc + 1
-      else acc)
-    0 keepers
-
-let active_agent_count config =
-  if not (Room.is_initialized config) then
-    0
-  else
-    Room.get_agents_raw config
-    |> List.fold_left
-         (fun acc (agent : Types.agent) ->
-           match agent.status with
-           | Types.Active | Types.Busy | Types.Listening -> acc + 1
-           | Types.Inactive -> acc)
-         0
 
 let session_payload_json session_json =
   match member_assoc "status" session_json with
@@ -777,17 +694,139 @@ let latest_message_to agent_name messages =
             if message.seq >= current.seq then Some message else best)
     None messages
 
-let build_agent_briefs config sessions attention_queue room_json =
+let read_recent_room_event_lines config ~limit =
+  let events_dir = Filename.concat (Room.masc_dir config) "events" in
+  if not (Sys.file_exists events_dir) then []
+  else
+    let month_dirs =
+      Sys.readdir events_dir |> Array.to_list |> List.sort compare |> List.rev
+    in
+    let collected = ref [] in
+    let remaining = ref limit in
+    let read_lines path =
+      let ic = open_in path in
+      Fun.protect
+        ~finally:(fun () -> close_in_noerr ic)
+        (fun () ->
+          let rec loop acc =
+            match input_line ic with
+            | line -> loop (line :: acc)
+            | exception End_of_file -> List.rev acc
+          in
+          loop [])
+    in
+    let add_lines path =
+      if !remaining <= 0 then ()
+      else
+        let lines = read_lines path in
+        let rec take lines_rev =
+          match lines_rev with
+          | [] -> ()
+          | line :: rest ->
+              if !remaining > 0 then (
+                collected := line :: !collected;
+                decr remaining;
+                take rest)
+        in
+        take (List.rev lines)
+    in
+    List.iter
+      (fun month ->
+        if !remaining > 0 then
+          let month_path = Filename.concat events_dir month in
+          if Sys.file_exists month_path && Sys.is_directory month_path then
+            let files =
+              Sys.readdir month_path |> Array.to_list |> List.sort compare |> List.rev
+            in
+            List.iter
+              (fun file ->
+                if !remaining > 0 then
+                  let path = Filename.concat month_path file in
+                  if Sys.file_exists path then add_lines path)
+              files)
+      month_dirs;
+    List.rev !collected
+
+let status_of_archived_session (session : session_context option) =
+  match session with
+  | Some session ->
+      if List.mem session.status [ "completed"; "interrupted"; "cancelled" ]
+      then "inactive"
+      else "offline"
+  | None -> "unknown"
+
+let archived_reason_for_session (session : session_context option) =
+  match session with
+  | Some session ->
+      Some
+        (if List.mem session.status [ "completed"; "interrupted"; "cancelled" ]
+         then "not in current room state"
+         else "missing from current room state")
+  | None -> None
+
+let archived_agent_meta_map config agent_names =
+  let wanted = Hashtbl.create (List.length agent_names) in
+  List.iter (fun agent_name -> Hashtbl.replace wanted agent_name ()) agent_names;
+  let table = Hashtbl.create (List.length agent_names) in
+  let ensure_row agent_name =
+    match Hashtbl.find_opt table agent_name with
+    | Some row -> row
+    | None ->
+        let row =
+          {
+            last_event_at = None;
+          }
+        in
+        Hashtbl.add table agent_name row;
+        row
+  in
+  read_recent_room_event_lines config ~limit:2000
+  |> List.rev
+  |> List.iter (fun line ->
+         try
+           let json = Yojson.Safe.from_string line in
+           let agent_name = string_field "agent" json in
+           if agent_name <> "" && Hashtbl.mem wanted agent_name then (
+             let row = ensure_row agent_name in
+             let last_event_at =
+               match trim_to_option (string_field "ts" json) with
+               | Some _ as value -> value
+               | None -> trim_to_option (string_field "timestamp" json)
+             in
+             let row =
+               if row.last_event_at = None
+               then { last_event_at }
+               else row
+             in
+             Hashtbl.replace table agent_name row)
+         with Yojson.Json_error _ -> ());
+  table
+
+let keeper_alias_by_agent_name snapshot_json =
+  let table = Hashtbl.create 8 in
+  let keepers =
+    match member_assoc "keepers" snapshot_json |> member_assoc "items" with
+    | `List items -> items
+    | _ -> []
+  in
+  List.iter
+    (fun keeper ->
+      let keeper_name = trim_to_option (string_field "name" keeper) in
+      let agent_name = trim_to_option (string_field "agent_name" keeper) in
+      match keeper_name, agent_name with
+      | Some keeper_name, Some agent_name ->
+          Hashtbl.replace table agent_name keeper_name
+      | _ -> ())
+    keepers;
+  table
+
+let build_agent_briefs config sessions attention_queue _room_json snapshot_json =
   let task_lookup = build_task_lookup config in
   let messages =
     if Room.is_initialized config then
       Room.get_messages_raw config ~since_seq:0 ~limit:200
     else
       []
-  in
-  let current_room =
-    trim_to_option (string_field "current_room" room_json)
-    |> Option.value ~default:"room"
   in
   let task_label task_id =
     match task_id with
@@ -809,6 +848,8 @@ let build_agent_briefs config sessions attention_queue room_json =
       (List.map (fun (agent : Types.agent) -> agent.name) room_agents
       @ List.concat_map (fun (session : session_context) -> session.member_names) sessions)
   in
+  let archived_meta_by_name = archived_agent_meta_map config agent_names in
+  let keeper_aliases = keeper_alias_by_agent_name snapshot_json in
   agent_names
   |> List.map (fun agent_name ->
          let agent = List.assoc_opt agent_name room_agent_by_name in
@@ -831,26 +872,12 @@ let build_agent_briefs config sessions attention_queue room_json =
          in
          let latest_out = latest_message_from agent_name messages in
          let latest_in = latest_message_to agent_name messages in
-         let where =
-           match related_session with
-           | Some session ->
-               compact_text
-                 (session.goal
-                 ^
-                 match session.room with
-                 | Some room -> " · " ^ room
-                 | None -> "")
-           | None -> current_room
-         in
-         let with_whom =
-           match related_session with
-           | Some session ->
-               session.member_names
-               |> List.filter (fun name -> not (String.equal name agent_name))
-           | None -> []
-         in
          let current_work =
            task_label (Option.bind agent (fun value -> value.current_task))
+         in
+         let archived_meta = Hashtbl.find_opt archived_meta_by_name agent_name in
+         let display_name =
+           Hashtbl.find_opt keeper_aliases agent_name |> Option.value ~default:agent_name
          in
          let recent_output_preview =
            latest_out |> Option.map (fun (message : Types.message) -> compact_text message.content)
@@ -858,53 +885,53 @@ let build_agent_briefs config sessions attention_queue room_json =
          let recent_input_preview =
            latest_in |> Option.map (fun (message : Types.message) -> compact_text message.content)
          in
-         let recent_event =
-           related_session |> Option.map (fun session -> session.last_event_summary)
-         in
          let status =
            match agent with
            | Some value -> Types.agent_status_to_string value.status
-           | None ->
-               if Option.is_some related_session then "active" else "unknown"
+           | None -> status_of_archived_session related_session
          in
          let last_activity_at =
            match agent with
            | Some value -> trim_to_option value.last_seen
-           | None ->
-               (match related_session with
-               | Some session -> session.last_event_at
-               | None -> None)
+            | None ->
+               (match archived_meta with
+               | Some meta when meta.last_event_at <> None -> meta.last_event_at
+               | _ ->
+                   match related_session with
+                   | Some session -> session.last_event_at
+                   | None -> None)
          in
          let last_seen_ts =
            match agent with
-           | Some value ->
-               parse_iso_opt (trim_to_option value.last_seen) |> Option.value ~default:0.0
-           | None ->
-               (match related_session with
-               | Some session -> session.last_event_ts
-               | None -> 0.0)
+            | Some value ->
+                parse_iso_opt (trim_to_option value.last_seen) |> Option.value ~default:0.0
+            | None ->
+                (match related_session with
+                | Some session -> session.last_event_ts
+                | None -> 0.0)
          in
          ({
            status_rank = status_rank status;
            related_attention_count;
            last_seen_ts;
            json =
-             `Assoc
-               ([
-                  ("agent_name", `String agent_name);
+              `Assoc
+                ([
+                   ("agent_name", `String agent_name);
+                  ("display_name", `String display_name);
+                  ("is_live", `Bool (Option.is_some agent));
+                  ( "archived_reason",
+                    json_string_option
+                      (if Option.is_some agent
+                       then None
+                       else archived_reason_for_session related_session) );
                   ("status", `String status);
-                  ("where", `String where);
-                  ("with_whom", `List (List.map (fun value -> `String value) with_whom));
                   ("current_work", json_string_option current_work);
                   ("related_session_id", json_string_option (Option.map (fun s -> s.session_id) related_session));
-                  ("related_attention_count", `Int related_attention_count);
                   ("last_activity_at", json_string_option last_activity_at);
                   ("recent_output_preview", json_string_option recent_output_preview);
                   ("recent_input_preview", json_string_option recent_input_preview);
-                  ("recent_event", json_string_option recent_event);
-                  ("recent_tool_names", string_list_json (recent_tool_names_for_agent agent_name));
-                ]
-                @ tool_audit_json_fields agent_name);
+                ]);
          } : agent_context))
   |> List.sort (fun (left : agent_context) (right : agent_context) ->
          let by_attention = Int.compare right.related_attention_count left.related_attention_count in
@@ -1143,12 +1170,12 @@ let participant_preview_json session_id member_names agent_briefs =
              (`Assoc
                [
                  ("agent_name", `String agent_name);
-                 ("status", member_assoc "status" row);
+                 ("display_name", member_assoc "display_name" row);
+                 ("is_live", member_assoc "is_live" row);
                  ("current_work", member_assoc "current_work" row);
-                 ("recent_input_preview", member_assoc "recent_input_preview" row);
-                 ("recent_output_preview", member_assoc "recent_output_preview" row);
-                 ("recent_tool_names", member_assoc "recent_tool_names" row);
-                 ("last_activity_at", member_assoc "last_activity_at" row);
+                  ("recent_input_preview", member_assoc "recent_input_preview" row);
+                  ("recent_output_preview", member_assoc "recent_output_preview" row);
+                  ("last_activity_at", member_assoc "last_activity_at" row);
                ]))
 
 let keeper_refs_for_session member_names keeper_briefs =
@@ -1260,26 +1287,6 @@ let session_timeline_json session_json =
              ("summary", `String (event_summary event_json));
            ])
 
-let summarize_queue_counts attention_queue =
-  let session_count =
-    attention_queue
-    |> List.concat_map (fun item -> item.related_session_ids)
-    |> dedup_strings
-    |> List.length
-  in
-  let agent_count =
-    attention_queue
-    |> List.concat_map (fun item -> item.related_agent_names)
-    |> dedup_strings
-    |> List.length
-  in
-  `Assoc
-    [
-      ("count", `Int (List.length attention_queue));
-      ("session_count", `Int session_count);
-      ("agent_count", `Int agent_count);
-    ]
-
 type mission_projection = {
   generated_at : string;
   snapshot_json : Yojson.Safe.t;
@@ -1355,7 +1362,9 @@ let build_projection ?actor ~config ~sw ~clock ~proc_mgr () =
   in
   let attention_queue = build_attention_queue incidents recommended_actions sessions in
   let session_briefs = build_session_briefs sessions attention_queue recommended_actions in
-  let agent_briefs = build_agent_briefs config sessions attention_queue room_json in
+  let agent_briefs =
+    build_agent_briefs config sessions attention_queue room_json snapshot_json
+  in
   let keeper_briefs = build_keeper_briefs snapshot_json in
   let internal_signals = build_internal_signals incidents recommended_actions in
   {
@@ -1390,17 +1399,6 @@ let json ?actor ~config ~sw ~clock ~proc_mgr () =
         ("cluster", json_string_option (Some (string_field "cluster" projection.room_json)));
         ("project", json_string_option (Some (string_field "project" projection.room_json)));
         ("current_room", member_assoc "current_room" projection.room_json);
-        ("paused", `Bool (bool_field "paused" projection.room_json));
-        ("tempo_interval_s", member_assoc "tempo_interval_s" projection.room_json);
-        ("active_agents", `Int (active_agent_count config));
-        ("keeper_pressure", `Int (keeper_pressure_count projection.snapshot_json));
-        ("active_operations", `Int (int_field "active" operations_summary));
-        ("pending_approvals", `Int (int_field "pending" decisions_summary));
-        ("incident_count", `Int (List.length projection.incidents));
-        ("recommended_action_count", `Int (List.length projection.recommended_actions));
-        ("top_attention", top_item projection.incidents);
-        ("top_action", top_item projection.recommended_actions);
-        ("attention_queue", summarize_queue_counts projection.attention_queue);
       ]
   in
   let command_focus_json =

--- a/lib/mcp_server_eio.ml
+++ b/lib/mcp_server_eio.ml
@@ -1565,6 +1565,10 @@ let execute_tool_eio ~sw ~clock ?mcp_session_id ?auth_token state ~name ~argumen
   match Tool_room.dispatch simple_ctx_room ~name ~args:arguments with
   | Some result -> result
   | None ->
+  let shard_ok, shard_json = Tool_shard.execute name arguments in
+  if shard_ok then
+    (true, Yojson.Safe.pretty_to_string shard_json)
+  else
   match Tool_control.dispatch simple_ctx_control ~name ~args:arguments with
   | Some result -> result
   | None ->
@@ -3289,10 +3293,6 @@ let maybe_assoc_field name = function
 let tool_output_schema_field _name = None
 
 let tool_json_for_profile ?usage_summary profile (schema : Types.tool_schema) =
-  let implementation_status =
-    Tool_catalog.implementation_status schema.name
-    |> Tool_catalog.implementation_status_to_string
-  in
   let base =
     [
       ("name", `String schema.name);
@@ -3302,10 +3302,10 @@ let tool_json_for_profile ?usage_summary profile (schema : Types.tool_schema) =
         `List
           (List.map Mcp_server.icon_to_json (tool_icons_for_name schema.name)) );
       ("inputSchema", schema.input_schema);
-      ("implementationStatus", `String implementation_status);
     ]
     @ maybe_assoc_field "outputSchema" (tool_output_schema_field schema.name)
     @ maybe_assoc_field "annotations" (tool_annotations_for_profile profile schema.name)
+    @ Tool_catalog.metadata_to_fields schema.name
     @
     match usage_summary with
     | Some summary -> Telemetry_eio.tool_usage_fields summary schema.name

--- a/lib/operator_control.ml
+++ b/lib/operator_control.ml
@@ -620,16 +620,10 @@ let keepers_json config =
               | `Bool value -> value
               | _ -> false
             in
-            let now_ts = Time_compat.now () in
             let diagnostic =
               Keeper_exec_status.keeper_diagnostic_json ~meta
                 ~agent_status:agent_json ~keepalive_running ~history_items:[]
-                ~now_ts
-              |> Keeper_exec_status.augment_keeper_diagnostic_json ~desired:true
-                   ~meta ~keepalive_running
-                   ~keepalive_started_at:
-                     (Keeper_keepalive.keeper_keepalive_started_at meta.name)
-                   ~now_ts
+                ~now_ts:(Time_compat.now ())
             in
             let allowed_tool_names, latest_tool_names, latest_tool_call_count,
                 tool_audit_source, tool_audit_at =
@@ -638,8 +632,9 @@ let keepers_json config =
             let agent_status =
               if not agent_exists then "offline"
               else
-                Keeper_exec_status.keeper_surface_status
-                  ~agent_status:agent_json ~diagnostic
+                match agent_json |> U.member "status" with
+                | `String status -> status
+                | _ -> "unknown"
             in
             Some
               (`Assoc
@@ -2939,6 +2934,23 @@ let swarm_run_chain_preview (request : action_request) swarm_json =
 let json_of_dispatch_output body =
   try Yojson.Safe.from_string body with Yojson.Json_error _ -> `String body
 
+let first_nonempty_string_field keys json =
+  let rec loop = function
+    | [] -> None
+    | key :: rest -> (
+        match U.member key json with
+        | `String value when String.trim value <> "" -> Some (String.trim value)
+        | _ -> loop rest)
+  in
+  loop keys
+
+let keeper_reply_text dispatched_json =
+  match dispatched_json with
+  | `String value when String.trim value <> "" -> Some (String.trim value)
+  | `Assoc _ ->
+      first_nonempty_string_field [ "reply"; "content"; "text"; "message" ] dispatched_json
+  | _ -> None
+
 let string_of_trigger = function
   | Lodge_heartbeat.Scheduled -> "scheduled"
   | Lodge_heartbeat.ContentAlert _ -> "content_alert"
@@ -3507,11 +3519,13 @@ let execute_action (ctx : 'a context) (request : action_request) :
         | None -> Error "masc_keeper_msg dispatch unavailable"
       in
       let _ = ok in
+      let dispatched_json = json_of_dispatch_output body in
       Ok
         (`Assoc
           [
             ("delegated_tool", `String "masc_keeper_msg");
-            ("result", json_of_dispatch_output body);
+            ("result", dispatched_json);
+            ("reply", string_option_to_json (keeper_reply_text dispatched_json));
           ])
   | "swarm_run_continue" ->
       let* () = validate_target_type "swarm_run" request in

--- a/lib/server_dashboard_http.ml
+++ b/lib/server_dashboard_http.ml
@@ -1876,13 +1876,6 @@ let keepers_dashboard_json ?(compact = false) (config : Room.config) : Yojson.Sa
                   ~keepalive_running
                   ~history_items:conversation_items
                   ~now_ts
-                |> Keeper_exec_status.augment_keeper_diagnostic_json
-                     ~desired:true
-                     ~meta:m
-                     ~keepalive_running
-                     ~keepalive_started_at:
-                       (Keeper_keepalive.keeper_keepalive_started_at m.name)
-                     ~now_ts
               in
               let detail_fields =
                 if compact then []
@@ -1941,10 +1934,6 @@ let keepers_dashboard_json ?(compact = false) (config : Room.config) : Yojson.Sa
               ("auto_handoff", `Bool m.auto_handoff);
               ("handoff_threshold", `Float m.handoff_threshold);
               ("agent", agent);
-              ( "status",
-                `String
-                  (Keeper_exec_status.keeper_surface_status ~agent_status:agent
-                     ~diagnostic) );
               ("diagnostic", diagnostic);
               ("keeper_age_s", `Float keeper_age_s);
               ("uptime_hours", `Float (keeper_age_s /. 3600.0));
@@ -2572,6 +2561,11 @@ let json_record_field key json =
   | `Assoc _ as value -> Some value
   | _ -> None
 
+let count_where items predicate =
+  List.fold_left
+    (fun acc item -> if predicate item then acc + 1 else acc)
+    0 items
+
 let dashboard_current_room_id config =
   Room.current_room_id config
 
@@ -2687,10 +2681,64 @@ let dashboard_room_truth_http_json ~state ~sw ~clock request =
     | `List items -> items
     | _ -> []
   in
+  let execution_session_briefs = json_list_field "session_briefs" execution_json in
+  let execution_operation_briefs = json_list_field "operation_briefs" execution_json in
+  let execution_worker_support =
+    json_list_field "worker_support_briefs" execution_json
+  in
+  let execution_continuity =
+    json_list_field "continuity_briefs" execution_json
+  in
+  let execution_keepers = json_list_field "keepers" execution_json in
   let top_queue =
     match execution_queue with
     | head :: _ -> head
     | [] -> `Null
+  in
+  let has_text key json =
+    match json_string_field_opt key json with
+    | Some _ -> true
+    | None -> false
+  in
+  let execution_summary =
+    let existing = json_assoc_field "summary" execution_json in
+    match Yojson.Safe.Util.member "blocked_sessions" existing with
+    | `Int _ | `Intlit _ ->
+        existing
+    | _ ->
+        `Assoc
+          [
+            ("active_sessions", `Int (List.length execution_session_briefs));
+            ( "blocked_sessions",
+              `Int
+                (count_where execution_session_briefs
+                   (fun row ->
+                     let health = json_string_field_opt "health" row in
+                     let status = json_string_field_opt "status" row in
+                     has_text "blocker_summary" row
+                     || health = Some "warn"
+                     || health = Some "bad"
+                     || status = Some "blocked")) );
+            ("active_operations", `Int (List.length execution_operation_briefs));
+            ( "blocked_operations",
+              `Int (count_where execution_operation_briefs (has_text "blocker_summary")) );
+            ( "worker_alerts",
+              `Int
+                (count_where execution_worker_support
+                   (fun row ->
+                     match json_string_field_opt "tone" row with
+                     | Some "warn" | Some "bad" -> true
+                     | _ -> false)) );
+            ( "continuity_alerts",
+              `Int
+                (count_where execution_continuity
+                   (fun row ->
+                     match json_string_field_opt "tone" row with
+                     | Some "warn" | Some "bad" -> true
+                     | _ -> false)) );
+            ("priority_items", `Int (List.length execution_queue));
+            ("keepers", `Int (List.length execution_keepers));
+          ]
   in
   let command_ops = json_assoc_field "operations" command_summary_json in
   let command_detachments = json_assoc_field "detachments" command_summary_json in
@@ -2794,7 +2842,7 @@ let dashboard_room_truth_http_json ~state ~sw ~clock request =
       ( "execution",
         `Assoc
           [
-            ("summary", json_assoc_field "summary" execution_json);
+            ("summary", execution_summary);
             ("top_queue", top_queue);
             ("provenance", `String "derived");
           ] );

--- a/lib/tool_catalog.ml
+++ b/lib/tool_catalog.ml
@@ -302,6 +302,18 @@ let metadata_to_fields name =
   | Some reason -> ("reason", `String reason) :: with_replacement
   | None -> with_replacement
 
+let public_contract_fields name =
+  let meta = metadata name in
+  let base =
+    [
+      ( "implementationStatus",
+        `String (implementation_status_to_string meta.implementation_status) );
+    ]
+  in
+  match meta.canonical_name with
+  | Some canonical_name -> ("canonicalName", `String canonical_name) :: base
+  | None -> base
+
 let allow_direct_call name =
   let meta = metadata name in
   match meta.visibility with

--- a/test/test_dashboard_execution.ml
+++ b/test/test_dashboard_execution.ml
@@ -39,7 +39,6 @@ let test_dashboard_execution_fixture () =
             ()
         in
         let open Yojson.Safe.Util in
-        let summary = json |> member "summary" in
         let execution_queue = json |> member "execution_queue" |> to_list in
         let session_briefs = json |> member "session_briefs" |> to_list in
         let operation_briefs = json |> member "operation_briefs" |> to_list in
@@ -48,8 +47,8 @@ let test_dashboard_execution_fixture () =
         let lodge_checkins = json |> member "lodge_checkins" |> to_list in
         let continuity_briefs = json |> member "continuity_briefs" |> to_list in
         let offline_worker_briefs = json |> member "offline_worker_briefs" |> to_list in
-        check int "fixture blocked sessions" 1 (summary |> member "blocked_sessions" |> to_int);
-        check int "fixture blocked operations" 2 (summary |> member "blocked_operations" |> to_int);
+        check bool "summary removed from execution payload" true
+          (json |> member "summary" = `Null);
         check int "lodge checked count" 3 (lodge_tick |> member "checked" |> to_int);
         check int "lodge checkins" 3 (List.length lodge_checkins);
         check string "top queue kind" "session"

--- a/test/test_dashboard_mission.ml
+++ b/test/test_dashboard_mission.ml
@@ -293,6 +293,8 @@ let test_dashboard_mission_projection () =
         ~context:"fixture context"
         ~allowed_tools:[ "masc_board_comment" ]
         ();
+      Sys.remove
+        (Filename.concat (Lib.Room_utils.agents_dir config) "llama-local-delta.json");
       Eio_main.run @@ fun env ->
       Eio.Switch.run (fun sw ->
         let json =
@@ -307,6 +309,7 @@ let test_dashboard_mission_projection () =
         let open Yojson.Safe.Util in
         let attention_queue = json |> member "attention_queue" |> to_list in
         let sessions = json |> member "sessions" |> to_list in
+        let summary = json |> member "summary" in
         let session_briefs = json |> member "session_briefs" |> to_list in
         let agent_briefs = json |> member "agent_briefs" |> to_list in
         let internal_signals = json |> member "internal_signals" |> to_list in
@@ -318,11 +321,6 @@ let test_dashboard_mission_projection () =
           agent_briefs
           |> List.find (fun row ->
                  row |> member "agent_name" |> to_string = "llama-local-alpha")
-        in
-        let beta_brief =
-          agent_briefs
-          |> List.find (fun row ->
-                 row |> member "agent_name" |> to_string = "llama-local-beta")
         in
         check bool "attention_queue present" true (attention_queue <> []);
         check string "top attention kind" "spawn_failure_present"
@@ -337,6 +335,10 @@ let test_dashboard_mission_projection () =
            |> member "top_action" |> member "action_type" |> to_string);
         check string "session brief id" session_id
           (session_briefs |> List.hd |> member "session_id" |> to_string);
+        check bool "mission summary trims paused" true
+          (summary |> member "paused" = `Null);
+        check bool "mission summary trims active_agents" true
+          (summary |> member "active_agents" = `Null);
         check string "session card id" session_id
           (sessions |> List.hd |> member "session_id" |> to_string);
         check bool "session blocker summary comes from attention" true
@@ -364,25 +366,29 @@ let test_dashboard_mission_projection () =
            |> List.exists (fun row ->
                   row |> member "agent_name" |> to_string = "llama-local-delta"
                   && row |> member "related_session_id" |> to_string = session_id));
+        let delta_brief =
+          agent_briefs
+          |> List.find (fun row ->
+                 row |> member "agent_name" |> to_string = "llama-local-delta")
+        in
+        check bool "summary-only participant marked non-live" false
+          (delta_brief |> member "is_live" |> to_bool);
+        check string "summary-only participant archived reason"
+          "not in current room state"
+          (delta_brief |> member "archived_reason" |> to_string);
+        check bool "participant preview omits old tool telemetry" true
+          (delta_brief |> member "recent_tool_names" = `Null);
         let alpha_input = alpha_brief |> member "recent_input_preview" |> to_string in
         check bool "recent input preserves exact alpha mention" true
           (contains alpha_input "@llama-local-alpha");
         check bool "recent input excludes unrelated beta mention" false
           (contains alpha_input "@llama-local-beta");
-        check bool "allowed tools captured" true
-          (alpha_brief |> member "allowed_tool_names" |> to_list
-           |> List.exists (fun value -> value |> to_string = "masc_board_vote"));
-        check bool "latest tool names captured" true
-          (alpha_brief |> member "latest_tool_names" |> to_list
-           |> List.exists (fun value -> value |> to_string = "masc_board_vote"));
-        check int "latest tool count captured" 2
-          (alpha_brief |> member "latest_tool_call_count" |> to_int);
-        check string "tool audit source" "heartbeat_result"
-          (alpha_brief |> member "tool_audit_source" |> to_string);
-        check string "newer task keeps prior result evidence" "heartbeat_task_pending_result"
-          (beta_brief |> member "tool_audit_source" |> to_string);
-        check bool "newer task preserves latest observed tools" true
-          ((beta_brief |> member "latest_tool_names" |> to_list) <> []);
+        check bool "agent brief omits old audit surface" true
+          (alpha_brief |> member "allowed_tool_names" = `Null);
+        check bool "agent brief omits social context fields" true
+          (alpha_brief |> member "where" = `Null);
+        check string "agent brief keeps session linkage" session_id
+          (alpha_brief |> member "related_session_id" |> to_string);
         check bool "internal signal includes pending confirm" true
           (internal_signals
            |> List.exists (fun row ->
@@ -463,8 +469,8 @@ let test_dashboard_mission_keeper_tool_audit_fallback () =
         in
         check bool "fallback allowed tools present" true
           ((brief |> member "allowed_tool_names" |> to_list) <> []);
-        check bool "fallback source omitted without evidence" true
-          (brief |> member "tool_audit_source" = `Null);
+        check string "fallback source" "keeper_policy"
+          (brief |> member "tool_audit_source" |> to_string);
         check bool "no observed tools without evidence" true
           ((brief |> member "latest_tool_names" |> to_list) = []);
       ))

--- a/test/test_mcp_server_eio.ml
+++ b/test/test_mcp_server_eio.ml
@@ -1231,6 +1231,48 @@ let test_handle_request_tools_call_trpg () =
 
   cleanup_dir base_path
 
+let test_handle_request_tools_call_tool_shard () =
+  Eio_main.run @@ fun env ->
+  let clock = Eio.Stdenv.clock env in
+  Eio.Switch.run @@ fun sw ->
+
+  let base_path = temp_dir () in
+  let state = Mcp_eio.create_state ~test_mode:true ~base_path () in
+
+  let request = Yojson.Safe.to_string (`Assoc [
+    ("jsonrpc", `String "2.0");
+    ("id", `Int 10);
+    ("method", `String "tools/call");
+    ("params", `Assoc [
+      ("name", `String "masc_tool_list");
+      ("arguments", `Assoc []);
+    ]);
+  ]) in
+
+  let response = Mcp_eio.handle_request ~clock ~sw state request in
+  (match response with
+  | `Assoc fields ->
+      (match List.assoc_opt "result" fields with
+      | Some (`Assoc result_fields) ->
+          Alcotest.(check bool) "tool call succeeded" false
+            (match List.assoc_opt "isError" result_fields with
+             | Some (`Bool is_error) -> is_error
+             | _ -> true);
+          let text =
+            match List.assoc_opt "content" result_fields with
+            | Some (`List (`Assoc content_fields :: _)) -> (
+                match List.assoc_opt "text" content_fields with
+                | Some (`String value) -> value
+                | _ -> "")
+            | _ -> ""
+          in
+          Alcotest.(check bool) "tool shard result present" true
+            (contains_substring text "\"shards\"")
+      | _ -> Alcotest.fail "result missing")
+  | _ -> Alcotest.fail "response not an object");
+
+  cleanup_dir base_path
+
 let test_handle_request_invalid_json () =
   Eio_main.run @@ fun env ->
   let clock = Eio.Stdenv.clock env in
@@ -1717,6 +1759,7 @@ let eio_tests = [
   "handle invalid json", `Quick, test_handle_request_invalid_json;
   "handle method not found", `Quick, test_handle_request_method_not_found;
   "handle tools/call trpg", `Quick, test_handle_request_tools_call_trpg;
+  "handle tools/call tool_shard", `Quick, test_handle_request_tools_call_tool_shard;
   "mode gate", `Quick, test_execute_tool_mode_gate;
   "hidden active utility direct call", `Quick,
     test_execute_tool_hidden_active_utility_direct_call;

--- a/test/test_tool_tier.ml
+++ b/test/test_tool_tier.ml
@@ -152,5 +152,29 @@ let () =
                 |> Option.value ~default:""
               in
               check string "tier field" "full" tier_val);
+          test_case "public contract keeps implementation status only" `Quick
+            (fun () ->
+              let fields = Tool_catalog.public_contract_fields "masc_join" in
+              let status_val =
+                List.assoc_opt "implementationStatus" fields
+                |> Option.map (function `String s -> s | _ -> "")
+                |> Option.value ~default:""
+              in
+              check string "status field" "real" status_val;
+              check bool "visibility omitted" true
+                (List.assoc_opt "visibility" fields = None);
+              check bool "lifecycle omitted" true
+                (List.assoc_opt "lifecycle" fields = None));
+          test_case "public contract keeps canonical alias" `Quick (fun () ->
+              let fields =
+                Tool_catalog.public_contract_fields "masc_llama_runtime_verify"
+              in
+              let canonical_val =
+                List.assoc_opt "canonicalName" fields
+                |> Option.map (function `String s -> s | _ -> "")
+                |> Option.value ~default:""
+              in
+              check string "canonical field" "masc_runtime_verify"
+                canonical_val);
         ] );
     ]


### PR DESCRIPTION
## Summary
- keep stale session participants inspectable without surfacing low-value dashboard noise
- route keeper direct messaging through the audited operator path and keep the visible UI focused on actionable context
- prune mission/execution/agent/keeper surfaces and trim the related dashboard projection contracts

## Validation
- dune build
- ./_build/default/test/test_dashboard_mission.exe
- dune exec ./test/test_dashboard_execution.exe
- dune exec ./test/test_mcp_server_eio.exe
- ./node_modules/.bin/tsc --noEmit --pretty
- npm run build