### PR TITLE
refactor: remove all OAS feature flags — OAS is the only path

### DIFF
--- a/lib/context_manager.ml
+++ b/lib/context_manager.ml
@@ -293,32 +293,16 @@ let sync_oas_context (ctx : working_context) : working_context =
     "context_ratio" (`Float (context_ratio ctx));
   ctx
 
-(** Feature flag: route compaction through OAS Context_reducer adapter.
-    Set MASC_USE_OAS_REDUCER=true to enable A/B testing.
-    Evaluated per call (not module load) for runtime toggling consistency. *)
-let use_oas_reducer () =
-  match Sys.getenv_opt "MASC_USE_OAS_REDUCER" with
-  | Some v -> String.lowercase_ascii (String.trim v) = "true"
-  | None -> false
-
-(** Identity mapping — both types are now [Compaction_types.compaction_strategy].
-    Kept as a named function for call-site readability. *)
-let oas_adapter_strategy_of (s : compaction_strategy) : Context_compact_oas.strategy = s
-
 let compact ctx strategies =
-  if use_oas_reducer () then
-    let oas_strategies = List.map oas_adapter_strategy_of strategies in
-    let messages, token_count =
-      Context_compact_oas.compact
-        ~system_prompt:ctx.system_prompt
-        ~messages:ctx.messages
-        ~strategies:oas_strategies
-    in
-    let ctx = { ctx with messages; token_count; importance_scores = [] } in
-    sync_oas_context ctx
-  else
-    let ctx = List.fold_left apply_strategy ctx strategies in
-    sync_oas_context ctx
+  let oas_strategies = List.map (fun (s : compaction_strategy) : Context_compact_oas.strategy -> s) strategies in
+  let messages, token_count =
+    Context_compact_oas.compact
+      ~system_prompt:ctx.system_prompt
+      ~messages:ctx.messages
+      ~strategies:oas_strategies
+  in
+  let ctx = { ctx with messages; token_count; importance_scores = [] } in
+  sync_oas_context ctx
 
 (* ================================================================ *)
 (* Conversation History Offload                                     *)
@@ -395,19 +379,16 @@ let compact_with_offload
       ~compaction_count
       pre_messages
   in
-  (* Run the compaction pipeline (OAS adapter or legacy) *)
+  (* Run the compaction pipeline via OAS adapter *)
   let compacted =
-    if use_oas_reducer () then begin
-      let oas_strategies = List.map oas_adapter_strategy_of strategies in
-      let messages, token_count =
-        Context_compact_oas.compact
-          ~system_prompt:ctx.system_prompt
-          ~messages:ctx.messages
-          ~strategies:oas_strategies
-      in
-      { ctx with messages; token_count; importance_scores = [] }
-    end else
-      List.fold_left apply_strategy ctx strategies
+    let oas_strategies = List.map (fun (s : compaction_strategy) : Context_compact_oas.strategy -> s) strategies in
+    let messages, token_count =
+      Context_compact_oas.compact
+        ~system_prompt:ctx.system_prompt
+        ~messages:ctx.messages
+        ~strategies:oas_strategies
+    in
+    { ctx with messages; token_count; importance_scores = [] }
   in
   (* If offload succeeded and SummarizeOld produced a summary, annotate it *)
   let compacted = match offloaded_path with

--- a/lib/llm_provider_oas.ml
+++ b/lib/llm_provider_oas.ml
@@ -1,35 +1,15 @@
 (** OAS LLM Provider adapter — bridges MASC LLM types to OAS Provider layer.
 
-    NOTE: Not yet wired into production code paths. These adapters will
-    replace existing implementations when feature flags are enabled.
-    Currently available for direct testing only.
-
-    Provides an alternative code path for LLM calls using OAS
-    {!Agent_sdk.Provider.config} and {!Agent_sdk.Provider.cascade} types
-    instead of the raw {!Llm_provider_bridge} direct HTTP path.
-
-    Enabled via [MASC_USE_OAS_LLM=true] environment variable.
-    When disabled, callers fall through to the existing
-    {!Llm_orchestration.complete} / {!Llm_orchestration.cascade} path.
+    All LLM calls route through OAS {!Agent_sdk.Provider.config} and
+    {!Agent_sdk.Provider.cascade} types via {!Llm_provider_bridge}.
 
     All types used here are from {!Llm_types} (the canonical type source
-    shared by {!Llm_orchestration} and {!Llm_provider_bridge}).
+    shared by {!Llm_provider_bridge}).
 
     @since 2.104.0 — Phase 3 OAS integration *)
 
 open Printf
 open Llm_types
-
-(* ================================================================ *)
-(* Feature flag                                                      *)
-(* ================================================================ *)
-
-let use_oas_llm () =
-  match Sys.getenv_opt "MASC_USE_OAS_LLM" with
-  | Some v ->
-      let v = String.lowercase_ascii (String.trim v) in
-      v = "true" || v = "1" || v = "yes"
-  | None -> false
 
 (* ================================================================ *)
 (* model_spec → Agent_sdk.Provider.config                           *)
@@ -156,10 +136,8 @@ let build_oas_cascade (specs : model_spec list)
     Each model is tried via {!complete_via_oas}; on failure,
     the next model in the cascade is attempted.
 
-    Concurrency control is NOT applied here (unlike
-    {!Llm_orchestration.cascade} which uses a semaphore).
-    Callers who need concurrency limiting should wrap this call
-    or use {!cascade} which dispatches based on feature flag.
+    Concurrency control is NOT applied here.
+    Callers who need concurrency limiting should wrap this call.
 
     @param accept Optional response validator. If a response is
     obtained but [accept] returns [false], the next model is tried.
@@ -221,54 +199,38 @@ let cascade_complete ?(accept = fun _ -> true) ?timeout_sec
   try_next [] requests
 
 (* ================================================================ *)
-(* Unified entry points — dispatch based on feature flag            *)
+(* Unified entry points                                             *)
 (* ================================================================ *)
 
-(** Single completion with automatic dispatch.
-    If [MASC_USE_OAS_LLM=true], uses {!complete_via_oas}.
-    Otherwise, falls through to {!Llm_orchestration.complete}. *)
+(** Single completion through OAS provider path. *)
 let complete ?timeout_sec (req : completion_request)
     : (completion_response, string) result =
-  if use_oas_llm () then
-    complete_via_oas ?timeout_sec req
-  else
-    Llm_orchestration.complete ?timeout_sec req
+  complete_via_oas ?timeout_sec req
 
-(** Cascade completion with automatic dispatch.
-    If [MASC_USE_OAS_LLM=true], uses {!cascade_complete}.
-    Otherwise, falls through to {!Llm_orchestration.cascade}. *)
+(** Cascade completion through OAS provider path. *)
 let cascade ?(accept = fun _ -> true) ?timeout_sec
     (requests : completion_request list)
     : (completion_response, string) result =
-  if use_oas_llm () then
-    cascade_complete ~accept ?timeout_sec requests
-  else
-    Llm_orchestration.cascade ~accept ?timeout_sec requests
+  cascade_complete ~accept ?timeout_sec requests
 
-(** Convenience: cascade from model_specs + prompt.
-    If [MASC_USE_OAS_LLM=true], builds requests and runs via OAS cascade.
-    Otherwise, falls through to {!Llm_orchestration.run_prompt_cascade}. *)
+(** Convenience: cascade from model_specs + prompt via OAS. *)
 let run_prompt_cascade ?(temperature = 0.7) ?timeout_sec
     ?(accept = fun _ -> true) ?system ~model_specs ~max_tokens
     ~prompt () : (completion_response, string) result =
-  if use_oas_llm () then begin
-    let msgs =
-      match system with
-      | Some s -> [ system_msg s; user_msg prompt ]
-      | None -> [ user_msg prompt ]
-    in
-    let requests =
-      List.map
-        (fun (model : model_spec) ->
-          ({ model; messages = msgs; temperature;
-             max_tokens; tools = []; response_format = `Text }
-            : completion_request))
-        model_specs
-    in
-    cascade_complete ~accept ?timeout_sec requests
-  end else
-    Llm_orchestration.run_prompt_cascade ~temperature ?timeout_sec
-      ~accept ?system ~model_specs ~max_tokens ~prompt ()
+  let msgs =
+    match system with
+    | Some s -> [ system_msg s; user_msg prompt ]
+    | None -> [ user_msg prompt ]
+  in
+  let requests =
+    List.map
+      (fun (model : model_spec) ->
+        ({ model; messages = msgs; temperature;
+           max_tokens; tools = []; response_format = `Text }
+          : completion_request))
+      model_specs
+  in
+  cascade_complete ~accept ?timeout_sec requests
 
 (** Summary of OAS-convertible model specs for diagnostics. *)
 let supported_providers_summary () : string =

--- a/lib/perpetual_oas.ml
+++ b/lib/perpetual_oas.ml
@@ -1,8 +1,7 @@
-(** Perpetual_oas — Adapter bridging MASC perpetual_loop to OAS Agent.t.
+(** Perpetual_oas — OAS Agent.t-based perpetual loop.
 
-    Demonstrates the complete migration path from MASC's bespoke perpetual
-    loop (think -> act -> observe -> verify -> compact -> heartbeat -> loop)
-    to OAS Agent.t with lifecycle hooks. Ties together all previous phases:
+    Runs the MASC perpetual loop via OAS Agent.t with lifecycle hooks.
+    Ties together all OAS integration phases:
 
     - Phase 1: Context_compact_oas (context reduction)
     - Phase 2: Succession_oas / Oas_checkpoint_bridge (checkpoint/DNA)
@@ -10,9 +9,7 @@
     - Phase 4: Verifier_oas (guardrails/hooks)
     - Phase 5: Worker_oas (Agent.run adapter)
 
-    Enabled via [MASC_USE_OAS_PERPETUAL=true] environment variable.
-
-    Split into sub-modules (H2):
+    Split into sub-modules:
     - {!Perpetual_oas_state}: mutable state + mutex ops
     - {!Perpetual_oas_hooks}: 4 lifecycle hooks + periodic callback
     - {!Perpetual_oas_build}: OAS Agent.t builder
@@ -22,17 +19,6 @@
 open Printf
 
 module Oas = Agent_sdk
-
-(* ================================================================ *)
-(* Feature Flag                                                      *)
-(* ================================================================ *)
-
-let use_oas_perpetual () =
-  match Sys.getenv_opt "MASC_USE_OAS_PERPETUAL" with
-  | Some v ->
-    let v = String.lowercase_ascii (String.trim v) in
-    v = "true" || v = "1" || v = "yes"
-  | None -> false
 
 (* ================================================================ *)
 (* Run perpetual loop via OAS Agent.run                              *)
@@ -213,21 +199,16 @@ let run_perpetual_via_oas
   Ok ()
 
 (* ================================================================ *)
-(* Unified entry point — dispatch based on feature flag              *)
+(* Unified entry point                                               *)
 (* ================================================================ *)
 
-(** Run the perpetual loop, dispatching to OAS or legacy path.
-
-    If [MASC_USE_OAS_PERPETUAL=true], uses {!run_perpetual_via_oas}.
-    Otherwise, delegates to {!Perpetual_loop.run}. *)
+(** Run the perpetual loop via OAS Agent.run.
+    Wraps {!run_perpetual_via_oas} and logs errors to stderr. *)
 let run
     ~(sw : Eio.Switch.t)
     ~(config : Perpetual_loop.loop_config)
     ~(state : Perpetual_loop.loop_state)
   : unit =
-  if use_oas_perpetual () then
-    run_perpetual_via_oas ~sw ~config ~state
-    |> Result.iter_error (fun e ->
-      eprintf "[perpetual_oas] OAS path aborted: %s\n%!" e)
-  else
-    Perpetual_loop.run ~config ~state
+  run_perpetual_via_oas ~sw ~config ~state
+  |> Result.iter_error (fun e ->
+    eprintf "[perpetual_oas] OAS path aborted: %s\n%!" e)

--- a/lib/succession_oas.ml
+++ b/lib/succession_oas.ml
@@ -1,9 +1,8 @@
-(** Succession_oas — Adapter bridging MASC succession DNA to OAS Checkpoint.t.
+(** Succession_oas — Bridges MASC succession DNA to OAS Checkpoint.t.
 
     Converts between MASC's [succession_dna] (generation handoff payload) and
-    OAS [Checkpoint.t] (versioned state snapshot). This enables DNA extraction
-    and hydration to use OAS's serialization format instead of MASC's custom
-    JSON, providing version tracking and cross-agent portability.
+    OAS [Checkpoint.t] (versioned state snapshot). DNA extraction and hydration
+    use OAS serialization format for version tracking and cross-agent portability.
 
     This module is independent of [context_compact_oas] (Phase 1) and
     [oas_checkpoint_bridge] (basic state persistence). It specifically handles
@@ -17,15 +16,6 @@
     @since Phase 2 — OAS Checkpoint adapter for succession *)
 
 open Printf
-
-(* ================================================================ *)
-(* Feature Flag                                                      *)
-(* ================================================================ *)
-
-let use_oas_checkpoint () =
-  match Sys.getenv_opt "MASC_USE_OAS_CHECKPOINT" with
-  | Some v -> String.lowercase_ascii (String.trim v) = "true"
-  | None -> false
 
 (* ================================================================ *)
 (* DNA Scope — Custom scope for succession metadata in Context.t     *)
@@ -199,9 +189,6 @@ let dna_of_checkpoint (ckpt : Agent_sdk.Checkpoint.t)
     Wraps [Succession.extract_dna] and converts the result to an OAS
     [Checkpoint.t]. The caller can then use [Checkpoint.to_string] for
     persistence instead of [Succession.dna_to_json].
-
-    When [MASC_USE_OAS_CHECKPOINT] is not set, falls back to returning
-    the checkpoint alongside the original DNA for comparison.
 
     @return [(dna, checkpoint)] — the original DNA and its OAS checkpoint form. *)
 let extract_dna_via_checkpoint

--- a/lib/verifier_oas.ml
+++ b/lib/verifier_oas.ml
@@ -1,28 +1,15 @@
-(** Verifier_oas — Adapter bridging MASC verifier to OAS Guardrails and Hooks.
+(** Verifier_oas — Bridges MASC verifier to OAS Guardrails and Hooks.
 
     Maps MASC's verification flow (should_skip, verify, verdict) to OAS
     {!Agent_sdk.Guardrails.Custom} filter and {!Agent_sdk.Hooks.hook} callbacks.
 
     - [verdict_to_hook_decision]: MASC Pass/Warn/Fail -> OAS Continue/Continue/Skip
     - [make_pre_tool_hook]: wraps MASC verify_action as an OAS PreToolUse hook
-    - [guardrails_of_read_only_detection]: wraps MASC should_skip as OAS Custom filter
-
-    Enabled via [MASC_USE_OAS_GUARDRAILS=true] environment variable.
+    - [guardrails_with_read_only_tag]: wraps MASC should_skip as OAS Custom filter
 
     @since Phase 4 — OAS Guardrails adapter for verifier *)
 
 open Printf
-
-(* ================================================================ *)
-(* Feature Flag                                                      *)
-(* ================================================================ *)
-
-let use_oas_guardrails () =
-  match Sys.getenv_opt "MASC_USE_OAS_GUARDRAILS" with
-  | Some v ->
-    let v = String.lowercase_ascii (String.trim v) in
-    v = "true" || v = "1" || v = "yes"
-  | None -> false
 
 (* ================================================================ *)
 (* Verdict -> Hook Decision                                          *)

--- a/lib/worker_oas.ml
+++ b/lib/worker_oas.ml
@@ -1,17 +1,8 @@
-(** Worker_oas — Adapter bridging MASC worker_container_meta to OAS Agent.t.
-
-    NOTE: Not yet wired into production code paths. These adapters will
-    replace existing implementations when feature flags are enabled.
-    Currently available for direct testing only.
+(** Worker_oas — Bridges MASC worker_container_meta to OAS Agent.t.
 
     Converts MASC worker metadata into OAS Agent configuration, using the
     OAS Builder pattern for agent construction. Wraps Agent.run with MASC
     worker lifecycle hooks (heartbeat, join/leave, board posting).
-
-    This module demonstrates the migration path from MASC's bespoke worker
-    runner (local_agent_eio_runners.ml) to the OAS Agent SDK. It does not
-    replace the existing runner; instead it provides an alternative entry
-    point gated by [MASC_USE_OAS_WORKERS=true].
 
     Key mappings:
     - worker_container_meta fields -> OAS agent_config + Builder options
@@ -25,17 +16,6 @@
 open Printf
 
 module Oas = Agent_sdk
-
-(* ================================================================ *)
-(* Feature Flag                                                      *)
-(* ================================================================ *)
-
-let use_oas_workers () =
-  match Sys.getenv_opt "MASC_USE_OAS_WORKERS" with
-  | Some v ->
-    let v = String.lowercase_ascii (String.trim v) in
-    v = "true" || v = "1" || v = "yes"
-  | None -> false
 
 (* ================================================================ *)
 (* worker_container_meta -> OAS Types.model                          *)


### PR DESCRIPTION
## Summary

- Remove 6 `MASC_USE_OAS_*` environment variable checks and their legacy fallback branches
- OAS adapter modules (`context_manager`, `llm_provider_oas`, `perpetual_oas`, `succession_oas`, `verifier_oas`, `worker_oas`) now execute unconditionally
- Clean up docstrings referencing feature flags, A/B testing, and legacy paths
- Net result: -122 lines of dead branching code

## Changes per file

| File | What changed |
|------|-------------|
| `context_manager.ml` | Removed `use_oas_reducer`, `oas_adapter_strategy_of`; `compact` and `compact_with_offload` always use `Context_compact_oas` |
| `llm_provider_oas.ml` | Removed `use_oas_llm`; `complete`, `cascade`, `run_prompt_cascade` always use OAS path. `Llm_orchestration` calls removed |
| `perpetual_oas.ml` | Removed `use_oas_perpetual`; `run` always calls `run_perpetual_via_oas`. `Perpetual_loop.run` fallback removed (still called by `mcp_server_eio_execute.ml` and `perpetual_cli.ml`) |
| `succession_oas.ml` | Removed unused `use_oas_checkpoint` |
| `verifier_oas.ml` | Removed unused `use_oas_guardrails` |
| `worker_oas.ml` | Removed unused `use_oas_workers` |

## Newly dead code (follow-up PR)

- `Llm_orchestration.complete` / `cascade` / `run_prompt_cascade` — zero callers after flag path removal

## Build note

Pre-existing build errors in `context_scoring.ml` (field `tool_call_id` removed from `Llm_client.message`) and `test_context_compact_oas_coverage.ml` (unbound record field `Llm.role`) are unrelated to this PR and exist on main.

## Test plan

- [x] `dune build --root .` — no new errors (identical build output vs main)
- [x] Grep confirms zero remaining references to `MASC_USE_OAS_*` in modified files
- [x] `Perpetual_loop.run` still has callers in `mcp_server_eio_execute.ml` and `perpetual_cli.ml` (not dead)
- [ ] Pre-existing build errors block test execution — fix in separate PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)