### PR TITLE
refactor: use OAS checkpoint cost and inline extract_text

### DIFF
--- a/lib/local_agent_eio.ml
+++ b/lib/local_agent_eio.ml
@@ -1157,16 +1157,11 @@ let oas_provider_of_model (model : Llm_client.model_spec) : Oas.Provider.config 
           static_token = None;
         };
     model_id = model.model_id;
-    api_key_env = "DUMMY_KEY";
+    api_key_env = Option.value ~default:"DUMMY_KEY" model.api_key_env;
   }
 
 let oas_tool_names (tools : Oas.Tool.t list) =
   List.map (fun (tool : Oas.Tool.t) -> tool.schema.name) tools
-
-let oas_extract_text (response : Oas.Types.api_response) =
-  response.content
-  |> List.filter_map (function Oas.Types.Text text -> Some text | _ -> None)
-  |> String.concat "\n"
 
 let make_worker_meta ~base_path ~workspace_path ~team_session_id ~worker_name
     ~mcp_session_id ~role ~selection_note ~execution_scope ~worker_class
@@ -1461,7 +1456,13 @@ let run_worker_oas ~sw ~base_path ~worker_name
           Oas.Agent.close agent;
           match result with
           | Ok response ->
-              let output = oas_extract_text response in
+              let output =
+                response.content
+                |> List.filter_map (function
+                     | Oas.Types.Text text -> Some text
+                     | _ -> None)
+                |> String.concat "\n"
+              in
               let* () =
                 append_worker_completion_log ~base_path ~team_session_id
                   ~worker_name ~prompt ~tool_names ~status:"ok" ~output ()
@@ -1474,9 +1475,7 @@ let run_worker_oas ~sw ~base_path ~worker_name
                      else model.model_id);
                   input_tokens = Some checkpoint.usage.total_input_tokens;
                   output_tokens = Some checkpoint.usage.total_output_tokens;
-                  cost_usd = estimate_cost_usd model
-                      (make_usage ~input_tokens:checkpoint.usage.total_input_tokens
-                         ~output_tokens:checkpoint.usage.total_output_tokens ());
+                  cost_usd = Some checkpoint.usage.estimated_cost_usd;
                   tool_call_count = List.length tool_names;
                   tool_names;
                   session_id = mcp_session_id;
@@ -1695,7 +1694,13 @@ let continue_worker ?worker_run_id ~sw ~base_path ~room_config ~worker_name
               Oas.Agent.close agent;
               match result with
               | Ok response ->
-                  let output = oas_extract_text response in
+                  let output =
+                    response.content
+                    |> List.filter_map (function
+                         | Oas.Types.Text text -> Some text
+                         | _ -> None)
+                    |> String.concat "\n"
+                  in
                   let* () =
                     append_worker_completion_log ~base_path ~team_session_id
                       ~worker_name ~prompt ~tool_names ~status:"ok" ~output ()
@@ -1708,12 +1713,7 @@ let continue_worker ?worker_run_id ~sw ~base_path ~room_config ~worker_name
                          else meta.effective_model);
                       input_tokens = Some next_checkpoint.usage.total_input_tokens;
                       output_tokens = Some next_checkpoint.usage.total_output_tokens;
-                      cost_usd =
-                        estimate_cost_usd model
-                          (make_usage
-                             ~input_tokens:next_checkpoint.usage.total_input_tokens
-                             ~output_tokens:next_checkpoint.usage.total_output_tokens
-                             ());
+                      cost_usd = Some next_checkpoint.usage.estimated_cost_usd;
                       tool_call_count = List.length tool_names;
                       tool_names;
                       session_id = meta.mcp_session_id;


### PR DESCRIPTION
## Summary
- OAS path의 cost 계산을 `checkpoint.usage.estimated_cost_usd`로 교체 (cache-aware pricing)
- `oas_extract_text` 함수 삭제, call site에 인라인
- provider config의 `api_key_env`를 `model.api_key_env`에서 가져오도록 수정

## Context
`local_agent_eio.ml`(1945줄)이 OAS 위에 불필요한 glue 레이어를 형성하고 있었다.
OAS가 이미 제공하는 기능(cache-aware pricing, structured content blocks)을 활용하도록 정리.

관련 PR: jeong-sik/oas (feat/v0.31.0-integration)

## Changes
- `lib/local_agent_eio.ml`: OAS path 2곳에서 `estimate_cost_usd` → `checkpoint.usage.estimated_cost_usd`, `oas_extract_text` 인라인 + 삭제, `api_key_env` 수정

## Test plan
- [x] `dune build --root .` 통과
- [x] test_team_session 44개 테스트 통과 (496s)
- [ ] keeper msg 1턴 실행 → cost_usd 필드가 OAS 값과 일치하는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)