### PR TITLE
fix(build): update OAS Raw_trace API for v0.29.0

### DIFF
--- a/lib/tool_team_session_support.ml
+++ b/lib/tool_team_session_support.ml
@@ -488,7 +488,7 @@ let raw_trace_session_payloads ~config ~fallback_session_id
         ( Oas.Raw_trace.run_summary_to_yojson summary,
           Oas.Raw_trace.run_validation_to_yojson validation )
   | _ -> (
-      match Oas.Raw_trace.summarize_run run_ref, Oas.Raw_trace.validate_run run_ref with
+      match Oas.Raw_trace_query.summarize_run run_ref, Oas.Raw_trace_query.validate_run run_ref with
       | Ok summary, Ok validation ->
           Some
             ( Oas.Raw_trace.run_summary_to_yojson summary,


### PR DESCRIPTION
## Summary
- OAS PR #97 extracted `Raw_trace.summarize_run` and `Raw_trace.validate_run` into a new `Raw_trace_query` module
- Updated `tool_team_session_support.ml` to use `Oas.Raw_trace_query.summarize_run` / `validate_run`
- Build verified clean (`dune build --root .` exit 0)

## Test plan
- [x] `dune build --root .` passes (clean build, exit 0)
- [x] No remaining references to old `Oas.Raw_trace.summarize_run` / `validate_run` API

Generated with [Claude Code](https://claude.com/claude-code)