### PR TITLE
fix(sentinel): auto-release orphaned tasks + slim join response

### DIFF
--- a/lib/room.ml
+++ b/lib/room.ml
@@ -540,30 +540,8 @@ and join config ~agent_name ?(agent_type_override=None) ~capabilities
     (Yojson.Safe.to_string (`List (List.map (fun s -> `String s) capabilities)))
     (now_iso ()));
 
-  Printf.sprintf {|✅ %s joined the room!
-
-🎫 **Your Identity**
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-  Nickname: %s
-  Type: %s
-  Session: %s
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-📋 **MASC 협업 가이드 (필독!)**
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-🔴 **필수 행동** (Lobby 가시성):
-1. 작업 시작시 broadcast
-2. 진행 상황 broadcast (30분마다)
-3. 완료시 broadcast
-4. @mention 응답 필수
-
-💡 **협업 패턴**:
-• "@에이전트 도움 요청"
-• "@에이전트 리뷰 요청"
-• "✅ [작업] 완료!"
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-|} nickname nickname agent_type session_id
+  Printf.sprintf "✅ %s joined\n  Nickname: %s\n  Type: %s\n  Session: %s"
+    nickname nickname agent_type session_id
   end
 
 and join_in_room config ~room_id ~agent_name ?(agent_type_override=None) ~capabilities

--- a/lib/sentinel.ml
+++ b/lib/sentinel.ml
@@ -278,39 +278,78 @@ let make_task_hygiene_consumer config : (module Pulse.Consumer) =
             ~prompt_id:"sentinel-task-hygiene"
             ~vars:[("task_list", task_list_str)] () in
 
-          let warnings = match llm_result with
-            | Some (`List items) ->
-                log_debug (sprintf "task hygiene LLM assessed %d tasks" (List.length items));
-                List.filter_map (fun item ->
-                  let open Yojson.Safe.Util in
-                  let action = item |> member "action" |> to_string_option
-                               |> Option.value ~default:"ignore" in
-                  if action = "ignore" then None
-                  else
-                    let task_id = item |> member "task_id" |> to_string_option
-                                  |> Option.value ~default:"?" in
-                    let reason = item |> member "reason" |> to_string_option
-                                 |> Option.value ~default:"" in
-                    let priority = item |> member "priority" |> to_string_option
-                                   |> Option.value ~default:"medium" in
-                    Some (sprintf "task %s: %s [%s] %s" task_id action priority reason)
-                ) items
-            | _ ->
-                log_debug (sprintf "%d candidate stuck tasks, LLM unavailable — skipping"
-                  (List.length !candidates));
-                []
-          in
-
-          if warnings <> [] then begin
-            Log.Sentinel.warn "%d task warning(s)" (List.length warnings);
-            List.iter (fun w -> Log.Sentinel.warn "  %s" w) warnings;
-            Sse.broadcast (`Assoc [
-              ("type", `String "sentinel_warning");
-              ("source", `String agent_name);
-              ("warnings", `List (List.map (fun w -> `String w) warnings));
-              ("ts", `String (Types.now_iso ()));
-            ])
-          end
+          (match llm_result with
+           | Some (`List items) ->
+               log_debug
+                 (sprintf "task hygiene LLM assessed %d tasks" (List.length items));
+               let warnings = ref [] in
+               List.iter
+                 (fun item ->
+                   let open Yojson.Safe.Util in
+                   let action =
+                     item |> member "action" |> to_string_option
+                     |> Option.value ~default:"ignore"
+                   in
+                   let task_id =
+                     item |> member "task_id" |> to_string_option
+                     |> Option.value ~default:"?"
+                   in
+                   let reason =
+                     item |> member "reason" |> to_string_option
+                     |> Option.value ~default:""
+                   in
+                   let priority =
+                     item |> member "priority" |> to_string_option
+                     |> Option.value ~default:"medium"
+                   in
+                   match action with
+                   | "ignore" -> ()
+                   | "reassign" -> (
+                       match
+                         Room.force_release_task_r config ~agent_name ~task_id ()
+                       with
+                       | Ok _msg ->
+                           Log.Sentinel.info "auto-released %s → todo (%s)" task_id
+                             reason;
+                           Sse.broadcast
+                             (`Assoc
+                               [
+                                 ("type", `String "sentinel_auto_reassign");
+                                 ("source", `String agent_name);
+                                 ("task_id", `String task_id);
+                                 ("reason", `String reason);
+                                 ("priority", `String priority);
+                                 ("ts", `String (Types.now_iso ()));
+                               ])
+                       | Error e ->
+                           log_debug
+                             (sprintf "auto-release %s skipped: %s" task_id
+                                (Types.masc_error_to_string e)))
+                   | _ ->
+                       warnings :=
+                         sprintf "task %s: %s [%s] %s" task_id action priority
+                           reason
+                         :: !warnings)
+                 items;
+               let all_warnings = List.rev !warnings in
+               if all_warnings <> [] then begin
+                 Log.Sentinel.warn "%d task warning(s)"
+                   (List.length all_warnings);
+                 List.iter (fun w -> Log.Sentinel.warn "  %s" w) all_warnings;
+                 Sse.broadcast
+                   (`Assoc
+                     [
+                       ("type", `String "sentinel_warning");
+                       ("source", `String agent_name);
+                       ( "warnings",
+                         `List (List.map (fun w -> `String w) all_warnings) );
+                       ("ts", `String (Types.now_iso ()));
+                     ])
+               end
+           | _ ->
+               log_debug
+                 (sprintf "%d candidate stuck tasks, LLM unavailable — skipping"
+                    (List.length !candidates)))
         end;
         Ok ()
       with exn ->


### PR DESCRIPTION
## Summary
- **Sentinel auto-reassign**: `task_hygiene_consumer`에서 LLM이 `reassign` 판정을 내리면 `force_release_task_r`로 태스크를 `Todo`로 자동 전환. 기존에는 warning 로그만 남기고 상태를 변경하지 않아 같은 경고가 무한 반복됨.
- **Join 경량화**: `masc_join` 응답을 23줄 정적 가이드 → 4줄 identity card로 축소. 매 호출당 ~600 토큰 절감.

## Changes
| File | What |
|------|------|
| `lib/sentinel.ml` | `reassign` action 분리 → `Room.force_release_task_r` 호출 + SSE broadcast (`sentinel_auto_reassign`) |
| `lib/room.ml` | join 응답 문자열 23줄 → 4줄 (`"  Nickname: "` 접두사 유지로 하위 파서 호환) |

## Safety
- `force_release_task_r`는 file lock + 상태 체크로 멱등. 이미 `Todo`면 Error 반환 (crash 안 함)
- Guardian/cleanup_zombies와 동시 호출 시에도 file lock으로 안전
- `"  Nickname: "` 파싱하는 3곳 (`mcp_server_eio.ml:924`, `:1764`, `room.ml:3180`) 모두 호환 확인

## Test plan
- [x] `dune build` 성공
- [x] `test_room.exe` — 77 tests 통과
- [x] `test_guardian_sentinel.exe` — 7 tests 통과
- [ ] 수동 확인: Sentinel pulse 후 dead agent task가 `Todo`로 전환되는지 로그 확인
- [ ] 수동 확인: `masc_join` 응답이 4줄인지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)