### PR TITLE
docs: worker shell constraints + v2.88.0 release feedback

### DIFF
--- a/docs/WORKER-SHELL-CONSTRAINTS.md
+++ b/docs/WORKER-SHELL-CONSTRAINTS.md
@@ -1,0 +1,46 @@
+# Worker Shell Constraints
+
+Workers spawned via MASC (`spawn_eio.ml`) have specific shell execution constraints.
+
+## Constraint: No compound shell commands in worker tool calls
+
+Workers stall when their tool calls contain shell metacharacters: `cd`, `&&`, `;`, `|`, `||`.
+
+### Why
+
+MASC workers execute tools through their respective CLI interfaces (claude, codex, gemini). When a worker calls a shell tool (e.g., `Bash`, `shell_exec`), the tool receives a single command string. Compound commands fail because:
+
+1. **CLI agents** (claude, codex, gemini): Spawned via `Eio.Process.spawn` with the prompt as stdin. The agent's Bash tool may handle compound commands, but the agent itself sometimes splits or misinterprets them.
+2. **Local llama workers**: Run via `Local_agent_eio.run_worker_oas`. The llama model frequently generates compound commands that exceed the tool's single-command expectation.
+
+### Affected patterns
+
+```bash
+# These cause worker stalls:
+cd /path && dune build          # compound (&&)
+git add . ; git commit -m "x"  # compound (;)
+cat file | grep pattern         # pipe (|)
+test -f x || echo "missing"    # conditional (||)
+
+# These work:
+dune build --root /path         # single command with flag
+git -C /path status             # git with -C flag
+grep pattern file               # no pipe needed
+```
+
+### Workarounds
+
+1. **Use tool-specific flags** instead of `cd`: `dune build --root /path`, `git -C /path`
+2. **Split into separate tool calls**: One command per Bash invocation
+3. **Use `bash -c`** to wrap compound commands: `bash -c "cd /path && dune build"` (works but fragile)
+
+### For prompt authors
+
+When writing prompts for MASC workers, avoid instructing them to use compound commands. Instead, provide explicit single-command alternatives.
+
+### For MASC developers
+
+Potential improvements (tracked as task-357):
+- Add prompt validation that warns on shell metacharacters in worker instructions
+- Wrap worker shell tool calls in `bash -c` at the spawn level
+- Document allowed tool schemas more explicitly for local workers

--- a/docs/release-feedback/v2.88.0-live-2026-03-14/README.md
+++ b/docs/release-feedback/v2.88.0-live-2026-03-14/README.md
@@ -1,0 +1,64 @@
+# v2.88.0 Live MCP Feedback Pack
+
+Date: 2026-03-14
+Audience: PM, Engineering, CS
+Truth source: live MCP on `127.0.0.1:8935` first, disposable sidecar reproductions second
+
+## One-page conclusion
+
+`2.88.0` 에서는 사용자 체감상 두 가지가 분명히 좋아졌다.
+
+- version truth가 맞아졌다. live `/health` 와 `agent_card` 가 모두 `2.88.0` 을 말한다.
+- `dashboard current` 가 더 이상 즉시 lock error를 뿜지 않고 최소 요약을 반환한다.
+
+하지만 execution 관점에서는 완전한 안정판은 아니다.
+
+- 권장: 단일 worker `blocking` 작업, 짧은 검증 루프, proof 확인
+- 실험적: 순차 multi-worker 협업
+- 비권장: `spawn_batch` 후 즉시 후속 delegate, unattended background swarm
+
+## Delta From Prior Package
+
+| Topic | Prior package | v2.88.0 result | Status |
+|------|---------------|----------------|--------|
+| Version truth | `/health` 2.87 vs `agent_card` 2.60 mismatch | both now report 2.88.0 | Fixed in 2.88.0 |
+| Dashboard current | distributed lock error surfaced to user | compact current summary returned normally | Fixed in 2.88.0 |
+| Single-worker coding | passed | passed again | Stable |
+| Sequential multi-worker | experimental and fragile | implementer path worked, verifier still failed | Improved but still experimental |
+| Batch follow-up delegate | opaque target-worker lookup failure | explicit `not ready for delegation yet` contract | Improved but still experimental |
+
+## What Users Can Reliably Do Now
+
+1. 한 명의 implementer worker에게 명확한 코드 수정과 검증을 맡긴다.
+2. `wait_mode="blocking"` 으로 단계 경계를 고정한다.
+3. 검증 명령은 `python3 check.py` 같은 단일 명령으로 준다.
+4. 결과는 `masc_team_session_prove` 로 확인한다.
+
+## What Users Should Still Avoid
+
+1. `spawn_batch` 후 곧바로 `target_agent` 로 follow-up delegate
+2. 복합 shell 예시: `cd`, `&&`, `;`, 절대 python 경로
+3. 독립 verifier worker가 자동으로 잘 끝날 거라고 가정하는 것
+4. background swarm만 믿고 unattended 운영하는 것
+
+## Evidence Basis
+
+Primary live evidence:
+
+- `curl http://127.0.0.1:8935/health` on 2026-03-14: `version=2.88.0`, `release_version=2.88.0`, `commit=c7444aa9`
+- `mcp__masc__masc_agent_card` on 2026-03-14: `version=2.88.0`
+- `mcp__masc__masc_auth_status` on 2026-03-14: auth disabled
+- `mcp__masc__masc_dashboard(scope="current")` on 2026-03-14: compact summary returned normally
+
+Disposable execution evidence:
+
+- `/tmp/masc-v2880-case1-summary.json`
+- `/tmp/masc-v2880-case2-summary.json`
+- `/tmp/masc-v2880-case3-summary.json`
+
+## Document Set
+
+- [user-report.md](./user-report.md)
+- [cs-playbook.md](./cs-playbook.md)
+- [next-version-feedback.md](./next-version-feedback.md)
+- [version-truth-audit.md](./version-truth-audit.md)

--- a/docs/release-feedback/v2.88.0-live-2026-03-14/cs-playbook.md
+++ b/docs/release-feedback/v2.88.0-live-2026-03-14/cs-playbook.md
@@ -1,0 +1,115 @@
+# CS 플레이북
+
+Date: 2026-03-14
+Target: live MCP `2.88.0`
+
+## 운영 원칙
+
+- 먼저 live `/health` 기준 버전을 확인한다.
+- read-path 이슈와 execution 이슈를 분리해서 본다.
+- 사용자에게는 `worker`, `delegate`, `proof`, `dashboard` 같은 public surface 용어만 쓴다.
+
+## 문의 1: "버전은 지금 몇이에요?"
+
+### 답변 기준
+
+- 기본 기준은 `http://127.0.0.1:8935/health`
+- 현재 관찰값: `2.88.0`
+
+### 응답 초안
+
+- "현재 live service 기준 버전은 `2.88.0` 입니다."
+- "이 버전에서는 `/health` 와 `agent_card` 표기가 일치합니다."
+
+## 문의 2: "대시보드 current 가 이제 정상인가요?"
+
+### 증상
+
+- current dashboard 요약을 읽고 싶다
+
+### 현재 답변
+
+- "이전처럼 즉시 lock error가 아니라 compact summary가 반환됩니다."
+- "다만 상세 조사에는 여전히 proof/events 교차 확인을 권장합니다."
+
+### Escalation 기준
+
+- 다시 distributed lock error가 반복적으로 발생
+
+## 문의 3: "단일 worker 코딩은 쓸 만한가요?"
+
+### 현재 판단
+
+- 예. 가장 추천 가능한 경로다.
+
+### 응답 초안
+
+- "단일 worker + blocking + proof 확인 조합은 현재 권장 경로입니다."
+- "작업 범위를 작게 유지할수록 안정적입니다."
+
+## 문의 4: "여러 worker를 순차로 붙이면 되나요?"
+
+### 현재 판단
+
+- 이전보다 낫지만 아직 실험적이다.
+
+### 실제 관찰
+
+- implementer patch는 성공
+- verifier 전용 worker는 `Max turns exceeded` 로 실패 가능
+
+### 응답 초안
+
+- "순차 multi-worker는 가능하지만 아직 완전히 안정적이지 않습니다."
+- "최종 성공은 verifier 답변만 보지 말고 proof와 산출물 검증도 함께 확인해 주세요."
+
+### 현재 우회
+
+- 검증까지 한 worker가 끝내거나
+- verifier worker를 쓰더라도 최종 판정은 실제 `check.py` 결과와 proof로 확인
+
+## 문의 5: "batch spawn 후 바로 delegate 되나요?"
+
+### 현재 판단
+
+- 아직 아니다.
+
+### 실제 관찰
+
+- batch 응답에 `ready:false`
+- 후속 delegate는 `not ready for delegation yet` 에러
+
+### 응답 초안
+
+- "현재 batch worker는 수락과 ready 상태가 분리되어 있습니다."
+- "성공적인 spawn event나 ready 상태가 확인되기 전에는 follow-up delegate를 붙이지 않는 것이 좋습니다."
+
+### 현재 우회
+
+- batch 대신 순차 spawn
+- 또는 ready state 관찰 후 delegate
+
+## 문의 6: "왜 검증 worker가 끝까지 못 가죠?"
+
+### 대표 증상
+
+- `Max turns exceeded`
+
+### 해석
+
+- task는 실제로 해결됐을 수 있지만, 검증 전용 worker가 제한된 turn budget 안에서 마무리하지 못하는 경우가 있다.
+
+### 현재 우회
+
+- 검증 지시를 더 짧게 만든다.
+- verifier를 별도 worker로 두지 않고 implementer가 최종 검증까지 맡는다.
+
+### Escalation 기준
+
+- 짧은 검증 prompt에서도 반복 실패
+- proof/event 상에서 실패 원인이 불명확
+
+## 지원팀용 한 줄 요약
+
+- "`2.88.0` 에서는 버전 표기와 dashboard current 는 좋아졌습니다."
+- "단일 worker 코딩은 권장, 순차 multi-worker는 실험적, batch 후 즉시 delegate는 아직 비권장입니다."

--- a/docs/release-feedback/v2.88.0-live-2026-03-14/next-version-feedback.md
+++ b/docs/release-feedback/v2.88.0-live-2026-03-14/next-version-feedback.md
@@ -1,0 +1,65 @@
+# 다음 버전 피드백
+
+Date: 2026-03-14
+Basis: live `2.88.0` + disposable sidecar reproductions
+
+## Summary
+
+`2.88.0` 에서는 read-path와 version truth가 실제로 좋아졌다. 다음 버전의 초점은 이제 “보이는 진실”보다 “협업의 안정성”으로 옮겨야 한다.
+
+## Fixed in 2.88.0
+
+- `agent_card` version이 `2.88.0` 으로 sync 되었다.
+- live `dashboard current` 가 compact summary를 반환한다.
+
+## P0
+
+### P0-1. Ready-to-Delegate Contract
+
+- 사용자 증상: batch spawn은 accepted 이지만 follow-up delegate는 즉시 못 붙음
+- 현재 상태: 에러 메시지는 정직해졌지만 end-to-end는 아직 안 됨
+- 필요 변경:
+  - accepted 와 ready 를 명확히 구분한 상태 모델 유지
+  - ready 전환 이벤트를 표준 읽기 경로에서 쉽게 확인 가능하게 만들기
+  - 가능하면 ready 이후 자동 delegate 또는 queueing 지원
+
+### P0-2. Verifier Turn-Budget Reliability
+
+- 사용자 증상: 독립 verifier worker가 `Max turns exceeded` 로 끝날 수 있음
+- 현재 상태: implementer patch는 성공하지만 verifier가 실패해 협업 안정성이 낮음
+- 필요 변경:
+  - verifier role의 default max-turns / prompt scaffold 조정
+  - verification 전용 path를 더 짧고 결정적으로 만들기
+
+## P1
+
+### P1-1. Sequential Multi-worker as a Supported Pattern
+
+- 사용자 증상: sequential multi-worker를 써도 언제 성공/실패하는지 예측이 어려움
+- 필요 변경:
+  - recommended prompt templates 제공
+  - role별 supported pattern 문서화
+  - final proof에서 role별 성공/실패를 더 명시적으로 요약
+
+### P1-2. Runtime Selection Transparency
+
+- 사용자 증상: worker가 어떤 runtime/model을 실제로 썼는지 직관적으로 읽기 어려움
+- 현재 상태: raw result에는 있지만 사용자/CS 입장에선 아직 파편적
+- 필요 변경:
+  - session status와 proof에 runtime/model summary를 더 전면 노출
+
+## P2
+
+### P2-1. Dashboard Deep Read Confidence
+
+- 현재 상태: compact summary는 살아났지만 상세 read-path 신뢰도는 추가 확인 필요
+- 필요 변경:
+  - current scope에서 compact beyond 상세 drill-down도 안정화
+  - operator/CS용 “read-only diagnosis bundle” 제공
+
+### P2-2. Regression Guard For Version Truth
+
+- 현재 상태: version mismatch는 고쳐졌지만 다시 깨질 수 있음
+- 필요 변경:
+  - `/health` 와 `agent_card` version sync regression test
+  - release pipeline에서 metadata parity check

--- a/docs/release-feedback/v2.88.0-live-2026-03-14/user-report.md
+++ b/docs/release-feedback/v2.88.0-live-2026-03-14/user-report.md
@@ -1,0 +1,100 @@
+# 사용자 리포트
+
+Date: 2026-03-14
+Target: live MCP `2.88.0`
+
+## Executive Summary
+
+`2.88.0` 은 사용자 입장에서 “운영 read path 신뢰도는 좋아졌고, execution은 조금 더 정직해졌다”로 요약할 수 있다.
+
+- 좋은 점: 버전 표기가 맞고, dashboard current 가 살아있다.
+- 여전히 좋은 점: 단일 worker coding flow는 실무적으로 쓸 수 있다.
+- 아직 남은 점: 여러 worker를 이어 붙이는 순간 readiness 와 max-turn 한계가 다시 드러난다.
+
+## Live Snapshot
+
+| 항목 | 관찰값 | 사용자 영향 |
+|------|--------|-------------|
+| Health version | `2.88.0` | live service 기준 버전 판단 가능 |
+| Agent card version | `2.88.0` | 클라이언트 버전 표기도 일치 |
+| Auth state | disabled | onboarding은 쉽지만 운영 정책은 느슨함 |
+| Dashboard current | compact summary 정상 반환 | 운영자가 최소 요약은 바로 읽을 수 있음 |
+
+## Case Matrix
+
+| Case | Goal | Result | 사용자 해석 |
+|------|------|--------|-------------|
+| Single worker coding | temp repo 코드 수정 + 검증 + proof | 성공 | 권장 경로 유지 |
+| Sequential multi-worker | implementer patch + verifier 재검증 | 부분 성공 | 실험적이지만 이전보다 낫다 |
+| Batch follow-up delegate | batch 후 implementer delegate | 계약 개선 | still experimental |
+
+## Case 1: Single Worker Coding Passed Again
+
+Observed behavior:
+
+- worker가 `file_read`, `shell_exec`, `file_write`, `shell_exec` 순서로 실제 tool을 사용했다.
+- temp repo `calc.py` 를 `return 4` 에서 `return 5` 로 수정했다.
+- `python3 check.py` 가 `ok 5` 로 통과했다.
+- proof는 다시 `proved`, `score_pct=100.0` 이었다.
+
+User interpretation:
+
+- 이 버전에서도 가장 추천 가능한 패턴은 바뀌지 않았다.
+- 작은 범위 patch, blocking completion, proof 확인 조합은 여전히 유효하다.
+
+## Case 2: Sequential Multi-worker Improved But Is Still Experimental
+
+Observed behavior:
+
+- implementer worker는 읽기 단계와 patch delegate를 모두 성공했다.
+- 실제 두 파일이 수정되었고 로컬 `python3 check.py` 는 `ok 14.00 ...` 로 통과했다.
+- 하지만 verifier worker는 `Max turns exceeded` 로 끝났고 독립 verification turn은 실패했다.
+
+User interpretation:
+
+- “작업 분업” 자체는 예전보다 더 현실적이 되었다.
+- 다만 “검증 전용 두 번째 worker도 안정적으로 끝난다”고 보기엔 아직 이르다.
+
+Current recommendation:
+
+- multi-worker를 쓰더라도 최종 성공 판정은 proof와 실제 산출물 검증으로 함께 본다.
+- verifier를 추가하는 것은 실험적 옵션으로 취급한다.
+
+## Case 3: Batch Follow-up Delegate Is More Honest Now
+
+Observed behavior:
+
+- `spawn_batch` 응답은 두 worker 모두 `accepted` 와 `ready:false` 를 명시했다.
+- 후속 delegate는 더 이상 opaque target-worker lookup failure 로 실패하지 않았다.
+- 대신 `target worker ... is not ready for delegation yet` 라는 명시적 에러를 반환했다.
+
+User interpretation:
+
+- 아직 즉시 delegate는 안 되지만, 실패 이유가 이제 public contract 수준에서 이해 가능하다.
+- 즉 “broken” 보다는 “아직 준비 안 됨”에 가까워졌다.
+
+Current recommendation:
+
+- batch worker는 `ready:true` 또는 성공적인 `team_step_spawn` 증거를 보기 전에는 follow-up 하지 않는다.
+
+## Product Readout
+
+### Fixed in 2.88.0
+
+- version truth mismatch
+- dashboard current immediate lock failure
+
+### Improved but still experimental
+
+- batch follow-up delegate
+- sequential multi-worker coding
+
+### Still safest
+
+- single worker coding + proof
+
+## User Message For This Version
+
+- "이번 버전에서는 운영 read path와 버전 표기가 더 신뢰 가능해졌습니다."
+- "단일 worker 실무 경로는 계속 추천합니다."
+- "다중 worker 협업은 이전보다 정직한 실패/상태 신호를 주지만, 아직 실험적입니다."

--- a/docs/release-feedback/v2.88.0-live-2026-03-14/version-truth-audit.md
+++ b/docs/release-feedback/v2.88.0-live-2026-03-14/version-truth-audit.md
@@ -1,0 +1,37 @@
+# Version Truth Audit
+
+Date: 2026-03-14
+Decision: closed mismatch for version number, keep regression guard
+
+## Summary
+
+`2.88.0` 에서는 직전 패키지에서 관찰된 version truth mismatch가 해소됐다.
+
+- live `/health` -> `2.88.0`
+- live `agent_card` -> `2.88.0`
+- repo `CHANGELOG` -> `2.88.0`
+
+즉 사용자에게 “현재 버전이 무엇인가”를 안내할 때 더 이상 서로 다른 숫자를 말하지 않는다.
+
+## Observations
+
+| Source | Observed value | Meaning |
+|--------|----------------|---------|
+| live `/health` | `2.88.0` | live build/release truth |
+| live `agent_card` | `2.88.0` | client-visible metadata truth |
+| repo `CHANGELOG.md` | `[2.88.0]` expected next line after bump | repo release line과 크게 충돌하지 않는 상태 |
+
+## Residual Gap
+
+완전히 끝난 건 아니다.
+
+- `/health` 는 `commit`, `started_at`, `uptime_seconds` 같은 build provenance를 준다.
+- `agent_card` 는 version은 맞지만 build provenance는 주지 않는다.
+
+따라서 운영/CS는 계속 `/health` 를 기준으로 보는 것이 맞다.
+
+## Decision
+
+- 사용자 안내용 버전 숫자: `/health` 또는 `agent_card` 어느 쪽을 써도 됨
+- 운영 기준 진실: `/health`
+- regression guard 필요: yes


### PR DESCRIPTION
## Summary
- `WORKER-SHELL-CONSTRAINTS.md`: 워커 spawn 시 compound shell 명령(`cd && build`, `;`, `|`)이 stall을 유발하는 제약 문서화
- `release-feedback/v2.88.0-live-2026-03-14/`: Codex 세션 worktree에서 main으로 복구한 피드백 패키지 (version-truth-audit, user-report, next-version-feedback, cs-playbook)

## Context
Pipeline health check 세션에서 발견:
- P0-3 (shell affordance) 문서화
- Codex worktree 정리 중 `docs/release-feedback/`가 untracked로 남아있어 main으로 구조

## Test plan
- [ ] docs 파일 내용 검토
- [ ] 빌드 영향 없음 (docs only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)