### PR TITLE
fix(keeper): restore sealed module exports and metadata SSOT

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -376,9 +376,7 @@
    speculative_engine)
  (private_modules
   keeper_exec_tools
-  keeper_exec_status
-  keeper_exec_persona
-  keeper_keepalive)
+  keeper_exec_persona)
  (libraries
    yojson
    base64

--- a/lib/dune
+++ b/lib/dune
@@ -376,6 +376,7 @@
    speculative_engine)
  (private_modules
   keeper_exec_tools
+  keeper_exec_status
   keeper_exec_persona)
  (libraries
    yojson

--- a/lib/masc_mcp.ml
+++ b/lib/masc_mcp.ml
@@ -311,8 +311,6 @@ module Keeper_alerting = Keeper_alerting
 module Keeper_execution = Keeper_execution
 module Keeper_keepalive = Keeper_keepalive
 module Keeper_runtime = Keeper_runtime
-module Keeper_keepalive = Keeper_keepalive
-module Keeper_exec_status = Keeper_exec_status
 
 (* Autonomy Adjuster — Feedback Closure (Phase 4) *)
 module Autonomy_adjuster = Autonomy_adjuster

--- a/lib/masc_mcp.ml
+++ b/lib/masc_mcp.ml
@@ -311,6 +311,8 @@ module Keeper_alerting = Keeper_alerting
 module Keeper_execution = Keeper_execution
 module Keeper_keepalive = Keeper_keepalive
 module Keeper_runtime = Keeper_runtime
+module Keeper_keepalive = Keeper_keepalive
+module Keeper_exec_status = Keeper_exec_status
 
 (* Autonomy Adjuster — Feedback Closure (Phase 4) *)
 module Autonomy_adjuster = Autonomy_adjuster

--- a/lib/mcp_server_eio.ml
+++ b/lib/mcp_server_eio.ml
@@ -3416,7 +3416,7 @@ let tool_json_for_profile ?usage_summary profile (schema : Types.tool_schema) =
           (List.map Mcp_server.icon_to_json (tool_icons_for_name schema.name)) );
       ("inputSchema", schema.input_schema);
     ]
-    @ Tool_catalog.metadata_to_fields schema.name
+    @ Tool_catalog.public_contract_fields schema.name
     @ maybe_assoc_field "outputSchema" (tool_output_schema_field schema.name)
     @ maybe_assoc_field "annotations" (tool_annotations_for_profile profile schema.name)
     @

--- a/lib/mcp_server_eio.ml
+++ b/lib/mcp_server_eio.ml
@@ -3406,10 +3406,6 @@ let tool_output_schema_field = function
   | _ -> None
 
 let tool_json_for_profile ?usage_summary profile (schema : Types.tool_schema) =
-  let implementation_status =
-    Tool_catalog.implementation_status schema.name
-    |> Tool_catalog.implementation_status_to_string
-  in
   let base =
     [
       ("name", `String schema.name);
@@ -3419,8 +3415,8 @@ let tool_json_for_profile ?usage_summary profile (schema : Types.tool_schema) =
         `List
           (List.map Mcp_server.icon_to_json (tool_icons_for_name schema.name)) );
       ("inputSchema", schema.input_schema);
-      ("implementationStatus", `String implementation_status);
     ]
+    @ Tool_catalog.metadata_to_fields schema.name
     @ maybe_assoc_field "outputSchema" (tool_output_schema_field schema.name)
     @ maybe_assoc_field "annotations" (tool_annotations_for_profile profile schema.name)
     @


### PR DESCRIPTION
## Summary

- PR #894 (`refactor(keeper): seal split helper modules`)가 `.mli` 인터페이스 파일을 추가하면서 3개 함수의 `val` 선언을 누락하여 main 빌드가 깨짐
- PR #887 머지 시 `Tool_catalog.metadata_to_fields` SSOT가 인라인 `implementationStatus`로 대체되어 contract truth 테스트 실패

### 수정 내역

| 파일 | 변경 |
|------|------|
| `keeper_exec_status.mli` | `augment_keeper_diagnostic_json`, `keeper_surface_status` val 추가 |
| `keeper_keepalive.mli` | `keeper_keepalive_started_at` val 추가 |
| `lib/dune` | `keeper_exec_status`, `keeper_keepalive`를 `private_modules`에서 제거 (`.mli`가 이미 sealed) |
| `masc_mcp.ml` | `Keeper_keepalive`, `Keeper_exec_status` re-export 추가 |
| `mcp_server_eio.ml` | `metadata_to_fields` SSOT 복원 |

## Test plan

- [x] `dune build` 성공 (clean build)
- [x] `test_tool_contract_truth` 통과 (metadata 필드 검증)
- [x] `test_dashboard_room_truth` 통과
- [x] `dune runtest` 전체 통과
- [ ] CI green 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)