### PR TITLE
fix: add build mutex and job limit to prevent process runaway

### DIFF
--- a/start-masc-mcp.sh
+++ b/start-masc-mcp.sh
@@ -15,6 +15,26 @@ fi
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cd "$SCRIPT_DIR"
 
+# Build concurrency limit: use half of available cores to prevent system freeze
+# when multiple worktrees trigger simultaneous dune builds.
+DUNE_JOBS="${MASC_DUNE_JOBS:-8}"
+
+# mkdir-based build mutex (atomic on POSIX, works on macOS without flock).
+# Prevents multiple start-masc-mcp.sh instances from building concurrently.
+MASC_BUILD_LOCK="/tmp/masc-mcp-build.lock"
+acquire_build_lock() {
+    if ! mkdir "$MASC_BUILD_LOCK" 2>/dev/null; then
+        echo "Another MASC build in progress, skipping rebuild" >&2
+        return 1
+    fi
+    # Clean up lock on exit (normal or error)
+    trap 'rmdir "$MASC_BUILD_LOCK" 2>/dev/null; trap - EXIT' EXIT
+    return 0
+}
+release_build_lock() {
+    rmdir "$MASC_BUILD_LOCK" 2>/dev/null || true
+}
+
 resolve_repo_env_root() {
     if command -v git >/dev/null 2>&1; then
         local common_dir
@@ -174,7 +194,10 @@ if [ -z "$MASC_EIO_EXE" ]; then
         echo "Error: dune not found. Install dune first." >&2
         exit 1
     fi
-    dune build --root "$SCRIPT_DIR" bin/main_eio.exe 1>&2
+    if acquire_build_lock; then
+        dune build -j "$DUNE_JOBS" --root "$SCRIPT_DIR" bin/main_eio.exe 1>&2
+        release_build_lock
+    fi
     if [ -x "$LOCAL_EIO_EXE" ]; then
         MASC_EIO_EXE="$LOCAL_EIO_EXE"
     else
@@ -189,7 +212,10 @@ if [ "$HTTP_MODE" = "false" ] && [ -z "$MASC_STDIO_EIO_EXE" ]; then
         echo "Error: dune not found. Cannot build stdio server." >&2
         exit 1
     fi
-    dune build --root "$SCRIPT_DIR" bin/main_stdio_eio.exe 1>&2
+    if acquire_build_lock; then
+        dune build -j "$DUNE_JOBS" --root "$SCRIPT_DIR" bin/main_stdio_eio.exe 1>&2
+        release_build_lock
+    fi
     if [ -x "$WORKSPACE_STDIO_EIO_EXE" ]; then
         MASC_STDIO_EIO_EXE="$WORKSPACE_STDIO_EIO_EXE"
     elif [ -x "$LOCAL_STDIO_EIO_EXE" ]; then
@@ -206,8 +232,11 @@ if [ -n "$MASC_EIO_EXE" ] && command -v dune >/dev/null 2>&1; then
     if find "$SCRIPT_DIR/bin" "$SCRIPT_DIR/lib" \
         -type f \( -name '*.ml' -o -name '*.mli' -o -name 'dune' \) \
         -newer "$MASC_EIO_EXE" 2>/dev/null | head -n 1 | grep -q .; then
-        echo "Rebuilding MASC MCP server (stale executable detected)..." >&2
-        dune build --root "$SCRIPT_DIR" bin/main_eio.exe 1>&2
+        if acquire_build_lock; then
+            echo "Rebuilding MASC MCP server (stale executable detected)..." >&2
+            dune build -j "$DUNE_JOBS" --root "$SCRIPT_DIR" bin/main_eio.exe 1>&2
+            release_build_lock
+        fi
 
         if [ -x "$WORKSPACE_EIO_EXE" ]; then
             MASC_EIO_EXE="$WORKSPACE_EIO_EXE"
@@ -305,7 +334,10 @@ if [ "$EIO_MODE" = "true" ]; then
             echo "Error: dune not found. Cannot build Eio server." >&2
             exit 1
         fi
-        dune build --root "$SCRIPT_DIR" bin/main_eio.exe 1>&2
+        if acquire_build_lock; then
+            dune build -j "$DUNE_JOBS" --root "$SCRIPT_DIR" bin/main_eio.exe 1>&2
+            release_build_lock
+        fi
         if [ -x "$WORKSPACE_EIO_EXE" ]; then
             MASC_EIO_EXE="$WORKSPACE_EIO_EXE"
         elif [ -x "$LOCAL_EIO_EXE" ]; then


### PR DESCRIPTION
## Summary
- 2026-03-16 incident: 20 worktrees에서 동시 `dune build` → 30+ ppx.exe + 30+ Claude 프로세스 → M3 Max 128GB system freeze
- `start-masc-mcp.sh`의 모든 `dune build` 호출(4곳)에 두 가지 안전장치 추가:
  - **mkdir-based mutex**: 동시 빌드 방지 (macOS 호환, `flock` 불필요)
  - **`-j 8` 제한**: 전체 코어의 50%만 사용 (`MASC_DUNE_JOBS` 환경변수로 override 가능)

## Root Cause
```
worktree 20개 누적 → 다수 세션 동시 작업 → stale executable 감지 자동 rebuild
→ 각 dune build -j 16 (기본) → 590+ sandbox burst → 30+ ppx.exe → system freeze
```

## Changes
- `acquire_build_lock()` / `release_build_lock()`: POSIX `mkdir` 기반 atomic lock
- `DUNE_JOBS` 변수 (`MASC_DUNE_JOBS` env override): 기본 8 (16코어의 50%)
- 4곳 `dune build` 모두에 lock guard + `-j $DUNE_JOBS` 적용

## Test plan
- [ ] `bash -n start-masc-mcp.sh` syntax 검증
- [ ] 두 터미널에서 동시 `./start-masc-mcp.sh` → 두 번째가 "Another MASC build in progress" 출력
- [ ] `grep -c "\-j \"\$DUNE_JOBS\"" start-masc-mcp.sh` → 4

🤖 Generated with [Claude Code](https://claude.com/claude-code)