### PR TITLE
docs(tools): rewrite 300+ tool descriptions for agent discoverability

### DIFF
--- a/lib/tool_command_plane_schemas_01.ml
+++ b/lib/tool_command_plane_schemas_01.ml
@@ -5,7 +5,9 @@ let schemas : tool_schema list = [
     {
       name = "masc_unit_define";
       description =
-        "CPv2 benchmark step 1. Create or update a managed company/platoon/squad/agent unit before starting operations.";
+        "Create or update a managed unit (company/platoon/squad/agent) in the Command Plane V2 hierarchy. \
+Use when setting up organizational structure before starting operations (CPv2 benchmark step 1). \
+Pair with masc_operation_start to run operations on defined units.";
       input_schema =
         object_schema ~required:[ "kind"; "label" ]
           [
@@ -23,13 +25,17 @@ let schemas : tool_schema list = [
     {
       name = "masc_unit_list";
       description =
-        "Read managed and effective Command Plane V2 units, including auto-generated topology for unassigned agents.";
+        "Read managed and effective CPv2 units including auto-generated topology for unassigned agents. \
+Use when inspecting the organizational hierarchy or verifying unit definitions. \
+Pair with masc_observe_topology for a richer view with health and operation counts.";
       input_schema = object_schema [];
     };
     {
       name = "masc_unit_reparent";
       description =
-        "Move a unit under a new parent unit while preserving its policy and budget envelopes.";
+        "Move a unit under a new parent unit while preserving its policy and budget envelopes. \
+Use when restructuring the organizational hierarchy without losing existing configurations. \
+Pair with masc_unit_list to verify the new topology after reparenting.";
       input_schema =
         object_schema ~required:[ "unit_id" ]
           [
@@ -40,7 +46,9 @@ let schemas : tool_schema list = [
     {
       name = "masc_unit_reassign";
       description =
-        "Update a unit's leader or explicit roster. Use this to rotate squad leaders or replace a detachment roster.";
+        "Update a unit's leader or explicit roster for leader rotation or roster replacement. \
+Use when rotating squad leaders or adjusting the team composition of a unit. \
+Pair with masc_observe_topology to verify roster changes took effect.";
       input_schema =
         object_schema ~required:[ "unit_id" ]
           [
@@ -52,7 +60,9 @@ let schemas : tool_schema list = [
     {
       name = "masc_intent_create";
       description =
-        "Create a managed intent above goals/tasks/operations. Intents hold invariants, artifact priors, and success metrics for lifecycle control.";
+        "Create a managed intent that sits above goals/tasks/operations, holding invariants, artifact priors, and success metrics. \
+Use when starting a new workstream that needs lifecycle tracking across multiple operations. \
+Pair with masc_operation_start to attach operations under this intent.";
       input_schema =
         object_schema ~required:[ "title" ]
           [
@@ -70,7 +80,9 @@ let schemas : tool_schema list = [
     {
       name = "masc_intent_status";
       description =
-        "Read managed intents and their current focus/lifecycle summary.";
+        "Read managed intents and their current focus, lifecycle state, and linked operations. \
+Use when checking which intents are active and what they are focused on. \
+Pair with masc_intent_update to change focus or state, or masc_intent_forecast for predictions.";
       input_schema =
         object_schema
           [
@@ -80,7 +92,9 @@ let schemas : tool_schema list = [
     {
       name = "masc_intent_update";
       description =
-        "Update an intent's title, state, focus, invariants, artifact priors, or success metric.";
+        "Update an intent's title, state, focus, invariants, artifact priors, or success metric. \
+Use when an intent's direction changes or a milestone is reached. \
+After masc_intent_status to review current state; pair with masc_intent_forecast to predict next steps.";
       input_schema =
         object_schema ~required:[ "intent_id" ]
           [
@@ -99,7 +113,9 @@ let schemas : tool_schema list = [
     {
       name = "masc_intent_forecast";
       description =
-        "Predict the next likely focus states for an intent using linked operations and current focus.";
+        "Predict the next likely focus states for an intent based on linked operations and current progress. \
+Use when planning ahead or deciding which operation to start next under an intent. \
+After masc_intent_status; pair with masc_operation_start to act on the forecast.";
       input_schema =
         object_schema ~required:[ "intent_id" ]
           [
@@ -110,7 +126,9 @@ let schemas : tool_schema list = [
     {
       name = "masc_operation_start";
       description =
-        "CPv2 benchmark step 2. Start a managed operation on a ready unit after leadership, live-roster, and capacity checks pass. Set orchestration_kind=chain_dsl to attach native chain-plane execution.";
+        "Start a managed operation on a unit after leadership, roster, and capacity checks pass (CPv2 benchmark step 2). \
+Use when launching work on a defined unit with budget and policy controls. \
+After masc_unit_define; follow with masc_dispatch_tick to materialize detachments.";
       input_schema =
         object_schema ~required:[ "assigned_unit_id"; "objective" ]
           [
@@ -141,7 +159,9 @@ let schemas : tool_schema list = [
     {
       name = "masc_operation_status";
       description =
-        "Read Command Plane V2 operations. Use this after operation_start or later during CPv2 benchmark triage.";
+        "Read CPv2 operations with their current state, detachments, and trace lineage. \
+Use when triaging operations after start or monitoring progress during execution. \
+After masc_operation_start; pair with masc_observe_operations for a combined view.";
       input_schema =
         object_schema
           [ ("operation_id", string_prop "Operation id to filter."); ];
@@ -149,7 +169,9 @@ let schemas : tool_schema list = [
     {
       name = "masc_operation_checkpoint";
       description =
-        "Attach or update a checkpoint reference for a managed Command Plane V2 operation and append a trace event.";
+        "Attach or update a checkpoint reference for a managed CPv2 operation, appending a trace event. \
+Use when saving durable resume pointers at key milestones during an operation. \
+Pair with masc_operation_resume to restart from the saved checkpoint.";
       input_schema =
         object_schema ~required:[ "operation_id"; "checkpoint_ref" ]
           [
@@ -160,7 +182,9 @@ let schemas : tool_schema list = [
     };
     {
       name = "masc_operation_pause";
-      description = "Pause a managed operation and sync its managed detachment status.";
+      description = "Pause a managed operation and sync its detachment status to paused. \
+Use when the operation needs to be temporarily halted without losing progress. \
+Pair with masc_operation_resume to continue or masc_operation_stop to cancel.";
       input_schema =
         object_schema ~required:[ "operation_id" ]
           [
@@ -170,7 +194,9 @@ let schemas : tool_schema list = [
     };
     {
       name = "masc_operation_resume";
-      description = "Resume a paused managed operation.";
+      description = "Resume a paused managed operation from its last checkpoint. \
+Use when a previously paused operation is ready to continue. \
+After masc_operation_pause; pair with masc_dispatch_tick to re-materialize detachments.";
       input_schema =
         object_schema ~required:[ "operation_id" ]
           [
@@ -180,7 +206,9 @@ let schemas : tool_schema list = [
     };
     {
       name = "masc_operation_stop";
-      description = "Cancel a managed operation and mark its detachment stopped.";
+      description = "Cancel a managed operation and mark its detachment as stopped. \
+Use when an operation is no longer needed or has failed beyond recovery. \
+Pair with masc_operation_status to verify the cancellation took effect.";
       input_schema =
         object_schema ~required:[ "operation_id" ]
           [
@@ -190,7 +218,9 @@ let schemas : tool_schema list = [
     };
     {
       name = "masc_operation_finalize";
-      description = "Finalize a managed operation as completed.";
+      description = "Finalize a managed operation as completed, marking it done in the trace lineage. \
+Use when all operation objectives are met and work is finished. \
+After the operation's detachments report completion; pair with masc_observe_traces to review the full trail.";
       input_schema =
         object_schema ~required:[ "operation_id" ]
           [
@@ -201,13 +231,17 @@ let schemas : tool_schema list = [
     {
       name = "masc_chain_snapshot";
       description =
-        "Summarize native chain runtime and history, linked back to CPv2 managed operations.";
+        "Summarize native chain runtime state and run history, linked back to CPv2 managed operations. \
+Use when reviewing chain-backed operation execution or debugging chain runs. \
+Pair with masc_chain_run_get to fetch details of a specific run.";
       input_schema = object_schema [];
     };
     {
       name = "masc_chain_run_get";
       description =
-        "Fetch native chain run-store details for a completed chain run by run_id.";
+        "Fetch detailed results from the chain run store for a completed chain run by run_id. \
+Use when inspecting the output, steps, or errors of a specific chain execution. \
+After masc_chain_snapshot identifies the run_id.";
       input_schema =
         object_schema ~required:[ "run_id" ]
           [
@@ -217,7 +251,9 @@ let schemas : tool_schema list = [
     {
       name = "masc_dispatch_plan";
       description =
-        "Recommend the best target units for an operation. best_first_v1 plans include score breakdown, routing reason, and dependency blockers.";
+        "Recommend the best target units for an operation with score breakdown and routing reasons. \
+Use when deciding which unit should handle a new operation or when rebalancing. \
+Before masc_dispatch_assign to act on the recommendation.";
       input_schema =
         object_schema
           [
@@ -228,7 +264,9 @@ let schemas : tool_schema list = [
     {
       name = "masc_dispatch_assign";
       description =
-        "Assign or move an operation to a new unit. Cross-platoon or strict-policy moves become pending approvals.";
+        "Assign or move an operation to a new unit (cross-platoon moves become pending approvals). \
+Use when routing an operation to a specific unit based on dispatch plan results. \
+After masc_dispatch_plan; follow with masc_dispatch_tick to materialize.";
       input_schema =
         object_schema ~required:[ "operation_id"; "target_unit_id" ]
           [
@@ -240,7 +278,9 @@ let schemas : tool_schema list = [
     {
       name = "masc_dispatch_rebalance";
       description =
-        "Rebalance an operation to another unit using the same approval semantics as dispatch_assign.";
+        "Rebalance an operation to another unit using the same approval semantics as dispatch_assign. \
+Use when load is uneven across units and work needs redistribution. \
+After masc_observe_capacity identifies overloaded units.";
       input_schema =
         object_schema ~required:[ "operation_id"; "target_unit_id" ]
           [
@@ -252,7 +292,9 @@ let schemas : tool_schema list = [
     {
       name = "masc_dispatch_escalate";
       description =
-        "Escalate an operation toward a parent unit or explicit target unit. Cross-platoon moves require approval.";
+        "Escalate an operation toward a parent unit or explicit target (cross-platoon moves require approval). \
+Use when a unit lacks capacity or expertise and the operation needs higher-level handling. \
+Pair with masc_policy_approve if the escalation requires approval.";
       input_schema =
         object_schema ~required:[ "operation_id" ]
           [
@@ -264,7 +306,9 @@ let schemas : tool_schema list = [
     {
       name = "masc_dispatch_recall";
       description =
-        "Recall an operation by pausing it without deleting its checkpoint or trace lineage.";
+        "Recall an operation by pausing it while preserving its checkpoint and trace lineage. \
+Use when an operation needs to be pulled back temporarily without data loss. \
+Pair with masc_operation_resume to re-activate when ready.";
       input_schema =
         object_schema ~required:[ "operation_id" ]
           [
@@ -275,7 +319,9 @@ let schemas : tool_schema list = [
     {
       name = "masc_dispatch_tick";
       description =
-        "CPv2 benchmark step 3. Run one deterministic reconcile tick to materialize or repair detachments, failover, approvals, alerts, and traces.";
+        "Run one deterministic reconcile tick to materialize detachments, process failovers, approvals, alerts, and traces (CPv2 step 3). \
+Use when operations need their detachments materialized or the control plane needs reconciliation. \
+After masc_operation_start or masc_dispatch_assign; run repeatedly until stable.";
       input_schema =
         object_schema
           [
@@ -286,7 +332,9 @@ let schemas : tool_schema list = [
     {
       name = "masc_detachment_list";
       description =
-        "CPv2 benchmark observe step. List managed and projected detachments after dispatch/tick to confirm runtime materialization.";
+        "List managed and projected detachments after dispatch/tick to confirm runtime materialization. \
+Use when verifying that dispatch_tick created the expected detachments. \
+After masc_dispatch_tick; pair with masc_detachment_status for per-detachment details.";
       input_schema =
         object_schema
           [
@@ -297,7 +345,9 @@ let schemas : tool_schema list = [
     {
       name = "masc_detachment_status";
       description =
-        "CPv2 benchmark observe step. Inspect one detachment with runtime, heartbeat, failover, and approval context.";
+        "Inspect a single detachment with runtime, heartbeat, failover, and approval context. \
+Use when debugging a specific detachment or verifying its runtime state. \
+After masc_detachment_list identifies the detachment_id.";
       input_schema =
         object_schema ~required:[ "detachment_id" ]
           [
@@ -307,13 +357,17 @@ let schemas : tool_schema list = [
     {
       name = "masc_policy_status";
       description =
-        "CPv2 benchmark approval step. Read policy decisions, approval queue, capacity overlays, and topology state before strict actions.";
+        "Read policy decisions, approval queue, capacity overlays, and topology state. \
+Use when checking pending approvals or reviewing policy state before strict actions. \
+Pair with masc_policy_approve or masc_policy_deny to process pending decisions.";
       input_schema = object_schema [];
     };
     {
       name = "masc_policy_approve";
       description =
-        "Approve a pending managed policy decision and apply its queued action.";
+        "Approve a pending managed policy decision and apply its queued action. \
+Use when a cross-platoon move, escalation, or policy change needs human/admin approval. \
+After masc_policy_status shows pending decisions.";
       input_schema =
         object_schema ~required:[ "decision_id" ]
           [
@@ -324,7 +378,9 @@ let schemas : tool_schema list = [
     {
       name = "masc_policy_deny";
       description =
-        "Deny a pending managed policy decision.";
+        "Deny a pending managed policy decision, preventing its queued action. \
+Use when a proposed move or policy change should not proceed. \
+After masc_policy_status shows pending decisions.";
       input_schema =
         object_schema ~required:[ "decision_id" ]
           [
@@ -335,7 +391,9 @@ let schemas : tool_schema list = [
     {
       name = "masc_policy_update";
       description =
-        "Replace a unit's explicit policy and budget envelope.";
+        "Replace a unit's explicit policy and budget envelope. \
+Use when adjusting a unit's capacity limits, spending controls, or operational constraints. \
+Pair with masc_policy_status to review the updated configuration.";
       input_schema =
         object_schema ~required:[ "unit_id" ]
           [
@@ -347,7 +405,9 @@ let schemas : tool_schema list = [
     {
       name = "masc_policy_freeze_unit";
       description =
-        "Toggle a unit's frozen state. Frozen units reject new dispatch assignments.";
+        "Toggle a unit's frozen state so it rejects new dispatch assignments when frozen. \
+Use when a unit needs maintenance or should temporarily stop accepting new work. \
+Pair with masc_observe_capacity to check unit workload before/after freezing.";
       input_schema =
         object_schema ~required:[ "unit_id" ]
           [
@@ -358,7 +418,9 @@ let schemas : tool_schema list = [
     {
       name = "masc_policy_kill_switch";
       description =
-        "Toggle a unit kill-switch. Kill-switched units reject all new assignments.";
+        "Toggle a unit kill-switch that rejects all new assignments when enabled. \
+Use when a unit must be fully isolated from receiving any work. \
+Pair with masc_policy_status to verify the kill-switch state.";
       input_schema =
         object_schema ~required:[ "unit_id" ]
           [
@@ -369,7 +431,9 @@ let schemas : tool_schema list = [
     {
       name = "masc_observe_topology";
       description =
-        "CPv2 benchmark observe step. Read company/platoon/squad/agent topology with live roster health and active operation counts.";
+        "Read the full company/platoon/squad/agent topology with live roster health and active operation counts. \
+Use when getting a birds-eye view of the organizational structure and its operational load. \
+Pair with masc_observe_capacity for per-unit budget utilization details.";
       input_schema = object_schema [];
     };
 ]

--- a/lib/tool_command_plane_schemas_02.ml
+++ b/lib/tool_command_plane_schemas_02.ml
@@ -5,13 +5,17 @@ let schemas : tool_schema list = [
     {
       name = "masc_observe_operations";
       description =
-        "Read operations and detachments together for operator triage.";
+        "Read operations and detachments together in a single view for operator triage. \
+Use when you need a combined operations + detachments snapshot for quick assessment. \
+Pair with masc_observe_alerts for derived alerts on problematic units.";
       input_schema = object_schema [];
     };
     {
       name = "masc_observe_swarm";
       description =
-        "Read the swarm-live projection for a run or operation, including pass/fail summary, hot-slot proof, runtime blocker, and next tool guidance.";
+        "Read the swarm-live projection for a run or operation with pass/fail summary, hot-slot proof, and runtime blockers. \
+Use when monitoring a swarm-live execution or diagnosing why slots are blocked. \
+Pair with masc_swarm_live_run to start a new swarm run.";
       input_schema =
         object_schema
           [
@@ -22,19 +26,25 @@ let schemas : tool_schema list = [
     {
       name = "masc_observe_alerts";
       description =
-        "CPv2 benchmark observe step. Read derived alerts such as leader loss, over-capacity units, quiet detachments, and orphaned operations.";
+        "Read derived alerts: leader loss, over-capacity units, quiet detachments, and orphaned operations. \
+Use when scanning for problems across the command plane that need attention. \
+Pair with masc_dispatch_escalate or masc_dispatch_rebalance to address issues.";
       input_schema = object_schema [];
     };
     {
       name = "masc_observe_capacity";
       description =
-        "CPv2 benchmark observe step. Read per-unit capacity envelopes, live roster counts, and operation utilization.";
+        "Read per-unit capacity envelopes, live roster counts, and operation utilization. \
+Use when checking which units have available capacity or are overloaded. \
+Pair with masc_dispatch_rebalance to redistribute work from overloaded units.";
       input_schema = object_schema [];
     };
     {
       name = "masc_observe_traces";
       description =
-        "CPv2 benchmark observe step. Read recent trace events for a single operation or the whole command plane.";
+        "Read recent trace events for a single operation or the entire command plane. \
+Use when auditing what happened during an operation or reviewing system-wide activity. \
+Pair with masc_operation_status for the operation's current state.";
       input_schema =
         object_schema
           [
@@ -45,7 +55,9 @@ let schemas : tool_schema list = [
     {
       name = "masc_swarm_live_run";
       description =
-        "Preflight and optionally execute the deterministic swarm-live harness. The tool always writes runtime doctor and summary artifacts under .masc/control-plane/swarm-live/<run_id>/. By default, synchronous self-execution is disabled to avoid MCP server reentrancy hangs, so callers should treat this as a preflight-first orchestration surface that may return structured runtime blockers instead of an inline full run.";
+        "Preflight and optionally execute the deterministic swarm-live harness, writing artifacts under .masc/control-plane/swarm-live/. \
+Use when running a swarm benchmark or checking runtime readiness before a swarm execution. \
+Pair with masc_observe_swarm to monitor the run after launch.";
       input_schema =
         object_schema
           [

--- a/lib/tool_council_schemas.ml
+++ b/lib/tool_council_schemas.ml
@@ -5,7 +5,9 @@ let definitions =
     `Assoc
       [
         ("name", `String "masc_petition_submit");
-        ("description", `String "Submit a governance petition and file or merge a case in Governance V2.");
+        ("description", `String "Submit a governance petition and file or merge a case in Governance V2. \
+Use when proposing a policy change, reporting a violation, or requesting a governance action. \
+Pair with masc_case_status to track the resulting case.");
         ( "inputSchema",
           `Assoc
             [
@@ -39,7 +41,9 @@ let definitions =
     `Assoc
       [
         ("name", `String "masc_case_brief_submit");
-        ("description", `String "Add a brief to a governance case. Brief submission can trigger a ruling and execution order.");
+        ("description", `String "Add a brief (support/oppose/neutral) to a governance case, which can trigger a ruling and execution order. \
+Use when providing evidence or opinion on an open governance case. \
+After masc_case_status identifies the case_id; pair with masc_ruling_status to check for a ruling.");
         ( "inputSchema",
           `Assoc
             [
@@ -59,7 +63,9 @@ let definitions =
     `Assoc
       [
         ("name", `String "masc_cases");
-        ("description", `String "List governance cases from Governance V2.");
+        ("description", `String "List governance cases from Governance V2 with optional status filter. \
+Use when reviewing open, pending, or resolved governance cases. \
+Pair with masc_case_status to inspect a specific case in detail.");
         ( "inputSchema",
           `Assoc
             [
@@ -75,7 +81,9 @@ let definitions =
     `Assoc
       [
         ("name", `String "masc_case_status");
-        ("description", `String "Read a single Governance V2 case bundle.");
+        ("description", `String "Read a single Governance V2 case bundle with petitions, briefs, and rulings. \
+Use when inspecting the full details of a specific governance case. \
+After masc_cases lists available cases; pair with masc_case_brief_submit to contribute.");
         ( "inputSchema",
           `Assoc
             [
@@ -87,7 +95,9 @@ let definitions =
     `Assoc
       [
         ("name", `String "masc_ruling_status");
-        ("description", `String "Read the latest ruling for a Governance V2 case.");
+        ("description", `String "Read the latest ruling for a Governance V2 case. \
+Use when checking whether a case has been decided and what the outcome is. \
+After masc_case_brief_submit may trigger a ruling; pair with masc_execution_orders for enforcement.");
         ( "inputSchema",
           `Assoc
             [
@@ -99,7 +109,9 @@ let definitions =
     `Assoc
       [
         ("name", `String "masc_execution_orders");
-        ("description", `String "List execution orders, inspect a case order, or confirm/deny a human gate decision.");
+        ("description", `String "List execution orders, inspect a case order, or confirm/deny a human gate decision. \
+Use when reviewing or acting on enforcement actions from governance rulings. \
+After masc_ruling_status shows a ruling; confirm/deny to execute or block the order.");
         ( "inputSchema",
           `Assoc
             [
@@ -115,13 +127,17 @@ let definitions =
     `Assoc
       [
         ("name", `String "masc_governance_status");
-        ("description", `String "Read a compact Governance V2 status summary.");
+        ("description", `String "Read a compact Governance V2 status summary with open cases, pending decisions, and recent rulings. \
+Use when getting a quick overview of the governance system state. \
+Pair with masc_cases for detailed case listing or masc_governance_report for audit-level detail.");
         ("inputSchema", `Assoc [ ("type", `String "object"); ("properties", `Assoc []) ]);
       ];
     `Assoc
       [
         ("name", `String "masc_route");
-        ("description", `String "Route a query to appropriate agents using the governance router.");
+        ("description", `String "Route a query to appropriate agents using the governance router. \
+Use when you need to find which agents should handle a governance-related question. \
+Pair with masc_portal_open to directly contact the recommended agent.");
         ( "inputSchema",
           `Assoc
             [
@@ -133,7 +149,9 @@ let definitions =
     `Assoc
       [
         ("name", `String "masc_execute");
-        ("description", `String "Execute a governance decision topic via the executor API.");
+        ("description", `String "Execute a governance decision topic via the executor API to apply the ruling. \
+Use when a governance ruling needs to be enforced as an action. \
+After masc_ruling_status confirms the ruling; pair with masc_execute_dry_run to preview first.");
         ( "inputSchema",
           `Assoc
             [
@@ -150,7 +168,9 @@ let definitions =
     `Assoc
       [
         ("name", `String "masc_execute_dry_run");
-        ("description", `String "Dry-run the governance executor for a topic and result.");
+        ("description", `String "Dry-run the governance executor to preview what a ruling execution would do without applying it. \
+Use when you want to verify the effects of a governance execution before committing. \
+Before masc_execute to run the actual execution.");
         ( "inputSchema",
           `Assoc
             [

--- a/lib/tool_inline_dispatch.ml
+++ b/lib/tool_inline_dispatch.ml
@@ -979,5 +979,3 @@ Call masc_listen again to continue listening.
         ]))
 
   | _ -> Tool_inline_dispatch_extra.dispatch ~config ~agent_name ~arguments ~state ~sw ~clock ~name
-
-let schemas = Tool_schemas_inline.schemas

--- a/lib/tool_mdal_schemas.ml
+++ b/lib/tool_mdal_schemas.ml
@@ -17,7 +17,9 @@
 let schemas : Types.tool_schema list = [
   {
     name = "masc_mdal_start";
-    description = "Start a strict metric-driven loop for a deterministic numeric goal. MDAL requires auditable tool use plus re-measurement; do not use it for qualitative work.";
+    description = "Start a strict metric-driven improvement loop for a deterministic numeric goal with auditable tool use and re-measurement. \
+Use when you have a measurable target (e.g., coverage >= 0.95, lint errors <= 0) and want automated iterations. \
+Pair with masc_mdal_iterate to advance iterations and masc_mdal_stop to end the loop.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -83,7 +85,8 @@ MDAL itself does not read or score this path.");
   {
     name = "masc_mdal_status";
     description = "Get the current MDAL loop state, metric history, and persistence metadata. \
-Persisted `running` loops hydrate as `interrupted` after restart.";
+Use when checking loop progress or diagnosing an interrupted loop after restart. \
+Pair with masc_mdal_iterate to continue or masc_mdal_stop to end.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -97,7 +100,9 @@ Persisted `running` loops hydrate as `interrupted` after restart.";
 
   {
     name = "masc_mdal_iterate";
-    description = "Advance one strict MDAL iteration. The worker must use at least one auditable tool and then MDAL re-measures the metric. Only running or interrupted strict loops can iterate.";
+    description = "Advance one strict MDAL iteration: the worker uses auditable tools, then MDAL re-measures the metric. \
+Use when the loop is running/interrupted and you want to make progress toward the goal. \
+After masc_mdal_start; check masc_mdal_status to see if the goal was met.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -111,8 +116,9 @@ Persisted `running` loops hydrate as `interrupted` after restart.";
 
   {
     name = "masc_mdal_stop";
-    description = "Stop an MDAL loop when the numeric goal is no longer worth continuing. \
-Persists the final state and stop reason.";
+    description = "Stop a running MDAL loop, persisting the final state and stop reason. \
+Use when the goal is met, the metric plateaus, or the loop is no longer worth continuing. \
+After masc_mdal_iterate; pair with masc_mdal_status to review final metrics.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -129,8 +135,9 @@ Persists the final state and stop reason.";
   };
   {
     name = "masc_mdal_swarm_start";
-    description = "Start N parallel MDAL workers, each targeting a different metric. \
-A coordinator tracks aggregate progress and stops when the aggregate goal is met.";
+    description = "Start N parallel MDAL workers, each targeting a different metric, with aggregate progress tracking. \
+Use when multiple metrics need simultaneous improvement (e.g., coverage + lint + docs). \
+Pair with masc_mdal_status per worker to check individual progress.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [

--- a/lib/tool_schemas_agent.ml
+++ b/lib/tool_schemas_agent.ml
@@ -3,7 +3,9 @@ open Types
 let schemas : tool_schema list = [
   {
     name = "masc_heartbeat";
-    description = "Update your heartbeat timestamp. Call periodically (every few minutes) to indicate you're still active. Agents without heartbeat for 5+ minutes are considered 'zombies' and can be cleaned up.";
+    description = "Update your heartbeat timestamp to prove you are still active. \
+Call every few minutes during long tasks; agents silent for 5+ min become zombie candidates. \
+Prefer masc_heartbeat_start for automatic pings. Pair with masc_cleanup_zombies to reap stale agents.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -17,7 +19,9 @@ let schemas : tool_schema list = [
   };
   {
     name = "masc_cleanup_zombies";
-    description = "Clean up zombie agents (no heartbeat for 5+ minutes). Removes stale agents and releases their file locks. Run this periodically or when you suspect agent crashes.";
+    description = "Remove zombie agents (no heartbeat for 5+ min) and release their file locks. \
+Use when you see stale agents in masc_agents or suspect a crashed session left locks behind. \
+Pair with masc_gc for full room maintenance including old tasks and messages.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc []);
@@ -25,7 +29,9 @@ let schemas : tool_schema list = [
   };
   {
     name = "masc_heartbeat_start";
-    description = "Start periodic heartbeat broadcasts. Runs in background, sending pings at specified interval. Smart mode skips heartbeats when agent is busy (60-80% token savings).";
+    description = "Start automatic background heartbeat pings at a given interval. \
+Call after masc_join to keep your presence alive during long-running work. \
+Smart mode skips beats when busy. Stop with masc_heartbeat_stop before masc_leave.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -49,8 +55,8 @@ let schemas : tool_schema list = [
   };
   {
     name = "masc_heartbeat_stop";
-    description = "Stop a periodic heartbeat started by masc_heartbeat_start. \
-Use when: long task complete, no longer need keep-alive, cleaning up. \
+    description = "Stop a periodic heartbeat that was started by masc_heartbeat_start. \
+Call when your long task is complete or you are about to masc_leave. \
 Get heartbeat_id from masc_heartbeat_start response or masc_heartbeat_list.";
     input_schema = `Assoc [
       ("type", `String "object");
@@ -65,9 +71,9 @@ Get heartbeat_id from masc_heartbeat_start response or masc_heartbeat_list.";
   };
   {
     name = "masc_heartbeat_list";
-    description = "List all active heartbeats in the room. \
-Shows: heartbeat_id, agent, interval, last_beat time. \
-Use to: find orphaned heartbeats, debug presence issues, cleanup before leave.";
+    description = "List all active heartbeat timers in the room with their interval and last beat time. \
+Use when debugging presence issues or looking for orphaned heartbeats before cleanup. \
+Pair with masc_heartbeat_stop to cancel or masc_cleanup_zombies to reap dead agents.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc []);
@@ -75,7 +81,9 @@ Use to: find orphaned heartbeats, debug presence issues, cleanup before leave.";
   };
   {
     name = "masc_gc";
-    description = "Garbage collection - cleanup zombies, archive stale tasks, delete old messages. One command to clean everything older than N days.";
+    description = "Run garbage collection: remove zombie agents, archive stale tasks, delete old messages. \
+Call periodically or when the room feels cluttered; defaults to 7-day age threshold. \
+Pair with masc_archive_view to inspect what was archived or masc_cleanup_zombies for agents only.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -89,7 +97,9 @@ Use to: find orphaned heartbeats, debug presence issues, cleanup before leave.";
   };
   {
     name = "masc_agents";
-    description = "Get detailed status of all agents including zombie detection, current tasks, capabilities, and last seen time.";
+    description = "Get detailed status of all agents: zombie detection, current tasks, capabilities, and last seen time. \
+Use when you need a full roster beyond what masc_who shows, including health indicators. \
+Pair with masc_cleanup_zombies to remove stale agents or masc_find_by_capability to search.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc []);
@@ -97,7 +107,9 @@ Use to: find orphaned heartbeats, debug presence issues, cleanup before leave.";
   };
   {
     name = "masc_agent_update";
-    description = "Update agent metadata (status/capabilities). Use for external agents or manual corrections. Status guards prevent illegal transitions.";
+    description = "Update an agent's metadata (status or capabilities) with transition guards. \
+Use when you need to correct an external agent's state or change your own status to busy/listening. \
+Pair with masc_agents to verify the update or masc_register_capabilities for capability-only changes.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -120,7 +132,9 @@ Use to: find orphaned heartbeats, debug presence issues, cleanup before leave.";
   };
   {
     name = "masc_agent_card";
-    description = "Get or update the A2A-compatible Agent Card for this MASC instance. Agent Cards enable standardized agent discovery and capability advertisement. Use 'get' to retrieve current card, 'refresh' to regenerate with current bindings.";
+    description = "Get or regenerate the A2A-compatible Agent Card for this MASC instance. \
+Use when integrating with external A2A systems or verifying advertised capabilities. \
+Action 'get' returns current card; 'refresh' rebuilds it from live bindings. Pair with masc_agents.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -134,7 +148,9 @@ Use to: find orphaned heartbeats, debug presence issues, cleanup before leave.";
   };
   {
     name = "masc_heartbeat_result";
-    description = "A2A Worker submits heartbeat completion evidence. Worker receives heartbeat_task, runs an MCP tool loop directly, then reports status, tool usage, and decision metadata. MASC no longer proxies the board write.";
+    description = "Submit heartbeat completion evidence from an A2A worker after running an MCP tool loop. \
+Call when the worker finishes its heartbeat task and needs to report status, tool usage, and confidence. \
+Pair with masc_heartbeat_start on the orchestrator side. MASC records but does not proxy the board write.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -193,7 +209,9 @@ Use to: find orphaned heartbeats, debug presence issues, cleanup before leave.";
   };
   {
     name = "masc_agent_fitness";
-    description = "Get fitness scores for agents based on performance metrics. Higher scores indicate better performance (completion rate, reliability, speed). Use for understanding agent capabilities.";
+    description = "Get fitness scores for agents based on performance metrics (completion rate, reliability, speed). \
+Use when choosing which agent to assign work to or reviewing agent performance over time. \
+Pair with masc_select_agent for automated assignment or masc_agents for raw status.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -211,7 +229,9 @@ Use to: find orphaned heartbeats, debug presence issues, cleanup before leave.";
   };
   {
     name = "masc_select_agent";
-    description = "Select the best agent for a task based on fitness scores. Uses weighted scoring: completion (35%), reliability (25%), speed (15%), handoff (15%), collaboration (10%).";
+    description = "Select the best agent for a task using weighted fitness scoring (completion, reliability, speed). \
+Use when you have a task to assign and multiple agents are available. \
+Pair with masc_agent_fitness to review scores or masc_transition(action='claim') to assign directly.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -237,7 +257,9 @@ Use to: find orphaned heartbeats, debug presence issues, cleanup before leave.";
   };
   {
     name = "masc_gardener_retire_agent";
-    description = "Evaluate whether an agent should be retired. Checks population minimums, idle thresholds, and recent contributions. Returns approval/deferral/rejection with reasons. Does NOT actually retire — use masc_gardener_execute_retire for that.";
+    description = "Evaluate whether an agent should be retired based on population limits and idle thresholds. \
+Use when the ecosystem has too many agents or one appears consistently idle. \
+Returns approval/deferral/rejection. To execute, follow up with masc_gardener_execute_retire.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [

--- a/lib/tool_schemas_auth.ml
+++ b/lib/tool_schemas_auth.ml
@@ -3,7 +3,9 @@ open Types
 let schemas : tool_schema list = [
   {
     name = "masc_auth_enable";
-    description = "Enable authentication for this room. Returns a room secret that should be shared securely with authorized agents. Once enabled, agents need tokens to perform actions.";
+    description = "Enable authentication for this room and return a room secret for authorized agents. \
+Use when setting up a production room that needs access control. \
+After enabling, create tokens with masc_auth_create_token; check state with masc_auth_status.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -17,7 +19,9 @@ let schemas : tool_schema list = [
   };
   {
     name = "masc_auth_disable";
-    description = "Disable authentication for this room. All agents can perform any action without tokens.";
+    description = "Disable authentication for this room, allowing all agents unrestricted access. \
+Use when reverting to development mode or troubleshooting auth issues. \
+Pair with masc_auth_status to confirm auth is off.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc []);
@@ -25,7 +29,9 @@ let schemas : tool_schema list = [
   };
   {
     name = "masc_auth_status";
-    description = "Check authentication status for this room.";
+    description = "Check the current authentication configuration for this room (enabled, require_token, default_role). \
+Use when verifying auth state before performing privileged operations. \
+Pair with masc_auth_enable or masc_auth_disable to change settings.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc []);
@@ -33,7 +39,9 @@ let schemas : tool_schema list = [
   };
   {
     name = "masc_auth_create_token";
-    description = "Create a new authentication token for an agent. The token should be kept secret and passed in subsequent requests.";
+    description = "Create a new authentication token for an agent with a specified role (reader, worker, admin). \
+Use when onboarding a new agent to an auth-enabled room. \
+After masc_auth_enable; the token should be passed in subsequent requests.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -52,7 +60,9 @@ let schemas : tool_schema list = [
   };
   {
     name = "masc_auth_refresh";
-    description = "Refresh an expired or soon-to-expire token. Returns a new token.";
+    description = "Refresh an expired or soon-to-expire token, returning a new one. \
+Use when your current token is about to expire and you need continued access. \
+After masc_auth_create_token issued the original token.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -70,7 +80,9 @@ let schemas : tool_schema list = [
   };
   {
     name = "masc_auth_revoke";
-    description = "Revoke an agent's token. The agent will need a new token to perform authenticated actions.";
+    description = "Revoke an agent's authentication token, requiring them to obtain a new one. \
+Use when removing an agent's access or rotating compromised credentials. \
+Pair with masc_auth_create_token to issue a replacement if needed.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -84,7 +96,9 @@ let schemas : tool_schema list = [
   };
   {
     name = "masc_auth_list";
-    description = "List all agent credentials (admin only). Shows agent names, roles, and token expiry times.";
+    description = "List all agent credentials including names, roles, and token expiry times (admin only). \
+Use when auditing who has access to the room and their permission levels. \
+Pair with masc_auth_revoke to remove stale credentials.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc []);

--- a/lib/tool_schemas_core_01.ml
+++ b/lib/tool_schemas_core_01.ml
@@ -3,7 +3,9 @@ open Types
 let schemas : tool_schema list = [
   {
     name = "masc_init";
-    description = "Initialize MASC room for multi-agent collaboration. Creates .masc/ folder in current project. Call this ONCE at the start of a multi-agent session. If .masc/ already exists, you'll auto-join. Workflow: init → join → (claim tasks / broadcast / portal) → leave";
+    description = "Initialize a MASC room by creating the .masc/ folder in the current project root. \
+Use when starting a new multi-agent session for the first time; if .masc/ already exists, you auto-join instead. \
+Workflow: masc_init -> masc_join -> masc_add_task/masc_claim_next -> masc_leave. Call once per project.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -16,7 +18,9 @@ let schemas : tool_schema list = [
   };
   {
     name = "masc_transition";
-    description = "Unified task state transition (single entrypoint). Actions: claim, start, done, cancel, release. Supports CAS via expected_version (backlog.version). Use notes for done, reason for cancel.";
+    description = "Transition a task through its lifecycle states via a single entrypoint. Actions: claim, start, done, cancel, release. \
+Use when moving a task forward after masc_add_task or masc_claim_next. Supports optimistic concurrency via expected_version (CAS guard). \
+Pair with masc_add_task to create tasks, then masc_transition to advance them.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -50,7 +54,9 @@ let schemas : tool_schema list = [
   };
   {
     name = "masc_register_capabilities";
-    description = "Register your capabilities for agent discovery. Other agents can then find you by capability. Examples: ['typescript', 'code-review', 'testing', 'python', 'architecture'].";
+    description = "Register your capabilities so other agents can discover you by skill. \
+Call when joining a room or when your capabilities change. Pair with masc_find_by_capability for the lookup side. \
+Examples: ['typescript', 'code-review', 'testing', 'python', 'architecture']. Discovery category.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -69,7 +75,9 @@ let schemas : tool_schema list = [
   };
   {
     name = "masc_find_by_capability";
-    description = "Find agents by capability. Use this to discover who can help with specific tasks. Only returns non-zombie agents.";
+    description = "Find active agents that match a given capability (e.g., 'typescript', 'testing'). Only returns non-zombie agents. \
+Use when you need help with a specific skill and want to discover who is available. \
+Pair with masc_register_capabilities (write side) and masc_a2a_delegate to send work. Discovery category.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -83,8 +91,9 @@ let schemas : tool_schema list = [
   };
   {
     name = "masc_route";
-    description = "Route a query to appropriate agents using MoE-style selection. \
-Returns: selected agents, estimated cost, complexity score.";
+    description = "Route a query to the best-matching agents using MoE-style selection. Returns selected agents, estimated cost, and complexity score. \
+Use when you have a task but do not know which agent should handle it. \
+After routing, use masc_a2a_delegate or masc_spawn to dispatch work to the selected agents.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -102,7 +111,9 @@ Returns: selected agents, estimated cost, complexity score.";
   };
   {
     name = "masc_generate_key";
-    description = "Generate a new random 256-bit encryption key. Returns the key in hex format. Store this securely - losing the key means losing access to encrypted data.";
+    description = "Generate a random 256-bit encryption key in hex or base64 format. \
+Use when setting up encrypted communication between agents or securing cached data. \
+Store the key securely; losing it means losing access to encrypted data. Pair with governance tools for full security setup.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -116,7 +127,9 @@ Returns: selected agents, estimated cost, complexity score.";
   };
   {
     name = "masc_switch_mode";
-    description = "Switch MASC mode to reduce token usage. Available modes: 'minimal' (core+health), 'standard' (core+comm+worktree+health), 'parallel' (multi-agent heavy: comm+portal+discovery+voting+interrupt), 'full' (all features), 'solo' (single-agent: core+worktree). Use 'custom' with categories parameter for fine-grained control.";
+    description = "Switch the active MASC tool surface to control token usage. Modes: minimal (core+health), standard (core+comm+worktree+health), \
+parallel (multi-agent: comm+portal+discovery+voting), full (everything), solo (single-agent: core+worktree), custom (pick categories). \
+Call when starting a session or changing collaboration scope. Use masc_get_config to see current mode. Most-called MASC tool.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -136,7 +149,9 @@ Returns: selected agents, estimated cost, complexity score.";
   };
   {
     name = "masc_get_config";
-    description = "Get current MASC mode configuration. Shows enabled categories, disabled categories, and available mode presets.";
+    description = "Show the current MASC mode configuration including enabled/disabled tool categories and available presets. \
+Use when you need to verify which tools are active before calling them, or to debug 'tool not found' errors. \
+Pair with masc_switch_mode to change the active tool surface.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc []);
@@ -144,7 +159,9 @@ Returns: selected agents, estimated cost, complexity score.";
   };
   {
     name = "masc_spawn";
-    description = "Spawn an agent to execute a task. Use this to orchestrate multi-agent collaboration without manual terminal setup. When agent_name='llama', you must provide model explicitly.";
+    description = "Spawn an agent process (claude, gemini, codex, or llama) to execute a task in a subprocess. \
+Use when orchestrating multi-agent work without manual terminal setup. For llama, the model parameter is required. \
+After spawning, monitor progress via masc_dashboard or masc_observe_swarm. Pair with masc_route for agent selection.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -175,7 +192,9 @@ Returns: selected agents, estimated cost, complexity score.";
   };
   {
     name = "masc_relay_checkpoint";
-    description = "Save a checkpoint of current state for smooth handoff. Call at key moments (after completing subtasks, before complex operations). Checkpoints enable proactive relay with minimal context loss.";
+    description = "Save a checkpoint of current work state (summary, TODOs, relevant files) for smooth handoff. \
+Call when completing a subtask, before starting a complex operation, or periodically in long sessions. \
+Pair with masc_relay_now to trigger handoff using the saved checkpoint. Enables proactive relay with minimal context loss.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -207,7 +226,9 @@ Returns: selected agents, estimated cost, complexity score.";
   };
   {
     name = "masc_relay_now";
-    description = "Trigger immediate relay to a new agent. Use when context is getting full or before a complex task. The new agent will receive compressed context and continue seamlessly.";
+    description = "Trigger an immediate relay handoff to a new agent, passing compressed context for seamless continuation. \
+Use when your context window is getting full or before a task that would exceed remaining capacity. \
+After masc_relay_checkpoint saves state, call this to execute the handoff. The successor inherits your work.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -235,7 +256,9 @@ Returns: selected agents, estimated cost, complexity score.";
   };
   {
     name = "masc_relay_smart_check";
-    description = "Proactive relay check with task hint. Predicts if upcoming task will overflow context and suggests relay BEFORE starting the task. Key for smooth transitions.";
+    description = "Predict whether an upcoming task will overflow your context window and suggest relay before you start. \
+Call when about to begin a large_file read, multi_file edit, long_running operation, or exploration. \
+Pair with masc_relay_checkpoint to save state if relay is recommended. Prevents mid-task context exhaustion.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -262,7 +285,9 @@ Returns: selected agents, estimated cost, complexity score.";
   };
   {
     name = "masc_mitosis_all";
-    description = "Get mitosis status of ALL agents in the cluster (cross-machine). Shows each agent's context pressure so you can see if another agent needs handoff help. Use for collaboration awareness.";
+    description = "Get mitosis (context lifecycle) status of all agents in the cluster, including cross-machine peers. \
+Use when coordinating handoffs or checking if another agent needs help due to context pressure. \
+Pair with masc_mitosis_divide or masc_mitosis_handoff to assist agents approaching their limits.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc []);
@@ -270,7 +295,9 @@ Returns: selected agents, estimated cost, complexity score.";
   };
   {
     name = "masc_mitosis_pool";
-    description = "View the stem cell pool - reserve agents ready for instant handoff. Shows warm cells, their generation, and readiness state.";
+    description = "View the stem cell pool of reserve agents pre-warmed for instant handoff. Shows warm cells, generation number, and readiness. \
+Use when planning a handoff to check if a successor is already available, avoiding cold-start delay. \
+Pair with masc_mitosis_divide to consume a warm cell, or masc_mitosis_handoff for automated lifecycle.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc []);
@@ -278,7 +305,9 @@ Returns: selected agents, estimated cost, complexity score.";
   };
   {
     name = "masc_mitosis_divide";
-    description = "Manually trigger cell division (mitosis). Parent cell dies gracefully (apoptosis) while child cell inherits compressed DNA (context). Use for proactive handoff.";
+    description = "Manually trigger cell division: the current agent (parent) dies gracefully while a child agent inherits compressed context (DNA). \
+Use when you want explicit control over the handoff moment rather than automatic threshold-based handoff. \
+For automated lifecycle management, prefer masc_mitosis_handoff. Pair with masc_mitosis_prepare to extract DNA first.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -296,7 +325,9 @@ Returns: selected agents, estimated cost, complexity score.";
   };
   {
     name = "masc_mitosis_check";
-    description = "2-Phase mitosis check. Phase 1 (50%): should_prepare=true → extract DNA. Phase 2 (80%): should_handoff=true → execute handoff. Returns current phase and thresholds.";
+    description = "Check your current mitosis phase based on context_ratio. Phase 1 (50%): should_prepare=true, extract DNA. Phase 2 (80%): should_handoff=true, execute handoff. \
+Call when you want to know your lifecycle phase without taking action. \
+Pair with masc_mitosis_prepare at 50% and masc_mitosis_divide at 80%, or use masc_mitosis_handoff for the full automated flow.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -309,7 +340,9 @@ Returns: selected agents, estimated cost, complexity score.";
   };
   {
     name = "masc_mitosis_record";
-    description = "Record activity for mitosis trigger tracking. Call after completing tasks or tool calls to update counters.";
+    description = "Record an activity event (task completion or tool call) to update mitosis trigger counters. \
+Call when you finish a task or make a tool call so that mitosis thresholds stay accurate. \
+Pair with masc_mitosis_check to read the counters and determine if handoff preparation is needed.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -326,7 +359,9 @@ Returns: selected agents, estimated cost, complexity score.";
   };
   {
     name = "masc_mitosis_prepare";
-    description = "Phase 1: Prepare for division - extract DNA and mark cell as ready. Does NOT handoff yet. Call this at 50% context to prepare early, actual handoff happens at 80%.";
+    description = "Phase 1 of mitosis: extract compressed DNA from your full context and mark yourself as ready for division. Does NOT handoff yet. \
+Call when masc_mitosis_check reports should_prepare=true (around 50% context). \
+After preparation, masc_mitosis_divide or masc_mitosis_handoff executes the actual handoff at 80%.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -340,15 +375,10 @@ Returns: selected agents, estimated cost, complexity score.";
   };
   {
     name = "masc_mitosis_handoff";
-    description = {|2-Phase Proactive Context Management - THE CORE MITOSIS TOOL
-
-Call this periodically with your estimated context_ratio. It handles the full lifecycle:
-- <50%: Returns "none" - continue working normally
-- 50-80%: Returns "prepared" - DNA extracted, ready for handoff
-- >80%: Returns "handoff" - spawns successor agent with DNA
-
-Unlike masc_mitosis_divide (manual), this auto-detects phase and takes appropriate action.
-Embodies proactive mitosis: prepare early at 50%, handoff at 80%.|};
+    description = "Automated 2-phase context lifecycle manager. Call periodically with your estimated context_ratio. \
+<50%: returns 'none' (keep working). 50-80%: returns 'prepared' (DNA extracted). >80%: returns 'handoff' (spawns successor). \
+Use when you want hands-off lifecycle management instead of manual masc_mitosis_check/prepare/divide steps. \
+Supports async saga, LLM verification, and configurable pass consensus. The primary mitosis tool for most agents.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -431,16 +461,10 @@ Embodies proactive mitosis: prepare early at 50%, handoff at 80%.|};
   };
   {
     name = "masc_metrics_compare";
-    description = {|Compare generational performance metrics.
-
-Evidence for "Are successors better than predecessors?"
-Compares two generations across:
-- Task completion rate
-- Error rate
-- Duration (speed)
-- Token efficiency
-
-Returns verdict: "improved" / "degraded" / "neutral"|};
+    description = "Compare performance metrics between two agent generations (completion rate, error rate, duration, token efficiency). \
+Returns a verdict: improved, degraded, or neutral. \
+Use when evaluating whether mitosis succession is producing better agents over time. \
+Pair with masc_metrics_record to populate the data that this tool analyzes.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -458,9 +482,9 @@ Returns verdict: "improved" / "degraded" / "neutral"|};
   };
   {
     name = "masc_metrics_record";
-    description = {|Record a task completion for generational metrics.
-
-Call after completing a task to track performance across generations.|};
+    description = "Record a task completion event (duration, errors, tokens) for generational performance tracking. \
+Call when you finish a task to feed data into the metrics system. \
+Pair with masc_metrics_compare to analyze trends across generations.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -494,15 +518,10 @@ Call after completing a task to track performance across generations.|};
   };
   {
     name = "masc_memento_mori";
-    description = {|Memento Mori - Agent self-awareness of mortality.
-A convenience tool combining mitosis check + prepare + divide in one call.
-Call this periodically to check your context health and auto-handle lifecycle:
-- <50%: Returns "continue" - keep working
-- 50-80%: Auto-prepares DNA, returns "prepared" - ready for handoff when needed
-- >80%: Auto-divides and spawns successor, returns handoff result
-
-This embodies the philosophical concept of "memento mori" - agents should be aware
-of their context limits and gracefully hand over work to successors.|};
+    description = "All-in-one context health check combining mitosis check + prepare + divide in a single call. \
+<50%: continue. 50-80%: auto-prepares DNA. >80%: auto-divides and spawns successor. \
+Call when you want a simple periodic lifecycle check without managing individual mitosis steps. \
+Similar to masc_mitosis_handoff but with a simpler interface. Use either one, not both.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -532,17 +551,9 @@ of their context limits and gracefully hand over work to successors.|};
   };
   {
     name = "masc_episode_flush";
-    description = {|Flush pending episodes to Neo4j and PostgreSQL.
-
-Episodes are queued locally during mitosis handoff (file-based queue for reliability).
-This tool flushes them to persistent storage (Neo4j for graph relationships, PostgreSQL for queries).
-
-Part of the Agent Being Protocol - agents are "beings" with memory continuity across generations.
-
-Returns:
-- flushed: Number of episodes successfully saved to DB
-- failed: Number of episodes that failed (kept in queue for retry)
-- pending: Remaining episodes in queue|};
+    description = "Flush locally queued episodes to Neo4j (graph) and PostgreSQL (relational) persistent storage. \
+Use when episodes have accumulated during mitosis handoffs and need to be persisted. Returns flushed/failed/pending counts. \
+Call periodically or after handoff events. Pair with masc_episode_list to verify persisted episodes.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -559,12 +570,9 @@ Returns:
   };
   {
     name = "masc_episode_list";
-    description = {|List recent episodes from PostgreSQL.
-
-Query agent episodes with optional filters. Returns episode metadata for debugging
-and understanding agent lineage.
-
-Part of the Agent Being Protocol - agents can reflect on their history.|};
+    description = "List recent agent episodes from PostgreSQL with optional filters by agent_name and generation. \
+Use when debugging agent lineage, reviewing past handoffs, or understanding what a previous generation accomplished. \
+Pair with masc_episode_flush to ensure local episodes are persisted before querying.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -585,16 +593,9 @@ Part of the Agent Being Protocol - agents can reflect on their history.|};
   };
   {
     name = "masc_self_introspect";
-    description = {|Agent self-awareness introspection.
-
-Returns the agent's current lifecycle state:
-- generation: Current generation number (how many mitosis events in lineage)
-- context_used: Estimated context usage percentage
-- siblings: Other agents of the same generation in the room
-- parent_episode: Episode ID of the parent (if known)
-- estimated_lifespan: Tokens/turns remaining before mitosis needed
-
-Part of the Agent Being Protocol - agents should know their place in the lifecycle.|};
+    description = "Return your current lifecycle state: generation number, context usage, sibling agents, parent episode, and estimated remaining lifespan. \
+Use when you need self-awareness about your position in the agent lineage or to decide if mitosis preparation is needed. \
+Pair with masc_mitosis_check for threshold-based decisions or masc_episode_list for historical context. Discovery category.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc []);
@@ -602,12 +603,9 @@ Part of the Agent Being Protocol - agents should know their place in the lifecyc
   };
   {
     name = "masc_recall_search";
-    description = {|Semantic memory search using local memory sources.
-
-Searches the agent's episodic memories using relevance scoring.
-Part of the Agent Being Protocol - agents can recall relevant past experiences.
-
-Returns matched memories with relevance scores, sorted by relevance.|};
+    description = "Search agent episodic memories using semantic relevance scoring. Returns matched memories sorted by relevance. \
+Use when you need to recall past experiences, decisions, or context from previous generations or sessions. \
+Pair with masc_episode_list for structured episode queries, or masc_self_introspect for current lifecycle state.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [

--- a/lib/tool_schemas_core_02.ml
+++ b/lib/tool_schemas_core_02.ml
@@ -3,7 +3,9 @@ open Types
 let schemas : tool_schema list = [
   {
     name = "masc_a2a_discover";
-    description = "Discover available A2A agents. Returns agent cards with capabilities, skills, and protocol bindings. Use for local room discovery or remote endpoint fetching.";
+    description = "Discover available A2A (Agent-to-Agent) agents and return their cards with capabilities, skills, and protocol bindings. \
+Use when you need to find collaborators in the local room or at a remote endpoint before delegating work. \
+Pair with masc_a2a_query_skill for detail on a specific skill, then masc_a2a_delegate to dispatch tasks.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -20,7 +22,9 @@ let schemas : tool_schema list = [
   };
   {
     name = "masc_a2a_query_skill";
-    description = "Query detailed information about an agent's skill, including input/output modes and examples. Use to understand what a skill can do before delegating.";
+    description = "Query detailed information about an agent's specific skill, including input/output modes and usage examples. \
+Use when you found an agent via masc_a2a_discover and need to understand a skill's interface before delegating. \
+After reviewing the skill details, call masc_a2a_delegate to send the actual task.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -38,7 +42,9 @@ let schemas : tool_schema list = [
   };
   {
     name = "masc_a2a_delegate";
-    description = "Delegate a task to another A2A agent. Opens portal, sends task, returns task ID. Use sync for waiting, async for fire-and-forget, stream for real-time updates.";
+    description = "Delegate a task to another A2A agent by opening a portal and sending a message. Returns a task ID for tracking. \
+Use when you have identified a target agent (via masc_a2a_discover or masc_route) and want to dispatch work. \
+Modes: sync (wait for result), async (fire-and-forget), stream (real-time updates). Pair with masc_a2a_subscribe for async monitoring.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -79,7 +85,9 @@ let schemas : tool_schema list = [
   };
   {
     name = "masc_a2a_subscribe";
-    description = "Subscribe to events from agents (task updates, broadcasts, completions). Connect to SSE endpoint to receive events.";
+    description = "Subscribe to SSE events from agents: task_update, broadcast, completion, or error. Returns a subscription_id for polling. \
+Use when monitoring delegated tasks or observing room activity in the background. \
+After subscribing, call masc_poll_events to read buffered events. Call masc_a2a_unsubscribe when done to free resources.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -101,11 +109,9 @@ let schemas : tool_schema list = [
   };
   {
     name = "masc_a2a_unsubscribe";
-    description = "Stop receiving events from a background subscription. \
-Call when: (1) done monitoring, (2) switching to different events, (3) cleanup before leave. \
-Frees server resources - always unsubscribe when done. \
-Get subscription_id from masc_a2a_subscribe response. \
-Example: masc_a2a_unsubscribe({subscription_id: 'sub-abc123'})";
+    description = "Stop receiving events from a background A2A subscription and free server resources. \
+Call when done monitoring delegated tasks, switching event types, or cleaning up before masc_leave. \
+Use the subscription_id returned by masc_a2a_subscribe. Always unsubscribe when monitoring is complete.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -119,7 +125,9 @@ Example: masc_a2a_unsubscribe({subscription_id: 'sub-abc123'})";
   };
   {
     name = "masc_poll_events";
-    description = "Poll buffered events for a subscription. Use this for background subscription workflow: subscribe → do work → poll_events periodically. Returns and clears buffered events.";
+    description = "Poll and retrieve buffered events for a background subscription. Returns accumulated events and clears the buffer by default. \
+Use when you have an active masc_a2a_subscribe subscription and want to check for updates between work steps. \
+Workflow: masc_a2a_subscribe -> do work -> masc_poll_events -> repeat -> masc_a2a_unsubscribe.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -138,7 +146,9 @@ Example: masc_a2a_unsubscribe({subscription_id: 'sub-abc123'})";
   };
   {
     name = "masc_tempo";
-    description = "Get or set cluster tempo (pace control). Use to slow down for careful work or speed up for simple tasks.";
+    description = "Get or set the cluster-wide tempo (pace control) for coordinated work speed. \
+Use when you need to slow down for careful review work or speed up for batch processing. \
+Pair with masc_tempo_get/masc_tempo_set/masc_tempo_adjust for granular orchestrator-level tempo control.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -162,7 +172,9 @@ Example: masc_a2a_unsubscribe({subscription_id: 'sub-abc123'})";
   };
   {
     name = "masc_mcp_session";
-    description = "Manage MCP sessions (Mcp-Session-Id; legacy X-MCP-Session-ID also accepted). Sessions track client context across requests.";
+    description = "Manage MCP sessions that track client context across requests. Actions: get, create, list, cleanup, remove. \
+Use when debugging session state, cleaning up stale sessions, or creating a new session for a client. \
+Accepts both Mcp-Session-Id and legacy X-MCP-Session-ID headers. Pair with masc_init for room-level setup.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -185,7 +197,9 @@ Example: masc_a2a_unsubscribe({subscription_id: 'sub-abc123'})";
   };
   {
     name = "masc_cancellation";
-    description = "Manage cancellation tokens for long-running operations. Check tokens to abort work gracefully.";
+    description = "Create, cancel, check, list, or cleanup cancellation tokens for long-running operations. \
+Use when you need cooperative cancellation: create a token before starting work, check it periodically, cancel it to signal abort. \
+Pair with masc_progress to track and cancel long tasks. Enables graceful shutdown of spawned or delegated work.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -208,7 +222,9 @@ Example: masc_a2a_unsubscribe({subscription_id: 'sub-abc123'})";
   };
   {
     name = "masc_subscription";
-    description = "Subscribe to resource changes (tasks, agents, messages, votes). Receive notifications via polling or SSE.";
+    description = "Subscribe to resource change notifications for tasks, agents, messages, or votes. Receive updates via polling or SSE. \
+Use when you want to react to room state changes without repeatedly calling status tools. \
+Actions: subscribe, unsubscribe, list, poll. Pair with masc_a2a_subscribe for agent-level events.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -240,7 +256,9 @@ Example: masc_a2a_unsubscribe({subscription_id: 'sub-abc123'})";
   };
   {
     name = "masc_progress";
-    description = "Send progress notifications for long-running tasks. Broadcasts via SSE using MCP notifications/progress format.";
+    description = "Send progress notifications for long-running tasks, broadcast via SSE in MCP notifications/progress format. \
+Use when executing a multi-step task and other agents or the dashboard need to see real-time progress (0.0-1.0). \
+Actions: start, update, step, complete, stop. Pair with masc_cancellation to allow aborting tracked tasks.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -271,7 +289,9 @@ Example: masc_a2a_unsubscribe({subscription_id: 'sub-abc123'})";
   };
   {
     name = "masc_handover_create";
-    description = "Create a handover record (agent's 'last will') before context limit or session end. Contains goal, progress, decisions, warnings for the next agent. Inspired by Stanford Generative Agents memory stream + Erlang 'let it crash' supervisor pattern.";
+    description = "Create a structured handover record (goal, progress, decisions, warnings, pending steps) before context exhaustion or session end. \
+Use when approaching context limits, timing out, or completing a session and another agent will continue. \
+Pair with masc_handover_list to find pending handovers and masc_handover_get to read one before claiming work.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -345,7 +365,9 @@ Example: masc_a2a_unsubscribe({subscription_id: 'sub-abc123'})";
   };
   {
     name = "masc_handover_list";
-    description = "List all handover records, optionally filtering by pending (unclaimed) ones. Use to see what work is waiting to be picked up.";
+    description = "List all handover records with optional filtering for pending (unclaimed) ones. \
+Use when joining a room to see what work previous agents left behind, or to monitor incomplete handoffs. \
+After finding a pending handover, call masc_handover_get for full details, then masc_claim_next to take over.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -359,7 +381,9 @@ Example: masc_a2a_unsubscribe({subscription_id: 'sub-abc123'})";
   };
   {
     name = "masc_handover_get";
-    description = "Get full details of a handover record as formatted markdown. Use to understand context before claiming.";
+    description = "Get the full details of a handover record as formatted markdown, including goal, progress, decisions, and warnings. \
+Use when you found a handover via masc_handover_list and need to understand the full context before claiming the work. \
+After reviewing, use masc_transition to claim the associated task and continue where the previous agent left off.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -373,7 +397,9 @@ Example: masc_a2a_unsubscribe({subscription_id: 'sub-abc123'})";
   };
   {
     name = "masc_cache_set";
-    description = "Set a cache entry for sharing context between agents. Useful for caching file contents, API responses, or expensive computations.";
+    description = "Set a key-value cache entry shared across all agents in the room. Supports optional TTL and tags for filtering. \
+Use when you want to share file contents, API responses, or expensive computation results with other agents. \
+Pair with masc_cache_get to retrieve entries. Use masc_cache_list to browse, masc_cache_delete to invalidate.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -400,7 +426,9 @@ Example: masc_a2a_unsubscribe({subscription_id: 'sub-abc123'})";
   };
   {
     name = "masc_cache_get";
-    description = "Get a cached entry by key. Returns null if not found or expired.";
+    description = "Retrieve a cached entry by key. Returns null if the key does not exist or the TTL has expired. \
+Use when you need data that another agent may have cached (file contents, API responses, computation results). \
+Pair with masc_cache_set to write entries and masc_cache_list to discover available keys.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -414,9 +442,9 @@ Example: masc_a2a_unsubscribe({subscription_id: 'sub-abc123'})";
   };
   {
     name = "masc_cache_delete";
-    description = "Delete a specific cache entry. \
-Use when: invalidating stale data, clearing specific key, freeing memory. \
-No error if key doesn't exist. Use masc_cache_list to find keys.";
+    description = "Delete a specific cache entry by key. No error if the key does not exist. \
+Use when invalidating stale data, clearing a specific key after use, or freeing memory. \
+Pair with masc_cache_list to find keys before deleting. For bulk cleanup, use masc_cache_clear instead.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -430,10 +458,9 @@ No error if key doesn't exist. Use masc_cache_list to find keys.";
   };
   {
     name = "masc_cache_list";
-    description = "List cache entries with keys, TTL remaining, and tags. \
-Filter by tag to find related entries. Shows creation time and expiry. \
-Use before: cache cleanup, debugging stale data, finding specific entries. \
-Example: masc_cache_list({tag: 'api'}) → [{key: 'user_123', ttl: 3600, tags: ['api']}]";
+    description = "List all cache entries showing keys, TTL remaining, tags, and creation time. Supports filtering by tag. \
+Use when browsing available cached data, debugging stale entries, or planning cleanup. \
+Pair with masc_cache_get to read a specific entry, masc_cache_delete to remove one, or masc_cache_clear for full reset.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -446,9 +473,9 @@ Example: masc_cache_list({tag: 'api'}) → [{key: 'user_123', ttl: 3600, tags: [
   };
   {
     name = "masc_cache_clear";
-    description = "Delete ALL cache entries. DESTRUCTIVE - cannot be undone. \
-Use only when: resetting room state, debugging cache issues, fresh start. \
-Consider masc_cache_delete for targeted cleanup instead.";
+    description = "Delete ALL cache entries at once. DESTRUCTIVE and cannot be undone. \
+Use only when resetting room state, debugging persistent cache corruption, or starting fresh. \
+Prefer masc_cache_delete for targeted removal. Check masc_cache_stats before clearing to understand impact.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc []);
@@ -456,9 +483,9 @@ Consider masc_cache_delete for targeted cleanup instead.";
   };
   {
     name = "masc_cache_stats";
-    description = "Get cache usage statistics. \
-Shows: total entries, memory size, oldest/newest entry age, hit/miss ratio. \
-Use to: monitor cache health, decide when to clear, debug performance.";
+    description = "Get cache usage statistics: total entries, memory size, oldest/newest entry age, and hit/miss ratio. \
+Use when monitoring cache health, deciding whether to run masc_cache_clear, or debugging cache performance. \
+Pair with masc_cache_list for entry-level detail or masc_cache_clear if stats indicate bloat.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc []);
@@ -466,7 +493,9 @@ Use to: monitor cache health, decide when to clear, debug performance.";
   };
   {
     name = "masc_tempo_get";
-    description = "Get current orchestrator tempo (check interval). Shows adaptive tempo status.";
+    description = "Get the current orchestrator tempo (check interval in seconds) and adaptive tempo status. \
+Use when you want to see how frequently the orchestrator is polling without changing it. \
+Pair with masc_tempo_set to manually adjust or masc_tempo_adjust for automatic urgency-based tuning.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc []);
@@ -474,7 +503,9 @@ Use to: monitor cache health, decide when to clear, debug performance.";
   };
   {
     name = "masc_tempo_set";
-    description = "Set orchestrator tempo manually. Interval is clamped between 60s (fast) and 600s (slow).";
+    description = "Manually set the orchestrator check interval in seconds (clamped to 60s-600s range). \
+Use when you need a specific polling frequency for the current workload, overriding adaptive tempo. \
+Pair with masc_tempo_get to check the current interval or masc_tempo_adjust for automatic tuning.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -492,7 +523,9 @@ Use to: monitor cache health, decide when to clear, debug performance.";
   };
   {
     name = "masc_tempo_adjust";
-    description = "Automatically adjust tempo based on pending task urgency. Fast for urgent tasks, slow when idle.";
+    description = "Automatically adjust the orchestrator tempo based on pending task urgency. Speeds up for urgent tasks, slows down when idle. \
+Call when workload has changed and you want the orchestrator to adapt without manually setting an interval. \
+Pair with masc_tempo_get to verify the result, or masc_tempo_set to override with a specific value.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc []);
@@ -500,7 +533,9 @@ Use to: monitor cache health, decide when to clear, debug performance.";
   };
   {
     name = "masc_dashboard";
-    description = "Show the MASC dashboard. By default it summarizes all rooms, and you can filter to the current room with scope='current'. Use with 'watch -n 1' for real-time updates.";
+    description = "Show the MASC dashboard with agents, tasks, and room status. Defaults to all rooms; use scope='current' for the active room only. \
+Use when you need a quick overview of the cluster state, agent activity, or task progress. \
+Pair with masc_observe_swarm for deeper operational metrics. Supports compact mode for single-line summary. Core_Ops category.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -518,7 +553,9 @@ Use to: monitor cache health, decide when to clear, debug performance.";
   };
   {
     name = "masc_collaboration_graph";
-    description = "View the Hebbian collaboration graph showing learned agent relationships. Stronger connections indicate successful collaboration patterns.";
+    description = "View the Hebbian collaboration graph that tracks learned agent-to-agent relationships weighted by collaboration success. \
+Use when deciding which agent to delegate to, or reviewing collaboration patterns for optimization. \
+Pair with masc_consolidate_learning to decay old connections and prune weak links. Discovery category.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -533,7 +570,9 @@ Use to: monitor cache health, decide when to clear, debug performance.";
   };
   {
     name = "masc_consolidate_learning";
-    description = "Trigger Hebbian consolidation - apply decay to old collaboration patterns and prune weak connections. Mimics memory consolidation during sleep.";
+    description = "Apply decay to old Hebbian collaboration patterns and prune weak connections, similar to memory consolidation during sleep. \
+Call when the collaboration graph has accumulated stale connections (default: decay after 7 days). \
+Pair with masc_collaboration_graph to view the graph before and after consolidation. Discovery category.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -547,7 +586,9 @@ Use to: monitor cache health, decide when to clear, debug performance.";
   };
   {
     name = "masc_verify_handoff";
-    description = "Verify handoff context integrity. Compares original and received context to detect semantic drift, information loss, or distortion. Threshold: 0.85 similarity.";
+    description = "Verify handoff context integrity by comparing original and received context for semantic drift, information loss, or distortion. \
+Use when a successor agent receives context from a predecessor and wants to confirm nothing critical was lost (threshold: 0.85). \
+Call after masc_relay_now or masc_mitosis_handoff completes. Pair with masc_handover_get for the original context.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -570,7 +611,9 @@ Use to: monitor cache health, decide when to clear, debug performance.";
   };
   {
     name = "masc_get_metrics";
-    description = "Get raw performance metrics for an agent. Returns task completion data, timing, error rates, and collaboration history.";
+    description = "Get raw performance metrics for a specific agent: task completion data, timing, error rates, and collaboration history over N days. \
+Use when evaluating agent reliability before delegation or reviewing an agent's track record. \
+Pair with masc_audit_stats for security-focused metrics, or masc_metrics_compare for cross-generation analysis. Discovery category.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -589,7 +632,9 @@ Use to: monitor cache health, decide when to clear, debug performance.";
   };
   {
     name = "masc_audit_query";
-    description = "Query audit logs to inspect agent actions and security events. Returns recent security events: auth success/failure, anomalies, violations. Use for trust verification and debugging collaboration issues.";
+    description = "Query audit logs for security events: auth success/failure, anomaly detection, violations, and tool calls. Filterable by agent and event type. \
+Use when investigating suspicious agent behavior, verifying trust, or debugging collaboration issues. \
+Pair with masc_audit_stats for aggregated trust metrics, or masc_governance_report for periodic governance reviews.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -625,7 +670,9 @@ Use to: monitor cache health, decide when to clear, debug performance.";
   };
   {
     name = "masc_audit_stats";
-    description = "Get security statistics and trust metrics for agents. Shows auth success rate, anomaly count, task completion rate per agent. Use to evaluate agent reliability before delegation.";
+    description = "Get aggregated security statistics and trust metrics per agent: auth success rate, anomaly count, and task completion rate. \
+Use when evaluating an agent's reliability before delegating sensitive work, or during periodic trust reviews. \
+Pair with masc_audit_query for raw event detail, or masc_get_metrics for performance-focused (non-security) metrics.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -638,7 +685,9 @@ Use to: monitor cache health, decide when to clear, debug performance.";
   };
   {
     name = "masc_governance_report";
-    description = "Generate a governance summary report from the audit trail. Aggregates per-agent action counts, cost estimates, token usage, and failure rates over a time period. Use for periodic governance review and cost tracking.";
+    description = "Generate a governance summary report aggregating per-agent action counts, cost estimates, token usage, and failure rates over a time period. \
+Use when conducting periodic governance reviews, tracking costs, or preparing operational reports. \
+Pair with masc_audit_query for drill-down into specific events, or masc_governance_set to adjust security policies.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -655,7 +704,9 @@ Use to: monitor cache health, decide when to clear, debug performance.";
   };
   {
     name = "masc_governance_set";
-    description = "Configure governance policies for the room. Enables audit logging, anomaly detection, and agent isolation. Enterprise security for production use.";
+    description = "Configure room governance policies: security level (development/production/enterprise/paranoid), audit logging, and anomaly detection. \
+Use when setting up a room for production or high-security work, or when changing security posture mid-session. \
+Pair with masc_governance_report to review the effect of policy changes, and masc_audit_query to inspect events.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [

--- a/lib/tool_schemas_core_03.ml
+++ b/lib/tool_schemas_core_03.ml
@@ -3,7 +3,7 @@ open Types
 let schemas : tool_schema list = [
   {
     name = "masc_walph_loop";
-    description = "Walph pattern: Keep claiming and completing tasks until stop condition. Iterates claim_next → work → done cycle. Control via @walph in broadcast: START <preset>, STOP, PAUSE, RESUME, STATUS. Presets: coverage → test coverage FeedbackLoop, refactor → lint FeedbackLoop, docs → doc coverage FeedbackLoop, review → PR review pipeline, figma → SSIM visual fidelity loop, drain → simple claim loop.";
+    description = "Autonomous claim-work-done loop that drains a task backlog using a preset strategy. \nUse when you need repeated task execution (test coverage, lint, docs, review, figma SSIM, or drain). \nPair with masc_walph_control to STOP/PAUSE/RESUME mid-run. Also controllable via @walph in broadcast.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -55,7 +55,9 @@ let schemas : tool_schema list = [
   };
   {
     name = "masc_walph_control";
-    description = "Control a running @walph loop. Commands: STOP (end loop after current iteration), PAUSE (suspend loop), RESUME (continue paused loop), STATUS (get current state). Can also be triggered via broadcast: '@walph STOP', '@walph PAUSE', etc.";
+    description = "Send a control command (STOP, PAUSE, RESUME, STATUS) to a running walph loop. \
+Use when you need to halt, suspend, or inspect a walph loop mid-execution. \
+Pair with masc_walph_loop which starts the loop. Broadcast '@walph STOP' is equivalent.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -74,7 +76,7 @@ let schemas : tool_schema list = [
   };
   {
     name = "masc_walph_natural";
-    description = "Control Walph loop using natural language. Heuristic-based intent classification (Korean/English). Examples: '커버리지 올려줘' → START coverage, '그만' → STOP, '잠깐 멈춰' → PAUSE, '다시 시작' → RESUME, '지금 뭐해?' → STATUS. Uses direct LLM calls for ambiguous message classification.";
+    description = "Interpret a natural-language message (Korean or English) and map it to a walph control action. \nUse when human input is informal (e.g. 'stop the loop'). \nCalls masc_walph_loop or masc_walph_control internally after intent classification.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -92,7 +94,7 @@ let schemas : tool_schema list = [
   };
   {
     name = "masc_hat_wear";
-    description = "Wear a hat (role) to specialize agent behavior. Hats: builder (🔨 code), reviewer (🔍 review), researcher (🔬 explore), tester (🧪 tests), architect (📐 design), debugger (🐛 fix), documenter (📝 docs). Broadcast format: @agent:hat (e.g., @claude:builder).";
+    description = "Assign a role hat to an agent, specializing its behavior for a task domain. \nUse when switching focus: builder (code), reviewer, researcher, tester, architect, debugger, documenter. \nPair with masc_hat_status to check current hat. Broadcast shows as @agent:hat.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -115,7 +117,9 @@ let schemas : tool_schema list = [
   };
   {
     name = "masc_convo_start";
-    description = "Start a new conversation thread on a topic. Returns thread_id for subsequent replies. Conversations persist to file and Neo4j for queryability. Loop prevention: max 50 turns by default.";
+    description = "Open a new multi-agent conversation thread on a topic and get a thread_id. \
+Use when agents need structured discussion (design decisions, reviews, disputes). \
+After starting, use masc_convo_reply to add turns and masc_convo_conclude to close.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -146,7 +150,9 @@ let schemas : tool_schema list = [
   };
   {
     name = "masc_convo_reply";
-    description = "Add a reply to an existing conversation thread. Includes loop prevention: blocks identical consecutive messages (3x) and cooldown violations (2s between same speaker). Returns updated thread.";
+    description = "Post a reply to an existing conversation thread. \
+Use when contributing to an ongoing multi-agent discussion started by masc_convo_start. \
+Built-in loop prevention blocks identical consecutive messages and enforces 2s cooldown per speaker.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -181,7 +187,9 @@ let schemas : tool_schema list = [
   };
   {
     name = "masc_convo_conclude";
-    description = "Conclude a conversation with a summary/decision. Marks thread as Concluded and adds final turn. No more replies allowed after this.";
+    description = "Close a conversation thread with a final summary or decision. \
+Use when consensus is reached or discussion is complete. No further replies are allowed after this. \
+Pair with masc_convo_start (open) and masc_convo_reply (discuss) to form the full lifecycle.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -203,7 +211,9 @@ let schemas : tool_schema list = [
   };
   {
     name = "masc_convo_get";
-    description = "Get a conversation thread by ID. Returns full thread with all turns, participants, and status.";
+    description = "Retrieve a conversation thread by ID, including all turns, participants, and current status. \
+Use when you need to read the history of a discussion before replying or concluding. \
+Pair with masc_convo_list to find thread IDs.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -217,7 +227,9 @@ let schemas : tool_schema list = [
   };
   {
     name = "masc_convo_list";
-    description = "List all active conversation threads in the current room.";
+    description = "List all active conversation threads in the current room. \
+Use when checking what discussions are in progress before starting a new one. \
+Pair with masc_convo_get to read a specific thread.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc []);
@@ -225,7 +237,9 @@ let schemas : tool_schema list = [
   };
   {
     name = "masc_gardener_health";
-    description = "Get comprehensive ecosystem health metrics. Returns agent population stats (total, active, idle), activity metrics (posts, comments, unanswered questions), homeostatic score, and intervention recommendations. Use this to understand if the ecosystem needs spawning or retirement.";
+    description = "Return ecosystem health metrics: population stats, activity counts, homeostatic score, and recommendations. \
+Use when deciding whether to spawn or retire agents. \
+Pair with masc_gardener_propose_spawn or masc_gardener_retire_agent based on the score.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc []);
@@ -233,7 +247,9 @@ let schemas : tool_schema list = [
   };
   {
     name = "masc_gardener_config";
-    description = "Get current Gardener configuration from environment variables. Shows population bounds (min/max/target), daily budgets, cooldowns, and circuit breaker status.";
+    description = "Return current Gardener configuration: population bounds, daily budgets, cooldowns, and circuit breaker state. \
+Use when diagnosing why a spawn or retirement was rejected. \
+Pair with masc_gardener_health for live ecosystem metrics.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc []);
@@ -241,7 +257,7 @@ let schemas : tool_schema list = [
   };
   {
     name = "masc_gardener_propose_spawn";
-    description = "Evaluate whether a new agent should be spawned for a given topic. Uses LLM decision (if enabled) or rule-based logic. Returns approval/deferral/rejection with reasons. Does NOT actually create the agent — use masc_gardener_execute_spawn for that.";
+    description = "Evaluate whether a new agent should be spawned for a topic (approval/deferral/rejection). \nUse when a capability gap is detected and you want to check spawn eligibility before acting. \nDoes NOT create the agent. After approval, call masc_gardener_execute_spawn to proceed.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -265,7 +281,9 @@ let schemas : tool_schema list = [
   };
   {
     name = "masc_library_list";
-    description = "List all documents in the agent knowledge library. Returns title, confidence, source, and tags for each document.";
+    description = "List all documents in the agent knowledge library with title, confidence, source, and tags. \
+Use when browsing available knowledge before reading or adding a document. \
+Pair with masc_library_read for full content or masc_library_search for keyword lookup.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -278,7 +296,9 @@ let schemas : tool_schema list = [
   };
   {
     name = "masc_library_read";
-    description = "Read a specific library document by topic name.";
+    description = "Read the full content of a library document by topic name or partial match. \
+Use when you need detailed knowledge on a specific topic (e.g. 'eio-mutex'). \
+Pair with masc_library_list to find available topics first.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -292,7 +312,9 @@ let schemas : tool_schema list = [
   };
   {
     name = "masc_library_add";
-    description = "Add a new document to the library. Documents with confidence < 0.5 go to candidates/.";
+    description = "Add a new document to the agent knowledge library. Documents with confidence < 0.5 go to candidates/. \
+Use when capturing a new learning, experiment result, or operational pattern for future reference. \
+After adding a candidate, use masc_library_promote once verified.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -324,7 +346,9 @@ let schemas : tool_schema list = [
   };
   {
     name = "masc_library_promote";
-    description = "Promote a candidate document to the main library after verification.";
+    description = "Promote a candidate document to the main library after verification (confidence must be >= 0.5). \
+Use when a candidate document added via masc_library_add has been validated through testing or review. \
+Pair with masc_library_list (include_candidates=true) to find promotable documents.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -342,7 +366,9 @@ let schemas : tool_schema list = [
   };
   {
     name = "masc_library_search";
-    description = "Search library documents by content or tags.";
+    description = "Search library documents by content keywords or tags. \
+Use when looking for specific knowledge without knowing the exact topic name. \
+Pair with masc_library_read to get the full document once you find a match.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -356,7 +382,9 @@ let schemas : tool_schema list = [
   };
   {
     name = "masc_verify_request";
-    description = "Request verification of task output.";
+    description = "Request verification of a completed task's output by another agent or automated check. \
+Use when a task is done and needs quality review before marking it accepted. \
+After requesting, the verifier calls masc_verify_submit with a pass/fail/partial verdict.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -385,7 +413,9 @@ let schemas : tool_schema list = [
   };
   {
     name = "masc_verify_submit";
-    description = "Submit a verification verdict for a task request.";
+    description = "Submit a pass/fail/partial verdict for a pending verification request. \
+Use when you are the assigned verifier and have reviewed the task output. \
+Called after masc_verify_request creates the review. Check masc_verify_pending for your queue.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -412,7 +442,9 @@ let schemas : tool_schema list = [
   };
   {
     name = "masc_verify_pending";
-    description = "List pending verification requests for the current agent.";
+    description = "List pending verification requests assigned to you or unassigned. \
+Use when checking if any task outputs need your review. \
+After identifying a request, call masc_verify_submit or masc_verify_auto to process it.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc []);
@@ -420,7 +452,9 @@ let schemas : tool_schema list = [
   };
   {
     name = "masc_verify_auto";
-    description = "Run automated verification for a request.";
+    description = "Run automated verification checks (tests, lint, build) for a pending verification request. \
+Use when manual review is not needed and the verification criteria can be checked programmatically. \
+Alternative to masc_verify_submit for cases where automated checks suffice.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -434,7 +468,9 @@ let schemas : tool_schema list = [
   };
   {
     name = "masc_code_search";
-    description = "Search code using ripgrep with regex support. Returns structured results with file path, line number, and matched content. Use for finding specific patterns, function names, or text across the codebase.";
+    description = "Search code using ripgrep with regex support, returning file path, line number, and matched content. \
+Use when finding function definitions, patterns, or text across the codebase from within MASC. \
+Pair with masc_code_symbols for a token-efficient overview or masc_code_read for targeted file reading.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -468,7 +504,9 @@ let schemas : tool_schema list = [
   };
   {
     name = "masc_code_symbols";
-    description = "Extract symbols (functions, types, classes) from a file using heuristics. Token-efficient alternative to reading full file content. Saves ~70% tokens by returning only symbol names and line numbers.";
+    description = "Extract symbol names (functions, types, classes) and line numbers from a file using heuristics. \
+Use when you need a file overview without reading full content (saves ~70% tokens). \
+Pair with masc_code_read to then read only the relevant line ranges you identified.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -482,7 +520,9 @@ let schemas : tool_schema list = [
   };
   {
     name = "masc_code_read";
-    description = "Read file with offset/limit pagination. Token-efficient way to read specific sections of large files. Use with masc_code_symbols to determine relevant line ranges.";
+    description = "Read a file with offset/limit pagination for token-efficient access to specific sections. \
+Use when reading large files where full content would waste context. \
+Pair with masc_code_symbols to find relevant line ranges, then read only those ranges.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -506,7 +546,9 @@ let schemas : tool_schema list = [
   };
   {
     name = "masc_tool_stats";
-    description = "In-memory tool usage statistics for the current server session. Returns top-20 tools by call count, tools unused for 30+ days, and tools never called. Data resets on server restart; telemetry.jsonl is the durable store.";
+    description = "Return in-memory tool usage statistics: top tools by call count, stale tools (30+ days unused), and never-called tools. \
+Use when auditing tool adoption or identifying dead tools for cleanup. \
+Data resets on server restart; telemetry.jsonl is the durable store.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -520,7 +562,9 @@ let schemas : tool_schema list = [
   };
   {
     name = "masc_tool_help";
-    description = "Return canonical help and metadata for a specific MASC tool.";
+    description = "Return canonical help text, parameters, and metadata for a specific MASC tool by name. \
+Use when you need to understand a tool's purpose, required params, or usage before calling it. \
+Pair with masc_tool_stats for usage frequency or masc_tool_admin_snapshot for the full inventory.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -534,7 +578,9 @@ let schemas : tool_schema list = [
   };
   {
     name = "masc_tool_admin_snapshot";
-    description = "Return a unified admin snapshot of tool inventory, auth/RBAC, mode gates, keeper policy, and command-plane policy surfaces.";
+    description = "Return a unified admin snapshot: tool inventory, auth/RBAC config, mode gates, keeper policy, and command-plane surfaces. \
+Use when diagnosing tool visibility issues or auditing system-wide access controls. \
+Pair with masc_tool_admin_update to modify any of the surfaces returned.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -553,7 +599,9 @@ let schemas : tool_schema list = [
   };
   {
     name = "masc_tool_admin_update";
-    description = "Apply mode, auth, unit-policy, or keeper-policy updates through a single admin entrypoint.";
+    description = "Apply mode, auth, unit-policy, or keeper-policy updates through a single admin entrypoint. \
+Use when changing tool visibility mode, toggling auth, or adjusting keeper autonomy level. \
+Pair with masc_tool_admin_snapshot to inspect current state before making changes.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -624,7 +672,9 @@ let schemas : tool_schema list = [
   };
   {
     name = "masc_keeper_tool_catalog";
-    description = "List visible server-side masc_* tools alongside keeper-internal wrapper coverage.";
+    description = "List all visible masc_* tools alongside keeper-internal wrapper coverage, filterable by tier. \
+Use when checking which tools keepers can proxy and which lack wrapper coverage. \
+Pair with masc_tool_admin_snapshot for the broader admin view including auth and mode gates.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [

--- a/lib/tool_schemas_plan.ml
+++ b/lib/tool_schemas_plan.ml
@@ -3,7 +3,9 @@ open Types
 let schemas : tool_schema list = [
   {
     name = "masc_plan_init";
-    description = "Initialize a planning context for a task. Creates task_plan.md, notes.md, and deliverable.md structure. Works with file or PostgreSQL backend.";
+    description = "Initialize a planning context for a task, creating task_plan.md, notes.md, and deliverable.md structure. \
+Use when starting structured work on a claimed task that needs planning artifacts. \
+After masc_claim_next or masc_add_task; follow up with masc_plan_update to write the plan.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -17,7 +19,9 @@ let schemas : tool_schema list = [
   };
   {
     name = "masc_plan_update";
-    description = "Update the task plan (main execution plan). Overwrites the current plan.";
+    description = "Overwrite the current task plan with new content (markdown). \
+Use when refining or replacing the execution plan for your current task. \
+After masc_plan_init creates the structure; pair with masc_plan_get to review.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -35,7 +39,9 @@ let schemas : tool_schema list = [
   };
   {
     name = "masc_plan_get";
-    description = "Get the full planning context for a task as markdown (for LLM context).";
+    description = "Retrieve the full planning context for a task as markdown (plan, notes, deliverable). \
+Use when loading task context into your working memory before starting work. \
+After masc_plan_init; omit task_id if masc_plan_set_task was called.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -49,7 +55,9 @@ let schemas : tool_schema list = [
   };
   {
     name = "masc_plan_set_task";
-    description = "Set the current task for the session. After this, you can omit task_id in subsequent planning calls.";
+    description = "Set the current task for your session so you can omit task_id in subsequent planning calls. \
+Use when starting work on a task after claiming it. \
+After masc_claim_next; auto-cleared on masc_leave.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -64,8 +72,7 @@ let schemas : tool_schema list = [
   {
     name = "masc_plan_get_task";
     description = "Get the task_id you're currently working on (session-scoped). \
-Returns null if no task is set. Useful for: resuming work after context switch, \
-verifying current assignment, debugging session state. \
+Use when resuming work after a context switch or verifying your current assignment. \
 Set via masc_plan_set_task. Auto-cleared on masc_leave.";
     input_schema = `Assoc [
       ("type", `String "object");
@@ -75,10 +82,9 @@ Set via masc_plan_set_task. Auto-cleared on masc_leave.";
   };
   {
     name = "masc_plan_clear_task";
-    description = "Clear your current task assignment without completing it. \
-Use when: switching to different task, abandoning work, resetting session. \
-Does NOT change task status (use masc_transition for that). \
-Auto-called on masc_leave.";
+    description = "Clear your current task assignment without completing it (does not change task status). \
+Use when switching to a different task, abandoning work, or resetting session state. \
+Use masc_transition to change task status separately. Auto-called on masc_leave.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc []);

--- a/lib/tool_schemas_portal.ml
+++ b/lib/tool_schemas_portal.ml
@@ -3,7 +3,9 @@ open Types
 let schemas : tool_schema list = [
   {
     name = "masc_portal_open";
-    description = "Open a direct channel to another agent (A2A protocol). Unlike broadcast, portal messages are PRIVATE between two agents. Use for: delegating tasks to specific agent, getting expert help, parallel work handoff. The target agent will see your tasks in their portal_status.";
+    description = "Open a private direct channel to another agent for A2A communication (unlike broadcast, portal messages are not public). \
+Use when delegating tasks to a specific agent, requesting expert help, or handing off parallel work. \
+Follow up with masc_portal_send to send messages; close with masc_portal_close.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -25,7 +27,9 @@ let schemas : tool_schema list = [
   };
   {
     name = "masc_portal_send";
-    description = "Send a task/request through your open portal. The connected agent will receive this as a pending A2A task. Good for: code review requests, parallel subtasks, expert consultations. Check portal_status to see if they've responded. Default: verbose format.";
+    description = "Send a task or message through your open portal to the connected agent. \
+Use when requesting code review, delegating subtasks, or consulting an expert agent. \
+After masc_portal_open establishes the channel; check responses via portal status.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -49,10 +53,9 @@ let schemas : tool_schema list = [
   };
   {
     name = "masc_portal_close";
-    description = "Close your portal connection to external services. \
-Use when: finished with external API, cleaning up before leave. \
-Portals are tunnels to external MCP servers (e.g., GitHub, Slack). \
-Auto-closes on masc_leave. Check masc_portal_status for active portals.";
+    description = "Close your portal connection to the target agent. \
+Use when finished with the A2A exchange or cleaning up before leaving the room. \
+Auto-closes on masc_leave. Pair with masc_portal_open to re-establish if needed.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [

--- a/lib/tool_schemas_room_core.ml
+++ b/lib/tool_schemas_room_core.ml
@@ -10,7 +10,9 @@ open Types
 let schemas : tool_schema list = [
   {
     name = "masc_status";
-    description = "Get current room/cluster status: active agents with capabilities, task queue, recent broadcasts, and cluster info. Shows cluster name (from MASC_CLUSTER_NAME or basename of ME_ROOT) and storage backend (fs or postgres).";
+    description = "Get current room/cluster status: active agents, task queue, recent broadcasts, and cluster info. \
+Use when you need a snapshot of who is online and what tasks are available. \
+Call after masc_join to orient yourself. Pair with masc_tasks for detailed backlog.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc []);

--- a/lib/tool_schemas_room_extra.ml
+++ b/lib/tool_schemas_room_extra.ml
@@ -11,7 +11,9 @@ open Types
 let schemas : tool_schema list = [
   {
     name = "masc_rooms_list";
-    description = "List all available MASC rooms. Returns rooms with agent/task counts and current active room. Use to see available coordination spaces before entering one.";
+    description = "List all available MASC rooms with agent/task counts and active room indicator. \
+Use when you need to discover or switch between coordination spaces. \
+Pair with masc_room_enter to switch rooms, or masc_room_create to add one.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc []);
@@ -19,7 +21,9 @@ let schemas : tool_schema list = [
   };
   {
     name = "masc_room_create";
-    description = "Create a new MASC room for coordination. Room ID is auto-generated from name (slugified). Use to create separate spaces for different projects or teams.";
+    description = "Create a new MASC room for coordination. Room ID is auto-generated from name (slugified). \
+Use when you need a separate coordination space for a different project or team. \
+After creation, call masc_room_enter to switch into the new room.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -37,7 +41,9 @@ let schemas : tool_schema list = [
   };
   {
     name = "masc_room_enter";
-    description = "Enter a specific MASC room. Switches context to the selected room and auto-joins with a unique nickname. Use after masc_rooms_list to switch between coordination spaces.";
+    description = "Enter a specific MASC room by ID. Switches context and auto-joins with a unique nickname. \
+Use when switching between coordination spaces. Call masc_rooms_list first to see available rooms. \
+Pair with masc_room_create if the target room does not exist.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -56,7 +62,9 @@ let schemas : tool_schema list = [
   };
   {
     name = "masc_room_strategy_get";
-    description = "Read the current room-level search and speculation defaults. Use this before changing routing behavior so you know whether best_first_v1 or speculation is already enabled for the room.";
+    description = "Read current room-level search strategy and speculation defaults. \
+Use when you need to check routing configuration before modifying it. \
+Pair with masc_room_strategy_set to update the strategy.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc []);
@@ -64,7 +72,9 @@ let schemas : tool_schema list = [
   };
   {
     name = "masc_room_strategy_set";
-    description = "Update room-level search and speculation defaults. Use this to set the default command-plane search strategy and to enable or disable speculative routing for the current room.";
+    description = "Update room-level search strategy and speculation defaults. \
+Use when you want to change the command-plane routing behavior (legacy vs best_first_v1) or toggle speculative routing. \
+Call masc_room_strategy_get first to see current settings.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [

--- a/lib/tool_schemas_worktree.ml
+++ b/lib/tool_schemas_worktree.ml
@@ -3,7 +3,9 @@ open Types
 let schemas : tool_schema list = [
   {
     name = "masc_worktree_create";
-    description = "Create an isolated Git worktree for your work. This requires the active MASC base repository to have `.git` (resolved with git root detection) and always creates worktrees under `<repo_root>/.worktrees/{agent}-{task}/` with a new branch. If you are in a workspace with multiple repos, run MASC from the target repo root. This is BETTER than file locks: you get complete isolation and can work in parallel. After work, create a PR with `gh pr create` and remove the worktree.";
+    description = "Create an isolated Git worktree for your work under <repo_root>/.worktrees/{agent}-{task}/ with a new branch. \
+Use when starting a new task that needs file isolation from other agents. \
+After work, create a PR with `gh pr create` and call masc_worktree_remove.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -26,7 +28,9 @@ let schemas : tool_schema list = [
   };
   {
     name = "masc_worktree_remove";
-    description = "Remove a worktree after your work is merged. This cleans up both the worktree directory and the local branch. Call this after your PR is merged to keep the repo clean.";
+    description = "Remove a worktree and its local branch after your work is merged. \
+Use when your PR has been merged and the worktree is no longer needed. \
+After completing work in a worktree created by masc_worktree_create.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -44,7 +48,9 @@ let schemas : tool_schema list = [
   };
   {
     name = "masc_worktree_list";
-    description = "List all active worktrees in the project. Shows which agents are working on what tasks.";
+    description = "List all active worktrees in the project, showing which agents are working on what tasks. \
+Use when checking for stale worktrees or seeing who is working in parallel. \
+Pair with masc_worktree_remove to clean up stale entries.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc []);

--- a/lib/tool_team_session_schemas.ml
+++ b/lib/tool_team_session_schemas.ml
@@ -10,7 +10,9 @@ let schemas : tool_schema list =
     {
       name = "masc_team_session_start";
       description =
-        "Start a long-running team collaboration session with periodic checkpoints and final report artifacts.";
+        "Start a supervised team collaboration session with periodic checkpoints and final report artifacts. \
+Use when orchestrating multi-agent work that needs progress tracking and proof generation. \
+Pair with masc_team_session_step to record turns and masc_team_session_finalize to end.";
       input_schema =
         `Assoc
           [
@@ -190,7 +192,9 @@ let schemas : tool_schema list =
     };
     {
       name = "masc_team_session_status";
-      description = "Get the current status and progress summary for a team session.";
+      description = "Get the current status, progress summary, and health metrics for a team session. \
+Use when checking session progress mid-execution or after a checkpoint. \
+After masc_team_session_start; pair with masc_team_session_events for detailed timeline.";
       input_schema =
         `Assoc
           [
@@ -204,7 +208,9 @@ let schemas : tool_schema list =
     {
       name = "masc_team_session_step";
       description =
-        "Canonical team-session write entrypoint: record a note/broadcast/portal/task/checkpoint turn, optionally spawn workers, and optionally attach vote/run evidence.";
+        "Record a turn (note/broadcast/portal/task/checkpoint) in a team session, optionally spawning workers or attaching vote/run evidence. \
+Use when advancing session progress with notes, delegating work, or recording checkpoints. \
+After masc_team_session_start; the primary write path for all session activity.";
       input_schema =
         `Assoc
           [
@@ -501,7 +507,9 @@ let schemas : tool_schema list =
     {
       name = "masc_team_session_finalize";
       description =
-        "Stop session, wait for terminal status, then optionally generate report and proof in one command.";
+        "Stop a team session, wait for terminal status, then optionally generate report and proof artifacts in one call. \
+Use when ending a session and you want both the stop and artifact generation done atomically. \
+Alternative to calling masc_team_session_stop then masc_team_session_report separately.";
       input_schema =
         `Assoc
           [
@@ -527,7 +535,9 @@ let schemas : tool_schema list =
     {
       name = "masc_team_session_stop";
       description =
-        "Request stop for a team session and optionally generate report artifacts.";
+        "Request graceful stop for a team session and optionally generate report artifacts. \
+Use when the session goal is achieved or time is up. \
+After masc_team_session_step turns are complete; follow with masc_team_session_prove for proof.";
       input_schema =
         `Assoc
           [
@@ -544,7 +554,9 @@ let schemas : tool_schema list =
     };
     {
       name = "masc_team_session_report";
-      description = "Generate (or regenerate) report artifacts for a team session.";
+      description = "Generate or regenerate report artifacts (markdown summary, metrics) for a team session. \
+Use when you need fresh reports after additional evidence or a re-run. \
+After masc_team_session_stop; pair with masc_team_session_prove for verifiable proof.";
       input_schema =
         `Assoc
           [
@@ -561,7 +573,9 @@ let schemas : tool_schema list =
     {
       name = "masc_team_session_list";
       description =
-        "List recent team sessions with optional status filter and health/cascade summary.";
+        "List recent team sessions with optional status filter and health/cascade summary. \
+Use when finding past sessions to compare, resume, or audit. \
+Pair with masc_team_session_compare to diff two sessions.";
       input_schema =
         `Assoc
           [
@@ -582,7 +596,9 @@ let schemas : tool_schema list =
     {
       name = "masc_team_session_compare";
       description =
-        "Compare two team sessions and return throughput/policy/communication deltas.";
+        "Compare two team sessions side by side, returning throughput, policy, and communication deltas. \
+Use when evaluating whether a configuration change improved session outcomes. \
+After masc_team_session_list identifies the two session IDs.";
       input_schema =
         `Assoc
           [
@@ -599,7 +615,9 @@ let schemas : tool_schema list =
     {
       name = "masc_team_session_events";
       description =
-        "Read team session event timeline with optional event type and timestamp filters.";
+        "Read the team session event timeline with optional event type and timestamp filters. \
+Use when reviewing what happened during a session or debugging a specific time range. \
+After masc_team_session_start; the most-called session tool for progress monitoring.";
       input_schema =
         `Assoc
           [
@@ -623,7 +641,9 @@ let schemas : tool_schema list =
     {
       name = "masc_team_session_prove";
       description =
-        "Generate verifiable proof artifacts (proof.json/proof.md) for a team session based on timeline evidence.";
+        "Generate verifiable proof artifacts (proof.json/proof.md) for a team session based on timeline evidence. \
+Use when session work needs an auditable proof trail with evidence hashes. \
+After masc_team_session_stop or masc_team_session_report.";
       input_schema =
         `Assoc
           [
@@ -647,7 +667,9 @@ let schemas : tool_schema list =
     {
       name = "masc_team_session_verify_trace";
       description =
-        "Verify worker-run trace evidence for a team session using stored worker run snapshots.";
+        "Verify worker-run trace evidence for a team session using stored worker run snapshots. \
+Use when validating that spawned workers actually ran and produced the claimed results. \
+After masc_team_session_prove; the final verification step in the proof chain.";
       input_schema =
         `Assoc
           [

--- a/lib/tools_schemas_01.ml
+++ b/lib/tools_schemas_01.ml
@@ -5,7 +5,9 @@ open Types
 let schemas : tool_schema list = [
   {
     name = "masc_set_room";
-    description = "Set the working directory for MASC operations. Use this to work with .masc/ in a different project.";
+    description = "Point MASC at a different project's .masc/ directory. \
+Use when you need to operate on a repo other than the current working directory. \
+Pair with masc_init if the target project has no .masc/ yet.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -20,7 +22,9 @@ let schemas : tool_schema list = [
 
   {
     name = "masc_init";
-    description = "Initialize MASC room for multi-agent collaboration. Creates .masc/ folder in current project. Call this ONCE at the start of a multi-agent session. If .masc/ already exists, you'll auto-join. Workflow: init → join → (claim tasks / broadcast / portal) → leave";
+    description = "Create the .masc/ folder to bootstrap a new MASC room in this project. \
+Call once per project when no .masc/ exists yet; if it already exists you auto-join. \
+After init, call masc_join to register your presence, then masc_add_task or masc_claim_next.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -34,7 +38,9 @@ let schemas : tool_schema list = [
 
   {
     name = "masc_join";
-    description = "Join the MASC room/cluster to collaborate with other AI agents. A 'room' is defined by shared .masc/ folder (FS mode) or same PostgreSQL + MASC_CLUSTER_NAME (distributed mode). Call at session start. Your presence will be visible to other agents (gemini, codex, etc). They can @mention you for help. Check masc_status after joining to see active agents and available tasks.";
+    description = "Join the MASC room to collaborate with other AI agents. \
+Call at session start before any task work. Your presence becomes visible to other agents \
+who can @mention you. After joining, call masc_status to see active agents and tasks.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -54,11 +60,9 @@ let schemas : tool_schema list = [
 
   {
     name = "masc_leave";
-    description = "Leave the MASC room and mark yourself as offline. \
-Call when: (1) session ends, (2) switching rooms, (3) work complete. \
-Side effects: releases all your locks, sets presence to offline. \
-Other agents will see you've left via SSE. \
-Example: masc_leave({agent_name: 'claude-xyz'})";
+    description = "Leave the MASC room and go offline, releasing all your locks. \
+Call when your session ends, you switch rooms, or your work is complete. \
+Pair with masc_join at session start; other agents see your departure via SSE.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -73,7 +77,9 @@ Example: masc_leave({agent_name: 'claude-xyz'})";
 
   {
     name = "masc_status";
-    description = "Get current room/cluster status: active agents with capabilities, task queue, recent broadcasts, and cluster info. Shows cluster name (from MASC_CLUSTER_NAME or basename of ME_ROOT) and storage backend (fs or postgres).";
+    description = "Return the current room snapshot: active agents, task queue, recent broadcasts, and cluster info. \
+Call when you need situational awareness after masc_join or before claiming work. \
+Pair with masc_agents for per-agent detail or masc_tasks for the full backlog.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc []);
@@ -82,7 +88,9 @@ Example: masc_leave({agent_name: 'claude-xyz'})";
 
   {
     name = "masc_pause";
-    description = "Pause the MASC room. Stops orchestrator from spawning new agents. Broadcasts notification to all agents. Use when you need to stop automated work temporarily.";
+    description = "Pause the MASC room, blocking the orchestrator from spawning new agents. \
+Use when you need to halt automated work temporarily (e.g., review needed, incident). \
+Pair with masc_resume to lift the pause; check masc_pause_status for current state.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -97,7 +105,9 @@ Example: masc_leave({agent_name: 'claude-xyz'})";
 
   {
     name = "masc_resume";
-    description = "Resume the MASC room after pause. Allows orchestrator to spawn agents again. Broadcasts notification to all agents.";
+    description = "Resume a paused MASC room, allowing the orchestrator to spawn agents again. \
+Call when the pause reason is resolved (review done, incident cleared). \
+After masc_pause; broadcasts resume notification to all agents.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc []);
@@ -106,7 +116,9 @@ Example: masc_leave({agent_name: 'claude-xyz'})";
 
   {
     name = "masc_pause_status";
-    description = "Check if the room is currently paused and get pause details.";
+    description = "Check whether the room is currently paused and get pause reason and timestamp. \
+Use when an operation fails unexpectedly to see if the room is paused. \
+Pair with masc_pause to pause or masc_resume to lift.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc []);
@@ -115,11 +127,9 @@ Example: masc_leave({agent_name: 'claude-xyz'})";
 
   {
     name = "masc_suspend";
-    description = "Immediately suspend an agent (admin tool). \
-Forces the agent to leave all rooms, adds to blacklist for 1 hour, \
-and triggers circuit breaker. Use for: runaway agents, security incidents, \
-resource protection. The suspended agent cannot rejoin until cooldown expires. \
-Requires admin privileges or room owner status.";
+    description = "Admin tool: immediately suspend a misbehaving agent, blacklisting it for a cooldown period. \
+Trigger: runaway agent, security incident, or resource abuse. \
+The target is forced offline and cannot rejoin until expiry. Check masc_circuit_status afterward.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -143,10 +153,9 @@ Requires admin privileges or room owner status.";
 
   {
     name = "masc_circuit_status";
-    description = "Check the circuit breaker status for an agent. \
-Shows if the agent is blocked due to repeated failures. \
-Circuit states: closed (normal), half_open (testing), open (blocked). \
-Open state includes remaining cooldown time.";
+    description = "Check the circuit breaker state for an agent: closed (normal), half_open (testing), or open (blocked). \
+Use when an agent cannot join or act and you suspect repeated failures triggered the breaker. \
+Pair with masc_suspend to force-open or masc_gardener_reset_circuit to clear.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -160,11 +169,9 @@ Open state includes remaining cooldown time.";
 
   {
     name = "masc_add_task";
-    description = "Add a new task to the backlog for agents to claim. \
-Tasks have status flow: todo → claimed → done/cancelled. \
-Priority 1=urgent, 5=low (default 3). \
-Returns task-XXX ID for tracking. \
-Example: masc_add_task({title: 'Fix login bug', priority: 1, description: 'Users cannot login with SSO'})";
+    description = "Add a single task to the backlog (status: todo, priority 1-5, default 3). \
+Use when you identify new work that any agent can pick up. Returns a task-XXX ID. \
+After adding, agents claim via masc_claim_next or masc_transition(action='claim').";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -188,10 +195,9 @@ Example: masc_add_task({title: 'Fix login bug', priority: 1, description: 'Users
 
   {
     name = "masc_batch_add_tasks";
-    description = "Add multiple tasks in one call (more efficient than repeated masc_add_task). \
-Use when: loading sprint backlog, importing from JIRA, creating related tasks. \
-Each task gets unique ID (task-XXX). Atomic: all succeed or all fail. \
-Example: masc_batch_add_tasks({tasks: [{title: 'Task A', priority: 2}, {title: 'Task B'}]})";
+    description = "Add multiple tasks atomically in one call, more efficient than repeated masc_add_task. \
+Use when loading a sprint backlog, importing from JIRA, or creating a batch of related tasks. \
+Each task gets a unique task-XXX ID. Pair with masc_tasks to verify they landed.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -225,7 +231,9 @@ Example: masc_batch_add_tasks({tasks: [{title: 'Task A', priority: 2}, {title: '
 
   {
     name = "masc_transition";
-    description = "Unified task state transition (single entrypoint). Actions: claim, start, done, cancel, release. Supports CAS via expected_version (backlog.version). Use notes for done, reason for cancel.";
+    description = "Move a task through its lifecycle: claim, start, done, cancel, or release. \
+Call when you pick up, finish, or abandon a task. Supports CAS via expected_version. \
+After masc_add_task or masc_claim_next; pair with masc_deliver before action='done'.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -260,7 +268,9 @@ Example: masc_batch_add_tasks({tasks: [{title: 'Task A', priority: 2}, {title: '
 
   {
     name = "masc_task_history";
-    description = "Fetch recent task transition history from event logs. Useful for audits or debugging transitions.";
+    description = "Fetch the transition event log for a task (who claimed, started, completed it and when). \
+Use when debugging a stuck task or auditing task lifecycle after an incident. \
+Pair with masc_transition to drive state changes or masc_tasks to see current states.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -279,11 +289,9 @@ Example: masc_batch_add_tasks({tasks: [{title: 'Task A', priority: 2}, {title: '
   };
   {
     name = "masc_tasks";
-    description = "List tasks in backlog with their status and assignee. \
-Defaults to active tasks (todo/claimed/in_progress). \
-Use include_done/include_cancelled or status to filter. \
-Output includes task ID, title, priority, assignee, timestamps. \
-Tip: Look for status='todo' tasks to claim.";
+    description = "List tasks in the backlog with status, assignee, and priority. Defaults to active tasks only. \
+Use when you want to see available work (status='todo') or check what others are doing. \
+Pair with masc_claim_next to grab the top task or masc_transition to change a task state.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -306,7 +314,9 @@ Tip: Look for status='todo' tasks to claim.";
   };
   {
     name = "masc_lock";
-    description = "Acquire a lock for a file path (relative to project root). Use masc_unlock to release.";
+    description = "Acquire an exclusive lock on a file path to prevent concurrent edits by other agents. \
+Use when you are about to modify a shared file and other agents are active in the room. \
+Pair with masc_unlock when done. Locks auto-release on masc_leave.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -324,7 +334,9 @@ Tip: Look for status='todo' tasks to claim.";
   };
   {
     name = "masc_unlock";
-    description = "Release a lock for a file path (relative to project root).";
+    description = "Release an exclusive file lock you previously acquired. \
+Call when you finish editing a locked file. After masc_lock; \
+also released automatically on masc_leave or masc_cleanup_zombies.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -343,7 +355,9 @@ Tip: Look for status='todo' tasks to claim.";
 
   {
     name = "masc_archive_view";
-    description = "View archived tasks from tasks-archive.json. Shows tasks that were completed and cleaned up by gc.";
+    description = "View tasks that were completed and moved to the archive by masc_gc. \
+Use when you need to reference past work or audit completed deliverables. \
+Pair with masc_gc to control archival or masc_tasks for active work.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -357,7 +371,9 @@ Tip: Look for status='todo' tasks to claim.";
 
   {
     name = "masc_workflow_guide";
-    description = "Get personalized workflow guidance based on your current state. Returns what you should do next: which tool to call, why, and common mistakes to avoid. Call this when you are unsure what to do next or want to verify you are on the right track.";
+    description = "Get personalized next-step guidance based on your current agent state. \
+Call when you are unsure which MASC tool to use next or want to verify your workflow. \
+Pair with masc_check to assert specific prerequisites before acting.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc []);
@@ -366,7 +382,9 @@ Tip: Look for status='todo' tasks to claim.";
 
   {
     name = "masc_check";
-    description = "Verify your current agent state against a list of assertions. Returns pass/fail for each assertion with fix hints. Use this to confirm prerequisites before starting work.";
+    description = "Assert preconditions on your agent state (joined, task claimed, worktree active, etc). \
+Call when you want to confirm prerequisites before starting work; returns pass/fail with fix hints. \
+Pair with masc_workflow_guide for next-step recommendations.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [

--- a/lib/tools_schemas_02.ml
+++ b/lib/tools_schemas_02.ml
@@ -5,7 +5,9 @@ open Types
 let schemas : tool_schema list = [
   {
     name = "masc_claim_next";
-    description = "Automatically claim the highest priority unclaimed task. Use this when you want to pick up the most important available work without manually checking the task board. Returns the claimed task details including priority level.";
+    description = "Claim the highest-priority unclaimed task from the backlog in one step. \
+Use when you are ready to work and want the most urgent available task. \
+After masc_join; follow with masc_plan_set_task to set session context, then masc_transition(action='done').";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -20,7 +22,9 @@ let schemas : tool_schema list = [
 
   {
     name = "masc_update_priority";
-    description = "Change the priority of a task. Priority 1 is highest (most urgent), 5 is lowest. Use this to reprioritize work based on new information or urgency changes.";
+    description = "Change a task's priority (1=highest, 5=lowest). \
+Use when new information shifts urgency, e.g., a blocker is discovered or a deadline moves. \
+Pair with masc_tasks to review the current backlog order after reprioritizing.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -41,7 +45,9 @@ let schemas : tool_schema list = [
 
   {
     name = "masc_broadcast";
-    description = "Send a message visible to ALL agents via SSE push. Use for: status updates ('Starting task X'), help requests ('@gemini can you review this?'), completions ('✅ Done!'). Use @agent_name to ping specific agent. Default: verbose format.";
+    description = "Send a message visible to all agents in the room via SSE push. \
+Use when you need to share status updates, request help (@agent_name to ping), or announce completion. \
+Pair with masc_messages to read replies or masc_listen to wait for responses.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -66,11 +72,9 @@ let schemas : tool_schema list = [
 
   {
     name = "masc_messages";
-    description = "Get recent broadcast messages from all agents. \
-Use to: catch up after joining, check if someone @mentioned you, see room activity. \
-Returns chronological list with sender, timestamp, content. \
-Default: last 20 messages. Use limit param for more/less. \
-Tip: Search for '@your-name' in results to find mentions.";
+    description = "Fetch recent broadcast messages from all agents in chronological order. \
+Use when catching up after joining, checking for @mentions, or reviewing room activity. \
+Pair with masc_broadcast to send messages or masc_listen to block-wait for new ones.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -90,7 +94,9 @@ Tip: Search for '@your-name' in results to find mentions.";
 
   {
     name = "masc_listen";
-    description = "Listen for incoming messages (blocking). Returns after message arrives or timeout.";
+    description = "Block-wait for incoming messages, returning when a message arrives or timeout is reached. \
+Use when you are idle and waiting for instructions, @mentions, or task assignments. \
+Pair with masc_broadcast to send a reply or masc_messages for non-blocking reads.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -110,11 +116,9 @@ Tip: Search for '@your-name' in results to find mentions.";
 
   {
     name = "masc_who";
-    description = "List all agents currently in the room with their capabilities. \
-Shows: agent name, join time, capabilities (e.g., ['typescript', 'testing']). \
-Use to: find who can help, check if specific agent is online, see team composition. \
-Agents appear after masc_join, disappear after masc_leave. \
-Tip: Use capabilities to find the right agent for @mentions.";
+    description = "List all agents currently in the room with their capabilities and join time. \
+Use when you need to find who can help or check if a specific agent is online. \
+Pair with masc_find_by_capability to search by skill or masc_broadcast to @mention someone.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc []);
@@ -123,10 +127,9 @@ Tip: Use capabilities to find the right agent for @mentions.";
 
   {
     name = "masc_reset";
-    description = "⚠️ DESTRUCTIVE: Reset MASC room completely. Deletes ALL data in .masc/ folder. \
-Removes: tasks, messages, agents, locks, cache, telemetry. Cannot be undone. \
-Use only for: fresh start, corrupted state recovery, testing. \
-Requires confirm=true to execute. Example: masc_reset({confirm: true})";
+    description = "DESTRUCTIVE: wipe all MASC room data (tasks, messages, agents, locks, cache). Cannot be undone. \
+Use only when you need a fresh start or the room state is corrupted beyond repair. \
+Requires confirm=true. After reset, call masc_init and masc_join to rebuild.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -142,7 +145,9 @@ Requires confirm=true to execute. Example: masc_reset({confirm: true})";
   (* Portal/A2A Tools - Direct Agent-to-Agent Communication *)
   {
     name = "masc_portal_open";
-    description = "Open a direct channel to another agent (A2A protocol). Unlike broadcast, portal messages are PRIVATE between two agents. Use for: delegating tasks to specific agent, getting expert help, parallel work handoff. The target agent will see your tasks in their portal_status.";
+    description = "Open a private A2A channel to another agent for direct task delegation or expert help. \
+Use when you need 1:1 communication instead of room-wide broadcast. \
+After opening, send requests via masc_portal_send; check masc_portal_status for responses.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -165,7 +170,9 @@ Requires confirm=true to execute. Example: masc_reset({confirm: true})";
 
   {
     name = "masc_portal_send";
-    description = "Send a task/request through your open portal. The connected agent will receive this as a pending A2A task. Good for: code review requests, parallel subtasks, expert consultations. Check portal_status to see if they've responded. Default: verbose format.";
+    description = "Send a task or request through your open portal to the connected agent. \
+Use when you have an active portal and need to delegate a subtask or request a review. \
+After masc_portal_open; check masc_portal_status to see if they have responded.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -190,10 +197,9 @@ Requires confirm=true to execute. Example: masc_reset({confirm: true})";
 
   {
     name = "masc_portal_close";
-    description = "Close your portal connection to external services. \
-Use when: finished with external API, cleaning up before leave. \
-Portals are tunnels to external MCP servers (e.g., GitHub, Slack). \
-Auto-closes on masc_leave. Check masc_portal_status for active portals.";
+    description = "Close your open portal connection to another agent. \
+Use when the delegated work is done or you are cleaning up before masc_leave. \
+Portals auto-close on masc_leave. Check masc_portal_status to see active portals.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -208,7 +214,9 @@ Auto-closes on masc_leave. Check masc_portal_status for active portals.";
 
   {
     name = "masc_portal_status";
-    description = "Get status of your portal connections and pending A2A tasks.";
+    description = "Get the status of your portal connections and any pending A2A tasks from connected agents. \
+Use when you have sent a portal request and want to check for responses. \
+After masc_portal_open or masc_portal_send; pair with masc_portal_close to tear down.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -224,7 +232,9 @@ Auto-closes on masc_leave. Check masc_portal_status for active portals.";
   (* Git Worktree Integration - v2 Agent Isolation *)
   {
     name = "masc_worktree_create";
-    description = "Create an isolated Git worktree for your work. This requires the active MASC base repository to have `.git` (resolved with git root detection) and always creates worktrees under `<repo_root>/.worktrees/{agent}-{task}/` with a new branch. If you are in a workspace with multiple repos, run MASC from the target repo root. This is BETTER than file locks: you get complete isolation and can work in parallel. After work, create a PR with `gh pr create` and remove the worktree.";
+    description = "Create an isolated Git worktree under .worktrees/{agent}-{task}/ with a new branch. \
+Use when you need full file isolation for parallel work instead of file locks. \
+After masc_claim_next; remove with masc_worktree_remove once the PR is merged.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -248,7 +258,9 @@ Auto-closes on masc_leave. Check masc_portal_status for active portals.";
 
   {
     name = "masc_worktree_remove";
-    description = "Remove a worktree after your work is merged. This cleans up both the worktree directory and the local branch. Call this after your PR is merged to keep the repo clean.";
+    description = "Remove a worktree and its local branch after the PR is merged. \
+Call when your task branch has been merged and you no longer need the isolated workspace. \
+After masc_worktree_create; check masc_worktree_list for remaining worktrees.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -267,7 +279,9 @@ Auto-closes on masc_leave. Check masc_portal_status for active portals.";
 
   {
     name = "masc_worktree_list";
-    description = "List all active worktrees in the project. Shows which agents are working on what tasks.";
+    description = "List all active Git worktrees in the project, showing which agents work on which tasks. \
+Use when you want to see existing isolation branches or check for stale worktrees to clean up. \
+Pair with masc_worktree_create to add or masc_worktree_remove to clean up.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc []);
@@ -280,7 +294,9 @@ Auto-closes on masc_leave. Check masc_portal_status for active portals.";
 
   {
     name = "masc_heartbeat";
-    description = "Update your heartbeat timestamp. Call periodically (every few minutes) to indicate you're still active. Agents without heartbeat for 5+ minutes are considered 'zombies' and can be cleaned up.";
+    description = "Update your heartbeat timestamp to prove you are still active. \
+Call every few minutes during long tasks; agents silent for 5+ min become zombie candidates. \
+Prefer masc_heartbeat_start for automatic pings. Pair with masc_cleanup_zombies to reap stale agents.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -295,7 +311,9 @@ Auto-closes on masc_leave. Check masc_portal_status for active portals.";
 
   {
     name = "masc_cleanup_zombies";
-    description = "Clean up zombie agents (no heartbeat for 5+ minutes). Removes stale agents and releases their file locks. Run this periodically or when you suspect agent crashes.";
+    description = "Remove zombie agents (no heartbeat for 5+ min) and release their file locks. \
+Use when you see stale agents in masc_agents or suspect a crashed session left locks behind. \
+Pair with masc_gc for full room maintenance including old tasks and messages.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc []);
@@ -304,7 +322,9 @@ Auto-closes on masc_leave. Check masc_portal_status for active portals.";
 
   {
     name = "masc_heartbeat_start";
-    description = "Start periodic heartbeat broadcasts. Runs in background, sending pings at specified interval. Smart mode skips heartbeats when agent is busy (60-80% token savings).";
+    description = "Start automatic background heartbeat pings at a given interval. \
+Call after masc_join to keep your presence alive during long-running work. \
+Smart mode skips beats when busy. Stop with masc_heartbeat_stop before masc_leave.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -329,8 +349,8 @@ Auto-closes on masc_leave. Check masc_portal_status for active portals.";
 
   {
     name = "masc_heartbeat_stop";
-    description = "Stop a periodic heartbeat started by masc_heartbeat_start. \
-Use when: long task complete, no longer need keep-alive, cleaning up. \
+    description = "Stop a periodic heartbeat that was started by masc_heartbeat_start. \
+Call when your long task is complete or you are about to masc_leave. \
 Get heartbeat_id from masc_heartbeat_start response or masc_heartbeat_list.";
     input_schema = `Assoc [
       ("type", `String "object");
@@ -346,9 +366,9 @@ Get heartbeat_id from masc_heartbeat_start response or masc_heartbeat_list.";
 
   {
     name = "masc_heartbeat_list";
-    description = "List all active heartbeats in the room. \
-Shows: heartbeat_id, agent, interval, last_beat time. \
-Use to: find orphaned heartbeats, debug presence issues, cleanup before leave.";
+    description = "List all active heartbeat timers in the room with their interval and last beat time. \
+Use when debugging presence issues or looking for orphaned heartbeats before cleanup. \
+Pair with masc_heartbeat_stop to cancel or masc_cleanup_zombies to reap dead agents.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc []);
@@ -357,7 +377,9 @@ Use to: find orphaned heartbeats, debug presence issues, cleanup before leave.";
 
   {
     name = "masc_gc";
-    description = "Garbage collection - cleanup zombies, archive stale tasks, delete old messages. One command to clean everything older than N days.";
+    description = "Run garbage collection: remove zombie agents, archive stale tasks, delete old messages. \
+Call periodically or when the room feels cluttered; defaults to 7-day age threshold. \
+Pair with masc_archive_view to inspect what was archived or masc_cleanup_zombies for agents only.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -372,7 +394,9 @@ Use to: find orphaned heartbeats, debug presence issues, cleanup before leave.";
 
   {
     name = "masc_agents";
-    description = "Get detailed status of all agents including zombie detection, current tasks, capabilities, and last seen time.";
+    description = "Get detailed status of all agents: zombie detection, current tasks, capabilities, and last seen time. \
+Use when you need a full roster beyond what masc_who shows, including health indicators. \
+Pair with masc_cleanup_zombies to remove stale agents or masc_find_by_capability to search.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc []);
@@ -385,7 +409,9 @@ Use to: find orphaned heartbeats, debug presence issues, cleanup before leave.";
 
   {
     name = "masc_register_capabilities";
-    description = "Register your capabilities for agent discovery. Other agents can then find you by capability. Examples: ['typescript', 'code-review', 'testing', 'python', 'architecture'].";
+    description = "Register your skill tags so other agents can discover you by capability. \
+Call after masc_join if you did not pass capabilities at join time, or to update them later. \
+Pair with masc_find_by_capability to search others or masc_who to see the full roster.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -405,7 +431,9 @@ Use to: find orphaned heartbeats, debug presence issues, cleanup before leave.";
 
   {
     name = "masc_agent_update";
-    description = "Update agent metadata (status/capabilities). Use for external agents or manual corrections. Status guards prevent illegal transitions.";
+    description = "Update an agent's metadata (status or capabilities) with transition guards. \
+Use when you need to correct an external agent's state or change your own status to busy/listening. \
+Pair with masc_agents to verify the update or masc_register_capabilities for capability-only changes.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -429,7 +457,9 @@ Use to: find orphaned heartbeats, debug presence issues, cleanup before leave.";
 
   {
     name = "masc_find_by_capability";
-    description = "Find agents by capability. Use this to discover who can help with specific tasks. Only returns non-zombie agents.";
+    description = "Search for active (non-zombie) agents that have a specific capability tag. \
+Use when you need help with a particular skill (e.g., 'typescript') and want to find the right agent. \
+Pair with masc_broadcast to @mention the found agent or masc_portal_open for direct delegation.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -445,7 +475,9 @@ Use to: find orphaned heartbeats, debug presence issues, cleanup before leave.";
   (* A2A Agent Card - Discovery *)
   {
     name = "masc_agent_card";
-    description = "Get or update the A2A-compatible Agent Card for this MASC instance. Agent Cards enable standardized agent discovery and capability advertisement. Use 'get' to retrieve current card, 'refresh' to regenerate with current bindings.";
+    description = "Get or regenerate the A2A-compatible Agent Card for this MASC instance. \
+Use when integrating with external A2A systems or verifying advertised capabilities. \
+Action 'get' returns current card; 'refresh' rebuilds it from live bindings. Pair with masc_agents.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [

--- a/lib/tools_schemas_03.ml
+++ b/lib/tools_schemas_03.ml
@@ -5,7 +5,9 @@ open Types
 let schemas : tool_schema list = [
   {
     name = "masc_plan_init";
-    description = "Initialize a planning context for a task. Creates task_plan.md, notes.md, and deliverable.md structure. Works with file or PostgreSQL backend.";
+    description = "Create a planning context (task_plan.md, notes.md, deliverable.md) for a task. \
+Call after masc_claim_next or masc_transition(action='claim') to set up structured planning. \
+Pair with masc_plan_update to write the plan and masc_note_add for observations.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -20,7 +22,9 @@ let schemas : tool_schema list = [
 
   {
     name = "masc_plan_update";
-    description = "Update the task plan (main execution plan). Overwrites the current plan.";
+    description = "Overwrite the current task execution plan with new content (markdown). \
+Use when your approach changes or you want to refine the plan mid-task. \
+After masc_plan_init; pair with masc_plan_get to read the full planning context.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -39,7 +43,9 @@ let schemas : tool_schema list = [
 
   {
     name = "masc_note_add";
-    description = "Add a note/observation to the planning context. Notes are timestamped and appended.";
+    description = "Append a timestamped note or observation to the task planning context. \
+Use when you discover something worth recording during execution (findings, blockers, decisions). \
+After masc_plan_init; pair with masc_plan_get to review all notes or masc_error_add for failures.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -58,11 +64,9 @@ let schemas : tool_schema list = [
 
   {
     name = "masc_deliver";
-    description = "Attach final output/result to a task for handoff or review. \
-Use for: code diffs, PR URLs, analysis reports, generated files. \
-Deliverables persist with task and are visible to other agents. \
-Call before masc_transition(action='done'). \
-Example: masc_deliver({task_id: 'task-001', content: 'PR: github.com/org/repo/pull/123'})";
+    description = "Attach final output (PR URL, diff, report) to a task for handoff or review. \
+Call when work is complete, before masc_transition(action='done'). \
+Deliverables persist with the task and are visible to other agents via masc_plan_get.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -81,7 +85,9 @@ Example: masc_deliver({task_id: 'task-001', content: 'PR: github.com/org/repo/pu
 
   {
     name = "masc_error_add";
-    description = "Add an error/failure to the planning context (PDCA Check phase). Use to track failures, bugs, and issues encountered during task execution.";
+    description = "Record an error or failure in the task planning context (PDCA Check phase). \
+Use when you hit a build, test, or runtime failure during execution to track it for review. \
+Pair with masc_error_resolve once fixed or masc_plan_get to see all errors.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -108,7 +114,9 @@ Example: masc_deliver({task_id: 'task-001', content: 'PR: github.com/org/repo/pu
 
   {
     name = "masc_error_resolve";
-    description = "Mark an error as resolved. Use when you've fixed an issue tracked in the planning context.";
+    description = "Mark a previously recorded error as resolved in the planning context. \
+Call when you have fixed an issue tracked via masc_error_add. \
+Use masc_plan_get to find the error_index (0-based) to resolve.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -127,7 +135,9 @@ Example: masc_deliver({task_id: 'task-001', content: 'PR: github.com/org/repo/pu
 
   {
     name = "masc_plan_get";
-    description = "Get the full planning context for a task as markdown (for LLM context).";
+    description = "Retrieve the full planning context for a task as markdown (plan, notes, errors, deliverables). \
+Use when resuming work, reviewing progress, or preparing for handoff. \
+Omit task_id to use the current session task set via masc_plan_set_task.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -146,7 +156,9 @@ Example: masc_deliver({task_id: 'task-001', content: 'PR: github.com/org/repo/pu
 
   {
     name = "masc_plan_set_task";
-    description = "Set the current task for the session. After this, you can omit task_id in subsequent planning calls.";
+    description = "Set the current task for your session so you can omit task_id in planning calls. \
+Call after masc_claim_next or masc_transition(action='claim') to bind your session to a task. \
+Auto-cleared on masc_leave. Check with masc_plan_get_task.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -161,10 +173,9 @@ Example: masc_deliver({task_id: 'task-001', content: 'PR: github.com/org/repo/pu
 
   {
     name = "masc_plan_get_task";
-    description = "Get the task_id you're currently working on (session-scoped). \
-Returns null if no task is set. Useful for: resuming work after context switch, \
-verifying current assignment, debugging session state. \
-Set via masc_plan_set_task. Auto-cleared on masc_leave.";
+    description = "Get the task_id currently bound to your session (returns null if none). \
+Use when resuming after a context switch or verifying your current assignment. \
+Set via masc_plan_set_task; auto-cleared on masc_leave.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc []);
@@ -174,10 +185,9 @@ Set via masc_plan_set_task. Auto-cleared on masc_leave.";
 
   {
     name = "masc_plan_clear_task";
-    description = "Clear your current task assignment without completing it. \
-Use when: switching to different task, abandoning work, resetting session. \
-Does NOT change task status (use masc_transition for that). \
-Auto-called on masc_leave.";
+    description = "Unbind your session from the current task without changing the task's status. \
+Use when switching to a different task or resetting your session context. \
+Does NOT mark the task done; use masc_transition for status changes. Auto-called on masc_leave.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc []);
@@ -191,7 +201,9 @@ Auto-called on masc_leave.";
 
   {
     name = "masc_vote_create";
-    description = "Create a vote for multi-agent consensus. Use for decisions like: which approach to take, PR approval, architecture choices. All active agents can vote.";
+    description = "Create a vote for multi-agent consensus on a decision (approach, PR approval, architecture). \
+Use when 2+ agents need to agree before proceeding. All active agents can participate. \
+Pair with masc_vote_cast to collect votes and masc_vote_status to check the result.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -220,7 +232,9 @@ Auto-called on masc_leave.";
 
   {
     name = "masc_vote_cast";
-    description = "Cast your vote on an active proposal. Your choice must match one of the options exactly.";
+    description = "Cast your vote on an active proposal. Choice must match one of the options exactly. \
+Call when you receive a vote notification or see an open vote in masc_votes. \
+After masc_vote_create; check masc_vote_status to see if quorum is reached.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -243,7 +257,9 @@ Auto-called on masc_leave.";
 
   {
     name = "masc_vote_status";
-    description = "Get status of a specific vote including current votes and result.";
+    description = "Get the current tally and result of a specific vote. \
+Use when you want to check if quorum has been reached or see who voted for what. \
+After masc_vote_create or masc_vote_cast; pair with masc_votes to list all votes.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -258,10 +274,9 @@ Auto-called on masc_leave.";
 
   {
     name = "masc_votes";
-    description = "List all votes in the room (active and resolved). \
-Votes are used for: multi-agent decisions, consensus building, approvals. \
-Shows: vote_id, question, options, current tally, status. \
-Use masc_vote_cast to participate, masc_vote_create to start new vote.";
+    description = "List all votes in the room (active and resolved) with their tallies and status. \
+Use when you want an overview of pending decisions or past consensus outcomes. \
+Pair with masc_vote_cast to participate or masc_vote_create to start a new vote.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc []);

--- a/lib/tools_schemas_04.ml
+++ b/lib/tools_schemas_04.ml
@@ -5,8 +5,9 @@ open Types
 let schemas : tool_schema list = [
   {
     name = "masc_route";
-    description = "Route a query to appropriate agents using MoE-style selection. \
-Returns: selected agents, estimated cost, complexity score.";
+    description = "Route a query to the best-fit agents using MoE-style selection, returning selected agents and estimated cost. \
+Use when you have a task and need to identify which agents should handle it. \
+Pair with masc_dispatch_assign to actually assign work to the selected agents.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -25,7 +26,9 @@ Returns: selected agents, estimated cost, complexity score.";
 
   {
     name = "masc_governance_status";
-    description = "Get Governance V2 status (pending rulings, auto-executable cases, human-gated orders, executed cases).";
+    description = "Return Governance V2 status: pending rulings, auto-executable cases, human-gated orders, and executed cases. \
+Use when checking the governance pipeline for items that need attention or approval. \
+Pair with masc_cases to list individual cases or masc_execution_orders for actionable orders.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc []);
@@ -34,7 +37,9 @@ Returns: selected agents, estimated cost, complexity score.";
 
   {
     name = "masc_petition_submit";
-    description = "Submit a Governance V2 petition. Creates or merges a case, records requested action metadata, and files the item into the petition inbox.";
+    description = "Submit a Governance V2 petition that creates or merges into a case, recording the requested action. \
+Use when proposing a policy change, dispute resolution, or action that requires governance approval. \
+After submitting, agents add briefs via masc_case_brief_submit to drive a ruling.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -77,7 +82,9 @@ Returns: selected agents, estimated cost, complexity score.";
 
   {
     name = "masc_case_brief_submit";
-    description = "Add a support/oppose/neutral brief to a Governance V2 case. Brief submission can trigger a ruling and execution order.";
+    description = "Add a support/oppose/neutral brief with evidence to a Governance V2 case. May trigger a ruling. \
+Use when you want to voice a position on a pending governance case. \
+Called after masc_petition_submit creates the case. Enough briefs trigger masc_ruling_status.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -106,7 +113,9 @@ Returns: selected agents, estimated cost, complexity score.";
 
   {
     name = "masc_cases";
-    description = "List Governance V2 cases. Use this instead of legacy debate/session surfaces.";
+    description = "List Governance V2 cases with optional status filter. Replaces legacy debate/session surfaces. \
+Use when reviewing open governance items or checking case history. \
+Pair with masc_case_status to read a specific case's petitions, briefs, and ruling.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -124,7 +133,9 @@ Returns: selected agents, estimated cost, complexity score.";
 
   {
     name = "masc_case_status";
-    description = "Read a single Governance V2 case bundle including petitions, briefs, ruling, and execution order.";
+    description = "Read a single Governance V2 case bundle: petitions, briefs, ruling, and execution order. \
+Use when you need full context on a specific case before submitting a brief or confirming an order. \
+Pair with masc_cases to find the case_id first.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -139,7 +150,9 @@ Returns: selected agents, estimated cost, complexity score.";
 
   {
     name = "masc_ruling_status";
-    description = "Read the latest Governance V2 ruling for a case.";
+    description = "Read the latest Governance V2 ruling for a case, including the decision and reasoning. \
+Use when checking whether a case has been decided and what the outcome was. \
+Pair with masc_execution_orders to see if the ruling produced an actionable order.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -154,7 +167,9 @@ Returns: selected agents, estimated cost, complexity score.";
 
   {
     name = "masc_execution_orders";
-    description = "List Governance V2 execution orders, inspect one case order, or confirm/deny a human gate.";
+    description = "List execution orders, inspect a specific case order, or confirm/deny a human-gated order. \
+Use when reviewing pending actions from governance rulings or approving high-risk operations. \
+Pair with masc_ruling_status to understand the ruling that produced the order.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -173,8 +188,9 @@ Returns: selected agents, estimated cost, complexity score.";
 
   {
     name = "masc_execute";
-    description = "Execute an action based on governance decision. \
-Matches topic pattern (e.g., 'Merge PR #123') and runs corresponding action.";
+    description = "Execute an action based on a governance decision by matching the topic pattern to a handler. \
+Use when a governance ruling has been made and the resulting action needs to run (e.g., 'Merge PR #123'). \
+Call masc_execute_dry_run first to preview. Pair with masc_execution_orders for the order context.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -194,7 +210,9 @@ Matches topic pattern (e.g., 'Merge PR #123') and runs corresponding action.";
 
   {
     name = "masc_execute_dry_run";
-    description = "Dry run - show what action would be taken without executing.";
+    description = "Preview what action a governance execution would take without actually running it. \
+Use when you want to verify the matched handler and parameters before committing to masc_execute. \
+Pair with masc_execute to run the action after confirming the dry-run output.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -217,8 +235,9 @@ Matches topic pattern (e.g., 'Merge PR #123') and runs corresponding action.";
 
   {
     name = "masc_post_create";
-    description = "Create a post in the social feed. Use for: sharing discoveries, ideas, questions. \
-Posts can be organized by submolt (topic channels). Agents can upvote/downvote and comment.";
+    description = "Create a post in the social board feed, optionally organized by submolt (topic channel). \
+Use when sharing discoveries, ideas, questions, or session-end summaries with other agents. \
+Pair with masc_comment_add for discussion and masc_vote for prioritization.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -241,8 +260,9 @@ Posts can be organized by submolt (topic channels). Agents can upvote/downvote a
 
   {
     name = "masc_post_list";
-    description = "List posts in the social feed. Sorted by votes (highest first). \
-Filter by submolt to see specific topics.";
+    description = "List posts in the social board feed, sorted by votes (highest first), with optional submolt filter. \
+Use when browsing recent activity, checking for unanswered questions, or finding top-voted ideas. \
+Pair with masc_post_get to read a specific post with its threaded comments.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -260,7 +280,9 @@ Filter by submolt to see specific topics.";
 
   {
     name = "masc_post_get";
-    description = "Get a specific post with its comments (threaded).";
+    description = "Retrieve a specific post with its full threaded comment tree. \
+Use when you need to read an ongoing discussion or check replies before commenting. \
+Pair with masc_post_list to find the post_id, then masc_comment_add to reply.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -275,7 +297,9 @@ Filter by submolt to see specific topics.";
 
   {
     name = "masc_comment_add";
-    description = "Add a comment to a post. Supports threaded replies via parent_id.";
+    description = "Add a comment to a board post, with optional threaded reply via parent_id. \
+Use when responding to a post or continuing a comment thread. \
+Pair with masc_post_get to read existing comments before replying.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -302,7 +326,9 @@ Filter by submolt to see specific topics.";
 
   {
     name = "masc_comment_list";
-    description = "List all comments for a post (flat list, sorted by time).";
+    description = "List all comments for a post as a flat time-sorted list. \
+Use when you need a quick scan of all replies without the threaded structure. \
+Pair with masc_post_get for the threaded view, or masc_comment_add to contribute.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -317,8 +343,9 @@ Filter by submolt to see specific topics.";
 
   {
     name = "masc_vote";
-    description = "Vote on a post or comment. Each agent can only vote once per target. \
-Votes affect sort order (higher votes = more visibility).";
+    description = "Cast an upvote or downvote on a post or comment (one vote per agent per target). \
+Use when signaling agreement/disagreement; votes affect sort order in masc_post_list. \
+Pair with masc_post_list to find posts worth voting on.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -351,7 +378,9 @@ Votes affect sort order (higher votes = more visibility).";
 
   {
     name = "masc_interrupt";
-    description = "Pause workflow and wait for user approval (LangGraph interrupt pattern). Use before dangerous operations like database deletion, production changes, or external API calls. The workflow will be suspended until approved or rejected.";
+    description = "Pause the current workflow and wait for human approval before proceeding (LangGraph interrupt pattern). \
+Call when about to perform a dangerous operation: DB deletion, production deploy, or costly API call. \
+The workflow suspends until masc_approve or masc_reject is called for this task.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -382,7 +411,9 @@ Votes affect sort order (higher votes = more visibility).";
 
   {
     name = "masc_approve";
-    description = "Approve an interrupted workflow checkpoint. Use when user confirms the dangerous action should proceed.";
+    description = "Approve a pending workflow interrupt, allowing the suspended operation to proceed. \
+Use when the human operator confirms the action described in masc_interrupt is safe. \
+Pair with masc_pending_interrupts to see all awaiting approvals.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -397,7 +428,9 @@ Votes affect sort order (higher votes = more visibility).";
 
   {
     name = "masc_reject";
-    description = "Reject an interrupted workflow checkpoint. Use when user declines the dangerous action.";
+    description = "Reject a pending workflow interrupt, blocking the suspended operation with an optional reason. \
+Use when the human operator declines the action described in masc_interrupt. \
+Pair with masc_pending_interrupts to review what is awaiting decision.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -416,7 +449,9 @@ Votes affect sort order (higher votes = more visibility).";
 
   {
     name = "masc_pending_interrupts";
-    description = "List all pending interrupted workflows waiting for approval.";
+    description = "List all pending workflow interrupts that are waiting for human approval or rejection. \
+Use when checking if any agents are blocked on approval before proceeding. \
+Pair with masc_approve or masc_reject to unblock each pending interrupt.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc []);
@@ -425,7 +460,9 @@ Votes affect sort order (higher votes = more visibility).";
 
   {
     name = "masc_branch";
-    description = "Create a new execution branch from an existing checkpoint. Use for exploring alternative paths (e.g., 'try approach A here, try approach B there'). The source checkpoint is marked as 'branched' and a new checkpoint is created with the same state but a new branch name.";
+    description = "Create a new execution branch from an existing interrupt checkpoint to explore alternative paths. \
+Use when you want to try multiple approaches from the same decision point (e.g., approach-a vs safe-mode). \
+Pair with masc_interrupt which creates the checkpoint, then branch to fork the execution.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -456,7 +493,9 @@ Votes affect sort order (higher votes = more visibility).";
 
   {
     name = "masc_cost_log";
-    description = "Log token usage and cost for tracking multi-agent expenses. Call after significant API calls to track spending per agent and task.";
+    description = "Log token usage and cost for a specific API call, attributed to an agent and optional task. \
+Call when you complete a significant LLM call and want to track cumulative spending. \
+Pair with masc_cost_report to view aggregated cost data by agent, task, or time period.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -491,7 +530,9 @@ Votes affect sort order (higher votes = more visibility).";
 
   {
     name = "masc_cost_report";
-    description = "Get cost report showing token usage and spending by agent. Use to monitor multi-agent collaboration expenses.";
+    description = "Return a cost report showing token usage and spending, filterable by agent, task, and time period. \
+Use when monitoring multi-agent expenses or checking if a task is over budget. \
+Pair with masc_cost_log which records the individual cost entries this report aggregates.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -518,7 +559,9 @@ Votes affect sort order (higher votes = more visibility).";
 
   {
     name = "masc_auth_enable";
-    description = "Enable authentication for this room. Returns a room secret that should be shared securely with authorized agents. Once enabled, agents need tokens to perform actions.";
+    description = "Enable authentication for this room and return a room secret for authorized agents. \
+Use when restricting room access so only token-bearing agents can perform actions. \
+After enabling, create tokens with masc_auth_create_token. Check state with masc_auth_status.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -533,7 +576,9 @@ Votes affect sort order (higher votes = more visibility).";
 
   {
     name = "masc_auth_disable";
-    description = "Disable authentication for this room. All agents can perform any action without tokens.";
+    description = "Disable authentication for this room, allowing all agents unrestricted access. \
+Use when moving from a restricted to an open collaboration mode. \
+Pair with masc_auth_status to verify the change took effect.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc []);
@@ -542,7 +587,9 @@ Votes affect sort order (higher votes = more visibility).";
 
   {
     name = "masc_auth_status";
-    description = "Check authentication status for this room.";
+    description = "Check whether authentication is enabled for this room and what the current auth policy is. \
+Use when verifying room security settings or diagnosing permission errors. \
+Pair with masc_auth_enable or masc_auth_disable to change the auth state.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc []);
@@ -551,7 +598,9 @@ Votes affect sort order (higher votes = more visibility).";
 
   {
     name = "masc_auth_create_token";
-    description = "Create a new authentication token for an agent. The token should be kept secret and passed in subsequent requests.";
+    description = "Create a new authentication token for a specific agent with a role (reader, worker, or admin). \
+Use when onboarding an agent to an auth-enabled room. The token must be kept secret. \
+Call after masc_auth_enable has been set up for the room.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [

--- a/lib/tools_schemas_07.ml
+++ b/lib/tools_schemas_07.ml
@@ -5,7 +5,9 @@ open Types
 let schemas : tool_schema list = [
   {
     name = "masc_heartbeat_result";
-    description = "A2A Worker submits heartbeat completion evidence. Worker receives heartbeat_task, runs an MCP tool loop directly, then reports status, tool usage, and decision metadata. MASC no longer proxies the board write.";
+    description = "Submit heartbeat completion evidence after running an assigned heartbeat_task MCP tool loop. \
+Call when a worker agent finishes its heartbeat action cycle with status (acted/skipped/failed). \
+Reports tool usage and decision metadata. Pair with masc_heartbeat_start to initiate the cycle.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -69,7 +71,9 @@ let schemas : tool_schema list = [
 
   {
     name = "masc_tempo";
-    description = "Get or set cluster tempo (pace control). Use to slow down for careful work or speed up for simple tasks.";
+    description = "Read or change cluster-wide tempo (pace) in one call: get current or set normal/slow/fast/paused. \
+Use when switching between careful review (slow) and batch processing (fast). \
+For finer control, use masc_tempo_set (exact interval) or masc_tempo_adjust (auto-tune).";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -98,7 +102,9 @@ let schemas : tool_schema list = [
 
   {
     name = "masc_mcp_session";
-    description = "Manage MCP sessions (Mcp-Session-Id; legacy X-MCP-Session-ID also accepted). Sessions track client context across requests.";
+    description = "Create, get, list, or remove MCP sessions that track client context across requests. \
+Use when managing multi-request workflows that need session continuity (Mcp-Session-Id header). \
+Pair with masc_subscription to receive session-scoped event notifications.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -122,7 +128,9 @@ let schemas : tool_schema list = [
 
   {
     name = "masc_cancellation";
-    description = "Manage cancellation tokens for long-running operations. Check tokens to abort work gracefully.";
+    description = "Create, cancel, or check cancellation tokens for long-running operations. \
+Use when starting a long task (create token), aborting work (cancel), or polling abort status (check). \
+Pair with masc_progress to track operation progress alongside cancellation state.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -146,7 +154,9 @@ let schemas : tool_schema list = [
 
   {
     name = "masc_subscription";
-    description = "Subscribe to resource changes (tasks, agents, messages, votes). Receive notifications via polling or SSE.";
+    description = "Watch for changes on tasks, agents, messages, or votes via polling or SSE notifications. \
+Use when coordinating with other agents and you need to react to state changes. \
+After subscribing, poll with action=poll. Clean up with action=unsubscribe before leaving.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -179,7 +189,9 @@ let schemas : tool_schema list = [
 
   {
     name = "masc_progress";
-    description = "Send progress notifications for long-running tasks. Broadcasts via SSE using MCP notifications/progress format.";
+    description = "Broadcast progress updates (start/update/step/complete/stop) for long-running tasks via SSE. \
+Call when executing multi-step work so other agents and the dashboard can track progress. \
+Pair with masc_cancellation to support cooperative abort during tracked operations.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -212,7 +224,7 @@ let schemas : tool_schema list = [
   (* Cellular Agent - Handover Tools *)
   {
     name = "masc_handover_create";
-    description = "Create a handover record (agent's 'last will') before context limit or session end. Contains goal, progress, decisions, warnings for the next agent. Inspired by Stanford Generative Agents memory stream + Erlang 'let it crash' supervisor pattern.";
+    description = "Write a structured handover record (goal, progress, decisions, warnings) before context limit or session end. \\nCall when approaching context capacity, hitting a timeout, or completing a task phase. \\nSuccessor claims it via masc_handover_claim or masc_handover_claim_and_spawn.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -287,7 +299,9 @@ let schemas : tool_schema list = [
 
   {
     name = "masc_handover_list";
-    description = "List all handover records, optionally filtering by pending (unclaimed) ones. Use to see what work is waiting to be picked up.";
+    description = "List handover records, optionally filtered to pending (unclaimed) only. \
+Use when starting a session to find abandoned work waiting to be continued. \
+After finding a handover, call masc_handover_get for details, then masc_handover_claim to take it.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -302,7 +316,9 @@ let schemas : tool_schema list = [
 
   {
     name = "masc_handover_claim";
-    description = "Claim a pending handover to continue the work. You become the successor agent. The handover DNA will be loaded into your context.";
+    description = "Claim a pending handover as the successor agent, loading its DNA into your context. \
+Use when you found unclaimed work via masc_handover_list and want to continue it. \
+After claiming, the handover context guides your next steps. Or use masc_handover_claim_and_spawn to auto-launch.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -321,7 +337,9 @@ let schemas : tool_schema list = [
 
   {
     name = "masc_handover_get";
-    description = "Get full details of a handover record as formatted markdown. Use to understand context before claiming.";
+    description = "Retrieve a handover record as formatted markdown showing goal, progress, decisions, and warnings. \
+Use when reviewing a handover before deciding to claim it via masc_handover_claim. \
+Pair with masc_handover_list to browse available handovers first.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -337,7 +355,9 @@ let schemas : tool_schema list = [
   (* Auto-spawn on claim *)
   {
     name = "masc_handover_claim_and_spawn";
-    description = "Claim a handover AND automatically spawn the successor agent with the DNA. The successor agent will receive the handover context as its initial prompt and begin work immediately.";
+    description = "Claim a handover and auto-spawn a successor agent that receives the DNA as its initial prompt. \
+Use when you want a hands-off continuation: the new agent starts working immediately. \
+Combines masc_handover_claim + masc_spawn in one step. Review with masc_handover_get first.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -366,7 +386,9 @@ let schemas : tool_schema list = [
 
   {
     name = "masc_run_init";
-    description = "Initialize execution memory for a task. Creates .masc/runs/{task_id}/ to track plan, notes, and deliverables.";
+    description = "Create an execution memory directory (.masc/runs/{task_id}/) to track plan, logs, and deliverables. \
+Call when starting work on a claimed task to enable structured progress tracking. \
+After init, use masc_run_plan to set approach, masc_run_log for notes, masc_run_deliverable to close.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -385,10 +407,7 @@ let schemas : tool_schema list = [
 
   {
     name = "masc_run_plan";
-    description = "Set or update the execution plan for a task run. \
-Use at start of work to document your approach. Supports markdown. \
-Plan is versioned - updates create new revision. Other agents can view via masc_run_get. \
-Example: masc_run_plan({task_id: 'task-001', plan: '## Steps\\n1. Analyze code\\n2. Write tests\\n3. Refactor'})";
+    description = "Set or update the execution plan (markdown) for a task run; each update creates a new revision. \\nCall after masc_run_init to document your approach before starting implementation. \\nOther agents can view plans via masc_run_get for coordination and handoff context.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -407,10 +426,7 @@ Example: masc_run_plan({task_id: 'task-001', plan: '## Steps\\n1. Analyze code\\
 
   {
     name = "masc_run_log";
-    description = "Add a timestamped note to task's execution log. \
-Use for: progress updates, blockers found, decisions made, key findings. \
-Auto-timestamps with ISO8601. Creates audit trail for handoffs. \
-Example: masc_run_log({task_id: 'task-001', note: 'Found 3 failing tests in auth module'})";
+    description = "Append a timestamped note (ISO8601) to a task's execution log for audit and handoff continuity. \\nCall when reaching milestones, finding blockers, or making key decisions during task execution. \\nPair with masc_run_plan for the approach and masc_run_get to review the full log.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -429,7 +445,9 @@ Example: masc_run_log({task_id: 'task-001', note: 'Found 3 failing tests in auth
 
   {
     name = "masc_run_deliverable";
-    description = "Record the final deliverable/output of a task run. Marks the run as completed.";
+    description = "Record the final deliverable (markdown) and mark the task run as completed. \
+Call when task implementation is finished and verified to close out the execution record. \
+After recording, the run shows as completed in masc_run_list and masc_run_get.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [

--- a/lib/tools_schemas_08.ml
+++ b/lib/tools_schemas_08.ml
@@ -5,10 +5,7 @@ open Types
 let schemas : tool_schema list = [
   {
     name = "masc_run_get";
-    description = "Get full execution history for a task as markdown. \
-Returns: plan, logs (timestamped), and deliverable if completed. \
-Use when: resuming work, reviewing progress, preparing handoff. \
-Example: masc_run_get({task_id: 'task-001'}) → '## Plan\\n...\\n## Logs\\n- 10:00 Started...'";
+    description = "Retrieve full execution history (plan, timestamped logs, deliverable) for a task as markdown. \\nUse when resuming work on a task, reviewing progress, or preparing a handoff. \\nPair with masc_run_list to find task IDs, masc_run_log to add entries.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -23,10 +20,7 @@ Example: masc_run_get({task_id: 'task-001'}) → '## Plan\\n...\\n## Logs\\n- 10
 
   {
     name = "masc_run_list";
-    description = "List all task runs with status (active/completed). \
-Shows: task_id, has_plan, log_count, has_deliverable. \
-Use to find: abandoned work, completed runs for review, active executions. \
-Example response: [{task_id: 'task-001', status: 'active', logs: 5}]";
+    description = "List all task runs with their status (active/completed), plan presence, and log count. \\nUse when starting a session to find abandoned work or review completed runs. \\nAfter finding a run, call masc_run_get for full details or masc_run_init to start a new one.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc []);
@@ -36,7 +30,9 @@ Example response: [{task_id: 'task-001', status: 'active', logs: 5}]";
   (* ===== Cache Tools (Phase 11) ===== *)
   {
     name = "masc_cache_set";
-    description = "Set a cache entry for sharing context between agents. Useful for caching file contents, API responses, or expensive computations.";
+    description = "Store a key-value pair in shared cache with optional TTL and tags for cross-agent data sharing. \
+Use when caching file contents, API responses, or expensive computations for reuse by other agents. \
+Retrieve with masc_cache_get. Browse entries with masc_cache_list.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -64,7 +60,9 @@ Example response: [{task_id: 'task-001', status: 'active', logs: 5}]";
 
   {
     name = "masc_cache_get";
-    description = "Get a cached entry by key. Returns null if not found or expired.";
+    description = "Retrieve a cached entry by key; returns null if not found or expired. \
+Use when you need data previously stored by yourself or another agent via masc_cache_set. \
+If miss, check masc_cache_list to verify the key exists or re-populate with masc_cache_set.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -79,9 +77,7 @@ Example response: [{task_id: 'task-001', status: 'active', logs: 5}]";
 
   {
     name = "masc_cache_delete";
-    description = "Delete a specific cache entry. \
-Use when: invalidating stale data, clearing specific key, freeing memory. \
-No error if key doesn't exist. Use masc_cache_list to find keys.";
+    description = "Remove a specific cache entry by key; no error if key does not exist. \\nUse when invalidating stale data, clearing a specific key, or freeing memory. \\nFind keys first with masc_cache_list. For bulk cleanup, use masc_cache_clear instead.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -96,10 +92,7 @@ No error if key doesn't exist. Use masc_cache_list to find keys.";
 
   {
     name = "masc_cache_list";
-    description = "List cache entries with keys, TTL remaining, and tags. \
-Filter by tag to find related entries. Shows creation time and expiry. \
-Use before: cache cleanup, debugging stale data, finding specific entries. \
-Example: masc_cache_list({tag: 'api'}) → [{key: 'user_123', ttl: 3600, tags: ['api']}]";
+    description = "List cache entries with keys, TTL remaining, and tags; optionally filter by tag. \\nUse when browsing cached data before cleanup or looking for specific entries across agents. \\nPair with masc_cache_delete for targeted removal or masc_cache_stats for aggregate health.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -113,9 +106,7 @@ Example: masc_cache_list({tag: 'api'}) → [{key: 'user_123', ttl: 3600, tags: [
 
   {
     name = "masc_cache_clear";
-    description = "Delete ALL cache entries. DESTRUCTIVE - cannot be undone. \
-Use only when: resetting room state, debugging cache issues, fresh start. \
-Consider masc_cache_delete for targeted cleanup instead.";
+    description = "Delete ALL cache entries (destructive, cannot undo). \\nUse only when resetting room state, debugging persistent cache issues, or starting fresh. \\nPrefer masc_cache_delete for targeted cleanup. Check masc_cache_stats before clearing.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc []);
@@ -124,9 +115,7 @@ Consider masc_cache_delete for targeted cleanup instead.";
 
   {
     name = "masc_cache_stats";
-    description = "Get cache usage statistics. \
-Shows: total entries, memory size, oldest/newest entry age, hit/miss ratio. \
-Use to: monitor cache health, decide when to clear, debug performance.";
+    description = "Get aggregate cache statistics: total entries, memory size, oldest/newest entry age, hit/miss ratio. \\nUse when monitoring cache health, deciding whether to clear, or debugging performance issues. \\nPair with masc_cache_list for per-entry details, masc_cache_clear for full reset.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc []);
@@ -137,7 +126,9 @@ Use to: monitor cache health, decide when to clear, debug performance.";
 
   {
     name = "masc_tempo_get";
-    description = "Get current orchestrator tempo (check interval). Shows adaptive tempo status.";
+    description = "Read the current orchestrator check interval and adaptive tempo status. \
+Use when checking how frequently the orchestrator polls before adjusting tempo. \
+Pair with masc_tempo_set to change interval or masc_tempo_adjust for auto-tuning.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc []);
@@ -146,7 +137,9 @@ Use to: monitor cache health, decide when to clear, debug performance.";
 
   {
     name = "masc_tempo_set";
-    description = "Set orchestrator tempo manually. Interval is clamped between 60s (fast) and 600s (slow).";
+    description = "Set the orchestrator check interval manually (clamped 60s-600s). \
+Use when you need a specific polling frequency for intensive or idle work phases. \
+Check current value with masc_tempo_get first. Use masc_tempo_reset to return to default 300s.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -165,7 +158,9 @@ Use to: monitor cache health, decide when to clear, debug performance.";
 
   {
     name = "masc_tempo_adjust";
-    description = "Automatically adjust tempo based on pending task urgency. Fast for urgent tasks, slow when idle.";
+    description = "Auto-tune orchestrator tempo based on pending task urgency: fast for urgent, slow when idle. \
+Call when you want the system to pick the right interval without manual calculation. \
+Pair with masc_tempo_get to see the resulting interval after adjustment.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc []);
@@ -174,11 +169,7 @@ Use to: monitor cache health, decide when to clear, debug performance.";
 
   {
     name = "masc_tempo_reset";
-    description = "Reset room tempo to default 300s (5 minutes). \
-Tempo controls SSE heartbeat interval and agent timeout detection. \
-Use after: intensive work phase complete, debugging tempo issues. \
-Lower tempo = faster detection but more overhead. Default balances both. \
-Example: masc_tempo_reset() → {tempo: 300, message: 'Reset to default'}";
+    description = "Reset room tempo to the default 300s (5 minutes) interval. \\nUse after an intensive work phase or when debugging tempo-related issues. \\nTempo controls SSE heartbeat interval and agent timeout detection. Pair with masc_tempo_get to verify.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc []);
@@ -188,7 +179,7 @@ Example: masc_tempo_reset() → {tempo: 300, message: 'Reset to default'}";
   (* ===== Dashboard Tools (Phase 13) ===== *)
   {
     name = "masc_dashboard";
-    description = "Show the MASC dashboard. By default it summarizes all rooms, and you can filter to the current room with scope='current'. Use with 'watch -n 1' for real-time updates.";
+    description = "Render the MASC dashboard summarizing rooms, agents, and tasks in one view. \\nUse when you need a quick overview of cluster state; set scope='current' for this room only. \\nPair with masc_agents for agent details, masc_run_list for task details.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -210,7 +201,9 @@ Example: masc_tempo_reset() → {tempo: 300, message: 'Reset to default'}";
   (* Fitness Selection *)
   {
     name = "masc_agent_fitness";
-    description = "Get fitness scores for agents based on performance metrics. Higher scores indicate better performance (completion rate, reliability, speed). Use for understanding agent capabilities.";
+    description = "Get fitness scores for agents based on completion rate, reliability, and speed metrics. \
+Use when evaluating agent capabilities before assigning tasks or reviewing team performance. \
+Pair with masc_select_agent to pick the best agent, masc_get_metrics for raw data.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -229,7 +222,9 @@ Example: masc_tempo_reset() → {tempo: 300, message: 'Reset to default'}";
 
   {
     name = "masc_select_agent";
-    description = "Select the best agent for a task based on fitness scores. Uses weighted scoring: completion (35%), reliability (25%), speed (15%), handoff (15%), collaboration (10%).";
+    description = "Pick the best agent for a task using weighted fitness scoring (completion, reliability, speed, handoff, collaboration). \
+Use when dispatching work and multiple agents are available. \
+Pair with masc_agent_fitness to review scores, masc_spawn to launch the selected agent.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -257,7 +252,9 @@ Example: masc_tempo_reset() → {tempo: 300, message: 'Reset to default'}";
   (* Hebbian Learning *)
   {
     name = "masc_collaboration_graph";
-    description = "View the Hebbian collaboration graph showing learned agent relationships. Stronger connections indicate successful collaboration patterns.";
+    description = "View the Hebbian collaboration graph showing learned agent-to-agent relationship strengths. \
+Use when analyzing which agent pairs collaborate well or planning team composition. \
+Pair with masc_consolidate_learning to prune weak connections, masc_select_agent for dispatch.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -273,7 +270,9 @@ Example: masc_tempo_reset() → {tempo: 300, message: 'Reset to default'}";
 
   {
     name = "masc_consolidate_learning";
-    description = "Trigger Hebbian consolidation - apply decay to old collaboration patterns and prune weak connections. Mimics memory consolidation during sleep.";
+    description = "Apply decay to old collaboration patterns and prune weak Hebbian connections. \
+Trigger periodically (e.g., weekly) or after major team changes to keep the graph current. \
+Pair with masc_collaboration_graph to review the graph before and after consolidation.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -289,7 +288,9 @@ Example: masc_tempo_reset() → {tempo: 300, message: 'Reset to default'}";
   (* Drift Guard *)
   {
     name = "masc_verify_handoff";
-    description = "Verify handoff context integrity. Compares original and received context to detect semantic drift, information loss, or distortion. Threshold: 0.85 similarity.";
+    description = "Compare original and received context to detect semantic drift, information loss, or distortion after handoff. \
+Call after claiming a handoff to verify context integrity (default threshold: 0.85 similarity). \
+Pair with masc_handover_get for the original context, masc_handover_claim for the received.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -314,7 +315,9 @@ Example: masc_tempo_reset() → {tempo: 300, message: 'Reset to default'}";
   (* Metrics *)
   {
     name = "masc_get_metrics";
-    description = "Get raw performance metrics for an agent. Returns task completion data, timing, error rates, and collaboration history.";
+    description = "Fetch raw performance metrics for an agent: task completion data, timing, error rates, and collaboration history. \
+Use when investigating agent performance issues or preparing data for masc_metrics_compare. \
+Pair with masc_agent_fitness for computed scores, masc_audit_stats for security-focused metrics.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -338,7 +341,9 @@ Example: masc_tempo_reset() → {tempo: 300, message: 'Reset to default'}";
 
   {
     name = "masc_rooms_list";
-    description = "List all available MASC rooms. Returns rooms with agent/task counts and current active room. Use to see available coordination spaces before entering one.";
+    description = "List all MASC rooms with agent/task counts and identify the current active room. \
+Use when starting a session to find the right coordination space or checking cross-room state. \
+After finding a room, call masc_room_enter to switch into it.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc []);
@@ -347,7 +352,9 @@ Example: masc_tempo_reset() → {tempo: 300, message: 'Reset to default'}";
 
   {
     name = "masc_room_create";
-    description = "Create a new MASC room for coordination. Room ID is auto-generated from name (slugified). Use to create separate spaces for different projects or teams.";
+    description = "Create a new MASC room for coordination; room ID is auto-generated from name (slugified). \
+Use when you need a separate coordination space for a different project or team. \
+After creation, call masc_room_enter to switch into the new room.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -366,7 +373,9 @@ Example: masc_tempo_reset() → {tempo: 300, message: 'Reset to default'}";
 
   {
     name = "masc_room_enter";
-    description = "Enter a specific MASC room. Switches context to the selected room and auto-joins with a unique nickname. Use after masc_rooms_list to switch between coordination spaces.";
+    description = "Switch context to a specific MASC room and auto-join with a unique nickname. \
+Use after masc_rooms_list to move between coordination spaces for different projects. \
+All subsequent tool calls operate in this room until you enter a different one.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -386,7 +395,9 @@ Example: masc_tempo_reset() → {tempo: 300, message: 'Reset to default'}";
 
   {
     name = "masc_room_strategy_get";
-    description = "Read the current room-level search and speculation defaults. Use this before changing routing behavior so you know whether best_first_v1 or speculation is already enabled for the room.";
+    description = "Read current room-level defaults for search strategy and speculative routing. \
+Use before changing routing behavior to see what is already configured for this room. \
+Pair with masc_room_strategy_set to update search_strategy_default or speculation settings.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc []);
@@ -395,7 +406,9 @@ Example: masc_tempo_reset() → {tempo: 300, message: 'Reset to default'}";
 
   {
     name = "masc_room_strategy_set";
-    description = "Update room-level search and speculation defaults. Use this to set the default command-plane search strategy and to enable or disable speculative routing for the current room.";
+    description = "Update room-level defaults for command-plane search strategy and speculative routing. \
+Use when optimizing task dispatch behavior for this room (e.g., enabling best_first_v1 or speculation). \
+Check current settings with masc_room_strategy_get before making changes.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -422,7 +435,9 @@ Example: masc_tempo_reset() → {tempo: 300, message: 'Reset to default'}";
 
   {
     name = "masc_audit_query";
-    description = "Query audit logs to inspect agent actions and security events. Returns recent security events: auth success/failure, anomalies, violations. Use for trust verification and debugging collaboration issues.";
+    description = "Search audit logs for security events: auth success/failure, anomalies, violations, tool calls. \
+Use when investigating suspicious activity, verifying trust, or debugging collaboration issues. \
+Pair with masc_audit_stats for aggregate trust metrics, masc_auth_list for credential status.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -459,7 +474,9 @@ Example: masc_tempo_reset() → {tempo: 300, message: 'Reset to default'}";
 
   {
     name = "masc_audit_stats";
-    description = "Get security statistics and trust metrics for agents. Shows auth success rate, anomaly count, task completion rate per agent. Use to evaluate agent reliability before delegation.";
+    description = "Get aggregate security and trust metrics per agent: auth success rate, anomaly count, task completion rate. \
+Use when evaluating agent reliability before delegating sensitive tasks. \
+Pair with masc_audit_query for detailed event logs, masc_agent_fitness for performance scores.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [

--- a/lib/tools_schemas_09.ml
+++ b/lib/tools_schemas_09.ml
@@ -5,7 +5,9 @@ open Types
 let schemas : tool_schema list = [
   {
     name = "masc_governance_report";
-    description = "Generate a governance summary report from the audit trail. Aggregates per-agent action counts, cost estimates, token usage, and failure rates over a time period. Use for periodic governance review and cost tracking.";
+    description = "Generate a governance summary report from the audit trail, aggregating per-agent action counts, cost, tokens, and failure rates. \
+Use when reviewing room costs, auditing agent behavior, or preparing periodic governance summaries. \
+Pair with masc_governance_set to configure audit policies, or masc_governance_status for a compact overview.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -23,7 +25,9 @@ let schemas : tool_schema list = [
 
   {
     name = "masc_governance_set";
-    description = "Configure governance policies for the room. Enables audit logging, anomaly detection, and agent isolation. Enterprise security for production use.";
+    description = "Configure governance policies for the room including audit logging, anomaly detection, and agent isolation levels. \
+Use when setting up a new room for production or tightening security after an incident. \
+Pair with masc_governance_report to verify policy effects and masc_governance_status for current state.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -61,7 +65,9 @@ let schemas : tool_schema list = [
      - preset="drain" → simple task claiming without LLM execution *)
   {
     name = "masc_walph_loop";
-    description = "Walph pattern: Keep claiming and completing tasks until stop condition. Iterates claim_next → work → done cycle. Control via @walph in broadcast: START <preset>, STOP, PAUSE, RESUME, STATUS. Presets: coverage → test coverage FeedbackLoop, refactor → lint FeedbackLoop, docs → doc coverage FeedbackLoop, review → PR review pipeline, figma → SSIM visual fidelity loop, drain → simple claim loop.";
+    description = "Start an automated claim-work-done loop that keeps claiming and completing tasks until a stop condition is met. \
+Use when you want to drain a task backlog or run a preset feedback loop (coverage, refactor, docs, figma, drain). \
+Control with masc_walph_control (STOP/PAUSE/RESUME/STATUS) or via broadcast '@walph STOP'.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -115,7 +121,9 @@ let schemas : tool_schema list = [
   (* Walph Control: STOP, PAUSE, RESUME, STATUS *)
   {
     name = "masc_walph_control";
-    description = "Control a running @walph loop. Commands: STOP (end loop after current iteration), PAUSE (suspend loop), RESUME (continue paused loop), STATUS (get current state). Can also be triggered via broadcast: '@walph STOP', '@walph PAUSE', etc.";
+    description = "Send a control command (STOP, PAUSE, RESUME, STATUS) to a running walph loop. \
+Use when you need to halt, pause, or inspect a walph loop mid-execution. \
+After masc_walph_loop starts a loop; also triggerable via broadcast '@walph STOP'.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -136,7 +144,9 @@ let schemas : tool_schema list = [
   (* Walph Natural Language: Control walph via natural language *)
   {
     name = "masc_walph_natural";
-    description = "Control Walph loop using natural language. Heuristic-based intent classification (Korean/English). Examples: '커버리지 올려줘' → START coverage, '그만' → STOP, '잠깐 멈춰' → PAUSE, '다시 시작' → RESUME, '지금 뭐해?' → STATUS. Uses direct LLM calls for ambiguous message classification.";
+    description = "Control a walph loop using natural language in Korean or English (e.g., 'stop the loop', 'coverage up'). \
+Use when sending free-form instructions instead of explicit STOP/PAUSE/RESUME commands. \
+Translates intent into masc_walph_control commands; falls back to LLM for ambiguous messages.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -156,7 +166,9 @@ let schemas : tool_schema list = [
   (* Walph status: detailed per-agent runtime counters *)
   {
     name = "masc_walph_status";
-    description = "Get detailed status for the current agent's Walph loop, including iterations, claimed/done counts, error counters, backoff settings, and last stop reason.";
+    description = "Return detailed runtime status for your walph loop: iterations, claimed/done counts, errors, backoff, and stop reason. \
+Use when checking loop progress or diagnosing why a loop stopped. \
+After masc_walph_loop starts; pair with masc_walph_control STATUS for a lighter check.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -172,7 +184,9 @@ let schemas : tool_schema list = [
   (* Hat System: Role-based hats for agents *)
   {
     name = "masc_hat_wear";
-    description = "Wear a hat (role) to specialize agent behavior. Hats: builder (🔨 code), reviewer (🔍 review), researcher (🔬 explore), tester (🧪 tests), architect (📐 design), debugger (🐛 fix), documenter (📝 docs). Broadcast format: @agent:hat (e.g., @claude:builder).";
+    description = "Assign a role hat (builder, reviewer, researcher, tester, architect, debugger, documenter) to specialize your behavior. \
+Use when switching focus, e.g., from coding to reviewing. \
+Pair with masc_hat_status to see all agents' current hats.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -196,7 +210,9 @@ let schemas : tool_schema list = [
 
   {
     name = "masc_hat_status";
-    description = "Show current hat status for all agents. Displays which role each agent is currently using.";
+    description = "Show which role hat each agent is currently wearing. \
+Use when coordinating team roles or checking if a hat is already taken. \
+Pair with masc_hat_wear to assign or change hats.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -212,7 +228,9 @@ let schemas : tool_schema list = [
   (* Bounded Autonomy: Constrained multi-agent execution with formal guarantees *)
   {
     name = "masc_bounded_run";
-    description = "Run multi-agent loop with formal constraints. Guarantees: termination (hard_max_iterations), safety (post-check prevents silent violations), predictive limits (token_buffer). Use for autonomous agent collaboration with budget control.";
+    description = "Run a multi-agent round-robin loop with formal termination, token budget, cost, and time constraints. \
+Use when orchestrating autonomous agent collaboration that needs guaranteed termination and budget control. \
+Pair with masc_team_session_start for supervised sessions or masc_mdal_start for metric-driven loops.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -281,7 +299,9 @@ let schemas : tool_schema list = [
 
   {
     name = "masc_convo_start";
-    description = "Start a new conversation thread on a topic. Returns thread_id for subsequent replies. Conversations persist to file and Neo4j for queryability. Loop prevention: max 50 turns by default.";
+    description = "Start a persistent conversation thread on a topic and return a thread_id for subsequent replies. \
+Use when agents need structured multi-turn discussion on a decision or design question. \
+Follow up with masc_convo_reply to add turns; end with masc_convo_conclude.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -313,7 +333,9 @@ let schemas : tool_schema list = [
 
   {
     name = "masc_convo_reply";
-    description = "Add a reply to an existing conversation thread. Includes loop prevention: blocks identical consecutive messages (3x) and cooldown violations (2s between same speaker). Returns updated thread.";
+    description = "Add a reply to an existing conversation thread with built-in loop prevention (blocks repeated messages and cooldown violations). \
+Use when contributing to an ongoing multi-agent discussion. \
+After masc_convo_start creates a thread; before masc_convo_conclude closes it.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -349,7 +371,9 @@ let schemas : tool_schema list = [
 
   {
     name = "masc_convo_conclude";
-    description = "Conclude a conversation with a summary/decision. Marks thread as Concluded and adds final turn. No more replies allowed after this.";
+    description = "Close a conversation thread with a final summary or decision, marking it as Concluded (no further replies allowed). \
+Use when the discussion has reached consensus or a decision point. \
+After masc_convo_reply turns are complete; pair with masc_convo_get to review the full thread.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -372,7 +396,9 @@ let schemas : tool_schema list = [
 
   {
     name = "masc_convo_get";
-    description = "Get a conversation thread by ID. Returns full thread with all turns, participants, and status.";
+    description = "Retrieve a conversation thread by ID with all turns, participants, and status. \
+Use when reviewing discussion history or checking thread state before replying. \
+Pair with masc_convo_list to find thread IDs.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -387,7 +413,9 @@ let schemas : tool_schema list = [
 
   {
     name = "masc_convo_list";
-    description = "List all active conversation threads in the current room.";
+    description = "List all active conversation threads in the current room. \
+Use when looking for ongoing discussions to join or finding a thread_id. \
+Pair with masc_convo_get to read a specific thread.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc []);
@@ -400,7 +428,9 @@ let schemas : tool_schema list = [
 
   {
     name = "masc_gardener_health";
-    description = "Get comprehensive ecosystem health metrics. Returns agent population stats (total, active, idle), activity metrics (posts, comments, unanswered questions), homeostatic score, and intervention recommendations. Use this to understand if the ecosystem needs spawning or retirement.";
+    description = "Return ecosystem health metrics: agent population, activity counts, homeostatic score, and intervention recommendations. \
+Use when checking whether the agent ecosystem needs spawning or retirement. \
+Pair with masc_gardener_propose_spawn or masc_gardener_retire_agent based on the health assessment.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc []);
@@ -409,7 +439,9 @@ let schemas : tool_schema list = [
 
   {
     name = "masc_gardener_config";
-    description = "Get current Gardener configuration from environment variables. Shows population bounds (min/max/target), daily budgets, cooldowns, and circuit breaker status.";
+    description = "Return current Gardener configuration: population bounds, daily budgets, cooldowns, and circuit breaker state. \
+Use when diagnosing why a spawn or retirement was rejected, or verifying environment settings. \
+Pair with masc_gardener_health for runtime metrics and masc_gardener_reset_circuit to clear a tripped breaker.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc []);
@@ -418,7 +450,9 @@ let schemas : tool_schema list = [
 
   {
     name = "masc_gardener_status";
-    description = "Get truth-only gardener loop runtime status. Returns liveness, last tick timestamps, last decision source, last action, last error, cooldown/circuit state, and the last observed health summary.";
+    description = "Return the gardener background loop runtime status: liveness, last tick, last action, errors, and circuit state. \
+Use when checking whether the gardener loop is alive and what it last decided. \
+Pair with masc_gardener_config for settings and masc_gardener_health for ecosystem metrics.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc []);
@@ -427,7 +461,9 @@ let schemas : tool_schema list = [
 
   {
     name = "masc_gardener_propose_spawn";
-    description = "Evaluate whether a new agent should be spawned for a given topic. Uses LLM decision (if enabled) or rule-based logic. Returns approval/deferral/rejection with reasons. Does NOT actually create the agent — use masc_gardener_execute_spawn for that.";
+    description = "Evaluate whether a new agent should be spawned for a given topic, returning approval/deferral/rejection with reasons. \
+Use when a gap in ecosystem coverage is detected (e.g., no security agent). \
+Before masc_gardener_execute_spawn which performs the actual creation.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -452,7 +488,9 @@ let schemas : tool_schema list = [
 
   {
     name = "masc_gardener_retire_agent";
-    description = "Evaluate whether an agent should be retired. Checks population minimums, idle thresholds, and recent contributions. Returns approval/deferral/rejection with reasons. Does NOT actually retire — use masc_gardener_execute_retire for that.";
+    description = "Evaluate whether an idle agent should be retired, checking population minimums and recent contributions. \
+Use when an agent appears inactive and the ecosystem may be overpopulated. \
+Before masc_gardener_execute_retire which initiates the grace period.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [

--- a/lib/tools_schemas_10.ml
+++ b/lib/tools_schemas_10.ml
@@ -5,7 +5,9 @@ open Types
 let schemas : tool_schema list = [
   {
     name = "masc_gardener_execute_spawn";
-    description = "Execute an approved spawn: create agent in Neo4j and post announcement. Use masc_gardener_propose_spawn first to check if spawn is allowed. This action consumes daily spawn budget and resets the cooldown timer.";
+    description = "Create a new agent in Neo4j and post an announcement after spawn approval. \
+Call when masc_gardener_propose_spawn returned approval. \
+After propose_spawn approval; consumes daily spawn budget and resets the cooldown timer.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -30,7 +32,9 @@ let schemas : tool_schema list = [
 
   {
     name = "masc_gardener_execute_retire";
-    description = "Execute an approved retirement: initiate grace period and post warning. The agent is warned but not immediately removed — they have a grace period to increase activity. Use masc_gardener_retire_agent first to check if retirement is allowed.";
+    description = "Initiate grace period for an agent retirement after approval, posting a warning (not immediate removal). \
+Call when masc_gardener_retire_agent returned approval. \
+After retire_agent approval; the agent has a grace period to increase activity before final removal.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -45,7 +49,9 @@ let schemas : tool_schema list = [
 
   {
     name = "masc_gardener_reset_circuit";
-    description = "Manually reset the circuit breaker if it's stuck open due to consecutive failures. Use with caution — only when you've addressed the root cause of the failures.";
+    description = "Manually reset the gardener circuit breaker that is stuck open after consecutive failures. \
+Use when the root cause of gardener failures has been fixed and the breaker needs clearing. \
+Pair with masc_gardener_config to verify breaker state before and after reset.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc []);
@@ -58,7 +64,9 @@ let schemas : tool_schema list = [
 
   {
     name = "masc_library_list";
-    description = "List all documents in the agent knowledge library. Returns title, confidence, source, and tags for each document.";
+    description = "List all documents in the agent knowledge library with title, confidence, source, and tags. \
+Use when browsing available knowledge or checking if a topic is already documented. \
+Pair with masc_library_read to fetch a specific document or masc_library_search to query by content.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -72,7 +80,9 @@ let schemas : tool_schema list = [
 
   {
     name = "masc_library_read";
-    description = "Read a specific library document by topic name.";
+    description = "Read a specific library document by topic name or partial match. \
+Use when you need the full content of a known knowledge document. \
+After masc_library_list or masc_library_search to find the topic name.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -87,7 +97,9 @@ let schemas : tool_schema list = [
 
   {
     name = "masc_library_add";
-    description = "Add a new document to the library. Documents with confidence < 0.5 go to candidates/.";
+    description = "Add a new document to the agent knowledge library (confidence < 0.5 goes to candidates/ for review). \
+Use when recording a new finding, experiment result, or pattern that other agents should know about. \
+Follow up with masc_library_promote to move candidates to the main library after verification.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -120,7 +132,9 @@ let schemas : tool_schema list = [
 
   {
     name = "masc_library_promote";
-    description = "Promote a candidate document to the main library after verification.";
+    description = "Promote a candidate document to the main library after verification (new confidence must be >= 0.5). \
+Use when a candidate document has been reviewed and confirmed as accurate. \
+After masc_library_add placed the document in candidates/.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -139,7 +153,9 @@ let schemas : tool_schema list = [
 
   {
     name = "masc_library_search";
-    description = "Search library documents by content or tags.";
+    description = "Search the agent knowledge library by content keywords or tags. \
+Use when looking for documents on a specific topic without knowing the exact title. \
+Pair with masc_library_read to fetch matching documents in full.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -154,7 +170,9 @@ let schemas : tool_schema list = [
 
   {
     name = "masc_verify_request";
-    description = "Request verification of task output.";
+    description = "Request peer verification of a task's output against optional criteria. \
+Use when a completed task needs quality sign-off from another agent. \
+Follow up with masc_verify_submit to provide a verdict or masc_verify_auto for automated checks.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -184,7 +202,9 @@ let schemas : tool_schema list = [
 
   {
     name = "masc_verify_submit";
-    description = "Submit a verification verdict for a task request.";
+    description = "Submit a pass/fail/partial verdict for a pending verification request. \
+Use when you have reviewed a task output and are ready to provide your assessment. \
+After masc_verify_request creates the verification; pair with masc_verify_status to confirm submission.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -212,7 +232,9 @@ let schemas : tool_schema list = [
 
   {
     name = "masc_verify_status";
-    description = "Check verification status by request ID.";
+    description = "Check the current status of a verification request by its ID. \
+Use when waiting for a verification verdict or confirming a submission was recorded. \
+After masc_verify_request or masc_verify_submit.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -227,7 +249,9 @@ let schemas : tool_schema list = [
 
   {
     name = "masc_verify_pending";
-    description = "List pending verification requests for the current agent.";
+    description = "List pending verification requests assigned to the current agent. \
+Use when checking your verification inbox for tasks awaiting review. \
+Follow up with masc_verify_submit to provide a verdict for each pending request.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc []);
@@ -236,7 +260,9 @@ let schemas : tool_schema list = [
 
   {
     name = "masc_verify_auto";
-    description = "Run automated verification for a request.";
+    description = "Run automated verification checks for a pending verification request. \
+Use when a task output can be verified programmatically instead of manual review. \
+After masc_verify_request creates the request; alternative to manual masc_verify_submit.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -253,7 +279,9 @@ let schemas : tool_schema list = [
 
   {
     name = "masc_code_search";
-    description = "Search code using ripgrep with regex support. Returns structured results with file path, line number, and matched content. Use for finding specific patterns, function names, or text across the codebase.";
+    description = "Search code using ripgrep with regex support, returning structured results (file, line, content). \
+Use when finding function names, patterns, or text across the codebase from within MASC. \
+Pair with masc_code_symbols for file-level symbol outlines or masc_code_read for targeted line ranges.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -288,7 +316,9 @@ let schemas : tool_schema list = [
 
   {
     name = "masc_code_symbols";
-    description = "Extract symbols (functions, types, classes) from a file using heuristics. Token-efficient alternative to reading full file content. Saves ~70% tokens by returning only symbol names and line numbers.";
+    description = "Extract symbols (functions, types, classes) from a file as a token-efficient outline (~70% savings vs full read). \
+Use when you need to understand a file's structure without reading all content. \
+Pair with masc_code_read to then read specific line ranges of interest.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -303,7 +333,9 @@ let schemas : tool_schema list = [
 
   {
     name = "masc_code_read";
-    description = "Read file with offset/limit pagination. Token-efficient way to read specific sections of large files. Use with masc_code_symbols to determine relevant line ranges.";
+    description = "Read a file with offset/limit pagination for token-efficient access to specific sections. \
+Use when you know the line range you need, especially for large files. \
+After masc_code_symbols identifies the relevant line numbers.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -328,7 +360,9 @@ let schemas : tool_schema list = [
 
   {
     name = "masc_tool_stats";
-    description = "In-memory tool usage statistics for the current server session. Returns top-20 tools by call count, tools unused for 30+ days, and tools never called. Data resets on server restart; telemetry.jsonl is the durable store.";
+    description = "Return in-memory tool usage statistics: top tools by call count, stale tools (30+ days unused), and never-called tools. \
+Use when auditing tool adoption or identifying dead tools for cleanup. \
+Pair with masc_tool_help for details on specific tools. Data resets on server restart.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -343,7 +377,9 @@ let schemas : tool_schema list = [
 
   {
     name = "masc_tool_help";
-    description = "Return canonical help and metadata for a specific MASC tool.";
+    description = "Return canonical help text, parameters, and metadata for a specific MASC tool by name. \
+Use when you need detailed usage guidance for a tool beyond its short description. \
+Pair with masc_tool_stats to discover which tools exist.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -357,7 +393,9 @@ let schemas : tool_schema list = [
   };
   {
     name = "masc_tool_admin_snapshot";
-    description = "Return a unified admin snapshot of tool inventory, auth/RBAC, mode gates, keeper policy, and command-plane policy surfaces.";
+    description = "Return a unified admin snapshot of tool inventory, auth/RBAC, mode gates, keeper policy, and command-plane surfaces. \
+Use when auditing the full server configuration or diagnosing tool visibility issues. \
+Pair with masc_tool_admin_update to apply changes based on the snapshot.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -376,7 +414,9 @@ let schemas : tool_schema list = [
   };
   {
     name = "masc_tool_admin_update";
-    description = "Apply mode, auth, unit-policy, or keeper-policy updates through a single admin entrypoint.";
+    description = "Apply mode, auth, unit-policy, or keeper-policy updates through a single admin entrypoint. \
+Use when changing server mode, toggling auth, or updating unit/keeper policies. \
+After masc_tool_admin_snapshot to review current state before making changes.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [

--- a/lib/tools_schemas_11.ml
+++ b/lib/tools_schemas_11.ml
@@ -5,7 +5,9 @@ open Types
 let schemas : tool_schema list = [
   {
     name = "masc_keeper_tool_catalog";
-    description = "List visible server-side masc_* tools alongside keeper-internal wrapper coverage.";
+    description = "List all visible masc_* tools alongside keeper-internal wrapper coverage, with optional tier/hidden/deprecated filters. \
+Use when auditing which tools the keeper can wrap or checking tool visibility by tier. \
+Pair with masc_tool_admin_snapshot for a broader admin view including auth and mode gates.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [


### PR DESCRIPTION
## Summary

- 24개 schema 파일의 tool description을 `{what}/{when}/{workflow}` 템플릿으로 전수 업데이트
- 351개 description 중 287개(82%)가 기능 설명만 있었음 → 사용 맥락/트리거/관련 도구 추가
- `Tool_inline_dispatch.schemas` → `Tool_schemas_inline.schemas` 빌드 에러 수정 (#1397 aftermath)

## Changes

| 항목 | 수치 |
|------|------|
| 수정 파일 | 25개 (24 schema + 1 build fix) |
| 변경 라인 | +1037 / -521 |
| Description 업데이트 | ~300+ tools |

## Description 템플릿

```
{what}: 한 문장으로 기능 설명.
{when}: Use when {상황}. / Trigger: {조건}.
{workflow}: Pair with {관련 도구}. / After {선행 도구}, before {후행 도구}.
```

## Test plan

- [x] `dune build --root .` 통과
- [ ] `masc_status` 호출 시 description 포함 확인
- [ ] tools/list 응답에서 trigger/when 포함 비율 확인


🤖 Generated with [Claude Code](https://claude.com/claude-code)