### PR TITLE
feat(autoresearch): productize mcp loop surfaces

### DIFF
--- a/lib/auth.ml
+++ b/lib/auth.ml
@@ -248,6 +248,7 @@ let permission_for_tool = function
   | "masc_gardener_health" | "masc_gardener_config" | "masc_gardener_status"
   | "masc_gardener_propose_spawn" | "masc_gardener_retire_agent" ->
       Some CanReadState
+  | "masc_autoresearch_status" -> Some CanReadState
   | "masc_add_task" -> Some CanAddTask
   | "masc_claim" | "masc_claim_next" -> Some CanClaimTask
   | "masc_done" | "masc_update_priority" | "masc_transition" | "masc_release" -> Some CanCompleteTask
@@ -283,6 +284,10 @@ let permission_for_tool = function
   | "masc_dispatch_recall" | "masc_policy_approve"
   | "masc_policy_deny" | "masc_policy_update" ->
       Some CanBroadcast
+  | "masc_autoresearch_start" | "masc_autoresearch_swarm_start"
+  | "masc_autoresearch_cycle" | "masc_autoresearch_inject"
+  | "masc_autoresearch_stop" ->
+      Some CanAdmin
   (* Command-plane write operations require Admin *)
   | "masc_policy_freeze_unit" | "masc_policy_kill_switch" ->
       Some CanAdmin

--- a/lib/autoresearch.ml
+++ b/lib/autoresearch.ml
@@ -46,6 +46,7 @@ type loop_state = {
   mutable baseline : float;
   mutable best_score : float;
   mutable best_cycle : int;
+  mutable queued_hypothesis : string option;
   mutable history : cycle_record list;  (** Most recent first *)
   mutable total_keeps : int;
   mutable total_discards : int;
@@ -54,7 +55,10 @@ type loop_state = {
   mutable updated_at : float;
   cycle_timeout_s : float;
   max_cycles : int;
-  workdir : string;
+  mutable workdir : string;
+  source_workdir : string;
+  mutable program_note : string option;
+  mutable warnings : string list;
 }
 
 type swarm_link = {
@@ -74,6 +78,7 @@ type persisted_summary = {
   baseline : float;
   best_score : float;
   best_cycle : int;
+  queued_hypothesis : string option;
   total_keeps : int;
   total_discards : int;
   goal : string;
@@ -85,6 +90,9 @@ type persisted_summary = {
   max_cycles : int;
   error_message : string option;
   elapsed_s : float;
+  source_workdir : string;
+  program_note : string option;
+  warnings : string list;
 }
 
 let active_loops : (string, loop_state) Hashtbl.t = Hashtbl.create 4
@@ -108,6 +116,9 @@ let generate_loop_id () =
 (* ================================================================ *)
 
 let decision_to_string = function Keep -> "keep" | Discard -> "discard"
+
+let option_first_some left right =
+  match left with Some _ -> left | None -> right
 
 let decision_of_string = function
   | "keep" -> Keep
@@ -169,14 +180,24 @@ let state_to_yojson (s : loop_state) : Yojson.Safe.t =
     ("baseline", `Float s.baseline);
     ("best_score", `Float s.best_score);
     ("best_cycle", `Int s.best_cycle);
+    ( "queued_hypothesis",
+      match s.queued_hypothesis with
+      | Some value -> `String value
+      | None -> `Null );
     ("total_keeps", `Int s.total_keeps);
     ("total_discards", `Int s.total_discards);
     ("max_cycles", `Int s.max_cycles);
     ("cycle_timeout_s", `Float s.cycle_timeout_s);
     ("workdir", `String s.workdir);
+    ("source_workdir", `String s.source_workdir);
     ("elapsed_s", `Float (Time_compat.now () -. s.start_time));
     ("history_count", `Int (List.length s.history));
     ("insights_count", `Int (List.length s.insights));
+    ( "program_note",
+      match s.program_note with
+      | Some value -> `String value
+      | None -> `Null );
+    ("warnings", `List (List.map (fun value -> `String value) s.warnings));
     ("error", match s.error_message with
       | Some e -> `String e | None -> `Null);
   ]
@@ -192,6 +213,7 @@ let state_of_yojson (json : Yojson.Safe.t) : persisted_summary =
     baseline = json |> member "baseline" |> to_float;
     best_score = json |> member "best_score" |> to_float;
     best_cycle = json |> member "best_cycle" |> to_int;
+    queued_hypothesis = json |> member "queued_hypothesis" |> to_string_option;
     total_keeps = json |> member "total_keeps" |> to_int;
     total_discards = json |> member "total_discards" |> to_int;
     goal = json |> member "goal" |> to_string;
@@ -203,6 +225,20 @@ let state_of_yojson (json : Yojson.Safe.t) : persisted_summary =
     max_cycles = json |> member "max_cycles" |> to_int;
     error_message = json |> member "error" |> to_string_option;
     elapsed_s = json |> member "elapsed_s" |> to_float;
+    source_workdir =
+      json |> member "source_workdir" |> to_string_option
+      |> Option.value ~default:(json |> member "workdir" |> to_string);
+    program_note = json |> member "program_note" |> to_string_option;
+    warnings =
+      match json |> member "warnings" with
+      | `List items ->
+          items
+          |> List.filter_map (function
+               | `String value ->
+                   let trimmed = String.trim value in
+                   if trimmed = "" then None else Some trimmed
+               | _ -> None)
+      | _ -> [];
   }
 
 let swarm_link_to_yojson (link : swarm_link) : Yojson.Safe.t =
@@ -250,6 +286,9 @@ let state_file ~base_path loop_id =
 
 let loop_link_file ~base_path loop_id =
   Filename.concat (results_dir ~base_path loop_id) "swarm.json"
+
+let managed_worktree_dir ~base_path loop_id =
+  Filename.concat (results_dir ~base_path loop_id) "worktree"
 
 let session_link_file ~base_path session_id =
   Filename.concat base_path
@@ -369,6 +408,7 @@ let stop_loop ~base_path ?reason loop_id =
               baseline = persisted.baseline;
               best_score = persisted.best_score;
               best_cycle = persisted.best_cycle;
+              queued_hypothesis = persisted.queued_hypothesis;
               history = [];
               total_keeps = persisted.total_keeps;
               total_discards = persisted.total_discards;
@@ -378,26 +418,49 @@ let stop_loop ~base_path ?reason loop_id =
               cycle_timeout_s = persisted.cycle_timeout_s;
               max_cycles = persisted.max_cycles;
               workdir = persisted.workdir;
+              source_workdir = persisted.source_workdir;
+              program_note = persisted.program_note;
+              warnings = persisted.warnings;
             }
           in
           Some (stop_state state))
 
 let linked_status_json ~base_path (link : swarm_link) =
-  let current_cycle, status, best_score, error_message =
+  let current_cycle, status, best_score, error_message, workdir, source_workdir,
+      program_note, warnings, queued_hypothesis =
     match Hashtbl.find_opt active_loops link.loop_id with
     | Some state ->
         ( state.current_cycle,
           status_to_string state.status,
           state.best_score,
-          state.error_message )
+          state.error_message,
+          state.workdir,
+          state.source_workdir,
+          state.program_note,
+          state.warnings,
+          state.queued_hypothesis )
     | None -> (
         match load_state ~base_path link.loop_id with
         | Some persisted ->
             ( persisted.current_cycle,
               status_to_string persisted.status,
               persisted.best_score,
-              persisted.error_message )
-        | None -> (0, "missing", 0.0, Some "state file missing"))
+              persisted.error_message,
+              persisted.workdir,
+              persisted.source_workdir,
+              persisted.program_note,
+              persisted.warnings,
+              persisted.queued_hypothesis )
+        | None ->
+            ( 0,
+              "missing",
+              0.0,
+              Some "state file missing",
+              managed_worktree_dir ~base_path link.loop_id,
+              "",
+              link.program_note,
+              [],
+              None ))
   in
   let last_decision =
     match latest_cycle_record ~base_path link.loop_id with
@@ -415,9 +478,14 @@ let linked_status_json ~base_path (link : swarm_link) =
         match last_decision with Some value -> `String value | None -> `Null );
       ("target_file", `String link.target_file);
       ( "program_note",
-        match link.program_note with Some value -> `String value | None -> `Null );
+        match option_first_some program_note link.program_note with Some value -> `String value | None -> `Null );
       ( "operation_id",
         match link.operation_id with Some value -> `String value | None -> `Null );
+      ("workdir", `String workdir);
+      ("source_workdir", `String source_workdir);
+      ("warnings", `List (List.map (fun value -> `String value) warnings));
+      ( "queued_hypothesis",
+        match queued_hypothesis with Some value -> `String value | None -> `Null );
       ("error", match error_message with Some value -> `String value | None -> `Null);
     ]
 
@@ -519,6 +587,12 @@ let git_commit ~workdir ~message
     | _ ->
       let output = String.concat "\n" (List.rev !lines) in
       Result.error (Printf.sprintf "git commit failed: %s" output)
+
+(** Restore worktree files to current HEAD without moving the branch. *)
+let git_restore_head ~workdir =
+  let cmd = Printf.sprintf "cd %s && git reset --hard HEAD 2>/dev/null"
+    (Filename.quote workdir) in
+  ignore (Sys.command cmd)
 
 (** Reset to HEAD~1, discarding the last commit. *)
 let git_reset_last ~workdir =
@@ -752,6 +826,7 @@ let create_state ~goal ~metric_fn ?(llm_model = "glm") ~target_file ~cycle_timeo
     baseline = 0.0;
     best_score = 0.0;
     best_cycle = 0;
+    queued_hypothesis = None;
     history = [];
     total_keeps = 0;
     total_discards = 0;
@@ -761,7 +836,89 @@ let create_state ~goal ~metric_fn ?(llm_model = "glm") ~target_file ~cycle_timeo
     cycle_timeout_s;
     max_cycles;
     workdir;
+    source_workdir = workdir;
+    program_note = None;
+    warnings = [];
   }
+
+let run_capture_lines cmd =
+  let ic = Unix.open_process_in cmd in
+  let lines = ref [] in
+  (try
+     while true do
+       lines := input_line ic :: !lines
+     done
+   with End_of_file -> ());
+  let status = Unix.close_process_in ic in
+  (status, List.rev !lines)
+
+let git_top_level ~workdir =
+  let cmd =
+    Printf.sprintf "cd %s && git rev-parse --show-toplevel 2>/dev/null"
+      (Filename.quote workdir)
+  in
+  match run_capture_lines cmd with
+  | Unix.WEXITED 0, top :: _ ->
+      let trimmed = String.trim top in
+      if trimmed = "" then Result.error "git top-level was empty"
+      else Result.ok trimmed
+  | _ -> Result.error "workdir is not inside a git repository"
+
+let git_current_branch ~workdir =
+  let cmd =
+    Printf.sprintf "cd %s && git rev-parse --abbrev-ref HEAD 2>/dev/null"
+      (Filename.quote workdir)
+  in
+  match run_capture_lines cmd with
+  | Unix.WEXITED 0, branch :: _ ->
+      let trimmed = String.trim branch in
+      if trimmed = "" then None else Some trimmed
+  | _ -> None
+
+let git_is_dirty ~workdir =
+  let cmd =
+    Printf.sprintf "cd %s && git status --porcelain 2>/dev/null"
+      (Filename.quote workdir)
+  in
+  match run_capture_lines cmd with
+  | Unix.WEXITED 0, lines -> List.exists (fun line -> String.trim line <> "") lines
+  | _ -> false
+
+let managed_branch_name loop_id =
+  "autoresearch/" ^ loop_id
+
+let prepare_managed_worktree ~base_path ~source_workdir ~loop_id =
+  match git_top_level ~workdir:source_workdir with
+  | Error _ as err -> err
+  | Ok repo_root ->
+      let warnings = ref [] in
+      if git_is_dirty ~workdir:source_workdir then
+        warnings := "source_workdir_dirty" :: !warnings;
+      (match git_current_branch ~workdir:source_workdir with
+      | Some branch when not (String.equal branch "main" || String.equal branch "master") ->
+          warnings := ("source_branch:" ^ branch) :: !warnings
+      | _ -> ());
+      let workdir = managed_worktree_dir ~base_path loop_id in
+      if Sys.file_exists workdir then
+        Result.error (Printf.sprintf "managed worktree already exists: %s" workdir)
+      else begin
+        ensure_dir (Filename.dirname workdir);
+        let branch = managed_branch_name loop_id in
+        let cmd =
+          Printf.sprintf
+            "cd %s && git worktree add -b %s %s HEAD 2>&1"
+            (Filename.quote repo_root)
+            (Filename.quote branch)
+            (Filename.quote workdir)
+        in
+        match run_capture_lines cmd with
+        | Unix.WEXITED 0, _ ->
+            Result.ok (workdir, repo_root, List.rev !warnings)
+        | _, lines ->
+            Result.error
+              (Printf.sprintf "failed to create managed worktree: %s"
+                 (String.concat "\n" lines))
+      end
 
 (** Append an insight, maintaining FIFO max 10 entries. *)
 let add_insight (state : loop_state) msg =

--- a/lib/tool_autoresearch.ml
+++ b/lib/tool_autoresearch.ml
@@ -280,11 +280,11 @@ type start_params = {
   goal : string;
   metric_fn : string;
   target_file : string;
-  workdir : string;
+  source_workdir : string;
   max_cycles : int;
   cycle_timeout_s : float;
   llm_model : string;
-  baseline : float;
+  baseline_override : float option;
 }
 
 let normalize_string_opt = function
@@ -306,13 +306,19 @@ let persisted_summary_json (summary : Autoresearch.persisted_summary) =
       ("baseline", `Float summary.baseline);
       ("best_score", `Float summary.best_score);
       ("best_cycle", `Int summary.best_cycle);
+      ( "queued_hypothesis",
+        match summary.queued_hypothesis with Some value -> `String value | None -> `Null );
       ("total_keeps", `Int summary.total_keeps);
       ("total_discards", `Int summary.total_discards);
       ("max_cycles", `Int summary.max_cycles);
       ("cycle_timeout_s", `Float summary.cycle_timeout_s);
       ("workdir", `String summary.workdir);
+      ("source_workdir", `String summary.source_workdir);
       ("elapsed_s", `Float summary.elapsed_s);
       ("recent_cycles", `List []);
+      ( "program_note",
+        match summary.program_note with Some value -> `String value | None -> `Null );
+      ("warnings", `List (List.map (fun value -> `String value) summary.warnings));
       ("error", match summary.error_message with Some e -> `String e | None -> `Null);
     ]
 
@@ -325,7 +331,7 @@ let prepare_start_params ctx args =
   let goal = get_string args "goal" "" in
   let metric_fn = get_string args "metric_fn" "" in
   let target_file = get_string args "target_file" "" in
-  let workdir = get_string args "workdir" ctx.base_path in
+  let source_workdir = get_string args "workdir" ctx.base_path in
   let max_cycles = get_int args "max_cycles" 100 in
   let cycle_timeout_s = get_float args "cycle_timeout_s" 300.0 in
   let llm_model = get_string args "llm_model" "glm" in
@@ -336,57 +342,98 @@ let prepare_start_params ctx args =
   else if target_file = "" then
     Error "target_file is required"
   else
-    match Autoresearch.validate_target_file ~workdir target_file with
-    | Error e ->
-        Error (Printf.sprintf "Invalid target_file: %s" e)
-    | Ok _abs_path -> (
-        match get_float_opt args "baseline" with
-        | Some baseline ->
-            Ok
-              {
-                goal;
-                metric_fn;
-                target_file;
-                workdir;
-                max_cycles;
-                cycle_timeout_s;
-                llm_model;
-                baseline;
-              }
-        | None -> (
-            match
-              Autoresearch.measure_metric ~workdir ~timeout_s:cycle_timeout_s
-                metric_fn
-            with
-            | Ok (baseline, _ms) ->
-                Ok
-                  {
-                    goal;
-                    metric_fn;
-                    target_file;
-                    workdir;
-                    max_cycles;
-                    cycle_timeout_s;
-                    llm_model;
-                    baseline;
-                  }
-            | Error e ->
-                Error
-                  (Printf.sprintf "Failed to measure baseline: %s" e)))
+    Ok
+      {
+        goal;
+        metric_fn;
+        target_file;
+        source_workdir;
+        max_cycles;
+        cycle_timeout_s;
+        llm_model;
+        baseline_override = get_float_opt args "baseline";
+      }
 
-let register_loop ctx (params : start_params) =
-  let state =
-    Autoresearch.create_state ~goal:params.goal ~metric_fn:params.metric_fn
-      ~llm_model:params.llm_model ~target_file:params.target_file
-      ~cycle_timeout_s:params.cycle_timeout_s ~max_cycles:params.max_cycles
-      ~workdir:params.workdir ()
-  in
-  state.baseline <- params.baseline;
-  state.best_score <- params.baseline;
+let register_loop ctx state =
   Autoresearch.save_state ~base_path:ctx.base_path state;
   Hashtbl.replace active_loops state.loop_id state;
   latest_loop_id := Some state.loop_id;
   state
+
+let setup_running_loop ctx (params : start_params) =
+  let state =
+    Autoresearch.create_state ~goal:params.goal ~metric_fn:params.metric_fn
+      ~llm_model:params.llm_model ~target_file:params.target_file
+      ~cycle_timeout_s:params.cycle_timeout_s ~max_cycles:params.max_cycles
+      ~workdir:params.source_workdir ()
+  in
+  match
+    Autoresearch.prepare_managed_worktree ~base_path:ctx.base_path
+      ~source_workdir:params.source_workdir ~loop_id:state.loop_id
+  with
+  | Error message -> Error message
+  | Ok (managed_workdir, source_workdir, warnings) -> (
+      state.workdir <- managed_workdir;
+      state.warnings <- warnings;
+      let baseline_result =
+        match Autoresearch.validate_target_file ~workdir:managed_workdir params.target_file with
+        | Error e ->
+            Error (Printf.sprintf "Invalid target_file: %s" e)
+        | Ok _ -> (
+            match params.baseline_override with
+            | Some baseline -> Ok baseline
+            | None -> (
+                match
+                  Autoresearch.measure_metric ~workdir:managed_workdir
+                    ~timeout_s:params.cycle_timeout_s params.metric_fn
+                with
+                | Ok (baseline, _ms) -> Ok baseline
+                | Error e ->
+                    Error
+                      (Printf.sprintf "Failed to measure baseline: %s" e)))
+      in
+      match baseline_result with
+      | Error message -> Error message
+      | Ok baseline ->
+          state.baseline <- baseline;
+          state.best_score <- baseline;
+          let state =
+            { state with source_workdir }
+          in
+          Ok (register_loop ctx state))
+
+let status_json ctx ~loop_id json_fields =
+  let strip_keys keys fields =
+    List.filter (fun (key, _value) -> not (List.mem key keys)) fields
+  in
+  let base_fields =
+    match json_fields with
+    | `Assoc fields ->
+        strip_keys [ "session_id"; "operation_id"; "program_note"; "queued_hypothesis" ] fields
+    | _ -> [ ("error", `String "invalid status payload") ]
+  in
+  let link =
+    Autoresearch.load_swarm_link_by_loop ~base_path:ctx.base_path loop_id
+  in
+  let queued_hypothesis = Hashtbl.find_opt pending_hypotheses loop_id in
+  let link_fields =
+    match link with
+    | Some link ->
+        [
+          ("session_id", `String link.session_id);
+          ( "operation_id",
+            match link.operation_id with Some value -> `String value | None -> `Null );
+        ]
+    | None ->
+        [ ("session_id", `Null); ("operation_id", `Null) ]
+  in
+  `Assoc
+    (base_fields
+    @ link_fields
+    @ [
+        ( "queued_hypothesis",
+          match queued_hypothesis with Some value -> `String value | None -> `Null );
+      ])
 
 let build_swarm_goal ~goal ~target_file ~program_note =
   match program_note with
@@ -422,8 +469,10 @@ let parse_session_launch ctx json =
 let handle_start ctx args =
   match prepare_start_params ctx args with
   | Error message -> `Assoc [ ("error", `String message) ]
-  | Ok params ->
-      let state = register_loop ctx params in
+  | Ok params -> (
+      match setup_running_loop ctx params with
+      | Error message -> `Assoc [ ("error", `String message) ]
+      | Ok state ->
       `Assoc [
         ("loop_id", `String state.loop_id);
         ("status", `String "running");
@@ -431,11 +480,14 @@ let handle_start ctx args =
         ("metric_fn", `String params.metric_fn);
         ("target_file", `String params.target_file);
         ("llm_model", `String params.llm_model);
-        ("baseline", `Float params.baseline);
+        ("baseline", `Float state.baseline);
         ("max_cycles", `Int params.max_cycles);
         ("cycle_timeout_s", `Float params.cycle_timeout_s);
-        ("workdir", `String params.workdir);
-      ]
+        ("workdir", `String state.workdir);
+        ("source_workdir", `String state.source_workdir);
+        ("queued_hypothesis", `Null);
+        ("warnings", `List (List.map (fun value -> `String value) state.warnings));
+      ])
 
 let handle_swarm_start ctx args =
   match ctx.start_team_session, ctx.agent_name with
@@ -456,8 +508,11 @@ let handle_swarm_start ctx args =
       | Error message -> `Assoc [ ("error", `String message) ]
       | Ok params ->
           let program_note = normalize_string_opt (get_string_opt args "program_note") in
-          let state = register_loop ctx params in
-          let warnings = ref [] in
+          (match setup_running_loop ctx params with
+          | Error message -> `Assoc [ ("error", `String message) ]
+          | Ok state ->
+          state.program_note <- program_note;
+          let warnings = ref state.warnings in
           let operation_id =
             match ctx.start_operation with
             | None -> None
@@ -470,6 +525,8 @@ let handle_swarm_start ctx args =
                     warnings := message :: !warnings;
                     None)
           in
+          state.warnings <- List.rev !warnings;
+          Autoresearch.save_state ~base_path:ctx.base_path state;
           let session_goal =
             build_swarm_goal ~goal:params.goal ~target_file:params.target_file
               ~program_note
@@ -529,16 +586,17 @@ let handle_swarm_start ctx args =
                         | Some value -> `String value
                         | None -> `Null );
                     ]))
+          )
 
 let handle_status ctx args =
   match resolve_loop_id args with
   | None -> `Assoc [("error", `String "No autoresearch loop running")]
   | Some id ->
     match Hashtbl.find_opt active_loops id with
-    | Some state -> Autoresearch.summary state
+    | Some state -> status_json ctx ~loop_id:id (Autoresearch.summary state)
     | None -> (
         match Autoresearch.load_state ~base_path:ctx.base_path id with
-        | Some summary -> persisted_summary_json summary
+        | Some summary -> status_json ctx ~loop_id:id (persisted_summary_json summary)
         | None ->
             `Assoc [("error", `String (Printf.sprintf "Loop %s not found" id))])
 
@@ -550,6 +608,21 @@ let handle_stop ctx args =
     match Autoresearch.stop_loop ~base_path:ctx.base_path ~reason id with
     | None -> `Assoc [("error", `String (Printf.sprintf "Loop %s not found" id))]
     | Some state ->
+        let config = Room.default_config ctx.base_path in
+        (match Autoresearch.load_swarm_link_by_loop ~base_path:ctx.base_path id with
+        | Some link ->
+            (try
+               Team_session_store.append_event config link.session_id
+                 ~event_type:"linked_autoresearch_stopped"
+                 ~detail:
+                   (`Assoc
+                     [
+                       ("loop_id", `String id);
+                       ("reason", `String reason);
+                       ("status", `String (Autoresearch.status_to_string state.status));
+                     ])
+             with _ -> ())
+        | None -> ());
         `Assoc [
           ("loop_id", `String id);
           ("status", `String "stopped");
@@ -575,6 +648,8 @@ let handle_inject _ctx args =
         if state.status <> Autoresearch.Running then
           `Assoc [("error", `String "Loop is not running")]
         else begin
+          state.queued_hypothesis <- Some hypothesis;
+          Autoresearch.save_state ~base_path:_ctx.base_path state;
           Hashtbl.replace pending_hypotheses id hypothesis;
           `Assoc [
             ("loop_id", `String id);
@@ -623,7 +698,11 @@ let handle_cycle ctx args =
         let code_result =
           let forced_hypothesis =
             match Hashtbl.find_opt pending_hypotheses id with
-            | Some h -> Hashtbl.remove pending_hypotheses id; Some h
+            | Some h ->
+                Hashtbl.remove pending_hypotheses id;
+                state.queued_hypothesis <- None;
+                Autoresearch.save_state ~base_path:ctx.base_path state;
+                Some h
             | None -> get_string_opt args "hypothesis"
           in
           let generate = get_generator id in
@@ -673,10 +752,10 @@ let handle_cycle ctx args =
                let commit_result = Autoresearch.git_commit_cycle
                  ~workdir ~cycle:state.current_cycle ~hypothesis ~baseline:score_before in
                (match commit_result with
-                | Error git_err ->
+               | Error git_err ->
                   (* Git commit failed (e.g. missing identity, hooks).
                      Revert file change to keep working tree clean. *)
-                  Autoresearch.git_reset_last ~workdir;
+                  Autoresearch.git_restore_head ~workdir;
                   `Assoc [
                     ("error", `String (Printf.sprintf "git commit failed: %s" git_err));
                     ("loop_id", `String id);
@@ -745,6 +824,25 @@ let handle_cycle ctx args =
                        state.baseline <- score_after);
                     state.current_cycle <- state.current_cycle + 1;
                     Autoresearch.save_state ~base_path:ctx.base_path state;
+                    let config = Room.default_config ctx.base_path in
+                    (match Autoresearch.load_swarm_link_by_loop ~base_path:ctx.base_path id with
+                    | Some link ->
+                        (try
+                           Team_session_store.append_event config link.session_id
+                             ~event_type:"linked_autoresearch_cycle"
+                             ~detail:
+                               (`Assoc
+                                 [
+                                   ("loop_id", `String id);
+                                   ("cycle", `Int record.cycle);
+                                   ("hypothesis", `String hypothesis);
+                                   ("decision", `String (Autoresearch.decision_to_string record.decision));
+                                   ("delta", `Float record.delta);
+                                   ("baseline", `Float state.baseline);
+                                   ("best_score", `Float state.best_score);
+                                 ])
+                         with _ -> ())
+                    | None -> ());
                     (* 10. SSE broadcast *)
                     broadcast_cycle_result state record;
                     (* 11. Return result *)

--- a/test/test_auth_coverage.ml
+++ b/test/test_auth_coverage.ml
@@ -345,6 +345,36 @@ let test_permission_for_tool_voice_speak () =
   | Some Types.CanBroadcast -> ()
   | _ -> fail "expected CanBroadcast"
 
+let test_permission_for_tool_autoresearch_status () =
+  match Auth.permission_for_tool "masc_autoresearch_status" with
+  | Some Types.CanReadState -> ()
+  | _ -> fail "expected CanReadState"
+
+let test_permission_for_tool_autoresearch_start () =
+  match Auth.permission_for_tool "masc_autoresearch_start" with
+  | Some Types.CanAdmin -> ()
+  | _ -> fail "expected CanAdmin"
+
+let test_permission_for_tool_autoresearch_swarm_start () =
+  match Auth.permission_for_tool "masc_autoresearch_swarm_start" with
+  | Some Types.CanAdmin -> ()
+  | _ -> fail "expected CanAdmin"
+
+let test_permission_for_tool_autoresearch_cycle () =
+  match Auth.permission_for_tool "masc_autoresearch_cycle" with
+  | Some Types.CanAdmin -> ()
+  | _ -> fail "expected CanAdmin"
+
+let test_permission_for_tool_autoresearch_inject () =
+  match Auth.permission_for_tool "masc_autoresearch_inject" with
+  | Some Types.CanAdmin -> ()
+  | _ -> fail "expected CanAdmin"
+
+let test_permission_for_tool_autoresearch_stop () =
+  match Auth.permission_for_tool "masc_autoresearch_stop" with
+  | Some Types.CanAdmin -> ()
+  | _ -> fail "expected CanAdmin"
+
 let test_permission_for_tool_keeper_create_from_persona () =
   match Auth.permission_for_tool "masc_keeper_create_from_persona" with
   | Some Types.CanBroadcast -> ()
@@ -475,6 +505,18 @@ let () =
       test_case "persona_list" `Quick test_permission_for_tool_persona_list;
       test_case "voice_sessions" `Quick test_permission_for_tool_voice_sessions;
       test_case "voice_speak" `Quick test_permission_for_tool_voice_speak;
+      test_case "autoresearch_status" `Quick
+        test_permission_for_tool_autoresearch_status;
+      test_case "autoresearch_start" `Quick
+        test_permission_for_tool_autoresearch_start;
+      test_case "autoresearch_swarm_start" `Quick
+        test_permission_for_tool_autoresearch_swarm_start;
+      test_case "autoresearch_cycle" `Quick
+        test_permission_for_tool_autoresearch_cycle;
+      test_case "autoresearch_inject" `Quick
+        test_permission_for_tool_autoresearch_inject;
+      test_case "autoresearch_stop" `Quick
+        test_permission_for_tool_autoresearch_stop;
       test_case "keeper_create_from_persona" `Quick
         test_permission_for_tool_keeper_create_from_persona;
       test_case "keeper_policy_set" `Quick

--- a/test/test_autoresearch.ml
+++ b/test/test_autoresearch.ml
@@ -23,6 +23,7 @@ let make_state
     ?(baseline = 1.0)
     ?(best_score = 1.0)
     ?(best_cycle = 0)
+    ?(queued_hypothesis = None)
     ?(history = [])
     ?(total_keeps = 0)
     ?(total_discards = 0)
@@ -30,6 +31,9 @@ let make_state
     ?(cycle_timeout_s = 60.0)
     ?(max_cycles = 10)
     ?(workdir = "/tmp/autoresearch-test")
+    ?(source_workdir = "/tmp/autoresearch-test")
+    ?(program_note = None)
+    ?(warnings = [])
     () : AR.loop_state =
   let now = 1000000.0 in
   {
@@ -44,6 +48,7 @@ let make_state
     baseline;
     best_score;
     best_cycle;
+    queued_hypothesis;
     history;
     total_keeps;
     total_discards;
@@ -53,6 +58,9 @@ let make_state
     cycle_timeout_s;
     max_cycles;
     workdir;
+    source_workdir;
+    program_note;
+    warnings;
   }
 
 (* ============================================ *)
@@ -383,6 +391,26 @@ let with_tmpdir f =
     ignore (Sys.command (Printf.sprintf "rm -rf %s" (Filename.quote dir)))
   ) (fun () -> f dir)
 
+let setup_git_repo () =
+  let workdir = Filename.temp_dir "autoresearch_git_" "" in
+  ignore
+    (Sys.command
+       (Printf.sprintf
+          "cd %s && git init -q -b main && git config user.email 'test@test.com' && git config user.name 'Test'"
+          (Filename.quote workdir)));
+  let target = Filename.concat workdir "target.py" in
+  let oc = open_out target in
+  output_string oc "print('hello')\n";
+  close_out oc;
+  ignore
+    (Sys.command
+       (Printf.sprintf "cd %s && git add -A && git commit -q -m 'initial'"
+          (Filename.quote workdir)));
+  workdir
+
+let cleanup_git_repo workdir =
+  ignore (Sys.command (Printf.sprintf "rm -rf %s" (Filename.quote workdir)))
+
 let test_append_cycle_creates_file () =
   with_tmpdir (fun base_path ->
     let record = make_cycle () in
@@ -553,6 +581,36 @@ let test_dispatch_start_missing_metric () =
   | Some (true, _) -> fail "expected error for missing metric_fn"
   | None -> fail "expected Some for start tool"
 
+let test_dispatch_start_success_uses_managed_worktree () =
+  let base_path = setup_git_repo () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_git_repo base_path)
+    (fun () ->
+      let ctx = make_tool_ctx ~base_path () in
+      let args =
+        `Assoc
+          [
+            ("goal", `String "improve throughput");
+            ("metric_fn", `String "echo 1.0");
+            ("target_file", `String "target.py");
+            ("baseline", `Float 1.0);
+          ]
+      in
+      match Tool.dispatch ctx ~name:"masc_autoresearch_start" ~args with
+      | Some (true, json_str) ->
+          let json = Yojson.Safe.from_string json_str in
+          let open Yojson.Safe.Util in
+          let workdir = json |> member "workdir" |> to_string in
+          let source_workdir = json |> member "source_workdir" |> to_string in
+          check bool "managed worktree path" true
+            (AR.contains_substring workdir "/.masc/autoresearch/");
+          check string "source workdir" (Unix.realpath base_path)
+            (Unix.realpath source_workdir);
+          check bool "target file present in managed worktree" true
+            (Sys.file_exists (Filename.concat workdir "target.py"))
+      | Some (false, s) -> fail ("unexpected error: " ^ s)
+      | None -> fail "expected Some for start tool")
+
 let test_dispatch_swarm_start_requires_runtime () =
   let ctx = make_tool_ctx () in
   let args =
@@ -573,11 +631,10 @@ let test_dispatch_swarm_start_requires_runtime () =
   | _ -> fail "expected runtime error for wrapper without callbacks"
 
 let test_dispatch_swarm_start_success () =
-  with_tmpdir (fun base_path ->
-      let target_path = Filename.concat base_path "target.py" in
-      let oc = open_out target_path in
-      output_string oc "print('hello')\n";
-      close_out oc;
+  let base_path = setup_git_repo () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_git_repo base_path)
+    (fun () ->
       let start_operation ~goal:_ ~target_file:_ =
         Ok (`Assoc [ ("operation_id", `String "op-autoresearch") ])
       in
@@ -620,6 +677,10 @@ let test_dispatch_swarm_start_success () =
             (json |> member "operation_id" |> to_string);
           check string "linked loop status" "running"
             (json |> member "linked_status" |> member "status" |> to_string);
+          check string "linked source workdir" (Unix.realpath base_path)
+            (Unix.realpath (json |> member "linked_status" |> member "source_workdir" |> to_string));
+          check string "linked program note" "Prefer simple edits"
+            (json |> member "linked_status" |> member "program_note" |> to_string);
           check bool "session link persisted" true
             (Option.is_some
                (AR.load_swarm_link_by_session ~base_path
@@ -668,12 +729,14 @@ let test_dispatch_inject_success () =
   let args = `Assoc [("hypothesis", `String "try dropout=0.3")] in
   match Tool.dispatch ctx ~name:"masc_autoresearch_inject" ~args with
   | Some (true, json_str) ->
-    let json = Yojson.Safe.from_string json_str in
-    let open Yojson.Safe.Util in
-    check string "status" "hypothesis_queued"
-      (json |> member "status" |> to_string);
-    check bool "pending stored" true
-      (Hashtbl.mem Tool.pending_hypotheses "ar-inject")
+      let json = Yojson.Safe.from_string json_str in
+      let open Yojson.Safe.Util in
+      check string "status" "hypothesis_queued"
+        (json |> member "status" |> to_string);
+      check (option string) "state queued hypothesis"
+        (Some "try dropout=0.3") state.queued_hypothesis;
+      check bool "pending stored" true
+        (Hashtbl.mem Tool.pending_hypotheses "ar-inject")
   | Some (false, s) -> fail ("unexpected error: " ^ s)
   | None -> fail "expected Some for inject tool"
 
@@ -1043,6 +1106,48 @@ let test_full_cycle_discard () =
     | None -> fail "expected Some for cycle"
   )
 
+let test_cycle_commit_failure_restores_head () =
+  let workdir = setup_integration_repo () in
+  Fun.protect ~finally:(fun () -> cleanup_integration_repo workdir) (fun () ->
+    ignore (Sys.command (Printf.sprintf
+      "cd %s && printf '#!/bin/sh\\nexit 1\\n' > .git/hooks/pre-commit && chmod +x .git/hooks/pre-commit"
+      (Filename.quote workdir)));
+    let state = make_state
+      ~loop_id:"ar-integ-commit-fail"
+      ~goal:"Maximize line count"
+      ~metric_fn:"sh metric.sh"
+      ~target_file:"target.py"
+      ~workdir
+      ~baseline:3.0
+      ~best_score:3.0
+      () in
+    Hashtbl.replace Tool.active_loops "ar-integ-commit-fail" state;
+    Tool.latest_loop_id := Some "ar-integ-commit-fail";
+    Tool.set_generator "ar-integ-commit-fail"
+      (fun ~goal:_ ~baseline:_ ~history:_ ~insights:_
+           ~target_file:_ ~file_content ~llm_model:_ ->
+        Ok ("Add a line", file_content ^ "line4\n"));
+    let ctx = make_tool_ctx ~base_path:workdir () in
+    match Tool.dispatch ctx ~name:"masc_autoresearch_cycle" ~args:(`Assoc []) with
+    | Some (false, json_str) ->
+      let json = Yojson.Safe.from_string json_str in
+      let open Yojson.Safe.Util in
+      check bool "git commit failure surfaced" true
+        (AR.contains_substring (json |> member "error" |> to_string) "git commit failed");
+      let content = AR.read_file (Filename.concat workdir "target.py") in
+      check bool "file restored to HEAD" true
+        (AR.contains_substring content "line3" && not (AR.contains_substring content "line4"));
+      let ic = Unix.open_process_in
+        (Printf.sprintf "cd %s && git log --oneline | wc -l | tr -d ' '"
+          (Filename.quote workdir)) in
+      let count = Fun.protect ~finally:(fun () ->
+        ignore (Unix.close_process_in ic)
+      ) (fun () -> try int_of_string (String.trim (input_line ic)) with _ -> 0) in
+      check int "HEAD commit preserved" 1 count
+    | Some (true, s) -> fail ("expected git commit failure, got success: " ^ s)
+    | None -> fail "expected Some for cycle"
+  )
+
 (* ============================================ *)
 (* Test runner                                  *)
 (* ============================================ *)
@@ -1118,6 +1223,8 @@ let () =
       test_case "unknown tool" `Quick test_dispatch_unknown_returns_none;
       test_case "start missing goal" `Quick test_dispatch_start_missing_goal;
       test_case "start missing metric" `Quick test_dispatch_start_missing_metric;
+      test_case "start success uses managed worktree" `Quick
+        test_dispatch_start_success_uses_managed_worktree;
       test_case "swarm start requires runtime" `Quick test_dispatch_swarm_start_requires_runtime;
       test_case "swarm start success" `Quick test_dispatch_swarm_start_success;
       test_case "status no loop" `Quick test_dispatch_status_no_loop;
@@ -1161,5 +1268,7 @@ let () =
     ("integration", [
       test_case "full cycle keep" `Quick test_full_cycle_keep;
       test_case "full cycle discard" `Quick test_full_cycle_discard;
+      test_case "commit failure restores HEAD" `Quick
+        test_cycle_commit_failure_restores_head;
     ]);
   ]


### PR DESCRIPTION
## Summary
- salvage the core MCP-first autoresearch productization from closed PR #921 on top of current main
- keep the backend/tooling changes that add managed loop surfaces and linked team-session integration
- intentionally defer stale dashboard asset churn from the original branch

## Validation
- dune build --root . test/test_auth_coverage.exe test/test_autoresearch.exe test/test_tool_team_session.exe
- ./_build/default/test/test_auth_coverage.exe
- ./_build/default/test/test_autoresearch.exe
- ./_build/default/test/test_tool_team_session.exe test team_session 31
