### PR TITLE
fix(dashboard): Stdlib.Mutex → Eio.Mutex deadlock fix

### DIFF
--- a/lib/dashboard_governance_judge.ml
+++ b/lib/dashboard_governance_judge.ml
@@ -11,7 +11,7 @@ type runtime_snapshot = {
 }
 
 type state = {
-  mutex : Mutex.t;
+  mutex : Eio.Mutex.t;
   mutable started : bool;
   mutable refreshing : bool;
   mutable judge_online : bool;
@@ -33,8 +33,7 @@ let judgments_path base_path =
 let states : (string, state) Hashtbl.t = Hashtbl.create 4
 
 let with_lock (st : state) f =
-  Mutex.lock st.mutex;
-  Fun.protect f ~finally:(fun () -> Mutex.unlock st.mutex)
+  Eio.Mutex.use_rw ~protect:true st.mutex f
 
 let rec ensure_dir path =
   if not (Sys.file_exists path) then (
@@ -72,7 +71,7 @@ let get_state base_path =
   | None ->
       let st =
         {
-          mutex = Mutex.create ();
+          mutex = Eio.Mutex.create ();
           started = false;
           refreshing = false;
           judge_online = false;

--- a/lib/dashboard_mission_briefing.ml
+++ b/lib/dashboard_mission_briefing.ml
@@ -8,7 +8,7 @@ let mission_briefing_surface_contract_json =
       ("basis", `String "truth");
     ]
 type cache_state = {
-  mutex : Mutex.t;
+  mutex : Eio.Mutex.t;
   mutable cached_at : float;
   mutable cached_json : Yojson.Safe.t option;
   mutable refresh_in_flight : bool;
@@ -17,7 +17,7 @@ type cache_state = {
 
 let cache =
   {
-    mutex = Mutex.create ();
+    mutex = Eio.Mutex.create ();
     cached_at = 0.0;
     cached_json = None;
     refresh_in_flight = false;
@@ -25,8 +25,7 @@ let cache =
   }
 
 let with_cache_lock f =
-  Mutex.lock cache.mutex;
-  Fun.protect f ~finally:(fun () -> Mutex.unlock cache.mutex)
+  Eio.Mutex.use_rw ~protect:true cache.mutex f
 
 let compact_text ?(max_len = 96) raw =
   let normalized =

--- a/lib/dashboard_operator_judge.ml
+++ b/lib/dashboard_operator_judge.ml
@@ -12,7 +12,7 @@ type runtime_snapshot = {
 }
 
 type state = {
-  mutex : Mutex.t;
+  mutex : Eio.Mutex.t;
   mutable started : bool;
   mutable refreshing : bool;
   mutable judge_online : bool;
@@ -27,8 +27,7 @@ let keeper_name = "operator-judge"
 let states : (string, state) Hashtbl.t = Hashtbl.create 4
 
 let with_lock st f =
-  Mutex.lock st.mutex;
-  Fun.protect f ~finally:(fun () -> Mutex.unlock st.mutex)
+  Eio.Mutex.use_rw ~protect:true st.mutex f
 
 let get_state base_path =
   match Hashtbl.find_opt states base_path with
@@ -36,7 +35,7 @@ let get_state base_path =
   | None ->
       let st =
         {
-          mutex = Mutex.create ();
+          mutex = Eio.Mutex.create ();
           started = false;
           refreshing = false;
           judge_online = false;


### PR DESCRIPTION
## Summary
- Dashboard `/mission`, `/room-truth` 엔드포인트에서 500 Internal Server Error 발생
- 원인: `Stdlib.Mutex`를 single-domain Eio 서버에서 사용 → concurrent fiber 접근 시 EDEADLK
- 3개 dashboard 모듈의 `Stdlib.Mutex` → `Eio.Mutex` 교체

## Changed files
- `dashboard_mission_briefing.ml`
- `dashboard_governance_judge.ml`
- `dashboard_operator_judge.ml`

## Note
코드베이스에 `Stdlib.Mutex` 사용이 40+개소 남아있으나, 이 PR은 실제 500 에러를 일으킨 dashboard 모듈만 수정. 나머지는 별도 이슈로 추적 권장.

## Test plan
- [x] `dune build --root .` 성공
- [ ] 서버 재시작 후 `/api/v1/dashboard/mission`, `/room-truth` 200 확인
- [ ] concurrent request 시 deadlock 미발생 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)