### PR TITLE
fix: 8 bugs from black-box user testing (#1349-#1356)

### DIFF
--- a/lib/mcp_server_eio.ml
+++ b/lib/mcp_server_eio.ml
@@ -52,6 +52,11 @@ let create_state_eio ~sw ~env ~proc_mgr ~fs ~clock ~net ~base_path =
   (try Team_session_engine_eio.recover_running_sessions ~sw ~clock
          ~config:state.Mcp_server.room_config
    with exn -> log_mcp_exn ~label:"team_session recovery skipped" exn);
+  (* Reconcile Prometheus active_agents gauge with existing agent files *)
+  (try
+     let masc_dir = Filename.concat state.Mcp_server.room_config.base_path ".masc" in
+     Prometheus.reconcile_active_agents_gauge masc_dir
+   with exn -> log_mcp_exn ~label:"prometheus agent reconciliation skipped" exn);
   state
 
 (** {1 Re-exported Mcp_server Functions} *)

--- a/lib/prometheus.ml
+++ b/lib/prometheus.ml
@@ -264,5 +264,16 @@ let llm_cache_metrics_json () =
       ("hit_rate", `Float hit_rate);
     ]
 
+(** Reconcile active_agents gauge with existing agent files on disk.
+    Call after Room/server initialization to sync Prometheus state. *)
+let reconcile_active_agents_gauge masc_dir =
+  let agents_dir = Filename.concat masc_dir "agents" in
+  if Sys.file_exists agents_dir && Sys.is_directory agents_dir then
+    let files = Sys.readdir agents_dir in
+    let count = Array.fold_left (fun acc f ->
+      if Filename.check_suffix f ".json" then acc + 1 else acc
+    ) 0 files in
+    set_active_agents count
+
 (** Initialize on module load *)
 let () = init ()

--- a/lib/team_session_engine_eio.ml
+++ b/lib/team_session_engine_eio.ml
@@ -307,8 +307,13 @@ let stop_session ~(config : Room.config) ~(session_id : string) ~(reason : strin
           match reloaded with
           | Some s when s.status <> Team_session_types.Running -> Some s
           | _ ->
+              let final_status =
+                if reason = "timeout" || reason = "error" || reason = "kill"
+                then Team_session_types.Interrupted
+                else Team_session_types.Completed
+              in
               finalize_session ~config ~session_id
-                ~final_status:Team_session_types.Interrupted ~reason
+                ~final_status ~reason
                 ~generate_report
         in
         (match updated with

--- a/lib/team_session_engine_policy.ml
+++ b/lib/team_session_engine_policy.ml
@@ -2,11 +2,13 @@ include Team_session_engine_status
 
 let write_checkpoint (config : Room.config) (session : Team_session_types.session) =
   let now = Time_compat.now () in
+  let active_agents = session_active_agent_names config session ~now in
+  let participant_agents = match active_agents with [] -> session.agent_names | a -> a in
   let backlog = Room.read_backlog config in
   let current_done = Team_session_types.done_counts_from_backlog backlog in
   let deltas =
     Team_session_types.done_delta_by_agent ~baseline:session.baseline_done_counts
-      ~current:current_done ~agents:session.agent_names
+      ~current:current_done ~agents:participant_agents
   in
   let done_total = List.fold_left (fun acc (_, n) -> acc + n) 0 deltas in
   let elapsed = max 0.0 (now -. session.started_at) in
@@ -17,7 +19,6 @@ let write_checkpoint (config : Room.config) (session : Team_session_types.sessio
     else
       min 100.0 (100.0 *. (elapsed /. float_of_int session.duration_seconds))
   in
-  let active_agents = session_active_agent_names config session ~now in
   let checkpoint : Team_session_types.checkpoint =
     {
       ts = now;
@@ -105,6 +106,8 @@ let maybe_add_fallback_task ~(config : Room.config)
   in
   if not should_create then
     session
+  else if session.fallback_task_created > 0 then
+    session  (* already created a fallback task for this session *)
   else
     let title =
       Printf.sprintf "Team session fallback (%s)" session.session_id

--- a/lib/team_session_report_proof_helpers.ml
+++ b/lib/team_session_report_proof_helpers.ml
@@ -139,6 +139,13 @@ let find_criterion criteria name =
   |> Option.value ~default:(criterion name false "missing")
   |> bool_of_criterion
 
+let has_criterion criteria name =
+  List.exists (fun item ->
+    match Yojson.Safe.Util.member "name" item with
+    | `String n -> String.equal n name
+    | _ -> false
+  ) criteria
+
 let all_criteria_pass criteria =
   List.for_all bool_of_criterion criteria
 
@@ -215,6 +222,8 @@ let mandatory_ok_for_level ~proof_level criteria =
       && find_criterion criteria "multi_actor_turn_coverage"
       && find_criterion criteria "turn_actor_authorized"
       && find_criterion criteria "report_artifacts"
+      && (not (has_criterion criteria "turn_volume_threshold") || find_criterion criteria "turn_volume_threshold")
+      && (not (has_criterion criteria "communication_volume_threshold") || find_criterion criteria "communication_volume_threshold")
   | Team_session_types.Proof_strong -> all_criteria_pass criteria
 
 let verdict_for_level ~proof_level ~mandatory_ok =

--- a/lib/team_session_types.ml
+++ b/lib/team_session_types.ml
@@ -959,7 +959,7 @@ let session_of_yojson json =
         status = json |> member "status" |> to_string_option |> Option.value ~default:"failed" |> status_of_string;
         duration_seconds;
         execution_scope =
-          json |> member "execution_scope" |> to_string_option |> Option.value ~default:"observe_only"
+          json |> member "execution_scope" |> to_string_option |> Option.value ~default:"limited_code_change"
           |> execution_scope_of_string;
         checkpoint_interval_sec = get_int_default "checkpoint_interval_sec" 60;
         min_agents = get_int_default "min_agents" 2;

--- a/lib/tool_inline_dispatch.ml
+++ b/lib/tool_inline_dispatch.ml
@@ -187,11 +187,15 @@ let dispatch (ctx : context) ~(name : string) : result option =
       in
       if not (Sys.file_exists expanded && Sys.is_directory expanded) then
         Some (false, Printf.sprintf "Directory not found: %s" expanded)
-      else begin
-        state.Mcp_server.room_config <- Room.default_config expanded;
-        let status = if Room.is_initialized state.Mcp_server.room_config then "ok" else "(not initialized)" in
-        Some (true, Printf.sprintf "MASC room set to: %s\n   .masc/ status: %s" expanded status)
-      end
+      else
+        let masc_dir = Filename.concat expanded ".masc" in
+        if not (Sys.file_exists masc_dir && Sys.is_directory masc_dir) then
+          Some (false, Printf.sprintf "No .masc/ directory found in: %s\nRun masc_init to initialize, or choose a MASC-enabled directory." expanded)
+        else begin
+          state.Mcp_server.room_config <- Room.default_config expanded;
+          let status = if Room.is_initialized state.Mcp_server.room_config then "ok" else "(not initialized)" in
+          Some (true, Printf.sprintf "MASC room set to: %s\n   .masc/ status: %s" expanded status)
+        end
 
   | "masc_join" ->
       let caps = arg_get_string_list "capabilities" in

--- a/lib/workflow_guide.ml
+++ b/lib/workflow_guide.ml
@@ -45,7 +45,7 @@ let after_join ~success =
   if success then
     { next_steps =
         [ s "masc_status" "Check current room state and available tasks";
-          s "masc_claim" "Claim an existing task if available";
+          s "masc_transition" "Claim an existing task if available (action=claim)";
           s "masc_add_task" "Create a new task if none exist" ];
       preconditions = [ "room_set" ];
       common_mistakes =
@@ -60,7 +60,7 @@ let after_join ~success =
 let after_status ~success =
   if success then
     { next_steps =
-        [ s "masc_claim" "Claim a task from the available list";
+        [ s "masc_transition" "Claim a task from the available list (action=claim)";
           s "masc_add_task" "Add a new task if the list is empty";
           s "masc_workflow_guide" "Get personalized guidance for your current state" ];
       preconditions = [ "room_set"; "joined" ];
@@ -91,7 +91,7 @@ let after_claim ~success =
 let after_add_task ~success =
   if success then
     { next_steps =
-        [ s "masc_claim" "Claim the task you just created";
+        [ s "masc_transition" "Claim the task you just created (action=claim)";
           s "masc_status" "Verify the task appears in the list" ];
       preconditions = [ "room_set"; "joined" ];
       common_mistakes =
@@ -111,7 +111,7 @@ let after_plan_set_task ~success =
       common_mistakes = [] }
   else
     { next_steps =
-        [ s "masc_claim" "Claim a task first";
+        [ s "masc_transition" "Claim a task first (action=claim)";
           s "masc_status" "Verify your claimed task exists" ];
       preconditions = [ "room_set"; "joined" ];
       common_mistakes =
@@ -121,7 +121,7 @@ let after_heartbeat ~success =
   if success then
     { next_steps =
         [ s "masc_broadcast" "Share progress with other agents";
-          s "masc_done" "Mark task complete when finished" ];
+          s "masc_transition" "Mark task complete when finished (action=done)" ];
       preconditions = [ "room_set"; "joined" ];
       common_mistakes = [] }
   else
@@ -134,7 +134,7 @@ let after_done ~success =
   if success then
     { next_steps =
         [ s "masc_status" "Check for remaining tasks";
-          s "masc_claim" "Pick up the next task";
+          s "masc_transition" "Pick up the next task (action=claim)";
           s "masc_leave" "Leave room if all work is complete" ];
       preconditions = [ "room_set"; "joined" ];
       common_mistakes = [] }
@@ -210,7 +210,7 @@ let after_team_session_prove ~success =
   if success then
     { next_steps =
         [ s "masc_team_session_stop" "End the session after evidence is collected";
-          s "masc_done" "Mark the underlying task as complete" ];
+          s "masc_transition" "Mark the underlying task as complete (action=done)" ];
       preconditions = [ "room_set"; "joined"; "session_active" ];
       common_mistakes = [] }
   else
@@ -402,7 +402,7 @@ let current_state_guidance ~room_set ~joined ~task_claimed
   else if not task_claimed then
     { next_steps =
         [ s "masc_status" "Check available tasks";
-          s "masc_claim" "Claim an existing task";
+          s "masc_transition" "Claim an existing task (action=claim)";
           s "masc_add_task" "Create a new task if none exist" ];
       preconditions = [ "room_set"; "joined" ];
       common_mistakes =
@@ -431,6 +431,6 @@ let current_state_guidance ~room_set ~joined ~task_claimed
     { next_steps =
         [ s "masc_heartbeat" "Signal liveness while working";
           s "masc_broadcast" "Share progress with teammates";
-          s "masc_done" "Mark task complete when finished" ];
+          s "masc_transition" "Mark task complete when finished (action=done)" ];
       preconditions = [ "room_set"; "joined"; "task_claimed"; "current_task_set"; "worktree_active" ];
       common_mistakes = [] }


### PR DESCRIPTION
## Summary

Black-box user testing에서 발견한 8개 버그 수정. 코드를 모르는 일반 사용자 관점에서 Room/Task, Team Session, CPv2 워크플로우를 실행하며 발견된 실제 문제들.

**High (4건):**
- **#1350**: `workflow_guidance`가 존재하지 않는 도구(`masc_claim`, `masc_done`) 추천 → `masc_transition`으로 변경
- **#1351**: Team session fallback task 중복 생성으로 Quest Board 범람 (370+ orphan tasks) → dedup guard 추가
- **#1352**: Proof threshold 검증 미작동 (항상 100% 통과) → `turn_volume_threshold`, `communication_volume_threshold`를 mandatory criteria에 추가
- **#1349**: Prometheus `masc_active_agents` 게이지가 서버 재시작 후 0으로 초기화 → 시작 시 agent 파일 스캔으로 reconcile

**Medium (2건):**
- **#1353**: `masc_set_room`이 존재하지 않는 경로를 에러 없이 수용 → `.masc/` 디렉토리 존재 검증 추가
- **#1354**: `done_delta_by_agent`에 세션 외부 에이전트의 글로벌 메트릭 혼입 → active participants만 필터

**Low (2건):**
- **#1355**: `stop_session`이 정상 종료 시에도 `status=interrupted` → reason 기반 conditional status
- **#1356**: `execution_scope` 기본값이 `observe_only` → `limited_code_change`로 변경

## Changes

- `lib/workflow_guide.ml` — 9개 deprecated 도구 참조 → `masc_transition`
- `lib/team_session_engine_eio.ml` — stop status conditional logic
- `lib/team_session_engine_policy.ml` — fallback dedup + done_delta filtering
- `lib/team_session_report_proof_helpers.ml` — threshold mandatory enforcement
- `lib/team_session_types.ml` — execution_scope default
- `lib/tool_inline_dispatch.ml` — .masc/ path validation
- `lib/prometheus.ml` + `lib/mcp_server_eio.ml` — gauge reconciliation

## Test plan

- [ ] `dune build --root .` passes
- [ ] `make test` passes
- [ ] HTTP test: `masc_add_task` → `workflow_guidance.next_steps` contains `masc_transition`
- [ ] HTTP test: `masc_set_room("/bad/path")` returns error
- [ ] HTTP test: team session stop → status = "completed"
- [ ] HTTP test: team session prove with < threshold turns → verdict != "proved"

Closes #1349, #1350, #1351, #1352, #1353, #1354, #1355, #1356

🤖 Generated with [Claude Code](https://claude.com/claude-code)