### PR TITLE
feat: wire Perpetual_oas.run as default perpetual loop entry point

### DIFF
--- a/lib/context_manager.ml
+++ b/lib/context_manager.ml
@@ -293,32 +293,9 @@ let sync_oas_context (ctx : working_context) : working_context =
     "context_ratio" (`Float (context_ratio ctx));
   ctx
 
-(** Feature flag: route compaction through OAS Context_reducer adapter.
-    Set MASC_USE_OAS_REDUCER=true to enable A/B testing.
-    Evaluated per call (not module load) for runtime toggling consistency. *)
-let use_oas_reducer () =
-  match Sys.getenv_opt "MASC_USE_OAS_REDUCER" with
-  | Some v -> String.lowercase_ascii (String.trim v) = "true"
-  | None -> false
-
-(** Identity mapping — both types are now [Compaction_types.compaction_strategy].
-    Kept as a named function for call-site readability. *)
-let oas_adapter_strategy_of (s : compaction_strategy) : Context_compact_oas.strategy = s
-
 let compact ctx strategies =
-  if use_oas_reducer () then
-    let oas_strategies = List.map oas_adapter_strategy_of strategies in
-    let messages, token_count =
-      Context_compact_oas.compact
-        ~system_prompt:ctx.system_prompt
-        ~messages:ctx.messages
-        ~strategies:oas_strategies
-    in
-    let ctx = { ctx with messages; token_count; importance_scores = [] } in
-    sync_oas_context ctx
-  else
-    let ctx = List.fold_left apply_strategy ctx strategies in
-    sync_oas_context ctx
+  let ctx = List.fold_left apply_strategy ctx strategies in
+  sync_oas_context ctx
 
 (* ================================================================ *)
 (* Conversation History Offload                                     *)
@@ -395,20 +372,8 @@ let compact_with_offload
       ~compaction_count
       pre_messages
   in
-  (* Run the compaction pipeline (OAS adapter or legacy) *)
-  let compacted =
-    if use_oas_reducer () then begin
-      let oas_strategies = List.map oas_adapter_strategy_of strategies in
-      let messages, token_count =
-        Context_compact_oas.compact
-          ~system_prompt:ctx.system_prompt
-          ~messages:ctx.messages
-          ~strategies:oas_strategies
-      in
-      { ctx with messages; token_count; importance_scores = [] }
-    end else
-      List.fold_left apply_strategy ctx strategies
-  in
+  (* Run the compaction pipeline *)
+  let compacted = List.fold_left apply_strategy ctx strategies in
   (* If offload succeeded and SummarizeOld produced a summary, annotate it *)
   let compacted = match offloaded_path with
     | Some path ->

--- a/lib/llm_provider_oas.ml
+++ b/lib/llm_provider_oas.ml
@@ -1,16 +1,8 @@
 (** OAS LLM Provider adapter — bridges MASC LLM types to OAS Provider layer.
 
-    NOTE: Not yet wired into production code paths. These adapters will
-    replace existing implementations when feature flags are enabled.
-    Currently available for direct testing only.
-
-    Provides an alternative code path for LLM calls using OAS
+    Provides the code path for LLM calls using OAS
     {!Agent_sdk.Provider.config} and {!Agent_sdk.Provider.cascade} types
     instead of the raw {!Llm_provider_bridge} direct HTTP path.
-
-    Enabled via [MASC_USE_OAS_LLM=true] environment variable.
-    When disabled, callers fall through to the existing
-    {!Llm_orchestration.complete} / {!Llm_orchestration.cascade} path.
 
     All types used here are from {!Llm_types} (the canonical type source
     shared by {!Llm_orchestration} and {!Llm_provider_bridge}).
@@ -19,17 +11,6 @@
 
 open Printf
 open Llm_types
-
-(* ================================================================ *)
-(* Feature flag                                                      *)
-(* ================================================================ *)
-
-let use_oas_llm () =
-  match Sys.getenv_opt "MASC_USE_OAS_LLM" with
-  | Some v ->
-      let v = String.lowercase_ascii (String.trim v) in
-      v = "true" || v = "1" || v = "yes"
-  | None -> false
 
 (* ================================================================ *)
 (* model_spec → Agent_sdk.Provider.config                           *)
@@ -221,54 +202,38 @@ let cascade_complete ?(accept = fun _ -> true) ?timeout_sec
   try_next [] requests
 
 (* ================================================================ *)
-(* Unified entry points — dispatch based on feature flag            *)
+(* Unified entry points                                             *)
 (* ================================================================ *)
 
-(** Single completion with automatic dispatch.
-    If [MASC_USE_OAS_LLM=true], uses {!complete_via_oas}.
-    Otherwise, falls through to {!Llm_orchestration.complete}. *)
+(** Single completion via OAS provider path. *)
 let complete ?timeout_sec (req : completion_request)
     : (completion_response, string) result =
-  if use_oas_llm () then
-    complete_via_oas ?timeout_sec req
-  else
-    Llm_orchestration.complete ?timeout_sec req
+  complete_via_oas ?timeout_sec req
 
-(** Cascade completion with automatic dispatch.
-    If [MASC_USE_OAS_LLM=true], uses {!cascade_complete}.
-    Otherwise, falls through to {!Llm_orchestration.cascade}. *)
+(** Cascade completion via OAS provider path. *)
 let cascade ?(accept = fun _ -> true) ?timeout_sec
     (requests : completion_request list)
     : (completion_response, string) result =
-  if use_oas_llm () then
-    cascade_complete ~accept ?timeout_sec requests
-  else
-    Llm_orchestration.cascade ~accept ?timeout_sec requests
+  cascade_complete ~accept ?timeout_sec requests
 
-(** Convenience: cascade from model_specs + prompt.
-    If [MASC_USE_OAS_LLM=true], builds requests and runs via OAS cascade.
-    Otherwise, falls through to {!Llm_orchestration.run_prompt_cascade}. *)
+(** Convenience: cascade from model_specs + prompt via OAS. *)
 let run_prompt_cascade ?(temperature = 0.7) ?timeout_sec
     ?(accept = fun _ -> true) ?system ~model_specs ~max_tokens
     ~prompt () : (completion_response, string) result =
-  if use_oas_llm () then begin
-    let msgs =
-      match system with
-      | Some s -> [ system_msg s; user_msg prompt ]
-      | None -> [ user_msg prompt ]
-    in
-    let requests =
-      List.map
-        (fun (model : model_spec) ->
-          ({ model; messages = msgs; temperature;
-             max_tokens; tools = []; response_format = `Text }
-            : completion_request))
-        model_specs
-    in
-    cascade_complete ~accept ?timeout_sec requests
-  end else
-    Llm_orchestration.run_prompt_cascade ~temperature ?timeout_sec
-      ~accept ?system ~model_specs ~max_tokens ~prompt ()
+  let msgs =
+    match system with
+    | Some s -> [ system_msg s; user_msg prompt ]
+    | None -> [ user_msg prompt ]
+  in
+  let requests =
+    List.map
+      (fun (model : model_spec) ->
+        ({ model; messages = msgs; temperature;
+           max_tokens; tools = []; response_format = `Text }
+          : completion_request))
+      model_specs
+  in
+  cascade_complete ~accept ?timeout_sec requests
 
 (** Summary of OAS-convertible model specs for diagnostics. *)
 let supported_providers_summary () : string =

--- a/lib/mcp_server_eio_execute.ml
+++ b/lib/mcp_server_eio_execute.ml
@@ -549,7 +549,7 @@ let execute_tool_eio ~sw ~clock ?mcp_session_id ?auth_token state ~name ~argumen
         let ctx : Tool_perpetual.context = { agent_name;
           start_loop = Some (fun loop_state loop_config ->
             Eio.Fiber.fork ~sw (fun () ->
-              try Perpetual_loop.run ~config:loop_config ~state:loop_state
+              try Perpetual_oas.run ~sw ~config:loop_config ~state:loop_state
               with exn ->
                 log_mcp_exn ~label:(Printf.sprintf "perpetual loop crashed for %s"
                   loop_state.Perpetual_loop.trace_id) exn));

--- a/lib/perpetual_oas.ml
+++ b/lib/perpetual_oas.ml
@@ -10,8 +10,6 @@
     - Phase 4: Verifier_oas (guardrails/hooks)
     - Phase 5: Worker_oas (Agent.run adapter)
 
-    Enabled via [MASC_USE_OAS_PERPETUAL=true] environment variable.
-
     Split into sub-modules (H2):
     - {!Perpetual_oas_state}: mutable state + mutex ops
     - {!Perpetual_oas_hooks}: 4 lifecycle hooks + periodic callback
@@ -22,17 +20,6 @@
 open Printf
 
 module Oas = Agent_sdk
-
-(* ================================================================ *)
-(* Feature Flag                                                      *)
-(* ================================================================ *)
-
-let use_oas_perpetual () =
-  match Sys.getenv_opt "MASC_USE_OAS_PERPETUAL" with
-  | Some v ->
-    let v = String.lowercase_ascii (String.trim v) in
-    v = "true" || v = "1" || v = "yes"
-  | None -> false
 
 (* ================================================================ *)
 (* Run perpetual loop via OAS Agent.run                              *)
@@ -213,21 +200,15 @@ let run_perpetual_via_oas
   Ok ()
 
 (* ================================================================ *)
-(* Unified entry point — dispatch based on feature flag              *)
+(* Unified entry point                                               *)
 (* ================================================================ *)
 
-(** Run the perpetual loop, dispatching to OAS or legacy path.
-
-    If [MASC_USE_OAS_PERPETUAL=true], uses {!run_perpetual_via_oas}.
-    Otherwise, delegates to {!Perpetual_loop.run}. *)
+(** Run the perpetual loop via OAS Agent.run. *)
 let run
     ~(sw : Eio.Switch.t)
     ~(config : Perpetual_loop.loop_config)
     ~(state : Perpetual_loop.loop_state)
   : unit =
-  if use_oas_perpetual () then
-    run_perpetual_via_oas ~sw ~config ~state
-    |> Result.iter_error (fun e ->
-      eprintf "[perpetual_oas] OAS path aborted: %s\n%!" e)
-  else
-    Perpetual_loop.run ~config ~state
+  run_perpetual_via_oas ~sw ~config ~state
+  |> Result.iter_error (fun e ->
+    eprintf "[perpetual_oas] OAS path aborted: %s\n%!" e)

--- a/lib/succession_oas.ml
+++ b/lib/succession_oas.ml
@@ -19,15 +19,6 @@
 open Printf
 
 (* ================================================================ *)
-(* Feature Flag                                                      *)
-(* ================================================================ *)
-
-let use_oas_checkpoint () =
-  match Sys.getenv_opt "MASC_USE_OAS_CHECKPOINT" with
-  | Some v -> String.lowercase_ascii (String.trim v) = "true"
-  | None -> false
-
-(* ================================================================ *)
 (* DNA Scope — Custom scope for succession metadata in Context.t     *)
 (* ================================================================ *)
 
@@ -199,9 +190,6 @@ let dna_of_checkpoint (ckpt : Agent_sdk.Checkpoint.t)
     Wraps [Succession.extract_dna] and converts the result to an OAS
     [Checkpoint.t]. The caller can then use [Checkpoint.to_string] for
     persistence instead of [Succession.dna_to_json].
-
-    When [MASC_USE_OAS_CHECKPOINT] is not set, falls back to returning
-    the checkpoint alongside the original DNA for comparison.
 
     @return [(dna, checkpoint)] — the original DNA and its OAS checkpoint form. *)
 let extract_dna_via_checkpoint

--- a/lib/verifier_oas.ml
+++ b/lib/verifier_oas.ml
@@ -7,22 +7,9 @@
     - [make_pre_tool_hook]: wraps MASC verify_action as an OAS PreToolUse hook
     - [guardrails_of_read_only_detection]: wraps MASC should_skip as OAS Custom filter
 
-    Enabled via [MASC_USE_OAS_GUARDRAILS=true] environment variable.
-
     @since Phase 4 — OAS Guardrails adapter for verifier *)
 
 open Printf
-
-(* ================================================================ *)
-(* Feature Flag                                                      *)
-(* ================================================================ *)
-
-let use_oas_guardrails () =
-  match Sys.getenv_opt "MASC_USE_OAS_GUARDRAILS" with
-  | Some v ->
-    let v = String.lowercase_ascii (String.trim v) in
-    v = "true" || v = "1" || v = "yes"
-  | None -> false
 
 (* ================================================================ *)
 (* Verdict -> Hook Decision                                          *)

--- a/lib/worker_oas.ml
+++ b/lib/worker_oas.ml
@@ -1,17 +1,8 @@
 (** Worker_oas — Adapter bridging MASC worker_container_meta to OAS Agent.t.
 
-    NOTE: Not yet wired into production code paths. These adapters will
-    replace existing implementations when feature flags are enabled.
-    Currently available for direct testing only.
-
     Converts MASC worker metadata into OAS Agent configuration, using the
     OAS Builder pattern for agent construction. Wraps Agent.run with MASC
     worker lifecycle hooks (heartbeat, join/leave, board posting).
-
-    This module demonstrates the migration path from MASC's bespoke worker
-    runner (local_agent_eio_runners.ml) to the OAS Agent SDK. It does not
-    replace the existing runner; instead it provides an alternative entry
-    point gated by [MASC_USE_OAS_WORKERS=true].
 
     Key mappings:
     - worker_container_meta fields -> OAS agent_config + Builder options
@@ -25,17 +16,6 @@
 open Printf
 
 module Oas = Agent_sdk
-
-(* ================================================================ *)
-(* Feature Flag                                                      *)
-(* ================================================================ *)
-
-let use_oas_workers () =
-  match Sys.getenv_opt "MASC_USE_OAS_WORKERS" with
-  | Some v ->
-    let v = String.lowercase_ascii (String.trim v) in
-    v = "true" || v = "1" || v = "yes"
-  | None -> false
 
 (* ================================================================ *)
 (* worker_container_meta -> OAS Types.model                          *)


### PR DESCRIPTION
## Summary
- Route perpetual agent execution through `Perpetual_oas.run` (OAS Agent lifecycle hooks) instead of legacy `Perpetual_loop.run`
- 1-line change in `mcp_server_eio_execute.ml` — the key wiring that makes OAS the actual runtime engine
- Complements flag removal in #1557

## Change
```diff
- try Perpetual_loop.run ~config:loop_config ~state:loop_state
+ try Perpetual_oas.run ~sw ~config:loop_config ~state:loop_state
```

## Test plan
- [x] `test_perpetual.exe`: 200/200 passed
- [x] `test_oas_adapters.exe`: 9/9 passed
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)