### PR TITLE
feat(team-session): add oas-backed local workers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,9 @@ jobs:
           chmod +x scripts/opam-pin-external-deps.sh
           scripts/opam-pin-external-deps.sh --with-bisect
 
+      - name: Pin agent_sdk to latest OAS
+        run: opam pin add -y agent_sdk git+https://github.com/jeong-sik/oas.git#main
+
       - name: Refresh system package index
         run: sudo apt-get update -qq
 
@@ -155,6 +158,9 @@ jobs:
           chmod +x scripts/opam-pin-external-deps.sh
           scripts/opam-pin-external-deps.sh --with-bisect
 
+      - name: Pin agent_sdk to latest OAS
+        run: opam pin add -y agent_sdk git+https://github.com/jeong-sik/oas.git#main
+
       - name: Refresh system package index
         run: sudo apt-get update -qq
 
@@ -236,6 +242,9 @@ jobs:
           chmod +x scripts/opam-pin-external-deps.sh
           scripts/opam-pin-external-deps.sh
 
+      - name: Pin agent_sdk to latest OAS
+        run: opam pin add -y agent_sdk git+https://github.com/jeong-sik/oas.git#main
+
       - name: Refresh system package index
         run: sudo apt-get update -qq
 
@@ -303,6 +312,9 @@ jobs:
           chmod +x scripts/opam-pin-external-deps.sh
           scripts/opam-pin-external-deps.sh
 
+      - name: Pin agent_sdk to latest OAS
+        run: opam pin add -y agent_sdk git+https://github.com/jeong-sik/oas.git#main
+
       - name: Refresh system package index
         run: sudo apt-get update -qq
 
@@ -344,6 +356,9 @@ jobs:
         run: |
           chmod +x scripts/opam-pin-external-deps.sh
           scripts/opam-pin-external-deps.sh
+
+      - name: Pin agent_sdk to latest OAS
+        run: opam pin add -y agent_sdk git+https://github.com/jeong-sik/oas.git#main
 
       - name: Refresh system package index
         run: sudo apt-get update -qq

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,9 +45,6 @@ jobs:
           chmod +x scripts/opam-pin-external-deps.sh
           scripts/opam-pin-external-deps.sh --with-bisect
 
-      - name: Pin agent_sdk to latest OAS
-        run: opam pin add -y agent_sdk git+https://github.com/jeong-sik/oas.git#main
-
       - name: Refresh system package index
         run: sudo apt-get update -qq
 
@@ -158,9 +155,6 @@ jobs:
           chmod +x scripts/opam-pin-external-deps.sh
           scripts/opam-pin-external-deps.sh --with-bisect
 
-      - name: Pin agent_sdk to latest OAS
-        run: opam pin add -y agent_sdk git+https://github.com/jeong-sik/oas.git#main
-
       - name: Refresh system package index
         run: sudo apt-get update -qq
 
@@ -242,9 +236,6 @@ jobs:
           chmod +x scripts/opam-pin-external-deps.sh
           scripts/opam-pin-external-deps.sh
 
-      - name: Pin agent_sdk to latest OAS
-        run: opam pin add -y agent_sdk git+https://github.com/jeong-sik/oas.git#main
-
       - name: Refresh system package index
         run: sudo apt-get update -qq
 
@@ -312,9 +303,6 @@ jobs:
           chmod +x scripts/opam-pin-external-deps.sh
           scripts/opam-pin-external-deps.sh
 
-      - name: Pin agent_sdk to latest OAS
-        run: opam pin add -y agent_sdk git+https://github.com/jeong-sik/oas.git#main
-
       - name: Refresh system package index
         run: sudo apt-get update -qq
 
@@ -356,9 +344,6 @@ jobs:
         run: |
           chmod +x scripts/opam-pin-external-deps.sh
           scripts/opam-pin-external-deps.sh
-
-      - name: Pin agent_sdk to latest OAS
-        run: opam pin add -y agent_sdk git+https://github.com/jeong-sik/oas.git#main
 
       - name: Refresh system package index
         run: sudo apt-get update -qq

--- a/.github/workflows/deploy-railway.yml
+++ b/.github/workflows/deploy-railway.yml
@@ -27,6 +27,9 @@ jobs:
           chmod +x scripts/opam-pin-external-deps.sh
           scripts/opam-pin-external-deps.sh --with-compact-protocol
 
+      - name: Pin agent_sdk to latest OAS
+        run: opam pin add -y agent_sdk git+https://github.com/jeong-sik/oas.git#main
+
       - name: Refresh apt index
         run: sudo apt-get update
 

--- a/.github/workflows/deploy-railway.yml
+++ b/.github/workflows/deploy-railway.yml
@@ -27,8 +27,6 @@ jobs:
           chmod +x scripts/opam-pin-external-deps.sh
           scripts/opam-pin-external-deps.sh --with-compact-protocol
 
-      - name: Pin agent_sdk to latest OAS
-        run: opam pin add -y agent_sdk git+https://github.com/jeong-sik/oas.git#main
 
       - name: Refresh apt index
         run: sudo apt-get update

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,8 +39,6 @@ jobs:
           chmod +x scripts/opam-pin-external-deps.sh
           scripts/opam-pin-external-deps.sh --with-compact-protocol
 
-      - name: Pin agent_sdk to latest OAS
-        run: opam pin add -y agent_sdk git+https://github.com/jeong-sik/oas.git#main
 
       - name: Install libpq (macOS)
         if: runner.os == 'macOS'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,6 +39,9 @@ jobs:
           chmod +x scripts/opam-pin-external-deps.sh
           scripts/opam-pin-external-deps.sh --with-compact-protocol
 
+      - name: Pin agent_sdk to latest OAS
+        run: opam pin add -y agent_sdk git+https://github.com/jeong-sik/oas.git#main
+
       - name: Install libpq (macOS)
         if: runner.os == 'macOS'
         run: |

--- a/bin/dune
+++ b/bin/dune
@@ -8,6 +8,13 @@
  (libraries masc_mcp council cmdliner eio eio_main h2 h2-eio httpun-eio gluten-eio caqti-eio dune-build-info))
 
 (executable
+ (name main_stdio_eio)
+ (modules main_stdio_eio)
+ (public_name masc-mcp-stdio)
+ (package masc_mcp)
+ (libraries masc_mcp cmdliner eio eio_main dune-build-info))
+
+(executable
  (name masc_cost)
  (modules masc_cost)
  (public_name masc-cost)

--- a/bin/main_stdio_eio.ml
+++ b/bin/main_stdio_eio.ml
@@ -1,0 +1,46 @@
+[@@@warning "-32-69"]
+
+module Mcp_eio = Masc_mcp.Mcp_server_eio
+module Server_runtime_bootstrap = Masc_mcp.Server_runtime_bootstrap
+module Shutdown_hooks = Masc_mcp.Shutdown_hooks
+module Board_dispatch = Masc_mcp.Board_dispatch
+
+open Cmdliner
+
+let default_base_path () = Masc_mcp.Server_mcp_transport_http.default_base_path ()
+
+let base_path =
+  let doc = "Base path for MASC data (.masc folder location)" in
+  Arg.(value & opt string (default_base_path ()) & info ["base-path"] ~docv:"PATH" ~doc)
+
+let run_cmd base_path =
+  Eio_main.run @@ fun env ->
+  Mirage_crypto_rng_unix.use_default ();
+  Masc_mcp.Prometheus.enable_eio ();
+  Masc_mcp.Llm_response_cache.enable_eio ();
+  Masc_mcp.Time_compat.set_clock (Eio.Stdenv.clock env);
+  Masc_mcp.Cancellation.TokenStore.init ();
+  Eio.Switch.run @@ fun sw ->
+  let clock, mono_clock, net, _domain_mgr, proc_mgr, fs =
+    Server_runtime_bootstrap.init_runtime_context env
+  in
+  let state =
+    Server_runtime_bootstrap.create_server_state ~sw ~base_path ~clock
+      ~mono_clock ~net ~proc_mgr ~fs
+  in
+  Server_runtime_bootstrap.bootstrap_server_state state;
+  Server_runtime_bootstrap.bootstrap_keepers ~sw ~clock state;
+  Server_runtime_bootstrap.init_task_backend ();
+  ignore (Server_runtime_bootstrap.start_background_maintenance ~sw ~clock state);
+  Fun.protect
+    ~finally:(fun () ->
+      (try Board_dispatch.flush () with _ -> ());
+      Shutdown_hooks.run_all ())
+    (fun () -> Mcp_eio.run_stdio ~sw ~env state)
+
+let cmd =
+  let doc = "MASC MCP Server (stdio, Eio)" in
+  let info = Cmd.info "masc-mcp-stdio" ~version:Masc_mcp.Version.version ~doc in
+  Cmd.v info Term.(const run_cmd $ base_path)
+
+let () = exit (Cmd.eval cmd)

--- a/dune-project
+++ b/dune-project
@@ -35,7 +35,7 @@
   (cmdliner (>= 1.1))
   (cohttp (>= 5.0))
   (cohttp-eio (and (>= 6.0) (< 6.2)))
-  (agent_sdk (>= 0.5.0))
+  (agent_sdk (>= 0.9.1))
   (uri (>= 4.4))
   (tls (>= 0.16))
   (tls-eio (>= 0.16))

--- a/lib/agent_swarm_dev_tools.ml
+++ b/lib/agent_swarm_dev_tools.ml
@@ -70,7 +70,7 @@ let validate_path ?workdir path =
 
 (** shell_exec intentionally supports only a narrow allowlist of dev/test
     commands and rejects shell control syntax to keep execution predictable. *)
-let allowed_commands =
+let dev_allowed_commands =
   [
     "cat"; "cargo"; "cmake"; "cut"; "dune"; "echo"; "env"; "file"; "find";
     "git"; "go"; "gofmt"; "gradle"; "grep"; "head"; "java"; "javac"; "ls";
@@ -78,6 +78,13 @@ let allowed_commands =
     "printf"; "pwd"; "pyright"; "pytest"; "python"; "python3"; "rg"; "ruff";
     "rustc"; "sed"; "sort"; "stat"; "tail"; "tr"; "uniq"; "uv"; "wc";
     "which"; "yarn";
+  ]
+
+let readonly_allowed_commands =
+  [
+    "cat"; "cut"; "echo"; "env"; "file"; "find"; "grep"; "head"; "ls";
+    "printf"; "pwd"; "rg"; "sed"; "sort"; "stat"; "tail"; "tr"; "uniq";
+    "wc"; "which";
   ]
 
 let forbidden_shell_chars =
@@ -101,7 +108,7 @@ let extract_command_name cmd =
     let token = String.sub trimmed 0 (find_sep 0) in
     Some (Filename.basename token)
 
-let validate_command cmd =
+let validate_command_with_allowlist ~allowed_commands cmd =
   let trimmed = String.trim cmd in
   if trimmed = "" then Error "command must not be empty"
   else if contains_forbidden_shell_chars trimmed then
@@ -115,6 +122,9 @@ let validate_command cmd =
         (Printf.sprintf
            "Command blocked: %s is not in the approved dev command allowlist"
            name)
+
+let validate_command cmd =
+  validate_command_with_allowlist ~allowed_commands:dev_allowed_commands cmd
 
 (* --- Recursive mkdir --- *)
 
@@ -189,14 +199,11 @@ let make_file_write ?workdir () =
            with Sys_error msg ->
              Error (Printf.sprintf "Cannot write: %s" msg))
 
-let make_shell_exec ~proc_mgr ~clock =
+let make_shell_exec_with_allowlist ~proc_mgr ~clock ~allowed_commands
+    ~description =
   Agent_sdk.Tool.create
     ~name:"shell_exec"
-    ~description:"Execute a shell command and return stdout+stderr. \
-      Timeout: 30s default, max 120s. \
-      Use for: running tests, git commands, build tools, directory listing. \
-      Unlike file_read (single file), this handles approved CLI operations. \
-      Commands run in /bin/sh but shell control syntax is rejected."
+    ~description
     ~parameters:[
       { name = "command";
         description = "Shell command to execute";
@@ -209,7 +216,7 @@ let make_shell_exec ~proc_mgr ~clock =
        match Agent_swarm_tool_input.extract_string "command" input with
        | Error e -> Error e
        | Ok command ->
-         (match validate_command command with
+         (match validate_command_with_allowlist ~allowed_commands command with
           | Error e -> Error e
           | Ok () ->
            let timeout =
@@ -240,9 +247,32 @@ let make_shell_exec ~proc_mgr ~clock =
            with exn ->
              Error (Printf.sprintf "Command failed: %s" (Printexc.to_string exn))))
 
+let make_shell_exec ~proc_mgr ~clock =
+  make_shell_exec_with_allowlist ~proc_mgr ~clock
+    ~allowed_commands:dev_allowed_commands
+    ~description:
+      "Execute a shell command and return stdout+stderr. \
+       Timeout: 30s default, max 120s. \
+       Use for: running tests, git commands, build tools, directory listing. \
+       Unlike file_read (single file), this handles approved CLI operations. \
+       Commands run in /bin/sh but shell control syntax is rejected."
+
+let make_shell_exec_readonly ~proc_mgr ~clock =
+  make_shell_exec_with_allowlist ~proc_mgr ~clock
+    ~allowed_commands:readonly_allowed_commands
+    ~description:
+      "Execute a read-only shell command and return stdout+stderr. \
+       Timeout: 30s default, max 120s. \
+       Use for search, inspection, and verification only. \
+       Write-oriented commands are intentionally excluded."
+
 (** Create dev tools that close over Eio capabilities.
     Returns [file_read; file_write; shell_exec]. *)
 let make_tools ~proc_mgr ~clock ?workdir () : Agent_sdk.Tool.t list =
   [ make_file_read ?workdir ();
     make_file_write ?workdir ();
     make_shell_exec ~proc_mgr ~clock ]
+
+let make_readonly_tools ~proc_mgr ~clock ?workdir () : Agent_sdk.Tool.t list =
+  [ make_file_read ?workdir ();
+    make_shell_exec_readonly ~proc_mgr ~clock ]

--- a/lib/agent_swarm_swarm.ml
+++ b/lib/agent_swarm_swarm.ml
@@ -362,7 +362,7 @@ let run_agent ~sw ~net ~clock ~masc_url ?(extra_tools=[]) spec ~goal =
             | Ok response ->
                 ensure_expected_final_marker response
                   ~expected_final_marker:spec.expected_final_marker
-            | Error _ as error -> error
+            | Error err -> Error (Agent_sdk__Error.to_string err)
           in
           let result =
             match result, managed_task with

--- a/lib/local_agent_eio.ml
+++ b/lib/local_agent_eio.ml
@@ -934,10 +934,15 @@ let load_worker_meta ~base_path ~team_session_id ~worker_name =
 
 let save_worker_meta ~base_path ~team_session_id ~worker_name
     (meta : worker_container_meta) =
-  ensure_worker_container_dirs ~base_path ~team_session_id ~worker_name;
-  Team_session_store.write_text_file
-    (worker_meta_path ~base_path ~team_session_id ~worker_name)
-    (meta |> worker_meta_to_yojson |> Yojson.Safe.pretty_to_string)
+  try
+    ensure_worker_container_dirs ~base_path ~team_session_id ~worker_name;
+    Team_session_store.write_text_file
+      (worker_meta_path ~base_path ~team_session_id ~worker_name)
+      (meta |> worker_meta_to_yojson |> Yojson.Safe.pretty_to_string);
+    Ok ()
+  with Sys_error msg ->
+    Error
+      (sprintf "failed to save worker meta for %s: %s" worker_name msg)
 
 let load_worker_checkpoint ~base_path ~team_session_id ~worker_name =
   let path =
@@ -952,16 +957,26 @@ let load_worker_checkpoint ~base_path ~team_session_id ~worker_name =
     None
 
 let save_worker_checkpoint ~base_path ~team_session_id ~worker_name checkpoint =
-  ensure_worker_container_dirs ~base_path ~team_session_id ~worker_name;
-  Team_session_store.write_text_file
-    (worker_checkpoint_path ~base_path ~team_session_id ~worker_name)
-    (Oas.Checkpoint.to_string checkpoint)
+  try
+    ensure_worker_container_dirs ~base_path ~team_session_id ~worker_name;
+    Team_session_store.write_text_file
+      (worker_checkpoint_path ~base_path ~team_session_id ~worker_name)
+      (Oas.Checkpoint.to_string checkpoint);
+    Ok ()
+  with Sys_error msg ->
+    Error
+      (sprintf "failed to save worker checkpoint for %s: %s" worker_name msg)
 
 let append_worker_turn_log ~base_path ~team_session_id ~worker_name json =
-  ensure_worker_container_dirs ~base_path ~team_session_id ~worker_name;
-  Team_session_store.append_text_file
-    (worker_turn_log_path ~base_path ~team_session_id ~worker_name)
-    (Yojson.Safe.to_string json ^ "\n")
+  try
+    ensure_worker_container_dirs ~base_path ~team_session_id ~worker_name;
+    Team_session_store.append_text_file
+      (worker_turn_log_path ~base_path ~team_session_id ~worker_name)
+      (Yojson.Safe.to_string json ^ "\n");
+    Ok ()
+  with Sys_error msg ->
+    Error
+      (sprintf "failed to append worker turn log for %s: %s" worker_name msg)
 
 let resolved_mcp_session_id ~base_path ~team_session_id ~worker_name =
   match load_worker_meta ~base_path ~team_session_id ~worker_name with
@@ -1237,16 +1252,22 @@ let run_worker_oas ~sw ~base_path ~worker_name
           let tool_names =
             List.rev !tool_names_ref |> unique_preserve_order
           in
-          save_worker_checkpoint ~base_path ~team_session_id ~worker_name
-            checkpoint;
-          save_worker_meta ~base_path ~team_session_id ~worker_name
-            { meta with last_run_at = Some (Time_compat.now ()) };
+          let* () =
+            save_worker_checkpoint ~base_path ~team_session_id ~worker_name
+              checkpoint
+          in
+          let* () =
+            save_worker_meta ~base_path ~team_session_id ~worker_name
+              { meta with last_run_at = Some (Time_compat.now ()) }
+          in
           Oas.Agent.close agent;
           match result with
           | Ok response ->
               let output = oas_extract_text response in
-              append_worker_completion_log ~base_path ~team_session_id
-                ~worker_name ~prompt ~tool_names ~status:"ok" ~output ();
+              let* () =
+                append_worker_completion_log ~base_path ~team_session_id
+                  ~worker_name ~prompt ~tool_names ~status:"ok" ~output ()
+              in
               Ok
                 {
                   output;
@@ -1264,9 +1285,11 @@ let run_worker_oas ~sw ~base_path ~worker_name
                 }
           | Error err ->
               let detail = Agent_sdk__Error.to_string err in
-              append_worker_completion_log ~base_path ~team_session_id
-                ~worker_name ~prompt ~tool_names ~status:"error"
-                ~output:detail ~error:detail ();
+              let* () =
+                append_worker_completion_log ~base_path ~team_session_id
+                  ~worker_name ~prompt ~tool_names ~status:"error"
+                  ~output:detail ~error:detail ()
+              in
               Error detail)
 
 let continue_worker ~sw ~base_path ~worker_name ~(team_session_id : string)
@@ -1365,16 +1388,22 @@ let continue_worker ~sw ~base_path ~worker_name ~(team_session_id : string)
               let tool_names =
                 List.rev !tool_names_ref |> unique_preserve_order
               in
-              save_worker_checkpoint ~base_path ~team_session_id ~worker_name
-                next_checkpoint;
-              save_worker_meta ~base_path ~team_session_id ~worker_name
-                { meta with last_run_at = Some (Time_compat.now ()) };
+              let* () =
+                save_worker_checkpoint ~base_path ~team_session_id ~worker_name
+                  next_checkpoint
+              in
+              let* () =
+                save_worker_meta ~base_path ~team_session_id ~worker_name
+                  { meta with last_run_at = Some (Time_compat.now ()) }
+              in
               Oas.Agent.close agent;
               match result with
               | Ok response ->
                   let output = oas_extract_text response in
-                  append_worker_completion_log ~base_path ~team_session_id
-                    ~worker_name ~prompt ~tool_names ~status:"ok" ~output ();
+                  let* () =
+                    append_worker_completion_log ~base_path ~team_session_id
+                      ~worker_name ~prompt ~tool_names ~status:"ok" ~output ()
+                  in
                   Ok
                     {
                       output;
@@ -1393,12 +1422,14 @@ let continue_worker ~sw ~base_path ~worker_name ~(team_session_id : string)
                       tool_names;
                       session_id = meta.mcp_session_id;
                     }
-          | Error err ->
-              let detail = Agent_sdk__Error.to_string err in
-              append_worker_completion_log ~base_path ~team_session_id
-                ~worker_name ~prompt ~tool_names ~status:"error"
-                ~output:detail ~error:detail ();
-              Error detail))
+              | Error err ->
+                  let detail = Agent_sdk__Error.to_string err in
+                  let* () =
+                    append_worker_completion_log ~base_path ~team_session_id
+                      ~worker_name ~prompt ~tool_names ~status:"error"
+                      ~output:detail ~error:detail ()
+                  in
+                  Error detail))
 
 let run_worker_legacy ~sw ~base_path ~worker_name
     ~(model : Llm_client.model_spec) ~team_session_id ~role

--- a/lib/local_agent_eio.ml
+++ b/lib/local_agent_eio.ml
@@ -1,5 +1,9 @@
 open Printf
 
+module Oas = Agent_sdk
+
+let ( let* ) = Result.bind
+
 type tool_exec_result = {
   text : string;
   is_error : bool;
@@ -15,6 +19,36 @@ type run_result = {
   tool_names : string list;
   session_id : string;
 }
+
+type tool_profile =
+  | Profile_session_min
+  | Profile_session_dev
+
+type shell_profile =
+  | Shell_none
+  | Shell_readonly
+  | Shell_dev
+
+type worker_container_meta = {
+  version : int;
+  worker_name : string;
+  mcp_session_id : string;
+  team_session_id : string option;
+  role : string option;
+  selection_note : string option;
+  execution_scope : Team_session_types.execution_scope;
+  tool_profile : tool_profile;
+  shell_profile : shell_profile;
+  worker_class : Team_session_types.worker_class option;
+  worker_size : Team_session_types.worker_size option;
+  effective_model : string;
+  effective_tier : Team_session_types.model_tier option;
+  checkpoint_path : string;
+  turn_log_path : string;
+  last_run_at : float option;
+}
+
+let worker_container_version = 1
 
 let jsonrpc_id = ref 1000
 
@@ -641,6 +675,299 @@ let worker_auth_token ~base_path ~worker_name =
   else
     Ok None
 
+let configured_backend () =
+  match Sys.getenv_opt "MASC_LOCAL_WORKER_BACKEND" with
+  | Some raw when String.lowercase_ascii (String.trim raw) = "legacy" -> `Legacy
+  | _ -> `Oas
+
+let tool_profile_to_string = function
+  | Profile_session_min -> "session_min"
+  | Profile_session_dev -> "session_dev"
+
+let tool_profile_of_string = function
+  | "session_min" -> Some Profile_session_min
+  | "session_dev" -> Some Profile_session_dev
+  | _ -> None
+
+let shell_profile_to_string = function
+  | Shell_none -> "none"
+  | Shell_readonly -> "readonly"
+  | Shell_dev -> "dev"
+
+let shell_profile_of_string = function
+  | "none" -> Some Shell_none
+  | "readonly" -> Some Shell_readonly
+  | "dev" -> Some Shell_dev
+  | _ -> None
+
+let worker_container_root ~base_path ~(team_session_id : string option) =
+  match team_session_id with
+  | Some session_id ->
+      Filename.concat
+        (Filename.concat
+           (Filename.concat (Filename.concat base_path ".masc") "team-sessions")
+           session_id)
+        "workers"
+  | None ->
+      Filename.concat (Filename.concat base_path ".masc") "local-workers"
+
+let safe_worker_token worker_name =
+  worker_name
+  |> String.to_seq
+  |> Seq.map (function
+       | ('a' .. 'z' | 'A' .. 'Z' | '0' .. '9' | '-' | '_' | '.') as ch -> ch
+       | _ -> '_')
+  |> String.of_seq
+
+let worker_container_dir ~base_path ~(team_session_id : string option)
+    ~worker_name =
+  Filename.concat
+    (worker_container_root ~base_path ~team_session_id)
+    (safe_worker_token worker_name)
+
+let worker_meta_path ~base_path ~team_session_id ~worker_name =
+  Filename.concat
+    (worker_container_dir ~base_path ~team_session_id ~worker_name)
+    "meta.json"
+
+let worker_checkpoint_path ~base_path ~team_session_id ~worker_name =
+  Filename.concat
+    (worker_container_dir ~base_path ~team_session_id ~worker_name)
+    "checkpoint.json"
+
+let worker_turn_log_path ~base_path ~team_session_id ~worker_name =
+  Filename.concat
+    (worker_container_dir ~base_path ~team_session_id ~worker_name)
+    "turns.jsonl"
+
+let ensure_worker_container_dirs ~base_path ~team_session_id ~worker_name =
+  let dir = worker_container_dir ~base_path ~team_session_id ~worker_name in
+  Team_session_store.write_text_file (Filename.concat dir ".keep") "";
+  (try Sys.remove (Filename.concat dir ".keep") with Sys_error _ -> ())
+
+let stable_worker_session_id ?team_session_id worker_name =
+  let basis =
+    String.concat "\n"
+      [
+        worker_name;
+        Option.value ~default:"global" team_session_id;
+      ]
+  in
+  let digest = Digest.string basis |> Digest.to_hex in
+  sprintf "worker-%s" (String.sub digest 0 12)
+
+let session_min_tool_names =
+  Agent_tool_surfaces.llama_worker_tool_names
+
+let execution_scope_or_default = function
+  | Some scope -> scope
+  | None -> Team_session_types.Limited_code_change
+
+let infer_model_tier_from_model_name model_name =
+  let model_name = String.trim model_name in
+  let haystack = String.lowercase_ascii model_name in
+  let contains needle =
+    let needle = String.lowercase_ascii needle in
+    let needle_len = String.length needle in
+    let haystack_len = String.length haystack in
+    let rec loop idx =
+      if needle_len = 0 then true
+      else if idx + needle_len > haystack_len then false
+      else if String.sub haystack idx needle_len = needle then true
+      else loop (idx + 1)
+    in
+    loop 0
+  in
+  if model_name = "" then
+    None
+  else if contains "35b" then
+      Some Team_session_types.Tier_35b
+  else if contains "27b" then
+      Some Team_session_types.Tier_27b
+  else if contains "9b" then
+      Some Team_session_types.Tier_9b
+  else
+    None
+
+let worker_profiles_of_scope scope =
+  match scope with
+  | Team_session_types.Observe_only ->
+      (Profile_session_min, Shell_readonly)
+  | Team_session_types.Limited_code_change ->
+      (Profile_session_dev, Shell_dev)
+
+let derive_effective_tier worker_size model_id =
+  match worker_size with
+  | Some size -> Team_session_types.model_tier_of_worker_size size
+  | None -> infer_model_tier_from_model_name model_id
+
+let effective_worker_size worker_size model_id =
+  match worker_size with
+  | Some _ as explicit -> explicit
+  | None ->
+      Option.bind
+        (infer_model_tier_from_model_name model_id)
+        Team_session_types.worker_size_of_model_tier
+
+let worker_meta_to_yojson (meta : worker_container_meta) =
+  `Assoc
+    [
+      ("version", `Int meta.version);
+      ("worker_name", `String meta.worker_name);
+      ("mcp_session_id", `String meta.mcp_session_id);
+      ( "team_session_id",
+        Option.fold ~none:`Null ~some:(fun s -> `String s) meta.team_session_id
+      );
+      ("role", Option.fold ~none:`Null ~some:(fun s -> `String s) meta.role);
+      ( "selection_note",
+        Option.fold ~none:`Null ~some:(fun s -> `String s) meta.selection_note
+      );
+      ( "execution_scope",
+        `String
+          (Team_session_types.execution_scope_to_string meta.execution_scope) );
+      ("tool_profile", `String (tool_profile_to_string meta.tool_profile));
+      ("shell_profile", `String (shell_profile_to_string meta.shell_profile));
+      ( "worker_class",
+        Option.fold ~none:`Null
+          ~some:(fun kind ->
+            `String (Team_session_types.worker_class_to_string kind))
+          meta.worker_class );
+      ( "worker_size",
+        Option.fold ~none:`Null
+          ~some:(fun size ->
+            `String (Team_session_types.worker_size_to_string size))
+          meta.worker_size );
+      ("effective_model", `String meta.effective_model);
+      ( "effective_tier",
+        Option.fold ~none:`Null
+          ~some:(fun tier ->
+            `String (Team_session_types.model_tier_to_string tier))
+          meta.effective_tier );
+      ("checkpoint_path", `String meta.checkpoint_path);
+      ("turn_log_path", `String meta.turn_log_path);
+      ( "last_run_at",
+        Option.fold ~none:`Null ~some:(fun ts -> `Float ts) meta.last_run_at );
+    ]
+
+let worker_meta_of_yojson json =
+  let open Yojson.Safe.Util in
+  match json with
+  | `Assoc _ -> (
+      match json |> member "worker_name" |> to_string_option with
+      | None -> None
+      | Some worker_name ->
+          let execution_scope =
+            json |> member "execution_scope" |> to_string_option
+            |> Option.map (fun value ->
+                   Team_session_types.execution_scope_of_string
+                     (String.lowercase_ascii (String.trim value)))
+            |> execution_scope_or_default
+          in
+          Some
+            {
+              version =
+                json |> member "version" |> to_int_option
+                |> Option.value ~default:worker_container_version;
+              worker_name;
+              mcp_session_id =
+                json |> member "mcp_session_id" |> to_string_option
+                |> Option.value ~default:(stable_worker_session_id worker_name);
+              team_session_id =
+                json |> member "team_session_id" |> to_string_option;
+              role = json |> member "role" |> to_string_option;
+              selection_note =
+                json |> member "selection_note" |> to_string_option;
+              execution_scope;
+              tool_profile =
+                (match json |> member "tool_profile" |> to_string_option with
+                | Some value -> (
+                    match tool_profile_of_string value with
+                    | Some profile -> profile
+                    | None -> fst (worker_profiles_of_scope execution_scope))
+                | None -> fst (worker_profiles_of_scope execution_scope));
+              shell_profile =
+                (match json |> member "shell_profile" |> to_string_option with
+                | Some value -> (
+                    match shell_profile_of_string value with
+                    | Some profile -> profile
+                    | None -> snd (worker_profiles_of_scope execution_scope))
+                | None -> snd (worker_profiles_of_scope execution_scope));
+              worker_class =
+                (match json |> member "worker_class" |> to_string_option with
+                | Some value ->
+                    Team_session_types.worker_class_of_string
+                      (String.lowercase_ascii (String.trim value))
+                | None -> None);
+              worker_size =
+                (match json |> member "worker_size" |> to_string_option with
+                | Some value ->
+                    Team_session_types.worker_size_of_string
+                      (String.lowercase_ascii (String.trim value))
+                | None -> None);
+              effective_model =
+                json |> member "effective_model" |> to_string_option
+                |> Option.value ~default:"";
+              effective_tier =
+                (match json |> member "effective_tier" |> to_string_option with
+                | Some value ->
+                    Team_session_types.model_tier_of_string
+                      (String.lowercase_ascii (String.trim value))
+                | None -> None);
+              checkpoint_path =
+                json |> member "checkpoint_path" |> to_string_option
+                |> Option.value ~default:"";
+              turn_log_path =
+                json |> member "turn_log_path" |> to_string_option
+                |> Option.value ~default:"";
+              last_run_at = json |> member "last_run_at" |> to_float_option;
+            })
+  | _ -> None
+
+let load_worker_meta ~base_path ~team_session_id ~worker_name =
+  let path = worker_meta_path ~base_path ~team_session_id ~worker_name in
+  if Sys.file_exists path then
+    try
+      Yojson.Safe.from_file path |> worker_meta_of_yojson
+    with Yojson.Json_error _ | Sys_error _ -> None
+  else
+    None
+
+let save_worker_meta ~base_path ~team_session_id ~worker_name
+    (meta : worker_container_meta) =
+  ensure_worker_container_dirs ~base_path ~team_session_id ~worker_name;
+  Team_session_store.write_text_file
+    (worker_meta_path ~base_path ~team_session_id ~worker_name)
+    (meta |> worker_meta_to_yojson |> Yojson.Safe.pretty_to_string)
+
+let load_worker_checkpoint ~base_path ~team_session_id ~worker_name =
+  let path =
+    worker_checkpoint_path ~base_path ~team_session_id ~worker_name
+  in
+  if Sys.file_exists path then
+    try
+      let raw = In_channel.with_open_text path In_channel.input_all in
+      Oas.Checkpoint.of_string raw |> Result.to_option
+    with Sys_error _ -> None
+  else
+    None
+
+let save_worker_checkpoint ~base_path ~team_session_id ~worker_name checkpoint =
+  ensure_worker_container_dirs ~base_path ~team_session_id ~worker_name;
+  Team_session_store.write_text_file
+    (worker_checkpoint_path ~base_path ~team_session_id ~worker_name)
+    (Oas.Checkpoint.to_string checkpoint)
+
+let append_worker_turn_log ~base_path ~team_session_id ~worker_name json =
+  ensure_worker_container_dirs ~base_path ~team_session_id ~worker_name;
+  Team_session_store.append_text_file
+    (worker_turn_log_path ~base_path ~team_session_id ~worker_name)
+    (Yojson.Safe.to_string json ^ "\n")
+
+let resolved_mcp_session_id ~base_path ~team_session_id ~worker_name =
+  match load_worker_meta ~base_path ~team_session_id ~worker_name with
+  | Some meta when String.trim meta.mcp_session_id <> "" -> meta.mcp_session_id
+  | _ -> stable_worker_session_id ?team_session_id worker_name
+
 let start_worker_heartbeat ~sw ~(auth_token : string option) ~session_id
     ~worker_name =
   let interval = local_worker_heartbeat_interval_sec () in
@@ -672,151 +999,498 @@ let start_worker_heartbeat ~sw ~(auth_token : string option) ~session_id
               worker_name (Printexc.to_string exn));
       fun () -> active := false
 
-let run_worker ~sw ~base_path ~worker_name ~model ~team_session_id ~role
-    ~selection_note
+let resolve_execution_scope ~base_path ~(team_session_id : string option)
+    ?execution_scope () =
+  match execution_scope with
+  | Some scope -> scope
+  | None -> (
+      match team_session_id with
+      | Some session_id -> (
+          match Team_session_store.load_session (Room.default_config base_path) session_id with
+          | Some session -> session.execution_scope
+          | None -> Team_session_types.Limited_code_change)
+      | None -> Team_session_types.Limited_code_change)
+
+let build_oas_mcp_tools ~sw ~auth_token ~session_id ~worker_name ~prompt
+    ~allowed_tools =
+  let allowed_names =
+    match allowed_tools |> List.map strip_mcp_prefix |> unique_preserve_order with
+    | [] -> session_min_tool_names
+    | names -> names
+  in
+  let listed_schemas =
+    list_masc_tools ~sw ~auth_token ~session_id ~names:(Some allowed_names) ()
+  in
+  Result.map
+    (fun schemas ->
+      schemas
+      |> List.filter (fun (schema : Types.tool_schema) ->
+             List.mem schema.name allowed_names)
+      |> List.map (fun (schema : Types.tool_schema) ->
+             let call_fn input =
+               let args =
+                 input
+                 |> inject_default_agent_name ~worker_name
+                      ~schema:(Some schema)
+                 |> inject_prompt_full_context ~prompt ~tool_name:schema.name
+               in
+               match
+                 call_masc_tool ~sw ~auth_token ~session_id ~tool_name:schema.name
+                   ~args
+               with
+               | Ok result when result.is_error -> Error result.text
+               | Ok result -> Ok result.text
+               | Error e -> Error e
+             in
+             Oas.Mcp.mcp_tool_to_sdk_tool ~call_fn
+               {
+                 Oas.Mcp.name = schema.name;
+                 description = schema.description;
+                 input_schema = schema.input_schema;
+               }))
+    listed_schemas
+
+let build_local_shell_tools ~execution_scope ~base_path =
+  match Process_eio.get_proc_mgr (), Process_eio.get_clock () with
+  | Ok proc_mgr, Ok clock -> (
+      match execution_scope with
+      | Team_session_types.Observe_only ->
+          Ok
+            (Agent_swarm_dev_tools.make_readonly_tools ~proc_mgr ~clock
+               ~workdir:base_path ())
+      | Team_session_types.Limited_code_change ->
+          Ok
+            (Agent_swarm_dev_tools.make_tools ~proc_mgr ~clock ~workdir:base_path
+               ()))
+  | Error e, _ | _, Error e -> Error e
+
+let oas_provider_of_model (model : Llm_client.model_spec) : Oas.Provider.config =
+  {
+    Oas.Provider.provider =
+      Oas.Provider.OpenAICompat
+        {
+          base_url = model.api_url;
+          auth_header = None;
+          path = "/v1/chat/completions";
+          static_token = None;
+        };
+    model_id = model.model_id;
+    api_key_env = "DUMMY_KEY";
+  }
+
+let oas_tool_names (tools : Oas.Tool.t list) =
+  List.map (fun (tool : Oas.Tool.t) -> tool.schema.name) tools
+
+let oas_extract_text (response : Oas.Types.api_response) =
+  response.content
+  |> List.filter_map (function Oas.Types.Text text -> Some text | _ -> None)
+  |> String.concat "\n"
+
+let make_worker_meta ~base_path ~team_session_id ~worker_name ~mcp_session_id
+    ~role ~selection_note ~execution_scope ~worker_class ~worker_size
+    ~effective_model =
+  let tool_profile, shell_profile = worker_profiles_of_scope execution_scope in
+  let effective_tier = derive_effective_tier worker_size effective_model in
+  {
+    version = worker_container_version;
+    worker_name;
+    mcp_session_id;
+    team_session_id;
+    role;
+    selection_note;
+    execution_scope;
+    tool_profile;
+    shell_profile;
+    worker_class;
+    worker_size = effective_worker_size worker_size effective_model;
+    effective_model;
+    effective_tier;
+    checkpoint_path =
+      worker_checkpoint_path ~base_path ~team_session_id ~worker_name;
+    turn_log_path =
+      worker_turn_log_path ~base_path ~team_session_id ~worker_name;
+    last_run_at = None;
+  }
+
+let append_worker_completion_log ~base_path ~team_session_id ~worker_name
+    ~prompt ~tool_names ~status ~output ?error () =
+  append_worker_turn_log ~base_path ~team_session_id ~worker_name
+    (`Assoc
+      [
+        ("ts", `Float (Time_compat.now ()));
+        ("status", `String status);
+        ("prompt", `String (safe_text_for_followup prompt));
+        ("tool_names", `List (List.map (fun name -> `String name) tool_names));
+        ("output_preview", `String (safe_text_for_followup output));
+        ( "error",
+          Option.fold ~none:`Null ~some:(fun value -> `String value) error );
+      ])
+
+let build_oas_agent ~worker_name ~model ~system_prompt ~tools ~max_turns
+    ~hooks =
+  let config =
+    {
+      Oas.Types.default_config with
+      name = worker_name;
+      model = Oas.Types.Custom model.Llm_client.model_id;
+      system_prompt = Some system_prompt;
+      max_tokens = local_worker_max_tokens ();
+      max_turns;
+      temperature = Some 0.2;
+      top_p = Some 0.95;
+      top_k = Some 20;
+      min_p = Some 0.0;
+      enable_thinking = Some false;
+      tool_choice = Some Oas.Types.Auto;
+    }
+  in
+  let options =
+    {
+      Oas.Agent.default_options with
+      provider = Some (oas_provider_of_model model);
+      hooks;
+      guardrails =
+        {
+          Oas.Guardrails.tool_filter =
+            Oas.Guardrails.AllowList (oas_tool_names tools);
+          max_tool_calls_per_turn = Some 12;
+        };
+    }
+  in
+  (config, options)
+
+let run_worker_oas ~sw ~base_path ~worker_name
+    ~(model : Llm_client.model_spec) ~team_session_id
+    ?worker_class ?worker_size ?execution_scope ~role ~selection_note
     ~(prompt : string) ~(allowed_tools : string list) ~(timeout_sec : int) :
-    (run_result, string) result =
-  let mcp_session_id = worker_session_id worker_name in
-  match worker_auth_token ~base_path ~worker_name with
-  | Error e -> Error e
-  | Ok auth_token ->
-      let _ =
-        match join_worker ~sw ~auth_token ~session_id:mcp_session_id ~worker_name with
-        | Ok _ -> ()
-        | Error e -> raise (Failure ("worker join failed: " ^ e))
-      in
-      let stop_heartbeat =
-        start_worker_heartbeat ~sw ~auth_token ~session_id:mcp_session_id
-          ~worker_name
-      in
-      Fun.protect
-        ~finally:(fun () ->
-          stop_heartbeat ();
-          ignore (leave_worker ~sw ~auth_token ~session_id:mcp_session_id ~worker_name))
-        (fun () ->
-          let allowed_names =
-            allowed_tools |> List.map strip_mcp_prefix |> unique_preserve_order
+    unit -> (run_result, string) result =
+  fun () ->
+    let mcp_session_id =
+      resolved_mcp_session_id ~base_path ~team_session_id ~worker_name
+    in
+    let execution_scope =
+      resolve_execution_scope ~base_path ~team_session_id ?execution_scope ()
+    in
+    let meta =
+      make_worker_meta ~base_path ~team_session_id ~worker_name ~mcp_session_id
+        ~role ~selection_note ~execution_scope ~worker_class ~worker_size
+        ~effective_model:model.model_id
+    in
+    match worker_auth_token ~base_path ~worker_name with
+    | Error e -> Error e
+    | Ok auth_token ->
+        let net = Eio_context.get_net () in
+        let system_prompt =
+          default_system_prompt ~worker_name ~model_id:model.model_id
+            ?session_id:team_session_id ?role ?selection_note ()
+        in
+        let stop_heartbeat =
+          start_worker_heartbeat ~sw ~auth_token ~session_id:mcp_session_id
+            ~worker_name
+        in
+        Fun.protect
+          ~finally:(fun () ->
+            stop_heartbeat ();
+            ignore
+              (leave_worker ~sw ~auth_token ~session_id:mcp_session_id
+                 ~worker_name))
+          (fun () ->
+          let _ =
+            match join_worker ~sw ~auth_token ~session_id:mcp_session_id
+                    ~worker_name with
+            | Ok _ -> ()
+            | Error e -> raise (Failure ("worker join failed: " ^ e))
           in
-          let listed_schemas =
-            match
-              list_masc_tools ~sw ~auth_token ~session_id:mcp_session_id
-                ~names:(Some allowed_names) ()
-            with
-            | Ok schemas -> schemas
-            | Error e -> raise (Failure ("tools/list failed: " ^ e))
+          let* mcp_tools =
+            build_oas_mcp_tools ~sw ~auth_token ~session_id:mcp_session_id
+              ~worker_name ~prompt ~allowed_tools
           in
-          let tool_schemas =
-            List.filter
-              (fun (schema : Types.tool_schema) ->
-                List.mem schema.name allowed_names)
-              listed_schemas
+          let* shell_tools =
+            build_local_shell_tools ~execution_scope ~base_path
           in
-          let tool_defs = tool_defs_of_schemas tool_schemas in
-          if tool_defs = [] then
-            Error "no MASC tool definitions available for local worker"
-          else
-            let zero_usage = make_usage () in
-            let rec loop ~round ~usage_acc ~tools_used current_prompt =
-              let request : Llm_client.completion_request =
+          let tools = mcp_tools @ shell_tools in
+          let tool_names_ref = ref [] in
+          let hooks =
+            {
+              Oas.Hooks.empty with
+              pre_tool_use =
+                Some
+                  (function
+                    | Oas.Hooks.PreToolUse { tool_name; _ } ->
+                        tool_names_ref := tool_name :: !tool_names_ref;
+                        Oas.Hooks.Continue
+                    | _ -> Oas.Hooks.Continue);
+            }
+          in
+          let max_turns = max 2 (min 12 (max 2 (timeout_sec / 20))) in
+          let config, options =
+            build_oas_agent ~worker_name ~model ~system_prompt ~tools
+              ~max_turns ~hooks
+          in
+          let agent = Oas.Agent.create ~net ~config ~tools ~options () in
+          let result =
+            Oas.Agent.run ~sw agent prompt
+          in
+          let checkpoint =
+            Oas.Agent.checkpoint ~session_id:mcp_session_id agent
+          in
+          let tool_names =
+            List.rev !tool_names_ref |> unique_preserve_order
+          in
+          save_worker_checkpoint ~base_path ~team_session_id ~worker_name
+            checkpoint;
+          save_worker_meta ~base_path ~team_session_id ~worker_name
+            { meta with last_run_at = Some (Time_compat.now ()) };
+          Oas.Agent.close agent;
+          match result with
+          | Ok response ->
+              let output = oas_extract_text response in
+              append_worker_completion_log ~base_path ~team_session_id
+                ~worker_name ~prompt ~tool_names ~status:"ok" ~output ();
+              Ok
                 {
-                  model;
-                  messages =
-                    [
-                      Llm_client.system_msg
-                        (default_system_prompt ~worker_name
-                           ~model_id:model.model_id ?session_id:team_session_id
-                           ?role ?selection_note ());
-                      Llm_client.user_msg current_prompt;
-                    ];
-                  temperature = 0.2;
-                  max_tokens = local_worker_max_tokens ();
-                  tools = tool_defs;
-                  response_format = `Text;
+                  output;
+                  model_used =
+                    (if String.trim response.model <> "" then response.model
+                     else model.model_id);
+                  input_tokens = Some checkpoint.usage.total_input_tokens;
+                  output_tokens = Some checkpoint.usage.total_output_tokens;
+                  cost_usd = estimate_cost_usd model
+                      (make_usage ~input_tokens:checkpoint.usage.total_input_tokens
+                         ~output_tokens:checkpoint.usage.total_output_tokens ());
+                  tool_call_count = List.length tool_names;
+                  tool_names;
+                  session_id = mcp_session_id;
+                }
+          | Error err ->
+              let detail = Agent_sdk__Error.to_string err in
+              append_worker_completion_log ~base_path ~team_session_id
+                ~worker_name ~prompt ~tool_names ~status:"error"
+                ~output:detail ~error:detail ();
+              Error detail)
+
+let continue_worker ~sw ~base_path ~worker_name ~(team_session_id : string)
+    ~(prompt : string) : (run_result, string) result =
+  let team_session_id = Some team_session_id in
+  let meta =
+    load_worker_meta ~base_path ~team_session_id ~worker_name
+  in
+  let checkpoint =
+    load_worker_checkpoint ~base_path ~team_session_id ~worker_name
+  in
+  match meta, checkpoint with
+  | None, _ -> Error (sprintf "worker container not found: %s" worker_name)
+  | _, None -> Error (sprintf "worker checkpoint not found: %s" worker_name)
+  | Some meta, Some checkpoint -> (
+      match worker_auth_token ~base_path ~worker_name with
+      | Error e -> Error e
+      | Ok auth_token ->
+          let net = Eio_context.get_net () in
+          let stop_heartbeat =
+            start_worker_heartbeat ~sw ~auth_token ~session_id:meta.mcp_session_id
+              ~worker_name
+          in
+          Fun.protect
+            ~finally:(fun () ->
+              stop_heartbeat ();
+              ignore
+                (leave_worker ~sw ~auth_token
+                   ~session_id:meta.mcp_session_id ~worker_name))
+            (fun () ->
+              let _ =
+                match join_worker ~sw ~auth_token
+                        ~session_id:meta.mcp_session_id ~worker_name with
+                | Ok _ -> ()
+                | Error e -> raise (Failure ("worker join failed: " ^ e))
+              in
+              let allowed_tools =
+                session_min_tool_names |> List.map (fun name -> "mcp__masc__" ^ name)
+              in
+              let* mcp_tools =
+                build_oas_mcp_tools ~sw ~auth_token
+                  ~session_id:meta.mcp_session_id ~worker_name ~prompt
+                  ~allowed_tools
+              in
+              let shell_tools =
+                match meta.shell_profile with
+                | Shell_none -> Ok []
+                | Shell_readonly ->
+                    build_local_shell_tools
+                      ~execution_scope:Team_session_types.Observe_only ~base_path
+                | Shell_dev ->
+                    build_local_shell_tools
+                      ~execution_scope:Team_session_types.Limited_code_change
+                      ~base_path
+              in
+              let* shell_tools = shell_tools in
+              let tools = mcp_tools @ shell_tools in
+              let tool_names_ref = ref [] in
+              let hooks =
+                {
+                  Oas.Hooks.empty with
+                  pre_tool_use =
+                    Some
+                      (function
+                        | Oas.Hooks.PreToolUse { tool_name; _ } ->
+                            tool_names_ref := tool_name :: !tool_names_ref;
+                            Oas.Hooks.Continue
+                        | _ -> Oas.Hooks.Continue);
                 }
               in
-              match Llm_client.complete ~timeout_sec request with
-              | Error e -> Error e
-              | Ok resp ->
-                  let tool_calls =
-                    match resp.tool_calls with
-                    | [] -> parse_text_tool_calls resp.content
-                    | calls -> calls
-                  in
-                  let usage_acc = merge_usage usage_acc resp.usage in
-                  if tool_calls = [] then
-                    let output =
-                      let trimmed = String.trim resp.content in
-                      if trimmed <> "" then trimmed
-                      else if tools_used <> [] then
-                        sprintf "(tools executed: %s)"
-                          (String.concat ", " (unique_preserve_order tools_used))
-                      else
-                        "(no output)"
+              let model =
+                let base_model = Llm_client.default_local_model_spec () in
+                match checkpoint.model with
+                | Oas.Types.Custom model_id ->
+                    { base_model with model_id }
+                | _ ->
+                    { base_model with model_id = meta.effective_model }
+              in
+              let config, options =
+                build_oas_agent ~worker_name ~model
+                  ~system_prompt:
+                    (default_system_prompt ~worker_name ~model_id:model.model_id
+                       ?session_id:meta.team_session_id ?role:meta.role
+                       ?selection_note:meta.selection_note ())
+                  ~tools ~max_turns:8 ~hooks
+              in
+              let agent =
+                Oas.Agent.resume ~net ~checkpoint ~tools ~options ~config ()
+              in
+              let result =
+                Oas.Agent.run ~sw agent prompt
+              in
+              let next_checkpoint =
+                Oas.Agent.checkpoint ~session_id:meta.mcp_session_id agent
+              in
+              let tool_names =
+                List.rev !tool_names_ref |> unique_preserve_order
+              in
+              save_worker_checkpoint ~base_path ~team_session_id ~worker_name
+                next_checkpoint;
+              save_worker_meta ~base_path ~team_session_id ~worker_name
+                { meta with last_run_at = Some (Time_compat.now ()) };
+              Oas.Agent.close agent;
+              match result with
+              | Ok response ->
+                  let output = oas_extract_text response in
+                  append_worker_completion_log ~base_path ~team_session_id
+                    ~worker_name ~prompt ~tool_names ~status:"ok" ~output ();
+                  Ok
+                    {
+                      output;
+                      model_used =
+                        (if String.trim response.model <> "" then response.model
+                         else meta.effective_model);
+                      input_tokens = Some next_checkpoint.usage.total_input_tokens;
+                      output_tokens = Some next_checkpoint.usage.total_output_tokens;
+                      cost_usd =
+                        estimate_cost_usd model
+                          (make_usage
+                             ~input_tokens:next_checkpoint.usage.total_input_tokens
+                             ~output_tokens:next_checkpoint.usage.total_output_tokens
+                             ());
+                      tool_call_count = List.length tool_names;
+                      tool_names;
+                      session_id = meta.mcp_session_id;
+                    }
+          | Error err ->
+              let detail = Agent_sdk__Error.to_string err in
+              append_worker_completion_log ~base_path ~team_session_id
+                ~worker_name ~prompt ~tool_names ~status:"error"
+                ~output:detail ~error:detail ();
+              Error detail))
+
+let run_worker_legacy ~sw ~base_path ~worker_name
+    ~(model : Llm_client.model_spec) ~team_session_id ~role
+    ~selection_note
+    ~(prompt : string) ~(allowed_tools : string list) ~(timeout_sec : int) :
+    unit -> (run_result, string) result =
+  fun () ->
+    let mcp_session_id =
+      resolved_mcp_session_id ~base_path ~team_session_id ~worker_name
+    in
+    match worker_auth_token ~base_path ~worker_name with
+    | Error e -> Error e
+    | Ok auth_token ->
+        let stop_heartbeat =
+          start_worker_heartbeat ~sw ~auth_token ~session_id:mcp_session_id
+            ~worker_name
+        in
+        Fun.protect
+          ~finally:(fun () ->
+            stop_heartbeat ();
+            ignore
+              (leave_worker ~sw ~auth_token ~session_id:mcp_session_id
+                 ~worker_name))
+          (fun () ->
+            let _ =
+              match
+                join_worker ~sw ~auth_token ~session_id:mcp_session_id
+                  ~worker_name
+              with
+              | Ok _ -> ()
+              | Error e -> raise (Failure ("worker join failed: " ^ e))
+            in
+            let allowed_names =
+              allowed_tools |> List.map strip_mcp_prefix |> unique_preserve_order
+            in
+            let listed_schemas =
+              match
+                list_masc_tools ~sw ~auth_token ~session_id:mcp_session_id
+                  ~names:(Some allowed_names) ()
+              with
+              | Ok schemas -> schemas
+              | Error e -> raise (Failure ("tools/list failed: " ^ e))
+            in
+            let tool_schemas =
+              List.filter
+                (fun (schema : Types.tool_schema) ->
+                  List.mem schema.name allowed_names)
+                listed_schemas
+            in
+            let tool_defs = tool_defs_of_schemas tool_schemas in
+            if tool_defs = [] then
+              Error "no MASC tool definitions available for local worker"
+            else
+              let zero_usage = make_usage () in
+              let rec loop ~round ~usage_acc ~tools_used current_prompt =
+                let request : Llm_client.completion_request =
+                  {
+                    model;
+                    messages =
+                      [
+                        Llm_client.system_msg
+                          (default_system_prompt ~worker_name
+                             ~model_id:model.model_id ?session_id:team_session_id
+                             ?role ?selection_note ());
+                        Llm_client.user_msg current_prompt;
+                      ];
+                    temperature = 0.2;
+                    max_tokens = local_worker_max_tokens ();
+                    tools = tool_defs;
+                    response_format = `Text;
+                  }
+                in
+                match Llm_client.complete ~timeout_sec request with
+                | Error e -> Error e
+                | Ok resp ->
+                    let tool_calls =
+                      match resp.tool_calls with
+                      | [] -> parse_text_tool_calls resp.content
+                      | calls -> calls
                     in
-                    Ok
-                      {
-                        output;
-                        model_used = resp.model_used;
-                        input_tokens = Some usage_acc.input_tokens;
-                        output_tokens = Some usage_acc.output_tokens;
-                        cost_usd = estimate_cost_usd model usage_acc;
-                        tool_call_count = List.length tools_used;
-                        tool_names = unique_preserve_order tools_used;
-                        session_id = mcp_session_id;
-                      }
-                  else
-                    let tool_outputs =
-                      List.map
-                        (fun (tc : Llm_client.tool_call) ->
-                          let schema =
-                            tool_schema_of_name tool_schemas tc.call_name
-                          in
-                          let parsed_args =
-                            match Yojson.Safe.from_string tc.call_arguments with
-                            | json -> json
-                            | exception Yojson.Json_error msg ->
-                                `Assoc [ ("error", `String ("invalid tool args: " ^ msg)) ]
-                          in
-                          let args =
-                            parsed_args
-                            |> inject_default_agent_name ~worker_name ~schema
-                            |> inject_prompt_full_context ~prompt ~tool_name:tc.call_name
-                          in
-                          let output =
-                            match
-                              call_masc_tool ~sw ~auth_token
-                                ~session_id:mcp_session_id
-                                ~tool_name:tc.call_name ~args
-                            with
-                            | Ok result ->
-                                if result.is_error then
-                                  Yojson.Safe.to_string
-                                    (`Assoc
-                                       [
-                                         ("tool", `String tc.call_name);
-                                         ("error", `String result.text);
-                                       ])
-                                else result.text
-                            | Error e ->
-                                Yojson.Safe.to_string
-                                  (`Assoc
-                                     [ ("tool", `String tc.call_name); ("error", `String e) ])
-                          in
-                          ((tc : Llm_client.tool_call), output))
-                        tool_calls
-                    in
-                    let round_tools =
-                      List.map (fun (tc : Llm_client.tool_call) -> tc.call_name) tool_calls
-                    in
-                    let tools_used = tools_used @ round_tools in
-                    let output =
-                      let trimmed = String.trim resp.content in
-                      if trimmed <> "" then trimmed
-                      else
-                        sprintf "(tools executed: %s)"
-                          (String.concat ", " (unique_preserve_order tools_used))
-                    in
-                    if round >= 3 then
+                    let usage_acc = merge_usage usage_acc resp.usage in
+                    if tool_calls = [] then
+                      let output =
+                        let trimmed = String.trim resp.content in
+                        if trimmed <> "" then trimmed
+                        else if tools_used <> [] then
+                          sprintf "(tools executed: %s)"
+                            (String.concat ", "
+                               (unique_preserve_order tools_used))
+                        else
+                          "(no output)"
+                      in
                       Ok
                         {
                           output;
@@ -829,8 +1503,97 @@ let run_worker ~sw ~base_path ~worker_name ~model ~team_session_id ~role
                           session_id = mcp_session_id;
                         }
                     else
-                      loop ~round:(round + 1) ~usage_acc ~tools_used
-                        (followup_prompt ~original_prompt:prompt ~tool_outputs
-                           ~already_used:tools_used)
-            in
-            loop ~round:1 ~usage_acc:zero_usage ~tools_used:[] prompt)
+                      let tool_outputs =
+                        List.map
+                          (fun (tc : Llm_client.tool_call) ->
+                            let schema =
+                              tool_schema_of_name tool_schemas tc.call_name
+                            in
+                            let parsed_args =
+                              match Yojson.Safe.from_string tc.call_arguments with
+                              | json -> json
+                              | exception Yojson.Json_error msg ->
+                                  `Assoc
+                                    [
+                                      ( "error",
+                                        `String
+                                          ("invalid tool args: " ^ msg) );
+                                    ]
+                            in
+                            let args =
+                              parsed_args
+                              |> inject_default_agent_name ~worker_name ~schema
+                              |> inject_prompt_full_context ~prompt
+                                   ~tool_name:tc.call_name
+                            in
+                            let output =
+                              match
+                                call_masc_tool ~sw ~auth_token
+                                  ~session_id:mcp_session_id
+                                  ~tool_name:tc.call_name ~args
+                              with
+                              | Ok result ->
+                                  if result.is_error then
+                                    Yojson.Safe.to_string
+                                      (`Assoc
+                                        [
+                                          ("tool", `String tc.call_name);
+                                          ("error", `String result.text);
+                                        ])
+                                  else result.text
+                              | Error e ->
+                                  Yojson.Safe.to_string
+                                    (`Assoc
+                                      [
+                                        ("tool", `String tc.call_name);
+                                        ("error", `String e);
+                                      ])
+                            in
+                            (tc, output))
+                          tool_calls
+                      in
+                      let round_tools =
+                        List.map
+                          (fun (tc : Llm_client.tool_call) -> tc.call_name)
+                          tool_calls
+                      in
+                      let tools_used = tools_used @ round_tools in
+                      let output =
+                        let trimmed = String.trim resp.content in
+                        if trimmed <> "" then trimmed
+                        else
+                          sprintf "(tools executed: %s)"
+                            (String.concat ", "
+                               (unique_preserve_order tools_used))
+                      in
+                      if round >= 3 then
+                        Ok
+                          {
+                            output;
+                            model_used = resp.model_used;
+                            input_tokens = Some usage_acc.input_tokens;
+                            output_tokens = Some usage_acc.output_tokens;
+                            cost_usd = estimate_cost_usd model usage_acc;
+                            tool_call_count = List.length tools_used;
+                            tool_names = unique_preserve_order tools_used;
+                            session_id = mcp_session_id;
+                          }
+                      else
+                        loop ~round:(round + 1) ~usage_acc ~tools_used
+                          (followup_prompt ~original_prompt:prompt ~tool_outputs
+                             ~already_used:tools_used)
+              in
+              loop ~round:1 ~usage_acc:zero_usage ~tools_used:[] prompt)
+
+let run_worker ~sw ~base_path ~worker_name ~model ~team_session_id
+    ?worker_class ?worker_size ?execution_scope ~role ~selection_note
+    ~(prompt : string) ~(allowed_tools : string list) ~(timeout_sec : int) :
+    unit -> (run_result, string) result =
+  match configured_backend () with
+  | `Legacy ->
+      run_worker_legacy ~sw ~base_path ~worker_name ~model ~team_session_id
+        ~role ~selection_note ~prompt ~allowed_tools ~timeout_sec
+  | `Oas ->
+      run_worker_oas ~sw ~base_path ~worker_name ~model ~team_session_id
+        ?worker_class ?worker_size ?execution_scope ~role ~selection_note
+        ~prompt ~allowed_tools ~timeout_sec

--- a/lib/lodge_worker.ml
+++ b/lib/lodge_worker.ml
@@ -199,7 +199,7 @@ let run_local ~agent_name ~identity_prompt ~goal ~context ~allow_post
       match
         Local_agent_eio.run_worker ~sw ~base_path:(base_path ()) ~worker_name ~model
           ~team_session_id:None ~role:(Some "lodge-worker") ~selection_note:None
-          ~prompt ~allowed_tools ~timeout_sec:90
+          ~prompt ~allowed_tools ~timeout_sec:90 ()
       with
       | Error e -> Error e
       | Ok run_result ->

--- a/lib/mcp_server_eio.ml
+++ b/lib/mcp_server_eio.ml
@@ -4068,33 +4068,90 @@ let run_stdio ~sw ~env state =
   Log.Mcp.info "MASC MCP Server (Eio stdio mode)";
   Log.Mcp.info "Default room: %s" Mcp_server.(state.room_config.Room.base_path);
 
-  (* Buffer for reading - framed mode (Content-Length) only for now *)
   let buf = Eio.Buf_read.of_flow stdin ~max_size:(16 * 1024 * 1024) in
 
-  Log.Mcp.debug "Transport mode: framed (Content-Length)";
+  let read_framed_message_after_first_line first_line =
+    let rec read_headers acc =
+      let line = Eio.Buf_read.line buf in
+      if String.length line = 0 || line = "\r" then
+        List.rev acc
+      else
+        read_headers (line :: acc)
+    in
+    let headers = read_headers [ first_line ] in
+    let content_length =
+      headers
+      |> List.find_map (fun header ->
+             let header = String.trim header in
+             if String.length header > 16
+                && String.lowercase_ascii (String.sub header 0 15)
+                   = "content-length:"
+             then
+               let len_str =
+                 String.trim
+                   (String.sub header 15 (String.length header - 15))
+               in
+               int_of_string_opt len_str
+             else
+               None)
+      |> Option.value ~default:0
+    in
+    if content_length > 0 then Some (Eio.Buf_read.take content_length buf)
+    else None
+  in
 
-  (* Main loop - framed mode only *)
-  let rec loop () =
-    match read_framed_message buf with
+  let respond ~mode response =
+    match response with
+    | `Null -> ()
+    | json -> (
+        match mode with
+        | Framed -> write_framed_message stdout json
+        | LineDelimited -> write_line_message stdout json)
+  in
+
+  let rec loop mode_opt =
+    match read_line_message buf with
     | None ->
         Log.Mcp.info "EOF received, shutting down";
         ()
-    | Some "" ->
-        (* Empty body, skip *)
-        loop ()
-    | Some request_str ->
-        (* Handle request with Eio clock - use "stdio" as session ID for agent persistence *)
-        let response = handle_request ~clock ~sw ~mcp_session_id:"stdio" state request_str in
-
-        (* Write response if not null *)
-        (match response with
-         | `Null -> ()
-         | json -> write_framed_message stdout json);
-
-        loop ()
+    | Some first_line ->
+        let first_line = String.trim first_line in
+        if first_line = "" then
+          loop mode_opt
+        else
+          let mode =
+            match mode_opt with
+            | Some mode -> mode
+            | None ->
+                let detected = detect_mode first_line in
+                let mode_name =
+                  match detected with
+                  | Framed -> "framed (Content-Length)"
+                  | LineDelimited -> "line-delimited JSON"
+                in
+                Log.Mcp.debug "Transport mode: %s" mode_name;
+                detected
+          in
+          let request_opt =
+            match mode with
+            | Framed -> read_framed_message_after_first_line first_line
+            | LineDelimited -> Some first_line
+          in
+          (match request_opt with
+          | None ->
+              Log.Mcp.info "EOF received, shutting down";
+              ()
+          | Some "" -> loop (Some mode)
+          | Some request_str ->
+              let response =
+                handle_request ~clock ~sw ~mcp_session_id:"stdio" state
+                  request_str
+              in
+              respond ~mode response;
+              loop (Some mode))
   in
 
-  try loop ()
+  try loop None
   with
   | End_of_file ->
       Log.Mcp.info "Connection closed"

--- a/lib/mdal_worker.ml
+++ b/lib/mdal_worker.ml
@@ -170,7 +170,7 @@ let run ~(sw : Eio.Switch.t) ~(config : Room.config) (state : Mdal.loop_state)
       ~worker_name ~model:model_spec ~team_session_id:None ~role:(Some "mdal")
       ~selection_note:(Some "strict-mdal-worker")
       ~prompt ~allowed_tools:state.profile.tools_allow
-      ~timeout_sec:(timeout_seconds state)
+      ~timeout_sec:(timeout_seconds state) ()
   with
   | Error message -> Error (Worker_failed message)
   | Ok result ->

--- a/lib/spawn_eio.ml
+++ b/lib/spawn_eio.ml
@@ -343,7 +343,8 @@ let spawn_glm_via_client ~prompt ~timeout ~start_time : spawn_result =
 *)
 let spawn ~sw ~proc_mgr ~agent_name ~prompt ?timeout_seconds ?working_dir
     ?room_config ?runtime_agent_name ?runtime_model ?runtime_role
-    ?runtime_session_id ?runtime_selection_note () : spawn_result =
+    ?runtime_session_id ?runtime_selection_note ?worker_class ?worker_size
+    ?execution_scope () : spawn_result =
   let start_time = Time_compat.now () in
   let normalized_agent = String.lowercase_ascii (String.trim agent_name) in
   if Provider_adapter.is_bare_ollama_label normalized_agent then
@@ -457,9 +458,10 @@ let spawn ~sw ~proc_mgr ~agent_name ~prompt ?timeout_seconds ?working_dir
          match
            Local_agent_eio.run_worker ~sw ~base_path ~worker_name ~model
              ~team_session_id:runtime_session_id ~role:runtime_role
+             ?worker_class ?worker_size ?execution_scope
              ~selection_note:runtime_selection_note
              ~prompt:augmented_prompt ~allowed_tools:llama_mcp_tools
-             ~timeout_sec:timeout
+             ~timeout_sec:timeout ()
          with
          | Ok result ->
              {

--- a/lib/team_session_engine_eio.ml
+++ b/lib/team_session_engine_eio.ml
@@ -535,6 +535,10 @@ let summary_json_of_session (config : Room.config)
     Team_session_types.model_tier_counts session.planned_workers
     |> Team_session_types.counts_to_json
   in
+  let worker_size_counts =
+    Team_session_types.worker_size_counts session.planned_workers
+    |> Team_session_types.counts_to_json
+  in
   let task_profile_counts =
     Team_session_types.task_profile_counts session.planned_workers
     |> Team_session_types.counts_to_json
@@ -575,6 +579,7 @@ let summary_json_of_session (config : Room.config)
       ("controller_counts", controller_counts);
       ("control_domain_counts", control_domain_counts);
       ("tier_counts", tier_counts);
+      ("worker_size_counts", worker_size_counts);
       ("task_profile_counts", task_profile_counts);
       ("escalation_count", `Int escalation_count);
       ( "routing_reason_summary",

--- a/lib/team_session_types.ml
+++ b/lib/team_session_types.ml
@@ -74,6 +74,11 @@ type model_tier =
   | Tier_27b
   | Tier_9b
 
+type worker_size =
+  | Worker_sm
+  | Worker_lg
+  | Worker_xlg
+
 type task_profile =
   | Profile_extract
   | Profile_normalize
@@ -352,6 +357,27 @@ let model_tier_of_string = function
   | "9b" -> Some Tier_9b
   | _ -> None
 
+let worker_size_to_string = function
+  | Worker_sm -> "sm"
+  | Worker_lg -> "lg"
+  | Worker_xlg -> "xlg"
+
+let worker_size_of_string = function
+  | "sm" -> Some Worker_sm
+  | "lg" -> Some Worker_lg
+  | "xlg" -> Some Worker_xlg
+  | _ -> None
+
+let model_tier_of_worker_size = function
+  | Worker_sm -> Some Tier_9b
+  | Worker_lg -> Some Tier_27b
+  | Worker_xlg -> Some Tier_35b
+
+let worker_size_of_model_tier = function
+  | Tier_9b -> Some Worker_sm
+  | Tier_27b -> Some Worker_lg
+  | Tier_35b -> Some Worker_xlg
+
 let task_profile_to_string = function
   | Profile_extract -> "extract"
   | Profile_normalize -> "normalize"
@@ -619,6 +645,19 @@ let model_tier_counts workers =
     workers;
   Hashtbl.fold (fun key count acc -> (key, count) :: acc) tbl []
 
+let worker_size_counts workers =
+  let tbl = Hashtbl.create 4 in
+  List.iter
+    (fun (worker : planned_worker) ->
+      match Option.bind worker.model_tier worker_size_of_model_tier with
+      | None -> ()
+      | Some size ->
+          let key = worker_size_to_string size in
+          let prev = Option.value ~default:0 (Hashtbl.find_opt tbl key) in
+          Hashtbl.replace tbl key (prev + 1))
+    workers;
+  Hashtbl.fold (fun key count acc -> (key, count) :: acc) tbl []
+
 let task_profile_counts workers =
   let tbl = Hashtbl.create 8 in
   List.iter
@@ -689,6 +728,10 @@ let planned_worker_to_yojson (w : planned_worker) =
         Option.fold ~none:`Null
           ~some:(fun tier -> `String (model_tier_to_string tier))
           w.model_tier );
+      ( "worker_size",
+        Option.fold ~none:`Null
+          ~some:(fun size -> `String (worker_size_to_string size))
+          (Option.bind w.model_tier worker_size_of_model_tier) );
       ( "task_profile",
         Option.fold ~none:`Null
           ~some:(fun profile -> `String (task_profile_to_string profile))
@@ -749,11 +792,23 @@ let planned_worker_of_yojson (json : Yojson.Safe.t) =
             supervisor_actor =
               member "supervisor_actor" json |> to_string_option;
             model_tier =
-              Option.bind
-                (member "model_tier" json |> to_string_option)
-                (fun value ->
-                  model_tier_of_string
-                    (String.lowercase_ascii (String.trim value)));
+              (match
+                 Option.bind
+                   (member "model_tier" json |> to_string_option)
+                   (fun value ->
+                     model_tier_of_string
+                       (String.lowercase_ascii (String.trim value)))
+               with
+              | Some tier -> Some tier
+              | None ->
+                  let size_opt =
+                    match member "worker_size" json |> to_string_option with
+                    | Some value ->
+                        worker_size_of_string
+                          (String.lowercase_ascii (String.trim value))
+                    | None -> None
+                  in
+                  Option.bind size_opt model_tier_of_worker_size);
             task_profile =
               Option.bind
                 (member "task_profile" json |> to_string_option)

--- a/lib/tool_team_session.ml
+++ b/lib/tool_team_session.ml
@@ -365,6 +365,15 @@ let derived_llama_runtime_actor ~session_id ~prompt =
   let digest = Digest.string (session_id ^ "\n" ^ prompt) |> Digest.to_hex in
   Printf.sprintf "llama-local-%s" (String.sub digest 0 8)
 
+let normalize_spawn_agent agent_name =
+  let normalized = String.lowercase_ascii (String.trim agent_name) in
+  if normalized = "" then "default" else normalized
+
+let is_local_spawn_agent agent_name =
+  match normalize_spawn_agent agent_name with
+  | "default" | "llama" -> true
+  | _ -> false
+
 type routing_decision = {
   model_tier : Team_session_types.model_tier;
   task_profile : Team_session_types.task_profile;
@@ -383,6 +392,7 @@ type spawn_spec = {
   spawn_model_explicit : bool;
   spawn_role : string option;
   worker_class : Team_session_types.worker_class option;
+  worker_size : Team_session_types.worker_size option;
   parent_actor : string option;
   capsule_mode : Team_session_types.capsule_mode option;
   runtime_pool : string option;
@@ -432,6 +442,29 @@ let int_env_default name ~default =
   | Some raw -> (
       try int_of_string raw with Failure _ -> default)
   | None -> default
+
+let default_worker_size_for_class = function
+  | Some Team_session_types.Worker_manager ->
+      Some Team_session_types.Worker_xlg
+  | Some Team_session_types.Worker_executor ->
+      Some Team_session_types.Worker_lg
+  | Some Team_session_types.Worker_scout
+  | Some Team_session_types.Worker_librarian ->
+      Some Team_session_types.Worker_sm
+  | Some Team_session_types.Worker_metacog ->
+      Some Team_session_types.Worker_lg
+  | None -> Some Team_session_types.Worker_lg
+
+let explicit_worker_size_of_spec (spec : spawn_spec) =
+  match spec.worker_size with
+  | Some _ as size -> size
+  | None ->
+      Option.bind spec.model_tier Team_session_types.worker_size_of_model_tier
+
+let worker_size_of_spec (spec : spawn_spec) =
+  match explicit_worker_size_of_spec spec with
+  | Some _ as size -> size
+  | None -> default_worker_size_for_class spec.worker_class
 
 let contains_ci haystack needle =
   let haystack = String.lowercase_ascii haystack in
@@ -839,13 +872,16 @@ let finalize_routing_decision ~spawn_model ~(decision : routing_decision) =
   (resolved_model, resolved_tier, escalated, reason)
 
 let resolve_routing_for_spec (spec : spawn_spec) =
-  if not (String.equal spec.spawn_agent "llama") then
+  if not (is_local_spawn_agent spec.spawn_agent) then
     spec
   else
     let explicit_tier =
-      match spec.model_tier with
-      | Some tier -> Some tier
-      | None -> infer_model_tier_from_model_name spec.spawn_model
+      match spec.worker_size with
+      | Some size -> Team_session_types.model_tier_of_worker_size size
+      | None -> (
+          match spec.model_tier with
+          | Some tier -> Some tier
+          | None -> infer_model_tier_from_model_name spec.spawn_model)
     in
     let heuristic =
       heuristic_routing ~spawn_prompt:spec.spawn_prompt ~spawn_role:spec.spawn_role
@@ -863,6 +899,7 @@ let resolve_routing_for_spec (spec : spawn_spec) =
           if confidence >= router_judge_confidence_threshold ()
              || Option.is_some spec.task_profile
              || Option.is_some spec.model_tier
+             || Option.is_some spec.worker_size
           then
             decision
           else
@@ -908,10 +945,17 @@ let resolve_routing_for_spec (spec : spawn_spec) =
     let routing_note =
       routing_summary_line { decision with model_tier; reason = routing_reason; escalated = routing_escalated }
     in
+    let worker_size =
+      match spec.worker_size with
+      | Some _ as explicit -> explicit
+      | None -> Team_session_types.worker_size_of_model_tier model_tier
+    in
     {
       spec with
+      spawn_agent = normalize_spawn_agent spec.spawn_agent;
       spawn_model;
       model_tier = Some model_tier;
+      worker_size;
       task_profile = Some decision.task_profile;
       risk_level = Some decision.risk_level;
       routing_confidence;
@@ -1045,6 +1089,13 @@ let parse_spawn_spec_from_object ?(default_timeout = 300) batch_index json =
         Error
           (Printf.sprintf "spawn_batch[%d].%s is required" batch_index key)
   in
+  let get_optional_required_string key =
+    match member key json with
+    | `String s ->
+        let trimmed = String.trim s in
+        if trimmed = "" then None else Some trimmed
+    | _ -> None
+  in
   let get_optional_string key =
     match member key json with
     | `String s ->
@@ -1057,6 +1108,13 @@ let parse_spawn_spec_from_object ?(default_timeout = 300) batch_index json =
       (get_optional_string key)
       (fun raw ->
         Team_session_types.worker_class_of_string
+          (String.lowercase_ascii (String.trim raw)))
+  in
+  let get_optional_worker_size key =
+    Option.bind
+      (get_optional_string key)
+      (fun raw ->
+        Team_session_types.worker_size_of_string
           (String.lowercase_ascii (String.trim raw)))
   in
   let get_optional_model_tier key =
@@ -1107,16 +1165,20 @@ let parse_spawn_spec_from_object ?(default_timeout = 300) batch_index json =
     | `Intlit s -> (try max 1 (int_of_string s) with Failure _ -> default_timeout)
     | _ -> default_timeout
   in
-  match (get_required_string "spawn_agent", get_required_string "spawn_prompt") with
-  | Ok spawn_agent, Ok spawn_prompt ->
+  match get_required_string "spawn_prompt" with
+  | Ok spawn_prompt ->
       Ok
         {
-          spawn_agent;
+          spawn_agent =
+            normalize_spawn_agent
+              (Option.value ~default:"default"
+                 (get_optional_required_string "spawn_agent"));
           spawn_prompt;
           spawn_model = get_optional_string "spawn_model";
           spawn_model_explicit = Option.is_some (get_optional_string "spawn_model");
           spawn_role = get_optional_string "spawn_role";
           worker_class = get_optional_worker_class "worker_class";
+          worker_size = get_optional_worker_size "worker_size";
           parent_actor = get_optional_string "parent_actor";
           capsule_mode = get_optional_capsule_mode "capsule_mode";
           runtime_pool = get_optional_string "runtime_pool";
@@ -1132,7 +1194,7 @@ let parse_spawn_spec_from_object ?(default_timeout = 300) batch_index json =
           spawn_selection_note = get_optional_string "spawn_selection_note";
           spawn_timeout_seconds = get_timeout "spawn_timeout_seconds";
         }
-  | Error e, _ | _, Error e -> Error e
+  | Error e -> Error e
 
 let parse_step_spawn_specs args =
   let singular_agent = get_string_opt args "spawn_agent" in
@@ -1172,13 +1234,11 @@ let parse_step_spawn_specs args =
       else
         match (singular_agent, singular_prompt) with
         | None, None -> Ok []
-        | Some _, None | None, Some _ ->
-            Error "spawn_agent and spawn_prompt must be provided together"
-        | Some spawn_agent, Some spawn_prompt ->
+        | None, Some spawn_prompt ->
             route_specs
               [
                 {
-                  spawn_agent;
+                  spawn_agent = "default";
                   spawn_prompt;
                   spawn_model = get_string_opt args "spawn_model";
                   spawn_model_explicit = Option.is_some (get_string_opt args "spawn_model");
@@ -1188,6 +1248,75 @@ let parse_step_spawn_specs args =
                       (get_string_opt args "worker_class")
                       (fun raw ->
                         Team_session_types.worker_class_of_string
+                          (String.lowercase_ascii (String.trim raw)));
+                  worker_size =
+                    Option.bind
+                      (get_string_opt args "worker_size")
+                      (fun raw ->
+                        Team_session_types.worker_size_of_string
+                          (String.lowercase_ascii (String.trim raw)));
+                  parent_actor = get_string_opt args "parent_actor";
+                  capsule_mode =
+                    Option.bind
+                      (get_string_opt args "capsule_mode")
+                      (fun raw ->
+                        Team_session_types.capsule_mode_of_string
+                          (String.lowercase_ascii (String.trim raw)));
+                  runtime_pool = get_string_opt args "runtime_pool";
+                  lane_id = get_string_opt args "lane_id";
+                  control_domain =
+                    Option.bind
+                      (get_string_opt args "control_domain")
+                      (fun raw ->
+                        Team_session_types.control_domain_of_string
+                          (String.lowercase_ascii (String.trim raw)));
+                  supervisor_actor = get_string_opt args "supervisor_actor";
+                  model_tier =
+                    Option.bind
+                      (get_string_opt args "model_tier")
+                      (fun raw ->
+                        Team_session_types.model_tier_of_string
+                          (String.lowercase_ascii (String.trim raw)));
+                  model_tier_explicit = Option.is_some (get_string_opt args "model_tier");
+                  task_profile =
+                    Option.bind
+                      (get_string_opt args "task_profile")
+                      (fun raw ->
+                        Team_session_types.task_profile_of_string
+                          (String.lowercase_ascii (String.trim raw)));
+                  risk_level =
+                    Option.bind
+                      (get_string_opt args "risk_level")
+                      (fun raw ->
+                        Team_session_types.risk_level_of_string
+                          (String.lowercase_ascii (String.trim raw)));
+                  routing_confidence = get_float_opt args "routing_confidence";
+                  routing_reason = get_string_opt args "routing_reason";
+                  spawn_selection_note = get_string_opt args "spawn_selection_note";
+                  spawn_timeout_seconds = get_int args "spawn_timeout_seconds" 300;
+                };
+              ]
+        | Some _, None -> Error "spawn_prompt is required when spawning a worker"
+        | Some spawn_agent, Some spawn_prompt ->
+            route_specs
+              [
+                {
+                  spawn_agent = normalize_spawn_agent spawn_agent;
+                  spawn_prompt;
+                  spawn_model = get_string_opt args "spawn_model";
+                  spawn_model_explicit = Option.is_some (get_string_opt args "spawn_model");
+                  spawn_role = get_string_opt args "spawn_role";
+                  worker_class =
+                    Option.bind
+                      (get_string_opt args "worker_class")
+                      (fun raw ->
+                        Team_session_types.worker_class_of_string
+                          (String.lowercase_ascii (String.trim raw)));
+                  worker_size =
+                    Option.bind
+                      (get_string_opt args "worker_size")
+                      (fun raw ->
+                        Team_session_types.worker_size_of_string
                           (String.lowercase_ascii (String.trim raw)));
                   parent_actor = get_string_opt args "parent_actor";
                   capsule_mode =
@@ -1260,6 +1389,28 @@ let planned_worker_of_spec ?runtime_actor (spec : spawn_spec) :
       | None -> false);
   }
 
+let resolve_target_worker_name (session : Team_session_types.session)
+    target_agent =
+  let trimmed = String.trim target_agent in
+  let matches_runtime_actor worker =
+    match worker.Team_session_types.runtime_actor with
+    | Some actor -> String.equal (String.trim actor) trimmed
+    | None -> false
+  in
+  let matches_role worker =
+    match worker.Team_session_types.spawn_role with
+    | Some role -> String.equal (String.trim role) trimmed
+    | None -> false
+  in
+  match List.find_opt matches_runtime_actor session.planned_workers with
+  | Some worker -> worker.Team_session_types.runtime_actor
+  | None -> (
+      match
+        session.planned_workers |> List.filter matches_role
+      with
+      | [ worker ] -> worker.Team_session_types.runtime_actor
+      | _ -> None)
+
 let register_planned_workers config session_id workers =
   match Team_session_store.update_session config session_id (fun session ->
             {
@@ -1294,6 +1445,9 @@ let register_planned_workers config session_id workers =
                 |> Team_session_types.counts_to_json );
               ( "tier_counts",
                 Team_session_types.model_tier_counts updated.planned_workers
+                |> Team_session_types.counts_to_json );
+              ( "worker_size_counts",
+                Team_session_types.worker_size_counts updated.planned_workers
                 |> Team_session_types.counts_to_json );
               ( "task_profile_counts",
                 Team_session_types.task_profile_counts updated.planned_workers
@@ -1402,18 +1556,21 @@ let handle_step ctx args : result =
       match ensure_session_access ctx session_id with
       | Error e -> (false, json_error e)
       | Ok () ->
+          let session_opt = Team_session_store.load_session ctx.config session_id in
           let spawn_specs_result = parse_step_spawn_specs args in
           match spawn_specs_result with
           | Error e -> (false, json_error e)
           | Ok raw_spawn_specs ->
               let spawn_specs =
-                match Team_session_store.load_session ctx.config session_id with
+                match session_opt with
                 | Some session ->
                     annotate_control_hierarchy_for_session session raw_spawn_specs
                 | None -> raw_spawn_specs
               in
+              let delegate_prompt_opt = get_string_opt args "delegate_prompt" in
               let turn_kind_result =
-                if spawn_specs <> [] then parse_turn_kind_opt args
+                if spawn_specs <> [] || Option.is_some delegate_prompt_opt then
+                  parse_turn_kind_opt args
                 else
                   match parse_turn_kind args with
                   | Ok kind -> Ok (Some kind)
@@ -1437,11 +1594,13 @@ let handle_step ctx args : result =
               | Ok actor ->
               let base_message = get_string_opt args "message" in
               let target_agent = get_string_opt args "target_agent" in
+              let delegate_prompt = delegate_prompt_opt in
               let task_title = get_string_opt args "task_title" in
               let task_description = get_string_opt args "task_description" in
               let task_priority = get_int args "task_priority" 3 in
               let append_spawn_event ?spawn_agent ?runtime_actor ?spawn_role
-                  ?spawn_model ?worker_class ?parent_actor ?capsule_mode
+                  ?spawn_model ?worker_class ?worker_size ?worker_backend
+                  ?parent_actor ?capsule_mode
                   ?runtime_pool ?lane_id ?controller_level ?control_domain
                   ?supervisor_actor ?model_tier ?task_profile ?risk_level
                   ?routing_confidence ?routing_reason ?assigned_runtime
@@ -1469,6 +1628,15 @@ let handle_step ctx args : result =
                             `String
                               (Team_session_types.worker_class_to_string kind))
                           worker_class );
+                      ( "worker_size",
+                        Option.fold ~none:`Null
+                          ~some:(fun size ->
+                            `String
+                              (Team_session_types.worker_size_to_string size))
+                          worker_size );
+                      ( "worker_backend",
+                        Option.fold ~none:`Null ~some:(fun s -> `String s)
+                          worker_backend );
                       ( "parent_actor",
                         Option.fold ~none:`Null ~some:(fun s -> `String s)
                           parent_actor );
@@ -1543,6 +1711,35 @@ let handle_step ctx args : result =
                 Team_session_store.append_event ctx.config session_id
                   ~event_type:"team_step_spawn" ~detail
               in
+              let append_delegate_event ~worker_name ~delegate_prompt ~success
+                  ?tool_names ?tool_call_count ?output_preview ?error () =
+                Team_session_store.append_event ctx.config session_id
+                  ~event_type:"team_step_delegate"
+                  ~detail:
+                    (`Assoc
+                      [
+                        ("actor", `String actor);
+                        ("target_agent", `String worker_name);
+                        ("delegate_prompt", `String delegate_prompt);
+                        ("worker_backend", `String "oas-local");
+                        ("success", `Bool success);
+                        ( "tool_names",
+                          Option.fold ~none:(`List [])
+                            ~some:(fun names ->
+                              `List (List.map (fun name -> `String name) names))
+                            tool_names );
+                        ( "tool_call_count",
+                          Option.fold ~none:`Null ~some:(fun n -> `Int n)
+                            tool_call_count );
+                        ( "output_preview",
+                          Option.fold ~none:`Null ~some:(fun s -> `String s)
+                            output_preview );
+                        ( "error",
+                          Option.fold ~none:`Null ~some:(fun s -> `String s)
+                            error );
+                        ("ts_iso", `String (Types.now_iso ()));
+                      ])
+              in
               let release_prepared_runtime (prepared : prepared_spawn) ~success
                   ?error ?latency_ms () =
                 match prepared.runtime_lease with
@@ -1558,7 +1755,7 @@ let handle_step ctx args : result =
               in
               let prepare_spawn (spec : spawn_spec) =
                 let runtime_actor_name =
-                  if String.equal spec.spawn_agent "llama" then
+                  if is_local_spawn_agent spec.spawn_agent then
                     Some
                       (derived_llama_runtime_actor ~session_id
                          ~prompt:spec.spawn_prompt)
@@ -1566,11 +1763,18 @@ let handle_step ctx args : result =
                     None
                 in
                 let runtime_model =
-                  if String.equal spec.spawn_agent "llama" then
-                    match spec.spawn_model with
-                    | None ->
-                        Error
-                          "spawn_model is required when spawn_agent=llama"
+                  if is_local_spawn_agent spec.spawn_agent then
+                    let model_name =
+                      match spec.spawn_model with
+                      | Some model_name -> Some model_name
+                      | None ->
+                          let default_model =
+                            Llm_client.default_local_model_spec ()
+                          in
+                          Some default_model.model_id
+                    in
+                    match model_name with
+                    | None -> Error "local worker model resolution failed"
                     | Some model_name -> (
                         match
                           Local_runtime_pool.acquire
@@ -1612,6 +1816,10 @@ let handle_step ctx args : result =
                             ?spawn_role:failed_spec.spawn_role
                             ?spawn_model:failed_spec.spawn_model
                             ?worker_class:failed_spec.worker_class
+                            ?worker_size:(worker_size_of_spec failed_spec)
+                            ?worker_backend:
+                              (if is_local_spawn_agent failed_spec.spawn_agent
+                               then Some "oas-local" else None)
                             ?parent_actor:failed_spec.parent_actor
                             ?capsule_mode:failed_spec.capsule_mode
                             ?runtime_pool:failed_spec.runtime_pool
@@ -1663,6 +1871,10 @@ let handle_step ctx args : result =
                               ?spawn_role:prepared.spec.spawn_role
                               ?spawn_model:prepared.spec.spawn_model
                               ?worker_class:prepared.spec.worker_class
+                              ?worker_size:(worker_size_of_spec prepared.spec)
+                              ?worker_backend:
+                                (if is_local_spawn_agent prepared.spec.spawn_agent
+                                 then Some "oas-local" else None)
                               ?parent_actor:prepared.spec.parent_actor
                               ?capsule_mode:prepared.spec.capsule_mode
                               ?runtime_pool:prepared.spec.runtime_pool
@@ -1697,6 +1909,10 @@ let handle_step ctx args : result =
                                   ?spawn_role:prepared.spec.spawn_role
                                   ?spawn_model:prepared.spec.spawn_model
                                   ?worker_class:prepared.spec.worker_class
+                                  ?worker_size:(worker_size_of_spec prepared.spec)
+                                  ?worker_backend:
+                                    (if is_local_spawn_agent prepared.spec.spawn_agent
+                                     then Some "oas-local" else None)
                                   ?parent_actor:prepared.spec.parent_actor
                                   ?capsule_mode:prepared.spec.capsule_mode
                                   ?runtime_pool:prepared.spec.runtime_pool
@@ -1736,13 +1952,17 @@ let handle_step ctx args : result =
                                    (fun prepared ->
                                      release_prepared_runtime prepared
                                        ~success:false ~error:msg ();
-                                     append_spawn_event
-                                       ~spawn_agent:prepared.spec.spawn_agent
-                                       ?runtime_actor:prepared.runtime_actor_name
-                                       ?spawn_role:prepared.spec.spawn_role
-                                       ?spawn_model:prepared.spec.spawn_model
-                                       ?worker_class:prepared.spec.worker_class
-                                       ?parent_actor:prepared.spec.parent_actor
+                                       append_spawn_event
+                                         ~spawn_agent:prepared.spec.spawn_agent
+                                         ?runtime_actor:prepared.runtime_actor_name
+                                         ?spawn_role:prepared.spec.spawn_role
+                                         ?spawn_model:prepared.spec.spawn_model
+                                         ?worker_class:prepared.spec.worker_class
+                                         ?worker_size:(worker_size_of_spec prepared.spec)
+                                         ?worker_backend:
+                                           (if is_local_spawn_agent prepared.spec.spawn_agent
+                                            then Some "oas-local" else None)
+                                         ?parent_actor:prepared.spec.parent_actor
                                        ?capsule_mode:prepared.spec.capsule_mode
                                        ?runtime_pool:prepared.spec.runtime_pool
                                        ?lane_id:prepared.spec.lane_id
@@ -1782,6 +2002,13 @@ let handle_step ctx args : result =
                                             ?runtime_role:prepared.spec.spawn_role
                                             ?runtime_selection_note:
                                               prepared.spec.spawn_selection_note
+                                            ?worker_class:prepared.spec.worker_class
+                                            ?worker_size:(worker_size_of_spec prepared.spec)
+                                            ?execution_scope:
+                                              (Option.map
+                                                 (fun (session : Team_session_types.session) ->
+                                                   session.execution_scope)
+                                                 session_opt)
                                             ~runtime_session_id:session_id ()
                                         in
                                         let output_preview =
@@ -1803,6 +2030,10 @@ let handle_step ctx args : result =
                                           ?spawn_role:prepared.spec.spawn_role
                                           ?spawn_model:prepared.spec.spawn_model
                                           ?worker_class:prepared.spec.worker_class
+                                          ?worker_size:(worker_size_of_spec prepared.spec)
+                                          ?worker_backend:
+                                            (if is_local_spawn_agent prepared.spec.spawn_agent
+                                             then Some "oas-local" else None)
                                           ?parent_actor:prepared.spec.parent_actor
                                           ?capsule_mode:prepared.spec.capsule_mode
                                           ?runtime_pool:prepared.spec.runtime_pool
@@ -1878,6 +2109,17 @@ let handle_step ctx args : result =
                                                         (Team_session_types.worker_class_to_string
                                                            kind))
                                                     prepared.spec.worker_class );
+                                                ( "worker_size",
+                                                  Option.fold ~none:`Null
+                                                    ~some:(fun size ->
+                                                      `String
+                                                        (Team_session_types.worker_size_to_string
+                                                           size))
+                                                    (worker_size_of_spec prepared.spec) );
+                                                ( "worker_backend",
+                                                  if is_local_spawn_agent prepared.spec.spawn_agent
+                                                  then `String "oas-local"
+                                                  else `Null );
                                                 ( "parent_actor",
                                                   Option.fold ~none:`Null
                                                     ~some:(fun s -> `String s)
@@ -2015,6 +2257,112 @@ let handle_step ctx args : result =
                   match turn_json_result with
                   | Error e -> (false, json_error e)
                   | Ok turn_json ->
+                      let delegate_result_json =
+                        match (delegate_prompt, target_agent) with
+                        | None, _ -> None
+                        | Some _, _ when spawn_specs <> [] ->
+                            Some
+                              (`Assoc
+                                [
+                                  ( "error",
+                                    `String
+                                      "delegate_prompt cannot be combined with worker spawn" );
+                                ])
+                        | Some _, None ->
+                            Some
+                              (`Assoc
+                                [
+                                  ( "error",
+                                    `String
+                                      "target_agent is required when delegate_prompt is provided" );
+                                ])
+                        | Some delegate_prompt, Some target_agent -> (
+                            match session_opt with
+                            | None ->
+                                Some
+                                  (`Assoc
+                                    [
+                                      ("error", `String "team session not found");
+                                    ])
+                            | Some session -> (
+                                match
+                                  resolve_target_worker_name session
+                                    target_agent
+                                with
+                                | None ->
+                                    Some
+                                      (`Assoc
+                                        [
+                                          ( "error",
+                                            `String
+                                              "target_agent did not match a known worker container"
+                                          );
+                                        ])
+                                | Some worker_name -> (
+                                    match
+                                      Local_agent_eio.continue_worker ~sw:ctx.sw
+                                        ~base_path:ctx.config.base_path
+                                        ~worker_name ~team_session_id:session_id
+                                        ~prompt:delegate_prompt
+                                    with
+                                    | Ok run_result ->
+                                        let output_preview =
+                                          truncate_for_event run_result.output
+                                        in
+                                        append_delegate_event ~worker_name
+                                          ~delegate_prompt
+                                          ~success:true
+                                          ~tool_names:run_result.tool_names
+                                          ~tool_call_count:
+                                            run_result.tool_call_count
+                                          ~output_preview ();
+                                        Some
+                                          (`Assoc
+                                            [
+                                              ("worker_name", `String worker_name);
+                                              ("worker_backend", `String "oas-local");
+                                              ( "output",
+                                                `String run_result.output );
+                                              ( "output_preview",
+                                                `String output_preview );
+                                              ( "tool_call_count",
+                                                `Int
+                                                  run_result.tool_call_count );
+                                              ( "tool_names",
+                                                `List
+                                                  (List.map
+                                                     (fun name -> `String name)
+                                                     run_result.tool_names) );
+                                              ( "input_tokens",
+                                                int_opt_to_json
+                                                  run_result.input_tokens );
+                                              ( "output_tokens",
+                                                int_opt_to_json
+                                                  run_result.output_tokens );
+                                              ( "cost_usd",
+                                                float_opt_to_json
+                                                  run_result.cost_usd );
+                                            ])
+                                    | Error err ->
+                                        append_delegate_event ~worker_name
+                                          ~delegate_prompt
+                                          ~success:false ~error:err ();
+                                        Some
+                                          (`Assoc
+                                            [ ("error", `String err) ]))))
+                      in
+                      let delegate_error =
+                        match delegate_result_json with
+                        | Some (`Assoc fields) -> (
+                            match List.assoc_opt "error" fields with
+                            | Some (`String e) when String.trim e <> "" ->
+                                Some e
+                            | _ -> None)
+                        | _ -> None
+                      in
+                      match delegate_error with
+                      | Some e -> (false, json_error e)
+                      | None ->
                       let vote_result_json =
                         match get_string_opt args "vote_topic" with
                         | None -> None
@@ -2147,6 +2495,7 @@ let handle_step ctx args : result =
                                 ("session_id", `String session_id);
                                 ("turn", Option.value ~default:`Null turn_json);
                                 ("spawn", Option.fold ~none:`Null ~some:(fun j -> j) spawn_result_json);
+                                ("delegate", Option.fold ~none:`Null ~some:(fun j -> j) delegate_result_json);
                                 ("vote", Option.fold ~none:`Null ~some:(fun j -> j) vote_result_json);
                                 ("run", Option.fold ~none:`Null ~some:(fun j -> j) run_json);
                               ]
@@ -2538,6 +2887,7 @@ let schemas : tool_schema list =
                       ] );
                   ("message", `Assoc [ ("type", `String "string") ]);
                   ("target_agent", `Assoc [ ("type", `String "string") ]);
+                  ("delegate_prompt", `Assoc [ ("type", `String "string") ]);
                   ("task_title", `Assoc [ ("type", `String "string") ]);
                   ("task_description", `Assoc [ ("type", `String "string") ]);
                   ("task_priority", `Assoc [ ("type", `String "integer") ]);
@@ -2557,6 +2907,12 @@ let schemas : tool_schema list =
 	                              `String "librarian";
 	                              `String "metacog";
 	                            ] );
+	                      ] );
+	                  ( "worker_size",
+	                    `Assoc
+	                      [
+	                        ("type", `String "string");
+	                        ("enum", `List [ `String "sm"; `String "lg"; `String "xlg" ]);
 	                      ] );
 	                  ("parent_actor", `Assoc [ ("type", `String "string") ]);
 	                  ( "capsule_mode",
@@ -2654,6 +3010,12 @@ let schemas : tool_schema list =
 	                                                `String "metacog";
 	                                              ] );
 	                                        ] );
+	                                    ( "worker_size",
+	                                      `Assoc
+	                                        [
+	                                          ("type", `String "string");
+	                                          ("enum", `List [ `String "sm"; `String "lg"; `String "xlg" ]);
+	                                        ] );
 	                                    ("parent_actor", `Assoc [ ("type", `String "string") ]);
 	                                    ( "capsule_mode",
 	                                      `Assoc
@@ -2728,7 +3090,6 @@ let schemas : tool_schema list =
                               ( "required",
                                 `List
                                   [
-                                    `String "spawn_agent";
                                     `String "spawn_prompt";
                                   ] );
                             ] );

--- a/masc_mcp.opam
+++ b/masc_mcp.opam
@@ -23,7 +23,7 @@ depends: [
   "cmdliner" {>= "1.1"}
   "cohttp" {>= "5.0"}
   "cohttp-eio" {>= "6.0" & < "6.2"}
-  "agent_sdk" {>= "0.5.0"}
+  "agent_sdk" {>= "0.9.1"}
   "uri" {>= "4.4"}
   "tls" {>= "0.16"}
   "tls-eio" {>= "0.16"}

--- a/scripts/opam-pin-external-deps.sh
+++ b/scripts/opam-pin-external-deps.sh
@@ -24,7 +24,8 @@ if $include_compact_protocol; then
 fi
 
 opam pin add mcp_protocol https://github.com/jeong-sik/mcp-protocol-sdk.git#main -n -y
-opam pin add agent_sdk https://github.com/jeong-sik/oas.git#fcf418d6be4b34e23bf76da0c99b798ef7843a41 -n -y
+opam pin add mcp_protocol_eio https://github.com/jeong-sik/mcp-protocol-sdk.git#main -n -y
+opam pin add agent_sdk https://github.com/jeong-sik/oas.git#main -n -y
 opam pin add ocaml-webrtc https://github.com/jeong-sik/ocaml-webrtc.git#main -n -y
 opam pin add grpc-direct-core https://github.com/jeong-sik/grpc-direct.git#main -n -y
 opam pin add grpc-direct https://github.com/jeong-sik/grpc-direct.git#main -n -y

--- a/start-masc-mcp.sh
+++ b/start-masc-mcp.sh
@@ -135,8 +135,11 @@ INSTALLED_EXE="$(command -v masc-mcp || true)"
 # Eio-based server (main_eio.exe) - for PostgresNative backend
 WORKSPACE_EIO_EXE="$SCRIPT_DIR/../_build/default/masc-mcp/bin/main_eio.exe"
 LOCAL_EIO_EXE="$SCRIPT_DIR/_build/default/bin/main_eio.exe"
+WORKSPACE_STDIO_EIO_EXE="$SCRIPT_DIR/../_build/default/masc-mcp/bin/main_stdio_eio.exe"
+LOCAL_STDIO_EIO_EXE="$SCRIPT_DIR/_build/default/bin/main_stdio_eio.exe"
 MASC_EXE=""
 MASC_EIO_EXE=""
+MASC_STDIO_EIO_EXE=""
 
 # 1. Pre-downloaded release binary (fastest, no build needed)
 if [ -x "$RELEASE_BINARY" ]; then
@@ -158,6 +161,12 @@ elif [ -x "$LOCAL_EIO_EXE" ]; then
     MASC_EIO_EXE="$LOCAL_EIO_EXE"
 fi
 
+if [ -x "$WORKSPACE_STDIO_EIO_EXE" ]; then
+    MASC_STDIO_EIO_EXE="$WORKSPACE_STDIO_EIO_EXE"
+elif [ -x "$LOCAL_STDIO_EIO_EXE" ]; then
+    MASC_STDIO_EIO_EXE="$LOCAL_STDIO_EIO_EXE"
+fi
+
 # 5. Build Eio version if not found (Lwt deprecated, download disabled)
 if [ -z "$MASC_EIO_EXE" ]; then
     echo "Building MASC MCP server from source..." >&2
@@ -170,6 +179,23 @@ if [ -z "$MASC_EIO_EXE" ]; then
         MASC_EIO_EXE="$LOCAL_EIO_EXE"
     else
         echo "Error: build failed." >&2
+        exit 1
+    fi
+fi
+
+if [ "$HTTP_MODE" = "false" ] && [ -z "$MASC_STDIO_EIO_EXE" ]; then
+    echo "Building MASC MCP stdio server from source..." >&2
+    if ! command -v dune >/dev/null 2>&1; then
+        echo "Error: dune not found. Cannot build stdio server." >&2
+        exit 1
+    fi
+    dune build --root "$SCRIPT_DIR" bin/main_stdio_eio.exe 1>&2
+    if [ -x "$WORKSPACE_STDIO_EIO_EXE" ]; then
+        MASC_STDIO_EIO_EXE="$WORKSPACE_STDIO_EIO_EXE"
+    elif [ -x "$LOCAL_STDIO_EIO_EXE" ]; then
+        MASC_STDIO_EIO_EXE="$LOCAL_STDIO_EIO_EXE"
+    else
+        echo "Error: failed to build stdio server." >&2
         exit 1
     fi
 fi
@@ -273,7 +299,7 @@ RUNTIME_NAME="Lwt"
 
 if [ "$EIO_MODE" = "true" ]; then
     RUNTIME_NAME="Eio"
-    if [ -z "$MASC_EIO_EXE" ]; then
+    if [ "$HTTP_MODE" = "true" ] && [ -z "$MASC_EIO_EXE" ]; then
         echo "Building MASC MCP server (Eio mode)..." >&2
         if ! command -v dune >/dev/null 2>&1; then
             echo "Error: dune not found. Cannot build Eio server." >&2
@@ -289,11 +315,15 @@ if [ "$EIO_MODE" = "true" ]; then
             exit 1
         fi
     fi
-    SELECTED_EXE="$MASC_EIO_EXE"
+    if [ "$HTTP_MODE" = "true" ]; then
+        SELECTED_EXE="$MASC_EIO_EXE"
+    else
+        SELECTED_EXE="$MASC_STDIO_EIO_EXE"
+    fi
 fi
 
 # Eio server has different CLI format and is HTTP-only
-if [ "$EIO_MODE" = "true" ]; then
+if [ "$EIO_MODE" = "true" ] && [ "$HTTP_MODE" = "true" ]; then
     echo "Starting MASC MCP server (HTTP mode, $RUNTIME_NAME)..." >&2
     echo "  Host: $HOST" >&2
     echo "  Port: $PORT" >&2
@@ -334,5 +364,9 @@ else
         echo "  Base path (input): $BASE_PATH" >&2
     fi
     echo "  MASC dir: $RESOLVED_BASE_PATH/.masc" >&2
-    exec "$SELECTED_EXE" --stdio --path "$BASE_PATH"
+    if [ "$EIO_MODE" = "true" ]; then
+        exec "$SELECTED_EXE" --base-path "$BASE_PATH"
+    else
+        exec "$SELECTED_EXE" --stdio --path "$BASE_PATH"
+    fi
 fi

--- a/test/test_agent_swarm_dev_tools.ml
+++ b/test/test_agent_swarm_dev_tools.ml
@@ -26,6 +26,15 @@ let test_tool_names () =
   let expected = ["file_read"; "file_write"; "shell_exec"] in
   Alcotest.(check (list string)) "tool names match" expected names
 
+let test_readonly_tool_names () =
+  Eio_main.run @@ fun env ->
+  let proc_mgr = Eio.Stdenv.process_mgr env in
+  let clock = Eio.Stdenv.clock env in
+  let tools = Agent_swarm_dev_tools.make_readonly_tools ~proc_mgr ~clock () in
+  let names = List.map (fun (t : Tool.t) -> t.schema.name) tools in
+  let expected = ["file_read"; "shell_exec"] in
+  Alcotest.(check (list string)) "readonly tool names match" expected names
+
 (* --- file_read tests --- *)
 
 let test_file_read_existing () =
@@ -281,6 +290,18 @@ let test_shell_exec_missing_param () =
        (String.length msg > 0)
    | Ok _ -> Alcotest.fail "should fail without command param")
 
+let test_readonly_shell_exec_blocks_git () =
+  Eio_main.run @@ fun env ->
+  let proc_mgr = Eio.Stdenv.process_mgr env in
+  let clock = Eio.Stdenv.clock env in
+  let tools = Agent_swarm_dev_tools.make_readonly_tools ~proc_mgr ~clock () in
+  let tool = find_tool "shell_exec" tools in
+  let result = Tool.execute tool
+    (`Assoc [("command", `String "git status")]) in
+  match result with
+  | Error _ -> ()
+  | Ok _ -> Alcotest.fail "readonly shell should block git"
+
 let test_workdir_enforcement () =
   Eio_main.run @@ fun env ->
   let proc_mgr = Eio.Stdenv.process_mgr env in
@@ -316,6 +337,7 @@ let () =
     "structure", [
       Alcotest.test_case "tool count" `Quick test_tool_count;
       Alcotest.test_case "tool names" `Quick test_tool_names;
+      Alcotest.test_case "readonly tool names" `Quick test_readonly_tool_names;
     ];
     "file_read", [
       Alcotest.test_case "read existing file" `Quick test_file_read_existing;
@@ -342,6 +364,8 @@ let () =
         test_shell_exec_rejects_shell_metacharacters;
       Alcotest.test_case "nonexistent command" `Quick test_shell_exec_nonexistent_cmd;
       Alcotest.test_case "missing param" `Quick test_shell_exec_missing_param;
+      Alcotest.test_case "readonly shell blocks git" `Quick
+        test_readonly_shell_exec_blocks_git;
     ];
     "workdir", [
       Alcotest.test_case "workdir enforcement" `Quick test_workdir_enforcement;

--- a/test/test_tool_team_session.ml
+++ b/test/test_tool_team_session.ml
@@ -36,8 +36,12 @@ let () =
             Test_tool_team_session_step_validation.test_step_actor_must_match_caller;
           Alcotest.test_case "step-spawn-requires-proc-mgr" `Quick
             Test_tool_team_session_step_validation.test_step_spawn_requires_proc_mgr;
-          Alcotest.test_case "step-spawn-llama-requires-spawn-model" `Quick
-            Test_tool_team_session_step_validation.test_step_spawn_llama_requires_spawn_model;
+          Alcotest.test_case "step-spawn-default-local-allows-worker-size" `Quick
+            Test_tool_team_session_step_validation.test_step_spawn_default_local_allows_worker_size_without_spawn_model;
+          Alcotest.test_case "step-delegate-requires-target-agent" `Quick
+            Test_tool_team_session_step_validation.test_step_delegate_requires_target_agent;
+          Alcotest.test_case "step-delegate-unknown-worker-rejected" `Quick
+            Test_tool_team_session_step_validation.test_step_delegate_unknown_worker_rejected;
           Alcotest.test_case "step-spawn-batch-records-planned-workers"
             `Quick Test_tool_team_session_step_routing.test_step_spawn_batch_records_planned_workers;
           Alcotest.test_case "step-spawn-batch-applies-hybrid-routing"

--- a/test/test_tool_team_session_step_validation.ml
+++ b/test/test_tool_team_session_step_validation.ml
@@ -153,7 +153,7 @@ let test_step_spawn_requires_proc_mgr () =
   ignore (wait_until_terminal ctx session_id);
   cleanup_dir base_dir
 
-let test_step_spawn_llama_requires_spawn_model () =
+let test_step_spawn_default_local_allows_worker_size_without_spawn_model () =
   Eio_main.run @@ fun env ->
   Eio.Switch.run @@ fun sw ->
   let base_dir = temp_dir () in
@@ -173,20 +173,25 @@ let test_step_spawn_llama_requires_spawn_model () =
         (`Assoc
           [
             ("session_id", `String session_id);
-            ("spawn_agent", `String "llama");
-            ("spawn_prompt", `String "inspect and report");
-            ("spawn_role", `String "planner");
+            ("spawn_prompt", `String "normalize evidence into strict JSON schema");
+            ("spawn_role", `String "normalizer");
+            ("worker_class", `String "executor");
+            ("worker_size", `String "lg");
             ("spawn_selection_note", `String selection_note);
           ])
   in
-  Alcotest.(check bool) "step should fail without spawn_model for llama" false step_ok;
+  Alcotest.(check bool) "step fails later because proc_mgr is missing" false step_ok;
   let body = parse_json_exn step_body in
   let message =
     body |> Yojson.Safe.Util.member "message" |> Yojson.Safe.Util.to_string
   in
-  Alcotest.(check bool) "error mentions spawn_model" true
+  Alcotest.(check bool) "error mentions proc manager" true
     (try
-       let _ = Str.search_forward (Str.regexp_string "spawn_model") message 0 in
+       let _ =
+         Str.search_forward
+           (Str.regexp_string "process manager unavailable")
+           message 0
+       in
        true
      with Not_found -> false);
   let events_ok, events_body =
@@ -200,20 +205,39 @@ let test_step_spawn_llama_requires_spawn_model () =
   in
   Alcotest.(check bool) "events query ok" true events_ok;
   let events = events_list_of_body events_body in
-  Alcotest.(check int) "spawn failure event recorded" 1 (List.length events);
+  Alcotest.(check int) "spawn event recorded" 1 (List.length events);
   let detail = Yojson.Safe.Util.member "detail" (List.hd events) in
-  let spawn_model =
-    detail |> Yojson.Safe.Util.member "spawn_model"
+  let worker_backend =
+    detail |> Yojson.Safe.Util.member "worker_backend"
+    |> Yojson.Safe.Util.to_string_option
   in
-  Alcotest.(check bool) "spawn_model absent in failure event" true (spawn_model = `Null);
+  Alcotest.(check (option string)) "worker backend" (Some "oas-local")
+    worker_backend;
+  let worker_size =
+    detail |> Yojson.Safe.Util.member "worker_size"
+    |> Yojson.Safe.Util.to_string_option
+  in
+  Alcotest.(check (option string)) "worker size in event" (Some "lg")
+    worker_size;
   let attached_events =
     Team_session_store.read_events config session_id
     |> List.filter (fun json ->
            Yojson.Safe.Util.member "event_type" json
            = `String "session_agent_attached")
   in
-  Alcotest.(check int) "no phantom attachment on validation failure" 0
+  Alcotest.(check int) "no phantom attachment before execution" 0
     (List.length attached_events);
+  let session =
+    Team_session_store.load_session config session_id |> Option.get
+  in
+  Alcotest.(check int) "planned worker recorded" 1
+    (List.length session.planned_workers);
+  let worker = List.hd session.planned_workers in
+  Alcotest.(check string) "spawn agent normalized" "default"
+    worker.Team_session_types.spawn_agent;
+  Alcotest.(check (option string)) "tier falls back when middle model is unavailable"
+    (Some "35b")
+    (Option.map Team_session_types.model_tier_to_string worker.model_tier);
   let recorded_selection_note =
     detail |> Yojson.Safe.Util.member "spawn_selection_note"
     |> Yojson.Safe.Util.to_string_option
@@ -241,3 +265,63 @@ let test_step_spawn_llama_requires_spawn_model () =
      with Not_found -> false);
   cleanup_dir base_dir
 
+let test_step_delegate_requires_target_agent () =
+  Eio_main.run @@ fun env ->
+  Eio.Switch.run @@ fun sw ->
+  let base_dir = temp_dir () in
+  let config = Room.default_config base_dir in
+  ignore (Room.init config ~agent_name:(Some "owner"));
+  ignore (Room.join config ~agent_name:"owner" ~capabilities:[] ());
+  let ctx : _ Tool_team_session.context =
+    { config; agent_name = "owner"; sw; clock = Eio.Stdenv.clock env; proc_mgr = None }
+  in
+  let session_id =
+    start_session_exn ctx ~goal:"step-delegate-requires-target-agent"
+    |> get_session_id
+  in
+  let ok, body =
+    dispatch_exn ctx ~name:"masc_team_session_step"
+      ~args:
+        (`Assoc
+          [
+            ("session_id", `String session_id);
+            ("delegate_prompt", `String "continue from previous work");
+          ])
+  in
+  Alcotest.(check bool) "delegate without target fails" false ok;
+  let json = parse_json_exn body in
+  Alcotest.(check string) "delegate target message"
+    "target_agent is required when delegate_prompt is provided"
+    (json |> Yojson.Safe.Util.member "message" |> Yojson.Safe.Util.to_string);
+  cleanup_dir base_dir
+
+let test_step_delegate_unknown_worker_rejected () =
+  Eio_main.run @@ fun env ->
+  Eio.Switch.run @@ fun sw ->
+  let base_dir = temp_dir () in
+  let config = Room.default_config base_dir in
+  ignore (Room.init config ~agent_name:(Some "owner"));
+  ignore (Room.join config ~agent_name:"owner" ~capabilities:[] ());
+  let ctx : _ Tool_team_session.context =
+    { config; agent_name = "owner"; sw; clock = Eio.Stdenv.clock env; proc_mgr = None }
+  in
+  let session_id =
+    start_session_exn ctx ~goal:"step-delegate-unknown-worker"
+    |> get_session_id
+  in
+  let ok, body =
+    dispatch_exn ctx ~name:"masc_team_session_step"
+      ~args:
+        (`Assoc
+          [
+            ("session_id", `String session_id);
+            ("target_agent", `String "llama-local-missing");
+            ("delegate_prompt", `String "continue from previous work");
+          ])
+  in
+  Alcotest.(check bool) "delegate unknown worker fails" false ok;
+  let json = parse_json_exn body in
+  Alcotest.(check string) "delegate unknown worker message"
+    "target_agent did not match a known worker container"
+    (json |> Yojson.Safe.Util.member "message" |> Yojson.Safe.Util.to_string);
+  cleanup_dir base_dir


### PR DESCRIPTION
## Summary
- add an OAS-backed local worker container path for team-session local workers
- expose public `worker_size` / default-local spawn semantics without surfacing provider/model details
- add an Eio stdio entrypoint and mixed framed/NDJSON stdio transport so OAS can talk to MASC over stdio again

## Key changes
- local workers now default to the OAS-backed container path with checkpoint/meta persistence and delegation support
- `masc_team_session_step` now supports default local spawn via `spawn_prompt`, `worker_size=sm|lg|xlg`, and `delegate_prompt`
- readonly vs dev shell profiles are split for observe-only vs limited-code-change workers
- `agent_sdk` minimum version is raised to `0.9.1` to match the newer local OAS API surface

## Validation
- `dune build`
- `./_build/default/test/test_agent_swarm_dev_tools.exe`
- `./_build/default/test/test_tool_team_session.exe test team_session 16-23 --show-errors`
- `env LLAMA_LIVE_TEST=1 LLAMA_LIVE_TOOL_TEST=1 dune exec ./test/test_local_llm.exe` in `oas`
- `env LLAMA_LIVE_TEST=1 LLAMA_LIVE_MASC_TEST=1 MASC_MCP_COMMAND=.../start-masc-mcp.sh MASC_MCP_BASE_PATH=... dune exec ./test/test_local_llm.exe` in `oas`

## Notes
- local development now expects the opam `agent_sdk` package to come from the local `oas` checkout or an equivalent `>= 0.9.1` build
- non-local providers remain unchanged in this PR
