### PR TITLE
fix(dashboard): execution queue UX — active/terminal 분리

### DIFF
--- a/dashboard/src/components/agents.ts
+++ b/dashboard/src/components/agents.ts
@@ -44,6 +44,12 @@ const selectedQueueId = signal<string | null>(null)
 const selectedSessionId = signal<string | null>(null)
 const selectedOperationId = signal<string | null>(null)
 
+const TERMINAL_STATUSES = new Set(['completed', 'interrupted', 'failed', 'cancelled'])
+
+function isTerminalStatus(status?: string | null): boolean {
+  return TERMINAL_STATUSES.has((status ?? '').trim().toLowerCase())
+}
+
 function toneClass(tone?: string | null): string {
   if (tone === 'bad' || tone === 'critical' || tone === 'offline') return 'bad'
   if (tone === 'warn' || tone === 'paused' || tone === 'blocked' || tone === 'interrupted') return 'warn'
@@ -64,8 +70,14 @@ function statusLabel(value?: string | null): string {
       return '일시정지'
     case 'blocked':
       return '막힘'
+    case 'completed':
+      return '완료'
     case 'interrupted':
       return '중단됨'
+    case 'failed':
+      return '실패'
+    case 'cancelled':
+      return '취소됨'
     case 'warn':
       return '주의'
     case 'bad':
@@ -234,9 +246,10 @@ function HandoffButtons({
 }
 
 function QueueCard({ item, selected }: { item: DashboardExecutionQueueItem; selected: boolean }) {
+  const terminal = isTerminalStatus(item.status)
   return html`
     <button
-      class="mission-card-select ${selected ? 'active' : ''}"
+      class="mission-card-select ${selected ? 'active' : ''} ${terminal ? 'terminated' : ''}"
       data-testid="execution.queue-card"
       onClick=${() => {
         selectedQueueId.value = selected ? null : item.id
@@ -249,25 +262,56 @@ function QueueCard({ item, selected }: { item: DashboardExecutionQueueItem; sele
           <div class="mission-card-target">${item.kind === 'session' ? item.target_id : item.linked_session_id ?? item.target_id}</div>
           <div class="mission-card-title">${item.summary}</div>
         </div>
-        <span class="command-chip ${toneClass(item.severity)}">${statusLabel(item.status ?? item.severity)}</span>
+        <span class="command-chip ${terminal ? 'muted' : toneClass(item.severity)}">${statusLabel(item.status ?? item.severity)}</span>
       </div>
       <div class="mission-card-meta">
         <span>${queueKindLabel(item.kind)}</span>
         ${item.linked_operation_id ? html`<span>연결 작전 · ${item.linked_operation_id}</span>` : null}
         ${item.last_seen_at ? html`<span><${TimeAgo} timestamp=${item.last_seen_at} /></span>` : null}
       </div>
-      <${HandoffButtons} intervene=${item.intervene_handoff} command=${item.command_handoff} />
+      <${HandoffButtons}
+        intervene=${terminal ? null : item.intervene_handoff}
+        command=${item.command_handoff}
+      />
     </button>
   `
 }
 
+function ExecutionQueueBody({ queueRows }: { queueRows: DashboardExecutionQueueItem[] }) {
+  const activeItems = queueRows.filter(item => !isTerminalStatus(item.status))
+  const terminalItems = queueRows.filter(item => isTerminalStatus(item.status))
+
+  return html`
+    <div class="monitor-section-head">
+      <h2 class="monitor-headline">개입이 필요한 실행</h2>
+      <p class="monitor-subheadline">진행 중인 세션과 작전 중 막힌 항목을 보여줍니다. 종료된 세션은 하단에 접혀 있습니다.</p>
+    </div>
+    <div class="monitor-alert-list">
+      ${activeItems.length === 0
+        ? html`<div class="empty-state">지금은 개입이 필요한 실행이 없습니다.</div>`
+        : activeItems.map(item => html`<${QueueCard} key=${item.id} item=${item} selected=${selectedQueueId.value === item.id} />`)}
+    </div>
+    ${terminalItems.length > 0
+      ? html`
+          <details class="runtime-collapsible" data-testid="execution.queue-terminal">
+            <summary class="runtime-summary">종료된 세션 ${terminalItems.length}건</summary>
+            <div class="monitor-alert-list">
+              ${terminalItems.map(item => html`<${QueueCard} key=${item.id} item=${item} selected=${selectedQueueId.value === item.id} />`)}
+            </div>
+          </details>
+        `
+      : null}
+  `
+}
+
 function SessionCard({ brief, selected }: { brief: DashboardExecutionSessionBrief; selected: boolean }) {
+  const terminal = isTerminalStatus(brief.status)
   const liveCount = brief.active_count ?? 0
   const seenCount = brief.seen_count ?? liveCount
   const plannedCount = brief.planned_count ?? brief.member_names.length
   return html`
     <button
-      class="mission-card-select ${selected ? 'active' : ''}"
+      class="mission-card-select ${selected ? 'active' : ''} ${terminal ? 'terminated' : ''}"
       data-testid="execution.session-card"
       onClick=${() => {
         selectedSessionId.value = selected ? null : brief.session_id
@@ -279,7 +323,7 @@ function SessionCard({ brief, selected }: { brief: DashboardExecutionSessionBrie
           <div class="mission-card-target">${brief.session_id}${brief.room ? ` · ${brief.room}` : ''}</div>
           <div class="mission-card-title">${brief.goal}</div>
         </div>
-        <span class="command-chip ${toneClass(brief.health ?? brief.status)}">${statusLabel(brief.status)}</span>
+        <span class="command-chip ${terminal ? 'muted' : toneClass(brief.health ?? brief.status)}">${statusLabel(brief.status)}</span>
       </div>
       <div class="mission-card-meta">
         <span>건강도 · ${statusLabel(brief.health ?? 'ok')}</span>
@@ -295,8 +339,41 @@ function SessionCard({ brief, selected }: { brief: DashboardExecutionSessionBrie
       <div class="monitor-footnote">
         ${brief.worker_gap_summary ?? `관측 기준 · ${brief.counts_basis ?? 'recent_turns'}`}
       </div>
-      <${HandoffButtons} intervene=${brief.intervene_handoff} command=${brief.command_handoff} />
+      <${HandoffButtons}
+        intervene=${terminal ? null : brief.intervene_handoff}
+        command=${brief.command_handoff}
+      />
     </button>
+  `
+}
+
+function SessionBriefsBody({ sessionRows }: { sessionRows: DashboardExecutionSessionBrief[] }) {
+  const activeSessions = sessionRows.filter(row => !isTerminalStatus(row.status))
+  const terminalSessions = sessionRows.filter(row => isTerminalStatus(row.status))
+
+  return html`
+    <div class="monitor-section-head">
+      <h2 class="monitor-headline">영향받는 세션</h2>
+      <p class="monitor-subheadline">대기열에서 고른 실행이 어떤 세션 목표와 실행 막힘을 갖는지 요약합니다.</p>
+    </div>
+    <div class="monitor-list">
+      ${activeSessions.length === 0 && terminalSessions.length === 0
+        ? html`<div class="empty-state">선택된 실행과 연결된 세션이 없습니다.</div>`
+        : activeSessions.map(row => html`<${SessionCard} key=${row.session_id} brief=${row} selected=${selectedSessionId.value === row.session_id} />`)}
+      ${activeSessions.length === 0 && terminalSessions.length > 0
+        ? html`<div class="empty-state">진행 중인 세션이 없습니다.</div>`
+        : null}
+    </div>
+    ${terminalSessions.length > 0
+      ? html`
+          <details class="runtime-collapsible" data-testid="execution.sessions-terminal">
+            <summary class="runtime-summary">종료된 세션 ${terminalSessions.length}건</summary>
+            <div class="monitor-list">
+              ${terminalSessions.map(row => html`<${SessionCard} key=${row.session_id} brief=${row} selected=${selectedSessionId.value === row.session_id} />`)}
+            </div>
+          </details>
+        `
+      : null}
   `
 }
 
@@ -561,15 +638,7 @@ export function Execution() {
         semanticId="execution.queue"
         testId="execution.queue"
       >
-        <div class="monitor-section-head">
-          <h2 class="monitor-headline">지금 막힌 실행과 다음 인계</h2>
-          <p class="monitor-subheadline">세션과 작전을 한 대기열로 보고, 어디를 먼저 개입 화면과 원인 화면으로 넘길지 판단합니다.</p>
-        </div>
-        <div class="monitor-alert-list">
-          ${queueRows.length === 0
-            ? html`<div class="empty-state">지금은 막힌 실행이 없습니다.</div>`
-            : queueRows.map(item => html`<${QueueCard} key=${item.id} item=${item} selected=${selectedQueueId.value === item.id} />`)}
-        </div>
+        ${html`<${ExecutionQueueBody} queueRows=${queueRows} />`}
       <//>
 
       <div class="agents-workbench">
@@ -579,15 +648,7 @@ export function Execution() {
           semanticId="execution.sessions"
           testId="execution.session-briefs"
         >
-          <div class="monitor-section-head">
-            <h2 class="monitor-headline">영향받는 세션</h2>
-            <p class="monitor-subheadline">대기열에서 고른 실행이 어떤 세션 목표와 실행 막힘을 갖는지 요약합니다.</p>
-          </div>
-          <div class="monitor-list">
-            ${sessionRows.length === 0
-              ? html`<div class="empty-state">선택된 실행과 연결된 세션이 없습니다.</div>`
-              : sessionRows.map(row => html`<${SessionCard} key=${row.session_id} brief=${row} selected=${selectedSessionId.value === row.session_id} />`)}
-          </div>
+          ${html`<${SessionBriefsBody} sessionRows=${sessionRows} />`}
         <//>
 
         <${Card}

--- a/dashboard/src/components/agents.ts
+++ b/dashboard/src/components/agents.ts
@@ -280,21 +280,23 @@ function QueueCard({ item, selected }: { item: DashboardExecutionQueueItem; sele
 function ExecutionQueueBody({ queueRows }: { queueRows: DashboardExecutionQueueItem[] }) {
   const activeItems = queueRows.filter(item => !isTerminalStatus(item.status))
   const terminalItems = queueRows.filter(item => isTerminalStatus(item.status))
+  const hasActive = activeItems.length > 0
+  const hasTerminal = terminalItems.length > 0
 
   return html`
     <div class="monitor-section-head">
       <h2 class="monitor-headline">개입이 필요한 실행</h2>
-      <p class="monitor-subheadline">진행 중인 세션과 작전 중 막힌 항목을 보여줍니다. 종료된 세션은 하단에 접혀 있습니다.</p>
+      <p class="monitor-subheadline">진행 중인 세션과 작전 중 막힌 항목을 보여줍니다.${hasTerminal ? ' 종료된 항목은 하단에 접혀 있습니다.' : ''}</p>
     </div>
     <div class="monitor-alert-list">
-      ${activeItems.length === 0
-        ? html`<div class="empty-state">지금은 개입이 필요한 실행이 없습니다.</div>`
-        : activeItems.map(item => html`<${QueueCard} key=${item.id} item=${item} selected=${selectedQueueId.value === item.id} />`)}
+      ${hasActive
+        ? activeItems.map(item => html`<${QueueCard} key=${item.id} item=${item} selected=${selectedQueueId.value === item.id} />`)
+        : html`<div class="empty-state">지금은 개입이 필요한 실행이 없습니다.</div>`}
     </div>
-    ${terminalItems.length > 0
+    ${hasTerminal
       ? html`
           <details class="runtime-collapsible" data-testid="execution.queue-terminal">
-            <summary class="runtime-summary">종료된 세션 ${terminalItems.length}건</summary>
+            <summary class="runtime-summary">종료된 항목 ${terminalItems.length}건</summary>
             <div class="monitor-alert-list">
               ${terminalItems.map(item => html`<${QueueCard} key=${item.id} item=${item} selected=${selectedQueueId.value === item.id} />`)}
             </div>
@@ -350,6 +352,8 @@ function SessionCard({ brief, selected }: { brief: DashboardExecutionSessionBrie
 function SessionBriefsBody({ sessionRows }: { sessionRows: DashboardExecutionSessionBrief[] }) {
   const activeSessions = sessionRows.filter(row => !isTerminalStatus(row.status))
   const terminalSessions = sessionRows.filter(row => isTerminalStatus(row.status))
+  const hasActive = activeSessions.length > 0
+  const hasTerminal = terminalSessions.length > 0
 
   return html`
     <div class="monitor-section-head">
@@ -357,14 +361,11 @@ function SessionBriefsBody({ sessionRows }: { sessionRows: DashboardExecutionSes
       <p class="monitor-subheadline">대기열에서 고른 실행이 어떤 세션 목표와 실행 막힘을 갖는지 요약합니다.</p>
     </div>
     <div class="monitor-list">
-      ${activeSessions.length === 0 && terminalSessions.length === 0
-        ? html`<div class="empty-state">선택된 실행과 연결된 세션이 없습니다.</div>`
-        : activeSessions.map(row => html`<${SessionCard} key=${row.session_id} brief=${row} selected=${selectedSessionId.value === row.session_id} />`)}
-      ${activeSessions.length === 0 && terminalSessions.length > 0
-        ? html`<div class="empty-state">진행 중인 세션이 없습니다.</div>`
-        : null}
+      ${hasActive
+        ? activeSessions.map(row => html`<${SessionCard} key=${row.session_id} brief=${row} selected=${selectedSessionId.value === row.session_id} />`)
+        : html`<div class="empty-state">${hasTerminal ? '진행 중인 세션이 없습니다.' : '선택된 실행과 연결된 세션이 없습니다.'}</div>`}
     </div>
-    ${terminalSessions.length > 0
+    ${hasTerminal
       ? html`
           <details class="runtime-collapsible" data-testid="execution.sessions-terminal">
             <summary class="runtime-summary">종료된 세션 ${terminalSessions.length}건</summary>
@@ -378,9 +379,10 @@ function SessionBriefsBody({ sessionRows }: { sessionRows: DashboardExecutionSes
 }
 
 function OperationCard({ brief, selected }: { brief: DashboardExecutionOperationBrief; selected: boolean }) {
+  const terminal = isTerminalStatus(brief.status)
   return html`
     <button
-      class="mission-card-select ${selected ? 'active' : ''}"
+      class="mission-card-select ${selected ? 'active' : ''} ${terminal ? 'terminated' : ''}"
       data-testid="execution.operation-card"
       onClick=${() => {
         selectedOperationId.value = selected ? null : brief.operation_id
@@ -392,7 +394,7 @@ function OperationCard({ brief, selected }: { brief: DashboardExecutionOperation
           <div class="mission-card-target">${brief.operation_id}${brief.assigned_unit_label ? ` · ${brief.assigned_unit_label}` : ''}</div>
           <div class="mission-card-title">${brief.objective}</div>
         </div>
-        <span class="command-chip ${toneClass(brief.blocker_summary ? 'warn' : brief.status)}">${statusLabel(brief.status)}</span>
+        <span class="command-chip ${terminal ? 'muted' : toneClass(brief.blocker_summary ? 'warn' : brief.status)}">${statusLabel(brief.status)}</span>
       </div>
       <div class="mission-card-meta">
         ${brief.stage ? html`<span>단계 · ${brief.stage}</span>` : null}
@@ -638,7 +640,7 @@ export function Execution() {
         semanticId="execution.queue"
         testId="execution.queue"
       >
-        ${html`<${ExecutionQueueBody} queueRows=${queueRows} />`}
+        <${ExecutionQueueBody} queueRows=${queueRows} />
       <//>
 
       <div class="agents-workbench">
@@ -648,7 +650,7 @@ export function Execution() {
           semanticId="execution.sessions"
           testId="execution.session-briefs"
         >
-          ${html`<${SessionBriefsBody} sessionRows=${sessionRows} />`}
+          <${SessionBriefsBody} sessionRows=${sessionRows} />
         <//>
 
         <${Card}

--- a/dashboard/src/components/agents.ts
+++ b/dashboard/src/components/agents.ts
@@ -50,6 +50,15 @@ function isTerminalStatus(status?: string | null): boolean {
   return TERMINAL_STATUSES.has((status ?? '').trim().toLowerCase())
 }
 
+function partitionByTerminal<T>(items: T[], getStatus: (item: T) => string | null | undefined): [active: T[], terminal: T[]] {
+  const active: T[] = []
+  const terminal: T[] = []
+  for (const item of items) {
+    ;(isTerminalStatus(getStatus(item)) ? terminal : active).push(item)
+  }
+  return [active, terminal]
+}
+
 function toneClass(tone?: string | null): string {
   if (tone === 'bad' || tone === 'critical' || tone === 'offline') return 'bad'
   if (tone === 'warn' || tone === 'paused' || tone === 'blocked' || tone === 'interrupted') return 'warn'
@@ -278,8 +287,7 @@ function QueueCard({ item, selected }: { item: DashboardExecutionQueueItem; sele
 }
 
 function ExecutionQueueBody({ queueRows }: { queueRows: DashboardExecutionQueueItem[] }) {
-  const activeItems = queueRows.filter(item => !isTerminalStatus(item.status))
-  const terminalItems = queueRows.filter(item => isTerminalStatus(item.status))
+  const [activeItems, terminalItems] = partitionByTerminal(queueRows, item => item.status)
   const hasActive = activeItems.length > 0
   const hasTerminal = terminalItems.length > 0
 
@@ -350,8 +358,7 @@ function SessionCard({ brief, selected }: { brief: DashboardExecutionSessionBrie
 }
 
 function SessionBriefsBody({ sessionRows }: { sessionRows: DashboardExecutionSessionBrief[] }) {
-  const activeSessions = sessionRows.filter(row => !isTerminalStatus(row.status))
-  const terminalSessions = sessionRows.filter(row => isTerminalStatus(row.status))
+  const [activeSessions, terminalSessions] = partitionByTerminal(sessionRows, row => row.status)
   const hasActive = activeSessions.length > 0
   const hasTerminal = terminalSessions.length > 0
 
@@ -405,6 +412,34 @@ function OperationCard({ brief, selected }: { brief: DashboardExecutionOperation
       ${brief.next_tool ? html`<div class="monitor-footnote">다음 도구 · ${brief.next_tool}</div>` : null}
       <${HandoffButtons} command=${brief.command_handoff} />
     </button>
+  `
+}
+
+function OperationBriefsBody({ operationRows }: { operationRows: DashboardExecutionOperationBrief[] }) {
+  const [activeOps, terminalOps] = partitionByTerminal(operationRows, row => row.status)
+  const hasActive = activeOps.length > 0
+  const hasTerminal = terminalOps.length > 0
+
+  return html`
+    <div class="monitor-section-head">
+      <h2 class="monitor-headline">영향받는 작전</h2>
+      <p class="monitor-subheadline">지휘 평면 작전의 막힘과 다음 도구만 얇게 보여주고, 자세한 근거는 원인 화면으로 넘깁니다.</p>
+    </div>
+    <div class="monitor-list">
+      ${hasActive
+        ? activeOps.map(row => html`<${OperationCard} key=${row.operation_id} brief=${row} selected=${selectedOperationId.value === row.operation_id} />`)
+        : html`<div class="empty-state">${hasTerminal ? '진행 중인 작전이 없습니다.' : '선택된 실행과 연결된 작전이 없습니다.'}</div>`}
+    </div>
+    ${hasTerminal
+      ? html`
+          <details class="runtime-collapsible" data-testid="execution.operations-terminal">
+            <summary class="runtime-summary">종료된 작전 ${terminalOps.length}건</summary>
+            <div class="monitor-list">
+              ${terminalOps.map(row => html`<${OperationCard} key=${row.operation_id} brief=${row} selected=${selectedOperationId.value === row.operation_id} />`)}
+            </div>
+          </details>
+        `
+      : null}
   `
 }
 
@@ -659,15 +694,7 @@ export function Execution() {
           semanticId="execution.operations"
           testId="execution.operation-briefs"
         >
-          <div class="monitor-section-head">
-            <h2 class="monitor-headline">영향받는 작전</h2>
-            <p class="monitor-subheadline">지휘 평면 작전의 막힘과 다음 도구만 얇게 보여주고, 자세한 근거는 원인 화면으로 넘깁니다.</p>
-          </div>
-          <div class="monitor-list">
-            ${operationRows.length === 0
-              ? html`<div class="empty-state">선택된 실행과 연결된 작전이 없습니다.</div>`
-              : operationRows.map(row => html`<${OperationCard} key=${row.operation_id} brief=${row} selected=${selectedOperationId.value === row.operation_id} />`)}
-          </div>
+          <${OperationBriefsBody} operationRows=${operationRows} />
         <//>
 
         <${Card}

--- a/dashboard/src/styles/animations.css
+++ b/dashboard/src/styles/animations.css
@@ -589,6 +589,7 @@ button.monitor-row.bad.state-quiet {
 
 .mission-card-select.terminated {
   opacity: 0.55;
+  border-left: 3px solid rgba(148, 163, 184, 0.3);
 }
 
 .mission-card-select.terminated:hover {

--- a/dashboard/src/styles/animations.css
+++ b/dashboard/src/styles/animations.css
@@ -587,6 +587,14 @@ button.monitor-row.bad.state-quiet {
   cursor: pointer;
 }
 
+.mission-card-select.terminated {
+  opacity: 0.55;
+}
+
+.mission-card-select.terminated:hover {
+  opacity: 0.75;
+}
+
 .mission-card-disclosure {
   padding-top: 4px;
   border-top: 1px solid rgba(255,255,255,0.06);


### PR DESCRIPTION
## Summary

- 실행 대기열에서 Running(활성)과 Completed/Interrupted(종료) 세션을 시각적으로 분리
- 종료된 세션의 "세션 개입 열기" 버튼 제거 (끝난 세션에 "개입"은 의미 없음)
- 종료 항목은 `<details>` collapsible로 접어서 NOC 운영자의 1차 시선 정리
- `statusLabel`에 완료/실패/취소 한국어 라벨 추가

## Changes

| 파일 | 변경 |
|------|------|
| `dashboard/src/components/agents.ts` | `isTerminalStatus()` 헬퍼, `ExecutionQueueBody`/`SessionBriefsBody` 분리 컴포넌트, 개입 버튼 조건부 표시, statusLabel 추가 |
| `dashboard/src/styles/animations.css` | `.mission-card-select.terminated` opacity 스타일 |

## Design decisions

- **Frontend-only**: 백엔드(OCaml) 변경 없이 프론트만으로 해결. 리빌드 불필요.
- **기존 CSS 패턴 재사용**: `.command-chip.muted` (이미 존재), `.runtime-collapsible` (이미 존재)
- **3-agent 병렬 분석**: UX Designer, Developer, Product Owner 관점에서 독립 분석 후 수렴

## Test plan

- [ ] `cd dashboard && npm run dev` → `:5173/dashboard/#execution` 접속
- [ ] Running 세션과 Completed 세션이 분리되어 표시되는지 확인
- [ ] Completed 세션에 "세션 개입 열기" 버튼이 표시되지 않는지 확인
- [ ] Completed 세션이 접힌 상태(`<details>`)로 하단에 위치하는지 확인
- [ ] 활성 세션이 없을 때 "지금은 개입이 필요한 실행이 없습니다" 메시지 표시 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)