### PR TITLE
fix(process_eio): re-raise Eio.Cancel.Cancelled instead of swallowing

### DIFF
--- a/lib/process_eio.ml
+++ b/lib/process_eio.ml
@@ -124,16 +124,27 @@ let with_unix_capture ?env ?stdin_content (argv : string list)
              in
              let (_pid, status) = Unix.waitpid [] pid in
              on_success status output)
-       with _exn ->
-         Option.iter close_quietly !stdin_r_ref;
-         stdin_r_ref := None;
-         Option.iter close_quietly !stdin_w_ref;
-         stdin_w_ref := None;
-         Option.iter close_quietly !stdout_r_ref;
-         stdout_r_ref := None;
-         Option.iter close_quietly !stdout_w_ref;
-         stdout_w_ref := None;
-         on_error ())
+       with
+       | Eio.Cancel.Cancelled _ as exn ->
+           Option.iter close_quietly !stdin_r_ref;
+           stdin_r_ref := None;
+           Option.iter close_quietly !stdin_w_ref;
+           stdin_w_ref := None;
+           Option.iter close_quietly !stdout_r_ref;
+           stdout_r_ref := None;
+           Option.iter close_quietly !stdout_w_ref;
+           stdout_w_ref := None;
+           raise exn
+       | _exn ->
+           Option.iter close_quietly !stdin_r_ref;
+           stdin_r_ref := None;
+           Option.iter close_quietly !stdin_w_ref;
+           stdin_w_ref := None;
+           Option.iter close_quietly !stdout_r_ref;
+           stdout_r_ref := None;
+           Option.iter close_quietly !stdout_w_ref;
+           stdout_w_ref := None;
+           on_error ())
 
 let run_unix_argv_fallback ?env (argv : string list) : string =
   with_unix_capture ?env argv ~on_error:(fun () -> "")
@@ -178,6 +189,7 @@ let run_argv ?(timeout_sec = 60.0) ?env (argv : string list) : string =
             Eio.traceln "[Process_eio] Timeout after %.0fs: %s" timeout_sec
               label;
             ""
+        | Eio.Cancel.Cancelled _ as exn -> raise exn
         | exn ->
             if should_retry_unix_fallback exn then (
               Eio.traceln
@@ -211,6 +223,7 @@ let run_argv_with_stdin ?(timeout_sec = 60.0) ?env ~(stdin_content : string) (ar
             Eio.traceln "[Process_eio] Timeout after %.0fs: %s" timeout_sec
               label;
             ""
+        | Eio.Cancel.Cancelled _ as exn -> raise exn
         | exn ->
             if should_retry_unix_fallback exn then (
               Eio.traceln
@@ -257,6 +270,7 @@ let run_argv_with_stdin_and_status
             Eio.traceln "[Process_eio] Timeout after %.0fs: %s" timeout_sec
               label;
             (Unix.WSIGNALED Sys.sigterm, Buffer.contents buf)
+        | Eio.Cancel.Cancelled _ as exn -> raise exn
         | exn ->
             if should_retry_unix_fallback exn then (
               Eio.traceln
@@ -298,6 +312,7 @@ let run_argv_with_status ?(timeout_sec = 60.0) ?env (argv : string list) : Unix.
             Eio.traceln "[Process_eio] Timeout after %.0fs: %s" timeout_sec
               label;
             (Unix.WSIGNALED Sys.sigterm, Buffer.contents buf)
+        | Eio.Cancel.Cancelled _ as exn -> raise exn
         | exn ->
             if should_retry_unix_fallback exn then (
               Eio.traceln

--- a/test/test_process_eio_coverage.ml
+++ b/test/test_process_eio_coverage.ml
@@ -48,6 +48,68 @@ let test_init_exposes_complete_runtime () =
   check bool "clock available" true
     (match M.Process_eio.get_clock () with Ok _ -> true | Error _ -> false)
 
+(** Verify that Eio.Cancel.Cancelled is re-raised, not swallowed *)
+let test_run_argv_propagates_cancelled () =
+  Eio_main.run @@ fun env ->
+  let proc_mgr = Eio.Stdenv.process_mgr env in
+  let clock = Eio.Stdenv.clock env in
+  let cwd_default = Eio.Stdenv.fs env in
+  M.Process_eio.init ~cwd_default ~proc_mgr ~clock;
+  let raised = ref false in
+  (try
+     Eio.Cancel.sub (fun cc ->
+         Eio.Cancel.cancel cc (Failure "test cancel");
+         ignore (M.Process_eio.run_argv [ "/bin/echo"; "should-not-run" ]))
+   with Eio.Cancel.Cancelled _ -> raised := true);
+  check bool "Cancelled propagated from run_argv" true !raised
+
+let test_run_argv_with_status_propagates_cancelled () =
+  Eio_main.run @@ fun env ->
+  let proc_mgr = Eio.Stdenv.process_mgr env in
+  let clock = Eio.Stdenv.clock env in
+  let cwd_default = Eio.Stdenv.fs env in
+  M.Process_eio.init ~cwd_default ~proc_mgr ~clock;
+  let raised = ref false in
+  (try
+     Eio.Cancel.sub (fun cc ->
+         Eio.Cancel.cancel cc (Failure "test cancel");
+         ignore (M.Process_eio.run_argv_with_status [ "/bin/echo"; "nope" ]))
+   with Eio.Cancel.Cancelled _ -> raised := true);
+  check bool "Cancelled propagated from run_argv_with_status" true !raised
+
+let test_run_argv_with_stdin_propagates_cancelled () =
+  Eio_main.run @@ fun env ->
+  let proc_mgr = Eio.Stdenv.process_mgr env in
+  let clock = Eio.Stdenv.clock env in
+  let cwd_default = Eio.Stdenv.fs env in
+  M.Process_eio.init ~cwd_default ~proc_mgr ~clock;
+  let raised = ref false in
+  (try
+     Eio.Cancel.sub (fun cc ->
+         Eio.Cancel.cancel cc (Failure "test cancel");
+         ignore
+           (M.Process_eio.run_argv_with_stdin ~stdin_content:"x"
+              [ "/bin/cat" ]))
+   with Eio.Cancel.Cancelled _ -> raised := true);
+  check bool "Cancelled propagated from run_argv_with_stdin" true !raised
+
+let test_run_argv_with_stdin_and_status_propagates_cancelled () =
+  Eio_main.run @@ fun env ->
+  let proc_mgr = Eio.Stdenv.process_mgr env in
+  let clock = Eio.Stdenv.clock env in
+  let cwd_default = Eio.Stdenv.fs env in
+  M.Process_eio.init ~cwd_default ~proc_mgr ~clock;
+  let raised = ref false in
+  (try
+     Eio.Cancel.sub (fun cc ->
+         Eio.Cancel.cancel cc (Failure "test cancel");
+         ignore
+           (M.Process_eio.run_argv_with_stdin_and_status ~stdin_content:"x"
+              [ "/bin/cat" ]))
+   with Eio.Cancel.Cancelled _ -> raised := true);
+  check bool "Cancelled propagated from run_argv_with_stdin_and_status" true
+    !raised
+
 let () =
   run "Process_eio coverage"
     [
@@ -63,5 +125,16 @@ let () =
             test_run_argv_with_stdin_fallback_preserves_input;
           test_case "init-exposes-complete-runtime" `Quick
             test_init_exposes_complete_runtime;
+        ] );
+      ( "cancellation-propagation",
+        [
+          test_case "run_argv-propagates-cancelled" `Quick
+            test_run_argv_propagates_cancelled;
+          test_case "run_argv_with_status-propagates-cancelled" `Quick
+            test_run_argv_with_status_propagates_cancelled;
+          test_case "run_argv_with_stdin-propagates-cancelled" `Quick
+            test_run_argv_with_stdin_propagates_cancelled;
+          test_case "run_argv_with_stdin_and_status-propagates-cancelled" `Quick
+            test_run_argv_with_stdin_and_status_propagates_cancelled;
         ] );
     ]


### PR DESCRIPTION
## Summary

- `lib/process_eio.ml`의 5개 함수에서 `| exn ->` catch-all이 `Eio.Cancel.Cancelled` 예외를 삼키던 버그 수정
- `with_unix_capture`: FD cleanup 후 re-raise
- `run_argv`, `run_argv_with_stdin`, `run_argv_with_status`, `run_argv_with_stdin_and_status`: 단순 re-raise
- 4개 취소 전파 검증 테스트 추가 (`Eio.Cancel.sub` 패턴)

## 문제

MASC 서버 실행 시 아래 노이즈 로그가 반복 출력:
```
[Process_eio] argv error: 'ps' '-ax' ... — Cancelled: Eio__core__Fiber.Not_first
[Process_eio] argv error: 'curl' '-sS' ... — Cancelled: Eio__core__Fiber.Not_first
```

정상 fiber 취소가 에러로 로깅되고, 취소된 fiber가 `""` 반환 후 좀비처럼 계속 실행됨.

## 수정

각 함수의 `with` 절에 `| Eio.Cancel.Cancelled _ as exn -> raise exn`을 catch-all 앞에 추가.
코드베이스의 기존 패턴과 동일 (`tool_heartbeat.ml`, `agent_swarm_fleet.ml` 등).

## Test plan

- [x] `dune build --root . lib` 성공
- [x] `dune exec --root . test/test_process_eio_coverage.exe` — 9/9 PASS
- [ ] MASC 서버 시작 후 `[Process_eio] argv error: ... Cancelled` 로그 소멸 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)