### PR TITLE
chore: bump version to 2.110.0

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -214,7 +214,7 @@ MASC_POSTGRES_URL="..." dune exec _build/default/test/test_board_pg.exe
 ### 환경변수 설정
 
 ```bash
-# 활성화 (기본: false)
+# 활성화 (기본: true, 비활성화하려면 =false)
 MASC_GARDENER_ENABLED=true
 
 # 인원 제한

--- a/dune-project
+++ b/dune-project
@@ -1,7 +1,7 @@
 (lang dune 3.13)
 
 (name masc_mcp)
-(version 2.109.0)
+(version 2.110.0)
 
 (generate_opam_files true)
 


### PR DESCRIPTION
## Summary
- `dune-project` version 2.109.0 → 2.110.0
- `CLAUDE.md` Gardener 문서에서 기본값 설명을 `false` → `true`로 수정

## Changes since 2.109.0
- #1483: fix(gardener): change default enabled from false to true
- #1505-#1507: dashboard fixes (warm cache, agent profile, agent card click)

## Test plan
- [x] `dune build` 성공

🤖 Generated with [Claude Code](https://claude.com/claude-code)