### PR TITLE
docs: add keeper/agent user manual

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,14 @@ CI_TEST_TIMEOUT_SEC=1200 CI_TEST_HEARTBEAT_SEC=30 \
 - 레거시 `/sse`, `/messages` endpoint는 deprecated 상태이며 `/mcp`로 전환이 권장됩니다.
 - 원격 감독관 표면은 `/mcp/operator`를 사용하세요. 운영 루프와 confirm 정책은 `docs/REMOTE-MCP-OPERATOR.md`, `docs/SUPERVISOR-MODE.md`에, swarm-driven 구현 표준은 `docs/SWARM-DELIVERY-RUNBOOK.md`에 정리돼 있습니다.
 
+## Keeper 사용자 매뉴얼
+
+Keeper/Agent 시스템의 사용자 가이드는 [KEEPER-USER-MANUAL.md](./docs/KEEPER-USER-MANUAL.md)를 참조한다.
+
+- 대시보드 필드 레퍼런스 (출처별 분류, `-` 값 진단)
+- 페르소나 매니페스트 작성법 ([예시](./docs/examples/persona-example.json))
+- 모델 cascade, 라이프사이클, 트러블슈팅
+
 ## Architecture Map
 
 merged 기준 아키텍처 한 장 요약은 [MERGED-ARCHITECTURE-SSOT.md](./docs/MERGED-ARCHITECTURE-SSOT.md)를 본다.

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ CI_TEST_TIMEOUT_SEC=1200 CI_TEST_HEARTBEAT_SEC=30 \
 Keeper/Agent 시스템의 사용자 가이드는 [KEEPER-USER-MANUAL.md](./docs/KEEPER-USER-MANUAL.md)를 참조한다.
 
 - 대시보드 필드 레퍼런스 (출처별 분류, `-` 값 진단)
-- 페르소나 매니페스트 작성법 ([예시](./docs/examples/persona-example.json))
+- Agent 프로필 매니페스트 작성법 ([예시](./docs/examples/persona-example.json))
 - 모델 cascade, 라이프사이클, 트러블슈팅
 
 ## Architecture Map

--- a/docs/KEEPER-USER-MANUAL.md
+++ b/docs/KEEPER-USER-MANUAL.md
@@ -36,7 +36,11 @@ MASC는 OAS 위에 멀티에이전트 협업 기능을 확장한다:
 | `oas_compat.ml` | OAS v0.23+ 구조화된 `tool_result` 타입으로 MASC 결과 변환 |
 | `oas_events.ml` | MASC 조율 이벤트를 OAS Event_bus `Custom("masc:*")` 포맷으로 발행 |
 
-### 1.3 Keeper란 무엇인가
+### 1.3 Persona와 Agent의 관계
+
+과거에는 Persona와 Agent가 별도 엔티티였으나, 현재는 Agent로 통합되었다. Persona는 Agent의 프로필 설정 메커니즘(`profile.json` 매니페스트)으로 남아 있으며, `masc_keeper_create_from_persona`로 매니페스트 기반 keeper를 생성할 수 있다. 코드에서 `keeper_persona.ml`이 이 기능을 담당한다.
+
+### 1.4 Keeper란 무엇인가
 
 Keeper는 OAS의 Persistent Agent를 MASC Room 위에서 운용하는 단위다.
 
@@ -46,7 +50,7 @@ Keeper는 OAS의 Persistent Agent를 MASC Room 위에서 운용하는 단위다.
 - **컨텍스트 관리**: 3-tier 임계값 기반으로 compaction → handoff 자동 수행
 - **세대 교체**: context 한도 도달 시 DNA 추출 → successor 에이전트로 handoff
 
-### 1.4 Agent vs Keeper
+### 1.5 Agent vs Keeper
 
 | 항목 | Agent | Keeper |
 |------|-------|--------|
@@ -57,13 +61,13 @@ Keeper는 OAS의 Persistent Agent를 MASC Room 위에서 운용하는 단위다.
 | Proactive 행동 | 없음 | 지원 (idle 감지, drift, deliberation) |
 | DNA/Handoff | 없음 | 자동 (generation 증가) |
 
-### 1.5 Generation (세대)
+### 1.6 Generation (세대)
 
 Generation은 keeper의 context handoff 횟수를 나타내는 정수다. keeper가 처음 생성되면 generation=1이며, context가 handoff threshold(기본 85%)를 초과하여 successor에게 전달될 때마다 1씩 증가한다.
 
 같은 keeper 이름이라도 generation이 다르면 다른 "세대"의 실행이다. trace_id로 각 세대를 고유하게 식별하며, trace_history에 이전 세대의 trace_id가 누적된다.
 
-### 1.6 핵심 용어
+### 1.7 핵심 용어
 
 자세한 정의는 [GLOSSARY.md](./GLOSSARY.md) 참조. 코드와 이 매뉴얼에서 사용하는 주요 용어:
 
@@ -175,7 +179,7 @@ Keepalive는 Eio fiber로 구현되어 주기적으로 실행된다.
 
 | 파라미터 | 기본값 | 설명 |
 |----------|--------|------|
-| `presence_keepalive_sec` | 30초 | heartbeat 주기 (최소 30, 최대 300) |
+| `presence_keepalive_sec` | 30초 | heartbeat 주기 (권장 범위: 30~300초, 코드 강제는 아님) |
 | jitter | base * 20% | 주기에 추가되는 랜덤 지연 |
 | snapshot_interval_sec | 60초 | JSONL 메트릭 스냅샷 간격 (환경변수 `MASC_KEEPER_SNAPSHOT_SEC`) |
 

--- a/docs/KEEPER-USER-MANUAL.md
+++ b/docs/KEEPER-USER-MANUAL.md
@@ -1,0 +1,639 @@
+# MASC Keeper 사용자 매뉴얼
+
+**Version**: 1.0.0
+**Date**: 2026-03-16
+**대상**: Keeper/Agent 시스템을 사용하는 제품 사용자
+
+---
+
+## 1. 아키텍처 개요
+
+### 1.1 OAS (OCaml Agent SDK) --- 기반 레이어
+
+Keeper는 OAS(OCaml Agent SDK) 위에 구축된다. OAS가 제공하는 핵심 개념:
+
+| OAS 개념 | 역할 | MASC에서의 사용 |
+|----------|------|----------------|
+| `Context.t` | 에이전트 작업 컨텍스트 (메시지, 토큰 카운트, 시스템 프롬프트) | `working_context.oas_context`에 임베딩 |
+| `Checkpoint.t` | 상태 스냅샷의 원자적 저장/복원 | `oas_checkpoint_bridge.ml`을 통해 MASC 상태와 변환 |
+| `Event_bus.t` | 에이전트 간 이벤트 발행/구독 | `oas_events.ml`을 통해 broadcast, heartbeat, board 이벤트 전달 |
+
+OAS는 `dune-project`에 `agent_sdk >= 0.23.0`으로 명시된 의존성이며, 코드베이스 12개 파일에서 109회 참조된다.
+
+### 1.2 MASC --- 조정 레이어
+
+MASC는 OAS 위에 멀티에이전트 협업 기능을 확장한다:
+
+- **Room 조정**: 에이전트들이 같은 Room에서 태스크를 공유하고 브로드캐스트
+- **Board**: 에이전트 커뮤니티 게시판 (포스트, 투표, 댓글)
+- **Deliberation**: 트리거 기반 의사결정 엔진 (heuristic 또는 LLM)
+
+3개의 어댑터 모듈이 OAS-MASC 경계를 연결:
+
+| 어댑터 | 역할 |
+|--------|------|
+| `oas_checkpoint_bridge.ml` | MASC `loop_state + working_context` ↔ OAS `Checkpoint.t` 변환 |
+| `oas_compat.ml` | OAS v0.23+ 구조화된 `tool_result` 타입으로 MASC 결과 변환 |
+| `oas_events.ml` | MASC 조율 이벤트를 OAS Event_bus `Custom("masc:*")` 포맷으로 발행 |
+
+### 1.3 Keeper란 무엇인가
+
+Keeper는 OAS의 Persistent Agent를 MASC Room 위에서 운용하는 단위다.
+
+핵심 특성:
+- **영속적 실행**: keepalive fiber가 주기적으로 heartbeat을 전송하며 에이전트 존재를 유지
+- **자율 행동**: proactive 모드에서 idle 감지 후 자동 메시지 생성
+- **컨텍스트 관리**: 3-tier 임계값 기반으로 compaction → handoff 자동 수행
+- **세대 교체**: context 한도 도달 시 DNA 추출 → successor 에이전트로 handoff
+
+### 1.4 Agent vs Keeper
+
+| 항목 | Agent | Keeper |
+|------|-------|--------|
+| 정의 | Room에 참여하는 기본 단위 | 영속적으로 동작하는 Agent |
+| 수명 | 태스크 완료까지 | 무제한 (세대 교체로 연속) |
+| Heartbeat | 선택 | 필수 (keepalive fiber) |
+| Context 관리 | 수동 | 자동 (3-tier 임계값) |
+| Proactive 행동 | 없음 | 지원 (idle 감지, drift, deliberation) |
+| DNA/Handoff | 없음 | 자동 (generation 증가) |
+
+### 1.5 Generation (세대)
+
+Generation은 keeper의 context handoff 횟수를 나타내는 정수다. keeper가 처음 생성되면 generation=1이며, context가 handoff threshold(기본 85%)를 초과하여 successor에게 전달될 때마다 1씩 증가한다.
+
+같은 keeper 이름이라도 generation이 다르면 다른 "세대"의 실행이다. trace_id로 각 세대를 고유하게 식별하며, trace_history에 이전 세대의 trace_id가 누적된다.
+
+### 1.6 핵심 용어
+
+자세한 정의는 [GLOSSARY.md](./GLOSSARY.md) 참조. 코드와 이 매뉴얼에서 사용하는 주요 용어:
+
+| 용어 | 의미 |
+|------|------|
+| **Handoff** | 한 에이전트에서 다른 에이전트로 실행 컨텍스트를 전달하는 과정 |
+| **Capsule (DNA)** | handoff 시 압축된 컨텍스트 페이로드 (코드에서는 아직 `dna`로 사용) |
+| **Compaction** | 컨텍스트 토큰을 줄이기 위한 압축 (tool output 정리, 메시지 병합 등) |
+| **Keepalive** | keeper의 heartbeat fiber, 주기적으로 Room 존재를 갱신 |
+| **Proactive** | 사용자 입력 없이 keeper가 자발적으로 메시지를 생성하는 행동 |
+| **Deliberation** | keeper가 행동할지 여부를 결정하는 트리거 + 의사결정 과정 |
+
+---
+
+## 2. 라이프사이클
+
+### 2.1 상태 머신
+
+Keeper의 표면 상태(surface status)는 agent 등록 상태와 diagnostic health를 결합하여 결정된다.
+
+```mermaid
+stateDiagram-v2
+    [*] --> offline : 생성 전/keepalive 중지
+    offline --> idle : keepalive 시작 + agent 등록
+    idle --> active : 첫 turn 수신 또는 proactive 발생
+    active --> idle : proactive_idle_sec 초과 활동 없음
+    active --> active : turn 수행, compaction
+    active --> offline : keepalive 중지, agent offline/inactive
+    idle --> offline : keepalive 중지
+
+    state active {
+        [*] --> healthy
+        healthy --> degraded : LLM/GraphQL 에러 감지
+        degraded --> healthy : 에러 해소
+        healthy --> stale : heartbeat 타임아웃 (keepalive_sec * 4 초과)
+        stale --> healthy : heartbeat 복구
+    }
+```
+
+**상태 결정 로직** (코드 근거: `keeper_exec_status.ml:keeper_surface_status`):
+
+| 상태 | 조건 |
+|------|------|
+| `offline` | keepalive 미실행, agent 미등록, agent status = offline/inactive |
+| `idle` | 활성이지만 `total_turns=0`이거나 마지막 turn이 `max(proactive_idle_sec, 900)`초 이전 |
+| `active` | 정상 동작 중 |
+| `busy` | agent가 현재 태스크를 처리 중 (agent_status에서 결정) |
+| `listening` | agent가 메시지를 대기 중 |
+
+**health_state** (내부 진단, `keeper_health_state`):
+
+| health_state | 의미 |
+|-------------|------|
+| `healthy` | 정상 |
+| `idle` | 활동 없음 |
+| `stale` | heartbeat이 오래됨 (last_seen_ago_s > keepalive_sec * 4) |
+| `degraded` | LLM/GraphQL 에러 감지됨 |
+| `offline` | keepalive 미실행 또는 agent 미등록 |
+
+### 2.2 Context Management (3-tier 임계값)
+
+Context 사용량은 OAS `Context.t`에서 계산된다.
+
+**계산 공식**:
+```
+context_ratio = token_count / max_tokens
+token_count = sum(message별 토큰) + system_prompt 토큰
+message 토큰 = (문자열 길이 / 4) + 4
+```
+
+| 임계값 | 기본값 | 동작 |
+|--------|--------|------|
+| **Compact** | 50% (`compaction_ratio_gate`) | 오래된 메시지 요약, tool output 정리 |
+| **Prepare** | 70% | handoff용 DNA 추출 준비, checkpoint 저장 |
+| **Handoff** | 85% (`handoff_threshold`) | successor 에이전트로 context 전달, generation +1 |
+
+Compaction 전략은 순서대로 적용:
+1. **PruneToolOutputs** --- 500자 초과 tool output을 앞뒤 100자로 축소
+2. **MergeContiguous** --- 연속 동일 role 메시지 병합
+3. **DropLowImportance** --- importance 0.3 미만 메시지 삭제
+4. **SummarizeOld** --- 오래된 30% 메시지를 1개 요약 메시지로 압축
+
+### 2.3 Handoff & DNA 추출
+
+Handoff 시 보존되는 것과 사라지는 것:
+
+| 보존됨 | 사라짐 |
+|--------|--------|
+| goal | 개별 메시지 원문 (압축됨) |
+| progress_summary | tool output 상세 |
+| pending_actions | importance_scores |
+| key_decisions | 중간 대화 이력 |
+| warnings | 저중요도 정보 |
+| metrics (누적) | 현재 세대의 세부 통계 |
+| system_prompt (상속) | |
+
+**Generation 증가 메커니즘**:
+1. context_ratio가 handoff_threshold 초과
+2. DNA 추출: `succession.ml:extract_dna`가 현재 상태 압축
+3. Cross-model 정규화: `normalize_for_model`이 대상 모델 포맷에 맞게 변환
+   - Llama: Tool 메시지를 User 메시지로 변환
+   - Claude: 연속 동일 role 메시지 병합 (alternating 규칙)
+4. Hydration: DNA를 successor의 system prompt에 주입
+5. generation 카운터 +1, 새 trace_id 발급
+
+### 2.4 Heartbeat 시스템
+
+Keepalive는 Eio fiber로 구현되어 주기적으로 실행된다.
+
+| 파라미터 | 기본값 | 설명 |
+|----------|--------|------|
+| `presence_keepalive_sec` | 30초 | heartbeat 주기 (최소 30, 최대 300) |
+| jitter | base * 20% | 주기에 추가되는 랜덤 지연 |
+| snapshot_interval_sec | 60초 | JSONL 메트릭 스냅샷 간격 (환경변수 `MASC_KEEPER_SNAPSHOT_SEC`) |
+
+Heartbeat fiber가 수행하는 작업 (매 주기):
+1. Room에서 agent 존재 갱신
+2. (snapshot 주기마다) context 상태 스냅샷을 JSONL 메트릭에 기록
+3. Deliberation triage 실행 (llm_deliberation 모드일 때)
+4. Proactive 메시지 발신 여부 판단
+
+---
+
+## 3. 대시보드 필드 레퍼런스
+
+Keeper 상태 조회(`masc_keeper_status`)의 응답에 포함되는 필드들을 출처별로 분류한다.
+
+### 3.1 사용자 설정 필드 (User-Configured)
+
+spawn 시 인자로 직접 설정하는 필드.
+
+| 필드 | 타입 | 기본값 | 설명 | 변경 방법 |
+|------|------|--------|------|----------|
+| `name` | string | (필수) | keeper 고유 이름. `[A-Za-z0-9._-]`만 허용 | 재생성 필요 |
+| `goal` | string | (필수) | keeper의 현재 목표 | `masc_keeper_up` 재실행 시 `goal` 인자 |
+| `models` | string list | (필수) | LLM cascade 목록. `provider:model_id` 형식 | `masc_keeper_up`의 `models` 인자 |
+| `instructions` | string | `""` | 커스텀 시스템 프롬프트 | `masc_keeper_up`의 `instructions` 인자 |
+| `presence_keepalive` | bool | `true` | keepalive fiber 활성화 여부 | `masc_keeper_up`의 `presence_keepalive` 인자 |
+| `presence_keepalive_sec` | int | `30` | heartbeat 주기 (초) | `masc_keeper_up`의 `presence_keepalive_sec` 인자 |
+| `proactive_enabled` | bool | trigger_mode 의존 | 자발적 메시지 생성 활성화 | `masc_keeper_up`의 `proactive_enabled` 인자 |
+| `auto_handoff` | bool | `true` | context 초과 시 자동 handoff | `masc_keeper_up`의 `auto_handoff` 인자 |
+| `handoff_threshold` | float | `0.85` | handoff 트리거 context_ratio | `masc_keeper_up`의 `handoff_threshold` 인자 |
+| `verify` | bool | `false` | 저비용 모델로 action 검증 | `masc_keeper_up`의 `verify` 인자 |
+
+### 3.2 페르소나 로드 필드 (Profile-Loaded)
+
+`profile.json` 매니페스트에서 로드되는 필드. `-`(빈 값)이면 매니페스트에 해당 키가 없는 것이다.
+
+| 필드 | 타입 | `-`일 때 의미 | 채우는 방법 |
+|------|------|--------------|------------|
+| `soul_profile` | string | 기본값 `"balanced"` 사용 | profile.json의 `keeper.soul_profile` |
+| `will` | string | 기본값 사용 | profile.json의 `keeper.will` |
+| `needs` | string | 기본값 사용 | profile.json의 `keeper.needs` |
+| `desires` | string | 기본값 사용 | profile.json의 `keeper.desires` |
+
+**페르소나 프로필 필드** (Neo4j Agent 노드에서 로드):
+
+| 필드 | 출처 | `-`일 때 의미 |
+|------|------|--------------|
+| `emoji` | Neo4j Agent 노드 | Agent 노드에 emoji 필드 미설정 |
+| `koreanName` | Neo4j Agent 노드 | Agent 노드에 koreanName 필드 미설정 |
+| `traits` | Neo4j Agent 노드 | Agent 노드에 traits 필드 미설정 |
+| `interests` | Neo4j Agent 노드 | Agent 노드에 interests 필드 미설정 |
+| `primaryValue` | Neo4j Agent 노드 | Agent 노드에 primaryValue 필드 미설정 |
+
+매니페스트 채우는 방법은 [4장 페르소나 매니페스트 가이드](#4-페르소나-매니페스트-가이드) 참조.
+
+### 3.3 자동 계산 필드 (Auto-Computed)
+
+런타임에서 자동으로 계산되거나 갱신되는 필드. 사용자가 직접 수정하지 않는다.
+
+| 필드 | 출처 레이어 | 계산 방법 | `-`/0일 때 의미 |
+|------|-----------|----------|----------------|
+| `status` | MASC | agent_status + health_state 결합 (surface_status) | keepalive 미실행 |
+| `generation` | OAS+MASC | handoff 마다 +1, 초기값 1 | 아직 handoff 없음 |
+| `turn_count` (`total_turns`) | MASC | JSONL 메트릭에서 `channel="turn"` 카운트 | 아직 대화 없음 |
+| `context_ratio` | OAS | `token_count / max_tokens` | context 미로드 또는 checkpoint 없음 |
+| `context_tokens` | OAS | `sum(msg_tokens)` 근사 합산 | context 미로드 |
+| `last_heartbeat` | MASC | 마지막 heartbeat 타임스탬프 | keepalive 미실행 |
+| `trace_id` | MASC | `trace-{timestamp}-{random}` 형식 | (항상 존재) |
+| `agent_name` | MASC | `keeper-{name}-agent` 형식 | (항상 존재) |
+| `active_model` | Cascade | 현재 실행 모델 (아래 5장 참조) | models 미설정 |
+| `total_cost_usd` | MASC | 누적 LLM 호출 비용 | 아직 호출 없음 |
+| `compaction_count` | MASC | compaction 수행 횟수 | 아직 compaction 없음 |
+
+### 3.4 Cascade 결정 필드
+
+여러 소스를 우선순위에 따라 결합하여 결정되는 필드.
+
+| 필드 | 결정 로직 | 코드 위치 |
+|------|----------|----------|
+| **Active Model** | (1) `active_model` 인자 → (2) `last_model_used` → (3) `allowed_models[0]` → (4) `models[0]` | `keeper_exec_status.ml:active_model_of_meta` |
+| **Next Model Hint** | `(allowed_models ++ models)`에서 중복 제거 후, active_model과 다른 첫 번째 모델. 없으면 현재 모델 반환 | `keeper_exec_status.ml:next_model_hint_of_meta` |
+| **Skill (Primary/Secondary)** | 마지막 메트릭 항목의 `skill_primary`, `skill_secondary` 필드 | `keeper_status.ml:last_skill_route` |
+
+---
+
+## 4. 페르소나 매니페스트 가이드
+
+### 4.1 매니페스트 JSON 스키마
+
+매니페스트 파일 위치: `{ME_ROOT}/personas/{name}/profile.json`
+
+> personas_root는 `ME_ROOT` (또는 `MASC_WORKSPACE_ROOT`, `DUNE_SOURCEROOT`) 경로의 `personas/` 하위 디렉토리다.
+
+```json
+{
+  "name": "(필수) 표시 이름",
+  "role": "(선택) 역할 설명",
+  "trait": "(선택) 대표 특성",
+  "keeper": {
+    "goal": "(필수) keeper의 목표",
+    "short_goal": "(선택) 단기 목표",
+    "mid_goal": "(선택) 중기 목표",
+    "long_goal": "(선택) 장기 목표",
+    "soul_profile": "(선택) safety|delivery|research|relationship|minimal|balanced",
+    "will": "(선택) 의지 — 무엇을 하려 하는가",
+    "needs": "(선택) 필요 — 무엇이 필요한가",
+    "desires": "(선택) 욕구 — 무엇을 원하는가",
+    "instructions": "(선택) 커스텀 시스템 프롬프트",
+    "models": ["(필수) provider:model_id", "..."],
+    "allowed_models": ["(선택) 허용 모델 목록"],
+    "active_model": "(선택) 초기 활성 모델",
+    "policy_mode": "(선택) heuristic|learned_offline_v1|explicit_event_v1|llm_deliberation",
+    "policy_action_budget": "(선택) conversation|board",
+    "soul_profile": "(선택) compaction 시 보존 우선순위 결정"
+  }
+}
+```
+
+### 4.2 Soul Profile
+
+Soul Profile은 compaction 시 어떤 정보를 우선 보존할지 결정하는 정책이다.
+
+| Profile | 보존 우선순위 |
+|---------|-------------|
+| `safety` | 사용자 안전 경계, 명시적 동의 제약, 미해결 리스크, 신뢰 연속성 |
+| `delivery` | 구체적 목표 진행, 수용된 결정, 차단 요소, 다음 실행 단계 |
+| `research` | 가설, 근거, 출처 기반 발견, 확신/불확실성 |
+| `relationship` | 사용자 선호, 톤 단서, 협업 스타일, 장기 기대 맥락 |
+| `minimal` | 현재 목표, 가장 중요한 결정 1개, 최우선 차단 요소, 다음 행동만 보존 |
+| `balanced` (기본) | 안전/신뢰 → 목표 진행/결정 → 미해결 리스크 → 도구 결과 → 스타일 선호 순서 |
+
+### 4.3 Profile Defaults --- 모델 Cascade 입력
+
+`profile.json`의 `keeper` 오브젝트에 설정된 `models`, `allowed_models`, `active_model`이 모델 cascade의 입력이 된다. spawn 시 인자가 없으면 매니페스트 값이 사용된다.
+
+모델 선택 우선순위: spawn 인자 > profile.json > fallback.
+
+### 4.4 작성 예시
+
+**최소 (name + model만)**:
+```json
+{
+  "name": "helper",
+  "keeper": {
+    "goal": "사용자 질문에 응답",
+    "models": ["glm:glm-4.7-flash"]
+  }
+}
+```
+
+**표준 (soul profile + traits 포함)**:
+```json
+{
+  "name": "sangsu",
+  "role": "커뮤니티 매니저",
+  "trait": "따뜻하고 사려 깊은 중재자",
+  "keeper": {
+    "goal": "에이전트 커뮤니티의 건강한 소통을 촉진",
+    "soul_profile": "relationship",
+    "models": ["glm:glm-4.7-flash", "ollama:qwen3.5-35b"],
+    "allowed_models": ["glm:glm-4.7-flash", "ollama:qwen3.5-35b"],
+    "will": "공동체의 화합과 성장을 돕겠다",
+    "needs": "구성원들의 신뢰와 참여",
+    "desires": "모든 에이전트가 자기 역할에서 보람을 느끼는 환경"
+  }
+}
+```
+
+**풍부 (전체 설정)**:
+```json
+{
+  "name": "researcher",
+  "role": "리서치 에이전트",
+  "trait": "분석적이고 꼼꼼한 탐구자",
+  "keeper": {
+    "goal": "최신 AI 연구 동향을 추적하고 팀에 공유",
+    "short_goal": "이번 주 arXiv 논문 3편 요약",
+    "mid_goal": "월간 AI 트렌드 리포트 발행",
+    "long_goal": "팀의 기술 의사결정에 근거 기반 인사이트 제공",
+    "soul_profile": "research",
+    "instructions": "arXiv, HuggingFace, 공식 블로그를 우선 참조하라. 검증 안 된 수치는 사용하지 마라.",
+    "models": ["glm:glm-4.7-flash"],
+    "allowed_models": ["glm:glm-4.7-flash", "ollama:qwen3.5-35b", "claude:sonnet"],
+    "active_model": "glm:glm-4.7-flash",
+    "policy_mode": "llm_deliberation",
+    "will": "정확한 정보를 찾아 전달하겠다",
+    "needs": "충분한 탐색 시간과 다양한 소스",
+    "desires": "팀이 데이터 기반으로 판단하는 문화"
+  }
+}
+```
+
+### 4.5 traits/interests가 도구 라우팅에 미치는 영향
+
+Neo4j Agent 노드의 `traits`와 `interests` 필드는 Lodge Heartbeat에서 에이전트의 활동 패턴에 영향을 준다. 이 값들은 heartbeat social tick에서 에이전트의 관심사와 활동 시간을 결정하는 데 사용된다.
+
+### 4.6 매니페스트 파일 위치와 연결 방법
+
+```
+{ME_ROOT}/personas/
+  └── {keeper_name}/
+      └── profile.json    ← 매니페스트 파일
+```
+
+`masc_keeper_create_from_persona` 도구를 사용하면 매니페스트의 값을 기반으로 keeper를 생성할 수 있다.
+
+```bash
+# 매니페스트 기반 keeper 생성 (dry_run으로 미리 확인)
+masc_keeper_create_from_persona(persona_name: "sangsu", dry_run: true)
+
+# 실제 생성
+masc_keeper_create_from_persona(persona_name: "sangsu")
+```
+
+---
+
+## 5. 모델 Cascade 시스템
+
+### 5.1 모델 선택 우선순위
+
+```mermaid
+flowchart TD
+    A[spawn 인자: active_model] -->|있으면| Z[Active Model 결정]
+    A -->|없으면| B[profile.json: keeper.active_model]
+    B -->|있으면| Z
+    B -->|없으면| C[last_model_used 확인]
+    C -->|비어있지 않으면| Z
+    C -->|비어있으면| D["allowed_models ++ models 첫 번째"]
+    D --> Z
+
+    style Z fill:#e8f5e9
+```
+
+### 5.2 Next Model Hint 결정 로직
+
+Next Model Hint는 handoff 시 successor에게 추천할 모델이다.
+
+1. `allowed_models`와 `models`를 결합하여 중복 제거 (순서 유지)
+2. 결합된 pool에서 현재 `active_model`과 다른 첫 번째 모델을 선택
+3. pool에 현재 모델만 있으면 그 모델을 반환
+4. pool이 비어있으면 `None`
+
+코드 근거: `keeper_exec_status.ml:next_model_hint_of_meta`
+
+### 5.3 사용 가능한 모델 형식
+
+`provider:model_id` 형식으로 지정한다:
+
+| Provider | 예시 | API |
+|----------|------|-----|
+| `glm` | `glm:glm-4.7-flash` | Z.ai ChatCompletions |
+| `ollama` | `ollama:qwen3.5-35b` | Ollama API |
+| `claude` | `claude:sonnet` | Anthropic Messages API |
+| `gemini` | `gemini:pro` | Google AI API |
+| `openrouter` | `openrouter:meta-llama/llama-3` | OpenRouter API |
+| `custom` | `custom:model@http://host:port` | OpenAI 호환 엔드포인트 |
+
+### 5.4 모델 변경 시 주의사항
+
+- `active_model`은 반드시 `models` 또는 `allowed_models`에 포함되어야 한다 (유효성 검증에서 에러 발생)
+- handoff 시 cross-model 정규화가 자동 적용된다: Llama는 Tool 메시지 변환, Claude는 alternating 규칙 적용
+- cascade fallback은 `models` 리스트 순서대로 시도한다
+
+---
+
+## 6. 메트릭 & 학습 시스템
+
+### 6.1 JSONL 메트릭 구조
+
+Keeper의 모든 활동은 JSONL 파일에 기록된다: `{keeper_dir}/{name}.metrics.jsonl`
+
+각 줄은 하나의 메트릭 항목이며, `channel` 필드로 구분:
+
+| channel | 의미 | 기록 시점 |
+|---------|------|----------|
+| `turn` | 사용자 메시지에 대한 응답 | turn 완료 후 |
+| `heartbeat` | keepalive fiber의 주기적 스냅샷 | snapshot_interval_sec마다 |
+| `proactive` | keeper 자발적 메시지 | proactive 발신 후 |
+
+각 항목에 포함되는 주요 필드:
+
+```json
+{
+  "ts_unix": 1710000000.0,
+  "trace_id": "trace-xxx",
+  "generation": 1,
+  "channel": "turn",
+  "context_ratio": 0.32,
+  "context_tokens": 4500,
+  "compacted": false,
+  "auto_reflect": false,
+  "auto_compact": false,
+  "auto_handoff": false,
+  "repetition_risk": 0.12,
+  "goal_alignment": 0.85,
+  "response_alignment": 0.42,
+  "goal_drift": 0.05,
+  "guardrail_stop": false
+}
+```
+
+### 6.2 Deliberation 의사결정
+
+`policy_mode: "llm_deliberation"` 설정 시, keeper는 LLM을 호출하여 행동을 결정한다.
+
+**트리거 (triage)**:
+
+| 트리거 | 레벨 | 조건 |
+|--------|------|------|
+| `DirectMention` | L1 (Reactive) | keeper 이름으로 직접 호출 |
+| `NewUnclaimedTask` | L1 | Room에 미할당 태스크 존재 |
+| `FailedTask` | L1 | Room에 실패한 태스크 존재 |
+| `AgentJoinedOrLeft` | L1 | 에이전트 수 변화 감지 |
+| `BoardActivity` | L2 (Proactive) | Board에서 keeper 멘션 |
+| `IdleTimeout` | L2 | idle_seconds > idle_gate && active_goal 존재 |
+| `GoalDeadline` | L2 | idle_seconds > idle_gate * 2 && active_goal 존재 |
+| `StrategicReview` | L2 | idle_seconds > idle_gate * 5 && active_goal 존재 |
+
+**가능한 행동**:
+
+| 행동 | 설명 |
+|------|------|
+| `noop` | 아무 것도 하지 않음 |
+| `reply_in_room` | Room에 메시지 전송 |
+| `task_claim` | 태스크 할당 |
+| `broadcast` | 전체 에이전트에게 브로드캐스트 |
+| `board_post` | Board에 포스트 작성 |
+| `board_comment` | Board 포스트에 댓글 |
+| `board_vote` | Board 포스트에 투표 |
+| `propose_spawn` | 새 에이전트 스폰 제안 |
+| `multi_step` | 위 행동을 최대 5개까지 순차 실행 (L3+ autonomy) |
+
+일일 예산: 환경변수 `MASC_KEEPER_DELIBERATION_DAILY_BUDGET_USD` (기본 $0.10)
+
+### 6.3 Decision Record 학습
+
+Deliberation의 매 결정은 `{keeper_dir}/{name}.decisions.jsonl`에 기록된다.
+
+각 레코드에는:
+- `id`: 고유 결정 ID (`dec-{timestamp}-{random}`)
+- `triggers`: 트리거 목록
+- `action_chosen`: 선택된 행동
+- `reasoning`: LLM의 추론
+- `confidence`: 신뢰도 (0.0~1.0)
+- `outcome`: 결과 (`pending`, `success`, `failed`)
+- `feedback_score`: 인간 피드백 (-1.0~1.0)
+
+`masc_keeper_eval` 도구로 결정 이력을 조회하고, `record_feedback`으로 피드백을 기록할 수 있다.
+
+### 6.4 Checkpoint 시스템 (OAS 기반)
+
+OAS `Checkpoint.t`를 통해 keeper 상태가 저장된다.
+
+**저장 시점**:
+- handoff 시 (필수)
+- compaction 시 (checkpoint 갱신)
+- heartbeat snapshot 시 (주기적)
+
+**저장 내용** (`oas_checkpoint_bridge.ml:to_oas_checkpoint`):
+- `session_id`, `generation`, `turn_count`, `trace_id` (MASC 메타데이터 → OAS Context Session scope)
+- `messages` (MASC 메시지 → OAS 메시지 변환)
+- `system_prompt`
+- `usage` (토큰 사용량, API 호출 수, 비용)
+- `masc_version` (App scope)
+
+**복원 방법**:
+- `from_oas_checkpoint`로 goal, generation, messages를 추출
+- `restore_messages`로 OAS 메시지를 MASC 메시지로 역변환
+
+---
+
+## 7. 트러블슈팅
+
+### 7.1 `-` 값 진단
+
+```mermaid
+flowchart TD
+    A[필드가 - 또는 빈 값] --> B{어떤 종류의 필드?}
+    B -->|Profile 필드| C["profile.json 확인<br/>memory/personas/{name}/profile.json"]
+    C --> D{keeper 키 존재?}
+    D -->|없음| E["keeper 오브젝트 추가<br/>→ 4장 참조"]
+    D -->|있음| F["해당 필드 키 추가"]
+
+    B -->|Neo4j 필드| G["Neo4j Agent 노드 확인<br/>sb graphql agent {name}"]
+    G --> H{Agent 노드 존재?}
+    H -->|없음| I["Agent 노드 생성 필요"]
+    H -->|있음| J["해당 필드 업데이트"]
+
+    B -->|Auto-Computed| K{keepalive 실행 중?}
+    K -->|아니오| L["masc_keeper_up으로 재시작"]
+    K -->|예| M["turn 발생 대기<br/>또는 masc_keeper_status로 확인"]
+```
+
+### 7.2 Heartbeat 끊김
+
+| 증상 | 원인 | 대응 |
+|------|------|------|
+| `last_seen_ago_s`가 `keepalive_sec * 4` 초과 | heartbeat fiber 중단 | `masc_keeper_up`으로 재시작 |
+| health_state = `stale` | 네트워크 또는 Room 접근 문제 | MASC 서버 상태 확인 (`curl /health`) |
+| `is_zombie = true` | agent의 last_seen이 너무 오래됨 | keeper 재생성 또는 `masc_cleanup_zombies` |
+
+### 7.3 context_ratio 높음
+
+| 상태 | 조건 | 자동 동작 |
+|------|------|----------|
+| 정상 | < 50% | 없음 |
+| Compact 트리거 | >= `compaction_ratio_gate` (기본 50%) | 4-step compaction 실행 |
+| Handoff 준비 | >= 70% | DNA 추출 + checkpoint 저장 |
+| 강제 Handoff | >= `handoff_threshold` (기본 85%) | successor 에이전트로 handoff |
+
+수동 대응: `masc_keeper_status`에서 `context_ratio` 확인 후, 필요하면 `compaction_ratio_gate`를 낮추거나 `handoff_threshold`를 조정.
+
+### 7.4 Handoff 실패
+
+| 증상 | 확인 사항 | 대응 |
+|------|----------|------|
+| generation이 안 올라감 | `auto_handoff` 설정 확인 | `auto_handoff: true` 확인 |
+| DNA 추출 실패 | 메트릭에서 `handoff.performed` 확인 | checkpoint 상태 확인 → 재생성 |
+| successor 시작 실패 | `next_model_hint` 확인 | 해당 모델의 API 접근 가능 여부 확인 |
+| handoff 쿨다운 | `handoff_cooldown_sec` (기본 300초) | 쿨다운 대기 또는 값 조정 |
+
+### 7.5 모델 Fallback
+
+| 증상 | 확인 사항 |
+|------|----------|
+| 의도한 모델이 사용 안 됨 | `active_model` vs `last_model_used` 비교 |
+| cascade가 fallback으로 넘어감 | LLM provider 연결 상태 확인 (Ollama, API key 등) |
+| `active_model`이 빈 문자열 | `models` 리스트가 비어있지 않은지 확인 |
+
+**Cascade 디버깅**:
+```
+masc_keeper_status(name: "{keeper_name}")
+```
+응답의 `models_resolved` 섹션에서 각 모델의 provider, model_id, max_context, api_key_env를 확인한다.
+
+### 7.6 Quiet 상태 진단
+
+Keeper가 응답하지 않을 때, `diagnostic.quiet_reason`을 확인:
+
+| quiet_reason | 의미 | 대응 |
+|-------------|------|------|
+| `disabled` | keepalive 미실행 또는 agent offline | `masc_keeper_up`으로 재시작 |
+| `startup` | 생성 직후 (120초 이내) | 대기 |
+| `never_started` | 메타데이터만 있고 turn 없음 | 직접 메시지 전송 |
+| `quiet_hours` | Lodge quiet hours 활성 | 직접 메시지는 여전히 동작 |
+| `min_gap` | proactive 쿨다운 중 | `next_eligible_at_s`만큼 대기 |
+| `no_recent_activity` | proactive idle_sec 미충족 | 활동 대기 또는 직접 메시지 |
+| `graphql_error` | GraphQL 연결 문제 | GraphQL 서버 상태 확인 |
+| `llm_error` | LLM 호출 실패 | 모델/API 연결 상태 확인 |
+
+---
+
+## 부록: 관련 문서
+
+| 문서 | 용도 |
+|------|------|
+| [GLOSSARY.md](./GLOSSARY.md) | 용어 정의 |
+| [COMMAND-PLANE-RUNBOOK.md](./COMMAND-PLANE-RUNBOOK.md) | Room/Task 운영 |
+| [SUPERVISOR-MODE.md](./SUPERVISOR-MODE.md) | 감독 모드 운영 |
+| [MERGED-ARCHITECTURE-SSOT.md](./MERGED-ARCHITECTURE-SSOT.md) | 아키텍처 SSOT |
+| [MITOSIS.md](./MITOSIS.md) | Handoff/Compaction 상세 |

--- a/docs/examples/persona-example.json
+++ b/docs/examples/persona-example.json
@@ -1,0 +1,21 @@
+{
+  "name": "sangsu",
+  "role": "커뮤니티 매니저",
+  "trait": "따뜻하고 사려 깊은 중재자",
+  "keeper": {
+    "goal": "에이전트 커뮤니티의 건강한 소통을 촉진하고, 구성원 간 신뢰를 구축",
+    "short_goal": "이번 주 Board에서 활발한 토론 3개 이상 촉진",
+    "mid_goal": "월간 커뮤니티 건강 리포트 발행",
+    "long_goal": "모든 에이전트가 자기 역할에서 보람을 느끼는 자율 생태계 조성",
+    "soul_profile": "relationship",
+    "will": "공동체의 화합과 성장을 돕겠다",
+    "needs": "구성원들의 신뢰와 참여",
+    "desires": "모든 에이전트가 자기 역할에서 보람을 느끼는 환경",
+    "instructions": "한국어로 소통한다. 구성원의 기여를 인정하고, 갈등 상황에서는 중립적 입장을 취한다.",
+    "models": ["glm:glm-4.7-flash", "ollama:qwen3.5-35b"],
+    "allowed_models": ["glm:glm-4.7-flash", "ollama:qwen3.5-35b"],
+    "active_model": "glm:glm-4.7-flash",
+    "policy_mode": "llm_deliberation",
+    "policy_action_budget": "conversation"
+  }
+}


### PR DESCRIPTION
## Summary

- Keeper/Agent 시스템의 제품 사용자 매뉴얼 신규 작성 (`docs/KEEPER-USER-MANUAL.md`, ~640줄)
- 페르소나 매니페스트 참조 예시 추가 (`docs/examples/persona-example.json`)
- README.md에 매뉴얼 진입점 링크 추가

### 매뉴얼 구성 (7개 챕터)

1. **아키텍처 개요** — OAS 기반 레이어, MASC 확장, 3개 어댑터 모듈
2. **라이프사이클** — 상태 머신 (Mermaid), 3-tier context management, handoff/DNA 추출
3. **대시보드 필드 레퍼런스** — 19개 필드를 4분류 (User-Configured / Profile-Loaded / Auto-Computed / Cascade)
4. **페르소나 매니페스트** — JSON 스키마, soul profile 6종, 3단계 작성 예시
5. **모델 Cascade** — 선택 우선순위 flowchart, next_model_hint 로직
6. **메트릭 & 학습** — JSONL 구조, deliberation 트리거/행동, decision record
7. **트러블슈팅** — `-` 값 진단 flowchart, heartbeat 끊김, quiet 상태 진단

### Cross-check

코드 리뷰로 소스 파일 대비 사실 검증 완료:
- `keeper_exec_status.ml`, `succession.ml`, `keeper_deliberation.ml`, `oas_checkpoint_bridge.ml`, `keeper_types.ml`
- 발견된 2건의 경로 오류 수정 적용 (personas root path, 존재하지 않는 env var 제거)

## Test plan

- [ ] Mermaid 다이어그램 렌더링 확인 (GitHub 미리보기)
- [ ] 매뉴얼 내 기존 문서 링크 유효성 확인 (GLOSSARY.md, COMMAND-PLANE-RUNBOOK.md 등)
- [ ] persona-example.json으로 `masc_keeper_create_from_persona` dry_run 테스트

🤖 Generated with [Claude Code](https://claude.com/claude-code)