### PR TITLE
fix(ci): remove stale dashboard asset contract check

### DIFF
--- a/scripts/check-pr-hygiene.sh
+++ b/scripts/check-pr-hygiene.sh
@@ -13,7 +13,6 @@ Usage: scripts/check-pr-hygiene.sh --base <git-ref> [--head <git-ref>] [--recent
 Checks:
   - fails on empty commits in the PR range
   - warns or fails on duplicate patch-ids already present in recent base history
-  - fails when dashboard source/config changes without refreshed assets/dashboard output
 EOF
 }
 
@@ -73,7 +72,6 @@ fi
 
 empty_failures=0
 duplicate_hits=0
-asset_contract_failures=0
 
 BASE_PATCH_FILE="$(mktemp)"
 SEEN_PATCH_FILE="$(mktemp)"
@@ -129,32 +127,8 @@ for commit in "${RANGE_COMMITS[@]}"; do
   fi
 done
 
-dashboard_source_changed=0
-dashboard_assets_changed=0
-while IFS= read -r path; do
-  [[ -z "$path" ]] && continue
-  case "$path" in
-    dashboard/src/*|dashboard/vite.config.ts|dashboard/package.json|dashboard/tsconfig.json)
-      dashboard_source_changed=1
-      ;;
-    assets/dashboard/*)
-      dashboard_assets_changed=1
-      ;;
-  esac
-done < <(git diff --name-only "$RANGE")
-
-if [[ "$dashboard_source_changed" -eq 1 && "$dashboard_assets_changed" -eq 0 ]]; then
-  echo "::error title=Dashboard assets missing::dashboard source or Vite config changed but assets/dashboard was not updated"
-  asset_contract_failures=1
-fi
-
 if [[ "$empty_failures" -ne 0 ]]; then
   echo "PR hygiene check failed: empty commits detected." >&2
-  exit 1
-fi
-
-if [[ "$asset_contract_failures" -ne 0 ]]; then
-  echo "PR hygiene check failed: dashboard assets are out of sync." >&2
   exit 1
 fi
 


### PR DESCRIPTION
## Summary

- `#1096`에서 `assets/dashboard/`를 `.gitignore`로 전환 (런타임 빌드)
- `check-pr-hygiene.sh`의 dashboard asset contract 검사가 이 변경과 불일치하여 dashboard source 변경 PR마다 무조건 실패
- 해당 검사 블록 및 관련 변수 제거 (26줄 삭제)

## Test plan

- [x] `bash -n` 문법 검증 통과
- [ ] 이 PR 자체의 PR Hygiene job이 pass하는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)