### PR TITLE
fix(room): preserve agent identity across leave/rejoin cycles

### DIFF
--- a/lib/room.ml
+++ b/lib/room.ml
@@ -62,12 +62,42 @@ let join config ~agent_name ?(agent_type_override=None) ~capabilities
     let existing_json = read_json config agent_file_dedup in
     (match agent_of_yojson existing_json with
      | Ok existing_agent ->
-       let updated = { existing_agent with last_seen = now_iso () } in
+       let is_inactive = existing_agent.status = Inactive in
+       let new_session_id = if is_inactive then generate_session_id () else
+         match existing_agent.meta with Some m -> m.session_id | None -> generate_session_id ()
+       in
+       let new_meta : agent_meta = {
+         session_id = new_session_id;
+         agent_type;
+         pid;
+         hostname = (match hostname with Some h -> Some h | None -> get_hostname ());
+         tty = (match tty with Some t -> Some t | None -> get_tty ());
+         worktree;
+         parent_task;
+       } in
+       let updated = { existing_agent with
+         status = Active;
+         last_seen = now_iso ();
+         capabilities;
+         meta = Some new_meta;
+       } in
        write_json config agent_file_dedup (agent_to_yojson updated);
        if is_pg_backend config then begin
          let agent_key = Printf.sprintf "agents:%s" (safe_filename nickname) in
          let _ = backend_set config ~key:agent_key
                    ~value:(Yojson.Safe.to_string (agent_to_yojson updated)) in ()
+       end;
+       if is_inactive then begin
+         (* Restore to active_agents on rejoin *)
+         let _ = update_state config (fun s ->
+           let agents = nickname :: List.filter ((<>) nickname) s.active_agents in
+           { s with active_agents = agents }
+         ) in
+         let _ = broadcast config ~from_agent:nickname
+                   ~content:(Printf.sprintf "👋 %s rejoined the room" nickname) in
+         log_event config (Printf.sprintf
+           "{\"type\":\"agent_join\",\"agent\":\"%s\",\"agent_type\":\"%s\",\"session_id\":\"%s\",\"rejoin\":true,\"ts\":\"%s\"}"
+           nickname agent_type new_session_id (now_iso ()))
        end
      | Error _ -> ());
     Printf.sprintf "✅ %s already in room (last_seen updated)" nickname
@@ -157,8 +187,22 @@ let join_in_room config ~room_id ~agent_name ?(agent_type_override=None) ~capabi
     let existing_json = read_json scoped agent_file_dedup in
     (match agent_of_yojson existing_json with
      | Ok existing_agent ->
-         let updated = { existing_agent with last_seen = now_iso () } in
-         write_json scoped agent_file_dedup (agent_to_yojson updated)
+         let is_inactive = existing_agent.status = Inactive in
+         let updated = { existing_agent with
+           status = Active;
+           last_seen = now_iso ();
+           capabilities;
+         } in
+         write_json scoped agent_file_dedup (agent_to_yojson updated);
+         if is_inactive then begin
+           let _ = update_state scoped (fun s ->
+             let agents = nickname :: List.filter ((<>) nickname) s.active_agents in
+             { s with active_agents = agents }
+           ) in
+           let _ = broadcast scoped ~from_agent:nickname
+                     ~content:(Printf.sprintf "👋 %s rejoined room %s" nickname room_id) in
+           ()
+         end
      | Error _ -> ());
     Printf.sprintf "✅ %s already in room %s (last_seen updated)" nickname room_id
   end else begin
@@ -226,13 +270,24 @@ let leave config ~agent_name =
       false
   in
   if in_fs || in_backend then begin
-    (* Remove from filesystem if exists *)
-    if in_fs then Sys.remove agent_file;
-    (* Remove from PostgreSQL backend if applicable *)
+    (* Mark agent as Inactive instead of deleting, so re-join can restore identity.
+       This prevents orphan state when the same agent_type re-joins later. *)
+    (if in_fs then
+      let existing_json = read_json config agent_file in
+      match agent_of_yojson existing_json with
+      | Ok existing_agent ->
+        let updated = { existing_agent with status = Inactive; last_seen = now_iso () } in
+        write_json config agent_file (agent_to_yojson updated)
+      | Error _ -> ());
     if is_pg_backend config then begin
       let agent_key = Printf.sprintf "agents:%s" (safe_filename actual_name) in
-      let _ = backend_delete config ~key:agent_key in
-      ()
+      (* Update backend entry to Inactive as well *)
+      (if in_fs then
+        let updated_json = read_json config agent_file in
+        let _ = backend_set config ~key:agent_key
+                  ~value:(Yojson.Safe.to_string updated_json) in ()
+      else
+        let _ = backend_delete config ~key:agent_key in ())
     end;
 
     let _ = update_state config (fun s ->

--- a/test/test_room.ml
+++ b/test/test_room.ml
@@ -1211,6 +1211,84 @@ let test_cleanup_zombies_releases_tasks () =
       (str_contains tasks "Todo" || str_contains tasks "todo")
   )
 
+(* --- Rejoin Identity Preservation (BUG-003) --- *)
+
+let test_rejoin_preserves_identity () =
+  with_test_env (fun config ->
+    (* 1. Join: get a nickname *)
+    let join1 = Room.join config ~agent_name:"claude" ~capabilities:["code"] () in
+    Alcotest.(check bool) "first join success" true (contains_check join1);
+
+    (* Extract nickname from active_agents *)
+    let state1 = Room.read_state config in
+    let nick1 = List.find (fun name ->
+      String.length name > 6 && String.sub name 0 6 = "claude"
+    ) state1.active_agents in
+
+    (* 2. Leave *)
+    let leave_result = Room.leave config ~agent_name:"claude" in
+    Alcotest.(check bool) "leave success" true (contains_check leave_result);
+
+    (* Agent should be removed from active_agents but file preserved *)
+    let state2 = Room.read_state config in
+    let still_active = List.exists (fun name ->
+      String.length name > 6 && String.sub name 0 6 = "claude"
+    ) state2.active_agents in
+    Alcotest.(check bool) "not in active_agents after leave" false still_active;
+
+    (* 3. Re-join: should get the SAME nickname *)
+    let join2 = Room.join config ~agent_name:"claude" ~capabilities:["code"; "review"] () in
+    Alcotest.(check bool) "rejoin success" true (contains_check join2);
+
+    let state3 = Room.read_state config in
+    let nick2 = List.find (fun name ->
+      String.length name > 6 && String.sub name 0 6 = "claude"
+    ) state3.active_agents in
+
+    (* The key assertion: same nickname after rejoin *)
+    Alcotest.(check string) "same identity after rejoin" nick1 nick2
+  )
+
+let test_rejoin_restores_active_status () =
+  with_test_env (fun config ->
+    let _ = Room.join config ~agent_name:"gemini" ~capabilities:["search"] () in
+    let _ = Room.leave config ~agent_name:"gemini" in
+
+    (* Re-join *)
+    let result = Room.join config ~agent_name:"gemini" ~capabilities:["search"] () in
+    Alcotest.(check bool) "rejoin success" true (contains_check result);
+
+    (* Should be back in active_agents *)
+    let state = Room.read_state config in
+    let is_active = List.exists (fun name ->
+      String.length name > 6 && String.sub name 0 6 = "gemini"
+    ) state.active_agents in
+    Alcotest.(check bool) "back in active_agents" true is_active
+  )
+
+let test_multiple_rejoin_cycles () =
+  with_test_env (fun config ->
+    let _ = Room.join config ~agent_name:"codex" ~capabilities:["impl"] () in
+    let state1 = Room.read_state config in
+    let nick1 = List.find (fun name ->
+      String.length name > 5 && String.sub name 0 5 = "codex"
+    ) state1.active_agents in
+
+    (* Three leave/rejoin cycles *)
+    for _ = 1 to 3 do
+      let _ = Room.leave config ~agent_name:"codex" in
+      let _ = Room.join config ~agent_name:"codex" ~capabilities:["impl"] () in
+      ()
+    done;
+
+    let state_final = Room.read_state config in
+    let nick_final = List.find (fun name ->
+      String.length name > 5 && String.sub name 0 5 = "codex"
+    ) state_final.active_agents in
+
+    Alcotest.(check string) "identity stable across 3 cycles" nick1 nick_final
+  )
+
 let () =
   Random.init 42;
   Alcotest.run "Room" [
@@ -1224,6 +1302,11 @@ let () =
     ];
     "leave", [
       Alcotest.test_case "removes agent" `Quick test_leave_removes_agent;
+    ];
+    "rejoin", [
+      Alcotest.test_case "preserves identity" `Quick test_rejoin_preserves_identity;
+      Alcotest.test_case "restores active status" `Quick test_rejoin_restores_active_status;
+      Alcotest.test_case "stable across 3 cycles" `Quick test_multiple_rejoin_cycles;
     ];
     "tasks", [
       Alcotest.test_case "add and claim" `Quick test_add_and_claim_task;


### PR DESCRIPTION
## Summary

Fixes #1255 — Leave 후 재Join 시 새 Identity 생성, 이전 상태 Orphan.

- `leave`가 에이전트 파일을 삭제하는 대신 `Inactive`로 표시하여 닉네임/상태를 보존
- `join`에서 기존 `Inactive` 에이전트 발견 시 새 identity 생성 없이 재활성화 (status -> Active, active_agents 복원, rejoin 브로드캐스트)
- `join_in_room` (deprecated)에도 동일한 재활성화 로직 적용

## 근본 원인

`leave`가 `Sys.remove agent_file` + `backend_delete`로 에이전트 데이터를 완전히 삭제했기 때문에, 재join 시 닉네임 lookup이 실패하여 매번 새 닉네임이 생성됨. 이전 identity의 claimed tasks, 대화 참여, error 기록이 orphan 상태가 됨.

## Test plan

- [x] `test_rejoin_preserves_identity` — leave/rejoin 후 동일 닉네임 유지 확인
- [x] `test_rejoin_restores_active_status` — rejoin 후 active_agents 복원 확인
- [x] `test_multiple_rejoin_cycles` — 3회 leave/rejoin 사이클에서 identity 안정성 확인
- [x] 기존 join/leave 테스트 통과 확인
- [x] `dune build --root .` 성공

Generated with [Claude Code](https://claude.com/claude-code)