### PR TITLE
fix: add PID-based stale lock detection to build mutex

### DIFF
--- a/start-masc-mcp.sh
+++ b/start-masc-mcp.sh
@@ -21,18 +21,41 @@ DUNE_JOBS="${MASC_DUNE_JOBS:-8}"
 
 # mkdir-based build mutex (atomic on POSIX, works on macOS without flock).
 # Prevents multiple start-masc-mcp.sh instances from building concurrently.
+# Stores owner PID to detect and recover from stale locks left by crashed processes.
 MASC_BUILD_LOCK="/tmp/masc-mcp-build.lock"
-acquire_build_lock() {
-    if ! mkdir "$MASC_BUILD_LOCK" 2>/dev/null; then
-        echo "Another MASC build in progress, skipping rebuild" >&2
-        return 1
+_MASC_LOCK_HELD=""
+_masc_cleanup_lock() {
+    if [ -n "$_MASC_LOCK_HELD" ] && [ -d "$MASC_BUILD_LOCK" ]; then
+        rm -f "$MASC_BUILD_LOCK/pid"
+        rmdir "$MASC_BUILD_LOCK" 2>/dev/null || true
+        _MASC_LOCK_HELD=""
     fi
-    # Clean up lock on exit (normal or error)
-    trap 'rmdir "$MASC_BUILD_LOCK" 2>/dev/null; trap - EXIT' EXIT
-    return 0
+}
+trap '_masc_cleanup_lock' EXIT
+acquire_build_lock() {
+    if mkdir "$MASC_BUILD_LOCK" 2>/dev/null; then
+        echo $$ > "$MASC_BUILD_LOCK/pid"
+        _MASC_LOCK_HELD="1"
+        return 0
+    fi
+    # Check for stale lock (owner process no longer running)
+    local owner_pid
+    owner_pid="$(cat "$MASC_BUILD_LOCK/pid" 2>/dev/null || echo "")"
+    if [ -n "$owner_pid" ] && ! kill -0 "$owner_pid" 2>/dev/null; then
+        echo "Removing stale build lock (pid $owner_pid no longer running)" >&2
+        rm -f "$MASC_BUILD_LOCK/pid"
+        rmdir "$MASC_BUILD_LOCK" 2>/dev/null || true
+        if mkdir "$MASC_BUILD_LOCK" 2>/dev/null; then
+            echo $$ > "$MASC_BUILD_LOCK/pid"
+            _MASC_LOCK_HELD="1"
+            return 0
+        fi
+    fi
+    echo "Another MASC build in progress (pid ${owner_pid:-unknown}), skipping rebuild" >&2
+    return 1
 }
 release_build_lock() {
-    rmdir "$MASC_BUILD_LOCK" 2>/dev/null || true
+    _masc_cleanup_lock
 }
 
 resolve_repo_env_root() {


### PR DESCRIPTION
## Summary
- Follow-up to #1085 (build mutex + job limit)
- 기존 mkdir lock은 crash 시 lock 디렉토리가 남아 영구 deadlock 가능
- PID를 lock 디렉토리 내 파일로 저장, `kill -0`으로 owner 생존 확인
- stale lock 자동 감지 및 회수

## Changes
- `acquire_build_lock()`: PID 저장 + stale lock 감지/회수 로직 추가
- `_masc_cleanup_lock()`: 단일 EXIT trap으로 통합 (trap 덮어쓰기 방지)
- `_MASC_LOCK_HELD` 변수로 lock 소유권 추적

## Test plan
- [ ] `bash -n start-masc-mcp.sh` syntax 검증
- [ ] 정상: 두 터미널에서 동시 실행 → 두 번째가 "Another MASC build in progress (pid N)" 출력
- [ ] stale: `mkdir /tmp/masc-mcp-build.lock && echo 99999 > /tmp/masc-mcp-build.lock/pid` → 실행 시 "Removing stale build lock" 출력 후 정상 진행

🤖 Generated with [Claude Code](https://claude.com/claude-code)