### PR TITLE
fix(dashboard): tier distribution NaN — API 필드명 불일치 수정

### DIFF
--- a/dashboard/src/components/tool-metrics.ts
+++ b/dashboard/src/components/tool-metrics.ts
@@ -60,27 +60,29 @@ function BarChart({ items, maxCount }: { items: ToolMetricsTopEntry[]; maxCount:
   `
 }
 
-function TierDistribution({ dist }: { dist: { essential: number; standard: number; full: number } }) {
-  const total = dist.full
-  const essentialPct = total > 0 ? ((dist.essential / total) * 100).toFixed(1) : '0'
-  const standardPct = total > 0 ? ((dist.standard / total) * 100).toFixed(1) : '0'
-  const fullOnlyCount = total - dist.standard
-  const fullOnlyPct = total > 0 ? ((fullOnlyCount / total) * 100).toFixed(1) : '0'
+function TierDistribution({ dist }: { dist: Record<string, number> }) {
+  const total = dist.total ?? dist.full ?? 0
+  const essential = dist.essential ?? 0
+  const standardOnly = dist.standard_only ?? dist.standard ?? 0
+  const fullOnly = dist.full_only ?? (total - standardOnly) ?? 0
+  const essentialPct = total > 0 ? ((essential / total) * 100).toFixed(1) : '0'
+  const standardPct = total > 0 ? ((standardOnly / total) * 100).toFixed(1) : '0'
+  const fullOnlyPct = total > 0 ? ((fullOnly / total) * 100).toFixed(1) : '0'
   return html`
     <div class="tier-dist">
       <div class="tier-dist-row">
         <span class="tier-dist-label badge-essential">필수</span>
-        <span class="tier-dist-count">${dist.essential}</span>
+        <span class="tier-dist-count">${essential}</span>
         <span class="tier-dist-pct">${essentialPct}%</span>
       </div>
       <div class="tier-dist-row">
         <span class="tier-dist-label badge-standard">표준</span>
-        <span class="tier-dist-count">${dist.standard}</span>
+        <span class="tier-dist-count">${standardOnly}</span>
         <span class="tier-dist-pct">${standardPct}%</span>
       </div>
       <div class="tier-dist-row">
         <span class="tier-dist-label badge-full">전체 전용</span>
-        <span class="tier-dist-count">${fullOnlyCount}</span>
+        <span class="tier-dist-count">${fullOnly}</span>
         <span class="tier-dist-pct">${fullOnlyPct}%</span>
       </div>
     </div>


### PR DESCRIPTION
## Summary

도구 사용 현황의 계층 분포에서 **전체 전용: NaN, 0%** 표시되던 버그 수정.

**원인**: API가 `{ essential, standard_only, full_only, total }`을 반환하는데 프론트엔드가 `{ essential, standard, full }`을 기대. `dist.standard`와 `dist.full`이 `undefined` → NaN 전파.

**수정**: `Record<string, number>` 타입으로 변경하고 fallback lookup (`standard_only ?? standard`, `full_only ?? full`) 적용.

## Test plan

- [ ] 대시보드에서 계층 분포가 숫자로 정상 표시 (필수 21, 표준 37, 전체 전용 344)
- [ ] NaN이 더 이상 표시되지 않음

🤖 Generated with [Claude Code](https://claude.com/claude-code)