### PR TITLE
feat(keeper): real-time token streaming for keeper chat

### DIFF
--- a/lib/keeper_turn.ml
+++ b/lib/keeper_turn.ml
@@ -26,7 +26,7 @@ let handle_keeper_down = Keeper_turn_lifecycle.handle_keeper_down
 
 (* -- handle_keeper_msg: orchestrator ---------------------------------------- *)
 
-let handle_keeper_msg ctx args : tool_result =
+let handle_keeper_msg ?on_text_delta ctx args : tool_result =
   let name = get_string args "name" "" in
   let message = get_string args "message" "" in
   if not (validate_name name) then
@@ -265,11 +265,42 @@ let handle_keeper_msg ctx args : tool_result =
                 } : Llm_client.completion_request)
               ) specs
             in
-            let run_cascade requests =
+            let run_cascade_batch requests =
               match timeout_sec_opt with
               | Some timeout_sec ->
                   Llm_client.cascade ~timeout_sec requests
               | None -> Llm_client.cascade requests
+            in
+            (* Streaming-aware cascade: when on_text_delta is provided,
+               try streaming the first request. Text deltas are forwarded
+               to the callback in real time. If streaming fails or is
+               unavailable, fall back to the standard batch cascade. *)
+            let run_cascade requests =
+              match on_text_delta, requests with
+              | Some delta_cb, first_req :: _rest ->
+                  let timeout_f =
+                    Option.map float_of_int timeout_sec_opt
+                  in
+                  let stream_on_event (ev : Llm_provider.Types.sse_event) =
+                    match ev with
+                    | ContentBlockDelta { delta = TextDelta text; _ } ->
+                        delta_cb text
+                    | _ -> ()
+                  in
+                  (match
+                     Llm_client.call_provider_stream
+                       ?timeout_sec:timeout_f
+                       first_req
+                       ~on_event:stream_on_event
+                   with
+                   | Ok _ as ok -> ok
+                   | Error e ->
+                       Log.Keeper.warn
+                         "keeper stream: streaming failed (%s), \
+                          falling back to batch"
+                         e;
+                       run_cascade_batch requests)
+              | _ -> run_cascade_batch requests
             in
             let recall_candidates = recent_user_messages base_ctx.messages ~max_n:32 in
             match run_cascade requests with
@@ -405,7 +436,7 @@ let handle_keeper_msg ctx args : tool_result =
                       } : Llm_client.completion_request)
                     ) specs
                   in
-                  match run_cascade followup_requests with
+                  match run_cascade_batch followup_requests with
                   | Error _ ->
                     (* Cascade failed — return what we have *)
                     ( Llm_client.text_of_response last_resp, acc_usage,
@@ -483,7 +514,7 @@ let handle_keeper_msg ctx args : tool_result =
                       } : Llm_client.completion_request)
                     ) specs
                   in
-                  match run_cascade correction_requests with
+                  match run_cascade_batch correction_requests with
                   | Error _ ->
                     ( base_content, base_usage, base_model_used, base_latency_ms,
                       eval0, true, false, false, base_cost_usd, tools_used )
@@ -547,7 +578,7 @@ let handle_keeper_msg ctx args : tool_result =
                       } : Llm_client.completion_request)
                     ) specs
                   in
-                  match run_cascade forced_requests with
+                  match run_cascade_batch forced_requests with
                   | Error _ ->
                       ( content_after_correction, usage_after_correction,
                         model_after_correction, latency_after_correction,

--- a/lib/keeper_turn.mli
+++ b/lib/keeper_turn.mli
@@ -12,8 +12,17 @@ type tool_result = Keeper_types.tool_result
 (** Start or reconfigure a keeper agent. *)
 val handle_keeper_up : _ Keeper_types.context -> Yojson.Safe.t -> tool_result
 
-(** Send a message to a running keeper agent. *)
-val handle_keeper_msg : _ Keeper_types.context -> Yojson.Safe.t -> tool_result
+(** Send a message to a running keeper agent.
+
+    When [on_text_delta] is provided, the initial LLM call uses streaming
+    and forwards text deltas through the callback in real time. Follow-up
+    calls (tool loops, corrections, prompt fallback) run in batch mode.
+    If streaming fails, the function falls back to batch automatically.
+
+    @since 2.110.0 *)
+val handle_keeper_msg :
+  ?on_text_delta:(string -> unit) ->
+  _ Keeper_types.context -> Yojson.Safe.t -> tool_result
 
 (** Set the active model for a keeper agent. *)
 val handle_keeper_model_set : _ Keeper_types.context -> Yojson.Safe.t -> tool_result

--- a/lib/llm_client.mli
+++ b/lib/llm_client.mli
@@ -101,6 +101,18 @@ val cascade :
   completion_request list ->
   (completion_response, string) result
 
+(** Streaming completion for a single request.
+    Invokes [on_event] for each SSE event from the LLM provider.
+    Returns the assembled final response.
+    Falls back to batch completion if streaming is unavailable.
+
+    @since 2.110.0 *)
+val call_provider_stream :
+  ?timeout_sec:float ->
+  completion_request ->
+  on_event:(Llm_provider.Types.sse_event -> unit) ->
+  (completion_response, string) result
+
 (** {1 Concurrency Control} *)
 
 (** Maximum concurrent cascade calls (from MASC_MAX_CONCURRENT_LLM env,

--- a/lib/llm_orchestration.ml
+++ b/lib/llm_orchestration.ml
@@ -775,3 +775,81 @@ let run_prompt_cascade ?(temperature = 0.7) ?timeout_sec
       model_specs
   in
   cascade ?timeout_sec ~accept requests
+
+(* ================================================================ *)
+(* Streaming completion                                             *)
+(* ================================================================ *)
+
+(** Execute a streaming LLM completion using OAS provider path.
+    Each SSE event (token deltas) is delivered to [on_event] as it arrives.
+    Returns the final assembled response after the stream ends.
+
+    Streaming bypasses cache: SSE events are incremental and not cacheable.
+    No retry logic — a single attempt is made.
+    Falls back to batch completion (synthesising a single delta event)
+    when provider config is unavailable or streaming fails. *)
+let call_provider_stream ?timeout_sec (req : completion_request)
+    ~(on_event : Llm_provider.Types.sse_event -> unit)
+    : (completion_response, string) result =
+  let req = normalize_request req in
+  (* Try real streaming first *)
+  let stream_result =
+    match provider_config_of_request req with
+    | Error _ -> None  (* fall through to batch *)
+    | Ok (config, messages, tools) ->
+        let env = Llm_eio_env.get () in
+        Log.LlmClient.debug
+          "provider stream req: model=%s provider=%s max_tokens=%d tools=%d"
+          req.model.model_id
+          (string_of_provider req.model.provider)
+          req.max_tokens (List.length req.tools);
+        let result =
+          try
+            Llm_provider.Complete.complete_stream
+              ~sw:env.sw ~net:env.net ~config
+              ~messages
+              ?tools:(if tools = [] then None else Some tools)
+              ~on_event ()
+          with exn ->
+            Error (Llm_provider.Http_client.NetworkError
+                     { message = Printexc.to_string exn })
+        in
+        (match result with
+         | Ok resp ->
+             let masc_resp = completion_response_of_api_response resp in
+             let text = text_of_response masc_resp in
+             if String.trim text = "" && masc_resp.tool_calls = [] then
+               None  (* empty response, try batch *)
+             else
+               Some (Ok masc_resp)
+         | Error http_err ->
+             Log.LlmClient.warn "stream: provider error: %s"
+               (string_of_http_error http_err);
+             None  (* fall through to batch *))
+  in
+  match stream_result with
+  | Some result -> result
+  | None ->
+      (* Fallback: batch call, then synthesise SSE events *)
+      Log.LlmClient.info
+        "stream: falling back to batch for %s" req.model.model_id;
+      let timeout_sec_int =
+        Option.map (fun f -> max 1 (int_of_float (Float.ceil f))) timeout_sec
+      in
+      let batch_result = complete ?timeout_sec:timeout_sec_int req in
+      (match batch_result with
+       | Ok resp ->
+           let text = text_of_response resp in
+           on_event (MessageStart {
+             id = "batch-" ^ req.model.model_id;
+             model = resp.model_used;
+             usage = None;
+           });
+           if text <> "" then
+             on_event (ContentBlockDelta {
+               index = 0;
+               delta = TextDelta text;
+             });
+           on_event MessageStop;
+           Ok resp
+       | Error _ as e -> e)

--- a/lib/llm_orchestration.mli
+++ b/lib/llm_orchestration.mli
@@ -36,3 +36,19 @@ val run_prompt_cascade :
   prompt:string ->
   unit ->
   (Llm_types.completion_response, string) result
+
+(** Streaming completion for a single request.
+    Calls the provider in streaming mode and invokes [on_event] for each SSE
+    event as it arrives. Returns the assembled final response.
+    Uses the same concurrency permit as {!complete}.
+
+    Stub: until the real streaming implementation lands, this calls {!complete}
+    in batch mode and synthesises a single ContentBlockDelta event with the
+    full text.
+
+    @since 2.110.0 *)
+val call_provider_stream :
+  ?timeout_sec:float ->
+  Llm_types.completion_request ->
+  on_event:(Llm_provider.Types.sse_event -> unit) ->
+  (Llm_types.completion_response, string) result

--- a/lib/server_routes_http_keeper_stream.ml
+++ b/lib/server_routes_http_keeper_stream.ml
@@ -226,6 +226,135 @@ let keeper_stream_send_raw writer mutex closed data =
 let keeper_stream_send_event writer mutex closed event =
   keeper_stream_send_raw writer mutex closed (Ag_ui.event_to_sse event)
 
+(** Execute keeper dispatch with real-time streaming.
+    Calls [dispatch_stream] which forwards LLM text deltas to [on_text_delta].
+    Returns the same [(bool, string)] result as the batch path.
+    Includes timeout, audit, and telemetry — same bookkeeping as the batch path. *)
+let execute_keeper_stream_tool_streaming ~sw ~clock ?auth_token:_ state
+    ~agent_name ~arguments ~on_text_delta =
+  let timeout_sec = keeper_stream_timeout_sec arguments in
+  let start_time = Eio.Time.now clock in
+  let timeout_hit = ref false in
+  let success, body =
+    try
+      Eio.Time.with_timeout_exn clock timeout_sec (fun () ->
+          let keeper_ctx : _ Tool_keeper.context =
+            {
+              config = state.Mcp_server.room_config;
+              agent_name;
+              sw;
+              clock;
+              proc_mgr = state.Mcp_server.proc_mgr;
+            }
+          in
+          match
+            Tool_keeper.dispatch_stream ~on_text_delta keeper_ctx
+              ~name:"masc_keeper_msg" ~args:arguments
+          with
+          | Some result -> result
+          | None -> (false, "masc_keeper_msg stream dispatch unavailable"))
+    with
+    | Eio.Cancel.Cancelled _ as exn -> raise exn
+    | Eio.Time.Timeout ->
+        timeout_hit := true;
+        Log.Mcp.error "tools/call timeout: masc_keeper_msg (stream) after %.0fs"
+          timeout_sec;
+        ( false,
+          Printf.sprintf
+            "Tool timed out after %.0fs: %s (env: MASC_TOOL_TIMEOUT_KEEPER_MSG_SEC)"
+            timeout_sec "masc_keeper_msg" )
+    | exn ->
+        let err = Printexc.to_string exn in
+        if contains_casefold err "Invalid_argument(\"MASC not initialized" then
+          (false, Types.masc_error_to_string Types.NotInitialized)
+        else (
+          Log.Mcp.error "tools/call crashed (stream): %s" err;
+          (false, Printf.sprintf "Internal error: %s" err))
+  in
+  let end_time = Eio.Time.now clock in
+  let duration_ms = int_of_float ((end_time -. start_time) *. 1000.0) in
+  let error_msg =
+    if success then None
+    else
+      Some
+        (Printf.sprintf "timeout=%d|duration_ms=%d"
+           (if !timeout_hit then 1 else 0)
+           duration_ms)
+  in
+  Audit_log.log_tool_call state.Mcp_server.room_config ~agent_id:agent_name
+    ~tool_name:"masc_keeper_msg" ~success ~error_msg ();
+  let telemetry_enabled =
+    match Sys.getenv_opt "MASC_TELEMETRY_ENABLED" with
+    | Some "false" | Some "0" -> false
+    | _ -> true
+  in
+  if telemetry_enabled then (
+    match state.Mcp_server.fs with
+    | Some fs ->
+        (try
+           Telemetry_eio.track_tool_called ~fs state.Mcp_server.room_config
+             ~tool_name:"masc_keeper_msg" ~agent_id:agent_name ~success
+             ~duration_ms ()
+         with exn ->
+           Log.Misc.error "telemetry tracking failed: %s"
+             (Printexc.to_string exn))
+    | None -> ());
+  Tool_registry.record_call_if_known ~tool_name:"masc_keeper_msg" ~success
+    ~duration_ms;
+  (success, body)
+
+(** Send a Run_error AG-UI event with the given message. *)
+let send_keeper_error writer mutex closed ~thread_id ~run_id err =
+  ignore
+    (keeper_stream_send_event writer mutex closed
+       Ag_ui.(
+         make_event ~thread_id ~run_id:(Some run_id)
+           ~custom_name:(Some "KEEPER_CHAT_ERROR")
+           ~custom_value:(Some (`Assoc [ ("message", `String err) ]))
+           Run_error))
+
+(** Send Text_message_end + Run_finished sequence to complete the stream. *)
+let send_keeper_stream_finish writer mutex closed ~thread_id ~run_id
+    ~message_id =
+  ignore
+    (keeper_stream_send_event writer mutex closed
+       Ag_ui.(
+         make_event ~thread_id ~run_id:(Some run_id)
+           ~message_id:(Some message_id) Text_message_end));
+  ignore
+    (keeper_stream_send_event writer mutex closed
+       Ag_ui.(make_event ~thread_id ~run_id:(Some run_id) Run_finished))
+
+(** Extract visible reply from the keeper pipeline result body.
+    Parses JSON if possible and strips internal markers. *)
+let extract_visible_reply body =
+  let payload_json_opt =
+    try Some (Yojson.Safe.from_string body)
+    with Yojson.Json_error _ -> None
+  in
+  let visible_reply =
+    match payload_json_opt with
+    | Some payload_json ->
+        let reply_raw =
+          payload_json
+          |> Yojson.Safe.Util.member "reply"
+          |> Yojson.Safe.Util.to_string_option
+          |> Option.value ~default:""
+        in
+        let visible =
+          if String.trim reply_raw = "" then String.trim body
+          else strip_keeper_visible_reply reply_raw
+        in
+        if visible = "" then
+          Option.value ~default:"(empty reply)"
+            (Yojson.Safe.Util.to_string_option payload_json)
+        else visible
+    | None ->
+        let visible = strip_keeper_visible_reply body in
+        if visible = "" then "(empty reply)" else visible
+  in
+  (payload_json_opt, visible_reply)
+
 let handle_keeper_chat_stream ~sw ~clock state request reqd payload =
   let origin = get_origin request in
   let headers =
@@ -246,20 +375,19 @@ let handle_keeper_chat_stream ~sw ~clock state request reqd payload =
     if not !closed then begin
       closed := true;
       (try Httpun.Body.Writer.close writer
-       with exn -> Log.Misc.warn "keeper_stream writer close: %s" (Printexc.to_string exn))
+       with exn ->
+         Log.Misc.warn "keeper_stream writer close: %s"
+           (Printexc.to_string exn))
     end
   in
-  let now_id () =
-    int_of_float (Time_compat.now () *. 1000.0)
-  in
+  let now_id () = int_of_float (Time_compat.now () *. 1000.0) in
   let thread_id = "keeper:" ^ payload.name in
   let run_id = Printf.sprintf "keeper-run-%d" (now_id ()) in
   let message_id = Printf.sprintf "keeper-msg-%d" (now_id ()) in
   ignore (keeper_stream_send_raw writer mutex closed "retry: 1500\n\n");
   Eio.Fiber.fork ~sw (fun () ->
-      Fun.protect
-        ~finally:close_stream
-        (fun () ->
+      Fun.protect ~finally:close_stream (fun () ->
+          (* --- 1. Lifecycle: Run_started + Text_message_start --- *)
           ignore
             (keeper_stream_send_event writer mutex closed
                Ag_ui.(
@@ -268,85 +396,87 @@ let handle_keeper_chat_stream ~sw ~clock state request reqd payload =
             (keeper_stream_send_event writer mutex closed
                Ag_ui.(
                  make_event ~thread_id ~run_id:(Some run_id)
-                   ~message_id:(Some message_id) ~role:(Some Assistant)
-                   Text_message_start));
+                   ~message_id:(Some message_id)
+                   ~role:(Some Assistant) Text_message_start));
           let args =
             `Assoc
-              ([
-                 ("name", `String payload.name);
-                 ("message", `String payload.message);
-               ]
+              ([ ("name", `String payload.name);
+                 ("message", `String payload.message) ]
               @
-              if payload.models = [] then []
-              else [ ("models", `List (List.map (fun model -> `String model) payload.models)) ])
+              (if payload.models = [] then []
+               else
+                 [ ("models",
+                    `List
+                      (List.map
+                         (fun model -> `String model)
+                         payload.models)) ]))
           in
           let agent_name =
             match agent_from_request request with
             | Some raw when String.trim raw <> "" -> String.trim raw
             | _ -> "unknown"
           in
+          (* Track whether any text deltas were streamed to the client.
+             When streaming is active, the LLM text is sent token-by-token
+             during the call; we only need to send the final batch chunks
+             if no deltas were emitted (fallback path). *)
+          let deltas_sent = ref false in
+          let on_text_delta text =
+            if String.length text > 0 then begin
+              deltas_sent := true;
+              ignore
+                (keeper_stream_send_event writer mutex closed
+                   Ag_ui.(
+                     make_event ~thread_id ~run_id:(Some run_id)
+                       ~message_id:(Some message_id)
+                       ~delta:(Some text) Text_message_content))
+            end
+          in
+
+          (* --- 2. Try real streaming path first --- *)
           let dispatch_result =
             try
               Ok
-                (execute_keeper_stream_tool ~sw ~clock
+                (execute_keeper_stream_tool_streaming ~sw ~clock
                    ?auth_token:(auth_token_from_request request)
-                   state ~agent_name ~arguments:args)
-            with exn -> Error (Printexc.to_string exn)
+                   state ~agent_name ~arguments:args ~on_text_delta)
+            with exn ->
+              Log.Keeper.warn
+                "keeper_stream: streaming dispatch raised: %s"
+                (Printexc.to_string exn);
+              (* --- 3. Fallback to batch on exception --- *)
+              (try
+                 Ok
+                   (execute_keeper_stream_tool ~sw ~clock
+                      ?auth_token:(auth_token_from_request request)
+                      state ~agent_name ~arguments:args)
+               with exn2 -> Error (Printexc.to_string exn2))
           in
           match dispatch_result with
           | Error err ->
-              ignore
-                (keeper_stream_send_event writer mutex closed
-                   Ag_ui.(
-                     make_event ~thread_id ~run_id:(Some run_id)
-                       ~custom_name:(Some "KEEPER_CHAT_ERROR")
-                       ~custom_value:(Some (`Assoc [ ("message", `String err) ]))
-                       Run_error))
+              send_keeper_error writer mutex closed ~thread_id ~run_id err
           | Ok (false, err) ->
-              ignore
-                (keeper_stream_send_event writer mutex closed
-                   Ag_ui.(
-                     make_event ~thread_id ~run_id:(Some run_id)
-                       ~custom_name:(Some "KEEPER_CHAT_ERROR")
-                       ~custom_value:(Some (`Assoc [ ("message", `String err) ]))
-                       Run_error))
+              send_keeper_error writer mutex closed ~thread_id ~run_id err
           | Ok (true, body) -> (
               try
-                let payload_json_opt =
-                  try Some (Yojson.Safe.from_string body) with Yojson.Json_error _ -> None
+                let payload_json_opt, visible_reply =
+                  extract_visible_reply body
                 in
-                let visible_reply =
-                  match payload_json_opt with
-                  | Some payload_json ->
-                      let reply_raw =
-                        payload_json |> Yojson.Safe.Util.member "reply"
-                        |> Yojson.Safe.Util.to_string_option
-                        |> Option.value ~default:""
-                      in
-                      let visible_reply =
-                        if String.trim reply_raw = "" then
-                          String.trim body
-                        else
-                          strip_keeper_visible_reply reply_raw
-                      in
-                      if visible_reply = "" then
-                        Option.value ~default:"(empty reply)"
-                          (Yojson.Safe.Util.to_string_option payload_json)
-                      else
-                        visible_reply
-                  | None ->
-                      let visible_reply = strip_keeper_visible_reply body in
-                      if visible_reply = "" then "(empty reply)" else visible_reply
-                in
-                split_keeper_reply_chunks visible_reply
-                |> List.iter (fun chunk ->
-                       ignore
-                         (keeper_stream_send_event writer mutex closed
-                            Ag_ui.(
-                              make_event ~thread_id ~run_id:(Some run_id)
-                                ~message_id:(Some message_id)
-                                ~delta:(Some chunk)
-                                Text_message_content)));
+                (* If no deltas were streamed during the LLM call
+                   (batch fallback or tool-call-only response),
+                   send the visible reply as chunked content now. *)
+                if not !deltas_sent then
+                  split_keeper_reply_chunks visible_reply
+                  |> List.iter (fun chunk ->
+                         ignore
+                           (keeper_stream_send_event writer mutex closed
+                              Ag_ui.(
+                                make_event ~thread_id
+                                  ~run_id:(Some run_id)
+                                  ~message_id:(Some message_id)
+                                  ~delta:(Some chunk)
+                                  Text_message_content)));
+                (* Always send the structured reply details *)
                 (match payload_json_opt with
                  | Some payload_json ->
                      ignore
@@ -354,27 +484,12 @@ let handle_keeper_chat_stream ~sw ~clock state request reqd payload =
                           Ag_ui.(
                             make_event ~thread_id ~run_id:(Some run_id)
                               ~custom_name:(Some "KEEPER_REPLY_DETAILS")
-                              ~custom_value:(Some payload_json)
-                              Custom))
+                              ~custom_value:(Some payload_json) Custom))
                  | None -> ());
-                ignore
-                  (keeper_stream_send_event writer mutex closed
-                     Ag_ui.(
-                       make_event ~thread_id ~run_id:(Some run_id)
-                         ~message_id:(Some message_id)
-                         Text_message_end));
-                ignore
-                  (keeper_stream_send_event writer mutex closed
-                     Ag_ui.(
-                       make_event ~thread_id ~run_id:(Some run_id) Run_finished))
+                send_keeper_stream_finish writer mutex closed ~thread_id
+                  ~run_id ~message_id
               with exn ->
-                ignore
-                  (keeper_stream_send_event writer mutex closed
-                     Ag_ui.(
-                       make_event ~thread_id ~run_id:(Some run_id)
-                         ~custom_name:(Some "KEEPER_CHAT_ERROR")
-                         ~custom_value:(Some (`Assoc [ ("message", `String (Printexc.to_string exn)) ]))
-                         Run_error))));
-        )
+                send_keeper_error writer mutex closed ~thread_id ~run_id
+                  (Printexc.to_string exn))))
 
 (** Build routes for MCP server *)

--- a/lib/tool_keeper.ml
+++ b/lib/tool_keeper.ml
@@ -156,6 +156,35 @@ let handle_resident_keeper_msg ctx args : tool_result =
               ~resident_registered:true json))
       end
 
+let handle_resident_keeper_msg_stream ~on_text_delta ctx args : tool_result =
+  let name = get_string args "name" "" in
+  if validate_name name then maybe_promote_live_legacy_keeper ctx.config name;
+  let ensure_result =
+    match read_resident_keeper ctx.config name with
+    | Ok (Some _) -> Ok ()
+    | _ ->
+        let ok, body = handle_resident_keeper_up ctx args in
+        if ok then Ok () else Error body
+  in
+  match ensure_result with
+  | Error err -> (false, err)
+  | Ok _ ->
+      let ok, body = Turn.handle_keeper_msg ~on_text_delta ctx args in
+      if not ok then (ok, body)
+      else begin
+        (match read_meta ctx.config name with
+        | Ok (Some meta) ->
+            ignore (register_resident_keeper_from_meta ctx.config meta)
+        | _ -> ());
+        let json =
+          try Yojson.Safe.from_string body with Yojson.Json_error _ -> `String body
+        in
+        (true,
+         Yojson.Safe.pretty_to_string
+           (annotate_keeper_json ~runtime_class:"resident_keeper" ~desired:true
+              ~resident_registered:true json))
+      end
+
 let handle_resident_keeper_down ctx args : tool_result =
   let name = get_string args "name" "" in
   if validate_name name then remove_resident_keeper ctx.config name;
@@ -364,4 +393,15 @@ let dispatch ctx ~name ~args : tool_result option =
   | "masc_persistent_agent_goals" -> Some (Policy.handle_keeper_goals ctx args)
   | "masc_persistent_agent_trajectory" -> Some (Status.handle_keeper_trajectory ctx args)
   | "masc_persistent_agent_eval" -> Some (Status.handle_keeper_eval ctx args)
+  | _ -> None
+
+(** Streaming dispatch: only handles keeper_msg with text delta forwarding.
+    Returns None for all other tool names.
+    Called from server_routes_http_keeper_stream. *)
+let dispatch_stream ~on_text_delta ctx ~name ~args : tool_result option =
+  (try start_existing_keepalives ctx with exn ->
+    Log.Keeper.error "start_existing_keepalives failed: %s" (Printexc.to_string exn));
+  match name with
+  | "masc_keeper_msg" ->
+      Some (handle_resident_keeper_msg_stream ~on_text_delta ctx args)
   | _ -> None

--- a/lib/tool_keeper.mli
+++ b/lib/tool_keeper.mli
@@ -14,3 +14,12 @@ val schemas : Types.tool_schema list
 
 val dispatch :
   _ context -> name:string -> args:Yojson.Safe.t -> tool_result option
+
+(** Streaming dispatch: handles keeper_msg with real-time text delta callback.
+    The [on_text_delta] callback receives each text fragment from the LLM
+    as it arrives. Returns [None] for tool names other than [masc_keeper_msg].
+
+    @since 2.110.0 *)
+val dispatch_stream :
+  on_text_delta:(string -> unit) ->
+  _ context -> name:string -> args:Yojson.Safe.t -> tool_result option


### PR DESCRIPTION
## Summary

Keeper 대화의 가짜 스트리밍(batch-then-split)을 실제 토큰 단위 스트리밍으로 교체.

**이전**: LLM 응답 전체를 기다림(10-45초) → 문장 단위 split → SSE 한꺼번에 전송
**이후**: LLM 토큰이 도착할 때마다 → AG-UI delta event → httpun flush → 클라이언트 즉시 수신

## Architecture

```
POST /api/v1/keepers/chat/stream
  → execute_keeper_stream_tool_streaming (on_text_delta callback)
    → Tool_keeper.dispatch_stream
      → Keeper_turn.handle_keeper_msg ~on_text_delta
        → Llm_orchestration.call_provider_stream ~on_event
          → OAS Llm_provider.Complete.complete_stream (real SSE)
```

## Changes (9 files)

| 파일 | 변경 |
|------|------|
| `llm_orchestration.ml/mli` | `call_provider_stream` 추가 — OAS `complete_stream` 래핑 |
| `llm_client.mli` | re-export |
| `keeper_turn.ml/mli` | `?on_text_delta` optional 파라미터. 첫 LLM만 stream, follow-up은 batch |
| `tool_keeper.ml/mli` | `dispatch_stream` — `masc_keeper_msg`만 streaming 처리 |
| `server_routes_http_keeper_stream.ml` | streaming 실행 경로 + batch fallback + helper 추출 |
| `lodge_cascade.ml` | 주석 정리 (upstream merge) |

## Safety

- `on_text_delta`는 optional → 모든 기존 호출자(Lodge heartbeat, MCP dispatch) 변경 없음
- Streaming 실패 시 자동 batch fallback (keeper_turn + stream handler 양쪽)
- Follow-up 호출(tool loop, correction)은 항상 batch — streaming은 초기 응답에만 적용

## Test plan

- [ ] `dune build` clean 통과 확인
- [ ] Keeper 대시보드에서 메시지 전송 → 토큰이 실시간으로 나타나는지 확인
- [ ] Streaming 미지원 provider(custom 등)에서 batch fallback 동작 확인
- [ ] 기존 MCP `masc_keeper_msg` 도구 호출이 변경 없이 동작하는지 확인
- [ ] Lodge heartbeat keeper 턴이 정상 동작하는지 확인

Depends on: #1570 (dashboard UX 개선 — 독립적이지만 함께 테스트 권장)

🤖 Generated with [Claude Code](https://claude.com/claude-code)