### PR TITLE
fix(swarm): narrow catch-all exception handlers in code_swarm_plan

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -1,7 +1,7 @@
 (lang dune 3.13)
 
 (name masc_mcp)
-(version 2.102.0)
+(version 2.102.1)
 
 (generate_opam_files true)
 

--- a/lib/code_swarm_plan.ml
+++ b/lib/code_swarm_plan.ml
@@ -274,13 +274,23 @@ let get_worker_diff ~base_path (worker : worker_plan) =
       [ "git"; "-C"; worktree_path; "diff"; "--stat"; "HEAD~1..HEAD" ]
     in
     let stat =
-      try Process_eio.run_argv ~timeout_sec:15.0 argv with _ -> ""
+      try Process_eio.run_argv ~timeout_sec:15.0 argv
+      with
+      | Eio.Io _ | Unix.Unix_error _ | Failure _ as exn ->
+        Eio.traceln "code_swarm_plan: git diff --stat failed: %s"
+          (Printexc.to_string exn);
+        ""
     in
     let argv_full =
       [ "git"; "-C"; worktree_path; "diff"; "HEAD~1..HEAD" ]
     in
     let diff =
-      try Process_eio.run_argv ~timeout_sec:15.0 argv_full with _ -> ""
+      try Process_eio.run_argv ~timeout_sec:15.0 argv_full
+      with
+      | Eio.Io _ | Unix.Unix_error _ | Failure _ as exn ->
+        Eio.traceln "code_swarm_plan: git diff failed: %s"
+          (Printexc.to_string exn);
+        ""
     in
     let changed =
       stat |> String.split_on_char '\n'
@@ -491,7 +501,12 @@ let merge_workers ~base_path ~plan_id ~strategy ~auto_pr ~build_verify
                     try
                       String.trim
                         (Process_eio.run_argv ~timeout_sec:10.0 commit_argv)
-                    with _ -> worker.worktree_branch
+                    with
+                    | Eio.Io _ | Unix.Unix_error _ | Failure _ as exn ->
+                      Eio.traceln
+                        "code_swarm_plan: git rev-parse failed for %s: %s"
+                        worker.worker_id (Printexc.to_string exn);
+                      worker.worktree_branch
                   in
                   [ "git"; "-C"; base_path; "cherry-pick"; commit ]
             in


### PR DESCRIPTION
## Summary
- Narrow 3 `with _ ->` catch-all handlers in `code_swarm_plan.ml` to specific exceptions (`Eio.Io _ | Unix.Unix_error _ | Failure _`)
- Add `Eio.traceln` logging when exceptions are caught (previously silent)
- Prevents `Out_of_memory`, `Stack_overflow`, and `Eio.Cancel.Cancelled` from being silently swallowed

## Test plan
- [x] `dune build` passes
- [ ] Verify git diff operations in code swarm still work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)