### PR TITLE
fix(init): replace ref circuit breaker with Eio-native timeout and fiber isolation

### DIFF
--- a/lib/backend.ml
+++ b/lib/backend.ml
@@ -804,10 +804,9 @@ end = struct
     (Caqti_type.unit ->. Caqti_type.unit)
     "DELETE FROM masc_kv WHERE expires_at IS NOT NULL AND expires_at < NOW()"
 
-  (* Circuit breaker for expired lock cleanup: after 3 consecutive failures,
-     skip cleanup for 60s to avoid blocking acquire_lock when PG is saturated *)
-  let cleanup_failures = ref 0
-  let cleanup_backoff_until = ref 0.0
+  (* Eio-native timeout for expired lock cleanup: cooperatively cancels
+     when PG is saturated instead of blocking the caller indefinitely *)
+  let cleanup_timeout_sec = 2.0
 
   let health_check_q =
     (Caqti_type.unit ->! Caqti_type.int)
@@ -1026,24 +1025,26 @@ end = struct
 
   let acquire_lock t ~key ~ttl_seconds ~owner =
     let nkey = namespaced_key t.namespace ("lock:" ^ key) in
-    (* Clean up expired locks — circuit breaker skips after 3 consecutive failures *)
-    (if Time_compat.now () < !cleanup_backoff_until then ()
-     else
-       match Caqti_eio.Pool.use (fun conn ->
-         let module C = (val conn : Caqti_eio.CONNECTION) in
-         C.exec cleanup_expired_q ()
-       ) t.pool with
-       | Ok () -> cleanup_failures := 0
-       | Error err ->
-         cleanup_failures := !cleanup_failures + 1;
-         if !cleanup_failures >= 3 then begin
-           cleanup_backoff_until := Time_compat.now () +. 60.0;
-           Log.Misc.warn
-             "[backend] expired lock cleanup failed %d times, backing off 60s: %s"
-             !cleanup_failures (Caqti_error.show err)
-         end else
-           Log.Misc.error "[backend] expired lock cleanup failed: %s"
-             (Caqti_error.show err));
+    (* Clean up expired locks with Eio cooperative timeout.
+       If PG is saturated, cleanup times out after 2s instead of blocking. *)
+    (try
+       let clock = Eio_context.get_clock () in
+       Eio.Time.with_timeout_exn clock cleanup_timeout_sec (fun () ->
+         match Caqti_eio.Pool.use (fun conn ->
+           let module C = (val conn : Caqti_eio.CONNECTION) in
+           C.exec cleanup_expired_q ()
+         ) t.pool with
+         | Ok () -> ()
+         | Error err ->
+             Log.Misc.error "[backend] expired lock cleanup failed: %s"
+               (Caqti_error.show err))
+     with
+     | Eio.Time.Timeout ->
+         Log.Misc.warn "[backend] expired lock cleanup timed out (%.0fs), skipping"
+           cleanup_timeout_sec
+     | exn ->
+         Log.Misc.error "[backend] expired lock cleanup error: %s"
+           (Printexc.to_string exn));
     (* Try to acquire lock *)
     match Caqti_eio.Pool.use (fun conn ->
       let module C = (val conn : Caqti_eio.CONNECTION) in

--- a/lib/server_runtime_bootstrap.ml
+++ b/lib/server_runtime_bootstrap.ml
@@ -87,35 +87,41 @@ let start_resident_loops ~sw ~clock ~net ~domain_mgr ~proc_mgr
   Progress.set_sse_callback Sse.broadcast;
   (* OAS Event_bus: shared instance for cross-subsystem communication *)
   let event_bus = Agent_sdk.Event_bus.create () in
-  (* Isolate each subsystem so one failure does not kill the rest *)
-  let try_start name f =
-    try f ()
-    with exn ->
-      Log.Server.error "subsystem %s failed to start: %s" name
-        (Printexc.to_string exn)
+  (* Eio fiber isolation: each subsystem runs in its own fiber.
+     If one crashes, others keep running — Eio's structured concurrency. *)
+  let fork_subsystem name f =
+    Eio.Fiber.fork ~sw (fun () ->
+      try f ()
+      with exn ->
+        Log.Server.error "subsystem %s crashed: %s" name
+          (Printexc.to_string exn))
   in
-  try_start "orchestrator" (fun () ->
+  (* Orchestrator needs synchronous registration for shutdown hook *)
+  (try
     let cancel_orchestrator =
       Orchestrator.start ~sw ~proc_mgr ~clock ~domain_mgr state.room_config
     in
-    Shutdown_hooks.register_cancel_orchestrator cancel_orchestrator);
-  try_start "social_runtime" (fun () ->
+    Shutdown_hooks.register_cancel_orchestrator cancel_orchestrator
+  with exn ->
+    Log.Server.error "subsystem orchestrator failed to start: %s"
+      (Printexc.to_string exn));
+  fork_subsystem "social_runtime" (fun () ->
     Social_runtime.start ~sw ~clock ~config:state.room_config);
-  try_start "gardener" (fun () ->
+  fork_subsystem "gardener" (fun () ->
     Gardener.start ~bus:event_bus ~sw ~clock ~room_config:state.room_config ());
-  try_start "sentinel_guardian" (fun () ->
+  fork_subsystem "sentinel_guardian" (fun () ->
     if Env_config.Sentinel.enabled then begin
       Sentinel.start ~bus:event_bus ~sw ~clock ~net state.room_config;
       if Env_config.Guardian.enabled then Guardian.start_lodge_loop ~sw ~clock ~net
     end else Guardian.start ~bus:event_bus ~sw ~clock ~net state.room_config);
-  try_start "governance_judge" (fun () ->
+  fork_subsystem "governance_judge" (fun () ->
     Dashboard_governance_judge.start ~sw ~clock
       ~base_path:state.room_config.base_path
       ~build_facts:(fun () ->
         Dashboard_governance.factual_snapshot_json
           ~base_path:state.room_config.base_path)
       ());
-  try_start "operator_judge" (fun () ->
+  fork_subsystem "operator_judge" (fun () ->
     let operator_judge_ctx : _ Operator_control.context =
       {
         config = state.room_config;
@@ -131,7 +137,7 @@ let start_resident_loops ~sw ~clock ~net ~domain_mgr ~proc_mgr
         Operator_control.snapshot_json ~actor:"operator-judge" ~view:"summary"
           ~include_messages:false ~include_keepers:false operator_judge_ctx)
       ());
-  try_start "session_cleanup" (fun () ->
+  fork_subsystem "session_cleanup" (fun () ->
     Session.start_mcp_session_cleanup_loop ~sw ~clock ());
   (* Phase 5: unified startup subsystem summary *)
   let on_off b = if b then "on" else "off" in


### PR DESCRIPTION
## Summary

#1249의 ref 기반 circuit breaker를 Eio-native 패턴으로 교체합니다.

### Before (ref 기반, Eio 반패턴)
```ocaml
let cleanup_failures = ref 0
let cleanup_backoff_until = ref 0.0
(* manual time check, mutable state *)
```

### After (Eio cooperative timeout)
```ocaml
Eio.Time.with_timeout_exn clock 2.0 (fun () -> cleanup ...)
(* Eio scheduler가 cooperative하게 cancel *)
```

### 변경 2: Subsystem fiber isolation

### Before (sequential try/with — 같은 fiber)
```ocaml
let try_start name f = try f () with exn -> log ...
```

### After (Eio.Fiber.fork — 독립 fiber)
```ocaml
let fork_subsystem name f =
  Eio.Fiber.fork ~sw (fun () -> try f () with exn -> log ...)
```

## Test plan
- [x] `DUNE_BUILD_DIR=_build_eio dune build --root .` clean
- [ ] 서버 재시작 후 PG 포화 상황에서 sentinel/gardener 정상 시작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)