### PR TITLE
fix(dashboard+server): complete anti-fake-info changes dropped in #1408

### DIFF
--- a/dashboard/src/components/overview/overview.ts
+++ b/dashboard/src/components/overview/overview.ts
@@ -2,8 +2,9 @@
 // 4-Layer information architecture: Situation -> Anomaly -> Entity Grid -> Timeline
 
 import { html } from 'htm/preact'
-import { agents, keepers, tasks, shellCounts } from '../../store'
+import { keepers, tasks, shellCounts } from '../../store'
 import { missionSnapshot } from '../../mission-store'
+import { observatoryGroups } from '../../observatory-store'
 import { journal } from '../../sse'
 import { navigate } from '../../router'
 import { formatDuration } from '../mission-utils'
@@ -34,19 +35,23 @@ function keeperHealthClass(status?: string): string {
 
 export function Overview() {
   const snap = missionSnapshot.value
-  const agentList = agents.value
   const keeperList = keepers.value
   const taskList = tasks.value
   const counts = shellCounts.value
 
-  const activeAgents = agentList.filter((a: { status: string }) =>
-    a.status === 'active' || a.status === 'busy' || a.status === 'listening'
-  )
   const activeTasks = taskList.filter((t: { status: string }) =>
     t.status === 'in_progress' || t.status === 'claimed'
   )
 
-  const agentCount = activeAgents.length > 0 ? activeAgents.length : (counts?.agents ?? 0)
+  // Use observatory groups for honest agent counting:
+  // only count agents with fresh signal (working/watching), not stale ones.
+  const obsGroups = observatoryGroups.value
+  const allObsAgents = obsGroups.flatMap(g => g.agents)
+  const freshAgentCount = allObsAgents.filter(a => a.state === 'working' || a.state === 'watching').length
+  const staleAgentCount = allObsAgents.filter(a => a.state === 'quiet' || a.state === 'offline').length
+  const totalAgentCount = allObsAgents.length
+
+  const agentCount = totalAgentCount > 0 ? freshAgentCount : (counts?.agents ?? 0)
   const taskCount = activeTasks.length > 0 ? activeTasks.length : (counts?.tasks ?? 0)
   const taskSource: TaskSource = activeTasks.length > 0 ? 'store' : 'cache'
   const keeperCount = keeperList.length > 0 ? keeperList.length : (counts?.keepers ?? 0)
@@ -70,6 +75,8 @@ export function Overview() {
 
       <${QuickStats}
         agentCount=${agentCount}
+        staleAgentCount=${staleAgentCount}
+        totalAgentCount=${totalAgentCount}
         activeTaskCount=${taskCount}
         keeperCount=${keeperCount}
         attentionCount=${attentionCount}

--- a/dashboard/src/components/overview/quick-stats.ts
+++ b/dashboard/src/components/overview/quick-stats.ts
@@ -11,6 +11,8 @@ export type TaskSource = 'store' | 'cache'
 
 interface QuickStatsProps {
   agentCount: number
+  staleAgentCount?: number
+  totalAgentCount?: number
   activeTaskCount: number
   keeperCount: number
   attentionCount: number
@@ -42,15 +44,29 @@ function TaskDistributionBar({ breakdown }: { breakdown: TaskBreakdown }) {
   `
 }
 
-export function QuickStats({ agentCount, activeTaskCount, keeperCount, attentionCount, taskBreakdown, taskSource }: QuickStatsProps) {
+export function QuickStats({
+  agentCount, staleAgentCount, totalAgentCount,
+  activeTaskCount, keeperCount, attentionCount, taskBreakdown, taskSource,
+}: QuickStatsProps) {
+  const hasStale = (staleAgentCount ?? 0) > 0 && agentCount === 0
+  const agentLabel = hasStale ? '활성 에이전트' : '에이전트'
+  const agentAnnotation = hasStale
+    ? `${totalAgentCount ?? staleAgentCount}개 등록됨 (모두 stale)`
+    : (staleAgentCount ?? 0) > 0
+      ? `+ ${staleAgentCount} stale`
+      : null
+
   return html`
     <div class="overview-stats">
-      <div class="overview-stat"
+      <div class="overview-stat ${hasStale ? 'overview-stat--dimmed' : ''}"
         style="cursor: pointer;"
         onClick=${() => navigate('agent-roster')}
       >
-        <span class="overview-stat__label">에이전트</span>
+        <span class="overview-stat__label">${agentLabel}</span>
         <strong class="overview-stat__value">${agentCount}</strong>
+        ${agentAnnotation ? html`
+          <span class="overview-stat__annotation">${agentAnnotation}</span>
+        ` : null}
       </div>
       <div class="overview-stat"
         style="cursor: pointer;"

--- a/dashboard/src/components/overview/situation-banner.ts
+++ b/dashboard/src/components/overview/situation-banner.ts
@@ -34,6 +34,13 @@ function synthesizeSituation(snap: DashboardMissionResponse | null): SituationRe
   const blocked = sessions.filter(s => s.blocker_summary).length
   const attentionItems = snap.attention_queue ?? []
   const attention = attentionItems.length
+  const hasAnyAgents = (snap.agent_briefs?.length ?? 0) > 0
+  const hasAnyKeepers = (snap.keeper_briefs?.length ?? 0) > 0
+
+  // Honest empty state: no sessions AND no agents/keepers means the room is idle
+  if (total === 0 && !hasAnyAgents && !hasAnyKeepers) {
+    return { text: '유휴 상태. 세션, 에이전트, 키퍼 모두 비활성.', tone: 'ok', reasons: [] }
+  }
 
   const reasons: SituationReason[] = []
 

--- a/lib/server_command_plane_http_support.ml
+++ b/lib/server_command_plane_http_support.ml
@@ -88,15 +88,12 @@ let start_cp_summary_refresh_loop ~state ~sw ~clock =
     in
     loop ())
 
-let command_plane_summary_http_json ~state =
-  let cached = !_cp_summary_ref in
-  match cached with
-  | `Assoc fields when List.mem_assoc "status" fields &&
-      (match List.assoc "status" fields with `String "initializing" -> true | _ -> false) ->
-    let result = compute_cp_summary ~state in
-    _cp_summary_ref := result;
-    result
-  | _ -> cached
+let command_plane_summary_http_json ~state:_ =
+  (* Always return the proactively cached ref.  Never compute synchronously —
+     compute_cp_summary can hang when Swarm_status.build_json blocks on
+     filesystem I/O, causing room-truth and /command-plane/summary to time out.
+     The background refresh loop populates the ref within one interval (120s). *)
+  !_cp_summary_ref
 
 let command_plane_snapshot_http_json ~state =
   let config = state.Mcp_server.room_config in


### PR DESCRIPTION
## Summary
PR #1408 머지 시 #1403과의 conflict로 3개 파일 + 서버 수정이 누락됨. 이 PR에서 보완.

- **overview.ts**: observatory groups 기반 stale/fresh 에이전트 분리 카운팅
- **quick-stats.ts**: stale annotation 표시 ("4개 등록됨, 모두 stale")
- **situation-banner.ts**: 유휴 상태 정직한 표시 ("세션, 에이전트, 키퍼 모두 비활성")
- **server_command_plane_http_support.ml**: cp-summary 동기 fallback 제거 (room-truth 타임아웃 원인)

## Problem
1. QuickStats가 shell counts fallback으로 stale 에이전트를 "활성 4"로 표시
2. `/dashboard/room-truth` API 타임아웃 — command_plane_summary의 동기 compute_cp_summary가 Swarm_status.build_json 파일 I/O에서 무한 block

## Test plan
- [ ] `cd dashboard && npx vite build` 빌드 성공
- [ ] 서버 재시작 후 `curl --max-time 5 /api/v1/dashboard/room-truth` 응답 확인
- [ ] `curl --max-time 5 /api/v1/command-plane/summary` 즉시 응답 확인
- [ ] Overview QuickStats: stale annotation 표시 확인

Generated with [Claude Code](https://claude.com/claude-code)