### PR TITLE
fix(dashboard): eliminate fake information by showing honest staleness

### DIFF
--- a/dashboard/src/components/governance.ts
+++ b/dashboard/src/components/governance.ts
@@ -273,9 +273,28 @@ async function respondToExecutionOrder(decision: 'confirm' | 'deny') {
   }
 }
 
+function formatAgeSummary(seconds: number | null | undefined): string | null {
+  if (seconds == null) return null
+  if (seconds < 3600) return `${Math.floor(seconds / 60)}분`
+  if (seconds < 86400) return `${Math.floor(seconds / 3600)}시간`
+  return `${Math.floor(seconds / 86400)}일`
+}
+
 function GovernanceSummaryStrip() {
   const summary = governanceData.value?.summary
+  const oldestAge = summary?.oldest_open_case_age_s
+  const lastActivityAge = summary?.last_activity_age_s
+  // Cases older than 24h with no recent activity are likely stale test artifacts
+  const isStale = (oldestAge != null && oldestAge > 86400) || (lastActivityAge != null && lastActivityAge > 86400)
+
   return html`
+    ${isStale ? html`
+      <div class="governance-stale-warning">
+        모든 열린 케이스가 ${formatAgeSummary(oldestAge)} 이상 경과됨.
+        ${lastActivityAge != null ? html` 마지막 활동: ${formatAgeSummary(lastActivityAge)} 전.` : null}
+        테스트 잔재일 가능성이 높습니다.
+      </div>
+    ` : null}
     <div class="board-summary-strip">
       <div class="board-summary-item">
         <span class="board-summary-label">열린 케이스</span>

--- a/dashboard/src/components/overview/agent-observatory.ts
+++ b/dashboard/src/components/overview/agent-observatory.ts
@@ -1,5 +1,6 @@
 // Agent Observatory — session-grouped agent view
 // Groups agents by team session, showing each agent's state, focus, tools, and signal age.
+// Stale agents are visually dimmed; all-stale state shows an honest summary.
 
 import { html } from 'htm/preact'
 import { AgentAvatar } from './agent-avatar'
@@ -73,13 +74,29 @@ function truncate(text: string | null, max = 60): string | null {
   return clean.length > max ? `${clean.slice(0, max - 1)}…` : clean
 }
 
+/** Determine if an agent's signal is stale (no fresh data in 10+ minutes) */
+function isStaleAgent(agent: ObservatoryAgent): boolean {
+  if (agent.signalTruth === 'stale' || agent.signalTruth === 'archived') return true
+  if (agent.lastSignalAgeSec != null && agent.lastSignalAgeSec > 600) return true
+  return agent.state === 'quiet' || agent.state === 'offline'
+}
+
+function staleDurationLabel(ageSec: number | null): string | null {
+  if (ageSec == null) return null
+  if (ageSec < 3600) return `${Math.floor(ageSec / 60)}분 전 마지막 신호`
+  if (ageSec < 86400) return `${Math.floor(ageSec / 3600)}시간 전 마지막 신호`
+  return `${Math.floor(ageSec / 86400)}일 전 마지막 신호`
+}
+
 function AgentRow({ agent, onAgentClick }: { agent: ObservatoryAgent; onAgentClick?: (name: string) => void }) {
   const focusText = truncate(agent.focus ?? agent.currentTask)
   const previewText = truncate(agent.recentOutputPreview, 80)
+  const stale = isStaleAgent(agent)
+  const staleLabel = stale ? staleDurationLabel(agent.lastSignalAgeSec) : null
 
   return html`
     <div
-      class="obs-agent-row obs-agent-row--${agent.state}"
+      class="obs-agent-row obs-agent-row--${agent.state} ${stale ? 'obs-agent-row--stale' : ''}"
       onClick=${onAgentClick ? () => onAgentClick(agent.name) : undefined}
       role=${onAgentClick ? 'button' : undefined}
       tabindex=${onAgentClick ? '0' : undefined}
@@ -104,9 +121,13 @@ function AgentRow({ agent, onAgentClick }: { agent: ObservatoryAgent; onAgentCli
           <span class="obs-agent-row__state obs-agent-row__state--${agent.state}">
             ${stateLabel(agent.state)}
           </span>
+          ${stale ? html`<span class="obs-agent-row__stale-badge">stale</span>` : null}
           ${agent.model ? html`<span class="obs-agent-row__model">${agent.model}</span>` : null}
         </div>
 
+        ${staleLabel && !focusText ? html`
+          <div class="obs-agent-row__focus obs-agent-row__focus--stale">${staleLabel}</div>
+        ` : null}
         ${focusText ? html`
           <div class="obs-agent-row__focus">${focusText}</div>
         ` : null}
@@ -166,7 +187,7 @@ export function AgentObservatory({ onAgentClick }: AgentObservatoryProps) {
   if (groups.length === 0) {
     return html`
       <div class="obs-empty">
-        <div style="color: var(--text-muted); padding: 16px;">에이전트 없음</div>
+        <div style="color: var(--text-muted); padding: 16px;">등록된 에이전트 없음</div>
       </div>
     `
   }
@@ -175,13 +196,22 @@ export function AgentObservatory({ onAgentClick }: AgentObservatoryProps) {
   const totalWorking = groups.reduce(
     (sum: number, g: ObservatoryGroup) => sum + g.agents.filter((a: ObservatoryAgent) => a.state === 'working').length, 0,
   )
+  const totalStale = groups.reduce(
+    (sum: number, g: ObservatoryGroup) => sum + g.agents.filter((a: ObservatoryAgent) => isStaleAgent(a)).length, 0,
+  )
+  const allStale = totalStale === totalAgents && totalAgents > 0
 
   return html`
-    <div class="obs-container">
+    <div class="obs-container ${allStale ? 'obs-container--all-stale' : ''}">
       <div class="obs-summary">
-        <span>${totalAgents} 에이전트</span>
-        ${totalWorking > 0 ? html`<span class="obs-summary__working">${totalWorking} 작업 중</span>` : null}
-        <span>${groups.filter((g: ObservatoryGroup) => g.sessionId).length} 세션</span>
+        ${allStale ? html`
+          <span class="obs-summary__stale-notice">${totalAgents}개 에이전트 등록됨 (활성 신호 없음)</span>
+        ` : html`
+          <span>${totalAgents} 에이전트</span>
+          ${totalWorking > 0 ? html`<span class="obs-summary__working">${totalWorking} 작업 중</span>` : null}
+          ${totalStale > 0 ? html`<span class="obs-summary__stale">${totalStale} stale</span>` : null}
+          <span>${groups.filter((g: ObservatoryGroup) => g.sessionId).length} 세션</span>
+        `}
       </div>
 
       ${groups.map(group => html`

--- a/dashboard/src/styles/governance.css
+++ b/dashboard/src/styles/governance.css
@@ -739,3 +739,15 @@ button.council-row.selected {
   background: rgba(71, 184, 255, 0.15);
   color: #c9ebff;
 }
+
+/* --- Governance staleness warning --- */
+.governance-stale-warning {
+  padding: 10px 14px;
+  margin-bottom: 8px;
+  border-radius: 6px;
+  border: 1px solid rgba(251, 191, 36, 0.25);
+  background: rgba(251, 191, 36, 0.06);
+  color: rgba(251, 191, 36, 0.85);
+  font-size: 12px;
+  line-height: 1.5;
+}

--- a/dashboard/src/styles/overview.css
+++ b/dashboard/src/styles/overview.css
@@ -1139,3 +1139,57 @@
     display: none;
   }
 }
+
+/* --- Staleness indicators (anti-fake-info) --- */
+
+/* QuickStats: dimmed stat when all agents are stale */
+.overview-stat--dimmed {
+  opacity: 0.55;
+}
+.overview-stat--dimmed .overview-stat__value {
+  color: var(--text-muted);
+}
+.overview-stat__annotation {
+  display: block;
+  font-size: 10px;
+  color: rgba(251, 191, 36, 0.7);
+  margin-top: 2px;
+  font-weight: 400;
+}
+
+/* Observatory: stale agent row */
+.obs-agent-row--stale {
+  opacity: 0.45;
+}
+.obs-agent-row--stale:hover {
+  opacity: 0.7;
+}
+.obs-agent-row__stale-badge {
+  font-size: 9px;
+  padding: 1px 4px;
+  border-radius: 3px;
+  background: rgba(251, 191, 36, 0.15);
+  color: rgba(251, 191, 36, 0.8);
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.3px;
+}
+.obs-agent-row__focus--stale {
+  color: var(--text-muted);
+  font-style: italic;
+  font-size: 11px;
+}
+
+/* Observatory: all-stale container */
+.obs-container--all-stale {
+  border: 1px dashed rgba(251, 191, 36, 0.2);
+  border-radius: 8px;
+  padding: 4px;
+}
+.obs-summary__stale-notice {
+  color: rgba(251, 191, 36, 0.7);
+  font-style: italic;
+}
+.obs-summary__stale {
+  color: rgba(251, 191, 36, 0.6);
+}


### PR DESCRIPTION
## Summary
- QuickStats에서 stale 에이전트를 활성 카운트에서 제외하고, stale annotation 표시
- Agent Observatory에 stale 감지 로직 추가 (signal_truth + 10분+ 경과), 시각적 dimming, stale 뱃지
- Situation Banner에서 유휴 상태 (세션/에이전트/키퍼 모두 없음)를 정직하게 표시
- Governance에서 24시간+ 경과된 케이스에 "테스트 잔재" 경고 배너 추가
- CSS: staleness 시각 지표 (dimmed rows, amber annotations, dashed border)

## Problem
대시보드가 가짜 정보를 보여주고 있었음:
1. Shell counts가 stale 에이전트를 포함하여 "에이전트 4" 표시 (실 활성 0)
2. QA 테스트 에이전트 (keeper-qa-*) 가 실제 에이전트처럼 동일하게 렌더링됨
3. Governance 13건 모두 70시간 전 테스트 잔재인데 실제 케이스처럼 표시됨
4. Mission 데이터가 모두 빈 배열인데 빈 상태에 대한 설명 부재

## Test plan
- [ ] `cd dashboard && npx vite build` 빌드 성공 확인
- [ ] 브라우저에서 Overview 페이지: stale 에이전트가 dimmed + stale 뱃지 표시
- [ ] QuickStats: "활성 에이전트 0" + "4개 등록됨 (모두 stale)" annotation 확인
- [ ] Governance 페이지: 노란 경고 배너 "모든 열린 케이스가 N일 이상 경과됨" 확인
- [ ] Situation Banner: "유휴 상태. 세션, 에이전트, 키퍼 모두 비활성." 확인

Generated with [Claude Code](https://claude.com/claude-code)