### PR TITLE
refactor: split perpetual_oas.ml (569->4 files) + shared compaction_types

### DIFF
--- a/lib/compaction_types.ml
+++ b/lib/compaction_types.ml
@@ -1,0 +1,19 @@
+(** Compaction_types — Shared compaction strategy type.
+
+    Single source of truth for the compaction strategy variant used by both
+    [Context_manager] and [Context_compact_oas]. Extracted to break the
+    type duplication between these modules.
+
+    @since 2.111.0 — M1 shared type extraction *)
+
+(** Compaction strategies applied in order during context reduction.
+
+    - [PruneToolOutputs]: truncate verbose tool results (keep first/last 100 chars)
+    - [MergeContiguous]: collapse consecutive same-role messages
+    - [DropLowImportance]: remove messages scoring below threshold (0.3)
+    - [SummarizeOld]: compress oldest messages into a summary *)
+type compaction_strategy =
+  | PruneToolOutputs
+  | MergeContiguous
+  | DropLowImportance
+  | SummarizeOld

--- a/lib/context_compact_oas.ml
+++ b/lib/context_compact_oas.ml
@@ -17,12 +17,13 @@
 open Printf
 
 (* ================================================================ *)
-(* Strategy Type (mirrors Context_manager.compaction_strategy)       *)
+(* Strategy Type (shared via Compaction_types)                       *)
 (* ================================================================ *)
 
-(** Local copy of compaction strategies to avoid Context_manager dependency.
-    Must stay in sync with Context_manager.compaction_strategy. *)
-type strategy =
+(** Re-export from [Compaction_types] for backward compatibility.
+    Consumers that used [Context_compact_oas.PruneToolOutputs] etc.
+    continue to work without changes. *)
+type strategy = Compaction_types.compaction_strategy =
   | PruneToolOutputs
   | MergeContiguous
   | DropLowImportance

--- a/lib/context_manager.ml
+++ b/lib/context_manager.ml
@@ -45,7 +45,10 @@ type session_context = {
   mutable checkpoints : checkpoint list;
 }
 
-type compaction_strategy =
+(** Re-export from [Compaction_types] for backward compatibility.
+    All consumers that used [Context_manager.PruneToolOutputs] etc.
+    continue to work without changes. *)
+type compaction_strategy = Compaction_types.compaction_strategy =
   | PruneToolOutputs
   | MergeContiguous
   | DropLowImportance
@@ -298,12 +301,9 @@ let use_oas_reducer () =
   | Some v -> String.lowercase_ascii (String.trim v) = "true"
   | None -> false
 
-(** Map MASC compaction_strategy to the adapter's local strategy type. *)
-let oas_adapter_strategy_of = function
-  | PruneToolOutputs -> Context_compact_oas.PruneToolOutputs
-  | MergeContiguous -> Context_compact_oas.MergeContiguous
-  | DropLowImportance -> Context_compact_oas.DropLowImportance
-  | SummarizeOld -> Context_compact_oas.SummarizeOld
+(** Identity mapping — both types are now [Compaction_types.compaction_strategy].
+    Kept as a named function for call-site readability. *)
+let oas_adapter_strategy_of (s : compaction_strategy) : Context_compact_oas.strategy = s
 
 let compact ctx strategies =
   if use_oas_reducer () then

--- a/lib/context_manager.mli
+++ b/lib/context_manager.mli
@@ -43,8 +43,9 @@ type session_context = {
 
 (** {1 Compaction} *)
 
-(** Compaction strategies, applied in order of increasing aggressiveness. *)
-type compaction_strategy =
+(** Compaction strategies, applied in order of increasing aggressiveness.
+    Alias for {!Compaction_types.compaction_strategy} (shared SSOT). *)
+type compaction_strategy = Compaction_types.compaction_strategy =
   | PruneToolOutputs   (** Remove verbose tool results > 500 chars, keep first/last 100 *)
   | MergeContiguous    (** Merge consecutive same-role messages *)
   | DropLowImportance  (** Remove messages with importance < 0.3 *)

--- a/lib/dune
+++ b/lib/dune
@@ -555,6 +555,7 @@
    llm_provider_oas
    llm_response_cache
    context_scoring
+   compaction_types
    context_manager
    context_compact_oas
    verifier
@@ -563,6 +564,9 @@
    succession_oas
    perpetual_loop
    perpetual_loop_types
+   perpetual_oas_state
+   perpetual_oas_hooks
+   perpetual_oas_build
    perpetual_oas
    procedural_memory
    oas_events
@@ -809,6 +813,9 @@
   autoresearch_types
   backend_eio_compression
   perpetual_loop_types
+  perpetual_oas_state
+  perpetual_oas_hooks
+  perpetual_oas_build
   room_multi
   dashboard_proof_helpers
   keeper_alerting_path)

--- a/lib/masc_mcp.ml
+++ b/lib/masc_mcp.ml
@@ -388,6 +388,9 @@ module Trpg_actor_match = Trpg_actor_match
 module Autoresearch = Autoresearch
 module Tool_autoresearch = Tool_autoresearch
 
+(* Compaction strategy type — shared SSOT *)
+module Compaction_types = Compaction_types
+
 (* OAS Integration — Agent SDK v0.24+ bridge *)
 module Oas_events = Oas_events
 module Oas_checkpoint_bridge = Oas_checkpoint_bridge

--- a/lib/perpetual_oas.ml
+++ b/lib/perpetual_oas.ml
@@ -12,13 +12,10 @@
 
     Enabled via [MASC_USE_OAS_PERPETUAL=true] environment variable.
 
-    Key mappings:
-    - perpetual_loop thresholds -> OAS BeforeTurn hook (threshold checking)
-    - idle detection -> OAS OnIdle hook
-    - heartbeat tick -> OAS periodic_callback
-    - verification -> OAS PreToolUse hook (via Phase 4 adapter)
-    - compaction -> OAS Context_reducer (via Phase 1 adapter)
-    - DNA/handoff -> OAS Checkpoint (via Phase 2 adapter)
+    Split into sub-modules (H2):
+    - {!Perpetual_oas_state}: mutable state + mutex ops
+    - {!Perpetual_oas_hooks}: 4 lifecycle hooks + periodic callback
+    - {!Perpetual_oas_build}: OAS Agent.t builder
 
     @since Phase 6 — OAS Agent adapter for perpetual loop *)
 
@@ -38,341 +35,6 @@ let use_oas_perpetual () =
   | None -> false
 
 (* ================================================================ *)
-(* Perpetual State — mutable tracking for hook closures              *)
-(* ================================================================ *)
-
-(** Mutable state carried through hook closures across turns.
-    Mirrors the subset of [Perpetual_loop.loop_state] that hooks need
-    for threshold checking, idle detection, and metrics accumulation. *)
-type perpetual_state = {
-  mutable turn_count : int;
-  mutable idle_turns : int;
-  mutable total_tokens : int;
-  mutable total_cost : float;
-  mutable last_heartbeat : float;
-  mutable compaction_count : int;
-  mutable generation : int;
-  mutable running : bool;
-  mutable handoff_triggered : bool;
-  trace_id : string;
-}
-
-let create_perpetual_state ~trace_id =
-  {
-    turn_count = 0;
-    idle_turns = 0;
-    total_tokens = 0;
-    total_cost = 0.0;
-    last_heartbeat = Time_compat.now ();
-    compaction_count = 0;
-    generation = 0;
-    running = true;
-    handoff_triggered = false;
-    trace_id;
-  }
-
-(** Mutex protecting all mutable [perpetual_state] fields from concurrent
-    access by Eio fibers (hook closures, periodic callbacks). *)
-let state_mutex = Eio.Mutex.create ()
-
-(* ================================================================ *)
-(* Perpetual Hooks — lifecycle via OAS hook events                   *)
-(* ================================================================ *)
-
-(** Create OAS hooks that implement perpetual loop lifecycle.
-
-    - BeforeTurn: increment turn counter, check context thresholds
-      (compact/prepare/handoff), inject context ratio into system messages.
-    - AfterTurn: update metrics (tokens, cost), track idle turns based on
-      whether tool calls occurred.
-    - OnIdle: when consecutive idle turns exceed [max_idle], signal stop.
-    - PreToolUse: delegates to Phase 4 verifier hook when feedback is enabled.
-
-    @param config The perpetual loop configuration.
-    @param pstate Mutable perpetual state (shared across turns).
-    @param emit Event emitter closure from perpetual_loop.
-    @param ctx_ref Reference to the current working context (for ratio checks). *)
-let perpetual_hooks
-    ~(config : Perpetual_loop.loop_config)
-    ~(pstate : perpetual_state)
-    ~(emit : Perpetual_loop.event -> unit)
-    ~(ctx_ref : Context_manager.working_context ref)
-  : Oas.Hooks.hooks =
-  let before_turn : Oas.Hooks.hook = fun event ->
-    match event with
-    | Oas.Hooks.BeforeTurn { turn; _ } ->
-      Eio.Mutex.use_rw ~protect:true state_mutex (fun () ->
-        pstate.turn_count <- turn);
-      emit (TurnStart turn);
-      (* Check thresholds against current context *)
-      let ratio = Context_manager.context_ratio !ctx_ref in
-      (* Compact threshold: apply context reduction via Phase 1 adapter *)
-      if ratio >= config.compact_threshold then begin
-        let before = (!ctx_ref).token_count in
-        let strategies =
-          List.map (function
-            | Context_manager.PruneToolOutputs ->
-              Context_compact_oas.PruneToolOutputs
-            | Context_manager.MergeContiguous ->
-              Context_compact_oas.MergeContiguous
-            | Context_manager.DropLowImportance ->
-              Context_compact_oas.DropLowImportance
-            | Context_manager.SummarizeOld ->
-              Context_compact_oas.SummarizeOld
-          ) config.compact_strategies
-        in
-        let compacted_msgs, new_token_count =
-          Context_compact_oas.compact
-            ~system_prompt:(!ctx_ref).system_prompt
-            ~messages:(!ctx_ref).messages
-            ~strategies
-        in
-        ctx_ref := {
-          !ctx_ref with
-          messages = compacted_msgs;
-          token_count = new_token_count;
-        };
-        let after = new_token_count in
-        Eio.Mutex.use_rw ~protect:true state_mutex (fun () ->
-          pstate.compaction_count <- pstate.compaction_count + 1);
-        emit (Compacted {
-          before_tokens = before;
-          after_tokens = after;
-          offloaded_path = None;
-        })
-      end;
-      (* Handoff threshold: signal generation handoff *)
-      let ratio2 = Context_manager.context_ratio !ctx_ref in
-      if ratio2 >= config.handoff_threshold then begin
-        let next_model = match config.model_cascade with
-          | _ :: m :: _ -> m
-          | [m] -> m
-          | [] -> Llm_client.default_local_model_spec ()
-        in
-        Eio.Mutex.use_rw ~protect:true state_mutex (fun () ->
-          pstate.handoff_triggered <- true;
-          pstate.running <- false);
-        emit (Handoff {
-          to_model = next_model.model_id;
-          generation = pstate.generation + 1;
-        })
-      end;
-      Oas.Hooks.Continue
-    | _ -> Oas.Hooks.Continue
-  in
-  let after_turn : Oas.Hooks.hook = fun event ->
-    match event with
-    | Oas.Hooks.AfterTurn { turn; response } ->
-      (* Track tokens from response usage *)
-      let tokens_used = match response.usage with
-        | Some u -> u.input_tokens + u.output_tokens
-        | None -> 0
-      in
-      (* Check for tool calls to determine idle state *)
-      let has_tool_use = List.exists (function
-        | Oas.Types.ToolUse _ -> true
-        | _ -> false
-      ) response.content in
-      Eio.Mutex.use_rw ~protect:true state_mutex (fun () ->
-        pstate.total_tokens <- pstate.total_tokens + tokens_used;
-        if has_tool_use then
-          pstate.idle_turns <- 0
-        else
-          pstate.idle_turns <- pstate.idle_turns + 1);
-      (* Check for goal completion or stuck signals in response text *)
-      let text = List.filter_map (function
-        | Oas.Types.Text s -> Some s
-        | _ -> None
-      ) response.content |> String.concat "\n" in
-      let upper = String.uppercase_ascii text in
-      if (try ignore (Str.search_forward
-            (Str.regexp_string "[GOAL_COMPLETE]") upper 0); true
-          with Not_found -> false) then begin
-        Eio.Mutex.use_rw ~protect:true state_mutex (fun () ->
-          pstate.running <- false);
-        emit (Terminated "Goal complete (OAS)")
-      end
-      else if (try ignore (Str.search_forward
-            (Str.regexp_string "[STUCK") upper 0); true
-          with Not_found -> false) then begin
-        Eio.Mutex.use_rw ~protect:true state_mutex (fun () ->
-          pstate.running <- false);
-        emit (Terminated "Agent stuck (OAS)")
-      end;
-      emit (TurnEnd { turn; tokens_used; cost = 0.0 });
-      Oas.Hooks.Continue
-    | _ -> Oas.Hooks.Continue
-  in
-  let on_idle : Oas.Hooks.hook = fun event ->
-    match event with
-    | Oas.Hooks.OnIdle { consecutive_idle_turns; _ } ->
-      Eio.Mutex.use_rw ~protect:true state_mutex (fun () ->
-        pstate.idle_turns <- consecutive_idle_turns);
-      if consecutive_idle_turns >= config.max_idle_turns then begin
-        Eio.Mutex.use_rw ~protect:true state_mutex (fun () ->
-          pstate.running <- false);
-        emit (IdleDetected consecutive_idle_turns);
-        emit (Terminated "Max idle turns reached (OAS)");
-        Oas.Hooks.Skip
-      end else
-        Oas.Hooks.Continue
-    | _ -> Oas.Hooks.Continue
-  in
-  let pre_tool_use =
-    if config.feedback_enabled then
-      Some (Verifier_oas.make_pre_tool_hook
-        ~model:config.verifier_model
-        ~goal:config.initial_goal
-        ~context_summary:(sprintf "Turn %d, generation %d"
-          pstate.turn_count pstate.generation))
-    else
-      None
-  in
-  {
-    Oas.Hooks.empty with
-    before_turn = Some before_turn;
-    after_turn = Some after_turn;
-    on_idle = Some on_idle;
-    pre_tool_use;
-  }
-
-(* ================================================================ *)
-(* Heartbeat as OAS periodic_callback                                *)
-(* ================================================================ *)
-
-(** Create an OAS periodic_callback that emits MASC heartbeat events.
-
-    Mirrors the heartbeat logic in [Perpetual_loop.run_turn]:
-    if [heartbeat_interval_s] has elapsed since last heartbeat,
-    emit a Heartbeat event with current turn and context percentage.
-
-    @param config Loop config (for interval).
-    @param pstate Mutable perpetual state (for last_heartbeat tracking).
-    @param emit Event emitter.
-    @param ctx_ref Current working context reference. *)
-let perpetual_periodic_callbacks
-    ~(config : Perpetual_loop.loop_config)
-    ~(pstate : perpetual_state)
-    ~(emit : Perpetual_loop.event -> unit)
-    ~(ctx_ref : Context_manager.working_context ref)
-  : Oas.Agent.periodic_callback list =
-  [{
-    Oas.Agent_types.interval_sec = config.heartbeat_interval_s;
-    callback = (fun () ->
-      let now = Time_compat.now () in
-      let turn = Eio.Mutex.use_rw ~protect:true state_mutex (fun () ->
-        pstate.last_heartbeat <- now;
-        pstate.turn_count) in
-      let pct = Context_manager.context_ratio !ctx_ref *. 100.0 in
-      emit (Heartbeat { turn; context_pct = pct })
-    );
-  }]
-
-(* ================================================================ *)
-(* Build perpetual Agent.t via OAS Builder                           *)
-(* ================================================================ *)
-
-(** Construct an OAS Agent.t configured for perpetual execution.
-
-    Ties together all phase adapters:
-    - Phase 1: context reducer strategies
-    - Phase 2: checkpoint config
-    - Phase 3: LLM provider mapping
-    - Phase 4: verifier hook / guardrails
-    - Phase 5: builder pattern
-
-    @param config The perpetual loop configuration.
-    @param pstate Mutable state for hook closures.
-    @param emit Event emitter.
-    @param ctx_ref Current working context ref.
-    @param net Eio network capability.
-    @return Agent.t configured for perpetual operation, or error. *)
-let build_perpetual_agent
-    ~(config : Perpetual_loop.loop_config)
-    ~(pstate : perpetual_state)
-    ~(emit : Perpetual_loop.event -> unit)
-    ~(ctx_ref : Context_manager.working_context ref)
-    ~(net : [> `Generic | `Unix ] Eio.Net.ty Eio.Resource.t)
-  : (Oas.Agent.t, string) result =
-  (* Resolve OAS model from primary cascade model *)
-  let primary_model = match config.model_cascade with
-    | m :: _ -> m
-    | [] -> Llm_client.default_local_model_spec ()
-  in
-  let oas_model = Oas.Types.Custom primary_model.model_id in
-  (* Build provider via Phase 3 adapter.
-     Uses Llm_client.to_oas_provider which handles the Llm_client.model_spec
-     -> Oas.Provider.config conversion (avoiding Llm_types nominality gap). *)
-  let provider = match Llm_client.to_oas_provider primary_model with
-    | Some cfg -> cfg
-    | None ->
-      (* Fallback for Custom providers — use OpenAICompat *)
-      { Oas.Provider.provider =
-          Oas.Provider.OpenAICompat {
-            base_url = primary_model.api_url;
-            auth_header = None;
-            path = "/v1/chat/completions";
-            static_token = None;
-          };
-        model_id = primary_model.model_id;
-        api_key_env = Option.value ~default:"" primary_model.api_key_env;
-      }
-  in
-  (* Hooks: perpetual lifecycle + Phase 4 verifier *)
-  let hooks = perpetual_hooks ~config ~pstate ~emit ~ctx_ref in
-  (* Heartbeat callback *)
-  let periodic_cbs =
-    perpetual_periodic_callbacks ~config ~pstate ~emit ~ctx_ref
-  in
-  (* Guardrails via Phase 4 adapter *)
-  let guardrails =
-    Verifier_oas.guardrails_with_read_only_tag
-      ~max_tool_calls_per_turn:12 ()
-  in
-  (* Convert MASC tool_defs to OAS Tool.t list.
-     Tool_bridge.oas_tool_of_masc creates OAS Tool.t from name/desc/schema/handler.
-     For the perpetual loop adapter, each tool delegates to a no-op handler since
-     actual tool dispatch remains in MASC's perpetual_loop infrastructure. *)
-  let tools = List.map (fun (td : Llm_client.tool_def) ->
-    Tool_bridge.oas_tool_of_masc
-      ~name:td.tool_name
-      ~description:td.tool_description
-      ~input_schema:td.parameters
-      (fun _input ->
-        (true, "[perpetual_oas] Tool dispatch delegated to MASC infrastructure"))
-  ) config.tools in
-  let tool_names =
-    List.map (fun (t : Oas.Tool.t) -> t.schema.name) tools
-  in
-  let system_prompt = (!ctx_ref).system_prompt in
-  (* Use max_turns as a reasonable upper bound per generation.
-     Perpetual loop handles multi-generation externally. *)
-  let max_turns = 100 in
-  let builder =
-    Oas.Builder.create ~net ~model:oas_model
-    |> Oas.Builder.with_name config.agent_name
-    |> Oas.Builder.with_system_prompt system_prompt
-    |> Oas.Builder.with_max_tokens 4096
-    |> Oas.Builder.with_max_turns max_turns
-    |> Oas.Builder.with_temperature 0.7
-    |> Oas.Builder.with_provider provider
-    |> Oas.Builder.with_tools tools
-    |> Oas.Builder.with_hooks hooks
-    |> Oas.Builder.with_guardrails { guardrails with
-      tool_filter =
-        if tool_names <> [] then
-          Oas.Guardrails.AllowList tool_names
-        else
-          Oas.Guardrails.AllowAll }
-    |> Oas.Builder.with_periodic_callbacks periodic_cbs
-    |> Oas.Builder.with_description
-         (sprintf "Perpetual agent (gen %d, trace %s)"
-           pstate.generation pstate.trace_id)
-  in
-  Oas.Builder.build_safe builder
-  |> Result.map_error Oas.Error.to_string
-
-(* ================================================================ *)
 (* Run perpetual loop via OAS Agent.run                              *)
 (* ================================================================ *)
 
@@ -384,15 +46,16 @@ let build_perpetual_agent
     3. On handoff: extract DNA via Phase 2, create new Agent via resume
     4. On stop: persist final checkpoint
 
+    Returns [Ok ()] on completion, [Error msg] on early abort.
+
     @param sw Eio switch for fiber management.
     @param config The perpetual loop configuration.
-    @param state The MASC loop state (for initial context and session).
-    @return Unit on completion. *)
+    @param state The MASC loop state (for initial context and session). *)
 let run_perpetual_via_oas
     ~(sw : Eio.Switch.t)
     ~(config : Perpetual_loop.loop_config)
     ~(state : Perpetual_loop.loop_state)
-  : unit =
+  : (unit, string) result =
   (* Event emitter: record locally, invoke callback, and bridge to OAS Event_bus.
      Cannot use Perpetual_loop.record_event (private). Inline the logic:
      prepend event to state.events, cap at 200 entries. *)
@@ -424,32 +87,31 @@ let run_perpetual_via_oas
       | _ -> ()
     ) config.event_bus
   in
-  let net = match Eio_context.get_net_opt () with
-    | Some net -> net
-    | None ->
-      eprintf "[perpetual_oas] Eio net not available, cannot run OAS path\n%!";
-      emit (Error "Eio net not available for OAS perpetual path");
-      state.running <- false;
-      raise Exit
-  in
+  (* Acquire Eio net — abort early if unavailable *)
+  match Eio_context.get_net_opt () with
+  | None ->
+    eprintf "[perpetual_oas] Eio net not available, cannot run OAS path\n%!";
+    emit (Error "Eio net not available for OAS perpetual path");
+    state.running <- false;
+    Error "Eio net not available for OAS perpetual path"
+  | Some net ->
   let trace_id = state.trace_id in
-  let pstate = create_perpetual_state ~trace_id in
-  Eio.Mutex.use_rw ~protect:true state_mutex (fun () ->
-    pstate.generation <- state.generation);
+  let pstate = Perpetual_oas_state.create_perpetual_state ~trace_id in
+  Perpetual_oas_state.update_state (fun ps ->
+    ps.generation <- state.generation) pstate;
   let ctx_ref = ref state.context in
   eprintf "[perpetual_oas] Starting OAS loop: goal=%s, trace=%s, gen=%d\n%!"
     config.initial_goal trace_id pstate.generation;
-  (* Build the initial agent *)
-  let agent = match
-    build_perpetual_agent ~config ~pstate ~emit ~ctx_ref ~net
+  (* Build the initial agent — abort early on failure *)
+  match
+    Perpetual_oas_build.build_perpetual_agent ~config ~pstate ~emit ~ctx_ref ~net
   with
-  | Ok a -> a
   | Error e ->
     eprintf "[perpetual_oas] Failed to build agent: %s\n%!" e;
     emit (Error (sprintf "OAS agent build failed: %s" e));
     state.running <- false;
-    raise Exit
-  in
+    Error (sprintf "OAS agent build failed: %s" e)
+  | Ok agent ->
   (* Run agent with goal as initial prompt *)
   let result = Oas.Agent.run ~sw agent config.initial_goal in
   (* Persist checkpoint via Phase 2 adapter *)
@@ -522,13 +184,13 @@ let run_perpetual_via_oas
       pstate.generation (pstate.generation + 1)))
   end;
   (* Sync mutable state back to MASC loop_state *)
-  Eio.Mutex.use_rw ~protect:true state_mutex (fun () ->
+  Perpetual_oas_state.update_state (fun _ps ->
     state.turn_count <- pstate.turn_count;
     state.idle_turns <- pstate.idle_turns;
     state.total_tokens <- pstate.total_tokens;
     state.total_cost <- pstate.total_cost;
     state.compaction_count <- pstate.compaction_count;
-    state.running <- false);
+    state.running <- false) pstate;
   Oas.Agent.close agent;
   (* Log result *)
   (match result with
@@ -547,7 +209,8 @@ let run_perpetual_via_oas
   | Error err ->
     let detail = Oas.Error.to_string err in
     eprintf "[perpetual_oas] Loop ended with error: %s\n%!" detail;
-    emit (Error (sprintf "OAS perpetual loop error: %s" detail)))
+    emit (Error (sprintf "OAS perpetual loop error: %s" detail)));
+  Ok ()
 
 (* ================================================================ *)
 (* Unified entry point — dispatch based on feature flag              *)
@@ -563,7 +226,8 @@ let run
     ~(state : Perpetual_loop.loop_state)
   : unit =
   if use_oas_perpetual () then
-    (try run_perpetual_via_oas ~sw ~config ~state
-     with Exit -> ())
+    run_perpetual_via_oas ~sw ~config ~state
+    |> Result.iter_error (fun e ->
+      eprintf "[perpetual_oas] OAS path aborted: %s\n%!" e)
   else
     Perpetual_loop.run ~config ~state

--- a/lib/perpetual_oas_build.ml
+++ b/lib/perpetual_oas_build.ml
@@ -1,0 +1,114 @@
+(** Perpetual_oas_build — OAS Agent.t builder for perpetual execution.
+
+    Extracted from [perpetual_oas.ml]. Ties together all phase adapters
+    (context reducer, checkpoint, LLM provider, verifier, builder) to
+    construct an OAS Agent.t configured for perpetual operation.
+
+    Dependencies: [Perpetual_oas_state], [Perpetual_oas_hooks],
+    [Llm_client], [Tool_bridge], OAS Builder.
+
+    @since 2.111.0 — H2 God File split *)
+
+open Printf
+
+module Oas = Agent_sdk
+
+(** Construct an OAS Agent.t configured for perpetual execution.
+
+    Ties together all phase adapters:
+    - Phase 1: context reducer strategies
+    - Phase 2: checkpoint config
+    - Phase 3: LLM provider mapping
+    - Phase 4: verifier hook / guardrails
+    - Phase 5: builder pattern
+
+    @param config The perpetual loop configuration.
+    @param pstate Mutable state for hook closures.
+    @param emit Event emitter.
+    @param ctx_ref Current working context ref.
+    @param net Eio network capability.
+    @return Agent.t configured for perpetual operation, or error. *)
+let build_perpetual_agent
+    ~(config : Perpetual_loop.loop_config)
+    ~(pstate : Perpetual_oas_state.perpetual_state)
+    ~(emit : Perpetual_loop.event -> unit)
+    ~(ctx_ref : Context_manager.working_context ref)
+    ~(net : [> `Generic | `Unix ] Eio.Net.ty Eio.Resource.t)
+  : (Oas.Agent.t, string) result =
+  (* Resolve OAS model from primary cascade model *)
+  let primary_model = match config.model_cascade with
+    | m :: _ -> m
+    | [] -> Llm_client.default_local_model_spec ()
+  in
+  let oas_model = Oas.Types.Custom primary_model.model_id in
+  (* Build provider via Phase 3 adapter.
+     Uses Llm_client.to_oas_provider which handles the Llm_client.model_spec
+     -> Oas.Provider.config conversion (avoiding Llm_types nominality gap). *)
+  let provider = match Llm_client.to_oas_provider primary_model with
+    | Some cfg -> cfg
+    | None ->
+      (* Fallback for Custom providers — use OpenAICompat *)
+      { Oas.Provider.provider =
+          Oas.Provider.OpenAICompat {
+            base_url = primary_model.api_url;
+            auth_header = None;
+            path = "/v1/chat/completions";
+            static_token = None;
+          };
+        model_id = primary_model.model_id;
+        api_key_env = Option.value ~default:"" primary_model.api_key_env;
+      }
+  in
+  (* Hooks: perpetual lifecycle + Phase 4 verifier *)
+  let hooks = Perpetual_oas_hooks.perpetual_hooks ~config ~pstate ~emit ~ctx_ref in
+  (* Heartbeat callback *)
+  let periodic_cbs =
+    Perpetual_oas_hooks.perpetual_periodic_callbacks ~config ~pstate ~emit ~ctx_ref
+  in
+  (* Guardrails via Phase 4 adapter *)
+  let guardrails =
+    Verifier_oas.guardrails_with_read_only_tag
+      ~max_tool_calls_per_turn:12 ()
+  in
+  (* Convert MASC tool_defs to OAS Tool.t list.
+     Tool_bridge.oas_tool_of_masc creates OAS Tool.t from name/desc/schema/handler.
+     For the perpetual loop adapter, each tool delegates to a no-op handler since
+     actual tool dispatch remains in MASC's perpetual_loop infrastructure. *)
+  let tools = List.map (fun (td : Llm_client.tool_def) ->
+    Tool_bridge.oas_tool_of_masc
+      ~name:td.tool_name
+      ~description:td.tool_description
+      ~input_schema:td.parameters
+      (fun _input ->
+        (true, "[perpetual_oas] Tool dispatch delegated to MASC infrastructure"))
+  ) config.tools in
+  let tool_names =
+    List.map (fun (t : Oas.Tool.t) -> t.schema.name) tools
+  in
+  let system_prompt = (!ctx_ref).system_prompt in
+  (* Use max_turns as a reasonable upper bound per generation.
+     Perpetual loop handles multi-generation externally. *)
+  let max_turns = 100 in
+  let builder =
+    Oas.Builder.create ~net ~model:oas_model
+    |> Oas.Builder.with_name config.agent_name
+    |> Oas.Builder.with_system_prompt system_prompt
+    |> Oas.Builder.with_max_tokens 4096
+    |> Oas.Builder.with_max_turns max_turns
+    |> Oas.Builder.with_temperature 0.7
+    |> Oas.Builder.with_provider provider
+    |> Oas.Builder.with_tools tools
+    |> Oas.Builder.with_hooks hooks
+    |> Oas.Builder.with_guardrails { guardrails with
+      tool_filter =
+        if tool_names <> [] then
+          Oas.Guardrails.AllowList tool_names
+        else
+          Oas.Guardrails.AllowAll }
+    |> Oas.Builder.with_periodic_callbacks periodic_cbs
+    |> Oas.Builder.with_description
+         (sprintf "Perpetual agent (gen %d, trace %s)"
+           pstate.generation pstate.trace_id)
+  in
+  Oas.Builder.build_safe builder
+  |> Result.map_error Oas.Error.to_string

--- a/lib/perpetual_oas_hooks.ml
+++ b/lib/perpetual_oas_hooks.ml
@@ -1,0 +1,189 @@
+(** Perpetual_oas_hooks — OAS lifecycle hooks for perpetual agent.
+
+    Extracted from [perpetual_oas.ml]. Creates 4 OAS hooks (before_turn,
+    after_turn, on_idle, pre_tool_use) and a periodic heartbeat callback.
+
+    Dependencies: [Perpetual_oas_state], [Context_compact_oas],
+    [Context_manager], [Verifier_oas], [Compaction_types].
+
+    @since 2.111.0 — H2 God File split *)
+
+open Printf
+
+module Oas = Agent_sdk
+
+(** Create OAS hooks that implement perpetual loop lifecycle.
+
+    - BeforeTurn: increment turn counter, check context thresholds
+      (compact/prepare/handoff), inject context ratio into system messages.
+    - AfterTurn: update metrics (tokens, cost), track idle turns based on
+      whether tool calls occurred.
+    - OnIdle: when consecutive idle turns exceed [max_idle], signal stop.
+    - PreToolUse: delegates to Phase 4 verifier hook when feedback is enabled.
+
+    @param config The perpetual loop configuration.
+    @param pstate Mutable perpetual state (shared across turns).
+    @param emit Event emitter closure from perpetual_loop.
+    @param ctx_ref Reference to the current working context (for ratio checks). *)
+let perpetual_hooks
+    ~(config : Perpetual_loop.loop_config)
+    ~(pstate : Perpetual_oas_state.perpetual_state)
+    ~(emit : Perpetual_loop.event -> unit)
+    ~(ctx_ref : Context_manager.working_context ref)
+  : Oas.Hooks.hooks =
+  let before_turn : Oas.Hooks.hook = fun event ->
+    match event with
+    | Oas.Hooks.BeforeTurn { turn; _ } ->
+      Perpetual_oas_state.update_state (fun ps ->
+        ps.turn_count <- turn) pstate;
+      emit (TurnStart turn);
+      (* Check thresholds against current context *)
+      let ratio = Context_manager.context_ratio !ctx_ref in
+      (* Compact threshold: apply context reduction via Phase 1 adapter *)
+      if ratio >= config.compact_threshold then begin
+        let before = (!ctx_ref).token_count in
+        (* Both Context_manager.compaction_strategy and Context_compact_oas.strategy
+           are now aliases for Compaction_types.compaction_strategy — no mapping needed. *)
+        let strategies = config.compact_strategies in
+        let compacted_msgs, new_token_count =
+          Context_compact_oas.compact
+            ~system_prompt:(!ctx_ref).system_prompt
+            ~messages:(!ctx_ref).messages
+            ~strategies
+        in
+        ctx_ref := {
+          !ctx_ref with
+          messages = compacted_msgs;
+          token_count = new_token_count;
+        };
+        let after = new_token_count in
+        Perpetual_oas_state.update_state (fun ps ->
+          ps.compaction_count <- ps.compaction_count + 1) pstate;
+        emit (Compacted {
+          before_tokens = before;
+          after_tokens = after;
+          offloaded_path = None;
+        })
+      end;
+      (* Handoff threshold: signal generation handoff *)
+      let ratio2 = Context_manager.context_ratio !ctx_ref in
+      if ratio2 >= config.handoff_threshold then begin
+        let next_model = match config.model_cascade with
+          | _ :: m :: _ -> m
+          | [m] -> m
+          | [] -> Llm_client.default_local_model_spec ()
+        in
+        Perpetual_oas_state.update_state (fun ps ->
+          ps.handoff_triggered <- true;
+          ps.running <- false) pstate;
+        emit (Handoff {
+          to_model = next_model.model_id;
+          generation = pstate.generation + 1;
+        })
+      end;
+      Oas.Hooks.Continue
+    | _ -> Oas.Hooks.Continue
+  in
+  let after_turn : Oas.Hooks.hook = fun event ->
+    match event with
+    | Oas.Hooks.AfterTurn { turn; response } ->
+      (* Track tokens from response usage *)
+      let tokens_used = match response.usage with
+        | Some u -> u.input_tokens + u.output_tokens
+        | None -> 0
+      in
+      (* Check for tool calls to determine idle state *)
+      let has_tool_use = List.exists (function
+        | Oas.Types.ToolUse _ -> true
+        | _ -> false
+      ) response.content in
+      Perpetual_oas_state.update_state (fun ps ->
+        ps.total_tokens <- ps.total_tokens + tokens_used;
+        if has_tool_use then
+          ps.idle_turns <- 0
+        else
+          ps.idle_turns <- ps.idle_turns + 1) pstate;
+      (* Check for goal completion or stuck signals in response text *)
+      let text = List.filter_map (function
+        | Oas.Types.Text s -> Some s
+        | _ -> None
+      ) response.content |> String.concat "\n" in
+      let upper = String.uppercase_ascii text in
+      if (try ignore (Str.search_forward
+            (Str.regexp_string "[GOAL_COMPLETE]") upper 0); true
+          with Not_found -> false) then begin
+        Perpetual_oas_state.update_state (fun ps ->
+          ps.running <- false) pstate;
+        emit (Terminated "Goal complete (OAS)")
+      end
+      else if (try ignore (Str.search_forward
+            (Str.regexp_string "[STUCK") upper 0); true
+          with Not_found -> false) then begin
+        Perpetual_oas_state.update_state (fun ps ->
+          ps.running <- false) pstate;
+        emit (Terminated "Agent stuck (OAS)")
+      end;
+      emit (TurnEnd { turn; tokens_used; cost = 0.0 });
+      Oas.Hooks.Continue
+    | _ -> Oas.Hooks.Continue
+  in
+  let on_idle : Oas.Hooks.hook = fun event ->
+    match event with
+    | Oas.Hooks.OnIdle { consecutive_idle_turns; _ } ->
+      Perpetual_oas_state.update_state (fun ps ->
+        ps.idle_turns <- consecutive_idle_turns) pstate;
+      if consecutive_idle_turns >= config.max_idle_turns then begin
+        Perpetual_oas_state.update_state (fun ps ->
+          ps.running <- false) pstate;
+        emit (IdleDetected consecutive_idle_turns);
+        emit (Terminated "Max idle turns reached (OAS)");
+        Oas.Hooks.Skip
+      end else
+        Oas.Hooks.Continue
+    | _ -> Oas.Hooks.Continue
+  in
+  let pre_tool_use =
+    if config.feedback_enabled then
+      Some (Verifier_oas.make_pre_tool_hook
+        ~model:config.verifier_model
+        ~goal:config.initial_goal
+        ~context_summary:(sprintf "Turn %d, generation %d"
+          pstate.turn_count pstate.generation))
+    else
+      None
+  in
+  {
+    Oas.Hooks.empty with
+    before_turn = Some before_turn;
+    after_turn = Some after_turn;
+    on_idle = Some on_idle;
+    pre_tool_use;
+  }
+
+(** Create an OAS periodic_callback that emits MASC heartbeat events.
+
+    Mirrors the heartbeat logic in [Perpetual_loop.run_turn]:
+    if [heartbeat_interval_s] has elapsed since last heartbeat,
+    emit a Heartbeat event with current turn and context percentage.
+
+    @param config Loop config (for interval).
+    @param pstate Mutable perpetual state (for last_heartbeat tracking).
+    @param emit Event emitter.
+    @param ctx_ref Current working context reference. *)
+let perpetual_periodic_callbacks
+    ~(config : Perpetual_loop.loop_config)
+    ~(pstate : Perpetual_oas_state.perpetual_state)
+    ~(emit : Perpetual_loop.event -> unit)
+    ~(ctx_ref : Context_manager.working_context ref)
+  : Oas.Agent.periodic_callback list =
+  [{
+    Oas.Agent_types.interval_sec = config.heartbeat_interval_s;
+    callback = (fun () ->
+      let now = Time_compat.now () in
+      let turn = Perpetual_oas_state.with_state (fun ps ->
+        ps.last_heartbeat <- now;
+        ps.turn_count) pstate in
+      let pct = Context_manager.context_ratio !ctx_ref *. 100.0 in
+      emit (Heartbeat { turn; context_pct = pct })
+    );
+  }]

--- a/lib/perpetual_oas_state.ml
+++ b/lib/perpetual_oas_state.ml
@@ -1,0 +1,51 @@
+(** Perpetual_oas_state — Mutable state for OAS perpetual agent hook closures.
+
+    Extracted from [perpetual_oas.ml] to isolate the mutable state type,
+    constructor, and mutex-protected access helpers.
+
+    The OAS hook API requires mutable state captured by closures —
+    immutable state is not an option here.
+
+    @since 2.111.0 — H2 God File split *)
+
+(** Mutable state carried through hook closures across turns.
+    Mirrors the subset of [Perpetual_loop.loop_state] that hooks need
+    for threshold checking, idle detection, and metrics accumulation. *)
+type perpetual_state = {
+  mutable turn_count : int;
+  mutable idle_turns : int;
+  mutable total_tokens : int;
+  mutable total_cost : float;
+  mutable last_heartbeat : float;
+  mutable compaction_count : int;
+  mutable generation : int;
+  mutable running : bool;
+  mutable handoff_triggered : bool;
+  trace_id : string;
+}
+
+let create_perpetual_state ~trace_id =
+  {
+    turn_count = 0;
+    idle_turns = 0;
+    total_tokens = 0;
+    total_cost = 0.0;
+    last_heartbeat = Time_compat.now ();
+    compaction_count = 0;
+    generation = 0;
+    running = true;
+    handoff_triggered = false;
+    trace_id;
+  }
+
+(** Mutex protecting all mutable [perpetual_state] fields from concurrent
+    access by Eio fibers (hook closures, periodic callbacks). *)
+let state_mutex = Eio.Mutex.create ()
+
+(** Read from state under mutex protection. *)
+let with_state (f : perpetual_state -> 'a) (pstate : perpetual_state) : 'a =
+  Eio.Mutex.use_rw ~protect:true state_mutex (fun () -> f pstate)
+
+(** Write to state under mutex protection. *)
+let update_state (f : perpetual_state -> unit) (pstate : perpetual_state) : unit =
+  Eio.Mutex.use_rw ~protect:true state_mutex (fun () -> f pstate)


### PR DESCRIPTION
## Summary

Addresses H2 and M1 review issues from PR #1517.

- **H2**: Split `perpetual_oas.ml` (569 lines, 9 mutable fields, `raise Exit`, scattered `eprintf`) into 4 focused sub-modules:
  - `perpetual_oas_state.ml` — mutable state type + Eio.Mutex-protected accessors
  - `perpetual_oas_hooks.ml` — 4 OAS lifecycle hooks (before_turn, after_turn, on_idle, pre_tool_use) + periodic heartbeat callback
  - `perpetual_oas_build.ml` — OAS Agent.t builder with all phase adapters
  - `perpetual_oas.ml` — slim run dispatcher (233 lines), `raise Exit` replaced with `Result` type
- **M1**: Extract `compaction_types.ml` with shared `compaction_strategy` variant, eliminating the type duplication between `context_manager.ml` and `context_compact_oas.ml`
  - Both modules now re-export `Compaction_types.compaction_strategy`
  - Strategy mapping boilerplate in perpetual_oas hooks is eliminated (identity mapping)
  - `.mli` updated to expose type equality

## Line counts

| File | Before | After |
|------|--------|-------|
| perpetual_oas.ml | 569 | 233 |
| perpetual_oas_state.ml | - | 51 |
| perpetual_oas_hooks.ml | - | 189 |
| perpetual_oas_build.ml | - | 114 |
| compaction_types.ml | - | 19 |

## Test plan

- [x] `dune build --root .` — clean build passes
- [x] `test_context_compact_oas_coverage.exe` — all 24 tests pass
- [ ] CI checks green

🤖 Generated with [Claude Code](https://claude.com/claude-code)