### PR TITLE
perf(operator): eliminate redundant DB queries in operator snapshot

### DIFF
--- a/lib/operator_control.ml
+++ b/lib/operator_control.ml
@@ -2088,8 +2088,12 @@ let build_session_digest config (session : Team_session_types.session) ~now =
     worker_cards;
   }
 
-let build_room_attention_items config =
-  let command_plane_summary = Command_plane_v2.summary_json config in
+let build_room_attention_items ?command_plane_summary config =
+  let command_plane_summary =
+    match command_plane_summary with
+    | Some s -> s
+    | None -> Command_plane_v2.summary_json config
+  in
   let microarch_signals =
     command_plane_summary
     |> U.member "operations"
@@ -2207,8 +2211,12 @@ let build_room_attention_items config =
   in
   List.sort compare_attention (pending_items @ signal_items @ intent_items)
 
-let room_recommendations config =
-  let command_plane_summary = Command_plane_v2.summary_json config in
+let room_recommendations ?command_plane_summary config =
+  let command_plane_summary =
+    match command_plane_summary with
+    | Some s -> s
+    | None -> Command_plane_v2.summary_json config
+  in
   let microarch_signals =
     command_plane_summary
     |> U.member "operations"
@@ -2409,20 +2417,23 @@ let snapshot_json ?actor ?view ?(include_messages = true) ?(include_sessions = t
     | Summary | Messages | Full -> true
     | Sessions | Keepers -> false
   in
+  let command_plane_summary =
+    if initialized then Some (Command_plane_v2.summary_json config) else None
+  in
   let summary_fields =
     if initialized && (match view with Summary | Full -> true | _ -> false) then
       let now = Time_compat.now () in
       let session_digests =
-        Team_session_store.list_sessions config
+        tracked_sessions
         |> List.map (fun session -> build_session_digest config session ~now)
       in
       let room_attention =
-        build_room_attention_items config
+        build_room_attention_items ?command_plane_summary config
         @ (session_digests |> List.concat_map (fun digest -> digest.attention_items))
         |> List.sort compare_attention
       in
       let room_recommendation_items =
-        room_recommendations config
+        room_recommendations ?command_plane_summary config
         @ (session_digests |> List.concat_map (fun digest -> digest.recommended_actions))
       in
       [


### PR DESCRIPTION
## Summary

- `Team_session_store.list_sessions` 중복 호출 제거 (44 sessions × ~350ms = ~15초 절감)
- `Command_plane_v2.summary_json` 2회 → 1회로 통합 (optional 파라미터로 주입)
- 기대 개선: 22초 → ~7초 (Supabase PostgreSQL 백엔드 기준)

## Root cause

`/api/v1/operator` snapshot이 44개 team session을 PostgreSQL에서 개별 로드하면서 세션당 ~350ms 왕복. `list_sessions`가 2번 호출되어 88번 DB 쿼리 발생.

## Test plan

- [x] 빌드 성공 (기존 main 에러와 동일, 새 에러 없음)
- [ ] 서버 재시작 후 `/api/v1/operator` 응답 시간 측정
- [ ] 외부 모델 리뷰

🤖 Generated with [Claude Code](https://claude.com/claude-code)