### PR TITLE
feat(keeper): bridge explicit keeper messages to team sessions

### DIFF
--- a/lib/keeper_turn.ml
+++ b/lib/keeper_turn.ml
@@ -927,17 +927,17 @@ let auto_team_session_spawn_batch (meta : keeper_meta) (message : string) =
         ];
     ]
 
-let team_session_ctx_of_keeper ctx (meta : keeper_meta) : _ Tool_team_session.context =
+let team_session_ctx_of_keeper (ctx : _ context) : _ Tool_team_session.context =
   {
     Tool_team_session.config = ctx.config;
-    agent_name = meta.agent_name;
+    agent_name = ctx.agent_name;
     sw = ctx.sw;
     clock = ctx.clock;
     proc_mgr = ctx.proc_mgr;
   }
 
-let dispatch_team_session ctx meta ~name ~args =
-  match Tool_team_session.dispatch (team_session_ctx_of_keeper ctx meta) ~name ~args with
+let dispatch_team_session (ctx : _ context) ~name ~args =
+  match Tool_team_session.dispatch (team_session_ctx_of_keeper ctx) ~name ~args with
   | Some result -> result
   | None -> (false, Yojson.Safe.to_string (`Assoc [ ("status", `String "error"); ("message", `String "team session dispatch unavailable") ]))
 
@@ -988,6 +988,11 @@ let keeper_auto_team_session_response_json
     () =
   `Assoc
     [
+      ( "reply",
+        `String
+          (Printf.sprintf
+             "Team session %s is ready. Use masc_team_session_status or masc_team_session_step."
+             session.session_id) );
       ("mode", `String "team_session");
       ("keeper_name", `String meta.name);
       ("session_id", `String session.session_id);
@@ -1004,7 +1009,8 @@ let keeper_auto_team_session_response_json
       ("next_write_tool", `String "masc_team_session_step");
     ]
 
-let start_keeper_auto_team_session ctx (meta : keeper_meta) (message : string) :
+let start_keeper_auto_team_session (ctx : _ context) (meta : keeper_meta)
+    (message : string) :
     (keeper_meta * Team_session_types.session * string option, string) result =
   let start_args =
     `Assoc
@@ -1021,11 +1027,15 @@ let start_keeper_auto_team_session ctx (meta : keeper_meta) (message : string) :
         ("instruction_profile", `String "strict");
         ("alert_channel", `String "both");
         ("model_cascade", `List (List.map (fun model -> `String model) meta.models));
-        ("agents", `List [ `String meta.agent_name ]);
+        ( "agents",
+          `List
+            (Team_session_types.dedup_strings
+               [ ctx.agent_name; meta.agent_name ]
+            |> List.map (fun agent -> `String agent)) );
       ]
   in
   let start_ok, start_body =
-    dispatch_team_session ctx meta ~name:"masc_team_session_start" ~args:start_args
+    dispatch_team_session ctx ~name:"masc_team_session_start" ~args:start_args
   in
   if not start_ok then
     Error ("team session start failed: " ^ start_body)
@@ -1059,7 +1069,7 @@ let start_keeper_auto_team_session ctx (meta : keeper_meta) (message : string) :
                     ]
                 in
                 let note_ok, note_body =
-                  dispatch_team_session ctx updated_meta ~name:"masc_team_session_step"
+                  dispatch_team_session ctx ~name:"masc_team_session_step"
                     ~args:note_args
                 in
                 if not note_ok then
@@ -1073,7 +1083,7 @@ let start_keeper_auto_team_session ctx (meta : keeper_meta) (message : string) :
                       ]
                   in
                   let spawn_ok, spawn_body =
-                    dispatch_team_session ctx updated_meta ~name:"masc_team_session_step"
+                    dispatch_team_session ctx ~name:"masc_team_session_step"
                       ~args:spawn_args
                   in
                   let spawn_error =
@@ -1081,7 +1091,7 @@ let start_keeper_auto_team_session ctx (meta : keeper_meta) (message : string) :
                   in
                   Ok (updated_meta, session, spawn_error)))
 
-let append_keeper_auto_team_session_note ctx (meta : keeper_meta)
+let append_keeper_auto_team_session_note (ctx : _ context) (meta : keeper_meta)
     (session : Team_session_types.session) (message : string) :
     (Team_session_types.session, string) result =
   let note_args =
@@ -1093,7 +1103,7 @@ let append_keeper_auto_team_session_note ctx (meta : keeper_meta)
       ]
   in
   let ok, body =
-    dispatch_team_session ctx meta ~name:"masc_team_session_step" ~args:note_args
+    dispatch_team_session ctx ~name:"masc_team_session_step" ~args:note_args
   in
   if not ok then
     Error ("team session note failed: " ^ body)
@@ -1102,7 +1112,8 @@ let append_keeper_auto_team_session_note ctx (meta : keeper_meta)
     | Some refreshed -> Ok refreshed
     | None -> Error ("team session disappeared after note: " ^ session.session_id)
 
-let maybe_handle_auto_team_session ctx (meta : keeper_meta) (message : string) :
+let maybe_handle_auto_team_session (ctx : _ context) (meta : keeper_meta)
+    (message : string) :
     ((tool_result option * keeper_meta), string) result =
   if not meta.auto_team_session_enabled then
     Ok (None, meta)
@@ -1128,7 +1139,6 @@ let maybe_handle_auto_team_session ctx (meta : keeper_meta) (message : string) :
                 ?spawn_error ()
             in
             Ok (Some (true, Yojson.Safe.pretty_to_string json), updated_meta))
-
 
 let handle_keeper_msg ctx args : tool_result =
   let name = get_string args "name" "" in
@@ -2855,6 +2865,17 @@ let handle_keeper_down ctx args : tool_result =
     | Error e -> (false, "❌ " ^ e)
     | Ok None -> (true, Printf.sprintf "keeper already absent: %s" name)
     | Ok (Some m) ->
+      let stop_linked_session session_id =
+        match
+          Team_session_engine_eio.stop_session ~config:ctx.config ~session_id
+            ~reason:"keeper_down" ~generate_report:false
+        with
+        | Ok _ -> ()
+        | Error err ->
+            Printf.eprintf "[keeper] linked team session stop failed: %s\n%!"
+              err
+      in
+      Option.iter stop_linked_session m.active_team_session_id;
       (if remove_meta then
          Safe_ops.remove_file_logged ~context:"keeper_down"
            (keeper_meta_path ctx.config name)

--- a/lib/keeper_types.ml
+++ b/lib/keeper_types.ml
@@ -8,6 +8,7 @@ let keeper_debug =
 
 type 'a context = {
   config: Room.config;
+  agent_name: string;
   sw: Eio.Switch.t;
   clock: 'a Eio.Time.clock;
   proc_mgr: Eio_unix.Process.mgr_ty Eio.Resource.t option;

--- a/lib/mcp_server_eio.ml
+++ b/lib/mcp_server_eio.ml
@@ -1146,7 +1146,13 @@ let execute_tool_eio ~sw ~clock ?mcp_session_id ?auth_token state ~name ~argumen
         Some
           (fun keeper_args ->
             let keeper_ctx : _ Tool_keeper.context =
-              { config; sw; clock; proc_mgr = state.Mcp_server.proc_mgr }
+              {
+                config;
+                agent_name;
+                sw;
+                clock;
+                proc_mgr = state.Mcp_server.proc_mgr;
+              }
             in
             match
               Tool_keeper.dispatch keeper_ctx ~name:"masc_keeper_msg"
@@ -1342,7 +1348,13 @@ let execute_tool_eio ~sw ~clock ?mcp_session_id ?auth_token state ~name ~argumen
     proc_mgr = state.Mcp_server.proc_mgr;
   } in
   let simple_ctx_keeper : _ Tool_keeper.context =
-    { config; sw; clock; proc_mgr = state.Mcp_server.proc_mgr }
+    {
+      config;
+      agent_name;
+      sw;
+      clock;
+      proc_mgr = state.Mcp_server.proc_mgr;
+    }
   in
   let trpg_keeper_call ~name:keeper_name ~message ~timeout_sec :
       Tool_trpg.keeper_call_result =

--- a/lib/operator_control.ml
+++ b/lib/operator_control.ml
@@ -3019,6 +3019,7 @@ let json_of_dispatch_output body =
 let tool_keeper_ctx (ctx : 'a context) : _ Tool_keeper.context =
   {
     config = ctx.config;
+    agent_name = ctx.agent_name;
     sw = ctx.sw;
     clock = ctx.clock;
     proc_mgr = ctx.proc_mgr;
@@ -3498,6 +3499,7 @@ let execute_action (ctx : 'a context) (request : action_request) :
       let keeper_ctx : _ Tool_keeper.context =
         {
           config = ctx.config;
+          agent_name = ctx.agent_name;
           sw = ctx.sw;
           clock = ctx.clock;
           proc_mgr = ctx.proc_mgr;

--- a/lib/server_routes_http_keeper_stream.ml
+++ b/lib/server_routes_http_keeper_stream.ml
@@ -61,6 +61,7 @@ let execute_keeper_stream_tool ~sw ~clock ?auth_token:_ state ~agent_name ~argum
           let keeper_ctx : _ Tool_keeper.context =
             {
               config = state.Mcp_server.room_config;
+              agent_name;
               sw;
               clock;
               proc_mgr = state.Mcp_server.proc_mgr;

--- a/lib/server_runtime_bootstrap.ml
+++ b/lib/server_runtime_bootstrap.ml
@@ -56,6 +56,7 @@ let bootstrap_keepers ~sw ~clock (state : Mcp_server.server_state) =
     let keeper_ctx : _ Tool_keeper.context =
       {
         config = state.room_config;
+        agent_name = "keeper-bootstrap";
         sw;
         clock;
         proc_mgr = state.Mcp_server.proc_mgr;

--- a/lib/server_trpg_rest.ml
+++ b/lib/server_trpg_rest.ml
@@ -2220,7 +2220,9 @@ let trpg_keeper_call_with_runtime
     ~message
     ~timeout_sec
   : Tool_trpg.keeper_call_result =
-  let keeper_ctx : _ Tool_keeper.context = { config; sw; clock; proc_mgr = None } in
+  let keeper_ctx : _ Tool_keeper.context =
+    { config; agent_name = "trpg-rest"; sw; clock; proc_mgr = None }
+  in
   let forced_models = trpg_keeper_models_for_round () in
   let forced_models_field =
     if forced_models = [] then []
@@ -2281,7 +2283,9 @@ let trpg_keeper_probe_with_runtime
     ~(clock : float Eio.Time.clock_ty Eio.Resource.t)
     ~name:keeper_name
   : Tool_trpg.keeper_probe_result =
-  let keeper_ctx : _ Tool_keeper.context = { config; sw; clock; proc_mgr = None } in
+  let keeper_ctx : _ Tool_keeper.context =
+    { config; agent_name = "trpg-rest"; sw; clock; proc_mgr = None }
+  in
   let keeper_args =
     `Assoc [ ("name", `String keeper_name); ("fast", `Bool true) ]
   in

--- a/lib/social_runtime.ml
+++ b/lib/social_runtime.ml
@@ -236,7 +236,15 @@ let process_event ~sw ~clock ~config (event : board_event) =
       set_last_result summary [];
       total_skipped := !total_skipped + 1
     end else begin
-      let ctx : _ Tool_keeper.context = { config; sw; clock; proc_mgr = None } in
+      let ctx : _ Tool_keeper.context =
+        {
+          config;
+          agent_name = "social-runtime";
+          sw;
+          clock;
+          proc_mgr = None;
+        }
+      in
       let row_pairs =
         keepers
         |> List.map (fun meta ->

--- a/lib/tool_keeper.ml
+++ b/lib/tool_keeper.ml
@@ -15,6 +15,7 @@ module Persona = Keeper_persona
 
 type 'a context = 'a Keeper_types.context = {
   config : Room.config;
+  agent_name : string;
   sw : Eio.Switch.t;
   clock : 'a Eio.Time.clock;
   proc_mgr : Eio_unix.Process.mgr_ty Eio.Resource.t option;

--- a/lib/tool_keeper.mli
+++ b/lib/tool_keeper.mli
@@ -2,6 +2,7 @@
 
 type 'a context = 'a Keeper_types.context = {
   config : Room.config;
+  agent_name : string;
   sw : Eio.Switch.t;
   clock : 'a Eio.Time.clock;
   proc_mgr : Eio_unix.Process.mgr_ty Eio.Resource.t option;

--- a/test/test_dashboard_mission.ml
+++ b/test/test_dashboard_mission.ml
@@ -448,7 +448,7 @@ let test_dashboard_mission_keeper_tool_audit_fallback () =
       Eio_main.run @@ fun env ->
       Eio.Switch.run (fun sw ->
         let keeper_ctx : _ Lib.Tool_keeper.context =
-          { config; sw; clock = Eio.Stdenv.clock env; proc_mgr = Some (Eio.Stdenv.process_mgr env) }
+          { config; agent_name = "fixture-root"; sw; clock = Eio.Stdenv.clock env; proc_mgr = Some (Eio.Stdenv.process_mgr env) }
         in
         let keeper_name = "audit-keeper" in
         let ok, _ =

--- a/test/test_operator_control_keeper.ml
+++ b/test/test_operator_control_keeper.ml
@@ -108,6 +108,7 @@ let test_keeper_status_exposes_summary_and_recoverable () =
       let keeper_ctx : _ Tool_keeper.context =
         {
           config;
+          agent_name = "operator";
           sw;
           clock = Eio.Stdenv.clock env;
           proc_mgr = Some (Eio.Stdenv.process_mgr env);
@@ -179,6 +180,7 @@ let test_snapshot_keeper_tool_audit_fallback () =
       let keeper_ctx : _ Tool_keeper.context =
         {
           config;
+          agent_name = "operator";
           sw;
           clock = Eio.Stdenv.clock env;
           proc_mgr = Some (Eio.Stdenv.process_mgr env);
@@ -233,6 +235,7 @@ let test_keeper_msg_auto_team_session_bridge () =
       let keeper_ctx : _ Tool_keeper.context =
         {
           config;
+          agent_name = "operator";
           sw;
           clock = Eio.Stdenv.clock env;
           proc_mgr = None;
@@ -281,6 +284,21 @@ let test_keeper_msg_auto_team_session_bridge () =
       Alcotest.(check string) "session goal" first_message session.goal;
       Alcotest.(check string) "session status" "running"
         (Team_session_types.status_to_string session.status);
+      let team_ctx : _ Tool_team_session.context =
+        {
+          config;
+          agent_name = "operator";
+          sw;
+          clock = Eio.Stdenv.clock env;
+          proc_mgr = None;
+        }
+      in
+      let team_status_ok, _ =
+        dispatch_team_exn team_ctx ~name:"masc_team_session_status"
+          ~args:(`Assoc [ ("session_id", `String session_id) ])
+      in
+      Alcotest.(check bool) "caller can access suggested team session tools" true
+        team_status_ok;
       Alcotest.(check bool) "spawn_error surfaced" true
         (first_json |> member "spawn_error" <> `Null);
       let meta =
@@ -364,12 +382,20 @@ let test_keeper_msg_auto_team_session_bridge () =
         | Ok None -> Alcotest.fail "keeper meta removed unexpectedly"
         | Error err -> Alcotest.fail ("meta read after down failed: " ^ err)
       in
+      let session_after_down =
+        match Team_session_store.load_session config session_id with
+        | Some session -> session
+        | None -> Alcotest.fail "team session removed unexpectedly on down"
+      in
+      Alcotest.(check string) "linked session interrupted on down" "interrupted"
+        (Team_session_types.status_to_string session_after_down.status);
       Alcotest.(check (option string)) "linked session cleared on down" None
         meta_after_down.active_team_session_id;
       Alcotest.(check string) "last started cleared on down" ""
         meta_after_down.last_team_session_started_at;
       Alcotest.(check int) "start count retained on down" 1
         meta_after_down.team_session_start_count_total)
+
 
 let test_manual_lodge_tick_updates_observable_state () =
   let base_dir = temp_dir () in

--- a/test/test_tool_keeper.ml
+++ b/test/test_tool_keeper.ml
@@ -205,7 +205,7 @@ let test_keeper_model_set_persists_active_model () =
       let config = Masc_mcp.Room.default_config base_dir in
       ignore (Masc_mcp.Room.init config ~agent_name:(Some "tester"));
       let keeper_ctx : _ Masc_mcp.Tool_keeper.context =
-        { config; sw; clock = Eio.Stdenv.clock env; proc_mgr = Some (Eio.Stdenv.process_mgr env) }
+        { config; agent_name = "tester"; sw; clock = Eio.Stdenv.clock env; proc_mgr = Some (Eio.Stdenv.process_mgr env) }
       in
       let dispatch name args =
         match Masc_mcp.Tool_keeper.dispatch keeper_ctx ~name ~args with
@@ -368,7 +368,7 @@ let test_persona_list_and_create_from_persona () =
         let config = Masc_mcp.Room.default_config base_dir in
         ignore (Masc_mcp.Room.init config ~agent_name:(Some "tester"));
         let keeper_ctx : _ Masc_mcp.Tool_keeper.context =
-          { config; sw; clock = Eio.Stdenv.clock env; proc_mgr = Some (Eio.Stdenv.process_mgr env) }
+          { config; agent_name = "tester"; sw; clock = Eio.Stdenv.clock env; proc_mgr = Some (Eio.Stdenv.process_mgr env) }
         in
         let dispatch name args =
           match Masc_mcp.Tool_keeper.dispatch keeper_ctx ~name ~args with
@@ -451,7 +451,7 @@ let test_resident_keeper_and_persistent_agent_lists_split () =
       let config = Masc_mcp.Room.default_config base_dir in
       ignore (Masc_mcp.Room.init config ~agent_name:(Some "tester"));
       let keeper_ctx : _ Masc_mcp.Tool_keeper.context =
-        { config; sw; clock = Eio.Stdenv.clock env; proc_mgr = Some (Eio.Stdenv.process_mgr env) }
+        { config; agent_name = "tester"; sw; clock = Eio.Stdenv.clock env; proc_mgr = Some (Eio.Stdenv.process_mgr env) }
       in
       let dispatch name args =
         match Masc_mcp.Tool_keeper.dispatch keeper_ctx ~name ~args with
@@ -520,7 +520,7 @@ let test_resident_and_persistent_detailed_lists_annotate_runtime_class () =
       let config = Masc_mcp.Room.default_config base_dir in
       ignore (Masc_mcp.Room.init config ~agent_name:(Some "tester"));
       let keeper_ctx : _ Masc_mcp.Tool_keeper.context =
-        { config; sw; clock = Eio.Stdenv.clock env; proc_mgr = Some (Eio.Stdenv.process_mgr env) }
+        { config; agent_name = "tester"; sw; clock = Eio.Stdenv.clock env; proc_mgr = Some (Eio.Stdenv.process_mgr env) }
       in
       let dispatch name args =
         match Masc_mcp.Tool_keeper.dispatch keeper_ctx ~name ~args with
@@ -596,7 +596,7 @@ let test_resident_keeper_msg_bootstraps_then_requires_message () =
       let config = Masc_mcp.Room.default_config base_dir in
       ignore (Masc_mcp.Room.init config ~agent_name:(Some "tester"));
       let keeper_ctx : _ Masc_mcp.Tool_keeper.context =
-        { config; sw; clock = Eio.Stdenv.clock env; proc_mgr = Some (Eio.Stdenv.process_mgr env) }
+        { config; agent_name = "tester"; sw; clock = Eio.Stdenv.clock env; proc_mgr = Some (Eio.Stdenv.process_mgr env) }
       in
       let dispatch name args =
         match Masc_mcp.Tool_keeper.dispatch keeper_ctx ~name ~args with
@@ -632,7 +632,7 @@ let test_persistent_agent_msg_rejects_missing_message () =
       let config = Masc_mcp.Room.default_config base_dir in
       ignore (Masc_mcp.Room.init config ~agent_name:(Some "tester"));
       let keeper_ctx : _ Masc_mcp.Tool_keeper.context =
-        { config; sw; clock = Eio.Stdenv.clock env; proc_mgr = Some (Eio.Stdenv.process_mgr env) }
+        { config; agent_name = "tester"; sw; clock = Eio.Stdenv.clock env; proc_mgr = Some (Eio.Stdenv.process_mgr env) }
       in
       let dispatch name args =
         match Masc_mcp.Tool_keeper.dispatch keeper_ctx ~name ~args with
@@ -697,7 +697,7 @@ let test_persistent_agent_create_from_persona_and_status () =
         let config = Masc_mcp.Room.default_config base_dir in
         ignore (Masc_mcp.Room.init config ~agent_name:(Some "tester"));
         let keeper_ctx : _ Masc_mcp.Tool_keeper.context =
-          { config; sw; clock = Eio.Stdenv.clock env; proc_mgr = Some (Eio.Stdenv.process_mgr env) }
+          { config; agent_name = "tester"; sw; clock = Eio.Stdenv.clock env; proc_mgr = Some (Eio.Stdenv.process_mgr env) }
         in
         let dispatch name args =
           match Masc_mcp.Tool_keeper.dispatch keeper_ctx ~name ~args with
@@ -748,7 +748,7 @@ let test_keeper_dispatch_auxiliary_surfaces_smoke () =
       let config = Masc_mcp.Room.default_config base_dir in
       ignore (Masc_mcp.Room.init config ~agent_name:(Some "tester"));
       let keeper_ctx : _ Masc_mcp.Tool_keeper.context =
-        { config; sw; clock = Eio.Stdenv.clock env; proc_mgr = Some (Eio.Stdenv.process_mgr env) }
+        { config; agent_name = "tester"; sw; clock = Eio.Stdenv.clock env; proc_mgr = Some (Eio.Stdenv.process_mgr env) }
       in
       let dispatch name args =
         match Masc_mcp.Tool_keeper.dispatch keeper_ctx ~name ~args with
@@ -859,7 +859,7 @@ let test_keeper_status_detailed_reads_metrics_history_and_memory () =
       let config = Masc_mcp.Room.default_config base_dir in
       ignore (Masc_mcp.Room.init config ~agent_name:(Some "tester"));
       let keeper_ctx : _ Masc_mcp.Tool_keeper.context =
-        { config; sw; clock = Eio.Stdenv.clock env; proc_mgr = Some (Eio.Stdenv.process_mgr env) }
+        { config; agent_name = "tester"; sw; clock = Eio.Stdenv.clock env; proc_mgr = Some (Eio.Stdenv.process_mgr env) }
       in
       let dispatch name args =
         match Masc_mcp.Tool_keeper.dispatch keeper_ctx ~name ~args with
@@ -957,7 +957,7 @@ let test_keeper_policy_tools_roundtrip () =
       let config = Masc_mcp.Room.default_config base_dir in
       ignore (Masc_mcp.Room.init config ~agent_name:(Some "tester"));
       let keeper_ctx : _ Masc_mcp.Tool_keeper.context =
-        { config; sw; clock = Eio.Stdenv.clock env; proc_mgr = Some (Eio.Stdenv.process_mgr env) }
+        { config; agent_name = "tester"; sw; clock = Eio.Stdenv.clock env; proc_mgr = Some (Eio.Stdenv.process_mgr env) }
       in
       let dispatch name args =
         match Masc_mcp.Tool_keeper.dispatch keeper_ctx ~name ~args with
@@ -1138,7 +1138,7 @@ let test_keeper_policy_set_rejects_invalid_mode () =
       let config = Masc_mcp.Room.default_config base_dir in
       ignore (Masc_mcp.Room.init config ~agent_name:(Some "tester"));
       let keeper_ctx : _ Masc_mcp.Tool_keeper.context =
-        { config; sw; clock = Eio.Stdenv.clock env; proc_mgr = Some (Eio.Stdenv.process_mgr env) }
+        { config; agent_name = "tester"; sw; clock = Eio.Stdenv.clock env; proc_mgr = Some (Eio.Stdenv.process_mgr env) }
       in
       let dispatch name args =
         match Masc_mcp.Tool_keeper.dispatch keeper_ctx ~name ~args with
@@ -1182,7 +1182,7 @@ let test_keeper_up_defaults_sangsu_to_explicit_voice_policy () =
       let config = Masc_mcp.Room.default_config base_dir in
       ignore (Masc_mcp.Room.init config ~agent_name:(Some "tester"));
       let keeper_ctx : _ Masc_mcp.Tool_keeper.context =
-        { config; sw; clock = Eio.Stdenv.clock env; proc_mgr = Some (Eio.Stdenv.process_mgr env) }
+        { config; agent_name = "tester"; sw; clock = Eio.Stdenv.clock env; proc_mgr = Some (Eio.Stdenv.process_mgr env) }
       in
       let dispatch name args =
         match Masc_mcp.Tool_keeper.dispatch keeper_ctx ~name ~args with
@@ -1230,7 +1230,7 @@ let test_keeper_policy_set_accepts_explicit_event_v1 () =
       let config = Masc_mcp.Room.default_config base_dir in
       ignore (Masc_mcp.Room.init config ~agent_name:(Some "tester"));
       let keeper_ctx : _ Masc_mcp.Tool_keeper.context =
-        { config; sw; clock = Eio.Stdenv.clock env; proc_mgr = Some (Eio.Stdenv.process_mgr env) }
+        { config; agent_name = "tester"; sw; clock = Eio.Stdenv.clock env; proc_mgr = Some (Eio.Stdenv.process_mgr env) }
       in
       let dispatch name args =
         match Masc_mcp.Tool_keeper.dispatch keeper_ctx ~name ~args with
@@ -1274,7 +1274,7 @@ let test_resident_bootstrap_marks_stale_explicit_keeper () =
       let config = Masc_mcp.Room.default_config base_dir in
       ignore (Masc_mcp.Room.init config ~agent_name:(Some "tester"));
       let keeper_ctx : _ Masc_mcp.Tool_keeper.context =
-        { config; sw; clock = Eio.Stdenv.clock env; proc_mgr = Some (Eio.Stdenv.process_mgr env) }
+        { config; agent_name = "tester"; sw; clock = Eio.Stdenv.clock env; proc_mgr = Some (Eio.Stdenv.process_mgr env) }
       in
       let dispatch name args =
         match Masc_mcp.Tool_keeper.dispatch keeper_ctx ~name ~args with

--- a/test/test_tool_misc_coverage.ml
+++ b/test/test_tool_misc_coverage.ml
@@ -268,6 +268,7 @@ let () = test "dispatch_tool_admin_update_keeper_policy" (fun () ->
   let keeper_ctx : _ Tool_keeper.context =
     {
       config = ctx.config;
+      agent_name = "tester";
       sw;
       clock = Eio.Stdenv.clock env;
       proc_mgr = Some (Eio.Stdenv.process_mgr env);


### PR DESCRIPTION
## Summary
- add an opt-in `auto_team_session_enabled` keeper capability on the public MCP surface
- bridge explicit `masc_keeper_msg` calls into projected Team Session create/reuse flows with planner/executor spawn batches
- expose linked team-session bridge state in keeper status/list output and cover the flow with operator/keeper tests

## Testing
- `dune build --root .`
- `./_build/default/test/test_operator_control.exe`
- `./_build/default/test/test_tool_keeper.exe`
