### PR TITLE
fix: narrow catch-all exceptions in bug-fix guards

### DIFF
--- a/lib/cp_lifecycle_policy.ml
+++ b/lib/cp_lifecycle_policy.ml
@@ -578,10 +578,11 @@ let pick_failover_leader live_agents (detachment : detachment_record) =
   | [] -> None
   | [single] -> Some single
   | _ ->
-      (* Shuffle: pick a random eligible agent for load distribution *)
+      (* Pick based on hash of current time to distribute without needing Random.self_init *)
       let arr = Array.of_list eligible in
       let n = Array.length arr in
-      Some arr.(Random.int n)
+      let idx = abs (Hashtbl.hash (Unix.gettimeofday ())) mod n in
+      Some arr.(idx)
 
 let maybe_escalation_target units (detachment : detachment_record) =
   match lookup_unit units detachment.assigned_unit_id with

--- a/lib/cp_unit.ml
+++ b/lib/cp_unit.ml
@@ -871,7 +871,7 @@ let topology_units config =
   let agents =
     Room.get_agents_raw config
     |> List.filter (fun (agent : Types.agent) ->
-         try Room.is_agent_joined config ~agent_name:agent.name with _ -> false)
+         try Room.is_agent_joined config ~agent_name:agent.name with Sys_error _ | Not_found -> false)
   in
   let managed_units = read_units config in
   let normalized_units = augment_managed_units managed_units agents in

--- a/lib/tool_inline_dispatch.ml
+++ b/lib/tool_inline_dispatch.ml
@@ -1068,7 +1068,7 @@ Call masc_listen again to continue listening.
       let current_room = Room.read_current_room config |> Option.value ~default:"default" in
       if thread_id = "" || content = "" then
         Some (false, "thread_id and content required")
-      else if not (try Room.is_agent_joined config ~agent_name:speaker with _ -> false) then
+      else if not (try Room.is_agent_joined config ~agent_name:speaker with Sys_error _ | Not_found -> false) then
         Some (false, Printf.sprintf "Speaker '%s' is not a member of this room" speaker)
       else begin
         let convo_config : Council.Conversation.config = {

--- a/lib/tool_task.ml
+++ b/lib/tool_task.ml
@@ -53,7 +53,7 @@ let handle_batch_add_tasks ctx args =
   (true, Room.batch_add_tasks ctx.config tasks)
 
 let handle_claim ctx args =
-  if not (try Room.is_agent_joined ctx.config ~agent_name:ctx.agent_name with _ -> false) then
+  if not (try Room.is_agent_joined ctx.config ~agent_name:ctx.agent_name with Sys_error _ | Not_found -> false) then
     result_to_response (Error (Types.AgentNotJoined ctx.agent_name))
   else
   let task_id = get_string args "task_id" "" in
@@ -82,7 +82,7 @@ let handle_claim ctx args =
   result_to_response result
 
 let handle_claim_next ctx _args =
-  if not (try Room.is_agent_joined ctx.config ~agent_name:ctx.agent_name with _ -> false) then
+  if not (try Room.is_agent_joined ctx.config ~agent_name:ctx.agent_name with Sys_error _ | Not_found -> false) then
     (false, Printf.sprintf "Agent '%s' is not a member of this room" ctx.agent_name)
   else
   (true, Room.claim_next ctx.config ~agent_name:ctx.agent_name)


### PR DESCRIPTION
## Summary
- `_ -> false` → `Sys_error _ | Not_found -> false` in is_agent_joined guards (#1288 방향과 일치)
- `Random.int` → `Hashtbl.hash(gettimeofday)` for failover leader selection (Random.self_init 불필요)

## Context
#1295 머지 이후 남아있던 리파인먼트. 4파일 7줄 변경.

## Test plan
- [ ] `dune build --root .` 통과
- [ ] 기존 테스트 영향 없음 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)