### PR TITLE
fix(build): resolve post-refactoring build errors

### DIFF
--- a/lib/council/conversation.ml
+++ b/lib/council/conversation.ml
@@ -300,8 +300,9 @@ let save_thread config (th : thread) : unit =
   write_json path (thread_to_yojson th)
 
 let start ~config ~topic ~initiator ?(max_turns = 50) ?(initial_content = "")
-    ?(_mentions = []) ?source_post_id ()
+    ?(mentions : string list = []) ?source_post_id ()
     : (thread, string) result =
+  ignore mentions;
   ensure_dirs config;
   let id = generate_thread_id () in
   let now = Time_compat.now () in

--- a/lib/trpg_round_fallback.ml
+++ b/lib/trpg_round_fallback.ml
@@ -1,6 +1,7 @@
 (** Trpg_round_fallback — deterministic fallback replies and NPC counterattack logic *)
 
 include Trpg_action
+open Trpg_bestiary
 open Yojson.Safe.Util
 
 let default_placeholder_reply = "상황을 살피며 다음 행동을 준비합니다."


### PR DESCRIPTION
## Summary
- `conversation.ml`: `?_mentions` → `?mentions:string list` to match `.mli` signature (broken by refactoring)
- `trpg_round_fallback.ml`: add `open Trpg_bestiary` for functions split out in #1237

## Context
#1237 split `trpg_action` into sub-modules but missed updating `trpg_round_fallback.ml` imports. Similarly, `conversation.ml` had a `?_mentions` parameter with polymorphic type that didn't match the `.mli` declaration.

## Test plan
- [x] `dune build --root .` passes
- [x] `test_dashboard_cache.exe` — 8/8 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)