### PR TITLE
fix(dashboard): resolve Dashboard_cache deadlock on nested get_or_compute

### DIFF
--- a/lib/dashboard_cache.ml
+++ b/lib/dashboard_cache.ml
@@ -1,21 +1,22 @@
 (** Dashboard response cache — time-bounded memoization for heavy JSON computations.
 
-    Prevents duplicate computation when multiple dashboard endpoints request
-    the same underlying data within a short window. For example, /room-truth
-    internally calls dashboard_execution which also serves /execution; the
-    cache ensures the expensive computation runs at most once per TTL window.
+    Per-key locking prevents deadlock from nested [get_or_compute] calls while
+    still guarding against stampede (multiple fibers computing the same key).
 
-    Thread-safety: Eio.Mutex guards all table access. The lock is held during
-    compute() — this is intentional in Eio's cooperative model where CPU-bound
-    work doesn't yield, so holding the lock prevents duplicate computation
-    without adding extra blocking. *)
+    The single [Eio.Mutex] guards only [Hashtbl] access.  [compute] functions
+    execute without holding the lock, so nested calls for different keys
+    proceed without blocking. *)
 
 type entry = {
   value : Yojson.Safe.t;
   expires_at : float;
 }
 
-let table : (string, entry) Hashtbl.t = Hashtbl.create 16
+type slot =
+  | Ready of entry
+  | Computing of Eio.Condition.t
+
+let table : (string, slot) Hashtbl.t = Hashtbl.create 16
 let mu = Eio.Mutex.create ()
 let eio_available = ref false
 
@@ -23,39 +24,112 @@ let enable_eio () = eio_available := true
 
 let now () = Time_compat.now ()
 
-let with_lock f =
-  if !eio_available then
-    Eio.Mutex.use_rw ~protect:true mu (fun () -> f ())
-  else
-    f ()
+(** Eio path: per-key locking with stampede protection.
+    [mu] is held only during [Hashtbl] lookups/updates, never during [compute]. *)
+let get_or_compute_eio key ~ttl compute =
+  let rec try_get () =
+    let action =
+      Eio.Mutex.use_rw ~protect:true mu (fun () ->
+        match Hashtbl.find_opt table key with
+        | Some (Ready entry) when entry.expires_at > now () ->
+          `Hit entry.value
+        | Some (Computing cond) ->
+          Eio.Condition.await cond mu;
+          `Retry
+        | _ ->
+          let cond = Eio.Condition.create () in
+          Hashtbl.replace table key (Computing cond);
+          `Compute cond)
+    in
+    match action with
+    | `Hit v -> v
+    | `Retry -> try_get ()
+    | `Compute cond ->
+      (match compute () with
+       | value ->
+         Eio.Mutex.use_rw ~protect:true mu (fun () ->
+           Hashtbl.replace table key
+             (Ready { value; expires_at = now () +. ttl }));
+         Eio.Condition.broadcast cond;
+         value
+       | exception exn ->
+         let bt = Printexc.get_raw_backtrace () in
+         Eio.Mutex.use_rw ~protect:true mu (fun () ->
+           Hashtbl.remove table key);
+         Eio.Condition.broadcast cond;
+         Printexc.raise_with_backtrace exn bt)
+  in
+  try_get ()
+
+(** Non-Eio fallback: no mutex, no concurrency. *)
+let get_or_compute_simple key ~ttl compute =
+  match Hashtbl.find_opt table key with
+  | Some (Ready entry) when entry.expires_at > now () -> entry.value
+  | _ ->
+    let value = compute () in
+    Hashtbl.replace table key (Ready { value; expires_at = now () +. ttl });
+    value
 
 let get_or_compute key ~ttl compute =
-  with_lock (fun () ->
-    match Hashtbl.find_opt table key with
-    | Some entry when entry.expires_at > now () -> entry.value
-    | _ ->
-      let value = compute () in
-      Hashtbl.replace table key
-        { value; expires_at = now () +. ttl };
-      value)
+  if !eio_available then get_or_compute_eio key ~ttl compute
+  else get_or_compute_simple key ~ttl compute
 
-let invalidate key = with_lock (fun () -> Hashtbl.remove table key)
+let invalidate key =
+  if !eio_available then
+    let cond_opt =
+      Eio.Mutex.use_rw ~protect:true mu (fun () ->
+        let c =
+          match Hashtbl.find_opt table key with
+          | Some (Computing cond) -> Some cond
+          | _ -> None
+        in
+        Hashtbl.remove table key;
+        c)
+    in
+    Option.iter Eio.Condition.broadcast cond_opt
+  else Hashtbl.remove table key
 
-let invalidate_all () = with_lock (fun () -> Hashtbl.clear table)
+let invalidate_all () =
+  if !eio_available then
+    let conds =
+      Eio.Mutex.use_rw ~protect:true mu (fun () ->
+        let cs =
+          Hashtbl.fold
+            (fun _key slot acc ->
+              match slot with Computing cond -> cond :: acc | _ -> acc)
+            table []
+        in
+        Hashtbl.clear table;
+        cs)
+    in
+    List.iter Eio.Condition.broadcast conds
+  else Hashtbl.clear table
 
 let stats () =
-  with_lock (fun () ->
+  let compute () =
     let now_ts = now () in
     let total = Hashtbl.length table in
     let active =
       Hashtbl.fold
-        (fun _key entry count ->
-          if entry.expires_at > now_ts then count + 1 else count)
+        (fun _key slot count ->
+          match slot with
+          | Ready entry when entry.expires_at > now_ts -> count + 1
+          | _ -> count)
+        table 0
+    in
+    let computing =
+      Hashtbl.fold
+        (fun _key slot count ->
+          match slot with Computing _ -> count + 1 | _ -> count)
         table 0
     in
     `Assoc
       [
         ("entries", `Int total);
         ("active", `Int active);
-        ("expired", `Int (total - active));
-      ])
+        ("computing", `Int computing);
+        ("expired", `Int (total - active - computing));
+      ]
+  in
+  if !eio_available then Eio.Mutex.use_rw ~protect:true mu compute
+  else compute ()

--- a/lib/dashboard_cache.mli
+++ b/lib/dashboard_cache.mli
@@ -1,7 +1,9 @@
 (** Dashboard response cache — time-bounded memoization for heavy JSON computations.
 
-    Prevents duplicate computation when multiple dashboard endpoints request
-    the same underlying data within a short window (e.g., room-truth + execution). *)
+    Per-key locking prevents deadlock from nested [get_or_compute] calls while
+    still guarding against stampede (multiple fibers computing the same key).
+    [compute] functions execute without holding the lock, so nested calls for
+    different keys proceed without blocking. *)
 
 val enable_eio : unit -> unit
 (** Activate Eio.Mutex guards. Call once inside [Eio_main.run]. *)
@@ -9,14 +11,19 @@ val enable_eio : unit -> unit
 val get_or_compute : string -> ttl:float -> (unit -> Yojson.Safe.t) -> Yojson.Safe.t
 (** [get_or_compute key ~ttl f] returns a cached value if [key] exists and
     has not expired, otherwise calls [f ()] and stores the result for [ttl]
-    seconds. The mutex is held during [f], which prevents duplicate
-    computation for the same key in a cooperative scheduler. *)
+    seconds.
+
+    Safe to nest: [f] may call [get_or_compute] for a different key without
+    deadlocking.  Concurrent requests for the same key are serialised — only
+    one [f] runs; others wait for the result (stampede protection). *)
 
 val invalidate : string -> unit
-(** Remove a single cache entry. *)
+(** Remove a single cache entry.  If the key is currently being computed,
+    waiting fibers are woken and will recompute. *)
 
 val invalidate_all : unit -> unit
 (** Remove all cache entries. Useful after mutations that change dashboard state. *)
 
 val stats : unit -> Yojson.Safe.t
-(** Returns [{"entries": N, "active": M, "expired": K}] for diagnostics. *)
+(** Returns [{"entries": N, "active": M, "computing": C, "expired": K}]
+    for diagnostics. *)

--- a/lib/dashboard_execution.ml
+++ b/lib/dashboard_execution.ml
@@ -1879,12 +1879,15 @@ let json ?actor ?fixture ~config ~sw ~clock ~proc_mgr () =
           mcp_session_id = None;
         }
       in
+      (* Yield between heavy phases so SSE / health-check fibers can progress *)
+      Eio.Fiber.yield ();
       (* Load sessions once; pass to snapshot_json to avoid repeated filesystem scans *)
       let sessions =
         if Room.is_initialized config then
           Team_session_store.list_sessions config
         else []
       in
+      Eio.Fiber.yield ();
       let snapshot_json =
         Dashboard_cache.get_or_compute
           (Printf.sprintf "snapshot:%s" effective_actor)
@@ -1899,6 +1902,7 @@ let json ?actor ?fixture ~config ~sw ~clock ~proc_mgr () =
               ~sessions
               ctx)
       in
+      Eio.Fiber.yield ();
       let digest_json =
         Dashboard_cache.get_or_compute
           (Printf.sprintf "digest:%s" effective_actor)

--- a/lib/server_dashboard_http.ml
+++ b/lib/server_dashboard_http.ml
@@ -342,7 +342,8 @@ let dashboard_messages_safe config ~since_seq ~limit =
   Room.get_messages_raw_in_room config ~room_id:(dashboard_current_room_id config) ~since_seq ~limit
 
 let dashboard_shell_http_json (config : Room.config) : Yojson.Safe.t =
-  let agents = dashboard_agents_safe config in
+  Dashboard_cache.get_or_compute "shell" ~ttl:2.0 (fun () ->
+    let agents = dashboard_agents_safe config in
   let tasks = dashboard_tasks_safe config in
   let keepers_json = keepers_dashboard_json ~compact:true config in
   let keepers_total = json_int_field "total" keepers_json ~default:0 in
@@ -357,7 +358,7 @@ let dashboard_shell_http_json (config : Room.config) : Yojson.Safe.t =
             ("tasks", `Int (List.length tasks));
             ("keepers", `Int keepers_total);
           ] );
-    ]
+      ])
 
 let dashboard_tools_http_json ?actor (config : Room.config) : Yojson.Safe.t =
   let ctx : Tool_misc.context =
@@ -550,10 +551,7 @@ let dashboard_room_truth_focus_json ~initialized ~agent_count ~operator_digest_j
 
 let dashboard_room_truth_http_json ~state ~sw ~clock request =
   let config = state.Mcp_server.room_config in
-  let shell_json =
-    Dashboard_cache.get_or_compute "shell" ~ttl:3.0 (fun () ->
-      dashboard_shell_http_json config)
-  in
+  let shell_json = dashboard_shell_http_json config in
   let execution_json = dashboard_execution_http_json ~state ~sw ~clock request in
   let command_summary_json =
     if Room.is_initialized config then

--- a/test/dune
+++ b/test/dune
@@ -81,6 +81,12 @@
  (modules test_dashboard_proof)
  (libraries masc_mcp alcotest yojson unix))
 
+; Dashboard cache deadlock regression + stampede tests (requires Eio)
+(test
+ (name test_dashboard_cache)
+ (modules test_dashboard_cache)
+ (libraries masc_mcp alcotest eio eio_main yojson))
+
 ; Dashboard execution test (requires Eio)
 (test
  (name test_dashboard_execution)

--- a/test/test_dashboard_cache.ml
+++ b/test/test_dashboard_cache.ml
@@ -1,0 +1,170 @@
+(** Dashboard_cache deadlock regression + stampede + expiry tests.
+
+    These tests run inside [Eio_main.run] so that [Eio.Mutex] and
+    [Eio.Condition] are fully operational. *)
+
+open Masc_mcp
+
+let check_json msg expected actual =
+  Alcotest.(check string) msg
+    (Yojson.Safe.to_string expected)
+    (Yojson.Safe.to_string actual)
+
+(* -- 1. Nested get_or_compute must not deadlock ----------------------------- *)
+
+let test_nested_no_deadlock () =
+  Dashboard_cache.invalidate_all ();
+  let result =
+    Dashboard_cache.get_or_compute "outer" ~ttl:5.0 (fun () ->
+      let inner =
+        Dashboard_cache.get_or_compute "inner" ~ttl:5.0 (fun () ->
+          `String "inner_ok")
+      in
+      `Assoc [("inner", inner)])
+  in
+  check_json "nested no deadlock"
+    (`Assoc [("inner", `String "inner_ok")])
+    result
+
+(* -- 2. Triple nesting (mirrors room-truth -> execution -> snapshot) -------- *)
+
+let test_triple_nesting () =
+  Dashboard_cache.invalidate_all ();
+  let result =
+    Dashboard_cache.get_or_compute "level1" ~ttl:5.0 (fun () ->
+      let l2 =
+        Dashboard_cache.get_or_compute "level2" ~ttl:5.0 (fun () ->
+          let l3 =
+            Dashboard_cache.get_or_compute "level3" ~ttl:5.0 (fun () ->
+              `String "deep")
+          in
+          `Assoc [("l3", l3)])
+      in
+      `Assoc [("l2", l2)])
+  in
+  check_json "triple nesting"
+    (`Assoc [("l2", `Assoc [("l3", `String "deep")])])
+    result
+
+(* -- 3. Cache hit: second call skips compute -------------------------------- *)
+
+let test_cache_hit () =
+  Dashboard_cache.invalidate_all ();
+  let counter = ref 0 in
+  let compute () = incr counter; `Int !counter in
+  let v1 = Dashboard_cache.get_or_compute "hit" ~ttl:5.0 compute in
+  let v2 = Dashboard_cache.get_or_compute "hit" ~ttl:5.0 compute in
+  check_json "same value" v1 v2;
+  Alcotest.(check int) "compute once" 1 !counter
+
+(* -- 4. Invalidate removes entry -------------------------------------------- *)
+
+let test_invalidate () =
+  Dashboard_cache.invalidate_all ();
+  let counter = ref 0 in
+  let compute () = incr counter; `Int !counter in
+  ignore (Dashboard_cache.get_or_compute "inv" ~ttl:5.0 compute);
+  Dashboard_cache.invalidate "inv";
+  let v = Dashboard_cache.get_or_compute "inv" ~ttl:5.0 compute in
+  Alcotest.(check int) "recompute after invalidate" 2 !counter;
+  check_json "new value" (`Int 2) v
+
+(* -- 5. Stats reports active + computing ------------------------------------ *)
+
+let test_stats () =
+  Dashboard_cache.invalidate_all ();
+  ignore (Dashboard_cache.get_or_compute "s1" ~ttl:10.0 (fun () -> `Null));
+  ignore (Dashboard_cache.get_or_compute "s2" ~ttl:10.0 (fun () -> `Null));
+  let stats = Dashboard_cache.stats () in
+  let active = Yojson.Safe.Util.(member "active" stats |> to_int) in
+  Alcotest.(check int) "2 active entries" 2 active
+
+(* -- 6. Stampede: N fibers, same key -> compute runs once ------------------- *)
+
+let test_stampede () =
+  Dashboard_cache.invalidate_all ();
+  let compute_count = Atomic.make 0 in
+  let slow_compute () =
+    Atomic.incr compute_count;
+    (* Yield to let other fibers attempt get_or_compute *)
+    Eio.Fiber.yield ();
+    `String "computed"
+  in
+  Eio.Fiber.all [
+    (fun () -> ignore (Dashboard_cache.get_or_compute "stmp" ~ttl:5.0 slow_compute));
+    (fun () -> ignore (Dashboard_cache.get_or_compute "stmp" ~ttl:5.0 slow_compute));
+    (fun () -> ignore (Dashboard_cache.get_or_compute "stmp" ~ttl:5.0 slow_compute));
+  ];
+  Alcotest.(check int) "stampede: compute once" 1 (Atomic.get compute_count)
+
+(* -- 7. Exception during compute: key cleaned up, next call retries --------- *)
+
+let test_exception_recovery () =
+  Dashboard_cache.invalidate_all ();
+  let raised =
+    (try
+       ignore
+         (Dashboard_cache.get_or_compute "fail" ~ttl:5.0 (fun () ->
+            failwith "boom"));
+       false
+     with Failure _ -> true)
+  in
+  Alcotest.(check bool) "exception propagated" true raised;
+  (* Key should be removed -- next call recomputes *)
+  let v =
+    Dashboard_cache.get_or_compute "fail" ~ttl:5.0 (fun () ->
+      `String "recovered")
+  in
+  check_json "recovered after exception" (`String "recovered") v
+
+(* -- 8. Invalidate_all wakes Computing waiters ------------------------------ *)
+
+let test_invalidate_all_wakes_waiters () =
+  Dashboard_cache.invalidate_all ();
+  let finished = Atomic.make false in
+  Eio.Fiber.both
+    (fun () ->
+       (* This fiber will block waiting for "blocking" to be computed *)
+       let v =
+         Dashboard_cache.get_or_compute "blocking" ~ttl:5.0 (fun () ->
+           (* Signal that compute started, then yield to let waiter attach *)
+           Eio.Fiber.yield ();
+           `String "first")
+       in
+       check_json "first compute" (`String "first") v)
+    (fun () ->
+       (* Let the first fiber start computing *)
+       Eio.Fiber.yield ();
+       Eio.Fiber.yield ();
+       (* invalidate_all should clear everything *)
+       Dashboard_cache.invalidate_all ();
+       Atomic.set finished true);
+  Alcotest.(check bool) "both fibers finished" true (Atomic.get finished)
+
+(* -- Harness ---------------------------------------------------------------- *)
+
+let () =
+  Eio_main.run @@ fun _env ->
+  Dashboard_cache.enable_eio ();
+  let open Alcotest in
+  run ~and_exit:false "Dashboard_cache"
+    [
+      ( "deadlock",
+        [
+          test_case "nested get_or_compute" `Quick test_nested_no_deadlock;
+          test_case "triple nesting" `Quick test_triple_nesting;
+        ] );
+      ( "correctness",
+        [
+          test_case "cache hit" `Quick test_cache_hit;
+          test_case "invalidate" `Quick test_invalidate;
+          test_case "stats" `Quick test_stats;
+          test_case "exception recovery" `Quick test_exception_recovery;
+          test_case "invalidate_all wakes waiters" `Quick
+            test_invalidate_all_wakes_waiters;
+        ] );
+      ( "concurrency",
+        [
+          test_case "stampede protection" `Quick test_stampede;
+        ] );
+    ]


### PR DESCRIPTION
## Summary

- **Root cause**: `Dashboard_cache` used a single non-reentrant `Eio.Mutex` that held the lock during `compute()`. Nested `get_or_compute` calls (room-truth -> execution -> snapshot) caused permanent deadlock, blocking 7+ dashboard endpoints.
- **Fix**: Per-key locking — mutex guards only `Hashtbl` access, `compute()` runs lock-free. `Eio.Condition` provides stampede protection for same-key concurrent requests.
- **Yields**: 3 `Eio.Fiber.yield()` before heavy computation phases so SSE/health-check fibers get execution time.
- **Shell cache**: Moved cache into `dashboard_shell_http_json` so all callers (direct, room-truth, h2 gateway) benefit.

## Test plan

- [x] 8 new regression tests: nested calls, triple nesting, stampede, exception recovery, invalidation
- [x] `dune build` passes
- [x] Full `dune test` suite passes (no regressions)
- [ ] Manual: `localhost:8935/dashboard` loads all panels in < 3s (no pending requests)
- [ ] Manual: Network tab shows no 30s timeouts

🤖 Generated with [Claude Code](https://claude.com/claude-code)