### PR TITLE
fix(dashboard): map keeper surfaces via backend_tool_name

### DIFF
--- a/lib/tool_misc.ml
+++ b/lib/tool_misc.ml
@@ -222,16 +222,21 @@ let keeper_policies_json ctx =
 let tool_inventory_json ctx ~include_hidden ~include_deprecated =
   let room_path = Room.masc_dir ctx.config in
   let cfg = Config.load room_path in
-  (* Build reverse index: tool_name -> surface string list *)
+  (* Build reverse index: tool_name -> surface string list.
+     Also index by backend_tool_name so keeper/privileged surfaces
+     are attached to the public tool name they dispatch to. *)
   let surface_map : (string, string list) Hashtbl.t = Hashtbl.create 256 in
+  let add_surface name s =
+    let prev =
+      match Hashtbl.find_opt surface_map name with Some l -> l | None -> []
+    in
+    if not (List.mem s prev) then Hashtbl.replace surface_map name (s :: prev)
+  in
   List.iter
     (fun (seed : Capability_registry.capability_seed) ->
-      let name = seed.projection.tool_name in
       let s = Capability_registry.surface_to_string seed.projection.surface in
-      let prev =
-        match Hashtbl.find_opt surface_map name with Some l -> l | None -> []
-      in
-      if not (List.mem s prev) then Hashtbl.replace surface_map name (s :: prev))
+      add_surface seed.projection.tool_name s;
+      add_surface seed.projection.backend_tool_name s)
     (Capability_registry.all_projection_seeds_from Config.raw_all_tool_schemas);
   let schemas =
     Config.raw_all_tool_schemas


### PR DESCRIPTION
## Summary

- Keeper 도구(keeper_board_post 등)가 dashboard tools 탭에서 surface 필터에 누락되던 버그 수정
- `surface_map` 역인덱스 구축 시 `tool_name`과 `backend_tool_name` 모두 인덱싱
- Keeper tools는 `keeper_board_post` -> `masc_board_post`로 dispatch되므로, `backend_tool_name`(masc_board_post)에도 `keeper_standard` surface를 매핑해야 inventory row에 반영됨

## Changed files

| 파일 | 변경 |
|------|------|
| `lib/tool_misc.ml` | `add_surface` 헬퍼 추출, `backend_tool_name`도 surface_map에 추가 |

## Test plan

- [ ] CI Build and Test 통과
- [ ] `/dashboard#tools` Keeper 탭에서 6+ 도구 표시 확인
- [ ] `masc_board_post` 등 공용 도구에 `keeper_standard` surface 뱃지 표시 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)