### PR TITLE
fix(build): make default target include dashboard build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,10 +3,10 @@
 
 .PHONY: build test test-unit test-contract test-contract-live test-all clean coverage coverage-summary coverage-html coverage-percent doc install-deps dev-setup fmt fmt-check health ci dashboard build-all viewer-build viewer-serve harness-game-view-contract harness-streamable-http-contract harness-trpg-session-contract harness-trpg-grimland-smoke viewer-local-e2e-check
 
-# Default target
-all: build
+# Default target — OCaml + dashboard
+all: build-all
 
-# Build the project
+# Build OCaml only
 build:
 	dune build --root .
 


### PR DESCRIPTION
## Summary

- `make` 기본 타겟을 `build` → `build-all`로 변경 (dune + Vite dashboard)
- `make build`는 OCaml-only 빌드로 유지
- `assets/dashboard/`가 `.gitignore` 전환(#1096) 이후 `dune build`만으로는 dashboard가 빌드되지 않는 문제 해결

## Test plan

- [x] `make` 실행 시 dune build + npm run build 모두 실행 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)