### PR TITLE
fix(ci): add mcp_protocol_http opam pin for dependency resolution

### DIFF
--- a/scripts/opam-pin-external-deps.sh
+++ b/scripts/opam-pin-external-deps.sh
@@ -25,6 +25,7 @@ fi
 
 opam pin add mcp_protocol https://github.com/jeong-sik/mcp-protocol-sdk.git#main -n -y
 opam pin add mcp_protocol_eio https://github.com/jeong-sik/mcp-protocol-sdk.git#main -n -y
+opam pin add mcp_protocol_http https://github.com/jeong-sik/mcp-protocol-sdk.git#main -n -y
 opam pin add agent_sdk https://github.com/jeong-sik/oas.git#main -n -y
 opam pin add ocaml-webrtc https://github.com/jeong-sik/ocaml-webrtc.git#main -n -y
 opam pin add grpc-direct-core https://github.com/jeong-sik/grpc-direct.git#main -n -y


### PR DESCRIPTION
## Summary
- Add `mcp_protocol_http` pin to `scripts/opam-pin-external-deps.sh`
- `mcp_protocol` and `mcp_protocol_eio` were already pinned; `mcp_protocol_http` was missing
- All CI jobs use this shared script, so the fix propagates to all of them (Health, Build and Test, Contract Harness, Lint, Documentation)

## Test plan
- [ ] All CI jobs pass dependency resolution

🤖 Generated with [Claude Code](https://claude.com/claude-code)