### PR TITLE
fix(config): add MASC_GUARDIAN_ENABLED=true to lodge.env

### DIFF
--- a/config/lodge.env
+++ b/config/lodge.env
@@ -53,6 +53,10 @@ MASC_LODGE_ROUTING_MODE=llm
 # Disabled: no external worker consumes these events, so delegation = no-op.
 MASC_DELEGATE_LLM=false
 
+# Guardian: enable internal loops (zombie cleanup, gc, lodge heartbeat).
+# Default is false — must be explicitly enabled.
+MASC_GUARDIAN_ENABLED=true
+
 # Guardian mode: "both" enables Lodge heartbeat alongside MASC housekeeping.
 # guardian.ml:27-30 requires Lodge|Both for lodge_enabled=true.
 MASC_GUARDIAN_MODE=both


### PR DESCRIPTION
## Summary

- Add missing `MASC_GUARDIAN_ENABLED=true` to `config/lodge.env`
- Without this, `guardian.ml` defaults `enabled=false`, making `lodge_enabled` stay `false` even with `MASC_GUARDIAN_MODE=both`

## Test plan

- [x] Server restart with `source config/lodge.env` confirms `lodge_enabled=true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)