### PR TITLE
fix: resolve 4 root causes of PG mode init crash

### DIFF
--- a/lib/council/archive.ml
+++ b/lib/council/archive.ml
@@ -247,7 +247,8 @@ let get_pg_pool ~sw ~env =
     match get_postgres_url () with
     | None -> Error "DATABASE_URL not set"
     | Some url ->
-      match Caqti_eio_unix.connect_pool ~sw (Uri.of_string url) ~stdenv:env with
+      let pool_config = Caqti_pool_config.create ~max_size:3 () in
+      match Caqti_eio_unix.connect_pool ~sw ~pool_config (Uri.of_string url) ~stdenv:env with
       | Ok pool ->
         pg_pool_ref := Some pool;
         Ok pool

--- a/lib/env_config_runtime.ml
+++ b/lib/env_config_runtime.ml
@@ -276,4 +276,13 @@ module Cp = struct
     get_int ~default:14 "MASC_CP_CLEANUP_DAYS"
 end
 
+(** {1 Message GC Configuration} *)
+
+module Message = struct
+  (** Maximum number of message files to retain per room (default 200).
+      Oldest messages (by filename sort) are deleted when count exceeds this. *)
+  let max_count =
+    get_int ~default:200 "MASC_MESSAGE_MAX_COUNT"
+end
+
 (** {1 Internal Guardian Configuration} *)

--- a/lib/jiphyeon/archive.ml
+++ b/lib/jiphyeon/archive.ml
@@ -263,7 +263,8 @@ let get_pg_pool ~sw ~env =
     match get_postgres_url () with
     | None -> Error "DATABASE_URL not set"
     | Some url ->
-      match Caqti_eio_unix.connect_pool ~sw (Uri.of_string url) ~stdenv:env with
+      let pool_config = Caqti_pool_config.create ~max_size:3 () in
+      match Caqti_eio_unix.connect_pool ~sw ~pool_config (Uri.of_string url) ~stdenv:env with
       | Ok pool ->
         pg_pool_ref := Some pool;
         Ok pool

--- a/lib/safe_ops.ml
+++ b/lib/safe_ops.ml
@@ -30,16 +30,14 @@ let parse_json_safe ~context str : (Yojson.Safe.t, string) result =
     let preview = if String.length str > 50 then String.sub str 0 50 ^ "..." else str in
     Error (Printf.sprintf "[%s] JSON parse error: %s (input: %s)" context msg preview)
 
-(** Read file contents with error handling *)
+(** Read file contents with error handling.
+    Uses Eio-native I/O via Fs_compat when available (after set_fs),
+    falls back to blocking I/O in non-Eio contexts. *)
 let read_file_safe path : (string, string) result =
   if not (Sys.file_exists path) then
     Error (Printf.sprintf "File not found: %s" path)
   else
-    try
-      let ic = open_in path in
-      let content = Common.protect ~module_name:"safe_ops" ~finally_label:"finalizer" ~finally:(fun () -> close_in_noerr ic) (fun () ->
-        really_input_string ic (in_channel_length ic)) in
-      Ok content
+    try Ok (Fs_compat.load_file path)
     with e ->
       Error (Printf.sprintf "Failed to read %s: %s" path (Printexc.to_string e))
 
@@ -70,6 +68,13 @@ let read_json_file_safe path : (Yojson.Safe.t, string) result =
   match read_file_safe path with
   | Error e -> Error e
   | Ok content -> parse_json_safe ~context:path content
+
+(** Read JSON file via Eio-native I/O (Fs_compat).
+    Drop-in replacement for [Yojson.Safe.from_file] in Eio fiber contexts.
+    Falls back to blocking I/O when Eio fs is not set. *)
+let read_json_eio (path : string) : Yojson.Safe.t =
+  let content = Fs_compat.load_file path in
+  Yojson.Safe.from_string content
 
 (** List files in directory safely *)
 let list_dir_safe path : (string list, string) result =

--- a/lib/sentinel.ml
+++ b/lib/sentinel.ml
@@ -459,7 +459,7 @@ let make_keeper_health_consumer _config : (module Pulse.Consumer) =
             if Filename.check_suffix name ".json" then begin
               let path = Filename.concat keepers_dir name in
               try
-                let json = Yojson.Safe.from_file path in
+                let json = Safe_ops.read_json_eio path in
                 (match Yojson.Safe.Util.member "last_turn_at" json with
                  | `String ts ->
                      let last = parse_iso_or_epoch ts in
@@ -606,7 +606,7 @@ let make_governance_sweep_consumer config : (module Pulse.Consumer) =
             if Filename.check_suffix fname ".json" then begin
               let path = Filename.concat keepers_dir fname in
               try
-                let json = Yojson.Safe.from_file path in
+                let json = Safe_ops.read_json_eio path in
                 let consecutive_failures =
                   match Yojson.Safe.Util.member "consecutive_failures" json with
                   | `Int n -> n
@@ -680,6 +680,41 @@ let make_governance_sweep_consumer config : (module Pulse.Consumer) =
         Error msg
   end)
 
+(** Message GC consumer: caps message files per room to MASC_MESSAGE_MAX_COUNT.
+    Runs on the same pulse as task hygiene (5min). Deletes oldest by filename sort. *)
+let make_message_gc_consumer config : (module Pulse.Consumer) =
+  (module struct
+    let name = "sentinel-message-gc"
+    let should_act _beat = true
+    let on_beat _beat =
+      try
+        let max_count = Env_config_runtime.Message.max_count in
+        let msgs_path = Room.messages_dir config in
+        if Sys.file_exists msgs_path && Sys.is_directory msgs_path then begin
+          let files = Sys.readdir msgs_path |> Array.to_list in
+          let count = List.length files in
+          if count > max_count then begin
+            let sorted = List.sort String.compare files in
+            let to_delete = count - max_count in
+            let deleted = ref 0 in
+            List.iteri (fun i name ->
+              if i < to_delete then begin
+                let path = Filename.concat msgs_path name in
+                (try Sys.remove path; incr deleted
+                 with Sys_error _ -> ())
+              end
+            ) sorted;
+            log_info (sprintf "message GC: removed %d/%d files (cap=%d)"
+              !deleted count max_count);
+          end
+        end;
+        Ok ()
+      with exn ->
+        let msg = sprintf "message GC failed: %s" (Printexc.to_string exn) in
+        log_warn msg;
+        Error msg
+  end)
+
 (* ── Status ────────────────────────────────────────────────── *)
 
 let started = ref false
@@ -716,6 +751,7 @@ let status_json () : Yojson.Safe.t =
       `String "sentinel-board-patrol";
       `String "sentinel-task-hygiene";
       `String "sentinel-keeper-health";
+      `String "sentinel-message-gc";
     ]
     @
     (if Env_config.Sentinel.governance_enabled then
@@ -774,7 +810,7 @@ let start ?bus ~sw ~clock ~net config =
     in
     Pulse.run ~sw p_board;
 
-    (* 5. Task hygiene + Keeper health (5min) *)
+    (* 5. Task hygiene + Keeper health + Message GC (5min) *)
     let p_ops = Pulse.create
       ~clock
       ~rhythm:(Guardian.fixed_rhythm Env_config.Sentinel.task_hygiene_interval_sec)
@@ -782,6 +818,7 @@ let start ?bus ~sw ~clock ~net config =
       ~consumers:[
         make_task_hygiene_consumer config;
         make_keeper_health_consumer config;
+        make_message_gc_consumer config;
       ]
     in
     Pulse.run ~sw p_ops;

--- a/lib/server_runtime_bootstrap.ml
+++ b/lib/server_runtime_bootstrap.ml
@@ -297,13 +297,36 @@ let run ~sw ~env ~host ~port ~base_path ~make_routes ~make_request_handler
 
   (* 2. All init in background fiber — protected so failures don't kill HTTP *)
   Eio.Fiber.fork ~sw (fun () ->
-    try
+    let init_state () =
       let state =
         create_server_state ~sw ~base_path ~clock ~mono_clock ~net ~proc_mgr ~fs
       in
       bootstrap_server_state state;
       bootstrap_keepers ~sw ~clock state;
       init_task_backend ();
+      state
+    in
+    try
+      let pg_init_timeout =
+        Safe_ops.get_env_float_logged "MASC_PG_INIT_TIMEOUT_SEC" ~default:10.0
+      in
+      let state =
+        let has_pg = match Sys.getenv_opt "MASC_POSTGRES_URL" with
+          | Some s when String.trim s <> "" -> true
+          | _ -> false
+        in
+        if has_pg then
+          (try
+             Eio.Time.with_timeout_exn clock pg_init_timeout init_state
+           with Eio.Time.Timeout ->
+             Log.Server.error
+               "PG init timed out after %.0fs, retrying with JSONL fallback"
+               pg_init_timeout;
+             Unix.putenv "MASC_POSTGRES_URL" "";
+             init_state ())
+        else
+          init_state ()
+      in
       let resolved_base, masc_dir =
         start_background_maintenance ~sw ~clock state
       in

--- a/lib/transport_grpc_next.ml
+++ b/lib/transport_grpc_next.ml
@@ -340,7 +340,7 @@ let get_messages_handler (room_config: Room.config) (data: string) : string =
           if !count >= req.limit then None
           else begin
             let path = Filename.concat msgs_path name in
-            match Yojson.Safe.from_file path with
+            match Safe_ops.read_json_eio path with
             | json ->
               (match Types.message_of_yojson json with
                | Ok msg when msg.seq > req.since_seq ->

--- a/lib/worker_container.ml
+++ b/lib/worker_container.ml
@@ -322,7 +322,7 @@ let load_worker_meta ~base_path ~team_session_id ~worker_name =
   let path = worker_meta_path ~base_path ~team_session_id ~worker_name in
   if Sys.file_exists path then
     try
-      Yojson.Safe.from_file path |> worker_meta_of_yojson
+      Safe_ops.read_json_eio path |> worker_meta_of_yojson
     with Yojson.Json_error _ | Sys_error _ -> None
   else
     None


### PR DESCRIPTION
## Summary

MASC-MCP 서버가 PG 모드에서 시작 시 init fiber가 crash하여 sentinel/guardian/gardener가 전부 죽는 문제를 4개 근본 원인별로 수정.

- **Train 1 (RC-2)**: council/jiphyeon archive의 unbounded PG pool → `max_size:3` bounded
- **Train 2 (RC-1)**: `Yojson.Safe.from_file` (blocking stdlib I/O) → `Fs_compat.load_file` (Eio-native) 전환
- **Train 3 (RC-3)**: PG init에 10초 timeout 추가, timeout 시 JSONL fallback 자동 전환
- **Train 4 (RC-4)**: Message GC consumer 추가 (5분 주기, 200개 초과 시 oldest 삭제)

## Changes

| 파일 | Train | 변경 |
|------|-------|------|
| `council/archive.ml` | 1 | `pool_config ~max_size:3` 추가 |
| `jiphyeon/archive.ml` | 1 | 동일 |
| `safe_ops.ml` | 2 | `read_file_safe`를 Fs_compat 기반으로 전환, `read_json_eio` 추가 |
| `sentinel.ml` | 2,4 | `from_file` → `read_json_eio`, `make_message_gc_consumer` 추가 |
| `transport_grpc_next.ml` | 2 | `from_file` → `read_json_eio` |
| `worker_container.ml` | 2 | `from_file` → `read_json_eio` |
| `server_runtime_bootstrap.ml` | 3 | PG init timeout + JSONL fallback |
| `env_config_runtime.ml` | 4 | `MASC_MESSAGE_MAX_COUNT` 환경변수 |

총: +90 lines, -14 lines, 8 files

## Test plan

- [ ] `dune build` 성공 확인 (완료)
- [ ] PG 모드 서버 시작 → 60초 내 sentinel=true, gardener=true
- [ ] 잘못된 PG URL → 10초 timeout → JSONL fallback → sentinel=true
- [ ] 5분 후 .masc/messages/ <= 200개
- [ ] "Failed to read" WARN 0건, Eio Cancelled 0건

🤖 Generated with [Claude Code](https://claude.com/claude-code)