### PR TITLE
fix(dashboard): fast initial render with shell counts fallback

### DIFF
--- a/dashboard/src/components/overview/overview.ts
+++ b/dashboard/src/components/overview/overview.ts
@@ -2,7 +2,7 @@
 // Combines all overview sub-components into the Home landing view.
 
 import { html } from 'htm/preact'
-import { agents, keepers, tasks } from '../../store'
+import { agents, keepers, tasks, shellCounts } from '../../store'
 import { missionSnapshot } from '../../mission-store'
 import { journal } from '../../sse'
 import { navigate } from '../../router'
@@ -11,12 +11,14 @@ import { EcosystemRing } from './ecosystem-ring'
 import { SessionStrip } from './session-strip'
 import { HealthBeacon } from './health-beacon'
 import { ActivityTicker } from './activity-ticker'
+import { DASHBOARD_SURFACES } from '../../config/navigation'
 
 export function Overview() {
   const snap = missionSnapshot.value
   const agentList = agents.value
   const keeperList = keepers.value
   const taskList = tasks.value
+  const counts = shellCounts.value
 
   const activeAgents = agentList.filter(a =>
     a.status === 'active' || a.status === 'busy' || a.status === 'listening'
@@ -24,6 +26,11 @@ export function Overview() {
   const activeTasks = taskList.filter(t =>
     t.status === 'in_progress' || t.status === 'claimed'
   )
+
+  // Use shell counts as fallback when execution data hasn't loaded yet
+  const agentCount = activeAgents.length > 0 ? activeAgents.length : (counts?.agents ?? 0)
+  const taskCount = activeTasks.length > 0 ? activeTasks.length : (counts?.tasks ?? 0)
+  const keeperCount = keeperList.length > 0 ? keeperList.length : (counts?.keepers ?? 0)
 
   const roomHealth = snap?.summary?.room_health ?? null
   const roomName = snap?.summary?.current_room ?? null
@@ -33,12 +40,15 @@ export function Overview() {
   // Keeper mini-cards for the health sidebar
   const keeperBriefs = snap?.keeper_briefs ?? []
 
+  // Navigation surfaces (excluding home itself)
+  const navSurfaces = DASHBOARD_SURFACES.filter(s => s.id !== 'home')
+
   return html`
     <div class="overview-surface">
       <${QuickStats}
-        agentCount=${activeAgents.length}
-        activeTaskCount=${activeTasks.length}
-        keeperCount=${keeperList.length}
+        agentCount=${agentCount}
+        activeTaskCount=${taskCount}
+        keeperCount=${keeperCount}
         attentionCount=${attentionCount}
       />
 
@@ -80,6 +90,21 @@ export function Overview() {
           ` : null}
         </div>
       </div>
+
+      <!-- Navigation to other surfaces (Home has no SideRail) -->
+      <nav class="overview-nav-strip">
+        ${navSurfaces.map(surface => html`
+          <button
+            class="overview-nav-btn"
+            key=${surface.id}
+            onClick=${() => navigate(surface.defaultTab)}
+          >
+            <span class="overview-nav-icon">${surface.icon}</span>
+            <span class="overview-nav-label">${surface.label}</span>
+            <span class="overview-nav-desc">${surface.description}</span>
+          </button>
+        `)}
+      </nav>
     </div>
   `
 }

--- a/dashboard/src/store.ts
+++ b/dashboard/src/store.ts
@@ -49,6 +49,16 @@ import {
 import { buildAgentMotion, type AgentMotionSnapshot } from './components/common/agent-motion'
 import { isRecord, asString, asNumber, asStringArray, toIsoTimestamp } from './components/common/normalize'
 
+// --- Shell counts (lightweight fallback from /dashboard/shell) ---
+
+export interface ShellCounts {
+  agents: number
+  tasks: number
+  keepers: number
+}
+
+export const shellCounts = signal<ShellCounts | null>(null)
+
 // --- Core state signals ---
 
 export const agents = signal<Agent[]>([])
@@ -932,6 +942,14 @@ export async function refreshShell(): Promise<void> {
     const normalizedStatus = normalizeServerStatus(data.status, data.generated_at)
     if (normalizedStatus) {
       serverStatus.value = mergeServerStatus(serverStatus.value, normalizedStatus)
+    }
+    // Extract lightweight counts for fast initial render (before execution loads)
+    if (data.counts) {
+      shellCounts.value = {
+        agents: data.counts.agents ?? 0,
+        tasks: data.counts.tasks ?? 0,
+        keepers: data.counts.keepers ?? 0,
+      }
     }
   } catch (err) {
     console.error('Dashboard shell fetch error:', err)

--- a/dashboard/src/styles/overview.css
+++ b/dashboard/src/styles/overview.css
@@ -313,8 +313,53 @@
   }
 }
 
+/* Navigation strip for Home (no SideRail on Home) */
+.overview-nav-strip {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: var(--space-sm, 8px);
+  margin-top: var(--space-sm, 8px);
+}
+
+.overview-nav-btn {
+  display: grid;
+  gap: 4px;
+  padding: 14px 16px;
+  border: 1px solid var(--card-border);
+  border-radius: var(--radius-sm, 10px);
+  background: var(--card);
+  cursor: pointer;
+  text-align: left;
+  transition: border-color 0.15s, background 0.15s;
+}
+
+.overview-nav-btn:hover {
+  border-color: rgba(71, 184, 255, 0.4);
+  background: rgba(71, 184, 255, 0.05);
+}
+
+.overview-nav-icon {
+  font-size: 18px;
+}
+
+.overview-nav-label {
+  color: var(--text-strong);
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.overview-nav-desc {
+  color: var(--text-muted);
+  font-size: 11px;
+  line-height: 1.4;
+}
+
 @media (max-width: 700px) {
   .overview-stats {
     grid-template-columns: 1fr;
+  }
+
+  .overview-nav-strip {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 }


### PR DESCRIPTION
## Summary
- 대시보드 Home이 모든 카운터 0으로 표시되는 문제 수정
- `/api/v1/dashboard/execution` (40초+) 타임아웃 시에도 `/api/v1/dashboard/shell` (0.14초)의 counts를 fallback으로 사용
- Home 페이지에 네비게이션 스트립 추가 (SideRail이 Home에서 숨겨져 다른 surface로 이동 불가했던 문제)

## Root Cause
- `refreshShell()`은 `serverStatus`만 갱신하고 `counts`를 무시
- `refreshExecution()`이 `agents`, `tasks`, `keepers` signal을 담당하지만 40초+ 소요로 15초 타임아웃 초과
- Home에서 `SideRail`이 의도적으로 숨겨져 있어 네비게이션 불가

## Changes
- `store.ts`: `shellCounts` signal 추가, `refreshShell()`에서 counts 추출
- `overview.ts`: 빈 배열일 때 `shellCounts` fallback 사용 + 네비게이션 스트립
- `overview.css`: 네비게이션 버튼 스타일

## Test plan
- [ ] `curl localhost:8935/api/v1/dashboard/shell` 응답에 counts 포함 확인
- [ ] 대시보드 Home에서 카운터가 0이 아닌 실제 값 표시
- [ ] 네비게이션 스트립으로 다른 surface 이동 가능

🤖 Generated with [Claude Code](https://claude.com/claude-code)