### PR TITLE
refactor(room): scope-based config to eliminate dual-path fallbacks

### DIFF
--- a/lib/mcp_server.ml
+++ b/lib/mcp_server.ml
@@ -540,7 +540,10 @@ type server_state = {
 }
 
 let create_state ~base_path =
-  let config = Room.default_config base_path in
+  let config =
+    Room.default_config base_path
+    |> Room.config_with_resolved_scope
+  in
   let registry = Session.create () in
   (* Restore sessions from disk for persistence across restarts *)
   let agents_path = Filename.concat config.base_path ".masc/agents" in
@@ -563,7 +566,10 @@ let create_state ~base_path =
 
 (** Create state with Eio context - required for PostgresNative backend *)
 let create_state_eio ~sw ~env ~proc_mgr ~fs ~clock ~net ~base_path =
-  let config = Room.default_config_eio ~sw ~env base_path in
+  let config =
+    Room.default_config_eio ~sw ~env base_path
+    |> Room.config_with_resolved_scope
+  in
   let registry = Session.create () in
   let agents_path = Filename.concat config.base_path ".masc/agents" in
   Session.restore_from_disk registry ~agents_path;

--- a/lib/room.ml
+++ b/lib/room.ml
@@ -110,9 +110,11 @@ let join config ~agent_name ?(agent_type_override=None) ~capabilities
     nickname nickname agent_type session_id
   end
 
+(** @deprecated Use [join (with_scope config (Named room_id))] instead. *)
 let join_in_room config ~room_id ~agent_name ?(agent_type_override=None) ~capabilities
     ?(pid=None) ?(hostname=None) ?(tty=None) ?(worktree=None) ?(parent_task=None) () =
-  ensure_room_bootstrap config room_id;
+  let scoped = with_scope config (Named room_id) in
+  ensure_room_bootstrap scoped room_id;
 
   let agent_type = match agent_type_override with
     | Some t -> t
@@ -127,14 +129,14 @@ let join_in_room config ~room_id ~agent_name ?(agent_type_override=None) ~capabi
     else Nickname.generate agent_type
   in
   let agent_file_dedup =
-    Filename.concat (agents_dir_in_room config room_id) (safe_filename nickname ^ ".json")
+    Filename.concat (agents_dir scoped) (safe_filename nickname ^ ".json")
   in
   if Sys.file_exists agent_file_dedup then begin
-    let existing_json = read_json config agent_file_dedup in
+    let existing_json = read_json scoped agent_file_dedup in
     (match agent_of_yojson existing_json with
      | Ok existing_agent ->
          let updated = { existing_agent with last_seen = now_iso () } in
-         write_json config agent_file_dedup (agent_to_yojson updated)
+         write_json scoped agent_file_dedup (agent_to_yojson updated)
      | Error _ -> ());
     Printf.sprintf "✅ %s already in room %s (last_seen updated)" nickname room_id
   end else begin
@@ -149,7 +151,7 @@ let join_in_room config ~room_id ~agent_name ?(agent_type_override=None) ~capabi
       parent_task;
     } in
     let agent_file =
-      Filename.concat (agents_dir_in_room config room_id) (safe_filename nickname ^ ".json")
+      Filename.concat (agents_dir scoped) (safe_filename nickname ^ ".json")
     in
     let agent = {
       name = nickname;
@@ -161,16 +163,16 @@ let join_in_room config ~room_id ~agent_name ?(agent_type_override=None) ~capabi
       last_seen = now_iso ();
       meta = Some meta;
     } in
-    write_json config agent_file (agent_to_yojson agent);
-    let _ = update_state_in_room config room_id (fun s ->
+    write_json scoped agent_file (agent_to_yojson agent);
+    let _ = update_state scoped (fun s ->
       let agents = nickname :: List.filter ((<>) nickname) s.active_agents in
       { s with active_agents = agents }
     ) in
     let _ =
-      broadcast_in_room config ~room_id ~from_agent:nickname
+      broadcast scoped ~from_agent:nickname
         ~content:(Printf.sprintf "👋 %s joined the room" nickname)
     in
-    log_event config (Printf.sprintf
+    log_event scoped (Printf.sprintf
       "{\"type\":\"agent_join\",\"room_id\":\"%s\",\"agent\":\"%s\",\"agent_type\":\"%s\",\"session_id\":\"%s\",\"capabilities\":%s,\"ts\":\"%s\"}"
       room_id
       nickname
@@ -850,16 +852,18 @@ let room_enter config ~room_id ?(agent_name="") ~agent_type () : Yojson.Safe.t =
             with e -> Printf.eprintf "[WARN] room: auto-leave from %s failed: %s\n%!" prev (Printexc.to_string e))
        | _ -> ());
 
-      (* Update current room *)
+      (* Update current room file (for external tools) and create scoped config *)
       write_current_room config room_id;
+      let target_scope = if room_id = "default" then Default else Named room_id in
+      let scoped = with_scope config target_scope in
 
       (* Initialize the room on first entry (no auto-join). *)
-      if not (is_initialized config) then
-        (try ignore (init config ~agent_name:None)
+      if not (is_initialized scoped) then
+        (try ignore (init scoped ~agent_name:None)
          with e -> Printf.eprintf "[WARN] room: init failed for %s: %s\n%!" room_id (Printexc.to_string e));
 
-      (* Join the new room *)
-      let join_result = join config ~agent_name:effective_agent_name ~capabilities:[] () in
+      (* Join the new room using scoped config *)
+      let join_result = join scoped ~agent_name:effective_agent_name ~capabilities:[] () in
 
       (* Extract nickname from join result (format: "  Nickname: xxx\n...") *)
       let nickname =

--- a/lib/room_gc.ml
+++ b/lib/room_gc.ml
@@ -44,26 +44,21 @@ let cp_cleanup_fn
   = ref (fun _config -> empty_cp_result)
 
 
-(** Update agent heartbeat - must be called periodically *)
+(** Update agent heartbeat - must be called periodically.
+    Uses scoped config for room-specific heartbeat. *)
 let heartbeat_in_room config ~room_id ~agent_name =
-  ensure_room_bootstrap config room_id;
-  let actual_name = resolve_agent_name_in_room config ~room_id agent_name in
+  let scoped = with_scope config (Named room_id) in
+  ensure_room_bootstrap scoped room_id;
+  let actual_name = resolve_agent_name config agent_name in
   let filename = safe_filename actual_name ^ ".json" in
-  (* Check room-scoped path first, fallback to root agents_dir *)
-  let room_file = Filename.concat (agents_dir_in_room config room_id) filename in
-  let root_file = Filename.concat (agents_dir config) filename in
-  let agent_file =
-    if path_exists config room_file then room_file
-    else if path_exists config root_file then root_file
-    else room_file (* will fail gracefully below *)
-  in
-  if path_exists config agent_file then begin
-    with_file_lock config agent_file (fun () ->
-      let json = read_json config agent_file in
+  let agent_file = Filename.concat (agents_dir scoped) filename in
+  if path_exists scoped agent_file then begin
+    with_file_lock scoped agent_file (fun () ->
+      let json = read_json scoped agent_file in
       match agent_of_yojson json with
       | Ok agent ->
           let updated = { agent with last_seen = now_iso () } in
-          write_json config agent_file (agent_to_yojson updated);
+          write_json scoped agent_file (agent_to_yojson updated);
           Printf.sprintf "💓 %s heartbeat updated in %s" actual_name room_id
       | Error _ ->
           Printf.sprintf "⚠ Invalid agent file for %s in %s" actual_name room_id
@@ -73,7 +68,22 @@ let heartbeat_in_room config ~room_id ~agent_name =
 
 let heartbeat config ~agent_name =
   ensure_initialized config;
-  heartbeat_in_room config ~room_id:(current_room_id config) ~agent_name
+  let actual_name = resolve_agent_name config agent_name in
+  let filename = safe_filename actual_name ^ ".json" in
+  let agent_file = Filename.concat (agents_dir config) filename in
+  if path_exists config agent_file then begin
+    with_file_lock config agent_file (fun () ->
+      let json = read_json config agent_file in
+      match agent_of_yojson json with
+      | Ok agent ->
+          let updated = { agent with last_seen = now_iso () } in
+          write_json config agent_file (agent_to_yojson updated);
+          Printf.sprintf "💓 %s heartbeat updated" actual_name
+      | Error _ ->
+          Printf.sprintf "⚠ Invalid agent file for %s" actual_name
+    )
+  end else
+    Printf.sprintf "⚠ Agent %s not found" agent_name
 
 (** Cleanup zombie agents - removes stale agents *)
 let is_keeper_runtime_agent_name = Resilience.Zombie.is_keeper_name
@@ -81,15 +91,10 @@ let is_keeper_runtime_agent_name = Resilience.Zombie.is_keeper_name
 let cleanup_zombies config =
   ensure_initialized config;
 
-  (* Scan both root and room-scoped agent directories for consistency
-     with heartbeat_in_room, which may write to either path. *)
-  let root_agents_path = agents_dir config in
-  let room_agents_path =
-    agents_dir_in_room config (current_room_id config)
-  in
+  (* Single path: agents_dir derives from config.scope *)
+  let agents_path = agents_dir config in
   let scan_paths =
-    List.filter Sys.file_exists
-      (List.sort_uniq String.compare [ root_agents_path; room_agents_path ])
+    if Sys.file_exists agents_path then [ agents_path ] else []
   in
   if scan_paths = [] then
     "📋 No agents directory"

--- a/lib/room_state.ml
+++ b/lib/room_state.ml
@@ -62,39 +62,18 @@ let update_state config f =
     new_state
   )
 
+(** @deprecated Use [read_state (with_scope config (Named room_id))] instead. *)
 let state_path_in_room config room_id =
-  Filename.concat (room_dir_for config room_id) "state.json"
+  state_path (with_scope config (Named room_id))
 
 let read_state_in_room config room_id =
-  let json = read_json config (state_path_in_room config room_id) in
-  match room_state_of_yojson json with
-  | Ok state -> state
-  | Error _ ->
-      {
-        protocol_version = "0.1.0";
-        project = Filename.basename config.base_path;
-        started_at = now_iso ();
-        message_seq = 0;
-        active_agents = [];
-        paused = false;
-        pause_reason = None;
-        paused_by = None;
-        paused_at = None;
-        search_strategy_default = Some "best_first_v1";
-        speculation_enabled = false;
-        speculation_budget = None;
-      }
+  read_state (with_scope config (Named room_id))
 
 let write_state_in_room config room_id state =
-  write_json config (state_path_in_room config room_id) (room_state_to_yojson state)
+  write_state (with_scope config (Named room_id)) state
 
 let update_state_in_room config room_id f =
-  with_file_lock config (state_path_in_room config room_id) (fun () ->
-    let state = read_state_in_room config room_id in
-    let new_state = f state in
-    write_state_in_room config room_id new_state;
-    new_state
-  )
+  update_state (with_scope config (Named room_id)) f
 
 (* ============================================ *)
 (* Sequence Numbers                             *)
@@ -106,10 +85,7 @@ let next_seq config =
   state.message_seq
 
 let next_seq_in_room config room_id =
-  let state =
-    update_state_in_room config room_id (fun s -> { s with message_seq = s.message_seq + 1 })
-  in
-  state.message_seq
+  next_seq (with_scope config (Named room_id))
 
 (* ============================================ *)
 (* Pause State                                  *)
@@ -146,23 +122,21 @@ let write_backlog config backlog =
 let current_room_id config =
   read_current_room config |> Option.value ~default:"default"
 
+(** @deprecated Use [agents_dir (with_scope config (Named room_id))] instead. *)
 let agents_dir_in_room config room_id =
-  Filename.concat (room_dir_for config room_id) "agents"
+  agents_dir (with_scope config (Named room_id))
 
 let tasks_dir_in_room config room_id =
-  Filename.concat (room_dir_for config room_id) "tasks"
+  tasks_dir (with_scope config (Named room_id))
 
 let messages_dir_in_room config room_id =
-  Filename.concat (room_dir_for config room_id) "messages"
+  messages_dir (with_scope config (Named room_id))
 
 let backlog_path_in_room config room_id =
-  Filename.concat (tasks_dir_in_room config room_id) "backlog.json"
+  backlog_path (with_scope config (Named room_id))
 
 let read_backlog_in_room config room_id =
-  let json = read_json config (backlog_path_in_room config room_id) in
-  match backlog_of_yojson json with
-  | Ok backlog -> backlog
-  | Error _ -> { tasks = []; last_updated = now_iso (); version = 1 }
+  read_backlog (with_scope config (Named room_id))
 
 (* ============================================ *)
 (* Task ID / Archive Management                 *)
@@ -290,122 +264,68 @@ let resolve_agent_name config agent_name =
       agent_name
   end
 
+(** @deprecated Use [resolve_agent_name (with_scope config (Named room_id))] instead. *)
 let resolve_agent_name_in_room config ~room_id agent_name =
-  let exact_file =
-    Filename.concat (agents_dir_in_room config room_id) (safe_filename agent_name ^ ".json")
-  in
-  if Sys.file_exists exact_file then
-    agent_name
-  else begin
-    let dir = agents_dir_in_room config room_id in
-    if Sys.file_exists dir then
-      let files = Sys.readdir dir in
-      let prefix = agent_name ^ "-" in
-      match Array.find_opt (fun f ->
-        String.length f > String.length prefix &&
-        String.sub f 0 (String.length prefix) = prefix
-      ) files with
-      | Some file -> String.sub file 0 (String.length file - 5)
-      | None ->
-          resolve_agent_name config agent_name
-    else
-      resolve_agent_name config agent_name
-  end
+  resolve_agent_name (with_scope config (Named room_id)) agent_name
 
 (* ============================================ *)
 (* Room Bootstrap                               *)
 (* ============================================ *)
 
+(** Default empty state for bootstrap. *)
+let default_room_state config = {
+  protocol_version = "0.1.0";
+  project = Filename.basename config.base_path;
+  started_at = now_iso ();
+  message_seq = 0;
+  active_agents = [];
+  paused = false;
+  pause_reason = None;
+  paused_by = None;
+  paused_at = None;
+  search_strategy_default = Some "best_first_v1";
+  speculation_enabled = false;
+  speculation_budget = None;
+}
+
 let ensure_room_bootstrap config room_id =
+  (* 1. Always ensure root infrastructure exists *)
   let root_dir = masc_root_dir config in
   let root_agents_dir = Filename.concat root_dir "agents" in
   let root_tasks_dir = Filename.concat root_dir "tasks" in
   let root_messages_dir = Filename.concat root_dir "messages" in
   let root_backlog_path = Filename.concat root_tasks_dir "backlog.json" in
   List.iter mkdir_p [ root_agents_dir; root_tasks_dir; root_messages_dir; rooms_root_dir config ];
-  if not (path_exists_root config (root_state_path config)) then begin
-    let root_state = {
-      protocol_version = "0.1.0";
-      project = Filename.basename config.base_path;
-      started_at = now_iso ();
-      message_seq = 0;
-      active_agents = [];
-      paused = false;
-      pause_reason = None;
-      paused_by = None;
-      paused_at = None;
-      search_strategy_default = Some "best_first_v1";
-      speculation_enabled = false;
-      speculation_budget = None;
-    } in
-    write_json_root config (root_state_path config) (room_state_to_yojson root_state)
-  end;
-  if not (path_exists_root config root_backlog_path) then begin
-    let root_backlog = { tasks = []; last_updated = now_iso (); version = 1 } in
-    write_json_root config root_backlog_path (backlog_to_yojson root_backlog)
-  end;
-  if room_id = "default" then begin
-    List.iter mkdir_p [ agents_dir_in_room config room_id; tasks_dir_in_room config room_id; messages_dir_in_room config room_id ];
-    if not (path_exists config (state_path_in_room config room_id)) then begin
-      let state = {
-        protocol_version = "0.1.0";
-        project = Filename.basename config.base_path;
-        started_at = now_iso ();
-        message_seq = 0;
-        active_agents = [];
-        paused = false;
-        pause_reason = None;
-        paused_by = None;
-        paused_at = None;
-        search_strategy_default = Some "best_first_v1";
-        speculation_enabled = false;
-        speculation_budget = None;
-      } in
-      write_state_in_room config room_id state
-    end;
-    if not (path_exists config (backlog_path_in_room config room_id)) then begin
-      let backlog = { tasks = []; last_updated = now_iso (); version = 1 } in
-      write_json config (backlog_path_in_room config room_id) (backlog_to_yojson backlog)
-    end
-  end
-  else begin
-    let room_path = room_dir_for config room_id in
-    let agents_path = agents_dir_in_room config room_id in
-    let tasks_path = tasks_dir_in_room config room_id in
-    let messages_path = messages_dir_in_room config room_id in
-    let state_path = state_path_in_room config room_id in
-    let backlog_path = backlog_path_in_room config room_id in
-    List.iter mkdir_p [ room_path; agents_path; tasks_path; messages_path ];
-    if not (path_exists config state_path) then begin
-      let state = {
-        protocol_version = "0.1.0";
-        project = Filename.basename config.base_path;
-        started_at = now_iso ();
-        message_seq = 0;
-        active_agents = [];
-        paused = false;
-        pause_reason = None;
-        paused_by = None;
-        paused_at = None;
-        search_strategy_default = Some "best_first_v1";
-        speculation_enabled = false;
-        speculation_budget = None;
-      } in
-      write_state_in_room config room_id state
-    end;
-    if not (path_exists config backlog_path) then begin
-      let backlog = { tasks = []; last_updated = now_iso (); version = 1 } in
-      write_json config backlog_path (backlog_to_yojson backlog)
-    end
-  end
+  if not (path_exists_root config (root_state_path config)) then
+    write_json_root config (root_state_path config)
+      (room_state_to_yojson (default_room_state config));
+  if not (path_exists_root config root_backlog_path) then
+    write_json_root config root_backlog_path
+      (backlog_to_yojson { tasks = []; last_updated = now_iso (); version = 1 });
+
+  (* 2. Bootstrap the target room via scoped config — unified path *)
+  let scoped = with_scope config (Named room_id) in
+  let scoped_agents = agents_dir scoped in
+  let scoped_tasks = tasks_dir scoped in
+  let scoped_messages = messages_dir scoped in
+  let scoped_state = state_path scoped in
+  let scoped_backlog = backlog_path scoped in
+  List.iter mkdir_p [ masc_dir scoped; scoped_agents; scoped_tasks; scoped_messages ];
+  if not (path_exists scoped scoped_state) then
+    write_json scoped scoped_state (room_state_to_yojson (default_room_state config));
+  if not (path_exists scoped scoped_backlog) then
+    write_json scoped scoped_backlog
+      (backlog_to_yojson { tasks = []; last_updated = now_iso (); version = 1 })
 
 (* ============================================ *)
 (* Broadcast                                    *)
 (* ============================================ *)
 
+(** @deprecated Use [broadcast (with_scope config (Named room_id))] instead. *)
 let broadcast_in_room config ~room_id ~from_agent ~content =
-  ensure_room_bootstrap config room_id;
-  let seq = next_seq_in_room config room_id in
+  let scoped = with_scope config (Named room_id) in
+  ensure_room_bootstrap scoped room_id;
+  let seq = next_seq scoped in
 
   let mention = Mention.extract content in
   let safe_content = sanitize_message content in
@@ -419,19 +339,41 @@ let broadcast_in_room config ~room_id ~from_agent ~content =
     timestamp = now_iso ();
   } in
   let msg_file =
-    Filename.concat (messages_dir_in_room config room_id)
+    Filename.concat (messages_dir scoped)
       (Printf.sprintf "%09d_%s_broadcast.json" seq (safe_filename from_agent))
   in
-  write_json config msg_file (message_to_yojson msg);
+  write_json scoped msg_file (message_to_yojson msg);
   let _ =
-    backend_publish config ~channel:(Printf.sprintf "broadcast:%s" room_id)
+    backend_publish scoped ~channel:(Printf.sprintf "broadcast:%s" room_id)
       ~message:(Yojson.Safe.to_string (message_to_yojson msg))
   in
   Printf.sprintf "📢 [%s@%s] %s" safe_agent room_id safe_content
 
 let broadcast config ~from_agent ~content =
   ensure_initialized config;
-  broadcast_in_room config ~room_id:(current_room_id config) ~from_agent ~content
+  let seq = next_seq config in
+  let mention = Mention.extract content in
+  let safe_content = sanitize_message content in
+  let safe_agent = sanitize_agent_name from_agent in
+  let msg = {
+    seq;
+    from_agent = safe_agent;
+    msg_type = "broadcast";
+    content = safe_content;
+    mention;
+    timestamp = now_iso ();
+  } in
+  let msg_file =
+    Filename.concat (messages_dir config)
+      (Printf.sprintf "%09d_%s_broadcast.json" seq (safe_filename from_agent))
+  in
+  write_json config msg_file (message_to_yojson msg);
+  let room_id = match config.scope with Default -> "default" | Named id -> id in
+  let _ =
+    backend_publish config ~channel:(Printf.sprintf "broadcast:%s" room_id)
+      ~message:(Yojson.Safe.to_string (message_to_yojson msg))
+  in
+  Printf.sprintf "📢 [%s@%s] %s" safe_agent room_id safe_content
 
 (* ============================================ *)
 (* Zombie Detection Helpers                     *)

--- a/lib/room_task.ml
+++ b/lib/room_task.ml
@@ -169,14 +169,11 @@ let claim_task_r config ~agent_name ~task_id
   | _, Error e -> Error e
   | Ok _, Ok _ ->
     (* BUG-005: Verify agent has joined before allowing claim.
-       Check both room-scoped and root agent directories for consistency
-       with heartbeat_in_room, which may write to either path. *)
+       Single path: agents_dir derives from config.scope. *)
     let actual_name = resolve_agent_name config agent_name in
     let filename = safe_filename actual_name ^ ".json" in
-    let room_path = Filename.concat
-      (agents_dir_in_room config (current_room_id config)) filename in
-    let root_path = Filename.concat (agents_dir config) filename in
-    let agent_joined = path_exists config room_path || path_exists config root_path in
+    let agent_path = Filename.concat (agents_dir config) filename in
+    let agent_joined = path_exists config agent_path in
     if not agent_joined then
       Error (Types.AgentNotJoined actual_name)
     else

--- a/lib/room_utils_backend_setup.ml
+++ b/lib/room_utils_backend_setup.ml
@@ -6,6 +6,12 @@ type storage_backend =
   | FileSystem of Backend.FileSystemBackend.t
   | PostgresNative of Backend.PostgresNative.t
 
+(** Room scope — determines which directory tree is active.
+    Resolved once at config creation time, never re-read from filesystem. *)
+type scope =
+  | Default          (** Root .masc/ directory *)
+  | Named of string  (** .masc/rooms/{id}/ directory *)
+
 (** Room configuration *)
 type config = {
   base_path: string;
@@ -13,7 +19,11 @@ type config = {
   lock_expiry_minutes: int;
   backend_config: Backend.config;
   backend: storage_backend;
+  scope: scope;
 }
+
+(** Create a config targeting a different scope. Cheap record copy. *)
+let with_scope config scope = { config with scope }
 
 (* ============================================ *)
 (* Git Root Detection (Worktree Support)        *)
@@ -264,6 +274,7 @@ let default_config base_path =
     lock_expiry_minutes = 2;
     backend_config;
     backend;
+    scope = Default;
   }
 
 (** Create config with Eio context - required for PostgresNative backend *)
@@ -309,6 +320,7 @@ let default_config_eio ~sw ~env base_path =
     lock_expiry_minutes = 2;
     backend_config;
     backend;
+    scope = Default;
   }
 
 (* ============================================ *)

--- a/lib/room_utils_paths_backend.ml
+++ b/lib/room_utils_paths_backend.ml
@@ -13,7 +13,8 @@ let rooms_root_dir config = Filename.concat (masc_root_dir config) "rooms"
 let registry_root_path config = Filename.concat (masc_root_dir config) "rooms.json"
 let current_room_root_path config = Filename.concat (masc_root_dir config) "current_room"
 
-(* Legacy paths (pre-room refactor) kept for backward compatibility *)
+(* Legacy paths (pre-room refactor) — kept for read_current_room backward compat.
+   @deprecated Will be removed after all users migrate to scope-based config. *)
 let legacy_rooms_root_dir config = Filename.concat config.base_path "rooms"
 let legacy_registry_root_path config = Filename.concat config.base_path "rooms.json"
 let legacy_current_room_path config = Filename.concat config.base_path "current_room"
@@ -48,10 +49,24 @@ let room_dir_for config room_id =
     else if Sys.file_exists legacy_path then legacy_path
     else root_path
 
-let masc_dir config =
+(** Resolve the initial scope from the current_room file.
+    Called once at config creation time; the result is stored in config.scope
+    so that all subsequent path lookups are pure and deterministic. *)
+let resolve_initial_scope config =
   match read_current_room config with
-  | Some room_id -> room_dir_for config room_id
-  | None -> masc_root_dir config
+  | Some "default" | None -> Default
+  | Some room_id -> Named room_id
+
+(** Scope-based directory resolution.
+    Named scope: pure, deterministic (no filesystem reads).
+    Default scope: reads current_room file for backward compatibility. *)
+let masc_dir config =
+  match config.scope with
+  | Named id -> room_dir_for config id
+  | Default ->
+    match read_current_room config with
+    | Some room_id -> room_dir_for config room_id
+    | None -> masc_root_dir config
 
 let agents_dir config = Filename.concat (masc_dir config) "agents"
 let tasks_dir config = Filename.concat (masc_dir config) "tasks"
@@ -267,6 +282,12 @@ let is_initialized config =
       Sys.file_exists (masc_dir config) &&
       Sys.is_directory (masc_dir config) &&
       Sys.file_exists (state_path config)
+
+(** Create a config with scope resolved from the current_room file.
+    Wraps default_config / default_config_eio output so that masc_dir
+    never needs to read the filesystem again. *)
+let config_with_resolved_scope config =
+  { config with scope = resolve_initial_scope config }
 
 (* ============================================ *)
 (* Validation helpers                           *)

--- a/test/test_handover_eio_coverage.ml
+++ b/test/test_handover_eio_coverage.ml
@@ -210,6 +210,7 @@ let make_test_config ~base_path : Room_utils.config =
     lock_expiry_minutes = 5;
     backend_config;
     backend = Room_utils.Memory memory_backend;
+    scope = Default;
   }
 
 let with_eio_env f =

--- a/test/test_keeper_learning.ml
+++ b/test/test_keeper_learning.ml
@@ -52,6 +52,7 @@ let make_test_config () =
     lock_expiry_minutes = 30;
     backend_config;
     backend = Room_utils.Memory memory_backend;
+    scope = Default;
   } in
   (tmp, config)
 

--- a/test/test_room.ml
+++ b/test/test_room.ml
@@ -234,6 +234,7 @@ let with_memory_test_env f =
     lock_expiry_minutes = 30;
     backend_config;
     backend = Room_utils.Memory memory_backend;
+    scope = Default;
   } in
   let _ = Room.init config ~agent_name:(Some "claude") in
   try

--- a/test/test_room_utils_coverage.ml
+++ b/test/test_room_utils_coverage.ml
@@ -405,6 +405,7 @@ let make_test_config ~base_path ~cluster_name : Room_utils.config =
     lock_expiry_minutes = 30;
     backend_config;
     backend = Room_utils.Memory memory_backend;
+    scope = Default;
   }
 
 let test_masc_root_dir_default_cluster () =

--- a/test/test_tempo_coverage.ml
+++ b/test/test_tempo_coverage.ml
@@ -231,6 +231,7 @@ let make_test_config ~base_path : Room_utils.config =
     lock_expiry_minutes = 30;
     backend_config;
     backend = Room_utils.Memory memory_backend;
+    scope = Default;
   }
 
 let test_tempo_file_basic () =


### PR DESCRIPTION
## Summary

- Room 경로 결정을 runtime 파일 읽기에서 config-time scope로 전환
- `scope = Default | Named of string` 타입을 config에 추가, `with_scope`로 cheap record copy
- heartbeat, cleanup_zombies, claim_task_r에서 dual-path fallback 제거 (버그 #1137, #1138, #1141 원인)
- 12개 `_in_room` 함수를 `with_scope` 기반 thin wrapper로 통합 (deprecated)
- `ensure_room_bootstrap` 단순화: default/non-default 분기 제거

## Background

QA AS1에서 critical 3건이 모두 room/root 경로 이중성에서 기인:
- `join`은 root에 쓰고, `heartbeat_in_room`은 room-scoped에서 읽고, fallback으로 root를 다시 확인
- 115개 `_in_room` 함수 중 95%가 `current_room_id config` 패스스루

## Design

```ocaml
type scope = Default | Named of string

(* Named: pure deterministic path, no filesystem reads *)
(* Default: backward compat, reads current_room file *)

let with_scope config scope = { config with scope }
```

## Test plan

- [x] room tests: 77/77 pass
- [x] multi_room tests: 12/12 pass (room isolation, agent move between rooms)
- [x] room_utils_coverage: 75/75 pass
- [x] `dune build` clean
- [ ] 외부 모델 리뷰 (GLM-5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)