### PR TITLE
feat(governance): wire consumers to Runtime_params

### DIFF
--- a/dashboard/src/types/sse.ts
+++ b/dashboard/src/types/sse.ts
@@ -22,6 +22,7 @@ export type SSEEventType =
   | 'mdal_iteration'
   | 'mdal_completed'
   | 'mdal_stopped'
+  | 'governance_param_changed'
 
 export interface SSEEvent {
   type: SSEEventType

--- a/lib/guardian.ml
+++ b/lib/guardian.ml
@@ -116,8 +116,8 @@ let is_quiet_hours () =
   else
     let tm = Unix.localtime (Time_compat.now ()) in
     let hour = tm.Unix.tm_hour in
-    let quiet_start = Env_config.LodgeV2.quiet_start in
-    let quiet_end = Env_config.LodgeV2.quiet_end in
+    let quiet_start = Runtime_params.get Governance_registry.lodge_quiet_start in
+    let quiet_end = Runtime_params.get Governance_registry.lodge_quiet_end in
     quiet_start < quiet_end && hour >= quiet_start && hour < quiet_end
 
 (* ── Pulse helpers ─────────────────────────────────────────── *)

--- a/lib/lodge_heartbeat.ml
+++ b/lib/lodge_heartbeat.ml
@@ -380,7 +380,7 @@ let select_agents_with_thompson ~ignore_quiet_hours
       Eio.traceln "   😴 [thompson] Quiet hours (%d-%d), skipping selection" quiet_start quiet_end;
     []
   end else begin
-    let tick_interval = Env_config.LodgeV2.tick_interval_seconds in
+    let tick_interval = Runtime_params.get Governance_registry.lodge_tick_interval in
     let agent_names = List.map (fun (a : agent) -> a.name) agents in
     let converted_triggers = List.map (fun (name, t) ->
       (name, selection_trigger_of_trigger t)
@@ -496,7 +496,7 @@ let tick ~ignore_quiet_hours ~config ~pending_triggers =
   let agents = get_agents () in
 
   (* Select which agents to check in — Thompson (default) / plan-based / legacy *)
-  let max_agents = Env_config.LodgeV2.agents_per_tick in
+  let max_agents = Runtime_params.get Governance_registry.lodge_agents_per_tick in
   let use_thompson = Env_config.LodgeV2.use_planner in  (* Reuse planner flag for Thompson *)
   let selected =
     if use_thompson then
@@ -693,10 +693,10 @@ let start ~sw ~clock room_config =
   Printf.printf "+Lodge Heartbeat v2 (Generative Agent): initializing...\n%!";
   lodge_init_lock ();
   let config = load_config () in
-  let tick_interval = Env_config.LodgeV2.tick_interval_seconds in
+  let tick_interval = config.interval_s in
   let use_planner = Env_config.LodgeV2.use_planner in
   Printf.printf "+Lodge Heartbeat: enabled=%b interval=%.0fs agents_per_tick=%d planner=%b\n%!"
-    config.enabled tick_interval Env_config.LodgeV2.agents_per_tick use_planner;
+    config.enabled tick_interval config.agents_per_tick use_planner;
 
   (* Configure and load persistent selection stats for Thompson Sampling *)
   Lodge_selection.set_base_path room_config.Room_utils.base_path;
@@ -716,7 +716,7 @@ let start ~sw ~clock room_config =
   end else begin
     _lodge_enabled := true;
     Eio.traceln "🫀 Lodge Heartbeat v2 (Generative): starting (interval=%.0fs, max=%d/tick, planner=%b)"
-      tick_interval Env_config.LodgeV2.agents_per_tick use_planner;
+      tick_interval config.agents_per_tick use_planner;
 
     (* Track last tick time for content alert scanning *)
     let last_tick_time = ref (Time_compat.now ()) in

--- a/lib/lodge_heartbeat_state.ml
+++ b/lib/lodge_heartbeat_state.ml
@@ -135,7 +135,7 @@ let can_agent_comment = Lodge_rate_limit.can_agent_comment
 let record_agent_comment = Lodge_rate_limit.record_agent_comment
 let min_post_gap = Lodge_rate_limit.min_post_gap
 let min_comment_gap = Lodge_rate_limit.min_comment_gap
-let max_posts_per_day = Lodge_rate_limit.max_posts_per_day
+let max_posts_per_day = Lodge_rate_limit.max_posts_per_day ()
 let max_comments_per_day = Lodge_rate_limit.max_comments_per_day
 let max_comments_per_agent_per_post = Lodge_rate_limit.max_comments_per_agent_per_post
 
@@ -431,14 +431,17 @@ let default_config = {
   quiet_hours = (1, 6);
 }
 
-(** Load config from Env_config.LodgeV2 (SSOT: MASC_LODGE_* env vars) *)
+(** Load config — governable fields read from Runtime_params,
+    non-governable from Env_config directly. *)
 let load_config () =
   {
-    interval_s = Env_config.LodgeV2.tick_interval_seconds;
+    interval_s = Runtime_params.get Governance_registry.lodge_tick_interval;
     enabled = Env_config.LodgeV2.enabled;
-    agents_per_tick = Env_config.LodgeV2.agents_per_tick;
+    agents_per_tick = Runtime_params.get Governance_registry.lodge_agents_per_tick;
     min_checkin_gap_s = Env_config.LodgeV2.min_checkin_gap_seconds;
-    quiet_hours = (Env_config.LodgeV2.quiet_start, Env_config.LodgeV2.quiet_end);
+    quiet_hours =
+      ( Runtime_params.get Governance_registry.lodge_quiet_start,
+        Runtime_params.get Governance_registry.lodge_quiet_end );
   }
 
 (** {1 Types — Check-in Model v2} *)
@@ -704,7 +707,7 @@ let lodge_status () : lodge_status =
   let agents = !agents_cache in
   {
     ls_enabled = !_lodge_enabled;
-    ls_interval_s = Env_config.LodgeV2.tick_interval_seconds;
+    ls_interval_s = Runtime_params.get Governance_registry.lodge_tick_interval;
     ls_agent_count = List.length agents;
     ls_agent_names = List.map (fun a -> a.name) agents;
     ls_last_tick = !_lodge_last_tick;

--- a/lib/lodge_rate_limit.ml
+++ b/lib/lodge_rate_limit.ml
@@ -30,7 +30,8 @@ let rate_states : (string, rate_state) Hashtbl.t = Hashtbl.create 10
 
 let min_post_gap = Env_config_governance.LodgeV2.min_post_gap_seconds
 let min_comment_gap = Env_config_governance.LodgeV2.min_comment_gap_seconds
-let max_posts_per_day = Env_config_governance.LodgeV2.max_posts_per_day
+(* Governable: read via Runtime_params so masc_set_param changes take effect *)
+let max_posts_per_day () = Runtime_params.get Governance_registry.lodge_max_posts_per_day
 let max_comments_per_day = Env_config_governance.LodgeV2.max_comments_per_day
 
 (** Get or create rate state for agent *)
@@ -58,7 +59,7 @@ let check_rate_limit ~agent_name action_type =
   let rs = get_rate_state ~agent_name in
   match action_type with
   | `Post ->
-    now -. rs.last_post >= min_post_gap && rs.posts_today < max_posts_per_day
+    now -. rs.last_post >= min_post_gap && rs.posts_today < max_posts_per_day ()
   | `Comment ->
     now -. rs.last_comment >= min_comment_gap && rs.comments_today < max_comments_per_day
   | `Vote -> true  (* Votes are always allowed *)

--- a/lib/lodge_rate_limit.mli
+++ b/lib/lodge_rate_limit.mli
@@ -29,8 +29,9 @@ val min_post_gap : float
 (** Minimum gap between comments in seconds. *)
 val min_comment_gap : float
 
-(** Maximum posts per day per agent. *)
-val max_posts_per_day : int
+(** Maximum posts per day per agent.
+    Reads from Runtime_params (governable via masc_set_param). *)
+val max_posts_per_day : unit -> int
 
 (** Maximum comments per day per agent. *)
 val max_comments_per_day : int


### PR DESCRIPTION
## Summary

거버넌스 enforcement (PR #1407)의 후속. 실제 소비자 코드가 Runtime_params에서 값을 읽도록 마이그레이션.

**이전**: `masc_set_param`으로 `lodge.tick_interval_seconds`를 변경해도, 실제 lodge 코드는 `Env_config_governance.LodgeV2.tick_interval_seconds`(상수)를 읽어서 변경이 반영되지 않았음.

**이후**: `Runtime_params.get Governance_registry.lodge_tick_interval`을 읽으므로 즉시 반영.

### 마이그레이션된 소비자 (5파일)
- `lodge_rate_limit.ml`: `max_posts_per_day` → `Runtime_params.get` (함수로 전환)
- `lodge_heartbeat_state.ml`: `load_config()` — tick_interval, agents_per_tick, quiet_start/end
- `lodge_heartbeat.ml`: `tick()` agents_per_tick, `start()` tick_interval
- `guardian.ml`: quiet hours

### 마이그레이션하지 않은 것 (의도적)
- `enabled`, `use_planner`, `min_post_gap` — 런타임 조정이 불필요한 on/off 설정

## Test plan
- [x] `test_runtime_params.exe` — 10/10 pass
- [x] `dune build` 성공
- [ ] E2E: `masc_set_param(param_key="lodge.agents_per_tick", value=5)` → lodge tick에서 5개 에이전트 선택 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)