### PR TITLE
feat: OAS Tool.t PoC (tool_vote) + work.ts unicode escape 재수정

### DIFF
--- a/dashboard/src/components/work.ts
+++ b/dashboard/src/components/work.ts
@@ -11,10 +11,10 @@ import { Planning } from './goals'
 type WorkSection = 'board' | 'governance' | 'evidence' | 'planning'
 
 const SECTIONS: { id: WorkSection; label: string; tooltip: string }[] = [
-  { id: 'board', label: '\uAC8C\uC2DC\uD310', tooltip: '\uC5D0\uC774\uC804\uD2B8 \uAC04 \uC18C\uD1B5\uACFC \uC9C0\uC2DD \uACF5\uC720' },
-  { id: 'governance', label: '\uAC70\uBC84\uB10C\uC2A4', tooltip: '\uC758\uC0AC\uACB0\uC815 \uAE30\uB85D\uACFC \uD310\uACB0' },
-  { id: 'evidence', label: '\uADFC\uAC70', tooltip: '\uC791\uC5C5 \uC99D\uAC70\uC640 \uAC80\uC99D \uACB0\uACFC' },
-  { id: 'planning', label: '\uACC4\uD68D', tooltip: '\uC7A5\uAE30 \uBAA9\uD45C\uC640 \uBA54\uD2B8\uB9AD \uB8E8\uD504' },
+  { id: 'board', label: '게시판', tooltip: '에이전트 간 소통과 지식 공유' },
+  { id: 'governance', label: '거버넌스', tooltip: '의사결정 기록과 판결' },
+  { id: 'evidence', label: '근거', tooltip: '작업 증거와 검증 결과' },
+  { id: 'planning', label: '계획', tooltip: '장기 목표와 메트릭 루프' },
 ]
 
 function isWorkSection(v: string | undefined): v is WorkSection {

--- a/lib/tool_vote.ml
+++ b/lib/tool_vote.ml
@@ -1,4 +1,7 @@
-(** Vote tools - Consensus voting system *)
+(** Vote tools - Consensus voting system.
+
+    Provides both MASC dispatch convention and OAS [Tool.t] interface.
+    OAS tools are created via {!Tool_bridge.oas_tool_of_masc}. *)
 
 open Tool_args
 
@@ -40,3 +43,57 @@ let dispatch ctx ~name ~args : result option =
   | "masc_vote_status" -> Some (handle_vote_status ctx args)
   | "masc_votes" -> Some (handle_votes ctx args)
   | _ -> None
+
+(** {1 OAS Tool.t Interface}
+
+    Creates OAS [Agent_sdk.Tool.t] list from vote handlers.
+    Context is captured via closure at creation time. *)
+
+let[@warning "-32"] oas_tools (ctx : context) : Agent_sdk.Tool.t list =
+  let mk = Tool_bridge.oas_tool_of_masc in
+  [
+    mk ~name:"masc_vote_create"
+      ~description:"Create a vote for multi-agent consensus on a decision."
+      ~input_schema:(`Assoc [
+        ("type", `String "object");
+        ("properties", `Assoc [
+          ("proposer", `Assoc [("type", `String "string"); ("description", `String "Your agent name")]);
+          ("topic", `Assoc [("type", `String "string"); ("description", `String "What to vote on")]);
+          ("options", `Assoc [("type", `String "array"); ("items", `Assoc [("type", `String "string")]); ("description", `String "Vote options")]);
+          ("required_votes", `Assoc [("type", `String "integer"); ("description", `String "Votes needed to resolve"); ("default", `Int 2)]);
+        ]);
+        ("required", `List [`String "proposer"; `String "topic"; `String "options"]);
+      ])
+      (fun args -> handle_vote_create ctx args);
+
+    mk ~name:"masc_vote_cast"
+      ~description:"Cast your vote on an active proposal."
+      ~input_schema:(`Assoc [
+        ("type", `String "object");
+        ("properties", `Assoc [
+          ("vote_id", `Assoc [("type", `String "string"); ("description", `String "Vote ID")]);
+          ("choice", `Assoc [("type", `String "string"); ("description", `String "Your choice")]);
+        ]);
+        ("required", `List [`String "vote_id"; `String "choice"]);
+      ])
+      (fun args -> handle_vote_cast ctx args);
+
+    mk ~name:"masc_vote_status"
+      ~description:"Get the current tally and result of a specific vote."
+      ~input_schema:(`Assoc [
+        ("type", `String "object");
+        ("properties", `Assoc [
+          ("vote_id", `Assoc [("type", `String "string"); ("description", `String "Vote ID")]);
+        ]);
+        ("required", `List [`String "vote_id"]);
+      ])
+      (fun args -> handle_vote_status ctx args);
+
+    mk ~name:"masc_votes"
+      ~description:"List all votes in the current room."
+      ~input_schema:(`Assoc [
+        ("type", `String "object");
+        ("properties", `Assoc []);
+      ])
+      (fun args -> handle_votes ctx args);
+  ]


### PR DESCRIPTION
## Summary

1. **tool_vote OAS PoC**: `Tool_bridge.oas_tool_of_masc`를 사용해 vote 도구 4개를 OAS `Tool.t`로 변환하는 `oas_tools` 함수 추가. 기존 `dispatch` 패턴은 그대로 유지하면서 OAS 인터페이스를 병렬 제공. 109개 도구 점진 이전의 첫 번째 증명.

2. **work.ts unicode escape 재수정**: PR #1502에서 tooltip 추가 시 다시 들어간 unicode escape를 UTF-8 한국어로 교체.

## Files

| 파일 | 변경 |
|------|------|
| `lib/tool_vote.ml` | `oas_tools` 함수 추가 (OAS Tool.t list 생성) |
| `dashboard/src/components/work.ts` | unicode escape → UTF-8 한국어 (label + tooltip) |

## Test plan

- [x] `dune build` 성공
- [ ] `make test` 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)