### PR TITLE
feat(dashboard): agent relations card — collaboration network + interests

### DIFF
--- a/dashboard/src/api/dashboard.ts
+++ b/dashboard/src/api/dashboard.ts
@@ -86,6 +86,31 @@ export function fetchAgentTimeline(
   return get(`/api/v1/agent-timeline?agent_name=${encodeURIComponent(agentName)}&since_hours=${sinceHours}&limit=${limit}`)
 }
 
+export type AgentCollaborator = {
+  name: string
+  collaborations: number
+  last_collab: string | null
+}
+
+export type AgentRelation = {
+  type: string
+  category: string | null
+  confidence: number | null
+  note: string | null
+  participants: { kind: string; display_name: string | null; role: string | null }[]
+}
+
+export type AgentRelationsResponse = {
+  agent_name: string
+  collaborators: AgentCollaborator[]
+  interests: string[]
+  relations: AgentRelation[]
+}
+
+export function fetchAgentRelations(agentName: string): Promise<AgentRelationsResponse> {
+  return get(`/api/v1/agent-relations?agent_name=${encodeURIComponent(agentName)}`)
+}
+
 export function fetchDashboardRoomTruth(): Promise<DashboardRoomTruthResponse> {
   return get('/api/v1/dashboard/room-truth', { timeoutMs: ROOM_TRUTH_GET_TIMEOUT_MS })
 }

--- a/dashboard/src/components/agent-profile.ts
+++ b/dashboard/src/components/agent-profile.ts
@@ -22,8 +22,10 @@ import {
   fetchTaskHistory,
   sendBroadcast,
   fetchAgentTimeline,
+  fetchAgentRelations,
   type AgentTimelineEvent,
   type AgentTimelineResponse,
+  type AgentRelationsResponse,
 } from '../api'
 import { journal } from '../sse'
 import { missionSnapshot } from '../mission-store'
@@ -47,6 +49,7 @@ const profileError = signal('')
 const roomActivity = signal<string[]>([])
 const taskHistories = signal<TaskHistoryRow[]>([])
 const agentTimeline = signal<AgentTimelineResponse | null>(null)
+const agentRelations = signal<AgentRelationsResponse | null>(null)
 const mentionText = signal('')
 const sendingMention = signal(false)
 
@@ -103,12 +106,16 @@ async function loadProfile(name: string): Promise<void> {
   roomActivity.value = []
   taskHistories.value = []
   agentTimeline.value = null
+  agentRelations.value = null
 
   try {
-    const [lines, timeline] = await Promise.all([
+    const [lines, timeline, relations] = await Promise.all([
       fetchRoomMessages(80),
       fetchAgentTimeline(name, 4, 20).catch(() => null),
+      fetchAgentRelations(name).catch(() => null),
     ])
+
+    agentRelations.value = relations
 
     roomActivity.value = lines
       .filter(line => line.includes(name))
@@ -344,6 +351,42 @@ export function AgentProfile({ name }: { name: string }) {
                 </div>
               `)}</div>`}
         <//>
+
+        ${(() => {
+          const rel = agentRelations.value
+          if (!rel) return null
+          const collabs = rel.collaborators ?? []
+          const interests = rel.interests ?? []
+          const hasData = collabs.length > 0 || interests.length > 0
+          if (!hasData) return null
+          return html`
+            <${Card} title="관계 (${collabs.length})" class="ff-card">
+              ${collabs.length > 0 ? html`
+                <div class="ff-relations-list">
+                  ${collabs.map(c => html`
+                    <div class="ff-relation-row" key=${c.name}
+                      onClick=${() => navigate('agents', { agent: c.name })}
+                      style="cursor:pointer;"
+                    >
+                      <span class="ff-relation-name">${c.name}</span>
+                      <span class="ff-relation-count">${c.collaborations}회</span>
+                      ${c.last_collab ? html`<span class="ff-relation-time"><${TimeAgo} timestamp=${c.last_collab} /></span>` : null}
+                    </div>
+                  `)}
+                </div>
+              ` : null}
+              ${interests.length > 0 ? html`
+                <div class="ff-interests" style="margin-top:8px;">
+                  <span class="ff-interests-label">관심사</span>
+                  <div class="ff-interests-tags">
+                    ${interests.slice(0, 12).map(t => html`<span class="ff-interest-tag" key=${t}>${t}</span>`)}
+                    ${interests.length > 12 ? html`<span class="ff-interest-tag">+${interests.length - 12}</span>` : null}
+                  </div>
+                </div>
+              ` : null}
+            <//>
+          `
+        })()}
 
         <${Card} title="타임라인" class="ff-card">
           ${!timeline || (timeline.events ?? []).length === 0

--- a/dashboard/src/styles/governance.css
+++ b/dashboard/src/styles/governance.css
@@ -798,6 +798,73 @@ button.council-row.selected {
   .ff-profile__grid { grid-template-columns: 1fr; }
 }
 
+/* --- Agent Relations Card --- */
+
+.ff-relations-list {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.ff-relation-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 8px;
+  border-radius: 4px;
+  transition: background 0.15s;
+}
+
+.ff-relation-row:hover {
+  background: rgba(255, 215, 0, 0.08);
+}
+
+.ff-relation-name {
+  color: #c8a84e;
+  font-weight: 600;
+  font-size: 13px;
+  flex: 1;
+}
+
+.ff-relation-count {
+  color: rgba(255, 255, 255, 0.5);
+  font-size: 12px;
+  font-variant-numeric: tabular-nums;
+}
+
+.ff-relation-time {
+  color: rgba(255, 255, 255, 0.35);
+  font-size: 11px;
+}
+
+.ff-interests {
+  border-top: 1px solid rgba(255, 255, 255, 0.06);
+  padding-top: 8px;
+}
+
+.ff-interests-label {
+  font-size: 11px;
+  color: rgba(255, 255, 255, 0.4);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.ff-interests-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  margin-top: 6px;
+}
+
+.ff-interest-tag {
+  background: rgba(255, 215, 0, 0.1);
+  color: rgba(255, 255, 255, 0.7);
+  padding: 2px 8px;
+  border-radius: 3px;
+  font-size: 11px;
+  border: 1px solid rgba(255, 215, 0, 0.15);
+}
+
 /* ── Keeper Rich Card (Overview) ──────────────────────────── */
 @keyframes keeperPulse {
   0%, 100% { opacity: 1; box-shadow: 0 0 0 0 rgba(74,222,128,0.4); }

--- a/lib/dashboard_agent_relations.ml
+++ b/lib/dashboard_agent_relations.ml
@@ -1,0 +1,100 @@
+(** Dashboard Agent Relations — proxy to GraphQL for agent relationship data.
+
+    Fetches COLLABORATED_WITH network and TRUSTS edges for an agent from
+    the Second Brain GraphQL server and returns them as dashboard JSON.
+
+    @since 2.113.0
+*)
+
+let collaborators_query = {|
+  query($name: String!) {
+    agentCollaborationNetworkByName(name: $name) {
+      hash name collaborations lastCollab
+    }
+  }
+|}
+
+let trusts_query = {|
+  query($name: String!) {
+    agent(name: $name) {
+      name
+      interests
+      relations(first: 20, visibility: "public") {
+        edges { node {
+          relationId type category confidence note
+          participants(first: 5) {
+            edges { node { kind displayName role agentUuid personUid } }
+          }
+        } }
+      }
+    }
+  }
+|}
+
+(** Build the JSON response for agent relations.
+    Combines collaboration network + trust edges + generic relations. *)
+let json ~agent_name () : Yojson.Safe.t =
+  let collaborators =
+    let variables = `Assoc [("name", `String agent_name)] in
+    match Graphql_client.query ~timeout_sec:8.0 ~query:collaborators_query ~variables () with
+    | Ok data ->
+      let open Yojson.Safe.Util in
+      data |> member "agentCollaborationNetworkByName" |> to_list
+      |> List.map (fun edge ->
+        `Assoc [
+          ("name", member "name" edge);
+          ("collaborations", member "collaborations" edge);
+          ("last_collab", member "lastCollab" edge);
+        ])
+    | Error _ -> []
+  in
+  let agent_data =
+    let variables = `Assoc [("name", `String agent_name)] in
+    match Graphql_client.query ~timeout_sec:8.0 ~query:trusts_query ~variables () with
+    | Ok data ->
+      let open Yojson.Safe.Util in
+      let agent = data |> member "agent" in
+      if agent = `Null then None
+      else Some agent
+    | Error _ -> None
+  in
+  let interests = match agent_data with
+    | Some agent ->
+      let open Yojson.Safe.Util in
+      (try agent |> member "interests" |> to_list
+       with _ -> [])
+    | None -> []
+  in
+  let relations = match agent_data with
+    | Some agent ->
+      let open Yojson.Safe.Util in
+      (try
+        agent |> member "relations" |> member "edges" |> to_list
+        |> List.map (fun edge ->
+          let node = edge |> member "node" in
+          let participants =
+            node |> member "participants" |> member "edges" |> to_list
+            |> List.map (fun p ->
+              let pn = p |> member "node" in
+              `Assoc [
+                ("kind", member "kind" pn);
+                ("display_name", member "displayName" pn);
+                ("role", member "role" pn);
+              ])
+          in
+          `Assoc [
+            ("type", member "type" node);
+            ("category", member "category" node);
+            ("confidence", member "confidence" node);
+            ("note", member "note" node);
+            ("participants", `List participants);
+          ])
+       with _ -> [])
+    | None -> []
+  in
+  `Assoc [
+    ("agent_name", `String agent_name);
+    ("collaborators", `List collaborators);
+    ("interests", `List interests);
+    ("relations", `List relations);
+  ]

--- a/lib/dune
+++ b/lib/dune
@@ -57,6 +57,7 @@
    context_router
    dashboard
    dashboard_labels
+   dashboard_agent_relations
    dashboard_attention
    dashboard_cache
    dashboard_governance

--- a/lib/server_routes_http_routes_dashboard.ml
+++ b/lib/server_routes_http_routes_dashboard.ml
@@ -211,6 +211,23 @@ let add_routes ~sw ~clock router =
              (Yojson.Safe.to_string json) reqd
        ) request reqd)
 
+  (* Agent relations — collaboration network + trust edges from Neo4j *)
+  |> Http.Router.get "/api/v1/agent-relations" (fun request reqd ->
+       with_public_read (fun _state req reqd ->
+         let agent_name =
+           match Server_utils.query_param req "agent_name" with
+           | Some n when String.trim n <> "" -> String.trim n
+           | _ -> ""
+         in
+         if agent_name = "" then
+           Http.Response.json ~status:`Bad_request
+             {|{"error":"agent_name query parameter is required"}|} reqd
+         else
+           let json = Dashboard_agent_relations.json ~agent_name () in
+           Http.Response.json ~compress:true ~request:req
+             (Yojson.Safe.to_string json) reqd
+       ) request reqd)
+
   |> Http.Router.get "/api/v1/mdal/loops" (fun request reqd ->
        with_public_read (fun state req reqd ->
          match mdal_loops_json ~config:state.Mcp_server.room_config req with


### PR DESCRIPTION
## Summary
- Agent Profile 페이지에 "관계" 카드 추가 — 협업 네트워크 + 관심사 표시
- `/api/v1/agent-relations` 엔드포인트 (MASC → GraphQL → Neo4j 프록시)
- FF 테마 스타일 적용 (gold accent, hover 효과)
- 협업자 이름 클릭 시 해당 에이전트 프로필로 이동

## Architecture
```
Dashboard → /api/v1/agent-relations?agent_name=X
  → dashboard_agent_relations.ml
    → Graphql_client.query (agentCollaborationNetworkByName + agent.interests)
      → Railway GraphQL → Neo4j
```

## Test plan
- [x] `dune build` 성공
- [x] `npx vite build` 성공
- [ ] 서버 재시작 후 실제 데이터 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)