### PR TITLE
fix(test): update source_guard for gitignored dashboard assets

### DIFF
--- a/test/test_ci_hardening_source.ml
+++ b/test/test_ci_hardening_source.ml
@@ -29,8 +29,8 @@ let test_ci_sync_and_asset_contracts () =
     (file_contains_pattern "scripts/check-pr-sync.sh" "workflow payload head");
   check bool "ci workflow verifies pr sync" true
     (file_contains_pattern ".github/workflows/ci.yml" "Verify PR sync");
-  check bool "pr hygiene checks dashboard assets" true
-    (file_contains_pattern "scripts/check-pr-hygiene.sh" "dashboard source or Vite config changed but assets/dashboard was not updated")
+  check bool "pr hygiene no longer checks dashboard assets (gitignored)" true
+    (not (file_contains_pattern "scripts/check-pr-hygiene.sh" "dashboard source or Vite config changed but assets/dashboard was not updated"))
 
 let test_health_and_ci_runner_diagnostics () =
   check bool "health snapshot records baseline source" true


### PR DESCRIPTION
## Summary
- `source_guard` 테스트의 dashboard asset 동기화 검증을 반전 (`true` → `not ...`)
- `check-pr-hygiene.sh`에서 dashboard asset 체크가 제거됐으나 (`assets/dashboard/` .gitignore 전환) 테스트가 업데이트 안 되어 CI 실패

## Test plan
- [x] `test/test_ci_hardening_source.exe` 3/3 pass (로컬 확인)
- [ ] CI `Build and Test` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)