### PR TITLE
fix(telemetry): propagate agent_id to track_tool_called

### DIFF
--- a/lib/mcp_server_eio_call_tool.ml
+++ b/lib/mcp_server_eio_call_tool.ml
@@ -271,7 +271,7 @@ let handle_call_tool_eio ~execute_tool_eio ~maybe_emit_resource_notifications
     (match state.Mcp_server.fs with
      | Some fs ->
          (try Telemetry_eio.track_tool_called ~fs state.Mcp_server.room_config
-                ~tool_name:name ~success ~duration_ms ()
+                ~tool_name:name ~agent_id:agent_name ~success ~duration_ms ()
           with exn ->
             log_mcp_exn ~label:"telemetry tracking failed" exn)
      | None -> ());

--- a/lib/server_routes_http_keeper_stream.ml
+++ b/lib/server_routes_http_keeper_stream.ml
@@ -107,7 +107,7 @@ let execute_keeper_stream_tool ~sw ~clock ?auth_token:_ state ~agent_name ~argum
     | Some fs ->
         (try
            Telemetry_eio.track_tool_called ~fs state.Mcp_server.room_config
-             ~tool_name:"masc_keeper_msg" ~success ~duration_ms ()
+             ~tool_name:"masc_keeper_msg" ~agent_id:agent_name ~success ~duration_ms ()
          with exn ->
            Log.Misc.error "telemetry tracking failed: %s"
              (Printexc.to_string exn))


### PR DESCRIPTION
## Summary

- `Telemetry_eio.track_tool_called`의 2개 주요 call site에서 `?agent_id` 파라미터가 생략되어, `.masc/telemetry.jsonl`의 모든 `Tool_called` 이벤트에 `"agent_id":null`이 기록되고 있었음
- 같은 함수 안에서 `Audit_log.log_tool_call`은 `~agent_id:agent_name`을 정확히 전달하고 있었으나, 텔레메트리만 누락
- `~agent_id:agent_name` 파라미터 추가로 수정 (2파일, 각 1줄)

### 변경 파일
- `lib/mcp_server_eio_call_tool.ml` — MCP main dispatch path
- `lib/server_routes_http_keeper_stream.ml` — Keeper stream path

### 영향 없음
- `telemetry_eio.ml` 시그니처 변경 없음 (`?agent_id`는 이미 optional)
- `local_agent_eio_container.ml`은 이미 `~agent_id:worker_name` 전달 중

## Test plan

- [x] `dune build` 성공
- [ ] `make test` — `test_keeper_msg_auto_team_session_bridge` 1건 실패 (Eio 타이밍 flaky, 변경 무관)
- [ ] 서버 시작 후 tool 호출 → `tail -3 .masc/telemetry.jsonl` 에서 `agent_id` non-null 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)