### PR TITLE
fix(agent-card): sync version from dune-build-info instead of hardcoded 2.60.0

### DIFF
--- a/lib/agent_card.ml
+++ b/lib/agent_card.ml
@@ -356,7 +356,7 @@ let generate_default ?(port=8935) ?(host="127.0.0.1") () : agent_card =
   let base_url = Printf.sprintf "http://%s:%d" host port in
   {
     name = "MASC-MCP";
-    version = "2.60.0";
+    version = Version.version;
     description = Some "Multi-Agent Streaming Coordination - A2A v0.3 compatible agent coordination system";
     provider = Some {
       organization = "Second Brain";

--- a/test/test_agent_card_coverage.ml
+++ b/test/test_agent_card_coverage.ml
@@ -285,7 +285,7 @@ let test_signature_of_json_invalid () =
 let test_generate_default () =
   let card = Agent_card.generate_default () in
   check string "name" "MASC-MCP" card.name;
-  check string "version" "2.60.0" card.version;
+  check string "version" Masc_mcp.Version.version card.version;
   check bool "has description" true (Option.is_some card.description);
   check bool "has provider" true (Option.is_some card.provider);
   check bool "streaming capability" true card.capabilities.streaming;


### PR DESCRIPTION
## Summary
- agent_card.generate_default의 version 필드가 `"2.60.0"`으로 하드코딩되어 있어서, health endpoint(2.87.0)와 불일치 발생
- `Version.version` (dune-build-info 자동 동기화)으로 교체하여 agent_card가 항상 dune-project 버전을 반영하도록 수정
- 테스트도 동적 버전 참조로 변경

## Root Cause
`lib/agent_card.ml:359`에서 version을 리터럴 문자열로 설정. 2.60.0 이후 27개 버전 동안 갱신되지 않음.

## Verification
- `dune build` 성공
- `test_agent_card_coverage.exe` 52개 테스트 전부 통과
- 검증 명령: `curl :8935/health` version == `masc_agent_card get` version (서버 재시작 후)

## Test plan
- [ ] `dune build --root .` 성공 확인
- [ ] `test_agent_card_coverage.exe` 52개 테스트 통과 확인
- [ ] 서버 재시작 후 `masc_agent_card get`의 version이 `2.87.0`과 일치 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)