### PR TITLE
feat(mcp): add masc_agent_relations tool

### DIFF
--- a/lib/tool_agent.ml
+++ b/lib/tool_agent.ml
@@ -272,6 +272,16 @@ let handle_agent_card _ctx args =
   in
   (true, Yojson.Safe.pretty_to_string response)
 
+(** Handle masc_agent_relations — proxy to Neo4j/GraphQL.
+    MASC is a consumer: it queries the GraphQL API, which owns the data. *)
+let handle_agent_relations ctx args =
+  let target = match get_string_opt args "agent_name" with
+    | Some name when name <> "" -> name
+    | _ -> ctx.agent_name
+  in
+  let json = Dashboard_agent_relations.json ~agent_name:target () in
+  (true, Yojson.Safe.pretty_to_string json)
+
 (** Dispatch handler. Returns Some (success, result) if handled, None otherwise *)
 let dispatch ctx ~name ~args =
   match name with
@@ -285,6 +295,7 @@ let dispatch ctx ~name ~args =
   | "masc_collaboration_graph" -> Some (handle_collaboration_graph ctx args)
   | "masc_consolidate_learning" -> Some (handle_consolidate_learning ctx args)
   | "masc_agent_card" -> Some (handle_agent_card ctx args)
+  | "masc_agent_relations" -> Some (handle_agent_relations ctx args)
   | _ -> None
 
 let schemas = Tool_schemas_agent.schemas

--- a/lib/tool_schemas_agent.ml
+++ b/lib/tool_schemas_agent.ml
@@ -373,4 +373,23 @@ Pair with masc_agent_fitness for computed scores, masc_audit_stats for security-
     ];
   };
 
+  (* masc_agent_relations — proxy to Neo4j/GraphQL for relationship data *)
+  {
+    name = "masc_agent_relations";
+    description = "Query an agent's collaboration network and trust relationships from Neo4j via GraphQL. \
+MASC proxies this data — Neo4j is the source of truth, not MASC. \
+Returns collaborators (with count and last-seen), interests, and typed relations. \
+If agent_name is omitted, defaults to the calling agent. \
+Pair with masc_agents for room-level status or masc_collaboration_graph for Hebbian weights.";
+    input_schema = `Assoc [
+      ("type", `String "object");
+      ("properties", `Assoc [
+        ("agent_name", `Assoc [
+          ("type", `String "string");
+          ("description", `String "Agent name to query. Defaults to calling agent if omitted.");
+        ]);
+      ]);
+    ];
+  };
+
 ]

--- a/test/test_tool_agent_coverage.ml
+++ b/test/test_tool_agent_coverage.ml
@@ -1,10 +1,10 @@
 (** Coverage tests for Tool_agent — Agent management and selection
 
     Tests dispatch routing, handler execution, helper functions, and
-    selection strategies for 10 tools: masc_agents, masc_register_capabilities,
+    selection strategies for 11 tools: masc_agents, masc_register_capabilities,
     masc_agent_update, masc_find_by_capability, masc_get_metrics,
     masc_agent_fitness, masc_select_agent, masc_collaboration_graph,
-    masc_consolidate_learning, masc_agent_card
+    masc_consolidate_learning, masc_agent_card, masc_agent_relations
 *)
 module Tool_args = Masc_mcp.Tool_args
 
@@ -254,6 +254,26 @@ let test_agent_card_refresh () =
   cleanup_dir base_dir
 
 (* ============================================================
+   Dispatch test — masc_agent_relations
+   ============================================================ *)
+
+let test_dispatch_agent_relations () =
+  let ctx, base_dir = make_ctx () in
+  let result = Tool_agent.dispatch ctx ~name:"masc_agent_relations" ~args:(`Assoc []) in
+  Alcotest.(check bool) "agent_relations dispatches" true (result <> None);
+  cleanup_dir base_dir
+
+(* ============================================================
+   Schema coverage — masc_agent_relations is registered
+   ============================================================ *)
+
+let test_schema_agent_relations_present () =
+  let schemas = Tool_agent.schemas in
+  let has_it = List.exists (fun (s : Masc_mcp.Types.tool_schema) ->
+    s.name = "masc_agent_relations") schemas in
+  Alcotest.(check bool) "schema registered" true has_it
+
+(* ============================================================
    Helper function tests
    ============================================================ *)
 
@@ -346,6 +366,10 @@ let () =
     ("agent_card", [
       Alcotest.test_case "get action" `Quick test_agent_card_get;
       Alcotest.test_case "refresh action" `Quick test_agent_card_refresh;
+    ]);
+    ("agent_relations", [
+      Alcotest.test_case "dispatches" `Quick test_dispatch_agent_relations;
+      Alcotest.test_case "schema present" `Quick test_schema_agent_relations_present;
     ]);
     ("helpers", [
       Alcotest.test_case "get_string present" `Quick test_get_string_present;


### PR DESCRIPTION
## Summary
- OAS 에이전트가 자신의 협업 네트워크를 조회할 수 있는 `masc_agent_relations` MCP tool 추가
- MASC는 소비자/프록시 — Neo4j/GraphQL이 source of truth
- `Dashboard_agent_relations.json` 재사용 (코드 중복 없음)
- `agent_name` 생략 시 호출 에이전트 자신의 관계 반환

## Changes
| File | Change |
|------|--------|
| `lib/tool_schemas_agent.ml` | Schema 추가 (description에 MASC=proxy 명시) |
| `lib/tool_agent.ml` | `handle_agent_relations` 핸들러 + dispatch |
| `test/test_tool_agent_coverage.ml` | dispatch routing + schema presence 테스트 |

## Architecture
```
OAS Agent → masc_agent_relations (MCP tool)
  → Tool_agent.handle_agent_relations
    → Dashboard_agent_relations.json (proxy)
      → Graphql_client.query (Railway GraphQL)
        → Neo4j (source of truth)
```

## Test plan
- [x] `dune build --root .` 성공
- [x] 32 tests pass (agent_relations 2개 포함)
- [ ] CI green 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)