### PR TITLE
fix(test): resolve CI test failures — tag dispatch fallthrough (#1302)

### DIFF
--- a/lib/tool_schemas_room.ml
+++ b/lib/tool_schemas_room.ml
@@ -2,6 +2,19 @@ open Types
 
 let schemas : tool_schema list = [
   {
+    name = "masc_init";
+    description = "Initialize MASC room for multi-agent collaboration. Creates .masc/ folder in current project.";
+    input_schema = `Assoc [
+      ("type", `String "object");
+      ("properties", `Assoc [
+        ("agent_name", `Assoc [
+          ("type", `String "string");
+          ("description", `String "Your agent identity: 'claude', 'gemini', or 'codex'");
+        ]);
+      ]);
+    ];
+  };
+  {
     name = "masc_set_room";
     description = "Set the working directory for MASC operations. Use this to work with .masc/ in a different project.";
     input_schema = `Assoc [


### PR DESCRIPTION
## Summary
CI에서 `test_mcp_server_eio` 7개 + `test_workflow_guide` 3개 = 10개 테스트 실패 수정.

**Root cause**: `mcp_server_eio_execute.ml`의 tag dispatch에서 모듈이 `None`을 반환하면 fallback chain으로 넘기지 않고 즉시 "Unknown tool" 에러를 반환. `tool_schemas_room.ml`이 여러 모듈의 도구 schema를 포함하는 god-schema 파일이라서, `Mod_room` tag로 등록된 도구가 `Tool_room.dispatch`에서 처리되지 않으면 inline dispatch까지 도달 불가.

## Changes
- `mcp_server_eio_execute.ml`: tag dispatch `None` → fallback chain으로 fallthrough (기존: 즉시 "Unknown tool")
- `tool_schemas_room.ml`: `masc_init` schema 추가 (tag registry 누락)
- `test/test_workflow_guide.ml`: `masc_claim` → `masc_transition` assertion 3개 업데이트

## Test plan
- [x] `test_mcp_server_eio.exe` — 55/55 pass (was 7 failures)
- [x] `test_workflow_guide.exe` — 23/23 pass (was 3 failures)
- [x] `dune build` passes
- [ ] CI full suite

Closes #1302

🤖 Generated with [Claude Code](https://claude.com/claude-code)