### PR TITLE
refactor(dispatch): register 6 tool modules with V2 dispatch

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -270,6 +270,12 @@
    tools_schemas_10
    tools_schemas_11
    tool_args
+   tool_schemas_plan
+   tool_schemas_portal
+   tool_schemas_worktree
+   tool_schemas_auth
+   tool_schemas_agent
+   tool_schemas_room
    tool_plan
    tool_run
    tool_cache
@@ -393,7 +399,13 @@
    perpetual_loop
    oas_events
    oas_checkpoint_bridge
-   env_config_core
+   tool_schemas_plan
+ tool_schemas_portal
+ tool_schemas_worktree
+ tool_schemas_auth
+ tool_schemas_agent
+ tool_schemas_room
+ env_config_core
    env_config_runtime
    env_config_governance
    env_config_keeper

--- a/lib/mcp_server_eio.ml
+++ b/lib/mcp_server_eio.ml
@@ -1483,6 +1483,19 @@ let execute_tool_eio ~sw ~clock ?mcp_session_id ?auth_token state ~name ~argumen
         ~handler:(fun ~name ~args -> Some (Tool_risc.dispatch name args));
       reg ~schemas:Tool_agent_timeline.schemas
         ~handler:(fun ~name ~args -> Tool_agent_timeline.dispatch simple_ctx_agent_timeline ~name ~args);
+      (* B-0a: newly registered modules with domain schema files *)
+      reg ~schemas:Tool_plan.schemas
+        ~handler:(fun ~name ~args -> Tool_plan.dispatch simple_ctx_config ~name ~args);
+      reg ~schemas:Tool_portal.schemas
+        ~handler:(fun ~name ~args -> Tool_portal.dispatch simple_ctx_portal ~name ~args);
+      reg ~schemas:Tool_worktree.schemas
+        ~handler:(fun ~name ~args -> Tool_worktree.dispatch simple_ctx_worktree ~name ~args);
+      reg ~schemas:Tool_auth.schemas
+        ~handler:(fun ~name ~args -> Tool_auth.dispatch simple_ctx_auth ~name ~args);
+      reg ~schemas:Tool_agent.schemas
+        ~handler:(fun ~name ~args -> Tool_agent.dispatch simple_ctx_agent ~name ~args);
+      reg ~schemas:Tool_room.schemas
+        ~handler:(fun ~name ~args -> Tool_room.dispatch simple_ctx_room ~name ~args);
       Tool_dispatch.dispatch ~name ~args:arguments
     end else None
   in

--- a/lib/tool_agent.ml
+++ b/lib/tool_agent.ml
@@ -286,3 +286,5 @@ let dispatch ctx ~name ~args =
   | "masc_consolidate_learning" -> Some (handle_consolidate_learning ctx args)
   | "masc_agent_card" -> Some (handle_agent_card ctx args)
   | _ -> None
+
+let schemas = Tool_schemas_agent.schemas

--- a/lib/tool_agent.mli
+++ b/lib/tool_agent.mli
@@ -8,6 +8,8 @@ type context = {
 (** Dispatch handler. Returns Some (success, result) if handled, None otherwise *)
 val dispatch : context -> name:string -> args:Yojson.Safe.t -> (bool * string) option
 
+val schemas : Types.tool_schema list
+
 (** Handle masc_agents *)
 val handle_agents : context -> Yojson.Safe.t -> bool * string
 

--- a/lib/tool_auth.ml
+++ b/lib/tool_auth.ml
@@ -117,3 +117,5 @@ let dispatch ctx ~name ~args : result option =
   | "masc_auth_revoke" -> Some (handle_auth_revoke ctx args)
   | "masc_auth_list" -> Some (handle_auth_list ctx args)
   | _ -> None
+
+let schemas = Tool_schemas_auth.schemas

--- a/lib/tool_auth.mli
+++ b/lib/tool_auth.mli
@@ -16,3 +16,5 @@ val handle_auth_revoke : context -> Yojson.Safe.t -> result
 val handle_auth_list : context -> Yojson.Safe.t -> result
 
 val dispatch : context -> name:string -> args:Yojson.Safe.t -> result option
+
+val schemas : Types.tool_schema list

--- a/lib/tool_plan.ml
+++ b/lib/tool_plan.ml
@@ -181,3 +181,5 @@ let dispatch ctx ~name ~args : result option =
   | "masc_plan_get_task" -> Some (handle_plan_get_task ctx args)
   | "masc_plan_clear_task" -> Some (handle_plan_clear_task ctx args)
   | _ -> None
+
+let schemas = Tool_schemas_plan.schemas

--- a/lib/tool_plan.mli
+++ b/lib/tool_plan.mli
@@ -30,3 +30,5 @@ val handle_plan_clear_task : context -> Yojson.Safe.t -> result
 
 (** Dispatch plan tool by name. Returns None if not a plan tool. *)
 val dispatch : context -> name:string -> args:Yojson.Safe.t -> result option
+
+val schemas : Types.tool_schema list

--- a/lib/tool_portal.ml
+++ b/lib/tool_portal.ml
@@ -43,3 +43,5 @@ let dispatch ctx ~name ~args : result option =
   | "masc_portal_close" -> Some (handle_portal_close ctx args)
   | "masc_portal_status" -> Some (handle_portal_status ctx args)
   | _ -> None
+
+let schemas = Tool_schemas_portal.schemas

--- a/lib/tool_portal.mli
+++ b/lib/tool_portal.mli
@@ -13,3 +13,5 @@ val handle_portal_close : context -> Yojson.Safe.t -> result
 val handle_portal_status : context -> Yojson.Safe.t -> result
 
 val dispatch : context -> name:string -> args:Yojson.Safe.t -> result option
+
+val schemas : Types.tool_schema list

--- a/lib/tool_room.ml
+++ b/lib/tool_room.ml
@@ -287,3 +287,5 @@ let dispatch ctx ~name ~args : result option =
   | "masc_workflow_guide" -> Some (handle_workflow_guide ctx args)
   | "masc_check" -> Some (handle_check ctx args)
   | _ -> None
+
+let schemas = Tool_schemas_room.schemas

--- a/lib/tool_worktree.ml
+++ b/lib/tool_worktree.ml
@@ -35,3 +35,5 @@ let dispatch ctx ~name ~args : result option =
   | "masc_worktree_remove" -> Some (handle_worktree_remove ctx args)
   | "masc_worktree_list" -> Some (handle_worktree_list ctx args)
   | _ -> None
+
+let schemas = Tool_schemas_worktree.schemas

--- a/lib/tool_worktree.mli
+++ b/lib/tool_worktree.mli
@@ -12,3 +12,5 @@ val handle_worktree_remove : context -> Yojson.Safe.t -> result
 val handle_worktree_list : context -> Yojson.Safe.t -> result
 
 val dispatch : context -> name:string -> args:Yojson.Safe.t -> result option
+
+val schemas : Types.tool_schema list


### PR DESCRIPTION
## Summary
- Add `schemas` re-export to 6 tool modules (Plan, Portal, Worktree, Auth, Agent, Room) via domain schema files
- Register all 6 with V2 hashtbl-based dispatch in mcp_server_eio.ml
- V2 coverage: 15 → 21 modules (28%)

## Details
Each module now re-exports `let schemas = Tool_schemas_*.schemas` and has `val schemas` in its .mli.
Registration follows existing V2 pattern with per-call handler closures.

No behavior change: V2 is still opt-in (MASC_DISPATCH_V2=1). Legacy match chain is untouched as fallback.

## Test plan
- [x] `dune build --root .` compiles clean
- [ ] `make test` (pending — dune lock contention from parallel sessions)
- [ ] Manual: `MASC_DISPATCH_V2=1 curl http://127.0.0.1:8935/health`

🤖 Generated with [Claude Code](https://claude.com/claude-code)