### PR TITLE
feat(metrics): warm up Tool_registry from telemetry.jsonl on startup

### DIFF
--- a/lib/server_runtime_bootstrap.ml
+++ b/lib/server_runtime_bootstrap.ml
@@ -51,6 +51,18 @@ let bootstrap_server_state (state : Mcp_server.server_state) =
    with exn ->
      Log.Misc.error "startup backfill failed: %s"
        (Printexc.to_string exn));
+  (* Warm up Tool_registry from persistent telemetry.jsonl *)
+  (try
+     let summary =
+       Telemetry_eio.summarize_tool_usage state.room_config
+     in
+     if summary.telemetry_available then
+       let n = Tool_registry.warm_up summary in
+       Log.Misc.info "tool registry: warmed up %d tools (%d calls) from telemetry"
+         n summary.total_calls
+   with exn ->
+     Log.Misc.error "tool registry warm-up failed: %s"
+       (Printexc.to_string exn));
   Mcp_server.set_sse_callback state Sse.broadcast
 
 let bootstrap_keepers ~sw ~clock (state : Mcp_server.server_state) =

--- a/lib/tool_registry.ml
+++ b/lib/tool_registry.ml
@@ -142,6 +142,29 @@ let stats_report ~top_n ~all_tool_names : Yojson.Safe.t =
     ("never_called_count", `Int (List.length never_called));
   ]
 
+(** Warm up registry from telemetry summary.
+    Called once at server startup to restore persistent metrics. *)
+let warm_up (summary : Telemetry_eio.tool_usage_summary) : int =
+  Eio.Mutex.use_rw ~protect:true registry_mutex (fun () ->
+      let count = ref 0 in
+      Hashtbl.iter
+        (fun tool_name (stats : Telemetry_eio.tool_usage_stats) ->
+          if not (Hashtbl.mem registry tool_name) then (
+            Hashtbl.replace registry tool_name
+              {
+                call_count = stats.count;
+                success_count = stats.success_count;
+                failure_count = stats.failure_count;
+                last_called_at =
+                  (match stats.last_used_at with
+                  | Some t -> t
+                  | None -> 0.0);
+                total_duration_ms = 0;
+              };
+            incr count))
+        summary.stats_by_tool;
+      !count)
+
 (** Reset all counters (for testing) *)
 let reset () =
   Eio.Mutex.use_rw ~protect:true registry_mutex (fun () -> Hashtbl.clear registry)


### PR DESCRIPTION
## Summary

- `Tool_registry`(in-memory)가 서버 재시작마다 0으로 리셋되어 대시보드가 텅 비는 문제 수정
- 서버 시작 시 `telemetry.jsonl`에서 누적 통계를 읽어 `Tool_registry`를 pre-populate
- `warm_up()`은 이미 존재하는 항목을 덮어쓰지 않음 (새로운 in-memory 데이터 보호)

### 변경 파일
- `lib/tool_registry.ml` — `warm_up` 함수 추가 (23줄)
- `lib/server_runtime_bootstrap.ml` — `bootstrap_server_state`에서 warm-up 호출 (12줄)

### P1 (#1368) 과의 관계
P1에서 `agent_id`가 telemetry에 기록되기 시작했으므로, 이제 warm-up된 데이터에 agent 차원 추가도 가능해짐.

## Test plan

- [x] `dune build` 성공
- [ ] 서버 시작 로그에서 `tool registry: warmed up N tools (M calls) from telemetry` 확인
- [ ] `/api/v1/tool-metrics` 응답의 `total_calls`가 재시작 후에도 0이 아닌지 확인
- [ ] `make test` 실행

🤖 Generated with [Claude Code](https://claude.com/claude-code)