### PR TITLE
feat(keeper): bridge explicit keeper messages to team sessions

### DIFF
--- a/lib/keeper_schema.ml
+++ b/lib/keeper_schema.ml
@@ -217,6 +217,10 @@ let resident_schemas : tool_schema list = [
           ("type", `String "integer");
           ("description", `String "TTL for initiative-created internal board posts (default: 24).");
         ]);
+        ("auto_team_session_enabled", `Assoc [
+          ("type", `String "boolean");
+          ("description", `String "If true, explicit masc_keeper_msg calls may start or reuse a projected Team Session instead of returning only a conversational reply.");
+        ]);
         ("scope_kind", `Assoc [
           ("type", `String "string");
           ("enum", `List [`String "local"; `String "global"]);

--- a/lib/keeper_status.ml
+++ b/lib/keeper_status.ml
@@ -12,6 +12,41 @@ open Keeper_exec_status
 
 type tool_result = Keeper_types.tool_result
 
+let linked_team_session config (meta : keeper_meta) =
+  match meta.active_team_session_id with
+  | Some session_id -> Team_session_store.load_session config session_id
+  | None -> None
+
+let team_session_state_json config (meta : keeper_meta) =
+  match linked_team_session config meta with
+  | Some session ->
+      `String (Team_session_types.status_to_string session.status)
+  | None -> `Null
+
+let team_session_bridge_json config (meta : keeper_meta) =
+  let session = linked_team_session config meta in
+  let session_exists = Option.is_some session in
+  let session_state =
+    match session with
+    | Some current ->
+        `String (Team_session_types.status_to_string current.status)
+    | None -> `Null
+  in
+  `Assoc
+    [
+      ("enabled", `Bool meta.auto_team_session_enabled);
+      ("active_session_id",
+       match meta.active_team_session_id with
+       | Some session_id -> `String session_id
+       | None -> `Null);
+      ("session_exists", `Bool session_exists);
+      ("session_state", session_state);
+      ("last_started_at",
+       if String.trim meta.last_team_session_started_at = "" then `Null
+       else `String meta.last_team_session_started_at);
+      ("start_count_total", `Int meta.team_session_start_count_total);
+    ]
+
 let handle_keeper_status ctx args : tool_result =
   let name = get_string args "name" "" in
   if not (validate_name name) then
@@ -466,6 +501,18 @@ let handle_keeper_status ctx args : tool_result =
              ("context_mode", `String m.initiative_context_mode);
              ("post_ttl_hours", `Int m.initiative_post_ttl_hours);
            ]);
+           ("auto_team_session_enabled", `Bool m.auto_team_session_enabled);
+           ("active_team_session_id",
+             match m.active_team_session_id with
+             | Some session_id -> `String session_id
+             | None -> `Null);
+           ("team_session_state", team_session_state_json ctx.config m);
+           ("last_team_session_started_at",
+             if String.trim m.last_team_session_started_at = "" then `Null
+             else `String m.last_team_session_started_at);
+           ("team_session_start_count_total",
+             `Int m.team_session_start_count_total);
+           ("team_session_bridge", team_session_bridge_json ctx.config m);
            ("compaction_policy", `Assoc [
              ("profile", `String m.compaction_profile);
              ("ratio_gate", `Float compact_ratio_gate);
@@ -721,6 +768,18 @@ let handle_keeper_list ctx args : tool_result =
                 if String.trim m.policy_reward_model_path = ""
                 then `Null
                 else `String m.policy_reward_model_path);
+              ("auto_team_session_enabled", `Bool m.auto_team_session_enabled);
+              ("active_team_session_id",
+                match m.active_team_session_id with
+                | Some session_id -> `String session_id
+                | None -> `Null);
+              ("team_session_state", team_session_state_json ctx.config m);
+              ("last_team_session_started_at",
+                if String.trim m.last_team_session_started_at = "" then `Null
+                else `String m.last_team_session_started_at);
+              ("team_session_start_count_total",
+                `Int m.team_session_start_count_total);
+              ("team_session_bridge", team_session_bridge_json ctx.config m);
               ("last_drift_turn", `Int m.last_drift_turn);
               ("last_drift_reason",
                 if String.trim m.last_drift_reason = ""

--- a/lib/keeper_turn.ml
+++ b/lib/keeper_turn.ml
@@ -40,6 +40,9 @@ let handle_keeper_up ctx args : tool_result =
     let initiative_cooldown_sec_opt = Safe_ops.json_int_opt "initiative_cooldown_sec" args in
     let initiative_context_mode_opt = get_string_opt args "initiative_context_mode" in
     let initiative_post_ttl_hours_opt = Safe_ops.json_int_opt "initiative_post_ttl_hours" args in
+    let auto_team_session_enabled_opt =
+      get_bool_opt args "auto_team_session_enabled"
+    in
     let room_scope_opt = get_string_opt args "room_scope" in
     let scope_kind_opt = get_string_opt args "scope_kind" in
     let trigger_mode_opt = get_string_opt args "trigger_mode" in
@@ -235,6 +238,9 @@ let handle_keeper_up ctx args : tool_result =
       in
       let voice_agent_id =
         Option.value ~default:(default_voice_agent_id_for name) voice_agent_id_opt
+      in
+      let auto_team_session_enabled =
+        Option.value ~default:false auto_team_session_enabled_opt
       in
       let mention_targets =
         let raw =
@@ -478,6 +484,10 @@ let handle_keeper_up ctx args : tool_result =
                 active_goal_ids = [];
                 last_autonomous_action_at = "";
                 autonomous_action_count = 0;
+                auto_team_session_enabled;
+                active_team_session_id = None;
+                last_team_session_started_at = "";
+                team_session_start_count_total = 0;
              } in
              match write_meta ctx.config meta with
              | Error e -> (false, "❌ " ^ e)
@@ -521,6 +531,7 @@ let handle_keeper_up ctx args : tool_result =
                  ("initiative_cooldown_sec", `Int meta.initiative_cooldown_sec);
                  ("initiative_context_mode", `String meta.initiative_context_mode);
                  ("initiative_post_ttl_hours", `Int meta.initiative_post_ttl_hours);
+                 ("auto_team_session_enabled", `Bool meta.auto_team_session_enabled);
                  ("drift_enabled", `Bool meta.drift_enabled);
                  ("drift_min_turn_gap", `Int meta.drift_min_turn_gap);
                  ("compaction_profile", `String meta.compaction_profile);
@@ -828,6 +839,10 @@ let handle_keeper_up ctx args : tool_result =
         handoff_threshold = Option.value ~default:old.handoff_threshold handoff_threshold_opt;
         handoff_cooldown_sec = Option.value ~default:old.handoff_cooldown_sec handoff_cooldown_sec_opt;
         context_budget = Option.value ~default:old.context_budget context_budget_opt;
+        auto_team_session_enabled =
+          Option.value
+            ~default:old.auto_team_session_enabled
+            auto_team_session_enabled_opt;
         updated_at = now_iso ();
       } in
       (match write_meta ctx.config updated with
@@ -836,6 +851,283 @@ let handle_keeper_up ctx args : tool_result =
          stop_keepalive updated.name;
          start_keepalive ctx updated;
          (true, Yojson.Safe.pretty_to_string (meta_to_json updated)))
+
+let auto_team_session_spawn_profile = "generic_pair_v1"
+
+let write_meta_logged config (meta : keeper_meta) =
+  match write_meta config meta with
+  | Ok () -> ()
+  | Error msg ->
+      Printf.eprintf "[keeper] write_meta failed: %s\n%!" msg
+
+let keeper_team_session_model (meta : keeper_meta) =
+  let active_model = String.trim meta.active_model in
+  if active_model <> "" && not (String.equal active_model "default") then
+    active_model
+  else
+    match meta.models with
+    | model :: _ -> model
+    | [] -> "default"
+
+let keeper_team_session_note (meta : keeper_meta) (message : string) =
+  Printf.sprintf
+    "[keeper auto-team-session]\nkeeper=%s\nrequest=%s\nkeeper_goal=%s\ninstructions=%s"
+    meta.name
+    (short_preview ~max_len:240 message)
+    (short_preview ~max_len:180 meta.goal)
+    (short_preview ~max_len:220 meta.instructions)
+
+let planner_spawn_prompt (meta : keeper_meta) (message : string) =
+  Printf.sprintf
+    "You are planner worker for keeper %s.\n\
+     Incoming request:\n%s\n\n\
+     Keeper goal:\n%s\n\n\
+     Keeper instructions:\n%s\n\n\
+     Leave exactly one non-empty planning note via masc_team_session_step that states:\n\
+     - intended scope\n\
+     - concrete success criteria\n\
+     - first work split\n"
+    meta.name message meta.goal
+    (if String.trim meta.instructions = "" then "(none)" else meta.instructions)
+
+let executor_spawn_prompt (meta : keeper_meta) (message : string) =
+  Printf.sprintf
+    "You are executor worker for keeper %s.\n\
+     Incoming request:\n%s\n\n\
+     Keeper goal:\n%s\n\n\
+     Keeper instructions:\n%s\n\n\
+     Leave exactly one non-empty execution note via masc_team_session_step that states:\n\
+     - first concrete action\n\
+     - likely files/surfaces/tools to inspect\n\
+     - immediate blocker if any\n"
+    meta.name message meta.goal
+    (if String.trim meta.instructions = "" then "(none)" else meta.instructions)
+
+let auto_team_session_spawn_batch (meta : keeper_meta) (message : string) =
+  let model = keeper_team_session_model meta in
+  `List
+    [
+      `Assoc
+        [
+          ("spawn_agent", `String "llama");
+          ("spawn_prompt", `String (planner_spawn_prompt meta message));
+          ("spawn_model", `String model);
+          ("spawn_role", `String "planner");
+          ("spawn_timeout_seconds", `Int 120);
+          ("spawn_selection_note", `String "keeper auto-team-session generic_pair_v1 planner");
+        ];
+      `Assoc
+        [
+          ("spawn_agent", `String "llama");
+          ("spawn_prompt", `String (executor_spawn_prompt meta message));
+          ("spawn_model", `String model);
+          ("spawn_role", `String "executor");
+          ("spawn_timeout_seconds", `Int 120);
+          ("spawn_selection_note", `String "keeper auto-team-session generic_pair_v1 executor");
+        ];
+    ]
+
+let team_session_ctx_of_keeper ctx (meta : keeper_meta) : _ Tool_team_session.context =
+  {
+    Tool_team_session.config = ctx.config;
+    agent_name = meta.agent_name;
+    sw = ctx.sw;
+    clock = ctx.clock;
+    proc_mgr = ctx.proc_mgr;
+  }
+
+let dispatch_team_session ctx meta ~name ~args =
+  match Tool_team_session.dispatch (team_session_ctx_of_keeper ctx meta) ~name ~args with
+  | Some result -> result
+  | None -> (false, Yojson.Safe.to_string (`Assoc [ ("status", `String "error"); ("message", `String "team session dispatch unavailable") ]))
+
+let parse_result_json body =
+  try
+    let open Yojson.Safe.Util in
+    let json = Yojson.Safe.from_string body in
+    Ok (json |> member "result")
+  with Yojson.Json_error err ->
+    Error ("invalid json: " ^ err)
+
+let session_id_of_result_json json =
+  try Some Yojson.Safe.Util.(json |> member "session_id" |> to_string)
+  with Yojson.Safe.Util.Type_error _ -> None
+
+let bool_option_to_json = function
+  | Some value -> `Bool value
+  | None -> `Null
+
+let string_option_to_json = function
+  | Some value -> `String value
+  | None -> `Null
+
+let running_session_for_keeper config (meta : keeper_meta) =
+  match meta.active_team_session_id with
+  | None -> (meta, None)
+  | Some session_id -> (
+      match Team_session_store.load_session config session_id with
+      | Some session when session.status = Team_session_types.Running ->
+          (meta, Some session)
+      | _ ->
+          let updated =
+            {
+              meta with
+              active_team_session_id = None;
+              updated_at = now_iso ();
+            }
+          in
+          write_meta_logged config updated;
+          (updated, None))
+
+let keeper_auto_team_session_response_json
+    ~(meta : keeper_meta)
+    ~(session : Team_session_types.session)
+    ~(created : bool)
+    ~(reused : bool)
+    ?spawn_error
+    () =
+  `Assoc
+    [
+      ("mode", `String "team_session");
+      ("keeper_name", `String meta.name);
+      ("session_id", `String session.session_id);
+      ("created", `Bool created);
+      ("reused", `Bool reused);
+      ("session_status", `String (Team_session_types.status_to_string session.status));
+      ("spawn_profile", `String auto_team_session_spawn_profile);
+      ("spawned_roles", `List [ `String "planner"; `String "executor" ]);
+      ("spawn_error", string_option_to_json spawn_error);
+      ("active_team_session_id", string_option_to_json meta.active_team_session_id);
+      ("last_team_session_started_at", `String meta.last_team_session_started_at);
+      ("team_session_start_count_total", `Int meta.team_session_start_count_total);
+      ("next_read_tool", `String "masc_team_session_status");
+      ("next_write_tool", `String "masc_team_session_step");
+    ]
+
+let start_keeper_auto_team_session ctx (meta : keeper_meta) (message : string) :
+    (keeper_meta * Team_session_types.session * string option, string) result =
+  let start_args =
+    `Assoc
+      [
+        ("goal", `String message);
+        ("duration_seconds", `Int 3600);
+        ("execution_scope", `String "observe_only");
+        ("checkpoint_interval_sec", `Int 60);
+        ("min_agents", `Int 2);
+        ("auto_resume", `Bool true);
+        ("report_formats", `List [ `String "markdown"; `String "json" ]);
+        ("orchestration_mode", `String "assist");
+        ("communication_mode", `String "hybrid");
+        ("instruction_profile", `String "strict");
+        ("alert_channel", `String "both");
+        ("model_cascade", `List (List.map (fun model -> `String model) meta.models));
+        ("agents", `List [ `String meta.agent_name ]);
+      ]
+  in
+  let start_ok, start_body =
+    dispatch_team_session ctx meta ~name:"masc_team_session_start" ~args:start_args
+  in
+  if not start_ok then
+    Error ("team session start failed: " ^ start_body)
+  else
+    match parse_result_json start_body with
+    | Error msg -> Error ("team session start parse failed: " ^ msg)
+    | Ok start_json -> (
+        match session_id_of_result_json start_json with
+        | None -> Error "team session start missing session_id"
+        | Some session_id -> (
+            match Team_session_store.load_session ctx.config session_id with
+            | None -> Error ("team session not found after start: " ^ session_id)
+            | Some session ->
+                let updated_meta =
+                  {
+                    meta with
+                    active_team_session_id = Some session_id;
+                    last_team_session_started_at = now_iso ();
+                    team_session_start_count_total =
+                      meta.team_session_start_count_total + 1;
+                    updated_at = now_iso ();
+                  }
+                in
+                write_meta_logged ctx.config updated_meta;
+                let note_args =
+                  `Assoc
+                    [
+                      ("session_id", `String session_id);
+                      ("turn_kind", `String "note");
+                      ("message", `String (keeper_team_session_note updated_meta message));
+                    ]
+                in
+                let note_ok, note_body =
+                  dispatch_team_session ctx updated_meta ~name:"masc_team_session_step"
+                    ~args:note_args
+                in
+                if not note_ok then
+                  Error ("team session note failed: " ^ note_body)
+                else
+                  let spawn_args =
+                    `Assoc
+                      [
+                        ("session_id", `String session_id);
+                        ("spawn_batch", auto_team_session_spawn_batch updated_meta message);
+                      ]
+                  in
+                  let spawn_ok, spawn_body =
+                    dispatch_team_session ctx updated_meta ~name:"masc_team_session_step"
+                      ~args:spawn_args
+                  in
+                  let spawn_error =
+                    if spawn_ok then None else Some spawn_body
+                  in
+                  Ok (updated_meta, session, spawn_error)))
+
+let append_keeper_auto_team_session_note ctx (meta : keeper_meta)
+    (session : Team_session_types.session) (message : string) :
+    (Team_session_types.session, string) result =
+  let note_args =
+    `Assoc
+      [
+        ("session_id", `String session.session_id);
+        ("turn_kind", `String "note");
+        ("message", `String (keeper_team_session_note meta message));
+      ]
+  in
+  let ok, body =
+    dispatch_team_session ctx meta ~name:"masc_team_session_step" ~args:note_args
+  in
+  if not ok then
+    Error ("team session note failed: " ^ body)
+  else
+    match Team_session_store.load_session ctx.config session.session_id with
+    | Some refreshed -> Ok refreshed
+    | None -> Error ("team session disappeared after note: " ^ session.session_id)
+
+let maybe_handle_auto_team_session ctx (meta : keeper_meta) (message : string) :
+    ((tool_result option * keeper_meta), string) result =
+  if not meta.auto_team_session_enabled then
+    Ok (None, meta)
+  else
+    let linked_meta, running_session = running_session_for_keeper ctx.config meta in
+    match running_session with
+    | Some session -> (
+        match append_keeper_auto_team_session_note ctx linked_meta session message with
+        | Error err -> Error err
+        | Ok session' ->
+            let json =
+              keeper_auto_team_session_response_json
+                ~meta:linked_meta ~session:session' ~created:false ~reused:true ()
+            in
+            Ok (Some (true, Yojson.Safe.pretty_to_string json), linked_meta))
+    | None -> (
+        match start_keeper_auto_team_session ctx linked_meta message with
+        | Error err -> Error err
+        | Ok (updated_meta, session, spawn_error) ->
+            let json =
+              keeper_auto_team_session_response_json
+                ~meta:updated_meta ~session ~created:true ~reused:false
+                ?spawn_error ()
+            in
+            Ok (Some (true, Yojson.Safe.pretty_to_string json), updated_meta))
 
 
 let handle_keeper_msg ctx args : tool_result =
@@ -1141,6 +1433,10 @@ let handle_keeper_msg ctx args : tool_result =
             active_goal_ids = [];
             last_autonomous_action_at = "";
             autonomous_action_count = 0;
+            auto_team_session_enabled = false;
+            active_team_session_id = None;
+            last_team_session_started_at = "";
+            team_session_start_count_total = 0;
           } in
           let base_dir = session_base_dir ctx.config in
           mkdir_p base_dir;
@@ -1267,6 +1563,10 @@ let handle_keeper_msg ctx args : tool_result =
           updated
       in
       start_keepalive ctx meta;
+      match maybe_handle_auto_team_session ctx meta message with
+      | Error err -> (false, "❌ " ^ err)
+      | Ok (Some result, _) -> result
+      | Ok (None, meta) ->
       (* === Harness: trajectory accumulator + eval gate config === *)
       let masc_root = Filename.concat ctx.config.base_path ".masc" in
       let trajectory_acc =
@@ -2555,9 +2855,20 @@ let handle_keeper_down ctx args : tool_result =
     | Error e -> (false, "❌ " ^ e)
     | Ok None -> (true, Printf.sprintf "keeper already absent: %s" name)
     | Ok (Some m) ->
-      if remove_meta then
-        Safe_ops.remove_file_logged ~context:"keeper_down" (keeper_meta_path ctx.config name);
-      if remove_session then begin
+      (if remove_meta then
+         Safe_ops.remove_file_logged ~context:"keeper_down"
+           (keeper_meta_path ctx.config name)
+       else
+         let retained =
+           {
+             m with
+             active_team_session_id = None;
+             last_team_session_started_at = "";
+             updated_at = now_iso ();
+           }
+         in
+         write_meta_logged ctx.config retained);
+      if remove_session then (
         let rec rm_rf path =
           if Sys.file_exists path then begin
             if Sys.is_directory path then begin
@@ -2569,11 +2880,11 @@ let handle_keeper_down ctx args : tool_result =
               Sys.remove path
           end
         in
-        if validate_name m.trace_id then
+        if validate_name m.trace_id then (
           let dir = Filename.concat (session_base_dir ctx.config) m.trace_id in
-          (try rm_rf dir with exn ->
-          Printf.eprintf "[keeper] session dir cleanup failed: %s\n%!" (Printexc.to_string exn))
-      end;
+          try rm_rf dir with exn ->
+            Printf.eprintf "[keeper] session dir cleanup failed: %s\n%!"
+              (Printexc.to_string exn)));
       let json = `Assoc [
         ("name", `String name);
         ("stopped", `Bool true);

--- a/lib/keeper_types.ml
+++ b/lib/keeper_types.ml
@@ -10,6 +10,7 @@ type 'a context = {
   config: Room.config;
   sw: Eio.Switch.t;
   clock: 'a Eio.Time.clock;
+  proc_mgr: Eio_unix.Process.mgr_ty Eio.Resource.t option;
 }
 
 type tool_result = bool * string
@@ -525,6 +526,10 @@ type keeper_meta = {
   continuity_summary: string;
   autonomy_level: string;
   active_goal_ids: string list;
+  auto_team_session_enabled: bool;
+  active_team_session_id: string option;
+  last_team_session_started_at: string;
+  team_session_start_count_total: int;
   last_autonomous_action_at: string;
   autonomous_action_count: int;
 }
@@ -620,6 +625,13 @@ let meta_to_json (m : keeper_meta) : Yojson.Safe.t =
       ("continuity_summary", `String m.continuity_summary);
       ("autonomy_level", `String m.autonomy_level);
       ("active_goal_ids", `List (List.map (fun s -> `String s) m.active_goal_ids));
+      ("auto_team_session_enabled", `Bool m.auto_team_session_enabled);
+      ( "active_team_session_id",
+        match m.active_team_session_id with
+        | Some value -> `String value
+        | None -> `Null );
+      ("last_team_session_started_at", `String m.last_team_session_started_at);
+      ("team_session_start_count_total", `Int m.team_session_start_count_total);
       ("last_autonomous_action_at", `String m.last_autonomous_action_at);
       ("autonomous_action_count", `Int m.autonomous_action_count);
     ]
@@ -843,6 +855,18 @@ let meta_of_json (json : Yojson.Safe.t) : (keeper_meta, string) result =
       Safe_ops.json_string ~default:"l1_reactive" "autonomy_level" json
     in
     let active_goal_ids = Safe_ops.json_string_list "active_goal_ids" json in
+    let auto_team_session_enabled =
+      Safe_ops.json_bool ~default:false "auto_team_session_enabled" json
+    in
+    let active_team_session_id =
+      Safe_ops.json_string_opt "active_team_session_id" json
+    in
+    let last_team_session_started_at =
+      Safe_ops.json_string ~default:"" "last_team_session_started_at" json
+    in
+    let team_session_start_count_total =
+      Safe_ops.json_int ~default:0 "team_session_start_count_total" json
+    in
     let last_autonomous_action_at =
       Safe_ops.json_string ~default:"" "last_autonomous_action_at" json
     in
@@ -942,6 +966,10 @@ let meta_of_json (json : Yojson.Safe.t) : (keeper_meta, string) result =
           continuity_summary;
           autonomy_level;
           active_goal_ids;
+          auto_team_session_enabled;
+          active_team_session_id;
+          last_team_session_started_at;
+          team_session_start_count_total;
           last_autonomous_action_at;
           autonomous_action_count;
         }

--- a/lib/mcp_server_eio.ml
+++ b/lib/mcp_server_eio.ml
@@ -1145,7 +1145,9 @@ let execute_tool_eio ~sw ~clock ?mcp_session_id ?auth_token state ~name ~argumen
       call_keeper_msg =
         Some
           (fun keeper_args ->
-            let keeper_ctx : _ Tool_keeper.context = { config; sw; clock } in
+            let keeper_ctx : _ Tool_keeper.context =
+              { config; sw; clock; proc_mgr = state.Mcp_server.proc_mgr }
+            in
             match
               Tool_keeper.dispatch keeper_ctx ~name:"masc_keeper_msg"
                 ~args:keeper_args
@@ -1339,7 +1341,9 @@ let execute_tool_eio ~sw ~clock ?mcp_session_id ?auth_token state ~name ~argumen
     sw = Some sw;
     proc_mgr = state.Mcp_server.proc_mgr;
   } in
-  let simple_ctx_keeper : _ Tool_keeper.context = { config; sw; clock } in
+  let simple_ctx_keeper : _ Tool_keeper.context =
+    { config; sw; clock; proc_mgr = state.Mcp_server.proc_mgr }
+  in
   let trpg_keeper_call ~name:keeper_name ~message ~timeout_sec :
       Tool_trpg.keeper_call_result =
     let keeper_args =

--- a/lib/operator_control.ml
+++ b/lib/operator_control.ml
@@ -3017,7 +3017,12 @@ let json_of_dispatch_output body =
   try Yojson.Safe.from_string body with Yojson.Json_error _ -> `String body
 
 let tool_keeper_ctx (ctx : 'a context) : _ Tool_keeper.context =
-  { config = ctx.config; sw = ctx.sw; clock = ctx.clock }
+  {
+    config = ctx.config;
+    sw = ctx.sw;
+    clock = ctx.clock;
+    proc_mgr = ctx.proc_mgr;
+  }
 
 let tool_command_plane_ctx (ctx : 'a context) : _ Tool_command_plane.context =
   {
@@ -3491,7 +3496,12 @@ let execute_action (ctx : 'a context) (request : action_request) :
           @ if models = [] then [] else [ ("models", `List models) ])
       in
       let keeper_ctx : _ Tool_keeper.context =
-        { config = ctx.config; sw = ctx.sw; clock = ctx.clock }
+        {
+          config = ctx.config;
+          sw = ctx.sw;
+          clock = ctx.clock;
+          proc_mgr = ctx.proc_mgr;
+        }
       in
       let* ok, body =
         match Tool_keeper.dispatch keeper_ctx ~name:"masc_keeper_msg" ~args with

--- a/lib/server_routes_http_keeper_stream.ml
+++ b/lib/server_routes_http_keeper_stream.ml
@@ -59,7 +59,12 @@ let execute_keeper_stream_tool ~sw ~clock ?auth_token:_ state ~agent_name ~argum
     try
       Eio.Time.with_timeout_exn clock timeout_sec (fun () ->
           let keeper_ctx : _ Tool_keeper.context =
-            { config = state.Mcp_server.room_config; sw; clock }
+            {
+              config = state.Mcp_server.room_config;
+              sw;
+              clock;
+              proc_mgr = state.Mcp_server.proc_mgr;
+            }
           in
           match Tool_keeper.dispatch keeper_ctx ~name:"masc_keeper_msg" ~args:arguments with
           | Some result -> result

--- a/lib/server_runtime_bootstrap.ml
+++ b/lib/server_runtime_bootstrap.ml
@@ -54,7 +54,12 @@ let bootstrap_server_state (state : Mcp_server.server_state) =
 let bootstrap_keepers ~sw ~clock (state : Mcp_server.server_state) =
   try
     let keeper_ctx : _ Tool_keeper.context =
-      { config = state.room_config; sw; clock }
+      {
+        config = state.room_config;
+        sw;
+        clock;
+        proc_mgr = state.Mcp_server.proc_mgr;
+      }
     in
     let stats = Keeper_runtime.bootstrap_existing_keepers keeper_ctx in
     if stats.enabled then

--- a/lib/server_trpg_rest.ml
+++ b/lib/server_trpg_rest.ml
@@ -2220,7 +2220,7 @@ let trpg_keeper_call_with_runtime
     ~message
     ~timeout_sec
   : Tool_trpg.keeper_call_result =
-  let keeper_ctx : _ Tool_keeper.context = { config; sw; clock } in
+  let keeper_ctx : _ Tool_keeper.context = { config; sw; clock; proc_mgr = None } in
   let forced_models = trpg_keeper_models_for_round () in
   let forced_models_field =
     if forced_models = [] then []
@@ -2281,7 +2281,7 @@ let trpg_keeper_probe_with_runtime
     ~(clock : float Eio.Time.clock_ty Eio.Resource.t)
     ~name:keeper_name
   : Tool_trpg.keeper_probe_result =
-  let keeper_ctx : _ Tool_keeper.context = { config; sw; clock } in
+  let keeper_ctx : _ Tool_keeper.context = { config; sw; clock; proc_mgr = None } in
   let keeper_args =
     `Assoc [ ("name", `String keeper_name); ("fast", `Bool true) ]
   in

--- a/lib/social_runtime.ml
+++ b/lib/social_runtime.ml
@@ -236,7 +236,7 @@ let process_event ~sw ~clock ~config (event : board_event) =
       set_last_result summary [];
       total_skipped := !total_skipped + 1
     end else begin
-      let ctx : _ Tool_keeper.context = { config; sw; clock } in
+      let ctx : _ Tool_keeper.context = { config; sw; clock; proc_mgr = None } in
       let row_pairs =
         keepers
         |> List.map (fun meta ->

--- a/lib/tool_keeper.ml
+++ b/lib/tool_keeper.ml
@@ -17,6 +17,7 @@ type 'a context = 'a Keeper_types.context = {
   config : Room.config;
   sw : Eio.Switch.t;
   clock : 'a Eio.Time.clock;
+  proc_mgr : Eio_unix.Process.mgr_ty Eio.Resource.t option;
 }
 
 type tool_result = Keeper_types.tool_result

--- a/lib/tool_keeper.mli
+++ b/lib/tool_keeper.mli
@@ -4,6 +4,7 @@ type 'a context = 'a Keeper_types.context = {
   config : Room.config;
   sw : Eio.Switch.t;
   clock : 'a Eio.Time.clock;
+  proc_mgr : Eio_unix.Process.mgr_ty Eio.Resource.t option;
 }
 
 type tool_result = Keeper_types.tool_result

--- a/test/test_dashboard_mission.ml
+++ b/test/test_dashboard_mission.ml
@@ -448,7 +448,7 @@ let test_dashboard_mission_keeper_tool_audit_fallback () =
       Eio_main.run @@ fun env ->
       Eio.Switch.run (fun sw ->
         let keeper_ctx : _ Lib.Tool_keeper.context =
-          { config; sw; clock = Eio.Stdenv.clock env }
+          { config; sw; clock = Eio.Stdenv.clock env; proc_mgr = Some (Eio.Stdenv.process_mgr env) }
         in
         let keeper_name = "audit-keeper" in
         let ok, _ =

--- a/test/test_operator_control.ml
+++ b/test/test_operator_control.ml
@@ -73,6 +73,8 @@ let () =
             .test_keeper_status_exposes_summary_and_recoverable;
           Alcotest.test_case "snapshot keeper tool audit fallback" `Quick
             Test_operator_control_keeper.test_snapshot_keeper_tool_audit_fallback;
+          Alcotest.test_case "keeper msg auto team session bridge" `Quick
+            Test_operator_control_keeper.test_keeper_msg_auto_team_session_bridge;
           Alcotest.test_case "manual lodge tick updates observable state" `Quick
             Test_operator_control_keeper
             .test_manual_lodge_tick_updates_observable_state;

--- a/test/test_operator_control_keeper.ml
+++ b/test/test_operator_control_keeper.ml
@@ -106,7 +106,12 @@ let test_keeper_status_exposes_summary_and_recoverable () =
       let config = Room.default_config base_dir in
       ignore (Room.init config ~agent_name:(Some "operator"));
       let keeper_ctx : _ Tool_keeper.context =
-        { config; sw; clock = Eio.Stdenv.clock env }
+        {
+          config;
+          sw;
+          clock = Eio.Stdenv.clock env;
+          proc_mgr = Some (Eio.Stdenv.process_mgr env);
+        }
       in
       let keeper_name = "probe-keeper" in
       let ok, _ =
@@ -172,7 +177,12 @@ let test_snapshot_keeper_tool_audit_fallback () =
       let config = Room.default_config base_dir in
       ignore (Room.init config ~agent_name:(Some "operator"));
       let keeper_ctx : _ Tool_keeper.context =
-        { config; sw; clock = Eio.Stdenv.clock env }
+        {
+          config;
+          sw;
+          clock = Eio.Stdenv.clock env;
+          proc_mgr = Some (Eio.Stdenv.process_mgr env);
+        }
       in
       let keeper_name = "audit-keeper" in
       let ok, _ =
@@ -210,6 +220,156 @@ let test_snapshot_keeper_tool_audit_fallback () =
         (keeper |> member "diagnostic" |> member "health_state" |> to_string);
       Alcotest.(check string) "diagnostic continuity offline" "offline"
         (keeper |> member "diagnostic" |> member "continuity_state" |> to_string))
+
+let test_keeper_msg_auto_team_session_bridge () =
+  Eio_main.run @@ fun env ->
+  Eio.Switch.run @@ fun sw ->
+  let base_dir = temp_dir () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir base_dir)
+    (fun () ->
+      let config = Room.default_config base_dir in
+      ignore (Room.init config ~agent_name:(Some "operator"));
+      let keeper_ctx : _ Tool_keeper.context =
+        {
+          config;
+          sw;
+          clock = Eio.Stdenv.clock env;
+          proc_mgr = None;
+        }
+      in
+      let keeper_name = "team-session-keeper" in
+      let ok, _ =
+        dispatch_keeper_exn keeper_ctx ~name:"masc_keeper_up"
+          ~args:
+            (`Assoc
+              [
+                ("name", `String keeper_name);
+                ("goal", `String "Start projected team sessions from explicit keeper messages");
+                ("models", `List [ `String "llama:qwen3.5-35b-a3b-ud-q8-xl" ]);
+                ("auto_team_session_enabled", `Bool true);
+                ("presence_keepalive", `Bool false);
+                ("proactive_enabled", `Bool false);
+              ])
+      in
+      Alcotest.(check bool) "keeper up ok" true ok;
+      let first_message = "QA the mission surface and report the first blocker." in
+      let ok, body =
+        dispatch_keeper_exn keeper_ctx ~name:"masc_keeper_msg"
+          ~args:
+            (`Assoc
+              [
+                ("name", `String keeper_name);
+                ("message", `String first_message);
+              ])
+      in
+      Alcotest.(check bool) "keeper msg ok" true ok;
+      let first_json = parse_json_exn body in
+      let open Yojson.Safe.Util in
+      Alcotest.(check string) "mode" "team_session"
+        (first_json |> member "mode" |> to_string);
+      Alcotest.(check bool) "created" true
+        (first_json |> member "created" |> to_bool);
+      Alcotest.(check bool) "reused" false
+        (first_json |> member "reused" |> to_bool);
+      let session_id = first_json |> member "session_id" |> to_string in
+      let session =
+        match Team_session_store.load_session config session_id with
+        | Some session -> session
+        | None -> Alcotest.fail "team session missing after keeper_msg"
+      in
+      Alcotest.(check string) "session goal" first_message session.goal;
+      Alcotest.(check string) "session status" "running"
+        (Team_session_types.status_to_string session.status);
+      Alcotest.(check bool) "spawn_error surfaced" true
+        (first_json |> member "spawn_error" <> `Null);
+      let meta =
+        match Masc_mcp.Keeper_types.read_meta config keeper_name with
+        | Ok (Some meta) -> meta
+        | Ok None -> Alcotest.fail "keeper meta missing after keeper_msg"
+        | Error err -> Alcotest.fail ("meta read failed: " ^ err)
+      in
+      Alcotest.(check bool) "auto team session enabled" true
+        meta.auto_team_session_enabled;
+      Alcotest.(check (option string)) "linked session id"
+        (Some session_id) meta.active_team_session_id;
+      Alcotest.(check int) "start count" 1 meta.team_session_start_count_total;
+      let status_ok, status_body =
+        dispatch_keeper_exn keeper_ctx ~name:"masc_keeper_status"
+          ~args:
+            (`Assoc
+              [
+                ("name", `String keeper_name);
+                ("include_context", `Bool false);
+                ("include_metrics_overview", `Bool false);
+                ("include_memory_bank", `Bool false);
+                ("include_history_tail", `Bool false);
+                ("include_compaction_history", `Bool false);
+              ])
+      in
+      Alcotest.(check bool) "keeper status ok" true status_ok;
+      let status_json = parse_json_exn status_body in
+      Alcotest.(check bool) "status exposes opt-in" true
+        Yojson.Safe.Util.(status_json |> member "auto_team_session_enabled" |> to_bool);
+      Alcotest.(check string) "status exposes running bridge" "running"
+        Yojson.Safe.Util.(status_json |> member "team_session_state" |> to_string);
+      let events = Team_session_store.read_recent_events config session_id ~max_count:10 in
+      let note_events =
+        List.filter
+          (fun event ->
+            event.Team_session_types.event_type = "team_turn"
+            && Yojson.Safe.Util.(
+                 event.detail |> member "kind" |> to_string = "note"))
+          events
+      in
+      Alcotest.(check bool) "note event recorded" true (note_events <> []);
+      let ok, second_body =
+        dispatch_keeper_exn keeper_ctx ~name:"masc_keeper_msg"
+          ~args:
+            (`Assoc
+              [
+                ("name", `String keeper_name);
+                ("message", `String "Continue with execution notes." );
+              ])
+      in
+      Alcotest.(check bool) "second keeper msg ok" true ok;
+      let second_json = parse_json_exn second_body in
+      Alcotest.(check string) "reused session id" session_id
+        Yojson.Safe.Util.(second_json |> member "session_id" |> to_string);
+      Alcotest.(check bool) "second created false" false
+        Yojson.Safe.Util.(second_json |> member "created" |> to_bool);
+      Alcotest.(check bool) "second reused true" true
+        Yojson.Safe.Util.(second_json |> member "reused" |> to_bool);
+      let events_after = Team_session_store.read_recent_events config session_id ~max_count:20 in
+      let note_count =
+        List.fold_left
+          (fun acc event ->
+            if
+              event.Team_session_types.event_type = "team_turn"
+              && Yojson.Safe.Util.(
+                   event.detail |> member "kind" |> to_string = "note")
+            then acc + 1
+            else acc)
+          0 events_after
+      in
+      Alcotest.(check bool) "second note recorded" true (note_count >= 2);
+      let ok, _ =
+        dispatch_keeper_exn keeper_ctx ~name:"masc_keeper_down"
+          ~args:(`Assoc [ ("name", `String keeper_name) ])
+      in
+      Alcotest.(check bool) "keeper down ok" true ok;
+      let meta_after_down =
+        match Masc_mcp.Keeper_types.read_meta config keeper_name with
+        | Ok (Some meta) -> meta
+        | Ok None -> Alcotest.fail "keeper meta removed unexpectedly"
+        | Error err -> Alcotest.fail ("meta read after down failed: " ^ err)
+      in
+      Alcotest.(check (option string)) "linked session cleared on down" None
+        meta_after_down.active_team_session_id;
+      Alcotest.(check string) "last started cleared on down" ""
+        meta_after_down.last_team_session_started_at;
+      Alcotest.(check int) "start count retained on down" 1
+        meta_after_down.team_session_start_count_total)
 
 let test_manual_lodge_tick_updates_observable_state () =
   let base_dir = temp_dir () in

--- a/test/test_tool_keeper.ml
+++ b/test/test_tool_keeper.ml
@@ -207,7 +207,7 @@ let test_keeper_model_set_persists_active_model () =
       let config = Masc_mcp.Room.default_config base_dir in
       ignore (Masc_mcp.Room.init config ~agent_name:(Some "tester"));
       let keeper_ctx : _ Masc_mcp.Tool_keeper.context =
-        { config; sw; clock = Eio.Stdenv.clock env }
+        { config; sw; clock = Eio.Stdenv.clock env; proc_mgr = Some (Eio.Stdenv.process_mgr env) }
       in
       let dispatch name args =
         match Masc_mcp.Tool_keeper.dispatch keeper_ctx ~name ~args with
@@ -370,7 +370,7 @@ let test_persona_list_and_create_from_persona () =
         let config = Masc_mcp.Room.default_config base_dir in
         ignore (Masc_mcp.Room.init config ~agent_name:(Some "tester"));
         let keeper_ctx : _ Masc_mcp.Tool_keeper.context =
-          { config; sw; clock = Eio.Stdenv.clock env }
+          { config; sw; clock = Eio.Stdenv.clock env; proc_mgr = Some (Eio.Stdenv.process_mgr env) }
         in
         let dispatch name args =
           match Masc_mcp.Tool_keeper.dispatch keeper_ctx ~name ~args with
@@ -453,7 +453,7 @@ let test_resident_keeper_and_persistent_agent_lists_split () =
       let config = Masc_mcp.Room.default_config base_dir in
       ignore (Masc_mcp.Room.init config ~agent_name:(Some "tester"));
       let keeper_ctx : _ Masc_mcp.Tool_keeper.context =
-        { config; sw; clock = Eio.Stdenv.clock env }
+        { config; sw; clock = Eio.Stdenv.clock env; proc_mgr = Some (Eio.Stdenv.process_mgr env) }
       in
       let dispatch name args =
         match Masc_mcp.Tool_keeper.dispatch keeper_ctx ~name ~args with
@@ -522,7 +522,7 @@ let test_resident_and_persistent_detailed_lists_annotate_runtime_class () =
       let config = Masc_mcp.Room.default_config base_dir in
       ignore (Masc_mcp.Room.init config ~agent_name:(Some "tester"));
       let keeper_ctx : _ Masc_mcp.Tool_keeper.context =
-        { config; sw; clock = Eio.Stdenv.clock env }
+        { config; sw; clock = Eio.Stdenv.clock env; proc_mgr = Some (Eio.Stdenv.process_mgr env) }
       in
       let dispatch name args =
         match Masc_mcp.Tool_keeper.dispatch keeper_ctx ~name ~args with
@@ -598,7 +598,7 @@ let test_resident_keeper_msg_bootstraps_then_requires_message () =
       let config = Masc_mcp.Room.default_config base_dir in
       ignore (Masc_mcp.Room.init config ~agent_name:(Some "tester"));
       let keeper_ctx : _ Masc_mcp.Tool_keeper.context =
-        { config; sw; clock = Eio.Stdenv.clock env }
+        { config; sw; clock = Eio.Stdenv.clock env; proc_mgr = Some (Eio.Stdenv.process_mgr env) }
       in
       let dispatch name args =
         match Masc_mcp.Tool_keeper.dispatch keeper_ctx ~name ~args with
@@ -634,7 +634,7 @@ let test_persistent_agent_msg_rejects_missing_message () =
       let config = Masc_mcp.Room.default_config base_dir in
       ignore (Masc_mcp.Room.init config ~agent_name:(Some "tester"));
       let keeper_ctx : _ Masc_mcp.Tool_keeper.context =
-        { config; sw; clock = Eio.Stdenv.clock env }
+        { config; sw; clock = Eio.Stdenv.clock env; proc_mgr = Some (Eio.Stdenv.process_mgr env) }
       in
       let dispatch name args =
         match Masc_mcp.Tool_keeper.dispatch keeper_ctx ~name ~args with
@@ -699,7 +699,7 @@ let test_persistent_agent_create_from_persona_and_status () =
         let config = Masc_mcp.Room.default_config base_dir in
         ignore (Masc_mcp.Room.init config ~agent_name:(Some "tester"));
         let keeper_ctx : _ Masc_mcp.Tool_keeper.context =
-          { config; sw; clock = Eio.Stdenv.clock env }
+          { config; sw; clock = Eio.Stdenv.clock env; proc_mgr = Some (Eio.Stdenv.process_mgr env) }
         in
         let dispatch name args =
           match Masc_mcp.Tool_keeper.dispatch keeper_ctx ~name ~args with
@@ -750,7 +750,7 @@ let test_keeper_dispatch_auxiliary_surfaces_smoke () =
       let config = Masc_mcp.Room.default_config base_dir in
       ignore (Masc_mcp.Room.init config ~agent_name:(Some "tester"));
       let keeper_ctx : _ Masc_mcp.Tool_keeper.context =
-        { config; sw; clock = Eio.Stdenv.clock env }
+        { config; sw; clock = Eio.Stdenv.clock env; proc_mgr = Some (Eio.Stdenv.process_mgr env) }
       in
       let dispatch name args =
         match Masc_mcp.Tool_keeper.dispatch keeper_ctx ~name ~args with
@@ -861,7 +861,7 @@ let test_keeper_status_detailed_reads_metrics_history_and_memory () =
       let config = Masc_mcp.Room.default_config base_dir in
       ignore (Masc_mcp.Room.init config ~agent_name:(Some "tester"));
       let keeper_ctx : _ Masc_mcp.Tool_keeper.context =
-        { config; sw; clock = Eio.Stdenv.clock env }
+        { config; sw; clock = Eio.Stdenv.clock env; proc_mgr = Some (Eio.Stdenv.process_mgr env) }
       in
       let dispatch name args =
         match Masc_mcp.Tool_keeper.dispatch keeper_ctx ~name ~args with
@@ -959,7 +959,7 @@ let test_keeper_policy_tools_roundtrip () =
       let config = Masc_mcp.Room.default_config base_dir in
       ignore (Masc_mcp.Room.init config ~agent_name:(Some "tester"));
       let keeper_ctx : _ Masc_mcp.Tool_keeper.context =
-        { config; sw; clock = Eio.Stdenv.clock env }
+        { config; sw; clock = Eio.Stdenv.clock env; proc_mgr = Some (Eio.Stdenv.process_mgr env) }
       in
       let dispatch name args =
         match Masc_mcp.Tool_keeper.dispatch keeper_ctx ~name ~args with
@@ -1140,7 +1140,7 @@ let test_keeper_policy_set_rejects_invalid_mode () =
       let config = Masc_mcp.Room.default_config base_dir in
       ignore (Masc_mcp.Room.init config ~agent_name:(Some "tester"));
       let keeper_ctx : _ Masc_mcp.Tool_keeper.context =
-        { config; sw; clock = Eio.Stdenv.clock env }
+        { config; sw; clock = Eio.Stdenv.clock env; proc_mgr = Some (Eio.Stdenv.process_mgr env) }
       in
       let dispatch name args =
         match Masc_mcp.Tool_keeper.dispatch keeper_ctx ~name ~args with
@@ -1184,7 +1184,7 @@ let test_keeper_up_defaults_sangsu_to_explicit_voice_policy () =
       let config = Masc_mcp.Room.default_config base_dir in
       ignore (Masc_mcp.Room.init config ~agent_name:(Some "tester"));
       let keeper_ctx : _ Masc_mcp.Tool_keeper.context =
-        { config; sw; clock = Eio.Stdenv.clock env }
+        { config; sw; clock = Eio.Stdenv.clock env; proc_mgr = Some (Eio.Stdenv.process_mgr env) }
       in
       let dispatch name args =
         match Masc_mcp.Tool_keeper.dispatch keeper_ctx ~name ~args with
@@ -1232,7 +1232,7 @@ let test_keeper_policy_set_accepts_explicit_event_v1 () =
       let config = Masc_mcp.Room.default_config base_dir in
       ignore (Masc_mcp.Room.init config ~agent_name:(Some "tester"));
       let keeper_ctx : _ Masc_mcp.Tool_keeper.context =
-        { config; sw; clock = Eio.Stdenv.clock env }
+        { config; sw; clock = Eio.Stdenv.clock env; proc_mgr = Some (Eio.Stdenv.process_mgr env) }
       in
       let dispatch name args =
         match Masc_mcp.Tool_keeper.dispatch keeper_ctx ~name ~args with
@@ -1276,7 +1276,7 @@ let test_resident_bootstrap_marks_stale_explicit_keeper () =
       let config = Masc_mcp.Room.default_config base_dir in
       ignore (Masc_mcp.Room.init config ~agent_name:(Some "tester"));
       let keeper_ctx : _ Masc_mcp.Tool_keeper.context =
-        { config; sw; clock = Eio.Stdenv.clock env }
+        { config; sw; clock = Eio.Stdenv.clock env; proc_mgr = Some (Eio.Stdenv.process_mgr env) }
       in
       let dispatch name args =
         match Masc_mcp.Tool_keeper.dispatch keeper_ctx ~name ~args with

--- a/test/test_tool_misc_coverage.ml
+++ b/test/test_tool_misc_coverage.ml
@@ -266,7 +266,12 @@ let () = test "dispatch_tool_admin_update_keeper_policy" (fun () ->
   Eio.Switch.run @@ fun sw ->
   let ctx = make_test_ctx () in
   let keeper_ctx : _ Tool_keeper.context =
-    { config = ctx.config; sw; clock = Eio.Stdenv.clock env }
+    {
+      config = ctx.config;
+      sw;
+      clock = Eio.Stdenv.clock env;
+      proc_mgr = Some (Eio.Stdenv.process_mgr env);
+    }
   in
   match
     Tool_keeper.dispatch keeper_ctx ~name:"masc_keeper_up"


### PR DESCRIPTION
## Summary
- add an opt-in `auto_team_session_enabled` keeper capability on the public MCP surface
- bridge explicit `masc_keeper_msg` calls into projected Team Session create/reuse flows with planner/executor spawn batches
- expose linked team-session bridge state in keeper status/list output and cover the flow with operator/keeper tests

## Testing
- `dune build --root .`
- `./_build/default/test/test_operator_control.exe`
- `./_build/default/test/test_tool_keeper.exe`
