### PR TITLE
fix(build): resolve unbound log_keeper_exn and partial-match errors

### DIFF
--- a/lib/agent_swarm_runner.ml
+++ b/lib/agent_swarm_runner.ml
@@ -90,7 +90,11 @@ let run_solo ~sw ~net ~clock ~proc_mgr config =
     | Provider.Local { base_url } -> base_url
     | Provider.Anthropic -> Api.default_base_url
     | Provider.Ollama { base_url; _ } -> base_url
-    | Provider.OpenAICompat { base_url; _ } -> base_url in
+    | Provider.OpenAICompat { base_url; _ } -> base_url
+    | Provider.Custom_registered _ ->
+        (match Provider.resolve provider_cfg with
+         | Ok (base_url, _, _) -> base_url
+         | Error _ -> "http://127.0.0.1:8085") in
   let dev_tools =
     Agent_swarm_dev_tools.make_tools ~proc_mgr ~clock ~workdir:config.workdir ()
   in

--- a/lib/keeper_execution.mli
+++ b/lib/keeper_execution.mli
@@ -31,6 +31,13 @@ type social_turn_outcome = {
   failure_reason : string option;
 }
 
+(** {1 Error Logging} *)
+
+(** Log a keeper error with [UNEXPECTED] tag for unrecognized exceptions.
+    Known IO/parse exceptions get a plain log; anything else is tagged for triage.
+    No re-raise — side-effect-only, does not change control flow. *)
+val log_keeper_exn : label:string -> exn -> unit
+
 (** {1 Context and Checkpoint} *)
 
 (** Load keeper context from checkpoint for resumption. *)


### PR DESCRIPTION
## Summary
- Export `log_keeper_exn` in `keeper_execution.mli` so `keeper_turn.ml` (which `open`s `Keeper_execution`) can access the error-logging helper. The function was defined in PR #1173 but the `.mli` was not updated to expose it.
- Add the missing `Custom_registered _` case in `agent_swarm_runner.ml`'s pattern match on `Provider.provider`, resolving the base URL via `Provider.resolve` with a local fallback.

## Test plan
- [x] `dune build --root .` passes with zero errors and zero warnings-as-errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)