### PR TITLE
refactor(log): migrate noisy modules to structured Log.* with per-module level control

### DIFF
--- a/lib/board.ml
+++ b/lib/board.ml
@@ -288,7 +288,7 @@ let maybe_sweep store =
   let now = Time_compat.now () in
   if now -. store.last_sweep > float_of_int Limits.sweeper_interval_sec then
     (try ignore (sweep store)
-     with exn -> Printf.eprintf "[board] sweep failed: %s\n%!" (Printexc.to_string exn));
+     with exn -> Log.BoardLog.warn "sweep failed: %s" (Printexc.to_string exn));
   if now -. store.last_flush > flush_interval_sec then
     !deferred_flush_fn store
 
@@ -341,13 +341,13 @@ let rotate_if_needed path =
       let backup = path ^ ".1" in
       (try Sys.rename backup (path ^ ".2") with Sys_error _ -> ());
       Sys.rename path backup;
-      Printf.eprintf "[Board] Rotated %s (was %d bytes)\n%!" path st.Unix.st_size
+      Log.BoardLog.info "rotated %s (was %d bytes)" path st.Unix.st_size
     end
   with
   | Unix.Unix_error (e, fn, arg) ->
-      Printf.eprintf "[Board] rotate error: %s(%s): %s\n%!" fn arg (Unix.error_message e)
+      Log.BoardLog.warn "rotate error: %s(%s): %s" fn arg (Unix.error_message e)
   | Sys_error msg ->
-      Printf.eprintf "[Board] rotate error: %s\n%!" msg
+      Log.BoardLog.warn "rotate error: %s" msg
 
 (** {1 JSON Serialization} *)
 
@@ -531,7 +531,7 @@ let rewrite_posts store =
         output_string oc (Yojson.Safe.to_string (post_to_yojson pst) ^ "\n")
       ) store.posts);
     Sys.rename tmp_path path
-  with Sys_error msg -> Printf.eprintf "[Board] persist error (rewrite_posts): %s\n%!" msg
+  with Sys_error msg -> Log.BoardLog.error "persist error (rewrite_posts): %s" msg
 
 let rewrite_comments store =
   try
@@ -544,7 +544,7 @@ let rewrite_comments store =
         output_string oc (Yojson.Safe.to_string (comment_to_yojson cmt) ^ "\n")
       ) store.comments);
     Sys.rename tmp_path path
-  with Sys_error msg -> Printf.eprintf "[Board] persist error (rewrite_comments): %s\n%!" msg
+  with Sys_error msg -> Log.BoardLog.error "persist error (rewrite_comments): %s" msg
 
 (** {1 Append Helpers} *)
 
@@ -556,7 +556,7 @@ let append_post (p : post) =
     Fun.protect ~finally:(fun () -> close_out_noerr oc) (fun () ->
       output_string oc (Yojson.Safe.to_string (post_to_yojson p) ^ "\n"));
     rotate_if_needed path
-  with Sys_error msg -> Printf.eprintf "[Board] persist error (append_post): %s\n%!" msg
+  with Sys_error msg -> Log.BoardLog.error "persist error (append_post): %s" msg
 
 let append_comment (c : comment) =
   try
@@ -566,7 +566,7 @@ let append_comment (c : comment) =
     Fun.protect ~finally:(fun () -> close_out_noerr oc) (fun () ->
       output_string oc (Yojson.Safe.to_string (comment_to_yojson c) ^ "\n"));
     rotate_if_needed path
-  with Sys_error msg -> Printf.eprintf "[Board] persist error (append_comment): %s\n%!" msg
+  with Sys_error msg -> Log.BoardLog.error "persist error (append_comment): %s" msg
 
 (** {1 Post Operations} *)
 
@@ -821,7 +821,7 @@ let append_vote_log ~target ~voter ~direction =
       ] in
       output_string oc (Yojson.Safe.to_string json ^ "\n"));
     rotate_if_needed path
-  with Sys_error msg -> Printf.eprintf "[Board] persist error (append_vote_log): %s\n%!" msg
+  with Sys_error msg -> Log.BoardLog.error "persist error (append_vote_log): %s" msg
 
 let vote store ~voter ~post_id ~direction : (int, board_error) result =
   match Agent_id.of_string voter with
@@ -1055,9 +1055,12 @@ let load_persisted_posts store =
           done
         with End_of_file -> ()));
       store.post_count := Hashtbl.length store.posts;
-      Printf.eprintf "[Board] Loaded %d posts from %s\n%!" !loaded path
+      if !loaded > 0 then
+        Log.BoardLog.info "loaded %d posts from %s" !loaded path
+      else
+        Log.BoardLog.debug "loaded 0 posts from %s" path
     with e ->
-      Printf.eprintf "[Board] Load posts failed: %s\n%!" (Printexc.to_string e)
+      Log.BoardLog.error "load posts failed: %s" (Printexc.to_string e)
   end
 
 let load_persisted_comments store =
@@ -1084,9 +1087,12 @@ let load_persisted_comments store =
               | _ -> ()
           done
         with End_of_file -> ()));
-      Printf.eprintf "[Board] Loaded %d comments from %s\n%!" !loaded path
+      if !loaded > 0 then
+        Log.BoardLog.info "loaded %d comments from %s" !loaded path
+      else
+        Log.BoardLog.debug "loaded 0 comments from %s" path
     with e ->
-      Printf.eprintf "[Board] Load comments failed: %s\n%!" (Printexc.to_string e)
+      Log.BoardLog.error "load comments failed: %s" (Printexc.to_string e)
   end
 
 (** Recalculate reply_count for all posts based on actual comments.
@@ -1105,7 +1111,7 @@ let recalculate_reply_counts store =
     | None -> ()
   ) store.comments;
   let total = Hashtbl.fold (fun _ (p : post) acc -> acc + p.reply_count) store.posts 0 in
-  Printf.eprintf "[Board] Recalculated reply_counts: %d total comments across posts\n%!" total
+  Log.BoardLog.debug "recalculated reply_counts: %d total comments across posts" total
 
 let load_persisted_votes store =
   let path = vote_log_path () in
@@ -1128,9 +1134,12 @@ let load_persisted_votes store =
             end
           done
         with End_of_file | Yojson.Safe.Util.Type_error _ | Yojson.Json_error _ -> ()));
-      Printf.eprintf "[Board] Loaded %d vote entries from %s\n%!" !loaded path
+      if !loaded > 0 then
+        Log.BoardLog.info "loaded %d vote entries from %s" !loaded path
+      else
+        Log.BoardLog.debug "loaded 0 vote entries from %s" path
     with e ->
-      Printf.eprintf "[Board] Load votes failed: %s\n%!" (Printexc.to_string e)
+      Log.BoardLog.error "load votes failed: %s" (Printexc.to_string e)
   end
 
 (** {1 Hearth (topic) operations} *)

--- a/lib/board_dispatch.ml
+++ b/lib/board_dispatch.ml
@@ -29,26 +29,26 @@ let is_initialized () =
 (** Initialize PostgreSQL backend. Call during server startup when PG pool is available. *)
 let init_pg pool =
   if is_initialized () then begin
-    Printf.eprintf "[Board_dispatch] WARNING: already initialized, ignoring init_pg\n%!";
+    Log.BoardLog.warn "already initialized, ignoring init_pg";
     Ok ()
   end else
   match Board_pg.create pool with
   | Ok t ->
       backend_state := Active (Postgres t);
-      Printf.eprintf "[Board_dispatch] PostgreSQL backend initialized.\n%!";
+      Log.BoardLog.info "PostgreSQL backend initialized";
       Ok ()
   | Error e ->
-      Printf.eprintf "[Board_dispatch] PG init failed, falling back to JSONL: %s\n%!"
+      Log.BoardLog.warn "PG init failed, falling back to JSONL: %s"
         (Board.show_board_error e);
       Error e
 
 (** Initialize JSONL backend. Default fallback. *)
 let init_jsonl () =
   if is_initialized () then
-    Printf.eprintf "[Board_dispatch] WARNING: already initialized, ignoring init_jsonl\n%!"
+    Log.BoardLog.warn "already initialized, ignoring init_jsonl"
   else begin
     backend_state := Active (Jsonl (Board.global ()));
-    Printf.eprintf "[Board_dispatch] JSONL backend initialized.\n%!"
+    Log.BoardLog.info "JSONL backend initialized"
   end
 
 (** Reset for testing. Clears backend state so init can be called again. *)

--- a/lib/guardian.ml
+++ b/lib/guardian.ml
@@ -61,8 +61,9 @@ let zombie_pulse : Pulse.t option ref = ref None
 let gc_pulse : Pulse.t option ref = ref None
 let lodge_pulse_inst : Pulse.t option ref = ref None
 
-let log msg =
-  eprintf "[guardian] %s\n%!" msg
+let log_debug msg = Log.Guardian.debug "%s" msg
+let log_info msg = Log.Guardian.info "%s" msg
+let log_warn msg = Log.Guardian.warn "%s" msg
 
 let set_last r =
   r := Some (Types.now_iso ())
@@ -126,11 +127,11 @@ let make_zombie_consumer config : (module Pulse.Consumer) =
         let result = Room.cleanup_zombies config in
         last_zombie_result := Some result;
         set_last last_zombie_cleanup;
-        log result;
+        log_debug result;
         Ok ()
       with exn ->
         let msg = sprintf "zombie cleanup failed: %s" (Printexc.to_string exn) in
-        log msg;
+        log_warn msg;
         Error msg
   end)
 
@@ -143,11 +144,11 @@ let make_gc_consumer config : (module Pulse.Consumer) =
         let result = Room.gc config ~days:gc_days () in
         last_gc_result := Some result;
         set_last last_gc;
-        log (sprintf "gc: %s" result);
+        log_debug (sprintf "gc: %s" result);
         Ok ()
       with exn ->
         let msg = sprintf "gc failed: %s" (Printexc.to_string exn) in
-        log msg;
+        log_warn msg;
         Error msg
   end)
 
@@ -157,7 +158,7 @@ let make_lodge_consumer ~net : (module Pulse.Consumer) =
 
     let should_act _beat =
       if is_quiet_hours () then begin
-        log "quiet hours - skipping lodge loop";
+        log_debug "quiet hours - skipping lodge loop";
         false
       end else
         true
@@ -178,8 +179,8 @@ let make_lodge_consumer ~net : (module Pulse.Consumer) =
       set_last last_lodge;
       lodge_running := false;
       match result with
-      | (true, msg) -> log (sprintf "lodge loop ok: %s" msg); Ok ()
-      | (false, msg) -> log (sprintf "lodge loop failed: %s" msg); Error msg
+      | (true, msg) -> log_info (sprintf "lodge loop ok: %s" msg); Ok ()
+      | (false, msg) -> log_warn (sprintf "lodge loop failed: %s" msg); Error msg
   end)
 
 (* ── Status ────────────────────────────────────────────────── *)
@@ -232,10 +233,10 @@ let status_json () : Yojson.Safe.t =
 let start_masc_loops_internal ~owner ~respect_guardian_toggle ~sw ~clock config =
   let can_start = if respect_guardian_toggle then masc_enabled else true in
   if not can_start then begin
-    log "masc guardian disabled";
+    log_debug "masc guardian disabled";
     ()
   end else if masc_loops_running () then begin
-    log
+    log_debug
       (sprintf "masc guardian loops already running (owner=%s)"
          (masc_runtime_owner_label ()))
   end else begin
@@ -267,7 +268,7 @@ let start_masc_loops_internal ~owner ~respect_guardian_toggle ~sw ~clock config 
     if !started_any then
       masc_loops_owner := Some owner
     else
-      log "masc guardian loops disabled by interval configuration"
+      log_debug "masc guardian loops disabled by interval configuration"
   end
 
 let start_masc_loops ~sw ~clock config =
@@ -280,13 +281,13 @@ let start_embedded_masc_loops ~sw ~clock config =
 
 let start_lodge_loop ~sw ~clock ~net =
   if not lodge_enabled then begin
-    log "lodge guardian disabled";
+    log_debug "lodge guardian disabled";
     ()
   end else if Option.is_some !lodge_pulse_inst then begin
-    log "guardian lodge loop already running";
+    log_debug "guardian lodge loop already running";
     ()
   end else if lodge_interval_s <= 0.0 || lodge_iterations <= 0 then begin
-    log "lodge guardian disabled by interval/iterations";
+    log_debug "lodge guardian disabled by interval/iterations";
     ()
   end else begin
     let p = Pulse.create
@@ -302,9 +303,9 @@ let start_lodge_loop ~sw ~clock ~net =
 
 let start ~sw ~clock ~net room_config =
   if not enabled then begin
-    log "guardian disabled (set MASC_GUARDIAN_ENABLED=true)";
+    log_debug "guardian disabled (set MASC_GUARDIAN_ENABLED=true)";
   end else begin
     start_masc_loops ~sw ~clock room_config;
     start_lodge_loop ~sw ~clock ~net;
-    log (sprintf "guardian started (mode=%s)" (Mode.to_string mode))
+    log_info (sprintf "guardian started (mode=%s)" (Mode.to_string mode))
   end

--- a/lib/llm_client.ml
+++ b/lib/llm_client.ml
@@ -615,7 +615,7 @@ let parse_openai_response (json_str : string) : (completion_response, string) re
       match Safe_ops.json_int_opt key usage_json with
       | Some n -> n
       | None ->
-        Printf.eprintf "[llm] token field missing or wrong type: %s\n%!" key;
+        Log.LlmClient.debug "token field missing or wrong type: %s" key;
         0
     in
     let usage = {
@@ -838,13 +838,13 @@ let call_openai_compatible ?timeout_sec (req : completion_request) : (completion
   | Ok (base_url, path, auth_headers) ->
       let url = sprintf "%s%s" base_url path in
       let body = build_openai_body effective_req in
-      Printf.eprintf
-        "[llm_client] openai-compat req: model=%s provider=%s requested_max_tokens=%d effective_max_tokens=%d tools=%d url=%s\n%!"
+      Log.LlmClient.debug
+        "openai-compat req: model=%s provider=%s requested_max_tokens=%d effective_max_tokens=%d tools=%d url=%s"
         req.model.model_id (string_of_provider req.model.provider) req.max_tokens
         effective_req.max_tokens (List.length req.tools) url;
       if req.tools <> [] then begin
         let body_trunc = if String.length body > 1500 then String.sub body 0 1500 ^ "..." else body in
-        Printf.eprintf "[llm_client] openai-compat body (tools present, %d bytes): %s\n%!" (String.length body) body_trunc
+        Log.LlmClient.debug "openai-compat body (tools present, %d bytes): %s" (String.length body) body_trunc
       end;
       let headers = [("Content-Type", "application/json")] @ auth_headers in
       let timeout_sec = Option.value timeout_sec ~default:60 in
@@ -852,7 +852,7 @@ let call_openai_compatible ?timeout_sec (req : completion_request) : (completion
       | Error e -> Error e
       | Ok raw ->
           let trunc = if String.length raw > 500 then String.sub raw 0 500 ^ "..." else raw in
-          Printf.eprintf "[llm_client] openai-compat raw (%d bytes): %s\n%!" (String.length raw) trunc;
+          Log.LlmClient.debug "openai-compat raw (%d bytes): %s" (String.length raw) trunc;
           parse_openai_response raw
 
 (** GLM Cloud call with pool-based load balancing.
@@ -905,14 +905,14 @@ let complete ?timeout_sec (req : completion_request) : (completion_response, str
             | Error e ->
                 Prometheus.inc_counter "masc_llm_cache_errors_total" ();
                 let _ = Llm_response_cache.delete ~key in
-                eprintf "[llm_client] cache decode error: %s\n%!" e;
+                Log.LlmClient.warn "cache decode error: %s" e;
                 None)
         | Ok None ->
             Prometheus.inc_counter "masc_llm_cache_misses_total" ();
             None
         | Error e ->
             Prometheus.inc_counter "masc_llm_cache_errors_total" ();
-            eprintf "[llm_client] cache read error: %s\n%!" e;
+            Log.LlmClient.warn "cache read error: %s" e;
             None)
   in
   let result =
@@ -936,7 +936,7 @@ let complete ?timeout_sec (req : completion_request) : (completion_response, str
             | Ok () -> Prometheus.inc_counter "masc_llm_cache_writes_total" ()
             | Error e ->
                 Prometheus.inc_counter "masc_llm_cache_errors_total" ();
-                eprintf "[llm_client] cache write error: %s\n%!" e);
+                Log.LlmClient.warn "cache write error: %s" e);
             Ok resp
         | _ -> upstream_result)
   in
@@ -952,7 +952,7 @@ let cascade ?(accept = fun _ -> true) ?timeout_sec
     (requests : completion_request list) : (completion_response, string) result =
   with_llm_permit (fun () ->
     let avail = Eio.Semaphore.get_value llm_semaphore in
-    eprintf "[llm_client] cascade: acquired permit (%d/%d available)\n%!"
+    Log.LlmClient.debug "cascade: acquired permit (%d/%d available)"
       avail max_concurrent_llm;
     let deadline_opt =
       Option.map (fun sec -> Time_compat.now () +. float_of_int sec) timeout_sec
@@ -974,7 +974,7 @@ let cascade ?(accept = fun _ -> true) ?timeout_sec
         in
         Error (sprintf "All models failed: %s" all_errors)
       | req :: rest ->
-        eprintf "[llm_client] cascade: trying %s (%s)\n%!"
+        Log.LlmClient.debug "cascade: trying %s (%s)"
           req.model.model_id (string_of_provider req.model.provider);
         let attempt_result =
           match remaining_timeout_sec () with
@@ -986,16 +986,16 @@ let cascade ?(accept = fun _ -> true) ?timeout_sec
         match attempt_result with
         | Ok resp ->
           if accept resp then (
-            eprintf "[llm_client] cascade: success with %s (%dms)\n%!"
+            Log.LlmClient.info "cascade: success with %s (%dms)"
               resp.model_used resp.latency_ms;
             Ok resp)
           else (
-            eprintf
-              "[llm_client] cascade: %s rejected by validator, continuing\n%!"
+            Log.LlmClient.warn
+              "cascade: %s rejected by validator, continuing"
               resp.model_used;
             try_next ("response rejected by validator" :: errors) rest)
         | Error e ->
-          eprintf "[llm_client] cascade: %s failed: %s\n%!"
+          Log.LlmClient.warn "cascade: %s failed: %s"
             req.model.model_id e;
           try_next (e :: errors) rest
     in
@@ -1130,7 +1130,7 @@ let available_model_specs_of_strings model_strs =
   |> List.filter_map (fun model_str ->
          match model_spec_of_string model_str with
          | Error err ->
-             eprintf "[llm_client] ignoring invalid model spec %s: %s\n%!"
+             Log.LlmClient.warn "ignoring invalid model spec %s: %s"
                model_str err;
              None
          | Ok spec -> (
@@ -1138,7 +1138,7 @@ let available_model_specs_of_strings model_strs =
              | Some env_name ->
                  let value = Sys.getenv_opt env_name |> Option.value ~default:"" in
                  if String.trim value = "" then (
-                   eprintf "[llm_client] skipping %s: %s not set\n%!"
+                   Log.LlmClient.debug "skipping %s: %s not set"
                      model_str env_name;
                    None)
                  else Some spec

--- a/lib/log.ml
+++ b/lib/log.ml
@@ -81,12 +81,37 @@ let info ?ctx fmt = log Info ?ctx fmt
 let warn ?ctx fmt = log Warn ?ctx fmt
 let error ?ctx fmt = log Error ?ctx fmt
 
-(** Module-specific loggers *)
+(** Module-specific loggers.
+    Each module checks MASC_LOG_{NAME}_LEVEL env var for per-module override,
+    falling back to the global level. *)
 module Make (M : sig val name : string end) = struct
-  let debug fmt = log Debug ~ctx:M.name fmt
-  let info fmt = log Info ~ctx:M.name fmt
-  let warn fmt = log Warn ~ctx:M.name fmt
-  let error fmt = log Error ~ctx:M.name fmt
+  let module_level : int option =
+    let env_key = Printf.sprintf "MASC_LOG_%s_LEVEL"
+      (String.uppercase_ascii M.name) in
+    match Sys.getenv_opt env_key with
+    | Some s -> Some (level_to_int (level_of_string s))
+    | None -> None
+
+  let should_log_module level =
+    let threshold = match module_level with
+      | Some l -> l
+      | None -> Atomic.get current_level
+    in
+    level_to_int level >= threshold
+
+  let log_module level fmt =
+    Printf.ksprintf (fun msg ->
+      if should_log_module level then begin
+        let prefix = Printf.sprintf "[%s] [%s] [%s]"
+          (timestamp ()) (level_to_string level) M.name in
+        Printf.eprintf "%s %s\n%!" prefix msg
+      end
+    ) fmt
+
+  let debug fmt = log_module Debug fmt
+  let info fmt = log_module Info fmt
+  let warn fmt = log_module Warn fmt
+  let error fmt = log_module Error fmt
 end
 
 (** Pre-defined module loggers *)
@@ -101,3 +126,9 @@ module Sub = Make(struct let name = "Subscriptions" end)
 module Mitosis_log = Make(struct let name = "Mitosis" end)
 module Glm_pool = Make(struct let name = "GlmPool" end)
 module Spawn = Make(struct let name = "Spawn" end)
+module Pulse = Make(struct let name = "Pulse" end)
+module Guardian = Make(struct let name = "Guardian" end)
+module Sentinel = Make(struct let name = "Sentinel" end)
+module LlmClient = Make(struct let name = "LlmClient" end)
+module Orchestrator = Make(struct let name = "Orchestrator" end)
+module BoardLog = Make(struct let name = "Board" end)

--- a/lib/orchestrator.ml
+++ b/lib/orchestrator.ml
@@ -51,7 +51,7 @@ let load_config () =
 let should_orchestrate room_config =
   (* Check if room is paused first *)
   if Room.is_paused room_config then begin
-    Eio.traceln "⏸️ Orchestrator: Room is paused, skipping\n%!";
+    Log.Orchestrator.debug "room is paused, skipping";
     false
   end else begin
   (* Get unclaimed tasks with priority <= min_priority *)
@@ -72,7 +72,7 @@ let should_orchestrate room_config =
   in
 
   if needs_orchestration then
-    Eio.traceln "🎯 Orchestrator: %d unclaimed tasks, %d active agents → spawning\n%!"
+    Log.Orchestrator.info "%d unclaimed tasks, %d active agents, spawning"
       (List.length unclaimed_important) (List.length active_agents);
 
   needs_orchestration
@@ -119,13 +119,13 @@ Start by calling mcp__masc__masc_status to see the current room state.|}
 let spawn_orchestrator ~sw ~proc_mgr ?domain_mgr config room_config =
   (* TOCTOU defense: re-check pause before spawn *)
   if Room.is_paused room_config then begin
-    Eio.traceln "⏸️ Orchestrator: Room paused before spawn, aborting\n%!";
+    Log.Orchestrator.debug "room paused before spawn, aborting";
     { Spawn_eio.success = false; output = "Room paused"; exit_code = 0; elapsed_ms = 0;
       tool_call_count = 0; tool_names = [];
       input_tokens = None; output_tokens = None; cache_creation_tokens = None;
       cache_read_tokens = None; cost_usd = None; raw_trace_run = None }
   end else begin
-  Eio.traceln "🚀 Spawning orchestrator agent: %s (with MCP tools)\n%!" config.orchestrator_agent;
+  Log.Orchestrator.info "spawning agent: %s (with MCP tools)" config.orchestrator_agent;
 
   (* Broadcast that orchestrator is starting *)
   let _ = Room.broadcast room_config ~from_agent:"system"
@@ -148,9 +148,9 @@ let spawn_orchestrator ~sw ~proc_mgr ?domain_mgr config room_config =
   in
 
   if result.success then
-    Eio.traceln "✅ Orchestrator completed in %dms\n%!" result.elapsed_ms
+    Log.Orchestrator.info "completed in %dms" result.elapsed_ms
   else
-    Eio.traceln "❌ Orchestrator failed (exit %d) in %dms\n%!"
+    Log.Orchestrator.warn "failed (exit %d) in %dms"
       result.exit_code result.elapsed_ms;
 
   result
@@ -182,11 +182,11 @@ let make_orchestrator_check_consumer ~sw ~proc_mgr ?domain_mgr ~config ~room_con
             try
               ignore (spawn_orchestrator ~sw ~proc_mgr ?domain_mgr config room_config)
             with exn ->
-              Printf.eprintf "[Orchestrator] spawn failed: %s\n%!" (Printexc.to_string exn));
+              Log.Orchestrator.error "spawn failed: %s" (Printexc.to_string exn));
         Ok ()
       with exn ->
         let msg = Printf.sprintf "orchestrator check error: %s" (Printexc.to_string exn) in
-        Eio.traceln "[Orchestrator] %s (recovering...)" msg;
+        Log.Orchestrator.warn "%s (recovering...)" msg;
         Error msg
   end)
 
@@ -210,7 +210,7 @@ let make_zero_zombie_consumer ~room_config
             with exn -> let _ = exn in false
           in
           if has_zombie_indicator then
-            Printf.eprintf "[ZeroZombie] %s\n%!" status_trimmed
+            Log.Orchestrator.info "[zombie] %s" status_trimmed
         end;
         Ok ()
       with exn ->
@@ -218,7 +218,7 @@ let make_zero_zombie_consumer ~room_config
           Ok ()
         else begin
           let msg = Printf.sprintf "zombie cleanup error: %s" (Printexc.to_string exn) in
-          Printf.eprintf "[ZeroZombie] %s\n%!" msg;
+          Log.Orchestrator.warn "[zombie] %s" msg;
           Error msg
         end
   end)
@@ -229,7 +229,7 @@ let start ~sw ~proc_mgr ~clock ?domain_mgr room_config =
   let config = load_config () in
 
   (* Zero-Zombie cleanup: always enabled, 60s interval *)
-  Eio.traceln "🧟 Zero-Zombie Protocol: Automatic cleanup enabled (interval: 60s)\n%!";
+  Log.Orchestrator.debug "zero-zombie cleanup enabled (interval: 60s)";
   let zombie_consumer = make_zero_zombie_consumer ~room_config in
   let zp = Pulse.create ~clock ~rhythm:(fixed_rhythm 60.0) ~lifecycle:Perpetual ~consumers:[zombie_consumer] in
   zombie_pulse := Some zp;
@@ -237,10 +237,10 @@ let start ~sw ~proc_mgr ~clock ?domain_mgr room_config =
 
   (* Orchestrator check: respects enabled flag via should_act *)
   if config.enabled then
-    Eio.traceln "🎮 Orchestrator loop enabled (interval: %.0fs, agent: %s)\n%!"
+    Log.Orchestrator.debug "loop enabled (interval: %.0fs, agent: %s)"
       config.check_interval_s config.orchestrator_agent
   else
-    Eio.traceln "💤 Orchestrator loop disabled (set MASC_ORCHESTRATOR_ENABLED=1 to enable)\n%!";
+    Log.Orchestrator.debug "loop disabled (set MASC_ORCHESTRATOR_ENABLED=1 to enable)";
 
   let orch_consumer = make_orchestrator_check_consumer ~sw ~proc_mgr ?domain_mgr ~config ~room_config () in
   let op = Pulse.create ~clock ~rhythm:(fixed_rhythm config.check_interval_s) ~lifecycle:Perpetual ~consumers:[orch_consumer] in

--- a/lib/pulse.ml
+++ b/lib/pulse.ml
@@ -121,7 +121,7 @@ let dispatch_consumers consumers beat =
       match C.on_beat beat with
       | Ok () -> ()
       | Error msg ->
-        Eio.traceln "[pulse] consumer %s error on beat #%d: %s"
+        Log.Pulse.warn "consumer %s error on beat #%d: %s"
           C.name beat.seq msg
     end
   ) consumers
@@ -144,14 +144,14 @@ let tick t trigger =
   } in
   t.last_beat_v <- Some beat;
   (match trigger with Nudge _ -> t.total_nudges <- t.total_nudges + 1 | _ -> ());
-  Eio.traceln "[pulse] beat #%d trigger=%s" beat.seq (trigger_to_string trigger);
+  Log.Pulse.debug "beat #%d trigger=%s" beat.seq (trigger_to_string trigger);
   dispatch_consumers t.consumers beat;
   (* Check bounded lifecycle *)
   (match t.lifecycle with
    | Perpetual -> ()
    | Bounded pred ->
      if pred beat && not (is_shutdown t) then begin
-       Eio.traceln "[pulse] bounded lifecycle condition met at beat #%d" beat.seq;
+       Log.Pulse.info "bounded lifecycle condition met at beat #%d" beat.seq;
        Eio.Promise.resolve t.shutdown_r ()
      end);
   beat
@@ -195,7 +195,7 @@ let loop t =
   (* Final beat: shutdown demand *)
   let _shutdown_beat = tick t Demand in
   t.alive <- false;
-  Eio.traceln "[pulse] stopped after %d beats" t.seq
+  Log.Pulse.info "stopped after %d beats" t.seq
 
 (* ── Public API ──────────────────────────────────────────────── *)
 

--- a/lib/sentinel.ml
+++ b/lib/sentinel.ml
@@ -17,8 +17,9 @@ open Printf
 
 let agent_name = "sentinel"
 
-let log msg =
-  eprintf "[sentinel] %s\n%!" msg
+let log_debug msg = Log.Sentinel.debug "%s" msg
+let log_info msg = Log.Sentinel.info "%s" msg
+let log_warn msg = Log.Sentinel.warn "%s" msg
 
 type board_patrol_decision = {
   needs_attention : bool;
@@ -56,21 +57,21 @@ let call_sentinel_llm ~cascade_name ~prompt_id ~vars () =
   else
     match Prompt_registry.render ~id:prompt_id ~vars () with
     | Error msg ->
-        log (sprintf "prompt %s render failed: %s" prompt_id msg);
+        log_warn (sprintf "prompt %s render failed: %s" prompt_id msg);
         None
     | Ok prompt ->
         let timeout = Env_config.Sentinel.llm_timeout_sec in
         (match Lodge_cascade.call ~cascade_name ~prompt
             ~temperature:0.3 ~timeout_sec:timeout ~max_tokens:800 () with
         | Ok r when String.length r.response > 5 ->
-            log (sprintf "LLM response from %s (%d chars)" r.llm_used
+            log_debug (sprintf "LLM response from %s (%d chars)" r.llm_used
                    (String.length r.response));
             parse_llm_json_safe r.response
         | Ok r ->
-            log (sprintf "LLM response too short from %s" r.llm_used);
+            log_warn (sprintf "LLM response too short from %s" r.llm_used);
             None
         | Error err ->
-            log (sprintf "LLM cascade %s failed: %s" cascade_name err);
+            log_warn (sprintf "LLM cascade %s failed: %s" cascade_name err);
             None)
 
 let trimmed_string_option = function
@@ -140,7 +141,7 @@ let make_heartbeat_consumer config : (module Pulse.Consumer) =
         Ok ()
       with exn ->
         let msg = sprintf "heartbeat failed: %s" (Printexc.to_string exn) in
-        log msg;
+        log_warn msg;
         Error msg
   end)
 
@@ -163,7 +164,7 @@ let make_board_patrol_consumer config : (module Pulse.Consumer) =
           last_daily_post := Some today_key;
           (try write_board_patrol_day_key_for_tests config today_key
            with exn ->
-             log
+             log_warn
                (sprintf "board patrol state persist failed: %s"
                   (Printexc.to_string exn)));
           let agent_names = String.concat ", " state.active_agents in
@@ -180,7 +181,7 @@ let make_board_patrol_consumer config : (module Pulse.Consumer) =
           if stale_posts = 0 then begin
             record_result ~checked_at:now_f ~action:"silent"
               ?reason:(Some "no stale posts over 7d") ~stale_count:stale_posts ();
-            log "no stale posts, skipping board patrol post"
+            log_debug "no stale posts, skipping board patrol post"
           end else begin
             let llm_content = call_sentinel_llm
               ~cascade_name:"sentinel_board"
@@ -197,7 +198,7 @@ let make_board_patrol_consumer config : (module Pulse.Consumer) =
                 if not decision.needs_attention then begin
                   record_result ~checked_at:now_f ~action:"silent"
                     ?reason:decision.reason ~stale_count:stale_posts ();
-                  log "board patrol decided no operator-visible action is needed"
+                  log_debug "board patrol decided no operator-visible action is needed"
                 end else
                   (match decision.board_post with
                    | Some summary when String.length summary > 10 ->
@@ -210,27 +211,27 @@ let make_board_patrol_consumer config : (module Pulse.Consumer) =
                         | Ok _post ->
                             record_result ~checked_at:now_f ~action:"posted"
                               ?reason:decision.reason ~stale_count:stale_posts ();
-                            log "board patrol attention posted"
+                            log_info "board patrol attention posted"
                         | Error e ->
                             let reason = Board.show_board_error e in
                             record_result ~checked_at:now_f ~action:"post_failed"
                               ?reason:(Some reason) ~stale_count:stale_posts ();
-                            log (sprintf "board patrol post failed: %s" reason))
+                            log_warn (sprintf "board patrol post failed: %s" reason))
                    | _ ->
                        record_result ~checked_at:now_f ~action:"suppressed"
                          ?reason:(Some "needs_attention=true but board_post was empty")
                          ~stale_count:stale_posts ();
-                       log "board patrol attention requested but board_post was empty; suppressing")
+                       log_debug "board patrol attention requested but board_post was empty; suppressing")
             | None ->
                 record_result ~checked_at:now_f ~action:"llm_unavailable"
                   ?reason:(Some "sentinel_board cascade unavailable") ~stale_count:stale_posts ();
-                log "LLM unavailable, skipping board patrol post"
+                log_debug "LLM unavailable, skipping board patrol post"
           end
         end;
         Ok ()
       with exn ->
         let msg = sprintf "board patrol failed: %s" (Printexc.to_string exn) in
-        log msg;
+        log_warn msg;
         Error msg
   end)
 
@@ -279,7 +280,7 @@ let make_task_hygiene_consumer config : (module Pulse.Consumer) =
 
           let warnings = match llm_result with
             | Some (`List items) ->
-                log (sprintf "task hygiene LLM assessed %d tasks" (List.length items));
+                log_debug (sprintf "task hygiene LLM assessed %d tasks" (List.length items));
                 List.filter_map (fun item ->
                   let open Yojson.Safe.Util in
                   let action = item |> member "action" |> to_string_option
@@ -295,15 +296,14 @@ let make_task_hygiene_consumer config : (module Pulse.Consumer) =
                     Some (sprintf "task %s: %s [%s] %s" task_id action priority reason)
                 ) items
             | _ ->
-                log (sprintf "%d candidate stuck tasks, LLM unavailable — skipping"
+                log_debug (sprintf "%d candidate stuck tasks, LLM unavailable — skipping"
                   (List.length !candidates));
                 []
           in
 
           if warnings <> [] then begin
-            let msg = sprintf "[sentinel] %d task warning(s): %s"
-              (List.length warnings) (String.concat "; " warnings) in
-            log msg;
+            Log.Sentinel.warn "%d task warning(s)" (List.length warnings);
+            List.iter (fun w -> Log.Sentinel.warn "  %s" w) warnings;
             Sse.broadcast (`Assoc [
               ("type", `String "sentinel_warning");
               ("source", `String agent_name);
@@ -315,7 +315,7 @@ let make_task_hygiene_consumer config : (module Pulse.Consumer) =
         Ok ()
       with exn ->
         let msg = sprintf "task hygiene failed: %s" (Printexc.to_string exn) in
-        log msg;
+        log_warn msg;
         Error msg
   end)
 
@@ -368,7 +368,7 @@ let make_keeper_health_consumer _config : (module Pulse.Consumer) =
 
             match llm_result with
             | Some (`List items) ->
-                log (sprintf "keeper health LLM assessed %d keepers" (List.length items));
+                log_debug (sprintf "keeper health LLM assessed %d keepers" (List.length items));
                 List.iter (fun item ->
                   let open Yojson.Safe.Util in
                   let keeper = item |> member "keeper" |> to_string_option
@@ -378,17 +378,17 @@ let make_keeper_health_consumer _config : (module Pulse.Consumer) =
                   let reason = item |> member "reason" |> to_string_option
                                |> Option.value ~default:"" in
                   if action <> "ignore" then
-                    log (sprintf "keeper %s: %s — %s" keeper action reason)
+                    log_warn (sprintf "keeper %s: %s — %s" keeper action reason)
                 ) items
             | _ ->
-                log (sprintf "%d stale keeper(s) detected, LLM unavailable — skipping"
+                log_debug (sprintf "%d stale keeper(s) detected, LLM unavailable — skipping"
                   (List.length !stale))
           end
         end;
         Ok ()
       with exn ->
         let msg = sprintf "keeper health failed: %s" (Printexc.to_string exn) in
-        log msg;
+        log_warn msg;
         Error msg
   end)
 
@@ -453,12 +453,12 @@ let status_json () : Yojson.Safe.t =
 
 let start ~sw ~clock ~net config =
   if not Env_config.Sentinel.enabled then
-    log "disabled (set MASC_SENTINEL_ENABLED=true)"
+    log_debug "disabled (set MASC_SENTINEL_ENABLED=true)"
   else begin
     ensure_room_initialized_for_start config;
     (* 1. Join room as sentinel agent *)
     let join_result = Room.join config ~agent_name ~capabilities:["sentinel"; "housekeeping"] () in
-    log (sprintf "join: %s" (String.sub join_result 0 (min 80 (String.length join_result))));
+    log_info (sprintf "join: %s" (String.sub join_result 0 (min 80 (String.length join_result))));
 
     (* 2. Heartbeat pulse (30s) *)
     let p_hb = Pulse.create
@@ -496,5 +496,5 @@ let start ~sw ~clock ~net config =
     started := true;
     start_ts := Time_compat.now ();
     ignore net;  (* net reserved for future HTTP-based health checks *)
-    log "started (heartbeat, embedded zombie/gc, board-patrol, task-hygiene, keeper-health)"
+    log_info "started (heartbeat, embedded zombie/gc, board-patrol, task-hygiene, keeper-health)"
   end

--- a/lib/server_runtime_bootstrap.ml
+++ b/lib/server_runtime_bootstrap.ml
@@ -117,7 +117,13 @@ let start_resident_loops ~sw ~clock ~net ~domain_mgr ~proc_mgr
       Operator_control.snapshot_json ~actor:"operator-judge" ~view:"summary"
         ~include_messages:false ~include_keepers:false operator_judge_ctx)
     ();
-  Session.start_mcp_session_cleanup_loop ~sw ~clock ()
+  Session.start_mcp_session_cleanup_loop ~sw ~clock ();
+  (* Phase 5: unified startup subsystem summary *)
+  let on_off b = if b then "on" else "off" in
+  Log.info ~ctx:"startup" "subsystems: sentinel=%s guardian=%s gardener=%s"
+    (on_off Env_config.Sentinel.enabled)
+    (on_off Env_config.Guardian.enabled)
+    (on_off Env_config.Gardener.enabled)
 
 let start_background_maintenance ~sw ~clock (state : Mcp_server.server_state) =
   (match Board_dispatch.get_pg_pool () with
@@ -173,7 +179,7 @@ let listen_socket ~sw ~net (config : Http.config) =
 
 let print_startup_banner ~(config : Http.config) ~resolved_base ~base_path
     ~masc_dir =
-  Printf.printf "🚀 MASC MCP Server listening on http://%s:%d\n%!" config.host
+  Printf.printf "MASC MCP Server listening on http://%s:%d\n%!" config.host
     config.port;
   Printf.printf "   Base path: %s\n%!" resolved_base;
   if resolved_base <> base_path then

--- a/lib/tool_lodge_llm_cycle.ml
+++ b/lib/tool_lodge_llm_cycle.ml
@@ -155,19 +155,19 @@ let smart_generate ~net ?(temperature = 0.7) ?(num_predict = 500) ~system prompt
   Printf.eprintf "[LLM] Trying %s...\n%!" (string_of_provider cli);
   match cli_generate cli ~system prompt with
   | Ok response ->
-      Printf.eprintf "[LLM] ✅ %s succeeded\n%!" (string_of_provider cli);
+      Printf.eprintf "[LLM] %s succeeded\n%!" (string_of_provider cli);
       Ok response
   | Error e1 ->
-      Printf.eprintf "[LLM] ❌ %s failed: %s\n%!" (string_of_provider cli) e1;
+      Printf.eprintf "[LLM] [fail] %s: %s\n%!" (string_of_provider cli) e1;
       (* 2. Try another CLI *)
       let cli2 = next_cli_provider () in
       Printf.eprintf "[LLM] Trying %s...\n%!" (string_of_provider cli2);
       match cli_generate cli2 ~system prompt with
       | Ok response ->
-          Printf.eprintf "[LLM] ✅ %s succeeded\n%!" (string_of_provider cli2);
+          Printf.eprintf "[LLM] %s succeeded\n%!" (string_of_provider cli2);
           Ok response
       | Error e2 ->
-          Printf.eprintf "[LLM] ❌ %s failed: %s\n%!" (string_of_provider cli2) e2;
+          Printf.eprintf "[LLM] [fail] %s: %s\n%!" (string_of_provider cli2) e2;
           (* 3. Fallback to cloud GLM via Z.ai API — 200K context, no VRAM *)
           Printf.eprintf "[LLM] Falling back to cloud GLM (Z.ai)...\n%!";
           glm_direct ~net ~temperature ~max_tokens:num_predict ~system prompt


### PR DESCRIPTION
## Summary

- `log.ml`에 6개 모듈 로거 추가 (Pulse, Guardian, Sentinel, LlmClient, Orchestrator, BoardLog) + `MASC_LOG_{NAME}_LEVEL` per-module env var 지원
- 6개 모듈의 `eprintf`/`Eio.traceln` 호출 ~70건을 `Log.*.{debug,info,warn,error}`로 마이그레이션
- sentinel 이중 prefix 버그 수정 (`[sentinel] [sentinel]` → `[Sentinel]`)
- sentinel wall-of-text 수정: 세미콜론 연결 경고 → 개별 라인
- stderr 로그에서 이모지 제거 (orchestrator, tool_lodge_llm_cycle)
- `server_runtime_bootstrap.ml`에 서브시스템 상태 요약 추가

## Excluded

- `lodge_heartbeat.ml` (3258줄, 95+ 로그 호출) → 별도 PR로 분리

## Test plan

- [x] `dune build` 성공
- [x] `dune runtest` 전체 통과 (44 tests)
- [ ] `MASC_LOG_LEVEL=info ./start-masc-mcp.sh` 실행 후 로그 라인 수 80%+ 감소 확인
- [ ] `MASC_LOG_LEVEL=debug ./start-masc-mcp.sh` 실행 후 기존 동일 정보 노출 확인
- [ ] `MASC_LOG_SENTINEL_LEVEL=warn` 설정으로 sentinel 로그만 억제 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)