### PR TITLE
feat(lodge,governance): activate social board and governance auto-trigger

### DIFF
--- a/config/lodge.env
+++ b/config/lodge.env
@@ -7,12 +7,12 @@
 # GRAPHQL_URL=http://127.0.0.1:8935/graphql
 # GRAPHQL_API_KEY=
 
-# Tick interval (seconds) — 2700 = 45 minutes
-MASC_LODGE_TICK_INTERVAL_SEC=2700
+# Tick interval (seconds) — 900 = 15 minutes (activation phase, raise to 1800 after stabilization)
+MASC_LODGE_TICK_INTERVAL_SEC=900
 
 # Max agents to activate per tick
-# Keep this conservative to avoid bursty external LLM calls during one tick.
-MASC_LODGE_AGENTS_PER_TICK=1
+# Raised from 1 to 3 for initial activation data collection.
+MASC_LODGE_AGENTS_PER_TICK=3
 
 # Keeper direct-message timeout budget (seconds).
 # dm-keeper now responds successfully around 4-32s depending on provider load;
@@ -50,4 +50,9 @@ MASC_LODGE_MAX_COMMENTS_PER_DAY=40
 MASC_LODGE_ROUTING_MODE=llm
 
 # A2A Delegation: emit heartbeat_task events instead of direct LLM call
-MASC_DELEGATE_LLM=true
+# Disabled: no external worker consumes these events, so delegation = no-op.
+MASC_DELEGATE_LLM=false
+
+# Guardian mode: "both" enables Lodge heartbeat alongside MASC housekeeping.
+# guardian.ml:27-30 requires Lodge|Both for lodge_enabled=true.
+MASC_GUARDIAN_MODE=both

--- a/lib/env_config_keeper.ml
+++ b/lib/env_config_keeper.ml
@@ -201,6 +201,13 @@ module Sentinel = struct
   let task_stale_threshold_sec = get_float ~default:1800.0 "MASC_SENTINEL_TASK_STALE_SEC"
   let llm_enabled = get_bool ~default:true "MASC_SENTINEL_LLM_ENABLED"
   let llm_timeout_sec = get_int ~default:30 "MASC_SENTINEL_LLM_TIMEOUT_SEC"
+
+  (** Governance sweep: auto-generate petitions for stuck tasks / inactive agents *)
+  let governance_enabled = get_bool ~default:true "MASC_SENTINEL_GOVERNANCE_ENABLED"
+  let governance_interval_sec = get_float ~default:1800.0 "MASC_SENTINEL_GOVERNANCE_INTERVAL_SEC"
+
+  (** Threshold: tasks stuck longer than this trigger a governance petition *)
+  let governance_task_stuck_sec = get_float ~default:86400.0 "MASC_SENTINEL_GOV_TASK_STUCK_SEC"
 end
 
 (** Print configuration summary for debugging *)

--- a/lib/lodge_decision.ml
+++ b/lib/lodge_decision.ml
@@ -397,7 +397,8 @@ Rules:
 - If decision.action is comment or upvote, target_post_id must match a listed post
 - If decision.action is comment or post, content must be non-empty and concrete
 - If there are no candidate posts, reactions must be []
-- If nothing is worth doing, choose "skip" with an explicit reason
+- You MUST take an active action (post, comment, or upvote) unless there is a specific blocking reason. "Nothing interesting" is not a valid skip reason
+- Prefer commenting on existing posts over creating new ones. Prefer action over inaction
 
 Candidate posts:
 %s|}
@@ -433,7 +434,7 @@ let selection_prompt ~agent_name ~candidate_agents ~posts ~extra_context ~max_ag
     if allow_post then
       "If posting is warranted, you may omit target_post_id and set a goal that writes a new board post."
     else
-      "Do not plan new top-level posts. Use existing posts or choose goals that lead to skipping."
+      "Do not plan new top-level posts. Focus on commenting or voting on existing posts."
   in
   Printf.sprintf
     {|You are the Lodge orchestrator for %s.

--- a/lib/sentinel.ml
+++ b/lib/sentinel.ml
@@ -431,6 +431,103 @@ let make_keeper_health_consumer _config : (module Pulse.Consumer) =
         Error msg
   end)
 
+(** Governance sweep consumer: detects stuck tasks and keeper failures,
+    then auto-generates governance petitions via Governance_v2.
+    No LLM dependency — purely data-driven threshold checks. *)
+let make_governance_sweep_consumer config : (module Pulse.Consumer) =
+  (module struct
+    let name = "sentinel-governance-sweep"
+    let should_act _beat = Env_config.Sentinel.governance_enabled
+    let on_beat _beat =
+      try
+        let base_path = config.Room_utils.base_path in
+        let now_f = Time_compat.now () in
+        let petitions_created = ref 0 in
+        let submit ~title ~subject_type ~risk_class =
+          match Council.Governance_v2.submit_petition base_path
+            ~title ~origin:"sentinel" ~subject_type ~risk_class
+            ~requested_action:None ~source_refs:[] ~created_by:agent_name with
+          | Ok result ->
+              incr petitions_created;
+              let merged_label = if result.merged then " (merged)" else "" in
+              log_info (sprintf "governance petition: %s -> case %s%s"
+                title result.case_.id merged_label)
+          | Error msg ->
+              log_warn (sprintf "governance petition failed: %s -- %s" title msg)
+        in
+
+        (* 1. Tasks stuck > threshold (default 24h) *)
+        let stuck_threshold = Env_config.Sentinel.governance_task_stuck_sec in
+        let backlog = Room.read_backlog config in
+        List.iter (fun (t : Types.task) ->
+          match t.task_status with
+          | Types.Claimed { assignee; claimed_at } ->
+              let age = now_f -. (parse_iso_or_epoch claimed_at) in
+              if age > stuck_threshold then
+                submit
+                  ~title:(sprintf "Stuck task: %s (claimed by %s, %.0fh ago)"
+                    t.title assignee (age /. 3600.0))
+                  ~subject_type:"task" ~risk_class:Council.Governance_v2.Low
+          | Types.InProgress { assignee; started_at } ->
+              let age = now_f -. (parse_iso_or_epoch started_at) in
+              if age > stuck_threshold then
+                submit
+                  ~title:(sprintf "Stuck task: %s (in_progress by %s, %.0fh ago)"
+                    t.title assignee (age /. 3600.0))
+                  ~subject_type:"task" ~risk_class:Council.Governance_v2.Low
+          | _ -> ()
+        ) backlog.tasks;
+
+        (* 2. Keepers with 3+ consecutive failures *)
+        let keepers_dir =
+          match Env_config.me_root_opt () with
+          | Some root -> Filename.concat root ".masc/keepers"
+          | None -> ".masc/keepers"
+        in
+        if Sys.file_exists keepers_dir && Sys.is_directory keepers_dir then
+          Sys.readdir keepers_dir |> Array.iter (fun fname ->
+            if Filename.check_suffix fname ".json" then begin
+              let path = Filename.concat keepers_dir fname in
+              try
+                let json = Yojson.Safe.from_file path in
+                let consecutive_failures =
+                  match Yojson.Safe.Util.member "consecutive_failures" json with
+                  | `Int n -> n
+                  | _ -> 0
+                in
+                if consecutive_failures >= 3 then begin
+                  let keeper_name = Filename.chop_suffix fname ".json" in
+                  submit
+                    ~title:(sprintf "Keeper %s failing (%d consecutive failures)"
+                      keeper_name consecutive_failures)
+                    ~subject_type:"keeper" ~risk_class:Council.Governance_v2.High
+                end
+              with _ -> ()
+            end
+          );
+
+        (* 3. Board posts with high downvote ratio *)
+        let board_posts = (try Board_dispatch.list_posts ~limit:50 ()
+                           with _ -> []) in
+        List.iter (fun (p : Board.post) ->
+          if p.votes_down >= 3 && p.votes_down > p.votes_up then
+            submit
+              ~title:(sprintf "Flagged post by %s (down=%d, up=%d)"
+                (Board.Agent_id.to_string p.author) p.votes_down p.votes_up)
+              ~subject_type:"board_post" ~risk_class:Council.Governance_v2.Low
+        ) board_posts;
+
+        if !petitions_created > 0 then
+          log_info (sprintf "governance sweep: %d petition(s) created" !petitions_created)
+        else
+          log_debug "governance sweep: no issues detected";
+        Ok ()
+      with exn ->
+        let msg = sprintf "governance sweep failed: %s" (Printexc.to_string exn) in
+        log_warn msg;
+        Error msg
+  end)
+
 (* ── Status ────────────────────────────────────────────────── *)
 
 let started = ref false
@@ -468,6 +565,10 @@ let status_json () : Yojson.Safe.t =
       `String "sentinel-task-hygiene";
       `String "sentinel-keeper-health";
     ]
+    @
+    (if Env_config.Sentinel.governance_enabled then
+       [ `String "sentinel-governance-sweep" ]
+     else [])
   in
   `Assoc [
     ("enabled", `Bool Env_config.Sentinel.enabled);
@@ -532,8 +633,20 @@ let start ~sw ~clock ~net config =
     in
     Pulse.run ~sw p_ops;
 
+    (* 6. Governance sweep (30min) *)
+    if Env_config.Sentinel.governance_enabled then begin
+      let p_gov = Pulse.create
+        ~clock
+        ~rhythm:(Guardian.fixed_rhythm Env_config.Sentinel.governance_interval_sec)
+        ~lifecycle:Perpetual
+        ~consumers:[make_governance_sweep_consumer config]
+      in
+      Pulse.run ~sw p_gov
+    end;
+
     started := true;
     start_ts := Time_compat.now ();
     ignore net;  (* net reserved for future HTTP-based health checks *)
-    log_info "started (heartbeat, embedded zombie/gc, board-patrol, task-hygiene, keeper-health)"
+    let gov_label = if Env_config.Sentinel.governance_enabled then ", governance-sweep" else "" in
+    log_info (sprintf "started (heartbeat, embedded zombie/gc, board-patrol, task-hygiene, keeper-health%s)" gov_label)
   end


### PR DESCRIPTION
## Summary

- **Phase 1 (Config)**: `MASC_GUARDIAN_MODE=both` to enable Lodge, `DELEGATE_LLM=false` (no-op without workers), tick interval 45min -> 15min, agents_per_tick 1 -> 3
- **Phase 2 (Prompts)**: Remove SKIP-inducing language from `batch_decision_prompt` and `selection_prompt` to reduce 95%+ skip rate
- **Phase 3 (Governance)**: Add `make_governance_sweep_consumer` to Sentinel that auto-generates Governance_v2 petitions for stuck tasks (>24h), keeper failures (3+ consecutive), and heavily-downvoted board posts
- **Phase 4 (Integration)**: Session-end hook posts to Board, governance-petition skill (in separate PR on me repo)

## Test plan

- [x] `dune build` passes
- [x] `test_lodge_decision.exe` — 9/9 pass
- [x] `test_guardian_sentinel.exe` — 7/7 pass
- [x] `test_dashboard_governance.exe` — 1/1 pass
- [ ] Deploy and verify `total_ticks > 0` within 20 minutes
- [ ] Verify skip rate drops below 50% after 3-5 tick cycles
- [ ] Verify governance petitions appear for stuck tasks (if any exist)

🤖 Generated with [Claude Code](https://claude.com/claude-code)