### PR TITLE
chore: bump version to 2.98.0

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -1,7 +1,7 @@
 (lang dune 3.13)
 
 (name masc_mcp)
-(version 2.97.0)
+(version 2.98.0)
 
 (generate_opam_files true)
 


### PR DESCRIPTION
## Summary

- Version bump: 2.97.0 → 2.98.0
- Includes: 21-bug campaign (#1180), dashboard/trpg module split (#1181, #1182), deploy fixes (#1183, #1192)

🤖 Generated with [Claude Code](https://claude.com/claude-code)