### PR TITLE
fix(lodge): graceful Eio fallback — unblock 8 CI test failures

### DIFF
--- a/lib/lodge_heartbeat_state.ml
+++ b/lib/lodge_heartbeat_state.ml
@@ -33,10 +33,15 @@ let lodge_lock : Eio.Mutex.t = Eio.Mutex.create ()
 
 let lodge_init_lock () = ()  (* kept for backward compat; lock is now eagerly created *)
 
-(** Run [f] under lodge mutex.  The lock is eagerly initialized so there
-    is no unprotected fallback path. *)
+(** Run [f] under lodge mutex when Eio context is available.
+    Falls back to unprotected execution outside Eio (e.g. in test harnesses
+    that call lodge_status without Eio_main.run).  This is safe because
+    the unprotected path only runs when no concurrent Eio fibers exist. *)
 let with_lodge_lock f =
-  Eio.Mutex.use_rw ~protect:true lodge_lock f
+  try Eio.Mutex.use_rw ~protect:true lodge_lock f
+  with Effect.Unhandled _ ->
+    (* No Eio scheduler: single-threaded context, safe to run unprotected *)
+    f ()
 
 (** Active agents: name -> (uuid, started_at) *)
 let active_agents : (string, string * float) Hashtbl.t = Hashtbl.create 10
@@ -671,7 +676,8 @@ let _lodge_enabled = ref false
 let _lodge_manual_tick_running = ref false
 
 let with_manual_tick_state f =
-  Eio.Mutex.use_rw ~protect:true lodge_lock f
+  try Eio.Mutex.use_rw ~protect:true lodge_lock f
+  with Effect.Unhandled _ -> f ()
 
 let set_manual_tick_running value =
   with_manual_tick_state (fun () -> _lodge_manual_tick_running := value)


### PR DESCRIPTION
## Summary
#1376에서 lodge_lock을 eager Eio.Mutex.t로 변경한 후, Eio context 없이 lodge_status()를 간접 호출하는 테스트 8건이 Effect.Unhandled로 실패.

#1386에서 직접 호출 3건은 수정했지만, team_session/swarm/operator 테스트가 dashboard_execution → lodge_status 경로를 간접 호출하면서 나머지 8건이 남아있었음.

## 접근
테스트마다 Eio_main.run을 추가하는 건 비현실적 (간접 호출 경로가 너무 많음). 대신 with_lodge_lock이 Effect.Unhandled를 잡아서 unprotected로 실행.

이건 안전함: Effect.Unhandled는 Eio scheduler가 없다는 뜻이고, scheduler가 없으면 concurrent fiber도 없어서 race condition 불가.

## Test plan
- [x] `dune build` 통과
- [ ] CI Build and Test — 8건 실패 → 0건 기대

🤖 Generated with [Claude Code](https://claude.com/claude-code)