### PR TITLE
fix: migrate remaining 17 Stdlib.Mutex to Eio.Mutex

### DIFF
--- a/lib/audit_log.ml
+++ b/lib/audit_log.ml
@@ -150,7 +150,7 @@ let entry_of_json (json : Yojson.Safe.t) : audit_entry option =
 
 (** {1 File Operations} *)
 
-let mutex = Mutex.create ()
+let mutex = Eio.Mutex.create ()
 
 let get_audit_path (config : Room.config) =
   let masc_dir = Room_utils.masc_dir config in
@@ -191,20 +191,15 @@ let ensure_dir path =
 
 (** Append a single entry to the audit log (thread-safe) *)
 let append_entry (config : Room.config) (entry : audit_entry) =
-  Mutex.lock mutex;
-  Common.protect
-    ~module_name:"audit_log"
-    ~finally_label:"unlock"
-    ~finally:(fun () -> Mutex.unlock mutex)
-    (fun () ->
-      let path = get_audit_path config in
-      ensure_dir path;  (* Now safe: EEXIST handled, inside mutex *)
-      let json_line = Yojson.Safe.to_string (entry_to_json entry) ^ "\n" in
-      let oc = open_out_gen [Open_append; Open_creat; Open_text] 0o644 path in
-      Fun.protect ~finally:(fun () -> close_out oc) (fun () ->
-        output_string oc json_line
-      )
+  Eio.Mutex.use_rw ~protect:true mutex (fun () ->
+    let path = get_audit_path config in
+    ensure_dir path;
+    let json_line = Yojson.Safe.to_string (entry_to_json entry) ^ "\n" in
+    let oc = open_out_gen [Open_append; Open_creat; Open_text] 0o644 path in
+    Fun.protect ~finally:(fun () -> close_out oc) (fun () ->
+      output_string oc json_line
     )
+  )
 
 (** {1 Logging API} *)
 

--- a/lib/backend.ml
+++ b/lib/backend.ml
@@ -180,20 +180,17 @@ module MemoryBackend : BACKEND = struct
   type t = {
     data: (string, string) Hashtbl.t;
     locks: (string, lock_info) Hashtbl.t;
-    mutex: Mutex.t;
+    mutex: Eio.Mutex.t;
   }
 
   let with_lock t f =
-    Mutex.lock t.mutex;
-    let result = try f () with e -> Mutex.unlock t.mutex; raise e in
-    Mutex.unlock t.mutex;
-    result
+    Eio.Mutex.use_rw ~protect:true t.mutex f
 
   let create (_cfg : config) : (t, error) result =
     Ok {
       data = Hashtbl.create 1000;
       locks = Hashtbl.create 100;
-      mutex = Mutex.create ();
+      mutex = Eio.Mutex.create ();
     }
 
   let close _t = ()
@@ -312,14 +309,11 @@ end
 module FileSystemBackend : BACKEND = struct
   type t = {
     base_path: string;
-    mutex: Mutex.t;
+    mutex: Eio.Mutex.t;
   }
 
   let with_lock t f =
-    Mutex.lock t.mutex;
-    let result = try f () with e -> Mutex.unlock t.mutex; raise e in
-    Mutex.unlock t.mutex;
-    result
+    Eio.Mutex.use_rw ~protect:true t.mutex f
 
   (* Security: validate key with strict allowlist (parse, don't sanitize) *)
   let validate_key key =
@@ -408,14 +402,13 @@ module FileSystemBackend : BACKEND = struct
         Unix.mkdir path 0o755
     with Unix.Unix_error (err, _, _) ->
       Log.Misc.error "Failed to mkdir %s: %s" path (Unix.error_message err));
-    Ok { base_path = path; mutex = Mutex.create () }
+    Ok { base_path = path; mutex = Eio.Mutex.create () }
 
   let close _t = ()
 
   (* Read operations are lock-free: writes use atomic rename, so a
      concurrent read always sees either the old or new complete content.
-     Removing the Stdlib.Mutex here eliminates 1-6s of Eio scheduler
-     starvation when background init fibers hold the write lock. *)
+     Eio.Mutex is cooperative and does not starve the scheduler. *)
   let get t ~key =
     match safe_key_to_path t key with
     | Error e -> Error e

--- a/lib/chain_native_eio.ml
+++ b/lib/chain_native_eio.ml
@@ -45,16 +45,11 @@ let tool_executor_ref : tool_executor option ref = ref None
 let set_tool_executor executor =
   tool_executor_ref := Some executor
 
-let bootstrap_mutex = Mutex.create ()
+let bootstrap_mutex = Eio.Mutex.create ()
 let bootstrapped_roots : (string, unit) Hashtbl.t = Hashtbl.create 4
 
 let with_mutex mutex f =
-  Mutex.lock mutex;
-  Common.protect
-    ~module_name:"chain_native_eio"
-    ~finally_label:"Mutex.unlock"
-    ~finally:(fun () -> Mutex.unlock mutex)
-    f
+  Eio.Mutex.use_rw ~protect:true mutex f
 
 let starts_with ~prefix s =
   let plen = String.length prefix in

--- a/lib/chain_registry.ml
+++ b/lib/chain_registry.ml
@@ -43,17 +43,10 @@ type registry_stats = {
 (** In-memory registry storage *)
 let registry : (string, registry_entry) Hashtbl.t = Hashtbl.create 64
 
-(** Standard mutex for thread-safe operations *)
-let registry_mutex = Mutex.create ()
+let registry_mutex = Eio.Mutex.create ()
 
-(** Helper for mutex-protected operations *)
 let with_mutex f =
-  Mutex.lock registry_mutex;
-  Common.protect
-    ~module_name:"chain_registry"
-    ~finally_label:"Mutex.unlock"
-    ~finally:(fun () -> Mutex.unlock registry_mutex)
-    f
+  Eio.Mutex.use_rw ~protect:true registry_mutex f
 
 (** File-based persistence directory *)
 let registry_dir = ref None

--- a/lib/federation.ml
+++ b/lib/federation.ml
@@ -211,15 +211,10 @@ let make_federation_member ~(org : organization) ~now : federation_member = {
 (* Thread Safety: Mutex for Global State       *)
 (* ============================================ *)
 
-(** Mutex for thread-safe state access *)
-let state_mutex = Mutex.create ()
+let state_mutex = Eio.Mutex.create ()
 
-(** Execute function with mutex held *)
 let with_lock f =
-  Mutex.lock state_mutex;
-  match f () with
-  | result -> Mutex.unlock state_mutex; result
-  | exception e -> Mutex.unlock state_mutex; raise e
+  Eio.Mutex.use_rw ~protect:true state_mutex f
 
 (* ============================================ *)
 (* Input Validation                            *)

--- a/lib/progress.ml
+++ b/lib/progress.ml
@@ -134,26 +134,21 @@ module State = struct
   type t = {
     mutable sse_broadcast: Yojson.Safe.t -> unit;
     trackers: (string, Tracker.t) Hashtbl.t;
-    mutex: Mutex.t;
+    mutex: Eio.Mutex.t;
   }
 
   let create () = {
     sse_broadcast = (fun _ ->
-      (* Default no-op. Unlike notify_ref, this is expected during init.
-         set_sse_callback should be called before any progress notifications. *)
       ()
     );
     trackers = Hashtbl.create 32;
-    mutex = Mutex.create ();
+    mutex = Eio.Mutex.create ();
   }
 
-  (** Module singleton - initialized once *)
   let global = create ()
 
-  (** Thread-safe operation wrapper *)
   let with_lock f =
-    Mutex.lock global.mutex;
-    Fun.protect ~finally:(fun () -> Mutex.unlock global.mutex) f
+    Eio.Mutex.use_rw ~protect:true global.mutex f
 
   (** Reset for testing only *)
   let reset () =

--- a/lib/prompt_registry.ml
+++ b/lib/prompt_registry.ml
@@ -89,17 +89,10 @@ let registry : (string, prompt_entry) Hashtbl.t = Hashtbl.create 64
 (** Version index: id -> [version list] for quick version lookup *)
 let version_index : (string, string list) Hashtbl.t = Hashtbl.create 64
 
-(** Standard mutex for thread-safe operations *)
-let registry_mutex = Mutex.create ()
+let registry_mutex = Eio.Mutex.create ()
 
-(** Helper for mutex-protected operations *)
 let with_mutex f =
-  Mutex.lock registry_mutex;
-  Common.protect
-    ~module_name:"prompt_registry"
-    ~finally_label:"Mutex.unlock"
-    ~finally:(fun () -> Mutex.unlock registry_mutex)
-    f
+  Eio.Mutex.use_rw ~protect:true registry_mutex f
 
 (** {1 Persistence} *)
 

--- a/lib/room_walph.ml
+++ b/lib/room_walph.ml
@@ -28,46 +28,37 @@ type walph_state = {
   mutable current_preset : string;
   mutable iterations : int;
   mutable completed : int;
-  mutex : Mutex.t;       (* Thread safety for state access *)
-  cond : Condition.t;    (* Proper wait for pause/resume, no busy-wait *)
+  mutex : Eio.Mutex.t;
+  cond : Eio.Condition.t;
 }
 
-(** Global Walph state table with its own mutex for thread-safe access *)
 let walph_states : (string, walph_state) Hashtbl.t = Hashtbl.create 16
-let walph_states_mutex = Mutex.create ()
+let walph_states_mutex = Eio.Mutex.create ()
 
-(** Get or create Walph state for a room (thread-safe) *)
 let get_walph_state config =
   let key = config.base_path in
-  Mutex.lock walph_states_mutex;
-  (* Deadlock fix: use Fun.protect to ensure unlock on exception *)
-  Fun.protect ~finally:(fun () -> Mutex.unlock walph_states_mutex) (fun () ->
+  Eio.Mutex.use_rw ~protect:true walph_states_mutex (fun () ->
     match Hashtbl.find_opt walph_states key with
     | Some s -> s
     | None ->
         let s = {
           running = false; paused = false; stop_requested = false;
           current_preset = ""; iterations = 0; completed = 0;
-          mutex = Mutex.create ();
-          cond = Condition.create ();
+          mutex = Eio.Mutex.create ();
+          cond = Eio.Condition.create ();
         } in
         Hashtbl.replace walph_states key s;
         s
   )
 
-(** Remove Walph state for a room (cleanup) *)
 let remove_walph_state config =
   let key = config.base_path in
-  Mutex.lock walph_states_mutex;
-  (* Deadlock fix: use Fun.protect to ensure unlock on exception *)
-  Fun.protect ~finally:(fun () -> Mutex.unlock walph_states_mutex) (fun () ->
+  Eio.Mutex.use_rw ~protect:true walph_states_mutex (fun () ->
     Hashtbl.remove walph_states key
   )
 
-(** Run with Walph state mutex locked *)
 let with_walph_lock state f =
-  Mutex.lock state.mutex;
-  Common.protect ~module_name:"room" ~finally_label:"finalizer" ~finally:(fun () -> Mutex.unlock state.mutex) f
+  Eio.Mutex.use_rw ~protect:true state.mutex f
 
 (** Parse @walph command from broadcast message
     Returns: (command, args) or None if not a walph command *)
@@ -104,7 +95,7 @@ let walph_control config ~from_agent ~command ~args =
     | "STOP" ->
         if state.running then begin
           state.stop_requested <- true;
-          Condition.broadcast state.cond;  (* Wake up pause wait *)
+          Eio.Condition.broadcast state.cond;  (* Wake up pause wait *)
           Printf.sprintf "🛑 @walph STOP requested by %s (will stop after current iteration)" from_agent
         end else
           "ℹ️ @walph is not currently running"
@@ -119,7 +110,7 @@ let walph_control config ~from_agent ~command ~args =
     | "RESUME" ->
         if state.paused then begin
           state.paused <- false;
-          Condition.broadcast state.cond;  (* Wake up pause wait *)
+          Eio.Condition.broadcast state.cond;  (* Wake up pause wait *)
           Printf.sprintf "▶️ @walph RESUMED by %s" from_agent
         end else if state.running then
           "ℹ️ @walph is already running"
@@ -155,7 +146,7 @@ let walph_should_continue config =
       (* Wait on condition variable - no busy-wait! *)
       (* Condition.wait atomically releases mutex and waits *)
       while state.paused && not state.stop_requested do
-        Condition.wait state.cond state.mutex
+        Eio.Condition.await state.cond state.mutex
       done;
       not state.stop_requested
     end else true

--- a/lib/server_trpg_rest_actor.ml
+++ b/lib/server_trpg_rest_actor.ml
@@ -11,23 +11,22 @@ type trpg_actor_spawn_cached = {
 }
 
 type trpg_actor_spawn_guard_state = {
-  mutex : Mutex.t;
-  room_mutexes : (string, Mutex.t) Hashtbl.t;
+  mutex : Eio.Mutex.t;
+  room_mutexes : (string, Eio.Mutex.t) Hashtbl.t;
   idempotency_cache : (string, trpg_actor_spawn_cached) Hashtbl.t;
   mutable next_seq : int;
 }
 
 let trpg_actor_spawn_guard : trpg_actor_spawn_guard_state =
   {
-    mutex = Mutex.create ();
+    mutex = Eio.Mutex.create ();
     room_mutexes = Hashtbl.create 64;
     idempotency_cache = Hashtbl.create 2048;
     next_seq = 0;
   }
 
 let trpg_with_actor_spawn_guard_lock f =
-  Mutex.lock trpg_actor_spawn_guard.mutex;
-  Fun.protect ~finally:(fun () -> Mutex.unlock trpg_actor_spawn_guard.mutex) f
+  Eio.Mutex.use_rw ~protect:true trpg_actor_spawn_guard.mutex f
 
 let trpg_with_actor_spawn_room_lock ~room_id f =
   let room_key = String.trim room_id in
@@ -37,12 +36,11 @@ let trpg_with_actor_spawn_room_lock ~room_id f =
         match Hashtbl.find_opt trpg_actor_spawn_guard.room_mutexes room_key with
         | Some m -> m
         | None ->
-            let m = Mutex.create () in
+            let m = Eio.Mutex.create () in
             Hashtbl.replace trpg_actor_spawn_guard.room_mutexes room_key m;
             m)
   in
-  Mutex.lock room_mutex;
-  Fun.protect ~finally:(fun () -> Mutex.unlock room_mutex) f
+  Eio.Mutex.use_rw ~protect:true room_mutex f
 
 let trpg_actor_spawn_cache_key ~room_id ~idempotency_key =
   room_id ^ "\x1f" ^ idempotency_key

--- a/lib/server_trpg_rest_models.ml
+++ b/lib/server_trpg_rest_models.ml
@@ -391,7 +391,7 @@ let trpg_available_models_json_base ?(warnings : string list = []) () : Yojson.S
   trpg_available_models_json_collect ~warnings ~include_live:false ()
 
 type trpg_model_catalog_cache = {
-  mutex : Mutex.t;
+  mutex : Eio.Mutex.t;
   mutable cached_at : float;
   mutable cached_json : Yojson.Safe.t option;
   mutable refresh_in_flight : bool;
@@ -401,7 +401,7 @@ let trpg_model_catalog_cache_ttl_sec = 15.0
 
 let trpg_model_catalog_cache : trpg_model_catalog_cache =
   {
-    mutex = Mutex.create ();
+    mutex = Eio.Mutex.create ();
     cached_at = 0.0;
     cached_json = None;
     refresh_in_flight = false;
@@ -410,8 +410,7 @@ let trpg_model_catalog_cache : trpg_model_catalog_cache =
 let trpg_available_models_json () : Yojson.Safe.t =
   let now = Unix.gettimeofday () in
   let cached, should_refresh =
-    Mutex.lock trpg_model_catalog_cache.mutex;
-    Fun.protect ~finally:(fun () -> Mutex.unlock trpg_model_catalog_cache.mutex) (fun () ->
+    Eio.Mutex.use_rw ~protect:true trpg_model_catalog_cache.mutex (fun () ->
       let snapshot = trpg_model_catalog_cache.cached_json in
       let fresh_snapshot =
         match trpg_model_catalog_cache.cached_json with
@@ -429,8 +428,7 @@ let trpg_available_models_json () : Yojson.Safe.t =
             trpg_model_catalog_cache.refresh_in_flight <- true;
             true
       in
-      ((match fresh_snapshot with Some json -> Some json | None -> snapshot), should_refresh)
-    )
+      ((match fresh_snapshot with Some json -> Some json | None -> snapshot), should_refresh))
   in
   match (cached, should_refresh) with
   | Some json, false -> json
@@ -441,9 +439,8 @@ let trpg_available_models_json () : Yojson.Safe.t =
       let fallback_json =
         Fun.protect
           ~finally:(fun () ->
-            Mutex.lock trpg_model_catalog_cache.mutex;
-            trpg_model_catalog_cache.refresh_in_flight <- false;
-            Mutex.unlock trpg_model_catalog_cache.mutex)
+            Eio.Mutex.use_rw ~protect:true trpg_model_catalog_cache.mutex (fun () ->
+              trpg_model_catalog_cache.refresh_in_flight <- false))
           (fun () ->
             let outcome =
               try Ok (trpg_available_models_json_uncached ())
@@ -461,9 +458,8 @@ let trpg_available_models_json () : Yojson.Safe.t =
                     trpg_available_models_json_base
                       ~warnings:[Printf.sprintf "가용 모델 조회 실패: %s" err] ()))
       in
-      Mutex.lock trpg_model_catalog_cache.mutex;
-      trpg_model_catalog_cache.cached_json <- Some fallback_json;
-      trpg_model_catalog_cache.cached_at <- Unix.gettimeofday ();
-      Mutex.unlock trpg_model_catalog_cache.mutex;
+      Eio.Mutex.use_rw ~protect:true trpg_model_catalog_cache.mutex (fun () ->
+        trpg_model_catalog_cache.cached_json <- Some fallback_json;
+        trpg_model_catalog_cache.cached_at <- Unix.gettimeofday ());
       fallback_json
 

--- a/lib/server_trpg_rest_runtime.ml
+++ b/lib/server_trpg_rest_runtime.ml
@@ -57,7 +57,7 @@ let trpg_keeper_call_with_runtime
   | exn -> `Error (Printexc.to_string exn)
 
 type trpg_round_run_guard_state = {
-  mutex : Mutex.t;
+  mutex : Eio.Mutex.t;
   inflight_rooms : (string, unit) Hashtbl.t;
   idempotency_cache : (string, Yojson.Safe.t) Hashtbl.t;
   mutable cache_writes : int;
@@ -65,7 +65,7 @@ type trpg_round_run_guard_state = {
 
 let trpg_round_run_guard : trpg_round_run_guard_state =
   {
-    mutex = Mutex.create ();
+    mutex = Eio.Mutex.create ();
     inflight_rooms = Hashtbl.create 64;
     idempotency_cache = Hashtbl.create 512;
     cache_writes = 0;
@@ -104,8 +104,7 @@ let trpg_round_run_json
     ~body_str
   : trpg_api_result =
   let with_round_run_guard_lock f =
-    Mutex.lock trpg_round_run_guard.mutex;
-    Fun.protect ~finally:(fun () -> Mutex.unlock trpg_round_run_guard.mutex) f
+    Eio.Mutex.use_rw ~protect:true trpg_round_run_guard.mutex f
   in
   let trpg_round_run_extract_room_id (args : Yojson.Safe.t) : string =
     let pick key =

--- a/lib/tool_lodge_agents_cache.ml
+++ b/lib/tool_lodge_agents_cache.ml
@@ -89,7 +89,7 @@ let builtin_core_agent_configs () =
 
 (** In-memory cache for dynamic agents (protected by mutex for concurrent access) *)
 let agent_cache : (string, agent_config) Hashtbl.t = Hashtbl.create 10
-let agent_cache_mu = Mutex.create ()
+let agent_cache_mu = Eio.Mutex.create ()
 
 (** {2 File-based cache for offline fallback} *)
 
@@ -142,9 +142,8 @@ let agent_config_of_yojson (json : Yojson.Safe.t) : agent_config option =
 
 (** Save in-memory agent cache to file *)
 let save_agents_to_file_cache () =
-  Mutex.lock agent_cache_mu;
-  let agents = Hashtbl.fold (fun _ v acc -> v :: acc) agent_cache [] in
-  Mutex.unlock agent_cache_mu;
+  let agents = Eio.Mutex.use_rw ~protect:true agent_cache_mu (fun () ->
+    Hashtbl.fold (fun _ v acc -> v :: acc) agent_cache []) in
   if agents = [] then ()
   else begin
     let cache_json = `Assoc [
@@ -184,9 +183,8 @@ let load_agents_from_file_cache () : bool =
       end else begin
         let agents_json = json |> member "agents" |> to_list in
         let loaded = List.filter_map agent_config_of_yojson agents_json in
-        Mutex.lock agent_cache_mu;
-        List.iter (fun a -> Hashtbl.replace agent_cache a.name a) loaded;
-        Mutex.unlock agent_cache_mu;
+        Eio.Mutex.use_rw ~protect:true agent_cache_mu (fun () ->
+          List.iter (fun a -> Hashtbl.replace agent_cache a.name a) loaded);
         Log.Lodge.info "Loaded %d agents from file cache (%.1f hours old)" (List.length loaded) age_hours;
         true
       end
@@ -196,9 +194,8 @@ let load_agents_from_file_cache () : bool =
   end
 
 let has_cached_agents_in_memory () =
-  Mutex.lock agent_cache_mu;
-  let n = Hashtbl.length agent_cache in
-  Mutex.unlock agent_cache_mu;
+  let n = Eio.Mutex.use_rw ~protect:true agent_cache_mu (fun () ->
+    Hashtbl.length agent_cache) in
   n > 0
 
 let load_agents_from_cache_if_available () =
@@ -208,11 +205,10 @@ let load_agents_from_cache_if_available () =
     false
 
 let prime_builtin_core_agents () =
-  Mutex.lock agent_cache_mu;
-  List.iter
-    (fun cfg -> Hashtbl.replace agent_cache cfg.name cfg)
-    (builtin_core_agent_configs ());
-  Mutex.unlock agent_cache_mu
+  Eio.Mutex.use_rw ~protect:true agent_cache_mu (fun () ->
+    List.iter
+      (fun cfg -> Hashtbl.replace agent_cache cfg.name cfg)
+      (builtin_core_agent_configs ()))
 
 (** Load agents from Neo4j via GraphQL API with file cache fallback *)
 let load_agents_config () =
@@ -259,14 +255,12 @@ let load_agents_config () =
                      model = Yojson.Safe.Util.(member "model" node |> to_string_option) |> Option.value ~default:(default_model ());
                      interests;
                    } in
-                   Mutex.lock agent_cache_mu;
-                   Hashtbl.replace agent_cache config.name config;
-                   Mutex.unlock agent_cache_mu
+                   Eio.Mutex.use_rw ~protect:true agent_cache_mu (fun () ->
+                     Hashtbl.replace agent_cache config.name config)
                  with Yojson.Safe.Util.Type_error _ | Yojson.Json_error _ -> ()
                ) edges;
-               Mutex.lock agent_cache_mu;
-               let n = Hashtbl.length agent_cache in
-               Mutex.unlock agent_cache_mu;
+               let n = Eio.Mutex.use_rw ~protect:true agent_cache_mu (fun () ->
+                 Hashtbl.length agent_cache) in
                if n > 0 then begin
                  graphql_success := true;
                  Log.Lodge.info "✅ Loaded %d SOUL agents from Neo4j" n;
@@ -289,10 +283,8 @@ let load_agents_config () =
 
 (** Get cached agent config, or None if not loaded *)
 let get_cached_agent name =
-  Mutex.lock agent_cache_mu;
-  let r = Hashtbl.find_opt agent_cache name in
-  Mutex.unlock agent_cache_mu;
-  r
+  Eio.Mutex.use_rw ~protect:true agent_cache_mu (fun () ->
+    Hashtbl.find_opt agent_cache name)
 
 (** Get primary value from cached agent (for SOUL-based decisions) *)
 let get_agent_primary_value name =
@@ -392,14 +384,12 @@ let evolve_agent ~name ~dimension ~outcome =
         in
         let (status, _output) = run_cmd_with_status ~timeout_sec:60.0 argv in
         (match status with Unix.WEXITED 0 -> () | _ -> raise (Failure "cypher-shell failed"));
-        (* Update cache *)
-        Mutex.lock agent_cache_mu;
-        Hashtbl.replace agent_cache name {
-          config with
-          value_weights = Some new_weights_json;
-          generation = new_gen;
-        };
-        Mutex.unlock agent_cache_mu;
+        Eio.Mutex.use_rw ~protect:true agent_cache_mu (fun () ->
+          Hashtbl.replace agent_cache name {
+            config with
+            value_weights = Some new_weights_json;
+            generation = new_gen;
+          });
         Log.Evolution.info "%s evolved: %s %s%.2f -> gen %d"
           name dimension
           (if delta >= 0.0 then "+" else "") delta new_gen;

--- a/lib/tool_lodge_agents_ops.ml
+++ b/lib/tool_lodge_agents_ops.ml
@@ -11,15 +11,13 @@ let core_lodge_agents () = get_all_agent_names ()
 
 (** Get all Lodge agents via GraphQL *)
 let get_cached_agents_tuple () =
-  Mutex.lock agent_cache_mu;
-  let agents = Hashtbl.fold (fun _ cfg acc ->
-    if cfg.status = "active" then
-      (cfg.name, Option.value cfg.primary_value ~default:"unknown", Option.value cfg.prompt_template ~default:"", cfg.korean_name, cfg.generation) :: acc
-    else
-      acc
-  ) agent_cache [] in
-  Mutex.unlock agent_cache_mu;
-  agents
+  Eio.Mutex.use_rw ~protect:true agent_cache_mu (fun () ->
+    Hashtbl.fold (fun _ cfg acc ->
+      if cfg.status = "active" then
+        (cfg.name, Option.value cfg.primary_value ~default:"unknown", Option.value cfg.prompt_template ~default:"", cfg.korean_name, cfg.generation) :: acc
+      else
+        acc
+    ) agent_cache [])
 
 let get_all_agents () =
   (* DO NOT reduce below 15: GRAPHQL_MAX_COST=2000 (c09140c). 15 agents exist. *)

--- a/lib/tool_lodge_react_core.ml
+++ b/lib/tool_lodge_react_core.ml
@@ -10,10 +10,8 @@ open Tool_lodge_agents_cache
 
 (** Get all cached agent names *)
 let get_all_agent_names () =
-  Mutex.lock agent_cache_mu;
-  let r = Hashtbl.fold (fun k _ acc -> k :: acc) agent_cache [] in
-  Mutex.unlock agent_cache_mu;
-  r
+  Eio.Mutex.use_rw ~protect:true agent_cache_mu (fun () ->
+    Hashtbl.fold (fun k _ acc -> k :: acc) agent_cache [])
 
 (** Pick a random agent name from cache *)
 let random_agent_name () =
@@ -28,13 +26,11 @@ let validate_agent_name name =
     | Some _ -> Some name
     | None ->
       (* Try Korean name lookup *)
-      Mutex.lock agent_cache_mu;
-      let found = Hashtbl.fold (fun k v acc ->
-        match acc with Some _ -> acc | None ->
-        if v.korean_name = name then Some k else None
-      ) agent_cache None in
-      Mutex.unlock agent_cache_mu;
-      found
+      Eio.Mutex.use_rw ~protect:true agent_cache_mu (fun () ->
+        Hashtbl.fold (fun k v acc ->
+          match acc with Some _ -> acc | None ->
+          if v.korean_name = name then Some k else None
+        ) agent_cache None)
 
 (** Get model for agent (from Neo4j cache) *)
 let get_agent_model name =

--- a/lib/tool_registry.ml
+++ b/lib/tool_registry.ml
@@ -21,7 +21,7 @@ type call_stats = {
 
 (** Global registry - process-lifetime, protected by mutex for fiber safety *)
 let registry : (string, call_stats) Hashtbl.t = Hashtbl.create 128
-let registry_mutex = Mutex.create ()
+let registry_mutex = Eio.Mutex.create ()
 
 let known_tool_names : (string, unit) Hashtbl.t Lazy.t =
   lazy
@@ -36,10 +36,7 @@ let is_known_tool tool_name =
 
 (** Record a tool call. Called from handle_call_tool_eio after execution. *)
 let record_call ~tool_name ~success ~duration_ms =
-  Mutex.lock registry_mutex;
-  Fun.protect
-    ~finally:(fun () -> Mutex.unlock registry_mutex)
-    (fun () ->
+  Eio.Mutex.use_rw ~protect:true registry_mutex (fun () ->
       let stats =
         match Hashtbl.find_opt registry tool_name with
         | Some s -> s
@@ -68,10 +65,7 @@ let record_call_if_known ~tool_name ~success ~duration_ms =
 
 (** Get all stats as a sorted list (by call_count descending) *)
 let get_stats () : (string * call_stats) list =
-  Mutex.lock registry_mutex;
-  Fun.protect
-    ~finally:(fun () -> Mutex.unlock registry_mutex)
-    (fun () ->
+  Eio.Mutex.use_rw ~protect:true registry_mutex (fun () ->
       Hashtbl.fold (fun name stats acc -> (name, stats) :: acc) registry []
       |> List.sort (fun (_, a) (_, b) -> compare b.call_count a.call_count))
 
@@ -89,10 +83,7 @@ let get_top_n n : (string * call_stats) list =
     Only includes tools that are registered (have been called at least once)
     but not recently. *)
 let get_unused_since (cutoff : float) : string list =
-  Mutex.lock registry_mutex;
-  Fun.protect
-    ~finally:(fun () -> Mutex.unlock registry_mutex)
-    (fun () ->
+  Eio.Mutex.use_rw ~protect:true registry_mutex (fun () ->
       Hashtbl.fold
         (fun name stats acc ->
           if stats.last_called_at < cutoff then name :: acc else acc)
@@ -102,10 +93,7 @@ let get_unused_since (cutoff : float) : string list =
 (** Get tools that have never been called (not in registry at all)
     compared against a list of all known tool names *)
 let get_never_called (all_tool_names : string list) : string list =
-  Mutex.lock registry_mutex;
-  Fun.protect
-    ~finally:(fun () -> Mutex.unlock registry_mutex)
-    (fun () ->
+  Eio.Mutex.use_rw ~protect:true registry_mutex (fun () ->
       List.filter
         (fun name -> not (Hashtbl.mem registry name))
         all_tool_names
@@ -113,18 +101,12 @@ let get_never_called (all_tool_names : string list) : string list =
 
 (** Total calls across all tools *)
 let total_calls () : int =
-  Mutex.lock registry_mutex;
-  Fun.protect
-    ~finally:(fun () -> Mutex.unlock registry_mutex)
-    (fun () ->
+  Eio.Mutex.use_rw ~protect:true registry_mutex (fun () ->
       Hashtbl.fold (fun _ stats acc -> acc + stats.call_count) registry 0)
 
 (** Number of distinct tools that have been called *)
 let distinct_tools_called () : int =
-  Mutex.lock registry_mutex;
-  Fun.protect
-    ~finally:(fun () -> Mutex.unlock registry_mutex)
-    (fun () -> Hashtbl.length registry)
+  Eio.Mutex.use_rw ~protect:true registry_mutex (fun () -> Hashtbl.length registry)
 
 (** Convert call_stats to JSON *)
 let stats_to_json (name, (stats : call_stats)) : Yojson.Safe.t =
@@ -162,7 +144,4 @@ let stats_report ~top_n ~all_tool_names : Yojson.Safe.t =
 
 (** Reset all counters (for testing) *)
 let reset () =
-  Mutex.lock registry_mutex;
-  Fun.protect
-    ~finally:(fun () -> Mutex.unlock registry_mutex)
-    (fun () -> Hashtbl.clear registry)
+  Eio.Mutex.use_rw ~protect:true registry_mutex (fun () -> Hashtbl.clear registry)

--- a/lib/tool_suspend.ml
+++ b/lib/tool_suspend.ml
@@ -19,42 +19,27 @@ open Tool_args
 
 (** Blacklist entry: agent_id -> until timestamp *)
 let blacklist : (string, float * string) Hashtbl.t = Hashtbl.create 32
-let blacklist_lock = Mutex.create ()
+let blacklist_lock = Eio.Mutex.create ()
 
 let add_to_blacklist ~agent_id ~until ~reason =
-  Mutex.lock blacklist_lock;
-  Common.protect
-    ~module_name:"tool_suspend"
-    ~finally_label:"blacklist_add"
-    ~finally:(fun () -> Mutex.unlock blacklist_lock)
-    (fun () -> Hashtbl.replace blacklist agent_id (until, reason))
+  Eio.Mutex.use_rw ~protect:true blacklist_lock (fun () ->
+    Hashtbl.replace blacklist agent_id (until, reason))
 
 let check_blacklist ~agent_id =
-  Mutex.lock blacklist_lock;
-  Common.protect
-    ~module_name:"tool_suspend"
-    ~finally_label:"blacklist_check"
-    ~finally:(fun () -> Mutex.unlock blacklist_lock)
-    (fun () ->
-      match Hashtbl.find_opt blacklist agent_id with
-      | None -> None
-      | Some (until, reason) ->
-          let now = Time_compat.now () in
-          if now >= until then begin
-            (* Expired - remove from blacklist *)
-            Hashtbl.remove blacklist agent_id;
-            None
-          end else
-            Some (until, reason)
-    )
+  Eio.Mutex.use_rw ~protect:true blacklist_lock (fun () ->
+    match Hashtbl.find_opt blacklist agent_id with
+    | None -> None
+    | Some (until, reason) ->
+        let now = Time_compat.now () in
+        if now >= until then begin
+          Hashtbl.remove blacklist agent_id;
+          None
+        end else
+          Some (until, reason))
 
 let remove_from_blacklist ~agent_id =
-  Mutex.lock blacklist_lock;
-  Common.protect
-    ~module_name:"tool_suspend"
-    ~finally_label:"blacklist_remove"
-    ~finally:(fun () -> Mutex.unlock blacklist_lock)
-    (fun () -> Hashtbl.remove blacklist agent_id)
+  Eio.Mutex.use_rw ~protect:true blacklist_lock (fun () ->
+    Hashtbl.remove blacklist agent_id)
 
 (** {1 Room Operations} *)
 

--- a/lib/trpg_types.ml
+++ b/lib/trpg_types.ml
@@ -172,7 +172,7 @@ let keeper_preflight ctx ~(keepers : string list) : (unit, string) Stdlib.result
           (Printf.sprintf "keeper preflight failed: %s"
              (String.concat "; " failures))
 
-let keeper_busy_mutex = Mutex.create ()
+let keeper_busy_mutex = Eio.Mutex.create ()
 let keeper_busy_counts : (string, int) Hashtbl.t = Hashtbl.create 128
 
 let with_keeper_reservation ~(keepers : string list)
@@ -183,41 +183,35 @@ let with_keeper_reservation ~(keepers : string list)
     |> List.sort_uniq String.compare
   in
   let reserve () =
-    Mutex.lock keeper_busy_mutex;
-    Fun.protect
-      ~finally:(fun () -> Mutex.unlock keeper_busy_mutex)
-      (fun () ->
-        let busy =
-          List.filter
-            (fun key ->
-              let cnt = Hashtbl.find_opt keeper_busy_counts key |> Option.value ~default:0 in
-              cnt > 0)
-            keeper_keys
-        in
-        if busy <> [] then
-          Error
-            (Printf.sprintf
-               "keeper busy: %s (each spawned keeper can handle only one round at a time)"
-               (String.concat ", " busy))
-        else (
-          List.iter
-            (fun key ->
-              let cnt = Hashtbl.find_opt keeper_busy_counts key |> Option.value ~default:0 in
-              Hashtbl.replace keeper_busy_counts key (cnt + 1))
-            keeper_keys;
-          Ok ()))
-  in
-  let release () =
-    Mutex.lock keeper_busy_mutex;
-    Fun.protect
-      ~finally:(fun () -> Mutex.unlock keeper_busy_mutex)
-      (fun () ->
+    Eio.Mutex.use_rw ~protect:true keeper_busy_mutex (fun () ->
+      let busy =
+        List.filter
+          (fun key ->
+            let cnt = Hashtbl.find_opt keeper_busy_counts key |> Option.value ~default:0 in
+            cnt > 0)
+          keeper_keys
+      in
+      if busy <> [] then
+        Error
+          (Printf.sprintf
+             "keeper busy: %s (each spawned keeper can handle only one round at a time)"
+             (String.concat ", " busy))
+      else (
         List.iter
           (fun key ->
             let cnt = Hashtbl.find_opt keeper_busy_counts key |> Option.value ~default:0 in
-            if cnt <= 1 then Hashtbl.remove keeper_busy_counts key
-            else Hashtbl.replace keeper_busy_counts key (cnt - 1))
-          keeper_keys)
+            Hashtbl.replace keeper_busy_counts key (cnt + 1))
+          keeper_keys;
+        Ok ()))
+  in
+  let release () =
+    Eio.Mutex.use_rw ~protect:true keeper_busy_mutex (fun () ->
+      List.iter
+        (fun key ->
+          let cnt = Hashtbl.find_opt keeper_busy_counts key |> Option.value ~default:0 in
+          if cnt <= 1 then Hashtbl.remove keeper_busy_counts key
+          else Hashtbl.replace keeper_busy_counts key (cnt - 1))
+        keeper_keys)
   in
   match reserve () with
   | Error _ as e -> e


### PR DESCRIPTION
## Summary
- PR #1362에서 dashboard 3파일만 머지 후 나머지 17파일 cherry-pick
- `Stdlib.Mutex` → `Eio.Mutex` 완전 제거 (lib/ 내 0건)
- EDEADLK 재발 방지를 위한 전체 마이그레이션

## Changed files (17)
audit_log, backend, chain_native_eio, chain_registry, federation, progress, prompt_registry, room_walph, server_trpg_rest_actor, server_trpg_rest_models, server_trpg_rest_runtime, tool_lodge_agents_cache, tool_lodge_agents_ops, tool_lodge_react_core, tool_registry, tool_suspend, trpg_types

## Test plan
- [x] `dune build --root .` 성공
- [ ] 서버 재시작 후 deadlock 미발생 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)