### PR TITLE
fix(planning): auto-init context in set_deliverable

### DIFF
--- a/lib/planning_eio.ml
+++ b/lib/planning_eio.ml
@@ -263,11 +263,17 @@ let resolve_error (config : Room.config) ~task_id ~index : (planning_context, st
         end
   with e -> Error (Printexc.to_string e)
 
-(** Set deliverable *)
+(** Set deliverable. Auto-creates planning context if none exists. *)
 let set_deliverable (config : Room.config) ~task_id ~content : (planning_context, string) result =
   try
     let dir = planning_dir config task_id in
-    match load config ~task_id with
+    let ctx = match load config ~task_id with
+      | Ok ctx -> Ok ctx
+      | Error _ ->
+          (* Auto-init planning context so deliver works without prior plan_init *)
+          init config ~task_id
+    in
+    match ctx with
     | Error e -> Error e
     | Ok ctx ->
         let updated = { ctx with deliverable = content; updated_at = now_iso () } in

--- a/test/test_operator_control_snapshot.ml
+++ b/test/test_operator_control_snapshot.ml
@@ -248,7 +248,17 @@ let test_digest_room_exposes_pending_confirm_attention () =
            (fun item ->
              String.equal "derived"
                Yojson.Safe.Util.(item |> member "provenance" |> to_string))
-           attention_items))
+           attention_items);
+      (* command_* attention items only appear when microarch signals
+         are warn/bad; in a fresh room they are absent *)
+      Alcotest.(check bool) "no command attention in fresh room" true
+        (not
+           (List.exists
+              (fun item ->
+                String.starts_with
+                  ~prefix:"command_"
+                  Yojson.Safe.Util.(item |> member "kind" |> to_string))
+              attention_items)))
 
 let test_digest_team_session_shape () =
   Eio_main.run @@ fun env ->

--- a/test/test_planning_eio.ml
+++ b/test/test_planning_eio.ml
@@ -172,6 +172,21 @@ let test_set_deliverable () =
   | Error e ->
       fail (Printf.sprintf "Set deliverable failed: %s" e)
 
+let test_set_deliverable_auto_init () =
+  let config = make_config () in
+  (* Do NOT call init -- set_deliverable should auto-init *)
+  let content = "# Auto-init Deliverable\n\nDelivered without prior plan_init." in
+  match Planning_eio.set_deliverable config ~task_id:"auto-init-deliver" ~content with
+  | Ok ctx ->
+      check string "deliverable" content ctx.deliverable;
+      check string "task_id" "auto-init-deliver" ctx.task_id;
+      (* Verify planning directory was auto-created *)
+      let dir = Filename.concat !temp_dir "planning/auto-init-deliver" in
+      check bool "context.json exists" true (Sys.file_exists (Filename.concat dir "context.json"));
+      check bool "deliverable.md exists" true (Sys.file_exists (Filename.concat dir "deliverable.md"))
+  | Error e ->
+      fail (Printf.sprintf "Set deliverable (auto-init) failed: %s" e)
+
 (* ===== Error Tracking Tests ===== *)
 
 let test_add_error () =
@@ -295,6 +310,7 @@ let () =
       test_case "update_plan" `Quick test_update_plan;
       test_case "add_note" `Quick test_add_note;
       test_case "set_deliverable" `Quick test_set_deliverable;
+      test_case "set_deliverable_auto_init" `Quick test_set_deliverable_auto_init;
     ];
     "error_tracking", [
       test_case "add_error" `Quick test_add_error;


### PR DESCRIPTION
## Summary
- `set_deliverable` (backing `masc_deliver`) always failed with "Planning context not found" for tasks that never called `plan_init`
- Root cause: `set_deliverable` propagated `load` errors instead of creating the planning context on demand
- Fix: fall back to `init` when `load` returns `Error`, making `masc_deliver` work for the common task lifecycle (`add_task` -> `claim` -> work -> `deliver`)

## QA Reference
Bug C-2 in `docs/qa/masc-mcp-qa-indictment-2026-03-13.md`

## Test plan
- [x] Existing 15 planning_eio tests pass (unchanged behavior for pre-initialized tasks)
- [x] New `set_deliverable_auto_init` test: calls `set_deliverable` without prior `init`, verifies context.json and deliverable.md are auto-created
- [x] 16/16 planning_eio tests green
- [x] Pre-existing `Operator_control` test failure (health "bad" vs "warn") confirmed on main -- unrelated

🤖 Generated with [Claude Code](https://claude.com/claude-code)