### PR TITLE
fix: remove unused schemas binding causing CI build failure

### DIFF
--- a/lib/tool_inline_dispatch.ml
+++ b/lib/tool_inline_dispatch.ml
@@ -979,5 +979,3 @@ Call masc_listen again to continue listening.
         ]))
 
   | _ -> Tool_inline_dispatch_extra.dispatch ~config ~agent_name ~arguments ~state ~sw ~clock ~name
-
-let schemas = Tool_schemas_inline.schemas


### PR DESCRIPTION
## Summary

- `tool_inline_dispatch.ml`에서 사용되지 않는 `let schemas` 바인딩 제거
- #1404 (tool discovery) 머지 후 이 값이 참조되지 않아 `warn-error=+a` 환경에서 warning 32 발생 → 전체 CI build failure

## Impact

이 수정이 머지되면 #1416, #1419, #1420 등 모든 열린 PR의 CI가 통과할 수 있음.

## Test plan

- [ ] `dune build --root .` 성공 확인 (CI에서)
- [ ] 다른 PR rebase 후 CI green 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)