### PR TITLE
fix(room): remove orphaned update_priority causing build failure

### DIFF
--- a/lib/room.ml
+++ b/lib/room.ml
@@ -477,10 +477,6 @@ include Room_task
 (* Walph control system: state machine, loop, presets *)
 include Room_walph
 
-
-(** Update task priority *)
-let update_priority config ~task_id ~priority =
-
 (* Task/agent/message query and listing *)
 include Room_query
 


### PR DESCRIPTION
## Summary

- PR #1208 room refactoring left a body-less `let update_priority config ~task_id ~priority =` before `include Room_query`, causing a syntax error on line 485
- The function already exists in `room_query.ml` — this was just a leftover declaration
- Fixes CI build failure on main (all 4 required checks failing)

## Test plan

- [x] `dune build` passes locally
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)