### PR TITLE
refactor(keeper_turn): narrow catch-all handlers with log_keeper_exn

### DIFF
--- a/lib/keeper_turn.ml
+++ b/lib/keeper_turn.ml
@@ -393,7 +393,7 @@ let handle_keeper_up ctx args : tool_result =
              in
              let ctx0 = Context_manager.create ~system_prompt ~max_tokens:primary.max_context in
              (try ignore (save_checkpoint session ctx0 ~generation:0)
-              with exn -> Printf.eprintf "[keeper] save_checkpoint (init) failed: %s\n%!" (Printexc.to_string exn));
+              with exn -> log_keeper_exn ~label:"save_checkpoint (init) failed" exn);
              let meta = {
                name;
                agent_name = keeper_agent_name name;
@@ -1479,7 +1479,7 @@ let handle_keeper_msg ctx args : tool_result =
                 in
                 let ctx0 = Context_manager.create ~system_prompt ~max_tokens:primary.max_context in
                 (try ignore (save_checkpoint session ctx0 ~generation:0)
-                 with exn -> Printf.eprintf "[keeper] save_checkpoint (ensure) failed: %s\n%!" (Printexc.to_string exn));
+                 with exn -> log_keeper_exn ~label:"save_checkpoint (ensure) failed" exn);
                 match write_meta ctx.config meta with
                 | Error e -> Error e
                 | Ok () -> Ok meta))
@@ -1576,7 +1576,7 @@ let handle_keeper_msg ctx args : tool_result =
             updated_at = now_iso ();
           } in
           (try ignore (write_meta ctx.config updated)
-           with exn -> Printf.eprintf "[keeper] write_meta (settings) failed: %s\n%!" (Printexc.to_string exn));
+           with exn -> log_keeper_exn ~label:"write_meta (settings) failed" exn);
           updated
       in
       start_keepalive ctx meta;
@@ -1769,7 +1769,7 @@ let handle_keeper_msg ctx args : tool_result =
             match run_cascade requests with
             | Error e ->
               (try ignore (Trajectory.finalize trajectory_acc (Trajectory.Failed e))
-               with exn -> Printf.eprintf "[keeper] trajectory finalize (error path) failed: %s\n%!" (Printexc.to_string exn));
+               with exn -> log_keeper_exn ~label:"trajectory finalize (error path) failed" exn);
               (false, Printf.sprintf "❌ LLM failed: %s" e)
             | Ok resp0 ->
               let used_model0 =
@@ -2245,7 +2245,7 @@ let handle_keeper_msg ctx args : tool_result =
               in
 
               (try ignore (save_checkpoint session ctx_work ~generation:meta_turn.generation)
-               with exn -> Printf.eprintf "[keeper] save_checkpoint (turn) failed: %s\n%!" (Printexc.to_string exn));
+               with exn -> log_keeper_exn ~label:"save_checkpoint (turn) failed" exn);
 
 		              let handoff_eval =
                 let auto_rules =
@@ -2281,7 +2281,7 @@ let handle_keeper_msg ctx args : tool_result =
                                    ~default:"policy threshold exceeded"
                                    auto_rules.guardrail_reason)))
                     with exn ->
-                      Printf.eprintf "[keeper] room broadcast (guardrail_stop) failed: %s\n%!" (Printexc.to_string exn));
+                      log_keeper_exn ~label:"room broadcast (guardrail_stop) failed" exn);
                    (* SSE: keeper_guardrail — dashboard real-time alert *)
                    (try Sse.broadcast (`Assoc [
                      ("type", `String "keeper_guardrail");
@@ -2289,7 +2289,7 @@ let handle_keeper_msg ctx args : tool_result =
                      ("reason", `String (Option.value ~default:"policy threshold exceeded"
                         auto_rules.guardrail_reason));
                    ]) with exn ->
-                     Printf.eprintf "[keeper] SSE keeper_guardrail broadcast failed: %s\n%!" (Printexc.to_string exn)));
+                     log_keeper_exn ~label:"SSE keeper_guardrail broadcast failed" exn));
                 let do_handoff =
                   auto_rules.handoff &&
 		                (now_ts -. meta_turn.last_handoff_ts >= float_of_int meta_turn.handoff_cooldown_sec)
@@ -2440,7 +2440,7 @@ let handle_keeper_msg ctx args : tool_result =
                    ] in
                    append_jsonl_line metrics_path metrics_json
                  with exn ->
-                   Printf.eprintf "[keeper] turn metrics JSONL write failed: %s\n%!" (Printexc.to_string exn));
+                   log_keeper_exn ~label:"turn metrics JSONL write failed" exn);
                 (* Harness: finalize trajectory with outcome *)
                 (let traj_outcome =
                   if trajectory_acc.Trajectory.total_cost >= gate_config.Eval_gate.max_cost_usd then
@@ -2464,7 +2464,7 @@ let handle_keeper_msg ctx args : tool_result =
                     ("trigger", match compaction_trigger with
                       | Some r -> `String r | None -> `Null);
                   ]) with exn ->
-                    Printf.eprintf "[keeper] SSE keeper_compaction broadcast failed: %s\n%!" (Printexc.to_string exn)));
+                    log_keeper_exn ~label:"SSE keeper_compaction broadcast failed" exn));
                 (* SSE: keeper_turn_complete — emitted on every normal turn finish *)
                 (try Sse.broadcast (`Assoc [
                   ("type", `String "keeper_turn_complete");
@@ -2476,8 +2476,7 @@ let handle_keeper_msg ctx args : tool_result =
                   ("context_ratio", `Float ctx_ratio);
                   ("model_used", `String final_model_used);
                 ]) with exn ->
-                  Printf.eprintf "[keeper] SSE keeper_turn_complete broadcast failed: %s\n%!"
-                    (Printexc.to_string exn));
+                  log_keeper_exn ~label:"SSE keeper_turn_complete broadcast failed" exn);
 
                 let json = `Assoc [
                   ("name", `String meta_turn.name);
@@ -2600,7 +2599,7 @@ let handle_keeper_msg ctx args : tool_result =
                 let successor_session = Context_manager.create_session
                   ~session_id:successor_trace ~base_dir in
                 (try ignore (save_checkpoint successor_session successor_ctx ~generation:next_generation)
-                 with exn -> Printf.eprintf "[keeper] save_checkpoint (succession) failed: %s\n%!" (Printexc.to_string exn));
+                 with exn -> log_keeper_exn ~label:"save_checkpoint (succession) failed" exn);
 
                 let prev_trace_id = meta_turn.trace_id in
                 let trace_history = take 20 (prev_trace_id :: meta_turn.trace_history) in
@@ -2612,7 +2611,7 @@ let handle_keeper_msg ctx args : tool_result =
                   updated_at = now_iso ();
                 } in
                 (try ignore (write_meta ctx.config meta')
-                 with exn -> Printf.eprintf "[keeper] write_meta (succession) failed: %s\n%!" (Printexc.to_string exn));
+                 with exn -> log_keeper_exn ~label:"write_meta (succession) failed" exn);
 
                 (try
                    let metrics_json = `Assoc [
@@ -2715,7 +2714,7 @@ let handle_keeper_msg ctx args : tool_result =
                    ] in
                    append_jsonl_line metrics_path metrics_json
                  with exn ->
-                   Printf.eprintf "[keeper] handoff metrics JSONL write failed: %s\n%!" (Printexc.to_string exn));
+                   log_keeper_exn ~label:"handoff metrics JSONL write failed" exn);
                 (* SSE: keeper_handoff — generation succession event *)
                 (try Sse.broadcast (`Assoc [
                   ("type", `String "keeper_handoff");
@@ -2724,7 +2723,7 @@ let handle_keeper_msg ctx args : tool_result =
                   ("to_generation", `Int next_generation);
                   ("to_model", `String next_model.model_id);
                 ]) with exn ->
-               Printf.eprintf "[keeper] SSE keeper_handoff broadcast failed: %s\n%!" (Printexc.to_string exn));
+               log_keeper_exn ~label:"SSE keeper_handoff broadcast failed" exn);
 
                 let json = `Assoc [
                   ("name", `String meta'.name);
@@ -2924,8 +2923,7 @@ let handle_keeper_down ctx args : tool_result =
         if validate_name m.trace_id then (
           let dir = Filename.concat (session_base_dir ctx.config) m.trace_id in
           try rm_rf dir with exn ->
-            Printf.eprintf "[keeper] session dir cleanup failed: %s\n%!"
-              (Printexc.to_string exn)));
+            log_keeper_exn ~label:"session dir cleanup failed" exn));
       let json = `Assoc [
         ("name", `String name);
         ("stopped", `Bool true);


### PR DESCRIPTION
## Summary

Train 3.2 — error handling narrowing for keeper_turn.ml.

15 of 16 catch-all patterns converted to `log_keeper_exn` (reuses helper from #1173). 1 pattern excluded (stores error string as data, not logging).

| Category | Count |
|----------|-------|
| save_checkpoint | 3 |
| SSE broadcast | 4 |
| write_meta | 2 |
| metrics JSONL | 2 |
| room broadcast | 1 |
| trajectory finalize | 1 |
| session cleanup | 1 |
| guardrail stop | 1 |

No behavior change. Net: -17 lines, +15 lines.

## Test plan

- [x] `dune build --root .` passes
- [ ] CI


🤖 Generated with [Claude Code](https://claude.com/claude-code)