### PR TITLE
refactor(mcp): prune dead hidden tool surfaces

### DIFF
--- a/docs/MCP-SURFACE-AUDIT.md
+++ b/docs/MCP-SURFACE-AUDIT.md
@@ -154,10 +154,10 @@ flowchart TD
 
 | Type | Examples | Status |
 |------|----------|--------|
-| Intentional compatibility | `masc_claim`, `masc_dispatch_route`, `experiment_start`, `masc_trpg_*` | Hidden aliases; keep if compatibility matters |
+| Intentional compatibility | `masc_claim`, `experiment_start`, `masc_trpg_*` | Hidden aliases; keep if compatibility matters |
 | Intentional internal-only | `Prompt_registry`, `data/prompts/*.json` | Real runtime feature, not public MCP surface |
 | Experimental but documented | `SWARM-RISC`, `GAME-VIEW-PROTOCOL` draft | Keep clearly labeled as non-canonical or draft |
-| Placeholder / review-needed | `masc_archive_save` | Hidden placeholder, not truthful default surface |
+| Placeholder / review-needed | none | Dead hidden placeholder removed from the MCP schema inventory |
 | Documentation orphan | old count claims, old module lists, stale “full spec” prose | Should be downgraded to historical or refreshed |
 
 ## Requirements Coverage

--- a/lib/auth.ml
+++ b/lib/auth.ml
@@ -239,7 +239,7 @@ let permission_for_tool = function
   | "masc_runtime_verify" | "masc_llama_runtime_verify"
   | "masc_llama_runtime_bench"
   | "masc_unit_list" | "masc_operation_status"
-  | "masc_policy_status" | "masc_dispatch_plan" | "masc_dispatch_route"
+  | "masc_policy_status" | "masc_dispatch_plan"
   | "masc_observe_topology" | "masc_observe_operations"
   | "masc_observe_swarm" | "masc_observe_capacity" | "masc_observe_alerts"
   | "masc_observe_traces"

--- a/lib/mode.ml
+++ b/lib/mode.ml
@@ -161,7 +161,7 @@ let tool_category tool_name =
   | "masc_operation_resume" | "masc_operation_stop"
   | "masc_operation_finalize"
   (* Dispatch *)
-  | "masc_dispatch_plan" | "masc_dispatch_route"
+  | "masc_dispatch_plan"
   | "masc_dispatch_assign" | "masc_dispatch_rebalance"
   | "masc_dispatch_escalate" | "masc_dispatch_recall"
   | "masc_dispatch_tick"
@@ -400,7 +400,6 @@ let tool_category tool_name =
   | "masc_risc_metrics" | "masc_risc_ooo_metrics" -> RISC
 
   (* ── Deprecated/archived tools (hidden via tool_catalog, excluded from presets) ── *)
-  | "masc_archive_save" -> Unknown
 
   (* ── Prefix-based fallbacks for legacy dot-separated names ── *)
   | _ when String.starts_with ~prefix:"lodge_" tool_name -> Comm

--- a/lib/tool_catalog.ml
+++ b/lib/tool_catalog.ml
@@ -69,22 +69,6 @@ let hidden_active ?canonical_name ?replacement ?(allow_direct_call_when_hidden =
 
 let explicit_metadata : (string * metadata) list =
   [
-    ( "masc_archive_save",
-      {
-        visibility = Hidden;
-        lifecycle = Active;
-        implementation_status = Placeholder;
-        canonical_name = None;
-        replacement = None;
-        reason =
-          Some
-            "Placeholder only: requires Eio server context for persistence and is not part of the truthful default tool surface.";
-        allow_direct_call_when_hidden = false;
-      } );
-    ( "masc_dispatch_route",
-      deprecated ~canonical_name:"masc_dispatch_plan"
-        ~replacement:"masc_dispatch_plan"
-        "Alias retained for compatibility; use masc_dispatch_plan." );
     ( "masc_post_create",
       hidden_active
         "Low-usage social feed utility hidden from the default tool list; board tools are the primary collaborative surface." );

--- a/lib/tool_command_plane_dispatch.ml
+++ b/lib/tool_command_plane_dispatch.ml
@@ -24,7 +24,6 @@ let dispatch (ctx : (_, _) context) ~name ~args : result option =
   | "masc_chain_snapshot" -> Some (handle_chain_snapshot ctx)
   | "masc_chain_run_get" -> Some (handle_chain_run_get ctx args)
   | "masc_dispatch_plan" -> Some (handle_dispatch_plan ctx args)
-  | "masc_dispatch_route" -> Some (handle_dispatch_route ctx args)
   | "masc_dispatch_assign" -> Some (handle_dispatch_assign ctx args)
   | "masc_dispatch_rebalance" -> Some (handle_dispatch_rebalance ctx args)
   | "masc_dispatch_escalate" -> Some (handle_dispatch_escalate ctx args)

--- a/lib/tool_command_plane_schemas_01.ml
+++ b/lib/tool_command_plane_schemas_01.ml
@@ -226,17 +226,6 @@ let schemas : tool_schema list = [
           ];
     };
     {
-      name = "masc_dispatch_route";
-      description =
-        "Alias for masc_dispatch_plan. Return recommended route candidates for large-scale hierarchy dispatch.";
-      input_schema =
-        object_schema
-          [
-            ("operation_id", string_prop "Optional operation id to route.");
-            ("assigned_unit_id", string_prop "Optional current unit id.");
-          ];
-    };
-    {
       name = "masc_dispatch_assign";
       description =
         "Assign or move an operation to a new unit. Cross-platoon or strict-policy moves become pending approvals.";

--- a/lib/tool_schemas_room.ml
+++ b/lib/tool_schemas_room.ml
@@ -744,30 +744,6 @@ Example: masc_deliver({task_id: 'task-001', content: 'PR: github.com/org/repo/pu
     ];
   };
   {
-    name = "masc_archive_save";
-    description = "Save a record to the archive (실록). Records debates, votes, and decisions.";
-    input_schema = `Assoc [
-      ("type", `String "object");
-      ("properties", `Assoc [
-        ("type", `Assoc [
-          ("type", `String "string");
-          ("enum", `List [`String "debate"; `String "vote"; `String "decision"; `String "post"]);
-          ("description", `String "Record type");
-        ]);
-        ("content", `Assoc [
-          ("type", `String "string");
-          ("description", `String "Record content");
-        ]);
-        ("agents", `Assoc [
-          ("type", `String "array");
-          ("items", `Assoc [("type", `String "string")]);
-          ("description", `String "Participating agents");
-        ]);
-      ]);
-      ("required", `List [`String "content"]);
-    ];
-  };
-  {
     name = "masc_interrupt";
     description = "Pause workflow and wait for user approval (LangGraph interrupt pattern). Use before dangerous operations like database deletion, production changes, or external API calls. The workflow will be suspended until approved or rejected.";
     input_schema = `Assoc [

--- a/lib/tools_schemas_04.ml
+++ b/lib/tools_schemas_04.ml
@@ -211,31 +211,6 @@ Matches topic pattern (e.g., 'Merge PR #123') and runs corresponding action.";
     ];
   };
 
-  {
-    name = "masc_archive_save";
-    description = "Save a record to the archive (실록). Records debates, votes, and decisions.";
-    input_schema = `Assoc [
-      ("type", `String "object");
-      ("properties", `Assoc [
-        ("type", `Assoc [
-          ("type", `String "string");
-          ("enum", `List [`String "debate"; `String "vote"; `String "decision"; `String "post"]);
-          ("description", `String "Record type");
-        ]);
-        ("content", `Assoc [
-          ("type", `String "string");
-          ("description", `String "Record content");
-        ]);
-        ("agents", `Assoc [
-          ("type", `String "array");
-          ("items", `Assoc [("type", `String "string")]);
-          ("description", `String "Participating agents");
-        ]);
-      ]);
-      ("required", `List [`String "content"]);
-    ];
-  };
-
   (* ============================================ *)
   (* Social Features (Moltbook-style)             *)
   (* ============================================ *)

--- a/test/test_mcp_server_eio.ml
+++ b/test/test_mcp_server_eio.ml
@@ -451,10 +451,6 @@ let test_handle_request_tools_list () =
     false
     (List.mem "masc_claim" names);
   Alcotest.(check bool)
-    "superseded masc_dispatch_route hidden from list"
-    false
-    (List.mem "masc_dispatch_route" names);
-  Alcotest.(check bool)
     "low-usage social tool hidden from list"
     false
     (List.mem "masc_post_create" names);
@@ -462,10 +458,6 @@ let test_handle_request_tools_list () =
     "low-usage vote utility hidden from list"
     false
     (List.mem "masc_vote_create" names);
-  Alcotest.(check bool)
-    "placeholder tool hidden by default"
-    false
-    (List.mem "masc_archive_save" names);
   Alcotest.(check bool) "first page non-empty" true (names <> []);
   Alcotest.(check bool) "first page exposes next cursor" true
     (Option.is_some (next_cursor_of_response first_page));
@@ -840,8 +832,8 @@ let test_handle_request_tools_list_with_placeholder_flag () =
       |> List.filter_map (function `String s -> Some s | _ -> None)
     in
     Alcotest.(check bool)
-      "placeholder tool visible with flag"
-      true
+      "placeholder tool removed even with flag"
+      false
       (List.mem "masc_archive_save" names);
 
     cleanup_dir base_path)

--- a/test/test_tool_contract_truth.ml
+++ b/test/test_tool_contract_truth.ml
@@ -94,8 +94,6 @@ let test_hidden_tools_report_contract_status () =
         tools_list_response ~clock ~sw ~include_hidden:true
           ~names:
             [
-              "masc_archive_save";
-              "masc_dispatch_route";
               "masc_dispatch_plan";
               "masc_transition";
               "masc_runtime_verify";
@@ -104,14 +102,6 @@ let test_hidden_tools_report_contract_status () =
           state
         |> response_tools
       in
-      let placeholder = find_tool_exn tools "masc_archive_save" in
-      check string "archive_save placeholder" "placeholder"
-        (tool_string_field placeholder "implementationStatus");
-      let alias = find_tool_exn tools "masc_dispatch_route" in
-      check string "dispatch_route adapter" "adapter"
-        (tool_string_field alias "implementationStatus");
-      check string "dispatch_route canonical" "masc_dispatch_plan"
-        (tool_string_field alias "canonicalName");
       let dispatch_plan = find_tool_exn tools "masc_dispatch_plan" in
       check string "dispatch_plan real" "real"
         (tool_string_field dispatch_plan "implementationStatus");

--- a/test/test_tool_tier.ml
+++ b/test/test_tool_tier.ml
@@ -165,16 +165,5 @@ let () =
                 (List.assoc_opt "visibility" fields = None);
               check bool "lifecycle omitted" true
                 (List.assoc_opt "lifecycle" fields = None));
-          test_case "public contract keeps canonical alias" `Quick (fun () ->
-              let fields =
-                Tool_catalog.public_contract_fields "masc_dispatch_route"
-              in
-              let canonical_val =
-                List.assoc_opt "canonicalName" fields
-                |> Option.map (function `String s -> s | _ -> "")
-                |> Option.value ~default:""
-              in
-              check string "canonical field" "masc_dispatch_plan"
-                canonical_val);
         ] );
     ]


### PR DESCRIPTION
## Summary
- remove two dead hidden MCP surfaces: placeholder  and deprecated alias 
- keep full mode as the default room behavior and verify it with config/mode contract coverage
- leave live hidden_active/compatibility surfaces intact

## Notes
-  was already the code default in ; this PR hardens the contract by re-running and keeping the relevant config/mode tests green rather than changing the mode policy.
- sentinel noise reduction stays in #971 and was not mixed into this PR.

## Validation
- dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix-full-default-safe-prune ./bin/main_eio.exe ./test/test_config_coverage.exe ./test/test_mode_tool_count.exe ./test/test_tool_contract_truth.exe ./test/test_mcp_server_eio.exe ./test/test_tool_tier.exe
- timeout 120 ./_build/default/test/test_config_coverage.exe
- timeout 120 ./_build/default/test/test_mode_tool_count.exe
- timeout 120 ./_build/default/test/test_tool_contract_truth.exe
- timeout 120 ./_build/default/test/test_tool_tier.exe
- timeout 120 ./_build/default/test/test_mcp_server_eio.exe