### PR TITLE
ci: configure llama runtime env for team_session spawn tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -180,6 +180,8 @@ jobs:
           ALCOTEST_QUICK_TESTS: "1"
           CI_TEST_TIMEOUT_SEC: 1200
           CI_TEST_HEARTBEAT_SEC: 30
+          MASC_DEFAULT_CASCADE: "llama:ci-default-model"
+          MASC_LLAMA_RUNTIMES_JSON: '[{"base_url":"http://127.0.0.1:8085","max_concurrency":4}]'
         run: |
           mkdir -p /tmp/me
           chmod +x scripts/ci-run-tests.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -180,7 +180,6 @@ jobs:
           ALCOTEST_QUICK_TESTS: "1"
           CI_TEST_TIMEOUT_SEC: 1200
           CI_TEST_HEARTBEAT_SEC: 30
-          MASC_DEFAULT_CASCADE: "llama:ci-default-model"
           MASC_LLAMA_RUNTIMES_JSON: '[{"base_url":"http://127.0.0.1:8085","max_concurrency":4}]'
         run: |
           mkdir -p /tmp/me


### PR DESCRIPTION
## Summary
- CI에서 team_session spawn 테스트 4건이 llama runtime/model 미설정으로 실패하던 문제 수정
- `MASC_DEFAULT_CASCADE`: `spawn_model` 없는 테스트에 기본 모델 제공
- `MASC_LLAMA_RUNTIMES_JSON`: generic runtime (model 필드 없음)으로 어떤 모델 요청이든 매칭

## Test plan
- [x] 로컬 44/44 team_session 테스트 통과 확인
- [ ] CI Build and Test green

🤖 Generated with [Claude Code](https://claude.com/claude-code)