### PR TITLE
feat: tool discovery — 363 tools → ~80 default + masc_discover_tools

### DIFF
--- a/lib/mcp_server_eio_protocol.ml
+++ b/lib/mcp_server_eio_protocol.ml
@@ -423,7 +423,19 @@ let handle_request
                        match TP.requested_tool_list_params req.params with
                        | Error msg -> make_error ~id (-32602) msg
                        | Ok { names; include_hidden; include_deprecated; include_usage; mode; tier; cursor } ->
-                           handle_list_tools_eio ~profile ?names ~include_hidden
+                           (* Default to room config mode instead of Full.
+                              Agents see only tools enabled for the current mode
+                              (e.g. ~80 in Coding). Use masc_discover_tools or
+                              mode=full param to access the full catalog. *)
+                           let list_profile =
+                             match mode with
+                             | Some _ -> profile  (* explicit mode param: respect it *)
+                             | None ->
+                               let room_path = Room.masc_dir state.Mcp_server.room_config in
+                               let config = Config.load room_path in
+                               Role_filtered config.Config.mode
+                           in
+                           handle_list_tools_eio ~profile:list_profile ?names ~include_hidden
                              ~include_deprecated ~include_usage ?mode ?tier ?cursor
                              state id)
                    | "tools/call" ->
@@ -431,7 +443,9 @@ let handle_request
                        | Some params ->
                            (try
                              let name = Yojson.Safe.Util.(params |> member "name" |> to_string) in
-                             if not (TP.tool_allowed_in_profile state profile name) then
+                             (* tools/call uses Full profile so that discovered tools
+                               (not in the default tools/list) remain callable. *)
+                            if not (TP.tool_allowed_in_profile state Full name) then
                                make_error ~id (-32601)
                                  (Printf.sprintf
                                     "Tool '%s' is not available on this MCP endpoint."

--- a/lib/mcp_server_eio_protocol.ml
+++ b/lib/mcp_server_eio_protocol.ml
@@ -428,12 +428,16 @@ let handle_request
                               (e.g. ~80 in Coding). Use masc_discover_tools or
                               mode=full param to access the full catalog. *)
                            let list_profile =
-                             match mode with
-                             | Some _ -> profile  (* explicit mode param: respect it *)
-                             | None ->
-                               let room_path = Room.masc_dir state.Mcp_server.room_config in
-                               let config = Config.load room_path in
-                               Role_filtered config.Config.mode
+                             match profile with
+                             | Managed_agent | Operator_remote ->
+                               profile  (* preserve non-Full profiles unconditionally *)
+                             | Full | Role_filtered _ ->
+                               (match mode with
+                                | Some _ -> profile  (* explicit mode param: respect it *)
+                                | None ->
+                                  let room_path = Room.masc_dir state.Mcp_server.room_config in
+                                  let config = Config.load room_path in
+                                  Role_filtered config.Config.mode)
                            in
                            handle_list_tools_eio ~profile:list_profile ?names ~include_hidden
                              ~include_deprecated ~include_usage ?mode ?tier ?cursor
@@ -443,9 +447,13 @@ let handle_request
                        | Some params ->
                            (try
                              let name = Yojson.Safe.Util.(params |> member "name" |> to_string) in
-                             (* tools/call uses Full profile so that discovered tools
-                               (not in the default tools/list) remain callable. *)
-                            if not (TP.tool_allowed_in_profile state Full name) then
+                             (* tools/call: allow discovered tools for local profiles,
+                                but preserve restrictions for remote/operator profiles. *)
+                             let call_profile = match profile with
+                               | Operator_remote -> profile
+                               | _ -> Full
+                             in
+                            if not (TP.tool_allowed_in_profile state call_profile name) then
                                make_error ~id (-32601)
                                  (Printf.sprintf
                                     "Tool '%s' is not available on this MCP endpoint."

--- a/lib/mode.ml
+++ b/lib/mode.ml
@@ -150,7 +150,8 @@ let tool_category tool_name =
 
   (* ── Core_Room: room entry/exit, essential coordination ── *)
   | "masc_start" | "masc_set_room" | "masc_init" | "masc_join" | "masc_leave"
-  | "masc_room_create" | "masc_room_enter" | "masc_rooms_list" -> Core_Room
+  | "masc_room_create" | "masc_room_enter" | "masc_rooms_list"
+  | "masc_discover_tools" -> Core_Room
 
   (* ── Core_Task: task lifecycle ── *)
   | "masc_add_task" | "masc_batch_add_tasks"

--- a/lib/tool_inline_dispatch.ml
+++ b/lib/tool_inline_dispatch.ml
@@ -61,8 +61,6 @@ let safe_exec args =
   | Unix.WEXITED 0, output -> (true, output)
   | _, output -> (false, if output = "" then "Command failed" else output)
 
-let schemas = Tool_schemas_inline.schemas
-
 (** Dispatch a tool call.
     Returns [Some (success, message)] if the tool name is handled,
     [None] if the tool name is not recognized by this module. *)
@@ -933,5 +931,39 @@ Call masc_listen again to continue listening.
       ] in
       Some (true, Yojson.Safe.pretty_to_string response)
 
+
+  | "masc_discover_tools" ->
+      let query = String.lowercase_ascii (arg_get_string "query" "") in
+      let limit = arg_get_int "limit" 20 in
+      if query = "" then
+        Some (false, "query is required")
+      else
+        let all_schemas = Config.visible_tool_schemas ~include_hidden:true ~include_deprecated:false () in
+        let words = String.split_on_char ' ' query |> List.filter (fun w -> String.length w > 0) in
+        let matches =
+          all_schemas
+          |> List.filter (fun (schema : Types.tool_schema) ->
+                 let name_l = String.lowercase_ascii schema.name in
+                 let desc_l = String.lowercase_ascii schema.description in
+                 let haystack = name_l ^ " " ^ desc_l in
+                 words |> List.exists (fun w ->
+                   try ignore (Str.search_forward (Str.regexp_string w) haystack 0); true
+                   with Not_found -> false))
+          |> List.filteri (fun i _ -> i < limit)
+        in
+        let results = List.map (fun (schema : Types.tool_schema) ->
+          `Assoc [
+            ("name", `String schema.name);
+            ("description", `String schema.description);
+            ("category", `String (Mode.category_to_string (Mode.tool_category schema.name)));
+            ("tier", `String (Tool_catalog.tier_to_string (Tool_catalog.tool_tier schema.name)));
+          ]
+        ) matches in
+        Some (true, Yojson.Safe.to_string (`Assoc [
+          ("query", `String query);
+          ("count", `Int (List.length results));
+          ("tools", `List results);
+          ("hint", `String "These tools are callable via tools/call even if not in the default tools/list.");
+        ]))
 
   | _ -> Tool_inline_dispatch_extra.dispatch ~config ~agent_name ~arguments ~state ~sw ~clock ~name

--- a/lib/tool_schemas_core_01.ml
+++ b/lib/tool_schemas_core_01.ml
@@ -623,4 +623,22 @@ Returns matched memories with relevance scores, sorted by relevance.|};
       ("required", `List [`String "query"]);
     ];
   };
+  {
+    name = "masc_discover_tools";
+    description = "Search the full MASC tool catalog by keyword. The default tools/list shows only tools for the current mode. Use this to find specialized tools (TRPG, gardener, perpetual, governance, etc.) that are not in the default list but still callable via tools/call.";
+    input_schema = `Assoc [
+      ("type", `String "object");
+      ("properties", `Assoc [
+        ("query", `Assoc [
+          ("type", `String "string");
+          ("description", `String "Search keyword (matches tool name and description). Examples: 'trpg', 'gardener', 'perpetual', 'vote', 'encrypt'");
+        ]);
+        ("limit", `Assoc [
+          ("type", `String "integer");
+          ("description", `String "Max results (default: 20)");
+        ]);
+      ]);
+      ("required", `List [`String "query"]);
+    ];
+  };
 ]


### PR DESCRIPTION
## Summary
에이전트가 `tools/list`로 363개 스키마를 받는 문제 해결. Claude Agent SDK의 deferred-tools 패턴 적용.

## Changes
1. **tools/list 기본 = config mode** — Full(363) → Coding(~80). `mode=full` 파라미터로 전체 접근 가능
2. **tools/call = 항상 Full** — discover된 도구도 호출 가능
3. **masc_discover_tools** — 키워드로 전체 카탈로그 검색. Core_Room 카테고리 (모든 모드에서 사용 가능)

## 에이전트 경험
```
Before: tools/list → 363 schemas (LLM이 전부 읽어야 함)
After:  tools/list → ~80 schemas + masc_discover_tools("trpg") → 필요한 것만
```

## Test plan
- [x] `dune build` 통과
- [ ] 서버 재시작 후 `tools/list` 기본 응답 도구 수 확인 (<100)
- [ ] `masc_discover_tools(query="trpg")` → TRPG 도구 반환
- [ ] discover된 도구를 `tools/call`로 호출 → 성공
- [ ] `mode=full` 파라미터로 전체 목록 접근 가능

🤖 Generated with [Claude Code](https://claude.com/claude-code)