### PR TITLE
style(dashboard): FF character-sheet aesthetic CSS layer

### DIFF
--- a/dashboard/src/main.ts
+++ b/dashboard/src/main.ts
@@ -30,6 +30,7 @@ import './styles/tool-metrics.css'
 import './styles/tools.css'
 import './styles/chat.css'
 import './styles/roster.css'
+import './styles/ff-theme.css'
 
 import { render } from 'preact'
 import { html } from 'htm/preact'

--- a/dashboard/src/styles/ff-theme.css
+++ b/dashboard/src/styles/ff-theme.css
@@ -1,0 +1,305 @@
+/* ── FF Character Sheet Theme Layer ────────────────────────────
+   Additive overrides using higher-specificity selectors.
+   Does not modify base styles; layers on top.
+   Color palette: navy #0a1628, gold #c8a84e, crystal #47b8ff
+   ─────────────────────────────────────────────────────────── */
+
+/* ============================================
+   1. Section Headers — gold accent underline
+   ============================================ */
+
+.agents-monitor .monitor-headline,
+.dashboard-panel .monitor-headline,
+.command-plane-view .monitor-headline {
+  position: relative;
+  padding-bottom: 10px;
+  color: var(--ff-gold-bright, #e8cc70);
+  text-shadow: 0 1px 6px rgba(200, 168, 78, 0.15);
+}
+
+.agents-monitor .monitor-headline::after,
+.dashboard-panel .monitor-headline::after,
+.command-plane-view .monitor-headline::after {
+  content: '';
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  width: 100%;
+  height: 2px;
+  background: linear-gradient(
+    90deg,
+    var(--ff-gold, #c8a84e) 0%,
+    rgba(200, 168, 78, 0.3) 60%,
+    transparent 100%
+  );
+  border-radius: 1px;
+}
+
+/* Section h2 (overview, agents tab, etc.) */
+.section h2,
+.overview-section-collapsible > summary {
+  color: var(--ff-gold-bright, #e8cc70);
+}
+
+/* ============================================
+   2. Agent Cards — character sheet panels
+   ============================================ */
+
+/* Monitor row cards (overview agent list) */
+button.monitor-row {
+  background:
+    linear-gradient(
+      180deg,
+      rgba(10, 22, 40, 0.85) 0%,
+      rgba(16, 28, 48, 0.75) 100%
+    );
+  border-color: var(--ff-border-subtle, rgba(200, 168, 78, 0.12));
+}
+
+button.monitor-row:hover {
+  border-color: var(--ff-border-hover, rgba(200, 168, 78, 0.6));
+  background:
+    linear-gradient(
+      180deg,
+      rgba(14, 26, 46, 0.92) 0%,
+      rgba(20, 34, 56, 0.85) 100%
+    );
+  box-shadow: 0 0 14px rgba(200, 168, 78, 0.08);
+}
+
+/* Agent grid cards */
+.agent-card {
+  background:
+    linear-gradient(
+      180deg,
+      rgba(10, 22, 40, 0.88) 0%,
+      rgba(14, 26, 46, 0.78) 100%
+    );
+  border-color: var(--ff-border-subtle, rgba(200, 168, 78, 0.12));
+}
+
+.agent-card:hover {
+  border-color: var(--ff-border-hover, rgba(200, 168, 78, 0.6));
+  box-shadow: 0 0 14px rgba(200, 168, 78, 0.08);
+}
+
+/* Agent name in cards — gold highlight */
+.monitor-row .monitor-title,
+.agent-card .agent-name {
+  color: var(--ff-gold-bright, #e8cc70);
+}
+
+/* Rail cards */
+.rail-card {
+  background: var(--ff-panel, rgba(10, 22, 40, 0.92));
+  border-color: var(--ff-border-subtle, rgba(200, 168, 78, 0.12));
+}
+
+/* ============================================
+   3. Status Chips — status effect badges
+   ============================================ */
+
+/* Command chips with FF-aligned colors */
+.command-chip.ok,
+.command-tag.ok {
+  background: rgba(74, 222, 128, 0.12);
+  color: var(--ff-hp-full, #4ade80);
+  border: 1px solid rgba(74, 222, 128, 0.25);
+}
+
+.command-chip.warn,
+.command-tag.warn {
+  background: rgba(200, 168, 78, 0.14);
+  color: var(--ff-gold-bright, #e8cc70);
+  border: 1px solid rgba(200, 168, 78, 0.28);
+}
+
+.command-chip.bad,
+.command-tag.bad {
+  background: rgba(248, 113, 113, 0.14);
+  color: var(--ff-hp-low, #f87171);
+  border: 1px solid rgba(248, 113, 113, 0.28);
+}
+
+/* Monitor pills — FF status effect style */
+.monitor-pill.ok {
+  background: rgba(74, 222, 128, 0.1);
+  color: var(--ff-hp-full, #4ade80);
+  border: 1px solid rgba(74, 222, 128, 0.2);
+}
+
+.monitor-pill.warn {
+  background: rgba(200, 168, 78, 0.12);
+  color: var(--ff-gold-bright, #e8cc70);
+  border: 1px solid rgba(200, 168, 78, 0.22);
+}
+
+.monitor-pill.bad {
+  background: rgba(248, 113, 113, 0.12);
+  color: var(--ff-hp-low, #f87171);
+  border: 1px solid rgba(248, 113, 113, 0.25);
+}
+
+/* Rail section chips — FF badge style */
+.rail-section-chip.ok {
+  color: var(--ff-hp-full, #4ade80);
+  border-color: rgba(74, 222, 128, 0.25);
+  background: rgba(74, 222, 128, 0.1);
+}
+
+.rail-section-chip.bad {
+  color: var(--ff-hp-low, #f87171);
+  border-color: rgba(248, 113, 113, 0.25);
+  background: rgba(248, 113, 113, 0.1);
+}
+
+/* ============================================
+   4. Context Ratio Bars — HP-style gradient
+   ============================================ */
+
+.ctx-bar {
+  height: 7px;
+  border-radius: 2px;
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid var(--ff-border-subtle, rgba(200, 168, 78, 0.12));
+}
+
+.ctx-fill {
+  background: linear-gradient(
+    90deg,
+    var(--ff-hp-full, #4ade80) 0%,
+    #2dd46a 100%
+  );
+  border-radius: 1px;
+  box-shadow: 0 0 4px rgba(74, 222, 128, 0.3);
+}
+
+.ctx-fill.warn {
+  background: linear-gradient(
+    90deg,
+    var(--ff-hp-mid, #fbbf24) 0%,
+    #e0a510 100%
+  );
+  box-shadow: 0 0 4px rgba(251, 191, 36, 0.3);
+}
+
+.ctx-fill.bad {
+  background: linear-gradient(
+    90deg,
+    var(--ff-hp-low, #f87171) 0%,
+    #e04040 100%
+  );
+  box-shadow: 0 0 4px rgba(248, 113, 113, 0.3);
+}
+
+/* Keeper roster pressure bar — same HP treatment */
+.keeper-roster__pressure-track {
+  height: 10px;
+  border-radius: 2px;
+  border-color: var(--ff-border-subtle, rgba(200, 168, 78, 0.12));
+}
+
+/* ============================================
+   5. Terminated Cards — KO'd look
+   ============================================ */
+
+.mission-card-select.terminated {
+  opacity: 0.4;
+  border-left: 3px solid var(--ff-ko-border, rgba(100, 100, 120, 0.25));
+  background: var(--ff-ko-bg, rgba(40, 40, 50, 0.6));
+  filter: saturate(0.3);
+}
+
+.mission-card-select.terminated:hover {
+  opacity: 0.6;
+  filter: saturate(0.5);
+}
+
+/* Offline agent rows — KO treatment */
+button.monitor-row.state-offline {
+  background: var(--ff-ko-bg, rgba(40, 40, 50, 0.6));
+  border-color: var(--ff-ko-border, rgba(100, 100, 120, 0.25));
+  filter: saturate(0.25);
+}
+
+button.monitor-row.state-offline:hover {
+  filter: saturate(0.45);
+}
+
+/* ============================================
+   6. Dashboard Header — FF accent
+   ============================================ */
+
+.dashboard-header {
+  border-color: var(--ff-border-subtle, rgba(200, 168, 78, 0.12));
+  background: rgba(10, 22, 40, 0.88);
+}
+
+.header-title-wrap h1 {
+  color: var(--ff-gold-bright, #e8cc70);
+}
+
+/* Version badge — crystal blue */
+.version-badge {
+  border-color: rgba(71, 184, 255, 0.3);
+  background: rgba(71, 184, 255, 0.12);
+  color: var(--ff-crystal, #47b8ff);
+}
+
+/* ============================================
+   7. Working/Active Agents — FF glow
+   ============================================ */
+
+button.monitor-row.state-working {
+  border-color: rgba(74, 222, 128, 0.25);
+  background:
+    linear-gradient(
+      180deg,
+      rgba(10, 22, 40, 0.88) 0%,
+      rgba(20, 40, 30, 0.72) 100%
+    );
+}
+
+button.monitor-row.state-watching {
+  border-color: rgba(71, 184, 255, 0.18);
+  background:
+    linear-gradient(
+      180deg,
+      rgba(10, 22, 40, 0.88) 0%,
+      rgba(16, 28, 48, 0.75) 100%
+    );
+}
+
+/* ============================================
+   8. KPI Strip — FF panel treatment
+   ============================================ */
+
+.kpi-item {
+  background: var(--ff-panel, rgba(10, 22, 40, 0.92));
+  border-color: var(--ff-border-subtle, rgba(200, 168, 78, 0.12));
+}
+
+.kpi-label {
+  color: rgba(200, 168, 78, 0.6);
+}
+
+/* ============================================
+   9. Stat Cards — FF panel
+   ============================================ */
+
+.stat-card {
+  background: var(--ff-panel, rgba(10, 22, 40, 0.92));
+  border-color: var(--ff-border-subtle, rgba(200, 168, 78, 0.12));
+}
+
+.stat-label {
+  color: rgba(200, 168, 78, 0.6);
+}
+
+/* ============================================
+   10. Body background — deeper navy
+   ============================================ */
+
+body {
+  background: var(--ff-navy, #0a1628);
+}

--- a/dashboard/src/styles/global.css
+++ b/dashboard/src/styles/global.css
@@ -26,17 +26,23 @@
   --warm-sage: #8dbd97;
 
   /* FF Character Sheet theme */
-  --ff-gold: #d4a94b;
-  --ff-gold-bright: #f0d080;
-  --ff-gold-dim: rgba(212, 169, 75, 0.25);
-  --ff-navy: #0d1526;
-  --ff-navy-light: #142040;
-  --ff-border: rgba(212, 169, 75, 0.35);
-  --ff-border-subtle: rgba(212, 169, 75, 0.12);
-  --ff-panel: rgba(13, 21, 38, 0.9);
-  --ff-hp: #3dcc5e;
+  --ff-navy: #0a1628;
+  --ff-navy-light: #122040;
+  --ff-gold: #c8a84e;
+  --ff-gold-bright: #e8cc70;
+  --ff-gold-dim: rgba(200, 168, 78, 0.25);
+  --ff-crystal: #47b8ff;
+  --ff-border: rgba(200, 168, 78, 0.35);
+  --ff-border-subtle: rgba(200, 168, 78, 0.12);
+  --ff-border-hover: rgba(200, 168, 78, 0.6);
+  --ff-panel: rgba(10, 22, 40, 0.92);
+  --ff-hp-full: #4ade80;
+  --ff-hp-mid: #fbbf24;
+  --ff-hp-low: #f87171;
   --ff-mp: #4a9ef5;
-  --ff-xp: #d4a94b;
+  --ff-xp: #c8a84e;
+  --ff-ko-bg: rgba(40, 40, 50, 0.6);
+  --ff-ko-border: rgba(100, 100, 120, 0.25);
 
   /* Agent status (soft tones) */
   --agent-working: #7ae09a;

--- a/dashboard/src/styles/overview.css
+++ b/dashboard/src/styles/overview.css
@@ -13,9 +13,9 @@
 
 .overview-stat {
   padding: 12px 14px;
-  border: 1px solid var(--ff-border-subtle, rgba(212, 169, 75, 0.12));
+  border: 1px solid var(--ff-border-subtle, rgba(200, 168, 78, 0.12));
   border-radius: 6px;
-  background: var(--ff-panel, rgba(13, 21, 38, 0.9));
+  background: var(--ff-panel, rgba(10, 22, 40, 0.92));
   display: grid;
   gap: 2px;
   position: relative;
@@ -23,11 +23,11 @@
 }
 
 .overview-stat:hover {
-  border-color: var(--ff-border, rgba(212, 169, 75, 0.35));
+  border-color: var(--ff-border, rgba(200, 168, 78, 0.35));
 }
 
 .overview-stat__label {
-  color: var(--ff-gold, #d4a94b);
+  color: var(--ff-gold, #c8a84e);
   font-size: 10px;
   letter-spacing: 0.1em;
   text-transform: uppercase;
@@ -50,9 +50,9 @@
   gap: 12px;
   padding: 14px 18px;
   border-radius: 6px;
-  background: var(--ff-panel, rgba(13, 21, 38, 0.9));
-  border: 1px solid var(--ff-border-subtle, rgba(212, 169, 75, 0.12));
-  border-left: 3px solid var(--ff-hp, #3dcc5e);
+  background: var(--ff-panel, rgba(10, 22, 40, 0.92));
+  border: 1px solid var(--ff-border-subtle, rgba(200, 168, 78, 0.12));
+  border-left: 3px solid var(--ff-hp-full, #4ade80);
   font-size: 14px;
   font-weight: 500;
   color: var(--text-strong);
@@ -60,11 +60,11 @@
 }
 
 .situation-banner--ok {
-  border-left-color: var(--ff-hp, #3dcc5e);
+  border-left-color: var(--ff-hp-full, #4ade80);
 }
 
 .situation-banner--warn {
-  border-left-color: var(--ff-xp, #d4a94b);
+  border-left-color: var(--ff-xp, #c8a84e);
 }
 
 .situation-banner--bad {

--- a/dashboard/src/styles/pixel-avatars.css
+++ b/dashboard/src/styles/pixel-avatars.css
@@ -33,8 +33,8 @@
   height: 96px;
   border-radius: 8px;
   box-shadow:
-    0 0 0 2px var(--ff-navy, #0d1526),
-    0 0 0 3px var(--ff-gold, #d4a94b),
+    0 0 0 2px var(--ff-navy, #0a1628),
+    0 0 0 3px var(--ff-gold, #c8a84e),
     0 2px 8px rgba(0, 0, 0, 0.4);
 }
 

--- a/dashboard/src/styles/roster.css
+++ b/dashboard/src/styles/roster.css
@@ -18,7 +18,7 @@
 .roster-title {
   font-size: 20px;
   font-weight: 600;
-  color: var(--ff-gold-bright, #f0d080);
+  color: var(--ff-gold-bright, #e8cc70);
   margin: 0 0 var(--space-md, 16px) 0;
   letter-spacing: 0.5px;
   text-shadow: 0 1px 4px rgba(212, 169, 75, 0.2);
@@ -34,8 +34,8 @@
 .roster-search {
   padding: 6px 12px;
   border-radius: 4px;
-  border: 1px solid var(--ff-border-subtle, rgba(212, 169, 75, 0.12));
-  background: var(--ff-navy, #0d1526);
+  border: 1px solid var(--ff-border-subtle, rgba(200, 168, 78, 0.12));
+  background: var(--ff-navy, #0a1628);
   color: rgba(255, 255, 255, 0.9);
   font-size: 13px;
   width: 200px;
@@ -44,8 +44,8 @@
 
 .roster-search:focus {
   outline: none;
-  border-color: var(--ff-gold, #d4a94b);
-  box-shadow: 0 0 0 2px var(--ff-gold-dim, rgba(212, 169, 75, 0.25));
+  border-color: var(--ff-gold, #c8a84e);
+  box-shadow: 0 0 0 2px var(--ff-gold-dim, rgba(200, 168, 78, 0.25));
 }
 
 .roster-search::placeholder {
@@ -60,7 +60,7 @@
 .roster-filter-btn {
   padding: 4px 10px;
   border-radius: 3px;
-  border: 1px solid var(--ff-border-subtle, rgba(212, 169, 75, 0.12));
+  border: 1px solid var(--ff-border-subtle, rgba(200, 168, 78, 0.12));
   background: transparent;
   color: rgba(255, 255, 255, 0.45);
   font-size: 12px;
@@ -69,15 +69,15 @@
 }
 
 .roster-filter-btn:hover {
-  background: var(--ff-gold-dim, rgba(212, 169, 75, 0.25));
-  color: var(--ff-gold-bright, #f0d080);
-  border-color: var(--ff-border, rgba(212, 169, 75, 0.35));
+  background: var(--ff-gold-dim, rgba(200, 168, 78, 0.25));
+  color: var(--ff-gold-bright, #e8cc70);
+  border-color: var(--ff-border, rgba(200, 168, 78, 0.35));
 }
 
 .roster-filter-btn.active {
-  background: var(--ff-gold-dim, rgba(212, 169, 75, 0.25));
-  color: var(--ff-gold-bright, #f0d080);
-  border-color: var(--ff-gold, #d4a94b);
+  background: var(--ff-gold-dim, rgba(200, 168, 78, 0.25));
+  color: var(--ff-gold-bright, #e8cc70);
+  border-color: var(--ff-gold, #c8a84e);
 }
 
 /* ============================================
@@ -94,8 +94,8 @@
   display: flex;
   gap: var(--space-md, 16px);
   padding: 16px 20px;
-  background: var(--ff-panel, rgba(13, 21, 38, 0.9));
-  border: 1px solid var(--ff-border, rgba(212, 169, 75, 0.35));
+  background: var(--ff-panel, rgba(10, 22, 40, 0.92));
+  border: 1px solid var(--ff-border, rgba(200, 168, 78, 0.35));
   border-radius: 6px;
   cursor: pointer;
   transition: all 0.2s;
@@ -109,7 +109,7 @@
   position: absolute;
   width: 8px;
   height: 8px;
-  border-color: var(--ff-gold, #d4a94b);
+  border-color: var(--ff-gold, #c8a84e);
   opacity: 0.5;
   transition: opacity 0.2s;
 }
@@ -129,8 +129,8 @@
 }
 
 .roster-card:hover {
-  background: var(--ff-navy-light, #142040);
-  border-color: var(--ff-gold, #d4a94b);
+  background: var(--ff-navy-light, #122040);
+  border-color: var(--ff-gold, #c8a84e);
   box-shadow: 0 0 12px rgba(212, 169, 75, 0.1);
 }
 
@@ -149,7 +149,7 @@
   content: '';
   position: absolute;
   inset: -3px;
-  border: 1px solid var(--ff-border-subtle, rgba(212, 169, 75, 0.12));
+  border: 1px solid var(--ff-border-subtle, rgba(200, 168, 78, 0.12));
   border-radius: 14px;
   pointer-events: none;
 }
@@ -171,7 +171,7 @@
 
 .roster-card__name {
   font-size: 15px;
-  color: var(--ff-gold-bright, #f0d080);
+  color: var(--ff-gold-bright, #e8cc70);
   font-weight: 600;
   letter-spacing: 0.3px;
 }
@@ -199,7 +199,7 @@
 .roster-card__model {
   padding: 1px 6px;
   background: rgba(212, 169, 75, 0.08);
-  border: 1px solid var(--ff-border-subtle, rgba(212, 169, 75, 0.12));
+  border: 1px solid var(--ff-border-subtle, rgba(200, 168, 78, 0.12));
   border-radius: 3px;
   color: rgba(212, 169, 75, 0.6);
 }
@@ -219,13 +219,13 @@
 
 .roster-badge--active {
   background: rgba(61, 204, 94, 0.12);
-  color: var(--ff-hp, #3dcc5e);
+  color: var(--ff-hp-full, #4ade80);
   border: 1px solid rgba(61, 204, 94, 0.25);
 }
 
 .roster-badge--idle {
   background: rgba(212, 169, 75, 0.1);
-  color: var(--ff-xp, #d4a94b);
+  color: var(--ff-xp, #c8a84e);
   border: 1px solid rgba(212, 169, 75, 0.2);
 }
 
@@ -240,7 +240,7 @@
   text-align: center;
   color: rgba(255, 255, 255, 0.2);
   font-size: 14px;
-  border: 1px dashed var(--ff-border-subtle, rgba(212, 169, 75, 0.12));
+  border: 1px dashed var(--ff-border-subtle, rgba(200, 168, 78, 0.12));
   border-radius: 6px;
 }
 
@@ -289,7 +289,7 @@
   background: rgba(255, 255, 255, 0.04);
   border-radius: 2px;
   overflow: hidden;
-  border: 1px solid var(--ff-border-subtle, rgba(212, 169, 75, 0.12));
+  border: 1px solid var(--ff-border-subtle, rgba(200, 168, 78, 0.12));
 }
 
 .keeper-roster__pressure-bar {
@@ -317,7 +317,7 @@
   gap: 4px;
   padding: 6px var(--space-md, 16px);
   margin-bottom: var(--space-sm, 8px);
-  border-left: 2px solid var(--ff-border, rgba(212, 169, 75, 0.35));
+  border-left: 2px solid var(--ff-border, rgba(200, 168, 78, 0.35));
 }
 
 .situation-reason {
@@ -333,7 +333,7 @@
 }
 
 .situation-reason--warn {
-  color: var(--ff-gold, #d4a94b);
+  color: var(--ff-gold, #c8a84e);
 }
 
 .situation-reason__tag {
@@ -341,7 +341,7 @@
   padding: 1px 6px;
   border-radius: 2px;
   background: rgba(212, 169, 75, 0.08);
-  border: 1px solid var(--ff-border-subtle, rgba(212, 169, 75, 0.12));
+  border: 1px solid var(--ff-border-subtle, rgba(200, 168, 78, 0.12));
   white-space: nowrap;
   text-transform: uppercase;
   letter-spacing: 0.5px;
@@ -366,14 +366,14 @@
 
 .overview-section-link {
   font-size: 12px;
-  color: var(--ff-gold, #d4a94b);
+  color: var(--ff-gold, #c8a84e);
   cursor: pointer;
   transition: color 0.15s;
   opacity: 0.6;
 }
 
 .overview-section-link:hover {
-  color: var(--ff-gold-bright, #f0d080);
+  color: var(--ff-gold-bright, #e8cc70);
   opacity: 1;
 }
 
@@ -386,7 +386,7 @@
 /* Attention badge — gold warning */
 .attention-badge {
   background: rgba(212, 169, 75, 0.15);
-  color: var(--ff-gold, #d4a94b);
+  color: var(--ff-gold, #c8a84e);
   border: 1px solid rgba(212, 169, 75, 0.3);
   border-radius: 3px;
   padding: 2px 8px;


### PR DESCRIPTION
## Summary
- Add Final Fantasy character-sheet visual theme to the MASC dashboard execution surface
- New `ff-theme.css` overlay file using higher-specificity selectors (additive, non-breaking)
- Updated `:root` CSS custom properties to unified FF palette: navy `#0a1628`, gold `#c8a84e`, crystal `#47b8ff`
- Aligned fallback values in existing CSS files (`roster.css`, `overview.css`, `pixel-avatars.css`)

## Changes
- **Section headers** (`.monitor-headline`): gold bottom-border accent with gradient fade
- **Agent cards** (`.monitor-row`, `.agent-card`): navy gradient background, gold border on hover
- **Status chips** (`.command-chip`, `.monitor-pill`): colors adjusted to FF palette
- **Context bars** (`.ctx-fill`): HP-style gradient with glow (green/yellow/red tiers)
- **Terminated cards** (`.mission-card-select.terminated`): KO'd look with desaturation filter
- **Header, KPI, stat cards**: FF panel treatment with updated borders and backgrounds

## Test plan
- [ ] `npm run build` in `dashboard/` compiles without errors
- [ ] Visual check on `/dashboard` overview page: navy bg, gold section headers
- [ ] Agent cards show gold border on hover
- [ ] Context ratio bars render HP-style gradients
- [ ] Terminated/offline cards appear greyed/desaturated
- [ ] No regressions on existing layout or responsive breakpoints

Generated with [Claude Code](https://claude.com/claude-code)