### PR TITLE
fix(llm): initialize discovery cache at bootstrap startup

### DIFF
--- a/lib/server_runtime_bootstrap.ml
+++ b/lib/server_runtime_bootstrap.ml
@@ -300,6 +300,7 @@ let run ~sw ~env ~host ~port ~base_path ~make_routes ~make_request_handler
 
   (* Initialize Eio environment for LLM HTTP calls (cohttp-eio via Llm_provider) *)
   Llm_eio_env.init ~sw ~net ~clock ();
+  Llm_discovery_cache.set_env ~sw ~net;
 
   (* 1. HTTP socket first — Railway healthcheck can reach /health immediately *)
   let config = make_http_config ~host ~port in


### PR DESCRIPTION
## Summary
- `Llm_discovery_cache.set_env` was only called in `http_server_eio.run` (legacy path)
- Bootstrap path (`server_runtime_bootstrap.run`) never initialized the discovery cache
- Result: `local endpoints=0` → llama-server skipped → cascade falls through to cloud → "Empty completion"

## Root Cause
```
http_server_eio.run → Llm_discovery_cache.set_env ✅ (legacy, unused)
server_runtime_bootstrap.run → ❌ (current path, missing)
```

## Fix
1-line: call `Llm_discovery_cache.set_env ~sw ~net` right after `Llm_eio_env.init`

## Test plan
- [x] `dune build --root .` 성공
- [ ] 서버 재시작 후 `cascade capacity: local endpoints=1 healthy=true` 확인
- [ ] gardener tick에서 llama-server 응답 수신 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)