### PR TITLE
fix(dashboard): warm cache on startup + agent profile page

### DIFF
--- a/dashboard/src/components/agent-profile.ts
+++ b/dashboard/src/components/agent-profile.ts
@@ -1,0 +1,406 @@
+// Agent Profile — full-page view for a single agent.
+// Reuses data-fetching from agent-detail and renders as a dedicated page
+// instead of an overlay modal.
+
+import { html } from 'htm/preact'
+import { signal } from '@preact/signals'
+import { useEffect } from 'preact/hooks'
+import { Card } from './common/card'
+import { StatusBadge } from './common/status-badge'
+import { TimeAgo } from './common/time-ago'
+import { showToast } from './common/toast'
+import { keeperIdentityHint } from './common/keeper-identity'
+import { AgentAvatar } from './overview/agent-avatar'
+import {
+  agents,
+  executionContinuityBriefs,
+  executionWorkerSupportBriefs,
+  keepers,
+  tasks,
+} from '../store'
+import {
+  fetchRoomMessages,
+  fetchTaskHistory,
+  sendBroadcast,
+  fetchAgentTimeline,
+  type AgentTimelineEvent,
+  type AgentTimelineResponse,
+} from '../api'
+import { journal } from '../sse'
+import { missionSnapshot } from '../mission-store'
+import { navigate } from '../router'
+import { formatDuration } from './mission-utils'
+import type { JournalEntry } from '../types'
+import type {
+  Agent,
+  DashboardExecutionContinuityBrief,
+  DashboardMissionAgentBrief,
+  Keeper,
+  Task,
+} from '../types'
+
+const AGENT_NAME_KEY = 'masc_dashboard_agent_name'
+
+type TaskHistoryRow = { taskId: string; text: string }
+
+const loading = signal(false)
+const profileError = signal('')
+const roomActivity = signal<string[]>([])
+const taskHistories = signal<TaskHistoryRow[]>([])
+const agentTimeline = signal<AgentTimelineResponse | null>(null)
+const mentionText = signal('')
+const sendingMention = signal(false)
+
+function findAgent(name: string): Agent | null {
+  return agents.value.find(a => a.name === name) ?? null
+}
+
+function assignedTasks(name: string): Task[] {
+  return tasks.value.filter(t => t.assignee === name)
+}
+
+function findKeeper(name: string): Keeper | null {
+  return keepers.value.find(
+    k => k.agent_name === name || k.name === name,
+  ) ?? null
+}
+
+function missionBrief(name: string): DashboardMissionAgentBrief | null {
+  const mission = missionSnapshot.value
+  if (!mission) return null
+  return mission.agent_briefs.find(b => b.agent_name === name) ?? null
+}
+
+function continuityBrief(name: string): DashboardExecutionContinuityBrief | null {
+  return executionContinuityBriefs.value.find(
+    b => b.agent_name === name || b.name === name,
+  ) ?? null
+}
+
+function workerBrief(name: string) {
+  return executionWorkerSupportBriefs.value.find(w => w.name === name) ?? null
+}
+
+function agentJournalEntries(name: string): JournalEntry[] {
+  const lower = name.toLowerCase()
+  return journal.value
+    .filter((e: JournalEntry) => {
+      const text = e.text.toLowerCase()
+      const agent = e.agent.toLowerCase()
+      return agent === lower || text.includes(lower) || text.includes(`@${lower}`)
+    })
+    .slice(0, 15)
+}
+
+function compactCopy(value: string | null | undefined, max = 160): string | null {
+  const text = (value ?? '').replace(/\s+/g, ' ').trim()
+  if (!text) return null
+  return text.length > max ? `${text.slice(0, max - 1)}…` : text
+}
+
+async function loadProfile(name: string): Promise<void> {
+  loading.value = true
+  profileError.value = ''
+  roomActivity.value = []
+  taskHistories.value = []
+  agentTimeline.value = null
+
+  try {
+    const [lines, timeline] = await Promise.all([
+      fetchRoomMessages(80),
+      fetchAgentTimeline(name, 4, 20).catch(() => null),
+    ])
+
+    roomActivity.value = lines
+      .filter(line => line.includes(name))
+      .slice(0, 20)
+
+    agentTimeline.value = timeline
+
+    const owned = assignedTasks(name).slice(0, 6)
+    if (owned.length > 0) {
+      const rows = await Promise.all(
+        owned.map(async task => {
+          try {
+            const text = await fetchTaskHistory(task.id, 25)
+            return { taskId: task.id, text: text.trim() }
+          } catch (err) {
+            const msg = err instanceof Error ? err.message : 'load failed'
+            return { taskId: task.id, text: `Failed: ${msg}` }
+          }
+        }),
+      )
+      taskHistories.value = rows
+    }
+  } catch (err) {
+    profileError.value = err instanceof Error ? err.message : 'Failed to load profile'
+  } finally {
+    loading.value = false
+  }
+}
+
+async function submitMention(target: string): Promise<void> {
+  const text = mentionText.value.trim()
+  if (!target || !text) return
+  const sender = localStorage.getItem(AGENT_NAME_KEY)?.trim() || 'dashboard'
+  sendingMention.value = true
+  try {
+    await sendBroadcast(sender, `@${target} ${text}`)
+    mentionText.value = ''
+    showToast(`Mention sent to ${target}`, 'success')
+    void loadProfile(target)
+  } catch (err) {
+    showToast(err instanceof Error ? err.message : 'Failed', 'error')
+  } finally {
+    sendingMention.value = false
+  }
+}
+
+function pressureClass(ratio: number | null | undefined): string {
+  if (ratio == null) return ''
+  const pct = ratio * 100
+  if (pct < 50) return 'pressure--ok'
+  if (pct < 70) return 'pressure--amber'
+  if (pct < 85) return 'pressure--orange'
+  return 'pressure--red'
+}
+
+function timelineEventIcon(type: string): string {
+  if (type === 'joined') return 'J'
+  if (type.startsWith('task_')) return 'T'
+  if (type === 'broadcast') return 'M'
+  return 'E'
+}
+
+function timelineEventLabel(type: string): string {
+  switch (type) {
+    case 'joined': return '참가'
+    case 'task_claimed': return '태스크 수임'
+    case 'task_started': return '태스크 시작'
+    case 'task_completed': return '태스크 완료'
+    case 'task_cancelled': return '태스크 취소'
+    case 'broadcast': return '브로드캐스트'
+    default: return type
+  }
+}
+
+function journalKindIcon(entry: JournalEntry): string {
+  if (entry.kind === 'board') return 'B'
+  if (entry.kind === 'tasks') return 'T'
+  if (entry.kind === 'keepers') return 'K'
+  return 'S'
+}
+
+export function AgentProfile({ name }: { name: string }) {
+  useEffect(() => {
+    void loadProfile(name)
+  }, [name])
+
+  const agent = findAgent(name)
+  const keeper = findKeeper(name)
+  const brief = missionBrief(name)
+  const contBrief = continuityBrief(name)
+  const worker = workerBrief(name)
+  const owned = assignedTasks(name)
+  const lines = roomActivity.value
+  const timeline = agentTimeline.value
+
+  const displayName = brief?.display_name ?? keeper?.name ?? name
+  const secondaryLabel = displayName !== name ? name : null
+  const headerStatus = agent?.status ?? brief?.status ?? 'unknown'
+  const lastSeenAt = agent?.last_seen ?? brief?.last_activity_at ?? null
+  const agentEmoji = agent?.emoji ?? keeper?.emoji
+  const koreanName = agent?.koreanName ?? keeper?.koreanName
+  const currentWork = keeper?.current_work ?? brief?.current_work ?? agent?.current_task ?? null
+  const ctxRatio = keeper?.context_ratio
+  const ctxPct = ctxRatio != null ? Math.round(ctxRatio * 100) : null
+  const keeperIdent = keeperIdentityHint(keeper?.name, keeper?.agent_name)
+  const continuitySummary =
+    compactCopy(contBrief?.continuity_summary)
+    ?? compactCopy(contBrief?.skill_route_summary)
+    ?? null
+  const lastActivity = keeper?.last_turn_ago_s ?? brief?.last_turn_ago_s ?? null
+
+  const journalEntries = agentJournalEntries(name)
+
+  return html`
+    <div class="agent-profile">
+      <div class="agent-profile__back">
+        <button class="control-btn ghost" onClick=${() => navigate('agents')}>
+          ← 목록으로
+        </button>
+        <button
+          class="control-btn ghost"
+          onClick=${() => { void loadProfile(name) }}
+          disabled=${loading.value}
+        >
+          ${loading.value ? '새로고침 중...' : '새로고침'}
+        </button>
+      </div>
+
+      ${profileError.value ? html`<div class="council-error">${profileError.value}</div>` : null}
+
+      <div class="agent-profile__header">
+        <div class="agent-profile__avatar">
+          <${AgentAvatar}
+            name=${name}
+            status=${headerStatus}
+            traits=${agent?.traits}
+            size="xl"
+            currentWork=${currentWork}
+            activityAge=${lastActivity}
+          />
+        </div>
+        <div class="agent-profile__identity">
+          <h2 class="agent-profile__name">
+            ${agentEmoji ? html`<span style="font-size:1.5em;margin-right:8px">${agentEmoji}</span>` : ''}
+            ${displayName}
+            ${koreanName ? html`<span class="agent-profile__korean">(${koreanName})</span>` : ''}
+            ${secondaryLabel ? html`<span class="mono agent-profile__secondary">${secondaryLabel}</span>` : ''}
+          </h2>
+          <div class="agent-profile__badges">
+            <${StatusBadge} status=${headerStatus} />
+            ${keeper ? html`<span class="pill">keeper</span>` : null}
+            ${keeper?.generation != null ? html`<span class="pill">G${keeper.generation}</span>` : null}
+            ${agent?.model ? html`<span class="mono pill">${agent.model}</span>` : ''}
+            ${brief?.signal_truth ? html`<span class="pill">signal · ${brief.signal_truth}</span>` : null}
+          </div>
+          <div class="agent-profile__meta">
+            ${currentWork ? html`<span>작업: ${currentWork}</span>` : html`<span class="text-muted">작업 없음</span>`}
+            ${lastSeenAt ? html`<span>마지막: <${TimeAgo} timestamp=${lastSeenAt} /></span>` : null}
+            ${lastActivity != null ? html`<span>${formatDuration(lastActivity)} 전 활동</span>` : null}
+          </div>
+          ${keeper && keeperIdent ? html`<div class="agent-profile__meta"><span>Keeper: ${keeper.name}${keeperIdent ? ` · ${keeperIdent}` : ''}</span></div>` : null}
+          ${continuitySummary ? html`<div class="agent-profile__meta"><span>${continuitySummary}</span></div>` : null}
+          ${brief?.related_session_id ? html`<div class="agent-profile__meta"><span>Session: ${brief.related_session_id}</span></div>` : null}
+        </div>
+      </div>
+
+      ${keeper && ctxPct != null ? html`
+        <div class="agent-profile__ctx-section">
+          <div class="agent-profile__ctx-label">Context ${ctxPct}%</div>
+          <div class="roster-card__gauge-track" style="max-width:400px">
+            <div class="roster-card__gauge-bar ${pressureClass(ctxRatio)}" style=${{ width: `${ctxPct}%` }} />
+          </div>
+          ${keeper?.autonomy_level ? html`<span class="pill">autonomy: ${keeper.autonomy_level}</span>` : null}
+        </div>
+      ` : null}
+
+      <div class="agent-profile__grid">
+        <${Card} title="할당된 태스크 (${owned.length})">
+          ${owned.length === 0
+            ? html`<div class="empty-state">할당된 태스크 없음</div>`
+            : html`<div class="agent-detail-task-list">${owned.map(t => html`
+                <div class="agent-detail-task" key=${t.id}>
+                  <span class="pill">${t.id}</span>
+                  <span class="agent-detail-task-title">${t.title}</span>
+                  <${StatusBadge} status=${t.status} />
+                </div>
+              `)}</div>`}
+        <//>
+
+        ${worker ? html`
+          <${Card} title="Worker 상태">
+            <div class="agent-worker-brief">
+              <div class="agent-worker-brief__row">
+                <span class="agent-worker-brief__label">State</span>
+                <${StatusBadge} status=${worker.state} />
+              </div>
+              ${worker.focus ? html`
+                <div class="agent-worker-brief__row">
+                  <span class="agent-worker-brief__label">Focus</span>
+                  <span>${worker.focus}</span>
+                </div>
+              ` : null}
+              ${worker.recent_output_preview ? html`
+                <div class="agent-worker-brief__row">
+                  <span class="agent-worker-brief__label">Output</span>
+                  <span class="mono">${compactCopy(worker.recent_output_preview, 120)}</span>
+                </div>
+              ` : null}
+            </div>
+          <//>
+        ` : null}
+
+        <${Card} title="최근 Room 활동">
+          ${lines.length === 0
+            ? html`<div class="empty-state">관련 활동 없음</div>`
+            : html`<div class="agent-activity-list">${lines.map((line: string, idx: number) =>
+                html`<div key=${idx} class="agent-activity-line">${line}</div>`)}</div>`}
+        <//>
+
+        <${Card} title="실시간 이벤트 (${journalEntries.length})">
+          ${journalEntries.length === 0
+            ? html`<div class="empty-state">관련 이벤트 없음</div>`
+            : html`<div class="agent-journal-stream">${journalEntries.map((entry: JournalEntry, idx: number) => html`
+                <div class="agent-journal-entry" key=${idx}>
+                  <span class="agent-journal-kind">${journalKindIcon(entry)}</span>
+                  <span class="agent-journal-type">${entry.eventType}</span>
+                  <span class="agent-journal-text">${compactCopy(entry.text, 120) ?? ''}</span>
+                  ${entry.timestamp ? html`<${TimeAgo} timestamp=${entry.timestamp} />` : null}
+                </div>
+              `)}</div>`}
+        <//>
+
+        ${timeline ? html`
+          <${Card} title="타임라인 (${timeline.summary?.total_events ?? 0})">
+            ${timeline.summary ? html`
+              <div class="agent-timeline-summary">
+                ${timeline.summary.tasks_completed > 0 ? html`<span class="pill">완료 ${timeline.summary.tasks_completed}</span>` : null}
+                ${timeline.summary.tasks_claimed > 0 ? html`<span class="pill">수임 ${timeline.summary.tasks_claimed}</span>` : null}
+                ${timeline.summary.messages_sent > 0 ? html`<span class="pill">메시지 ${timeline.summary.messages_sent}</span>` : null}
+                ${timeline.summary.active_duration_minutes > 0 ? html`<span class="pill">${Math.round(timeline.summary.active_duration_minutes)}분 활동</span>` : null}
+              </div>
+            ` : null}
+            ${(timeline.events ?? []).length === 0
+              ? html`<div class="empty-state">타임라인 이벤트 없음</div>`
+              : html`<div class="agent-timeline-list">${(timeline.events ?? []).map((evt: AgentTimelineEvent, idx: number) => {
+                  const detail = evt.detail as Record<string, string | undefined>
+                  const title = detail.title ?? detail.content ?? ''
+                  return html`
+                    <div class="agent-timeline-event" key=${idx}>
+                      <span class="agent-journal-kind">${timelineEventIcon(evt.type)}</span>
+                      <span class="agent-timeline-type">${timelineEventLabel(evt.type)}</span>
+                      ${title ? html`<span class="agent-timeline-detail">${compactCopy(title, 80)}</span>` : null}
+                      ${evt.ts ? html`<${TimeAgo} timestamp=${evt.ts} />` : null}
+                    </div>
+                  `
+                })}</div>`}
+          <//>
+        ` : null}
+
+        <${Card} title="태스크 이력">
+          ${taskHistories.value.length === 0
+            ? html`<div class="empty-state">태스크 이력 없음</div>`
+            : html`<div class="agent-history-list">${taskHistories.value.map((row: TaskHistoryRow) => html`
+                <div class="agent-history-row" key=${row.taskId}>
+                  <div class="agent-history-head"><span class="pill">${row.taskId}</span></div>
+                  <pre class="agent-history-pre">${row.text || 'No history yet'}</pre>
+                </div>
+              `)}</div>`}
+        <//>
+
+        <${Card} title="@mention 보내기">
+          <div class="agent-mention-row">
+            <input
+              class="control-input"
+              type="text"
+              placeholder="메시지 입력..."
+              value=${mentionText.value}
+              onInput=${(e: Event) => { mentionText.value = (e.target as HTMLInputElement).value }}
+              onKeyDown=${(e: KeyboardEvent) => { if (e.key === 'Enter') void submitMention(name) }}
+              disabled=${sendingMention.value}
+            />
+            <button
+              class="control-btn"
+              onClick=${() => { void submitMention(name) }}
+              disabled=${sendingMention.value || mentionText.value.trim() === ''}
+            >
+              ${sendingMention.value ? '전송 중...' : '전송'}
+            </button>
+          </div>
+        <//>
+      </div>
+    </div>
+  `
+}

--- a/dashboard/src/components/agent-roster.ts
+++ b/dashboard/src/components/agent-roster.ts
@@ -151,7 +151,7 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
             <div
               class="roster-card ${isKeeper ? 'roster-card--keeper' : ''}"
               key=${agent.name}
-              onClick=${() => navigate('execution', { agent: agent.name })}
+              onClick=${() => navigate('agents', { agent: agent.name })}
               role="button"
               tabindex="0"
             >

--- a/dashboard/src/components/agents-unified.ts
+++ b/dashboard/src/components/agents-unified.ts
@@ -7,6 +7,7 @@ import { route } from '../router'
 import { agents, keepers } from '../store'
 import { missionSnapshot } from '../mission-store'
 import { AgentRoster } from './agent-roster'
+import { AgentProfile } from './agent-profile'
 import { Execution } from './agents'
 
 type AgentsView = 'all' | 'agents' | 'keepers' | 'sessions'
@@ -43,6 +44,12 @@ const CHIPS: { id: AgentsView; label: string }[] = [
 ]
 
 export function AgentsUnified() {
+  // If an agent name is in the route params, show the profile page
+  const agentParam = route.value.params.agent as string | undefined
+  if (agentParam) {
+    return html`<${AgentProfile} name=${agentParam} />`
+  }
+
   // Sync from route params if present
   const viewParam = route.value.params.view as string | undefined
   if (viewParam === 'sessions' && activeView.value !== 'sessions') {

--- a/dashboard/src/components/dashboard-shell.ts
+++ b/dashboard/src/components/dashboard-shell.ts
@@ -4,6 +4,7 @@ import { route, navigate } from '../router'
 import { connected } from '../sse'
 import { dashboardLoading, serverStatus } from '../store'
 import { missionSnapshot } from '../mission-store'
+import { roomTruthInitializing } from '../room-truth-store'
 import { Mission } from './mission'
 import { Overview } from './overview/overview'
 import { AgentsUnified } from './agents-unified'
@@ -199,6 +200,9 @@ export function TabContent() {
 }
 
 export function DashboardMain() {
+  if (roomTruthInitializing.value) {
+    return html`<div class="loading-indicator">서버가 데이터를 준비하고 있습니다. 잠시 후 자동으로 새로고침됩니다...</div>`
+  }
   return dashboardLoading.value && !connected.value
     ? html`<div class="loading-indicator">대시보드 불러오는 중...</div>`
     : html`<${TabContent} />`

--- a/dashboard/src/room-truth-store.ts
+++ b/dashboard/src/room-truth-store.ts
@@ -156,6 +156,12 @@ function normalizeRoomTruth(raw: unknown): DashboardRoomTruthResponse {
   }
 }
 
+/** True while the server is still computing its first cache (warm-up). */
+export const roomTruthInitializing = signal(false)
+
+const WARM_RETRY_DELAY_MS = 3_000
+const WARM_MAX_RETRIES = 10
+
 export async function refreshRoomTruth(): Promise<void> {
   if (inflightRoomTruthRefresh) return inflightRoomTruthRefresh
 
@@ -164,6 +170,15 @@ export async function refreshRoomTruth(): Promise<void> {
   inflightRoomTruthRefresh = (async () => {
     try {
       const raw = await fetchDashboardRoomTruth()
+      const isInitializing =
+        isRecord(raw)
+        && asString((raw as Record<string, unknown>).status) === 'initializing'
+      if (isInitializing) {
+        roomTruthInitializing.value = true
+        scheduleWarmRetry(1)
+        return
+      }
+      roomTruthInitializing.value = false
       roomTruth.value = normalizeRoomTruth(raw)
     } catch (err) {
       roomTruthError.value = err instanceof Error ? err.message : 'Failed to load room truth'
@@ -174,4 +189,22 @@ export async function refreshRoomTruth(): Promise<void> {
   })()
 
   return inflightRoomTruthRefresh
+}
+
+function scheduleWarmRetry(attempt: number): void {
+  if (attempt > WARM_MAX_RETRIES) {
+    roomTruthInitializing.value = false
+    roomTruthError.value = 'Server warm-up timed out. Try refreshing.'
+    roomTruthLoading.value = false
+    inflightRoomTruthRefresh = null
+    return
+  }
+  window.setTimeout(() => {
+    inflightRoomTruthRefresh = null
+    void refreshRoomTruth().then(() => {
+      if (roomTruthInitializing.value) {
+        scheduleWarmRetry(attempt + 1)
+      }
+    })
+  }, WARM_RETRY_DELAY_MS)
 }

--- a/dashboard/src/styles/governance.css
+++ b/dashboard/src/styles/governance.css
@@ -503,6 +503,107 @@ button.council-row.selected {
   gap: 8px;
 }
 
+/* ── Agent Profile Page ──────────────────────────────────── */
+.agent-profile {
+  padding: 0 4px;
+}
+
+.agent-profile__back {
+  display: flex;
+  gap: 8px;
+  margin-bottom: 16px;
+}
+
+.agent-profile__header {
+  display: flex;
+  gap: 16px;
+  align-items: flex-start;
+  margin-bottom: 20px;
+  padding: 16px;
+  border-radius: 12px;
+  background: rgba(16, 25, 45, 0.7);
+  border: 1px solid rgba(138, 163, 211, 0.2);
+}
+
+.agent-profile__avatar {
+  flex-shrink: 0;
+}
+
+.agent-profile__identity {
+  flex: 1;
+  min-width: 0;
+}
+
+.agent-profile__name {
+  margin: 0;
+  font-size: 22px;
+  color: var(--text-strong);
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.agent-profile__korean {
+  font-size: 0.7em;
+  color: #888;
+}
+
+.agent-profile__secondary {
+  font-size: 0.65em;
+  color: #888;
+}
+
+.agent-profile__badges {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-wrap: wrap;
+  margin-top: 8px;
+}
+
+.agent-profile__meta {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+  margin-top: 6px;
+  color: #9ab3de;
+  font-size: 13px;
+}
+
+.agent-profile__ctx-section {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 16px;
+  padding: 10px 16px;
+  border-radius: 10px;
+  background: rgba(16, 25, 45, 0.5);
+  border: 1px solid rgba(138, 163, 211, 0.15);
+}
+
+.agent-profile__ctx-label {
+  font-size: 13px;
+  font-variant-numeric: tabular-nums;
+  color: var(--text-strong);
+  white-space: nowrap;
+}
+
+.agent-profile__grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 14px;
+}
+
+@media (max-width: 800px) {
+  .agent-profile__grid {
+    grid-template-columns: 1fr;
+  }
+  .agent-profile__header {
+    flex-direction: column;
+  }
+}
+
 /* ── Keeper Rich Card (Overview) ──────────────────────────── */
 .keeper-ctx-row {
   display: flex;

--- a/lib/operator_control_snapshot.ml
+++ b/lib/operator_control_snapshot.ml
@@ -310,7 +310,7 @@ let sessions_json config =
     List.map
       (fun (session : Team_session_types.session) ->
         let recent_events =
-          Team_session_store.read_events ~max_events:200 config session.session_id
+          Team_session_store.read_events ~max_events:5 config session.session_id
           |> Team_session_engine_eio.take_last 5
         in
         `Assoc

--- a/lib/server_dashboard_http.ml
+++ b/lib/server_dashboard_http.ml
@@ -42,6 +42,20 @@ let _execution_refresh_interval_s = 60.0
 let start_execution_refresh_loop ~state ~sw ~clock =
   let config = state.Mcp_server.room_config in
   let proc_mgr = state.Mcp_server.proc_mgr in
+  (* Warm cache: compute once synchronously so the first browser request
+     sees real data instead of the "initializing" placeholder. *)
+  (let t0 = Time_compat.now () in
+   try
+     let json =
+       Dashboard_execution.json ~light:true ~config ~sw ~clock ~proc_mgr ()
+     in
+     _execution_json_ref := json;
+     let dt = Time_compat.now () -. t0 in
+     Printf.eprintf "[INFO] Dashboard: execution warm cache done (%.1fs).\n%!" dt
+   with exn ->
+     let dt = Time_compat.now () -. t0 in
+     Printf.eprintf "[WARN] Dashboard: execution warm cache failed (%.1fs): %s\n%!"
+       dt (Printexc.to_string exn));
   Eio.Fiber.fork ~sw (fun () ->
     Printf.eprintf "[INFO] Dashboard: starting execution refresh loop.\n%!";
     let rec loop () =

--- a/lib/server_dashboard_http_core.ml
+++ b/lib/server_dashboard_http_core.ml
@@ -313,6 +313,20 @@ let _mission_refresh_interval_s = 120.0
 let start_mission_refresh_loop ~state ~sw ~clock =
   let config = state.Mcp_server.room_config in
   let proc_mgr = state.Mcp_server.proc_mgr in
+  (* Warm cache: compute once synchronously so the first browser request
+     sees real data instead of the empty placeholder. *)
+  (let t0 = Time_compat.now () in
+   try
+     let json =
+       Dashboard_mission.json ~config ~sw ~clock ~proc_mgr ()
+     in
+     _mission_json_ref := json;
+     let dt = Time_compat.now () -. t0 in
+     Printf.eprintf "[INFO] Dashboard: mission warm cache done (%.1fs).\n%!" dt
+   with exn ->
+     let dt = Time_compat.now () -. t0 in
+     Printf.eprintf "[WARN] Dashboard: mission warm cache failed (%.1fs): %s\n%!"
+       dt (Printexc.to_string exn));
   Eio.Fiber.fork ~sw (fun () ->
     Printf.eprintf "[INFO] Dashboard: starting mission proactive refresh loop.\n%!";
     let rec loop () =


### PR DESCRIPTION
## Summary
- **성능**: 서버 시작 시 execution/mission 캐시를 즉시 계산하여 첫 접속 60초 대기 제거
- **I/O 최적화**: `read_events ~max_events:200` → `~max_events:5` (last 5만 사용, 40배 I/O 감소)
- **UX**: 에이전트 카드 클릭 시 legacy "execution" 탭 대신 전용 프로필 페이지로 이동
- **Client retry**: 서버 warm-up 중 "initializing" 감지 시 3초 간격 자동 재시도

## Changes

### Performance (OCaml)
| 파일 | 변경 |
|------|------|
| `lib/server_dashboard_http.ml` | execution refresh loop 시작 전 synchronous warm cache |
| `lib/server_dashboard_http_core.ml` | mission refresh loop 시작 전 synchronous warm cache |
| `lib/operator_control_snapshot.ml` | `sessions_json`: `read_events 200` → `5` |

### Dashboard (TypeScript)
| 파일 | 변경 |
|------|------|
| `dashboard/src/components/agent-profile.ts` | **새 파일** — 에이전트 전용 프로필 페이지 |
| `dashboard/src/components/agents-unified.ts` | `route.params.agent` 분기 → AgentProfile 렌더 |
| `dashboard/src/components/agent-roster.ts` | `navigate('execution')` → `navigate('agents')` |
| `dashboard/src/room-truth-store.ts` | `initializing` 감지 + 3초 auto-retry |
| `dashboard/src/components/dashboard-shell.ts` | warm-up 중 "서버 준비 중" 메시지 |
| `dashboard/src/styles/governance.css` | 프로필 페이지 스타일 |

## Test plan
- [ ] 서버 재시작 후 즉시 대시보드 접속 → 데이터 즉시 표시 확인
- [ ] 에이전트 카드 클릭 → 프로필 페이지 표시 확인
- [ ] 프로필에서 "← 목록으로" 클릭 → roster 복귀 확인
- [ ] `dune build --root .` 성공 확인
- [ ] `make test` pre-existing 외 새 실패 없음 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)