### PR TITLE
feat(lodge): LLM-based topic extraction with Heuristic/LLM/Hybrid modes

### DIFF
--- a/config/llm_cascade.json
+++ b/config/llm_cascade.json
@@ -86,5 +86,9 @@
     "glm:glm-4.7-flash",
     "glm:glm-5",
     "glm:glm-5-code"
+  ],
+  "topic_extraction_models": [
+    "ollama:glm-4.7-flash",
+    "glm:glm-4.7"
   ]
 }

--- a/lib/dune
+++ b/lib/dune
@@ -164,6 +164,7 @@
    lodge_memory
    lodge_memory_gc
    lodge_reaction
+   lodge_topic
    lodge_tom
    lodge_selection
    memory_stream

--- a/lib/lodge_cascade.ml
+++ b/lib/lodge_cascade.ml
@@ -122,6 +122,10 @@ let default_model_strings ~cascade_name =
       [ Printf.sprintf "glm:%s" Env_config.Llm.default_model;
         Printf.sprintf "glm:%s" Env_config.Llm.flash_model;
         "glm:glm-5"; "glm:glm-5-code" ]
+  (* topic extraction — fast local model, glm fallback *)
+  | "topic_extraction" ->
+      [ Printf.sprintf "ollama:%s" Env_config.Llm.flash_model;
+        Printf.sprintf "glm:%s" Env_config.Llm.default_model ]
   (* unregistered cascade: llama + glm as safety net *)
   | _ -> llama_glm
 

--- a/lib/lodge_reaction.ml
+++ b/lib/lodge_reaction.ml
@@ -315,24 +315,10 @@ let get_or_compute_signature ~agent_name : agent_signature =
 (** {1 Topic Extraction} *)
 
 (** Extract topics from post content.
-    Simple keyword extraction — can be enhanced with NLP later. *)
+    Delegates to Lodge_topic which supports Heuristic/LLM/Hybrid modes.
+    @since 4.1.0 — LLM-based extraction via MASC_TOPIC_MODE env var *)
 let extract_topics (content : string) : string list =
-  (* Common tech/domain keywords to look for *)
-  let keywords = [
-    "ocaml"; "eio"; "graphql"; "neo4j"; "rust"; "typescript"; "react";
-    "agent"; "mcp"; "llm"; "ai"; "ml"; "api"; "webrtc"; "grpc";
-    "postgresql"; "sqlite"; "redis"; "vector";
-    "test"; "debug"; "deploy"; "ci"; "docker"; "kubernetes";
-    "architecture"; "design"; "pattern"; "refactor";
-    "performance"; "memory"; "concurrency"; "async";
-  ] in
-
-  let lower = String.lowercase_ascii content in
-  List.filter (fun kw ->
-    let pattern = Str.regexp_string kw in
-    try ignore (Str.search_forward pattern lower 0); true
-    with Not_found -> false
-  ) keywords
+  Lodge_topic.extract_topics content
 
 (** {1 Prompt Generation} *)
 

--- a/lib/lodge_topic.ml
+++ b/lib/lodge_topic.ml
@@ -151,8 +151,12 @@ let extract_topics_llm (content : string) : (string list, string) result =
         | _ -> []
       in
       Ok topics
-    | Ok None | Error _ ->
-      (* Cache miss — call LLM via cascade *)
+    | cache_result ->
+      (* Log cache read errors separately from clean misses *)
+      (match cache_result with
+       | Error e -> eprintf "[lodge_topic] cache read error: %s\n%!" e
+       | _ -> ());
+      (* Cache miss or error — call LLM via cascade *)
       let prompt = build_topic_prompt content in
       begin match
         Lodge_cascade.call
@@ -167,12 +171,14 @@ let extract_topics_llm (content : string) : (string list, string) result =
         let topics = parse_topics_response result.Lodge_cascade.response in
         (* Cache the result *)
         let json = `List (List.map (fun t -> `String t) topics) in
-        let _ =
+        (match
           Llm_response_cache.set_json
             ~key:cache_key
             ~ttl_seconds:cache_ttl_seconds
             json
-        in
+        with
+        | Ok () -> ()
+        | Error e -> eprintf "[lodge_topic] cache write failed: %s\n%!" e);
         Ok topics
       | Error msg ->
         Error (sprintf "topic_extraction cascade failed: %s" msg)

--- a/lib/lodge_topic.ml
+++ b/lib/lodge_topic.ml
@@ -1,0 +1,196 @@
+(** Lodge Topic Extraction — Heuristic, LLM, and Hybrid modes.
+
+    Follows the Heuristic/Llm/Hybrid pattern from context_router.ml.
+    Uses Lodge_cascade.call + Llm_response_cache for LLM extraction + caching.
+
+    @since 4.1.0 (ROADMAP Phase 2.2.2) *)
+
+open Printf
+
+(** {1 Types} *)
+
+type topic_mode =
+  | Heuristic
+  | Llm
+  | Hybrid
+
+(** {1 Mode Selection} *)
+
+let get_topic_mode () =
+  match Sys.getenv_opt "MASC_TOPIC_MODE" with
+  | Some "heuristic" -> Heuristic
+  | Some "llm" -> Llm
+  | Some "hybrid" -> Hybrid
+  | _ -> Hybrid
+
+(** {1 Constants} *)
+
+(** Maximum number of topics to return *)
+let max_topics = 8
+
+(** Maximum length of a single topic string *)
+let max_topic_length = 50
+
+(** Minimum content length to attempt LLM extraction *)
+let min_content_length = 10
+
+(** Maximum content length sent to LLM (truncated beyond this) *)
+let max_prompt_content_length = 1000
+
+(** Cache TTL for topic extraction results (seconds) *)
+let cache_ttl_seconds = 3600
+
+(** {1 Heuristic Extraction} *)
+
+(** Common tech/domain keywords — moved from lodge_reaction.ml *)
+let keywords = [
+  "ocaml"; "eio"; "graphql"; "neo4j"; "rust"; "typescript"; "react";
+  "agent"; "mcp"; "llm"; "ai"; "ml"; "api"; "webrtc"; "grpc";
+  "postgresql"; "sqlite"; "redis"; "vector";
+  "test"; "debug"; "deploy"; "ci"; "docker"; "kubernetes";
+  "architecture"; "design"; "pattern"; "refactor";
+  "performance"; "memory"; "concurrency"; "async";
+]
+
+let extract_topics_heuristic (content : string) : string list =
+  let lower = String.lowercase_ascii content in
+  List.filter (fun kw ->
+    let pattern = Str.regexp_string kw in
+    try ignore (Str.search_forward pattern lower 0); true
+    with Not_found -> false
+  ) keywords
+
+(** {1 LLM Prompt} *)
+
+let build_topic_prompt (content : string) : string =
+  let truncated =
+    if String.length content > max_prompt_content_length then
+      String.sub content 0 max_prompt_content_length
+    else
+      content
+  in
+  sprintf {|Extract the main topics from this post. Return a JSON array of lowercase topic strings.
+Rules:
+- Return 1 to 8 topics
+- Topics should be specific (e.g. "functional-programming" not "programming")
+- Use kebab-case for multi-word topics
+- Include both explicit and implied topics
+- Focus on technical concepts, tools, and domains
+
+Post:
+"%s"
+
+Topics (JSON array only):|} truncated
+
+(** {1 Response Parsing} *)
+
+(** Try to find and parse a JSON array from text.
+    Handles: clean JSON, JSON embedded in prose, malformed input. *)
+let parse_topics_response (text : string) : string list =
+  let try_parse_json s =
+    try
+      match Yojson.Safe.from_string s with
+      | `List items ->
+        List.filter_map (function
+          | `String topic ->
+            let t = String.trim (String.lowercase_ascii topic) in
+            if String.length t > 0 && String.length t <= max_topic_length then
+              Some t
+            else
+              None
+          | _ -> None
+        ) items
+      | _ -> []
+    with Yojson.Json_error _ -> []
+  in
+  (* First: try parsing the entire text as JSON *)
+  let trimmed = String.trim text in
+  match try_parse_json trimmed with
+  | (_ :: _) as topics ->
+    if List.length topics > max_topics then
+      List.filteri (fun i _ -> i < max_topics) topics
+    else
+      topics
+  | [] ->
+    (* Second: try to find a JSON array within the text *)
+    let result =
+      try
+        let start = String.index trimmed '[' in
+        let stop = String.rindex trimmed ']' in
+        if stop > start then
+          let json_str = String.sub trimmed start (stop - start + 1) in
+          try_parse_json json_str
+        else
+          []
+      with Not_found -> []
+    in
+    if List.length result > max_topics then
+      List.filteri (fun i _ -> i < max_topics) result
+    else
+      result
+
+(** {1 LLM Extraction} *)
+
+let extract_topics_llm (content : string) : (string list, string) result =
+  (* Skip very short content *)
+  if String.length (String.trim content) < min_content_length then
+    Ok []
+  else
+    let cache_key =
+      Llm_response_cache.make_key ~namespace:"topic" ~content
+    in
+    (* Check cache first *)
+    match Llm_response_cache.get_json ~key:cache_key with
+    | Ok (Some cached_json) ->
+      let topics = match cached_json with
+        | `List items ->
+          List.filter_map (function
+            | `String s -> Some s
+            | _ -> None
+          ) items
+        | _ -> []
+      in
+      Ok topics
+    | Ok None | Error _ ->
+      (* Cache miss — call LLM via cascade *)
+      let prompt = build_topic_prompt content in
+      begin match
+        Lodge_cascade.call
+          ~cascade_name:"topic_extraction"
+          ~prompt
+          ~temperature:0.1
+          ~timeout_sec:5
+          ~max_tokens:150
+          ()
+      with
+      | Ok result ->
+        let topics = parse_topics_response result.Lodge_cascade.response in
+        (* Cache the result *)
+        let json = `List (List.map (fun t -> `String t) topics) in
+        let _ =
+          Llm_response_cache.set_json
+            ~key:cache_key
+            ~ttl_seconds:cache_ttl_seconds
+            json
+        in
+        Ok topics
+      | Error msg ->
+        Error (sprintf "topic_extraction cascade failed: %s" msg)
+      end
+
+(** {1 Main Dispatch} *)
+
+let extract_topics (content : string) : string list =
+  match get_topic_mode () with
+  | Heuristic ->
+    extract_topics_heuristic content
+  | Llm ->
+    begin match extract_topics_llm content with
+    | Ok topics when topics <> [] -> topics
+    | _ -> []
+    end
+  | Hybrid ->
+    begin match extract_topics_llm content with
+    | Ok topics when topics <> [] -> topics
+    | _ -> extract_topics_heuristic content
+    end

--- a/lib/lodge_topic.mli
+++ b/lib/lodge_topic.mli
@@ -1,0 +1,49 @@
+(** Lodge Topic Extraction — Heuristic, LLM, and Hybrid modes.
+
+    Extracts topics from post content using keyword matching (heuristic),
+    LLM-based semantic extraction, or a hybrid that falls back to heuristic
+    when LLM fails or returns empty.
+
+    Mode is controlled by MASC_TOPIC_MODE env var:
+    - "heuristic" — keyword matching only (original behavior)
+    - "llm" — LLM only (empty list on failure)
+    - "hybrid" — LLM with heuristic fallback (default)
+
+    @since 4.1.0 (ROADMAP Phase 2.2.2) *)
+
+(** {1 Types} *)
+
+(** Topic extraction mode *)
+type topic_mode =
+  | Heuristic  (** Keyword matching only *)
+  | Llm        (** LLM-based extraction only *)
+  | Hybrid     (** LLM with heuristic fallback *)
+
+(** {1 Mode} *)
+
+val get_topic_mode : unit -> topic_mode
+(** Read MASC_TOPIC_MODE env var. Default: Hybrid. *)
+
+(** {1 Extraction} *)
+
+val extract_topics : string -> string list
+(** Main entry point. Dispatches to heuristic, LLM, or hybrid based on mode. *)
+
+val extract_topics_heuristic : string -> string list
+(** Keyword-based extraction. Matches against a fixed set of tech keywords.
+    Moved from Lodge_reaction.extract_topics. *)
+
+val extract_topics_llm : string -> (string list, string) result
+(** LLM-based extraction with caching. Returns Error on LLM failure. *)
+
+(** {1 Parsing} *)
+
+val parse_topics_response : string -> string list
+(** Parse LLM response text into topic list.
+    Handles clean JSON arrays, JSON embedded in prose, and malformed input.
+    Filters oversized topics (>50 chars) and truncates to 8 items. *)
+
+(** {1 Prompt} *)
+
+val build_topic_prompt : string -> string
+(** Build the extraction prompt for a given content string. *)

--- a/lib/masc_mcp.ml
+++ b/lib/masc_mcp.ml
@@ -282,6 +282,7 @@ module Lodge_heartbeat = Lodge_heartbeat
 module Lodge_memory = Lodge_memory
 module Lodge_selection = Lodge_selection
 module Lodge_reaction = Lodge_reaction
+module Lodge_topic = Lodge_topic
 module Lodge_tom = Lodge_tom
 
 module Game_view_state = Game_view_state

--- a/test/dune
+++ b/test/dune
@@ -252,6 +252,12 @@
  (modules test_guardian_sentinel)
  (libraries masc_mcp alcotest yojson unix))
 
+; Lodge_topic module tests (Heuristic/LLM/Hybrid Topic Extraction)
+(test
+ (name test_lodge_topic)
+ (modules test_lodge_topic)
+ (libraries masc_mcp alcotest str yojson unix))
+
 ; Lodge_reaction module tests (Emergent Identity System)
 (test
  (name test_lodge_reaction)

--- a/test/test_lodge_reaction.ml
+++ b/test/test_lodge_reaction.ml
@@ -61,17 +61,20 @@ let test_trait_weight_100_reactions () =
   let w = Lodge_reaction.trait_weight ~reaction_count:100 in
   check (float 0.01) "100 reactions = 0% traits (clamped)" 0.0 w
 
-(* Topic extraction tests *)
+(* Topic extraction tests — pinned to heuristic mode for deterministic results *)
 let test_extract_topics_ocaml () =
+  Unix.putenv "MASC_TOPIC_MODE" "heuristic";
   let topics = Lodge_reaction.extract_topics "I love OCaml and Eio for async programming" in
   check bool "contains ocaml" true (List.mem "ocaml" topics);
   check bool "contains eio" true (List.mem "eio" topics)
 
 let test_extract_topics_empty () =
+  Unix.putenv "MASC_TOPIC_MODE" "heuristic";
   let topics = Lodge_reaction.extract_topics "Hello world" in
   check int "no topics" 0 (List.length topics)
 
 let test_extract_topics_multiple () =
+  Unix.putenv "MASC_TOPIC_MODE" "heuristic";
   let topics = Lodge_reaction.extract_topics "GraphQL API with Neo4j and React frontend" in
   check bool "contains graphql" true (List.mem "graphql" topics);
   check bool "contains neo4j" true (List.mem "neo4j" topics);

--- a/test/test_lodge_topic.ml
+++ b/test/test_lodge_topic.ml
@@ -3,6 +3,15 @@
 open Alcotest
 open Masc_mcp
 
+(* Helper: run f with MASC_TOPIC_MODE set, restore after (even on exception) *)
+let with_topic_mode mode f =
+  let prev = Sys.getenv_opt "MASC_TOPIC_MODE" in
+  Unix.putenv "MASC_TOPIC_MODE" mode;
+  Fun.protect f ~finally:(fun () ->
+    match prev with
+    | Some v -> Unix.putenv "MASC_TOPIC_MODE" v
+    | None -> Unix.putenv "MASC_TOPIC_MODE" "hybrid")
+
 (* ============================================
    Parsing tests — pure functions, no I/O
    ============================================ *)
@@ -90,26 +99,20 @@ let test_heuristic_case_insensitive () =
    ============================================ *)
 
 let test_mode_dispatch_heuristic () =
-  (* Force heuristic mode *)
-  Unix.putenv "MASC_TOPIC_MODE" "heuristic";
-  let topics = Lodge_topic.extract_topics "I love OCaml and Eio" in
-  check bool "contains ocaml" true (List.mem "ocaml" topics);
-  check bool "contains eio" true (List.mem "eio" topics);
-  (* Clean up *)
-  Unix.putenv "MASC_TOPIC_MODE" "hybrid"
+  with_topic_mode "heuristic" (fun () ->
+    let topics = Lodge_topic.extract_topics "I love OCaml and Eio" in
+    check bool "contains ocaml" true (List.mem "ocaml" topics);
+    check bool "contains eio" true (List.mem "eio" topics))
 
 let test_mode_env_parsing () =
-  Unix.putenv "MASC_TOPIC_MODE" "heuristic";
-  check bool "heuristic mode" true (Lodge_topic.get_topic_mode () = Lodge_topic.Heuristic);
-  Unix.putenv "MASC_TOPIC_MODE" "llm";
-  check bool "llm mode" true (Lodge_topic.get_topic_mode () = Lodge_topic.Llm);
-  Unix.putenv "MASC_TOPIC_MODE" "hybrid";
-  check bool "hybrid mode" true (Lodge_topic.get_topic_mode () = Lodge_topic.Hybrid);
-  (* Unknown defaults to Hybrid *)
-  Unix.putenv "MASC_TOPIC_MODE" "unknown";
-  check bool "unknown defaults to hybrid" true (Lodge_topic.get_topic_mode () = Lodge_topic.Hybrid);
-  (* Restore *)
-  Unix.putenv "MASC_TOPIC_MODE" "hybrid"
+  with_topic_mode "heuristic" (fun () ->
+    check bool "heuristic mode" true (Lodge_topic.get_topic_mode () = Lodge_topic.Heuristic));
+  with_topic_mode "llm" (fun () ->
+    check bool "llm mode" true (Lodge_topic.get_topic_mode () = Lodge_topic.Llm));
+  with_topic_mode "hybrid" (fun () ->
+    check bool "hybrid mode" true (Lodge_topic.get_topic_mode () = Lodge_topic.Hybrid));
+  with_topic_mode "unknown" (fun () ->
+    check bool "unknown defaults to hybrid" true (Lodge_topic.get_topic_mode () = Lodge_topic.Hybrid))
 
 (* ============================================
    Prompt generation tests
@@ -139,12 +142,10 @@ let test_build_prompt_has_json_instruction () =
    ============================================ *)
 
 let test_llm_skip_short_content () =
-  (* Very short content should return Ok [] without LLM call *)
-  Unix.putenv "MASC_TOPIC_MODE" "llm";
-  let result = Lodge_topic.extract_topics_llm "hi" in
-  check bool "short content returns Ok" true (Result.is_ok result);
-  check int "empty topics" 0 (List.length (Result.get_ok result));
-  Unix.putenv "MASC_TOPIC_MODE" "hybrid"
+  with_topic_mode "llm" (fun () ->
+    let result = Lodge_topic.extract_topics_llm "hi" in
+    check bool "short content returns Ok" true (Result.is_ok result);
+    check int "empty topics" 0 (List.length (Result.get_ok result)))
 
 (* ============================================
    Test suite

--- a/test/test_lodge_topic.ml
+++ b/test/test_lodge_topic.ml
@@ -1,0 +1,184 @@
+(** Tests for Lodge_topic module — Heuristic/LLM/Hybrid Topic Extraction *)
+
+open Alcotest
+open Masc_mcp
+
+(* ============================================
+   Parsing tests — pure functions, no I/O
+   ============================================ *)
+
+let test_parse_clean_json () =
+  let topics = Lodge_topic.parse_topics_response {|["ocaml","eio"]|} in
+  check int "2 topics" 2 (List.length topics);
+  check bool "contains ocaml" true (List.mem "ocaml" topics);
+  check bool "contains eio" true (List.mem "eio" topics)
+
+let test_parse_json_in_prose () =
+  let topics = Lodge_topic.parse_topics_response {|Here are the topics: ["agent","mcp"]|} in
+  check int "2 topics" 2 (List.length topics);
+  check bool "contains agent" true (List.mem "agent" topics);
+  check bool "contains mcp" true (List.mem "mcp" topics)
+
+let test_parse_malformed () =
+  let topics = Lodge_topic.parse_topics_response "not json at all" in
+  check int "0 topics" 0 (List.length topics)
+
+let test_parse_empty_array () =
+  let topics = Lodge_topic.parse_topics_response "[]" in
+  check int "0 topics" 0 (List.length topics)
+
+let test_parse_truncation () =
+  (* 10+ items should be truncated to 8 *)
+  let json = {|["a","b","c","d","e","f","g","h","i","j","k"]|} in
+  let topics = Lodge_topic.parse_topics_response json in
+  check int "truncated to 8" 8 (List.length topics)
+
+let test_parse_oversized_topic () =
+  (* Topics longer than 50 chars should be filtered out *)
+  let long_topic = String.make 51 'x' in
+  let json = Printf.sprintf {|["%s", "ocaml"]|} long_topic in
+  let topics = Lodge_topic.parse_topics_response json in
+  check int "only 1 valid topic" 1 (List.length topics);
+  check bool "contains ocaml" true (List.mem "ocaml" topics)
+
+let test_parse_mixed_types () =
+  (* Non-string items in array should be filtered *)
+  let topics = Lodge_topic.parse_topics_response {|["ocaml", 42, true, "eio"]|} in
+  check int "2 string topics" 2 (List.length topics);
+  check bool "contains ocaml" true (List.mem "ocaml" topics);
+  check bool "contains eio" true (List.mem "eio" topics)
+
+let test_parse_whitespace_and_case () =
+  (* Should trim and lowercase *)
+  let topics = Lodge_topic.parse_topics_response {|["  OCaml  ", "EIO"]|} in
+  check int "2 topics" 2 (List.length topics);
+  check bool "lowercased ocaml" true (List.mem "ocaml" topics);
+  check bool "lowercased eio" true (List.mem "eio" topics)
+
+let test_parse_empty_string_topic () =
+  (* Empty strings should be filtered *)
+  let topics = Lodge_topic.parse_topics_response {|["", "ocaml", ""]|} in
+  check int "1 valid topic" 1 (List.length topics)
+
+(* ============================================
+   Heuristic tests — keyword matching
+   ============================================ *)
+
+let test_heuristic_ocaml () =
+  let topics = Lodge_topic.extract_topics_heuristic "I love OCaml and Eio" in
+  check bool "contains ocaml" true (List.mem "ocaml" topics);
+  check bool "contains eio" true (List.mem "eio" topics)
+
+let test_heuristic_empty () =
+  let topics = Lodge_topic.extract_topics_heuristic "Hello world" in
+  check int "no topics" 0 (List.length topics)
+
+let test_heuristic_multiple () =
+  let topics = Lodge_topic.extract_topics_heuristic "GraphQL API with Neo4j and React frontend" in
+  check bool "contains graphql" true (List.mem "graphql" topics);
+  check bool "contains neo4j" true (List.mem "neo4j" topics);
+  check bool "contains react" true (List.mem "react" topics);
+  check bool "contains api" true (List.mem "api" topics)
+
+let test_heuristic_case_insensitive () =
+  let topics = Lodge_topic.extract_topics_heuristic "RUST and DOCKER" in
+  check bool "contains rust" true (List.mem "rust" topics);
+  check bool "contains docker" true (List.mem "docker" topics)
+
+(* ============================================
+   Mode dispatch tests
+   ============================================ *)
+
+let test_mode_dispatch_heuristic () =
+  (* Force heuristic mode *)
+  Unix.putenv "MASC_TOPIC_MODE" "heuristic";
+  let topics = Lodge_topic.extract_topics "I love OCaml and Eio" in
+  check bool "contains ocaml" true (List.mem "ocaml" topics);
+  check bool "contains eio" true (List.mem "eio" topics);
+  (* Clean up *)
+  Unix.putenv "MASC_TOPIC_MODE" "hybrid"
+
+let test_mode_env_parsing () =
+  Unix.putenv "MASC_TOPIC_MODE" "heuristic";
+  check bool "heuristic mode" true (Lodge_topic.get_topic_mode () = Lodge_topic.Heuristic);
+  Unix.putenv "MASC_TOPIC_MODE" "llm";
+  check bool "llm mode" true (Lodge_topic.get_topic_mode () = Lodge_topic.Llm);
+  Unix.putenv "MASC_TOPIC_MODE" "hybrid";
+  check bool "hybrid mode" true (Lodge_topic.get_topic_mode () = Lodge_topic.Hybrid);
+  (* Unknown defaults to Hybrid *)
+  Unix.putenv "MASC_TOPIC_MODE" "unknown";
+  check bool "unknown defaults to hybrid" true (Lodge_topic.get_topic_mode () = Lodge_topic.Hybrid);
+  (* Restore *)
+  Unix.putenv "MASC_TOPIC_MODE" "hybrid"
+
+(* ============================================
+   Prompt generation tests
+   ============================================ *)
+
+let test_build_prompt_contains_content () =
+  let prompt = Lodge_topic.build_topic_prompt "OCaml is great for systems programming" in
+  check bool "contains content" true
+    (try ignore (Str.search_forward (Str.regexp_string "OCaml is great") prompt 0); true
+     with Not_found -> false)
+
+let test_build_prompt_truncates_long_content () =
+  let long_content = String.make 2000 'x' in
+  let prompt = Lodge_topic.build_topic_prompt long_content in
+  (* Prompt should not contain the full 2000 chars *)
+  check bool "prompt is shorter than content + overhead" true
+    (String.length prompt < 2000 + 500)
+
+let test_build_prompt_has_json_instruction () =
+  let prompt = Lodge_topic.build_topic_prompt "test content" in
+  check bool "mentions JSON array" true
+    (try ignore (Str.search_forward (Str.regexp_string "JSON array") prompt 0); true
+     with Not_found -> false)
+
+(* ============================================
+   LLM extraction tests (short content skip)
+   ============================================ *)
+
+let test_llm_skip_short_content () =
+  (* Very short content should return Ok [] without LLM call *)
+  Unix.putenv "MASC_TOPIC_MODE" "llm";
+  let result = Lodge_topic.extract_topics_llm "hi" in
+  check bool "short content returns Ok" true (Result.is_ok result);
+  check int "empty topics" 0 (List.length (Result.get_ok result));
+  Unix.putenv "MASC_TOPIC_MODE" "hybrid"
+
+(* ============================================
+   Test suite
+   ============================================ *)
+
+let () =
+  run "Lodge_topic" [
+    "parsing", [
+      test_case "clean json" `Quick test_parse_clean_json;
+      test_case "json in prose" `Quick test_parse_json_in_prose;
+      test_case "malformed" `Quick test_parse_malformed;
+      test_case "empty array" `Quick test_parse_empty_array;
+      test_case "truncation" `Quick test_parse_truncation;
+      test_case "oversized topic" `Quick test_parse_oversized_topic;
+      test_case "mixed types" `Quick test_parse_mixed_types;
+      test_case "whitespace and case" `Quick test_parse_whitespace_and_case;
+      test_case "empty string topic" `Quick test_parse_empty_string_topic;
+    ];
+    "heuristic", [
+      test_case "ocaml keywords" `Quick test_heuristic_ocaml;
+      test_case "empty" `Quick test_heuristic_empty;
+      test_case "multiple keywords" `Quick test_heuristic_multiple;
+      test_case "case insensitive" `Quick test_heuristic_case_insensitive;
+    ];
+    "mode", [
+      test_case "dispatch heuristic" `Quick test_mode_dispatch_heuristic;
+      test_case "env parsing" `Quick test_mode_env_parsing;
+    ];
+    "prompt", [
+      test_case "contains content" `Quick test_build_prompt_contains_content;
+      test_case "truncates long content" `Quick test_build_prompt_truncates_long_content;
+      test_case "has json instruction" `Quick test_build_prompt_has_json_instruction;
+    ];
+    "llm", [
+      test_case "skip short content" `Quick test_llm_skip_short_content;
+    ];
+  ]


### PR DESCRIPTION
## Summary
- `lodge_topic.ml` 신규 모듈: `MASC_TOPIC_MODE` 환경변수로 Heuristic/LLM/Hybrid 3-mode 디스패치
- `lodge_reaction.ml`의 하드코딩된 30개 키워드 `extract_topics`를 `Lodge_topic.extract_topics`로 위임
- `Lodge_cascade`에 `topic_extraction` 케이스 추가 (ollama:glm-4.7-flash → glm:glm-4.7)
- `Llm_response_cache`로 동일 content에 대해 시간당 최대 1회 LLM 호출
- "functional-programming", "distributed-systems" 같은 개념적 주제 감지 가능

## Changes
| 파일 | 변경 |
|------|------|
| `lib/lodge_topic.{ml,mli}` | 신규 — LLM/Heuristic/Hybrid topic extraction |
| `lib/lodge_reaction.ml` | extract_topics → Lodge_topic 위임 |
| `lib/lodge_cascade.ml` | topic_extraction cascade 추가 |
| `lib/masc_mcp.ml` | Lodge_topic 모듈 alias |
| `config/llm_cascade.json` | topic_extraction_models 엔트리 |
| `test/test_lodge_topic.ml` | 19개 유닛 테스트 |
| `test/test_lodge_reaction.ml` | 기존 3개 테스트에 heuristic 모드 핀 |

## Test plan
- [x] `test_lodge_topic.exe` — 19/19 pass (파싱, heuristic, mode, prompt, llm skip)
- [x] `test_lodge_reaction.exe` — 33/33 pass (기존 테스트 regression 없음)
- [x] `test_lodge_cascade.exe` — 9/9 pass
- [ ] LLM 통합 테스트: `MASC_TOPIC_MODE=hybrid` + Ollama 실행 상태에서 검증
- [ ] 수동 검증: MASC 서버 재시작 후 dashboard에서 topic extraction 로그 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)