### PR TITLE
fix(deploy): early HTTP binding for Railway healthcheck

### DIFF
--- a/lib/server_runtime_bootstrap.ml
+++ b/lib/server_runtime_bootstrap.ml
@@ -265,14 +265,8 @@ let run ~sw ~env ~host ~port ~base_path ~make_routes ~make_request_handler
   let clock, mono_clock, net, domain_mgr, proc_mgr, fs =
     init_runtime_context env
   in
-  let state =
-    create_server_state ~sw ~base_path ~clock ~mono_clock ~net ~proc_mgr ~fs
-  in
-  bootstrap_server_state state;
-  bootstrap_keepers ~sw ~clock state;
-  init_task_backend ();
-  (* HTTP server starts FIRST — resident loops (GraphQL, Lodge, Sentinel)
-     run in a background fiber to avoid blocking /health during startup. *)
+
+  (* 1. HTTP socket first — Railway healthcheck can reach /health immediately *)
   let config = make_http_config ~host ~port in
   let routes = make_routes ~port:config.port ~host:config.host ~sw ~clock in
   let request_handler = make_request_handler routes in
@@ -281,10 +275,21 @@ let run ~sw ~env ~host ~port ~base_path ~make_routes ~make_request_handler
   in
   let _h2_error_handler = make_h2_error_handler () in
   let socket = listen_socket ~sw ~net config in
-  let resolved_base, masc_dir =
-    start_background_maintenance ~sw ~clock state
-  in
-  print_startup_banner ~config ~resolved_base ~base_path ~masc_dir;
+
+  (* 2. All init in background fiber (PG connect 3s + Lodge GraphQL 20-40s) *)
   Eio.Fiber.fork ~sw (fun () ->
-    start_resident_loops ~sw ~clock ~net ~domain_mgr ~proc_mgr state);
+    let state =
+      create_server_state ~sw ~base_path ~clock ~mono_clock ~net ~proc_mgr ~fs
+    in
+    bootstrap_server_state state;
+    bootstrap_keepers ~sw ~clock state;
+    init_task_backend ();
+    let resolved_base, masc_dir =
+      start_background_maintenance ~sw ~clock state
+    in
+    print_startup_banner ~config ~resolved_base ~base_path ~masc_dir;
+    start_resident_loops ~sw ~clock ~net ~domain_mgr ~proc_mgr state
+  );
+
+  (* 3. Start serving — /health responds before init completes *)
   serve ~sw ~clock ~socket ~request_handler


### PR DESCRIPTION
## Summary
- HTTP 소켓을 서버 초기화 전에 바인딩하여 Railway healthcheck가 즉시 `/health`에 도달 가능
- `create_server_state`, `bootstrap_server_state`, `bootstrap_keepers`, `start_resident_loops` 모두 `Eio.Fiber.fork ~sw` 백그라운드 fiber로 이동
- `/health` 응답 시간: **23-43초 → ~2초** (PG 연결 + Lodge GraphQL 로드 대기 제거)
- `agent_swarm_runner.ml`의 `Custom_registered` 패턴 매치 누락도 수정 (기존 빌드 에러)

## 변경 내용

| 파일 | 변경 |
|------|------|
| `lib/server_runtime_bootstrap.ml` | `run` 함수의 초기화 순서 재구성 — HTTP bind first, heavy init in fiber |
| `lib/agent_swarm_runner.ml` | `Custom_registered` exhaustive match 추가 |

## 설계 근거
- `make_routes`는 `~port ~host ~sw ~clock`만 받으며 `state`에 의존하지 않음
- `/health`는 stateless — `version`과 `"ok"` 반환만 하므로 초기화 전에도 안전
- governance endpoint(`/api/v1/governance/cases/`)는 `!server_state = None`일 때 `{"error":"not initialized"}` 반환 (기존 동작)
- `Eio.Fiber.fork ~sw`는 Switch 범위 내에서 구조적 동시성 보장

## Test plan
- [x] `dune build --root .` — 빌드 성공
- [x] 로컬 서버 기동 후 2.8초에 `/health` HTTP 200 확인
- [ ] Railway 배포 후 healthcheck 통과 확인
- [ ] 기존 `make test` 통과 확인 (MCP reconnection flaky test 제외)

🤖 Generated with [Claude Code](https://claude.com/claude-code)