### PR TITLE
fix: route keeper cascade through Llm_orchestration + fix broken main build

### DIFF
--- a/lib/keeper_exec_autonomy.ml
+++ b/lib/keeper_exec_autonomy.ml
@@ -147,7 +147,7 @@ Do NOT use destructive tools (bash rm, edit, delete).|}
          (tc, result))
       tcs
   in
-  let run_cascade requests = Llm_client.cascade requests in
+  let run_cascade requests = Llm_orchestration.cascade requests in
   let max_rounds = 3 in
   let initial_request =
     { Llm_client.model = primary;

--- a/lib/keeper_exec_context.ml
+++ b/lib/keeper_exec_context.ml
@@ -603,7 +603,7 @@ let run_proactive_generation
          (tc, output))
       tcs
   in
-  let run_cascade requests = Llm_client.cascade requests in
+  let run_cascade requests = Llm_orchestration.cascade requests in
   let rec loop attempt usage_acc latency_acc cost_acc retry_hint =
     if attempt > max_attempts then
       Some {

--- a/lib/keeper_exec_social.ml
+++ b/lib/keeper_exec_social.ml
@@ -91,7 +91,7 @@ let generate_explicit_room_reply (ctx : _ context) ~(meta : keeper_meta) ~(room_
                 } : Llm_client.completion_request))
               specs
           in
-          match Llm_client.cascade requests with
+          match Llm_orchestration.cascade requests with
           | Error e -> Error e
           | Ok resp ->
               let used_model =
@@ -258,7 +258,7 @@ let run_social_board_event_turn
                    : Llm_client.completion_request))
               specs
           in
-          match Llm_client.cascade requests with
+          match Llm_orchestration.cascade requests with
           | Error e -> Error e
           | Ok resp0 ->
               let max_tool_rounds = Keeper_config.keeper_max_tool_rounds () in
@@ -325,7 +325,7 @@ let run_social_board_event_turn
                            : Llm_client.completion_request))
                       specs
                   in
-                  match Llm_client.cascade followup_requests with
+                  match Llm_orchestration.cascade followup_requests with
                   | Error _ ->
                       ( Llm_types.text_of_response last_resp,
                         acc_usage,

--- a/lib/keeper_turn.ml
+++ b/lib/keeper_turn.ml
@@ -268,8 +268,8 @@ let handle_keeper_msg ?on_text_delta ctx args : tool_result =
             let run_cascade_batch requests =
               match timeout_sec_opt with
               | Some timeout_sec ->
-                  Llm_client.cascade ~timeout_sec requests
-              | None -> Llm_client.cascade requests
+                  Llm_orchestration.cascade ~timeout_sec requests
+              | None -> Llm_orchestration.cascade requests
             in
             (* Streaming-aware cascade: when on_text_delta is provided,
                try streaming the first request. Text deltas are forwarded

--- a/lib/llm_orchestration.ml
+++ b/lib/llm_orchestration.ml
@@ -313,7 +313,7 @@ let call_provider_stream ?timeout_sec (req : completion_request)
   let req = normalize_request req in
   (* Try real streaming first *)
   let stream_result =
-    match provider_config_of_request req with
+    match Llm_provider_dispatch.provider_config_of_request req with
     | Error _ -> None  (* fall through to batch *)
     | Ok (config, messages, tools) ->
         let env = Llm_eio_env.get () in


### PR DESCRIPTION
## Summary
- Fix broken main build: `provider_config_of_request` moved in #1574 but `llm_orchestration.ml` reference not updated
- Replace 7 `Llm_client.cascade` calls with `Llm_orchestration.cascade` in keeper modules

## After this PR
**Zero** `Llm_client.complete` and **zero** `Llm_client.cascade` calls remain in `lib/`.
All LLM traffic routes through `Llm_orchestration` → OAS Provider.

## Files changed (5)
| File | Change |
|------|--------|
| `llm_orchestration.ml` | Fix `provider_config_of_request` → `Llm_provider_dispatch.provider_config_of_request` |
| `keeper_turn.ml` | 2x `Llm_client.cascade` → `Llm_orchestration.cascade` |
| `keeper_exec_context.ml` | 1x cascade migration |
| `keeper_exec_autonomy.ml` | 1x cascade migration |
| `keeper_exec_social.ml` | 3x cascade migration |

## Test plan
- [ ] Build passes (main is currently broken without this)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)