### PR TITLE
fix: remove Provider.Ollama reference (OAS #151 follow-up)

### DIFF
--- a/lib/agent_swarm_runner.ml
+++ b/lib/agent_swarm_runner.ml
@@ -89,7 +89,6 @@ let run_solo ~sw ~net ~clock ~proc_mgr config =
   let base_url = match provider_cfg.provider with
     | Provider.Local { base_url } -> base_url
     | Provider.Anthropic -> Api.default_base_url
-    | Provider.Ollama { base_url; _ } -> base_url
     | Provider.OpenAICompat { base_url; _ } -> base_url
     | Provider.Custom_registered { name } ->
       (match Provider.find_provider name with


### PR DESCRIPTION
## Summary
OAS #151에서 Ollama provider variant 제거 후 MASC에 남은 1개 참조 수정.

- `agent_swarm_runner.ml`: `Provider.Ollama { base_url; _ }` match arm 제거 (1줄)

## Test plan
- [x] `dune build --root .` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)