### PR TITLE
feat(dashboard): make observability truth explicit on main

### DIFF
--- a/dashboard/src/components/agent-detail.ts
+++ b/dashboard/src/components/agent-detail.ts
@@ -184,6 +184,17 @@ export function AgentDetailOverlay() {
     agent?.last_seen
     ?? missionBrief?.last_activity_at
     ?? null
+  const signalTruth =
+    missionBrief?.signal_truth === 'live'
+      ? 'live'
+      : missionBrief?.signal_truth === 'stale'
+        ? 'stale'
+        : missionBrief?.signal_truth === 'archived'
+          ? 'archived'
+          : missionBrief?.signal_truth === 'unknown'
+            ? 'unknown'
+            : null
+  const evidenceSource = missionBrief?.evidence_source ?? null
   const agentEmoji = agent?.emoji ?? keeper?.emoji
   const koreanName = agent?.koreanName ?? keeper?.koreanName
   const continuitySummary =
@@ -218,6 +229,8 @@ export function AgentDetailOverlay() {
                   ${!agent && missionBrief?.archived_reason
                     ? html`<span style="font-size:0.75rem;color:#888">${missionBrief.archived_reason}</span>`
                     : null}
+                  ${signalTruth ? html`<span class="pill">signal · ${signalTruth}</span>` : null}
+                  ${evidenceSource ? html`<span class="pill">source · ${evidenceSource}</span>` : null}
                 </div>
               </div>
             </div>

--- a/dashboard/src/components/agents.ts
+++ b/dashboard/src/components/agents.ts
@@ -103,6 +103,24 @@ function agentStateLabel(state: DashboardExecutionWorkerSupportBrief['state']): 
   }
 }
 
+function signalTruthLabel(value?: DashboardExecutionWorkerSupportBrief['signal_truth'] | null): string {
+  switch (value) {
+    case 'live': return '최근 신호(≤5m)'
+    case 'stale': return '오래된 신호(>5m)'
+    case 'absent': return 'signal 없음'
+    default: return value ?? 'signal 미상'
+  }
+}
+
+function evidenceSourceLabel(value?: DashboardExecutionWorkerSupportBrief['evidence_source'] | null): string {
+  switch (value) {
+    case 'message': return '최근 출력'
+    case 'presence': return 'presence/하트비트'
+    case 'none': return '근거 없음'
+    default: return value ?? '근거 미상'
+  }
+}
+
 function continuityStateLabel(state: DashboardExecutionContinuityBrief['state']): string {
   switch (state) {
     case 'critical': return '위험'
@@ -114,8 +132,8 @@ function continuityStateLabel(state: DashboardExecutionContinuityBrief['state'])
 function lodgeOutcomeLabel(outcome: DashboardExecutionLodgeCheckin['outcome']): string {
   switch (outcome) {
     case 'acted': return '행동'
-    case 'passed': return '판단 패스'
-    case 'skipped': return '시스템 스킵'
+    case 'passed': return '통과'
+    case 'skipped': return '건너뜀'
     case 'failed': return '실패'
     default: return outcome
   }
@@ -129,7 +147,7 @@ function lodgeActionKindLabel(value?: DashboardExecutionLodgeCheckin['action_kin
     case 'none':
     case null:
     case undefined:
-      return '없음'
+      return 'none'
     default:
       return value
   }
@@ -245,6 +263,9 @@ function QueueCard({ item, selected }: { item: DashboardExecutionQueueItem; sele
 }
 
 function SessionCard({ brief, selected }: { brief: DashboardExecutionSessionBrief; selected: boolean }) {
+  const liveCount = brief.active_count ?? 0
+  const seenCount = brief.seen_count ?? liveCount
+  const plannedCount = brief.planned_count ?? brief.member_names.length
   return html`
     <button
       class="mission-card-select ${selected ? 'active' : ''}"
@@ -263,6 +284,7 @@ function SessionCard({ brief, selected }: { brief: DashboardExecutionSessionBrie
       </div>
       <div class="mission-card-meta">
         <span>건강도 · ${statusLabel(brief.health ?? 'ok')}</span>
+        <span>live ${liveCount} · seen ${seenCount} · planned ${plannedCount}</span>
         ${brief.linked_operation_id ? html`<span>연결 작전 · ${brief.linked_operation_id}</span>` : null}
         ${brief.last_activity_at ? html`<span><${TimeAgo} timestamp=${brief.last_activity_at} /></span>` : null}
       </div>
@@ -271,7 +293,9 @@ function SessionCard({ brief, selected }: { brief: DashboardExecutionSessionBrie
         : brief.last_activity_summary
           ? html`<div class="mission-card-detail">${brief.last_activity_summary}</div>`
           : null}
-      ${brief.worker_gap_summary ? html`<div class="monitor-footnote">${brief.worker_gap_summary}</div>` : null}
+      <div class="monitor-footnote">
+        ${brief.worker_gap_summary ?? `관측 기준 · ${brief.counts_basis ?? 'recent_turns'}`}
+      </div>
       <${HandoffButtons} intervene=${brief.intervene_handoff} command=${brief.command_handoff} />
     </button>
   `
@@ -313,16 +337,15 @@ function LodgeTickCard({ tick }: { tick: DashboardExecutionLodgeTick | null }) {
   return html`
     <div class="monitor-nested-card">
       <div class="stats-grid">
-        <${MonitorStat} label="검토" value=${tick.checked ?? 0} color="#22d3ee" />
-        <${MonitorStat} label="행동" value=${tick.acted ?? 0} color="#4ade80" />
-        <${MonitorStat} label="판단 패스" value=${tick.passed ?? 0} color="#94a3b8" />
-        <${MonitorStat} label="시스템 스킵" value=${tick.skipped ?? 0} color="#fbbf24" />
-        <${MonitorStat} label="실패" value=${tick.failed ?? 0} color="#fb7185" />
+        <${MonitorStat} label="checked" value=${tick.checked ?? 0} color="#22d3ee" />
+        <${MonitorStat} label="acted" value=${tick.acted ?? 0} color="#4ade80" />
+        <${MonitorStat} label="passed" value=${tick.passed ?? 0} color="#94a3b8" />
+        <${MonitorStat} label="skipped" value=${tick.skipped ?? 0} color="#fbbf24" />
+        <${MonitorStat} label="failed" value=${tick.failed ?? 0} color="#fb7185" />
       </div>
       <div class="monitor-meta">
         ${tick.last_tick_at ? html`<span>마지막 tick <${TimeAgo} timestamp=${tick.last_tick_at} /></span>` : html`<span>마지막 tick 없음</span>`}
-        ${tick.last_pass_reason ? html`<span>대표 패스 이유 · ${tick.last_pass_reason}</span>` : null}
-        ${tick.last_system_skip_reason ? html`<span>대표 시스템 스킵 이유 · ${tick.last_system_skip_reason}</span>` : null}
+        ${tick.last_skip_reason ? html`<span>대표 skip 이유 · ${tick.last_skip_reason}</span>` : null}
       </div>
       ${tick.activity_report ? html`<div class="monitor-footnote">${tick.activity_report}</div>` : null}
     </div>
@@ -387,6 +410,8 @@ function WorkerSupportRow({
 
       <div class="monitor-meta">
         ${row.last_signal_at ? html`<span>신호 <${TimeAgo} timestamp=${row.last_signal_at} /></span>` : html`<span>최근 신호 없음</span>`}
+        <span>${signalTruthLabel(row.signal_truth)} · ${evidenceSourceLabel(row.evidence_source)}</span>
+        ${typeof row.last_signal_age_sec === 'number' ? html`<span>${row.last_signal_age_sec}s ago</span>` : null}
         <span>${(row.active_task_count ?? 0) > 0 ? `활성 작업 ${row.active_task_count}개` : '활성 작업 없음'}</span>
         ${row.related_session_id ? html`<span>세션 · ${row.related_session_id}</span>` : null}
         ${row.related_operation_id ? html`<span>작전 · ${row.related_operation_id}</span>` : null}
@@ -585,7 +610,7 @@ export function Execution() {
         >
           <div class="monitor-section-head">
             <h2 class="monitor-headline">Lodge Check-ins</h2>
-            <p class="monitor-subheadline">최근 lodge tick에서 누가 실제로 행동했고, 누가 판단상 패스했고, 누가 시스템에 의해 스킵됐는지 먼저 보여줍니다.</p>
+            <p class="monitor-subheadline">최근 lodge tick에서 누가 무엇을 허용받았고, 실제로 어떻게 행동했는지 먼저 보여줍니다.</p>
           </div>
           <${LodgeTickCard} tick=${lodgeTick} />
           <div class="monitor-list">

--- a/dashboard/src/components/mission-cards.ts
+++ b/dashboard/src/components/mission-cards.ts
@@ -323,6 +323,9 @@ export function SessionBriefCard({
   const members = brief.member_previews.slice(0, 4)
   const action = brief.top_recommendation ?? null
   const incident = brief.top_attention ?? null
+  const liveCount = brief.active_count ?? 0
+  const seenCount = brief.seen_count ?? liveCount
+  const plannedCount = brief.planned_count ?? brief.member_names.length
 
   return html`
     <article class="mission-crew-card ${toneClass(brief.top_attention?.severity ?? brief.health ?? brief.status)} ${selected ? 'is-selected' : ''}">
@@ -353,13 +356,14 @@ export function SessionBriefCard({
           </div>
           <div class="mission-fact-tile">
             <span>충원 상태</span>
-            <strong>${brief.active_count ?? 0}/${brief.required_count || 1}</strong>
-            <small>활성 / 필요</small>
+            <strong>${liveCount}/${brief.required_count || 1}</strong>
+            <small>live · seen ${seenCount} · planned ${plannedCount}</small>
           </div>
         </div>
       </button>
 
       ${brief.blocker_summary ? html`<div class="mission-inline-note">막힘 · ${brief.blocker_summary}</div>` : null}
+      ${brief.counts_basis ? html`<div class="mission-inline-note">관측 기준 · ${brief.counts_basis}</div>` : null}
 
       <div class="mission-crew-event">
         <span>최근 사건</span>
@@ -385,7 +389,10 @@ export function SessionBriefCard({
               ${members.map(member => html`
                 <button class="mission-member-preview" onClick=${() => openAgentDetail(member.agent_name)}>
                   <strong>${member.agent_name}</strong>
-                  <span>${member.current_work ?? '현재 작업 없음'}</span>
+                  <span>
+                    ${member.current_work ?? '현재 작업 없음'}
+                    ${member.is_live === false ? ' · archived' : member.is_live === true ? ' · live' : ''}
+                  </span>
                   <small>${member.recent_output_preview ?? member.recent_input_preview ?? '최근 입출력 없음'}</small>
                 </button>
               `)}

--- a/dashboard/src/mission-store.ts
+++ b/dashboard/src/mission-store.ts
@@ -357,7 +357,10 @@ function normalizeSessionBrief(raw: unknown): DashboardMissionSessionBrief | nul
     last_event_summary: asString(raw.last_event_summary) ?? null,
     communication_summary: asString(raw.communication_summary) ?? null,
     active_count: asNumber(raw.active_count),
+    seen_count: asNumber(raw.seen_count),
+    planned_count: asNumber(raw.planned_count),
     required_count: asNumber(raw.required_count),
+    counts_basis: asString(raw.counts_basis) ?? null,
     related_attention_count: asNumber(raw.related_attention_count) ?? 0,
     top_attention: normalizeAttentionItem(raw.top_attention),
     top_recommendation: normalizeRecommendedAction(raw.top_recommendation),
@@ -446,6 +449,21 @@ function normalizeAgentBrief(raw: unknown): DashboardMissionAgentBrief | null {
     related_session_id: asString(raw.related_session_id) ?? null,
     related_attention_count: asNumber(raw.related_attention_count) ?? 0,
     last_activity_at: asString(raw.last_activity_at) ?? null,
+    last_activity_age_sec: asNumber(raw.last_activity_age_sec) ?? null,
+    signal_truth:
+      asString(raw.signal_truth) === 'live'
+      || asString(raw.signal_truth) === 'stale'
+      || asString(raw.signal_truth) === 'archived'
+      || asString(raw.signal_truth) === 'unknown'
+        ? (asString(raw.signal_truth) as DashboardMissionAgentBrief['signal_truth'])
+        : undefined,
+    evidence_source:
+      asString(raw.evidence_source) === 'message'
+      || asString(raw.evidence_source) === 'presence'
+      || asString(raw.evidence_source) === 'session'
+      || asString(raw.evidence_source) === 'none'
+        ? (asString(raw.evidence_source) as DashboardMissionAgentBrief['evidence_source'])
+        : undefined,
     recent_output_preview: asString(raw.recent_output_preview) ?? null,
     recent_input_preview: asString(raw.recent_input_preview) ?? null,
     recent_tool_names: extractArray(raw.recent_tool_names)

--- a/dashboard/src/store.ts
+++ b/dashboard/src/store.ts
@@ -379,7 +379,10 @@ function normalizeExecutionSessionBrief(raw: unknown): DashboardExecutionSession
     last_activity_summary: asString(raw.last_activity_summary) ?? null,
     communication_summary: asString(raw.communication_summary) ?? null,
     active_count: asNumber(raw.active_count),
+    seen_count: asNumber(raw.seen_count),
+    planned_count: asNumber(raw.planned_count),
     required_count: asNumber(raw.required_count),
+    counts_basis: asString(raw.counts_basis) ?? null,
     top_handoff: normalizeExecutionHandoff(raw.top_handoff),
     intervene_handoff: normalizeExecutionHandoff(raw.intervene_handoff),
     command_handoff: normalizeExecutionHandoff(raw.command_handoff),
@@ -418,6 +421,16 @@ function normalizeExecutionWorkerSupportBrief(raw: unknown): DashboardExecutionW
   if (!name || !note || !focus || (state !== 'working' && state !== 'watching' && state !== 'quiet' && state !== 'offline')) {
     return null
   }
+  const signalTruthRaw = asString(raw.signal_truth)
+  const signalTruth =
+    signalTruthRaw === 'live' || signalTruthRaw === 'stale' || signalTruthRaw === 'absent'
+      ? signalTruthRaw
+      : undefined
+  const evidenceSourceRaw = asString(raw.evidence_source)
+  const evidenceSource =
+    evidenceSourceRaw === 'message' || evidenceSourceRaw === 'presence' || evidenceSourceRaw === 'none'
+      ? evidenceSourceRaw
+      : undefined
   return {
     name,
     agent_name: asString(raw.agent_name),
@@ -427,6 +440,9 @@ function normalizeExecutionWorkerSupportBrief(raw: unknown): DashboardExecutionW
     note,
     focus,
     last_signal_at: asString(raw.last_signal_at) ?? null,
+    last_signal_age_sec: asNumber(raw.last_signal_age_sec) ?? null,
+    signal_truth: signalTruth,
+    evidence_source: evidenceSource,
     active_task_count: asNumber(raw.active_task_count),
     related_session_id: asString(raw.related_session_id) ?? null,
     related_operation_id: asString(raw.related_operation_id) ?? null,
@@ -440,7 +456,6 @@ function normalizeExecutionWorkerSupportBrief(raw: unknown): DashboardExecutionW
 
 function normalizeExecutionLodgeTick(raw: unknown): DashboardExecutionLodgeTick | null {
   if (!isRecord(raw)) return null
-  const lastSystemSkipReason = asString(raw.last_system_skip_reason) ?? asString(raw.last_skip_reason) ?? null
   return {
     checked: asNumber(raw.checked),
     acted: asNumber(raw.acted),
@@ -448,9 +463,7 @@ function normalizeExecutionLodgeTick(raw: unknown): DashboardExecutionLodgeTick 
     skipped: asNumber(raw.skipped),
     failed: asNumber(raw.failed),
     last_tick_at: asString(raw.last_tick_at) ?? null,
-    last_skip_reason: lastSystemSkipReason,
-    last_pass_reason: asString(raw.last_pass_reason) ?? null,
-    last_system_skip_reason: lastSystemSkipReason,
+    last_skip_reason: asString(raw.last_skip_reason) ?? null,
     activity_report: asString(raw.activity_report) ?? null,
   }
 }

--- a/dashboard/src/types.ts
+++ b/dashboard/src/types.ts
@@ -862,7 +862,7 @@ export interface LodgeTickResult {
   acted_names: string[]
   activity_report?: string
   quiet_hours_overridden?: boolean
-  skipped_reason?: string
+  skipped_reason?: string | null
   last_pass_reason?: string | null
   last_system_skip_reason?: string | null
   acted_rows?: Array<{ name: string; summary?: string }>
@@ -1102,7 +1102,10 @@ export interface DashboardExecutionSessionBrief {
   last_activity_summary?: string | null
   communication_summary?: string | null
   active_count?: number
+  seen_count?: number
+  planned_count?: number
   required_count?: number
+  counts_basis?: string | null
   top_handoff?: DashboardExecutionHandoff | null
   intervene_handoff?: DashboardExecutionHandoff | null
   command_handoff?: DashboardExecutionHandoff | null
@@ -1134,6 +1137,9 @@ export interface DashboardExecutionWorkerSupportBrief {
   note: string
   focus: string
   last_signal_at?: string | null
+  last_signal_age_sec?: number | null
+  signal_truth?: 'live' | 'stale' | 'absent'
+  evidence_source?: 'message' | 'presence' | 'none'
   active_task_count?: number
   related_session_id?: string | null
   related_operation_id?: string | null
@@ -1152,8 +1158,6 @@ export interface DashboardExecutionLodgeTick {
   failed?: number
   last_tick_at?: string | null
   last_skip_reason?: string | null
-  last_pass_reason?: string | null
-  last_system_skip_reason?: string | null
   activity_report?: string | null
 }
 
@@ -1350,7 +1354,10 @@ export interface DashboardMissionSessionBrief {
   last_event_summary?: string | null
   communication_summary?: string | null
   active_count?: number
+  seen_count?: number
+  planned_count?: number
   required_count?: number
+  counts_basis?: string | null
   related_attention_count: number
   top_attention?: OperatorAttentionItem | null
   top_recommendation?: OperatorRecommendedAction | null
@@ -1405,6 +1412,9 @@ export interface DashboardMissionAgentBrief {
   related_session_id?: string | null
   related_attention_count: number
   last_activity_at?: string | null
+  last_activity_age_sec?: number | null
+  signal_truth?: 'live' | 'stale' | 'archived' | 'unknown'
+  evidence_source?: 'message' | 'presence' | 'session' | 'none'
   recent_output_preview?: string | null
   recent_input_preview?: string | null
   recent_event?: string | null

--- a/lib/dashboard_execution.ml
+++ b/lib/dashboard_execution.ml
@@ -16,7 +16,10 @@ type session_seed = {
   last_activity_summary : string;
   communication_summary : string;
   active_count : int;
+  seen_count : int;
+  planned_count : int;
   required_count : int;
+  counts_basis : string;
   runtime_blocker : string option;
   worker_gap_summary : string option;
   top_attention : Yojson.Safe.t option;
@@ -224,21 +227,15 @@ let lodge_outcome_rank = function
   | "passed" | "skipped" -> 1
   | _ -> 0
 
-let lodge_tick_last_pass_reason (result : Lodge_heartbeat.heartbeat_result) =
-  let rec first_reason = function
-    | [] -> None
-    | (_, _, Lodge_heartbeat.Passed reason) :: _ -> Some reason
-    | _ :: tl -> first_reason tl
-  in
-  first_reason result.checkins
-
-let lodge_tick_last_system_skip_reason (result : Lodge_heartbeat.heartbeat_result) =
+let lodge_tick_last_reason (result : Lodge_heartbeat.heartbeat_result) =
   if result.agents_checked = 0 then
     Some "no agents selected for this tick"
   else
     let rec first_reason = function
       | [] -> None
-      | (_, _, Lodge_heartbeat.Skipped reason) :: _ -> Some reason
+      | (_, _, Lodge_heartbeat.Passed reason) :: _
+      | (_, _, Lodge_heartbeat.Skipped reason) :: _ ->
+          Some reason
       | _ :: tl -> first_reason tl
     in
     first_reason result.checkins
@@ -397,9 +394,7 @@ let execution_smoke_fixture_json () =
             ("skipped", `Int 1);
             ("failed", `Int 0);
             ("last_tick_at", `String generated_at);
-            ("last_skip_reason", `String "rate-limited after a recent board action");
-            ("last_pass_reason", `String "stayed read-only after evaluating the board");
-            ("last_system_skip_reason", `String "rate-limited after a recent board action");
+            ("last_skip_reason", `String "delegated_tool_loop: watcher stayed read-only");
             ("activity_report", `String "alpha acted, beta passed, gamma skipped");
           ] );
       ( "lodge_checkins",
@@ -541,7 +536,10 @@ let execution_smoke_fixture_json () =
                 ("last_activity_summary", `String "local64 smoke cleanup");
                 ("communication_summary", `String "hybrid · broadcast 0 · portal 0");
                 ("active_count", `Int 3);
+                ("seen_count", `Int 3);
+                ("planned_count", `Int 4);
                 ("required_count", `Int 1);
+                ("counts_basis", `String "live=recent_turns · planned=roster");
                 ("top_handoff", intervene_handoff);
                 ("intervene_handoff", intervene_handoff);
                 ("command_handoff", command_handoff);
@@ -562,7 +560,10 @@ let execution_smoke_fixture_json () =
                 ("last_activity_summary", `String "healthy runtime census");
                 ("communication_summary", `String "hybrid · broadcast 1 · portal 0");
                 ("active_count", `Int 1);
+                ("seen_count", `Int 1);
+                ("planned_count", `Int 1);
                 ("required_count", `Int 1);
+                ("counts_basis", `String "live=recent_turns · planned=roster");
                 ("top_handoff", command_handoff);
                 ("intervene_handoff", intervene_handoff);
                 ("command_handoff", command_handoff);
@@ -619,6 +620,9 @@ let execution_smoke_fixture_json () =
                 ("note", `String "Task and live signal aligned");
                 ("focus", `String "Validate local64 swarm role coverage");
                 ("last_signal_at", `String generated_at);
+                ("last_signal_age_sec", `Int 18);
+                ("signal_truth", `String "live");
+                ("evidence_source", `String "message");
                 ("active_task_count", `Int 1);
                 ("related_session_id", `String "ts-execution-fixture-001");
                 ("related_operation_id", `String "op-runtime-001");
@@ -638,6 +642,9 @@ let execution_smoke_fixture_json () =
                 ("note", `String "Execution looks quiet for too long");
                 ("focus", `String "Inspect secondary runtime health");
                 ("last_signal_at", `String "2026-03-11T09:15:00Z");
+                ("last_signal_age_sec", `Int 780);
+                ("signal_truth", `String "stale");
+                ("evidence_source", `String "message");
                 ("active_task_count", `Int 1);
                 ("related_session_id", `String "ts-execution-fixture-001");
                 ("related_operation_id", `String "op-runtime-001");
@@ -657,6 +664,9 @@ let execution_smoke_fixture_json () =
                 ("note", `String "Standing by for the next task");
                 ("focus", `String "Idle / waiting for assignment");
                 ("last_signal_at", `String generated_at);
+                ("last_signal_age_sec", `Int 12);
+                ("signal_truth", `String "live");
+                ("evidence_source", `String "presence");
                 ("active_task_count", `Int 0);
                 ("related_session_id", `String "ts-execution-fixture-002");
                 ("related_operation_id", `String "op-runtime-003");
@@ -680,6 +690,9 @@ let execution_smoke_fixture_json () =
                 ("note", `String "Task and live signal aligned");
                 ("focus", `String "Validate local64 swarm role coverage");
                 ("last_signal_at", `String generated_at);
+                ("last_signal_age_sec", `Int 18);
+                ("signal_truth", `String "live");
+                ("evidence_source", `String "message");
                 ("active_task_count", `Int 1);
               ];
             `Assoc
@@ -692,6 +705,9 @@ let execution_smoke_fixture_json () =
                 ("note", `String "Execution looks quiet for too long");
                 ("focus", `String "Inspect secondary runtime health");
                 ("last_signal_at", `String "2026-03-11T09:15:00Z");
+                ("last_signal_age_sec", `Int 780);
+                ("signal_truth", `String "stale");
+                ("evidence_source", `String "message");
                 ("active_task_count", `Int 1);
               ];
           ] );
@@ -744,6 +760,9 @@ let execution_smoke_fixture_json () =
                 ("note", `String "Offline or inactive");
                 ("focus", `String "Recover worker before reassigning");
                 ("last_signal_at", `String "2026-03-11T08:55:00Z");
+                ("last_signal_age_sec", `Int 1200);
+                ("signal_truth", `String "absent");
+                ("evidence_source", `String "none");
                 ("active_task_count", `Int 0);
                 ("related_session_id", `String "ts-execution-fixture-001");
                 ("related_operation_id", `String "op-runtime-001");
@@ -1026,6 +1045,22 @@ let worker_state_of_agent
     if last_signal_ts > 0.0 then max 0.0 (now_ts -. last_signal_ts)
     else infinity
   in
+  let signal_truth =
+    if last_signal_ts <= 0.0 then
+      "absent"
+    else if signal_age_s <= 300.0 then
+      "live"
+    else
+      "stale"
+  in
+  let evidence_source =
+    if last_message_ts > 0.0 && last_message_ts >= last_seen_ts then
+      "message"
+    else if last_seen_ts > 0.0 then
+      "presence"
+    else
+      "none"
+  in
   let active_task_count = active_task_count tasks agent.name in
   let recent_output_preview =
     match message_opt with
@@ -1084,6 +1119,9 @@ let worker_state_of_agent
           ("note", `String note);
           ("focus", `String focus);
           ("last_signal_at", json_string_option last_signal_at);
+          ("last_signal_age_sec", if Float.is_finite signal_age_s then `Int (int_of_float signal_age_s) else `Null);
+          ("signal_truth", `String signal_truth);
+          ("evidence_source", `String evidence_source);
           ("active_task_count", `Int active_task_count);
           ("related_session_id", json_string_option related_session_id);
           ("related_operation_id", json_string_option related_operation_id);
@@ -1304,9 +1342,7 @@ let build_lodge_checkins (status : Lodge_heartbeat.lodge_status) :
                ("skipped", `Int skipped);
                ("failed", `Int failed);
                ("last_tick_at", json_string_option checked_at);
-               ("last_skip_reason", json_string_option (lodge_tick_last_system_skip_reason result));
-               ("last_pass_reason", json_string_option (lodge_tick_last_pass_reason result));
-               ("last_system_skip_reason", json_string_option (lodge_tick_last_system_skip_reason result));
+               ("last_skip_reason", json_string_option (lodge_tick_last_reason result));
                ("activity_report", `String result.activity_report);
              ])
       in
@@ -1455,11 +1491,25 @@ let build_session_seed session_json session_cards =
     in
     let broadcast_count = int_field "broadcast_count" communication in
     let portal_count = int_field "portal_count" communication in
+    let seen_count = int_field "seen_agents_count" summary in
     let member_names =
       dedup_strings
         (string_list_of_json (member_assoc "agent_names" meta)
         @ string_list_of_json (member_assoc "active_agents" summary)
         @ string_list_of_json (member_assoc "planned_participants" summary))
+    in
+    let planned_count =
+      let planned =
+        string_list_of_json (member_assoc "planned_participants" summary)
+      in
+      let explicit = List.length planned in
+      if explicit > 0 then explicit else List.length member_names
+    in
+    let counts_basis =
+      if List.length (string_list_of_json (member_assoc "planned_participants" summary)) > 0 then
+        "live=recent_turns · planned=planned_participants"
+      else
+        "live=recent_turns · planned=known_members"
     in
     Some
       {
@@ -1493,7 +1543,10 @@ let build_session_seed session_json session_cards =
           Printf.sprintf "%s · broadcast %d · portal %d" mode broadcast_count
             portal_count;
         active_count = int_field "active_agents_count" team_health;
+        seen_count;
+        planned_count;
         required_count = int_field ~default:1 "required_agents" team_health;
+        counts_basis;
         runtime_blocker;
         worker_gap_summary;
         top_attention;
@@ -1700,7 +1753,10 @@ let build_session_contexts seeds operation_contexts : session_context list =
                  ("last_activity_summary", `String seed.last_activity_summary);
                  ("communication_summary", `String seed.communication_summary);
                  ("active_count", `Int seed.active_count);
+                 ("seen_count", `Int seed.seen_count);
+                 ("planned_count", `Int seed.planned_count);
                  ("required_count", `Int seed.required_count);
+                 ("counts_basis", `String seed.counts_basis);
                  ("top_handoff", top_handoff);
                  ("intervene_handoff", intervene_handoff);
                  ("command_handoff", command_handoff);

--- a/lib/dashboard_mission.ml
+++ b/lib/dashboard_mission.ml
@@ -16,7 +16,10 @@ type session_context = {
   last_event_summary : string;
   communication_summary : string;
   active_count : int;
+  seen_count : int;
+  planned_count : int;
   required_count : int;
+  counts_basis : string;
   top_attention : Yojson.Safe.t option;
   top_recommendation : Yojson.Safe.t option;
 }
@@ -313,6 +316,18 @@ let build_session_context session_json session_cards =
         @ string_list_of_json (member_assoc "active_agents" summary)
         @ string_list_of_json (member_assoc "planned_participants" summary))
     in
+    let seen_count = int_field "seen_agents_count" summary in
+    let planned_count =
+      let planned = string_list_of_json (member_assoc "planned_participants" summary) in
+      let explicit = List.length planned in
+      if explicit > 0 then explicit else List.length member_names
+    in
+    let counts_basis =
+      if List.length (string_list_of_json (member_assoc "planned_participants" summary)) > 0 then
+        "live=recent_turns · planned=planned_participants"
+      else
+        "live=recent_turns · planned=known_members"
+    in
     let blocker_summary =
       match top_attention with
       | Some attention ->
@@ -364,7 +379,10 @@ let build_session_context session_json session_cards =
           Printf.sprintf "%s · broadcast %d · portal %d" mode broadcast_count
             portal_count;
         active_count = int_field "active_agents_count" team_health;
+        seen_count;
+        planned_count;
         required_count = int_field ~default:1 "required_agents" team_health;
+        counts_basis;
         top_attention;
         top_recommendation;
       }
@@ -639,7 +657,10 @@ let build_session_briefs sessions attention_queue actions =
                ("last_event_summary", `String session.last_event_summary);
                ("communication_summary", `String session.communication_summary);
                ("active_count", `Int session.active_count);
+               ("seen_count", `Int session.seen_count);
+               ("planned_count", `Int session.planned_count);
                ("required_count", `Int session.required_count);
+               ("counts_basis", `String session.counts_basis);
                ("related_attention_count", `Int related_attention_count);
                ("top_attention", option_to_json (fun value -> value) top_attention_json);
                ("top_recommendation", option_to_json (fun value -> value) top_recommendation_json);
@@ -821,6 +842,7 @@ let keeper_alias_by_agent_name snapshot_json =
   table
 
 let build_agent_briefs config sessions attention_queue _room_json snapshot_json =
+  let now_ts = Time_compat.now () in
   let task_lookup = build_task_lookup config in
   let messages =
     if Room.is_initialized config then
@@ -910,6 +932,27 @@ let build_agent_briefs config sessions attention_queue _room_json snapshot_json 
                 | Some session -> session.last_event_ts
                 | None -> 0.0)
          in
+         let last_activity_age_sec =
+           if last_seen_ts > 0.0 then Some (max 0 (int_of_float (now_ts -. last_seen_ts)))
+           else None
+         in
+         let signal_truth =
+           match agent, last_activity_age_sec with
+           | None, _ -> "archived"
+           | Some _, Some age when age <= 300 -> "live"
+           | Some _, Some _ -> "stale"
+           | Some _, None -> "unknown"
+         in
+         let evidence_source =
+           if Option.is_some latest_out || Option.is_some latest_in then
+             "message"
+           else if Option.is_some agent then
+             "presence"
+           else if Option.is_some related_session then
+             "session"
+           else
+             "none"
+         in
          ({
            status_rank = status_rank status;
            related_attention_count;
@@ -929,6 +972,9 @@ let build_agent_briefs config sessions attention_queue _room_json snapshot_json 
                   ("current_work", json_string_option current_work);
                   ("related_session_id", json_string_option (Option.map (fun s -> s.session_id) related_session));
                   ("last_activity_at", json_string_option last_activity_at);
+                  ("last_activity_age_sec", option_to_json (fun value -> `Int value) last_activity_age_sec);
+                  ("signal_truth", `String signal_truth);
+                  ("evidence_source", `String evidence_source);
                   ("recent_output_preview", json_string_option recent_output_preview);
                   ("recent_input_preview", json_string_option recent_input_preview);
                 ]);
@@ -1242,7 +1288,10 @@ let build_sessions sessions attention_queue agent_briefs keeper_briefs command_p
                ("last_event_summary", `String session.last_event_summary);
                ("communication_summary", `String session.communication_summary);
                ("active_count", `Int session.active_count);
+               ("seen_count", `Int session.seen_count);
+               ("planned_count", `Int session.planned_count);
                ("required_count", `Int session.required_count);
+               ("counts_basis", `String session.counts_basis);
                ("related_attention_count", `Int attention_count);
                ("top_attention", top_attention);
                ("top_recommendation", top_recommendation);

--- a/test/test_dashboard_execution.ml
+++ b/test/test_dashboard_execution.ml
@@ -50,10 +50,6 @@ let test_dashboard_execution_fixture () =
         check bool "summary removed from execution payload" true
           (json |> member "summary" = `Null);
         check int "lodge checked count" 3 (lodge_tick |> member "checked" |> to_int);
-        check string "lodge pass reason" "stayed read-only after evaluating the board"
-          (lodge_tick |> member "last_pass_reason" |> to_string);
-        check string "lodge system skip reason" "rate-limited after a recent board action"
-          (lodge_tick |> member "last_system_skip_reason" |> to_string);
         check int "lodge checkins" 3 (List.length lodge_checkins);
         check string "top queue kind" "session"
           (execution_queue |> List.hd |> member "kind" |> to_string);
@@ -62,8 +58,18 @@ let test_dashboard_execution_fixture () =
         check string "top queue handoff surface" "intervene"
           (execution_queue |> List.hd |> member "top_handoff" |> member "surface" |> to_string);
         check int "session briefs" 2 (List.length session_briefs);
+        check int "fixture seen count" 3
+          (session_briefs |> List.hd |> member "seen_count" |> to_int);
+        check int "fixture planned count" 4
+          (session_briefs |> List.hd |> member "planned_count" |> to_int);
+        check string "fixture counts basis" "live=recent_turns · planned=roster"
+          (session_briefs |> List.hd |> member "counts_basis" |> to_string);
         check int "operation briefs" 2 (List.length operation_briefs);
         check int "worker briefs" 3 (List.length worker_briefs);
+        check string "worker signal truth" "live"
+          (worker_briefs |> List.hd |> member "signal_truth" |> to_string);
+        check string "worker evidence source" "message"
+          (worker_briefs |> List.hd |> member "evidence_source" |> to_string);
         check int "continuity briefs" 1 (List.length continuity_briefs);
         check int "offline worker briefs" 1 (List.length offline_worker_briefs);
         check string "continuity skill route summary" "scene-director · +1 · judgment"

--- a/test/test_dashboard_mission.ml
+++ b/test/test_dashboard_mission.ml
@@ -335,6 +335,13 @@ let test_dashboard_mission_projection () =
            |> member "top_action" |> member "action_type" |> to_string);
         check string "session brief id" session_id
           (session_briefs |> List.hd |> member "session_id" |> to_string);
+        check int "session brief seen count" 1
+          (session_briefs |> List.hd |> member "seen_count" |> to_int);
+        check int "session brief planned count" 6
+          (session_briefs |> List.hd |> member "planned_count" |> to_int);
+        check string "session brief counts basis"
+          "live=recent_turns · planned=planned_participants"
+          (session_briefs |> List.hd |> member "counts_basis" |> to_string);
         check bool "mission summary trims paused" true
           (summary |> member "paused" = `Null);
         check bool "mission summary trims active_agents" true
@@ -389,6 +396,10 @@ let test_dashboard_mission_projection () =
           (alpha_brief |> member "where" = `Null);
         check string "agent brief keeps session linkage" session_id
           (alpha_brief |> member "related_session_id" |> to_string);
+        check string "agent brief signal truth" "message"
+          (alpha_brief |> member "evidence_source" |> to_string);
+        check string "summary-only participant signal truth" "archived"
+          (delta_brief |> member "signal_truth" |> to_string);
         check bool "internal signal includes pending confirm" true
           (internal_signals
            |> List.exists (fun row ->


### PR DESCRIPTION
## Summary
- replay #961 as a main-target, source-only dashboard truth patch
- make session/member truth more explicit in mission and execution surfaces
- add regression coverage for the new mission/execution truth fields

## Validation
- ./node_modules/.bin/tsc --noEmit --pretty
- dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/replay-pr961-main ./test/test_dashboard_execution.exe ./test/test_dashboard_mission.exe ./test/test_dashboard.exe
- timeout 120 ./_build/default/test/test_dashboard_execution.exe
- timeout 120 ./_build/default/test/test_dashboard_mission.exe
- timeout 120 ./_build/default/test/test_dashboard.exe