### PR TITLE
fix(test): wrap test_http_negotiation in Eio_main.run

### DIFF
--- a/test/test_http_negotiation.ml
+++ b/test/test_http_negotiation.ml
@@ -163,6 +163,7 @@ let test_initialize_never_uses_sse () =
        Masc_mcp.Mcp_protocol.Http_negotiation.Streamable)
 
 let () =
+  Eio_main.run @@ fun _env ->
   run "http_negotiation"
     [
       ("accepts_sse_header", [test_case "parses Accept" `Quick test_accepts_sse_header]);


### PR DESCRIPTION
## Summary
- `protocol_continuity` 테스트 3건이 `Effect.Unhandled(Get_context)`로 실패
- `Session.remember_protocol_version`이 내부적으로 Eio.Mutex 사용
- 1줄 추가: `Eio_main.run @@ fun _env ->`

## Test plan
- [x] 11 tests pass locally
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)