### PR TITLE
fix(gardener): change default enabled from false to true

### DIFF
--- a/lib/env_config_keeper.ml
+++ b/lib/env_config_keeper.ml
@@ -47,7 +47,7 @@ end
 module Gardener = struct
   (** Master switch for Gardener Agent *)
   let enabled =
-    get_bool ~default:false "MASC_GARDENER_ENABLED"
+    get_bool ~default:true "MASC_GARDENER_ENABLED"
 
   (** Minimum agent population (never retire below this) *)
   let min_agents =


### PR DESCRIPTION
## Summary
- `env_config_keeper.ml`에서 `MASC_GARDENER_ENABLED` 기본값을 `false` → `true`로 변경
- 환경변수 미설정 시에도 Gardener가 자동 활성화되어 에이전트 생태계 자율 관리 시작

## Why
Gardener `default:false`로 인해 환경변수 미설정 시 Gardener가 비활성화됨.
실제 발생한 증상:
- 54개 세션 전부 stuck (18시간+ 방치)
- 32개 pending task, 0개 task 할당
- 11개 에이전트 하트비트 정상이지만 작업 없음

`MASC_GARDENER_ENABLED=false`로 명시적 opt-out은 여전히 가능.

## Test plan
- [x] `test_gardener.exe` 77개 테스트 통과
- [x] `dune build` 성공
- [x] 서버 재시작 후 health check에서 `gardener.enabled=true, alive=true` 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)