### PR TITLE
fix(build): register split modules in dune and fix extraction bugs

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -90,6 +90,9 @@
    server_routes_http_routes_command_plane_write
    server_routes_http_routes_social
    server_h2_gateway
+   server_h2_gateway_helpers
+   server_h2_gateway_cp_write
+   server_h2_gateway_routes_extra
    server_runtime_bootstrap
    server_command_plane_http
    server_command_plane_http_support
@@ -251,7 +254,11 @@
    noosphere_eio
    operator_pending_confirm
    operator_digest
+   operator_digest_types
+   operator_digest_session
    operator_control
+   operator_control_snapshot
+   operator_control_action
    operator_judgment
    notify
    orchestrator

--- a/lib/operator_control.ml
+++ b/lib/operator_control.ml
@@ -1,11 +1,5 @@
-module U = Yojson.Safe.Util
 open Tool_args
 
-let ( let* ) = Result.bind
-
-include Operator_pending_confirm
-include Operator_digest
-include Operator_control_snapshot
 include Operator_control_action
 
 let json_of_dispatch_output body =

--- a/lib/operator_control_action.ml
+++ b/lib/operator_control_action.ml
@@ -1,7 +1,4 @@
-module U = Yojson.Safe.Util
 open Tool_args
-include Operator_pending_confirm
-include Operator_digest
 include Operator_control_snapshot
 
 let ( let* ) = Result.bind

--- a/lib/operator_control_snapshot.ml
+++ b/lib/operator_control_snapshot.ml
@@ -1,5 +1,4 @@
 module U = Yojson.Safe.Util
-open Tool_args
 include Operator_pending_confirm
 include Operator_digest
 

--- a/lib/operator_digest.ml
+++ b/lib/operator_digest.ml
@@ -1,7 +1,4 @@
-module U = Yojson.Safe.Util
 open Operator_pending_confirm
-
-let ( let* ) = Result.bind
 
 include Operator_digest_types
 include Operator_digest_session

--- a/lib/operator_digest_session.ml
+++ b/lib/operator_digest_session.ml
@@ -1,4 +1,3 @@
-module U = Yojson.Safe.Util
 open Operator_pending_confirm
 include Operator_digest_types
 

--- a/lib/server_h2_gateway_cp_write.ml
+++ b/lib/server_h2_gateway_cp_write.ml
@@ -63,7 +63,7 @@ let dispatch ~h2_reqd ~httpun_request ~cors ~sw ~clock path =
   | "/api/v1/command-plane/operations" ->
       cp_post ~tool_name:"masc_operation_create"
         ~handler:(fun ~state ~httpun_request ~args ->
-          command_plane_operation_create_http_json ~state httpun_request ~args)
+          command_plane_operation_start_http_json ~state httpun_request ~args)
   | "/api/v1/command-plane/operations/checkpoint" ->
       cp_post ~tool_name:"masc_operation_checkpoint"
         ~handler:(fun ~state ~httpun_request ~args ->

--- a/lib/server_h2_gateway_routes_extra.ml
+++ b/lib/server_h2_gateway_routes_extra.ml
@@ -540,8 +540,10 @@ let dispatch ~h2_reqd ~httpun_request ~cors ~path
   | `GET, p when String.length p > 18
                && String.sub p 0 18 = "/dashboard/assets/" ->
       let filename = String.sub p 18 (String.length p - 18) in
-      if not (Web_dashboard.is_safe_asset_relative_path filename) then
-        h2_respond_text h2_reqd "404 Not Found" ~status:`Not_found
+      if not (Web_dashboard.is_safe_asset_relative_path filename) then begin
+        h2_respond_text h2_reqd "404 Not Found" ~status:`Not_found;
+        true
+      end
       else
         let file_path = Filename.concat (dashboard_asset_root ()) ("assets/" ^ filename) in
         (match read_file file_path with


### PR DESCRIPTION
## Summary

PR #1227에서 분할된 7개 모듈이 `lib/dune`에 등록되지 않아 main 빌드가 깨진 상태를 수정.

- `operator_digest_types`, `operator_digest_session`, `operator_control_snapshot`, `operator_control_action`, `server_h2_gateway_helpers`, `server_h2_gateway_cp_write`, `server_h2_gateway_routes_extra` — dune 등록
- `module U = Yojson.Safe.Util` 중복 정의 제거 (include chain에서 발생)
- `command_plane_operation_create_http_json` → `operation_start` 함수명 수정
- `h2_respond_text` 반환값 `unit` vs `bool` 불일치 수정
- unused `open Tool_args` 제거 (warning-as-error)

CodeRabbit P0 리뷰 대응: https://github.com/jeong-sik/masc-mcp/pull/1227#discussion_r2940198798

## Test plan

- [x] `dune build --root .` 성공
- [x] `test_room` (77 tests) 통과
- [x] `test_dashboard` (13 tests) 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)