### PR TITLE
refactor: remove CLI spawn artifacts (proc_mgr, cli_adapters, spawn_config)

### DIFF
--- a/lib/chain_native_eio.ml
+++ b/lib/chain_native_eio.ml
@@ -265,9 +265,9 @@ let model_runner_of_string raw =
 let call_spawn_model (runtime : runtime) ~agent_name ?model_override ~prompt ~timeout_sec () =
   match runtime.mcp_state.Mcp_server.proc_mgr with
   | None -> Error "spawn runtime unavailable"
-  | Some proc_mgr ->
+  | Some _proc_mgr ->
       let result =
-        Spawn_eio.spawn ~sw:runtime.sw ~proc_mgr ~agent_name ~prompt
+        Spawn_eio.spawn ~sw:runtime.sw ~agent_name ~prompt
           ~timeout_seconds:timeout_sec
           ?working_dir:(Some runtime.config.base_path)
           ?model_override

--- a/lib/handover_eio.ml
+++ b/lib/handover_eio.ml
@@ -298,7 +298,7 @@ let build_successor_prompt (h : handover_record) ~additional_instructions : stri
 Begin work now.|} dna instructions
 
 (** Claim a handover and spawn the successor agent *)
-let claim_and_spawn ~sw ~fs ~proc_mgr config ~handover_id ~agent_name ?additional_instructions ?timeout_seconds () 
+let claim_and_spawn ~sw ~fs ~proc_mgr:_ config ~handover_id ~agent_name ?additional_instructions ?timeout_seconds () 
     : (Spawn_eio.spawn_result, string) result =
   match claim_handover ~fs config ~handover_id ~agent_name with
   | Error e -> Error e
@@ -306,7 +306,6 @@ let claim_and_spawn ~sw ~fs ~proc_mgr config ~handover_id ~agent_name ?additiona
       let prompt = build_successor_prompt h ~additional_instructions in
       let result = Spawn_eio.spawn
         ~sw
-        ~proc_mgr
         ~agent_name
         ~prompt
         ?timeout_seconds

--- a/lib/mitosis_helpers.ml
+++ b/lib/mitosis_helpers.ml
@@ -57,9 +57,9 @@ let spawn_eio_to_spawn (r : Spawn_eio.spawn_result) : Spawn.spawn_result =
 (** Create non-blocking spawn_fn when Eio context is available *)
 let make_spawn_fn ~ctx ~agent_name ~timeout_seconds : (prompt:string -> Spawn.spawn_result) =
   match ctx.sw, ctx.proc_mgr with
-  | Some sw, Some pm ->
+  | Some sw, Some _pm ->
       (fun ~prompt ->
-        let result = Spawn_eio.spawn ~sw ~proc_mgr:pm ~agent_name ~prompt
+        let result = Spawn_eio.spawn ~sw ~agent_name ~prompt
           ~timeout_seconds ~room_config:ctx.config ()
         in
         spawn_eio_to_spawn result)

--- a/lib/orchestrator.ml
+++ b/lib/orchestrator.ml
@@ -116,7 +116,7 @@ You have access to MASC MCP tools via mcp__masc__* prefix.
 Start by calling mcp__masc__masc_status to see the current room state.|}
 
 (** Spawn the orchestrator agent (Eio-friendly, runs in a domain if provided) *)
-let spawn_orchestrator ~sw ~proc_mgr ?domain_mgr config room_config =
+let spawn_orchestrator ~sw ~proc_mgr:_ ?domain_mgr config room_config =
   (* TOCTOU defense: re-check pause before spawn *)
   if Room.is_paused room_config then begin
     Log.Orchestrator.debug "room paused before spawn, aborting";
@@ -136,7 +136,6 @@ let spawn_orchestrator ~sw ~proc_mgr ?domain_mgr config room_config =
   let run () =
     Spawn_eio.spawn
       ~sw
-      ~proc_mgr
       ~agent_name:config.orchestrator_agent
       ~prompt
       ~timeout_seconds:config.agent_timeout_s

--- a/lib/perpetual_loop.ml
+++ b/lib/perpetual_loop.ml
@@ -208,7 +208,7 @@ let calculate_cost (usage : Llm_client.token_usage) (model : Llm_client.model_sp
     Returns the spawn result for the caller to interpret. *)
 let coding_turn ~config ~state =
   match config.coding_sw, config.coding_proc_mgr with
-  | Some sw, Some proc_mgr ->
+  | Some sw, Some _proc_mgr ->
     let goal = config.initial_goal in
     let turn = state.turn_count in
     (* Extract latest state block from context messages for progress tracking *)
@@ -236,7 +236,7 @@ let coding_turn ~config ~state =
     in
     let prompt_with_lifecycle = prompt ^ Spawn_eio.masc_lifecycle_suffix in
     let result = Spawn_eio.spawn
-      ~sw ~proc_mgr
+      ~sw
       ~agent_name:config.coding_agent
       ~prompt:prompt_with_lifecycle
       ~timeout_seconds:config.coding_timeout_s

--- a/lib/provider_adapter.ml
+++ b/lib/provider_adapter.ml
@@ -1,7 +1,6 @@
 type runtime_kind =
   | Local
   | Direct_api
-  | Cli_agent
 
 type provider_family =
   | Claude_family
@@ -15,19 +14,10 @@ type provider_family =
 type auth_mode =
   | No_auth
   | Api_key of string
-  | Cli_cached_login
   | Vertex_adc of {
       project_env : string;
       location_env : string;
     }
-
-type prompt_transport =
-  | Prompt_stdin
-  | Prompt_arg of string
-
-type output_contract =
-  | Human_stdout
-  | Json_stdout
 
 type voice_transport =
   | Voice_openai_compat
@@ -40,14 +30,6 @@ type adapter = {
   provider_family : provider_family;
   auth_mode : auth_mode;
   aliases : string list;
-}
-
-type cli_adapter = {
-  meta : adapter;
-  command : string;
-  prompt_transport : prompt_transport;
-  output_contract : output_contract;
-  default_allowed_mcp_servers : string list;
 }
 
 type voice_adapter = {
@@ -78,7 +60,6 @@ let google_cloud_location_env = "GOOGLE_CLOUD_LOCATION"
 let string_of_runtime_kind = function
   | Local -> "local"
   | Direct_api -> "direct_api"
-  | Cli_agent -> "cli_agent"
 
 let string_of_provider_family = function
   | Claude_family -> "claude"
@@ -92,17 +73,8 @@ let string_of_provider_family = function
 let string_of_auth_mode = function
   | No_auth -> "none"
   | Api_key env_name -> "api_key:" ^ env_name
-  | Cli_cached_login -> "cli_cached_login"
   | Vertex_adc { project_env; location_env } ->
       "vertex_adc:" ^ project_env ^ ":" ^ location_env
-
-let string_of_prompt_transport = function
-  | Prompt_stdin -> "stdin"
-  | Prompt_arg flag -> "arg:" ^ flag
-
-let string_of_output_contract = function
-  | Human_stdout -> "human_stdout"
-  | Json_stdout -> "json_stdout"
 
 let string_of_voice_transport = function
   | Voice_openai_compat -> "openai_compat"
@@ -162,52 +134,6 @@ let direct_adapters =
     };
   ]
 
-let cli_adapters =
-  [
-    {
-      meta =
-        {
-          canonical_name = "claude";
-          runtime_kind = Cli_agent;
-          provider_family = Claude_family;
-          auth_mode = Cli_cached_login;
-          aliases = [ "claude"; "claude-code" ];
-        };
-      command = "claude --output-format json -p";
-      prompt_transport = Prompt_stdin;
-      output_contract = Json_stdout;
-      default_allowed_mcp_servers = [ "masc" ];
-    };
-    {
-      meta =
-        {
-          canonical_name = "codex";
-          runtime_kind = Cli_agent;
-          provider_family = OpenAI_family;
-          auth_mode = Cli_cached_login;
-          aliases = [ "codex"; "codex-cli" ];
-        };
-      command = "codex exec --json";
-      prompt_transport = Prompt_stdin;
-      output_contract = Json_stdout;
-      default_allowed_mcp_servers = [ "masc" ];
-    };
-    {
-      meta =
-        {
-          canonical_name = "gemini";
-          runtime_kind = Cli_agent;
-          provider_family = Gemini_family;
-          auth_mode = Cli_cached_login;
-          aliases = [ "gemini"; "gemini-cli" ];
-        };
-      command = "gemini --yolo --output-format json";
-      prompt_transport = Prompt_arg "-p";
-      output_contract = Json_stdout;
-      default_allowed_mcp_servers = [ "masc" ];
-    };
-  ]
-
 let voice_openai_compat_adapter =
   {
     canonical_name = "voice-openai-compat";
@@ -249,17 +175,9 @@ let resolve_direct_adapter label =
     (fun (adapter : adapter) ->
       List.exists (fun alias -> normalize_label alias = normalized) adapter.aliases)
     direct_adapters
-let resolve_cli_adapter label =
-  let normalized = normalize_label label in
-  List.find_opt
-    (fun adapter ->
-      List.exists
-        (fun alias -> normalize_label alias = normalized)
-        adapter.meta.aliases)
-    cli_adapters
 
-let resolve_cli_canonical_name label =
-  Option.map (fun adapter -> adapter.meta.canonical_name) (resolve_cli_adapter label)
+let resolve_direct_canonical_name label =
+  Option.map (fun (adapter : adapter) -> adapter.canonical_name) (resolve_direct_adapter label)
 
 let resolve_voice_adapter label =
   let normalized = normalize_label label in

--- a/lib/spawn.ml
+++ b/lib/spawn.ml
@@ -210,7 +210,7 @@ let default_configs = [
 (** Get spawn config for agent *)
 let get_config agent_name =
   let canonical =
-    match Provider_adapter.resolve_cli_canonical_name agent_name with
+    match Provider_adapter.resolve_direct_canonical_name agent_name with
     | Some value -> value
     | None -> agent_name
   in
@@ -220,7 +220,7 @@ let get_config agent_name =
 let build_mcp_args agent_name tools =
   if tools = [] then []
   else
-    match Provider_adapter.resolve_cli_canonical_name agent_name |> Option.value ~default:agent_name with
+    match Provider_adapter.resolve_direct_canonical_name agent_name |> Option.value ~default:agent_name with
   | "claude" ->
     (* Claude: --allowedTools "tool1,tool2,..." *)
     let tools_str = String.concat "," tools in
@@ -236,7 +236,7 @@ let build_mcp_args agent_name tools =
   | _ -> []
 
 let build_prompt_args agent_name prompt =
-  match Provider_adapter.resolve_cli_canonical_name agent_name |> Option.value ~default:agent_name with
+  match Provider_adapter.resolve_direct_canonical_name agent_name |> Option.value ~default:agent_name with
   | "gemini" -> ["-p"; prompt]
   | _ -> []
 

--- a/lib/spawn_eio.ml
+++ b/lib/spawn_eio.ml
@@ -7,15 +7,6 @@
 
 module Oas = Agent_sdk
 
-(** Spawn configuration for an agent *)
-type spawn_config = {
-  agent_name: string;
-  command: string;
-  timeout_seconds: int;
-  working_dir: string option;
-  mcp_tools: string list;
-}
-
 (** Structured termination reason for subagent lifecycle tracking *)
 type termination_reason =
   | Task_completed
@@ -190,7 +181,7 @@ let make_error_result ~agent_name ~start_time ~exit_code ~output ~timeout_second
     - When room_config is provided, loads institution memory and injects it
     - New agents inherit: mission, values, patterns, onboarding steps
 *)
-let spawn ~sw ~proc_mgr:_ ~agent_name ~prompt ?timeout_seconds ?working_dir
+let spawn ~sw ~agent_name ~prompt ?timeout_seconds ?working_dir
     ?room_config ?runtime_agent_name ?runtime_model ?runtime_role
     ?runtime_session_id ?runtime_selection_note ?worker_run_id ?worker_class ?worker_size
     ?execution_scope ?thinking_enabled ?max_turns ?model_override:_ () : spawn_result =

--- a/lib/tool_async_spawn.ml
+++ b/lib/tool_async_spawn.ml
@@ -107,14 +107,13 @@ let handle_async_spawn (ctx : context) args : bool * string =
     match ctx.proc_mgr with
     | None ->
         (false, "proc_mgr unavailable (server not in Eio mode)")
-    | Some proc_mgr ->
+    | Some _proc_mgr ->
         let timeout_seconds = Safe_ops.json_int_opt "timeout_seconds" args in
         let working_dir = Safe_ops.json_string_opt "working_dir" args in
         let room_config = Some ctx.config in
         let run_fn () =
           Spawn_eio.spawn
             ~sw:ctx.sw
-            ~proc_mgr
             ~agent_name:agent_target
             ~prompt
             ?timeout_seconds

--- a/lib/tool_inline_dispatch.ml
+++ b/lib/tool_inline_dispatch.ml
@@ -391,9 +391,9 @@ let dispatch (ctx : context) ~(name : string) : result option =
       let constraints = Bounded.constraints_of_json constraints_json in
       let goal = Bounded.goal_of_json goal_json in
       (match state.Mcp_server.proc_mgr with
-       | Some pm ->
+       | Some _pm ->
            let spawn_fn agent_name prompt =
-             Spawn_eio.spawn ~sw ~proc_mgr:pm ~agent_name ~prompt
+             Spawn_eio.spawn ~sw ~agent_name ~prompt
                ~timeout_seconds:Env_config.Spawn.timeout_seconds
                ~room_config:state.Mcp_server.room_config ()
            in
@@ -649,9 +649,9 @@ Call masc_listen again to continue listening.
        | Error e -> Some (false, e)
        | Ok runtime_model ->
            (match state.Mcp_server.proc_mgr with
-            | Some pm ->
+            | Some _pm ->
                 let result =
-                  Spawn_eio.spawn ~sw ~proc_mgr:pm ~agent_name:spawn_agent_name
+                  Spawn_eio.spawn ~sw ~agent_name:spawn_agent_name
                     ~prompt ~timeout_seconds ?working_dir ?execution_scope
                     ~room_config:state.Mcp_server.room_config
                     ~runtime_model ()
@@ -733,9 +733,9 @@ Call masc_listen again to continue listening.
           match state.Mcp_server.proc_mgr with
           | None ->
               Some (false, "Process manager not available for mitosis spawn")
-          | Some pm ->
+          | Some _pm ->
               let spawn_fn ~prompt =
-                let result = Spawn_eio.spawn ~sw ~proc_mgr:pm ~agent_name:target_agent
+                let result = Spawn_eio.spawn ~sw ~agent_name:target_agent
                   ~prompt ~timeout_seconds:Env_config.Spawn.timeout_seconds
                   ~room_config:state.Mcp_server.room_config ()
                 in

--- a/lib/tool_inline_dispatch_extra.ml
+++ b/lib/tool_inline_dispatch_extra.ml
@@ -155,9 +155,9 @@ let dispatch ~config ~agent_name ~arguments ~(state : Mcp_server.server_state) ~
           match state.Mcp_server.proc_mgr with
           | None ->
               Some (false, "Process manager not available for mitosis spawn")
-          | Some pm ->
+          | Some _pm ->
               let spawn_fn ~prompt =
-                let result = Spawn_eio.spawn ~sw ~proc_mgr:pm ~agent_name:target_agent
+                let result = Spawn_eio.spawn ~sw ~agent_name:target_agent
                   ~prompt ~timeout_seconds:Env_config.Spawn.timeout_seconds
                   ~room_config:state.Mcp_server.room_config () in
                 { Spawn.success = result.Spawn_eio.success;

--- a/lib/tool_relay.ml
+++ b/lib/tool_relay.ml
@@ -106,8 +106,8 @@ let handle_relay_now ctx args =
   (* Use Eio-native spawn to avoid blocking HTTP server *)
   match ctx.proc_mgr with
   | None -> (false, "❌ Process manager not available for relay spawn")
-  | Some pm ->
-      let result = Spawn_eio.spawn ~sw:ctx.sw ~proc_mgr:pm ~agent_name:target_agent
+  | Some _pm ->
+      let result = Spawn_eio.spawn ~sw:ctx.sw ~agent_name:target_agent
         ~prompt ~timeout_seconds:Env_config.Spawn.timeout_seconds
         ~room_config:ctx.config ()
       in

--- a/lib/tool_team_session_step.ml
+++ b/lib/tool_team_session_step.ml
@@ -60,7 +60,7 @@ let execute_spawn_pipeline
               in
               fail_all_prepared prepared_spawns ~error:msg;
               Some (`Assoc [ ("error", `String msg) ])
-          | Some pm ->
+          | Some _pm ->
               let rec ensure_all = function
                 | [] -> Ok ()
                 | prepared :: rest -> (
@@ -81,7 +81,7 @@ let execute_spawn_pipeline
                | Ok () ->
                    let execute_spawn index prepared =
                      let spawn_result =
-                       Spawn_eio.spawn ~sw:ctx.sw ~proc_mgr:pm
+                       Spawn_eio.spawn ~sw:ctx.sw
                          ~agent_name:prepared.spec.spawn_agent
                          ~prompt:prepared.spec.spawn_prompt
                          ~timeout_seconds:

--- a/test/test_provider_adapter.ml
+++ b/test/test_provider_adapter.ml
@@ -22,14 +22,6 @@ let test_resolve_direct_aliases () =
   let codex = Option.get (Adapter.resolve_direct_adapter "openai") in
   check string "codex-api alias" "codex-api" codex.canonical_name
 
-let test_resolve_cli_aliases () =
-  let claude = Option.get (Adapter.resolve_cli_adapter "claude-code") in
-  check string "claude cli alias" "claude" claude.meta.canonical_name;
-  let gemini = Option.get (Adapter.resolve_cli_adapter "gemini-cli") in
-  check string "gemini cli alias" "gemini" gemini.meta.canonical_name;
-  check string "gemini prompt transport" "arg:-p"
-    (Adapter.string_of_prompt_transport gemini.prompt_transport)
-
 let test_gemini_direct_auth_vertex_adc () =
   with_env "GOOGLE_CLOUD_PROJECT" (Some "demo-project") (fun () ->
       with_env "GOOGLE_CLOUD_LOCATION" (Some "asia-northeast3") (fun () ->
@@ -109,7 +101,6 @@ let () =
       ( "registry",
         [
           test_case "resolve direct aliases" `Quick test_resolve_direct_aliases;
-          test_case "resolve cli aliases" `Quick test_resolve_cli_aliases;
           test_case "gemini vertex adc" `Quick test_gemini_direct_auth_vertex_adc;
           test_case "gemini api key fallback" `Quick
             test_gemini_direct_auth_api_key_fallback;

--- a/test/test_spawn_eio_coverage.ml
+++ b/test/test_spawn_eio_coverage.ml
@@ -1,7 +1,6 @@
 (** Spawn Eio Module Coverage Tests
 
     Tests for spawn types, constants, and Provider_adapter routing:
-    - spawn_config type (backward compat)
     - spawn_result type
     - masc_mcp_tools constant
     - resolve_model_spec (Provider_adapter → model_spec)
@@ -11,44 +10,6 @@
 open Alcotest
 
 module Spawn_eio = Masc_mcp.Spawn_eio
-
-(* ============================================================
-   spawn_config Type Tests (backward compat — type still exists)
-   ============================================================ *)
-
-let test_spawn_config_type () =
-  let cfg : Spawn_eio.spawn_config = {
-    agent_name = "claude";
-    command = "claude --print";
-    timeout_seconds = 300;
-    working_dir = Some "/tmp/test";
-    mcp_tools = ["masc_status"; "masc_broadcast"];
-  } in
-  check string "agent_name" "claude" cfg.agent_name;
-  check string "command" "claude --print" cfg.command;
-  check int "timeout_seconds" 300 cfg.timeout_seconds
-
-let test_spawn_config_no_working_dir () =
-  let cfg : Spawn_eio.spawn_config = {
-    agent_name = "codex";
-    command = "codex";
-    timeout_seconds = 60;
-    working_dir = None;
-    mcp_tools = [];
-  } in
-  match cfg.working_dir with
-  | None -> ()
-  | Some _ -> fail "expected None"
-
-let test_spawn_config_mcp_tools () =
-  let cfg : Spawn_eio.spawn_config = {
-    agent_name = "test";
-    command = "test";
-    timeout_seconds = 30;
-    working_dir = None;
-    mcp_tools = ["tool1"; "tool2"; "tool3"];
-  } in
-  check int "mcp_tools count" 3 (List.length cfg.mcp_tools)
 
 (* ============================================================
    spawn_result Type Tests
@@ -256,10 +217,10 @@ let test_resolve_model_spec_gemini () =
    ============================================================ *)
 
 let test_spawn_bare_ollama_rejected () =
-  Eio_main.run @@ fun env ->
+  Eio_main.run @@ fun _env ->
   Eio.Switch.run @@ fun sw ->
   let result =
-    Spawn_eio.spawn ~sw ~proc_mgr:(Eio.Stdenv.process_mgr env)
+    Spawn_eio.spawn ~sw
       ~agent_name:"ollama" ~prompt:"hello" ()
   in
   check bool "spawn fails" false result.success;
@@ -275,10 +236,10 @@ let test_spawn_bare_ollama_rejected () =
      with Not_found -> false)
 
 let test_spawn_unknown_agent_fails () =
-  Eio_main.run @@ fun env ->
+  Eio_main.run @@ fun _env ->
   Eio.Switch.run @@ fun sw ->
   let result =
-    Spawn_eio.spawn ~sw ~proc_mgr:(Eio.Stdenv.process_mgr env)
+    Spawn_eio.spawn ~sw
       ~agent_name:"totally_unknown_agent_xyz" ~prompt:"hello" ()
   in
   check bool "spawn fails" false result.success;
@@ -338,11 +299,6 @@ let test_state_isolation_notice_contains_focus () =
 
 let () =
   run "Spawn Eio Coverage" [
-    "spawn_config", [
-      test_case "type" `Quick test_spawn_config_type;
-      test_case "no working_dir" `Quick test_spawn_config_no_working_dir;
-      test_case "mcp_tools" `Quick test_spawn_config_mcp_tools;
-    ];
     "spawn_result", [
       test_case "success" `Quick test_spawn_result_success;
       test_case "failure" `Quick test_spawn_result_failure;


### PR DESCRIPTION
## Summary
Follow-up cleanup for #1512. Removes all remaining CLI subprocess artifacts.

- **provider_adapter.ml**: -88 lines. Remove `cli_adapter` type, `cli_adapters` list, `resolve_cli_*`, `Cli_agent`, `Cli_cached_login`, `prompt_transport`, `output_contract`
- **spawn_eio.ml**: Remove `~proc_mgr` param, `spawn_config` type
- **11 callers**: Remove `~proc_mgr` arg from `Spawn_eio.spawn` calls
- **Tests**: Remove cli adapter and spawn_config test groups

## Depends on
- #1512 (OAS Agent.t routing) — base branch

## Test plan
- [x] `dune build` — success
- [x] `test_spawn_eio_coverage` — 38 tests pass
- [x] `test_provider_adapter` — 11 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)