### PR TITLE
refactor(dashboard): replace all legacy tab navigations with canonical tabs

### DIFF
--- a/dashboard/src/components/command/index.ts
+++ b/dashboard/src/components/command/index.ts
@@ -56,7 +56,7 @@ function SurfaceTabs() {
                   class="command-surface-tab ${commandPlaneSurface.value === surface.id ? 'active' : ''}"
                   onClick=${() => {
                     setCommandPlaneSurface(surface.id)
-                    navigate('command', surfaceRouteParams(surface.id))
+                    navigate('lab', surfaceRouteParams(surface.id))
                   }}
                 >
                   ${surface.label}
@@ -255,7 +255,7 @@ export function Command() {
               class="control-btn ghost"
               onClick=${() => {
                 setCommandPlaneSurface('warroom')
-                navigate('command', { ...surfaceRouteParams('warroom'), presentation: 'wallboard' })
+                navigate('lab', { ...surfaceRouteParams('warroom'), presentation: 'wallboard' })
               }}
             >
               Wallboard

--- a/dashboard/src/components/command/operations.ts
+++ b/dashboard/src/components/command/operations.ts
@@ -196,7 +196,7 @@ function OperationCard({ card }: { card: CommandPlaneOperationCard }) {
           class="control-btn ghost"
           onClick=${() => {
             setCommandPlaneSurface('swarm')
-            navigate('command', {
+            navigate('lab', {
               surface: 'swarm',
               operation_id: op.operation_id,
               ...(runId ? { run_id: runId } : {}),
@@ -212,7 +212,7 @@ function OperationCard({ card }: { card: CommandPlaneOperationCard }) {
                 onClick=${() => {
                   focusCommandPlaneChainOperation(op.operation_id)
                   setCommandPlaneSurface('chains')
-                  navigate('command', { surface: 'chains', operation: op.operation_id })
+                  navigate('lab', { surface: 'chains', operation: op.operation_id })
                 }}
               >
                 체인 열기

--- a/dashboard/src/components/command/orchestra-drawer.ts
+++ b/dashboard/src/components/command/orchestra-drawer.ts
@@ -55,17 +55,17 @@ function jumpTo(tab: string, surface: CommandPlaneSurface | string | null | unde
   if (tab === 'command') {
     if (surface) {
       setCommandPlaneSurface(surface as CommandPlaneSurface)
-      navigate('command', { ...surfaceRouteParams(surface as CommandPlaneSurface), ...params })
+      navigate('lab', { ...surfaceRouteParams(surface as CommandPlaneSurface), ...params })
       return
     }
-    navigate('command', params)
+    navigate('lab', params)
     return
   }
   if (tab === 'intervene') {
-    navigate('intervene', params)
+    navigate('control', params)
     return
   }
-  navigate('command', params)
+  navigate('lab', params)
 }
 
 // ── Node rendering helpers ──────────────────────────────

--- a/dashboard/src/components/command/war-room-metrics.ts
+++ b/dashboard/src/components/command/war-room-metrics.ts
@@ -360,10 +360,10 @@ export function WarRoomJumpButton({
       onClick=${() => {
         if (surface) {
           setCommandPlaneSurface(surface)
-          navigate('command', { ...surfaceRouteParams(surface), ...params })
+          navigate('lab', { ...surfaceRouteParams(surface), ...params })
           return
         }
-        navigate('intervene')
+        navigate('control')
       }}
     >
       ${label}

--- a/dashboard/src/components/command/war-room.ts
+++ b/dashboard/src/components/command/war-room.ts
@@ -266,7 +266,7 @@ export function WarRoomSurface({ wallboard = false }: { wallboard?: boolean }) {
                         void document.exitFullscreen?.()
                       }
                       setCommandPlaneSurface('warroom')
-                      navigate('command', surfaceRouteParams('warroom'))
+                      navigate('lab', surfaceRouteParams('warroom'))
                     }}
                   >
                     표준 보기

--- a/dashboard/src/components/common/room-truth-strip.ts
+++ b/dashboard/src/components/common/room-truth-strip.ts
@@ -9,10 +9,10 @@ function openFocus(): void {
   if (!focus?.suggested_tab) return
   const params = focus.suggested_params ?? {}
   if (focus.suggested_tab === 'intervene') {
-    navigate('intervene', params)
+    navigate('control', params)
     return
   }
-  navigate('command', {
+  navigate('lab', {
     ...(focus.suggested_surface ? { surface: focus.suggested_surface } : {}),
     ...params,
   })

--- a/dashboard/src/components/common/tool-audit.ts
+++ b/dashboard/src/components/common/tool-audit.ts
@@ -73,5 +73,5 @@ export function linkedRecentToolsEmptyState(keeper: Keeper | null | undefined): 
 
 export function openToolsInventory(search?: string | null): void {
   const q = search?.trim()
-  navigate('tools', q ? { q } : undefined)
+  navigate('control', { section: 'tools', ...(q ? { q } : {}) })
 }

--- a/dashboard/src/components/memory.ts
+++ b/dashboard/src/components/memory.ts
@@ -341,7 +341,7 @@ function PostDetail({ post }: { post: BoardPost }) {
 
   return html`
     <div>
-      <button class="back-btn" onClick=${() => navigate('memory')}>← 메모리로 돌아가기</button>
+      <button class="back-btn" onClick=${() => navigate('work', { section: 'board' })}>← 게시판으로 돌아가기</button>
       <${Card} title=${post.title} semanticId="memory.feed">
         <div class="board-detail">
           <div class="post-body">
@@ -413,7 +413,7 @@ export function Memory() {
       : html`
           <div>
             <${MemorySummary} />
-            <button class="back-btn" onClick=${() => navigate('memory')}>← 메모리로 돌아가기</button>
+            <button class="back-btn" onClick=${() => navigate('work', { section: 'board' })}>← 게시판으로 돌아가기</button>
             ${detailLoading.value
               ? html`<div class="loading-indicator">글 불러오는 중...</div>`
               : html`<div class="empty-state">글을 찾지 못했습니다</div>`}

--- a/dashboard/src/components/mission-cards.ts
+++ b/dashboard/src/components/mission-cards.ts
@@ -408,8 +408,8 @@ export function SessionBriefCard({
         : null}
 
       <div class="mission-card-actions">
-        <button class="control-btn ghost" onClick=${() => openSession('intervene', brief.session_id)}>세션 개입 열기</button>
-        <button class="control-btn ghost" onClick=${() => openSession('command', brief.session_id)}>세션 원인 보기</button>
+        <button class="control-btn ghost" onClick=${() => openSession('control', brief.session_id)}>세션 개입 열기</button>
+        <button class="control-btn ghost" onClick=${() => openSession('lab', brief.session_id)}>세션 원인 보기</button>
         ${action
           ? html`<button class="control-btn ghost" onClick=${() => openActionIntervene(action, incident, '상황판 세션 요약')}>추천 액션 열기</button>`
           : null}
@@ -509,7 +509,7 @@ export function SessionDetailCard({
           <div class="mission-link-list">
             ${detail.operations.length > 0
               ? detail.operations.map(operation => html`
-                  <button class="mission-link-row" onClick=${() => openSession('command', session.session_id)}>
+                  <button class="mission-link-row" onClick=${() => openSession('lab', session.session_id)}>
                     <strong>${operation.operation_id}</strong>
                     <span>${statusLabel(operation.status)}${operation.stage ? ` · ${operation.stage}` : ''}</span>
                     <small>${operation.detachment_status ?? operation.objective ?? '분견대 정보 없음'}</small>

--- a/dashboard/src/components/mission-utils.ts
+++ b/dashboard/src/components/mission-utils.ts
@@ -99,19 +99,19 @@ export function actionTargetLabel(action?: OperatorRecommendedAction | null): st
 }
 
 function navigateWithContext(
-  tab: 'intervene' | 'command',
+  tab: 'control' | 'lab',
   context = createMissionWorkflowContext(),
 ): void {
   persistWorkflowContext(context)
-  navigate(tab, tab === 'intervene' ? missionInterveneParams(context) : missionCommandParams(context))
+  navigate(tab, tab === 'control' ? missionInterveneParams(context) : missionCommandParams(context))
 }
 
 export function openIncidentIntervene(item: OperatorAttentionItem): void {
-  navigateWithContext('intervene', createMissionWorkflowContext(null, item, '상황판 incident'))
+  navigateWithContext('control', createMissionWorkflowContext(null, item, '상황판 incident'))
 }
 
 export function openIncidentCommand(item: OperatorAttentionItem): void {
-  navigateWithContext('command', createMissionWorkflowContext(null, item, '상황판 incident'))
+  navigateWithContext('lab', createMissionWorkflowContext(null, item, '상황판 incident'))
 }
 
 export function openActionIntervene(
@@ -119,7 +119,7 @@ export function openActionIntervene(
   incident?: OperatorAttentionItem | null,
   sourceLabel = '상황판 추천 액션',
 ): void {
-  navigateWithContext('intervene', createMissionWorkflowContext(action, incident, sourceLabel))
+  navigateWithContext('control', createMissionWorkflowContext(action, incident, sourceLabel))
 }
 
 export function openActionCommand(
@@ -127,17 +127,17 @@ export function openActionCommand(
   incident?: OperatorAttentionItem | null,
   sourceLabel = '상황판 추천 액션',
 ): void {
-  navigateWithContext('command', createMissionWorkflowContext(action, incident, sourceLabel))
+  navigateWithContext('lab', createMissionWorkflowContext(action, incident, sourceLabel))
 }
 
-export function openSession(tab: 'intervene' | 'command', sessionId: string): void {
+export function openSession(tab: 'control' | 'lab', sessionId: string): void {
   const params: Record<string, string> = {
     source: 'mission',
     target_type: 'team_session',
     target_id: sessionId,
     focus_kind: 'team_session',
   }
-  if (tab === 'command') params.surface = 'swarm'
+  if (tab === 'lab') params.surface = 'swarm'
   navigate(tab, params)
 }
 

--- a/dashboard/src/components/mission.ts
+++ b/dashboard/src/components/mission.ts
@@ -218,8 +218,8 @@ export function Mission() {
               : html`<div class="empty-state">지금 보이는 키퍼가 없습니다.</div>`}
           </div>
           <div class="mission-card-actions">
-            <button class="control-btn ghost" onClick=${() => navigate('execution')}>실행 관찰면 보기</button>
-            <button class="control-btn ghost" onClick=${() => navigate('command')}>지휘 진단면 보기</button>
+            <button class="control-btn ghost" onClick=${() => navigate('agents', { view: 'sessions' })}>세션 보기</button>
+            <button class="control-btn ghost" onClick=${() => navigate('lab')}>지휘 진단면 보기</button>
           </div>
         <//>
       </details>

--- a/dashboard/src/components/resident-runtime-rail.ts
+++ b/dashboard/src/components/resident-runtime-rail.ts
@@ -223,7 +223,7 @@ export function SnapshotCard({ currentTab }: { currentTab: string }) {
         >
           새로고침
         </button>
-        <button class="rail-secondary-btn" onClick=${() => navigate('intervene')}>
+        <button class="rail-secondary-btn" onClick=${() => navigate('control')}>
           개입 열기
         </button>
       </div>
@@ -278,7 +278,7 @@ export function InterveneRailCard() {
         >
           개입 데이터 갱신
         </button>
-        <button class="rail-secondary-btn" onClick=${() => navigate('intervene')}>
+        <button class="rail-secondary-btn" onClick=${() => navigate('control')}>
           개입 열기
         </button>
       </div>


### PR DESCRIPTION
## Summary
- 대시보드 내 모든 legacy 탭 ID navigate 호출을 canonical 7-tab ID로 교체
- redirect 레이어(LEGACY_TAB_REDIRECTS)에 의존하지 않고 직접 목적지로 이동

## Changes

| Legacy Tab | Canonical Tab | 파일 수 |
|-----------|--------------|--------|
| `execution` | `agents` (view: sessions) | 1 |
| `command` | `lab` | 8 |
| `intervene` | `control` | 5 |
| `tools` | `control` (section: tools) | 1 |
| `memory` | `work` (section: board) | 1 |

**버그 수정:**
- `mission.ts`: "실행 관찰면 보기" 버튼이 에이전트 목록으로 가던 것 → "세션 보기"로 라벨+목적지 수정
- `memory.ts`: "← 메모리로 돌아가기" → "← 게시판으로 돌아가기" (실제 목적지와 라벨 일치)

**12 files, 31 lines changed (순수 rename, 로직 변경 없음)**

## Test plan
- [ ] 상황판에서 "세션 보기" 클릭 → 에이전트 탭 세션 뷰 표시
- [ ] 상황판에서 "지휘 진단면 보기" → lab 탭 이동
- [ ] 게시판 상세에서 "← 게시판으로 돌아가기" → work/board 이동
- [ ] Room truth strip 클릭 → control/lab 정상 이동
- [ ] Vite build 성공 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)