### PR TITLE
fix(ci): unblock quick suite contract assertions

### DIFF
--- a/lib/mcp_server_eio.ml
+++ b/lib/mcp_server_eio.ml
@@ -3299,6 +3299,7 @@ let tool_json_for_profile ?usage_summary profile (schema : Types.tool_schema) =
           (List.map Mcp_server.icon_to_json (tool_icons_for_name schema.name)) );
       ("inputSchema", schema.input_schema);
     ]
+    @ Tool_catalog.metadata_to_fields schema.name
     @ maybe_assoc_field "outputSchema" (tool_output_schema_field schema.name)
     @ maybe_assoc_field "annotations" (tool_annotations_for_profile profile schema.name)
     @

--- a/test/test_silent_failures_p2a.ml
+++ b/test/test_silent_failures_p2a.ml
@@ -128,8 +128,8 @@ let file_contains_pattern file_rel pattern =
 (* HIGH priority patterns *)
 
 let test_source_main_keeper_bootstrap () =
-  check bool "main_eio.ml has keeper bootstrap logging"
-    true (file_contains_pattern "bin/main_eio.ml"
+  check bool "server_runtime_bootstrap.ml has keeper bootstrap logging"
+    true (file_contains_pattern "lib/server_runtime_bootstrap.ml"
       {|[main] keeper bootstrap failed:|})
 
 let test_source_metrics_fd_close () =
@@ -148,8 +148,8 @@ let test_source_llm_token_parse () =
       {|[llm] token field missing or wrong type|})
 
 let test_source_keeper_proactive () =
-  check bool "keeper_execution.ml has proactive emission logging"
-    true (file_contains_pattern "lib/keeper_execution.ml"
+  check bool "keeper_keepalive.ml has proactive emission logging"
+    true (file_contains_pattern "lib/keeper_keepalive.ml"
       {|[keeper] proactive emission failed:|})
 
 (* MEDIUM priority patterns *)


### PR DESCRIPTION
## Summary
- restore MCP tool metadata fields in  responses
- update silent-failure source assertions to the current implementation files
- unblock the common quick-suite failures currently breaking 

## Verification
- 
- Testing `tool contract truth'.
This run has ID `9TGOR1Q0'.

  [OK]          visible          0   visible tools stay truthful.
  [OK]          hidden           0   hidden metadata exposes implementation s...

Full test results in `~/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix-ci-main-failing-tests/_build/_tests/tool contract truth'.
Test Successful in 0.006s. 2 tests run.
- Testing `Silent failure logging (Phase 2A)'.
This run has ID `A2GQJPL3'.

  [OK]          social_stderr                   0   vote on missing post logs...
  [OK]          source_high_priority            0   MA-H1: keeper bootstrap l...
  [OK]          source_high_priority            1   MA-H2a: metrics fd close ...
  [OK]          source_high_priority            2   MA-H2b: metrics fd unlock...
  [OK]          source_high_priority            3   MA-H3: llm token parse lo...
  [OK]          source_high_priority            4   MA-H4: keeper proactive l...
  [OK]          source_medium_priority          0   MA-M1: worktree agent sta...
  [OK]          source_medium_priority          1   MA-M2a: social vote post ...
  [OK]          source_medium_priority          2   MA-M2b: social vote comme...
  [OK]          source_medium_priority          3   MA-M3: board_pg vote migr...
  [OK]          source_medium_priority          4   MA-M4a: heartbeat traits ...
  [OK]          source_medium_priority          5   MA-M4b: heartbeat preferr...
  [OK]          source_medium_priority          6   MA-M4c: heartbeat interes...
  [OK]          source_medium_priority          7   MA-M5: keeper log parse l...
  [OK]          source_medium_priority          8   MA-M7: trpg npc heal logg...

Full test results in `~/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix-ci-main-failing-tests/_build/_tests/Silent failure logging U+0028Phase 2AU+0029'.
Test Successful in 0.014s. 15 tests run.

## Notes
- This is a queue-unblocker PR: it addresses the current  failures observed in  and the same failures propagated into unrelated PRs like  and .