### PR TITLE
perf(a2a): cache Agent Card with generation-based invalidation

### DIFF
--- a/lib/agent_card.ml
+++ b/lib/agent_card.ml
@@ -413,3 +413,34 @@ let with_extension (card : agent_card) (key : string) (value : Yojson.Safe.t) : 
     @ [(key, value)]
   in
   { card with extensions; updated_at = timestamp }
+
+(* ── Agent Card Cache ─────────────────────────────────────── *)
+
+(** Cached agent card with generation counter for invalidation.
+    The card is generated once on first access and reused until
+    [invalidate_cache] is called (e.g. when tools change). *)
+type cached_card = {
+  card: agent_card;
+  card_json: string;  (** Pre-serialized JSON for fast HTTP response *)
+  generation: int;
+}
+
+let _cache : cached_card option ref = ref None
+let _cache_generation : int ref = ref 0
+
+(** Get cached agent card, generating if needed.
+    [schemas] is used only on first generation or after invalidation.
+    Returns [(card, json_string)] for direct HTTP response. *)
+let get_cached ?(port=8935) ?(host="127.0.0.1") ~schemas () : agent_card * string =
+  let gen = !_cache_generation in
+  match !_cache with
+  | Some c when c.generation = gen -> (c.card, c.card_json)
+  | _ ->
+    let card = generate_default ~port ~host ~schemas () in
+    let json_str = to_json card |> Yojson.Safe.to_string in
+    _cache := Some { card; card_json = json_str; generation = gen };
+    (card, json_str)
+
+(** Invalidate the cached agent card. Call when tools are added/removed. *)
+let invalidate_cache () =
+  incr _cache_generation

--- a/lib/mcp_server_eio.ml
+++ b/lib/mcp_server_eio.ml
@@ -3082,6 +3082,7 @@ let send_resource_updated_notification ~session_id ~uri =
        ~params:(`Assoc [ ("uri", `String uri) ]))
 
 let broadcast_tools_list_changed () =
+  Agent_card.invalidate_cache ();
   Sse.broadcast (jsonrpc_notification "notifications/tools/list_changed")
 
 let dedup_strings items =

--- a/lib/server_auth.ml
+++ b/lib/server_auth.ml
@@ -381,11 +381,10 @@ let serve_agent_card ~host ~port request reqd =
                 (host_name, resolved_port)
             | _ -> (host, port))
       in
-      let card =
-        Agent_card.generate_default ~host:resolved_host
+      let (_card, json) =
+        Agent_card.get_cached ~host:resolved_host
           ~port:resolved_port ~schemas:Config.raw_all_tool_schemas ()
       in
-      let json = Agent_card.to_json card |> Yojson.Safe.to_string in
       let a2a_version = A2a_tools.default_a2a_version in
       Http_server_eio.Response.json ~extra_headers:[ ("A2A-Version", a2a_version) ] json
         reqd)


### PR DESCRIPTION
## Summary

Agent Card was regenerated on every `/.well-known/agent-card.json` request (skills_from_tools hashing + JSON serialization per call). Now cached with generation-based invalidation.

- `get_cached()`: returns `(card, pre-serialized_json)` from module-level cache
- `invalidate_cache()`: increments generation counter, called on `tools/list_changed`
- `server_auth.ml`: uses cached JSON directly (no re-serialization)
- Part of T1.2 in Agent SDK competitive analysis plan

## Changed Files (3)

| File | Change |
|------|--------|
| `lib/agent_card.ml` | +31 lines: cache type, get_cached, invalidate_cache |
| `lib/server_auth.ml` | Use get_cached instead of generate_default |
| `lib/mcp_server_eio.ml` | invalidate_cache on tools/list_changed |

## Test plan

- [x] `test_agent_card_coverage.exe`: 54/54 PASS
- [x] `dune build`: compilation success

🤖 Generated with [Claude Code](https://claude.com/claude-code)