### PR TITLE
refactor(dashboard): Phase 2.1 — deduplicate mission-store normalizers

### DIFF
--- a/dashboard/src/mission-store.ts
+++ b/dashboard/src/mission-store.ts
@@ -31,6 +31,7 @@ import type {
   OperatorSessionSnapshot,
   PendingConfirmation,
 } from './types'
+import { isRecord, asString, asNumber, asBoolean, extractArray } from './components/common/normalize'
 
 export const missionSnapshot = signal<DashboardMissionResponse | null>(null)
 export const missionLoading = signal(false)
@@ -57,32 +58,6 @@ function scheduleMissionBriefingPoll(delayMs = 1500): void {
     missionBriefingPollTimer = null
     void refreshMissionBriefing(false)
   }, delayMs)
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null && !Array.isArray(value)
-}
-
-function asString(value: unknown): string | undefined {
-  return typeof value === 'string' && value.trim() !== '' ? value : undefined
-}
-
-function asNumber(value: unknown): number | undefined {
-  return typeof value === 'number' && Number.isFinite(value) ? value : undefined
-}
-
-function asBoolean(value: unknown): boolean | undefined {
-  return typeof value === 'boolean' ? value : undefined
-}
-
-function extractArray(value: unknown, keys: string[] = []): unknown[] {
-  if (Array.isArray(value)) return value
-  if (!isRecord(value)) return []
-  for (const key of keys) {
-    const candidate = value[key]
-    if (Array.isArray(candidate)) return candidate
-  }
-  return []
 }
 
 function normalizeAttentionItem(raw: unknown): OperatorAttentionItem | null {


### PR DESCRIPTION
## Summary

`mission-store.ts`의 5개 노멀라이저 함수를 기존 `common/normalize.ts` SSOT import로 교체.

- `isRecord`, `asString`, `asNumber`, `asBoolean`, `extractArray` 로컬 정의 제거
- `asString`의 trim 동작 차이: mission-store(원본 반환) → normalize(trimmed 반환). API payload 특성상 실질 영향 없음
- `proof.ts`, `workflow-context.ts`는 `null` 반환 타입 사용 → null/undefined 통일 후 별도 PR

| 항목 | 값 |
|------|-----|
| 수정 파일 | 1 |
| 제거 | 26줄 |
| 추가 | 1줄 |
| 순 변경 | -25줄 |

## Test plan

- [x] `npx vite build` 성공
- [ ] 상황판 탭에서 mission 데이터 정상 표시 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)