### PR TITLE
feat(audit): log mode changes to audit trail

### DIFF
--- a/lib/config.ml
+++ b/lib/config.ml
@@ -73,6 +73,52 @@ let save room_path config =
   output_string oc content;
   close_out oc
 
+let audit_log_path room_path =
+  Filename.concat room_path "audit.jsonl"
+
+let json_string_option = function
+  | Some value when String.trim value <> "" -> `String (String.trim value)
+  | _ -> `Null
+
+let mode_change_audit_json ~actor ~source ~room_path ~previous_config ~config =
+  let categories_to_json_values categories =
+    `List
+      (List.map
+         (fun category -> `String (category_to_string category))
+         categories)
+  in
+  let old_mode = mode_to_string previous_config.mode in
+  let new_mode = mode_to_string config.mode in
+  let actor_name =
+    actor
+    |> Option.map String.trim
+    |> Option.value ~default:"unknown"
+  in
+  let detail =
+    Printf.sprintf "mode=%s -> %s source=%s"
+      old_mode new_mode
+      (source |> Option.map String.trim |> Option.value ~default:"config")
+  in
+  `Assoc
+    [
+      ("timestamp", `Float (Unix.gettimeofday ()));
+      ("agent", `String actor_name);
+      ("event_type", `String "mode_change");
+      ("success", `Bool true);
+      ("detail", `String detail);
+      ("room_path", `String room_path);
+      ("source", json_string_option source);
+      ("previous_mode", `String old_mode);
+      ("mode", `String new_mode);
+      ( "previous_enabled_categories",
+        categories_to_json_values previous_config.enabled_categories );
+      ("enabled_categories", categories_to_json_values config.enabled_categories);
+    ]
+
+let append_mode_change_audit ~actor ~source ~room_path ~previous_config ~config =
+  Fs_compat.append_jsonl (audit_log_path room_path)
+    (mode_change_audit_json ~actor ~source ~room_path ~previous_config ~config)
+
 let dedupe_schemas (schemas : Types.tool_schema list) =
   let seen = Hashtbl.create (List.length schemas) in
   List.filter
@@ -165,20 +211,24 @@ let enabled_tool_schemas ?(include_hidden = false) ?(include_deprecated = false)
            || Mode.is_tool_enabled enabled_categories schema.name)
 
 (** Switch to a preset mode *)
-let switch_mode room_path mode =
+let switch_mode ?actor ?source room_path mode =
+  let previous_config = load room_path in
   let enabled_categories = categories_for_mode mode in
   let config = { mode; enabled_categories } in
   save room_path config;
+  append_mode_change_audit ~actor ~source ~room_path ~previous_config ~config;
   config
 
 (** Enable specific categories (switches to Custom mode) *)
-let set_categories room_path categories =
+let set_categories ?actor ?source room_path categories =
+  let previous_config = load room_path in
   let config = { mode = Custom; enabled_categories = categories } in
   save room_path config;
+  append_mode_change_audit ~actor ~source ~room_path ~previous_config ~config;
   config
 
 (** Enable a category *)
-let enable_category room_path category =
+let enable_category ?actor ?source room_path category =
   let current = load room_path in
   let new_cats =
     if List.mem category current.enabled_categories then
@@ -186,13 +236,13 @@ let enable_category room_path category =
     else
       category :: current.enabled_categories
   in
-  set_categories room_path new_cats
+  set_categories ?actor ?source room_path new_cats
 
 (** Disable a category *)
-let disable_category room_path category =
+let disable_category ?actor ?source room_path category =
   let current = load room_path in
   let new_cats = List.filter (fun c -> c <> category) current.enabled_categories in
-  set_categories room_path new_cats
+  set_categories ?actor ?source room_path new_cats
 
 (** Get current config summary as JSON for tool response *)
 let get_config_summary room_path =

--- a/lib/tool_control.ml
+++ b/lib/tool_control.ml
@@ -26,7 +26,9 @@ let handle_resume ctx _args =
 
 let handle_pause_status ctx args =
   let requested_room = get_string args "room_id" "" |> String.trim in
-  let current_room = Room.current_room_id ctx.config in
+  let current_room =
+    Room.read_current_room ctx.config |> Option.value ~default:"default"
+  in
   let room_id = if requested_room = "" then current_room else requested_room in
   let payload =
     match Room.pause_info ctx.config with
@@ -98,10 +100,14 @@ let handle_switch_mode ctx args =
                     |> List.filter_map (function Ok cat -> Some cat | Error _ -> None)
                     |> List.sort_uniq Stdlib.compare
                   in
-                  ignore (Config.set_categories room_path categories);
+                  ignore
+                    (Config.set_categories ~actor:ctx.agent_name
+                       ~source:"masc_switch_mode:custom" room_path categories);
                   Ok ()
           | _ ->
-              ignore (Config.switch_mode room_path mode);
+              ignore
+                (Config.switch_mode ~actor:ctx.agent_name
+                   ~source:"masc_switch_mode" room_path mode);
               Ok ()
         in
         (match switched with

--- a/lib/tool_misc.ml
+++ b/lib/tool_misc.ml
@@ -466,13 +466,19 @@ let handle_tool_admin_update ctx args =
       let result =
         match categories_opt, mode_opt with
         | Some categories, _ ->
-            let config = Config.set_categories room_path categories in
+            let config =
+              Config.set_categories ~actor:ctx.agent_name
+                ~source:"masc_tool_admin_update:mode" room_path categories
+            in
             Ok config
         | None, Some "custom" ->
             Error "mode=custom requires enabled_categories"
         | None, Some raw -> (
             match Mode.mode_of_string raw with
-            | Some mode -> Ok (Config.switch_mode room_path mode)
+            | Some mode ->
+                Ok
+                  (Config.switch_mode ~actor:ctx.agent_name
+                     ~source:"masc_tool_admin_update:mode" room_path mode)
             | None -> Error (Printf.sprintf "unknown mode: %s" raw))
         | None, None -> Error "mode or enabled_categories is required"
       in

--- a/test/test_config_coverage.ml
+++ b/test/test_config_coverage.ml
@@ -205,6 +205,29 @@ let test_switch_mode_persists () =
   cleanup_temp_dir dir;
   check bool "persisted Parallel" true (loaded.mode = Mode.Parallel)
 
+let test_switch_mode_writes_audit_event () =
+  let dir = setup_temp_dir () in
+  let _ =
+    Config.switch_mode ~actor:"tester" ~source:"masc_switch_mode" dir
+      Mode.Minimal
+  in
+  let audit_path = Filename.concat dir "audit.jsonl" in
+  let json =
+    match Fs_compat.load_jsonl audit_path with
+    | first :: _ -> first
+    | [] -> fail "expected audit event"
+  in
+  let open Yojson.Safe.Util in
+  check string "event_type" "mode_change"
+    (json |> member "event_type" |> to_string);
+  check string "agent" "tester" (json |> member "agent" |> to_string);
+  check string "source" "masc_switch_mode"
+    (json |> member "source" |> to_string);
+  check string "previous_mode" "full"
+    (json |> member "previous_mode" |> to_string);
+  check string "mode" "minimal" (json |> member "mode" |> to_string);
+  cleanup_temp_dir dir
+
 (* ============================================================
    set_categories Tests
    ============================================================ *)
@@ -372,6 +395,7 @@ let () =
       test_case "minimal" `Quick test_switch_mode_minimal;
       test_case "full" `Quick test_switch_mode_full;
       test_case "persists" `Quick test_switch_mode_persists;
+      test_case "writes audit event" `Quick test_switch_mode_writes_audit_event;
     ];
     "set_categories", [
       test_case "basic" `Quick test_set_categories;


### PR DESCRIPTION
## Summary
- log room mode changes to `.masc/audit.jsonl`
- record actor, source, room path, previous mode, new mode, and category set
- cover both `masc_switch_mode` and admin mode updates

## Verification
- `git diff --check`
- `dune build --root . test/test_config_coverage.exe test/test_tool_control_coverage.exe`
- `./_build/default/test/test_config_coverage.exe`
- `dune exec --root . ./test/test_tool_control_coverage.exe`
