### PR TITLE
chore: bump version to 2.105.0

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -1,7 +1,7 @@
 (lang dune 3.13)
 
 (name masc_mcp)
-(version 2.104.0)
+(version 2.105.0)
 
 (generate_opam_files true)
 


### PR DESCRIPTION
2.104.0 → 2.105.0. New: recall stack + state isolation (#1435).