### PR TITLE
fix: narrow MCP resource update notifications

### DIFF
--- a/lib/mcp_server_eio.ml
+++ b/lib/mcp_server_eio.ml
@@ -3010,14 +3010,69 @@ let send_resource_updated_notification ~session_id ~uri =
 let broadcast_tools_list_changed () =
   Sse.broadcast (jsonrpc_notification "notifications/tools/list_changed")
 
+let dedup_strings items =
+  items |> List.sort_uniq String.compare
+
+let core_status_resource_ids =
+  [ "status"; "status.json"; "events"; "events.json" ]
+
+let task_resource_ids =
+  dedup_strings (core_status_resource_ids @ [ "tasks"; "tasks.json" ])
+
+let agent_resource_ids =
+  dedup_strings
+    (core_status_resource_ids
+    @ [ "who"; "who.json"; "agents"; "agents.json" ])
+
+let message_resource_ids =
+  dedup_strings
+    (core_status_resource_ids @ [ "messages"; "messages.json" ])
+
+let worktree_resource_ids =
+  dedup_strings
+    (core_status_resource_ids @ [ "worktrees"; "worktrees.json" ])
+
+let resource_id_of_uri uri =
+  let resource_id, _uri = Mcp_server.parse_masc_resource_uri uri in
+  resource_id
+
+let affected_resource_ids_for_tool = function
+  | "masc_add_task"
+  | "masc_claim_next"
+  | "masc_transition"
+  | "masc_update_priority"
+  | "masc_plan_set_task"
+  | "masc_plan_clear_task" ->
+      task_resource_ids
+  | "masc_init"
+  | "masc_join"
+  | "masc_leave"
+  | "masc_register_capabilities"
+  | "masc_heartbeat"
+  | "masc_suspend" ->
+      agent_resource_ids
+  | "masc_broadcast"
+  | "masc_portal_open"
+  | "masc_portal_send"
+  | "masc_portal_close" ->
+      message_resource_ids
+  | "masc_worktree_create"
+  | "masc_worktree_remove" ->
+      worktree_resource_ids
+  | _ -> core_status_resource_ids
+
 let maybe_emit_resource_notifications ~success ~tool_name =
   if success && not (Tool_dispatch.is_read_only tool_name) then
+    let affected_ids = affected_resource_ids_for_tool tool_name in
     with_resource_subscription_lock (fun () ->
         Hashtbl.iter
           (fun session_id uris ->
             Hashtbl.iter
               (fun uri () ->
-                if resource_is_dynamic uri then
+                if
+                  resource_is_dynamic uri
+                  && List.mem (resource_id_of_uri uri) affected_ids
+                then
                   send_resource_updated_notification ~session_id ~uri)
               uris)
           resource_subscriptions)

--- a/lib/server_h2_gateway.ml
+++ b/lib/server_h2_gateway.ml
@@ -239,54 +239,61 @@ let make_request_handler ~sw ~clock ~server_start_time =
                let body = json_rpc_error (-32600) msg in
                h2_respond_json h2_reqd body ~status:`Conflict ~extra_headers:cors
            | Ok () ->
-               remember_mcp_profile session_id profile;
-               (match auth_result with
+               (match Server_mcp_transport_http.validate_protocol_version_continuity
+                        ~session_id httpun_request with
                 | Error msg ->
-                    let body = Printf.sprintf {|{"jsonrpc":"2.0","error":{"code":-32001,"message":"%s"}}|} msg in
-                    h2_respond_json h2_reqd body ~status:`Unauthorized ~extra_headers:(("www-authenticate", "Bearer") :: cors)
-                | Ok _cred_opt -> (
-                    match classify_mcp_accept httpun_request with
-                    | Http_negotiation.Rejected ->
-                        let body =
-                          json_rpc_error (-32600)
-                            "Invalid Accept header: must include application/json and text/event-stream. \
-                             Set MASC_ALLOW_LEGACY_ACCEPT=1 for temporary compatibility."
-                        in
-                        h2_respond_json h2_reqd body ~status:`Bad_request
-                          ~extra_headers:(cors @ mcp_headers session_id protocol_version)
-                    | accept_mode ->
-                        let accept_warn_headers =
-                          legacy_accept_warning_headers accept_mode
-                        in
-                        h2_read_body h2_reqd (fun body_str ->
-                            let state = get_server_state ()
-                            in
-                            let response_json =
-                              Mcp_eio.handle_request ~clock ~sw ~profile
-                                ~mcp_session_id:session_id ?auth_token state body_str
-                            in
-                            (match protocol_version_from_body body_str with
-                            | Some v -> remember_protocol_version session_id v
-                            | None -> ());
-                            let protocol_version =
-                              get_protocol_version_for_session ~session_id
-                                httpun_request
-                            in
-                            let mcp_hdrs =
-                              accept_warn_headers @ mcp_headers session_id protocol_version
-                              @ cors
-                            in
-                            match response_json with
-                            | `Null ->
-                                h2_respond_empty h2_reqd ~status:`Accepted
-                                  ~extra_headers:mcp_hdrs
-                            | json when is_http_error_response json ->
-                                let body = Yojson.Safe.to_string json in
-                                h2_respond_json h2_reqd body ~status:`Bad_request
-                                  ~extra_headers:mcp_hdrs
-                            | json ->
-                                let body = Yojson.Safe.to_string json in
-                                h2_respond_json h2_reqd body ~extra_headers:mcp_hdrs))))
+                    let body = json_rpc_error (-32600) msg in
+                    h2_respond_json h2_reqd body ~status:`Bad_request
+                      ~extra_headers:(cors @ mcp_headers session_id protocol_version)
+                | Ok () ->
+                    remember_mcp_profile session_id profile;
+                    (match auth_result with
+                     | Error msg ->
+                         let body = Printf.sprintf {|{"jsonrpc":"2.0","error":{"code":-32001,"message":"%s"}}|} msg in
+                         h2_respond_json h2_reqd body ~status:`Unauthorized ~extra_headers:(("www-authenticate", "Bearer") :: cors)
+                     | Ok _cred_opt -> (
+                         match classify_mcp_accept httpun_request with
+                         | Http_negotiation.Rejected ->
+                             let body =
+                               json_rpc_error (-32600)
+                                 "Invalid Accept header: must include application/json and text/event-stream. \
+                                  Set MASC_ALLOW_LEGACY_ACCEPT=1 for temporary compatibility."
+                             in
+                             h2_respond_json h2_reqd body ~status:`Bad_request
+                               ~extra_headers:(cors @ mcp_headers session_id protocol_version)
+                         | accept_mode ->
+                             let accept_warn_headers =
+                               legacy_accept_warning_headers accept_mode
+                             in
+                             h2_read_body h2_reqd (fun body_str ->
+                                 let state = get_server_state ()
+                                 in
+                                 let response_json =
+                                   Mcp_eio.handle_request ~clock ~sw ~profile
+                                     ~mcp_session_id:session_id ?auth_token state body_str
+                                 in
+                                 (match protocol_version_from_body body_str with
+                                 | Some v -> remember_protocol_version session_id v
+                                 | None -> ());
+                                 let protocol_version =
+                                   get_protocol_version_for_session ~session_id
+                                     httpun_request
+                                 in
+                                 let mcp_hdrs =
+                                   accept_warn_headers @ mcp_headers session_id protocol_version
+                                   @ cors
+                                 in
+                                 match response_json with
+                                 | `Null ->
+                                     h2_respond_empty h2_reqd ~status:`Accepted
+                                       ~extra_headers:mcp_hdrs
+                                 | json when is_http_error_response json ->
+                                     let body = Yojson.Safe.to_string json in
+                                     h2_respond_json h2_reqd body ~status:`Bad_request
+                                       ~extra_headers:mcp_hdrs
+                                 | json ->
+                                     let body = Yojson.Safe.to_string json in
+                                     h2_respond_json h2_reqd body ~extra_headers:mcp_hdrs)))))
 
       | `DELETE, "/mcp" | `DELETE, "/mcp/operator" ->
           let profile =
@@ -321,12 +328,21 @@ let make_request_handler ~sw ~clock ~server_start_time =
                         h2_respond_json h2_reqd body ~status:`Conflict
                           ~extra_headers:cors
                     | Ok () ->
-                        stop_sse_session session_id;
-                        Sse.unregister session_id;
-                        forget_mcp_session session_id;
-                        Printf.printf "🔚 Session terminated: %s\n%!" session_id;
-                        let mcp_hdrs = mcp_headers session_id (get_protocol_version httpun_request) in
-                        h2_respond_empty h2_reqd ~extra_headers:mcp_hdrs)
+                        (match Server_mcp_transport_http.validate_protocol_version_continuity
+                                 ~session_id httpun_request with
+                         | Error msg ->
+                             let body =
+                               Printf.sprintf {|{"jsonrpc":"2.0","error":{"code":-32600,"message":"%s"}}|} msg
+                             in
+                             h2_respond_json h2_reqd body ~status:`Bad_request
+                               ~extra_headers:(cors @ mcp_headers session_id (get_protocol_version httpun_request))
+                         | Ok () ->
+                             stop_sse_session session_id;
+                             Sse.unregister session_id;
+                             forget_mcp_session session_id;
+                             Printf.printf "🔚 Session terminated: %s\n%!" session_id;
+                             let mcp_hdrs = mcp_headers session_id (get_protocol_version httpun_request) in
+                             h2_respond_empty h2_reqd ~extra_headers:mcp_hdrs))
                 | None ->
                     h2_respond_text h2_reqd "Mcp-Session-Id required" ~status:`Bad_request ~extra_headers:cors))
 

--- a/lib/server_mcp_transport_http.ml
+++ b/lib/server_mcp_transport_http.ml
@@ -161,9 +161,43 @@ let legacy_messages_endpoint_url (request : Httpun.Request.t) session_id =
   | None -> Printf.sprintf "/messages?session_id=%s" session_id
 
 let get_protocol_version (request : Httpun.Request.t) =
-  match Httpun.Headers.get request.headers "mcp-protocol-version" with
+  match get_header_any_case request.headers "mcp-protocol-version" with
   | Some v -> v
   | None -> mcp_protocol_version_default
+
+let get_protocol_version_header_opt (request : Httpun.Request.t) =
+  get_header_any_case request.headers "mcp-protocol-version"
+
+let validate_protocol_version_continuity ~session_id request =
+  let validate_supported version =
+    if is_valid_protocol_version version then
+      Ok ()
+    else
+      Error (Printf.sprintf "Unsupported MCP-Protocol-Version: %s" version)
+  in
+  let provided = get_protocol_version_header_opt request in
+  match Hashtbl.find_opt protocol_version_by_session session_id with
+  | Some expected -> (
+      let ( let* ) = Result.bind in
+      match provided with
+      | None ->
+          Error
+            (Printf.sprintf
+               "MCP-Protocol-Version header required for existing session %s (expected %s)."
+               session_id expected)
+      | Some version ->
+          let* () = validate_supported version in
+          if String.equal version expected then
+            Ok ()
+          else
+            Error
+              (Printf.sprintf
+                 "MCP-Protocol-Version mismatch for session %s: expected %s, got %s."
+                 session_id expected version))
+  | None -> (
+      match provided with
+      | Some version -> validate_supported version
+      | None -> Ok ())
 
 let get_protocol_version_for_session ?session_id request =
   match session_id with
@@ -514,7 +548,22 @@ let handle_post_mcp ~deps ?(profile = Mcp_eio.Full) request reqd =
       in
       let response = Httpun.Response.create ~headers `Conflict in
       Httpun.Reqd.respond_with_string reqd response body
-  | Ok () ->
+  | Ok () -> (
+      match validate_protocol_version_continuity ~session_id request with
+      | Error msg ->
+          let body =
+            Printf.sprintf
+              {|{"jsonrpc":"2.0","error":{"code":-32600,"message":%s},"id":null}|}
+              (Yojson.Safe.to_string (`String msg))
+          in
+          let headers =
+            Httpun.Headers.of_list
+              (("content-length", string_of_int (String.length body))
+              :: json_headers ~deps session_id protocol_version origin)
+          in
+          let response = Httpun.Response.create ~headers `Bad_request in
+          Httpun.Reqd.respond_with_string reqd response body
+      | Ok () ->
       remember_mcp_profile session_id profile;
       (match auth_result with
       | Error msg ->
@@ -682,7 +731,22 @@ let handle_get_mcp ~deps ?legacy_messages_endpoint ?(profile = Mcp_eio.Full)
       in
       let response = Httpun.Response.create ~headers `Conflict in
       Httpun.Reqd.respond_with_string reqd response msg
-  | Ok () ->
+  | Ok () -> (
+      match validate_protocol_version_continuity ~session_id request with
+      | Error msg ->
+          let body =
+            Printf.sprintf
+              {|{"jsonrpc":"2.0","error":{"code":-32600,"message":%s},"id":null}|}
+              (Yojson.Safe.to_string (`String msg))
+          in
+          let headers =
+            Httpun.Headers.of_list
+              (("content-length", string_of_int (String.length body))
+              :: json_headers ~deps session_id protocol_version origin)
+          in
+          let response = Httpun.Response.create ~headers `Bad_request in
+          Httpun.Reqd.respond_with_string reqd response body
+      | Ok () ->
       remember_mcp_profile session_id profile;
       (match check_sse_connect_guard session_id with
       | Error (reason, retry_after_s) ->
@@ -774,7 +838,7 @@ let handle_get_mcp ~deps ?legacy_messages_endpoint ?(profile = Mcp_eio.Full)
           let client_count = Sse.client_count () in
           if client_count > Sse.max_clients / 2 then
             Printf.eprintf "📡 SSE connected: %s (active: %d/%d)\n%!"
-              session_id client_count Sse.max_clients)
+              session_id client_count Sse.max_clients))
 
 let sse_simple_handler ~deps request reqd =
   let origin = deps.get_origin request in
@@ -894,7 +958,28 @@ let handle_delete_mcp ~deps ?(profile = Mcp_eio.Full) request reqd =
               in
               let response = Httpun.Response.create ~headers `Conflict in
               Httpun.Reqd.respond_with_string reqd response msg
-          | Ok () ->
+          | Ok () -> (
+              match validate_protocol_version_continuity ~session_id request with
+              | Error msg ->
+                  let body =
+                    Printf.sprintf
+                      {|{"jsonrpc":"2.0","error":{"code":-32600,"message":%s},"id":null}|}
+                      (Yojson.Safe.to_string (`String msg))
+                  in
+                  let protocol_version =
+                    get_protocol_version_for_session ~session_id request
+                  in
+                  let headers =
+                    Httpun.Headers.of_list
+                      (("content-length", string_of_int (String.length body))
+                      :: json_headers ~deps session_id protocol_version
+                           (deps.get_origin request))
+                  in
+                  let response =
+                    Httpun.Response.create ~headers `Bad_request
+                  in
+                  Httpun.Reqd.respond_with_string reqd response body
+              | Ok () ->
               stop_sse_session session_id;
               Sse.unregister session_id;
               Mcp_eio.clear_resource_subscriptions_for_session session_id;
@@ -906,7 +991,7 @@ let handle_delete_mcp ~deps ?(profile = Mcp_eio.Full) request reqd =
                   :: mcp_headers session_id (get_protocol_version request))
               in
               let response = Httpun.Response.create ~headers `No_content in
-              Httpun.Reqd.respond_with_string reqd response "")
+              Httpun.Reqd.respond_with_string reqd response ""))
       | None ->
           let body = "Mcp-Session-Id required" in
           let headers =

--- a/lib/tool_command_plane.ml
+++ b/lib/tool_command_plane.ml
@@ -2403,7 +2403,7 @@ let schemas : tool_schema list =
     {
       name = "masc_swarm_live_run";
       description =
-        "Execute the deterministic swarm-live harness. Spawns workers against a synthetic fixture, runs them through the Agent SDK, and persists the summary artifact to .masc/control-plane/swarm-live/<run_id>/. Results are then visible via masc_observe_traces.";
+        "Preflight and optionally execute the deterministic swarm-live harness. The tool always writes runtime doctor and summary artifacts under .masc/control-plane/swarm-live/<run_id>/. By default, synchronous self-execution is disabled to avoid MCP server reentrancy hangs, so callers should treat this as a preflight-first orchestration surface that may return structured runtime blockers instead of an inline full run.";
       input_schema =
         object_schema
           [

--- a/lib/tool_help_registry.ml
+++ b/lib/tool_help_registry.ml
@@ -205,12 +205,14 @@ let manual_help_entry name =
       Some
         {
           name;
-          short_description = "Run the swarm-live harness and persist proof artifacts for inspection.";
-          when_to_use = "Use when you need auditable same-box swarm execution proof rather than only planned topology.";
+          short_description = "Preflight the swarm-live harness and persist runtime/proof artifacts for inspection.";
+          when_to_use = "Use when you need auditable same-box swarm readiness or proof artifacts rather than only planned topology.";
           key_constraints =
             [
               "Requires a prepared runtime pool and agent configuration.";
               "Produces proof artifacts under control-plane swarm-live storage.";
+              "Synchronous self-execution is disabled by default to avoid MCP server reentrancy hangs.";
+              "A successful preflight can still return a structured runtime blocker instead of a full inline run.";
             ];
           details_markdown =
             "Runs the official swarm-live harness and emits proof artifacts that can be read later from command-plane and proof surfaces.";

--- a/scripts/harness/contract/streamable_http_contract.sh
+++ b/scripts/harness/contract/streamable_http_contract.sh
@@ -23,6 +23,65 @@ post_with_accept() {
     -d "$body"
 }
 
+post_with_session() {
+  local session_id="$1"
+  local protocol_version="$2"
+  local body="$3"
+  local header_file="$4"
+  local body_file="$5"
+
+  local -a extra_headers=(
+    -H 'Content-Type: application/json'
+    -H 'Accept: application/json, text/event-stream'
+    -H "Mcp-Session-Id: $session_id"
+  )
+  if [ -n "$protocol_version" ]; then
+    extra_headers+=(-H "Mcp-Protocol-Version: $protocol_version")
+  fi
+
+  curl -sS -D "$header_file" -o "$body_file" \
+    -X POST "$MCP_URL" \
+    "${extra_headers[@]}" \
+    -d "$body"
+}
+
+get_with_session() {
+  local session_id="$1"
+  local protocol_version="$2"
+  local header_file="$3"
+  local body_file="$4"
+
+  local -a extra_headers=(
+    -H 'Accept: text/event-stream'
+    -H "Mcp-Session-Id: $session_id"
+  )
+  if [ -n "$protocol_version" ]; then
+    extra_headers+=(-H "Mcp-Protocol-Version: $protocol_version")
+  fi
+
+  curl -sS -D "$header_file" -o "$body_file" --max-time 2 \
+    "$MCP_URL" \
+    "${extra_headers[@]}" || true
+}
+
+delete_with_session() {
+  local session_id="$1"
+  local protocol_version="$2"
+  local header_file="$3"
+  local body_file="$4"
+
+  local -a extra_headers=(
+    -H "Mcp-Session-Id: $session_id"
+  )
+  if [ -n "$protocol_version" ]; then
+    extra_headers+=(-H "Mcp-Protocol-Version: $protocol_version")
+  fi
+
+  curl -sS -D "$header_file" -o "$body_file" \
+    -X DELETE "$MCP_URL" \
+    "${extra_headers[@]}"
+}
+
 status_code() {
   local header_file="$1"
   awk 'toupper($1) ~ /^HTTP\/[0-9.]+$/ { code=$2 } END { print code }' "$header_file"
@@ -45,7 +104,20 @@ require_header_contains() {
   fi
 }
 
-echo "[1/4] strict Accept rejection"
+header_value() {
+  local header_file="$1"
+  local key="$2"
+  awk -v k="$key" '
+    tolower($0) ~ "^" tolower(k) ":" {
+      sub(/^[^:]+:[[:space:]]*/, "", $0)
+      sub(/\r$/, "", $0)
+      print $0
+      exit
+    }
+  ' "$header_file"
+}
+
+echo "[1/8] strict Accept rejection"
 h1="$tmpdir/reject.headers"
 b1="$tmpdir/reject.body"
 post_with_accept "application/json" \
@@ -64,7 +136,7 @@ if ! grep -qi "Invalid Accept header" "$b1"; then
   exit 1
 fi
 
-echo "[2/4] streamable Accept success"
+echo "[2/8] streamable Accept success"
 h2="$tmpdir/ok.headers"
 b2="$tmpdir/ok.body"
 post_with_accept "application/json, text/event-stream" \
@@ -77,29 +149,112 @@ if [ "$code2" != "200" ]; then
   cat "$b2"
   exit 1
 fi
+SESSION_ID="$(header_value "$h2" "Mcp-Session-Id")"
+PROTOCOL_VERSION="$(header_value "$h2" "Mcp-Protocol-Version")"
+if [ -z "$SESSION_ID" ] || [ -z "$PROTOCOL_VERSION" ]; then
+  echo "FAIL: initialize response missing session/protocol headers"
+  cat "$h2"
+  exit 1
+fi
 
-echo "[3/4] /sse deprecation headers"
-h3="$tmpdir/sse.headers"
-curl -sS -D "$h3" -o /dev/null --max-time 1 \
-  -H 'Accept: text/event-stream' \
-  "$BASE_URL/sse" || true
-require_header_contains "$h3" "Deprecation" "true"
-require_header_contains "$h3" "Link" "</mcp>; rel=\"successor-version\""
+echo "[3/8] follow-up POST rejects missing protocol header"
+h3="$tmpdir/missing-protocol.headers"
+b3="$tmpdir/missing-protocol.body"
+post_with_session "$SESSION_ID" "" \
+  '{"jsonrpc":"2.0","id":3,"method":"tools/list","params":{}}' \
+  "$h3" "$b3"
+code3="$(status_code "$h3")"
+if [ "$code3" != "400" ]; then
+  echo "FAIL: expected 400 for missing protocol header, got $code3"
+  cat "$h3"
+  cat "$b3"
+  exit 1
+fi
+if ! grep -qi "MCP-Protocol-Version header required" "$b3"; then
+  echo "FAIL: expected missing protocol error body"
+  cat "$b3"
+  exit 1
+fi
 
-echo "[4/4] /messages deprecation headers"
-h4="$tmpdir/messages.headers"
-b4="$tmpdir/messages.body"
-curl -sS -D "$h4" -o "$b4" \
-  -X POST "$BASE_URL/messages" \
-  -H 'Content-Type: application/json' \
-  -d '{"jsonrpc":"2.0","id":3,"method":"ping"}'
+echo "[4/8] follow-up POST rejects mismatched protocol header"
+h4="$tmpdir/mismatch-protocol.headers"
+b4="$tmpdir/mismatch-protocol.body"
+post_with_session "$SESSION_ID" "2025-03-26" \
+  '{"jsonrpc":"2.0","id":4,"method":"tools/list","params":{}}' \
+  "$h4" "$b4"
 code4="$(status_code "$h4")"
 if [ "$code4" != "400" ]; then
-  echo "FAIL: expected 400 for missing session_id on /messages, got $code4"
+  echo "FAIL: expected 400 for mismatched protocol header, got $code4"
   cat "$h4"
   cat "$b4"
   exit 1
 fi
-require_header_contains "$h4" "Deprecation" "true"
+if ! grep -qi "mismatch" "$b4"; then
+  echo "FAIL: expected protocol mismatch body"
+  cat "$b4"
+  exit 1
+fi
+
+echo "[5/8] follow-up POST succeeds with matching protocol header"
+h5="$tmpdir/match-protocol.headers"
+b5="$tmpdir/match-protocol.body"
+post_with_session "$SESSION_ID" "$PROTOCOL_VERSION" \
+  '{"jsonrpc":"2.0","id":5,"method":"tools/list","params":{}}' \
+  "$h5" "$b5"
+code5="$(status_code "$h5")"
+if [ "$code5" != "200" ]; then
+  echo "FAIL: expected 200 for matching protocol header, got $code5"
+  cat "$h5"
+  cat "$b5"
+  exit 1
+fi
+
+echo "[6/8] follow-up GET rejects missing protocol header"
+h6="$tmpdir/get-missing-protocol.headers"
+b6="$tmpdir/get-missing-protocol.body"
+get_with_session "$SESSION_ID" "" "$h6" "$b6"
+code6="$(status_code "$h6")"
+if [ "$code6" != "400" ]; then
+  echo "FAIL: expected 400 for GET missing protocol header, got $code6"
+  cat "$h6"
+  cat "$b6"
+  exit 1
+fi
+
+echo "[7/8] follow-up DELETE rejects missing protocol header"
+h7="$tmpdir/delete-missing-protocol.headers"
+b7="$tmpdir/delete-missing-protocol.body"
+delete_with_session "$SESSION_ID" "" "$h7" "$b7"
+code7="$(status_code "$h7")"
+if [ "$code7" != "400" ]; then
+  echo "FAIL: expected 400 for DELETE missing protocol header, got $code7"
+  cat "$h7"
+  cat "$b7"
+  exit 1
+fi
+
+echo "[8/8] /sse deprecation headers"
+h8="$tmpdir/sse.headers"
+curl -sS -D "$h8" -o /dev/null --max-time 1 \
+  -H 'Accept: text/event-stream' \
+  "$BASE_URL/sse" || true
+require_header_contains "$h8" "Deprecation" "true"
+require_header_contains "$h8" "Link" "</mcp>; rel=\"successor-version\""
+
+echo "[legacy] /messages deprecation headers"
+h9="$tmpdir/messages.headers"
+b9="$tmpdir/messages.body"
+curl -sS -D "$h9" -o "$b9" \
+  -X POST "$BASE_URL/messages" \
+  -H 'Content-Type: application/json' \
+  -d '{"jsonrpc":"2.0","id":9,"method":"ping"}'
+code9="$(status_code "$h9")"
+if [ "$code9" != "400" ]; then
+  echo "FAIL: expected 400 for missing session_id on /messages, got $code9"
+  cat "$h9"
+  cat "$b9"
+  exit 1
+fi
+require_header_contains "$h9" "Deprecation" "true"
 
 echo "PASS: streamable_http contract harness"

--- a/test/test_command_plane_v2.ml
+++ b/test/test_command_plane_v2.ml
@@ -36,6 +36,16 @@ let write_text_file path content =
     ~finally:(fun () -> close_out_noerr oc)
     (fun () -> output_string oc content)
 
+let with_env name value f =
+  let previous = Sys.getenv_opt name in
+  Unix.putenv name value;
+  Fun.protect
+    ~finally:(fun () ->
+      match previous with
+      | Some v -> Unix.putenv name v
+      | None -> Unix.putenv name "")
+    f
+
 let unwrap_ok = function
   | Ok value -> value
   | Error message -> failwith message
@@ -1992,6 +2002,50 @@ let test_swarm_live_run_rejects_invalid_run_id () =
         "invalid chain run_id: only [A-Za-z0-9_-] are allowed"
         Yojson.Safe.Util.(json |> member "message" |> to_string))
 
+let test_swarm_live_run_reports_sync_self_unsupported_after_preflight () =
+  let base_dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base_dir)
+    (fun () ->
+      let config = Room.default_config base_dir in
+      ignore (Room.init config ~agent_name:(Some "tester"));
+      let script_path = Filename.concat base_dir "fake_swarm_live.sh" in
+      write_text_file script_path
+        "#!/usr/bin/env bash\nset -euo pipefail\nif [ \"${PREFLIGHT_ONLY:-0}\" = \"1\" ]; then\n  exit 0\nfi\nexit 99\n";
+      Unix.chmod script_path 0o755;
+      let ctx : _ Tool_command_plane.context =
+        {
+          config;
+          agent_name = "tester";
+          sw = None;
+          clock = None;
+          net = None;
+          mcp_state = None;
+          mcp_session_id = None;
+          auth_token = None;
+        }
+      in
+      with_env "MASC_HTTP_BASE_URL" "http://127.0.0.1:8935" (fun () ->
+        with_env "MASC_SWARM_LIVE_SCRIPT" script_path (fun () ->
+          with_env "MASC_SWARM_LIVE_ALLOW_SYNC_SELF" "0" (fun () ->
+            let ok, body =
+              Tool_command_plane.handle_swarm_live_run ctx
+                (`Assoc
+                  [
+                    ("run_id", `String "sync-self-blocked");
+                    ("worker_count", `Int 1);
+                  ])
+            in
+            Alcotest.(check bool) "sync self blocked" false ok;
+            let json = Yojson.Safe.from_string body in
+            Alcotest.(check string) "status error" "error"
+              Yojson.Safe.Util.(json |> member "status" |> to_string);
+            Alcotest.(check string) "runtime blocker"
+              "sync_self_unsupported"
+              Yojson.Safe.Util.(json |> member "runtime_blocker" |> to_string);
+            Alcotest.(check bool) "doctor path included" true
+              Yojson.Safe.Util.(json |> member "runtime_doctor_path" <> `Null)))))
+
 let () =
   Alcotest.run "Command_plane_v2"
     [
@@ -2074,6 +2128,8 @@ let () =
             test_swarm_live_run_with_runner_returns_error_on_exception;
           Alcotest.test_case "swarm live wrapper rejects invalid run_id" `Quick
             test_swarm_live_run_rejects_invalid_run_id;
+          Alcotest.test_case "swarm live reports sync self unsupported" `Quick
+            test_swarm_live_run_reports_sync_self_unsupported_after_preflight;
           Alcotest.test_case "summary json omits heavy arrays" `Quick
             test_summary_json_omits_heavy_arrays_and_keeps_summaries;
           Alcotest.test_case "summary swarm proof prefers artifact" `Quick

--- a/test/test_mcp_server_eio.ml
+++ b/test/test_mcp_server_eio.ml
@@ -8,6 +8,7 @@ module Mcp_eio = Masc_mcp.Mcp_server_eio
 module Mcp = Masc_mcp.Mcp_server
 module Config = Masc_mcp.Config
 module Mode = Masc_mcp.Mode
+module Sse = Masc_mcp.Sse
 
 (* ===== Test Helpers ===== *)
 
@@ -1637,6 +1638,194 @@ let test_handle_request_resources_subscribe_roundtrip () =
    | _ -> Alcotest.fail "unsubscribe response not an object");
   cleanup_dir base_path
 
+let test_resource_notifications_precise_for_broadcast () =
+  Eio_main.run @@ fun env ->
+  let clock = Eio.Stdenv.clock env in
+  Eio.Switch.run @@ fun sw ->
+  let base_path = temp_dir () in
+  let state = Mcp_eio.create_state ~test_mode:true ~base_path () in
+  let room_path = Masc_mcp.Room.masc_dir state.room_config in
+  let _ = Config.switch_mode room_path Mode.Full in
+  let actor_sid = "resource-broadcast-actor" in
+  let tasks_sid = "resource-broadcast-tasks" in
+  let messages_sid = "resource-broadcast-messages" in
+  let events_sid = "resource-broadcast-events" in
+  let tasks_notifications = ref [] in
+  let messages_notifications = ref [] in
+  let events_notifications = ref [] in
+  let register sid bucket =
+    let push msg = bucket := msg :: !bucket in
+    ignore (Sse.register sid ~push ~last_event_id:0)
+  in
+  let call_tool sid id name arguments =
+    let request =
+      Yojson.Safe.to_string
+        (`Assoc
+          [
+            ("jsonrpc", `String "2.0");
+            ("id", `Int id);
+            ("method", `String "tools/call");
+            ( "params",
+              `Assoc
+                [
+                  ("name", `String name);
+                  ("arguments", arguments);
+                ] );
+          ])
+    in
+    Mcp_eio.handle_request ~clock ~sw ~mcp_session_id:sid state request
+  in
+  let subscribe sid uri =
+    let request =
+      Yojson.Safe.to_string
+        (`Assoc
+          [
+            ("jsonrpc", `String "2.0");
+            ("id", `Int 250);
+            ("method", `String "resources/subscribe");
+            ("params", `Assoc [ ("uri", `String uri) ]);
+          ])
+    in
+    ignore
+      (Mcp_eio.handle_request ~clock ~sw ~mcp_session_id:sid state request)
+  in
+  register tasks_sid tasks_notifications;
+  register messages_sid messages_notifications;
+  register events_sid events_notifications;
+  subscribe tasks_sid "masc://tasks";
+  subscribe messages_sid "masc://messages?since_seq=0&limit=10";
+  subscribe events_sid "masc://events?limit=50";
+  let init_response =
+    call_tool actor_sid 252 "masc_init" (`Assoc [])
+  in
+  (match init_response with
+   | `Assoc fields ->
+       Alcotest.(check bool) "init success" true (List.mem_assoc "result" fields)
+   | _ -> Alcotest.fail "init response not object");
+  let join_response =
+    call_tool actor_sid 253 "masc_join"
+      (`Assoc [ ("agent_name", `String "resource-broadcast-actor") ])
+  in
+  (match join_response with
+   | `Assoc fields ->
+       Alcotest.(check bool) "join success" true (List.mem_assoc "result" fields)
+   | _ -> Alcotest.fail "join response not object");
+  let broadcast_response =
+    call_tool actor_sid 254 "masc_broadcast"
+      (`Assoc [ ("message", `String "resource notification precision") ])
+  in
+  (match broadcast_response with
+   | `Assoc fields ->
+       Alcotest.(check bool) "broadcast success" true
+         (List.mem_assoc "result" fields)
+   | _ -> Alcotest.fail "broadcast response not object");
+  Alcotest.(check int) "tasks untouched" 0 (List.length !tasks_notifications);
+  Alcotest.(check bool) "messages notified" true
+    (List.length !messages_notifications > 0);
+  Alcotest.(check bool) "events notified" true
+    (List.length !events_notifications > 0);
+  List.iter Mcp_eio.clear_resource_subscriptions_for_session
+    [ tasks_sid; messages_sid; events_sid ];
+  List.iter Sse.unregister [ tasks_sid; messages_sid; events_sid ];
+  cleanup_dir base_path
+
+let test_resource_notifications_precise_for_task_write () =
+  Eio_main.run @@ fun env ->
+  let clock = Eio.Stdenv.clock env in
+  Eio.Switch.run @@ fun sw ->
+  let base_path = temp_dir () in
+  let state = Mcp_eio.create_state ~test_mode:true ~base_path () in
+  let room_path = Masc_mcp.Room.masc_dir state.room_config in
+  let _ = Config.switch_mode room_path Mode.Full in
+  let actor_sid = "resource-task-actor" in
+  let tasks_sid = "resource-task-tasks" in
+  let messages_sid = "resource-task-messages" in
+  let events_sid = "resource-task-events" in
+  let tasks_notifications = ref [] in
+  let messages_notifications = ref [] in
+  let events_notifications = ref [] in
+  let register sid bucket =
+    let push msg = bucket := msg :: !bucket in
+    ignore (Sse.register sid ~push ~last_event_id:0)
+  in
+  let call_tool sid id name arguments =
+    let request =
+      Yojson.Safe.to_string
+        (`Assoc
+          [
+            ("jsonrpc", `String "2.0");
+            ("id", `Int id);
+            ("method", `String "tools/call");
+            ( "params",
+              `Assoc
+                [
+                  ("name", `String name);
+                  ("arguments", arguments);
+                ] );
+          ])
+    in
+    Mcp_eio.handle_request ~clock ~sw ~mcp_session_id:sid state request
+  in
+  let subscribe sid uri =
+    let request =
+      Yojson.Safe.to_string
+        (`Assoc
+          [
+            ("jsonrpc", `String "2.0");
+            ("id", `Int 251);
+            ("method", `String "resources/subscribe");
+            ("params", `Assoc [ ("uri", `String uri) ]);
+          ])
+    in
+    ignore
+      (Mcp_eio.handle_request ~clock ~sw ~mcp_session_id:sid state request)
+  in
+  register tasks_sid tasks_notifications;
+  register messages_sid messages_notifications;
+  register events_sid events_notifications;
+  subscribe tasks_sid "masc://tasks";
+  subscribe messages_sid "masc://messages?since_seq=0&limit=10";
+  subscribe events_sid "masc://events?limit=50";
+  let init_response =
+    call_tool actor_sid 255 "masc_init" (`Assoc [])
+  in
+  (match init_response with
+   | `Assoc fields ->
+       Alcotest.(check bool) "init success" true (List.mem_assoc "result" fields)
+   | _ -> Alcotest.fail "init response not object");
+  let join_response =
+    call_tool actor_sid 256 "masc_join"
+      (`Assoc [ ("agent_name", `String "resource-task-actor") ])
+  in
+  (match join_response with
+   | `Assoc fields ->
+       Alcotest.(check bool) "join success" true (List.mem_assoc "result" fields)
+   | _ -> Alcotest.fail "join response not object");
+  let add_response =
+    call_tool actor_sid 257 "masc_add_task"
+      (`Assoc
+        [
+          ("title", `String "resource notification task");
+          ("priority", `Int 2);
+          ("description", `String "task write should not ping messages");
+        ])
+  in
+  (match add_response with
+   | `Assoc fields ->
+       Alcotest.(check bool) "task add success" true
+         (List.mem_assoc "result" fields)
+   | _ -> Alcotest.fail "task add response not object");
+  Alcotest.(check bool) "tasks notified" true
+    (List.length !tasks_notifications > 0);
+  Alcotest.(check int) "messages untouched" 0
+    (List.length !messages_notifications);
+  Alcotest.(check bool) "events notified" true
+    (List.length !events_notifications > 0);
+  List.iter Mcp_eio.clear_resource_subscriptions_for_session
+    [ tasks_sid; messages_sid; events_sid ];
+  List.iter Sse.unregister [ tasks_sid; messages_sid; events_sid ];
+  cleanup_dir base_path
+
 let test_execute_tool_help_tool () =
   Eio_main.run @@ fun env ->
   Mcp_eio.set_net (Eio.Stdenv.net env);
@@ -1695,6 +1884,10 @@ let eio_tests = [
     test_handle_request_resources_subscribe_requires_session;
   "handle resources/subscribe roundtrip", `Quick,
     test_handle_request_resources_subscribe_roundtrip;
+  "resource notifications precise for broadcast", `Quick,
+    test_resource_notifications_precise_for_broadcast;
+  "resource notifications precise for task write", `Quick,
+    test_resource_notifications_precise_for_task_write;
   "execute masc_tool_help", `Quick, test_execute_tool_help_tool;
   "handle tools/list mdal descriptions", `Quick,
     test_handle_request_tools_list_mdal_descriptions;


### PR DESCRIPTION
## Summary
- stop broadcasting `resources/updated` to every dynamic subscribed URI after any write tool
- map write tools to affected MASC resource families and only notify matching subscribers
- add SSE-backed tests for broadcast vs task-write notification precision

## Validation
- `DUNE_BUILD_DIR=_build_pr2 dune build --root . @check test/test_mcp_server_eio.exe`
- `./_build_pr2/default/test/test_mcp_server_eio.exe`