### PR TITLE
feat(dashboard): Agent Observatory — session-grouped agent visibility

### DIFF
--- a/dashboard/src/api.ts
+++ b/dashboard/src/api.ts
@@ -542,6 +542,33 @@ export function fetchAgentActivity(hours = 24): Promise<AgentActivityResponse> {
   return get(`/api/v1/agent-activity?hours=${hours}`)
 }
 
+export interface AgentTimelineEvent {
+  ts: string
+  type: string
+  detail: Record<string, unknown>
+}
+
+export interface AgentTimelineResponse {
+  agent: string
+  period: { from: string; to: string }
+  events: AgentTimelineEvent[]
+  summary: {
+    tasks_completed: number
+    tasks_claimed: number
+    messages_sent: number
+    active_duration_minutes: number
+    total_events: number
+  }
+}
+
+export function fetchAgentTimeline(
+  agentName: string,
+  sinceHours = 4,
+  limit = 20,
+): Promise<AgentTimelineResponse> {
+  return get(`/api/v1/agent-timeline?agent_name=${encodeURIComponent(agentName)}&since_hours=${sinceHours}&limit=${limit}`)
+}
+
 export function fetchDashboardRoomTruth(): Promise<DashboardRoomTruthResponse> {
   return get('/api/v1/dashboard/room-truth', { timeoutMs: ROOM_TRUTH_GET_TIMEOUT_MS })
 }

--- a/dashboard/src/components/agent-detail.ts
+++ b/dashboard/src/components/agent-detail.ts
@@ -14,7 +14,10 @@ import {
   tasks,
 } from '../store'
 import { fetchRoomMessages, fetchTaskHistory, sendBroadcast } from '../api'
+import { journal } from '../sse'
 import { missionSnapshot } from '../mission-store'
+import { executionWorkerSupportBriefs } from '../store'
+import type { JournalEntry } from '../types'
 import type {
   Agent,
   DashboardExecutionContinuityBrief,
@@ -137,6 +140,30 @@ async function submitMention(): Promise<void> {
   } finally {
     sendingMention.value = false
   }
+}
+
+function agentJournalEntries(agentName: string | null): JournalEntry[] {
+  if (!agentName) return []
+  const nameLower = agentName.toLowerCase()
+  return journal.value
+    .filter((entry: JournalEntry) => {
+      const text = entry.text.toLowerCase()
+      const agent = entry.agent.toLowerCase()
+      return agent === nameLower || text.includes(nameLower) || text.includes(`@${nameLower}`)
+    })
+    .slice(0, 15)
+}
+
+function workerBriefForAgent(agentName: string | null) {
+  if (!agentName) return null
+  return executionWorkerSupportBriefs.value.find(w => w.name === agentName) ?? null
+}
+
+function journalKindIcon(entry: JournalEntry): string {
+  if (entry.kind === 'board') return 'B'
+  if (entry.kind === 'tasks') return 'T'
+  if (entry.kind === 'keepers') return 'K'
+  return 'S'
 }
 
 function TaskSummary({ task }: { task: Task }) {
@@ -272,13 +299,16 @@ export function AgentDetailOverlay() {
           <${Card} title="Recent Activity">
             ${lines.length === 0
               ? html`<div class="empty-state">No recent room activity match</div>`
-              : html`<div class="agent-activity-list">${lines.map((line, idx) => html`<div key=${idx} class="agent-activity-line">${line}</div>`)}</div>`}
+              : html`<div class="agent-activity-list">${lines.map((line: string, idx: number) => html`<div key=${idx} class="agent-activity-line">${line}</div>`)}</div>`}
           <//>
         </div>
+
+        <${AgentJournalStream} agentName=${agentName} />
+        <${AgentWorkerBrief} agentName=${agentName} />
         <${Card} title="Task History">
           ${taskHistories.value.length === 0
             ? html`<div class="empty-state">No task history loaded</div>`
-            : html`<div class="agent-history-list">${taskHistories.value.map(row => html`<${TaskHistoryPanel} key=${row.taskId} row=${row} />`)}</div>`}
+            : html`<div class="agent-history-list">${taskHistories.value.map((row: TaskHistoryRow) => html`<${TaskHistoryPanel} key=${row.taskId} row=${row} />`)}</div>`}
         <//>
 
         <${Card} title="Direct Mention">
@@ -303,5 +333,69 @@ export function AgentDetailOverlay() {
         <//>
       </div>
     </div>
+  `
+}
+
+function AgentJournalStream({ agentName }: { agentName: string }) {
+  const entries = agentJournalEntries(agentName)
+
+  return html`
+    <${Card} title="실시간 활동 스트림">
+      ${entries.length === 0
+        ? html`<div class="empty-state">관련 이벤트 없음</div>`
+        : html`
+            <div class="agent-journal-stream">
+              ${entries.map((entry: JournalEntry, idx: number) => html`
+                <div class="agent-journal-entry" key=${idx}>
+                  <span class="agent-journal-kind">${journalKindIcon(entry)}</span>
+                  <span class="agent-journal-type">${entry.eventType}</span>
+                  <span class="agent-journal-text">${compactCopy(entry.text, 120) ?? ''}</span>
+                  ${entry.timestamp ? html`<${TimeAgo} timestamp=${entry.timestamp} />` : null}
+                </div>
+              `)}
+            </div>
+          `}
+    <//>
+  `
+}
+
+function AgentWorkerBrief({ agentName }: { agentName: string }) {
+  const worker = workerBriefForAgent(agentName)
+  if (!worker) return null
+
+  return html`
+    <${Card} title="Worker Status">
+      <div class="agent-worker-brief">
+        <div class="agent-worker-brief__row">
+          <span class="agent-worker-brief__label">State</span>
+          <${StatusBadge} status=${worker.state} />
+        </div>
+        ${worker.focus ? html`
+          <div class="agent-worker-brief__row">
+            <span class="agent-worker-brief__label">Focus</span>
+            <span>${worker.focus}</span>
+          </div>
+        ` : null}
+        ${worker.recent_output_preview ? html`
+          <div class="agent-worker-brief__row">
+            <span class="agent-worker-brief__label">Output</span>
+            <span class="agent-worker-brief__preview">${compactCopy(worker.recent_output_preview, 200)}</span>
+          </div>
+        ` : null}
+        ${worker.related_session_id ? html`
+          <div class="agent-worker-brief__row">
+            <span class="agent-worker-brief__label">Session</span>
+            <span class="mono" style="font-size: 11px">${worker.related_session_id}</span>
+          </div>
+        ` : null}
+        ${worker.last_signal_at ? html`
+          <div class="agent-worker-brief__row">
+            <span class="agent-worker-brief__label">Signal</span>
+            <${TimeAgo} timestamp=${worker.last_signal_at} />
+            ${worker.signal_truth ? html`<span class="pill">${worker.signal_truth}</span>` : null}
+          </div>
+        ` : null}
+      </div>
+    <//>
   `
 }

--- a/dashboard/src/components/agent-detail.ts
+++ b/dashboard/src/components/agent-detail.ts
@@ -13,7 +13,7 @@ import {
   keepers,
   tasks,
 } from '../store'
-import { fetchRoomMessages, fetchTaskHistory, sendBroadcast } from '../api'
+import { fetchRoomMessages, fetchTaskHistory, sendBroadcast, fetchAgentTimeline, type AgentTimelineEvent, type AgentTimelineResponse } from '../api'
 import { journal } from '../sse'
 import { missionSnapshot } from '../mission-store'
 import { executionWorkerSupportBriefs } from '../store'
@@ -38,6 +38,7 @@ const loading = signal(false)
 const detailError = signal('')
 const roomActivity = signal<string[]>([])
 const taskHistories = signal<TaskHistoryRow[]>([])
+const agentTimeline = signal<AgentTimelineResponse | null>(null)
 const mentionText = signal('')
 const sendingMention = signal(false)
 
@@ -51,6 +52,7 @@ export function closeAgentDetail(): void {
   detailError.value = ''
   roomActivity.value = []
   taskHistories.value = []
+  agentTimeline.value = null
   mentionText.value = ''
 }
 
@@ -92,12 +94,20 @@ async function refreshAgentDetail(): Promise<void> {
   detailError.value = ''
   roomActivity.value = []
   taskHistories.value = []
+  agentTimeline.value = null
 
   try {
-    const lines = await fetchRoomMessages(80)
+    // Fetch room messages, task histories, and timeline in parallel
+    const [lines, timelineResult] = await Promise.all([
+      fetchRoomMessages(80),
+      fetchAgentTimeline(agentName, 4, 20).catch(() => null),
+    ])
+
     roomActivity.value = lines
       .filter(line => line.includes(agentName))
       .slice(0, 20)
+
+    agentTimeline.value = timelineResult
 
     const ownedTasks = assignedTasks(agentName).slice(0, 6)
     if (ownedTasks.length === 0) return
@@ -304,6 +314,7 @@ export function AgentDetailOverlay() {
         </div>
 
         <${AgentJournalStream} agentName=${agentName} />
+        <${AgentTimelineSection} />
         <${AgentWorkerBrief} agentName=${agentName} />
         <${Card} title="Task History">
           ${taskHistories.value.length === 0
@@ -353,6 +364,64 @@ function AgentJournalStream({ agentName }: { agentName: string }) {
                   ${entry.timestamp ? html`<${TimeAgo} timestamp=${entry.timestamp} />` : null}
                 </div>
               `)}
+            </div>
+          `}
+    <//>
+  `
+}
+
+function timelineEventIcon(type: string): string {
+  if (type === 'joined') return 'J'
+  if (type.startsWith('task_')) return 'T'
+  if (type === 'broadcast') return 'M'
+  return 'E'
+}
+
+function timelineEventLabel(type: string): string {
+  switch (type) {
+    case 'joined': return '참가'
+    case 'task_claimed': return '태스크 수임'
+    case 'task_started': return '태스크 시작'
+    case 'task_completed': return '태스크 완료'
+    case 'task_cancelled': return '태스크 취소'
+    case 'broadcast': return '브로드캐스트'
+    default: return type
+  }
+}
+
+function AgentTimelineSection() {
+  const timeline = agentTimeline.value
+  if (!timeline) return null
+
+  const events = timeline.events ?? []
+  const summary = timeline.summary
+
+  return html`
+    <${Card} title="활동 타임라인 (${summary?.total_events ?? 0} events)">
+      ${summary ? html`
+        <div class="agent-timeline-summary">
+          ${summary.tasks_completed > 0 ? html`<span class="pill">완료 ${summary.tasks_completed}</span>` : null}
+          ${summary.tasks_claimed > 0 ? html`<span class="pill">수임 ${summary.tasks_claimed}</span>` : null}
+          ${summary.messages_sent > 0 ? html`<span class="pill">메시지 ${summary.messages_sent}</span>` : null}
+          ${summary.active_duration_minutes > 0 ? html`<span class="pill">${Math.round(summary.active_duration_minutes)}분 활동</span>` : null}
+        </div>
+      ` : null}
+      ${events.length === 0
+        ? html`<div class="empty-state">타임라인 이벤트 없음</div>`
+        : html`
+            <div class="agent-timeline-list">
+              ${events.map((evt: AgentTimelineEvent, idx: number) => {
+                const detail = evt.detail as Record<string, string | undefined>
+                const title = detail.title ?? detail.content ?? ''
+                return html`
+                  <div class="agent-timeline-event" key=${idx}>
+                    <span class="agent-journal-kind">${timelineEventIcon(evt.type)}</span>
+                    <span class="agent-timeline-type">${timelineEventLabel(evt.type)}</span>
+                    ${title ? html`<span class="agent-timeline-detail">${compactCopy(title, 80)}</span>` : null}
+                    ${evt.ts ? html`<${TimeAgo} timestamp=${evt.ts} />` : null}
+                  </div>
+                `
+              })}
             </div>
           `}
     <//>

--- a/dashboard/src/components/overview/agent-observatory.ts
+++ b/dashboard/src/components/overview/agent-observatory.ts
@@ -1,0 +1,199 @@
+// Agent Observatory — session-grouped agent view
+// Groups agents by team session, showing each agent's state, focus, tools, and signal age.
+
+import { html } from 'htm/preact'
+import { AgentAvatar } from './agent-avatar'
+import { StatusBadge } from '../common/status-badge'
+import { TimeAgo } from '../common/time-ago'
+import { observatoryGroups, type ObservatoryAgent, type ObservatoryGroup } from '../../observatory-store'
+
+interface AgentObservatoryProps {
+  onAgentClick?: (name: string) => void
+}
+
+function stateLabel(state: string): string {
+  switch (state) {
+    case 'working': return '작업 중'
+    case 'watching': return '관찰 중'
+    case 'quiet': return '조용함'
+    case 'offline': return '오프라인'
+    default: return state
+  }
+}
+
+function healthColor(health: string | null): string {
+  if (!health) return 'var(--text-muted, #666)'
+  switch (health) {
+    case 'ok':
+    case 'healthy':
+      return 'var(--status-ok, #4ade80)'
+    case 'degraded':
+      return 'var(--status-warn, #fbbf24)'
+    case 'critical':
+    case 'bad':
+      return 'var(--status-bad, #f87171)'
+    default:
+      return 'var(--text-muted, #666)'
+  }
+}
+
+function contextBar(ratio: number | null) {
+  if (ratio == null) return null
+  const pct = Math.round(ratio * 100)
+  const barColor =
+    pct < 50 ? 'var(--status-ok, #4ade80)'
+    : pct < 70 ? 'var(--status-warn, #fbbf24)'
+    : pct < 85 ? '#f97316'
+    : 'var(--status-bad, #f87171)'
+
+  return html`
+    <span class="obs-ctx" title="context ${pct}%">
+      <span class="obs-ctx__bar" style=${{ width: `${pct}%`, background: barColor }} />
+      <span class="obs-ctx__label">${pct}%</span>
+    </span>
+  `
+}
+
+function toolChips(tools: string[]) {
+  if (tools.length === 0) return null
+  const display = tools.slice(0, 3)
+  const remaining = tools.length - display.length
+  return html`
+    <span class="obs-tools">
+      ${display.map(t => html`<span class="obs-tool-chip" key=${t}>${t}</span>`)}
+      ${remaining > 0 ? html`<span class="obs-tool-chip obs-tool-chip--more">+${remaining}</span>` : null}
+    </span>
+  `
+}
+
+function truncate(text: string | null, max = 60): string | null {
+  if (!text) return null
+  const clean = text.replace(/\s+/g, ' ').trim()
+  if (!clean) return null
+  return clean.length > max ? `${clean.slice(0, max - 1)}…` : clean
+}
+
+function AgentRow({ agent, onAgentClick }: { agent: ObservatoryAgent; onAgentClick?: (name: string) => void }) {
+  const focusText = truncate(agent.focus ?? agent.currentTask)
+  const previewText = truncate(agent.recentOutputPreview, 80)
+
+  return html`
+    <div
+      class="obs-agent-row obs-agent-row--${agent.state}"
+      onClick=${onAgentClick ? () => onAgentClick(agent.name) : undefined}
+      role=${onAgentClick ? 'button' : undefined}
+      tabindex=${onAgentClick ? '0' : undefined}
+      onKeyDown=${onAgentClick ? (e: KeyboardEvent) => {
+        if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); onAgentClick(agent.name) }
+      } : undefined}
+    >
+      <div class="obs-agent-row__avatar">
+        <${AgentAvatar}
+          name=${agent.name}
+          status=${agent.status}
+          size="sm"
+          activityAge=${agent.lastSignalAgeSec}
+          signalTruth=${agent.signalTruth}
+        />
+      </div>
+
+      <div class="obs-agent-row__info">
+        <div class="obs-agent-row__name-line">
+          <span class="obs-agent-row__name">${agent.name}</span>
+          ${agent.koreanName ? html`<span class="obs-agent-row__korean">(${agent.koreanName})</span>` : null}
+          <span class="obs-agent-row__state obs-agent-row__state--${agent.state}">
+            ${stateLabel(agent.state)}
+          </span>
+          ${agent.model ? html`<span class="obs-agent-row__model">${agent.model}</span>` : null}
+        </div>
+
+        ${focusText ? html`
+          <div class="obs-agent-row__focus">${focusText}</div>
+        ` : null}
+
+        <div class="obs-agent-row__meta">
+          ${toolChips(agent.recentTools)}
+          ${contextBar(agent.contextRatio)}
+          ${agent.lastSignalAt ? html`
+            <span class="obs-agent-row__signal">
+              <${TimeAgo} timestamp=${agent.lastSignalAt} />
+            </span>
+          ` : null}
+        </div>
+
+        ${previewText ? html`
+          <div class="obs-agent-row__preview">${previewText}</div>
+        ` : null}
+      </div>
+    </div>
+  `
+}
+
+function SessionGroupHeader({ group }: { group: ObservatoryGroup }) {
+  if (!group.sessionId) {
+    return html`
+      <div class="obs-group-header obs-group-header--unassigned">
+        <span class="obs-group-header__title">미배정 에이전트</span>
+        <span class="obs-group-header__count">${group.agents.length}</span>
+      </div>
+    `
+  }
+
+  const workingCount = group.agents.filter(a => a.state === 'working').length
+
+  return html`
+    <div class="obs-group-header">
+      <div class="obs-group-header__top">
+        <span
+          class="obs-group-header__health-dot"
+          style=${{ background: healthColor(group.health) }}
+        />
+        <span class="obs-group-header__title">${group.goal ?? group.sessionId}</span>
+        ${group.status ? html`<${StatusBadge} status=${group.status} />` : null}
+      </div>
+      <div class="obs-group-header__stats">
+        <span>${group.memberCount} 에이전트</span>
+        ${workingCount > 0 ? html`<span class="obs-group-header__working">${workingCount} 작업 중</span>` : null}
+        <span class="obs-group-header__session-id">${group.sessionId}</span>
+      </div>
+    </div>
+  `
+}
+
+export function AgentObservatory({ onAgentClick }: AgentObservatoryProps) {
+  const groups = observatoryGroups.value
+
+  if (groups.length === 0) {
+    return html`
+      <div class="obs-empty">
+        <div style="color: var(--text-muted); padding: 16px;">에이전트 없음</div>
+      </div>
+    `
+  }
+
+  const totalAgents = groups.reduce((sum: number, g: ObservatoryGroup) => sum + g.agents.length, 0)
+  const totalWorking = groups.reduce(
+    (sum: number, g: ObservatoryGroup) => sum + g.agents.filter((a: ObservatoryAgent) => a.state === 'working').length, 0,
+  )
+
+  return html`
+    <div class="obs-container">
+      <div class="obs-summary">
+        <span>${totalAgents} 에이전트</span>
+        ${totalWorking > 0 ? html`<span class="obs-summary__working">${totalWorking} 작업 중</span>` : null}
+        <span>${groups.filter((g: ObservatoryGroup) => g.sessionId).length} 세션</span>
+      </div>
+
+      ${groups.map(group => html`
+        <div class="obs-group" key=${group.sessionId ?? '__unassigned'}>
+          <${SessionGroupHeader} group=${group} />
+          <div class="obs-agent-list">
+            ${group.agents.map(agent => html`
+              <${AgentRow} key=${agent.name} agent=${agent} onAgentClick=${onAgentClick} />
+            `)}
+          </div>
+        </div>
+      `)}
+    </div>
+  `
+}

--- a/dashboard/src/components/overview/overview.ts
+++ b/dashboard/src/components/overview/overview.ts
@@ -10,7 +10,7 @@ import { navigate } from '../../router'
 import { formatDuration } from '../mission-utils'
 import { SituationBanner } from './situation-banner'
 import { AttentionSpotlight } from './attention-spotlight'
-import { AgentGrid } from './agent-grid'
+import { AgentObservatory } from './agent-observatory'
 import { SessionTriage } from './session-triage'
 import { NarrativeTimeline } from './narrative-timeline'
 import { QuickStats } from './quick-stats'
@@ -63,7 +63,6 @@ export function Overview() {
   const roomHealth = snap?.summary?.room_health ?? null
   const attentionCount = snap?.attention_queue?.length ?? snap?.summary?.pending_approvals ?? 0
   const sessions = snap?.sessions ?? snap?.session_briefs ?? []
-  const agentBriefs = snap?.agent_briefs ?? []
   const keeperBriefs = snap?.keeper_briefs ?? []
 
   const navSurfaces = DASHBOARD_SURFACES.filter(s => s.id !== 'home')
@@ -85,10 +84,8 @@ export function Overview() {
 
       <div class="overview-main-v2">
         <div class="overview-left-col">
-          <div class="overview-section-label">에이전트</div>
-          <${AgentGrid}
-            agents=${agentList}
-            agentBriefs=${agentBriefs}
+          <div class="overview-section-label">에이전트 Observatory</div>
+          <${AgentObservatory}
             onAgentClick=${(name: string) => navigate('execution', { agent: name })}
           />
         </div>

--- a/dashboard/src/observatory-store.ts
+++ b/dashboard/src/observatory-store.ts
@@ -1,0 +1,204 @@
+// Agent Observatory — computed signals that join agents, workers, sessions, continuity
+// into session-grouped views for the observatory surface.
+
+import { computed, type ReadonlySignal } from '@preact/signals'
+import {
+  agents,
+  executionWorkerSupportBriefs,
+  executionSessionBriefs,
+  executionContinuityBriefs,
+} from './store'
+import type {
+  Agent,
+  DashboardExecutionWorkerSupportBrief,
+  DashboardExecutionSessionBrief,
+  DashboardExecutionContinuityBrief,
+} from './types'
+
+// --- Types ---
+
+export type ObservatoryAgentState = 'working' | 'watching' | 'quiet' | 'offline'
+
+export interface ObservatoryAgent {
+  name: string
+  koreanName: string | null
+  emoji: string | null
+  model: string | null
+  status: string
+  state: ObservatoryAgentState
+  focus: string | null
+  currentTask: string | null
+  recentTools: string[]
+  recentOutputPreview: string | null
+  contextRatio: number | null
+  lastSignalAt: string | null
+  lastSignalAgeSec: number | null
+  signalTruth: string | null
+  relatedSessionId: string | null
+}
+
+export interface ObservatoryGroup {
+  sessionId: string | null
+  goal: string | null
+  status: string | null
+  health: string | null
+  memberCount: number
+  agents: ObservatoryAgent[]
+}
+
+// --- Helpers ---
+
+function deriveAgentState(
+  agent: Agent | null,
+  worker: DashboardExecutionWorkerSupportBrief | null,
+): ObservatoryAgentState {
+  // WorkerState: 'working' | 'watching' | 'quiet' | 'offline'
+  const workerState = worker?.state
+  if (workerState === 'working') return 'working'
+  if (workerState === 'watching') return 'watching'
+  if (workerState === 'quiet') return 'quiet'
+  if (workerState === 'offline') return 'offline'
+
+  // Fallback to agent status if no worker state
+  const agentStatus = agent?.status ?? (worker?.status as string | undefined)
+  if (agentStatus === 'active' || agentStatus === 'busy') return 'working'
+  if (agentStatus === 'listening' || agentStatus === 'idle') return 'watching'
+  if (agentStatus === 'offline' || agentStatus === 'inactive') return 'offline'
+
+  return 'quiet'
+}
+
+const STATE_ORDER: Record<ObservatoryAgentState, number> = {
+  working: 0,
+  watching: 1,
+  quiet: 2,
+  offline: 3,
+}
+
+function buildObservatoryAgent(
+  agent: Agent | null,
+  worker: DashboardExecutionWorkerSupportBrief | null,
+  continuity: DashboardExecutionContinuityBrief | null,
+): ObservatoryAgent {
+  const name = agent?.name ?? worker?.name ?? continuity?.name ?? 'unknown'
+
+  return {
+    name,
+    koreanName: agent?.koreanName ?? worker?.korean_name ?? continuity?.korean_name ?? null,
+    emoji: agent?.emoji ?? worker?.emoji ?? continuity?.emoji ?? null,
+    model: agent?.model ?? worker?.model ?? continuity?.model ?? null,
+    status: (agent?.status ?? worker?.status ?? continuity?.status ?? 'unknown') as string,
+    state: deriveAgentState(agent, worker),
+    focus: worker?.focus ?? continuity?.focus ?? null,
+    currentTask: agent?.current_task ?? null,
+    recentTools: continuity?.recent_tool_names ?? continuity?.latest_tool_names ?? [],
+    recentOutputPreview: worker?.recent_output_preview ?? continuity?.recent_output_preview ?? null,
+    contextRatio: continuity?.context_ratio ?? null,
+    lastSignalAt: worker?.last_signal_at ?? continuity?.last_signal_at ?? null,
+    lastSignalAgeSec: worker?.last_signal_age_sec ?? null,
+    signalTruth: worker?.signal_truth ?? null,
+    relatedSessionId: worker?.related_session_id ?? continuity?.related_session_id ?? null,
+  }
+}
+
+// --- Computed signal ---
+
+export const observatoryGroups: ReadonlySignal<ObservatoryGroup[]> = computed(() => {
+  const agentList = agents.value
+  const workers = executionWorkerSupportBriefs.value
+  const sessions = executionSessionBriefs.value
+  const continuities = executionContinuityBriefs.value
+
+  // Build lookup maps
+  const agentMap = new Map<string, Agent>()
+  for (const a of agentList) agentMap.set(a.name, a)
+
+  const workerMap = new Map<string, DashboardExecutionWorkerSupportBrief>()
+  for (const w of workers) workerMap.set(w.name, w)
+
+  const continuityMap = new Map<string, DashboardExecutionContinuityBrief>()
+  for (const c of continuities) continuityMap.set(c.agent_name ?? c.name, c)
+
+  const sessionMap = new Map<string, DashboardExecutionSessionBrief>()
+  for (const s of sessions) sessionMap.set(s.session_id, s)
+
+  // Collect all known agent names
+  const allNames = new Set<string>()
+  for (const a of agentList) allNames.add(a.name)
+  for (const w of workers) allNames.add(w.name)
+  for (const c of continuities) allNames.add(c.agent_name ?? c.name)
+
+  // Build ObservatoryAgent for each, grouped by session
+  const grouped = new Map<string | null, ObservatoryAgent[]>()
+
+  for (const name of allNames) {
+    const agent = agentMap.get(name) ?? null
+    const worker = workerMap.get(name) ?? null
+    const continuity = continuityMap.get(name) ?? null
+
+    const obsAgent = buildObservatoryAgent(agent, worker, continuity)
+    const sessionId = obsAgent.relatedSessionId ?? null
+
+    const list = grouped.get(sessionId) ?? []
+    list.push(obsAgent)
+    grouped.set(sessionId, list)
+  }
+
+  // Sort agents within each group: working > watching > quiet > offline, then name
+  for (const [, list] of grouped) {
+    list.sort((a, b) => {
+      const stateA = STATE_ORDER[a.state]
+      const stateB = STATE_ORDER[b.state]
+      if (stateA !== stateB) return stateA - stateB
+      return a.name.localeCompare(b.name)
+    })
+  }
+
+  // Build groups with session metadata
+  const groups: ObservatoryGroup[] = []
+
+  // Sessions with agents first (sorted: active sessions before completed)
+  const sessionIds = [...grouped.keys()].filter((k): k is string => k !== null)
+  sessionIds.sort((a, b) => {
+    const sa = sessionMap.get(a)
+    const sb = sessionMap.get(b)
+    const healthOrder = (h?: string) => {
+      if (h === 'critical' || h === 'bad') return 0
+      if (h === 'degraded') return 1
+      if (h === 'ok' || h === 'healthy') return 2
+      return 3
+    }
+    const ha = healthOrder(sa?.health)
+    const hb = healthOrder(sb?.health)
+    if (ha !== hb) return ha - hb
+    return a.localeCompare(b)
+  })
+
+  for (const sessionId of sessionIds) {
+    const session = sessionMap.get(sessionId)
+    const agentsList = grouped.get(sessionId) ?? []
+    groups.push({
+      sessionId,
+      goal: session?.goal ?? null,
+      status: session?.status ?? null,
+      health: session?.health ?? null,
+      memberCount: session?.member_names?.length ?? agentsList.length,
+      agents: agentsList,
+    })
+  }
+
+  // Unassigned bucket
+  const unassigned = grouped.get(null)
+  if (unassigned && unassigned.length > 0) {
+    groups.push({
+      sessionId: null,
+      goal: null,
+      status: null,
+      health: null,
+      memberCount: unassigned.length,
+      agents: unassigned,
+    })
+  }
+
+  return groups
+})

--- a/dashboard/src/observatory-store.ts
+++ b/dashboard/src/observatory-store.ts
@@ -128,6 +128,15 @@ export const observatoryGroups: ReadonlySignal<ObservatoryGroup[]> = computed(()
   for (const w of workers) allNames.add(w.name)
   for (const c of continuities) allNames.add(c.agent_name ?? c.name)
 
+  // Build reverse lookup: agent name → session ID from member_names
+  // Covers agents whose relatedSessionId is missing but are still session members
+  const membershipLookup = new Map<string, string>()
+  for (const s of sessions) {
+    for (const memberName of (s.member_names ?? [])) {
+      membershipLookup.set(memberName, s.session_id)
+    }
+  }
+
   // Build ObservatoryAgent for each, grouped by session
   const grouped = new Map<string | null, ObservatoryAgent[]>()
 
@@ -137,7 +146,9 @@ export const observatoryGroups: ReadonlySignal<ObservatoryGroup[]> = computed(()
     const continuity = continuityMap.get(name) ?? null
 
     const obsAgent = buildObservatoryAgent(agent, worker, continuity)
-    const sessionId = obsAgent.relatedSessionId ?? null
+    // Primary: relatedSessionId from worker/continuity briefs
+    // Fallback: reverse lookup from session member_names
+    const sessionId = obsAgent.relatedSessionId ?? membershipLookup.get(name) ?? null
 
     const list = grouped.get(sessionId) ?? []
     list.push(obsAgent)

--- a/dashboard/src/styles/agent.css
+++ b/dashboard/src/styles/agent.css
@@ -155,3 +155,50 @@
   max-width: 400px;
 }
 
+/* ── Agent Timeline Section (Phase 3) ─────────────────────── */
+.agent-timeline-summary {
+  display: flex;
+  gap: 6px;
+  flex-wrap: wrap;
+  margin-bottom: 8px;
+}
+
+.agent-timeline-list {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  max-height: 300px;
+  overflow-y: auto;
+}
+
+.agent-timeline-event {
+  display: flex;
+  align-items: baseline;
+  gap: 6px;
+  padding: 4px 8px;
+  font-size: 12px;
+  border-radius: 4px;
+  transition: background 0.1s;
+}
+
+.agent-timeline-event:hover {
+  background: rgba(255, 255, 255, 0.04);
+}
+
+.agent-timeline-type {
+  font-size: 11px;
+  font-weight: 500;
+  color: var(--text-strong, #e8ecf1);
+  flex-shrink: 0;
+  min-width: 80px;
+}
+
+.agent-timeline-detail {
+  color: var(--text-body, #b0bec5);
+  flex: 1;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  min-width: 0;
+}
+

--- a/dashboard/src/styles/agent.css
+++ b/dashboard/src/styles/agent.css
@@ -71,3 +71,87 @@
   display: flex; flex-wrap: wrap; gap: 4px; margin-top: 8px;
 }
 
+/* ── Agent Journal Stream (Phase 2) ───────────────────────── */
+.agent-journal-stream {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  max-height: 280px;
+  overflow-y: auto;
+}
+
+.agent-journal-entry {
+  display: flex;
+  align-items: baseline;
+  gap: 6px;
+  padding: 4px 8px;
+  font-size: 12px;
+  border-radius: 4px;
+  transition: background 0.1s;
+}
+
+.agent-journal-entry:hover {
+  background: rgba(255, 255, 255, 0.04);
+}
+
+.agent-journal-kind {
+  font-size: 10px;
+  font-weight: 600;
+  font-family: var(--font-mono, monospace);
+  background: rgba(138, 163, 211, 0.12);
+  color: var(--text-muted);
+  width: 16px;
+  height: 16px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 3px;
+  flex-shrink: 0;
+}
+
+.agent-journal-type {
+  font-size: 10px;
+  font-family: var(--font-mono, monospace);
+  color: rgba(71, 184, 255, 0.7);
+  flex-shrink: 0;
+}
+
+.agent-journal-text {
+  color: var(--text-body, #b0bec5);
+  flex: 1;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  min-width: 0;
+}
+
+/* ── Agent Worker Brief ───────────────────────────────────── */
+.agent-worker-brief {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.agent-worker-brief__row {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  font-size: 12px;
+}
+
+.agent-worker-brief__label {
+  font-size: 11px;
+  color: var(--text-muted);
+  min-width: 60px;
+  flex-shrink: 0;
+}
+
+.agent-worker-brief__preview {
+  color: var(--text-body, #b0bec5);
+  font-style: italic;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 400px;
+}
+

--- a/dashboard/src/styles/overview.css
+++ b/dashboard/src/styles/overview.css
@@ -840,3 +840,295 @@
   text-align: center; font-size: 11px; color: var(--text-muted);
   margin-top: var(--space-xs, 4px);
 }
+
+/* ── Agent Observatory ───────────────────── */
+.obs-container {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-sm, 8px);
+}
+
+.obs-summary {
+  display: flex;
+  gap: 12px;
+  font-size: 11px;
+  color: var(--text-muted);
+  padding: 4px 0;
+}
+
+.obs-summary__working {
+  color: var(--status-ok, #4ade80);
+  font-weight: 500;
+}
+
+.obs-group {
+  border: 1px solid var(--card-border, rgba(138, 163, 211, 0.12));
+  border-radius: 8px;
+  overflow: hidden;
+  background: rgba(255, 255, 255, 0.02);
+}
+
+.obs-group-header {
+  padding: 8px 12px;
+  background: rgba(255, 255, 255, 0.03);
+  border-bottom: 1px solid var(--card-border, rgba(138, 163, 211, 0.08));
+}
+
+.obs-group-header--unassigned {
+  padding: 8px 12px;
+  background: rgba(138, 163, 211, 0.04);
+  border-bottom: 1px solid var(--card-border, rgba(138, 163, 211, 0.08));
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.obs-group-header__top {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.obs-group-header__health-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.obs-group-header__title {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text-strong, #e8ecf1);
+  flex: 1;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.obs-group-header__count {
+  font-size: 11px;
+  color: var(--text-muted);
+  background: rgba(138, 163, 211, 0.12);
+  padding: 1px 6px;
+  border-radius: 8px;
+}
+
+.obs-group-header__stats {
+  display: flex;
+  gap: 10px;
+  font-size: 11px;
+  color: var(--text-muted);
+  margin-top: 4px;
+}
+
+.obs-group-header__working {
+  color: var(--status-ok, #4ade80);
+}
+
+.obs-group-header__session-id {
+  font-family: var(--font-mono, monospace);
+  font-size: 10px;
+  opacity: 0.6;
+}
+
+.obs-agent-list {
+  display: flex;
+  flex-direction: column;
+}
+
+.obs-agent-row {
+  display: flex;
+  gap: 10px;
+  padding: 8px 12px;
+  border-bottom: 1px solid rgba(138, 163, 211, 0.05);
+  cursor: pointer;
+  transition: background 0.12s;
+}
+
+.obs-agent-row:last-child {
+  border-bottom: none;
+}
+
+.obs-agent-row:hover {
+  background: rgba(71, 184, 255, 0.06);
+}
+
+.obs-agent-row--working {
+  border-left: 2px solid var(--status-ok, #4ade80);
+}
+
+.obs-agent-row--watching {
+  border-left: 2px solid var(--status-warn, #fbbf24);
+}
+
+.obs-agent-row--quiet {
+  border-left: 2px solid rgba(138, 163, 211, 0.15);
+}
+
+.obs-agent-row--offline {
+  border-left: 2px solid rgba(138, 163, 211, 0.08);
+  opacity: 0.5;
+}
+
+.obs-agent-row__avatar {
+  flex-shrink: 0;
+  display: flex;
+  align-items: flex-start;
+  padding-top: 2px;
+}
+
+.obs-agent-row__info {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+}
+
+.obs-agent-row__name-line {
+  display: flex;
+  align-items: baseline;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+
+.obs-agent-row__name {
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--text-strong, #e8ecf1);
+}
+
+.obs-agent-row__korean {
+  font-size: 11px;
+  color: var(--text-muted);
+}
+
+.obs-agent-row__state {
+  font-size: 10px;
+  padding: 1px 5px;
+  border-radius: 4px;
+  font-weight: 500;
+}
+
+.obs-agent-row__state--working {
+  background: rgba(74, 222, 128, 0.15);
+  color: var(--status-ok, #4ade80);
+}
+
+.obs-agent-row__state--watching {
+  background: rgba(251, 191, 36, 0.15);
+  color: var(--status-warn, #fbbf24);
+}
+
+.obs-agent-row__state--quiet {
+  background: rgba(138, 163, 211, 0.1);
+  color: var(--text-muted);
+}
+
+.obs-agent-row__state--offline {
+  background: rgba(138, 163, 211, 0.06);
+  color: var(--text-muted);
+}
+
+.obs-agent-row__model {
+  font-size: 10px;
+  font-family: var(--font-mono, monospace);
+  background: rgba(138, 163, 211, 0.1);
+  padding: 1px 5px;
+  border-radius: 3px;
+  color: var(--text-muted);
+}
+
+.obs-agent-row__focus {
+  font-size: 12px;
+  color: var(--text-body, #b0bec5);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.obs-agent-row__meta {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.obs-agent-row__signal {
+  font-size: 10px;
+  color: var(--text-muted);
+}
+
+.obs-agent-row__preview {
+  font-size: 11px;
+  color: var(--text-muted);
+  font-style: italic;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  opacity: 0.7;
+}
+
+/* Tool chips */
+.obs-tools {
+  display: flex;
+  gap: 3px;
+  flex-wrap: wrap;
+}
+
+.obs-tool-chip {
+  font-size: 10px;
+  font-family: var(--font-mono, monospace);
+  background: rgba(138, 163, 211, 0.1);
+  color: var(--text-muted);
+  padding: 1px 5px;
+  border-radius: 3px;
+}
+
+.obs-tool-chip--more {
+  background: rgba(71, 184, 255, 0.1);
+  color: rgba(71, 184, 255, 0.7);
+}
+
+/* Context ratio bar */
+.obs-ctx {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  width: 48px;
+  height: 6px;
+  background: rgba(138, 163, 211, 0.1);
+  border-radius: 3px;
+  overflow: hidden;
+}
+
+.obs-ctx__bar {
+  position: absolute;
+  left: 0;
+  top: 0;
+  height: 100%;
+  border-radius: 3px;
+  transition: width 0.3s ease;
+}
+
+.obs-ctx__label {
+  position: relative;
+  z-index: 1;
+  font-size: 9px;
+  font-family: var(--font-mono, monospace);
+  color: var(--text-muted);
+  margin-left: 52px;
+  white-space: nowrap;
+}
+
+.obs-empty {
+  text-align: center;
+  padding: 24px;
+}
+
+@media (max-width: 1100px) {
+  .obs-agent-row__preview {
+    display: none;
+  }
+}

--- a/lib/server_routes_http_routes_dashboard.ml
+++ b/lib/server_routes_http_routes_dashboard.ml
@@ -179,6 +179,38 @@ let add_routes ~sw ~clock router =
          Http.Response.json ~compress:true ~request:req (Yojson.Safe.to_string json) reqd
        ) request reqd)
 
+  (* Agent timeline — per-agent activity timeline for Observatory detail *)
+  |> Http.Router.get "/api/v1/agent-timeline" (fun request reqd ->
+       with_public_read (fun state req reqd ->
+         let agent_name =
+           match Server_utils.query_param req "agent_name" with
+           | Some n when String.trim n <> "" -> String.trim n
+           | _ -> ""
+         in
+         if agent_name = "" then
+           Http.Response.json ~status:`Bad_request
+             {|{"error":"agent_name query parameter is required"}|} reqd
+         else
+           let since_hours =
+             match Server_utils.query_param req "since_hours" with
+             | Some h -> (try float_of_string h with _ -> 4.0)
+             | None -> 4.0
+           in
+           let limit =
+             match Server_utils.query_param req "limit" with
+             | Some l -> (try int_of_string l with _ -> 20)
+             | None -> 20
+           in
+           let json =
+             Tool_agent_timeline.build_timeline
+               state.Mcp_server.room_config
+               ~agent_name ~since_hours ~limit
+               ~include_tasks:true ~include_board:false
+           in
+           Http.Response.json ~compress:true ~request:req
+             (Yojson.Safe.to_string json) reqd
+       ) request reqd)
+
   |> Http.Router.get "/api/v1/mdal/loops" (fun request reqd ->
        with_public_read (fun state req reqd ->
          match mdal_loops_json ~config:state.Mcp_server.room_config req with

--- a/lib/tool_agent_timeline.ml
+++ b/lib/tool_agent_timeline.ml
@@ -242,15 +242,17 @@ let build_timeline (config : Room.config) ~agent_name ~since_hours ~limit
     |> List.filter (fun e -> e.ts >= cutoff)
     |> List.sort (fun a b -> compare a.ts b.ts)
   in
-  (* Truncate to limit *)
+  (* Truncate to limit — keep the most recent events (tail of sorted list) *)
   let events =
-    if List.length filtered > limit then
-      let rec take n acc = function
-        | [] -> List.rev acc
-        | _ when n <= 0 -> List.rev acc
-        | x :: rest -> take (n - 1) (x :: acc) rest
+    let len = List.length filtered in
+    if len > limit then
+      let drop = len - limit in
+      let rec skip n = function
+        | [] -> []
+        | _ :: rest when n > 0 -> skip (n - 1) rest
+        | remaining -> remaining
       in
-      take limit [] filtered
+      skip drop filtered
     else filtered
   in
   (* Compute summary *)


### PR DESCRIPTION
## Summary

- **Phase 1**: Agent Observatory 뷰 — 기존 flat AgentGrid를 세션별 그룹 뷰로 교체. `observatory-store.ts`에서 agents, workerSupportBriefs, sessionBriefs, continuityBriefs를 computed signal로 조인
- **Phase 2**: 에이전트별 실시간 활동 스트림 — journal 필터링 + Worker Brief 섹션을 agent-detail overlay에 추가  
- **Phase 3**: `/api/v1/agent-timeline` HTTP 엔드포인트 추가 (OCaml) + AgentTimelineSection 컴포넌트로 시간순 이벤트 표시

## Changes

### Backend (OCaml)
- `server_routes_http_routes_dashboard.ml`: `GET /api/v1/agent-timeline?agent_name=X&since_hours=4&limit=20` 추가. `Tool_agent_timeline.build_timeline`을 직접 호출

### Frontend (Preact + HTM)
- `observatory-store.ts` (신규): 4개 데이터 소스를 세션별 `ObservatoryGroup[]`로 조인하는 computed signal
- `agent-observatory.ts` (신규): 세션 그룹 헤더 + 에이전트 행 렌더링. state/focus/tools/context ratio 표시
- `overview.ts`: AgentGrid → AgentObservatory 교체
- `agent-detail.ts`: journal stream, worker brief, timeline section 추가
- `api.ts`: `fetchAgentTimeline` 타입 클라이언트
- CSS: Observatory 레이아웃 + timeline/journal/worker brief 스타일

## Test plan

- [ ] `cd dashboard && npm run dev` — Vite HMR으로 Observatory 뷰 확인
- [ ] `http://localhost:5173/#overview` — 세션별 에이전트 그룹핑
- [ ] 에이전트 클릭 → detail overlay에 journal stream + timeline + worker brief 확인
- [ ] SSE 이벤트 시 실시간 갱신 확인
- [ ] `dune build --root .` — OCaml 빌드 통과 확인
- [ ] `npx vite build` — 프론트엔드 빌드 통과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)