### PR TITLE
fix(mcp): keep initialize on JSON compatibility path

### DIFF
--- a/lib/server_mcp_transport_http.ml
+++ b/lib/server_mcp_transport_http.ml
@@ -262,6 +262,10 @@ let classify_mcp_accept_for_body request body_str =
   Server_mcp_transport_http_headers.classify_mcp_accept_for_body request
     body_str
 
+let should_use_sse_for_body request body_str accept_mode =
+  Server_mcp_transport_http_headers.should_use_sse_for_body request body_str
+    accept_mode
+
 let legacy_accept_warning_headers = function
   | Http_negotiation.Legacy_accepted ->
       [
@@ -639,9 +643,7 @@ let handle_post_mcp ~deps ?(profile = Mcp_eio.Full) request reqd =
                               get_protocol_version_for_session ~session_id request
                             in
                             let wants_sse =
-                              accept_mode = Http_negotiation.Streamable
-                              && Http_negotiation.accepts_sse_header
-                                   (Httpun.Headers.get request.headers "accept")
+                              should_use_sse_for_body request body_str accept_mode
                               && not force_json_response
                               && not (request_force_json_response request)
                             in

--- a/lib/server_mcp_transport_http.mli
+++ b/lib/server_mcp_transport_http.mli
@@ -38,6 +38,11 @@ val classify_mcp_accept :
   Httpun.Request.t -> Mcp_protocol.Http_negotiation.accept_mode
 val classify_mcp_accept_for_body :
   Httpun.Request.t -> string -> Mcp_protocol.Http_negotiation.accept_mode
+val should_use_sse_for_body :
+  Httpun.Request.t ->
+  string ->
+  Mcp_protocol.Http_negotiation.accept_mode ->
+  bool
 val legacy_accept_warning_headers :
   Mcp_protocol.Http_negotiation.accept_mode -> (string * string) list
 val legacy_transport_deprecation_headers : (string * string) list

--- a/lib/server_mcp_transport_http_headers.ml
+++ b/lib/server_mcp_transport_http_headers.ml
@@ -55,13 +55,12 @@ let classify_mcp_accept (request : Httpun.Request.t) =
   Http_negotiation.classify_mcp_accept ~allow_legacy:allow_legacy_accept
     (Httpun.Headers.get request.headers "accept")
 
-let body_notification_method body_str =
+let body_jsonrpc_method body_str =
   try
     match Yojson.Safe.from_string body_str with
     | `Assoc fields -> (
         match List.assoc_opt "method" fields with
-        | Some (`String method_) when not (List.mem_assoc "id" fields) ->
-            Some method_
+        | Some (`String method_) -> Some (method_, List.mem_assoc "id" fields)
         | _ -> None)
     | _ -> None
   with Yojson.Json_error _ -> None
@@ -72,14 +71,35 @@ let is_notification_method method_ =
   String.length method_ >= prefix_len
   && String.sub method_ 0 prefix_len = prefix
 
-let classify_mcp_accept_for_body request body_str =
+let is_initialize_method method_ = String.equal method_ "initialize"
+
+let request_accepts_json (request : Httpun.Request.t) =
+  let media_types =
+    Http_negotiation.parse_accept_header
+      (Httpun.Headers.get request.headers "accept")
+  in
+  Http_negotiation.is_media_type_accepted media_types
+    Http_negotiation.json_content_type
+
+let classify_mcp_accept_for_body (request : Httpun.Request.t) body_str =
   match classify_mcp_accept request with
   | Http_negotiation.Rejected -> (
-      match body_notification_method body_str with
-      | Some method_ when is_notification_method method_ ->
+      match body_jsonrpc_method body_str with
+      | Some (method_, true) when request_accepts_json request
+                               && is_initialize_method method_ ->
+          Http_negotiation.Legacy_accepted
+      | Some (method_, false) when is_notification_method method_ ->
           Http_negotiation.Legacy_accepted
       | _ -> Http_negotiation.Rejected)
   | accept_mode -> accept_mode
+
+let should_use_sse_for_body (request : Httpun.Request.t) body_str accept_mode =
+  match body_jsonrpc_method body_str with
+  | Some (method_, _) when is_initialize_method method_ -> false
+  | _ ->
+      accept_mode = Http_negotiation.Streamable
+      && Http_negotiation.accepts_sse_header
+           (Httpun.Headers.get request.headers "accept")
 
 let legacy_accept_warning_headers = function
   | Http_negotiation.Legacy_accepted ->

--- a/lib/server_mcp_transport_http_mcp_handlers.ml
+++ b/lib/server_mcp_transport_http_mcp_handlers.ml
@@ -137,9 +137,9 @@ let handle_post_mcp ~(deps : deps) ?(profile = Mcp_eio.Full) request reqd =
                                 request
                             in
                             let wants_sse =
-                              accept_mode = Http_negotiation.Streamable
-                              && Http_negotiation.accepts_sse_header
-                                   (Httpun.Headers.get request.headers "accept")
+                              Server_mcp_transport_http_headers
+                              .should_use_sse_for_body request body_str
+                                accept_mode
                               && not
                                    Server_mcp_transport_http_headers
                                    .force_json_response

--- a/test/test_http_negotiation.ml
+++ b/test/test_http_negotiation.ml
@@ -106,6 +106,33 @@ let test_request_body_stays_strict () =
     | Masc_mcp.Mcp_protocol.Http_negotiation.Rejected -> true
     | _ -> false)
 
+let test_initialize_body_relaxes_json_accept () =
+  let module Transport = Masc_mcp.Server_mcp_transport_http in
+  let headers = Httpun.Headers.of_list [("accept", "application/json")] in
+  let request = Httpun.Request.create ~headers `POST "/mcp" in
+  let body =
+    {|{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"test","version":"0.1"}}}|}
+  in
+  let mode = Transport.classify_mcp_accept_for_body request body in
+  check bool "initialize legacy accepted" true
+    (match mode with
+    | Masc_mcp.Mcp_protocol.Http_negotiation.Legacy_accepted -> true
+    | _ -> false)
+
+let test_initialize_never_uses_sse () =
+  let module Transport = Masc_mcp.Server_mcp_transport_http in
+  let headers =
+    Httpun.Headers.of_list
+      [("accept", "application/json, text/event-stream")]
+  in
+  let request = Httpun.Request.create ~headers `POST "/mcp" in
+  let body =
+    {|{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"test","version":"0.1"}}}|}
+  in
+  check bool "initialize disables sse" false
+    (Transport.should_use_sse_for_body request body
+       Masc_mcp.Mcp_protocol.Http_negotiation.Streamable)
+
 let () =
   run "http_negotiation"
     [
@@ -119,5 +146,7 @@ let () =
       ("body_aware_accept", [
         test_case "notification relaxes accept" `Quick test_notification_body_relaxes_accept;
         test_case "request remains strict" `Quick test_request_body_stays_strict;
+        test_case "initialize relaxes json accept" `Quick test_initialize_body_relaxes_json_accept;
+        test_case "initialize disables sse" `Quick test_initialize_never_uses_sse;
       ]);
     ]


### PR DESCRIPTION
## Summary
- follow up merged PR #979 with initialize-specific HTTP compatibility handling
- keep JSON-RPC initialize on the JSON response path even when the client advertises SSE
- accept JSON-only initialize requests while keeping the broader request path strict where appropriate

## Why Separate PR
- #979 is already merged into main
- this PR contains only the follow-up initialize-response compatibility fix discovered after that merge

## Validation
- dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix-mcp-wire-compat-v2
- dune exec --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix-mcp-wire-compat-v2 ./test/test_http_negotiation.exe
