### PR TITLE
fix(deploy): increase Railway healthcheck timeout to 120s

### DIFF
--- a/railway.toml
+++ b/railway.toml
@@ -5,6 +5,6 @@ dockerfilePath = "Dockerfile"
 [deploy]
 startCommand = "sh -c '/app/masc-mcp --port $PORT --base-path /app'"
 healthcheckPath = "/health"
-healthcheckTimeout = 30
+healthcheckTimeout = 120
 restartPolicyType = "on_failure"
 restartPolicyMaxRetries = 3


### PR DESCRIPTION
## Summary
- Railway healthcheck timeout 30s → 120s
- GraphQL agent 로딩이 Eio event loop을 블로킹하여 서버 시작 후 20-40초간 HTTP 응답 불가
- 30초 timeout으로는 배포 실패 (Railway "Deploy failed")

## Test plan
- [ ] Deploy to Railway 성공
- [ ] `curl https://masc.crying.pictures/health` 정상