### PR TITLE
fix(test): wrap 7 test suites in Eio_main.run for Eio.Mutex context

### DIFF
--- a/lib/backend.ml
+++ b/lib/backend.ml
@@ -6,6 +6,7 @@ include Backend_core
 module FileSystemBackend : BACKEND = struct
   type t = {
     base_path: string;
+    pubsub: Backend_core.Pubsub_mem.t;
     mutex: Eio.Mutex.t;
   }
 
@@ -115,7 +116,7 @@ module FileSystemBackend : BACKEND = struct
       Fs_compat.mkdir_p path
     with Unix.Unix_error (err, _, _) ->
       Log.Misc.error "Failed to mkdir %s: %s" path (Unix.error_message err));
-    Ok { base_path = path; mutex = Eio.Mutex.create () }
+    Ok { base_path = path; pubsub = Backend_core.Pubsub_mem.create (); mutex = Eio.Mutex.create () }
 
   let close _t = ()
 
@@ -376,11 +377,11 @@ module FileSystemBackend : BACKEND = struct
     | Invalid_argument msg -> Error (InvalidKey msg)
     | exn -> Error (OperationFailed (Printexc.to_string exn))
 
-  let publish _t ~channel:_ ~message:_ =
-    Error (BackendNotSupported "FileSystem backend does not support pub/sub")
+  let publish t ~channel ~message =
+    with_lock t (fun () -> Backend_core.Pubsub_mem.publish t.pubsub ~channel ~message)
 
-  let subscribe _t ~channel:_ ~callback:_ =
-    Error (BackendNotSupported "FileSystem backend does not support pub/sub")
+  let subscribe t ~channel ~callback =
+    with_lock t (fun () -> Backend_core.Pubsub_mem.subscribe t.pubsub ~channel ~callback)
 
   let health_check t =
     try

--- a/lib/backend_core.ml
+++ b/lib/backend_core.ml
@@ -168,6 +168,34 @@ let release_flock fd =
     Log.Misc.error "Failed to release flock: %s" (Unix.error_message err)
 
 (* ============================================ *)
+(* In-Memory Pub/Sub (shared by Memory + FS)    *)
+(* ============================================ *)
+
+module Pubsub_mem = struct
+  type t = {
+    subscribers: (string, (string -> unit) list) Hashtbl.t;
+  }
+
+  let create () = { subscribers = Hashtbl.create 16 }
+
+  let publish t ~channel ~message =
+    match Hashtbl.find_opt t.subscribers channel with
+    | None -> Ok 0
+    | Some callbacks ->
+        List.iter (fun cb ->
+          try cb message with _ -> ()
+        ) callbacks;
+        Ok (List.length callbacks)
+
+  let subscribe t ~channel ~callback =
+    let existing = match Hashtbl.find_opt t.subscribers channel with
+      | Some cbs -> cbs | None -> []
+    in
+    Hashtbl.replace t.subscribers channel (callback :: existing);
+    Ok ()
+end
+
+(* ============================================ *)
 (* Memory Backend (In-Process)                  *)
 (* ============================================ *)
 
@@ -180,6 +208,7 @@ module MemoryBackend : BACKEND = struct
   type t = {
     data: (string, string) Hashtbl.t;
     locks: (string, lock_info) Hashtbl.t;
+    pubsub: Pubsub_mem.t;
     mutex: Eio.Mutex.t;
   }
 
@@ -190,6 +219,7 @@ module MemoryBackend : BACKEND = struct
     Ok {
       data = Hashtbl.create 1000;
       locks = Hashtbl.create 100;
+      pubsub = Pubsub_mem.create ();
       mutex = Eio.Mutex.create ();
     }
 
@@ -293,11 +323,11 @@ module MemoryBackend : BACKEND = struct
           Ok false
     )
 
-  let publish _t ~channel:_ ~message:_ =
-    Error (BackendNotSupported "Memory backend does not support pub/sub")
+  let publish t ~channel ~message =
+    with_lock t (fun () -> Pubsub_mem.publish t.pubsub ~channel ~message)
 
-  let subscribe _t ~channel:_ ~callback:_ =
-    Error (BackendNotSupported "Memory backend does not support pub/sub")
+  let subscribe t ~channel ~callback =
+    with_lock t (fun () -> Pubsub_mem.subscribe t.pubsub ~channel ~callback)
 
   let health_check _t = Ok true
 end

--- a/test/dune
+++ b/test/dune
@@ -139,7 +139,7 @@
 (test
  (name test_social_motion)
  (modules test_social_motion)
- (libraries masc_mcp alcotest unix yojson))
+ (libraries masc_mcp alcotest unix yojson eio eio_main))
 
 (test
  (name test_ci_hardening_source)
@@ -416,7 +416,7 @@
 (test
  (name test_tool_trpg_coverage)
  (modules test_tool_trpg_coverage)
- (libraries masc_mcp alcotest yojson unix))
+ (libraries masc_mcp alcotest yojson unix eio eio_main))
 
 ; Narrative Intelligence tests (inventory, relationships, dedup, JSON recovery)
 (test
@@ -947,7 +947,7 @@
 (test
  (name test_tool_registry)
  (modules test_tool_registry)
- (libraries masc_mcp alcotest yojson))
+ (libraries masc_mcp alcotest yojson eio eio_main))
 
 ; Tool Dispatch — O(1) Hashtbl central dispatch registry (P4 Phase 4.3)
 (test
@@ -1007,7 +1007,7 @@
 (test
  (name test_tool_unified)
  (modules test_tool_unified)
- (libraries masc_mcp alcotest yojson))
+ (libraries masc_mcp alcotest yojson eio eio_main))
 
 ; Mode Tool Count — end-to-end Config.enabled_tool_schemas per mode
 (test

--- a/test/dune
+++ b/test/dune
@@ -509,7 +509,7 @@
 (test
  (name test_protocol_game_view)
  (modules test_protocol_game_view)
- (libraries masc_mcp alcotest yojson unix))
+ (libraries masc_mcp alcotest yojson unix eio eio_main))
 
 (test
  (name test_tool_keeper)

--- a/test/test_backend.ml
+++ b/test/test_backend.ml
@@ -371,6 +371,7 @@ let test_corrupted_lock_recovery () =
 
 (* All tests *)
 let () =
+  Eio_main.run @@ fun _env ->
   run "Backend" [
     "config", [
       test_case "node ID generation" `Quick test_node_id_generation;

--- a/test/test_backend_coverage.ml
+++ b/test/test_backend_coverage.ml
@@ -741,6 +741,7 @@ let test_eio_fs_list_keys_empty () =
 (* ============================================================ *)
 
 let () =
+  Eio_main.run @@ fun _env ->
   run "Backend Coverage" [
     "validate_ttl", [
       test_case "zero TTL" `Quick test_validate_ttl_zero;

--- a/test/test_backend_coverage.ml
+++ b/test/test_backend_coverage.ml
@@ -178,35 +178,75 @@ let test_filesystem_health_check () =
 (* Backend.ml - Memory Pub/Sub (BackendNotSupported)             *)
 (* ============================================================ *)
 
-let test_memory_pubsub_not_supported () =
+let test_memory_pubsub () =
   let cfg = Backend.{ default_config with backend_type = Memory } in
   match Backend.MemoryBackend.create cfg with
   | Error _ -> fail "Failed to create"
   | Ok backend ->
-      (* Publish should return BackendNotSupported *)
-      (match Backend.MemoryBackend.publish backend ~channel:"test" ~message:"msg" with
-      | Error (Backend.BackendNotSupported _) -> ()
-      | _ -> fail "publish should return BackendNotSupported");
+      let received = ref "" in
+      (match Backend.MemoryBackend.subscribe backend
+          ~channel:"test" ~callback:(fun msg -> received := msg) with
+       | Ok () -> ()
+       | Error e -> fail (Backend.show_error e));
+      (match Backend.MemoryBackend.publish backend
+          ~channel:"test" ~message:"hello" with
+       | Ok count -> check int "1 subscriber" 1 count
+       | Error e -> fail (Backend.show_error e));
+      check string "received message" "hello" !received
 
-      (* Subscribe should return BackendNotSupported *)
-      match Backend.MemoryBackend.subscribe backend ~channel:"test" ~callback:(fun _ -> ()) with
-      | Error (Backend.BackendNotSupported _) -> ()
-      | _ -> fail "subscribe should return BackendNotSupported"
-
-let test_filesystem_pubsub_not_supported () =
+let test_filesystem_pubsub () =
   let cfg = { Backend.default_config with base_path = make_test_dir "masc_ps_test" } in
   match Backend.FileSystemBackend.create cfg with
   | Error _ -> fail "Failed to create"
   | Ok backend ->
-      (* Publish should return BackendNotSupported *)
-      (match Backend.FileSystemBackend.publish backend ~channel:"test" ~message:"msg" with
-      | Error (Backend.BackendNotSupported _) -> ()
-      | _ -> fail "publish should return BackendNotSupported");
+      let received = ref "" in
+      (match Backend.FileSystemBackend.subscribe backend
+          ~channel:"test" ~callback:(fun msg -> received := msg) with
+       | Ok () -> ()
+       | Error e -> fail (Backend.show_error e));
+      (match Backend.FileSystemBackend.publish backend
+          ~channel:"test" ~message:"hello" with
+       | Ok count -> check int "1 subscriber" 1 count
+       | Error e -> fail (Backend.show_error e));
+      check string "received message" "hello" !received
 
-      (* Subscribe should return BackendNotSupported *)
-      match Backend.FileSystemBackend.subscribe backend ~channel:"test" ~callback:(fun _ -> ()) with
-      | Error (Backend.BackendNotSupported _) -> ()
-      | _ -> fail "subscribe should return BackendNotSupported"
+let test_pubsub_no_subscribers () =
+  let cfg = Backend.{ default_config with backend_type = Memory } in
+  match Backend.MemoryBackend.create cfg with
+  | Error _ -> fail "Failed to create"
+  | Ok backend ->
+      (match Backend.MemoryBackend.publish backend ~channel:"empty" ~message:"msg" with
+       | Ok count -> check int "0 subscribers" 0 count
+       | Error e -> fail (Backend.show_error e))
+
+let test_pubsub_multi_subscribers () =
+  let cfg = Backend.{ default_config with backend_type = Memory } in
+  match Backend.MemoryBackend.create cfg with
+  | Error _ -> fail "Failed to create"
+  | Ok backend ->
+      let count_a = ref 0 in
+      let count_b = ref 0 in
+      ignore (Backend.MemoryBackend.subscribe backend
+          ~channel:"ch" ~callback:(fun _ -> incr count_a));
+      ignore (Backend.MemoryBackend.subscribe backend
+          ~channel:"ch" ~callback:(fun _ -> incr count_b));
+      (match Backend.MemoryBackend.publish backend ~channel:"ch" ~message:"x" with
+       | Ok count -> check int "2 subscribers" 2 count
+       | Error e -> fail (Backend.show_error e));
+      check int "a received" 1 !count_a;
+      check int "b received" 1 !count_b
+
+let test_pubsub_channel_isolation () =
+  let cfg = Backend.{ default_config with backend_type = Memory } in
+  match Backend.MemoryBackend.create cfg with
+  | Error _ -> fail "Failed to create"
+  | Ok backend ->
+      let received = ref false in
+      ignore (Backend.MemoryBackend.subscribe backend
+          ~channel:"alpha" ~callback:(fun _ -> received := true));
+      ignore (Backend.MemoryBackend.publish backend
+          ~channel:"beta" ~message:"msg");
+      check bool "alpha not triggered by beta" false !received
 
 (* ============================================================ *)
 (* Backend.ml - Lock Edge Cases                                  *)
@@ -765,8 +805,11 @@ let () =
       test_case "health_check" `Quick test_filesystem_health_check;
     ];
     "pubsub", [
-      test_case "memory not supported" `Quick test_memory_pubsub_not_supported;
-      test_case "filesystem not supported" `Quick test_filesystem_pubsub_not_supported;
+      test_case "memory publish and subscribe" `Quick test_memory_pubsub;
+      test_case "filesystem publish and subscribe" `Quick test_filesystem_pubsub;
+      test_case "no subscribers returns 0" `Quick test_pubsub_no_subscribers;
+      test_case "multi subscribers all receive" `Quick test_pubsub_multi_subscribers;
+      test_case "channel isolation" `Quick test_pubsub_channel_isolation;
     ];
     "lock_edge_cases", [
       test_case "nonowner release" `Quick test_lock_nonowner_release;

--- a/test/test_progress.ml
+++ b/test/test_progress.ml
@@ -186,6 +186,7 @@ let test_validate_progress_negative () =
   check bool "error mentions range" true (String.length msg > 0)
 
 let () =
+  Eio_main.run @@ fun _env ->
   run "progress"
     [
       ("notify", [

--- a/test/test_protocol_game_view.ml
+++ b/test/test_protocol_game_view.ml
@@ -648,6 +648,7 @@ let test_client_snapshot_get () =
         ((json |> member "payload" |> member "trpg" |> member "event_count" |> to_int) >= 2))
 
 let () =
+  Eio_main.run @@ fun _env ->
   Alcotest.run "Protocol GAME-VIEW"
     [
       ( "protocol",

--- a/test/test_relay_coverage.ml
+++ b/test/test_relay_coverage.ml
@@ -833,6 +833,7 @@ let test_estimate_context_claude_sonnet () =
    ============================================================ *)
 
 let () =
+  Eio_main.run @@ fun _env ->
   run "Relay Coverage" [
     "relay_config.defaults", [
       test_case "threshold" `Quick test_default_config_threshold;

--- a/test/test_room.ml
+++ b/test/test_room.ml
@@ -1290,6 +1290,7 @@ let test_multiple_rejoin_cycles () =
   )
 
 let () =
+  Eio_main.run @@ fun _env ->
   Random.init 42;
   Alcotest.run "Room" [
     (* === Happy Path Tests === *)

--- a/test/test_social_motion.ml
+++ b/test/test_social_motion.ml
@@ -117,6 +117,7 @@ let test_graph_json_summarizes_relationships () =
         (List.length (json |> member "timeline" |> to_list)))
 
 let () =
+  Eio_main.run @@ fun _env ->
   run "Social Motion"
     [
       ( "core",

--- a/test/test_tool_registry.ml
+++ b/test/test_tool_registry.ml
@@ -3,6 +3,7 @@
 module Tool_registry = Masc_mcp.Tool_registry
 
 let () =
+  Eio_main.run @@ fun _env ->
   let open Alcotest in
   run "Tool_registry"
     [

--- a/test/test_tool_task_coverage.ml
+++ b/test/test_tool_task_coverage.ml
@@ -9,7 +9,7 @@ let () = Printf.printf "\n=== Tool_task Coverage Tests ===\n"
 (* Test helper *)
 let test name f =
   try
-    f ();
+    Eio_main.run @@ (fun _env -> f ());
     Printf.printf "✓ %s passed\n" name
   with e ->
     Printf.printf "✗ %s FAILED: %s\n" name (Printexc.to_string e);

--- a/test/test_tool_trpg_coverage.ml
+++ b/test/test_tool_trpg_coverage.ml
@@ -3178,6 +3178,7 @@ let test_round_run_dm_persona_override_in_prompt_and_summary () =
   cleanup_dir base_dir
 
 let () =
+  Eio_main.run @@ fun _env ->
   Alcotest.run "Tool_trpg coverage"
     [
       ( "preset",

--- a/test/test_tool_unified.ml
+++ b/test/test_tool_unified.ml
@@ -6,6 +6,7 @@ module Tool_dispatch = Masc_mcp.Tool_dispatch
 module Tool_registry = Masc_mcp.Tool_registry
 
 let () =
+  Eio_main.run @@ fun _env ->
   let open Alcotest in
   run "Tool_unified"
     [


### PR DESCRIPTION
## Summary

3단계로 MASC 테스트 인프라를 수정:

### Wave 1-2: Eio test context (11 files, 64 failures fixed)
- `Eio.Mutex`를 사용하는 모듈 호출 시 `Effect.Unhandled(Get_context)` 크래시 수정
- 각 테스트 진입점에 `Eio_main.run @@ fun _env ->` 래핑
- 355개 전체 테스트 스캔 후 `Effect.Unhandled` 0건 확인

### Wave 3: In-memory pub/sub (3 files, ~+75 lines)
- `Pubsub_mem` 모듈 추가 — Hashtbl 기반 in-process event bus
- FileSystem/Memory 백엔드가 `BackendNotSupported` 대신 실제 pub/sub 동작
- MASC는 단일 프로세스이므로 in-memory dispatch가 의미적으로 정확
- 5개 pub/sub 테스트 추가 (subscribe, multi-subscriber, channel isolation)
- Resolves #1446

### Build fix
- `Tool_schemas_inline.schemas` 빌드 수정 cherry-pick (f0dc6310)

## Test plan
- [x] `dune build` 성공
- [x] 11개 Eio 수정 대상 테스트 개별 실행 확인
- [x] 355개 전체 `Effect.Unhandled` 스캔: 0건
- [x] pub/sub 5개 테스트 통과
- [x] test_backend + test_backend_coverage regression 없음
- [ ] CI green 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)