### PR TITLE
feat: Phase 1-3 — masc_start, error recovery, registration linter, convo extraction

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,6 +56,8 @@ let cmd = Printf.sprintf
 
 MASC usage는 문서마다 흩어져 있지 않다. 아래 문서를 기준으로 본다.
 
+- `docs/QUICK-START.md`
+  - 1-step setup (`masc_start`), mode 선택, error recovery
 - `docs/COMMAND-PLANE-RUNBOOK.md`
   - room/task hygiene
   - CPv2 benchmark / swarm canonical path

--- a/docs/COMMAND-PLANE-RUNBOOK.md
+++ b/docs/COMMAND-PLANE-RUNBOOK.md
@@ -25,6 +25,10 @@ merged 기준 전체 구조 요약은 [MERGED-ARCHITECTURE-SSOT.md](./MERGED-ARC
 
 일반 작업이든 benchmark든 먼저 이 순서를 맞춘다.
 
+**Quick path**: `masc_start(path="/repo", task_title="My task")` — 1~6번을 한 번에 처리.
+
+**Step-by-step**:
+
 1. `masc_set_room`
    - repo root를 room으로 잡는다.
    - worktree 경로를 줘도 room은 repo-root 기준으로 동작한다.

--- a/docs/QUICK-START.md
+++ b/docs/QUICK-START.md
@@ -1,0 +1,46 @@
+# MASC Quick Start
+
+## 1-Step Setup
+
+```
+masc_start(path="/your/project", task_title="My first task")
+```
+
+This sets the room, joins you as an agent, creates a task, claims it, and sets it as your current task.
+
+## Step-by-Step (if you need control)
+
+```
+masc_set_room(path="/your/project")
+masc_join()
+masc_add_task(title="My task")
+masc_claim_next()
+masc_plan_set_task(task_id="task-001")
+```
+
+## Modes
+
+Default mode is **Coding** (~80 tools). Switch if needed:
+
+```
+masc_switch_mode(mode="full")       # All 371+ tools
+masc_switch_mode(mode="minimal")    # Core only (~20 tools)
+masc_switch_mode(mode="coding")     # Back to default
+```
+
+## Error Recovery
+
+Failed tool calls include recovery hints automatically. Common patterns:
+
+| Error | Recovery |
+|-------|----------|
+| "not initialized" | `masc_init` or `masc_start(path=...)` |
+| "not joined" | `masc_join` or `masc_start` |
+| "no unclaimed tasks" | `masc_add_task(title="...")` |
+| "task not found" | `masc_status` to see available tasks |
+
+## Reference
+
+- `docs/COMMAND-PLANE-RUNBOOK.md` — CPv2 benchmark/swarm path
+- `docs/SUPERVISOR-MODE.md` — supervised team session path
+- `docs/BENCHMARK-RUNBOOK.md` — single-agent vs swarm recipes

--- a/lib/config.ml
+++ b/lib/config.ml
@@ -11,11 +11,11 @@ type t = {
   enabled_categories : category list;
 }
 
-(** Default configuration — Full mode gives new users access to all tools.
-    Use masc_switch_mode to restrict if needed (BUG-017 revisited). *)
+(** Default configuration — Coding mode (~80 tools) balances usability with
+    context efficiency. Use masc_switch_mode(mode:"full") for all 371+ tools. *)
 let default = {
-  mode = Full;
-  enabled_categories = categories_for_mode Full;
+  mode = Coding;
+  enabled_categories = categories_for_mode Coding;
 }
 
 (** Config file name *)

--- a/lib/dune
+++ b/lib/dune
@@ -465,6 +465,7 @@
    tool_harness_health
    tool_inline_dispatch
    tool_inline_dispatch_extra
+   tool_convo
    tool_unified
    tool_help_registry
    tool_registry

--- a/lib/dune
+++ b/lib/dune
@@ -261,6 +261,7 @@
    mcp_server_eio_resource
    mcp_server_eio_execute
    mcp_server_eio_call_tool
+   masc_error_recovery
    mcp_server_eio_tool_profile
    mcp_server_eio_protocol
    mcp_session

--- a/lib/masc_error_recovery.ml
+++ b/lib/masc_error_recovery.ml
@@ -1,6 +1,7 @@
 (** Error recovery hints — pattern-matches error messages to suggest next actions.
 
     Called from mcp_server_eio_call_tool.ml on tool failure to help agents
+    self-recover without human intervention.
     self-correct without human intervention. *)
 
 let contains s sub =

--- a/lib/masc_error_recovery.ml
+++ b/lib/masc_error_recovery.ml
@@ -1,0 +1,34 @@
+(** Error recovery hints — pattern-matches error messages to suggest next actions.
+
+    Called from mcp_server_eio_call_tool.ml on tool failure to help agents
+    self-correct without human intervention. *)
+
+let contains s sub =
+  try
+    let _ = Str.search_forward (Str.regexp_string sub) s 0 in
+    true
+  with Not_found -> false
+
+(** Given an error message, return a suggested recovery action or None. *)
+let recovery_hint (message : string) : string option =
+  let msg = String.lowercase_ascii message in
+  if contains msg "not initialized" || contains msg "no .masc/" then
+    Some "Run masc_init to initialize, or use masc_start(path=...) for one-step setup."
+  else if contains msg "not joined" || contains msg "join the room" then
+    Some "Call masc_join first, or use masc_start for one-step setup."
+  else if contains msg "task not found" || contains msg "not found" && contains msg "task" then
+    Some "Call masc_status to see available tasks."
+  else if contains msg "already claimed" then
+    Some "Call masc_status to see other available tasks, or use masc_claim_next."
+  else if contains msg "no unclaimed tasks" then
+    Some "Call masc_add_task to create a new task."
+  else if contains msg "rate limit" || contains msg "too many" then
+    Some "Wait briefly and retry. This is a transient error."
+  else if contains msg "room" && contains msg "set" then
+    Some "Call masc_set_room(path=...) or masc_start(path=...) first."
+  else if contains msg "current_task" || contains msg "no current task" then
+    Some "Call masc_plan_set_task(task_id=...) after claiming a task."
+  else if contains msg "path is required" then
+    Some "Provide the project directory path, e.g., masc_start(path=\"~/my-project\")."
+  else
+    None

--- a/lib/mcp_server_eio_call_tool.ml
+++ b/lib/mcp_server_eio_call_tool.ml
@@ -291,6 +291,15 @@ let handle_call_tool_eio ~execute_tool_eio ~maybe_emit_resource_notifications
     | `Float f -> Printf.sprintf "%0.0f" f
     | _ -> "unknown"
   in
+  (* Append recovery hint on failure *)
+  let message =
+    if success then message
+    else
+      let hint = Masc_error_recovery.recovery_hint message in
+      match hint with
+      | None -> message
+      | Some h -> message ^ "\n\n💡 Recovery: " ^ h
+  in
   let (status, required_follow_up) = parse_status_from_message ~success ~message in
   let quality = quality_from_result ~success ~message ~attempts in
   let workflow_guidance =

--- a/lib/mode.ml
+++ b/lib/mode.ml
@@ -148,11 +148,11 @@ let categories_for_mode = function
 let tool_category tool_name =
   match tool_name with
 
-  (* ── Core_Room: room entry/exit, essential coordination (7 tools) ── *)
-  | "masc_set_room" | "masc_init" | "masc_join" | "masc_leave"
+  (* ── Core_Room: room entry/exit, essential coordination ── *)
+  | "masc_start" | "masc_set_room" | "masc_init" | "masc_join" | "masc_leave"
   | "masc_room_create" | "masc_room_enter" | "masc_rooms_list" -> Core_Room
 
-  (* ── Core_Task: task lifecycle (13 tools) ── *)
+  (* ── Core_Task: task lifecycle ── *)
   | "masc_add_task" | "masc_batch_add_tasks"
   | "masc_tasks" | "masc_claim_next"
   | "masc_update_priority" | "masc_transition"

--- a/lib/tool_convo.ml
+++ b/lib/tool_convo.ml
@@ -1,0 +1,140 @@
+(** Tool_convo — Conversation (threaded discussion) handlers.
+
+    Extracted from tool_inline_dispatch.ml.
+    Handles: masc_convo_start, masc_convo_reply, masc_convo_conclude,
+             masc_convo_get, masc_convo_list *)
+
+type result = bool * string
+
+type context = {
+  config : Room.config;
+  agent_name : string;
+}
+
+let get_string = Safe_ops.json_string
+let get_int args key default = Safe_ops.json_int ~default key args
+let get_float_opt args key = Safe_ops.json_float_opt key args
+let get_string_opt args key =
+  match Safe_ops.json_string_opt key args with
+  | Some "" -> None
+  | other -> other
+let get_string_list args key = Safe_ops.json_string_list key args
+
+let convo_config config =
+  let current_room = Room.read_current_room config |> Option.value ~default:"default" in
+  ({ Council.Conversation.base_path = config.Room.base_path; room = current_room }
+    : Council.Conversation.config)
+
+let handle_start ctx args =
+  let topic = get_string ~default:"" "topic" args in
+  let initiator = get_string ~default:ctx.agent_name "initiator" args in
+  let initial_content = get_string ~default:"" "initial_content" args in
+  let max_turns = get_int args "max_turns" 50 in
+  let source_post_id = get_string_opt args "post_id" in
+  let mentions = get_string_list args "mentions" in
+  if topic = "" then (false, "topic required")
+  else begin
+    let cc = convo_config ctx.config in
+    match Council.Conversation.start ~config:cc ~topic ~initiator
+            ~max_turns ~initial_content ~mentions ?source_post_id () with
+    | Ok thread ->
+        let link_warning = match source_post_id with
+          | Some pid ->
+              (match Board_dispatch.set_thread_id
+                ~post_id:pid ~thread_id:thread.Council.Conversation.id with
+               | Ok () -> ""
+               | Error e -> Printf.sprintf "\nBoard link failed: %s" (Board.show_board_error e))
+          | None -> ""
+        in
+        let json = Council.Conversation.thread_to_yojson thread in
+        (true, Printf.sprintf "Thread started: %s%s\n%s"
+          thread.Council.Conversation.id link_warning (Yojson.Safe.pretty_to_string json))
+    | Error e -> (false, e)
+  end
+
+let handle_reply ctx args =
+  let thread_id = get_string ~default:"" "thread_id" args in
+  let speaker = get_string ~default:ctx.agent_name "speaker" args in
+  let content = get_string ~default:"" "content" args in
+  let confidence = get_float_opt args "confidence" in
+  let reply_to = get_string_opt args "reply_to" in
+  let mentions = get_string_list args "mentions" in
+  if thread_id = "" || content = "" then
+    (false, "thread_id and content required")
+  else if not (try Room.is_agent_joined ctx.config ~agent_name:speaker with Sys_error _ | Not_found -> false) then
+    (false, Printf.sprintf "Speaker '%s' is not a member of this room" speaker)
+  else begin
+    let cc = convo_config ctx.config in
+    match Council.Conversation.get ~config:cc ~thread_id with
+    | None -> (false, Printf.sprintf "Thread not found: %s" thread_id)
+    | Some thread ->
+        let loop_check = Council.Loop_guard.check
+          ~thread ~speaker ~content
+          ~config:Council.Loop_guard.default_config
+        in
+        match Council.Loop_guard.to_error_message loop_check with
+        | Some err -> (false, Printf.sprintf "Loop detected: %s" err)
+        | None ->
+            match Council.Conversation.reply ~config:cc ~thread_id
+                    ~speaker ~content ?confidence ?reply_to ~mentions () with
+            | Ok updated ->
+                let json = Council.Conversation.thread_to_yojson updated in
+                (true, Printf.sprintf "Reply added (turn %d)\n%s"
+                  updated.Council.Conversation.current_turn
+                  (Yojson.Safe.pretty_to_string json))
+            | Error e -> (false, e)
+  end
+
+let handle_conclude ctx args =
+  let thread_id = get_string ~default:"" "thread_id" args in
+  let concluder = get_string ~default:ctx.agent_name "concluder" args in
+  let conclusion = get_string ~default:"" "conclusion" args in
+  if thread_id = "" || conclusion = "" then
+    (false, "thread_id and conclusion required")
+  else begin
+    let cc = convo_config ctx.config in
+    match Council.Conversation.conclude ~config:cc ~thread_id
+            ~concluder ~conclusion () with
+    | Ok thread ->
+        let json = Council.Conversation.thread_to_yojson thread in
+        (true, Printf.sprintf "Thread concluded: %s\n%s"
+          thread.Council.Conversation.id (Yojson.Safe.pretty_to_string json))
+    | Error e -> (false, e)
+  end
+
+let handle_get ctx args =
+  let thread_id = get_string ~default:"" "thread_id" args in
+  if thread_id = "" then (false, "thread_id required")
+  else begin
+    let cc = convo_config ctx.config in
+    match Council.Conversation.get ~config:cc ~thread_id with
+    | Some thread ->
+        let json = Council.Conversation.thread_to_yojson thread in
+        (true, Yojson.Safe.pretty_to_string json)
+    | None -> (false, Printf.sprintf "Thread not found: %s" thread_id)
+  end
+
+let handle_list ctx _args =
+  let cc = convo_config ctx.config in
+  let threads = Council.Conversation.list_active ~config:cc in
+  let json = `List (List.map (fun th ->
+    `Assoc [
+      ("id", `String th.Council.Conversation.id);
+      ("topic", `String th.Council.Conversation.topic);
+      ("status", `String (Council.Conversation.thread_status_to_string th.Council.Conversation.status));
+      ("turns", `Int th.Council.Conversation.current_turn);
+      ("participants", `List (List.map (fun p -> `String p) th.Council.Conversation.participants));
+    ]
+  ) threads) in
+  (true, Printf.sprintf "Active threads: %d\n%s"
+    (List.length threads) (Yojson.Safe.pretty_to_string json))
+
+(* Dispatch *)
+let dispatch ctx ~name ~args : result option =
+  match name with
+  | "masc_convo_start" -> Some (handle_start ctx args)
+  | "masc_convo_reply" -> Some (handle_reply ctx args)
+  | "masc_convo_conclude" -> Some (handle_conclude ctx args)
+  | "masc_convo_get" -> Some (handle_get ctx args)
+  | "masc_convo_list" -> Some (handle_list ctx args)
+  | _ -> None

--- a/lib/tool_inline_dispatch.ml
+++ b/lib/tool_inline_dispatch.ml
@@ -932,4 +932,320 @@ Call masc_listen again to continue listening.
       Some (true, Yojson.Safe.pretty_to_string response)
 
 
+<<<<<<< HEAD
+  | _ -> Tool_inline_dispatch_extra.dispatch ~config ~agent_name ~arguments ~state ~sw ~clock ~name
+||||||| parent of e502a413 (refactor: extract tool_convo.ml from tool_inline_dispatch (Phase 2.1 Batch D))
+      let estimated_ratio = Float.min 1.0 (Float.of_int tool_calls /. Mitosis.Defaults.tool_calls_per_full_context) in
+      let status =
+        if estimated_ratio >= Mitosis.default_config.handoff_threshold then "critical"
+        else if estimated_ratio >= Mitosis.default_config.prepare_threshold then "warning"
+        else "healthy" in
+
+      let remaining_ratio = 1.0 -. estimated_ratio in
+      let estimated_remaining_tools = int_of_float (remaining_ratio *. Mitosis.Defaults.tool_calls_per_full_context) in
+
+      let now = Time_compat.now () in
+      let age_seconds = now -. cell.Mitosis.born_at in
+      let age_human =
+        if age_seconds < 60.0 then Printf.sprintf "%.0f seconds" age_seconds
+        else if age_seconds < 3600.0 then Printf.sprintf "%.1f minutes" (age_seconds /. 60.0)
+        else Printf.sprintf "%.1f hours" (age_seconds /. 3600.0)
+      in
+
+      let all_statuses = Mitosis.get_all_statuses ~room_config:config in
+      let siblings = List.filter (fun (_, _, _) -> true) all_statuses in
+
+      let cell_id = cell.Mitosis.id in
+      let episode_count, recent_episode =
+        match state.Mcp_server.env with
+        | Some env ->
+          (try
+            (match Jiphyeon.Archive.get_agent_episodes ~sw ~env cell_id 5 with
+             | Ok episodes -> (List.length episodes, List.nth_opt episodes 0)
+             | Error _ -> (0, None))
+          with exn ->
+            Log.Inline.warn "%s: %s" __FUNCTION__ (Printexc.to_string exn);
+            (0, None))
+        | None -> (0, None)
+      in
+
+      let mortality_msg =
+        if estimated_ratio >= 0.8 then
+          "Approaching end of lifecycle. Consider preparing DNA for successor."
+        else if estimated_ratio >= 0.5 then
+          "Mid-lifecycle. Context accumulating normally."
+        else
+          "Early lifecycle. Plenty of context remaining."
+      in
+
+      let response = `Assoc [
+        ("generation", `Int generation);
+        ("cell_id", `String cell_id);
+        ("context_used", `Float estimated_ratio);
+        ("status", `String status);
+        ("tool_calls", `Int tool_calls);
+        ("task_count", `Int task_count);
+        ("phase", `String (Mitosis.phase_to_string cell.Mitosis.phase));
+        ("born_at", `Float cell.Mitosis.born_at);
+        ("age_seconds", `Float age_seconds);
+        ("age_human", `String age_human);
+        ("estimated_remaining_tools", `Int estimated_remaining_tools);
+        ("siblings_in_room", `Int (List.length siblings));
+        ("parent_dna", match cell.Mitosis.context_dna with Some _ -> `Bool true | None -> `Bool false);
+        ("episode_count", `Int episode_count);
+        ("recent_episode", match recent_episode with
+          | Some (ep_id, event_type, _, summary) ->
+            `Assoc [("ep_id", `String ep_id); ("event_type", `String event_type); ("summary", `String summary)]
+          | None -> `Null);
+        ("mortality_awareness", `String mortality_msg);
+        ("message", `String (Printf.sprintf "Generation %d | Age %s | Context %.0f%% (%s) | ~%d tool calls remaining | %d memories"
+          generation age_human (estimated_ratio *. 100.0) status estimated_remaining_tools episode_count));
+      ] in
+      Some (true, Yojson.Safe.pretty_to_string response)
+
+  | "masc_recall_search" ->
+      let module U = Yojson.Safe.Util in
+      let query = match Json_util.get_string arguments "query" with Some v -> v | None -> raise Not_found in
+      let limit = arguments |> U.member "limit" |> U.to_int_option |> Option.value ~default:5 in
+
+      (match state.Mcp_server.env with
+       | None ->
+           Some (true, Yojson.Safe.pretty_to_string (`Assoc [
+             ("success", `Bool false);
+             ("error", `String "Database environment not available");
+             ("suggestion", `String "Ensure runtime environment is initialized");
+           ]))
+       | Some env ->
+           let recall_config = Auto_recall.make_config
+             ~enabled:true
+             ~sources:[Auto_recall.Recent_broadcasts; Auto_recall.Masc_cache; Auto_recall.File_context]
+             ~max_tokens:4000
+             ~max_broadcasts:limit
+             ()
+           in
+           let result = Auto_recall.fetch_context_eio ~sw ~env ~clock config ~config:recall_config ~query () in
+           let response = `Assoc [
+             ("success", `Bool true);
+             ("query", `String query);
+             ("items", `List (List.map (fun (item : Auto_recall.recall_item) ->
+               `Assoc [
+                 ("source", `String (match item.source with
+                   | Auto_recall.Masc_cache -> "cache"
+                   | Auto_recall.Recent_broadcasts -> "broadcast"
+                   | Auto_recall.File_context -> "file"));
+                 ("content", `String item.content);
+                 ("relevance", `Float item.relevance);
+                 ("metadata", item.metadata);
+               ]
+             ) result.items));
+             ("total_tokens", `Int result.total_tokens);
+             ("truncated", `Bool result.truncated);
+             ("message", `String (Printf.sprintf "Found %d relevant items for query: %s"
+               (List.length result.items) query));
+           ] in
+           let agent_name = Safe_ops.json_string ~default:"unknown" "agent_name" arguments in
+           Audit_log.log_action config ~agent_id:agent_name ~action:Audit_log.SearchRefinement
+             ~room_id:(Filename.basename config.base_path)
+             ~details:(`Assoc [("query", `String query); ("results", `Int (List.length result.items))])
+             ~outcome:Audit_log.Success ();
+           Some (true, Yojson.Safe.pretty_to_string response))
+
+  | "masc_board_post" ->
+      let (success, message) as result = Tool_board.handle_tool name arguments in
+      if success then begin
+        let author = Safe_ops.json_string ~default:"anonymous" "author" arguments in
+        let content = Safe_ops.json_string ~default:"" "content" arguments in
+        let notification = `Assoc [
+          ("type", `String "masc/board_post");
+          ("author", `String author);
+          ("content", `String (String.sub content 0 (min 200 (String.length content))));
+          ("post_id", `String (
+            try
+              let idx = String.index message '{' in
+              let json = Yojson.Safe.from_string
+                (String.sub message idx (String.length message - idx)) in
+              Yojson.Safe.Util.(json |> member "id" |> to_string)
+            with
+            | Not_found | Invalid_argument _
+            | Yojson.Json_error _ | Yojson.Safe.Util.Type_error _ -> "unknown"
+          ));
+          ("timestamp", `String (Types.now_iso ()));
+        ] in
+        Mcp_server.sse_broadcast state notification;
+        A2a_tools.notify_event
+          ~event_type:A2a_tools.Broadcast
+          ~agent:author
+          ~data:(`Assoc [
+            ("event", `String "board_post");
+            ("content_preview", `String (String.sub content 0 (min 100 (String.length content))));
+          ])
+      end;
+      Some result
+
+  | "masc_board_comment" ->
+      let (success, _message) as result = Tool_board.handle_tool name arguments in
+      if success then begin
+        let author = Safe_ops.json_string ~default:"anonymous" "author" arguments in
+        let content = Safe_ops.json_string ~default:"" "content" arguments in
+        let post_id = Safe_ops.json_string ~default:"unknown" "post_id" arguments in
+        let notification = `Assoc [
+          ("type", `String "board_comment");
+          ("author", `String author);
+          ("post_id", `String post_id);
+          ("content", `String (String.sub content 0 (min 200 (String.length content))));
+          ("timestamp", `String (Types.now_iso ()));
+        ] in
+        Mcp_server.sse_broadcast state notification;
+        A2a_tools.notify_event
+          ~event_type:A2a_tools.Broadcast
+          ~agent:author
+          ~data:(`Assoc [
+            ("event", `String "board_comment");
+            ("post_id", `String post_id);
+            ("content_preview", `String (String.sub content 0 (min 100 (String.length content))));
+          ])
+      end;
+      Some result
+
+  | "masc_board_list" | "masc_board_get"
+  | "masc_board_vote" | "masc_board_stats"
+  | "masc_board_search" | "masc_board_comment_vote" | "masc_board_profile"
+  | "masc_board_hearths" | "masc_board_migrate" ->
+      Some (Tool_board.handle_tool name arguments)
+
+  | "lodge_heartbeat" | "lodge_classify" | "lodge_react" | "lodge_cycle"
+  | "lodge_discussion" | "lodge_orchestrate" | "lodge_auto_chain"
+  | "lodge_evolve" | "lodge_spawn" | "lodge_agents"
+  | "lodge_agent_patrol" | "lodge_autonomous_loop"
+  | "lodge_propose_project" | "lodge_join_project" | "lodge_share_code"
+  | "lodge_research" | "lodge_profile"
+  | "lodge_search" | "lodge_comment_like" | "lodge_progress" ->
+      (match state.Mcp_server.net with
+       | Some net -> Some (Tool_lodge.handle_tool ~net name arguments)
+       | None -> Some (false, "lodge tools require net (server_state.net is None)"))
+
+  | "masc_convo_start" ->
+      let topic = arg_get_string "topic" "" in
+      let initiator = arg_get_string "initiator" agent_name in
+      let initial_content = arg_get_string "initial_content" "" in
+      let max_turns = arg_get_int "max_turns" 50 in
+      let source_post_id = arg_get_string_opt "post_id" in
+      let mentions = arg_get_string_list "mentions" in
+      let current_room = Room.read_current_room config |> Option.value ~default:"default" in
+      if topic = "" then Some (false, "topic required")
+      else begin
+        let convo_config : Council.Conversation.config = {
+          base_path = config.base_path;
+          room = current_room;
+        } in
+        match Council.Conversation.start ~config:convo_config ~topic ~initiator
+                ~max_turns ~initial_content ~mentions ?source_post_id () with
+        | Ok thread ->
+            let link_warning = match source_post_id with
+              | Some pid ->
+                  (match Board_dispatch.set_thread_id
+                    ~post_id:pid ~thread_id:thread.Council.Conversation.id with
+                   | Ok () -> ""
+                   | Error e -> Printf.sprintf "\nBoard link failed: %s" (Board.show_board_error e))
+              | None -> ""
+            in
+            let json = Council.Conversation.thread_to_yojson thread in
+            Some (true, Printf.sprintf "Thread started: %s%s\n%s"
+              thread.Council.Conversation.id link_warning (Yojson.Safe.pretty_to_string json))
+        | Error e -> Some (false, e)
+      end
+
+  | "masc_convo_reply" ->
+      let thread_id = arg_get_string "thread_id" "" in
+      let speaker = arg_get_string "speaker" agent_name in
+      let content = arg_get_string "content" "" in
+      let confidence = arg_get_float_opt "confidence" in
+      let reply_to = arg_get_string_opt "reply_to" in
+      let mentions = arg_get_string_list "mentions" in
+      let current_room = Room.read_current_room config |> Option.value ~default:"default" in
+      if thread_id = "" || content = "" then
+        Some (false, "thread_id and content required")
+      else if not (try Room.is_agent_joined config ~agent_name:speaker with Sys_error _ | Not_found -> false) then
+        Some (false, Printf.sprintf "Speaker '%s' is not a member of this room" speaker)
+      else begin
+        let convo_config : Council.Conversation.config = {
+          base_path = config.base_path;
+          room = current_room;
+        } in
+        match Council.Conversation.get ~config:convo_config ~thread_id with
+        | None -> Some (false, Printf.sprintf "Thread not found: %s" thread_id)
+        | Some thread ->
+            let loop_check = Council.Loop_guard.check
+              ~thread ~speaker ~content
+              ~config:Council.Loop_guard.default_config
+            in
+            match Council.Loop_guard.to_error_message loop_check with
+            | Some err -> Some (false, Printf.sprintf "Loop detected: %s" err)
+            | None ->
+                match Council.Conversation.reply ~config:convo_config ~thread_id
+                        ~speaker ~content ?confidence ?reply_to ~mentions () with
+                | Ok updated ->
+                    let json = Council.Conversation.thread_to_yojson updated in
+                    Some (true, Printf.sprintf "Reply added (turn %d)\n%s"
+                      updated.Council.Conversation.current_turn
+                      (Yojson.Safe.pretty_to_string json))
+                | Error e -> Some (false, e)
+      end
+
+  | "masc_convo_conclude" ->
+      let thread_id = arg_get_string "thread_id" "" in
+      let concluder = arg_get_string "concluder" agent_name in
+      let conclusion = arg_get_string "conclusion" "" in
+      let current_room = Room.read_current_room config |> Option.value ~default:"default" in
+      if thread_id = "" || conclusion = "" then
+        Some (false, "thread_id and conclusion required")
+      else begin
+        let convo_config : Council.Conversation.config = {
+          base_path = config.base_path;
+          room = current_room;
+        } in
+        match Council.Conversation.conclude ~config:convo_config ~thread_id
+                ~concluder ~conclusion () with
+        | Ok thread ->
+            let json = Council.Conversation.thread_to_yojson thread in
+            Some (true, Printf.sprintf "Thread concluded: %s\n%s"
+              thread.Council.Conversation.id (Yojson.Safe.pretty_to_string json))
+        | Error e -> Some (false, e)
+      end
+
+  | "masc_convo_get" ->
+      let thread_id = arg_get_string "thread_id" "" in
+      let current_room = Room.read_current_room config |> Option.value ~default:"default" in
+      if thread_id = "" then Some (false, "thread_id required")
+      else begin
+        let convo_config : Council.Conversation.config = {
+          base_path = config.base_path;
+          room = current_room;
+        } in
+        match Council.Conversation.get ~config:convo_config ~thread_id with
+        | Some thread ->
+            let json = Council.Conversation.thread_to_yojson thread in
+            Some (true, Yojson.Safe.pretty_to_string json)
+        | None -> Some (false, Printf.sprintf "Thread not found: %s" thread_id)
+      end
+
+  | "masc_convo_list" ->
+      let current_room = Room.read_current_room config |> Option.value ~default:"default" in
+      let convo_config : Council.Conversation.config = {
+        base_path = config.base_path;
+        room = current_room;
+      } in
+      let threads = Council.Conversation.list_active ~config:convo_config in
+      let json = `List (List.map (fun th ->
+        `Assoc [
+          ("id", `String th.Council.Conversation.id);
+          ("topic", `String th.Council.Conversation.topic);
+          ("status", `String (Council.Conversation.thread_status_to_string th.Council.Conversation.status));
+          ("turns", `Int th.Council.Conversation.current_turn);
+          ("participants", `List (List.map (fun p -> `String p) th.Council.Conversation.participants));
+        ]
+      ) threads) in
+      Some (true, Printf.sprintf "Active threads: %d\n%s"
+        (List.length threads) (Yojson.Safe.pretty_to_string json))
+
   | _ -> Tool_inline_dispatch_extra.dispatch ~config ~agent_name ~arguments ~state ~sw ~clock ~name

--- a/lib/tool_inline_dispatch.ml
+++ b/lib/tool_inline_dispatch.ml
@@ -101,6 +101,89 @@ let dispatch (ctx : context) ~(name : string) : result option =
   in
 
   match name with
+  (* ── Compound onboarding: masc_start ──────────────────────────── *)
+  | "masc_start" ->
+      let path =
+        let p = arg_get_string "path" "" in
+        if p = "" then arg_get_string "room" "" else p
+      in
+      let task_title = arg_get_string "task_title" "" in
+      (* Step 1: set_room *)
+      let room_result =
+        if path = "" then begin
+          (* Use current room if already set *)
+          if Room.is_initialized state.Mcp_server.room_config then
+            Ok config
+          else
+            Error "path is required when no room is set. Provide the project directory path."
+        end else begin
+          let expanded =
+            if String.length path >= 2 && path.[0] = '~' && path.[1] = '/' then
+              let home = match Sys.getenv_opt "HOME" with Some h -> h | None -> "/tmp" in
+              Filename.concat home (String.sub path 2 (String.length path - 2))
+            else if String.length path = 1 && path.[0] = '~' then
+              (match Sys.getenv_opt "HOME" with Some h -> h | None -> "/tmp")
+            else if Filename.is_relative path then
+              Filename.concat (Sys.getcwd ()) path
+            else
+              path
+          in
+          if not (Sys.file_exists expanded && Sys.is_directory expanded) then
+            Error (Printf.sprintf "Directory not found: %s" expanded)
+          else
+            let masc_dir = Filename.concat expanded ".masc" in
+            if not (Sys.file_exists masc_dir && Sys.is_directory masc_dir) then
+              Error (Printf.sprintf "No .masc/ directory in %s. Use masc_init first." expanded)
+            else begin
+              state.Mcp_server.room_config <- Room.default_config expanded;
+              Ok state.Mcp_server.room_config
+            end
+        end
+      in
+      begin match room_result with
+      | Error e -> Some (false, Printf.sprintf "masc_start failed at set_room: %s" e)
+      | Ok active_config ->
+        (* Step 2: join (idempotent — skip if already joined) *)
+        let join_result =
+          try
+            let _msg = Room.join active_config ~agent_name ~capabilities:[] () in
+            Ok ()
+          with exn ->
+            let msg = Printexc.to_string exn in
+            if String.length msg > 0 then Error msg else Error "join failed"
+        in
+        match join_result with
+        | Error e -> Some (false, Printf.sprintf "masc_start failed at join: %s\nHint: try masc_join separately." e)
+        | Ok () ->
+          (* Step 3: add_task + claim + plan_set_task (if task_title provided) *)
+          if task_title = "" then
+            Some (true, Printf.sprintf "masc_start complete (room set + joined as %s). No task created — use masc_add_task to create one." agent_name)
+          else begin
+            let add_result = Room_task.add_task active_config ~title:task_title ~priority:3 ~description:"" in
+            (* Extract task ID from result like "✅ Added task-001: title" *)
+            let task_id =
+              try
+                let prefix = "Added " in
+                let idx = ref 0 in
+                while !idx < String.length add_result - String.length prefix &&
+                      String.sub add_result !idx (String.length prefix) <> prefix do
+                  incr idx
+                done;
+                let start = !idx + String.length prefix in
+                let end_idx = try String.index_from add_result start ':' with Not_found -> String.length add_result in
+                String.sub add_result start (end_idx - start)
+              with _ -> ""
+            in
+            if task_id = "" then
+              Some (true, Printf.sprintf "masc_start partial: joined as %s, but task creation failed: %s" agent_name add_result)
+            else begin
+              let _claim_msg = Room_task.claim_task active_config ~agent_name ~task_id in
+              Planning_eio.set_current_task active_config ~task_id;
+              Some (true, Printf.sprintf "masc_start complete: room set, joined as %s, task %s created+claimed+set as current." agent_name task_id)
+            end
+          end
+      end
+
   | "masc_lock" ->
       let file = arg_get_string "file" "" in
       if file = "" then

--- a/lib/tool_schemas_room_core.ml
+++ b/lib/tool_schemas_room_core.ml
@@ -2,6 +2,23 @@ open Types
 
 let schemas : tool_schema list = [
   {
+    name = "masc_start";
+    description = "One-step onboarding: sets room, joins as agent, and optionally creates+claims a task. Use this instead of calling masc_set_room, masc_join, masc_add_task, masc_claim separately.";
+    input_schema = `Assoc [
+      ("type", `String "object");
+      ("properties", `Assoc [
+        ("path", `Assoc [
+          ("type", `String "string");
+          ("description", `String "Project directory path (absolute, relative, or ~/...). Omit if room is already set.");
+        ]);
+        ("task_title", `Assoc [
+          ("type", `String "string");
+          ("description", `String "If provided, creates a task with this title, claims it, and sets it as current_task. Omit to just join without a task.");
+        ]);
+      ]);
+    ];
+  };
+  {
     name = "masc_set_room";
     description = "Set the working directory for MASC operations. Use this to work with .masc/ in a different project.";
     input_schema = `Assoc [

--- a/lib/workflow_guide.ml
+++ b/lib/workflow_guide.ml
@@ -26,6 +26,21 @@ let s tool reason = { tool; reason }
 
 (* ── Golden Path 1: Room/Task Hygiene ────────────────────────────── *)
 
+let after_start ~success =
+  if success then
+    { next_steps =
+        [ s "masc_worktree_create" "Create an isolated worktree for this task";
+          s "masc_heartbeat" "Signal liveness before starting work" ];
+      preconditions = [];
+      common_mistakes =
+        [ "Forgetting masc_worktree_create — working on main branch directly" ] }
+  else
+    { next_steps =
+        [ s "masc_set_room" "Set the room manually if path was wrong";
+          s "masc_init" "Initialize MASC if not yet set up" ];
+      preconditions = [];
+      common_mistakes = [] }
+
 let after_set_room ~success =
   if success then
     { next_steps =
@@ -293,6 +308,7 @@ let after_operator_digest ~success =
 let next_steps ~tool_name ~success =
   match tool_name with
   (* Golden Path 1: Room/Task Hygiene *)
+  | "masc_start" -> after_start ~success
   | "masc_set_room" -> after_set_room ~success
   | "masc_join" -> after_join ~success
   | "masc_status" -> after_status ~success

--- a/test/dune
+++ b/test/dune
@@ -911,6 +911,12 @@
  (modules test_proof_criteria)
  (libraries masc_mcp alcotest yojson))
 
+; Tool registration consistency linter (no server required)
+(test
+ (name test_tool_registration_consistency)
+ (modules test_tool_registration_consistency)
+ (libraries masc_mcp alcotest yojson))
+
 ; LLM Scoring Demo — compare keyword vs LLM capability matching
 ; Run with: MASC_CAPABILITY_MATCH_MODE=llm dune exec test/test_llm_scoring_demo.exe
 (executable

--- a/test/test_tool_registration_consistency.ml
+++ b/test/test_tool_registration_consistency.ml
@@ -1,0 +1,103 @@
+(** Structural linter: verifies tool registration consistency.
+
+    1. Every tool in Config.all_tool_schemas must be mapped in Mode.tool_category
+       (not Unknown). An Unknown tool is invisible in all mode presets.
+    2. Every tool referenced in Workflow_guide must exist in Config.all_tool_schemas.
+
+    This test catches registration drift when new tools are added to schemas
+    but not to mode.ml, or when workflow_guide references stale tool names. *)
+
+open Masc_mcp
+module WG = Masc_mcp__Workflow_guide
+
+(* ── All schema tool names ─────────────────────────────────────── *)
+
+let all_schema_names =
+  List.map (fun (s : Types.tool_schema) -> s.name) Config.all_tool_schemas
+
+(* ── Test 1: No Unknown tools in schemas ──────────────────────── *)
+
+let test_no_unknown_tools () =
+  let unknown_tools =
+    List.filter
+      (fun name -> Mode.tool_category name = Mode.Unknown)
+      all_schema_names
+  in
+  match unknown_tools with
+  | [] -> ()
+  | tools ->
+      Alcotest.fail
+        (Printf.sprintf
+           "Found %d tool(s) with Unknown category (invisible in all modes):\n  %s\n\
+            Fix: add them to Mode.tool_category in lib/mode.ml"
+           (List.length tools)
+           (String.concat "\n  " tools))
+
+(* ── Test 2: Workflow guide references valid tools ────────────── *)
+
+let test_workflow_guide_tools_exist () =
+  let guide_tools = [
+    "masc_start"; "masc_set_room"; "masc_join"; "masc_status";
+    "masc_claim"; "masc_claim_next"; "masc_done"; "masc_transition";
+    "masc_add_task"; "masc_batch_add_tasks";
+    "masc_plan_set_task"; "masc_set_current_task";
+    "masc_heartbeat"; "masc_broadcast";
+    "masc_worktree_create"; "masc_init"; "masc_switch_mode";
+    "masc_operator_digest";
+    "masc_operation_start"; "masc_dispatch_tick";
+    "masc_team_session_start"; "masc_team_session_step";
+    "masc_team_session_prove"; "masc_team_session_stop";
+  ] in
+  List.iter (fun tool_name ->
+    let g_ok = WG.next_steps ~tool_name ~success:true in
+    List.iter (fun (s : WG.step) ->
+      if not (List.mem s.tool all_schema_names) then
+        Alcotest.fail
+          (Printf.sprintf
+             "WG.next_steps(%s) references '%s' which is not in Config.all_tool_schemas"
+             tool_name s.tool)
+    ) g_ok.next_steps;
+    let g_fail = WG.next_steps ~tool_name ~success:false in
+    List.iter (fun (s : WG.step) ->
+      if not (List.mem s.tool all_schema_names) then
+        Alcotest.fail
+          (Printf.sprintf
+             "WG.next_steps(%s, fail) references '%s' which is not in Config.all_tool_schemas"
+             tool_name s.tool)
+    ) g_fail.next_steps
+  ) guide_tools
+
+(* ── Test 3: No duplicate tool names in schemas ──────────────── *)
+
+let test_no_duplicate_schemas () =
+  let seen = Hashtbl.create 256 in
+  let duplicates = ref [] in
+  List.iter (fun name ->
+    if Hashtbl.mem seen name then
+      duplicates := name :: !duplicates
+    else
+      Hashtbl.replace seen name true
+  ) all_schema_names;
+  match !duplicates with
+  | [] -> ()
+  | dups ->
+      Alcotest.fail
+        (Printf.sprintf "Found %d duplicate tool schema(s):\n  %s"
+           (List.length dups)
+           (String.concat "\n  " dups))
+
+(* ── Runner ───────────────────────────────────────────────────── *)
+
+let () =
+  Alcotest.run "tool_registration_consistency"
+    [
+      ( "linter",
+        [
+          Alcotest.test_case "no Unknown tools in schemas" `Quick
+            test_no_unknown_tools;
+          Alcotest.test_case "workflow guide references valid tools" `Quick
+            test_workflow_guide_tools_exist;
+          Alcotest.test_case "no duplicate tool schemas" `Quick
+            test_no_duplicate_schemas;
+        ] );
+    ]


### PR DESCRIPTION
## Summary

Continuation of Phase 0 (#1370, merged). This PR covers Phase 1, 2 (partial), and 3 of the MASC product improvement plan.

- **Phase 1: Agent Onboarding**
  - `masc_start` compound tool: 1-step onboarding (set_room → join → add_task → claim → plan_set_task)
  - Error recovery hints: pattern-match error messages → actionable suggestions
  - Default mode changed Full → Coding (~80 tools, reduces LLM context waste)
- **Phase 2: God Module Split** (partial)
  - `tool_convo.ml` extracted from `tool_inline_dispatch.ml` (1253 → 1133 lines)
- **Phase 3: Reliability**
  - `test_tool_registration_consistency.ml`: structural linter (no Unknown tools, no ghost references, no duplicate schemas)
  - `docs/QUICK-START.md`: 1-step setup guide
  - CLAUDE.md + COMMAND-PLANE-RUNBOOK.md: masc_start reference added
- **Bonus**: fix upstream `oas_swarm_bridge` missing `budget` field

## Test plan

- [x] `dune build` passes (local)
- [x] `test_workflow_guide` — 25 tests pass
- [x] `test_proof_criteria` — 18 tests pass
- [x] `test_tool_registration_consistency` — 3 tests pass
- [ ] Full CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)