### PR TITLE
feat(social): Phase 4 — temporal reputation, institution episodes, trust

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -340,6 +340,7 @@
    debate
    mention_inbox
    agent_reputation
+   reputation_evolution
    activity_feed
    social
    tool_social

--- a/lib/institution_eio.ml
+++ b/lib/institution_eio.ml
@@ -558,3 +558,62 @@ let load_and_format_for_welcome ~fs:_ (config : config) : string =
     | exn ->
         Printf.eprintf "[WARN] Unexpected institution load error: %s\n%!" (Printexc.to_string exn); ""
   else ""
+
+(** {1 Lightweight JSONL Episode Recording (No Eio Required)}
+
+    Append-only episode log for contexts that don't have Eio fs.
+    Used by Lodge heartbeat, keeper decisions, etc.
+    Storage: .masc/institution_episodes.jsonl *)
+
+let episodes_jsonl_path () =
+  let me_root = Env_config.me_root () in
+  Filename.concat me_root ".masc/institution_episodes.jsonl"
+
+(** Record an episode to JSONL without Eio context.
+    This is the primary entry point for Lodge/Keeper integration. *)
+let record_episode_jsonl ~event_type ~summary ~participants ~outcome ~learnings =
+  let episode : episode = {
+    id = Printf.sprintf "ep-%d-%06d"
+      (int_of_float (Time_compat.now ())) (Level4_config.random_int 999999);
+    timestamp = Time_compat.now ();
+    participants;
+    event_type;
+    summary;
+    outcome;
+    learnings;
+    context = [];
+  } in
+  let path = episodes_jsonl_path () in
+  (try
+    let oc = open_out_gen [Open_append; Open_creat; Open_text] 0o644 path in
+    output_string oc (Yojson.Safe.to_string (episode_to_json episode));
+    output_char oc '\n';
+    close_out oc
+  with exn ->
+    Printf.eprintf "[institution] JSONL episode write failed: %s\n%!"
+      (Printexc.to_string exn));
+  episode
+
+(** Load recent episodes from JSONL (last N entries). *)
+let load_recent_episodes_jsonl ~limit : episode list =
+  let path = episodes_jsonl_path () in
+  if not (Sys.file_exists path) then []
+  else begin
+    let ic = open_in path in
+    Fun.protect ~finally:(fun () -> close_in_noerr ic) (fun () ->
+      let eps = ref [] in
+      (try while true do
+        let line = input_line ic in
+        if String.length line > 0 then
+          (try eps := episode_of_json (Yojson.Safe.from_string line) :: !eps
+           with _ -> ())
+      done with End_of_file -> ());
+      let all = List.rev !eps in
+      let total = List.length all in
+      if total <= limit then all
+      else
+        let rec drop n = function
+          | [] -> [] | _ when n <= 0 -> all | _ :: rest -> drop (n-1) rest
+        in
+        drop (total - limit) all)
+  end

--- a/lib/oas_events.ml
+++ b/lib/oas_events.ml
@@ -54,3 +54,36 @@ let publish_heartbeat_recovered (bus : Agent_sdk.Event_bus.t) ~agent_name ~previ
     ("timestamp", `Float (Time_compat.now ()));
   ] in
   Agent_sdk.Event_bus.publish bus (Agent_sdk.Event_bus.Custom ("masc:heartbeat_recovered", payload))
+
+(** {1 Phase 4: Social Events} *)
+
+(** Publish a trust score update between two agents. *)
+let publish_trust_updated (bus : Agent_sdk.Event_bus.t) ~agent_a ~agent_b ~trust_score =
+  let payload = `Assoc [
+    ("agent_a", `String agent_a);
+    ("agent_b", `String agent_b);
+    ("trust_score", `Float trust_score);
+    ("timestamp", `Float (Time_compat.now ()));
+  ] in
+  Agent_sdk.Event_bus.publish bus (Agent_sdk.Event_bus.Custom ("masc:trust_updated", payload))
+
+(** Publish a reputation change event. *)
+let publish_reputation_changed (bus : Agent_sdk.Event_bus.t) ~agent_name ~old_score ~new_score ~trend =
+  let payload = `Assoc [
+    ("agent_name", `String agent_name);
+    ("old_score", `Float old_score);
+    ("new_score", `Float new_score);
+    ("trend", `String trend);
+    ("timestamp", `Float (Time_compat.now ()));
+  ] in
+  Agent_sdk.Event_bus.publish bus (Agent_sdk.Event_bus.Custom ("masc:reputation_changed", payload))
+
+(** Publish an institution episode event. *)
+let publish_institution_episode (bus : Agent_sdk.Event_bus.t) ~episode_id ~event_type ~participants =
+  let payload = `Assoc [
+    ("episode_id", `String episode_id);
+    ("event_type", `String event_type);
+    ("participant_count", `Int (List.length participants));
+    ("timestamp", `Float (Time_compat.now ()));
+  ] in
+  Agent_sdk.Event_bus.publish bus (Agent_sdk.Event_bus.Custom ("masc:institution_episode", payload))

--- a/lib/reputation_evolution.ml
+++ b/lib/reputation_evolution.ml
@@ -1,0 +1,220 @@
+(** Reputation Evolution — Temporal reputation with trend analysis.
+
+    Extends Agent_reputation's snapshot model with:
+    - Time-series history (JSONL per agent)
+    - Exponential decay (0.95/day)
+    - Trend detection (improving / stable / declining)
+    - Trust score integration with Hebbian synapses
+
+    Storage: .masc/reputation/{agent}/history.jsonl
+
+    @since 2.90.0 *)
+
+open Printf
+
+(** A single reputation snapshot in time. *)
+type reputation_snapshot = {
+  timestamp : float;
+  overall_score : float;
+  tasks_completed : int;
+  completion_rate : float;
+  response_rate : float;
+  board_posts : int;
+}
+
+(** Trend direction derived from comparing recent vs historical scores. *)
+type trend = Improving | Stable | Declining
+
+let string_of_trend = function
+  | Improving -> "improving"
+  | Stable -> "stable"
+  | Declining -> "declining"
+
+(** Reputation with temporal context. *)
+type temporal_reputation = {
+  agent_name : string;
+  current_score : float;
+  trend : trend;
+  score_7d : float;       (** Average score over last 7 days *)
+  score_30d : float;      (** Average score over last 30 days *)
+  history_count : int;    (** Number of snapshots in history *)
+}
+
+(* ================================================================ *)
+(* Paths                                                            *)
+(* ================================================================ *)
+
+let reputation_dir ~agent_name =
+  let me_root = Env_config.me_root () in
+  sprintf "%s/.masc/reputation/%s" me_root agent_name
+
+let history_path ~agent_name =
+  sprintf "%s/history.jsonl" (reputation_dir ~agent_name)
+
+let ensure_dir path =
+  let rec mkdir_p dir =
+    if not (Sys.file_exists dir) then begin
+      mkdir_p (Filename.dirname dir);
+      (try Unix.mkdir dir 0o755 with Unix.Unix_error (Unix.EEXIST, _, _) -> ())
+    end
+  in
+  mkdir_p path
+
+(* ================================================================ *)
+(* JSON Serialization                                               *)
+(* ================================================================ *)
+
+let snapshot_to_json (s : reputation_snapshot) : Yojson.Safe.t =
+  `Assoc [
+    ("timestamp", `Float s.timestamp);
+    ("overall_score", `Float s.overall_score);
+    ("tasks_completed", `Int s.tasks_completed);
+    ("completion_rate", `Float s.completion_rate);
+    ("response_rate", `Float s.response_rate);
+    ("board_posts", `Int s.board_posts);
+  ]
+
+let snapshot_of_json (json : Yojson.Safe.t) : reputation_snapshot option =
+  try
+    let open Yojson.Safe.Util in
+    Some {
+      timestamp = json |> member "timestamp" |> to_float;
+      overall_score = json |> member "overall_score" |> to_float;
+      tasks_completed =
+        (try json |> member "tasks_completed" |> to_int with Type_error _ -> 0);
+      completion_rate =
+        (try json |> member "completion_rate" |> to_float with Type_error _ -> 0.0);
+      response_rate =
+        (try json |> member "response_rate" |> to_float with Type_error _ -> 0.0);
+      board_posts =
+        (try json |> member "board_posts" |> to_int with Type_error _ -> 0);
+    }
+  with _ -> None
+
+(* ================================================================ *)
+(* File I/O                                                         *)
+(* ================================================================ *)
+
+let append_snapshot ~agent_name (s : reputation_snapshot) =
+  let dir = reputation_dir ~agent_name in
+  ensure_dir dir;
+  let path = history_path ~agent_name in
+  let oc = open_out_gen [Open_append; Open_creat; Open_text] 0o644 path in
+  output_string oc (Yojson.Safe.to_string (snapshot_to_json s));
+  output_char oc '\n';
+  close_out oc
+
+let load_history ~agent_name : reputation_snapshot list =
+  let path = history_path ~agent_name in
+  if not (Sys.file_exists path) then []
+  else begin
+    let ic = open_in path in
+    Fun.protect ~finally:(fun () -> close_in_noerr ic) (fun () ->
+      let snaps = ref [] in
+      (try while true do
+        let line = input_line ic in
+        if String.length line > 0 then
+          match Yojson.Safe.from_string line |> snapshot_of_json with
+          | Some s -> snaps := s :: !snaps
+          | None -> ()
+      done with End_of_file -> ());
+      List.rev !snaps)
+  end
+
+(* ================================================================ *)
+(* Core Logic                                                       *)
+(* ================================================================ *)
+
+(** Exponential decay factor: 0.95 per day. *)
+let decay_rate = 0.95
+
+(** Apply decay to a score based on age in days. *)
+let decay_score ~score ~age_days =
+  score *. (decay_rate ** age_days)
+
+(** Record a new reputation snapshot from Agent_reputation data. *)
+let record_snapshot ~agent_name (rep : Agent_reputation.agent_reputation) =
+  let snap = {
+    timestamp = Time_compat.now ();
+    overall_score = rep.overall_score;
+    tasks_completed = rep.tasks_completed;
+    completion_rate = rep.completion_rate;
+    response_rate = rep.response_rate;
+    board_posts = rep.board_posts;
+  } in
+  append_snapshot ~agent_name snap;
+  snap
+
+(** Compute average score over a time window (with decay). *)
+let windowed_score ~agent_name ~days : float =
+  let now = Time_compat.now () in
+  let cutoff = now -. (days *. 86400.0) in
+  let history = load_history ~agent_name in
+  let in_window = List.filter (fun s -> s.timestamp >= cutoff) history in
+  if List.length in_window = 0 then 0.0
+  else begin
+    let sum = List.fold_left (fun acc s ->
+      let age_days = (now -. s.timestamp) /. 86400.0 in
+      acc +. decay_score ~score:s.overall_score ~age_days
+    ) 0.0 in_window in
+    sum /. Float.of_int (List.length in_window)
+  end
+
+(** Detect trend by comparing 7-day vs 30-day average. *)
+let detect_trend ~score_7d ~score_30d : trend =
+  let delta = score_7d -. score_30d in
+  if delta > 0.05 then Improving
+  else if delta < -0.05 then Declining
+  else Stable
+
+(** Get full temporal reputation for an agent. *)
+let get_temporal_reputation ~agent_name : temporal_reputation =
+  let score_7d = windowed_score ~agent_name ~days:7.0 in
+  let score_30d = windowed_score ~agent_name ~days:30.0 in
+  let trend = detect_trend ~score_7d ~score_30d in
+  let current = if score_7d > 0.0 then score_7d else score_30d in
+  let history = load_history ~agent_name in
+  {
+    agent_name;
+    current_score = current;
+    trend;
+    score_7d;
+    score_30d;
+    history_count = List.length history;
+  }
+
+(** {1 Trust Integration with Hebbian Synapses}
+
+    Trust(A,B) = synapse_weight(A,B) × reputation(B)
+    This combines collaboration history with individual reputation. *)
+
+let compute_trust ~agent_a ~agent_b ~(synapse_weight : float) : float =
+  let rep_b = get_temporal_reputation ~agent_name:agent_b in
+  synapse_weight *. rep_b.current_score
+
+(** {1 Reputation-Weighted Voting}
+
+    Reputation-based vote weight: bounded [0.5, 1.5].
+    Prevents complete disenfranchisement while rewarding reliability. *)
+
+let vote_weight ~agent_name : float =
+  let rep = get_temporal_reputation ~agent_name in
+  let raw_weight =
+    if rep.current_score >= 0.8 then 1.2
+    else if rep.current_score >= 0.6 then 1.0
+    else if rep.current_score >= 0.4 then 0.8
+    else 0.7
+  in
+  (* Clamp to [0.5, 1.5] *)
+  max 0.5 (min 1.5 raw_weight)
+
+(** Serialize temporal reputation to JSON. *)
+let to_json (tr : temporal_reputation) : Yojson.Safe.t =
+  `Assoc [
+    ("agent_name", `String tr.agent_name);
+    ("current_score", `Float tr.current_score);
+    ("trend", `String (string_of_trend tr.trend));
+    ("score_7d", `Float tr.score_7d);
+    ("score_30d", `Float tr.score_30d);
+    ("history_count", `Int tr.history_count);
+  ]


### PR DESCRIPTION
## Summary

영속성이 확보된 에이전트들 위에 사회적 관계 레이어를 구축. 존재가 유지되어야 신뢰도 축적된다.

### 4A — Institution Episode Recording
- `record_episode_jsonl`: Eio 불필요한 경량 JSONL 에피소드 기록
- Lodge heartbeat, Keeper에서 직접 호출 가능
- `.masc/institution_episodes.jsonl`에 append-only 저장

### 4B — Temporal Reputation (`reputation_evolution.ml`)
- JSONL 기반 시계열 레퓨테이션 스냅샷
- 지수 감쇠 (0.95/day): 오래된 평가는 자연 감소
- 트렌드 분석: 7일 vs 30일 평균 비교 (improving/stable/declining)
- Trust = synapse_weight(A,B) x reputation(B)

### 4C — Reputation-Weighted Voting
- `vote_weight`: reputation 0.8+ → 1.2x, 0.3- → 0.7x
- 범위 [0.5x, 1.5x]로 clamp (완전한 무력화 방지)

### 4D — OAS Social Events
- `masc:trust_updated`, `masc:reputation_changed`, `masc:institution_episode`

## Test plan
- [ ] `dune build --root .` clean build
- [ ] reputation snapshot write/read/decay round-trip
- [ ] episode JSONL write/load round-trip
- [ ] vote_weight bounds verification

🤖 Generated with [Claude Code](https://claude.com/claude-code)