### PR TITLE
docs: align versioned roadmap with feature trains

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,0 +1,68 @@
+name: Bug report
+description: Report a broken behavior, regression, or incorrect result.
+title: "[Bug] "
+labels:
+  - "type:bug"
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this for behavior that is broken, incorrect, or regressed.
+        Human reporters, Codex, and internal agents may all file this form.
+        Add exactly one `target:*` label after triage.
+  - type: input
+    id: version
+    attributes:
+      label: Observed version
+      description: "Example: v2.86.0, main HEAD, local branch"
+      placeholder: v2.86.0
+    validations:
+      required: true
+  - type: dropdown
+    id: severity
+    attributes:
+      label: Severity
+      options:
+        - blocks release or data safety
+        - major workflow broken
+        - moderate incorrect behavior
+        - minor but real bug
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      placeholder: |
+        1. Run ...
+        2. Open ...
+        3. Observe ...
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+    validations:
+      required: true
+  - type: textarea
+    id: evidence
+    attributes:
+      label: Evidence
+      description: Logs, screenshots, run IDs, failing command, or artifact path
+      placeholder: Attach the smallest concrete proof you have.
+    validations:
+      required: false
+  - type: textarea
+    id: notes
+    attributes:
+      label: Scope notes
+      description: Say whether this looks like a regression, one-off, or repeat issue.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Versioned roadmap
+    url: https://github.com/jeong-sik/masc-mcp/blob/main/docs/VERSIONED-ROADMAP.md
+    about: Check the active feature train and target versioning rules before filing.

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,0 +1,40 @@
+name: Feature request
+description: Propose a new capability, workflow, or public surface.
+title: "[Feature] "
+labels:
+  - "type:feature"
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this for net-new capability work.
+        Human reporters, Codex, and internal agents may all file this form.
+        Every accepted feature should be assigned to exactly one `target:*` release train.
+  - type: input
+    id: outcome
+    attributes:
+      label: Desired outcome
+      placeholder: What becomes possible if this exists?
+    validations:
+      required: true
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem statement
+      placeholder: What is currently missing or too expensive?
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed approach
+      description: Rough ideas are enough. This can stay incomplete.
+    validations:
+      required: false
+  - type: textarea
+    id: non_goals
+    attributes:
+      label: Non-goals
+      description: What should this request explicitly not try to solve?
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/friction-report.yml
+++ b/.github/ISSUE_TEMPLATE/friction-report.yml
@@ -1,0 +1,63 @@
+name: Friction report
+description: Report something that works but is annoying, confusing, slow, or sharp-edged.
+title: "[Friction] "
+labels:
+  - "type:friction"
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this for dogfooding discomfort.
+        Human reporters, Codex, and internal agents may all file this form.
+        If the fix is small, it should land in the current patch lane.
+        If the fix needs workflow redesign, it should be promoted into the next feature train.
+  - type: input
+    id: version
+    attributes:
+      label: Observed version
+      description: "Example: v2.86.0, main HEAD, local branch"
+      placeholder: v2.86.0
+    validations:
+      required: true
+  - type: dropdown
+    id: category
+    attributes:
+      label: Friction category
+      options:
+        - UX confusion
+        - too many steps
+        - slow feedback
+        - noisy output
+        - missing affordance
+        - naming or discoverability
+        - other
+    validations:
+      required: true
+  - type: textarea
+    id: workflow
+    attributes:
+      label: What were you trying to do?
+      placeholder: Describe the workflow in one short paragraph.
+    validations:
+      required: true
+  - type: textarea
+    id: pain
+    attributes:
+      label: What felt bad?
+      placeholder: Explain the annoying part, wasted steps, or confusion point.
+    validations:
+      required: true
+  - type: textarea
+    id: desired
+    attributes:
+      label: What would feel better?
+      description: A rough expectation is enough. It does not need a perfect solution.
+    validations:
+      required: true
+  - type: textarea
+    id: evidence
+    attributes:
+      label: Evidence
+      description: Screenshots, logs, command transcript, or paths
+    validations:
+      required: false

--- a/docs/VERSIONED-ROADMAP.md
+++ b/docs/VERSIONED-ROADMAP.md
@@ -1,229 +1,225 @@
-# masc-mcp Versioned Roadmap — Swarm Stability First
+# masc-mcp Versioned Roadmap — Feature Trains First
 
 > Last updated: 2026-03-13
-> Baseline: v2.86.0 (313 MCP tools, 579 OCaml modules, 645K lines)
+> Baseline: v2.86.0
 
-## Context
+## Why This Document Exists
 
-masc-mcp v2.86.0, CI failure 존재, worktree ~200개 누적.
-v2.86.1 패치 안정화 중.
+`masc-mcp` has enough internal surface area that "stability work" can easily drift away from a clear release promise.
+This roadmap keeps release planning anchored to one rule:
 
-**핵심 우선순위: Swarm이 안정적으로 돌아야 한다.**
+**Each minor release must ship a user-visible capability promise.**
 
-Swarm 아키텍처는 건전하지만 **운영 guardrail이 부족**하다.
-탐색 결과 6개 fragile point가 발견됨:
+Internal hardening still matters, but it should land as part of a named feature train instead of as an unbounded backlog.
 
-| # | Fragile Point | Risk | Location |
-|---|---------------|------|----------|
-| 1 | Provider 단일 장애점 (`:3034` only) | High | `agent_swarm_live_harness.ml` |
-| 2 | Policy approval timeout 없음 → 작업 hang | High | CPv2 policy 모듈 |
-| 3 | Dispatch tick 동시성 보호 없음 | Medium | `tool_command_plane_dispatch.ml` |
-| 4 | Artifact 존재만 체크 (내용 검증 없음) | Medium | harness artifact persistence |
-| 5 | Heartbeat 장기 drift → zombie agent | Medium | heartbeat daemon |
-| 6 | Final marker 누락 시 silent success | Low | `agent_swarm_swarm.ml` |
+## Versioning Rules
 
-## Cross-Reference (기존 로드맵 문서)
+These version layers are separate and should not be mixed:
 
-이 문서는 아래 3개 기존 로드맵의 항목을 우선순위 순으로 재배치한 통합 뷰다.
-기존 문서는 상세 참조용으로 유지.
+| Layer | Meaning | When it changes | Source |
+|------|---------|-----------------|--------|
+| Release SemVer | Product release train | Every patch/minor/major release | `dune-project`, `README.md`, `CHANGELOG.md` |
+| Protocol version | Public MCP contract compatibility | Only when public MCP contract changes | `/health.protocol`, `mcp-protocol-version` |
+| Artifact schema version | Report/proof/checkpoint payload format | Only when stored payload shape changes | report/proof/checkpoint schema |
 
-| 기존 문서 | 역할 | 이 로드맵 내 위치 |
-|-----------|------|------------------|
-| `docs/RELEASE-ROADMAP.md` | v2.86.1 안정화 | Milestone 1 |
-| `docs/IMPROVEMENT-PLAN-2026-01.md` | 안정성 개선 (P1~P3) | Milestone 2~4 |
-| `docs/IMMORTAL-SERVER-ROADMAP.md` | 고가용성 (Phase 1~3) | Milestone 5, 7 |
+Release lane rules:
 
----
+- `2.x.0`: feature train release. A minor must have one primary promise.
+- `2.x.1+`: patch stabilization for the current train only.
+- Public MCP surface expansion belongs in `minor` or `major`, not in patch.
+- Migration-heavy cleanup belongs in a named train, not in a stabilization patch.
 
-## Milestone 1: v2.86.1 — "Green Main" (즉시)
+Cross-check: `scripts/bump-version.sh` already treats these as distinct layers.
 
-main을 green으로 복원. 이후 Swarm 작업의 전제 조건.
+## Intake and Triage
 
-| Task | Priority | Effort |
-|------|----------|--------|
-| CI failure 해소 (main) | P0 | 1-2h |
-| CHANGELOG v2.86.0 TBD 항목 채우기 | P0 | 30m |
-| Worktree 정리 (~200 → <15) | P1 | 1h |
-| Version bump 2.86.1 | P1 | 5m |
+The user remains the primary dogfooding reporter, but Codex and internal agents are also allowed to file issues when they observe a concrete problem.
+Agent-filed reports should follow the same evidence standard as human-filed reports.
+To keep reports actionable, intake is split into three buckets:
 
-**상세**: `docs/RELEASE-ROADMAP.md`
+| Type | Use for | Default routing |
+|------|---------|-----------------|
+| `type:bug` | Broken behavior, regression, data loss, incorrect result | Current patch or current train blocker |
+| `type:friction` | Usable but annoying, confusing, too slow, sharp UX edge | Current patch if small, next minor if workflow redesign |
+| `type:feature` | New capability, new workflow, new public surface | Next unopened minor train |
 
-**Exit Criteria**:
-- `gh run list --branch main -L 5` 전부 success
-- `git worktree list | wc -l` < 15
-- CHANGELOG에 TBD 없음
+Release labeling rules:
 
----
+- Every issue gets exactly one `target:*` label.
+- `release-blocker` means the issue must be closed before the tagged release.
+- Legacy labels such as `bug` or `enhancement` may remain, but `type:*` and `target:*` are the planning SSOT going forward.
+- Agent-filed reports should include reproducible evidence, a concrete symptom, and the smallest plausible target train.
 
-## Milestone 2: v2.87.x — "Swarm Guardrails" (1-2주)
+## Source Documents
 
-Swarm의 가장 위험한 fragile point 4개를 해소.
+This roadmap is a priority-ordered view over the existing planning docs.
+The detailed design documents remain the implementation references.
 
-### 2-1. Provider Fallback Chain (Risk #1)
+| Source document | Role in this roadmap |
+|-----------------|----------------------|
+| `docs/RELEASE-ROADMAP.md` | Patch stabilization policy for `v2.86.1` |
+| `docs/IMPROVEMENT-PLAN-2026-01.md` | Swarm reliability and recovery improvements |
+| `docs/IMMORTAL-SERVER-ROADMAP.md` | Server HA and self-healing follow-up |
 
-현재 live harness가 `:3034` 단일 endpoint에 의존.
-Provider crash → 12-agent 전체 실패.
+## Milestone 1: v2.86.1 — Green Main
 
-| Task | Detail |
-|------|--------|
-| Provider SLO 계약 | smoke test baseline (<10s) 정의 |
-| Fallback cascade 연결 | `llm_client.ml`의 기존 cascade를 harness에 연결 |
-| Circuit breaker on provider | 연속 3회 실패 시 fallback 전환 |
-| Preflight validation 강화 | health check 실패 시 runtime-doctor.json 생성 |
+**Release promise**: main is releasable again.
 
-**Exit**: provider down 시 fallback으로 harness 계속 실행 (테스트 증명)
+This is the only active patch lane right now.
+It is not a feature release.
 
-### 2-2. Policy Approval Timeout (Risk #2)
+Includes:
 
-승인 대기 중 무한 hang 방지.
+- CI failure fixes on `main`
+- release metadata cleanup
+- changelog completion
+- worktree cleanup that reduces operational drag
+- compatibility fixes that do not widen the public contract
 
-| Task | Detail |
-|------|--------|
-| Approval SLA timeout | 기본 5분, 설정 가능. 초과 시 auto-deny + broadcast |
-| Pre-approved policy 지원 | swarm operation 시작 시 정책 사전 승인 옵션 |
-| Queue depth alert | 승인 대기 >1건 시 broadcast 경고 |
+Stays out:
 
-**Exit**: approval 없이 5분 경과 → auto-deny + 로그 (테스트 증명)
+- new public MCP tools or schemas
+- dashboard IA redesign
+- migration-heavy alias cleanup
+- future-train feature work
 
-### 2-3. Dispatch Tick Serialization (Risk #3)
+Exit criteria:
 
-동시 tick 호출 시 JSONL 상태 파일 corruption 방지.
+- required CI on `main` is green
+- `CHANGELOG.md` has no `TBD` entries for `2.86.0` and `2.86.1`
+- worktree count is back to an operational baseline
 
-| Task | Detail |
-|------|--------|
-| File lock 또는 Eio.Mutex | `.masc/dispatch.lock` 기반 직렬화 |
-| Concurrent tick detection | 두 번째 tick 시도 시 경고 반환 |
+## Milestone 2: v2.87.0 — Reliable Swarm
 
-**Exit**: 동시 tick 2개 → 1개만 실행, 다른 하나는 경고 반환 (테스트 증명)
+**Release promise**: a live swarm keeps progressing when one runtime path fails.
 
-### 2-4. Artifact Content Validation (Risk #4)
+This train turns the most urgent Swarm fragility into explicit product behavior.
 
-존재 체크 → JSON 구조 + 필수 필드 검증.
+Includes:
 
-| Task | Detail |
-|------|--------|
-| JSON parse 검증 | artifact 파일 read 후 `Yojson.Safe.from_string` 성공 확인 |
-| Required fields 체크 | agent IDs, final_markers array 존재 확인 |
-| Explicit failure | malformed artifact → 명확한 에러 메시지 |
+- provider fallback chain for live harness execution
+- approval timeout with explicit auto-deny behavior
+- dispatch tick serialization to prevent state corruption
+- artifact content validation instead of file-exists-only checks
 
-**Exit**: corrupt JSON artifact → harness 명시적 실패 (테스트 증명)
+User-visible effect:
 
----
+- one provider outage should not collapse the whole swarm run
+- approval deadlocks should resolve into an explicit failure state
+- concurrent dispatch should fail safely, not corrupt state
+- broken artifacts should fail loudly
 
-## Milestone 3: v2.88.x — "Swarm Observability" (2-4주)
+Exit criteria:
 
-운영 중 문제를 **감지**할 수 있는 체계.
+- provider-down scenario falls back and completes with proof
+- approval timeout emits auto-deny and broadcast evidence
+- concurrent tick race is serialized with one rejected attempt
+- malformed artifact fails with an explicit error
 
-### 3-1. Heartbeat Monitoring (Risk #5)
+## Milestone 3: v2.88.0 — Visible Swarm
 
-| Task | Detail |
-|------|--------|
-| Heartbeat latency 수집 | broadcast timestamp 비교 |
-| Zombie agent 탐지 | 연속 3회 miss → 자동 retire |
-| Dashboard 표시 | agent 상태 + last heartbeat + drift 경고 |
+**Release promise**: operators can see swarm health before failure becomes silent.
 
-### 3-2. Marker Handling (Risk #6)
+Includes:
 
-| Task | Detail |
-|------|--------|
-| Assisted marker 명시 경고 | `final_marker_assisted=true` → broadcast 알림 |
-| Marker format 유연화 | exact + 정규식 패턴 매칭 허용 |
-| Swarm summary에 marker 통계 | 성공/실패/assisted 비율 |
+- heartbeat latency and drift tracking
+- zombie agent detection and automatic retire
+- final marker warning and assisted-marker accounting
+- dashboard health surfacing for agent heartbeat state
+- Swarm coverage gate in CI
 
-### 3-3. Coverage Gate in CI
+User-visible effect:
 
-| Task | Detail |
-|------|--------|
-| bisect_ppx threshold | Swarm 관련 모듈 70%+ 필수 |
-| CI job 추가 | coverage report + threshold warning |
+- unhealthy agents become diagnosable from the dashboard and logs
+- missing or assisted final markers are visible instead of silently blending into success
 
-**Exit Criteria**:
-- zombie agent 탐지 후 자동 retire (테스트 증명)
-- marker 누락 시 경고 broadcast (테스트 증명)
-- CI coverage report 생성
+Exit criteria:
 
----
+- zombie agent detection is test-proven
+- marker anomalies are broadcast and summarized
+- coverage report is produced in CI for Swarm-critical modules
 
-## Milestone 4: v2.89.x — "Swarm Resilience" (4-8주)
+## Milestone 4: v2.89.0 — Recoverable Swarm
 
-Swarm이 **장애에서 복구**할 수 있는 체계.
+**Release promise**: long-running swarm work can resume instead of restarting from zero.
 
-| Task | Source | Detail |
-|------|--------|--------|
-| Automatic Checkpointing | IMPROVEMENT-PLAN 1.2 | ~400 LOC. swarm operation 중간 상태 저장 |
-| Schema-based Message Validation | IMPROVEMENT-PLAN 1.1 | ~200 LOC. SSE 메시지 포맷 검증 |
-| Lamport Timestamps | IMPROVEMENT-PLAN 2.2 | ~100 LOC. 메시지 순서 보장 |
-| Keeper timeout 영속성 | WIP | 서버 재시작 시 keeper 상태 보존 |
+Includes:
 
-**Exit Criteria**:
-- swarm crash → restart → checkpoint에서 재개 (테스트 증명)
-- 순서 역전 메시지 탐지 + 경고 (테스트 증명)
+- automatic checkpointing
+- schema-based message validation
+- Lamport timestamps for ordering-sensitive analysis
+- keeper timeout persistence across restart
 
----
+User-visible effect:
 
-## Milestone 5: v2.90.x — "Immortal Server P1" (8-12주)
+- restart and recovery become part of the supported workflow
+- malformed messages fail as contract errors, not vague runtime drift
+- message ordering bugs become diagnosable
 
-Swarm 안정성 확보 후, 서버 자체의 HA.
+Exit criteria:
 
-| Task | Source | Effort |
-|------|--------|--------|
-| Supervision Tree | IMMORTAL P1.1 | 2-3d |
-| Health Check System | IMMORTAL P1.2 | 1d |
-| Graceful Shutdown | IMMORTAL P1.3 | 1d |
-| Judge Agent Pattern | IMPROVEMENT-PLAN 2.1 | ~250 LOC |
+- crash and restart can resume from checkpoint
+- schema-invalid messages fail with explicit contract errors
+- ordering inversions are detected and reported
 
-**상세**: `docs/IMMORTAL-SERVER-ROADMAP.md` Phase 1
+## Milestone 5: v2.90.0 — Immortal Base
 
-**Exit Criteria**:
-- `curl :8935/health` → 컴포넌트별 상태 반환
-- SIGTERM → 진행 중 swarm 완료 후 종료
-- supervision crash → 자동 재시작
+**Release promise**: the server survives component failure and shuts down cleanly.
 
----
+Includes:
 
-## Milestone 6: v2.91.x — "Graduate or Archive" (12-16주)
+- supervision tree
+- health check system
+- graceful shutdown
+- first-pass recovery hooks for critical children
 
-Tier 3 Experimental 도구의 Graduate/Archive 결정.
+Exit criteria:
 
-| Category | Tool Count | Criteria |
-|----------|------------|---------|
-| TRPG | 20 | 3개월 사용 0이면 archive |
-| Voice | 11 | stub 유지면 도구 수 축소 |
-| Autoresearch | 6 | 사이클 완주 기록으로 판단 |
-| MDAL | 6 | skill 연동 실적 기준 |
-| RISC | 21 | stable 확인 시 Tier 2 승격 + 문서화 |
+- `/health` reports component-level state
+- `SIGTERM` drains active work instead of dropping it
+- supervised child crash triggers controlled restart behavior
 
-**Exit**: 카테고리별 Graduate/Archive/Keep 결정 문서
+## Milestone 6: v2.91.0 — Product Portfolio Trim
 
----
+**Release promise**: experimental surfaces have explicit keep, graduate, or archive decisions.
 
-## Milestone 7: v2.92.x+ — "Immortal P2 + Architecture"
+Includes:
 
-| Task | Source |
-|------|--------|
-| Auto Recovery (exponential backoff) | IMMORTAL P2.1 |
-| Circuit Breaker (Closed/Open/HalfOpen) | IMMORTAL P2.2 |
-| State Persistence (checkpoint 기반 복구) | IMMORTAL P2.3 |
-| Chain partial rollback | WIP |
-| Board JSONL → PG migration | WIP |
+- category review for TRPG, Voice, Autoresearch, MDAL, and RISC
+- explicit graduation criteria for Tier 2 promotion
+- archive decisions for stale or unowned surfaces
 
-**상세**: `docs/IMMORTAL-SERVER-ROADMAP.md` Phase 2
+Exit criteria:
 
-**v3.0 진입 조건**: public MCP schema 변경이 필요할 때.
+- each experimental category has a written keep / graduate / archive decision
+- deprecated or archived surfaces are reflected in docs and labels
 
----
+## Milestone 7: v2.92.0+ — Immortal P2
 
-## Summary
+**Release promise**: recovery becomes automatic instead of merely supervised.
 
-```
-v2.86.1  Green Main          즉시      CI fix, CHANGELOG, worktree cleanup
-v2.87.x  Swarm Guardrails    1-2주     Provider fallback, Policy timeout, Tick lock, Artifact validation
-v2.88.x  Swarm Observability 2-4주     Heartbeat monitoring, Marker handling, Coverage gate
-v2.89.x  Swarm Resilience    4-8주     Checkpointing, Schema validation, Lamport, Keeper persistence
-v2.90.x  Immortal P1         8-12주    Supervision, Health, Graceful shutdown
-v2.91.x  Graduate/Archive    12-16주   Experimental tier 결정
-v2.92.x+ Immortal P2         16주+     Auto recovery, Circuit breaker, State persistence
-```
+Includes:
 
-Swarm 안정성 (v2.87~v2.89)이 전체 로드맵의 60%를 차지.
-HA/Immortal은 Swarm이 안정된 후에만 의미가 있다.
+- exponential-backoff auto recovery
+- circuit breaker state machine
+- persistent state restore for restart paths
+- follow-up architecture moves such as board storage migration when justified
+
+## Release Summary
+
+| Version | Train | Primary promise |
+|---------|-------|-----------------|
+| `v2.86.1` | Green Main | main is releasable again |
+| `v2.87.0` | Reliable Swarm | Swarm keeps going when one runtime path fails |
+| `v2.88.0` | Visible Swarm | Swarm health becomes visible before silent failure |
+| `v2.89.0` | Recoverable Swarm | Swarm work can resume after interruption |
+| `v2.90.0` | Immortal Base | server survives component failure cleanly |
+| `v2.91.0` | Product Portfolio Trim | experimental surfaces get explicit decisions |
+| `v2.92.0+` | Immortal P2 | recovery becomes automatic and persistent |
+
+## Planning Rules to Keep
+
+- Do not open a new train without naming the user-visible promise first.
+- Do not pull future-train work into the active patch lane.
+- Do not treat `friction` as "not a bug, ignore it"; small friction belongs in patch, repeated friction becomes the next train.
+- Tag releases only after the train exit criteria are evidenced, not merely asserted.

--- a/docs/VERSIONED-ROADMAP.md
+++ b/docs/VERSIONED-ROADMAP.md
@@ -1,0 +1,229 @@
+# masc-mcp Versioned Roadmap — Swarm Stability First
+
+> Last updated: 2026-03-13
+> Baseline: v2.86.0 (313 MCP tools, 579 OCaml modules, 645K lines)
+
+## Context
+
+masc-mcp v2.86.0, CI failure 존재, worktree ~200개 누적.
+v2.86.1 패치 안정화 중.
+
+**핵심 우선순위: Swarm이 안정적으로 돌아야 한다.**
+
+Swarm 아키텍처는 건전하지만 **운영 guardrail이 부족**하다.
+탐색 결과 6개 fragile point가 발견됨:
+
+| # | Fragile Point | Risk | Location |
+|---|---------------|------|----------|
+| 1 | Provider 단일 장애점 (`:3034` only) | High | `agent_swarm_live_harness.ml` |
+| 2 | Policy approval timeout 없음 → 작업 hang | High | CPv2 policy 모듈 |
+| 3 | Dispatch tick 동시성 보호 없음 | Medium | `tool_command_plane_dispatch.ml` |
+| 4 | Artifact 존재만 체크 (내용 검증 없음) | Medium | harness artifact persistence |
+| 5 | Heartbeat 장기 drift → zombie agent | Medium | heartbeat daemon |
+| 6 | Final marker 누락 시 silent success | Low | `agent_swarm_swarm.ml` |
+
+## Cross-Reference (기존 로드맵 문서)
+
+이 문서는 아래 3개 기존 로드맵의 항목을 우선순위 순으로 재배치한 통합 뷰다.
+기존 문서는 상세 참조용으로 유지.
+
+| 기존 문서 | 역할 | 이 로드맵 내 위치 |
+|-----------|------|------------------|
+| `docs/RELEASE-ROADMAP.md` | v2.86.1 안정화 | Milestone 1 |
+| `docs/IMPROVEMENT-PLAN-2026-01.md` | 안정성 개선 (P1~P3) | Milestone 2~4 |
+| `docs/IMMORTAL-SERVER-ROADMAP.md` | 고가용성 (Phase 1~3) | Milestone 5, 7 |
+
+---
+
+## Milestone 1: v2.86.1 — "Green Main" (즉시)
+
+main을 green으로 복원. 이후 Swarm 작업의 전제 조건.
+
+| Task | Priority | Effort |
+|------|----------|--------|
+| CI failure 해소 (main) | P0 | 1-2h |
+| CHANGELOG v2.86.0 TBD 항목 채우기 | P0 | 30m |
+| Worktree 정리 (~200 → <15) | P1 | 1h |
+| Version bump 2.86.1 | P1 | 5m |
+
+**상세**: `docs/RELEASE-ROADMAP.md`
+
+**Exit Criteria**:
+- `gh run list --branch main -L 5` 전부 success
+- `git worktree list | wc -l` < 15
+- CHANGELOG에 TBD 없음
+
+---
+
+## Milestone 2: v2.87.x — "Swarm Guardrails" (1-2주)
+
+Swarm의 가장 위험한 fragile point 4개를 해소.
+
+### 2-1. Provider Fallback Chain (Risk #1)
+
+현재 live harness가 `:3034` 단일 endpoint에 의존.
+Provider crash → 12-agent 전체 실패.
+
+| Task | Detail |
+|------|--------|
+| Provider SLO 계약 | smoke test baseline (<10s) 정의 |
+| Fallback cascade 연결 | `llm_client.ml`의 기존 cascade를 harness에 연결 |
+| Circuit breaker on provider | 연속 3회 실패 시 fallback 전환 |
+| Preflight validation 강화 | health check 실패 시 runtime-doctor.json 생성 |
+
+**Exit**: provider down 시 fallback으로 harness 계속 실행 (테스트 증명)
+
+### 2-2. Policy Approval Timeout (Risk #2)
+
+승인 대기 중 무한 hang 방지.
+
+| Task | Detail |
+|------|--------|
+| Approval SLA timeout | 기본 5분, 설정 가능. 초과 시 auto-deny + broadcast |
+| Pre-approved policy 지원 | swarm operation 시작 시 정책 사전 승인 옵션 |
+| Queue depth alert | 승인 대기 >1건 시 broadcast 경고 |
+
+**Exit**: approval 없이 5분 경과 → auto-deny + 로그 (테스트 증명)
+
+### 2-3. Dispatch Tick Serialization (Risk #3)
+
+동시 tick 호출 시 JSONL 상태 파일 corruption 방지.
+
+| Task | Detail |
+|------|--------|
+| File lock 또는 Eio.Mutex | `.masc/dispatch.lock` 기반 직렬화 |
+| Concurrent tick detection | 두 번째 tick 시도 시 경고 반환 |
+
+**Exit**: 동시 tick 2개 → 1개만 실행, 다른 하나는 경고 반환 (테스트 증명)
+
+### 2-4. Artifact Content Validation (Risk #4)
+
+존재 체크 → JSON 구조 + 필수 필드 검증.
+
+| Task | Detail |
+|------|--------|
+| JSON parse 검증 | artifact 파일 read 후 `Yojson.Safe.from_string` 성공 확인 |
+| Required fields 체크 | agent IDs, final_markers array 존재 확인 |
+| Explicit failure | malformed artifact → 명확한 에러 메시지 |
+
+**Exit**: corrupt JSON artifact → harness 명시적 실패 (테스트 증명)
+
+---
+
+## Milestone 3: v2.88.x — "Swarm Observability" (2-4주)
+
+운영 중 문제를 **감지**할 수 있는 체계.
+
+### 3-1. Heartbeat Monitoring (Risk #5)
+
+| Task | Detail |
+|------|--------|
+| Heartbeat latency 수집 | broadcast timestamp 비교 |
+| Zombie agent 탐지 | 연속 3회 miss → 자동 retire |
+| Dashboard 표시 | agent 상태 + last heartbeat + drift 경고 |
+
+### 3-2. Marker Handling (Risk #6)
+
+| Task | Detail |
+|------|--------|
+| Assisted marker 명시 경고 | `final_marker_assisted=true` → broadcast 알림 |
+| Marker format 유연화 | exact + 정규식 패턴 매칭 허용 |
+| Swarm summary에 marker 통계 | 성공/실패/assisted 비율 |
+
+### 3-3. Coverage Gate in CI
+
+| Task | Detail |
+|------|--------|
+| bisect_ppx threshold | Swarm 관련 모듈 70%+ 필수 |
+| CI job 추가 | coverage report + threshold warning |
+
+**Exit Criteria**:
+- zombie agent 탐지 후 자동 retire (테스트 증명)
+- marker 누락 시 경고 broadcast (테스트 증명)
+- CI coverage report 생성
+
+---
+
+## Milestone 4: v2.89.x — "Swarm Resilience" (4-8주)
+
+Swarm이 **장애에서 복구**할 수 있는 체계.
+
+| Task | Source | Detail |
+|------|--------|--------|
+| Automatic Checkpointing | IMPROVEMENT-PLAN 1.2 | ~400 LOC. swarm operation 중간 상태 저장 |
+| Schema-based Message Validation | IMPROVEMENT-PLAN 1.1 | ~200 LOC. SSE 메시지 포맷 검증 |
+| Lamport Timestamps | IMPROVEMENT-PLAN 2.2 | ~100 LOC. 메시지 순서 보장 |
+| Keeper timeout 영속성 | WIP | 서버 재시작 시 keeper 상태 보존 |
+
+**Exit Criteria**:
+- swarm crash → restart → checkpoint에서 재개 (테스트 증명)
+- 순서 역전 메시지 탐지 + 경고 (테스트 증명)
+
+---
+
+## Milestone 5: v2.90.x — "Immortal Server P1" (8-12주)
+
+Swarm 안정성 확보 후, 서버 자체의 HA.
+
+| Task | Source | Effort |
+|------|--------|--------|
+| Supervision Tree | IMMORTAL P1.1 | 2-3d |
+| Health Check System | IMMORTAL P1.2 | 1d |
+| Graceful Shutdown | IMMORTAL P1.3 | 1d |
+| Judge Agent Pattern | IMPROVEMENT-PLAN 2.1 | ~250 LOC |
+
+**상세**: `docs/IMMORTAL-SERVER-ROADMAP.md` Phase 1
+
+**Exit Criteria**:
+- `curl :8935/health` → 컴포넌트별 상태 반환
+- SIGTERM → 진행 중 swarm 완료 후 종료
+- supervision crash → 자동 재시작
+
+---
+
+## Milestone 6: v2.91.x — "Graduate or Archive" (12-16주)
+
+Tier 3 Experimental 도구의 Graduate/Archive 결정.
+
+| Category | Tool Count | Criteria |
+|----------|------------|---------|
+| TRPG | 20 | 3개월 사용 0이면 archive |
+| Voice | 11 | stub 유지면 도구 수 축소 |
+| Autoresearch | 6 | 사이클 완주 기록으로 판단 |
+| MDAL | 6 | skill 연동 실적 기준 |
+| RISC | 21 | stable 확인 시 Tier 2 승격 + 문서화 |
+
+**Exit**: 카테고리별 Graduate/Archive/Keep 결정 문서
+
+---
+
+## Milestone 7: v2.92.x+ — "Immortal P2 + Architecture"
+
+| Task | Source |
+|------|--------|
+| Auto Recovery (exponential backoff) | IMMORTAL P2.1 |
+| Circuit Breaker (Closed/Open/HalfOpen) | IMMORTAL P2.2 |
+| State Persistence (checkpoint 기반 복구) | IMMORTAL P2.3 |
+| Chain partial rollback | WIP |
+| Board JSONL → PG migration | WIP |
+
+**상세**: `docs/IMMORTAL-SERVER-ROADMAP.md` Phase 2
+
+**v3.0 진입 조건**: public MCP schema 변경이 필요할 때.
+
+---
+
+## Summary
+
+```
+v2.86.1  Green Main          즉시      CI fix, CHANGELOG, worktree cleanup
+v2.87.x  Swarm Guardrails    1-2주     Provider fallback, Policy timeout, Tick lock, Artifact validation
+v2.88.x  Swarm Observability 2-4주     Heartbeat monitoring, Marker handling, Coverage gate
+v2.89.x  Swarm Resilience    4-8주     Checkpointing, Schema validation, Lamport, Keeper persistence
+v2.90.x  Immortal P1         8-12주    Supervision, Health, Graceful shutdown
+v2.91.x  Graduate/Archive    12-16주   Experimental tier 결정
+v2.92.x+ Immortal P2         16주+     Auto recovery, Circuit breaker, State persistence
+```
+
+Swarm 안정성 (v2.87~v2.89)이 전체 로드맵의 60%를 차지.
+HA/Immortal은 Swarm이 안정된 후에만 의미가 있다.


### PR DESCRIPTION
## Summary

- rewrite `docs/VERSIONED-ROADMAP.md` around feature-train release promises instead of internal-only stability buckets
- define release semver vs protocol version vs artifact schema version rules in one place
- add bug/friction/feature issue templates so dogfooding reports route into the right release train
- explicitly allow the user, Codex, and internal agents to file evidence-backed reports
- operational follow-up: created `type:*`, `target:*`, and `release-blocker` labels in GitHub for this workflow

## Test plan

- [x] `git diff --check`
- [x] `ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f) }' .github/ISSUE_TEMPLATE/bug-report.yml .github/ISSUE_TEMPLATE/friction-report.yml .github/ISSUE_TEMPLATE/feature-request.yml .github/ISSUE_TEMPLATE/config.yml`
