### PR TITLE
feat(memory): Phase 2 — stability retention, JSONL persistence, A-MEM linking

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -167,6 +167,7 @@
    lodge_reaction
    lodge_tom
    lodge_selection
+   memory_consolidation
    memory_stream
    agent_planner
    reflection

--- a/lib/generational_metrics.ml
+++ b/lib/generational_metrics.ml
@@ -80,10 +80,93 @@ let with_lock f =
   else
     f ()
 
-(** In-memory store for quick prototyping *)
+(** In-memory store — also backed by JSONL for restart survival *)
 let task_records : task_record list ref = ref []
 let handoff_records : handoff_record list ref = ref []
 let retention_tests : retention_test list ref = ref []
+
+(** {1 JSONL Persistence}
+
+    Append-only JSONL backup under .masc/metrics/{agent}/
+    Used as fallback when in-memory store is empty (post-restart). *)
+
+let metrics_dir () =
+  let me_root = Env_config.me_root () in
+  Filename.concat me_root ".masc/metrics"
+
+let ensure_dir dir =
+  let rec mkdir_p path =
+    let parent = Filename.dirname path in
+    if parent <> path && not (Sys.file_exists parent) then
+      mkdir_p parent;
+    if not (Sys.file_exists path) then
+      (try Unix.mkdir path 0o755 with Unix.Unix_error (Unix.EEXIST, _, _) -> ())
+  in
+  mkdir_p dir
+
+let task_record_to_json (r : task_record) =
+  `Assoc [
+    ("type", `String "task");
+    ("generation", `Int r.generation);
+    ("task_id", `String r.task_id);
+    ("completed", `Bool r.completed);
+    ("duration_ms", `Int r.duration_ms);
+    ("error_count", `Int r.error_count);
+    ("input_tokens", `Int r.input_tokens);
+    ("output_tokens", `Int r.output_tokens);
+    ("timestamp", `Float r.timestamp);
+  ]
+
+let handoff_record_to_json (r : handoff_record) =
+  `Assoc [
+    ("type", `String "handoff");
+    ("from_generation", `Int r.from_generation);
+    ("to_generation", `Int r.to_generation);
+    ("dna_size", `Int r.dna_size);
+    ("context_ratio", `Float r.context_ratio);
+    ("timestamp", `Float r.timestamp);
+  ]
+
+let append_jsonl ~agent_name json_line =
+  let dir = Filename.concat (metrics_dir ()) agent_name in
+  ensure_dir dir;
+  let path = Filename.concat dir "generations.jsonl" in
+  let oc = open_out_gen [Open_append; Open_creat; Open_text] 0o644 path in
+  output_string oc (Yojson.Safe.to_string json_line);
+  output_char oc '\n';
+  close_out oc
+
+(** Load task records from JSONL file for a given agent. *)
+let load_task_records_from_jsonl ~agent_name : task_record list =
+  let dir = Filename.concat (metrics_dir ()) agent_name in
+  let path = Filename.concat dir "generations.jsonl" in
+  if not (Sys.file_exists path) then []
+  else begin
+    let ic = open_in path in
+    Fun.protect ~finally:(fun () -> close_in_noerr ic) (fun () ->
+      let records = ref [] in
+      (try while true do
+        let line = input_line ic in
+        if String.length line > 0 then begin
+          try
+            let json = Yojson.Safe.from_string line in
+            let open Yojson.Safe.Util in
+            if json |> member "type" |> to_string = "task" then
+              records := {
+                generation = json |> member "generation" |> to_int;
+                task_id = json |> member "task_id" |> to_string;
+                completed = json |> member "completed" |> to_bool;
+                duration_ms = json |> member "duration_ms" |> to_int;
+                error_count = json |> member "error_count" |> to_int;
+                input_tokens = json |> member "input_tokens" |> to_int;
+                output_tokens = json |> member "output_tokens" |> to_int;
+                timestamp = json |> member "timestamp" |> to_float;
+              } :: !records
+          with _ -> ()
+        end
+      done with End_of_file -> ());
+      List.rev !records)
+  end
 
 (** Record a task completion *)
 let record_task ~generation ~task_id ~completed ~duration_ms ~error_count
@@ -100,6 +183,9 @@ let record_task ~generation ~task_id ~completed ~duration_ms ~error_count
       timestamp = Time_compat.now ();
     } in
     task_records := record :: !task_records;
+    (* JSONL backup — best effort, don't fail the record *)
+    (try append_jsonl ~agent_name:"_global" (task_record_to_json record)
+     with _ -> ());
     record)
 
 (** Record a handoff *)
@@ -113,6 +199,8 @@ let record_handoff ~from_generation ~to_generation ~dna_size ~context_ratio =
       timestamp = Time_compat.now ();
     } in
     handoff_records := record :: !handoff_records;
+    (try append_jsonl ~agent_name:"_global" (handoff_record_to_json record)
+     with _ -> ());
     record)
 
 (** Record a knowledge retention test *)
@@ -125,7 +213,14 @@ let record_retention_test ~generation ~question ~expected ~actual ~confidence =
 
 (** Internal: summarize without acquiring lock (caller must hold lock) *)
 let summarize_generation_unlocked generation =
-  let tasks = List.filter (fun (t : task_record) -> t.generation = generation) !task_records in
+  (* Fallback: if in-memory is empty, try loading from JSONL *)
+  let all_tasks =
+    if !task_records = [] then
+      (try load_task_records_from_jsonl ~agent_name:"_global"
+       with _ -> [])
+    else !task_records
+  in
+  let tasks = List.filter (fun (t : task_record) -> t.generation = generation) all_tasks in
   let total = List.length tasks in
   if total = 0 then None
   else

--- a/lib/memory_consolidation.ml
+++ b/lib/memory_consolidation.ml
@@ -1,0 +1,108 @@
+(** Memory Consolidation — Stability-based retention tiers.
+
+    Based on Ebbinghaus forgetting curve + spaced repetition (SRS) principles.
+    Memories transition through stability tiers based on access patterns
+    and importance, determining their GC eligibility.
+
+    Stability formula:
+      S = alpha * ln(1 + access_count) + beta * importance/10 + gamma * (1 - e^(-t/tau))
+
+    Tiers:
+    - Volatile:   < 3 accesses, < 7 days   → aggressive GC
+    - Developing: 3-10 accesses or 7-30 days → normal retention
+    - Stable:     10+ accesses or high importance → preserved
+    - Core:       Reflection output, high-importance decisions → permanent
+
+    @since 2.90.0 *)
+
+(** Stability tiers for memory retention. *)
+type stability_tier =
+  | Volatile     (** < 3 accesses, < 7 days: aggressive GC *)
+  | Developing   (** 3-10 accesses or 7-30 days: normal retention *)
+  | Stable       (** 10+ accesses or high importance: preserved *)
+  | Core         (** Reflection output, high-importance: permanent *)
+
+let string_of_tier = function
+  | Volatile -> "volatile"
+  | Developing -> "developing"
+  | Stable -> "stable"
+  | Core -> "core"
+
+(** Stability scoring coefficients *)
+type coefficients = {
+  alpha : float;  (** Weight for access frequency *)
+  beta : float;   (** Weight for importance *)
+  gamma : float;  (** Weight for age maturation *)
+  tau : float;    (** Time constant for age (days) *)
+}
+
+let default_coefficients = {
+  alpha = 0.4;
+  beta = 0.35;
+  gamma = 0.25;
+  tau = 14.0;  (* 14 days half-maturation *)
+}
+
+(** Compute stability score for a memory entry.
+    S = alpha * ln(1 + access_count) + beta * importance/10 + gamma * (1 - e^(-t/tau)) *)
+let stability_score ?(coeffs = default_coefficients) (entry : Memory_stream.memory_entry) =
+  let age_days = (Time_compat.now () -. entry.timestamp) /. 86400.0 in
+  let freq_component = coeffs.alpha *. log (1.0 +. Float.of_int entry.access_count) in
+  let importance_component = coeffs.beta *. (Float.of_int entry.importance /. 10.0) in
+  let age_component = coeffs.gamma *. (1.0 -. exp (-. age_days /. coeffs.tau)) in
+  freq_component +. importance_component +. age_component
+
+(** Classify a memory entry into a stability tier. *)
+let classify (entry : Memory_stream.memory_entry) : stability_tier =
+  let age_days = (Time_compat.now () -. entry.timestamp) /. 86400.0 in
+  (* Core: reflections with importance >= 8 *)
+  match entry.entry_type with
+  | Memory_stream.Reflection _ when entry.importance >= 8 -> Core
+  | _ ->
+    if entry.access_count >= 10 || entry.importance >= 9 then Stable
+    else if entry.access_count >= 3 || age_days >= 7.0 then Developing
+    else Volatile
+
+(** GC eligibility based on tier and age. *)
+let should_gc (entry : Memory_stream.memory_entry) : bool =
+  match classify entry with
+  | Core -> false  (* never GC *)
+  | Stable -> false  (* preserve *)
+  | Developing ->
+    let age_days = (Time_compat.now () -. entry.timestamp) /. 86400.0 in
+    age_days > 60.0 && entry.importance < 5  (* GC after 60 days if low importance *)
+  | Volatile ->
+    let age_days = (Time_compat.now () -. entry.timestamp) /. 86400.0 in
+    age_days > 7.0  (* aggressive: GC after 7 days *)
+
+(** Run GC on agent memories. Returns (kept, removed) counts. *)
+let gc_agent_memories ~agent_name : int * int =
+  let entries = Memory_stream.load_all_entries ~agent_name in
+  let kept, removed = List.partition (fun e -> not (should_gc e)) entries in
+  let removed_count = List.length removed in
+  if removed_count > 0 then begin
+    Memory_stream.rewrite_entries ~agent_name kept;
+    Printf.eprintf "[memory_gc] %s: kept=%d removed=%d (volatile=%d developing=%d)\n%!"
+      agent_name (List.length kept) removed_count
+      (List.length (List.filter (fun e -> classify e = Volatile) removed))
+      (List.length (List.filter (fun e -> classify e = Developing) removed))
+  end;
+  (List.length kept, removed_count)
+
+(** Get tier distribution for an agent's memories. *)
+let tier_distribution ~agent_name
+  : (stability_tier * int) list =
+  let entries = Memory_stream.load_all_entries ~agent_name in
+  let count tier = List.length (List.filter (fun e -> classify e = tier) entries) in
+  [
+    (Volatile, count Volatile);
+    (Developing, count Developing);
+    (Stable, count Stable);
+    (Core, count Core);
+  ]
+
+(** Serialize tier distribution to JSON. *)
+let distribution_to_json dist =
+  `Assoc (List.map (fun (tier, count) ->
+    (string_of_tier tier, `Int count)
+  ) dist)

--- a/lib/memory_stream.ml
+++ b/lib/memory_stream.ml
@@ -30,6 +30,10 @@ type memory_entry = {
   timestamp: float;
   importance: int;
   entry_type: memory_type;
+  (* Phase 2: Stability-based retention fields *)
+  access_count: int;
+  last_accessed: float;
+  links: string list;       (** IDs of related memories (A-MEM style) *)
 }
 
 type scoring_weights = {
@@ -94,18 +98,33 @@ let entry_to_json (e : memory_entry) : Yojson.Safe.t =
     ("timestamp", `Float e.timestamp);
     ("importance", `Int e.importance);
     ("entry_type", memory_type_to_json e.entry_type);
+    ("access_count", `Int e.access_count);
+    ("last_accessed", `Float e.last_accessed);
+    ("links", `List (List.map (fun l -> `String l) e.links));
   ]
 
+(** Deserialize entry from JSON. Unknown fields are ignored for forward compat.
+    Missing Phase 2 fields default to safe values. *)
 let entry_of_json (json : Yojson.Safe.t) : memory_entry option =
   try
     let open Yojson.Safe.Util in
+    let ts = json |> member "timestamp" |> to_float in
     Some {
       id = json |> member "id" |> to_string;
       agent_name = json |> member "agent_name" |> to_string;
       content = json |> member "content" |> to_string;
-      timestamp = json |> member "timestamp" |> to_float;
+      timestamp = ts;
       importance = json |> member "importance" |> to_int;
       entry_type = json |> member "entry_type" |> memory_type_of_json;
+      access_count =
+        (try json |> member "access_count" |> to_int
+         with Type_error _ -> 0);
+      last_accessed =
+        (try json |> member "last_accessed" |> to_float
+         with Type_error _ -> ts);
+      links =
+        (try json |> member "links" |> to_list |> List.map to_string
+         with Type_error _ -> []);
     }
   with Yojson.Safe.Util.Type_error _ | Yojson.Json_error _ -> None
 
@@ -215,15 +234,51 @@ let add_memory ~agent_name ~content ~importance entry_type =
     (int_of_float (Time_compat.now ()))
     (Random.int 999999)
   in
+  let now = Time_compat.now () in
   let entry = {
     id;
     agent_name;
     content;
-    timestamp = Time_compat.now ();
+    timestamp = now;
     importance;
     entry_type;
+    access_count = 0;
+    last_accessed = now;
+    links = [];
   } in
-  append_entry ~agent_name entry
+  append_entry ~agent_name entry;
+  (* A-MEM style: link to recent entries with keyword overlap >= 30% *)
+  let recent_entries = load_all_entries ~agent_name in
+  let to_check = List.filteri (fun i _ -> i < 20) (List.rev recent_entries) in
+  let content_words =
+    content |> String.lowercase_ascii |> String.split_on_char ' '
+    |> List.filter (fun w -> String.length w > 2) |> List.sort_uniq String.compare
+  in
+  if List.length content_words > 0 then begin
+    let linked_ids = List.filter_map (fun (e : memory_entry) ->
+      if e.id = id then None
+      else
+        let e_words =
+          e.content |> String.lowercase_ascii |> String.split_on_char ' '
+          |> List.filter (fun w -> String.length w > 2) |> List.sort_uniq String.compare
+        in
+        let overlap = List.filter (fun w -> List.mem w e_words) content_words in
+        let ratio = Float.of_int (List.length overlap) /. Float.of_int (List.length content_words) in
+        if ratio >= 0.3 then Some e.id else None
+    ) to_check in
+    if List.length linked_ids > 0 then begin
+      (* Update this entry with links *)
+      let updated = { entry with links = linked_ids } in
+      let all = load_all_entries ~agent_name in
+      let patched = List.map (fun e ->
+        if e.id = id then updated
+        else if List.mem e.id linked_ids then
+          { e with links = id :: (List.filter (fun l -> l <> id) e.links) }
+        else e
+      ) all in
+      rewrite_entries ~agent_name patched
+    end
+  end
 
 let retrieve ~agent_name ~query ~limit =
   let entries = load_all_entries ~agent_name in

--- a/lib/memory_stream.mli
+++ b/lib/memory_stream.mli
@@ -23,6 +23,9 @@ type memory_entry = {
   timestamp: float;
   importance: int;          (** 1-10, LLM-judged *)
   entry_type: memory_type;
+  access_count: int;        (** How many times this memory was retrieved. @since 2.90.0 *)
+  last_accessed: float;     (** Last retrieval timestamp. @since 2.90.0 *)
+  links: string list;       (** IDs of related memories (A-MEM style). @since 2.90.0 *)
 }
 
 (** {1 Scoring Weights} *)


### PR DESCRIPTION
## Summary

에이전트 기억의 영속성을 강화하는 Phase 2 구현. 재시작/세대 교체를 거쳐도 기억이 살아남는 구조.

### 2B — Stability-based Memory Retention
- `memory_entry`에 `access_count`, `last_accessed`, `links` 필드 추가 (후방 호환)
- `memory_consolidation.ml`: Ebbinghaus 망각 곡선 기반 4-tier 분류
  - **Volatile**: < 3 accesses, < 7 days → 적극 정리
  - **Developing**: 3-10 accesses or 7-30 days → 보통 보존
  - **Stable**: 10+ accesses or high importance → 보존
  - **Core**: Reflection 출력, 고중요도 → 영구
- 안정성 공식: `S = α·ln(1+access) + β·importance/10 + γ·(1-e^(-t/τ))`

### 2C — Generational Metrics JSONL Persistence
- `record_task`/`record_handoff` 시 `.masc/metrics/_global/generations.jsonl`에 append
- `summarize_generation`에서 in-memory 비어있으면 JSONL fallback
- 서버 재시작 후에도 세대별 성능 데이터 보존

### 2D — A-MEM Style Memory Linking
- 새 기억 저장 시 최근 20개와 키워드 겹침 30%+ 검사
- 양방향 링크 저장 (`links` 필드)
- LLM 호출 없이 순수 키워드 매칭 (비용 0)

## Test plan
- [x] `dune build --root .` clean build
- [ ] `dune test --root .` (running in background)
- [ ] memory_entry JSON round-trip 검증 (backward compat: old entries without new fields)
- [ ] generational_metrics JSONL write/read after restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)