### PR TITLE
refactor: replace Unix.sleepf with Time_compat.sleep (God Module 2/4)

### DIFF
--- a/lib/autoresearch.ml
+++ b/lib/autoresearch.ml
@@ -540,7 +540,7 @@ let measure_metric_with_retry ~workdir ~timeout_s ?(max_retries = 2) metric_fn =
     match measure_metric ~workdir ~timeout_s metric_fn with
     | Ok _ as ok -> ok
     | Error e when n < max_retries && is_transient e ->
-      Unix.sleepf 1.0;
+      Time_compat.sleep 1.0;
       attempt (n + 1)
     | Error _ as err -> err
   in

--- a/lib/chain_category.ml
+++ b/lib/chain_category.ml
@@ -247,7 +247,7 @@ end = struct
       match f x with
       | Ok y -> Ok y
       | Error _ when n > 0 ->
-        Unix.sleepf delay;
+        Time_compat.sleep delay;
         loop (n - 1)
       | Error e -> Error e
     in

--- a/lib/chain_retry.ml
+++ b/lib/chain_retry.ml
@@ -110,7 +110,7 @@ let execute_with_retry_sync ~policy f =
       { value = Error last_error; attempts = attempt; total_delay_ms = total_delay; errors = List.rev errors }
     else
       let delay = calculate_delay policy attempt in
-      if delay > 0 then Unix.sleepf (float_of_int delay /. 1000.0);
+      if delay > 0 then Time_compat.sleep (float_of_int delay /. 1000.0);
       match f () with
       | Ok v ->
           { value = Ok v; attempts = attempt + 1; total_delay_ms = total_delay + delay; errors = List.rev errors }

--- a/lib/tool_command_plane_support.ml
+++ b/lib/tool_command_plane_support.ml
@@ -170,7 +170,7 @@ let wait_for_pid_with_timeout ~clock_opt ~timeout_sec pid =
         else (
           (match clock_opt with
           | Some clock -> Eio.Time.sleep clock 0.2
-          | None -> Unix.sleepf 0.2);
+          | None -> Time_compat.sleep 0.2);
           loop ())
     | _, status -> `Exited status
   in
@@ -214,7 +214,7 @@ let run_process_with_timeout ~clock_opt ~timeout_sec ~prog ~argv ~env =
        | exn -> Log.CmdPlane.warn "sigterm pid %d: %s" pid (Printexc.to_string exn));
       (match clock_opt with
       | Some clock -> Eio.Time.sleep clock 1.0
-      | None -> Unix.sleepf 1.0);
+      | None -> Time_compat.sleep 1.0);
       let exit_code =
         match Unix.waitpid [ Unix.WNOHANG ] pid with
         | 0, _ ->

--- a/lib/tool_task.ml
+++ b/lib/tool_task.ml
@@ -263,7 +263,7 @@ let handle_transition ctx args =
     if is_version_mismatch r && attempt < max_cas_retries then begin
       Log.Task.info "CAS version mismatch on %s (attempt %d/%d), retrying in %.0fms"
         task_id (attempt + 1) max_cas_retries (cas_retry_delay_s *. 1000.0);
-      Unix.sleepf cas_retry_delay_s;
+      Time_compat.sleep cas_retry_delay_s;
       try_transition (attempt + 1)
     end else
       r


### PR DESCRIPTION
## Summary
God Module 리팩토링 시리즈 2/4. `Unix.sleepf` 6곳을 `Time_compat.sleep`으로 교체.

`Unix.sleepf`는 OS thread를 블로킹하여 같은 Eio domain의 모든 fiber를 멈춤. `Time_compat.sleep`은 Eio clock이 설정되었을 때 `Eio.Time.sleep`을 사용하여 cooperative scheduling을 유지.

### 변경 파일 (5)
- `chain_retry.ml`: retry 간 delay
- `chain_category.ml`: Kleisli retry delay
- `tool_command_plane_support.ml`: process wait poll (2곳)
- `tool_task.ml`: CAS retry delay
- `autoresearch.ml`: transient error retry

동작 변경: Eio clock 설정 시 cooperative sleep으로 전환. 미설정 시 기존과 동일 (Unix.sleepf fallback).

## Test plan
- [x] `dune build` passes
- [x] `grep -rn "Unix.sleepf" lib/` → time_compat.ml만 남음
- [ ] CI Build and Test green

🤖 Generated with [Claude Code](https://claude.com/claude-code)