### PR TITLE
fix: surface 28 silent exception handlers with proper logging (v2)

### DIFF
--- a/lib/adaptive_thresholds.ml
+++ b/lib/adaptive_thresholds.ml
@@ -166,7 +166,7 @@ let load_state ~(room : string) : adaptive_state option =
           let json = Yojson.Safe.from_string content in
           state_of_json json)
     with exn ->
-      ignore exn;
+      Log.Misc.warn "adaptive_thresholds: state load failed: %s" (Printexc.to_string exn);
       None
   else None
 

--- a/lib/agent_planner.ml
+++ b/lib/agent_planner.ml
@@ -111,7 +111,9 @@ let load_plan ~agent_name ~date : daily_plan option =
         let buf = Bytes.create n in
         really_input ic buf 0 n;
         Yojson.Safe.from_string (Bytes.to_string buf) |> plan_of_json)
-    with exn -> let _ = exn in None
+    with exn ->
+      Log.Misc.warn "agent_planner: plan load failed: %s" (Printexc.to_string exn);
+      None
   end
 
 let save_plan (plan : daily_plan) =

--- a/lib/audit_log.ml
+++ b/lib/audit_log.ml
@@ -144,7 +144,9 @@ let entry_of_json (json : Yojson.Safe.t) : audit_entry option =
       with Yojson.Safe.Util.Type_error _ -> None
     in
     Some { timestamp; agent_id; action; room_id; details; outcome; cost_estimate; token_count }
-  with _exn -> None
+  with exn ->
+    Log.Misc.warn "audit_log: entry parse failed: %s" (Printexc.to_string exn);
+    None
 
 (** {1 File Operations} *)
 

--- a/lib/auto_responder.ml
+++ b/lib/auto_responder.ml
@@ -210,7 +210,7 @@ let masc_call ~sw ~tool_name ~(args : Yojson.Safe.t) : (string, string) result =
             in
             Ok txt
           with exn ->
-            ignore exn;
+            Log.Misc.warn "auto_responder: MCP response parse failed: %s" (Printexc.to_string exn);
             Ok body_str
       with exn ->
         Error (Printexc.to_string exn)

--- a/lib/chain_run_store.ml
+++ b/lib/chain_run_store.ml
@@ -374,7 +374,7 @@ let read_persisted_run_json ~(run_id : string) : Yojson.Safe.t option =
                | `String value when String.equal value run_id -> Some json
                | _ -> None
              with exn ->
-               ignore exn;
+               Log.Chain.warn "chain_run_store: run entry parse failed: %s" (Printexc.to_string exn);
                None)
 
 let list_runs_json () : Yojson.Safe.t =

--- a/lib/chain_telemetry.ml
+++ b/lib/chain_telemetry.ml
@@ -240,7 +240,7 @@ let emit event =
   (* Call handlers outside of lock to avoid deadlocks *)
   List.iter (fun handler ->
     try handler event
-    with exn -> ignore exn (* Ignore handler errors *)
+    with exn -> Log.Chain.warn "chain_telemetry: event handler failed: %s" (Printexc.to_string exn)
   ) handlers
 
 (** {1 Subscription API} *)

--- a/lib/goal_store.ml
+++ b/lib/goal_store.ml
@@ -286,7 +286,9 @@ let parse_yyyy_mm_dd s =
         in
         let ts, _ = Unix.mktime tm in
         Some ts)
-  with exn -> ignore exn; None
+  with exn ->
+    Log.Misc.warn "goal_store: parse_yyyy_mm_dd failed: %s" (Printexc.to_string exn);
+    None
 
 let days_until due_date =
   match due_date with

--- a/lib/keeper_exec_proactive.ml
+++ b/lib/keeper_exec_proactive.ml
@@ -143,11 +143,15 @@ let maybe_emit_proactive (ctx : _ context) (meta : keeper_meta) : keeper_meta =
                                 backlog.tasks)
                          in
                          (unclaimed, failed)
-                       with _exn -> (0, 0))
+                       with exn ->
+                         Log.Keeper.warn "proactive: task count query failed: %s" (Printexc.to_string exn);
+                         (0, 0))
                     in
                     let active_agents =
                       (try List.length (Room.get_agents_raw ctx.config)
-                       with _exn -> 0)
+                       with exn ->
+                         Log.Keeper.warn "proactive: agent count query failed: %s" (Printexc.to_string exn);
+                         0)
                     in
                     let obs =
                       { (Keeper_deliberation.empty_world_observation

--- a/lib/keeper_execution.ml
+++ b/lib/keeper_execution.ml
@@ -1009,11 +1009,15 @@ let maybe_emit_proactive (ctx : _ context) (meta : keeper_meta) : keeper_meta =
                                 backlog.tasks)
                          in
                          (unclaimed, failed)
-                       with _exn -> (0, 0))
+                       with exn ->
+                         Log.Keeper.warn "execution: task count query failed: %s" (Printexc.to_string exn);
+                         (0, 0))
                     in
                     let active_agents =
                       (try List.length (Room.get_agents_raw ctx.config)
-                       with _exn -> 0)
+                       with exn ->
+                         Log.Keeper.warn "execution: agent count query failed: %s" (Printexc.to_string exn);
+                         0)
                     in
                     let obs =
                       { (Keeper_deliberation.empty_world_observation

--- a/lib/keeper_keepalive.ml
+++ b/lib/keeper_keepalive.ml
@@ -251,12 +251,16 @@ let start_keepalive ?(proactive_warmup_sec = 0) (ctx : _ context)
                             backlog.tasks)
                      in
                      (unclaimed, failed)
-                   with _exn -> (0, 0))
+                   with exn ->
+                     Log.Keeper.warn "keepalive: task count query failed: %s" (Printexc.to_string exn);
+                     (0, 0))
                 in
                 let current_agent_count =
                   (try
                      List.length (Room.get_agents_raw ctx.config)
-                   with _exn -> 0)
+                   with exn ->
+                     Log.Keeper.warn "keepalive: agent count query failed: %s" (Printexc.to_string exn);
+                     0)
                 in
                 let agent_count_changed =
                   let last_count =

--- a/lib/keeper_learning.ml
+++ b/lib/keeper_learning.ml
@@ -88,7 +88,9 @@ let decision_record_of_json (json : Yojson.Safe.t) : decision_record option =
           feedback_comment =
             Safe_ops.json_string ~default:"" "feedback_comment" json;
         }
-  with _exn -> None
+  with exn ->
+    Log.Misc.warn "keeper_learning: decision record parse failed: %s" (Printexc.to_string exn);
+    None
 
 let decisions_path (config : Room.config) (name : string) : string =
   Filename.concat (keeper_dir config) (name ^ ".decisions.jsonl")

--- a/lib/orchestrator.ml
+++ b/lib/orchestrator.ml
@@ -207,7 +207,9 @@ let make_zero_zombie_consumer ~room_config
             try
               String.sub status_trimmed 0 (min 4 (String.length status_trimmed)) = "\xf0\x9f\xa7\x9f" ||
               String.length status_trimmed >= 7 && String.sub status_trimmed 0 7 = "Cleaned"
-            with exn -> let _ = exn in false
+            with exn ->
+              Log.Orchestrator.warn "zombie indicator check failed: %s" (Printexc.to_string exn);
+              false
           in
           if has_zombie_indicator then
             Log.Orchestrator.info "[zombie] %s" status_trimmed

--- a/lib/reflection.ml
+++ b/lib/reflection.ml
@@ -54,7 +54,7 @@ let load_meta ~agent_name : float =
         let json = Yojson.Safe.from_string (Bytes.to_string buf) in
                 Json_util.get_float json "last_reflection" |> Option.value ~default:0.0)
     with exn ->
-      ignore (Printexc.to_string exn);
+      Log.Misc.warn "reflection: meta load failed: %s" (Printexc.to_string exn);
       0.0
   end
 

--- a/lib/room_state.ml
+++ b/lib/room_state.ml
@@ -51,7 +51,7 @@ let write_state config state =
     let json_str = Yojson.Safe.to_string (room_state_to_yojson state) in
     (match backend_set config ~key:"room:state" ~value:json_str with
      | Ok () -> ()
-     | Error e -> Log.Misc.error "room_state write_state backend_set failed: %s" e)
+     | Error e -> Log.Misc.error "room_state write_state backend_set failed: %s" (Backend.show_error e))
   end
 
 (** Update state with function - uses file lock for atomic read-modify-write *)
@@ -346,8 +346,8 @@ let broadcast_in_room config ~room_id ~from_agent ~content =
   write_json scoped msg_file (message_to_yojson msg);
   (match backend_publish scoped ~channel:(Printf.sprintf "broadcast:%s" room_id)
       ~message:(Yojson.Safe.to_string (message_to_yojson msg)) with
-   | Ok () -> ()
-   | Error e -> Log.Misc.error "broadcast_scoped publish failed for %s: %s" room_id e);
+   | Ok _ -> ()
+   | Error e -> Log.Misc.error "broadcast_scoped publish failed for %s: %s" room_id (Backend.show_error e));
   Printf.sprintf "📢 [%s@%s] %s" safe_agent room_id safe_content
 
 let broadcast config ~from_agent ~content =
@@ -372,8 +372,8 @@ let broadcast config ~from_agent ~content =
   let room_id = match config.scope with Default -> "default" | Named id -> id in
   (match backend_publish config ~channel:(Printf.sprintf "broadcast:%s" room_id)
       ~message:(Yojson.Safe.to_string (message_to_yojson msg)) with
-   | Ok () -> ()
-   | Error e -> Log.Misc.error "broadcast publish failed for %s: %s" room_id e);
+   | Ok _ -> ()
+   | Error e -> Log.Misc.error "broadcast publish failed for %s: %s" room_id (Backend.show_error e));
   Printf.sprintf "📢 [%s@%s] %s" safe_agent room_id safe_content
 
 (* ============================================ *)

--- a/lib/succession.ml
+++ b/lib/succession.ml
@@ -365,7 +365,7 @@ let hydrate (dna : succession_dna) (spec : successor_spec) : Context_manager.wor
       try Some (Context_manager.deserialize_context
                   dna.compressed_context ~max_tokens:spec.model.max_context)
       with exn ->
-        ignore (Printexc.to_string exn);
+        Log.Misc.warn "succession: context deserialize failed: %s" (Printexc.to_string exn);
         None
   in
   (* Preserve the previous system prompt (keeper/perpetual constitution + custom instructions).

--- a/lib/task_pg.ml
+++ b/lib/task_pg.ml
@@ -235,7 +235,7 @@ let row_to_task (((id, title, description), (priority, status, assignee),
     | `List items -> List.filter_map Yojson.Safe.Util.to_string_option items
     | _ -> []
   with exn ->
-    ignore (Printexc.to_string exn);
+    Log.Misc.warn "task_pg: files JSON parse failed: %s" (Printexc.to_string exn);
     [] in
   let required_role = Agent_identity.role_of_string required_role_str in
   {

--- a/lib/tool_experiment.ml
+++ b/lib/tool_experiment.ml
@@ -154,7 +154,7 @@ let write_json path json =
   let closed = ref false in
   Fun.protect
     ~finally:(fun () ->
-      if not !closed then (try close_out oc with exn -> let _ = exn in ());
+      if not !closed then (try close_out oc with exn -> Log.Misc.warn "tool_experiment: close_out failed: %s" (Printexc.to_string exn));
       if Sys.file_exists tmp then (try Sys.remove tmp with Sys_error _ -> ()))
     (fun () ->
       output_string oc content;
@@ -171,7 +171,9 @@ let read_json path =
         really_input_string ic (in_channel_length ic))
     in
     Some (Yojson.Safe.from_string content)
-  with exn -> let _ = exn in None
+  with exn ->
+    Log.Misc.warn "tool_experiment: read_json failed for %s: %s" path (Printexc.to_string exn);
+    None
 
 let save_experiment config (exp : experiment) =
   ensure_dir (experiments_dir config);

--- a/lib/tool_mdal.ml
+++ b/lib/tool_mdal.ml
@@ -459,7 +459,7 @@ let post_final_summary (state : Mdal.loop_state) =
          ~ttl_hours:24
          ~hearth:(Mdal.state_hearth state.loop_id)
          ())
-  with exn -> ignore exn
+  with exn -> Log.Misc.warn "tool_mdal: final board post failed: %s" (Printexc.to_string exn)
 
 let terminal_response ?config (state : Mdal.loop_state) ~reason ~error_message =
   assoc_with_fields (state_to_json ?config state)
@@ -485,7 +485,7 @@ let emit_stop_event (state : Mdal.loop_state) ~reason =
           ("final_metric", `Float final_metric);
           ("iterations", `Int state.current_iteration);
         ])
-  with exn -> ignore exn
+  with exn -> Log.Misc.warn "tool_mdal: emit_stop_event SSE failed: %s" (Printexc.to_string exn)
 
 let emit_completed_event ~loop_id ~final_metric ~iterations =
   try
@@ -497,7 +497,7 @@ let emit_completed_event ~loop_id ~final_metric ~iterations =
           ("final_metric", `Float final_metric);
           ("iterations", `Int iterations);
         ])
-  with exn -> ignore exn
+  with exn -> Log.Misc.warn "tool_mdal: emit_completed_event SSE failed: %s" (Printexc.to_string exn)
 
 let run_worker_iteration (ctx : context) (config : Room.config)
     (state : Mdal.loop_state) current_metric =
@@ -707,7 +707,7 @@ let handle_start (ctx : context) args =
          ("evidence_policy", `String "hard");
          ("execution_mode", `String (Mdal.execution_mode_to_string state.execution_mode));
          ("persistence_backend", `String (config_persistence_backend config));
-       ]) with exn -> ignore exn);
+       ]) with exn -> Log.Misc.warn "tool_mdal: mdal_started SSE failed: %s" (Printexc.to_string exn));
 
       assoc_with_fields (state_to_json ~config state)
         [ ("worker_prompt", `String (Mdal.render_worker_prompt profile [] baseline)) ])
@@ -868,7 +868,7 @@ let handle_iterate (ctx : context) args =
                                 ~ttl_hours:24
                                 ~hearth:(Mdal.iter_hearth state.loop_id)
                                 ())
-                    with exn -> ignore exn);
+                    with exn -> Log.Misc.warn "tool_mdal: iter board post failed: %s" (Printexc.to_string exn));
 
                    (* Broadcast via SSE *)
                    (try Sse.broadcast (`Assoc [
@@ -878,7 +878,7 @@ let handle_iterate (ctx : context) args =
                       ("metric_before", `Float metric_before);
                       ("metric_after", `Float metric_after);
                       ("delta", `Float delta);
-                    ]) with exn -> ignore exn);
+                    ]) with exn -> Log.Misc.warn "tool_mdal: iter SSE broadcast failed: %s" (Printexc.to_string exn));
 
                    (* Check if goal is met *)
                    let evaluation = Mdal.evaluate_iteration record in

--- a/lib/trpg_preset_store.ml
+++ b/lib/trpg_preset_store.ml
@@ -546,7 +546,9 @@ let load_scenario_world_presets ~base_dir : world_preset list =
             let path = Filename.concat scenarios_dir file_name in
             try
               Yojson.Safe.from_file path |> parse_scenario_world_preset
-            with exn -> let _ = exn in None)
+            with exn ->
+              Log.Trpg.warn "trpg_preset_store: scenario preset parse failed for %s: %s" path (Printexc.to_string exn);
+              None)
      with exn ->
        Log.Trpg.error "failed to load scenario presets from %s: %s"
          scenarios_dir (Printexc.to_string exn);


### PR DESCRIPTION
## Summary

- Replace 28 silent exception swallowing patterns across 19 files with proper `Log.*.warn` calls
- Follows up on PR #1248 which fixed 8 patterns in 10 files
- Also fixes pre-existing build error in `room_state.ml` from PR #1248 (`Backend.error` type mismatch + `Ok ()` vs `Ok _` for publish)

## Patterns fixed

| Pattern | Count | Fix |
|---------|-------|-----|
| `ignore exn` | 9 | `Log.*.warn "context: %s" (Printexc.to_string exn)` |
| `let _ = exn in` | 5 | Same |
| `_exn -> None` / `_exn -> 0` | 8 | Same |
| `ignore (Printexc.to_string exn)` | 3 | Replace `ignore` with `Log.*.warn` |
| `room_state.ml` build fix | 3 | `Backend.show_error`, `Ok _` |

## Files changed

**Data parsing** (8): audit_log, keeper_learning, chain_run_store, task_pg, trpg_preset_store, agent_planner, tool_experiment, goal_store
**SSE/Board** (1): tool_mdal (6 handlers)
**Keeper observation** (3): keeper_exec_proactive, keeper_execution, keeper_keepalive
**Persistence** (3): adaptive_thresholds, succession, reflection
**Execution** (3): chain_telemetry, orchestrator, auto_responder
**Build fix** (1): room_state

## What was NOT changed

- Handlers that already log (Printf.eprintf, Log.*, Printexc usage)
- `Eio.Cancel.Cancelled` / `is_cancelled` guards (correct behavior)
- `cancellation.ml` (intentional callback isolation)
- Simple `Sys_error` catches in cleanup code
- Files already fixed in PR #1248

## Test plan

- [x] `dune build` passes
- [ ] `make test` (running)
- [ ] No behavioral changes -- only logging added, all return values preserved


Generated with [Claude Code](https://claude.com/claude-code)