### PR TITLE
refactor: Llm_client → Agent_sdk.Types direct (batch 1/4)

### DIFF
--- a/lib/auto_responder.ml
+++ b/lib/auto_responder.ml
@@ -140,7 +140,7 @@ let cascade_name_for_agent_type agent_type =
   Printf.sprintf "auto_responder_%s" agent_type
 
 let llm_response_is_valid (resp : Llm_client.completion_response) =
-  let s = String.trim (Llm_client.text_of_response resp) in
+  let s = String.trim (Llm_types.text_of_response resp) in
   let s_lower = String.lowercase_ascii s in
   let len = String.length s in
   len > 0

--- a/lib/autoresearch.ml
+++ b/lib/autoresearch.ml
@@ -688,7 +688,7 @@ let generate_code_change ~goal ~baseline ~history ~insights
   | Result.Ok model ->
     let req : Llm_client.completion_request = {
       model;
-      messages = [Llm_client.user_msg prompt];
+      messages = [Agent_sdk.Types.user_msg prompt];
       temperature = 0.7;
       max_tokens = 4096;
       tools = [];
@@ -696,7 +696,7 @@ let generate_code_change ~goal ~baseline ~history ~insights
     } in
     (match Llm_orchestration.complete ~timeout_sec:120 req with
     | Result.Error e -> Result.error (Printf.sprintf "LLM call failed: %s" e)
-    | Result.Ok resp -> parse_llm_code_response (Llm_client.text_of_response resp))
+    | Result.Ok resp -> parse_llm_code_response (Llm_types.text_of_response resp))
 
 (* ================================================================ *)
 (* Loop State Management                                            *)

--- a/lib/capability_match.ml
+++ b/lib/capability_match.ml
@@ -246,7 +246,7 @@ let parse_llm_score (text : string) : float option =
 
 (** Validate that an LLM response contains a parseable score. *)
 let llm_score_is_valid (resp : Llm_client.completion_response) : bool =
-  parse_llm_score (Llm_client.text_of_response resp) <> None
+  parse_llm_score (Llm_types.text_of_response resp) <> None
 
 (** Call LLM to score agent-task compatibility.
     Returns Ok float or Error string. *)

--- a/lib/chain_native_eio.ml
+++ b/lib/chain_native_eio.ml
@@ -301,8 +301,8 @@ let call_llm_text (runtime : runtime) ~model ?system ?tools ?thinking:_ ~prompt
           messages =
             (match system with
             | Some sys when trim sys <> "" ->
-                [ Llm_client.system_msg sys; Llm_client.user_msg prompt ]
-            | _ -> [ Llm_client.user_msg prompt ]);
+                [ Agent_sdk.Types.system_msg sys; Agent_sdk.Types.user_msg prompt ]
+            | _ -> [ Agent_sdk.Types.user_msg prompt ]);
           temperature = 0.2;
           max_tokens = 4096;
           tools = llm_tool_defs_of_json tools;
@@ -310,7 +310,7 @@ let call_llm_text (runtime : runtime) ~model ?system ?tools ?thinking:_ ~prompt
         }
       in
       (match Llm_orchestration.complete ~timeout_sec req with
-      | Ok resp when trim (Llm_client.text_of_response resp) <> "" -> Ok (Llm_client.text_of_response resp)
+      | Ok resp when trim (Llm_types.text_of_response resp) <> "" -> Ok (Llm_types.text_of_response resp)
       | Ok resp when resp.tool_calls <> [] ->
           Ok (Yojson.Safe.to_string (llm_tool_calls_json resp.tool_calls))
       | Ok _ -> Error "empty completion"

--- a/lib/code_swarm_plan.ml
+++ b/lib/code_swarm_plan.ml
@@ -336,7 +336,7 @@ let verify_worker ~model ~pattern (worker : worker_plan) diff =
     let req : Llm_client.completion_request =
       {
         model;
-        messages = [ Llm_client.user_msg prompt ];
+        messages = [ Agent_sdk.Types.user_msg prompt ];
         temperature = 0.0;
         max_tokens = 200;
         tools = [];
@@ -345,7 +345,7 @@ let verify_worker ~model ~pattern (worker : worker_plan) diff =
     in
     let verdict =
       match Llm_orchestration.complete req with
-      | Ok resp -> Verifier_oas.parse_verdict (Llm_client.text_of_response resp)
+      | Ok resp -> Verifier_oas.parse_verdict (Llm_types.text_of_response resp)
       | Error e -> Verifier_oas.Warn ("verifier_unavailable: " ^ e)
     in
     let our_verdict =

--- a/lib/context_compact_oas.ml
+++ b/lib/context_compact_oas.ml
@@ -49,16 +49,16 @@ let starts_with ~prefix s =
 (** Convert a MASC message to an OAS message with role tags for lossless roundtrip.
     System and Tool roles are mapped to User with a sentinel prefix so OAS
     strategies (which expect User/Assistant alternation) handle them correctly. *)
-let masc_msg_to_oas (m : Llm_client.message) : Agent_sdk.Types.message =
-  let text = Llm_client.text_of_message m in
+let masc_msg_to_oas (m : Agent_sdk.Types.message) : Agent_sdk.Types.message =
+  let text = Agent_sdk.Types.text_of_message m in
   let role, tagged_text = match m.role with
-    | Llm_client.System -> Agent_sdk.Types.User, system_role_tag ^ text
-    | Llm_client.Tool -> Agent_sdk.Types.User, tool_role_tag ^ text
-    | Llm_client.User -> Agent_sdk.Types.User, text
-    | Llm_client.Assistant -> Agent_sdk.Types.Assistant, text
+    | Agent_sdk.Types.System -> Agent_sdk.Types.User, system_role_tag ^ text
+    | Agent_sdk.Types.Tool -> Agent_sdk.Types.User, tool_role_tag ^ text
+    | Agent_sdk.Types.User -> Agent_sdk.Types.User, text
+    | Agent_sdk.Types.Assistant -> Agent_sdk.Types.Assistant, text
   in
   let content = match m.role with
-    | Llm_client.Tool ->
+    | Agent_sdk.Types.Tool ->
       let tool_use_id =
         List.find_map (function Agent_sdk.Types.ToolResult { tool_use_id; _ } -> Some tool_use_id | _ -> None) m.content
         |> Option.value ~default:"masc-tool"
@@ -70,7 +70,7 @@ let masc_msg_to_oas (m : Llm_client.message) : Agent_sdk.Types.message =
 
 (** Recover a MASC message from a tagged OAS message.
     Strips sentinel prefixes and restores the original MASC role. *)
-let oas_msg_to_masc (m : Agent_sdk.Types.message) : Llm_client.message =
+let oas_msg_to_masc (m : Agent_sdk.Types.message) : Agent_sdk.Types.message =
   let text, tool_id =
     let parts = List.filter_map (fun (block : Agent_sdk.Types.content_block) ->
       match block with
@@ -85,23 +85,23 @@ let oas_msg_to_masc (m : Agent_sdk.Types.message) : Llm_client.message =
   in
   let role, content =
     if starts_with ~prefix:system_role_tag text then
-      Llm_client.System,
+      Agent_sdk.Types.System,
       String.sub text (String.length system_role_tag)
         (String.length text - String.length system_role_tag)
     else if starts_with ~prefix:tool_role_tag text then
-      Llm_client.Tool,
+      Agent_sdk.Types.Tool,
       String.sub text (String.length tool_role_tag)
         (String.length text - String.length tool_role_tag)
     else
       (match m.role with
-       | Agent_sdk.Types.User -> Llm_client.User
-       | Agent_sdk.Types.Assistant -> Llm_client.Assistant
-       | Agent_sdk.Types.System -> Llm_client.System
-       | Agent_sdk.Types.Tool -> Llm_client.Tool),
+       | Agent_sdk.Types.User -> Agent_sdk.Types.User
+       | Agent_sdk.Types.Assistant -> Agent_sdk.Types.Assistant
+       | Agent_sdk.Types.System -> Agent_sdk.Types.System
+       | Agent_sdk.Types.Tool -> Agent_sdk.Types.Tool),
       text
   in
   let content_blocks = match role with
-    | Llm_client.Tool ->
+    | Agent_sdk.Types.Tool ->
       let tool_use_id = Option.value ~default:"masc-tool" tool_id in
       [Agent_sdk.Types.ToolResult { tool_use_id; content; is_error = false }]
     | _ -> [Agent_sdk.Types.Text content]
@@ -116,10 +116,10 @@ let oas_msg_to_masc (m : Agent_sdk.Types.message) : Llm_client.message =
 (* Token Estimation                                                 *)
 (* ================================================================ *)
 
-let msg_tokens (m : Llm_client.message) =
-  (String.length (Llm_client.text_of_message m) / 4) + 4
+let msg_tokens (m : Agent_sdk.Types.message) =
+  (String.length (Agent_sdk.Types.text_of_message m) / 4) + 4
 
-let count_tokens (system_prompt : string) (msgs : Llm_client.message list) =
+let count_tokens (system_prompt : string) (msgs : Agent_sdk.Types.message list) =
   let sys_tokens = (String.length system_prompt / 4) + 4 in
   List.fold_left (fun acc m -> acc + msg_tokens m) sys_tokens msgs
 
@@ -205,14 +205,14 @@ let oas_strategy_of (s : strategy) : Agent_sdk.Context_reducer.strategy =
     from strategies like Merge_contiguous or Summarize_old that may
     concatenate or truncate content containing \x00 sentinel bytes. *)
 let validate_roundtrip
-    ~(original : Llm_client.message list)
-    ~(reduced : Llm_client.message list)
+    ~(original : Agent_sdk.Types.message list)
+    ~(reduced : Agent_sdk.Types.message list)
   : bool =
   (* Count sentinel-tagged messages (System and Tool roles) in original *)
   let count_sentinels msgs =
-    List.fold_left (fun acc (m : Llm_client.message) ->
+    List.fold_left (fun acc (m : Agent_sdk.Types.message) ->
       match m.role with
-      | Llm_client.System | Llm_client.Tool -> acc + 1
+      | Agent_sdk.Types.System | Agent_sdk.Types.Tool -> acc + 1
       | _ -> acc
     ) 0 msgs
   in
@@ -221,8 +221,8 @@ let validate_roundtrip
   if original_sentinel_count = 0 then true
   else begin
     (* Verify each reduced message with a sentinel tag can be cleanly parsed *)
-    let valid = List.for_all (fun (m : Llm_client.message) ->
-      let text = Llm_client.text_of_message m in
+    let valid = List.for_all (fun (m : Agent_sdk.Types.message) ->
+      let text = Agent_sdk.Types.text_of_message m in
       (* Check for corrupted sentinels: \x00 present but not as valid prefix *)
       if String.contains text '\x00' then
         starts_with ~prefix:system_role_tag text
@@ -252,9 +252,9 @@ let validate_roundtrip
     but routes through OAS Context_reducer, enabling A/B comparison. *)
 let compact
     ~(system_prompt : string)
-    ~(messages : Llm_client.message list)
+    ~(messages : Agent_sdk.Types.message list)
     ~(strategies : strategy list)
-  : Llm_client.message list * int =
+  : Agent_sdk.Types.message list * int =
   let oas_strategies = List.map oas_strategy_of strategies in
   let reducer = Agent_sdk.Context_reducer.compose
     (List.map (fun s -> { Agent_sdk.Context_reducer.strategy = s }) oas_strategies) in

--- a/lib/context_manager.ml
+++ b/lib/context_manager.ml
@@ -14,7 +14,7 @@
 
 open Printf
 
-let text_of_message = Llm_client.text_of_message
+let text_of_message = Agent_sdk.Types.text_of_message
 
 (* ================================================================ *)
 (* Types                                                            *)
@@ -22,7 +22,7 @@ let text_of_message = Llm_client.text_of_message
 
 type working_context = {
   system_prompt : string;
-  messages : Llm_client.message list;
+  messages : Agent_sdk.Types.message list;
   token_count : int;
   max_tokens : int;
   importance_scores : (int * float) list;
@@ -41,7 +41,7 @@ type checkpoint = {
 type session_context = {
   session_id : string;
   session_dir : string;
-  mutable full_history : Llm_client.message list;
+  mutable full_history : Agent_sdk.Types.message list;
   mutable checkpoints : checkpoint list;
 }
 
@@ -108,10 +108,10 @@ let ensure_dir path =
 (* ================================================================ *)
 
 (** Count tokens in a message (~4 chars/token + role overhead). *)
-let msg_tokens (m : Llm_client.message) =
+let msg_tokens (m : Agent_sdk.Types.message) =
   (String.length (text_of_message m) / 4) + 4
 
-let count_tokens (system_prompt : string) (msgs : Llm_client.message list) =
+let count_tokens (system_prompt : string) (msgs : Agent_sdk.Types.message list) =
   let sys_tokens = (String.length system_prompt / 4) + 4 in
   List.fold_left (fun acc m -> acc + msg_tokens m) sys_tokens msgs
 
@@ -140,14 +140,14 @@ let set_system_prompt (ctx : working_context) ~system_prompt =
   (* Avoid leaking prior compaction summaries into the "system prompt" channel for providers
      that treat all system-role messages as instructions (notably Claude). *)
   let messages =
-    List.map (fun (m : Llm_client.message) ->
-      if m.role = Llm_client.System then { m with role = Llm_client.Assistant } else m
+    List.map (fun (m : Agent_sdk.Types.message) ->
+      if m.role = Agent_sdk.Types.System then { m with role = Agent_sdk.Types.Assistant } else m
     ) ctx.messages
   in
   let token_count = count_tokens system_prompt messages in
   { ctx with system_prompt; messages; token_count; importance_scores = [] }
 
-let append ctx (msg : Llm_client.message) =
+let append ctx (msg : Agent_sdk.Types.message) =
   let new_tokens = msg_tokens msg in
   { ctx with
     messages = ctx.messages @ [msg];
@@ -174,9 +174,9 @@ let score_importance ctx =
 (** Truncate tool output messages longer than max_len.
     Keeps first keep_len and last keep_len characters with "[...truncated...]". *)
 let prune_tool_outputs ?(max_len=500) ?(keep_len=100) ctx =
-  let messages = List.map (fun (m : Llm_client.message) ->
+  let messages = List.map (fun (m : Agent_sdk.Types.message) ->
     match m.role with
-    | Llm_client.Tool when String.length (text_of_message m) > max_len ->
+    | Agent_sdk.Types.Tool when String.length (text_of_message m) > max_len ->
       let mc = text_of_message m in
       let head = String.sub mc 0 keep_len in
       let tail_start = String.length mc - keep_len in
@@ -193,7 +193,7 @@ let merge_contiguous ctx =
   let rec merge = function
     | [] -> []
     | [m] -> [m]
-    | (m1 : Llm_client.message) :: (m2 :: rest as tail) ->
+    | (m1 : Agent_sdk.Types.message) :: (m2 :: rest as tail) ->
       if m1.role = m2.role then
         let merged = { m1 with content = [Agent_sdk.Types.Text (text_of_message m1 ^ "\n" ^ text_of_message m2)] } in
         merge (merged :: rest)
@@ -233,7 +233,7 @@ let summarize_old ?(oldest_pct=0.3) ctx =
        "instructions" and breaking behavior. *)
     let blocks =
       old_msgs
-      |> List.concat_map (fun (m : Llm_client.message) -> extract_state_blocks (text_of_message m))
+      |> List.concat_map (fun (m : Agent_sdk.Types.message) -> extract_state_blocks (text_of_message m))
     in
     let take_last n lst =
       let len = List.length lst in
@@ -252,7 +252,7 @@ let summarize_old ?(oldest_pct=0.3) ctx =
           memory_summary_prefix rendered
       else
         (* Fallback heuristic: role-tagged truncation. *)
-        let summary_parts = List.map (fun (m : Llm_client.message) ->
+        let summary_parts = List.map (fun (m : Agent_sdk.Types.message) ->
           let role_str = match m.role with
             | System -> "SYS" | User -> "USR"
             | Assistant -> "AST" | Tool -> "TOOL"
@@ -266,7 +266,7 @@ let summarize_old ?(oldest_pct=0.3) ctx =
         sprintf "%s\n(Fallback summary of %d earlier messages; reference only.)\n%s"
           memory_summary_prefix (List.length old_msgs) (String.concat "\n" summary_parts)
     in
-    let summary_msg = Llm_client.assistant_msg summary in
+    let summary_msg = Agent_sdk.Types.assistant_msg summary in
     let messages = summary_msg :: recent_msgs in
     let token_count = count_tokens ctx.system_prompt messages in
     { ctx with messages; token_count; importance_scores = [] }
@@ -309,15 +309,15 @@ let compact ctx strategies =
 (* ================================================================ *)
 
 (** Format a single message as human-readable text: "role: content". *)
-let format_message_readable (m : Llm_client.message) : string =
+let format_message_readable (m : Agent_sdk.Types.message) : string =
   let role_str = match m.role with
-    | Llm_client.System -> "system"
-    | Llm_client.User -> "user"
-    | Llm_client.Assistant -> "assistant"
-    | Llm_client.Tool -> "tool"
+    | Agent_sdk.Types.System -> "system"
+    | Agent_sdk.Types.User -> "user"
+    | Agent_sdk.Types.Assistant -> "assistant"
+    | Agent_sdk.Types.Tool -> "tool"
   in
   let tool_suffix = match m.role with
-    | Llm_client.Tool ->
+    | Agent_sdk.Types.Tool ->
       let tool_id = List.find_map (function
         | Agent_sdk.Types.ToolResult { tool_use_id; _ } -> Some tool_use_id
         | _ -> None) m.content in
@@ -331,7 +331,7 @@ let format_message_readable (m : Llm_client.message) : string =
 let offload_messages
     ~(session_dir : string)
     ~(compaction_count : int)
-    (messages : Llm_client.message list) : string option =
+    (messages : Agent_sdk.Types.message list) : string option =
   try
     let offload_dir = Filename.concat session_dir "offloaded" in
     ensure_dir offload_dir;
@@ -394,7 +394,7 @@ let compact_with_offload
   let compacted = match offloaded_path with
     | Some path ->
       let annotation = sprintf "[Full conversation history saved to %s]\n\n" path in
-      let messages = List.map (fun (m : Llm_client.message) ->
+      let messages = List.map (fun (m : Agent_sdk.Types.message) ->
         let mt = text_of_message m in
         if starts_with ~prefix:memory_summary_prefix mt then
           { m with content = [Agent_sdk.Types.Text (annotation ^ mt)] }
@@ -416,19 +416,19 @@ let compact_with_offload
 let system_role_tag = "\x00__MASC_ROLE:system__\x00"
 let tool_role_tag = "\x00__MASC_ROLE:tool__\x00"
 
-let masc_msg_to_oas_tagged (m : Llm_client.message) : Agent_sdk.Types.message =
+let masc_msg_to_oas_tagged (m : Agent_sdk.Types.message) : Agent_sdk.Types.message =
   let role, tag = match m.role with
-    | Llm_client.System -> Agent_sdk.Types.User, Some system_role_tag
-    | Llm_client.Tool -> Agent_sdk.Types.User, Some tool_role_tag
-    | Llm_client.User -> Agent_sdk.Types.User, None
-    | Llm_client.Assistant -> Agent_sdk.Types.Assistant, None
+    | Agent_sdk.Types.System -> Agent_sdk.Types.User, Some system_role_tag
+    | Agent_sdk.Types.Tool -> Agent_sdk.Types.User, Some tool_role_tag
+    | Agent_sdk.Types.User -> Agent_sdk.Types.User, None
+    | Agent_sdk.Types.Assistant -> Agent_sdk.Types.Assistant, None
   in
   let text = match tag with
     | Some t -> t ^ text_of_message m
     | None -> text_of_message m
   in
   let content = match m.role with
-    | Llm_client.Tool ->
+    | Agent_sdk.Types.Tool ->
       let tool_use_id =
         List.find_map (function Agent_sdk.Types.ToolResult { tool_use_id; _ } -> Some tool_use_id | _ -> None) m.content
         |> Option.value ~default:"masc-tool"
@@ -438,7 +438,7 @@ let masc_msg_to_oas_tagged (m : Llm_client.message) : Agent_sdk.Types.message =
   in
   { Agent_sdk.Types.role; content }
 
-let oas_msg_to_masc_tagged (m : Agent_sdk.Types.message) : Llm_client.message =
+let oas_msg_to_masc_tagged (m : Agent_sdk.Types.message) : Agent_sdk.Types.message =
   (* Extract text and tool_use_id from content blocks *)
   let text, tool_id =
     let parts = List.filter_map (fun (block : Agent_sdk.Types.content_block) ->
@@ -454,23 +454,23 @@ let oas_msg_to_masc_tagged (m : Agent_sdk.Types.message) : Llm_client.message =
   in
   let role, content =
     if starts_with ~prefix:system_role_tag text then
-      Llm_client.System,
+      Agent_sdk.Types.System,
       String.sub text (String.length system_role_tag)
         (String.length text - String.length system_role_tag)
     else if starts_with ~prefix:tool_role_tag text then
-      Llm_client.Tool,
+      Agent_sdk.Types.Tool,
       String.sub text (String.length tool_role_tag)
         (String.length text - String.length tool_role_tag)
     else
       (match m.role with
-       | Agent_sdk.Types.User -> Llm_client.User
-       | Agent_sdk.Types.Assistant -> Llm_client.Assistant
-       | Agent_sdk.Types.System -> Llm_client.System
-       | Agent_sdk.Types.Tool -> Llm_client.Tool),
+       | Agent_sdk.Types.User -> Agent_sdk.Types.User
+       | Agent_sdk.Types.Assistant -> Agent_sdk.Types.Assistant
+       | Agent_sdk.Types.System -> Agent_sdk.Types.System
+       | Agent_sdk.Types.Tool -> Agent_sdk.Types.Tool),
       text
   in
   let content_blocks = match role with
-    | Llm_client.Tool ->
+    | Agent_sdk.Types.Tool ->
       let tool_use_id = Option.value ~default:"masc-tool" tool_id in
       [Agent_sdk.Types.ToolResult { tool_use_id; content; is_error = false }]
     | _ -> [Agent_sdk.Types.Text content]
@@ -523,15 +523,15 @@ let generate_checkpoint_id () =
   let ts = int_of_float (Time_compat.now () *. 1000.0) in
   sprintf "ckpt-%d" ts
 
-let role_to_string (r : Llm_client.role) = match r with
+let role_to_string (r : Agent_sdk.Types.role) = match r with
   | System -> "system" | User -> "user"
   | Assistant -> "assistant" | Tool -> "tool"
 
 let role_of_string = function
-  | "system" -> Llm_client.System | "user" -> Llm_client.User
-  | "assistant" -> Llm_client.Assistant | _ -> Llm_client.Tool
+  | "system" -> Agent_sdk.Types.System | "user" -> Agent_sdk.Types.User
+  | "assistant" -> Agent_sdk.Types.Assistant | _ -> Agent_sdk.Types.Tool
 
-let message_to_json (m : Llm_client.message) : Yojson.Safe.t =
+let message_to_json (m : Agent_sdk.Types.message) : Yojson.Safe.t =
   let m = Llm_client.sanitize_message_utf8 m in
   let base = [
     ("role", `String (role_to_string m.role));
@@ -539,7 +539,7 @@ let message_to_json (m : Llm_client.message) : Yojson.Safe.t =
   ] in
   (* Preserve tool_use_id for backward compat with old "tool_call_id" JSON field *)
   let with_tool_id = match m.role with
-    | Llm_client.Tool ->
+    | Agent_sdk.Types.Tool ->
       let tool_id = List.find_map (function
         | Agent_sdk.Types.ToolResult { tool_use_id; _ } -> Some tool_use_id
         | _ -> None) m.content in
@@ -548,12 +548,12 @@ let message_to_json (m : Llm_client.message) : Yojson.Safe.t =
   in
   `Assoc with_tool_id
 
-let message_of_json (json : Yojson.Safe.t) : Llm_client.message =
+let message_of_json (json : Yojson.Safe.t) : Agent_sdk.Types.message =
   let open Yojson.Safe.Util in
   let role = json |> member "role" |> to_string |> role_of_string in
   let text = json |> member "content" |> to_string |> Llm_client.sanitize_text_utf8 in
   match role with
-  | Llm_client.Tool ->
+  | Agent_sdk.Types.Tool ->
     let tool_use_id = json |> member "tool_call_id" |> to_string_option |> Option.value ~default:"masc-tool" in
     { Agent_sdk.Types.role; content = [Agent_sdk.Types.ToolResult { tool_use_id; content = text; is_error = false }] }
   | _ ->

--- a/lib/context_router.ml
+++ b/lib/context_router.ml
@@ -187,7 +187,7 @@ let parse_intent_response (text : string) : (query_intent * float) option =
 
 (** Validate that an LLM response contains a parseable intent. *)
 let intent_response_is_valid (resp : Llm_client.completion_response) : bool =
-  parse_intent_response (Llm_client.text_of_response resp) <> None
+  parse_intent_response (Llm_types.text_of_response resp) <> None
 
 (** Classify query intent using LLM semantic understanding.
     Returns (intent, confidence) or falls back to low-confidence default. *)

--- a/lib/context_scoring.ml
+++ b/lib/context_scoring.ml
@@ -35,20 +35,20 @@ let starts_with ~prefix s =
 
     Messages starting with [memory_summary_prefix] or [goal_prefix]
     receive a minimum score of 0.95 (sticky memory). *)
-let score_messages (msgs : Llm_client.message list) : (int * float) list =
+let score_messages (msgs : Agent_sdk.Types.message list) : (int * float) list =
   let n = List.length msgs in
-  List.mapi (fun i (m : Llm_client.message) ->
+  List.mapi (fun i (m : Agent_sdk.Types.message) ->
     let recency = if n <= 1 then 1.0
       else let t = float_of_int i /. float_of_int (n - 1) in
            t *. t
     in
     let role_w = match m.role with
-      | Llm_client.System -> 1.0
-      | Llm_client.Tool -> 0.7
-      | Llm_client.User -> 0.6
-      | Llm_client.Assistant -> 0.4
+      | Agent_sdk.Types.System -> 1.0
+      | Agent_sdk.Types.Tool -> 0.7
+      | Agent_sdk.Types.User -> 0.6
+      | Agent_sdk.Types.Assistant -> 0.4
     in
-    let msg_text = Llm_client.text_of_message m in
+    let msg_text = Agent_sdk.Types.text_of_message m in
     let len = String.length msg_text in
     let content_w = if len < 20 then 0.3
       else if len < 100 then 0.6

--- a/lib/dashboard_governance_judge.ml
+++ b/lib/dashboard_governance_judge.ml
@@ -293,7 +293,7 @@ let compute_judgments ~base_path:_ ~factual_json =
     | Error message -> Error message
     | Ok response -> (
         try
-          let parsed = Yojson.Safe.from_string (Llm_client.text_of_response response) in
+          let parsed = Yojson.Safe.from_string (Llm_types.text_of_response response) in
           let generated_at = now_iso () in
           let expires_at = iso_of_unix (Unix.gettimeofday () +. cache_ttl_sec ()) in
           let items =


### PR DESCRIPTION
## Summary

- `Llm_client.system_msg`, `user_msg`, `assistant_msg` → `Agent_sdk.Types.*` 직접 사용
- `Llm_client.text_of_message` → `Agent_sdk.Types.text_of_message`
- `Llm_client.text_of_response` → `Llm_types.text_of_response` (completion_response 전용)
- `Llm_client.message`/`role` 타입 어노테이션 → `Agent_sdk.Types.*`
- `Llm_client.System`/`User`/`Assistant`/`Tool` → `Agent_sdk.Types.*`

총 10개 파일 (알파벳 순 batch 1):
`auto_responder`, `autoresearch`, `capability_match`, `chain_native_eio`,
`code_swarm_plan`, `context_compact_oas`, `context_manager`, `context_router`,
`context_scoring`, `dashboard_governance_judge`

## 주의사항

- `Llm_client.complete`, `completion_request`, `completion_response`, `model_spec`, `tool_def`, `tool_call`, `sanitize_*` 등은 변경하지 않음 (Llm_client 고유 기능)
- `text_of_response`는 `Llm_types`로 라우팅 (completion_response용, api_response가 아님)
- `token_usage` → `api_usage` 이름 변경은 이 batch에 해당 파일 없음

## Test plan

- [x] `dune build` 통과 확인 (origin/main 기준 rebase 후)
- [ ] CI green 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)