### PR TITLE
feat(team-session): harden worker proof and async evidence

### DIFF
--- a/docs/SUPERVISOR-MODE.md
+++ b/docs/SUPERVISOR-MODE.md
@@ -55,7 +55,7 @@ Use `/mcp` when an agent needs the full room and team-session tool inventory.
 `masc-mcp` can run a worker directly on the hidden local worker backend.
 
 - canonical team-session spawn path: `masc_team_session_step(spawn_role="...", worker_class="...", worker_size="...", spawn_prompt="...")`
-- implementation detail: local OAS worker on the configured local runtime
+- implementation detail: local worker on the configured local runtime
 
 Environment:
 

--- a/lib/agent_swarm_dev_tools.ml
+++ b/lib/agent_swarm_dev_tools.ml
@@ -139,9 +139,12 @@ let rec mkdir_p path perm =
     (try Unix.mkdir path perm with Unix.Unix_error (Unix.EEXIST, _, _) -> ())
   end
 
+type tool_exec_observer =
+  tool_name:string -> success:bool -> duration_ms:int -> unit
+
 (* --- Tool implementations --- *)
 
-let make_file_read ?workdir () =
+let make_file_read ?workdir ?on_exec () =
   Agent_sdk.Tool.create
     ~name:"file_read"
     ~description:"Read file contents by absolute path. Returns file text. \
@@ -156,20 +159,41 @@ let make_file_read ?workdir () =
        match Agent_swarm_tool_input.extract_string "path" input with
        | Error e -> Error e
        | Ok path ->
+         let started = Time_compat.now () in
          let resolved_path = resolve_path ?base_dir:workdir path in
          if not (validate_path ?workdir path) then
-           Error (Printf.sprintf
-             "Path blocked: %s (outside allowed directories)" path)
+           let err =
+             Printf.sprintf "Path blocked: %s (outside allowed directories)" path
+           in
+           let duration_ms =
+             int_of_float ((Time_compat.now () -. started) *. 1000.0)
+           in
+           Option.iter
+             (fun f -> f ~tool_name:"file_read" ~success:false ~duration_ms)
+             on_exec;
+           Error err
          else
            try
              let content = In_channel.with_open_text resolved_path In_channel.input_all in
+             let duration_ms =
+               int_of_float ((Time_compat.now () -. started) *. 1000.0)
+             in
+             Option.iter
+               (fun f -> f ~tool_name:"file_read" ~success:true ~duration_ms)
+               on_exec;
              if String.length content > 100_000 then
                Ok (String.sub content 0 100_000 ^ "\n[TRUNCATED at 100KB]")
              else Ok content
            with Sys_error msg ->
+             let duration_ms =
+               int_of_float ((Time_compat.now () -. started) *. 1000.0)
+             in
+             Option.iter
+               (fun f -> f ~tool_name:"file_read" ~success:false ~duration_ms)
+               on_exec;
              Error (Printf.sprintf "Cannot read: %s" msg))
 
-let make_file_write ?workdir () =
+let make_file_write ?workdir ?on_exec () =
   Agent_sdk.Tool.create
     ~name:"file_write"
     ~description:"Write content to a file by absolute path. Creates the file \
@@ -188,21 +212,42 @@ let make_file_write ?workdir () =
              Agent_swarm_tool_input.extract_string "content" input with
        | Error e, _ | _, Error e -> Error e
        | Ok path, Ok content ->
+         let started = Time_compat.now () in
          let resolved_path = resolve_path ?base_dir:workdir path in
          if not (validate_path ?workdir path) then
-           Error (Printf.sprintf
-             "Path blocked: %s (outside allowed directories)" path)
+           let err =
+             Printf.sprintf "Path blocked: %s (outside allowed directories)" path
+           in
+           let duration_ms =
+             int_of_float ((Time_compat.now () -. started) *. 1000.0)
+           in
+           Option.iter
+             (fun f -> f ~tool_name:"file_write" ~success:false ~duration_ms)
+             on_exec;
+           Error err
          else
            try
              mkdir_p (Filename.dirname resolved_path) 0o755;
              Out_channel.with_open_text resolved_path
                (fun oc -> Out_channel.output_string oc content);
+             let duration_ms =
+               int_of_float ((Time_compat.now () -. started) *. 1000.0)
+             in
+             Option.iter
+               (fun f -> f ~tool_name:"file_write" ~success:true ~duration_ms)
+               on_exec;
              Ok (Printf.sprintf "Written %d bytes to %s"
                (String.length content) resolved_path)
            with Sys_error msg ->
+             let duration_ms =
+               int_of_float ((Time_compat.now () -. started) *. 1000.0)
+             in
+             Option.iter
+               (fun f -> f ~tool_name:"file_write" ~success:false ~duration_ms)
+               on_exec;
              Error (Printf.sprintf "Cannot write: %s" msg))
 
-let make_shell_exec_with_allowlist ~workdir ~proc_mgr ~clock ~allowed_commands
+let make_shell_exec_with_allowlist ~workdir ~on_exec ~proc_mgr ~clock ~allowed_commands
     ~description =
   Agent_sdk.Tool.create
     ~name:"shell_exec"
@@ -228,7 +273,9 @@ let make_shell_exec_with_allowlist ~workdir ~proc_mgr ~clock ~allowed_commands
              |> Float.min 120.0
            in
            try
-             Eio.Fiber.first
+             let started = Time_compat.now () in
+             let result =
+               Eio.Fiber.first
                (fun () ->
                   Eio.Switch.run @@ fun sw ->
                   let buf = Buffer.create 1024 in
@@ -253,11 +300,25 @@ let make_shell_exec_with_allowlist ~workdir ~proc_mgr ~clock ~allowed_commands
                (fun () ->
                   Eio.Time.sleep clock timeout;
                   Error (Printf.sprintf "Timeout after %.0fs: %s" timeout command))
+             in
+             let duration_ms =
+               int_of_float ((Time_compat.now () -. started) *. 1000.0)
+             in
+             Option.iter
+               (fun f ->
+                 f ~tool_name:"shell_exec"
+                   ~success:(Result.is_ok result) ~duration_ms)
+               on_exec;
+             result
            with exn ->
+             let duration_ms = 0 in
+             Option.iter
+               (fun f -> f ~tool_name:"shell_exec" ~success:false ~duration_ms)
+               on_exec;
              Error (Printf.sprintf "Command failed: %s" (Printexc.to_string exn))))
 
-let make_shell_exec ~workdir ~proc_mgr ~clock =
-  make_shell_exec_with_allowlist ~workdir ~proc_mgr ~clock
+let make_shell_exec ~workdir ~on_exec ~proc_mgr ~clock =
+  make_shell_exec_with_allowlist ~workdir ~on_exec ~proc_mgr ~clock
     ~allowed_commands:dev_allowed_commands
     ~description:
       "Execute a shell command and return stdout+stderr. \
@@ -266,8 +327,8 @@ let make_shell_exec ~workdir ~proc_mgr ~clock =
        Unlike file_read (single file), this handles approved CLI operations. \
        Commands run in /bin/sh but shell control syntax is rejected."
 
-let make_shell_exec_readonly ~workdir ~proc_mgr ~clock =
-  make_shell_exec_with_allowlist ~workdir ~proc_mgr ~clock
+let make_shell_exec_readonly ~workdir ~on_exec ~proc_mgr ~clock =
+  make_shell_exec_with_allowlist ~workdir ~on_exec ~proc_mgr ~clock
     ~allowed_commands:readonly_allowed_commands
     ~description:
       "Execute a read-only shell command and return stdout+stderr. \
@@ -277,11 +338,11 @@ let make_shell_exec_readonly ~workdir ~proc_mgr ~clock =
 
 (** Create dev tools that close over Eio capabilities.
     Returns [file_read; file_write; shell_exec]. *)
-let make_tools ~proc_mgr ~clock ?workdir () : Agent_sdk.Tool.t list =
-  [ make_file_read ?workdir ();
-    make_file_write ?workdir ();
-    make_shell_exec ~workdir ~proc_mgr ~clock ]
+let make_tools ~proc_mgr ~clock ?workdir ?on_exec () : Agent_sdk.Tool.t list =
+  [ make_file_read ?workdir ?on_exec ();
+    make_file_write ?workdir ?on_exec ();
+    make_shell_exec ~workdir ~on_exec ~proc_mgr ~clock ]
 
-let make_readonly_tools ~proc_mgr ~clock ?workdir () : Agent_sdk.Tool.t list =
-  [ make_file_read ?workdir ();
-    make_shell_exec_readonly ~workdir ~proc_mgr ~clock ]
+let make_readonly_tools ~proc_mgr ~clock ?workdir ?on_exec () : Agent_sdk.Tool.t list =
+  [ make_file_read ?workdir ?on_exec ();
+    make_shell_exec_readonly ~workdir ~on_exec ~proc_mgr ~clock ]

--- a/lib/fs_compat/fs_compat.ml
+++ b/lib/fs_compat/fs_compat.ml
@@ -25,6 +25,9 @@ let set_fs fs =
 let clear_fs () =
   global_fs := None
 
+let get_fs_opt () =
+  !global_fs
+
 (** Check if Eio fs is available *)
 let has_fs () =
   Option.is_some !global_fs

--- a/lib/fs_compat/fs_compat.mli
+++ b/lib/fs_compat/fs_compat.mli
@@ -9,6 +9,9 @@ val set_fs : Eio.Fs.dir_ty Eio.Path.t -> unit
 val clear_fs : unit -> unit
 (** Clear global fs (testing/shutdown). *)
 
+val get_fs_opt : unit -> Eio.Fs.dir_ty Eio.Path.t option
+(** Get the global Eio filesystem if available. *)
+
 val has_fs : unit -> bool
 (** Check if Eio fs is available. *)
 

--- a/lib/local_agent_eio.ml
+++ b/lib/local_agent_eio.ml
@@ -18,6 +18,7 @@ type run_result = {
   tool_call_count : int;
   tool_names : string list;
   session_id : string;
+  raw_trace_run : Oas.Raw_trace.run_ref option;
 }
 
 type tool_profile =
@@ -38,6 +39,9 @@ type worker_container_meta = {
   role : string option;
   selection_note : string option;
   execution_scope : Team_session_types.execution_scope;
+  thinking_enabled : bool option;
+  max_turns_override : int option;
+  timeout_seconds : int option;
   tool_profile : tool_profile;
   shell_profile : shell_profile;
   worker_class : Team_session_types.worker_class option;
@@ -741,6 +745,11 @@ let worker_turn_log_path ~base_path ~team_session_id ~worker_name =
     (worker_container_dir ~base_path ~team_session_id ~worker_name)
     "turns.jsonl"
 
+let worker_raw_trace_path ~base_path ~team_session_id ~worker_name =
+  Filename.concat
+    (worker_container_dir ~base_path ~team_session_id ~worker_name)
+    "raw-trace.jsonl"
+
 let ensure_worker_container_dirs ~base_path ~team_session_id ~worker_name =
   let dir = worker_container_dir ~base_path ~team_session_id ~worker_name in
   Team_session_store.write_text_file (Filename.concat dir ".keep") "";
@@ -827,6 +836,9 @@ let worker_meta_to_yojson (meta : worker_container_meta) =
       ( "execution_scope",
         `String
           (Team_session_types.execution_scope_to_string meta.execution_scope) );
+      ("thinking_enabled", Option.fold ~none:`Null ~some:(fun v -> `Bool v) meta.thinking_enabled);
+      ("max_turns_override", Option.fold ~none:`Null ~some:(fun n -> `Int n) meta.max_turns_override);
+      ("timeout_seconds", Option.fold ~none:`Null ~some:(fun n -> `Int n) meta.timeout_seconds);
       ("tool_profile", `String (tool_profile_to_string meta.tool_profile));
       ("shell_profile", `String (shell_profile_to_string meta.shell_profile));
       ( "worker_class",
@@ -883,6 +895,12 @@ let worker_meta_of_yojson json =
               selection_note =
                 json |> member "selection_note" |> to_string_option;
               execution_scope;
+              thinking_enabled =
+                json |> member "thinking_enabled" |> to_bool_option;
+              max_turns_override =
+                json |> member "max_turns_override" |> to_int_option;
+              timeout_seconds =
+                json |> member "timeout_seconds" |> to_int_option;
               tool_profile =
                 (match json |> member "tool_profile" |> to_string_option with
                 | Some value -> (
@@ -1070,17 +1088,30 @@ let build_oas_mcp_tools ~sw ~auth_token ~session_id ~worker_name ~prompt
                }))
     listed_schemas
 
-let build_local_shell_tools ~execution_scope ~workdir =
+let build_local_shell_tools ~room_config ~worker_name ~execution_scope ~workdir =
   match Process_eio.get_proc_mgr (), Process_eio.get_clock () with
   | Ok proc_mgr, Ok clock -> (
+      let on_exec ~tool_name ~success ~duration_ms =
+        (match room_config, Fs_compat.get_fs_opt () with
+        | Some config, Some fs -> (
+            try
+              Telemetry_eio.track_tool_called ~fs config ~tool_name ~success
+                ~duration_ms ~agent_id:worker_name ()
+            with exn ->
+              eprintf "[local-worker] telemetry error for %s/%s: %s\n%!"
+                worker_name tool_name (Printexc.to_string exn))
+        | _ -> ());
+        ()
+      in
       match execution_scope with
       | Team_session_types.Observe_only ->
           Ok
             (Agent_swarm_dev_tools.make_readonly_tools ~proc_mgr ~clock
-               ~workdir ())
+               ~workdir ~on_exec ())
       | Team_session_types.Limited_code_change ->
           Ok
-            (Agent_swarm_dev_tools.make_tools ~proc_mgr ~clock ~workdir ()))
+            (Agent_swarm_dev_tools.make_tools ~proc_mgr ~clock ~workdir
+               ~on_exec ()))
   | Error e, _ | _, Error e -> Error e
 
 let oas_provider_of_model (model : Llm_client.model_spec) : Oas.Provider.config =
@@ -1107,7 +1138,8 @@ let oas_extract_text (response : Oas.Types.api_response) =
 
 let make_worker_meta ~base_path ~workspace_path ~team_session_id ~worker_name
     ~mcp_session_id ~role ~selection_note ~execution_scope ~worker_class
-    ~worker_size ~effective_model =
+    ~worker_size ~effective_model ~thinking_enabled ~max_turns_override
+    ~timeout_seconds =
   let tool_profile, shell_profile = worker_profiles_of_scope execution_scope in
   let effective_tier = derive_effective_tier worker_size effective_model in
   {
@@ -1119,6 +1151,9 @@ let make_worker_meta ~base_path ~workspace_path ~team_session_id ~worker_name
     role;
     selection_note;
     execution_scope;
+    thinking_enabled;
+    max_turns_override;
+    timeout_seconds;
     tool_profile;
     shell_profile;
     worker_class;
@@ -1147,7 +1182,7 @@ let append_worker_completion_log ~base_path ~team_session_id ~worker_name
       ])
 
 let build_oas_agent ~worker_name ~model ~system_prompt ~tools ~max_turns
-    ~hooks =
+    ~thinking_enabled ~hooks ~raw_trace =
   let config =
     {
       Oas.Types.default_config with
@@ -1160,7 +1195,7 @@ let build_oas_agent ~worker_name ~model ~system_prompt ~tools ~max_turns
       top_p = Some 0.95;
       top_k = Some 20;
       min_p = Some 0.0;
-      enable_thinking = Some false;
+      enable_thinking = Some thinking_enabled;
       tool_choice = Some Oas.Types.Auto;
     }
   in
@@ -1175,13 +1210,16 @@ let build_oas_agent ~worker_name ~model ~system_prompt ~tools ~max_turns
             Oas.Guardrails.AllowList (oas_tool_names tools);
           max_tool_calls_per_turn = Some 12;
         };
+      raw_trace = Some raw_trace;
     }
   in
   (config, options)
 
 let run_worker_oas ~sw ~base_path ~worker_name
     ~(model : Llm_client.model_spec) ~team_session_id
-    ?working_dir ?worker_class ?worker_size ?execution_scope ~role
+    ~room_config ?working_dir ?worker_class ?worker_size ?execution_scope
+    ?thinking_enabled ?max_turns
+    ~role
     ~selection_note
     ~(prompt : string) ~(allowed_tools : string list) ~(timeout_sec : int) :
     unit -> (run_result, string) result =
@@ -1201,6 +1239,8 @@ let run_worker_oas ~sw ~base_path ~worker_name
       make_worker_meta ~base_path ~workspace_path ~team_session_id ~worker_name
         ~mcp_session_id ~role ~selection_note ~execution_scope ~worker_class
         ~worker_size ~effective_model:model.model_id
+        ~thinking_enabled ~max_turns_override:max_turns
+        ~timeout_seconds:(Some timeout_sec)
     in
     match worker_auth_token ~base_path ~worker_name with
     | Error e -> Error e
@@ -1256,9 +1296,19 @@ let run_worker_oas ~sw ~base_path ~worker_name
               ~worker_name ~prompt ~allowed_tools
           in
           let* shell_tools =
-            build_local_shell_tools ~execution_scope ~workdir:workspace_path
+            build_local_shell_tools ~room_config ~worker_name ~execution_scope
+              ~workdir:workspace_path
           in
           let tools = mcp_tools @ shell_tools in
+          let* raw_trace =
+            Oas.Raw_trace.create ~session_id:mcp_session_id
+              ~path:
+                (worker_raw_trace_path ~base_path
+                   ~team_session_id
+                   ~worker_name)
+              ()
+            |> Result.map_error Oas.Error.to_string
+          in
           let tool_names_ref = ref [] in
           let hooks =
             {
@@ -1277,15 +1327,23 @@ let run_worker_oas ~sw ~base_path ~worker_name
             | Team_session_types.Limited_code_change -> 20
             | Team_session_types.Observe_only -> 12
           in
-          let max_turns = max 2 (min max_turn_cap (max 2 (timeout_sec / 20))) in
+          let max_turns =
+            match max_turns with
+            | Some value -> max 1 (min max_turn_cap value)
+            | None -> max 2 (min max_turn_cap (max 2 (timeout_sec / 20)))
+          in
+          let thinking_enabled =
+            Option.value ~default:false thinking_enabled
+          in
           let config, options =
             build_oas_agent ~worker_name ~model ~system_prompt ~tools
-              ~max_turns ~hooks
+              ~max_turns ~thinking_enabled ~hooks ~raw_trace
           in
           let agent = Oas.Agent.create ~net ~config ~tools ~options () in
           let result =
             Oas.Agent.run ~sw agent prompt
           in
+          let raw_trace_run = Oas.Agent.last_raw_trace_run agent in
           let checkpoint =
             Oas.Agent.checkpoint ~session_id:mcp_session_id agent
           in
@@ -1322,6 +1380,7 @@ let run_worker_oas ~sw ~base_path ~worker_name
                   tool_call_count = List.length tool_names;
                   tool_names;
                   session_id = mcp_session_id;
+                  raw_trace_run;
                 }
           | Error err ->
               let detail = Agent_sdk__Error.to_string err in
@@ -1332,8 +1391,9 @@ let run_worker_oas ~sw ~base_path ~worker_name
               in
               Error detail)
 
-let continue_worker ~sw ~base_path ~worker_name ~(team_session_id : string)
-    ~(prompt : string) : (run_result, string) result =
+let continue_worker ~sw ~base_path ~room_config ~worker_name
+    ~(team_session_id : string) ~(prompt : string) :
+    (run_result, string) result =
   let team_session_id = Some team_session_id in
   let meta =
     load_worker_meta ~base_path ~team_session_id ~worker_name
@@ -1392,14 +1452,24 @@ let continue_worker ~sw ~base_path ~worker_name ~(team_session_id : string)
                 | Shell_none -> Ok []
                 | Shell_readonly ->
                     build_local_shell_tools
+                      ~room_config ~worker_name
                       ~execution_scope:Team_session_types.Observe_only
                       ~workdir:workspace_path
                 | Shell_dev ->
                     build_local_shell_tools
+                      ~room_config ~worker_name
                       ~execution_scope:Team_session_types.Limited_code_change
                       ~workdir:workspace_path
               in
               let* shell_tools = shell_tools in
+              let* raw_trace =
+                Oas.Raw_trace.create ~session_id:meta.mcp_session_id
+                  ~path:
+                    (worker_raw_trace_path ~base_path ~team_session_id
+                       ~worker_name)
+                  ()
+                |> Result.map_error Oas.Error.to_string
+              in
               let tools = mcp_tools @ shell_tools in
               let tool_names_ref = ref [] in
               let hooks =
@@ -1444,9 +1514,15 @@ let continue_worker ~sw ~base_path ~worker_name ~(team_session_id : string)
                 String.concat "\n\n" [ tool_contract; workflow_contract; prompt ]
               in
               let max_turns =
-                match meta.execution_scope with
-                | Team_session_types.Limited_code_change -> 20
-                | Team_session_types.Observe_only -> 8
+                match meta.max_turns_override with
+                | Some value -> max 1 value
+                | None ->
+                    (match meta.execution_scope with
+                    | Team_session_types.Limited_code_change -> 20
+                    | Team_session_types.Observe_only -> 8)
+              in
+              let thinking_enabled =
+                Option.value ~default:false meta.thinking_enabled
               in
               let config, options =
                 build_oas_agent ~worker_name ~model
@@ -1454,7 +1530,7 @@ let continue_worker ~sw ~base_path ~worker_name ~(team_session_id : string)
                     (default_system_prompt ~worker_name ~model_id:model.model_id
                        ?session_id:meta.team_session_id ?role:meta.role
                        ?selection_note:meta.selection_note ())
-                  ~tools ~max_turns ~hooks
+                  ~tools ~max_turns ~thinking_enabled ~hooks ~raw_trace
               in
               let agent =
                 Oas.Agent.resume ~net ~checkpoint ~tools ~options ~config ()
@@ -1462,6 +1538,7 @@ let continue_worker ~sw ~base_path ~worker_name ~(team_session_id : string)
               let result =
                 Oas.Agent.run ~sw agent prompt
               in
+              let raw_trace_run = Oas.Agent.last_raw_trace_run agent in
               let next_checkpoint =
                 Oas.Agent.checkpoint ~session_id:meta.mcp_session_id agent
               in
@@ -1501,6 +1578,7 @@ let continue_worker ~sw ~base_path ~worker_name ~(team_session_id : string)
                       tool_call_count = List.length tool_names;
                       tool_names;
                       session_id = meta.mcp_session_id;
+                      raw_trace_run;
                     }
               | Error err ->
                   let detail = Agent_sdk__Error.to_string err in
@@ -1612,6 +1690,7 @@ let run_worker_legacy ~sw ~base_path ~worker_name
                           tool_call_count = List.length tools_used;
                           tool_names = unique_preserve_order tools_used;
                           session_id = mcp_session_id;
+                          raw_trace_run = None;
                         }
                     else
                       let tool_outputs =
@@ -1688,6 +1767,7 @@ let run_worker_legacy ~sw ~base_path ~worker_name
                             tool_call_count = List.length tools_used;
                             tool_names = unique_preserve_order tools_used;
                             session_id = mcp_session_id;
+                            raw_trace_run = None;
                           }
                       else
                         loop ~round:(round + 1) ~usage_acc ~tools_used
@@ -1697,7 +1777,8 @@ let run_worker_legacy ~sw ~base_path ~worker_name
               loop ~round:1 ~usage_acc:zero_usage ~tools_used:[] prompt)
 
 let run_worker ~sw ~base_path ~worker_name ~model ~team_session_id
-    ?working_dir ?worker_class ?worker_size ?execution_scope ~role
+    ~room_config ?working_dir ?worker_class ?worker_size ?execution_scope
+    ?thinking_enabled ?max_turns ~role
     ~selection_note
     ~(prompt : string) ~(allowed_tools : string list) ~(timeout_sec : int) :
     unit -> (run_result, string) result =
@@ -1707,5 +1788,6 @@ let run_worker ~sw ~base_path ~worker_name ~model ~team_session_id
         ~role ~selection_note ~prompt ~allowed_tools ~timeout_sec
   | `Oas ->
       run_worker_oas ~sw ~base_path ~worker_name ~model ~team_session_id
-        ?working_dir ?worker_class ?worker_size ?execution_scope ~role
+        ~room_config ?working_dir ?worker_class ?worker_size ?execution_scope
+        ?thinking_enabled ?max_turns ~role
         ~selection_note ~prompt ~allowed_tools ~timeout_sec

--- a/lib/lodge_worker.ml
+++ b/lib/lodge_worker.ml
@@ -198,6 +198,7 @@ let run_local ~agent_name ~identity_prompt ~goal ~context ~allow_post
   Eio.Switch.run (fun sw ->
       match
         Local_agent_eio.run_worker ~sw ~base_path:(base_path ()) ~worker_name ~model
+          ~room_config:None
           ~team_session_id:None ~role:(Some "lodge-worker") ~selection_note:None
           ~prompt ~allowed_tools ~timeout_sec:90 ()
       with

--- a/lib/mcp_server_eio.ml
+++ b/lib/mcp_server_eio.ml
@@ -1222,6 +1222,9 @@ let execute_tool_eio ~sw ~clock ?mcp_session_id ?auth_token state ~name ~argumen
         risk_level = Some Team_session_types.Risk_medium;
         routing_confidence = Some 0.9;
         routing_reason = Some routing_reason;
+        thinking_enabled = None;
+        max_turns = None;
+        timeout_seconds = None;
         routing_escalated = false;
       }
     in

--- a/lib/mdal_worker.ml
+++ b/lib/mdal_worker.ml
@@ -167,6 +167,7 @@ let run ~(sw : Eio.Switch.t) ~(config : Room.config) (state : Mdal.loop_state)
   let worker_name = worker_name_for_state state in
   match
     Local_agent_eio.run_worker ~sw ~base_path:config.Room_utils.base_path
+      ~room_config:(Some config)
       ~worker_name ~model:model_spec ~team_session_id:None ~role:(Some "mdal")
       ~selection_note:(Some "strict-mdal-worker")
       ~prompt ~allowed_tools:state.profile.tools_allow

--- a/lib/mode.ml
+++ b/lib/mode.ml
@@ -146,7 +146,7 @@ let tool_category tool_name =
   | "masc_team_session_stop" | "masc_team_session_report"
   | "masc_team_session_list" | "masc_team_session_compare"
   | "masc_team_session_events"
-  | "masc_team_session_prove"
+  | "masc_team_session_prove" | "masc_team_session_verify_trace"
   | "masc_autoresearch_swarm_start"
   (* LLM runtime *)
   | "masc_llama_models" | "masc_llama_runtime_status"

--- a/lib/orchestrator.ml
+++ b/lib/orchestrator.ml
@@ -123,7 +123,7 @@ let spawn_orchestrator ~sw ~proc_mgr ?domain_mgr config room_config =
     { Spawn_eio.success = false; output = "Room paused"; exit_code = 0; elapsed_ms = 0;
       tool_call_count = 0; tool_names = [];
       input_tokens = None; output_tokens = None; cache_creation_tokens = None;
-      cache_read_tokens = None; cost_usd = None }
+      cache_read_tokens = None; cost_usd = None; raw_trace_run = None }
   end else begin
   Eio.traceln "🚀 Spawning orchestrator agent: %s (with MCP tools)\n%!" config.orchestrator_agent;
 

--- a/lib/server_runtime_bootstrap.ml
+++ b/lib/server_runtime_bootstrap.ml
@@ -19,6 +19,7 @@ let init_runtime_context env =
 
 let create_server_state ~sw ~base_path ~clock ~mono_clock ~net ~proc_mgr ~fs
     : Mcp_server.server_state =
+  Fs_compat.set_fs fs;
   Mcp_eio.set_net net;
   Mcp_eio.set_clock clock;
   Eio_context.set_switch sw;

--- a/lib/spawn_eio.ml
+++ b/lib/spawn_eio.ml
@@ -1,5 +1,7 @@
 (** MASC Spawn - Eio Native Agent subprocess management *)
 
+module Oas = Agent_sdk
+
 (** Mutex to serialize Sys.chdir + process fork.
     Sys.chdir is process-global; under Eio's fiber concurrency,
     concurrent spawn_agent calls would race on CWD without this. *)
@@ -27,6 +29,7 @@ type spawn_result = {
   cache_creation_tokens: int option;
   cache_read_tokens: int option;
   cost_usd: float option;
+  raw_trace_run: Oas.Raw_trace.run_ref option;
 }
 
 (** MASC MCP tools available for spawned agents *)
@@ -305,6 +308,7 @@ let spawn_glm_via_client ~prompt ~timeout ~start_time : spawn_result =
       cache_creation_tokens = None;
       cache_read_tokens = None;
       cost_usd = None;
+      raw_trace_run = None;
     }
   else
     match
@@ -328,6 +332,7 @@ let spawn_glm_via_client ~prompt ~timeout ~start_time : spawn_result =
             (let v = resp.Llm_client.usage.Llm_client.cache_read_input_tokens in
              if v > 0 then Some v else None);
           cost_usd = None;
+          raw_trace_run = None;
         }
     | Error e ->
         {
@@ -342,6 +347,7 @@ let spawn_glm_via_client ~prompt ~timeout ~start_time : spawn_result =
           cache_creation_tokens = None;
           cache_read_tokens = None;
           cost_usd = None;
+          raw_trace_run = None;
         }
 
 
@@ -355,7 +361,7 @@ let spawn_glm_via_client ~prompt ~timeout ~start_time : spawn_result =
 let spawn ~sw ~proc_mgr ~agent_name ~prompt ?timeout_seconds ?working_dir
     ?room_config ?runtime_agent_name ?runtime_model ?runtime_role
     ?runtime_session_id ?runtime_selection_note ?worker_class ?worker_size
-    ?execution_scope () : spawn_result =
+    ?execution_scope ?thinking_enabled ?max_turns () : spawn_result =
   let start_time = Time_compat.now () in
   let normalized_agent = String.lowercase_ascii (String.trim agent_name) in
   if Provider_adapter.is_bare_ollama_label normalized_agent then
@@ -371,6 +377,7 @@ let spawn ~sw ~proc_mgr ~agent_name ~prompt ?timeout_seconds ?working_dir
       cache_creation_tokens = None;
       cache_read_tokens = None;
       cost_usd = None;
+      raw_trace_run = None;
     }
   else
 
@@ -463,6 +470,7 @@ let spawn ~sw ~proc_mgr ~agent_name ~prompt ?timeout_seconds ?working_dir
            cache_creation_tokens = None;
            cache_read_tokens = None;
            cost_usd = None;
+           raw_trace_run = None;
          }
      | Some model when model.Llm_client.provider <> Llm_client.Llama ->
          {
@@ -478,13 +486,15 @@ let spawn ~sw ~proc_mgr ~agent_name ~prompt ?timeout_seconds ?working_dir
            cache_creation_tokens = None;
            cache_read_tokens = None;
            cost_usd = None;
+           raw_trace_run = None;
          }
      | Some model ->
          match
            Local_agent_eio.run_worker ~sw ~base_path ~worker_name ~model
+             ~room_config
              ~team_session_id:runtime_session_id ~role:runtime_role
              ?working_dir:worker_working_dir ?worker_class ?worker_size
-             ?execution_scope
+             ?execution_scope ?thinking_enabled ?max_turns
              ~selection_note:runtime_selection_note
              ~prompt:augmented_prompt
              ~allowed_tools:
@@ -507,6 +517,7 @@ let spawn ~sw ~proc_mgr ~agent_name ~prompt ?timeout_seconds ?working_dir
                cache_creation_tokens = None;
                cache_read_tokens = None;
                cost_usd = result.cost_usd;
+               raw_trace_run = result.raw_trace_run;
              }
          | Error e ->
              {
@@ -521,6 +532,7 @@ let spawn ~sw ~proc_mgr ~agent_name ~prompt ?timeout_seconds ?working_dir
                cache_creation_tokens = None;
                cache_read_tokens = None;
                cost_usd = None;
+               raw_trace_run = None;
              })
   else
     (* Build command arguments outside the chdir critical section *)
@@ -586,6 +598,7 @@ let spawn ~sw ~proc_mgr ~agent_name ~prompt ?timeout_seconds ?working_dir
           cache_creation_tokens = cache_creation;
           cache_read_tokens = cache_read;
           cost_usd;
+          raw_trace_run = None;
         }
       with e ->
         {
@@ -600,6 +613,7 @@ let spawn ~sw ~proc_mgr ~agent_name ~prompt ?timeout_seconds ?working_dir
           cache_creation_tokens = None;
           cache_read_tokens = None;
           cost_usd = None;
+          raw_trace_run = None;
         }
     in
     result

--- a/lib/team_session_engine_eio.ml
+++ b/lib/team_session_engine_eio.ml
@@ -609,6 +609,46 @@ let status_sections (config : Room.config) (session : Team_session_types.session
   (summary, team_health, communication_metrics, orchestration_state, cascade_metrics)
 
 let session_status_json (config : Room.config) (session : Team_session_types.session) =
+  let worker_run_summary =
+    let events = Team_session_store.read_events ~max_events:2000 config session.session_id in
+    let requested = ref [] in
+    let completed = Hashtbl.create 16 in
+    List.iter
+      (fun json ->
+        let open Yojson.Safe.Util in
+        match member "event_type" json, member "detail" json with
+        | `String ("team_step_spawn_requested" | "team_step_delegate_requested"), `Assoc _ -> (
+            match member "worker_run_id" (member "detail" json) with
+            | `String id -> requested := id :: !requested
+            | _ -> ())
+        | `String ("team_step_spawn" | "team_step_delegate"), `Assoc _ -> (
+            match member "worker_run_id" (member "detail" json),
+                  member "success" (member "detail" json) with
+            | `String id, `Bool success -> Hashtbl.replace completed id success
+            | _ -> ())
+        | _ -> ())
+      events;
+    let requested_ids = Team_session_types.dedup_strings !requested in
+    let completed_ids =
+      Hashtbl.fold (fun id success (done_count, failed_count, ids) ->
+          if success then (done_count + 1, failed_count, id :: ids)
+          else (done_count, failed_count + 1, id :: ids))
+        completed (0, 0, [])
+    in
+    let completed_success, completed_failed, completed_id_list = completed_ids in
+    let in_flight =
+      requested_ids
+      |> List.filter (fun id -> not (List.mem id completed_id_list))
+    in
+    `Assoc
+      [
+        ("requested_count", `Int (List.length requested_ids));
+        ("completed_success_count", `Int completed_success);
+        ("completed_failed_count", `Int completed_failed);
+        ("in_flight_count", `Int (List.length in_flight));
+        ("in_flight_run_ids", `List (List.map (fun id -> `String id) in_flight));
+      ]
+  in
   let runtime_running =
     with_runtimes_lock (fun () -> Hashtbl.mem runtimes session.session_id)
   in
@@ -643,6 +683,7 @@ let session_status_json (config : Room.config) (session : Team_session_types.ses
       ("cascade_metrics", cascade_metrics);
       ("local_runtime", local_runtime);
       ("llm_cache_metrics", llm_cache_metrics);
+      ("worker_runs", worker_run_summary);
       ( "command_plane",
         `Assoc
           [

--- a/lib/team_session_store.ml
+++ b/lib/team_session_store.ml
@@ -11,6 +11,36 @@ let session_dir config session_id =
 let checkpoints_dir config session_id =
   Filename.concat (session_dir config session_id) "checkpoints"
 
+let worker_runs_dir config session_id =
+  Filename.concat (session_dir config session_id) "worker-runs"
+
+let workers_dir config session_id =
+  Filename.concat (session_dir config session_id) "workers"
+
+let worker_container_dir config session_id worker_name =
+  Filename.concat (workers_dir config session_id) worker_name
+
+let worker_container_meta_path config session_id worker_name =
+  Filename.concat (worker_container_dir config session_id worker_name) "meta.json"
+
+let worker_container_checkpoint_path config session_id worker_name =
+  Filename.concat (worker_container_dir config session_id worker_name) "checkpoint.json"
+
+let worker_container_turn_log_path config session_id worker_name =
+  Filename.concat (worker_container_dir config session_id worker_name) "turns.jsonl"
+
+let worker_run_dir config session_id worker_run_id =
+  Filename.concat (worker_runs_dir config session_id) worker_run_id
+
+let worker_run_json_path config session_id worker_run_id =
+  Filename.concat (worker_run_dir config session_id worker_run_id) "run.json"
+
+let worker_run_checkpoint_path config session_id worker_run_id =
+  Filename.concat (worker_run_dir config session_id worker_run_id) "checkpoint.json"
+
+let worker_run_meta_path config session_id worker_run_id =
+  Filename.concat (worker_run_dir config session_id worker_run_id) "meta.json"
+
 let session_json_path config session_id =
   Filename.concat (session_dir config session_id) "session.json"
 
@@ -33,7 +63,8 @@ let now_iso () = Types.now_iso ()
 
 let ensure_session_dirs config session_id =
   mkdir_p (session_dir config session_id);
-  mkdir_p (checkpoints_dir config session_id)
+  mkdir_p (checkpoints_dir config session_id);
+  mkdir_p (worker_runs_dir config session_id)
 
 let read_text_file path =
   if Sys.file_exists path then
@@ -133,6 +164,27 @@ let write_checkpoint config session_id (checkpoint : Team_session_types.checkpoi
   let filename = Printf.sprintf "%Ld.json" (Int64.of_float (checkpoint.ts *. 1000.0)) in
   let path = Filename.concat (checkpoints_dir config session_id) filename in
   write_json config path (Team_session_types.checkpoint_to_yojson checkpoint)
+
+let save_worker_run_json config session_id worker_run_id json =
+  let path = worker_run_json_path config session_id worker_run_id in
+  write_json config path json
+
+let save_worker_run_checkpoint_text config session_id worker_run_id content =
+  let path = worker_run_checkpoint_path config session_id worker_run_id in
+  write_text_file path content
+
+let save_worker_run_meta_json config session_id worker_run_id json =
+  let path = worker_run_meta_path config session_id worker_run_id in
+  write_json config path json
+
+let list_worker_run_ids config session_id =
+  let dir = worker_runs_dir config session_id in
+  if not (path_exists config dir) then
+    []
+  else
+    Sys.readdir dir
+    |> Array.to_list
+    |> List.sort String.compare
 
 let list_checkpoint_paths config session_id =
   let dir = checkpoints_dir config session_id in

--- a/lib/team_session_types.ml
+++ b/lib/team_session_types.ml
@@ -14,6 +14,10 @@ type execution_scope =
   | Observe_only
   | Limited_code_change
 
+type wait_mode =
+  | Wait_background
+  | Wait_blocking
+
 type orchestration_mode =
   | Manual
   | Assist
@@ -116,6 +120,9 @@ type planned_worker = {
   spawn_role : string option;
   spawn_model : string option;
   execution_scope : execution_scope option;
+  thinking_enabled : bool option;
+  max_turns : int option;
+  timeout_seconds : int option;
   worker_class : worker_class option;
   parent_actor : string option;
   capsule_mode : capsule_mode option;
@@ -223,6 +230,14 @@ let execution_scope_to_string = function
 let execution_scope_of_string = function
   | "limited_code_change" -> Limited_code_change
   | _ -> Observe_only
+
+let wait_mode_to_string = function
+  | Wait_background -> "background"
+  | Wait_blocking -> "blocking"
+
+let wait_mode_of_string = function
+  | "blocking" -> Wait_blocking
+  | _ -> Wait_background
 
 let orchestration_mode_to_string = function
   | Manual -> "manual"
@@ -462,6 +477,15 @@ let planned_worker_key (w : planned_worker) =
           "scope:"
           ^ Option.value ~default:""
               (Option.map execution_scope_to_string w.execution_scope);
+          "thinking:"
+          ^ Option.value ~default:""
+              (Option.map string_of_bool w.thinking_enabled);
+          "max_turns:"
+          ^ Option.value ~default:""
+              (Option.map string_of_int w.max_turns);
+          "timeout:"
+          ^ Option.value ~default:""
+              (Option.map string_of_int w.timeout_seconds);
           "class:"
           ^ Option.value ~default:""
               (Option.map worker_class_to_string w.worker_class);
@@ -710,6 +734,9 @@ let planned_worker_to_yojson (w : planned_worker) =
         Option.fold ~none:`Null
           ~some:(fun scope -> `String (execution_scope_to_string scope))
           w.execution_scope );
+      ("thinking_enabled", Option.fold ~none:`Null ~some:(fun v -> `Bool v) w.thinking_enabled);
+      ("max_turns", Option.fold ~none:`Null ~some:(fun n -> `Int n) w.max_turns);
+      ("timeout_seconds", Option.fold ~none:`Null ~some:(fun n -> `Int n) w.timeout_seconds);
       ( "worker_class",
         Option.fold ~none:`Null
           ~some:(fun kind -> `String (worker_class_to_string kind))
@@ -774,6 +801,12 @@ let planned_worker_of_yojson (json : Yojson.Safe.t) =
               Option.map
                 execution_scope_of_string
                 (member "execution_scope" json |> to_string_option);
+            thinking_enabled =
+              member "thinking_enabled" json |> to_bool_option;
+            max_turns =
+              member "max_turns" json |> to_int_option;
+            timeout_seconds =
+              member "timeout_seconds" json |> to_int_option;
             worker_class =
               Option.bind
                 (member "worker_class" json |> to_string_option)

--- a/lib/tool_team_session.ml
+++ b/lib/tool_team_session.ml
@@ -2,6 +2,7 @@
 
 open Types
 open Tool_args
+module Oas = Agent_sdk
 
 type 'a context = {
   config : Room.config;
@@ -125,6 +126,13 @@ let parse_proof_level args =
   in
   Team_session_types.proof_level_of_string raw
 
+let parse_wait_mode args =
+  let raw =
+    get_string args "wait_mode" "background"
+    |> String.trim |> String.lowercase_ascii
+  in
+  Team_session_types.wait_mode_of_string raw
+
 let is_all_digits s =
   let len = String.length s in
   len > 0 && String.for_all (function '0' .. '9' -> true | _ -> false) s
@@ -145,6 +153,13 @@ let is_valid_session_id session_id =
   match String.split_on_char '-' session_id with
   | [ "ts"; epoch_ms; suffix ] -> is_all_digits epoch_ms && is_all_hex suffix
   | _ -> false
+
+let make_worker_run_id () =
+  let ms = Int64.of_float (Time_compat.now () *. 1000.0) in
+  let high = Int64.of_int (Random.bits ()) in
+  let low = Int64.of_int (Random.bits ()) in
+  let rnd = Int64.logor (Int64.shift_left high 30) low in
+  Printf.sprintf "wr-%Ld-%015Lx" ms rnd
 
 let get_valid_session_id_key args key =
   match get_string_opt args key with
@@ -179,6 +194,240 @@ let ensure_session_access ctx session_id =
         Ok ()
       else
         Error "not authorized for this team session"
+
+let latest_worker_run_id config session_id =
+  Team_session_store.list_worker_run_ids config session_id
+  |> List.rev |> List.find_opt (fun _ -> true)
+
+let load_worker_run_meta config session_id worker_run_id =
+  let path =
+    Team_session_store.worker_run_meta_path config session_id worker_run_id
+  in
+  if not (Room_utils.path_exists config path) then
+    Error (Printf.sprintf "worker run not found: %s" worker_run_id)
+  else
+    Ok (Room_utils.read_json config path)
+
+let load_worker_run_checkpoint config session_id worker_run_id =
+  let path =
+    Team_session_store.worker_run_checkpoint_path config session_id worker_run_id
+  in
+  if not (Room_utils.path_exists config path) then
+    Error (Printf.sprintf "worker run checkpoint not found: %s" worker_run_id)
+  else
+    let raw = Team_session_store.read_text_file path in
+    match Oas.Checkpoint.of_string raw with
+    | Ok checkpoint -> Ok checkpoint
+    | Error err -> Error (Oas.Error.to_string err)
+
+let raw_trace_run_ref_of_json json =
+  let open Yojson.Safe.Util in
+  match member "trace_ref" json with
+  | `Assoc _ as trace_json -> (
+      try
+        Some
+          {
+            Oas.Raw_trace.worker_run_id =
+              trace_json |> member "worker_run_id" |> to_string;
+            path = trace_json |> member "path" |> to_string;
+            start_seq = trace_json |> member "start_seq" |> to_int;
+            end_seq = trace_json |> member "end_seq" |> to_int;
+            agent_name = trace_json |> member "agent_name" |> to_string;
+            session_id = trace_json |> member "session_id" |> to_string_option;
+          }
+      with _ -> None)
+  | _ -> None
+
+let raw_trace_run_ref_to_json (run_ref : Oas.Raw_trace.run_ref) =
+  `Assoc
+    [
+      ("worker_run_id", `String run_ref.worker_run_id);
+      ("path", `String run_ref.path);
+      ("start_seq", `Int run_ref.start_seq);
+      ("end_seq", `Int run_ref.end_seq);
+      ("agent_name", `String run_ref.agent_name);
+      ( "session_id",
+        Option.fold ~none:`Null ~some:(fun s -> `String s)
+          run_ref.session_id );
+    ]
+
+let verify_trace_from_trace_json trace =
+  let uses =
+    trace
+    |> List.filter (fun json ->
+           Yojson.Safe.Util.member "kind" json = `String "tool_use")
+  in
+  let results =
+    trace
+    |> List.filter (fun json ->
+           Yojson.Safe.Util.member "kind" json = `String "tool_result")
+  in
+  let pair_count =
+    List.fold_left
+      (fun acc use_json ->
+        match Yojson.Safe.Util.member "tool_use_id" use_json with
+        | `String id ->
+            if
+              List.exists
+                (fun result_json ->
+                  Yojson.Safe.Util.member "tool_use_id" result_json
+                  = `String id)
+                results
+            then acc + 1
+            else acc
+        | _ -> acc)
+      0 uses
+  in
+  let tool_names =
+    uses
+    |> List.filter_map (fun json ->
+           match Yojson.Safe.Util.member "tool_name" json with
+           | `String name -> Some name
+           | _ -> None)
+    |> Team_session_types.dedup_strings
+  in
+  let rec find_file_write idx = function
+    | [] -> None
+    | json :: rest -> (
+        match
+          Yojson.Safe.Util.member "kind" json,
+          Yojson.Safe.Util.member "tool_name" json
+        with
+        | `String "tool_use", `String "file_write" -> Some idx
+        | _ -> find_file_write (idx + 1) rest)
+  in
+  let file_write_index = find_file_write 0 trace in
+  let verification_pass =
+    match file_write_index with
+    | None -> not (List.mem "file_write" tool_names)
+    | Some idx ->
+        trace
+        |> List.mapi (fun i json -> (i, json))
+        |> List.exists (fun (i, json) ->
+               i > idx
+               &&
+               match
+                 Yojson.Safe.Util.member "kind" json,
+                 Yojson.Safe.Util.member "is_error" json,
+                 Yojson.Safe.Util.member "content" json
+               with
+               | `String "tool_result", `Bool false, `String content ->
+                   let trimmed = String.trim content in
+                   trimmed = "PASS"
+                   || String.starts_with ~prefix:"PASS" trimmed
+               | _ -> false)
+  in
+  `Assoc
+    [
+      ("tool_trace", `List trace);
+      ("tool_names", `List (List.map (fun name -> `String name) tool_names));
+      ("tool_use_count", `Int (List.length uses));
+      ("tool_result_count", `Int (List.length results));
+      ("paired_tool_result_count", `Int pair_count);
+      ("has_file_write", `Bool (List.mem "file_write" tool_names));
+      ("has_shell_exec", `Bool (List.mem "shell_exec" tool_names));
+      ("verification_pass_after_file_write", `Bool verification_pass);
+      ("ok", `Bool (pair_count = List.length uses && verification_pass));
+    ]
+
+let tool_trace_of_checkpoint (checkpoint : Oas.Checkpoint.t) =
+  let rec loop acc = function
+    | [] -> List.rev acc
+    | (msg : Oas.Types.message) :: rest ->
+        let blocks =
+          msg.Oas.Types.content
+          |> List.filter_map (function
+                 | Oas.Types.ToolUse (id, name, input) ->
+                     Some
+                       (`Assoc
+                         [
+                           ("kind", `String "tool_use");
+                           ("tool_use_id", `String id);
+                           ("tool_name", `String name);
+                           ("input", input);
+                         ])
+                 | Oas.Types.ToolResult (id, content, is_error) ->
+                     Some
+                       (`Assoc
+                         [
+                           ("kind", `String "tool_result");
+                           ("tool_use_id", `String id);
+                           ("content", `String content);
+                           ("is_error", `Bool is_error);
+                         ])
+                 | Oas.Types.Text text ->
+                     Some (`Assoc [ ("kind", `String "text"); ("content", `String text) ])
+                 | _ -> None)
+        in
+        loop (List.rev_append blocks acc) rest
+  in
+  loop [] checkpoint.messages
+
+let tool_trace_of_raw_records (records : Oas.Raw_trace.record list) =
+  records
+  |> List.filter_map (fun record ->
+         match record.Oas.Raw_trace.record_type with
+         | Oas.Raw_trace.Tool_execution_started ->
+             Some
+               (`Assoc
+                 [
+                   ("kind", `String "tool_use");
+                   ( "tool_use_id",
+                     Option.fold ~none:`Null ~some:(fun s -> `String s)
+                       record.tool_use_id );
+                   ( "tool_name",
+                     Option.fold ~none:`Null ~some:(fun s -> `String s)
+                       record.tool_name );
+                   ( "input",
+                     Option.fold ~none:`Null ~some:(fun json -> json)
+                       record.tool_input );
+                 ])
+         | Oas.Raw_trace.Tool_execution_finished ->
+             Some
+               (`Assoc
+                 [
+                   ("kind", `String "tool_result");
+                   ( "tool_use_id",
+                     Option.fold ~none:`Null ~some:(fun s -> `String s)
+                       record.tool_use_id );
+                   ( "tool_name",
+                     Option.fold ~none:`Null ~some:(fun s -> `String s)
+                       record.tool_name );
+                   ( "content",
+                     Option.fold ~none:`Null ~some:(fun s -> `String s)
+                       record.tool_result );
+                   ( "is_error",
+                     Option.fold ~none:`Null ~some:(fun v -> `Bool v)
+                       record.tool_error );
+                 ])
+         | Oas.Raw_trace.Assistant_block ->
+             Option.map
+               (fun block ->
+                 `Assoc
+                   [
+                     ("kind", `String "assistant_block");
+                     ("block", block);
+                   ])
+               record.assistant_block
+         | Oas.Raw_trace.Run_finished ->
+             Some
+               (`Assoc
+                 [
+                   ("kind", `String "run_finished");
+                   ( "final_text",
+                     Option.fold ~none:`Null ~some:(fun s -> `String s)
+                       record.final_text );
+                   ( "error",
+                     Option.fold ~none:`Null ~some:(fun s -> `String s)
+                       record.error );
+                 ])
+         | Oas.Raw_trace.Run_started -> None)
+
+let verify_trace_from_checkpoint (checkpoint : Oas.Checkpoint.t) =
+  verify_trace_from_trace_json (tool_trace_of_checkpoint checkpoint)
+
+let verify_trace_from_raw_records (records : Oas.Raw_trace.record list) =
+  verify_trace_from_trace_json (tool_trace_of_raw_records records)
 
 let record_session_turn_json ~(config : Room.config) ~session_id ~actor
     ~turn_kind ~message ~target_agent ~task_title ~task_description
@@ -410,6 +659,8 @@ type spawn_spec = {
   spawn_model_explicit : bool;
   spawn_role : string option;
   execution_scope : Team_session_types.execution_scope option;
+  thinking_enabled : bool option;
+  max_turns : int option;
   worker_class : Team_session_types.worker_class option;
   worker_size : Team_session_types.worker_size option;
   parent_actor : string option;
@@ -429,6 +680,7 @@ type spawn_spec = {
 }
 
 type prepared_spawn = {
+  worker_run_id : string;
   spec : spawn_spec;
   runtime_actor_name : string option;
   runtime_model : Llm_client.model_spec;
@@ -1107,7 +1359,8 @@ let annotate_control_hierarchy_for_session
         })
       specs
 
-let parse_spawn_spec_from_object ?(default_timeout = 300) batch_index json =
+let parse_spawn_spec_from_object ?(default_timeout = 300)
+    ?top_level_worker_policy batch_index json =
   match find_present_json_key legacy_spawn_fields json with
   | Some field -> Error (legacy_spawn_field_error ~batch_index field)
   | None ->
@@ -1192,6 +1445,40 @@ let parse_spawn_spec_from_object ?(default_timeout = 300) batch_index json =
     | `Intlit s -> (try max 1 (int_of_string s) with Failure _ -> default_timeout)
     | _ -> default_timeout
   in
+  let worker_policy =
+    match member "worker_policy" json with
+    | `Assoc _ as obj -> Some obj
+    | _ -> None
+  in
+  let policy_json key =
+    let lookup = function
+      | Some obj -> (
+          match member key obj with
+          | `Null -> None
+          | value -> Some value)
+      | None -> None
+    in
+    match lookup worker_policy with
+    | Some value -> Some value
+    | None -> lookup top_level_worker_policy
+  in
+  let policy_bool key =
+    match policy_json key with
+    | Some value -> (
+        match value with
+        | `Bool value -> Some value
+        | _ -> None)
+    | None -> None
+  in
+  let policy_int key =
+    match policy_json key with
+    | Some value -> (
+        match value with
+        | `Int value -> Some (max 1 value)
+        | `Intlit raw -> (try Some (max 1 (int_of_string raw)) with Failure _ -> None)
+        | _ -> None)
+    | None -> None
+  in
   match get_required_string "spawn_prompt" with
   | Ok spawn_prompt ->
       Ok
@@ -1207,6 +1494,8 @@ let parse_spawn_spec_from_object ?(default_timeout = 300) batch_index json =
             | None ->
                 default_execution_scope_for_worker_class
                   (get_optional_worker_class "worker_class"));
+          thinking_enabled = policy_bool "thinking";
+          max_turns = policy_int "max_turns";
           worker_class = get_optional_worker_class "worker_class";
           worker_size = get_optional_worker_size "worker_size";
           parent_actor = get_optional_string "parent_actor";
@@ -1222,7 +1511,9 @@ let parse_spawn_spec_from_object ?(default_timeout = 300) batch_index json =
           routing_confidence = get_optional_float "routing_confidence";
           routing_reason = get_optional_string "routing_reason";
           spawn_selection_note = get_optional_string "spawn_selection_note";
-          spawn_timeout_seconds = get_timeout "spawn_timeout_seconds";
+          spawn_timeout_seconds =
+            Option.value ~default:(get_timeout "spawn_timeout_seconds")
+              (policy_int "timeout_seconds");
         }
   | Error e -> Error e
 
@@ -1239,6 +1530,11 @@ let parse_step_spawn_specs args =
     | _ -> max 1 (get_int args "spawn_timeout_seconds" 300)
   in
   let batch_specs_result =
+    let top_level_worker_policy =
+      match Yojson.Safe.Util.member "worker_policy" args with
+      | `Assoc _ as obj -> Some obj
+      | _ -> None
+    in
     match Yojson.Safe.Util.member "spawn_batch" args with
     | `Null -> Ok []
     | `List xs ->
@@ -1247,6 +1543,7 @@ let parse_step_spawn_specs args =
           | json :: rest -> (
               match
                 parse_spawn_spec_from_object ~default_timeout:default_batch_timeout
+                  ?top_level_worker_policy
                   idx json
               with
               | Ok spec -> loop (idx + 1) (spec :: acc) rest
@@ -1267,6 +1564,28 @@ let parse_step_spawn_specs args =
         match singular_prompt with
         | None -> Ok []
         | Some spawn_prompt ->
+            let worker_policy =
+              match Yojson.Safe.Util.member "worker_policy" args with
+              | `Assoc _ as obj -> Some obj
+              | _ -> None
+            in
+            let policy_bool key =
+              match worker_policy with
+              | Some obj -> (
+                  match Yojson.Safe.Util.member key obj with
+                  | `Bool value -> Some value
+                  | _ -> None)
+              | None -> None
+            in
+            let policy_int key =
+              match worker_policy with
+              | Some obj -> (
+                  match Yojson.Safe.Util.member key obj with
+                  | `Int value -> Some (max 1 value)
+                  | `Intlit raw -> (try Some (max 1 (int_of_string raw)) with Failure _ -> None)
+                  | _ -> None)
+              | None -> None
+            in
             route_specs
               [
                 {
@@ -1283,6 +1602,8 @@ let parse_step_spawn_specs args =
                      with
                     | Some _ as explicit -> explicit
                     | None -> Some Team_session_types.Limited_code_change);
+                  thinking_enabled = policy_bool "thinking";
+                  max_turns = policy_int "max_turns";
                   worker_class =
                     Option.bind
                       (get_string_opt args "worker_class")
@@ -1328,7 +1649,9 @@ let parse_step_spawn_specs args =
                   routing_confidence = get_float_opt args "routing_confidence";
                   routing_reason = get_string_opt args "routing_reason";
                   spawn_selection_note = get_string_opt args "spawn_selection_note";
-                  spawn_timeout_seconds = get_int args "spawn_timeout_seconds" 300;
+                  spawn_timeout_seconds =
+                    Option.value ~default:(get_int args "spawn_timeout_seconds" 300)
+                      (policy_int "timeout_seconds");
                 };
               ]
 
@@ -1340,6 +1663,9 @@ let planned_worker_of_spec ?runtime_actor (spec : spawn_spec) :
     spawn_role = spec.spawn_role;
     spawn_model = spec.spawn_model;
     execution_scope = effective_execution_scope_of_spec spec;
+    thinking_enabled = spec.thinking_enabled;
+    max_turns = spec.max_turns;
+    timeout_seconds = Some spec.spawn_timeout_seconds;
     worker_class = spec.worker_class;
     parent_actor = spec.parent_actor;
     capsule_mode = spec.capsule_mode;
@@ -1565,15 +1891,16 @@ let handle_step ctx args : result =
               match actor_result with
               | Error e -> (false, json_error e)
               | Ok actor ->
+              let wait_mode = parse_wait_mode args in
               let base_message = get_string_opt args "message" in
               let target_agent = get_string_opt args "target_agent" in
               let delegate_prompt = delegate_prompt_opt in
               let task_title = get_string_opt args "task_title" in
               let task_description = get_string_opt args "task_description" in
               let task_priority = get_int args "task_priority" 3 in
-              let append_spawn_event ?spawn_agent ?runtime_actor ?spawn_role
+              let append_spawn_event ?worker_run_id ?spawn_agent ?runtime_actor ?spawn_role
                   ?spawn_model ?execution_scope ?worker_class ?worker_size
-                  ?worker_backend
+                  ?worker_backend ?wait_mode ?trace_capability
                   ?parent_actor ?capsule_mode
                   ?runtime_pool ?lane_id ?controller_level ?control_domain
                   ?supervisor_actor ?model_tier ?task_profile ?risk_level
@@ -1586,6 +1913,7 @@ let handle_step ctx args : result =
                   `Assoc
                     [
                       ("actor", `String actor);
+                      ("worker_run_id", Option.fold ~none:`Null ~some:(fun s -> `String s) worker_run_id);
                       ( "runtime_actor",
                         Option.fold ~none:`Null ~some:(fun s -> `String s)
                           runtime_actor );
@@ -1614,6 +1942,12 @@ let handle_step ctx args : result =
                       ( "worker_backend",
                         Option.fold ~none:`Null ~some:(fun s -> `String s)
                           worker_backend );
+                      ( "wait_mode",
+                        Option.fold ~none:`Null ~some:(fun mode -> `String mode)
+                          wait_mode );
+                      ( "trace_capability",
+                        Option.fold ~none:`Null ~some:(fun s -> `String s)
+                          trace_capability );
                       ( "parent_actor",
                         Option.fold ~none:`Null ~some:(fun s -> `String s)
                           parent_actor );
@@ -1690,7 +2024,8 @@ let handle_step ctx args : result =
                 Team_session_store.append_event ctx.config session_id
                   ~event_type:"team_step_spawn" ~detail
               in
-              let append_delegate_event ~worker_name ~delegate_prompt ~success
+              let append_delegate_event ~worker_run_id ~worker_name ~delegate_prompt ~success
+                  ?execution_scope ?wait_mode ?trace_capability
                   ?tool_names ?tool_call_count ?output_preview ?error () =
                 Team_session_store.append_event ctx.config session_id
                   ~event_type:"team_step_delegate"
@@ -1698,9 +2033,13 @@ let handle_step ctx args : result =
                     (`Assoc
                       [
                         ("actor", `String actor);
+                        ("worker_run_id", `String worker_run_id);
                         ("target_agent", `String worker_name);
                         ("delegate_prompt", `String delegate_prompt);
-                        ("worker_backend", `String "oas-local");
+                        ("worker_backend", `String "local");
+                        ("execution_scope", Option.fold ~none:`Null ~some:(fun scope -> `String (Team_session_types.execution_scope_to_string scope)) execution_scope);
+                        ("wait_mode", Option.fold ~none:`Null ~some:(fun mode -> `String mode) wait_mode);
+                        ("trace_capability", Option.fold ~none:`Null ~some:(fun s -> `String s) trace_capability);
                         ("success", `Bool success);
                         ( "tool_names",
                           Option.fold ~none:(`List [])
@@ -1718,6 +2057,79 @@ let handle_step ctx args : result =
                             error );
                         ("ts_iso", `String (Types.now_iso ()));
                       ])
+              in
+              let append_spawn_requested_event ~worker_run_id prepared =
+                Team_session_store.append_event ctx.config session_id
+                  ~event_type:"team_step_spawn_requested"
+                  ~detail:
+                    (`Assoc
+                      [
+                        ("actor", `String actor);
+                        ("worker_run_id", `String worker_run_id);
+                        ( "runtime_actor",
+                          Option.fold ~none:`Null
+                            ~some:(fun s -> `String s)
+                            prepared.runtime_actor_name );
+                        ("spawn_role", Option.fold ~none:`Null ~some:(fun s -> `String s) prepared.spec.spawn_role);
+                        ("worker_backend", if is_local_spawn_agent prepared.spec.spawn_agent then `String "local" else `Null);
+                        ("wait_mode", `String (Team_session_types.wait_mode_to_string wait_mode));
+                        ("ts_iso", `String (Types.now_iso ()));
+                      ])
+              in
+              let append_delegate_requested_event ~worker_run_id ~worker_name ~delegate_prompt =
+                Team_session_store.append_event ctx.config session_id
+                  ~event_type:"team_step_delegate_requested"
+                  ~detail:
+                    (`Assoc
+                      [
+                        ("actor", `String actor);
+                        ("worker_run_id", `String worker_run_id);
+                        ("target_agent", `String worker_name);
+                        ("delegate_prompt", `String delegate_prompt);
+                        ("worker_backend", `String "local");
+                        ("wait_mode", `String (Team_session_types.wait_mode_to_string wait_mode));
+                        ("ts_iso", `String (Types.now_iso ()));
+                      ])
+              in
+              let persist_worker_run_snapshot ~worker_run_id ~worker_name
+                  ~mode ~wait_mode ?execution_scope ?tool_names ?tool_call_count
+                  ~success ?output_preview ?error ?trace_capability ?trace_ref
+                  () =
+                let checkpoint_path =
+                  Team_session_store.worker_container_checkpoint_path ctx.config
+                    session_id worker_name
+                in
+                let trace_capability =
+                  match trace_capability with
+                  | Some value -> value
+                  | None when Option.is_some trace_ref -> "raw"
+                  | None ->
+                      if Room_utils.path_exists ctx.config checkpoint_path then
+                        "checkpoint_snapshot"
+                      else "summary_only"
+                in
+                if Room_utils.path_exists ctx.config checkpoint_path then
+                  Team_session_store.save_worker_run_checkpoint_text ctx.config
+                    session_id worker_run_id
+                    (Team_session_store.read_text_file checkpoint_path);
+                Team_session_store.save_worker_run_meta_json ctx.config session_id
+                  worker_run_id
+                  (`Assoc
+                    [
+                      ("worker_run_id", `String worker_run_id);
+                      ("worker_name", `String worker_name);
+                      ("mode", `String mode);
+                      ("wait_mode", `String (Team_session_types.wait_mode_to_string wait_mode));
+                      ("trace_capability", `String trace_capability);
+                      ("success", `Bool success);
+                      ("execution_scope", Option.fold ~none:`Null ~some:(fun scope -> `String (Team_session_types.execution_scope_to_string scope)) execution_scope);
+                      ("tool_names", Option.fold ~none:(`List []) ~some:(fun names -> `List (List.map (fun name -> `String name) names)) tool_names);
+                      ("tool_call_count", Option.fold ~none:`Null ~some:(fun n -> `Int n) tool_call_count);
+                      ("output_preview", Option.fold ~none:`Null ~some:(fun s -> `String s) output_preview);
+                      ("error", Option.fold ~none:`Null ~some:(fun s -> `String s) error);
+                      ("trace_ref", Option.fold ~none:`Null ~some:raw_trace_run_ref_to_json trace_ref);
+                      ("ts_iso", `String (Types.now_iso ()));
+                    ])
               in
               let release_prepared_runtime (prepared : prepared_spawn) ~success
                   ?error ?latency_ms () =
@@ -1775,6 +2187,7 @@ let handle_step ctx args : result =
                 | Ok (runtime_model, runtime_lease, assigned_runtime) ->
                     Ok
                       {
+                        worker_run_id = make_worker_run_id ();
                         spec;
                         runtime_actor_name;
                         runtime_model;
@@ -1800,7 +2213,7 @@ let handle_step ctx args : result =
                             ?worker_size:(worker_size_of_spec failed_spec)
                             ?worker_backend:
                               (if is_local_spawn_agent failed_spec.spawn_agent
-                               then Some "oas-local" else None)
+                               then Some "local" else None)
                             ?parent_actor:failed_spec.parent_actor
                             ?capsule_mode:failed_spec.capsule_mode
                             ?runtime_pool:failed_spec.runtime_pool
@@ -1857,7 +2270,7 @@ let handle_step ctx args : result =
                               ?worker_size:(worker_size_of_spec prepared.spec)
                               ?worker_backend:
                                 (if is_local_spawn_agent prepared.spec.spawn_agent
-                                 then Some "oas-local" else None)
+                                 then Some "local" else None)
                               ?parent_actor:prepared.spec.parent_actor
                               ?capsule_mode:prepared.spec.capsule_mode
                               ?runtime_pool:prepared.spec.runtime_pool
@@ -1887,6 +2300,7 @@ let handle_step ctx args : result =
                                 release_prepared_runtime prepared ~success:false
                                   ~error:msg ();
                                 append_spawn_event
+                                  ~worker_run_id:prepared.worker_run_id
                                   ~spawn_agent:prepared.spec.spawn_agent
                                   ?runtime_actor:prepared.runtime_actor_name
                                   ?spawn_role:prepared.spec.spawn_role
@@ -1897,7 +2311,7 @@ let handle_step ctx args : result =
                                   ?worker_size:(worker_size_of_spec prepared.spec)
                                   ?worker_backend:
                                     (if is_local_spawn_agent prepared.spec.spawn_agent
-                                     then Some "oas-local" else None)
+                                     then Some "local" else None)
                                   ?parent_actor:prepared.spec.parent_actor
                                   ?capsule_mode:prepared.spec.capsule_mode
                                   ?runtime_pool:prepared.spec.runtime_pool
@@ -1938,6 +2352,7 @@ let handle_step ctx args : result =
                                      release_prepared_runtime prepared
                                        ~success:false ~error:msg ();
                                        append_spawn_event
+                                         ~worker_run_id:prepared.worker_run_id
                                          ~spawn_agent:prepared.spec.spawn_agent
                                          ?runtime_actor:prepared.runtime_actor_name
                                          ?spawn_role:prepared.spec.spawn_role
@@ -1948,7 +2363,7 @@ let handle_step ctx args : result =
                                          ?worker_size:(worker_size_of_spec prepared.spec)
                                          ?worker_backend:
                                            (if is_local_spawn_agent prepared.spec.spawn_agent
-                                            then Some "oas-local" else None)
+                                            then Some "local" else None)
                                          ?parent_actor:prepared.spec.parent_actor
                                        ?capsule_mode:prepared.spec.capsule_mode
                                        ?runtime_pool:prepared.spec.runtime_pool
@@ -1970,264 +2385,209 @@ let handle_step ctx args : result =
                                    prepared_spawns;
                                  Some (`Assoc [ ("error", `String msg) ])
                              | Ok () ->
-                                 let results =
-                                   Array.make (List.length prepared_spawns) None
+                                 let execute_spawn index prepared =
+                                   let spawn_result =
+                                     Spawn_eio.spawn ~sw:ctx.sw ~proc_mgr:pm
+                                       ~agent_name:prepared.spec.spawn_agent
+                                       ~prompt:prepared.spec.spawn_prompt
+                                       ~timeout_seconds:
+                                         prepared.spec.spawn_timeout_seconds
+                                       ~room_config:ctx.config
+                                       ?runtime_agent_name:
+                                         prepared.runtime_actor_name
+                                       ~runtime_model:prepared.runtime_model
+                                       ?runtime_role:prepared.spec.spawn_role
+                                       ?runtime_selection_note:
+                                         prepared.spec.spawn_selection_note
+                                       ?worker_class:prepared.spec.worker_class
+                                       ?worker_size:(worker_size_of_spec prepared.spec)
+                                       ?execution_scope:
+                                         (effective_execution_scope_of_spec prepared.spec)
+                                       ?thinking_enabled:prepared.spec.thinking_enabled
+                                       ?max_turns:prepared.spec.max_turns
+                                       ~runtime_session_id:session_id ()
+                                   in
+                                   let output_preview =
+                                     truncate_for_event spawn_result.output
+                                   in
+                                   (match spawn_result.success with
+                                   | true ->
+                                       release_prepared_runtime prepared
+                                         ~success:true
+                                         ~latency_ms:spawn_result.elapsed_ms ()
+                                   | false ->
+                                       release_prepared_runtime prepared
+                                         ~success:false
+                                         ~error:spawn_result.output
+                                         ~latency_ms:spawn_result.elapsed_ms ());
+                                   persist_worker_run_snapshot
+                                     ~worker_run_id:prepared.worker_run_id
+                                     ~worker_name:
+                                       (Option.value
+                                          ~default:(Printf.sprintf "spawn-%d" index)
+                                          prepared.runtime_actor_name)
+                                     ~mode:"spawn" ~wait_mode
+                                     ?execution_scope:
+                                       (effective_execution_scope_of_spec prepared.spec)
+                                     ~tool_names:spawn_result.tool_names
+                                     ~tool_call_count:spawn_result.tool_call_count
+                                     ~success:spawn_result.success
+                                     ~output_preview
+                                     ?trace_ref:spawn_result.raw_trace_run
+                                     ~trace_capability:
+                                       (if Option.is_some spawn_result.raw_trace_run then
+                                          "raw"
+                                        else if is_local_spawn_agent prepared.spec.spawn_agent
+                                        then "checkpoint_snapshot"
+                                        else "summary_only")
+                                     ();
+                                   append_spawn_event
+                                     ~worker_run_id:prepared.worker_run_id
+                                     ~spawn_agent:prepared.spec.spawn_agent
+                                     ?runtime_actor:prepared.runtime_actor_name
+                                     ?spawn_role:prepared.spec.spawn_role
+                                     ?spawn_model:prepared.spec.spawn_model
+                                     ?execution_scope:
+                                       (effective_execution_scope_of_spec prepared.spec)
+                                     ?worker_class:prepared.spec.worker_class
+                                     ?worker_size:(worker_size_of_spec prepared.spec)
+                                     ?worker_backend:
+                                       (if is_local_spawn_agent prepared.spec.spawn_agent
+                                        then Some "local" else None)
+                                     ~wait_mode:(Team_session_types.wait_mode_to_string wait_mode)
+                                     ~trace_capability:
+                                       (if is_local_spawn_agent prepared.spec.spawn_agent
+                                        then "checkpoint_snapshot"
+                                        else "summary_only")
+                                     ?parent_actor:prepared.spec.parent_actor
+                                     ?capsule_mode:prepared.spec.capsule_mode
+                                     ?runtime_pool:prepared.spec.runtime_pool
+                                     ?lane_id:prepared.spec.lane_id
+                                     ?controller_level:(inferred_controller_level_of_spec prepared.spec)
+                                     ?control_domain:prepared.spec.control_domain
+                                     ?supervisor_actor:prepared.spec.supervisor_actor
+                                     ?model_tier:prepared.spec.model_tier
+                                     ?task_profile:prepared.spec.task_profile
+                                     ?risk_level:prepared.spec.risk_level
+                                     ?routing_confidence:prepared.spec.routing_confidence
+                                     ?routing_reason:prepared.spec.routing_reason
+                                     ?assigned_runtime:prepared.assigned_runtime
+                                     ?spawn_selection_note:
+                                       prepared.spec.spawn_selection_note
+                                     ~tool_names:spawn_result.tool_names
+                                     ~tool_call_count:spawn_result.tool_call_count
+                                     ~success:spawn_result.success
+                                     ~exit_code:spawn_result.exit_code
+                                     ~elapsed_ms:spawn_result.elapsed_ms
+                                     ~output_preview ();
+                                   (match
+                                      ( spawn_result.success,
+                                        prepared.runtime_actor_name,
+                                        auto_note_message_of_spawn_output
+                                          spawn_result.output )
+                                    with
+                                   | true, Some worker_actor, Some auto_note
+                                     when not
+                                            (session_has_turn_for_actor
+                                               ctx.config session_id worker_actor) ->
+                                       ignore
+                                         (record_session_turn_json
+                                            ~config:ctx.config ~session_id
+                                            ~actor:worker_actor
+                                            ~turn_kind:Team_session_types.Turn_note
+                                            ~message:(Some auto_note)
+                                            ~target_agent:None
+                                            ~task_title:None
+                                            ~task_description:None
+                                            ~task_priority:3)
+                                   | _ -> ());
+                                   (match (spawn_result.success, prepared.runtime_actor_name) with
+                                   | false, Some worker_actor ->
+                                       ignore
+                                         (reconcile_failed_spawn_actor
+                                            ctx.config session_id worker_actor)
+                                   | _ -> ());
+                                   `Assoc
+                                     [
+                                       ("worker_run_id", `String prepared.worker_run_id);
+                                       ("runtime_actor", Option.fold ~none:`Null ~some:(fun s -> `String s) prepared.runtime_actor_name);
+                                       ("spawn_role", Option.fold ~none:`Null ~some:(fun s -> `String s) prepared.spec.spawn_role);
+                                       ("execution_scope", Option.fold ~none:`Null ~some:(fun scope -> `String (Team_session_types.execution_scope_to_string scope)) (effective_execution_scope_of_spec prepared.spec));
+                                       ("thinking_enabled", Option.fold ~none:`Null ~some:(fun v -> `Bool v) prepared.spec.thinking_enabled);
+                                       ("max_turns", Option.fold ~none:`Null ~some:(fun n -> `Int n) prepared.spec.max_turns);
+                                       ("worker_class", Option.fold ~none:`Null ~some:(fun kind -> `String (Team_session_types.worker_class_to_string kind)) prepared.spec.worker_class);
+                                       ("worker_size", Option.fold ~none:`Null ~some:(fun size -> `String (Team_session_types.worker_size_to_string size)) (worker_size_of_spec prepared.spec));
+                                       ("worker_backend", if is_local_spawn_agent prepared.spec.spawn_agent then `String "local" else `Null);
+                                       ("wait_mode", `String (Team_session_types.wait_mode_to_string wait_mode));
+                                       ("trace_capability", `String (if Option.is_some spawn_result.raw_trace_run then "raw" else if is_local_spawn_agent prepared.spec.spawn_agent then "checkpoint_snapshot" else "summary_only"));
+                                       ("tool_call_count", `Int spawn_result.tool_call_count);
+                                       ("tool_names", `List (List.map (fun name -> `String name) spawn_result.tool_names));
+                                       ("success", `Bool spawn_result.success);
+                                       ("elapsed_ms", `Int spawn_result.elapsed_ms);
+                                       ("output_preview", `String output_preview);
+                                     ]
                                  in
-                                 Eio.Fiber.all
-                                   (List.mapi
-                                      (fun index prepared () ->
-                                        let spawn_result =
-                                          Spawn_eio.spawn ~sw:ctx.sw ~proc_mgr:pm
-                                            ~agent_name:prepared.spec.spawn_agent
-                                            ~prompt:prepared.spec.spawn_prompt
-                                            ~timeout_seconds:
-                                              prepared.spec.spawn_timeout_seconds
-                                            ~room_config:ctx.config
-                                            ?runtime_agent_name:
-                                              prepared.runtime_actor_name
-                                            ~runtime_model:prepared.runtime_model
-                                            ?runtime_role:prepared.spec.spawn_role
-                                            ?runtime_selection_note:
-                                              prepared.spec.spawn_selection_note
-                                            ?worker_class:prepared.spec.worker_class
-                                            ?worker_size:(worker_size_of_spec prepared.spec)
-                                            ?execution_scope:
-                                              (effective_execution_scope_of_spec
-                                                 prepared.spec)
-                                            ~runtime_session_id:session_id ()
-                                        in
-                                        let output_preview =
-                                          truncate_for_event spawn_result.output
-                                        in
-                                        (match spawn_result.success with
-                                        | true ->
-                                            release_prepared_runtime prepared
-                                              ~success:true
-                                              ~latency_ms:spawn_result.elapsed_ms ()
-                                        | false ->
-                                            release_prepared_runtime prepared
-                                              ~success:false
-                                              ~error:spawn_result.output
-                                              ~latency_ms:spawn_result.elapsed_ms ());
-                                        append_spawn_event
-                                          ~spawn_agent:prepared.spec.spawn_agent
-                                          ?runtime_actor:prepared.runtime_actor_name
-                                          ?spawn_role:prepared.spec.spawn_role
-                                          ?spawn_model:prepared.spec.spawn_model
-                                          ?execution_scope:
-                                            (effective_execution_scope_of_spec prepared.spec)
-                                          ?worker_class:prepared.spec.worker_class
-                                          ?worker_size:(worker_size_of_spec prepared.spec)
-                                          ?worker_backend:
-                                            (if is_local_spawn_agent prepared.spec.spawn_agent
-                                             then Some "oas-local" else None)
-                                          ?parent_actor:prepared.spec.parent_actor
-                                          ?capsule_mode:prepared.spec.capsule_mode
-                                          ?runtime_pool:prepared.spec.runtime_pool
-                                          ?lane_id:prepared.spec.lane_id
-                                          ?controller_level:(inferred_controller_level_of_spec prepared.spec)
-                                          ?control_domain:prepared.spec.control_domain
-                                          ?supervisor_actor:prepared.spec.supervisor_actor
-                                          ?model_tier:prepared.spec.model_tier
-                                          ?task_profile:prepared.spec.task_profile
-                                          ?risk_level:prepared.spec.risk_level
-                                          ?routing_confidence:prepared.spec.routing_confidence
-                                          ?routing_reason:prepared.spec.routing_reason
-                                          ?assigned_runtime:prepared.assigned_runtime
-                                          ?spawn_selection_note:
-                                            prepared.spec.spawn_selection_note
-                                          ~tool_names:spawn_result.tool_names
-                                          ~tool_call_count:
-                                            spawn_result.tool_call_count
-                                          ~success:spawn_result.success
-                                          ~exit_code:spawn_result.exit_code
-                                          ~elapsed_ms:spawn_result.elapsed_ms
-                                          ~output_preview ();
-                                        (match
-                                           ( spawn_result.success,
-                                             prepared.runtime_actor_name,
-                                             auto_note_message_of_spawn_output
-                                               spawn_result.output )
-                                         with
-                                        | true, Some worker_actor, Some auto_note
-                                          when not
-                                                 (session_has_turn_for_actor
-                                                    ctx.config session_id
-                                                    worker_actor) ->
-                                            ignore
-                                              (record_session_turn_json
-                                                 ~config:ctx.config ~session_id
-                                                 ~actor:worker_actor
-                                                 ~turn_kind:
-                                                   Team_session_types.Turn_note
-                                                 ~message:(Some auto_note)
-                                                 ~target_agent:None
-                                                 ~task_title:None
-                                                 ~task_description:None
-                                                 ~task_priority:3)
-                                        | _ -> ());
-                                        (match
-                                           (spawn_result.success, prepared.runtime_actor_name)
-                                         with
-                                        | false, Some worker_actor ->
-                                            ignore
-                                              (reconcile_failed_spawn_actor
-                                                 ctx.config session_id
-                                                 worker_actor)
-                                        | _ -> ());
-                                        results.(index) <-
-                                          Some
-                                            (`Assoc
-                                              [
-                                                ( "runtime_actor",
-                                                  Option.fold ~none:`Null
-                                                    ~some:(fun s -> `String s)
-                                                    prepared.runtime_actor_name );
-                                                ( "spawn_role",
-                                                  Option.fold ~none:`Null
-                                                    ~some:(fun s -> `String s)
-                                                    prepared.spec.spawn_role );
-                                                ( "execution_scope",
-                                                  Option.fold ~none:`Null
-                                                    ~some:(fun scope ->
-                                                      `String
-                                                        (Team_session_types.execution_scope_to_string
-                                                           scope))
-                                                    (effective_execution_scope_of_spec
-                                                       prepared.spec) );
-                                                ( "worker_class",
-                                                  Option.fold ~none:`Null
-                                                    ~some:(fun kind ->
-                                                      `String
-                                                        (Team_session_types.worker_class_to_string
-                                                           kind))
-                                                    prepared.spec.worker_class );
-                                                ( "worker_size",
-                                                  Option.fold ~none:`Null
-                                                    ~some:(fun size ->
-                                                      `String
-                                                        (Team_session_types.worker_size_to_string
-                                                           size))
-                                                    (worker_size_of_spec prepared.spec) );
-                                                ( "worker_backend",
-                                                  if is_local_spawn_agent prepared.spec.spawn_agent
-                                                  then `String "oas-local"
-                                                  else `Null );
-                                                ( "parent_actor",
-                                                  Option.fold ~none:`Null
-                                                    ~some:(fun s -> `String s)
-                                                    prepared.spec.parent_actor );
-                                                ( "capsule_mode",
-                                                  Option.fold ~none:`Null
-                                                    ~some:(fun mode ->
-                                                      `String
-                                                        (Team_session_types.capsule_mode_to_string
-                                                           mode))
-                                                    prepared.spec.capsule_mode );
-                                                ( "runtime_pool",
-                                                  Option.fold ~none:`Null
-                                                    ~some:(fun s -> `String s)
-                                                    prepared.spec.runtime_pool );
-                                                ( "lane_id",
-                                                  Option.fold ~none:`Null
-                                                    ~some:(fun s -> `String s)
-                                                    prepared.spec.lane_id );
-                                                ( "controller_level",
-                                                  Option.fold ~none:`Null
-                                                    ~some:(fun level ->
-                                                      `String
-                                                        (Team_session_types.controller_level_to_string
-                                                           level))
-                                                    (inferred_controller_level_of_spec
-                                                       prepared.spec) );
-                                                ( "control_domain",
-                                                  Option.fold ~none:`Null
-                                                    ~some:(fun domain ->
-                                                      `String
-                                                        (Team_session_types.control_domain_to_string
-                                                           domain))
-                                                    prepared.spec.control_domain );
-                                                ( "supervisor_actor",
-                                                  Option.fold ~none:`Null
-                                                    ~some:(fun s -> `String s)
-                                                    prepared.spec.supervisor_actor );
-                                                ( "task_profile",
-                                                  Option.fold ~none:`Null
-                                                    ~some:(fun profile ->
-                                                      `String
-                                                        (Team_session_types.task_profile_to_string
-                                                           profile))
-                                                    prepared.spec.task_profile );
-                                                ( "risk_level",
-                                                  Option.fold ~none:`Null
-                                                    ~some:(fun level ->
-                                                      `String
-                                                        (Team_session_types.risk_level_to_string
-                                                           level))
-                                                    prepared.spec.risk_level );
-                                                ( "routing_confidence",
-                                                  float_opt_to_json
-                                                    prepared.spec.routing_confidence
-                                                );
-                                                ( "routing_reason",
-                                                  Option.fold ~none:`Null
-                                                    ~some:(fun s -> `String s)
-                                                    prepared.spec.routing_reason );
-                                                ( "assigned_runtime",
-                                                  Option.fold ~none:`Null
-                                                    ~some:(fun s -> `String s)
-                                                    prepared.assigned_runtime );
-                                                ( "spawn_selection_note",
-                                                  Option.fold ~none:`Null
-                                                    ~some:(fun s -> `String s)
-                                                    prepared.spec.spawn_selection_note );
-                                                ( "tool_call_count",
-                                                  `Int
-                                                    spawn_result.tool_call_count
-                                                );
-                                                ( "tool_names",
-                                                  `List
-                                                    (List.map
-                                                       (fun name -> `String name)
-                                                       spawn_result.tool_names)
-                                                );
-                                                ("success", `Bool spawn_result.success);
-                                                ("exit_code", `Int spawn_result.exit_code);
-                                                ("elapsed_ms", `Int spawn_result.elapsed_ms);
-                                                ("output_preview", `String output_preview);
-                                                ( "input_tokens",
-                                                  int_opt_to_json
-                                                    spawn_result.input_tokens );
-                                                ( "output_tokens",
-                                                  int_opt_to_json
-                                                    spawn_result.output_tokens );
-                                                ( "cache_creation_tokens",
-                                                  int_opt_to_json
-                                                    spawn_result.cache_creation_tokens
-                                                );
-                                                ( "cache_read_tokens",
-                                                  int_opt_to_json
-                                                    spawn_result.cache_read_tokens );
-                                                ( "cost_usd",
-                                                  float_opt_to_json
-                                                    spawn_result.cost_usd );
-                                              ]))
-                                      prepared_spawns);
-                                 let spawn_results =
-                                   results
-                                   |> Array.to_list
-                                   |> List.filter_map (fun item -> item)
-                                 in
-                                 Some
-                                   (if List.length spawn_results = 1 then
-                                      List.hd spawn_results
-                                    else
-                                      `Assoc
-                                        [
-                                          ("mode", `String "batch");
-                                          ("count", `Int (List.length spawn_results));
-                                          ("results", `List spawn_results);
-                                        ])
+                                 (match wait_mode with
+                                 | Team_session_types.Wait_background ->
+                                     let sw_bg =
+                                       Option.value ~default:ctx.sw
+                                         (Eio_context.get_switch_opt ())
+                                     in
+                                     List.iter
+                                       (fun prepared ->
+                                         append_spawn_requested_event
+                                           ~worker_run_id:prepared.worker_run_id
+                                           prepared;
+                                         Eio.Fiber.fork ~sw:sw_bg (fun () ->
+                                             ignore (execute_spawn 0 prepared)))
+                                       prepared_spawns;
+                                     let accepted =
+                                       prepared_spawns
+                                       |> List.map (fun prepared ->
+                                              `Assoc
+                                                [
+                                                  ("worker_run_id", `String prepared.worker_run_id);
+                                                  ("status", `String "accepted");
+                                                  ("wait_mode", `String "background");
+                                                  ("runtime_actor", Option.fold ~none:`Null ~some:(fun s -> `String s) prepared.runtime_actor_name);
+                                                  ("spawn_role", Option.fold ~none:`Null ~some:(fun s -> `String s) prepared.spec.spawn_role);
+                                                  ("worker_class", Option.fold ~none:`Null ~some:(fun kind -> `String (Team_session_types.worker_class_to_string kind)) prepared.spec.worker_class);
+                                                  ("worker_size", Option.fold ~none:`Null ~some:(fun size -> `String (Team_session_types.worker_size_to_string size)) (worker_size_of_spec prepared.spec));
+                                                ])
+                                     in
+                                     Some
+                                       (if List.length accepted = 1 then
+                                          List.hd accepted
+                                        else
+                                          `Assoc
+                                            [
+                                              ("mode", `String "batch");
+                                              ("count", `Int (List.length accepted));
+                                              ("results", `List accepted);
+                                            ])
+                                 | Team_session_types.Wait_blocking ->
+                                     let results =
+                                       Array.make (List.length prepared_spawns) None
+                                     in
+                                     Eio.Fiber.all
+                                       (List.mapi
+                                          (fun index prepared () ->
+                                            results.(index) <- Some (execute_spawn index prepared))
+                                          prepared_spawns);
+                                     let spawn_results =
+                                       results |> Array.to_list
+                                       |> List.filter_map (fun item -> item)
+                                     in
+                                     Some
+                                       (if List.length spawn_results = 1 then
+                                          List.hd spawn_results
+                                        else
+                                          `Assoc
+                                            [
+                                              ("mode", `String "batch");
+                                              ("count", `Int (List.length spawn_results));
+                                              ("results", `List spawn_results);
+                                            ]))
               in
               let spawn_error =
                 match spawn_result_json with
@@ -2295,57 +2655,120 @@ let handle_step ctx args : result =
                                           );
                                         ])
                                 | Some worker_name -> (
-                                    match
-                                      Local_agent_eio.continue_worker ~sw:ctx.sw
-                                        ~base_path:ctx.config.base_path
-                                        ~worker_name ~team_session_id:session_id
-                                        ~prompt:delegate_prompt
-                                    with
-                                    | Ok run_result ->
-                                        let output_preview =
-                                          truncate_for_event run_result.output
-                                        in
-                                        append_delegate_event ~worker_name
-                                          ~delegate_prompt
-                                          ~success:true
-                                          ~tool_names:run_result.tool_names
-                                          ~tool_call_count:
-                                            run_result.tool_call_count
-                                          ~output_preview ();
-                                        Some
-                                          (`Assoc
+                                    let worker_run_id = make_worker_run_id () in
+                                    let execution_scope =
+                                      Option.bind session_opt (fun session ->
+                                          List.find_map
+                                            (fun w ->
+                                              match
+                                                w.Team_session_types.runtime_actor
+                                              with
+                                              | Some actor
+                                                when String.equal actor
+                                                       worker_name ->
+                                                  w.execution_scope
+                                              | _ -> None)
+                                            session.planned_workers)
+                                    in
+                                    let run_delegate () =
+                                      match
+                                        Local_agent_eio.continue_worker ~sw:ctx.sw
+                                          ~base_path:ctx.config.base_path
+                                          ~room_config:(Some ctx.config)
+                                          ~worker_name ~team_session_id:session_id
+                                          ~prompt:delegate_prompt
+                                      with
+                                      | Ok run_result ->
+                                          let output_preview =
+                                            truncate_for_event run_result.output
+                                          in
+                                          persist_worker_run_snapshot
+                                            ~worker_run_id ~worker_name
+                                            ~mode:"delegate"
+                                            ~wait_mode ?execution_scope
+                                            ~tool_names:run_result.tool_names
+                                            ~tool_call_count:
+                                              run_result.tool_call_count
+                                            ~success:true ~output_preview
+                                            ?trace_ref:run_result.raw_trace_run
+                                            ~trace_capability:
+                                              (if Option.is_some run_result.raw_trace_run
+                                               then "raw"
+                                               else "checkpoint_snapshot") ();
+                                          append_delegate_event ~worker_run_id
+                                            ~worker_name ~delegate_prompt
+                                            ?execution_scope
+                                            ~wait_mode:(Team_session_types.wait_mode_to_string wait_mode)
+                                            ~trace_capability:
+                                              (if Option.is_some run_result.raw_trace_run
+                                               then "raw"
+                                               else "checkpoint_snapshot")
+                                            ~success:true
+                                            ~tool_names:run_result.tool_names
+                                            ~tool_call_count:
+                                              run_result.tool_call_count
+                                            ~output_preview ();
+                                          `Assoc
                                             [
+                                              ("worker_run_id", `String worker_run_id);
                                               ("worker_name", `String worker_name);
-                                              ("worker_backend", `String "oas-local");
+                                              ("worker_backend", `String "local");
+                                              ("wait_mode", `String (Team_session_types.wait_mode_to_string wait_mode));
+                                              ("trace_capability", `String (if Option.is_some run_result.raw_trace_run then "raw" else "checkpoint_snapshot"));
                                               ( "output",
                                                 `String run_result.output );
                                               ( "output_preview",
                                                 `String output_preview );
                                               ( "tool_call_count",
-                                                `Int
-                                                  run_result.tool_call_count );
+                                                `Int run_result.tool_call_count );
                                               ( "tool_names",
                                                 `List
                                                   (List.map
                                                      (fun name -> `String name)
                                                      run_result.tool_names) );
                                               ( "input_tokens",
-                                                int_opt_to_json
-                                                  run_result.input_tokens );
+                                                int_opt_to_json run_result.input_tokens );
                                               ( "output_tokens",
-                                                int_opt_to_json
-                                                  run_result.output_tokens );
+                                                int_opt_to_json run_result.output_tokens );
                                               ( "cost_usd",
-                                                float_opt_to_json
-                                                  run_result.cost_usd );
-                                            ])
-                                    | Error err ->
-                                        append_delegate_event ~worker_name
-                                          ~delegate_prompt
-                                          ~success:false ~error:err ();
+                                                float_opt_to_json run_result.cost_usd );
+                                            ]
+                                      | Error err ->
+                                          persist_worker_run_snapshot
+                                            ~worker_run_id ~worker_name
+                                            ~mode:"delegate" ~wait_mode
+                                            ~success:false ~error:err
+                                            ~trace_capability:"checkpoint_snapshot" ();
+                                          append_delegate_event ~worker_run_id
+                                            ~worker_name ~delegate_prompt
+                                            ?execution_scope
+                                            ~wait_mode:(Team_session_types.wait_mode_to_string wait_mode)
+                                            ~trace_capability:"checkpoint_snapshot"
+                                            ~success:false ~error:err ();
+                                          `Assoc [ ("error", `String err) ]
+                                    in
+                                    (match wait_mode with
+                                    | Team_session_types.Wait_blocking ->
+                                        Some (run_delegate ())
+                                    | Team_session_types.Wait_background ->
+                                        let sw_bg =
+                                          Option.value ~default:ctx.sw
+                                            (Eio_context.get_switch_opt ())
+                                        in
+                                        append_delegate_requested_event
+                                          ~worker_run_id ~worker_name
+                                          ~delegate_prompt;
+                                        Eio.Fiber.fork ~sw:sw_bg (fun () ->
+                                            ignore (run_delegate ()));
                                         Some
                                           (`Assoc
-                                            [ ("error", `String err) ]))))
+                                            [
+                                              ("worker_run_id", `String worker_run_id);
+                                              ("worker_name", `String worker_name);
+                                              ("worker_backend", `String "local");
+                                              ("status", `String "accepted");
+                                              ("wait_mode", `String "background");
+                                            ])))))
                       in
                       let delegate_error =
                         match delegate_result_json with
@@ -2637,6 +3060,91 @@ let handle_prove ctx args : result =
           | Ok json -> (true, json_ok [ ("result", json) ])
           | Error e -> (false, json_error e)))
 
+let handle_verify_trace ctx args : result =
+  match get_valid_session_id args with
+  | Error e -> (false, json_error e)
+  | Ok session_id -> (
+      match ensure_session_access ctx session_id with
+      | Error e -> (false, json_error e)
+      | Ok () ->
+          let worker_run_id =
+            match get_string_opt args "worker_run_id" with
+            | Some id when String.trim id <> "" -> Some (String.trim id)
+            | _ -> latest_worker_run_id ctx.config session_id
+          in
+          match worker_run_id with
+          | None -> (false, json_error "no worker run found for session")
+          | Some worker_run_id -> (
+              match load_worker_run_meta ctx.config session_id worker_run_id with
+              | Error e -> (false, json_error e)
+              | Ok meta_json -> (
+                  match raw_trace_run_ref_of_json meta_json with
+                  | Some run_ref -> (
+                      match Oas.Raw_trace.read_run run_ref with
+                      | Ok records ->
+                          let verification =
+                            verify_trace_from_raw_records records
+                          in
+                          ( true,
+                            json_ok
+                              [
+                                ( "result",
+                                  `Assoc
+                                    [
+                                      ("worker_run_id", `String worker_run_id);
+                                      ("trace_capability", `String "raw");
+                                      ("meta", meta_json);
+                                      ( "trace_ref",
+                                        raw_trace_run_ref_to_json run_ref );
+                                      ("verification", verification);
+                                    ] );
+                              ] )
+                      | Error err ->
+                          let detail = Oas.Error.to_string err in
+                          ( true,
+                            json_ok
+                              [
+                                ( "result",
+                                  `Assoc
+                                    [
+                                      ("worker_run_id", `String worker_run_id);
+                                      ("trace_capability", `String "summary_only");
+                                      ("ok", `Bool false);
+                                      ("error", `String detail);
+                                      ("meta", meta_json);
+                                    ] );
+                              ] ))
+                  | None -> (
+                      match load_worker_run_checkpoint ctx.config session_id worker_run_id with
+                      | Error e ->
+                          ( true,
+                            json_ok
+                              [
+                                ( "result",
+                                  `Assoc
+                                    [
+                                      ("worker_run_id", `String worker_run_id);
+                                      ("trace_capability", `String "summary_only");
+                                      ("ok", `Bool false);
+                                      ("error", `String e);
+                                      ("meta", meta_json);
+                                    ] );
+                              ] )
+                      | Ok checkpoint ->
+                          let verification = verify_trace_from_checkpoint checkpoint in
+                          ( true,
+                            json_ok
+                              [
+                                ( "result",
+                                  `Assoc
+                                    [
+                                      ("worker_run_id", `String worker_run_id);
+                                      ("trace_capability", `String "checkpoint_snapshot");
+                                      ("meta", meta_json);
+                                      ("verification", verification);
+                                    ] );
+                              ] )))))
+
 let dispatch ctx ~name ~args : result option =
   match name with
   | "masc_team_session_start" -> Some (handle_start ctx args)
@@ -2650,6 +3158,7 @@ let dispatch ctx ~name ~args : result option =
   | "masc_team_session_turn" -> Some (handle_turn ctx args)
   | "masc_team_session_events" -> Some (handle_events ctx args)
   | "masc_team_session_prove" -> Some (handle_prove ctx args)
+  | "masc_team_session_verify_trace" -> Some (handle_verify_trace ctx args)
   | _ -> None
 
 let schemas : tool_schema list =
@@ -2981,6 +3490,24 @@ let schemas : tool_schema list =
 	                  ("spawn_selection_note", `Assoc [ ("type", `String "string") ]);
 	                  ("spawn_prompt", `Assoc [ ("type", `String "string") ]);
 	                  ("spawn_timeout_seconds", `Assoc [ ("type", `String "integer") ]);
+                  ( "wait_mode",
+                    `Assoc
+                      [
+                        ("type", `String "string");
+                        ("enum", `List [ `String "background"; `String "blocking" ]);
+                      ] );
+                  ( "worker_policy",
+                    `Assoc
+                      [
+                        ("type", `String "object");
+                        ( "properties",
+                          `Assoc
+                            [
+                              ("thinking", `Assoc [ ("type", `String "boolean") ]);
+                              ("timeout_seconds", `Assoc [ ("type", `String "integer") ]);
+                              ("max_turns", `Assoc [ ("type", `String "integer") ]);
+                            ] );
+                      ] );
                   ( "spawn_batch",
                     `Assoc
                       [
@@ -3088,6 +3615,18 @@ let schemas : tool_schema list =
 	                                    ("spawn_prompt", `Assoc [ ("type", `String "string") ]);
                                     ( "spawn_timeout_seconds",
                                       `Assoc [ ("type", `String "integer") ] );
+                                    ( "worker_policy",
+                                      `Assoc
+                                        [
+                                          ("type", `String "object");
+                                          ( "properties",
+                                            `Assoc
+                                              [
+                                                ("thinking", `Assoc [ ("type", `String "boolean") ]);
+                                                ("timeout_seconds", `Assoc [ ("type", `String "integer") ]);
+                                                ("max_turns", `Assoc [ ("type", `String "integer") ]);
+                                              ] );
+                                        ] );
                                   ] );
                               ( "required",
                                 `List
@@ -3254,6 +3793,23 @@ let schemas : tool_schema list =
                         ("type", `String "string");
                         ("enum", `List [ `String "standard"; `String "strong" ]);
                       ] );
+                ] );
+            ("required", `List [ `String "session_id" ]);
+          ];
+    };
+    {
+      name = "masc_team_session_verify_trace";
+      description =
+        "Verify worker-run trace evidence for a team session using stored worker run snapshots.";
+      input_schema =
+        `Assoc
+          [
+            ("type", `String "object");
+            ( "properties",
+              `Assoc
+                [
+                  ("session_id", `Assoc [ ("type", `String "string") ]);
+                  ("worker_run_id", `Assoc [ ("type", `String "string") ]);
                 ] );
             ("required", `List [ `String "session_id" ]);
           ];

--- a/scripts/harness/workload/coding_worker_quickwin.sh
+++ b/scripts/harness/workload/coding_worker_quickwin.sh
@@ -10,6 +10,7 @@ HTTP_TIMEOUT_SEC="${HTTP_TIMEOUT_SEC:-120}"
 STOP_WAIT_SEC="${STOP_WAIT_SEC:-60}"
 LLAMA_SWARM_MODEL="${LLAMA_SWARM_MODEL:-qwen3.5-35b-a3b-ud-q8-xl}"
 SMOKE_AGENT="${SMOKE_AGENT:-coding-smoke-supervisor}"
+TEAM_STEP_WAIT_MODE="${TEAM_STEP_WAIT_MODE:-blocking}"
 
 PORT=""
 MCP_URL=""
@@ -180,6 +181,42 @@ wait_until_terminal() {
   done
 }
 
+wait_for_worker_run_event() {
+  local client_session_id="$1"
+  local team_session_id="$2"
+  local worker_run_id="$3"
+  local expected_event="$4"
+  local deadline=$(( $(date +%s) + STOP_WAIT_SEC ))
+  while :; do
+    local raw events_json match
+    raw="$(call_tool "$client_session_id" 91 "masc_team_session_events" "$(jq -cn --arg s "$team_session_id" --arg ev "$expected_event" '{session_id:$s,event_types:[$ev],limit:200}')")"
+    require_tool_success "$raw"
+    events_json="$(printf '%s' "$raw" | extract_tool_result)"
+    match="$(printf '%s' "$events_json" | jq -c --arg id "$worker_run_id" '.events[]? | select(.detail.worker_run_id? == $id) | .detail' | tail -n1)"
+    if [ -n "$match" ]; then
+      printf '%s' "$match"
+      return 0
+    fi
+    if [ "$(date +%s)" -ge "$deadline" ]; then
+      echo "FAIL: worker run ${worker_run_id} did not emit ${expected_event} in time"
+      printf '%s\n' "$events_json"
+      exit 1
+    fi
+    sleep 1
+  done
+}
+
+verify_worker_run_trace() {
+  local client_session_id="$1"
+  local team_session_id="$2"
+  local worker_run_id="$3"
+  local raw result
+  raw="$(call_tool "$client_session_id" 92 "masc_team_session_verify_trace" "$(jq -cn --arg s "$team_session_id" --arg r "$worker_run_id" '{session_id:$s,worker_run_id:$r}')")"
+  require_tool_success "$raw"
+  result="$(printf '%s' "$raw" | extract_tool_result)"
+  printf '%s' "$result"
+}
+
 fixture_repo_setup() {
   local fixture_dir
   fixture_dir="$(mktemp -d "${TMPDIR:-/tmp}/coding-worker-fixture.XXXXXX")"
@@ -254,24 +291,50 @@ EOF
   raw="$(call_tool "fixture-client" 10 "masc_team_session_step" "$(jq -cn \
     --arg s "$team_session_id" \
     --arg prompt "$inspect_prompt" \
-    '{session_id:$s,spawn_role:"coder",worker_class:"executor",worker_size:"lg",execution_scope:"limited_code_change",spawn_prompt:$prompt}')")"
+    --arg wait_mode "$TEAM_STEP_WAIT_MODE" \
+    '{session_id:$s,spawn_role:"coder",worker_class:"executor",worker_size:"lg",execution_scope:"limited_code_change",wait_mode:$wait_mode,spawn_prompt:$prompt}')")"
   require_tool_success "$raw"
   result="$(printf '%s' "$raw" | extract_tool_result)"
   spawn="$(printf '%s' "$result" | jq -c '.spawn')"
-  printf '%s' "$spawn" | jq -e '.success == true' >/dev/null
-  printf '%s' "$spawn" | jq -e '.tool_call_count > 0' >/dev/null
-  printf '%s' "$spawn" | jq -e '(.tool_names | index("file_read")) != null and (.tool_names | index("shell_exec")) != null' >/dev/null
+  if [ "$TEAM_STEP_WAIT_MODE" = "background" ]; then
+    local fixture_spawn_run_id fixture_spawn_detail fixture_spawn_verify
+    printf '%s' "$spawn" | jq -e '.status == "accepted"' >/dev/null
+    fixture_spawn_run_id="$(printf '%s' "$spawn" | jq -r '.worker_run_id')"
+    fixture_spawn_detail="$(wait_for_worker_run_event "fixture-client" "$team_session_id" "$fixture_spawn_run_id" "team_step_spawn")"
+    printf '%s' "$fixture_spawn_detail" | jq -e '.success == true' >/dev/null
+    printf '%s' "$fixture_spawn_detail" | jq -e '.tool_call_count > 0' >/dev/null
+    printf '%s' "$fixture_spawn_detail" | jq -e '(.tool_names | index("file_read")) != null and (.tool_names | index("shell_exec")) != null' >/dev/null
+    fixture_spawn_verify="$(verify_worker_run_trace "fixture-client" "$team_session_id" "$fixture_spawn_run_id")"
+    printf '%s' "$fixture_spawn_verify" | jq -e '.verification.ok == true' >/dev/null
+  else
+    printf '%s' "$spawn" | jq -e '.success == true' >/dev/null
+    printf '%s' "$spawn" | jq -e '.tool_call_count > 0' >/dev/null
+    printf '%s' "$spawn" | jq -e '(.tool_names | index("file_read")) != null and (.tool_names | index("shell_exec")) != null' >/dev/null
+  fi
   delegate_raw="$(call_tool "fixture-client" 10 "masc_team_session_step" "$(jq -cn \
     --arg s "$team_session_id" \
     --arg prompt "$write_prompt" \
-    '{session_id:$s,target_agent:"coder",delegate_prompt:$prompt}')")"
+    --arg wait_mode "$TEAM_STEP_WAIT_MODE" \
+    '{session_id:$s,target_agent:"coder",wait_mode:$wait_mode,delegate_prompt:$prompt}')")"
   require_tool_success "$delegate_raw"
   delegate_json="$(printf '%s' "$delegate_raw" | extract_tool_result | jq -c '.delegate')"
-  printf '%s' "$delegate_json" | jq -e '.tool_call_count > 0' >/dev/null
-  printf '%s' "$delegate_json" | jq -e '(.tool_names | index("file_write")) != null and (.tool_names | index("shell_exec")) != null' >/dev/null
+  if [ "$TEAM_STEP_WAIT_MODE" = "background" ]; then
+    local fixture_delegate_run_id fixture_delegate_detail fixture_delegate_verify
+    printf '%s' "$delegate_json" | jq -e '.status == "accepted"' >/dev/null
+    fixture_delegate_run_id="$(printf '%s' "$delegate_json" | jq -r '.worker_run_id')"
+    fixture_delegate_detail="$(wait_for_worker_run_event "fixture-client" "$team_session_id" "$fixture_delegate_run_id" "team_step_delegate")"
+    printf '%s' "$fixture_delegate_detail" | jq -e '.success == true' >/dev/null
+    printf '%s' "$fixture_delegate_detail" | jq -e '.tool_call_count > 0' >/dev/null
+    printf '%s' "$fixture_delegate_detail" | jq -e '(.tool_names | index("file_write")) != null and (.tool_names | index("shell_exec")) != null' >/dev/null
+    fixture_delegate_verify="$(verify_worker_run_trace "fixture-client" "$team_session_id" "$fixture_delegate_run_id")"
+    printf '%s' "$fixture_delegate_verify" | jq -e '.verification.ok == true and .verification.has_file_write == true' >/dev/null
+  else
+    printf '%s' "$delegate_json" | jq -e '.tool_call_count > 0' >/dev/null
+    printf '%s' "$delegate_json" | jq -e '(.tool_names | index("file_write")) != null and (.tool_names | index("shell_exec")) != null' >/dev/null
+  fi
   (cd "$fixture_dir" && python3 check.py >/dev/null)
-  if [ -z "$(git -C "$fixture_dir" status --short)" ]; then
-    echo "FAIL: fixture repo has no file changes after coding worker run"
+  if ! grep -q 'return 5' "$fixture_dir/calc.py"; then
+    echo "FAIL: fixture repo calc.py was not patched to return 5"
     exit 1
   fi
   require_tool_success "$(call_tool "fixture-client" 11 "masc_team_session_stop" "$(jq -cn --arg s "$team_session_id" '{session_id:$s,reason:"fixture_done",generate_report:true}')")"
@@ -325,30 +388,60 @@ EOF
     --arg s "$team_session_id" \
     --arg planner "$planner_prompt" \
     --arg implementer "$implementer_prompt" \
+    --arg wait_mode "$TEAM_STEP_WAIT_MODE" \
     '{session_id:$s,spawn_batch:[
-      {spawn_role:"planner",worker_class:"manager",worker_size:"xlg",execution_scope:"observe_only",spawn_prompt:$planner},
-      {spawn_role:"implementer",worker_class:"executor",worker_size:"lg",execution_scope:"limited_code_change",spawn_prompt:$implementer}
+      {spawn_role:"planner",worker_class:"manager",worker_size:"xlg",execution_scope:"observe_only",wait_mode:$wait_mode,spawn_prompt:$planner},
+      {spawn_role:"implementer",worker_class:"executor",worker_size:"lg",execution_scope:"limited_code_change",wait_mode:$wait_mode,spawn_prompt:$implementer}
     ]}')")"
   require_tool_success "$raw"
   result="$(printf '%s' "$raw" | extract_tool_result)"
   printf '%s' "$result" | jq -e '.spawn.mode == "batch" and .spawn.count == 2 and (.spawn.results | length) == 2' >/dev/null
-  printf '%s' "$result" | jq -e '[.spawn.results[] | .execution_scope] | index("limited_code_change") != null' >/dev/null
-  printf '%s' "$result" | jq -e '[.spawn.results[] | .tool_names[]?] | index("file_read") != null and index("shell_exec") != null' >/dev/null
+  if [ "$TEAM_STEP_WAIT_MODE" = "background" ]; then
+    local planner_run_id implementer_run_id planner_detail implementer_detail planner_verify implementer_verify
+    printf '%s' "$result" | jq -e '[.spawn.results[] | .status] | all(. == "accepted")' >/dev/null
+    planner_run_id="$(printf '%s' "$result" | jq -r '.spawn.results[] | select(.spawn_role=="planner") | .worker_run_id')"
+    implementer_run_id="$(printf '%s' "$result" | jq -r '.spawn.results[] | select(.spawn_role=="implementer") | .worker_run_id')"
+    planner_detail="$(wait_for_worker_run_event "repo-client" "$team_session_id" "$planner_run_id" "team_step_spawn")"
+    implementer_detail="$(wait_for_worker_run_event "repo-client" "$team_session_id" "$implementer_run_id" "team_step_spawn")"
+    printf '%s' "$planner_detail" | jq -e '.success == true and .execution_scope == "observe_only"' >/dev/null
+    printf '%s' "$implementer_detail" | jq -e '.success == true and .execution_scope == "limited_code_change"' >/dev/null
+    printf '%s' "$planner_detail" | jq -e '(.tool_names | index("file_read")) != null' >/dev/null
+    printf '%s' "$implementer_detail" | jq -e '(.tool_names | index("shell_exec")) != null' >/dev/null
+    planner_verify="$(verify_worker_run_trace "repo-client" "$team_session_id" "$planner_run_id")"
+    implementer_verify="$(verify_worker_run_trace "repo-client" "$team_session_id" "$implementer_run_id")"
+    printf '%s' "$planner_verify" | jq -e '.verification.ok == true and .verification.has_file_write == false' >/dev/null
+    printf '%s' "$implementer_verify" | jq -e '.verification.ok == true' >/dev/null
+  else
+    printf '%s' "$result" | jq -e '[.spawn.results[] | .execution_scope] | index("limited_code_change") != null' >/dev/null
+    printf '%s' "$result" | jq -e '[.spawn.results[] | .tool_names[]?] | index("file_read") != null and index("shell_exec") != null' >/dev/null
+  fi
   delegate_raw="$(call_tool "repo-client" 21 "masc_team_session_step" "$(jq -cn \
     --arg s "$team_session_id" \
     --arg prompt "$implementer_write_prompt" \
-    '{session_id:$s,target_agent:"implementer",delegate_prompt:$prompt}')")"
+    --arg wait_mode "$TEAM_STEP_WAIT_MODE" \
+    '{session_id:$s,target_agent:"implementer",wait_mode:$wait_mode,delegate_prompt:$prompt}')")"
   require_tool_success "$delegate_raw"
   delegate_json="$(printf '%s' "$delegate_raw" | extract_tool_result | jq -c '.delegate')"
-  printf '%s' "$delegate_json" | jq -e '.tool_call_count > 0' >/dev/null
-  printf '%s' "$delegate_json" | jq -e '(.tool_names | index("file_write")) != null and (.tool_names | index("shell_exec")) != null' >/dev/null
+  if [ "$TEAM_STEP_WAIT_MODE" = "background" ]; then
+    local repo_delegate_run_id repo_delegate_detail repo_delegate_verify
+    printf '%s' "$delegate_json" | jq -e '.status == "accepted"' >/dev/null
+    repo_delegate_run_id="$(printf '%s' "$delegate_json" | jq -r '.worker_run_id')"
+    repo_delegate_detail="$(wait_for_worker_run_event "repo-client" "$team_session_id" "$repo_delegate_run_id" "team_step_delegate")"
+    printf '%s' "$repo_delegate_detail" | jq -e '.success == true' >/dev/null
+    printf '%s' "$repo_delegate_detail" | jq -e '(.tool_names | index("file_write")) != null and (.tool_names | index("shell_exec")) != null' >/dev/null
+    repo_delegate_verify="$(verify_worker_run_trace "repo-client" "$team_session_id" "$repo_delegate_run_id")"
+    printf '%s' "$repo_delegate_verify" | jq -e '.verification.ok == true and .verification.has_file_write == true' >/dev/null
+  else
+    printf '%s' "$delegate_json" | jq -e '.tool_call_count > 0' >/dev/null
+    printf '%s' "$delegate_json" | jq -e '(.tool_names | index("file_write")) != null and (.tool_names | index("shell_exec")) != null' >/dev/null
+  fi
   require_tool_success "$(call_tool "repo-client" 21 "masc_team_session_step" "$(jq -cn \
     --arg s "$team_session_id" \
     --arg message "planner inspected the smoke target and implementer patched calc.py; verification passed" \
     '{session_id:$s,turn_kind:"note",message:$message}')")"
   (cd "$repo_dir" && python3 test/fixtures/coding_worker_repo_smoke/check.py >/dev/null)
-  if [ -z "$(git -C "$repo_dir" status --short --untracked-files=all -- test/fixtures/coding_worker_repo_smoke)" ]; then
-    echo "FAIL: real repo smoke worktree has no status change after coding pair run"
+  if ! grep -q 'return 5' "$repo_dir/test/fixtures/coding_worker_repo_smoke/calc.py"; then
+    echo "FAIL: real repo smoke calc.py was not patched to return 5"
     exit 1
   fi
   require_tool_success "$(call_tool "repo-client" 22 "masc_team_session_stop" "$(jq -cn --arg s "$team_session_id" '{session_id:$s,reason:"repo_done",generate_report:true}')")"
@@ -375,4 +468,4 @@ echo "[1/2] fixture coding worker smoke"
 run_fixture_smoke
 echo "[2/2] real repo coding pair smoke"
 run_real_repo_smoke
-echo "PASS: coding worker quick win"
+echo "PASS: coding worker quick win (${TEAM_STEP_WAIT_MODE})"

--- a/test/dune
+++ b/test/dune
@@ -400,7 +400,7 @@
           test_tool_team_session_step_routing
           test_tool_team_session_step_followup
           test_tool_team_session_misc)
- (libraries masc_mcp alcotest yojson unix eio eio_main))
+ (libraries masc_mcp agent_sdk alcotest yojson unix eio eio_main))
 
 (test
  (name test_lodge_memory_local)

--- a/test/test_agent_swarm_dev_tools.ml
+++ b/test/test_agent_swarm_dev_tools.ml
@@ -253,6 +253,73 @@ let test_shell_exec_blocked_command () =
        (String.length msg > 0)
    | Ok _ -> Alcotest.fail "should reject rm -rf /")
 
+let test_tool_exec_observer_bridges_to_telemetry () =
+  Eio_main.run @@ fun env ->
+  let proc_mgr = Eio.Stdenv.process_mgr env in
+  let clock = Eio.Stdenv.clock env in
+  let fs = Eio.Stdenv.fs env in
+  let base_dir = Filename.temp_file "dev_tools_telemetry_" "" in
+  Sys.remove base_dir;
+  Unix.mkdir base_dir 0o755;
+  Fun.protect
+    ~finally:(fun () ->
+      let rec rm path =
+        if Sys.file_exists path then
+          if Sys.is_directory path then (
+            Array.iter
+              (fun name -> rm (Filename.concat path name))
+              (Sys.readdir path);
+            Unix.rmdir path)
+          else
+            Unix.unlink path
+      in
+      try rm base_dir with _ -> ())
+    (fun () ->
+      let config = Room.default_config base_dir in
+      ignore (Room.init config ~agent_name:(Some "owner"));
+      let on_exec ~tool_name ~success ~duration_ms =
+        Telemetry_eio.track_tool_called ~fs config ~tool_name ~success
+          ~duration_ms ~agent_id:"llama-local-worker" ()
+      in
+      let tools =
+        Agent_swarm_dev_tools.make_tools ~proc_mgr ~clock ~on_exec ()
+      in
+      let tmp_path = Filename.concat "/tmp" "dev_tools_observer_bridge.txt" in
+      if Sys.file_exists tmp_path then Sys.remove tmp_path;
+      let write_tool = find_tool "file_write" tools in
+      let read_tool = find_tool "file_read" tools in
+      let shell_tool = find_tool "shell_exec" tools in
+      (match
+         Tool.execute write_tool
+           (`Assoc
+             [ ("path", `String tmp_path); ("content", `String "bridge") ])
+       with
+      | Ok _ -> ()
+      | Error e ->
+          Alcotest.fail (Printf.sprintf "file_write failed: %s" e));
+      (match Tool.execute read_tool (`Assoc [ ("path", `String tmp_path) ]) with
+      | Ok _ -> ()
+      | Error e ->
+          Alcotest.fail (Printf.sprintf "file_read failed: %s" e));
+      (match
+         Tool.execute shell_tool
+           (`Assoc [ ("command", `String "echo telemetry-ok") ])
+       with
+      | Ok _ -> ()
+      | Error e ->
+          Alcotest.fail (Printf.sprintf "shell_exec failed: %s" e));
+      let summary = Telemetry_eio.summarize_tool_usage ~fs config in
+      let stats name =
+        match Hashtbl.find_opt summary.stats_by_tool name with
+        | Some stats -> stats
+        | None -> Alcotest.fail ("missing telemetry stats for " ^ name)
+      in
+      Alcotest.(check int) "telemetry total calls" 3 summary.total_calls;
+      Alcotest.(check int) "file_write count" 1 (stats "file_write").count;
+      Alcotest.(check int) "file_read count" 1 (stats "file_read").count;
+      Alcotest.(check int) "shell_exec count" 1 (stats "shell_exec").count;
+      Sys.remove tmp_path)
+
 let test_shell_exec_rejects_shell_metacharacters () =
   Eio_main.run @@ fun env ->
   let proc_mgr = Eio.Stdenv.process_mgr env in
@@ -360,6 +427,8 @@ let () =
     "shell_exec", [
       Alcotest.test_case "echo hello" `Quick test_shell_exec_echo;
       Alcotest.test_case "blocked command" `Quick test_shell_exec_blocked_command;
+      Alcotest.test_case "observer bridges to telemetry" `Quick
+        test_tool_exec_observer_bridges_to_telemetry;
       Alcotest.test_case "reject shell metacharacters" `Quick
         test_shell_exec_rejects_shell_metacharacters;
       Alcotest.test_case "nonexistent command" `Quick test_shell_exec_nonexistent_cmd;

--- a/test/test_dashboard_mission.ml
+++ b/test/test_dashboard_mission.ml
@@ -126,6 +126,9 @@ let seed_room config session_id =
             risk_level = Some Risk_high;
             routing_confidence = Some 0.94;
             routing_reason = Some "manager must hold root synthesis";
+            thinking_enabled = None;
+            max_turns = None;
+            timeout_seconds = None;
             routing_escalated = false;
           };
           {
@@ -147,6 +150,9 @@ let seed_room config session_id =
             risk_level = Some Risk_medium;
             routing_confidence = Some 0.68;
             routing_reason = Some "spawn failures hide runtime census";
+            thinking_enabled = None;
+            max_turns = None;
+            timeout_seconds = None;
             routing_escalated = true;
           };
           {
@@ -168,6 +174,9 @@ let seed_room config session_id =
             risk_level = Some Risk_medium;
             routing_confidence = Some 0.88;
             routing_reason = Some "executor covers direct runtime checks";
+            thinking_enabled = None;
+            max_turns = None;
+            timeout_seconds = None;
             routing_escalated = false;
           };
           {
@@ -189,6 +198,9 @@ let seed_room config session_id =
             risk_level = Some Risk_low;
             routing_confidence = Some 0.72;
             routing_reason = Some "observer preserves room-level runtime census";
+            thinking_enabled = None;
+            max_turns = None;
+            timeout_seconds = None;
             routing_escalated = false;
           };
         ];

--- a/test/test_dashboard_proof.ml
+++ b/test/test_dashboard_proof.ml
@@ -68,6 +68,9 @@ let sample_session ?(min_agents = 2) ?(agent_names = [ "worker-a"; "worker-b" ])
           risk_level = Some Risk_medium;
           routing_confidence = Some 0.9;
           routing_reason = Some "worker-a implements proof surface";
+          thinking_enabled = None;
+          max_turns = None;
+          timeout_seconds = None;
           routing_escalated = false;
         };
       ];

--- a/test/test_operator_control_judgment.ml
+++ b/test/test_operator_control_judgment.ml
@@ -254,6 +254,9 @@ let test_digest_recommends_worker_spawn_batch_for_planned_worker_without_turn ()
                     risk_level = Some Team_session_types.Risk_low;
                     routing_confidence = Some 0.82;
                     routing_reason = Some "rule:machine_checkable";
+                    thinking_enabled = None;
+                    max_turns = None;
+                    timeout_seconds = None;
                     routing_escalated = false;
                   };
                 ];

--- a/test/test_operator_control_snapshot.ml
+++ b/test/test_operator_control_snapshot.ml
@@ -359,6 +359,9 @@ let test_snapshot_and_digest_expose_role_runtime_census () =
                     risk_level = Some Team_session_types.Risk_high;
                     routing_confidence = Some 0.94;
                     routing_reason = Some "explicit:lead_manager";
+                    thinking_enabled = None;
+                    max_turns = None;
+                    timeout_seconds = None;
                     routing_escalated = false;
                   };
                   {
@@ -380,6 +383,9 @@ let test_snapshot_and_digest_expose_role_runtime_census () =
                     risk_level = Some Team_session_types.Risk_high;
                     routing_confidence = Some 0.88;
                     routing_reason = Some "policy:metacog_guard";
+                    thinking_enabled = None;
+                    max_turns = None;
+                    timeout_seconds = None;
                     routing_escalated = true;
                   };
                   {
@@ -401,6 +407,9 @@ let test_snapshot_and_digest_expose_role_runtime_census () =
                     risk_level = Some Team_session_types.Risk_low;
                     routing_confidence = Some 0.83;
                     routing_reason = Some "rule:machine_checkable";
+                    thinking_enabled = None;
+                    max_turns = None;
+                    timeout_seconds = None;
                     routing_escalated = false;
                   };
                 ];

--- a/test/test_tool_team_session.ml
+++ b/test/test_tool_team_session.ml
@@ -56,6 +56,10 @@ let () =
             `Quick Test_tool_team_session_step_routing.test_step_spawn_batch_applies_hybrid_routing;
           Alcotest.test_case "parse-step-spawn-specs-applies-top-level-batch-timeout"
             `Quick Test_tool_team_session_step_routing.test_parse_step_spawn_specs_applies_top_level_batch_timeout;
+          Alcotest.test_case "parse-step-spawn-specs-applies-worker-policy-fields"
+            `Quick Test_tool_team_session_step_routing.test_parse_step_spawn_specs_applies_worker_policy_fields;
+          Alcotest.test_case "status-reports-worker-run-progress-summary" `Quick
+            Test_tool_team_session_step_routing.test_status_reports_worker_run_progress_summary;
           Alcotest.test_case "step-spawn-batch-infers-exact-env-model-tiers"
             `Quick Test_tool_team_session_step_routing.test_step_spawn_batch_infers_exact_env_model_tiers;
           Alcotest.test_case
@@ -76,6 +80,12 @@ let () =
             Test_tool_team_session_misc.test_unauthorized_session_access;
           Alcotest.test_case "final-done-delta-snapshot-stable" `Quick
             Test_tool_team_session_misc.test_final_done_delta_snapshot_stable;
+          Alcotest.test_case "verify-trace-uses-worker-run-checkpoint-snapshot"
+            `Quick
+            Test_tool_team_session_misc.test_verify_trace_uses_worker_run_checkpoint_snapshot;
+          Alcotest.test_case
+            "verify-trace-reports-summary-only-without-checkpoint" `Quick
+            Test_tool_team_session_misc.test_verify_trace_reports_summary_only_without_checkpoint;
           Alcotest.test_case "status-and-stop-linked-autoresearch" `Quick
             Test_tool_team_session_misc.test_status_and_stop_linked_autoresearch;
         ] );

--- a/test/test_tool_team_session_misc.ml
+++ b/test/test_tool_team_session_misc.ml
@@ -317,3 +317,85 @@ let test_status_and_stop_linked_autoresearch () =
       Alcotest.(check bool) "loop registry updated" true
         (state.status = Autoresearch.Stopped))
 
+let test_verify_trace_uses_worker_run_checkpoint_snapshot () =
+  Eio_main.run @@ fun env ->
+  Eio.Switch.run @@ fun sw ->
+  let base_dir = temp_dir () in
+  let config = Room.default_config base_dir in
+  ignore (Room.init config ~agent_name:(Some "owner"));
+  ignore (Room.join config ~agent_name:"owner" ~capabilities:[] ());
+  let ctx : _ Tool_team_session.context =
+    { config; agent_name = "owner"; sw; clock = Eio.Stdenv.clock env; proc_mgr = None }
+  in
+  let session_id = start_session_exn ctx ~goal:"verify-trace-checkpoint" |> get_session_id in
+  let worker_run_id = "run-trace-1" in
+  save_worker_run_checkpoint_exn config ~session_id ~worker_run_id
+    ~worker_name:"llama-local-impl"
+    (make_oas_tool_trace_checkpoint ~session_id
+       ~agent_name:"llama-local-impl" ());
+  let verify_ok, verify_body =
+    dispatch_exn ctx ~name:"masc_team_session_verify_trace"
+      ~args:
+        (`Assoc
+          [
+            ("session_id", `String session_id);
+            ("worker_run_id", `String worker_run_id);
+          ])
+  in
+  Alcotest.(check bool) "verify trace ok" true verify_ok;
+  let result = parse_json_exn verify_body |> result_field in
+  Alcotest.(check string) "trace capability" "checkpoint_snapshot"
+    Yojson.Safe.Util.(result |> member "trace_capability" |> to_string);
+  let verification = Yojson.Safe.Util.member "verification" result in
+  Alcotest.(check bool) "verification ok" true
+    Yojson.Safe.Util.(verification |> member "ok" |> to_bool);
+  Alcotest.(check bool) "has file_write" true
+    Yojson.Safe.Util.(verification |> member "has_file_write" |> to_bool);
+  Alcotest.(check bool) "verification pass after file_write" true
+    Yojson.Safe.Util.(
+      verification |> member "verification_pass_after_file_write" |> to_bool);
+  Alcotest.(check int) "paired tool result count" 3
+    Yojson.Safe.Util.(verification |> member "paired_tool_result_count" |> to_int);
+  Alcotest.(check (list string)) "tool names"
+    [ "file_read"; "file_write"; "shell_exec" ]
+    Yojson.Safe.Util.(
+      verification |> member "tool_names" |> to_list |> List.map to_string);
+  cleanup_dir base_dir
+
+let test_verify_trace_reports_summary_only_without_checkpoint () =
+  Eio_main.run @@ fun env ->
+  Eio.Switch.run @@ fun sw ->
+  let base_dir = temp_dir () in
+  let config = Room.default_config base_dir in
+  ignore (Room.init config ~agent_name:(Some "owner"));
+  ignore (Room.join config ~agent_name:"owner" ~capabilities:[] ());
+  let ctx : _ Tool_team_session.context =
+    { config; agent_name = "owner"; sw; clock = Eio.Stdenv.clock env; proc_mgr = None }
+  in
+  let session_id = start_session_exn ctx ~goal:"verify-trace-summary-only" |> get_session_id in
+  let worker_run_id = "run-trace-missing" in
+  Team_session_store.save_worker_run_meta_json config session_id worker_run_id
+    (`Assoc
+      [
+        ("worker_run_id", `String worker_run_id);
+        ("worker_name", `String "llama-local-impl");
+      ]);
+  let verify_ok, verify_body =
+    dispatch_exn ctx ~name:"masc_team_session_verify_trace"
+      ~args:
+        (`Assoc
+          [
+            ("session_id", `String session_id);
+            ("worker_run_id", `String worker_run_id);
+          ])
+  in
+  Alcotest.(check bool) "verify trace call still succeeds" true verify_ok;
+  let result = parse_json_exn verify_body |> result_field in
+  Alcotest.(check string) "trace capability" "summary_only"
+    Yojson.Safe.Util.(result |> member "trace_capability" |> to_string);
+  Alcotest.(check bool) "summary_only ok=false" false
+    Yojson.Safe.Util.(result |> member "ok" |> to_bool);
+  let error = Yojson.Safe.Util.(result |> member "error" |> to_string) in
+  Alcotest.(check bool) "missing checkpoint surfaced" true
+    (String.length error > 0);
+  cleanup_dir base_dir

--- a/test/test_tool_team_session_proof.ml
+++ b/test/test_tool_team_session_proof.ml
@@ -61,6 +61,9 @@ let test_proof_exposes_spawn_selection_rationale () =
                    risk_level = Some Team_session_types.Risk_high;
                    routing_confidence = Some 0.97;
                    routing_reason = Some "explicit:lead";
+                   thinking_enabled = None;
+                   max_turns = None;
+                   timeout_seconds = None;
                    routing_escalated = false;
                  };
                ];
@@ -180,7 +183,7 @@ let test_report_and_proof_expose_spawn_tool_usage () =
           ("execution_scope", `String "limited_code_change");
           ("worker_class", `String "executor");
           ("worker_size", `String "lg");
-          ("worker_backend", `String "oas-local");
+          ("worker_backend", `String "local");
           ("tool_call_count", `Int 3);
           ("tool_names", `List [ `String "file_read"; `String "file_write"; `String "shell_exec" ]);
           ("success", `Bool true);
@@ -215,6 +218,9 @@ let test_report_and_proof_expose_spawn_tool_usage () =
                    risk_level = Some Team_session_types.Risk_medium;
                    routing_confidence = Some 0.9;
                    routing_reason = Some "coding quick win";
+                   thinking_enabled = None;
+                   max_turns = None;
+                   timeout_seconds = None;
                    routing_escalated = false;
                  };
                ];

--- a/test/test_tool_team_session_step_routing.ml
+++ b/test/test_tool_team_session_step_routing.ml
@@ -216,6 +216,101 @@ let test_parse_step_spawn_specs_applies_top_level_batch_timeout () =
         second.spawn_timeout_seconds
   | _ -> Alcotest.fail "expected exactly two parsed spawn specs"
 
+let test_parse_step_spawn_specs_applies_worker_policy_fields () =
+  let args =
+    `Assoc
+      [
+        ( "worker_policy",
+          `Assoc
+            [
+              ("thinking", `Bool true);
+              ("timeout_seconds", `Int 42);
+              ("max_turns", `Int 7);
+            ] );
+        ( "spawn_batch",
+          `List
+            [
+              `Assoc [ ("spawn_prompt", `String "planner prompt") ];
+              `Assoc
+                [
+                  ("spawn_prompt", `String "implementer prompt");
+                  ( "worker_policy",
+                    `Assoc
+                      [
+                        ("thinking", `Bool false);
+                        ("timeout_seconds", `Int 9);
+                        ("max_turns", `Int 2);
+                      ] );
+                ];
+            ] );
+      ]
+  in
+  let specs = unwrap_ok (Tool_team_session.parse_step_spawn_specs args) in
+  match specs with
+  | [ first; second ] ->
+      Alcotest.(check (option bool)) "top-level thinking" (Some true)
+        first.thinking_enabled;
+      Alcotest.(check (option int)) "top-level max_turns" (Some 7)
+        first.max_turns;
+      Alcotest.(check int) "top-level timeout applied" 42
+        first.spawn_timeout_seconds;
+      Alcotest.(check (option bool)) "item thinking override" (Some false)
+        second.thinking_enabled;
+      Alcotest.(check (option int)) "item max_turns override" (Some 2)
+        second.max_turns;
+      Alcotest.(check int) "item timeout override" 9
+        second.spawn_timeout_seconds
+  | _ -> Alcotest.fail "expected exactly two parsed spawn specs"
+
+let test_status_reports_worker_run_progress_summary () =
+  Eio_main.run @@ fun env ->
+  Eio.Switch.run @@ fun sw ->
+  let base_dir = temp_dir () in
+  let config = Room.default_config base_dir in
+  ignore (Room.init config ~agent_name:(Some "owner"));
+  ignore (Room.join config ~agent_name:"owner" ~capabilities:[] ());
+  let ctx : _ Tool_team_session.context =
+    { config; agent_name = "owner"; sw; clock = Eio.Stdenv.clock env; proc_mgr = None }
+  in
+  let session_id = start_session_exn ctx ~goal:"worker-run-summary" |> get_session_id in
+  Team_session_store.append_event config session_id
+    ~event_type:"team_step_spawn_requested"
+    ~detail:(`Assoc [ ("worker_run_id", `String "run-a") ]);
+  Team_session_store.append_event config session_id
+    ~event_type:"team_step_spawn_requested"
+    ~detail:(`Assoc [ ("worker_run_id", `String "run-b") ]);
+  Team_session_store.append_event config session_id
+    ~event_type:"team_step_delegate_requested"
+    ~detail:(`Assoc [ ("worker_run_id", `String "run-c") ]);
+  Team_session_store.append_event config session_id
+    ~event_type:"team_step_spawn"
+    ~detail:
+      (`Assoc [ ("worker_run_id", `String "run-a"); ("success", `Bool true) ]);
+  Team_session_store.append_event config session_id
+    ~event_type:"team_step_delegate"
+    ~detail:
+      (`Assoc [ ("worker_run_id", `String "run-c"); ("success", `Bool false) ]);
+  let status_ok, status_body =
+    dispatch_exn ctx ~name:"masc_team_session_status"
+      ~args:(`Assoc [ ("session_id", `String session_id) ])
+  in
+  Alcotest.(check bool) "status ok" true status_ok;
+  let worker_runs =
+    parse_json_exn status_body |> result_field |> Yojson.Safe.Util.member "worker_runs"
+  in
+  Alcotest.(check int) "requested count" 3
+    Yojson.Safe.Util.(worker_runs |> member "requested_count" |> to_int);
+  Alcotest.(check int) "completed success count" 1
+    Yojson.Safe.Util.(worker_runs |> member "completed_success_count" |> to_int);
+  Alcotest.(check int) "completed failed count" 1
+    Yojson.Safe.Util.(worker_runs |> member "completed_failed_count" |> to_int);
+  Alcotest.(check int) "in flight count" 1
+    Yojson.Safe.Util.(worker_runs |> member "in_flight_count" |> to_int);
+  Alcotest.(check (list string)) "in flight run ids" [ "run-b" ]
+    Yojson.Safe.Util.(
+      worker_runs |> member "in_flight_run_ids" |> to_list |> List.map to_string);
+  cleanup_dir base_dir
+
 let test_step_spawn_batch_infers_exact_env_model_tiers () =
   Eio_main.run @@ fun env ->
   Eio.Switch.run @@ fun sw ->

--- a/test/test_tool_team_session_step_validation.ml
+++ b/test/test_tool_team_session_step_validation.ml
@@ -210,7 +210,7 @@ let test_step_spawn_default_local_allows_worker_size_without_spawn_model () =
     detail |> Yojson.Safe.Util.member "worker_backend"
     |> Yojson.Safe.Util.to_string_option
   in
-  Alcotest.(check (option string)) "worker backend" (Some "oas-local")
+  Alcotest.(check (option string)) "worker backend" (Some "local")
     worker_backend;
   let worker_size =
     detail |> Yojson.Safe.Util.member "worker_size"

--- a/test/test_tool_team_session_support.ml
+++ b/test/test_tool_team_session_support.ml
@@ -1,4 +1,5 @@
 open Masc_mcp
+module Oas = Agent_sdk
 
 let temp_dir () =
   let dir = Filename.temp_file "test_tool_team_session_" "" in
@@ -195,3 +196,97 @@ let make_manual_session config ~goal ~created_by ~agent_names ~min_agents
   Team_session_store.save_session config session;
   session
 
+let make_oas_tool_trace_checkpoint ?(session_id = "worker-session")
+    ?(agent_name = "llama-local-test") () : Oas.Checkpoint.t =
+  let msg role content : Oas.Types.message = { role; content } in
+  {
+    version = Oas.Checkpoint.checkpoint_version;
+    session_id;
+    agent_name;
+    model = Oas.Types.Custom "qwen3.5";
+    system_prompt = None;
+    messages =
+      [
+        msg Oas.Types.User [ Oas.Types.Text "inspect calc.py and fix it" ];
+        msg Oas.Types.Assistant
+          [
+            Oas.Types.ToolUse
+              ( "toolu_read",
+                "file_read",
+                `Assoc
+                  [
+                    ( "path",
+                      `String "test/fixtures/coding_worker_repo_smoke/calc.py" );
+                  ] );
+          ];
+        msg Oas.Types.User
+          [
+            Oas.Types.ToolResult
+              ("toolu_read", "def add_two_and_three():\n    return 4", false);
+          ];
+        msg Oas.Types.Assistant
+          [
+            Oas.Types.ToolUse
+              ( "toolu_write",
+                "file_write",
+                `Assoc
+                  [
+                    ( "path",
+                      `String "test/fixtures/coding_worker_repo_smoke/calc.py" );
+                    ( "content",
+                      `String "def add_two_and_three():\n    return 5\n" );
+                  ] );
+          ];
+        msg Oas.Types.User
+          [ Oas.Types.ToolResult ("toolu_write", "Written 37 bytes", false) ];
+        msg Oas.Types.Assistant
+          [
+            Oas.Types.ToolUse
+              ( "toolu_shell",
+                "shell_exec",
+                `Assoc
+                  [
+                    ( "command",
+                      `String
+                        "python3 test/fixtures/coding_worker_repo_smoke/check.py"
+                    );
+                  ] );
+          ];
+        msg Oas.Types.User
+          [ Oas.Types.ToolResult ("toolu_shell", "PASS", false) ];
+        msg Oas.Types.Assistant
+          [ Oas.Types.Text "Patched calc.py and verification passed." ];
+      ];
+    usage = Oas.Types.empty_usage;
+    turn_count = 3;
+    created_at = Time_compat.now ();
+    tools = [];
+    tool_choice = None;
+    temperature = None;
+    top_p = None;
+    top_k = None;
+    min_p = None;
+    enable_thinking = Some false;
+    response_format_json = false;
+    thinking_budget = None;
+    cache_system_prompt = false;
+    max_input_tokens = None;
+    max_total_tokens = None;
+    context = Oas.Context.create ();
+    mcp_sessions = [];
+  }
+
+let save_worker_run_checkpoint_exn config ~session_id ~worker_run_id
+    ~worker_name checkpoint =
+  Team_session_store.save_worker_run_meta_json config session_id worker_run_id
+    (`Assoc
+      [
+        ("worker_run_id", `String worker_run_id);
+        ("worker_name", `String worker_name);
+        ("mode", `String "delegate");
+        ("wait_mode", `String "blocking");
+        ("trace_capability", `String "checkpoint_snapshot");
+      ]);
+  Team_session_store.save_worker_run_checkpoint_text config session_id
+    worker_run_id
+    (Oas.Checkpoint.to_string checkpoint)


### PR DESCRIPTION
## Summary
- harden team-session worker evidence and telemetry in MASC only
- adopt latest local agent_sdk raw trace integration for local workers
- make background coding-worker quick win verifiable via status/events/verify_trace
- remove OAS naming from public worker backend surface

## Validation
- ./_build/default/test/test_agent_swarm_dev_tools.exe
- ./_build/default/test/test_tool_team_session.exe test team_session 26-40 --show-errors
- ./_build/default/test/test_operator_control.exe
- TEAM_STEP_WAIT_MODE=background ./scripts/harness_coding_worker_quickwin.sh