### PR TITLE
fix: resolve 6 buyer-test bugs for better first-use experience

### DIFF
--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -55,7 +55,18 @@ curl -s http://127.0.0.1:8935/api/v1/command-plane/help | jq '.golden_paths[].id
 curl -s http://127.0.0.1:8935/api/v1/command-plane | jq '.operations.summary'
 ```
 
-## 5. 주의
+## 5. 모드 확인
+
+기본 모드는 `Full` (모든 도구 사용 가능). 제한이 필요하면 `Standard`나 `Coding`으로 전환한다.
+
+```
+masc_get_config                       # 현재 모드 확인
+masc_switch_mode(mode="standard")     # 도구 수 제한 시
+```
+
+기존 `.masc/config.json`에 `"mode":"coding"`이 남아 있으면 도구가 차단될 수 있다. 삭제 후 서버 재시작하면 Full 모드로 초기화된다.
+
+## 6. 주의
 
 - `masc_set_room`은 repo-root room semantics를 따른다.
 - `masc_claim`만으로는 session `current_task`가 잡히지 않는다.

--- a/lib/config.ml
+++ b/lib/config.ml
@@ -11,11 +11,11 @@ type t = {
   enabled_categories : category list;
 }
 
-(** Default configuration — Standard mode reduces initial tool count
-    for better agent experience (BUG-017). Use masc_get_config to switch. *)
+(** Default configuration — Full mode gives new users access to all tools.
+    Use masc_switch_mode to restrict if needed (BUG-017 revisited). *)
 let default = {
-  mode = Standard;
-  enabled_categories = categories_for_mode Standard;
+  mode = Full;
+  enabled_categories = categories_for_mode Full;
 }
 
 (** Config file name *)

--- a/lib/council/conversation.ml
+++ b/lib/council/conversation.ml
@@ -299,7 +299,8 @@ let save_thread config (th : thread) : unit =
   let path = thread_path config th.id in
   write_json path (thread_to_yojson th)
 
-let start ~config ~topic ~initiator ?(max_turns = 50) ?(initial_content = "") ?source_post_id ()
+let start ~config ~topic ~initiator ?(max_turns = 50) ?(initial_content = "")
+    ?(mentions = []) ?source_post_id ()
     : (thread, string) result =
   ensure_dirs config;
   let id = generate_thread_id () in
@@ -317,7 +318,7 @@ let start ~config ~topic ~initiator ?(max_turns = 50) ?(initial_content = "") ?s
         created_at = now;
         confidence = None;
         reply_to = None;
-        mentions = [];
+        mentions;
       } in
       ([turn], 1)
     else

--- a/lib/council/conversation.mli
+++ b/lib/council/conversation.mli
@@ -90,6 +90,7 @@ val start :
   initiator:string ->
   ?max_turns:int ->
   ?initial_content:string ->
+  ?mentions:string list ->
   ?source_post_id:string ->
   unit ->
   (thread, string) result

--- a/lib/council/governance_v2.ml
+++ b/lib/council/governance_v2.ml
@@ -862,6 +862,28 @@ let save_ruling base_path (ruling : ruling) =
   let updated_case = { case_ with status = next_status; updated_at = now_unix () } in
   write_case base_path updated_case;
   write_ruling base_path ruling;
+  (* Auto-create execution order when ruling triggers Ready_auto_execute
+     and no order exists yet. This closes the gap where sentinel-submitted
+     rulings set the case status but never create the order needed for
+     downstream execution. *)
+  (if next_status = Ready_auto_execute then
+     match load_execution_order base_path ruling.case_id with
+     | Some _ -> ()  (* Order already exists *)
+     | None ->
+         let now = now_unix () in
+         let order : execution_order = {
+           id = generate_id "order";
+           case_id = ruling.case_id;
+           status = Queued_auto;
+           risk_class = ruling.risk_class;
+           action_request = ruling.recommended_action;
+           created_at = now;
+           updated_at = now;
+           execution_ref = None;
+           result_summary = None;
+           actor = Some ruling.keeper_name;
+         } in
+         write_execution_order base_path order);
   Ok updated_case
 
 let save_execution_order base_path (order : execution_order) =

--- a/lib/room.ml
+++ b/lib/room.ml
@@ -24,12 +24,29 @@ let join config ~agent_name ?(agent_type_override=None) ~capabilities
           agent_name  (* Legacy: agent_name is the type *)
   in
 
-  (* Generate unique nickname if agent_name is just a type *)
+  (* Reuse existing nickname for same agent_type if already joined,
+     otherwise generate a new one. This prevents identity drift when
+     the same agent_name joins multiple times within a session. *)
   let nickname =
     if Nickname.is_generated_nickname agent_name then
       agent_name  (* Already a nickname, use as-is *)
-    else
-      Nickname.generate agent_type  (* Generate new nickname *)
+    else begin
+      let dir = agents_dir config in
+      let prefix = safe_filename agent_type ^ "-" in
+      let existing =
+        if Sys.file_exists dir && Sys.is_directory dir then
+          Array.to_list (Sys.readdir dir)
+          |> List.find_opt (fun f ->
+               Filename.check_suffix f ".json"
+               && String.length f > String.length prefix
+               && String.sub f 0 (String.length prefix) = prefix)
+          |> Option.map (fun f -> Filename.chop_suffix f ".json")
+        else None
+      in
+      match existing with
+      | Some nick -> nick  (* Reuse existing nickname for this agent_type *)
+      | None -> Nickname.generate agent_type
+    end
   in
 
   (* Dedup: if agent already joined, update last_seen and return early *)

--- a/lib/sentinel.ml
+++ b/lib/sentinel.ml
@@ -525,10 +525,10 @@ let make_governance_sweep_consumer config : (module Pulse.Consumer) =
         let base_path = config.Room_utils.base_path in
         let now_f = Time_compat.now () in
         let petitions_created = ref 0 in
-        let submit ~title ~subject_type ~risk_class =
+        let submit ~title ~subject_type ~risk_class ?(source_refs=[]) () =
           match Council.Governance_v2.submit_petition base_path
             ~title ~origin:"sentinel" ~subject_type ~risk_class
-            ~requested_action:None ~source_refs:[] ~created_by:agent_name with
+            ~requested_action:None ~source_refs ~created_by:agent_name with
           | Ok result ->
               incr petitions_created;
               (* Auto-submit brief for new cases to unblock ruling pipeline *)
@@ -566,6 +566,7 @@ let make_governance_sweep_consumer config : (module Pulse.Consumer) =
                 submit
                   ~title:(sprintf "Stuck task: %s (claimed by %s)" t.title assignee)
                   ~subject_type:"task" ~risk_class:Council.Governance_v2.Low
+                  ~source_refs:["task-" ^ t.id] ()
               end
           | Types.InProgress { assignee; started_at } ->
               let age = now_f -. (parse_iso_or_epoch started_at) in
@@ -575,6 +576,7 @@ let make_governance_sweep_consumer config : (module Pulse.Consumer) =
                 submit
                   ~title:(sprintf "Stuck task: %s (in_progress by %s)" t.title assignee)
                   ~subject_type:"task" ~risk_class:Council.Governance_v2.Low
+                  ~source_refs:["task-" ^ t.id] ()
               end
           | _ -> ()
         ) backlog.tasks;
@@ -602,6 +604,7 @@ let make_governance_sweep_consumer config : (module Pulse.Consumer) =
                     ~title:(sprintf "Keeper %s failing (%d consecutive failures)"
                       keeper_name consecutive_failures)
                     ~subject_type:"keeper" ~risk_class:Council.Governance_v2.High
+                    ~source_refs:["keeper-" ^ keeper_name] ()
                 end
               with
               | Yojson.Json_error _ | Sys_error _ -> ()
@@ -621,6 +624,7 @@ let make_governance_sweep_consumer config : (module Pulse.Consumer) =
               ~title:(sprintf "Flagged post by %s (down=%d, up=%d)"
                 (Board.Agent_id.to_string p.author) p.votes_down p.votes_up)
               ~subject_type:"board_post" ~risk_class:Council.Governance_v2.Low
+              ~source_refs:["post-" ^ Board.Post_id.to_string p.id] ()
         ) board_posts;
 
         if !petitions_created > 0 then

--- a/lib/server_dashboard_http.ml
+++ b/lib/server_dashboard_http.ml
@@ -13,6 +13,19 @@ include Dashboard_http_monitoring
 include Dashboard_http_keeper
 include Dashboard_http_mdal
 
+(** Wrap a dashboard computation with a 15-second timeout.
+    Returns a partial-response JSON on timeout instead of hanging. *)
+let with_dashboard_timeout ~clock compute =
+  match Eio.Time.with_timeout clock 15.0 (fun () -> Ok (compute ())) with
+  | Ok v -> v
+  | Error `Timeout ->
+      `Assoc [
+        ("error", `String "timeout");
+        ("partial", `Bool true);
+        ("message", `String "Dashboard computation timed out after 15s. Check LLM backend availability.");
+        ("generated_at", `String (Types.now_iso ()));
+      ]
+
 let dashboard_semantics_http_json () =
   Dashboard_semantics.json ()
 
@@ -218,10 +231,11 @@ let dashboard_mission_http_json ~state ~sw ~clock request =
   let cache_key =
     Printf.sprintf "mission:%s" (Option.value ~default:"" actor)
   in
-  Dashboard_cache.get_or_compute cache_key ~ttl:3.0 (fun () ->
-    Dashboard_mission.json ?actor
-      ~config:state.Mcp_server.room_config ~sw ~clock
-      ~proc_mgr:state.Mcp_server.proc_mgr ())
+  with_dashboard_timeout ~clock (fun () ->
+    Dashboard_cache.get_or_compute cache_key ~ttl:3.0 (fun () ->
+      Dashboard_mission.json ?actor
+        ~config:state.Mcp_server.room_config ~sw ~clock
+        ~proc_mgr:state.Mcp_server.proc_mgr ()))
 
 let dashboard_session_http_json ~state ~sw ~clock request =
   match query_param request "session_id" with
@@ -244,10 +258,11 @@ let dashboard_session_http_json ~state ~sw ~clock request =
         ]
 
 let dashboard_mission_briefing_http_json ~state ~sw ~clock request =
-  Dashboard_mission_briefing.json ?actor:(operator_actor_hint request)
-    ~force:(bool_query_param request "force" ~default:false)
-    ~config:state.Mcp_server.room_config ~sw ~clock
-    ~proc_mgr:state.Mcp_server.proc_mgr ()
+  with_dashboard_timeout ~clock (fun () ->
+    Dashboard_mission_briefing.json ?actor:(operator_actor_hint request)
+      ~force:(bool_query_param request "force" ~default:false)
+      ~config:state.Mcp_server.room_config ~sw ~clock
+      ~proc_mgr:state.Mcp_server.proc_mgr ())
 
 let dashboard_proof_http_json ~state request =
   let session_id = query_param request "session_id" in
@@ -382,10 +397,11 @@ let dashboard_execution_http_json ~state ~sw ~clock request =
       (Option.value ~default:"" actor)
       (Option.value ~default:"" fixture)
   in
-  Dashboard_cache.get_or_compute cache_key ~ttl:3.0 (fun () ->
-    Dashboard_execution.json ?actor ?fixture
-      ~config:state.Mcp_server.room_config ~sw ~clock
-      ~proc_mgr:state.Mcp_server.proc_mgr ())
+  with_dashboard_timeout ~clock (fun () ->
+    Dashboard_cache.get_or_compute cache_key ~ttl:3.0 (fun () ->
+      Dashboard_execution.json ?actor ?fixture
+        ~config:state.Mcp_server.room_config ~sw ~clock
+        ~proc_mgr:state.Mcp_server.proc_mgr ()))
 
 let dashboard_room_truth_focus_json ~initialized ~agent_count ~operator_digest_json ~top_queue =
   let recommendation_summary =

--- a/lib/tool_inline_dispatch.ml
+++ b/lib/tool_inline_dispatch.ml
@@ -1032,6 +1032,7 @@ Call masc_listen again to continue listening.
       let initial_content = arg_get_string "initial_content" "" in
       let max_turns = arg_get_int "max_turns" 50 in
       let source_post_id = arg_get_string_opt "post_id" in
+      let mentions = arg_get_string_list "mentions" in
       let current_room = Room.read_current_room config |> Option.value ~default:"default" in
       if topic = "" then Some (false, "topic required")
       else begin
@@ -1040,7 +1041,7 @@ Call masc_listen again to continue listening.
           room = current_room;
         } in
         match Council.Conversation.start ~config:convo_config ~topic ~initiator
-                ~max_turns ~initial_content ?source_post_id () with
+                ~max_turns ~initial_content ~mentions ?source_post_id () with
         | Ok thread ->
             let link_warning = match source_post_id with
               | Some pid ->

--- a/lib/tool_schemas_core.ml
+++ b/lib/tool_schemas_core.ml
@@ -1444,6 +1444,11 @@ Use to: monitor cache health, decide when to clear, debug performance.";
           ("type", `String "string");
           ("description", `String "Board post ID to link this thread to (bidirectional: thread.source_post_id ↔ post.thread_id)");
         ]);
+        ("mentions", `Assoc [
+          ("type", `String "array");
+          ("items", `Assoc [("type", `String "string")]);
+          ("description", `String "Agents @mentioned in the opening message");
+        ]);
       ]);
       ("required", `List [`String "topic"; `String "initiator"]);
     ];


### PR DESCRIPTION
## Summary

구매자/연구자 관점 테스트(Buyer Test)에서 발견된 14건 중 코드 수정이 필요한 6건을 수정.

- **FIX-1**: 기본 config 모드를 `Standard`→`Full`로 변경. 새 사용자가 모든 도구에 즉시 접근 가능
- **FIX-2**: Sentinel governance sweep에서 `source_refs`에 entity ID(`task-*`, `keeper-*`, `post-*`)를 전달하여 기존 dedup 로직 활성화. 동일 stuck task에 대한 반복 case 생성 방지
- **FIX-3**: `masc_convo_start`에 `mentions` 파라미터 추가 (스키마 + 핸들러 + API). `masc_convo_reply`와 동일한 패턴
- **FIX-4**: 같은 `agent_type`으로 반복 `masc_join` 시 기존 nickname 재사용. identity drift 방지
- **FIX-5**: Dashboard mission/briefing/execution 엔드포인트에 15초 Eio timeout 방어. LLM 미가동 시 무한 대기 대신 partial JSON 반환
- **FIX-6**: `save_ruling`에서 `Ready_auto_execute` 전환 시 execution order 자동 생성. sentinel 경로의 auto-execute gap 해소

추가: `room.ml`의 orphaned `update_priority` stub 제거 (빌드 에러 수정)

## Test plan

- [x] `test_config_coverage` (39 tests) 통과
- [x] `test_mode_coverage` (50 tests) 통과
- [x] `test_room` (77 tests) 통과
- [x] `test_dashboard_governance` (1 test) 통과
- [x] `test_guardian_sentinel` (7 tests) 통과
- [x] `test_dashboard` (13 tests) 통과
- [x] `test_mode_tool_count` (18 tests) 통과
- [ ] `.masc/config.json` 삭제 후 서버 재시작 → `masc_get_config` mode=full 확인
- [ ] 동일 stuck task에 대해 sweep 2회 → case 중복 없음 확인
- [ ] `masc_convo_start(mentions=["sangsu"])` → turn.mentions 확인
- [ ] `masc_join(claude)` 2회 → 동일 nickname 반환 확인
- [ ] LLM 미가동 상태에서 `/dashboard/mission` → 15초 내 partial response
- [ ] `ready_auto_execute` case → execution_orders에 order 존재 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)