### PR TITLE
fix(ci): restore baseline health and quick-suite checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Pin external dependencies
         run: |
           chmod +x scripts/opam-pin-external-deps.sh
-          scripts/opam-pin-external-deps.sh
+          scripts/opam-pin-external-deps.sh --with-bisect
 
       - name: Refresh system package index
         run: sudo apt-get update -qq

--- a/lib/keeper_execution.ml
+++ b/lib/keeper_execution.ml
@@ -1448,6 +1448,9 @@ let run_autonomous_goal_turn ~(config : Room.config) ~(meta : keeper_meta)
                  None)
 
 let maybe_emit_proactive (ctx : _ context) (meta : keeper_meta) : keeper_meta =
+  let log_proactive_failure reason =
+    Printf.eprintf "[keeper] proactive emission failed: %s\n%!" reason
+  in
   if not meta.proactive_enabled then meta
   else
     let now_ts = Time_compat.now () in
@@ -1470,10 +1473,14 @@ let maybe_emit_proactive (ctx : _ context) (meta : keeper_meta) : keeper_meta =
     if idle_seconds < idle_gate || cooldown_elapsed < cooldown_gate then meta
     else
       match model_specs_of_strings meta.models with
-      | Error _ -> meta
+      | Error msg ->
+          log_proactive_failure ("model specs: " ^ msg);
+          meta
       | Ok specs ->
           (match ensure_api_keys specs with
-           | Error _ -> meta
+           | Error msg ->
+               log_proactive_failure ("api keys: " ^ msg);
+               meta
            | Ok () ->
                (* Phase 2: Autonomous goal turn (L2+ with active goals) *)
                (match run_autonomous_goal_turn ~config:ctx.config ~meta ~specs with
@@ -1497,7 +1504,9 @@ let maybe_emit_proactive (ctx : _ context) (meta : keeper_meta) : keeper_meta =
                    ~base_dir
                in
                match ctx_opt with
-               | None -> meta
+               | None ->
+                   log_proactive_failure "continuity context unavailable";
+                   meta
                | Some ctx_work ->
                    let continuity_snapshot = latest_state_snapshot_from_messages ctx_work.messages in
                    let continuity_summary =
@@ -1534,8 +1543,11 @@ let maybe_emit_proactive (ctx : _ context) (meta : keeper_meta) : keeper_meta =
                        ~continuity_summary
                        ~idle_seconds
                    with
-                       | None -> meta
-	                   | Some generated ->
+                       | None ->
+                           log_proactive_failure
+                             "generation returned no proactive reply";
+                           meta
+                       | Some generated ->
 	                       let model_used =
 	                         let m = String.trim generated.model_used in
 	                         if m <> "" then m else primary.model_id

--- a/lib/mcp_server_eio.ml
+++ b/lib/mcp_server_eio.ml
@@ -3299,6 +3299,7 @@ let tool_json_for_profile ?usage_summary profile (schema : Types.tool_schema) =
           (List.map Mcp_server.icon_to_json (tool_icons_for_name schema.name)) );
       ("inputSchema", schema.input_schema);
     ]
+    @ Tool_catalog.metadata_to_fields schema.name
     @ maybe_assoc_field "outputSchema" (tool_output_schema_field schema.name)
     @ maybe_assoc_field "annotations" (tool_annotations_for_profile profile schema.name)
     @

--- a/test/test_mcp_server_eio.ml
+++ b/test/test_mcp_server_eio.ml
@@ -657,8 +657,10 @@ let test_handle_request_tools_list_include_hidden_metadata () =
     (Yojson.Safe.Util.member "icons" status_tool <> `Null);
   Alcotest.(check bool) "standard tools expose annotations" true
     (Yojson.Safe.Util.member "annotations" status_tool <> `Null);
-  Alcotest.(check bool) "hidden metadata not leaked" false
+  Alcotest.(check bool) "visibility metadata exposed" true
     (Yojson.Safe.Util.member "visibility" status_tool <> `Null);
+  Alcotest.(check bool) "implementation status exposed" true
+    (Yojson.Safe.Util.member "implementationStatus" status_tool <> `Null);
   Alcotest.(check bool) "hidden utility omitted" false
     (List.exists
        (function

--- a/test/test_silent_failures_p2a.ml
+++ b/test/test_silent_failures_p2a.ml
@@ -128,8 +128,8 @@ let file_contains_pattern file_rel pattern =
 (* HIGH priority patterns *)
 
 let test_source_main_keeper_bootstrap () =
-  check bool "main_eio.ml has keeper bootstrap logging"
-    true (file_contains_pattern "bin/main_eio.ml"
+  check bool "server_runtime_bootstrap.ml has keeper bootstrap logging"
+    true (file_contains_pattern "lib/server_runtime_bootstrap.ml"
       {|[main] keeper bootstrap failed:|})
 
 let test_source_metrics_fd_close () =


### PR DESCRIPTION
## Summary
- fix the Health workflow to pin bisect before installing test dependencies
- restore tools/list metadata fields used by the tool-truth contract
- add explicit proactive keeper failure logging and align silent-failure source checks with the current bootstrap module
- update the MCP server hidden-metadata test to match the current public tools/list contract

## Local verification
- dune build --root .
- ./_build/default/test/test_tool_contract_truth.exe
- ./_build/default/test/test_silent_failures_p2a.exe
- ./_build/default/test/test_tools_coverage.exe
- ./_build/default/test/test_mcp_server_eio.exe