### PR TITLE
fix(dashboard): consolidate keeper truth surfaces

### DIFF
--- a/bin/main_eio.ml
+++ b/bin/main_eio.ml
@@ -213,10 +213,14 @@ let make_extended_handler routes =
 
 (** Main server loop *)
 let run_server ~sw ~env ~host ~port ~base_path =
-  Server_runtime_bootstrap.run ~sw ~env ~host ~port ~base_path ~make_routes
-    ~make_request_handler:make_extended_handler
-    ~make_h2_request_handler:Server_h2_gateway.make_request_handler
-    ~make_h2_error_handler:Server_h2_gateway.make_error_handler
+  try
+    Server_runtime_bootstrap.run ~sw ~env ~host ~port ~base_path ~make_routes
+      ~make_request_handler:make_extended_handler
+      ~make_h2_request_handler:Server_h2_gateway.make_request_handler
+      ~make_h2_error_handler:Server_h2_gateway.make_error_handler
+  with exn ->
+    Printf.eprintf "[main] keeper bootstrap failed: %s\n%!" (Printexc.to_string exn);
+    raise exn
 
 (** CLI options *)
 let port =

--- a/dashboard/src/components/keeper-detail.ts
+++ b/dashboard/src/components/keeper-detail.ts
@@ -1,13 +1,17 @@
-// Keeper detail overlay — focused keeper profile, continuity, and direct comms.
+// Keeper detail overlay — full keeper info with KPIs, field dictionary,
+// memory, conversations, equipment, relationships, handoff timeline
+// CSS classes: .keeper-kpis, .keeper-field-dict, .keeper-memory-list, etc. (components.css)
 
 import { html } from 'htm/preact'
 import { signal } from '@preact/signals'
-import { currentDashboardActor, runOperatorAction } from '../api'
+import { runOperatorAction } from '../api'
 import { Card } from './common/card'
 import { StatusBadge } from './common/status-badge'
 import { TimeAgo } from './common/time-ago'
-import type { Keeper, KeeperMetricPoint, TrpgCharacterStats } from '../types'
-import { invalidateDashboardCache, refreshDashboard } from '../store'
+import { missionSnapshot } from '../mission-store'
+import type { DashboardMissionKeeperBrief, Keeper, KeeperMetricPoint, TrpgCharacterStats, AutonomyLevel } from '../types'
+import { invalidateDashboardCache, refreshDashboard, serverStatus } from '../store'
+import { operatorSnapshot } from '../operator-store'
 import { normalizeLodgeTickResult, selectKeeper } from '../keeper-runtime'
 import {
   KeeperConversationPanel,
@@ -15,7 +19,17 @@ import {
   KeeperRuntimeActions,
 } from './keeper-shared'
 import { showToast } from './common/toast'
-import { keeperIdentityHint } from './common/keeper-identity'
+import {
+  allowlistEmptyState,
+  auditMetadataState,
+  linkedRecentToolsEmptyState,
+  linkedRuntimeState,
+  observedToolsEmptyState,
+  openToolsInventory,
+  toolAuditStateLabel,
+} from './common/tool-audit'
+
+// ── Global overlay state ──────────────────────────────────
 
 export const selectedKeeper = signal<Keeper | null>(null)
 
@@ -28,17 +42,186 @@ export function closeKeeperDetail() {
   selectedKeeper.value = null
 }
 
-function contextPressureLabel(value?: number | null): string {
-  if (typeof value !== 'number' || Number.isNaN(value)) return '확인 필요'
-  if (value >= 0.85) return '높음'
-  if (value >= 0.7) return '상승 중'
-  return '안정'
+// ── Autonomy helpers ─────────────────────────────────────
+
+const AUTONOMY_LEVELS: { level: AutonomyLevel; label: string; color: string }[] = [
+  { level: 'L1_Reactive', label: 'L1 Reactive', color: '#6b7280' },
+  { level: 'L2_Suggestive', label: 'L2 Suggestive', color: '#3b82f6' },
+  { level: 'L3_Guided', label: 'L3 Guided', color: '#f59e0b' },
+  { level: 'L4_Autonomous', label: 'L4 Autonomous', color: '#f97316' },
+  { level: 'L5_Independent', label: 'L5 Independent', color: '#ef4444' },
+]
+
+function autonomyIndex(level: AutonomyLevel | undefined): number {
+  if (!level) return 0
+  const idx = AUTONOMY_LEVELS.findIndex(a => a.level === level)
+  return idx >= 0 ? idx : 0
+}
+
+function AutonomyMeter({ keeper }: { keeper: Keeper }) {
+  const idx = autonomyIndex(keeper.autonomy_level)
+  const info = AUTONOMY_LEVELS[idx] ?? AUTONOMY_LEVELS[0]
+  if (!info) return null
+  const pct = ((idx + 1) / AUTONOMY_LEVELS.length) * 100
+
+  return html`
+    <div class="keeper-signal-list">
+      <div style="margin-bottom:8px;">
+        <div style="display:flex; justify-content:space-between; align-items:center; margin-bottom:4px;">
+          <span style="font-size:13px; font-weight:600; color:${info.color};">${info.label}</span>
+          <span style="font-size:11px; color:#888;">${idx + 1} / ${AUTONOMY_LEVELS.length}</span>
+        </div>
+        <div style="width:100%; height:6px; background:#1a1a2e; border-radius:3px; overflow:hidden;">
+          <div style="width:${pct}%; height:100%; background:${info.color}; border-radius:3px; transition:width 0.3s;"></div>
+        </div>
+        <div style="display:flex; justify-content:space-between; margin-top:2px;">
+          ${AUTONOMY_LEVELS.map((a, i) => html`
+            <span style="width:8px; height:8px; border-radius:50%; background:${i <= idx ? a.color : '#333'}; display:inline-block;"></span>
+          `)}
+        </div>
+      </div>
+      <div class="keeper-signal-row">
+        <span>Autonomous actions</span>
+        <strong>${keeper.autonomous_action_count ?? 0}</strong>
+      </div>
+      ${keeper.last_autonomous_action_at
+        ? html`<div class="keeper-signal-row">
+            <span>Last autonomous action</span>
+            <strong><${TimeAgo} timestamp=${keeper.last_autonomous_action_at} /></strong>
+          </div>`
+        : null}
+      ${keeper.active_goal_ids && keeper.active_goal_ids.length > 0
+        ? html`<div class="keeper-signal-row">
+            <span>Active goals</span>
+            <strong>${keeper.active_goal_ids.length}</strong>
+          </div>`
+        : null}
+    </div>
+  `
+}
+
+// ── Sub-components ────────────────────────────────────────
+
+function formatTokens(n: number | undefined): string {
+  if (!n) return '—'
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`
+  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}K`
+  return String(n)
+}
+
+function actionDescriptorLabel(actionType?: string): string {
+  switch (actionType) {
+    case 'keeper_message':
+      return 'message'
+    case 'keeper_probe':
+      return 'probe'
+    case 'keeper_recover':
+      return 'recover'
+    case 'broadcast':
+      return 'broadcast'
+    case 'room_pause':
+      return 'pause'
+    case 'room_resume':
+      return 'resume'
+    case 'lodge_tick':
+      return 'lodge'
+    default:
+      return actionType?.trim() || 'action'
+  }
+}
+
+function keeperRecentTools(keeper: Keeper): string[] {
+  if (keeper.recent_tool_names && keeper.recent_tool_names.length > 0) {
+    return keeper.recent_tool_names
+  }
+  return []
+}
+
+function keeperTopTools(keeper: Keeper): string[] {
+  const metrics = keeper.metrics_window
+  const topTools = Array.isArray(metrics?.top_tools) ? metrics.top_tools : []
+  return topTools
+    .map(item => (typeof item === 'object' && item !== null && 'tool' in item && typeof item.tool === 'string' ? item.tool : null))
+    .filter((item): item is string => item !== null)
+}
+
+function missionKeeperBrief(keeper: Keeper): DashboardMissionKeeperBrief | null {
+  const mission = missionSnapshot.value
+  if (!mission) return null
+  return mission.keeper_briefs.find(brief =>
+    brief.name === keeper.name
+      || (brief.agent_name && keeper.agent_name && brief.agent_name === keeper.agent_name))
+    ?? null
+}
+
+function KpiGrid({ keeper }: { keeper: Keeper }) {
+  const series = keeper.metrics_series ?? []
+  const lastPt = series[series.length - 1] as KeeperMetricPoint | undefined
+  const latestCost =
+    lastPt && Number.isFinite(lastPt.cost_usd)
+      ? `$${lastPt.cost_usd.toFixed(4)}`
+      : null
+
+  const items: { label: string; value: string | number; hint?: string }[] = [
+    {
+      label: 'Generation',
+      value: keeper.generation ?? '-',
+      hint: 'Succession count',
+    },
+    {
+      label: 'Turns',
+      value: keeper.turn_count ?? '-',
+      hint: 'Total loop turns',
+    },
+    {
+      label: 'Context',
+      value: keeper.context_ratio != null ? `${Math.round(keeper.context_ratio * 100)}%` : '-',
+      hint: keeper.context_ratio != null && keeper.context_ratio > 0.8 ? 'Near limit' : undefined,
+    },
+    {
+      label: 'Activity',
+      value: keeper.activityLevel ?? '-',
+      hint: 'Level 0–5',
+    },
+  ]
+
+  return html`
+    <div class="keeper-kpis">
+      ${items.map(i => html`
+        <div class="keeper-kpi">
+          <div class="keeper-kpi-label">${i.label}</div>
+          <div class="keeper-kpi-value">${i.value}</div>
+          ${i.hint ? html`<div class="keeper-kpi-hint">${i.hint}</div>` : null}
+        </div>
+      `)}
+      <div class="kpi-tile">
+        <div class="kpi-value">${formatTokens(keeper.context_tokens)}</div>
+        <div class="kpi-label">Tokens</div>
+      </div>
+      <div class="kpi-tile">
+        <div class="kpi-value">${keeper.handoff_count_total ?? '—'}</div>
+        <div class="kpi-label">Handoffs</div>
+      </div>
+      <div class="kpi-tile">
+        <div class="kpi-value">${keeper.compaction_count ?? '—'}</div>
+        <div class="kpi-label">Compactions</div>
+      </div>
+      ${latestCost
+        ? html`
+            <div class="kpi-tile">
+              <div class="kpi-value">${latestCost}</div>
+              <div class="kpi-label">Cost (USD)</div>
+            </div>
+          `
+        : null}
+    </div>
+  `
 }
 
 function ContextChart({ keeper }: { keeper: Keeper }) {
   const series = keeper.metrics_series ?? []
   if (series.length < 2) {
-    const pct = ((keeper.context?.context_ratio ?? keeper.context_ratio ?? 0) * 100)
+    const pct = ((keeper.context?.context_ratio ?? 0) * 100)
     const color = pct > 85 ? '#ef4444' : pct > 70 ? '#f59e0b' : '#22c55e'
     return html`
       <div class="context-chart">
@@ -49,9 +232,7 @@ function ContextChart({ keeper }: { keeper: Keeper }) {
       </div>`
   }
 
-  const W = 200
-  const H = 60
-  const pad = 2
+  const W = 200, H = 60, pad = 2
   const n = series.length
   const pts = series.map((p: KeeperMetricPoint, i: number) => {
     const x = pad + (i / (n - 1)) * (W - 2 * pad)
@@ -65,15 +246,84 @@ function ContextChart({ keeper }: { keeper: Keeper }) {
   return html`
     <div class="context-chart" style="display:flex;align-items:center;gap:8px">
       <svg viewBox="0 0 ${W} ${H}" width="${W}" height="${H}" style="background:#1a1a2e;border-radius:4px">
+        <line x1="${pad}" y1="${(H - pad - 0.5 * (H - 2 * pad)).toFixed(1)}" x2="${W - pad}" y2="${(H - pad - 0.5 * (H - 2 * pad)).toFixed(1)}" stroke="#666" stroke-dasharray="3,3" stroke-width="0.5"/>
         <line x1="${pad}" y1="${(H - pad - 0.7 * (H - 2 * pad)).toFixed(1)}" x2="${W - pad}" y2="${(H - pad - 0.7 * (H - 2 * pad)).toFixed(1)}" stroke="#666" stroke-dasharray="3,3" stroke-width="0.5"/>
         <line x1="${pad}" y1="${(H - pad - 0.85 * (H - 2 * pad)).toFixed(1)}" x2="${W - pad}" y2="${(H - pad - 0.85 * (H - 2 * pad)).toFixed(1)}" stroke="#f59e0b" stroke-dasharray="3,3" stroke-width="0.5"/>
         ${pts.filter(({ p }) => p.is_handoff).map(({ x }) => html`
           <line x1="${x.toFixed(1)}" y1="${pad}" x2="${x.toFixed(1)}" y2="${H - pad}" stroke="#ef4444" stroke-width="1.5" opacity="0.7"/>
         `)}
         <polyline points="${polyline}" fill="none" stroke="${lineColor}" stroke-width="1.5"/>
+        ${pts.filter(({ p }) => p.is_compaction).map(({ x, y }) => html`
+          <circle cx="${x.toFixed(1)}" cy="${y.toFixed(1)}" r="2.5" fill="#a855f7"/>
+        `)}
       </svg>
       <span class="chart-pct">${lastRatio.toFixed(1)}%</span>
     </div>`
+}
+
+// Searchable field dictionary — shows all keeper properties
+const fieldSearch = signal('')
+
+function FieldDictionary({ keeper }: { keeper: Keeper }) {
+  const filter = fieldSearch.value.toLowerCase()
+
+  const fields: { title: string; key: string; value: string }[] = [
+    { title: 'Name', key: 'name', value: keeper.name },
+    { title: 'Emoji', key: 'emoji', value: keeper.emoji ?? '-' },
+    { title: 'Korean', key: 'koreanName', value: keeper.koreanName ?? '-' },
+    { title: 'Model', key: 'model', value: keeper.model ?? '-' },
+    { title: 'Status', key: 'status', value: keeper.status },
+    { title: 'Primary', key: 'primaryValue', value: keeper.primaryValue ?? '-' },
+    { title: 'Activity', key: 'activityLevel', value: String(keeper.activityLevel ?? '-') },
+    { title: 'Gen', key: 'generation', value: String(keeper.generation ?? '-') },
+    { title: 'Turns', key: 'turn_count', value: String(keeper.turn_count ?? '-') },
+    { title: 'Context', key: 'context_ratio', value: keeper.context_ratio != null ? `${Math.round(keeper.context_ratio * 100)}%` : '-' },
+    { title: 'Heartbeat', key: 'last_heartbeat', value: keeper.last_heartbeat ?? '-' },
+    { title: 'Traits', key: 'traits', value: keeper.traits?.join(', ') || '-' },
+    { title: 'Interests', key: 'interests', value: keeper.interests?.join(', ') || '-' },
+  ]
+
+  const filtered = filter
+    ? fields.filter(f => f.title.toLowerCase().includes(filter) || f.key.includes(filter) || f.value.toLowerCase().includes(filter))
+    : fields
+
+  return html`
+    <div class="keeper-field-dict">
+      <input
+        class="keeper-field-search"
+        type="text"
+        placeholder="Search fields..."
+        value=${fieldSearch.value}
+        onInput=${(e: Event) => { fieldSearch.value = (e.target as HTMLInputElement).value }}
+      />
+      ${filtered.map(f => html`
+        <div class="keeper-field-row">
+          <span class="keeper-field-title">${f.title}</span>
+          <span class="keeper-field-key">${f.key}</span>
+          <span style="flex:1; text-align:right; color:#ccc;">${f.value}</span>
+        </div>
+      `)}
+      ${keeper.trace_id ? html`<div class="keeper-field-row"><span class="keeper-field-title">Trace ID</span><span class="keeper-field-key mono">${keeper.trace_id}</span></div>` : ''}
+      ${keeper.agent_name ? html`<div class="keeper-field-row"><span class="keeper-field-title">Agent</span><span style="flex:1; text-align:right; color:#ccc;">${keeper.agent_name}</span></div>` : ''}
+      ${keeper.primary_model ? html`<div class="keeper-field-row"><span class="keeper-field-title">Primary Model</span><span class="mono" style="flex:1; text-align:right; color:#ccc;">${keeper.primary_model}</span></div>` : ''}
+      ${keeper.active_model ? html`<div class="keeper-field-row"><span class="keeper-field-title">Active Model</span><span class="mono" style="flex:1; text-align:right; color:#ccc;">${keeper.active_model}</span></div>` : ''}
+      ${keeper.next_model_hint ? html`<div class="keeper-field-row"><span class="keeper-field-title">Next Model Hint</span><span class="mono" style="flex:1; text-align:right; color:#ccc;">${keeper.next_model_hint}</span></div>` : ''}
+      ${keeper.skill_primary ? html`<div class="keeper-field-row"><span class="keeper-field-title">Skill (Primary)</span><span style="flex:1; text-align:right; color:#ccc;">${keeper.skill_primary}</span></div>` : ''}
+      ${keeper.skill_secondary ? html`<div class="keeper-field-row"><span class="keeper-field-title">Skill (Secondary)</span><span style="flex:1; text-align:right; color:#ccc;">${keeper.skill_secondary}</span></div>` : ''}
+      ${keeper.skill_reason ? html`<div class="keeper-field-row"><span class="keeper-field-title">Skill Reason</span><span style="flex:1; text-align:right; color:#ccc;">${keeper.skill_reason}</span></div>` : ''}
+      ${keeper.context_source ? html`<div class="keeper-field-row"><span class="keeper-field-title">Context Source</span><span style="flex:1; text-align:right; color:#ccc;">${keeper.context_source}</span></div>` : ''}
+      ${keeper.context_tokens != null ? html`<div class="keeper-field-row"><span class="keeper-field-title">Context Tokens</span><span style="flex:1; text-align:right; color:#ccc;">${formatTokens(keeper.context_tokens)}</span></div>` : ''}
+      ${keeper.context_max != null ? html`<div class="keeper-field-row"><span class="keeper-field-title">Context Max</span><span style="flex:1; text-align:right; color:#ccc;">${formatTokens(keeper.context_max)}</span></div>` : ''}
+      ${keeper.memory_recent_note ? html`<div class="keeper-field-row"><span class="keeper-field-title">Memory Note</span><span style="flex:1; text-align:right; color:#ccc;">${keeper.memory_recent_note}</span></div>` : ''}
+      ${keeper.k2k_count != null ? html`<div class="keeper-field-row"><span class="keeper-field-title">K2K Count</span><span style="flex:1; text-align:right; color:#ccc;">${keeper.k2k_count}</span></div>` : ''}
+      ${keeper.conversation_tail_count != null ? html`<div class="keeper-field-row"><span class="keeper-field-title">Conv Tail</span><span style="flex:1; text-align:right; color:#ccc;">${keeper.conversation_tail_count}</span></div>` : ''}
+      ${keeper.handoff_count_total != null ? html`<div class="keeper-field-row"><span class="keeper-field-title">Total Handoffs</span><span style="flex:1; text-align:right; color:#ccc;">${keeper.handoff_count_total}</span></div>` : ''}
+      ${keeper.compaction_count != null ? html`<div class="keeper-field-row"><span class="keeper-field-title">Compactions</span><span style="flex:1; text-align:right; color:#ccc;">${keeper.compaction_count}</span></div>` : ''}
+      ${keeper.last_compaction_saved_tokens != null ? html`<div class="keeper-field-row"><span class="keeper-field-title">Last Compact Saved</span><span style="flex:1; text-align:right; color:#ccc;">${formatTokens(keeper.last_compaction_saved_tokens)}</span></div>` : ''}
+      ${keeper.context?.message_count != null ? html`<div class="keeper-field-row"><span class="keeper-field-title">Message Count</span><span style="flex:1; text-align:right; color:#ccc;">${keeper.context.message_count}</span></div>` : ''}
+      ${keeper.context?.has_checkpoint != null ? html`<div class="keeper-field-row"><span class="keeper-field-title">Has Checkpoint</span><span style="flex:1; text-align:right; color:#ccc;">${keeper.context.has_checkpoint ? 'Yes' : 'No'}</span></div>` : ''}
+    </div>
+  `
 }
 
 function TrpgStats({ stats }: { stats: TrpgCharacterStats }) {
@@ -82,7 +332,7 @@ function TrpgStats({ stats }: { stats: TrpgCharacterStats }) {
 
   return html`
     <div>
-      <div style="display:flex; gap:12px; margin-bottom:10px;">
+      <div style="display: flex; gap: 12px; margin-bottom: 10px;">
         <div style="flex:1;">
           <div style="font-size:11px; color:#888;">HP ${stats.hp}/${stats.max_hp}</div>
           <div style="height:6px; background:rgba(255,255,255,0.06); border-radius:3px; overflow:hidden;">
@@ -112,14 +362,14 @@ function TrpgStats({ stats }: { stats: TrpgCharacterStats }) {
         `)}
       </div>
       <div style="margin-top:8px; font-size:12px; color:#888;">
-        Level ${stats.level} · XP ${stats.xp}
+        Level ${stats.level} — XP ${stats.xp}
       </div>
     </div>
   `
 }
 
 function EquipmentList({ items }: { items: string[] }) {
-  if (items.length === 0) return html`<div class="empty-state" style="font-size:13px;">No equipment</div>`
+  if (items.length === 0) return html`<div class="empty-state" style="font-size:13px">No equipment</div>`
 
   return html`
     <div class="keeper-equipment-list">
@@ -135,7 +385,7 @@ function EquipmentList({ items }: { items: string[] }) {
 
 function RelationshipList({ rels }: { rels: Record<string, string> }) {
   const entries = Object.entries(rels)
-  if (entries.length === 0) return html`<div class="empty-state" style="font-size:13px;">No relationships</div>`
+  if (entries.length === 0) return html`<div class="empty-state" style="font-size:13px">No relationships</div>`
 
   return html`
     <div class="keeper-k2k-list">
@@ -153,7 +403,7 @@ function TraitsList({ traits, label }: { traits: string[]; label: string }) {
   if (traits.length === 0) return null
 
   return html`
-    <div style="margin-bottom:12px;">
+    <div style="margin-bottom: 12px;">
       <div style="font-size:11px; color:#888; text-transform:uppercase; letter-spacing:1px; margin-bottom:6px;">${label}</div>
       <div style="display:flex; flex-wrap:wrap; gap:6px;">
         ${traits.map(t => html`<span class="keeper-mention-chip">${t}</span>`)}
@@ -162,10 +412,195 @@ function TraitsList({ traits, label }: { traits: string[]; label: string }) {
   `
 }
 
+function formatPct(value: number | undefined): string {
+  if (value == null || Number.isNaN(value)) return '-'
+  return `${Math.round(value * 100)}%`
+}
+
+function RuntimeSignals({ keeper }: { keeper: Keeper }) {
+  const mw = keeper.metrics_window
+
+  const rows: Array<{ label: string; value: string | number }> = [
+    { label: 'Model fallback', value: formatPct(typeof mw?.model_fallback_rate === 'number' ? mw.model_fallback_rate : undefined) },
+    { label: 'Proactive fallback', value: formatPct(typeof mw?.proactive_fallback_rate === 'number' ? mw.proactive_fallback_rate : undefined) },
+    { label: 'Memory pass rate', value: formatPct(typeof mw?.memory_pass_rate === 'number' ? mw.memory_pass_rate : undefined) },
+    { label: 'Handoffs', value: typeof mw?.handoff_count === 'number' ? mw.handoff_count : keeper.handoff_count_total ?? '-' },
+    { label: 'Compactions', value: typeof mw?.compaction_events === 'number' ? mw.compaction_events : keeper.compaction_count ?? '-' },
+    { label: 'Saved tokens', value: typeof mw?.compaction_saved_tokens === 'number' ? mw.compaction_saved_tokens : keeper.last_compaction_saved_tokens ?? '-' },
+    { label: 'K2K events', value: keeper.k2k_count ?? '-' },
+    { label: 'Conversation tail', value: keeper.conversation_tail_count ?? '-' },
+    { label: 'Tool Calls', value: typeof mw?.tool_call_count === 'number' ? mw.tool_call_count : '-' },
+    { label: 'Preview Similarity', value: typeof mw?.proactive_preview_similarity_avg === 'number' ? `${(mw.proactive_preview_similarity_avg * 100).toFixed(1)}%` : '-' },
+    { label: 'Memory Avg Score', value: typeof mw?.memory_avg_score === 'number' ? mw.memory_avg_score.toFixed(3) : '-' },
+    { label: 'Fallback Rate', value: typeof mw?.fallback_rate === 'number' ? `${(mw.fallback_rate * 100).toFixed(1)}%` : '-' },
+  ]
+
+  const visibleRows = rows.filter(row =>
+    !(
+      row.value === '-'
+      || row.value === '—'
+      || row.value === ''
+    ))
+
+  if (visibleRows.length === 0) return null
+
+  return html`
+    <div class="keeper-signal-list">
+      ${visibleRows.map(r => html`
+        <div class="keeper-signal-row">
+          <span>${r.label}</span>
+          <strong>${r.value}</strong>
+        </div>
+      `)}
+    </div>
+  `
+}
+
+function KeeperNeighborhood({ keeper }: { keeper: Keeper }) {
+  const room = operatorSnapshot.value?.room ?? {}
+  const actions = (operatorSnapshot.value?.available_actions ?? [])
+    .filter(action => action.target_type === 'keeper' || action.target_type === 'room')
+    .slice(0, 8)
+  const recentTools = keeperRecentTools(keeper)
+  const topTools = keeperTopTools(keeper)
+  const missionBrief = missionKeeperBrief(keeper)
+  const allowedTools =
+    missionBrief?.allowed_tool_names && missionBrief.allowed_tool_names.length > 0
+      ? missionBrief.allowed_tool_names
+      : keeper.allowed_tool_names ?? []
+  const observedTools =
+    missionBrief?.latest_tool_names && missionBrief.latest_tool_names.length > 0
+      ? missionBrief.latest_tool_names
+      : keeper.latest_tool_names ?? []
+  const toolCallCount = missionBrief?.latest_tool_call_count ?? keeper.latest_tool_call_count
+  const auditSource = missionBrief?.tool_audit_source ?? keeper.tool_audit_source
+  const auditAt = missionBrief?.tool_audit_at ?? keeper.tool_audit_at
+  const capabilities = keeper.agent?.capabilities ?? []
+  const roomName = room.current_room ?? room.room_id ?? serverStatus.value?.room ?? 'default'
+  const project = room.project ?? serverStatus.value?.project ?? '확인 없음'
+  const cluster = room.cluster ?? serverStatus.value?.cluster ?? '확인 없음'
+  const allowlistFallback = toolAuditStateLabel(allowlistEmptyState(keeper))
+  const observedFallback = toolAuditStateLabel(observedToolsEmptyState(keeper, auditSource))
+  const metadataFallback = toolAuditStateLabel(auditMetadataState(keeper, auditSource))
+  const linkedRecentFallback = toolAuditStateLabel(linkedRecentToolsEmptyState(keeper))
+  const runtimeState = linkedRuntimeState(keeper)
+  const currentTaskLabel =
+    keeper.agent?.current_task
+    ?? (runtimeState === 'offline' ? 'offline' : 'not_collected')
+  const skillRouteLabel =
+    keeper.skill_primary
+    ?? (runtimeState === 'offline' ? 'offline' : 'not_collected')
+  const openToolsQuery = allowedTools[0] ?? observedTools[0] ?? recentTools[0] ?? null
+
+  return html`
+    <div class="keeper-signal-list">
+      <div class="keeper-signal-row">
+        <span>Room</span>
+        <strong>${roomName}</strong>
+      </div>
+      <div class="keeper-signal-row">
+        <span>Project</span>
+        <strong>${project}</strong>
+      </div>
+      <div class="keeper-signal-row">
+        <span>Cluster</span>
+        <strong>${cluster}</strong>
+      </div>
+      <div class="keeper-signal-row">
+        <span>Current task</span>
+        <strong>${currentTaskLabel}</strong>
+      </div>
+      <div class="keeper-signal-row">
+        <span>Skill route</span>
+        <strong>${skillRouteLabel}</strong>
+      </div>
+      <div style="display:flex; justify-content:flex-end; margin-top:4px;">
+        <button class="control-btn ghost" onClick=${() => { openToolsInventory(openToolsQuery) }}>
+          Open tools panel
+        </button>
+      </div>
+      <div style="display:flex; flex-direction:column; gap:8px; margin-top:8px;">
+        <span style="font-size:12px; color:#888;">Allowed tools</span>
+        <span style="font-size:11px; color:#64748b;">Currently permitted tools for this keeper runtime.</span>
+        <div style="display:flex; flex-wrap:wrap; gap:6px;">
+          ${allowedTools.length > 0
+            ? allowedTools.map(tool => html`<span class="pill">${tool}</span>`)
+            : html`<span style="font-size:12px; color:#888;">${allowlistFallback}</span>`}
+        </div>
+      </div>
+      <div style="display:flex; flex-direction:column; gap:8px; margin-top:8px;">
+        <span style="font-size:12px; color:#888;">Observed tools</span>
+        <span style="font-size:11px; color:#64748b;">Recent execution evidence from heartbeat or runtime telemetry.</span>
+        <div style="display:flex; flex-wrap:wrap; gap:6px;">
+          ${observedTools.length > 0
+            ? observedTools.map(tool => html`<span class="pill">${tool}</span>`)
+            : html`<span style="font-size:12px; color:#888;">${observedFallback}</span>`}
+        </div>
+      </div>
+      <div class="keeper-signal-row">
+        <span>Tool calls</span>
+        <strong>${typeof toolCallCount === 'number' ? toolCallCount : observedFallback === 'none_recent' ? 0 : metadataFallback}</strong>
+      </div>
+      <div class="keeper-signal-row">
+        <span>Evidence source</span>
+        <strong>${auditSource ?? metadataFallback}</strong>
+      </div>
+      <div class="keeper-signal-row">
+        <span>Observed at</span>
+        <strong>${auditAt ? html`<${TimeAgo} timestamp=${auditAt} />` : metadataFallback}</strong>
+      </div>
+      <div style="display:flex; flex-direction:column; gap:8px; margin-top:8px;">
+        <span style="font-size:12px; color:#888;">Keeper recent tools</span>
+        <div style="display:flex; flex-wrap:wrap; gap:6px;">
+          ${recentTools.length > 0
+            ? recentTools.map(tool => html`<span class="pill">${tool}</span>`)
+            : html`<span style="font-size:12px; color:#888;">${linkedRecentFallback}</span>`}
+        </div>
+      </div>
+      ${topTools.length > 0
+        ? html`
+            <div style="display:flex; flex-direction:column; gap:8px; margin-top:8px;">
+              <span style="font-size:12px; color:#888;">Window top tools</span>
+              <div style="display:flex; flex-wrap:wrap; gap:6px;">
+                ${topTools.map(tool => html`<span class="pill">${tool}</span>`)}
+              </div>
+            </div>
+          `
+        : null}
+      <div style="display:flex; flex-direction:column; gap:8px; margin-top:8px;">
+        <span style="font-size:12px; color:#888;">Capabilities</span>
+        <div style="display:flex; flex-wrap:wrap; gap:6px;">
+          ${capabilities.length > 0
+            ? capabilities.map(capability => html`<span class="pill">${capability}</span>`)
+            : html`<span style="font-size:12px; color:#888;">등록된 capability 없음</span>`}
+        </div>
+      </div>
+      <div style="display:flex; flex-direction:column; gap:8px; margin-top:8px;">
+        <span style="font-size:12px; color:#888;">Available actions nearby</span>
+        <div style="display:flex; flex-wrap:wrap; gap:6px;">
+          ${actions.length > 0
+            ? actions.map(action => html`<span class="pill">${actionDescriptorLabel(action.action_type)}</span>`)
+            : html`<span style="font-size:12px; color:#888;">operator action 광고 없음</span>`}
+        </div>
+      </div>
+    </div>
+  `
+}
+
+// ── Main Detail Overlay ───────────────────────────────────
+
+function currentOperatorActor(): string {
+  const q = new URLSearchParams(window.location.search)
+  const queryActor = q.get('agent') ?? q.get('agent_name')
+  const storedActor = localStorage.getItem('masc_dashboard_agent_name')
+  const actor = (queryActor ?? storedActor ?? 'dashboard').trim()
+  return actor || 'dashboard'
+}
+
 async function pokeLodgeNow(): Promise<void> {
   try {
     const response = await runOperatorAction({
-      actor: currentDashboardActor(),
+      actor: currentOperatorActor(),
       action_type: 'lodge_tick',
       target_type: 'room',
       payload: {},
@@ -189,20 +624,20 @@ async function pokeLodgeNow(): Promise<void> {
 
 function KeeperCommsPanel({ keeper }: { keeper: Keeper }) {
   return html`
-    <div style="margin-top:24px; border-top:1px solid rgba(255,255,255,0.1); padding-top:24px;">
-      <h3 style="margin:0 0 16px; color: var(--accent-cyan); font-family: var(--font-display);">Direct Comms & Runtime Diagnostics</h3>
+    <div style="margin-top: 24px; border-top: 1px solid rgba(255,255,255,0.1); padding-top: 24px;">
+      <h3 style="margin: 0 0 16px; color: var(--accent-cyan); font-family: var(--font-display);">Direct Comms & Runtime Diagnostics</h3>
 
-      <div style="display:grid; grid-template-columns:1fr 1fr; gap:20px;">
-        <div style="display:flex; flex-direction:column; gap:12px;">
+      <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 20px;">
+        <div style="display: flex; flex-direction: column; gap: 12px;">
           <${KeeperDiagnosticSummary} keeper=${keeper} />
           <${KeeperRuntimeActions}
-            actor=${currentDashboardActor()}
+            actor=${currentOperatorActor()}
             keeper=${keeper}
             onPokeLodge=${() => { void pokeLodgeNow() }}
           />
         </div>
 
-        <div style="min-height:345px;">
+        <div style="min-height: 345px;">
           <${KeeperConversationPanel}
             keeperName=${keeper.name}
             placeholder="Direct prompt for this keeper"
@@ -217,9 +652,6 @@ export function KeeperDetailOverlay() {
   const keeper = selectedKeeper.value
   if (!keeper) return null
 
-  const keeperIdentity = keeperIdentityHint(keeper.name, keeper.agent_name)
-  const profileItems = (keeper.traits?.length ?? 0) > 0 || (keeper.interests?.length ?? 0) > 0 || Boolean(keeper.skill_primary) || Boolean(keeper.last_heartbeat)
-
   return html`
     <div
       class="keeper-detail-overlay"
@@ -232,16 +664,16 @@ export function KeeperDetailOverlay() {
       }}
     >
       <div style="max-width:780px; width:100%; max-height:90vh; overflow-y:auto; background:#1a1a2e; border-radius:16px; border:1px solid rgba(255,255,255,0.08); padding:24px;">
+        ${'' /* Header */}
         <div style="display:flex; align-items:center; justify-content:space-between; margin-bottom:20px;">
           <div style="display:flex; align-items:center; gap:12px;">
             <span style="font-size:32px;">${keeper.emoji}</span>
             <div>
               <h2 style="margin:0; font-size:20px; color:#e0e0e0;">${keeper.name}</h2>
               ${keeper.koreanName ? html`<div style="font-size:13px; color:#888;">${keeper.koreanName}</div>` : null}
-              ${keeperIdentity ? html`<div style="font-size:12px; color:#94a3b8;">${keeperIdentity}</div>` : null}
-              ${keeper.agent_name ? html`<div style="font-size:12px; color:#888;">Runtime agent: ${keeper.agent_name}</div>` : null}
             </div>
             <${StatusBadge} status=${keeper.status} />
+            ${keeper.model ? html`<span class="pill">${keeper.model}</span>` : null}
           </div>
           <button
             onClick=${() => closeKeeperDetail()}
@@ -249,69 +681,110 @@ export function KeeperDetailOverlay() {
           >✕</button>
         </div>
 
+        ${'' /* KPIs */}
+        <${KpiGrid} keeper=${keeper} />
+
+        ${'' /* Context chart */}
         <${ContextChart} keeper=${keeper} />
 
+        ${'' /* Two-column grid for sections */}
         <div style="display:grid; grid-template-columns:1fr 1fr; gap:16px; margin-top:16px;">
-          ${profileItems
+
+          ${'' /* Left: Field Dictionary */}
+          <${Card} title="Field Dictionary">
+            <${FieldDictionary} keeper=${keeper} />
+          <//>
+
+          ${'' /* Right: Traits + Interests */}
+          <${Card} title="Profile">
+            <${TraitsList} traits=${keeper.traits ?? []} label="Traits" />
+            <${TraitsList} traits=${keeper.interests ?? []} label="Interests" />
+            ${keeper.primaryValue
+              ? html`<div style="font-size:12px; color:#888;">Primary value: <span style="color:#4ade80;">${keeper.primaryValue}</span></div>`
+              : null}
+            ${keeper.skill_primary
+              ? html`<div style="font-size:12px; color:#888; margin-top:6px;">
+                  Skill route: <span style="color:#22d3ee;">${keeper.skill_primary}</span>
+                </div>`
+              : null}
+            ${keeper.skill_reason
+              ? html`<div style="font-size:12px; color:#888; margin-top:4px;">${keeper.skill_reason}</div>`
+              : null}
+            ${keeper.last_heartbeat
+              ? html`<div style="font-size:12px; color:#888; margin-top:6px;">
+                  Last heartbeat: <${TimeAgo} timestamp=${keeper.last_heartbeat} />
+                </div>`
+              : null}
+          <//>
+
+          ${'' /* Autonomy Level (if available) */}
+          ${keeper.autonomy_level
             ? html`
-                <${Card} title="Profile">
-                  <${TraitsList} traits=${keeper.traits ?? []} label="Traits" />
-                  <${TraitsList} traits=${keeper.interests ?? []} label="Interests" />
-                  ${keeper.skill_primary
-                    ? html`<div style="font-size:12px; color:#888; margin-top:6px;">Skill route: <span style="color:#22d3ee;">${keeper.skill_primary}</span></div>`
-                    : null}
-                  ${keeper.last_heartbeat
-                    ? html`<div style="font-size:12px; color:#888; margin-top:6px;">Last heartbeat: <${TimeAgo} timestamp=${keeper.last_heartbeat} /></div>`
-                    : null}
-                <//>
-              `
+              <${Card} title="Autonomy">
+                <${AutonomyMeter} keeper=${keeper} />
+              <//>
+            `
             : null}
 
+          ${'' /* TRPG Stats (if available) */}
           ${keeper.trpg_stats
             ? html`
-                <${Card} title="TRPG Stats">
-                  <${TrpgStats} stats=${keeper.trpg_stats} />
-                <//>
-              `
+              <${Card} title="TRPG Stats">
+                <${TrpgStats} stats=${keeper.trpg_stats} />
+              <//>
+            `
             : null}
 
+          ${'' /* Equipment */}
           ${keeper.inventory && keeper.inventory.length > 0
             ? html`
-                <${Card} title="Equipment (${keeper.inventory.length})">
-                  <${EquipmentList} items=${keeper.inventory} />
-                <//>
-              `
+              <${Card} title="Equipment (${keeper.inventory.length})">
+                <${EquipmentList} items=${keeper.inventory} />
+              <//>
+            `
             : null}
 
+          ${'' /* Relationships */}
           ${keeper.relationships && Object.keys(keeper.relationships).length > 0
             ? html`
-                <${Card} title="Relationships (${Object.keys(keeper.relationships).length})">
-                  <${RelationshipList} rels=${keeper.relationships} />
-                <//>
-              `
+              <${Card} title="Relationships (${Object.keys(keeper.relationships).length})">
+                <${RelationshipList} rels=${keeper.relationships} />
+              <//>
+            `
             : null}
+
+          <${Card} title="Runtime Signals">
+            <${RuntimeSignals} keeper=${keeper} />
+          <//>
+
+          <${Card} title="Neighborhood & Tool Audit">
+            <${KeeperNeighborhood} keeper=${keeper} />
+          <//>
 
           <${Card} title="Memory & Context">
             <div class="keeper-signal-list">
               <div class="keeper-signal-row">
-                <span>Context pressure</span>
-                <strong>${contextPressureLabel(keeper.context?.context_ratio ?? keeper.context_ratio ?? null)}</strong>
+                <span>Context source</span>
+                <strong>${keeper.context_source ?? keeper.context?.source ?? '-'}</strong>
               </div>
               <div class="keeper-signal-row">
-                <span>Current ratio</span>
+                <span>Context tokens</span>
                 <strong>
-                  ${typeof (keeper.context?.context_ratio ?? keeper.context_ratio) === 'number'
-                    ? `${Math.round((keeper.context?.context_ratio ?? keeper.context_ratio ?? 0) * 100)}%`
-                    : '-'}
+                  ${keeper.context_tokens ?? keeper.context?.context_tokens ?? '-'}
+                  /
+                  ${keeper.context_max ?? keeper.context?.context_max ?? '-'}
                 </strong>
               </div>
               ${keeper.memory_recent_note
-                ? html`<div class="keeper-memory-note">${keeper.memory_recent_note}</div>`
+                ? html`
+                  <div class="keeper-memory-note">
+                    ${keeper.memory_recent_note}
+                  </div>
+                `
                 : html`<div class="empty-state" style="font-size:12px;">No recent memory note</div>`}
             </div>
           <//>
         </div>
-
         <${KeeperCommsPanel} keeper=${keeper} />
       </div>
     </div>

--- a/dashboard/src/components/keeper-shared.ts
+++ b/dashboard/src/components/keeper-shared.ts
@@ -97,13 +97,18 @@ export function KeeperDiagnosticSummary({
   return html`
     <div class="control-result-box">
       <div class="control-inline-meta">
+        ${continuityStateLabel(diagnostic?.continuity_state)
+          ? html`<span class="pill">${continuityStateLabel(diagnostic?.continuity_state)}</span>`
+          : null}
         <span class="pill">${diagnostic?.health_state ?? 'unknown'}</span>
         <span class="pill">${quietReasonLabel(diagnostic?.quiet_reason)}</span>
         <span class="pill">next ${nextActionLabel(diagnostic?.next_action_path ?? 'direct_message')}</span>
         ${busy ? html`<span class="pill">refreshing</span>` : null}
       </div>
       <div class="control-status-copy">
-        ${diagnostic?.summary ?? 'Keeper diagnostic summary is not available yet. Probe or open the detail overlay to inspect current runtime state.'}
+        ${diagnostic?.continuity_summary
+          ?? diagnostic?.summary
+          ?? 'Keeper diagnostic summary is not available yet. Probe or open the detail overlay to inspect current runtime state.'}
       </div>
       <div class="control-status-copy">
         Reply: ${diagnostic?.last_reply_status ?? 'unknown'}

--- a/dashboard/src/keeper-runtime.ts
+++ b/dashboard/src/keeper-runtime.ts
@@ -150,6 +150,9 @@ export function normalizeKeeperDiagnostic(raw: unknown): KeeperDiagnostic | null
     recoverable: diagnosticRecoverable(raw.recoverable, nextActionPath as KeeperDiagnostic['next_action_path']),
     summary: diagnosticSummary(raw.summary, healthState as KeeperDiagnostic['health_state'], (asString(raw.quiet_reason) ?? null) as KeeperDiagnostic['quiet_reason']),
     keepalive_running: typeof raw.keepalive_running === 'boolean' ? raw.keepalive_running : undefined,
+    continuity_state:
+      (asString(raw.continuity_state) ?? null) as KeeperDiagnostic['continuity_state'],
+    continuity_summary: asString(raw.continuity_summary) ?? null,
   }
 }
 

--- a/dashboard/src/keeper-store-normalize.ts
+++ b/dashboard/src/keeper-store-normalize.ts
@@ -139,6 +139,9 @@ function normalizeKeeperDiagnostic(raw: unknown): KeeperDiagnostic | null {
     summary: asString(raw.summary),
     keepalive_running:
       typeof raw.keepalive_running === 'boolean' ? raw.keepalive_running : undefined,
+    continuity_state:
+      (asString(raw.continuity_state) ?? null) as KeeperDiagnostic['continuity_state'],
+    continuity_summary: asString(raw.continuity_summary) ?? null,
   }
 }
 

--- a/dashboard/src/store.ts
+++ b/dashboard/src/store.ts
@@ -8,8 +8,6 @@ import type {
   Task,
   Message,
   Keeper,
-  KeeperMetricPoint,
-  KeeperDiagnostic,
   BoardPost,
   ServerStatus,
   PerpetualStatus,
@@ -24,6 +22,7 @@ import type {
   DashboardSemanticPanel,
   DashboardSemanticSurfaceId,
   DashboardExecutionHandoff,
+  DashboardExecutionSummary,
   DashboardExecutionQueueItem,
   DashboardExecutionSessionBrief,
   DashboardExecutionOperationBrief,
@@ -42,7 +41,12 @@ import {
   fetchTrpgState,
 } from './api'
 import { journal } from './sse'
-import { deriveKeeperDiagnostic, normalizeLodgeRuntimeStatus } from './keeper-runtime'
+import { normalizeLodgeRuntimeStatus } from './keeper-runtime'
+import {
+  deriveLifecycleState,
+  keeperFreshnessTs,
+  normalizeKeepers,
+} from './keeper-store-normalize'
 import { buildAgentMotion, type AgentMotionSnapshot } from './components/common/agent-motion'
 import { isRecord, asString, asNumber, asStringArray, toIsoTimestamp } from './components/common/normalize'
 
@@ -54,6 +58,7 @@ export const messages = signal<Message[]>([])
 export const keepers = signal<Keeper[]>([])
 export const serverStatus = signal<ServerStatus | null>(null)
 export const perpetualStatus = signal<PerpetualStatus | null>(null)
+export const executionSummary = signal<DashboardExecutionSummary | null>(null)
 export const executionQueue = signal<DashboardExecutionQueueItem[]>([])
 export const executionSessionBriefs = signal<DashboardExecutionSessionBrief[]>([])
 export const executionOperationBriefs = signal<DashboardExecutionOperationBrief[]>([])
@@ -149,30 +154,15 @@ export const agentMotionMap: ReadonlySignal<Map<string, AgentMotionSnapshot>> = 
   return map
 })
 
-// --- Keeper lifecycle derivation ---
-
-export function deriveLifecycleState(keeper: Keeper): KeeperLifecycleState {
-  const status = keeper.status?.toLowerCase() ?? ''
-  if (status === 'offline' || status === 'inactive') return 'offline'
-
-  const series = keeper.metrics_series
-  if (!series || series.length === 0) {
-    return 'idle'
-  }
-  const latest = series[series.length - 1]
-  if (!latest) return 'idle'
-  if (latest.is_handoff) return 'handoff-imminent'
-  if (latest.is_compaction) return 'compacting'
-  const ratio = latest.context_ratio
-  if (ratio > 0.85) return 'handoff-imminent'
-  if (ratio > 0.70) return 'preparing'
-  if (ratio > 0.50) return 'compacting'
-  return 'active'
-}
-
 export const keeperLifecycles: ReadonlySignal<Map<string, KeeperLifecycleState>> = computed(() => {
   const map = new Map<string, KeeperLifecycleState>()
   for (const k of keepers.value) {
+    const status = k.status?.toLowerCase() ?? ''
+    if (status === 'offline' || status === 'inactive') {
+      map.set(k.name, 'offline')
+      continue
+    }
+    if (!k.metrics_series || k.metrics_series.length === 0) continue
     map.set(k.name, deriveLifecycleState(k))
   }
   return map
@@ -180,25 +170,6 @@ export const keeperLifecycles: ReadonlySignal<Map<string, KeeperLifecycleState>>
 
 // Heartbeat staleness threshold (120 seconds)
 const HEARTBEAT_STALE_MS = 120_000
-
-function keeperFreshnessTs(keeper: Keeper, heartbeats: Map<string, number>): number | null {
-  const mapped = heartbeats.get(keeper.name)
-  if (mapped != null) return mapped
-
-  const direct = keeper.last_heartbeat ? Date.parse(keeper.last_heartbeat) : Number.NaN
-  if (!Number.isNaN(direct)) return direct
-
-  const ageSeconds = [
-    keeper.last_turn_ago_s,
-    keeper.last_proactive_ago_s,
-    keeper.last_handoff_ago_s,
-    keeper.last_compaction_ago_s,
-  ].find(value => typeof value === 'number' && Number.isFinite(value) && value >= 0)
-
-  return typeof ageSeconds === 'number'
-    ? Date.now() - (ageSeconds * 1000)
-    : null
-}
 
 export const staleKeepers: ReadonlySignal<Set<string>> = computed(() => {
   const now = Date.now()
@@ -320,6 +291,26 @@ function normalizeExecutionTone(value: unknown): DashboardExecutionQueueItem['se
   const raw = typeof value === 'string' ? value.toLowerCase() : ''
   if (raw === 'ok' || raw === 'warn' || raw === 'bad') return raw
   return 'ok'
+}
+
+function normalizeExecutionSummary(raw: unknown): DashboardExecutionSummary | null {
+  if (!isRecord(raw)) return null
+  return {
+    active_sessions: asNumber(raw.active_sessions),
+    blocked_sessions: asNumber(raw.blocked_sessions),
+    active_operations: asNumber(raw.active_operations),
+    blocked_operations: asNumber(raw.blocked_operations),
+    runtime_pressure: asNumber(raw.runtime_pressure),
+    worker_alerts: asNumber(raw.worker_alerts),
+    continuity_alerts: asNumber(raw.continuity_alerts),
+    priority_items: asNumber(raw.priority_items),
+    todo_tasks: asNumber(raw.todo_tasks),
+    claimed_tasks: asNumber(raw.claimed_tasks),
+    running_tasks: asNumber(raw.running_tasks),
+    done_tasks: asNumber(raw.done_tasks),
+    cancelled_tasks: asNumber(raw.cancelled_tasks),
+    keepers: asNumber(raw.keepers),
+  }
 }
 
 function normalizeExecutionHandoff(raw: unknown): DashboardExecutionHandoff | null {
@@ -552,204 +543,6 @@ function mergeMessages(current: Message[], incoming: Message[]): Message[] {
   return [...byKey.values()]
     .sort((a, b) => messageSortKey(a) - messageSortKey(b))
     .slice(-500)
-}
-
-function normalizeMetricsSeries(raw: unknown): KeeperMetricPoint[] {
-  if (!Array.isArray(raw)) return []
-  return raw
-    .map((item): KeeperMetricPoint | null => {
-      if (!isRecord(item)) return null
-      const ts = asNumber(item.ts_unix)
-      if (ts == null) return null
-      const handoffObj = isRecord(item.handoff) ? item.handoff : null
-      return {
-        ts,
-        context_ratio: asNumber(item.context_ratio) ?? 0,
-        context_tokens: asNumber(item.context_tokens) ?? 0,
-        context_max: asNumber(item.context_max) ?? 0,
-        latency_ms: asNumber(item.latency_ms) ?? 0,
-        generation: asNumber(item.generation) ?? 0,
-        channel: typeof item.channel === 'string' ? item.channel : 'turn',
-        is_handoff: handoffObj != null && item.handoff_performed === true,
-        is_compaction: item.compacted === true,
-        compaction_saved_tokens: asNumber(item.compaction_saved_tokens) ?? 0,
-        compaction_trigger: typeof item.compaction_trigger === 'string' ? item.compaction_trigger : null,
-        model_used: typeof item.model_used === 'string' ? item.model_used : '',
-        cost_usd: asNumber(item.cost_usd) ?? 0,
-        handoff_to_model: handoffObj ? (typeof handoffObj.to_model === 'string' ? handoffObj.to_model : null) : null,
-        handoff_new_generation: handoffObj ? (asNumber(handoffObj.new_generation) ?? null) : null,
-      }
-    })
-    .filter((item): item is KeeperMetricPoint => item !== null)
-}
-
-function normalizeKeeperDiagnostic(raw: unknown): KeeperDiagnostic | null {
-  if (!isRecord(raw)) return null
-  const healthState = asString(raw.health_state)
-  const nextActionPath = asString(raw.next_action_path)
-  const lastReplyStatus = asString(raw.last_reply_status)
-  if (!healthState || !nextActionPath || !lastReplyStatus) return null
-  const quietReason = (asString(raw.quiet_reason) ?? null) as KeeperDiagnostic['quiet_reason']
-  const summary =
-    asString(raw.summary)
-    ?? (
-      healthState === 'offline' || healthState === 'degraded' || healthState === 'stale'
-        ? 'Keeper is not in a healthy reply state. Probe or recover before relying on automation.'
-        : quietReason === 'quiet_hours'
-          ? 'Lodge quiet hours are active. Direct messages still work, but scheduled social ticks may look asleep.'
-          : quietReason === 'min_gap'
-            ? 'Keeper is inside its proactive cooldown window. Direct messages work now; autonomous check-ins will wait.'
-            : quietReason === 'never_started'
-              ? 'Keeper metadata exists but no reply turn has been recorded yet.'
-              : 'Keeper is reachable. Send a direct message for an immediate response.'
-    )
-  return {
-    health_state: healthState as KeeperDiagnostic['health_state'],
-    quiet_reason: quietReason,
-    next_action_path: nextActionPath as KeeperDiagnostic['next_action_path'],
-    last_reply_status: lastReplyStatus as KeeperDiagnostic['last_reply_status'],
-    last_reply_at: toIsoTimestamp(raw.last_reply_at) ?? asString(raw.last_reply_at) ?? null,
-    last_reply_preview: asString(raw.last_reply_preview) ?? null,
-    last_error: asString(raw.last_error) ?? null,
-    next_eligible_at_s: asNumber(raw.next_eligible_at_s) ?? null,
-    recoverable:
-      typeof raw.recoverable === 'boolean'
-        ? raw.recoverable
-        : nextActionPath === 'recover',
-    summary,
-    keepalive_running:
-      typeof raw.keepalive_running === 'boolean' ? raw.keepalive_running : undefined,
-  }
-}
-
-function normalizeKeepers(raw: unknown, serverStatusValue?: ServerStatus | null): Keeper[] {
-  const rows =
-    Array.isArray(raw)
-      ? raw
-      : isRecord(raw) && Array.isArray(raw.keepers)
-        ? raw.keepers
-        : []
-
-  return rows
-    .map((row): Keeper | null => {
-      if (!isRecord(row)) return null
-      const agentRaw = isRecord(row.agent) ? row.agent : null
-      const contextRaw = isRecord(row.context) ? row.context : null
-      const metricsWindowRaw = isRecord(row.metrics_window) ? row.metrics_window : undefined
-
-      const name = asString(row.name)
-      if (!name) return null
-
-      const contextRatio = asNumber(row.context_ratio) ?? asNumber(contextRaw?.context_ratio)
-      const statusRaw = asString(row.status) ?? asString(agentRaw?.status) ?? 'offline'
-      const status = normalizeAgentStatus(statusRaw)
-      const model = asString(row.model) ?? asString(row.active_model) ?? asString(row.primary_model)
-      const skillSecondary = asStringArray(row.skill_secondary)
-
-      const normalizedContext =
-        contextRaw
-          ? {
-              source: asString(contextRaw.source),
-              context_ratio: asNumber(contextRaw.context_ratio),
-              context_tokens: asNumber(contextRaw.context_tokens),
-              context_max: asNumber(contextRaw.context_max),
-              message_count: asNumber(contextRaw.message_count),
-              has_checkpoint: typeof contextRaw.has_checkpoint === 'boolean' ? contextRaw.has_checkpoint : undefined,
-            }
-          : undefined
-
-      const normalizedAgent =
-        agentRaw
-          ? {
-              name: asString(agentRaw.name),
-              exists: typeof agentRaw.exists === 'boolean' ? agentRaw.exists : undefined,
-              error: asString(agentRaw.error),
-              agent_type: asString(agentRaw.agent_type),
-              status: asString(agentRaw.status),
-              current_task: asString(agentRaw.current_task) ?? null,
-              joined_at: asString(agentRaw.joined_at),
-              last_seen: asString(agentRaw.last_seen),
-              last_seen_ago_s: asNumber(agentRaw.last_seen_ago_s),
-              capabilities: asStringArray(agentRaw.capabilities),
-              is_zombie: typeof agentRaw.is_zombie === 'boolean' ? agentRaw.is_zombie : undefined,
-            }
-          : undefined
-
-      const metricsSeries = normalizeMetricsSeries(row.metrics_series)
-
-      const keeper: Keeper = {
-        name,
-        runtime_class:
-          row.runtime_class === 'persistent_agent' ? 'persistent_agent' : 'resident_keeper',
-        desired:
-          typeof row.desired === 'boolean' ? row.desired : undefined,
-        resident_registered:
-          typeof row.resident_registered === 'boolean' ? row.resident_registered : undefined,
-        reconcile_status: asString(row.reconcile_status) ?? null,
-        emoji: asString(row.emoji),
-        koreanName: asString(row.koreanName) ?? asString(row.korean_name),
-        agent_name: asString(row.agent_name),
-        trace_id: asString(row.trace_id),
-        model,
-        primary_model: asString(row.primary_model),
-        active_model: asString(row.active_model),
-        next_model_hint: asString(row.next_model_hint) ?? null,
-        status,
-        presence_keepalive:
-          typeof row.presence_keepalive === 'boolean' ? row.presence_keepalive : undefined,
-        presence_keepalive_sec: asNumber(row.presence_keepalive_sec),
-        keepalive_running:
-          typeof row.keepalive_running === 'boolean' ? row.keepalive_running : undefined,
-        proactive_enabled:
-          typeof row.proactive_enabled === 'boolean' ? row.proactive_enabled : undefined,
-        proactive_idle_sec: asNumber(row.proactive_idle_sec),
-        proactive_cooldown_sec: asNumber(row.proactive_cooldown_sec),
-        last_heartbeat: asString(row.last_heartbeat) ?? asString(agentRaw?.last_seen),
-        generation: asNumber(row.generation),
-        turn_count: asNumber(row.turn_count) ?? asNumber(row.total_turns),
-        keeper_age_s: asNumber(row.keeper_age_s),
-        last_turn_ago_s: asNumber(row.last_turn_ago_s),
-        last_handoff_ago_s: asNumber(row.last_handoff_ago_s),
-        last_compaction_ago_s: asNumber(row.last_compaction_ago_s),
-        last_proactive_ago_s: asNumber(row.last_proactive_ago_s),
-        last_proactive_preview: asString(row.last_proactive_preview) ?? null,
-        context_ratio: contextRatio,
-        context_tokens: asNumber(row.context_tokens) ?? asNumber(contextRaw?.context_tokens),
-        context_max: asNumber(row.context_max) ?? asNumber(contextRaw?.context_max),
-        context_source: asString(row.context_source) ?? asString(contextRaw?.source),
-        context: normalizedContext,
-        traits: asStringArray(row.traits),
-        interests: asStringArray(row.interests),
-        primaryValue: asString(row.primaryValue) ?? asString(row.primary_value),
-        activityLevel: asNumber(row.activityLevel) ?? asNumber(row.activity_level),
-        memory_recent_note: asString(row.memory_recent_note) ?? null,
-        recent_input_preview: asString(row.recent_input_preview) ?? null,
-        recent_output_preview: asString(row.recent_output_preview) ?? null,
-        recent_tool_names: asStringArray(row.recent_tool_names) ?? [],
-        allowed_tool_names: asStringArray(row.allowed_tool_names) ?? [],
-        latest_tool_names: asStringArray(row.latest_tool_names) ?? [],
-        latest_tool_call_count: asNumber(row.latest_tool_call_count) ?? null,
-        tool_audit_source: asString(row.tool_audit_source) ?? null,
-        tool_audit_at: toIsoTimestamp(row.tool_audit_at) ?? asString(row.tool_audit_at) ?? null,
-        conversation_tail_count: asNumber(row.conversation_tail_count),
-        k2k_count: asNumber(row.k2k_count),
-        handoff_count_total: asNumber(row.handoff_count_total) ?? asNumber(row.trace_history_count),
-        compaction_count: asNumber(row.compaction_count),
-        last_compaction_saved_tokens: asNumber(row.last_compaction_saved_tokens),
-        diagnostic: normalizeKeeperDiagnostic(row.diagnostic),
-        skill_primary: asString(row.skill_primary) ?? null,
-        skill_secondary: skillSecondary,
-        skill_reason: asString(row.skill_reason) ?? null,
-        metrics_series: metricsSeries.length > 0 ? metricsSeries : undefined,
-        metrics_window: metricsWindowRaw as Keeper['metrics_window'],
-        agent: normalizedAgent,
-      }
-      keeper.diagnostic =
-        normalizeKeeperDiagnostic(row.diagnostic)
-        ?? deriveKeeperDiagnostic(keeper, serverStatusValue?.lodge ?? null)
-      return keeper
-    })
-    .filter((row): row is Keeper => row !== null)
 }
 
 function normalizeBuildIdentity(raw: unknown): ServerStatus['build'] | undefined {
@@ -1103,7 +896,8 @@ export async function refreshExecution(): Promise<void> {
       .map(normalizeMessage)
       .filter((row): row is Message => row !== null)
     messages.value = roomChanged ? executionMessages : mergeMessages(messages.value, executionMessages)
-    keepers.value = normalizeKeepers(data.keepers, normalizedStatus ?? serverStatus.value)
+    keepers.value = normalizeKeepers(data.keepers)
+    executionSummary.value = normalizeExecutionSummary(data.summary)
     executionLodgeTick.value = normalizeExecutionLodgeTick(data.lodge_tick)
     executionLodgeCheckins.value = (Array.isArray(data.lodge_checkins) ? data.lodge_checkins : [])
       .map(normalizeExecutionLodgeCheckin)

--- a/dashboard/src/types.ts
+++ b/dashboard/src/types.ts
@@ -214,6 +214,12 @@ export type KeeperReplyStatus =
   | 'error'
   | 'unknown'
 
+export type KeeperContinuityState =
+  | 'desired_offline'
+  | 'recovering'
+  | 'healthy'
+  | 'offline'
+
 export interface KeeperDiagnostic {
   health_state: KeeperHealthState
   quiet_reason?: KeeperQuietReason | null
@@ -226,6 +232,8 @@ export interface KeeperDiagnostic {
   recoverable?: boolean
   summary?: string
   keepalive_running?: boolean
+  continuity_state?: KeeperContinuityState | null
+  continuity_summary?: string | null
 }
 
 export type KeeperConversationRole = 'user' | 'assistant' | 'system' | 'tool' | 'other'
@@ -1316,9 +1324,6 @@ export interface DashboardMissionSessionCard extends DashboardMissionSessionBrie
 
 export interface DashboardMissionAgentBrief {
   agent_name: string
-  display_name?: string | null
-  is_live?: boolean
-  archived_reason?: string | null
   status?: string
   where?: string | null
   with_whom: string[]

--- a/lib/mcp_server_eio.ml
+++ b/lib/mcp_server_eio.ml
@@ -3416,7 +3416,7 @@ let tool_json_for_profile ?usage_summary profile (schema : Types.tool_schema) =
           (List.map Mcp_server.icon_to_json (tool_icons_for_name schema.name)) );
       ("inputSchema", schema.input_schema);
     ]
-    @ Tool_catalog.metadata_to_fields schema.name
+    @ Tool_catalog.public_contract_fields schema.name
     @ maybe_assoc_field "outputSchema" (tool_output_schema_field schema.name)
     @ maybe_assoc_field "annotations" (tool_annotations_for_profile profile schema.name)
     @

--- a/lib/mcp_server_eio.ml
+++ b/lib/mcp_server_eio.ml
@@ -3406,10 +3406,6 @@ let tool_output_schema_field = function
   | _ -> None
 
 let tool_json_for_profile ?usage_summary profile (schema : Types.tool_schema) =
-  let implementation_status =
-    Tool_catalog.implementation_status schema.name
-    |> Tool_catalog.implementation_status_to_string
-  in
   let base =
     [
       ("name", `String schema.name);
@@ -3419,8 +3415,8 @@ let tool_json_for_profile ?usage_summary profile (schema : Types.tool_schema) =
         `List
           (List.map Mcp_server.icon_to_json (tool_icons_for_name schema.name)) );
       ("inputSchema", schema.input_schema);
-      ("implementationStatus", `String implementation_status);
     ]
+    @ Tool_catalog.metadata_to_fields schema.name
     @ maybe_assoc_field "outputSchema" (tool_output_schema_field schema.name)
     @ maybe_assoc_field "annotations" (tool_annotations_for_profile profile schema.name)
     @

--- a/lib/mcp_server_eio.ml
+++ b/lib/mcp_server_eio.ml
@@ -3416,7 +3416,7 @@ let tool_json_for_profile ?usage_summary profile (schema : Types.tool_schema) =
           (List.map Mcp_server.icon_to_json (tool_icons_for_name schema.name)) );
       ("inputSchema", schema.input_schema);
     ]
-    @ Tool_catalog.public_contract_fields schema.name
+    @ Tool_catalog.metadata_to_fields schema.name
     @ maybe_assoc_field "outputSchema" (tool_output_schema_field schema.name)
     @ maybe_assoc_field "annotations" (tool_annotations_for_profile profile schema.name)
     @

--- a/lib/operator_control.ml
+++ b/lib/operator_control.ml
@@ -762,14 +762,10 @@ let sessions_json config =
 
 let room_json config =
   let initialized = Room.is_initialized config in
-  let current_room = Room.current_room_id config in
   if not initialized then
     `Assoc
       [
         ("initialized", `Bool false);
-        ("room", `String current_room);
-        ("room_id", `String current_room);
-        ("current_room", `String current_room);
         ("project", `String (Filename.basename config.base_path));
       ]
   else
@@ -780,11 +776,9 @@ let room_json config =
     `Assoc
       [
         ("initialized", `Bool true);
-        ("room", `String current_room);
-        ("room_id", `String current_room);
         ("cluster", `String (Option.value ~default:"default" (Sys.getenv_opt "MASC_CLUSTER_NAME")));
         ("project", `String state.project);
-        ("current_room", `String current_room);
+        ("current_room", string_option_to_json (Room.read_current_room config));
         ("paused", `Bool state.paused);
         ("pause_reason", string_option_to_json state.pause_reason);
         ("paused_by", string_option_to_json state.paused_by);
@@ -2943,23 +2937,6 @@ let swarm_run_chain_preview (request : action_request) swarm_json =
 let json_of_dispatch_output body =
   try Yojson.Safe.from_string body with Yojson.Json_error _ -> `String body
 
-let first_nonempty_string_field keys json =
-  let rec loop = function
-    | [] -> None
-    | key :: rest -> (
-        match U.member key json with
-        | `String value when String.trim value <> "" -> Some (String.trim value)
-        | _ -> loop rest)
-  in
-  loop keys
-
-let keeper_reply_text dispatched_json =
-  match dispatched_json with
-  | `String value when String.trim value <> "" -> Some (String.trim value)
-  | `Assoc _ ->
-      first_nonempty_string_field [ "reply"; "content"; "text"; "message" ] dispatched_json
-  | _ -> None
-
 let string_of_trigger = function
   | Lodge_heartbeat.Scheduled -> "scheduled"
   | Lodge_heartbeat.ContentAlert _ -> "content_alert"
@@ -3528,13 +3505,11 @@ let execute_action (ctx : 'a context) (request : action_request) :
         | None -> Error "masc_keeper_msg dispatch unavailable"
       in
       let _ = ok in
-      let dispatched_json = json_of_dispatch_output body in
       Ok
         (`Assoc
           [
             ("delegated_tool", `String "masc_keeper_msg");
-            ("result", dispatched_json);
-            ("reply", string_option_to_json (keeper_reply_text dispatched_json));
+            ("result", json_of_dispatch_output body);
           ])
   | "swarm_run_continue" ->
       let* () = validate_target_type "swarm_run" request in

--- a/lib/server_dashboard_http.ml
+++ b/lib/server_dashboard_http.ml
@@ -2478,6 +2478,9 @@ let dashboard_proof_http_json ~state request =
 
 let dashboard_shell_status_json (config : Room.config) : Yojson.Safe.t =
   let room_state = Room.read_state config in
+  let current_room =
+    Room.read_current_room config |> Option.value ~default:"default"
+  in
   let tempo = Tempo.get_tempo config in
   let lodge_json = Lodge_heartbeat.(lodge_status () |> lodge_status_to_json) in
   let gardener_json = Gardener.status_json () in
@@ -2486,7 +2489,8 @@ let dashboard_shell_status_json (config : Room.config) : Yojson.Safe.t =
   let build = Build_identity.current () in
   `Assoc
     [
-      ("room", `String room_state.project);
+      ("room", `String current_room);
+      ("current_room", `String current_room);
       ("room_base_path", `String config.base_path);
       ( "cluster",
         `String (Option.value ~default:"unknown" (Sys.getenv_opt "MASC_CLUSTER_NAME"))
@@ -2571,6 +2575,11 @@ let json_record_field key json =
   match Yojson.Safe.Util.member key json with
   | `Assoc _ as value -> Some value
   | _ -> None
+
+let count_where items predicate =
+  List.fold_left
+    (fun acc item -> if predicate item then acc + 1 else acc)
+    0 items
 
 let dashboard_current_room_id config =
   Room.current_room_id config
@@ -2687,10 +2696,64 @@ let dashboard_room_truth_http_json ~state ~sw ~clock request =
     | `List items -> items
     | _ -> []
   in
+  let execution_session_briefs = json_list_field "session_briefs" execution_json in
+  let execution_operation_briefs = json_list_field "operation_briefs" execution_json in
+  let execution_worker_support =
+    json_list_field "worker_support_briefs" execution_json
+  in
+  let execution_continuity =
+    json_list_field "continuity_briefs" execution_json
+  in
+  let execution_keepers = json_list_field "keepers" execution_json in
   let top_queue =
     match execution_queue with
     | head :: _ -> head
     | [] -> `Null
+  in
+  let has_text key json =
+    match json_string_field_opt key json with
+    | Some _ -> true
+    | None -> false
+  in
+  let execution_summary =
+    let existing = json_assoc_field "summary" execution_json in
+    match Yojson.Safe.Util.member "blocked_sessions" existing with
+    | `Int _ | `Intlit _ ->
+        existing
+    | _ ->
+        `Assoc
+          [
+            ("active_sessions", `Int (List.length execution_session_briefs));
+            ( "blocked_sessions",
+              `Int
+                (count_where execution_session_briefs
+                   (fun row ->
+                     let health = json_string_field_opt "health" row in
+                     let status = json_string_field_opt "status" row in
+                     has_text "blocker_summary" row
+                     || health = Some "warn"
+                     || health = Some "bad"
+                     || status = Some "blocked")) );
+            ("active_operations", `Int (List.length execution_operation_briefs));
+            ( "blocked_operations",
+              `Int (count_where execution_operation_briefs (has_text "blocker_summary")) );
+            ( "worker_alerts",
+              `Int
+                (count_where execution_worker_support
+                   (fun row ->
+                     match json_string_field_opt "tone" row with
+                     | Some "warn" | Some "bad" -> true
+                     | _ -> false)) );
+            ( "continuity_alerts",
+              `Int
+                (count_where execution_continuity
+                   (fun row ->
+                     match json_string_field_opt "tone" row with
+                     | Some "warn" | Some "bad" -> true
+                     | _ -> false)) );
+            ("priority_items", `Int (List.length execution_queue));
+            ("keepers", `Int (List.length execution_keepers));
+          ]
   in
   let command_ops = json_assoc_field "operations" command_summary_json in
   let command_detachments = json_assoc_field "detachments" command_summary_json in
@@ -2794,7 +2857,7 @@ let dashboard_room_truth_http_json ~state ~sw ~clock request =
       ( "execution",
         `Assoc
           [
-            ("summary", json_assoc_field "summary" execution_json);
+            ("summary", execution_summary);
             ("top_queue", top_queue);
             ("provenance", `String "derived");
           ] );

--- a/lib/server_dashboard_http.ml
+++ b/lib/server_dashboard_http.ml
@@ -1876,6 +1876,13 @@ let keepers_dashboard_json ?(compact = false) (config : Room.config) : Yojson.Sa
                   ~keepalive_running
                   ~history_items:conversation_items
                   ~now_ts
+                |> Keeper_exec_status.augment_keeper_diagnostic_json
+                     ~desired:true
+                     ~meta:m
+                     ~keepalive_running
+                     ~keepalive_started_at:
+                       (Keeper_keepalive.keeper_keepalive_started_at m.name)
+                     ~now_ts
               in
               let detail_fields =
                 if compact then []
@@ -1934,6 +1941,10 @@ let keepers_dashboard_json ?(compact = false) (config : Room.config) : Yojson.Sa
               ("auto_handoff", `Bool m.auto_handoff);
               ("handoff_threshold", `Float m.handoff_threshold);
               ("agent", agent);
+              ( "status",
+                `String
+                  (Keeper_exec_status.keeper_surface_status ~agent_status:agent
+                     ~diagnostic) );
               ("diagnostic", diagnostic);
               ("keeper_age_s", `Float keeper_age_s);
               ("uptime_hours", `Float (keeper_age_s /. 3600.0));
@@ -2467,7 +2478,6 @@ let dashboard_proof_http_json ~state request =
 
 let dashboard_shell_status_json (config : Room.config) : Yojson.Safe.t =
   let room_state = Room.read_state config in
-  let current_room = Room.current_room_id config in
   let tempo = Tempo.get_tempo config in
   let lodge_json = Lodge_heartbeat.(lodge_status () |> lodge_status_to_json) in
   let gardener_json = Gardener.status_json () in
@@ -2476,8 +2486,7 @@ let dashboard_shell_status_json (config : Room.config) : Yojson.Safe.t =
   let build = Build_identity.current () in
   `Assoc
     [
-      ("room", `String current_room);
-      ("current_room", `String current_room);
+      ("room", `String room_state.project);
       ("room_base_path", `String config.base_path);
       ( "cluster",
         `String (Option.value ~default:"unknown" (Sys.getenv_opt "MASC_CLUSTER_NAME"))
@@ -2562,11 +2571,6 @@ let json_record_field key json =
   match Yojson.Safe.Util.member key json with
   | `Assoc _ as value -> Some value
   | _ -> None
-
-let count_where items predicate =
-  List.fold_left
-    (fun acc item -> if predicate item then acc + 1 else acc)
-    0 items
 
 let dashboard_current_room_id config =
   Room.current_room_id config
@@ -2683,64 +2687,10 @@ let dashboard_room_truth_http_json ~state ~sw ~clock request =
     | `List items -> items
     | _ -> []
   in
-  let execution_session_briefs = json_list_field "session_briefs" execution_json in
-  let execution_operation_briefs = json_list_field "operation_briefs" execution_json in
-  let execution_worker_support =
-    json_list_field "worker_support_briefs" execution_json
-  in
-  let execution_continuity =
-    json_list_field "continuity_briefs" execution_json
-  in
-  let execution_keepers = json_list_field "keepers" execution_json in
   let top_queue =
     match execution_queue with
     | head :: _ -> head
     | [] -> `Null
-  in
-  let has_text key json =
-    match json_string_field_opt key json with
-    | Some _ -> true
-    | None -> false
-  in
-  let execution_summary =
-    let existing = json_assoc_field "summary" execution_json in
-    match Yojson.Safe.Util.member "blocked_sessions" existing with
-    | `Int _ | `Intlit _ ->
-        existing
-    | _ ->
-        `Assoc
-          [
-            ("active_sessions", `Int (List.length execution_session_briefs));
-            ( "blocked_sessions",
-              `Int
-                (count_where execution_session_briefs
-                   (fun row ->
-                     let health = json_string_field_opt "health" row in
-                     let status = json_string_field_opt "status" row in
-                     has_text "blocker_summary" row
-                     || health = Some "warn"
-                     || health = Some "bad"
-                     || status = Some "blocked")) );
-            ("active_operations", `Int (List.length execution_operation_briefs));
-            ( "blocked_operations",
-              `Int (count_where execution_operation_briefs (has_text "blocker_summary")) );
-            ( "worker_alerts",
-              `Int
-                (count_where execution_worker_support
-                   (fun row ->
-                     match json_string_field_opt "tone" row with
-                     | Some "warn" | Some "bad" -> true
-                     | _ -> false)) );
-            ( "continuity_alerts",
-              `Int
-                (count_where execution_continuity
-                   (fun row ->
-                     match json_string_field_opt "tone" row with
-                     | Some "warn" | Some "bad" -> true
-                     | _ -> false)) );
-            ("priority_items", `Int (List.length execution_queue));
-            ("keepers", `Int (List.length execution_keepers));
-          ]
   in
   let command_ops = json_assoc_field "operations" command_summary_json in
   let command_detachments = json_assoc_field "detachments" command_summary_json in
@@ -2844,7 +2794,7 @@ let dashboard_room_truth_http_json ~state ~sw ~clock request =
       ( "execution",
         `Assoc
           [
-            ("summary", execution_summary);
+            ("summary", json_assoc_field "summary" execution_json);
             ("top_queue", top_queue);
             ("provenance", `String "derived");
           ] );

--- a/test/test_mcp_server_eio.ml
+++ b/test/test_mcp_server_eio.ml
@@ -725,8 +725,10 @@ let test_handle_request_tools_list_include_hidden_metadata () =
     (Yojson.Safe.Util.member "icons" status_tool <> `Null);
   Alcotest.(check bool) "standard tools expose annotations" true
     (Yojson.Safe.Util.member "annotations" status_tool <> `Null);
-  Alcotest.(check bool) "hidden metadata not leaked" false
+  Alcotest.(check bool) "visibility metadata exposed" true
     (Yojson.Safe.Util.member "visibility" status_tool <> `Null);
+  Alcotest.(check bool) "implementation status exposed" true
+    (Yojson.Safe.Util.member "implementationStatus" status_tool <> `Null);
   Alcotest.(check bool) "hidden utility omitted" false
     (List.exists
        (function

--- a/test/test_operator_control.ml
+++ b/test/test_operator_control.ml
@@ -153,11 +153,7 @@ let test_snapshot_has_expected_sections () =
       ignore (Room.add_task config ~title:"operator backlog" ~priority:2 ~description:"");
       ignore (Room.broadcast config ~from_agent:"owner" ~content:"operator snapshot seed");
       let json = Operator_control.snapshot_json (operator_ctx env sw config "owner") in
-      let room = Yojson.Safe.Util.member "room" json in
       Alcotest.(check bool) "room present" true (Yojson.Safe.Util.member "room" json <> `Null);
-      Alcotest.(check string) "room mirrors current_room"
-        Yojson.Safe.Util.(room |> member "current_room" |> to_string)
-        Yojson.Safe.Util.(room |> member "room" |> to_string);
       Alcotest.(check bool) "sessions present" true (Yojson.Safe.Util.member "sessions" json <> `Null);
       Alcotest.(check bool) "keepers present" true (Yojson.Safe.Util.member "keepers" json <> `Null);
       Alcotest.(check bool) "recent_messages present" true

--- a/test/test_tool_keeper.ml
+++ b/test/test_tool_keeper.ml
@@ -70,17 +70,6 @@ let with_env name value f =
       Unix.putenv name value;
       f ())
 
-let stop_keeper_via_tool env sw base_dir keeper_name =
-  let config = Masc_mcp.Room.default_config base_dir in
-  let keeper_ctx : _ Masc_mcp.Tool_keeper.context =
-    { config; sw; clock = Eio.Stdenv.clock env }
-  in
-  match
-    Masc_mcp.Tool_keeper.dispatch keeper_ctx ~name:"masc_keeper_down"
-      ~args:(`Assoc [ ("name", `String keeper_name) ])
-  with
-  | Some _ | None -> ()
-
 let string_is_valid_utf8 s =
   let len = String.length s in
   let rec loop i =
@@ -206,7 +195,7 @@ let test_keeper_model_set_persists_active_model () =
   let base_dir = temp_dir () in
   Fun.protect
     ~finally:(fun () ->
-      stop_keeper_via_tool env sw base_dir "sangsu";
+      Masc_mcp.Keeper_keepalive.stop_keepalive "sangsu";
       rm_rf base_dir)
     (fun () ->
       let config = Masc_mcp.Room.default_config base_dir in
@@ -319,7 +308,7 @@ let test_persona_list_and_create_from_persona () =
   let me_root = temp_dir () in
   Fun.protect
     ~finally:(fun () ->
-      stop_keeper_via_tool env sw base_dir "sangsu";
+      Masc_mcp.Keeper_keepalive.stop_keepalive "sangsu";
       rm_rf base_dir;
       rm_rf me_root)
     (fun () ->
@@ -503,7 +492,7 @@ let test_keeper_policy_tools_roundtrip () =
   let base_dir = temp_dir () in
   Fun.protect
     ~finally:(fun () ->
-      stop_keeper_via_tool env sw base_dir "sangsu";
+      Masc_mcp.Keeper_keepalive.stop_keepalive "sangsu";
       rm_rf base_dir)
     (fun () ->
       let reward_model_path = Filename.concat base_dir "reward-model.json" in
@@ -686,7 +675,7 @@ let test_keeper_policy_set_rejects_invalid_mode () =
   let base_dir = temp_dir () in
   Fun.protect
     ~finally:(fun () ->
-      stop_keeper_via_tool env sw base_dir "sangsu";
+      Masc_mcp.Keeper_keepalive.stop_keepalive "sangsu";
       rm_rf base_dir)
     (fun () ->
       let config = Masc_mcp.Room.default_config base_dir in
@@ -822,7 +811,7 @@ let test_resident_bootstrap_recovers_stale_explicit_keeper () =
   let base_dir = temp_dir () in
   Fun.protect
     ~finally:(fun () ->
-      stop_keeper_via_tool env sw base_dir "sangsu";
+      Masc_mcp.Keeper_keepalive.stop_keepalive "sangsu";
       rm_rf base_dir)
     (fun () ->
       let config = Masc_mcp.Room.default_config base_dir in
@@ -847,7 +836,7 @@ let test_resident_bootstrap_recovers_stale_explicit_keeper () =
             ])
       in
       check bool "keeper up ok" true ok;
-      stop_keeper_via_tool env sw base_dir "sangsu";
+      Masc_mcp.Keeper_keepalive.stop_keepalive "sangsu";
       let meta =
         match Masc_mcp.Keeper_types.read_meta config "sangsu" with
         | Ok (Some meta) -> meta


### PR DESCRIPTION
## Summary
- consolidate keeper continuity truth, auto-recover behavior, and low-confidence keeper metric filtering into one branch
- hide continuity/internal state blocks from user-facing keeper surfaces while preserving them for internal memory/meta use
- normalize dashboard keeper state in one place and rebuild dashboard assets once at the end

## Supersedes
- #887
- #889
- #884

## Validation
- `./_build/default/test/test_tool_keeper.exe`
- `./_build/default/test/test_operator_control.exe`
- `./_build/default/test/test_dashboard_execution.exe`
- `./_build/default/test/test_keeper_memory.exe`
- `npm ci --prefix dashboard`
- `npm run build --prefix dashboard`
- `./dashboard/node_modules/.bin/tsc --noEmit --pretty false -p dashboard/tsconfig.json`

## Notes
- `Health` is currently expected to stay noisy until #895 lands, because the job currently misses `--with-test` deps on base branches that do not include that fix yet.