### PR TITLE
fix(rc1): eliminate remaining Yojson.Safe.from_file blocking I/O

### DIFF
--- a/lib/code_swarm_plan.ml
+++ b/lib/code_swarm_plan.ml
@@ -122,7 +122,7 @@ let load_plan base_path plan_id : (swarm_plan, string) result =
   if not (Sys.file_exists path) then Error (sprintf "Plan not found: %s" plan_id)
   else
     try
-      let json = Yojson.Safe.from_file path in
+      let json = Safe_ops.read_json_eio path in
       let open Yojson.Safe.Util in
       let workers =
         json |> member "workers" |> to_list

--- a/lib/cp_search_fabric.ml
+++ b/lib/cp_search_fabric.ml
@@ -151,7 +151,7 @@ let load_store path : stats_store =
           | _ -> default_store)
       | `List rows -> List.filter_map stats_entry_of_json rows
       | _ -> default_store
-    with Yojson.Json_error _ | Sys_error _ -> default_store
+    with Yojson.Json_error _ | Sys_error _ | Eio.Io _ -> default_store
 
 let save_store path (store : stats_store) =
   ensure_dir (Filename.dirname path);

--- a/lib/cp_search_fabric.ml
+++ b/lib/cp_search_fabric.ml
@@ -144,7 +144,7 @@ let load_store path : stats_store =
     default_store
   else
     try
-      match Yojson.Safe.from_file path with
+      match Safe_ops.read_json_eio path with
       | `Assoc fields -> (
           match List.assoc_opt "entries" fields with
           | Some (`List rows) -> List.filter_map stats_entry_of_json rows

--- a/lib/local_agent_eio_container.ml
+++ b/lib/local_agent_eio_container.ml
@@ -280,7 +280,7 @@ let load_worker_meta ~base_path ~team_session_id ~worker_name =
   let path = worker_meta_path ~base_path ~team_session_id ~worker_name in
   if Sys.file_exists path then
     try
-      Yojson.Safe.from_file path |> worker_meta_of_yojson
+      Safe_ops.read_json_eio path |> worker_meta_of_yojson
     with Yojson.Json_error _ | Sys_error _ -> None
   else
     None

--- a/lib/local_agent_eio_container.ml
+++ b/lib/local_agent_eio_container.ml
@@ -281,7 +281,7 @@ let load_worker_meta ~base_path ~team_session_id ~worker_name =
   if Sys.file_exists path then
     try
       Safe_ops.read_json_eio path |> worker_meta_of_yojson
-    with Yojson.Json_error _ | Sys_error _ -> None
+    with Yojson.Json_error _ | Sys_error _ | Eio.Io _ -> None
   else
     None
 

--- a/lib/tool_command_plane_support.ml
+++ b/lib/tool_command_plane_support.ml
@@ -111,7 +111,7 @@ let json_string_member_opt json key =
 
 let read_json_file_opt path =
   if Sys.file_exists path then
-    Some (Yojson.Safe.from_file path)
+    (try Some (Safe_ops.read_json_eio path) with _ -> None)
   else
     None
 

--- a/lib/transport_grpc_next.ml
+++ b/lib/transport_grpc_next.ml
@@ -406,7 +406,7 @@ let plan_path config task_id =
 let read_plan config task_id =
   let path = plan_path config task_id in
   if Sys.file_exists path then
-    match Yojson.Safe.from_file path with
+    match Safe_ops.read_json_eio path with
     | json -> Some json
     | exception e ->
       Eio.traceln "[WARN] Failed to read plan %s: %s" path (Printexc.to_string e);

--- a/lib/trpg_bdi.ml
+++ b/lib/trpg_bdi.ml
@@ -241,7 +241,7 @@ let bdi_path ~room_dir ~actor_id =
 let load ~room_dir ~actor_id =
   let path = bdi_path ~room_dir ~actor_id in
   try
-    let json = Yojson.Safe.from_file path in
+    let json = Safe_ops.read_json_eio path in
     match of_yojson json with
     | Ok st -> st
     | Error _e -> empty ~actor_id

--- a/lib/trpg_preset_store.ml
+++ b/lib/trpg_preset_store.ml
@@ -468,7 +468,7 @@ let find_skill catalog ~id =
 let load_json_list path parse fallback =
   if Sys.file_exists path then
     try
-      let json = Yojson.Safe.from_file path in
+      let json = Safe_ops.read_json_eio path in
       let items = json |> to_list |> List.map parse in
       Ok items
     with exn -> Error (Printf.sprintf "failed to parse %s: %s" path (Printexc.to_string exn))
@@ -545,7 +545,7 @@ let load_scenario_world_presets ~base_dir : world_preset list =
        |> List.filter_map (fun file_name ->
             let path = Filename.concat scenarios_dir file_name in
             try
-              Yojson.Safe.from_file path |> parse_scenario_world_preset
+              Safe_ops.read_json_eio path |> parse_scenario_world_preset
             with exn ->
               Log.Trpg.warn "trpg_preset_store: scenario preset parse failed for %s: %s" path (Printexc.to_string exn);
               None)

--- a/lib/trpg_store.ml
+++ b/lib/trpg_store.ml
@@ -43,7 +43,7 @@ let load_world_contracts_from_dir ~base_dir : Yojson.Safe.t =
   let path = world_contracts_path ~base_dir in
   if not (Sys.file_exists path) then `Null
   else
-    match Yojson.Safe.from_file path with
+    match Safe_ops.read_json_eio path with
     | exception _ -> `Null
     | json -> json
 

--- a/lib/verification.ml
+++ b/lib/verification.ml
@@ -290,7 +290,7 @@ let load_request base_path req_id =
   let path = request_path base_path req_id in
   if Sys.file_exists path then
     try
-      let json = Yojson.Safe.from_file path in
+      let json = Safe_ops.read_json_eio path in
       request_of_yojson json
     with exn ->
       Error (Printf.sprintf "Failed to load verification %s: %s" req_id (Printexc.to_string exn))

--- a/lib/voice_config.ml
+++ b/lib/voice_config.ml
@@ -295,7 +295,7 @@ let load () =
     Error (Printf.sprintf "voice config missing at %s" path)
   else
     try
-      let json = Yojson.Safe.from_file path in
+      let json = Safe_ops.read_json_eio path in
       let open Result in
       let* tts = parse_tts json in
       let* stt = parse_stt json in

--- a/lib/voice_config.ml
+++ b/lib/voice_config.ml
@@ -307,6 +307,8 @@ let load () =
         Error (Printf.sprintf "invalid voice config json: %s" error)
     | Sys_error error ->
         Error (Printf.sprintf "voice config read failed: %s" error)
+    | Eio.Io _ as exn ->
+        Error (Printf.sprintf "voice config Eio read failed: %s" (Printexc.to_string exn))
 
 let enabled_endpoints (endpoints : endpoint list) =
   List.filter (fun (endpoint : endpoint) -> endpoint.enabled) endpoints


### PR DESCRIPTION
## Summary
- RC-1 (Blocking I/O in Eio fibers) 잔여 수정 완료
- 11개 `Yojson.Safe.from_file` 호출을 `Safe_ops.read_json_eio`로 변환
- 변환 후 활성 `.ml` 파일에 `from_file` 호출 0건

## 배경
기존 Train 2에서 HIGH 우선순위 파일(sentinel, worker_container, transport_grpc_next:343)은 이미 변환됨.
이 PR은 잔여 11개 호출을 제거하여 RC-1을 완전히 해소.

## 변경 파일 (우선순위순)

**HIGH (Eio fiber 내 직접 호출)**:
- `transport_grpc_next.ml:409` — gRPC handler에서 plan 읽기
- `local_agent_eio_container.ml:283` — team session fiber에서 worker meta 읽기
- `tool_command_plane_support.ml:114` — MCP tool handler에서 JSON 읽기

**MEDIUM**:
- `verification.ml:293`, `code_swarm_plan.ml:125`, `cp_search_fabric.ml:147`

**LOW (TRPG/Voice)**:
- `voice_config.ml:298`, `trpg_preset_store.ml:471,548`, `trpg_store.ml:46`, `trpg_bdi.ml:244`

## 원리
`Safe_ops.read_json_eio`는 `Fs_compat.load_file` (Eio-native) → `Yojson.Safe.from_string` 패턴.
Eio scheduler를 block하지 않아 동시 fiber 간 `Eio__core__Fiber.Not_first` cancel을 방지.

## Test plan
- [x] `dune build --root .` 통과 (exit 0)
- [x] 실패 테스트는 pre-existing (social_stderr, operator, source_priority — 변경 파일과 무관)
- [ ] PG 모드 서버 기동 후 "Failed to read" WARN 0건, Eio Cancelled 0건 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)