### PR TITLE
fix(build): add missing Tool_inline_dispatch.schemas export

### DIFF
--- a/lib/tool_inline_dispatch.ml
+++ b/lib/tool_inline_dispatch.ml
@@ -973,3 +973,8 @@ Call masc_listen again to continue listening.
         ]))
 
   | _ -> Tool_inline_dispatch_extra.dispatch ~config ~agent_name ~arguments ~state ~sw ~clock ~name
+
+(* Inline dispatch tools have schemas in Tool_schemas_core_01 and other
+   schema modules. This empty list satisfies register_module_tag;
+   name-based registration is handled by Tool_tag_init. *)
+let schemas : Types.tool_schema list = []


### PR DESCRIPTION
## Summary
- Post-merge breakage from #1404 + #1409: `mcp_server_eio.ml:181` references `Tool_inline_dispatch.schemas` but the value was never defined
- Add empty `schemas` list — actual schema registration is handled by `Tool_tag_init` via name-based lookup

## Test plan
- [x] `dune build` passes

Generated with [Claude Code](https://claude.com/claude-code)