### PR TITLE
feat(team-session): adopt oas raw trace validation in dashboard

### DIFF
--- a/lib/dashboard_proof.ml
+++ b/lib/dashboard_proof.ml
@@ -245,6 +245,72 @@ let get_or_create_actor table session actor =
 let tool_name_union xs ys =
   Team_session_types.dedup_strings (xs @ ys)
 
+let worker_run_meta_jsons config = function
+  | None -> []
+  | Some session_id ->
+      Team_session_store.list_worker_run_ids config session_id
+      |> List.sort String.compare
+      |> List.rev
+      |> List.filter_map (fun worker_run_id ->
+             let path =
+               Team_session_store.worker_run_meta_path config session_id
+                 worker_run_id
+             in
+             if Room_utils.path_exists config path then
+               Some (Room_utils.read_json config path)
+             else None)
+
+let worker_run_trace_capability json =
+  match U.member "trace_capability" json with
+  | `String value -> Some value
+  | _ -> None
+
+let worker_run_trace_validated json =
+  match U.member "trace_validation" json |> U.member "ok" with
+  | `Bool value -> Some value
+  | _ -> None
+
+let worker_run_validation_failures json =
+  match U.member "trace_validation" json |> U.member "checks" with
+  | `List items ->
+      items
+      |> List.filter_map (fun item ->
+             match U.member "name" item, U.member "passed" item with
+             | `String name, `Bool false -> Some name
+             | _ -> None)
+  | _ -> []
+
+let worker_run_summary_json json =
+  let summary = U.member "trace_summary" json in
+  `Assoc
+    [
+      ("worker_run_id", U.member "worker_run_id" json);
+      ("worker_name", U.member "worker_name" json);
+      ("mode", U.member "mode" json);
+      ("wait_mode", U.member "wait_mode" json);
+      ( "trace_capability",
+        Option.fold ~none:`Null ~some:(fun s -> `String s)
+          (worker_run_trace_capability json) );
+      ( "trace_validated",
+        Option.fold ~none:`Null ~some:(fun v -> `Bool v)
+          (worker_run_trace_validated json) );
+      ( "validation_failures",
+        `List
+          (List.map (fun item -> `String item)
+             (worker_run_validation_failures json)) );
+      ("success", U.member "success" json);
+      ("execution_scope", U.member "execution_scope" json);
+      ("tool_names", U.member "tool_names" json);
+      ("tool_call_count", U.member "tool_call_count" json);
+      ("output_preview", U.member "output_preview" json);
+      ("record_count", U.member "record_count" summary);
+      ("assistant_block_count", U.member "assistant_block_count" summary);
+      ("final_text", U.member "final_text" summary);
+      ("stop_reason", U.member "stop_reason" summary);
+      ("error", U.member "error" summary);
+      ("ts_iso", U.member "ts_iso" json);
+    ]
+
 let actor_activity_state (acc : actor_acc) =
   if acc.observed_event_count > 0 then
     "acted"
@@ -512,7 +578,8 @@ let cp_backing_json config operation_id =
 
 let session_summary_json session verdict ~planned_actor_count ~active_actor_count
     ~mentioned_actor_count ~unanswered_actor_count ~interaction_count
-    ~evidence_count ~cp_trace_count ~live_verdict ~historical_verdict
+    ~evidence_count ~cp_trace_count ~raw_trace_run_count
+    ~validated_worker_run_count ~live_verdict ~historical_verdict
     ~verdict_basis =
   let detail_with_history base_detail =
     match historical_verdict, live_verdict, verdict_basis with
@@ -546,6 +613,8 @@ let session_summary_json session verdict ~planned_actor_count ~active_actor_coun
           ("interaction_count", `Int interaction_count);
           ("evidence_count", `Int evidence_count);
           ("cp_trace_count", `Int cp_trace_count);
+          ("raw_trace_run_count", `Int raw_trace_run_count);
+          ("validated_worker_run_count", `Int validated_worker_run_count);
         ]
   | Some session ->
       let headline =
@@ -584,6 +653,8 @@ let session_summary_json session verdict ~planned_actor_count ~active_actor_coun
           ("interaction_count", `Int interaction_count);
           ("evidence_count", `Int evidence_count);
           ("cp_trace_count", `Int cp_trace_count);
+          ("raw_trace_run_count", `Int raw_trace_run_count);
+          ("validated_worker_run_count", `Int validated_worker_run_count);
         ]
 
 let selection_json ~requested_session_id ~requested_operation_id ~session ~operation_id
@@ -761,6 +832,25 @@ let json ?actor:_ ?session_id ?operation_id ~config () =
     tool_evidence_count > 0 || deliverable_count > 0 || checkpoints_count > 0
     || Option.is_some proof_doc
   in
+  let worker_run_meta = worker_run_meta_jsons config session_id in
+  let raw_trace_run_count =
+    worker_run_meta
+    |> List.fold_left
+         (fun acc json ->
+           match worker_run_trace_capability json with
+           | Some "raw" -> acc + 1
+           | _ -> acc)
+         0
+  in
+  let validated_worker_run_count =
+    worker_run_meta
+    |> List.fold_left
+         (fun acc json ->
+           match worker_run_trace_validated json with
+           | Some true -> acc + 1
+           | _ -> acc)
+         0
+  in
   let live_verdict =
     proof_verdict ~active_actor_count ~interaction_present:(interaction_count > 0)
       ~evidence_present ~artifact_present
@@ -829,11 +919,25 @@ let json ?actor:_ ?session_id ?operation_id ~config () =
           ~active_actor_count ~mentioned_actor_count ~unanswered_actor_count
           ~interaction_count
           ~evidence_count:(tool_evidence_count + deliverable_count + checkpoints_count)
-          ~cp_trace_count ~live_verdict ~historical_verdict ~verdict_basis );
+          ~cp_trace_count ~raw_trace_run_count ~validated_worker_run_count
+          ~live_verdict ~historical_verdict ~verdict_basis );
       ("timeline", timeline_json ?session_id ?operation_id events cp_traces);
       ("actor_contributions", `List (actor_contributions_json contributions));
       ("goal_binding", goal_binding);
       ("tool_evidence", tool_evidence);
+      ( "worker_run_evidence",
+        `List
+          (worker_run_meta
+          |> List.filter (fun json ->
+                 match worker_run_trace_capability json with
+                 | Some "raw" | Some "summary_only" -> true
+                 | _ -> false)
+          |> List.fold_left
+               (fun acc json ->
+                 if List.length acc >= 12 then acc
+                 else worker_run_summary_json json :: acc)
+               []
+          |> List.rev) );
       ("cp_backing_evidence", match cp_backing with Some value -> value | None -> `Null);
       ("artifacts", `List artifact_paths);
       ("raw_proof", match proof_doc with Some value -> value | None -> `Null);

--- a/lib/tool_team_session.ml
+++ b/lib/tool_team_session.ml
@@ -208,18 +208,6 @@ let load_worker_run_meta config session_id worker_run_id =
   else
     Ok (Room_utils.read_json config path)
 
-let load_worker_run_checkpoint config session_id worker_run_id =
-  let path =
-    Team_session_store.worker_run_checkpoint_path config session_id worker_run_id
-  in
-  if not (Room_utils.path_exists config path) then
-    Error (Printf.sprintf "worker run checkpoint not found: %s" worker_run_id)
-  else
-    let raw = Team_session_store.read_text_file path in
-    match Oas.Checkpoint.of_string raw with
-    | Ok checkpoint -> Ok checkpoint
-    | Error err -> Error (Oas.Error.to_string err)
-
 let raw_trace_run_ref_of_json json =
   let open Yojson.Safe.Util in
   match member "trace_ref" json with
@@ -251,117 +239,47 @@ let raw_trace_run_ref_to_json (run_ref : Oas.Raw_trace.run_ref) =
           run_ref.session_id );
     ]
 
-let verify_trace_from_trace_json trace =
-  let uses =
-    trace
-    |> List.filter (fun json ->
-           Yojson.Safe.Util.member "kind" json = `String "tool_use")
-  in
-  let results =
-    trace
-    |> List.filter (fun json ->
-           Yojson.Safe.Util.member "kind" json = `String "tool_result")
-  in
-  let pair_count =
-    List.fold_left
-      (fun acc use_json ->
-        match Yojson.Safe.Util.member "tool_use_id" use_json with
-        | `String id ->
-            if
-              List.exists
-                (fun result_json ->
-                  Yojson.Safe.Util.member "tool_use_id" result_json
-                  = `String id)
-                results
-            then acc + 1
-            else acc
-        | _ -> acc)
-      0 uses
-  in
-  let tool_names =
-    uses
-    |> List.filter_map (fun json ->
-           match Yojson.Safe.Util.member "tool_name" json with
-           | `String name -> Some name
-           | _ -> None)
-    |> Team_session_types.dedup_strings
-  in
-  let rec find_file_write idx = function
-    | [] -> None
-    | json :: rest -> (
-        match
-          Yojson.Safe.Util.member "kind" json,
-          Yojson.Safe.Util.member "tool_name" json
-        with
-        | `String "tool_use", `String "file_write" -> Some idx
-        | _ -> find_file_write (idx + 1) rest)
-  in
-  let file_write_index = find_file_write 0 trace in
-  let verification_pass =
-    match file_write_index with
-    | None -> not (List.mem "file_write" tool_names)
-    | Some idx ->
-        trace
-        |> List.mapi (fun i json -> (i, json))
-        |> List.exists (fun (i, json) ->
-               i > idx
-               &&
-               match
-                 Yojson.Safe.Util.member "kind" json,
-                 Yojson.Safe.Util.member "is_error" json,
-                 Yojson.Safe.Util.member "content" json
-               with
-               | `String "tool_result", `Bool false, `String content ->
-                   let trimmed = String.trim content in
-                   trimmed = "PASS"
-                   || String.starts_with ~prefix:"PASS" trimmed
-               | _ -> false)
-  in
+let raw_trace_summary_to_json
+    (summary : Oas.Sessions.raw_trace_summary) =
   `Assoc
     [
-      ("tool_trace", `List trace);
-      ("tool_names", `List (List.map (fun name -> `String name) tool_names));
-      ("tool_use_count", `Int (List.length uses));
-      ("tool_result_count", `Int (List.length results));
-      ("paired_tool_result_count", `Int pair_count);
-      ("has_file_write", `Bool (List.mem "file_write" tool_names));
-      ("has_shell_exec", `Bool (List.mem "shell_exec" tool_names));
-      ("verification_pass_after_file_write", `Bool verification_pass);
-      ("ok", `Bool (pair_count = List.length uses && verification_pass));
+      ("run_ref", raw_trace_run_ref_to_json summary.run_ref);
+      ("record_count", `Int summary.record_count);
+      ("assistant_block_count", `Int summary.assistant_block_count);
+      ( "tool_execution_started_count",
+        `Int summary.tool_execution_started_count );
+      ( "tool_execution_finished_count",
+        `Int summary.tool_execution_finished_count );
+      ( "tool_names",
+        `List (List.map (fun name -> `String name) summary.tool_names) );
+      ( "final_text",
+        Option.fold ~none:`Null ~some:(fun s -> `String s) summary.final_text
+      );
+      ( "stop_reason",
+        Option.fold ~none:`Null ~some:(fun s -> `String s) summary.stop_reason
+      );
+      ("error", Option.fold ~none:`Null ~some:(fun s -> `String s) summary.error);
     ]
 
-let tool_trace_of_checkpoint (checkpoint : Oas.Checkpoint.t) =
-  let rec loop acc = function
-    | [] -> List.rev acc
-    | (msg : Oas.Types.message) :: rest ->
-        let blocks =
-          msg.Oas.Types.content
-          |> List.filter_map (function
-                 | Oas.Types.ToolUse (id, name, input) ->
-                     Some
-                       (`Assoc
-                         [
-                           ("kind", `String "tool_use");
-                           ("tool_use_id", `String id);
-                           ("tool_name", `String name);
-                           ("input", input);
-                         ])
-                 | Oas.Types.ToolResult (id, content, is_error) ->
-                     Some
-                       (`Assoc
-                         [
-                           ("kind", `String "tool_result");
-                           ("tool_use_id", `String id);
-                           ("content", `String content);
-                           ("is_error", `Bool is_error);
-                         ])
-                 | Oas.Types.Text text ->
-                     Some (`Assoc [ ("kind", `String "text"); ("content", `String text) ])
-                 | _ -> None)
-        in
-        loop (List.rev_append blocks acc) rest
-  in
-  loop [] checkpoint.messages
+let raw_trace_validation_to_json
+    (validation : Oas.Sessions.raw_trace_validation) =
+  `Assoc
+    [
+      ("run_ref", raw_trace_run_ref_to_json validation.run_ref);
+      ("ok", `Bool validation.ok);
+      ( "checks",
+        `List
+          (List.map
+             (fun (check : Oas.Raw_trace.validation_check) ->
+               `Assoc
+                 [
+                   ("name", `String check.name);
+                   ("passed", `Bool check.passed);
+                 ])
+             validation.checks) );
+      ( "evidence",
+        `List (List.map (fun item -> `String item) validation.evidence) );
+    ]
 
 let tool_trace_of_raw_records (records : Oas.Raw_trace.record list) =
   records
@@ -423,11 +341,35 @@ let tool_trace_of_raw_records (records : Oas.Raw_trace.record list) =
                  ])
          | Oas.Raw_trace.Run_started -> None)
 
-let verify_trace_from_checkpoint (checkpoint : Oas.Checkpoint.t) =
-  verify_trace_from_trace_json (tool_trace_of_checkpoint checkpoint)
+let verification_json ~records
+    ~(summary : Oas.Sessions.raw_trace_summary)
+    ~(validation : Oas.Sessions.raw_trace_validation) =
+  `Assoc
+    [
+      ("tool_trace", `List (tool_trace_of_raw_records records));
+      ("summary", raw_trace_summary_to_json summary);
+      ("validation", raw_trace_validation_to_json validation);
+      ("ok", `Bool validation.ok);
+      ( "tool_names",
+        `List (List.map (fun name -> `String name) summary.tool_names) );
+      ("tool_use_count", `Int summary.tool_execution_started_count);
+      ("tool_result_count", `Int summary.tool_execution_finished_count);
+      ("paired_tool_result_count", `Int summary.tool_execution_finished_count);
+      ( "has_file_write",
+        `Bool (List.mem "file_write" summary.tool_names) );
+      ( "has_shell_exec",
+        `Bool (List.mem "shell_exec" summary.tool_names) );
+      ( "verification_pass_after_file_write",
+        `Bool validation.ok );
+    ]
 
-let verify_trace_from_raw_records (records : Oas.Raw_trace.record list) =
-  verify_trace_from_trace_json (tool_trace_of_raw_records records)
+let raw_trace_summary_and_validation run_ref =
+  match Oas.Raw_trace.summarize_run run_ref, Oas.Raw_trace.validate_run run_ref with
+  | Ok summary, Ok validation ->
+      Some
+        ( raw_trace_summary_to_json summary,
+          raw_trace_validation_to_json validation )
+  | _ -> None
 
 let record_session_turn_json ~(config : Room.config) ~session_id ~actor
     ~turn_kind ~message ~target_agent ~task_title ~task_description
@@ -2094,6 +2036,7 @@ let handle_step ctx args : result =
               let persist_worker_run_snapshot ~worker_run_id ~worker_name
                   ~mode ~wait_mode ?execution_scope ?tool_names ?tool_call_count
                   ~success ?output_preview ?error ?trace_capability ?trace_ref
+                  ?trace_summary ?trace_validation
                   () =
                 let checkpoint_path =
                   Team_session_store.worker_container_checkpoint_path ctx.config
@@ -2128,6 +2071,8 @@ let handle_step ctx args : result =
                       ("output_preview", Option.fold ~none:`Null ~some:(fun s -> `String s) output_preview);
                       ("error", Option.fold ~none:`Null ~some:(fun s -> `String s) error);
                       ("trace_ref", Option.fold ~none:`Null ~some:raw_trace_run_ref_to_json trace_ref);
+                      ("trace_summary", Option.fold ~none:`Null ~some:(fun json -> json) trace_summary);
+                      ("trace_validation", Option.fold ~none:`Null ~some:(fun json -> json) trace_validation);
                       ("ts_iso", `String (Types.now_iso ()));
                     ])
               in
@@ -2407,8 +2352,16 @@ let handle_step ctx args : result =
                                        ?max_turns:prepared.spec.max_turns
                                        ~runtime_session_id:session_id ()
                                    in
-                                   let output_preview =
+                                 let output_preview =
                                      truncate_for_event spawn_result.output
+                                   in
+                                   let trace_summary_json, trace_validation_json =
+                                     match spawn_result.raw_trace_run with
+                                     | Some run_ref -> (
+                                         match raw_trace_summary_and_validation run_ref with
+                                         | Some pair -> (Some (fst pair), Some (snd pair))
+                                         | None -> (None, None))
+                                     | None -> (None, None)
                                    in
                                    (match spawn_result.success with
                                    | true ->
@@ -2434,6 +2387,8 @@ let handle_step ctx args : result =
                                      ~success:spawn_result.success
                                      ~output_preview
                                      ?trace_ref:spawn_result.raw_trace_run
+                                     ?trace_summary:trace_summary_json
+                                     ?trace_validation:trace_validation_json
                                      ~trace_capability:
                                        (if Option.is_some spawn_result.raw_trace_run then
                                           "raw"
@@ -2682,6 +2637,14 @@ let handle_step ctx args : result =
                                           let output_preview =
                                             truncate_for_event run_result.output
                                           in
+                                          let trace_summary_json, trace_validation_json =
+                                            match run_result.raw_trace_run with
+                                            | Some run_ref -> (
+                                                match raw_trace_summary_and_validation run_ref with
+                                                | Some pair -> (Some (fst pair), Some (snd pair))
+                                                | None -> (None, None))
+                                            | None -> (None, None)
+                                          in
                                           persist_worker_run_snapshot
                                             ~worker_run_id ~worker_name
                                             ~mode:"delegate"
@@ -2691,6 +2654,8 @@ let handle_step ctx args : result =
                                               run_result.tool_call_count
                                             ~success:true ~output_preview
                                             ?trace_ref:run_result.raw_trace_run
+                                            ?trace_summary:trace_summary_json
+                                            ?trace_validation:trace_validation_json
                                             ~trace_capability:
                                               (if Option.is_some run_result.raw_trace_run
                                                then "raw"
@@ -3080,10 +3045,14 @@ let handle_verify_trace ctx args : result =
               | Ok meta_json -> (
                   match raw_trace_run_ref_of_json meta_json with
                   | Some run_ref -> (
-                      match Oas.Raw_trace.read_run run_ref with
-                      | Ok records ->
+                      match
+                        Oas.Raw_trace.read_run run_ref,
+                        Oas.Raw_trace.summarize_run run_ref,
+                        Oas.Raw_trace.validate_run run_ref
+                      with
+                      | Ok records, Ok summary, Ok validation ->
                           let verification =
-                            verify_trace_from_raw_records records
+                            verification_json ~records ~summary ~validation
                           in
                           ( true,
                             json_ok
@@ -3099,8 +3068,15 @@ let handle_verify_trace ctx args : result =
                                       ("verification", verification);
                                     ] );
                               ] )
-                      | Error err ->
-                          let detail = Oas.Error.to_string err in
+                      | records_result, summary_result, validation_result ->
+                          let detail =
+                            match records_result, summary_result, validation_result with
+                            | Error err, _, _
+                            | _, Error err, _
+                            | _, _, Error err ->
+                                Oas.Error.to_string err
+                            | _ -> "raw trace verification failed"
+                          in
                           ( true,
                             json_ok
                               [
@@ -3114,36 +3090,22 @@ let handle_verify_trace ctx args : result =
                                       ("meta", meta_json);
                                     ] );
                               ] ))
-                  | None -> (
-                      match load_worker_run_checkpoint ctx.config session_id worker_run_id with
-                      | Error e ->
-                          ( true,
-                            json_ok
-                              [
-                                ( "result",
-                                  `Assoc
-                                    [
-                                      ("worker_run_id", `String worker_run_id);
-                                      ("trace_capability", `String "summary_only");
-                                      ("ok", `Bool false);
-                                      ("error", `String e);
-                                      ("meta", meta_json);
-                                    ] );
-                              ] )
-                      | Ok checkpoint ->
-                          let verification = verify_trace_from_checkpoint checkpoint in
-                          ( true,
-                            json_ok
-                              [
-                                ( "result",
-                                  `Assoc
-                                    [
-                                      ("worker_run_id", `String worker_run_id);
-                                      ("trace_capability", `String "checkpoint_snapshot");
-                                      ("meta", meta_json);
-                                      ("verification", verification);
-                                    ] );
-                              ] )))))
+                  | None ->
+                      ( true,
+                        json_ok
+                          [
+                            ( "result",
+                              `Assoc
+                                [
+                                  ("worker_run_id", `String worker_run_id);
+                                  ("trace_capability", `String "summary_only");
+                                  ("ok", `Bool false);
+                                  ( "error",
+                                    `String
+                                      "raw trace reference missing for worker run" );
+                                  ("meta", meta_json);
+                                ] );
+                          ] ))))
 
 let dispatch ctx ~name ~args : result option =
   match name with

--- a/lib/tool_team_session.ml
+++ b/lib/tool_team_session.ml
@@ -341,26 +341,94 @@ let tool_trace_of_raw_records (records : Oas.Raw_trace.record list) =
                  ])
          | Oas.Raw_trace.Run_started -> None)
 
+let verification_rollup_of_trace trace =
+  let uses =
+    trace
+    |> List.filter (fun json ->
+           Yojson.Safe.Util.member "kind" json = `String "tool_use")
+  in
+  let results =
+    trace
+    |> List.filter (fun json ->
+           Yojson.Safe.Util.member "kind" json = `String "tool_result")
+  in
+  let pair_count =
+    List.fold_left
+      (fun acc use_json ->
+        match Yojson.Safe.Util.member "tool_use_id" use_json with
+        | `String id ->
+            if
+              List.exists
+                (fun result_json ->
+                  Yojson.Safe.Util.member "tool_use_id" result_json
+                  = `String id)
+                results
+            then acc + 1
+            else acc
+        | _ -> acc)
+      0 uses
+  in
+  let tool_names =
+    uses
+    |> List.filter_map (fun json ->
+           match Yojson.Safe.Util.member "tool_name" json with
+           | `String name -> Some name
+           | _ -> None)
+    |> Team_session_types.dedup_strings
+  in
+  let rec find_file_write idx = function
+    | [] -> None
+    | json :: rest -> (
+        match
+          Yojson.Safe.Util.member "kind" json,
+          Yojson.Safe.Util.member "tool_name" json
+        with
+        | `String "tool_use", `String "file_write" -> Some idx
+        | _ -> find_file_write (idx + 1) rest)
+  in
+  let file_write_index = find_file_write 0 trace in
+  let verification_pass_after_file_write =
+    match file_write_index with
+    | None -> not (List.mem "file_write" tool_names)
+    | Some idx ->
+        trace
+        |> List.mapi (fun i json -> (i, json))
+        |> List.exists (fun (i, json) ->
+               i > idx
+               &&
+               match
+                 Yojson.Safe.Util.member "kind" json,
+                 Yojson.Safe.Util.member "is_error" json,
+                 Yojson.Safe.Util.member "content" json
+               with
+               | `String "tool_result", `Bool false, `String content ->
+                   let trimmed = String.trim content in
+                   trimmed = "PASS"
+                   || String.starts_with ~prefix:"PASS" trimmed
+               | _ -> false)
+  in
+  (pair_count, tool_names, verification_pass_after_file_write)
+
 let verification_json ~records
     ~(summary : Oas.Sessions.raw_trace_summary)
     ~(validation : Oas.Sessions.raw_trace_validation) =
+  let tool_trace = tool_trace_of_raw_records records in
+  let pair_count, tool_names, verification_pass_after_file_write =
+    verification_rollup_of_trace tool_trace
+  in
   `Assoc
     [
-      ("tool_trace", `List (tool_trace_of_raw_records records));
+      ("tool_trace", `List tool_trace);
       ("summary", raw_trace_summary_to_json summary);
       ("validation", raw_trace_validation_to_json validation);
       ("ok", `Bool validation.ok);
-      ( "tool_names",
-        `List (List.map (fun name -> `String name) summary.tool_names) );
+      ("tool_names", `List (List.map (fun name -> `String name) tool_names));
       ("tool_use_count", `Int summary.tool_execution_started_count);
       ("tool_result_count", `Int summary.tool_execution_finished_count);
-      ("paired_tool_result_count", `Int summary.tool_execution_finished_count);
-      ( "has_file_write",
-        `Bool (List.mem "file_write" summary.tool_names) );
-      ( "has_shell_exec",
-        `Bool (List.mem "shell_exec" summary.tool_names) );
-      ( "verification_pass_after_file_write",
-        `Bool validation.ok );
+      ("paired_tool_result_count", `Int pair_count);
+      ("has_file_write", `Bool (List.mem "file_write" tool_names));
+      ("has_shell_exec", `Bool (List.mem "shell_exec" tool_names));
+      ("verification_pass_after_file_write", `Bool verification_pass_after_file_write);
     ]
 
 let raw_trace_summary_and_validation run_ref =

--- a/test/test_dashboard_proof.ml
+++ b/test/test_dashboard_proof.ml
@@ -172,6 +172,47 @@ let write_manual_proof config session_id verdict =
     (Lib.Team_session_store.proof_md_path config session_id)
     ("# proof\n\nverdict: " ^ verdict)
 
+let seed_worker_run_meta config session_id =
+  Lib.Team_session_store.save_worker_run_meta_json config session_id
+    "wr-proof-raw"
+    (`Assoc
+      [
+        ("worker_run_id", `String "wr-proof-raw");
+        ("worker_name", `String "worker-a");
+        ("mode", `String "delegate");
+        ("wait_mode", `String "background");
+        ("trace_capability", `String "raw");
+        ("success", `Bool true);
+        ("execution_scope", `String "limited_code_change");
+        ("tool_names", `List [ `String "file_write"; `String "shell_exec" ]);
+        ("tool_call_count", `Int 2);
+        ("output_preview", `String "Patched calc.py and verification passed.");
+        ( "trace_summary",
+          `Assoc
+            [
+              ("record_count", `Int 8);
+              ("assistant_block_count", `Int 3);
+              ("tool_execution_started_count", `Int 2);
+              ("tool_execution_finished_count", `Int 2);
+              ("tool_names", `List [ `String "file_write"; `String "shell_exec" ]);
+              ("final_text", `String "Patched calc.py and verification passed.");
+              ("stop_reason", `String "end_turn");
+              ("error", `Null);
+            ] );
+        ( "trace_validation",
+          `Assoc
+            [
+              ("ok", `Bool true);
+              ( "checks",
+                `List
+                  [
+                    `Assoc [ ("name", `String "seq_monotonic"); ("passed", `Bool true) ];
+                    `Assoc [ ("name", `String "run_started"); ("passed", `Bool true) ];
+                  ] );
+              ("evidence", `List [ `String "record_count=8" ]);
+            ] );
+      ])
+
 let test_dashboard_proof_projection () =
   let dir = test_dir () in
   Fun.protect
@@ -198,6 +239,31 @@ let test_dashboard_proof_projection () =
         ((json |> U.member "artifacts" |> U.to_list) <> []);
       check bool "cp backing present" true
         (json |> U.member "cp_backing_evidence" <> `Null))
+
+let test_dashboard_proof_exposes_validated_worker_run_evidence () =
+  let dir = test_dir () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir dir)
+    (fun () ->
+      let config = Lib.Room.default_config dir in
+      ignore (Lib.Room.init config ~agent_name:(Some "fixture-root"));
+      let session_id = "ts-proof-worker-runs" in
+      seed_session_artifacts config session_id;
+      seed_worker_run_meta config session_id;
+      let json = Lib.Dashboard_proof.json ~config ~session_id () in
+      check int "raw trace run count" 1
+        (json |> U.member "summary" |> U.member "raw_trace_run_count" |> U.to_int);
+      check int "validated worker run count" 1
+        (json |> U.member "summary" |> U.member "validated_worker_run_count" |> U.to_int);
+      let worker_runs = json |> U.member "worker_run_evidence" |> U.to_list in
+      check int "worker run evidence count" 1 (List.length worker_runs);
+      let worker = List.hd worker_runs in
+      check string "worker run capability" "raw"
+        (worker |> U.member "trace_capability" |> U.to_string);
+      check bool "worker run validated" true
+        (worker |> U.member "trace_validated" |> U.to_bool);
+      check string "worker final text" "Patched calc.py and verification passed."
+        (worker |> U.member "final_text" |> U.to_string))
 
 let test_timeline_json_orders_command_plane_events_by_timestamp () =
   let dir = test_dir () in
@@ -408,6 +474,8 @@ let () =
       ( "projection",
         [
           test_case "builds collaboration proof projection" `Quick test_dashboard_proof_projection;
+          test_case "exposes validated worker run evidence" `Quick
+            test_dashboard_proof_exposes_validated_worker_run_evidence;
           test_case "orders merged timeline chronologically" `Quick
             test_timeline_json_orders_command_plane_events_by_timestamp;
           test_case "prefers actual activity over stronger persisted proof" `Quick

--- a/test/test_tool_team_session.ml
+++ b/test/test_tool_team_session.ml
@@ -80,9 +80,9 @@ let () =
             Test_tool_team_session_misc.test_unauthorized_session_access;
           Alcotest.test_case "final-done-delta-snapshot-stable" `Quick
             Test_tool_team_session_misc.test_final_done_delta_snapshot_stable;
-          Alcotest.test_case "verify-trace-uses-worker-run-checkpoint-snapshot"
+          Alcotest.test_case "verify-trace-uses-worker-run-raw-trace"
             `Quick
-            Test_tool_team_session_misc.test_verify_trace_uses_worker_run_checkpoint_snapshot;
+            Test_tool_team_session_misc.test_verify_trace_uses_worker_run_raw_trace;
           Alcotest.test_case
             "verify-trace-reports-summary-only-without-checkpoint" `Quick
             Test_tool_team_session_misc.test_verify_trace_reports_summary_only_without_checkpoint;

--- a/test/test_tool_team_session_misc.ml
+++ b/test/test_tool_team_session_misc.ml
@@ -317,7 +317,7 @@ let test_status_and_stop_linked_autoresearch () =
       Alcotest.(check bool) "loop registry updated" true
         (state.status = Autoresearch.Stopped))
 
-let test_verify_trace_uses_worker_run_checkpoint_snapshot () =
+let test_verify_trace_uses_worker_run_raw_trace () =
   Eio_main.run @@ fun env ->
   Eio.Switch.run @@ fun sw ->
   let base_dir = temp_dir () in
@@ -327,12 +327,11 @@ let test_verify_trace_uses_worker_run_checkpoint_snapshot () =
   let ctx : _ Tool_team_session.context =
     { config; agent_name = "owner"; sw; clock = Eio.Stdenv.clock env; proc_mgr = None }
   in
-  let session_id = start_session_exn ctx ~goal:"verify-trace-checkpoint" |> get_session_id in
+  let session_id = start_session_exn ctx ~goal:"verify-trace-raw" |> get_session_id in
   let worker_run_id = "run-trace-1" in
-  save_worker_run_checkpoint_exn config ~session_id ~worker_run_id
-    ~worker_name:"llama-local-impl"
-    (make_oas_tool_trace_checkpoint ~session_id
-       ~agent_name:"llama-local-impl" ());
+  ignore
+    (write_worker_run_raw_trace_exn config ~session_id ~worker_run_id
+       ~worker_name:"llama-local-impl");
   let verify_ok, verify_body =
     dispatch_exn ctx ~name:"masc_team_session_verify_trace"
       ~args:
@@ -344,11 +343,15 @@ let test_verify_trace_uses_worker_run_checkpoint_snapshot () =
   in
   Alcotest.(check bool) "verify trace ok" true verify_ok;
   let result = parse_json_exn verify_body |> result_field in
-  Alcotest.(check string) "trace capability" "checkpoint_snapshot"
+  Alcotest.(check string) "trace capability" "raw"
     Yojson.Safe.Util.(result |> member "trace_capability" |> to_string);
   let verification = Yojson.Safe.Util.member "verification" result in
   Alcotest.(check bool) "verification ok" true
     Yojson.Safe.Util.(verification |> member "ok" |> to_bool);
+  Alcotest.(check bool) "summary present" true
+    (Yojson.Safe.Util.member "summary" verification <> `Null);
+  Alcotest.(check bool) "validation present" true
+    (Yojson.Safe.Util.member "validation" verification <> `Null);
   Alcotest.(check bool) "has file_write" true
     Yojson.Safe.Util.(verification |> member "has_file_write" |> to_bool);
   Alcotest.(check bool) "verification pass after file_write" true

--- a/test/test_tool_team_session_support.ml
+++ b/test/test_tool_team_session_support.ml
@@ -196,88 +196,185 @@ let make_manual_session config ~goal ~created_by ~agent_names ~min_agents
   Team_session_store.save_session config session;
   session
 
-let make_oas_tool_trace_checkpoint ?(session_id = "worker-session")
-    ?(agent_name = "llama-local-test") () : Oas.Checkpoint.t =
-  let msg role content : Oas.Types.message = { role; content } in
-  {
-    version = Oas.Checkpoint.checkpoint_version;
-    session_id;
-    agent_name;
-    model = Oas.Types.Custom "qwen3.5";
-    system_prompt = None;
-    messages =
-      [
-        msg Oas.Types.User [ Oas.Types.Text "inspect calc.py and fix it" ];
-        msg Oas.Types.Assistant
-          [
-            Oas.Types.ToolUse
-              ( "toolu_read",
-                "file_read",
-                `Assoc
-                  [
-                    ( "path",
-                      `String "test/fixtures/coding_worker_repo_smoke/calc.py" );
-                  ] );
-          ];
-        msg Oas.Types.User
-          [
-            Oas.Types.ToolResult
-              ("toolu_read", "def add_two_and_three():\n    return 4", false);
-          ];
-        msg Oas.Types.Assistant
-          [
-            Oas.Types.ToolUse
-              ( "toolu_write",
-                "file_write",
-                `Assoc
-                  [
-                    ( "path",
-                      `String "test/fixtures/coding_worker_repo_smoke/calc.py" );
-                    ( "content",
-                      `String "def add_two_and_three():\n    return 5\n" );
-                  ] );
-          ];
-        msg Oas.Types.User
-          [ Oas.Types.ToolResult ("toolu_write", "Written 37 bytes", false) ];
-        msg Oas.Types.Assistant
-          [
-            Oas.Types.ToolUse
-              ( "toolu_shell",
-                "shell_exec",
-                `Assoc
-                  [
-                    ( "command",
-                      `String
-                        "python3 test/fixtures/coding_worker_repo_smoke/check.py"
-                    );
-                  ] );
-          ];
-        msg Oas.Types.User
-          [ Oas.Types.ToolResult ("toolu_shell", "PASS", false) ];
-        msg Oas.Types.Assistant
-          [ Oas.Types.Text "Patched calc.py and verification passed." ];
-      ];
-    usage = Oas.Types.empty_usage;
-    turn_count = 3;
-    created_at = Time_compat.now ();
-    tools = [];
-    tool_choice = None;
-    temperature = None;
-    top_p = None;
-    top_k = None;
-    min_p = None;
-    enable_thinking = Some false;
-    response_format_json = false;
-    thinking_budget = None;
-    cache_system_prompt = false;
-    max_input_tokens = None;
-    max_total_tokens = None;
-    context = Oas.Context.create ();
-    mcp_sessions = [];
-  }
+let raw_trace_run_ref_to_json (run_ref : Oas.Raw_trace.run_ref) =
+  `Assoc
+    [
+      ("worker_run_id", `String run_ref.worker_run_id);
+      ("path", `String run_ref.path);
+      ("start_seq", `Int run_ref.start_seq);
+      ("end_seq", `Int run_ref.end_seq);
+      ("agent_name", `String run_ref.agent_name);
+      ( "session_id",
+        Option.fold ~none:`Null ~some:(fun s -> `String s)
+          run_ref.session_id );
+    ]
 
-let save_worker_run_checkpoint_exn config ~session_id ~worker_run_id
-    ~worker_name checkpoint =
+let write_worker_run_raw_trace_exn config ~session_id ~worker_run_id
+    ~worker_name =
+  let raw_trace_path =
+    Filename.concat
+      (Team_session_store.worker_run_dir config session_id worker_run_id)
+      "raw-trace.jsonl"
+  in
+  let raw_worker_run_id = "wr-fixture-raw-1" in
+  let lines =
+    [
+      `Assoc
+        [
+          ("trace_version", `Int 1);
+          ("worker_run_id", `String raw_worker_run_id);
+          ("seq", `Int 1);
+          ("ts", `Float 1.0);
+          ("agent_name", `String worker_name);
+          ("session_id", `String session_id);
+          ("record_type", `String "run_started");
+          ("prompt", `String "inspect calc.py and fix it");
+        ];
+      `Assoc
+        [
+          ("trace_version", `Int 1);
+          ("worker_run_id", `String raw_worker_run_id);
+          ("seq", `Int 2);
+          ("ts", `Float 2.0);
+          ("agent_name", `String worker_name);
+          ("session_id", `String session_id);
+          ("record_type", `String "assistant_block");
+          ("block_index", `Int 0);
+          ("block_kind", `String "tool_use");
+          ( "assistant_block",
+            `Assoc
+              [
+                ("type", `String "tool_use");
+                ("id", `String "toolu_read");
+                ("name", `String "file_read");
+                ( "input",
+                  `Assoc
+                    [
+                      ("path", `String "test/fixtures/coding_worker_repo_smoke/calc.py");
+                    ] );
+              ] );
+        ];
+      `Assoc
+        [
+          ("trace_version", `Int 1);
+          ("worker_run_id", `String raw_worker_run_id);
+          ("seq", `Int 3);
+          ("ts", `Float 3.0);
+          ("agent_name", `String worker_name);
+          ("session_id", `String session_id);
+          ("record_type", `String "tool_execution_started");
+          ("tool_use_id", `String "toolu_read");
+          ("tool_name", `String "file_read");
+          ( "tool_input",
+            `Assoc
+              [
+                ("path", `String "test/fixtures/coding_worker_repo_smoke/calc.py");
+              ] );
+        ];
+      `Assoc
+        [
+          ("trace_version", `Int 1);
+          ("worker_run_id", `String raw_worker_run_id);
+          ("seq", `Int 4);
+          ("ts", `Float 4.0);
+          ("agent_name", `String worker_name);
+          ("session_id", `String session_id);
+          ("record_type", `String "tool_execution_finished");
+          ("tool_use_id", `String "toolu_read");
+          ("tool_name", `String "file_read");
+          ("tool_result", `String "def add_two_and_three():\n    return 4");
+          ("tool_error", `Bool false);
+        ];
+      `Assoc
+        [
+          ("trace_version", `Int 1);
+          ("worker_run_id", `String raw_worker_run_id);
+          ("seq", `Int 5);
+          ("ts", `Float 5.0);
+          ("agent_name", `String worker_name);
+          ("session_id", `String session_id);
+          ("record_type", `String "tool_execution_started");
+          ("tool_use_id", `String "toolu_write");
+          ("tool_name", `String "file_write");
+          ( "tool_input",
+            `Assoc
+              [
+                ("path", `String "test/fixtures/coding_worker_repo_smoke/calc.py");
+                ("content", `String "def add_two_and_three():\n    return 5\n");
+              ] );
+        ];
+      `Assoc
+        [
+          ("trace_version", `Int 1);
+          ("worker_run_id", `String raw_worker_run_id);
+          ("seq", `Int 6);
+          ("ts", `Float 6.0);
+          ("agent_name", `String worker_name);
+          ("session_id", `String session_id);
+          ("record_type", `String "tool_execution_finished");
+          ("tool_use_id", `String "toolu_write");
+          ("tool_name", `String "file_write");
+          ("tool_result", `String "Written 37 bytes");
+          ("tool_error", `Bool false);
+        ];
+      `Assoc
+        [
+          ("trace_version", `Int 1);
+          ("worker_run_id", `String raw_worker_run_id);
+          ("seq", `Int 7);
+          ("ts", `Float 7.0);
+          ("agent_name", `String worker_name);
+          ("session_id", `String session_id);
+          ("record_type", `String "tool_execution_started");
+          ("tool_use_id", `String "toolu_shell");
+          ("tool_name", `String "shell_exec");
+          ( "tool_input",
+            `Assoc
+              [
+                ( "command",
+                  `String "python3 test/fixtures/coding_worker_repo_smoke/check.py" );
+              ] );
+        ];
+      `Assoc
+        [
+          ("trace_version", `Int 1);
+          ("worker_run_id", `String raw_worker_run_id);
+          ("seq", `Int 8);
+          ("ts", `Float 8.0);
+          ("agent_name", `String worker_name);
+          ("session_id", `String session_id);
+          ("record_type", `String "tool_execution_finished");
+          ("tool_use_id", `String "toolu_shell");
+          ("tool_name", `String "shell_exec");
+          ("tool_result", `String "PASS\n");
+          ("tool_error", `Bool false);
+        ];
+      `Assoc
+        [
+          ("trace_version", `Int 1);
+          ("worker_run_id", `String raw_worker_run_id);
+          ("seq", `Int 9);
+          ("ts", `Float 9.0);
+          ("agent_name", `String worker_name);
+          ("session_id", `String session_id);
+          ("record_type", `String "run_finished");
+          ("final_text", `String "Patched calc.py and verification passed.");
+          ("stop_reason", `String "end_turn");
+        ];
+    ]
+  in
+  Team_session_store.write_text_file raw_trace_path
+    (String.concat "\n" (List.map Yojson.Safe.to_string lines) ^ "\n");
+  let run_ref : Oas.Raw_trace.run_ref =
+    {
+      worker_run_id = raw_worker_run_id;
+      path = raw_trace_path;
+      start_seq = 1;
+      end_seq = 9;
+      agent_name = worker_name;
+      session_id = Some session_id;
+    }
+  in
   Team_session_store.save_worker_run_meta_json config session_id worker_run_id
     (`Assoc
       [
@@ -285,8 +382,7 @@ let save_worker_run_checkpoint_exn config ~session_id ~worker_run_id
         ("worker_name", `String worker_name);
         ("mode", `String "delegate");
         ("wait_mode", `String "blocking");
-        ("trace_capability", `String "checkpoint_snapshot");
+        ("trace_capability", `String "raw");
+        ("trace_ref", raw_trace_run_ref_to_json run_ref);
       ]);
-  Team_session_store.save_worker_run_checkpoint_text config session_id
-    worker_run_id
-    (Oas.Checkpoint.to_string checkpoint)
+  run_ref


### PR DESCRIPTION
## Summary
- switch team-session trace verification to OAS raw trace validators
- surface validated worker trace evidence in dashboard proof
- keep background coding-worker quick win passing on the updated evidence path

## Included commits
- 319e686f feat(dashboard): surface validated worker trace evidence
- e89dfb95 feat(team-session): consume oas raw trace validators

## Validation
- ./_build/default/test/test_dashboard_proof.exe
- ./_build/default/test/test_tool_team_session.exe test team_session 39-40 --show-errors
- TEAM_STEP_WAIT_MODE=background ./scripts/harness_coding_worker_quickwin.sh