### PR TITLE
fix(dashboard): cap SituationBanner blocker reasons + collapsible

### DIFF
--- a/dashboard/src/components/overview/situation-banner.ts
+++ b/dashboard/src/components/overview/situation-banner.ts
@@ -44,14 +44,18 @@ function synthesizeSituation(snap: DashboardMissionResponse | null): SituationRe
 
   const reasons: SituationReason[] = []
 
-  // Collect blocker reasons
+  // Collect blocker reasons (top 3 — full count shown in summary text)
+  let blockerCount = 0
   for (const s of sessions) {
     if (s.blocker_summary) {
-      reasons.push({
-        category: 'blocker',
-        text: `${s.goal ?? s.session_id}: ${s.blocker_summary.slice(0, 80)}`,
-        severity: 'bad',
-      })
+      blockerCount++
+      if (blockerCount <= 3) {
+        reasons.push({
+          category: 'blocker',
+          text: `${s.goal ?? s.session_id}: ${s.blocker_summary.slice(0, 80)}`,
+          severity: 'bad',
+        })
+      }
     }
   }
 
@@ -110,14 +114,19 @@ export function SituationBanner({ snap, roomHealth }: SituationBannerProps) {
       <span class="situation-banner__text">${text}</span>
     </div>
     ${showReasons ? html`
-      <div class="situation-reasons">
-        ${reasons.map((r, i) => html`
-          <div class="situation-reason situation-reason--${r.severity}" key=${i}>
-            <span class="situation-reason__tag">${CATEGORY_LABELS[r.category] ?? r.category}</span>
-            <span class="situation-reason__text">${r.text}</span>
-          </div>
-        `)}
-      </div>
+      <details class="situation-reasons-collapse" open=${reasons.length <= 5}>
+        <summary class="situation-reasons-collapse__summary">
+          상세 ${reasons.length}건
+        </summary>
+        <div class="situation-reasons">
+          ${reasons.map((r, i) => html`
+            <div class="situation-reason situation-reason--${r.severity}" key=${i}>
+              <span class="situation-reason__tag">${CATEGORY_LABELS[r.category] ?? r.category}</span>
+              <span class="situation-reason__text">${r.text}</span>
+            </div>
+          `)}
+        </div>
+      </details>
     ` : null}
   `
 }

--- a/dashboard/src/config/navigation.ts
+++ b/dashboard/src/config/navigation.ts
@@ -118,23 +118,6 @@ export const DASHBOARD_NAV_ITEMS: DashboardNavItem[] = [
   },
 ]
 
-// Legacy compatibility: old section types used by SideRail
-export type DashboardNavGroupLegacy = 'now' | 'why' | 'act' | 'lab'
-
-export interface DashboardNavSection {
-  id: DashboardNavGroupLegacy
-  label: string
-  description: string
-}
-
-// Kept for backward compat — unused in the new nav but referenced by semantic-layer
-export const DASHBOARD_NAV_SECTIONS: DashboardNavSection[] = [
-  { id: 'now', label: '\uC9C0\uAE08', description: '\uD604\uC7AC \uC0C1\uD0DC' },
-  { id: 'why', label: '\uC774\uC720', description: '\uADFC\uAC70\uC640 \uB9E5\uB77D' },
-  { id: 'act', label: '\uAC1C\uC785', description: '\uC6B4\uC601 \uC561\uC158' },
-  { id: 'lab', label: '\uC2E4\uD5D8', description: '\uC2E4\uD5D8 \uD654\uBA74' },
-]
-
 // Surface lookup by tab id
 export function surfaceForTab(tabId: TabId): SurfaceId {
   for (const surface of DASHBOARD_SURFACES) {

--- a/dashboard/src/styles/roster.css
+++ b/dashboard/src/styles/roster.css
@@ -327,12 +327,25 @@
    Situation Reasons (WHY panel)
    ============================================ */
 
+.situation-reasons-collapse {
+  margin-bottom: var(--space-sm, 8px);
+}
+.situation-reasons-collapse__summary {
+  cursor: pointer;
+  font-size: 11px;
+  color: var(--text-muted, #94a3b8);
+  padding: 4px var(--space-md, 16px);
+  letter-spacing: 0.04em;
+}
+.situation-reasons-collapse__summary:hover {
+  color: var(--text-primary, #e2e8f0);
+}
+
 .situation-reasons {
   display: flex;
   flex-direction: column;
   gap: 4px;
   padding: 6px var(--space-md, 16px);
-  margin-bottom: var(--space-sm, 8px);
   border-left: 2px solid var(--ff-border, var(--ff-border));
 }
 


### PR DESCRIPTION
## Summary

- SituationBanner blocker reasons를 3개로 제한 (기존: 무제한. 54개 blocked 세션이 Home viewport 전체를 차지하는 문제)
- Reasons 영역을 collapsible `<details>`로 감쌈 (5건 이하 auto-open, 초과 시 접힘)
- 미사용 `DASHBOARD_NAV_SECTIONS` legacy compat 제거

#1462 squash merge 이후 누락된 Phase 7 변경분.

## Test plan

- [ ] `npm run build` 성공
- [ ] Home 탭에서 blocked 세션이 많을 때 reasons가 접혀 있는지 확인
- [ ] HotSessions, AgentPulse가 viewport 안에 보이는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)