### PR TITLE
refactor(gardener): migrate spawn LLM from Lodge_cascade to OAS

### DIFF
--- a/lib/gardener_decisions.ml
+++ b/lib/gardener_decisions.ml
@@ -42,10 +42,13 @@ let decide_spawn_with_llm ~config ~health ~gap : spawn_decision =
     gap.maturity_hours
   in
 
+  let model_specs = Lodge_cascade.get_cascade ~cascade_name:"gardener_spawn" () in
   let response =
-    match Lodge_cascade.call ~cascade_name:"gardener_spawn"
-        ~prompt ~temperature:0.3 ~timeout_sec:15 ~max_tokens:200 () with
-    | Ok r -> r.response
+    match
+      Llm_client.run_prompt_cascade ~temperature:0.3
+        ~timeout_sec:Env_config.Llm.gardener_spawn_timeout_seconds
+        ~model_specs ~max_tokens:200 ~prompt () with
+    | Ok resp -> Llm_client.text_of_response resp
     | Error _ -> ""
   in
 


### PR DESCRIPTION
## Summary
- `gardener_decisions.ml`에서 `Lodge_cascade.call` (직접 Ollama/GLM 호출)을 `Llm_client.run_prompt_cascade` (OAS 추상화)로 교체
- 같은 파일 L432-440에 이미 올바른 패턴이 존재했음 — spawn 결정도 동일 패턴으로 통일

## Why
- Ollama 제거됨 (GPU working set 한계). GLM 직접 호출도 불필요
- `Lodge_cascade.call`은 provider에 직접 결합 → OAS 추상화 계층 우회
- Gardener health check에서 `"All models failed: Empty completion"` 에러 발생 중

## Test plan
- [x] `test_gardener.exe` 77개 테스트 통과
- [x] `dune build` 성공
- [x] `grep Lodge_cascade.call lib/gardener*.ml` → 0 hits

🤖 Generated with [Claude Code](https://claude.com/claude-code)