### PR TITLE
fix(dashboard): resolve all 17 TypeScript errors — clean tsc

### DIFF
--- a/dashboard/src/components/agent-profile.ts
+++ b/dashboard/src/components/agent-profile.ts
@@ -195,14 +195,14 @@ function CharacterPlate({ name }: { name: string }) {
   const koreanName = agent?.koreanName ?? keeper?.koreanName
   const headerStatus = agent?.status ?? brief?.status ?? 'unknown'
   const agentEmoji = agent?.emoji ?? keeper?.emoji
-  const currentWork = keeper?.current_work ?? brief?.current_work ?? agent?.current_task ?? null
+  const currentWork = brief?.current_work ?? agent?.current_task ?? null
   const lastSeenAt = agent?.last_seen ?? brief?.last_activity_at ?? null
-  const lastActivity = keeper?.last_turn_ago_s ?? brief?.last_turn_ago_s ?? null
+  const lastActivity = keeper?.last_turn_ago_s ?? brief?.last_activity_age_sec ?? null
   const ctxRatio = keeper?.context_ratio
   const ctxPct = ctxRatio != null ? Math.round(ctxRatio * 100) : null
   const generation = keeper?.generation
   const autonomy = keeper?.autonomy_level
-  const model = agent?.model ?? brief?.model ?? keeper?.model
+  const model = agent?.model ?? keeper?.model ?? null
   const keeperIdent = keeperIdentityHint(keeper?.name, keeper?.agent_name)
   const signalTruth = brief?.signal_truth
   const continuitySummary =

--- a/dashboard/src/components/agent-roster.ts
+++ b/dashboard/src/components/agent-roster.ts
@@ -4,6 +4,7 @@
 
 import { html } from 'htm/preact'
 import { useState } from 'preact/hooks'
+import type { Agent } from '../types'
 import { agents, keepers } from '../store'
 import { missionSnapshot } from '../mission-store'
 import { AgentAvatar } from './overview/agent-avatar'
@@ -82,7 +83,7 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
   const briefs = snap?.agent_briefs ?? []
   const keeperBriefs = snap?.keeper_briefs ?? []
 
-  const briefMap = new Map(briefs.map(b => [b.name, b]))
+  const briefMap = new Map(briefs.map(b => [b.agent_name, b]))
 
   const filtered = agentList
     .filter((a: { name: string; status: string }) => {
@@ -139,12 +140,12 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
       </div>
 
       <div class="roster-list">
-        ${filtered.map((agent: { name: string; status: string; current_task?: string; traits?: string[] }) => {
+        ${filtered.map((agent: Agent) => {
           const brief = briefMap.get(agent.name)
           const keeper = findKeeper(agent.name, keeperList, keeperBriefs)
           const isKeeper = keeper != null
           const currentWork = keeper?.current_work ?? brief?.current_work ?? agent.current_task ?? null
-          const lastActivity = keeper?.last_turn_ago_s ?? brief?.last_turn_ago_s ?? null
+          const lastActivity = keeper?.last_turn_ago_s ?? brief?.last_activity_age_sec ?? null
           const ctxPct = keeper?.context_ratio != null ? Math.round(keeper.context_ratio * 100) : null
 
           return html`
@@ -200,8 +201,8 @@ export function AgentRoster({ keeperFilter = 'all' }: { keeperFilter?: KeeperFil
                   ${lastActivity != null ? html`
                     <span>${formatDuration(lastActivity)} 전</span>
                   ` : null}
-                  ${(keeper?.model ?? brief?.model) ? html`
-                    <span class="roster-card__model">${keeper?.model ?? brief?.model}</span>
+                  ${keeper?.model ? html`
+                    <span class="roster-card__model">${keeper.model}</span>
                   ` : null}
                 </div>
               </div>

--- a/dashboard/src/components/command/war-room-metrics.ts
+++ b/dashboard/src/components/command/war-room-metrics.ts
@@ -16,7 +16,6 @@ import {
   displayStatus,
   formatElapsed,
   formatPercent,
-  hasSwarmActivity,
   historySummary,
   prettyJson,
   relativeTime,

--- a/dashboard/src/room-truth-store.ts
+++ b/dashboard/src/room-truth-store.ts
@@ -1,8 +1,6 @@
 import { signal } from '@preact/signals'
 import { fetchDashboardRoomTruth } from './api'
 import type {
-  DashboardExecutionQueueItem,
-  DashboardExecutionSummary,
   DashboardRoomTruthAttentionSummary,
   DashboardRoomTruthFocus,
   DashboardRoomTruthRecommendationSummary,

--- a/dashboard/src/store.ts
+++ b/dashboard/src/store.ts
@@ -16,10 +16,8 @@ import type {
   KeeperLifecycleState,
   Goal,
   MdalLoop,
-  MdalIterationRecord,
   DashboardSemanticsResponse,
   DashboardSemanticPanel,
-  DashboardExecutionHandoff,
   DashboardExecutionSummary,
   DashboardExecutionQueueItem,
   DashboardExecutionSessionBrief,
@@ -27,7 +25,6 @@ import type {
   DashboardExecutionWorkerSupportBrief,
   DashboardExecutionLodgeTick,
   DashboardExecutionLodgeCheckin,
-  SocialRuntimeStatus,
   DashboardExecutionContinuityBrief,
 } from './types'
 import {
@@ -51,14 +48,14 @@ import { buildAgentMotion, type AgentMotionSnapshot } from './components/common/
 import { isRecord, asString, asNumber } from './components/common/normalize'
 import {
   normalizeAgent, normalizeTask, normalizeMessage,
-  normalizeExecutionSummary, normalizeExecutionHandoff,
+  normalizeExecutionSummary,
   normalizeExecutionQueueItem, normalizeExecutionSessionBrief,
   normalizeExecutionOperationBrief, normalizeExecutionWorkerSupportBrief,
   normalizeExecutionLodgeTick, normalizeExecutionLodgeCheckin,
   normalizeExecutionContinuityBrief,
-  messageSortKey, mergeMessages,
+  mergeMessages,
   normalizeServerStatus, mergeServerStatus,
-  normalizeMdalLoop, normalizeBuildIdentity,
+  normalizeMdalLoop,
 } from './store-normalizers'
 
 // --- Shell counts (lightweight fallback from /dashboard/shell) ---


### PR DESCRIPTION
## Summary
- 17개 TS 에러 → 0개. `tsc --noEmit` clean pass.
- unused import/declaration 8건 제거
- `DashboardMissionAgentBrief` field 접근 오류 수정 (`.name`→`.agent_name`, dead fallback 제거)
- `Agent` 타입 import로 map 콜백 타입 불일치 해소

## 변경 파일 (5)
- `store.ts` — unused type/value imports 제거
- `room-truth-store.ts` — unused type imports 제거
- `agent-roster.ts` — briefMap key 수정, Agent 타입 사용, dead model fallback 제거
- `agent-profile.ts` — dead fallback 제거 (keeper?.current_work, brief?.model, brief?.last_turn_ago_s)
- `war-room-metrics.ts` — unused hasSwarmActivity import 제거

## Test plan
- [x] `tsc --noEmit` 통과 (0 errors)
- [x] `npm run build` 성공 (4.35s)
- [ ] agent roster에서 briefMap 매칭 정상 동작 확인

Closes #1520

Generated with [Claude Code](https://claude.com/claude-code)