### PR TITLE
docs: align MCP canonical header contract

### DIFF
--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -268,7 +268,7 @@ Status here is code-level (unverified). Use test logs for runtime verification.
 | Requirement | Status | Implementation |
 |-------------|--------|----------------|
 | JSON-RPC 2.0 Format | yes | `mcp_protocol.ml` |
-| Protocol Version Header | yes | `X-MCP-Protocol-Version: 2025-11-25` |
+| Protocol Version Header | yes | `MCP-Protocol-Version: 2025-11-25` |
 | Standard Error Codes | yes | -32700, -32600, -32601, -32602, -32603 |
 | Origin Validation | yes | `validate_origin` with allowlist |
 
@@ -285,7 +285,7 @@ Status here is code-level (unverified). Use test logs for runtime verification.
 
 | Requirement | Status | Implementation |
 |-------------|--------|----------------|
-| Session ID | yes | `session.ml` - `X-MCP-Session-ID` header |
+| Session ID | yes | `session.ml` - `Mcp-Session-Id` header (legacy `X-MCP-Session-ID` still accepted for compatibility) |
 | Event IDs (Resumability) | yes | SSE `id:` field, `Last-Event-ID` reconnect |
 | Cancellation Tokens | yes | `cancellation.ml` - LIFO callbacks |
 | Resource Subscriptions | yes | `subscriptions.ml` - 6 resource types |

--- a/lib/session.ml
+++ b/lib/session.ml
@@ -427,7 +427,8 @@ let restore_from_disk registry ~agents_path =
   end
 
 (* ============================================ *)
-(* MCP 2025-11-25 Spec: X-MCP-Session-ID        *)
+(* MCP 2025-11-25 Spec: Mcp-Session-Id          *)
+(* Legacy compatibility: X-MCP-Session-ID       *)
 (* ============================================ *)
 
 (** MCP Session ID store - separate from agent sessions *)
@@ -522,7 +523,9 @@ let start_mcp_session_cleanup_loop ~sw ~clock ?(interval=Env_config.Session.max_
     loop ()
   )
 
-(** Extract MCP Session ID from HTTP headers (supports both naming conventions) *)
+(** Extract MCP Session ID from HTTP headers.
+    Prefers the canonical Mcp-Session-Id header and falls back to the legacy
+    X-MCP-Session-ID alias for compatibility. *)
 let extract_mcp_session_id (headers : Cohttp.Header.t) : string option =
   match Cohttp.Header.get headers "Mcp-Session-Id" with
   | Some _ as result -> result

--- a/lib/tools.ml
+++ b/lib/tools.ml
@@ -2764,7 +2764,7 @@ Example: masc_a2a_unsubscribe({subscription_id: 'sub-abc123'})";
 
   {
     name = "masc_mcp_session";
-    description = "Manage MCP sessions (X-MCP-Session-ID). Sessions track client context across requests.";
+    description = "Manage MCP sessions (Mcp-Session-Id; legacy X-MCP-Session-ID also accepted). Sessions track client context across requests.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [

--- a/test/test_tool_contract_truth.ml
+++ b/test/test_tool_contract_truth.ml
@@ -4,7 +4,6 @@ module Mcp_eio = Masc_mcp.Mcp_server_eio
 module Config = Masc_mcp.Config
 module Mode = Masc_mcp.Mode
 module Room = Masc_mcp.Room
-module Tool_catalog = Masc_mcp.Tool_catalog
 
 let temp_dir () =
   let dir = Filename.temp_file "test_tool_contract_truth_" "" in
@@ -83,40 +82,48 @@ let test_visible_tools_expose_only_truthful_statuses () =
         tools)
 
 let test_hidden_tools_report_contract_status () =
-  let hidden_tool name =
-    let fields = Tool_catalog.metadata_to_fields name in
-    `Assoc (("name", `String name) :: fields)
-  in
-  let tools =
-    [
-      hidden_tool "masc_archive_save";
-      hidden_tool "masc_claim";
-      hidden_tool "masc_transition";
-      hidden_tool "masc_runtime_verify";
-      hidden_tool "masc_llama_runtime_verify";
-      hidden_tool "masc_verify_handoff";
-    ]
-  in
-  let placeholder = find_tool_exn tools "masc_archive_save" in
-  check string "archive_save placeholder" "placeholder"
-    (tool_string_field placeholder "implementationStatus");
-  let alias = find_tool_exn tools "masc_claim" in
-  check string "claim adapter" "adapter"
-    (tool_string_field alias "implementationStatus");
-  let canonical = find_tool_exn tools "masc_transition" in
-  check string "transition real" "real"
-    (tool_string_field canonical "implementationStatus");
-  let runtime_verify = find_tool_exn tools "masc_runtime_verify" in
-  check string "runtime verify real" "real"
-    (tool_string_field runtime_verify "implementationStatus");
-  let runtime_alias = find_tool_exn tools "masc_llama_runtime_verify" in
-  check string "llama runtime verify adapter alias" "adapter"
-    (tool_string_field runtime_alias "implementationStatus");
-  check string "llama runtime verify canonical" "masc_runtime_verify"
-    (tool_string_field runtime_alias "canonicalName");
-  let verify_handoff = find_tool_exn tools "masc_verify_handoff" in
-  check string "verify_handoff real" "real"
-    (tool_string_field verify_handoff "implementationStatus")
+  Eio_main.run @@ fun env ->
+  let clock = Eio.Stdenv.clock env in
+  Eio.Switch.run @@ fun sw ->
+  let base_path = temp_dir () in
+  Fun.protect ~finally:(fun () -> cleanup_dir base_path) (fun () ->
+      let state = Mcp_eio.create_state ~test_mode:true ~base_path () in
+      let room_path = Room.masc_dir state.room_config in
+      ignore (Config.switch_mode room_path Mode.Full);
+      let tools =
+        tools_list_response ~clock ~sw ~include_hidden:true
+          ~names:
+            [
+              "masc_archive_save";
+              "masc_claim";
+              "masc_transition";
+              "masc_runtime_verify";
+              "masc_llama_runtime_verify";
+              "masc_verify_handoff";
+            ]
+          state
+        |> response_tools
+      in
+      let placeholder = find_tool_exn tools "masc_archive_save" in
+      check string "archive_save placeholder" "placeholder"
+        (tool_string_field placeholder "implementationStatus");
+      let alias = find_tool_exn tools "masc_claim" in
+      check string "claim adapter" "adapter"
+        (tool_string_field alias "implementationStatus");
+      let canonical = find_tool_exn tools "masc_transition" in
+      check string "transition real" "real"
+        (tool_string_field canonical "implementationStatus");
+      let runtime_verify = find_tool_exn tools "masc_runtime_verify" in
+      check string "runtime verify real" "real"
+        (tool_string_field runtime_verify "implementationStatus");
+      let runtime_alias = find_tool_exn tools "masc_llama_runtime_verify" in
+      check string "llama runtime verify adapter alias" "adapter"
+        (tool_string_field runtime_alias "implementationStatus");
+      check string "llama runtime verify canonical" "masc_runtime_verify"
+        (tool_string_field runtime_alias "canonicalName");
+      let verify_handoff = find_tool_exn tools "masc_verify_handoff" in
+      check string "verify_handoff real" "real"
+        (tool_string_field verify_handoff "implementationStatus"))
 
 let () =
   run "tool contract truth"


### PR DESCRIPTION
## Summary
- align docs and tool text with canonical MCP protocol header naming
- document canonical session header and legacy compatibility fallback
- keep implementation unchanged; this is a contract/docs cleanup around current behavior

## Validation
- DUNE_BUILD_DIR=_build_header_docs dune build --root . @check
