### PR TITLE
fix(cp): clear stale attached detachment metadata

### DIFF
--- a/lib/cp_lifecycle.ml
+++ b/lib/cp_lifecycle.ml
@@ -1381,7 +1381,7 @@ let detachment_semantic_equal (left : detachment_record) (right : detachment_rec
 let make_detachment_runtime config (target_unit : unit_record) (operation : operation_record)
     ~target_count ~base =
   let session_id =
-    if target_count = 1 then option_first_some operation.detachment_session_id base.session_id
+    if target_count = 1 then operation.detachment_session_id
     else None
   in
   let session_last_event =
@@ -1393,8 +1393,17 @@ let make_detachment_runtime config (target_unit : unit_record) (operation : oper
     | None -> None
   in
   let last_progress_at =
-    option_first_some session_last_event
-      (option_first_some base.last_progress_at (Some operation.updated_at))
+    match session_last_event, session_id with
+    | Some ts, _ -> Some ts
+    | None, Some _ ->
+        option_first_some base.last_progress_at (Some operation.updated_at)
+    | None, None -> Some operation.updated_at
+  in
+  let last_event_at =
+    match session_last_event, session_id with
+    | Some ts, _ -> Some ts
+    | None, Some _ -> base.last_event_at
+    | None, None -> Some operation.updated_at
   in
   let heartbeat_deadline =
     if operation.status = Active || operation.status = Planned then
@@ -1420,7 +1429,7 @@ let make_detachment_runtime config (target_unit : unit_record) (operation : oper
          else Some target_unit.unit_id);
       source = "managed";
       status = string_of_operation_status operation.status;
-      last_event_at = option_first_some session_last_event base.last_event_at;
+      last_event_at;
       last_progress_at;
       heartbeat_deadline;
       created_at = base.created_at;

--- a/test/test_tool_team_session_lifecycle.ml
+++ b/test/test_tool_team_session_lifecycle.ml
@@ -253,6 +253,24 @@ let test_start_attached_operation_session () =
   in
   Alcotest.(check (option string)) "operation detached after finalize" None
     detached_session_id;
+  let detachment_json =
+    match
+      Command_plane_v2.detachment_status_json config
+        (`Assoc [ ("operation_id", `String operation.operation_id) ])
+    with
+    | Ok json -> json |> result_field
+    | Error err -> Alcotest.failf "detachment status failed: %s" err
+  in
+  Alcotest.(check (option string)) "detachment session cleared after finalize"
+    None
+    (detachment_json |> Yojson.Safe.Util.member "detachment"
+    |> Yojson.Safe.Util.member "session_id"
+    |> Yojson.Safe.Util.to_string_option);
+  Alcotest.(check string) "detachment runtime kind falls back to managed"
+    "managed"
+    (detachment_json |> Yojson.Safe.Util.member "detachment"
+    |> Yojson.Safe.Util.member "runtime_kind"
+    |> Yojson.Safe.Util.to_string);
   let reattach_ok, reattach_body =
     dispatch_exn ctx ~name:"masc_team_session_start"
       ~args:
@@ -375,4 +393,3 @@ let test_recover_elapsed_session () =
     (Room_utils.path_exists config
        (Team_session_store.report_json_path config session_id));
   cleanup_dir base_dir
-


### PR DESCRIPTION
## Summary
- stop managed detachment sync from reusing stale attached session metadata after a team session is finalized
- reset detached managed runtime timestamps to operation updates instead of the old team-session heartbeat
- add a regression test covering attached session finalize -> detached managed detachment fallback

## Root cause
A managed operation could have `detachment_session_id = null` while its persisted detachment still kept the old `session_id` and `runtime_kind = team_session`. That stale fallback made swarm state look active/stalled even after the attached session had ended.

## Verification
- `/tmp/masc-build-fix-stale-swarm/default/test/test_tool_team_session.exe test team_session 1`
- `/tmp/masc-build-fix-stale-swarm/default/test/test_tool_team_session.exe test team_session 6,7,8`
- restarted MASC with build `3e8e7fb0`
- finalized stale live operation `op-1773306548334-db40` and verified detachment became `session_id=null`, `runtime_kind=managed`, `status=completed`
- dashboard now reports `Swarm: 1 moving, 0 stalled, 0 projected`

## Notes
- existing unrelated `chain-smoke` alert residue was left untouched
