### PR TITLE
fix(test): CI flaky — wrap lodge tick test in Eio_main.run

### DIFF
--- a/test/dune
+++ b/test/dune
@@ -55,7 +55,7 @@
           test_code_swarm
           test_autonomy_liberation)
  (libraries masc_mcp alcotest str yojson mirage-crypto
-            mirage-crypto-rng mirage-crypto-rng.unix cohttp cstruct unix))
+            mirage-crypto-rng mirage-crypto-rng.unix cohttp cstruct unix eio eio_main))
 
 ; Room coverage tests (claim_next auto-release, batch ops, transitions)
 ; Requires eio_main because Room.init uses Eio.Mutex internally

--- a/test/test_dashboard.ml
+++ b/test/test_dashboard.ml
@@ -128,6 +128,7 @@ let test_worktrees_section_empty () =
   cleanup_dir dir
 
 let test_lodge_status_json_has_runtime_fields () =
+  Eio_main.run @@ fun _env ->
   let json = Lib.Lodge_heartbeat.(lodge_status () |> lodge_status_to_json) in
   let open Yojson.Safe.Util in
   let has_key key =

--- a/test/test_lodge_graphql_failure_coverage.ml
+++ b/test/test_lodge_graphql_failure_coverage.ml
@@ -50,6 +50,7 @@ let () = test "load_lodge_agents_full_invalid_endpoint_errors_cleanly" (fun () -
       | Error msg -> assert (String.length msg > 0)))
 
 let () = test "tool_lodge_invalid_endpoint_uses_builtin_cache_fallback" (fun () ->
+  Eio_main.run @@ fun _env ->
   with_env "GRAPHQL_URL" (Some "http://127.0.0.1:9/graphql") (fun () ->
       Tool_lodge.load_agents_config ();
       let agents = Tool_lodge.get_all_agents () in

--- a/test/test_operator_control_keeper.ml
+++ b/test/test_operator_control_keeper.ml
@@ -398,6 +398,7 @@ let test_keeper_msg_auto_team_session_bridge () =
 
 
 let test_manual_lodge_tick_updates_observable_state () =
+  Eio_main.run @@ fun _env ->
   let base_dir = temp_dir () in
   Fun.protect
     ~finally:(fun () -> cleanup_dir base_dir)


### PR DESCRIPTION
## Summary
오늘 5개 이상 PR에서 반복된 CI 실패의 원인.

#1376에서 `lodge_lock`을 lazy `option ref` → eager `Eio.Mutex.t`로 바꿨는데,
`test_manual_lodge_tick_updates_observable_state`가 Eio context 없이 `lodge_status()`를
호출해서 `Effect.Unhandled(Get_context)` 발생.

## Fix
테스트를 `Eio_main.run` 안에서 실행하도록 1줄 추가.

## Verification
- [x] `test_operator_control.exe` 29/29 pass (로컬)
- [ ] CI full suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)