### PR TITLE
fix(ci): increase smoke test healthcheck timeout to 45s

### DIFF
--- a/.github/workflows/deploy-railway.yml
+++ b/.github/workflows/deploy-railway.yml
@@ -76,7 +76,7 @@ jobs:
           cid="$(docker run -d -e PORT=8080 -p 18080:8080 masc-mcp-railway-smoke)"
           trap 'docker logs "$cid" || true; docker rm -f "$cid" || true' EXIT
 
-          for attempt in $(seq 1 20); do
+          for attempt in $(seq 1 45); do
             if curl -fsS "http://127.0.0.1:18080/health" >/dev/null 2>&1; then
               echo "Container healthcheck passed."
               exit 0


### PR DESCRIPTION
## Summary
- Deploy smoke test 대기 시간 20초 → 45초로 증가
- CI 환경에서 GraphQL DNS 실패 → curl fallback `-m 10` → 서버 시작 ~20초 소요
- 이전 20초 timeout으로는 서버 시작 직후 타이밍에서 실패

## Root Cause
서버 시작 전 GraphQL agent 로딩이 동기적으로 실행되며, DNS 실패 + curl timeout 체인이 15-20초 소요

## Test plan
- [ ] Deploy to Railway workflow 성공