### PR TITLE
fix: guard outer catch-all and backend_eio.set against Cancelled swallowing

### DIFF
--- a/lib/backend_eio.ml
+++ b/lib/backend_eio.ml
@@ -265,7 +265,9 @@ module FileSystem = struct
             (* Write file *)
             Eio.Path.save ~create:(`Or_truncate 0o644) path compressed;
             Ok ()
-          with exn ->
+          with
+          | Eio.Cancel.Cancelled _ as exn -> raise exn
+          | exn ->
             Error (IOError (Printexc.to_string exn))
     )
 

--- a/lib/mcp_server_eio_handlers.ml
+++ b/lib/mcp_server_eio_handlers.ml
@@ -326,7 +326,9 @@ let handle_request
                        let err = Printexc.to_string exn in
                        Log.Mcp.error "Request handling failed: %s" err;
                        make_error ~id (-32603) (Printf.sprintf "Internal error: %s" err))
-  with exn ->
+  with
+  | Eio.Cancel.Cancelled _ as exn -> raise exn
+  | exn ->
     make_error ~id:`Null ~data:(`String (Printexc.to_string exn)) (-32603) "Internal error"
 
 (** {1 Transport} *)

--- a/lib/mcp_server_eio_protocol.ml
+++ b/lib/mcp_server_eio_protocol.ml
@@ -458,7 +458,9 @@ let handle_request
                        let err = Printexc.to_string exn in
                        Log.Mcp.error "Request handling failed: %s" err;
                        make_error ~id (-32603) (Printf.sprintf "Internal error: %s" err))
-  with exn ->
+  with
+  | Eio.Cancel.Cancelled _ as exn -> raise exn
+  | exn ->
     make_error ~id:`Null ~data:(`String (Printexc.to_string exn)) (-32603) "Internal error"
 
 (** {1 Transport} *)


### PR DESCRIPTION
## Summary

#1288 후속. 3곳 누락 수정:

1. **backend_eio.ml `set`**: `Eio.Path.save` 중 Cancelled 삼킴 — 같은 파일의 `get`/`delete`/`list_keys`/`set_if_not_exists`는 #1288에서 수정했지만 `set`만 누락
2. **mcp_server_eio_handlers.ml 외부 catch-all**: 내부 handler의 `Cancelled` re-raise를 외부 `with exn ->`가 즉시 재삼킴 — #1288의 내부 가드가 dead code가 됨
3. **mcp_server_eio_protocol.ml 외부 catch-all**: 동일 구조

## 위험도

handlers/protocol의 외부 catch-all은 서버의 마지막 방어선이지만, `Cancelled`는 Eio fiber 정리 신호이므로 반드시 전파되어야 함. 삼키면 좀비 fiber가 됨.

## Test plan

- [x] `dune build --root .` passes
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)