### PR TITLE
fix(dashboard): prevent Cloudflare Rocket Loader from breaking module scripts

### DIFF
--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -8,6 +8,6 @@
 </head>
 <body>
   <div id="app"></div>
-  <script type="module" src="/src/main.ts"></script>
+  <script data-cfasync="false" type="module" src="/src/main.ts"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
Cloudflare Rocket Loader가 `type="module"`을 `type="<id>-module"`로 변환하여 대시보드가 빈 화면으로 표시되는 문제 수정.

`data-cfasync="false"` 속성을 script 태그에 추가하여 Rocket Loader가 해당 스크립트를 건드리지 않도록 합니다.

## Change
- `dashboard/index.html`: `<script data-cfasync="false" type="module" ...>`

## Test plan
- [x] `curl -s https://masc.crying.pictures/dashboard | grep 'type="module"'` — type 보존 확인
- [x] 로컬 대시보드 정상 동작

🤖 Generated with [Claude Code](https://claude.com/claude-code)