### PR TITLE
fix: re-raise Eio.Cancel.Cancelled in 27 catch-all patterns

### DIFF
--- a/lib/backend_eio.ml
+++ b/lib/backend_eio.ml
@@ -242,6 +242,7 @@ module FileSystem = struct
           with
           | Eio.Io (Eio.Fs.E (Eio.Fs.Not_found _), _) ->
               Error (NotFound key)
+          | Eio.Cancel.Cancelled _ as exn -> raise exn
           | exn ->
               Error (IOError (Printexc.to_string exn))
     )
@@ -291,6 +292,7 @@ module FileSystem = struct
           with
           | Eio.Io (Eio.Fs.E (Eio.Fs.Not_found _), _) ->
               Error (NotFound key)
+          | Eio.Cancel.Cancelled _ as exn -> raise exn
           | exn ->
               Error (IOError (Printexc.to_string exn))
     )
@@ -312,6 +314,7 @@ module FileSystem = struct
         with
         | Eio.Io (Eio.Fs.E (Eio.Fs.Not_found _), _) ->
             Ok []  (* Directory doesn't exist = no keys *)
+        | Eio.Cancel.Cancelled _ as exn -> raise exn
         | exn ->
             Error (IOError (Printexc.to_string exn))
 
@@ -351,6 +354,7 @@ module FileSystem = struct
                    Ok true)
           | Eio.Io (Eio.Fs.E (Eio.Fs.Already_exists _), _) ->
               Error (AlreadyExists key)
+          | Eio.Cancel.Cancelled _ as exn -> raise exn
           | exn ->
               Error (IOError (Printexc.to_string exn))
     )

--- a/lib/chain_executor_eio.ml
+++ b/lib/chain_executor_eio.ml
@@ -686,6 +686,7 @@ and execute_cascade ctx ~sw ~clock ~exec_fn ~tool_exec (node : node)
             try_tier rest escalations (hard_failures + 1) prev_context
         with
         | Out_of_memory | Stack_overflow | Sys.Break as exn -> raise exn
+        | Eio.Cancel.Cancelled _ as exn -> raise exn
         | exn ->
           record_error ctx node.id (Printexc.to_string exn);
           try_tier rest escalations (hard_failures + 1) prev_context

--- a/lib/checkpoint_store.ml
+++ b/lib/checkpoint_store.ml
@@ -156,6 +156,7 @@ let load_eio ~fs (store : checkpoint_store) ~run_id : (checkpoint, string) resul
     checkpoint_of_json json
   with
   | Eio.Io _ -> Error (Printf.sprintf "Checkpoint not found: %s" run_id)
+  | Eio.Cancel.Cancelled _ as exn -> raise exn
   | exn -> Error (Printf.sprintf "Failed to load checkpoint: %s" (Printexc.to_string exn))
 
 (** Load a checkpoint (non-Eio version) *)

--- a/lib/council/thread_persist.ml
+++ b/lib/council/thread_persist.ml
@@ -368,10 +368,14 @@ let execute_cypher_raw ~cypher : (Yojson.Safe.t, string) result =
       | Some clock -> (
           try Eio.Time.with_timeout_exn clock timeout_sec run
           with
+          | Eio.Cancel.Cancelled _ as exn -> raise exn
           | Eio.Time.Timeout -> Error "Neo4j HTTP timeout"
           | exn -> Error (Printexc.to_string exn))
       | None -> (
-          try run () with exn -> Error (Printexc.to_string exn)))
+          try run ()
+          with
+          | Eio.Cancel.Cancelled _ as exn -> raise exn
+          | exn -> Error (Printexc.to_string exn)))
 
 (** Execute a Cypher query, ignoring the response data.
     Returns Ok () on success, Error msg on failure. *)

--- a/lib/handover_eio.ml
+++ b/lib/handover_eio.ml
@@ -173,6 +173,7 @@ let load_handover ~fs config handover_id : (handover_record, string) result =
   with
   | Eio.Io (Eio.Fs.E (Eio.Fs.Not_found _), _) ->
       Error (Printf.sprintf "Handover not found: %s" handover_id)
+  | Eio.Cancel.Cancelled _ as exn -> raise exn
   | exn ->
       Error (Printf.sprintf "Failed to load handover: %s" (Printexc.to_string exn))
 

--- a/lib/mcp_server_eio_execute.ml
+++ b/lib/mcp_server_eio_execute.ml
@@ -266,6 +266,7 @@ let execute_tool_eio ~sw ~clock ?mcp_session_id ?auth_token state ~name ~argumen
        with Invalid_argument msg -> Some msg
           | Sys_error msg -> Some msg
           | Yojson.Json_error msg -> Some msg
+          | Eio.Cancel.Cancelled _ as exn -> raise exn
           | exn -> Some (Printexc.to_string exn))
     else
       None
@@ -354,6 +355,7 @@ let execute_tool_eio ~sw ~clock ?mcp_session_id ?auth_token state ~name ~argumen
       try
         ignore (Room.heartbeat config ~agent_name)
       with
+      | Eio.Cancel.Cancelled _ as exn -> raise exn
       | exn ->
           Log.Misc.warn "heartbeat update skipped for %s on %s: %s"
             agent_name name (Printexc.to_string exn)
@@ -689,6 +691,7 @@ let execute_tool_eio ~sw ~clock ?mcp_session_id ?auth_token state ~name ~argumen
                 `Error (Printf.sprintf "keeper returned invalid json: %s" e))
           | Some (false, msg) -> `Error msg)
     with
+    | Eio.Cancel.Cancelled _ as exn -> raise exn
     | Eio.Time.Timeout -> `Timeout
     | exn -> `Error (Printexc.to_string exn)
   in
@@ -706,6 +709,7 @@ let execute_tool_eio ~sw ~clock ?mcp_session_id ?auth_token state ~name ~argumen
           | Some (true, _body) -> `Ok
           | Some (false, msg) -> `Error msg)
     with
+    | Eio.Cancel.Cancelled _ as exn -> raise exn
     | Eio.Time.Timeout -> `Error "timeout"
     | exn -> `Error (Printexc.to_string exn)
   in

--- a/lib/mcp_server_eio_handlers.ml
+++ b/lib/mcp_server_eio_handlers.ml
@@ -321,6 +321,7 @@ let handle_request
                  | Invalid_argument msg
                    when TC.contains_casefold msg "invalid_argument(\"masc not initialized" ->
                      make_error ~id (-32603) (Types.masc_error_to_string Types.NotInitialized)
+                   | Eio.Cancel.Cancelled _ as exn -> raise exn
                    | exn ->
                        let err = Printexc.to_string exn in
                        Log.Mcp.error "Request handling failed: %s" err;
@@ -457,5 +458,6 @@ let run_stdio ~sw ~env ~execute_tool_eio ~log_mcp_exn state =
   with
   | End_of_file ->
       Log.Mcp.info "Connection closed"
+  | Eio.Cancel.Cancelled _ as exn -> raise exn
   | exn ->
       Log.Mcp.error "Server error: %s" (Printexc.to_string exn)

--- a/lib/mcp_server_eio_protocol.ml
+++ b/lib/mcp_server_eio_protocol.ml
@@ -453,6 +453,7 @@ let handle_request
                  | Invalid_argument msg
                    when contains_casefold msg "invalid_argument(\"masc not initialized" ->
                      make_error ~id (-32603) (Types.masc_error_to_string Types.NotInitialized)
+                   | Eio.Cancel.Cancelled _ as exn -> raise exn
                    | exn ->
                        let err = Printexc.to_string exn in
                        Log.Mcp.error "Request handling failed: %s" err;
@@ -588,5 +589,6 @@ let run_stdio ~handle_request ~sw ~env state =
   with
   | End_of_file ->
       Log.Mcp.info "Connection closed"
+  | Eio.Cancel.Cancelled _ as exn -> raise exn
   | exn ->
       Log.Mcp.error "Server error: %s" (Printexc.to_string exn)

--- a/lib/mitosis_helpers.ml
+++ b/lib/mitosis_helpers.ml
@@ -474,6 +474,7 @@ let run_handoff_verifier ~ctx ~args ~(parsed_result : Yojson.Safe.t) : (Yojson.S
                 in
                 `Verdict verdict
               with
+              | Eio.Cancel.Cancelled _ as exn -> raise exn
               | Eio.Time.Timeout ->
                   `Timeout
               | exn ->

--- a/lib/server_routes_http_keeper_stream.ml
+++ b/lib/server_routes_http_keeper_stream.ml
@@ -71,6 +71,7 @@ let execute_keeper_stream_tool ~sw ~clock ?auth_token:_ state ~agent_name ~argum
           | Some result -> result
           | None -> (false, "masc_keeper_msg dispatch unavailable"))
     with
+    | Eio.Cancel.Cancelled _ as exn -> raise exn
     | Eio.Time.Timeout ->
         timeout_hit := true;
         Log.Mcp.error "tools/call timeout: masc_keeper_msg after %.0fs" timeout_sec;

--- a/lib/server_trpg_rest_runtime.ml
+++ b/lib/server_trpg_rest_runtime.ml
@@ -52,6 +52,7 @@ let trpg_keeper_call_with_runtime
             `Error (Printf.sprintf "keeper returned invalid json: %s" e))
       | Some (false, msg) -> `Error msg)
   with
+  | Eio.Cancel.Cancelled _ as exn -> raise exn
   | Eio.Time.Timeout -> `Timeout
   | exn -> `Error (Printexc.to_string exn)
 
@@ -91,6 +92,7 @@ let trpg_keeper_probe_with_runtime
       | Some (true, _body) -> `Ok
       | Some (false, msg) -> `Error msg)
   with
+  | Eio.Cancel.Cancelled _ as exn -> raise exn
   | Eio.Time.Timeout -> `Error "timeout"
   | exn -> `Error (Printexc.to_string exn)
 let trpg_round_run_json

--- a/lib/sse_client.ml
+++ b/lib/sse_client.ml
@@ -221,6 +221,7 @@ let connect_with_retry ~sw (net : _ Eio.Net.t) (clock : _ Eio.Time.clock) (t : t
       try
         connect_raw ~sw net t ~on_event ~on_state_change
       with
+      | Eio.Cancel.Cancelled _ as exn -> raise exn
       | exn ->
           if retry_count < t.max_retries && t.state <> Closed then begin
             t.state <- Reconnecting retry_count;

--- a/lib/tool_inline_dispatch.ml
+++ b/lib/tool_inline_dispatch.ml
@@ -232,6 +232,7 @@ let dispatch (ctx : context) ~(name : string) : result option =
             (try Institution_eio.load_and_format_for_welcome ~fs config
              with
              | Eio.Io _ | Yojson.Json_error _ | Yojson.Safe.Util.Type_error _ -> ""
+             | Eio.Cancel.Cancelled _ as exn -> raise exn
              | exn ->
                  Eio.traceln "[WARN] Unexpected institution error: %s" (Printexc.to_string exn); "")
         | None -> ""

--- a/lib/tool_lodge_agents_ops.ml
+++ b/lib/tool_lodge_agents_ops.ml
@@ -101,7 +101,9 @@ let neo4j_http_cypher cypher =
 	      Log.Lodge.info "response: %s" (if String.length output < 200 then output else String.sub output 0 200 ^ "...");
 	      if String.length output > 0 then Ok output
 	      else Error "empty response"
-	    with exn -> Error (Printexc.to_string exn)
+	    with
+	    | Eio.Cancel.Cancelled _ as exn -> raise exn
+	    | exn -> Error (Printexc.to_string exn)
 
 (** Spawn a new agent — can be called by another agent.
     Uses GraphQL createAgent mutation (works in Railway production). *)
@@ -182,6 +184,7 @@ let spawn_agent ~net:_ ~parent_name ~child_name ~child_role ~child_prompt =
             let msg = result |> member "message" |> to_string_option |> Option.value ~default:"Unknown" in
             (false, Printf.sprintf "❌ Lodge: %s" msg)
       with
+      | Eio.Cancel.Cancelled _ as exn -> raise exn
       | Yojson.Json_error e -> (false, Printf.sprintf "❌ Lodge: JSON parse error: %s" e)
       | exn -> (false, Printf.sprintf "❌ Lodge: %s" (Printexc.to_string exn))
 

--- a/lib/tool_lodge_llm_cycle.ml
+++ b/lib/tool_lodge_llm_cycle.ml
@@ -44,7 +44,9 @@ let cli_generate provider ~system prompt =
     | Unix.WEXITED 0 -> Ok content
     | Unix.WEXITED n -> Error (Printf.sprintf "❌ LLM: %s exit %d" cli_cmd n)
     | _ -> Error (Printf.sprintf "❌ LLM: %s signaled" cli_cmd)
-  with exn ->
+  with
+  | Eio.Cancel.Cancelled _ as exn -> raise exn
+  | exn ->
     Error (Printf.sprintf "❌ LLM: %s exception [%s]" cli_cmd (Printexc.to_string exn))
 
 (** Unified LLM generate with automatic provider selection *)
@@ -145,6 +147,7 @@ let _local_llama_generate ~net:_ ?model ?(temperature = 0.7) ?(num_predict = 500
     | Unix.WEXITED n -> Error (Printf.sprintf "❌ LLM: llama exit %d" n)
     | _ -> Error "❌ LLM: llama signaled"
   with
+  | Eio.Cancel.Cancelled _ as exn -> raise exn
   | Yojson.Json_error msg -> Error (Printf.sprintf "❌ Parse: JSON error [%s]" msg)
   | exn -> Error (Printf.sprintf "❌ LLM: llama exception [%s]" (Printexc.to_string exn))
 


### PR DESCRIPTION
## Summary

- Eio structured concurrency에서 catch-all `| exn ->`가 `Eio.Cancel.Cancelled`를 삼키면 좀비 fiber, scope cleanup 체인 파괴, 로그 노이즈 발생
- 15개 파일 27곳에 `| Eio.Cancel.Cancelled _ as exn -> raise exn` 가드 추가
- 4 severity tiers: CRITICAL (8), HIGH-Process (4), HIGH-Filesystem (10), MEDIUM-Server (5)

## Changed files

| Tier | Files |
|------|-------|
| CRITICAL | mcp_server_eio_execute, server_routes_http_keeper_stream, server_trpg_rest_runtime, mitosis_helpers, council/thread_persist |
| HIGH | tool_lodge_llm_cycle, tool_lodge_agents_ops |
| HIGH | backend_eio, chain_executor_eio, handover_eio, checkpoint_store, tool_inline_dispatch |
| MEDIUM | mcp_server_eio_handlers, mcp_server_eio_protocol, sse_client |

## Pattern

```ocaml
(* Before *)  | exn -> ...           (* swallows Cancelled *)
(* After *)   | Eio.Cancel.Cancelled _ as exn -> raise exn
              | exn -> ...
```

## Test plan

- [x] `dune build --root .` passes (0 errors)
- [ ] `make test` (CI)
- [ ] External model review

🤖 Generated with [Claude Code](https://claude.com/claude-code)