### PR TITLE
fix(gc): cleanup dead topology units (#1142)

### DIFF
--- a/lib/room_gc.ml
+++ b/lib/room_gc.ml
@@ -313,9 +313,78 @@ let gc config ?(days=7) () =
   else
     results := "✅ No team sessions to archive" :: !results;
 
+  (* 7. Cleanup dead topology units (leader offline, 0 live roster, stale).
+     Read/write units.json directly to avoid Cp_io dependency cycle. *)
+  let dead_unit_count = ref 0 in
+  let cp_dir = Filename.concat (Filename.concat config.base_path ".masc") "control-plane" in
+  let units_file = Filename.concat cp_dir "units.json" in
+  (try
+    if Sys.file_exists units_file then begin
+      let json = Yojson.Safe.from_file units_file in
+      let unit_rows = match json with
+        | `Assoc fields -> (match List.assoc_opt "units" fields with
+            | Some (`List rows) -> rows | _ -> [])
+        | `List rows -> rows
+        | _ -> []
+      in
+      if unit_rows <> [] then begin
+        (* Collect active agent names from the agents directory *)
+        let agents_dir = Filename.concat (Filename.concat config.base_path ".masc") "agents" in
+        let active_agent_names =
+          if Sys.file_exists agents_dir && Sys.is_directory agents_dir then
+            Sys.readdir agents_dir |> Array.to_list
+            |> List.filter_map (fun fname ->
+              if Filename.check_suffix fname ".json" then
+                try
+                  let agent_json = Yojson.Safe.from_file (Filename.concat agents_dir fname) in
+                  let status = Yojson.Safe.Util.(member "status" agent_json |> to_string_option)
+                    |> Option.value ~default:"offline" in
+                  let name = Yojson.Safe.Util.(member "name" agent_json |> to_string_option) in
+                  if status <> "offline" then name else None
+                with _ -> None
+              else None)
+          else []
+        in
+        let is_dead unit_json =
+          let leader = Yojson.Safe.Util.(member "leader_id" unit_json |> to_string_option) in
+          let roster = match Yojson.Safe.Util.member "roster" unit_json with
+            | `List items -> List.filter_map Yojson.Safe.Util.to_string_option items
+            | _ -> []
+          in
+          let updated = Yojson.Safe.Util.(member "updated_at" unit_json |> to_string_option)
+            |> Option.value ~default:"" in
+          let leader_offline = match leader with
+            | None -> true
+            | Some l -> not (List.mem l active_agent_names)
+          in
+          let live_roster = List.filter (fun m -> List.mem m active_agent_names) roster in
+          leader_offline && live_roster = [] && updated <> "" && updated < cutoff_iso
+        in
+        let kept = List.filter (fun u -> not (is_dead u)) unit_rows in
+        let removed = List.length unit_rows - List.length kept in
+        if removed > 0 then begin
+          let out_json = `Assoc [
+            ("version", `String "cp-v2");
+            ("updated_at", `String (now_iso ()));
+            ("units", `List kept);
+          ] in
+          let oc = open_out units_file in
+          output_string oc (Yojson.Safe.pretty_to_string out_json);
+          close_out oc;
+          dead_unit_count := removed
+        end
+      end
+    end
+  with exn ->
+    Printf.eprintf "[gc] topology unit cleanup failed: %s\n%!" (Printexc.to_string exn));
+  if !dead_unit_count > 0 then
+    results := Printf.sprintf "Removed %d dead topology unit(s) (leader offline, empty roster, stale)" !dead_unit_count :: !results
+  else
+    results := "No dead topology units" :: !results;
+
   (* Log event *)
   log_event config (Printf.sprintf
-    "{\"type\":\"gc\",\"stale_tasks\":%d,\"old_messages\":%d,\"preserved\":%d,\"pubsub_cleaned\":%d,\"keeper_orphans\":%d,\"sessions_archived\":%d,\"days\":%d,\"ts\":\"%s\"}"
-    !stale_count !old_msg_count !preserved_count !pubsub_cleanup_count !keeper_orphan_count !session_archive_count days (now_iso ()));
+    "{\"type\":\"gc\",\"stale_tasks\":%d,\"old_messages\":%d,\"preserved\":%d,\"pubsub_cleaned\":%d,\"keeper_orphans\":%d,\"sessions_archived\":%d,\"dead_units\":%d,\"days\":%d,\"ts\":\"%s\"}"
+    !stale_count !old_msg_count !preserved_count !pubsub_cleanup_count !keeper_orphan_count !session_archive_count !dead_unit_count days (now_iso ()));
 
   String.concat "\n" (List.rev !results)


### PR DESCRIPTION
## Summary

- `masc_gc`에 dead topology unit 자동 정리 기능 추가 (step 7)
- 조건: leader offline + roster 0명 active + updated_at이 GC threshold보다 오래됨
- units.json에서 dead unit을 제거하여 alert fatigue 해소

## Changes

- `lib/room_gc.ml` — GC 함수에 dead topology unit 정리 단계 추가
  - agents 디렉토리에서 active agent 목록 수집
  - units.json의 각 unit에 대해 leader/roster 활성 여부 + 날짜 판단
  - dead unit 제거 후 units.json 재작성

## Design Note

`Cp_io.read_units`/`write_units` 대신 직접 파일 읽기를 사용. 이유:
- `Room` → `Room_gc` → `Cp_io` → `Room` 순환 의존 방지
- TODO: Cp_io에서 Room 의존을 분리하면 canonical path로 전환 가능

## Test plan

- [ ] `dune build --root .` — 빌드 성공
- [ ] dead unit이 있는 상태에서 `masc_gc` 실행 → unit 제거 확인
- [ ] active unit이 있는 상태에서 `masc_gc` 실행 → unit 보존 확인

Closes #1142

🤖 Generated with [Claude Code](https://claude.com/claude-code)