### PR TITLE
chore: bump version to 2.112.0

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -1,7 +1,7 @@
 (lang dune 3.13)
 
 (name masc_mcp)
-(version 2.111.0)
+(version 2.112.0)
 
 (generate_opam_files true)
 


### PR DESCRIPTION
## Summary
- `dune-project` version 2.111.0 → 2.112.0

## Changes since 2.111.0
- #1517: OAS Context_reducer adapter (Phase 1 runtime migration)
- #1530: classify 20 masc_trpg_* tools into TRPG category
- #1533: improve 11 short tool descriptions

## Test plan
- [x] `dune build` 성공

🤖 Generated with [Claude Code](https://claude.com/claude-code)