### PR TITLE
fix: accept MCP protocol version 2025-06-18

### DIFF
--- a/lib/mcp_server.ml
+++ b/lib/mcp_server.ml
@@ -105,6 +105,7 @@ let make_error ?data ~id code message =
 let supported_protocol_versions = [
   "2024-11-05";
   "2025-03-26";
+  "2025-06-18";
   "2025-11-25";
 ]
 

--- a/test/test_mcp_server_eio.ml
+++ b/test/test_mcp_server_eio.ml
@@ -295,9 +295,14 @@ let test_is_notification () =
    | Error _ -> Alcotest.fail "parse error")
 
 let test_protocol_version () =
-  let params = Some (`Assoc [("protocolVersion", `String "2025-03-26")]) in
+  let params = Some (`Assoc [("protocolVersion", `String "2025-06-18")]) in
   let version = Mcp_eio.protocol_version_from_params params in
-  Alcotest.(check string) "version extracted" "2025-03-26" version;
+  Alcotest.(check string) "version extracted" "2025-06-18" version;
+
+  (match Mcp.validate_protocol_version "2025-06-18" with
+   | Ok version ->
+       Alcotest.(check string) "2025-06-18 is supported" "2025-06-18" version
+   | Error msg -> Alcotest.fail msg);
 
   let normalized = Mcp_eio.normalize_protocol_version "unknown" in
   Alcotest.(check string) "normalized to default" "2025-11-25" normalized;
@@ -348,7 +353,7 @@ let test_handle_request_initialize () =
     ("id", `Int 1);
     ("method", `String "initialize");
     ("params", `Assoc [
-      ("protocolVersion", `String "2025-11-25");
+      ("protocolVersion", `String "2025-06-18");
       ("capabilities", `Assoc []);
       ("clientInfo", `Assoc [
         ("name", `String "test");
@@ -364,6 +369,11 @@ let test_handle_request_initialize () =
        Alcotest.(check bool) "has result" true (List.mem_assoc "result" fields);
        (match List.assoc_opt "result" fields with
         | Some (`Assoc result_fields) ->
+            Alcotest.(check (option string)) "echoes requested protocol version"
+              (Some "2025-06-18")
+              (match List.assoc_opt "protocolVersion" result_fields with
+               | Some (`String version) -> Some version
+               | _ -> None);
             Alcotest.(check bool) "has serverInfo" true
               (List.mem_assoc "serverInfo" result_fields);
             Alcotest.(check bool) "has capabilities" true

--- a/test/test_mcp_server_eio_coverage.ml
+++ b/test/test_mcp_server_eio_coverage.ml
@@ -42,8 +42,8 @@ let test_is_jsonrpc_v2_missing () =
    ============================================================ *)
 
 let test_normalize_protocol_version () =
-  check string "2024-11-05" "2024-11-05"
-    (Mcp_server.normalize_protocol_version "2024-11-05")
+  check string "2025-06-18" "2025-06-18"
+    (Mcp_server.normalize_protocol_version "2025-06-18")
 
 let test_normalize_protocol_version_unknown () =
   let result = Mcp_server.normalize_protocol_version "unknown" in
@@ -58,9 +58,9 @@ let test_protocol_version_from_params_none () =
   check bool "returns default" true (String.length result > 0)
 
 let test_protocol_version_from_params_some () =
-  let params = `Assoc [("protocolVersion", `String "2024-11-05")] in
+  let params = `Assoc [("protocolVersion", `String "2025-06-18")] in
   let result = Mcp_server.protocol_version_from_params (Some params) in
-  check string "extracts version" "2024-11-05" result
+  check string "extracts version" "2025-06-18" result
 
 (* ============================================================
    make_response Tests


### PR DESCRIPTION
## Summary
- add MCP protocol version `2025-06-18` to the initialize whitelist
- cover the Codex handshake version in `test_mcp_server_eio` and `test_mcp_server_eio_coverage`
- keep the default protocol version unchanged while restoring compatibility with current clients

## Problem
Codex currently initializes `masc` with `protocolVersion: 2025-06-18`, but the server rejects it with `Unsupported protocolVersion '2025-06-18' (supported: 2024-11-05, 2025-03-26, 2025-11-25)`.\n\n## Testing\n- `dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix-mcp-protocol-2025-06-18`\n- `MASC_STORAGE_TYPE=filesystem GRAPHQL_API_KEY= ZAI_API_KEY= /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix-mcp-protocol-2025-06-18/_build/default/test/test_mcp_server_eio.exe`\n- `MASC_STORAGE_TYPE=filesystem GRAPHQL_API_KEY= ZAI_API_KEY= /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix-mcp-protocol-2025-06-18/_build/default/test/test_mcp_server_eio_coverage.exe`