### PR TITLE
feat(cp): CP data cleanup + snapshot quality improvements (BUG-006)

### DIFF
--- a/lib/command_plane_v2.ml
+++ b/lib/command_plane_v2.ml
@@ -11,3 +11,18 @@
 *)
 
 include Cp_lifecycle_policy
+
+(* Connect CP cleanup callback to Room_gc to break the circular dependency.
+   Room_gc cannot directly reference Cp_cleanup (which depends on Room via
+   Cp_io -> Cp_paths -> Room), so we use a ref-based callback. *)
+let () =
+  Room_gc.cp_cleanup_fn :=
+    (fun config ->
+      let r = Cp_cleanup.cleanup_cp config in
+      {
+        Room_gc.dead_units_removed = r.Cp_cleanup.dead_units_removed;
+        orphaned_units_removed = r.Cp_cleanup.orphaned_units_removed;
+        operations_archived = r.Cp_cleanup.operations_archived;
+        detachments_removed = r.Cp_cleanup.detachments_removed;
+        intents_removed = r.Cp_cleanup.intents_removed;
+      })

--- a/lib/cp_cleanup.ml
+++ b/lib/cp_cleanup.ml
@@ -1,0 +1,272 @@
+(** CP Data Cleanup — Dead/stale control plane data detection and removal.
+
+    Handles: dead units, orphaned units, terminal operations,
+    orphaned detachments, and dropped intents.
+
+    Depends only on Cp_io (no Room dependency — safe from circular deps). *)
+
+include Cp_io
+
+type cleanup_result = {
+  dead_units_removed : int;
+  orphaned_units_removed : int;
+  operations_archived : int;
+  detachments_removed : int;
+  intents_removed : int;
+}
+
+let empty_result = {
+  dead_units_removed = 0;
+  orphaned_units_removed = 0;
+  operations_archived = 0;
+  detachments_removed = 0;
+  intents_removed = 0;
+}
+
+let cleanup_result_to_json (r : cleanup_result) =
+  `Assoc
+    [
+      ("dead_units_removed", `Int r.dead_units_removed);
+      ("orphaned_units_removed", `Int r.orphaned_units_removed);
+      ("operations_archived", `Int r.operations_archived);
+      ("detachments_removed", `Int r.detachments_removed);
+      ("intents_removed", `Int r.intents_removed);
+    ]
+
+(** Compute ISO cutoff string for N days ago *)
+let cutoff_iso ~days =
+  let now = Time_compat.now () in
+  let cutoff_time = now -. (float_of_int days *. 86400.0) in
+  let tm = Unix.gmtime cutoff_time in
+  Printf.sprintf "%04d-%02d-%02dT%02d:%02d:%02dZ"
+    (tm.Unix.tm_year + 1900) (tm.Unix.tm_mon + 1) tm.Unix.tm_mday
+    tm.Unix.tm_hour tm.Unix.tm_min tm.Unix.tm_sec
+
+(** Find dead units: empty roster, no leader, updated_at older than threshold *)
+let find_dead_units ~days units =
+  let cutoff = cutoff_iso ~days in
+  List.filter
+    (fun (unit : unit_record) ->
+      unit.roster = []
+      && unit.leader_id = None
+      && unit.updated_at < cutoff)
+    units
+
+(** Find orphaned units: parent_unit_id references a non-existent unit *)
+let find_orphaned_units units =
+  let unit_ids =
+    List.map (fun (unit : unit_record) -> unit.unit_id) units
+  in
+  List.filter
+    (fun (unit : unit_record) ->
+      match unit.parent_unit_id with
+      | None -> false
+      | Some parent_id -> not (List.mem parent_id unit_ids))
+    units
+
+(** Check if an operation status is terminal *)
+let is_terminal_status = function
+  | Completed | Cancelled | Failed -> true
+  | Planned | Active | Paused -> false
+
+(** Find terminal operations older than threshold *)
+let find_terminal_operations ~days operations =
+  let cutoff = cutoff_iso ~days in
+  List.filter
+    (fun (op : operation_record) ->
+      is_terminal_status op.status && op.updated_at < cutoff)
+    operations
+
+(** Find orphaned detachments: operation_id references no existing operation *)
+let find_orphaned_detachments ~operation_ids detachments =
+  List.filter
+    (fun (det : detachment_record) ->
+      not (List.mem det.operation_id operation_ids))
+    detachments
+
+(** Find dropped intents older than threshold *)
+let find_dropped_intents ~days intents =
+  let cutoff = cutoff_iso ~days in
+  List.filter
+    (fun (intent : intent_record) ->
+      intent.state = Dropped_intent && intent.updated_at < cutoff)
+    intents
+
+(** Archive terminal operations to .masc/cp/archive/ *)
+let archive_operations config (ops : operation_record list) =
+  if ops = [] then ()
+  else begin
+    let archive_dir =
+      Filename.concat (control_plane_dir config) "archive"
+    in
+    Room_utils.mkdir_p archive_dir;
+    let archive_path =
+      Filename.concat archive_dir "operations.json"
+    in
+    let existing =
+      if Sys.file_exists archive_path then
+        match Room_utils.read_json_opt config archive_path with
+        | Some (`Assoc fields) -> (
+            match List.assoc_opt "operations" fields with
+            | Some (`List rows) -> List.filter_map operation_of_json rows
+            | _ -> [])
+        | Some (`List rows) -> List.filter_map operation_of_json rows
+        | _ -> []
+      else []
+    in
+    let merged = existing @ ops in
+    Room_utils.write_json config archive_path
+      (`Assoc
+        [
+          ("version", `String "cp-v2");
+          ("archived_at", `String (Types.now_iso ()));
+          ("operations", `List (List.map operation_to_json merged));
+        ])
+  end
+
+(** Remove dead units: empty roster + no leader + stale *)
+let cleanup_dead_units config ~days units =
+  let dead = find_dead_units ~days units in
+  if dead = [] then (units, 0)
+  else begin
+    let dead_ids =
+      List.map (fun (unit : unit_record) -> unit.unit_id) dead
+    in
+    let kept =
+      List.filter
+        (fun (unit : unit_record) ->
+          not (List.mem unit.unit_id dead_ids))
+        units
+    in
+    write_units config kept;
+    (kept, List.length dead)
+  end
+
+(** Remove orphaned units: parent references non-existent unit *)
+let cleanup_orphaned_units config units =
+  let orphaned = find_orphaned_units units in
+  if orphaned = [] then (units, 0)
+  else begin
+    let orphaned_ids =
+      List.map (fun (unit : unit_record) -> unit.unit_id) orphaned
+    in
+    let kept =
+      List.filter
+        (fun (unit : unit_record) ->
+          not (List.mem unit.unit_id orphaned_ids))
+        units
+    in
+    write_units config kept;
+    (kept, List.length orphaned)
+  end
+
+(** Archive terminal operations and remove from active list *)
+let archive_terminal_operations config ~days operations =
+  let terminal = find_terminal_operations ~days operations in
+  if terminal = [] then (operations, 0)
+  else begin
+    archive_operations config terminal;
+    let terminal_ids =
+      List.map (fun (op : operation_record) -> op.operation_id) terminal
+    in
+    let kept =
+      List.filter
+        (fun (op : operation_record) ->
+          not (List.mem op.operation_id terminal_ids))
+        operations
+    in
+    write_operations config kept;
+    (kept, List.length terminal)
+  end
+
+(** Remove detachments whose operation_id no longer exists *)
+let cleanup_orphaned_detachments config ~operation_ids detachments =
+  let orphaned = find_orphaned_detachments ~operation_ids detachments in
+  if orphaned = [] then (detachments, 0)
+  else begin
+    let orphaned_ids =
+      List.map (fun (det : detachment_record) -> det.detachment_id) orphaned
+    in
+    let kept =
+      List.filter
+        (fun (det : detachment_record) ->
+          not (List.mem det.detachment_id orphaned_ids))
+        detachments
+    in
+    write_detachments config kept;
+    (kept, List.length orphaned)
+  end
+
+(** Remove dropped intents older than threshold *)
+let cleanup_dropped_intents config ~days intents =
+  let dropped = find_dropped_intents ~days intents in
+  if dropped = [] then (intents, 0)
+  else begin
+    let dropped_ids =
+      List.map (fun (intent : intent_record) -> intent.intent_id) dropped
+    in
+    let kept =
+      List.filter
+        (fun (intent : intent_record) ->
+          not (List.mem intent.intent_id dropped_ids))
+        intents
+    in
+    write_intents config kept;
+    (kept, List.length dropped)
+  end
+
+(** Run all CP cleanup steps. Returns a summary result. *)
+let cleanup_cp config =
+  let days = Env_config_runtime.Cp.cleanup_days in
+  let units = read_units config in
+  let operations = read_operations config in
+  let detachments = read_detachments config in
+  let intents = read_intents config in
+
+  (* 1. Dead units *)
+  let units, dead_count = cleanup_dead_units config ~days units in
+
+  (* 2. Orphaned units (run after dead cleanup to catch cascading orphans) *)
+  let _units, orphaned_count = cleanup_orphaned_units config units in
+
+  (* 3. Terminal operations *)
+  let operations, archived_count =
+    archive_terminal_operations config ~days operations
+  in
+
+  (* 4. Orphaned detachments (based on remaining operation IDs) *)
+  let operation_ids =
+    List.map (fun (op : operation_record) -> op.operation_id) operations
+  in
+  let _detachments, det_count =
+    cleanup_orphaned_detachments config ~operation_ids detachments
+  in
+
+  (* 5. Dropped intents *)
+  let _intents, intent_count =
+    cleanup_dropped_intents config ~days intents
+  in
+
+  {
+    dead_units_removed = dead_count;
+    orphaned_units_removed = orphaned_count;
+    operations_archived = archived_count;
+    detachments_removed = det_count;
+    intents_removed = intent_count;
+  }
+
+let cleanup_cp_summary config =
+  let result = cleanup_cp config in
+  let total =
+    result.dead_units_removed + result.orphaned_units_removed
+    + result.operations_archived + result.detachments_removed
+    + result.intents_removed
+  in
+  if total = 0 then
+    "✅ No stale CP data"
+  else
+    Printf.sprintf
+      "🧹 CP cleanup: %d dead unit(s), %d orphan unit(s), %d operation(s) archived, %d orphan detachment(s), %d dropped intent(s)"
+      result.dead_units_removed result.orphaned_units_removed
+      result.operations_archived result.detachments_removed
+      result.intents_removed

--- a/lib/cp_snapshot.ml
+++ b/lib/cp_snapshot.ml
@@ -17,6 +17,63 @@ type snapshot_state = {
   unit_lookup : (string * unit_record) list;
 }
 
+let count_operation_statuses operations =
+  List.fold_left
+    (fun (acc : operation_status_counts) (op : operation_record) ->
+      match op.status with
+      | Planned -> { acc with planned_count = acc.planned_count + 1 }
+      | Active -> { acc with active_count = acc.active_count + 1 }
+      | Paused -> { acc with paused_count = acc.paused_count + 1 }
+      | Completed -> { acc with completed_count = acc.completed_count + 1 }
+      | Failed -> { acc with failed_count = acc.failed_count + 1 }
+      | Cancelled -> { acc with cancelled_count = acc.cancelled_count + 1 })
+    { planned_count = 0; active_count = 0; paused_count = 0;
+      completed_count = 0; failed_count = 0; cancelled_count = 0 }
+    operations
+
+let build_topology_summary ~units ~managed_units ~agents ~operations =
+  let stale_cutoff = Cp_cleanup.cutoff_iso ~days:Env_config_runtime.Cp.cleanup_days in
+  let op_counts = count_operation_statuses operations in
+  {
+    total_units = List.length units;
+    company_count = List.length (List.filter (fun (u : unit_record) -> u.kind = Company) units);
+    platoon_count = List.length (List.filter (fun (u : unit_record) -> u.kind = Platoon) units);
+    squad_count = List.length (List.filter (fun (u : unit_record) -> u.kind = Squad) units);
+    leaf_agent_unit_count = List.length (List.filter (fun (u : unit_record) -> u.kind = Agent_unit) units);
+    live_agent_count = List.length (live_agent_names agents);
+    managed_unit_count = List.length managed_units;
+    active_operation_count = op_counts.planned_count + op_counts.active_count + op_counts.paused_count;
+    stale_unit_count =
+      List.length (List.filter (fun (u : unit_record) -> u.updated_at < stale_cutoff) units);
+    operation_status_counts = op_counts;
+  }
+
+let operation_status_counts_to_json (c : operation_status_counts) =
+  `Assoc
+    [
+      ("planned", `Int c.planned_count);
+      ("active", `Int c.active_count);
+      ("paused", `Int c.paused_count);
+      ("completed", `Int c.completed_count);
+      ("failed", `Int c.failed_count);
+      ("cancelled", `Int c.cancelled_count);
+    ]
+
+let topology_summary_to_json (s : topology_summary) =
+  `Assoc
+    [
+      ("total_units", `Int s.total_units);
+      ("company_count", `Int s.company_count);
+      ("platoon_count", `Int s.platoon_count);
+      ("squad_count", `Int s.squad_count);
+      ("leaf_agent_unit_count", `Int s.leaf_agent_unit_count);
+      ("live_agent_count", `Int s.live_agent_count);
+      ("managed_unit_count", `Int s.managed_unit_count);
+      ("active_operation_count", `Int s.active_operation_count);
+      ("stale_unit_count", `Int s.stale_unit_count);
+      ("operation_status_counts", operation_status_counts_to_json s.operation_status_counts);
+    ]
+
 let build_snapshot_state ?sessions config =
   let agents, managed_units, units, source = topology_units config in
   let sessions =
@@ -73,38 +130,13 @@ let topology_json_from_state (state : snapshot_state) =
              ~agent_statuses:(agent_status_map agents)
              ~live_agents:(live_agent_names agents) ~operations unit.unit_id)
   in
-  let summary =
-    {
-      total_units = List.length units;
-      company_count = List.length (List.filter (fun (unit : unit_record) -> unit.kind = Company) units);
-      platoon_count = List.length (List.filter (fun (unit : unit_record) -> unit.kind = Platoon) units);
-      squad_count = List.length (List.filter (fun (unit : unit_record) -> unit.kind = Squad) units);
-      leaf_agent_unit_count = List.length (List.filter (fun (unit : unit_record) -> unit.kind = Agent_unit) units);
-      live_agent_count = List.length (live_agent_names agents);
-      managed_unit_count = List.length managed_units;
-      active_operation_count =
-        operations
-        |> List.filter (fun (operation : operation_record) -> active_operation_status operation.status)
-        |> List.length;
-    }
-  in
+  let summary = build_topology_summary ~units ~managed_units ~agents ~operations in
   `Assoc
     [
       ("version", `String "cp-v2");
       ("generated_at", `String (Types.now_iso ()));
       ("source", `String source);
-      ( "summary",
-        `Assoc
-          [
-            ("total_units", `Int summary.total_units);
-            ("company_count", `Int summary.company_count);
-            ("platoon_count", `Int summary.platoon_count);
-            ("squad_count", `Int summary.squad_count);
-            ("leaf_agent_unit_count", `Int summary.leaf_agent_unit_count);
-            ("live_agent_count", `Int summary.live_agent_count);
-            ("managed_unit_count", `Int summary.managed_unit_count);
-            ("active_operation_count", `Int summary.active_operation_count);
-          ] );
+      ("summary", topology_summary_to_json summary);
       ("units", `List trees);
     ]
 
@@ -764,54 +796,15 @@ let swarm_proof_json config =
 
 let topology_summary_json_from_state (state : snapshot_state) =
   let summary =
-    {
-      total_units = List.length state.units;
-      company_count =
-        List.length
-          (List.filter
-             (fun (unit : unit_record) -> unit.kind = Company)
-             state.units);
-      platoon_count =
-        List.length
-          (List.filter
-             (fun (unit : unit_record) -> unit.kind = Platoon)
-             state.units);
-      squad_count =
-        List.length
-          (List.filter
-             (fun (unit : unit_record) -> unit.kind = Squad)
-             state.units);
-      leaf_agent_unit_count =
-        List.length
-          (List.filter
-             (fun (unit : unit_record) -> unit.kind = Agent_unit)
-             state.units);
-      live_agent_count = List.length state.live_agents;
-      managed_unit_count = List.length state.managed_units;
-      active_operation_count =
-        state.operations
-        |> List.filter (fun (operation : operation_record) ->
-               active_operation_status operation.status)
-        |> List.length;
-    }
+    build_topology_summary ~units:state.units ~managed_units:state.managed_units
+      ~agents:state.agents ~operations:state.operations
   in
   `Assoc
     [
       ("version", `String "cp-v2");
       ("generated_at", `String (Types.now_iso ()));
       ("source", `String state.source);
-      ( "summary",
-        `Assoc
-          [
-            ("total_units", `Int summary.total_units);
-            ("company_count", `Int summary.company_count);
-            ("platoon_count", `Int summary.platoon_count);
-            ("squad_count", `Int summary.squad_count);
-            ("leaf_agent_unit_count", `Int summary.leaf_agent_unit_count);
-            ("live_agent_count", `Int summary.live_agent_count);
-            ("managed_unit_count", `Int summary.managed_unit_count);
-            ("active_operation_count", `Int summary.active_operation_count);
-          ] );
+      ("summary", topology_summary_to_json summary);
     ]
 
 let operations_summary_json_from_state (state : snapshot_state) =
@@ -896,17 +889,22 @@ let operations_summary_json_from_state (state : snapshot_state) =
          (fun (operation : operation_record) -> operation.source = "managed")
          state.operations)
   in
-  let active_count =
-    List.length
-      (List.filter
-         (fun (operation : operation_record) -> operation.status = Active)
-         state.operations)
-  in
-  let paused_count =
-    List.length
-      (List.filter
-         (fun (operation : operation_record) -> operation.status = Paused)
-         state.operations)
+  let op_counts = count_operation_statuses state.operations in
+  let recent_active =
+    state.operations
+    |> List.filter (fun (op : operation_record) -> active_operation_status op.status)
+    |> List.sort (fun (a : operation_record) (b : operation_record) ->
+           compare b.updated_at a.updated_at)
+    |> (fun ops -> if List.length ops > 10 then List.filteri (fun i _ -> i < 10) ops else ops)
+    |> List.map (fun (op : operation_record) ->
+           `Assoc
+             [
+               ("operation_id", `String op.operation_id);
+               ("objective", `String op.objective);
+               ("status", `String (string_of_operation_status op.status));
+               ("assigned_unit_id", `String op.assigned_unit_id);
+               ("updated_at", `String op.updated_at);
+             ])
   in
   let microarch = Cp_microarch_summary.summary_json ~search_rows in
   `Assoc
@@ -917,11 +915,16 @@ let operations_summary_json_from_state (state : snapshot_state) =
         `Assoc
           [
             ("total", `Int (List.length state.operations));
-            ("active", `Int active_count);
-            ("paused", `Int paused_count);
+            ("active", `Int op_counts.active_count);
+            ("planned", `Int op_counts.planned_count);
+            ("paused", `Int op_counts.paused_count);
+            ("completed", `Int op_counts.completed_count);
+            ("failed", `Int op_counts.failed_count);
+            ("cancelled", `Int op_counts.cancelled_count);
             ("managed", `Int managed_count);
             ("projected", `Int (List.length state.operations - managed_count));
           ] );
+      ("recent_active", `List recent_active);
       ("microarch", microarch);
     ]
 

--- a/lib/cp_types.ml
+++ b/lib/cp_types.ml
@@ -172,6 +172,15 @@ type policy_decision_record = {
   expires_at : string option;
 }
 
+type operation_status_counts = {
+  planned_count : int;
+  active_count : int;
+  paused_count : int;
+  completed_count : int;
+  failed_count : int;
+  cancelled_count : int;
+}
+
 type topology_summary = {
   total_units : int;
   company_count : int;
@@ -181,4 +190,6 @@ type topology_summary = {
   live_agent_count : int;
   managed_unit_count : int;
   active_operation_count : int;
+  stale_unit_count : int;
+  operation_status_counts : operation_status_counts;
 }

--- a/lib/cp_unit.ml
+++ b/lib/cp_unit.ml
@@ -824,6 +824,10 @@ let rec build_tree_json ~child_map ~unit_lookup ~agent_statuses ~live_agents ~op
         else if !reasons <> [] then "warn"
         else "ok"
       in
+      let cleanup_days = Env_config_runtime.Cp.cleanup_days in
+      let stale_cutoff = Cp_cleanup.cutoff_iso ~days:cleanup_days in
+      let is_stale = unit.updated_at < stale_cutoff in
+      if is_stale then reasons := "stale" :: !reasons;
       Some
         (`Assoc
           [
@@ -831,7 +835,15 @@ let rec build_tree_json ~child_map ~unit_lookup ~agent_statuses ~live_agents ~op
             ("leader_status", `String leader_status);
             ("roster_total", `Int (List.length unit.roster));
             ("roster_live", `Int live_roster);
+            ("roster_health",
+             `Assoc
+               [
+                 ("total", `Int (List.length unit.roster));
+                 ("live", `Int live_roster);
+                 ("offline", `Int (List.length unit.roster - live_roster));
+               ]);
             ("active_operation_count", `Int descendant_op_count);
+            ("is_stale", `Bool is_stale);
             ("health", `String health);
             ("reasons", json_list_of_strings (List.rev !reasons));
             ("children", `List children);

--- a/lib/dune
+++ b/lib/dune
@@ -39,6 +39,7 @@
    cp_io
    cp_unit
    cp_snapshot
+   cp_cleanup
    cp_lifecycle
    cp_lifecycle_swarm_live
    cp_lifecycle_search

--- a/lib/env_config_runtime.ml
+++ b/lib/env_config_runtime.ml
@@ -268,4 +268,12 @@ module Llm_defaults = struct
     get_int ~default:1500 "MASC_LOG_TRUNCATION_LEN"
 end
 
+(** {1 Control Plane Cleanup Configuration} *)
+
+module Cp = struct
+  (** Number of days before dead/stale CP data is eligible for cleanup (default 14) *)
+  let cleanup_days =
+    get_int ~default:14 "MASC_CP_CLEANUP_DAYS"
+end
+
 (** {1 Internal Guardian Configuration} *)

--- a/lib/masc_mcp.ml
+++ b/lib/masc_mcp.ml
@@ -16,6 +16,7 @@ module Validation = Validation
 module Command_plane_v2 = Command_plane_v2
 module Command_plane_orchestra = Command_plane_orchestra
 module Cp_search_fabric = Cp_search_fabric
+module Cp_cleanup = Cp_cleanup
 module Config = Config
 module Env_config = Env_config
 module Resilience = Resilience

--- a/lib/room_gc.ml
+++ b/lib/room_gc.ml
@@ -15,6 +15,32 @@ let force_release_task_fn
   = ref (fun _config ~agent_name:_ ~task_id:_ () ->
       Error (Types.TaskInvalidState "Room_gc: force_release_task_fn not connected"))
 
+(** CP cleanup result type — mirrors Cp_cleanup.cleanup_result without
+    introducing a dependency on Cp_cleanup (which depends on Room). *)
+type cp_cleanup_result = {
+  dead_units_removed : int;
+  orphaned_units_removed : int;
+  operations_archived : int;
+  detachments_removed : int;
+  intents_removed : int;
+}
+
+let empty_cp_result = {
+  dead_units_removed = 0;
+  orphaned_units_removed = 0;
+  operations_archived = 0;
+  detachments_removed = 0;
+  intents_removed = 0;
+}
+
+(** Callback for CP cleanup — set by the module that connects Room_gc
+    and Cp_cleanup (e.g. command_plane_v2.ml or room.ml post-include).
+    This avoids a circular dependency: Cp_cleanup depends on Cp_io which
+    depends on Room, and Room includes Room_gc. *)
+let cp_cleanup_fn
+  : (config -> cp_cleanup_result) ref
+  = ref (fun _config -> empty_cp_result)
+
 
 (** Update agent heartbeat - must be called periodically *)
 let heartbeat_in_room config ~room_id ~agent_name =
@@ -314,78 +340,31 @@ let gc config ?(days=7) () =
   else
     results := "✅ No team sessions to archive" :: !results;
 
-  (* 7. Cleanup dead topology units (leader offline, 0 live roster, stale).
-     Read/write units.json directly to avoid Cp_io dependency cycle. *)
-  let dead_unit_count = ref 0 in
-  let cp_dir = Filename.concat (Filename.concat config.base_path ".masc") "control-plane" in
-  let units_file = Filename.concat cp_dir "units.json" in
-  (try
-    if Sys.file_exists units_file then begin
-      let json = Yojson.Safe.from_file units_file in
-      let unit_rows = match json with
-        | `Assoc fields -> (match List.assoc_opt "units" fields with
-            | Some (`List rows) -> rows | _ -> [])
-        | `List rows -> rows
-        | _ -> []
-      in
-      if unit_rows <> [] then begin
-        (* Collect active agent names from the agents directory *)
-        let agents_dir = Filename.concat (Filename.concat config.base_path ".masc") "agents" in
-        let active_agent_names =
-          if Sys.file_exists agents_dir && Sys.is_directory agents_dir then
-            Sys.readdir agents_dir |> Array.to_list
-            |> List.filter_map (fun fname ->
-              if Filename.check_suffix fname ".json" then
-                try
-                  let agent_json = Yojson.Safe.from_file (Filename.concat agents_dir fname) in
-                  let status = Yojson.Safe.Util.(member "status" agent_json |> to_string_option)
-                    |> Option.value ~default:"offline" in
-                  let name = Yojson.Safe.Util.(member "name" agent_json |> to_string_option) in
-                  if status <> "offline" then name else None
-                with _ -> None
-              else None)
-          else []
-        in
-        let is_dead unit_json =
-          let leader = Yojson.Safe.Util.(member "leader_id" unit_json |> to_string_option) in
-          let roster = match Yojson.Safe.Util.member "roster" unit_json with
-            | `List items -> List.filter_map Yojson.Safe.Util.to_string_option items
-            | _ -> []
-          in
-          let updated = Yojson.Safe.Util.(member "updated_at" unit_json |> to_string_option)
-            |> Option.value ~default:"" in
-          let leader_offline = match leader with
-            | None -> true
-            | Some l -> not (List.mem l active_agent_names)
-          in
-          let live_roster = List.filter (fun m -> List.mem m active_agent_names) roster in
-          leader_offline && live_roster = [] && updated <> "" && updated < cutoff_iso
-        in
-        let kept = List.filter (fun u -> not (is_dead u)) unit_rows in
-        let removed = List.length unit_rows - List.length kept in
-        if removed > 0 then begin
-          let out_json = `Assoc [
-            ("version", `String "cp-v2");
-            ("updated_at", `String (now_iso ()));
-            ("units", `List kept);
-          ] in
-          let oc = open_out units_file in
-          output_string oc (Yojson.Safe.pretty_to_string out_json);
-          close_out oc;
-          dead_unit_count := removed
-        end
-      end
-    end
-  with exn ->
-    Printf.eprintf "[gc] topology unit cleanup failed: %s\n%!" (Printexc.to_string exn));
-  if !dead_unit_count > 0 then
-    results := Printf.sprintf "Removed %d dead topology unit(s) (leader offline, empty roster, stale)" !dead_unit_count :: !results
+  (* 7. CP data cleanup (dead units, stale operations, orphaned detachments) *)
+  let cp_result = !cp_cleanup_fn config in
+  let cp_total =
+    cp_result.dead_units_removed + cp_result.orphaned_units_removed
+    + cp_result.operations_archived + cp_result.detachments_removed
+    + cp_result.intents_removed
+  in
+  if cp_total > 0 then
+    results := Printf.sprintf
+      "🧹 CP cleanup: %d dead unit(s), %d orphan unit(s), %d operation(s) archived, %d orphan detachment(s), %d dropped intent(s)"
+      cp_result.dead_units_removed cp_result.orphaned_units_removed
+      cp_result.operations_archived cp_result.detachments_removed
+      cp_result.intents_removed :: !results
   else
-    results := "No dead topology units" :: !results;
-
+    results := "✅ No stale CP data" :: !results;
   (* Log event *)
+  let cp_json =
+    Printf.sprintf "{\"dead_units\":%d,\"orphan_units\":%d,\"ops_archived\":%d,\"orphan_dets\":%d,\"dropped_intents\":%d}"
+      cp_result.dead_units_removed cp_result.orphaned_units_removed
+      cp_result.operations_archived cp_result.detachments_removed
+      cp_result.intents_removed
+  in
   log_event config (Printf.sprintf
-    "{\"type\":\"gc\",\"stale_tasks\":%d,\"old_messages\":%d,\"preserved\":%d,\"pubsub_cleaned\":%d,\"keeper_orphans\":%d,\"sessions_archived\":%d,\"dead_units\":%d,\"days\":%d,\"ts\":\"%s\"}"
-    !stale_count !old_msg_count !preserved_count !pubsub_cleanup_count !keeper_orphan_count !session_archive_count !dead_unit_count days (now_iso ()));
+    "{\"type\":\"gc\",\"stale_tasks\":%d,\"old_messages\":%d,\"preserved\":%d,\"pubsub_cleaned\":%d,\"keeper_orphans\":%d,\"sessions_archived\":%d,\"cp_cleanup\":%s,\"days\":%d,\"ts\":\"%s\"}"
+    !stale_count !old_msg_count !preserved_count !pubsub_cleanup_count !keeper_orphan_count !session_archive_count
+    cp_json days (now_iso ()));
 
   String.concat "\n" (List.rev !results)

--- a/test/dune
+++ b/test/dune
@@ -409,6 +409,11 @@
  (libraries masc_mcp alcotest yojson unix))
 
 (test
+ (name test_cp_cleanup)
+ (modules test_cp_cleanup)
+ (libraries masc_mcp alcotest yojson unix))
+
+(test
  (name test_cp_search_fabric)
  (modules test_cp_search_fabric)
  (libraries masc_mcp alcotest yojson unix))

--- a/test/test_cp_cleanup.ml
+++ b/test/test_cp_cleanup.ml
@@ -1,0 +1,364 @@
+open Alcotest
+open Masc_mcp
+
+(** Helper: create a minimal unit_record for testing *)
+let make_unit ?(roster = []) ?(leader_id = None) ?(parent_unit_id = None)
+    ?(updated_at = "2026-01-01T00:00:00Z") ~unit_id ~label ~kind () =
+  Cp_cleanup.
+    {
+      unit_id;
+      label;
+      kind;
+      parent_unit_id;
+      leader_id;
+      roster;
+      capability_profile = [];
+      policy = Cp_cleanup.default_policy kind;
+      budget = Cp_cleanup.default_budget kind;
+      source = "managed";
+      created_at = "2026-01-01T00:00:00Z";
+      updated_at;
+    }
+
+(** Helper: create a minimal operation_record for testing *)
+let make_operation ?(status = Cp_cleanup.Active) ?(updated_at = "2026-01-01T00:00:00Z")
+    ~operation_id ~assigned_unit_id () =
+  Cp_cleanup.
+    {
+      operation_id;
+      objective = "test objective";
+      intent_id = None;
+      assigned_unit_id;
+      autonomy_level = "L4_Autonomous";
+      policy_class = "strict";
+      budget_class = "standard";
+      workload_template = None;
+      workload_profile = "coding_task";
+      stage = None;
+      artifact_scope = [];
+      depends_on_operation_ids = [];
+      search_strategy = "best_first_v1";
+      detachment_session_id = None;
+      trace_id = "trace-test";
+      checkpoint_ref = None;
+      active_goal_ids = [];
+      note = None;
+      created_by = "test";
+      source = "managed";
+      status;
+      chain = None;
+      created_at = "2026-01-01T00:00:00Z";
+      updated_at;
+    }
+
+(** Helper: create a minimal detachment_record for testing *)
+let make_detachment ~detachment_id ~operation_id () =
+  Cp_cleanup.
+    {
+      detachment_id;
+      operation_id;
+      assigned_unit_id = "unit-1";
+      leader_id = None;
+      roster = [];
+      session_id = None;
+      checkpoint_ref = None;
+      runtime_kind = None;
+      runtime_ref = None;
+      source = "managed";
+      status = "active";
+      last_event_at = None;
+      last_progress_at = None;
+      heartbeat_deadline = None;
+      created_at = "2026-01-01T00:00:00Z";
+      updated_at = "2026-01-01T00:00:00Z";
+    }
+
+(** Helper: create a minimal intent_record for testing *)
+let make_intent ?(state = Cp_cleanup.Active_intent) ?(updated_at = "2026-01-01T00:00:00Z")
+    ~intent_id () =
+  Cp_cleanup.
+    {
+      intent_id;
+      title = "test intent";
+      owner = "test";
+      workload_profile = "coding_task";
+      success_metric = None;
+      invariants = [];
+      artifact_priors = [];
+      state;
+      current_focus =
+        { stage = None; artifact_scope = []; unit_id = None; verification_state = None };
+      checkpoint_ref = None;
+      source = "managed";
+      created_at = "2026-01-01T00:00:00Z";
+      updated_at;
+    }
+
+(* ====================== *)
+(* find_dead_units tests   *)
+(* ====================== *)
+
+let test_find_dead_units_detects_empty_roster_stale () =
+  let units =
+    [
+      make_unit ~unit_id:"u1" ~label:"Dead Unit" ~kind:Squad
+        ~roster:[] ~leader_id:None ~updated_at:"2025-01-01T00:00:00Z" ();
+      make_unit ~unit_id:"u2" ~label:"Live Unit" ~kind:Squad
+        ~roster:[ "agent-a" ] ~leader_id:(Some "agent-a")
+        ~updated_at:"2026-03-15T00:00:00Z" ();
+    ]
+  in
+  let dead = Cp_cleanup.find_dead_units ~days:14 units in
+  check int "one dead unit" 1 (List.length dead);
+  check string "dead unit id" "u1"
+    (List.hd dead).Cp_cleanup.unit_id
+
+let test_find_dead_units_skips_units_with_leader () =
+  let units =
+    [
+      make_unit ~unit_id:"u1" ~label:"Has Leader" ~kind:Squad
+        ~roster:[] ~leader_id:(Some "leader-1")
+        ~updated_at:"2025-01-01T00:00:00Z" ();
+    ]
+  in
+  let dead = Cp_cleanup.find_dead_units ~days:14 units in
+  check int "no dead units (has leader)" 0 (List.length dead)
+
+let test_find_dead_units_skips_recent () =
+  let units =
+    [
+      make_unit ~unit_id:"u1" ~label:"Recent Empty" ~kind:Squad
+        ~roster:[] ~leader_id:None
+        ~updated_at:"2099-01-01T00:00:00Z" ();
+    ]
+  in
+  let dead = Cp_cleanup.find_dead_units ~days:14 units in
+  check int "no dead units (recent)" 0 (List.length dead)
+
+(* ========================== *)
+(* find_orphaned_units tests   *)
+(* ========================== *)
+
+let test_find_orphaned_units_detects_missing_parent () =
+  let units =
+    [
+      make_unit ~unit_id:"root" ~label:"Root" ~kind:Company ();
+      make_unit ~unit_id:"child" ~label:"Child" ~kind:Platoon
+        ~parent_unit_id:(Some "non-existent") ();
+    ]
+  in
+  let orphaned = Cp_cleanup.find_orphaned_units units in
+  check int "one orphaned unit" 1 (List.length orphaned);
+  check string "orphaned id" "child"
+    (List.hd orphaned).Cp_cleanup.unit_id
+
+let test_find_orphaned_units_accepts_valid_parent () =
+  let units =
+    [
+      make_unit ~unit_id:"root" ~label:"Root" ~kind:Company ();
+      make_unit ~unit_id:"child" ~label:"Child" ~kind:Platoon
+        ~parent_unit_id:(Some "root") ();
+    ]
+  in
+  let orphaned = Cp_cleanup.find_orphaned_units units in
+  check int "no orphans" 0 (List.length orphaned)
+
+let test_find_orphaned_units_skips_root () =
+  let units =
+    [
+      make_unit ~unit_id:"root" ~label:"Root" ~kind:Company ();
+    ]
+  in
+  let orphaned = Cp_cleanup.find_orphaned_units units in
+  check int "root is not orphaned" 0 (List.length orphaned)
+
+(* ================================= *)
+(* find_terminal_operations tests     *)
+(* ================================= *)
+
+let test_find_terminal_operations_detects_completed_stale () =
+  let ops =
+    [
+      make_operation ~operation_id:"op1" ~assigned_unit_id:"u1"
+        ~status:Completed ~updated_at:"2025-01-01T00:00:00Z" ();
+      make_operation ~operation_id:"op2" ~assigned_unit_id:"u1"
+        ~status:Active ~updated_at:"2025-01-01T00:00:00Z" ();
+      make_operation ~operation_id:"op3" ~assigned_unit_id:"u1"
+        ~status:Failed ~updated_at:"2025-01-01T00:00:00Z" ();
+    ]
+  in
+  let terminal = Cp_cleanup.find_terminal_operations ~days:14 ops in
+  check int "two terminal operations" 2 (List.length terminal)
+
+let test_find_terminal_operations_skips_recent () =
+  let ops =
+    [
+      make_operation ~operation_id:"op1" ~assigned_unit_id:"u1"
+        ~status:Completed ~updated_at:"2099-01-01T00:00:00Z" ();
+    ]
+  in
+  let terminal = Cp_cleanup.find_terminal_operations ~days:14 ops in
+  check int "no terminal (recent)" 0 (List.length terminal)
+
+(* ====================================== *)
+(* find_orphaned_detachments tests         *)
+(* ====================================== *)
+
+let test_find_orphaned_detachments_detects_missing_operation () =
+  let detachments =
+    [
+      make_detachment ~detachment_id:"det1" ~operation_id:"op-exists" ();
+      make_detachment ~detachment_id:"det2" ~operation_id:"op-gone" ();
+    ]
+  in
+  let orphaned =
+    Cp_cleanup.find_orphaned_detachments
+      ~operation_ids:[ "op-exists" ] detachments
+  in
+  check int "one orphaned detachment" 1 (List.length orphaned);
+  check string "orphaned det id" "det2"
+    (List.hd orphaned).Cp_cleanup.detachment_id
+
+(* =============================== *)
+(* find_dropped_intents tests       *)
+(* =============================== *)
+
+let test_find_dropped_intents_detects_dropped_stale () =
+  let intents =
+    [
+      make_intent ~intent_id:"i1" ~state:Dropped_intent
+        ~updated_at:"2025-01-01T00:00:00Z" ();
+      make_intent ~intent_id:"i2" ~state:Active_intent
+        ~updated_at:"2025-01-01T00:00:00Z" ();
+    ]
+  in
+  let dropped = Cp_cleanup.find_dropped_intents ~days:14 intents in
+  check int "one dropped intent" 1 (List.length dropped);
+  check string "dropped intent id" "i1"
+    (List.hd dropped).Cp_cleanup.intent_id
+
+let test_find_dropped_intents_skips_recent () =
+  let intents =
+    [
+      make_intent ~intent_id:"i1" ~state:Dropped_intent
+        ~updated_at:"2099-01-01T00:00:00Z" ();
+    ]
+  in
+  let dropped = Cp_cleanup.find_dropped_intents ~days:14 intents in
+  check int "no dropped (recent)" 0 (List.length dropped)
+
+(* ========================== *)
+(* is_terminal_status tests    *)
+(* ========================== *)
+
+let test_is_terminal_status () =
+  check bool "completed is terminal" true
+    (Cp_cleanup.is_terminal_status Completed);
+  check bool "cancelled is terminal" true
+    (Cp_cleanup.is_terminal_status Cancelled);
+  check bool "failed is terminal" true
+    (Cp_cleanup.is_terminal_status Failed);
+  check bool "active is not terminal" false
+    (Cp_cleanup.is_terminal_status Active);
+  check bool "planned is not terminal" false
+    (Cp_cleanup.is_terminal_status Planned);
+  check bool "paused is not terminal" false
+    (Cp_cleanup.is_terminal_status Paused)
+
+(* ============================== *)
+(* cleanup_result_to_json tests    *)
+(* ============================== *)
+
+let test_cleanup_result_to_json () =
+  let result =
+    Cp_cleanup.
+      {
+        dead_units_removed = 2;
+        orphaned_units_removed = 1;
+        operations_archived = 3;
+        detachments_removed = 0;
+        intents_removed = 1;
+      }
+  in
+  let json = Cp_cleanup.cleanup_result_to_json result in
+  let open Yojson.Safe.Util in
+  check int "dead_units_removed" 2
+    (json |> member "dead_units_removed" |> to_int);
+  check int "operations_archived" 3
+    (json |> member "operations_archived" |> to_int);
+  check int "intents_removed" 1
+    (json |> member "intents_removed" |> to_int)
+
+(* ====================== *)
+(* cutoff_iso tests        *)
+(* ====================== *)
+
+let test_cutoff_iso_format () =
+  let iso = Cp_cleanup.cutoff_iso ~days:14 in
+  check bool "ISO format (starts with 20)" true
+    (String.length iso > 0 && String.sub iso 0 2 = "20");
+  check bool "ISO format (ends with Z)" true
+    (iso.[String.length iso - 1] = 'Z');
+  check bool "ISO format (contains T)" true
+    (String.contains iso 'T')
+
+(* ============================================ *)
+(* Test suite registration                       *)
+(* ============================================ *)
+
+let () =
+  run "cp_cleanup"
+    [
+      ( "find_dead_units",
+        [
+          test_case "detects empty roster + stale" `Quick
+            test_find_dead_units_detects_empty_roster_stale;
+          test_case "skips units with leader" `Quick
+            test_find_dead_units_skips_units_with_leader;
+          test_case "skips recent empty units" `Quick
+            test_find_dead_units_skips_recent;
+        ] );
+      ( "find_orphaned_units",
+        [
+          test_case "detects missing parent" `Quick
+            test_find_orphaned_units_detects_missing_parent;
+          test_case "accepts valid parent" `Quick
+            test_find_orphaned_units_accepts_valid_parent;
+          test_case "skips root units" `Quick
+            test_find_orphaned_units_skips_root;
+        ] );
+      ( "find_terminal_operations",
+        [
+          test_case "detects completed/failed stale" `Quick
+            test_find_terminal_operations_detects_completed_stale;
+          test_case "skips recent terminal" `Quick
+            test_find_terminal_operations_skips_recent;
+        ] );
+      ( "find_orphaned_detachments",
+        [
+          test_case "detects missing operation" `Quick
+            test_find_orphaned_detachments_detects_missing_operation;
+        ] );
+      ( "find_dropped_intents",
+        [
+          test_case "detects dropped stale" `Quick
+            test_find_dropped_intents_detects_dropped_stale;
+          test_case "skips recent dropped" `Quick
+            test_find_dropped_intents_skips_recent;
+        ] );
+      ( "is_terminal_status",
+        [
+          test_case "terminal vs active status" `Quick
+            test_is_terminal_status;
+        ] );
+      ( "cleanup_result_to_json",
+        [
+          test_case "serializes correctly" `Quick
+            test_cleanup_result_to_json;
+        ] );
+      ( "cutoff_iso",
+        [
+          test_case "produces valid ISO format" `Quick
+            test_cutoff_iso_format;
+        ] );
+    ]


### PR DESCRIPTION
## Summary

- **BUG-006 수정**: `Room.gc()`가 CP 데이터(units, operations, detachments, intents)를 무시하던 문제 해결
- 신규 `cp_cleanup.ml` 모듈: dead units, orphaned units, terminal operations(archive), orphaned detachments, dropped intents 감지 및 정리
- `cp_snapshot.ml`: `is_stale`, `roster_health`, `stale_unit_count`, `operation_status_counts`, `recent_active` 필드 추가

## Changes

| File | Purpose |
|------|---------|
| `lib/cp_cleanup.ml` (신규) | CP data 감지 + 정리 엔진 |
| `lib/room_gc.ml` | GC 8단계에 CP cleanup 연동 (ref 콜백) |
| `lib/command_plane_v2.ml` | 순환 의존 회피 위한 콜백 연결 |
| `lib/env_config_runtime.ml` | `MASC_CP_CLEANUP_DAYS` (기본 14일) |
| `lib/cp_types.ml` | `operation_status_counts`, `stale_unit_count` 타입 추가 |
| `lib/cp_unit.ml` | Tree JSON에 `is_stale`, `roster_health` 추가 |
| `lib/cp_snapshot.ml` | Summary 빌드 헬퍼 추출, status counts/recent_active 추가 |
| `test/test_cp_cleanup.ml` | 14개 unit test |

## Architecture Note

`Room_gc`에서 `Cp_cleanup`을 직접 호출하면 순환 참조 발생 (`Room_gc → Cp_cleanup → Cp_io → Cp_paths → Room → Room_gc`). 기존 `force_release_task_fn` 패턴과 동일한 `ref` 콜백으로 해결.

## Test plan

- [x] `dune build --root .` 성공
- [x] 14개 신규 unit test 통과 (find_dead_units, find_orphaned_units, find_terminal_operations, find_orphaned_detachments, find_dropped_intents, is_terminal_status, cleanup_result_to_json, cutoff_iso)
- [ ] `masc_gc` 호출 시 CP cleanup 결과 출력 확인
- [ ] `masc_observe_topology` 호출 시 `is_stale` 필드 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)