### PR TITLE
fix(a2a): resolve empty skills and JSON backward compat

### DIFF
--- a/lib/a2a_tools.ml
+++ b/lib/a2a_tools.ml
@@ -426,16 +426,15 @@ let discover config ?(endpoint : string option) ?(capability : string option) ()
     @param skill_id Skill ID to query
     @return Skill details
 *)
-let query_skill config ~agent_name ~skill_id : (Yojson.Safe.t, string) result =
+let query_skill config ~schemas ~agent_name ~skill_id : (Yojson.Safe.t, string) result =
   (* First, find the agent *)
   let agents = Room.get_agents_raw config in
   let agent_opt = List.find_opt (fun (a : agent) -> a.name = agent_name) agents in
   match agent_opt with
   | None -> Error (Printf.sprintf "Agent '%s' not found" agent_name)
   | Some _agent ->
-    (* Look up skill from MASC skills *)
-    let card = Agent_card.generate_default () in
-    let skills = card.skills in
+    (* Look up skill from dynamic MCP tool schemas *)
+    let skills = Agent_card.skills_from_tools schemas in
     let skill_opt = List.find_opt (fun (s : Agent_card.skill) -> s.id = skill_id) skills in
     match skill_opt with
     | None -> Error (Printf.sprintf "Skill '%s' not found" skill_id)

--- a/lib/agent_card.ml
+++ b/lib/agent_card.ml
@@ -27,10 +27,10 @@ type skill = {
   id: string;
   name: string;
   description: string option;
-  tags: string list;           (** Category tags for skill discovery *)
+  tags: string list [@default []];           (** Category tags for skill discovery *)
   input_modes: string list;    (** MIME types: "text/plain", "application/json" *)
   output_modes: string list;   (** MIME types: "text/plain", "application/json" *)
-  tool_count: int;             (** Number of MCP tools under this skill *)
+  tool_count: int [@default 0];             (** Number of MCP tools under this skill *)
 } [@@deriving yojson, show, eq]
 
 (** Protocol binding for agent communication.

--- a/lib/tool_a2a.ml
+++ b/lib/tool_a2a.ml
@@ -21,7 +21,7 @@ let handle_a2a_discover ctx args =
 let handle_a2a_query_skill ctx args =
   let skill_agent_name = get_string args "agent_name" "" in
   let skill_id = get_string args "skill_id" "" in
-  match A2a_tools.query_skill ctx.config ~agent_name:skill_agent_name ~skill_id with
+  match A2a_tools.query_skill ctx.config ~schemas:Config.raw_all_tool_schemas ~agent_name:skill_agent_name ~skill_id with
   | Ok json -> (true, Yojson.Safe.pretty_to_string json)
   | Error e -> (false, Printf.sprintf "❌ Query skill failed: %s" e)
 


### PR DESCRIPTION
## Summary

Post-merge fix for #1115 (dynamic skill registry).

- **CRITICAL**: `query_skill` called `generate_default()` without schemas → empty skills → always "Skill not found". Fix: add `~schemas` param, inject `Config.raw_all_tool_schemas` at `tool_a2a.ml` call site.
- **HIGH**: New `tags`/`tool_count` fields break `skill_of_yojson` for external agent cards. Fix: `[@default []]` and `[@default 0]` annotations.
- Add `tags`/`tool_count` to skill records in guardian, sentinel, gardener.
- Pre-existing: `oas_checkpoint_bridge.ml` missing `disable_parallel_tool_use`.

Found by GLM-5 external review.

## Test plan

- [x] `test_agent_card_coverage.exe`: 54/54 PASS
- [x] `dune build`: compilation success
- [x] No new test failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)