### PR TITLE
refactor(cascade): route Lodge_cascade through OAS provider path

### DIFF
--- a/lib/chain_error.ml
+++ b/lib/chain_error.ml
@@ -17,7 +17,6 @@ type llm_error =
   | GeminiError of gemini_error
   | ClaudeError of claude_error
   | CodexError of codex_error
-  | OllamaError of ollama_error
 [@@deriving yojson]
 
 and gemini_error =
@@ -42,13 +41,6 @@ and codex_error =
   | CodexSandboxViolation
   | CodexTimeout
   | CodexUnknown of string
-[@@deriving yojson]
-
-and ollama_error =
-  | OllamaNotRunning
-  | OllamaModelNotFound of string
-  | OllamaTimeout
-  | OllamaUnknown of string
 [@@deriving yojson]
 
 (** Chain execution errors *)
@@ -108,7 +100,6 @@ let is_recoverable = function
   | Llm (GeminiError GeminiRateLimit) -> true
   | Llm (ClaudeError ClaudeRateLimit) -> true
   | Llm (CodexError CodexRateLimit) -> true
-  | Llm (OllamaError OllamaTimeout) -> true
   | Process (ProcessTimeout _) -> true
   | Io (NetworkError _) -> true
   | _ -> false
@@ -136,12 +127,6 @@ let to_string = function
       | CodexSandboxViolation -> "Codex sandbox policy violated"
       | CodexTimeout -> "Codex request timed out"
       | CodexUnknown msg -> Printf.sprintf "Codex error: %s" msg)
-  | Llm (OllamaError e) -> (
-      match e with
-      | OllamaNotRunning -> "Ollama server not running"
-      | OllamaModelNotFound model -> Printf.sprintf "Ollama model not found: %s" model
-      | OllamaTimeout -> "Ollama request timed out"
-      | OllamaUnknown msg -> Printf.sprintf "Ollama error: %s" msg)
   | Chain e -> (
       match e with
       | ChainParseError msg -> Printf.sprintf "Chain parse error: %s" msg

--- a/lib/llm_client.mli
+++ b/lib/llm_client.mli
@@ -10,10 +10,12 @@
 
     @since 2.61.0 *)
 
-(** {1 Provider Types} *)
+(** {1 Provider Types}
 
-(** Supported LLM providers. *)
-type provider =
+    All types are re-exported from {!Llm_types} to ensure nominal
+    equality across [Llm_client], [Llm_types], and [Llm_provider_oas]. *)
+
+type provider = Llm_types.provider =
   | Llama
   | Claude
   | OpenAI
@@ -22,50 +24,40 @@ type provider =
   | OpenRouter
   | Custom of string
 
-(** Model specification — everything needed to call a specific model. *)
-type model_spec = {
+type model_spec = Llm_types.model_spec = {
   provider : provider;
-  model_id : string;           (** e.g. "glm-4.7-flash", "claude-opus-4-6" *)
-  max_context : int;           (** Max context window in tokens *)
-  api_url : string;            (** Base API URL *)
-  api_key_env : string option; (** Env var name for API key *)
-  cost_per_1k_input : float;   (** USD per 1K input tokens *)
-  cost_per_1k_output : float;  (** USD per 1K output tokens *)
+  model_id : string;
+  max_context : int;
+  api_url : string;
+  api_key_env : string option;
+  cost_per_1k_input : float;
+  cost_per_1k_output : float;
 }
 
 (** {1 Message Types} *)
 
-(** Role in a conversation. *)
-type role = Agent_sdk.Types.role = System | User | Assistant | Tool
+type role = Llm_types.role = System | User | Assistant | Tool
+type message = Llm_types.message
 
-(** A single message in a conversation.
-    [content] uses {!Agent_sdk.Types.content_block} list for OAS type convergence. *)
-type message = Agent_sdk.Types.message
-
-(** Tool/function definition for function calling. *)
-type tool_def = {
+type tool_def = Llm_types.tool_def = {
   tool_name : string;
   tool_description : string;
-  parameters : Yojson.Safe.t;  (** JSON Schema for parameters *)
+  parameters : Yojson.Safe.t;
 }
 
-(** A tool call requested by the model. *)
-type tool_call = {
+type tool_call = Llm_types.tool_call = {
   call_id : string;
   call_name : string;
-  call_arguments : string;     (** JSON string of arguments *)
+  call_arguments : string;
 }
 
-(** Token usage — unified with OAS api_usage. *)
-type token_usage = Agent_sdk.Types.api_usage
+type token_usage = Llm_types.token_usage
 
-(** Compute total tokens (input + output). *)
 val total_tokens : token_usage -> int
 
 (** {1 Request/Response} *)
 
-(** Completion request. *)
-type completion_request = {
+type completion_request = Llm_types.completion_request = {
   model : model_spec;
   messages : message list;
   temperature : float;
@@ -74,10 +66,7 @@ type completion_request = {
   response_format : [ `Text | `Json ];
 }
 
-(** Completion response.
-    [content] is a list of {!Agent_sdk.Types.content_block} for type convergence
-    with OAS api_response. Use {!text_of_response} to extract text. *)
-type completion_response = {
+type completion_response = Llm_types.completion_response = {
   content : Agent_sdk.Types.content_block list;
   tool_calls : tool_call list;
   usage : token_usage;

--- a/lib/lodge_cascade.ml
+++ b/lib/lodge_cascade.ml
@@ -5,7 +5,14 @@
     Invalid entries are ignored with a warning.
 
     The file is hot-reloaded via a simple mtime cache.
-    When the file or requested key is missing, built-in defaults are used. *)
+    When the file or requested key is missing, built-in defaults are used.
+
+    All LLM calls route through {!Llm_provider_oas} (OAS provider path).
+    This bypasses the legacy [Llm_orchestration] global semaphore,
+    eliminating the permit-contention bottleneck between sentinel,
+    heartbeat, and lodge subsystems.
+
+    @since 2.114.0 — OAS-native cascade *)
 
 open Printf
 
@@ -119,9 +126,7 @@ let default_model_strings ~cascade_name =
       labels_of [ ("glm", glm_model); ("glm", glm_flash) ]
       @ [ "glm:auto" ]
   (* topic extraction — fast local model, glm fallback *)
-  | "topic_extraction" ->
-      labels_of [ ("ollama", glm_flash) ]
-      @ [ "glm:auto" ]
+  | "topic_extraction" -> llama_glm
   (* unregistered cascade: llama + glm as safety net *)
   | _ -> llama_glm
 
@@ -187,6 +192,9 @@ let get_cascade ?(config_path = "") ~cascade_name () :
         cascade_name;
       Llm_client.available_model_specs_of_strings defaults)
 
+(** Call LLM cascade via OAS provider path (no global semaphore).
+    Bypasses [Llm_orchestration.cascade] and its global [Eio.Semaphore]
+    (max=2), routing directly through [Llm_provider_oas] instead. *)
 let call ~cascade_name ~prompt
     ?(config_path = "") ?(temperature = 0.3) ?(timeout_sec = 30)
     ?(max_tokens = 500) ?(accept = fun _ -> true) ?system () =
@@ -195,7 +203,7 @@ let call ~cascade_name ~prompt
     Error (Printf.sprintf "[cascade] no callable models for %s" cascade_name)
   else
     match
-      Llm_client.run_prompt_cascade ~temperature
+      Llm_provider_oas.run_prompt_cascade ~temperature
         ~timeout_sec ~model_specs:specs ~max_tokens ~accept ?system ~prompt ()
     with
     | Ok resp ->


### PR DESCRIPTION
## Summary

모든 LLM 호출을 레거시 `Llm_orchestration` 경로에서 `Llm_provider_oas` (OAS 직통)로 전환.

- **22개 call site** 마이그레이션 (complete 8, cascade 8, run_prompt_cascade 6)
- `Llm_client.mli` 7개 타입을 `Llm_types` nominal alias로 통합
- Dead `OllamaError` 타입 + ollama cascade 참조 제거
- `Llm_orchestration.{complete,cascade}` → dead code (Phase 3 삭제 대상)

## Before/After

```
Before: sentinel/heartbeat/lodge/keeper/perpetual
          → Llm_Client.{complete,cascade,run_prompt_cascade}
            → Llm_Orchestration (global Eio.Semaphore max=2)
              → Llm_provider_bridge.call

After:  sentinel/heartbeat/lodge/keeper/perpetual
          → Llm_provider_oas.{complete,cascade,run_prompt_cascade}
            → complete_via_oas (no semaphore, OAS native)
```

## Commits (3)

1. **Lodge_cascade → OAS** + type unification + OllamaError removal
2. **run_prompt_cascade** (5 remaining sites) → OAS
3. **complete + cascade** (16 sites) → OAS

## Files changed (21)

| Category | Files |
|----------|-------|
| Core routing | `lodge_cascade.ml` |
| Type unification | `llm_client.mli` |
| Dead code removal | `chain_error.ml` |
| Judges | `dashboard_governance_judge.ml`, `dashboard_operator_judge.ml` |
| Keeper | `keeper_turn.ml`, `keeper_exec_*.ml` (4), `keeper_autonomy.ml` |
| Perpetual | `perpetual_loop.ml` |
| Infra | `verifier.ml`, `chain_native_eio.ml`, `local_agent_eio_runners.ml` |
| Features | `trpg_harness.ml`, `autoresearch.ml`, `code_swarm_plan.ml`, `gardener_decisions.ml` |
| Config | `env_config_keeper.ml`, `tool_team_session_routing.ml` |

## Test plan

- [x] `dune build` passes (all 3 commits)
- [x] operator tests (29/29 pass)
- [ ] Full CI green
- [ ] Live MASC: sentinel governance sweep completes
- [ ] Live MASC: heartbeat LLM calls succeed without semaphore contention

Closes #1560
Progresses #1549 (Phase 1 complete, Phase 2 type unification done)

🤖 Generated with [Claude Code](https://claude.com/claude-code)