### PR TITLE
fix: replace Eio.Mutex with Stdlib.Mutex in FileSystemBackend facade

### DIFF
--- a/lib/local_agent_eio_runners.ml
+++ b/lib/local_agent_eio_runners.ml
@@ -86,7 +86,7 @@ let run_worker_oas ~sw ~base_path ~worker_name
         let heartbeat_cbs =
           let interval = local_worker_heartbeat_interval_sec () in
           if interval > 0 then
-            [ { Oas.Agent.interval_sec = float_of_int interval;
+            [ { Oas.Agent_types.interval_sec = float_of_int interval;
                 callback = (fun () ->
                   match
                     call_masc_tool ~sw ~auth_token ~session_id:mcp_session_id
@@ -288,7 +288,7 @@ let continue_worker ?worker_run_id ~sw ~base_path ~room_config ~worker_name
           let heartbeat_cbs =
             let interval = local_worker_heartbeat_interval_sec () in
             if interval > 0 then
-              [ { Oas.Agent.interval_sec = float_of_int interval;
+              [ { Oas.Agent_types.interval_sec = float_of_int interval;
                   callback = (fun () ->
                     match
                       call_masc_tool ~sw ~auth_token


### PR DESCRIPTION
## Summary

OAS v0.43 호환성 수정 + FileSystemBackend Eio.Mutex 제거.

### 변경 1: FileSystemBackend Eio.Mutex -> Stdlib.Mutex
- backend.ml의 FileSystemBackend는 blocking Sys/Unix I/O만 사용
- Eio.Mutex는 Eio context 필요 -> 테스트에서 Unhandled + Poisoned cascade
- Stdlib.Mutex가 올바른 선택 (blocking I/O 모듈)

### 변경 2: OAS v0.43 Agent_types 경로
- periodic_callback이 Agent -> Agent_types 모듈로 이동
- Oas.Agent.interval_sec -> Oas.Agent_types.interval_sec

### 남은 이슈 (별도 PR 필요)
16개 lib 모듈이 Eio.Mutex를 직접 사용하여 테스트에서 Unhandled 발생:
Social_motion, Llm_orchestration, Gardener_decisions, Lodge_cascade, Relay, Trpg 등.
공통 테스트 harness에 Eio_main.run 래핑 필요 (대규모 리팩토링).

## Test plan
- [x] Local dune build 성공
- [x] Local test_room_coverage.exe 51/51 pass
- [x] Local Unhandled 에러 0건 (backend.ml 경유)
- [x] CI Lint, Health, Contract Harness pass
- [ ] CI Build and Test: 다른 모듈의 Eio.Mutex로 일부 실패 (pre-existing)