### PR TITLE
refactor(config): extract timeout and LLM defaults (Phase 4)

### DIFF
--- a/lib/a2a_tools.ml
+++ b/lib/a2a_tools.ml
@@ -333,7 +333,7 @@ let fetch_remote_agent_card url :
         in
         try
           let (status, body) =
-            Process_eio.run_argv_with_status ~timeout_sec:15.0 argv
+            Process_eio.run_argv_with_status ~timeout_sec:Env_config_runtime.Timeout.gcloud_auth_sec argv
           in
           match status with
           | Unix.WEXITED 0 when String.length body > 0 -> (

--- a/lib/env_config_runtime.ml
+++ b/lib/env_config_runtime.ml
@@ -204,4 +204,48 @@ module Network = struct
     || String.length host >= 4 && String.sub host 0 4 = "127."
 end
 
+(** {1 Timeout Defaults} *)
+
+module Timeout = struct
+  (** gcloud auth token fetch (used by a2a_tools, llm_client, keeper_alerting) *)
+  let gcloud_auth_sec =
+    get_float ~default:15.0 "MASC_TIMEOUT_GCLOUD_AUTH_SEC"
+
+  (** Anthropic / Claude API request timeout *)
+  let anthropic_api_sec =
+    get_int ~default:120 "MASC_TIMEOUT_ANTHROPIC_SEC"
+
+  (** OpenAI-compatible API request timeout *)
+  let openai_compat_api_sec =
+    get_int ~default:60 "MASC_TIMEOUT_OPENAI_COMPAT_SEC"
+
+  (** Grace period added on top of LLM timeouts for curl/network overhead *)
+  let llm_grace_sec =
+    get_float ~default:5.0 "MASC_TIMEOUT_LLM_GRACE_SEC"
+
+  (** GraphQL query timeout (agent loading, etc.) *)
+  let graphql_query_sec =
+    get_float ~default:5.0 "MASC_TIMEOUT_GRAPHQL_SEC"
+
+  (** Keeper status check timeout *)
+  let keeper_status_sec =
+    get_float ~default:5.0 "MASC_TIMEOUT_KEEPER_STATUS_SEC"
+end
+
+(** {1 LLM Generation Defaults} *)
+
+module Llm_defaults = struct
+  (** Default max_tokens for LLM generation (used by spawn, chain, perpetual, etc.) *)
+  let default_max_tokens =
+    get_int ~default:4096 "MASC_LLM_DEFAULT_MAX_TOKENS"
+
+  (** SSE retry interval in milliseconds (client reconnection hint) *)
+  let sse_retry_ms =
+    get_int ~default:3000 "MASC_SSE_RETRY_MS"
+
+  (** Log output truncation length *)
+  let log_truncation_len =
+    get_int ~default:1500 "MASC_LOG_TRUNCATION_LEN"
+end
+
 (** {1 Internal Guardian Configuration} *)

--- a/lib/llm_client.ml
+++ b/lib/llm_client.ml
@@ -696,7 +696,7 @@ let fetch_vertex_adc_access_token () =
   else
     let status, output =
       Process_eio.run_argv_with_status
-        ~timeout_sec:15.0
+        ~timeout_sec:Env_config_runtime.Timeout.gcloud_auth_sec
         [ "gcloud"; "auth"; "application-default"; "print-access-token" ]
     in
     match status with
@@ -826,7 +826,7 @@ let call_claude ?timeout_sec (req : completion_request) : (completion_response, 
       ("x-api-key", api_key);
       ("anthropic-version", "2023-06-01");
     ] in
-    let timeout_sec = Option.value timeout_sec ~default:120 in
+    let timeout_sec = Option.value timeout_sec ~default:Env_config_runtime.Timeout.anthropic_api_sec in
     match curl_post ~url ~headers ~body ~timeout_sec with
     | Error e -> Error e
     | Ok raw -> parse_claude_response raw
@@ -843,11 +843,12 @@ let call_openai_compatible ?timeout_sec (req : completion_request) : (completion
         req.model.model_id (string_of_provider req.model.provider) req.max_tokens
         effective_req.max_tokens (List.length req.tools) url;
       if req.tools <> [] then begin
-        let body_trunc = if String.length body > 1500 then String.sub body 0 1500 ^ "..." else body in
+        let trunc = Env_config_runtime.Llm_defaults.log_truncation_len in
+        let body_trunc = if String.length body > trunc then String.sub body 0 trunc ^ "..." else body in
         Log.LlmClient.debug "openai-compat body (tools present, %d bytes): %s" (String.length body) body_trunc
       end;
       let headers = [("Content-Type", "application/json")] @ auth_headers in
-      let timeout_sec = Option.value timeout_sec ~default:60 in
+      let timeout_sec = Option.value timeout_sec ~default:Env_config_runtime.Timeout.openai_compat_api_sec in
       match curl_post ~url ~headers ~body ~timeout_sec with
       | Error e -> Error e
       | Ok raw ->

--- a/lib/mcp_server_eio.ml
+++ b/lib/mcp_server_eio.ml
@@ -1383,7 +1383,7 @@ let execute_tool_eio ~sw ~clock ?mcp_session_id ?auth_token state ~name ~argumen
     in
     (* Eio outer timeout includes LLM time + protocol overhead (serialization,
        network). Add 10s grace to avoid racing the LLM timeout. *)
-    let eio_timeout = timeout_sec +. 10.0 in
+    let eio_timeout = timeout_sec +. (Env_config_runtime.Timeout.llm_grace_sec *. 2.0) in
     try
       Eio.Time.with_timeout_exn clock eio_timeout (fun () ->
           match


### PR DESCRIPTION
## Summary

masc-mcp 매직넘버를 env_config_runtime 서브모듈로 추출합니다.

### Timeout 서브모듈
- `MASC_TIMEOUT_GCLOUD_AUTH_SEC` (기본 15초) — gcloud auth token fetch
- `MASC_TIMEOUT_ANTHROPIC_SEC` (기본 120초) — Anthropic API
- `MASC_TIMEOUT_OPENAI_COMPAT_SEC` (기본 60초) — OpenAI-compatible API
- `MASC_TIMEOUT_LLM_GRACE_SEC` (기본 5초) — LLM 타임아웃 위 grace period
- `MASC_TIMEOUT_GRAPHQL_SEC` (기본 5초) — GraphQL 쿼리
- `MASC_TIMEOUT_KEEPER_STATUS_SEC` (기본 5초) — Keeper 상태 확인

### Llm_defaults 서브모듈
- `MASC_LLM_DEFAULT_MAX_TOKENS` (기본 4096)
- `MASC_SSE_RETRY_MS` (기본 3000ms)
- `MASC_LOG_TRUNCATION_LEN` (기본 1500자)

### 적용 파일
- `llm_client.ml`: 4개 매직넘버 교체
- `a2a_tools.ml`: gcloud auth timeout
- `mcp_server_eio.ml`: LLM grace period

## Test plan
- [x] `dune build --root .` 성공
- [ ] CI checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)