### PR TITLE
fix(cp): GLM review — O(n²) → Hashtbl, silent failure warning

### DIFF
--- a/lib/command_plane_v2.ml
+++ b/lib/command_plane_v2.ml
@@ -16,6 +16,7 @@ include Cp_lifecycle_policy
    Room_gc cannot directly reference Cp_cleanup (which depends on Room via
    Cp_io -> Cp_paths -> Room), so we use a ref-based callback. *)
 let () =
+  Room_gc.cp_cleanup_connected := true;
   Room_gc.cp_cleanup_fn :=
     (fun config ->
       let r = Cp_cleanup.cleanup_cp config in

--- a/lib/cp_cleanup.ml
+++ b/lib/cp_cleanup.ml
@@ -7,6 +7,14 @@
 
 include Cp_io
 
+(** Build a hash set from a string list for O(1) membership checks *)
+let string_set_of_list xs =
+  let tbl = Hashtbl.create (List.length xs) in
+  List.iter (fun x -> Hashtbl.replace tbl x ()) xs;
+  tbl
+
+let mem_set tbl key = Hashtbl.mem tbl key
+
 type cleanup_result = {
   dead_units_removed : int;
   orphaned_units_removed : int;
@@ -54,14 +62,14 @@ let find_dead_units ~days units =
 
 (** Find orphaned units: parent_unit_id references a non-existent unit *)
 let find_orphaned_units units =
-  let unit_ids =
-    List.map (fun (unit : unit_record) -> unit.unit_id) units
+  let id_set =
+    string_set_of_list (List.map (fun (u : unit_record) -> u.unit_id) units)
   in
   List.filter
     (fun (unit : unit_record) ->
       match unit.parent_unit_id with
       | None -> false
-      | Some parent_id -> not (List.mem parent_id unit_ids))
+      | Some parent_id -> not (mem_set id_set parent_id))
     units
 
 (** Check if an operation status is terminal *)
@@ -79,9 +87,10 @@ let find_terminal_operations ~days operations =
 
 (** Find orphaned detachments: operation_id references no existing operation *)
 let find_orphaned_detachments ~operation_ids detachments =
+  let op_set = string_set_of_list operation_ids in
   List.filter
     (fun (det : detachment_record) ->
-      not (List.mem det.operation_id operation_ids))
+      not (mem_set op_set det.operation_id))
     detachments
 
 (** Find dropped intents older than threshold *)
@@ -129,14 +138,11 @@ let cleanup_dead_units config ~days units =
   let dead = find_dead_units ~days units in
   if dead = [] then (units, 0)
   else begin
-    let dead_ids =
-      List.map (fun (unit : unit_record) -> unit.unit_id) dead
+    let dead_set =
+      string_set_of_list (List.map (fun (u : unit_record) -> u.unit_id) dead)
     in
     let kept =
-      List.filter
-        (fun (unit : unit_record) ->
-          not (List.mem unit.unit_id dead_ids))
-        units
+      List.filter (fun (u : unit_record) -> not (mem_set dead_set u.unit_id)) units
     in
     write_units config kept;
     (kept, List.length dead)
@@ -147,14 +153,11 @@ let cleanup_orphaned_units config units =
   let orphaned = find_orphaned_units units in
   if orphaned = [] then (units, 0)
   else begin
-    let orphaned_ids =
-      List.map (fun (unit : unit_record) -> unit.unit_id) orphaned
+    let orphan_set =
+      string_set_of_list (List.map (fun (u : unit_record) -> u.unit_id) orphaned)
     in
     let kept =
-      List.filter
-        (fun (unit : unit_record) ->
-          not (List.mem unit.unit_id orphaned_ids))
-        units
+      List.filter (fun (u : unit_record) -> not (mem_set orphan_set u.unit_id)) units
     in
     write_units config kept;
     (kept, List.length orphaned)
@@ -166,14 +169,11 @@ let archive_terminal_operations config ~days operations =
   if terminal = [] then (operations, 0)
   else begin
     archive_operations config terminal;
-    let terminal_ids =
-      List.map (fun (op : operation_record) -> op.operation_id) terminal
+    let terminal_set =
+      string_set_of_list (List.map (fun (op : operation_record) -> op.operation_id) terminal)
     in
     let kept =
-      List.filter
-        (fun (op : operation_record) ->
-          not (List.mem op.operation_id terminal_ids))
-        operations
+      List.filter (fun (op : operation_record) -> not (mem_set terminal_set op.operation_id)) operations
     in
     write_operations config kept;
     (kept, List.length terminal)
@@ -184,14 +184,11 @@ let cleanup_orphaned_detachments config ~operation_ids detachments =
   let orphaned = find_orphaned_detachments ~operation_ids detachments in
   if orphaned = [] then (detachments, 0)
   else begin
-    let orphaned_ids =
-      List.map (fun (det : detachment_record) -> det.detachment_id) orphaned
+    let orphan_set =
+      string_set_of_list (List.map (fun (det : detachment_record) -> det.detachment_id) orphaned)
     in
     let kept =
-      List.filter
-        (fun (det : detachment_record) ->
-          not (List.mem det.detachment_id orphaned_ids))
-        detachments
+      List.filter (fun (det : detachment_record) -> not (mem_set orphan_set det.detachment_id)) detachments
     in
     write_detachments config kept;
     (kept, List.length orphaned)
@@ -202,14 +199,11 @@ let cleanup_dropped_intents config ~days intents =
   let dropped = find_dropped_intents ~days intents in
   if dropped = [] then (intents, 0)
   else begin
-    let dropped_ids =
-      List.map (fun (intent : intent_record) -> intent.intent_id) dropped
+    let drop_set =
+      string_set_of_list (List.map (fun (i : intent_record) -> i.intent_id) dropped)
     in
     let kept =
-      List.filter
-        (fun (intent : intent_record) ->
-          not (List.mem intent.intent_id dropped_ids))
-        intents
+      List.filter (fun (i : intent_record) -> not (mem_set drop_set i.intent_id)) intents
     in
     write_intents config kept;
     (kept, List.length dropped)

--- a/lib/room_gc.ml
+++ b/lib/room_gc.ml
@@ -37,6 +37,8 @@ let empty_cp_result = {
     and Cp_cleanup (e.g. command_plane_v2.ml or room.ml post-include).
     This avoids a circular dependency: Cp_cleanup depends on Cp_io which
     depends on Room, and Room includes Room_gc. *)
+let cp_cleanup_connected = ref false
+
 let cp_cleanup_fn
   : (config -> cp_cleanup_result) ref
   = ref (fun _config -> empty_cp_result)
@@ -341,6 +343,10 @@ let gc config ?(days=7) () =
     results := "✅ No team sessions to archive" :: !results;
 
   (* 7. CP data cleanup (dead units, stale operations, orphaned detachments) *)
+  if not !cp_cleanup_connected then
+    log_event config (Printf.sprintf
+      "{\"type\":\"gc_warning\",\"msg\":\"cp_cleanup_fn not connected, CP cleanup skipped\",\"ts\":\"%s\"}"
+      (now_iso ()));
   let cp_result = !cp_cleanup_fn config in
   let cp_total =
     cp_result.dead_units_removed + cp_result.orphaned_units_removed


### PR DESCRIPTION
## Summary

PR #1211 (CP cleanup) 머지 후 GLM-5 외부 리뷰 대응.

## Changes

- `cp_cleanup.ml`: 모든 `List.mem` 내 `List.filter` → `Hashtbl` 기반 `string_set_of_list`로 O(n) 전환 (O(n²) → O(n))
- `room_gc.ml`: `cp_cleanup_connected` 플래그 추가. 콜백 미연결 시 경고 이벤트 로그 (silent failure 방지)
- `command_plane_v2.ml`: 콜백 설정 시 `cp_cleanup_connected := true`

## CI Note

main에 #1213 리팩토링(`mcp_server_eio` 분할)으로 빌드 에러가 존재. 이 PR의 변경(3개 파일)과 무관. #1213 수정 후 CI green 예상.

## Test plan

- [x] `dune build --root . lib/masc_mcp.a` 성공 (라이브러리 빌드 OK)
- [x] 14개 CP cleanup 테스트 통과
- [ ] #1213 수정 후 전체 빌드 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)