### PR TITLE
fix(tools): 도구 설명 개선 — 11개 짧은 설명에 what/when/workflow 추가

### DIFF
--- a/lib/tool_board.ml
+++ b/lib/tool_board.ml
@@ -443,7 +443,7 @@ let tool_post_list : Types.tool_schema = {
 
 let tool_post_get : Types.tool_schema = {
   name = "masc_board_get";
-  description = "Get a specific post with comments";
+  description = "Get a specific post with its full comment thread. Use when you want to read discussion context before replying, or when you received a post_id from board_list/search.";
   input_schema = `Assoc [
     ("type", `String "object");
     ("properties", `Assoc [
@@ -455,7 +455,7 @@ let tool_post_get : Types.tool_schema = {
 
 let tool_comment_add : Types.tool_schema = {
   name = "masc_board_comment";
-  description = "Add a comment to a post";
+  description = "Add a comment to an existing board post. Use after reading a post with board_get to contribute your perspective, ask a question, or provide feedback.";
   input_schema = `Assoc [
     ("type", `String "object");
     ("properties", `Assoc [
@@ -471,7 +471,7 @@ let tool_comment_add : Types.tool_schema = {
 
 let tool_vote : Types.tool_schema = {
   name = "masc_board_vote";
-  description = "Vote on a post (up or down)";
+  description = "Vote on a board post (up or down) to signal agreement or quality. Use when you find a post valuable or want to deprioritize noise.";
   input_schema = `Assoc [
     ("type", `String "object");
     ("properties", `Assoc [
@@ -485,7 +485,7 @@ let tool_vote : Types.tool_schema = {
 
 let tool_stats : Types.tool_schema = {
   name = "masc_board_stats";
-  description = "Get board statistics";
+  description = "Get board activity statistics: total posts, comments, votes, active hearths. Use to understand overall board health and engagement levels.";
   input_schema = `Assoc [
     ("type", `String "object");
     ("properties", `Assoc []);
@@ -494,7 +494,7 @@ let tool_stats : Types.tool_schema = {
 
 let tool_search : Types.tool_schema = {
   name = "masc_board_search";
-  description = "Search posts by keyword";
+  description = "Search board posts by keyword across titles and content. Use when looking for specific topics, past discussions, or related prior work.";
   input_schema = `Assoc [
     ("type", `String "object");
     ("properties", `Assoc [
@@ -507,7 +507,7 @@ let tool_search : Types.tool_schema = {
 
 let tool_comment_vote : Types.tool_schema = {
   name = "masc_board_comment_vote";
-  description = "Vote on a comment (up or down)";
+  description = "Vote on a comment (up or down) to signal agreement or quality. Use after reading a comment thread to highlight valuable contributions.";
   input_schema = `Assoc [
     ("type", `String "object");
     ("properties", `Assoc [
@@ -521,7 +521,7 @@ let tool_comment_vote : Types.tool_schema = {
 
 let tool_profile : Types.tool_schema = {
   name = "masc_board_profile";
-  description = "Get agent profile with activity stats";
+  description = "Get an agent's board profile: post count, comment count, vote activity, and engagement stats. Use to understand an agent's contribution patterns.";
   input_schema = `Assoc [
     ("type", `String "object");
     ("properties", `Assoc [

--- a/lib/tool_lodge_project.ml
+++ b/lib/tool_lodge_project.ml
@@ -142,7 +142,7 @@ let tool_join_project : Types.tool_schema = {
 
 let tool_share_code : Types.tool_schema = {
   name = "lodge_share_code";
-  description = "Share a code snippet with other agents";
+  description = "Share a code snippet on the board for other agents to review, learn from, or discuss. Use when you found an interesting pattern or solution worth sharing.";
   input_schema = `Assoc [
     ("type", `String "object");
     ("properties", `Assoc [

--- a/lib/tool_protocol_game_view.ml
+++ b/lib/tool_protocol_game_view.ml
@@ -176,7 +176,7 @@ let schema name description input_schema : Types.tool_schema =
 let schemas : Types.tool_schema list =
   [
     schema "decision.create"
-      "Create a decision record for a session."
+      "Create a decision record for a team session. Use when the team needs to formally evaluate options with criteria and weights before committing to an approach."
       (object_schema
          ~required:[ "session_id"; "issue"; "options" ]
          [
@@ -187,7 +187,7 @@ let schemas : Types.tool_schema list =
            ("weights", object_schema []);
          ]);
     schema "decision.finalize"
-      "Finalize a decision. If verifier=WARN, risk_ack is required."
+      "Finalize a decision by selecting an option with rationale. Use after discussion/evaluation. If verifier=WARN, provide risk_ack to acknowledge the risk."
       (object_schema
          ~required:[ "session_id"; "decision_id"; "selected_option"; "rationale" ]
          [
@@ -483,12 +483,12 @@ let schemas : Types.tool_schema list =
          ~required:[ "session_id"; "input" ]
          [ ("session_id", string_schema); ("input", string_schema) ]);
     schema "client.input.approve"
-      "Approve a queued human input."
+      "Approve a queued human input so it becomes visible to the session. Use after reviewing a pending input from client.input.submit."
       (object_schema
          ~required:[ "session_id"; "input_id" ]
          [ ("session_id", string_schema); ("input_id", string_schema) ]);
     schema "client.input.reject"
-      "Reject a queued human input."
+      "Reject a queued human input with an optional reason. The input is removed from the queue and the submitter is notified."
       (object_schema
          ~required:[ "session_id"; "input_id" ]
          [ ("session_id", string_schema); ("input_id", string_schema); ("reason", string_schema) ]);


### PR DESCRIPTION
## Summary

40자 미만의 짧은 도구 설명 11개에 사용 맥락(when)과 워크플로우 연결 정보를 추가.

### 수정 패턴
Before: `"Add a comment to a post"`
After: `"Add a comment to an existing board post. Use after reading a post with board_get to contribute your perspective, ask a question, or provide feedback."`

### 수정 파일
| 파일 | 도구 수 | 도구 |
|------|---------|------|
| `tool_board.ml` | 7 | board_get, board_comment, board_vote, board_stats, board_search, board_comment_vote, board_profile |
| `tool_protocol_game_view.ml` | 3 | client.input.approve, client.input.reject, decision.create, decision.finalize |
| `tool_lodge_project.ml` | 1 | lodge_share_code |

### 남은 작업
25개 짧은 설명 + 전체 402개 what/when/workflow 구조화는 별도 이슈로 추적 예정.

## Test plan
- [x] `dune build` 성공

🤖 Generated with [Claude Code](https://claude.com/claude-code)