### PR TITLE
feat(a2a,tools): dynamic skill registry and tool discoverability

### DIFF
--- a/lib/a2a_tools.ml
+++ b/lib/a2a_tools.ml
@@ -434,7 +434,8 @@ let query_skill config ~agent_name ~skill_id : (Yojson.Safe.t, string) result =
   | None -> Error (Printf.sprintf "Agent '%s' not found" agent_name)
   | Some _agent ->
     (* Look up skill from MASC skills *)
-    let skills = Agent_card.masc_skills in
+    let card = Agent_card.generate_default () in
+    let skills = card.skills in
     let skill_opt = List.find_opt (fun (s : Agent_card.skill) -> s.id = skill_id) skills in
     match skill_opt with
     | None -> Error (Printf.sprintf "Skill '%s' not found" skill_id)

--- a/lib/agent_card.ml
+++ b/lib/agent_card.ml
@@ -20,13 +20,17 @@ type provider = {
   url: string option;
 } [@@deriving yojson, show, eq]
 
-(** Skill definition for agent capabilities *)
+(** Skill definition for agent capabilities.
+    A2A v0.3 compatible with [tags] for category-based discovery.
+    [tool_count] tracks how many MCP tools this skill aggregates. *)
 type skill = {
   id: string;
   name: string;
   description: string option;
-  input_modes: string list;   (** MIME types: "text/plain", "application/json" *)
-  output_modes: string list;  (** MIME types: "text/plain", "application/json" *)
+  tags: string list;           (** Category tags for skill discovery *)
+  input_modes: string list;    (** MIME types: "text/plain", "application/json" *)
+  output_modes: string list;   (** MIME types: "text/plain", "application/json" *)
+  tool_count: int;             (** Number of MCP tools under this skill *)
 } [@@deriving yojson, show, eq]
 
 (** Protocol binding for agent communication.
@@ -290,70 +294,50 @@ let now_iso8601 () : string =
     tm.Unix.tm_min
     tm.Unix.tm_sec
 
-(** MASC skill definitions (MIME-typed for v0.3) *)
-let masc_skills : skill list = [
-  {
-    id = "task-management";
-    name = "Task Management";
-    description = Some "Create, claim, and complete tasks on the quest board";
-    input_modes = ["text/plain"; "application/json"];
-    output_modes = ["text/plain"; "application/json"];
-  };
-  {
-    id = "agent-coordination";
-    name = "Agent Coordination";
-    description = Some "Join room, broadcast messages, coordinate with other agents";
-    input_modes = ["text/plain"];
-    output_modes = ["text/plain"; "text/event-stream"];
-  };
-  {
-    id = "file-locking";
-    name = "File Locking";
-    description = Some "Lock and unlock files to prevent concurrent edits";
-    input_modes = ["text/plain"];
-    output_modes = ["text/plain"];
-  };
-  {
-    id = "git-worktree";
-    name = "Git Worktree Management";
-    description = Some "Create isolated git worktrees for parallel development";
-    input_modes = ["text/plain"];
-    output_modes = ["text/plain"; "application/octet-stream"];
-  };
-  {
-    id = "voting";
-    name = "Multi-Agent Voting";
-    description = Some "Create votes and reach consensus among agents";
-    input_modes = ["text/plain"; "application/json"];
-    output_modes = ["text/plain"; "application/json"];
-  };
-  {
-    id = "cost-tracking";
-    name = "Cost Tracking";
-    description = Some "Log and report token usage and API costs";
-    input_modes = ["application/json"];
-    output_modes = ["text/plain"; "application/json"];
-  };
-  {
-    id = "human-in-loop";
-    name = "Human-in-the-Loop";
-    description = Some "Interrupt workflows for user approval on sensitive actions";
-    input_modes = ["text/plain"];
-    output_modes = ["text/plain"];
-  };
-  {
-    id = "portal-a2a";
-    name = "A2A Portal Communication";
-    description = Some "Direct agent-to-agent private communication channels";
-    input_modes = ["text/plain"; "application/json"];
-    output_modes = ["text/plain"; "text/event-stream"];
-  };
-]
+(** Build A2A skills dynamically from MCP tool schemas grouped by category.
 
-(** Generate default MASC agent card (A2A v0.3 compliant) *)
-let generate_default ?(port=8935) ?(host="127.0.0.1") () : agent_card =
+    Each [Mode.category] becomes one A2A skill. The skill description comes
+    from [Mode.category_description] and [tool_count] tracks how many
+    MCP tools are aggregated under that category.
+
+    Categories with zero visible tools are excluded. [Unknown] is always excluded. *)
+let skills_from_tools (schemas : Types.tool_schema list) : skill list =
+  let tbl : (string, int) Hashtbl.t = Hashtbl.create 20 in
+  List.iter (fun (schema : Types.tool_schema) ->
+    let cat = Mode.tool_category schema.name in
+    if cat <> Mode.Unknown then begin
+      let key = Mode.category_to_string cat in
+      let prev = try Hashtbl.find tbl key with Not_found -> 0 in
+      Hashtbl.replace tbl key (prev + 1)
+    end
+  ) schemas;
+  Hashtbl.fold (fun cat_str count acc ->
+    match Mode.category_of_string cat_str with
+    | None -> acc
+    | Some cat ->
+      let skill : skill = {
+        id = cat_str;
+        name = String.capitalize_ascii cat_str;
+        description = Some (Mode.category_description cat);
+        tags = [cat_str; "masc"];
+        input_modes = ["application/json"];
+        output_modes = ["application/json"; "text/plain"];
+        tool_count = count;
+      } in
+      skill :: acc
+  ) tbl []
+  |> List.sort (fun (a : skill) (b : skill) -> String.compare a.id b.id)
+
+(** Generate default MASC agent card (A2A v0.3 compliant).
+    [schemas] defaults to [Config.raw_all_tool_schemas] when provided,
+    populating skills dynamically from actual MCP tools. *)
+let generate_default ?(port=8935) ?(host="127.0.0.1") ?(schemas=[]) () : agent_card =
   let timestamp = now_iso8601 () in
   let base_url = Printf.sprintf "http://%s:%d" host port in
+  let skills = match schemas with
+    | [] -> []  (* Caller should pass schemas for dynamic skills *)
+    | ss -> skills_from_tools ss
+  in
   {
     name = "MASC-MCP";
     version = Version.version;
@@ -368,7 +352,7 @@ let generate_default ?(port=8935) ?(host="127.0.0.1") () : agent_card =
       push_notifications = true;
       extended_agent_card = false;
     };
-    skills = masc_skills;
+    skills;
     supported_interfaces = [
       { protocol = "SSE"; url = Printf.sprintf "%s/sse" base_url };
       { protocol = "JSONRPC"; url = Printf.sprintf "%s/mcp" base_url };

--- a/lib/mcp_server_eio.ml
+++ b/lib/mcp_server_eio.ml
@@ -3555,6 +3555,8 @@ let tool_output_schema_field = function
   | _ -> None
 
 let tool_json_for_profile ?usage_summary profile (schema : Types.tool_schema) =
+  let category_str = Mode.category_to_string (Mode.tool_category schema.name) in
+  let tier_str = Tool_catalog.tier_to_string (Tool_catalog.tool_tier schema.name) in
   let base =
     [
       ("name", `String schema.name);
@@ -3564,14 +3566,16 @@ let tool_json_for_profile ?usage_summary profile (schema : Types.tool_schema) =
         `List
           (List.map Mcp_server.icon_to_json (tool_icons_for_name schema.name)) );
       ("inputSchema", schema.input_schema);
+      ("x-category", `String category_str);
+      ("x-tier", `String tier_str);
     ]
     @ Tool_catalog.metadata_to_fields schema.name
     @ maybe_assoc_field "outputSchema" (tool_output_schema_field schema.name)
     @ maybe_assoc_field "annotations" (tool_annotations_for_profile profile schema.name)
     @
-    match usage_summary with
+    (match usage_summary with
     | Some summary -> Telemetry_eio.tool_usage_fields summary schema.name
-    | None -> []
+    | None -> [])
   in
   `Assoc base
 

--- a/lib/server_auth.ml
+++ b/lib/server_auth.ml
@@ -383,7 +383,7 @@ let serve_agent_card ~host ~port request reqd =
       in
       let card =
         Agent_card.generate_default ~host:resolved_host
-          ~port:resolved_port ()
+          ~port:resolved_port ~schemas:Config.raw_all_tool_schemas ()
       in
       let json = Agent_card.to_json card |> Yojson.Safe.to_string in
       let a2a_version = A2a_tools.default_a2a_version in

--- a/lib/tool_agent.ml
+++ b/lib/tool_agent.ml
@@ -253,7 +253,7 @@ let handle_consolidate_learning ctx args =
 (** Handle masc_agent_card *)
 let handle_agent_card _ctx args =
   let action = get_string args "action" "get" in
-  let card = Agent_card.generate_default () in
+  let card = Agent_card.generate_default ~schemas:Config.raw_all_tool_schemas () in
   let json = Agent_card.to_json card in
   let response = match action with
     | "refresh" ->

--- a/test/test_agent_card_coverage.ml
+++ b/test/test_agent_card_coverage.ml
@@ -3,6 +3,7 @@
 open Alcotest
 
 module Agent_card = Masc_mcp.Agent_card
+module Config = Masc_mcp.Config
 
 (* ============================================================
    Provider Tests
@@ -57,8 +58,8 @@ let test_skill_json_roundtrip () =
     id = "test-skill";
     name = "Test Skill";
     description = Some "A test skill";
-    input_modes = ["text/plain"; "application/json"];
-    output_modes = ["text/plain"; "application/octet-stream"];
+    tags = []; input_modes = ["text/plain"; "application/json"];
+    output_modes = ["text/plain"; "application/octet-stream"]; tool_count = 0;
   } in
   let json = Agent_card.skill_to_yojson s in
   match Agent_card.skill_of_yojson json with
@@ -75,8 +76,8 @@ let test_skill_without_description () =
     id = "minimal";
     name = "Minimal";
     description = None;
-    input_modes = [];
-    output_modes = [];
+    tags = []; input_modes = [];
+    output_modes = []; tool_count = 0;
   } in
   let json = Agent_card.skill_to_yojson s in
   match Agent_card.skill_of_yojson json with
@@ -90,21 +91,21 @@ let test_skill_show () =
     id = "show-test";
     name = "Show Test Skill";
     description = Some "Test";
-    input_modes = ["text/plain"];
-    output_modes = ["text/plain"];
+    tags = []; input_modes = ["text/plain"];
+    output_modes = ["text/plain"]; tool_count = 0;
   } in
   let str = Agent_card.show_skill s in
   check bool "non-empty" true (String.length str > 0)
 
 let test_skill_eq () =
   let s1 : Agent_card.skill = {
-    id = "a"; name = "A"; description = None; input_modes = []; output_modes = []
+    id = "a"; name = "A"; description = None; tags = []; input_modes = []; output_modes = []; tool_count = 0
   } in
   let s2 : Agent_card.skill = {
-    id = "a"; name = "A"; description = None; input_modes = []; output_modes = []
+    id = "a"; name = "A"; description = None; tags = []; input_modes = []; output_modes = []; tool_count = 0
   } in
   let s3 : Agent_card.skill = {
-    id = "b"; name = "B"; description = None; input_modes = []; output_modes = []
+    id = "b"; name = "B"; description = None; tags = []; input_modes = []; output_modes = []; tool_count = 0
   } in
   check bool "equal same" true (Agent_card.equal_skill s1 s2);
   check bool "not equal diff" false (Agent_card.equal_skill s1 s3)
@@ -283,7 +284,7 @@ let test_signature_of_json_invalid () =
    ============================================================ *)
 
 let test_generate_default () =
-  let card = Agent_card.generate_default () in
+  let card = Agent_card.generate_default ~schemas:Config.raw_all_tool_schemas () in
   check string "name" "MASC-MCP" card.name;
   check string "version" Masc_mcp.Version.version card.version;
   check bool "has description" true (Option.is_some card.description);
@@ -431,36 +432,53 @@ let test_agent_card_eq () =
    MASC Skills Tests
    ============================================================ *)
 
+let dynamic_skills () =
+  Agent_card.skills_from_tools Config.raw_all_tool_schemas
+
 let test_masc_skills_not_empty () =
-  check bool "has skills" true (List.length Agent_card.masc_skills > 0)
+  check bool "has skills" true (List.length (dynamic_skills ()) > 0)
 
 let test_masc_skills_have_ids () =
   let all_have_ids = List.for_all (fun (s : Agent_card.skill) ->
     String.length s.id > 0
-  ) Agent_card.masc_skills in
+  ) (dynamic_skills ()) in
   check bool "all have ids" true all_have_ids
 
 let test_masc_skills_unique_ids () =
-  let ids = List.map (fun (s : Agent_card.skill) -> s.id) Agent_card.masc_skills in
+  let ids = List.map (fun (s : Agent_card.skill) -> s.id) (dynamic_skills ()) in
   let unique_ids = List.sort_uniq String.compare ids in
   check int "unique ids" (List.length ids) (List.length unique_ids)
 
 let test_masc_skills_have_names () =
   let all_have_names = List.for_all (fun (s : Agent_card.skill) ->
     String.length s.name > 0
-  ) Agent_card.masc_skills in
+  ) (dynamic_skills ()) in
   check bool "all have names" true all_have_names
 
 let test_masc_skills_expected_count () =
-  check int "skill count" 8 (List.length Agent_card.masc_skills)
+  (* Dynamic skills: one per Mode.category with tools (excluding Unknown) *)
+  let count = List.length (dynamic_skills ()) in
+  check bool "skill count > 8 (was hardcoded 8, now dynamic from categories)"
+    true (count >= 8)
 
 let test_masc_skills_mime_types () =
-  (* v0.3: input/output modes should be MIME types *)
   let all_mime = List.for_all (fun (s : Agent_card.skill) ->
     List.for_all (fun m -> String.contains m '/') s.input_modes
     && List.for_all (fun m -> String.contains m '/') s.output_modes
-  ) Agent_card.masc_skills in
+  ) (dynamic_skills ()) in
   check bool "all modes are MIME types" true all_mime
+
+let test_masc_skills_have_tags () =
+  let all_have_tags = List.for_all (fun (s : Agent_card.skill) ->
+    List.length s.tags > 0
+  ) (dynamic_skills ()) in
+  check bool "all have tags" true all_have_tags
+
+let test_masc_skills_have_tool_count () =
+  let all_positive = List.for_all (fun (s : Agent_card.skill) ->
+    s.tool_count > 0
+  ) (dynamic_skills ()) in
+  check bool "all have positive tool_count" true all_positive
 
 (* ============================================================
    Now ISO8601 Tests
@@ -603,6 +621,8 @@ let () =
       test_case "have names" `Quick test_masc_skills_have_names;
       test_case "expected count" `Quick test_masc_skills_expected_count;
       test_case "MIME types" `Quick test_masc_skills_mime_types;
+      test_case "have tags" `Quick test_masc_skills_have_tags;
+      test_case "have tool_count" `Quick test_masc_skills_have_tool_count;
     ];
     "now_iso8601", [
       test_case "format" `Quick test_now_iso8601_format;


### PR DESCRIPTION
## Summary

- **T3.1+T3.2**: `tools/list` 응답에 `x-category`, `x-tier` 메타데이터 추가. 에이전트가 카테고리별로 도구를 필터링할 수 있음.
- **T1.1**: Agent Card의 8개 hardcoded skills를 MCP tool schemas에서 동적 생성하는 `skills_from_tools()` 함수로 교체. 20개 category-level A2A skills.
- **skill 타입 확장**: `tags` (category tags), `tool_count` (aggregated tool count) 필드 추가.

## Changed Files (6)

| File | Change |
|------|--------|
| `lib/agent_card.ml` | skill type + dynamic generation |
| `lib/mcp_server_eio.ml` | x-category, x-tier in tools/list |
| `lib/server_auth.ml` | Pass schemas to agent-card.json endpoint |
| `lib/tool_agent.ml` | Pass schemas to handle_agent_card |
| `lib/a2a_tools.ml` | Remove masc_skills reference |
| `test/test_agent_card_coverage.ml` | Dynamic skills tests (54/54 pass) |

## Context

Part of Agent SDK competitive analysis & MASC-MCP 3-track improvement plan:
- Track 1: A2A Protocol Gap (this PR covers T1.1 Dynamic Skill Registry)
- Track 3: Tool Discoverability (this PR covers T3.1 + T3.2)
- Track 2: SDK comparison (separate, in `~/me/features/agent-sdk-comparison/`)

## Test plan

- [x] `test_agent_card_coverage.exe`: 54/54 PASS
- [x] `dune build`: compilation success
- [ ] Full `make test` (running)
- [ ] Manual: `curl localhost:8935/.well-known/agent-card.json | jq '.skills | length'`
- [ ] Manual: `curl -X POST localhost:8935/mcp -d '{"method":"tools/list"}' | jq '.[0] | keys'`

🤖 Generated with [Claude Code](https://claude.com/claude-code)