### PR TITLE
feat: wire Perpetual_oas.run as default perpetual loop entry point

### DIFF
--- a/lib/mcp_server_eio_execute.ml
+++ b/lib/mcp_server_eio_execute.ml
@@ -549,7 +549,7 @@ let execute_tool_eio ~sw ~clock ?mcp_session_id ?auth_token state ~name ~argumen
         let ctx : Tool_perpetual.context = { agent_name;
           start_loop = Some (fun loop_state loop_config ->
             Eio.Fiber.fork ~sw (fun () ->
-              try Perpetual_loop.run ~config:loop_config ~state:loop_state
+              try Perpetual_oas.run ~sw ~config:loop_config ~state:loop_state
               with exn ->
                 log_mcp_exn ~label:(Printf.sprintf "perpetual loop crashed for %s"
                   loop_state.Perpetual_loop.trace_id) exn));


### PR DESCRIPTION
## Summary
- Route perpetual agent execution through `Perpetual_oas.run` (OAS Agent lifecycle hooks) instead of legacy `Perpetual_loop.run`
- 1-line change in `mcp_server_eio_execute.ml` — the key wiring that makes OAS the actual runtime engine
- Complements flag removal in #1557

## Change
```diff
- try Perpetual_loop.run ~config:loop_config ~state:loop_state
+ try Perpetual_oas.run ~sw ~config:loop_config ~state:loop_state
```

## Test plan
- [x] `test_perpetual.exe`: 200/200 passed
- [x] `test_oas_adapters.exe`: 9/9 passed
- [x] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)