### PR TITLE
fix(swarm): enable local HTTP/1.1 swarm harness execution

### DIFF
--- a/lib/agent_swarm_client.ml
+++ b/lib/agent_swarm_client.ml
@@ -145,13 +145,13 @@ let leave ~sw t =
     ~arguments:[("agent_name", `String t.agent_name)]
 
 let status ~sw t =
-  call_operation_assoc ~sw t ~operation_id:"masc_status"
+  call_operation_assoc ~sw t ~operation_id:"masc_room_status"
     ~arguments:[]
 
 (* --- Task operations --- *)
 
 let list_tasks ~sw t =
-  call_operation_assoc ~sw t ~operation_id:"masc_tasks"
+  call_operation_assoc ~sw t ~operation_id:"masc_list_tasks"
     ~arguments:[]
 
 let add_task ~sw t ~title ~description =
@@ -174,10 +174,8 @@ let batch_add_tasks ~sw t ~tasks =
     ~arguments:[("tasks", tasks_json)]
 
 let claim ~sw t ~task_id =
-  call_operation_assoc ~sw t ~operation_id:"masc_transition"
+  call_operation_assoc ~sw t ~operation_id:"masc_claim_task"
     ~arguments:[
-      ("action", `String "claim");
-      ("agent_name", `String t.agent_name);
       ("task_id", `String task_id);
     ]
 
@@ -186,32 +184,26 @@ let claim_next ~sw t =
     ~arguments:[("agent_name", `String t.agent_name)]
 
 let set_current_task ~sw t ~task_id =
-  call_operation_assoc ~sw t ~operation_id:"masc_plan_set_task"
+  call_operation_assoc ~sw t ~operation_id:"masc_set_current_task"
     ~arguments:[
       ("task_id", `String task_id);
     ]
 
 let done_task ~sw t ~task_id =
-  call_operation_assoc ~sw t ~operation_id:"masc_transition"
+  call_operation_assoc ~sw t ~operation_id:"masc_complete_task"
     ~arguments:[
-      ("action", `String "done");
-      ("agent_name", `String t.agent_name);
       ("task_id", `String task_id);
     ]
 
 let release_task ~sw t ~task_id =
-  call_operation_assoc ~sw t ~operation_id:"masc_transition"
+  call_operation_assoc ~sw t ~operation_id:"masc_release_task"
     ~arguments:[
-      ("action", `String "release");
-      ("agent_name", `String t.agent_name);
       ("task_id", `String task_id);
     ]
 
 let cancel_task ~sw t ~task_id ~reason =
-  call_operation_assoc ~sw t ~operation_id:"masc_transition"
+  call_operation_assoc ~sw t ~operation_id:"masc_cancel_task"
     ~arguments:[
-      ("action", `String "cancel");
-      ("agent_name", `String t.agent_name);
       ("task_id", `String task_id);
       ("reason", `String reason);
     ]
@@ -228,10 +220,9 @@ let broadcast ~sw t ~message =
 (** Send a direct message to a specific agent. Unlike broadcast (room-wide),
     this is private 1:1 delivery. *)
 let send_direct ~sw t ~target ~message =
-  call_operation_assoc ~sw t ~operation_id:"masc_a2a_delegate"
+  call_operation_assoc ~sw t ~operation_id:"masc_send_direct"
     ~arguments:[
       ("target_agent", `String target);
-      ("task_type", `String "async");
       ("message", `String message);
     ]
 

--- a/lib/agent_swarm_live_harness.ml
+++ b/lib/agent_swarm_live_harness.ml
@@ -311,8 +311,31 @@ let manifest_json cfg =
       ("workers", `List workers);
     ]
 
+let seed_tasks ~sw ~net ~masc_url plans =
+  let coordinator =
+    Agent_swarm_client.create_managed ~net ~base_url:masc_url
+      ~agent_name:"swarm-coordinator"
+  in
+  (match Agent_swarm_client.join ~sw coordinator with
+   | Error e ->
+       Printf.eprintf "[swarm-coordinator] MASC join warning: %s\n%!" e
+   | Ok _ -> ());
+  let tasks =
+    List.map
+      (fun (plan : worker_plan) -> (plan.task_title, plan.task_description))
+      plans
+  in
+  (match Agent_swarm_client.batch_add_tasks ~sw coordinator ~tasks with
+   | Error e ->
+       Printf.eprintf "[swarm-coordinator] batch_add_tasks warning: %s\n%!" e
+   | Ok _ ->
+       Printf.eprintf "[swarm-coordinator] seeded %d tasks\n%!"
+         (List.length tasks));
+  ignore (Agent_swarm_client.leave ~sw coordinator)
+
 let run ~sw ~net ~clock cfg =
   let plans = build_worker_plans ~worker_count:cfg.worker_count cfg.run_id in
+  seed_tasks ~sw ~net ~masc_url:cfg.masc_url plans;
   let swarm_config =
     {
       Agent_swarm_swarm.masc_url = cfg.masc_url;

--- a/lib/server_routes_http_routes_frontend.ml
+++ b/lib/server_routes_http_routes_frontend.ml
@@ -113,6 +113,7 @@ let add_routes ~port ~host router =
   |> Http.Router.get "/mcp/operator" handle_get_operator_mcp
   |> Http.Router.post "/" handle_post_mcp
   |> Http.Router.post "/mcp" handle_post_mcp
+  |> Http.Router.post "/mcp/managed" (handle_post_mcp ~profile:Mcp_eio.Managed_agent)
   |> Http.Router.post "/mcp/operator" (handle_post_mcp ~profile:Mcp_eio.Operator_remote)
   |> Http.Router.add ~path:"/graphql" ~methods:[`GET; `POST]
        ~handler:(fun request reqd ->


### PR DESCRIPTION
## Summary
- POST `/mcp/managed` 라우트를 HTTP/1.1 서버에 추가 (H2 gateway에만 존재하던 누락 수정)
- `agent_swarm_client.ml`의 tool operation ID를 managed profile SDK alias로 전환 (`masc_tasks` → `masc_list_tasks`, `masc_transition` → `masc_claim_task`/`masc_complete_task` 등)
- `agent_swarm_live_harness.ml`에 `seed_tasks` coordinator 추가 — worker 실행 전 task를 MASC room에 사전 등록

## Test plan
- [x] `dune build` 성공
- [x] smoke-test: `--worker-count 2 --max-turns 3` → status: ok, 2/2 workers 완료, 2/2 FINAL_MARKER 자체 생성
- [ ] 기존 테스트 (`dune runtest`) 통과 확인 필요

Generated with [Claude Code](https://claude.com/claude-code)