### PR TITLE
refactor(dashboard): restructure 15 tabs to 7 narrative-first tabs

### DIFF
--- a/dashboard/src/components/activity.ts
+++ b/dashboard/src/components/activity.ts
@@ -1,0 +1,25 @@
+// MASC Dashboard — Activity Tab
+// Absorbs: live + social into one view. Live stream default, social graph collapsible.
+
+import { html } from 'htm/preact'
+import { signal } from '@preact/signals'
+import { Live } from './live'
+import { Social } from './social'
+
+const socialExpanded = signal(false)
+
+export function Activity() {
+  return html`
+    <div class="tab-unified">
+      <${Live} />
+      <details
+        class="tab-collapsible"
+        open=${socialExpanded.value}
+        onToggle=${(e: Event) => { socialExpanded.value = (e.target as HTMLDetailsElement).open }}
+      >
+        <summary class="tab-collapsible__summary">소셜 그래프</summary>
+        <${Social} />
+      </details>
+    </div>
+  `
+}

--- a/dashboard/src/components/agents-unified.ts
+++ b/dashboard/src/components/agents-unified.ts
@@ -1,0 +1,42 @@
+// MASC Dashboard — Unified Agents Tab
+// Absorbs: agent-roster + execution + keeper-roster into one view with chip toggle.
+
+import { html } from 'htm/preact'
+import { signal } from '@preact/signals'
+import { route } from '../router'
+import { AgentRoster } from './agent-roster'
+import { Execution } from './agents'
+
+type AgentsView = 'roster' | 'sessions'
+
+const activeView = signal<AgentsView>('roster')
+
+function chipClass(view: AgentsView): string {
+  return `agents-chip ${activeView.value === view ? 'agents-chip--active' : ''}`
+}
+
+export function AgentsUnified() {
+  // Sync from route params if present
+  const viewParam = route.value.params.view
+  if (viewParam === 'sessions' && activeView.value !== 'sessions') {
+    activeView.value = 'sessions'
+  }
+
+  return html`
+    <div class="agents-unified">
+      <div class="agents-chip-bar">
+        <button class=${chipClass('roster')} onClick=${() => { activeView.value = 'roster' }}>
+          에이전트/키퍼
+        </button>
+        <button class=${chipClass('sessions')} onClick=${() => { activeView.value = 'sessions' }}>
+          세션
+        </button>
+      </div>
+
+      ${activeView.value === 'roster'
+        ? html`<${AgentRoster} />`
+        : html`<${Execution} />`
+      }
+    </div>
+  `
+}

--- a/dashboard/src/components/command/index.ts
+++ b/dashboard/src/components/command/index.ts
@@ -116,7 +116,7 @@ export function Command() {
   }, [])
 
   useEffect(() => {
-    if (route.value.tab !== 'command') return
+    if (route.value.tab !== 'lab') return
     const requestedSurface = route.value.params.surface
     const requestedOperation = route.value.params.operation
     const workflowContext = workflowContextForRoute(route.value)

--- a/dashboard/src/components/control.ts
+++ b/dashboard/src/components/control.ts
@@ -1,0 +1,37 @@
+// MASC Dashboard — Control Tab
+// Absorbs: intervene + tools. Ops (intervene) default, tools as secondary.
+
+import { html } from 'htm/preact'
+import { route, navigate } from '../router'
+import { Ops } from './ops'
+import { Tools } from './tools'
+
+type ControlSection = 'intervene' | 'tools'
+
+export function Control() {
+  const section: ControlSection = route.value.params.section === 'tools' ? 'tools' : 'intervene'
+
+  return html`
+    <div class="tab-unified">
+      <div class="tab-pill-bar">
+        <button
+          class="tab-pill ${section === 'intervene' ? 'tab-pill--active' : ''}"
+          onClick=${() => navigate('control')}
+        >
+          \uAC1C\uC785
+        </button>
+        <button
+          class="tab-pill ${section === 'tools' ? 'tab-pill--active' : ''}"
+          onClick=${() => navigate('control', { section: 'tools' })}
+        >
+          \uB3C4\uAD6C
+        </button>
+      </div>
+
+      ${section === 'tools'
+        ? html`<${Tools} />`
+        : html`<${Ops} />`
+      }
+    </div>
+  `
+}

--- a/dashboard/src/components/dashboard-shell.ts
+++ b/dashboard/src/components/dashboard-shell.ts
@@ -9,11 +9,9 @@ import { Proof } from './proof'
 import { Command } from './command'
 import { Ops } from './ops'
 import { Memory } from './memory'
-import { Execution } from './agents'
 import { Tools } from './tools'
 import { Planning } from './goals'
 import { Governance } from './governance'
-import { Social } from './social'
 import { Lab } from './lab'
 import { Live } from './live'
 import { Overview } from './overview/overview'
@@ -188,34 +186,29 @@ export function TabContent() {
   switch (tab) {
     case 'home':
       return html`<${Overview} />`
-    case 'mission':
+    case 'situation':
       return html`<${Mission} />`
-    case 'proof':
-      return html`<${Proof} />`
-    case 'agent-roster':
+    case 'agents':
       return html`<${AgentRoster} />`
-    case 'keeper-roster':
-      return html`<${AgentRoster} />`
-    case 'execution':
-      return html`<${Execution} />`
-    case 'tools':
-      return html`<${Tools} />`
-    case 'live':
+    case 'activity':
       return html`<${Live} />`
-    case 'memory':
-      return html`<${Memory} />`
-    case 'governance':
-      return html`<${Governance} />`
-    case 'social':
-      return html`<${Social} />`
-    case 'planning':
-      return html`<${Planning} />`
-    case 'intervene':
-      return html`<${Ops} />`
-    case 'command':
-      return html`<${Command} />`
+    case 'work': {
+      const section = route.value.params.section
+      switch (section) {
+        case 'evidence': return html`<${Proof} />`
+        case 'governance': return html`<${Governance} />`
+        case 'planning': return html`<${Planning} />`
+        default: return html`<${Memory} />`
+      }
+    }
+    case 'control':
+      return route.value.params.section === 'tools'
+        ? html`<${Tools} />`
+        : html`<${Ops} />`
     case 'lab':
-      return html`<${Lab} />`
+      return route.value.params.surface === 'trpg'
+        ? html`<${Lab} />`
+        : html`<${Command} />`
     default:
       return html`<${Overview} />`
   }

--- a/dashboard/src/components/dashboard-shell.ts
+++ b/dashboard/src/components/dashboard-shell.ts
@@ -5,17 +5,12 @@ import { connected } from '../sse'
 import { dashboardLoading, serverStatus } from '../store'
 import { missionSnapshot } from '../mission-store'
 import { Mission } from './mission'
-import { Proof } from './proof'
-import { Command } from './command'
-import { Ops } from './ops'
-import { Memory } from './memory'
-import { Tools } from './tools'
-import { Planning } from './goals'
-import { Governance } from './governance'
-import { Lab } from './lab'
-import { Live } from './live'
 import { Overview } from './overview/overview'
 import { AgentsUnified } from './agents-unified'
+import { Activity } from './activity'
+import { Work } from './work'
+import { Control } from './control'
+import { LabUnified } from './lab-unified'
 import { TimeAgo } from './common/time-ago'
 import { PanelSemanticDetails } from './common/semantic-layer'
 import {
@@ -191,24 +186,13 @@ export function TabContent() {
     case 'agents':
       return html`<${AgentsUnified} />`
     case 'activity':
-      return html`<${Live} />`
-    case 'work': {
-      const section = route.value.params.section
-      switch (section) {
-        case 'evidence': return html`<${Proof} />`
-        case 'governance': return html`<${Governance} />`
-        case 'planning': return html`<${Planning} />`
-        default: return html`<${Memory} />`
-      }
-    }
+      return html`<${Activity} />`
+    case 'work':
+      return html`<${Work} />`
     case 'control':
-      return route.value.params.section === 'tools'
-        ? html`<${Tools} />`
-        : html`<${Ops} />`
+      return html`<${Control} />`
     case 'lab':
-      return route.value.params.surface === 'trpg'
-        ? html`<${Lab} />`
-        : html`<${Command} />`
+      return html`<${LabUnified} />`
     default:
       return html`<${Overview} />`
   }

--- a/dashboard/src/components/dashboard-shell.ts
+++ b/dashboard/src/components/dashboard-shell.ts
@@ -15,7 +15,7 @@ import { Governance } from './governance'
 import { Lab } from './lab'
 import { Live } from './live'
 import { Overview } from './overview/overview'
-import { AgentRoster } from './agent-roster'
+import { AgentsUnified } from './agents-unified'
 import { TimeAgo } from './common/time-ago'
 import { PanelSemanticDetails } from './common/semantic-layer'
 import {
@@ -189,7 +189,7 @@ export function TabContent() {
     case 'situation':
       return html`<${Mission} />`
     case 'agents':
-      return html`<${AgentRoster} />`
+      return html`<${AgentsUnified} />`
     case 'activity':
       return html`<${Live} />`
     case 'work': {

--- a/dashboard/src/components/lab-unified.ts
+++ b/dashboard/src/components/lab-unified.ts
@@ -1,0 +1,35 @@
+// MASC Dashboard — Lab Tab
+// Absorbs: command + lab(TRPG). Command plane default, TRPG as subsection.
+
+import { html } from 'htm/preact'
+import { route, navigate } from '../router'
+import { Command } from './command'
+import { Lab } from './lab'
+
+export function LabUnified() {
+  const surface = route.value.params.surface
+
+  return html`
+    <div class="tab-unified">
+      <div class="tab-pill-bar">
+        <button
+          class="tab-pill ${surface !== 'trpg' ? 'tab-pill--active' : ''}"
+          onClick=${() => navigate('lab')}
+        >
+          \uC9C0\uD718
+        </button>
+        <button
+          class="tab-pill ${surface === 'trpg' ? 'tab-pill--active' : ''}"
+          onClick=${() => navigate('lab', { surface: 'trpg' })}
+        >
+          TRPG
+        </button>
+      </div>
+
+      ${surface === 'trpg'
+        ? html`<${Lab} />`
+        : html`<${Command} />`
+      }
+    </div>
+  `
+}

--- a/dashboard/src/components/ops/index.ts
+++ b/dashboard/src/components/ops/index.ts
@@ -46,7 +46,7 @@ import { OpsKeeperColumn } from './ops-keeper-column'
 
 export function Ops() {
   const snapshot = operatorSnapshot.value
-  const workflowContext = route.value.tab === 'intervene' ? workflowContextForRoute(route.value) : null
+  const workflowContext = route.value.tab === 'control' ? workflowContextForRoute(route.value) : null
   const roomDigest = operatorRoomDigest.value
   const room = snapshot?.room ?? {}
   const sessions = snapshot?.sessions ?? []
@@ -69,7 +69,7 @@ export function Ops() {
   }, [])
 
   useEffect(() => {
-    if (route.value.tab !== 'intervene') {
+    if (route.value.tab !== 'control') {
       hydratedWorkflowId.value = null
       return
     }

--- a/dashboard/src/components/overview/keeper-summary-card.ts
+++ b/dashboard/src/components/overview/keeper-summary-card.ts
@@ -36,7 +36,7 @@ export function KeeperSummaryCard({ keeper }: KeeperSummaryCardProps) {
   const tools = (keeper.recent_tool_names ?? []).slice(0, 3)
 
   return html`
-    <div class="keeper-summary-card" onClick=${() => navigate('keepers')}>
+    <div class="keeper-summary-card" onClick=${() => navigate('agents')}>
       <div class="keeper-summary-card__header">
         <span class="keeper-summary-card__name">${keeper.name}</span>
         <span class="keeper-summary-card__meta">

--- a/dashboard/src/components/overview/narrative-timeline.ts
+++ b/dashboard/src/components/overview/narrative-timeline.ts
@@ -3,6 +3,7 @@
 // Groups events by time window and actor, synthesizes Korean descriptions.
 
 import { html } from 'htm/preact'
+import { signal } from '@preact/signals'
 import type { ReadonlySignal } from '@preact/signals'
 import type { JournalEntry } from '../../types'
 
@@ -10,6 +11,8 @@ interface NarrativeTimelineProps {
   entries: ReadonlySignal<JournalEntry[]>
   maxItems?: number
 }
+
+const expandedItems = signal(0)
 
 interface TimeGroup {
   label: string
@@ -100,7 +103,9 @@ function groupByTime(events: NarrativeEvent[]): TimeGroup[] {
 }
 
 export function NarrativeTimeline({ entries, maxItems }: NarrativeTimelineProps) {
-  const limit = maxItems ?? 12
+  const baseLimit = maxItems ?? 8
+  const limit = baseLimit + expandedItems.value
+  const totalAvailable = entries.value.length
   const raw = entries.value.slice(-limit).reverse()
 
   if (raw.length === 0) {
@@ -113,6 +118,7 @@ export function NarrativeTimeline({ entries, maxItems }: NarrativeTimelineProps)
 
   const narratives = raw.map(buildNarrative)
   const groups = groupByTime(narratives)
+  const hasMore = totalAvailable > limit
 
   return html`
     <div class="narrative-timeline">
@@ -132,6 +138,14 @@ export function NarrativeTimeline({ entries, maxItems }: NarrativeTimelineProps)
           </div>
         </div>
       `)}
+      ${hasMore ? html`
+        <button
+          class="narrative-timeline__load-more"
+          onClick=${() => { expandedItems.value += baseLimit }}
+        >
+          더 보기 (${totalAvailable - limit}건 남음)
+        </button>
+      ` : null}
     </div>
   `
 }

--- a/dashboard/src/components/overview/overview.ts
+++ b/dashboard/src/components/overview/overview.ts
@@ -1,147 +1,125 @@
-// MASC Dashboard — Home Overview Surface (Redesigned)
-// 4-Layer information architecture: Situation -> Anomaly -> Entity Grid -> Timeline
+// MASC Dashboard — Home Command Center
+// "What's happening right now?" — answer in 1 second, no scroll.
+// Quiet when healthy, loud when something needs attention.
 
 import { html } from 'htm/preact'
-import { keepers, tasks, shellCounts } from '../../store'
 import { missionSnapshot } from '../../mission-store'
-import { observatoryGroups } from '../../observatory-store'
+import { topActiveAgents } from '../../observatory-store'
 import { journal } from '../../sse'
 import { navigate } from '../../router'
 import { formatDuration } from '../mission-utils'
 import { SituationBanner } from './situation-banner'
 import { AttentionSpotlight } from './attention-spotlight'
-import { AgentObservatory } from './agent-observatory'
-import { SessionTriage } from './session-triage'
 import { NarrativeTimeline } from './narrative-timeline'
-import { QuickStats } from './quick-stats'
-import type { TaskBreakdown, TaskSource } from './quick-stats'
+import { AgentAvatar } from './agent-avatar'
+import type { ObservatoryAgent } from '../../observatory-store'
 
-function pressureClass(ratio: number | null | undefined): string {
-  if (ratio == null) return ''
-  const pct = ratio * 100
-  if (pct < 50) return 'pressure--ok'
-  if (pct < 70) return 'pressure--amber'
-  if (pct < 85) return 'pressure--orange'
-  return 'pressure--red'
-}
+// --- Hot Sessions: top 3 active sessions (critical/watch first) ---
 
-function keeperHealthClass(status?: string): string {
-  const s = (status ?? '').toLowerCase()
-  if (s === 'active' || s === 'running' || s === 'ok') return 'keeper-status--ok'
-  if (s === 'idle' || s === 'listening') return 'keeper-status--idle'
-  if (s === 'offline' || s === 'inactive') return 'keeper-status--offline'
-  return ''
-}
-
-export function Overview() {
+function HotSessions() {
   const snap = missionSnapshot.value
-  const keeperList = keepers.value
-  const taskList = tasks.value
-  const counts = shellCounts.value
-
-  const activeTasks = taskList.filter((t: { status: string }) =>
-    t.status === 'in_progress' || t.status === 'claimed'
-  )
-
-  // Use observatory groups for honest agent counting:
-  // only count agents with fresh signal (working/watching), not stale ones.
-  const obsGroups = observatoryGroups.value
-  const allObsAgents = obsGroups.flatMap(g => g.agents)
-  const freshAgentCount = allObsAgents.filter(a => a.state === 'working' || a.state === 'watching').length
-  const staleAgentCount = allObsAgents.filter(a => a.state === 'quiet' || a.state === 'offline').length
-  const totalAgentCount = allObsAgents.length
-
-  const agentCount = totalAgentCount > 0 ? freshAgentCount : (counts?.agents ?? 0)
-  const taskCount = activeTasks.length > 0 ? activeTasks.length : (counts?.tasks ?? 0)
-  const taskSource: TaskSource = activeTasks.length > 0 ? 'store' : 'cache'
-  const keeperCount = keeperList.length > 0 ? keeperList.length : (counts?.keepers ?? 0)
-
-  const taskBreakdown: TaskBreakdown = {
-    todo: taskList.filter((t: { status: string }) => t.status === 'todo').length,
-    claimed: taskList.filter((t: { status: string }) => t.status === 'claimed').length,
-    inProgress: taskList.filter((t: { status: string }) => t.status === 'in_progress').length,
-    done: taskList.filter((t: { status: string }) => t.status === 'done').length,
-  }
-
-  const roomHealth = snap?.summary?.room_health ?? null
-  const attentionCount = snap?.attention_queue?.length ?? snap?.summary?.pending_approvals ?? 0
   const sessions = snap?.sessions ?? snap?.session_briefs ?? []
-  const keeperBriefs = snap?.keeper_briefs ?? []
+  if (sessions.length === 0) return null
+
+  // Sort: blocker/attention first, then by elapsed time desc
+  const sorted = [...sessions].sort((a, b) => {
+    const aCrit = a.blocker_summary ? 2 : (a.related_attention_count > 0 ? 1 : 0)
+    const bCrit = b.blocker_summary ? 2 : (b.related_attention_count > 0 ? 1 : 0)
+    if (aCrit !== bCrit) return bCrit - aCrit
+    return (b.elapsed_sec ?? 0) - (a.elapsed_sec ?? 0)
+  })
+  const top = sorted.slice(0, 3)
 
   return html`
-    <div class="overview-surface">
-      <${SituationBanner} snap=${snap} roomHealth=${roomHealth} />
-      <${AttentionSpotlight} snap=${snap} />
-
-      <${QuickStats}
-        agentCount=${agentCount}
-        staleAgentCount=${staleAgentCount}
-        totalAgentCount=${totalAgentCount}
-        activeTaskCount=${taskCount}
-        keeperCount=${keeperCount}
-        attentionCount=${attentionCount}
-        taskBreakdown=${taskBreakdown}
-        taskSource=${taskSource}
-      />
-
-      <div class="overview-main-v2">
-        <div class="overview-left-col">
-          <div class="overview-section-header">
-            <span class="overview-section-label">에이전트 Observatory</span>
-            <a class="overview-section-link" onClick=${() => navigate('agent-roster')}>전체 보기</a>
+    <div class="hot-sessions">
+      <div class="home-section-header">
+        <span class="home-section-label">활성 세션</span>
+        <a class="home-section-link" onClick=${() => navigate('situation')}>전체 보기</a>
+      </div>
+      <div class="hot-sessions__grid">
+        ${top.map(s => html`
+          <div
+            class="hot-session-card ${s.blocker_summary ? 'hot-session-card--critical' : ''}"
+            key=${s.session_id}
+            onClick=${() => navigate('situation', { session_id: s.session_id })}
+          >
+            <div class="hot-session-card__goal">${s.goal ?? s.session_id}</div>
+            <div class="hot-session-card__meta">
+              ${s.member_names?.length ? html`
+                <span>${s.member_names.slice(0, 3).join(', ')}${s.member_names.length > 3 ? ` +${s.member_names.length - 3}` : ''}</span>
+              ` : null}
+              ${s.elapsed_sec ? html`<span>${formatDuration(s.elapsed_sec)}</span>` : null}
+            </div>
+            ${s.blocker_summary ? html`
+              <div class="hot-session-card__blocker">${s.blocker_summary}</div>
+            ` : null}
           </div>
-          <${AgentObservatory}
-            onAgentClick=${(name: string) => navigate('execution', { agent: name })}
-          />
-        </div>
-
-        <div class="overview-right-col">
-          <div class="overview-section-label">세션</div>
-          <${SessionTriage} sessions=${sessions} />
-
-          ${keeperBriefs.length > 0 ? html`
-            <div class="overview-section-header" style="margin-top: var(--space-md, 16px)">
-              <span class="overview-section-label">키퍼</span>
-              <a class="overview-section-link" onClick=${() => navigate('agent-roster')}>전체 보기</a>
-            </div>
-            <div class="keeper-cards-v2">
-              ${keeperBriefs.map(k => html`
-                <div class="keeper-card-v2 ${keeperHealthClass(k.status)}" key=${k.name}>
-                  <div class="keeper-card-v2__header">
-                    <span class="keeper-card-v2__name">${k.name}</span>
-                    ${k.generation != null ? html`
-                      <span class="keeper-card-v2__gen">G${k.generation}</span>
-                    ` : null}
-                  </div>
-                  ${k.current_work ? html`
-                    <div class="keeper-card-v2__work">${k.current_work}</div>
-                  ` : null}
-                  ${k.context_ratio != null ? html`
-                    <div class="keeper-card-v2__pressure">
-                      <div
-                        class="keeper-card-v2__pressure-bar ${pressureClass(k.context_ratio)}"
-                        style=${{ width: `${Math.round(k.context_ratio * 100)}%` }}
-                      />
-                      <span class="keeper-card-v2__pressure-label">
-                        ctx ${Math.round(k.context_ratio * 100)}%
-                      </span>
-                    </div>
-                  ` : null}
-                  ${k.last_turn_ago_s != null ? html`
-                    <span class="keeper-card-v2__activity">
-                      ${formatDuration(k.last_turn_ago_s)} 전
-                    </span>
-                  ` : null}
-                </div>
-              `)}
-            </div>
-          ` : null}
-
-          <div class="overview-section-label" style="margin-top: var(--space-md, 16px)">최근 활동</div>
-          <${NarrativeTimeline} entries=${journal} maxItems=${12} />
-        </div>
+        `)}
       </div>
     </div>
   `
 }
 
+// --- Agent Pulse: top 8 active agents ---
+
+function stateIcon(state: string): string {
+  if (state === 'working') return '\u26A1'
+  if (state === 'watching') return '\uD83D\uDC41\uFE0F'
+  if (state === 'quiet') return '\uD83D\uDCA4'
+  return '\u26AB'
+}
+
+function AgentPulse() {
+  const agents = topActiveAgents.value
+  if (agents.length === 0) return null
+
+  return html`
+    <div class="agent-pulse">
+      <div class="home-section-header">
+        <span class="home-section-label">에이전트</span>
+        <a class="home-section-link" onClick=${() => navigate('agents')}>전체 보기</a>
+      </div>
+      <div class="agent-pulse__grid">
+        ${agents.map((a: ObservatoryAgent) => html`
+          <div
+            class="agent-pulse-card agent-pulse-card--${a.state}"
+            key=${a.name}
+            onClick=${() => navigate('agents', { agent: a.name })}
+          >
+            <${AgentAvatar} name=${a.name} emoji=${a.emoji} size=${28} />
+            <div class="agent-pulse-card__info">
+              <span class="agent-pulse-card__name">${a.koreanName ?? a.name}</span>
+              <span class="agent-pulse-card__status">
+                ${stateIcon(a.state)} ${a.focus ?? a.currentTask ?? a.status}
+              </span>
+            </div>
+          </div>
+        `)}
+      </div>
+    </div>
+  `
+}
+
+// --- Overview (Home) ---
+
+export function Overview() {
+  const snap = missionSnapshot.value
+  const roomHealth = snap?.summary?.room_health ?? null
+
+  return html`
+    <div class="overview-surface overview-surface--home">
+      <${SituationBanner} snap=${snap} roomHealth=${roomHealth} />
+      <${AttentionSpotlight} snap=${snap} />
+
+      <div class="home-body">
+        <${HotSessions} />
+        <${AgentPulse} />
+
+        <div class="home-section-header">
+          <span class="home-section-label">최근 활동</span>
+        </div>
+        <${NarrativeTimeline} entries=${journal} maxItems=${8} />
+      </div>
+    </div>
+  `
+}

--- a/dashboard/src/components/tools.ts
+++ b/dashboard/src/components/tools.ts
@@ -157,7 +157,7 @@ export function Tools() {
   }, [])
 
   useEffect(() => {
-    if (route.value.tab !== 'tools') return
+    if (route.value.tab !== 'control') return
     const q = route.value.params.q?.trim()
     if (q && q !== searchQuery.value) {
       searchQuery.value = q

--- a/dashboard/src/components/work.ts
+++ b/dashboard/src/components/work.ts
@@ -1,0 +1,50 @@
+// MASC Dashboard — Work Tab
+// Absorbs: memory(board) + governance + proof + planning into pill-switched sections.
+
+import { html } from 'htm/preact'
+import { route, navigate } from '../router'
+import { Memory } from './memory'
+import { Governance } from './governance'
+import { Proof } from './proof'
+import { Planning } from './goals'
+
+type WorkSection = 'board' | 'governance' | 'evidence' | 'planning'
+
+const SECTIONS: { id: WorkSection; label: string }[] = [
+  { id: 'board', label: '\uAC8C\uC2DC\uD310' },
+  { id: 'governance', label: '\uAC70\uBC84\uB10C\uC2A4' },
+  { id: 'evidence', label: '\uADFC\uAC70' },
+  { id: 'planning', label: '\uACC4\uD68D' },
+]
+
+function isWorkSection(v: string | undefined): v is WorkSection {
+  return v === 'board' || v === 'governance' || v === 'evidence' || v === 'planning'
+}
+
+export function Work() {
+  const current: WorkSection = isWorkSection(route.value.params.section)
+    ? route.value.params.section
+    : 'board'
+
+  return html`
+    <div class="tab-unified">
+      <div class="tab-pill-bar">
+        ${SECTIONS.map(s => html`
+          <button
+            key=${s.id}
+            class="tab-pill ${current === s.id ? 'tab-pill--active' : ''}"
+            onClick=${() => navigate('work', { section: s.id })}
+          >
+            ${s.label}
+          </button>
+        `)}
+      </div>
+
+      ${current === 'board' ? html`<${Memory} />`
+        : current === 'governance' ? html`<${Governance} />`
+        : current === 'evidence' ? html`<${Proof} />`
+        : html`<${Planning} />`
+      }
+    </div>
+  `
+}

--- a/dashboard/src/config/navigation.ts
+++ b/dashboard/src/config/navigation.ts
@@ -1,8 +1,8 @@
 import type { TabId } from '../types'
 
-// --- Surface grouping: 12 tabs -> 5 surfaces ---
+// --- Surface grouping: 7 tabs -> 5 surfaces ---
 
-export type SurfaceId = 'home' | 'agents' | 'work' | 'control' | 'lab'
+export type SurfaceId = 'home' | 'observe' | 'work' | 'control' | 'lab'
 
 export interface DashboardNavGroup {
   id: SurfaceId
@@ -25,145 +25,96 @@ export interface DashboardNavItem {
 export const DASHBOARD_SURFACES: DashboardNavGroup[] = [
   {
     id: 'home',
-    label: '홈',
+    label: '\uD64D',
     icon: '\uD83C\uDFE0',
-    description: '에이전트 생태계 전체를 한눈에',
+    description: '\uC5D0\uC774\uC804\uD2B8 \uC0DD\uD0DC\uACC4 \uC804\uCCB4\uB97C \uD55C\uB208\uC5D0',
     defaultTab: 'home',
     tabs: ['home'],
   },
   {
-    id: 'agents',
-    label: '에이전트',
-    icon: '\uD83E\uDD16',
-    description: '에이전트, 키퍼, 세션, 관계',
-    defaultTab: 'agent-roster',
-    tabs: ['agent-roster', 'mission', 'execution', 'live', 'social'],
+    id: 'observe',
+    label: '\uAD00\uCC30',
+    icon: '\uD83D\uDD2D',
+    description: '\uC5D0\uC774\uC804\uD2B8, \uC0C1\uD669, \uD65C\uB3D9 \uD750\uB984',
+    defaultTab: 'situation',
+    tabs: ['situation', 'agents', 'activity'],
   },
   {
     id: 'work',
-    label: '작업',
+    label: '\uC791\uC5C5',
     icon: '\uD83D\uDCCB',
-    description: '태스크, 근거, 거버넌스, 메모리',
-    defaultTab: 'proof',
-    tabs: ['proof', 'memory', 'governance'],
+    description: '\uAC8C\uC2DC\uD310, \uAC70\uBC84\uB10C\uC2A4, \uADFC\uAC70, \uACC4\uD68D',
+    defaultTab: 'work',
+    tabs: ['work'],
   },
   {
     id: 'control',
-    label: '운영',
+    label: '\uC6B4\uC601',
     icon: '\uD83C\uDFAE',
-    description: '목표, 도구, 개입',
-    defaultTab: 'planning',
-    tabs: ['planning', 'tools', 'intervene'],
+    description: '\uAC1C\uC785, \uB3C4\uAD6C \uD604\uD669',
+    defaultTab: 'control',
+    tabs: ['control'],
   },
   {
     id: 'lab',
-    label: '실험',
-    icon: '\u2694\uFE0F',
-    description: '지휘, TRPG, 실험',
-    defaultTab: 'command',
-    tabs: ['command', 'lab'],
+    label: '\uC2E4\uD5D8',
+    icon: '\u2697\uFE0F',
+    description: '\uC9C0\uD718, TRPG, \uC2E4\uD5D8',
+    defaultTab: 'lab',
+    tabs: ['lab'],
   },
 ]
 
-// Full nav item list (all 13 tabs including 'home')
+// Full nav item list (all 7 tabs)
 export const DASHBOARD_NAV_ITEMS: DashboardNavItem[] = [
   {
     id: 'home',
-    label: '홈',
+    label: '\uD64D',
     icon: '\uD83C\uDFE0',
     group: 'home',
-    description: '에이전트 생태계 전체를 한눈에 보는 개요',
+    description: '\uC5D0\uC774\uC804\uD2B8 \uC0DD\uD0DC\uACC4 \uC804\uCCB4\uB97C \uD55C\uB208\uC5D0 \uBCF4\uB294 \uAC1C\uC694',
   },
   {
-    id: 'agent-roster',
-    label: '에이전트 목록',
-    icon: '\uD83D\uDC65',
-    group: 'agents',
-    description: '전체 에이전트를 스크롤하며 탐색하는 목록 화면',
-  },
-  {
-    id: 'mission',
-    label: '상황판',
+    id: 'situation',
+    label: '\uC0C1\uD669\uD310',
     icon: '\uD83C\uDFE0',
-    group: 'agents',
-    description: '방 중심으로 지금 상황과 흐름을 가장 먼저 읽는 기본 화면',
+    group: 'observe',
+    description: '\uBC29 \uC911\uC2EC\uC73C\uB85C \uC9C0\uAE08 \uC0C1\uD669\uACFC \uD750\uB984\uC744 \uAC00\uC7A5 \uBA3C\uC800 \uC77D\uB294 \uAE30\uBCF8 \uD654\uBA74',
   },
   {
-    id: 'execution',
-    label: '실행',
-    icon: '\uD83E\uDD16',
-    group: 'agents',
-    description: '에이전트, 키퍼, 세션을 중심으로 참여자를 파악하는 화면',
+    id: 'agents',
+    label: '\uC5D0\uC774\uC804\uD2B8',
+    icon: '\uD83D\uDC65',
+    group: 'observe',
+    description: '\uC5D0\uC774\uC804\uD2B8, \uD0A4\uD37C, \uC138\uC158\uC744 \uD55C\uACF3\uC5D0\uC11C \uD0D0\uC0C9',
   },
   {
-    id: 'live',
-    label: '라이브',
+    id: 'activity',
+    label: '\uD65C\uB3D9',
     icon: '\uD83D\uDCE1',
-    group: 'agents',
-    description: '실시간 에이전트 활동과 이벤트 흐름을 관찰하는 화면',
+    group: 'observe',
+    description: '\uC2E4\uC2DC\uAC04 \uC774\uBCA4\uD2B8 \uD750\uB984\uACFC \uC18C\uC15C \uADF8\uB798\uD504',
   },
   {
-    id: 'social',
-    label: '소셜',
-    icon: '\uD83D\uDD17',
-    group: 'agents',
-    description: '에이전트 관계 그래프와 활동 흐름을 보는 관계 분석 화면',
-  },
-  {
-    id: 'proof',
-    label: '근거',
-    icon: '\uD83D\uDD0D',
+    id: 'work',
+    label: '\uC791\uC5C5',
+    icon: '\uD83D\uDCCB',
     group: 'work',
-    description: '협업, 대화, 실행의 증거 경로를 확인하는 화면',
+    description: '\uAC8C\uC2DC\uD310, \uAC70\uBC84\uB10C\uC2A4, \uADFC\uAC70, \uACC4\uD68D\uC744 \uC11C\uBE0C\uC139\uC158\uC73C\uB85C \uD0D0\uC0C9',
   },
   {
-    id: 'memory',
-    label: '메모리',
-    icon: '\uD83D\uDCAC',
-    group: 'work',
-    description: '게시글, 댓글, 비동기 기억으로 방의 누적 맥락을 읽는 화면',
-  },
-  {
-    id: 'governance',
-    label: '거버넌스',
-    icon: '\u2696\uFE0F',
-    group: 'work',
-    description: '토론, 표결, 판단 구조를 규범과 결정의 관점에서 읽는 화면',
-  },
-  {
-    id: 'planning',
-    label: '계획',
-    icon: '\uD83C\uDFAF',
-    group: 'control',
-    description: '목표, 백로그, 우선순위를 운영 관점으로 읽는 계획 화면',
-  },
-  {
-    id: 'tools',
-    label: '도구',
-    icon: '\uD83E\uDDF0',
-    group: 'control',
-    description: '시스템 전체 도구 목록과 사용 현황을 확인하는 운영 화면',
-  },
-  {
-    id: 'intervene',
-    label: '개입',
+    id: 'control',
+    label: '\uC6B4\uC601',
     icon: '\uD83C\uDFAE',
     group: 'control',
-    description: '룸, 세션, 키퍼에 직접 개입하는 운영 화면',
-  },
-  {
-    id: 'command',
-    label: '지휘',
-    icon: '\uD83E\uDDED',
-    group: 'lab',
-    description: 'command-plane, swarm, resolution 같은 고급 지휘/실험 화면',
+    description: '\uB8F8/\uC138\uC158/\uD0A4\uD37C\uC5D0 \uC9C1\uC811 \uAC1C\uC785\uD558\uACE0 \uB3C4\uAD6C \uD604\uD669\uC744 \uD655\uC778',
   },
   {
     id: 'lab',
-    label: '실험',
-    icon: '\u2694\uFE0F',
+    label: '\uC2E4\uD5D8',
+    icon: '\u2697\uFE0F',
     group: 'lab',
-    description: 'TRPG 같은 실험 기능을 메인 대시보드 밖에서 다룹니다',
+    description: '\uC9C0\uD718\uBA74, TRPG \uB4F1 \uC2E4\uD5D8 \uAE30\uB2A5',
   },
 ]
 
@@ -178,10 +129,10 @@ export interface DashboardNavSection {
 
 // Kept for backward compat — unused in the new nav but referenced by semantic-layer
 export const DASHBOARD_NAV_SECTIONS: DashboardNavSection[] = [
-  { id: 'now', label: '지금', description: '현재 상태' },
-  { id: 'why', label: '이유', description: '근거와 맥락' },
-  { id: 'act', label: '개입', description: '운영 액션' },
-  { id: 'lab', label: '실험', description: '실험 화면' },
+  { id: 'now', label: '\uC9C0\uAE08', description: '\uD604\uC7AC \uC0C1\uD0DC' },
+  { id: 'why', label: '\uC774\uC720', description: '\uADFC\uAC70\uC640 \uB9E5\uB77D' },
+  { id: 'act', label: '\uAC1C\uC785', description: '\uC6B4\uC601 \uC561\uC158' },
+  { id: 'lab', label: '\uC2E4\uD5D8', description: '\uC2E4\uD5D8 \uD654\uBA74' },
 ]
 
 // Surface lookup by tab id

--- a/dashboard/src/observatory-store.ts
+++ b/dashboard/src/observatory-store.ts
@@ -213,3 +213,11 @@ export const observatoryGroups: ReadonlySignal<ObservatoryGroup[]> = computed(()
 
   return groups
 })
+
+/** Top active agents (working/watching first), capped at `limit`. Used by Home AgentPulse. */
+export const topActiveAgents: ReadonlySignal<ObservatoryAgent[]> = computed(() => {
+  const allAgents = observatoryGroups.value.flatMap(g => g.agents)
+  return allAgents
+    .sort((a, b) => STATE_ORDER[a.state] - STATE_ORDER[b.state] || a.name.localeCompare(b.name))
+    .slice(0, 8)
+})

--- a/dashboard/src/router.ts
+++ b/dashboard/src/router.ts
@@ -1,15 +1,24 @@
 // MASC Dashboard — Hash-based router
-// Reads location.hash for canonical dashboard routes only.
-// Legacy aliases were intentionally removed during the operator-console rewrite.
+// Reads location.hash for canonical dashboard routes.
+// Legacy tab IDs (pre-restructure) are transparently redirected to new 7-tab structure.
 
 import { signal, type ReadonlySignal } from '@preact/signals'
-import type { RouteState, TabId } from './types'
-import { VALID_TABS } from './types'
+import type { RouteState, TabId, AnyTabId, LegacyTabId } from './types'
+import { VALID_TABS, LEGACY_TAB_REDIRECTS } from './types'
 
 const DEFAULT_ROUTE: RouteState = { tab: 'home', params: {}, postId: null }
 
 function isTabId(v: string | null | undefined): v is TabId {
   return !!v && VALID_TABS.includes(v as TabId)
+}
+
+/** Resolve a raw string to a new TabId, applying legacy redirects if needed. */
+function resolveTab(raw: string | null | undefined): { tab: TabId; params?: Record<string, string> } | null {
+  if (!raw) return null
+  if (isTabId(raw)) return { tab: raw }
+  const redirect = LEGACY_TAB_REDIRECTS[raw as LegacyTabId]
+  if (redirect) return { tab: redirect.tab, params: redirect.params }
+  return null
 }
 
 function decodeSafe(input: string): string {
@@ -42,14 +51,16 @@ function parseSegments(
   segments: string[],
   params: Record<string, string>,
 ): RouteState {
+  // Deep-link: /chains/operation/:id -> lab tab
   if (segments[0] === 'chains') {
     const nextParams: Record<string, string> = { ...params, surface: 'chains' }
     if (segments[1] === 'operation' && segments[2]) {
       nextParams.operation = decodeSafe(segments[2])
     }
-    return { tab: 'command', params: nextParams, postId: null }
+    return { tab: 'lab', params: nextParams, postId: null }
   }
 
+  // Deep-link: /lab/:surface -> lab tab
   if (segments[0] === 'lab') {
     const nextParams = { ...params }
     if (segments[1]) {
@@ -60,13 +71,12 @@ function parseSegments(
 
   const tabFromPath = segments[0]
   const tabFromQuery = params.tab
-  const tab: TabId = isTabId(tabFromPath)
-    ? tabFromPath
-    : isTabId(tabFromQuery)
-      ? tabFromQuery
-      : 'home'
 
-  return { tab, params, postId: null }
+  // Resolve with legacy redirect support
+  const resolved = resolveTab(tabFromPath) || resolveTab(tabFromQuery) || { tab: 'home' as TabId }
+  const mergedParams = { ...params, ...(resolved.params ?? {}) }
+
+  return { tab: resolved.tab, params: mergedParams, postId: null }
 }
 
 function parseHash(hash: string): RouteState {
@@ -128,20 +138,35 @@ function toHash(r: RouteState): string {
 
 export const route = signal<RouteState>(parseHash(window.location.hash))
 
-// Listen for hash changes
+// Listen for hash changes — silently replace legacy hashes with canonical form
 window.addEventListener('hashchange', () => {
-  route.value = parseHash(window.location.hash)
+  const parsed = parseHash(window.location.hash)
+  route.value = parsed
+  const canonical = toHash(parsed)
+  if (window.location.hash !== canonical) {
+    window.history.replaceState(
+      null,
+      '',
+      `${window.location.pathname}${window.location.search}${canonical}`,
+    )
+  }
 })
 
 // --- Navigation helpers ---
 
-export function navigate(tab: TabId, params?: Record<string, string>): void {
-  const next = { tab, params: params ?? {}, postId: null } satisfies RouteState
+/** Navigate to a tab. Accepts both new and legacy tab IDs (legacy are silently redirected). */
+export function navigate(tab: AnyTabId, params?: Record<string, string>): void {
+  const redirect = LEGACY_TAB_REDIRECTS[tab as LegacyTabId]
+  const resolvedTab: TabId = redirect ? redirect.tab : tab as TabId
+  const resolvedParams = redirect?.params
+    ? { ...redirect.params, ...(params ?? {}) }
+    : params ?? {}
+  const next = { tab: resolvedTab, params: resolvedParams, postId: null } satisfies RouteState
   window.location.hash = toHash(next)
 }
 
 export function navigateToPost(postId: string): void {
-  window.location.hash = `#memory?post=${encodeURIComponent(postId)}`
+  window.location.hash = `#work?section=board&post=${encodeURIComponent(postId)}`
 }
 
 export function navigateBack(): void {
@@ -159,6 +184,15 @@ export function initRouter(): void {
   // Priority 1: explicit hash route
   if (window.location.hash && window.location.hash !== '#') {
     route.value = parseHash(window.location.hash)
+    // Replace legacy hash with canonical form
+    const canonical = toHash(route.value)
+    if (window.location.hash !== canonical) {
+      window.history.replaceState(
+        null,
+        '',
+        `${window.location.pathname}${window.location.search}${canonical}`,
+      )
+    }
     return
   }
 

--- a/dashboard/src/styles/agent.css
+++ b/dashboard/src/styles/agent.css
@@ -202,3 +202,34 @@
   min-width: 0;
 }
 
+/* ── Agents Unified Tab (chip toggle) ────────── */
+.agents-unified {
+  display: grid;
+  gap: var(--space-md, 16px);
+}
+
+.agents-chip-bar {
+  display: flex;
+  gap: 6px;
+}
+
+.agents-chip {
+  padding: 4px 14px;
+  border-radius: 16px;
+  border: 1px solid var(--border, rgba(255, 255, 255, 0.1));
+  background: none;
+  color: var(--text-muted);
+  font-size: 12px;
+  cursor: pointer;
+  transition: all 0.15s;
+}
+.agents-chip:hover {
+  border-color: var(--accent, #60a5fa);
+  color: var(--text-primary, #e2e8f0);
+}
+.agents-chip--active {
+  background: var(--accent, #60a5fa);
+  border-color: var(--accent, #60a5fa);
+  color: #fff;
+}
+

--- a/dashboard/src/styles/dashboard.css
+++ b/dashboard/src/styles/dashboard.css
@@ -964,3 +964,51 @@
   opacity: 0.85;
 }
 
+/* ── Shared: tab-unified, pill bar, collapsible ── */
+.tab-unified {
+  display: grid;
+  gap: var(--space-md, 16px);
+}
+
+.tab-pill-bar {
+  display: flex;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+
+.tab-pill {
+  padding: 4px 14px;
+  border-radius: 16px;
+  border: 1px solid var(--border, rgba(255, 255, 255, 0.1));
+  background: none;
+  color: var(--text-muted);
+  font-size: 12px;
+  cursor: pointer;
+  transition: all 0.15s;
+}
+.tab-pill:hover {
+  border-color: var(--accent, #60a5fa);
+  color: var(--text-primary, #e2e8f0);
+}
+.tab-pill--active {
+  background: var(--accent, #60a5fa);
+  border-color: var(--accent, #60a5fa);
+  color: #fff;
+}
+
+.tab-collapsible {
+  border: 1px solid var(--border, rgba(255, 255, 255, 0.06));
+  border-radius: 8px;
+}
+.tab-collapsible__summary {
+  padding: 8px 12px;
+  cursor: pointer;
+  color: var(--text-muted);
+  font-size: 12px;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+.tab-collapsible__summary:hover {
+  color: var(--text-primary, #e2e8f0);
+}
+

--- a/dashboard/src/styles/overview.css
+++ b/dashboard/src/styles/overview.css
@@ -1193,3 +1193,156 @@
 .obs-summary__stale {
   color: rgba(251, 191, 36, 0.6);
 }
+
+/* ── Phase 1: Home Command Center ───────────── */
+
+.overview-surface--home {
+  display: grid;
+  gap: var(--space-md, 16px);
+}
+
+.home-body {
+  display: grid;
+  gap: var(--space-md, 16px);
+}
+
+.home-section-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: var(--space-xs, 4px);
+}
+
+.home-section-label {
+  color: var(--text-muted);
+  font-size: 11px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.home-section-link {
+  font-size: 11px;
+  color: var(--accent, #60a5fa);
+  cursor: pointer;
+  text-decoration: none;
+}
+.home-section-link:hover { text-decoration: underline; }
+
+/* Hot Sessions */
+.hot-sessions__grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+  gap: var(--space-sm, 8px);
+}
+
+.hot-session-card {
+  background: var(--card-bg, rgba(255, 255, 255, 0.03));
+  border: 1px solid var(--border, rgba(255, 255, 255, 0.08));
+  border-radius: 8px;
+  padding: 10px 12px;
+  cursor: pointer;
+  transition: border-color 0.15s;
+}
+.hot-session-card:hover {
+  border-color: var(--accent, #60a5fa);
+}
+.hot-session-card--critical {
+  border-color: var(--danger, #ef4444);
+  background: rgba(239, 68, 68, 0.06);
+}
+.hot-session-card__goal {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text-primary, #e2e8f0);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.hot-session-card__meta {
+  display: flex;
+  gap: 8px;
+  font-size: 11px;
+  color: var(--text-muted);
+  margin-top: 4px;
+}
+.hot-session-card__blocker {
+  font-size: 11px;
+  color: var(--danger, #ef4444);
+  margin-top: 4px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* Agent Pulse */
+.agent-pulse__grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+  gap: var(--space-xs, 4px);
+}
+
+.agent-pulse-card {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 10px;
+  border-radius: 6px;
+  cursor: pointer;
+  transition: background 0.15s;
+}
+.agent-pulse-card:hover {
+  background: rgba(255, 255, 255, 0.04);
+}
+.agent-pulse-card--working {
+  border-left: 2px solid var(--success, #22c55e);
+}
+.agent-pulse-card--watching {
+  border-left: 2px solid var(--accent, #60a5fa);
+}
+.agent-pulse-card--quiet {
+  border-left: 2px solid var(--text-muted, #64748b);
+  opacity: 0.7;
+}
+.agent-pulse-card--offline {
+  border-left: 2px solid var(--text-muted, #64748b);
+  opacity: 0.4;
+}
+.agent-pulse-card__info {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+}
+.agent-pulse-card__name {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--text-primary, #e2e8f0);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.agent-pulse-card__status {
+  font-size: 11px;
+  color: var(--text-muted);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* Narrative Timeline load more */
+.narrative-timeline__load-more {
+  display: block;
+  width: 100%;
+  padding: 8px;
+  margin-top: 4px;
+  background: none;
+  border: 1px dashed var(--border, rgba(255, 255, 255, 0.1));
+  border-radius: 6px;
+  color: var(--text-muted);
+  font-size: 11px;
+  cursor: pointer;
+  text-align: center;
+}
+.narrative-timeline__load-more:hover {
+  border-color: var(--accent, #60a5fa);
+  color: var(--accent, #60a5fa);
+}

--- a/dashboard/src/tab-refresh.ts
+++ b/dashboard/src/tab-refresh.ts
@@ -31,6 +31,7 @@ export function refreshForTab(tab: string) {
   if (tab === 'agents') {
     refreshRoomTruth()
     refreshExecution()
+    refreshMissionSnapshot()
   }
 
   if (tab === 'activity') {

--- a/dashboard/src/tab-refresh.ts
+++ b/dashboard/src/tab-refresh.ts
@@ -22,51 +22,67 @@ export function refreshForTab(tab: string) {
     refreshMissionSnapshot()
   }
 
-  if (tab === 'command') {
-    refreshRoomTruth()
-    refreshCommandPlaneCurrentSurface()
-    refreshCommandPlaneChainSummary()
-    if (
-      commandPlaneSurface.value === 'swarm'
-      || commandPlaneSurface.value === 'warroom'
-      || commandPlaneSurface.value === 'orchestra'
-    ) {
-      refreshCommandPlaneSwarm()
-    }
-    if (commandPlaneSurface.value === 'orchestra') {
-      refreshCommandPlaneOrchestra()
-    }
-    if (commandPlaneSurface.value === 'warroom') {
-      refreshOperatorSnapshot()
-    }
-  }
-
-  if (tab === 'mission') {
+  if (tab === 'situation') {
     refreshRoomTruth()
     refreshMissionSnapshot()
     refreshMissionBriefing()
   }
 
-  if (tab === 'proof') {
-    refreshProofSnapshot(route.value.params.session_id, route.value.params.operation_id)
-  }
-
-  if (tab === 'execution') {
+  if (tab === 'agents') {
     refreshRoomTruth()
     refreshExecution()
   }
 
-  if (tab === 'intervene') {
-    refreshRoomTruth()
-    refreshOperatorSnapshot()
-    refreshOperatorRoomDigest()
+  if (tab === 'activity') {
+    refreshExecution()
+    refreshSocial()
   }
 
-  if (tab === 'memory') refreshBoard()
-  if (tab === 'planning') refreshGoals()
-  if (tab === 'lab') refreshTrpg()
-  if (tab === 'governance') refreshGovernance()
-  if (tab === 'live') refreshExecution()
-  if (tab === 'tools') refreshTools()
-  if (tab === 'social') refreshSocial()
+  if (tab === 'work') {
+    const section = route.value.params.section
+    if (section === 'evidence') {
+      refreshProofSnapshot(route.value.params.session_id, route.value.params.operation_id)
+    } else if (section === 'governance') {
+      refreshGovernance()
+    } else if (section === 'planning') {
+      refreshGoals()
+    } else {
+      refreshBoard()
+    }
+  }
+
+  if (tab === 'control') {
+    const section = route.value.params.section
+    if (section === 'tools') {
+      refreshTools()
+    } else {
+      refreshRoomTruth()
+      refreshOperatorSnapshot()
+      refreshOperatorRoomDigest()
+    }
+  }
+
+  if (tab === 'lab') {
+    const surface = route.value.params.surface
+    if (surface === 'trpg') {
+      refreshTrpg()
+    } else {
+      refreshRoomTruth()
+      refreshCommandPlaneCurrentSurface()
+      refreshCommandPlaneChainSummary()
+      if (
+        commandPlaneSurface.value === 'swarm'
+        || commandPlaneSurface.value === 'warroom'
+        || commandPlaneSurface.value === 'orchestra'
+      ) {
+        refreshCommandPlaneSwarm()
+      }
+      if (commandPlaneSurface.value === 'orchestra') {
+        refreshCommandPlaneOrchestra()
+      }
+      if (commandPlaneSurface.value === 'warroom') {
+        refreshOperatorSnapshot()
+      }
+    }
+  }
 }

--- a/dashboard/src/types/sse.ts
+++ b/dashboard/src/types/sse.ts
@@ -146,6 +146,15 @@ export interface DashboardSemanticsResponse {
 
 export type TabId =
   | 'home'
+  | 'situation'
+  | 'agents'
+  | 'activity'
+  | 'work'
+  | 'control'
+  | 'lab'
+
+/** Pre-restructure tab IDs kept for redirect aliases. */
+export type LegacyTabId =
   | 'mission'
   | 'proof'
   | 'execution'
@@ -156,28 +165,39 @@ export type TabId =
   | 'planning'
   | 'intervene'
   | 'command'
-  | 'lab'
   | 'social'
   | 'agent-roster'
   | 'keeper-roster'
 
+/** Accepts both new and legacy tab IDs (for navigate() backward compat). */
+export type AnyTabId = TabId | LegacyTabId
+
 export const VALID_TABS: TabId[] = [
   'home',
-  'mission',
-  'proof',
-  'execution',
-  'tools',
-  'live',
-  'memory',
-  'governance',
-  'planning',
-  'intervene',
-  'command',
+  'situation',
+  'agents',
+  'activity',
+  'work',
+  'control',
   'lab',
-  'social',
-  'agent-roster',
-  'keeper-roster',
 ]
+
+/** Maps legacy tab IDs to new tab + optional section params. */
+export const LEGACY_TAB_REDIRECTS: Record<LegacyTabId, { tab: TabId; params?: Record<string, string> }> = {
+  'mission': { tab: 'situation' },
+  'agent-roster': { tab: 'agents' },
+  'execution': { tab: 'agents' },
+  'keeper-roster': { tab: 'agents' },
+  'live': { tab: 'activity' },
+  'social': { tab: 'activity' },
+  'proof': { tab: 'work', params: { section: 'evidence' } },
+  'memory': { tab: 'work', params: { section: 'board' } },
+  'governance': { tab: 'work', params: { section: 'governance' } },
+  'planning': { tab: 'work', params: { section: 'planning' } },
+  'tools': { tab: 'control', params: { section: 'tools' } },
+  'intervene': { tab: 'control' },
+  'command': { tab: 'lab' },
+}
 
 // --- Social Graph types ---
 

--- a/dashboard/src/workflow-context.ts
+++ b/dashboard/src/workflow-context.ts
@@ -426,7 +426,7 @@ export function workflowCommandSurfaceLabel(surface?: string | null): string {
 }
 
 export function clearWorkflowContextForTab(tab: TabId): void {
-  if (tab === 'mission') {
+  if (tab === 'situation') {
     persistWorkflowContext(null)
   }
 }


### PR DESCRIPTION
## Summary

MASC 대시보드를 API 토폴로지 기반 15탭에서 운영자 멘탈 모델 기반 7탭으로 재구조화.

- **Phase 0**: TabId 15→7 축소 + legacy hash redirect alias (기존 URL 보존)
- **Phase 1**: Home을 command center로 재설계 (HotSessions, AgentPulse, NarrativeTimeline)
- **Phase 2**: agent-roster + execution → AgentsUnified (chip toggle)
- **Phase 3-6**: Activity(live+social), Work(board/governance/evidence/planning), Control(intervene/tools), Lab(command+TRPG) 통합

### New 7 tabs

| Tab | Absorbed | 근거 |
|-----|----------|------|
| Home | home | narrative command center |
| Situation | mission | 이름 변경, 세션 중심 상황 뷰 |
| Agents | agent-roster + execution + keeper-roster | 하나의 엔티티 뷰 |
| Activity | live + social | "누가 뭘 하고 있나" |
| Work | proof + memory + governance + planning | 저빈도 참조 4개를 pill 전환 |
| Control | intervene + tools | 운영자 개입 + 도구 |
| Lab | command + lab | 실험/고급 뷰 |

### Backward compatibility

- `navigate('mission')` → 자동으로 `situation`으로 redirect
- `#memory?post=abc` → `#work?section=board&post=abc`
- `AnyTabId` 타입으로 기존 컴포넌트 코드 수정 불필요

## 21 files changed, +748 / -328

## Test plan

- [ ] `npm run build` 빌드 성공 확인
- [ ] 7개 탭 렌더링 확인 (dev server)
- [ ] 기존 hash route redirect 동작 (#mission → #situation)
- [ ] AgentDetail/KeeperDetail 오버레이 동작
- [ ] Work 탭 pill 전환 (board/governance/evidence/planning)

🤖 Generated with [Claude Code](https://claude.com/claude-code)