### PR TITLE
feat(llm): per-provider retry via OAS Complete.complete_with_retry

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -35,7 +35,7 @@
   (cmdliner (>= 1.1))
   (cohttp (>= 5.0))
   (cohttp-eio (and (>= 6.0) (< 6.2)))
-  (agent_sdk (>= 0.52.0))
+  (agent_sdk (>= 0.53.0))
   (uri (>= 4.4))
   (tls (>= 0.16))
   (tls-eio (>= 0.16))

--- a/lib/llm_eio_env.ml
+++ b/lib/llm_eio_env.ml
@@ -9,11 +9,12 @@
 type t = {
   sw : Eio.Switch.t;
   net : [ `Generic | `Unix ] Eio.Net.ty Eio.Resource.t;
+  clock : float Eio.Time.clock_ty Eio.Resource.t option;
 }
 
 let env : t option Atomic.t = Atomic.make None
 
-let init ~sw ~net = Atomic.set env (Some { sw; net })
+let init ~sw ~net ?clock () = Atomic.set env (Some { sw; net; clock })
 
 let get () =
   match Atomic.get env with

--- a/lib/llm_provider_bridge.ml
+++ b/lib/llm_provider_bridge.ml
@@ -371,7 +371,12 @@ let string_of_http_error = function
 (* ================================================================ *)
 
 (** Execute an LLM completion using Llm_provider (cohttp-eio).
-    Replaces curl-subprocess calls for all providers. *)
+    Uses {!Llm_provider.Complete.complete_with_retry} when a clock is
+    available (server runtime), falls back to bare {!complete} otherwise
+    (unit tests without Eio clock).
+
+    @since 2.103.0 — v0.49 curl-subprocess replacement
+    @since 2.106.0 — per-provider retry via OAS Complete.complete_with_retry *)
 let call ?timeout_sec:_ (req : completion_request)
     : (completion_response, string) result =
   let req = normalize_request req in
@@ -384,10 +389,17 @@ let call ?timeout_sec:_ (req : completion_request)
         req.model.model_id
         (string_of_provider req.model.provider)
         req.max_tokens (List.length req.tools);
-      match
-        Llm_provider.Complete.complete ~sw:env.sw ~net:env.net ~config
-          ~messages ~tools ()
-      with
+      let result = match env.clock with
+        | Some clock ->
+            Llm_provider.Complete.complete_with_retry
+              ~sw:env.sw ~net:env.net ~clock ~config
+              ~messages ~tools ()
+        | None ->
+            Llm_provider.Complete.complete
+              ~sw:env.sw ~net:env.net ~config
+              ~messages ~tools ()
+      in
+      match result with
       | Ok resp ->
           let masc_resp = completion_response_of_api_response resp in
           let text = text_of_response masc_resp in

--- a/lib/server_runtime_bootstrap.ml
+++ b/lib/server_runtime_bootstrap.ml
@@ -299,7 +299,7 @@ let run ~sw ~env ~host ~port ~base_path ~make_routes ~make_request_handler
   in
 
   (* Initialize Eio environment for LLM HTTP calls (cohttp-eio via Llm_provider) *)
-  Llm_eio_env.init ~sw ~net;
+  Llm_eio_env.init ~sw ~net ~clock ();
 
   (* 1. HTTP socket first — Railway healthcheck can reach /health immediately *)
   let config = make_http_config ~host ~port in

--- a/masc_mcp.opam
+++ b/masc_mcp.opam
@@ -23,7 +23,7 @@ depends: [
   "cmdliner" {>= "1.1"}
   "cohttp" {>= "5.0"}
   "cohttp-eio" {>= "6.0" & < "6.2"}
-  "agent_sdk" {>= "0.52.0"}
+  "agent_sdk" {>= "0.53.0"}
   "uri" {>= "4.4"}
   "tls" {>= "0.16"}
   "tls-eio" {>= "0.16"}

--- a/test/test_gardener.ml
+++ b/test/test_gardener.ml
@@ -262,7 +262,7 @@ let test_homeostatic_score_at_maximum () =
 let test_spawn_decision_returns_valid () =
   Eio_main.run @@ fun env ->
   Eio.Switch.run @@ fun sw ->
-  Llm_eio_env.init ~sw ~net:(Eio.Stdenv.net env);
+  Llm_eio_env.init ~sw ~net:(Eio.Stdenv.net env) ();
   (* Use propose_spawn which internally calculates health from real data *)
   let decision = Gardener.propose_spawn ~topic:"test-topic" ~reason:"test" ~urgency:High in
   (* Verify decision is one of the valid ADT variants *)

--- a/test/test_lodge_cascade.ml
+++ b/test/test_lodge_cascade.ml
@@ -71,7 +71,7 @@ let test_call_returns_error_when_no_models () =
      requires a missing API key. *)
   Eio_main.run @@ fun env ->
   Eio.Switch.run @@ fun sw ->
-  Masc_mcp.Llm_eio_env.init ~sw ~net:(Eio.Stdenv.net env);
+  Masc_mcp.Llm_eio_env.init ~sw ~net:(Eio.Stdenv.net env) ();
   with_env "ZAI_API_KEY" "" (fun () ->
     with_env "GEMINI_API_KEY" "" (fun () ->
       with_temp_json


### PR DESCRIPTION
## Summary

MASC `Llm_provider_bridge.call`이 OAS `Complete.complete_with_retry`를 사용하도록 전환.

- per-provider 자동 retry (exponential backoff: 429/500/502/503/529/network errors)
- clock 없는 환경(테스트)에서는 기존과 동일하게 bare `complete` 사용
- `Llm_eio_env`에 optional clock 필드 추가
- `server_runtime_bootstrap`에서 clock을 env에 전달

## Context

OAS PR jeong-sik/oas#146 (merged)에서 `Llm_provider.Complete`에 retry/cascade/streaming 추가.
이 PR은 MASC 측에서 해당 기능 중 retry를 소비하는 첫 단계.

MASC 고유 cascade 로직 (`llm_orchestration.cascade`)은 유지 — health check, accept predicate, semaphore, cache 등 MASC 전용 기능 포함.

## Test plan

- [x] `dune build` green
- [x] `test_lodge_cascade` 9/9 pass
- [x] `test_gardener` 76/77 pass (1 failure = pre-existing flaky, main에서도 동일)

Requires: `agent_sdk >= 0.53.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)