### PR TITLE
feat(profiles): add Role_filtered tool_profile for mode-based filtering

### DIFF
--- a/lib/mcp_server_eio.ml
+++ b/lib/mcp_server_eio.ml
@@ -17,6 +17,7 @@ type tool_profile =
   | Full
   | Managed_agent
   | Operator_remote
+  | Role_filtered of Mode.mode
 
 (** {1 Network Context for LLM Chain Calls} *)
 
@@ -3186,7 +3187,7 @@ let handle_call_tool_eio ~sw ~clock ?(profile = Full) ?mcp_session_id ?auth_toke
             raise
               (Invalid_argument
                  ("managed agent tool translation failed: " ^ msg)))
-    | Full | Operator_remote ->
+    | Full | Operator_remote | Role_filtered _ ->
         (params |> U.member "name" |> U.to_string, params |> U.member "arguments")
   in
   let is_read_only = Tool_dispatch.is_read_only name in
@@ -3433,6 +3434,9 @@ let tool_schemas_for_profile ?(include_hidden = false) ?(include_deprecated = fa
       dedupe_tool_schemas_by_name
         (Agent_swarm_contract.sdk_tool_schemas @ passthrough)
   | Operator_remote -> Tool_operator.remote_schemas
+  | Role_filtered mode ->
+      let categories = Mode.categories_for_mode mode in
+      Config.enabled_tool_schemas ~include_hidden ~include_deprecated categories
 
 let tool_allowed_in_profile state profile tool_name =
   match profile with
@@ -3442,6 +3446,8 @@ let tool_allowed_in_profile state profile tool_name =
       |> List.exists (fun (schema : Types.tool_schema) ->
              String.equal schema.name tool_name)
   | Operator_remote -> List.mem tool_name Tool_operator.remote_tool_names
+  | Role_filtered mode ->
+      Mode.is_tool_enabled (Mode.categories_for_mode mode) tool_name
 
 let is_destructive_tool_name name =
   let lowered = String.lowercase_ascii name in
@@ -3839,7 +3845,7 @@ let handle_initialize_eio ?(profile = Full) id params =
              ( "instructions",
                `String
                  (match profile with
-                 | Full -> default_instructions
+                 | Full | Role_filtered _ -> default_instructions
                  | Managed_agent -> managed_agent_instructions
                  | Operator_remote -> operator_remote_instructions) );
            ]))

--- a/lib/mcp_server_eio.mli
+++ b/lib/mcp_server_eio.mli
@@ -29,6 +29,7 @@ type tool_profile =
   | Full
   | Managed_agent
   | Operator_remote
+  | Role_filtered of Mode.mode
 
 (** {1 JSON-RPC Helpers (re-exported)} *)
 

--- a/lib/server_h2_gateway.ml
+++ b/lib/server_h2_gateway.ml
@@ -242,7 +242,7 @@ let make_request_handler ~sw ~clock ~server_start_time =
           in
           let auth_result =
             match profile with
-            | Mcp_eio.Full | Mcp_eio.Managed_agent ->
+            | Mcp_eio.Full | Mcp_eio.Managed_agent | Mcp_eio.Role_filtered _ ->
                 verify_mcp_auth ~base_path httpun_request
             | Mcp_eio.Operator_remote ->
                 verify_operator_mcp_auth ~base_path httpun_request
@@ -324,7 +324,7 @@ let make_request_handler ~sw ~clock ~server_start_time =
           in
           let auth_result =
             match profile with
-            | Mcp_eio.Full | Mcp_eio.Managed_agent -> Ok None
+            | Mcp_eio.Full | Mcp_eio.Managed_agent | Mcp_eio.Role_filtered _ -> Ok None
             | Mcp_eio.Operator_remote ->
                 verify_operator_mcp_auth ~base_path httpun_request
           in

--- a/lib/server_mcp_transport_http.ml
+++ b/lib/server_mcp_transport_http.ml
@@ -47,6 +47,7 @@ let profile_label = function
   | Mcp_eio.Full -> "/mcp"
   | Mcp_eio.Managed_agent -> "/mcp/managed"
   | Mcp_eio.Operator_remote -> "/mcp/operator"
+  | Mcp_eio.Role_filtered mode -> Printf.sprintf "/mcp/role/%s" (Mode.mode_to_string mode)
 
 let validate_mcp_session_profile ~profile session_id =
   match Hashtbl.find_opt mcp_profile_by_session session_id with
@@ -70,7 +71,7 @@ let validate_mcp_session_delete_profile ~profile session_id =
           Error
             (Printf.sprintf "Session %s is not registered on %s." session_id
                (profile_label profile)))
-  | Mcp_eio.Full | Mcp_eio.Managed_agent ->
+  | Mcp_eio.Full | Mcp_eio.Managed_agent | Mcp_eio.Role_filtered _ ->
       validate_mcp_session_profile ~profile session_id
 
 let protocol_version_from_body body_str =
@@ -539,7 +540,7 @@ let handle_post_mcp ~deps ?(profile = Mcp_eio.Full) request reqd =
   in
   let auth_result =
     match profile with
-    | Mcp_eio.Full | Mcp_eio.Managed_agent ->
+    | Mcp_eio.Full | Mcp_eio.Managed_agent | Mcp_eio.Role_filtered _ ->
         deps.verify_mcp_auth ~base_path request
     | Mcp_eio.Operator_remote ->
         deps.verify_operator_mcp_auth ~base_path request
@@ -962,7 +963,7 @@ let handle_delete_mcp ~deps ?(profile = Mcp_eio.Full) request reqd =
   in
   let auth_result =
     match profile with
-    | Mcp_eio.Full | Mcp_eio.Managed_agent -> Ok ()
+    | Mcp_eio.Full | Mcp_eio.Managed_agent | Mcp_eio.Role_filtered _ -> Ok ()
     | Mcp_eio.Operator_remote ->
         deps.verify_operator_mcp_auth ~base_path request
   in

--- a/lib/server_mcp_transport_http_admin.ml
+++ b/lib/server_mcp_transport_http_admin.ml
@@ -100,7 +100,7 @@ let handle_delete_mcp ~(deps : deps) ?(profile = Mcp_eio.Full) request reqd =
   in
   let auth_result =
     match profile with
-    | Mcp_eio.Full | Mcp_eio.Managed_agent -> Ok ()
+    | Mcp_eio.Full | Mcp_eio.Managed_agent | Mcp_eio.Role_filtered _ -> Ok ()
     | Mcp_eio.Operator_remote ->
         deps.verify_operator_mcp_auth ~base_path request
   in

--- a/lib/server_mcp_transport_http_mcp_handlers.ml
+++ b/lib/server_mcp_transport_http_mcp_handlers.ml
@@ -23,7 +23,7 @@ let handle_post_mcp ~(deps : deps) ?(profile = Mcp_eio.Full) request reqd =
   in
   let auth_result =
     match profile with
-    | Mcp_eio.Full | Mcp_eio.Managed_agent ->
+    | Mcp_eio.Full | Mcp_eio.Managed_agent | Mcp_eio.Role_filtered _ ->
         deps.verify_mcp_auth ~base_path request
     | Mcp_eio.Operator_remote ->
         deps.verify_operator_mcp_auth ~base_path request

--- a/lib/server_mcp_transport_http_session.ml
+++ b/lib/server_mcp_transport_http_session.ml
@@ -33,6 +33,7 @@ let profile_label = function
   | Mcp_eio.Full -> "/mcp"
   | Mcp_eio.Managed_agent -> "/mcp/managed"
   | Mcp_eio.Operator_remote -> "/mcp/operator"
+  | Mcp_eio.Role_filtered mode -> Printf.sprintf "/mcp/role/%s" (Mode.mode_to_string mode)
 
 let validate_mcp_session_profile ~profile session_id =
   match Hashtbl.find_opt mcp_profile_by_session session_id with
@@ -56,7 +57,7 @@ let validate_mcp_session_delete_profile ~profile session_id =
           Error
             (Printf.sprintf "Session %s is not registered on %s." session_id
                (profile_label profile)))
-  | Mcp_eio.Full | Mcp_eio.Managed_agent ->
+  | Mcp_eio.Full | Mcp_eio.Managed_agent | Mcp_eio.Role_filtered _ ->
       validate_mcp_session_profile ~profile session_id
 
 let protocol_version_from_body body_str =


### PR DESCRIPTION
## Summary

Extends `tool_profile` with `Role_filtered(mode)` variant that maps `Mode.mode` (Minimal/Standard/Parallel/Coding/etc.) directly to tool filtering profiles. Enables role-specific MCP endpoints like `/mcp/role/coding`.

- T3.4 in Agent SDK competitive analysis plan
- 7 files updated for exhaustive match handling
- `Role_filtered` behaves like `Full` for auth/instructions, filtered by mode categories for tool selection

## Test plan

- [x] `dune build`: 0 errors
- [x] `test_agent_card_coverage.exe`: 54/54 PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)