### PR TITLE
feat: Phase 1 quick wins — glm_pool config, board PG primary (#1270, #1007, #603)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,6 +93,8 @@ curl http://127.0.0.1:8935/health
 - `MASC_ORCHESTRATOR_ENABLED=0` — Orchestrator 비활성화 (EADDRINUSE 방지)
 - `ME_ROOT` — repo 루트. 미지정 시 `$HOME/me`를 우선 사용
 - `MASC_DASHBOARD_PROXY_TARGET` — dashboard dev server가 프록시할 API origin
+- `MASC_BOARD_BACKEND` — Board 백엔드 선택 (`pg` default, `jsonl` for file-based)
+- `MASC_GLM_POOL_LIMIT_<MODEL>` — GLM 모델별 concurrency limit 오버라이드
 
 ### 로그
 script-based 실행에서는 표준 출력/표준 오류를 현재 셸 또는 호출 스크립트에서 직접 관리한다.
@@ -161,14 +163,15 @@ cd dashboard && npm run build  # Production build → ../assets/dashboard/
 
 ## Board System
 
-- Posts: `.masc/board_posts.jsonl` (JSONL mode)
-- Comments: `.masc/board_comments.jsonl` (JSONL mode)
+- Posts: `.masc/board_posts.jsonl` (JSONL mode) or `masc_board_posts` table (PG mode)
+- Comments: `.masc/board_comments.jsonl` (JSONL mode) or `masc_board_comments` table (PG mode)
 - Sort: Hot / Trending / Recent / Updated / Discussed
 - `updated_at` 필드: vote, comment 시 자동 갱신
 
-### PostgreSQL Mode (Optional)
+### PostgreSQL Mode (Primary)
 
-Board는 JSONL (기본) 또는 PostgreSQL 백엔드를 지원.
+Board는 PostgreSQL (primary) 또는 JSONL (fallback) 백엔드를 지원.
+`MASC_POSTGRES_URL` 설정 시 PG가 자동 선택됨. `MASC_BOARD_BACKEND=jsonl`로 강제 전환 가능.
 
 **설정 방법 (~/.zshenv):**
 ```bash

--- a/config/glm_pool.json
+++ b/config/glm_pool.json
@@ -1,0 +1,12 @@
+{
+  "_comment": "GLM Cloud model pool configuration. Concurrency limits from Z.ai docs.",
+  "models": [
+    { "model_id": "glm-4.5", "concurrency_limit": 10, "description": "High concurrency, general purpose" },
+    { "model_id": "glm-4.6v", "concurrency_limit": 10, "description": "High concurrency, vision-capable" },
+    { "model_id": "glm-5", "concurrency_limit": 5, "description": "Flagship model" },
+    { "model_id": "glm-4.7", "concurrency_limit": 5, "description": "Latest generation" },
+    { "model_id": "glm-4.6", "concurrency_limit": 3, "description": "Balanced performance" },
+    { "model_id": "glm-4.6v-flashx", "concurrency_limit": 3, "description": "Fast variant with vision" },
+    { "model_id": "glm-4.7-flashx", "concurrency_limit": 3, "description": "Fast latest generation" }
+  ]
+}

--- a/lib/board_dispatch.ml
+++ b/lib/board_dispatch.ml
@@ -3,6 +3,11 @@
     Routes Board operations to either JSONL (Board.store) or PostgreSQL (Board_pg.t).
     Backend is selected once at server startup and fixed for the session.
 
+    PG is the primary backend when MASC_POSTGRES_URL is available.
+    JSONL serves as fallback when PG is unavailable or explicitly selected.
+
+    Control: MASC_BOARD_BACKEND env var ("pg" default, "jsonl" to force file-based).
+
     @since 0.6.0
 *)
 
@@ -55,16 +60,24 @@ let init_jsonl () =
 let reset_for_test () =
   backend_state := Uninitialized
 
-(** Get backend or fail *)
+(** Check MASC_BOARD_BACKEND env var. Returns true if JSONL is explicitly forced. *)
+let jsonl_forced () =
+  match Sys.getenv_opt "MASC_BOARD_BACKEND" with
+  | Some s -> String.lowercase_ascii (String.trim s) = "jsonl"
+  | None -> false
+
+(** Get backend or fail.
+    Normal path: Board is initialized by room_utils_backend_setup during server startup.
+    Auto-init: JSONL fallback when startup init was skipped (tests, standalone tools). *)
 let backend () =
   match !backend_state with
   | Active backend -> backend
   | Uninitialized ->
-      (* Auto-init JSONL as safe default *)
+      Log.BoardLog.warn "backend() called before server init, auto-initializing JSONL";
       init_jsonl ();
-      match !backend_state with
-      | Active backend -> backend
-      | Uninitialized -> failwith "[Board_dispatch] init_jsonl failed to activate backend"
+      (match !backend_state with
+       | Active backend -> backend
+       | Uninitialized -> failwith "[Board_dispatch] auto-init failed to activate backend")
 
 (** Get PostgreSQL pool if PG backend is active (for Board_listener) *)
 let get_pg_pool () =

--- a/lib/glm_pool.ml
+++ b/lib/glm_pool.ml
@@ -77,7 +77,18 @@ let load_config_models () : glm_model array option =
       | `Assoc fields -> (
           match List.assoc_opt "models" fields with
           | Some (`List items) ->
-              let models = List.filter_map parse_model_json items in
+              let raw_models = List.filter_map parse_model_json items in
+              (* Reject duplicate model_id entries — pool accounting assumes uniqueness *)
+              let seen = Hashtbl.create (List.length raw_models) in
+              let models = List.filter (fun (m : glm_model) ->
+                if Hashtbl.mem seen m.model_id then begin
+                  Log.Glm_pool.warn "duplicate model_id %s in %s, skipping" m.model_id path;
+                  false
+                end else begin
+                  Hashtbl.replace seen m.model_id ();
+                  true
+                end
+              ) raw_models in
               if models = [] then begin
                 Log.Glm_pool.warn "config %s has no valid models, using hardcoded defaults" path;
                 None

--- a/lib/glm_pool.ml
+++ b/lib/glm_pool.ml
@@ -35,7 +35,9 @@ let parse_model_json (json : Yojson.Safe.t) : glm_model option =
       in
       let get_int key =
         match List.assoc_opt key fields with
-        | Some (`Int n) -> Some n | _ -> None
+        | Some (`Int n) -> Some n
+        | Some (`Float f) -> Some (Float.to_int f)
+        | _ -> None
       in
       (match get_string "model_id", get_int "concurrency_limit" with
        | Some model_id, Some concurrency_limit when concurrency_limit > 0 ->

--- a/lib/glm_pool.ml
+++ b/lib/glm_pool.ml
@@ -3,16 +3,8 @@
     Distributes requests across GLM models with different concurrency limits
     to maximize throughput for MASC social experiments and games.
 
-    Model Concurrency Limits (from Z.ai docs):
-    - GLM-4.5: 10 concurrent
-    - GLM-4.6V: 10 concurrent
-    - GLM-5: 5 concurrent
-    - GLM-4.7: 5 concurrent
-    - GLM-4.6: 3 concurrent
-    - GLM-4.6V-FlashX: 3 concurrent
-    - GLM-4.7-FlashX: 3 concurrent
-    - GLM-4.7-Flash: 1 concurrent
-    - Total: ~39 concurrent calls possible
+    Model configuration loaded from config/glm_pool.json at startup.
+    Falls back to hardcoded defaults if config file is missing or malformed.
 
     @since 2.66.0 *)
 
@@ -22,9 +14,8 @@ type glm_model = {
   description: string;
 }
 
-(** All available GLM Cloud models with default concurrency limits.
-    Ordered by preference (higher concurrency models first for better throughput). *)
-let base_models : glm_model array = [|
+(** Hardcoded fallback models used when config/glm_pool.json is unavailable. *)
+let hardcoded_models : glm_model array = [|
   { model_id = "glm-4.5"; concurrency_limit = 10; description = "High concurrency, general purpose" };
   { model_id = "glm-4.6v"; concurrency_limit = 10; description = "High concurrency, vision-capable" };
   { model_id = "glm-5"; concurrency_limit = 5; description = "Flagship model" };
@@ -32,8 +23,83 @@ let base_models : glm_model array = [|
   { model_id = "glm-4.6"; concurrency_limit = 3; description = "Balanced performance" };
   { model_id = "glm-4.6v-flashx"; concurrency_limit = 3; description = "Fast variant with vision" };
   { model_id = "glm-4.7-flashx"; concurrency_limit = 3; description = "Fast latest generation" };
-  (* glm-4.7-flash has limit 1, excluded from pool for efficiency *)
 |]
+
+(** Parse a single model entry from JSON. Returns None on malformed entries. *)
+let parse_model_json (json : Yojson.Safe.t) : glm_model option =
+  match json with
+  | `Assoc fields ->
+      let get_string key =
+        match List.assoc_opt key fields with
+        | Some (`String s) -> Some s | _ -> None
+      in
+      let get_int key =
+        match List.assoc_opt key fields with
+        | Some (`Int n) -> Some n | _ -> None
+      in
+      (match get_string "model_id", get_int "concurrency_limit" with
+       | Some model_id, Some concurrency_limit when concurrency_limit > 0 ->
+           let description = match get_string "description" with
+             | Some d -> d | None -> ""
+           in
+           Some { model_id; concurrency_limit; description }
+       | _ -> None)
+  | _ -> None
+
+(** Resolve config file path relative to the MASC MCP project root.
+    Priority: DUNE_SOURCEROOT (project root in tests/builds)
+    > MASC_WORKSPACE_ROOT (explicit override) > cwd.
+    ME_ROOT is the parent workspace, not the project root. *)
+let config_file_path () : string =
+  let base =
+    match Sys.getenv_opt "DUNE_SOURCEROOT" with
+    | Some root when String.trim root <> "" -> root
+    | _ -> (
+        match Sys.getenv_opt "MASC_WORKSPACE_ROOT" with
+        | Some root when String.trim root <> "" -> root
+        | _ -> Sys.getcwd ())
+  in
+  Filename.concat base "config/glm_pool.json"
+
+(** Load models from config/glm_pool.json. Returns None on any failure. *)
+let load_config_models () : glm_model array option =
+  let path = config_file_path () in
+  if not (Sys.file_exists path) then begin
+    Log.Glm_pool.info "config not found at %s, using hardcoded defaults" path;
+    None
+  end else
+    try
+      let content = In_channel.with_open_text path In_channel.input_all in
+      let json = Yojson.Safe.from_string content in
+      match json with
+      | `Assoc fields -> (
+          match List.assoc_opt "models" fields with
+          | Some (`List items) ->
+              let models = List.filter_map parse_model_json items in
+              if models = [] then begin
+                Log.Glm_pool.warn "config %s has no valid models, using hardcoded defaults" path;
+                None
+              end else begin
+                let arr = Array.of_list models in
+                Log.Glm_pool.info "loaded %d models from %s" (Array.length arr) path;
+                Some arr
+              end
+          | _ ->
+              Log.Glm_pool.warn "config %s missing 'models' array, using hardcoded defaults" path;
+              None)
+      | _ ->
+          Log.Glm_pool.warn "config %s is not a JSON object, using hardcoded defaults" path;
+          None
+    with exn ->
+      Log.Glm_pool.warn "failed to load config %s: %s, using hardcoded defaults"
+        path (Printexc.to_string exn);
+      None
+
+(** Load models from config file, fall back to hardcoded defaults. *)
+let base_models : glm_model array =
+  match load_config_models () with
+  | Some models -> models
+  | None -> hardcoded_models
 
 let env_key_for_limit (model_id : string) : string =
   let b = Buffer.create (String.length model_id + 24) in

--- a/lib/room_utils_backend_setup.ml
+++ b/lib/room_utils_backend_setup.ml
@@ -292,14 +292,21 @@ let default_config_eio ~sw ~env base_path =
            | Memory _ -> "Memory"
            | FileSystem _ -> "FileSystem"
            | PostgresNative _ -> "PostgresNative");
-        (* Initialize Board backend based on storage type *)
-        (match backend with
-         | PostgresNative pg ->
-             let pool = Backend.PostgresNative.get_pool pg in
-             (match Board_dispatch.init_pg pool with
-              | Ok () -> ()
-              | Error _ -> Board_dispatch.init_jsonl ())
-         | _ -> Board_dispatch.init_jsonl ());
+        (* Initialize Board backend based on storage type.
+           MASC_BOARD_BACKEND env var controls selection:
+           - "pg" (default): use PG when available, JSONL fallback
+           - "jsonl": force JSONL regardless of PG availability *)
+        (if Board_dispatch.jsonl_forced () then begin
+           Log.Backend.info "Board: JSONL forced by MASC_BOARD_BACKEND=jsonl";
+           Board_dispatch.init_jsonl ()
+         end else
+           match backend with
+           | PostgresNative pg ->
+               let pool = Backend.PostgresNative.get_pool pg in
+               (match Board_dispatch.init_pg pool with
+                | Ok () -> ()
+                | Error _ -> Board_dispatch.init_jsonl ())
+           | _ -> Board_dispatch.init_jsonl ());
         backend
     | Error e ->
         Log.Backend.warn "Backend init failed (%s). Falling back to filesystem."

--- a/test/test_board_dispatch.ml
+++ b/test/test_board_dispatch.ml
@@ -184,6 +184,31 @@ let test_invalid_author () =
   | Ok _ -> Alcotest.fail "Expected validation error for empty author"
   | Error _ -> ()
 
+(** {1 MASC_BOARD_BACKEND env var} *)
+
+let test_jsonl_forced_default () =
+  (try Unix.putenv "MASC_BOARD_BACKEND" "" with _ -> ());
+  Alcotest.(check bool) "empty env not forced"
+    false (Board_dispatch.jsonl_forced ())
+
+let test_jsonl_forced_explicit () =
+  Unix.putenv "MASC_BOARD_BACKEND" "jsonl";
+  Alcotest.(check bool) "jsonl is forced"
+    true (Board_dispatch.jsonl_forced ());
+  Unix.putenv "MASC_BOARD_BACKEND" ""
+
+let test_jsonl_forced_pg () =
+  Unix.putenv "MASC_BOARD_BACKEND" "pg";
+  Alcotest.(check bool) "pg is not forced"
+    false (Board_dispatch.jsonl_forced ());
+  Unix.putenv "MASC_BOARD_BACKEND" ""
+
+let test_jsonl_forced_case_insensitive () =
+  Unix.putenv "MASC_BOARD_BACKEND" "JSONL";
+  Alcotest.(check bool) "JSONL uppercase is forced"
+    true (Board_dispatch.jsonl_forced ());
+  Unix.putenv "MASC_BOARD_BACKEND" ""
+
 (** {1 Test Runner} *)
 
 let () =
@@ -215,5 +240,11 @@ let () =
     "validation", [
       Alcotest.test_case "empty content" `Quick (with_eio test_empty_content);
       Alcotest.test_case "invalid author" `Quick (with_eio test_invalid_author);
+    ];
+    "env_control", [
+      Alcotest.test_case "default not forced" `Quick (with_eio test_jsonl_forced_default);
+      Alcotest.test_case "jsonl forced" `Quick (with_eio test_jsonl_forced_explicit);
+      Alcotest.test_case "pg not forced" `Quick (with_eio test_jsonl_forced_pg);
+      Alcotest.test_case "case insensitive" `Quick (with_eio test_jsonl_forced_case_insensitive);
     ];
   ]

--- a/test/test_glm_pool_coverage.ml
+++ b/test/test_glm_pool_coverage.ml
@@ -274,6 +274,15 @@ let test_parse_model_json_no_description () =
   | Some m -> check string "default empty description" "" m.description
   | None -> fail "expected Some"
 
+let test_parse_model_json_float_limit () =
+  let json = `Assoc [
+    ("model_id", `String "x");
+    ("concurrency_limit", `Float 5.0)
+  ] in
+  match Glm_pool.parse_model_json json with
+  | Some m -> check int "float parsed as int" 5 m.concurrency_limit
+  | None -> fail "expected Some for float limit"
+
 let test_hardcoded_models_count () =
   check int "hardcoded has 7 models" 7
     (Array.length Glm_pool.hardcoded_models)
@@ -346,5 +355,6 @@ let () =
       test_case "parse no description" `Quick test_parse_model_json_no_description;
       test_case "hardcoded model count" `Quick test_hardcoded_models_count;
       test_case "hardcoded total capacity" `Quick test_hardcoded_models_total_capacity;
+      test_case "parse float limit" `Quick test_parse_model_json_float_limit;
     ];
   ]

--- a/test/test_glm_pool_coverage.ml
+++ b/test/test_glm_pool_coverage.ml
@@ -236,6 +236,56 @@ let test_select_model_preferring_non_pool () =
   check string "non-pool model passed through" "gpt-4" model
 
 (* ============================================================
+   config loading (parse_model_json, hardcoded_models)
+   ============================================================ *)
+
+let test_parse_model_json_valid () =
+  let json = `Assoc [
+    ("model_id", `String "test-model");
+    ("concurrency_limit", `Int 5);
+    ("description", `String "test")
+  ] in
+  match Glm_pool.parse_model_json json with
+  | Some m ->
+      check string "model_id" "test-model" m.model_id;
+      check int "concurrency_limit" 5 m.concurrency_limit;
+      check string "description" "test" m.description
+  | None -> fail "expected Some"
+
+let test_parse_model_json_missing_fields () =
+  let json = `Assoc [("model_id", `String "x")] in
+  check bool "missing limit returns None" true
+    (Glm_pool.parse_model_json json = None)
+
+let test_parse_model_json_invalid_limit () =
+  let json = `Assoc [
+    ("model_id", `String "x");
+    ("concurrency_limit", `Int 0)
+  ] in
+  check bool "zero limit returns None" true
+    (Glm_pool.parse_model_json json = None)
+
+let test_parse_model_json_no_description () =
+  let json = `Assoc [
+    ("model_id", `String "x");
+    ("concurrency_limit", `Int 3)
+  ] in
+  match Glm_pool.parse_model_json json with
+  | Some m -> check string "default empty description" "" m.description
+  | None -> fail "expected Some"
+
+let test_hardcoded_models_count () =
+  check int "hardcoded has 7 models" 7
+    (Array.length Glm_pool.hardcoded_models)
+
+let test_hardcoded_models_total_capacity () =
+  let cap = Array.fold_left
+    (fun acc (m : Glm_pool.glm_model) -> acc + m.concurrency_limit) 0
+    Glm_pool.hardcoded_models
+  in
+  check int "hardcoded total is 39" 39 cap
+
+(* ============================================================
    Test Runner
    ============================================================ *)
 
@@ -288,5 +338,13 @@ let () =
       test_case "uses preferred" `Quick test_select_model_preferring_available;
       test_case "fallback at capacity" `Quick test_select_model_preferring_at_capacity;
       test_case "non-pool passthrough" `Quick test_select_model_preferring_non_pool;
+    ];
+    "config_loading", [
+      test_case "parse valid JSON model" `Quick test_parse_model_json_valid;
+      test_case "parse missing fields" `Quick test_parse_model_json_missing_fields;
+      test_case "parse invalid limit" `Quick test_parse_model_json_invalid_limit;
+      test_case "parse no description" `Quick test_parse_model_json_no_description;
+      test_case "hardcoded model count" `Quick test_hardcoded_models_count;
+      test_case "hardcoded total capacity" `Quick test_hardcoded_models_total_capacity;
     ];
   ]


### PR DESCRIPTION
## Summary

- **#1270 glm_pool simplification**: Externalize 7 hardcoded model IDs to `config/glm_pool.json`. JSON config loaded at startup with hardcoded fallback on parse failure. Path resolves via `DUNE_SOURCEROOT` > `MASC_WORKSPACE_ROOT` > cwd.
- **#1007 Board PG primary**: Add `MASC_BOARD_BACKEND` env var (default `"pg"`). PG is now the primary backend when `MASC_POSTGRES_URL` is available. `MASC_BOARD_BACKEND=jsonl` forces file-based mode. Auto-init fallback logs a warning.
- **#603 llama.cpp variants**: Closed — resolved by PR #818 (multi-instance support) and Qwen3.5 benchmarking.

## Changes

| File | Change |
|------|--------|
| `config/glm_pool.json` | New config file with 7 GLM model definitions |
| `lib/glm_pool.ml` | JSON config loading + hardcoded fallback + `parse_model_json` export |
| `lib/board_dispatch.ml` | `jsonl_forced()` function + improved auto-init with warning log |
| `lib/room_utils_backend_setup.ml` | `MASC_BOARD_BACKEND` env var check in Board init |
| `test/test_glm_pool_coverage.ml` | +6 tests for config parsing |
| `test/test_board_dispatch.ml` | +4 tests for env var control |
| `CLAUDE.md` | Updated Board docs (PG primary) + new env vars |

## Test plan

- [x] `dune build` passes
- [x] `test_glm_pool_coverage` — 34/34 pass (including 6 new config_loading tests)
- [x] `test_board_dispatch` — 20/20 pass (including 4 new env_control tests)
- [x] Full `dune test` — 1 pre-existing flaky Eio test (unrelated)
- [ ] GLM-5 external review

Closes #1270, closes #1007. #603 already closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)