### PR TITLE
feat(graphql): add GraphQL client module for Neo4j migration

### DIFF
--- a/lib/graphql_client.ml
+++ b/lib/graphql_client.ml
@@ -1,0 +1,197 @@
+(** GraphQL Client — typed interface to second-brain-graphql server.
+
+    Provides [query] and [mutate] functions that send GraphQL operations
+    to the Second Brain GraphQL API with Bearer token auth.
+
+    Uses Cohttp_eio with curl fallback (same pattern as lodge_heartbeat).
+
+    @since 2.91.0
+*)
+
+(** {1 Configuration} *)
+
+let graphql_url () = Graphql_endpoint.graphql_url ()
+
+let api_key () =
+  Sys.getenv_opt "GRAPHQL_API_KEY" |> Option.value ~default:""
+
+(** {1 HTTP Transport} *)
+
+let looks_like_html_response body =
+  let trimmed = String.lowercase_ascii (String.trim body) in
+  trimmed <> "" && String.length trimmed > 0 && trimmed.[0] = '<'
+
+let ensure_json_response body =
+  if String.length body = 0 then Error "empty response"
+  else if looks_like_html_response body then
+    Error "endpoint returned HTML instead of JSON"
+  else Ok body
+
+(** Write auth header to temp file (keeps token out of argv).  *)
+let with_auth_header_file key f =
+  if key = "" then f None
+  else
+    let path = Filename.temp_file "masc-gql-auth-" ".hdr" in
+    Fun.protect
+      ~finally:(fun () -> try Sys.remove path with Sys_error _ -> ())
+      (fun () ->
+         let fd = Unix.openfile path [Unix.O_WRONLY; Unix.O_CREAT; Unix.O_TRUNC] 0o600 in
+         let oc = Unix.out_channel_of_descr fd in
+         output_string oc ("Authorization: Bearer " ^ key ^ "\n");
+         close_out oc;
+         f (Some path))
+
+let with_body_file body f =
+  let path = Filename.temp_file "masc-gql-body-" ".json" in
+  Fun.protect
+    ~finally:(fun () -> try Sys.remove path with Sys_error _ -> ())
+    (fun () ->
+       let oc = open_out_bin path in
+       Fun.protect
+         ~finally:(fun () -> close_out_noerr oc)
+         (fun () -> output_string oc body);
+       f path)
+
+(** curl-based fallback for Railway containers with DNS issues. *)
+let request_curl ~timeout_sec body =
+  let url = graphql_url () in
+  let key = api_key () in
+  with_auth_header_file key (fun auth_file ->
+      with_body_file body (fun body_file ->
+          let argv =
+            [ "curl"; "-s"; "-m"; string_of_int (int_of_float timeout_sec);
+              "-X"; "POST"; url;
+              "-H"; "Content-Type: application/json";
+              "-H"; "Accept: application/json"
+            ]
+            |> fun base ->
+            (match auth_file with
+             | None -> base
+             | Some hf -> base @ [ "-H"; "@" ^ hf ])
+            |> fun with_auth ->
+            with_auth @ [ "-d"; "@" ^ body_file ]
+          in
+          if Process_eio.is_initialized () then
+            (try
+               let output = Process_eio.run_argv ~timeout_sec argv in
+               ensure_json_response output
+             with exn -> Error (Printf.sprintf "curl: %s" (Printexc.to_string exn)))
+          else
+            (* Unix fallback when Eio loop not started *)
+            (try
+               let ic = Unix.open_process_args_in "curl" (Array.of_list argv) in
+               let output =
+                 Fun.protect
+                   ~finally:(fun () -> ignore (Unix.close_process_in ic))
+                   (fun () -> In_channel.input_all ic)
+               in
+               ensure_json_response output
+             with exn -> Error (Printexc.to_string exn))))
+
+(** Cohttp_eio primary transport with curl fallback. *)
+let request ?(timeout_sec=10.0) body : (string, string) result =
+  let url = graphql_url () in
+  let key = api_key () in
+  let max_response_bytes = 1_000_000 in
+  let cohttp_result = match Eio_context.get_net_opt () with
+    | None -> Error "Eio net not initialized"
+    | Some net ->
+      let headers =
+        if key = "" then
+          Cohttp.Header.of_list [("Content-Type", "application/json")]
+        else
+          Cohttp.Header.of_list [
+            ("Content-Type", "application/json");
+            ("Authorization", "Bearer " ^ key);
+          ]
+      in
+      let uri = Uri.of_string url in
+      let is_https = Uri.scheme uri = Some "https" in
+      let run () =
+        Eio.Switch.run (fun sw ->
+          let client =
+            if is_https then
+              Cohttp_eio.Client.make ~https:(Some (Eio_context.get_https_connector ())) net
+            else
+              Cohttp_eio.Client.make ~https:None net
+          in
+          let body_content = Eio.Flow.string_source body in
+          let resp, resp_body =
+            Cohttp_eio.Client.post client ~sw uri ~headers ~body:body_content
+          in
+          let status = Cohttp.Response.status resp |> Cohttp.Code.code_of_status in
+          let body_str =
+            Eio.Buf_read.(parse_exn take_all) resp_body ~max_size:max_response_bytes
+          in
+          if not (Cohttp.Code.is_success status) then
+            Error (Printf.sprintf "HTTP %d" status)
+          else
+            ensure_json_response body_str
+        )
+      in
+      match Eio_context.get_clock_opt () with
+      | Some clock ->
+        (try Eio.Time.with_timeout_exn clock timeout_sec run
+         with exn -> Error (Printexc.to_string exn))
+      | None ->
+        (try run () with exn -> Error (Printexc.to_string exn))
+  in
+  match cohttp_result with
+  | Ok _ as success -> success
+  | Error _cohttp_err ->
+    request_curl ~timeout_sec body
+
+(** {1 GraphQL Response Parsing} *)
+
+(** Parse GraphQL JSON response into data or error. *)
+let parse_response body : (Yojson.Safe.t, string) result =
+  match Yojson.Safe.from_string body with
+  | exception Yojson.Json_error msg -> Error ("JSON parse error: " ^ msg)
+  | json ->
+    let open Yojson.Safe.Util in
+    (match member "errors" json with
+     | `List (err :: _) ->
+       let msg = err |> member "message" |> to_string_option
+                 |> Option.value ~default:"Unknown GraphQL error" in
+       Error ("GraphQL error: " ^ msg)
+     | _ ->
+       match member "data" json with
+       | `Null -> Error "GraphQL data is null"
+       | data -> Ok data)
+
+(** {1 Public API} *)
+
+(** Build a GraphQL request body with query and optional variables. *)
+let build_body ~query ?(variables=`Null) () =
+  Yojson.Safe.to_string
+    (`Assoc [
+      ("query", `String query);
+      ("variables", variables);
+    ])
+
+(** Execute a GraphQL query. Returns parsed data or error message. *)
+let query ?(timeout_sec=10.0) ~query:q ?(variables=`Null) ()
+    : (Yojson.Safe.t, string) result =
+  let body = build_body ~query:q ~variables () in
+  match request ~timeout_sec body with
+  | Error msg -> Error msg
+  | Ok raw -> parse_response raw
+
+(** Execute a GraphQL mutation. Same as [query] but named for clarity. *)
+let mutate ?(timeout_sec=10.0) ~mutation ?(variables=`Null) ()
+    : (Yojson.Safe.t, string) result =
+  let body = build_body ~query:mutation ~variables () in
+  match request ~timeout_sec body with
+  | Error msg -> Error msg
+  | Ok raw -> parse_response raw
+
+(** Convenience: extract a mutation result (success/message). *)
+let extract_mutation_result field_name data : (bool * string option, string) result =
+  let open Yojson.Safe.Util in
+  let field = member field_name data in
+  if field = `Null then Error ("Field " ^ field_name ^ " not found in response")
+  else
+    let success = field |> member "success" |> to_bool_option
+                  |> Option.value ~default:false in
+    let message = field |> member "message" |> to_string_option in
+    Ok (success, message)

--- a/lib/masc_mcp.ml
+++ b/lib/masc_mcp.ml
@@ -79,6 +79,7 @@ module Mcp_session = Mcp_session
 module Http_server_eio = Http_server_eio
 module Http_server_h2 = Http_server_h2
 module Graphql_endpoint = Graphql_endpoint
+module Graphql_client = Graphql_client
 module Graphql_api = Graphql_api
 module Safe_ops = Safe_ops
 module Sse = Sse


### PR DESCRIPTION
## Summary

Neo4j→GraphQL 마이그레이션 Phase 5. second-brain-graphql API에 대한 타입 안전한 GraphQL 클라이언트 모듈 추가.

### 추가된 파일
- `lib/graphql_client.ml` — 범용 GraphQL query/mutate 인터페이스

### 주요 기능
- Cohttp_eio 우선 전송 + curl fallback (Railway DNS workaround)
- Bearer token auth via temp file (argv에 토큰 미노출)
- `query` / `mutate` 함수 — `(Yojson.Safe.t, string) result` 반환
- `extract_mutation_result` — mutation 응답의 success/message 추출
- `graphql_endpoint.ml` URL 로직 재사용

### 의존 관계
- **선행**: [second-brain-graphql PR #12](https://github.com/jeong-sik/second-brain-graphql/pull/12) (Phase 0-4)
- **후속**: Phase 6 (직접 Neo4j 호출 교체) — 이 PR 머지 + Phase 0-4 배포 후 진행

### Phase 6 로드맵 (후속 PR)
| 파일 | 변환 내용 |
|------|----------|
| `agent_neo4j.ml` | 12개 쿼리 빌더 → `Graphql_client.mutate/query` |
| `lodge_heartbeat.ml` | `create_agent_in_neo4j` → `mergeAgentEcosystem` |
| `tool_lodge_llm_cycle.ml` | interests/visit → GraphQL mutation |
| `council/thread_persist.ml` | Neo4j HTTP → `mergeThread`/`mergeTurn` |

## Test plan
- [x] `dune build --root .` 성공
- [ ] Phase 0-4 배포 후 `Graphql_client.query` 실제 호출 검증
- [ ] `Graphql_client.mutate` + `extract_mutation_result` 검증

🤖 Generated with [Claude Code](https://claude.com/claude-code)