### PR TITLE
feat(orchestration): provider-aware capacity check in cascade

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -550,6 +550,7 @@
    llm_types
    llm_eio_env
    llm_provider_bridge
+   llm_discovery_cache
    llm_orchestration
    llm_client
    llm_provider_oas

--- a/lib/llm_discovery_cache.ml
+++ b/lib/llm_discovery_cache.ml
@@ -1,0 +1,216 @@
+(** Llm_discovery_cache — probes local LLM endpoints and maintains a
+    cached snapshot of their status.
+
+    This module has no dependency on Llm_client or Llm_orchestration,
+    so it can be used by both without circular dependencies.
+
+    @since 2.113.0 *)
+
+(* ── Env config ──────────────────────────────────────────── *)
+
+let default_endpoint = "http://127.0.0.1:8085"
+
+let endpoints_from_env () =
+  match Sys.getenv_opt "LLM_ENDPOINTS" with
+  | None | Some "" -> [default_endpoint]
+  | Some value ->
+    value
+    |> String.split_on_char ','
+    |> List.map String.trim
+    |> List.filter (fun s -> s <> "")
+
+(* ── HTTP probing via curl ───────────────────────────────── *)
+
+let http_get_json ?(timeout_sec = 5) url =
+  let status, body =
+    Process_eio.run_argv_with_status ~timeout_sec:10.0
+      [ "curl"; "-sS"; "--http1.1"; "--max-time";
+        string_of_int (max 1 timeout_sec); url ]
+  in
+  match status with
+  | Unix.WEXITED 0 ->
+    (try Ok (Yojson.Safe.from_string body)
+     with Yojson.Json_error msg -> Error msg)
+  | Unix.WEXITED code ->
+    Error (Printf.sprintf "curl exit %d for %s" code url)
+  | _ -> Error (Printf.sprintf "curl failed for %s" url)
+
+let http_get_ok ?(timeout_sec = 3) url =
+  let status, _ =
+    Process_eio.run_argv_with_status ~timeout_sec:5.0
+      [ "curl"; "-sS"; "--http1.1"; "--max-time";
+        string_of_int (max 1 timeout_sec); url ]
+  in
+  match status with Unix.WEXITED 0 -> true | _ -> false
+
+(* ── Parsers ─────────────────────────────────────────────── *)
+
+let parse_models json =
+  let open Yojson.Safe.Util in
+  match member "data" json with
+  | `List items ->
+    items |> List.filter_map (fun item ->
+      match item |> member "id" |> to_string_option with
+      | Some id ->
+        let owned_by =
+          item |> member "owned_by" |> to_string_option
+          |> Option.value ~default:"unknown"
+        in
+        Some (id, owned_by)
+      | None -> None)
+  | _ -> []
+
+let parse_props json =
+  let open Yojson.Safe.Util in
+  match member "total_slots" json with
+  | `Int total_slots ->
+    let dgs = member "default_generation_settings" json in
+    let ctx_size = match dgs with
+      | `Assoc _ -> (match member "n_ctx" dgs with `Int n -> n | _ -> 0)
+      | _ -> 0
+    in
+    let model = match dgs with
+      | `Assoc _ -> (match member "model" dgs with `String s -> s | _ -> "")
+      | _ -> ""
+    in
+    Some (total_slots, ctx_size, model)
+  | _ -> None
+
+let parse_slots json =
+  let open Yojson.Safe.Util in
+  let items = match json with `List items -> items | _ -> [] in
+  if items = [] then None
+  else
+    let total = List.length items in
+    let busy = List.fold_left (fun acc slot ->
+      let is_busy =
+        (slot |> member "is_processing" |> to_bool_option
+         |> Option.value ~default:false)
+        || (match slot |> member "state" with `Int n -> n <> 0 | _ -> false)
+      in
+      if is_busy then acc + 1 else acc
+    ) 0 items in
+    Some (total, busy, total - busy)
+
+let string_contains_ci ~haystack ~needle =
+  let h = String.lowercase_ascii haystack in
+  let n = String.lowercase_ascii needle in
+  let nlen = String.length n in
+  let hlen = String.length h in
+  if nlen > hlen then false
+  else
+    let found = ref false in
+    let i = ref 0 in
+    while !i <= hlen - nlen && not !found do
+      if String.sub h !i nlen = n then found := true;
+      incr i
+    done;
+    !found
+
+(* ── Endpoint info ───────────────────────────────────────── *)
+
+type endpoint_info = {
+  url: string;
+  healthy: bool;
+  model: string option;
+  context_size: int option;
+  slots_total: int option;
+  slots_busy: int option;
+  slots_idle: int option;
+  supports_reasoning: bool;
+  supports_tools: bool;
+  supports_streaming: bool;
+}
+
+let probe_endpoint url =
+  let base = String.trim url in
+  let healthy = http_get_ok (base ^ "/health") in
+  if not healthy then
+    { url = base; healthy = false; model = None; context_size = None;
+      slots_total = None; slots_busy = None; slots_idle = None;
+      supports_reasoning = false; supports_tools = false;
+      supports_streaming = false }
+  else
+    let models = match http_get_json (base ^ "/v1/models") with
+      | Ok json -> parse_models json | Error _ -> [] in
+    let props = match http_get_json (base ^ "/props") with
+      | Ok json -> parse_props json | Error _ -> None in
+    let slots = match http_get_json (base ^ "/slots") with
+      | Ok json -> parse_slots json | Error _ -> None in
+    let model_id = match models with (id, _) :: _ -> Some id | [] -> None in
+    let has_qwen = List.exists (fun (id, _) ->
+      string_contains_ci ~haystack:id ~needle:"qwen") models in
+    { url = base;
+      healthy = true;
+      model = (match props with Some (_, _, m) when m <> "" -> Some m
+                               | _ -> model_id);
+      context_size = (match props with Some (_, ctx, _) when ctx > 0 -> Some ctx
+                                      | _ -> None);
+      slots_total = (match slots with Some (t, _, _) -> Some t
+                                     | None -> Option.map (fun (t, _, _) -> t) props);
+      slots_busy = (match slots with Some (_, b, _) -> Some b | None -> None);
+      slots_idle = (match slots with Some (_, _, i) -> Some i | None -> None);
+      supports_reasoning = has_qwen;
+      supports_tools = true;
+      supports_streaming = true;
+    }
+
+(* ── Cache ───────────────────────────────────────────────── *)
+
+let cached_endpoints : endpoint_info list ref = ref []
+let cache_updated_at : float ref = ref 0.0
+let cache_ttl = 30.0
+
+let refresh_cache () =
+  let endpoints = endpoints_from_env () in
+  let results = List.map probe_endpoint endpoints in
+  cached_endpoints := results;
+  cache_updated_at := Time_compat.now ()
+
+let get_cached_or_refresh () =
+  let now = Time_compat.now () in
+  if now -. !cache_updated_at > cache_ttl || !cached_endpoints = [] then
+    refresh_cache ();
+  !cached_endpoints
+
+let cache_age_seconds () =
+  Time_compat.now () -. !cache_updated_at
+
+(* ── Convenience queries ─────────────────────────────────── *)
+
+let any_local_healthy () =
+  let endpoints = get_cached_or_refresh () in
+  List.exists (fun (e : endpoint_info) -> e.healthy) endpoints
+
+let idle_slot_count () =
+  let endpoints = get_cached_or_refresh () in
+  List.fold_left (fun acc (e : endpoint_info) ->
+    acc + Option.value ~default:0 e.slots_idle) 0 endpoints
+
+let busy_slot_count () =
+  let endpoints = get_cached_or_refresh () in
+  List.fold_left (fun acc (e : endpoint_info) ->
+    acc + Option.value ~default:0 e.slots_busy) 0 endpoints
+
+(* ── JSON ────────────────────────────────────────────────── *)
+
+let int_opt_to_json = function Some v -> `Int v | None -> `Null
+let string_opt_to_json = function Some v -> `String v | None -> `Null
+
+let endpoint_to_json (e : endpoint_info) =
+  `Assoc [
+    ("url", `String e.url);
+    ("healthy", `Bool e.healthy);
+    ("model", string_opt_to_json e.model);
+    ("context_size", int_opt_to_json e.context_size);
+    ("slots", `Assoc [
+      ("total", int_opt_to_json e.slots_total);
+      ("busy", int_opt_to_json e.slots_busy);
+      ("idle", int_opt_to_json e.slots_idle);
+    ]);
+    ("capabilities", `Assoc [
+      ("reasoning", `Bool e.supports_reasoning);
+      ("tools", `Bool e.supports_tools);
+      ("streaming", `Bool e.supports_streaming);
+    ]);
+  ]

--- a/lib/llm_orchestration.ml
+++ b/lib/llm_orchestration.ml
@@ -279,11 +279,45 @@ let complete ?timeout_sec (req : completion_request) : (completion_response, str
   Result.map (fun resp -> { resp with latency_ms = elapsed_ms }) result
 
 (* ================================================================ *)
+(* Provider-aware capacity check                                    *)
+(* ================================================================ *)
+
+(** Check whether local providers (Llama) have healthy endpoints.
+    Returns the request list with unhealthy local providers removed.
+    Cloud providers (Anthropic, Gemini, GLM, etc.) always pass through. *)
+let filter_by_provider_health (requests : completion_request list)
+    : completion_request list =
+  let has_local_request =
+    List.exists (fun (r : completion_request) ->
+      r.model.provider = Llama) requests
+  in
+  if not has_local_request then requests
+  else
+    let endpoints = Llm_discovery_cache.get_cached_or_refresh () in
+    let any_healthy = Llm_discovery_cache.any_local_healthy () in
+    let idle = Llm_discovery_cache.idle_slot_count () in
+    let busy = Llm_discovery_cache.busy_slot_count () in
+    Log.LlmClient.info
+      "cascade capacity: local endpoints=%d healthy=%b idle=%d busy=%d"
+      (List.length endpoints) any_healthy idle busy;
+    if not any_healthy then begin
+      Log.LlmClient.warn
+        "cascade: all local endpoints unhealthy, skipping local providers";
+      List.filter (fun (r : completion_request) ->
+        r.model.provider <> Llama) requests
+    end else
+      requests
+
+(* ================================================================ *)
 (* Cascade: try models in order                                     *)
 (* ================================================================ *)
 
 let cascade ?(accept = fun _ -> true) ?timeout_sec
     (requests : completion_request list) : (completion_response, string) result =
+  let requests = filter_by_provider_health requests in
+  if requests = [] then
+    Error "All providers unhealthy (local endpoints down, no cloud fallback)"
+  else
   with_llm_permit (fun () ->
     let avail = Eio.Semaphore.get_value llm_semaphore in
     Log.LlmClient.debug "cascade: acquired permit (%d/%d available)"

--- a/lib/llm_orchestration.mli
+++ b/lib/llm_orchestration.mli
@@ -8,6 +8,13 @@ val llm_permits_in_use : unit -> int
 
 val cache_key_of_request : Llm_types.completion_request -> string
 
+(** Filter cascade requests by provider health.
+    Removes local (Llama) providers when all local endpoints are unhealthy,
+    allowing cloud providers to serve as fallback.
+    Cloud providers always pass through. *)
+val filter_by_provider_health :
+  Llm_types.completion_request list -> Llm_types.completion_request list
+
 val complete :
   ?timeout_sec:int ->
   Llm_types.completion_request ->

--- a/lib/tool_llm_catalog.ml
+++ b/lib/tool_llm_catalog.ml
@@ -1,12 +1,13 @@
 [@@@warning "-32-33-69"]
 (** Tool_llm_catalog — LLM endpoint discovery and capacity management.
 
+    Thin MCP tool layer over {!Llm_discovery_cache}.
     Provides agents with visibility into available LLM infrastructure:
     - list: enumerate configured endpoints and loaded models
     - status: current slot utilization and capacity
     - recommend: pick best endpoint for a given task type
 
-    @since 2.95.0 *)
+    @since 2.113.0 *)
 
 open Types
 
@@ -21,221 +22,32 @@ let json_error message =
 let json_ok fields =
   Yojson.Safe.to_string (`Assoc (("status", `String "ok") :: fields))
 
-let int_opt_to_json = function Some v -> `Int v | None -> `Null
 let string_opt_to_json = function Some v -> `String v | None -> `Null
-
-(* ── Env config ──────────────────────────────────────────── *)
-
-let default_endpoint = "http://127.0.0.1:8085"
-
-let endpoints_from_env () =
-  match Sys.getenv_opt "LLM_ENDPOINTS" with
-  | None | Some "" -> [default_endpoint]
-  | Some value ->
-    value
-    |> String.split_on_char ','
-    |> List.map String.trim
-    |> List.filter (fun s -> s <> "")
-
-(* ── HTTP probing via curl (consistent with tool_llama) ──── *)
-
-let http_get_json ?(timeout_sec = 5) url =
-  let status, body =
-    Process_eio.run_argv_with_status ~timeout_sec:10.0
-      [ "curl"; "-sS"; "--http1.1"; "--max-time";
-        string_of_int (max 1 timeout_sec); url ]
-  in
-  match status with
-  | Unix.WEXITED 0 ->
-    (try Ok (Yojson.Safe.from_string body)
-     with Yojson.Json_error msg -> Error msg)
-  | Unix.WEXITED code ->
-    Error (Printf.sprintf "curl exit %d for %s" code url)
-  | _ -> Error (Printf.sprintf "curl failed for %s" url)
-
-let http_get_ok ?(timeout_sec = 3) url =
-  let status, _ =
-    Process_eio.run_argv_with_status ~timeout_sec:5.0
-      [ "curl"; "-sS"; "--http1.1"; "--max-time";
-        string_of_int (max 1 timeout_sec); url ]
-  in
-  match status with Unix.WEXITED 0 -> true | _ -> false
-
-(* ── Parsers ─────────────────────────────────────────────── *)
-
-let parse_models json =
-  let open Yojson.Safe.Util in
-  match member "data" json with
-  | `List items ->
-    items |> List.filter_map (fun item ->
-      match item |> member "id" |> to_string_option with
-      | Some id ->
-        let owned_by =
-          item |> member "owned_by" |> to_string_option
-          |> Option.value ~default:"unknown"
-        in
-        Some (id, owned_by)
-      | None -> None)
-  | _ -> []
-
-let parse_props json =
-  let open Yojson.Safe.Util in
-  match member "total_slots" json with
-  | `Int total_slots ->
-    let dgs = member "default_generation_settings" json in
-    let ctx_size = match dgs with
-      | `Assoc _ ->
-        (match member "n_ctx" dgs with `Int n -> n | _ -> 0)
-      | _ -> 0
-    in
-    let model = match dgs with
-      | `Assoc _ ->
-        (match member "model" dgs with `String s -> s | _ -> "")
-      | _ -> ""
-    in
-    Some (total_slots, ctx_size, model)
-  | _ -> None
-
-let parse_slots json =
-  let open Yojson.Safe.Util in
-  let items = match json with `List items -> items | _ -> [] in
-  if items = [] then None
-  else
-    let total = List.length items in
-    let busy = List.fold_left (fun acc slot ->
-      let is_busy =
-        (slot |> member "is_processing" |> to_bool_option
-         |> Option.value ~default:false)
-        || (match slot |> member "state" with
-            | `Int n -> n <> 0 | _ -> false)
-      in
-      if is_busy then acc + 1 else acc
-    ) 0 items in
-    Some (total, busy, total - busy)
-
-let string_contains_ci ~haystack ~needle =
-  let h = String.lowercase_ascii haystack in
-  let n = String.lowercase_ascii needle in
-  let nlen = String.length n in
-  let hlen = String.length h in
-  if nlen > hlen then false
-  else
-    let found = ref false in
-    let i = ref 0 in
-    while !i <= hlen - nlen && not !found do
-      if String.sub h !i nlen = n then found := true;
-      incr i
-    done;
-    !found
-
-(* ── Probe single endpoint ───────────────────────────────── *)
-
-type endpoint_info = {
-  url: string;
-  healthy: bool;
-  model: string option;
-  context_size: int option;
-  slots_total: int option;
-  slots_busy: int option;
-  slots_idle: int option;
-  supports_reasoning: bool;
-  supports_tools: bool;
-  supports_streaming: bool;
-}
-
-let probe_endpoint url =
-  let base = String.trim url in
-  let healthy = http_get_ok (base ^ "/health") in
-  if not healthy then
-    { url = base; healthy = false; model = None; context_size = None;
-      slots_total = None; slots_busy = None; slots_idle = None;
-      supports_reasoning = false; supports_tools = false;
-      supports_streaming = false }
-  else
-    let models = match http_get_json (base ^ "/v1/models") with
-      | Ok json -> parse_models json | Error _ -> [] in
-    let props = match http_get_json (base ^ "/props") with
-      | Ok json -> parse_props json | Error _ -> None in
-    let slots = match http_get_json (base ^ "/slots") with
-      | Ok json -> parse_slots json | Error _ -> None in
-    let model_id = match models with (id, _) :: _ -> Some id | [] -> None in
-    let has_qwen = List.exists (fun (id, _) ->
-      string_contains_ci ~haystack:id ~needle:"qwen") models in
-    { url = base;
-      healthy = true;
-      model = (match props with Some (_, _, m) when m <> "" -> Some m
-                               | _ -> model_id);
-      context_size = (match props with Some (_, ctx, _) when ctx > 0 -> Some ctx
-                                      | _ -> None);
-      slots_total = (match slots with Some (t, _, _) -> Some t
-                                     | None -> Option.map (fun (t, _, _) -> t) props);
-      slots_busy = (match slots with Some (_, b, _) -> Some b | None -> None);
-      slots_idle = (match slots with Some (_, _, i) -> Some i | None -> None);
-      supports_reasoning = has_qwen;
-      supports_tools = true;
-      supports_streaming = true;
-    }
-
-let endpoint_to_json (e : endpoint_info) =
-  `Assoc [
-    ("url", `String e.url);
-    ("healthy", `Bool e.healthy);
-    ("model", string_opt_to_json e.model);
-    ("context_size", int_opt_to_json e.context_size);
-    ("slots", `Assoc [
-      ("total", int_opt_to_json e.slots_total);
-      ("busy", int_opt_to_json e.slots_busy);
-      ("idle", int_opt_to_json e.slots_idle);
-    ]);
-    ("capabilities", `Assoc [
-      ("reasoning", `Bool e.supports_reasoning);
-      ("tools", `Bool e.supports_tools);
-      ("streaming", `Bool e.supports_streaming);
-    ]);
-  ]
-
-(* ── Discovery cache (Eio.Mutex protected) ───────────────── *)
-
-let cached_endpoints : endpoint_info list ref = ref []
-let cache_updated_at : float ref = ref 0.0
-let cache_ttl = 30.0
-
-let refresh_cache () =
-  let endpoints = endpoints_from_env () in
-  let results = List.map probe_endpoint endpoints in
-  cached_endpoints := results;
-  cache_updated_at := Time_compat.now ()
-
-let get_cached_or_refresh () =
-  let now = Time_compat.now () in
-  if now -. !cache_updated_at > cache_ttl || !cached_endpoints = [] then
-    refresh_cache ();
-  !cached_endpoints
 
 (* ── Handlers ────────────────────────────────────────────── *)
 
 let handle_list _ctx _args : result =
-  let endpoints = get_cached_or_refresh () in
+  let endpoints = Llm_discovery_cache.get_cached_or_refresh () in
   (true, json_ok [
     ("result", `Assoc [
-      ("endpoints", `List (List.map endpoint_to_json endpoints));
+      ("endpoints", `List (List.map Llm_discovery_cache.endpoint_to_json endpoints));
       ("count", `Int (List.length endpoints));
     ]);
   ])
 
 let handle_status _ctx _args : result =
-  let endpoints = get_cached_or_refresh () in
-  let total_cap = List.fold_left (fun acc (e : endpoint_info) ->
+  let endpoints = Llm_discovery_cache.get_cached_or_refresh () in
+  let total_cap = List.fold_left (fun acc (e : Llm_discovery_cache.endpoint_info) ->
     acc + Option.value ~default:0 e.slots_total) 0 endpoints in
-  let available = List.fold_left (fun acc (e : endpoint_info) ->
+  let available = List.fold_left (fun acc (e : Llm_discovery_cache.endpoint_info) ->
     acc + Option.value ~default:0 e.slots_idle) 0 endpoints in
-  let active = List.fold_left (fun acc (e : endpoint_info) ->
+  let active = List.fold_left (fun acc (e : Llm_discovery_cache.endpoint_info) ->
     acc + Option.value ~default:0 e.slots_busy) 0 endpoints in
   let permits_available = Llm_client.llm_semaphore_available () in
   let permits_in_use = Llm_client.llm_permits_in_use () in
   (true, json_ok [
     ("result", `Assoc [
-      ("endpoints", `List (List.map endpoint_to_json endpoints));
+      ("endpoints", `List (List.map Llm_discovery_cache.endpoint_to_json endpoints));
       ("summary", `Assoc [
         ("total_capacity", `Int total_cap);
         ("available_capacity", `Int available);
@@ -244,12 +56,12 @@ let handle_status _ctx _args : result =
         ("masc_permits_in_use", `Int permits_in_use);
         ("masc_max_concurrent_llm", `Int Llm_client.max_concurrent_llm);
       ]);
-      ("cached_at", `Float !cache_updated_at);
+      ("cache_age_seconds", `Float (Llm_discovery_cache.cache_age_seconds ()));
     ]);
   ])
 
 let handle_recommend _ctx args : result =
-  let endpoints = get_cached_or_refresh () in
+  let endpoints = Llm_discovery_cache.get_cached_or_refresh () in
   let task_type =
     args |> Yojson.Safe.Util.member "task_type"
     |> Yojson.Safe.Util.to_string_option
@@ -258,11 +70,12 @@ let handle_recommend _ctx args : result =
     | Some "reasoning" | Some "analysis" | Some "planning" -> true
     | _ -> false
   in
-  let healthy = List.filter (fun (e : endpoint_info) -> e.healthy) endpoints in
-  let with_idle = List.filter (fun (e : endpoint_info) ->
+  let healthy = List.filter (fun (e : Llm_discovery_cache.endpoint_info) ->
+    e.healthy) endpoints in
+  let with_idle = List.filter (fun (e : Llm_discovery_cache.endpoint_info) ->
     match e.slots_idle with Some n -> n > 0 | None -> true) healthy in
   let candidates = if with_idle <> [] then with_idle else healthy in
-  let scored = List.map (fun (e : endpoint_info) ->
+  let scored = List.map (fun (e : Llm_discovery_cache.endpoint_info) ->
     let idle_score = Option.value ~default:0 e.slots_idle in
     let reasoning_bonus = if needs_reasoning && e.supports_reasoning then 10 else 0 in
     (e, idle_score + reasoning_bonus)
@@ -283,7 +96,7 @@ let handle_recommend _ctx args : result =
         ("recommended_endpoint", `String best.url);
         ("model", string_opt_to_json best.model);
         ("reason", `String reason);
-        ("endpoint_detail", endpoint_to_json best);
+        ("endpoint_detail", Llm_discovery_cache.endpoint_to_json best);
       ]);
     ])
   | [] ->


### PR DESCRIPTION
## Summary
- Extract `llm_discovery_cache.ml` — probing + cache without Llm_client dependency (breaks cycle)
- `filter_by_provider_health` in cascade: skip unhealthy local providers, pass cloud through
- `tool_llm_catalog.ml` simplified to thin wrapper over `llm_discovery_cache` (-145 lines)

## Architecture
```
llm_discovery_cache.ml  ← pure probing + cache (no Llm_client dep)
  ↑                ↑
tool_llm_catalog   llm_orchestration  (both read cache)
  ↓
Llm_client         (permit info only)
```

## Cascade behavior
- Local provider (Llama) in cascade → check discovery cache for endpoint health
- All local endpoints unhealthy → skip Llama requests, cloud fallback
- Slot busy → log only, provider internal queue handles it
- Cloud providers → always pass through (no local health check)

## Test plan
- [x] `dune build --root .` — clean, no cycles
- [x] `test_mode_tool_count.exe` — 18/18 pass
- [x] `test_tool_dispatch.exe` — 13/13 pass
- [ ] Integration: cascade with llama-server down → cloud fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)