### PR TITLE
fix(startup): protect init fiber from crashing HTTP server

### DIFF
--- a/lib/server_runtime_bootstrap.ml
+++ b/lib/server_runtime_bootstrap.ml
@@ -276,20 +276,23 @@ let run ~sw ~env ~host ~port ~base_path ~make_routes ~make_request_handler
   let _h2_error_handler = make_h2_error_handler () in
   let socket = listen_socket ~sw ~net config in
 
-  (* 2. All init in background fiber (PG connect 3s + Lodge GraphQL 20-40s) *)
+  (* 2. All init in background fiber — protected so failures don't kill HTTP *)
   Eio.Fiber.fork ~sw (fun () ->
-    let state =
-      create_server_state ~sw ~base_path ~clock ~mono_clock ~net ~proc_mgr ~fs
-    in
-    bootstrap_server_state state;
-    bootstrap_keepers ~sw ~clock state;
-    init_task_backend ();
-    let resolved_base, masc_dir =
-      start_background_maintenance ~sw ~clock state
-    in
-    print_startup_banner ~config ~resolved_base ~base_path ~masc_dir;
-    start_resident_loops ~sw ~clock ~net ~domain_mgr ~proc_mgr state
-  );
+    try
+      let state =
+        create_server_state ~sw ~base_path ~clock ~mono_clock ~net ~proc_mgr ~fs
+      in
+      bootstrap_server_state state;
+      bootstrap_keepers ~sw ~clock state;
+      init_task_backend ();
+      let resolved_base, masc_dir =
+        start_background_maintenance ~sw ~clock state
+      in
+      print_startup_banner ~config ~resolved_base ~base_path ~masc_dir;
+      start_resident_loops ~sw ~clock ~net ~domain_mgr ~proc_mgr state
+    with exn ->
+      Printf.eprintf "[startup] Background init failed (HTTP still serving): %s\n%!"
+        (Printexc.to_string exn));
 
   (* 3. Start serving — /health responds before init completes *)
   serve ~sw ~clock ~socket ~request_handler

--- a/railway.toml
+++ b/railway.toml
@@ -4,6 +4,7 @@ dockerfilePath = "Dockerfile"
 
 [deploy]
 startCommand = "sh -c '/app/masc-mcp --port $PORT --base-path /app'"
-healthcheckTimeout = 300
+healthcheckPath = "/health"
+healthcheckTimeout = 30
 restartPolicyType = "on_failure"
 restartPolicyMaxRetries = 3


### PR DESCRIPTION
init fiber exception이 Switch.fail로 전파되어 HTTP 서버를 죽이는 문제 수정. try-with로 보호하여 init 실패해도 /health 유지. Railway healthcheck 30s 재활성화.