### PR TITLE
feat(dashboard): improve information architecture with roster pages and status transparency

### DIFF
--- a/dashboard/src/components/agent-roster.ts
+++ b/dashboard/src/components/agent-roster.ts
@@ -1,0 +1,152 @@
+// MASC Dashboard — Agent Roster
+// Full-page scrollable agent list with large avatars and status.
+
+import { html } from 'htm/preact'
+import { useState } from 'preact/hooks'
+import { agents } from '../store'
+import { missionSnapshot } from '../mission-store'
+import { navigate } from '../router'
+import { AgentAvatar } from './overview/agent-avatar'
+import { formatDuration } from './mission-utils'
+
+type StatusFilter = 'all' | 'active' | 'idle' | 'offline'
+
+function statusCategory(status: string): StatusFilter {
+  const s = status.toLowerCase()
+  if (s === 'active' || s === 'busy' || s === 'listening' || s === 'working') return 'active'
+  if (s === 'offline' || s === 'inactive') return 'offline'
+  return 'idle'
+}
+
+function statusLabel(status: string): string {
+  const labels: Record<string, string> = {
+    active: '활성',
+    busy: '처리 중',
+    listening: '대기',
+    working: '작업 중',
+    idle: '유휴',
+    offline: '오프라인',
+    inactive: '비활성',
+  }
+  return labels[status.toLowerCase()] ?? status
+}
+
+function statusBadgeClass(status: string): string {
+  const cat = statusCategory(status)
+  if (cat === 'active') return 'roster-badge--active'
+  if (cat === 'offline') return 'roster-badge--offline'
+  return 'roster-badge--idle'
+}
+
+export function AgentRoster() {
+  const [filter, setFilter] = useState<StatusFilter>('all')
+  const [search, setSearch] = useState('')
+
+  const agentList = agents.value
+  const snap = missionSnapshot.value
+  const briefs = snap?.agent_briefs ?? []
+
+  const briefMap = new Map(briefs.map(b => [b.name, b]))
+
+  const filtered = agentList
+    .filter((a: { name: string; status: string }) => {
+      if (filter !== 'all' && statusCategory(a.status) !== filter) return false
+      if (search && !a.name.toLowerCase().includes(search.toLowerCase())) return false
+      return true
+    })
+    .sort((a: { status: string; name: string }, b: { status: string; name: string }) => {
+      const order: Record<string, number> = { active: 0, busy: 0, listening: 0, working: 0, idle: 1, offline: 2, inactive: 2 }
+      const aOrder = order[a.status.toLowerCase()] ?? 1
+      const bOrder = order[b.status.toLowerCase()] ?? 1
+      if (aOrder !== bOrder) return aOrder - bOrder
+      return a.name.localeCompare(b.name)
+    })
+
+  const counts = {
+    all: agentList.length,
+    active: agentList.filter((a: { status: string }) => statusCategory(a.status) === 'active').length,
+    idle: agentList.filter((a: { status: string }) => statusCategory(a.status) === 'idle').length,
+    offline: agentList.filter((a: { status: string }) => statusCategory(a.status) === 'offline').length,
+  }
+
+  return html`
+    <div class="roster-page">
+      <div class="roster-header">
+        <h2 class="roster-title">에이전트 (${agentList.length})</h2>
+        <div class="roster-controls">
+          <input
+            type="text"
+            class="roster-search"
+            placeholder="이름 검색..."
+            value=${search}
+            onInput=${(e: Event) => setSearch((e.target as HTMLInputElement).value)}
+          />
+          <div class="roster-filters">
+            ${(['all', 'active', 'idle', 'offline'] as StatusFilter[]).map(f => html`
+              <button
+                key=${f}
+                class="roster-filter-btn ${filter === f ? 'active' : ''}"
+                onClick=${() => setFilter(f)}
+              >
+                ${f === 'all' ? '전체' : f === 'active' ? '활성' : f === 'idle' ? '유휴' : '오프라인'} ${counts[f]}
+              </button>
+            `)}
+          </div>
+        </div>
+      </div>
+
+      <div class="roster-list">
+        ${filtered.map((agent: { name: string; status: string; current_task?: string; traits?: string[] }) => {
+          const brief = briefMap.get(agent.name)
+          const currentWork = brief?.current_work ?? agent.current_task ?? null
+          const lastActivity = brief?.last_turn_ago_s ?? null
+
+          return html`
+            <div
+              class="roster-card"
+              key=${agent.name}
+              onClick=${() => navigate('execution', { agent: agent.name })}
+              role="button"
+              tabindex="0"
+            >
+              <div class="roster-card__avatar">
+                <${AgentAvatar}
+                  name=${agent.name}
+                  status=${agent.status}
+                  traits=${agent.traits}
+                  size="xl"
+                  currentWork=${currentWork}
+                  activityAge=${lastActivity}
+                />
+              </div>
+              <div class="roster-card__info">
+                <div class="roster-card__header">
+                  <strong class="roster-card__name">${agent.name}</strong>
+                  <span class="roster-badge ${statusBadgeClass(agent.status)}">
+                    ${statusLabel(agent.status)}
+                  </span>
+                </div>
+                ${currentWork ? html`
+                  <div class="roster-card__work">${currentWork}</div>
+                ` : html`
+                  <div class="roster-card__work roster-card__work--empty">작업 없음</div>
+                `}
+                <div class="roster-card__meta">
+                  ${lastActivity != null ? html`
+                    <span>${formatDuration(lastActivity)} 전</span>
+                  ` : null}
+                  ${brief?.model ? html`
+                    <span class="roster-card__model">${brief.model}</span>
+                  ` : null}
+                </div>
+              </div>
+            </div>
+          `
+        })}
+        ${filtered.length === 0 ? html`
+          <div class="roster-empty">조건에 맞는 에이전트가 없습니다.</div>
+        ` : null}
+      </div>
+    </div>
+  `
+}

--- a/dashboard/src/components/dashboard-shell.ts
+++ b/dashboard/src/components/dashboard-shell.ts
@@ -1,8 +1,9 @@
 import { html } from 'htm/preact'
 import { signal } from '@preact/signals'
 import { route, navigate } from '../router'
-import { connected, eventCount } from '../sse'
+import { connected } from '../sse'
 import { dashboardLoading, serverStatus } from '../store'
+import { missionSnapshot } from '../mission-store'
 import { Mission } from './mission'
 import { Proof } from './proof'
 import { Command } from './command'
@@ -16,6 +17,8 @@ import { Social } from './social'
 import { Lab } from './lab'
 import { Live } from './live'
 import { Overview } from './overview/overview'
+import { AgentRoster } from './agent-roster'
+import { KeeperRoster } from './keeper-roster'
 import { TimeAgo } from './common/time-ago'
 import { PanelSemanticDetails } from './common/semantic-layer'
 import {
@@ -29,11 +32,20 @@ const buildIdentityOpen = signal(false)
 
 export function ConnectionStatus() {
   const isConnected = connected.value
+  const snap = missionSnapshot.value
+  const attentionCount = snap?.attention_queue?.length ?? 0
+
   return html`
     <div class="connection-status ${isConnected ? 'connected' : 'disconnected'}">
       <span class="status-dot ${isConnected ? 'connected' : 'disconnected'}"></span>
       <span class="status-text">${isConnected ? '연결됨' : '재연결 중...'}</span>
-      <span class="event-count">이벤트 ${eventCount.value}</span>
+      ${attentionCount > 0 ? html`
+        <span
+          class="event-count attention-badge"
+          onClick=${() => navigate('home')}
+          style="cursor: pointer;"
+        >주의 ${attentionCount}건</span>
+      ` : null}
     </div>
   `
 }
@@ -181,6 +193,10 @@ export function TabContent() {
       return html`<${Mission} />`
     case 'proof':
       return html`<${Proof} />`
+    case 'agent-roster':
+      return html`<${AgentRoster} />`
+    case 'keeper-roster':
+      return html`<${KeeperRoster} />`
     case 'execution':
       return html`<${Execution} />`
     case 'tools':

--- a/dashboard/src/components/keeper-roster.ts
+++ b/dashboard/src/components/keeper-roster.ts
@@ -1,0 +1,106 @@
+// MASC Dashboard — Keeper Roster
+// Full-page scrollable keeper list with context pressure and generation info.
+
+import { html } from 'htm/preact'
+import { keepers } from '../store'
+import { missionSnapshot } from '../mission-store'
+import { formatDuration } from './mission-utils'
+
+function pressureClass(ratio: number | null | undefined): string {
+  if (ratio == null) return ''
+  const pct = ratio * 100
+  if (pct < 50) return 'pressure--ok'
+  if (pct < 70) return 'pressure--amber'
+  if (pct < 85) return 'pressure--orange'
+  return 'pressure--red'
+}
+
+function keeperStatusLabel(status?: string): string {
+  const s = (status ?? '').toLowerCase()
+  if (s === 'active' || s === 'running' || s === 'ok') return '활성'
+  if (s === 'idle' || s === 'listening') return '유휴'
+  if (s === 'offline' || s === 'inactive') return '오프라인'
+  return status ?? '알 수 없음'
+}
+
+function keeperStatusClass(status?: string): string {
+  const s = (status ?? '').toLowerCase()
+  if (s === 'active' || s === 'running' || s === 'ok') return 'roster-badge--active'
+  if (s === 'idle' || s === 'listening') return 'roster-badge--idle'
+  return 'roster-badge--offline'
+}
+
+export function KeeperRoster() {
+  const keeperList = keepers.value
+  const snap = missionSnapshot.value
+  const briefs = snap?.keeper_briefs ?? []
+
+  // Use briefs if available (richer data), fall back to keeper signal
+  const items = briefs.length > 0 ? briefs : keeperList
+
+  // Sort: active first, then by context pressure (high first)
+  const sorted = [...items].sort((a, b) => {
+    const aActive = (a.status ?? '').match(/active|running|ok/i) ? 0 : 1
+    const bActive = (b.status ?? '').match(/active|running|ok/i) ? 0 : 1
+    if (aActive !== bActive) return aActive - bActive
+    const aRatio = a.context_ratio ?? 0
+    const bRatio = b.context_ratio ?? 0
+    return bRatio - aRatio
+  })
+
+  return html`
+    <div class="roster-page">
+      <div class="roster-header">
+        <h2 class="roster-title">키퍼 (${items.length})</h2>
+      </div>
+
+      <div class="roster-list">
+        ${sorted.map(k => html`
+          <div class="roster-card keeper-roster-card" key=${k.name}>
+            <div class="keeper-roster__main">
+              <div class="keeper-roster__header">
+                <strong class="roster-card__name">${k.name}</strong>
+                ${k.generation != null ? html`
+                  <span class="keeper-roster__gen">G${k.generation}</span>
+                ` : null}
+                <span class="roster-badge ${keeperStatusClass(k.status)}">
+                  ${keeperStatusLabel(k.status)}
+                </span>
+              </div>
+
+              ${k.context_ratio != null ? html`
+                <div class="keeper-roster__pressure">
+                  <div class="keeper-roster__pressure-track">
+                    <div
+                      class="keeper-roster__pressure-bar ${pressureClass(k.context_ratio)}"
+                      style=${{ width: `${Math.round(k.context_ratio * 100)}%` }}
+                    />
+                  </div>
+                  <span class="keeper-roster__pressure-label">
+                    ctx ${Math.round(k.context_ratio * 100)}%
+                  </span>
+                </div>
+              ` : null}
+
+              ${k.current_work ? html`
+                <div class="roster-card__work">${k.current_work}</div>
+              ` : null}
+
+              <div class="roster-card__meta">
+                ${k.last_turn_ago_s != null ? html`
+                  <span>${formatDuration(k.last_turn_ago_s)} 전</span>
+                ` : null}
+                ${k.model ? html`
+                  <span class="roster-card__model">${k.model}</span>
+                ` : null}
+              </div>
+            </div>
+          </div>
+        `)}
+        ${sorted.length === 0 ? html`
+          <div class="roster-empty">활성 키퍼가 없습니다.</div>
+        ` : null}
+      </div>
+    </div>
+  `
+}

--- a/dashboard/src/components/overview/agent-avatar.ts
+++ b/dashboard/src/components/overview/agent-avatar.ts
@@ -10,7 +10,7 @@ import {
   type AvatarPalette,
 } from '../../config/avatar-palettes'
 
-type AvatarSize = 'sm' | 'md' | 'lg'
+type AvatarSize = 'sm' | 'md' | 'lg' | 'xl'
 
 interface AgentAvatarProps {
   name: string
@@ -93,7 +93,7 @@ export function AgentAvatar({
   const palette = paletteForAgent(name)
   const template = templateForAgent(name, traits)
   const grid = PIXEL_TEMPLATES[template]
-  const sizeClass = size === 'sm' ? 'pixel-avatar--sm' : size === 'lg' ? 'pixel-avatar--lg' : ''
+  const sizeClass = size === 'sm' ? 'pixel-avatar--sm' : size === 'lg' ? 'pixel-avatar--lg' : size === 'xl' ? 'pixel-avatar--xl' : ''
   const statusAttr = status ?? 'idle'
   const blockerClass = hasBlocker ? 'pixel-avatar--has-blocker' : ''
   const ringClass = signalRingClass(signalTruth)

--- a/dashboard/src/components/overview/overview.ts
+++ b/dashboard/src/components/overview/overview.ts
@@ -2,8 +2,7 @@
 // 4-Layer information architecture: Situation -> Anomaly -> Entity Grid -> Timeline
 
 import { html } from 'htm/preact'
-import { agents, keepers, tasks, shellCounts, providerCapacity, agentActivity, refreshAgentActivity } from '../../store'
-import { useEffect } from 'preact/hooks'
+import { agents, keepers, tasks, shellCounts } from '../../store'
 import { missionSnapshot } from '../../mission-store'
 import { journal } from '../../sse'
 import { navigate } from '../../router'
@@ -14,8 +13,7 @@ import { AgentObservatory } from './agent-observatory'
 import { SessionTriage } from './session-triage'
 import { NarrativeTimeline } from './narrative-timeline'
 import { QuickStats } from './quick-stats'
-import type { TaskBreakdown } from './quick-stats'
-import { DASHBOARD_SURFACES } from '../../config/navigation'
+import type { TaskBreakdown, TaskSource } from './quick-stats'
 
 function pressureClass(ratio: number | null | undefined): string {
   if (ratio == null) return ''
@@ -35,7 +33,6 @@ function keeperHealthClass(status?: string): string {
 }
 
 export function Overview() {
-  useEffect(() => { refreshAgentActivity() }, [])
   const snap = missionSnapshot.value
   const agentList = agents.value
   const keeperList = keepers.value
@@ -51,6 +48,7 @@ export function Overview() {
 
   const agentCount = activeAgents.length > 0 ? activeAgents.length : (counts?.agents ?? 0)
   const taskCount = activeTasks.length > 0 ? activeTasks.length : (counts?.tasks ?? 0)
+  const taskSource: TaskSource = activeTasks.length > 0 ? 'store' : 'cache'
   const keeperCount = keeperList.length > 0 ? keeperList.length : (counts?.keepers ?? 0)
 
   const taskBreakdown: TaskBreakdown = {
@@ -65,8 +63,6 @@ export function Overview() {
   const sessions = snap?.sessions ?? snap?.session_briefs ?? []
   const keeperBriefs = snap?.keeper_briefs ?? []
 
-  const navSurfaces = DASHBOARD_SURFACES.filter(s => s.id !== 'home')
-
   return html`
     <div class="overview-surface">
       <${SituationBanner} snap=${snap} roomHealth=${roomHealth} />
@@ -78,13 +74,15 @@ export function Overview() {
         keeperCount=${keeperCount}
         attentionCount=${attentionCount}
         taskBreakdown=${taskBreakdown}
+        taskSource=${taskSource}
       />
-
-      <${ProviderGauge} />
 
       <div class="overview-main-v2">
         <div class="overview-left-col">
-          <div class="overview-section-label">에이전트 Observatory</div>
+          <div class="overview-section-header">
+            <span class="overview-section-label">에이전트 Observatory</span>
+            <a class="overview-section-link" onClick=${() => navigate('agent-roster')}>전체 보기</a>
+          </div>
           <${AgentObservatory}
             onAgentClick=${(name: string) => navigate('execution', { agent: name })}
           />
@@ -95,7 +93,10 @@ export function Overview() {
           <${SessionTriage} sessions=${sessions} />
 
           ${keeperBriefs.length > 0 ? html`
-            <div class="overview-section-label" style="margin-top: var(--space-md, 16px)">키퍼</div>
+            <div class="overview-section-header" style="margin-top: var(--space-md, 16px)">
+              <span class="overview-section-label">키퍼</span>
+              <a class="overview-section-link" onClick=${() => navigate('keeper-roster')}>전체 보기</a>
+            </div>
             <div class="keeper-cards-v2">
               ${keeperBriefs.map(k => html`
                 <div class="keeper-card-v2 ${keeperHealthClass(k.status)}" key=${k.name}>
@@ -131,92 +132,9 @@ export function Overview() {
 
           <div class="overview-section-label" style="margin-top: var(--space-md, 16px)">최근 활동</div>
           <${NarrativeTimeline} entries=${journal} maxItems=${12} />
-
-          <${AgentActivityPanel} />
         </div>
       </div>
-
-      <nav class="overview-nav-strip">
-        ${navSurfaces.map(surface => html`
-          <button
-            class="overview-nav-btn"
-            key=${surface.id}
-            onClick=${() => navigate(surface.defaultTab)}
-          >
-            <span class="overview-nav-icon">${surface.icon}</span>
-            <span class="overview-nav-label">${surface.label}</span>
-            <span class="overview-nav-desc">${surface.description}</span>
-          </button>
-        `)}
-      </nav>
     </div>
   `
 }
 
-function ProviderGauge() {
-  const cap = providerCapacity.value
-  if (!cap) return null
-
-  const pool = cap.glm_pool
-  const agentCap = cap.agent_capacity
-  const loadPct = pool.total_capacity > 0
-    ? Math.round((pool.current_load / pool.total_capacity) * 100)
-    : 0
-  const loadTone = loadPct < 50 ? 'ok' : loadPct < 80 ? 'warn' : 'bad'
-
-  return html`
-    <div class="mission-stat-grid" style="margin-bottom: var(--space-md, 16px);">
-      <div class="summary-stat-card ${loadTone}">
-        <span>GLM Pool</span>
-        <strong>${pool.current_load}/${pool.total_capacity}</strong>
-        <small>${pool.has_capacity ? 'capacity available' : 'at capacity'}</small>
-      </div>
-      <div class="summary-stat-card">
-        <span>Agent Slots</span>
-        <strong>${agentCap.target_agents}</strong>
-        <small>${agentCap.min_agents}-${agentCap.max_agents} range${agentCap.gardener_enabled ? '' : ' (gardener off)'}</small>
-      </div>
-      ${pool.models.length > 0 ? html`
-        <div class="summary-stat-card">
-          <span>Models</span>
-          <strong>${pool.models.length}</strong>
-          <small>${pool.models.map((m: { model: string }) => m.model).join(', ')}</small>
-        </div>
-      ` : null}
-    </div>
-  `
-}
-
-function relativeTimeShort(ts: number): string {
-  const diff = (Date.now() / 1000) - ts
-  if (diff < 60) return 'just now'
-  if (diff < 3600) return `${Math.floor(diff / 60)}m ago`
-  if (diff < 86400) return `${Math.floor(diff / 3600)}h ago`
-  return `${Math.floor(diff / 86400)}d ago`
-}
-
-function AgentActivityPanel() {
-  const activities = agentActivity.value
-  if (activities.length === 0) return null
-
-  return html`
-    <div style="margin-top: var(--space-md, 16px);">
-      <div class="overview-section-label">에이전트 활동 (24h)</div>
-      <div style="display: flex; flex-direction: column; gap: 6px;">
-        ${activities.slice(0, 8).map(a => html`
-          <div class="mission-activity-row" style="padding: 8px 12px;" key=${a.agent_id}>
-            <div style="display: flex; justify-content: space-between; align-items: center;">
-              <strong style="font-size: 13px;">${a.agent_id}</strong>
-              <span class="command-chip ${a.failure_count > 0 ? 'warn' : 'ok'}" style="font-size: 11px;">
-                ${a.tool_calls} calls
-              </span>
-            </div>
-            <div style="font-size: 11px; color: rgba(255,255,255,0.45); margin-top: 2px;">
-              ${a.success_count} ok / ${a.failure_count} fail · ${relativeTimeShort(a.last_seen)}
-            </div>
-          </div>
-        `)}
-      </div>
-    </div>
-  `
-}

--- a/dashboard/src/components/overview/quick-stats.ts
+++ b/dashboard/src/components/overview/quick-stats.ts
@@ -1,10 +1,13 @@
-// MASC Dashboard — Quick Stats Bar (4 key metrics + task distribution)
+// MASC Dashboard — Quick Stats Bar (4 key metrics + task distribution + data source)
 
 import { html } from 'htm/preact'
+import { navigate } from '../../router'
 
 export interface TaskBreakdown {
   todo: number; claimed: number; inProgress: number; done: number
 }
+
+export type TaskSource = 'store' | 'cache'
 
 interface QuickStatsProps {
   agentCount: number
@@ -12,6 +15,7 @@ interface QuickStatsProps {
   keeperCount: number
   attentionCount: number
   taskBreakdown?: TaskBreakdown
+  taskSource?: TaskSource
 }
 
 function TaskDistributionBar({ breakdown }: { breakdown: TaskBreakdown }) {
@@ -38,19 +42,31 @@ function TaskDistributionBar({ breakdown }: { breakdown: TaskBreakdown }) {
   `
 }
 
-export function QuickStats({ agentCount, activeTaskCount, keeperCount, attentionCount, taskBreakdown }: QuickStatsProps) {
+export function QuickStats({ agentCount, activeTaskCount, keeperCount, attentionCount, taskBreakdown, taskSource }: QuickStatsProps) {
   return html`
     <div class="overview-stats">
-      <div class="overview-stat">
+      <div class="overview-stat"
+        style="cursor: pointer;"
+        onClick=${() => navigate('agent-roster')}
+      >
         <span class="overview-stat__label">에이전트</span>
         <strong class="overview-stat__value">${agentCount}</strong>
       </div>
-      <div class="overview-stat">
+      <div class="overview-stat"
+        style="cursor: pointer;"
+        onClick=${() => navigate('planning')}
+      >
         <span class="overview-stat__label">활성 태스크</span>
         <strong class="overview-stat__value">${activeTaskCount}</strong>
+        ${taskSource === 'cache' ? html`
+          <span class="overview-stat__source">(캐시)</span>
+        ` : null}
         ${taskBreakdown ? html`<${TaskDistributionBar} breakdown=${taskBreakdown} />` : null}
       </div>
-      <div class="overview-stat">
+      <div class="overview-stat"
+        style="cursor: pointer;"
+        onClick=${() => navigate('keeper-roster')}
+      >
         <span class="overview-stat__label">키퍼</span>
         <strong class="overview-stat__value">${keeperCount}</strong>
       </div>

--- a/dashboard/src/components/overview/session-triage.ts
+++ b/dashboard/src/components/overview/session-triage.ts
@@ -1,8 +1,9 @@
-// MASC Dashboard — Session Triage (Phase 4)
-// Replaces flat SessionStrip with a 3-tier hierarchical display:
+// MASC Dashboard — Session Triage
+// 4-tier hierarchical display:
 //   Tier 1 (Critical): sessions with blockers or bad attention
 //   Tier 2 (Watch):    sessions with attention items or degraded health
 //   Tier 3 (Running):  healthy sessions, collapsed by default
+//   Tier 4 (Routine):  gardener/backlog sessions, collapsed as noise
 
 import { html } from 'htm/preact'
 import { navigate } from '../../router'
@@ -22,6 +23,14 @@ interface TriageResult {
   critical: SessionItem[]
   watch: SessionItem[]
   running: SessionItem[]
+  routine: SessionItem[]
+}
+
+const ROUTINE_PATTERNS = ['backlog triage', 'gardener', '[gardener]']
+
+function isRoutineSession(s: SessionItem): boolean {
+  const goal = (s.goal ?? '').toLowerCase()
+  return ROUTINE_PATTERNS.some(p => goal.includes(p))
 }
 
 function handleKeyActivate(fn: () => void) {
@@ -37,8 +46,14 @@ function triageSessions(sessions: SessionItem[]): TriageResult {
   const critical: SessionItem[] = []
   const watch: SessionItem[] = []
   const running: SessionItem[] = []
+  const routine: SessionItem[] = []
 
   for (const s of sessions) {
+    if (isRoutineSession(s)) {
+      routine.push(s)
+      continue
+    }
+
     const isCritical =
       s.blocker_summary ||
       (s.top_attention && (s.top_attention.severity === 'bad' || s.top_attention.severity === 'critical'))
@@ -56,7 +71,13 @@ function triageSessions(sessions: SessionItem[]): TriageResult {
     else running.push(s)
   }
 
-  return { critical, watch, running }
+  return { critical, watch, running, routine }
+}
+
+function memberDisplay(names: string[] | undefined): string | null {
+  if (!names?.length) return null
+  if (names.length <= 3) return names.join(', ')
+  return `${names.slice(0, 3).join(', ')} +${names.length - 3}`
 }
 
 function CriticalCard({ session }: { session: SessionItem }) {
@@ -80,8 +101,7 @@ function CriticalCard({ session }: { session: SessionItem }) {
       <div class="triage-card__meta">
         ${session.member_names?.length ? html`
           <span class="triage-card__members">
-            ${session.member_names.slice(0, 4).join(', ')}
-            ${session.member_names.length > 4 ? ` +${session.member_names.length - 4}` : ''}
+            ${memberDisplay(session.member_names)}
           </span>
         ` : null}
         ${session.elapsed_sec ? html`
@@ -94,6 +114,10 @@ function CriticalCard({ session }: { session: SessionItem }) {
 
 function WatchCard({ session }: { session: SessionItem }) {
   const go = () => navigate('mission', { session_id: session.session_id })
+  const summary = (session as DashboardMissionSessionBrief).last_event_summary
+    ?? (session as DashboardMissionSessionBrief).communication_summary
+    ?? null
+
   return html`
     <div
       class="triage-card triage-card--watch"
@@ -103,6 +127,9 @@ function WatchCard({ session }: { session: SessionItem }) {
       onKeyDown=${handleKeyActivate(go)}
     >
       <strong class="triage-card__goal">${session.goal ?? session.session_id}</strong>
+      ${summary ? html`
+        <div class="triage-card__summary">${trimText(summary, 100)}</div>
+      ` : null}
       <div class="triage-card__meta">
         ${session.related_attention_count > 0 ? html`
           <span>주의 ${session.related_attention_count}건</span>
@@ -111,7 +138,7 @@ function WatchCard({ session }: { session: SessionItem }) {
           <span>${formatDuration(session.elapsed_sec)}</span>
         ` : null}
         ${session.member_names?.length ? html`
-          <span>${session.member_names.length}명</span>
+          <span>${memberDisplay(session.member_names)}</span>
         ` : null}
       </div>
     </div>
@@ -131,7 +158,7 @@ function RunningRow({ session }: { session: SessionItem }) {
       <span class="triage-row__goal">${trimText(session.goal, 60) ?? session.session_id}</span>
       <span class="triage-row__meta">
         ${session.elapsed_sec ? formatDuration(session.elapsed_sec) : ''}
-        ${session.member_names?.length ? ` / ${session.member_names.length}명` : ''}
+        ${session.member_names?.length ? ` / ${memberDisplay(session.member_names)}` : ''}
       </span>
     </div>
   `
@@ -142,7 +169,7 @@ export function SessionTriage({ sessions }: SessionTriageProps) {
     return html`<div class="session-triage" style="color: var(--text-muted)">활성 세션 없음</div>`
   }
 
-  const { critical, watch, running } = triageSessions(sessions)
+  const { critical, watch, running, routine } = triageSessions(sessions)
 
   return html`
     <div class="session-triage">
@@ -163,6 +190,15 @@ export function SessionTriage({ sessions }: SessionTriageProps) {
           <summary class="triage-running-label">순조로운 세션 ${running.length}개</summary>
           <div class="triage-running-list">
             ${running.map(s => html`<${RunningRow} session=${s} key=${s.session_id} />`)}
+          </div>
+        </details>
+      ` : null}
+
+      ${routine.length > 0 ? html`
+        <details class="triage-tier triage-tier--routine">
+          <summary class="triage-running-label triage-routine-label">자동 정리 세션 ${routine.length}개</summary>
+          <div class="triage-running-list">
+            ${routine.map(s => html`<${RunningRow} session=${s} key=${s.session_id} />`)}
           </div>
         </details>
       ` : null}

--- a/dashboard/src/components/overview/situation-banner.ts
+++ b/dashboard/src/components/overview/situation-banner.ts
@@ -1,6 +1,5 @@
-// MASC Dashboard — Situation Banner (Phase 1A)
-// Synthesizes a one-line situation summary from mission snapshot data.
-// Replaces raw number display with a human-readable sentence.
+// MASC Dashboard — Situation Banner
+// Synthesizes situation summary with reasons from mission snapshot data.
 
 import { html } from 'htm/preact'
 import { HealthBeacon } from './health-beacon'
@@ -12,35 +11,81 @@ import type {
 
 type SituationTone = 'ok' | 'warn' | 'bad'
 
+interface SituationReason {
+  category: 'blocker' | 'attention' | 'incident'
+  text: string
+  severity: SituationTone
+}
+
 interface SituationResult {
   text: string
   tone: SituationTone
+  reasons: SituationReason[]
 }
 
 type SessionItem = DashboardMissionSessionBrief | DashboardMissionSessionCard
 
 function synthesizeSituation(snap: DashboardMissionResponse | null): SituationResult {
-  if (!snap) return { text: '데이터 로딩 중...', tone: 'ok' }
+  if (!snap) return { text: '데이터 로딩 중...', tone: 'ok', reasons: [] }
 
   const sessions: SessionItem[] =
     snap.sessions.length > 0 ? snap.sessions : snap.session_briefs
   const total = sessions.length
   const blocked = sessions.filter(s => s.blocker_summary).length
-  const attention = snap.attention_queue.length
+  const attentionItems = snap.attention_queue ?? []
+  const attention = attentionItems.length
 
-  if (total === 0) return { text: '진행 중인 세션 없음.', tone: 'ok' }
+  const reasons: SituationReason[] = []
+
+  // Collect blocker reasons
+  for (const s of sessions) {
+    if (s.blocker_summary) {
+      reasons.push({
+        category: 'blocker',
+        text: `${s.goal ?? s.session_id}: ${s.blocker_summary.slice(0, 80)}`,
+        severity: 'bad',
+      })
+    }
+  }
+
+  // Collect attention reasons
+  for (const item of attentionItems.slice(0, 5)) {
+    reasons.push({
+      category: 'attention',
+      text: item.summary ?? item.kind ?? '주의 항목',
+      severity: item.severity === 'critical' || item.severity === 'bad' ? 'bad' : 'warn',
+    })
+  }
+
+  // Collect incident reasons
+  const incidents = snap.incidents ?? []
+  for (const inc of incidents.slice(0, 3)) {
+    reasons.push({
+      category: 'incident',
+      text: inc.summary ?? '인시던트',
+      severity: inc.severity === 'critical' ? 'bad' : 'warn',
+    })
+  }
+
+  if (total === 0) return { text: '진행 중인 세션 없음.', tone: 'ok', reasons }
 
   if (blocked === 0 && attention === 0) {
-    return { text: `${total}개 세션 순조롭게 진행 중.`, tone: 'ok' }
+    return { text: `${total}개 세션 순조롭게 진행 중.`, tone: 'ok', reasons }
   }
 
   if (blocked > 0) {
     const suffix = attention > 0 ? ` ${attention}건 주의 필요.` : ''
     const tone: SituationTone = blocked > total / 2 ? 'bad' : 'warn'
-    return { text: `${total}개 세션 중 ${blocked}개 막힘.${suffix}`, tone }
+    return { text: `${total}개 세션 중 ${blocked}개 막힘.${suffix}`, tone, reasons }
   }
 
-  return { text: `${total}개 세션 진행 중. ${attention}건 주의 항목.`, tone: 'warn' }
+  return { text: `${total}개 세션 진행 중. ${attention}건 주의 항목.`, tone: 'warn', reasons }
+}
+
+const CATEGORY_LABELS: Record<string, string> = {
+  blocker: '막힘',
+  attention: '주의',
+  incident: '인시던트',
 }
 
 interface SituationBannerProps {
@@ -49,12 +94,23 @@ interface SituationBannerProps {
 }
 
 export function SituationBanner({ snap, roomHealth }: SituationBannerProps) {
-  const { text, tone } = synthesizeSituation(snap)
+  const { text, tone, reasons } = synthesizeSituation(snap)
+  const showReasons = tone !== 'ok' && reasons.length > 0
 
   return html`
     <div class="situation-banner situation-banner--${tone}">
       <${HealthBeacon} health=${roomHealth ?? tone} />
       <span class="situation-banner__text">${text}</span>
     </div>
+    ${showReasons ? html`
+      <div class="situation-reasons">
+        ${reasons.map((r, i) => html`
+          <div class="situation-reason situation-reason--${r.severity}" key=${i}>
+            <span class="situation-reason__tag">${CATEGORY_LABELS[r.category] ?? r.category}</span>
+            <span class="situation-reason__text">${r.text}</span>
+          </div>
+        `)}
+      </div>
+    ` : null}
   `
 }

--- a/dashboard/src/config/navigation.ts
+++ b/dashboard/src/config/navigation.ts
@@ -36,8 +36,8 @@ export const DASHBOARD_SURFACES: DashboardNavGroup[] = [
     label: '에이전트',
     icon: '\uD83E\uDD16',
     description: '에이전트, 키퍼, 세션, 관계',
-    defaultTab: 'execution',
-    tabs: ['mission', 'execution', 'live', 'social'],
+    defaultTab: 'agent-roster',
+    tabs: ['agent-roster', 'keeper-roster', 'mission', 'execution', 'live', 'social'],
   },
   {
     id: 'work',
@@ -73,6 +73,20 @@ export const DASHBOARD_NAV_ITEMS: DashboardNavItem[] = [
     icon: '\uD83C\uDFE0',
     group: 'home',
     description: '에이전트 생태계 전체를 한눈에 보는 개요',
+  },
+  {
+    id: 'agent-roster',
+    label: '에이전트 목록',
+    icon: '\uD83D\uDC65',
+    group: 'agents',
+    description: '전체 에이전트를 스크롤하며 탐색하는 목록 화면',
+  },
+  {
+    id: 'keeper-roster',
+    label: '키퍼 목록',
+    icon: '\uD83D\uDEE1\uFE0F',
+    group: 'agents',
+    description: '전체 키퍼를 스크롤하며 탐색하는 목록 화면',
   },
   {
     id: 'mission',

--- a/dashboard/src/main.ts
+++ b/dashboard/src/main.ts
@@ -29,6 +29,7 @@ import './styles/live.css'
 import './styles/tool-metrics.css'
 import './styles/tools.css'
 import './styles/chat.css'
+import './styles/roster.css'
 
 import { render } from 'preact'
 import { html } from 'htm/preact'

--- a/dashboard/src/styles/global.css
+++ b/dashboard/src/styles/global.css
@@ -25,6 +25,19 @@
   --warm-lavender: #b8a4d6;
   --warm-sage: #8dbd97;
 
+  /* FF Character Sheet theme */
+  --ff-gold: #d4a94b;
+  --ff-gold-bright: #f0d080;
+  --ff-gold-dim: rgba(212, 169, 75, 0.25);
+  --ff-navy: #0d1526;
+  --ff-navy-light: #142040;
+  --ff-border: rgba(212, 169, 75, 0.35);
+  --ff-border-subtle: rgba(212, 169, 75, 0.12);
+  --ff-panel: rgba(13, 21, 38, 0.9);
+  --ff-hp: #3dcc5e;
+  --ff-mp: #4a9ef5;
+  --ff-xp: #d4a94b;
+
   /* Agent status (soft tones) */
   --agent-working: #7ae09a;
   --agent-idle: #b8cae8;

--- a/dashboard/src/styles/overview.css
+++ b/dashboard/src/styles/overview.css
@@ -13,18 +13,25 @@
 
 .overview-stat {
   padding: 12px 14px;
-  border: 1px solid var(--card-border);
-  border-radius: var(--radius-sm, 10px);
-  background: var(--card);
+  border: 1px solid var(--ff-border-subtle, rgba(212, 169, 75, 0.12));
+  border-radius: 6px;
+  background: var(--ff-panel, rgba(13, 21, 38, 0.9));
   display: grid;
   gap: 2px;
+  position: relative;
+  transition: border-color 0.2s;
+}
+
+.overview-stat:hover {
+  border-color: var(--ff-border, rgba(212, 169, 75, 0.35));
 }
 
 .overview-stat__label {
-  color: var(--text-muted);
-  font-size: 11px;
-  letter-spacing: 0.06em;
+  color: var(--ff-gold, #d4a94b);
+  font-size: 10px;
+  letter-spacing: 0.1em;
   text-transform: uppercase;
+  font-weight: 600;
 }
 
 .overview-stat__value {
@@ -42,10 +49,10 @@
   align-items: center;
   gap: 12px;
   padding: 14px 18px;
-  border-radius: var(--radius-sm, 10px);
-  background: var(--card);
-  border: 1px solid var(--card-border);
-  border-left: 3px solid var(--agent-working, #7ae09a);
+  border-radius: 6px;
+  background: var(--ff-panel, rgba(13, 21, 38, 0.9));
+  border: 1px solid var(--ff-border-subtle, rgba(212, 169, 75, 0.12));
+  border-left: 3px solid var(--ff-hp, #3dcc5e);
   font-size: 14px;
   font-weight: 500;
   color: var(--text-strong);
@@ -53,11 +60,11 @@
 }
 
 .situation-banner--ok {
-  border-left-color: var(--agent-working, #7ae09a);
+  border-left-color: var(--ff-hp, #3dcc5e);
 }
 
 .situation-banner--warn {
-  border-left-color: var(--agent-busy, #f0c060);
+  border-left-color: var(--ff-xp, #d4a94b);
 }
 
 .situation-banner--bad {

--- a/dashboard/src/styles/pixel-avatars.css
+++ b/dashboard/src/styles/pixel-avatars.css
@@ -28,6 +28,12 @@
   border-radius: 8px;
 }
 
+.pixel-avatar--xl {
+  width: 96px;
+  height: 96px;
+  border-radius: 12px;
+}
+
 .pixel-avatar__cell {
   /* Each cell's color is set via inline style */
 }

--- a/dashboard/src/styles/pixel-avatars.css
+++ b/dashboard/src/styles/pixel-avatars.css
@@ -31,7 +31,11 @@
 .pixel-avatar--xl {
   width: 96px;
   height: 96px;
-  border-radius: 12px;
+  border-radius: 8px;
+  box-shadow:
+    0 0 0 2px var(--ff-navy, #0d1526),
+    0 0 0 3px var(--ff-gold, #d4a94b),
+    0 2px 8px rgba(0, 0, 0, 0.4);
 }
 
 .pixel-avatar__cell {

--- a/dashboard/src/styles/roster.css
+++ b/dashboard/src/styles/roster.css
@@ -1,4 +1,10 @@
-/* MASC Dashboard — Roster Pages (Agent & Keeper) */
+/* MASC Dashboard — Roster Pages (FF Character Sheet Theme) */
+
+/* ============================================
+   Roster Page — Full-page entity list
+   FF-inspired: navy panels, gold borders,
+   ornamental corners, RPG stat blocks
+   ============================================ */
 
 .roster-page {
   padding: var(--space-lg, 24px);
@@ -12,8 +18,10 @@
 .roster-title {
   font-size: 20px;
   font-weight: 600;
-  color: rgba(255, 255, 255, 0.9);
+  color: var(--ff-gold-bright, #f0d080);
   margin: 0 0 var(--space-md, 16px) 0;
+  letter-spacing: 0.5px;
+  text-shadow: 0 1px 4px rgba(212, 169, 75, 0.2);
 }
 
 .roster-controls {
@@ -25,16 +33,23 @@
 
 .roster-search {
   padding: 6px 12px;
-  border-radius: 6px;
-  border: 1px solid rgba(255, 255, 255, 0.15);
-  background: rgba(255, 255, 255, 0.05);
+  border-radius: 4px;
+  border: 1px solid var(--ff-border-subtle, rgba(212, 169, 75, 0.12));
+  background: var(--ff-navy, #0d1526);
   color: rgba(255, 255, 255, 0.9);
   font-size: 13px;
   width: 200px;
+  transition: border-color 0.2s;
+}
+
+.roster-search:focus {
+  outline: none;
+  border-color: var(--ff-gold, #d4a94b);
+  box-shadow: 0 0 0 2px var(--ff-gold-dim, rgba(212, 169, 75, 0.25));
 }
 
 .roster-search::placeholder {
-  color: rgba(255, 255, 255, 0.35);
+  color: rgba(255, 255, 255, 0.25);
 }
 
 .roster-filters {
@@ -44,52 +59,99 @@
 
 .roster-filter-btn {
   padding: 4px 10px;
-  border-radius: 4px;
-  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 3px;
+  border: 1px solid var(--ff-border-subtle, rgba(212, 169, 75, 0.12));
   background: transparent;
-  color: rgba(255, 255, 255, 0.5);
+  color: rgba(255, 255, 255, 0.45);
   font-size: 12px;
   cursor: pointer;
   transition: all 0.15s;
 }
 
 .roster-filter-btn:hover {
-  background: rgba(255, 255, 255, 0.05);
-  color: rgba(255, 255, 255, 0.7);
+  background: var(--ff-gold-dim, rgba(212, 169, 75, 0.25));
+  color: var(--ff-gold-bright, #f0d080);
+  border-color: var(--ff-border, rgba(212, 169, 75, 0.35));
 }
 
 .roster-filter-btn.active {
-  background: rgba(255, 255, 255, 0.1);
-  color: rgba(255, 255, 255, 0.9);
-  border-color: rgba(255, 255, 255, 0.25);
+  background: var(--ff-gold-dim, rgba(212, 169, 75, 0.25));
+  color: var(--ff-gold-bright, #f0d080);
+  border-color: var(--ff-gold, #d4a94b);
 }
 
-/* Roster List */
+/* ============================================
+   Roster Cards — FF Character Sheet style
+   ============================================ */
 
 .roster-list {
   display: flex;
   flex-direction: column;
-  gap: var(--space-sm, 8px);
+  gap: 10px;
 }
 
 .roster-card {
   display: flex;
   gap: var(--space-md, 16px);
-  padding: var(--space-md, 16px);
-  background: rgba(255, 255, 255, 0.03);
-  border: 1px solid rgba(255, 255, 255, 0.08);
-  border-radius: 10px;
+  padding: 16px 20px;
+  background: var(--ff-panel, rgba(13, 21, 38, 0.9));
+  border: 1px solid var(--ff-border, rgba(212, 169, 75, 0.35));
+  border-radius: 6px;
   cursor: pointer;
-  transition: background 0.15s, border-color 0.15s;
+  transition: all 0.2s;
+  position: relative;
+}
+
+/* FF corner ornaments */
+.roster-card::before,
+.roster-card::after {
+  content: '';
+  position: absolute;
+  width: 8px;
+  height: 8px;
+  border-color: var(--ff-gold, #d4a94b);
+  opacity: 0.5;
+  transition: opacity 0.2s;
+}
+
+.roster-card::before {
+  top: -1px;
+  left: -1px;
+  border-top: 2px solid;
+  border-left: 2px solid;
+}
+
+.roster-card::after {
+  bottom: -1px;
+  right: -1px;
+  border-bottom: 2px solid;
+  border-right: 2px solid;
 }
 
 .roster-card:hover {
-  background: rgba(255, 255, 255, 0.06);
-  border-color: rgba(255, 255, 255, 0.15);
+  background: var(--ff-navy-light, #142040);
+  border-color: var(--ff-gold, #d4a94b);
+  box-shadow: 0 0 12px rgba(212, 169, 75, 0.1);
 }
 
+.roster-card:hover::before,
+.roster-card:hover::after {
+  opacity: 1;
+}
+
+/* Avatar frame — pixel art portrait */
 .roster-card__avatar {
   flex-shrink: 0;
+  position: relative;
+}
+
+.roster-card__avatar::after {
+  content: '';
+  position: absolute;
+  inset: -3px;
+  border: 1px solid var(--ff-border-subtle, rgba(212, 169, 75, 0.12));
+  border-radius: 14px;
+  pointer-events: none;
 }
 
 .roster-card__info {
@@ -97,7 +159,7 @@
   min-width: 0;
   display: flex;
   flex-direction: column;
-  gap: 4px;
+  gap: 5px;
   justify-content: center;
 }
 
@@ -109,19 +171,21 @@
 
 .roster-card__name {
   font-size: 15px;
-  color: rgba(255, 255, 255, 0.9);
+  color: var(--ff-gold-bright, #f0d080);
+  font-weight: 600;
+  letter-spacing: 0.3px;
 }
 
 .roster-card__work {
   font-size: 13px;
-  color: rgba(255, 255, 255, 0.6);
+  color: rgba(255, 255, 255, 0.55);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
 
 .roster-card__work--empty {
-  color: rgba(255, 255, 255, 0.25);
+  color: rgba(255, 255, 255, 0.2);
   font-style: italic;
 }
 
@@ -129,56 +193,70 @@
   display: flex;
   gap: var(--space-sm, 8px);
   font-size: 11px;
-  color: rgba(255, 255, 255, 0.35);
+  color: rgba(255, 255, 255, 0.3);
 }
 
 .roster-card__model {
   padding: 1px 6px;
-  background: rgba(255, 255, 255, 0.06);
+  background: rgba(212, 169, 75, 0.08);
+  border: 1px solid var(--ff-border-subtle, rgba(212, 169, 75, 0.12));
   border-radius: 3px;
+  color: rgba(212, 169, 75, 0.6);
 }
 
-/* Status badges */
+/* ============================================
+   Status Badges — RPG class labels
+   ============================================ */
 
 .roster-badge {
-  font-size: 11px;
+  font-size: 10px;
   padding: 2px 8px;
-  border-radius: 4px;
-  font-weight: 500;
+  border-radius: 3px;
+  font-weight: 600;
+  letter-spacing: 0.5px;
+  text-transform: uppercase;
 }
 
 .roster-badge--active {
-  background: rgba(122, 224, 154, 0.15);
-  color: #7ae09a;
+  background: rgba(61, 204, 94, 0.12);
+  color: var(--ff-hp, #3dcc5e);
+  border: 1px solid rgba(61, 204, 94, 0.25);
 }
 
 .roster-badge--idle {
-  background: rgba(240, 192, 96, 0.15);
-  color: #f0c060;
+  background: rgba(212, 169, 75, 0.1);
+  color: var(--ff-xp, #d4a94b);
+  border: 1px solid rgba(212, 169, 75, 0.2);
 }
 
 .roster-badge--offline {
-  background: rgba(168, 168, 168, 0.1);
-  color: #888;
+  background: rgba(100, 100, 120, 0.1);
+  color: #667;
+  border: 1px solid rgba(100, 100, 120, 0.15);
 }
 
 .roster-empty {
   padding: var(--space-xl, 32px);
   text-align: center;
-  color: rgba(255, 255, 255, 0.3);
+  color: rgba(255, 255, 255, 0.2);
   font-size: 14px;
+  border: 1px dashed var(--ff-border-subtle, rgba(212, 169, 75, 0.12));
+  border-radius: 6px;
 }
 
-/* Keeper Roster specific */
+/* ============================================
+   Keeper Roster — HP/MP bar style
+   ============================================ */
 
 .keeper-roster-card {
   flex-direction: column;
+  padding: 14px 20px;
 }
 
 .keeper-roster__main {
   display: flex;
   flex-direction: column;
-  gap: 6px;
+  gap: 8px;
 }
 
 .keeper-roster__header {
@@ -188,42 +266,50 @@
 }
 
 .keeper-roster__gen {
-  font-size: 11px;
-  padding: 1px 6px;
+  font-size: 10px;
+  padding: 2px 7px;
   border-radius: 3px;
-  background: rgba(122, 184, 224, 0.15);
-  color: #7ab8e0;
-  font-weight: 600;
+  background: rgba(74, 158, 245, 0.12);
+  color: var(--ff-mp, #4a9ef5);
+  border: 1px solid rgba(74, 158, 245, 0.2);
+  font-weight: 700;
+  letter-spacing: 0.5px;
 }
 
+/* Context pressure — FF HP bar */
 .keeper-roster__pressure {
   display: flex;
   align-items: center;
-  gap: var(--space-sm, 8px);
+  gap: 10px;
 }
 
 .keeper-roster__pressure-track {
   flex: 1;
-  height: 8px;
-  background: rgba(255, 255, 255, 0.06);
-  border-radius: 4px;
+  height: 10px;
+  background: rgba(255, 255, 255, 0.04);
+  border-radius: 2px;
   overflow: hidden;
+  border: 1px solid var(--ff-border-subtle, rgba(212, 169, 75, 0.12));
 }
 
 .keeper-roster__pressure-bar {
   height: 100%;
-  border-radius: 4px;
+  border-radius: 1px;
   transition: width 0.3s ease;
+  box-shadow: 0 0 4px rgba(0, 0, 0, 0.3);
 }
 
 .keeper-roster__pressure-label {
-  font-size: 12px;
-  color: rgba(255, 255, 255, 0.5);
+  font-size: 11px;
+  color: rgba(255, 255, 255, 0.45);
   white-space: nowrap;
   min-width: 60px;
+  font-variant-numeric: tabular-nums;
 }
 
-/* Situation reasons */
+/* ============================================
+   Situation Reasons (WHY panel)
+   ============================================ */
 
 .situation-reasons {
   display: flex;
@@ -231,6 +317,7 @@
   gap: 4px;
   padding: 6px var(--space-md, 16px);
   margin-bottom: var(--space-sm, 8px);
+  border-left: 2px solid var(--ff-border, rgba(212, 169, 75, 0.35));
 }
 
 .situation-reason {
@@ -238,7 +325,7 @@
   align-items: center;
   gap: var(--space-sm, 8px);
   font-size: 12px;
-  color: rgba(255, 255, 255, 0.6);
+  color: rgba(255, 255, 255, 0.55);
 }
 
 .situation-reason--bad {
@@ -246,15 +333,19 @@
 }
 
 .situation-reason--warn {
-  color: rgba(245, 158, 11, 0.9);
+  color: var(--ff-gold, #d4a94b);
 }
 
 .situation-reason__tag {
-  font-size: 10px;
-  padding: 1px 5px;
-  border-radius: 3px;
-  background: rgba(255, 255, 255, 0.06);
+  font-size: 9px;
+  padding: 1px 6px;
+  border-radius: 2px;
+  background: rgba(212, 169, 75, 0.08);
+  border: 1px solid var(--ff-border-subtle, rgba(212, 169, 75, 0.12));
   white-space: nowrap;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  font-weight: 600;
 }
 
 .situation-reason__text {
@@ -263,7 +354,9 @@
   white-space: nowrap;
 }
 
-/* Overview section header with link */
+/* ============================================
+   Overview Enhancements
+   ============================================ */
 
 .overview-section-header {
   display: flex;
@@ -273,37 +366,38 @@
 
 .overview-section-link {
   font-size: 12px;
-  color: rgba(122, 184, 224, 0.7);
+  color: var(--ff-gold, #d4a94b);
   cursor: pointer;
   transition: color 0.15s;
+  opacity: 0.6;
 }
 
 .overview-section-link:hover {
-  color: rgba(122, 184, 224, 1);
+  color: var(--ff-gold-bright, #f0d080);
+  opacity: 1;
 }
-
-/* Task source indicator */
 
 .overview-stat__source {
   font-size: 10px;
-  color: rgba(255, 255, 255, 0.25);
+  color: rgba(212, 169, 75, 0.35);
   margin-left: 4px;
 }
 
-/* Attention badge in header */
-
+/* Attention badge — gold warning */
 .attention-badge {
-  background: rgba(245, 158, 11, 0.2);
-  color: #f59e0b;
-  border-radius: 4px;
+  background: rgba(212, 169, 75, 0.15);
+  color: var(--ff-gold, #d4a94b);
+  border: 1px solid rgba(212, 169, 75, 0.3);
+  border-radius: 3px;
   padding: 2px 8px;
+  font-weight: 600;
+  font-size: 11px;
 }
 
-/* Session triage: summary line + routine tier */
-
+/* Session triage additions */
 .triage-card__summary {
   font-size: 12px;
-  color: rgba(255, 255, 255, 0.45);
+  color: rgba(255, 255, 255, 0.4);
   margin: 2px 0;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -311,23 +405,22 @@
 }
 
 .triage-routine-label {
-  color: rgba(255, 255, 255, 0.3);
+  color: rgba(255, 255, 255, 0.25);
 }
 
-/* Pressure bar colors */
-
+/* Pressure bar colors — FF HP gradient */
 .pressure--ok {
-  background: #22c55e;
+  background: linear-gradient(90deg, #1a9c3a, #3dcc5e);
 }
 
 .pressure--amber {
-  background: #f59e0b;
+  background: linear-gradient(90deg, #c98a0a, #f5c542);
 }
 
 .pressure--orange {
-  background: #f97316;
+  background: linear-gradient(90deg, #c65d0a, #f97316);
 }
 
 .pressure--red {
-  background: #ef4444;
+  background: linear-gradient(90deg, #b91c1c, #ef4444);
 }

--- a/dashboard/src/styles/roster.css
+++ b/dashboard/src/styles/roster.css
@@ -1,0 +1,333 @@
+/* MASC Dashboard — Roster Pages (Agent & Keeper) */
+
+.roster-page {
+  padding: var(--space-lg, 24px);
+  max-width: 960px;
+}
+
+.roster-header {
+  margin-bottom: var(--space-lg, 24px);
+}
+
+.roster-title {
+  font-size: 20px;
+  font-weight: 600;
+  color: rgba(255, 255, 255, 0.9);
+  margin: 0 0 var(--space-md, 16px) 0;
+}
+
+.roster-controls {
+  display: flex;
+  gap: var(--space-md, 16px);
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.roster-search {
+  padding: 6px 12px;
+  border-radius: 6px;
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  background: rgba(255, 255, 255, 0.05);
+  color: rgba(255, 255, 255, 0.9);
+  font-size: 13px;
+  width: 200px;
+}
+
+.roster-search::placeholder {
+  color: rgba(255, 255, 255, 0.35);
+}
+
+.roster-filters {
+  display: flex;
+  gap: 4px;
+}
+
+.roster-filter-btn {
+  padding: 4px 10px;
+  border-radius: 4px;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  background: transparent;
+  color: rgba(255, 255, 255, 0.5);
+  font-size: 12px;
+  cursor: pointer;
+  transition: all 0.15s;
+}
+
+.roster-filter-btn:hover {
+  background: rgba(255, 255, 255, 0.05);
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.roster-filter-btn.active {
+  background: rgba(255, 255, 255, 0.1);
+  color: rgba(255, 255, 255, 0.9);
+  border-color: rgba(255, 255, 255, 0.25);
+}
+
+/* Roster List */
+
+.roster-list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-sm, 8px);
+}
+
+.roster-card {
+  display: flex;
+  gap: var(--space-md, 16px);
+  padding: var(--space-md, 16px);
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 10px;
+  cursor: pointer;
+  transition: background 0.15s, border-color 0.15s;
+}
+
+.roster-card:hover {
+  background: rgba(255, 255, 255, 0.06);
+  border-color: rgba(255, 255, 255, 0.15);
+}
+
+.roster-card__avatar {
+  flex-shrink: 0;
+}
+
+.roster-card__info {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  justify-content: center;
+}
+
+.roster-card__header {
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm, 8px);
+}
+
+.roster-card__name {
+  font-size: 15px;
+  color: rgba(255, 255, 255, 0.9);
+}
+
+.roster-card__work {
+  font-size: 13px;
+  color: rgba(255, 255, 255, 0.6);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.roster-card__work--empty {
+  color: rgba(255, 255, 255, 0.25);
+  font-style: italic;
+}
+
+.roster-card__meta {
+  display: flex;
+  gap: var(--space-sm, 8px);
+  font-size: 11px;
+  color: rgba(255, 255, 255, 0.35);
+}
+
+.roster-card__model {
+  padding: 1px 6px;
+  background: rgba(255, 255, 255, 0.06);
+  border-radius: 3px;
+}
+
+/* Status badges */
+
+.roster-badge {
+  font-size: 11px;
+  padding: 2px 8px;
+  border-radius: 4px;
+  font-weight: 500;
+}
+
+.roster-badge--active {
+  background: rgba(122, 224, 154, 0.15);
+  color: #7ae09a;
+}
+
+.roster-badge--idle {
+  background: rgba(240, 192, 96, 0.15);
+  color: #f0c060;
+}
+
+.roster-badge--offline {
+  background: rgba(168, 168, 168, 0.1);
+  color: #888;
+}
+
+.roster-empty {
+  padding: var(--space-xl, 32px);
+  text-align: center;
+  color: rgba(255, 255, 255, 0.3);
+  font-size: 14px;
+}
+
+/* Keeper Roster specific */
+
+.keeper-roster-card {
+  flex-direction: column;
+}
+
+.keeper-roster__main {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.keeper-roster__header {
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm, 8px);
+}
+
+.keeper-roster__gen {
+  font-size: 11px;
+  padding: 1px 6px;
+  border-radius: 3px;
+  background: rgba(122, 184, 224, 0.15);
+  color: #7ab8e0;
+  font-weight: 600;
+}
+
+.keeper-roster__pressure {
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm, 8px);
+}
+
+.keeper-roster__pressure-track {
+  flex: 1;
+  height: 8px;
+  background: rgba(255, 255, 255, 0.06);
+  border-radius: 4px;
+  overflow: hidden;
+}
+
+.keeper-roster__pressure-bar {
+  height: 100%;
+  border-radius: 4px;
+  transition: width 0.3s ease;
+}
+
+.keeper-roster__pressure-label {
+  font-size: 12px;
+  color: rgba(255, 255, 255, 0.5);
+  white-space: nowrap;
+  min-width: 60px;
+}
+
+/* Situation reasons */
+
+.situation-reasons {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 6px var(--space-md, 16px);
+  margin-bottom: var(--space-sm, 8px);
+}
+
+.situation-reason {
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm, 8px);
+  font-size: 12px;
+  color: rgba(255, 255, 255, 0.6);
+}
+
+.situation-reason--bad {
+  color: rgba(239, 68, 68, 0.9);
+}
+
+.situation-reason--warn {
+  color: rgba(245, 158, 11, 0.9);
+}
+
+.situation-reason__tag {
+  font-size: 10px;
+  padding: 1px 5px;
+  border-radius: 3px;
+  background: rgba(255, 255, 255, 0.06);
+  white-space: nowrap;
+}
+
+.situation-reason__text {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* Overview section header with link */
+
+.overview-section-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.overview-section-link {
+  font-size: 12px;
+  color: rgba(122, 184, 224, 0.7);
+  cursor: pointer;
+  transition: color 0.15s;
+}
+
+.overview-section-link:hover {
+  color: rgba(122, 184, 224, 1);
+}
+
+/* Task source indicator */
+
+.overview-stat__source {
+  font-size: 10px;
+  color: rgba(255, 255, 255, 0.25);
+  margin-left: 4px;
+}
+
+/* Attention badge in header */
+
+.attention-badge {
+  background: rgba(245, 158, 11, 0.2);
+  color: #f59e0b;
+  border-radius: 4px;
+  padding: 2px 8px;
+}
+
+/* Session triage: summary line + routine tier */
+
+.triage-card__summary {
+  font-size: 12px;
+  color: rgba(255, 255, 255, 0.45);
+  margin: 2px 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.triage-routine-label {
+  color: rgba(255, 255, 255, 0.3);
+}
+
+/* Pressure bar colors */
+
+.pressure--ok {
+  background: #22c55e;
+}
+
+.pressure--amber {
+  background: #f59e0b;
+}
+
+.pressure--orange {
+  background: #f97316;
+}
+
+.pressure--red {
+  background: #ef4444;
+}

--- a/dashboard/src/types/sse.ts
+++ b/dashboard/src/types/sse.ts
@@ -157,6 +157,8 @@ export type TabId =
   | 'command'
   | 'lab'
   | 'social'
+  | 'agent-roster'
+  | 'keeper-roster'
 
 export const VALID_TABS: TabId[] = [
   'home',
@@ -172,6 +174,8 @@ export const VALID_TABS: TabId[] = [
   'command',
   'lab',
   'social',
+  'agent-roster',
+  'keeper-roster',
 ]
 
 // --- Social Graph types ---


### PR DESCRIPTION
## Summary

- **"이벤트 N" → "주의 N건"**: SSE 이벤트 카운터(무의미)를 attention queue 길이(의미 있는 수치)로 교체. 0이면 숨김, 클릭 시 홈 이동.
- **SituationBanner 이유 표시**: warn/bad 상태일 때 blocker/attention/incident별 이유를 배너 아래에 펼쳐서 표시. WHY가 보인다.
- **Agent Roster 전용 페이지** (`#agent-roster`): 96px 대형 픽셀 아바타 + 이름/상태/작업/시간. 상태별 필터 + 텍스트 검색.
- **Keeper Roster 전용 페이지** (`#keeper-roster`): 넓은 컨텍스트 바 + 세대 + 상태. context pressure 순 정렬.
- **세션 카드 개선**: Gardener/backlog 세션을 routine tier로 자동 접기. WatchCard에 `last_event_summary` 표시. "N명" → 이름 나열.
- **홈 페이지 정리**: ProviderGauge, AgentActivityPanel, nav-strip 제거 (226줄 → 144줄). 에이전트/키퍼 섹션에 "전체 보기 →" 링크.

## Files Changed (13)

**New**: `agent-roster.ts`, `keeper-roster.ts`, `roster.css`
**Modified**: `dashboard-shell.ts`, `overview.ts`, `situation-banner.ts`, `quick-stats.ts`, `session-triage.ts`, `agent-avatar.ts`, `navigation.ts`, `pixel-avatars.css`, `sse.ts`, `main.ts`

## Test plan

- [ ] `cd dashboard && npm run dev` → localhost:5173 에서 HMR 확인
- [ ] 홈: 시스템 상태가 warn일 때 이유 목록이 배너 아래에 표시되는지 확인
- [ ] 홈: 헤더의 "주의 N건"이 attention queue 수와 일치하는지 확인
- [ ] 홈: Gardener 세션이 "자동 정리 세션 N개"로 접혀 있는지 확인
- [ ] `#agent-roster`: 96px 아바타 + 필터/검색 동작 확인
- [ ] `#keeper-roster`: 컨텍스트 바 + 세대 표시 확인
- [ ] 에이전트/키퍼 "전체 보기 →" 클릭 시 roster 페이지 이동 확인
- [ ] 사이드바에서 에이전트 클릭 시 agent-roster가 기본 탭으로 열리는지 확인
- [ ] `npm run build` 에러 없음

Generated with [Claude Code](https://claude.com/claude-code)