### PR TITLE
fix(test): wrap protocol_continuity in Eio_main.run

### DIFF
--- a/test/test_http_negotiation.ml
+++ b/test/test_http_negotiation.ml
@@ -50,6 +50,7 @@ let test_classify_mcp_accept () =
   ()
 
 let test_protocol_continuity_allows_missing_header () =
+  Eio_main.run @@ fun _env ->
   let module Session = Masc_mcp.Server_mcp_transport_http in
   let session_id = "compat-session-missing-header" in
   let headers = Httpun.Headers.of_list [] in
@@ -64,6 +65,7 @@ let test_protocol_continuity_allows_missing_header () =
           failf "expected missing protocol header to use session continuity, got %s" msg)
 
 let test_protocol_version_for_session_falls_back_to_negotiated_version () =
+  Eio_main.run @@ fun _env ->
   let module Session = Masc_mcp.Server_mcp_transport_http in
   let session_id = "compat-session-negotiated-version" in
   let headers = Httpun.Headers.of_list [] in
@@ -76,6 +78,7 @@ let test_protocol_version_for_session_falls_back_to_negotiated_version () =
         (Session.get_protocol_version_for_session ~session_id request))
 
 let test_protocol_continuity_rejects_mismatch () =
+  Eio_main.run @@ fun _env ->
   let module Session = Masc_mcp.Server_mcp_transport_http in
   let session_id = "compat-session-mismatch" in
   let headers =


### PR DESCRIPTION
## Summary

- `protocol_continuity` 3개 테스트가 `Effect.Unhandled(Eio.Cancel.Get_context)`로 크래시
- 원인: `remember_protocol_version` 내부에서 `Eio.Mutex.use_rw` 호출하는데 Eio context 없음
- 수정: 3개 테스트 함수를 `Eio_main.run @@ fun _env ->` 로 감쌈

## Test plan

- [x] `protocol_continuity` 3개 테스트 통과
- [x] `dune build` 성공

🤖 Generated with [Claude Code](https://claude.com/claude-code)