### PR TITLE
fix(ci): install test deps for health job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Install dependencies
         run: |
           for attempt in 1 2 3; do
-            opam install . --deps-only --yes && break
+            opam install . --deps-only --with-test --yes && break
             if [ "$attempt" -eq 3 ]; then
               echo "opam install failed after ${attempt} attempts"
               exit 1


### PR DESCRIPTION
## Summary
- make the CI `Health` job install test dependencies before running `dune build --root . @check`

## Why
- current `Health` failures on multiple open PRs are false negatives caused by missing test-only deps such as `alcotest`
- this unblocks meaningful health ratchet results for subsequent PR triage and replacement work

## Validation
- `git diff --check`
- root cause confirmed from failing Health logs on #887 and #882 (`Library "alcotest" not found` in `dune build @check`)