### PR TITLE
fix(dashboard): remove read-path lock contention + add agent timeline tool

### DIFF
--- a/lib/dashboard.ml
+++ b/lib/dashboard.ml
@@ -435,6 +435,29 @@ let locks_section locks : section =
 let count_locks (config : Room_utils.config) : int =
   count_locks_for_room config (Room.current_room_id config)
 
+(* Agent workflow summaries: recent activity per active agent *)
+let agent_workflow_section now (_config : Room_utils.config) (agents : Types.agent list) : section =
+  let content =
+    agents
+    |> List.filter (fun (a : Types.agent) ->
+           match a.status with Types.Active | Types.Busy -> true | _ -> false)
+    |> List.map (fun (agent : Types.agent) ->
+           let status_icon =
+             match agent.status with
+             | Types.Active -> "[active]"
+             | Types.Busy -> "[busy]"
+             | _ -> "[idle]"
+           in
+           let task_info =
+             match agent.current_task with
+             | Some t -> Printf.sprintf " task=%s" (truncate_message t)
+             | None -> ""
+           in
+           let elapsed = format_elapsed now agent.last_seen agent.last_seen in
+           Printf.sprintf "%s %s %s%s" agent.name status_icon elapsed task_info)
+  in
+  { title = "Agent Workflows"; content; empty_msg = "(no active agents)" }
+
 let generate ?(scope = All) (config : Room_utils.config) : string =
   let now = Time_compat.now () in
   let timestamp =
@@ -456,8 +479,10 @@ let generate ?(scope = All) (config : Room_utils.config) : string =
   let sections =
     match scope with
     | All ->
+        let all_agents = List.concat_map (fun s -> s.agents) snapshots in
         [
           room_overview_section snapshots;
+          agent_workflow_section now config all_agents;
           swarm_section now config;
           tempo_section config;
           worktrees_section config;
@@ -467,6 +492,7 @@ let generate ?(scope = All) (config : Room_utils.config) : string =
         let snapshot = room_snapshot config ~current_room current_room in
         [
           agents_section now snapshot.agents;
+          agent_workflow_section now config snapshot.agents;
           tasks_section snapshot.tasks;
           messages_section snapshot.messages;
           locks_section snapshot.locks;

--- a/lib/dune
+++ b/lib/dune
@@ -299,6 +299,7 @@
    tool_control
    tool_verification
    tool_misc
+   tool_agent_timeline
    tool_llama
    tool_board
    tool_command_plane

--- a/lib/mcp_server_eio.ml
+++ b/lib/mcp_server_eio.ml
@@ -1179,6 +1179,7 @@ let execute_tool_eio ~sw ~clock ?mcp_session_id ?auth_token state ~name ~argumen
   let simple_ctx_room : Tool_room.context = { config; agent_name } in
   let simple_ctx_control : Tool_control.context = { config; agent_name } in
   let simple_ctx_misc : Tool_misc.context = { config; agent_name } in
+  let simple_ctx_agent_timeline : Tool_agent_timeline.context = { config; agent_name } in
   let simple_ctx_llama : Tool_llama.context = { config; agent_name } in
   let simple_ctx_voice : _ Tool_voice.context =
     { agent_name; sw; clock; net = state.Mcp_server.net }
@@ -1480,6 +1481,8 @@ let execute_tool_eio ~sw ~clock ?mcp_session_id ?auth_token state ~name ~argumen
         ~handler:(fun ~name ~args -> Tool_autoresearch.dispatch simple_ctx_autoresearch ~name ~args);
       reg ~schemas:Tool_risc.schemas
         ~handler:(fun ~name ~args -> Some (Tool_risc.dispatch name args));
+      reg ~schemas:Tool_agent_timeline.schemas
+        ~handler:(fun ~name ~args -> Tool_agent_timeline.dispatch simple_ctx_agent_timeline ~name ~args);
       Tool_dispatch.dispatch ~name ~args:arguments
     end else None
   in
@@ -1592,6 +1595,9 @@ let execute_tool_eio ~sw ~clock ?mcp_session_id ?auth_token state ~name ~argumen
   | Some result -> result
   | None ->
   match Tool_control.dispatch simple_ctx_control ~name ~args:arguments with
+  | Some result -> result
+  | None ->
+  match Tool_agent_timeline.dispatch simple_ctx_agent_timeline ~name ~args:arguments with
   | Some result -> result
   | None ->
   match Tool_misc.dispatch simple_ctx_misc ~name ~args:arguments with

--- a/lib/mode.ml
+++ b/lib/mode.ml
@@ -136,7 +136,7 @@ let tool_category tool_name =
   | "masc_status" | "masc_add_task" | "masc_batch_add_tasks"
   | "masc_tasks" | "masc_archive_view" | "masc_claim_next"
   | "masc_update_priority" | "masc_transition"
-  | "masc_task_history" | "masc_dashboard"
+  | "masc_task_history" | "masc_dashboard" | "masc_agent_timeline"
   (* Run pipeline *)
   | "masc_run_init" | "masc_run_plan" | "masc_run_log"
   | "masc_run_deliverable" | "masc_run_get" | "masc_run_list"

--- a/lib/room_utils_ops.ml
+++ b/lib/room_utils_ops.ml
@@ -241,12 +241,12 @@ let with_file_lock config path f =
               Time_compat.sleep 0.05;
               acquire (attempts - 1)
       in
-      if acquire 20 then
+      if acquire 100 then
         Common.protect ~module_name:"room_utils" ~finally_label:"finalizer"
           ~finally:(fun () -> ignore (backend_release_lock config ~key ~owner))
           f
       else
-        invalid_arg (Printf.sprintf "Failed to acquire distributed lock for key: %s (20 attempts exhausted)" key)
+        invalid_arg (Printf.sprintf "Failed to acquire distributed lock for key: %s (100 attempts exhausted)" key)
 
 let with_file_lock_r config path f : ('a, masc_error) result =
   match key_of_path config path with
@@ -273,7 +273,7 @@ let with_file_lock_r config path f : ('a, masc_error) result =
           | Ok true -> true
           | _ -> Time_compat.sleep 0.05; acquire (attempts - 1)
       in
-      if acquire 20 then
+      if acquire 100 then
         Common.protect ~module_name:"room_utils" ~finally_label:"finalizer"
           ~finally:(fun () -> ignore (backend_release_lock config ~key ~owner))
           (fun () -> Ok (f ()))

--- a/lib/team_session_store.ml
+++ b/lib/team_session_store.ml
@@ -97,8 +97,8 @@ let load_session config session_id : Team_session_types.session option =
   if not (path_exists config path) then
     None
   else
-    with_file_lock config path (fun () ->
-        Team_session_types.session_of_yojson (read_json config path))
+    (* Read-only: no lock needed. read_json is atomic (tmp+rename writes). *)
+    Team_session_types.session_of_yojson (read_json config path)
 
 let load_session_or_error config session_id =
   match load_session config session_id with
@@ -119,46 +119,46 @@ let read_events ?max_events config session_id : Yojson.Safe.t list =
   if not (path_exists config path) then
     []
   else
-    with_file_lock config path (fun () ->
-        match max_events with
-        | Some n when n > 0 ->
-            let q = Queue.create () in
-            In_channel.with_open_text path (fun ic ->
-                (try
-                   while true do
-                     let line = input_line ic in
-                     let trimmed = String.trim line in
-                     if trimmed <> "" then
-                       match
-                         Safe_ops.parse_json_safe ~context:"team_session.events" trimmed
-                       with
-                       | Ok json ->
-                           Queue.add json q;
-                           if Queue.length q > n then ignore (Queue.take q)
-                       | Error _ -> ()
-                   done
-                 with End_of_file -> ());
-                Queue.to_seq q |> List.of_seq)
-        | _ ->
-            In_channel.with_open_text path (fun ic ->
-                let rec loop acc =
-                  match input_line ic with
-                  | line ->
-                      let trimmed = String.trim line in
-                      let acc' =
-                        if trimmed = "" then
-                          acc
-                        else
-                          match
-                            Safe_ops.parse_json_safe ~context:"team_session.events" trimmed
-                          with
-                          | Ok json -> json :: acc
-                          | Error _ -> acc
-                      in
-                      loop acc'
-                  | exception End_of_file -> List.rev acc
-                in
-                loop []))
+    (* Read-only: no lock needed. Append-only JSONL is safe for concurrent reads. *)
+    match max_events with
+    | Some n when n > 0 ->
+        let q = Queue.create () in
+        In_channel.with_open_text path (fun ic ->
+            (try
+               while true do
+                 let line = input_line ic in
+                 let trimmed = String.trim line in
+                 if trimmed <> "" then
+                   match
+                     Safe_ops.parse_json_safe ~context:"team_session.events" trimmed
+                   with
+                   | Ok json ->
+                       Queue.add json q;
+                       if Queue.length q > n then ignore (Queue.take q)
+                   | Error _ -> ()
+               done
+             with End_of_file -> ());
+            Queue.to_seq q |> List.of_seq)
+    | _ ->
+        In_channel.with_open_text path (fun ic ->
+            let rec loop acc =
+              match input_line ic with
+              | line ->
+                  let trimmed = String.trim line in
+                  let acc' =
+                    if trimmed = "" then
+                      acc
+                    else
+                      match
+                        Safe_ops.parse_json_safe ~context:"team_session.events" trimmed
+                      with
+                      | Ok json -> json :: acc
+                      | Error _ -> acc
+                  in
+                  loop acc'
+              | exception End_of_file -> List.rev acc
+            in
+            loop [])
 
 let write_checkpoint config session_id (checkpoint : Team_session_types.checkpoint) =
   let filename = Printf.sprintf "%Ld.json" (Int64.of_float (checkpoint.ts *. 1000.0)) in

--- a/lib/tool_agent_timeline.ml
+++ b/lib/tool_agent_timeline.ml
@@ -1,0 +1,384 @@
+(** Tool_agent_timeline - Unified agent activity timeline.
+
+    Collects events from multiple data sources and merges them into
+    a single chronological timeline for a given agent.
+
+    Data sources:
+    - Agent join status (Room.get_agents_raw_in_room)
+    - Task state transitions (Room.get_tasks_raw_in_room)
+    - Broadcast messages (Room.get_messages_raw_in_room)
+*)
+
+open Tool_args
+
+type result = bool * string
+
+type context = {
+  config : Room.config;
+  agent_name : string;
+}
+
+(* ISO timestamp parsing (reuses Dashboard logic) *)
+let parse_iso_timestamp (s : string) : float option =
+  try
+    let open Scanf in
+    sscanf s "%d-%d-%dT%d:%d:%d" (fun y m d h min sec ->
+        let tm =
+          {
+            Unix.tm_sec = sec;
+            tm_min = min;
+            tm_hour = h;
+            tm_mday = d;
+            tm_mon = m - 1;
+            tm_year = y - 1900;
+            tm_wday = 0;
+            tm_yday = 0;
+            tm_isdst = false;
+          }
+        in
+        let (local_t, _) = Unix.mktime tm in
+        let utc_tm = Unix.gmtime local_t in
+        let (utc_as_local, _) = Unix.mktime utc_tm in
+        let tz_offset = local_t -. utc_as_local in
+        Some (local_t -. tz_offset))
+  with Scanf.Scan_failure _ | Failure _ | End_of_file -> None
+
+(* Event type for the unified timeline *)
+type timeline_event = {
+  ts : float;
+  ts_iso : string;
+  event_type : string;
+  detail : Yojson.Safe.t;
+}
+
+let event_to_json (e : timeline_event) : Yojson.Safe.t =
+  `Assoc
+    [
+      ("ts", `String e.ts_iso);
+      ("type", `String e.event_type);
+      ("detail", e.detail);
+    ]
+
+(* Collect agent join/status events *)
+let agent_events (config : Room.config) ~agent_name ~room_id :
+    timeline_event list =
+  let agents = Room.get_agents_raw_in_room config room_id in
+  agents
+  |> List.filter (fun (a : Types.agent) -> String.equal a.name agent_name)
+  |> List.filter_map (fun (a : Types.agent) ->
+         match parse_iso_timestamp a.joined_at with
+         | Some ts ->
+             Some
+               {
+                 ts;
+                 ts_iso = a.joined_at;
+                 event_type = "joined";
+                 detail =
+                   `Assoc
+                     [
+                       ("room", `String room_id);
+                       ( "status",
+                         `String (Types.agent_status_to_string a.status) );
+                       ( "current_task",
+                         match a.current_task with
+                         | Some t -> `String t
+                         | None -> `Null );
+                     ];
+               }
+         | None -> None)
+
+(* Collect task-related events for an agent *)
+let task_events (config : Room.config) ~agent_name ~room_id :
+    timeline_event list =
+  let tasks = Room.get_tasks_raw_in_room config room_id in
+  tasks
+  |> List.filter_map (fun (task : Types.task) ->
+         match task.task_status with
+         | Types.Claimed { assignee; claimed_at }
+           when String.equal assignee agent_name -> (
+             match parse_iso_timestamp claimed_at with
+             | Some ts ->
+                 Some
+                   {
+                     ts;
+                     ts_iso = claimed_at;
+                     event_type = "task_claimed";
+                     detail =
+                       `Assoc
+                         [
+                           ("task_id", `String task.id);
+                           ("title", `String task.title);
+                           ("priority", `Int task.priority);
+                         ];
+                   }
+             | None -> None)
+         | Types.InProgress { assignee; started_at }
+           when String.equal assignee agent_name -> (
+             match parse_iso_timestamp started_at with
+             | Some ts ->
+                 Some
+                   {
+                     ts;
+                     ts_iso = started_at;
+                     event_type = "task_started";
+                     detail =
+                       `Assoc
+                         [
+                           ("task_id", `String task.id);
+                           ("title", `String task.title);
+                           ("priority", `Int task.priority);
+                         ];
+                   }
+             | None -> None)
+         | Types.Done { assignee; completed_at; notes }
+           when String.equal assignee agent_name -> (
+             match parse_iso_timestamp completed_at with
+             | Some ts ->
+                 Some
+                   {
+                     ts;
+                     ts_iso = completed_at;
+                     event_type = "task_completed";
+                     detail =
+                       `Assoc
+                         [
+                           ("task_id", `String task.id);
+                           ("title", `String task.title);
+                           ("priority", `Int task.priority);
+                           ( "notes",
+                             match notes with
+                             | Some n -> `String n
+                             | None -> `Null );
+                         ];
+                   }
+             | None -> None)
+         | Types.Cancelled { cancelled_by; cancelled_at; reason }
+           when String.equal cancelled_by agent_name -> (
+             match parse_iso_timestamp cancelled_at with
+             | Some ts ->
+                 Some
+                   {
+                     ts;
+                     ts_iso = cancelled_at;
+                     event_type = "task_cancelled";
+                     detail =
+                       `Assoc
+                         [
+                           ("task_id", `String task.id);
+                           ("title", `String task.title);
+                           ( "reason",
+                             match reason with
+                             | Some r -> `String r
+                             | None -> `Null );
+                         ];
+                   }
+             | None -> None)
+         | _ -> None)
+
+(* Collect broadcast messages from agent *)
+let message_events (config : Room.config) ~agent_name ~room_id ~limit :
+    timeline_event list =
+  let messages =
+    Room.get_messages_raw_in_room config ~room_id ~since_seq:0 ~limit
+  in
+  messages
+  |> List.filter (fun (m : Types.message) ->
+         String.equal m.from_agent agent_name)
+  |> List.filter_map (fun (m : Types.message) ->
+         match parse_iso_timestamp m.timestamp with
+         | Some ts ->
+             Some
+               {
+                 ts;
+                 ts_iso = m.timestamp;
+                 event_type = "broadcast";
+                 detail =
+                   `Assoc
+                     [
+                       ("content", `String m.content);
+                       ("type", `String m.msg_type);
+                       ( "mention",
+                         match m.mention with
+                         | Some target -> `String target
+                         | None -> `Null );
+                     ];
+               }
+         | None -> None)
+
+(* Build the full timeline *)
+let build_timeline (config : Room.config) ~agent_name ~since_hours ~limit
+    ~include_tasks ~include_board:_ =
+  let now = Time_compat.now () in
+  let cutoff = now -. (since_hours *. 3600.0) in
+  let rooms =
+    let open Yojson.Safe.Util in
+    let result = Room.rooms_list config in
+    match result |> member "rooms" with
+    | `List rooms ->
+        List.filter_map
+          (fun room ->
+            match room |> member "id" with
+            | `String id when String.trim id <> "" -> Some id
+            | _ -> None)
+          rooms
+    | _ -> [ "default" ]
+  in
+  (* Collect events from all rooms *)
+  let all_events =
+    List.concat_map
+      (fun room_id ->
+        let agent_evts = agent_events config ~agent_name ~room_id in
+        let task_evts =
+          if include_tasks then task_events config ~agent_name ~room_id
+          else []
+        in
+        let msg_evts = message_events config ~agent_name ~room_id ~limit:200 in
+        agent_evts @ task_evts @ msg_evts)
+      rooms
+  in
+  (* Filter by time cutoff and sort chronologically *)
+  let filtered =
+    all_events
+    |> List.filter (fun e -> e.ts >= cutoff)
+    |> List.sort (fun a b -> compare a.ts b.ts)
+  in
+  (* Truncate to limit *)
+  let events =
+    if List.length filtered > limit then
+      let rec take n acc = function
+        | [] -> List.rev acc
+        | _ when n <= 0 -> List.rev acc
+        | x :: rest -> take (n - 1) (x :: acc) rest
+      in
+      take limit [] filtered
+    else filtered
+  in
+  (* Compute summary *)
+  let tasks_completed =
+    List.length
+      (List.filter
+         (fun e -> String.equal e.event_type "task_completed")
+         events)
+  in
+  let tasks_claimed =
+    List.length
+      (List.filter
+         (fun e -> String.equal e.event_type "task_claimed")
+         events)
+  in
+  let messages_sent =
+    List.length
+      (List.filter (fun e -> String.equal e.event_type "broadcast") events)
+  in
+  (* Active duration: time between first and last event *)
+  let active_duration_minutes =
+    match (events, List.rev events) with
+    | first :: _, last :: _ ->
+        let diff = last.ts -. first.ts in
+        Float.round (diff /. 60.0)
+    | _ -> 0.0
+  in
+  let since_iso =
+    let tm = Unix.gmtime cutoff in
+    Printf.sprintf "%04d-%02d-%02dT%02d:%02d:%02dZ"
+      (tm.Unix.tm_year + 1900)
+      (tm.Unix.tm_mon + 1) tm.Unix.tm_mday tm.Unix.tm_hour tm.Unix.tm_min
+      tm.Unix.tm_sec
+  in
+  let now_iso = Types.now_iso () in
+  `Assoc
+    [
+      ("agent", `String agent_name);
+      ( "period",
+        `Assoc [ ("from", `String since_iso); ("to", `String now_iso) ] );
+      ("events", `List (List.map event_to_json events));
+      ( "summary",
+        `Assoc
+          [
+            ("tasks_completed", `Int tasks_completed);
+            ("tasks_claimed", `Int tasks_claimed);
+            ("messages_sent", `Int messages_sent);
+            ("active_duration_minutes", `Float active_duration_minutes);
+            ("total_events", `Int (List.length events));
+          ] );
+    ]
+
+(* Schema for MCP tool registration *)
+let schemas : Types.tool_schema list =
+  [
+    {
+      name = "masc_agent_timeline";
+      description =
+        "Unified timeline of an agent's activity across all data sources \
+         (tasks, messages, joins). Answers: what has this agent been doing?";
+      input_schema =
+        `Assoc
+          [
+            ("type", `String "object");
+            ( "properties",
+              `Assoc
+                [
+                  ( "agent_name",
+                    `Assoc
+                      [
+                        ("type", `String "string");
+                        ("description", `String "Agent name to query");
+                      ] );
+                  ( "since_hours",
+                    `Assoc
+                      [
+                        ("type", `String "number");
+                        ( "description",
+                          `String "Look back N hours (default: 24)" );
+                      ] );
+                  ( "limit",
+                    `Assoc
+                      [
+                        ("type", `String "integer");
+                        ( "description",
+                          `String "Max events to return (default: 50)" );
+                      ] );
+                  ( "include_tasks",
+                    `Assoc
+                      [
+                        ("type", `String "boolean");
+                        ( "description",
+                          `String
+                            "Include task state changes (default: true)" );
+                      ] );
+                  ( "include_board",
+                    `Assoc
+                      [
+                        ("type", `String "boolean");
+                        ( "description",
+                          `String
+                            "Include board activity (default: false, \
+                             reserved)" );
+                      ] );
+                ] );
+            ("required", `List [ `String "agent_name" ]);
+          ];
+    };
+  ]
+
+(* Handler *)
+let handle_agent_timeline (ctx : context) args : result =
+  let agent_name = get_string args "agent_name" "" in
+  if String.length agent_name = 0 then
+    (false, "agent_name is required")
+  else
+    let since_hours = get_float args "since_hours" 24.0 in
+    let limit = get_int args "limit" 50 in
+    let include_tasks = get_bool args "include_tasks" true in
+    let include_board = get_bool args "include_board" false in
+    let json =
+      build_timeline ctx.config ~agent_name ~since_hours ~limit ~include_tasks
+        ~include_board
+    in
+    (true, Yojson.Safe.pretty_to_string json)
+
+(* Dispatch *)
+let dispatch (ctx : context) ~name ~args : result option =
+  match name with
+  | "masc_agent_timeline" -> Some (handle_agent_timeline ctx args)
+  | _ -> None

--- a/lib/tool_catalog.ml
+++ b/lib/tool_catalog.ml
@@ -170,7 +170,7 @@ let essential_tools =
     "masc_broadcast"; "masc_heartbeat"; "masc_messages";
     "masc_worktree_create"; "masc_worktree_list"; "masc_worktree_remove";
     "masc_plan_init"; "masc_plan_get"; "masc_plan_set_task"; "masc_plan_update";
-    "masc_who"; "masc_dashboard";
+    "masc_who"; "masc_dashboard"; "masc_agent_timeline";
   ]
 
 let standard_tools =

--- a/lib/tools.ml
+++ b/lib/tools.ml
@@ -23,7 +23,7 @@ let all_schemas_with_perpetual =
   all_schemas @ Tool_perpetual.schemas @ Tool_keeper.schemas
   @ Tool_operator.schemas @ Tool_llama.schemas @ Tool_command_plane.schemas @ Tool_goals.schemas
   @ Tool_team_session.schemas @ Tool_voice.schemas @ Tool_shard.schemas
-  @ Tool_notifications.schemas
+  @ Tool_notifications.schemas @ Tool_agent_timeline.schemas
 
 (** Get tool by name *)
 let find_tool name =


### PR DESCRIPTION
## Summary

- **BUG-001/002 fix**: `team_session_store.ml`의 `load_session`/`read_events`에서 distributed lock 제거 (읽기 전용 경로는 lock 불필요 — `read_json`은 atomic tmp+rename, JSONL은 append-only)
- **Safety net**: `with_file_lock` 재시도 예산 20→100회 (1초→5초)
- **New tool**: `masc_agent_timeline` — 에이전트 활동 통합 타임라인 (tasks + messages + join events)
- **Dashboard**: `Agent Workflows` 섹션 추가 (active 에이전트별 상태/task/last-seen)

## Root Cause

`append_event`가 연속 호출되면서 team-session lock 점유 → `load_session`/`read_events`의 읽기 경로도 같은 lock 경쟁 → 1초 타임아웃(20×50ms) 초과 → "20 attempts exhausted" 에러.

읽기 경로는 원자적 쓰기 보장이 이미 있으므로 lock이 불필요했음.

## Test plan

- [x] `dune build` 성공 (경고 0)
- [x] Dashboard 테스트 13/13 PASS
- [x] Team Session 테스트 44/44 PASS
- [ ] `masc_dashboard` / `masc_dashboard(compact=true)` 실행 확인
- [ ] `masc_agent_timeline(agent_name="keeper-sangsu-agent")` 실행 확인
- [ ] 기존 쓰기 경로 (join, add_task, claim_next, deliver) 영향 없음 확인

## Reference

- 평가 리포트: `docs/analysis/masc-mcp-product-evaluation-2026-03-14.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)