### PR TITLE
fix(mcp): widen wire compatibility for HTTP clients

### DIFF
--- a/lib/server_h2_gateway.ml
+++ b/lib/server_h2_gateway.ml
@@ -259,21 +259,25 @@ let make_request_handler ~sw ~clock ~server_start_time =
                      | Error msg ->
                          let body = Printf.sprintf {|{"jsonrpc":"2.0","error":{"code":-32001,"message":"%s"}}|} msg in
                          h2_respond_json h2_reqd body ~status:`Unauthorized ~extra_headers:(("www-authenticate", "Bearer") :: cors)
-                     | Ok _cred_opt -> (
-                         match classify_mcp_accept httpun_request with
-                         | Http_negotiation.Rejected ->
-                             let body =
-                               json_rpc_error (-32600)
-                                 "Invalid Accept header: must include application/json and text/event-stream. \
-                                  Set MASC_ALLOW_LEGACY_ACCEPT=1 for temporary compatibility."
+                     | Ok _cred_opt ->
+                         h2_read_body h2_reqd (fun body_str ->
+                             let accept_mode =
+                               Server_mcp_transport_http_headers
+                               .classify_mcp_accept_for_body httpun_request body_str
                              in
-                             h2_respond_json h2_reqd body ~status:`Bad_request
-                               ~extra_headers:(cors @ mcp_headers session_id protocol_version)
-                         | accept_mode ->
-                             let accept_warn_headers =
-                               legacy_accept_warning_headers accept_mode
-                             in
-                             h2_read_body h2_reqd (fun body_str ->
+                             match accept_mode with
+                             | Http_negotiation.Rejected ->
+                                 let body =
+                                   json_rpc_error (-32600)
+                                     "Invalid Accept header: must include application/json and text/event-stream. \
+                                      Set MASC_ALLOW_LEGACY_ACCEPT=1 for temporary compatibility."
+                                 in
+                                 h2_respond_json h2_reqd body ~status:`Bad_request
+                                   ~extra_headers:(cors @ mcp_headers session_id protocol_version)
+                             | accept_mode ->
+                                 let accept_warn_headers =
+                                   legacy_accept_warning_headers accept_mode
+                                 in
                                  let state = get_server_state ()
                                  in
                                  let response_json =
@@ -301,7 +305,7 @@ let make_request_handler ~sw ~clock ~server_start_time =
                                        ~extra_headers:mcp_hdrs
                                  | json ->
                                      let body = Yojson.Safe.to_string json in
-                                     h2_respond_json h2_reqd body ~extra_headers:mcp_hdrs)))))
+                                     h2_respond_json h2_reqd body ~extra_headers:mcp_hdrs))))
 
       | `DELETE, "/mcp" | `DELETE, "/mcp/managed" | `DELETE, "/mcp/operator" ->
           let profile =

--- a/lib/server_mcp_transport_http.ml
+++ b/lib/server_mcp_transport_http.ml
@@ -182,11 +182,7 @@ let validate_protocol_version_continuity ~session_id request =
   | Some expected -> (
       let ( let* ) = Result.bind in
       match provided with
-      | None ->
-          Error
-            (Printf.sprintf
-               "MCP-Protocol-Version header required for existing session %s (expected %s)."
-               session_id expected)
+      | None -> Ok ()
       | Some version ->
           let* () = validate_supported version in
           if String.equal version expected then
@@ -261,6 +257,10 @@ let allow_legacy_accept = env_flag "MASC_ALLOW_LEGACY_ACCEPT"
 let classify_mcp_accept (request : Httpun.Request.t) =
   Http_negotiation.classify_mcp_accept ~allow_legacy:allow_legacy_accept
     (Httpun.Headers.get request.headers "accept")
+
+let classify_mcp_accept_for_body request body_str =
+  Server_mcp_transport_http_headers.classify_mcp_accept_for_body request
+    body_str
 
 let legacy_accept_warning_headers = function
   | Http_negotiation.Legacy_accepted ->
@@ -589,35 +589,39 @@ let handle_post_mcp ~deps ?(profile = Mcp_eio.Full) request reqd =
               respond_mcp_auth_error ~deps request reqd ~session_id
                 ~protocol_version msg
           | Ok () ->
-              match classify_mcp_accept request with
-              | Http_negotiation.Rejected ->
-                  let body =
-                    Yojson.Safe.to_string
-                      (`Assoc
-                        [
-                          ("jsonrpc", `String "2.0");
-                          ( "error",
-                            `Assoc
-                              [
-                                ("code", `Int (-32600));
-                                ( "message",
-                                  `String
-                                    "Invalid Accept header: must include application/json and text/event-stream. Set MASC_ALLOW_LEGACY_ACCEPT=1 for temporary compatibility." );
-                              ] );
-                        ])
+              Http.Request.read_body_async reqd (fun body_str ->
+                  let accept_mode =
+                    Server_mcp_transport_http_headers.classify_mcp_accept_for_body
+                      request body_str
                   in
-                  let headers =
-                    Httpun.Headers.of_list
-                      (("content-length", string_of_int (String.length body))
-                      :: json_headers ~deps session_id protocol_version origin)
-                  in
-                  let response = Httpun.Response.create ~headers `Bad_request in
-                  Httpun.Reqd.respond_with_string reqd response body
-              | accept_mode ->
-                  let accept_warn_headers =
-                    legacy_accept_warning_headers accept_mode
-                  in
-                  Http.Request.read_body_async reqd (fun body_str ->
+                  match accept_mode with
+                  | Http_negotiation.Rejected ->
+                      let body =
+                        Yojson.Safe.to_string
+                          (`Assoc
+                            [
+                              ("jsonrpc", `String "2.0");
+                              ( "error",
+                                `Assoc
+                                  [
+                                    ("code", `Int (-32600));
+                                    ( "message",
+                                      `String
+                                        "Invalid Accept header: must include application/json and text/event-stream. Set MASC_ALLOW_LEGACY_ACCEPT=1 for temporary compatibility." );
+                                  ] );
+                            ])
+                      in
+                      let headers =
+                        Httpun.Headers.of_list
+                          (("content-length", string_of_int (String.length body))
+                          :: json_headers ~deps session_id protocol_version origin)
+                      in
+                      let response = Httpun.Response.create ~headers `Bad_request in
+                      Httpun.Reqd.respond_with_string reqd response body
+                  | accept_mode ->
+                      let accept_warn_headers =
+                        legacy_accept_warning_headers accept_mode
+                      in
                       try
                         match request_runtime_result deps with
                         | Error msg ->
@@ -635,8 +639,9 @@ let handle_post_mcp ~deps ?(profile = Mcp_eio.Full) request reqd =
                               get_protocol_version_for_session ~session_id request
                             in
                             let wants_sse =
-                              Http_negotiation.accepts_sse_header
-                                (Httpun.Headers.get request.headers "accept")
+                              accept_mode = Http_negotiation.Streamable
+                              && Http_negotiation.accepts_sse_header
+                                   (Httpun.Headers.get request.headers "accept")
                               && not force_json_response
                               && not (request_force_json_response request)
                             in

--- a/lib/server_mcp_transport_http.mli
+++ b/lib/server_mcp_transport_http.mli
@@ -36,6 +36,8 @@ val request_force_json_response : Httpun.Request.t -> bool
 val allow_legacy_accept : bool
 val classify_mcp_accept :
   Httpun.Request.t -> Mcp_protocol.Http_negotiation.accept_mode
+val classify_mcp_accept_for_body :
+  Httpun.Request.t -> string -> Mcp_protocol.Http_negotiation.accept_mode
 val legacy_accept_warning_headers :
   Mcp_protocol.Http_negotiation.accept_mode -> (string * string) list
 val legacy_transport_deprecation_headers : (string * string) list

--- a/lib/server_mcp_transport_http_headers.ml
+++ b/lib/server_mcp_transport_http_headers.ml
@@ -55,6 +55,32 @@ let classify_mcp_accept (request : Httpun.Request.t) =
   Http_negotiation.classify_mcp_accept ~allow_legacy:allow_legacy_accept
     (Httpun.Headers.get request.headers "accept")
 
+let body_notification_method body_str =
+  try
+    match Yojson.Safe.from_string body_str with
+    | `Assoc fields -> (
+        match List.assoc_opt "method" fields with
+        | Some (`String method_) when not (List.mem_assoc "id" fields) ->
+            Some method_
+        | _ -> None)
+    | _ -> None
+  with Yojson.Json_error _ -> None
+
+let is_notification_method method_ =
+  let prefix = "notifications/" in
+  let prefix_len = String.length prefix in
+  String.length method_ >= prefix_len
+  && String.sub method_ 0 prefix_len = prefix
+
+let classify_mcp_accept_for_body request body_str =
+  match classify_mcp_accept request with
+  | Http_negotiation.Rejected -> (
+      match body_notification_method body_str with
+      | Some method_ when is_notification_method method_ ->
+          Http_negotiation.Legacy_accepted
+      | _ -> Http_negotiation.Rejected)
+  | accept_mode -> accept_mode
+
 let legacy_accept_warning_headers = function
   | Http_negotiation.Legacy_accepted ->
       [

--- a/lib/server_mcp_transport_http_mcp_handlers.ml
+++ b/lib/server_mcp_transport_http_mcp_handlers.ml
@@ -72,38 +72,42 @@ let handle_post_mcp ~(deps : deps) ?(profile = Mcp_eio.Full) request reqd =
           | Error msg ->
               Server_mcp_transport_http_headers.respond_mcp_auth_error ~deps
                 request reqd ~session_id ~protocol_version msg
-          | Ok () -> (
-              match Server_mcp_transport_http_headers.classify_mcp_accept request with
-              | Http_negotiation.Rejected ->
-                  let body =
-                    Yojson.Safe.to_string
-                      (`Assoc
-                        [
-                          ("jsonrpc", `String "2.0");
-                          ( "error",
-                            `Assoc
-                              [
-                                ("code", `Int (-32600));
-                                ( "message",
-                                  `String
-                                    "Invalid Accept header: must include application/json and text/event-stream. Set MASC_ALLOW_LEGACY_ACCEPT=1 for temporary compatibility." );
-                              ] );
-                        ])
+          | Ok () ->
+              Http.Request.read_body_async reqd (fun body_str ->
+                  let accept_mode =
+                    Server_mcp_transport_http_headers.classify_mcp_accept_for_body
+                      request body_str
                   in
-                  let headers =
-                    Httpun.Headers.of_list
-                      (("content-length", string_of_int (String.length body))
-                      :: Server_mcp_transport_http_headers.json_headers ~deps
-                           session_id protocol_version origin)
-                  in
-                  let response = Httpun.Response.create ~headers `Bad_request in
-                  Httpun.Reqd.respond_with_string reqd response body
-              | accept_mode ->
-                  let accept_warn_headers =
-                    Server_mcp_transport_http_headers.legacy_accept_warning_headers
-                      accept_mode
-                  in
-                  Http.Request.read_body_async reqd (fun body_str ->
+                  match accept_mode with
+                  | Http_negotiation.Rejected ->
+                      let body =
+                        Yojson.Safe.to_string
+                          (`Assoc
+                            [
+                              ("jsonrpc", `String "2.0");
+                              ( "error",
+                                `Assoc
+                                  [
+                                    ("code", `Int (-32600));
+                                    ( "message",
+                                      `String
+                                        "Invalid Accept header: must include application/json and text/event-stream. Set MASC_ALLOW_LEGACY_ACCEPT=1 for temporary compatibility." );
+                                  ] );
+                            ])
+                      in
+                      let headers =
+                        Httpun.Headers.of_list
+                          (("content-length", string_of_int (String.length body))
+                          :: Server_mcp_transport_http_headers.json_headers
+                               ~deps session_id protocol_version origin)
+                      in
+                      let response = Httpun.Response.create ~headers `Bad_request in
+                      Httpun.Reqd.respond_with_string reqd response body
+                  | accept_mode ->
+                      let accept_warn_headers =
+                        Server_mcp_transport_http_headers.legacy_accept_warning_headers
+                          accept_mode
+                      in
                       try
                         match
                           Server_mcp_transport_http_headers.request_runtime_result
@@ -133,8 +137,9 @@ let handle_post_mcp ~(deps : deps) ?(profile = Mcp_eio.Full) request reqd =
                                 request
                             in
                             let wants_sse =
-                              Http_negotiation.accepts_sse_header
-                                (Httpun.Headers.get request.headers "accept")
+                              accept_mode = Http_negotiation.Streamable
+                              && Http_negotiation.accepts_sse_header
+                                   (Httpun.Headers.get request.headers "accept")
                               && not
                                    Server_mcp_transport_http_headers
                                    .force_json_response
@@ -225,7 +230,7 @@ let handle_post_mcp ~(deps : deps) ?(profile = Mcp_eio.Full) request reqd =
                         in
                         Server_mcp_transport_http_headers.respond_mcp_internal_error
                           ~deps request reqd ~session_id ~protocol_version
-                          ("Internal error: " ^ Printexc.to_string exn)))))
+                          ("Internal error: " ^ Printexc.to_string exn))))
 
 let handle_get_mcp ~(deps : deps) ?legacy_messages_endpoint
     ?(profile = Mcp_eio.Full)

--- a/lib/server_mcp_transport_http_session.ml
+++ b/lib/server_mcp_transport_http_session.ml
@@ -168,11 +168,7 @@ let validate_protocol_version_continuity ~session_id request =
   | Some expected -> (
       let ( let* ) = Result.bind in
       match provided with
-      | None ->
-          Error
-            (Printf.sprintf
-               "MCP-Protocol-Version header required for existing session %s (expected %s)."
-               session_id expected)
+      | None -> Ok ()
       | Some version ->
           let* () = validate_supported version in
           if String.equal version expected then

--- a/test/test_http_negotiation.ml
+++ b/test/test_http_negotiation.ml
@@ -49,10 +49,75 @@ let test_classify_mcp_accept () =
     (classify_mcp_accept ~allow_legacy:false (Some "text/event-stream"));
   ()
 
+let test_protocol_continuity_allows_missing_header () =
+  let module Session = Masc_mcp.Server_mcp_transport_http in
+  let session_id = "compat-session-missing-header" in
+  let headers = Httpun.Headers.of_list [] in
+  let request = Httpun.Request.create ~headers `POST "/mcp" in
+  Session.remember_protocol_version session_id "2025-11-25";
+  Fun.protect
+    ~finally:(fun () -> Session.forget_mcp_session session_id)
+    (fun () ->
+      match Session.validate_protocol_version_continuity ~session_id request with
+      | Ok () -> ()
+      | Error msg -> failf "expected missing protocol header to be accepted, got %s" msg)
+
+let test_protocol_continuity_rejects_mismatch () =
+  let module Session = Masc_mcp.Server_mcp_transport_http in
+  let session_id = "compat-session-mismatch" in
+  let headers =
+    Httpun.Headers.of_list [("mcp-protocol-version", "2025-03-26")]
+  in
+  let request = Httpun.Request.create ~headers `POST "/mcp" in
+  Session.remember_protocol_version session_id "2025-11-25";
+  Fun.protect
+    ~finally:(fun () -> Session.forget_mcp_session session_id)
+    (fun () ->
+      match Session.validate_protocol_version_continuity ~session_id request with
+      | Ok () -> fail "expected mismatched protocol version to be rejected"
+      | Error msg ->
+          check bool "mentions mismatch" true
+            (String.length msg > 0
+            && String.contains msg ':'))
+
+let test_notification_body_relaxes_accept () =
+  let module Transport = Masc_mcp.Server_mcp_transport_http in
+  let headers = Httpun.Headers.of_list [("accept", "application/json")] in
+  let request = Httpun.Request.create ~headers `POST "/mcp" in
+  let body =
+    {|{"jsonrpc":"2.0","method":"notifications/initialized","params":{}}|}
+  in
+  let mode = Transport.classify_mcp_accept_for_body request body in
+  check bool "notification legacy accepted" true
+    (match mode with
+    | Masc_mcp.Mcp_protocol.Http_negotiation.Legacy_accepted -> true
+    | _ -> false)
+
+let test_request_body_stays_strict () =
+  let module Transport = Masc_mcp.Server_mcp_transport_http in
+  let headers = Httpun.Headers.of_list [("accept", "application/json")] in
+  let request = Httpun.Request.create ~headers `POST "/mcp" in
+  let body =
+    {|{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"test","version":"0.1"}}}|}
+  in
+  let mode = Transport.classify_mcp_accept_for_body request body in
+  check bool "request still rejected" true
+    (match mode with
+    | Masc_mcp.Mcp_protocol.Http_negotiation.Rejected -> true
+    | _ -> false)
+
 let () =
   run "http_negotiation"
     [
       ("accepts_sse_header", [test_case "parses Accept" `Quick test_accepts_sse_header]);
       ("accepts_streamable_mcp", [test_case "requires json+sse" `Quick test_accepts_streamable_mcp]);
       ("classify_mcp_accept", [test_case "strict vs legacy fallback" `Quick test_classify_mcp_accept]);
+      ("protocol_continuity", [
+        test_case "missing header falls back to session" `Quick test_protocol_continuity_allows_missing_header;
+        test_case "mismatch still rejects" `Quick test_protocol_continuity_rejects_mismatch;
+      ]);
+      ("body_aware_accept", [
+        test_case "notification relaxes accept" `Quick test_notification_body_relaxes_accept;
+        test_case "request remains strict" `Quick test_request_body_stays_strict;
+      ]);
     ]


### PR DESCRIPTION
## Summary
- relax per-session protocol continuity so existing sessions can omit  and keep using the negotiated version
- make POST  Accept handling body-aware so notification flows can use legacy-ish JSON-only clients while initialize/request flows stay strict
- keep mismatch handling strict and add targeted coverage for the widened compatibility window

## Validation
- 
- Testing `[1mhttp_negotiation[0m'.
[2mThis run has ID `BXXWF5KV'.

[0m  [32m[OK][0m          [36maccepts_sse_header[0m              0   parses Accept.
  [32m[OK][0m          [36maccepts_streamable_mcp[0m          0   requires json+sse.
  [32m[OK][0m          [36mclassify_mcp_accept[0m             0   strict vs legacy fallback.
  [32m[OK][0m          [36mprotocol_continuity[0m             0   missing header falls back...
  [32m[OK][0m          [36mprotocol_continuity[0m             1   mismatch still rejects.
  [32m[OK][0m          [36mbody_aware_accept[0m               0   notification relaxes accept.
  [32m[OK][0m          [36mbody_aware_accept[0m               1   request remains strict.

Full test results in `[36m~/me/_build/_tests/http_negotiation[0m'.
[32mTest Successful[0m in 0.001s. 7 tests run.
