### PR TITLE
chore: bump version to 2.113.0

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -1,7 +1,7 @@
 (lang dune 3.13)
 
 (name masc_mcp)
-(version 2.112.0)
+(version 2.113.0)
 
 (generate_opam_files true)
 


### PR DESCRIPTION
## Summary
- `dune-project` version 2.112.0 → 2.113.0

## Changes since 2.112.0 (7 commits)
- #1535: `masc_llm_catalog` for LLM endpoint discovery
- #1536: remove 26 unreferenced OCaml modules (-5,485 lines)
- #1537: extract shared scoring, add 20 tests, unify feature flags
- #1538: expand 26 short tool descriptions
- #1540: protect sentinel tags from OAS Merge_contiguous corruption + .mli
- #1541: provider-aware capacity check in cascade
- #1542: agent collaboration network and interests in dashboard profile

## Test plan
- [x] `dune build` 성공

🤖 Generated with [Claude Code](https://claude.com/claude-code)