### PR TITLE
fix(build): resolve type errors from mcp_server_eio split

### DIFF
--- a/lib/mcp_server_eio.ml
+++ b/lib/mcp_server_eio.ml
@@ -158,8 +158,8 @@ let handle_request
     ~handle_call_tool_eio:(fun ~sw ~clock ~profile ?mcp_session_id ?auth_token state id params ->
        Mcp_server_eio_call_tool.handle_call_tool_eio
          ~execute_tool_eio
-         ~maybe_emit_resource_notifications:(fun ~success:_ ~tool_name:_ -> ())
-         ~broadcast_tools_list_changed:(fun () -> ())
+         ~maybe_emit_resource_notifications:Mcp_server_eio_protocol.maybe_emit_resource_notifications
+         ~broadcast_tools_list_changed:Mcp_server_eio_protocol.broadcast_tools_list_changed
          ~sw ~clock ~profile ?mcp_session_id ?auth_token state id params)
     ~handle_read_resource_eio:Mcp_server_eio_resource.handle_read_resource_eio
     ~clock ~sw

--- a/lib/mcp_server_eio.ml
+++ b/lib/mcp_server_eio.ml
@@ -155,9 +155,23 @@ let handle_request
     state
     request_str =
   Mcp_server_eio_protocol.handle_request
-    ~clock ~sw ~execute_tool_eio ~log_mcp_exn
+    ~handle_call_tool_eio:(fun ~sw ~clock ~profile ?mcp_session_id ?auth_token state id params ->
+       Mcp_server_eio_call_tool.handle_call_tool_eio
+         ~execute_tool_eio
+         ~maybe_emit_resource_notifications:(fun ~success:_ ~tool_name:_ -> ())
+         ~broadcast_tools_list_changed:(fun () -> ())
+         ~sw ~clock ~profile ?mcp_session_id ?auth_token state id params)
+    ~handle_read_resource_eio:Mcp_server_eio_resource.handle_read_resource_eio
+    ~clock ~sw
     ~profile:(profile : tool_profile :> Mcp_server_eio_types.tool_profile)
     ?mcp_session_id ?auth_token state request_str
 
+(** Re-export transport mode from protocol for backward compatibility *)
+type transport_mode = Mcp_server_eio_protocol.transport_mode = Framed | LineDelimited
+let detect_mode = Mcp_server_eio_protocol.detect_mode
+
 let run_stdio ~sw ~env state =
-  Mcp_server_eio_protocol.run_stdio ~sw ~env ~execute_tool_eio ~log_mcp_exn state
+  let handle_request ~clock ~sw ~mcp_session_id state request_str =
+    handle_request ~clock ~sw ~mcp_session_id state request_str
+  in
+  Mcp_server_eio_protocol.run_stdio ~handle_request ~sw ~env state

--- a/lib/mcp_server_eio.mli
+++ b/lib/mcp_server_eio.mli
@@ -177,13 +177,7 @@ val make_response : id:Yojson.Safe.t -> Yojson.Safe.t -> Yojson.Safe.t
 val make_error : ?data:Yojson.Safe.t -> id:Yojson.Safe.t -> int -> string -> Yojson.Safe.t
 
 (** {1 Protocol Detection} *)
-
-(** Transport mode for stdio transport *)
 type transport_mode = Framed | LineDelimited
-
-(** Detect transport mode from first line of input.
-    If line starts with "Content-Length" (case-insensitive), returns Framed.
-    Otherwise returns LineDelimited. *)
 val detect_mode : string -> transport_mode
 
 (** {1 Governance} *)

--- a/lib/mcp_server_eio_dispatch.ml
+++ b/lib/mcp_server_eio_dispatch.ml
@@ -5,7 +5,7 @@
 *)
 
 (** All pre-built tool contexts needed for the dispatch chain. *)
-type dispatch_contexts = {
+type ('clock, 'net) dispatch_contexts = {
   config : Room.config;
   agent_name : string;
   arguments : Yojson.Safe.t;
@@ -18,9 +18,9 @@ type dispatch_contexts = {
   registry : Session.registry;
   ctx_plan : Tool_plan.context;
   ctx_run : Tool_run.context;
-  ctx_team_session : float Tool_team_session.context;
-  ctx_operator : Tool_operator.context;
-  ctx_command_plane : (Eio.Net.Sockaddr.stream, Eio.Net.connection_handler) Tool_command_plane.context;
+  ctx_team_session : float Eio.Time.clock_ty Tool_team_session.context;
+  ctx_operator : float Eio.Time.clock_ty Tool_operator.context;
+  ctx_command_plane : ('clock, 'net) Tool_command_plane.context;
   ctx_cache : Tool_cache.context;
   ctx_tempo : Tool_tempo.context;
   ctx_mitosis : Tool_mitosis.context;
@@ -35,14 +35,14 @@ type dispatch_contexts = {
   ctx_handover : Tool_handover.context;
   ctx_relay : Tool_relay.context;
   ctx_goals : Tool_goals.context;
-  ctx_heartbeat : Tool_heartbeat.context;
+  ctx_heartbeat : float Eio.Time.clock_ty Tool_heartbeat.context;
   ctx_encryption : Tool_encryption.context;
   ctx_auth : Tool_auth.context;
   ctx_hat : Tool_hat.context;
   ctx_audit : Tool_audit.context;
   ctx_rate_limit : Tool_rate_limit.context;
   ctx_cost : Tool_cost.context;
-  ctx_walph : (float Tool_walph.context, string) result;
+  ctx_walph : (('net, float Eio.Time.clock_ty) Tool_walph.context, string) result;
   ctx_agent : Tool_agent.context;
   ctx_task : Tool_task.context;
   ctx_room : Tool_room.context;
@@ -50,19 +50,19 @@ type dispatch_contexts = {
   ctx_misc : Tool_misc.context;
   ctx_agent_timeline : Tool_agent_timeline.context;
   ctx_llama : Tool_llama.context;
-  ctx_voice : float Tool_voice.context;
+  ctx_voice : float Eio.Time.clock_ty Tool_voice.context;
   ctx_suspend : Tool_suspend.context;
   ctx_library : Tool_library.context;
   ctx_mdal : Tool_mdal.context;
   ctx_autoresearch : Tool_autoresearch.context;
   ctx_perpetual : Tool_perpetual.context;
-  ctx_keeper : float Tool_keeper.context;
+  ctx_keeper : float Eio.Time.clock_ty Tool_keeper.context;
   ctx_trpg : Tool_trpg.context;
   ctx_protocol : Tool_protocol_game_view.context;
   build_inline_ctx : unit -> Tool_inline_dispatch.context;
 }
 
-let dispatch (c : dispatch_contexts) : bool * string =
+let dispatch (c : (_, _) dispatch_contexts) : bool * string =
   let name = c.name in
   let arguments = c.arguments in
 


### PR DESCRIPTION
## Summary

- PR #1213 (mcp_server split) introduced type errors that break `dune build`
- Fixes clock type parameter mismatches in `dispatch_contexts` (6 fields)
- Wires `handle_call_tool_eio` / `handle_read_resource_eio` with correct labels in protocol call
- Re-exports `transport_mode` / `detect_mode` for backward compatibility

## Test plan

- [x] `dune build` passes locally (was failing before)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)