### PR TITLE
fix(deploy): remove healthcheckPath for Railway cold start

### DIFF
--- a/railway.toml
+++ b/railway.toml
@@ -4,7 +4,6 @@ dockerfilePath = "Dockerfile"
 
 [deploy]
 startCommand = "sh -c '/app/masc-mcp --port $PORT --base-path /app'"
-healthcheckPath = "/health"
-healthcheckTimeout = 30
+healthcheckTimeout = 300
 restartPolicyType = "on_failure"
 restartPolicyMaxRetries = 3


### PR DESCRIPTION
Railway healthcheck 제거. OCaml cold start 10-20s + protected async init → 30s timeout 부족.