### PR TITLE
feat(mode): dead tool cleanup + progressive disclosure

### DIFF
--- a/lib/config.ml
+++ b/lib/config.ml
@@ -136,7 +136,7 @@ let raw_all_tool_schemas : Types.tool_schema list =
     (Tools.raw_schemas
     @ Tool_board.tools
     @ Tool_lodge.tools
-    @ Tool_perpetual.schemas
+    (* Tool_perpetual: 0 calls in 6-day audit *)
     @ Tool_mdal.schemas
     @ Tool_keeper.schemas
     @ Tool_operator.schemas
@@ -147,7 +147,8 @@ let raw_all_tool_schemas : Types.tool_schema list =
     @ Tool_voice.schemas
     @ Tool_protocol_game_view.schemas
     @ Tool_trpg.schemas
-    @ Tool_code_swarm.schemas)
+    (* Tool_code_swarm: 0 calls in 6-day audit *)
+    )
 
 (** Validate tool schemas at module initialization time.
     Logs warnings for: duplicate names, empty names/descriptions,

--- a/lib/mode.ml
+++ b/lib/mode.ml
@@ -160,7 +160,8 @@ let tool_category tool_name =
   | "masc_status" | "masc_workflow_guide" | "masc_check"
   | "masc_room_strategy_get" | "masc_room_strategy_set"
   (* Mode management - always available via is_tool_enabled bypass *)
-  | "masc_switch_mode" | "masc_get_config" -> Core_Task
+  | "masc_switch_mode" | "masc_get_config"
+  | "masc_tool_enable" | "masc_tool_disable" -> Core_Task
 
   (* ── Core_Session: team session orchestration (11 tools) ── *)
   | "masc_team_session_start" | "masc_team_session_step"
@@ -416,11 +417,31 @@ let tool_category tool_name =
      Add new tools explicitly above to make them available. *)
   | _ -> Unknown
 
+(** Per-session extra enabled tools (progressive disclosure).
+    Tools in this set bypass mode filtering. *)
+let extra_enabled_tools : (string, unit) Hashtbl.t = Hashtbl.create 16
+
+let tool_enable name =
+  Hashtbl.replace extra_enabled_tools name ()
+
+let tool_disable name =
+  Hashtbl.remove extra_enabled_tools name
+
+let tool_enable_list () =
+  Hashtbl.fold (fun name () acc -> name :: acc) extra_enabled_tools []
+
+let tool_enable_clear () =
+  Hashtbl.clear extra_enabled_tools
+
 (** Check if a tool is enabled for given categories.
     Core is a virtual super-category — if enabled_categories contains Core,
-    all Core sub-categories are allowed. *)
+    all Core sub-categories are allowed.
+    Extra-enabled tools bypass category filtering. *)
 let is_tool_enabled enabled_categories tool_name =
-  if tool_name = "masc_switch_mode" || tool_name = "masc_get_config" then
+  if tool_name = "masc_switch_mode" || tool_name = "masc_get_config"
+     || tool_name = "masc_tool_enable" || tool_name = "masc_tool_disable" then
+    true
+  else if Hashtbl.mem extra_enabled_tools tool_name then
     true
   else
     match tool_category tool_name with

--- a/lib/tool_control.ml
+++ b/lib/tool_control.ml
@@ -121,23 +121,41 @@ let handle_get_config ctx _args =
   let summary = Config.get_config_summary room_path in
   (true, Yojson.Safe.pretty_to_string summary)
 
+let tools_in_category cat =
+  Config.raw_all_tool_schemas
+  |> List.filter (fun (s : Types.tool_schema) -> Mode.tool_category s.name = cat)
+  |> List.map (fun (s : Types.tool_schema) -> s.name)
+
 let handle_tool_enable _ctx args =
   let tools = get_string_list args "tools" in
   let tool = get_string args "tool" "" |> String.trim in
+  let category = get_string args "category" "" |> String.trim |> String.lowercase_ascii in
+  let category_tools =
+    if category = "" then []
+    else match Mode.category_of_string category with
+    | Some cat -> tools_in_category cat
+    | None -> []
+  in
   let all_tools =
-    (if tool <> "" then [tool] else []) @ tools
+    (if tool <> "" then [tool] else []) @ tools @ category_tools
     |> List.filter (fun t -> String.trim t <> "")
+    |> List.sort_uniq String.compare
   in
   if all_tools = [] then
-    (false, "tool or tools is required")
+    (false, Printf.sprintf "tool, tools, or category is required. Available categories: %s"
+       (String.concat ", " (List.map Mode.category_to_string
+          [Mode.Ecosystem; Discovery; Code; Board; Portal; Worktree;
+           Consensus; Voting; Encryption; Auth; Cost; Health])))
   else begin
     List.iter Mode.tool_enable all_tools;
     let enabled = Mode.tool_enable_list () in
-    let json = `Assoc [
+    let json = `Assoc ([
       ("enabled", `List (List.map (fun t -> `String t) all_tools));
       ("extra_enabled_total", `Int (List.length enabled));
-      ("all_extra", `List (List.map (fun t -> `String t) (List.sort String.compare enabled)));
-    ] in
+    ] @ (if category <> "" then
+           [("category", `String category);
+            ("category_tool_count", `Int (List.length category_tools))]
+         else [])) in
     (true, Yojson.Safe.pretty_to_string json)
   end
 

--- a/lib/tool_control.ml
+++ b/lib/tool_control.ml
@@ -121,6 +121,52 @@ let handle_get_config ctx _args =
   let summary = Config.get_config_summary room_path in
   (true, Yojson.Safe.pretty_to_string summary)
 
+let handle_tool_enable _ctx args =
+  let tools = get_string_list args "tools" in
+  let tool = get_string args "tool" "" |> String.trim in
+  let all_tools =
+    (if tool <> "" then [tool] else []) @ tools
+    |> List.filter (fun t -> String.trim t <> "")
+  in
+  if all_tools = [] then
+    (false, "tool or tools is required")
+  else begin
+    List.iter Mode.tool_enable all_tools;
+    let enabled = Mode.tool_enable_list () in
+    let json = `Assoc [
+      ("enabled", `List (List.map (fun t -> `String t) all_tools));
+      ("extra_enabled_total", `Int (List.length enabled));
+      ("all_extra", `List (List.map (fun t -> `String t) (List.sort String.compare enabled)));
+    ] in
+    (true, Yojson.Safe.pretty_to_string json)
+  end
+
+let handle_tool_disable _ctx args =
+  let tools = get_string_list args "tools" in
+  let tool = get_string args "tool" "" |> String.trim in
+  let clear = get_bool args "clear" false in
+  if clear then begin
+    Mode.tool_enable_clear ();
+    (true, "All extra-enabled tools cleared.")
+  end
+  else begin
+    let all_tools =
+      (if tool <> "" then [tool] else []) @ tools
+      |> List.filter (fun t -> String.trim t <> "")
+    in
+    if all_tools = [] then
+      (false, "tool, tools, or clear=true is required")
+    else begin
+      List.iter Mode.tool_disable all_tools;
+      let enabled = Mode.tool_enable_list () in
+      let json = `Assoc [
+        ("disabled", `List (List.map (fun t -> `String t) all_tools));
+        ("extra_enabled_total", `Int (List.length enabled));
+      ] in
+      (true, Yojson.Safe.pretty_to_string json)
+    end
+  end
+
 (* Dispatch function *)
 let dispatch ctx ~name ~args : result option =
   match name with
@@ -129,4 +175,6 @@ let dispatch ctx ~name ~args : result option =
   | "masc_pause_status" -> Some (handle_pause_status ctx args)
   | "masc_switch_mode" -> Some (handle_switch_mode ctx args)
   | "masc_get_config" -> Some (handle_get_config ctx args)
+  | "masc_tool_enable" -> Some (handle_tool_enable ctx args)
+  | "masc_tool_disable" -> Some (handle_tool_disable ctx args)
   | _ -> None

--- a/lib/tool_inline_dispatch.ml
+++ b/lib/tool_inline_dispatch.ml
@@ -931,4 +931,5 @@ Call masc_listen again to continue listening.
       ] in
       Some (true, Yojson.Safe.pretty_to_string response)
 
+
   | _ -> Tool_inline_dispatch_extra.dispatch ~config ~agent_name ~arguments ~state ~sw ~clock ~name

--- a/lib/tool_inline_dispatch_extra.ml
+++ b/lib/tool_inline_dispatch_extra.ml
@@ -100,6 +100,98 @@ let dispatch ~config ~agent_name ~arguments ~(state : Mcp_server.server_state) ~
       ] in
       Some (true, Yojson.Safe.pretty_to_string response)
 
+  | "masc_memento_mori" ->
+      let context_ratio = arg_get_float "context_ratio" 0.0 in
+      let full_context = arg_get_string "full_context" "" in
+      let summary = arg_get_string "summary" "" in
+      let current_task = arg_get_string "current_task" "" in
+      let target_agent = arg_get_string "target_agent" "claude" in
+      let cell = !(Mcp_server.current_cell) in
+      let mitosis_config = Mitosis.default_config in
+      let should_prepare_now = Mitosis.should_prepare ~config:mitosis_config ~cell ~context_ratio in
+      let should_handoff_now = Mitosis.should_handoff ~config:mitosis_config ~cell ~context_ratio in
+      if not should_prepare_now && not should_handoff_now then begin
+        let warning = if context_ratio = 0.0 then
+          [("warning", `String "context_ratio is 0.0 - did you forget to provide it?")]
+        else [] in
+        let response = `Assoc ([
+          ("status", `String "continue");
+          ("context_ratio", `Float context_ratio);
+          ("threshold_prepare", `Float mitosis_config.prepare_threshold);
+          ("threshold_handoff", `Float mitosis_config.handoff_threshold);
+          ("message", `String (Printf.sprintf "Context healthy (%.0f%%). Continue working." (context_ratio *. 100.0)));
+        ] @ warning) in
+        Some (true, Yojson.Safe.pretty_to_string response)
+      end
+      else if should_prepare_now && not should_handoff_now then begin
+        if full_context = "" then
+          Some (false, "full_context required when context_ratio > 50%")
+        else begin
+          let prepared_cell = Mitosis.prepare_for_division ~config:mitosis_config ~cell ~full_context in
+          Mcp_server.current_cell := prepared_cell;
+          let response = `Assoc [
+            ("status", `String "prepared");
+            ("context_ratio", `Float context_ratio);
+            ("phase", `String (Mitosis.phase_to_string prepared_cell.phase));
+            ("dna_extracted", `Bool (prepared_cell.prepared_dna <> None));
+            ("message", `String (Printf.sprintf "Context at %.0f%%. DNA prepared. Handoff at 80%%." (context_ratio *. 100.0)));
+          ] in
+          Some (true, Yojson.Safe.pretty_to_string response)
+        end
+      end
+      else begin
+        if full_context = "" then
+          Some (false, "full_context required for handoff")
+        else begin
+          let last_words = Printf.sprintf
+            "LAST WORDS from Generation %d\n\nI am %s, about to divide.\n%s\n\nTasks completed: %d | Tool calls: %d\nAge: %.1f minutes\n\nMy context is full (%.0f%%), but my work continues through Generation %d.\nCarry on, successors."
+            cell.Mitosis.generation cell.Mitosis.id
+            (if summary = "" then "My time has come." else summary)
+            cell.Mitosis.task_count cell.Mitosis.tool_call_count
+            ((Time_compat.now () -. cell.Mitosis.born_at) /. 60.0)
+            (context_ratio *. 100.0) (cell.Mitosis.generation + 1)
+          in
+          let _ = Room.broadcast config ~from_agent:agent_name ~content:last_words in
+          match state.Mcp_server.proc_mgr with
+          | None ->
+              Some (false, "Process manager not available for mitosis spawn")
+          | Some pm ->
+              let spawn_fn ~prompt =
+                let result = Spawn_eio.spawn ~sw ~proc_mgr:pm ~agent_name:target_agent
+                  ~prompt ~timeout_seconds:Env_config.Spawn.timeout_seconds
+                  ~room_config:state.Mcp_server.room_config () in
+                { Spawn.success = result.Spawn_eio.success;
+                  output = result.Spawn_eio.output;
+                  exit_code = result.Spawn_eio.exit_code;
+                  elapsed_ms = result.Spawn_eio.elapsed_ms;
+                  input_tokens = result.Spawn_eio.input_tokens;
+                  output_tokens = result.Spawn_eio.output_tokens;
+                  cache_creation_tokens = result.Spawn_eio.cache_creation_tokens;
+                  cache_read_tokens = result.Spawn_eio.cache_read_tokens;
+                  cost_usd = result.Spawn_eio.cost_usd } in
+              let (spawn_result, new_cell, new_pool, _handoff_dna) =
+                Mitosis.execute_mitosis ~config:mitosis_config
+                  ~pool:!(Mcp_server.stem_pool) ~parent:cell
+                  ~full_context:(Printf.sprintf "Summary: %s\n\nCurrent Task: %s\n\nContext:\n%s"
+                      (if summary = "" then "Memento mori - context limit reached" else summary)
+                      current_task full_context)
+                  ~spawn_fn in
+              Mcp_server.current_cell := new_cell;
+              Mcp_server.stem_pool := new_pool;
+              let response = `Assoc [
+                ("status", `String "divided");
+                ("context_ratio", `Float context_ratio);
+                ("previous_generation", `Int cell.generation);
+                ("new_generation", `Int new_cell.generation);
+                ("successor_spawned", `Bool spawn_result.Spawn.success);
+                ("successor_agent", `String target_agent);
+                ("successor_output", `String (String.sub spawn_result.Spawn.output 0 (min 500 (String.length spawn_result.Spawn.output))));
+                ("message", `String (Printf.sprintf "Context critical (%.0f%%). Cell divided. %s successor spawned." (context_ratio *. 100.0) target_agent));
+              ] in
+              Some (true, Yojson.Safe.pretty_to_string response)
+        end
+      end
+
   | "masc_recall_search" ->
       let module U = Yojson.Safe.Util in
       let query = match Json_util.get_string arguments "query" with Some v -> v | None -> raise Not_found in

--- a/lib/tools.ml
+++ b/lib/tools.ml
@@ -20,11 +20,12 @@ let all_schemas : tool_schema list = raw_schemas
 
 (** All schemas including Perpetual Agent Runtime tools *)
 let all_schemas_with_perpetual =
-  all_schemas @ Tool_perpetual.schemas @ Tool_keeper.schemas
+  all_schemas @ Tool_keeper.schemas
   @ Tool_operator.schemas @ Tool_llama.schemas @ Tool_command_plane.schemas @ Tool_goals.schemas
   @ Tool_team_session.schemas @ Tool_voice.schemas @ Tool_shard.schemas
-  @ Tool_notifications.schemas @ Tool_agent_timeline.schemas
   @ Tool_autoresearch.schemas
+  (* Removed from surface (0 calls in 6-day audit):
+     Tool_perpetual, Tool_code_swarm, Tool_notifications, Tool_agent_timeline *)
 
 (** Get tool by name *)
 let find_tool name =

--- a/lib/tools_schemas_05.ml
+++ b/lib/tools_schemas_05.ml
@@ -423,4 +423,50 @@ let schemas : tool_schema list = [
       ("required", `List [`String "full_context"]);
     ];
   };
+
+  (* ============================================ *)
+  (* Progressive Tool Disclosure                  *)
+  (* ============================================ *)
+
+  {
+    name = "masc_tool_enable";
+    description = "Enable specific tools without switching to Full mode. Bypasses mode filtering for listed tools. Use when you need a tool that is not in the current mode. Always available.";
+    input_schema = `Assoc [
+      ("type", `String "object");
+      ("properties", `Assoc [
+        ("tool", `Assoc [
+          ("type", `String "string");
+          ("description", `String "Single tool name to enable (e.g. masc_perpetual_start)");
+        ]);
+        ("tools", `Assoc [
+          ("type", `String "array");
+          ("items", `Assoc [("type", `String "string")]);
+          ("description", `String "Multiple tool names to enable at once");
+        ]);
+      ]);
+    ];
+  };
+
+  {
+    name = "masc_tool_disable";
+    description = "Disable previously extra-enabled tools, or clear all extra-enabled tools with clear=true.";
+    input_schema = `Assoc [
+      ("type", `String "object");
+      ("properties", `Assoc [
+        ("tool", `Assoc [
+          ("type", `String "string");
+          ("description", `String "Single tool name to disable");
+        ]);
+        ("tools", `Assoc [
+          ("type", `String "array");
+          ("items", `Assoc [("type", `String "string")]);
+          ("description", `String "Multiple tool names to disable");
+        ]);
+        ("clear", `Assoc [
+          ("type", `String "boolean");
+          ("description", `String "Clear all extra-enabled tools");
+        ]);
+      ]);
+    ];
+  };
 ]

--- a/lib/tools_schemas_05.ml
+++ b/lib/tools_schemas_05.ml
@@ -430,7 +430,7 @@ let schemas : tool_schema list = [
 
   {
     name = "masc_tool_enable";
-    description = "Enable specific tools without switching to Full mode. Bypasses mode filtering for listed tools. Use when you need a tool that is not in the current mode. Always available.";
+    description = "Enable specific tools or categories without switching to Full mode. Use when you need a tool not in the current mode. Categories: ecosystem (perpetual, gardener, keeper, mdal, handover, library), discovery (capabilities, agent_card, fitness), code (code_search, code_symbols, code_read), board (post, comment, vote), portal, worktree, consensus (debate, convo, walph), voting, encryption, auth, cost. Pass category= for bulk enable or tool= for individual.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -442,6 +442,10 @@ let schemas : tool_schema list = [
           ("type", `String "array");
           ("items", `Assoc [("type", `String "string")]);
           ("description", `String "Multiple tool names to enable at once");
+        ]);
+        ("category", `Assoc [
+          ("type", `String "string");
+          ("description", `String "Enable all tools in a category (e.g. ecosystem, discovery, code, board)");
         ]);
       ]);
     ];


### PR DESCRIPTION
## Summary

Phase 4: data-driven dead tool cleanup + progressive tool disclosure.

### Problem

294 MCP tools defined, 134 (46%) never called in 6-day audit.
Root cause: mode system is all-or-nothing. Standard mode has ~80 tools, Full has ~294.
Agents can't access Ecosystem/Discovery/etc. tools without switching to Full.

### Solution

**1. Remove dead tools from MCP surface** (Commit 1)
- Tool_perpetual (4 tools), Tool_code_swarm (3), Tool_notifications (3), Tool_agent_timeline (1)
- Handler code preserved — only definitions removed
- Fix merge conflict in tool_inline_dispatch.ml (orphaned diff3 markers)

**2. Restore lost handler** (Commit 2)
- `masc_memento_mori` (16 calls, Active) was lost in merge conflict
- Restored to tool_inline_dispatch_extra.ml

**3. Progressive tool disclosure** (Commits 3-4)
- New: `masc_tool_enable(tool: "masc_perpetual_start")` — enable individual tools
- New: `masc_tool_enable(category: "ecosystem")` — bulk enable by category
- New: `masc_tool_disable(clear: true)` — reset extra tools
- Both tools always available (bypass mode filtering)
- Description lists available categories for agent discovery

### Usage

```
# Standard mode에서 ecosystem 도구가 필요할 때
masc_tool_enable(category: "ecosystem")

# 개별 도구만
masc_tool_enable(tool: "masc_code_swarm_plan")

# 정리
masc_tool_disable(clear: true)
```

### Changes

| File | Change |
|------|--------|
| `config.ml` | Remove Tool_perpetual, Tool_code_swarm from schemas |
| `tools.ml` | Remove 4 dead modules from lookup |
| `tool_inline_dispatch.ml` | Resolve merge conflict (-120 lines) |
| `tool_inline_dispatch_extra.ml` | Restore memento_mori handler (+92 lines) |
| `mode.ml` | extra_enabled_tools Hashtbl + is_tool_enabled bypass |
| `tool_control.ml` | masc_tool_enable/disable handlers with category support |
| `tools_schemas_05.ml` | MCP schema definitions for new tools |

## Test plan

- [x] `dune build` passes
- [ ] `make test` (CI)
- [ ] Verify `masc_tool_enable(category: "ecosystem")` works
- [ ] Verify `masc_tool_disable(clear: true)` resets

🤖 Generated with [Claude Code](https://claude.com/claude-code)