### PR TITLE
refactor: Llm_client → Agent_sdk.Types direct (batch 2/4)

### DIFF
--- a/lib/dashboard_operator_judge.ml
+++ b/lib/dashboard_operator_judge.ml
@@ -297,7 +297,7 @@ let compute_judgments ~facts_json =
     with
     | Error message -> Error message
     | Ok response -> (
-        try Ok (response.model_used, Yojson.Safe.from_string (Llm_client.text_of_response response))
+        try Ok (response.model_used, Yojson.Safe.from_string (Llm_types.text_of_response response))
         with
         | Yojson.Json_error msg ->
             Error (Printf.sprintf "Operator judge returned invalid JSON: %s" msg)

--- a/lib/gardener_decisions.ml
+++ b/lib/gardener_decisions.ml
@@ -48,7 +48,7 @@ let decide_spawn_with_llm ~config ~health ~gap : spawn_decision =
       Llm_client.run_prompt_cascade ~temperature:0.3
         ~timeout_sec:Env_config.Llm.gardener_spawn_timeout_seconds
         ~model_specs ~max_tokens:200 ~prompt () with
-    | Ok resp -> Llm_client.text_of_response resp
+    | Ok resp -> Llm_types.text_of_response resp
     | Error _ -> ""
   in
 
@@ -438,7 +438,7 @@ Room 내 활성 에이전트: %d
       Llm_client.run_prompt_cascade ~temperature:0.3
         ~timeout_sec:Env_config.Llm.gardener_spawn_timeout_seconds
         ~model_specs ~max_tokens:300 ~prompt () with
-    | Ok resp -> Ok (Llm_client.text_of_response resp)
+    | Ok resp -> Ok (Llm_types.text_of_response resp)
     | Error err -> Error ("llm intervention failed: " ^ err)
   in
 

--- a/lib/keeper_alerting_path.ml
+++ b/lib/keeper_alerting_path.ml
@@ -66,9 +66,9 @@ let is_weather_text (s : string) : bool =
 
 let extract_user_messages (ctx_work : Context_manager.working_context) : string list =
   ctx_work.messages
-  |> List.filter_map (fun (m : Llm_client.message) ->
-       if m.role = Llm_client.User then
-         let c = String.trim (Llm_client.text_of_message m) in
+  |> List.filter_map (fun (m : Agent_sdk.Types.message) ->
+       if m.role = Agent_sdk.Types.User then
+         let c = String.trim (Agent_sdk.Types.text_of_message m) in
          if c = "" then None else Some c
        else
          None)

--- a/lib/keeper_autonomy.ml
+++ b/lib/keeper_autonomy.ml
@@ -239,12 +239,12 @@ let generate_action_plan ~model ~goal ~keeper_context =
   let prompt = build_plan_prompt goal ~keeper_context in
   let req : Llm_client.completion_request = {
     model;
-    messages = [Llm_client.user_msg prompt];
+    messages = [Agent_sdk.Types.user_msg prompt];
     temperature = 0.3;
     max_tokens = 500;
     tools = [];
     response_format = `Text;
   } in
   match Llm_client.complete req with
-  | Ok resp -> Ok (Llm_client.text_of_response resp)
+  | Ok resp -> Ok (Llm_types.text_of_response resp)
   | Error e -> Error (sprintf "plan generation failed: %s" e)

--- a/lib/keeper_exec_autonomy.ml
+++ b/lib/keeper_exec_autonomy.ml
@@ -152,8 +152,8 @@ Do NOT use destructive tools (bash rm, edit, delete).|}
   let initial_request =
     { Llm_client.model = primary;
       messages = [
-        Llm_client.system_msg system_prompt;
-        Llm_client.user_msg "Execute the first step of the plan now.";
+        Agent_sdk.Types.system_msg system_prompt;
+        Agent_sdk.Types.user_msg "Execute the first step of the plan now.";
       ];
       temperature = 0.3;
       max_tokens = 1024;
@@ -171,7 +171,7 @@ Do NOT use destructive tools (bash rm, edit, delete).|}
       let rec exec_loop ~round ~acc_cost ~acc_tools ~last_resp =
         if last_resp.Llm_client.tool_calls = [] || round > max_rounds then
           let content =
-            let c = String.trim (Llm_client.text_of_response last_resp) in
+            let c = String.trim (Llm_types.text_of_response last_resp) in
             if c = "" && acc_tools <> [] then
               Printf.sprintf "(autonomous execution: %s)"
                 (String.concat ", " acc_tools)
@@ -188,7 +188,7 @@ Do NOT use destructive tools (bash rm, edit, delete).|}
           let followup_prompt =
             keeper_tool_followup_prompt
               ~user_message:"Execute the next step of the plan."
-              ~draft_reply:(Llm_client.text_of_response last_resp)
+              ~draft_reply:(Llm_types.text_of_response last_resp)
               ~tool_outputs
               ~already_executed:all_tools
           in
@@ -200,8 +200,8 @@ Do NOT use destructive tools (bash rm, edit, delete).|}
           let followup_requests = List.map (fun (spec : Llm_client.model_spec) ->
             { Llm_client.model = spec;
               messages = [
-                Llm_client.system_msg system_prompt;
-                Llm_client.user_msg followup_prompt;
+                Agent_sdk.Types.system_msg system_prompt;
+                Agent_sdk.Types.user_msg followup_prompt;
               ];
               temperature = 0.3;
               max_tokens = 1024;
@@ -211,7 +211,7 @@ Do NOT use destructive tools (bash rm, edit, delete).|}
           ) specs in
           match run_cascade followup_requests with
           | Error _ ->
-              (Llm_client.text_of_response last_resp, acc_cost, all_tools)
+              (Llm_types.text_of_response last_resp, acc_cost, all_tools)
           | Ok next_resp ->
               let used_spec =
                 model_spec_for_used specs next_resp.model_used

--- a/lib/keeper_exec_context.ml
+++ b/lib/keeper_exec_context.ml
@@ -343,7 +343,7 @@ let proactive_prompt_for_keeper
 
 type proactive_generation_result = {
   reply: string;
-  usage: Llm_client.token_usage;
+  usage: Agent_sdk.Types.api_usage;
   model_used: string;
   latency_ms: int;
   attempts: int;
@@ -556,7 +556,7 @@ let run_proactive_generation
   let base_prompt =
     proactive_prompt_for_keeper ~meta ~idle_seconds continuity_snapshot continuity_summary
   in
-  let zero_usage : Llm_client.token_usage =
+  let zero_usage : Agent_sdk.Types.api_usage =
     { Agent_sdk.Types.input_tokens = 0; output_tokens = 0;
       cache_creation_input_tokens = 0; cache_read_input_tokens = 0 }
   in
@@ -627,8 +627,8 @@ let run_proactive_generation
             ({
                Llm_client.model;
                messages =
-                 (Llm_client.system_msg turn_system_prompt)
-                 :: (ctx_work.messages @ [ Llm_client.user_msg prompt ]);
+                 (Agent_sdk.Types.system_msg turn_system_prompt)
+                 :: (ctx_work.messages @ [ Agent_sdk.Types.user_msg prompt ]);
                temperature = proactive_temperature attempt;
                max_tokens = 1024; (* increased from 220 to allow tool calls *)
                tools = keeper_allowed_llm_tools meta;
@@ -649,11 +649,11 @@ let run_proactive_generation
               ~acc_tools_used ~last_resp =
             if last_resp.Llm_client.tool_calls = [] || round > max_tool_rounds then
               let content =
-                let c = String.trim (Llm_client.text_of_response last_resp) in
+                let c = String.trim (Llm_types.text_of_response last_resp) in
                 if c = "" && acc_tools_used <> [] then
                   Printf.sprintf "(tools executed: %s)"
                     (String.concat ", " acc_tools_used)
-                else Llm_client.text_of_response last_resp
+                else Llm_types.text_of_response last_resp
               in
               ( content,
                 acc_usage,
@@ -674,7 +674,7 @@ let run_proactive_generation
               let followup_prompt =
                 keeper_tool_followup_prompt
                   ~user_message:prompt
-                  ~draft_reply:(Llm_client.text_of_response last_resp)
+                  ~draft_reply:(Llm_types.text_of_response last_resp)
                   ~tool_outputs
                   ~already_executed:all_tools_so_far
               in
@@ -693,10 +693,10 @@ let run_proactive_generation
                      ({
                         Llm_client.model;
                         messages = [
-                          Llm_client.system_msg
+                          Agent_sdk.Types.system_msg
                             (keeper_tool_loop_system_prompt
                                ~character_context:turn_system_prompt);
-                          Llm_client.user_msg followup_prompt;
+                          Agent_sdk.Types.user_msg followup_prompt;
                         ];
                         temperature = 0.3;
                         max_tokens = 1024; (* increased from 220 to allow tool calls *)
@@ -708,7 +708,7 @@ let run_proactive_generation
               in
               match run_cascade followup_requests with
               | Error _ ->
-                  ( Llm_client.text_of_response last_resp,
+                  ( Llm_types.text_of_response last_resp,
                     acc_usage,
                     last_resp.Llm_client.model_used,
                     acc_latency,

--- a/lib/keeper_exec_proactive.ml
+++ b/lib/keeper_exec_proactive.ml
@@ -214,12 +214,12 @@ let maybe_emit_proactive (ctx : _ context) (meta : keeper_meta) : keeper_meta =
                         in
                         (match
                            Keeper_deliberation.parse_deliberation_response
-                             (Llm_client.text_of_response response)
+                             (Llm_types.text_of_response response)
                          with
                          | Error msg ->
                              Log.KeeperExec.error "%s parse failed: %s (raw: %s)"
                                meta.name msg
-                               (Keeper_types.short_preview (Llm_client.text_of_response response));
+                               (Keeper_types.short_preview (Llm_types.text_of_response response));
                              (* Update meta with cost even on parse failure *)
                              let updated =
                                { meta with
@@ -480,7 +480,7 @@ let maybe_emit_proactive (ctx : _ context) (meta : keeper_meta) : keeper_meta =
                                    + response.usage.output_tokens;
                                  total_tokens =
                                    meta.total_tokens
-                                   + Llm_client.total_tokens response.usage;
+                                   + Llm_types.total_tokens response.usage;
                                  total_cost_usd =
                                    meta.total_cost_usd +. turn_cost;
                                  last_turn_ts = now_ts;
@@ -490,7 +490,7 @@ let maybe_emit_proactive (ctx : _ context) (meta : keeper_meta) : keeper_meta =
                                  last_output_tokens =
                                    response.usage.output_tokens;
                                  last_total_tokens =
-                                   Llm_client.total_tokens response.usage;
+                                   Llm_types.total_tokens response.usage;
                                  last_latency_ms = response.latency_ms;
                                  last_proactive_ts = now_ts;
                                  last_proactive_reason =
@@ -601,7 +601,7 @@ let maybe_emit_proactive (ctx : _ context) (meta : keeper_meta) : keeper_meta =
 	                           ~fallback:(proactive_fallback_reply ~meta ~idle_seconds)
 	                           raw_reply
 	                       in
-	                       let assistant_msg = Llm_client.assistant_msg safe_reply in
+	                       let assistant_msg = Agent_sdk.Types.assistant_msg safe_reply in
 	                       let ctx_work = Context_manager.append ctx_work assistant_msg in
                        Context_manager.persist_message session assistant_msg;
                        let before_compact_tokens = ctx_work.token_count in
@@ -631,13 +631,13 @@ let maybe_emit_proactive (ctx : _ context) (meta : keeper_meta) : keeper_meta =
                              meta.total_input_tokens + generated.usage.input_tokens;
                            total_output_tokens =
                              meta.total_output_tokens + generated.usage.output_tokens;
-                           total_tokens = meta.total_tokens + Llm_client.total_tokens generated.usage;
+                           total_tokens = meta.total_tokens + Llm_types.total_tokens generated.usage;
                            total_cost_usd = meta.total_cost_usd +. turn_cost;
                            last_turn_ts = now_ts;
                            last_model_used = model_used;
                            last_input_tokens = generated.usage.input_tokens;
                            last_output_tokens = generated.usage.output_tokens;
-                           last_total_tokens = Llm_client.total_tokens generated.usage;
+                           last_total_tokens = Llm_types.total_tokens generated.usage;
                            last_latency_ms = generated.latency_ms;
                            compaction_count =
                              meta.compaction_count + if compacted then 1 else 0;
@@ -683,7 +683,7 @@ let maybe_emit_proactive (ctx : _ context) (meta : keeper_meta) : keeper_meta =
                                     [
                                       ("input_tokens", `Int generated.usage.input_tokens);
                                       ("output_tokens", `Int generated.usage.output_tokens);
-                                      ("total_tokens", `Int (Llm_client.total_tokens generated.usage));
+                                      ("total_tokens", `Int (Llm_types.total_tokens generated.usage));
                                     ] );
                                 ("latency_ms", `Int generated.latency_ms);
                                 ("cost_usd", `Float turn_cost);

--- a/lib/keeper_exec_social.ml
+++ b/lib/keeper_exec_social.ml
@@ -75,7 +75,7 @@ let generate_explicit_room_reply (ctx : _ context) ~(meta : keeper_meta) ~(room_
                    ~instructions:meta.instructions)
           in
           let prompt = explicit_room_prompt ~meta ~room_id msg in
-          let user_message = Llm_client.user_msg prompt in
+          let user_message = Agent_sdk.Types.user_msg prompt in
           let ctx_work = Context_manager.append ctx_work user_message in
           Context_manager.persist_message session user_message;
           let requests =
@@ -83,7 +83,7 @@ let generate_explicit_room_reply (ctx : _ context) ~(meta : keeper_meta) ~(room_
               (fun (model : Llm_client.model_spec) ->
                 ({
                   Llm_client.model;
-                  messages = (Llm_client.system_msg ctx_work.system_prompt) :: ctx_work.messages;
+                  messages = (Agent_sdk.Types.system_msg ctx_work.system_prompt) :: ctx_work.messages;
                   temperature = Keeper_config.keeper_reflection_temp ();
                   max_tokens = Keeper_config.keeper_explicit_reply_max_tokens ();
                   tools = [];
@@ -97,14 +97,14 @@ let generate_explicit_room_reply (ctx : _ context) ~(meta : keeper_meta) ~(room_
               let used_model =
                 model_spec_for_used specs resp.model_used |> Option.value ~default:primary
               in
-              let reply_raw = String.trim (Llm_client.text_of_response resp) in
+              let reply_raw = String.trim (Llm_types.text_of_response resp) in
               let reply =
                 if reply_raw = "" then
                   Printf.sprintf "@%s 야, 다시 한 번만 말해봐." msg.from_agent
                 else
                   reply_raw
               in
-              let assistant_message = Llm_client.assistant_msg reply in
+              let assistant_message = Agent_sdk.Types.assistant_msg reply in
               let ctx_work = Context_manager.append ctx_work assistant_message in
               Context_manager.persist_message session assistant_message;
               (try ignore (save_checkpoint session ctx_work ~generation:meta.generation)
@@ -119,14 +119,14 @@ let generate_explicit_room_reply (ctx : _ context) ~(meta : keeper_meta) ~(room_
                   total_turns = meta.total_turns + 1;
                   total_input_tokens = meta.total_input_tokens + usage.input_tokens;
                   total_output_tokens = meta.total_output_tokens + usage.output_tokens;
-                  total_tokens = meta.total_tokens + Llm_client.total_tokens usage;
+                  total_tokens = meta.total_tokens + Llm_types.total_tokens usage;
                   total_cost_usd =
                     meta.total_cost_usd +. cost_usd_of_usage usage used_model;
                   last_turn_ts = now_ts;
                   last_model_used = resp.model_used;
                   last_input_tokens = usage.input_tokens;
                   last_output_tokens = usage.output_tokens;
-                  last_total_tokens = Llm_client.total_tokens usage;
+                  last_total_tokens = Llm_types.total_tokens usage;
                   last_latency_ms = resp.latency_ms;
                 }
               in
@@ -221,7 +221,7 @@ let run_social_board_event_turn
                    ~instructions:meta.instructions)
           in
           let prompt = social_board_event_prompt ~meta event in
-          let user_message = Llm_client.user_msg prompt in
+          let user_message = Agent_sdk.Types.user_msg prompt in
           let ctx_work = Context_manager.append ctx_work user_message in
           Context_manager.persist_message session user_message;
           let execute_tool_calls
@@ -248,8 +248,8 @@ let run_social_board_event_turn
                  ({
                     Llm_client.model;
                     messages =
-                      (Llm_client.system_msg ctx_work.system_prompt)
-                      :: (ctx_work.messages @ [ Llm_client.user_msg prompt ]);
+                      (Agent_sdk.Types.system_msg ctx_work.system_prompt)
+                      :: (ctx_work.messages @ [ Agent_sdk.Types.user_msg prompt ]);
                     temperature = Keeper_config.keeper_planning_temp ();
                     max_tokens = Keeper_config.keeper_social_initial_max_tokens ();
                     tools = keeper_allowed_llm_tools meta;
@@ -271,12 +271,12 @@ let run_social_board_event_turn
                   ~acc_tools_used ~last_resp =
                 if last_resp.Llm_client.tool_calls = [] || round > max_tool_rounds then
                   let content =
-                    let trimmed = String.trim (Llm_client.text_of_response last_resp) in
+                    let trimmed = String.trim (Llm_types.text_of_response last_resp) in
                     if trimmed = "" && acc_tools_used <> [] then
                       Printf.sprintf "(tools executed: %s)"
                         (String.concat ", " acc_tools_used)
                     else
-                      Llm_client.text_of_response last_resp
+                      Llm_types.text_of_response last_resp
                   in
                   ( content,
                     acc_usage,
@@ -297,7 +297,7 @@ let run_social_board_event_turn
                   let followup_prompt =
                     keeper_tool_followup_prompt
                       ~user_message:prompt
-                      ~draft_reply:(Llm_client.text_of_response last_resp)
+                      ~draft_reply:(Llm_types.text_of_response last_resp)
                       ~tool_outputs
                       ~already_executed:all_tools_so_far
                   in
@@ -312,10 +312,10 @@ let run_social_board_event_turn
                          ({
                             Llm_client.model;
                             messages = [
-                              Llm_client.system_msg
+                              Agent_sdk.Types.system_msg
                                 (keeper_tool_loop_system_prompt
                                    ~character_context:ctx_work.system_prompt);
-                              Llm_client.user_msg followup_prompt;
+                              Agent_sdk.Types.user_msg followup_prompt;
                             ];
                             temperature = Keeper_config.keeper_deterministic_temp ();
                             max_tokens = Keeper_config.keeper_social_followup_max_tokens ();
@@ -327,7 +327,7 @@ let run_social_board_event_turn
                   in
                   match Llm_client.cascade followup_requests with
                   | Error _ ->
-                      ( Llm_client.text_of_response last_resp,
+                      ( Llm_types.text_of_response last_resp,
                         acc_usage,
                         last_resp.Llm_client.model_used,
                         acc_latency,
@@ -366,7 +366,7 @@ let run_social_board_event_turn
                 else
                   trimmed
               in
-              let assistant_message = Llm_client.assistant_msg assistant_text in
+              let assistant_message = Agent_sdk.Types.assistant_msg assistant_text in
               let ctx_work = Context_manager.append ctx_work assistant_message in
               Context_manager.persist_message session assistant_message;
               (try ignore (save_checkpoint session ctx_work ~generation:meta.generation)
@@ -384,13 +384,13 @@ let run_social_board_event_turn
                   total_turns = meta.total_turns + 1;
                   total_input_tokens = meta.total_input_tokens + final_usage.input_tokens;
                   total_output_tokens = meta.total_output_tokens + final_usage.output_tokens;
-                  total_tokens = meta.total_tokens + Llm_client.total_tokens final_usage;
+                  total_tokens = meta.total_tokens + Llm_types.total_tokens final_usage;
                   total_cost_usd = meta.total_cost_usd +. final_cost_usd;
                   last_turn_ts = now_ts;
                   last_model_used = final_model_used;
                   last_input_tokens = final_usage.input_tokens;
                   last_output_tokens = final_usage.output_tokens;
-                  last_total_tokens = Llm_client.total_tokens final_usage;
+                  last_total_tokens = Llm_types.total_tokens final_usage;
                   last_latency_ms = final_latency_ms;
                   last_autonomous_action_at =
                     (if action_kind = "none" then meta.last_autonomous_action_at else now_iso ());

--- a/lib/keeper_memory_policy.ml
+++ b/lib/keeper_memory_policy.ml
@@ -482,13 +482,13 @@ let keeper_state_snapshot_to_json (snapshot : keeper_state_snapshot) : Yojson.Sa
     ("constraints", `List (List.map (fun s -> `String s) snapshot.constraints));
   ]
 
-let latest_state_snapshot_from_messages (messages : Llm_client.message list) :
+let latest_state_snapshot_from_messages (messages : Agent_sdk.Types.message list) :
     keeper_state_snapshot option =
-  let rec loop (msgs : Llm_client.message list) =
+  let rec loop (msgs : Agent_sdk.Types.message list) =
     match msgs with
     | [] -> None
     | msg :: rest ->
-      match parse_state_snapshot_from_reply (Llm_client.text_of_message msg) with
+      match parse_state_snapshot_from_reply (Agent_sdk.Types.text_of_message msg) with
       | None -> loop rest
       | Some snapshot -> Some snapshot
   in

--- a/lib/keeper_memory_recall.ml
+++ b/lib/keeper_memory_recall.ml
@@ -4,7 +4,7 @@ open Keeper_types
 
 include Keeper_memory_bank
 
-let cost_usd_of_usage (usage : Llm_client.token_usage) (model : Llm_client.model_spec) : float =
+let cost_usd_of_usage (usage : Agent_sdk.Types.api_usage) (model : Llm_client.model_spec) : float =
   let input_cost = float_of_int usage.input_tokens *. model.cost_per_1k_input /. 1000.0 in
   let output_cost = float_of_int usage.output_tokens *. model.cost_per_1k_output /. 1000.0 in
   input_cost +. output_cost
@@ -151,23 +151,23 @@ let jaccard_similarity (a : string) (b : string) : float =
     if union = 0 then 0.0 else float_of_int !inter /. float_of_int union
 
 let latest_message_content_by_role
-    ~(role : Llm_client.role)
-    (messages : Llm_client.message list) : string option =
+    ~(role : Agent_sdk.Types.role)
+    (messages : Agent_sdk.Types.message list) : string option =
   match
     messages
     |> List.rev
-    |> List.find_opt (fun (m : Llm_client.message) -> m.role = role)
+    |> List.find_opt (fun (m : Agent_sdk.Types.message) -> m.role = role)
   with
   | None -> None
-  | Some m -> trim_nonempty (String.trim (Llm_client.text_of_message m))
+  | Some m -> trim_nonempty (String.trim (Agent_sdk.Types.text_of_message m))
 
 let previous_assistant_message_content
-    (messages : Llm_client.message list) : string option =
+    (messages : Agent_sdk.Types.message list) : string option =
   let assistants =
     messages
     |> List.rev
-    |> List.filter_map (fun (m : Llm_client.message) ->
-         if m.role = Llm_client.Assistant then trim_nonempty (Llm_client.text_of_message m) else None)
+    |> List.filter_map (fun (m : Agent_sdk.Types.message) ->
+         if m.role = Agent_sdk.Types.Assistant then trim_nonempty (Agent_sdk.Types.text_of_message m) else None)
   in
   match assistants with
   | _latest :: previous :: _ -> Some previous
@@ -223,17 +223,17 @@ let goal_alignment_score
     | Some u, Some r -> (u +. r) /. 2.0
 
 let repetition_risk_score
-    ~(messages : Llm_client.message list)
+    ~(messages : Agent_sdk.Types.message list)
     ~(candidate_reply : string option) : float =
   match candidate_reply with
   | Some reply -> (
-      match latest_message_content_by_role ~role:Llm_client.Assistant messages with
+      match latest_message_content_by_role ~role:Agent_sdk.Types.Assistant messages with
       | Some prev -> jaccard_similarity reply prev
       | None -> 0.0)
   | None -> (
       match
         previous_assistant_message_content messages,
-        latest_message_content_by_role ~role:Llm_client.Assistant messages
+        latest_message_content_by_role ~role:Agent_sdk.Types.Assistant messages
       with
       | Some prev, Some latest -> jaccard_similarity latest prev
       | _ -> 0.0)
@@ -500,12 +500,12 @@ let learned_policy_auto_rules
       ];
   }
 
-let recent_user_messages (msgs : Llm_client.message list) ~(max_n : int) : string list =
+let recent_user_messages (msgs : Agent_sdk.Types.message list) ~(max_n : int) : string list =
   msgs
   |> List.rev
-  |> List.filter_map (fun (m : Llm_client.message) ->
-       if m.role = Llm_client.User then
-         let c = String.trim (Llm_client.text_of_message m) in
+  |> List.filter_map (fun (m : Agent_sdk.Types.message) ->
+       if m.role = Agent_sdk.Types.User then
+         let c = String.trim (Agent_sdk.Types.text_of_message m) in
          if c = "" then None else Some c
        else None)
   |> take max_n

--- a/lib/lodge_cascade.ml
+++ b/lib/lodge_cascade.ml
@@ -192,9 +192,7 @@ let get_cascade ?(config_path = "") ~cascade_name () :
         cascade_name;
       Llm_client.available_model_specs_of_strings defaults)
 
-(** Call LLM cascade via OAS provider path (no global semaphore).
-    Bypasses [Llm_orchestration.cascade] and its global [Eio.Semaphore]
-    (max=2), routing directly through [Llm_provider_oas] instead. *)
+(** Call LLM cascade via OAS orchestration path. *)
 let call ~cascade_name ~prompt
     ?(config_path = "") ?(temperature = 0.3) ?(timeout_sec = 30)
     ?(max_tokens = 500) ?(accept = fun _ -> true) ?system () =
@@ -203,13 +201,13 @@ let call ~cascade_name ~prompt
     Error (Printf.sprintf "[cascade] no callable models for %s" cascade_name)
   else
     match
-      Llm_provider_oas.run_prompt_cascade ~temperature
+      Llm_orchestration.run_prompt_cascade ~temperature
         ~timeout_sec ~model_specs:specs ~max_tokens ~accept ?system ~prompt ()
     with
     | Ok resp ->
         Ok
           {
-            response = Llm_client.text_of_response resp;
+            response = Llm_types.text_of_response resp;
             llm_used = resp.Llm_client.model_used;
             duration_ms = resp.Llm_client.latency_ms;
           }


### PR DESCRIPTION
## 요약

Llm_client의 메시지 생성자/타입 alias를 Agent_sdk.Types 및 Llm_types 직접 참조로 전환하는 리팩토링의 **2번째 배치** (10개 파일).

### 변경 대상 파일
- `lib/dashboard_operator_judge.ml`
- `lib/gardener_decisions.ml`
- `lib/keeper_alerting_path.ml`
- `lib/keeper_autonomy.ml`
- `lib/keeper_exec_autonomy.ml`
- `lib/keeper_exec_context.ml`
- `lib/keeper_exec_proactive.ml`
- `lib/keeper_exec_social.ml`
- `lib/keeper_memory_policy.ml`
- `lib/keeper_memory_recall.ml`

### 치환 규칙
| Before | After |
|--------|-------|
| `Llm_client.system_msg` | `Agent_sdk.Types.system_msg` |
| `Llm_client.user_msg` | `Agent_sdk.Types.user_msg` |
| `Llm_client.assistant_msg` | `Agent_sdk.Types.assistant_msg` |
| `Llm_client.text_of_message` | `Agent_sdk.Types.text_of_message` |
| `Llm_client.text_of_response` | `Llm_types.text_of_response` |
| `Llm_client.total_tokens` | `Llm_types.total_tokens` |
| `Llm_client.token_usage` | `Agent_sdk.Types.api_usage` |
| `Llm_client.message` / `role` / `User` / `Assistant` | `Agent_sdk.Types.*` |

### 추가 수정
- `lodge_cascade.ml`: #1571에서 삭제된 `Llm_provider_oas` 모듈 참조 수정 (pre-existing build break) → `Llm_orchestration.run_prompt_cascade`로 교체

### 건드리지 않은 것
`Llm_client.complete`, `cascade`, `run_prompt_cascade`, `model_spec`, `completion_request`, `completion_response`, `tool_def`, `tool_call`, `provider`, `sanitize*`, `normalize*`

## 테스트 계획
- [x] `dune build` 통과 확인
- [ ] `make test` 전체 테스트 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)