### PR TITLE
refactor: migrate OAS heartbeat to Agent.periodic_callback

### DIFF
--- a/lib/local_agent_eio_container.ml
+++ b/lib/local_agent_eio_container.ml
@@ -523,7 +523,7 @@ let append_worker_completion_log ~base_path ~team_session_id ~worker_name
       ])
 
 let build_oas_agent ~worker_name ~model ~system_prompt ~tools ~max_turns
-    ~thinking_enabled ~hooks ~raw_trace =
+    ~thinking_enabled ~hooks ~raw_trace ?(periodic_callbacks = []) () =
   let config =
     {
       Oas.Types.default_config with
@@ -552,6 +552,7 @@ let build_oas_agent ~worker_name ~model ~system_prompt ~tools ~max_turns
           max_tool_calls_per_turn = Some 12;
         };
       raw_trace = Some raw_trace;
+      periodic_callbacks;
     }
   in
   (config, options)

--- a/lib/local_agent_eio_runners.ml
+++ b/lib/local_agent_eio_runners.ml
@@ -69,13 +69,23 @@ let run_worker_oas ~sw ~base_path ~worker_name
         let* () =
           save_worker_meta ~base_path ~team_session_id ~worker_name meta
         in
-        let stop_heartbeat =
-          start_worker_heartbeat ~sw ~auth_token ~session_id:mcp_session_id
-            ~worker_name
+        let heartbeat_cbs =
+          let interval = local_worker_heartbeat_interval_sec () in
+          if interval > 0 then
+            [ { Oas.Agent.interval_sec = float_of_int interval;
+                callback = (fun () ->
+                  match
+                    call_masc_tool ~sw ~auth_token ~session_id:mcp_session_id
+                      ~tool_name:"masc_heartbeat" ~args:(`Assoc [])
+                  with
+                  | Ok _ -> ()
+                  | Error e ->
+                      eprintf "[local-worker] heartbeat error for %s: %s\n%!"
+                        worker_name e) } ]
+          else []
         in
         Fun.protect
           ~finally:(fun () ->
-            stop_heartbeat ();
             ignore
               (leave_worker ~sw ~auth_token ~session_id:mcp_session_id
                  ~worker_name))
@@ -147,6 +157,7 @@ let run_worker_oas ~sw ~base_path ~worker_name
           let config, options =
             build_oas_agent ~worker_name ~model ~system_prompt ~tools
               ~max_turns ~thinking_enabled ~hooks ~raw_trace
+              ~periodic_callbacks:heartbeat_cbs ()
           in
           let agent = Oas.Agent.create ~net ~config ~tools ~options () in
           let result =
@@ -255,13 +266,24 @@ let continue_worker ?worker_run_id ~sw ~base_path ~room_config ~worker_name
             | Some net -> Ok net
             | None -> Error "Eio net not initialized"
           in
-          let stop_heartbeat =
-            start_worker_heartbeat ~sw ~auth_token ~session_id:meta.mcp_session_id
-              ~worker_name
+          let heartbeat_cbs =
+            let interval = local_worker_heartbeat_interval_sec () in
+            if interval > 0 then
+              [ { Oas.Agent.interval_sec = float_of_int interval;
+                  callback = (fun () ->
+                    match
+                      call_masc_tool ~sw ~auth_token
+                        ~session_id:meta.mcp_session_id
+                        ~tool_name:"masc_heartbeat" ~args:(`Assoc [])
+                    with
+                    | Ok _ -> ()
+                    | Error e ->
+                        eprintf "[local-worker] heartbeat error for %s: %s\n%!"
+                          worker_name e) } ]
+            else []
           in
           Fun.protect
             ~finally:(fun () ->
-              stop_heartbeat ();
               ignore
                 (leave_worker ~sw ~auth_token
                    ~session_id:meta.mcp_session_id ~worker_name))
@@ -383,6 +405,7 @@ let continue_worker ?worker_run_id ~sw ~base_path ~room_config ~worker_name
                        ?session_id:meta.team_session_id ?role:meta.role
                        ?selection_note:meta.selection_note ())
                   ~tools ~max_turns ~thinking_enabled ~hooks ~raw_trace
+                  ~periodic_callbacks:heartbeat_cbs ()
               in
               let agent =
                 Oas.Agent.resume ~net ~checkpoint ~tools ~options ~config ()


### PR DESCRIPTION
## Summary
- OAS path의 heartbeat fiber를 `Agent.periodic_callback`으로 마이그레이션
- `start_worker_heartbeat` 수동 fiber 관리 → OAS `Agent.run` 내부 자동 관리
- `Fun.protect ~finally`에서 `stop_heartbeat()` 제거 (Agent.run이 자동 처리)

## Changes
- `lib/local_agent_eio_container.ml`: `build_oas_agent`에 `~periodic_callbacks` 파라미터 추가
- `lib/local_agent_eio_runners.ml`: `run_worker_oas`와 `continue_worker`에서 heartbeat closure 생성 → `build_oas_agent`로 전달

Legacy path (`run_worker_legacy`)는 변경 없음.

Depends on: OAS v0.31.0 (PR #103, merged)

## Test plan
- [x] `dune build --root .` 통과
- [ ] keeper msg 1턴 실행 → heartbeat가 주기적으로 호출되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)