### PR TITLE
refactor(mode): hardcode Mode to Full, remove mode switching

### DIFF
--- a/lib/config.ml
+++ b/lib/config.ml
@@ -11,8 +11,7 @@ type t = {
   enabled_categories : category list;
 }
 
-(** Default configuration — Full mode exposes all tools.
-    Agents can switch to a narrower mode via masc_switch_mode. *)
+(** Default configuration — always Full mode. Mode switching has been removed. *)
 let default = {
   mode = Full;
   enabled_categories = categories_for_mode Full;
@@ -32,30 +31,8 @@ let to_json config =
     ("enabled_categories", categories_to_json config.enabled_categories);
   ]
 
-(** Parse config from JSON *)
-let of_json json =
-  try
-    let mode_str =
-      match Yojson.Safe.Util.member "mode" json with
-      | `String s -> s
-      | _ -> "full"
-    in
-    let mode =
-      match mode_of_string mode_str with
-      | Some m -> m
-      | None -> Full
-    in
-    let enabled_categories =
-      match mode with
-      | Custom ->
-        let cats_json = Yojson.Safe.Util.member "enabled_categories" json in
-        categories_of_json cats_json
-      | _ -> categories_for_mode mode
-    in
-    { mode; enabled_categories }
-  with e ->
-    Log.Misc.error "config of_json failed: %s" (Printexc.to_string e);
-    default
+(** Parse config from JSON — always returns Full mode regardless of stored value. *)
+let of_json _json = default
 
 (** Load config from file *)
 let load room_path =
@@ -207,39 +184,17 @@ let enabled_tool_schemas ?(include_hidden = false) ?(include_deprecated = false)
          if include_hidden then true
          else Mode.is_tool_enabled enabled_categories schema.name)
 
-(** Switch to a preset mode *)
-let switch_mode ?actor ?source room_path mode =
-  let previous_config = load room_path in
-  let enabled_categories = categories_for_mode mode in
-  let config = { mode; enabled_categories } in
-  save room_path config;
-  append_mode_change_audit ~actor ~source ~room_path ~previous_config ~config;
-  config
+(** Switch mode — no-op, always returns Full. *)
+let switch_mode ?actor:_ ?source:_ _room_path _mode = default
 
-(** Enable specific categories (switches to Custom mode) *)
-let set_categories ?actor ?source room_path categories =
-  let previous_config = load room_path in
-  let config = { mode = Custom; enabled_categories = categories } in
-  save room_path config;
-  append_mode_change_audit ~actor ~source ~room_path ~previous_config ~config;
-  config
+(** Set categories — no-op, always returns Full. *)
+let set_categories ?actor:_ ?source:_ _room_path _categories = default
 
-(** Enable a category *)
-let enable_category ?actor ?source room_path category =
-  let current = load room_path in
-  let new_cats =
-    if List.mem category current.enabled_categories then
-      current.enabled_categories
-    else
-      category :: current.enabled_categories
-  in
-  set_categories ?actor ?source room_path new_cats
+(** Enable a category — no-op, always returns Full. *)
+let enable_category ?actor:_ ?source:_ _room_path _category = default
 
-(** Disable a category *)
-let disable_category ?actor ?source room_path category =
-  let current = load room_path in
-  let new_cats = List.filter (fun c -> c <> category) current.enabled_categories in
-  set_categories ?actor ?source room_path new_cats
+(** Disable a category — no-op, always returns Full. *)
+let disable_category ?actor:_ ?source:_ _room_path _category = default
 
 (** Get current config summary as JSON for tool response *)
 let get_config_summary room_path =
@@ -259,12 +214,5 @@ let get_config_summary room_path =
     ("enabled_tool_count", `Int tool_count);
     ("placeholder_tools_enabled", `Bool (Tool_catalog.placeholder_tools_enabled ()));
     ("hidden_placeholder_tools", `List (List.map (fun s -> `String s) hidden_placeholder_tools));
-    ("available_modes", `List [
-      `Assoc [("name", `String "minimal"); ("description", `String (mode_description Minimal))];
-      `Assoc [("name", `String "standard"); ("description", `String (mode_description Standard))];
-      `Assoc [("name", `String "parallel"); ("description", `String (mode_description Parallel))];
-      `Assoc [("name", `String "coding"); ("description", `String (mode_description Coding))];
-      `Assoc [("name", `String "full"); ("description", `String (mode_description Full))];
-      `Assoc [("name", `String "solo"); ("description", `String (mode_description Solo))];
-    ]);
+    ("mode_note", `String "Mode is hardcoded to Full. Mode switching has been removed.");
   ]

--- a/test/test_config_coverage.ml
+++ b/test/test_config_coverage.ml
@@ -75,12 +75,12 @@ let test_of_json_valid () =
     ("enabled_categories", `List []);
   ] in
   let config = Config.of_json json in
-  check bool "parsed mode" true (config.mode = Mode.Standard)
+  check bool "always Full" true (config.mode = Mode.Full)
 
 let test_of_json_minimal () =
   let json = `Assoc [("mode", `String "minimal")] in
   let config = Config.of_json json in
-  check bool "minimal mode" true (config.mode = Mode.Minimal)
+  check bool "always Full" true (config.mode = Mode.Full)
 
 let test_of_json_full () =
   let json = `Assoc [("mode", `String "full")] in
@@ -90,12 +90,12 @@ let test_of_json_full () =
 let test_of_json_parallel () =
   let json = `Assoc [("mode", `String "parallel")] in
   let config = Config.of_json json in
-  check bool "parallel mode" true (config.mode = Mode.Parallel)
+  check bool "always Full" true (config.mode = Mode.Full)
 
 let test_of_json_solo () =
   let json = `Assoc [("mode", `String "solo")] in
   let config = Config.of_json json in
-  check bool "solo mode" true (config.mode = Mode.Solo)
+  check bool "always Full" true (config.mode = Mode.Full)
 
 let test_of_json_invalid_mode () =
   let json = `Assoc [("mode", `String "invalid")] in
@@ -113,7 +113,7 @@ let test_of_json_custom_with_categories () =
     ("enabled_categories", `List [`String "task"; `String "agent"]);
   ] in
   let config = Config.of_json json in
-  check bool "custom mode" true (config.mode = Mode.Custom)
+  check bool "always Full" true (config.mode = Mode.Full)
 
 (* ============================================================
    Roundtrip Tests
@@ -131,7 +131,7 @@ let test_roundtrip_minimal () =
   } in
   let json = Config.to_json config in
   let config' = Config.of_json json in
-  check bool "roundtrip minimal" true (config'.mode = Mode.Minimal)
+  check bool "roundtrip always Full" true (config'.mode = Mode.Full)
 
 let test_roundtrip_full () =
   let config : Config.t = {
@@ -186,102 +186,31 @@ let test_save_creates_file () =
    switch_mode Tests
    ============================================================ *)
 
-let test_switch_mode_minimal () =
+let test_switch_mode_noop () =
   let dir = setup_temp_dir () in
   let config = Config.switch_mode dir Mode.Minimal in
   cleanup_temp_dir dir;
-  check bool "switched to Minimal" true (config.mode = Mode.Minimal)
-
-let test_switch_mode_full () =
-  let dir = setup_temp_dir () in
-  let config = Config.switch_mode dir Mode.Full in
-  cleanup_temp_dir dir;
-  check bool "switched to Full" true (config.mode = Mode.Full)
-
-let test_switch_mode_persists () =
-  let dir = setup_temp_dir () in
-  let _ = Config.switch_mode dir Mode.Parallel in
-  let loaded = Config.load dir in
-  cleanup_temp_dir dir;
-  check bool "persisted Parallel" true (loaded.mode = Mode.Parallel)
-
-let test_switch_mode_writes_audit_event () =
-  let dir = setup_temp_dir () in
-  let _ =
-    Config.switch_mode ~actor:"tester" ~source:"masc_switch_mode" dir
-      Mode.Minimal
-  in
-  let audit_path = Filename.concat dir "audit.jsonl" in
-  let json =
-    match Fs_compat.load_jsonl audit_path with
-    | first :: _ -> first
-    | [] -> fail "expected audit event"
-  in
-  let open Yojson.Safe.Util in
-  check string "event_type" "mode_change"
-    (json |> member "event_type" |> to_string);
-  check string "agent" "tester" (json |> member "agent" |> to_string);
-  check string "source" "masc_switch_mode"
-    (json |> member "source" |> to_string);
-  check string "previous_mode" "full"
-    (json |> member "previous_mode" |> to_string);
-  check string "mode" "minimal" (json |> member "mode" |> to_string);
-  cleanup_temp_dir dir
+  check bool "always Full" true (config.mode = Mode.Full)
 
 (* ============================================================
    set_categories Tests
    ============================================================ *)
 
-let test_set_categories () =
+let test_set_categories_noop () =
   let dir = setup_temp_dir () in
-  let cats = [Mode.Core; Mode.Comm] in
-  let config = Config.set_categories dir cats in
+  let config = Config.set_categories dir [Mode.Core; Mode.Comm] in
   cleanup_temp_dir dir;
-  check bool "Custom mode" true (config.mode = Mode.Custom);
-  check int "2 categories" 2 (List.length config.enabled_categories)
-
-let test_set_categories_persists () =
-  let dir = setup_temp_dir () in
-  let cats = [Mode.Core] in
-  let _ = Config.set_categories dir cats in
-  let loaded = Config.load dir in
-  cleanup_temp_dir dir;
-  check bool "Custom mode loaded" true (loaded.mode = Mode.Custom)
+  check bool "always Full" true (config.mode = Mode.Full)
 
 (* ============================================================
    enable_category / disable_category Tests
    ============================================================ *)
 
-let test_enable_category () =
+let test_enable_disable_noop () =
   let dir = setup_temp_dir () in
-  let _ = Config.set_categories dir [Mode.Core] in
   let config = Config.enable_category dir Mode.Comm in
   cleanup_temp_dir dir;
-  check bool "has Comm" true (List.mem Mode.Comm config.enabled_categories);
-  check bool "has Core" true (List.mem Mode.Core config.enabled_categories)
-
-let test_enable_category_duplicate () =
-  let dir = setup_temp_dir () in
-  let _ = Config.set_categories dir [Mode.Core] in
-  let config = Config.enable_category dir Mode.Core in
-  cleanup_temp_dir dir;
-  let core_count = List.length (List.filter (fun c -> c = Mode.Core) config.enabled_categories) in
-  check int "no duplicate" 1 core_count
-
-let test_disable_category () =
-  let dir = setup_temp_dir () in
-  let _ = Config.set_categories dir [Mode.Core; Mode.Comm] in
-  let config = Config.disable_category dir Mode.Core in
-  cleanup_temp_dir dir;
-  check bool "removed Core" false (List.mem Mode.Core config.enabled_categories);
-  check bool "kept Comm" true (List.mem Mode.Comm config.enabled_categories)
-
-let test_disable_category_not_present () =
-  let dir = setup_temp_dir () in
-  let _ = Config.set_categories dir [Mode.Core] in
-  let config = Config.disable_category dir Mode.Comm in
-  cleanup_temp_dir dir;
-  check bool "Core still there" true (List.mem Mode.Core config.enabled_categories)
+  check bool "always Full" true (config.mode = Mode.Full)
 
 (* ============================================================
    get_config_summary Tests
@@ -305,13 +234,13 @@ let test_get_config_summary_has_tool_count () =
   | `Assoc fields -> check bool "has enabled_tool_count" true (List.mem_assoc "enabled_tool_count" fields)
   | _ -> fail "expected Assoc"
 
-let test_get_config_summary_has_available_modes () =
+let test_get_config_summary_has_mode_note () =
   let dir = setup_temp_dir () in
   Config.save dir Config.default;
   let summary = Config.get_config_summary dir in
   cleanup_temp_dir dir;
   match summary with
-  | `Assoc fields -> check bool "has available_modes" true (List.mem_assoc "available_modes" fields)
+  | `Assoc fields -> check bool "has mode_note" true (List.mem_assoc "mode_note" fields)
   | _ -> fail "expected Assoc"
 
 let test_get_config_summary_has_categories () =
@@ -392,25 +321,18 @@ let () =
       test_case "save creates file" `Quick test_save_creates_file;
     ];
     "switch_mode", [
-      test_case "minimal" `Quick test_switch_mode_minimal;
-      test_case "full" `Quick test_switch_mode_full;
-      test_case "persists" `Quick test_switch_mode_persists;
-      test_case "writes audit event" `Quick test_switch_mode_writes_audit_event;
+      test_case "noop returns Full" `Quick test_switch_mode_noop;
     ];
     "set_categories", [
-      test_case "basic" `Quick test_set_categories;
-      test_case "persists" `Quick test_set_categories_persists;
+      test_case "noop returns Full" `Quick test_set_categories_noop;
     ];
     "enable_disable", [
-      test_case "enable" `Quick test_enable_category;
-      test_case "enable duplicate" `Quick test_enable_category_duplicate;
-      test_case "disable" `Quick test_disable_category;
-      test_case "disable not present" `Quick test_disable_category_not_present;
+      test_case "noop returns Full" `Quick test_enable_disable_noop;
     ];
     "get_config_summary", [
       test_case "has mode" `Quick test_get_config_summary_has_mode;
       test_case "has tool count" `Quick test_get_config_summary_has_tool_count;
-      test_case "has available modes" `Quick test_get_config_summary_has_available_modes;
+      test_case "has mode note" `Quick test_get_config_summary_has_mode_note;
       test_case "has categories" `Quick test_get_config_summary_has_categories;
       test_case "has mode description" `Quick test_get_config_summary_mode_description;
     ];

--- a/test/test_misc_coverage.ml
+++ b/test/test_misc_coverage.ml
@@ -176,7 +176,7 @@ let test_config_of_json () =
     ("mode", `String "standard");
   ] in
   let c = Config.of_json json in
-  check bool "mode is Standard" true (c.mode = Mode.Standard)
+  check bool "always Full" true (c.mode = Mode.Full)
 
 let test_config_of_json_custom () =
   let json = `Assoc [
@@ -184,7 +184,7 @@ let test_config_of_json_custom () =
     ("enabled_categories", `List [`String "room"; `String "task"]);
   ] in
   let c = Config.of_json json in
-  check bool "mode is Custom" true (c.mode = Mode.Custom)
+  check bool "always Full" true (c.mode = Mode.Full)
 
 let test_config_of_json_invalid () =
   let json = `String "invalid" in

--- a/test/test_tool_control_coverage.ml
+++ b/test/test_tool_control_coverage.ml
@@ -93,7 +93,7 @@ let () = test "dispatch_switch_mode" (fun () ->
       let mode =
         json |> Yojson.Safe.Util.member "mode" |> Yojson.Safe.Util.to_string
       in
-      assert (mode = "minimal")
+      assert (mode = "full")
   | None -> failwith "dispatch returned None"
 )
 

--- a/test/test_tool_misc_coverage.ml
+++ b/test/test_tool_misc_coverage.ml
@@ -174,9 +174,7 @@ let () = test "dispatch_tool_admin_update_mode" (fun () ->
       let json = parse_json result in
       assert (Yojson.Safe.Util.(json |> member "section" |> to_string) = "mode");
       let cfg = Config.load (Room.masc_dir ctx.config) in
-      assert (cfg.mode = Mode.Custom);
-      assert (List.mem Mode.Core cfg.enabled_categories);
-      assert (List.mem Mode.Auth cfg.enabled_categories)
+      assert (cfg.mode = Mode.Full)
   | None -> failwith "dispatch returned None"
 )
 

--- a/test/test_tool_unified.ml
+++ b/test/test_tool_unified.ml
@@ -53,8 +53,8 @@ let () =
               let open Yojson.Safe.Util in
               let dist = report |> member "tier_distribution" in
               let _ = dist |> member "essential" |> to_int in
-              let _ = dist |> member "standard" |> to_int in
-              let _ = dist |> member "full" |> to_int in
+              let _ = dist |> member "standard_only" |> to_int in
+              let _ = dist |> member "full_only" |> to_int in
               ());
         ] );
     ]


### PR DESCRIPTION
## Summary

- Mode를 항상 Full로 고정. 모드 전환 기능 제거.
  - `Config.default`: Full
  - `Config.of_json`: 저장된 mode 무시, 항상 Full 반환
  - `switch_mode`/`set_categories`/`enable_category`/`disable_category`: no-op
  - `get_config_summary`: `available_modes` → `mode_note` 교체
- `tier_distribution` 테스트 키 불일치 수정 (pre-existing bug)
- 6개 테스트 파일 업데이트

## Test plan

- [x] `dune build` 성공
- [x] Mode 관련 테스트 전부 수정
- [ ] 외부 모델 리뷰

🤖 Generated with [Claude Code](https://claude.com/claude-code)