### PR TITLE
fix: gardener validation order + room Active agent filter

### DIFF
--- a/lib/room_query.ml
+++ b/lib/room_query.ml
@@ -84,11 +84,13 @@ let get_agents_raw_in_room config room_id =
           let path = Filename.concat agents_path name in
           let json = read_json config path in
           match agent_of_yojson json with
-          | Ok agent -> Some agent
-          | Error _ -> None
+          | Ok agent when agent.status <> Types.Inactive -> Some agent
+          | Ok _ | Error _ -> None
         )
 
-(** Audit tasks: find claimed/in_progress tasks whose assignees are not active agents. *)
+(** Audit tasks: find claimed/in_progress tasks whose assignees are not active agents.
+    Matches assignees by exact name or agent-type prefix (e.g. "claude" matches "claude-xxx").
+    Agents with Inactive status are excluded from the active set. *)
 let audit_orphan_tasks config : (Types.task * string) list =
   if not (is_initialized config) then []
   else
@@ -103,16 +105,24 @@ let audit_orphan_tasks config : (Types.task * string) list =
             let path = Filename.concat agents_path name in
             let json = read_json config path in
             match agent_of_yojson json with
-            | Ok agent -> Some agent.name
-            | Error _ -> None)
+            | Ok agent when agent.status <> Types.Inactive -> Some agent.name
+            | Ok _ | Error _ -> None)
       else []
+    in
+    let is_active_agent assignee =
+      List.mem assignee active_names
+      || let prefix = assignee ^ "-" in
+         List.exists (fun name ->
+           String.length name > String.length prefix
+           && String.sub name 0 (String.length prefix) = prefix
+         ) active_names
     in
     let backlog = read_backlog config in
     List.filter_map (fun (task : Types.task) ->
       match task.task_status with
       | Types.Claimed { assignee; _ }
       | Types.InProgress { assignee; _ } ->
-          if List.mem assignee active_names then None
+          if is_active_agent assignee then None
           else Some (task, assignee)
       | _ -> None
     ) backlog.tasks

--- a/lib/tool_gardener.ml
+++ b/lib/tool_gardener.ml
@@ -90,13 +90,13 @@ let handle_status _ctx _args : result =
     - urgency: low/medium/high/critical (default: medium) *)
 let handle_propose_spawn _ctx args : result =
   try
-    let config = Gardener.get_config () in
-    if not config.enabled then
-      (false, "Gardener is disabled. Enable with MASC_GARDENER_ENABLED=true")
-    else
     let topic = get_string args "topic" "" in
     if topic = "" then
       (false, "Missing required parameter: topic")
+    else
+    let config = Gardener.get_config () in
+    if not config.enabled then
+      (false, "Gardener is disabled. Enable with MASC_GARDENER_ENABLED=true")
     else begin
       let reason = get_string args "reason" "Manual spawn request" in
       let urgency_str = get_string args "urgency" "medium" in
@@ -131,13 +131,13 @@ let handle_propose_spawn _ctx args : result =
     - agent_name: Name of the agent to consider (required) *)
 let handle_retire_agent _ctx args : result =
   try
-    let config = Gardener.get_config () in
-    if not config.enabled then
-      (false, "Gardener is disabled. Enable with MASC_GARDENER_ENABLED=true")
-    else
     let agent_name = get_string args "agent_name" "" in
     if agent_name = "" then
       (false, "Missing required parameter: agent_name")
+    else
+    let config = Gardener.get_config () in
+    if not config.enabled then
+      (false, "Gardener is disabled. Enable with MASC_GARDENER_ENABLED=true")
     else begin
       let decision = Gardener.propose_retire ~agent_name in
       let decision_provenance = retirement_decision_provenance decision in

--- a/test/test_tool_team_session.ml
+++ b/test/test_tool_team_session.ml
@@ -1,5 +1,5 @@
 let () =
-  Alcotest.run "Tool_team_session"
+  Alcotest.run ~verbose:true "Tool_team_session"
     [
       ( "team_session",
         [


### PR DESCRIPTION
## Summary
- **tool_gardener**: validate required params (topic/agent_name) before checking config.enabled — error messages are now specific instead of generic "gardener disabled"
- **room_query**: `get_agents_raw_in_room` filters to Active agents only — prevents Inactive agents inflating room counts after leave/rejoin
- **room_query**: `audit_orphan_tasks` filters to Active agents only — consistent with room agent visibility

Fixes gardener validation tests (2) and multi-room agent isolation test (1).

## Test plan
- [x] test_tool_gardener_coverage: 13/13 pass
- [ ] test_multi_room: verify agent count after move
- [ ] CI Build and Test green

🤖 Generated with [Claude Code](https://claude.com/claude-code)