### PR TITLE
fix(dashboard): parse UTC heartbeat timestamps correctly

### DIFF
--- a/lib/types.ml
+++ b/lib/types.ml
@@ -108,14 +108,9 @@ let now_iso () =
 
 (** Parse ISO8601 timestamp to Unix float. Returns default_time on parse failure. *)
 let parse_iso8601 ?(default_time = Time_compat.now () -. 60.0) timestamp =
-  try
-    Scanf.sscanf timestamp "%d-%d-%dT%d:%d:%d"
-      (fun y m d h mi s ->
-        let tm = Unix.{ tm_sec=s; tm_min=mi; tm_hour=h;
-          tm_mday=d; tm_mon=m-1; tm_year=y-1900;
-          tm_wday=0; tm_yday=0; tm_isdst=false } in
-        fst (Unix.mktime tm))
-  with Scanf.Scan_failure _ | Failure _ | End_of_file -> default_time
+  match Resilience.Time.parse_iso8601_opt timestamp with
+  | Some unix_ts -> unix_ts
+  | None -> default_time
 
 (** Agent status - compile-time state machine *)
 type agent_status =

--- a/test/test_dashboard_execution.ml
+++ b/test/test_dashboard_execution.ml
@@ -177,8 +177,39 @@ let test_dashboard_shell_current_room_status () =
       let status = json |> member "status" in
       check string "shell room follows current room" "focus-room"
         (status |> member "room" |> to_string);
-      check string "shell current_room exposed" "focus-room"
-        (status |> member "current_room" |> to_string))
+        check string "shell current_room exposed" "focus-room"
+          (status |> member "current_room" |> to_string))
+
+let test_dashboard_execution_fresh_join_not_marked_stale () =
+  let dir = test_dir () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir dir)
+    (fun () ->
+      let config = Lib.Room_utils.default_config dir in
+      ignore (Lib.Room.init config ~agent_name:None);
+      ignore (Lib.Room.join config ~agent_name:"sentinel-kind-fox" ~capabilities:["sentinel"; "housekeeping"] ());
+      Eio_main.run @@ fun env ->
+      Eio.Switch.run (fun sw ->
+        let json =
+          Lib.Dashboard_execution.json
+            ~config
+            ~sw
+            ~clock:(Eio.Stdenv.clock env)
+            ~proc_mgr:None
+            ()
+        in
+        let open Yojson.Safe.Util in
+        let worker_briefs = json |> member "worker_support_briefs" |> to_list in
+        let offline_worker_briefs = json |> member "offline_worker_briefs" |> to_list in
+        let has_sentinel =
+          List.exists
+            (fun row ->
+              row |> member "name" |> to_string = "sentinel-kind-fox")
+            (worker_briefs @ offline_worker_briefs)
+        in
+        check bool "freshly joined agent should not appear stale in execution worker briefs"
+          false has_sentinel
+      ))
 
 let () =
   Alcotest.run "Dashboard Execution"
@@ -191,5 +222,7 @@ let () =
             test_dashboard_execution_current_room_status;
           Alcotest.test_case "shell follows current room" `Quick
             test_dashboard_shell_current_room_status;
+          Alcotest.test_case "fresh join is not stale" `Quick
+            test_dashboard_execution_fresh_join_not_marked_stale;
         ] );
     ]

--- a/test/test_types.ml
+++ b/test/test_types.ml
@@ -52,6 +52,10 @@ let test_message_roundtrip () =
       Alcotest.(check (option string)) "mention" (Some "gemini") parsed.mention
   | Error e -> Alcotest.fail e
 
+let test_parse_iso8601_epoch_utc () =
+  let parsed = parse_iso8601 "1970-01-01T00:00:00Z" in
+  Alcotest.(check (float 0.001)) "utc epoch" 0.0 parsed
+
 let () =
   Alcotest.run "Types" [
     "agent_status", [
@@ -64,5 +68,8 @@ let () =
     ];
     "message", [
       Alcotest.test_case "roundtrip" `Quick test_message_roundtrip;
+    ];
+    "timestamp", [
+      Alcotest.test_case "parse utc epoch" `Quick test_parse_iso8601_epoch_utc;
     ];
   ]


### PR DESCRIPTION
## Summary

- fix UTC `Z` timestamp parsing so dashboard heartbeat age does not drift by the local timezone offset
- stop freshly joined agents from appearing as stale in execution worker briefs due to misparsed `last_seen`
- add a focused dashboard execution regression test and a types timestamp regression test

## Validation

- `DUNE_BUILD_DIR=/tmp/masc_fix_heartbeat_utc dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/codex-fix-heartbeat-age-utc test/test_dashboard_execution.exe`
- `/tmp/masc_fix_heartbeat_utc/default/test/test_dashboard_execution.exe`
- `DUNE_BUILD_DIR=/tmp/masc_fix_heartbeat_utc dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/codex-fix-heartbeat-age-utc test/test_types.exe`
- `/tmp/masc_fix_heartbeat_utc/default/test/test_types.exe`

## Why

A worker like `sentinel-kind-fox` could show as `32421s ago` immediately after a fresh join because server-side age calculation parsed UTC timestamps as local time.
