### PR TITLE
feat(tool-bridge): OAS Tool.t migration adapter — schema + handler conversion

### DIFF
--- a/lib/tool_bridge.ml
+++ b/lib/tool_bridge.ml
@@ -1,4 +1,4 @@
-(** OAS boundary adapter for tool results.
+(** OAS boundary adapter for tool results, schemas, and tool definitions.
 
     MASC tools use [(bool * string)] internally (success flag + message).
     OAS uses [Agent_sdk.Types.tool_result = (tool_output, tool_error) result].
@@ -6,7 +6,10 @@
     This module converts at the OAS boundary only — internal MASC
     tool handlers keep their existing convention unchanged.
 
-    @since 2.95.1 *)
+    @since 2.95.1 — result conversion
+    @since 2.110.0 — schema conversion + OAS Tool.t creation *)
+
+(** {1 Result Conversion} *)
 
 let to_oas_tool_result ?(recoverable = true) (success, msg)
   : Agent_sdk.Types.tool_result =
@@ -16,3 +19,76 @@ let to_oas_tool_result ?(recoverable = true) (success, msg)
 let of_oas_tool_result : Agent_sdk.Types.tool_result -> bool * string = function
   | Ok { content } -> (true, content)
   | Error { message; _ } -> (false, message)
+
+(** {1 Schema Conversion}
+
+    Convert MASC JSON Schema (input_schema) to OAS [tool_param list].
+    MASC schemas use raw JSON objects; OAS uses typed [tool_param] records. *)
+
+let param_type_of_string = function
+  | "string" -> Agent_sdk.Types.String
+  | "integer" -> Agent_sdk.Types.Integer
+  | "number" -> Agent_sdk.Types.Number
+  | "boolean" -> Agent_sdk.Types.Boolean
+  | "array" -> Agent_sdk.Types.Array
+  | "object" -> Agent_sdk.Types.Object
+  | _ -> Agent_sdk.Types.String
+
+(** Extract OAS [tool_param list] from a MASC [input_schema] JSON object.
+
+    Reads ["properties"] and ["required"] fields from the JSON Schema.
+    Unknown types default to [String]. *)
+let params_of_json_schema (schema : Yojson.Safe.t) : Agent_sdk.Types.tool_param list =
+  let open Yojson.Safe.Util in
+  let props =
+    try schema |> member "properties" |> to_assoc
+    with _ -> []
+  in
+  let required_keys =
+    try schema |> member "required" |> to_list |> List.filter_map (fun j ->
+      try Some (to_string j) with _ -> None)
+    with _ -> []
+  in
+  List.filter_map (fun (key, prop) ->
+    try
+      let type_str =
+        try prop |> member "type" |> to_string
+        with _ -> "string"
+      in
+      let description =
+        try prop |> member "description" |> to_string
+        with _ -> ""
+      in
+      Some {
+        Agent_sdk.Types.name = key;
+        description;
+        param_type = param_type_of_string type_str;
+        required = List.mem key required_keys;
+      }
+    with _ -> None
+  ) props
+
+(** {1 OAS Tool.t Creation}
+
+    Create OAS [Tool.t] from MASC schema definition + dispatch handler.
+    This allows incremental migration: each tool can be converted independently. *)
+
+(** Create an OAS [Tool.t] from a MASC tool schema and a handler function.
+
+    [handler] receives raw JSON args and returns MASC [(bool * string)].
+    The bridge converts the result to OAS [tool_result] automatically.
+
+    {[
+      let oas_tool = oas_tool_of_masc
+        ~name:"masc_vote_create"
+        ~description:"Create a vote..."
+        ~input_schema:schema_json
+        (fun args -> handle_vote_create ctx args)
+    ]} *)
+let oas_tool_of_masc ~name ~description ~input_schema handler : Agent_sdk.Tool.t =
+  let parameters = params_of_json_schema input_schema in
+  let oas_handler json_args =
+    let success, msg = handler json_args in
+    to_oas_tool_result (success, msg)
+  in
+  Agent_sdk.Tool.create ~name ~description ~parameters oas_handler

--- a/lib/tool_bridge.mli
+++ b/lib/tool_bridge.mli
@@ -1,0 +1,44 @@
+(** OAS boundary adapter for tool results, schemas, and tool definitions.
+
+    Converts between MASC tool conventions [(bool * string)] and
+    OAS typed [{!Agent_sdk.Types.tool_result}].
+
+    Also converts MASC JSON schemas to OAS [{!Agent_sdk.Types.tool_param}] lists,
+    and creates OAS [{!Agent_sdk.Tool.t}] from MASC handler functions.
+
+    @since 2.95.1 — result conversion
+    @since 2.110.0 — schema conversion + OAS Tool.t creation *)
+
+(** {1 Result Conversion} *)
+
+val to_oas_tool_result :
+  ?recoverable:bool -> bool * string -> Agent_sdk.Types.tool_result
+(** Convert MASC [(success, message)] to OAS [tool_result].
+    [recoverable] defaults to [true] for error cases. *)
+
+val of_oas_tool_result : Agent_sdk.Types.tool_result -> bool * string
+(** Convert OAS [tool_result] back to MASC [(success, message)]. *)
+
+(** {1 Schema Conversion} *)
+
+val param_type_of_string : string -> Agent_sdk.Types.param_type
+(** Map JSON Schema type string to OAS [param_type].
+    Unknown types default to [String]. *)
+
+val params_of_json_schema : Yojson.Safe.t -> Agent_sdk.Types.tool_param list
+(** Extract OAS [tool_param list] from a MASC [input_schema] JSON object.
+    Reads ["properties"] and ["required"] fields. *)
+
+(** {1 OAS Tool.t Creation} *)
+
+val oas_tool_of_masc :
+  name:string ->
+  description:string ->
+  input_schema:Yojson.Safe.t ->
+  (Yojson.Safe.t -> bool * string) ->
+  Agent_sdk.Tool.t
+(** Create an OAS [Tool.t] from a MASC tool name, description,
+    JSON input schema, and handler function.
+
+    The handler receives raw JSON args and returns MASC [(bool * string)].
+    Result conversion is applied automatically via {!to_oas_tool_result}. *)


### PR DESCRIPTION
## Summary

MASC→OAS 경계 정리의 첫 단추. 109개 MASC tool 모듈을 OAS `Tool.create`로 점진 이전하기 위한 bridge 함수 추가.

**추가된 함수:**
- `params_of_json_schema` — MASC JSON Schema → OAS `tool_param list` 변환
- `oas_tool_of_masc` — MASC 핸들러 + 스키마 → OAS `Tool.t` 생성
- `.mli` 인터페이스 추가

**기존 함수 (유지):**
- `to_oas_tool_result` — `(bool * string)` → OAS `tool_result`
- `of_oas_tool_result` — OAS `tool_result` → `(bool * string)`

## Architecture Context

OAS #144 (generic provider support) 진행과 병렬로, MASC 도구 정의를 OAS `Tool.t`로 이전하는 작업의 기반.

```
현재: MASC dispatch (match name → handler) + JSON schema (별도 파일)
목표: OAS Tool.t (schema + handler 통합) + MASC는 MCP thin wrapper만 유지
```

## Test plan

- [x] `dune build` 성공
- [ ] `make test` 통과 확인
- [ ] PoC: tool_vote를 oas_tool_of_masc로 변환하는 후속 커밋

🤖 Generated with [Claude Code](https://claude.com/claude-code)