### PR TITLE
fix(tools): harden tool exposure pipeline across MCP profiles

### DIFF
--- a/lib/agent_tool_surfaces.ml
+++ b/lib/agent_tool_surfaces.ml
@@ -66,9 +66,8 @@ let spawned_agent_public_tool_names : string list =
     "masc_tool_help";
     "masc_tool_admin_snapshot";
     "masc_keeper_tool_catalog";
-    "masc_tool_list";
-    "masc_tool_grant";
-    "masc_tool_revoke";
+    (* masc_tool_list, masc_tool_grant, masc_tool_revoke removed:
+       no matching schema found (dead entries) *)
     "masc_portal_open";
     "masc_portal_send";
     "masc_portal_status";
@@ -88,19 +87,17 @@ let spawned_agent_public_tool_names : string list =
     "masc_a2a_delegate";
     "masc_a2a_subscribe";
     "masc_poll_events";
-    "masc_vote_create";
-    "masc_vote_cast";
-    "masc_vote_status";
+    (* masc_vote_create, masc_vote_cast, masc_vote_status removed:
+       hidden in Tool_catalog (prefer decision/governance V2 tools) *)
     "masc_run_init";
     "masc_run_log";
     "masc_run_deliverable";
     "masc_run_get";
     "masc_spawn";
     "masc_heartbeat_list";
-    "masc_trpg_dice_roll";
-    "masc_trpg_turn_advance";
-    "masc_trpg_stream";
-    "masc_trpg_round_run";
+    (* masc_trpg_dice_roll, masc_trpg_turn_advance, masc_trpg_stream,
+       masc_trpg_round_run removed: legacy aliases deprecated in
+       Tool_protocol_game_view; use canonical trpg.* names instead *)
   ]
 
 let spawned_agent_prefixed_tools : string list =

--- a/lib/mcp_server_eio.ml
+++ b/lib/mcp_server_eio.ml
@@ -3424,9 +3424,10 @@ let tool_schemas_for_profile ?(include_hidden = false) ?(include_deprecated = fa
       Config.enabled_tool_schemas ~include_hidden ~include_deprecated categories
   | Managed_agent ->
       let passthrough =
-        Config.visible_tool_schemas ~include_hidden ~include_deprecated ()
+        Config.visible_tool_schemas ~include_hidden:false ~include_deprecated:false ()
         |> List.filter (fun (schema : Types.tool_schema) ->
-               List.mem schema.name managed_agent_passthrough_tool_names)
+               List.mem schema.name managed_agent_passthrough_tool_names
+               && Tool_catalog.is_visible schema.name)
       in
       dedupe_tool_schemas_by_name
         (Agent_swarm_contract.sdk_tool_schemas @ passthrough)
@@ -3465,19 +3466,26 @@ let is_idempotent_tool_name name =
     [ "masc_status"; "masc_get_"; "masc_list"; "masc_tool_"; "masc_keeper_tool_catalog" ]
 
 let tool_annotations_for_profile _profile tool_name =
-  let read_only = Tool_dispatch.is_read_only tool_name in
+  let meta = Tool_catalog.metadata tool_name in
+  let read_only =
+    match meta.readonly with
+    | Some v -> v
+    | None -> Tool_dispatch.is_read_only tool_name
+  in
+  let destructive =
+    match meta.destructive with
+    | Some v -> v
+    | None -> is_destructive_tool_name tool_name
+  in
+  let idempotent =
+    match meta.idempotent with
+    | Some v -> v
+    | None -> is_idempotent_tool_name tool_name || read_only
+  in
   let fields =
     [ ("readOnlyHint", `Bool read_only) ]
-    @
-    if is_destructive_tool_name tool_name then
-      [ ("destructiveHint", `Bool true) ]
-    else
-      []
-    @
-    if is_idempotent_tool_name tool_name || read_only then
-      [ ("idempotentHint", `Bool true) ]
-    else
-      []
+    @ (if destructive then [ ("destructiveHint", `Bool true) ] else [])
+    @ (if idempotent then [ ("idempotentHint", `Bool true) ] else [])
   in
   if fields = [] then None else Some (`Assoc fields)
 

--- a/lib/tool_catalog.ml
+++ b/lib/tool_catalog.ml
@@ -25,6 +25,9 @@ type metadata = {
   replacement : string option;
   reason : string option;
   allow_direct_call_when_hidden : bool;
+  readonly : bool option;
+  destructive : bool option;
+  idempotent : bool option;
 }
 
 let default_metadata =
@@ -36,6 +39,9 @@ let default_metadata =
     replacement = None;
     reason = None;
     allow_direct_call_when_hidden = false;
+    readonly = None;
+    destructive = None;
+    idempotent = None;
   }
 
 let placeholder_tools_enabled () =
@@ -53,6 +59,9 @@ let deprecated ?canonical_name ?replacement ?(allow_direct_call_when_hidden = fa
     replacement;
     reason = Some reason;
     allow_direct_call_when_hidden;
+    readonly = None;
+    destructive = None;
+    idempotent = None;
   }
 
 let hidden_active ?canonical_name ?replacement ?(allow_direct_call_when_hidden = true)
@@ -65,6 +74,9 @@ let hidden_active ?canonical_name ?replacement ?(allow_direct_call_when_hidden =
     replacement;
     reason = Some reason;
     allow_direct_call_when_hidden;
+    readonly = None;
+    destructive = None;
+    idempotent = None;
   }
 
 let explicit_metadata : (string * metadata) list =
@@ -105,6 +117,17 @@ let explicit_metadata : (string * metadata) list =
     ( "masc_operator_judgment_latest",
       hidden_active
         "Internal resident-judge read path hidden from the default tool list; use for operator judgment experiments and keeper automation." );
+    (* Annotation overrides: correct misclassifications from name-pattern heuristics *)
+    ( "masc_run_get",
+      { default_metadata with readonly = Some true; idempotent = Some true } );
+    ( "masc_operation_stop",
+      { default_metadata with destructive = Some true } );
+    ( "masc_operation_pause",
+      { default_metadata with destructive = Some false } );
+    ( "masc_chain_snapshot",
+      { default_metadata with readonly = Some true; idempotent = Some true } );
+    ( "masc_chain_run_get",
+      { default_metadata with readonly = Some true; idempotent = Some true } );
   ]
 
 let implementation_status_to_string = function

--- a/test/dune
+++ b/test/dune
@@ -27,7 +27,8 @@
         test_keeper_memory
         test_keeper_deliberation
         test_metrics_rotation
-        test_tool_tier)
+        test_tool_tier
+        test_tool_exposure)
  (modules test_room test_types test_checkpoint test_auth test_http_negotiation
           test_sse test_encryption test_backend test_cancellation test_graphql_api
           test_graphql_endpoint
@@ -41,7 +42,8 @@
           test_keeper_memory
           test_keeper_deliberation
           test_metrics_rotation
-          test_tool_tier)
+          test_tool_tier
+          test_tool_exposure)
  (libraries masc_mcp alcotest str yojson mirage-crypto
             mirage-crypto-rng mirage-crypto-rng.unix cohttp cstruct unix))
 

--- a/test/test_tool_exposure.ml
+++ b/test/test_tool_exposure.ml
@@ -1,0 +1,140 @@
+(** Tests for tool exposure consistency across MCP profiles.
+
+    Validates that:
+    1. Hidden tools do not leak into spawned agent passthrough lists
+    2. Passthrough list entries correspond to real tool schemas (no dead entries)
+    3. SDK alias tools have consistent visibility with Tool_catalog
+    4. Tier system maintains essential ⊂ standard ⊂ full inclusion
+    5. Annotation overrides in Tool_catalog take precedence *)
+
+module Tool_catalog = Masc_mcp.Tool_catalog
+module Agent_tool_surfaces = Masc_mcp.Agent_tool_surfaces
+module Config = Masc_mcp.Config
+
+let () =
+  let open Alcotest in
+  run "Tool_exposure"
+    [
+      ( "hidden_tool_leak",
+        [
+          test_case "no hidden tools in spawned_agent_public_tool_names" `Quick
+            (fun () ->
+              let names = Agent_tool_surfaces.spawned_agent_public_tool_names in
+              let leaked =
+                List.filter
+                  (fun name ->
+                    not (Tool_catalog.is_visible ~include_hidden:false name))
+                  names
+              in
+              check (list string) "leaked hidden tools" [] leaked);
+        ] );
+      ( "passthrough_dead_entries",
+        [
+          test_case "all passthrough names exist in visible schemas" `Quick
+            (fun () ->
+              let all_schemas =
+                Config.visible_tool_schemas ~include_hidden:false
+                  ~include_deprecated:false ()
+              in
+              let schema_names =
+                List.map
+                  (fun (s : Masc_mcp.Types.tool_schema) -> s.name)
+                  all_schemas
+              in
+              let names =
+                Agent_tool_surfaces.spawned_agent_public_tool_names
+              in
+              let dead =
+                List.filter
+                  (fun name -> not (List.mem name schema_names))
+                  names
+              in
+              (* Dead entries indicate tools that were removed from schemas
+                 but left in the static list. Not a hard failure since the
+                 passthrough filter naturally drops them, but worth tracking. *)
+              if dead <> [] then
+                Alcotest.failf
+                  "dead passthrough entries (no matching schema): %s"
+                  (String.concat ", " dead));
+        ] );
+      ( "tier_inclusion",
+        [
+          test_case "essential ⊂ standard" `Quick (fun () ->
+              let essentials =
+                List.filter
+                  (fun name ->
+                    Tool_catalog.is_in_tier Tool_catalog.Essential name)
+                  Tool_catalog.essential_tools
+              in
+              List.iter
+                (fun name ->
+                  check bool
+                    (name ^ " essential should be in standard")
+                    true
+                    (Tool_catalog.is_in_tier Tool_catalog.Standard name))
+                essentials);
+          test_case "standard ⊂ full" `Quick (fun () ->
+              let standards =
+                List.filter
+                  (fun name ->
+                    Tool_catalog.is_in_tier Tool_catalog.Standard name)
+                  Tool_catalog.standard_tools
+              in
+              List.iter
+                (fun name ->
+                  check bool
+                    (name ^ " standard should be in full")
+                    true
+                    (Tool_catalog.is_in_tier Tool_catalog.Full name))
+                standards);
+        ] );
+      ( "annotation_overrides",
+        [
+          test_case "masc_run_get has readonly override" `Quick (fun () ->
+              let meta = Tool_catalog.metadata "masc_run_get" in
+              check (option bool) "readonly" (Some true) meta.readonly;
+              check (option bool) "idempotent" (Some true) meta.idempotent);
+          test_case "masc_operation_stop has destructive override" `Quick
+            (fun () ->
+              let meta = Tool_catalog.metadata "masc_operation_stop" in
+              check (option bool) "destructive" (Some true) meta.destructive);
+          test_case "masc_operation_pause is not destructive" `Quick
+            (fun () ->
+              let meta = Tool_catalog.metadata "masc_operation_pause" in
+              check (option bool) "destructive" (Some false) meta.destructive);
+          test_case "default tools have None annotations" `Quick (fun () ->
+              let meta = Tool_catalog.metadata "masc_join" in
+              check (option bool) "readonly" None meta.readonly;
+              check (option bool) "destructive" None meta.destructive;
+              check (option bool) "idempotent" None meta.idempotent);
+        ] );
+      ( "hidden_tools_contract",
+        [
+          test_case "known hidden tools are not visible by default" `Quick
+            (fun () ->
+              let hidden_names =
+                [
+                  "masc_vote_create";
+                  "masc_vote_cast";
+                  "masc_vote_status";
+                  "masc_post_create";
+                  "masc_post_list";
+                ]
+              in
+              List.iter
+                (fun name ->
+                  check bool (name ^ " should be hidden") false
+                    (Tool_catalog.is_visible name))
+                hidden_names);
+          test_case "hidden tools are visible with include_hidden" `Quick
+            (fun () ->
+              let hidden_names =
+                [ "masc_vote_create"; "masc_vote_cast"; "masc_vote_status" ]
+              in
+              List.iter
+                (fun name ->
+                  check bool (name ^ " should be visible with flag") true
+                    (Tool_catalog.is_visible ~include_hidden:true name))
+                hidden_names);
+        ] );
+    ]


### PR DESCRIPTION
## Summary

- spawned_agent_public_tool_names에서 hidden/deprecated/dead 도구 10개 제거 (hidden vote 3개, TRPG legacy alias 4개, dead entry 3개)
- Managed_agent 프로필에 `include_hidden:false` 고정 + `Tool_catalog.is_visible` 이중 체크 추가 (defense in depth)
- `Tool_catalog.metadata`에 `readonly/destructive/idempotent` annotation 필드 추가, `mcp_server_eio.ml`에서 metadata override 우선 사용
- `test_tool_exposure.ml` 신규 테스트 10건 (hidden leak, dead entry, tier inclusion, annotation override, hidden contract)

## Test plan

- [x] `dune build --root .` 성공
- [x] `test_tool_exposure` 10/10 통과
- [x] `test_tool_tier` 21/21 regression 없음
- [ ] 외부 모델 코드 리뷰 (GLM-5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)