### PR TITLE
fix: resolve 6 semantic bugs — Phase 0 product improvement

### DIFF
--- a/lib/team_session_engine_eio.ml
+++ b/lib/team_session_engine_eio.ml
@@ -26,9 +26,15 @@ let start_runtime_loop ~sw ~(clock : _ Eio.Time.clock) ~(config : Room.config)
               in
               let now = Time_compat.now () in
               if stop_requested then
+                let final_status =
+                  match stop_reason with
+                  | "runtime_missing" | "interrupted" | "signal" ->
+                      Team_session_types.Interrupted
+                  | _ -> Team_session_types.Completed
+                in
                 ignore
                   (finalize_session ~config ~session_id
-                     ~final_status:Team_session_types.Interrupted ~reason:stop_reason
+                     ~final_status ~reason:stop_reason
                      ~generate_report:generate_report_on_finalize)
               else if now >= session.planned_end_at then
                 ignore

--- a/lib/team_session_report_proof.ml
+++ b/lib/team_session_report_proof.ml
@@ -260,7 +260,7 @@ let generate_proof ?(proof_level = default_proof_level) config
         ~communication_total ~goal_recorded ~participants_count
         ~unique_turn_actors_count ~required_turn_actors
         ~unauthorized_turn_actors ~report_json_exists ~report_md_exists
-        ~done_delta_total
+        ~done_delta_total ()
     in
     let required_spawn_agents = required_spawn_agents_for_session session in
     let spawn_events = count_event_type events "team_step_spawn" in

--- a/lib/team_session_report_proof_helpers.ml
+++ b/lib/team_session_report_proof_helpers.ml
@@ -153,7 +153,8 @@ let make_standard_criteria ~event_started ~checkpoints_count ~turn_events
     ~communication_total ~goal_recorded ~participants_count
     ~unique_turn_actors_count ~required_turn_actors
     ~unauthorized_turn_actors ~report_json_exists ~report_md_exists
-    ~done_delta_total =
+    ~done_delta_total
+    ?(min_turn_events = 1) ?(min_communication = 0) () =
   [
     criterion "session_started_event" event_started "session_started 이벤트 존재";
     criterion "checkpoint_recorded" (checkpoints_count > 0)
@@ -162,6 +163,13 @@ let make_standard_criteria ~event_started ~checkpoints_count ~turn_events
       (turn_events > 0 || communication_total > 0)
       (Printf.sprintf "turn_events=%d communication_total=%d" turn_events
          communication_total);
+    criterion "turn_volume_threshold" (turn_events >= min_turn_events)
+      (Printf.sprintf "turn_events=%d min_turn_events=%d" turn_events
+         min_turn_events);
+    criterion "communication_volume_threshold"
+      (communication_total >= min_communication)
+      (Printf.sprintf "communication_total=%d min_communication=%d"
+         communication_total min_communication);
     criterion "goal_recorded" goal_recorded "goal 문자열 존재";
     criterion "participants_recorded" (participants_count > 0)
       (Printf.sprintf "participants=%d" participants_count);

--- a/lib/team_session_types.ml
+++ b/lib/team_session_types.ml
@@ -228,8 +228,8 @@ let execution_scope_to_string = function
   | Limited_code_change -> "limited_code_change"
 
 let execution_scope_of_string = function
-  | "limited_code_change" -> Limited_code_change
-  | _ -> Observe_only
+  | "observe_only" -> Observe_only
+  | _ -> Limited_code_change
 
 let wait_mode_to_string = function
   | Wait_background -> "background"
@@ -553,7 +553,9 @@ let done_delta_by_agent ~(baseline : (string * int) list) ~(current : (string * 
   in
   let extra_agents =
     current
-    |> List.filter (fun (agent, _) -> not (List.mem_assoc agent from_agents))
+    |> List.filter (fun (agent, _) ->
+         not (List.mem_assoc agent from_agents)
+         && List.mem agent normalized_agents)
   in
   (from_agents @ extra_agents)
   |> List.sort (fun (a, _) (b, _) -> compare a b)

--- a/lib/tool_inline_dispatch.ml
+++ b/lib/tool_inline_dispatch.ml
@@ -183,9 +183,11 @@ let dispatch (ctx : context) ~(name : string) : result option =
         Some (false, "path is required: provide the absolute or relative path to your project directory")
       else
       let expanded =
-        if String.length path > 0 && path.[0] = '~' then
+        if String.length path >= 2 && path.[0] = '~' && path.[1] = '/' then
           let home = match Sys.getenv_opt "HOME" with Some h -> h | None -> "/tmp" in
-          Filename.concat home (String.sub path 1 (String.length path - 1))
+          Filename.concat home (String.sub path 2 (String.length path - 2))
+        else if String.length path = 1 && path.[0] = '~' then
+          (match Sys.getenv_opt "HOME" with Some h -> h | None -> "/tmp")
         else if Filename.is_relative path then
           Filename.concat (Sys.getcwd ()) path
         else

--- a/lib/tool_room.ml
+++ b/lib/tool_room.ml
@@ -226,7 +226,7 @@ let check_assertion st assertion =
          "Call masc_join to register your agent in the room")
     | "task_claimed" ->
         (st.task_claimed,
-         "Call masc_claim or masc_add_task + masc_claim to get a task")
+         "Call masc_claim_next or masc_transition(action=claim) to get a task")
     | "current_task_set" ->
         (st.current_task_set,
          "Call masc_plan_set_task after claiming a task")

--- a/lib/tool_team_session_support.ml
+++ b/lib/tool_team_session_support.ml
@@ -25,9 +25,8 @@ let json_ok fields =
 
 let parse_execution_scope args =
   match String.lowercase_ascii (get_string args "execution_scope" "limited_code_change") with
-  | "limited_code_change" -> Team_session_types.Limited_code_change
   | "observe_only" -> Team_session_types.Observe_only
-  | _ -> Team_session_types.Observe_only
+  | _ -> Team_session_types.Limited_code_change
 
 let parse_orchestration_mode args =
   match String.lowercase_ascii (get_string args "orchestration_mode" "assist") with

--- a/lib/workflow_guide.ml
+++ b/lib/workflow_guide.ml
@@ -296,11 +296,12 @@ let next_steps ~tool_name ~success =
   | "masc_set_room" -> after_set_room ~success
   | "masc_join" -> after_join ~success
   | "masc_status" -> after_status ~success
-  | "masc_claim" | "masc_claim_next" | "masc_claim_task" -> after_claim ~success
+  | "masc_claim" | "masc_claim_next" -> after_claim ~success
   | "masc_add_task" | "masc_batch_add_tasks" -> after_add_task ~success
   | "masc_plan_set_task" | "masc_set_current_task" -> after_plan_set_task ~success
   | "masc_heartbeat" -> after_heartbeat ~success
-  | "masc_done" | "masc_complete_task" -> after_done ~success
+  | "masc_done" -> after_done ~success
+  | "masc_transition" -> after_claim ~success  (* most common: claim/done; claim path is safer *)
   (* Golden Path 2: CPv2 *)
   | "masc_operation_start" -> after_operation_start ~success
   | "masc_dispatch_tick" -> after_dispatch_tick ~success
@@ -349,16 +350,18 @@ let workflow_context ~tool_name =
   let before = match tool_name with
     | "masc_join" -> [ "masc_set_room" ]
     | "masc_status" -> [ "masc_set_room"; "masc_join" ]
-    | "masc_claim" | "masc_claim_next" | "masc_claim_task" ->
+    | "masc_claim" | "masc_claim_next" ->
         [ "masc_join"; "masc_status" ]
     | "masc_plan_set_task" | "masc_set_current_task" ->
-        [ "masc_claim" ]
+        [ "masc_claim_next" ]
     | "masc_worktree_create" ->
         [ "masc_plan_set_task" ]
     | "masc_heartbeat" ->
         [ "masc_join" ]
-    | "masc_done" | "masc_complete_task" ->
+    | "masc_done" ->
         [ "masc_plan_set_task" ]
+    | "masc_transition" ->
+        [ "masc_join"; "masc_status" ]
     | "masc_operation_start" ->
         [ "masc_unit_define" ]
     | "masc_dispatch_tick" ->

--- a/test/test_proof_criteria.ml
+++ b/test/test_proof_criteria.ml
@@ -20,7 +20,7 @@ let test_standard_all_pass () =
       ~goal_recorded:true ~participants_count:2
       ~unique_turn_actors_count:2 ~required_turn_actors:2
       ~unauthorized_turn_actors:[] ~report_json_exists:true
-      ~report_md_exists:true ~done_delta_total:5
+      ~report_md_exists:true ~done_delta_total:5 ()
   in
   check_bool "all_criteria_pass (happy path)" true
     (Team_session_report.all_criteria_pass criteria);
@@ -51,7 +51,7 @@ let test_standard_all_fail () =
       ~unique_turn_actors_count:0 ~required_turn_actors:2
       ~unauthorized_turn_actors:["intruder"]
       ~report_json_exists:false ~report_md_exists:false
-      ~done_delta_total:(-1)
+      ~done_delta_total:(-1) ()
   in
   check_bool "all_criteria_pass (all fail)" false
     (Team_session_report.all_criteria_pass criteria);
@@ -77,7 +77,7 @@ let test_checkpoint_boundary () =
       ~goal_recorded:true ~participants_count:1
       ~unique_turn_actors_count:1 ~required_turn_actors:1
       ~unauthorized_turn_actors:[] ~report_json_exists:true
-      ~report_md_exists:true ~done_delta_total:0
+      ~report_md_exists:true ~done_delta_total:0 ()
   in
   check_bool "checkpoint=0 fails" false
     (Team_session_report.find_criterion c0 "checkpoint_recorded");
@@ -87,7 +87,7 @@ let test_checkpoint_boundary () =
       ~goal_recorded:true ~participants_count:1
       ~unique_turn_actors_count:1 ~required_turn_actors:1
       ~unauthorized_turn_actors:[] ~report_json_exists:true
-      ~report_md_exists:true ~done_delta_total:0
+      ~report_md_exists:true ~done_delta_total:0 ()
   in
   check_bool "checkpoint=1 passes" true
     (Team_session_report.find_criterion c1 "checkpoint_recorded")
@@ -100,7 +100,7 @@ let test_turn_or_communication_edge () =
       ~goal_recorded:true ~participants_count:1
       ~unique_turn_actors_count:1 ~required_turn_actors:1
       ~unauthorized_turn_actors:[] ~report_json_exists:true
-      ~report_md_exists:true ~done_delta_total:0
+      ~report_md_exists:true ~done_delta_total:0 ()
   in
   check_bool "turn=0,comm=0 fails" false
     (Team_session_report.find_criterion c_none "turn_or_communication_recorded");
@@ -111,7 +111,7 @@ let test_turn_or_communication_edge () =
       ~goal_recorded:true ~participants_count:1
       ~unique_turn_actors_count:1 ~required_turn_actors:1
       ~unauthorized_turn_actors:[] ~report_json_exists:true
-      ~report_md_exists:true ~done_delta_total:0
+      ~report_md_exists:true ~done_delta_total:0 ()
   in
   check_bool "turn=0,comm=1 passes (OR)" true
     (Team_session_report.find_criterion c_comm "turn_or_communication_recorded");
@@ -122,7 +122,7 @@ let test_turn_or_communication_edge () =
       ~goal_recorded:true ~participants_count:1
       ~unique_turn_actors_count:1 ~required_turn_actors:1
       ~unauthorized_turn_actors:[] ~report_json_exists:true
-      ~report_md_exists:true ~done_delta_total:0
+      ~report_md_exists:true ~done_delta_total:0 ()
   in
   check_bool "turn=1,comm=0 passes (OR)" true
     (Team_session_report.find_criterion c_turn "turn_or_communication_recorded")
@@ -134,7 +134,7 @@ let test_unauthorized_actors () =
       ~goal_recorded:true ~participants_count:1
       ~unique_turn_actors_count:1 ~required_turn_actors:1
       ~unauthorized_turn_actors:["x"]
-      ~report_json_exists:true ~report_md_exists:true ~done_delta_total:0
+      ~report_json_exists:true ~report_md_exists:true ~done_delta_total:0 ()
   in
   check_bool "one unauthorized actor fails" false
     (Team_session_report.find_criterion c_one "turn_actor_authorized")
@@ -146,7 +146,7 @@ let test_report_artifacts_partial () =
       ~goal_recorded:true ~participants_count:1
       ~unique_turn_actors_count:1 ~required_turn_actors:1
       ~unauthorized_turn_actors:[]
-      ~report_json_exists:true ~report_md_exists:false ~done_delta_total:0
+      ~report_json_exists:true ~report_md_exists:false ~done_delta_total:0 ()
   in
   check_bool "json only -> report_artifacts fails" false
     (Team_session_report.find_criterion c_json_only "report_artifacts");
@@ -156,7 +156,7 @@ let test_report_artifacts_partial () =
       ~goal_recorded:true ~participants_count:1
       ~unique_turn_actors_count:1 ~required_turn_actors:1
       ~unauthorized_turn_actors:[]
-      ~report_json_exists:false ~report_md_exists:true ~done_delta_total:0
+      ~report_json_exists:false ~report_md_exists:true ~done_delta_total:0 ()
   in
   check_bool "md only -> report_artifacts fails" false
     (Team_session_report.find_criterion c_md_only "report_artifacts")
@@ -168,7 +168,7 @@ let test_done_delta_boundary () =
       ~goal_recorded:true ~participants_count:1
       ~unique_turn_actors_count:1 ~required_turn_actors:1
       ~unauthorized_turn_actors:[]
-      ~report_json_exists:true ~report_md_exists:true ~done_delta_total:(-1)
+      ~report_json_exists:true ~report_md_exists:true ~done_delta_total:(-1) ()
   in
   check_bool "done_delta=-1 fails" false
     (Team_session_report.find_criterion c_neg "outcome_traceable");
@@ -178,7 +178,7 @@ let test_done_delta_boundary () =
       ~goal_recorded:true ~participants_count:1
       ~unique_turn_actors_count:1 ~required_turn_actors:1
       ~unauthorized_turn_actors:[]
-      ~report_json_exists:true ~report_md_exists:true ~done_delta_total:0
+      ~report_json_exists:true ~report_md_exists:true ~done_delta_total:0 ()
   in
   check_bool "done_delta=0 passes" true
     (Team_session_report.find_criterion c_zero "outcome_traceable")
@@ -194,7 +194,7 @@ let test_find_criterion_missing () =
       ~goal_recorded:true ~participants_count:1
       ~unique_turn_actors_count:1 ~required_turn_actors:1
       ~unauthorized_turn_actors:[]
-      ~report_json_exists:true ~report_md_exists:true ~done_delta_total:0
+      ~report_json_exists:true ~report_md_exists:true ~done_delta_total:0 ()
   in
   check_bool "nonexistent criterion returns false" false
     (Team_session_report.find_criterion criteria "nonexistent_criterion_xyz")
@@ -210,7 +210,7 @@ let test_mandatory_standard_pass () =
       ~goal_recorded:true ~participants_count:1
       ~unique_turn_actors_count:1 ~required_turn_actors:1
       ~unauthorized_turn_actors:[]
-      ~report_json_exists:true ~report_md_exists:true ~done_delta_total:0
+      ~report_json_exists:true ~report_md_exists:true ~done_delta_total:0 ()
   in
   check_bool "standard mandatory ok" true
     (Team_session_report.mandatory_ok_for_level
@@ -223,7 +223,7 @@ let test_mandatory_standard_fail_no_checkpoint () =
       ~goal_recorded:true ~participants_count:1
       ~unique_turn_actors_count:1 ~required_turn_actors:1
       ~unauthorized_turn_actors:[]
-      ~report_json_exists:true ~report_md_exists:true ~done_delta_total:0
+      ~report_json_exists:true ~report_md_exists:true ~done_delta_total:0 ()
   in
   check_bool "standard fails without checkpoint" false
     (Team_session_report.mandatory_ok_for_level
@@ -238,7 +238,7 @@ let test_mandatory_strong_requires_all () =
       ~participants_count:1
       ~unique_turn_actors_count:1 ~required_turn_actors:1
       ~unauthorized_turn_actors:[]
-      ~report_json_exists:true ~report_md_exists:true ~done_delta_total:0
+      ~report_json_exists:true ~report_md_exists:true ~done_delta_total:0 ()
   in
   check_bool "strong fails when goal missing" false
     (Team_session_report.mandatory_ok_for_level

--- a/test/test_workflow_guide.ml
+++ b/test/test_workflow_guide.ml
@@ -153,9 +153,42 @@ let test_claim_next_alias () =
   let g = WG.next_steps ~tool_name:"masc_claim_next" ~success:true in
   check_has_tool g.next_steps "masc_plan_set_task"
 
-let test_complete_task_alias () =
+let test_complete_task_removed () =
+  (* masc_complete_task was a ghost tool — it no longer routes to guidance *)
   let g = WG.next_steps ~tool_name:"masc_complete_task" ~success:true in
-  check_has_tool g.next_steps "masc_status"
+  check (list string) "removed ghost returns empty" []
+    (List.map (fun (s : WG.step) -> s.tool) g.next_steps)
+
+let test_transition_routes_to_claim () =
+  let g = WG.next_steps ~tool_name:"masc_transition" ~success:true in
+  check_has_tool g.next_steps "masc_plan_set_task"
+
+(* Structural: all tool names in guidance output exist in Config.all_tool_schemas *)
+let all_schema_names =
+  List.map (fun (s : Masc_mcp.Types.tool_schema) -> s.name) Masc_mcp.Config.all_tool_schemas
+
+let check_tool_exists_in_schemas name =
+  if not (List.mem name all_schema_names) then
+    Alcotest.fail
+      (Printf.sprintf "Workflow_guide references tool '%s' not in Config.all_tool_schemas" name)
+
+let test_next_steps_reference_real_tools () =
+  let tools_to_check = [
+    "masc_set_room"; "masc_join"; "masc_status";
+    "masc_claim"; "masc_claim_next";
+    "masc_done"; "masc_transition";
+    "masc_add_task"; "masc_batch_add_tasks";
+    "masc_plan_set_task"; "masc_set_current_task";
+    "masc_heartbeat"; "masc_broadcast";
+    "masc_worktree_create"; "masc_init";
+    "masc_switch_mode"; "masc_operator_digest";
+  ] in
+  List.iter (fun tool_name ->
+    let g_ok = WG.next_steps ~tool_name ~success:true in
+    List.iter (fun (s : WG.step) -> check_tool_exists_in_schemas s.tool) g_ok.next_steps;
+    let g_fail = WG.next_steps ~tool_name ~success:false in
+    List.iter (fun (s : WG.step) -> check_tool_exists_in_schemas s.tool) g_fail.next_steps
+  ) tools_to_check
 
 (* ── Test runner ─────────────────────────────────────────────────── *)
 
@@ -181,7 +214,11 @@ let () =
     "edge_cases", [
       test_case "unknown tool" `Quick test_unknown_tool;
       test_case "claim_next alias" `Quick test_claim_next_alias;
-      test_case "complete_task alias" `Quick test_complete_task_alias;
+      test_case "complete_task removed" `Quick test_complete_task_removed;
+      test_case "transition routes to claim" `Quick test_transition_routes_to_claim;
+    ];
+    "structural", [
+      test_case "next_steps reference real tools" `Quick test_next_steps_reference_real_tools;
     ];
     "json", [
       test_case "null for empty" `Quick test_guidance_to_json_null_for_empty;


### PR DESCRIPTION
## Summary

Phase 0 of MASC product improvement plan. Fixes 6 semantic bugs (#1349-#1356) that cause agents to learn incorrect behavior.

- **workflow_guide**: Remove ghost tool references (masc_claim_task, masc_complete_task), add masc_transition dispatch, add structural test verifying all referenced tools exist in Config.all_tool_schemas
- **tilde expansion**: Fix ~/path → /path bug in masc_set_room (Filename.concat absolute path trap)
- **session stop status**: User-initiated stop now correctly sets Completed instead of Interrupted
- **done_delta leak**: Filter extra_agents by session participants in done_delta_by_agent
- **execution_scope default**: Fallback changed from Observe_only to Limited_code_change
- **proof threshold**: Add turn_volume_threshold and communication_volume_threshold to make_standard_criteria

## Test plan

- [x] `dune build` passes
- [x] `test_proof_criteria` — 18 tests pass
- [x] `test_workflow_guide` — 25 tests pass (including new structural test)
- [ ] Full `make test` on CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)