### PR TITLE
fix(test): wrap Room.init in Eio_main.run for dashboard tests

### DIFF
--- a/test/dune
+++ b/test/dune
@@ -118,7 +118,7 @@
 (test
  (name test_dashboard_governance)
  (modules test_dashboard_governance)
- (libraries masc_mcp alcotest yojson unix))
+ (libraries masc_mcp alcotest eio eio_main yojson unix))
 
 (test
  (name test_dashboard_labels)
@@ -218,7 +218,7 @@
 (test
  (name test_mdal_store)
  (modules test_mdal_store)
- (libraries masc_mcp alcotest yojson unix))
+ (libraries masc_mcp alcotest eio eio_main yojson unix))
 
 (test
  (name test_agent_swarm_live_harness)
@@ -250,7 +250,7 @@
 (test
  (name test_chain_native_eio_bootstrap)
  (modules test_chain_native_eio_bootstrap)
- (libraries masc_mcp alcotest yojson unix))
+ (libraries masc_mcp alcotest eio eio_main yojson unix))
 
 (test
  (name test_metrics_store_eio)

--- a/test/dune
+++ b/test/dune
@@ -96,7 +96,7 @@
 (test
  (name test_dashboard_proof)
  (modules test_dashboard_proof)
- (libraries masc_mcp alcotest yojson unix))
+ (libraries masc_mcp alcotest eio eio_main yojson unix))
 
 ; Dashboard cache deadlock regression + stampede tests (requires Eio)
 (test
@@ -113,7 +113,7 @@
 (test
  (name test_dashboard_tools)
  (modules test_dashboard_tools)
- (libraries masc_mcp alcotest yojson unix))
+ (libraries masc_mcp alcotest eio eio_main yojson unix))
 
 (test
  (name test_dashboard_governance)

--- a/test/test_chain_native_eio_bootstrap.ml
+++ b/test/test_chain_native_eio_bootstrap.ml
@@ -35,6 +35,7 @@ let test_ensure_bootstrap_loads_sentinel_prompts () =
         | None -> Sys.getcwd ()
       in
       Unix.putenv "MASC_CHAIN_SOURCE_BASE_PATH" source_root;
+      Eio_main.run @@ fun _env ->
       let config = Lib.Room.default_config dir in
       ignore (Lib.Room.init config ~agent_name:(Some "fixture-root"));
       Lib.Chain_native_eio.ensure_bootstrap config;

--- a/test/test_dashboard_execution.ml
+++ b/test/test_dashboard_execution.ml
@@ -136,6 +136,7 @@ let test_dashboard_execution_current_room_status () =
     ~finally:(fun () -> cleanup_dir dir)
     (fun () ->
       let config = Lib.Room_utils.default_config dir in
+      Eio_main.run @@ fun env ->
       ignore (Lib.Room.init config ~agent_name:None);
       ignore (Lib.Room.room_create config ~name:"Focus Room" ~description:None);
       let enter_result =
@@ -146,7 +147,6 @@ let test_dashboard_execution_current_room_status () =
         (enter_result |> member "current_room" |> to_string);
       check (option string) "room state current_room" (Some "focus-room")
         (Lib.Room.read_current_room config);
-      Eio_main.run @@ fun env ->
       Eio.Switch.run (fun sw ->
         let json =
           Lib.Dashboard_execution.json
@@ -168,6 +168,7 @@ let test_dashboard_shell_current_room_status () =
   Fun.protect
     ~finally:(fun () -> cleanup_dir dir)
     (fun () ->
+      Eio_main.run @@ fun _env ->
       let config = Lib.Room_utils.default_config dir in
       ignore (Lib.Room.init config ~agent_name:None);
       ignore (Lib.Room.room_create config ~name:"Focus Room" ~description:None);
@@ -186,9 +187,9 @@ let test_dashboard_execution_fresh_join_not_marked_stale () =
     ~finally:(fun () -> cleanup_dir dir)
     (fun () ->
       let config = Lib.Room_utils.default_config dir in
+      Eio_main.run @@ fun env ->
       ignore (Lib.Room.init config ~agent_name:None);
       ignore (Lib.Room.join config ~agent_name:"sentinel-kind-fox" ~capabilities:["sentinel"; "housekeeping"] ());
-      Eio_main.run @@ fun env ->
       Eio.Switch.run (fun sw ->
         let json =
           Lib.Dashboard_execution.json

--- a/test/test_dashboard_governance.ml
+++ b/test/test_dashboard_governance.ml
@@ -26,6 +26,7 @@ let test_empty_governance_structure () =
   Fun.protect
     ~finally:(fun () -> cleanup_dir dir)
     (fun () ->
+      Eio_main.run @@ fun _env ->
       let config = Lib.Room_utils.default_config dir in
       ignore (Lib.Room.init config ~agent_name:(Some "dashboard"));
       let json =

--- a/test/test_dashboard_mission.ml
+++ b/test/test_dashboard_mission.ml
@@ -274,6 +274,7 @@ let test_dashboard_mission_projection () =
     (fun () ->
       let config = Lib.Room_utils.default_config dir in
       let session_id = "ts-mission-fixture-001" in
+      Eio_main.run @@ fun env ->
       seed_room config session_id;
       Lib.A2a_tools.emit_heartbeat_task
         ~agent:"llama-local-alpha"
@@ -311,7 +312,6 @@ let test_dashboard_mission_projection () =
         ();
       Sys.remove
         (Filename.concat (Lib.Room_utils.agents_dir config) "llama-local-delta.json");
-      Eio_main.run @@ fun env ->
       Eio.Switch.run (fun sw ->
         let json =
           Lib.Dashboard_mission.json
@@ -455,8 +455,8 @@ let test_dashboard_mission_keeper_tool_audit_fallback () =
     ~finally:(fun () -> cleanup_dir dir)
     (fun () ->
       let config = Lib.Room_utils.default_config dir in
-      ignore (Lib.Room.init config ~agent_name:(Some "fixture-root"));
       Eio_main.run @@ fun env ->
+      ignore (Lib.Room.init config ~agent_name:(Some "fixture-root"));
       Eio.Switch.run (fun sw ->
         let keeper_ctx : _ Lib.Tool_keeper.context =
           { config; agent_name = "fixture-root"; sw; clock = Eio.Stdenv.clock env; proc_mgr = Some (Eio.Stdenv.process_mgr env) }

--- a/test/test_dashboard_proof.ml
+++ b/test/test_dashboard_proof.ml
@@ -243,6 +243,7 @@ let test_dashboard_proof_projection () =
   Fun.protect
     ~finally:(fun () -> cleanup_dir dir)
     (fun () ->
+      Eio_main.run @@ fun _env ->
       let config = Lib.Room.default_config dir in
       ignore (Lib.Room.init config ~agent_name:(Some "fixture-root"));
       let session_id = "ts-proof-fixture-001" in
@@ -270,6 +271,7 @@ let test_dashboard_proof_exposes_validated_worker_run_evidence () =
   Fun.protect
     ~finally:(fun () -> cleanup_dir dir)
     (fun () ->
+      Eio_main.run @@ fun _env ->
       let config = Lib.Room.default_config dir in
       ignore (Lib.Room.init config ~agent_name:(Some "fixture-root"));
       let session_id = "ts-proof-worker-runs" in
@@ -299,6 +301,7 @@ let test_timeline_json_orders_command_plane_events_by_timestamp () =
   Fun.protect
     ~finally:(fun () -> cleanup_dir dir)
     (fun () ->
+      Eio_main.run @@ fun _env ->
       let config = Lib.Room.default_config dir in
       ignore (Lib.Room.init config ~agent_name:(Some "fixture-root"));
       let session_id = "ts-proof-fixture-ordered" in
@@ -334,6 +337,7 @@ let test_dashboard_proof_prefers_actual_activity_over_stronger_persisted_verdict
   Fun.protect
     ~finally:(fun () -> cleanup_dir dir)
     (fun () ->
+      Eio_main.run @@ fun _env ->
       let config = Lib.Room.default_config dir in
       ignore (Lib.Room.init config ~agent_name:(Some "fixture-root"));
       let session_id = "ts-proof-persisted-verdict" in
@@ -386,6 +390,7 @@ let test_dashboard_proof_marks_mentioned_only_actor_as_unanswered () =
   Fun.protect
     ~finally:(fun () -> cleanup_dir dir)
     (fun () ->
+      Eio_main.run @@ fun _env ->
       let config = Lib.Room.default_config dir in
       ignore (Lib.Room.init config ~agent_name:(Some "fixture-root"));
       let session_id = "ts-proof-mentioned-only" in
@@ -436,6 +441,7 @@ let test_dashboard_proof_ignores_unknown_mentions_outside_session () =
   Fun.protect
     ~finally:(fun () -> cleanup_dir dir)
     (fun () ->
+      Eio_main.run @@ fun _env ->
       let config = Lib.Room.default_config dir in
       ignore (Lib.Room.init config ~agent_name:(Some "fixture-root"));
       let session_id = "ts-proof-ignore-unknown-mentions" in
@@ -478,6 +484,7 @@ let test_dashboard_proof_uses_historical_verdict_when_live_is_empty () =
   Fun.protect
     ~finally:(fun () -> cleanup_dir dir)
     (fun () ->
+      Eio_main.run @@ fun _env ->
       let config = Lib.Room.default_config dir in
       ignore (Lib.Room.init config ~agent_name:(Some "fixture-root"));
       let session_id = "ts-proof-historical-only" in

--- a/test/test_dashboard_tools.ml
+++ b/test/test_dashboard_tools.ml
@@ -26,6 +26,7 @@ let test_dashboard_tools_projection () =
   Fun.protect
     ~finally:(fun () -> cleanup_dir dir)
     (fun () ->
+      Eio_main.run @@ fun _env ->
       let config = Lib.Room_utils.default_config dir in
       ignore (Lib.Room.init config ~agent_name:(Some "dashboard"));
       let json = Lib.Server_dashboard_http.dashboard_tools_http_json config in

--- a/test/test_gardener.ml
+++ b/test/test_gardener.ml
@@ -900,6 +900,7 @@ let test_tick_opens_backlog_triage_session_for_orphans () =
     ~finally:(fun () -> cleanup_dir dir)
     (fun () ->
       let config = Room.default_config dir in
+      Eio_main.run @@ fun env ->
       ignore (Room.init config ~agent_name:(Some "fixture-root"));
       ignore (Room.join config ~agent_name:"worker-a" ~capabilities:[ "executor" ] ());
       ignore (Room.add_task config ~title:"Orphan Candidate" ~priority:1 ~description:"needs owner");
@@ -913,7 +914,6 @@ let test_tick_opens_backlog_triage_session_for_orphans () =
           check_interval_sec = 1.0;
         }
       in
-      Eio_main.run @@ fun env ->
       (try
          Eio.Switch.run (fun sw ->
            Gardener.tick ~sw ~clock:(Eio.Stdenv.clock env)
@@ -946,6 +946,7 @@ let test_tick_reuses_existing_backlog_triage_session () =
     ~finally:(fun () -> cleanup_dir dir)
     (fun () ->
       let config = Room.default_config dir in
+      Eio_main.run @@ fun env ->
       ignore (Room.init config ~agent_name:(Some "fixture-root"));
       ignore (Room.join config ~agent_name:"worker-a" ~capabilities:[ "executor" ] ());
       ignore (Room.add_task config ~title:"Orphan Candidate" ~priority:1 ~description:"needs owner");
@@ -959,7 +960,6 @@ let test_tick_reuses_existing_backlog_triage_session () =
           check_interval_sec = 1.0;
         }
       in
-      Eio_main.run @@ fun env ->
       (try
          Eio.Switch.run (fun sw ->
            Gardener.tick ~sw ~clock:(Eio.Stdenv.clock env)
@@ -983,6 +983,7 @@ let test_tick_opens_backlog_triage_session_with_inactive_joined_agent () =
     ~finally:(fun () -> cleanup_dir dir)
     (fun () ->
       let config = Room.default_config dir in
+      Eio_main.run @@ fun env ->
       ignore (Room.init config ~agent_name:(Some "fixture-root"));
       ignore (Room.join config ~agent_name:"worker-a" ~capabilities:[ "executor" ] ());
       (* Mark only worker-a as inactive; fixture-root stays active so
@@ -1000,7 +1001,6 @@ let test_tick_opens_backlog_triage_session_with_inactive_joined_agent () =
           check_interval_sec = 1.0;
         }
       in
-      Eio_main.run @@ fun env ->
       (try
          Eio.Switch.run (fun sw ->
              Gardener.tick ~sw ~clock:(Eio.Stdenv.clock env)

--- a/test/test_mdal_store.ml
+++ b/test/test_mdal_store.ml
@@ -70,6 +70,7 @@ let dummy_state () : Mdal.loop_state =
   }
 
 let test_round_trip () =
+  Eio_main.run @@ fun _env ->
   let base_dir = temp_dir () in
   let config = Room.default_config base_dir in
   ignore (Room.init config ~agent_name:(Some "tester"));
@@ -93,6 +94,7 @@ let test_round_trip () =
   cleanup_dir base_dir
 
 let test_latest_pointer_and_listing () =
+  Eio_main.run @@ fun _env ->
   let base_dir = temp_dir () in
   let config = Room.default_config base_dir in
   ignore (Room.init config ~agent_name:(Some "tester"));


### PR DESCRIPTION
## Summary
- masc-mcp CI 연속 failure 복구 (빌드 깨짐 + 수백 개 테스트 실패 → 2개 잔여)
- OAS v0.46 호환성 수정 (budget 필드, Agent_types 경로)
- Eio.Mutex → Stdlib.Mutex 체계적 전환 (44 lib files)
- Merge conflict markers 제거, Config.default mode 테스트 수정

## Root Causes
1. **빌드**: OAS v0.46에서 `Agent.t` abstract화 → `Agent_types.interval_sec` 경로 변경 + leftover merge conflict markers
2. **테스트**: cross-project Eio.Mutex audit에서 module-level Stdlib.Mutex를 Eio.Mutex로 전환했으나, Eio.Mutex.use_rw는 Eio runtime context 필수 → 테스트 환경에서 Effect.Unhandled
3. **Config 테스트**: PR #1378 mode enforcement에서 default Full → Coding 변경 후 테스트 미갱신

## Changes
- **44 lib files**: module-level Eio.Mutex → Stdlib.Mutex (HTTP/SSE handler 제외)
- **1 lib file**: FileSystemBackend Eio.Mutex → Stdlib.Mutex
- **1 lib file**: merge conflict markers + dead code 71줄 제거
- **1 lib file**: OAS Agent_types.interval_sec 경로 수정
- **8 test files**: Eio_main.run 래핑 추가
- **3 test files**: Config.default mode assertion Full → Coding
- **1 test file**: MCP server Full mode config 설정

## Known Remaining (pre-existing, not introduced by this PR)
- `test_mcp_server_eio` test 36: tools/call trpg mode filtering path mismatch
- `test_tool_team_session` test 38: final-done-delta-snapshot-stable assertion

## Test plan
- [x] `dune build` — clean build
- [x] `dune test` — 2 pre-existing failures only
- [x] CI Health — GREEN
- [x] CI Lint — GREEN
- [x] CI Contract Harness — GREEN
- [x] CI Build and Test — 2 pre-existing failures only

🤖 Generated with [Claude Code](https://claude.com/claude-code)