### PR TITLE
fix(test): wrap 5 test runners in Eio_main.run for Eio.Mutex compat

### DIFF
--- a/test/dune
+++ b/test/dune
@@ -139,7 +139,7 @@
 (test
  (name test_social_motion)
  (modules test_social_motion)
- (libraries masc_mcp alcotest unix yojson))
+ (libraries masc_mcp alcotest eio eio_main unix yojson))
 
 (test
  (name test_ci_hardening_source)
@@ -246,7 +246,7 @@
 (test
  (name test_lodge_cascade)
  (modules test_lodge_cascade)
- (libraries masc_mcp alcotest unix))
+ (libraries masc_mcp alcotest eio eio_main unix))
 
 (test
  (name test_llm_client_cascade)
@@ -416,7 +416,7 @@
 (test
  (name test_tool_trpg_coverage)
  (modules test_tool_trpg_coverage)
- (libraries masc_mcp alcotest yojson unix))
+ (libraries masc_mcp alcotest eio eio_main yojson unix))
 
 ; Narrative Intelligence tests (inventory, relationships, dedup, JSON recovery)
 (test
@@ -509,7 +509,7 @@
 (test
  (name test_protocol_game_view)
  (modules test_protocol_game_view)
- (libraries masc_mcp alcotest yojson unix))
+ (libraries masc_mcp alcotest eio eio_main yojson unix))
 
 (test
  (name test_tool_keeper)

--- a/test/test_gardener.ml
+++ b/test/test_gardener.ml
@@ -1140,6 +1140,7 @@ let suite = [
 ]
 
 let () =
+  Eio_main.run @@ fun _env ->
   Alcotest.run "Gardener" [
     "gardener", suite;
   ]

--- a/test/test_lodge_cascade.ml
+++ b/test/test_lodge_cascade.ml
@@ -140,6 +140,7 @@ let test_model_key_format () =
   check string "key format" "heartbeat_action_models" key
 
 let () =
+  Eio_main.run @@ fun _env ->
   run "lodge_cascade"
     [
       ( "loader",

--- a/test/test_protocol_game_view.ml
+++ b/test/test_protocol_game_view.ml
@@ -648,6 +648,7 @@ let test_client_snapshot_get () =
         ((json |> member "payload" |> member "trpg" |> member "event_count" |> to_int) >= 2))
 
 let () =
+  Eio_main.run @@ fun _env ->
   Alcotest.run "Protocol GAME-VIEW"
     [
       ( "protocol",

--- a/test/test_social_motion.ml
+++ b/test/test_social_motion.ml
@@ -117,6 +117,7 @@ let test_graph_json_summarizes_relationships () =
         (List.length (json |> member "timeline" |> to_list)))
 
 let () =
+  Eio_main.run @@ fun _env ->
   run "Social Motion"
     [
       ( "core",

--- a/test/test_tool_trpg_coverage.ml
+++ b/test/test_tool_trpg_coverage.ml
@@ -3178,6 +3178,7 @@ let test_round_run_dm_persona_override_in_prompt_and_summary () =
   cleanup_dir base_dir
 
 let () =
+  Eio_main.run @@ fun _env ->
   Alcotest.run "Tool_trpg coverage"
     [
       ( "preset",


### PR DESCRIPTION
## Summary
- `Effect.Unhandled(Eio__core__Cancel.Get_context)` 에러로 main CI Build and Test 실패하는 문제 수정
- 5개 테스트 runner를 `Eio_main.run`으로 감싸서 Eio runtime context 제공
- 4개 테스트 dune에 `eio eio_main` 의존성 추가

## 수정 대상
- `test_social_motion` — core: filtered client, graph summary
- `test_lodge_cascade` — call: no callable models
- `test_gardener` — spawn_decision
- `test_protocol_game_view` — client.input, client.snapshot
- `test_tool_trpg_coverage` — session, round_run

## Test plan
- [ ] `dune build` 성공 확인 (local verified)
- [ ] CI Build and Test pass 확인
- [ ] 이 PR 머지 후 다른 PR들의 CI re-run으로 green 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)