### PR TITLE
feat: Phase 5 validation + SDK — swarm envelope, keeper AG-UI (#991, #897)

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -471,6 +471,7 @@
    backoff
    shutdown
    supervisor
+   keeper_chat_ag_ui
    audit_log
    build_identity
   voice_config

--- a/lib/keeper_chat_ag_ui.ml
+++ b/lib/keeper_chat_ag_ui.ml
@@ -1,0 +1,128 @@
+(** Keeper Chat AG-UI Bridge — SDK-aligned token streaming
+
+    Translates keeper chat interactions to AG-UI protocol events.
+    Enables SDK consumers (CopilotKit, custom UIs) to receive
+    keeper responses as standard TEXT_MESSAGE_CONTENT delta events.
+
+    Event sequence for a keeper chat turn:
+    1. RUN_STARTED (thread=keeper_name)
+    2. TEXT_MESSAGE_START (role=assistant, message_id=unique)
+    3. TEXT_MESSAGE_CONTENT* (delta=chunk) — one per streaming chunk
+    4. TEXT_MESSAGE_END
+    5. RUN_FINISHED
+
+    @since 2.102.0 *)
+
+(** {1 Session State} *)
+
+type chat_session = {
+  keeper_name : string;
+  thread_id : string;
+  run_id : string;
+  mutable message_seq : int;
+}
+
+let session_counter = ref 0
+
+let make_session ~keeper_name =
+  incr session_counter;
+  let run_id = Printf.sprintf "keeper-%s-%d-%d"
+    keeper_name (int_of_float (Time_compat.now () *. 1000.0)) !session_counter in
+  let thread_id = Printf.sprintf "keeper-chat-%s" keeper_name in
+  { keeper_name; thread_id; run_id; message_seq = 0 }
+
+let next_message_id session =
+  session.message_seq <- session.message_seq + 1;
+  Printf.sprintf "%s-msg-%d" session.run_id session.message_seq
+
+(** {1 AG-UI Event Generators} *)
+
+let event_run_started session : Ag_ui.event =
+  Ag_ui.make_event
+    ~thread_id:session.thread_id
+    ~run_id:(Some session.run_id)
+    Ag_ui.Run_started
+
+let event_text_start session : string * Ag_ui.event =
+  let msg_id = next_message_id session in
+  msg_id,
+  Ag_ui.make_event
+    ~thread_id:session.thread_id
+    ~run_id:(Some session.run_id)
+    ~message_id:(Some msg_id)
+    ~role:(Some Ag_ui.Assistant)
+    Ag_ui.Text_message_start
+
+let event_text_delta session ~message_id ~delta : Ag_ui.event =
+  Ag_ui.make_event
+    ~thread_id:session.thread_id
+    ~run_id:(Some session.run_id)
+    ~message_id:(Some message_id)
+    ~delta:(Some delta)
+    Ag_ui.Text_message_content
+
+let event_text_end session ~message_id : Ag_ui.event =
+  Ag_ui.make_event
+    ~thread_id:session.thread_id
+    ~run_id:(Some session.run_id)
+    ~message_id:(Some message_id)
+    Ag_ui.Text_message_end
+
+let event_run_finished session : Ag_ui.event =
+  Ag_ui.make_event
+    ~thread_id:session.thread_id
+    ~run_id:(Some session.run_id)
+    Ag_ui.Run_finished
+
+let event_run_error session ~error : Ag_ui.event =
+  Ag_ui.make_event
+    ~thread_id:session.thread_id
+    ~run_id:(Some session.run_id)
+    ~custom_name:(Some "error")
+    ~custom_value:(Some (`Assoc [("message", `String error)]))
+    Ag_ui.Run_error
+
+(** {1 Streaming Adapter}
+
+    Converts a keeper response (full text) into a sequence of AG-UI events.
+    For post-assembly chunking (current backend), splits the response into
+    fixed-size chunks and emits TEXT_MESSAGE_CONTENT events.
+
+    When native provider streaming is available, this adapter should be
+    replaced with direct delta forwarding from llm_client. *)
+
+let chunk_size = 64  (* characters per chunk *)
+
+let events_for_response session ~response : Ag_ui.event list =
+  let msg_id, start_event = event_text_start session in
+  let chunks =
+    let len = String.length response in
+    let rec split pos acc =
+      if pos >= len then List.rev acc
+      else
+        let end_pos = min (pos + chunk_size) len in
+        let chunk = String.sub response pos (end_pos - pos) in
+        split end_pos (chunk :: acc)
+    in
+    split 0 []
+  in
+  let delta_events = List.map (fun delta ->
+    event_text_delta session ~message_id:msg_id ~delta
+  ) chunks in
+  [event_run_started session; start_event]
+  @ delta_events
+  @ [event_text_end session ~message_id:msg_id;
+     event_run_finished session]
+
+(** Emit events as SSE data lines. *)
+let sse_for_response session ~response : string =
+  let events = events_for_response session ~response in
+  String.concat "" (List.map Ag_ui.event_to_sse events)
+
+(** Emit error as SSE. *)
+let sse_for_error session ~error : string =
+  let events = [
+    event_run_started session;
+    event_run_error session ~error;
+  ] in
+  String.concat "" (List.map Ag_ui.event_to_sse events)

--- a/lib/keeper_chat_ag_ui.ml
+++ b/lib/keeper_chat_ag_ui.ml
@@ -91,7 +91,19 @@ let event_run_error session ~error : Ag_ui.event =
     When native provider streaming is available, this adapter should be
     replaced with direct delta forwarding from llm_client. *)
 
-let chunk_size = 64  (* characters per chunk *)
+let chunk_size = 64  (* target bytes per chunk *)
+
+(** Advance [pos] to the next UTF-8 character boundary at or after [pos].
+    UTF-8 continuation bytes have the form 10xxxxxx (0x80..0xBF). *)
+let utf8_safe_boundary s pos =
+  let len = String.length s in
+  if pos >= len then len
+  else
+    let p = ref pos in
+    while !p < len && Char.code (String.get s !p) land 0xC0 = 0x80 do
+      incr p
+    done;
+    !p
 
 let events_for_response session ~response : Ag_ui.event list =
   let msg_id, start_event = event_text_start session in
@@ -100,7 +112,7 @@ let events_for_response session ~response : Ag_ui.event list =
     let rec split pos acc =
       if pos >= len then List.rev acc
       else
-        let end_pos = min (pos + chunk_size) len in
+        let end_pos = utf8_safe_boundary response (min (pos + chunk_size) len) in
         let chunk = String.sub response pos (end_pos - pos) in
         split end_pos (chunk :: acc)
     in

--- a/lib/masc_mcp.ml
+++ b/lib/masc_mcp.ml
@@ -125,6 +125,7 @@ module Backoff = Backoff
 module Server_checkpoint = Server_checkpoint
 module Shutdown = Shutdown
 module Supervisor = Supervisor
+module Keeper_chat_ag_ui = Keeper_chat_ag_ui
 module Mind_eio = Mind_eio
 module Noosphere_eio = Noosphere_eio
 module Metrics_store_eio = Metrics_store_eio

--- a/lib/message_schema.ml
+++ b/lib/message_schema.ml
@@ -235,6 +235,94 @@ let json_schema =
     ]);
   ]
 
+(** {1 Swarm Message Envelope — #991}
+
+    Wraps structured_message with sender/timestamp metadata for swarm channels.
+    Rejects malformed envelopes at the boundary. *)
+
+type swarm_envelope = {
+  sender : string;
+  timestamp : float;
+  sequence : int;
+  channel : string;  (** e.g. "broadcast", "direct", "swarm" *)
+  message : structured_message;
+}
+[@@deriving show, eq]
+
+let envelope_to_json (e : swarm_envelope) : Yojson.Safe.t =
+  `Assoc [
+    ("sender", `String e.sender);
+    ("timestamp", `Float e.timestamp);
+    ("sequence", `Int e.sequence);
+    ("channel", `String e.channel);
+    ("message", to_json e.message);
+  ]
+
+let envelope_of_json (json : Yojson.Safe.t) : (swarm_envelope, string) result =
+  match json with
+  | `Assoc fields ->
+      let sender = match List.assoc_opt "sender" fields with
+        | Some (`String s) when String.trim s <> "" -> Ok s
+        | Some (`String _) -> Error "envelope: sender cannot be empty"
+        | _ -> Error "envelope: missing or invalid 'sender' (string)"
+      in
+      let timestamp = match List.assoc_opt "timestamp" fields with
+        | Some (`Float f) -> Ok f
+        | Some (`Int n) -> Ok (float_of_int n)
+        | _ -> Error "envelope: missing or invalid 'timestamp' (number)"
+      in
+      let sequence = match List.assoc_opt "sequence" fields with
+        | Some (`Int n) when n >= 0 -> Ok n
+        | _ -> Error "envelope: missing or invalid 'sequence' (non-negative int)"
+      in
+      let channel = match List.assoc_opt "channel" fields with
+        | Some (`String s) when String.trim s <> "" -> Ok s
+        | _ -> Error "envelope: missing or invalid 'channel' (string)"
+      in
+      let message = match List.assoc_opt "message" fields with
+        | Some msg_json -> of_json msg_json
+        | None -> Error "envelope: missing 'message' field"
+      in
+      (match sender, timestamp, sequence, channel, message with
+       | Ok sender, Ok timestamp, Ok sequence, Ok channel, Ok message ->
+           Ok { sender; timestamp; sequence; channel; message }
+       | Error e, _, _, _, _ | _, Error e, _, _, _
+       | _, _, Error e, _, _ | _, _, _, Error e, _
+       | _, _, _, _, Error e -> Error e)
+  | _ -> Error "envelope: expected JSON object"
+
+(** Validate a raw JSON string as a swarm envelope.
+    In Strict mode, rejects invalid envelopes.
+    In Permissive mode, wraps invalid content as a Freeform envelope. *)
+let validate_envelope ?(mode=Permissive) raw_json =
+  match Yojson.Safe.from_string raw_json with
+  | json ->
+      (match envelope_of_json json with
+       | Ok envelope -> Ok envelope
+       | Error reason ->
+           match mode with
+           | Strict -> Error (Printf.sprintf "Envelope validation failed: %s" reason)
+           | Warn ->
+               Log.Session.warn "[MessageSchema] envelope warn: %s" reason;
+               Ok { sender = "unknown"; timestamp = Time_compat.now ();
+                    sequence = 0; channel = "freeform";
+                    message = Freeform raw_json }
+           | Permissive ->
+               Ok { sender = "unknown"; timestamp = Time_compat.now ();
+                    sequence = 0; channel = "freeform";
+                    message = Freeform raw_json })
+  | exception _ ->
+      match mode with
+      | Strict -> Error "Envelope must be valid JSON in strict mode"
+      | _ ->
+          Ok { sender = "unknown"; timestamp = Time_compat.now ();
+               sequence = 0; channel = "freeform";
+               message = Freeform raw_json }
+
 let roundtrip msg =
   let json = to_json msg in
   of_json json
+
+let roundtrip_envelope env =
+  let json = envelope_to_json env in
+  envelope_of_json json

--- a/lib/message_schema.mli
+++ b/lib/message_schema.mli
@@ -21,3 +21,18 @@ val message_type_string : structured_message -> string
 val is_targeted_at : string -> structured_message -> bool
 val json_schema : Yojson.Safe.t
 val roundtrip : structured_message -> (structured_message, string) result
+
+(** {1 Swarm Message Envelope} *)
+
+type swarm_envelope = {
+  sender : string;
+  timestamp : float;
+  sequence : int;
+  channel : string;
+  message : structured_message;
+}
+
+val envelope_to_json : swarm_envelope -> Yojson.Safe.t
+val envelope_of_json : Yojson.Safe.t -> (swarm_envelope, string) result
+val validate_envelope : ?mode:validation_mode -> string -> (swarm_envelope, string) result
+val roundtrip_envelope : swarm_envelope -> (swarm_envelope, string) result

--- a/masc_mcp.opam
+++ b/masc_mcp.opam
@@ -14,7 +14,6 @@ depends: [
   "ocaml" {>= "5.1"}
   "dune" {>= "3.13" & >= "3.13"}
   "mcp_protocol" {>= "0.13.0"}
-  "ocaml-webrtc" {>= "0.2.3"}
   "grpc-direct-core" {>= "0.1.0"}
   "grpc-direct" {>= "0.1.0"}
   "yojson" {>= "2.0"}

--- a/masc_mcp.opam
+++ b/masc_mcp.opam
@@ -14,6 +14,7 @@ depends: [
   "ocaml" {>= "5.1"}
   "dune" {>= "3.13" & >= "3.13"}
   "mcp_protocol" {>= "0.13.0"}
+  "ocaml-webrtc" {>= "0.2.3"}
   "grpc-direct-core" {>= "0.1.0"}
   "grpc-direct" {>= "0.1.0"}
   "yojson" {>= "2.0"}

--- a/test/dune
+++ b/test/dune
@@ -1017,3 +1017,9 @@
  (name test_lifecycle)
  (modules test_lifecycle)
  (libraries masc_mcp eio eio_main yojson unix))
+
+; Phase 5: Validation + SDK tests
+(test
+ (name test_phase5_validation)
+ (modules test_phase5_validation)
+ (libraries masc_mcp eio eio_main str yojson))

--- a/test/test_phase5_validation.ml
+++ b/test/test_phase5_validation.ml
@@ -1,0 +1,174 @@
+(** Test Phase 5: Swarm envelope validation + Keeper chat AG-UI bridge *)
+
+open Masc_mcp
+
+let passed = ref 0
+let failed = ref 0
+
+let test name fn =
+  try fn (); incr passed; Printf.printf "  PASS  %s\n%!" name
+  with e -> incr failed; Printf.printf "  FAIL  %s: %s\n%!" name (Printexc.to_string e)
+
+(* ══════════════════════════════════════════════════════════════
+   #991 — Swarm envelope validation
+   ══════════════════════════════════════════════════════════════ *)
+
+let () = test "envelope round-trip" (fun () ->
+  let env : Message_schema.swarm_envelope = {
+    sender = "claude";
+    timestamp = 1700000000.0;
+    sequence = 42;
+    channel = "broadcast";
+    message = Message_schema.TaskUpdate {
+      task_id = "task-1"; status = "done"; payload = None };
+  } in
+  match Message_schema.roundtrip_envelope env with
+  | Ok env2 ->
+      assert (env2.sender = "claude");
+      assert (env2.sequence = 42);
+      assert (env2.channel = "broadcast");
+      assert (Message_schema.message_type_string env2.message = "task_update")
+  | Error e -> failwith e
+)
+
+let () = test "envelope rejects empty sender" (fun () ->
+  let json = `Assoc [
+    ("sender", `String "");
+    ("timestamp", `Float 1.0);
+    ("sequence", `Int 0);
+    ("channel", `String "broadcast");
+    ("message", `Assoc [("type", `String "freeform"); ("text", `String "hi")]);
+  ] in
+  match Message_schema.envelope_of_json json with
+  | Error msg -> assert (String.length msg > 0)
+  | Ok _ -> failwith "expected error for empty sender"
+)
+
+let () = test "envelope rejects negative sequence" (fun () ->
+  let json = `Assoc [
+    ("sender", `String "agent");
+    ("timestamp", `Float 1.0);
+    ("sequence", `Int (-1));
+    ("channel", `String "broadcast");
+    ("message", `Assoc [("type", `String "freeform"); ("text", `String "hi")]);
+  ] in
+  match Message_schema.envelope_of_json json with
+  | Error _ -> ()
+  | Ok _ -> failwith "expected error for negative sequence"
+)
+
+let () = test "envelope rejects missing message" (fun () ->
+  let json = `Assoc [
+    ("sender", `String "agent");
+    ("timestamp", `Float 1.0);
+    ("sequence", `Int 0);
+    ("channel", `String "broadcast");
+  ] in
+  match Message_schema.envelope_of_json json with
+  | Error msg -> assert (String.length msg > 0)
+  | Ok _ -> failwith "expected error for missing message"
+)
+
+let () = test "envelope strict mode rejects invalid" (fun () ->
+  match Message_schema.validate_envelope ~mode:Strict "{\"bad\": true}" with
+  | Error _ -> ()
+  | Ok _ -> failwith "expected strict rejection"
+)
+
+let () = test "envelope permissive mode wraps invalid" (fun () ->
+  match Message_schema.validate_envelope ~mode:Permissive "{\"bad\": true}" with
+  | Ok env ->
+      assert (env.sender = "unknown");
+      assert (env.channel = "freeform")
+  | Error _ -> failwith "expected permissive acceptance"
+)
+
+let () = test "envelope all message types" (fun () ->
+  let messages = [
+    Message_schema.TaskUpdate { task_id = "t1"; status = "pending"; payload = None };
+    Message_schema.StatusReport { agent = "a"; progress = 0.5; details = "half" };
+    Message_schema.Request { target = "b"; action = "ping"; params = `Null };
+    Message_schema.Response { request_id = "r1"; success = true; result = `Int 42 };
+    Message_schema.Freeform "hello";
+  ] in
+  List.iter (fun msg ->
+    let env : Message_schema.swarm_envelope = {
+      sender = "test"; timestamp = 1.0; sequence = 0;
+      channel = "test"; message = msg;
+    } in
+    match Message_schema.roundtrip_envelope env with
+    | Ok _ -> ()
+    | Error e -> failwith (Printf.sprintf "roundtrip failed for %s: %s"
+        (Message_schema.message_type_string msg) e)
+  ) messages
+)
+
+(* ══════════════════════════════════════════════════════════════
+   #897 — Keeper chat AG-UI bridge
+   ══════════════════════════════════════════════════════════════ *)
+
+let () = test "keeper session creates unique IDs" (fun () ->
+  let s1 = Keeper_chat_ag_ui.make_session ~keeper_name:"dreamer" in
+  let s2 = Keeper_chat_ag_ui.make_session ~keeper_name:"dreamer" in
+  assert (s1.run_id <> s2.run_id);
+  assert (s1.thread_id = s2.thread_id)  (* same keeper = same thread *)
+)
+
+let () = test "events_for_response has correct sequence" (fun () ->
+  let session = Keeper_chat_ag_ui.make_session ~keeper_name:"sangsu" in
+  let events = Keeper_chat_ag_ui.events_for_response session ~response:"hello world" in
+  (* Sequence: RUN_STARTED, TEXT_START, TEXT_CONTENT*, TEXT_END, RUN_FINISHED *)
+  assert (List.length events >= 5);
+  let types = List.map (fun (e : Ag_ui.event) -> e.event_type) events in
+  assert (List.hd types = Ag_ui.Run_started);
+  assert (List.nth types 1 = Ag_ui.Text_message_start);
+  let last = List.nth types (List.length types - 1) in
+  assert (last = Ag_ui.Run_finished);
+  let second_last = List.nth types (List.length types - 2) in
+  assert (second_last = Ag_ui.Text_message_end)
+)
+
+let () = test "events_for_response chunks long text" (fun () ->
+  let session = Keeper_chat_ag_ui.make_session ~keeper_name:"luna" in
+  (* 200 chars → ceil(200/64) = 4 chunks *)
+  let long_text = String.make 200 'x' in
+  let events = Keeper_chat_ag_ui.events_for_response session ~response:long_text in
+  let content_events = List.filter (fun (e : Ag_ui.event) ->
+    e.event_type = Ag_ui.Text_message_content
+  ) events in
+  assert (List.length content_events >= 3);
+  (* Verify deltas concatenate to original *)
+  let reconstructed = String.concat "" (List.filter_map (fun (e : Ag_ui.event) ->
+    e.delta
+  ) content_events) in
+  assert (reconstructed = long_text)
+)
+
+let () = test "sse_for_response produces valid SSE" (fun () ->
+  let session = Keeper_chat_ag_ui.make_session ~keeper_name:"miso" in
+  let sse = Keeper_chat_ag_ui.sse_for_response session ~response:"test" in
+  (* Each event should be "data: {...}\n\n" *)
+  assert (String.length sse > 0);
+  let lines = String.split_on_char '\n' sse in
+  let data_lines = List.filter (fun l ->
+    String.length l > 5 && String.sub l 0 5 = "data:"
+  ) lines in
+  assert (List.length data_lines >= 5)
+)
+
+let () = test "sse_for_error produces RUN_ERROR event" (fun () ->
+  let session = Keeper_chat_ag_ui.make_session ~keeper_name:"err" in
+  let sse = Keeper_chat_ag_ui.sse_for_error session ~error:"timeout" in
+  assert (String.length sse > 0);
+  (* Should contain RUN_ERROR *)
+  let has_error = try
+    ignore (Str.search_forward (Str.regexp_string "RUN_ERROR") sse 0); true
+  with Not_found -> false in
+  assert has_error
+)
+
+(* ── Summary ──────────────────────────────────── *)
+
+let () =
+  Printf.printf "\nPhase 5 tests: %d passed, %d failed\n%!" !passed !failed;
+  if !failed > 0 then exit 1


### PR DESCRIPTION
## Summary

- **#991 Swarm message schema**: Extended `message_schema.ml` with `swarm_envelope` type (sender, timestamp, sequence, channel, message). Strict/Warn/Permissive validation modes for envelopes. Rejects empty sender, negative sequence, missing fields.
- **#897 Keeper chat AG-UI**: New `keeper_chat_ag_ui.ml` — translates keeper chat to AG-UI event protocol. Standard event sequence (RUN_STARTED → TEXT_MESSAGE_* → RUN_FINISHED). Post-assembly 64-char chunking as TEXT_MESSAGE_CONTENT deltas. SSE output helpers.

## Changes

| File | Description |
|------|-------------|
| `lib/message_schema.ml` | +swarm_envelope type, envelope_of_json/to_json/validate |
| `lib/message_schema.mli` | Expose new types and functions |
| `lib/keeper_chat_ag_ui.ml` | New: AG-UI bridge for keeper chat streaming |
| `test/test_phase5_validation.ml` | 12 tests (7 envelope + 5 AG-UI) |

## Test plan

- [x] `dune build` passes
- [x] 12/12 Phase 5 tests pass
- [ ] GLM-5 external review

Closes #991, closes #897.

🤖 Generated with [Claude Code](https://claude.com/claude-code)