### PR TITLE
docs: clarify swarm live MCP contract

### DIFF
--- a/lib/tool_command_plane.ml
+++ b/lib/tool_command_plane.ml
@@ -2403,7 +2403,7 @@ let schemas : tool_schema list =
     {
       name = "masc_swarm_live_run";
       description =
-        "Execute the deterministic swarm-live harness. Spawns workers against a synthetic fixture, runs them through the Agent SDK, and persists the summary artifact to .masc/control-plane/swarm-live/<run_id>/. Results are then visible via masc_observe_traces.";
+        "Preflight and optionally execute the deterministic swarm-live harness. The tool always writes runtime doctor and summary artifacts under .masc/control-plane/swarm-live/<run_id>/. By default, synchronous self-execution is disabled to avoid MCP server reentrancy hangs, so callers should treat this as a preflight-first orchestration surface that may return structured runtime blockers instead of an inline full run.";
       input_schema =
         object_schema
           [

--- a/lib/tool_help_registry.ml
+++ b/lib/tool_help_registry.ml
@@ -205,12 +205,14 @@ let manual_help_entry name =
       Some
         {
           name;
-          short_description = "Run the swarm-live harness and persist proof artifacts for inspection.";
-          when_to_use = "Use when you need auditable same-box swarm execution proof rather than only planned topology.";
+          short_description = "Preflight the swarm-live harness and persist runtime/proof artifacts for inspection.";
+          when_to_use = "Use when you need auditable same-box swarm readiness or proof artifacts rather than only planned topology.";
           key_constraints =
             [
               "Requires a prepared runtime pool and agent configuration.";
               "Produces proof artifacts under control-plane swarm-live storage.";
+              "Synchronous self-execution is disabled by default to avoid MCP server reentrancy hangs.";
+              "A successful preflight can still return a structured runtime blocker instead of a full inline run.";
             ];
           details_markdown =
             "Runs the official swarm-live harness and emits proof artifacts that can be read later from command-plane and proof surfaces.";

--- a/test/test_command_plane_v2.ml
+++ b/test/test_command_plane_v2.ml
@@ -36,6 +36,16 @@ let write_text_file path content =
     ~finally:(fun () -> close_out_noerr oc)
     (fun () -> output_string oc content)
 
+let with_env name value f =
+  let previous = Sys.getenv_opt name in
+  Unix.putenv name value;
+  Fun.protect
+    ~finally:(fun () ->
+      match previous with
+      | Some v -> Unix.putenv name v
+      | None -> Unix.putenv name "")
+    f
+
 let unwrap_ok = function
   | Ok value -> value
   | Error message -> failwith message
@@ -1992,6 +2002,50 @@ let test_swarm_live_run_rejects_invalid_run_id () =
         "invalid chain run_id: only [A-Za-z0-9_-] are allowed"
         Yojson.Safe.Util.(json |> member "message" |> to_string))
 
+let test_swarm_live_run_reports_sync_self_unsupported_after_preflight () =
+  let base_dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base_dir)
+    (fun () ->
+      let config = Room.default_config base_dir in
+      ignore (Room.init config ~agent_name:(Some "tester"));
+      let script_path = Filename.concat base_dir "fake_swarm_live.sh" in
+      write_text_file script_path
+        "#!/usr/bin/env bash\nset -euo pipefail\nif [ \"${PREFLIGHT_ONLY:-0}\" = \"1\" ]; then\n  exit 0\nfi\nexit 99\n";
+      Unix.chmod script_path 0o755;
+      let ctx : _ Tool_command_plane.context =
+        {
+          config;
+          agent_name = "tester";
+          sw = None;
+          clock = None;
+          net = None;
+          mcp_state = None;
+          mcp_session_id = None;
+          auth_token = None;
+        }
+      in
+      with_env "MASC_HTTP_BASE_URL" "http://127.0.0.1:8935" (fun () ->
+        with_env "MASC_SWARM_LIVE_SCRIPT" script_path (fun () ->
+          with_env "MASC_SWARM_LIVE_ALLOW_SYNC_SELF" "0" (fun () ->
+            let ok, body =
+              Tool_command_plane.handle_swarm_live_run ctx
+                (`Assoc
+                  [
+                    ("run_id", `String "sync-self-blocked");
+                    ("worker_count", `Int 1);
+                  ])
+            in
+            Alcotest.(check bool) "sync self blocked" false ok;
+            let json = Yojson.Safe.from_string body in
+            Alcotest.(check string) "status error" "error"
+              Yojson.Safe.Util.(json |> member "status" |> to_string);
+            Alcotest.(check string) "runtime blocker"
+              "sync_self_unsupported"
+              Yojson.Safe.Util.(json |> member "runtime_blocker" |> to_string);
+            Alcotest.(check bool) "doctor path included" true
+              Yojson.Safe.Util.(json |> member "runtime_doctor_path" <> `Null)))))
+
 let () =
   Alcotest.run "Command_plane_v2"
     [
@@ -2074,6 +2128,8 @@ let () =
             test_swarm_live_run_with_runner_returns_error_on_exception;
           Alcotest.test_case "swarm live wrapper rejects invalid run_id" `Quick
             test_swarm_live_run_rejects_invalid_run_id;
+          Alcotest.test_case "swarm live reports sync self unsupported" `Quick
+            test_swarm_live_run_reports_sync_self_unsupported_after_preflight;
           Alcotest.test_case "summary json omits heavy arrays" `Quick
             test_summary_json_omits_heavy_arrays_and_keeps_summaries;
           Alcotest.test_case "summary swarm proof prefers artifact" `Quick


### PR DESCRIPTION
## Summary
- keep `masc_swarm_live_run` public name unchanged
- align tool description and help text with the current preflight-first behavior
- add command-plane test coverage for `sync_self_unsupported` error contract

## Validation
- `DUNE_BUILD_DIR=_build_pr3 dune build --root . @check test/test_command_plane_v2.exe`
- `./_build_pr3/default/test/test_command_plane_v2.exe`