### PR TITLE
refactor(keeper): metrics rotation + architecture complexity analysis

### DIFF
--- a/docs/ARCHITECTURE-COMPLEXITY-ANALYSIS.md
+++ b/docs/ARCHITECTURE-COMPLEXITY-ANALYSIS.md
@@ -1,0 +1,198 @@
+# MASC-MCP Architecture Complexity Analysis
+
+Date: 2026-03-16
+Version: 2.93.0
+
+## Executive Summary
+
+masc-mcp grew from a multi-agent coordination MCP server into a 34K-line system with
+85 tool modules, 72 dispatch entries, and 371 MCP tools. A typical MCP server exposes
+5-15 tools. This analysis identifies what is essential, what is experimental residue,
+and proposes a phased reduction plan.
+
+## Verified Metrics
+
+| Metric | Value | Typical MCP server |
+|--------|-------|--------------------|
+| Dispatch entries | 72 | 5-15 |
+| tool_*.ml files | 85 | 3-10 |
+| Total tool lines | 34,667 | 1-3K |
+| MCP tool schemas | ~371 | 5-15 |
+| .masc/ state dir | 62MB (before cleanup) | <1MB |
+| dune modules | 579 | 20-50 |
+| Environment vars | 50+ | 5-10 |
+
+## Module Tier Classification
+
+### Tier 1: Core (5 modules, ~1.5K lines)
+
+MASC's minimum viable feature set. join -> claim -> work -> done.
+
+| Module | Lines | Role |
+|--------|-------|------|
+| tool_agent | 290 | Agent registration/profiles |
+| tool_room | 291 | Room join/leave/broadcast |
+| tool_task | 418 | Task CRUD + claim/done |
+| tool_heartbeat | ~119 | Liveness tracking |
+| tool_dispatch | ~200 | Generic fallback router |
+
+### Tier 2: Production (12 modules, ~8K lines)
+
+Modules that deliver real value in daily operation.
+
+| Module | Lines | Role | Necessity |
+|--------|-------|------|-----------|
+| tool_operator | 856 | dispatch/assign/rebalance | High |
+| tool_command_plane* | ~960 | command-plane truth layer | High |
+| tool_keeper | 624 | persistent agent runtime | High |
+| tool_perpetual | 643 | autonomous agent loops | Medium |
+| tool_plan | 186 | planning context | High |
+| tool_worktree | 40 | git isolation | High |
+| tool_board/misc | ~770 | bulletin board | Medium |
+| tool_auth | 122 | token auth | Medium |
+| tool_cost | ~100 | cost tracking | Low |
+| tool_cache | ~100 | cache management | Low |
+| tool_goals | 643 | goal management | Medium |
+| tool_vote | ~200 | voting/consensus | Low |
+
+### Tier 3: Extensions (12 modules, ~8K lines)
+
+Useful but not core to coordination.
+
+| Module | Lines | Role | Status |
+|--------|-------|------|--------|
+| tool_team_session | **4412** | Team session spawning | Active, too large |
+| tool_mdal | 1092 | Metric-Driven Agent Loop | Active |
+| tool_mitosis | 1722 | Context split/succession | OFF by default |
+| tool_gardener | ~200 | Ecosystem management | OFF by default |
+| tool_llama | 1052 | llama.cpp runtime mgmt | Active |
+| tool_voice | ~200 | TTS/voice | OFF by default |
+| tool_portal | ~200 | 1:1 secret messaging | Active |
+| tool_encryption | ~100 | AES-256 | OFF by default |
+| tool_rate_limit | ~100 | Rate limiting | Active |
+| tool_social | ~200 | Lodge social | Active |
+| tool_notifications | ~100 | Notifications | Active |
+| tool_audit | ~100 | Audit logging | Active |
+
+### Tier 4: Experimental/Game (18 modules, ~11K lines, 32% of total)
+
+Not related to core coordination. Candidates for separation or removal.
+
+| Module | Lines | Role | Verdict |
+|--------|-------|------|---------|
+| tool_trpg | **1934** | TRPG simulation | Separate package |
+| tool_protocol_game_view | **1674** | Protocol game view | Separate package |
+| tool_risc | **1070** | Role sampling campaigns | Experimental residue |
+| tool_autoresearch | **889** | Auto research loop | Experimental residue |
+| tool_council | **950** | Consensus protocol | Usage unclear |
+| tool_experiment | **898** | Sandbox | Experimental residue |
+| tool_walph | ~300 | Walph loop | Experimental |
+| tool_code | ~200 | Code read/search | Utility |
+| tool_tempo | ~200 | Tempo/rhythm | Experimental |
+| tool_relay | ~200 | Relay | Experimental |
+| tool_handover | ~200 | Handover | Experimental |
+| tool_a2a | ~200 | Agent-to-Agent | Experimental |
+| tool_hat | 39 | Role hat | Minimal |
+| tool_agent_timeline | ~200 | Agent timeline | Utility |
+| tool_library | ~200 | Library | Utility |
+| tool_control | ~200 | Control | Utility |
+| tool_suspend | ~200 | Suspend | Utility |
+| tool_verification | ~200 | Verification | Utility |
+
+## Guardian / Sentinel / Gardener Distinction
+
+These three systems operate at different layers and must not be merged.
+
+| System | Role | Decision method | Default |
+|--------|------|-----------------|---------|
+| **Guardian** | Zombie cleanup + GC (infra loop) | Deterministic (60s/7d threshold) | OFF |
+| **Sentinel** | Standing guard (board patrol, task hygiene) | LLM + deterministic hybrid | ON |
+| **Gardener** | Agent population management (spawn/retire) | LLM + budget/circuit | OFF |
+
+Guardian is embedded in Sentinel (guardian.ml:278, sentinel.ml:512).
+`masc_loops_owner` ref prevents concurrent execution.
+
+## Perpetual Keepers Problem
+
+### Before cleanup (Phase 1 complete)
+
+| Path | Size before | Size after | Action |
+|------|------------|------------|--------|
+| perpetual-keepers/*.metrics.jsonl | 25MB | 0 (deleted) | Stale idle heartbeat logs |
+| perpetual/trace-17716*,17724* | 1.2MB | 0 (deleted) | Ended experiment traces |
+| **Total .masc/** | **63MB** | **36MB** | **27MB freed** |
+
+### Root cause
+
+- No retention/rotation on metrics files -> unbounded growth (~2MB/day)
+- dm-keeper: goal_drift 97%, goal_alignment 3%, tokens=0 (idle ticking)
+- sangsu: goal_drift 100%, goal_alignment 0% (completely idle)
+- No downstream consumer of these metrics
+
+### Fix applied
+
+- Size-based rotation added to `append_jsonl_line` (keeper_types.ml)
+- Config: `MASC_KEEPER_METRICS_MAX_BYTES` (default 10MB), `MASC_KEEPER_METRICS_MAX_ROTATED` (default 1)
+- At threshold: current -> .1, .1 -> .2, etc.
+
+## tool_team_session.ml Split Plan (4412 lines)
+
+Recommended 4-module split:
+
+| New module | Lines | Content |
+|-----------|-------|---------|
+| tool_team_session_types.ml | ~90 | Type definitions (leaf) |
+| tool_team_session_parse.ml | ~700 | JSON parsers + OAS converters (pure) |
+| tool_team_session_spawn.ml | ~1050 | Risk routing + spawn logic |
+| tool_team_session_handlers.ml | ~1570 | Request handlers + orchestration |
+| tool_team_session.ml | ~670 | Dispatcher + schema definitions |
+
+Dependency graph (no cycles):
+```
+types (leaf) <- parse <- spawn <- handlers <- tool_team_session (entry)
+```
+
+## Complexity Root Causes
+
+1. **Features accumulate, never removed** — feature flags OFF = "done"
+2. **Experiments land in lib/ directly** — no plugin/package boundary
+3. **TRPG/games cohabitate with coordination** — unrelated concerns in one binary
+4. **No metrics retention** — logs grow without bound (fixed in this PR)
+
+## Phased Reduction Plan
+
+### Phase 1: Immediate (this PR)
+
+- [x] Delete stale .masc/ data (27MB freed)
+- [x] Add metrics rotation to append_jsonl_line
+- [ ] Architecture analysis document (this file)
+
+### Phase 2: Separation (separate PRs)
+
+- [ ] TRPG + protocol_game_view -> `masc-games` library (3600+ lines)
+- [ ] risc + autoresearch + council + experiment -> `masc-experiments` (3800+ lines)
+- [ ] dune optional library separation
+
+### Phase 3: Structural improvements (separate PRs)
+
+- [ ] tool_team_session split (4412 lines -> 5 files)
+- [ ] Mode/profile system: core (5) / standard (17) / full (72) dispatchers
+- [ ] Environment variables -> config file consolidation
+
+## TRPG as Agent Play (Design Note)
+
+TRPG is not "waste" — it represents non-deterministic agent activity.
+
+```
+Agent life = Work (tasks) + Social (board) + Play (TRPG)
+```
+
+Current problems:
+- dm-keeper runs always-on with zero output
+- No participation mechanism (who joins when?)
+- TRPG sessions not linked to MASC tasks
+
+Proposed changes:
+- dm-keeper -> on-demand (start when game needed)
+- Agent idle time + interests -> participation probability (Thompson sampling)
+- TRPG experience feeds back into agent interests/traits

--- a/lib/env_config_keeper.ml
+++ b/lib/env_config_keeper.ml
@@ -127,6 +127,18 @@ module KeeperBootstrap = struct
     get_int ~default:10000 "MASC_KEEPER_BOOTSTRAP_MAX_ACTIVE_KEEPERS"
 end
 
+(** {1 Keeper Metrics Rotation Configuration} *)
+
+module KeeperMetrics = struct
+  (** Maximum metrics file size in bytes before rotation (default: 10MB) *)
+  let max_file_bytes =
+    get_int ~default:10_485_760 "MASC_KEEPER_METRICS_MAX_BYTES"
+
+  (** Number of rotated files to keep (default: 1, i.e. .1 only) *)
+  let max_rotated_files =
+    get_int ~default:1 "MASC_KEEPER_METRICS_MAX_ROTATED"
+end
+
 (** {1 Keeper Interesting Alert Configuration} *)
 
 module KeeperAlert = struct

--- a/lib/keeper_types.ml
+++ b/lib/keeper_types.ml
@@ -1332,7 +1332,29 @@ let keeper_alert_retry_path config =
 let keeper_alert_deadletter_path config =
   Filename.concat (keeper_dir config) "_alerts.deadletter.jsonl"
 
+(** Rotate [path] if it exceeds the configured size threshold.
+    Keeps at most [max_rotated] numbered backups (.1, .2, ...). *)
+let maybe_rotate_file path =
+  let max_bytes = Env_config.KeeperMetrics.max_file_bytes in
+  let max_rotated = Env_config.KeeperMetrics.max_rotated_files in
+  if max_bytes <= 0 then ()
+  else
+    match (try Some (Unix.stat path) with Unix.Unix_error _ -> None) with
+    | None -> ()
+    | Some st ->
+        if st.Unix.st_size >= max_bytes then begin
+          (* Shift existing rotated files: .2 <- .1, .1 <- current *)
+          for i = max_rotated downto 2 do
+            let src = Printf.sprintf "%s.%d" path (i - 1) in
+            let dst = Printf.sprintf "%s.%d" path i in
+            (try Sys.rename src dst with Sys_error _ -> ())
+          done;
+          let rotated = Printf.sprintf "%s.1" path in
+          (try Sys.rename path rotated with Sys_error _ -> ())
+        end
+
 let append_jsonl_line path (json : Yojson.Safe.t) =
+  maybe_rotate_file path;
   let line = utf8_repair_string (Yojson.Safe.to_string json) ^ "\n" in
   let fd =
     Unix.openfile path [Unix.O_WRONLY; Unix.O_CREAT; Unix.O_APPEND] 0o644

--- a/test/dune
+++ b/test/dune
@@ -26,6 +26,7 @@
         test_swarm_checkpoint test_swarm_goal_loop test_mdal_swarm
         test_keeper_memory
         test_keeper_deliberation
+        test_metrics_rotation
         test_tool_tier)
  (modules test_room test_types test_checkpoint test_auth test_http_negotiation
           test_sse test_encryption test_backend test_cancellation test_graphql_api
@@ -39,6 +40,7 @@
           test_swarm_checkpoint test_swarm_goal_loop test_mdal_swarm
           test_keeper_memory
           test_keeper_deliberation
+          test_metrics_rotation
           test_tool_tier)
  (libraries masc_mcp alcotest str yojson mirage-crypto
             mirage-crypto-rng mirage-crypto-rng.unix cohttp cstruct unix))

--- a/test/test_metrics_rotation.ml
+++ b/test/test_metrics_rotation.ml
@@ -1,0 +1,91 @@
+(** Test suite for metrics file rotation in keeper_types.ml *)
+open Alcotest
+
+module Keeper_types = Masc_mcp.Keeper_types
+
+let tmpdir () =
+  let dir = Filename.concat (Filename.get_temp_dir_name ())
+    (Printf.sprintf "masc-rotation-test-%d" (Random.int 1_000_000)) in
+  Unix.mkdir dir 0o755;
+  dir
+
+let cleanup dir =
+  let entries = Sys.readdir dir in
+  Array.iter (fun f -> Sys.remove (Filename.concat dir f)) entries;
+  Unix.rmdir dir
+
+let write_bytes path n =
+  let fd = Unix.openfile path [Unix.O_WRONLY; Unix.O_CREAT; Unix.O_TRUNC] 0o644 in
+  let buf = Bytes.make n 'x' in
+  Fun.protect ~finally:(fun () -> Unix.close fd) (fun () ->
+    ignore (Unix.write fd buf 0 n))
+
+let file_size path =
+  try (Unix.stat path).Unix.st_size with Unix.Unix_error _ -> -1
+
+let test_no_rotation_under_threshold () =
+  let dir = tmpdir () in
+  Fun.protect ~finally:(fun () -> cleanup dir) (fun () ->
+    let path = Filename.concat dir "test.metrics.jsonl" in
+    write_bytes path 100;
+    Keeper_types.maybe_rotate_file path;
+    check bool "original exists" true (Sys.file_exists path);
+    check bool "no .1 file" false (Sys.file_exists (path ^ ".1")))
+
+let test_rotation_at_threshold () =
+  let dir = tmpdir () in
+  Fun.protect ~finally:(fun () -> cleanup dir) (fun () ->
+    let path = Filename.concat dir "test.metrics.jsonl" in
+    (* Write just at the default 10MB threshold *)
+    write_bytes path 10_485_760;
+    Keeper_types.maybe_rotate_file path;
+    check bool "original removed (renamed)" false (Sys.file_exists path);
+    check bool ".1 exists" true (Sys.file_exists (path ^ ".1"));
+    check int ".1 has original size" 10_485_760 (file_size (path ^ ".1")))
+
+let test_rotation_shifts_existing () =
+  let dir = tmpdir () in
+  Fun.protect ~finally:(fun () -> cleanup dir) (fun () ->
+    let path = Filename.concat dir "test.metrics.jsonl" in
+    (* Create a .1 file first *)
+    write_bytes (path ^ ".1") 50;
+    (* Write large current file *)
+    write_bytes path 10_485_760;
+    Keeper_types.maybe_rotate_file path;
+    check bool ".1 is the new rotation" true (Sys.file_exists (path ^ ".1"));
+    check int ".1 is the big file" 10_485_760 (file_size (path ^ ".1")))
+
+let test_nonexistent_file () =
+  let dir = tmpdir () in
+  Fun.protect ~finally:(fun () -> cleanup dir) (fun () ->
+    let path = Filename.concat dir "nonexistent.jsonl" in
+    (* Should not raise *)
+    Keeper_types.maybe_rotate_file path;
+    check bool "no file created" false (Sys.file_exists path))
+
+let test_append_with_rotation () =
+  let dir = tmpdir () in
+  Fun.protect ~finally:(fun () -> cleanup dir) (fun () ->
+    let path = Filename.concat dir "test.metrics.jsonl" in
+    (* Write exactly at threshold so rotation triggers on append *)
+    write_bytes path 10_485_760;
+    (* Append should trigger rotation then write to fresh file *)
+    Keeper_types.append_jsonl_line path (`Assoc [("test", `Bool true)]);
+    check bool "new current file exists" true (Sys.file_exists path);
+    check bool ".1 (rotated) exists" true (Sys.file_exists (path ^ ".1"));
+    (* New file should be small (just the appended line) *)
+    let new_size = file_size path in
+    check bool "new file is small" true (new_size < 1000);
+    (* Rotated file should have original size *)
+    check int ".1 has original size" 10_485_760 (file_size (path ^ ".1")))
+
+let () =
+  run "Keeper metrics rotation" [
+    "rotation", [
+      test_case "no rotation under threshold" `Quick test_no_rotation_under_threshold;
+      test_case "rotation at threshold" `Quick test_rotation_at_threshold;
+      test_case "rotation shifts existing backups" `Quick test_rotation_shifts_existing;
+      test_case "nonexistent file safe" `Quick test_nonexistent_file;
+      test_case "append triggers rotation" `Quick test_append_with_rotation;
+    ];
+  ]


### PR DESCRIPTION
## Summary
- **Metrics rotation** 추가: `append_jsonl_line`에 size-based log rotation (default 10MB, configurable via `MASC_KEEPER_METRICS_MAX_BYTES`)
- **Stale data cleanup**: `.masc/` 63MB → 36MB (27MB freed) — idle keeper metrics + terminated perpetual traces 삭제
- **Architecture analysis**: 34K줄, 72 dispatcher, 371 MCP tool의 4-Tier 분류 및 단계별 축소 계획 문서

### 변경 파일
| File | Change |
|------|--------|
| `lib/env_config_keeper.ml` | `KeeperMetrics` config module 추가 |
| `lib/keeper_types.ml` | `maybe_rotate_file` + `append_jsonl_line` rotation 통합 |
| `test/test_metrics_rotation.ml` | 5개 rotation 테스트 (threshold, shift, append trigger) |
| `test/dune` | 테스트 등록 |
| `docs/ARCHITECTURE-COMPLEXITY-ANALYSIS.md` | 아키텍처 복잡도 분석 문서 |

### 검증
- Rotation 테스트 5/5 PASS
- Keeper memory 테스트 7/7 PASS (regression 없음)
- `dune build` clean compile

### Known: `test_tool_team_session` Alcotest 내부 에러
main에서도 동일 발생 — `.041.output` 디렉토리 생성 실패. 이 PR과 무관.

## Test plan
- [x] `test_metrics_rotation.exe` 5/5 pass
- [x] `test_keeper_memory.exe` 7/7 pass (no regression)
- [x] `dune build` clean
- [ ] CI checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)