### PR TITLE
refactor(keeper): extract hardcoded temperature/threshold values into env config

### DIFF
--- a/lib/keeper_config.ml
+++ b/lib/keeper_config.ml
@@ -383,6 +383,66 @@ let keeper_proactive_similarity_threshold () : float =
     ~max_v:1.0
 
 (* ================================================================ *)
+(* Keeper execution parameters (previously hardcoded)               *)
+(* ================================================================ *)
+
+let keeper_proactive_max_tokens () : int =
+  int_of_env_default
+    "MASC_KEEPER_PROACTIVE_MAX_TOKENS"
+    ~default:1024
+    ~min_v:128
+    ~max_v:4096
+
+let keeper_deterministic_temp () : float =
+  float_of_env_default
+    "MASC_KEEPER_DETERMINISTIC_TEMP"
+    ~default:0.3
+    ~min_v:0.0
+    ~max_v:2.0
+
+let keeper_reflection_temp () : float =
+  float_of_env_default
+    "MASC_KEEPER_REFLECTION_TEMP"
+    ~default:0.6
+    ~min_v:0.0
+    ~max_v:2.0
+
+let keeper_planning_temp () : float =
+  float_of_env_default
+    "MASC_KEEPER_PLANNING_TEMP"
+    ~default:0.35
+    ~min_v:0.0
+    ~max_v:2.0
+
+let keeper_batch_limit () : int =
+  int_of_env_default
+    "MASC_KEEPER_BATCH_LIMIT"
+    ~default:200
+    ~min_v:10
+    ~max_v:2000
+
+let keeper_msg_timeout_max_sec () : int =
+  int_of_env_default
+    "MASC_KEEPER_MSG_TIMEOUT_MAX_SEC"
+    ~default:300
+    ~min_v:5
+    ~max_v:3600
+
+let keeper_cost_gate_usd () : float =
+  float_of_env_default
+    "MASC_KEEPER_COST_GATE_USD"
+    ~default:0.10
+    ~min_v:0.01
+    ~max_v:10.0
+
+let keeper_tool_cost_max_usd () : float =
+  float_of_env_default
+    "MASC_KEEPER_TOOL_COST_MAX_USD"
+    ~default:0.50
+    ~min_v:0.01
+    ~max_v:50.0
+
+(* ================================================================ *)
 (* Rule engine thresholds                                           *)
 (* ================================================================ *)
 

--- a/lib/keeper_execution.ml
+++ b/lib/keeper_execution.ml
@@ -750,7 +750,7 @@ let run_proactive_generation
                  (Llm_client.system_msg turn_system_prompt)
                  :: (ctx_work.messages @ [ Llm_client.user_msg prompt ]);
                temperature = proactive_temperature attempt;
-               max_tokens = 1024; (* increased from 220 to allow tool calls *)
+               max_tokens = Keeper_config.keeper_proactive_max_tokens ();
                tools = keeper_allowed_llm_tools meta;
                response_format = `Text;
              }
@@ -818,8 +818,8 @@ let run_proactive_generation
                                ~character_context:turn_system_prompt);
                           Llm_client.user_msg followup_prompt;
                         ];
-                        temperature = 0.3;
-                        max_tokens = 1024; (* increased from 220 to allow tool calls *)
+                        temperature = Keeper_config.keeper_deterministic_temp ();
+                        max_tokens = Keeper_config.keeper_proactive_max_tokens ();
                         tools = next_tools;
                         response_format = `Text;
                       }
@@ -960,7 +960,7 @@ let autonomous_gate_config
   | L4_Autonomous ->
       (* L4: allow bash for safe commands *)
       {
-        max_cost_usd = 0.10;
+        max_cost_usd = Keeper_config.keeper_cost_gate_usd ();
         max_tool_calls_per_turn = 5;
         entropy_threshold = 2;
         destructive_check_enabled = true;
@@ -971,7 +971,7 @@ let autonomous_gate_config
   | L5_Independent ->
       (* L5: all tools allowed, higher budget *)
       {
-        max_cost_usd = 0.50;
+        max_cost_usd = Keeper_config.keeper_tool_cost_max_usd ();
         max_tool_calls_per_turn = 10;
         entropy_threshold = 3;
         destructive_check_enabled = true;
@@ -982,7 +982,7 @@ let autonomous_gate_config
   | _ ->
       (* L3 and below: strict safe-only *)
       {
-        max_cost_usd = 0.10;
+        max_cost_usd = Keeper_config.keeper_cost_gate_usd ();
         max_tool_calls_per_turn = 5;
         entropy_threshold = 2;
         destructive_check_enabled = true;
@@ -1081,8 +1081,8 @@ Do NOT use destructive tools (bash rm, edit, delete).|}
         Llm_client.system_msg system_prompt;
         Llm_client.user_msg "Execute the first step of the plan now.";
       ];
-      temperature = 0.3;
-      max_tokens = 1024;
+      temperature = Keeper_config.keeper_deterministic_temp ();
+      max_tokens = Keeper_config.keeper_proactive_max_tokens ();
       tools = keeper_allowed_llm_tools meta;
       response_format = `Text;
     }
@@ -1129,8 +1129,8 @@ Do NOT use destructive tools (bash rm, edit, delete).|}
                 Llm_client.system_msg system_prompt;
                 Llm_client.user_msg followup_prompt;
               ];
-              temperature = 0.3;
-              max_tokens = 1024;
+              temperature = Keeper_config.keeper_deterministic_temp ();
+              max_tokens = Keeper_config.keeper_proactive_max_tokens ();
               tools = next_tools;
               response_format = `Text;
             }
@@ -2255,7 +2255,7 @@ let generate_explicit_room_reply (ctx : _ context) ~(meta : keeper_meta) ~(room_
                 ({
                   Llm_client.model;
                   messages = (Llm_client.system_msg ctx_work.system_prompt) :: ctx_work.messages;
-                  temperature = 0.6;
+                  temperature = Keeper_config.keeper_reflection_temp ();
                   max_tokens = 256;
                   tools = [];
                   response_format = `Text;
@@ -2421,7 +2421,7 @@ let run_social_board_event_turn
                     messages =
                       (Llm_client.system_msg ctx_work.system_prompt)
                       :: (ctx_work.messages @ [ Llm_client.user_msg prompt ]);
-                    temperature = 0.35;
+                    temperature = Keeper_config.keeper_planning_temp ();
                     max_tokens = 768;
                     tools = keeper_allowed_llm_tools meta;
                     response_format = `Text;
@@ -2488,7 +2488,7 @@ let run_social_board_event_turn
                                    ~character_context:ctx_work.system_prompt);
                               Llm_client.user_msg followup_prompt;
                             ];
-                            temperature = 0.3;
+                            temperature = Keeper_config.keeper_deterministic_temp ();
                             max_tokens = 512;
                             tools = next_tools;
                             response_format = `Text;
@@ -2752,7 +2752,7 @@ let maybe_emit_explicit_room_replies (ctx : _ context) (meta : keeper_meta) : ke
     let targets =
       if meta.mention_targets <> [] then meta.mention_targets else [ meta.name ]
     in
-    let batch_limit = 200 in
+    let batch_limit = Keeper_config.keeper_batch_limit () in
     let next_meta =
       List.fold_left
         (fun meta_acc room_id ->

--- a/lib/keeper_turn.ml
+++ b/lib/keeper_turn.ml
@@ -2093,7 +2093,7 @@ let handle_keeper_msg ctx args : tool_result =
       Safe_ops.json_float_opt "timeout_sec" args
       |> Option.map (fun v ->
              let sec = int_of_float (Float.ceil v) in
-             max 5 (min 300 sec))
+             max 5 (min (Keeper_config.keeper_msg_timeout_max_sec ()) sec))
     in
     match inline_soul_profile_res, new_soul_profile_res with
     | Error e, _ | _, Error e -> (false, "❌ " ^ e)


### PR DESCRIPTION
## Summary

- keeper_execution.ml과 keeper_turn.ml에 하드코딩된 11개 값을 `Keeper_config` 환경변수 함수로 추출
- 기본값은 기존과 동일 — 환경변수 미설정 시 동작 변경 없음
- 모든 값에 min/max clamp 적용 (잘못된 환경변수로 인한 폭주 방지)

### 새 환경변수 8개

| 환경변수 | 기본값 | 용도 |
|---------|--------|------|
| `MASC_KEEPER_PROACTIVE_MAX_TOKENS` | 1024 | proactive/tool loop max_tokens |
| `MASC_KEEPER_DETERMINISTIC_TEMP` | 0.3 | tool followup, verifier, correction |
| `MASC_KEEPER_REFLECTION_TEMP` | 0.6 | reflection context |
| `MASC_KEEPER_PLANNING_TEMP` | 0.35 | planning context |
| `MASC_KEEPER_BATCH_LIMIT` | 200 | room message batch fetch |
| `MASC_KEEPER_MSG_TIMEOUT_MAX_SEC` | 300 | msg timeout upper bound |
| `MASC_KEEPER_COST_GATE_USD` | 0.10 | L3/L4 autonomy cost gate |
| `MASC_KEEPER_TOOL_COST_MAX_USD` | 0.50 | L5 autonomy cost gate |

### 변경 파일

- `lib/keeper_config.ml` — 8개 config 함수 추가 (+60줄)
- `lib/keeper_execution.ml` — 하드코딩 → config 함수 호출 (14개 치환)
- `lib/keeper_turn.ml` — timeout 300 → config 함수 (1개 치환)

## Test plan

- [x] `dune build` 에러 수 main과 동일 (기존 OAS 이슈 1건, 본 변경 무관)
- [x] 하드코딩 잔존 grep 검증: `temperature = 0.`, `max_cost_usd = 0.`, `batch_limit = 200`, `min 300 sec` — 모두 0건
- [ ] 환경변수 오버라이드 동작 확인 (수동)

🤖 Generated with [Claude Code](https://claude.com/claude-code)