### PR TITLE
fix: handle System/Tool role variants in OAS message conversion

### DIFF
--- a/lib/context_manager.ml
+++ b/lib/context_manager.ml
@@ -370,7 +370,9 @@ let oas_msg_to_masc_tagged (m : Agent_sdk.Types.message) : Llm_client.message =
     else
       (match m.role with
        | Agent_sdk.Types.User -> Llm_client.User
-       | Agent_sdk.Types.Assistant -> Llm_client.Assistant),
+       | Agent_sdk.Types.Assistant -> Llm_client.Assistant
+       | Agent_sdk.Types.System -> Llm_client.System
+       | Agent_sdk.Types.Tool -> Llm_client.Tool),
       text
   in
   let tool_call_id = match role with

--- a/lib/llm_client.ml
+++ b/lib/llm_client.ml
@@ -79,6 +79,8 @@ let of_oas_message (m : Agent_sdk.Types.message) : message =
   let role = match m.role with
     | Agent_sdk.Types.User -> User
     | Agent_sdk.Types.Assistant -> Assistant
+    | Agent_sdk.Types.System -> System
+    | Agent_sdk.Types.Tool -> Tool
   in
   let content =
     m.content

--- a/lib/llm_client_providers.ml
+++ b/lib/llm_client_providers.ml
@@ -586,6 +586,8 @@ let of_oas_message (m : Agent_sdk.Types.message) : message =
   let role = match m.role with
     | Agent_sdk.Types.User -> User
     | Agent_sdk.Types.Assistant -> Assistant
+    | Agent_sdk.Types.System -> System
+    | Agent_sdk.Types.Tool -> Tool
   in
   let content =
     m.content


### PR DESCRIPTION
## Summary

- `agent_sdk` `Types.role`에 `System`/`Tool` variant가 추가되면서 3개 파일의 exhaustive pattern match가 깨짐
- `context_manager.ml`, `llm_client.ml`, `llm_client_providers.ml`에서 warning 8 (partial-match) → build error

이것이 main CI 전체와 모든 open PR CI를 깨뜨린 근본 원인.

## Test plan

- [x] `dune build` 통과 (warning 8 에러 0개)
- [ ] CI Build and Test green

🤖 Generated with [Claude Code](https://claude.com/claude-code)