### PR TITLE
perf(dashboard): filter sessions to active + recent 24h

### DIFF
--- a/lib/dashboard_execution.ml
+++ b/lib/dashboard_execution.ml
@@ -113,12 +113,27 @@ let json ?actor ?fixture ~config ~sw ~clock ~proc_mgr () =
       in
       (* Yield between heavy phases so SSE / health-check fibers can progress *)
       Eio.Fiber.yield ();
-      (* Load sessions once; pass to snapshot_json to avoid repeated filesystem scans *)
-      let sessions =
+      (* Load sessions once; pass to snapshot_json to avoid repeated filesystem scans.
+         Only include active (Running/Paused) sessions plus recently finished ones
+         (last 24h) to avoid loading all historical sessions on every poll. *)
+      let all_sessions =
         if Room.is_initialized config then
           Team_session_store.list_sessions config
         else []
       in
+      let cutoff_iso =
+        let t = Time_compat.now () -. 86400.0 in
+        let tm = Unix.gmtime t in
+        Printf.sprintf "%04d-%02d-%02dT%02d:%02d:%02dZ"
+          (tm.Unix.tm_year + 1900) (tm.Unix.tm_mon + 1) tm.Unix.tm_mday
+          tm.Unix.tm_hour tm.Unix.tm_min tm.Unix.tm_sec
+      in
+      let is_active_or_recent (s : Team_session_types.session) =
+        match s.status with
+        | Running | Paused -> true
+        | _ -> s.updated_at_iso >= cutoff_iso
+      in
+      let sessions = List.filter is_active_or_recent all_sessions in
       Eio.Fiber.yield ();
       (* Compute directly without Dashboard_cache to avoid nested
          get_or_compute deadlock — the caller (dashboard_execution_http_json)


### PR DESCRIPTION
## Summary
- `/execution` endpoint가 44개 completed/interrupted 세션을 매번 전부 로드 (7.8MB I/O, 3.5초)
- active 0개인데도 매 poll마다 반복 → server hang 원인 (#1251의 SWR로 방어했으나 근본 수정)
- `Running`/`Paused` + 최근 24h 세션만 `snapshot_json`에 전달

## Before/After
| Metric | Before | After |
|--------|--------|-------|
| Sessions loaded into execution | 44 (all) | ~4 (active + recent 24h) |
| Compute time (0 active) | 2.5-3.5s | <0.5s (expected) |

## Test plan
- [x] `dune build` clean
- [ ] 서버 재시작 후 `/api/v1/dashboard/execution` 응답 시간 측정

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>