### PR TITLE
docs: point chain runtime examples to masc-mcp

### DIFF
--- a/data/chains/MCTS-MANTRA-README.md
+++ b/data/chains/MCTS-MANTRA-README.md
@@ -32,9 +32,11 @@ Monte Carlo Tree Search 기반 MANTRA 코드 리뷰 체인 시스템.
 
 ### 사용법
 
+`masc-mcp` is the canonical chain runtime. Run the native chain server on port `8935`; old `llm-mcp` `8932` examples are retired.
+
 ```bash
 # MCP tool call
-curl -X POST http://localhost:8932/mcp -d '{
+curl -X POST http://localhost:8935/mcp -d '{
   "jsonrpc": "2.0",
   "method": "tools/call",
   "params": {

--- a/data/chains/examples/README.md
+++ b/data/chains/examples/README.md
@@ -2,10 +2,12 @@
 
 ## 🚀 Quick Start
 
+`masc-mcp` is now the canonical chain runtime. These examples target the native chain server on port `8935`; older `llm-mcp` `8932` references are retired.
+
 ### 1. Mermaid DSL로 바로 실행
 ```bash
 # 터미널에서
-curl -X POST http://localhost:8932/mcp \
+curl -X POST http://localhost:8935/mcp \
   -H "Content-Type: application/json" \
   -d '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"chain.run","arguments":{"mermaid":"graph LR\n    A[LLM:ollama \"Hello\"]"}}}'
 ```

--- a/lib/chain_log.ml
+++ b/lib/chain_log.ml
@@ -4,7 +4,7 @@
 
     Usage:
     {[
-      let () = Log.info "mcp_server" "Starting server on port %d" 8932
+      let () = Log.info "mcp_server" "Starting server on port %d" 8935
       let () = Log.warn "chain" "Node %s timed out" node_id
       let () = Log.error "gemini" ~ctx:[("model", model)] "Rate limit exceeded"
     ]}


### PR DESCRIPTION
## Summary
- update active chain example docs to use masc-mcp on port 8935
- add a short retirement note where llm-mcp was previously implied
- fix the chain_log example comment to match the canonical runtime

## Verification
- rg -n "8932|llm-mcp" data/chains lib
- git diff --check