### PR TITLE
fix(security): add guardrail for masc_gc days=0

### DIFF
--- a/lib/room_gc.ml
+++ b/lib/room_gc.ml
@@ -169,6 +169,7 @@ let cleanup_zombies config =
 
 (** Garbage collection - cleanup zombies, stale tasks, old messages *)
 let gc config ?(days=7) () =
+  let days = max 1 days in
   ensure_initialized config;
 
   let results = ref [] in

--- a/lib/tool_misc.ml
+++ b/lib/tool_misc.ml
@@ -664,7 +664,10 @@ let handle_verify_handoff _ctx args =
     (true, Yojson.Safe.pretty_to_string result)
 
 let handle_gc ctx args =
-  let days = get_int args "days" 7 in
+  let days_raw = get_int args "days" 7 in
+  let days = max 1 days_raw in
+  if days_raw < 1 then
+    Log.Misc.warn "masc_gc days=%d clamped to 1 (minimum guardrail)" days_raw;
   let gc_result = Room.gc ctx.config ~days () in
   (* Also expire pending decisions past TTL *)
   let expired =


### PR DESCRIPTION
## Summary

- [C-1] `masc_gc(days=0)` could delete ALL tasks/messages with no confirmation
- Defense in depth: guardrail at both `tool_misc.ml` (handler) and `room_gc.ml` (implementation)
- `days` clamped to minimum 1, with warning log when clamped

## Test plan

- [x] `dune build --root .` passes
- [ ] CI green
- [ ] Manual test: `masc_gc(days=0)` now uses days=1

🤖 Generated with [Claude Code](https://claude.com/claude-code)