### PR TITLE
fix: restore spawn eio test build

### DIFF
--- a/test/test_bounded.ml
+++ b/test/test_bounded.ml
@@ -125,6 +125,7 @@ let mock_spawn_result ?(success=true) ?(output="{}") () =
     cache_creation_tokens = None;
     cache_read_tokens = None;
     cost_usd = Some 0.001;
+    raw_trace_run = None;
   }
 
 let test_bounded_run_empty_agents () =

--- a/test/test_spawn_eio_coverage.ml
+++ b/test/test_spawn_eio_coverage.ml
@@ -65,6 +65,7 @@ let test_spawn_result_success () =
     cache_creation_tokens = None;
     cache_read_tokens = Some 50;
     cost_usd = Some 0.005;
+    raw_trace_run = None;
   } in
   check bool "success" true r.success;
   check int "exit_code" 0 r.exit_code;
@@ -83,6 +84,7 @@ let test_spawn_result_failure () =
     cache_creation_tokens = None;
     cache_read_tokens = None;
     cost_usd = None;
+    raw_trace_run = None;
   } in
   check bool "success" false r.success;
   check int "exit_code" 1 r.exit_code
@@ -100,6 +102,7 @@ let test_spawn_result_tokens () =
     cache_creation_tokens = Some 500;
     cache_read_tokens = Some 300;
     cost_usd = Some 0.025;
+    raw_trace_run = None;
   } in
   match r.input_tokens, r.output_tokens, r.cost_usd with
   | Some i, Some o, Some c ->


### PR DESCRIPTION
## Summary
- add the missing `raw_trace_run = None` field to `Spawn_eio.spawn_result` test fixtures
- restore `test_bounded` and `test_spawn_eio_coverage` compilation after the record type change
- keep the change scoped to test fixture initialization only

## Verification
- `dune build --root .`
- `_build/default/test/test_bounded.exe`
- `_build/default/test/test_spawn_eio_coverage.exe`