### PR TITLE
refactor: remove hardcoded LLM model names, use provider-level defaults

### DIFF
--- a/lib/chain_native_eio.ml
+++ b/lib/chain_native_eio.ml
@@ -252,8 +252,8 @@ let model_runner_of_string raw =
       match Provider_adapter.explicit_llama_model_label_result () with
       | Ok label -> direct label
       | Error msg -> Error msg)
-  | "glm" | "glm-4.7" ->
-      direct (Printf.sprintf "glm:%s" Env_config.Llm.default_model)
+  | "glm" ->
+      direct "glm:auto"
   | "stub" | "mock" -> Ok Stub
   | "codex" | "gpt-5.2" -> Ok (Spawn "codex")
   | value when starts_with ~prefix:"codex:" value -> Ok (Spawn "codex")

--- a/lib/chain_stats.ml
+++ b/lib/chain_stats.ml
@@ -349,16 +349,27 @@ let is_enabled () =
 
 (** {1 Model Statistics} *)
 
-(** Cost per 1K tokens by model (approximate) *)
-let cost_per_1k_tokens = function
-  | "gpt-4" | "gpt-4-turbo" -> 0.03
-  | "gpt-3.5-turbo" -> 0.002
-  | "claude-3-opus" | "claude-opus-4" -> 0.015
-  | "claude-3-sonnet" | "claude-sonnet-4" -> 0.003
-  | "claude-3-haiku" | "claude-haiku-4" -> 0.00025
-  | "gemini-pro" | "gemini-2.0-flash" -> 0.00025
-  | "codex" | "gpt-5.2-codex" -> 0.01
-  | _ -> 0.001  (* Default estimate *)
+let starts_with_prefix ~prefix s =
+  String.length s >= String.length prefix
+  && String.sub s 0 (String.length prefix) = prefix
+
+(** Cost per 1K tokens by provider prefix (approximate).
+    Uses prefix matching so concrete model versions don't need updating. *)
+let cost_per_1k_tokens model =
+  if starts_with_prefix ~prefix:"gpt-4" model then 0.03
+  else if starts_with_prefix ~prefix:"gpt-3" model then 0.002
+  else if starts_with_prefix ~prefix:"gpt-5" model then 0.01
+  else if starts_with_prefix ~prefix:"claude" model then (
+    if starts_with_prefix ~prefix:"claude-haiku" model
+       || starts_with_prefix ~prefix:"claude-3-haiku" model then 0.00025
+    else if starts_with_prefix ~prefix:"claude-opus" model
+       || starts_with_prefix ~prefix:"claude-3-opus" model then 0.015
+    else 0.003  (* sonnet-class default *)
+  )
+  else if starts_with_prefix ~prefix:"gemini" model then 0.00025
+  else if starts_with_prefix ~prefix:"glm" model then 0.001
+  else if starts_with_prefix ~prefix:"codex" model then 0.01
+  else 0.001  (* default estimate *)
 
 (** Calculate model-specific statistics *)
 let model_statistics () : model_stats list =

--- a/lib/env_config_governance.ml
+++ b/lib/env_config_governance.ml
@@ -74,9 +74,10 @@ module Llm = struct
       (get_int ~default:timeout_seconds_int
          "MASC_GARDENER_SPAWN_LLM_TIMEOUT_SEC")
 
-  (** Default GLM model for Z.ai API calls *)
+  (** Default GLM model for Z.ai API calls.
+      Empty = let Glm_pool select at runtime. *)
   let default_model =
-    get_string ~default:"glm-4.7" "MASC_GLM_DEFAULT_MODEL"
+    get_string ~default:"" "MASC_GLM_DEFAULT_MODEL"
 
   (** Enable LLM response cache (L1+L2). *)
   let cache_enabled =
@@ -106,37 +107,42 @@ module Llm = struct
     |> String.trim
     |> String.lowercase_ascii
 
-  (** Default GLM flash model for lightweight tasks *)
+  (** Default GLM flash model for lightweight tasks.
+      Empty = provider decides. *)
   let flash_model =
-    get_string ~default:"glm-4.7-flash" "MASC_GLM_FLASH_MODEL"
+    get_string ~default:"" "MASC_GLM_FLASH_MODEL"
 end
 
 (** {1 Gemini Configuration} *)
 
 module Gemini = struct
-  (** Default Gemini model *)
+  (** Default Gemini model.
+      Empty = skip Gemini in cascades unless env-var overridden. *)
   let default_model =
-    get_string ~default:"gemini-2.5-pro" "MASC_GEMINI_DEFAULT_MODEL"
+    get_string ~default:"" "MASC_GEMINI_DEFAULT_MODEL"
 
-  (** Gemini flash model for lightweight tasks *)
+  (** Gemini flash model for lightweight tasks.
+      Empty = skip Gemini flash in cascades. *)
   let flash_model =
-    get_string ~default:"gemini-2.5-flash" "MASC_GEMINI_FLASH_MODEL"
+    get_string ~default:"" "MASC_GEMINI_FLASH_MODEL"
 end
 
 (** {1 Claude Configuration} *)
 
 module Claude = struct
-  (** Default Claude model *)
+  (** Default Claude model.
+      Empty = skip Claude in cascades unless env-var overridden. *)
   let default_model =
-    get_string ~default:"claude-sonnet-4-5-20250929" "MASC_CLAUDE_DEFAULT_MODEL"
+    get_string ~default:"" "MASC_CLAUDE_DEFAULT_MODEL"
 end
 
 (** {1 OpenAI Configuration} *)
 
 module OpenAI = struct
-  (** Default OpenAI model *)
+  (** Default OpenAI model.
+      Empty = skip OpenAI in cascades unless env-var overridden. *)
   let default_model =
-    get_string ~default:"gpt-5" "MASC_OPENAI_DEFAULT_MODEL"
+    get_string ~default:"" "MASC_OPENAI_DEFAULT_MODEL"
 end
 
 (** {1 Rate Limit Cleanup Configuration} *)

--- a/lib/llm_client_core.ml
+++ b/lib/llm_client_core.ml
@@ -203,7 +203,7 @@ let llama_default = {
 
 let claude_opus = {
   provider = Claude;
-  model_id = "claude-opus-4-6";
+  model_id = Env_config.Claude.default_model;
   max_context = 200000;
   api_url = "https://api.anthropic.com";
   api_key_env = Some "ANTHROPIC_API_KEY";

--- a/lib/llm_client_providers.ml
+++ b/lib/llm_client_providers.ml
@@ -387,7 +387,9 @@ let rec model_spec_of_string s =
         | Some adapter when adapter.canonical_name = "codex-api" ->
           Ok { openai_default with model_id }
         | Some adapter when adapter.canonical_name = "glm" ->
-          Ok { glm_cloud with model_id }
+          (* "auto" or empty → Glm_pool selects at runtime *)
+          let effective_id = if model_id = "auto" then "" else model_id in
+          Ok { glm_cloud with model_id = effective_id }
         | Some adapter when adapter.canonical_name = "openrouter" ->
           Ok {
             provider = OpenRouter;

--- a/lib/llm_types.ml
+++ b/lib/llm_types.ml
@@ -114,7 +114,7 @@ let llama_default = {
 
 let claude_opus = {
   provider = Claude;
-  model_id = "claude-opus-4-6";
+  model_id = Env_config.Claude.default_model;
   max_context = 200000;
   api_url = "https://api.anthropic.com";
   api_key_env = Some "ANTHROPIC_API_KEY";
@@ -232,7 +232,9 @@ let rec model_spec_of_string s =
         | Some adapter when adapter.canonical_name = "codex-api" ->
           Ok { openai_default with model_id }
         | Some adapter when adapter.canonical_name = "glm" ->
-          Ok { glm_cloud with model_id }
+          (* "auto" or empty → Glm_pool selects at runtime *)
+          let effective_id = if model_id = "auto" then "" else model_id in
+          Ok { glm_cloud with model_id = effective_id }
         | Some adapter when adapter.canonical_name = "openrouter" ->
           Ok {
             provider = OpenRouter;

--- a/lib/lodge_cascade.ml
+++ b/lib/lodge_cascade.ml
@@ -64,18 +64,23 @@ let default_config_path () =
       | first :: _ -> first
       | [] -> Filename.concat (Sys.getcwd ()) "config/llm_cascade.json")
 
+(** Build a provider:model label, filtering out empty models. *)
+let label provider model =
+  if model = "" then None
+  else Some (Printf.sprintf "%s:%s" provider model)
+
+(** Build a label list, discarding entries with empty models. *)
+let labels_of pairs =
+  List.filter_map (fun (p, m) -> label p m) pairs
+
 let default_model_strings ~cascade_name =
+  let llama_model = Env_config.Llama.default_model in
+  let glm_model = Env_config.Llm.default_model in
+  let glm_flash = Env_config.Llm.flash_model in
+  (* llama + glm:auto — Glm_pool selects model at runtime *)
   let llama_glm =
-    [
-      Printf.sprintf "llama:%s" Env_config.Llama.default_model;
-      Printf.sprintf "glm:%s" Env_config.Llm.default_model;
-    ]
-  in
-  let local_llama_glm =
-    [
-      Printf.sprintf "llama:%s" Env_config.Llama.default_model;
-      Printf.sprintf "glm:%s" Env_config.Llm.default_model;
-    ]
+    (if llama_model <> "" then [ Printf.sprintf "llama:%s" llama_model ] else [])
+    @ [ "glm:auto" ]
   in
   match cascade_name with
   (* heartbeat — llama first, glm fallback *)
@@ -89,43 +94,40 @@ let default_model_strings ~cascade_name =
   (* gardener — llama first, glm fallback *)
   | "gardener_spawn" -> llama_glm
   (* classification — local llama, glm fallback *)
-  | "classification" | "context_router" | "capability_match" -> local_llama_glm
+  | "classification" | "context_router" | "capability_match" -> llama_glm
   (* theory of mind — local llama, glm fallback *)
-  | "tom" -> local_llama_glm
+  | "tom" -> llama_glm
   (* verifier — local llama, glm fallback *)
-  | "verifier" -> local_llama_glm
+  | "verifier" -> llama_glm
   (* trpg — local llama, glm fallback *)
-  | "trpg_intent" -> local_llama_glm
-  (* briefing — llama first, flash-tier cloud chain, local llama final fallback *)
+  | "trpg_intent" -> llama_glm
+  (* briefing — llama first, flash-tier cloud chain, glm fallback *)
   | "briefing" ->
-      [
-        Printf.sprintf "llama:%s" Env_config.Llama.default_model;
-        Printf.sprintf "glm:%s" Env_config.Llm.flash_model;
-        Printf.sprintf "gemini:%s" Env_config.Gemini.flash_model;
-        Printf.sprintf "glm:%s" Env_config.Llm.default_model;
-      ]
+      (if llama_model <> "" then [ Printf.sprintf "llama:%s" llama_model ] else [])
+      @ labels_of [ ("glm", glm_flash); ("gemini", Env_config.Gemini.flash_model) ]
+      @ [ "glm:auto" ]
   | "governance_judge" | "operator_judge" -> llama_glm
   (* walph — default execution models *)
   | "walph" -> llama_glm
   (* auto_responder — agent_type-specific cascades *)
   | "auto_responder_claude" ->
-      [ Printf.sprintf "claude:%s" Env_config.Claude.default_model;
-        Printf.sprintf "glm:%s" Env_config.Llm.default_model ]
+      labels_of [ ("claude", Env_config.Claude.default_model) ]
+      @ [ "glm:auto" ]
   | "auto_responder_gemini" ->
-      [ Printf.sprintf "gemini:%s" Env_config.Gemini.flash_model;
-        Printf.sprintf "glm:%s" Env_config.Llm.default_model ]
+      labels_of [ ("gemini", Env_config.Gemini.flash_model) ]
+      @ [ "glm:auto" ]
   | "auto_responder_glm" ->
-      [ Printf.sprintf "glm:%s" Env_config.Llm.default_model ]
+      labels_of [ ("glm", glm_model) ]
+      @ [ "glm:auto" ]
   | "auto_responder" -> llama_glm
-  (* spawn glm — cloud cascade for spawn_eio direct client path *)
+  (* spawn glm — cloud cascade via Glm_pool *)
   | "spawn_glm" ->
-      [ Printf.sprintf "glm:%s" Env_config.Llm.default_model;
-        Printf.sprintf "glm:%s" Env_config.Llm.flash_model;
-        "glm:glm-5"; "glm:glm-5-code" ]
+      labels_of [ ("glm", glm_model); ("glm", glm_flash) ]
+      @ [ "glm:auto" ]
   (* topic extraction — fast local model, glm fallback *)
   | "topic_extraction" ->
-      [ Printf.sprintf "ollama:%s" Env_config.Llm.flash_model;
-        Printf.sprintf "glm:%s" Env_config.Llm.default_model ]
+      labels_of [ ("ollama", glm_flash) ]
+      @ [ "glm:auto" ]
   (* unregistered cascade: llama + glm as safety net *)
   | _ -> llama_glm
 

--- a/lib/provider_adapter.ml
+++ b/lib/provider_adapter.ml
@@ -576,6 +576,10 @@ let configured_verifier_model_label_result () =
   | Some label -> Ok label
   | None -> configured_default_model_label_result ()
 
+let provider_model_label provider model =
+  if model = "" then None
+  else Some (Printf.sprintf "%s:%s" provider model)
+
 let preferred_execution_model_labels () =
   dedupe_keep_order
     (List.filter_map
@@ -587,18 +591,23 @@ let preferred_execution_model_labels () =
          (match explicit_llama_model_label_result () with
          | Ok label -> Some label
          | Error _ -> None);
-         if env_present "ZAI_API_KEY" then
-           Some (Printf.sprintf "glm:%s" Env_config.Llm.default_model)
-         else None;
-         if gemini_direct_available () then
-           Some (Printf.sprintf "gemini:%s" Env_config.Gemini.default_model)
-         else None;
-         if env_present "ANTHROPIC_API_KEY" then
-           Some (Printf.sprintf "claude:%s" Env_config.Claude.default_model)
-         else None;
-         if env_present "OPENAI_API_KEY" then
-           Some (Printf.sprintf "openai:%s" Env_config.OpenAI.default_model)
-         else None;
+         (* GLM: even with empty model config, include as "glm:" — Glm_pool
+            selects the model at runtime. *)
+         (if env_present "ZAI_API_KEY" then
+           let m = Env_config.Llm.default_model in
+           Some (Printf.sprintf "glm:%s" (if m = "" then "auto" else m))
+         else None);
+         (* Non-GLM providers: only include when model is explicitly configured.
+            APIs require a model field, so empty model = skip. *)
+         (if gemini_direct_available () then
+           provider_model_label "gemini" Env_config.Gemini.default_model
+         else None);
+         (if env_present "ANTHROPIC_API_KEY" then
+           provider_model_label "claude" Env_config.Claude.default_model
+         else None);
+         (if env_present "OPENAI_API_KEY" then
+           provider_model_label "openai" Env_config.OpenAI.default_model
+         else None);
        ])
 
 let preferred_verifier_model_labels () =
@@ -612,18 +621,19 @@ let preferred_verifier_model_labels () =
          (match explicit_llama_model_label_result () with
          | Ok label -> Some label
          | Error _ -> None);
-         if env_present "ZAI_API_KEY" then
-           Some (Printf.sprintf "glm:%s" Env_config.Llm.default_model)
-         else None;
-         if gemini_direct_available () then
-           Some (Printf.sprintf "gemini:%s" Env_config.Gemini.flash_model)
-         else None;
-         if env_present "ANTHROPIC_API_KEY" then
-           Some (Printf.sprintf "claude:%s" Env_config.Claude.default_model)
-         else None;
-         if env_present "OPENAI_API_KEY" then
-           Some (Printf.sprintf "openai:%s" Env_config.OpenAI.default_model)
-         else None;
+         (if env_present "ZAI_API_KEY" then
+           let m = Env_config.Llm.default_model in
+           Some (Printf.sprintf "glm:%s" (if m = "" then "auto" else m))
+         else None);
+         (if gemini_direct_available () then
+           provider_model_label "gemini" Env_config.Gemini.flash_model
+         else None);
+         (if env_present "ANTHROPIC_API_KEY" then
+           provider_model_label "claude" Env_config.Claude.default_model
+         else None);
+         (if env_present "OPENAI_API_KEY" then
+           provider_model_label "openai" Env_config.OpenAI.default_model
+         else None);
        ])
 
 let default_model_labels_result () =

--- a/lib/room_state.ml
+++ b/lib/room_state.ml
@@ -51,7 +51,7 @@ let write_state config state =
     let json_str = Yojson.Safe.to_string (room_state_to_yojson state) in
     (match backend_set config ~key:"room:state" ~value:json_str with
      | Ok () -> ()
-     | Error e -> Log.Misc.error "room_state write_state backend_set failed: %s" e)
+     | Error e -> Log.Misc.error "room_state write_state backend_set failed: %s" (Backend.show_error e))
   end
 
 (** Update state with function - uses file lock for atomic read-modify-write *)
@@ -346,8 +346,8 @@ let broadcast_in_room config ~room_id ~from_agent ~content =
   write_json scoped msg_file (message_to_yojson msg);
   (match backend_publish scoped ~channel:(Printf.sprintf "broadcast:%s" room_id)
       ~message:(Yojson.Safe.to_string (message_to_yojson msg)) with
-   | Ok () -> ()
-   | Error e -> Log.Misc.error "broadcast_scoped publish failed for %s: %s" room_id e);
+   | Ok _ -> ()
+   | Error e -> Log.Misc.error "broadcast_scoped publish failed for %s: %s" room_id (Backend.show_error e));
   Printf.sprintf "📢 [%s@%s] %s" safe_agent room_id safe_content
 
 let broadcast config ~from_agent ~content =
@@ -372,8 +372,8 @@ let broadcast config ~from_agent ~content =
   let room_id = match config.scope with Default -> "default" | Named id -> id in
   (match backend_publish config ~channel:(Printf.sprintf "broadcast:%s" room_id)
       ~message:(Yojson.Safe.to_string (message_to_yojson msg)) with
-   | Ok () -> ()
-   | Error e -> Log.Misc.error "broadcast publish failed for %s: %s" room_id e);
+   | Ok _ -> ()
+   | Error e -> Log.Misc.error "broadcast publish failed for %s: %s" room_id (Backend.show_error e));
   Printf.sprintf "📢 [%s@%s] %s" safe_agent room_id safe_content
 
 (* ============================================ *)

--- a/test/test_lodge_cascade.ml
+++ b/test/test_lodge_cascade.ml
@@ -111,18 +111,21 @@ let test_all_known_names_return_nonempty () =
         true (models <> []))
     known_cascade_names
 
-let test_unknown_name_returns_llama_fallback () =
+let test_unknown_name_returns_fallback () =
   let models =
     Lodge_cascade.default_model_strings ~cascade_name:"nonexistent_xyz"
   in
   check bool "catch-all returns non-empty" true (models <> []);
-  let first = List.hd models in
-  check bool "first is llama" true
-    (String.length first > 6 && String.sub first 0 6 = "llama:")
+  (* Always ends with glm:auto as safety net *)
+  let last = List.nth models (List.length models - 1) in
+  check string "last is glm:auto" "glm:auto" last
 
-let test_briefing_has_four_models () =
+let test_briefing_always_has_glm_auto () =
   let models = Lodge_cascade.default_model_strings ~cascade_name:"briefing" in
-  check int "briefing has 4 models" 4 (List.length models)
+  check bool "briefing is non-empty" true (List.length models >= 1);
+  (* glm:auto is always the final fallback *)
+  let last = List.nth models (List.length models - 1) in
+  check string "briefing ends with glm:auto" "glm:auto" last
 
 let test_classification_uses_llama_first () =
   let models =
@@ -157,10 +160,10 @@ let () =
         [
           test_case "all known names return non-empty" `Quick
             test_all_known_names_return_nonempty;
-          test_case "unknown name returns llama fallback" `Quick
-            test_unknown_name_returns_llama_fallback;
-          test_case "briefing has four models" `Quick
-            test_briefing_has_four_models;
+          test_case "unknown name returns fallback" `Quick
+            test_unknown_name_returns_fallback;
+          test_case "briefing always has glm:auto" `Quick
+            test_briefing_always_has_glm_auto;
           test_case "classification uses llama first" `Quick
             test_classification_uses_llama_first;
           test_case "model_key appends _models" `Quick


### PR DESCRIPTION
## Summary
- 6개 하드코딩된 LLM 모델명(`glm-4.7`, `gemini-2.5-pro`, `claude-sonnet-4-5-20250929`, `gpt-5` 등)을 `env_config_governance.ml`에서 제거
- 환경변수(`MASC_GLM_DEFAULT_MODEL`, `MASC_GEMINI_DEFAULT_MODEL` 등)로 override하거나 provider가 런타임에 결정
- GLM은 `"glm:auto"` → `Glm_pool`이 가용 모델 자동 선택
- Non-GLM provider는 모델 미설정 시 cascade에서 제외 (API가 model 필드 필수)
- `chain_stats.ml` 비용 테이블: exact match → prefix match
- `room_state.ml` #1248 빌드 에러 수정 (Backend.error 타입 + int result)

## Changed files (10)
- `lib/env_config_governance.ml` — 6 defaults → `""`
- `lib/provider_adapter.ml` — empty model 필터링 + `"glm:auto"` label
- `lib/llm_types.ml` + `lib/llm_client_core.ml` — `claude_opus` hardcoding 제거
- `lib/llm_client_providers.ml` — `"glm:auto"` → empty model_id
- `lib/lodge_cascade.ml` — `"glm:glm-5"` 제거, `labels_of` helper
- `lib/chain_stats.ml` — prefix-based cost matching
- `lib/chain_native_eio.ml` — `"glm-4.7"` alias 제거
- `lib/room_state.ml` — type error fixes from #1248
- `test/test_lodge_cascade.ml` — config-independent assertions

## Test plan
- [x] `dune build --root .` 통과
- [x] test_lodge_cascade 9/9
- [x] test_dashboard_cache 8/8
- [x] test_provider_adapter 12/12
- [x] test_glm_pool_coverage 28/28
- [x] test_llm_client_cascade 11/11
- [x] test_env_config_coverage 58/58
- [ ] `MASC_GLM_DEFAULT_MODEL="" ./start-masc-mcp.sh` → health OK
- [ ] 환경변수 설정 시 이전과 동일 동작 확인

Closes #1244

🤖 Generated with [Claude Code](https://claude.com/claude-code)