### PR TITLE
feat(dashboard): domain-local Caqti pool for Executor_pool compute

### DIFF
--- a/lib/backend.ml
+++ b/lib/backend.ml
@@ -717,6 +717,9 @@ module PostgresNative : sig
   (* create_eio requires Caqti-compatible Eio environment (net, clock, mono_clock) *)
   val create_eio : sw:Eio.Switch.t -> env:Caqti_eio.stdenv -> config -> (t, error) result
 
+  (** Lightweight pool for a different Eio domain (no schema init, max_size=1). *)
+  val create_eio_readonly : sw:Eio.Switch.t -> env:Caqti_eio.stdenv -> config -> (t, error) result
+
   (* Expose Caqti pool for Board_pg and other PG-backed modules *)
   val get_pool : t -> (Caqti_eio.connection, Caqti_error.t) Caqti_eio.Pool.t
 
@@ -937,6 +940,22 @@ end = struct
             (match init_result with
              | Error err -> Error (caqti_error_to_masc err)
              | Ok () -> Ok { pool; namespace = cfg.cluster_name; _sw = sw })
+
+  (** Lightweight pool creation for use in a different Eio domain.
+      Skips schema initialization (assumed already done by the main pool).
+      Uses max_size=1 since this is for read-heavy dashboard compute.
+      The caller's [sw] is captured by Caqti, making this pool safe to
+      use from the domain that owns [sw]. *)
+  let[@warning "-32"] create_eio_readonly ~sw ~env (cfg : config) : (t, error) result =
+    match cfg.postgres_url with
+    | None -> Error (ConnectionFailed "PostgreSQL URL not configured")
+    | Some url ->
+        let uri = Uri.of_string url in
+        let pool_config = Caqti_pool_config.create ~max_size:1 () in
+        match Caqti_eio_unix.connect_pool ~sw ~stdenv:env ~pool_config uri with
+        | Error err -> Error (caqti_error_to_masc err)
+        | Ok pool ->
+            Ok { pool; namespace = cfg.cluster_name; _sw = sw }
 
   let close _t = ()
 

--- a/lib/eio_context.ml
+++ b/lib/eio_context.ml
@@ -7,6 +7,7 @@ type eio_net = [`Generic | `Unix] Eio.Net.ty Eio.Resource.t
 
 let current_net : eio_net option ref = ref None
 let current_clock : float Eio.Time.clock_ty Eio.Resource.t option ref = ref None
+let current_mono_clock : Eio.Time.Mono.ty Eio.Resource.t option ref = ref None
 let current_sw : Eio.Switch.t option ref = ref None
 let net_initialized : bool ref = ref false
 let global_ctx_mutex = Eio.Mutex.create ()
@@ -19,6 +20,16 @@ let set_net net =
 let set_clock clock =
   Eio.Mutex.use_rw ~protect:true global_ctx_mutex (fun () ->
       current_clock := Some clock)
+
+let set_mono_clock mc =
+  Eio.Mutex.use_rw ~protect:true global_ctx_mutex (fun () ->
+      current_mono_clock := Some mc)
+
+let get_mono_clock () =
+  Eio.Mutex.use_ro global_ctx_mutex (fun () ->
+      match !current_mono_clock with
+      | Some mc -> mc
+      | None -> invalid_arg "Eio mono_clock not initialized")
 
 let set_switch sw =
   Eio.Mutex.use_rw ~protect:true global_ctx_mutex (fun () ->

--- a/lib/room_utils_backend_setup.ml
+++ b/lib/room_utils_backend_setup.ml
@@ -25,6 +25,35 @@ type config = {
 (** Create a config targeting a different scope. Cheap record copy. *)
 let with_scope config scope = { config with scope }
 
+(** Create a config with a domain-local PostgresNative backend.
+    Use when running in a different Eio domain (e.g., Executor_pool)
+    where the main domain's Caqti pool would crash due to Switch
+    being domain-bound.  Skips schema init (already done by main pool).
+    Constructs [Caqti_eio.stdenv] from [Eio_context] globals (net/clock
+    are cross-domain safe, only Switch is domain-bound).
+    Returns [None] on failure. *)
+let with_domain_local_pg_backend ~sw config =
+  match config.backend with
+  | PostgresNative _ ->
+    let net = Eio_context.get_net () in
+    let clock = Eio_context.get_clock () in
+    let mono_clock = Eio_context.get_mono_clock () in
+    let env : Caqti_eio.stdenv =
+      object
+        method net = (net :> [`Generic] Eio.Net.ty Eio.Resource.t)
+        method clock = clock
+        method mono_clock = mono_clock
+      end
+    in
+    (match Backend.PostgresNative.create_eio_readonly ~sw ~env config.backend_config with
+    | Ok t -> Some { config with backend = PostgresNative t }
+    | Error err ->
+      Printf.eprintf "[WARN] Domain-local PG backend failed: %s\n%!"
+        (Backend.show_error err);
+      None)
+  | Memory _ | FileSystem _ ->
+    Some config
+
 (* ============================================ *)
 (* Git Root Detection (Worktree Support)        *)
 (* ============================================ *)

--- a/lib/server_dashboard_http.ml
+++ b/lib/server_dashboard_http.ml
@@ -432,12 +432,13 @@ let start_execution_refresh_loop ~state ~sw ~clock =
                cross-domain Switch crash in Caqti release. *)
             Eio.Executor_pool.submit_exn pool ~weight:1.0 (fun () ->
               Eio.Switch.run @@ fun pool_sw ->
-              let domain_config =
-                match Room_utils_backend_setup.with_domain_local_pg_backend ~sw:pool_sw config with
-                | Some c -> c
-                | None -> config  (* fallback: use original, will crash on PG but FS is fine *)
-              in
-              Dashboard_execution.json ~config:domain_config ~sw:pool_sw ~clock ~proc_mgr ())
+              match Room_utils_backend_setup.with_domain_local_pg_backend ~sw:pool_sw config with
+              | Some domain_config ->
+                Dashboard_execution.json ~config:domain_config ~sw:pool_sw ~clock ~proc_mgr ()
+              | None ->
+                (* Cannot safely use main-domain PG pool in a different domain
+                   (Switch is domain-bound). Raise to trigger the outer catch. *)
+                failwith "domain-local PG backend creation failed; skipping pool refresh")
           | None ->
             Dashboard_execution.json ~config ~sw ~clock ~proc_mgr ()
         in

--- a/lib/server_dashboard_http.ml
+++ b/lib/server_dashboard_http.ml
@@ -398,15 +398,11 @@ let dashboard_tools_http_json ?actor (config : Room.config) : Yojson.Safe.t =
       ("tool_usage", Tool_unified.summary_report ());
     ]
 
-(** Proactive execution cache.  A background fiber recomputes the
-    execution JSON periodically, so HTTP requests never block on
-    computation.  This avoids the Eio cooperative-scheduling problem
-    where on-demand compute gets starved by other fibers (Guardian,
-    Lodge, SSE), inflating wall-clock time from 60ms to 30s+.
-
-    The HTTP handler reads [_execution_json_ref] immediately (0ms).
-    Parameterized requests (fixture/actor) fall back to on-demand
-    compute with a generous timeout. *)
+(** Executor pool for offloading heavy dashboard compute to a separate
+    OS domain, bypassing Eio cooperative-scheduling starvation.
+    Set via [set_executor_pool] at server startup. *)
+let _executor_pool : Eio.Executor_pool.t option ref = ref None
+let set_executor_pool pool = _executor_pool := Some pool
 
 let _execution_json_ref : Yojson.Safe.t ref =
   ref (`Assoc [
@@ -415,51 +411,58 @@ let _execution_json_ref : Yojson.Safe.t ref =
     ("message", `String "Execution data is being computed. Refresh in a few seconds.");
   ])
 
-let _execution_refresh_interval_s = 120.0
+let _execution_refresh_interval_s = 60.0
 
-(** Start the proactive execution refresh loop.  Call once after server
-    state is initialized.  The loop runs forever, recomputing every
-    [_execution_refresh_interval_s] seconds. *)
+(** Start the proactive execution refresh loop.  When an Executor_pool
+    is available, each refresh runs in a pool domain with a domain-local
+    Caqti pool (the main domain's Caqti pool is domain-bound due to
+    Switch capture in release).  Falls back to in-domain compute. *)
 let start_execution_refresh_loop ~state ~sw ~clock =
   let config = state.Mcp_server.room_config in
   let proc_mgr = state.Mcp_server.proc_mgr in
   Eio.Fiber.fork ~sw (fun () ->
-    Printf.eprintf "[INFO] Dashboard: starting execution proactive refresh loop.\n%!";
+    Printf.eprintf "[INFO] Dashboard: starting execution refresh loop.\n%!";
     let rec loop () =
+      let t0 = Time_compat.now () in
       (try
         let json =
-          Dashboard_execution.json ~config ~sw ~clock ~proc_mgr ()
+          match !_executor_pool with
+          | Some pool ->
+            (* Pool domain: create domain-local Caqti pool to avoid
+               cross-domain Switch crash in Caqti release. *)
+            Eio.Executor_pool.submit_exn pool ~weight:1.0 (fun () ->
+              Eio.Switch.run @@ fun pool_sw ->
+              let domain_config =
+                match Room_utils_backend_setup.with_domain_local_pg_backend ~sw:pool_sw config with
+                | Some c -> c
+                | None -> config  (* fallback: use original, will crash on PG but FS is fine *)
+              in
+              Dashboard_execution.json ~config:domain_config ~sw:pool_sw ~clock ~proc_mgr ())
+          | None ->
+            Dashboard_execution.json ~config ~sw ~clock ~proc_mgr ()
         in
         _execution_json_ref := json;
-        Printf.eprintf "[INFO] Dashboard: execution cache refreshed (%.0fB).\n%!"
+        let dt = Time_compat.now () -. t0 in
+        Printf.eprintf "[INFO] Dashboard: execution refreshed (%.0fB, %.1fs, %s).\n%!"
           (Float.of_int (String.length (Yojson.Safe.to_string json)))
+          dt
+          (if !_executor_pool <> None then "pool" else "in-domain")
       with exn ->
-        Printf.eprintf "[WARN] Dashboard: execution refresh failed: %s\n%!"
-          (Printexc.to_string exn));
+        let dt = Time_compat.now () -. t0 in
+        Printf.eprintf "[WARN] Dashboard: execution refresh failed (%.1fs): %s\n%!"
+          dt (Printexc.to_string exn));
       Eio.Time.sleep clock _execution_refresh_interval_s;
       loop ()
     in
     loop ())
 
-let dashboard_execution_http_json ~state ~sw ~clock request =
-  let fixture = query_param request "fixture" in
-  let actor = operator_actor_hint request in
-  match fixture, actor with
-  | None, None ->
-    (* Fast path: return proactively cached value immediately. *)
-    !_execution_json_ref
-  | _ ->
-    (* Parameterized request (fixture/actor): on-demand with short TTL. *)
-    let cache_key =
-      Printf.sprintf "execution:%s:%s"
-        (Option.value ~default:"" actor)
-        (Option.value ~default:"" fixture)
-    in
-    Dashboard_cache.get_or_compute_with_timeout cache_key ~ttl:10.0
-      ~clock ~timeout_sec:10.0 (fun () ->
-      Dashboard_execution.json ?actor ?fixture
-        ~config:state.Mcp_server.room_config ~sw ~clock
-        ~proc_mgr:state.Mcp_server.proc_mgr ())
+let dashboard_execution_http_json ~state:_ ~sw:_ ~clock:_ request =
+  let _fixture = query_param request "fixture" in
+  let _actor = operator_actor_hint request in
+  (* Always return proactively cached value immediately.
+     With Executor_pool, the cache is refreshed every 60s in a separate
+     OS domain with ~60ms latency instead of 30s+ fiber starvation. *)
+  !_execution_json_ref
 
 let dashboard_room_truth_focus_json ~initialized ~agent_count ~operator_digest_json ~top_queue =
   let recommendation_summary =

--- a/lib/server_dashboard_http.ml
+++ b/lib/server_dashboard_http.ml
@@ -456,13 +456,26 @@ let start_execution_refresh_loop ~state ~sw ~clock =
     in
     loop ())
 
-let dashboard_execution_http_json ~state:_ ~sw:_ ~clock:_ request =
-  let _fixture = query_param request "fixture" in
-  let _actor = operator_actor_hint request in
-  (* Always return proactively cached value immediately.
-     With Executor_pool, the cache is refreshed every 60s in a separate
-     OS domain with ~60ms latency instead of 30s+ fiber starvation. *)
-  !_execution_json_ref
+let dashboard_execution_http_json ~state ~sw ~clock request =
+  let fixture = query_param request "fixture" in
+  let actor = operator_actor_hint request in
+  match fixture, actor with
+  | None, None ->
+    (* Default: return proactively cached value immediately (0ms). *)
+    !_execution_json_ref
+  | _ ->
+    (* Parameterized requests (fixture/actor): on-demand with SWR cache.
+       These are rare (test fixtures, actor-specific views). *)
+    let cache_key =
+      Printf.sprintf "execution:%s:%s"
+        (Option.value ~default:"" actor)
+        (Option.value ~default:"" fixture)
+    in
+    Dashboard_cache.get_or_compute_with_timeout cache_key ~ttl:120.0
+      ~clock ~timeout_sec:120.0 (fun () ->
+      Dashboard_execution.json ?actor ?fixture
+        ~config:state.Mcp_server.room_config ~sw ~clock
+        ~proc_mgr:state.Mcp_server.proc_mgr ())
 
 let dashboard_room_truth_focus_json ~initialized ~agent_count ~operator_digest_json ~top_queue =
   let recommendation_summary =

--- a/lib/server_runtime_bootstrap.ml
+++ b/lib/server_runtime_bootstrap.ml
@@ -25,6 +25,7 @@ let create_server_state ~sw ~base_path ~clock ~mono_clock ~net ~proc_mgr ~fs
   Eio_context.set_switch sw;
   Eio_context.set_net net;
   Eio_context.set_clock clock;
+  Eio_context.set_mono_clock mono_clock;
   Council.Thread_persist.set_eio_context ~clock
     ~https_connector:(Eio_context.get_https_connector ()) net;
   Process_eio.init ~cwd_default:Eio.Path.(fs / base_path) ~proc_mgr ~clock;
@@ -331,8 +332,11 @@ let run ~sw ~env ~host ~port ~base_path ~make_routes ~make_request_handler
         start_background_maintenance ~sw ~clock state
       in
       print_startup_banner ~config ~resolved_base ~base_path ~masc_dir;
-      (* Start proactive execution refresh so dashboard requests never
-         block on computation.  The loop runs in its own fiber. *)
+      (* Create Executor_pool for CPU-heavy dashboard compute.
+         Runs in separate OS domains, bypassing fiber contention. *)
+      let exec_pool = Eio.Executor_pool.create ~sw ~domain_count:2 domain_mgr in
+      Server_dashboard_http.set_executor_pool exec_pool;
+      Printf.eprintf "[INFO] Executor_pool created (2 domains) for dashboard.\n%!";
       Server_dashboard_http.start_execution_refresh_loop ~state ~sw ~clock;
       start_resident_loops ~sw ~clock ~net ~domain_mgr ~proc_mgr state
     with exn ->


### PR DESCRIPTION
## Summary
- `Backend.PostgresNative.create_eio_readonly`: 스키마 초기화 없는 경량 Caqti pool 생성
- `Eio_context`: mono_clock 저장 추가 (domain-local Caqti_eio.stdenv 구성용)
- `Room_utils_backend_setup.with_domain_local_pg_backend`: pool domain에서 domain-safe PG backend 생성
- `Executor_pool` (2 domains) 생성 + proactive refresh에서 pool domain 경유

## Root Cause
Caqti `pool.ml:284`에서 `async ~sw:pool.switch`로 커넥션 release. `pool.switch`는 pool 생성 시 캡처된 main domain의 Switch. pool domain에서 접근하면 `"Switch accessed from wrong domain!"` crash.

## Solution
Pool domain 진입 시 **domain-local Caqti pool**을 새로 생성. 이 pool은 pool domain의 Switch를 캡처하므로 cross-domain 문제 없음.

```
Main domain Switch ──→ Main Caqti pool (서버 전체용)
Pool domain Switch ──→ Domain-local Caqti pool (dashboard compute용, max_size=1)
```

## Verification
- Switch crash: 해결 (130.7s compute 완료, 이전: runtime error)
- 130.7s 소요: Supabase PG (ap-south-1 → KR) 네트워크 레이턴시. 별도 최적화 필요.
- HTTP 응답: 여전히 proactive ref read (0ms)

## Next Steps
- PG 쿼리 batch 최적화 (N+1 제거) → 130s → 수 초
- 또는 FileSystem backend 병행 (dual-write) → pool domain에서 local I/O

Closes #1336

🤖 Generated with [Claude Code](https://claude.com/claude-code)