### PR TITLE
feat(dashboard): per-agent activity tracking and timeline (P3+P7)

### DIFF
--- a/dashboard/src/api.ts
+++ b/dashboard/src/api.ts
@@ -524,6 +524,24 @@ export function fetchDashboardShell(): Promise<DashboardShellResponse> {
   return get('/api/v1/dashboard/shell')
 }
 
+export interface AgentActivityEntry {
+  agent_id: string
+  tool_calls: number
+  success_count: number
+  failure_count: number
+  first_seen: number
+  last_seen: number
+}
+
+export interface AgentActivityResponse {
+  hours: number
+  agents: AgentActivityEntry[]
+}
+
+export function fetchAgentActivity(hours = 24): Promise<AgentActivityResponse> {
+  return get(`/api/v1/agent-activity?hours=${hours}`)
+}
+
 export function fetchDashboardRoomTruth(): Promise<DashboardRoomTruthResponse> {
   return get('/api/v1/dashboard/room-truth', { timeoutMs: ROOM_TRUTH_GET_TIMEOUT_MS })
 }

--- a/dashboard/src/components/overview/overview.ts
+++ b/dashboard/src/components/overview/overview.ts
@@ -2,7 +2,8 @@
 // 4-Layer information architecture: Situation -> Anomaly -> Entity Grid -> Timeline
 
 import { html } from 'htm/preact'
-import { agents, keepers, tasks, shellCounts, providerCapacity } from '../../store'
+import { agents, keepers, tasks, shellCounts, providerCapacity, agentActivity, refreshAgentActivity } from '../../store'
+import { useEffect } from 'preact/hooks'
 import { missionSnapshot } from '../../mission-store'
 import { journal } from '../../sse'
 import { navigate } from '../../router'
@@ -34,6 +35,7 @@ function keeperHealthClass(status?: string): string {
 }
 
 export function Overview() {
+  useEffect(() => { refreshAgentActivity() }, [])
   const snap = missionSnapshot.value
   const agentList = agents.value
   const keeperList = keepers.value
@@ -132,6 +134,8 @@ export function Overview() {
 
           <div class="overview-section-label" style="margin-top: var(--space-md, 16px)">최근 활동</div>
           <${NarrativeTimeline} entries=${journal} maxItems=${12} />
+
+          <${AgentActivityPanel} />
         </div>
       </div>
 
@@ -182,6 +186,40 @@ function ProviderGauge() {
           <small>${pool.models.map((m: { model: string }) => m.model).join(', ')}</small>
         </div>
       ` : null}
+    </div>
+  `
+}
+
+function relativeTimeShort(ts: number): string {
+  const diff = (Date.now() / 1000) - ts
+  if (diff < 60) return 'just now'
+  if (diff < 3600) return `${Math.floor(diff / 60)}m ago`
+  if (diff < 86400) return `${Math.floor(diff / 3600)}h ago`
+  return `${Math.floor(diff / 86400)}d ago`
+}
+
+function AgentActivityPanel() {
+  const activities = agentActivity.value
+  if (activities.length === 0) return null
+
+  return html`
+    <div style="margin-top: var(--space-md, 16px);">
+      <div class="overview-section-label">에이전트 활동 (24h)</div>
+      <div style="display: flex; flex-direction: column; gap: 6px;">
+        ${activities.slice(0, 8).map(a => html`
+          <div class="mission-activity-row" style="padding: 8px 12px;" key=${a.agent_id}>
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+              <strong style="font-size: 13px;">${a.agent_id}</strong>
+              <span class="command-chip ${a.failure_count > 0 ? 'warn' : 'ok'}" style="font-size: 11px;">
+                ${a.tool_calls} calls
+              </span>
+            </div>
+            <div style="font-size: 11px; color: rgba(255,255,255,0.45); margin-top: 2px;">
+              ${a.success_count} ok / ${a.failure_count} fail · ${relativeTimeShort(a.last_seen)}
+            </div>
+          </div>
+        `)}
+      </div>
     </div>
   `
 }

--- a/dashboard/src/store.ts
+++ b/dashboard/src/store.ts
@@ -38,6 +38,8 @@ import {
   fetchDashboardShell,
   fetchMessagesList,
   fetchTrpgState,
+  fetchAgentActivity,
+  type AgentActivityEntry,
 } from './api'
 import { journal } from './sse'
 import {
@@ -68,6 +70,7 @@ export interface ShellCounts {
 }
 
 export const shellCounts = signal<ShellCounts | null>(null)
+export const agentActivity = signal<AgentActivityEntry[]>([])
 
 // --- Provider capacity ---
 
@@ -358,6 +361,15 @@ export async function refreshShell(): Promise<void> {
     }
   } catch (err) {
     console.error('Dashboard shell fetch error:', err)
+  }
+}
+
+export async function refreshAgentActivity(): Promise<void> {
+  try {
+    const data = await fetchAgentActivity(24)
+    agentActivity.value = data.agents ?? []
+  } catch (err) {
+    console.error('Agent activity fetch error:', err)
   }
 }
 

--- a/lib/server_routes_http_routes_dashboard.ml
+++ b/lib/server_routes_http_routes_dashboard.ml
@@ -145,6 +145,33 @@ let add_routes ~sw ~clock router =
          )
        ) request reqd)
 
+  (* Agent activity — per-agent tool call stats from telemetry *)
+  |> Http.Router.get "/api/v1/agent-activity" (fun request reqd ->
+       with_public_read (fun state req reqd ->
+         let hours =
+           match Server_utils.query_param req "hours" with
+           | Some h -> (try float_of_string h with _ -> 24.0)
+           | None -> 24.0
+         in
+         let since = Time_compat.now () -. (hours *. 3600.0) in
+         let activities =
+           Telemetry_eio.summarize_agent_activity state.Mcp_server.room_config ~since
+         in
+         let json = `Assoc [
+           ("hours", `Float hours);
+           ("agents", `List (List.map (fun (a : Telemetry_eio.agent_activity) ->
+             `Assoc [
+               ("agent_id", `String a.agent_id);
+               ("tool_calls", `Int a.tool_calls);
+               ("success_count", `Int a.success_count);
+               ("failure_count", `Int a.failure_count);
+               ("first_seen", `Float a.first_seen);
+               ("last_seen", `Float a.last_seen);
+             ]) activities));
+         ] in
+         Http.Response.json ~compress:true ~request:req (Yojson.Safe.to_string json) reqd
+       ) request reqd)
+
   (* Tool metrics — unified registry stats for dashboard (P4 Phase 4.5) *)
   |> Http.Router.get "/api/v1/tool-metrics" (fun request reqd ->
        with_public_read (fun _state req reqd ->

--- a/lib/telemetry_eio.ml
+++ b/lib/telemetry_eio.ml
@@ -172,6 +172,52 @@ let summarize_tool_usage ?fs config : tool_usage_summary =
     stats_by_tool;
   }
 
+(** Agent activity summary from telemetry, filtered by time window. *)
+type agent_activity = {
+  agent_id: string;
+  tool_calls: int;
+  success_count: int;
+  failure_count: int;
+  first_seen: float;
+  last_seen: float;
+}
+
+let summarize_agent_activity ?fs config ~since : agent_activity list =
+  let records =
+    match fs with
+    | Some fs -> read_all_events ~fs config
+    | None -> read_all_events_from_path (telemetry_file config)
+  in
+  let by_agent : (string, agent_activity) Hashtbl.t = Hashtbl.create 16 in
+  List.iter (fun (record : event_record) ->
+    if record.timestamp >= since then
+      match record.event with
+      | Tool_called { agent_id = Some aid; success; _ } ->
+          let current =
+            match Hashtbl.find_opt by_agent aid with
+            | Some a -> a
+            | None -> { agent_id = aid; tool_calls = 0; success_count = 0;
+                        failure_count = 0; first_seen = record.timestamp;
+                        last_seen = record.timestamp }
+          in
+          Hashtbl.replace by_agent aid
+            { current with
+              tool_calls = current.tool_calls + 1;
+              success_count = current.success_count + (if success then 1 else 0);
+              failure_count = current.failure_count + (if success then 0 else 1);
+              first_seen = min current.first_seen record.timestamp;
+              last_seen = max current.last_seen record.timestamp;
+            }
+      | Agent_joined { agent_id; _ } ->
+          if not (Hashtbl.mem by_agent agent_id) then
+            Hashtbl.replace by_agent agent_id
+              { agent_id; tool_calls = 0; success_count = 0; failure_count = 0;
+                first_seen = record.timestamp; last_seen = record.timestamp }
+      | _ -> ()
+  ) records;
+  Hashtbl.fold (fun _ v acc -> v :: acc) by_agent []
+  |> List.sort (fun a b -> compare b.tool_calls a.tool_calls)
+
 let tool_usage_fields summary tool_name =
   let stats =
     match Hashtbl.find_opt summary.stats_by_tool tool_name with


### PR DESCRIPTION
## Summary

**P3: Solo agent 증거 시스템**
- `Telemetry_eio.summarize_agent_activity()` — telemetry.jsonl에서 agent별 tool call 집계
- `GET /api/v1/agent-activity?hours=24` — 시간 윈도우 기반 agent별 활동 API

**P7: Agent 활동 타임라인**
- Overview 페이지에 "에이전트 활동 (24h)" 패널 추가
- 상위 8개 agent의 tool call 수, 성공/실패, 마지막 활동 시각 표시
- P1(#1368)에서 agent_id가 수리되었으므로 의미 있는 데이터 제공 가능

### 변경 파일
- `lib/telemetry_eio.ml` — agent_activity 타입 + summarize 함수 (46줄)
- `lib/server_routes_http_routes_dashboard.ml` — /api/v1/agent-activity endpoint (27줄)
- `dashboard/src/api.ts` — fetchAgentActivity (18줄)
- `dashboard/src/store.ts` — agentActivity signal + refresh (12줄)
- `dashboard/src/components/overview/overview.ts` — AgentActivityPanel (40줄)

## Test plan

- [x] `dune build` 성공
- [x] `npx vite build` 성공
- [ ] `curl localhost:8935/api/v1/agent-activity?hours=24` 응답 확인
- [ ] Overview에서 agent 활동 패널 렌더링 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)