### PR TITLE
fix: QA round 2 — routing, metrics, API status

### DIFF
--- a/bin/main_eio.ml
+++ b/bin/main_eio.ml
@@ -169,12 +169,12 @@ let make_extended_handler routes =
             ] in
             Http.Response.json (Yojson.Safe.to_string json) reqd
         | `GET, p
-          when String.length p > 23
-               && String.sub p 0 23 = "/api/v1/governance/cases/" ->
+          when String.length p > 25
+               && String.sub p 0 25 = "/api/v1/governance/cases/" ->
             (match !server_state with
              | None -> Http.Response.json {|{"error":"not initialized"}|} reqd
              | Some state ->
-                 let case_id = String.sub p 23 (String.length p - 23) in
+                 let case_id = String.sub p 25 (String.length p - 25) in
                  let base_path = state.Mcp_server.room_config.base_path in
                  let (status, json) = governance_case_detail_json ~base_path ~case_id in
                  Http.Response.json ~status (Yojson.Safe.to_string json) reqd)

--- a/lib/cp_microarch_summary.ml
+++ b/lib/cp_microarch_summary.ml
@@ -137,7 +137,7 @@ let search_fabric_json (rows : search_row list) =
     else
       float_of_int duplicate_count /. float_of_int (List.length rows_with_scope)
   in
-  let artifact_scope_drift =
+  let artifact_scope_drift, artifact_scope_active =
     let scoped_rows =
       coding_rows
       |> List.filter (fun row ->
@@ -145,14 +145,22 @@ let search_fabric_json (rows : search_row list) =
              | Some "decompose" -> false
              | _ -> true)
     in
+    let active =
+      scoped_rows
+      |> List.filter (fun row -> row.artifact_scope_count > 0)
+      |> List.length
+    in
     let drifted =
       scoped_rows
       |> List.filter (fun row -> row.artifact_scope_count = 0)
       |> List.length
     in
-    if scoped_rows = [] then 0.0
-    else
-      float_of_int drifted /. float_of_int (List.length scoped_rows)
+    let drift =
+      if scoped_rows = [] then 0.0
+      else
+        float_of_int drifted /. float_of_int (List.length scoped_rows)
+    in
+    (drift, active)
   in
   let top_stage =
     rows
@@ -174,6 +182,7 @@ let search_fabric_json (rows : search_row list) =
     ("verification_gate_failures", `Int verification_gate_failures);
     ("rework_rate", `Float rework_rate);
     ("artifact_scope_drift", `Float artifact_scope_drift);
+    ("artifact_scope_active", `Int artifact_scope_active);
     ("top_stage", match top_stage with Some stage -> `String stage | None -> `Null);
   ]
 
@@ -199,6 +208,9 @@ let signals_json ~(pipeline : Yojson.Safe.t) ~(cache : Yojson.Safe.t)
   in
   let artifact_scope_drift =
     get_float_opt search_fabric "artifact_scope_drift" |> Option.value ~default:0.0
+  in
+  let artifact_scope_active =
+    get_int_default search_fabric "artifact_scope_active" 0
   in
   let spec_active = get_int_default speculative "active_sessions" 0 in
   let spec_commit_rate = get_float_opt speculative "commit_rate" |> Option.value ~default:0.0 in
@@ -252,8 +264,12 @@ let signals_json ~(pipeline : Yojson.Safe.t) ~(cache : Yojson.Safe.t)
       ("value", `Float rework_rate);
     ]);
     ("artifact_scope_drift", `Assoc [
-      ("tone", `String (if artifact_scope_drift >= 0.5 then "bad" else if artifact_scope_drift >= 0.25 then "warn" else "ok"));
+      ("tone", `String (if artifact_scope_active = 0 then "ok"  (* no tasks use artifact scopes = feature dormant *)
+                        else if artifact_scope_drift >= 0.5 then "bad"
+                        else if artifact_scope_drift >= 0.25 then "warn"
+                        else "ok"));
       ("value", `Float artifact_scope_drift);
+      ("active", `Int artifact_scope_active);
     ]);
     ("speculative_posture", `Assoc [
       ("tone", `String (if spec_active > 0 && spec_commit_rate < 0.5 then "warn" else "ok"));

--- a/lib/server_routes_http_routes_room.ml
+++ b/lib/server_routes_http_routes_room.ml
@@ -39,8 +39,8 @@ let add_routes router =
          let status_filter = query_param req "status" in
          let include_done = bool_query_param req "include_done" ~default:false in
          let include_cancelled = bool_query_param req "include_cancelled" ~default:false in
-         let limit = int_query_param req "limit" ~default:50 in
-         let offset = int_query_param req "offset" ~default:0 in
+         let limit = int_query_param req "limit" ~default:50 |> clamp ~min_v:1 ~max_v:200 in
+         let offset = int_query_param req "offset" ~default:0 |> clamp ~min_v:0 ~max_v:5000 in
          let tasks = Room.get_tasks_raw config in
          let filtered =
            match status_filter with
@@ -95,8 +95,8 @@ let add_routes router =
        with_public_read (fun state req reqd ->
          let config = state.Mcp_server.room_config in
          let status_filter = query_param req "status" in
-         let limit = int_query_param req "limit" ~default:50 in
-         let offset = int_query_param req "offset" ~default:0 in
+         let limit = int_query_param req "limit" ~default:50 |> clamp ~min_v:1 ~max_v:200 in
+         let offset = int_query_param req "offset" ~default:0 |> clamp ~min_v:0 ~max_v:5000 in
          let agents = Room.get_agents_raw config in
          let filtered =
            match status_filter with

--- a/lib/server_routes_http_routes_trpg.ml
+++ b/lib/server_routes_http_routes_trpg.ml
@@ -340,7 +340,7 @@ let add_routes router =
          Http.Request.read_body_async reqd (fun body_str ->
            match trpg_actor_release_json ~base_dir ~body_str with
            | Ok json ->
-               respond_json_with_cors request reqd
+               respond_json_with_cors ~status:`Created request reqd
                  (Yojson.Safe.to_string json)
            | Error (`Bad_request, msg) ->
                respond_json_with_cors ~status:`Bad_request request reqd


### PR DESCRIPTION
## Summary

QA round 2에서 발견한 4개 이슈 수정:

- **governance case route dead code**: `main_eio.ml`에서 prefix length 23→25 수정. `/api/v1/governance/cases/`는 25자인데 23으로 비교하여 항상 실패하고 fallthrough 라우터에서 처리됨
- **room.ml unclamped query params**: tasks/agents 엔드포인트의 limit/offset에 clamp 추가 (limit: 1-200, offset: 0-5000). social.ml과 동일한 패턴 적용
- **TRPG actors/release HTTP status**: 다른 POST 엔드포인트(spawn/claim/advance)가 201 Created를 반환하는데 release만 200 OK → 201 Created로 통일
- **artifact_scope_drift false positive**: idle 서버에서 모든 태스크에 artifact scope가 없으면(기능 미사용) drift=1.0 → tone "bad" 발생. `artifact_scope_active = 0`일 때 "ok" 반환하는 zero-state guard 추가 (cache_contention 수정과 동일 패턴)

## Test plan

- [x] 56 MCP server tests pass
- [x] 143 perpetual tests pass
- [x] 7 search fabric tests pass
- [x] 31 command plane v2 tests pass
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)