### PR TITLE
fix: isolate dashboard side rail scrolling

### DIFF
--- a/dashboard/src/styles/global.css
+++ b/dashboard/src/styles/global.css
@@ -260,6 +260,11 @@ a:hover {
   display: flex;
   flex-direction: column;
   gap: 12px;
+  max-height: calc(100dvh - var(--header-h) - 32px);
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  scrollbar-gutter: stable;
+  padding-right: 4px;
 }
 
 .dashboard-rail.compact {
@@ -942,6 +947,9 @@ a:hover {
     display: grid;
     grid-template-columns: 1fr;
     gap: 10px;
+    max-height: none;
+    overflow-y: visible;
+    padding-right: 0;
   }
 
   .rail-tab-list {


### PR DESCRIPTION
## Summary
- make the dashboard side rail independently scroll inside the viewport on desktop
- keep the single-column and mobile breakpoint using the existing document scroll behavior
- add rail overscroll containment and a stable scrollbar gutter to reduce cross-pane scroll bleed

## Verification
- browser validation on the mission dashboard confirmed rail-only scroll changed while body scroll stayed at 0 after scrolling the rail
- attempted local dashboard build and TypeScript validation, but the dashboard tsc step did not complete cleanly in this session
- this patch is therefore validated by browser behavior rather than a completed local build in this run
