### PR TITLE
feat: relation materializer — auto-record agent collaboration to Neo4j

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -244,6 +244,7 @@
    norm_detector
    agent_planner
    reflection
+   relation_materializer
    prometheus
    rate_limit
    masc_mcp

--- a/lib/relation_materializer.ml
+++ b/lib/relation_materializer.ml
@@ -1,9 +1,9 @@
 (** Relation Materializer — automatically records agent relationships
     to Neo4j via GraphQL when MASC lifecycle events occur.
 
-    All calls run in a detached Eio fiber: failures are logged but never
-    block the caller.  This ensures the main MASC event loop is not
-    affected by GraphQL latency or downtime.
+    Uses GraphQL alias batching to send ALL collaboration pairs in a
+    single HTTP request.  Runs in a detached Eio fiber so the caller
+    is never blocked.
 
     @since 2.112.0
 *)
@@ -13,36 +13,47 @@
 let log_err tag msg =
   Printf.eprintf "[relation-materializer] %s failed: %s\n%!" tag msg
 
-let collab_mutation = {|
-  mutation($a1: String!, $a2: String!, $ctx: String!) {
-    recordCollaborationByName(agent1Name: $a1, agent2Name: $a2, context: $ctx) {
-      success message
-    }
-  }
-|}
+(** Build a single batched GraphQL mutation using aliases.
+    20 peers → 1 HTTP request with 20 aliased fields.
 
-(** Record collaboration for a single pair. Synchronous, logs errors. *)
-let record_one ~tag ~context ~agent ~peer =
-  let variables = `Assoc [
-    ("a1", `String agent); ("a2", `String peer);
-    ("ctx", `String context);
-  ] in
-  match Graphql_client.mutate ~timeout_sec:5.0 ~mutation:collab_mutation ~variables () with
-  | Ok _ -> ()
-  | Error msg -> log_err tag msg
+    Example output:
+    {[
+      mutation {
+        c0: recordCollaborationByName(agent1Name: "a", agent2Name: "b", context: "ctx") { success }
+        c1: recordCollaborationByName(agent1Name: "a", agent2Name: "c", context: "ctx") { success }
+      }
+    ]}
+*)
+let build_batch_mutation ~agent ~peers ~context =
+  let escape s =
+    (* Minimal escape for GraphQL string literals *)
+    let parts = String.split_on_char '"' s in
+    String.concat "\\\"" parts
+  in
+  let fields = List.mapi (fun i peer ->
+    Printf.sprintf
+      "c%d: recordCollaborationByName(agent1Name: \"%s\", agent2Name: \"%s\", context: \"%s\") { success }"
+      i (escape agent) (escape peer) (escape context)
+  ) peers in
+  "mutation { " ^ String.concat " " fields ^ " }"
 
-(** Send collaboration mutations in a detached Eio fiber when possible.
-    Each pair gets its own GraphQL call (the server does MERGE, so
-    duplicates are safe). Returns immediately when Eio switch is available. *)
+(** Send all collaboration pairs in one batched HTTP request.
+    Detaches to an Eio fiber when runtime is available. *)
 let record_collaborations_async ~tag ~context ~agent ~peers =
+  let do_batch () =
+    let mutation = build_batch_mutation ~agent ~peers ~context in
+    match Graphql_client.mutate ~timeout_sec:10.0 ~mutation () with
+    | Ok _ -> ()
+    | Error msg -> log_err tag msg
+  in
   match Eio_context.get_switch_opt () with
   | None ->
     (* No Eio runtime — synchronous best-effort *)
-    List.iter (fun peer -> record_one ~tag ~context ~agent ~peer) peers
+    do_batch ()
   | Some sw ->
     (* Detach into an Eio fiber — returns immediately *)
     Eio.Fiber.fork_daemon ~sw (fun () ->
-      List.iter (fun peer -> record_one ~tag ~context ~agent ~peer) peers;
+      do_batch ();
       `Stop_daemon
     )
 
@@ -50,7 +61,8 @@ let record_collaborations_async ~tag ~context ~agent ~peers =
 
 (** When an agent leaves a room, record [COLLABORATED_WITH] edges
     between the departing agent and every other active agent.
-    Runs asynchronously — returns immediately. *)
+    Runs asynchronously — returns immediately.
+    20 peers = 1 HTTP request (alias batching). *)
 let on_agent_leave ~leaving_agent ~active_agents =
   let peers = List.filter (fun name -> name <> leaving_agent) active_agents in
   if peers <> [] then
@@ -63,8 +75,7 @@ let on_agent_leave ~leaving_agent ~active_agents =
 
 (** When a task is completed, record collaboration between the
     assignee and all active agents in the room.
-    Skipped if the assignee already appeared in a recent leave event
-    (since leave also records co-presence). *)
+    20 peers = 1 HTTP request (alias batching). *)
 let on_task_done ~assignee ~active_agents =
   let peers = List.filter (fun name -> name <> assignee) active_agents in
   if peers <> [] then

--- a/lib/relation_materializer.ml
+++ b/lib/relation_materializer.ml
@@ -1,67 +1,74 @@
 (** Relation Materializer — automatically records agent relationships
     to Neo4j via GraphQL when MASC lifecycle events occur.
 
-    All calls are fire-and-forget: failures are logged but never block
-    the caller.  This ensures the main MASC event loop is not affected
-    by GraphQL latency or downtime.
+    All calls run in a detached Eio fiber: failures are logged but never
+    block the caller.  This ensures the main MASC event loop is not
+    affected by GraphQL latency or downtime.
 
     @since 2.112.0
 *)
 
 (** {1 Internal helpers} *)
 
-let log_ok tag msg =
-  Printf.eprintf "[relation-materializer] %s: %s\n%!" tag msg
-
 let log_err tag msg =
   Printf.eprintf "[relation-materializer] %s failed: %s\n%!" tag msg
 
-(** Fire-and-forget GraphQL mutation.  Logs result, never raises. *)
-let fire_mutation ~tag ~mutation ?(variables=`Null) () =
-  match Graphql_client.mutate ~timeout_sec:5.0 ~mutation ~variables () with
-  | Ok _data -> log_ok tag "ok"
+let collab_mutation = {|
+  mutation($a1: String!, $a2: String!, $ctx: String!) {
+    recordCollaborationByName(agent1Name: $a1, agent2Name: $a2, context: $ctx) {
+      success message
+    }
+  }
+|}
+
+(** Record collaboration for a single pair. Synchronous, logs errors. *)
+let record_one ~tag ~context ~agent ~peer =
+  let variables = `Assoc [
+    ("a1", `String agent); ("a2", `String peer);
+    ("ctx", `String context);
+  ] in
+  match Graphql_client.mutate ~timeout_sec:5.0 ~mutation:collab_mutation ~variables () with
+  | Ok _ -> ()
   | Error msg -> log_err tag msg
+
+(** Send collaboration mutations in a detached Eio fiber when possible.
+    Each pair gets its own GraphQL call (the server does MERGE, so
+    duplicates are safe). Returns immediately when Eio switch is available. *)
+let record_collaborations_async ~tag ~context ~agent ~peers =
+  match Eio_context.get_switch_opt () with
+  | None ->
+    (* No Eio runtime — synchronous best-effort *)
+    List.iter (fun peer -> record_one ~tag ~context ~agent ~peer) peers
+  | Some sw ->
+    (* Detach into an Eio fiber — returns immediately *)
+    Eio.Fiber.fork_daemon ~sw (fun () ->
+      List.iter (fun peer -> record_one ~tag ~context ~agent ~peer) peers;
+      `Stop_daemon
+    )
 
 (** {1 Collaboration — agent leave} *)
 
 (** When an agent leaves a room, record [COLLABORATED_WITH] edges
-    between the departing agent and every other active agent. *)
+    between the departing agent and every other active agent.
+    Runs asynchronously — returns immediately. *)
 let on_agent_leave ~leaving_agent ~active_agents =
   let peers = List.filter (fun name -> name <> leaving_agent) active_agents in
-  List.iter (fun peer ->
-    let mutation = {|
-      mutation($a1: String!, $a2: String!, $ctx: String!) {
-        recordCollaborationByName(agent1Name: $a1, agent2Name: $a2, context: $ctx) {
-          success message
-        }
-      }
-    |} in
-    let variables = `Assoc [
-      ("a1", `String leaving_agent);
-      ("a2", `String peer);
-      ("ctx", `String (Printf.sprintf "co-present in MASC room at %s" (Types.now_iso ())));
-    ] in
-    fire_mutation ~tag:"collab" ~mutation ~variables ()
-  ) peers
+  if peers <> [] then
+    record_collaborations_async
+      ~tag:"collab"
+      ~context:(Printf.sprintf "co-present in MASC room at %s" (Types.now_iso ()))
+      ~agent:leaving_agent ~peers
 
 (** {1 Task completion} *)
 
 (** When a task is completed, record collaboration between the
-    assignee and all active agents in the room. *)
+    assignee and all active agents in the room.
+    Skipped if the assignee already appeared in a recent leave event
+    (since leave also records co-presence). *)
 let on_task_done ~assignee ~active_agents =
   let peers = List.filter (fun name -> name <> assignee) active_agents in
-  List.iter (fun peer ->
-    let mutation = {|
-      mutation($a1: String!, $a2: String!, $ctx: String!) {
-        recordCollaborationByName(agent1Name: $a1, agent2Name: $a2, context: $ctx) {
-          success message
-        }
-      }
-    |} in
-    let variables = `Assoc [
-      ("a1", `String assignee);
-      ("a2", `String peer);
-      ("ctx", `String (Printf.sprintf "task collaboration at %s" (Types.now_iso ())));
-    ] in
-    fire_mutation ~tag:"task-collab" ~mutation ~variables ()
-  ) peers
+  if peers <> [] then
+    record_collaborations_async
+      ~tag:"task-collab"
+      ~context:(Printf.sprintf "task collaboration at %s" (Types.now_iso ()))
+      ~agent:assignee ~peers

--- a/lib/relation_materializer.ml
+++ b/lib/relation_materializer.ml
@@ -1,0 +1,67 @@
+(** Relation Materializer — automatically records agent relationships
+    to Neo4j via GraphQL when MASC lifecycle events occur.
+
+    All calls are fire-and-forget: failures are logged but never block
+    the caller.  This ensures the main MASC event loop is not affected
+    by GraphQL latency or downtime.
+
+    @since 2.112.0
+*)
+
+(** {1 Internal helpers} *)
+
+let log_ok tag msg =
+  Printf.eprintf "[relation-materializer] %s: %s\n%!" tag msg
+
+let log_err tag msg =
+  Printf.eprintf "[relation-materializer] %s failed: %s\n%!" tag msg
+
+(** Fire-and-forget GraphQL mutation.  Logs result, never raises. *)
+let fire_mutation ~tag ~mutation ?(variables=`Null) () =
+  match Graphql_client.mutate ~timeout_sec:5.0 ~mutation ~variables () with
+  | Ok _data -> log_ok tag "ok"
+  | Error msg -> log_err tag msg
+
+(** {1 Collaboration — agent leave} *)
+
+(** When an agent leaves a room, record [COLLABORATED_WITH] edges
+    between the departing agent and every other active agent. *)
+let on_agent_leave ~leaving_agent ~active_agents =
+  let peers = List.filter (fun name -> name <> leaving_agent) active_agents in
+  List.iter (fun peer ->
+    let mutation = {|
+      mutation($a1: String!, $a2: String!, $ctx: String!) {
+        recordCollaborationByName(agent1Name: $a1, agent2Name: $a2, context: $ctx) {
+          success message
+        }
+      }
+    |} in
+    let variables = `Assoc [
+      ("a1", `String leaving_agent);
+      ("a2", `String peer);
+      ("ctx", `String (Printf.sprintf "co-present in MASC room at %s" (Types.now_iso ())));
+    ] in
+    fire_mutation ~tag:"collab" ~mutation ~variables ()
+  ) peers
+
+(** {1 Task completion} *)
+
+(** When a task is completed, record collaboration between the
+    assignee and all active agents in the room. *)
+let on_task_done ~assignee ~active_agents =
+  let peers = List.filter (fun name -> name <> assignee) active_agents in
+  List.iter (fun peer ->
+    let mutation = {|
+      mutation($a1: String!, $a2: String!, $ctx: String!) {
+        recordCollaborationByName(agent1Name: $a1, agent2Name: $a2, context: $ctx) {
+          success message
+        }
+      }
+    |} in
+    let variables = `Assoc [
+      ("a1", `String assignee);
+      ("a2", `String peer);
+      ("ctx", `String (Printf.sprintf "task collaboration at %s" (Types.now_iso ())));
+    ] in
+    fire_mutation ~tag:"task-collab" ~mutation ~variables ()
+  ) peers

--- a/lib/room.ml
+++ b/lib/room.ml
@@ -304,10 +304,12 @@ let leave config ~agent_name =
       "{\"type\":\"agent_leave\",\"agent\":\"%s\",\"ts\":\"%s\"}"
       actual_name (now_iso ()));
 
-    (* Record co-presence relationships to Neo4j (fire-and-forget) *)
+    (* Record co-presence relationships to Neo4j (async, non-blocking) *)
     (try Relation_materializer.on_agent_leave
            ~leaving_agent:actual_name ~active_agents:peers_before_leave
-     with _ -> ());
+     with exn ->
+       Printf.eprintf "[relation-materializer] leave hook error: %s\n%!"
+         (Printexc.to_string exn));
 
     Printf.sprintf "✅ %s left the room" actual_name
   end else

--- a/lib/room.ml
+++ b/lib/room.ml
@@ -290,6 +290,9 @@ let leave config ~agent_name =
         let _ = backend_delete config ~key:agent_key in ())
     end;
 
+    (* Capture active agents before removal for relationship materialization *)
+    let peers_before_leave = (read_state config).active_agents in
+
     let _ = update_state config (fun s ->
       { s with active_agents = List.filter ((<>) actual_name) s.active_agents }
     ) in
@@ -300,6 +303,11 @@ let leave config ~agent_name =
     log_event config (Printf.sprintf
       "{\"type\":\"agent_leave\",\"agent\":\"%s\",\"ts\":\"%s\"}"
       actual_name (now_iso ()));
+
+    (* Record co-presence relationships to Neo4j (fire-and-forget) *)
+    (try Relation_materializer.on_agent_leave
+           ~leaving_agent:actual_name ~active_agents:peers_before_leave
+     with _ -> ());
 
     Printf.sprintf "✅ %s left the room" actual_name
   end else

--- a/lib/room_task.ml
+++ b/lib/room_task.ml
@@ -406,11 +406,13 @@ let complete_task config ~agent_name ~task_id ~notes =
               agent_name task_id
               (if notes = "" then "null" else Printf.sprintf "\"%s\"" notes)
               (now_iso ()));
-            (* Record task collaboration to Neo4j (fire-and-forget) *)
+            (* Record task collaboration to Neo4j (async, non-blocking) *)
             (try
                let active = (Room_state.read_state config).active_agents in
                Relation_materializer.on_task_done ~assignee:agent_name ~active_agents:active
-             with _ -> ());
+             with exn ->
+               Printf.eprintf "[relation-materializer] task hook error: %s\n%!"
+                 (Printexc.to_string exn));
             Printf.sprintf "✅ %s completed %s" agent_name task_id
           end
     with e ->

--- a/lib/room_task.ml
+++ b/lib/room_task.ml
@@ -406,6 +406,11 @@ let complete_task config ~agent_name ~task_id ~notes =
               agent_name task_id
               (if notes = "" then "null" else Printf.sprintf "\"%s\"" notes)
               (now_iso ()));
+            (* Record task collaboration to Neo4j (fire-and-forget) *)
+            (try
+               let active = (Room_state.read_state config).active_agents in
+               Relation_materializer.on_task_done ~assignee:agent_name ~active_agents:active
+             with _ -> ());
             Printf.sprintf "✅ %s completed %s" agent_name task_id
           end
     with e ->


### PR DESCRIPTION
## Summary
- 에이전트가 Room을 떠날 때 (`masc_leave`) 모든 동석 에이전트와 `COLLABORATED_WITH` 관계를 Neo4j에 자동 기록
- 태스크 완료 시 (`masc_done`) 동일한 관계 기록
- 모든 GraphQL 호출은 fire-and-forget (실패해도 MASC 동작에 영향 없음)

## Architecture
```
[agent leave/task done]
  → Relation_materializer.on_agent_leave / on_task_done
    → Graphql_client.mutate (recordCollaborationByName)
      → Railway GraphQL → Neo4j COLLABORATED_WITH edge
```

## Why
현재 Neo4j에 `COLLABORATED_WITH` 관계가 0건. 뮤테이션은 있지만 호출하는 곳이 없었음.
이 PR로 MASC 세션 참여만으로 에이전트 소셜 그래프가 자연스럽게 성장.

## Dependencies
- second-brain-graphql#16 (`recordCollaborationByName` 뮤테이션) — merged

## Files changed
| File | Change |
|------|--------|
| `lib/relation_materializer.ml` | New module (66 lines) |
| `lib/room.ml` | +8 lines (leave hook) |
| `lib/room_task.ml` | +5 lines (task done hook) |
| `lib/dune` | +1 line (module registration) |

## Test plan
- [x] `dune build` 성공
- [x] `make test` — 0 failures
- [ ] 실제 masc_leave 호출 시 Neo4j에 관계 생성 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)