### PR TITLE
fix(test): update MA-H3 pattern for Log.* structured logging

### DIFF
--- a/test/test_silent_failures_p2a.ml
+++ b/test/test_silent_failures_p2a.ml
@@ -161,7 +161,7 @@ let test_source_metrics_fd_unlock () =
 let test_source_llm_token_parse () =
   check bool "llm_client.ml has token count parse logging"
     true (file_contains_pattern "lib/llm_client.ml"
-      {|[llm] token field missing or wrong type|})
+      {|token field missing or wrong type|})
 
 let test_source_keeper_proactive () =
   check bool "keeper sources have proactive emission logging"


### PR DESCRIPTION
## Summary

- MA-H3 테스트가 `llm_client.ml`에서 `[llm] token field missing or wrong type` 리터럴을 찾지만, 최근 `refactor(log)` PR에서 `Log.LlmClient.debug`로 마이그레이션되면서 `[llm]` prefix가 소스에서 사라짐
- 패턴을 `token field missing or wrong type`으로 수정 (prefix 없이 메시지 본문만 매칭)

## Root cause

`refactor(log): migrate 6 noisy modules to structured Log.*` 에서 `Printf.eprintf "[llm] ..."` → `Log.LlmClient.debug "..."`로 변환. `Log` 모듈이 런타임에 자동으로 `[LlmClient]` prefix를 추가하므로, 소스 코드에는 `[llm]`이 존재하지 않음.

## Test plan

- [x] `grep -c 'token field missing or wrong type' lib/llm_client.ml` → 1 match
- [ ] CI "Build and Test" green

Generated with [Claude Code](https://claude.com/claude-code)