### PR TITLE
fix: catch LLM exception in dm_intent + fix done_delta nickname mismatch

### DIFF
--- a/lib/team_session_engine_helpers.ml
+++ b/lib/team_session_engine_helpers.ml
@@ -445,9 +445,19 @@ let compute_live_done_delta (config : Room.config)
     (session : Team_session_types.session) =
   let backlog = Room.read_backlog config in
   let current_done = Team_session_types.done_counts_from_backlog backlog in
+  (* Include backlog assignee names alongside session agent names.
+     Room.join generates nicknames (e.g. "owner-jolly-llama") stored in
+     session.agent_names, but task assignees use the raw name ("owner").
+     Merging both sets ensures delta counts are not lost to name mismatch. *)
+  let agents =
+    Team_session_types.dedup_strings
+      (session.agent_names
+       @ List.map fst current_done
+       @ List.map fst session.baseline_done_counts)
+  in
   let deltas =
     Team_session_types.done_delta_by_agent ~baseline:session.baseline_done_counts
-      ~current:current_done ~agents:session.agent_names
+      ~current:current_done ~agents
   in
   let done_total = List.fold_left (fun acc (_, n) -> acc + n) 0 deltas in
   (deltas, done_total)

--- a/lib/team_session_engine_policy.ml
+++ b/lib/team_session_engine_policy.ml
@@ -6,9 +6,17 @@ let write_checkpoint (config : Room.config) (session : Team_session_types.sessio
   let participant_agents = match active_agents with [] -> session.agent_names | a -> a in
   let backlog = Room.read_backlog config in
   let current_done = Team_session_types.done_counts_from_backlog backlog in
+  (* Include backlog assignee names to handle nickname vs raw-name mismatches.
+     See compute_live_done_delta for rationale. *)
+  let agents =
+    Team_session_types.dedup_strings
+      (participant_agents
+       @ List.map fst current_done
+       @ List.map fst session.baseline_done_counts)
+  in
   let deltas =
     Team_session_types.done_delta_by_agent ~baseline:session.baseline_done_counts
-      ~current:current_done ~agents:participant_agents
+      ~current:current_done ~agents
   in
   let done_total = List.fold_left (fun acc (_, n) -> acc + n) 0 deltas in
   let elapsed = max 0.0 (now -. session.started_at) in

--- a/lib/trpg_dm_intent.ml
+++ b/lib/trpg_dm_intent.ml
@@ -298,16 +298,21 @@ let llm_response_is_valid (resp : Llm_client.completion_response) : bool =
   | Ok intent -> not (equal_intent_category intent.primary Unknown)
   | Error _ -> false
 
-(** LLM-based intent extraction. Returns Error on failure. *)
+(** LLM-based intent extraction. Returns Error on failure.
+    Catches exceptions (e.g. Llm_eio_env not initialized in test)
+    so callers can fall back to keyword extraction. *)
 let extract_with_llm (text : string) : (dm_intent, string) result =
   let prompt = build_classification_prompt text in
-  match
-    Lodge_cascade.call ~cascade_name:"trpg_intent" ~prompt
-      ~temperature:0.1 ~timeout_sec:15 ~max_tokens:200
-      ~accept:llm_response_is_valid ()
-  with
-  | Ok r -> parse_llm_intent r.response
-  | Error err -> Error err
+  try
+    match
+      Lodge_cascade.call ~cascade_name:"trpg_intent" ~prompt
+        ~temperature:0.1 ~timeout_sec:15 ~max_tokens:200
+        ~accept:llm_response_is_valid ()
+    with
+    | Ok r -> parse_llm_intent r.response
+    | Error err -> Error err
+  with exn ->
+    Error (Printf.sprintf "extract_with_llm exception: %s" (Printexc.to_string exn))
 
 (* ── Public API ─────────────────────────────────────────────────────── *)
 


### PR DESCRIPTION
## Summary

- **TRPG dm_intent**: `extract_with_llm`이 `Llm_eio_env not initialized` 예외를 `Error`로 변환하지 못해 Hybrid 모드 fallback이 동작하지 않음. `try/catch`로 예외를 Result.Error로 변환하여 keyword fallback 경로가 정상 작동하도록 수정. (21 round_run 테스트 수정)
- **team_session done_delta**: `session.agent_names`에는 Room.join이 생성한 닉네임(`owner-jolly-llama`)이 저장되지만, task assignee는 raw name(`owner`)을 사용. `done_delta_by_agent`가 닉네임으로만 필터링하여 실제 완료 건수를 놓침. backlog assignee 이름을 agent 집합에 포함하여 수정. (test #38 수정)

Closes #1445, closes #1422.

## Changed Files

| File | Change |
|------|--------|
| `lib/trpg_dm_intent.ml` | `extract_with_llm`에 try/catch 추가 |
| `lib/team_session_engine_helpers.ml` | `compute_live_done_delta` agent 집합 확장 |
| `lib/team_session_engine_policy.ml` | `write_checkpoint` 동일 패턴 적용 |

## Test plan

- [x] `dune exec test/test_tool_trpg_coverage.exe` — 50/50 pass (이전 21 fail)
- [x] `dune exec test/test_tool_team_session.exe -- test "team_session" 38` — pass (이전 fail)
- [x] `dune test` — exit 0 (전체 통과)
- [ ] CI green 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)