### PR TITLE
fix(build): add missing skill record fields and remove duplicate checkpoint field

### DIFF
--- a/lib/gardener.ml
+++ b/lib/gardener.ml
@@ -30,12 +30,15 @@ let agent_card : Agent_card.agent_card = {
   skills = [
     { id = "health-monitor"; name = "Health Monitor";
       description = Some "Calculate ecosystem health metrics and homeostatic score";
+      tags = ["ecosystem"]; tool_count = 1;
       input_modes = []; output_modes = ["application/json"] };
     { id = "spawn-decision"; name = "Spawn Decision";
       description = Some "Evaluate and execute agent spawn proposals";
+      tags = ["ecosystem"]; tool_count = 2;
       input_modes = ["application/json"]; output_modes = ["application/json"] };
     { id = "retire-decision"; name = "Retire Decision";
       description = Some "Evaluate and execute agent retirement proposals";
+      tags = ["ecosystem"]; tool_count = 2;
       input_modes = ["application/json"]; output_modes = ["application/json"] };
   ];
   supported_interfaces = [];

--- a/lib/guardian.ml
+++ b/lib/guardian.ml
@@ -16,9 +16,11 @@ let agent_card : Agent_card.agent_card = {
   skills = [
     { id = "zombie-cleanup"; name = "Zombie Cleanup";
       description = Some "Remove stale room entries";
+      tags = ["housekeeping"]; tool_count = 0;
       input_modes = []; output_modes = ["application/json"] };
     { id = "garbage-collection"; name = "Garbage Collection";
       description = Some "Purge old records beyond retention window";
+      tags = ["housekeeping"]; tool_count = 0;
       input_modes = []; output_modes = ["application/json"] };
   ];
   supported_interfaces = [];

--- a/lib/oas_checkpoint_bridge.ml
+++ b/lib/oas_checkpoint_bridge.ml
@@ -83,7 +83,6 @@ let to_oas_checkpoint
     disable_parallel_tool_use = false;
     context = oas_ctx;
     mcp_sessions = [];
-    disable_parallel_tool_use = false;
   }
 
 (** Extract MASC metadata from an OAS Checkpoint for loop state initialization. *)

--- a/lib/sentinel.ml
+++ b/lib/sentinel.ml
@@ -31,15 +31,19 @@ let agent_card : Agent_card.agent_card = {
   skills = [
     { id = "heartbeat"; name = "Heartbeat";
       description = Some "Keep sentinel visible in the room";
+      tags = ["governance"]; tool_count = 0;
       input_modes = []; output_modes = ["application/json"] };
     { id = "board-patrol"; name = "Board Patrol";
       description = Some "LLM-driven stale post detection";
+      tags = ["governance"]; tool_count = 0;
       input_modes = []; output_modes = ["application/json"] };
     { id = "task-hygiene"; name = "Task Hygiene";
       description = Some "LLM-driven orphaned/stuck task detection";
+      tags = ["governance"]; tool_count = 0;
       input_modes = []; output_modes = ["application/json"] };
     { id = "keeper-health"; name = "Keeper Health";
       description = Some "LLM-driven stale keeper monitoring";
+      tags = ["governance"]; tool_count = 0;
       input_modes = []; output_modes = ["application/json"] };
   ];
   supported_interfaces = [];


### PR DESCRIPTION
## Summary
빌드 깨진 원인 3가지 수정:

1. **guardian.ml, gardener.ml, sentinel.ml**: `agent_card.ml`의 `skill` 타입에 `tags: string list`와 `tool_count: int` 필드 추가 후, 기존 skill 리터럴 미수정
2. **oas_checkpoint_bridge.ml**: `disable_parallel_tool_use` 필드 중복 정의 (line 83 + 86)

## Changes
- 4 files, +9 -1 lines
- `dune build --root .` 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)