### PR TITLE
feat(dashboard): 4-layer NOC situational awareness redesign

### DIFF
--- a/dashboard/src/components/overview/agent-avatar.ts
+++ b/dashboard/src/components/overview/agent-avatar.ts
@@ -52,6 +52,24 @@ function signalRingClass(truth?: string): string {
   return ''
 }
 
+function activityDotLabel(ageSec: number | null): string | undefined {
+  if (ageSec == null) return undefined
+  if (ageSec < 60) return '방금 활동'
+  if (ageSec < 300) return '최근 활동'
+  if (ageSec < 1800) return '잠시 비활성'
+  return '비활성'
+}
+
+function handleKeyActivate(onClick?: () => void) {
+  if (!onClick) return undefined
+  return (e: KeyboardEvent) => {
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault()
+      onClick()
+    }
+  }
+}
+
 function truncateWork(text: string | null | undefined, max = 20): string | null {
   if (!text) return null
   const clean = text.replace(/\s+/g, ' ').trim()
@@ -100,11 +118,15 @@ export function AgentAvatar({
       data-status=${statusAttr}
       title=${name}
       onClick=${onClick}
+      onKeyDown=${handleKeyActivate(onClick)}
       role=${onClick ? 'button' : undefined}
       tabindex=${onClick ? '0' : undefined}
     >
       ${cells}
-      <span class="pixel-avatar__activity-dot ${dotClass}" />
+      <span
+        class="pixel-avatar__activity-dot ${dotClass}"
+        aria-label=${activityDotLabel(activityAge ?? null)}
+      />
       ${bubbleText ? html`
         <span class="pixel-avatar__speech-bubble ${alwaysShowBubble ? 'always-visible' : ''}">
           ${bubbleText}

--- a/dashboard/src/components/overview/agent-avatar.ts
+++ b/dashboard/src/components/overview/agent-avatar.ts
@@ -1,5 +1,6 @@
-// MASC Dashboard — CSS Pixel Art Avatar Component
+// MASC Dashboard — CSS Pixel Art Avatar Component (Phase 2 enhanced)
 // Renders an 8x8 grid avatar with deterministic colors from agent name.
+// Now includes operational overlays: activity dot, speech bubble, blocker ring.
 
 import { html } from 'htm/preact'
 import {
@@ -18,6 +19,12 @@ interface AgentAvatarProps {
   size?: AvatarSize
   showName?: boolean
   onClick?: () => void
+  // Phase 2: operational info overlays
+  currentWork?: string | null
+  activityAge?: number | null
+  hasBlocker?: boolean
+  signalTruth?: 'live' | 'stale' | 'archived' | 'unknown'
+  alwaysShowBubble?: boolean
 }
 
 function colorForCell(value: number, palette: AvatarPalette): string | null {
@@ -30,12 +37,48 @@ function colorForCell(value: number, palette: AvatarPalette): string | null {
   }
 }
 
-export function AgentAvatar({ name, status, traits, size, showName, onClick }: AgentAvatarProps) {
+function activityDotClass(ageSec: number | null): string {
+  if (ageSec == null) return 'activity-dot--unknown'
+  if (ageSec < 60) return 'activity-dot--live-pulse'
+  if (ageSec < 300) return 'activity-dot--live'
+  if (ageSec < 1800) return 'activity-dot--stale'
+  return 'activity-dot--inactive'
+}
+
+function signalRingClass(truth?: string): string {
+  if (truth === 'live') return 'signal-ring--live'
+  if (truth === 'stale') return 'signal-ring--stale'
+  if (truth === 'archived') return 'signal-ring--archived'
+  return ''
+}
+
+function truncateWork(text: string | null | undefined, max = 20): string | null {
+  if (!text) return null
+  const clean = text.replace(/\s+/g, ' ').trim()
+  if (!clean) return null
+  return clean.length > max ? `${clean.slice(0, max - 1)}…` : clean
+}
+
+export function AgentAvatar({
+  name,
+  status,
+  traits,
+  size,
+  showName,
+  onClick,
+  currentWork,
+  activityAge,
+  hasBlocker,
+  signalTruth,
+  alwaysShowBubble,
+}: AgentAvatarProps) {
   const palette = paletteForAgent(name)
   const template = templateForAgent(name, traits)
   const grid = PIXEL_TEMPLATES[template]
   const sizeClass = size === 'sm' ? 'pixel-avatar--sm' : size === 'lg' ? 'pixel-avatar--lg' : ''
   const statusAttr = status ?? 'idle'
+  const blockerClass = hasBlocker ? 'pixel-avatar--has-blocker' : ''
+  const ringClass = signalRingClass(signalTruth)
 
   const cells = []
   for (let i = 0; i < 64; i++) {
@@ -48,9 +91,12 @@ export function AgentAvatar({ name, status, traits, size, showName, onClick }: A
     )
   }
 
+  const dotClass = activityDotClass(activityAge ?? null)
+  const bubbleText = truncateWork(currentWork)
+
   const avatar = html`
     <div
-      class="pixel-avatar ${sizeClass}"
+      class="pixel-avatar ${sizeClass} ${blockerClass} ${ringClass}"
       data-status=${statusAttr}
       title=${name}
       onClick=${onClick}
@@ -58,6 +104,12 @@ export function AgentAvatar({ name, status, traits, size, showName, onClick }: A
       tabindex=${onClick ? '0' : undefined}
     >
       ${cells}
+      <span class="pixel-avatar__activity-dot ${dotClass}" />
+      ${bubbleText ? html`
+        <span class="pixel-avatar__speech-bubble ${alwaysShowBubble ? 'always-visible' : ''}">
+          ${bubbleText}
+        </span>
+      ` : null}
     </div>
   `
 

--- a/dashboard/src/components/overview/agent-grid.ts
+++ b/dashboard/src/components/overview/agent-grid.ts
@@ -3,8 +3,7 @@
 // Sorts agents by attention count, signal truth, then name.
 
 import { html } from 'htm/preact'
-import type { Agent } from '../../types'
-import type { DashboardMissionAgentBrief } from '../../types'
+import type { Agent, DashboardMissionAgentBrief } from '../../types'
 import { AgentAvatar } from './agent-avatar'
 
 interface AgentGridProps {

--- a/dashboard/src/components/overview/agent-grid.ts
+++ b/dashboard/src/components/overview/agent-grid.ts
@@ -1,0 +1,91 @@
+// MASC Dashboard — Agent Grid (Phase 3)
+// Replaces circular EcosystemRing with a responsive CSS grid.
+// Sorts agents by attention count, signal truth, then name.
+
+import { html } from 'htm/preact'
+import type { Agent } from '../../types'
+import type { DashboardMissionAgentBrief } from '../../types'
+import { AgentAvatar } from './agent-avatar'
+
+interface AgentGridProps {
+  agents: Agent[]
+  agentBriefs: DashboardMissionAgentBrief[]
+  onAgentClick?: (name: string) => void
+}
+
+function signalTruthOrder(truth?: string): number {
+  if (truth === 'live') return 0
+  if (truth === 'stale') return 1
+  if (truth === 'archived') return 2
+  return 3
+}
+
+export function AgentGrid({ agents, agentBriefs, onAgentClick }: AgentGridProps) {
+  const briefMap = new Map(agentBriefs.map(b => [b.agent_name, b]))
+
+  // Combine agent list with briefs for sorting
+  const sorted = [...agents].sort((a, b) => {
+    const ba = briefMap.get(a.name)
+    const bb = briefMap.get(b.name)
+
+    // 1. Attention count DESC
+    const attA = ba?.related_attention_count ?? 0
+    const attB = bb?.related_attention_count ?? 0
+    if (attA !== attB) return attB - attA
+
+    // 2. Signal truth (live first)
+    const stA = signalTruthOrder(ba?.signal_truth)
+    const stB = signalTruthOrder(bb?.signal_truth)
+    if (stA !== stB) return stA - stB
+
+    // 3. Name alpha
+    return a.name.localeCompare(b.name)
+  })
+
+  // Top 5 active agents always show speech bubbles
+  const topActiveNames = new Set(
+    sorted
+      .filter(a => {
+        const brief = briefMap.get(a.name)
+        return brief?.signal_truth === 'live' && brief.current_work
+      })
+      .slice(0, 5)
+      .map(a => a.name),
+  )
+
+  if (sorted.length === 0) {
+    return html`
+      <div class="agent-grid">
+        <div style="color: var(--text-muted); padding: 12px;">에이전트 없음</div>
+      </div>
+    `
+  }
+
+  return html`
+    <div class="agent-grid">
+      ${sorted.map(agent => {
+        const brief = briefMap.get(agent.name)
+        const hasBlocker = (brief?.related_attention_count ?? 0) > 0
+        const isTopActive = topActiveNames.has(agent.name)
+
+        return html`
+          <div class="agent-grid__cell" key=${agent.name}>
+            <${AgentAvatar}
+              name=${agent.name}
+              status=${agent.status}
+              traits=${agent.traits}
+              size="sm"
+              showName=${true}
+              currentWork=${brief?.current_work ?? null}
+              activityAge=${brief?.last_activity_age_sec ?? null}
+              hasBlocker=${hasBlocker}
+              signalTruth=${brief?.signal_truth ?? 'unknown'}
+              alwaysShowBubble=${isTopActive}
+              onClick=${onAgentClick ? () => onAgentClick(agent.name) : undefined}
+            />
+          </div>
+        `
+      })}
+    </div>
+  `
+}

--- a/dashboard/src/components/overview/agent-grid.ts
+++ b/dashboard/src/components/overview/agent-grid.ts
@@ -20,28 +20,31 @@ function signalTruthOrder(truth?: string): number {
 }
 
 export function AgentGrid({ agents, agentBriefs, onAgentClick }: AgentGridProps) {
+  if (agents.length === 0) {
+    return html`
+      <div class="agent-grid">
+        <div style="color: var(--text-muted); padding: 12px;">에이전트 없음</div>
+      </div>
+    `
+  }
+
   const briefMap = new Map(agentBriefs.map(b => [b.agent_name, b]))
 
-  // Combine agent list with briefs for sorting
   const sorted = [...agents].sort((a, b) => {
     const ba = briefMap.get(a.name)
     const bb = briefMap.get(b.name)
 
-    // 1. Attention count DESC
     const attA = ba?.related_attention_count ?? 0
     const attB = bb?.related_attention_count ?? 0
     if (attA !== attB) return attB - attA
 
-    // 2. Signal truth (live first)
     const stA = signalTruthOrder(ba?.signal_truth)
     const stB = signalTruthOrder(bb?.signal_truth)
     if (stA !== stB) return stA - stB
 
-    // 3. Name alpha
     return a.name.localeCompare(b.name)
   })
 
-  // Top 5 active agents always show speech bubbles
   const topActiveNames = new Set(
     sorted
       .filter(a => {
@@ -51,14 +54,6 @@ export function AgentGrid({ agents, agentBriefs, onAgentClick }: AgentGridProps)
       .slice(0, 5)
       .map(a => a.name),
   )
-
-  if (sorted.length === 0) {
-    return html`
-      <div class="agent-grid">
-        <div style="color: var(--text-muted); padding: 12px;">에이전트 없음</div>
-      </div>
-    `
-  }
 
   return html`
     <div class="agent-grid">

--- a/dashboard/src/components/overview/attention-spotlight.ts
+++ b/dashboard/src/components/overview/attention-spotlight.ts
@@ -1,0 +1,97 @@
+// MASC Dashboard — Attention Spotlight (Phase 1B)
+// Highlights top 3 anomalies (blockers + attention queue items).
+// Renders only when there are items that need attention; vanishes when clean.
+
+import { html } from 'htm/preact'
+import { toneClass, relativeTime, trimText } from '../mission-utils'
+import type {
+  DashboardMissionResponse,
+  DashboardMissionSessionBrief,
+  DashboardMissionSessionCard,
+} from '../../types'
+
+interface SpotlightItem {
+  id: string
+  severity: string
+  summary: string
+  relatedNames: string[]
+  lastSeen: string | null
+}
+
+type SessionItem = DashboardMissionSessionBrief | DashboardMissionSessionCard
+
+function gatherSpotlightItems(snap: DashboardMissionResponse): SpotlightItem[] {
+  const items: SpotlightItem[] = []
+
+  // 1. Attention queue items
+  for (const aq of snap.attention_queue) {
+    items.push({
+      id: aq.id,
+      severity: aq.severity,
+      summary: aq.summary,
+      relatedNames: [...aq.related_agent_names],
+      lastSeen: aq.last_seen_at ?? null,
+    })
+  }
+
+  // 2. Sessions with blockers (that aren't already captured in attention queue)
+  const sessions: SessionItem[] =
+    snap.sessions.length > 0 ? snap.sessions : snap.session_briefs
+  const aqIds = new Set(items.map(i => i.id))
+
+  for (const s of sessions) {
+    if (s.blocker_summary && !aqIds.has(`blocker-${s.session_id}`)) {
+      items.push({
+        id: `blocker-${s.session_id}`,
+        severity: 'bad',
+        summary: s.blocker_summary,
+        relatedNames: s.member_names.slice(0, 3),
+        lastSeen: s.last_event_at ?? null,
+      })
+    }
+  }
+
+  // Sort by severity (bad > warn > ok) then by recency
+  const severityOrder: Record<string, number> = { bad: 0, critical: 0, warn: 1, watch: 1, ok: 2 }
+  items.sort((a, b) => {
+    const sa = severityOrder[a.severity] ?? 1
+    const sb = severityOrder[b.severity] ?? 1
+    return sa - sb
+  })
+
+  return items.slice(0, 3)
+}
+
+interface AttentionSpotlightProps {
+  snap: DashboardMissionResponse | null
+}
+
+export function AttentionSpotlight({ snap }: AttentionSpotlightProps) {
+  if (!snap) return null
+
+  const items = gatherSpotlightItems(snap)
+  if (items.length === 0) return null
+
+  return html`
+    <div class="attention-spotlight">
+      ${items.map(item => html`
+        <div class="attention-spotlight__card ${toneClass(item.severity)}" key=${item.id}>
+          <div class="attention-spotlight__bar" />
+          <div class="attention-spotlight__body">
+            <span class="attention-spotlight__summary">
+              ${trimText(item.summary, 100)}
+            </span>
+            <div class="attention-spotlight__meta">
+              ${item.relatedNames.map(name => html`
+                <span class="attention-spotlight__chip" key=${name}>${name}</span>
+              `)}
+              ${item.lastSeen ? html`
+                <span class="attention-spotlight__time">${relativeTime(item.lastSeen)}</span>
+              ` : null}
+            </div>
+          </div>
+        </div>
+      `)}
+    </div>
+  `
+}

--- a/dashboard/src/components/overview/narrative-timeline.ts
+++ b/dashboard/src/components/overview/narrative-timeline.ts
@@ -116,12 +116,12 @@ export function NarrativeTimeline({ entries, maxItems }: NarrativeTimelineProps)
 
   return html`
     <div class="narrative-timeline">
-      ${groups.map((group, gi) => html`
-        <div class="narrative-group" key=${gi}>
+      ${groups.map(group => html`
+        <div class="narrative-group" key=${group.label}>
           <div class="narrative-group__label">${group.label}</div>
           <div class="narrative-group__events">
-            ${group.events.map((event, ei) => html`
-              <div class="narrative-event" key=${ei}>
+            ${group.events.map(event => html`
+              <div class="narrative-event" key=${event.timestamp}>
                 <span class="narrative-event__text">${event.text}</span>
                 <details class="narrative-event__raw">
                   <summary>원본</summary>

--- a/dashboard/src/components/overview/narrative-timeline.ts
+++ b/dashboard/src/components/overview/narrative-timeline.ts
@@ -1,0 +1,139 @@
+// MASC Dashboard — Narrative Timeline (Phase 5)
+// Replaces raw log-line ActivityTicker with grouped, narrative-style timeline.
+// Groups events by time window and actor, synthesizes Korean descriptions.
+
+import { html } from 'htm/preact'
+import type { ReadonlySignal } from '@preact/signals'
+import type { JournalEntry } from '../../types'
+
+interface NarrativeTimelineProps {
+  entries: ReadonlySignal<JournalEntry[]>
+  maxItems?: number
+}
+
+interface TimeGroup {
+  label: string
+  events: NarrativeEvent[]
+}
+
+interface NarrativeEvent {
+  actor: string | null
+  text: string
+  raw: string
+  timestamp: number
+}
+
+function eventVerb(kind?: string, eventType?: string): string {
+  const k = kind ?? ''
+  const e = (eventType ?? '').toLowerCase()
+
+  if (e.includes('claim')) return '태스크를 claim'
+  if (e.includes('done') || e.includes('complete')) return '태스크를 완료'
+  if (e.includes('join')) return 'room에 참여'
+  if (e.includes('leave')) return 'room에서 퇴장'
+  if (e.includes('broadcast')) return '메시지를 브로드캐스트'
+  if (e.includes('heartbeat')) return '하트비트를 전송'
+  if (e.includes('post') || e.includes('board')) return '게시글을 작성'
+  if (e.includes('vote')) return '투표'
+  if (e.includes('comment')) return '댓글을 작성'
+  if (e.includes('spawn')) return '에이전트를 생성'
+  if (e.includes('commit')) return '커밋을 생성'
+  if (e.includes('pr') || e.includes('pull_request')) return 'PR을 처리'
+  if (k === 'tasks') return '태스크를 처리'
+  if (k === 'keepers') return '키퍼 활동'
+  if (k === 'system') return '시스템 이벤트'
+
+  return '활동'
+}
+
+function buildNarrative(entry: JournalEntry): NarrativeEvent {
+  const actor = entry.agent ?? null
+  const preview = entry.preview ?? entry.text
+  const verb = eventVerb(entry.kind, entry.eventType)
+
+  const actorPrefix = actor ? `${actor}가 ` : ''
+  const text = preview
+    ? `${actorPrefix}${verb}: ${preview}`
+    : `${actorPrefix}${verb}.`
+
+  return {
+    actor,
+    text,
+    raw: `${entry.preview ?? entry.text}`,
+    timestamp: entry.timestamp,
+  }
+}
+
+function timeGroupLabel(deltaSec: number): string {
+  if (deltaSec < 120) return '지금'
+  if (deltaSec < 600) return `${Math.round(deltaSec / 60)}분 전`
+  if (deltaSec < 1800) return `${Math.round(deltaSec / 60)}분 전`
+  if (deltaSec < 3600) return `${Math.round(deltaSec / 60)}분 전`
+  return `${Math.round(deltaSec / 3600)}시간 전`
+}
+
+function groupByTime(events: NarrativeEvent[]): TimeGroup[] {
+  if (events.length === 0) return []
+
+  const now = Date.now()
+  const groups: TimeGroup[] = []
+  let currentLabel = ''
+  let currentEvents: NarrativeEvent[] = []
+
+  for (const event of events) {
+    const deltaSec = Math.max(0, (now - event.timestamp) / 1000)
+    const label = timeGroupLabel(deltaSec)
+
+    if (label !== currentLabel) {
+      if (currentEvents.length > 0) {
+        groups.push({ label: currentLabel, events: currentEvents })
+      }
+      currentLabel = label
+      currentEvents = []
+    }
+    currentEvents.push(event)
+  }
+
+  if (currentEvents.length > 0) {
+    groups.push({ label: currentLabel, events: currentEvents })
+  }
+
+  return groups
+}
+
+export function NarrativeTimeline({ entries, maxItems }: NarrativeTimelineProps) {
+  const limit = maxItems ?? 12
+  const raw = entries.value.slice(-limit).reverse()
+
+  if (raw.length === 0) {
+    return html`
+      <div class="narrative-timeline">
+        <div class="narrative-timeline__empty">이벤트 대기 중...</div>
+      </div>
+    `
+  }
+
+  const narratives = raw.map(buildNarrative)
+  const groups = groupByTime(narratives)
+
+  return html`
+    <div class="narrative-timeline">
+      ${groups.map((group, gi) => html`
+        <div class="narrative-group" key=${gi}>
+          <div class="narrative-group__label">${group.label}</div>
+          <div class="narrative-group__events">
+            ${group.events.map((event, ei) => html`
+              <div class="narrative-event" key=${ei}>
+                <span class="narrative-event__text">${event.text}</span>
+                <details class="narrative-event__raw">
+                  <summary>원본</summary>
+                  <span>${event.raw}</span>
+                </details>
+              </div>
+            `)}
+          </div>
+        </div>
+      `)}
+    </div>
+  `
+}

--- a/dashboard/src/components/overview/narrative-timeline.ts
+++ b/dashboard/src/components/overview/narrative-timeline.ts
@@ -66,8 +66,6 @@ function buildNarrative(entry: JournalEntry): NarrativeEvent {
 
 function timeGroupLabel(deltaSec: number): string {
   if (deltaSec < 120) return '지금'
-  if (deltaSec < 600) return `${Math.round(deltaSec / 60)}분 전`
-  if (deltaSec < 1800) return `${Math.round(deltaSec / 60)}분 전`
   if (deltaSec < 3600) return `${Math.round(deltaSec / 60)}분 전`
   return `${Math.round(deltaSec / 3600)}시간 전`
 }

--- a/dashboard/src/components/overview/overview.ts
+++ b/dashboard/src/components/overview/overview.ts
@@ -1,17 +1,38 @@
-// MASC Dashboard — Home Overview Surface
-// Combines all overview sub-components into the Home landing view.
+// MASC Dashboard — Home Overview Surface (Redesigned)
+// 4-Layer information architecture: Situation -> Anomaly -> Entity Grid -> Timeline
+// Replaces flat number display + ring + strip with hierarchical NOC dashboard pattern.
 
 import { html } from 'htm/preact'
 import { agents, keepers, tasks, shellCounts } from '../../store'
 import { missionSnapshot } from '../../mission-store'
 import { journal } from '../../sse'
 import { navigate } from '../../router'
+import { formatDuration } from '../mission-utils'
+import { SituationBanner } from './situation-banner'
+import { AttentionSpotlight } from './attention-spotlight'
+import { AgentGrid } from './agent-grid'
+import { SessionTriage } from './session-triage'
+import { NarrativeTimeline } from './narrative-timeline'
 import { QuickStats } from './quick-stats'
-import { EcosystemRing } from './ecosystem-ring'
-import { SessionStrip } from './session-strip'
-import { HealthBeacon } from './health-beacon'
-import { ActivityTicker } from './activity-ticker'
 import { DASHBOARD_SURFACES } from '../../config/navigation'
+
+// Phase 6: Context pressure bar color thresholds
+function pressureClass(ratio: number | null | undefined): string {
+  if (ratio == null) return ''
+  const pct = ratio * 100
+  if (pct < 50) return 'pressure--ok'
+  if (pct < 70) return 'pressure--amber'
+  if (pct < 85) return 'pressure--orange'
+  return 'pressure--red'
+}
+
+function keeperHealthClass(status?: string): string {
+  const s = (status ?? '').toLowerCase()
+  if (s === 'active' || s === 'running' || s === 'ok') return 'keeper-status--ok'
+  if (s === 'idle' || s === 'listening') return 'keeper-status--idle'
+  if (s === 'offline' || s === 'inactive') return 'keeper-status--offline'
+  return ''
+}
 
 export function Overview() {
   const snap = missionSnapshot.value
@@ -27,24 +48,27 @@ export function Overview() {
     t.status === 'in_progress' || t.status === 'claimed'
   )
 
-  // Use shell counts as fallback when execution data hasn't loaded yet
   const agentCount = activeAgents.length > 0 ? activeAgents.length : (counts?.agents ?? 0)
   const taskCount = activeTasks.length > 0 ? activeTasks.length : (counts?.tasks ?? 0)
   const keeperCount = keeperList.length > 0 ? keeperList.length : (counts?.keepers ?? 0)
 
   const roomHealth = snap?.summary?.room_health ?? null
-  const roomName = snap?.summary?.current_room ?? null
   const attentionCount = snap?.attention_queue?.length ?? snap?.summary?.pending_approvals ?? 0
   const sessions = snap?.sessions ?? snap?.session_briefs ?? []
-
-  // Keeper mini-cards for the health sidebar
+  const agentBriefs = snap?.agent_briefs ?? []
   const keeperBriefs = snap?.keeper_briefs ?? []
 
-  // Navigation surfaces (excluding home itself)
   const navSurfaces = DASHBOARD_SURFACES.filter(s => s.id !== 'home')
 
   return html`
     <div class="overview-surface">
+      <!-- Layer 1: Situation Line -->
+      <${SituationBanner} snap=${snap} roomHealth=${roomHealth} />
+
+      <!-- Layer 2: Anomaly Spotlight (only when anomalies exist) -->
+      <${AttentionSpotlight} snap=${snap} />
+
+      <!-- Quick Stats (compact, below situation context) -->
       <${QuickStats}
         agentCount=${agentCount}
         activeTaskCount=${taskCount}
@@ -52,46 +76,64 @@ export function Overview() {
         attentionCount=${attentionCount}
       />
 
-      <div class="overview-main">
-        <div class="overview-ring-col">
-          <div class="overview-section-label">에이전트 생태계</div>
-          <${EcosystemRing}
+      <!-- Layer 3+4: Entity Grid + Session Triage + Timeline -->
+      <div class="overview-main-v2">
+        <div class="overview-left-col">
+          <div class="overview-section-label">에이전트</div>
+          <${AgentGrid}
             agents=${agentList}
-            roomName=${roomName}
-            roomHealth=${roomHealth}
+            agentBriefs=${agentBriefs}
             onAgentClick=${(name: string) => navigate('execution', { agent: name })}
           />
         </div>
 
-        <div class="overview-sessions-col">
-          <div class="overview-section-label">활성 세션</div>
-          <${SessionStrip} sessions=${sessions} />
+        <div class="overview-right-col">
+          <div class="overview-section-label">세션</div>
+          <${SessionTriage} sessions=${sessions} />
 
-          <div class="overview-section-label" style="margin-top: var(--space-sm, 8px)">최근 활동</div>
-          <${ActivityTicker} entries=${journal} maxItems=${8} />
-        </div>
-
-        <div class="overview-health-col">
-          <div class="overview-section-label">시스템 상태</div>
-          <${HealthBeacon} health=${roomHealth} />
-
+          <!-- Phase 6: Enhanced Keeper Cards -->
           ${keeperBriefs.length > 0 ? html`
-            <div class="overview-section-label" style="margin-top: var(--space-sm, 8px)">키퍼</div>
-            ${keeperBriefs.map(k => html`
-              <div class="keeper-mini-card" key=${k.name}>
-                <span class="keeper-mini-card__name">${k.name}</span>
-                <span class="keeper-mini-card__meta">
-                  ${k.status ?? ''}
-                  ${k.context_ratio != null ? ` / ctx ${Math.round(k.context_ratio * 100)}%` : ''}
-                  ${k.generation != null ? ` / gen ${k.generation}` : ''}
-                </span>
-              </div>
-            `)}
+            <div class="overview-section-label" style="margin-top: var(--space-md, 16px)">키퍼</div>
+            <div class="keeper-cards-v2">
+              ${keeperBriefs.map(k => html`
+                <div class="keeper-card-v2 ${keeperHealthClass(k.status)}" key=${k.name}>
+                  <div class="keeper-card-v2__header">
+                    <span class="keeper-card-v2__name">${k.name}</span>
+                    ${k.generation != null ? html`
+                      <span class="keeper-card-v2__gen">G${k.generation}</span>
+                    ` : null}
+                  </div>
+                  ${k.current_work ? html`
+                    <div class="keeper-card-v2__work">${k.current_work}</div>
+                  ` : null}
+                  ${k.context_ratio != null ? html`
+                    <div class="keeper-card-v2__pressure">
+                      <div
+                        class="keeper-card-v2__pressure-bar ${pressureClass(k.context_ratio)}"
+                        style=${{ width: `${Math.round(k.context_ratio * 100)}%` }}
+                      />
+                      <span class="keeper-card-v2__pressure-label">
+                        ctx ${Math.round(k.context_ratio * 100)}%
+                      </span>
+                    </div>
+                  ` : null}
+                  ${k.last_turn_ago_s != null ? html`
+                    <span class="keeper-card-v2__activity">
+                      ${formatDuration(k.last_turn_ago_s)} 전
+                    </span>
+                  ` : null}
+                </div>
+              `)}
+            </div>
           ` : null}
+
+          <!-- Layer 4: Narrative Timeline -->
+          <div class="overview-section-label" style="margin-top: var(--space-md, 16px)">최근 활동</div>
+          <${NarrativeTimeline} entries=${journal} maxItems=${12} />
         </div>
       </div>
 
-      <!-- Navigation to other surfaces (Home has no SideRail) -->
+      <!-- Navigation to other surfaces -->
       <nav class="overview-nav-strip">
         ${navSurfaces.map(surface => html`
           <button

--- a/dashboard/src/components/overview/session-triage.ts
+++ b/dashboard/src/components/overview/session-triage.ts
@@ -1,0 +1,150 @@
+// MASC Dashboard — Session Triage (Phase 4)
+// Replaces flat SessionStrip with a 3-tier hierarchical display:
+//   Tier 1 (Critical): sessions with blockers or bad attention
+//   Tier 2 (Watch):    sessions with attention items or degraded health
+//   Tier 3 (Running):  healthy sessions, collapsed by default
+
+import { html } from 'htm/preact'
+import { navigate } from '../../router'
+import { trimText, formatDuration } from '../mission-utils'
+import type {
+  DashboardMissionSessionBrief,
+  DashboardMissionSessionCard,
+} from '../../types'
+
+type SessionItem = DashboardMissionSessionBrief | DashboardMissionSessionCard
+
+interface SessionTriageProps {
+  sessions: SessionItem[]
+}
+
+interface TriageResult {
+  critical: SessionItem[]
+  watch: SessionItem[]
+  running: SessionItem[]
+}
+
+function triageSessions(sessions: SessionItem[]): TriageResult {
+  const critical: SessionItem[] = []
+  const watch: SessionItem[] = []
+  const running: SessionItem[] = []
+
+  for (const s of sessions) {
+    const isCritical =
+      s.blocker_summary ||
+      (s.top_attention && (s.top_attention.severity === 'bad' || s.top_attention.severity === 'critical'))
+
+    const isWatch =
+      !isCritical && (
+        s.related_attention_count > 0 ||
+        s.health === 'warn' ||
+        s.health === 'degraded' ||
+        s.health === 'yellow'
+      )
+
+    if (isCritical) critical.push(s)
+    else if (isWatch) watch.push(s)
+    else running.push(s)
+  }
+
+  return { critical, watch, running }
+}
+
+function CriticalCard({ session }: { session: SessionItem }) {
+  return html`
+    <div
+      class="triage-card triage-card--critical"
+      onClick=${() => navigate('mission', { session_id: session.session_id })}
+    >
+      <div class="triage-card__header">
+        <strong class="triage-card__goal">${session.goal ?? session.session_id}</strong>
+      </div>
+      ${session.blocker_summary ? html`
+        <div class="triage-card__blocker">
+          ${trimText(session.blocker_summary, 120)}
+        </div>
+      ` : null}
+      <div class="triage-card__meta">
+        ${session.member_names?.length ? html`
+          <span class="triage-card__members">
+            ${session.member_names.slice(0, 4).join(', ')}
+            ${session.member_names.length > 4 ? ` +${session.member_names.length - 4}` : ''}
+          </span>
+        ` : null}
+        ${session.elapsed_sec ? html`
+          <span>${formatDuration(session.elapsed_sec)}</span>
+        ` : null}
+      </div>
+    </div>
+  `
+}
+
+function WatchCard({ session }: { session: SessionItem }) {
+  return html`
+    <div
+      class="triage-card triage-card--watch"
+      onClick=${() => navigate('mission', { session_id: session.session_id })}
+    >
+      <strong class="triage-card__goal">${session.goal ?? session.session_id}</strong>
+      <div class="triage-card__meta">
+        ${session.related_attention_count > 0 ? html`
+          <span>주의 ${session.related_attention_count}건</span>
+        ` : null}
+        ${session.elapsed_sec ? html`
+          <span>${formatDuration(session.elapsed_sec)}</span>
+        ` : null}
+        ${session.member_names?.length ? html`
+          <span>${session.member_names.length}명</span>
+        ` : null}
+      </div>
+    </div>
+  `
+}
+
+function RunningRow({ session }: { session: SessionItem }) {
+  return html`
+    <div
+      class="triage-row"
+      onClick=${() => navigate('mission', { session_id: session.session_id })}
+    >
+      <span class="triage-row__goal">${trimText(session.goal, 60) ?? session.session_id}</span>
+      <span class="triage-row__meta">
+        ${session.elapsed_sec ? formatDuration(session.elapsed_sec) : ''}
+        ${session.member_names?.length ? ` / ${session.member_names.length}명` : ''}
+      </span>
+    </div>
+  `
+}
+
+export function SessionTriage({ sessions }: SessionTriageProps) {
+  if (sessions.length === 0) {
+    return html`<div class="session-triage" style="color: var(--text-muted)">활성 세션 없음</div>`
+  }
+
+  const { critical, watch, running } = triageSessions(sessions)
+
+  return html`
+    <div class="session-triage">
+      ${critical.length > 0 ? html`
+        <div class="triage-tier triage-tier--critical">
+          ${critical.map(s => html`<${CriticalCard} session=${s} key=${s.session_id} />`)}
+        </div>
+      ` : null}
+
+      ${watch.length > 0 ? html`
+        <div class="triage-tier triage-tier--watch">
+          ${watch.map(s => html`<${WatchCard} session=${s} key=${s.session_id} />`)}
+        </div>
+      ` : null}
+
+      ${running.length > 0 ? html`
+        <details class="triage-tier triage-tier--running">
+          <summary class="triage-running-label">순조로운 세션 ${running.length}개</summary>
+          <div class="triage-running-list">
+            ${running.map(s => html`<${RunningRow} session=${s} key=${s.session_id} />`)}
+          </div>
+        </details>
+      ` : null}
+    </div>
+  `
+}

--- a/dashboard/src/components/overview/session-triage.ts
+++ b/dashboard/src/components/overview/session-triage.ts
@@ -24,6 +24,15 @@ interface TriageResult {
   running: SessionItem[]
 }
 
+function handleKeyActivate(fn: () => void) {
+  return (e: KeyboardEvent) => {
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault()
+      fn()
+    }
+  }
+}
+
 function triageSessions(sessions: SessionItem[]): TriageResult {
   const critical: SessionItem[] = []
   const watch: SessionItem[] = []
@@ -51,10 +60,14 @@ function triageSessions(sessions: SessionItem[]): TriageResult {
 }
 
 function CriticalCard({ session }: { session: SessionItem }) {
+  const go = () => navigate('mission', { session_id: session.session_id })
   return html`
     <div
       class="triage-card triage-card--critical"
-      onClick=${() => navigate('mission', { session_id: session.session_id })}
+      role="button"
+      tabindex="0"
+      onClick=${go}
+      onKeyDown=${handleKeyActivate(go)}
     >
       <div class="triage-card__header">
         <strong class="triage-card__goal">${session.goal ?? session.session_id}</strong>
@@ -80,10 +93,14 @@ function CriticalCard({ session }: { session: SessionItem }) {
 }
 
 function WatchCard({ session }: { session: SessionItem }) {
+  const go = () => navigate('mission', { session_id: session.session_id })
   return html`
     <div
       class="triage-card triage-card--watch"
-      onClick=${() => navigate('mission', { session_id: session.session_id })}
+      role="button"
+      tabindex="0"
+      onClick=${go}
+      onKeyDown=${handleKeyActivate(go)}
     >
       <strong class="triage-card__goal">${session.goal ?? session.session_id}</strong>
       <div class="triage-card__meta">
@@ -102,10 +119,14 @@ function WatchCard({ session }: { session: SessionItem }) {
 }
 
 function RunningRow({ session }: { session: SessionItem }) {
+  const go = () => navigate('mission', { session_id: session.session_id })
   return html`
     <div
       class="triage-row"
-      onClick=${() => navigate('mission', { session_id: session.session_id })}
+      role="button"
+      tabindex="0"
+      onClick=${go}
+      onKeyDown=${handleKeyActivate(go)}
     >
       <span class="triage-row__goal">${trimText(session.goal, 60) ?? session.session_id}</span>
       <span class="triage-row__meta">

--- a/dashboard/src/components/overview/situation-banner.ts
+++ b/dashboard/src/components/overview/situation-banner.ts
@@ -1,0 +1,60 @@
+// MASC Dashboard — Situation Banner (Phase 1A)
+// Synthesizes a one-line situation summary from mission snapshot data.
+// Replaces raw number display with a human-readable sentence.
+
+import { html } from 'htm/preact'
+import { HealthBeacon } from './health-beacon'
+import type {
+  DashboardMissionResponse,
+  DashboardMissionSessionBrief,
+  DashboardMissionSessionCard,
+} from '../../types'
+
+type SituationTone = 'ok' | 'warn' | 'bad'
+
+interface SituationResult {
+  text: string
+  tone: SituationTone
+}
+
+type SessionItem = DashboardMissionSessionBrief | DashboardMissionSessionCard
+
+function synthesizeSituation(snap: DashboardMissionResponse | null): SituationResult {
+  if (!snap) return { text: '데이터 로딩 중...', tone: 'ok' }
+
+  const sessions: SessionItem[] =
+    snap.sessions.length > 0 ? snap.sessions : snap.session_briefs
+  const total = sessions.length
+  const blocked = sessions.filter(s => s.blocker_summary).length
+  const attention = snap.attention_queue.length
+
+  if (total === 0) return { text: '진행 중인 세션 없음.', tone: 'ok' }
+
+  if (blocked === 0 && attention === 0) {
+    return { text: `${total}개 세션 순조롭게 진행 중.`, tone: 'ok' }
+  }
+
+  if (blocked > 0) {
+    const suffix = attention > 0 ? ` ${attention}건 주의 필요.` : ''
+    const tone: SituationTone = blocked > total / 2 ? 'bad' : 'warn'
+    return { text: `${total}개 세션 중 ${blocked}개 막힘.${suffix}`, tone }
+  }
+
+  return { text: `${total}개 세션 진행 중. ${attention}건 주의 항목.`, tone: 'warn' }
+}
+
+interface SituationBannerProps {
+  snap: DashboardMissionResponse | null
+  roomHealth?: string | null
+}
+
+export function SituationBanner({ snap, roomHealth }: SituationBannerProps) {
+  const { text, tone } = synthesizeSituation(snap)
+
+  return html`
+    <div class="situation-banner situation-banner--${tone}">
+      <${HealthBeacon} health=${roomHealth ?? tone} />
+      <span class="situation-banner__text">${text}</span>
+    </div>
+  `
+}

--- a/dashboard/src/styles/overview.css
+++ b/dashboard/src/styles/overview.css
@@ -1,6 +1,10 @@
-/* MASC Dashboard — Overview (Home) surface styles */
+/* MASC Dashboard — Overview (Home) surface styles
+ * Redesigned: 4-layer NOC dashboard pattern
+ * Layer 1: SituationBanner, Layer 2: AttentionSpotlight
+ * Layer 3: AgentGrid + SessionTriage, Layer 4: NarrativeTimeline
+ */
 
-/* Quick stats bar */
+/* ── Quick stats bar ───────────────────────── */
 .overview-stats {
   display: grid;
   grid-template-columns: repeat(4, minmax(0, 1fr));
@@ -32,7 +36,450 @@
   font-feature-settings: "tnum";
 }
 
-/* Ecosystem ring */
+/* ── Phase 1A: Situation Banner ────────────── */
+.situation-banner {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 14px 18px;
+  border-radius: var(--radius-sm, 10px);
+  background: var(--card);
+  border: 1px solid var(--card-border);
+  border-left: 3px solid var(--agent-working, #7ae09a);
+  font-size: 14px;
+  font-weight: 500;
+  color: var(--text-strong);
+  line-height: 1.4;
+}
+
+.situation-banner--ok {
+  border-left-color: var(--agent-working, #7ae09a);
+}
+
+.situation-banner--warn {
+  border-left-color: var(--agent-busy, #f0c060);
+}
+
+.situation-banner--bad {
+  border-left-color: var(--bad, #ef4444);
+}
+
+.situation-banner__text {
+  flex: 1;
+  min-width: 0;
+}
+
+/* ── Phase 1B: Attention Spotlight ─────────── */
+.attention-spotlight {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xs, 4px);
+}
+
+.attention-spotlight__card {
+  display: flex;
+  gap: 0;
+  border-radius: var(--radius-sm, 10px);
+  background: var(--card);
+  border: 1px solid var(--card-border);
+  overflow: hidden;
+  animation: fadeSlide 0.3s ease both;
+}
+
+.attention-spotlight__card.ok { border-color: rgba(74, 222, 128, 0.3); }
+.attention-spotlight__card.warn { border-color: rgba(251, 191, 36, 0.3); }
+.attention-spotlight__card.bad { border-color: rgba(248, 113, 113, 0.3); }
+
+.attention-spotlight__bar {
+  width: 4px;
+  flex-shrink: 0;
+}
+
+.attention-spotlight__card.ok .attention-spotlight__bar { background: var(--agent-working, #7ae09a); }
+.attention-spotlight__card.warn .attention-spotlight__bar { background: var(--agent-busy, #f0c060); }
+.attention-spotlight__card.bad .attention-spotlight__bar { background: var(--bad, #ef4444); }
+
+.attention-spotlight__body {
+  display: grid;
+  gap: 6px;
+  padding: 10px 14px;
+  min-width: 0;
+}
+
+.attention-spotlight__summary {
+  color: var(--text-strong);
+  font-size: 13px;
+  font-weight: 500;
+  line-height: 1.4;
+}
+
+.attention-spotlight__meta {
+  display: flex;
+  gap: 6px;
+  flex-wrap: wrap;
+  align-items: center;
+}
+
+.attention-spotlight__chip {
+  padding: 2px 8px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  font-size: 11px;
+  color: var(--warm-amber, #f5c542);
+  font-weight: 500;
+}
+
+.attention-spotlight__time {
+  color: var(--text-muted);
+  font-size: 11px;
+}
+
+/* ── Phase 3: Agent Grid ───────────────────── */
+.agent-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(80px, 1fr));
+  gap: 10px;
+}
+
+.agent-grid__cell {
+  display: flex;
+  justify-content: center;
+}
+
+/* ── Phase 4: Session Triage ───────────────── */
+.session-triage {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-sm, 8px);
+}
+
+.triage-tier {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xs, 4px);
+}
+
+.triage-tier--watch {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: var(--space-xs, 4px);
+}
+
+/* Critical cards: full width, red left border */
+.triage-card {
+  padding: 12px 14px;
+  border-radius: var(--radius-sm, 10px);
+  background: var(--card);
+  border: 1px solid var(--card-border);
+  cursor: pointer;
+  display: grid;
+  gap: 6px;
+  transition: border-color 0.15s;
+}
+
+.triage-card:hover {
+  border-color: rgba(71, 184, 255, 0.4);
+}
+
+.triage-card--critical {
+  border-left: 3px solid var(--bad, #ef4444);
+}
+
+.triage-card--watch {
+  border-left: 3px solid var(--agent-busy, #f0c060);
+}
+
+.triage-card__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 8px;
+}
+
+.triage-card__goal {
+  color: var(--text-strong);
+  font-size: 13px;
+  font-weight: 500;
+  line-height: 1.35;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.triage-card__blocker {
+  color: var(--bad, #ef4444);
+  font-size: 12px;
+  line-height: 1.4;
+  opacity: 0.9;
+}
+
+.triage-card__meta {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  color: var(--text-muted);
+  font-size: 11px;
+}
+
+.triage-card__members {
+  color: var(--warm-amber, #f5c542);
+}
+
+/* Running sessions: collapsed by default */
+.triage-tier--running {
+  border: 1px solid var(--card-border);
+  border-radius: var(--radius-sm, 10px);
+  background: var(--card);
+}
+
+.triage-running-label {
+  padding: 10px 14px;
+  color: var(--text-muted);
+  font-size: 12px;
+  cursor: pointer;
+}
+
+.triage-running-list {
+  display: flex;
+  flex-direction: column;
+  border-top: 1px solid var(--card-border);
+}
+
+.triage-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 14px;
+  cursor: pointer;
+  transition: background 0.1s;
+  border-bottom: 1px solid rgba(138, 163, 211, 0.06);
+}
+
+.triage-row:last-child {
+  border-bottom: none;
+}
+
+.triage-row:hover {
+  background: rgba(71, 184, 255, 0.04);
+}
+
+.triage-row__goal {
+  color: var(--text-body);
+  font-size: 12px;
+  line-height: 1.4;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.triage-row__meta {
+  color: var(--text-muted);
+  font-size: 11px;
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
+/* ── Phase 5: Narrative Timeline ───────────── */
+.narrative-timeline {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-sm, 8px);
+  padding: 12px 14px;
+  border: 1px solid var(--card-border);
+  border-radius: var(--radius-sm, 10px);
+  background: var(--card);
+  max-height: 320px;
+  overflow-y: auto;
+  scrollbar-width: thin;
+  scrollbar-color: rgba(138, 163, 211, 0.15) transparent;
+}
+
+.narrative-timeline__empty {
+  color: var(--text-muted);
+  text-align: center;
+  padding: 12px;
+  font-size: 12px;
+}
+
+.narrative-group {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.narrative-group__label {
+  color: var(--text-muted);
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  padding-bottom: 2px;
+  border-bottom: 1px solid rgba(138, 163, 211, 0.08);
+}
+
+.narrative-group__events {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.narrative-event {
+  padding: 4px 0;
+}
+
+.narrative-event__text {
+  color: var(--text-body);
+  font-size: 12px;
+  line-height: 1.45;
+}
+
+.narrative-event__raw {
+  margin-top: 2px;
+}
+
+.narrative-event__raw summary {
+  cursor: pointer;
+  color: var(--text-muted);
+  font-size: 10px;
+}
+
+.narrative-event__raw span {
+  display: block;
+  color: var(--text-muted);
+  font-size: 11px;
+  padding: 4px 8px;
+  background: rgba(255, 255, 255, 0.02);
+  border-radius: 4px;
+  margin-top: 2px;
+  line-height: 1.4;
+}
+
+/* ── Phase 6: Enhanced Keeper Cards ────────── */
+.keeper-cards-v2 {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xs, 4px);
+}
+
+.keeper-card-v2 {
+  padding: 10px 12px;
+  border: 1px solid var(--card-border);
+  border-left: 3px solid var(--card-border);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.03);
+  display: grid;
+  gap: 6px;
+  font-size: 12px;
+}
+
+.keeper-card-v2.keeper-status--ok {
+  border-left-color: var(--agent-working, #7ae09a);
+}
+
+.keeper-card-v2.keeper-status--idle {
+  border-left-color: rgba(138, 163, 211, 0.4);
+}
+
+.keeper-card-v2.keeper-status--offline {
+  border-left-color: rgba(85, 85, 85, 0.4);
+  opacity: 0.6;
+}
+
+.keeper-card-v2__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.keeper-card-v2__name {
+  color: var(--text-strong);
+  font-weight: 500;
+}
+
+.keeper-card-v2__gen {
+  color: var(--text-muted);
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+}
+
+.keeper-card-v2__work {
+  color: var(--text-body);
+  line-height: 1.4;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.keeper-card-v2__pressure {
+  position: relative;
+  height: 6px;
+  background: rgba(255, 255, 255, 0.06);
+  border-radius: 999px;
+  overflow: hidden;
+}
+
+.keeper-card-v2__pressure-bar {
+  position: absolute;
+  top: 0;
+  left: 0;
+  height: 100%;
+  border-radius: 999px;
+  transition: width 0.3s ease;
+}
+
+.keeper-card-v2__pressure-bar.pressure--ok { background: var(--agent-working, #7ae09a); }
+.keeper-card-v2__pressure-bar.pressure--amber { background: var(--agent-busy, #f0c060); }
+.keeper-card-v2__pressure-bar.pressure--orange { background: #f97316; }
+.keeper-card-v2__pressure-bar.pressure--red { background: var(--bad, #ef4444); }
+
+.keeper-card-v2__pressure-label {
+  position: absolute;
+  right: 4px;
+  top: -14px;
+  font-size: 10px;
+  color: var(--text-muted);
+  font-variant-numeric: tabular-nums;
+}
+
+.keeper-card-v2__activity {
+  color: var(--text-muted);
+  font-size: 11px;
+}
+
+/* ── Layout: v2 two-zone ───────────────────── */
+.overview-surface {
+  display: grid;
+  gap: var(--space-md, 16px);
+}
+
+.overview-main-v2 {
+  display: grid;
+  grid-template-columns: minmax(0, 2fr) minmax(0, 1fr);
+  gap: var(--space-md, 16px);
+  align-items: start;
+}
+
+.overview-left-col,
+.overview-right-col {
+  display: grid;
+  gap: var(--space-sm, 8px);
+  min-width: 0;
+}
+
+.overview-section-label {
+  color: var(--text-muted);
+  font-size: 11px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  margin-bottom: var(--space-xs, 4px);
+}
+
+/* ── Legacy: kept for backward compat (ecosystem ring, session strip) ── */
 .ecosystem-ring {
   position: relative;
   width: 100%;
@@ -74,7 +521,6 @@
   z-index: 2;
 }
 
-/* Session strip */
 .session-strip {
   display: flex;
   gap: var(--space-sm, 8px);
@@ -84,10 +530,7 @@
   scrollbar-color: rgba(138, 163, 211, 0.2) transparent;
 }
 
-.session-strip::-webkit-scrollbar {
-  height: 4px;
-}
-
+.session-strip::-webkit-scrollbar { height: 4px; }
 .session-strip::-webkit-scrollbar-thumb {
   background: rgba(138, 163, 211, 0.25);
   border-radius: 999px;
@@ -105,10 +548,7 @@
   transition: border-color 0.15s;
 }
 
-.session-card-mini:hover {
-  border-color: rgba(71, 184, 255, 0.4);
-}
-
+.session-card-mini:hover { border-color: rgba(71, 184, 255, 0.4); }
 .session-card-mini.ok { border-color: rgba(74, 222, 128, 0.3); }
 .session-card-mini.warn { border-color: rgba(251, 191, 36, 0.3); }
 .session-card-mini.bad { border-color: rgba(248, 113, 113, 0.3); }
@@ -132,12 +572,7 @@
   font-size: 11px;
 }
 
-.session-card-mini__members {
-  display: flex;
-  gap: -4px;
-}
-
-/* Health beacon */
+/* ── Health beacon ─────────────────────────── */
 .health-beacon {
   display: inline-flex;
   align-items: center;
@@ -177,7 +612,7 @@
 .health-beacon.warn { color: var(--agent-busy, #f0c060); }
 .health-beacon.bad { color: var(--bad, #ef4444); }
 
-/* Activity ticker */
+/* ── Activity ticker (legacy, kept for other surfaces) ── */
 .activity-ticker {
   display: flex;
   flex-direction: column;
@@ -204,9 +639,7 @@
   animation: fadeSlide 0.3s ease both;
 }
 
-.activity-ticker__item:last-child {
-  border-bottom: none;
-}
+.activity-ticker__item:last-child { border-bottom: none; }
 
 .activity-ticker__time {
   color: var(--text-muted);
@@ -222,98 +655,17 @@
   white-space: nowrap;
 }
 
-/* Overview layout */
-.overview-surface {
-  display: grid;
-  gap: var(--space-md, 16px);
-}
-
-.overview-main {
-  display: grid;
-  grid-template-columns: 280px minmax(0, 1fr) 240px;
-  gap: var(--space-md, 16px);
-  align-items: start;
-}
-
-.overview-ring-col {
-  display: grid;
-  gap: var(--space-md, 16px);
-}
-
-.overview-sessions-col {
-  display: grid;
-  gap: var(--space-md, 16px);
-  min-width: 0;
-}
-
-.overview-health-col {
-  display: grid;
-  gap: var(--space-sm, 8px);
-}
-
-.overview-section-label {
-  color: var(--text-muted);
-  font-size: 11px;
-  letter-spacing: 0.06em;
-  text-transform: uppercase;
-  margin-bottom: var(--space-xs, 4px);
-}
-
-/* Keeper mini cards in health sidebar */
-.keeper-mini-card {
-  padding: 10px 12px;
-  border: 1px solid var(--card-border);
-  border-radius: 8px;
-  background: rgba(255, 255, 255, 0.03);
-  display: grid;
-  gap: 4px;
-  font-size: 12px;
-}
-
-.keeper-mini-card__name {
-  color: var(--text-strong);
-  font-weight: 500;
-}
-
-.keeper-mini-card__meta {
-  color: var(--text-muted);
-  font-size: 11px;
-}
-
-/* Slim header variant for Home */
+/* ── Slim header variant for Home ──────────── */
 .dashboard-header--slim {
   min-height: auto;
   padding: 10px 18px;
 }
 
-.dashboard-header--slim .header-title-wrap h1 {
-  font-size: 20px;
-}
+.dashboard-header--slim .header-title-wrap h1 { font-size: 20px; }
+.dashboard-header--slim .header-subtitle { display: none; }
+.dashboard-layout--home { grid-template-columns: 1fr; }
 
-.dashboard-header--slim .header-subtitle {
-  display: none;
-}
-
-/* Home layout: no sidebar */
-.dashboard-layout--home {
-  grid-template-columns: 1fr;
-}
-
-@media (max-width: 1100px) {
-  .overview-main {
-    grid-template-columns: 1fr;
-  }
-
-  .ecosystem-ring {
-    max-width: 260px;
-  }
-
-  .overview-stats {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-  }
-}
-
-/* Navigation strip for Home (no SideRail on Home) */
+/* ── Navigation strip ──────────────────────── */
 .overview-nav-strip {
   display: grid;
   grid-template-columns: repeat(4, minmax(0, 1fr));
@@ -338,20 +690,27 @@
   background: rgba(71, 184, 255, 0.05);
 }
 
-.overview-nav-icon {
-  font-size: 18px;
-}
+.overview-nav-icon { font-size: 18px; }
+.overview-nav-label { color: var(--text-strong); font-size: 14px; font-weight: 600; }
+.overview-nav-desc { color: var(--text-muted); font-size: 11px; line-height: 1.4; }
 
-.overview-nav-label {
-  color: var(--text-strong);
-  font-size: 14px;
-  font-weight: 600;
-}
+/* ── Responsive ────────────────────────────── */
+@media (max-width: 1100px) {
+  .overview-main-v2 {
+    grid-template-columns: 1fr;
+  }
 
-.overview-nav-desc {
-  color: var(--text-muted);
-  font-size: 11px;
-  line-height: 1.4;
+  .overview-stats {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .triage-tier--watch {
+    grid-template-columns: 1fr;
+  }
+
+  .agent-grid {
+    grid-template-columns: repeat(auto-fill, minmax(64px, 1fr));
+  }
 }
 
 @media (max-width: 700px) {
@@ -362,4 +721,25 @@
   .overview-nav-strip {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
+}
+
+/* ── Legacy: keeper mini cards ─────────────── */
+.keeper-mini-card {
+  padding: 10px 12px;
+  border: 1px solid var(--card-border);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.03);
+  display: grid;
+  gap: 4px;
+  font-size: 12px;
+}
+
+.keeper-mini-card__name {
+  color: var(--text-strong);
+  font-weight: 500;
+}
+
+.keeper-mini-card__meta {
+  color: var(--text-muted);
+  font-size: 11px;
 }

--- a/dashboard/src/styles/pixel-avatars.css
+++ b/dashboard/src/styles/pixel-avatars.css
@@ -1,6 +1,7 @@
 /* MASC Dashboard — CSS Pixel Art Avatar System
  * 8x8 CSS Grid avatars with state-based animations.
  * Each agent gets a deterministic palette from their name hash.
+ * Phase 2: operational overlays (activity dot, speech bubble, blocker ring)
  */
 
 .pixel-avatar {
@@ -9,9 +10,10 @@
   width: 48px;
   height: 48px;
   border-radius: 6px;
-  overflow: hidden;
+  overflow: visible;
   flex-shrink: 0;
   image-rendering: pixelated;
+  position: relative;
 }
 
 .pixel-avatar--sm {
@@ -52,6 +54,107 @@
 .pixel-avatar[data-status="inactive"] {
   filter: grayscale(0.85) brightness(0.6);
   opacity: 0.55;
+}
+
+/* ── Phase 2: Signal truth ring ────────────── */
+.pixel-avatar.signal-ring--live {
+  box-shadow: 0 0 0 2px var(--agent-working, #7ae09a);
+}
+
+.pixel-avatar.signal-ring--stale {
+  box-shadow: 0 0 0 2px var(--agent-busy, #f0c060);
+}
+
+.pixel-avatar.signal-ring--archived {
+  box-shadow: 0 0 0 2px rgba(138, 163, 211, 0.3);
+}
+
+/* ── Phase 2: Blocker pulse ring ───────────── */
+.pixel-avatar--has-blocker {
+  animation: blocker-pulse 1.5s ease-in-out infinite;
+}
+
+@keyframes blocker-pulse {
+  0%, 100% { box-shadow: 0 0 0 2px rgba(239, 68, 68, 0.4); }
+  50% { box-shadow: 0 0 0 4px rgba(239, 68, 68, 0.7); }
+}
+
+/* ── Phase 2: Activity dot (top-right) ─────── */
+.pixel-avatar__activity-dot {
+  position: absolute;
+  top: -2px;
+  right: -2px;
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  pointer-events: none;
+  z-index: 1;
+}
+
+.activity-dot--live-pulse {
+  background: var(--agent-working, #7ae09a);
+  box-shadow: 0 0 4px rgba(122, 224, 154, 0.8);
+  animation: pulse 1.5s ease-in-out infinite;
+}
+
+.activity-dot--live {
+  background: var(--agent-working, #7ae09a);
+}
+
+.activity-dot--stale {
+  background: var(--agent-busy, #f0c060);
+}
+
+.activity-dot--inactive {
+  background: rgba(138, 163, 211, 0.4);
+}
+
+.activity-dot--unknown {
+  background: rgba(138, 163, 211, 0.2);
+}
+
+/* ── Phase 2: Speech bubble ────────────────── */
+.pixel-avatar__speech-bubble {
+  position: absolute;
+  bottom: calc(100% + 4px);
+  left: 50%;
+  transform: translateX(-50%);
+  white-space: nowrap;
+  padding: 3px 8px;
+  border-radius: 6px;
+  background: rgba(30, 30, 40, 0.92);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  color: var(--text-strong);
+  font-size: 10px;
+  line-height: 1.3;
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 0.15s ease;
+  z-index: 10;
+  max-width: 160px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* Bubble triangle */
+.pixel-avatar__speech-bubble::after {
+  content: '';
+  position: absolute;
+  top: 100%;
+  left: 50%;
+  transform: translateX(-50%);
+  border: 4px solid transparent;
+  border-top-color: rgba(30, 30, 40, 0.92);
+}
+
+/* Show on hover */
+.pixel-avatar:hover .pixel-avatar__speech-bubble {
+  opacity: 1;
+}
+
+/* Top 5 active agents always show */
+.pixel-avatar__speech-bubble.always-visible {
+  opacity: 1;
 }
 
 /* Avatar name label */
@@ -96,5 +199,12 @@
   }
   .pixel-avatar-particle {
     display: none;
+  }
+  .pixel-avatar--has-blocker {
+    animation: none;
+    box-shadow: 0 0 0 2px rgba(239, 68, 68, 0.6);
+  }
+  .activity-dot--live-pulse {
+    animation: none;
   }
 }


### PR DESCRIPTION
## Summary

MASC 대시보드를 장난감 수준에서 운영 상황판으로 전환. 동일 백엔드 데이터로 프론트엔드만 변경하여 3초 상황 파악 달성.

### 4-Layer 정보 아키텍처 (NOC 대시보드 패턴)
- **Layer 1 - SituationBanner**: 데이터를 한국어 문장으로 합성한 한 줄 상황 요약
- **Layer 2 - AttentionSpotlight**: 비정상 항목만 상위 3건 하이라이트 (없으면 영역 자체 숨김)
- **Layer 3 - AgentGrid + SessionTriage**: 반응형 그리드 + 3-tier 세션 분류 (Critical/Watch/Running)
- **Layer 4 - NarrativeTimeline**: SSE 로그를 시간+행위자 기준 한국어 서사로 그룹핑

### Phase별 구현 내역
| Phase | 컴포넌트 | 변경 |
|-------|---------|------|
| 1A | `situation-banner.ts` | 숫자 -> 문장 합성 (tone: ok/warn/bad) |
| 1B | `attention-spotlight.ts` | attention_queue + blocker 통합, severity 정렬 |
| 2 | `agent-avatar.ts` | activity dot, speech bubble, blocker ring, signal ring 오버레이 |
| 3 | `agent-grid.ts` | EcosystemRing -> CSS Grid 교체, attention/signal/name 정렬 |
| 4 | `session-triage.ts` | SessionStrip -> 3-tier triage (Critical/Watch/Running 접힘) |
| 5 | `narrative-timeline.ts` | ActivityTicker -> 시간 그룹 + 한국어 verb 매핑 서사 |
| 6 | `overview.ts` inline | Keeper pressure bar + health status border |

### 레이아웃 변경
```
기존: [Ring 280px] [Sessions + Ticker 1fr] [Health 240px]
변경: [SituationBanner 전폭]
      [AttentionSpotlight 전폭]
      [QuickStats 전폭]
      [AgentGrid 2/3] [SessionTriage + Keepers + Timeline 1/3]
```

### 교차 모델 리뷰 수행
- GLM-5, Adversarial Agent, Best-Programmer Agent 3-way 교차 리뷰
- 6건 발견 -> 전수 수정 (키보드 접근성, stable keys, aria-label, semantic HTML)

### 수정하지 않은 것
- OCaml 백엔드 / API 레이어
- 라우팅/탭 구조, SSE/Signal 아키텍처
- 픽셀 아바타 8x8 그리드/팔레트 (아이덴티티 유지, 래퍼만 강화)

## Test plan
- [ ] `cd dashboard && npm run dev` -- Vite dev server (HMR)
- [ ] `localhost:5173` -- SituationBanner 문장이 세션 수/blocker에 따라 변하는지 확인
- [ ] AttentionSpotlight -- attention 없으면 영역 자체가 사라지는지 확인
- [ ] AgentGrid -- activity dot 색상이 last_activity_age_sec와 일치하는지
- [ ] SessionTriage -- blocker 있는 세션이 Critical tier에 배치되는지
- [ ] SessionTriage 키보드 -- Tab 이동 후 Enter/Space로 세션 열리는지
- [ ] AgentAvatar 키보드 -- Tab 이동 후 Enter/Space로 에이전트 상세 열리는지
- [ ] NarrativeTimeline -- SSE 이벤트가 시간별 그룹으로 표시되는지
- [ ] Keeper pressure bar -- context_ratio와 bar 너비 일치
- [ ] `npm run build` -- 프로덕션 빌드 성공 (새 TS 에러 0건)
- [ ] 반응형: 1100px 이하에서 single-column 전환

🤖 Generated with [Claude Code](https://claude.com/claude-code)