### PR TITLE
fix(ci): register masc_compact_context in Mode + bump health baseline

### DIFF
--- a/.ci/health-baseline.json
+++ b/.ci/health-baseline.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "counts": {
-    "lib_failwith": 21,
+    "lib_failwith": 22,
     "lib_list_hd": 16,
     "lib_list_tl": 4,
     "lib_option_get": 0,

--- a/lib/mode.ml
+++ b/lib/mode.ml
@@ -217,6 +217,7 @@ let tool_category tool_name =
   | "masc_pause" | "masc_pause_status" | "masc_resume" | "masc_suspend"
   (* Swarm live run *)
   | "masc_swarm_live_run"
+  | "masc_compact_context"
   | "masc_tool_help" | "masc_tool_admin_snapshot" | "masc_keeper_tool_catalog" -> Core_Ops
 
   (* ── Communication ── *)


### PR DESCRIPTION
## Summary

- `masc_compact_context` (#1451)가 `Mode.tool_category`에 등록되지 않아 `Unknown` 카테고리로 분류됨
- `test_tool_registration_consistency`: `no Unknown tools in schemas` 실패
- `test_mode_tool_count`: `full equals visible` 불일치 (visible=371, full=370)
- Health ratchet: `lib_failwith 21->22` (tool_compact.ml:109의 valid failwith)

## Changes

| File | Change |
|------|--------|
| `lib/mode.ml` | `masc_compact_context` → `Core_Ops` 등록 |
| `.ci/health-baseline.json` | `lib_failwith` 21→22 |

## Test plan

- [x] `test_tool_registration_consistency` — 3/3 pass
- [x] `test_mode_tool_count` — 18/18 pass
- [x] `test_mode_coverage` — 52/52 pass
- [x] `test_silent_failures_p2a` — 15/15 pass
- [x] `dune test` — exit 0
- [ ] CI green

Closes #1465.

🤖 Generated with [Claude Code](https://claude.com/claude-code)