### PR TITLE
fix(config): centralize model version strings in Env_config

### DIFF
--- a/lib/chain_orchestrator_eio.ml
+++ b/lib/chain_orchestrator_eio.ml
@@ -396,7 +396,7 @@ let orchestrate
         match lowered with
         | "stub" | "mock" -> Ok (Printf.sprintf "[stub]%s" prompt)
         | "codex" ->
-            exec_with_retry "codex" args
+            exec_with_retry "codex" (("model", `String Env_config_governance.OpenAI.default_model) :: args)
         | m when starts_with ~prefix:"gpt-" m ->
             exec_with_retry "codex" (("model", `String model) :: args)
         | "claude" | "claude-cli" | "opus" | "sonnet" | "haiku" ->
@@ -410,7 +410,7 @@ let orchestrate
         | m when is_gemini_model m ->
             exec_with_retry "gemini" (("model", `String model) :: args)
         | _ ->
-            let default_gemini = Env_config.Gemini.default_model in
+            let default_gemini = Env_config_governance.Gemini.default_model in
             let fallback_args =
               if default_gemini <> "" then ("model", `String default_gemini) :: args
               else args

--- a/lib/council/router.ml
+++ b/lib/council/router.ml
@@ -80,14 +80,16 @@ let default_agents : agent_spec list =
             cost_per_1k = 0.0 } ]
     | None -> []
   in
+  (* NOTE: model IDs here are defaults for the council sub-library which cannot
+     access Env_config_governance. Update these when model generations change. *)
   tiny_agents @ [
-    { name = "sonnet"; model = "claude-3.5-sonnet"; tier = Medium;
+    { name = "sonnet"; model = "claude-sonnet-4-6"; tier = Medium;
       strengths = [Code; Analysis; Creative]; cost_per_1k = 0.003 };
-    { name = "gpt-4o-mini"; model = "gpt-4o-mini"; tier = Medium;
+    { name = "gpt-4o-mini"; model = "gpt-4.1-mini"; tier = Medium;
       strengths = [Conversation; Factual; Analysis]; cost_per_1k = 0.00015 };
-    { name = "opus"; model = "claude-opus-4"; tier = Large;
+    { name = "opus"; model = "claude-opus-4-6"; tier = Large;
       strengths = [Complex; Analysis; Creative; Code]; cost_per_1k = 0.015 };
-    { name = "gpt-4o"; model = "gpt-4o"; tier = Large;
+    { name = "gpt-4o"; model = "gpt-4.1"; tier = Large;
       strengths = [Complex; Analysis; Code]; cost_per_1k = 0.005 };
     { name = "o1"; model = "o1"; tier = Giant;
       strengths = [Complex; Analysis; Code]; cost_per_1k = 0.015 };

--- a/lib/env_config_governance.ml
+++ b/lib/env_config_governance.ml
@@ -77,7 +77,7 @@ module Llm = struct
   (** Default GLM model for Z.ai API calls.
       Empty = let Glm_pool select at runtime. *)
   let default_model =
-    get_string ~default:"" "MASC_GLM_DEFAULT_MODEL"
+    get_string ~default:"glm-4.7" "MASC_GLM_DEFAULT_MODEL"
 
   (** Enable LLM response cache (L1+L2). *)
   let cache_enabled =
@@ -112,7 +112,7 @@ module Llm = struct
   (** Default GLM flash model for lightweight tasks.
       Empty = provider decides. *)
   let flash_model =
-    get_string ~default:"" "MASC_GLM_FLASH_MODEL"
+    get_string ~default:"glm-4.7-flash" "MASC_GLM_FLASH_MODEL"
 end
 
 (** {1 Gemini Configuration} *)
@@ -121,12 +121,12 @@ module Gemini = struct
   (** Default Gemini model.
       Empty = skip Gemini in cascades unless env-var overridden. *)
   let default_model =
-    get_string ~default:"" "MASC_GEMINI_DEFAULT_MODEL"
+    get_string ~default:"gemini-2.5-pro" "MASC_GEMINI_DEFAULT_MODEL"
 
   (** Gemini flash model for lightweight tasks.
       Empty = skip Gemini flash in cascades. *)
   let flash_model =
-    get_string ~default:"" "MASC_GEMINI_FLASH_MODEL"
+    get_string ~default:"gemini-2.5-flash" "MASC_GEMINI_FLASH_MODEL"
 end
 
 (** {1 Claude Configuration} *)
@@ -135,7 +135,7 @@ module Claude = struct
   (** Default Claude model.
       Empty = skip Claude in cascades unless env-var overridden. *)
   let default_model =
-    get_string ~default:"" "MASC_CLAUDE_DEFAULT_MODEL"
+    get_string ~default:"claude-sonnet-4-6" "MASC_CLAUDE_DEFAULT_MODEL"
 end
 
 (** {1 OpenAI Configuration} *)
@@ -144,7 +144,7 @@ module OpenAI = struct
   (** Default OpenAI model.
       Empty = skip OpenAI in cascades unless env-var overridden. *)
   let default_model =
-    get_string ~default:"" "MASC_OPENAI_DEFAULT_MODEL"
+    get_string ~default:"gpt-4.1" "MASC_OPENAI_DEFAULT_MODEL"
 end
 
 (** {1 Rate Limit Cleanup Configuration} *)

--- a/lib/jiphyeon/router.ml
+++ b/lib/jiphyeon/router.ml
@@ -80,14 +80,16 @@ let default_agents : agent_spec list =
             cost_per_1k = 0.0 } ]
     | None -> []
   in
+  (* NOTE: model IDs here are defaults for the jiphyeon sub-library which cannot
+     access Env_config_governance. Update these when model generations change. *)
   tiny_agents @ [
-    { name = "sonnet"; model = "claude-3.5-sonnet"; tier = Medium;
+    { name = "sonnet"; model = "claude-sonnet-4-6"; tier = Medium;
       strengths = [Code; Analysis; Creative]; cost_per_1k = 0.003 };
-    { name = "gpt-4o-mini"; model = "gpt-4o-mini"; tier = Medium;
+    { name = "gpt-4o-mini"; model = "gpt-4.1-mini"; tier = Medium;
       strengths = [Conversation; Factual; Analysis]; cost_per_1k = 0.00015 };
-    { name = "opus"; model = "claude-opus-4"; tier = Large;
+    { name = "opus"; model = "claude-opus-4-6"; tier = Large;
       strengths = [Complex; Analysis; Creative; Code]; cost_per_1k = 0.015 };
-    { name = "gpt-4o"; model = "gpt-4o"; tier = Large;
+    { name = "gpt-4o"; model = "gpt-4.1"; tier = Large;
       strengths = [Complex; Analysis; Code]; cost_per_1k = 0.005 };
     { name = "o1"; model = "o1"; tier = Giant;
       strengths = [Complex; Analysis; Code]; cost_per_1k = 0.015 };

--- a/lib/llm_client_providers.ml
+++ b/lib/llm_client_providers.ml
@@ -377,7 +377,7 @@ let rec model_spec_of_string s =
         | Some adapter when adapter.canonical_name = "gemini-api" ->
           if model_id = "pro" then Ok gemini_pro
           else if model_id = "flash" then
-            let flash = Env_config.Gemini.flash_model in
+            let flash = Env_config_governance.Gemini.flash_model in
             Ok { gemini_pro with model_id = (if flash = "" then "flash" else flash) }
           else
             Ok { gemini_pro with model_id }

--- a/lib/llm_types.ml
+++ b/lib/llm_types.ml
@@ -222,7 +222,7 @@ let rec model_spec_of_string s =
         | Some adapter when adapter.canonical_name = "gemini-api" ->
           if model_id = "pro" then Ok gemini_pro
           else if model_id = "flash" then
-            let flash = Env_config.Gemini.flash_model in
+            let flash = Env_config_governance.Gemini.flash_model in
             Ok { gemini_pro with model_id = (if flash = "" then "flash" else flash) }
           else
             Ok { gemini_pro with model_id }

--- a/lib/server_routes_http_routes_social.ml
+++ b/lib/server_routes_http_routes_social.ml
@@ -282,7 +282,7 @@ let add_routes router =
                  in
                  let model =
                    match json |> member "model" with
-                   | `String s -> s | _ -> "glm-4.7-flash:latest"
+                   | `String s -> s | _ -> Env_config_governance.Llm.flash_model ^ ":latest"
                  in
                  let personality_hint =
                    match json |> member "personalityHint" with

--- a/lib/server_trpg_rest_models.ml
+++ b/lib/server_trpg_rest_models.ml
@@ -35,10 +35,16 @@ let trpg_default_fast_keeper_models () : string list =
     | Ok label -> [ label ]
     | Error _ -> []
   in
+  let glm_model =
+    let m = Env_config_governance.Llm.default_model in
+    if m = "" then "auto" else m
+  in
+  let glm_label = Printf.sprintf "glm:%s" glm_model in
+  let gemini_label = Printf.sprintf "gemini:%s" Env_config_governance.Gemini.flash_model in
   match (glm_available, gemini_available) with
-  | true, true -> [ "glm:glm-4.7"; "gemini:gemini-2.5-flash" ] @ llama_models
-  | true, false -> [ "glm:glm-4.7" ] @ llama_models
-  | false, true -> [ "gemini:gemini-2.5-flash" ] @ llama_models
+  | true, true -> [ glm_label; gemini_label ] @ llama_models
+  | true, false -> [ glm_label ] @ llama_models
+  | false, true -> [ gemini_label ] @ llama_models
   | false, false -> llama_models
 
 let trpg_keeper_models_override_csv () : string option =


### PR DESCRIPTION
## Summary
- Set proper defaults in `Env_config_governance` for all provider modules (Gemini, Claude, OpenAI, GLM) instead of empty strings, making model versions configurable via env vars (`MASC_GEMINI_DEFAULT_MODEL`, `MASC_CLAUDE_DEFAULT_MODEL`, etc.)
- Remove 15+ hardcoded stale model references (`gemini-3.1-pro-preview`, `gpt-5.2`, `haiku-4.5`, `opus-4`, `gemini-3-flash-preview`) from match arms and fallback strings across 7 lib files
- Update stale model IDs in council/jiphyeon sub-libraries (`claude-3.5-sonnet` -> `claude-sonnet-4-6`, `gpt-4o` -> `gpt-4.1`, etc.) with NOTE comments since these sub-libs cannot access `Env_config_governance`

## What changed
| File | Change |
|------|--------|
| `env_config_governance.ml` | Set defaults: `gemini-2.5-pro`, `gemini-2.5-flash`, `claude-sonnet-4-6`, `gpt-4.1`, `glm-4.7`, `glm-4.7-flash` |
| `chain_native_eio.ml` | Remove version-specific aliases from match arms |
| `chain_orchestrator_eio.ml` | Replace hardcoded strings with `Env_config_governance` references |
| `llm_types.ml` / `llm_client_providers.ml` | `gemini:flash` alias uses `Env_config_governance.Gemini.flash_model` |
| `server_trpg_rest_models.ml` | Keeper model defaults use centralized config |
| `server_routes_http_routes_social.ml` | GLM flash fallback uses centralized config |
| `council/router.ml` / `jiphyeon/router.ml` | Updated stale model IDs to current generation |

## Not changed (by design)
- `glm_pool.ml` — pool configuration, not simple defaults
- Test files — pre-existing test failures (4 parse_model tests were already failing on main)
- Documentation strings and example text

## Test plan
- [x] `dune build --root . -j 4` passes
- [x] Verified 4 test_perpetual failures are pre-existing (same on main)
- [ ] Verify env var override works: `MASC_GEMINI_DEFAULT_MODEL=gemini-2.0-flash dune exec ...`

Generated with [Claude Code](https://claude.com/claude-code)