### PR TITLE
fix(governance): deduplicate cases by source_refs (#1261)

### DIFF
--- a/lib/council/governance_v2.ml
+++ b/lib/council/governance_v2.ml
@@ -766,11 +766,29 @@ let submit_petition base_path ~title ~origin ~subject_type ~risk_class
       if task_id_suffix = "" then base_key
       else base_key ^ "::" ^ task_id_suffix
     in
-    let existing_case =
+    let all_active_cases =
       list_cases ~include_test:true base_path
-      |> List.find_opt (fun case_ ->
-             String.equal case_.normalized_key normalized_key
-             && not (is_terminal_case_status case_.status))
+      |> List.filter (fun (case_ : case_record) -> not (is_terminal_case_status case_.status))
+    in
+    (* Primary dedup: exact normalized_key match *)
+    let existing_case =
+      List.find_opt (fun case_ ->
+             String.equal case_.normalized_key normalized_key)
+        all_active_cases
+    in
+    (* Secondary dedup: match by shared source_refs for same subject_type.
+       This catches duplicates when title changes (e.g. assignee or status
+       changes) but the underlying subject (task/keeper) is the same. *)
+    let existing_case =
+      match existing_case with
+      | Some _ -> existing_case
+      | None when source_refs <> [] ->
+          List.find_opt (fun (case_ : case_record) ->
+            String.equal case_.subject_type subject_type
+            && List.exists (fun ref_ ->
+                 List.mem ref_ case_.source_refs) source_refs)
+            all_active_cases
+      | None -> None
     in
     let now = now_unix () in
     let case_, merged =

--- a/test/test_tool_council.ml
+++ b/test/test_tool_council.ml
@@ -181,6 +181,55 @@ let test_legacy_surfaces_return_removed_error () =
   check bool "mentions removed" true
     (contains_substring ~needle:"removed in governance v2" body)
 
+let test_duplicate_petition_merges_by_source_ref () =
+  with_base_path @@ fun base_path ->
+  let module GV2 = Council.Governance_v2 in
+  (* First petition: stuck task claimed by agent-a *)
+  let result1 =
+    GV2.submit_petition base_path
+      ~title:"Stuck task: QA-TEST-01 (claimed by agent-a)"
+      ~origin:"sentinel" ~subject_type:"task" ~risk_class:GV2.Low
+      ~requested_action:(Some { action_type = "release_task";
+                                target_type = Some "task";
+                                target_id = None; payload = None })
+      ~source_refs:["task-QA-TEST-01"] ~created_by:"sentinel"
+  in
+  let result1 = Result.get_ok result1 in
+  check bool "first petition not merged" false result1.merged;
+  let case_id_1 = result1.case_.id in
+  (* Second petition: same task, different title (assignee changed) *)
+  let result2 =
+    GV2.submit_petition base_path
+      ~title:"Stuck task: QA-TEST-01 (in_progress by agent-b)"
+      ~origin:"sentinel" ~subject_type:"task" ~risk_class:GV2.Low
+      ~requested_action:(Some { action_type = "release_task";
+                                target_type = Some "task";
+                                target_id = None; payload = None })
+      ~source_refs:["task-QA-TEST-01"] ~created_by:"sentinel"
+  in
+  let result2 = Result.get_ok result2 in
+  check bool "second petition merged (source_ref dedup)" true result2.merged;
+  check string "merged into same case" case_id_1 result2.case_.id;
+  (* Third petition: identical to first (repeated sweep) *)
+  let result3 =
+    GV2.submit_petition base_path
+      ~title:"Stuck task: QA-TEST-01 (claimed by agent-a)"
+      ~origin:"sentinel" ~subject_type:"task" ~risk_class:GV2.Low
+      ~requested_action:(Some { action_type = "release_task";
+                                target_type = Some "task";
+                                target_id = None; payload = None })
+      ~source_refs:["task-QA-TEST-01"] ~created_by:"sentinel"
+  in
+  let result3 = Result.get_ok result3 in
+  check bool "third petition merged" true result3.merged;
+  check string "third merged into same case" case_id_1 result3.case_.id;
+  (* Verify only 1 active case exists *)
+  let cases = GV2.list_cases ~include_test:true base_path in
+  check int "exactly 1 case" 1 (List.length cases);
+  (* The case should have 3 petitions *)
+  let the_case = List.hd cases in
+  check int "case has 3 petitions" 3 (List.length the_case.petition_ids)
+
 let test_petition_rejects_unsupported_action_type () =
   with_base_path @@ fun base_path ->
   let ctx = make_ctx ~base_path ~agent_name:"alice" in
@@ -216,5 +265,7 @@ let () =
             test_legacy_surfaces_return_removed_error;
           test_case "unsupported action type rejected" `Quick
             test_petition_rejects_unsupported_action_type;
+          test_case "duplicate petitions merge by source_ref" `Quick
+            test_duplicate_petition_merges_by_source_ref;
         ] );
     ]


### PR DESCRIPTION
## Summary

- Sentinel governance sweep가 매 beat마다 stuck task에 대한 petition을 생성할 때, `normalized_key`만으로 중복 검사를 수행하여 같은 task에 대해 반복적으로 새 case가 생성되는 버그 수정
- `normalized_key`에는 assignee와 status가 포함된 title이 들어가므로, 같은 task라도 assignee 변경이나 Claimed->InProgress 전환 시 key가 달라져 중복 case 발생
- **Secondary dedup 추가**: `normalized_key` 매칭 실패 시, 동일 `subject_type`의 active case 중 `source_refs`를 공유하는 case가 있으면 해당 case에 병합
- 테스트: 같은 task에 대해 title이 다른 3개 petition이 모두 1개 case로 병합되는 것을 검증

## Test plan

- [x] `dune build --root .` 성공
- [x] `dune exec --root . test/test_tool_council.exe` 6/6 통과
- [ ] CI green 확인

Closes #1261

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>