### PR TITLE
fix: add logging to 7 silent failure catch-all patterns

### DIFF
--- a/lib/board_pg.ml
+++ b/lib/board_pg.ml
@@ -192,7 +192,9 @@ let post_of_row
       in
       let meta_json =
         match meta_raw with
-        | Some raw -> (try Some (Yojson.Safe.from_string raw) with _ -> None)
+        | Some raw -> (try Some (Yojson.Safe.from_string raw) with exn ->
+            Log.BoardPg.warn "meta_json parse failed: %s (raw=%s)" (Printexc.to_string exn) raw;
+            None)
         | None -> None
       in
       let title, body, post_kind, meta_json =

--- a/lib/dashboard_http_helpers.ml
+++ b/lib/dashboard_http_helpers.ml
@@ -69,7 +69,8 @@ let parse_tool_call_detail (detail_opt : string option)
           | Some ("timeout", v) ->
               timeout := bool_of_tag_value v
           | Some ("duration_ms", v) ->
-              (try duration_ms := Some (max 0 (int_of_string v)) with _ -> ())
+              (try duration_ms := Some (max 0 (int_of_string v)) with _ ->
+                Log.Dashboard.warn "invalid duration_ms value: %s" v)
           | _ -> ())
         tags;
       (tool_name, !timeout, !duration_ms)

--- a/lib/federation.ml
+++ b/lib/federation.ml
@@ -304,11 +304,17 @@ let safe_append_file (path : string) (content : string) : (unit, string) result 
 let validate_path (base_path : string) (target_path : string) : (string, string) result =
   let normalized_base =
     try Unix.realpath base_path
-    with Unix.Unix_error _ -> base_path
+    with Unix.Unix_error (err, _, _) ->
+      Log.Misc.warn "federation: realpath failed for base %s: %s"
+        base_path (Unix.error_message err);
+      base_path
   in
   let normalized_target =
     try Unix.realpath (Filename.dirname target_path) ^ "/" ^ Filename.basename target_path
-    with Unix.Unix_error _ -> target_path
+    with Unix.Unix_error (err, _, _) ->
+      Log.Misc.warn "federation: realpath failed for target %s: %s"
+        target_path (Unix.error_message err);
+      target_path
   in
   if String.length normalized_target >= String.length normalized_base &&
      String.sub normalized_target 0 (String.length normalized_base) = normalized_base then

--- a/lib/room_gc.ml
+++ b/lib/room_gc.ml
@@ -120,7 +120,8 @@ let cleanup_zombies config =
               (* Stop heartbeats owned by this zombie agent *)
               let _stopped = Heartbeat.stop_by_agent ~agent_name:agent.name in
               (* Remove agent file *)
-              (try Sys.remove path with Sys_error _ -> ())
+              (try Sys.remove path with Sys_error msg ->
+                Log.Gc.warn "failed to remove zombie agent file %s: %s" path msg)
           | _ -> ()
         end
       )

--- a/lib/server_trpg_rest_runtime.ml
+++ b/lib/server_trpg_rest_runtime.ml
@@ -326,7 +326,9 @@ let handle_trpg_sse ~base_dir ~room_id ~event_type_filter request reqd =
                  ignore (send_raw_data (trpg_event_to_sse ev));
                  last_seq := max !last_seq ev.Trpg_engine_event.seq
                end) events
-         | Error _ -> ());
+         | Error err ->
+             Log.Trpg.warn "SSE initial event read failed for room %s: %s"
+               room_id err);
 
         (* Start polling fiber for new events + keepalive *)
         (match Eio_context.get_switch_opt (), Eio_context.get_clock_opt () with

--- a/lib/tool_command_plane_support.ml
+++ b/lib/tool_command_plane_support.ml
@@ -198,8 +198,10 @@ let run_process_with_timeout ~clock_opt ~timeout_sec ~prog ~argv ~env =
   let finalize exit_code =
     let stdout = In_channel.with_open_bin stdout_path In_channel.input_all in
     let stderr = In_channel.with_open_bin stderr_path In_channel.input_all in
-    (try Sys.remove stdout_path with _ -> ());
-    (try Sys.remove stderr_path with _ -> ());
+    (try Sys.remove stdout_path with exn ->
+      Log.CmdPlane.warn "failed to remove stdout tmpfile %s: %s" stdout_path (Printexc.to_string exn));
+    (try Sys.remove stderr_path with exn ->
+      Log.CmdPlane.warn "failed to remove stderr tmpfile %s: %s" stderr_path (Printexc.to_string exn));
     { exit_code; stdout; stderr }
   in
   match wait_for_pid_with_timeout ~clock_opt ~timeout_sec pid with


### PR DESCRIPTION
## Summary
- Replace 7 bare `_ -> ()` / `_ -> None` catch-alls with structured `Log.warn` calls across 7 files
- No behavior change: errors still fall through to existing defaults, but failures are now observable
- Includes `masc_mcp.opam` version sync (dune-project already at 2.101.0)

## Files changed
| File | Pattern | Log module |
|------|---------|------------|
| `dashboard_http_helpers.ml:72` | `int_of_string` failure in duration_ms | `Log.Dashboard.warn` |
| `tool_command_plane_support.ml:201` | tmpfile cleanup `Sys.remove` | `Log.CmdPlane.warn` |
| `board_pg.ml:195` | JSON parse failure in meta_raw | `Log.BoardPg.warn` |
| `server_trpg_rest_runtime.ml:329` | SSE initial event read error | `Log.Trpg.warn` |
| `federation.ml:307` | `Unix.realpath` fallback in path validation | `Log.Misc.warn` |
| `room_gc.ml:123` | zombie agent file removal | `Log.Gc.warn` |
| `autoresearch.ml:697` | tmp file cleanup after write failure | `Log.Autoresearch.warn` |

## Test plan
- [x] `dune build --root .` passes
- [ ] Manual: trigger each path and verify log output appears

Closes #1286

Generated with [Claude Code](https://claude.com/claude-code)