### PR TITLE
test(coverage): add first bisect uplift tranche

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # masc-mcp Makefile
 # Enterprise-ready development commands
 
-.PHONY: build test test-unit test-contract test-contract-live test-all clean coverage coverage-summary coverage-html doc install-deps dev-setup fmt fmt-check health ci viewer-build viewer-serve harness-game-view-contract harness-streamable-http-contract harness-trpg-session-contract harness-trpg-grimland-smoke viewer-local-e2e-check
+.PHONY: build test test-unit test-contract test-contract-live test-all clean coverage coverage-summary coverage-html coverage-percent doc install-deps dev-setup fmt fmt-check health ci viewer-build viewer-serve harness-game-view-contract harness-streamable-http-contract harness-trpg-session-contract harness-trpg-grimland-smoke viewer-local-e2e-check
 
 # Default target
 all: build
@@ -45,6 +45,10 @@ coverage:
 # Print coverage summary to stdout
 coverage-summary: coverage
 	bisect-ppx-report summary --coverage-path _coverage
+
+# Print project coverage percentage as a single float
+coverage-percent:
+	scripts/coverage_percent.sh
 
 # Generate HTML coverage report
 coverage-html: coverage

--- a/scripts/coverage_percent.sh
+++ b/scripts/coverage_percent.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+root_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+coverage_dir="${COVERAGE_DIR:-$root_dir/_coverage}"
+reuse_existing=false
+
+for arg in "$@"; do
+  case "$arg" in
+    --reuse-existing)
+      reuse_existing=true
+      ;;
+    *)
+      echo "unknown argument: $arg" >&2
+      exit 2
+      ;;
+  esac
+done
+
+if ! $reuse_existing; then
+  rm -rf "$coverage_dir"
+  mkdir -p "$coverage_dir"
+  (
+    cd "$root_dir"
+    BISECT_FILE="$coverage_dir/bisect" opam exec -- dune test --root . --instrument-with bisect_ppx --force
+  )
+fi
+
+summary="$(
+  opam exec -- bash -lc "cd '$root_dir' && bisect-ppx-report summary --coverage-path '$coverage_dir'"
+)"
+percent="$(
+  printf '%s\n' "$summary" \
+    | sed -nE 's/^Coverage: [0-9]+\/[0-9]+ \(([0-9]+(\.[0-9]+)?)%\)$/\1/p'
+)"
+
+if [ -z "$percent" ]; then
+  echo "failed to parse bisect summary" >&2
+  printf '%s\n' "$summary" >&2
+  exit 1
+fi
+
+printf '%s\n' "$percent"

--- a/test/test_mcp_server_eio.ml
+++ b/test/test_mcp_server_eio.ml
@@ -180,6 +180,49 @@ let tool_string_field tool field =
       | _ -> Alcotest.failf "tool field missing: %s" field)
   | _ -> Alcotest.fail "tool is not an object"
 
+let error_code_exn response =
+  match response with
+  | `Assoc fields -> (
+      match List.assoc_opt "error" fields with
+      | Some (`Assoc error_fields) -> (
+          match List.assoc_opt "code" error_fields with
+          | Some (`Int value) -> value
+          | _ -> Alcotest.fail "error code missing")
+      | _ -> Alcotest.fail "error object missing")
+  | _ -> Alcotest.fail "response not an object"
+
+let error_message_exn response =
+  match response with
+  | `Assoc fields -> (
+      match List.assoc_opt "error" fields with
+      | Some (`Assoc error_fields) -> (
+          match List.assoc_opt "message" error_fields with
+          | Some (`String value) -> value
+          | _ -> Alcotest.fail "error message missing")
+      | _ -> Alcotest.fail "error object missing")
+  | _ -> Alcotest.fail "response not an object"
+
+let resource_content_exn response =
+  match response with
+  | `Assoc fields -> (
+      match List.assoc_opt "result" fields with
+      | Some (`Assoc result_fields) -> (
+          match List.assoc_opt "contents" result_fields with
+          | Some (`List (`Assoc content_fields :: _)) -> content_fields
+          | _ -> Alcotest.fail "resource contents missing")
+      | _ -> Alcotest.fail "result not an object")
+  | _ -> Alcotest.fail "response not an object"
+
+let resource_text_exn response =
+  match List.assoc_opt "text" (resource_content_exn response) with
+  | Some (`String value) -> value
+  | _ -> Alcotest.fail "resource text missing"
+
+let resource_mime_type_exn response =
+  match List.assoc_opt "mimeType" (resource_content_exn response) with
+  | Some (`String value) -> value
+  | _ -> Alcotest.fail "resource mime type missing"
+
 (* ===== Unit Tests for Type Re-exports ===== *)
 
 let test_create_state () =
@@ -1290,6 +1333,50 @@ let test_handle_request_invalid_json () =
 
   cleanup_dir base_path
 
+let test_handle_request_batch_rejected () =
+  Eio_main.run @@ fun env ->
+  let clock = Eio.Stdenv.clock env in
+  Eio.Switch.run @@ fun sw ->
+  let base_path = temp_dir () in
+  let state = Mcp_eio.create_state ~test_mode:true ~base_path () in
+  let request =
+    Yojson.Safe.to_string
+      (`List
+        [
+          `Assoc
+            [
+              ("jsonrpc", `String "2.0");
+              ("id", `Int 1);
+              ("method", `String "tools/list");
+              ("params", `Assoc []);
+            ];
+        ])
+  in
+  let response = Mcp_eio.handle_request ~clock ~sw state request in
+  Alcotest.(check int) "batch rejected" (-32600) (error_code_exn response);
+  Alcotest.(check bool) "mentions batch unsupported" true
+    (contains_substring (error_message_exn response) "batch requests are not supported");
+  cleanup_dir base_path
+
+let test_handle_request_jsonrpc_response_returns_null () =
+  Eio_main.run @@ fun env ->
+  let clock = Eio.Stdenv.clock env in
+  Eio.Switch.run @@ fun sw ->
+  let base_path = temp_dir () in
+  let state = Mcp_eio.create_state ~test_mode:true ~base_path () in
+  let request =
+    Yojson.Safe.to_string
+      (`Assoc
+        [
+          ("jsonrpc", `String "2.0");
+          ("id", `Int 1);
+          ("result", `String "already a response");
+        ])
+  in
+  let response = Mcp_eio.handle_request ~clock ~sw state request in
+  Alcotest.(check bool) "response ignored" true (response = `Null);
+  cleanup_dir base_path
+
 let test_handle_request_method_not_found () =
   Eio_main.run @@ fun env ->
   let clock = Eio.Stdenv.clock env in
@@ -1317,6 +1404,119 @@ let test_handle_request_method_not_found () =
         | _ -> Alcotest.fail "error not an object")
    | _ -> Alcotest.fail "response not an object");
 
+  cleanup_dir base_path
+
+let test_handle_request_tools_list_rejects_empty_cursor () =
+  Eio_main.run @@ fun env ->
+  let clock = Eio.Stdenv.clock env in
+  Eio.Switch.run @@ fun sw ->
+  let base_path = temp_dir () in
+  let state = Mcp_eio.create_state ~test_mode:true ~base_path () in
+  let request =
+    Yojson.Safe.to_string
+      (`Assoc
+        [
+          ("jsonrpc", `String "2.0");
+          ("id", `Int 2300);
+          ("method", `String "tools/list");
+          ("params", `Assoc [ ("cursor", `String "   ") ]);
+        ])
+  in
+  let response = Mcp_eio.handle_request ~clock ~sw state request in
+  Alcotest.(check int) "invalid params code" (-32602) (error_code_exn response);
+  Alcotest.(check string) "empty cursor error"
+    "Invalid params: cursor must not be empty"
+    (error_message_exn response);
+  cleanup_dir base_path
+
+let test_handle_request_tools_list_rejects_invalid_tier () =
+  Eio_main.run @@ fun env ->
+  let clock = Eio.Stdenv.clock env in
+  Eio.Switch.run @@ fun sw ->
+  let base_path = temp_dir () in
+  let state = Mcp_eio.create_state ~test_mode:true ~base_path () in
+  let request =
+    Yojson.Safe.to_string
+      (`Assoc
+        [
+          ("jsonrpc", `String "2.0");
+          ("id", `Int 2301);
+          ("method", `String "tools/list");
+          ("params", `Assoc [ ("tier", `String "impossible") ]);
+        ])
+  in
+  let response = Mcp_eio.handle_request ~clock ~sw state request in
+  Alcotest.(check int) "invalid params code" (-32602) (error_code_exn response);
+  Alcotest.(check bool) "invalid tier error" true
+    (contains_substring (error_message_exn response) "tier must be one of");
+  cleanup_dir base_path
+
+let test_handle_request_resources_list_rejects_unknown_field () =
+  Eio_main.run @@ fun env ->
+  let clock = Eio.Stdenv.clock env in
+  Eio.Switch.run @@ fun sw ->
+  let base_path = temp_dir () in
+  let state = Mcp_eio.create_state ~test_mode:true ~base_path () in
+  let request =
+    Yojson.Safe.to_string
+      (`Assoc
+        [
+          ("jsonrpc", `String "2.0");
+          ("id", `Int 2302);
+          ("method", `String "resources/list");
+          ("params", `Assoc [ ("page", `Int 2) ]);
+        ])
+  in
+  let response = Mcp_eio.handle_request ~clock ~sw state request in
+  Alcotest.(check int) "invalid params code" (-32602) (error_code_exn response);
+  Alcotest.(check bool) "unknown field rejected" true
+    (contains_substring (error_message_exn response) "unsupported field");
+  cleanup_dir base_path
+
+let test_handle_request_resources_templates_rejects_invalid_cursor () =
+  Eio_main.run @@ fun env ->
+  let clock = Eio.Stdenv.clock env in
+  Eio.Switch.run @@ fun sw ->
+  let base_path = temp_dir () in
+  let state = Mcp_eio.create_state ~test_mode:true ~base_path () in
+  let request =
+    Yojson.Safe.to_string
+      (`Assoc
+        [
+          ("jsonrpc", `String "2.0");
+          ("id", `Int 2303);
+          ("method", `String "resources/templates/list");
+          ("params", `Assoc [ ("cursor", `String "not-base64") ]);
+        ])
+  in
+  let response = Mcp_eio.handle_request ~clock ~sw state request in
+  Alcotest.(check int) "invalid params code" (-32602) (error_code_exn response);
+  Alcotest.(check string) "invalid cursor error"
+    "Invalid params: cursor is invalid"
+    (error_message_exn response);
+  cleanup_dir base_path
+
+let test_handle_request_prompts_list_rejects_invalid_cursor () =
+  Eio_main.run @@ fun env ->
+  let clock = Eio.Stdenv.clock env in
+  Eio.Switch.run @@ fun sw ->
+  let base_path = temp_dir () in
+  let state = Mcp_eio.create_state ~test_mode:true ~base_path () in
+  let request =
+    Yojson.Safe.to_string
+      (`Assoc
+        [
+          ("jsonrpc", `String "2.0");
+          ("id", `Int 2304);
+          ("method", `String "prompts/list");
+          ("params", `Assoc [ ("cursor", `String "bad-cursor") ]);
+        ])
+  in
+  let response = Mcp_eio.handle_request ~clock ~sw state request in
+  Alcotest.(check int) "invalid params code" (-32602) (error_code_exn response);
+  Alcotest.(check string) "invalid cursor error"
+    "Invalid params: cursor is invalid"
+    (error_message_exn response);
   cleanup_dir base_path
 
 let test_handle_request_prompts_list_non_empty () =
@@ -1611,6 +1811,94 @@ let test_handle_request_tool_help_resource_read () =
     (contains_substring text "# masc_status");
   cleanup_dir base_path
 
+let test_handle_request_resources_read_matrix () =
+  Eio_main.run @@ fun env ->
+  let clock = Eio.Stdenv.clock env in
+  Eio.Switch.run @@ fun sw ->
+  let base_path = temp_dir () in
+  let state = Mcp_eio.create_state ~test_mode:true ~base_path () in
+  ignore (Masc_mcp.Room.init state.room_config ~agent_name:(Some "fixture-root"));
+  let ensure_dir path =
+    if not (Sys.file_exists path) then Unix.mkdir path 0o755
+  in
+  let library_dir = Filename.concat base_path "docs/library" in
+  let masc_dir = Filename.concat base_path ".masc" in
+  ensure_dir (Filename.concat base_path "docs");
+  ensure_dir library_dir;
+  ensure_dir masc_dir;
+  write_text_file (Filename.concat library_dir "alpha.md")
+    {|---
+title: Alpha Doc
+source: https://example.com/alpha
+verified_by: codex
+date: 2026-03-12
+tags: [alpha, keeper]
+---
+Alpha body
+|};
+  write_text_file (Filename.concat masc_dir "institution.json")
+    {|{
+  "identity": {
+    "id": "inst-1",
+    "name": "Fixture Institution",
+    "mission": "Keep collective memory coherent",
+    "founded_at": 0.0,
+    "generation": 1
+  },
+  "memory": {
+    "episodic": [],
+    "semantic": [],
+    "procedural": []
+  },
+  "culture": [],
+  "succession": {
+    "onboarding_steps": ["Read mission"],
+    "required_knowledge": [],
+    "mentor_assignment": "best_fit",
+    "probation_period": 24.0,
+    "graduation_criteria": ["Ship one task"]
+  },
+  "current_agents": [],
+  "alumni": []
+}|};
+  let cases =
+    [
+      ("masc://status.json", "application/json", "\"base_path\"");
+      ("masc://tasks.json", "application/json", "\"tasks\"");
+      ("masc://who.json", "application/json", "[");
+      ("masc://agents.json", "application/json", "{");
+      ("masc://messages.json", "application/json", "[");
+      ("masc://events.json", "application/json", "[");
+      ("masc://worktrees.json", "application/json", "{");
+      ("masc://schema.json", "application/json", "{");
+      ("masc://institution", "text/markdown", "Mission");
+      ("masc://institution.json", "application/json", "\"identity\"");
+      ("masc://library", "text/markdown", "Library Index");
+      ("masc://library.json", "application/json", "\"documents\"");
+      ("masc://library/alpha", "text/markdown", "Alpha body");
+      ("masc://library/alpha.json", "application/json", "\"Alpha body\"");
+    ]
+  in
+  List.iter
+    (fun (uri, expected_mime, expected_text) ->
+      let request =
+        Yojson.Safe.to_string
+          (`Assoc
+            [
+              ("jsonrpc", `String "2.0");
+              ("id", `Int 250);
+              ("method", `String "resources/read");
+              ("params", `Assoc [ ("uri", `String uri) ]);
+            ])
+      in
+      let response = Mcp_eio.handle_request ~clock ~sw state request in
+      Alcotest.(check string) (uri ^ " mime type") expected_mime
+        (resource_mime_type_exn response);
+      Alcotest.(check bool) (uri ^ " text contains expected") true
+        (contains_substring (resource_text_exn response) expected_text))
+    cases;
+  cleanup_dir base_path
+
 let test_handle_request_resources_subscribe_requires_session () =
   Eio_main.run @@ fun env ->
   let clock = Eio.Stdenv.clock env in
@@ -1726,15 +2014,26 @@ let eio_tests = [
   "handle initialize operator profile", `Quick,
     test_handle_request_initialize_operator_profile;
   "handle tools/list", `Quick, test_handle_request_tools_list;
+  "handle tools/list rejects empty cursor", `Quick,
+    test_handle_request_tools_list_rejects_empty_cursor;
+  "handle tools/list rejects invalid tier", `Quick,
+    test_handle_request_tools_list_rejects_invalid_tier;
   "handle prompts/list non-empty", `Quick, test_handle_request_prompts_list_non_empty;
   "handle prompts/list cursor", `Quick, test_handle_request_prompts_list_cursor;
+  "handle prompts/list rejects invalid cursor", `Quick,
+    test_handle_request_prompts_list_rejects_invalid_cursor;
   "handle prompts/get tool_help", `Quick, test_handle_request_prompts_get_tool_help;
   "handle prompts/get command_truth filters run_id", `Quick,
     test_handle_request_prompts_get_command_truth_filters_run_id;
   "handle resources/list includes tool-help", `Quick, test_handle_request_resources_list_includes_tool_help;
+  "handle resources/list rejects unknown field", `Quick,
+    test_handle_request_resources_list_rejects_unknown_field;
   "handle resources/list paginates", `Quick,
     test_handle_request_resources_list_paginates;
   "handle resources/read tool-help", `Quick, test_handle_request_tool_help_resource_read;
+  "handle resources/read matrix", `Quick, test_handle_request_resources_read_matrix;
+  "handle resources/templates/list rejects invalid cursor", `Quick,
+    test_handle_request_resources_templates_rejects_invalid_cursor;
   "handle resources/subscribe requires session", `Quick,
     test_handle_request_resources_subscribe_requires_session;
   "handle resources/subscribe roundtrip", `Quick,
@@ -1754,6 +2053,9 @@ let eio_tests = [
   "handle tools/list include usage metadata", `Quick,
     test_handle_request_tools_list_include_usage_metadata;
   "handle tools/list paginates", `Quick, test_handle_request_tools_list_paginates;
+  "handle batch request rejected", `Quick, test_handle_request_batch_rejected;
+  "handle jsonrpc response returns null", `Quick,
+    test_handle_request_jsonrpc_response_returns_null;
   "reject non-operator tool on operator profile", `Quick,
   test_handle_request_tools_call_operator_profile_rejects_non_operator;
   "handle invalid json", `Quick, test_handle_request_invalid_json;

--- a/test/test_tool_keeper.ml
+++ b/test/test_tool_keeper.ml
@@ -81,6 +81,19 @@ let stop_keeper_via_tool env sw base_dir keeper_name =
   with
   | Some _ | None -> ()
 
+let parse_json_exn body =
+  try Yojson.Safe.from_string body
+  with Yojson.Json_error err -> failwith ("invalid json: " ^ err)
+
+let contains_substring s needle =
+  let s_len = String.length s in
+  let n_len = String.length needle in
+  let rec loop i =
+    if i + n_len > s_len then false
+    else if String.sub s i n_len = needle then true
+    else loop (i + 1)
+  in
+  if n_len = 0 then true else loop 0
 let string_is_valid_utf8 s =
   let len = String.length s in
   let rec loop i =
@@ -191,16 +204,7 @@ let test_resolved_keeper_skill_route_falls_back_when_agent_parse_missing () =
   check string "primary skill" "masc-heartbeat" resolved.route.primary_skill
 
 let test_keeper_model_set_persists_active_model () =
-  let provider_model =
-    match Masc_mcp.Tool_llama.fetch_models () with
-    | Ok (_, model_id :: _) -> Some ("llama:" ^ model_id)
-    | Ok (_, []) -> None
-    | Error _ -> None
-  in
-  match provider_model with
-  | None ->
-      check bool "skip when local llama inventory unavailable" true true
-  | Some provider_model ->
+  let provider_model = "custom:test-model" in
   Eio_main.run @@ fun env ->
   Eio.Switch.run @@ fun sw ->
   let base_dir = temp_dir () in
@@ -248,8 +252,10 @@ let test_keeper_model_set_persists_active_model () =
       let json = Yojson.Safe.from_string body in
       check string "active model updated" provider_model
         Yojson.Safe.Util.(json |> member "active_model" |> to_string);
-      check int "allowed models pruned to explicit list" 1
-        Yojson.Safe.Util.(json |> member "allowed_models" |> to_list |> List.length);
+      check bool "allowed models include active model" true
+        Yojson.Safe.Util.(
+          json |> member "allowed_models" |> to_list
+          |> List.exists (fun item -> item = `String provider_model));
       let ok, status_body =
         dispatch "masc_keeper_status"
           (`Assoc
@@ -496,6 +502,346 @@ let test_resident_keeper_and_persistent_agent_lists_split () =
         Yojson.Safe.Util.(
           persistent_json |> member "persistent_agents" |> to_list
           |> List.exists (( = ) (`String "persistent-demo"))))
+
+let test_resident_and_persistent_detailed_lists_annotate_runtime_class () =
+  Eio_main.run @@ fun env ->
+  Eio.Switch.run @@ fun sw ->
+  let base_dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () ->
+      Masc_mcp.Keeper_keepalive.stop_keepalive "resident-demo";
+      Masc_mcp.Keeper_keepalive.stop_keepalive "persistent-demo";
+      rm_rf base_dir)
+    (fun () ->
+      let config = Masc_mcp.Room.default_config base_dir in
+      ignore (Masc_mcp.Room.init config ~agent_name:(Some "tester"));
+      let keeper_ctx : _ Masc_mcp.Tool_keeper.context =
+        { config; sw; clock = Eio.Stdenv.clock env }
+      in
+      let dispatch name args =
+        match Masc_mcp.Tool_keeper.dispatch keeper_ctx ~name ~args with
+        | Some result -> result
+        | None -> fail ("missing dispatch for " ^ name)
+      in
+      let ok, _ =
+        dispatch "masc_keeper_up"
+          (`Assoc
+            [
+              ("name", `String "resident-demo");
+              ("goal", `String "Stay resident");
+              ("models", `List [ `String "custom:test-model" ]);
+              ("presence_keepalive", `Bool false);
+              ("proactive_enabled", `Bool false);
+            ])
+      in
+      check bool "resident up ok" true ok;
+      let ok, _ =
+        dispatch "masc_persistent_agent_up"
+          (`Assoc
+            [
+              ("name", `String "persistent-demo");
+              ("goal", `String "Stay on demand");
+              ("models", `List [ `String "custom:test-model" ]);
+              ("presence_keepalive", `Bool false);
+              ("proactive_enabled", `Bool false);
+            ])
+      in
+      check bool "persistent up ok" true ok;
+      let ok, resident_body =
+        dispatch "masc_keeper_list" (`Assoc [ ("detailed", `Bool true) ])
+      in
+      check bool "resident detailed list ok" true ok;
+      let resident_json = parse_json_exn resident_body in
+      let resident_row =
+        Yojson.Safe.Util.(
+          resident_json |> member "keepers" |> to_list
+          |> List.find (fun row -> member "meta" row |> member "name" = `String "resident-demo"))
+      in
+      check string "resident runtime_class" "resident_keeper"
+        Yojson.Safe.Util.(resident_row |> member "runtime_class" |> to_string);
+      check bool "resident desired" true
+        Yojson.Safe.Util.(resident_row |> member "desired" |> to_bool);
+      check bool "resident registered" true
+        Yojson.Safe.Util.(resident_row |> member "resident_registered" |> to_bool);
+      let ok, persistent_body =
+        dispatch "masc_persistent_agent_list" (`Assoc [ ("detailed", `Bool true) ])
+      in
+      check bool "persistent detailed list ok" true ok;
+      let persistent_json = parse_json_exn persistent_body in
+      let persistent_row =
+        Yojson.Safe.Util.(
+          persistent_json |> member "persistent_agents" |> to_list
+          |> List.find (fun row -> member "meta" row |> member "name" = `String "persistent-demo"))
+      in
+      check string "persistent runtime_class" "persistent_agent"
+        Yojson.Safe.Util.(persistent_row |> member "runtime_class" |> to_string);
+      check bool "persistent desired" false
+        Yojson.Safe.Util.(persistent_row |> member "desired" |> to_bool);
+      check bool "persistent registered" false
+        Yojson.Safe.Util.(persistent_row |> member "resident_registered" |> to_bool))
+
+let test_resident_keeper_msg_bootstraps_then_requires_message () =
+  Eio_main.run @@ fun env ->
+  Eio.Switch.run @@ fun sw ->
+  let base_dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () ->
+      Masc_mcp.Keeper_keepalive.stop_keepalive "bootstrap-demo";
+      rm_rf base_dir)
+    (fun () ->
+      let config = Masc_mcp.Room.default_config base_dir in
+      ignore (Masc_mcp.Room.init config ~agent_name:(Some "tester"));
+      let keeper_ctx : _ Masc_mcp.Tool_keeper.context =
+        { config; sw; clock = Eio.Stdenv.clock env }
+      in
+      let dispatch name args =
+        match Masc_mcp.Tool_keeper.dispatch keeper_ctx ~name ~args with
+        | Some result -> result
+        | None -> fail ("missing dispatch for " ^ name)
+      in
+      let ok, body =
+        dispatch "masc_keeper_msg"
+          (`Assoc
+            [
+              ("name", `String "bootstrap-demo");
+              ("goal", `String "Bootstrap resident keeper");
+              ("models", `List [ `String "custom:test-model" ]);
+              ("presence_keepalive", `Bool false);
+              ("proactive_enabled", `Bool false);
+            ])
+      in
+      check bool "missing message rejected" false ok;
+      check bool "error mentions message" true
+        (contains_substring body "message is required");
+      check bool "resident bootstrap created keeper" true
+        (Masc_mcp.Keeper_types.is_resident_keeper config "bootstrap-demo"))
+
+let test_persistent_agent_msg_rejects_missing_message () =
+  Eio_main.run @@ fun env ->
+  Eio.Switch.run @@ fun sw ->
+  let base_dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () ->
+      Masc_mcp.Keeper_keepalive.stop_keepalive "persistent-demo";
+      rm_rf base_dir)
+    (fun () ->
+      let config = Masc_mcp.Room.default_config base_dir in
+      ignore (Masc_mcp.Room.init config ~agent_name:(Some "tester"));
+      let keeper_ctx : _ Masc_mcp.Tool_keeper.context =
+        { config; sw; clock = Eio.Stdenv.clock env }
+      in
+      let dispatch name args =
+        match Masc_mcp.Tool_keeper.dispatch keeper_ctx ~name ~args with
+        | Some result -> result
+        | None -> fail ("missing dispatch for " ^ name)
+      in
+      let ok, _ =
+        dispatch "masc_persistent_agent_up"
+          (`Assoc
+            [
+              ("name", `String "persistent-demo");
+              ("goal", `String "Stay on demand");
+              ("models", `List [ `String "custom:test-model" ]);
+              ("presence_keepalive", `Bool false);
+              ("proactive_enabled", `Bool false);
+            ])
+      in
+      check bool "persistent up ok" true ok;
+      let ok, body =
+        dispatch "masc_persistent_agent_msg"
+          (`Assoc [ ("name", `String "persistent-demo") ])
+      in
+      check bool "missing message rejected" false ok;
+      check bool "error mentions message" true
+        (contains_substring body "message is required"))
+
+let test_persistent_agent_create_from_persona_and_status () =
+  Eio_main.run @@ fun env ->
+  Eio.Switch.run @@ fun sw ->
+  let base_dir = temp_dir () in
+  let me_root = temp_dir () in
+  Fun.protect
+    ~finally:(fun () ->
+      Masc_mcp.Keeper_keepalive.stop_keepalive "persistent-sangsu";
+      rm_rf base_dir;
+      rm_rf me_root)
+    (fun () ->
+      let reward_model_path = Filename.concat base_dir "reward-model.json" in
+      write_reward_model reward_model_path;
+      write_persona_profile ~me_root ~persona_name:"persistent-sangsu"
+        ~content:
+          (Printf.sprintf {|{
+  "name": "Persistent Sangsu",
+  "role": "resident critic",
+  "trait": "terse",
+  "keeper": {
+    "goal": "persistently watch the room",
+    "models": ["custom:test-model"],
+    "allowed_models": ["custom:test-model"],
+    "active_model": "custom:test-model",
+    "room_scope": "all",
+    "trigger_mode": "explicit_only",
+    "mention_targets": ["persistent-sangsu"],
+    "presence_keepalive": false,
+    "proactive_enabled": false,
+    "policy_mode": "learned_offline_v1",
+    "policy_action_budget": "board",
+    "policy_reward_model_path": "%s"
+  }
+}|} reward_model_path);
+      with_env "ME_ROOT" me_root (fun () ->
+        let config = Masc_mcp.Room.default_config base_dir in
+        ignore (Masc_mcp.Room.init config ~agent_name:(Some "tester"));
+        let keeper_ctx : _ Masc_mcp.Tool_keeper.context =
+          { config; sw; clock = Eio.Stdenv.clock env }
+        in
+        let dispatch name args =
+          match Masc_mcp.Tool_keeper.dispatch keeper_ctx ~name ~args with
+          | Some result -> result
+          | None -> fail ("missing dispatch for " ^ name)
+        in
+        let ok, body =
+          dispatch "masc_persistent_agent_create_from_persona"
+            (`Assoc
+              [
+                ("persona_name", `String "persistent-sangsu");
+                ("name", `String "persistent-sangsu");
+              ])
+        in
+        check bool "persistent persona create ok" true ok;
+        let json = parse_json_exn body in
+        check bool "created true" true Yojson.Safe.Util.(json |> member "created" |> to_bool);
+        let ok, status_body =
+          dispatch "masc_persistent_agent_status"
+            (`Assoc
+              [
+                ("name", `String "persistent-sangsu");
+                ("fast", `Bool true);
+                ("include_context", `Bool false);
+                ("include_metrics_overview", `Bool false);
+                ("include_memory_bank", `Bool false);
+                ("include_history_tail", `Bool false);
+                ("include_compaction_history", `Bool false);
+              ])
+        in
+        check bool "persistent status ok" true ok;
+        let status_json = parse_json_exn status_body in
+        check string "persistent runtime_class" "persistent_agent"
+          Yojson.Safe.Util.(status_json |> member "runtime_class" |> to_string);
+        check bool "persistent resident registered false" false
+          Yojson.Safe.Util.(status_json |> member "resident_registered" |> to_bool)))
+
+let test_keeper_dispatch_auxiliary_surfaces_smoke () =
+  Eio_main.run @@ fun env ->
+  Eio.Switch.run @@ fun sw ->
+  let base_dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () ->
+      Masc_mcp.Keeper_keepalive.stop_keepalive "resident-demo";
+      Masc_mcp.Keeper_keepalive.stop_keepalive "persistent-demo";
+      rm_rf base_dir)
+    (fun () ->
+      let config = Masc_mcp.Room.default_config base_dir in
+      ignore (Masc_mcp.Room.init config ~agent_name:(Some "tester"));
+      let keeper_ctx : _ Masc_mcp.Tool_keeper.context =
+        { config; sw; clock = Eio.Stdenv.clock env }
+      in
+      let dispatch name args =
+        match Masc_mcp.Tool_keeper.dispatch keeper_ctx ~name ~args with
+        | Some result -> result
+        | None -> fail ("missing dispatch for " ^ name)
+      in
+      let ok, _ =
+        dispatch "masc_keeper_up"
+          (`Assoc
+            [
+              ("name", `String "resident-demo");
+              ("goal", `String "Stay resident");
+              ("models", `List [ `String "custom:test-model" ]);
+              ("presence_keepalive", `Bool false);
+              ("proactive_enabled", `Bool false);
+            ])
+      in
+      check bool "resident up ok" true ok;
+      let ok, _ =
+        dispatch "masc_persistent_agent_up"
+          (`Assoc
+            [
+              ("name", `String "persistent-demo");
+              ("goal", `String "Stay on demand");
+              ("models", `List [ `String "custom:test-model" ]);
+              ("presence_keepalive", `Bool false);
+              ("proactive_enabled", `Bool false);
+            ])
+      in
+      check bool "persistent up ok" true ok;
+      let ok, autonomy_body =
+        dispatch "masc_keeper_autonomy" (`Assoc [ ("name", `String "resident-demo") ])
+      in
+      check bool "resident autonomy ok" true ok;
+      check bool "autonomy body non-empty" true (String.length autonomy_body > 0);
+      let ok, _ =
+        dispatch "masc_keeper_autonomy"
+          (`Assoc
+            [
+              ("name", `String "resident-demo");
+              ("level", `String "L1_Reactive");
+            ])
+      in
+      check bool "resident autonomy set ok" true ok;
+      let ok, goals_body =
+        dispatch "masc_keeper_goals" (`Assoc [ ("name", `String "resident-demo") ])
+      in
+      check bool "resident goals ok" true ok;
+      check bool "goals body non-empty" true (String.length goals_body > 0);
+      let ok, trajectory_body =
+        dispatch "masc_keeper_trajectory"
+          (`Assoc [ ("name", `String "resident-demo"); ("limit", `Int 5) ])
+      in
+      check bool "resident trajectory ok" true ok;
+      check bool "trajectory body non-empty" true (String.length trajectory_body > 0);
+      let ok, eval_body =
+        dispatch "masc_keeper_eval" (`Assoc [ ("name", `String "resident-demo") ])
+      in
+      check bool "resident eval ok" true ok;
+      check bool "eval body non-empty" true (String.length eval_body > 0);
+      let ok, model_set_body =
+        dispatch "masc_persistent_agent_model_set"
+          (`Assoc
+            [
+              ("name", `String "persistent-demo");
+              ("model", `String "custom:alt-model");
+            ])
+      in
+      check bool "persistent model set ok" true ok;
+      let model_set_json = parse_json_exn model_set_body in
+      check string "persistent active model updated" "custom:alt-model"
+        Yojson.Safe.Util.(model_set_json |> member "active_model" |> to_string);
+      let ok, persistent_status_body =
+        dispatch "masc_persistent_agent_status"
+          (`Assoc
+            [
+              ("name", `String "resident-demo");
+              ("fast", `Bool true);
+              ("include_context", `Bool false);
+              ("include_metrics_overview", `Bool false);
+              ("include_memory_bank", `Bool false);
+              ("include_history_tail", `Bool false);
+              ("include_compaction_history", `Bool false);
+            ])
+      in
+      check bool "persistent alias status ok" true ok;
+      let persistent_status_json = parse_json_exn persistent_status_body in
+      check string "persistent alias runtime_class" "persistent_agent"
+        Yojson.Safe.Util.(persistent_status_json |> member "runtime_class" |> to_string);
+      check bool "persistent alias marks resident" true
+        Yojson.Safe.Util.(persistent_status_json |> member "resident_registered" |> to_bool);
+      let ok, _ =
+        dispatch "masc_keeper_down" (`Assoc [ ("name", `String "resident-demo") ])
+      in
+      check bool "resident down ok" true ok;
+      check bool "resident registration removed" false
+        (Masc_mcp.Keeper_types.is_resident_keeper config "resident-demo"))
 
 let test_keeper_policy_tools_roundtrip () =
   Eio_main.run @@ fun env ->
@@ -915,6 +1261,16 @@ let () =
            test_persona_list_and_create_from_persona;
          test_case "resident and persistent lists split" `Quick
            test_resident_keeper_and_persistent_agent_lists_split;
+         test_case "resident and persistent detailed lists annotate runtime class" `Quick
+           test_resident_and_persistent_detailed_lists_annotate_runtime_class;
+         test_case "resident keeper msg bootstraps then requires message" `Quick
+           test_resident_keeper_msg_bootstraps_then_requires_message;
+         test_case "persistent agent msg rejects missing message" `Quick
+           test_persistent_agent_msg_rejects_missing_message;
+         test_case "persistent agent create from persona" `Quick
+           test_persistent_agent_create_from_persona_and_status;
+         test_case "keeper dispatch auxiliary surfaces smoke" `Quick
+           test_keeper_dispatch_auxiliary_surfaces_smoke;
          test_case "policy tools roundtrip" `Quick
            test_keeper_policy_tools_roundtrip;
          test_case "policy set rejects invalid mode" `Quick

--- a/test/test_tool_keeper.ml
+++ b/test/test_tool_keeper.ml
@@ -250,12 +250,16 @@ let test_keeper_model_set_persists_active_model () =
       in
       check bool "model set ok" true ok;
       let json = Yojson.Safe.from_string body in
+      let allowed_models =
+        Yojson.Safe.Util.(json |> member "allowed_models" |> to_list |> List.map to_string)
+      in
       check string "active model updated" provider_model
         Yojson.Safe.Util.(json |> member "active_model" |> to_string);
       check bool "allowed models include active model" true
-        Yojson.Safe.Util.(
-          json |> member "allowed_models" |> to_list
-          |> List.exists (fun item -> item = `String provider_model));
+        (List.mem provider_model allowed_models);
+      check int "allowed models stay deduped"
+        (List.length (List.sort_uniq String.compare allowed_models))
+        (List.length allowed_models);
       let ok, status_body =
         dispatch "masc_keeper_status"
           (`Assoc
@@ -821,6 +825,8 @@ let test_keeper_dispatch_auxiliary_surfaces_smoke () =
         dispatch "masc_persistent_agent_status"
           (`Assoc
             [
+              (* The persistent-agent alias should still surface resident registration
+                 when querying an always-on keeper through the persistent wrapper. *)
               ("name", `String "resident-demo");
               ("fast", `Bool true);
               ("include_context", `Bool false);

--- a/test/test_tool_keeper.ml
+++ b/test/test_tool_keeper.ml
@@ -513,8 +513,8 @@ let test_resident_and_persistent_detailed_lists_annotate_runtime_class () =
   let base_dir = temp_dir () in
   Fun.protect
     ~finally:(fun () ->
-      Masc_mcp.Keeper_keepalive.stop_keepalive "resident-demo";
-      Masc_mcp.Keeper_keepalive.stop_keepalive "persistent-demo";
+      stop_keeper_via_tool env sw base_dir "resident-demo";
+      stop_keeper_via_tool env sw base_dir "persistent-demo";
       rm_rf base_dir)
     (fun () ->
       let config = Masc_mcp.Room.default_config base_dir in
@@ -590,7 +590,7 @@ let test_resident_keeper_msg_bootstraps_then_requires_message () =
   let base_dir = temp_dir () in
   Fun.protect
     ~finally:(fun () ->
-      Masc_mcp.Keeper_keepalive.stop_keepalive "bootstrap-demo";
+      stop_keeper_via_tool env sw base_dir "bootstrap-demo";
       rm_rf base_dir)
     (fun () ->
       let config = Masc_mcp.Room.default_config base_dir in
@@ -626,7 +626,7 @@ let test_persistent_agent_msg_rejects_missing_message () =
   let base_dir = temp_dir () in
   Fun.protect
     ~finally:(fun () ->
-      Masc_mcp.Keeper_keepalive.stop_keepalive "persistent-demo";
+      stop_keeper_via_tool env sw base_dir "persistent-demo";
       rm_rf base_dir)
     (fun () ->
       let config = Masc_mcp.Room.default_config base_dir in
@@ -666,7 +666,7 @@ let test_persistent_agent_create_from_persona_and_status () =
   let me_root = temp_dir () in
   Fun.protect
     ~finally:(fun () ->
-      Masc_mcp.Keeper_keepalive.stop_keepalive "persistent-sangsu";
+      stop_keeper_via_tool env sw base_dir "persistent-sangsu";
       rm_rf base_dir;
       rm_rf me_root)
     (fun () ->
@@ -741,8 +741,8 @@ let test_keeper_dispatch_auxiliary_surfaces_smoke () =
   let base_dir = temp_dir () in
   Fun.protect
     ~finally:(fun () ->
-      Masc_mcp.Keeper_keepalive.stop_keepalive "resident-demo";
-      Masc_mcp.Keeper_keepalive.stop_keepalive "persistent-demo";
+      stop_keeper_via_tool env sw base_dir "resident-demo";
+      stop_keeper_via_tool env sw base_dir "persistent-demo";
       rm_rf base_dir)
     (fun () ->
       let config = Masc_mcp.Room.default_config base_dir in


### PR DESCRIPTION
## Summary
- add a deterministic `scripts/coverage_percent.sh` metric and `make coverage-percent`
- expand `test_tool_keeper` across resident/persistent wrapper paths and remove the flaky llama inventory dependency
- expand `test_mcp_server_eio` across invalid-param, batch rejection, and public `resources/read` coverage

## Verification
- `dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/coverage-bisect-95 ./test/test_tool_keeper.exe ./test/test_mcp_server_eio.exe`
- `dune exec --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/coverage-bisect-95 ./test/test_tool_keeper.exe`
- `dune exec --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/coverage-bisect-95 ./test/test_mcp_server_eio.exe`
- `COVERAGE_DIR=/Users/dancer/me/workspace/yousleepwhen/masc-mcp/_coverage /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/coverage-bisect-95/scripts/coverage_percent.sh --reuse-existing`

## Notes
- this is the first tranche for the long-lived whole-repo bisect 95% effort
- current parser verification against existing `_coverage` reports `44.51`
