### PR TITLE
fix: isolate subsystem init failures and circuit-break expired lock cleanup

### DIFF
--- a/lib/backend.ml
+++ b/lib/backend.ml
@@ -804,6 +804,11 @@ end = struct
     (Caqti_type.unit ->. Caqti_type.unit)
     "DELETE FROM masc_kv WHERE expires_at IS NOT NULL AND expires_at < NOW()"
 
+  (* Circuit breaker for expired lock cleanup: after 3 consecutive failures,
+     skip cleanup for 60s to avoid blocking acquire_lock when PG is saturated *)
+  let cleanup_failures = ref 0
+  let cleanup_backoff_until = ref 0.0
+
   let health_check_q =
     (Caqti_type.unit ->! Caqti_type.int)
     "SELECT 1"
@@ -1021,15 +1026,24 @@ end = struct
 
   let acquire_lock t ~key ~ttl_seconds ~owner =
     let nkey = namespaced_key t.namespace ("lock:" ^ key) in
-    (* Clean up expired locks first *)
-    (match Caqti_eio.Pool.use (fun conn ->
-      let module C = (val conn : Caqti_eio.CONNECTION) in
-      C.exec cleanup_expired_q ()
-    ) t.pool with
-    | Ok () -> ()
-    | Error err ->
-      Log.Misc.error "[backend] expired lock cleanup failed: %s"
-        (Caqti_error.show err));
+    (* Clean up expired locks — circuit breaker skips after 3 consecutive failures *)
+    (if Time_compat.now () < !cleanup_backoff_until then ()
+     else
+       match Caqti_eio.Pool.use (fun conn ->
+         let module C = (val conn : Caqti_eio.CONNECTION) in
+         C.exec cleanup_expired_q ()
+       ) t.pool with
+       | Ok () -> cleanup_failures := 0
+       | Error err ->
+         cleanup_failures := !cleanup_failures + 1;
+         if !cleanup_failures >= 3 then begin
+           cleanup_backoff_until := Time_compat.now () +. 60.0;
+           Log.Misc.warn
+             "[backend] expired lock cleanup failed %d times, backing off 60s: %s"
+             !cleanup_failures (Caqti_error.show err)
+         end else
+           Log.Misc.error "[backend] expired lock cleanup failed: %s"
+             (Caqti_error.show err));
     (* Try to acquire lock *)
     match Caqti_eio.Pool.use (fun conn ->
       let module C = (val conn : Caqti_eio.CONNECTION) in

--- a/lib/room_state.ml
+++ b/lib/room_state.ml
@@ -51,7 +51,7 @@ let write_state config state =
     let json_str = Yojson.Safe.to_string (room_state_to_yojson state) in
     (match backend_set config ~key:"room:state" ~value:json_str with
      | Ok () -> ()
-     | Error e -> Log.Misc.error "room_state write_state backend_set failed: %s" e)
+     | Error e -> Log.Misc.error "room_state write_state backend_set failed: %s" (Backend.show_error e))
   end
 
 (** Update state with function - uses file lock for atomic read-modify-write *)
@@ -346,8 +346,8 @@ let broadcast_in_room config ~room_id ~from_agent ~content =
   write_json scoped msg_file (message_to_yojson msg);
   (match backend_publish scoped ~channel:(Printf.sprintf "broadcast:%s" room_id)
       ~message:(Yojson.Safe.to_string (message_to_yojson msg)) with
-   | Ok () -> ()
-   | Error e -> Log.Misc.error "broadcast_scoped publish failed for %s: %s" room_id e);
+   | Ok _ -> ()
+   | Error e -> Log.Misc.error "broadcast_scoped publish failed for %s: %s" room_id (Backend.show_error e));
   Printf.sprintf "📢 [%s@%s] %s" safe_agent room_id safe_content
 
 let broadcast config ~from_agent ~content =
@@ -372,8 +372,8 @@ let broadcast config ~from_agent ~content =
   let room_id = match config.scope with Default -> "default" | Named id -> id in
   (match backend_publish config ~channel:(Printf.sprintf "broadcast:%s" room_id)
       ~message:(Yojson.Safe.to_string (message_to_yojson msg)) with
-   | Ok () -> ()
-   | Error e -> Log.Misc.error "broadcast publish failed for %s: %s" room_id e);
+   | Ok _ -> ()
+   | Error e -> Log.Misc.error "broadcast publish failed for %s: %s" room_id (Backend.show_error e));
   Printf.sprintf "📢 [%s@%s] %s" safe_agent room_id safe_content
 
 (* ============================================ *)

--- a/lib/server_runtime_bootstrap.ml
+++ b/lib/server_runtime_bootstrap.ml
@@ -87,38 +87,52 @@ let start_resident_loops ~sw ~clock ~net ~domain_mgr ~proc_mgr
   Progress.set_sse_callback Sse.broadcast;
   (* OAS Event_bus: shared instance for cross-subsystem communication *)
   let event_bus = Agent_sdk.Event_bus.create () in
-  let cancel_orchestrator =
-    Orchestrator.start ~sw ~proc_mgr ~clock ~domain_mgr state.room_config
+  (* Isolate each subsystem so one failure does not kill the rest *)
+  let try_start name f =
+    try f ()
+    with exn ->
+      Log.Server.error "subsystem %s failed to start: %s" name
+        (Printexc.to_string exn)
   in
-  Shutdown_hooks.register_cancel_orchestrator cancel_orchestrator;
-  Social_runtime.start ~sw ~clock ~config:state.room_config;
-  Gardener.start ~bus:event_bus ~sw ~clock ~room_config:state.room_config ();
-  if Env_config.Sentinel.enabled then begin
-    Sentinel.start ~bus:event_bus ~sw ~clock ~net state.room_config;
-    if Env_config.Guardian.enabled then Guardian.start_lodge_loop ~sw ~clock ~net
-  end else Guardian.start ~bus:event_bus ~sw ~clock ~net state.room_config;
-  Dashboard_governance_judge.start ~sw ~clock
-    ~base_path:state.room_config.base_path
-    ~build_facts:(fun () ->
-      Dashboard_governance.factual_snapshot_json
-        ~base_path:state.room_config.base_path)
-    ();
-  let operator_judge_ctx : _ Operator_control.context =
-    {
-      config = state.room_config;
-      agent_name = "operator-judge";
-      sw;
-      clock;
-      proc_mgr = Some proc_mgr;
-      mcp_session_id = None;
-    }
-  in
-  Dashboard_operator_judge.start ~sw ~clock ~config:state.room_config
-    ~build_facts:(fun () ->
-      Operator_control.snapshot_json ~actor:"operator-judge" ~view:"summary"
-        ~include_messages:false ~include_keepers:false operator_judge_ctx)
-    ();
-  Session.start_mcp_session_cleanup_loop ~sw ~clock ();
+  try_start "orchestrator" (fun () ->
+    let cancel_orchestrator =
+      Orchestrator.start ~sw ~proc_mgr ~clock ~domain_mgr state.room_config
+    in
+    Shutdown_hooks.register_cancel_orchestrator cancel_orchestrator);
+  try_start "social_runtime" (fun () ->
+    Social_runtime.start ~sw ~clock ~config:state.room_config);
+  try_start "gardener" (fun () ->
+    Gardener.start ~bus:event_bus ~sw ~clock ~room_config:state.room_config ());
+  try_start "sentinel_guardian" (fun () ->
+    if Env_config.Sentinel.enabled then begin
+      Sentinel.start ~bus:event_bus ~sw ~clock ~net state.room_config;
+      if Env_config.Guardian.enabled then Guardian.start_lodge_loop ~sw ~clock ~net
+    end else Guardian.start ~bus:event_bus ~sw ~clock ~net state.room_config);
+  try_start "governance_judge" (fun () ->
+    Dashboard_governance_judge.start ~sw ~clock
+      ~base_path:state.room_config.base_path
+      ~build_facts:(fun () ->
+        Dashboard_governance.factual_snapshot_json
+          ~base_path:state.room_config.base_path)
+      ());
+  try_start "operator_judge" (fun () ->
+    let operator_judge_ctx : _ Operator_control.context =
+      {
+        config = state.room_config;
+        agent_name = "operator-judge";
+        sw;
+        clock;
+        proc_mgr = Some proc_mgr;
+        mcp_session_id = None;
+      }
+    in
+    Dashboard_operator_judge.start ~sw ~clock ~config:state.room_config
+      ~build_facts:(fun () ->
+        Operator_control.snapshot_json ~actor:"operator-judge" ~view:"summary"
+          ~include_messages:false ~include_keepers:false operator_judge_ctx)
+      ());
+  try_start "session_cleanup" (fun () ->
+    Session.start_mcp_session_cleanup_loop ~sw ~clock ());
   (* Phase 5: unified startup subsystem summary *)
   let on_off b = if b then "on" else "off" in
   Log.info ~ctx:"startup" "subsystems: sentinel=%s guardian=%s gardener=%s"


### PR DESCRIPTION
## Summary

- **Circuit breaker for expired lock cleanup** (`lib/backend.ml`): When PostgreSQL hits max clients, `acquire_lock` cleanup fails repeatedly causing Eio fiber cancellation that cascades through the init fiber. After 3 consecutive failures, cleanup is skipped for 60s (resets on success).
- **Subsystem isolation in `start_resident_loops`** (`lib/server_runtime_bootstrap.ml`): Each subsystem start (orchestrator, social_runtime, gardener, sentinel/guardian, governance_judge, operator_judge, session_cleanup) is wrapped in `try_start` so one failure does not prevent subsequent subsystems from starting.
- **Pre-existing type error fix** (`lib/room_state.ml`): `Backend.error` values were passed as strings, and `publish` return type (`int`) was matched as `unit`. These broke the build on main.

## Test plan

- [x] `dune build --root .` passes (was failing on main due to room_state.ml type errors)
- [ ] Verify server starts with `MASC_POSTGRES_URL` pointed at a saturated PG pool -- subsystems should start independently
- [ ] Verify expired lock cleanup circuit breaker triggers after 3 failures and resets after success

Generated with [Claude Code](https://claude.com/claude-code)