### PR TITLE
fix: surface 8 silent failures with proper error logging

### DIFF
--- a/lib/lodge_heartbeat_agents.ml
+++ b/lib/lodge_heartbeat_agents.ml
@@ -190,7 +190,7 @@ let post_activity_report ~(result : heartbeat_result) =
          ("content", `String content);
        ])
        with exn ->
-         Printf.eprintf "[warn] %s: %s\n" __FUNCTION__ (Printexc.to_string exn))
+         Log.Misc.warn "%s: %s" __FUNCTION__ (Printexc.to_string exn))
     end
 
 (** {1 Daemon Loop} *)

--- a/lib/mitosis_helpers.ml
+++ b/lib/mitosis_helpers.ml
@@ -119,7 +119,7 @@ let queue_episode ~base_path ~session_id ~agent_name ~generation
     Printf.printf "[EPISODE/QUEUE] Queued episode %s (gen %d) → %s\n%!" ep_id generation file;
     Some ep_id
   with exn ->
-    Printf.eprintf "[EPISODE/ERROR] Failed to queue episode: %s\n%!" (Printexc.to_string exn);
+    Log.Misc.error "episode queue failed: %s" (Printexc.to_string exn);
     None
 
 (** Saga status tracking for async handoff *)
@@ -151,7 +151,7 @@ let write_saga_state ~base_path ~saga_id ~status ~payload : string option =
       (fun () -> output_string oc (Yojson.Safe.pretty_to_string json));
     Some file
   with exn ->
-    Printf.eprintf "[MITOSIS/SAGA] Failed writing %s: %s\n%!" file (Printexc.to_string exn);
+    Log.Misc.error "mitosis saga write failed %s: %s" file (Printexc.to_string exn);
     None
 
 (** Get current session ID from environment or generate *)

--- a/lib/room_state.ml
+++ b/lib/room_state.ml
@@ -49,8 +49,9 @@ let write_state config state =
   write_json config (state_path config) (room_state_to_yojson state);
   if is_pg_backend config then begin
     let json_str = Yojson.Safe.to_string (room_state_to_yojson state) in
-    let _ = backend_set config ~key:"room:state" ~value:json_str in
-    ()
+    (match backend_set config ~key:"room:state" ~value:json_str with
+     | Ok () -> ()
+     | Error e -> Log.Misc.error "room_state write_state backend_set failed: %s" e)
   end
 
 (** Update state with function - uses file lock for atomic read-modify-write *)
@@ -343,10 +344,10 @@ let broadcast_in_room config ~room_id ~from_agent ~content =
       (Printf.sprintf "%09d_%s_broadcast.json" seq (safe_filename from_agent))
   in
   write_json scoped msg_file (message_to_yojson msg);
-  let _ =
-    backend_publish scoped ~channel:(Printf.sprintf "broadcast:%s" room_id)
-      ~message:(Yojson.Safe.to_string (message_to_yojson msg))
-  in
+  (match backend_publish scoped ~channel:(Printf.sprintf "broadcast:%s" room_id)
+      ~message:(Yojson.Safe.to_string (message_to_yojson msg)) with
+   | Ok () -> ()
+   | Error e -> Log.Misc.error "broadcast_scoped publish failed for %s: %s" room_id e);
   Printf.sprintf "📢 [%s@%s] %s" safe_agent room_id safe_content
 
 let broadcast config ~from_agent ~content =
@@ -369,10 +370,10 @@ let broadcast config ~from_agent ~content =
   in
   write_json config msg_file (message_to_yojson msg);
   let room_id = match config.scope with Default -> "default" | Named id -> id in
-  let _ =
-    backend_publish config ~channel:(Printf.sprintf "broadcast:%s" room_id)
-      ~message:(Yojson.Safe.to_string (message_to_yojson msg))
-  in
+  (match backend_publish config ~channel:(Printf.sprintf "broadcast:%s" room_id)
+      ~message:(Yojson.Safe.to_string (message_to_yojson msg)) with
+   | Ok () -> ()
+   | Error e -> Log.Misc.error "broadcast publish failed for %s: %s" room_id e);
   Printf.sprintf "📢 [%s@%s] %s" safe_agent room_id safe_content
 
 (* ============================================ *)

--- a/lib/server_routes_http_keeper_stream.ml
+++ b/lib/server_routes_http_keeper_stream.ml
@@ -244,7 +244,8 @@ let handle_keeper_chat_stream ~sw ~clock state request reqd payload =
   let close_stream () =
     if not !closed then begin
       closed := true;
-      (try Httpun.Body.Writer.close writer with _ -> ())
+      (try Httpun.Body.Writer.close writer
+       with exn -> Log.Misc.warn "keeper_stream writer close: %s" (Printexc.to_string exn))
     end
   in
   let now_id () =

--- a/lib/server_runtime_bootstrap.ml
+++ b/lib/server_runtime_bootstrap.ml
@@ -218,7 +218,8 @@ let serve ~sw ~clock ~socket ~request_handler =
       Eio.Fiber.fork ~sw (fun () ->
           Eio.Switch.run (fun conn_sw ->
               Eio.Switch.on_release conn_sw (fun () ->
-                  try Eio.Flow.close flow with _ -> ());
+                  try Eio.Flow.close flow
+                  with exn -> Log.Misc.warn "flow close: %s" (Printexc.to_string exn));
               try
                 let conn_handler =
                   Httpun_eio.Server.create_connection_handler ~sw:conn_sw
@@ -251,7 +252,8 @@ let serve ~sw ~clock ~socket ~request_handler =
       if is_cancelled exn then ()
       else begin
         Log.Misc.error "Accept error: %s" (Printexc.to_string exn);
-        (try Eio.Time.sleep clock backoff_s with _ -> ());
+        (try Eio.Time.sleep clock backoff_s
+         with exn -> Log.Misc.warn "backoff sleep: %s" (Printexc.to_string exn));
         accept_loop (Float.min 2.0 (backoff_s *. 1.5))
       end
   in

--- a/lib/tool_misc.ml
+++ b/lib/tool_misc.ml
@@ -793,7 +793,8 @@ let handle_purge_test_data ctx args =
     if Sys.file_exists agents_path then
       Sys.readdir agents_path |> Array.iter (fun name ->
         if String.length name > 5 && String.sub name 0 5 = "test-" then begin
-          (try Sys.remove (Filename.concat agents_path name) with _ -> ());
+          (try Sys.remove (Filename.concat agents_path name)
+           with Sys_error msg -> Log.Misc.warn "purge remove %s: %s" name msg);
           incr removed
         end);
     (* Remove test-* messages *)
@@ -801,7 +802,8 @@ let handle_purge_test_data ctx args =
     if Sys.file_exists messages_path then
       Sys.readdir messages_path |> Array.iter (fun name ->
         if String.length name > 5 && String.sub name 0 5 = "test-" then begin
-          (try Sys.remove (Filename.concat messages_path name) with _ -> ());
+          (try Sys.remove (Filename.concat messages_path name)
+           with Sys_error msg -> Log.Misc.warn "purge remove %s: %s" name msg);
           incr removed
         end);
     (true, Printf.sprintf "Purged %d test-* files" !removed)


### PR DESCRIPTION
## Summary
- **CRITICAL**: `room_state.ml` — `backend_set`/`backend_publish`의 Result를 `let _ =`로 무시하던 3곳 수정. PostgreSQL 장애 시 상태 손실 무감지였음.
- **HIGH**: `server_routes_http_keeper_stream.ml` — Httpun writer close의 `with _ -> ()` → 로그 추가
- **HIGH**: `server_runtime_bootstrap.ml` — Eio.Flow.close, sleep의 예외 삼킴 → 로그 추가
- **MEDIUM**: `lodge_heartbeat_agents.ml`, `mitosis_helpers.ml` — 잔여 Printf.eprintf를 Log 모듈로 마이그레이션
- **MEDIUM**: `tool_misc.ml` — Sys.remove의 `with _ -> ()` → Sys_error 캐치 + 로그

## Test plan
- [ ] `dune build` 성공
- [ ] `make test` 통과
- [ ] 서버 기동 후 broadcast 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)