### PR TITLE
refactor(dashboard): Phase 2.1 — deduplicate mission-store normalizers (v2)

### DIFF
--- a/dashboard/src/mission-store.ts
+++ b/dashboard/src/mission-store.ts
@@ -4,6 +4,7 @@ import {
   fetchDashboardMissionBriefing,
   fetchDashboardMissionSession,
 } from './api'
+import { isRecord, asString, asNumber, asBoolean, extractArray } from './components/common/normalize'
 import type {
   DashboardMissionAgentBrief,
   DashboardMissionAttentionQueueItem,
@@ -59,31 +60,6 @@ function scheduleMissionBriefingPoll(delayMs = 1500): void {
   }, delayMs)
 }
 
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null && !Array.isArray(value)
-}
-
-function asString(value: unknown): string | undefined {
-  return typeof value === 'string' && value.trim() !== '' ? value : undefined
-}
-
-function asNumber(value: unknown): number | undefined {
-  return typeof value === 'number' && Number.isFinite(value) ? value : undefined
-}
-
-function asBoolean(value: unknown): boolean | undefined {
-  return typeof value === 'boolean' ? value : undefined
-}
-
-function extractArray(value: unknown, keys: string[] = []): unknown[] {
-  if (Array.isArray(value)) return value
-  if (!isRecord(value)) return []
-  for (const key of keys) {
-    const candidate = value[key]
-    if (Array.isArray(candidate)) return candidate
-  }
-  return []
-}
 
 function normalizeAttentionItem(raw: unknown): OperatorAttentionItem | null {
   if (!isRecord(raw)) return null


### PR DESCRIPTION
## Summary

- Replace 5 local normalizer functions (`isRecord`, `asString`, `asNumber`, `asBoolean`, `extractArray`) in `mission-store.ts` with imports from `components/common/normalize.ts`
- Removes 25 lines of duplicated code
- Recreates closed PR #1448 on latest main (v2.107.0) after merge conflicts

## Test plan

- [x] `npx vite build` passes with no errors
- [ ] Verify dashboard loads and mission data renders correctly at `/dashboard`

Generated with [Claude Code](https://claude.com/claude-code)