### PR TITLE
fix(deploy): GLM-only LLM cascade for Railway (no local llama)

### DIFF
--- a/.github/workflows/deploy-railway.yml
+++ b/.github/workflows/deploy-railway.yml
@@ -58,6 +58,24 @@ jobs:
           file masc-mcp-linux-x64
           file masc-mcp-linux-x64 | grep -q 'ELF 64-bit'
 
+      - name: Create Railway LLM cascade config
+        run: |
+          mkdir -p config
+          cat > config/llm_cascade.json << 'CASCADEJSON'
+          {
+            "governance_judge_models": ["glm:glm-4.7-flash"],
+            "operator_judge_models": ["glm:glm-4.7-flash"],
+            "sentinel_board_models": ["glm:glm-4.7-flash"],
+            "sentinel_task_models": ["glm:glm-4.7-flash"],
+            "sentinel_keeper_models": ["glm:glm-4.7-flash"],
+            "heartbeat_action_models": ["glm:glm-4.7-flash"],
+            "heartbeat_wake_models": ["glm:glm-4.7-flash"],
+            "lodge_direct_models": ["glm:glm-4.7-flash"],
+            "classification_models": ["glm:glm-4.7-flash"],
+            "verifier_models": ["glm:glm-4.7-flash"]
+          }
+          CASCADEJSON
+
       - name: Build deployment image
         run: docker build -t masc-mcp-railway-smoke .
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,9 @@ RUN chmod +x /app/masc-mcp
 # Create data directory for JSONL fallback
 RUN mkdir -p /app/.masc
 
+# LLM cascade config (GLM-only for Railway, no local llama-server)
+COPY config/llm_cascade.json /app/config/llm_cascade.json
+
 ENV PORT=8080
 ENV MASC_BASE_PATH=/app
 ENV MASC_WORKSPACE_ROOT=/app


### PR DESCRIPTION
Railway에 llama-server가 없어 LLM cascade가 127.0.0.1:8085에 blocking connect → event loop freeze → 502. config/llm_cascade.json을 GLM Cloud only로 Docker 이미지에 포함.