### PR TITLE
fix(test): team_session hang — add Time_compat.set_clock (#1320)

### DIFF
--- a/test/test_tool_team_session_flow.ml
+++ b/test/test_tool_team_session_flow.ml
@@ -3,6 +3,7 @@ open Test_tool_team_session_support
 
 let test_recover_orphan_session () =
   Eio_main.run @@ fun env ->
+  Time_compat.set_clock (Eio.Stdenv.clock env);
   Eio.Switch.run @@ fun sw ->
   let base_dir = temp_dir () in
   let config = Room.default_config base_dir in
@@ -105,6 +106,7 @@ let test_read_events_limit () =
 
 let test_list_and_compare () =
   Eio_main.run @@ fun env ->
+  Time_compat.set_clock (Eio.Stdenv.clock env);
   Eio.Switch.run @@ fun sw ->
   let base_dir = temp_dir () in
   let config = Room.default_config base_dir in
@@ -171,6 +173,7 @@ let test_list_and_compare () =
 
 let test_turn_events_and_prove () =
   Eio_main.run @@ fun env ->
+  Time_compat.set_clock (Eio.Stdenv.clock env);
   Eio.Switch.run @@ fun sw ->
   let base_dir = temp_dir () in
   let config = Room.default_config base_dir in
@@ -305,6 +308,7 @@ let test_turn_events_and_prove () =
 
 let test_step_plain_turn_matches_legacy_turn () =
   Eio_main.run @@ fun env ->
+  Time_compat.set_clock (Eio.Stdenv.clock env);
   Eio.Switch.run @@ fun sw ->
   let base_dir = temp_dir () in
   let config = Room.default_config base_dir in

--- a/test/test_tool_team_session_lifecycle.ml
+++ b/test/test_tool_team_session_lifecycle.ml
@@ -3,6 +3,7 @@ open Test_tool_team_session_support
 
 let test_start_status_report_stop () =
   Eio_main.run @@ fun env ->
+  Time_compat.set_clock (Eio.Stdenv.clock env);
   Eio.Switch.run @@ fun sw ->
   let base_dir = temp_dir () in
   let config = Room.default_config base_dir in
@@ -103,6 +104,7 @@ let test_start_status_report_stop () =
 
 let test_start_attached_operation_session () =
   Eio_main.run @@ fun env ->
+  Time_compat.set_clock (Eio.Stdenv.clock env);
   Eio.Switch.run @@ fun sw ->
   let base_dir = temp_dir () in
   let config = Room.default_config base_dir in
@@ -300,6 +302,7 @@ let test_start_attached_operation_session () =
 
 let test_duration_reached_path () =
   Eio_main.run @@ fun env ->
+  Time_compat.set_clock (Eio.Stdenv.clock env);
   Eio.Switch.run @@ fun sw ->
   let base_dir = temp_dir () in
   let config = Room.default_config base_dir in
@@ -326,6 +329,7 @@ let test_duration_reached_path () =
 
 let test_recover_elapsed_session () =
   Eio_main.run @@ fun env ->
+  Time_compat.set_clock (Eio.Stdenv.clock env);
   Eio.Switch.run @@ fun sw ->
   let base_dir = temp_dir () in
   let config = Room.default_config base_dir in

--- a/test/test_tool_team_session_misc.ml
+++ b/test/test_tool_team_session_misc.ml
@@ -3,6 +3,7 @@ open Test_tool_team_session_support
 
 let test_prove_strong_requires_additional_evidence () =
   Eio_main.run @@ fun env ->
+  Time_compat.set_clock (Eio.Stdenv.clock env);
   Eio.Switch.run @@ fun sw ->
   let base_dir = temp_dir () in
   let config = Room.default_config base_dir in
@@ -51,6 +52,7 @@ let test_prove_strong_requires_additional_evidence () =
 
 let test_dispatch_unknown () =
   Eio_main.run @@ fun env ->
+  Time_compat.set_clock (Eio.Stdenv.clock env);
   Eio.Switch.run @@ fun sw ->
   let base_dir = temp_dir () in
   let config = Room.default_config base_dir in
@@ -66,6 +68,7 @@ let test_dispatch_unknown () =
 
 let test_unauthorized_session_access () =
   Eio_main.run @@ fun env ->
+  Time_compat.set_clock (Eio.Stdenv.clock env);
   Eio.Switch.run @@ fun sw ->
   let base_dir = temp_dir () in
   let config = Room.default_config base_dir in
@@ -161,6 +164,7 @@ let test_unauthorized_session_access () =
 
 let test_final_done_delta_snapshot_stable () =
   Eio_main.run @@ fun env ->
+  Time_compat.set_clock (Eio.Stdenv.clock env);
   Eio.Switch.run @@ fun sw ->
   let base_dir = temp_dir () in
   let config = Room.default_config base_dir in
@@ -233,6 +237,7 @@ let test_final_done_delta_snapshot_stable () =
 
 let test_verify_trace_uses_worker_run_raw_trace () =
   Eio_main.run @@ fun env ->
+  Time_compat.set_clock (Eio.Stdenv.clock env);
   Eio.Switch.run @@ fun sw ->
   let base_dir = temp_dir () in
   let config = Room.default_config base_dir in
@@ -281,6 +286,7 @@ let test_verify_trace_uses_worker_run_raw_trace () =
 
 let test_verify_trace_reports_summary_only_without_checkpoint () =
   Eio_main.run @@ fun env ->
+  Time_compat.set_clock (Eio.Stdenv.clock env);
   Eio.Switch.run @@ fun sw ->
   let base_dir = temp_dir () in
   let config = Room.default_config base_dir in
@@ -319,6 +325,7 @@ let test_verify_trace_reports_summary_only_without_checkpoint () =
 
 let test_verify_trace_reports_summary_only_when_direct_evidence_missing () =
   Eio_main.run @@ fun env ->
+  Time_compat.set_clock (Eio.Stdenv.clock env);
   Eio.Switch.run @@ fun sw ->
   let base_dir = temp_dir () in
   let config = Room.default_config base_dir in
@@ -358,6 +365,7 @@ let test_verify_trace_reports_summary_only_when_direct_evidence_missing () =
 
 let test_delegate_rejects_not_ready_worker_with_guidance () =
   Eio_main.run @@ fun env ->
+  Time_compat.set_clock (Eio.Stdenv.clock env);
   Eio.Switch.run @@ fun sw ->
   let base_dir = temp_dir () in
   let config = Room.default_config base_dir in


### PR DESCRIPTION
## Summary

- team_session 테스트가 test 13부터 무한 hang (CI에서 435초 후 timeout)
- 원인: `Eio_main.run` 후 `Time_compat.set_clock` 미호출 → `Time_compat.sleep`이 `Unix.sleepf` (blocking) 사용
- `with_file_lock` retry 루프에서 Eio 스케줄러가 차단됨

## Changes

3파일 16곳에 `Time_compat.set_clock (Eio.Stdenv.clock env);` 삽입:
- `test_tool_team_session_lifecycle.ml` (4곳)
- `test_tool_team_session_flow.ml` (4곳)
- `test_tool_team_session_misc.ml` (8곳)

## Test plan
- [x] `dune build` 성공
- [ ] CI team_session tests 통과 확인

Closes #1320