### PR TITLE
fix(telemetry): wire dead-code metrics + fix Eio concurrency bugs

### DIFF
--- a/bin/main_eio.ml
+++ b/bin/main_eio.ml
@@ -227,9 +227,11 @@ let run_cmd host port base_path =
   (* Initialize Mirage_crypto RNG - MUST be inside Eio_main.run for thread-local state *)
   Mirage_crypto_rng_unix.use_default ();
 
-  (* Enable Eio-aware locking in Prometheus metrics *)
+  (* Enable Eio-aware locking in modules with dual-mode mutex guards *)
   Masc_mcp.Prometheus.enable_eio ();
   Masc_mcp.Llm_response_cache.enable_eio ();
+  Masc_mcp.Chain_telemetry.enable_eio ();
+  Masc_mcp.Generational_metrics.enable_eio ();
 
   (* Set global clock for Time_compat (Eio-native timestamps) *)
   Masc_mcp.Time_compat.set_clock (Eio.Stdenv.clock env);

--- a/bin/main_stdio_eio.ml
+++ b/bin/main_stdio_eio.ml
@@ -18,6 +18,8 @@ let run_cmd base_path =
   Mirage_crypto_rng_unix.use_default ();
   Masc_mcp.Prometheus.enable_eio ();
   Masc_mcp.Llm_response_cache.enable_eio ();
+  Masc_mcp.Chain_telemetry.enable_eio ();
+  Masc_mcp.Generational_metrics.enable_eio ();
   Masc_mcp.Time_compat.set_clock (Eio.Stdenv.clock env);
   Masc_mcp.Cancellation.TokenStore.init ();
   Eio.Switch.run @@ fun sw ->

--- a/lib/chain_telemetry.ml
+++ b/lib/chain_telemetry.ml
@@ -16,14 +16,19 @@
 
 open Chain_category
 
-(** {1 Helper for Stdlib.Mutex} *)
+(** {1 Eio-aware Mutex Guard}
+
+    Follows the dual-mode pattern from prometheus.ml:
+    Before Eio runtime starts (module init), runs unlocked (single-threaded).
+    After {!enable_eio} is called inside [Eio_main.run], uses [Eio.Mutex]. *)
+let eio_available = ref false
+let enable_eio () = eio_available := true
+
 let with_mutex mutex f =
-  Mutex.lock mutex;
-  Common.protect
-    ~module_name:"chain_telemetry"
-    ~finally_label:"Mutex.unlock"
-    ~finally:(fun () -> Mutex.unlock mutex)
-    f
+  if !eio_available then
+    Eio.Mutex.use_rw ~protect:true mutex (fun () -> f ())
+  else
+    f ()
 
 (** {1 History Persistence} *)
 
@@ -127,7 +132,7 @@ type event_handler = chain_event -> unit
 (** Global subscription registry *)
 let next_sub_id = ref 0
 let subscribers : (subscription_id, event_handler) Hashtbl.t = Hashtbl.create 16
-let subscribers_mutex = Mutex.create ()
+let subscribers_mutex = Eio.Mutex.create ()
 
 (** {1 Running Chains Tracking} *)
 
@@ -141,7 +146,7 @@ type running_chain_info = {
 }
 
 let running_chains : (string, running_chain_info) Hashtbl.t = Hashtbl.create 16
-let running_chains_mutex = Mutex.create ()
+let running_chains_mutex = Eio.Mutex.create ()
 
 (** Register a chain as running *)
 let register_running_chain ~chain_id ~total_nodes =
@@ -318,7 +323,7 @@ let error ~node_id ~message ~retries =
 
 (** Event log buffer for persistence *)
 let event_log : chain_event list ref = ref []
-let event_log_mutex = Mutex.create ()
+let event_log_mutex = Eio.Mutex.create ()
 let max_log_size = ref 10000
 
 (** Logging subscriber that buffers events *)

--- a/lib/chain_telemetry.mli
+++ b/lib/chain_telemetry.mli
@@ -6,11 +6,17 @@
     - 비동기 이벤트 발행 (emit)
     - 다중 구독자 지원 (subscribe/unsubscribe)
     - 구조화된 이벤트 타입 (ChainStart, NodeComplete, Error 등)
-    - Thread-safe 구독자 관리 (Stdlib.Mutex 사용)
+    - Fiber-safe 구독자 관리 (Eio.Mutex, dual-mode guard)
 
     @author Chain Engine
     @since 2026-01
 *)
+
+(** {1 Eio Runtime Activation} *)
+
+(** [enable_eio ()] activates Eio.Mutex guards.
+    Must be called once inside [Eio_main.run] before any concurrent access. *)
+val enable_eio : unit -> unit
 
 (** {1 Event Payload Types} *)
 

--- a/lib/generational_metrics.ml
+++ b/lib/generational_metrics.ml
@@ -2,7 +2,7 @@
 
     Tracks metrics across generations to prove (or disprove) that
     successor agents perform better than their predecessors.
-    
+
     Key metrics:
     - Task completion rate
     - Error rate
@@ -65,48 +65,66 @@ type generation_comparison = {
   verdict: string;              (* "improved" | "degraded" | "neutral" *)
 }
 
+(** {1 Eio-aware Mutex Guard}
+
+    Follows the dual-mode pattern from prometheus.ml:
+    Before Eio runtime starts, runs unlocked (single-threaded).
+    After {!enable_eio}, uses [Eio.Mutex]. *)
+let mu = Eio.Mutex.create ()
+let eio_available = ref false
+let enable_eio () = eio_available := true
+
+let with_lock f =
+  if !eio_available then
+    Eio.Mutex.use_rw ~protect:true mu (fun () -> f ())
+  else
+    f ()
+
 (** In-memory store for quick prototyping *)
 let task_records : task_record list ref = ref []
 let handoff_records : handoff_record list ref = ref []
 let retention_tests : retention_test list ref = ref []
 
 (** Record a task completion *)
-let record_task ~generation ~task_id ~completed ~duration_ms ~error_count 
+let record_task ~generation ~task_id ~completed ~duration_ms ~error_count
     ~input_tokens ~output_tokens =
-  let record = {
-    generation;
-    task_id;
-    completed;
-    duration_ms;
-    error_count;
-    input_tokens;
-    output_tokens;
-    timestamp = Time_compat.now ();
-  } in
-  task_records := record :: !task_records;
-  record
+  with_lock (fun () ->
+    let record = {
+      generation;
+      task_id;
+      completed;
+      duration_ms;
+      error_count;
+      input_tokens;
+      output_tokens;
+      timestamp = Time_compat.now ();
+    } in
+    task_records := record :: !task_records;
+    record)
 
 (** Record a handoff *)
 let record_handoff ~from_generation ~to_generation ~dna_size ~context_ratio =
-  let record = {
-    from_generation;
-    to_generation;
-    dna_size;
-    context_ratio;
-    timestamp = Time_compat.now ();
-  } in
-  handoff_records := record :: !handoff_records;
-  record
+  with_lock (fun () ->
+    let record = {
+      from_generation;
+      to_generation;
+      dna_size;
+      context_ratio;
+      timestamp = Time_compat.now ();
+    } in
+    handoff_records := record :: !handoff_records;
+    record)
 
 (** Record a knowledge retention test *)
 let record_retention_test ~generation ~question ~expected ~actual ~confidence =
-  let correct = String.lowercase_ascii expected = String.lowercase_ascii actual in
-  let record = { generation; question; expected; actual; correct; confidence } in
-  retention_tests := record :: !retention_tests;
-  record
+  with_lock (fun () ->
+    let correct = String.lowercase_ascii expected = String.lowercase_ascii actual in
+    let record = { generation; question; expected; actual; correct; confidence } in
+    retention_tests := record :: !retention_tests;
+    record)
 
-(** Summarize a generation's performance *)
-let summarize_generation generation =
+(** Internal: summarize without acquiring lock (caller must hold lock) *)
+let summarize_generation_unlocked generation =
   let tasks = List.filter (fun (t : task_record) -> t.generation = generation) !task_records in
   let total = List.length tasks in
   if total = 0 then None
@@ -116,15 +134,15 @@ let summarize_generation generation =
     let duration_sum = List.fold_left (fun acc t -> acc + t.duration_ms) 0 tasks in
     let input_sum = List.fold_left (fun acc t -> acc + t.input_tokens) 0 tasks in
     let output_sum = List.fold_left (fun acc t -> acc + t.output_tokens) 0 tasks in
-    
+
     let retention_tests_gen = List.filter (fun (r : retention_test) -> r.generation = generation) !retention_tests in
-    let retention = 
+    let retention =
       if List.length retention_tests_gen = 0 then None
       else
         let correct_count = List.filter (fun r -> r.correct) retention_tests_gen |> List.length in
         Some (float_of_int correct_count /. float_of_int (List.length retention_tests_gen))
     in
-    
+
     Some {
       generation;
       total_tasks = total;
@@ -136,46 +154,51 @@ let summarize_generation generation =
       knowledge_retention = retention;
     }
 
+(** Summarize a generation's performance *)
+let summarize_generation generation =
+  with_lock (fun () -> summarize_generation_unlocked generation)
+
 (** Compare two generations *)
 let compare_generations gen_a gen_b =
-  match summarize_generation gen_a, summarize_generation gen_b with
-  | None, _ | _, None -> None
-  | Some a, Some b ->
-      let completion_rate_a = float_of_int a.completed_tasks /. float_of_int a.total_tasks in
-      let completion_rate_b = float_of_int b.completed_tasks /. float_of_int b.total_tasks in
-      let error_rate_a = float_of_int a.total_errors /. float_of_int a.total_tasks in
-      let error_rate_b = float_of_int b.total_errors /. float_of_int b.total_tasks in
-      let tokens_per_task_a = float_of_int (a.total_input_tokens + a.total_output_tokens) /. float_of_int a.total_tasks in
-      let tokens_per_task_b = float_of_int (b.total_input_tokens + b.total_output_tokens) /. float_of_int b.total_tasks in
-      
-      let completion_delta = completion_rate_b -. completion_rate_a in
-      let error_delta = error_rate_b -. error_rate_a in
-      let duration_delta = b.avg_duration_ms -. a.avg_duration_ms in
-      let token_delta = tokens_per_task_b -. tokens_per_task_a in
-      
-      (* Verdict: improved if majority of metrics are better *)
-      let improvements = 
-        (if completion_delta > 0.05 then 1 else 0) +
-        (if error_delta < -0.05 then 1 else 0) +
-        (if duration_delta < 0.0 then 1 else 0) +
-        (if token_delta < 0.0 then 1 else 0)
-      in
-      let verdict = 
-        if improvements >= 3 then "improved"
-        else if improvements <= 1 then "degraded"
-        else "neutral"
-      in
-      
-      Some {
-        gen_a;
-        gen_b;
-        completion_delta;
-        error_delta;
-        duration_delta;
-        token_delta;
-        retention_b = b.knowledge_retention;
-        verdict;
-      }
+  with_lock (fun () ->
+    match summarize_generation_unlocked gen_a, summarize_generation_unlocked gen_b with
+    | None, _ | _, None -> None
+    | Some a, Some b ->
+        let completion_rate_a = float_of_int a.completed_tasks /. float_of_int a.total_tasks in
+        let completion_rate_b = float_of_int b.completed_tasks /. float_of_int b.total_tasks in
+        let error_rate_a = float_of_int a.total_errors /. float_of_int a.total_tasks in
+        let error_rate_b = float_of_int b.total_errors /. float_of_int b.total_tasks in
+        let tokens_per_task_a = float_of_int (a.total_input_tokens + a.total_output_tokens) /. float_of_int a.total_tasks in
+        let tokens_per_task_b = float_of_int (b.total_input_tokens + b.total_output_tokens) /. float_of_int b.total_tasks in
+
+        let completion_delta = completion_rate_b -. completion_rate_a in
+        let error_delta = error_rate_b -. error_rate_a in
+        let duration_delta = b.avg_duration_ms -. a.avg_duration_ms in
+        let token_delta = tokens_per_task_b -. tokens_per_task_a in
+
+        (* Verdict: improved if majority of metrics are better *)
+        let improvements =
+          (if completion_delta > 0.05 then 1 else 0) +
+          (if error_delta < -0.05 then 1 else 0) +
+          (if duration_delta < 0.0 then 1 else 0) +
+          (if token_delta < 0.0 then 1 else 0)
+        in
+        let verdict =
+          if improvements >= 3 then "improved"
+          else if improvements <= 1 then "degraded"
+          else "neutral"
+        in
+
+        Some {
+          gen_a;
+          gen_b;
+          completion_delta;
+          error_delta;
+          duration_delta;
+          token_delta;
+          retention_b = b.knowledge_retention;
+          verdict;
+        })
 
 (** Format comparison as string *)
 let format_comparison comp =
@@ -197,36 +220,38 @@ let format_comparison comp =
 
 (** Reset all metrics (for testing) *)
 let reset () =
-  task_records := [];
-  handoff_records := [];
-  retention_tests := []
+  with_lock (fun () ->
+    task_records := [];
+    handoff_records := [];
+    retention_tests := [])
 
 (** Export metrics to JSON *)
 let to_json () =
-  let tasks_json = `List (List.map (fun (t : task_record) ->
+  with_lock (fun () ->
+    let tasks_json = `List (List.map (fun (t : task_record) ->
+      `Assoc [
+        ("generation", `Int t.generation);
+        ("task_id", `String t.task_id);
+        ("completed", `Bool t.completed);
+        ("duration_ms", `Int t.duration_ms);
+        ("error_count", `Int t.error_count);
+        ("input_tokens", `Int t.input_tokens);
+        ("output_tokens", `Int t.output_tokens);
+        ("timestamp", `Float t.timestamp);
+      ]
+    ) !task_records) in
+
+    let handoffs_json = `List (List.map (fun (h : handoff_record) ->
+      `Assoc [
+        ("from_generation", `Int h.from_generation);
+        ("to_generation", `Int h.to_generation);
+        ("dna_size", `Int h.dna_size);
+        ("context_ratio", `Float h.context_ratio);
+        ("timestamp", `Float h.timestamp);
+      ]
+    ) !handoff_records) in
+
     `Assoc [
-      ("generation", `Int t.generation);
-      ("task_id", `String t.task_id);
-      ("completed", `Bool t.completed);
-      ("duration_ms", `Int t.duration_ms);
-      ("error_count", `Int t.error_count);
-      ("input_tokens", `Int t.input_tokens);
-      ("output_tokens", `Int t.output_tokens);
-      ("timestamp", `Float t.timestamp);
-    ]
-  ) !task_records) in
-  
-  let handoffs_json = `List (List.map (fun (h : handoff_record) ->
-    `Assoc [
-      ("from_generation", `Int h.from_generation);
-      ("to_generation", `Int h.to_generation);
-      ("dna_size", `Int h.dna_size);
-      ("context_ratio", `Float h.context_ratio);
-      ("timestamp", `Float h.timestamp);
-    ]
-  ) !handoff_records) in
-  
-  `Assoc [
-    ("tasks", tasks_json);
-    ("handoffs", handoffs_json);
-  ]
+      ("tasks", tasks_json);
+      ("handoffs", handoffs_json);
+    ])

--- a/lib/generational_metrics.mli
+++ b/lib/generational_metrics.mli
@@ -16,6 +16,12 @@
 
     @since 0.4.0 *)
 
+(** {1 Eio Runtime Activation} *)
+
+(** [enable_eio ()] activates Eio.Mutex guards for concurrent access safety.
+    Must be called once inside [Eio_main.run] before any concurrent access. *)
+val enable_eio : unit -> unit
+
 (** {1 Types} *)
 
 (** A single task completion record within a generation.

--- a/lib/mcp_server_eio.ml
+++ b/lib/mcp_server_eio.ml
@@ -695,6 +695,9 @@ let execute_tool_eio ~sw ~clock ?mcp_session_id ?auth_token state ~name ~argumen
   (* mcp_session_id: HTTP MCP session ID for agent_name persistence across tool calls *)
   let module U = Yojson.Safe.Util in
 
+  (* Prometheus: count every inbound tool call *)
+  Prometheus.record_request ();
+
   let config = state.Mcp_server.room_config in
   let registry = state.Mcp_server.session_registry in
 
@@ -1013,6 +1016,13 @@ let execute_tool_eio ~sw ~clock ?mcp_session_id ?auth_token state ~name ~argumen
         write_term_session_agent nickname;
         (try ignore (Session.register registry ~agent_name:nickname)
          with exn -> Printf.eprintf "[mcp_server] session register (nickname) failed: %s\n%!" (Printexc.to_string exn));
+        (* Prometheus + Telemetry: track auto-join *)
+        Prometheus.inc_gauge "masc_active_agents" ();
+        (match state.Mcp_server.fs with
+         | Some fs ->
+             (try Telemetry_eio.track_agent_joined ~fs config ~agent_id:nickname ()
+              with _ -> ())
+         | None -> ());
         nickname
       end
     end else
@@ -1789,6 +1799,14 @@ let execute_tool_eio ~sw ~clock ?mcp_session_id ?auth_token state ~name ~argumen
       (* Audit: log join event *)
       Audit_log.log_join config ~agent_id:nickname
         ~room_id:(Filename.basename config.base_path) ();
+      (* Prometheus: increment active agent gauge *)
+      Prometheus.inc_gauge "masc_active_agents" ();
+      (* Telemetry_eio: track agent joined *)
+      (match state.Mcp_server.fs with
+       | Some fs ->
+           (try Telemetry_eio.track_agent_joined ~fs config ~agent_id:nickname ()
+            with _ -> ())
+       | None -> ());
       (true, final_result)
 
   | "masc_leave" ->
@@ -1811,6 +1829,14 @@ let execute_tool_eio ~sw ~clock ?mcp_session_id ?auth_token state ~name ~argumen
       (* Audit: log leave event *)
       Audit_log.log_leave config ~agent_id:agent_name
         ~room_id:(Filename.basename config.base_path) ();
+      (* Prometheus: decrement active agent gauge *)
+      Prometheus.dec_gauge "masc_active_agents" ();
+      (* Telemetry_eio: track agent left *)
+      (match state.Mcp_server.fs with
+       | Some fs ->
+           (try Telemetry_eio.track_agent_left ~fs config ~agent_id:agent_name ~reason:"leave"
+            with _ -> ())
+       | None -> ());
       (true, result)
 
 
@@ -3231,6 +3257,10 @@ in
           with exn ->
             Printf.eprintf "[WARN] telemetry tracking failed: %s\n%!" (Printexc.to_string exn))
      | None -> ());
+
+  (* Prometheus: record errors for failed tool calls *)
+  if not success then
+    Prometheus.record_error ~error_type:name ();
 
   (* Track in-memory call counter only for declared tool names. *)
   Tool_registry.record_call_if_known ~tool_name:name ~success ~duration_ms;

--- a/lib/perpetual_loop.ml
+++ b/lib/perpetual_loop.ml
@@ -312,6 +312,49 @@ let coding_turn ~config ~state =
     Error "coding_mode requires coding_sw and coding_proc_mgr to be set"
 
 (* ================================================================ *)
+(* Event Bus Bridge                                                 *)
+(* ================================================================ *)
+
+(** Publish perpetual_loop events to OAS Event_bus when configured.
+    Extracted to module level to avoid duplication across emit closures. *)
+let publish_to_event_bus bus (ev : event) =
+  match ev with
+  | Heartbeat { turn; context_pct } ->
+    Oas_events.publish_heartbeat bus ~agent_name:"perpetual"
+      ~turn ~context_pct
+  | TurnStart turn ->
+    Agent_sdk.Event_bus.publish bus
+      (Agent_sdk.Event_bus.TurnStarted
+         { agent_name = "perpetual"; turn })
+  | TurnEnd { turn; _ } ->
+    Agent_sdk.Event_bus.publish bus
+      (Agent_sdk.Event_bus.TurnCompleted
+         { agent_name = "perpetual"; turn })
+  | Error msg ->
+    Agent_sdk.Event_bus.publish bus
+      (Agent_sdk.Event_bus.Custom ("masc:perpetual:error",
+        `Assoc [("message", `String msg);
+                ("timestamp", `Float (Time_compat.now ()))]))
+  | Terminated reason ->
+    Agent_sdk.Event_bus.publish bus
+      (Agent_sdk.Event_bus.Custom ("masc:perpetual:terminated",
+        `Assoc [("reason", `String reason);
+                ("timestamp", `Float (Time_compat.now ()))]))
+  | Compacted { before_tokens; after_tokens } ->
+    Agent_sdk.Event_bus.publish bus
+      (Agent_sdk.Event_bus.Custom ("masc:perpetual:compacted",
+        `Assoc [("before", `Int before_tokens);
+                ("after", `Int after_tokens);
+                ("timestamp", `Float (Time_compat.now ()))]))
+  | Handoff { to_model; generation } ->
+    Agent_sdk.Event_bus.publish bus
+      (Agent_sdk.Event_bus.Custom ("masc:perpetual:handoff",
+        `Assoc [("to_model", `String to_model);
+                ("generation", `Int generation);
+                ("timestamp", `Float (Time_compat.now ()))]))
+  | _ -> ()
+
+(* ================================================================ *)
 (* Single Turn Execution                                            *)
 (* ================================================================ *)
 
@@ -323,21 +366,7 @@ let run_coding_turn ~config ~state =
   let emit ev =
     record_event state ev;
     config.on_event ev;
-    Option.iter (fun bus ->
-      match ev with
-      | Heartbeat { turn; context_pct } ->
-        Oas_events.publish_heartbeat bus ~agent_name:"perpetual"
-          ~turn ~context_pct
-      | TurnStart turn ->
-        Agent_sdk.Event_bus.publish bus
-          (Agent_sdk.Event_bus.TurnStarted
-             { agent_name = "perpetual"; turn })
-      | TurnEnd { turn; _ } ->
-        Agent_sdk.Event_bus.publish bus
-          (Agent_sdk.Event_bus.TurnCompleted
-             { agent_name = "perpetual"; turn })
-      | _ -> ()
-    ) config.event_bus
+    Option.iter (fun bus -> publish_to_event_bus bus ev) config.event_bus
   in
   match coding_turn ~config ~state with
   | Error e ->
@@ -451,21 +480,7 @@ let run_turn ~config ~state =
       record_event state ev;
       config.on_event ev;
       (* Bridge to OAS Event_bus when configured *)
-      Option.iter (fun bus ->
-        match ev with
-        | Heartbeat { turn; context_pct } ->
-          Oas_events.publish_heartbeat bus ~agent_name:"perpetual"
-            ~turn ~context_pct
-        | TurnStart turn ->
-          Agent_sdk.Event_bus.publish bus
-            (Agent_sdk.Event_bus.TurnStarted
-               { agent_name = "perpetual"; turn })
-        | TurnEnd { turn; _ } ->
-          Agent_sdk.Event_bus.publish bus
-            (Agent_sdk.Event_bus.TurnCompleted
-               { agent_name = "perpetual"; turn })
-        | _ -> ()
-      ) config.event_bus
+      Option.iter (fun bus -> publish_to_event_bus bus ev) config.event_bus
     in
     emit (TurnStart turn);
 

--- a/lib/telemetry_eio.ml
+++ b/lib/telemetry_eio.ml
@@ -279,35 +279,6 @@ let get_metrics ~fs config : metrics =
     error_rate = calculate_error_rate events;
   }
 
-(** Export metrics in Prometheus format *)
-let export_prometheus ~fs config : string =
-  let m = get_metrics ~fs config in
-  Printf.sprintf {|# HELP masc_active_agents Number of active agents
-# TYPE masc_active_agents gauge
-masc_active_agents %d
-
-# HELP masc_tasks_in_progress Tasks currently in progress
-# TYPE masc_tasks_in_progress gauge
-masc_tasks_in_progress %d
-
-# HELP masc_tasks_completed Tasks completed in last 24h
-# TYPE masc_tasks_completed counter
-masc_tasks_completed %d
-
-# HELP masc_avg_task_duration Average task duration in ms
-# TYPE masc_avg_task_duration gauge
-masc_avg_task_duration %.2f
-
-# HELP masc_handoff_rate Handoff rate (0-1)
-# TYPE masc_handoff_rate gauge
-masc_handoff_rate %.4f
-
-# HELP masc_error_rate Error rate (0-1)
-# TYPE masc_error_rate gauge
-masc_error_rate %.4f
-|} m.active_agents m.tasks_in_progress m.tasks_completed_24h
-     m.avg_task_duration_ms m.handoff_rate m.error_rate
-
 (** Convenience tracking functions *)
 let track_agent_joined ~fs config ~agent_id ?(capabilities=[]) () =
   track ~fs config (Agent_joined { agent_id; capabilities })

--- a/lib/tool_task.ml
+++ b/lib/tool_task.ml
@@ -132,6 +132,8 @@ let handle_done ctx args =
         with exn -> Printf.eprintf "[task] Metrics_store_eio.record(done) failed: %s\n%!" (Printexc.to_string exn));
        (* Feed success into Thompson Sampling quality signal *)
        Lodge_selection.record_vote ~agent_name:ctx.agent_name ~direction:`Up;
+       (* Prometheus: record task completion *)
+       Prometheus.record_task_completed ();
        (* Audit: log done event *)
        Audit_log.log_done_task ctx.config ~agent_id:ctx.agent_name
          ~room_id:(Filename.basename ctx.config.base_path)
@@ -174,6 +176,8 @@ let handle_cancel_task ctx args =
         with exn -> Printf.eprintf "[task] Metrics_store_eio.record(cancel) failed: %s\n%!" (Printexc.to_string exn));
        (* Feed failure into Thompson Sampling quality signal *)
        Lodge_selection.record_vote ~agent_name:ctx.agent_name ~direction:`Down;
+       (* Prometheus: record task failure *)
+       Prometheus.record_task_failed ();
        (* Notification harness: push cancel event to all active sessions *)
        Subscriptions.push_event_to_sessions (`Assoc [
          ("type", `String "masc/task_cancelled");
@@ -284,7 +288,8 @@ let handle_transition ctx args =
        } in
        (try ignore (Metrics_store_eio.record ctx.config metric)
         with exn -> Printf.eprintf "[task] Metrics_store_eio.record(transition-done) failed: %s\n%!" (Printexc.to_string exn));
-       Lodge_selection.record_vote ~agent_name:ctx.agent_name ~direction:`Up
+       Lodge_selection.record_vote ~agent_name:ctx.agent_name ~direction:`Up;
+       Prometheus.record_task_completed ()
    | Ok _, "cancel" ->
        let metric : Metrics_store_eio.task_metric = {
          id = Printf.sprintf "metric-%s-%d" task_id (int_of_float (Time_compat.now () *. 1000.));
@@ -300,7 +305,8 @@ let handle_transition ctx args =
        } in
        (try ignore (Metrics_store_eio.record ctx.config metric)
         with exn -> Printf.eprintf "[task] Metrics_store_eio.record(transition-cancel) failed: %s\n%!" (Printexc.to_string exn));
-       Lodge_selection.record_vote ~agent_name:ctx.agent_name ~direction:`Down
+       Lodge_selection.record_vote ~agent_name:ctx.agent_name ~direction:`Down;
+       Prometheus.record_task_failed ()
    | _ -> ());
   result_to_response result
 


### PR DESCRIPTION
## Summary

- **Phase 1 (Concurrency)**: `chain_telemetry.ml`과 `generational_metrics.ml`의 `Stdlib.Mutex`를 Eio.Mutex dual-mode guard 패턴으로 교체. Stdlib.Mutex는 Eio fiber scheduler 전체를 블로킹하는 버그. `compare_generations`에서 비재귀 Eio.Mutex deadlock 방지를 위해 `summarize_generation_unlocked` 내부 함수 분리.
- **Phase 2 (Prometheus wiring)**: `record_request`, `record_error`, `record_task_completed/failed`, `inc/dec active_agents` gauge를 production dispatch 경로에 배선. 기존에는 테스트에서만 호출되어 `/metrics` 엔드포인트가 항상 0을 반환.
- **Phase 3 (Telemetry_eio, 부분)**: `track_agent_joined/left`를 join/leave + auto-join 경로에 배선. `track_handoff`는 context 확장 필요하므로 후속 PR.
- **Phase 4 (perpetual_loop events)**: 중복 emit 클로저를 `publish_to_event_bus` 모듈 레벨 헬퍼로 추출. Error/Terminated/Compacted/Handoff 이벤트를 OAS Event_bus에 전파 (기존에는 `| _ -> ()`로 무시).
- **Phase 5 (Dead code)**: `telemetry_eio.ml`의 `export_prometheus` 함수 삭제 (어떤 route에서도 미호출, `Prometheus.to_prometheus_text()`가 실제 사용 경로).

## Evidence

| Issue | Severity | Fix |
|-------|----------|-----|
| `chain_telemetry.ml` Stdlib.Mutex in Eio context | MEDIUM | Eio.Mutex dual-mode guard |
| `generational_metrics.ml` bare refs without mutex | MEDIUM | Eio.Mutex `with_lock` wrapper |
| Prometheus convenience functions test-only | HIGH | Wired into dispatch/join/leave/done/cancel |
| `Telemetry_eio.track_agent_*` never called | CRITICAL | Wired into join/leave paths |
| `perpetual_loop` Event_bus `\| _ -> ()` | LOW | Added Error/Terminated/Compacted/Handoff events |
| `export_prometheus` dead code | LOW | Deleted |

## Test plan

- [x] `test_prometheus_coverage` (51 tests)
- [x] `test_mitosis_metrics` (12 tests)
- [x] `test_telemetry_eio_coverage` (32 tests)
- [x] `test_perpetual` (143 tests)
- [x] `test_chain_orchestrator_eio` (5 tests)
- [x] `test_tool_perpetual_coverage` (22 tests)
- [x] `test_dispatch_chain_evidence` (all passed)
- [ ] Full `make test` (CI)
- [ ] Manual: `curl /metrics | grep masc_` returns non-zero values after tool calls

Generated with [Claude Code](https://claude.com/claude-code)