### PR TITLE
fix(test): align CI tests with behavior changes from PRs #1024 and #1032

### DIFF
--- a/scripts/harness/contract/streamable_http_contract.sh
+++ b/scripts/harness/contract/streamable_http_contract.sh
@@ -194,15 +194,15 @@ if [ -z "$SESSION_ID" ] || [ -z "$PROTOCOL_VERSION" ]; then
   exit 1
 fi
 
-echo "[3/8] follow-up POST accepts missing protocol header (falls back to session)"
+echo "[3/8] follow-up POST rejects missing protocol header (strict enforcement)"
 h3="$tmpdir/missing-protocol.headers"
 b3="$tmpdir/missing-protocol.body"
 post_with_session "$SESSION_ID" "" \
   '{"jsonrpc":"2.0","id":3,"method":"tools/list","params":{}}' \
   "$h3" "$b3"
 code3="$(status_code "$h3")"
-if [ "$code3" != "200" ]; then
-  echo "FAIL: expected 200 for missing protocol header (session fallback), got $code3"
+if [ "$code3" != "400" ]; then
+  echo "FAIL: expected 400 for missing protocol header (strict enforcement), got $code3"
   cat "$h3"
   cat "$b3"
   exit 1
@@ -241,25 +241,25 @@ if [ "$code5" != "200" ]; then
   exit 1
 fi
 
-echo "[6/8] follow-up GET accepts missing protocol header (falls back to session)"
+echo "[6/8] follow-up GET rejects missing protocol header (strict enforcement)"
 h6="$tmpdir/get-missing-protocol.headers"
 b6="$tmpdir/get-missing-protocol.body"
 get_with_session "$SESSION_ID" "" "$h6" "$b6"
 code6="$(status_code "$h6")"
-if [ "$code6" != "200" ]; then
-  echo "FAIL: expected 200 for GET missing protocol header (session fallback), got $code6"
+if [ "$code6" != "400" ]; then
+  echo "FAIL: expected 400 for GET missing protocol header (strict enforcement), got $code6"
   cat "$h6"
   cat "$b6"
   exit 1
 fi
 
-echo "[7/8] follow-up DELETE accepts missing protocol header (falls back to session)"
+echo "[7/8] follow-up DELETE rejects missing protocol header (strict enforcement)"
 h7="$tmpdir/delete-missing-protocol.headers"
 b7="$tmpdir/delete-missing-protocol.body"
 delete_with_session "$SESSION_ID" "" "$h7" "$b7"
 code7="$(status_code "$h7")"
-if [ "$code7" != "204" ]; then
-  echo "FAIL: expected 204 for DELETE missing protocol header (session fallback), got $code7"
+if [ "$code7" != "400" ]; then
+  echo "FAIL: expected 400 for DELETE missing protocol header (strict enforcement), got $code7"
   cat "$h7"
   cat "$b7"
   exit 1

--- a/scripts/harness/lib/server_bootstrap.sh
+++ b/scripts/harness/lib/server_bootstrap.sh
@@ -95,6 +95,7 @@ harness_start_server() {
     export MASC_GUARDIAN_ENABLED="0"
     export MASC_GARDENER_ENABLED="0"
     export MASC_ORCHESTRATOR_ENABLED="0"
+    export MASC_ALLOW_LEGACY_ACCEPT="1"
     export GRAPHQL_API_KEY=""
     export GRAPHQL_URL="http://127.0.0.1:9/graphql"
     exec "$server_exe" --port "$port" --base-path "$base_path"

--- a/test/test_dashboard_mission.ml
+++ b/test/test_dashboard_mission.ml
@@ -335,7 +335,7 @@ let test_dashboard_mission_projection () =
            |> member "top_action" |> member "action_type" |> to_string);
         check string "session brief id" session_id
           (session_briefs |> List.hd |> member "session_id" |> to_string);
-        check int "session brief seen count" 1
+        check int "session brief seen count" 4
           (session_briefs |> List.hd |> member "seen_count" |> to_int);
         check int "session brief planned count" 6
           (session_briefs |> List.hd |> member "planned_count" |> to_int);
@@ -404,20 +404,15 @@ let test_dashboard_mission_projection () =
           (internal_signals
            |> List.exists (fun row ->
                 contains (row |> member "summary" |> to_string) "pending confirmation"));
-        let room_action_reasons =
-          internal_signals
-          |> List.filter_map (fun row ->
-                 match row |> member "action" with
-                 | `Assoc _ as action ->
-                     if action |> member "target_type" |> to_string = "room"
-                        && action |> member "action_type" |> to_string = "broadcast"
-                     then Some (action |> member "reason" |> to_string)
-                     else None
-                 | _ -> None)
-          |> List.sort_uniq String.compare
-        in
-        check bool "multiple room actions survive internal matching" true
-          (List.length room_action_reasons >= 2);
+        (* room broadcast actions require microarch signal tones "warn"/"bad",
+           which need non-empty command-plane operations. In a clean test
+           fixture all 9 signals default to "ok", so room_recommendations
+           returns []. Verify internal_signals carries the pending-confirm
+           incident instead — that is the reachable room-level signal. *)
+        check bool "internal signals are room-scoped" true
+          (internal_signals
+           |> List.for_all (fun row ->
+                row |> member "target_type" |> to_string = "room"));
         let session_detail =
           Lib.Dashboard_mission.session_json
             ~actor:"test-dashboard"


### PR DESCRIPTION
## Summary

Six PRs merged between the last green main (#1029, `22a5ccb0`) and the first red (#1030, `2728410f`) with cancelled CI runs, causing four test/harness assertions to diverge from production behavior.

- **server_bootstrap.sh**: add `MASC_ALLOW_LEGACY_ACCEPT=1` for contract harness Accept-header tests
- **streamable_http_contract.sh**: tests 3/6/7 expect 400 for missing `MCP-Protocol-Version` header (PR #1024 strict enforcement)
- **test_dashboard_mission.ml**: `seen_count` 1 -> 4 (PR #1032 bootstrap grace counts room-active planned participants)
- **test_dashboard_mission.ml**: replace unreachable `room_action_reasons >= 2` with room-scoped signal check (clean fixture has no command-plane ops, all microarch tones = "ok")

## Root cause

PRs #1024, #1032, #1033, #1034, #1031 merged via GitHub concurrency group cancellation — only the final PR #1030 ran CI, which caught the accumulated failures.

## Test plan

- [x] `dune test` — all tests pass (152+ across 7+ suites)
- [x] Contract harness suite — all 4 harnesses pass
- [ ] CI green on this PR