### PR TITLE
feat(collective): Phase 5 — norm detection + knowledge graph

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -168,8 +168,10 @@
    lodge_topic
    lodge_tom
    lodge_selection
+   knowledge_graph
    memory_consolidation
    memory_stream
+   norm_detector
    agent_planner
    reflection
    prometheus

--- a/lib/knowledge_graph.ml
+++ b/lib/knowledge_graph.ml
@@ -1,0 +1,163 @@
+(** Knowledge Graph — Neo4j Knowledge node management.
+
+    Schema:
+      (:Agent)-[:KNOWS]->(:Knowledge {content, confidence, source, created_at})
+      (:Knowledge)-[:SUPERSEDES]->(:Knowledge)
+      (:Knowledge)-[:RELATES_TO]->(:Knowledge)
+
+    Confidence decays 0.01/day. Re-verification resets decay.
+    Injected into agent context on startup (within token budget).
+
+    @since 2.90.0 *)
+
+open Printf
+
+(** A knowledge entry for Neo4j persistence. *)
+type knowledge_entry = {
+  id : string;
+  agent_name : string;
+  content : string;
+  confidence : float;       (** 0.0-1.0, decays over time *)
+  source : string;          (** Where this knowledge came from *)
+  category : string;        (** "decision" | "learning" | "fact" | "procedure" *)
+  created_at : float;
+  last_verified : float;
+  supersedes : string option;   (** ID of knowledge this supersedes *)
+}
+
+(** Escape string for Cypher queries. *)
+let escape s =
+  s
+  |> String.split_on_char '\''
+  |> String.concat "\\'"
+  |> String.split_on_char '\n'
+  |> String.concat "\\n"
+
+(* ================================================================ *)
+(* Cypher Query Builders                                            *)
+(* ================================================================ *)
+
+(** Create or update a Knowledge node and link it to an Agent. *)
+let build_create_knowledge_query (k : knowledge_entry) =
+  let supersedes_clause = match k.supersedes with
+    | Some prev_id ->
+      sprintf {|
+WITH k
+OPTIONAL MATCH (prev:Knowledge {id: '%s'})
+FOREACH (_ IN CASE WHEN prev IS NOT NULL THEN [1] ELSE [] END |
+  CREATE (k)-[:SUPERSEDES]->(prev)
+  SET prev.superseded = true
+)|} (escape prev_id)
+    | None -> ""
+  in
+  sprintf {|MERGE (a:Agent {name: '%s'})
+MERGE (k:Knowledge {id: '%s'})
+ON CREATE SET
+  k.content = '%s',
+  k.confidence = %f,
+  k.source = '%s',
+  k.category = '%s',
+  k.created_at = datetime({epochSeconds: %d}),
+  k.last_verified = datetime({epochSeconds: %d}),
+  k.superseded = false
+ON MATCH SET
+  k.content = '%s',
+  k.confidence = %f,
+  k.last_verified = datetime({epochSeconds: %d})
+MERGE (a)-[:KNOWS]->(k)%s
+RETURN k.id AS id, k.confidence AS confidence|}
+    (escape k.agent_name)
+    (escape k.id)
+    (escape k.content) k.confidence (escape k.source) (escape k.category)
+    (int_of_float k.created_at) (int_of_float k.last_verified)
+    (escape k.content) k.confidence (int_of_float k.last_verified)
+    supersedes_clause
+
+(** Create a RELATES_TO relationship between two Knowledge nodes. *)
+let build_relate_knowledge_query ~id_a ~id_b =
+  sprintf {|MATCH (a:Knowledge {id: '%s'}), (b:Knowledge {id: '%s'})
+MERGE (a)-[:RELATES_TO]->(b)
+RETURN a.id, b.id|}
+    (escape id_a) (escape id_b)
+
+(** Apply confidence decay to all Knowledge nodes.
+    decay = 0.01 per day since last_verified. *)
+let build_decay_query () =
+  {|MATCH (k:Knowledge)
+WHERE k.superseded = false AND k.confidence > 0.0
+WITH k, duration.between(k.last_verified, datetime()).days AS days_since
+WHERE days_since > 0
+SET k.confidence = CASE
+  WHEN k.confidence - (days_since * 0.01) < 0.0 THEN 0.0
+  ELSE k.confidence - (days_since * 0.01)
+END
+RETURN count(k) AS updated_count|}
+
+(** Query recent Knowledge for an agent (within token budget). *)
+let build_agent_knowledge_query ~agent_name ~limit =
+  sprintf {|MATCH (a:Agent {name: '%s'})-[:KNOWS]->(k:Knowledge)
+WHERE k.superseded = false AND k.confidence > 0.1
+RETURN k.id, k.content, k.confidence, k.category, k.source
+ORDER BY k.confidence DESC, k.last_verified DESC
+LIMIT %d|}
+    (escape agent_name) limit
+
+(* ================================================================ *)
+(* Local JSONL Cache (for offline/fallback)                         *)
+(* ================================================================ *)
+
+let knowledge_dir () =
+  let me_root = Env_config.me_root () in
+  Filename.concat me_root ".masc/knowledge"
+
+let ensure_dir path =
+  let rec mkdir_p dir =
+    if not (Sys.file_exists dir) then begin
+      mkdir_p (Filename.dirname dir);
+      (try Unix.mkdir dir 0o755 with Unix.Unix_error (Unix.EEXIST, _, _) -> ())
+    end
+  in
+  mkdir_p path
+
+let entry_to_json (k : knowledge_entry) : Yojson.Safe.t =
+  `Assoc [
+    ("id", `String k.id);
+    ("agent_name", `String k.agent_name);
+    ("content", `String k.content);
+    ("confidence", `Float k.confidence);
+    ("source", `String k.source);
+    ("category", `String k.category);
+    ("created_at", `Float k.created_at);
+    ("last_verified", `Float k.last_verified);
+    ("supersedes", match k.supersedes with Some s -> `String s | None -> `Null);
+  ]
+
+(** Append knowledge entry to local JSONL cache. *)
+let cache_locally (k : knowledge_entry) =
+  let dir = knowledge_dir () in
+  ensure_dir dir;
+  let path = Filename.concat dir (k.agent_name ^ ".jsonl") in
+  let oc = open_out_gen [Open_append; Open_creat; Open_text] 0o644 path in
+  output_string oc (Yojson.Safe.to_string (entry_to_json k));
+  output_char oc '\n';
+  close_out oc
+
+(** Create a knowledge entry with auto-generated ID. *)
+let create ~agent_name ~content ~confidence ~source ~category ?supersedes () =
+  let now = Time_compat.now () in
+  let id = sprintf "k-%s-%d-%06d" agent_name (int_of_float now) (Random.int 999999) in
+  let entry = {
+    id; agent_name; content; confidence; source; category;
+    created_at = now; last_verified = now; supersedes;
+  } in
+  cache_locally entry;
+  entry
+
+(** Format knowledge entries for agent prompt injection. *)
+let format_for_context (entries : knowledge_entry list) : string =
+  if List.length entries = 0 then ""
+  else
+    let lines = List.map (fun k ->
+      sprintf "- [%s/%.0f%%] %s" k.category (k.confidence *. 100.0) k.content
+    ) entries in
+    "[KNOWLEDGE]\n" ^ String.concat "\n" lines ^ "\n[/KNOWLEDGE]"

--- a/lib/norm_detector.ml
+++ b/lib/norm_detector.ml
@@ -1,0 +1,241 @@
+(** Norm Detector — Extract behavioral norms from interaction patterns.
+
+    Scans social_motion event streams over a 7-day sliding window.
+    Repeated patterns (5+ occurrences, 70%+ success rate) become
+    candidate norms that can be promoted to active cultural values
+    through agent voting.
+
+    Norm lifecycle: emerging → candidate → active → fading → retired
+
+    @since 2.90.0 *)
+
+open Printf
+
+(** Norm lifecycle states. *)
+type norm_status =
+  | Emerging    (** Detected but not yet validated *)
+  | Candidate   (** Meets threshold, awaiting agent votes *)
+  | Active      (** 3+ distinct agent endorsements *)
+  | Fading      (** No recent activity, declining *)
+  | Retired     (** Deactivated *)
+
+let string_of_status = function
+  | Emerging -> "emerging" | Candidate -> "candidate"
+  | Active -> "active" | Fading -> "fading" | Retired -> "retired"
+
+let status_of_string = function
+  | "emerging" -> Emerging | "candidate" -> Candidate
+  | "active" -> Active | "fading" -> Fading | _ -> Retired
+
+(** A detected behavioral norm. *)
+type norm = {
+  id : string;
+  pattern : string;            (** "When X, agents tend to Y" *)
+  occurrence_count : int;
+  success_count : int;
+  success_rate : float;
+  status : norm_status;
+  endorsers : string list;     (** Agent names that voted for this norm *)
+  detractors : string list;    (** Agent names that voted against *)
+  first_seen : float;
+  last_seen : float;
+  summary : string;            (** Human-readable description *)
+}
+
+(* ================================================================ *)
+(* Paths                                                            *)
+(* ================================================================ *)
+
+let norms_dir () =
+  let me_root = Env_config.me_root () in
+  Filename.concat me_root ".masc/norms"
+
+let norms_path () =
+  Filename.concat (norms_dir ()) "norms.jsonl"
+
+let ensure_dir path =
+  let rec mkdir_p dir =
+    if not (Sys.file_exists dir) then begin
+      mkdir_p (Filename.dirname dir);
+      (try Unix.mkdir dir 0o755 with Unix.Unix_error (Unix.EEXIST, _, _) -> ())
+    end
+  in
+  mkdir_p path
+
+(* ================================================================ *)
+(* JSON                                                             *)
+(* ================================================================ *)
+
+let to_json (n : norm) : Yojson.Safe.t =
+  `Assoc [
+    ("id", `String n.id);
+    ("pattern", `String n.pattern);
+    ("occurrence_count", `Int n.occurrence_count);
+    ("success_count", `Int n.success_count);
+    ("success_rate", `Float n.success_rate);
+    ("status", `String (string_of_status n.status));
+    ("endorsers", `List (List.map (fun e -> `String e) n.endorsers));
+    ("detractors", `List (List.map (fun d -> `String d) n.detractors));
+    ("first_seen", `Float n.first_seen);
+    ("last_seen", `Float n.last_seen);
+    ("summary", `String n.summary);
+  ]
+
+let of_json (json : Yojson.Safe.t) : norm option =
+  try
+    let open Yojson.Safe.Util in
+    Some {
+      id = json |> member "id" |> to_string;
+      pattern = json |> member "pattern" |> to_string;
+      occurrence_count = json |> member "occurrence_count" |> to_int;
+      success_count = json |> member "success_count" |> to_int;
+      success_rate = json |> member "success_rate" |> to_float;
+      status = json |> member "status" |> to_string |> status_of_string;
+      endorsers =
+        (try json |> member "endorsers" |> to_list |> List.map to_string
+         with Type_error _ -> []);
+      detractors =
+        (try json |> member "detractors" |> to_list |> List.map to_string
+         with Type_error _ -> []);
+      first_seen = json |> member "first_seen" |> to_float;
+      last_seen = json |> member "last_seen" |> to_float;
+      summary =
+        (try json |> member "summary" |> to_string
+         with Type_error _ -> "");
+    }
+  with _ -> None
+
+(* ================================================================ *)
+(* File I/O                                                         *)
+(* ================================================================ *)
+
+let load_norms () : norm list =
+  let path = norms_path () in
+  if not (Sys.file_exists path) then []
+  else begin
+    let ic = open_in path in
+    Fun.protect ~finally:(fun () -> close_in_noerr ic) (fun () ->
+      let norms = ref [] in
+      (try while true do
+        let line = input_line ic in
+        if String.length line > 0 then
+          match Yojson.Safe.from_string line |> of_json with
+          | Some n -> norms := n :: !norms
+          | None -> ()
+      done with End_of_file -> ());
+      List.rev !norms)
+  end
+
+let save_norms (norms : norm list) =
+  let dir = norms_dir () in
+  ensure_dir dir;
+  let path = norms_path () in
+  let tmp = path ^ ".tmp" in
+  let oc = open_out tmp in
+  Fun.protect ~finally:(fun () -> close_out_noerr oc) (fun () ->
+    List.iter (fun n ->
+      output_string oc (Yojson.Safe.to_string (to_json n));
+      output_char oc '\n'
+    ) norms);
+  Sys.rename tmp path
+
+(* ================================================================ *)
+(* Norm Operations                                                  *)
+(* ================================================================ *)
+
+(** Report an observed pattern (increments count, creates if new). *)
+let report_pattern ~pattern ~success ~summary =
+  let norms = load_norms () in
+  let now = Time_compat.now () in
+  let existing = List.find_opt (fun n -> n.pattern = pattern) norms in
+  let updated = match existing with
+    | Some n ->
+      let occ = n.occurrence_count + 1 in
+      let succ = n.success_count + (if success then 1 else 0) in
+      let rate = Float.of_int succ /. Float.of_int occ in
+      let status =
+        if occ >= 5 && rate >= 0.7 && n.status = Emerging then Candidate
+        else n.status
+      in
+      { n with
+        occurrence_count = occ;
+        success_count = succ;
+        success_rate = rate;
+        status;
+        last_seen = now;
+      }
+    | None ->
+      let id = sprintf "norm-%d-%06d" (int_of_float now) (Random.int 999999) in
+      {
+        id; pattern;
+        occurrence_count = 1;
+        success_count = (if success then 1 else 0);
+        success_rate = (if success then 1.0 else 0.0);
+        status = Emerging;
+        endorsers = []; detractors = [];
+        first_seen = now; last_seen = now;
+        summary;
+      }
+  in
+  let patched = match existing with
+    | Some _ -> List.map (fun n ->
+        if n.pattern = pattern then updated else n) norms
+    | None -> updated :: norms
+  in
+  save_norms patched;
+  updated
+
+(** Agent endorses or opposes a norm. *)
+let vote ~norm_id ~agent_name ~endorse =
+  let norms = load_norms () in
+  let patched = List.map (fun n ->
+    if n.id <> norm_id then n
+    else
+      let endorsers, detractors =
+        if endorse then
+          (if List.mem agent_name n.endorsers then n.endorsers
+           else agent_name :: n.endorsers),
+          List.filter (fun d -> d <> agent_name) n.detractors
+        else
+          List.filter (fun e -> e <> agent_name) n.endorsers,
+          (if List.mem agent_name n.detractors then n.detractors
+           else agent_name :: n.detractors)
+      in
+      (* Promote to Active if 3+ distinct endorsers *)
+      let distinct_endorsers = List.sort_uniq String.compare endorsers in
+      let status =
+        if List.length distinct_endorsers >= 3 && n.status = Candidate then Active
+        else n.status
+      in
+      { n with endorsers; detractors; status }
+  ) norms in
+  save_norms patched
+
+(** Decay: mark norms with no activity in 30 days as Fading. *)
+let decay_norms () =
+  let norms = load_norms () in
+  let now = Time_compat.now () in
+  let cutoff = now -. (30.0 *. 86400.0) in
+  let patched = List.map (fun n ->
+    if n.last_seen < cutoff && n.status = Active then
+      { n with status = Fading }
+    else if n.last_seen < cutoff -. (30.0 *. 86400.0) && n.status = Fading then
+      { n with status = Retired }
+    else n
+  ) norms in
+  save_norms patched
+
+(** Get active norms for injection into agent context. *)
+let active_norms () : norm list =
+  load_norms () |> List.filter (fun n -> n.status = Active)
+
+(** Format active norms for agent prompt injection. *)
+let format_for_context () : string =
+  let norms = active_norms () in
+  if List.length norms = 0 then ""
+  else
+    let lines = List.map (fun n ->
+      sprintf "- %s (endorsed by %d agents, success %.0f%%)"
+        n.summary (List.length n.endorsers) (n.success_rate *. 100.0)
+    ) norms in
+    "[NORMS]\n" ^ String.concat "\n" lines ^ "\n[/NORMS]"


### PR DESCRIPTION
## Summary

집단 인지의 두 축: 행동 규범 자동 생성과 지식 그래프.

### 5A — Norm Detector (`norm_detector.ml`)
- 상호작용 패턴에서 규범 자동 탐지
- 생애주기: `emerging` → `candidate` (5+회, 70%+) → `active` (3+ 에이전트 찬성) → `fading` → `retired`
- 에이전트 투표 (endorse/oppose), 30일 비활동 시 자연 감쇠
- `[NORMS]...[/NORMS]` 블록으로 에이전트 컨텍스트 주입

### 5C — Knowledge Graph (`knowledge_graph.ml`)
- Neo4j Cypher 빌더: Knowledge 노드 CRUD + SUPERSEDES/RELATES_TO 관계
- Confidence 감쇠: 0.01/day (재검증 시 리셋)
- 에이전트별 지식 조회 (confidence + recency 정렬)
- 로컬 JSONL 캐시 (오프라인 fallback)
- `[KNOWLEDGE]...[/KNOWLEDGE]` 블록으로 프롬프트 주입

## Architecture
```
social_motion events
    → norm_detector (pattern detection)
        → institution_eio (cultural_value)
            → agent prompt injection

session decisions
    → knowledge_graph (Neo4j + JSONL)
        → agent startup injection
```

## Test plan
- [ ] `dune build --root .`
- [ ] norm lifecycle: report → candidate → vote → active
- [ ] knowledge confidence decay verification
- [ ] Cypher query syntax validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)