### PR TITLE
fix: add schema-gap modules to dispatch fallback chain

### DIFF
--- a/lib/mcp_server_eio_execute.ml
+++ b/lib/mcp_server_eio_execute.ml
@@ -539,7 +539,7 @@ let execute_tool_eio ~sw ~clock ?mcp_session_id ?auth_token state ~name ~argumen
         Tool_cost.dispatch { Tool_cost.agent_name } ~name ~args:arguments
     | Mod_walph ->
         (match state.Mcp_server.net with
-         | None -> Some (false, "walph requires net (server_state.net is None)")
+         | None -> None  (* net unavailable: skip walph, let other modules handle *)
          | Some net ->
            let ctx : _ Tool_walph.context = { config; agent_name; net; clock } in
            Tool_walph.dispatch ctx ~name ~args:arguments)
@@ -616,18 +616,37 @@ let execute_tool_eio ~sw ~clock ?mcp_session_id ?auth_token state ~name ~argumen
         Tool_inline_dispatch.dispatch inline_ctx ~name
   in
 
-  (* Primary dispatch: O(1) tag lookup → lazy context creation *)
-  match Tool_dispatch.lookup_tag name with
-  | Some tag ->
-    (match dispatch_by_tag tag with
-     | Some result -> result
-     | None -> (false, Printf.sprintf "Unknown tool: %s" name))
+  (* Primary dispatch: O(1) tag lookup → lazy context creation.
+     Falls through to brute-force chain when tag lookup misses
+     (e.g., tools defined in tool_schemas_core but dispatched by
+     a module whose schemas don't include them). *)
+  let tag_result =
+    match Tool_dispatch.lookup_tag name with
+    | Some tag -> dispatch_by_tag tag
+    | None -> None
+  in
+  match tag_result with
+  | Some result -> result
   | None ->
-    (* Fallback for tools not in tag registry: lazy context per-module chain.
-       This handles modules without exported schemas. Each module's context
-       is created only if the match arm is reached. *)
+    (* Fallback: try tag-registered modules whose schemas may not include
+       all their handled tools (e.g. masc_init is in tool_schemas_core_01
+       but dispatched by Tool_room), then non-tag modules. *)
     let try_dispatch f = f () in
     let fallback_result =
+      (* Tag-registered modules with known schema gaps *)
+      try_dispatch (fun () -> Tool_plan.dispatch { Tool_plan.config } ~name ~args:arguments)
+      |> function Some r -> Some r | None ->
+      try_dispatch (fun () -> Tool_room.dispatch { Tool_room.config; agent_name } ~name ~args:arguments)
+      |> function Some r -> Some r | None ->
+      try_dispatch (fun () -> Tool_agent.dispatch { Tool_agent.config; agent_name } ~name ~args:arguments)
+      |> function Some r -> Some r | None ->
+      try_dispatch (fun () -> Tool_auth.dispatch { Tool_auth.config; agent_name } ~name ~args:arguments)
+      |> function Some r -> Some r | None ->
+      try_dispatch (fun () -> Tool_misc.dispatch { Tool_misc.config; agent_name } ~name ~args:arguments)
+      |> function Some r -> Some r | None ->
+      try_dispatch (fun () -> Tool_control.dispatch { Tool_control.config; agent_name } ~name ~args:arguments)
+      |> function Some r -> Some r | None ->
+      (* Non-tag modules *)
       try_dispatch (fun () -> Tool_run.dispatch { Tool_run.config } ~name ~args:arguments)
       |> function Some r -> Some r | None ->
       try_dispatch (fun () -> Tool_cache.dispatch { Tool_cache.config } ~name ~args:arguments)


### PR DESCRIPTION
## Summary

tag-based dispatch 도입 후 `tool_schemas_core_*`에 정의되었지만 해당 모듈의 `.schemas`에는 포함 안 된 도구들(`masc_init`, `masc_join` 등)이 "Unknown tool"로 실패.

- Tag lookup miss → fallback chain에 해당 모듈 없음 → unreachable
- `Mod_walph`가 net 없을 때 `Some (false, ...)` 반환 → brute-force시 false positive

## Fix

- Tool_plan, Tool_room, Tool_agent, Tool_auth, Tool_misc, Tool_control을 fallback chain에 추가 (lazy context creation)
- `Mod_walph` net 없을 때 `None` 반환으로 변경

## Test plan

- [x] `test_mcp_server_eio` 전체 0 failures (로컬)
- [ ] CI Build and Test green

🤖 Generated with [Claude Code](https://claude.com/claude-code)