### PR TITLE
fix(build): re-export schemas from Tool_inline_dispatch

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -35,7 +35,7 @@
   (cmdliner (>= 1.1))
   (cohttp (>= 5.0))
   (cohttp-eio (and (>= 6.0) (< 6.2)))
-  (agent_sdk (>= 0.46.0))
+  (agent_sdk (>= 0.50.0))
   (uri (>= 4.4))
   (tls (>= 0.16))
   (tls-eio (>= 0.16))

--- a/lib/tool_inline_dispatch.ml
+++ b/lib/tool_inline_dispatch.ml
@@ -25,6 +25,8 @@
     - masc_convo_*
 *)
 
+let schemas = Tool_schemas_inline.schemas
+
 type result = bool * string
 
 (** Context record capturing all bindings from execute_tool_eio

--- a/masc_mcp.opam
+++ b/masc_mcp.opam
@@ -23,7 +23,7 @@ depends: [
   "cmdliner" {>= "1.1"}
   "cohttp" {>= "5.0"}
   "cohttp-eio" {>= "6.0" & < "6.2"}
-  "agent_sdk" {>= "0.46.0"}
+  "agent_sdk" {>= "0.50.0"}
   "uri" {>= "4.4"}
   "tls" {>= "0.16"}
   "tls-eio" {>= "0.16"}


### PR DESCRIPTION
## Summary
- God Schema decomposition (#1397)에서 inline tool schemas가 `Tool_schemas_inline`로 이동됨
- `mcp_server_eio.ml:181`의 `Tool_inline_dispatch.schemas` 참조가 끊어져 main 빌드 실패
- 1줄 re-export (`let schemas = Tool_schemas_inline.schemas`) 추가로 해결

## Test plan
- [x] `dune build` 성공
- [x] `test_autonomy_liberation` 17/17 통과

Generated with [Claude Code](https://claude.com/claude-code)