### PR TITLE
feat(task): add CAS retry wrapper for version mismatch recovery

### DIFF
--- a/lib/tool_task.ml
+++ b/lib/tool_task.ml
@@ -213,9 +213,28 @@ let handle_transition ctx args =
         | _ -> (default_time, []))
     | None -> (default_time, [])
   in
-  let result =
-    Room.transition_task_r ctx.config ~agent_name:ctx.agent_name ~task_id ~action ?expected_version ~notes ~reason ()
+  let max_cas_retries = 3 in
+  let cas_retry_delay_s = 0.05 in
+  let is_version_mismatch = function
+    | Error (Types.TaskInvalidState msg) ->
+        let prefix = "Version mismatch" in
+        String.length msg >= String.length prefix
+        && String.sub msg 0 (String.length prefix) = prefix
+    | _ -> false
   in
+  let rec try_transition attempt =
+    let ev = if attempt = 0 then expected_version else None in
+    let r = Room.transition_task_r ctx.config ~agent_name:ctx.agent_name
+              ~task_id ~action ?expected_version:ev ~notes ~reason () in
+    if is_version_mismatch r && attempt < max_cas_retries then begin
+      Printf.eprintf "[task] CAS version mismatch on %s (attempt %d/%d), retrying in %.0fms\n%!"
+        task_id (attempt + 1) max_cas_retries (cas_retry_delay_s *. 1000.0);
+      Unix.sleepf cas_retry_delay_s;
+      try_transition (attempt + 1)
+    end else
+      r
+  in
+  let result = try_transition 0 in
   (* Notify A2A subscribers on successful transition *)
   (match result with
    | Ok _ ->


### PR DESCRIPTION
## Summary
- Backlog version은 모든 task 변경마다 전역 증가 → 서로 다른 task를 수정하는 병렬 에이전트끼리 false-positive version mismatch 발생
- `tool_task.ml`의 `handle_transition`에 retry wrapper 추가 (max 3 attempts, 50ms delay)
- 첫 시도는 caller의 `expected_version` 사용, 재시도 시 `None`으로 전환 (FSM exhaustive match가 안전 보장)

## Changes
- `lib/tool_task.ml`: `is_version_mismatch` 감지 + `try_transition` 재귀 루프

## Test plan
- [x] `dune build` 통과
- [x] `test_room.exe` 77/77 통과
- [ ] CI green 확인
- [ ] 병렬 에이전트 시나리오에서 수동 검증 (masc_transition 동시 호출)

Generated with [Claude Code](https://claude.com/claude-code)