### PR TITLE
chore: bump version to 2.97.0

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -1,7 +1,7 @@
 (lang dune 3.13)
 
 (name masc_mcp)
-(version 2.96.0)
+(version 2.97.0)
 
 (generate_opam_files true)
 


### PR DESCRIPTION
## Summary

- Version bump: 2.96.0 → 2.97.0
- Includes: catch-all cleanup (#1184), operator TTL cache (#1176), mcp_server catch-all narrowing (#1177)

🤖 Generated with [Claude Code](https://claude.com/claude-code)