### PR TITLE
feat(context): conversation history offload on compaction

### DIFF
--- a/lib/context_manager.ml
+++ b/lib/context_manager.ml
@@ -388,7 +388,9 @@ let offload_messages
     Fun.protect ~finally:(fun () -> Unix.close fd) (fun () ->
       let _ = Unix.write_substring fd content 0 (String.length content) in ());
     Some path
-  with _exn ->
+  with exn ->
+    Printf.eprintf "[context_manager] offload_messages failed: %s\n%!"
+      (Printexc.to_string exn);
     None
 
 (** Apply compaction with history offload.

--- a/lib/context_manager.ml
+++ b/lib/context_manager.ml
@@ -51,6 +51,11 @@ type compaction_strategy =
   | DropLowImportance
   | SummarizeOld
 
+type compaction_result = {
+  context : working_context;
+  offloaded_path : string option;
+}
+
 (* ================================================================ *)
 (* Memory Formats                                                  *)
 (* ================================================================ *)
@@ -89,6 +94,19 @@ let extract_state_blocks (s : string) : string list =
          loop next_from (body :: acc))
   in
   loop 0 []
+
+(* ================================================================ *)
+(* Filesystem Utilities                                             *)
+(* ================================================================ *)
+
+let ensure_dir path =
+  let rec mkdir_p dir =
+    if not (Sys.file_exists dir) then begin
+      mkdir_p (Filename.dirname dir);
+      (try Unix.mkdir dir 0o755 with Unix.Unix_error (Unix.EEXIST, _, _) -> ())
+    end
+  in
+  mkdir_p path
 
 (* ================================================================ *)
 (* Token Estimation                                                 *)
@@ -322,6 +340,94 @@ let compact ctx strategies =
   sync_oas_context ctx
 
 (* ================================================================ *)
+(* Conversation History Offload                                     *)
+(* ================================================================ *)
+
+(** Format a single message as human-readable text: "role: content". *)
+let format_message_readable (m : Llm_client.message) : string =
+  let role_str = match m.role with
+    | Llm_client.System -> "system"
+    | Llm_client.User -> "user"
+    | Llm_client.Assistant -> "assistant"
+    | Llm_client.Tool -> "tool"
+  in
+  let name_suffix = match m.name with
+    | Some n -> sprintf " (%s)" n
+    | None -> ""
+  in
+  sprintf "%s%s: %s" role_str name_suffix (text_of_message m)
+
+(** Offload messages to a markdown file for later retrieval.
+    Returns [Some path] on success, [None] on failure (fail-safe). *)
+let offload_messages
+    ~(session_dir : string)
+    ~(compaction_count : int)
+    (messages : Llm_client.message list) : string option =
+  try
+    let offload_dir = Filename.concat session_dir "offloaded" in
+    ensure_dir offload_dir;
+    let path = Filename.concat offload_dir
+      (sprintf "%d.md" compaction_count) in
+    let timestamp =
+      let t = Time_compat.now () in
+      (* ISO 8601 UTC: manual formatting to avoid external dependency *)
+      let open Unix in
+      let tm = gmtime t in
+      sprintf "%04d-%02d-%02dT%02d:%02d:%02dZ"
+        (tm.tm_year + 1900) (tm.tm_mon + 1) tm.tm_mday
+        tm.tm_hour tm.tm_min tm.tm_sec
+    in
+    let rendered =
+      messages
+      |> List.map format_message_readable
+      |> String.concat "\n\n"
+    in
+    let content = sprintf "## Compacted at %s\n\n%s\n\n" timestamp rendered in
+    let fd = Unix.openfile path
+      [Unix.O_WRONLY; Unix.O_CREAT; Unix.O_TRUNC] 0o644 in
+    Fun.protect ~finally:(fun () -> Unix.close fd) (fun () ->
+      let _ = Unix.write_substring fd content 0 (String.length content) in ());
+    Some path
+  with _exn ->
+    None
+
+(** Apply compaction with history offload.
+    Messages that would be removed by compaction are saved to a markdown file
+    before compaction runs. The summary message is annotated with the offload path.
+    If offload fails, compaction proceeds normally. *)
+let compact_with_offload
+    ~(session_ctx : session_context)
+    ~(compaction_count : int)
+    (ctx : working_context)
+    (strategies : compaction_strategy list) : compaction_result =
+  (* Capture pre-compaction messages for offload *)
+  let pre_messages = ctx.messages in
+  let offloaded_path =
+    offload_messages
+      ~session_dir:session_ctx.session_dir
+      ~compaction_count
+      pre_messages
+  in
+  (* Run the normal compaction pipeline *)
+  let compacted = List.fold_left apply_strategy ctx strategies in
+  (* If offload succeeded and SummarizeOld produced a summary, annotate it *)
+  let compacted = match offloaded_path with
+    | Some path ->
+      let annotation = sprintf "[Full conversation history saved to %s]\n\n" path in
+      let messages = List.map (fun (m : Llm_client.message) ->
+        let mt = text_of_message m in
+        if starts_with ~prefix:memory_summary_prefix mt then
+          { m with content = [Agent_sdk.Types.Text (annotation ^ mt)] }
+        else m
+      ) compacted.messages in
+      let token_count = count_tokens compacted.system_prompt messages in
+      { compacted with messages; token_count }
+    | None -> compacted
+  in
+  let compacted = sync_oas_context compacted in
+  { context = compacted; offloaded_path }
+
+(* ================================================================ *)
 (* OAS Context_reducer Integration                                  *)
 (* ================================================================ *)
 
@@ -499,15 +605,6 @@ let restore_checkpoint ckpt ~max_tokens =
 (* ================================================================ *)
 (* Session Persistence                                              *)
 (* ================================================================ *)
-
-let ensure_dir path =
-  let rec mkdir_p dir =
-    if not (Sys.file_exists dir) then begin
-      mkdir_p (Filename.dirname dir);
-      (try Unix.mkdir dir 0o755 with Unix.Unix_error (Unix.EEXIST, _, _) -> ())
-    end
-  in
-  mkdir_p path
 
 let create_session ~session_id ~base_dir =
   let session_dir = Filename.concat base_dir session_id in

--- a/lib/context_manager.mli
+++ b/lib/context_manager.mli
@@ -50,6 +50,12 @@ type compaction_strategy =
   | DropLowImportance  (** Remove messages with importance < 0.3 *)
   | SummarizeOld       (** LLM-summarize oldest 30% into 1 summary message *)
 
+(** Result of compaction with optional history offload. *)
+type compaction_result = {
+  context : working_context;
+  offloaded_path : string option;  (** Path to offloaded history markdown, if saved *)
+}
+
 (** {1 Context Ratio Thresholds} *)
 
 (** Context window usage as a ratio 0.0-1.0. *)
@@ -90,6 +96,23 @@ val apply_strategy : working_context -> compaction_strategy -> working_context
 
 (** Apply a pipeline of compaction strategies in order. *)
 val compact : working_context -> compaction_strategy list -> working_context
+
+(** Format a single message as human-readable text: "role: content". *)
+val format_message_readable : Llm_client.message -> string
+
+(** Offload messages to a markdown file in [{session_dir}/offloaded/{compaction_count}.md].
+    Returns [Some path] on success, [None] on failure (fail-safe, never raises). *)
+val offload_messages :
+  session_dir:string -> compaction_count:int ->
+  Llm_client.message list -> string option
+
+(** Apply compaction with history offload.
+    Before compaction, saves the full pre-compaction messages to a markdown file.
+    The summary message is annotated with the offload path.
+    If offload fails, compaction proceeds normally. *)
+val compact_with_offload :
+  session_ctx:session_context -> compaction_count:int ->
+  working_context -> compaction_strategy list -> compaction_result
 
 (** Sync working context stats (message_count, token_count, context_ratio)
     into the OAS Context scoped keys. Called automatically by [compact]. *)

--- a/lib/tool_inline_dispatch.ml
+++ b/lib/tool_inline_dispatch.ml
@@ -25,8 +25,6 @@
     - masc_convo_*
 *)
 
-let schemas = Tool_schemas_inline.schemas
-
 type result = bool * string
 
 (** Context record capturing all bindings from execute_tool_eio

--- a/test/test_perpetual.ml
+++ b/test/test_perpetual.ml
@@ -866,6 +866,103 @@ let test_integration () = group "Integration" (fun () ->
 )
 
 (* ================================================================ *)
+(* 7. History Offload Tests                                         *)
+(* ================================================================ *)
+
+let test_history_offload () = group "History Offload" (fun () ->
+
+  (* 1. format_message_readable produces role: content format *)
+  let user_msg = Llm_client.user_msg "hello world" in
+  let formatted = Context_manager.format_message_readable user_msg in
+  assert_true "format:user" (formatted = "user: hello world");
+
+  let tool_msg = Llm_client.tool_msg ~name:"grep" ~call_id:"c1" "search results" in
+  let formatted_tool = Context_manager.format_message_readable tool_msg in
+  assert_true "format:tool_with_name"
+    (String.length formatted_tool > 0
+     && String.sub formatted_tool 0 4 = "tool");
+
+  (* 2. offload_messages creates file in correct location *)
+  let tmp_dir = Filename.concat (Filename.get_temp_dir_name ())
+    (sprintf "masc-offload-test-%d" (int_of_float (Unix.gettimeofday () *. 1000.0))) in
+  let messages = [
+    Llm_client.user_msg "question 1";
+    Llm_client.assistant_msg "answer 1";
+    Llm_client.user_msg "question 2";
+  ] in
+  let result = Context_manager.offload_messages
+    ~session_dir:tmp_dir ~compaction_count:0 messages in
+  assert_true "offload:returns_some" (Option.is_some result);
+  let path = Option.get result in
+  assert_true "offload:file_exists" (Sys.file_exists path);
+  assert_true "offload:correct_filename"
+    (Filename.basename path = "0.md");
+  assert_true "offload:in_offloaded_dir"
+    (Filename.basename (Filename.dirname path) = "offloaded");
+
+  (* 3. offload file contains readable content *)
+  let ic = open_in path in
+  let n = in_channel_length ic in
+  let buf = Bytes.create n in
+  really_input ic buf 0 n;
+  close_in ic;
+  let content = Bytes.to_string buf in
+  assert_true "offload:has_header"
+    (let len = String.length "## Compacted at" in
+     String.length content >= len
+     && String.sub content 0 len = "## Compacted at");
+  assert_true "offload:has_user_msg"
+    (try let _ = Str.search_forward (Str.regexp_string "user: question 1") content 0 in true
+     with Not_found -> false);
+  assert_true "offload:has_assistant_msg"
+    (try let _ = Str.search_forward (Str.regexp_string "assistant: answer 1") content 0 in true
+     with Not_found -> false);
+
+  (* 4. offload with invalid path returns None (fail-safe) *)
+  let bad_result = Context_manager.offload_messages
+    ~session_dir:"/nonexistent/path/that/cannot/exist" ~compaction_count:0 messages in
+  assert_true "offload:failsafe" (Option.is_none bad_result);
+
+  (* 5. compact_with_offload returns both context and offload path *)
+  let session = Context_manager.create_session
+    ~session_id:"offload-test"
+    ~base_dir:(Filename.get_temp_dir_name ()) in
+  let ctx = Context_manager.create ~system_prompt:"test" ~max_tokens:100000 in
+  let ctx = Context_manager.append_many ctx
+    (List.init 20 (fun i ->
+      if i mod 2 = 0
+      then Llm_client.user_msg (sprintf "question %d with detail: %s" i (String.make 200 'x'))
+      else Llm_client.assistant_msg (sprintf "answer %d: %s" i (String.make 300 'y')))) in
+  let result = Context_manager.compact_with_offload
+    ~session_ctx:session ~compaction_count:1
+    ctx [Context_manager.PruneToolOutputs; Context_manager.MergeContiguous;
+         Context_manager.SummarizeOld] in
+  assert_true "compact_offload:has_path" (Option.is_some result.offloaded_path);
+  assert_true "compact_offload:context_reduced"
+    (result.context.token_count < ctx.token_count);
+  assert_true "compact_offload:file_exists"
+    (Sys.file_exists (Option.get result.offloaded_path));
+
+  (* 6. Summary message contains offload path annotation *)
+  let has_annotation = List.exists (fun (m : Llm_client.message) ->
+    let text = Llm_client.text_of_message m in
+    try let _ = Str.search_forward
+      (Str.regexp_string "[Full conversation history saved to") text 0 in true
+    with Not_found -> false
+  ) result.context.messages in
+  assert_true "compact_offload:has_annotation" has_annotation;
+
+  (* 7. compact (original) still works unchanged *)
+  let orig = Context_manager.compact ctx
+    [Context_manager.PruneToolOutputs; Context_manager.SummarizeOld] in
+  assert_true "compact:original_unchanged"
+    (orig.token_count < ctx.token_count);
+
+  (* Cleanup temp dirs *)
+  (try Sys.remove path with _ -> ());
+)
+
+(* ================================================================ *)
 (* Runner                                                           *)
 (* ================================================================ *)
 
@@ -880,6 +977,7 @@ let () =
   test_perpetual_loop ();
   test_auto_claim ();
   test_integration ();
+  test_history_offload ();
 
   printf "\n====================================\n%!";
   printf "Results: %d/%d passed (%d failed)\n%!"


### PR DESCRIPTION
## Summary
- Inspired by [Deep Agents](https://github.com/langchain-ai/deepagents) `SummarizationMiddleware._offload_to_backend()` pattern
- When compaction removes old messages, saves them as human-readable markdown to `{session_dir}/offloaded/{N}.md`
- New `compact_with_offload` function (opt-in), original `compact` unchanged (backward-compatible)
- Summary message annotated with offload file path for later context retrieval

## Test plan
- [x] 201/201 tests passing (186 existing + 15 new)
- [x] Offload file creation, content verification, fail-safe behavior tested
- [ ] Integration: wire `compact_with_offload` into `perpetual_loop.ml` (follow-up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)