### PR TITLE
refactor: remove global LLM semaphore + fix broken main build

### DIFF
--- a/lib/llm_orchestration.ml
+++ b/lib/llm_orchestration.ml
@@ -4,42 +4,33 @@ open Printf
 open Llm_types
 
 (* ================================================================ *)
-(* Concurrency limiter — throttle simultaneous LLM requests          *)
+(* Concurrency diagnostics (no throttling)                           *)
 (* ================================================================ *)
 
-(** Maximum concurrent cascade/LLM calls.
-    Default 2 is conservative for local llama.cpp runtimes on 128GB hosts. *)
+(** Maximum concurrent LLM calls — retained for diagnostics/dashboard.
+    No longer enforced via semaphore: llama-server handles slot-based
+    parallelism internally, and cloud APIs return rate-limit errors.
+    The old Eio.Semaphore (max=2) caused permit-contention stalls
+    between sentinel, heartbeat, and lodge subsystems. *)
 let max_concurrent_llm =
-  int_of_env_default "MASC_MAX_CONCURRENT_LLM" ~default:2 ~min_v:1 ~max_v:128
+  int_of_env_default "MASC_MAX_CONCURRENT_LLM" ~default:8 ~min_v:1 ~max_v:128
 
-let llm_semaphore = Eio.Semaphore.make max_concurrent_llm
+(** Atomic counter tracking in-flight LLM calls (observability only). *)
+let inflight = Atomic.make 0
 
-let llm_semaphore_available () = Eio.Semaphore.get_value llm_semaphore
+let llm_semaphore_available () = max_concurrent_llm - Atomic.get inflight
+let llm_permits_in_use () = Atomic.get inflight
 
-(** Outstanding permit counter for diagnostics.
-    Tracks how many LLM calls are currently holding a permit. *)
-let permits_outstanding = Atomic.make 0
-
-let [@warning "-32"] permits_outstanding_count () = Atomic.get permits_outstanding
-
-(** Eio-safe permit acquisition: explicit try/with ensures release on any
-    exception including Eio.Cancel.Cancelled.
-    Also tracks outstanding permits via Atomic counter for diagnostics. *)
-let with_llm_permit f =
-  Eio.Semaphore.acquire llm_semaphore;
-  Atomic.incr permits_outstanding;
+(** Track in-flight calls for diagnostics. No blocking. *)
+let with_inflight_tracking f =
+  Atomic.incr inflight;
   match f () with
   | result ->
-      Atomic.decr permits_outstanding;
-      Eio.Semaphore.release llm_semaphore;
+      Atomic.decr inflight;
       result
   | exception exn ->
-      Atomic.decr permits_outstanding;
-      Eio.Semaphore.release llm_semaphore;
+      Atomic.decr inflight;
       raise exn
-
-let llm_permits_in_use () =
-  max_concurrent_llm - Eio.Semaphore.get_value llm_semaphore
 
 (* ================================================================ *)
 (* Response cache helpers                                            *)
@@ -217,10 +208,8 @@ let filter_by_provider_health (requests : completion_request list)
 let cascade ?(accept = fun _ -> true) ?timeout_sec
     (requests : completion_request list) : (completion_response, string) result =
   let requests = filter_by_provider_health requests in
-  with_llm_permit (fun () ->
-    let avail = Eio.Semaphore.get_value llm_semaphore in
-    Log.LlmClient.debug "cascade: acquired permit (%d/%d available)"
-      avail max_concurrent_llm;
+  with_inflight_tracking (fun () ->
+    Log.LlmClient.debug "cascade: inflight=%d" (Atomic.get inflight);
     let deadline_opt =
       Option.map (fun sec -> Time_compat.now () +. float_of_int sec) timeout_sec
     in

--- a/lib/lodge_cascade.ml
+++ b/lib/lodge_cascade.ml
@@ -7,12 +7,7 @@
     The file is hot-reloaded via a simple mtime cache.
     When the file or requested key is missing, built-in defaults are used.
 
-    All LLM calls route through {!Llm_provider_oas} (OAS provider path).
-    This bypasses the legacy [Llm_orchestration] global semaphore,
-    eliminating the permit-contention bottleneck between sentinel,
-    heartbeat, and lodge subsystems.
-
-    @since 2.114.0 — OAS-native cascade *)
+    @since 2.114.0 *)
 
 open Printf
 
@@ -192,7 +187,8 @@ let get_cascade ?(config_path = "") ~cascade_name () :
         cascade_name;
       Llm_client.available_model_specs_of_strings defaults)
 
-(** Call LLM cascade via OAS orchestration path. *)
+(** Call LLM cascade. Routes through [Llm_orchestration.run_prompt_cascade]
+    which uses OAS-inlined provider calls (no global semaphore after v2.114). *)
 let call ~cascade_name ~prompt
     ?(config_path = "") ?(temperature = 0.3) ?(timeout_sec = 30)
     ?(max_tokens = 500) ?(accept = fun _ -> true) ?system () =
@@ -207,7 +203,7 @@ let call ~cascade_name ~prompt
     | Ok resp ->
         Ok
           {
-            response = Llm_types.text_of_response resp;
+            response = Llm_client.text_of_response resp;
             llm_used = resp.Llm_client.model_used;
             duration_ms = resp.Llm_client.latency_ms;
           }


### PR DESCRIPTION
## Summary

- Global `Eio.Semaphore` (max=2) 제거 — cascade 호출 간 permit-contention 해소
- `lodge_cascade.ml`의 삭제된 `Llm_provider_oas` 참조 수정 (main 빌드 깨짐 수정)
- 기존 semaphore → Atomic inflight counter로 전환 (observability 유지, blocking 제거)

## 왜 semaphore를 제거하는가

| 과거 | 현재 |
|------|------|
| local Ollama가 동시 요청을 못 버팀 | llama-server가 slot 기반 병렬 처리 내장 |
| cloud fallback 없음 | GLM Cloud + Gemini fallback 존재 |
| 2개 subsystem만 LLM 호출 | sentinel + heartbeat + lodge + keeper가 동시 호출 |

max=2 semaphore가 4+ subsystem의 cascade를 직렬화하면서, 먼저 permit을 잡은 호출이 30초+ GLM을 기다리는 동안 sentinel이 cascade deadline을 초과해 governance가 stall.

## Files changed (2)

| File | Change |
|------|--------|
| `lib/llm_orchestration.ml` | `Eio.Semaphore` → `Atomic` counter, `with_llm_permit` → `with_inflight_tracking` |
| `lib/lodge_cascade.ml` | `Llm_provider_oas` (deleted module) → `Llm_client` + stale comment 정리 |

## Test plan

- [x] `dune build` passes (main was broken before this fix)
- [ ] Full CI green
- [ ] Live: sentinel governance completes without stall

🤖 Generated with [Claude Code](https://claude.com/claude-code)