### PR TITLE
refactor: unify Llm_types.role with Llm_provider.Types (Phase 3a)

### DIFF
--- a/lib/llm_client.ml
+++ b/lib/llm_client.ml
@@ -76,22 +76,9 @@ let to_oas_message (m : message) : Agent_sdk.Types.message option =
     Some { Agent_sdk.Types.role = Assistant; content = [Text m.content] }
 
 let of_oas_message (m : Agent_sdk.Types.message) : message =
-  let role = match m.role with
-    | Agent_sdk.Types.User -> User
-    | Agent_sdk.Types.Assistant -> Assistant
-    | Agent_sdk.Types.System -> System
-    | Agent_sdk.Types.Tool -> Tool
-  in
-  let content =
-    m.content
-    |> List.filter_map (fun (block : Agent_sdk.Types.content_block) ->
-         match block with
-         | Agent_sdk.Types.Text s -> Some s
-         | Agent_sdk.Types.ToolResult { content; _ } -> Some content
-         | _ -> None)
-    |> String.concat "\n"
-  in
-  { role; content; name = None; tool_call_id = None }
+  (* Role is now the same type -- no mapping needed *)
+  let content = Agent_sdk.Types.text_of_content m.content in
+  { role = m.role; content; name = None; tool_call_id = None }
 
 let of_oas_usage (u : Agent_sdk.Types.api_usage) : token_usage =
   {

--- a/lib/llm_types.ml
+++ b/lib/llm_types.ml
@@ -31,7 +31,7 @@ type model_spec = {
   cost_per_1k_output : float;
 }
 
-type role = System | User | Assistant | Tool
+type role = Agent_sdk.Types.role = System | User | Assistant | Tool
 
 type message = {
   role : role;
@@ -96,11 +96,7 @@ let string_of_provider = function
   | OpenRouter -> "openrouter"
   | Custom s -> sprintf "custom(%s)" s
 
-let string_of_role = function
-  | System -> "system"
-  | User -> "user"
-  | Assistant -> "assistant"
-  | Tool -> "tool"
+let string_of_role = Agent_sdk.Types.role_to_string
 
 let llama_default = {
   provider = Llama;

--- a/lib/llm_types.mli
+++ b/lib/llm_types.mli
@@ -31,8 +31,9 @@ type model_spec = {
 
 (** {1 Message Types} *)
 
-(** Role in a conversation. *)
-type role = System | User | Assistant | Tool
+(** Role in a conversation.
+    Unified with {!Agent_sdk.Types.role} via {!Llm_provider.Types}. *)
+type role = Agent_sdk.Types.role = System | User | Assistant | Tool
 
 (** A single message in a conversation. *)
 type message = {
@@ -98,7 +99,8 @@ val normalize_request : completion_request -> completion_request
 (** String representation of provider. *)
 val string_of_provider : provider -> string
 
-(** String representation of role. *)
+(** String representation of role.
+    Delegates to {!Llm_provider.Types.role_to_string}. *)
 val string_of_role : role -> string
 
 (** {1 Built-in Model Specs} *)


### PR DESCRIPTION
## Summary

- MASC `Llm_types.role`을 `Agent_sdk.Types.role`과 동일 타입으로 통합 (nominal type equality)
- `of_oas_message`에서 role 매핑 제거 (4-branch match → identity)
- `string_of_role`를 `Agent_sdk.Types.role_to_string`에 위임
- adapter 코드 15줄 제거

### Phase 3 로드맵

| Phase | 내용 | 상태 |
|-------|------|------|
| 3a | role 타입 통합 | 이 PR |
| 3b | message 타입 통합 (flat string → content_block list) | 미착수, 116곳 |
| 3c | adapter 완전 제거 | 3b 이후 |

## Test plan

- [x] `dune build` 성공
- [x] perpetual 186/186 통과
- [x] operator_control 29/29 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)