### PR TITLE
fix: enforce MCP protocol continuity per session

### DIFF
--- a/lib/server_mcp_transport_http.ml
+++ b/lib/server_mcp_transport_http.ml
@@ -549,152 +549,163 @@ let handle_post_mcp ~deps ?(profile = Mcp_eio.Full) request reqd =
       let response = Httpun.Response.create ~headers `Conflict in
       Httpun.Reqd.respond_with_string reqd response body
   | Ok () ->
-      remember_mcp_profile session_id profile;
-      (match auth_result with
+      match validate_protocol_version_continuity ~session_id request with
       | Error msg ->
-          respond_mcp_auth_error ~deps request reqd ~session_id
-            ~protocol_version msg
-      | Ok () -> (
-          match classify_mcp_accept request with
-          | Http_negotiation.Rejected ->
-              let body =
-                Yojson.Safe.to_string
-                  (`Assoc
-                    [
-                      ("jsonrpc", `String "2.0");
-                      ( "error",
-                        `Assoc
-                          [
-                            ("code", `Int (-32600));
-                            ( "message",
-                              `String
-                                "Invalid Accept header: must include application/json and text/event-stream. Set MASC_ALLOW_LEGACY_ACCEPT=1 for temporary compatibility." );
-                          ] );
-                    ])
-              in
-              let headers =
-                Httpun.Headers.of_list
-                  (("content-length", string_of_int (String.length body))
-                  :: json_headers ~deps session_id protocol_version origin)
-              in
-              let response = Httpun.Response.create ~headers `Bad_request in
-              Httpun.Reqd.respond_with_string reqd response body
-          | accept_mode ->
-              let accept_warn_headers =
-                legacy_accept_warning_headers accept_mode
-              in
-              Http.Request.read_body_async reqd (fun body_str ->
-                  try
-                    match request_runtime_result deps with
-                    | Error msg ->
-                        respond_mcp_internal_error ~deps request reqd
-                          ~session_id ~protocol_version msg
-                    | Ok (state, sw, clock) ->
-                        let response_json =
-                          Mcp_eio.handle_request ~clock ~sw ~profile
-                            ~mcp_session_id:session_id ?auth_token state body_str
-                        in
-                        (match protocol_version_from_body body_str with
-                        | Some v -> remember_protocol_version session_id v
-                        | None -> ());
+          let body =
+            Printf.sprintf
+              {|{"jsonrpc":"2.0","error":{"code":-32600,"message":%s},"id":null}|}
+              (Yojson.Safe.to_string (`String msg))
+          in
+          let headers =
+            Httpun.Headers.of_list
+              (("content-length", string_of_int (String.length body))
+              :: json_headers ~deps session_id protocol_version origin)
+          in
+          let response = Httpun.Response.create ~headers `Bad_request in
+          Httpun.Reqd.respond_with_string reqd response body
+      | Ok () ->
+          remember_mcp_profile session_id profile;
+          match auth_result with
+          | Error msg ->
+              respond_mcp_auth_error ~deps request reqd ~session_id
+                ~protocol_version msg
+          | Ok () ->
+              match classify_mcp_accept request with
+              | Http_negotiation.Rejected ->
+                  let body =
+                    Yojson.Safe.to_string
+                      (`Assoc
+                        [
+                          ("jsonrpc", `String "2.0");
+                          ( "error",
+                            `Assoc
+                              [
+                                ("code", `Int (-32600));
+                                ( "message",
+                                  `String
+                                    "Invalid Accept header: must include application/json and text/event-stream. Set MASC_ALLOW_LEGACY_ACCEPT=1 for temporary compatibility." );
+                              ] );
+                        ])
+                  in
+                  let headers =
+                    Httpun.Headers.of_list
+                      (("content-length", string_of_int (String.length body))
+                      :: json_headers ~deps session_id protocol_version origin)
+                  in
+                  let response = Httpun.Response.create ~headers `Bad_request in
+                  Httpun.Reqd.respond_with_string reqd response body
+              | accept_mode ->
+                  let accept_warn_headers =
+                    legacy_accept_warning_headers accept_mode
+                  in
+                  Http.Request.read_body_async reqd (fun body_str ->
+                      try
+                        match request_runtime_result deps with
+                        | Error msg ->
+                            respond_mcp_internal_error ~deps request reqd
+                              ~session_id ~protocol_version msg
+                        | Ok (state, sw, clock) ->
+                            let response_json =
+                              Mcp_eio.handle_request ~clock ~sw ~profile
+                                ~mcp_session_id:session_id ?auth_token state body_str
+                            in
+                            (match protocol_version_from_body body_str with
+                            | Some v -> remember_protocol_version session_id v
+                            | None -> ());
+                            let protocol_version =
+                              get_protocol_version_for_session ~session_id request
+                            in
+                            let wants_sse =
+                              Http_negotiation.accepts_sse_header
+                                (Httpun.Headers.get request.headers "accept")
+                              && not force_json_response
+                              && not (request_force_json_response request)
+                            in
+                            if wants_sse then
+                              match response_json with
+                              | `Null ->
+                                  let headers =
+                                    Httpun.Headers.of_list
+                                      ( ("content-length", "0")
+                                      :: accept_warn_headers
+                                      @ mcp_headers session_id protocol_version )
+                                  in
+                                  let response =
+                                    Httpun.Response.create ~headers `Accepted
+                                  in
+                                  Httpun.Reqd.respond_with_string reqd response ""
+                              | json when is_http_error_response json ->
+                                  let body = Yojson.Safe.to_string json in
+                                  let headers =
+                                    Httpun.Headers.of_list
+                                      ( ("content-length", string_of_int (String.length body))
+                                      :: accept_warn_headers
+                                      @ json_headers ~deps session_id protocol_version
+                                          origin )
+                                  in
+                                  let response =
+                                    Httpun.Response.create ~headers `Bad_request
+                                  in
+                                  Httpun.Reqd.respond_with_string reqd response body
+                              | json ->
+                                  let event =
+                                    Sse.format_event ~event_type:"message"
+                                      (Yojson.Safe.to_string json)
+                                  in
+                                  let body = sse_prime_event () ^ event in
+                                  let headers =
+                                    Httpun.Headers.of_list
+                                      ( ("content-length", string_of_int (String.length body))
+                                      :: accept_warn_headers
+                                      @ sse_headers ~deps session_id protocol_version
+                                          origin )
+                                  in
+                                  let response = Httpun.Response.create ~headers `OK in
+                                  Httpun.Reqd.respond_with_string reqd response body
+                            else
+                              match response_json with
+                              | `Null ->
+                                  let headers =
+                                    Httpun.Headers.of_list
+                                      ( ("content-length", "0")
+                                      :: accept_warn_headers
+                                      @ mcp_headers session_id protocol_version )
+                                  in
+                                  let response =
+                                    Httpun.Response.create ~headers `Accepted
+                                  in
+                                  Httpun.Reqd.respond_with_string reqd response ""
+                              | json when is_http_error_response json ->
+                                  let body = Yojson.Safe.to_string json in
+                                  let headers =
+                                    Httpun.Headers.of_list
+                                      ( ("content-length", string_of_int (String.length body))
+                                      :: accept_warn_headers
+                                      @ json_headers ~deps session_id protocol_version
+                                          origin )
+                                  in
+                                  let response =
+                                    Httpun.Response.create ~headers `Bad_request
+                                  in
+                                  Httpun.Reqd.respond_with_string reqd response body
+                              | json ->
+                                  let body = Yojson.Safe.to_string json in
+                                  let headers =
+                                    Httpun.Headers.of_list
+                                      ( ("content-length", string_of_int (String.length body))
+                                      :: accept_warn_headers
+                                      @ json_headers ~deps session_id protocol_version
+                                          origin )
+                                  in
+                                  let response = Httpun.Response.create ~headers `OK in
+                                  Httpun.Reqd.respond_with_string reqd response body
+                      with exn ->
                         let protocol_version =
                           get_protocol_version_for_session ~session_id request
                         in
-                        let wants_sse =
-                          Http_negotiation.accepts_sse_header
-                            (Httpun.Headers.get request.headers "accept")
-                          && not force_json_response
-                          && not (request_force_json_response request)
-                        in
-                        if wants_sse then
-                          match response_json with
-                          | `Null ->
-                              let headers =
-                                Httpun.Headers.of_list
-                                  ( ("content-length", "0")
-                                  :: accept_warn_headers
-                                  @ mcp_headers session_id protocol_version )
-                              in
-                              let response =
-                                Httpun.Response.create ~headers `Accepted
-                              in
-                              Httpun.Reqd.respond_with_string reqd response ""
-                          | json when is_http_error_response json ->
-                              let body = Yojson.Safe.to_string json in
-                              let headers =
-                                Httpun.Headers.of_list
-                                  ( ("content-length", string_of_int (String.length body))
-                                  :: accept_warn_headers
-                                  @ json_headers ~deps session_id protocol_version
-                                      origin )
-                              in
-                              let response =
-                                Httpun.Response.create ~headers `Bad_request
-                              in
-                              Httpun.Reqd.respond_with_string reqd response body
-                          | json ->
-                              let event =
-                                Sse.format_event ~event_type:"message"
-                                  (Yojson.Safe.to_string json)
-                              in
-                              let body = sse_prime_event () ^ event in
-                              let headers =
-                                Httpun.Headers.of_list
-                                  ( ("content-length", string_of_int (String.length body))
-                                  :: accept_warn_headers
-                                  @ sse_headers ~deps session_id protocol_version
-                                      origin )
-                              in
-                              let response =
-                                Httpun.Response.create ~headers `OK
-                              in
-                              Httpun.Reqd.respond_with_string reqd response body
-                        else
-                          match response_json with
-                          | `Null ->
-                              let headers =
-                                Httpun.Headers.of_list
-                                  ( ("content-length", "0")
-                                  :: accept_warn_headers
-                                  @ mcp_headers session_id protocol_version )
-                              in
-                              let response =
-                                Httpun.Response.create ~headers `Accepted
-                              in
-                              Httpun.Reqd.respond_with_string reqd response ""
-                          | json when is_http_error_response json ->
-                              let body = Yojson.Safe.to_string json in
-                              let headers =
-                                Httpun.Headers.of_list
-                                  ( ("content-length", string_of_int (String.length body))
-                                  :: accept_warn_headers
-                                  @ json_headers ~deps session_id protocol_version
-                                      origin )
-                              in
-                              let response =
-                                Httpun.Response.create ~headers `Bad_request
-                              in
-                              Httpun.Reqd.respond_with_string reqd response body
-                          | json ->
-                              let body = Yojson.Safe.to_string json in
-                              let headers =
-                                Httpun.Headers.of_list
-                                  ( ("content-length", string_of_int (String.length body))
-                                  :: accept_warn_headers
-                                  @ json_headers ~deps session_id protocol_version
-                                      origin )
-                              in
-                              let response =
-                                Httpun.Response.create ~headers `OK
-                              in
-                              Httpun.Reqd.respond_with_string reqd response body
-                  with exn ->
-                    let protocol_version =
-                      get_protocol_version_for_session ~session_id request
-                    in
-	                    respond_mcp_internal_error ~deps request reqd ~session_id
-	                      ~protocol_version
-	                      ("Internal error: " ^ Printexc.to_string exn))))
+                        respond_mcp_internal_error ~deps request reqd ~session_id
+                          ~protocol_version
+                          ("Internal error: " ^ Printexc.to_string exn))
 
 let handle_get_mcp ~deps ?legacy_messages_endpoint ?(profile = Mcp_eio.Full)
     request reqd =
@@ -716,7 +727,22 @@ let handle_get_mcp ~deps ?legacy_messages_endpoint ?(profile = Mcp_eio.Full)
       in
       let response = Httpun.Response.create ~headers `Conflict in
       Httpun.Reqd.respond_with_string reqd response msg
-  | Ok () ->
+  | Ok () -> (
+      match validate_protocol_version_continuity ~session_id request with
+      | Error msg ->
+          let body =
+            Printf.sprintf
+              {|{"jsonrpc":"2.0","error":{"code":-32600,"message":%s},"id":null}|}
+              (Yojson.Safe.to_string (`String msg))
+          in
+          let headers =
+            Httpun.Headers.of_list
+              (("content-length", string_of_int (String.length body))
+              :: json_headers ~deps session_id protocol_version origin)
+          in
+          let response = Httpun.Response.create ~headers `Bad_request in
+          Httpun.Reqd.respond_with_string reqd response body
+      | Ok () ->
       remember_mcp_profile session_id profile;
       (match check_sse_connect_guard session_id with
       | Error (reason, retry_after_s) ->
@@ -808,7 +834,7 @@ let handle_get_mcp ~deps ?legacy_messages_endpoint ?(profile = Mcp_eio.Full)
           let client_count = Sse.client_count () in
           if client_count > Sse.max_clients / 2 then
             Printf.eprintf "📡 SSE connected: %s (active: %d/%d)\n%!"
-              session_id client_count Sse.max_clients)
+              session_id client_count Sse.max_clients))
 
 let sse_simple_handler ~deps request reqd =
   let origin = deps.get_origin request in

--- a/scripts/harness/contract/streamable_http_contract.sh
+++ b/scripts/harness/contract/streamable_http_contract.sh
@@ -10,13 +10,52 @@ cleanup() {
 }
 trap cleanup EXIT
 
+curl_with_retry() {
+  local attempt=1
+  local max_attempts="${CURL_RETRY_COUNT:-1}"
+  local retry_delay="${CURL_RETRY_DELAY_SEC:-1}"
+  local timeout_sec="${CURL_TIMEOUT_SEC:-25}"
+
+  while true; do
+    if curl --max-time "$timeout_sec" "$@"; then
+      return 0
+    fi
+    local status=$?
+    if [ "$attempt" -ge "$max_attempts" ]; then
+      return "$status"
+    fi
+    case "$status" in
+      7|28)
+        sleep "$retry_delay"
+        attempt=$((attempt + 1))
+        ;;
+      *)
+        return "$status"
+        ;;
+    esac
+  done
+}
+
+wait_for_mcp_ready() {
+  local timeout_sec="${MCP_READY_TIMEOUT_SEC:-20}"
+  local deadline=$(( $(date +%s) + timeout_sec ))
+  while [[ "$(date +%s)" -lt "$deadline" ]]; do
+    if curl -fsS --max-time 2 "$BASE_URL/health" >/dev/null 2>&1; then
+      return 0
+    fi
+    sleep 1
+  done
+  echo "FAIL: MCP server did not become ready at $BASE_URL" >&2
+  return 1
+}
+
 post_with_accept() {
   local accept_header="$1"
   local body="$2"
   local header_file="$3"
   local body_file="$4"
 
-  curl -sS -D "$header_file" -o "$body_file" \
+  curl_with_retry -sS -D "$header_file" -o "$body_file" \
     -X POST "$MCP_URL" \
     -H 'Content-Type: application/json' \
     -H "Accept: $accept_header" \
@@ -39,7 +78,7 @@ post_with_session() {
     extra_headers+=(-H "Mcp-Protocol-Version: $protocol_version")
   fi
 
-  curl -sS -D "$header_file" -o "$body_file" \
+  curl_with_retry -sS -D "$header_file" -o "$body_file" \
     -X POST "$MCP_URL" \
     "${extra_headers[@]}" \
     -d "$body"
@@ -59,7 +98,7 @@ get_with_session() {
     extra_headers+=(-H "Mcp-Protocol-Version: $protocol_version")
   fi
 
-  curl -sS -D "$header_file" -o "$body_file" --max-time 2 \
+  curl_with_retry -sS -D "$header_file" -o "$body_file" --max-time 2 \
     "$MCP_URL" \
     "${extra_headers[@]}" || true
 }
@@ -77,7 +116,7 @@ delete_with_session() {
     extra_headers+=(-H "Mcp-Protocol-Version: $protocol_version")
   fi
 
-  curl -sS -D "$header_file" -o "$body_file" \
+  curl_with_retry -sS -D "$header_file" -o "$body_file" \
     -X DELETE "$MCP_URL" \
     "${extra_headers[@]}"
 }
@@ -118,6 +157,7 @@ header_value() {
 }
 
 echo "[1/8] strict Accept rejection"
+wait_for_mcp_ready
 h1="$tmpdir/reject.headers"
 b1="$tmpdir/reject.body"
 post_with_accept "application/json" \

--- a/scripts/harness/lib/server_bootstrap.sh
+++ b/scripts/harness/lib/server_bootstrap.sh
@@ -5,6 +5,9 @@ harness_find_server_exe() {
   local repo_root="$1"
   local explicit="${2:-}"
   local common_root=""
+  local dune_build_dir="${DUNE_BUILD_DIR:-_build}"
+  local repo_build_dir="$repo_root/$dune_build_dir"
+  local common_build_dir=""
   if [[ -n "$explicit" && -x "$explicit" ]]; then
     printf '%s\n' "$explicit"
     return 0
@@ -18,15 +21,25 @@ harness_find_server_exe() {
         common_dir="$repo_root/$common_dir"
       fi
       common_root="$(cd "$(dirname "$common_dir")" && pwd)"
+      common_build_dir="$common_root/$dune_build_dir"
+    fi
+  fi
+
+  if [[ "$dune_build_dir" = /* ]]; then
+    repo_build_dir="$dune_build_dir"
+    if [[ -n "$common_root" ]]; then
+      common_build_dir="$dune_build_dir"
     fi
   fi
 
   local -a candidates=(
+    "${repo_build_dir}/default/bin/main_eio.exe"
     "${repo_root}/_build/default/bin/main_eio.exe"
     "${repo_root}/bin/main_eio.exe"
   )
   if [[ -n "$common_root" && "$common_root" != "$repo_root" ]]; then
     candidates+=(
+      "${common_build_dir}/default/bin/main_eio.exe"
       "${common_root}/_build/default/bin/main_eio.exe"
       "${common_root}/bin/main_eio.exe"
     )
@@ -78,7 +91,9 @@ harness_start_server() {
     export MASC_STORAGE_TYPE="filesystem"
     export MASC_LODGE_ENABLED="0"
     export MASC_LODGE_DAEMON_ENABLED="0"
+    export MASC_SENTINEL_ENABLED="0"
     export MASC_GUARDIAN_ENABLED="0"
+    export MASC_GARDENER_ENABLED="0"
     export MASC_ORCHESTRATOR_ENABLED="0"
     export GRAPHQL_API_KEY=""
     export GRAPHQL_URL="http://127.0.0.1:9/graphql"


### PR DESCRIPTION
## Summary
- bind MCP protocol version to initialized sessions
- reject missing or mismatched `MCP-Protocol-Version` on follow-up POST/GET/DELETE requests
- extend streamable HTTP contract harness coverage for protocol continuity

## Validation
- `DUNE_BUILD_DIR=_build_pr1 dune build --root . @check`
- `bash -n scripts/harness/contract/streamable_http_contract.sh`
- `MCP_URL=http://127.0.0.1:8992/mcp bash scripts/harness/contract/streamable_http_contract.sh`