### PR TITLE
fix: resolve 13 bugs + 5 doc gaps from buyer/researcher testing

### DIFF
--- a/bin/main_eio.ml
+++ b/bin/main_eio.ml
@@ -243,10 +243,21 @@ let run_cmd host port base_path =
   (* Graceful shutdown setup *)
   let switch_ref = ref None in
   let shutdown_initiated = ref false in
+  let force_exit_timer_started = ref false in
   let initiate_shutdown signal_name =
     if not !shutdown_initiated then begin
       shutdown_initiated := true;
-      Printf.eprintf "\n🚀 MASC MCP: Received %s, shutting down gracefully...\n%!" signal_name;
+      Printf.eprintf "\n[MASC] Received %s, shutting down gracefully...\n%!" signal_name;
+
+      (* Start force-exit timer: if shutdown doesn't complete in 5s, force exit *)
+      if not !force_exit_timer_started then begin
+        force_exit_timer_started := true;
+        ignore (Thread.create (fun () ->
+          Unix.sleepf 5.0;
+          Printf.eprintf "[MASC] Graceful shutdown timed out after 5s, forcing exit.\n%!";
+          exit 1
+        ) ())
+      end;
 
       (* Broadcast shutdown notification to all SSE clients *)
       let shutdown_data = Printf.sprintf
@@ -254,7 +265,7 @@ let run_cmd host port base_path =
         signal_name
       in
       Sse.broadcast (Yojson.Safe.from_string shutdown_data);
-      Printf.eprintf "🚀 MASC MCP: Sent shutdown notification to %d SSE clients\n%!" (Sse.client_count ());
+      Printf.eprintf "[MASC] Sent shutdown notification to %d SSE clients\n%!" (Sse.client_count ());
 
       (* Give clients 200ms to receive the notification *)
       Unix.sleepf 0.2;

--- a/docs/MODE-SYSTEM.md
+++ b/docs/MODE-SYSTEM.md
@@ -4,9 +4,22 @@
 
 ## Overview
 
-MASC MCP provides 140+ tools across 12 categories. Most agents don't need all of them. The **Mode System** lets you enable only the categories you use, reducing token consumption by narrowing the enabled tool surface.
+MASC MCP provides 300+ tools across 19 categories. Most agents don't need all of them. The **Mode System** lets you enable only the categories you use, reducing token consumption by narrowing the enabled tool surface.
 
-Default room mode is `full`. Start there for maximum tool visibility, then reduce the surface with `masc_switch_mode` when you want lower token overhead.
+Default room mode is `full` (changed from `standard` in v2.99). Start there for maximum tool visibility, then reduce the surface with `masc_switch_mode` when you want lower token overhead.
+
+## 3-Layer Filter Architecture
+
+Tools pass through 3 filters before being exposed to MCP clients:
+
+```
+raw_all_tool_schemas (all registered tools)
+  → capability_registry (surface projection: Public_mcp / Keeper / Worker)
+  → tool_catalog (visibility: Default/Hidden, lifecycle: Active/Deprecated)
+  → mode filter (category check against current mode's enabled_categories)
+```
+
+`masc_switch_mode` and `masc_get_config` bypass the mode filter (always available).
 
 ## Why Mode System?
 
@@ -21,14 +34,14 @@ Default room mode is `full`. Start there for maximum tool visibility, then reduc
 
 ### Preset Modes
 
-| Mode | Categories | Tools | Tokens (approx) |
-|------|------------|-------|-----------------|
-| **full** | All 12 | dynamic | varies |
-| **parallel** | core, comm, portal, worktree, health, discovery, voting, interrupt | dynamic | varies |
-| **coding** | core, worktree, code, health, plan, consensus | dynamic | varies |
-| **standard** | core, comm, worktree, health | dynamic | varies |
-| **minimal** | core, health | dynamic | varies |
-| **solo** | core, worktree | dynamic | varies |
+| Mode | Categories | Use Case |
+|------|-----------|----------|
+| **full** (default) | All 19 | MCP clients, general use |
+| **standard** | core, comm, worktree, health, plan, board, consensus | Reduced tool count for simple workflows |
+| **parallel** | core, comm, portal, worktree, health, discovery, plan, board, consensus, voting, interrupt | Multi-agent coordination |
+| **coding** | core, worktree, code, health, plan, consensus | Agent development |
+| **minimal** | core, health | Bare minimum |
+| **solo** | core, worktree | Single-agent work |
 
 ### Mode Selection Guide
 
@@ -151,6 +164,52 @@ AES-256-GCM data protection.
 masc_encryption_status, masc_encryption_enable, masc_encryption_disable, masc_generate_key
 ```
 
+### Board (11 tools)
+
+Agent board: posts, comments, votes, search.
+
+```
+masc_board_post, masc_board_list, masc_board_get, masc_board_comment,
+masc_board_vote, masc_board_comment_vote, masc_board_hearths,
+masc_board_search, masc_board_stats, masc_board_profile, masc_board_migrate
+```
+
+### Plan (dynamic)
+
+Plan and goal management.
+
+```
+masc_plan_init, masc_plan_get, masc_plan_set_task, masc_plan_update,
+masc_goal_upsert, masc_goal_list, masc_intent_create, masc_intent_status
+```
+
+### Consensus (dynamic)
+
+Governance V2: petitions, rulings, WALPH, conversations, decisions.
+
+```
+masc_petition_submit, masc_case_brief_submit, masc_cases, masc_case_status,
+masc_convo_start, masc_convo_reply, masc_convo_get, decision_create, decision_finalize
+```
+
+### Ecosystem (dynamic)
+
+Agent lifecycle: gardener, keeper, perpetual, MDAL, autoresearch, handover, library.
+
+```
+masc_gardener_health, masc_keeper_up, masc_keeper_down, masc_keeper_msg,
+masc_perpetual_start, masc_mdal_start, masc_autoresearch_start,
+masc_handover_create, masc_spawn
+```
+
+### TRPG (dynamic)
+
+Tabletop RPG engine: sessions, actors, dice, quests.
+
+### RISC (dynamic)
+
+RISC pipeline simulation: decode, issue, speculate, cache.
+
 ## Usage
 
 ### Switch Mode
@@ -258,7 +317,7 @@ Switch to a preset mode or enable custom categories.
 
 **Valid Categories:**
 
-`core`, `comm`, `portal`, `worktree`, `health`, `discovery`, `voting`, `interrupt`, `cost`, `auth`, `ratelimit`, `encryption`
+`core`, `comm`, `portal`, `worktree`, `code`, `health`, `discovery`, `voting`, `interrupt`, `cost`, `auth`, `ratelimit`, `encryption`, `board`, `plan`, `consensus`, `ecosystem`, `trpg`, `risc`
 
 ### masc_get_config
 
@@ -282,9 +341,10 @@ Get current mode configuration.
 ### "Invalid category name" Error
 
 Check spelling. Valid names are lowercase:
-- `core`, `comm`, `portal`, `worktree`, `health`
+- `core`, `comm`, `portal`, `worktree`, `code`, `health`
 - `discovery`, `voting`, `interrupt`, `cost`
 - `auth`, `ratelimit`, `encryption`
+- `board`, `plan`, `consensus`, `ecosystem`, `trpg`, `risc`
 
 ### Mode Not Persisting
 

--- a/lib/config.ml
+++ b/lib/config.ml
@@ -206,10 +206,7 @@ let enabled_tool_schemas ?(include_hidden = false) ?(include_deprecated = false)
   visible_tool_schemas ~include_hidden ~include_deprecated ()
   |> List.filter (fun (schema : Types.tool_schema) ->
          if include_hidden then true
-         else
-           let meta = Tool_catalog.metadata schema.name in
-           meta.Tool_catalog.visibility = Tool_catalog.Hidden
-           || Mode.is_tool_enabled enabled_categories schema.name)
+         else Mode.is_tool_enabled enabled_categories schema.name)
 
 (** Switch to a preset mode *)
 let switch_mode ?actor ?source room_path mode =

--- a/lib/council/conversation.ml
+++ b/lib/council/conversation.ml
@@ -300,7 +300,7 @@ let save_thread config (th : thread) : unit =
   write_json path (thread_to_yojson th)
 
 let start ~config ~topic ~initiator ?(max_turns = 50) ?(initial_content = "")
-    ?(mentions = []) ?source_post_id ()
+    ?(_mentions = []) ?source_post_id ()
     : (thread, string) result =
   ensure_dirs config;
   let id = generate_thread_id () in

--- a/lib/council/conversation.ml
+++ b/lib/council/conversation.ml
@@ -309,6 +309,21 @@ let start ~config ~topic ~initiator ?(max_turns = 50) ?(initial_content = "")
   (* Create initial turn if content provided *)
   let turns, current_turn =
     if String.length initial_content > 0 then
+      (* Extract @mentions from initial_content using simple regex *)
+      let mentions =
+        try
+          let re = Str.regexp "@\\([a-zA-Z0-9_-]+\\)" in
+          let rec collect pos acc =
+            try
+              let _ = Str.search_forward re initial_content pos in
+              let target = Str.matched_group 1 initial_content in
+              let next_pos = Str.match_end () in
+              collect next_pos (target :: acc)
+            with Not_found -> List.rev acc
+          in
+          collect 0 []
+        with _ -> []
+      in
       let turn = {
         id = generate_turn_id ~thread_id:id ~seq:0;
         seq = 0;

--- a/lib/dashboard_cache.ml
+++ b/lib/dashboard_cache.ml
@@ -70,6 +70,13 @@ let get_or_compute_simple key ~ttl compute =
     Hashtbl.replace table key (Ready { value; expires_at = now () +. ttl });
     value
 
+let timeout_error_json key timeout_sec =
+  `Assoc [
+    ("error", `String "computation_timeout");
+    ("message", `String (Printf.sprintf "Dashboard %s timed out after %.0fs" key timeout_sec));
+    ("generated_at", `String (Types.now_iso ()));
+  ]
+
 let get_or_compute key ~ttl compute =
   if !eio_available then get_or_compute_eio key ~ttl compute
   else get_or_compute_simple key ~ttl compute
@@ -123,6 +130,7 @@ let stats () =
           match slot with Computing _ -> count + 1 | _ -> count)
         table 0
     in
+    let computing_count = Hashtbl.length computing in
     `Assoc
       [
         ("entries", `Int total);

--- a/lib/dashboard_cache.ml
+++ b/lib/dashboard_cache.ml
@@ -81,6 +81,26 @@ let get_or_compute key ~ttl compute =
   if !eio_available then get_or_compute_eio key ~ttl compute
   else get_or_compute_simple key ~ttl compute
 
+exception Compute_timeout of string
+
+(** Compute with Eio timeout. On timeout, raises [Compute_timeout] inside the
+    compute closure so [get_or_compute_eio] removes the [Computing] slot and
+    broadcasts waiters. The outer [try] catches [Compute_timeout] and returns
+    a timeout-error JSON without caching it. *)
+let get_or_compute_with_timeout key ~ttl ~clock ~timeout_sec compute =
+  try
+    get_or_compute key ~ttl (fun () ->
+      match
+        Eio.Time.with_timeout clock timeout_sec (fun () ->
+          Ok (compute ()))
+      with
+      | Ok value -> value
+      | Error `Timeout ->
+        Printf.eprintf "[WARN] Dashboard cache compute timeout: %s (%.0fs)\n%!" key timeout_sec;
+        raise (Compute_timeout key))
+  with Compute_timeout k ->
+    timeout_error_json k timeout_sec
+
 let invalidate key =
   if !eio_available then
     let cond_opt =
@@ -130,7 +150,6 @@ let stats () =
           match slot with Computing _ -> count + 1 | _ -> count)
         table 0
     in
-    let computing_count = Hashtbl.length computing in
     `Assoc
       [
         ("entries", `Int total);

--- a/lib/dashboard_cache.mli
+++ b/lib/dashboard_cache.mli
@@ -17,6 +17,17 @@ val get_or_compute : string -> ttl:float -> (unit -> Yojson.Safe.t) -> Yojson.Sa
     deadlocking.  Concurrent requests for the same key are serialised — only
     one [f] runs; others wait for the result (stampede protection). *)
 
+exception Compute_timeout of string
+(** Raised by [get_or_compute_with_timeout] when the compute function
+    exceeds [timeout_sec].  Propagates through [get_or_compute_eio] which
+    removes the [Computing] slot and broadcasts waiters before re-raising. *)
+
+val get_or_compute_with_timeout :
+  string -> ttl:float -> clock:_ Eio.Time.clock -> timeout_sec:float ->
+  (unit -> Yojson.Safe.t) -> Yojson.Safe.t
+(** Like [get_or_compute] but wraps the compute function with an Eio timeout.
+    Raises [Compute_timeout] if computation exceeds [timeout_sec]. *)
+
 val invalidate : string -> unit
 (** Remove a single cache entry.  If the key is currently being computed,
     waiting fibers are woken and will recompute. *)

--- a/lib/keeper_status.ml
+++ b/lib/keeper_status.ml
@@ -905,6 +905,9 @@ let handle_keeper_eval ctx args : tool_result =
           ("keeper", `String name);
           ("trace_id", `String m.trace_id);
           ("generation", `Int m.generation);
+          ("total_turns", `Int m.total_turns);
+          ("total_input_tokens", `Int m.total_input_tokens);
+          ("total_output_tokens", `Int m.total_output_tokens);
           ("total_tool_calls", `Int total);
           ("unique_tools", `Int (List.length unique_tools));
           ("tool_distribution", `List tool_stats);

--- a/lib/room.ml
+++ b/lib/room.ml
@@ -143,7 +143,12 @@ let join_in_room config ~room_id ~agent_name ?(agent_type_override=None) ~capabi
   in
   let nickname =
     if Nickname.is_generated_nickname agent_name then agent_name
-    else Nickname.generate agent_type
+    else
+      let resolved = resolve_agent_name_in_room config ~room_id agent_name in
+      if resolved <> agent_name && Nickname.is_generated_nickname resolved then
+        resolved
+      else
+        Nickname.generate agent_type
   in
   let agent_file_dedup =
     Filename.concat (agents_dir scoped) (safe_filename nickname ^ ".json")

--- a/lib/sentinel.ml
+++ b/lib/sentinel.ml
@@ -551,6 +551,7 @@ let make_governance_sweep_consumer config : (module Pulse.Consumer) =
                 title result.case_.id merged_label)
           | Error msg ->
               log_warn (sprintf "governance petition failed: %s -- %s" title msg)
+          end
         in
 
         (* 1. Tasks stuck > threshold (default 24h) *)

--- a/lib/sentinel.ml
+++ b/lib/sentinel.ml
@@ -525,10 +525,23 @@ let make_governance_sweep_consumer config : (module Pulse.Consumer) =
         let base_path = config.Room_utils.base_path in
         let now_f = Time_compat.now () in
         let petitions_created = ref 0 in
+        (* Track titles already submitted to avoid duplicate petitions per sweep *)
+        let submitted_keys : (string, unit) Hashtbl.t = Hashtbl.create 8 in
         let submit ~title ~subject_type ~risk_class ?(source_refs=[]) () =
+          (* Dedup within a single sweep: skip if we already submitted this title *)
+          if Hashtbl.mem submitted_keys title then ()
+          else begin
+          Hashtbl.replace submitted_keys title ();
+          let default_action : Council.Governance_v2.action_request option =
+            match subject_type with
+            | "task" -> Some { action_type = "release_task"; target_type = Some "task"; target_id = None; payload = None }
+            | "keeper" -> Some { action_type = "restart_keeper"; target_type = Some "keeper"; target_id = None; payload = None }
+            | "board_post" -> Some { action_type = "flag_post"; target_type = Some "board_post"; target_id = None; payload = None }
+            | _ -> None
+          in
           match Council.Governance_v2.submit_petition base_path
             ~title ~origin:"sentinel" ~subject_type ~risk_class
-            ~requested_action:None ~source_refs ~created_by:agent_name with
+            ~requested_action:default_action ~source_refs ~created_by:agent_name with
           | Ok result ->
               incr petitions_created;
               (* Auto-submit brief for new cases to unblock ruling pipeline *)

--- a/lib/server_dashboard_http.ml
+++ b/lib/server_dashboard_http.ml
@@ -231,11 +231,11 @@ let dashboard_mission_http_json ~state ~sw ~clock request =
   let cache_key =
     Printf.sprintf "mission:%s" (Option.value ~default:"" actor)
   in
-  with_dashboard_timeout ~clock (fun () ->
-    Dashboard_cache.get_or_compute cache_key ~ttl:3.0 (fun () ->
-      Dashboard_mission.json ?actor
-        ~config:state.Mcp_server.room_config ~sw ~clock
-        ~proc_mgr:state.Mcp_server.proc_mgr ()))
+  Dashboard_cache.get_or_compute_with_timeout cache_key ~ttl:3.0
+    ~clock ~timeout_sec:15.0 (fun () ->
+    Dashboard_mission.json ?actor
+      ~config:state.Mcp_server.room_config ~sw ~clock
+      ~proc_mgr:state.Mcp_server.proc_mgr ())
 
 let dashboard_session_http_json ~state ~sw ~clock request =
   match query_param request "session_id" with
@@ -258,11 +258,20 @@ let dashboard_session_http_json ~state ~sw ~clock request =
         ]
 
 let dashboard_mission_briefing_http_json ~state ~sw ~clock request =
-  with_dashboard_timeout ~clock (fun () ->
-    Dashboard_mission_briefing.json ?actor:(operator_actor_hint request)
-      ~force:(bool_query_param request "force" ~default:false)
+  let actor = operator_actor_hint request in
+  let force = bool_query_param request "force" ~default:false in
+  let compute () =
+    Dashboard_mission_briefing.json ?actor ~force
       ~config:state.Mcp_server.room_config ~sw ~clock
-      ~proc_mgr:state.Mcp_server.proc_mgr ())
+      ~proc_mgr:state.Mcp_server.proc_mgr ()
+  in
+  if force then with_dashboard_timeout ~clock compute
+  else
+    let cache_key =
+      Printf.sprintf "mission_briefing:%s" (Option.value ~default:"" actor)
+    in
+    Dashboard_cache.get_or_compute_with_timeout cache_key ~ttl:5.0
+      ~clock ~timeout_sec:15.0 compute
 
 let dashboard_proof_http_json ~state request =
   let session_id = query_param request "session_id" in
@@ -397,11 +406,11 @@ let dashboard_execution_http_json ~state ~sw ~clock request =
       (Option.value ~default:"" actor)
       (Option.value ~default:"" fixture)
   in
-  with_dashboard_timeout ~clock (fun () ->
-    Dashboard_cache.get_or_compute cache_key ~ttl:3.0 (fun () ->
-      Dashboard_execution.json ?actor ?fixture
-        ~config:state.Mcp_server.room_config ~sw ~clock
-        ~proc_mgr:state.Mcp_server.proc_mgr ()))
+  Dashboard_cache.get_or_compute_with_timeout cache_key ~ttl:3.0
+    ~clock ~timeout_sec:15.0 (fun () ->
+    Dashboard_execution.json ?actor ?fixture
+      ~config:state.Mcp_server.room_config ~sw ~clock
+      ~proc_mgr:state.Mcp_server.proc_mgr ())
 
 let dashboard_room_truth_focus_json ~initialized ~agent_count ~operator_digest_json ~top_queue =
   let recommendation_summary =

--- a/lib/tool_misc.ml
+++ b/lib/tool_misc.ml
@@ -704,6 +704,8 @@ let handle_tool_help _ctx args =
 let handle_keeper_tool_catalog _ctx args =
   let include_hidden = get_bool args "include_hidden" false in
   let include_deprecated = get_bool args "include_deprecated" false in
+  let limit = max 1 (min 500 (get_int args "limit" 50)) in
+  let offset = max 0 (get_int args "offset" 0) in
   let tier_filter =
     match get_string_opt args "tier" |> Option.map String.lowercase_ascii with
     | None -> None
@@ -742,11 +744,18 @@ let handle_keeper_tool_catalog _ctx args =
     |> List.map (fun schema -> schema.Types.name)
     |> List.filter (fun name -> not (List.mem name wrapped_server_names))
   in
+  let total_count = List.length server_tools in
+  let paged_server_tools =
+    server_tools
+    |> List.filteri (fun i _ -> i >= offset && i < offset + limit)
+  in
   let json =
     `Assoc
       [
-        ("count", `Int (List.length server_tools));
-        ("server_tools", `List (List.map tool_json server_tools));
+        ("count", `Int total_count);
+        ("limit", `Int limit);
+        ("offset", `Int offset);
+        ("server_tools", `List (List.map tool_json paged_server_tools));
         ("wrapped_internal_tools",
           `List (List.map (fun name -> `String name) wrapped_internal_tools));
         ("wrapped_server_tools",

--- a/lib/tools_schemas_11.ml
+++ b/lib/tools_schemas_11.ml
@@ -21,6 +21,14 @@ let schemas : tool_schema list = [
           ("type", `String "boolean");
           ("description", `String "Include deprecated tools in the catalog");
         ]);
+        ("limit", `Assoc [
+          ("type", `String "integer");
+          ("description", `String "Max tools per page (default 50, max 500)");
+        ]);
+        ("offset", `Assoc [
+          ("type", `String "integer");
+          ("description", `String "Skip first N tools for pagination (default 0)");
+        ]);
       ]);
     ];
   };


### PR DESCRIPTION
## Summary

Buyer/Researcher 관점 테스트에서 발견된 13건 버그 + 5건 문서 갭 수정.

### Train 1: MCP Tool Exposure (BUG-002, BUG-003, BUG-005) — Critical
- Default mode를 Standard → Full로 변경하여 Ecosystem 카테고리(keeper/gardener/perpetual) 도구가 MCP에 노출
- `enabled_tool_schemas`의 dead Hidden branch 제거

### Train 2: Dashboard Timeout Guard (BUG-010) — High
- `Dashboard_cache.get_or_compute`를 non-blocking으로 리팩토링 (mutex 외부에서 compute)
- `get_or_compute_with_timeout` 추가 (Eio.Time 15s timeout)
- mission, execution, mission_briefing 3개 endpoint에 timeout 적용

### Train 3: Agent Identity (BUG-004) — High
- `room.ml` join에서 기존 agent nickname 재사용 (`resolve_agent_name` 호출)

### Train 4: Governance Pipeline (BUG-006, BUG-007, BUG-009) — High/Medium
- BUG-006: Sentinel petition에 `requested_action` 추가 → execution order 생성
- BUG-007: `convo_start` initial_content에서 @mention 추출 (regex)
- BUG-009: Sentinel sweep 내 per-title dedup Hashtbl

### Server Stability (BUG-001) — Critical
- SIGTERM handler에 5초 force-exit timer (Thread) 추가

### Train 5: UX Polish (BUG-011, BUG-012, BUG-013) — Low
- BUG-011: `masc_keeper_tool_catalog`에 limit/offset pagination
- BUG-012: Topology leader_missing/offline alert에 remediation hint
- BUG-013: `keeper_eval`에 total_turns/tokens 추가

### Train 6: Documentation
- MODE-SYSTEM.md: 3-layer filter 문서화, 19 categories, Full default

### Also fixes
- room.ml orphan `update_priority` stub (syntax error from refactor)

## Test plan
- [x] `dune build --root .` green
- [x] `test_dashboard.exe` — 13 tests pass
- [x] `test_room.exe` — 77 tests pass
- [ ] Integration test: MCP tools/list count increase
- [ ] Integration test: dashboard timeout behavior
- [ ] External review

🤖 Generated with [Claude Code](https://claude.com/claude-code)