### PR TITLE
refactor: OAS-only migration — eliminate custom LLM wrapper

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -35,7 +35,7 @@
   (cmdliner (>= 1.1))
   (cohttp (>= 5.0))
   (cohttp-eio (and (>= 6.0) (< 6.2)))
-  (agent_sdk (>= 0.50.0))
+  (agent_sdk (>= 0.52.0))
   (uri (>= 4.4))
   (tls (>= 0.16))
   (tls-eio (>= 0.16))

--- a/lib/context_compact_oas.ml
+++ b/lib/context_compact_oas.ml
@@ -58,7 +58,10 @@ let masc_msg_to_oas (m : Llm_client.message) : Agent_sdk.Types.message =
   in
   let content = match m.role with
     | Llm_client.Tool ->
-      let tool_use_id = Option.value ~default:"masc-tool" m.tool_call_id in
+      let tool_use_id =
+        List.find_map (function Agent_sdk.Types.ToolResult { tool_use_id; _ } -> Some tool_use_id | _ -> None) m.content
+        |> Option.value ~default:"masc-tool"
+      in
       [Agent_sdk.Types.ToolResult { tool_use_id; content = tagged_text; is_error = false }]
     | _ -> [Agent_sdk.Types.Text tagged_text]
   in
@@ -96,11 +99,13 @@ let oas_msg_to_masc (m : Agent_sdk.Types.message) : Llm_client.message =
        | Agent_sdk.Types.Tool -> Llm_client.Tool),
       text
   in
-  let tool_call_id = match role with
-    | Llm_client.Tool -> tool_id
-    | _ -> None
+  let content_blocks = match role with
+    | Llm_client.Tool ->
+      let tool_use_id = Option.value ~default:"masc-tool" tool_id in
+      [Agent_sdk.Types.ToolResult { tool_use_id; content; is_error = false }]
+    | _ -> [Agent_sdk.Types.Text content]
   in
-  { Llm_client.role; content = [Agent_sdk.Types.Text content]; name = None; tool_call_id }
+  { Agent_sdk.Types.role; content = content_blocks }
 
 (* ================================================================ *)
 (* Importance Scoring — delegated to Context_scoring (shared SSOT)  *)

--- a/lib/context_manager.ml
+++ b/lib/context_manager.ml
@@ -332,11 +332,7 @@ let format_message_readable (m : Llm_client.message) : string =
     | Llm_client.Assistant -> "assistant"
     | Llm_client.Tool -> "tool"
   in
-  let name_suffix = match m.name with
-    | Some n -> sprintf " (%s)" n
-    | None -> ""
-  in
-  sprintf "%s%s: %s" role_str name_suffix (text_of_message m)
+  sprintf "%s: %s" role_str (text_of_message m)
 
 (** Offload messages to a markdown file for later retrieval.
     Returns [Some path] on success, [None] on failure (fail-safe). *)
@@ -444,7 +440,10 @@ let masc_msg_to_oas_tagged (m : Llm_client.message) : Agent_sdk.Types.message =
   in
   let content = match m.role with
     | Llm_client.Tool ->
-      let tool_use_id = Option.value ~default:"masc-tool" m.tool_call_id in
+      let tool_use_id =
+        List.find_map (function Agent_sdk.Types.ToolResult { tool_use_id; _ } -> Some tool_use_id | _ -> None) m.content
+        |> Option.value ~default:"masc-tool"
+      in
       [Agent_sdk.Types.ToolResult { tool_use_id; content = text; is_error = false }]
     | _ -> [Agent_sdk.Types.Text text]
   in
@@ -481,11 +480,13 @@ let oas_msg_to_masc_tagged (m : Agent_sdk.Types.message) : Llm_client.message =
        | Agent_sdk.Types.Tool -> Llm_client.Tool),
       text
   in
-  let tool_call_id = match role with
-    | Llm_client.Tool -> tool_id
-    | _ -> None
+  let content_blocks = match role with
+    | Llm_client.Tool ->
+      let tool_use_id = Option.value ~default:"masc-tool" tool_id in
+      [Agent_sdk.Types.ToolResult { tool_use_id; content; is_error = false }]
+    | _ -> [Agent_sdk.Types.Text content]
   in
-  { Llm_client.role; content = [Agent_sdk.Types.Text content]; name = None; tool_call_id }
+  { Agent_sdk.Types.role; content = content_blocks }
 
 let oas_strategy_of_compaction (s : compaction_strategy) : Agent_sdk.Context_reducer.strategy =
   match s with
@@ -543,26 +544,21 @@ let role_of_string = function
 
 let message_to_json (m : Llm_client.message) : Yojson.Safe.t =
   let m = Llm_client.sanitize_message_utf8 m in
-  let base = [
+  `Assoc [
     ("role", `String (role_to_string m.role));
     ("content", `String (text_of_message m));
-  ] in
-  let with_name = match m.name with
-    | Some n -> ("name", `String n) :: base | None -> base in
-  let with_id = match m.tool_call_id with
-    | Some id -> ("tool_call_id", `String id) :: with_name | None -> with_name in
-  `Assoc with_id
+  ]
 
 let message_of_json (json : Yojson.Safe.t) : Llm_client.message =
   let open Yojson.Safe.Util in
-  {
-    role = json |> member "role" |> to_string |> role_of_string;
-    content = [Agent_sdk.Types.Text (json |> member "content" |> to_string |> Llm_client.sanitize_text_utf8)];
-    name = json |> member "name" |> to_string_option |> Option.map Llm_client.sanitize_text_utf8;
-    tool_call_id =
-      json |> member "tool_call_id" |> to_string_option
-      |> Option.map Llm_client.sanitize_text_utf8;
-  }
+  let role = json |> member "role" |> to_string |> role_of_string in
+  let text = json |> member "content" |> to_string |> Llm_client.sanitize_text_utf8 in
+  match role with
+  | Llm_client.Tool ->
+    let tool_use_id = json |> member "tool_call_id" |> to_string_option |> Option.value ~default:"masc-tool" in
+    { Agent_sdk.Types.role; content = [Agent_sdk.Types.ToolResult { tool_use_id; content = text; is_error = false }] }
+  | _ ->
+    { Agent_sdk.Types.role; content = [Agent_sdk.Types.Text text] }
 
 let serialize_context (ctx : working_context) : string =
   let json = `Assoc [

--- a/lib/context_manager.ml
+++ b/lib/context_manager.ml
@@ -332,7 +332,15 @@ let format_message_readable (m : Llm_client.message) : string =
     | Llm_client.Assistant -> "assistant"
     | Llm_client.Tool -> "tool"
   in
-  sprintf "%s: %s" role_str (text_of_message m)
+  let tool_suffix = match m.role with
+    | Llm_client.Tool ->
+      let tool_id = List.find_map (function
+        | Agent_sdk.Types.ToolResult { tool_use_id; _ } -> Some tool_use_id
+        | _ -> None) m.content in
+      (match tool_id with Some id -> Printf.sprintf " (%s)" id | None -> "")
+    | _ -> ""
+  in
+  sprintf "%s%s: %s" role_str tool_suffix (text_of_message m)
 
 (** Offload messages to a markdown file for later retrieval.
     Returns [Some path] on success, [None] on failure (fail-safe). *)
@@ -544,10 +552,20 @@ let role_of_string = function
 
 let message_to_json (m : Llm_client.message) : Yojson.Safe.t =
   let m = Llm_client.sanitize_message_utf8 m in
-  `Assoc [
+  let base = [
     ("role", `String (role_to_string m.role));
     ("content", `String (text_of_message m));
-  ]
+  ] in
+  (* Preserve tool_use_id for backward compat with old "tool_call_id" JSON field *)
+  let with_tool_id = match m.role with
+    | Llm_client.Tool ->
+      let tool_id = List.find_map (function
+        | Agent_sdk.Types.ToolResult { tool_use_id; _ } -> Some tool_use_id
+        | _ -> None) m.content in
+      (match tool_id with Some id -> ("tool_call_id", `String id) :: base | None -> base)
+    | _ -> base
+  in
+  `Assoc with_tool_id
 
 let message_of_json (json : Yojson.Safe.t) : Llm_client.message =
   let open Yojson.Safe.Util in

--- a/lib/keeper_alerting.ml
+++ b/lib/keeper_alerting.ml
@@ -9,15 +9,12 @@ let keeper_llm_tools = Tool_shard.keeper_llm_tools
 let merge_usage
     (a : Llm_client.token_usage)
     (b : Llm_client.token_usage) : Llm_client.token_usage =
-  {
-    Llm_client.input_tokens = a.input_tokens + b.input_tokens;
+  { Agent_sdk.Types.input_tokens = a.input_tokens + b.input_tokens;
     output_tokens = a.output_tokens + b.output_tokens;
-    total_tokens = a.total_tokens + b.total_tokens;
     cache_creation_input_tokens =
       a.cache_creation_input_tokens + b.cache_creation_input_tokens;
     cache_read_input_tokens =
-      a.cache_read_input_tokens + b.cache_read_input_tokens;
-  }
+      a.cache_read_input_tokens + b.cache_read_input_tokens }
 
 let contains_ci (haystack : string) (needle : string) : bool =
   let h = String.lowercase_ascii haystack in

--- a/lib/keeper_exec_context.ml
+++ b/lib/keeper_exec_context.ml
@@ -557,8 +557,8 @@ let run_proactive_generation
     proactive_prompt_for_keeper ~meta ~idle_seconds continuity_snapshot continuity_summary
   in
   let zero_usage : Llm_client.token_usage =
-    { Llm_client.input_tokens = 0; output_tokens = 0; total_tokens = 0;
-      cache_creation_input_tokens = 0; cache_read_input_tokens = 0; }
+    { Agent_sdk.Types.input_tokens = 0; output_tokens = 0;
+      cache_creation_input_tokens = 0; cache_read_input_tokens = 0 }
   in
   let max_attempts = 3 in
   let previous_preview = String.trim meta.last_proactive_preview in

--- a/lib/keeper_exec_proactive.ml
+++ b/lib/keeper_exec_proactive.ml
@@ -480,7 +480,7 @@ let maybe_emit_proactive (ctx : _ context) (meta : keeper_meta) : keeper_meta =
                                    + response.usage.output_tokens;
                                  total_tokens =
                                    meta.total_tokens
-                                   + response.usage.total_tokens;
+                                   + Llm_client.total_tokens response.usage;
                                  total_cost_usd =
                                    meta.total_cost_usd +. turn_cost;
                                  last_turn_ts = now_ts;
@@ -490,7 +490,7 @@ let maybe_emit_proactive (ctx : _ context) (meta : keeper_meta) : keeper_meta =
                                  last_output_tokens =
                                    response.usage.output_tokens;
                                  last_total_tokens =
-                                   response.usage.total_tokens;
+                                   Llm_client.total_tokens response.usage;
                                  last_latency_ms = response.latency_ms;
                                  last_proactive_ts = now_ts;
                                  last_proactive_reason =
@@ -631,13 +631,13 @@ let maybe_emit_proactive (ctx : _ context) (meta : keeper_meta) : keeper_meta =
                              meta.total_input_tokens + generated.usage.input_tokens;
                            total_output_tokens =
                              meta.total_output_tokens + generated.usage.output_tokens;
-                           total_tokens = meta.total_tokens + generated.usage.total_tokens;
+                           total_tokens = meta.total_tokens + Llm_client.total_tokens generated.usage;
                            total_cost_usd = meta.total_cost_usd +. turn_cost;
                            last_turn_ts = now_ts;
                            last_model_used = model_used;
                            last_input_tokens = generated.usage.input_tokens;
                            last_output_tokens = generated.usage.output_tokens;
-                           last_total_tokens = generated.usage.total_tokens;
+                           last_total_tokens = Llm_client.total_tokens generated.usage;
                            last_latency_ms = generated.latency_ms;
                            compaction_count =
                              meta.compaction_count + if compacted then 1 else 0;
@@ -683,7 +683,7 @@ let maybe_emit_proactive (ctx : _ context) (meta : keeper_meta) : keeper_meta =
                                     [
                                       ("input_tokens", `Int generated.usage.input_tokens);
                                       ("output_tokens", `Int generated.usage.output_tokens);
-                                      ("total_tokens", `Int generated.usage.total_tokens);
+                                      ("total_tokens", `Int (Llm_client.total_tokens generated.usage));
                                     ] );
                                 ("latency_ms", `Int generated.latency_ms);
                                 ("cost_usd", `Float turn_cost);

--- a/lib/keeper_exec_social.ml
+++ b/lib/keeper_exec_social.ml
@@ -119,14 +119,14 @@ let generate_explicit_room_reply (ctx : _ context) ~(meta : keeper_meta) ~(room_
                   total_turns = meta.total_turns + 1;
                   total_input_tokens = meta.total_input_tokens + usage.input_tokens;
                   total_output_tokens = meta.total_output_tokens + usage.output_tokens;
-                  total_tokens = meta.total_tokens + usage.total_tokens;
+                  total_tokens = meta.total_tokens + Llm_client.total_tokens usage;
                   total_cost_usd =
                     meta.total_cost_usd +. cost_usd_of_usage usage used_model;
                   last_turn_ts = now_ts;
                   last_model_used = resp.model_used;
                   last_input_tokens = usage.input_tokens;
                   last_output_tokens = usage.output_tokens;
-                  last_total_tokens = usage.total_tokens;
+                  last_total_tokens = Llm_client.total_tokens usage;
                   last_latency_ms = resp.latency_ms;
                 }
               in
@@ -384,13 +384,13 @@ let run_social_board_event_turn
                   total_turns = meta.total_turns + 1;
                   total_input_tokens = meta.total_input_tokens + final_usage.input_tokens;
                   total_output_tokens = meta.total_output_tokens + final_usage.output_tokens;
-                  total_tokens = meta.total_tokens + final_usage.total_tokens;
+                  total_tokens = meta.total_tokens + Llm_client.total_tokens final_usage;
                   total_cost_usd = meta.total_cost_usd +. final_cost_usd;
                   last_turn_ts = now_ts;
                   last_model_used = final_model_used;
                   last_input_tokens = final_usage.input_tokens;
                   last_output_tokens = final_usage.output_tokens;
-                  last_total_tokens = final_usage.total_tokens;
+                  last_total_tokens = Llm_client.total_tokens final_usage;
                   last_latency_ms = final_latency_ms;
                   last_autonomous_action_at =
                     (if action_kind = "none" then meta.last_autonomous_action_at else now_iso ());

--- a/lib/keeper_turn.ml
+++ b/lib/keeper_turn.ml
@@ -705,13 +705,13 @@ let handle_keeper_msg ctx args : tool_result =
                 continuity_summary = continuity_summary_from_reply;
                 last_continuity_update_ts;
                 total_output_tokens = meta.total_output_tokens + final_usage.output_tokens;
-                total_tokens = meta.total_tokens + final_usage.total_tokens;
+                total_tokens = meta.total_tokens + Llm_client.total_tokens final_usage;
                 total_cost_usd = meta.total_cost_usd +. total_cost_usd_turn;
                 last_turn_ts = now_ts;
                 last_model_used = final_model_used;
                 last_input_tokens = final_usage.input_tokens;
                 last_output_tokens = final_usage.output_tokens;
-                last_total_tokens = final_usage.total_tokens;
+                last_total_tokens = Llm_client.total_tokens final_usage;
                 last_latency_ms = final_latency_ms;
                 compaction_count = meta.compaction_count + (if compacted then 1 else 0);
                 last_compaction_ts = (if compacted then now_ts else meta.last_compaction_ts);

--- a/lib/keeper_turn_response.ml
+++ b/lib/keeper_turn_response.ml
@@ -52,7 +52,7 @@ let build_turn_metrics_fields (env : turn_env) : (string * Yojson.Safe.t) list =
     ("usage", `Assoc [
       ("input_tokens", `Int env.final_usage.input_tokens);
       ("output_tokens", `Int env.final_usage.output_tokens);
-      ("total_tokens", `Int env.final_usage.total_tokens);
+      ("total_tokens", `Int (Llm_client.total_tokens env.final_usage));
     ]);
     ("latency_ms", `Int env.final_latency_ms);
     ("cost_usd", `Float env.total_cost_usd_turn);
@@ -163,7 +163,7 @@ let build_normal_turn_response_json (env : turn_env) : Yojson.Safe.t =
     ("usage", `Assoc [
       ("input_tokens", `Int env.final_usage.input_tokens);
       ("output_tokens", `Int env.final_usage.output_tokens);
-      ("total_tokens", `Int env.final_usage.total_tokens);
+      ("total_tokens", `Int (Llm_client.total_tokens env.final_usage));
     ]);
     ("latency_ms", `Int env.final_latency_ms);
     ("cost_usd", `Float env.total_cost_usd_turn);

--- a/lib/llm_client.ml
+++ b/lib/llm_client.ml
@@ -70,19 +70,6 @@ let to_oas_message (m : message) : Agent_sdk.Types.message option =
 let of_oas_message (m : Agent_sdk.Types.message) : message =
   m
 
-let of_oas_usage (u : Agent_sdk.Types.api_usage) : token_usage =
-  {
-    input_tokens = u.input_tokens;
-    output_tokens = u.output_tokens;
-    total_tokens = u.input_tokens + u.output_tokens;
-    cache_creation_input_tokens = u.cache_creation_input_tokens;
-    cache_read_input_tokens = u.cache_read_input_tokens;
-  }
-
-let to_oas_usage (u : token_usage) : Agent_sdk.Types.api_usage =
-  {
-    Agent_sdk.Types.input_tokens = u.input_tokens;
-    output_tokens = u.output_tokens;
-    cache_creation_input_tokens = u.cache_creation_input_tokens;
-    cache_read_input_tokens = u.cache_read_input_tokens;
-  }
+(** Identity after type unification. *)
+let of_oas_usage (u : Agent_sdk.Types.api_usage) : token_usage = u
+let to_oas_usage (u : token_usage) : Agent_sdk.Types.api_usage = u

--- a/lib/llm_client.ml
+++ b/lib/llm_client.ml
@@ -64,11 +64,11 @@ let to_oas_provider (spec : model_spec) : Agent_sdk.Provider.config option =
 let to_oas_message (m : message) : Agent_sdk.Types.message option =
   match m.role with
   | System -> None
-  | _ -> Some { Agent_sdk.Types.role = m.role; content = m.content }
+  | _ -> Some m
 
 (** Convert OAS message to MASC message. Near-identity after type convergence. *)
 let of_oas_message (m : Agent_sdk.Types.message) : message =
-  { role = m.role; content = m.content; name = None; tool_call_id = None }
+  m
 
 let of_oas_usage (u : Agent_sdk.Types.api_usage) : token_usage =
   {

--- a/lib/llm_client.mli
+++ b/lib/llm_client.mli
@@ -36,16 +36,11 @@ type model_spec = {
 (** {1 Message Types} *)
 
 (** Role in a conversation. *)
-type role = System | User | Assistant | Tool
+type role = Agent_sdk.Types.role = System | User | Assistant | Tool
 
 (** A single message in a conversation.
     [content] uses {!Agent_sdk.Types.content_block} list for OAS type convergence. *)
-type message = {
-  role : role;
-  content : Agent_sdk.Types.content_block list;
-  name : string option;       (** For tool messages: tool name *)
-  tool_call_id : string option; (** For tool result messages *)
-}
+type message = Agent_sdk.Types.message
 
 (** Tool/function definition for function calling. *)
 type tool_def = {

--- a/lib/llm_client.mli
+++ b/lib/llm_client.mli
@@ -56,16 +56,11 @@ type tool_call = {
   call_arguments : string;     (** JSON string of arguments *)
 }
 
-(** Token usage from a completion.
-    [cache_creation_input_tokens] and [cache_read_input_tokens] track
-    Anthropic prompt caching metrics (0 for non-Anthropic providers). *)
-type token_usage = {
-  input_tokens : int;
-  output_tokens : int;
-  total_tokens : int;
-  cache_creation_input_tokens : int;
-  cache_read_input_tokens : int;
-}
+(** Token usage — unified with OAS api_usage. *)
+type token_usage = Agent_sdk.Types.api_usage
+
+(** Compute total tokens (input + output). *)
+val total_tokens : token_usage -> int
 
 (** {1 Request/Response} *)
 

--- a/lib/llm_orchestration.ml
+++ b/lib/llm_orchestration.ml
@@ -83,7 +83,7 @@ let token_usage_to_json (u : token_usage) : Yojson.Safe.t =
     [
       ("input_tokens", `Int u.input_tokens);
       ("output_tokens", `Int u.output_tokens);
-      ("total_tokens", `Int u.total_tokens);
+      ("total_tokens", `Int (Llm_types.total_tokens u));
       ("cache_creation_input_tokens", `Int u.cache_creation_input_tokens);
       ("cache_read_input_tokens", `Int u.cache_read_input_tokens);
     ]
@@ -92,10 +92,8 @@ let token_usage_of_json (json : Yojson.Safe.t) : (token_usage, string) result =
   let open Yojson.Safe.Util in
   try
     Ok
-      {
-        input_tokens = json |> member "input_tokens" |> to_int;
+      { Agent_sdk.Types.input_tokens = json |> member "input_tokens" |> to_int;
         output_tokens = json |> member "output_tokens" |> to_int;
-        total_tokens = json |> member "total_tokens" |> to_int;
         cache_creation_input_tokens =
           json |> member "cache_creation_input_tokens" |> to_int;
         cache_read_input_tokens = json |> member "cache_read_input_tokens" |> to_int;

--- a/lib/llm_orchestration.ml
+++ b/lib/llm_orchestration.ml
@@ -51,18 +51,12 @@ let response_format_to_string = function
   | `Text -> "text"
   | `Json -> "json"
 
-let string_opt_to_json = function
-  | Some v -> `String v
-  | None -> `Null
-
 let message_fingerprint_json (m : message) : Yojson.Safe.t =
   let m = sanitize_message_utf8 m in
   `Assoc
     [
       ("role", `String (string_of_role m.role));
       ("content", `String (text_of_message m));
-      ("name", string_opt_to_json m.name);
-      ("tool_call_id", string_opt_to_json m.tool_call_id);
     ]
 
 let completion_request_fingerprint_json (req : completion_request) : Yojson.Safe.t =

--- a/lib/llm_provider_bridge.ml
+++ b/lib/llm_provider_bridge.ml
@@ -335,24 +335,14 @@ let tool_calls_of_content (blocks : Llm_provider.Types.content_block list)
 let completion_response_of_api_response
     (resp : Llm_provider.Types.api_response) : completion_response =
   let tool_calls = tool_calls_of_content resp.content in
-  let usage =
+  let usage : Llm_types.token_usage =
     match resp.usage with
-    | Some u ->
-        {
-          input_tokens = u.input_tokens;
-          output_tokens = u.output_tokens;
-          total_tokens = u.input_tokens + u.output_tokens;
-          cache_creation_input_tokens = u.cache_creation_input_tokens;
-          cache_read_input_tokens = u.cache_read_input_tokens;
-        }
+    | Some u -> u
     | None ->
-        {
-          input_tokens = 0;
+        { Agent_sdk.Types.input_tokens = 0;
           output_tokens = 0;
-          total_tokens = 0;
           cache_creation_input_tokens = 0;
-          cache_read_input_tokens = 0;
-        }
+          cache_read_input_tokens = 0 }
   in
   {
     content = resp.content;

--- a/lib/llm_types.ml
+++ b/lib/llm_types.ml
@@ -48,13 +48,12 @@ type tool_call = {
   call_arguments : string;
 }
 
-type token_usage = {
-  input_tokens : int;
-  output_tokens : int;
-  total_tokens : int;
-  cache_creation_input_tokens : int;
-  cache_read_input_tokens : int;
-}
+(** Token usage — now unified with OAS api_usage. Use [total_tokens] function
+    instead of the removed field. *)
+type token_usage = Agent_sdk.Types.api_usage
+
+(** Compute total tokens (was a record field, now derived). *)
+let total_tokens (u : token_usage) = u.input_tokens + u.output_tokens
 
 type completion_request = {
   model : model_spec;

--- a/lib/llm_types.ml
+++ b/lib/llm_types.ml
@@ -33,12 +33,8 @@ type model_spec = {
 
 type role = Agent_sdk.Types.role = System | User | Assistant | Tool
 
-type message = {
-  role : role;
-  content : Agent_sdk.Types.content_block list;
-  name : string option;
-  tool_call_id : string option;
-}
+(** Message type — now unified with OAS. No more MASC-specific name/tool_call_id fields. *)
+type message = Agent_sdk.Types.message
 
 type tool_def = {
   tool_name : string;
@@ -163,22 +159,16 @@ let gemini_pro = {
   cost_per_1k_output = 0.0;
 }
 
-let system_msg text =
-  { role = System; content = [Agent_sdk.Types.Text text]; name = None; tool_call_id = None }
-let user_msg text =
-  { role = User; content = [Agent_sdk.Types.Text text]; name = None; tool_call_id = None }
-let assistant_msg text =
-  { role = Assistant; content = [Agent_sdk.Types.Text text]; name = None; tool_call_id = None }
+let system_msg = Agent_sdk.Types.system_msg
+let user_msg = Agent_sdk.Types.user_msg
+let assistant_msg = Agent_sdk.Types.assistant_msg
 
-let tool_msg ~name ~call_id text =
-  { role = Tool;
-    content = [Agent_sdk.Types.ToolResult { tool_use_id = call_id; content = text; is_error = false }];
-    name = Some name; tool_call_id = Some call_id }
+let tool_msg ~name:_ ~call_id text =
+  Agent_sdk.Types.tool_result_msg ~tool_use_id:call_id ~content:text ()
 
 (** Extract text content from a message.
     Delegates to Agent_sdk.Types.text_of_content for rich content_block list. *)
-let text_of_message (m : message) : string =
-  Agent_sdk.Types.text_of_content m.content
+let text_of_message = Agent_sdk.Types.text_of_message
 
 (* ================================================================ *)
 (* UTF-8 Sanitization                                               *)
@@ -214,8 +204,6 @@ let sanitize_message_utf8 (m : message) : message =
             is_error }
       | other -> other
     ) m.content;
-    name = Option.map sanitize_text_utf8 m.name;
-    tool_call_id = Option.map sanitize_text_utf8 m.tool_call_id;
   }
 
 let sanitize_messages_utf8 (msgs : message list) : message list =

--- a/lib/llm_types.mli
+++ b/lib/llm_types.mli
@@ -38,13 +38,7 @@ type role = Agent_sdk.Types.role = System | User | Assistant | Tool
 (** A single message in a conversation.
     [content] is a list of {!Agent_sdk.Types.content_block} for type convergence
     with OAS message. Use {!text_of_message} to extract text. *)
-type message = {
-  role : role;
-  content : Agent_sdk.Types.content_block list;
-  name : string option;       (** For tool messages: tool name *)
-  tool_call_id : string option; (** For tool result messages *)
-}
-
+type message = Agent_sdk.Types.message
 (** Tool/function definition for function calling. *)
 type tool_def = {
   tool_name : string;

--- a/lib/llm_types.mli
+++ b/lib/llm_types.mli
@@ -56,13 +56,9 @@ type tool_call = {
 (** Token usage from a completion.
     [cache_creation_input_tokens] and [cache_read_input_tokens] track
     Anthropic prompt caching metrics (0 for non-Anthropic providers). *)
-type token_usage = {
-  input_tokens : int;
-  output_tokens : int;
-  total_tokens : int;
-  cache_creation_input_tokens : int;
-  cache_read_input_tokens : int;
-}
+type token_usage = Agent_sdk.Types.api_usage
+
+val total_tokens : token_usage -> int
 
 (** {1 Request/Response} *)
 

--- a/lib/local_agent_eio_types.ml
+++ b/lib/local_agent_eio_types.ml
@@ -568,25 +568,19 @@ let parse_text_tool_calls (content : string) : Llm_client.tool_call list =
   in
   collect 0 1 []
 
-let make_usage ?(input_tokens = 0) ?(output_tokens = 0) () =
-  {
-    Llm_client.input_tokens;
+let make_usage ?(input_tokens = 0) ?(output_tokens = 0) () : Llm_client.token_usage =
+  { Agent_sdk.Types.input_tokens;
     output_tokens;
-    total_tokens = input_tokens + output_tokens;
     cache_creation_input_tokens = 0;
-    cache_read_input_tokens = 0;
-  }
+    cache_read_input_tokens = 0 }
 
-let merge_usage a b =
-  {
-    Llm_client.input_tokens = a.Llm_client.input_tokens + b.Llm_client.input_tokens;
+let merge_usage (a : Llm_client.token_usage) (b : Llm_client.token_usage) : Llm_client.token_usage =
+  { Agent_sdk.Types.input_tokens = a.input_tokens + b.input_tokens;
     output_tokens = a.output_tokens + b.output_tokens;
-    total_tokens = a.total_tokens + b.total_tokens;
     cache_creation_input_tokens =
       a.cache_creation_input_tokens + b.cache_creation_input_tokens;
     cache_read_input_tokens =
-      a.cache_read_input_tokens + b.cache_read_input_tokens;
-  }
+      a.cache_read_input_tokens + b.cache_read_input_tokens }
 
 let estimate_cost_usd (model : Llm_client.model_spec)
     (usage : Llm_client.token_usage) : float option =

--- a/lib/perpetual_loop.ml
+++ b/lib/perpetual_loop.ml
@@ -111,7 +111,7 @@ let create_state config =
     ~session_id:trace_id
     ~base_dir:config.session_base_dir in
   let zero_usage : Llm_client.token_usage = {
-    input_tokens = 0; output_tokens = 0; total_tokens = 0;
+    Agent_sdk.Types.input_tokens = 0; output_tokens = 0;
     cache_creation_input_tokens = 0; cache_read_input_tokens = 0;
   } in
   let now_ts = Time_compat.now () in
@@ -581,7 +581,7 @@ let run_turn ~config ~state =
       in
       let cost = calculate_cost resp.usage used_model in
       state.total_cost <- state.total_cost +. cost;
-      state.total_tokens <- state.total_tokens + resp.usage.total_tokens;
+      state.total_tokens <- state.total_tokens + Llm_client.total_tokens resp.usage;
 
       (* Track activity: tool calls = active, text only = potentially idle *)
       if resp.tool_calls <> [] then
@@ -748,7 +748,7 @@ let run_turn ~config ~state =
         end else begin
           emit (TurnEnd {
             turn;
-            tokens_used = resp.usage.total_tokens;
+            tokens_used = Llm_client.total_tokens resp.usage;
             cost;
           });
           true  (* Continue *)
@@ -904,7 +904,7 @@ let status ~config state : Yojson.Safe.t =
     ("last_usage", `Assoc [
       ("input_tokens", `Int state.last_usage.input_tokens);
       ("output_tokens", `Int state.last_usage.output_tokens);
-      ("total_tokens", `Int state.last_usage.total_tokens);
+      ("total_tokens", `Int (Llm_client.total_tokens state.last_usage));
     ]);
     ("last_latency_ms", `Int state.last_latency_ms);
     ("last_heartbeat_ts", `Float state.last_heartbeat);

--- a/lib/succession.ml
+++ b/lib/succession.ml
@@ -277,9 +277,12 @@ let normalize_for_model (msgs : Llm_client.message list)
         match m.role with
         | Llm_client.Tool ->
           (* Convert tool messages to user messages for models without tool support *)
+          let tool_id = List.find_map (function
+            | Agent_sdk.Types.ToolResult { tool_use_id; _ } -> Some tool_use_id
+            | _ -> None) m.content |> Option.value ~default:"unknown" in
           { Agent_sdk.Types.role = Llm_client.User;
-                   content = [Agent_sdk.Types.Text (sprintf "[Tool result]\n%s"
-                     (Llm_client.text_of_message m))] }
+                   content = [Agent_sdk.Types.Text (sprintf "[Tool result: %s]\n%s"
+                     tool_id (Llm_client.text_of_message m))] }
         | _ -> m
       ) msgs
     | Llm_client.Claude ->

--- a/lib/succession.ml
+++ b/lib/succession.ml
@@ -277,9 +277,9 @@ let normalize_for_model (msgs : Llm_client.message list)
         match m.role with
         | Llm_client.Tool ->
           (* Convert tool messages to user messages for models without tool support *)
-          { m with role = Llm_client.User;
-                   content = [Agent_sdk.Types.Text (sprintf "[Tool result: %s]\n%s"
-                     (Option.value ~default:"unknown" m.name) (text_of_message m))] }
+          { Agent_sdk.Types.role = Llm_client.User;
+                   content = [Agent_sdk.Types.Text (sprintf "[Tool result]\n%s"
+                     (Llm_client.text_of_message m))] }
         | _ -> m
       ) msgs
     | Llm_client.Claude ->

--- a/lib/tool_compact.ml
+++ b/lib/tool_compact.ml
@@ -113,10 +113,11 @@ let parse_message (json : Yojson.Safe.t) : Llm_client.message =
   let open Yojson.Safe.Util in
   let role = json |> member "role" |> to_string |> role_of_string in
   let content = json |> member "content" |> to_string in
-  { Llm_client.role;
-    content = [Agent_sdk.Types.Text content];
-    name = None;
-    tool_call_id = None }
+  match role with
+  | Llm_client.Tool ->
+    { Agent_sdk.Types.role; content = [Agent_sdk.Types.ToolResult { tool_use_id = "compact"; content; is_error = false }] }
+  | _ ->
+    { Agent_sdk.Types.role; content = [Agent_sdk.Types.Text content] }
 
 (** Serialize an Llm_client.message back to JSON. *)
 let message_to_json (m : Llm_client.message) : Yojson.Safe.t =

--- a/masc_mcp.opam
+++ b/masc_mcp.opam
@@ -23,7 +23,7 @@ depends: [
   "cmdliner" {>= "1.1"}
   "cohttp" {>= "5.0"}
   "cohttp-eio" {>= "6.0" & < "6.2"}
-  "agent_sdk" {>= "0.50.0"}
+  "agent_sdk" {>= "0.52.0"}
   "uri" {>= "4.4"}
   "tls" {>= "0.16"}
   "tls-eio" {>= "0.16"}

--- a/test/test_llm_client_coverage.ml
+++ b/test/test_llm_client_coverage.ml
@@ -33,8 +33,9 @@ let test_message_constructors () =
   let tool_msg = Llm.tool_msg ~name:"grep" ~call_id:"call-1" "done" in
   check bool "system role" true
     (match (Llm.system_msg "x").role with Llm.System -> true | _ -> false);
-  check (option string) "tool name" (Some "grep") tool_msg.name;
-  check (option string) "tool call id" (Some "call-1") tool_msg.tool_call_id
+  let has_call1 = List.exists (function
+    | Agent_sdk.Types.ToolResult { tool_use_id = "call-1"; _ } -> true | _ -> false) tool_msg.content in
+  check bool "tool call id in content" true has_call1
 
 let test_estimate_tokens_positive () =
   let tokens = Llm.estimate_tokens [ Llm.user_msg "hello world" ] in

--- a/test/test_lodge_topic.ml
+++ b/test/test_lodge_topic.ml
@@ -178,7 +178,7 @@ let make_llm_response content =
     content = [Agent_sdk.Types.Text content];
     tool_calls = [];
     usage = {
-      input_tokens = 0; output_tokens = 0; total_tokens = 0;
+      Agent_sdk.Types.input_tokens = 0; output_tokens = 0;
       cache_creation_input_tokens = 0; cache_read_input_tokens = 0;
     };
     model_used = "test";

--- a/test/test_oas_integration.ml
+++ b/test/test_oas_integration.ml
@@ -52,12 +52,9 @@ let test_event_bus_task_transition () =
 (* ================================================================ *)
 
 let test_message_roundtrip () =
-  let masc_msg : Llm_client.message = {
-    role = Llm_client.Assistant;
-    content = [Agent_sdk.Types.Text "test content"];
-    name = None;
-    tool_call_id = None;
-  } in
+  let masc_msg : Llm_client.message =
+    Llm_client.assistant_msg "test content"
+  in
   let oas_msg = Llm_client.to_oas_message masc_msg in
   (match oas_msg with
    | None -> Alcotest.fail "Assistant message should not be dropped"
@@ -70,12 +67,9 @@ let test_message_roundtrip () =
        "test content" (Llm_client.text_of_message roundtrip))
 
 let test_system_role_dropped () =
-  let masc_msg : Llm_client.message = {
-    role = Llm_client.System;
-    content = [Agent_sdk.Types.Text "system prompt"];
-    name = None;
-    tool_call_id = None;
-  } in
+  let masc_msg : Llm_client.message =
+    Llm_client.system_msg "system prompt"
+  in
   let oas_msg = Llm_client.to_oas_message masc_msg in
   Alcotest.(check bool) "system message dropped (belongs in system_prompt)"
     true (Option.is_none oas_msg)

--- a/test/test_perpetual.ml
+++ b/test/test_perpetual.ml
@@ -840,7 +840,7 @@ let test_integration () = group "Integration" (fun () ->
      assert_true "oas_adapter:msg_roundtrip" (Llm_client.text_of_message back_m = "test"));
 
   let test_usage : Llm_client.token_usage =
-    { input_tokens = 100; output_tokens = 50; total_tokens = 150;
+    { Agent_sdk.Types.input_tokens = 100; output_tokens = 50;
       cache_creation_input_tokens = 10; cache_read_input_tokens = 20 } in
   let oas_u = Llm_client.to_oas_usage test_usage in
   let back_u = Llm_client.of_oas_usage oas_u in

--- a/test/test_perpetual.ml
+++ b/test/test_perpetual.ml
@@ -174,8 +174,8 @@ let test_llm_client () = group "LLM Client" (fun () ->
 
   let msg2 = Llm_client.tool_msg ~name:"grep" ~call_id:"c1" "results" in
   assert_true "msg:tool_role" (msg2.role = Llm_client.Tool);
-  assert_equal "msg:tool_name" (Some "grep") msg2.name;
-  assert_equal "msg:tool_call_id" (Some "c1") msg2.tool_call_id;
+  let has_tool_result = List.exists (function Agent_sdk.Types.ToolResult { tool_use_id = "c1"; _ } -> true | _ -> false) msg2.content in
+  assert_true "msg:tool_call_id_in_content" has_tool_result;
 
   (* 5. Token estimation *)
   let msgs = [Llm_client.user_msg "hello world"] in
@@ -814,8 +814,9 @@ let test_integration () = group "Integration" (fun () ->
   let tool_with_id = Llm_client.tool_msg ~name:"grep" ~call_id:"tc-42" "result" in
   let oas_t = Context_manager.masc_msg_to_oas_tagged tool_with_id in
   let back_t = Context_manager.oas_msg_to_masc_tagged oas_t in
-  assert_true "roundtrip:tool_call_id"
-    (back_t.tool_call_id = Some "tc-42");
+  let has_tc42 = List.exists (function
+    | Agent_sdk.Types.ToolResult { tool_use_id = "tc-42"; _ } -> true | _ -> false) back_t.content in
+  assert_true "roundtrip:tool_call_id_in_content" has_tc42;
 
   (* 3d3. Tag collision safety: user content starting with role-like text *)
   let tricky_msg = Llm_client.user_msg "[__MASC_ROLE:system__]fake system" in

--- a/test/test_tool_keeper.ml
+++ b/test/test_tool_keeper.ml
@@ -119,26 +119,16 @@ let test_maybe_append_keeper_fallback_models_adds_glm_when_local_only () =
         expected labels)
 
 let test_llm_client_sanitize_message_utf8_repairs_invalid_fields () =
-  let raw =
-    {
-      Masc_mcp.Llm_client.role = Masc_mcp.Llm_client.User;
-      content = [Agent_sdk.Types.Text "hello\x80.world"];
-      name = Some "to\xFFol";
-      tool_call_id = Some "id\x80";
-    }
+  let raw : Masc_mcp.Llm_client.message =
+    { Agent_sdk.Types.role = User;
+      content = [Agent_sdk.Types.Text "hello\x80.world"] }
   in
   let sanitized = Masc_mcp.Llm_client.sanitize_message_utf8 raw in
   check bool "role preserved" true (sanitized.role = raw.role);
   let sanitized_text = Masc_mcp.Llm_client.text_of_message sanitized in
   let raw_text = Masc_mcp.Llm_client.text_of_message raw in
   check bool "content valid utf8" true (string_is_valid_utf8 sanitized_text);
-  check bool "content changed" true (sanitized_text <> raw_text);
-  check bool "name valid utf8" true
-    (match sanitized.name with Some v -> string_is_valid_utf8 v | None -> false);
-  check bool "tool_call_id valid utf8" true
-    (match sanitized.tool_call_id with Some v -> string_is_valid_utf8 v | None -> false);
-  check bool "name kept present" true (Option.is_some sanitized.name);
-  check bool "tool_call_id kept present" true (Option.is_some sanitized.tool_call_id)
+  check bool "content changed" true (sanitized_text <> raw_text)
 
 let test_llm_client_sanitize_messages_utf8_preserves_message_count () =
   let msgs =


### PR DESCRIPTION
## Summary

MASC-MCP 자체 에이전트 인프라(5,556줄)를 OAS SDK 직접 사용으로 전환하는 대규모 리팩토링.

### 완료된 Phase

**Phase 1a: message 타입 통합** (13 files, -46 lines)
- `Llm_client.message` → `Agent_sdk.Types.message` 타입 alias
- `name`/`tool_call_id` 필드 제거 (ToolResult content block에 내장)
- Message constructors → OAS delegates

**Phase 1a+: context_compact_oas 적응** (1 file, +6 lines)
- PR #1517 어댑터를 통합 message 타입에 맞춤

**Phase 1c: token_usage 타입 통합** (17 files, -44 lines)
- `Llm_client.token_usage` → `Agent_sdk.Types.api_usage` 타입 alias
- `total_tokens` 필드 → `total_tokens` 함수 (input + output)
- `of_oas_usage`/`to_oas_usage` → identity functions

### 남은 Phase (후속 커밋)
- Phase 1b: `completion_response` → `api_response`
- Phase 1d: `complete`/`cascade` → `Api.create_message`
- Phase 1e: `model_spec` → `Provider.config`
- Phase 1f: LLM core 모듈 삭제
- Step 2-6: context_manager, perpetual_loop, succession, verifier 삭제 + OAS Agent.run 전환

### 정량 진행

| 지표 | 시작 | 현재 | 목표 |
|------|------|------|------|
| 순 줄수 변화 | 0 | **-84** | -5,556 |
| 통합 타입 | 0 | **2** (message, token_usage) | 5+ |
| identity 변환 | 0 | **4** (to/of message, to/of usage) | 삭제 |

## Test plan
- [x] `dune build --root . lib/` 통과
- [x] `test_llm_client_coverage` 8/8 pass
- [x] `test_oas_integration` 8/8 pass
- [x] `test_tool_keeper` 22/22 pass
- [ ] Phase 1b-1f 변환 후 전체 테스트 재검증
- [ ] `rg "Llm_client" lib/ test/ | wc -l` = 0 (최종 목표)

🤖 Generated with [Claude Code](https://claude.com/claude-code)