### PR TITLE
fix(types): classify legacy task aliases as task ops

### DIFF
--- a/lib/types.ml
+++ b/lib/types.ml
@@ -722,8 +722,17 @@ let limit_for_category config = function
 (** Map tool to rate limit category *)
 let category_for_tool = function
   | "masc_broadcast" | "masc_listen" -> BroadcastLimit
-  | "masc_add_task" | "masc_claim_next"
-  | "masc_update_priority" | "masc_transition" -> TaskOpsLimit
+  | "masc_add_task"
+  | "masc_claim"
+  | "masc_done"
+  | "masc_claim_next"
+  | "masc_claim_task"
+  | "masc_set_current_task"
+  | "masc_complete_task"
+  | "masc_release_task"
+  | "masc_cancel_task"
+  | "masc_update_priority"
+  | "masc_transition" -> TaskOpsLimit
   | _ -> GeneralLimit
 
 (** Rate limit error - returned when limit exceeded *)


### PR DESCRIPTION
## Summary
- classify legacy task-operation aliases under `Types.TaskOpsLimit`
- fixes local quick-suite failure in `test_types_coverage`

## Validation
- `dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix-masc-claim-category test/test_types_coverage.exe test/test_types_utils_coverage.exe`
- `./_build/default/test/test_types_coverage.exe`
- `./_build/default/test/test_types_utils_coverage.exe`