### PR TITLE
fix(dashboard): improve keeper conversation UX

### DIFF
--- a/dashboard/src/components/keeper-detail.ts
+++ b/dashboard/src/components/keeper-detail.ts
@@ -83,25 +83,30 @@ async function pokeLodgeNow(): Promise<void> {
 
 function KeeperCommsPanel({ keeper }: { keeper: Keeper }) {
   return html`
-    <div style="margin-top: 24px; border-top: 1px solid rgba(255,255,255,0.1); padding-top: 24px;">
-      <h3 style="margin: 0 0 16px; color: var(--accent-cyan); font-family: var(--font-display);">Direct Comms & Runtime Diagnostics</h3>
+    <div class="keeper-comms-section">
+      <h3 class="keeper-comms-heading">Direct Comms</h3>
 
-      <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 20px;">
-        <div style="display: flex; flex-direction: column; gap: 12px;">
-          <${KeeperDiagnosticSummary} keeper=${keeper} />
-          <${KeeperRuntimeActions}
-            actor=${currentOperatorActor()}
-            keeper=${keeper}
-            onPokeLodge=${() => { void pokeLodgeNow() }}
-          />
-        </div>
-
-        <div style="min-height: 345px;">
+      <div class="keeper-comms-layout">
+        ${'' /* Chat takes full width — the primary interaction surface */}
+        <div class="keeper-comms-chat">
           <${KeeperConversationPanel}
             keeperName=${keeper.name}
             placeholder="이 키퍼에게 직접 프롬프트"
           />
         </div>
+
+        ${'' /* Diagnostics and actions in a collapsible panel below */}
+        <details class="keeper-comms-diagnostics">
+          <summary class="keeper-comms-diagnostics-toggle">런타임 진단 및 액션</summary>
+          <div class="keeper-comms-diagnostics-body">
+            <${KeeperDiagnosticSummary} keeper=${keeper} />
+            <${KeeperRuntimeActions}
+              actor=${currentOperatorActor()}
+              keeper=${keeper}
+              onPokeLodge=${() => { void pokeLodgeNow() }}
+            />
+          </div>
+        </details>
       </div>
     </div>
   `
@@ -122,7 +127,7 @@ export function KeeperDetailOverlay() {
         }
       }}
     >
-      <div style="max-width:780px; width:100%; max-height:90vh; overflow-y:auto; background:#1a1a2e; border-radius:16px; border:1px solid rgba(255,255,255,0.08); padding:24px;">
+      <div style="max-width:1100px; width:100%; max-height:90vh; overflow-y:auto; background:#1a1a2e; border-radius:16px; border:1px solid rgba(255,255,255,0.08); padding:24px;">
         ${'' /* Header */}
         <div style="display:flex; align-items:center; justify-content:space-between; margin-bottom:20px;">
           <div style="display:flex; align-items:center; gap:12px;">
@@ -145,6 +150,9 @@ export function KeeperDetailOverlay() {
 
         ${'' /* Context chart */}
         <${ContextChart} keeper=${keeper} />
+
+        ${'' /* Direct conversation — placed prominently before detail cards */}
+        <${KeeperCommsPanel} keeper=${keeper} />
 
         ${'' /* Two-column grid for sections */}
         <div style="display:grid; grid-template-columns:1fr 1fr; gap:16px; margin-top:16px;">
@@ -244,7 +252,6 @@ export function KeeperDetailOverlay() {
             </div>
           <//>
         </div>
-        <${KeeperCommsPanel} keeper=${keeper} />
       </div>
     </div>
   `

--- a/dashboard/src/components/keeper-shared.ts
+++ b/dashboard/src/components/keeper-shared.ts
@@ -156,7 +156,11 @@ export function KeeperConversationPanel({
     }
   }, [keeperName])
 
-  const thread = keeperThreads.value[keeperName] ?? []
+  const rawThread = keeperThreads.value[keeperName] ?? []
+  // Filter out system/tool messages — only show user and assistant conversation
+  const thread = rawThread.filter(
+    entry => entry.role === 'user' || entry.role === 'assistant',
+  )
   const sending = keeperSending.value[keeperName] ?? false
   const error = keeperActionErrors.value[keeperName]
 

--- a/dashboard/src/sse-store.ts
+++ b/dashboard/src/sse-store.ts
@@ -11,6 +11,7 @@ import {
   refreshBoard,
   refreshMdal,
 } from './store'
+import { activeKeeperName, hydrateKeeperStatus } from './keeper-runtime'
 
 // --- Governance/CommandPlane/Operator refresh registration (avoids circular import) ---
 
@@ -91,6 +92,18 @@ export function setupSSEReaction(): () => void {
     ) {
       scheduleRefresh('execution', refreshExecution)
       scheduleRefresh('operator', () => _refreshOperatorFn?.(), 600)
+
+      // Re-hydrate conversation thread for the active keeper so chat
+      // updates without a manual page refresh.
+      if (event.type === 'keeper_turn_complete') {
+        const keeperName = event.name ?? ''
+        const viewing = activeKeeperName.value
+        if (keeperName && keeperName === viewing) {
+          scheduleRefresh(`keeper_thread_${keeperName}`, () => {
+            void hydrateKeeperStatus(keeperName, true)
+          }, 800)
+        }
+      }
     }
 
     // Client input approval/rejection → operator refresh

--- a/dashboard/src/styles/chat.css
+++ b/dashboard/src/styles/chat.css
@@ -3,7 +3,7 @@
   flex-direction: column;
   gap: 10px;
   min-height: 200px;
-  max-height: 360px;
+  max-height: 480px;
   overflow: auto;
   padding: 12px;
   border-radius: 14px;
@@ -302,7 +302,7 @@
 }
 
 .chat-composer-input {
-  min-height: 112px;
+  min-height: 72px;
 }
 
 .chat-composer-actions {

--- a/dashboard/src/styles/keeper.css
+++ b/dashboard/src/styles/keeper.css
@@ -158,3 +158,73 @@
   background: rgba(74,222,128,0.12);
   color: var(--ok);
 }
+
+/* ── Keeper Comms Section (chat + diagnostics) ────────── */
+.keeper-comms-section {
+  margin-top: 20px;
+  border-top: 1px solid rgba(255, 255, 255, 0.1);
+  padding-top: 20px;
+}
+
+.keeper-comms-heading {
+  margin: 0 0 14px;
+  color: var(--accent-cyan, #22d3ee);
+  font-family: var(--font-display, inherit);
+  font-size: 15px;
+}
+
+.keeper-comms-layout {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.keeper-comms-chat {
+  width: 100%;
+}
+
+.keeper-comms-diagnostics {
+  border: 1px solid rgba(138, 163, 211, 0.14);
+  border-radius: 10px;
+  background: rgba(5, 14, 31, 0.5);
+}
+
+.keeper-comms-diagnostics-toggle {
+  cursor: pointer;
+  padding: 10px 14px;
+  font-size: 12px;
+  color: #8ca8d5;
+  letter-spacing: 0.03em;
+  list-style: none;
+  user-select: none;
+}
+
+.keeper-comms-diagnostics-toggle::-webkit-details-marker {
+  display: none;
+}
+
+.keeper-comms-diagnostics-toggle::before {
+  content: ">";
+  display: inline-block;
+  margin-right: 8px;
+  transition: transform 0.15s ease;
+  font-size: 11px;
+}
+
+.keeper-comms-diagnostics[open] > .keeper-comms-diagnostics-toggle::before {
+  transform: rotate(90deg);
+}
+
+.keeper-comms-diagnostics-body {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 0 14px 14px;
+}
+
+/* Shell wrapper for conversation panel inside comms section */
+.keeper-conversation-shell {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}


### PR DESCRIPTION
## Summary

- Keeper 대화창이 작고 하단에 숨어있어 사실상 사용 불가 → 전폭 상단 배치로 이동
- 시스템/도구 메시지가 대화에 노출되어 노이즈 → user/assistant만 표시
- 메시지 보내도 리프레시 해야 보임 → `keeper_turn_complete` SSE에서 자동 hydrate
- 진단 패널이 대화 공간을 반으로 줄임 → 접이식(`<details>`)으로 변경

## Changes

| 파일 | 변경 |
|------|------|
| `keeper-detail.ts` | overlay 780→1100px, chat을 KPI 아래 전폭 배치, 하단 제거 |
| `keeper-shared.ts` | system/tool role 필터링 |
| `sse-store.ts` | `keeper_turn_complete` SSE → 활성 keeper thread 자동 re-hydrate |
| `chat.css` | transcript max-height 360→480px, composer 112→72px |
| `keeper.css` | comms section, collapsible diagnostics 스타일 추가 |

## Test plan

- [ ] Keeper detail overlay 열기 → 대화창이 KPI 아래 전폭으로 표시되는지 확인
- [ ] 시스템 메시지가 대화 목록에 나타나지 않는지 확인
- [ ] Keeper에 메시지 전송 후 응답이 자동으로 표시되는지 확인 (리프레시 없이)
- [ ] "런타임 진단 및 액션" 접이식 패널 동작 확인
- [ ] 대화 내역이 480px 높이까지 스크롤 가능한지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)