### PR TITLE
fix: exhaustive pattern match for Agent_sdk.Types.role

### DIFF
--- a/lib/context_manager.ml
+++ b/lib/context_manager.ml
@@ -370,7 +370,9 @@ let oas_msg_to_masc_tagged (m : Agent_sdk.Types.message) : Llm_client.message =
     else
       (match m.role with
        | Agent_sdk.Types.User -> Llm_client.User
-       | Agent_sdk.Types.Assistant -> Llm_client.Assistant),
+       | Agent_sdk.Types.Assistant -> Llm_client.Assistant
+       | Agent_sdk.Types.System -> Llm_client.System
+       | Agent_sdk.Types.Tool -> Llm_client.Tool),
       text
   in
   let tool_call_id = match role with

--- a/lib/llm_client.ml
+++ b/lib/llm_client.ml
@@ -79,6 +79,8 @@ let of_oas_message (m : Agent_sdk.Types.message) : message =
   let role = match m.role with
     | Agent_sdk.Types.User -> User
     | Agent_sdk.Types.Assistant -> Assistant
+    | Agent_sdk.Types.System -> System
+    | Agent_sdk.Types.Tool -> Tool
   in
   let content =
     m.content

--- a/lib/llm_client_providers.ml
+++ b/lib/llm_client_providers.ml
@@ -586,6 +586,8 @@ let of_oas_message (m : Agent_sdk.Types.message) : message =
   let role = match m.role with
     | Agent_sdk.Types.User -> User
     | Agent_sdk.Types.Assistant -> Assistant
+    | Agent_sdk.Types.System -> System
+    | Agent_sdk.Types.Tool -> Tool
   in
   let content =
     m.content


### PR DESCRIPTION
## Summary
- Add `System` and `Tool` cases to `of_oas_message` in 3 files
- Fixes warning 8 (partial-match) that breaks CI lint on all open PRs
- `Agent_sdk.Types.role` has 4 variants (`User | Assistant | System | Tool`) but only 2 were matched

## Files
- `lib/llm_client.ml`
- `lib/llm_client_providers.ml`
- `lib/context_manager.ml`

## Test plan
- [ ] CI lint passes (warning 8 resolved)
- [ ] Build succeeds

Generated with [Claude Code](https://claude.com/claude-code)