### PR TITLE
fix: tag dispatch fallback + keeper_down session status

### DIFF
--- a/lib/mcp_server_eio.ml
+++ b/lib/mcp_server_eio.ml
@@ -164,6 +164,12 @@ let () =
   register_module_tag ~schemas:Tool_autoresearch.schemas ~tag:Mod_autoresearch;
   register_module_tag ~schemas:Tool_trpg.schemas ~tag:Mod_trpg;
   register_module_tag ~schemas:Tool_notifications.schemas ~tag:Mod_notifications;
+  (* Core schema tools dispatched by tag-only modules (not in fallback chain)
+     need explicit name registration. These have schemas in Tool_schemas_core
+     but dispatch via modules only reachable through the tag system. *)
+  register_name_tag ~tool_name:"masc_init" ~tag:Mod_room;
+  register_name_tag ~tool_name:"masc_register_capabilities" ~tag:Mod_agent;
+  register_name_tag ~tool_name:"masc_find_by_capability" ~tag:Mod_agent;
   mark_tag_registry_initialized ();
   Log.Mcp.info "Tag registry initialized: %d tools registered" (tag_registry_count ())
 

--- a/lib/team_session_engine_eio.ml
+++ b/lib/team_session_engine_eio.ml
@@ -315,6 +315,7 @@ let stop_session ~(config : Room.config) ~(session_id : string) ~(reason : strin
           | _ ->
               let final_status =
                 if reason = "timeout" || reason = "error" || reason = "kill"
+                   || reason = "keeper_down"
                 then Team_session_types.Interrupted
                 else Team_session_types.Completed
               in


### PR DESCRIPTION
## Summary
- Register 3 core tools (`masc_init`, `masc_register_capabilities`, `masc_find_by_capability`) with explicit tag entries in the O(1 dispatch registry. These tools have schemas in `Tool_schemas_core` but are dispatched by tag-only modules (`Tool_room`, `Tool_agent`) not in the fallback chain.
- Treat `keeper_down` reason as `Interrupted` status (not `Completed`) in `stop_session` — keeper shutdown is involuntary termination.

## Root Cause
PR #1330 introduced O(1) tag-based dispatch. The fallback chain fix (tag dispatch `None` → fallback) was already merged to main. However, 3 tools dispatched exclusively through the tag system (not in the fallback chain) still lacked registry entries, causing `visible=372 full=369` invariant violation.

The `keeper_down` bug was a logic gap: `stop_session` only mapped `timeout|error|kill` to `Interrupted`, so `keeper_down` defaulted to `Completed`.

## Test plan
- [x] `test_mode_tool_count`: 18/18 pass (was 17/18)
- [x] `test_operator_control`: 29/29 pass (was 28/29, keeper session bridge)
- [x] `test_mcp_server_eio`: 55/55 pass
- [x] `test_gardener`: 70/70 pass
- [x] `test_operator_mcp_e2e`: 3/3 pass
- [x] `test_agent_swarm_live_harness`: 3/3 pass
- [x] Full suite `dune build @runtest --force`: exit 0 (remaining failures are pre-existing on main)

🤖 Generated with [Claude Code](https://claude.com/claude-code)