### PR TITLE
fix(test): align tests with PR #976 and #979 behavior changes

### DIFF
--- a/scripts/harness/contract/streamable_http_contract.sh
+++ b/scripts/harness/contract/streamable_http_contract.sh
@@ -156,25 +156,22 @@ header_value() {
   ' "$header_file"
 }
 
-echo "[1/8] strict Accept rejection"
+echo "[1/8] legacy Accept compatibility (deprecation warning)"
 wait_for_mcp_ready
-h1="$tmpdir/reject.headers"
-b1="$tmpdir/reject.body"
+h1="$tmpdir/legacy-accept.headers"
+b1="$tmpdir/legacy-accept.body"
 post_with_accept "application/json" \
   '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","clientInfo":{"name":"contract","version":"1.0"},"capabilities":{}}}' \
   "$h1" "$b1"
 code1="$(status_code "$h1")"
-if [ "$code1" != "400" ]; then
-  echo "FAIL: expected 400 for non-streamable Accept, got $code1"
+if [ "$code1" != "200" ]; then
+  echo "FAIL: expected 200 for legacy Accept with deprecation, got $code1"
   cat "$h1"
   cat "$b1"
   exit 1
 fi
-if ! grep -qi "Invalid Accept header" "$b1"; then
-  echo "FAIL: expected invalid accept error body"
-  cat "$b1"
-  exit 1
-fi
+require_header_contains "$h1" "x-masc-legacy-accept" "1"
+require_header_contains "$h1" "warning" "deprecated"
 
 echo "[2/8] streamable Accept success"
 h2="$tmpdir/ok.headers"

--- a/test/test_dashboard_tools.ml
+++ b/test/test_dashboard_tools.ml
@@ -40,18 +40,18 @@ let test_dashboard_tools_projection () =
         (match usage |> member "dispatch_v2_enabled" with
          | `Bool _ -> true
          | _ -> false);
-      let legacy_team_session_turn =
+      let hidden_post_create =
         inventory_rows
         |> List.find_opt (fun row ->
-               row |> member "name" |> to_string = "masc_team_session_turn")
+               row |> member "name" |> to_string = "masc_post_create")
       in
-      check bool "includes hidden legacy tool" true (Option.is_some legacy_team_session_turn);
-      match legacy_team_session_turn with
+      check bool "includes hidden tool" true (Option.is_some hidden_post_create);
+      match hidden_post_create with
       | None -> ()
       | Some row ->
           check string "visibility surfaced" "hidden"
             (row |> member "visibility" |> to_string);
-          check string "lifecycle surfaced" "deprecated"
+          check string "lifecycle surfaced" "active"
             (row |> member "lifecycle" |> to_string);
           check bool "direct call flag surfaced" true
             (row |> member "direct_call_allowed" |> to_bool))


### PR DESCRIPTION
## Summary

- **test_dashboard_tools.ml**: PR #976 pruned `masc_team_session_turn` from tool schemas, but the dashboard projection test still referenced it. Replaced with `masc_post_create` (hidden_active tool that remains in inventory).
- **streamable_http_contract.sh**: PR #979 changed legacy `Accept: application/json` from 400 rejection to 200 with deprecation headers (`x-masc-legacy-accept: 1`, `warning: 299`). Updated test [1/8] accordingly.

## Test plan

- [x] `dune build` passes
- [x] `test_dashboard_tools.exe` passes locally (hidden tool projection verified)
- [ ] CI contract harness passes (requires running MCP server — verified by CI)
- [ ] All GitHub Actions checks green

🤖 Generated with [Claude Code](https://claude.com/claude-code)