### PR TITLE
fix(mode): TRPG 도구 20개 unknown→trpg 카테고리 수정

### DIFF
--- a/lib/mode.ml
+++ b/lib/mode.ml
@@ -390,8 +390,20 @@ let tool_category tool_name =
   | "masc_spawn"
   | "masc_async_spawn" | "masc_job_status" | "masc_job_list" -> Ecosystem
 
-  (* ── TRPG (canonical names only) ── *)
-  | "trpg_roleplay" -> TRPG
+  (* ── TRPG (canonical + legacy masc_trpg_* names) ── *)
+  | "trpg_roleplay"
+  | "masc_trpg_actor_claim" | "masc_trpg_actor_delete"
+  | "masc_trpg_actor_match" | "masc_trpg_actor_release"
+  | "masc_trpg_actor_spawn" | "masc_trpg_actor_update"
+  | "masc_trpg_dice_roll"
+  | "masc_trpg_intervention_submit"
+  | "masc_trpg_join_eligibility" | "masc_trpg_mid_join_request"
+  | "masc_trpg_party_select" | "masc_trpg_pool_generate"
+  | "masc_trpg_preset_list"
+  | "masc_trpg_quest_update" | "masc_trpg_round_run"
+  | "masc_trpg_scene_transition"
+  | "masc_trpg_session_start" | "masc_trpg_stream"
+  | "masc_trpg_turn_advance" | "masc_trpg_world_event" -> TRPG
 
   (* ── Deprecated/archived tools (hidden via tool_catalog, excluded from presets) ── *)
 
@@ -402,6 +414,7 @@ let tool_category tool_name =
   | _ when String.starts_with ~prefix:"experiment." tool_name -> Ecosystem
   | _ when String.starts_with ~prefix:"experiment_" tool_name -> Ecosystem
   | _ when String.starts_with ~prefix:"trpg." tool_name -> TRPG
+  | _ when String.starts_with ~prefix:"masc_trpg_" tool_name -> TRPG
   | _ when String.starts_with ~prefix:"client." tool_name -> Core_Ops
   | _ when String.starts_with ~prefix:"client_" tool_name -> Core_Ops
 


### PR DESCRIPTION
## Summary

대시보드에서 `unknown` 카테고리로 표시되던 TRPG 도구 20개를 `trpg` 카테고리로 수정.

**원인**: `Mode.tool_category`에서 `"trpg_roleplay"` 하나만 TRPG에 등록, prefix fallback은 `"trpg."` (dot)만 매칭. `"masc_trpg_*"` (underscore) 패턴의 20개 도구가 catch-all `Unknown`으로 떨어짐.

**수정**:
- 20개 `masc_trpg_*` 도구를 TRPG match arm에 명시 추가
- `masc_trpg_` prefix fallback 추가 (향후 새 도구 대비)

## Test plan

- [ ] `dune build` 성공
- [ ] 대시보드 도구 탭에서 unknown 카테고리 0개 확인
- [ ] TRPG 카테고리에 21개 도구 표시 (기존 1 + 추가 20)

🤖 Generated with [Claude Code](https://claude.com/claude-code)