### PR TITLE
fix(deploy): add MASC_WORKSPACE_ROOT env and update release branch

### DIFF
--- a/.github/workflows/deploy-railway.yml
+++ b/.github/workflows/deploy-railway.yml
@@ -2,7 +2,7 @@ name: Deploy to Railway
 
 on:
   push:
-    branches: [release/v2.86.1-baseline]
+    branches: [release/v2.94.0]
   workflow_dispatch:
 
 concurrency:

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,7 @@ RUN mkdir -p /app/.masc
 
 ENV PORT=8080
 ENV MASC_BASE_PATH=/app
+ENV MASC_WORKSPACE_ROOT=/app
 
 EXPOSE 8080
 


### PR DESCRIPTION
## Summary
- Dockerfile에 `ENV MASC_WORKSPACE_ROOT=/app` 추가 — `Env_config.me_root()` 30+ 호출 지점에서 `failwith` 방지
- deploy-railway.yml 트리거 브랜치를 `release/v2.86.1-baseline` → `release/v2.94.0`으로 업데이트 (8버전 뒤처짐 해소)

## Root Cause
Railway 컨테이너에서 `MASC_WORKSPACE_ROOT` 미설정 → `me_root()` failwith → Lodge heartbeat, GraphQL agent 로딩, Board 재연결 등 핵심 서브시스템 크래시. 서버 프로세스는 떠있지만 zombie 상태.

## Changes
| File | Change |
|------|--------|
| `Dockerfile` | `ENV MASC_WORKSPACE_ROOT=/app` 추가 |
| `.github/workflows/deploy-railway.yml` | 브랜치 트리거 `release/v2.94.0` |

## Post-merge TODO
1. `release/v2.94.0` 브랜치 생성 (main에서)
2. Railway 환경변수 확인: `GRAPHQL_API_KEY`, `MASC_POSTGRES_URL` (Supabase Session Pooler port 5432)
3. `curl https://masc.crying.pictures/health` 정상 응답 확인

## Test plan
- [ ] CI smoke test (Docker build + healthcheck) 통과
- [ ] merge 후 `release/v2.94.0` 브랜치 생성 → CI 트리거 → Railway 배포
- [ ] Lodge heartbeat 정상 동작 확인
- [ ] Board PostgreSQL 연결 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)