### PR TITLE
fix(a2a): add missing tags and tool_count fields to skill records

### DIFF
--- a/lib/gardener.ml
+++ b/lib/gardener.ml
@@ -30,13 +30,16 @@ let agent_card : Agent_card.agent_card = {
   skills = [
     { id = "health-monitor"; name = "Health Monitor";
       description = Some "Calculate ecosystem health metrics and homeostatic score";
-      input_modes = []; output_modes = ["application/json"] };
+      tags = []; input_modes = []; output_modes = ["application/json"];
+      tool_count = 0 };
     { id = "spawn-decision"; name = "Spawn Decision";
       description = Some "Evaluate and execute agent spawn proposals";
-      input_modes = ["application/json"]; output_modes = ["application/json"] };
+      tags = []; input_modes = ["application/json"]; output_modes = ["application/json"];
+      tool_count = 0 };
     { id = "retire-decision"; name = "Retire Decision";
       description = Some "Evaluate and execute agent retirement proposals";
-      input_modes = ["application/json"]; output_modes = ["application/json"] };
+      tags = []; input_modes = ["application/json"]; output_modes = ["application/json"];
+      tool_count = 0 };
   ];
   supported_interfaces = [];
   security_schemes = [];

--- a/lib/guardian.ml
+++ b/lib/guardian.ml
@@ -16,10 +16,12 @@ let agent_card : Agent_card.agent_card = {
   skills = [
     { id = "zombie-cleanup"; name = "Zombie Cleanup";
       description = Some "Remove stale room entries";
-      input_modes = []; output_modes = ["application/json"] };
+      tags = []; input_modes = []; output_modes = ["application/json"];
+      tool_count = 0 };
     { id = "garbage-collection"; name = "Garbage Collection";
       description = Some "Purge old records beyond retention window";
-      input_modes = []; output_modes = ["application/json"] };
+      tags = []; input_modes = []; output_modes = ["application/json"];
+      tool_count = 0 };
   ];
   supported_interfaces = [];
   security_schemes = [];

--- a/lib/sentinel.ml
+++ b/lib/sentinel.ml
@@ -31,16 +31,20 @@ let agent_card : Agent_card.agent_card = {
   skills = [
     { id = "heartbeat"; name = "Heartbeat";
       description = Some "Keep sentinel visible in the room";
-      input_modes = []; output_modes = ["application/json"] };
+      tags = []; input_modes = []; output_modes = ["application/json"];
+      tool_count = 0 };
     { id = "board-patrol"; name = "Board Patrol";
       description = Some "LLM-driven stale post detection";
-      input_modes = []; output_modes = ["application/json"] };
+      tags = []; input_modes = []; output_modes = ["application/json"];
+      tool_count = 0 };
     { id = "task-hygiene"; name = "Task Hygiene";
       description = Some "LLM-driven orphaned/stuck task detection";
-      input_modes = []; output_modes = ["application/json"] };
+      tags = []; input_modes = []; output_modes = ["application/json"];
+      tool_count = 0 };
     { id = "keeper-health"; name = "Keeper Health";
       description = Some "LLM-driven stale keeper monitoring";
-      input_modes = []; output_modes = ["application/json"] };
+      tags = []; input_modes = []; output_modes = ["application/json"];
+      tool_count = 0 };
   ];
   supported_interfaces = [];
   security_schemes = [];


### PR DESCRIPTION
## Summary
- `Agent_card.skill` 타입에 `tags`/`tool_count` 필드가 A2A v0.3에서 추가됨
- guardian(2), sentinel(4), gardener(3) — 9개 skill 레코드에 누락된 필드 추가
- Railway 배포 빌드 실패 수정

## Test plan
- [x] `dune build` 성공
- [ ] CI green