### PR TITLE
fix(oas): add missing disable_parallel_tool_use field

### DIFF
--- a/lib/oas_checkpoint_bridge.ml
+++ b/lib/oas_checkpoint_bridge.ml
@@ -82,6 +82,7 @@ let to_oas_checkpoint
     max_total_tokens = None;
     context = oas_ctx;
     mcp_sessions = [];
+    disable_parallel_tool_use = false;
   }
 
 (** Extract MASC metadata from an OAS Checkpoint for loop state initialization. *)


### PR DESCRIPTION
## Summary
- OAS agent_sdk v0.25.0에서 `Checkpoint.t`에 `disable_parallel_tool_use: bool` 필드 추가됨
- `oas_checkpoint_bridge.ml`에 누락되어 모든 브랜치 CI 빌드 실패

## Change
`disable_parallel_tool_use = false` 추가 (OAS 기본값과 동일)

## Test plan
- [ ] CI Build and Test 통과
- [ ] Contract Harness 통과