### PR TITLE
fix: harden bugbash runtime and harness flows

### DIFF
--- a/lib/tool_llama.ml
+++ b/lib/tool_llama.ml
@@ -316,6 +316,51 @@ let string_member json key =
   let open Yojson.Safe.Util in
   Option.bind (member key json |> to_string_option) trim_to_option
 
+let provider_health_reachable ~status ~body:_ =
+  (* Reachability should reflect whether the health endpoint answered
+     successfully, not the exact body encoding. Current runtimes return either
+     plain text or JSON payloads for /health. *)
+  status = Some 200
+
+let classify_runtime_blocker ~provider_reachable ~slot_reachable ~expected_model
+    ~actual_model_id ~expected_slots ~actual_slots_total ~expected_ctx ~actual_ctx
+    =
+  if not provider_reachable || not slot_reachable then
+    (Some "provider_unreachable", Some "llama runtime health or slots endpoint failed")
+  else if
+    match expected_model, actual_model_id with
+    | Some expected, Some actual -> not (String.equal expected actual)
+    | Some _, None -> true
+    | _ -> false
+  then
+    ( Some "provider_model_mismatch",
+      Some
+        (Printf.sprintf "expected model %s, got %s"
+           (Option.value ~default:"<missing>" expected_model)
+           (Option.value ~default:"<mixed-or-missing>" actual_model_id)) )
+  else if
+    match expected_slots with
+    | Some expected -> actual_slots_total < expected
+    | None -> false
+  then
+    ( Some "slot_count_insufficient",
+      Some
+        (Printf.sprintf "expected at least %d slots, got %d"
+           (Option.value ~default:0 expected_slots) actual_slots_total) )
+  else if
+    match expected_ctx, actual_ctx with
+    | Some expected, Some actual -> expected <> actual
+    | Some _, None -> true
+    | _ -> false
+  then
+    ( Some "ctx_mismatch",
+      Some
+        (Printf.sprintf "expected ctx %s, got %s"
+           (match expected_ctx with Some value -> string_of_int value | None -> "<none>")
+           (match actual_ctx with Some value -> string_of_int value | None -> "<mixed-or-missing>")) )
+  else
+    (None, None)
+
 let runtime_verify_json ?runtime_pool ?expected_slots ?expected_ctx ?expected_model () =
   let runtimes = runtime_snapshots_for_pool runtime_pool in
   let configured_capacity =
@@ -361,8 +406,7 @@ let runtime_verify_json ?runtime_pool ?expected_slots ?expected_ctx ?expected_mo
         in
         let provider_ok' =
           provider_ok
-          && provider_status = Some 200
-          && (match provider_body with Some body -> String.trim body = "ok" | None -> false)
+          && provider_health_reachable ~status:provider_status ~body:provider_body
         in
         let slot_ok' = slot_ok && slot_status = Some 200 in
         let actual_slots =
@@ -428,41 +472,8 @@ let runtime_verify_json ?runtime_pool ?expected_slots ?expected_ctx ?expected_mo
     | _ -> None
   in
   let runtime_blocker, detail =
-    if not provider_reachable || not slot_reachable then
-      (Some "provider_unreachable", Some "llama runtime health or slots endpoint failed")
-    else if
-      match expected_model, actual_model_id with
-      | Some expected, Some actual -> not (String.equal expected actual)
-      | Some _, None -> true
-      | _ -> false
-    then
-      ( Some "provider_model_mismatch",
-        Some
-          (Printf.sprintf "expected model %s, got %s"
-             (Option.value ~default:"<missing>" expected_model)
-             (Option.value ~default:"<mixed-or-missing>" actual_model_id)) )
-    else if
-      match expected_slots with
-      | Some expected -> actual_slots_total < expected
-      | None -> false
-    then
-      ( Some "slot_count_insufficient",
-        Some
-          (Printf.sprintf "expected at least %d slots, got %d"
-             (Option.value ~default:0 expected_slots) actual_slots_total) )
-    else if
-      match expected_ctx, actual_ctx with
-      | Some expected, Some actual -> expected <> actual
-      | Some _, None -> true
-      | _ -> false
-    then
-      ( Some "ctx_mismatch",
-        Some
-          (Printf.sprintf "expected ctx %s, got %s"
-             (match expected_ctx with Some value -> string_of_int value | None -> "<none>")
-             (match actual_ctx with Some value -> string_of_int value | None -> "<mixed-or-missing>")) )
-    else
-      (None, None)
+    classify_runtime_blocker ~provider_reachable ~slot_reachable ~expected_model
+      ~actual_model_id ~expected_slots ~actual_slots_total ~expected_ctx ~actual_ctx
   in
   `Assoc
     [

--- a/lib/tool_lodge_agents_cache.ml
+++ b/lib/tool_lodge_agents_cache.ml
@@ -417,9 +417,9 @@ let record_feedback ~name ~dimension ~is_positive =
 (** Initialize Lodge module after Eio context is ready.
     Call from main_eio.ml after Eio_context.set_net *)
 let init () =
-  if Env_config.LodgeV2.enabled then
-    (* Load agents for evolution triggers *)
-    load_agents_config ()
+  (* load_agents_config already handles the Lodge-disabled path by priming
+     builtin identities without touching GraphQL or file cache. *)
+  load_agents_config ()
 
 (** Module initialization - only register callbacks (no network calls) *)
 let () =

--- a/lib/tool_lodge_agents_cache.ml
+++ b/lib/tool_lodge_agents_cache.ml
@@ -207,9 +207,18 @@ let load_agents_from_cache_if_available () =
   else
     false
 
+let prime_builtin_core_agents () =
+  Mutex.lock agent_cache_mu;
+  List.iter
+    (fun cfg -> Hashtbl.replace agent_cache cfg.name cfg)
+    (builtin_core_agent_configs ());
+  Mutex.unlock agent_cache_mu
+
 (** Load agents from Neo4j via GraphQL API with file cache fallback *)
 let load_agents_config () =
-  if load_agents_from_cache_if_available () then begin
+  if not Env_config.LodgeV2.enabled then begin
+    if not (has_cached_agents_in_memory ()) then prime_builtin_core_agents ()
+  end else if load_agents_from_cache_if_available () then begin
     Printf.eprintf "[Lodge] Using cached agents (skipping GraphQL bootstrap)\n%!";
   end else begin
     Printf.eprintf "[Lodge] Loading agents from GraphQL...\n%!";
@@ -271,9 +280,7 @@ let load_agents_config () =
       Printf.eprintf "[Lodge] Trying file cache fallback...\n%!";
       if not (load_agents_from_file_cache ()) then begin
         Printf.eprintf "[Lodge] Falling back to builtin core identities\n%!";
-        Mutex.lock agent_cache_mu;
-        List.iter (fun cfg -> Hashtbl.replace agent_cache cfg.name cfg) (builtin_core_agent_configs ());
-        Mutex.unlock agent_cache_mu;
+        prime_builtin_core_agents ();
       end;
       if not (has_cached_agents_in_memory ()) then
         Printf.eprintf "[Lodge] ⚠ No agents available (GraphQL failed, no valid cache)\n%!"
@@ -410,8 +417,9 @@ let record_feedback ~name ~dimension ~is_positive =
 (** Initialize Lodge module after Eio context is ready.
     Call from main_eio.ml after Eio_context.set_net *)
 let init () =
-  (* Load agents for evolution triggers *)
-  load_agents_config ()
+  if Env_config.LodgeV2.enabled then
+    (* Load agents for evolution triggers *)
+    load_agents_config ()
 
 (** Module initialization - only register callbacks (no network calls) *)
 let () =

--- a/scripts/harness/lib/server_bootstrap.sh
+++ b/scripts/harness/lib/server_bootstrap.sh
@@ -85,6 +85,7 @@ harness_start_server() {
   local base_path="$3"
   local log_file="$4"
 
+  mkdir -p "$base_path"
   (
     export ME_ROOT="$base_path"
     export MASC_BASE_PATH="$base_path"

--- a/scripts/harness/workload/supervisor_team_session.sh
+++ b/scripts/harness/workload/supervisor_team_session.sh
@@ -367,9 +367,15 @@ llama_models_raw="$(call_tool "$MCP_URL" "$SUPERVISOR_SESSION_ID" "$SUPERVISOR_T
 require_tool_success "$llama_models_raw"
 llama_models_result="$(printf '%s' "$llama_models_raw" | extract_tool_result)"
 if [ -z "$LLAMA_SWARM_MODEL" ]; then
-  echo "FAIL: LLAMA_SWARM_MODEL is required; available models:"
-  printf '%s\n' "$llama_models_result" | jq -r '.models[]?'
-  exit 1
+  single_model="$(printf '%s\n' "$llama_models_result" | jq -r 'if (.models | length) == 1 then .models[0] else "" end')"
+  if [ -n "$single_model" ]; then
+    LLAMA_SWARM_MODEL="$single_model"
+    printf 'auto-selected single llama model: %s\n' "$LLAMA_SWARM_MODEL"
+  else
+    echo "FAIL: LLAMA_SWARM_MODEL is required; available models:"
+    printf '%s\n' "$llama_models_result" | jq -r '.models[]?'
+    exit 1
+  fi
 fi
 if ! printf '%s' "$llama_models_result" | jq -e --arg model "$LLAMA_SWARM_MODEL" '.models | index($model) != null' >/dev/null; then
   echo "FAIL: LLAMA_SWARM_MODEL not present in inventory: $LLAMA_SWARM_MODEL"

--- a/scripts/harness_team_session_local64_smoke.sh
+++ b/scripts/harness_team_session_local64_smoke.sh
@@ -102,12 +102,15 @@ if [ "$MCP_URL" = "http://127.0.0.1:${PORT}/mcp" ]; then
     DUNE_SOURCEROOT="${DUNE_SOURCEROOT:-$ROOT_DIR}" \
     MASC_STORAGE_TYPE=filesystem \
     MASC_BASE_PATH="$BASE_PATH" \
+    MASC_SENTINEL_ENABLED=false \
     MASC_GUARDIAN_ENABLED=false \
+    MASC_GARDENER_ENABLED=false \
     MASC_ORCHESTRATOR_ENABLED=false \
     MASC_LODGE_ENABLED=false \
     MASC_LODGE_DAEMON_ENABLED=false \
     MASC_LODGE_NEO4J_ENABLED=false \
     GRAPHQL_API_KEY="" \
+    GRAPHQL_URL="http://127.0.0.1:9/graphql" \
     "$SERVER_EXE" --port "$PORT" --base-path "$BASE_PATH" >"$LOG_FILE" 2>&1 &
   SERVER_PID="$!"
   if ! wait_for_health; then

--- a/test/dune
+++ b/test/dune
@@ -118,6 +118,11 @@
  (modules test_capability_registry)
  (libraries masc_mcp alcotest yojson))
 
+(test
+ (name test_tool_llama_runtime_verify)
+ (modules test_tool_llama_runtime_verify)
+ (libraries masc_mcp alcotest yojson))
+
 ; Voice tool wrapper tests
 (test
  (name test_tool_voice)

--- a/test/test_tool_llama_runtime_verify.ml
+++ b/test/test_tool_llama_runtime_verify.ml
@@ -1,0 +1,43 @@
+open Alcotest
+
+let test_provider_health_reachable_accepts_json_health () =
+  check bool "json health body counts as reachable" true
+    (Masc_mcp.Tool_llama.provider_health_reachable ~status:(Some 200)
+       ~body:(Some {|{"status":"ok"}|}));
+  check bool "plain text health body counts as reachable" true
+    (Masc_mcp.Tool_llama.provider_health_reachable ~status:(Some 200)
+       ~body:(Some "ok"));
+  check bool "non-200 is unreachable" false
+    (Masc_mcp.Tool_llama.provider_health_reachable ~status:(Some 503)
+       ~body:(Some {|{"status":"error"}|}))
+
+let test_classify_runtime_blocker_prefers_slot_count_when_health_ok () =
+  let blocker, detail =
+    Masc_mcp.Tool_llama.classify_runtime_blocker ~provider_reachable:true
+      ~slot_reachable:true
+      ~expected_model:(Some "qwen3.5-35b-a3b-ud-q8-xl")
+      ~actual_model_id:(Some "qwen3.5-35b-a3b-ud-q8-xl")
+      ~expected_slots:(Some 12) ~actual_slots_total:4
+      ~expected_ctx:(Some 262144) ~actual_ctx:(Some 262144)
+  in
+  check (option string) "slot blocker" (Some "slot_count_insufficient")
+    blocker;
+  check bool "detail mentions expected slots" true
+    (match detail with
+    | Some msg -> String.contains msg '1' && String.contains msg '4'
+    | None -> false)
+
+let () =
+  run "tool_llama_runtime_verify"
+    [
+      ( "provider_health_reachable",
+        [
+          test_case "accepts json health payload" `Quick
+            test_provider_health_reachable_accepts_json_health;
+        ] );
+      ( "runtime_blocker",
+        [
+          test_case "slot shortage beats provider_unreachable" `Quick
+            test_classify_runtime_blocker_prefers_slot_count_when_health_ok;
+        ] );
+    ]


### PR DESCRIPTION
## Summary
- restore fresh `main_eio.exe` builds after the `agent_sdk 0.23.0` tool result change
- harden runtime doctor so JSON `/health` responses still count as reachable and slot shortages classify as `slot_count_insufficient`
- make bug-bash harness flows more reliable by auto-selecting the only llama model, ensuring contract harness base paths exist, and keeping Lodge bootstrap quiet when disabled

## Validation
- `bash -n scripts/harness/lib/server_bootstrap.sh`
- `bash -n scripts/harness/workload/supervisor_team_session.sh`
- `bash -n scripts/harness_team_session_local64_smoke.sh`
- `dune build --root . ./bin/main_eio.exe ./bin/agent_swarm_harness_cli.exe ./test/test_tool_llama_runtime_verify.exe ./test/test_http_negotiation.exe`
- `./_build/default/test/test_tool_llama_runtime_verify.exe`
- `./_build/default/test/test_http_negotiation.exe`
- `scripts/harness/contract/run_all.sh`
- `scripts/harness_supervisor_team_session.sh`
- `PREFLIGHT_ONLY=1 RUN_ID=swarm-preflight-fixed-1 scripts/harness_agent_swarm_live.sh`

## Notes
- the original `spawn_agent is required` and follow-up protocol failures came from stale fallback binaries; the fresh worktree build now matches the current source contract
- `scripts/harness_team_session_local64_smoke.sh` still assumes the full default role mix and will fail if `WORKER_COUNT` is manually reduced below that expectation
