### PR TITLE
fix(auth): align H2 write routes with tool permissions

### DIFF
--- a/lib/server_h2_gateway.ml
+++ b/lib/server_h2_gateway.ml
@@ -148,6 +148,12 @@ let make_request_handler ~sw ~clock ~server_start_time =
           h2_respond_html h2_reqd "<html><body>Dashboard build not found. Run: cd dashboard &amp;&amp; npm run build</body></html>" ~extra_headers:cors
     in
 
+    let h2_authorize_tool state ~tool_name =
+      authorize_tool_request
+        ~base_path:state.Mcp_server.room_config.base_path
+        ~tool_name httpun_request
+    in
+
     let dispatch_h2_route () =
       match httpun_meth, path with
       (* ─────────────────────────────────────────────────────────────────────
@@ -714,9 +720,7 @@ let make_request_handler ~sw ~clock ~server_start_time =
 
       | `POST, "/api/v1/operator/action" ->
           let state = get_server_state () in
-          (match authorize_permission_request
-                    ~base_path:state.Mcp_server.room_config.base_path
-                    ~permission:Types.CanBroadcast httpun_request with
+          (match h2_authorize_tool state ~tool_name:"masc_operator_action" with
            | Error err ->
                let status = http_status_of_auth_error err in
                h2_respond_json h2_reqd (auth_error_json err) ~status ~extra_headers:cors
@@ -740,9 +744,7 @@ let make_request_handler ~sw ~clock ~server_start_time =
 
       | `POST, "/api/v1/command-plane/units" ->
           let state = get_server_state () in
-          (match authorize_permission_request
-                    ~base_path:state.Mcp_server.room_config.base_path
-                    ~permission:Types.CanBroadcast httpun_request with
+          (match h2_authorize_tool state ~tool_name:"masc_unit_define" with
            | Error err ->
                let status = http_status_of_auth_error err in
                h2_respond_json h2_reqd (auth_error_json err) ~status ~extra_headers:cors
@@ -770,9 +772,7 @@ let make_request_handler ~sw ~clock ~server_start_time =
 
       | `POST, "/api/v1/command-plane/units/reparent" ->
           let state = get_server_state () in
-          (match authorize_permission_request
-                    ~base_path:state.Mcp_server.room_config.base_path
-                    ~permission:Types.CanBroadcast httpun_request with
+          (match h2_authorize_tool state ~tool_name:"masc_unit_reparent" with
            | Error err ->
                let status = http_status_of_auth_error err in
                h2_respond_json h2_reqd (auth_error_json err) ~status ~extra_headers:cors
@@ -797,9 +797,7 @@ let make_request_handler ~sw ~clock ~server_start_time =
 
       | `POST, "/api/v1/command-plane/units/reassign" ->
           let state = get_server_state () in
-          (match authorize_permission_request
-                    ~base_path:state.Mcp_server.room_config.base_path
-                    ~permission:Types.CanBroadcast httpun_request with
+          (match h2_authorize_tool state ~tool_name:"masc_unit_reassign" with
            | Error err ->
                let status = http_status_of_auth_error err in
                h2_respond_json h2_reqd (auth_error_json err) ~status ~extra_headers:cors
@@ -824,9 +822,7 @@ let make_request_handler ~sw ~clock ~server_start_time =
 
       | `POST, "/api/v1/command-plane/operations" ->
           let state = get_server_state () in
-          (match authorize_permission_request
-                    ~base_path:state.Mcp_server.room_config.base_path
-                    ~permission:Types.CanBroadcast httpun_request with
+          (match h2_authorize_tool state ~tool_name:"masc_operation_start" with
            | Error err ->
                let status = http_status_of_auth_error err in
                h2_respond_json h2_reqd (auth_error_json err) ~status ~extra_headers:cors
@@ -854,9 +850,7 @@ let make_request_handler ~sw ~clock ~server_start_time =
 
       | `POST, "/api/v1/command-plane/operations/checkpoint" ->
           let state = get_server_state () in
-          (match authorize_permission_request
-                    ~base_path:state.Mcp_server.room_config.base_path
-                    ~permission:Types.CanBroadcast httpun_request with
+          (match h2_authorize_tool state ~tool_name:"masc_operation_checkpoint" with
            | Error err ->
                let status = http_status_of_auth_error err in
                h2_respond_json h2_reqd (auth_error_json err) ~status ~extra_headers:cors
@@ -884,9 +878,7 @@ let make_request_handler ~sw ~clock ~server_start_time =
 
       | `POST, "/api/v1/command-plane/operations/pause" ->
           let state = get_server_state () in
-          (match authorize_permission_request
-                    ~base_path:state.Mcp_server.room_config.base_path
-                    ~permission:Types.CanBroadcast httpun_request with
+          (match h2_authorize_tool state ~tool_name:"masc_operation_pause" with
            | Error err ->
                let status = http_status_of_auth_error err in
                h2_respond_json h2_reqd (auth_error_json err) ~status ~extra_headers:cors
@@ -911,9 +903,7 @@ let make_request_handler ~sw ~clock ~server_start_time =
 
       | `POST, "/api/v1/command-plane/operations/resume" ->
           let state = get_server_state () in
-          (match authorize_permission_request
-                    ~base_path:state.Mcp_server.room_config.base_path
-                    ~permission:Types.CanBroadcast httpun_request with
+          (match h2_authorize_tool state ~tool_name:"masc_operation_resume" with
            | Error err ->
                let status = http_status_of_auth_error err in
                h2_respond_json h2_reqd (auth_error_json err) ~status ~extra_headers:cors
@@ -938,9 +928,7 @@ let make_request_handler ~sw ~clock ~server_start_time =
 
       | `POST, "/api/v1/command-plane/operations/stop" ->
           let state = get_server_state () in
-          (match authorize_permission_request
-                    ~base_path:state.Mcp_server.room_config.base_path
-                    ~permission:Types.CanBroadcast httpun_request with
+          (match h2_authorize_tool state ~tool_name:"masc_operation_stop" with
            | Error err ->
                let status = http_status_of_auth_error err in
                h2_respond_json h2_reqd (auth_error_json err) ~status ~extra_headers:cors
@@ -965,9 +953,7 @@ let make_request_handler ~sw ~clock ~server_start_time =
 
       | `POST, "/api/v1/command-plane/operations/finalize" ->
           let state = get_server_state () in
-          (match authorize_permission_request
-                    ~base_path:state.Mcp_server.room_config.base_path
-                    ~permission:Types.CanBroadcast httpun_request with
+          (match h2_authorize_tool state ~tool_name:"masc_operation_finalize" with
            | Error err ->
                let status = http_status_of_auth_error err in
                h2_respond_json h2_reqd (auth_error_json err) ~status ~extra_headers:cors
@@ -992,9 +978,7 @@ let make_request_handler ~sw ~clock ~server_start_time =
 
       | `POST, "/api/v1/command-plane/dispatch/plan" ->
           let state = get_server_state () in
-          (match authorize_permission_request
-                    ~base_path:state.Mcp_server.room_config.base_path
-                    ~permission:Types.CanBroadcast httpun_request with
+          (match h2_authorize_tool state ~tool_name:"masc_dispatch_plan" with
            | Error err ->
                let status = http_status_of_auth_error err in
                h2_respond_json h2_reqd (auth_error_json err) ~status ~extra_headers:cors
@@ -1019,9 +1003,7 @@ let make_request_handler ~sw ~clock ~server_start_time =
 
       | `POST, "/api/v1/command-plane/dispatch/assign" ->
           let state = get_server_state () in
-          (match authorize_permission_request
-                    ~base_path:state.Mcp_server.room_config.base_path
-                    ~permission:Types.CanBroadcast httpun_request with
+          (match h2_authorize_tool state ~tool_name:"masc_dispatch_assign" with
            | Error err ->
                let status = http_status_of_auth_error err in
                h2_respond_json h2_reqd (auth_error_json err) ~status ~extra_headers:cors
@@ -1046,9 +1028,7 @@ let make_request_handler ~sw ~clock ~server_start_time =
 
       | `POST, "/api/v1/command-plane/dispatch/rebalance" ->
           let state = get_server_state () in
-          (match authorize_permission_request
-                    ~base_path:state.Mcp_server.room_config.base_path
-                    ~permission:Types.CanBroadcast httpun_request with
+          (match h2_authorize_tool state ~tool_name:"masc_dispatch_rebalance" with
            | Error err ->
                let status = http_status_of_auth_error err in
                h2_respond_json h2_reqd (auth_error_json err) ~status ~extra_headers:cors
@@ -1073,9 +1053,7 @@ let make_request_handler ~sw ~clock ~server_start_time =
 
       | `POST, "/api/v1/command-plane/dispatch/escalate" ->
           let state = get_server_state () in
-          (match authorize_permission_request
-                    ~base_path:state.Mcp_server.room_config.base_path
-                    ~permission:Types.CanBroadcast httpun_request with
+          (match h2_authorize_tool state ~tool_name:"masc_dispatch_escalate" with
            | Error err ->
                let status = http_status_of_auth_error err in
                h2_respond_json h2_reqd (auth_error_json err) ~status ~extra_headers:cors
@@ -1100,9 +1078,7 @@ let make_request_handler ~sw ~clock ~server_start_time =
 
       | `POST, "/api/v1/command-plane/dispatch/recall" ->
           let state = get_server_state () in
-          (match authorize_permission_request
-                    ~base_path:state.Mcp_server.room_config.base_path
-                    ~permission:Types.CanBroadcast httpun_request with
+          (match h2_authorize_tool state ~tool_name:"masc_dispatch_recall" with
            | Error err ->
                let status = http_status_of_auth_error err in
                h2_respond_json h2_reqd (auth_error_json err) ~status ~extra_headers:cors
@@ -1127,9 +1103,7 @@ let make_request_handler ~sw ~clock ~server_start_time =
 
       | `POST, "/api/v1/command-plane/dispatch/tick" ->
           let state = get_server_state () in
-          (match authorize_permission_request
-                    ~base_path:state.Mcp_server.room_config.base_path
-                    ~permission:Types.CanBroadcast httpun_request with
+          (match h2_authorize_tool state ~tool_name:"masc_dispatch_tick" with
            | Error err ->
                let status = http_status_of_auth_error err in
                h2_respond_json h2_reqd (auth_error_json err) ~status ~extra_headers:cors
@@ -1154,9 +1128,7 @@ let make_request_handler ~sw ~clock ~server_start_time =
 
       | `POST, "/api/v1/command-plane/policy/approve" ->
           let state = get_server_state () in
-          (match authorize_permission_request
-                    ~base_path:state.Mcp_server.room_config.base_path
-                    ~permission:Types.CanBroadcast httpun_request with
+          (match h2_authorize_tool state ~tool_name:"masc_policy_approve" with
            | Error err ->
                let status = http_status_of_auth_error err in
                h2_respond_json h2_reqd (auth_error_json err) ~status ~extra_headers:cors
@@ -1181,9 +1153,7 @@ let make_request_handler ~sw ~clock ~server_start_time =
 
       | `POST, "/api/v1/command-plane/policy/deny" ->
           let state = get_server_state () in
-          (match authorize_permission_request
-                    ~base_path:state.Mcp_server.room_config.base_path
-                    ~permission:Types.CanBroadcast httpun_request with
+          (match h2_authorize_tool state ~tool_name:"masc_policy_deny" with
            | Error err ->
                let status = http_status_of_auth_error err in
                h2_respond_json h2_reqd (auth_error_json err) ~status ~extra_headers:cors
@@ -1208,9 +1178,7 @@ let make_request_handler ~sw ~clock ~server_start_time =
 
       | `POST, "/api/v1/command-plane/policy/update" ->
           let state = get_server_state () in
-          (match authorize_permission_request
-                    ~base_path:state.Mcp_server.room_config.base_path
-                    ~permission:Types.CanBroadcast httpun_request with
+          (match h2_authorize_tool state ~tool_name:"masc_policy_update" with
            | Error err ->
                let status = http_status_of_auth_error err in
                h2_respond_json h2_reqd (auth_error_json err) ~status ~extra_headers:cors
@@ -1235,9 +1203,7 @@ let make_request_handler ~sw ~clock ~server_start_time =
 
       | `POST, "/api/v1/command-plane/policy/freeze" ->
           let state = get_server_state () in
-          (match authorize_permission_request
-                    ~base_path:state.Mcp_server.room_config.base_path
-                    ~permission:Types.CanBroadcast httpun_request with
+          (match h2_authorize_tool state ~tool_name:"masc_policy_freeze_unit" with
            | Error err ->
                let status = http_status_of_auth_error err in
                h2_respond_json h2_reqd (auth_error_json err) ~status ~extra_headers:cors
@@ -1262,9 +1228,7 @@ let make_request_handler ~sw ~clock ~server_start_time =
 
       | `POST, "/api/v1/command-plane/policy/kill-switch" ->
           let state = get_server_state () in
-          (match authorize_permission_request
-                    ~base_path:state.Mcp_server.room_config.base_path
-                    ~permission:Types.CanBroadcast httpun_request with
+          (match h2_authorize_tool state ~tool_name:"masc_policy_kill_switch" with
            | Error err ->
                let status = http_status_of_auth_error err in
                h2_respond_json h2_reqd (auth_error_json err) ~status ~extra_headers:cors
@@ -1289,9 +1253,7 @@ let make_request_handler ~sw ~clock ~server_start_time =
 
       | `POST, "/api/v1/operator/confirm" ->
           let state = get_server_state () in
-          (match authorize_permission_request
-                    ~base_path:state.Mcp_server.room_config.base_path
-                    ~permission:Types.CanBroadcast httpun_request with
+          (match h2_authorize_tool state ~tool_name:"masc_operator_confirm" with
            | Error err ->
                let status = http_status_of_auth_error err in
                h2_respond_json h2_reqd (auth_error_json err) ~status ~extra_headers:cors


### PR DESCRIPTION
## Summary
- reapply the missing H2-side tool auth sweep that did not land on main from stacked PR #958
- switch command-plane/operator H2 write routes from coarse CanBroadcast checks to per-tool auth
- keep the patch scoped to server_h2_gateway only

## Validation
- dune build --root . test/test_ci_hardening_source.exe test/test_auth_coverage.exe test/test_mcp_server_eio.exe
- dune exec --root . ./test/test_ci_hardening_source.exe
- dune exec --root . ./test/test_mcp_server_eio.exe

## Notes
- test_auth_coverage currently exposes baseline permission expectation drift on main (claim/done/llama_runtime_verify) and is not caused by this H2-only patch