### PR TITLE
fix: remove remaining hardcoded model names + fix stale source-pattern tests

### DIFF
--- a/lib/chain_native_eio.ml
+++ b/lib/chain_native_eio.ml
@@ -228,7 +228,8 @@ let llm_tool_calls_json (calls : Llm_client.tool_call list) =
 type llm_runner =
   | Stub
   | Direct of Llm_client.model_spec
-  | Spawn of string
+  | Spawn of string (* agent name *)
+  | SpawnWithModel of { agent: string; model: string }
 
 let model_runner_of_string raw =
   let model = trim raw in
@@ -270,10 +271,10 @@ let model_runner_of_string raw =
       | Error _ when starts_with ~prefix:"claude-" value ->
           direct (Printf.sprintf "claude:%s" value)
       | Error _ when starts_with ~prefix:"gpt-" value ->
-          Ok (Spawn "codex")
+          Ok (SpawnWithModel { agent = "codex"; model = value })
       | Error msg -> Error msg)
 
-let call_spawn_model (runtime : runtime) ~agent_name ~prompt ~timeout_sec =
+let call_spawn_model (runtime : runtime) ~agent_name ?model_override ~prompt ~timeout_sec () =
   match runtime.mcp_state.Mcp_server.proc_mgr with
   | None -> Error "spawn runtime unavailable"
   | Some proc_mgr ->
@@ -281,6 +282,7 @@ let call_spawn_model (runtime : runtime) ~agent_name ~prompt ~timeout_sec =
         Spawn_eio.spawn ~sw:runtime.sw ~proc_mgr ~agent_name ~prompt
           ~timeout_seconds:timeout_sec
           ?working_dir:(Some runtime.config.base_path)
+          ?model_override
           ~room_config:runtime.config ()
       in
       if result.success then Ok result.output else Error result.output
@@ -296,7 +298,14 @@ let call_llm_text (runtime : runtime) ~model ?system ?tools ?thinking:_ ~prompt
         | Some sys when trim sys <> "" -> sprintf "[system]\n%s\n\n[user]\n%s" sys prompt
         | _ -> prompt
       in
-      call_spawn_model runtime ~agent_name ~prompt:full_prompt ~timeout_sec
+      call_spawn_model runtime ~agent_name ~prompt:full_prompt ~timeout_sec ()
+  | Ok (SpawnWithModel { agent = agent_name; model = model_override }) ->
+      let full_prompt =
+        match system with
+        | Some sys when trim sys <> "" -> sprintf "[system]\n%s\n\n[user]\n%s" sys prompt
+        | _ -> prompt
+      in
+      call_spawn_model runtime ~agent_name ~model_override ~prompt:full_prompt ~timeout_sec ()
   | Ok (Direct spec) ->
       let req : Llm_client.completion_request =
         {

--- a/lib/chain_native_eio.ml
+++ b/lib/chain_native_eio.ml
@@ -239,14 +239,12 @@ let model_runner_of_string raw =
     | Error msg -> Error msg
   in
   match lower with
-  | "" | "gemini" | "gemini-3.1-pro-preview" | "gemini-3-pro-preview"
-  | "gemini-2.5-pro" ->
-      direct "gemini:pro"
+  | "" | "gemini" -> direct "gemini:pro"
   | "pro" -> direct "gemini:pro"
-  | "flash" | "flash-lite" | "3-flash" -> direct "gemini:flash"
-  | "claude" | "claude-cli" | "opus" | "opus-4" -> direct "claude:opus"
+  | "flash" | "flash-lite" -> direct "gemini:flash"
+  | "claude" | "claude-cli" | "opus" -> direct "claude:opus"
   | "sonnet" -> direct "claude:sonnet"
-  | "haiku" | "haiku-4.5" -> direct "claude:haiku"
+  | "haiku" -> direct "claude:haiku"
   | "ollama" -> Error (Provider_adapter.bare_ollama_migration_message ())
   | "llama" -> (
       match Provider_adapter.explicit_llama_model_label_result () with
@@ -255,7 +253,7 @@ let model_runner_of_string raw =
   | "glm" ->
       direct "glm:auto"
   | "stub" | "mock" -> Ok Stub
-  | "codex" | "gpt-5.2" -> Ok (Spawn "codex")
+  | "codex" -> Ok (Spawn "codex")
   | value when starts_with ~prefix:"codex:" value -> Ok (Spawn "codex")
   | value -> (
       match Llm_client.model_spec_of_string model with
@@ -264,9 +262,15 @@ let model_runner_of_string raw =
       | Error _ when starts_with ~prefix:"gemini:" value -> direct model
       | Error _ when starts_with ~prefix:"claude:" value -> direct model
       | Error _ when starts_with ~prefix:"glm:" value -> direct model
-      (* Bare GLM model names (e.g. "glm-4.7") → route to GLM provider *)
+      (* Bare provider model names → route to provider *)
       | Error _ when starts_with ~prefix:"glm-" value ->
           direct (Printf.sprintf "glm:%s" value)
+      | Error _ when starts_with ~prefix:"gemini-" value ->
+          direct (Printf.sprintf "gemini:%s" value)
+      | Error _ when starts_with ~prefix:"claude-" value ->
+          direct (Printf.sprintf "claude:%s" value)
+      | Error _ when starts_with ~prefix:"gpt-" value ->
+          Ok (Spawn "codex")
       | Error msg -> Error msg)
 
 let call_spawn_model (runtime : runtime) ~agent_name ~prompt ~timeout_sec =

--- a/lib/chain_native_eio.ml
+++ b/lib/chain_native_eio.ml
@@ -264,6 +264,9 @@ let model_runner_of_string raw =
       | Error _ when starts_with ~prefix:"gemini:" value -> direct model
       | Error _ when starts_with ~prefix:"claude:" value -> direct model
       | Error _ when starts_with ~prefix:"glm:" value -> direct model
+      (* Bare GLM model names (e.g. "glm-4.7") → route to GLM provider *)
+      | Error _ when starts_with ~prefix:"glm-" value ->
+          direct (Printf.sprintf "glm:%s" value)
       | Error msg -> Error msg)
 
 let call_spawn_model (runtime : runtime) ~agent_name ~prompt ~timeout_sec =

--- a/lib/chain_orchestrator_eio.ml
+++ b/lib/chain_orchestrator_eio.ml
@@ -395,11 +395,11 @@ let orchestrate
         in
         match lowered with
         | "stub" | "mock" -> Ok (Printf.sprintf "[stub]%s" prompt)
-        | "codex" | "gpt-5.2" ->
-            exec_with_retry "codex" (("model", `String "gpt-5.2") :: args)
+        | "codex" ->
+            exec_with_retry "codex" args
         | m when starts_with ~prefix:"gpt-" m ->
             exec_with_retry "codex" (("model", `String model) :: args)
-        | "claude" | "claude-cli" | "opus" | "sonnet" | "haiku" | "haiku-4.5" ->
+        | "claude" | "claude-cli" | "opus" | "sonnet" | "haiku" ->
             exec_with_retry "claude" (("model", `String model) :: args)
         | "ollama" ->
             Error (Provider_adapter.bare_ollama_migration_message ())
@@ -410,7 +410,7 @@ let orchestrate
         | m when is_gemini_model m ->
             exec_with_retry "gemini" (("model", `String model) :: args)
         | _ ->
-            exec_with_retry "gemini" (("model", `String "gemini-3.1-pro-preview") :: args)
+            exec_with_retry "gemini" args
       in
 
       (* Create tool execution wrapper *)

--- a/lib/chain_orchestrator_eio.ml
+++ b/lib/chain_orchestrator_eio.ml
@@ -410,7 +410,12 @@ let orchestrate
         | m when is_gemini_model m ->
             exec_with_retry "gemini" (("model", `String model) :: args)
         | _ ->
-            exec_with_retry "gemini" args
+            let default_gemini = Env_config.Gemini.default_model in
+            let fallback_args =
+              if default_gemini <> "" then ("model", `String default_gemini) :: args
+              else args
+            in
+            exec_with_retry "gemini" fallback_args
       in
 
       (* Create tool execution wrapper *)

--- a/lib/llm_client_providers.ml
+++ b/lib/llm_client_providers.ml
@@ -377,7 +377,8 @@ let rec model_spec_of_string s =
         | Some adapter when adapter.canonical_name = "gemini-api" ->
           if model_id = "pro" then Ok gemini_pro
           else if model_id = "flash" then
-            Ok { gemini_pro with model_id = "gemini-3-flash-preview" }
+            let flash = Env_config.Gemini.flash_model in
+            Ok { gemini_pro with model_id = (if flash = "" then "flash" else flash) }
           else
             Ok { gemini_pro with model_id }
         | Some adapter when adapter.canonical_name = "claude-api" ->

--- a/lib/llm_types.ml
+++ b/lib/llm_types.ml
@@ -222,7 +222,8 @@ let rec model_spec_of_string s =
         | Some adapter when adapter.canonical_name = "gemini-api" ->
           if model_id = "pro" then Ok gemini_pro
           else if model_id = "flash" then
-            Ok { gemini_pro with model_id = "gemini-3-flash-preview" }
+            let flash = Env_config.Gemini.flash_model in
+            Ok { gemini_pro with model_id = (if flash = "" then "flash" else flash) }
           else
             Ok { gemini_pro with model_id }
         | Some adapter when adapter.canonical_name = "claude-api" ->

--- a/lib/spawn_eio.ml
+++ b/lib/spawn_eio.ml
@@ -361,7 +361,7 @@ let spawn_glm_via_client ~prompt ~timeout ~start_time : spawn_result =
 let spawn ~sw ~proc_mgr ~agent_name ~prompt ?timeout_seconds ?working_dir
     ?room_config ?runtime_agent_name ?runtime_model ?runtime_role
     ?runtime_session_id ?runtime_selection_note ?worker_run_id ?worker_class ?worker_size
-    ?execution_scope ?thinking_enabled ?max_turns () : spawn_result =
+    ?execution_scope ?thinking_enabled ?max_turns ?model_override () : spawn_result =
   let start_time = Time_compat.now () in
   let normalized_agent = String.lowercase_ascii (String.trim agent_name) in
   if Provider_adapter.is_bare_ollama_label normalized_agent then
@@ -537,8 +537,12 @@ let spawn ~sw ~proc_mgr ~agent_name ~prompt ?timeout_seconds ?working_dir
   else
     (* Build command arguments outside the chdir critical section *)
     let base_args = parse_command config.command |> add_default_model_arg agent_name in
+    let model_args = match model_override with
+      | Some m -> ["-m"; m]
+      | None -> []
+    in
     let prompt_args = build_prompt_args agent_name augmented_prompt in
-    let cmd_args = base_args @ mcp_args @ prompt_args in
+    let cmd_args = base_args @ model_args @ mcp_args @ prompt_args in
     let full_args = ["timeout"; string_of_int timeout] @ cmd_args in
     let stdin_content = if agent_name = "gemini" then "" else augmented_prompt in
 

--- a/test/test_lodge_heartbeat_cleanup_coverage.ml
+++ b/test/test_lodge_heartbeat_cleanup_coverage.ml
@@ -120,7 +120,7 @@ let test_lodge_heartbeat_no_heuristic_fallback_policy () =
     (file_contains_pattern "lib/lodge_heartbeat_agents.ml" "| Scheduled | ManualTrigger -> true");
   check bool "content alerts cannot request post tool"
     true
-    (file_contains_pattern "lib/lodge_heartbeat.ml" "| ContentAlert _ | Mentioned _ -> false");
+    (file_contains_pattern "lib/lodge_heartbeat_agents.ml" "| ContentAlert _ | Mentioned _ -> false");
   check bool "selection failures are explicit"
     true
     (file_contains_pattern "lib/lodge_heartbeat.ml"

--- a/test/test_lodge_heartbeat_cleanup_coverage.ml
+++ b/test/test_lodge_heartbeat_cleanup_coverage.ml
@@ -56,7 +56,7 @@ let test_lodge_heartbeat_uses_tool_assignment_prompt () =
 let test_lodge_graphql_defaults_and_guards () =
   check bool "heartbeat GraphQL uses shared client"
     true
-    (file_contains_pattern "lib/lodge_heartbeat.ml" "Graphql_client.request");
+    (file_contains_pattern "lib/lodge_heartbeat_state.ml" "Graphql_client.request");
   check bool "tool_lodge GraphQL uses shared endpoint helper"
     true
     (file_contains_pattern "lib/tool_lodge_config_http.ml"
@@ -80,7 +80,7 @@ let test_lodge_graphql_defaults_and_guards () =
        "endpoint returned HTML instead of JSON");
   check bool "null agents guard present in heartbeat"
     true
-    (file_contains_pattern "lib/lodge_heartbeat.ml" "GraphQL agents is null");
+    (file_contains_pattern "lib/lodge_heartbeat_state.ml" "GraphQL agents is null");
   check bool "null agents guard present in tool_lodge"
     true
     (file_contains_pattern "lib/tool_lodge_config_http.ml" "GraphQL agents is null");
@@ -97,7 +97,7 @@ let test_lodge_heartbeat_updates_self_summary () =
 let test_lodge_heartbeat_uses_shared_prompt_cascade () =
   check bool "heartbeat uses shared prompt cascade"
     true
-    (file_contains_pattern "lib/lodge_heartbeat.ml" "Lodge_cascade.call")
+    (file_contains_pattern "lib/lodge_heartbeat_agents.ml" "Lodge_cascade.call")
 
 let test_lodge_heartbeat_uses_runtime_verifier_mode () =
   check bool "heartbeat uses verifier auto mode for posts"
@@ -112,12 +112,12 @@ let test_lodge_heartbeat_uses_runtime_verifier_mode () =
 let test_lodge_heartbeat_uses_tom_context () =
   check bool "ToM context used"
     true
-    (file_contains_pattern "lib/lodge_heartbeat.ml" "Lodge_tom.predict_top_k")
+    (file_contains_pattern "lib/lodge_heartbeat_agents.ml" "Lodge_tom.predict_top_k")
 
 let test_lodge_heartbeat_no_heuristic_fallback_policy () =
   check bool "scheduled trigger can request post tool"
     true
-    (file_contains_pattern "lib/lodge_heartbeat.ml" "| Scheduled | ManualTrigger -> true");
+    (file_contains_pattern "lib/lodge_heartbeat_agents.ml" "| Scheduled | ManualTrigger -> true");
   check bool "content alerts cannot request post tool"
     true
     (file_contains_pattern "lib/lodge_heartbeat.ml" "| ContentAlert _ | Mentioned _ -> false");


### PR DESCRIPTION
## Summary
- #1250 머지 이후 남아있던 하드코딩 모델명 제거
- 모듈 split 이후 깨진 source-pattern 테스트 수정

## Changes
- `chain_native_eio`: version-specific aliases 제거 (`gemini-2.5-pro`, `gpt-5.2` 등), prefix catch-all 라우팅 (`glm-*`, `gemini-*`, `claude-*`, `gpt-*`)
- `chain_orchestrator_eio`: `"gpt-5.2"`, `"gemini-3.1-pro-preview"` 하드코딩 제거
- `llm_types` + `llm_client_providers`: `"gemini-3-flash-preview"` → `Env_config.Gemini.flash_model`
- `test_lodge_heartbeat_cleanup_coverage`: 5개 source-pattern 경로를 split 후 실제 위치로 수정

## Test plan
- [x] `dune build` 통과
- [x] lodge_cascade 9/9, provider_adapter 12/12, llm_client_cascade 11/11

Follow-up: #1270 (glm_pool 단순화)

🤖 Generated with [Claude Code](https://claude.com/claude-code)