### PR TITLE
fix(ci): use Oas.Agent_types for record field access

### DIFF
--- a/lib/local_agent_eio_runners.ml
+++ b/lib/local_agent_eio_runners.ml
@@ -86,7 +86,7 @@ let run_worker_oas ~sw ~base_path ~worker_name
         let heartbeat_cbs =
           let interval = local_worker_heartbeat_interval_sec () in
           if interval > 0 then
-            [ { Oas.Agent.interval_sec = float_of_int interval;
+            [ { Oas.Agent_types.interval_sec = float_of_int interval;
                 callback = (fun () ->
                   match
                     call_masc_tool ~sw ~auth_token ~session_id:mcp_session_id
@@ -288,7 +288,7 @@ let continue_worker ?worker_run_id ~sw ~base_path ~room_config ~worker_name
           let heartbeat_cbs =
             let interval = local_worker_heartbeat_interval_sec () in
             if interval > 0 then
-              [ { Oas.Agent.interval_sec = float_of_int interval;
+              [ { Oas.Agent_types.interval_sec = float_of_int interval;
                   callback = (fun () ->
                     match
                       call_masc_tool ~sw ~auth_token


### PR DESCRIPTION
## Summary

- `Oas.Agent.interval_sec` → `Oas.Agent_types.interval_sec` (2 occurrences)
- OCaml type aliases (`type t = M.t`) don't import record field namespaces
- Fixes CI build failure on all open PRs

## Test plan

- [x] `dune build` clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)