### PR TITLE
refactor: delegate discovery probing to OAS Llm_provider.Discovery

### DIFF
--- a/lib/http_server_eio.ml
+++ b/lib/http_server_eio.ml
@@ -574,6 +574,7 @@ let error_handler _client_addr ?request:_ error start_response =
 
 (** Run the HTTP server with Eio *)
 let run ~sw ~net ~clock config routes =
+  Llm_discovery_cache.set_env ~sw ~net;
   let request_handler = make_request_handler routes in
   (* Parse IP address using Ipaddr library then convert to Eio format *)
   let ip = match Ipaddr.of_string config.host with

--- a/lib/llm_discovery_cache.ml
+++ b/lib/llm_discovery_cache.ml
@@ -1,171 +1,41 @@
-(** Llm_discovery_cache — probes local LLM endpoints and maintains a
-    cached snapshot of their status.
+(** Llm_discovery_cache — cached wrapper over OAS [Llm_provider.Discovery].
 
-    This module has no dependency on Llm_client or Llm_orchestration,
-    so it can be used by both without circular dependencies.
+    All probing logic lives in OAS. This module adds:
+    - TTL-based caching (30s default)
+    - Convenience queries (any_local_healthy, idle/busy counts)
+    - Eio capability injection (set_env at server init)
+
+    No dependency on Llm_client or Llm_orchestration.
 
     @since 2.113.0 *)
 
-(* ── Env config ──────────────────────────────────────────── *)
+(* ── Eio capability refs (set once at server init) ───────── *)
 
-let default_endpoint = "http://127.0.0.1:8085"
+let sw_ref : Eio.Switch.t option ref = ref None
+let net_ref : [`Generic | `Unix] Eio.Net.ty Eio.Resource.t option ref = ref None
 
-let endpoints_from_env () =
-  match Sys.getenv_opt "LLM_ENDPOINTS" with
-  | None | Some "" -> [default_endpoint]
-  | Some value ->
-    value
-    |> String.split_on_char ','
-    |> List.map String.trim
-    |> List.filter (fun s -> s <> "")
+let set_env ~sw ~(net : [`Generic | `Unix] Eio.Net.ty Eio.Resource.t) =
+  sw_ref := Some sw;
+  net_ref := Some net
 
-(* ── HTTP probing via curl ───────────────────────────────── *)
+(* ── Cache state ─────────────────────────────────────────── *)
 
-let http_get_json ?(timeout_sec = 5) url =
-  let status, body =
-    Process_eio.run_argv_with_status ~timeout_sec:10.0
-      [ "curl"; "-sS"; "--http1.1"; "--max-time";
-        string_of_int (max 1 timeout_sec); url ]
-  in
-  match status with
-  | Unix.WEXITED 0 ->
-    (try Ok (Yojson.Safe.from_string body)
-     with Yojson.Json_error msg -> Error msg)
-  | Unix.WEXITED code ->
-    Error (Printf.sprintf "curl exit %d for %s" code url)
-  | _ -> Error (Printf.sprintf "curl failed for %s" url)
-
-let http_get_ok ?(timeout_sec = 3) url =
-  let status, _ =
-    Process_eio.run_argv_with_status ~timeout_sec:5.0
-      [ "curl"; "-sS"; "--http1.1"; "--max-time";
-        string_of_int (max 1 timeout_sec); url ]
-  in
-  match status with Unix.WEXITED 0 -> true | _ -> false
-
-(* ── Parsers ─────────────────────────────────────────────── *)
-
-let parse_models json =
-  let open Yojson.Safe.Util in
-  match member "data" json with
-  | `List items ->
-    items |> List.filter_map (fun item ->
-      match item |> member "id" |> to_string_option with
-      | Some id ->
-        let owned_by =
-          item |> member "owned_by" |> to_string_option
-          |> Option.value ~default:"unknown"
-        in
-        Some (id, owned_by)
-      | None -> None)
-  | _ -> []
-
-let parse_props json =
-  let open Yojson.Safe.Util in
-  match member "total_slots" json with
-  | `Int total_slots ->
-    let dgs = member "default_generation_settings" json in
-    let ctx_size = match dgs with
-      | `Assoc _ -> (match member "n_ctx" dgs with `Int n -> n | _ -> 0)
-      | _ -> 0
-    in
-    let model = match dgs with
-      | `Assoc _ -> (match member "model" dgs with `String s -> s | _ -> "")
-      | _ -> ""
-    in
-    Some (total_slots, ctx_size, model)
-  | _ -> None
-
-let parse_slots json =
-  let open Yojson.Safe.Util in
-  let items = match json with `List items -> items | _ -> [] in
-  if items = [] then None
-  else
-    let total = List.length items in
-    let busy = List.fold_left (fun acc slot ->
-      let is_busy =
-        (slot |> member "is_processing" |> to_bool_option
-         |> Option.value ~default:false)
-        || (match slot |> member "state" with `Int n -> n <> 0 | _ -> false)
-      in
-      if is_busy then acc + 1 else acc
-    ) 0 items in
-    Some (total, busy, total - busy)
-
-let string_contains_ci ~haystack ~needle =
-  let h = String.lowercase_ascii haystack in
-  let n = String.lowercase_ascii needle in
-  let nlen = String.length n in
-  let hlen = String.length h in
-  if nlen > hlen then false
-  else
-    let found = ref false in
-    let i = ref 0 in
-    while !i <= hlen - nlen && not !found do
-      if String.sub h !i nlen = n then found := true;
-      incr i
-    done;
-    !found
-
-(* ── Endpoint info ───────────────────────────────────────── *)
-
-type endpoint_info = {
-  url: string;
-  healthy: bool;
-  model: string option;
-  context_size: int option;
-  slots_total: int option;
-  slots_busy: int option;
-  slots_idle: int option;
-  supports_reasoning: bool;
-  supports_tools: bool;
-  supports_streaming: bool;
-}
-
-let probe_endpoint url =
-  let base = String.trim url in
-  let healthy = http_get_ok (base ^ "/health") in
-  if not healthy then
-    { url = base; healthy = false; model = None; context_size = None;
-      slots_total = None; slots_busy = None; slots_idle = None;
-      supports_reasoning = false; supports_tools = false;
-      supports_streaming = false }
-  else
-    let models = match http_get_json (base ^ "/v1/models") with
-      | Ok json -> parse_models json | Error _ -> [] in
-    let props = match http_get_json (base ^ "/props") with
-      | Ok json -> parse_props json | Error _ -> None in
-    let slots = match http_get_json (base ^ "/slots") with
-      | Ok json -> parse_slots json | Error _ -> None in
-    let model_id = match models with (id, _) :: _ -> Some id | [] -> None in
-    let has_qwen = List.exists (fun (id, _) ->
-      string_contains_ci ~haystack:id ~needle:"qwen") models in
-    { url = base;
-      healthy = true;
-      model = (match props with Some (_, _, m) when m <> "" -> Some m
-                               | _ -> model_id);
-      context_size = (match props with Some (_, ctx, _) when ctx > 0 -> Some ctx
-                                      | _ -> None);
-      slots_total = (match slots with Some (t, _, _) -> Some t
-                                     | None -> Option.map (fun (t, _, _) -> t) props);
-      slots_busy = (match slots with Some (_, b, _) -> Some b | None -> None);
-      slots_idle = (match slots with Some (_, _, i) -> Some i | None -> None);
-      supports_reasoning = has_qwen;
-      supports_tools = true;
-      supports_streaming = true;
-    }
-
-(* ── Cache ───────────────────────────────────────────────── *)
+type endpoint_info = Llm_provider.Discovery.endpoint_status
 
 let cached_endpoints : endpoint_info list ref = ref []
 let cache_updated_at : float ref = ref 0.0
 let cache_ttl = 30.0
 
 let refresh_cache () =
-  let endpoints = endpoints_from_env () in
-  let results = List.map probe_endpoint endpoints in
-  cached_endpoints := results;
-  cache_updated_at := Time_compat.now ()
+  match !sw_ref, !net_ref with
+  | Some sw, Some net ->
+    let endpoints = Llm_provider.Discovery.endpoints_from_env () in
+    let results = Llm_provider.Discovery.discover ~sw ~net ~endpoints in
+    cached_endpoints := results;
+    cache_updated_at := Time_compat.now ()
+  | _ ->
+    (* Eio env not yet injected — return empty. Server init calls set_env. *)
+    ()
 
 let get_cached_or_refresh () =
   let now = Time_compat.now () in
@@ -185,32 +55,17 @@ let any_local_healthy () =
 let idle_slot_count () =
   let endpoints = get_cached_or_refresh () in
   List.fold_left (fun acc (e : endpoint_info) ->
-    acc + Option.value ~default:0 e.slots_idle) 0 endpoints
+    match e.slots with
+    | Some s -> acc + s.idle
+    | None -> acc) 0 endpoints
 
 let busy_slot_count () =
   let endpoints = get_cached_or_refresh () in
   List.fold_left (fun acc (e : endpoint_info) ->
-    acc + Option.value ~default:0 e.slots_busy) 0 endpoints
+    match e.slots with
+    | Some s -> acc + s.busy
+    | None -> acc) 0 endpoints
 
-(* ── JSON ────────────────────────────────────────────────── *)
+(* ── JSON (delegates to OAS) ─────────────────────────────── *)
 
-let int_opt_to_json = function Some v -> `Int v | None -> `Null
-let string_opt_to_json = function Some v -> `String v | None -> `Null
-
-let endpoint_to_json (e : endpoint_info) =
-  `Assoc [
-    ("url", `String e.url);
-    ("healthy", `Bool e.healthy);
-    ("model", string_opt_to_json e.model);
-    ("context_size", int_opt_to_json e.context_size);
-    ("slots", `Assoc [
-      ("total", int_opt_to_json e.slots_total);
-      ("busy", int_opt_to_json e.slots_busy);
-      ("idle", int_opt_to_json e.slots_idle);
-    ]);
-    ("capabilities", `Assoc [
-      ("reasoning", `Bool e.supports_reasoning);
-      ("tools", `Bool e.supports_tools);
-      ("streaming", `Bool e.supports_streaming);
-    ]);
-  ]
+let endpoint_to_json = Llm_provider.Discovery.endpoint_status_to_json

--- a/lib/tool_llm_catalog.ml
+++ b/lib/tool_llm_catalog.ml
@@ -1,15 +1,13 @@
 [@@@warning "-32-33-69"]
-(** Tool_llm_catalog — LLM endpoint discovery and capacity management.
+(** Tool_llm_catalog — MCP tool layer over OAS Discovery (via {!Llm_discovery_cache}).
 
-    Thin MCP tool layer over {!Llm_discovery_cache}.
-    Provides agents with visibility into available LLM infrastructure:
-    - list: enumerate configured endpoints and loaded models
-    - status: current slot utilization and capacity
-    - recommend: pick best endpoint for a given task type
+    All probing logic is in OAS [Llm_provider.Discovery].
+    This module provides the MCP tool interface for agents.
 
     @since 2.113.0 *)
 
 open Types
+module D = Llm_discovery_cache
 
 (* ── Types ───────────────────────────────────────────────── *)
 
@@ -27,41 +25,34 @@ let string_opt_to_json = function Some v -> `String v | None -> `Null
 (* ── Handlers ────────────────────────────────────────────── *)
 
 let handle_list _ctx _args : result =
-  let endpoints = Llm_discovery_cache.get_cached_or_refresh () in
+  let endpoints = D.get_cached_or_refresh () in
   (true, json_ok [
     ("result", `Assoc [
-      ("endpoints", `List (List.map Llm_discovery_cache.endpoint_to_json endpoints));
+      ("endpoints", `List (List.map D.endpoint_to_json endpoints));
       ("count", `Int (List.length endpoints));
     ]);
   ])
 
 let handle_status _ctx _args : result =
-  let endpoints = Llm_discovery_cache.get_cached_or_refresh () in
-  let total_cap = List.fold_left (fun acc (e : Llm_discovery_cache.endpoint_info) ->
-    acc + Option.value ~default:0 e.slots_total) 0 endpoints in
-  let available = List.fold_left (fun acc (e : Llm_discovery_cache.endpoint_info) ->
-    acc + Option.value ~default:0 e.slots_idle) 0 endpoints in
-  let active = List.fold_left (fun acc (e : Llm_discovery_cache.endpoint_info) ->
-    acc + Option.value ~default:0 e.slots_busy) 0 endpoints in
+  let endpoints = D.get_cached_or_refresh () in
+  let summary = Llm_provider.Discovery.summary_to_json endpoints in
   let permits_available = Llm_client.llm_semaphore_available () in
   let permits_in_use = Llm_client.llm_permits_in_use () in
   (true, json_ok [
     ("result", `Assoc [
-      ("endpoints", `List (List.map Llm_discovery_cache.endpoint_to_json endpoints));
-      ("summary", `Assoc [
-        ("total_capacity", `Int total_cap);
-        ("available_capacity", `Int available);
-        ("active_requests", `Int active);
-        ("masc_permits_available", `Int permits_available);
-        ("masc_permits_in_use", `Int permits_in_use);
-        ("masc_max_concurrent_llm", `Int Llm_client.max_concurrent_llm);
+      ("endpoints", `List (List.map D.endpoint_to_json endpoints));
+      ("summary", summary);
+      ("masc_permits", `Assoc [
+        ("available", `Int permits_available);
+        ("in_use", `Int permits_in_use);
+        ("max_concurrent", `Int Llm_client.max_concurrent_llm);
       ]);
-      ("cache_age_seconds", `Float (Llm_discovery_cache.cache_age_seconds ()));
+      ("cache_age_seconds", `Float (D.cache_age_seconds ()));
     ]);
   ])
 
 let handle_recommend _ctx args : result =
-  let endpoints = Llm_discovery_cache.get_cached_or_refresh () in
+  let endpoints = D.get_cached_or_refresh () in
   let task_type =
     args |> Yojson.Safe.Util.member "task_type"
     |> Yojson.Safe.Util.to_string_option
@@ -70,33 +61,39 @@ let handle_recommend _ctx args : result =
     | Some "reasoning" | Some "analysis" | Some "planning" -> true
     | _ -> false
   in
-  let healthy = List.filter (fun (e : Llm_discovery_cache.endpoint_info) ->
-    e.healthy) endpoints in
-  let with_idle = List.filter (fun (e : Llm_discovery_cache.endpoint_info) ->
-    match e.slots_idle with Some n -> n > 0 | None -> true) healthy in
+  let open Llm_provider.Discovery in
+  let healthy = List.filter (fun (e : endpoint_status) -> e.healthy) endpoints in
+  let with_idle = List.filter (fun (e : endpoint_status) ->
+    match e.slots with Some s -> s.idle > 0 | None -> true) healthy in
   let candidates = if with_idle <> [] then with_idle else healthy in
-  let scored = List.map (fun (e : Llm_discovery_cache.endpoint_info) ->
-    let idle_score = Option.value ~default:0 e.slots_idle in
-    let reasoning_bonus = if needs_reasoning && e.supports_reasoning then 10 else 0 in
-    (e, idle_score + reasoning_bonus)
+  let scored = List.map (fun (e : endpoint_status) ->
+    let idle = match e.slots with Some s -> s.idle | None -> 0 in
+    let reasoning_bonus =
+      if needs_reasoning && e.capabilities.supports_reasoning then 10 else 0
+    in
+    (e, idle + reasoning_bonus)
   ) candidates in
   let sorted = List.sort (fun (_, a) (_, b) -> compare b a) scored in
   match sorted with
-  | (best, _score) :: _ ->
+  | (best, _) :: _ ->
     let reason =
-      match best.slots_idle, needs_reasoning with
-      | Some n, true when n > 0 && best.supports_reasoning ->
+      let idle = match best.slots with Some s -> s.idle | None -> 0 in
+      match idle, needs_reasoning with
+      | n, true when n > 0 && best.capabilities.supports_reasoning ->
         Printf.sprintf "%d idle slot(s), reasoning supported" n
-      | Some n, _ when n > 0 ->
+      | n, _ when n > 0 ->
         Printf.sprintf "%d idle slot(s) available" n
       | _ -> "best available endpoint"
+    in
+    let model_id = match best.models with
+      | m :: _ -> Some m.id | [] -> None
     in
     (true, json_ok [
       ("result", `Assoc [
         ("recommended_endpoint", `String best.url);
-        ("model", string_opt_to_json best.model);
+        ("model", string_opt_to_json model_id);
         ("reason", `String reason);
-        ("endpoint_detail", Llm_discovery_cache.endpoint_to_json best);
+        ("endpoint_detail", D.endpoint_to_json best);
       ]);
     ])
   | [] ->
@@ -130,11 +127,11 @@ let dispatch ctx ~name ~args : result option =
 let schemas : tool_schema list = [
   { name = "masc_llm_catalog";
     description =
-      "Query local LLM infrastructure status and get endpoint recommendations. \
+      "Query LLM provider infrastructure status and get endpoint recommendations. \
        Actions: 'list' (enumerate endpoints), 'status' (slot utilization + \
        MASC permit state), 'recommend' (pick best endpoint for task_type: \
-       reasoning|analysis|planning|generation|general). Use before spawning \
-       local LLM workers to check available capacity.";
+       reasoning|analysis|planning|generation|general). Uses OAS Discovery \
+       to probe OpenAI-compatible endpoints.";
     input_schema = `Assoc [
       ("type", `String "object");
       ("properties", `Assoc [


### PR DESCRIPTION
## Summary
- `llm_discovery_cache.ml`: curl probing 150+ 줄 제거, OAS `Discovery.discover` 호출로 교체
- `tool_llm_catalog.ml`: OAS `endpoint_status`, `capabilities`, `summary_to_json` 타입 직접 사용
- `http_server_eio.ml`: `Llm_discovery_cache.set_env ~sw ~net` 1줄 추가 (Eio 환경 주입)

## Context
PR #1541에서 누락된 2번째 커밋(OAS 위임 리팩토링)을 별도 PR로 분리.
프로빙 로직의 Single Source of Truth = OAS `lib/llm_provider/discovery.ml` (v0.53.0)

## Note
main에 `context_scoring.ml` / `test_context_compact_oas_coverage.ml` 빌드 에러가 있음 (이 PR과 무관). 변경 파일 3개는 정상 컴파일.

## Test plan
- [x] 변경 파일 개별 빌드 성공
- [ ] main 빌드 에러 해소 후 전체 빌드/테스트 확인 필요

🤖 Generated with [Claude Code](https://claude.com/claude-code)