### PR TITLE
chore: upgrade agent_sdk to v0.40.0

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -35,7 +35,7 @@
   (cmdliner (>= 1.1))
   (cohttp (>= 5.0))
   (cohttp-eio (and (>= 6.0) (< 6.2)))
-  (agent_sdk (>= 0.24.0))
+  (agent_sdk (>= 0.40.0))
   (uri (>= 4.4))
   (tls (>= 0.16))
   (tls-eio (>= 0.16))

--- a/masc_mcp.opam
+++ b/masc_mcp.opam
@@ -23,7 +23,7 @@ depends: [
   "cmdliner" {>= "1.1"}
   "cohttp" {>= "5.0"}
   "cohttp-eio" {>= "6.0" & < "6.2"}
-  "agent_sdk" {>= "0.24.0"}
+  "agent_sdk" {>= "0.40.0"}
   "uri" {>= "4.4"}
   "tls" {>= "0.16"}
   "tls-eio" {>= "0.16"}


### PR DESCRIPTION
## Summary
- Upgrade `agent_sdk` (OAS) dependency from v0.31.0 to v0.40.0
- Update `dune-project` version constraint from `>= 0.24.0` to `>= 0.40.0`
- Build passes with no compilation errors; `test_dashboard_cache` (8 tests) all green

## Test plan
- [x] `dune build --root .` compiles without errors
- [x] `dune exec --root . test/test_dashboard_cache.exe` passes (8/8)
- [ ] CI checks pass after push

🤖 Generated with [Claude Code](https://claude.com/claude-code)