### PR TITLE
fix(sentinel): persist board patrol daily dedupe state

### DIFF
--- a/lib/sentinel.ml
+++ b/lib/sentinel.ml
@@ -107,6 +107,26 @@ let note_board_patrol_result_for_tests ?checked_at ~action ?reason ?(stale_count
   last_board_patrol_reason := Option.value ~default:"" reason;
   last_board_patrol_stale_count := stale_count
 
+let board_patrol_state_path (config : Room_utils.config) =
+  Filename.concat (Filename.concat config.base_path ".masc")
+    "sentinel_board_patrol_state.json"
+
+let board_patrol_day_key_of_unix ts =
+  let tm = Unix.localtime ts in
+  sprintf "%04d-%03d" (tm.Unix.tm_year + 1900) tm.Unix.tm_yday
+
+let read_board_patrol_day_key_for_tests (config : Room_utils.config) =
+  let json = Room_utils.read_json_local (board_patrol_state_path config) in
+  json
+  |> Yojson.Safe.Util.member "last_daily_post_day"
+  |> Yojson.Safe.Util.to_string_option
+  |> trimmed_string_option
+
+let write_board_patrol_day_key_for_tests (config : Room_utils.config) day_key =
+  Room_utils.write_json_local
+    (board_patrol_state_path config)
+    (`Assoc [ ("last_daily_post_day", `String day_key) ])
+
 (* ── Sentinel-specific Pulse Consumers ─────────────────────── *)
 
 (** Heartbeat consumer: keeps sentinel visible in the room. *)
@@ -127,7 +147,7 @@ let make_heartbeat_consumer config : (module Pulse.Consumer) =
 (** Board patrol consumer: posts a daily status summary via LLM.
     Skips posting when LLM is unavailable. *)
 let make_board_patrol_consumer config : (module Pulse.Consumer) =
-  let last_daily_post = ref 0 in (* day-of-year of last post *)
+  let last_daily_post = ref (read_board_patrol_day_key_for_tests config) in
   let record_result ~checked_at ~action ?reason ~stale_count () =
     note_board_patrol_result_for_tests ~checked_at ~action ?reason ~stale_count ()
   in
@@ -137,15 +157,19 @@ let make_board_patrol_consumer config : (module Pulse.Consumer) =
     let on_beat _beat =
       try
         let state = Room.read_state config in
-        let tm = Unix.localtime (Time_compat.now ()) in
-        let today = tm.Unix.tm_yday in
-        if today <> !last_daily_post then begin
-          last_daily_post := today;
+        let now_f = Time_compat.now () in
+        let today_key = board_patrol_day_key_of_unix now_f in
+        if Some today_key <> !last_daily_post then begin
+          last_daily_post := Some today_key;
+          (try write_board_patrol_day_key_for_tests config today_key
+           with exn ->
+             log
+               (sprintf "board patrol state persist failed: %s"
+                  (Printexc.to_string exn)));
           let agent_names = String.concat ", " state.active_agents in
           let board_posts = (try Board_dispatch.list_posts ~limit:50 ()
                              with _ -> []) in
           let post_count = List.length board_posts in
-          let now_f = Time_compat.now () in
           let stale_posts = List.filter (fun (p : Board.post) ->
             now_f -. p.created_at > 604800.0 (* 7 days *)
           ) board_posts |> List.length in

--- a/lib/sentinel.mli
+++ b/lib/sentinel.mli
@@ -45,6 +45,14 @@ val note_board_patrol_result_for_tests :
   unit ->
   unit
 
+(** Test helper: reads the persisted daily-post dedupe key from .masc state. *)
+val read_board_patrol_day_key_for_tests :
+  Room_utils.config -> string option
+
+(** Test helper: persists the daily-post dedupe key into .masc state. *)
+val write_board_patrol_day_key_for_tests :
+  Room_utils.config -> string -> unit
+
 (** Ensures the room root/current room state exists before sentinel joins. *)
 val ensure_room_initialized_for_start : Room_utils.config -> unit
 

--- a/test/test_guardian_sentinel.ml
+++ b/test/test_guardian_sentinel.ml
@@ -81,6 +81,18 @@ let test_board_patrol_decision_parser () =
   check (option string) "board post"
     (Some "Two stale sentinel-board posts need review.") decision.board_post
 
+let test_sentinel_board_patrol_day_key_roundtrip () =
+  with_temp_room_root (fun config ->
+    Sentinel.ensure_room_initialized_for_start config;
+    check (option string) "empty default" None
+      (Sentinel.read_board_patrol_day_key_for_tests config);
+    Sentinel.write_board_patrol_day_key_for_tests config "2026-072";
+    check (option string) "persisted day key" (Some "2026-072")
+      (Sentinel.read_board_patrol_day_key_for_tests config);
+    reset_runtime_state ();
+    check (option string) "persists across runtime reset" (Some "2026-072")
+      (Sentinel.read_board_patrol_day_key_for_tests config))
+
 let () =
   run "Guardian/Sentinel"
     [
@@ -91,5 +103,6 @@ let () =
         test_case "sentinel reports embedded guardian runtime" `Quick test_sentinel_status_reports_embedded_guardian_runtime;
         test_case "sentinel board patrol status defaults to silent" `Quick test_sentinel_board_patrol_status_defaults_to_silent;
         test_case "board patrol decision parser" `Quick test_board_patrol_decision_parser;
+        test_case "board patrol day key roundtrip" `Quick test_sentinel_board_patrol_day_key_roundtrip;
       ]);
     ]


### PR DESCRIPTION
## Summary
- persist sentinel board patrol daily dedupe state in `.masc/sentinel_board_patrol_state.json`
- keep the once-per-day posting guard stable across process restarts
- add a guardian/sentinel roundtrip test for the persisted day key

## Why
`last_daily_post` lived only in memory, so restarting `masc-mcp` could cause repeated Sentinel Daily posts within the same day.

## Validation
- `dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix-sentinel-daily-dedupe`
- `dune exec --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/fix-sentinel-daily-dedupe ./test/test_guardian_sentinel.exe`
