### PR TITLE
[BUG-004] claim_next 재호출 시 이전 claim 자동 해제

### DIFF
--- a/lib/room_task.ml
+++ b/lib/room_task.ml
@@ -542,6 +542,7 @@ type claim_next_result =
       task_id : string;
       title : string;
       priority : int;
+      released_task_id : string option;  (** Previous task auto-released, if any *)
       message : string;
     }
   | Claim_next_no_unclaimed
@@ -557,6 +558,33 @@ let claim_next_r config ~agent_name ?(exclude_task_ids=[]) () =
   with_file_lock config backlog_path (fun () ->
     try
       let backlog = read_backlog config in
+
+      (* BUG-004: Detect and auto-release previous claim to prevent orphaned tasks.
+         If this agent already holds a Claimed or InProgress task, release it
+         back to Todo before proceeding. This prevents "claimed but orphaned"
+         tasks that permanently block the backlog. *)
+      let previous_claim = List.find_opt (fun (t : Types.task) ->
+        match t.task_status with
+        | Claimed { assignee; _ } | InProgress { assignee; _ } ->
+            String.equal assignee agent_name
+        | Todo | Done _ | Cancelled _ -> false
+      ) backlog.tasks in
+      let released_task_id, working_tasks = match previous_claim with
+        | None -> None, backlog.tasks
+        | Some prev ->
+            log_event config (Printf.sprintf
+              "{\"type\":\"task_claim_next_auto_release\",\"agent\":\"%s\",\"released_task\":\"%s\",\"ts\":\"%s\"}"
+              agent_name prev.id (now_iso ()));
+            let _ = broadcast config ~from_agent:agent_name
+              ~content:(Printf.sprintf
+                "⚠ Auto-released %s (was %s) before claiming next task"
+                prev.id (Types.task_status_to_string prev.task_status)) in
+            let updated = List.map (fun (t : Types.task) ->
+              if String.equal t.id prev.id then { t with task_status = Todo }
+              else t
+            ) backlog.tasks in
+            Some prev.id, updated
+      in
 
       (* Starvation prevention: Calculate effective priority
          Tasks waiting >24h get priority boost (-1 per 24h, min 1) *)
@@ -588,18 +616,44 @@ let claim_next_r config ~agent_name ?(exclude_task_ids=[]) () =
         let priority_cmp = compare (effective_priority a) (effective_priority b) in
         if priority_cmp <> 0 then priority_cmp
         else compare a.created_at b.created_at  (* Older first for same priority *)
-      ) backlog.tasks in
+      ) working_tasks in
       let unclaimed = List.filter (fun t ->
         match t.task_status with
         | Todo -> true
         | _ -> false
       ) sorted in
-      let eligible = List.filter (fun t -> not (List.mem t.id exclude_task_ids)) unclaimed in
+      (* Also exclude the just-released task: the agent is moving on,
+         re-claiming the same task would be a no-op loop. *)
+      let all_excluded = match released_task_id with
+        | Some rid -> rid :: exclude_task_ids
+        | None -> exclude_task_ids
+      in
+      let eligible = List.filter (fun t -> not (List.mem t.id all_excluded)) unclaimed in
 
       match unclaimed, eligible with
       | [], _ ->
+          (* Even if we released a task, there may be nothing else to claim.
+             Write the release if it happened. *)
+          (match released_task_id with
+           | Some _ ->
+               let new_backlog = {
+                 tasks = working_tasks;
+                 last_updated = now_iso ();
+                 version = backlog.version + 1;
+               } in
+               write_backlog config new_backlog
+           | None -> ());
           Claim_next_no_unclaimed
       | _ :: _, [] ->
+          (match released_task_id with
+           | Some _ ->
+               let new_backlog = {
+                 tasks = working_tasks;
+                 last_updated = now_iso ();
+                 version = backlog.version + 1;
+               } in
+               write_backlog config new_backlog
+           | None -> ());
           Claim_next_no_eligible { excluded_count = List.length exclude_task_ids }
       | _ :: _, task :: _ ->
           (* Claim this task *)
@@ -611,7 +665,7 @@ let claim_next_r config ~agent_name ?(exclude_task_ids=[]) () =
                 }
               }
             else t
-          ) backlog.tasks in
+          ) working_tasks in
 
           let new_backlog = {
             tasks = new_tasks;
@@ -632,19 +686,32 @@ let claim_next_r config ~agent_name ?(exclude_task_ids=[]) () =
                 Log.Misc.error "agent state write failed: %s" msg
           end;
 
+          let release_note = match released_task_id with
+            | Some rid -> Printf.sprintf " (auto-released %s)" rid
+            | None -> ""
+          in
           let _ = broadcast config ~from_agent:agent_name
-            ~content:(Printf.sprintf "📋 Auto-claimed [P%d] %s: %s" task.priority task.id task.title) in
+            ~content:(Printf.sprintf "📋 Auto-claimed [P%d] %s: %s%s"
+              task.priority task.id task.title release_note) in
 
           log_event config (Printf.sprintf
             "{\"type\":\"task_claim_next\",\"agent\":\"%s\",\"task\":\"%s\",\"priority\":%d,\"ts\":\"%s\"}"
             agent_name task.id task.priority (now_iso ()));
 
+          let message = match released_task_id with
+            | Some rid ->
+                Printf.sprintf "⚠ %s auto-released %s, then claimed [P%d] %s: %s"
+                  agent_name rid task.priority task.id task.title
+            | None ->
+                Printf.sprintf "✅ %s auto-claimed [P%d] %s: %s"
+                  agent_name task.priority task.id task.title
+          in
           Claim_next_claimed {
             task_id = task.id;
             title = task.title;
             priority = task.priority;
-            message =
-              Printf.sprintf "✅ %s auto-claimed [P%d] %s: %s" agent_name task.priority task.id task.title;
+            released_task_id;
+            message;
           }
     with e ->
       Claim_next_error (Printexc.to_string e)

--- a/test/dune
+++ b/test/dune
@@ -47,6 +47,12 @@
  (libraries masc_mcp alcotest str yojson mirage-crypto
             mirage-crypto-rng mirage-crypto-rng.unix cohttp cstruct unix))
 
+; Room coverage tests (claim_next auto-release, batch ops, transitions)
+(test
+ (name test_room_coverage)
+ (modules test_room_coverage)
+ (libraries masc_mcp alcotest yojson unix))
+
 ; Streamable HTTP test (requires Eio for Eio.Mutex)
 (test
  (name test_streamable_http)

--- a/test/test_room_coverage.ml
+++ b/test/test_room_coverage.ml
@@ -181,11 +181,14 @@ let test_claim_next_auto_releases_previous () =
     Alcotest.(check bool) "mentions released task" true (str_contains r2 "task-001");
     Alcotest.(check bool) "claims new task" true (str_contains r2 "task-002");
 
-    (* Verify task-001 is back to Todo (not orphaned) *)
-    let status = Room.status config in
-    Alcotest.(check bool) "task-001 released to todo" true
-      (str_contains status "task-001" &&
-       (str_contains status "todo" || str_contains status "Todo"))
+    (* Verify task-001 is back to Todo (not orphaned) via raw task data *)
+    let tasks = Room.get_tasks_raw config in
+    let task_001 = List.find_opt (fun (t : Types.task) -> t.id = "task-001") tasks in
+    (match task_001 with
+     | Some t ->
+         Alcotest.(check string) "task-001 released to todo"
+           "todo" (Types.task_status_to_string t.task_status)
+     | None -> Alcotest.fail "task-001 not found in backlog")
   )
 
 (** BUG-004: After auto-release, the released task is claimable by others. *)

--- a/test/test_room_coverage.ml
+++ b/test/test_room_coverage.ml
@@ -29,7 +29,7 @@ let contains_error result =
   String.length result >= 3 && String.sub result 0 3 = "\xE2\x9D\x8C"  (* ❌ *)
 
 (** Check for cancel emoji *)
-let contains_cancel result =
+let _contains_cancel result =
   String.length result >= 4 && String.sub result 0 4 = "\xF0\x9F\x9A\xAB"  (* 🚫 *)
 
 (** Substring check helper *)
@@ -156,6 +156,79 @@ let test_claim_next_consecutive () =
     (* Different agents should get different tasks *)
     Alcotest.(check bool) "different tasks" true
       (str_contains r1 "task-001" || str_contains r2 "task-002")
+  )
+
+(* ============================================================ *)
+(* BUG-004: claim_next auto-release Tests                        *)
+(* ============================================================ *)
+
+(** BUG-004: Same agent calling claim_next twice should auto-release
+    the first task, not orphan it. *)
+let test_claim_next_auto_releases_previous () =
+  with_test_env (fun config ->
+    let _ = Room.add_task config ~title:"First" ~priority:1 ~description:"" in
+    let _ = Room.add_task config ~title:"Second" ~priority:2 ~description:"" in
+
+    (* First claim: agent gets task-001 *)
+    let r1 = Room.claim_next config ~agent_name:"claude" in
+    Alcotest.(check bool) "first claim ok" true (contains_check r1);
+    Alcotest.(check bool) "first claim has task-001" true (str_contains r1 "task-001");
+
+    (* Second claim by same agent: should auto-release task-001, claim task-002 *)
+    let r2 = Room.claim_next config ~agent_name:"claude" in
+    (* Result should contain warning about auto-release *)
+    Alcotest.(check bool) "second claim contains warning" true (contains_warning r2);
+    Alcotest.(check bool) "mentions released task" true (str_contains r2 "task-001");
+    Alcotest.(check bool) "claims new task" true (str_contains r2 "task-002");
+
+    (* Verify task-001 is back to Todo (not orphaned) *)
+    let status = Room.status config in
+    Alcotest.(check bool) "task-001 released to todo" true
+      (str_contains status "task-001" &&
+       (str_contains status "todo" || str_contains status "Todo"))
+  )
+
+(** BUG-004: After auto-release, the released task is claimable by others. *)
+let test_claim_next_released_task_claimable_by_others () =
+  with_test_env (fun config ->
+    let _ = Room.add_task config ~title:"Task A" ~priority:1 ~description:"" in
+    let _ = Room.add_task config ~title:"Task B" ~priority:2 ~description:"" in
+
+    (* Claude claims task-001 *)
+    let _ = Room.claim_next config ~agent_name:"claude" in
+    (* Claude claims again, auto-releasing task-001 *)
+    let _ = Room.claim_next config ~agent_name:"claude" in
+
+    (* Gemini should be able to claim the released task-001 *)
+    let r = Room.claim_next config ~agent_name:"gemini" in
+    Alcotest.(check bool) "gemini can claim released task" true (contains_check r);
+    Alcotest.(check bool) "gemini gets task-001" true (str_contains r "task-001")
+  )
+
+(** BUG-004: claim_next_r returns released_task_id in structured result. *)
+let test_claim_next_r_released_task_field () =
+  with_test_env (fun config ->
+    let _ = Room.add_task config ~title:"Alpha" ~priority:1 ~description:"" in
+    let _ = Room.add_task config ~title:"Beta" ~priority:2 ~description:"" in
+
+    (* First claim: no previous task to release *)
+    let r1 = Room.claim_next_r config ~agent_name:"claude" () in
+    (match r1 with
+     | Room.Claim_next_claimed { released_task_id = None; task_id; _ } ->
+         Alcotest.(check string) "first claim is task-001" "task-001" task_id
+     | Room.Claim_next_claimed { released_task_id = Some _; _ } ->
+         Alcotest.fail "first claim should not release anything"
+     | _ -> Alcotest.fail "first claim should succeed");
+
+    (* Second claim: should release task-001 *)
+    let r2 = Room.claim_next_r config ~agent_name:"claude" () in
+    (match r2 with
+     | Room.Claim_next_claimed { released_task_id = Some rid; task_id; _ } ->
+         Alcotest.(check string) "released task-001" "task-001" rid;
+         Alcotest.(check string) "claimed task-002" "task-002" task_id
+     | Room.Claim_next_claimed { released_task_id = None; _ } ->
+         Alcotest.fail "second claim should report released task"
+     | _ -> Alcotest.fail "second claim should succeed")
   )
 
 (* ============================================================ *)
@@ -499,13 +572,13 @@ let test_update_agent_status () =
     let _ = Room.join config ~agent_name:"gemini" ~capabilities:["test"] () in
 
     (* Get the actual agent name (auto-generated nickname) *)
-    let agents : Types.agent list = Room.get_agents_raw config in
-    let gemini = List.find_opt (fun a ->
-      String.length a.Types.name >= 6 && String.sub a.Types.name 0 6 = "gemini"
+    let agents = Room.get_agents_raw config in
+    let gemini = List.find_opt (fun (a : Types.agent) ->
+      String.length a.name >= 6 && String.sub a.name 0 6 = "gemini"
     ) agents in
     match gemini with
     | Some agent ->
-        let result = Room.update_agent_r config ~agent_name:agent.name ~status:(Some "listening") () in
+        let result = Room.update_agent_r config ~agent_name:agent.name ~status:"listening" () in
         (match result with
          | Ok _ -> ()
          | Error _ -> Alcotest.fail "Expected Ok")
@@ -516,14 +589,14 @@ let test_update_agent_capabilities () =
   with_test_env (fun config ->
     let _ = Room.join config ~agent_name:"gemini" ~capabilities:[] () in
 
-    let agents : Types.agent list = Room.get_agents_raw config in
-    let gemini = List.find_opt (fun a ->
-      String.length a.Types.name >= 6 && String.sub a.Types.name 0 6 = "gemini"
+    let agents = Room.get_agents_raw config in
+    let gemini = List.find_opt (fun (a : Types.agent) ->
+      String.length a.name >= 6 && String.sub a.name 0 6 = "gemini"
     ) agents in
     match gemini with
     | Some agent ->
         let result = Room.update_agent_r config ~agent_name:agent.name
-                       ~capabilities:(Some ["python"; "code-review"]) () in
+                       ~capabilities:["python"; "code-review"] () in
         (match result with
          | Ok _ -> ()
          | Error _ -> Alcotest.fail "Expected Ok")
@@ -532,7 +605,7 @@ let test_update_agent_capabilities () =
 
 let test_update_agent_not_found () =
   with_test_env (fun config ->
-    let result = Room.update_agent_r config ~agent_name:"nonexistent" ~status:(Some "active") () in
+    let result = Room.update_agent_r config ~agent_name:"nonexistent" ~status:"active" () in
     match result with
     | Error Types.AgentNotFound _ -> ()
     | _ -> Alcotest.fail "Expected AgentNotFound"
@@ -588,6 +661,9 @@ let () =
       Alcotest.test_case "empty backlog" `Quick test_claim_next_empty_backlog;
       Alcotest.test_case "all claimed" `Quick test_claim_next_all_claimed;
       Alcotest.test_case "consecutive" `Quick test_claim_next_consecutive;
+      Alcotest.test_case "BUG-004: auto-releases previous" `Quick test_claim_next_auto_releases_previous;
+      Alcotest.test_case "BUG-004: released task claimable" `Quick test_claim_next_released_task_claimable_by_others;
+      Alcotest.test_case "BUG-004: released_task_id field" `Quick test_claim_next_r_released_task_field;
     ];
 
     (* === Update Priority === *)


### PR DESCRIPTION
## Summary
- `claim_next`를 같은 에이전트가 연속 호출할 때, 이전에 claim된 태스크가 "claimed but orphaned" 상태로 영구 잠금되는 버그 수정
- 이전 claim을 자동으로 `Todo`로 되돌리고, 경고 메시지와 이벤트 로그를 남긴 뒤 새 태스크를 claim
- 자동 해제된 태스크는 같은 호출에서 재claim되지 않도록 eligible 목록에서 제외

## 변경 사항
- `lib/room_task.ml`: `claim_next_r`에서 에이전트의 기존 Claimed/InProgress 태스크 감지 및 자동 해제 로직 추가. `claim_next_result` 타입에 `released_task_id` 필드 추가
- `test/dune`: `test_room_coverage` 테스트 실행 등록 (기존에 누락됨)
- `test/test_room_coverage.ml`: BUG-004 검증 테스트 3개 추가 + 기존 코드의 pre-existing 타입 에러 수정

## Test plan
- [x] 같은 에이전트의 연속 `claim_next` 호출 시 이전 태스크가 `Todo`로 복원되는지 확인
- [x] 자동 해제된 태스크를 다른 에이전트가 claim할 수 있는지 확인
- [x] `claim_next_r`의 `released_task_id` 필드가 올바르게 설정되는지 확인
- [x] 기존 claim_next 테스트 5개 모두 통과 (regression 없음)
- [x] 전체 test_room_coverage 51개 테스트 통과

Closes #1256

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>