### PR TITLE
fix(mcp): restore follow-up protocol continuity compatibility

### DIFF
--- a/lib/server_mcp_transport_http.ml
+++ b/lib/server_mcp_transport_http.ml
@@ -182,11 +182,10 @@ let validate_protocol_version_continuity ~session_id request =
   | Some expected -> (
       let ( let* ) = Result.bind in
       match provided with
-      | None ->
-          Error
-            (Printf.sprintf
-               "MCP-Protocol-Version header required for session %s."
-               session_id)
+      (* When the session already negotiated a protocol version, tolerate
+         omitted follow-up headers and continue with the remembered version.
+         Explicit mismatches still fail hard. *)
+      | None -> Ok ()
       | Some version ->
           let* () = validate_supported version in
           if String.equal version expected then

--- a/lib/server_mcp_transport_http_session.ml
+++ b/lib/server_mcp_transport_http_session.ml
@@ -168,11 +168,10 @@ let validate_protocol_version_continuity ~session_id request =
   | Some expected -> (
       let ( let* ) = Result.bind in
       match provided with
-      | None ->
-          Error
-            (Printf.sprintf
-               "MCP-Protocol-Version header required for session %s."
-               session_id)
+      (* When the session already negotiated a protocol version, tolerate
+         omitted follow-up headers and continue with the remembered version.
+         Explicit mismatches still fail hard. *)
+      | None -> Ok ()
       | Some version ->
           let* () = validate_supported version in
           if String.equal version expected then

--- a/scripts/harness/contract/streamable_http_contract.sh
+++ b/scripts/harness/contract/streamable_http_contract.sh
@@ -194,15 +194,15 @@ if [ -z "$SESSION_ID" ] || [ -z "$PROTOCOL_VERSION" ]; then
   exit 1
 fi
 
-echo "[3/8] follow-up POST rejects missing protocol header (strict enforcement)"
+echo "[3/8] follow-up POST accepts missing protocol header via session continuity"
 h3="$tmpdir/missing-protocol.headers"
 b3="$tmpdir/missing-protocol.body"
 post_with_session "$SESSION_ID" "" \
   '{"jsonrpc":"2.0","id":3,"method":"tools/list","params":{}}' \
   "$h3" "$b3"
 code3="$(status_code "$h3")"
-if [ "$code3" != "400" ]; then
-  echo "FAIL: expected 400 for missing protocol header (strict enforcement), got $code3"
+if [ "$code3" != "200" ]; then
+  echo "FAIL: expected 200 for missing protocol header via session continuity, got $code3"
   cat "$h3"
   cat "$b3"
   exit 1
@@ -241,25 +241,25 @@ if [ "$code5" != "200" ]; then
   exit 1
 fi
 
-echo "[6/8] follow-up GET rejects missing protocol header (strict enforcement)"
+echo "[6/8] follow-up GET accepts missing protocol header via session continuity"
 h6="$tmpdir/get-missing-protocol.headers"
 b6="$tmpdir/get-missing-protocol.body"
 get_with_session "$SESSION_ID" "" "$h6" "$b6"
 code6="$(status_code "$h6")"
-if [ "$code6" != "400" ]; then
-  echo "FAIL: expected 400 for GET missing protocol header (strict enforcement), got $code6"
+if [ "$code6" != "200" ]; then
+  echo "FAIL: expected 200 for GET missing protocol header via session continuity, got $code6"
   cat "$h6"
   cat "$b6"
   exit 1
 fi
 
-echo "[7/8] follow-up DELETE rejects missing protocol header (strict enforcement)"
+echo "[7/8] follow-up DELETE accepts missing protocol header via session continuity"
 h7="$tmpdir/delete-missing-protocol.headers"
 b7="$tmpdir/delete-missing-protocol.body"
 delete_with_session "$SESSION_ID" "" "$h7" "$b7"
 code7="$(status_code "$h7")"
-if [ "$code7" != "400" ]; then
-  echo "FAIL: expected 400 for DELETE missing protocol header (strict enforcement), got $code7"
+if [ "$code7" != "200" ]; then
+  echo "FAIL: expected 200 for DELETE missing protocol header via session continuity, got $code7"
   cat "$h7"
   cat "$b7"
   exit 1

--- a/test/test_http_negotiation.ml
+++ b/test/test_http_negotiation.ml
@@ -49,7 +49,7 @@ let test_classify_mcp_accept () =
     (classify_mcp_accept ~allow_legacy:false (Some "text/event-stream"));
   ()
 
-let test_protocol_continuity_rejects_missing_header () =
+let test_protocol_continuity_allows_missing_header () =
   let module Session = Masc_mcp.Server_mcp_transport_http in
   let session_id = "compat-session-missing-header" in
   let headers = Httpun.Headers.of_list [] in
@@ -59,11 +59,21 @@ let test_protocol_continuity_rejects_missing_header () =
     ~finally:(fun () -> Session.forget_mcp_session session_id)
     (fun () ->
       match Session.validate_protocol_version_continuity ~session_id request with
-      | Ok () -> fail "expected missing protocol header to be rejected"
+      | Ok () -> ()
       | Error msg ->
-          check bool "mentions required header" true
-            (String.length msg > 0
-            && String.starts_with ~prefix:"MCP-Protocol-Version header required" msg))
+          failf "expected missing protocol header to use session continuity, got %s" msg)
+
+let test_protocol_version_for_session_falls_back_to_negotiated_version () =
+  let module Session = Masc_mcp.Server_mcp_transport_http in
+  let session_id = "compat-session-negotiated-version" in
+  let headers = Httpun.Headers.of_list [] in
+  let request = Httpun.Request.create ~headers `POST "/mcp" in
+  Session.remember_protocol_version session_id "2025-03-26";
+  Fun.protect
+    ~finally:(fun () -> Session.forget_mcp_session session_id)
+    (fun () ->
+      check string "falls back to remembered session version" "2025-03-26"
+        (Session.get_protocol_version_for_session ~session_id request))
 
 let test_protocol_continuity_rejects_mismatch () =
   let module Session = Masc_mcp.Server_mcp_transport_http in
@@ -143,7 +153,8 @@ let () =
       ("accepts_streamable_mcp", [test_case "requires json+sse" `Quick test_accepts_streamable_mcp]);
       ("classify_mcp_accept", [test_case "strict vs legacy fallback" `Quick test_classify_mcp_accept]);
       ("protocol_continuity", [
-        test_case "missing header rejected" `Quick test_protocol_continuity_rejects_missing_header;
+        test_case "missing header falls back to session" `Quick test_protocol_continuity_allows_missing_header;
+        test_case "remembered session version is reused" `Quick test_protocol_version_for_session_falls_back_to_negotiated_version;
         test_case "mismatch still rejects" `Quick test_protocol_continuity_rejects_mismatch;
       ]);
       ("body_aware_accept", [


### PR DESCRIPTION
## Summary
- allow follow-up MCP requests to reuse the negotiated session protocol version when the header is omitted
- keep explicit MCP protocol mismatches rejected and leave initialize/body-aware accept strictness unchanged
- update regression tests and the streamable HTTP contract harness to cover the compatibility boundary

## Verification
- dune build --root /Users/dancer/me/workspace/yousleepwhen/masc-mcp/.worktrees/codex-widen-mcp-followup-compat
- _build/default/test/test_http_negotiation.exe
- local wire smoke: initialize=200, notifications/initialized without protocol header=202, tools/list without protocol header=200, mismatched protocol header=400

## Notes
- local server smoke was run with keeper/sentinel/autonomy loops disabled so transport behavior could be isolated from unrelated bootstrap failures