### PR TITLE
feat(dashboard): add provider capacity visibility to overview

### DIFF
--- a/dashboard/src/components/overview/overview.ts
+++ b/dashboard/src/components/overview/overview.ts
@@ -2,7 +2,7 @@
 // 4-Layer information architecture: Situation -> Anomaly -> Entity Grid -> Timeline
 
 import { html } from 'htm/preact'
-import { agents, keepers, tasks, shellCounts } from '../../store'
+import { agents, keepers, tasks, shellCounts, providerCapacity } from '../../store'
 import { missionSnapshot } from '../../mission-store'
 import { journal } from '../../sse'
 import { navigate } from '../../router'
@@ -79,6 +79,8 @@ export function Overview() {
         taskBreakdown=${taskBreakdown}
       />
 
+      <${ProviderGauge} />
+
       <div class="overview-main-v2">
         <div class="overview-left-col">
           <div class="overview-section-label">에이전트</div>
@@ -146,6 +148,40 @@ export function Overview() {
           </button>
         `)}
       </nav>
+    </div>
+  `
+}
+
+function ProviderGauge() {
+  const cap = providerCapacity.value
+  if (!cap) return null
+
+  const pool = cap.glm_pool
+  const agentCap = cap.agent_capacity
+  const loadPct = pool.total_capacity > 0
+    ? Math.round((pool.current_load / pool.total_capacity) * 100)
+    : 0
+  const loadTone = loadPct < 50 ? 'ok' : loadPct < 80 ? 'warn' : 'bad'
+
+  return html`
+    <div class="mission-stat-grid" style="margin-bottom: var(--space-md, 16px);">
+      <div class="summary-stat-card ${loadTone}">
+        <span>GLM Pool</span>
+        <strong>${pool.current_load}/${pool.total_capacity}</strong>
+        <small>${pool.has_capacity ? 'capacity available' : 'at capacity'}</small>
+      </div>
+      <div class="summary-stat-card">
+        <span>Agent Slots</span>
+        <strong>${agentCap.target_agents}</strong>
+        <small>${agentCap.min_agents}-${agentCap.max_agents} range${agentCap.gardener_enabled ? '' : ' (gardener off)'}</small>
+      </div>
+      ${pool.models.length > 0 ? html`
+        <div class="summary-stat-card">
+          <span>Models</span>
+          <strong>${pool.models.length}</strong>
+          <small>${pool.models.map((m: { model: string }) => m.model).join(', ')}</small>
+        </div>
+      ` : null}
     </div>
   `
 }

--- a/dashboard/src/store.ts
+++ b/dashboard/src/store.ts
@@ -69,6 +69,31 @@ export interface ShellCounts {
 
 export const shellCounts = signal<ShellCounts | null>(null)
 
+// --- Provider capacity ---
+
+export interface GlmModelStats {
+  model: string
+  in_flight: number
+  limit: number
+}
+
+export interface ProviderCapacity {
+  glm_pool: {
+    models: GlmModelStats[]
+    total_capacity: number
+    current_load: number
+    has_capacity: boolean
+  }
+  agent_capacity: {
+    gardener_enabled: boolean
+    min_agents: number
+    target_agents: number
+    max_agents: number
+  }
+}
+
+export const providerCapacity = signal<ProviderCapacity | null>(null)
+
 // --- Core state signals ---
 
 export const agents = signal<Agent[]>([])
@@ -327,6 +352,9 @@ export async function refreshShell(): Promise<void> {
         tasks: data.counts.tasks ?? 0,
         keepers: data.counts.keepers ?? 0,
       }
+    }
+    if (data.providers) {
+      providerCapacity.value = data.providers as ProviderCapacity
     }
   } catch (err) {
     console.error('Dashboard shell fetch error:', err)

--- a/dashboard/src/types/dashboard-execution.ts
+++ b/dashboard/src/types/dashboard-execution.ts
@@ -13,6 +13,7 @@ export interface DashboardShellResponse {
     tasks?: number
     keepers?: number
   }
+  providers?: Record<string, unknown>
 }
 
 export interface DashboardRoomTruthAttentionSummary {

--- a/lib/server_dashboard_http.ml
+++ b/lib/server_dashboard_http.ml
@@ -421,6 +421,49 @@ let dashboard_agents_safe config =
 let dashboard_messages_safe config ~since_seq ~limit =
   Room.get_messages_raw_in_room config ~room_id:(dashboard_current_room_id config) ~since_seq ~limit
 
+let provider_capacity_json () : Yojson.Safe.t =
+  let glm_stats = Glm_pool.get_stats () in
+  let glm_models =
+    List.map
+      (fun (model_id, in_flight, limit) ->
+        `Assoc
+          [
+            ("model", `String model_id);
+            ("in_flight", `Int in_flight);
+            ("limit", `Int limit);
+          ])
+      glm_stats
+  in
+  let gardener_enabled =
+    match Sys.getenv_opt "MASC_GARDENER_ENABLED" with
+    | Some "true" | Some "1" -> true
+    | _ -> false
+  in
+  let env_int key default =
+    match Sys.getenv_opt key with
+    | Some s -> (try int_of_string s with _ -> default)
+    | None -> default
+  in
+  `Assoc
+    [
+      ( "glm_pool",
+        `Assoc
+          [
+            ("models", `List glm_models);
+            ("total_capacity", `Int Glm_pool.total_capacity);
+            ("current_load", `Int (Glm_pool.current_load ()));
+            ("has_capacity", `Bool (Glm_pool.has_capacity ()));
+          ] );
+      ( "agent_capacity",
+        `Assoc
+          [
+            ("gardener_enabled", `Bool gardener_enabled);
+            ("min_agents", `Int (env_int "MASC_GARDENER_MIN_AGENTS" 5));
+            ("target_agents", `Int (env_int "MASC_GARDENER_TARGET_AGENTS" 15));
+            ("max_agents", `Int (env_int "MASC_GARDENER_MAX_AGENTS" 30));
+          ] );
+    ]
+
 let dashboard_shell_http_json (config : Room.config) : Yojson.Safe.t =
   Dashboard_cache.get_or_compute "shell" ~ttl:2.0 (fun () ->
     let agents = dashboard_agents_safe config in
@@ -438,6 +481,7 @@ let dashboard_shell_http_json (config : Room.config) : Yojson.Safe.t =
             ("tasks", `Int (List.length tasks));
             ("keepers", `Int keepers_total);
           ] );
+      ("providers", provider_capacity_json ());
       ])
 
 let dashboard_tools_http_json ?actor (config : Room.config) : Yojson.Safe.t =


### PR DESCRIPTION
## Summary

대시보드에서 LLM provider 상태와 agent capacity를 확인할 수 없던 문제(P4) 수정.

### Backend (OCaml)
- `provider_capacity_json()` 함수 추가 — GLM pool 모델별 in_flight/limit + agent capacity config
- `/api/v1/dashboard/shell` 응답에 `"providers"` 필드 추가

### Frontend (Preact)
- `ProviderCapacity` 타입 + signal 추가 (`store.ts`)
- `ProviderGauge` 컴포넌트 — overview의 QuickStats 아래에 표시:
  - GLM Pool: current_load/total_capacity (green/yellow/red)
  - Agent Slots: target (min-max range)
  - Models: 사용 가능한 모델 목록

### 변경 파일
- `lib/server_dashboard_http.ml` — provider_capacity_json (44줄)
- `dashboard/src/store.ts` — ProviderCapacity 타입 + signal (28줄)
- `dashboard/src/components/overview/overview.ts` — ProviderGauge (38줄)
- `dashboard/src/types/dashboard-execution.ts` — providers 필드 추가

## Test plan

- [x] `dune build` 성공
- [x] `npx vite build` 성공
- [ ] `/api/v1/dashboard/shell` 응답에 `providers.glm_pool`, `providers.agent_capacity` 포함 확인
- [ ] Overview에서 GLM Pool gauge 렌더링 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)