### PR TITLE
refactor(sentinel): LLM-first governance sweep with threshold fallback

### DIFF
--- a/lib/oas_checkpoint_bridge.ml
+++ b/lib/oas_checkpoint_bridge.ml
@@ -80,6 +80,7 @@ let to_oas_checkpoint
     cache_system_prompt = false;
     max_input_tokens = Some ctx.max_tokens;
     max_total_tokens = None;
+    disable_parallel_tool_use = false;
     context = oas_ctx;
     mcp_sessions = [];
   }

--- a/lib/sentinel.ml
+++ b/lib/sentinel.ml
@@ -431,9 +431,10 @@ let make_keeper_health_consumer _config : (module Pulse.Consumer) =
         Error msg
   end)
 
-(** Governance sweep consumer: detects stuck tasks and keeper failures,
-    then auto-generates governance petitions via Governance_v2.
-    No LLM dependency — purely data-driven threshold checks. *)
+(** Governance sweep consumer: collects candidate issues (stuck tasks,
+    keeper failures, flagged posts), asks LLM to assess each, then
+    auto-generates governance petitions for confirmed issues.
+    Falls back to threshold-based submission when LLM is unavailable. *)
 let make_governance_sweep_consumer config : (module Pulse.Consumer) =
   (module struct
     let name = "sentinel-governance-sweep"
@@ -456,6 +457,9 @@ let make_governance_sweep_consumer config : (module Pulse.Consumer) =
               log_warn (sprintf "governance petition failed: %s -- %s" title msg)
         in
 
+        (* Collect all candidates *)
+        let candidates = ref [] in
+
         (* 1. Tasks stuck > threshold (default 24h) *)
         let stuck_threshold = Env_config.Sentinel.governance_task_stuck_sec in
         let backlog = Room.read_backlog config in
@@ -464,17 +468,19 @@ let make_governance_sweep_consumer config : (module Pulse.Consumer) =
           | Types.Claimed { assignee; claimed_at } ->
               let age = now_f -. (parse_iso_or_epoch claimed_at) in
               if age > stuck_threshold then
-                submit
-                  ~title:(sprintf "Stuck task: %s (claimed by %s, %.0fh ago)"
-                    t.title assignee (age /. 3600.0))
-                  ~subject_type:"task" ~risk_class:Council.Governance_v2.Low
+                candidates := (sprintf "- task:%s status=claimed assignee=%s age=%.0fh title=%s"
+                  t.id assignee (age /. 3600.0) t.title,
+                  t.title, "task", Council.Governance_v2.Low,
+                  sprintf "Stuck task: %s (claimed by %s, %.0fh ago)" t.title assignee (age /. 3600.0)
+                ) :: !candidates
           | Types.InProgress { assignee; started_at } ->
               let age = now_f -. (parse_iso_or_epoch started_at) in
               if age > stuck_threshold then
-                submit
-                  ~title:(sprintf "Stuck task: %s (in_progress by %s, %.0fh ago)"
-                    t.title assignee (age /. 3600.0))
-                  ~subject_type:"task" ~risk_class:Council.Governance_v2.Low
+                candidates := (sprintf "- task:%s status=in_progress assignee=%s age=%.0fh title=%s"
+                  t.id assignee (age /. 3600.0) t.title,
+                  t.title, "task", Council.Governance_v2.Low,
+                  sprintf "Stuck task: %s (in_progress by %s, %.0fh ago)" t.title assignee (age /. 3600.0)
+                ) :: !candidates
           | _ -> ()
         ) backlog.tasks;
 
@@ -497,10 +503,11 @@ let make_governance_sweep_consumer config : (module Pulse.Consumer) =
                 in
                 if consecutive_failures >= 3 then begin
                   let keeper_name = Filename.chop_suffix fname ".json" in
-                  submit
-                    ~title:(sprintf "Keeper %s failing (%d consecutive failures)"
-                      keeper_name consecutive_failures)
-                    ~subject_type:"keeper" ~risk_class:Council.Governance_v2.High
+                  candidates := (sprintf "- keeper:%s consecutive_failures=%d"
+                    keeper_name consecutive_failures,
+                    keeper_name, "keeper", Council.Governance_v2.High,
+                    sprintf "Keeper %s failing (%d consecutive failures)" keeper_name consecutive_failures
+                  ) :: !candidates
                 end
               with _ -> ()
             end
@@ -510,12 +517,71 @@ let make_governance_sweep_consumer config : (module Pulse.Consumer) =
         let board_posts = (try Board_dispatch.list_posts ~limit:50 ()
                            with _ -> []) in
         List.iter (fun (p : Board.post) ->
-          if p.votes_down >= 3 && p.votes_down > p.votes_up then
-            submit
-              ~title:(sprintf "Flagged post by %s (down=%d, up=%d)"
-                (Board.Agent_id.to_string p.author) p.votes_down p.votes_up)
-              ~subject_type:"board_post" ~risk_class:Council.Governance_v2.Low
+          if p.votes_down >= 3 && p.votes_down > p.votes_up then begin
+            let author_str = Board.Agent_id.to_string p.author in
+            candidates := (sprintf "- post:%s author=%s votes_down=%d votes_up=%d"
+              (Board.Post_id.to_string p.id) author_str p.votes_down p.votes_up,
+              author_str, "board_post", Council.Governance_v2.Low,
+              sprintf "Flagged post by %s (down=%d, up=%d)" author_str p.votes_down p.votes_up
+            ) :: !candidates
+          end
         ) board_posts;
+
+        if !candidates <> [] then begin
+          let candidate_lines = List.map (fun (line, _, _, _, _) -> line) !candidates in
+          let candidate_list_str = String.concat "\n" candidate_lines in
+
+          (* LLM-first: ask LLM to assess each candidate *)
+          let llm_result = call_sentinel_llm
+            ~cascade_name:"sentinel_governance"
+            ~prompt_id:"sentinel-governance-sweep"
+            ~vars:[("candidate_list", candidate_list_str)] () in
+
+          match llm_result with
+          | Some (`List items) ->
+              log_debug (sprintf "governance sweep LLM assessed %d candidates" (List.length items));
+              List.iter (fun item ->
+                let open Yojson.Safe.Util in
+                let action = item |> member "action" |> to_string_option
+                             |> Option.value ~default:"ignore" in
+                let id = item |> member "id" |> to_string_option
+                         |> Option.value ~default:"?" in
+                let title_override = item |> member "title" |> to_string_option in
+                let risk = item |> member "risk" |> to_string_option
+                           |> Option.value ~default:"low" in
+                if action = "petition" || action = "submit" then begin
+                  (* Find matching candidate for subject_type and risk_class *)
+                  let matching = List.find_opt (fun (line, _, _, _, _) ->
+                    let has_id = try String.sub line 0 (String.length line)
+                                 |> fun s -> String.length s > 0 && (
+                                   try ignore (Str.search_forward (Str.regexp_string id) s 0); true
+                                   with Not_found -> false)
+                    with _ -> false in
+                    has_id
+                  ) !candidates in
+                  match matching with
+                  | Some (_, _, subject_type, default_risk, default_title) ->
+                      let risk_class = match risk with
+                        | "high" -> Council.Governance_v2.High
+                        | _ -> default_risk
+                      in
+                      let title = match title_override with
+                        | Some t when String.length (String.trim t) > 5 -> t
+                        | _ -> default_title
+                      in
+                      submit ~title ~subject_type ~risk_class
+                  | None ->
+                      log_debug (sprintf "governance LLM referenced unknown candidate: %s" id)
+                end
+              ) items
+          | _ ->
+              (* Fallback: LLM unavailable, submit all candidates directly *)
+              log_debug (sprintf "governance sweep: LLM unavailable, threshold fallback for %d candidates"
+                (List.length !candidates));
+              List.iter (fun (_, _, subject_type, risk_class, title) ->
+                submit ~title ~subject_type ~risk_class
+              ) !candidates
+        end;
 
         if !petitions_created > 0 then
           log_info (sprintf "governance sweep: %d petition(s) created" !petitions_created)


### PR DESCRIPTION
## Summary

- Replace pure-heuristic governance sweep with LLM-first assessment pattern
- Candidates still collected via threshold pre-filter (stuck >24h, keeper 3+ failures, downvoted posts)
- LLM assesses each candidate and returns action=petition or action=ignore
- When LLM is unavailable, all candidates are submitted directly (threshold fallback)
- Follows the same pattern as `task_hygiene` and `keeper_health` consumers
- Also fixes `oas_checkpoint_bridge` missing `disable_parallel_tool_use` field

## Test plan

- [x] `dune build` passes
- [x] `test_guardian_sentinel.exe` 7/7 pass
- [ ] Verify LLM assessment triggers when cascade is available
- [ ] Verify threshold fallback when LLM is offline

🤖 Generated with [Claude Code](https://claude.com/claude-code)