### PR TITLE
fix: re-raise Eio.Cancel.Cancelled in 7 remaining catch-all handlers

### DIFF
--- a/lib/chain_executor_eio.ml
+++ b/lib/chain_executor_eio.ml
@@ -662,7 +662,9 @@ and execute_spawn ctx ~sw ~clock ~exec_fn ~tool_exec (node : node)
       (* Execute inner node in spawned context *)
       let result =
         try execute_node spawn_ctx ~sw ~clock ~exec_fn ~tool_exec inner
-        with exn ->
+        with
+        | Eio.Cancel.Cancelled _ as exn -> raise exn
+        | exn ->
           Error (Printf.sprintf "Spawn execution failed: %s" (Printexc.to_string exn))
       in
 

--- a/lib/checkpoint_store.ml
+++ b/lib/checkpoint_store.ml
@@ -129,7 +129,9 @@ let save_eio ~fs (store : checkpoint_store) (cp : checkpoint) : (unit, string) r
     let file_path = Eio.Path.(fs / path) in
     Eio.Path.save ~create:(`Or_truncate 0o644) file_path content;
     Ok ()
-  with exn ->
+  with
+  | Eio.Cancel.Cancelled _ as exn -> raise exn
+  | exn ->
     Error (Printf.sprintf "Failed to save checkpoint: %s" (Printexc.to_string exn))
 
 (** Save a checkpoint (non-Eio version for compatibility) *)

--- a/lib/handover_eio.ml
+++ b/lib/handover_eio.ml
@@ -157,7 +157,9 @@ let save_handover ~fs config (h : handover_record) : (unit, string) result =
     let path = Eio.Path.(fs / file) in
     Eio.Path.save ~create:(`Or_truncate 0o600) path (Yojson.Safe.pretty_to_string json);
     Ok ()
-  with exn ->
+  with
+  | Eio.Cancel.Cancelled _ as exn -> raise exn
+  | exn ->
     Error (Printf.sprintf "Failed to save handover: %s" (Printexc.to_string exn))
 
 (** Load handover from filesystem *)

--- a/lib/tool_inline_dispatch.ml
+++ b/lib/tool_inline_dispatch.ml
@@ -252,7 +252,9 @@ let dispatch (ctx : context) ~(name : string) : result option =
       (match state.Mcp_server.fs with
        | Some fs ->
            (try Telemetry_eio.track_agent_joined ~fs config ~agent_id:nickname ()
-            with exn ->
+            with
+            | Eio.Cancel.Cancelled _ as exn -> raise exn
+            | exn ->
               Log.Telemetry.debug "track_agent_joined (join): %s" (Printexc.to_string exn))
        | None -> ());
       Some (true, final_result)
@@ -278,7 +280,9 @@ let dispatch (ctx : context) ~(name : string) : result option =
       (match state.Mcp_server.fs with
        | Some fs ->
            (try Telemetry_eio.track_agent_left ~fs config ~agent_id:agent_name ~reason:"leave"
-            with exn ->
+            with
+            | Eio.Cancel.Cancelled _ as exn -> raise exn
+            | exn ->
               Log.Telemetry.debug "track_agent_left: %s" (Printexc.to_string exn))
        | None -> ());
       Some (true, result)

--- a/lib/tool_lodge_llm_cycle.ml
+++ b/lib/tool_lodge_llm_cycle.ml
@@ -43,7 +43,9 @@ let fetch_hn_article ~net =
             |> Option.value ~default:(Printf.sprintf "https://news.ycombinator.com/item?id=%d" story_id) in
           if title = "" then Error "❌ Fetch: HN story has empty title"
           else Ok { title; url; source = HackerNews }
-    with exn -> Error (Printf.sprintf "❌ Parse: HN JSON error [%s]" (Printexc.to_string exn))
+    with
+    | Eio.Cancel.Cancelled _ as exn -> raise exn
+    | exn -> Error (Printf.sprintf "❌ Parse: HN JSON error [%s]" (Printexc.to_string exn))
 
 let decode_xml_entities s =
   s
@@ -190,7 +192,9 @@ let save_interests_to_neo4j ~agent_name interests =
           Ok (Printf.sprintf "saved %d interests for %s" (List.length interests) agent_name)
       | Unix.WEXITED n -> Error (Printf.sprintf "Neo4j exit %d" n)
       | _ -> Error "Neo4j signaled"
-    with exn -> Error (Printf.sprintf "Neo4j error: %s" (Printexc.to_string exn))
+    with
+    | Eio.Cancel.Cancelled _ as exn -> raise exn
+    | exn -> Error (Printf.sprintf "Neo4j error: %s" (Printexc.to_string exn))
 
 (** Get agent's existing interests from Neo4j *)
 let get_agent_interests ~agent_name =


### PR DESCRIPTION
## Summary

- Eio structured concurrency에서 `Cancelled` 예외를 catch-all `| exn ->`가 삼키면 좀비 fiber, scope cleanup 체인 파괴, 로그 노이즈 발생
- 코드베이스 전체 sweep 결과 ~19곳은 이미 수정 완료, 남은 7곳에 `| Eio.Cancel.Cancelled _ as exn -> raise exn` guard 추가
- 5 files, 7 sites:
  - `chain_executor_eio.ml`: `execute_node` in spawned context (Eio switch/clock)
  - `handover_eio.ml`: `save_handover` — `Eio.Path.save`
  - `checkpoint_store.ml`: `save_eio` — `Eio.Path.save`
  - `tool_inline_dispatch.ml`: `track_agent_joined/left` — `Telemetry_eio` I/O
  - `tool_lodge_llm_cycle.ml`: HN fetch (`http_get_json ~net`), Neo4j query

## Context

원래 4-PR sweep 계획이었으나 검수 결과 PR 1(8곳), PR 2(2곳), PR 3/4 대부분이 이미 수정 완료 → 남은 7곳 단일 PR.

## Test plan

- [x] `dune build --root .` — 기존 빌드 에러(Agent_sdk partial match)만 발생, 본 변경과 무관
- [ ] `make test` 통과 확인 (빌드 에러 해소 후)
- [ ] 수동 확인: 각 사이트에서 fiber cancellation 시 Cancelled가 올바르게 전파되는지

🤖 Generated with [Claude Code](https://claude.com/claude-code)