### PR TITLE
docs(tools): update schemas_05/06 descriptions (37 tools)

### DIFF
--- a/lib/tools_schemas_05.ml
+++ b/lib/tools_schemas_05.ml
@@ -5,7 +5,9 @@ open Types
 let schemas : tool_schema list = [
   {
     name = "masc_auth_refresh";
-    description = "Refresh an expired or soon-to-expire token. Returns a new token.";
+    description = "Refresh an expired or soon-to-expire authentication token. \
+Use when your token is about to expire during a long session. \
+Pair with masc_auth_status to check expiry, or masc_auth_create_token for a fresh one.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -24,7 +26,9 @@ let schemas : tool_schema list = [
 
   {
     name = "masc_auth_revoke";
-    description = "Revoke an agent's token. The agent will need a new token to perform authenticated actions.";
+    description = "Revoke an agent's authentication token (admin). \
+Use when revoking access for a misbehaving or departed agent. \
+The agent must call masc_auth_create_token to regain access. Pair with masc_auth_list to find targets.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -39,7 +43,9 @@ let schemas : tool_schema list = [
 
   {
     name = "masc_auth_list";
-    description = "List all agent credentials (admin only). Shows agent names, roles, and token expiry times.";
+    description = "List all agent credentials with roles and token expiry (admin only). \
+Use when auditing who has access or checking for expired tokens. \
+Pair with masc_auth_revoke to clean up stale credentials.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc []);
@@ -49,7 +55,9 @@ let schemas : tool_schema list = [
   (* Rate limit tools *)
   {
     name = "masc_rate_limit_status";
-    description = "Get your current rate limit status. Shows remaining requests per category (general, broadcast, task ops, file locks) and burst tokens.";
+    description = "Get your current rate limit status: remaining requests per category and burst tokens. \
+Use when you are hitting rate limits or want to check budget before a batch operation. \
+Pair with masc_rate_limit_config to adjust limits (admin).";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -64,7 +72,9 @@ let schemas : tool_schema list = [
 
   {
     name = "masc_rate_limit_config";
-    description = "Get or update rate limit configuration (admin only). Shows limits per category and role multipliers.";
+    description = "Get or update rate limit configuration (admin only). \
+Use when adjusting per-minute limits, burst tokens, or role multipliers. \
+Pair with masc_rate_limit_status to verify the effect of changes.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -94,7 +104,9 @@ let schemas : tool_schema list = [
 
   {
     name = "masc_encryption_status";
-    description = "Get encryption status for this MASC room. Shows if encryption is enabled, key status, and RNG state.";
+    description = "Get encryption status for this MASC room: enabled flag, key status, and RNG state. \
+Use when verifying data protection is active before handling sensitive information. \
+Pair with masc_encryption_enable to turn on, or masc_generate_key for a new key.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc []);
@@ -103,7 +115,9 @@ let schemas : tool_schema list = [
 
   {
     name = "masc_encryption_enable";
-    description = "Enable encryption for sensitive data in this MASC room. Requires setting MASC_ENCRYPTION_KEY environment variable (32-byte key) or providing a key file path.";
+    description = "Enable encryption for sensitive data in this MASC room. \
+Use when the room will handle credentials, tokens, or private data. \
+Requires MASC_ENCRYPTION_KEY env var or key_source='generate'. Pair with masc_encryption_status to verify.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -118,7 +132,9 @@ let schemas : tool_schema list = [
 
   {
     name = "masc_encryption_disable";
-    description = "Disable encryption for this MASC room. Existing encrypted data will remain encrypted but new data will be stored in plain text.";
+    description = "Disable encryption for this MASC room. Existing encrypted data stays encrypted; new data is plain text. \
+Use when encryption overhead is not needed or for debugging. \
+Pair with masc_encryption_status to confirm the change.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc []);
@@ -127,7 +143,9 @@ let schemas : tool_schema list = [
 
   {
     name = "masc_generate_key";
-    description = "Generate a new random 256-bit encryption key. Returns the key in hex format. Store this securely - losing the key means losing access to encrypted data.";
+    description = "Generate a random 256-bit encryption key in hex or base64 format. \
+Use when setting up encryption for the first time or rotating keys. \
+Store the key securely. Pair with masc_encryption_enable to apply.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -146,7 +164,10 @@ let schemas : tool_schema list = [
 
   {
     name = "masc_switch_mode";
-    description = "Switch MASC mode to reduce token usage. Available modes: 'minimal' (core+health), 'standard' (core+comm+worktree+health), 'parallel' (multi-agent heavy: comm+portal+discovery+voting+interrupt), 'full' (all features), 'solo' (single-agent: core+worktree). Use 'custom' with categories parameter for fine-grained control.";
+    description = "Switch MASC mode to control which tool categories are visible. \
+Use when you want to reduce token overhead (minimal/solo) or enable more features (parallel/full). \
+Modes: minimal (~20), standard, parallel, full (~322), solo (~23), agent (~20), custom. \
+Pair with masc_get_config to see current mode, masc_tool_enable for individual tools.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -167,7 +188,9 @@ let schemas : tool_schema list = [
 
   {
     name = "masc_get_config";
-    description = "Get current MASC mode configuration. Shows enabled categories, disabled categories, and available mode presets.";
+    description = "Get current MASC mode configuration: enabled/disabled categories and available presets. \
+Use when checking which tools are visible before requesting a mode switch. \
+Pair with masc_switch_mode to change modes.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc []);
@@ -180,7 +203,9 @@ let schemas : tool_schema list = [
 
   {
     name = "masc_spawn";
-    description = "Spawn an agent to execute a task. Use this to orchestrate multi-agent collaboration without manual terminal setup. When agent_name='llama', you must provide model explicitly.";
+    description = "Spawn an agent process (claude, gemini, codex, or llama) to execute a task. \
+Use when you need another agent to work in parallel on a subtask. \
+For llama, provide model explicitly. Pair with masc_add_task to create the task first.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -216,7 +241,9 @@ let schemas : tool_schema list = [
 
   {
     name = "masc_relay_status";
-    description = "Check current context usage and relay readiness. Shows estimated token count, usage ratio, and whether relay is recommended. Call periodically to monitor context health.";
+    description = "Check current context usage and relay readiness: token count, usage ratio, and recommendation. \
+Use when monitoring context health during long sessions. Call periodically. \
+Pair with masc_relay_now when relay is recommended, or masc_relay_checkpoint to save state.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -239,7 +266,9 @@ let schemas : tool_schema list = [
 
   {
     name = "masc_relay_checkpoint";
-    description = "Save a checkpoint of current state for smooth handoff. Call at key moments (after completing subtasks, before complex operations). Checkpoints enable proactive relay with minimal context loss.";
+    description = "Save a checkpoint of current work state (summary, TODOs, relevant files) for smooth handoff. \
+Use when completing a subtask or before starting a complex operation. \
+Pair with masc_relay_now to trigger handoff, or masc_relay_status to check if relay is needed.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -272,7 +301,9 @@ let schemas : tool_schema list = [
 
   {
     name = "masc_relay_now";
-    description = "Trigger immediate relay to a new agent. Use when context is getting full or before a complex task. The new agent will receive compressed context and continue seamlessly.";
+    description = "Trigger immediate relay to a new agent with compressed context. \
+Use when context is getting full (>70%) or before a task that will overflow. \
+Call masc_relay_checkpoint first to save state. The successor continues where you left off.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -301,7 +332,9 @@ let schemas : tool_schema list = [
 
   {
     name = "masc_relay_smart_check";
-    description = "Proactive relay check with task hint. Predicts if upcoming task will overflow context and suggests relay BEFORE starting the task. Key for smooth transitions.";
+    description = "Proactive relay check with task complexity hint. Predicts if the next task will overflow context. \
+Use when about to start a large_file, multi_file, or long_running task. \
+Returns relay recommendation before you commit. Pair with masc_relay_now if relay is advised.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -333,7 +366,9 @@ let schemas : tool_schema list = [
 
   {
     name = "masc_mitosis_status";
-    description = "Get current agent cell status and stem pool state. Shows generation, task count, tool calls, and available reserve cells. Use to monitor lifecycle state.";
+    description = "Get current agent cell status: generation, task count, tool calls, and stem pool reserve. \
+Use when monitoring your lifecycle state or deciding if mitosis is approaching. \
+Pair with masc_mitosis_check for threshold-based recommendations.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc []);
@@ -342,7 +377,9 @@ let schemas : tool_schema list = [
 
   {
     name = "masc_mitosis_all";
-    description = "Get mitosis status of ALL agents in the cluster (cross-machine). Shows each agent's context pressure so you can see if another agent needs handoff help. Use for collaboration awareness.";
+    description = "Get mitosis status of ALL agents in the cluster (cross-machine). \
+Use when checking if any agent is under context pressure and needs handoff help. \
+Pair with masc_mitosis_divide to assist an agent approaching threshold.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc []);
@@ -351,7 +388,9 @@ let schemas : tool_schema list = [
 
   {
     name = "masc_mitosis_pool";
-    description = "View the stem cell pool - reserve agents ready for instant handoff. Shows warm cells, their generation, and readiness state.";
+    description = "View the stem cell pool: reserve agents ready for instant handoff. \
+Use when checking if warm cells are available before triggering mitosis. \
+Pair with masc_mitosis_divide for manual division, or masc_memento_mori for auto-lifecycle.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc []);
@@ -360,7 +399,9 @@ let schemas : tool_schema list = [
 
   {
     name = "masc_mitosis_divide";
-    description = "Manually trigger cell division (mitosis). Parent cell dies gracefully (apoptosis) while child cell inherits compressed DNA (context). Use for proactive handoff.";
+    description = "Manually trigger cell division (mitosis): parent cell dies, child inherits compressed context DNA. \
+Use when you decide to hand off proactively rather than waiting for auto-threshold. \
+Pair with masc_mitosis_prepare to extract DNA first, or use masc_memento_mori for auto mode.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -379,7 +420,9 @@ let schemas : tool_schema list = [
 
   {
     name = "masc_mitosis_check";
-    description = "2-Phase mitosis check. Phase 1 (50%): should_prepare=true → extract DNA. Phase 2 (80%): should_handoff=true → execute handoff. Returns current phase and thresholds.";
+    description = "2-phase mitosis check: Phase 1 (50%) should_prepare, Phase 2 (80%) should_handoff. \
+Use when periodically checking context health. Returns current phase and thresholds. \
+After should_prepare: call masc_mitosis_prepare. After should_handoff: call masc_mitosis_divide.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -393,7 +436,9 @@ let schemas : tool_schema list = [
 
   {
     name = "masc_mitosis_record";
-    description = "Record activity for mitosis trigger tracking. Call after completing tasks or tool calls to update counters.";
+    description = "Record an activity event (task completion or tool call) to update mitosis trigger counters. \
+Use when completing a task or making a significant tool call to keep lifecycle tracking accurate. \
+Pair with masc_mitosis_check to see if the counters have triggered a threshold.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -411,7 +456,9 @@ let schemas : tool_schema list = [
 
   {
     name = "masc_mitosis_prepare";
-    description = "Phase 1: Prepare for division - extract DNA and mark cell as ready. Does NOT handoff yet. Call this at 50% context to prepare early, actual handoff happens at 80%.";
+    description = "Phase 1: Extract DNA from current context and mark cell as ready for division. Does NOT hand off yet. \
+Use when masc_mitosis_check returns should_prepare=true (context ~50%). \
+Actual handoff happens at 80% via masc_mitosis_divide or masc_memento_mori.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -430,7 +477,10 @@ let schemas : tool_schema list = [
 
   {
     name = "masc_tool_enable";
-    description = "Enable specific tools or categories without switching to Full mode. Use when you need a tool not in the current mode. Categories: ecosystem (perpetual, gardener, keeper, mdal, handover, library), discovery (capabilities, agent_card, fitness), code (code_search, code_symbols, code_read), board (post, comment, vote), portal, worktree, consensus (debate, convo, walph), voting, encryption, auth, cost. Pass category= for bulk enable or tool= for individual.";
+    description = "Enable specific tools or entire categories without switching to Full mode. \
+Use when you need a tool not in the current mode preset (e.g., masc_perpetual_start in Standard mode). \
+Pass tool= for individual, tools= for multiple, or category= for bulk (ecosystem, discovery, code, board, etc.). \
+Pair with masc_tool_disable to revert, or masc_switch_mode for wholesale changes.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -453,7 +503,9 @@ let schemas : tool_schema list = [
 
   {
     name = "masc_tool_disable";
-    description = "Disable previously extra-enabled tools, or clear all extra-enabled tools with clear=true.";
+    description = "Disable previously extra-enabled tools, or clear all extra-enabled tools with clear=true. \
+Use when cleaning up tools you no longer need, or resetting to the mode preset baseline. \
+Pair with masc_tool_enable to re-add tools later.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [

--- a/lib/tools_schemas_06.ml
+++ b/lib/tools_schemas_06.ml
@@ -5,15 +5,10 @@ open Types
 let schemas : tool_schema list = [
   {
     name = "masc_mitosis_handoff";
-    description = {|2-Phase Proactive Context Management - THE CORE MITOSIS TOOL
-
-Call this periodically with your estimated context_ratio. It handles the full lifecycle:
-- <50%: Returns "none" - continue working normally
-- 50-80%: Returns "prepared" - DNA extracted, ready for handoff
-- >80%: Returns "handoff" - spawns successor agent with DNA
-
-Unlike masc_mitosis_divide (manual), this auto-detects phase and takes appropriate action.
-Embodies proactive mitosis: prepare early at 50%, handoff at 80%.|};
+    description = "Automated 2-phase context lifecycle manager. Call periodically with your estimated context_ratio. \
+<50%: continue, 50-80%: DNA extracted (prepared), >80%: spawns successor (handoff). \
+Use when you want automatic lifecycle management instead of manual masc_mitosis_check + prepare + divide. \
+Pair with masc_memento_mori for the all-in-one convenience wrapper.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -97,16 +92,9 @@ Embodies proactive mitosis: prepare early at 50%, handoff at 80%.|};
 
   {
     name = "masc_metrics_compare";
-    description = {|Compare generational performance metrics.
-
-Evidence for "Are successors better than predecessors?"
-Compares two generations across:
-- Task completion rate
-- Error rate
-- Duration (speed)
-- Token efficiency
-
-Returns verdict: "improved" / "degraded" / "neutral"|};
+    description = "Compare performance metrics between two agent generations (completion rate, errors, speed, tokens). \
+Use when evaluating whether successor agents are improving over predecessors. \
+Returns verdict: improved/degraded/neutral. Pair with masc_metrics_record to collect data first.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -125,9 +113,9 @@ Returns verdict: "improved" / "degraded" / "neutral"|};
 
   {
     name = "masc_metrics_record";
-    description = {|Record a task completion for generational metrics.
-
-Call after completing a task to track performance across generations.|};
+    description = "Record a task completion event (duration, errors, tokens) for generational performance tracking. \
+Use when finishing a task to feed data into the metrics system. \
+Pair with masc_metrics_compare to evaluate generational improvement.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -162,15 +150,10 @@ Call after completing a task to track performance across generations.|};
 
   {
     name = "masc_memento_mori";
-    description = {|Memento Mori - Agent self-awareness of mortality.
-A convenience tool combining mitosis check + prepare + divide in one call.
-Call this periodically to check your context health and auto-handle lifecycle:
-- <50%: Returns "continue" - keep working
-- 50-80%: Auto-prepares DNA, returns "prepared" - ready for handoff when needed
-- >80%: Auto-divides and spawns successor, returns handoff result
-
-This embodies the philosophical concept of "memento mori" - agents should be aware
-of their context limits and gracefully hand over work to successors.|};
+    description = "All-in-one context health check combining mitosis check + prepare + divide in a single call. \
+Use when you want a simple periodic lifecycle check without managing individual mitosis steps. \
+<50%: continue, 50-80%: auto-prepare DNA, >80%: auto-divide and spawn successor. \
+Pair with masc_mitosis_status to see cell state, or masc_mitosis_handoff for async saga variant.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -205,17 +188,9 @@ of their context limits and gracefully hand over work to successors.|};
 
   {
     name = "masc_episode_flush";
-    description = {|Flush pending episodes to Neo4j and PostgreSQL.
-
-Episodes are queued locally during mitosis handoff (file-based queue for reliability).
-This tool flushes them to persistent storage (Neo4j for graph relationships, PostgreSQL for queries).
-
-Part of the Agent Being Protocol - agents are "beings" with memory continuity across generations.
-
-Returns:
-- flushed: Number of episodes successfully saved to DB
-- failed: Number of episodes that failed (kept in queue for retry)
-- pending: Remaining episodes in queue|};
+    description = "Flush locally queued episodes to Neo4j (graph) and PostgreSQL (relational) persistent storage. \
+Use when episodes have been queued during mitosis handoff and need to be persisted. \
+Returns flushed/failed/pending counts. Pair with masc_episode_list to verify stored episodes.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -233,12 +208,9 @@ Returns:
 
   {
     name = "masc_episode_list";
-    description = {|List recent episodes from PostgreSQL.
-
-Query agent episodes with optional filters. Returns episode metadata for debugging
-and understanding agent lineage.
-
-Part of the Agent Being Protocol - agents can reflect on their history.|};
+    description = "List recent agent episodes from PostgreSQL with optional filters by agent_name and generation. \
+Use when debugging agent lineage, reviewing past actions, or understanding generational history. \
+Pair with masc_episode_flush to ensure episodes are persisted before querying.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -260,16 +232,9 @@ Part of the Agent Being Protocol - agents can reflect on their history.|};
 
   {
     name = "masc_self_introspect";
-    description = {|Agent self-awareness introspection.
-
-Returns the agent's current lifecycle state:
-- generation: Current generation number (how many mitosis events in lineage)
-- context_used: Estimated context usage percentage
-- siblings: Other agents of the same generation in the room
-- parent_episode: Episode ID of the parent (if known)
-- estimated_lifespan: Tokens/turns remaining before mitosis needed
-
-Part of the Agent Being Protocol - agents should know their place in the lifecycle.|};
+    description = "Agent self-awareness introspection: generation, context usage, siblings, parent episode, estimated lifespan. \
+Use when you need to understand your place in the agent lifecycle or check remaining capacity. \
+Pair with masc_mitosis_check for threshold-based action, or masc_recall_search for memory queries.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc []);
@@ -278,12 +243,9 @@ Part of the Agent Being Protocol - agents should know their place in the lifecyc
 
   {
     name = "masc_recall_search";
-    description = {|Semantic memory search using local memory sources.
-
-Searches the agent's episodic memories using relevance scoring.
-Part of the Agent Being Protocol - agents can recall relevant past experiences.
-
-Returns matched memories with relevance scores, sorted by relevance.|};
+    description = "Semantic memory search across the agent's episodic memories using relevance scoring. \
+Use when you need to recall past experiences, decisions, or context from previous generations. \
+Returns matched memories sorted by relevance. Pair with masc_episode_list for structured queries.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -306,7 +268,9 @@ Returns matched memories with relevance scores, sorted by relevance.|};
 
   {
     name = "masc_a2a_discover";
-    description = "Discover available A2A agents. Returns agent cards with capabilities, skills, and protocol bindings. Use for local room discovery or remote endpoint fetching.";
+    description = "Discover available A2A agents with capabilities, skills, and protocol bindings. \
+Use when looking for agents to delegate tasks to, or checking what skills are available in the room. \
+Pair with masc_a2a_delegate to send work, or masc_a2a_query_skill for skill details.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -324,7 +288,9 @@ Returns matched memories with relevance scores, sorted by relevance.|};
 
   {
     name = "masc_a2a_query_skill";
-    description = "Query detailed information about an agent's skill, including input/output modes and examples. Use to understand what a skill can do before delegating.";
+    description = "Query detailed information about an agent's skill: input/output modes and usage examples. \
+Use when you want to understand a skill's capabilities before delegating work via masc_a2a_delegate. \
+Call masc_a2a_discover first to find available agents and skill IDs.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -343,7 +309,9 @@ Returns matched memories with relevance scores, sorted by relevance.|};
 
   {
     name = "masc_a2a_delegate";
-    description = "Delegate a task to another A2A agent. Opens portal, sends task, returns task ID. Use sync for waiting, async for fire-and-forget, stream for real-time updates.";
+    description = "Delegate a task to another A2A agent via portal. Returns task ID. \
+Use when you want another agent to handle a subtask. Modes: sync (wait), async (fire-and-forget), stream (real-time). \
+Call masc_a2a_discover first to find capable agents. Pair with masc_a2a_subscribe for async results.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -385,7 +353,9 @@ Returns matched memories with relevance scores, sorted by relevance.|};
 
   {
     name = "masc_a2a_subscribe";
-    description = "Subscribe to events from agents (task updates, broadcasts, completions). Connect to SSE endpoint to receive events.";
+    description = "Subscribe to events from agents (task_update, broadcast, completion, error) via SSE. \
+Use when monitoring delegated tasks or wanting real-time updates from other agents. \
+Pair with masc_poll_events to read buffered events, and masc_a2a_unsubscribe to clean up.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [
@@ -427,7 +397,9 @@ Example: masc_a2a_unsubscribe({subscription_id: 'sub-abc123'})";
 
   {
     name = "masc_poll_events";
-    description = "Poll buffered events for a subscription. Use this for background subscription workflow: subscribe → do work → poll_events periodically. Returns and clears buffered events.";
+    description = "Poll buffered events for a subscription and optionally clear the buffer. \
+Use when checking for async task updates or broadcast events between work steps. \
+Workflow: masc_a2a_subscribe -> do work -> masc_poll_events periodically -> masc_a2a_unsubscribe.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [


### PR DESCRIPTION
## Summary

- `tools_schemas_05.ml`: 23개 도구 (Auth, RateLimit, Encryption, Mode, Spawn, Relay, Mitosis, Tool Disclosure)
- `tools_schemas_06.ml`: 14개 도구 (Mitosis Handoff, Metrics, Memento Mori, Episode, A2A, Self-Introspect)
- #1418 follow-up: Batch E quota 한계로 누락된 2개 파일 완료

## Changes

| 파일 | 도구 수 | 변경 |
|------|---------|------|
| tools_schemas_05.ml | 23 | +70/-32 |
| tools_schemas_06.ml | 14 | +48/-62 |

모든 description이 `{what}/{when}/{workflow}` 템플릿을 따르며, multi-line `{| |}` 문자열을 표준 `"...\n..."` 형식으로 통일.

## Test plan

- [x] `dune build --root .` 통과
- [ ] CI green 확인


🤖 Generated with [Claude Code](https://claude.com/claude-code)