### PR TITLE
fix(dashboard): room-truth audit — emptiness, digest shape, freshness

### DIFF
--- a/dashboard/src/components/governance.ts
+++ b/dashboard/src/components/governance.ts
@@ -535,6 +535,20 @@ function ActivityRail() {
   `
 }
 
+function GovernanceFreshnessStrip() {
+  const data = governanceData.value
+  if (!data) return null
+  const itemCount = data.items?.length ?? 0
+  const activityCount = data.activity?.length ?? 0
+  return html`
+    <div class="monitor-meta" style="margin-top:4px;margin-bottom:8px">
+      <span>데이터 범위: 진행 중 ${itemCount}건</span>
+      <span>최근 활동: ${activityCount}건</span>
+      ${data.generated_at ? html`<span>생성 시각: ${data.generated_at}</span>` : null}
+    </div>
+  `
+}
+
 export function Governance() {
   useEffect(() => {
     void refreshGovernance()
@@ -542,6 +556,7 @@ export function Governance() {
 
   return html`
     <div class="section-grid">
+      <${GovernanceFreshnessStrip} />
       <${GovernanceSummaryStrip} />
       <${GovernanceToolbar} />
       <div class="governance-layout">

--- a/dashboard/src/components/social.ts
+++ b/dashboard/src/components/social.ts
@@ -226,7 +226,7 @@ export function Social() {
         <${GraphView} data=${data} />
         <div class="monitor-meta" style="margin-top:8px">
           <span>생성 시각: ${data.generated_at}</span>
-          <span>이벤트 윈도우: ${data.window.limit}</span>
+          <span>데이터 범위: 최근 ${data.window.limit}건 이벤트</span>
           ${data.window.room_id ? html`<span>room: ${data.window.room_id}</span>` : null}
         </div>
       <//>

--- a/dashboard/src/components/tools.ts
+++ b/dashboard/src/components/tools.ts
@@ -352,6 +352,12 @@ export function Tools() {
           : null}
         <${ToolMetrics} />
       <//>
+      ${data?.generated_at
+        ? html`<div class="monitor-meta" style="margin-top:8px">
+            <span>생성 시각: ${data.generated_at}</span>
+            <span>metrics 기준: 최근 1시간</span>
+          </div>`
+        : null}
     </div>
   `
 }

--- a/lib/server_dashboard_http.ml
+++ b/lib/server_dashboard_http.ml
@@ -2638,7 +2638,7 @@ let dashboard_execution_http_json ~state ~sw ~clock request =
     ~config:state.Mcp_server.room_config ~sw ~clock
     ~proc_mgr:state.Mcp_server.proc_mgr ()
 
-let dashboard_room_truth_focus_json ~initialized ~operator_digest_json ~top_queue =
+let dashboard_room_truth_focus_json ~initialized ~agent_count ~operator_digest_json ~top_queue =
   let recommendation_summary =
     json_assoc_field "recommendation_summary" operator_digest_json
   in
@@ -2770,22 +2770,29 @@ let dashboard_room_truth_focus_json ~initialized ~operator_digest_json ~top_queu
           match top_queue with
           | `Assoc _ as queue -> focus_of_queue queue
           | _ ->
+              let label, reason, source, provenance =
+                if not initialized then
+                  ( "초기 room truth",
+                    "방이 아직 초기화되지 않았습니다. 기본 room 상태부터 확인하세요.",
+                    "orchestra",
+                    "derived" )
+                else if agent_count = 0 then
+                  ( "에이전트가 없습니다. 활동이 시작되면 여기에 포커스가 나타납니다.",
+                    "No agents joined yet; room is idle.",
+                    "room",
+                    "fallback" )
+                else
+                  ( "지금은 방 전체가 비교적 안정적입니다",
+                    "Room-wide view is healthy enough; start from the command overview.",
+                    "room",
+                    "fallback" )
+              in
               `Assoc
                 [
-                  ( "label",
-                    `String
-                      (if initialized then
-                         "지금은 방 전체가 비교적 안정적입니다"
-                       else
-                         "초기 room truth") );
-                  ( "reason",
-                    `String
-                      (if initialized then
-                         "Room-wide view is healthy enough; start from the command overview."
-                       else
-                         "방이 아직 초기화되지 않았습니다. 기본 room 상태부터 확인하세요.") );
-                  ("source", `String (if initialized then "room" else "orchestra"));
-                  ("provenance", `String (if initialized then "fallback" else "derived"));
+                  ("label", `String label);
+                  ("reason", `String reason);
+                  ("source", `String source);
+                  ("provenance", `String provenance);
                   ("target_kind", `String "node");
                   ("target_id", `String "room:default");
                   ("suggested_tab", `String "command");
@@ -2925,9 +2932,11 @@ let dashboard_room_truth_http_json ~state ~sw ~clock request =
         ("provenance", `String "truth");
       ]
   in
+  let agent_count = json_int_field "agents" (json_assoc_field "counts" shell_json) ~default:0 in
   let focus_json =
     dashboard_room_truth_focus_json
       ~initialized:(Room.is_initialized config)
+      ~agent_count
       ~operator_digest_json ~top_queue
   in
   `Assoc

--- a/test/test_dashboard_room_truth.ml
+++ b/test/test_dashboard_room_truth.ml
@@ -74,6 +74,51 @@ let test_dashboard_room_truth_execution_fixture () =
           (json |> member "execution" |> member "top_queue" |> member "target_id" |> to_string);
       ))
 
+let test_dashboard_room_truth_empty_room_focus_label () =
+  let dir = test_dir () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir dir)
+    (fun () ->
+      let state = Lib.Mcp_server_eio.create_state ~test_mode:true ~base_path:dir () in
+      Eio_main.run @@ fun env ->
+      Eio.Switch.run (fun sw ->
+        let json =
+          Lib.Server_dashboard_http.dashboard_room_truth_http_json
+            ~state ~sw ~clock:(Eio.Stdenv.clock env)
+            (request "/api/v1/dashboard/room-truth")
+        in
+        let open Yojson.Safe.Util in
+        let focus_label = json |> member "focus" |> member "label" |> to_string in
+        check bool "empty room focus mentions no agents"
+          true
+          (String.length focus_label > 0
+           && focus_label <> "지금은 방 전체가 비교적 안정적입니다");
+      ))
+
+let test_operator_digest_shape_matches_room_truth () =
+  let dir = test_dir () in
+  Fun.protect
+    ~finally:(fun () -> cleanup_dir dir)
+    (fun () ->
+      let state = Lib.Mcp_server_eio.create_state ~test_mode:true ~base_path:dir () in
+      Eio_main.run @@ fun env ->
+      Eio.Switch.run (fun sw ->
+        let json =
+          Lib.Server_dashboard_http.dashboard_room_truth_http_json
+            ~state ~sw ~clock:(Eio.Stdenv.clock env)
+            (request "/api/v1/dashboard/room-truth")
+        in
+        let open Yojson.Safe.Util in
+        let operator = json |> member "operator" in
+        let expected_keys = ["health"; "attention_summary"; "recommendation_summary"; "pending_confirm_summary"; "provenance"] in
+        List.iter (fun key ->
+          let value = operator |> member key in
+          check bool (Printf.sprintf "operator.%s present" key)
+            true
+            (value <> `Null)
+        ) expected_keys;
+      ))
+
 let () =
   Alcotest.run "Dashboard Room Truth"
     [
@@ -81,5 +126,7 @@ let () =
         [
           test_case "empty room shape" `Quick test_dashboard_room_truth_empty_room;
           test_case "execution fixture surfaces top queue" `Quick test_dashboard_room_truth_execution_fixture;
+          test_case "empty room focus label reflects no agents" `Quick test_dashboard_room_truth_empty_room_focus_label;
+          test_case "operator digest shape matches room-truth" `Quick test_operator_digest_shape_matches_room_truth;
         ] );
     ]


### PR DESCRIPTION
## Summary

Dashboard room-truth 진정성 audit에서 발견한 3개 gap을 수정합니다.

- **Gap 1 (focus label emptiness)**: 에이전트 0명인 초기화된 room에서 "안정적" 대신 "에이전트가 없습니다" 표시
- **Gap 2 (digest shape test)**: derived shortcut과 원본 digest의 키 일치를 검증하는 regression 테스트 2개 추가
- **Gap 3 (data freshness)**: governance/tools/social 탭에 데이터 윈도우/신선도 라벨 추가

## Changed files

| 파일 | 변경 |
|------|------|
| `lib/server_dashboard_http.ml` | `~agent_count` 파라미터 추가, 3분기 focus label |
| `test/test_dashboard_room_truth.ml` | focus label + operator shape 테스트 2개 |
| `dashboard/src/components/governance.ts` | `GovernanceFreshnessStrip` 컴포넌트 |
| `dashboard/src/components/tools.ts` | metrics 시간 윈도우 라벨 |
| `dashboard/src/components/social.ts` | 이벤트 윈도우 라벨 개선 |

## Test plan

- [x] `dune build` 통과
- [x] `test_dashboard_room_truth.exe` 4/4 통과
- [ ] 빈 room → `/api/v1/dashboard/room-truth` → focus label "에이전트가 없습니다" 확인
- [ ] governance/tools/social 탭에서 데이터 윈도우 라벨 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)