### PR TITLE
chore: bump version to 2.99.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,28 @@
 # Changelog
 
 
+## [2.99.0] - 2026-03-16
+
+### Fixed
+- **Social system recovery** — sentinel auto-brief for governance deadlock, social eligibility relaxation, Standard+Consensus mode (#1179)
+- **QA AS1 critical+high bugs** — zombie detection, agent count, LLM permit, governance race condition, decision TTL, claim guard (#1196)
+- **Cloudflare Rocket Loader** — `data-cfasync="false"` on dashboard script tags
+- **Exhaustive match** — `Provider.Custom_registered` in agent_swarm_runner
+
+### Changed (God File Refactoring Campaign)
+- **keeper_turn** — split into 6 focused sub-modules: init, settings, handoff, context, metrics, response (#1199)
+- **keeper_execution** — split 2823 lines into keeper_exec_status, keeper_exec_tools, keeper_exec_llm, keeper_exec_social (#1200)
+- **handle_keeper_msg** — extract internals to module-level functions (#1178)
+- **env_config** — extract 11 hardcoded values into env-configurable functions (#1197)
+- **catch-all handlers** — narrow with log_keeper_exn (#1173, #1174) and log_mcp_exn (#1177)
+
+### Performance
+- **operator snapshot** — TTL cache for snapshot_json (#1176)
+
+### Infrastructure
+- **OAS** — update Raw_trace API for v0.29.0 (#1198)
+- **startup** — run resident loops in background fiber for fast HTTP readiness (#1175)
+
 ## [2.96.0] - 2026-03-16
 
 ### Added

--- a/dune-project
+++ b/dune-project
@@ -1,7 +1,7 @@
 (lang dune 3.13)
 
 (name masc_mcp)
-(version 2.98.0)
+(version 2.99.0)
 
 (generate_opam_files true)
 

--- a/lib/sentinel.ml
+++ b/lib/sentinel.ml
@@ -23,7 +23,7 @@ let agent_name = "sentinel"
 
 let agent_card : Agent_card.agent_card = {
   name = "sentinel";
-  version = "2.95.1";
+  version = "2.99.0";
   description = Some "Default resident agent: heartbeat, board patrol, task hygiene, keeper health";
   provider = Some { organization = "MASC"; url = None };
   protocol_versions = ["0.3"];


### PR DESCRIPTION
## Summary
- `dune-project`: 2.98.0 → 2.99.0
- `sentinel.ml` agent_card: 2.95.1 → 2.99.0
- CHANGELOG: 2.99.0 section added (social fixes, QA bugs, refactoring campaign, Rocket Loader fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)