### PR TITLE
fix(deploy): temporarily disable Railway healthcheck

### DIFF
--- a/railway.toml
+++ b/railway.toml
@@ -4,7 +4,8 @@ dockerfilePath = "Dockerfile"
 
 [deploy]
 startCommand = "sh -c '/app/masc-mcp --port $PORT --base-path /app'"
-healthcheckPath = "/health"
-healthcheckTimeout = 120
+# healthcheckPath = "/health"
+# healthcheckTimeout = 120
+# TODO: re-enable after making GraphQL/Lodge init non-blocking (blocks Eio event loop)
 restartPolicyType = "on_failure"
 restartPolicyMaxRetries = 3


### PR DESCRIPTION
Railway healthcheck 일시 비활성화. GraphQL/Lodge init이 Eio event loop을 블로킹하여 시작 시 HTTP 응답 불가. 비동기 init 구현 후 재활성화.