### PR TITLE
feat(workflow): add workflow guidance layer and verification signals

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -296,6 +296,7 @@
    task_pg
    task_dispatch
    tool_room
+   workflow_guide
    tool_control
    tool_verification
    tool_misc

--- a/lib/mcp_server_eio.ml
+++ b/lib/mcp_server_eio.ml
@@ -3239,6 +3239,10 @@ in
   in
   let (status, required_follow_up) = parse_status_from_message ~success ~message in
   let quality = quality_from_result ~success ~message ~attempts in
+  let workflow_guidance =
+    Workflow_guide.guidance_to_json
+      (Workflow_guide.next_steps ~tool_name:name ~success)
+  in
   let envelope =
     `Assoc [
       ("kind", `String "tool_call");
@@ -3251,6 +3255,7 @@ in
         | Some value -> `String value));
       ("trace_id", `String trace_id);
       ("quality", quality);
+      ("workflow_guidance", workflow_guidance);
     ]
   in
   let content_items =

--- a/lib/mode.ml
+++ b/lib/mode.ml
@@ -133,7 +133,8 @@ let tool_category tool_name =
 
   (* ── Core: room, tasks, run pipeline, team session, CPv2 orchestration ── *)
   | "masc_set_room" | "masc_init" | "masc_join" | "masc_leave"
-  | "masc_status" | "masc_add_task" | "masc_batch_add_tasks"
+  | "masc_status" | "masc_workflow_guide" | "masc_check"
+  | "masc_add_task" | "masc_batch_add_tasks"
   | "masc_tasks" | "masc_archive_view" | "masc_claim_next"
   | "masc_update_priority" | "masc_transition"
   | "masc_task_history" | "masc_dashboard"

--- a/lib/tool_help_registry.ml
+++ b/lib/tool_help_registry.ml
@@ -338,6 +338,15 @@ let canonicalize_schemas schemas =
 
 let entry_json (entry : help_entry) =
   let meta_fields = Tool_catalog.metadata_to_fields entry.name in
+  let workflow_fields =
+    match Workflow_guide.workflow_context ~tool_name:entry.name with
+    | Some (before, after, mistakes) ->
+        let str_list xs = `List (List.map (fun s -> `String s) xs) in
+        [ ("before", str_list before);
+          ("after", str_list after);
+          ("common_mistakes", str_list mistakes) ]
+    | None -> []
+  in
   `Assoc
     ([
        ("name", `String entry.name);
@@ -348,7 +357,8 @@ let entry_json (entry : help_entry) =
        ("doc_refs", `List (List.map (fun value -> `String value) entry.doc_refs));
        ("prompt_hints", `List (List.map (fun value -> `String value) entry.prompt_hints));
      ]
-    @ meta_fields)
+    @ meta_fields
+    @ workflow_fields)
 
 let entry_markdown (entry : help_entry) =
   let meta = Tool_catalog.metadata entry.name in
@@ -418,9 +428,21 @@ let entry_markdown (entry : help_entry) =
       ]
       @ List.map (fun item -> "- " ^ item) entry.prompt_hints
   in
+  let workflow_lines =
+    match Workflow_guide.workflow_context ~tool_name:entry.name with
+    | Some (before, after, mistakes) ->
+        let before_items = List.map (fun t -> "- `" ^ t ^ "`") before in
+        let after_items = List.map (fun t -> "- `" ^ t ^ "`") after in
+        let mistake_items = List.map (fun m -> "- " ^ m) mistakes in
+        [ ""; "## Workflow Context"; "" ]
+        @ (if before <> [] then [ "**Call before this tool:**" ] @ before_items else [])
+        @ (if after <> [] then [ ""; "**Call after this tool:**" ] @ after_items else [])
+        @ (if mistakes <> [] then [ ""; "**Common mistakes:**" ] @ mistake_items else [])
+    | None -> []
+  in
   String.concat "\n"
     (header @ replacement_lines @ when_lines @ constraint_lines @ detail_lines
-   @ doc_lines @ prompt_lines)
+   @ doc_lines @ prompt_lines @ workflow_lines)
 
 let index_json (schemas : Types.tool_schema list) =
   `Assoc

--- a/lib/tool_room.ml
+++ b/lib/tool_room.ml
@@ -240,11 +240,13 @@ let check_assertion st assertion =
 
 let handle_check ctx args =
   let st = inspect_state ctx in
+  let default_assertions = [ "room_set"; "joined"; "task_claimed"; "current_task_set" ] in
   let assertions =
     match Yojson.Safe.Util.member "assertions" args with
     | `List items ->
-        List.filter_map (function `String s -> Some s | _ -> None) items
-    | _ -> [ "room_set"; "joined"; "task_claimed"; "current_task_set" ]
+        let parsed = List.filter_map (function `String s -> Some s | _ -> None) items in
+        if parsed = [] then default_assertions else parsed
+    | _ -> default_assertions
   in
   let results = List.map (check_assertion st) assertions in
   let all_passed = List.for_all (fun r ->

--- a/lib/tool_room.ml
+++ b/lib/tool_room.ml
@@ -138,6 +138,139 @@ let handle_room_strategy_set ctx args =
               ("project", `String updated.project);
             ]) )
 
+(* ── State inspection (shared by workflow_guide and check) ──────── *)
+
+type agent_state = {
+  room_set : bool;
+  joined : bool;
+  task_claimed : bool;
+  current_task_set : bool;
+  worktree_active : bool;
+}
+
+let inspect_state ctx =
+  let room_set = Room.is_initialized ctx.config in
+  let joined =
+    if room_set then
+      (try Room.is_agent_joined ctx.config ~agent_name:ctx.agent_name
+       with Sys_error _ | Yojson.Json_error _ -> false)
+    else false
+  in
+  let (task_claimed, current_task_set) =
+    if joined then
+      let agents_path =
+        Filename.concat
+          (Room.agents_dir ctx.config)
+          (Room.safe_filename ctx.agent_name ^ ".json")
+      in
+      if Sys.file_exists agents_path then
+        match Room.read_json ctx.config agents_path |> Types.agent_of_yojson with
+        | Ok agent ->
+            let claimed = agent.Types.current_task <> None in
+            (claimed, claimed)
+        | Error _ -> (false, false)
+      else (false, false)
+    else (false, false)
+  in
+  let worktree_active =
+    if room_set then
+      let wt_dir = Filename.concat ctx.config.base_path ".worktrees" in
+      (try Sys.file_exists wt_dir && Sys.is_directory wt_dir &&
+           Array.length (Sys.readdir wt_dir) > 0
+       with _ -> false)
+    else false
+  in
+  { room_set; joined; task_claimed; current_task_set; worktree_active }
+
+let state_to_json st =
+  `Assoc [
+    ("room_set", `Bool st.room_set);
+    ("joined", `Bool st.joined);
+    ("task_claimed", `Bool st.task_claimed);
+    ("current_task_set", `Bool st.current_task_set);
+    ("worktree_active", `Bool st.worktree_active);
+    ("session_active", `Bool false);
+  ]
+
+(* ── Workflow guide ─────────────────────────────────────────────── *)
+
+let handle_workflow_guide ctx _args =
+  let st = inspect_state ctx in
+  let guidance =
+    Workflow_guide.current_state_guidance
+      ~room_set:st.room_set ~joined:st.joined
+      ~task_claimed:st.task_claimed ~current_task_set:st.current_task_set
+      ~worktree_active:st.worktree_active ~session_active:false
+  in
+  let result =
+    `Assoc [
+      ("current_state", state_to_json st);
+      ("guidance", Workflow_guide.guidance_to_json guidance);
+    ]
+  in
+  (true, Yojson.Safe.pretty_to_string result)
+
+(* ── State check (assertion-based verification) ────────────────── *)
+
+let check_assertion st assertion =
+  let (passed, fix_hint) = match assertion with
+    | "room_set" ->
+        (st.room_set,
+         "Call masc_set_room with your project root path")
+    | "joined" ->
+        (st.joined,
+         "Call masc_join to register your agent in the room")
+    | "task_claimed" ->
+        (st.task_claimed,
+         "Call masc_claim or masc_add_task + masc_claim to get a task")
+    | "current_task_set" ->
+        (st.current_task_set,
+         "Call masc_plan_set_task after claiming a task")
+    | "worktree_active" ->
+        (st.worktree_active,
+         "Call masc_worktree_create to work in an isolated branch")
+    | other ->
+        (false, Printf.sprintf "Unknown assertion: %s" other)
+  in
+  `Assoc [
+    ("assertion", `String assertion);
+    ("passed", `Bool passed);
+    ("fix_hint", if passed then `Null else `String fix_hint);
+  ]
+
+let handle_check ctx args =
+  let st = inspect_state ctx in
+  let assertions =
+    match Yojson.Safe.Util.member "assertions" args with
+    | `List items ->
+        List.filter_map (function `String s -> Some s | _ -> None) items
+    | _ -> [ "room_set"; "joined"; "task_claimed"; "current_task_set" ]
+  in
+  let results = List.map (check_assertion st) assertions in
+  let all_passed = List.for_all (fun r ->
+    match Yojson.Safe.Util.member "passed" r with
+    | `Bool b -> b | _ -> false) results
+  in
+  let fix_hint =
+    if all_passed then `Null
+    else
+      let first_fail = List.find_opt (fun r ->
+        match Yojson.Safe.Util.member "passed" r with
+        | `Bool false -> true | _ -> false) results
+      in
+      match first_fail with
+      | Some r -> Yojson.Safe.Util.member "fix_hint" r
+      | None -> `Null
+  in
+  let result =
+    `Assoc [
+      ("assertions", `List results);
+      ("all_passed", `Bool all_passed);
+      ("fix_hint", fix_hint);
+    ]
+  in
+  (true, Yojson.Safe.pretty_to_string result)
+
 (* Dispatch function *)
 let dispatch ctx ~name ~args : result option =
   match name with
@@ -149,4 +282,6 @@ let dispatch ctx ~name ~args : result option =
   | "masc_room_enter" -> Some (handle_room_enter ctx args)
   | "masc_room_strategy_get" -> Some (handle_room_strategy_get ctx args)
   | "masc_room_strategy_set" -> Some (handle_room_strategy_set ctx args)
+  | "masc_workflow_guide" -> Some (handle_workflow_guide ctx args)
+  | "masc_check" -> Some (handle_check ctx args)
   | _ -> None

--- a/lib/tools_schemas_01.ml
+++ b/lib/tools_schemas_01.ml
@@ -354,4 +354,35 @@ Tip: Look for status='todo' tasks to claim.";
       ]);
     ];
   };
+
+  {
+    name = "masc_workflow_guide";
+    description = "Get personalized workflow guidance based on your current state. Returns what you should do next: which tool to call, why, and common mistakes to avoid. Call this when you are unsure what to do next or want to verify you are on the right track.";
+    input_schema = `Assoc [
+      ("type", `String "object");
+      ("properties", `Assoc []);
+    ];
+  };
+
+  {
+    name = "masc_check";
+    description = "Verify your current agent state against a list of assertions. Returns pass/fail for each assertion with fix hints. Use this to confirm prerequisites before starting work.";
+    input_schema = `Assoc [
+      ("type", `String "object");
+      ("properties", `Assoc [
+        ("assertions", `Assoc [
+          ("type", `String "array");
+          ("items", `Assoc [
+            ("type", `String "string");
+            ("enum", `List [
+              `String "room_set"; `String "joined"; `String "task_claimed";
+              `String "current_task_set"; `String "worktree_active";
+            ]);
+          ]);
+          ("description", `String "List of state assertions to check. Each returns true/false with a fix hint if false.");
+        ]);
+      ]);
+      ("required", `List [`String "assertions"]);
+    ];
+  };
 ]

--- a/lib/workflow_guide.ml
+++ b/lib/workflow_guide.ml
@@ -1,0 +1,436 @@
+(** Workflow Guidance — encodes Golden Path sequences.
+
+    Three canonical paths are encoded:
+    1. Room/Task Hygiene (prerequisite for all work)
+    2. CPv2 Direct (benchmark / swarm)
+    3. Team Session / Supervisor
+
+    @since 2.89.0 *)
+
+type step = {
+  tool : string;
+  reason : string;
+}
+
+type guidance = {
+  next_steps : step list;
+  preconditions : string list;
+  common_mistakes : string list;
+}
+
+let empty = { next_steps = []; preconditions = []; common_mistakes = [] }
+
+(* ── helpers ─────────────────────────────────────────────────────── *)
+
+let s tool reason = { tool; reason }
+
+(* ── Golden Path 1: Room/Task Hygiene ────────────────────────────── *)
+
+let after_set_room ~success =
+  if success then
+    { next_steps =
+        [ s "masc_join" "Register your agent identity in the room";
+          s "masc_status" "Verify room state before proceeding" ];
+      preconditions = [];
+      common_mistakes =
+        [ "Starting work without masc_join — other agents cannot see you" ] }
+  else
+    { next_steps =
+        [ s "masc_init" "Initialize MASC if not yet set up";
+          s "masc_rooms_list" "Check available rooms" ];
+      preconditions = [];
+      common_mistakes = [] }
+
+let after_join ~success =
+  if success then
+    { next_steps =
+        [ s "masc_status" "Check current room state and available tasks";
+          s "masc_claim" "Claim an existing task if available";
+          s "masc_add_task" "Create a new task if none exist" ];
+      preconditions = [ "room_set" ];
+      common_mistakes =
+        [ "Skipping masc_status — you may duplicate work another agent claimed" ] }
+  else
+    { next_steps =
+        [ s "masc_set_room" "Set the room first";
+          s "masc_init" "Initialize MASC if not set up" ];
+      preconditions = [];
+      common_mistakes = [] }
+
+let after_status ~success =
+  if success then
+    { next_steps =
+        [ s "masc_claim" "Claim a task from the available list";
+          s "masc_add_task" "Add a new task if the list is empty";
+          s "masc_workflow_guide" "Get personalized guidance for your current state" ];
+      preconditions = [ "room_set"; "joined" ];
+      common_mistakes = [] }
+  else
+    { next_steps =
+        [ s "masc_set_room" "Ensure room is configured";
+          s "masc_join" "Join the room first" ];
+      preconditions = [];
+      common_mistakes = [] }
+
+let after_claim ~success =
+  if success then
+    { next_steps =
+        [ s "masc_plan_set_task" "Bind claimed task as your current_task — required before work";
+          s "masc_worktree_create" "Create an isolated worktree for this task" ];
+      preconditions = [ "room_set"; "joined" ];
+      common_mistakes =
+        [ "Starting work without masc_plan_set_task — current_task will be unset";
+          "Forgetting masc_worktree_create — working on main branch directly" ] }
+  else
+    { next_steps =
+        [ s "masc_status" "Check which tasks are available";
+          s "masc_add_task" "Create a task if none exist" ];
+      preconditions = [ "room_set"; "joined" ];
+      common_mistakes = [] }
+
+let after_add_task ~success =
+  if success then
+    { next_steps =
+        [ s "masc_claim" "Claim the task you just created";
+          s "masc_status" "Verify the task appears in the list" ];
+      preconditions = [ "room_set"; "joined" ];
+      common_mistakes =
+        [ "Creating a task without claiming it — another agent may take it" ] }
+  else
+    { next_steps =
+        [ s "masc_status" "Check room state for errors" ];
+      preconditions = [ "room_set"; "joined" ];
+      common_mistakes = [] }
+
+let after_plan_set_task ~success =
+  if success then
+    { next_steps =
+        [ s "masc_worktree_create" "Create worktree for isolated work";
+          s "masc_heartbeat" "Signal liveness before starting long work" ];
+      preconditions = [ "room_set"; "joined"; "task_claimed" ];
+      common_mistakes = [] }
+  else
+    { next_steps =
+        [ s "masc_claim" "Claim a task first";
+          s "masc_status" "Verify your claimed task exists" ];
+      preconditions = [ "room_set"; "joined" ];
+      common_mistakes =
+        [ "Calling plan_set_task without a claimed task" ] }
+
+let after_heartbeat ~success =
+  if success then
+    { next_steps =
+        [ s "masc_broadcast" "Share progress with other agents";
+          s "masc_done" "Mark task complete when finished" ];
+      preconditions = [ "room_set"; "joined" ];
+      common_mistakes = [] }
+  else
+    { next_steps =
+        [ s "masc_join" "Rejoin if session expired" ];
+      preconditions = [];
+      common_mistakes = [] }
+
+let after_done ~success =
+  if success then
+    { next_steps =
+        [ s "masc_status" "Check for remaining tasks";
+          s "masc_claim" "Pick up the next task";
+          s "masc_leave" "Leave room if all work is complete" ];
+      preconditions = [ "room_set"; "joined" ];
+      common_mistakes = [] }
+  else
+    { next_steps =
+        [ s "masc_status" "Check task state — it may already be completed" ];
+      preconditions = [ "room_set"; "joined" ];
+      common_mistakes = [] }
+
+(* ── Golden Path 2: CPv2 Direct ──────────────────────────────────── *)
+
+let after_operation_start ~success =
+  if success then
+    { next_steps =
+        [ s "masc_dispatch_tick" "Trigger the scheduler to advance the operation";
+          s "masc_observe_topology" "View the operation topology" ];
+      preconditions = [ "room_set"; "joined"; "unit_defined" ];
+      common_mistakes =
+        [ "Forgetting masc_dispatch_tick — the operation will not advance" ] }
+  else
+    { next_steps =
+        [ s "masc_unit_define" "Define organizational unit first";
+          s "masc_status" "Check room prerequisites" ];
+      preconditions = [ "room_set"; "joined" ];
+      common_mistakes = [] }
+
+let after_dispatch_tick ~success =
+  if success then
+    { next_steps =
+        [ s "masc_detachment_list" "Check materialized detachments";
+          s "masc_observe_operations" "Monitor operation progress";
+          s "masc_policy_status" "Review pending policy approvals" ];
+      preconditions = [ "room_set"; "joined"; "operation_active" ];
+      common_mistakes = [] }
+  else
+    { next_steps =
+        [ s "masc_operation_start" "Ensure an operation is active" ];
+      preconditions = [ "room_set"; "joined" ];
+      common_mistakes = [] }
+
+(* ── Golden Path 3: Team Session / Supervisor ────────────────────── *)
+
+let after_team_session_start ~success =
+  if success then
+    { next_steps =
+        [ s "masc_team_session_step" "Record the first session turn";
+          s "masc_team_session_status" "View session state" ];
+      preconditions = [ "room_set"; "joined" ];
+      common_mistakes =
+        [ "Not recording turns — the session has no audit trail" ] }
+  else
+    { next_steps =
+        [ s "masc_join" "Ensure you have joined the room";
+          s "masc_status" "Check room state" ];
+      preconditions = [ "room_set" ];
+      common_mistakes = [] }
+
+let after_team_session_step ~success =
+  if success then
+    { next_steps =
+        [ s "masc_team_session_step" "Record the next turn or spawn workers";
+          s "masc_team_session_status" "Review session progress";
+          s "masc_team_session_prove" "Generate collaboration evidence when ready" ];
+      preconditions = [ "room_set"; "joined"; "session_active" ];
+      common_mistakes = [] }
+  else
+    { next_steps =
+        [ s "masc_team_session_status" "Check session state for errors" ];
+      preconditions = [ "room_set"; "joined"; "session_active" ];
+      common_mistakes = [] }
+
+let after_team_session_prove ~success =
+  if success then
+    { next_steps =
+        [ s "masc_team_session_stop" "End the session after evidence is collected";
+          s "masc_done" "Mark the underlying task as complete" ];
+      preconditions = [ "room_set"; "joined"; "session_active" ];
+      common_mistakes = [] }
+  else
+    { next_steps =
+        [ s "masc_team_session_step" "Record more evidence before proving";
+          s "masc_team_session_status" "Check what evidence is missing" ];
+      preconditions = [ "room_set"; "joined"; "session_active" ];
+      common_mistakes = [] }
+
+(* ── Common tools ────────────────────────────────────────────────── *)
+
+let after_broadcast ~success =
+  if success then
+    { next_steps =
+        [ s "masc_heartbeat" "Keep your presence alive" ];
+      preconditions = [ "room_set"; "joined" ];
+      common_mistakes = [] }
+  else
+    { next_steps =
+        [ s "masc_join" "Ensure you are in the room" ];
+      preconditions = [ "room_set" ];
+      common_mistakes = [] }
+
+let after_worktree_create ~success =
+  if success then
+    { next_steps =
+        [ s "masc_heartbeat" "Signal liveness before starting work";
+          s "masc_broadcast" "Let other agents know you started work" ];
+      preconditions = [ "room_set"; "joined"; "task_claimed" ];
+      common_mistakes = [] }
+  else
+    { next_steps =
+        [ s "masc_plan_set_task" "Ensure current_task is set";
+          s "masc_status" "Check room configuration" ];
+      preconditions = [ "room_set"; "joined"; "task_claimed" ];
+      common_mistakes = [] }
+
+let after_init ~success =
+  if success then
+    { next_steps =
+        [ s "masc_set_room" "Set the room to your project root";
+          s "masc_join" "Join the room" ];
+      preconditions = [];
+      common_mistakes = [] }
+  else
+    { next_steps =
+        [ s "masc_status" "Check if MASC is already initialized" ];
+      preconditions = [];
+      common_mistakes = [] }
+
+let after_switch_mode ~success =
+  if success then
+    { next_steps =
+        [ s "masc_status" "Verify the new mode is active" ];
+      preconditions = [ "room_set"; "joined" ];
+      common_mistakes = [] }
+  else
+    { next_steps =
+        [ s "masc_tool_help" "Check available modes" ];
+      preconditions = [];
+      common_mistakes = [] }
+
+let after_operator_digest ~success =
+  if success then
+    { next_steps =
+        [ s "masc_operator_action" "Execute a suggested action from the digest";
+          s "masc_team_session_status" "Drill into a specific session" ];
+      preconditions = [ "room_set"; "joined"; "session_active" ];
+      common_mistakes =
+        [ "Reading the digest without acting on critical items" ] }
+  else
+    { next_steps =
+        [ s "masc_operator_snapshot" "Get raw state instead";
+          s "masc_status" "Check basic room state" ];
+      preconditions = [ "room_set"; "joined" ];
+      common_mistakes = [] }
+
+(* ── Main dispatch ───────────────────────────────────────────────── *)
+
+let next_steps ~tool_name ~success =
+  match tool_name with
+  (* Golden Path 1: Room/Task Hygiene *)
+  | "masc_set_room" -> after_set_room ~success
+  | "masc_join" -> after_join ~success
+  | "masc_status" -> after_status ~success
+  | "masc_claim" | "masc_claim_next" | "masc_claim_task" -> after_claim ~success
+  | "masc_add_task" | "masc_batch_add_tasks" -> after_add_task ~success
+  | "masc_plan_set_task" | "masc_set_current_task" -> after_plan_set_task ~success
+  | "masc_heartbeat" -> after_heartbeat ~success
+  | "masc_done" | "masc_complete_task" -> after_done ~success
+  (* Golden Path 2: CPv2 *)
+  | "masc_operation_start" -> after_operation_start ~success
+  | "masc_dispatch_tick" -> after_dispatch_tick ~success
+  (* Golden Path 3: Team Session *)
+  | "masc_team_session_start" -> after_team_session_start ~success
+  | "masc_team_session_step" -> after_team_session_step ~success
+  | "masc_team_session_prove" -> after_team_session_prove ~success
+  (* Common *)
+  | "masc_broadcast" -> after_broadcast ~success
+  | "masc_worktree_create" -> after_worktree_create ~success
+  | "masc_init" -> after_init ~success
+  | "masc_switch_mode" -> after_switch_mode ~success
+  | "masc_operator_digest" -> after_operator_digest ~success
+  (* No guidance registered *)
+  | _ -> empty
+
+(* ── JSON serialisation ──────────────────────────────────────────── *)
+
+let step_to_json { tool; reason } =
+  `Assoc [ ("tool", `String tool); ("reason", `String reason) ]
+
+let guidance_to_json g =
+  match g.next_steps with
+  | [] -> `Null
+  | steps ->
+      let fields =
+        [ ("next_steps", `List (List.map step_to_json steps)) ]
+      in
+      let fields =
+        match g.preconditions with
+        | [] -> fields
+        | ps -> fields @ [ ("preconditions", `List (List.map (fun p -> `String p) ps)) ]
+      in
+      let fields =
+        match g.common_mistakes with
+        | [] -> fields
+        | ms -> fields @ [ ("common_mistakes", `List (List.map (fun m -> `String m) ms)) ]
+      in
+      `Assoc fields
+
+(* ── Workflow context for tool help ──────────────────────────────── *)
+
+(** Returns (before_tools, after_tools, common_mistakes) for a given tool.
+    Used by tool_help_registry to enrich help responses. *)
+let workflow_context ~tool_name =
+  let before = match tool_name with
+    | "masc_join" -> [ "masc_set_room" ]
+    | "masc_status" -> [ "masc_set_room"; "masc_join" ]
+    | "masc_claim" | "masc_claim_next" | "masc_claim_task" ->
+        [ "masc_join"; "masc_status" ]
+    | "masc_plan_set_task" | "masc_set_current_task" ->
+        [ "masc_claim" ]
+    | "masc_worktree_create" ->
+        [ "masc_plan_set_task" ]
+    | "masc_heartbeat" ->
+        [ "masc_join" ]
+    | "masc_done" | "masc_complete_task" ->
+        [ "masc_plan_set_task" ]
+    | "masc_operation_start" ->
+        [ "masc_unit_define" ]
+    | "masc_dispatch_tick" ->
+        [ "masc_operation_start" ]
+    | "masc_team_session_start" ->
+        [ "masc_join" ]
+    | "masc_team_session_step" ->
+        [ "masc_team_session_start" ]
+    | "masc_team_session_prove" ->
+        [ "masc_team_session_step" ]
+    | "masc_team_session_stop" ->
+        [ "masc_team_session_prove" ]
+    | "masc_operator_digest" ->
+        [ "masc_team_session_start" ]
+    | _ -> []
+  in
+  let after_g = next_steps ~tool_name ~success:true in
+  let after = List.map (fun s -> s.tool) after_g.next_steps in
+  let mistakes = after_g.common_mistakes in
+  match before, after, mistakes with
+  | [], [], [] -> None
+  | _ -> Some (before, after, mistakes)
+
+(* ── State-based guidance (for masc_workflow_guide tool) ──────────── *)
+
+let current_state_guidance ~room_set ~joined ~task_claimed
+    ~current_task_set ~worktree_active ~session_active =
+  if not room_set then
+    { next_steps =
+        [ s "masc_set_room" "Set the room to your project root (repo root)";
+          s "masc_init" "Initialize MASC if this is a fresh setup" ];
+      preconditions = [];
+      common_mistakes =
+        [ "Calling any MASC tool without setting a room first" ] }
+  else if not joined then
+    { next_steps =
+        [ s "masc_join" "Register your agent identity in the room" ];
+      preconditions = [ "room_set" ];
+      common_mistakes =
+        [ "Operating without joining — other agents cannot see or coordinate with you" ] }
+  else if not task_claimed then
+    { next_steps =
+        [ s "masc_status" "Check available tasks";
+          s "masc_claim" "Claim an existing task";
+          s "masc_add_task" "Create a new task if none exist" ];
+      preconditions = [ "room_set"; "joined" ];
+      common_mistakes =
+        [ "Modifying code without a claimed task — changes are untracked" ] }
+  else if not current_task_set then
+    { next_steps =
+        [ s "masc_plan_set_task" "Bind your claimed task as current_task" ];
+      preconditions = [ "room_set"; "joined"; "task_claimed" ];
+      common_mistakes =
+        [ "masc_claim alone does not set current_task — you must call masc_plan_set_task" ] }
+  else if not worktree_active then
+    { next_steps =
+        [ s "masc_worktree_create" "Create an isolated git worktree for this task";
+          s "masc_heartbeat" "Signal liveness if worktree is not needed" ];
+      preconditions = [ "room_set"; "joined"; "task_claimed"; "current_task_set" ];
+      common_mistakes =
+        [ "Working directly on main branch without a worktree" ] }
+  else if session_active then
+    { next_steps =
+        [ s "masc_team_session_step" "Record the next turn in your session";
+          s "masc_team_session_status" "Check session progress";
+          s "masc_heartbeat" "Keep your presence alive during work" ];
+      preconditions = [ "room_set"; "joined"; "task_claimed"; "current_task_set"; "worktree_active"; "session_active" ];
+      common_mistakes = [] }
+  else
+    { next_steps =
+        [ s "masc_heartbeat" "Signal liveness while working";
+          s "masc_broadcast" "Share progress with teammates";
+          s "masc_done" "Mark task complete when finished" ];
+      preconditions = [ "room_set"; "joined"; "task_claimed"; "current_task_set"; "worktree_active" ];
+      common_mistakes = [] }

--- a/lib/workflow_guide.mli
+++ b/lib/workflow_guide.mli
@@ -1,0 +1,50 @@
+(** Workflow Guidance — encodes Golden Path sequences so agents know
+    "what to do next" without reading documentation.
+
+    Each tool call returns structured next_steps based on the tool name
+    and whether the call succeeded. This data is injected into the MCP
+    response envelope as an additive field.
+
+    @since 2.89.0 *)
+
+(** A single suggested next action. *)
+type step = {
+  tool : string;
+  reason : string;
+}
+
+(** Guidance returned for a tool invocation. *)
+type guidance = {
+  next_steps : step list;
+  preconditions : string list;
+  common_mistakes : string list;
+}
+
+(** [next_steps ~tool_name ~success] returns workflow guidance for the
+    tool that was just called.  When [success] is false the guidance
+    focuses on recovery / prerequisite steps. *)
+val next_steps : tool_name:string -> success:bool -> guidance
+
+(** [guidance_to_json g] serialises guidance to a Yojson value suitable
+    for embedding in the MCP response envelope. *)
+val guidance_to_json : guidance -> Yojson.Safe.t
+
+(** [workflow_context ~tool_name] returns before/after/common_mistakes
+    context for use in tool help responses.  Returns [None] for tools
+    that have no registered workflow context. *)
+val workflow_context :
+  tool_name:string ->
+  (string list * string list * string list) option
+
+(** [current_state_guidance ~room_set ~joined ~task_claimed
+     ~current_task_set ~worktree_active ~session_active] returns
+    the next recommended steps based on the agent's current state.
+    Used by the [masc_workflow_guide] tool. *)
+val current_state_guidance :
+  room_set:bool ->
+  joined:bool ->
+  task_claimed:bool ->
+  current_task_set:bool ->
+  worktree_active:bool ->
+  session_active:bool ->
+  guidance

--- a/test/dune
+++ b/test/dune
@@ -917,3 +917,9 @@
  (name test_build_identity)
  (modules test_build_identity)
  (libraries masc_mcp alcotest unix))
+
+; Workflow guidance — Golden Path encoding and next_steps
+(test
+ (name test_workflow_guide)
+ (modules test_workflow_guide)
+ (libraries masc_mcp alcotest yojson))

--- a/test/test_workflow_guide.ml
+++ b/test/test_workflow_guide.ml
@@ -1,0 +1,201 @@
+(** Tests for Workflow_guide — Golden Path encoding and next_steps. *)
+
+(* Use canonical prefix due to OCaml 5.x -H flag interaction *)
+module WG = Masc_mcp__Workflow_guide
+
+open Alcotest
+
+(* ── Helpers ─────────────────────────────────────────────────────── *)
+
+let check_has_tool steps tool_name =
+  let found =
+    List.exists
+      (fun (s : WG.step) -> s.tool = tool_name)
+      steps
+  in
+  check bool (Printf.sprintf "next_steps contains %s" tool_name) true found
+
+let check_not_empty msg steps =
+  check bool msg true (List.length steps > 0)
+
+(* ── Golden Path 1: Room/Task Hygiene ────────────────────────────── *)
+
+let test_set_room_success () =
+  let g = WG.next_steps ~tool_name:"masc_set_room" ~success:true in
+  check_not_empty "set_room success has next_steps" g.next_steps;
+  check_has_tool g.next_steps "masc_join"
+
+let test_set_room_failure () =
+  let g = WG.next_steps ~tool_name:"masc_set_room" ~success:false in
+  check_not_empty "set_room failure has recovery steps" g.next_steps;
+  check_has_tool g.next_steps "masc_init"
+
+let test_join_success () =
+  let g = WG.next_steps ~tool_name:"masc_join" ~success:true in
+  check_has_tool g.next_steps "masc_status";
+  check_has_tool g.next_steps "masc_claim";
+  check bool "join has preconditions" true (List.length g.preconditions > 0)
+
+let test_join_failure () =
+  let g = WG.next_steps ~tool_name:"masc_join" ~success:false in
+  check_has_tool g.next_steps "masc_set_room"
+
+let test_claim_success () =
+  let g = WG.next_steps ~tool_name:"masc_claim" ~success:true in
+  check_has_tool g.next_steps "masc_plan_set_task";
+  check bool "claim has common_mistakes" true (List.length g.common_mistakes > 0)
+
+let test_plan_set_task_success () =
+  let g = WG.next_steps ~tool_name:"masc_plan_set_task" ~success:true in
+  check_has_tool g.next_steps "masc_worktree_create"
+
+let test_done_success () =
+  let g = WG.next_steps ~tool_name:"masc_done" ~success:true in
+  check_has_tool g.next_steps "masc_status";
+  check_has_tool g.next_steps "masc_claim"
+
+(* ── Golden Path 2: CPv2 ─────────────────────────────────────────── *)
+
+let test_operation_start_success () =
+  let g = WG.next_steps ~tool_name:"masc_operation_start" ~success:true in
+  check_has_tool g.next_steps "masc_dispatch_tick"
+
+let test_dispatch_tick_success () =
+  let g = WG.next_steps ~tool_name:"masc_dispatch_tick" ~success:true in
+  check_has_tool g.next_steps "masc_detachment_list"
+
+(* ── Golden Path 3: Team Session ─────────────────────────────────── *)
+
+let test_team_session_start_success () =
+  let g = WG.next_steps ~tool_name:"masc_team_session_start" ~success:true in
+  check_has_tool g.next_steps "masc_team_session_step"
+
+let test_team_session_prove_success () =
+  let g = WG.next_steps ~tool_name:"masc_team_session_prove" ~success:true in
+  check_has_tool g.next_steps "masc_team_session_stop"
+
+(* ── Unknown tools return empty guidance ─────────────────────────── *)
+
+let test_unknown_tool () =
+  let g = WG.next_steps ~tool_name:"masc_nonexistent_tool" ~success:true in
+  check (list string) "unknown tool returns empty next_steps" []
+    (List.map (fun (s : WG.step) -> s.tool) g.next_steps)
+
+(* ── JSON serialization ──────────────────────────────────────────── *)
+
+let test_guidance_to_json_null_for_empty () =
+  let g = WG.next_steps ~tool_name:"masc_nonexistent" ~success:true in
+  let json = WG.guidance_to_json g in
+  check bool "empty guidance serializes to Null" true (json = `Null)
+
+let test_guidance_to_json_has_next_steps () =
+  let g = WG.next_steps ~tool_name:"masc_join" ~success:true in
+  let json = WG.guidance_to_json g in
+  match json with
+  | `Assoc fields ->
+      check bool "JSON has next_steps field" true (List.mem_assoc "next_steps" fields)
+  | _ -> fail "Expected Assoc for non-empty guidance"
+
+(* ── Workflow context for tool help ──────────────────────────────── *)
+
+let test_workflow_context_join () =
+  match WG.workflow_context ~tool_name:"masc_join" with
+  | Some (before, after, _mistakes) ->
+      check bool "join before includes set_room" true
+        (List.mem "masc_set_room" before);
+      check bool "join after is non-empty" true (List.length after > 0)
+  | None -> fail "Expected workflow context for masc_join"
+
+let test_workflow_context_unknown () =
+  let ctx = WG.workflow_context ~tool_name:"masc_nonexistent" in
+  check bool "unknown tool has no workflow context" true (ctx = None)
+
+(* ── State-based guidance ────────────────────────────────────────── *)
+
+let test_state_not_room_set () =
+  let g = WG.current_state_guidance
+    ~room_set:false ~joined:false ~task_claimed:false
+    ~current_task_set:false ~worktree_active:false ~session_active:false
+  in
+  check_has_tool g.next_steps "masc_set_room"
+
+let test_state_room_set_not_joined () =
+  let g = WG.current_state_guidance
+    ~room_set:true ~joined:false ~task_claimed:false
+    ~current_task_set:false ~worktree_active:false ~session_active:false
+  in
+  check_has_tool g.next_steps "masc_join"
+
+let test_state_joined_no_task () =
+  let g = WG.current_state_guidance
+    ~room_set:true ~joined:true ~task_claimed:false
+    ~current_task_set:false ~worktree_active:false ~session_active:false
+  in
+  check_has_tool g.next_steps "masc_claim"
+
+let test_state_task_claimed_no_current () =
+  let g = WG.current_state_guidance
+    ~room_set:true ~joined:true ~task_claimed:true
+    ~current_task_set:false ~worktree_active:false ~session_active:false
+  in
+  check_has_tool g.next_steps "masc_plan_set_task"
+
+let test_state_ready_to_work () =
+  let g = WG.current_state_guidance
+    ~room_set:true ~joined:true ~task_claimed:true
+    ~current_task_set:true ~worktree_active:true ~session_active:false
+  in
+  check_has_tool g.next_steps "masc_heartbeat"
+
+(* ── Alias coverage ──────────────────────────────────────────────── *)
+
+let test_claim_next_alias () =
+  let g = WG.next_steps ~tool_name:"masc_claim_next" ~success:true in
+  check_has_tool g.next_steps "masc_plan_set_task"
+
+let test_complete_task_alias () =
+  let g = WG.next_steps ~tool_name:"masc_complete_task" ~success:true in
+  check_has_tool g.next_steps "masc_status"
+
+(* ── Test runner ─────────────────────────────────────────────────── *)
+
+let () =
+  run "Workflow_guide" [
+    "golden_path_1", [
+      test_case "set_room success" `Quick test_set_room_success;
+      test_case "set_room failure" `Quick test_set_room_failure;
+      test_case "join success" `Quick test_join_success;
+      test_case "join failure" `Quick test_join_failure;
+      test_case "claim success" `Quick test_claim_success;
+      test_case "plan_set_task success" `Quick test_plan_set_task_success;
+      test_case "done success" `Quick test_done_success;
+    ];
+    "golden_path_2", [
+      test_case "operation_start success" `Quick test_operation_start_success;
+      test_case "dispatch_tick success" `Quick test_dispatch_tick_success;
+    ];
+    "golden_path_3", [
+      test_case "team_session_start success" `Quick test_team_session_start_success;
+      test_case "team_session_prove success" `Quick test_team_session_prove_success;
+    ];
+    "edge_cases", [
+      test_case "unknown tool" `Quick test_unknown_tool;
+      test_case "claim_next alias" `Quick test_claim_next_alias;
+      test_case "complete_task alias" `Quick test_complete_task_alias;
+    ];
+    "json", [
+      test_case "null for empty" `Quick test_guidance_to_json_null_for_empty;
+      test_case "has next_steps" `Quick test_guidance_to_json_has_next_steps;
+    ];
+    "workflow_context", [
+      test_case "join context" `Quick test_workflow_context_join;
+      test_case "unknown context" `Quick test_workflow_context_unknown;
+    ];
+    "state_guidance", [
+      test_case "not room set" `Quick test_state_not_room_set;
+      test_case "room set not joined" `Quick test_state_room_set_not_joined;
+      test_case "joined no task" `Quick test_state_joined_no_task;
+      test_case "task claimed no current" `Quick test_state_task_claimed_no_current;
+      test_case "ready to work" `Quick test_state_ready_to_work;
+    ];
+  ]


### PR DESCRIPTION
## Summary

- **Workflow Guidance Layer (Phase 1)**: 모든 Essential 도구 응답에 `workflow_guidance` 필드 추가. 에이전트가 문서를 읽지 않아도 다음 단계를 알 수 있음
- **Verification Signals (Phase 2)**: `masc_check` 도구로 assertion 기반 상태 검증. `["room_set", "joined", "task_claimed"]` → pass/fail + fix_hint
- **Tool Help Enhancement (Phase 5)**: `masc_tool_help` 응답에 before/after/common_mistakes workflow context 추가

### 새 도구
| 도구 | 용도 |
|------|------|
| `masc_workflow_guide` | 현재 상태 기반 "다음에 뭘 해야 하는지" 안내 |
| `masc_check` | assertion 리스트로 상태 검증 + fix_hint |

### 설계 원칙
- **Additive only**: 기존 응답 구조 불변. 새 필드만 추가 (backward compatible)
- **단일 데이터 소스**: `workflow_guide.ml`이 Golden Path 3개를 인코딩, Phase 1/2/5가 공유
- **Agent SDK Workshop 원칙**: Progressive Context Disclosure, Gather→Act→Verify loop

### Golden Path 인코딩
1. **Room/Task Hygiene**: set_room → join → status → claim → plan_set_task → worktree → heartbeat → done
2. **CPv2 Direct**: unit_define → operation_start → dispatch_tick → observe → policy → finalize
3. **Team Session**: start → step → prove → stop

## Test plan
- [x] 23개 Alcotest 테스트 통과 (Golden Path 1/2/3, edge cases, JSON, state guidance)
- [x] `dune build` 성공
- [x] `make test` exit code 0 (기존 테스트 전체 통과)
- [ ] 교차 모델 리뷰

🤖 Generated with [Claude Code](https://claude.com/claude-code)