### PR TITLE
refactor(oas): fix responsibility boundary violations at OAS interface

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -292,6 +292,7 @@
    tool_schemas_room
    tool_plan
    tool_run
+   tool_bridge
    tool_cache
    tool_tempo
    tool_mitosis

--- a/lib/llm_client.ml
+++ b/lib/llm_client.ml
@@ -1242,18 +1242,20 @@ let to_oas_provider (spec : model_spec) : Agent_sdk.Provider.config option =
     }
   | Custom _ -> None
 
-let to_oas_message (m : message) : Agent_sdk.Types.message =
-  let role = match m.role with
-    | System | Tool | User -> Agent_sdk.Types.User
-    | Assistant -> Agent_sdk.Types.Assistant
-  in
-  let content = match m.role with
-    | Tool ->
-      let tool_use_id = Option.value ~default:"masc-tool" m.tool_call_id in
-      [Agent_sdk.Types.ToolResult { tool_use_id; content = m.content; is_error = false }]
-    | _ -> [Agent_sdk.Types.Text m.content]
-  in
-  { Agent_sdk.Types.role; content }
+let to_oas_message (m : message) : Agent_sdk.Types.message option =
+  match m.role with
+  | System ->
+    (* System messages belong in Checkpoint.system_prompt, not in messages.
+       Dropping here prevents duplication at the OAS boundary. *)
+    None
+  | Tool ->
+    let tool_use_id = Option.value ~default:"masc-tool" m.tool_call_id in
+    Some { Agent_sdk.Types.role = User;
+           content = [ToolResult { tool_use_id; content = m.content; is_error = false }] }
+  | User ->
+    Some { Agent_sdk.Types.role = User; content = [Text m.content] }
+  | Assistant ->
+    Some { Agent_sdk.Types.role = Assistant; content = [Text m.content] }
 
 let of_oas_message (m : Agent_sdk.Types.message) : message =
   let role = match m.role with

--- a/lib/llm_client.mli
+++ b/lib/llm_client.mli
@@ -208,8 +208,9 @@ val string_of_provider : provider -> string
 val to_oas_provider : model_spec -> Agent_sdk.Provider.config option
 
 (** Convert a masc message to an OAS Types.message.
-    System and Tool roles map to User. *)
-val to_oas_message : message -> Agent_sdk.Types.message
+    System messages return None (they belong in system_prompt).
+    Tool messages map to User with ToolResult content. *)
+val to_oas_message : message -> Agent_sdk.Types.message option
 
 (** Convert an OAS Types.message back to a masc message. *)
 val of_oas_message : Agent_sdk.Types.message -> message

--- a/lib/oas_checkpoint_bridge.ml
+++ b/lib/oas_checkpoint_bridge.ml
@@ -8,15 +8,19 @@
     - Version-tracked serialization
     - Session-based file layout
 
+    Boundary contract:
+    - System messages are excluded from checkpoint messages
+      (they live in [Checkpoint.system_prompt] to avoid duplication).
+    - Checkpoint parameters are configurable via [checkpoint_config].
+
     @since 2.90.0 *)
 
-(** Convert a MASC Llm_client.message to an OAS Types.message.
-    Delegates to [Llm_client.to_oas_message] — the canonical conversion. *)
-let masc_msg_to_oas (m : Llm_client.message) : Agent_sdk.Types.message =
+(** Convert a MASC Llm_client.message to an OAS Types.message option.
+    System messages return None (belong in system_prompt, not messages). *)
+let masc_msg_to_oas (m : Llm_client.message) : Agent_sdk.Types.message option =
   Llm_client.to_oas_message m
 
-(** Convert an OAS Types.message back to MASC Llm_client.message.
-    Delegates to [Llm_client.of_oas_message]. *)
+(** Convert an OAS Types.message back to MASC Llm_client.message. *)
 let oas_msg_to_masc (m : Agent_sdk.Types.message) : Llm_client.message =
   Llm_client.of_oas_message m
 
@@ -30,13 +34,32 @@ type checkpoint_state = {
   trace_id : string;
 }
 
+(** Configuration for OAS checkpoint serialization.
+    Avoids hard-coding parameters that depend on the agent's runtime context. *)
+type checkpoint_config = {
+  thinking_budget : int option;
+  response_format_json : bool;
+  cache_system_prompt : bool;
+  disable_parallel_tool_use : bool;
+}
+
+let default_checkpoint_config = {
+  thinking_budget = None;
+  response_format_json = false;
+  cache_system_prompt = false;
+  disable_parallel_tool_use = false;
+}
+
 (** Build an OAS Checkpoint from perpetual loop state and working context.
     Stores MASC-specific metadata (generation, goal, turn_count) in the
-    checkpoint's context via scoped keys. *)
+    checkpoint's context via scoped keys.
+    @param config Checkpoint serialization config (default: all disabled). *)
 let to_oas_checkpoint
     ~(state : checkpoint_state)
     ~(ctx : Context_manager.working_context)
     ~(goal : string)
+    ?(config = default_checkpoint_config)
+    ()
   : Agent_sdk.Checkpoint.t =
   let oas_ctx = Agent_sdk.Context.copy ctx.oas_context in
   (* Store MASC metadata in Session scope *)
@@ -50,7 +73,7 @@ let to_oas_checkpoint
     "trace_id" (`String state.trace_id);
   Agent_sdk.Context.set_scoped oas_ctx Agent_sdk.Context.App
     "masc_version" (`String Version.version);
-  let messages = List.map masc_msg_to_oas ctx.messages in
+  let messages = List.filter_map masc_msg_to_oas ctx.messages in
   {
     Agent_sdk.Checkpoint.version = 3;
     session_id = state.session_id;
@@ -75,12 +98,12 @@ let to_oas_checkpoint
     top_k = None;
     min_p = None;
     enable_thinking = None;
-    response_format_json = false;
-    thinking_budget = None;
-    cache_system_prompt = false;
+    response_format_json = config.response_format_json;
+    thinking_budget = config.thinking_budget;
+    cache_system_prompt = config.cache_system_prompt;
     max_input_tokens = Some ctx.max_tokens;
     max_total_tokens = None;
-    disable_parallel_tool_use = false;
+    disable_parallel_tool_use = config.disable_parallel_tool_use;
     context = oas_ctx;
     mcp_sessions = [];
   }

--- a/lib/perpetual_loop.ml
+++ b/lib/perpetual_loop.ml
@@ -629,7 +629,7 @@ let run_turn ~config ~state =
                 total_cost = state.total_cost;
                 trace_id = state.trace_id;
               }
-            ~ctx:state.context ~goal:config.initial_goal in
+            ~ctx:state.context ~goal:config.initial_goal () in
           let checkpoint_path =
             Filename.concat config.session_base_dir (state.trace_id ^ ".json")
           in

--- a/lib/tool_bridge.ml
+++ b/lib/tool_bridge.ml
@@ -1,0 +1,17 @@
+(** OAS boundary adapter for tool results.
+
+    MASC tools use [(bool * string)] internally (success flag + message).
+    OAS uses [Agent_sdk.Types.tool_result = (tool_output, tool_error) result].
+
+    This module converts at the OAS boundary only — internal MASC
+    tool handlers keep their existing convention unchanged.
+
+    @since 2.95.1 *)
+
+let to_oas_tool_result (success, msg) : Agent_sdk.Types.tool_result =
+  if success then Ok { Agent_sdk.Types.content = msg }
+  else Error { Agent_sdk.Types.message = msg; recoverable = true }
+
+let of_oas_tool_result : Agent_sdk.Types.tool_result -> bool * string = function
+  | Ok { content } -> (true, content)
+  | Error { message; _ } -> (false, message)

--- a/lib/tool_bridge.ml
+++ b/lib/tool_bridge.ml
@@ -8,9 +8,10 @@
 
     @since 2.95.1 *)
 
-let to_oas_tool_result (success, msg) : Agent_sdk.Types.tool_result =
+let to_oas_tool_result ?(recoverable = true) (success, msg)
+  : Agent_sdk.Types.tool_result =
   if success then Ok { Agent_sdk.Types.content = msg }
-  else Error { Agent_sdk.Types.message = msg; recoverable = true }
+  else Error { Agent_sdk.Types.message = msg; recoverable }
 
 let of_oas_tool_result : Agent_sdk.Types.tool_result -> bool * string = function
   | Ok { content } -> (true, content)

--- a/test/test_oas_integration.ml
+++ b/test/test_oas_integration.ml
@@ -59,14 +59,17 @@ let test_message_roundtrip () =
     tool_call_id = None;
   } in
   let oas_msg = Oas_checkpoint_bridge.masc_msg_to_oas masc_msg in
-  let roundtrip = Oas_checkpoint_bridge.oas_msg_to_masc oas_msg in
-  Alcotest.(check string) "role preserved"
-    "assistant"
-    (match roundtrip.role with Llm_client.Assistant -> "assistant" | _ -> "other");
-  Alcotest.(check string) "content preserved"
-    "test content" roundtrip.content
+  (match oas_msg with
+   | None -> Alcotest.fail "Assistant message should not be dropped"
+   | Some msg ->
+     let roundtrip = Oas_checkpoint_bridge.oas_msg_to_masc msg in
+     Alcotest.(check string) "role preserved"
+       "assistant"
+       (match roundtrip.role with Llm_client.Assistant -> "assistant" | _ -> "other");
+     Alcotest.(check string) "content preserved"
+       "test content" roundtrip.content)
 
-let test_system_role_maps_to_user () =
+let test_system_role_dropped () =
   let masc_msg : Llm_client.message = {
     role = Llm_client.System;
     content = "system prompt";
@@ -74,11 +77,8 @@ let test_system_role_maps_to_user () =
     tool_call_id = None;
   } in
   let oas_msg = Oas_checkpoint_bridge.masc_msg_to_oas masc_msg in
-  Alcotest.(check string) "system maps to user"
-    "user"
-    (match oas_msg.Agent_sdk.Types.role with
-     | Agent_sdk.Types.User -> "user"
-     | Agent_sdk.Types.Assistant -> "assistant")
+  Alcotest.(check bool) "system message dropped (belongs in system_prompt)"
+    true (Option.is_none oas_msg)
 
 let test_restore_messages () =
   let oas_msgs : Agent_sdk.Types.message list = [
@@ -133,8 +133,8 @@ let () =
     ];
     "oas_checkpoint_bridge", [
       Alcotest.test_case "message roundtrip" `Quick test_message_roundtrip;
-      Alcotest.test_case "system role maps to user" `Quick
-        test_system_role_maps_to_user;
+      Alcotest.test_case "system role dropped" `Quick
+        test_system_role_dropped;
       Alcotest.test_case "restore messages" `Quick test_restore_messages;
     ];
     "context_oas_sync", [

--- a/test/test_perpetual.ml
+++ b/test/test_perpetual.ml
@@ -729,9 +729,11 @@ let test_integration () = group "Integration" (fun () ->
 
   (* 3f. Llm_client message/usage roundtrip *)
   let test_msg = Llm_client.user_msg "test" in
-  let oas_m = Llm_client.to_oas_message test_msg in
-  let back_m = Llm_client.of_oas_message oas_m in
-  assert_true "oas_adapter:msg_roundtrip" (back_m.content = "test");
+  (match Llm_client.to_oas_message test_msg with
+   | None -> assert_true "oas_adapter:msg_roundtrip" false
+   | Some oas_m ->
+     let back_m = Llm_client.of_oas_message oas_m in
+     assert_true "oas_adapter:msg_roundtrip" (back_m.content = "test"));
 
   let test_usage : Llm_client.token_usage =
     { input_tokens = 100; output_tokens = 50; total_tokens = 150;


### PR DESCRIPTION
## Summary

OAS-MASC 책임 경계 위반 3건 수정.

- **Message Role 손실 수정**: `to_oas_message`가 `option`을 반환하도록 변경. System 메시지는 `None`으로 드롭 (Checkpoint.system_prompt 필드에 이미 포함되므로 중복 제거). 이전에는 System/Tool이 모두 User로 축소되어 역직렬화 시 복원 불가능했음.
- **Checkpoint 파라미터 설정 가능**: `checkpoint_config` 레코드 추가. `thinking_budget`, `response_format_json`, `cache_system_prompt`, `disable_parallel_tool_use` 4개 하드코딩 제거.
- **Tool Bridge 유틸리티**: MASC `(bool * string)` <-> OAS `tool_result` 경계 변환 모듈 추가.

## Changed files

| 파일 | 변경 |
|------|------|
| `lib/llm_client.ml` + `.mli` | `to_oas_message` -> `option` 반환 |
| `lib/oas_checkpoint_bridge.ml` | `checkpoint_config` 추가, `filter_map` 사용 |
| `lib/tool_bridge.ml` (NEW) | OAS 경계 tool result 변환 |
| `lib/perpetual_loop.ml` | `to_oas_checkpoint` unit arg 추가 |
| `test/test_oas_integration.ml` | system role dropped 테스트 |
| `test/test_perpetual.ml` | option 처리 업데이트 |

## Test plan

- [x] `dune build --root .` clean
- [x] 162/162 perpetual tests pass
- [x] 8/8 OAS integration tests pass
- [ ] GLM-5 외부 리뷰

🤖 Generated with [Claude Code](https://claude.com/claude-code)