### PR TITLE
fix: replace remaining hardcoded model names with Env_config

### DIFF
--- a/lib/tool_perpetual.ml
+++ b/lib/tool_perpetual.ml
@@ -19,7 +19,7 @@ let schemas : Types.tool_schema list = [
 The agent will think → act → observe → verify in a loop, compacting context as needed \
 and handing off to successor agents when context fills up. \
 Requires: goal (what to accomplish), models (LLM cascade in priority order). \
-Example models: 'default', 'default:glm-5', 'gemini:gemini-3-flash-preview', 'claude:opus'.";
+Example models: 'default', 'default:auto', 'gemini:flash', 'claude:opus'.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -31,7 +31,7 @@ Example models: 'default', 'default:glm-5', 'gemini:gemini-3-flash-preview', 'cl
           ("type", `String "array");
           ("items", `Assoc [("type", `String "string")]);
           ("description", `String "LLM model cascade in priority order. \
-Format: 'provider:model_id' or 'default[:model_id]'. Examples: 'default', 'default:glm-5', 'gemini:gemini-3-flash-preview', 'claude:opus'");
+Format: 'provider:model_id' or 'default[:model_id]'. Examples: 'default', 'default:auto', 'gemini:flash', 'claude:opus'");
         ]);
         ("verify", `Assoc [
           ("type", `String "boolean");

--- a/lib/tool_schemas_room.ml
+++ b/lib/tool_schemas_room.ml
@@ -851,7 +851,7 @@ Example: masc_deliver({task_id: 'task-001', content: 'PR: github.com/org/repo/pu
         ]);
         ("model", `Assoc [
           ("type", `String "string");
-          ("description", `String "Model name (e.g., opus-4, gemini-2)");
+          ("description", `String "Model name (e.g., opus, sonnet, pro, flash)");
         ]);
         ("input_tokens", `Assoc [
           ("type", `String "integer");

--- a/lib/tools_schemas_04.ml
+++ b/lib/tools_schemas_04.ml
@@ -466,7 +466,7 @@ Votes affect sort order (higher votes = more visibility).";
         ]);
         ("model", `Assoc [
           ("type", `String "string");
-          ("description", `String "Model name (e.g., opus-4, gemini-2)");
+          ("description", `String "Model name (e.g., opus, sonnet, pro, flash)");
         ]);
         ("input_tokens", `Assoc [
           ("type", `String "integer");


### PR DESCRIPTION
## Summary
PR #1272 머지 후 남아있던 하드코딩 모델명 제거 (followup).

- `server_trpg_rest_models`: `glm-4.7` → `Env_config.Llm.default_model`, `gemini-2.5-flash` → `Env_config.Gemini.flash_model`
- `tool_perpetual`: doc 예시 `gemini-3-flash-preview` → `gemini:flash`, `glm-5` → `auto`
- `tool_schemas_room` + `tools_schemas_04`: 버전 없는 예시 (`opus, sonnet, pro, flash`)

## Context
P1/P2 리뷰 코멘트 대응은 PR #1272 squash에 이미 포함됨 (SpawnWithModel + gemini fallback).
이 PR은 나머지 파일의 하드코딩 정리.

## Test plan
- [x] `dune build` 통과
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)