### PR TITLE
fix(team-session): count bootstrap participants as live

### DIFF
--- a/lib/team_session_engine_eio.ml
+++ b/lib/team_session_engine_eio.ml
@@ -75,6 +75,20 @@ let event_ts_of_json json =
       | `String iso -> Resilience.Time.parse_iso8601_opt iso
       | _ -> None)
 
+let bootstrap_present_agent_names (config : Room.config)
+    (session : Team_session_types.session) ~now =
+  let bootstrap_grace =
+    float_of_int (session.checkpoint_interval_sec * max 1 session.min_agents)
+  in
+  if now -. session.started_at >= bootstrap_grace then
+    []
+  else
+    let room_active = room_active_agent_names config in
+    Team_session_types.planned_participant_names session
+    |> List.filter (fun agent -> List.mem agent room_active)
+    |> Team_session_types.dedup_strings
+    |> List.sort String.compare
+
 let session_seen_and_live_agent_names (config : Room.config)
     (session : Team_session_types.session) ~now =
   let events =
@@ -93,8 +107,13 @@ let session_seen_and_live_agent_names (config : Room.config)
         | _ -> (seen_acc, live_acc))
       ([], []) events
   in
-  ( seen_agents |> Team_session_types.dedup_strings |> List.sort String.compare,
-    live_agents |> Team_session_types.dedup_strings |> List.sort String.compare )
+  let bootstrap_agents = bootstrap_present_agent_names config session ~now in
+  ( (seen_agents @ bootstrap_agents)
+    |> Team_session_types.dedup_strings
+    |> List.sort String.compare,
+    (live_agents @ bootstrap_agents)
+    |> Team_session_types.dedup_strings
+    |> List.sort String.compare )
 
 let session_active_agent_names config session ~now =
   session_seen_and_live_agent_names config session ~now |> snd

--- a/test/test_tool_team_session_lifecycle.ml
+++ b/test/test_tool_team_session_lifecycle.ml
@@ -30,6 +30,15 @@ let test_start_status_report_stop () =
   let status_result = result_field status_json in
   Alcotest.(check string) "status wrapper" "ok"
     (Yojson.Safe.Util.member "status" status_json |> Yojson.Safe.Util.to_string);
+  Alcotest.(check string) "fresh session health is not critical" "healthy"
+    (status_result |> Yojson.Safe.Util.member "team_health"
+     |> Yojson.Safe.Util.member "status" |> Yojson.Safe.Util.to_string);
+  Alcotest.(check bool) "fresh session has visible active participants" true
+    ((status_result |> Yojson.Safe.Util.member "summary"
+      |> Yojson.Safe.Util.member "active_agents_count" |> Yojson.Safe.Util.to_int) > 0);
+  Alcotest.(check bool) "fresh session has visible seen participants" true
+    ((status_result |> Yojson.Safe.Util.member "summary"
+      |> Yojson.Safe.Util.member "seen_agents_count" |> Yojson.Safe.Util.to_int) > 0);
   Alcotest.(check bool) "team_health present" true
     (Yojson.Safe.Util.member "team_health" status_result <> `Null);
   Alcotest.(check bool) "communication_metrics present" true
@@ -375,4 +384,3 @@ let test_recover_elapsed_session () =
     (Room_utils.path_exists config
        (Team_session_store.report_json_path config session_id));
   cleanup_dir base_dir
-


### PR DESCRIPTION
## Summary

- stop fresh team sessions from reporting `critical` health with `active_agents_count=0` before any turn has been written
- treat planned participants already present in the room as seen/live during bootstrap grace
- add a lifecycle regression assertion that a fresh session is not immediately marked critical

## Validation

- `DUNE_BUILD_DIR=/tmp/masc_fix_team_session_bootstrap dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/codex-fix-team-session-bootstrap-health test/test_tool_team_session.exe`
- `/tmp/masc_fix_team_session_bootstrap/default/test/test_tool_team_session.exe`

## Why

`masc_team_session_start` and `masc_team_session_step` were working, but `masc_team_session_status` immediately showed `critical` with zero active/seen agents because status health only counted recent `team_turn` events and ignored bootstrap participants already present in the room.
