### PR TITLE
perf(operator): eliminate N+1 queries in operator snapshot

### DIFF
--- a/lib/keeper_types.ml
+++ b/lib/keeper_types.ml
@@ -1175,9 +1175,12 @@ let register_resident_keeper_from_meta config (meta : keeper_meta) :
       updated_at = now_iso ();
     }
 
-let persistent_agent_names config =
+let persistent_agent_names ?resident_names config =
   let dir = keeper_dir config in
-  let resident = resident_keeper_names config in
+  let resident = match resident_names with
+    | Some n -> n
+    | None -> resident_keeper_names config
+  in
   match Safe_ops.list_dir_safe dir with
   | Error _ -> []
   | Ok files ->

--- a/lib/operator_control.ml
+++ b/lib/operator_control.ml
@@ -622,8 +622,11 @@ let keeper_tool_audit_fields config (meta : Keeper_types.keeper_meta) =
   | None, None ->
       (fallback_allowed, fallback_latest, fallback_count, fallback_source, fallback_at)
 
-let keepers_json config =
-  let names = Keeper_types.resident_keeper_names config in
+let keepers_json ?keeper_names config =
+  let names = match keeper_names with
+    | Some n -> n
+    | None -> Keeper_types.resident_keeper_names config
+  in
   let rows =
     List.filter_map
       (fun name ->
@@ -716,8 +719,8 @@ let keepers_json config =
   in
   `Assoc [ ("count", `Int (List.length rows)); ("items", `List rows) ]
 
-let persistent_agents_json config =
-  let names = Keeper_types.persistent_agent_names config in
+let persistent_agents_json ?keeper_names config =
+  let names = Keeper_types.persistent_agent_names ?resident_names:keeper_names config in
   let rows =
     List.filter_map
       (fun name ->
@@ -2452,6 +2455,11 @@ let snapshot_json ?actor ?view ?(include_messages = true) ?(include_sessions = t
     else
       Swarm_status.empty_json
   in
+  let keeper_names =
+    if initialized && include_keepers then
+      Keeper_types.resident_keeper_names config
+    else []
+  in
   `Assoc
     ([
        ("trace_id", `String trace_id);
@@ -2465,10 +2473,10 @@ let snapshot_json ?actor ?view ?(include_messages = true) ?(include_sessions = t
          if initialized && include_sessions then sessions_json config
          else `Assoc [ ("count", `Int 0); ("items", `List []) ] );
        ( "keepers",
-         if initialized && include_keepers then keepers_json config
+         if initialized && include_keepers then keepers_json ~keeper_names config
          else `Assoc [ ("count", `Int 0); ("items", `List []) ] );
        ( "persistent_agents",
-         if initialized && include_keepers then persistent_agents_json config
+         if initialized && include_keepers then persistent_agents_json ~keeper_names config
          else `Assoc [ ("count", `Int 0); ("items", `List []) ] );
        ("command_plane", command_plane_json);
        ("swarm_status", swarm_status_json);

--- a/lib/room_utils_ops.ml
+++ b/lib/room_utils_ops.ml
@@ -205,10 +205,21 @@ let path_exists config path =
   | None -> Sys.file_exists path
 
 let read_json_opt config path =
-  if path_exists config path then
-    Some (read_json config path)
-  else
-    None
+  match key_of_path config path with
+  | Some key -> (
+      match backend_get config ~key with
+      | Ok (Some content) ->
+          let trimmed = String.trim content in
+          if trimmed = "" then None
+          else (
+            match Safe_ops.parse_json_safe ~context:"read_json_opt" trimmed with
+            | Ok json -> Some json
+            | Error _ -> None)
+      | Ok None -> None
+      | Error _ -> None)
+  | None ->
+      if Sys.file_exists path then Some (read_json_local path)
+      else None
 
 (* ============================================ *)
 (* File locking                                 *)

--- a/lib/team_session_store.ml
+++ b/lib/team_session_store.ml
@@ -94,11 +94,9 @@ let save_session config (session : Team_session_types.session) =
 
 let load_session config session_id : Team_session_types.session option =
   let path = session_json_path config session_id in
-  if not (path_exists config path) then
-    None
-  else
-    (* Read-only: no lock needed. read_json is atomic (tmp+rename writes). *)
-    Team_session_types.session_of_yojson (read_json config path)
+  match read_json_opt config path with
+  | None -> None
+  | Some json -> Team_session_types.session_of_yojson json
 
 let load_session_or_error config session_id =
   match load_session config session_id with
@@ -229,13 +227,25 @@ let read_recent_events config session_id ~max_count :
     []
 
 let list_sessions config : Team_session_types.session list =
-  let root = sessions_root config in
-  if not (path_exists config root) then
-    []
-  else
-    Sys.readdir root
-    |> Array.to_list
-    |> List.filter_map (fun session_id -> load_session config session_id)
+  match backend_get_all config ~prefix:"team-sessions:" with
+  | Ok pairs ->
+      pairs
+      |> List.filter_map (fun (key, value) ->
+             if not (String.ends_with ~suffix:":session.json" key) then None
+             else
+               let trimmed = String.trim value in
+               if trimmed = "" then None
+               else
+                 match Safe_ops.parse_json_safe ~context:"list_sessions" trimmed with
+                 | Ok json -> Team_session_types.session_of_yojson json
+                 | Error _ -> None)
+  | Error _ ->
+      let root = sessions_root config in
+      if not (path_exists config root) then []
+      else
+        Sys.readdir root
+        |> Array.to_list
+        |> List.filter_map (fun session_id -> load_session config session_id)
 
 let update_session config session_id f =
   let path = session_json_path config session_id in


### PR DESCRIPTION
## Summary

- `read_json_opt`: 2 queries (EXISTS + SELECT) → 1 query (GET)
- `list_sessions`: N individual loads → 1 batch `backend_get_all` query
- `load_session`: uses optimized `read_json_opt` (1 query instead of 2)
- `snapshot_json`: `resident_keeper_names` computed once, shared between `keepers_json` and `persistent_agents_json`

Estimated reduction: ~115 DB queries per `/api/v1/operator` call.

## Changed files

| File | Change |
|------|--------|
| `lib/room_utils_ops.ml` | `read_json_opt` uses `backend_get` directly (1 query) |
| `lib/team_session_store.ml` | `list_sessions` batch load + `load_session` uses `read_json_opt` |
| `lib/operator_control.ml` | `keepers_json`/`persistent_agents_json` accept `?keeper_names`; `snapshot_json` pre-computes |
| `lib/keeper_types.ml` | `persistent_agent_names` accepts `?resident_names` |

## Test plan

- [x] `dune build --root .` passes
- [x] `test_tool_exposure` — 10/10 pass
- [x] `test_tool_tier` — 21/21 pass
- [ ] Server restart + `/api/v1/operator` response time measurement
- [ ] Verify JSON output structure unchanged (diff before/after)

🤖 Generated with [Claude Code](https://claude.com/claude-code)