### PR TITLE
fix(mode): remove mode gate from tool execution path

### DIFF
--- a/lib/mcp_server_eio_execute.ml
+++ b/lib/mcp_server_eio_execute.ml
@@ -113,7 +113,7 @@ let execute_tool_eio ~sw ~clock ?mcp_session_id ?auth_token state ~name ~argumen
   in
 
   let room_path = Room.masc_dir config in
-  let mode_config = Config.load room_path in
+  let _mode_config = Config.load room_path in
 
   let mode_gate_error =
     if not (Tool_catalog.allow_direct_call name) then
@@ -121,11 +121,6 @@ let execute_tool_eio ~sw ~clock ?mcp_session_id ?auth_token state ~name ~argumen
         (Printf.sprintf
            "Tool '%s' is hidden from the default tool surface and not callable directly."
            name)
-    else if not (Mode.is_tool_enabled mode_config.enabled_categories name) then
-      Some
-        (Printf.sprintf
-           "Tool '%s' is disabled in current mode '%s'. Run masc_get_config or masc_switch_mode first."
-           name (Mode.mode_to_string mode_config.mode))
     else
       None
   in

--- a/test/test_mcp_server_eio.ml
+++ b/test/test_mcp_server_eio.ml
@@ -1009,31 +1009,6 @@ let test_execute_tool_trpg_flow () =
 
   cleanup_dir base_path
 
-let test_execute_tool_mode_gate () =
-  Eio_main.run @@ fun env ->
-  Mcp_eio.set_net (Eio.Stdenv.net env);
-  Mcp_eio.set_clock (Eio.Stdenv.clock env);
-  let clock = Eio.Stdenv.clock env in
-  Eio.Switch.run @@ fun sw ->
-
-  let base_path = temp_dir () in
-  let state = Mcp_eio.create_state ~test_mode:true ~base_path () in
-  let room_path = Masc_mcp.Room.masc_dir state.room_config in
-  let _ = Config.switch_mode room_path Mode.Minimal in
-
-  let (ok, msg) =
-    Mcp_eio.execute_tool_eio ~sw ~clock state
-      ~name:"masc_portal_status"
-      ~arguments:(`Assoc [ ("agent_name", `String "codex") ])
-  in
-  Alcotest.(check bool) "portal tool blocked in minimal mode" false ok;
-  Alcotest.(check bool)
-    "mode gate message"
-    true
-    (contains_substring msg "disabled in current mode");
-
-  cleanup_dir base_path
-
 let test_execute_tool_coding_mode_allows_governance_status () =
   Eio_main.run @@ fun env ->
   Mcp_eio.set_net (Eio.Stdenv.net env);
@@ -2214,7 +2189,6 @@ let eio_tests = [
   "handle invalid json", `Quick, test_handle_request_invalid_json;
   "handle method not found", `Quick, test_handle_request_method_not_found;
   "handle tools/call trpg", `Quick, test_handle_request_tools_call_trpg;
-  "mode gate", `Quick, test_execute_tool_mode_gate;
   "coding mode allows governance status", `Quick, test_execute_tool_coding_mode_allows_governance_status;
   "hidden active utility direct call", `Quick,
     test_execute_tool_hidden_active_utility_direct_call;


### PR DESCRIPTION
## Summary
- `mcp_server_eio_execute.ml`에서 `Mode.is_tool_enabled` 체크를 제거
- coding 모드로 영속화되면 Comm 카테고리 도구(masc_messages, masc_broadcast 등)가 차단되는 문제 해결
- `Tool_catalog.allow_direct_call` (hidden tool 보호)은 유지

## 건드리지 않은 것
- `mode.ml` — 카테고리 분류 (스키마 필터링에 사용)
- `config.ml` — 설정 영속화 (masc_get_config에서 사용)
- `tool_control.ml` — masc_switch_mode 도구
- `mcp_server_eio_tool_profile.ml` — 프로필 기반 도구 노출 (실행 차단 아님)

## Test plan
- [x] `dune build --root .` 통과
- [x] `make test` — 기존 Tool_team_session 실패 4건 외 신규 실패 없음
- [ ] 서버 시작 후 `masc_messages` 호출 시 모드 에러 없이 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)