### PR TITLE
fix: adapt context_scoring and tests to unified message type

### DIFF
--- a/lib/context_scoring.ml
+++ b/lib/context_scoring.ml
@@ -55,7 +55,11 @@ let score_messages (msgs : Llm_client.message list) : (int * float) list =
       else if len < 500 then 0.8
       else 0.7
     in
-    let tool_w = match m.tool_call_id with Some _ -> 0.8 | None -> 0.5 in
+    let has_tool_content = List.exists (function
+      | Agent_sdk.Types.ToolUse _ | Agent_sdk.Types.ToolResult _ -> true
+      | _ -> false) m.content
+    in
+    let tool_w = if has_tool_content then 0.8 else 0.5 in
     let score = 0.4 *. recency +. 0.25 *. role_w +. 0.2 *. content_w +. 0.15 *. tool_w in
     let score =
       if starts_with ~prefix:memory_summary_prefix msg_text

--- a/test/test_context_compact_oas_coverage.ml
+++ b/test/test_context_compact_oas_coverage.ml
@@ -11,14 +11,12 @@ module Types = Agent_sdk.Types
 module Compact = Masc_mcp.Context_compact_oas
 module Scoring = Masc_mcp.Context_scoring
 
-let msg role text =
-  { Llm.role; content = [Types.Text text];
-    name = None; tool_call_id = None }
+let msg role text : Llm.message =
+  { role; content = [Types.Text text] }
 
-let tool_msg ?(id = "tool-1") text =
-  { Llm.role = Llm.Tool;
-    content = [Types.Text text];
-    name = None; tool_call_id = Some id }
+let tool_msg ?(id = "tool-1") text : Llm.message =
+  { role = Types.Tool;
+    content = [Types.ToolResult { tool_use_id = id; content = text; is_error = false }] }
 
 (* ================================================================ *)
 (* Sentinel Roundtrip Tests (C2)                                    *)
@@ -59,8 +57,11 @@ let test_roundtrip_tool () =
     (match back.role with Llm.Tool -> "Tool" | _ -> "other");
   check string "text preserved" "Result data"
     (Llm.text_of_message back);
-  check (option string) "tool_call_id preserved" (Some "call-42")
-    back.tool_call_id
+  let tool_id = List.find_map (function
+    | Types.ToolResult { tool_use_id; _ } -> Some tool_use_id
+    | _ -> None) back.content
+  in
+  check (option string) "tool_use_id preserved" (Some "call-42") tool_id
 
 let test_roundtrip_empty_text () =
   let m = msg Llm.System "" in


### PR DESCRIPTION
## Summary
main 빌드 깨짐 수정. OAS type convergence 후 `message`에서 `name`/`tool_call_id` 필드가 제거되었으나 2개 파일이 미갱신.

- `context_scoring.ml`: `m.tool_call_id` → content blocks에서 `ToolUse`/`ToolResult` 존재 여부 확인
- `test_context_compact_oas_coverage.ml`: 메시지 생성자 `{ role; content }` 형태로 수정, `tool_use_id`를 `ToolResult` content block에서 추출

## Test plan
- [x] `dune build --root .` — clean build
- [x] `test_context_compact_oas_coverage.exe` — 24/24 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)