### PR TITLE
refactor: Llm_client → Agent_sdk.Types direct (batch 3/4, 10 files)

### DIFF
--- a/lib/keeper_turn.ml
+++ b/lib/keeper_turn.ml
@@ -229,7 +229,7 @@ let handle_keeper_msg ?on_text_delta ctx args : tool_result =
                   Printf.sprintf "%s\n\n--- Turn-specific instructions ---\n%s"
                     turn_system_prompt ti
             in
-	            let user_msg = Llm_client.user_msg message in
+	            let user_msg = Agent_sdk.Types.user_msg message in
 	            let ctx_work = Context_manager.append ctx_work user_msg in
 	            Context_manager.persist_message session user_msg;
             let turn_max_tokens = keeper_turn_max_tokens () in
@@ -253,7 +253,7 @@ let handle_keeper_msg ?on_text_delta ctx args : tool_result =
             let requests =
 	              List.map (fun (model : Llm_client.model_spec) ->
 	                let msgs =
-	                  (Llm_client.system_msg turn_system_prompt) :: ctx_work.messages
+	                  (Agent_sdk.Types.system_msg turn_system_prompt) :: ctx_work.messages
 	                in
 	                ({
                   Llm_client.model;
@@ -378,11 +378,11 @@ let handle_keeper_msg ?on_text_delta ctx args : tool_result =
                 if last_resp.Llm_client.tool_calls = [] || round > max_tool_rounds then
                   (* Terminal: no more tool calls or hit round limit *)
                   let content =
-                    let c = String.trim (Llm_client.text_of_response last_resp) in
+                    let c = String.trim (Llm_types.text_of_response last_resp) in
                     if c = "" && acc_tools_used <> [] then
                       Printf.sprintf "(tools executed: %s)"
                         (String.concat ", " acc_tools_used)
-                    else Llm_client.text_of_response last_resp
+                    else Llm_types.text_of_response last_resp
                   in
                   ( content, acc_usage, last_resp.Llm_client.model_used,
                     acc_latency, acc_cost, acc_tools_used )
@@ -399,7 +399,7 @@ let handle_keeper_msg ?on_text_delta ctx args : tool_result =
                   let followup_prompt =
                     keeper_tool_followup_prompt
                       ~user_message:message
-                      ~draft_reply:(Llm_client.text_of_response last_resp)
+                      ~draft_reply:(Llm_types.text_of_response last_resp)
                       ~tool_outputs
                       ~already_executed:all_tools_so_far
                   in
@@ -425,9 +425,9 @@ let handle_keeper_msg ?on_text_delta ctx args : tool_result =
                       ({
                         Llm_client.model;
                         messages = [
-                          Llm_client.system_msg (keeper_tool_loop_system_prompt
+                          Agent_sdk.Types.system_msg (keeper_tool_loop_system_prompt
                             ~character_context:ctx_work.system_prompt);
-                          Llm_client.user_msg followup_prompt;
+                          Agent_sdk.Types.user_msg followup_prompt;
                         ];
                         temperature = 0.3;
                         max_tokens = followup_max_tokens;
@@ -439,14 +439,14 @@ let handle_keeper_msg ?on_text_delta ctx args : tool_result =
                   match run_cascade_batch followup_requests with
                   | Error _ ->
                     (* Cascade failed — return what we have *)
-                    ( Llm_client.text_of_response last_resp, acc_usage,
+                    ( Llm_types.text_of_response last_resp, acc_usage,
                       last_resp.Llm_client.model_used, acc_latency,
                       acc_cost, acc_tools_used @ round_tools )
                   | Ok resp_next ->
                     Log.Trpg.info "Follow-up round %d resp: tool_calls=%d content_len=%d model=%s"
                       round
                       (List.length resp_next.Llm_client.tool_calls)
-                      (String.length (Llm_client.text_of_response resp_next))
+                      (String.length (Llm_types.text_of_response resp_next))
                       resp_next.Llm_client.model_used;
                     let used_model_next =
                       model_spec_for_used specs resp_next.model_used
@@ -504,8 +504,8 @@ let handle_keeper_msg ?on_text_delta ctx args : tool_result =
 	                      ({
 	                        Llm_client.model;
 	                        messages = [
-	                          Llm_client.system_msg turn_system_prompt;
-	                          Llm_client.user_msg correction_prompt;
+	                          Agent_sdk.Types.system_msg turn_system_prompt;
+	                          Agent_sdk.Types.user_msg correction_prompt;
 	                        ];
                         temperature = 0.2;
                         max_tokens = correction_max_tokens;
@@ -527,12 +527,12 @@ let handle_keeper_msg ?on_text_delta ctx args : tool_result =
                     let eval1 =
                       evaluate_memory_recall
                         ~user_message:message
-                        ~assistant_reply:(Llm_client.text_of_response corr)
+                        ~assistant_reply:(Llm_types.text_of_response corr)
                         ~candidates:recall_candidates
                     in
                     let evalf = { eval1 with initial_score = eval0.final_score } in
                     let merged_usage = merge_usage base_usage corr.usage in
-                    ( Llm_client.text_of_response corr, merged_usage, corr.model_used,
+                    ( Llm_types.text_of_response corr, merged_usage, corr.model_used,
                       base_latency_ms + corr.latency_ms,
                       evalf, true, evalf.passed, false, base_cost_usd +. cost1,
                       tools_used )
@@ -568,8 +568,8 @@ let handle_keeper_msg ?on_text_delta ctx args : tool_result =
 	                      ({
 	                        Llm_client.model;
 	                        messages = [
-	                          Llm_client.system_msg turn_system_prompt;
-	                          Llm_client.user_msg forced_prompt;
+	                          Agent_sdk.Types.system_msg turn_system_prompt;
+	                          Agent_sdk.Types.user_msg forced_prompt;
 	                        ];
                         temperature = 0.0;
                         max_tokens = correction_max_tokens;
@@ -592,8 +592,8 @@ let handle_keeper_msg ?on_text_delta ctx args : tool_result =
                       let merged_usage = merge_usage usage_after_correction forced.usage in
                       let merged_latency = latency_after_correction + forced.latency_ms in
                       let grounded_content =
-                        let c = String.trim (Llm_client.text_of_response forced) in
-                        if c = "" then content_after_correction else Llm_client.text_of_response forced
+                        let c = String.trim (Llm_types.text_of_response forced) in
+                        if c = "" then content_after_correction else Llm_types.text_of_response forced
                       in
                       let eval2 =
                         evaluate_memory_recall
@@ -693,7 +693,7 @@ let handle_keeper_msg ?on_text_delta ctx args : tool_result =
 	              in
               let response_alignment = jaccard_similarity message safe_reply in
 
-		              let assistant_msg = Llm_client.assistant_msg safe_reply in
+		              let assistant_msg = Agent_sdk.Types.assistant_msg safe_reply in
 	              let ctx_work = Context_manager.append ctx_work assistant_msg in
               Context_manager.persist_message session assistant_msg;
               let now_ts = Time_compat.now () in
@@ -736,13 +736,13 @@ let handle_keeper_msg ?on_text_delta ctx args : tool_result =
                 continuity_summary = continuity_summary_from_reply;
                 last_continuity_update_ts;
                 total_output_tokens = meta.total_output_tokens + final_usage.output_tokens;
-                total_tokens = meta.total_tokens + Llm_client.total_tokens final_usage;
+                total_tokens = meta.total_tokens + Llm_types.total_tokens final_usage;
                 total_cost_usd = meta.total_cost_usd +. total_cost_usd_turn;
                 last_turn_ts = now_ts;
                 last_model_used = final_model_used;
                 last_input_tokens = final_usage.input_tokens;
                 last_output_tokens = final_usage.output_tokens;
-                last_total_tokens = Llm_client.total_tokens final_usage;
+                last_total_tokens = Llm_types.total_tokens final_usage;
                 last_latency_ms = final_latency_ms;
                 compaction_count = meta.compaction_count + (if compacted then 1 else 0);
                 last_compaction_ts = (if compacted then now_ts else meta.last_compaction_ts);

--- a/lib/keeper_turn_response.ml
+++ b/lib/keeper_turn_response.ml
@@ -14,7 +14,7 @@ open Keeper_execution
 type turn_env = {
   meta_turn : keeper_meta;
   safe_reply : string;
-  final_usage : Llm_client.token_usage;
+  final_usage : Llm_types.token_usage;
   final_model_used : string;
   final_latency_ms : int;
   total_cost_usd_turn : float;
@@ -52,7 +52,7 @@ let build_turn_metrics_fields (env : turn_env) : (string * Yojson.Safe.t) list =
     ("usage", `Assoc [
       ("input_tokens", `Int env.final_usage.input_tokens);
       ("output_tokens", `Int env.final_usage.output_tokens);
-      ("total_tokens", `Int (Llm_client.total_tokens env.final_usage));
+      ("total_tokens", `Int (Llm_types.total_tokens env.final_usage));
     ]);
     ("latency_ms", `Int env.final_latency_ms);
     ("cost_usd", `Float env.total_cost_usd_turn);
@@ -163,7 +163,7 @@ let build_normal_turn_response_json (env : turn_env) : Yojson.Safe.t =
     ("usage", `Assoc [
       ("input_tokens", `Int env.final_usage.input_tokens);
       ("output_tokens", `Int env.final_usage.output_tokens);
-      ("total_tokens", `Int (Llm_client.total_tokens env.final_usage));
+      ("total_tokens", `Int (Llm_types.total_tokens env.final_usage));
     ]);
     ("latency_ms", `Int env.final_latency_ms);
     ("cost_usd", `Float env.total_cost_usd_turn);

--- a/lib/llm_orchestration.ml
+++ b/lib/llm_orchestration.ml
@@ -313,7 +313,7 @@ let call_provider_stream ?timeout_sec (req : completion_request)
   let req = normalize_request req in
   (* Try real streaming first *)
   let stream_result =
-    match provider_config_of_request req with
+    match Llm_provider_dispatch.provider_config_of_request req with
     | Error _ -> None  (* fall through to batch *)
     | Ok (config, messages, tools) ->
         let env = Llm_eio_env.get () in
@@ -335,7 +335,7 @@ let call_provider_stream ?timeout_sec (req : completion_request)
         in
         (match result with
          | Ok resp ->
-             let masc_resp = completion_response_of_api_response resp in
+             let masc_resp = Llm_provider_dispatch.completion_response_of_api_response resp in
              let text = text_of_response masc_resp in
              if String.trim text = "" && masc_resp.tool_calls = [] then
                None  (* empty response, try batch *)
@@ -343,7 +343,7 @@ let call_provider_stream ?timeout_sec (req : completion_request)
                Some (Ok masc_resp)
          | Error http_err ->
              Log.LlmClient.warn "stream: provider error: %s"
-               (string_of_http_error http_err);
+               (Llm_provider_dispatch.string_of_http_error http_err);
              None  (* fall through to batch *))
   in
   match stream_result with

--- a/lib/llm_provider_dispatch.mli
+++ b/lib/llm_provider_dispatch.mli
@@ -30,3 +30,15 @@ val completion_response_of_api_response :
     Sets [id] to ["cached"] and [stop_reason] to [EndTurn]. *)
 val api_response_of_completion_response :
   Llm_types.completion_response -> Llm_provider.Types.api_response
+
+(** Build a provider config, messages, and tools from a completion request.
+    Used by {!Llm_orchestration.call_provider_stream}. *)
+val provider_config_of_request :
+  Llm_types.completion_request ->
+  (Llm_provider.Provider_config.t
+   * Llm_provider.Types.message list
+   * Yojson.Safe.t list, string) result
+
+(** Human-readable string from an HTTP client error. *)
+val string_of_http_error :
+  Llm_provider.Http_client.http_error -> string

--- a/lib/lodge_heartbeat_agents.ml
+++ b/lib/lodge_heartbeat_agents.ml
@@ -400,7 +400,7 @@ let heartbeat_response_is_valid ?(require_json = false) s =
 
 let heartbeat_response_accepted ?(require_json = false)
     (resp : Llm_client.completion_response) =
-  heartbeat_response_is_valid ~require_json (Llm_client.text_of_response resp)
+  heartbeat_response_is_valid ~require_json (Llm_types.text_of_response resp)
 
 let run_heartbeat_llm_once ?(require_json = false) ?(temperature = 0.7) ~agent_name ~prompt () =
   let accept = heartbeat_response_accepted ~require_json in

--- a/lib/lodge_tom.ml
+++ b/lib/lodge_tom.ml
@@ -171,7 +171,7 @@ let parse_tom_response (text : string)
 
 (** Validate that an LLM ToM response is parseable and non-trivial. *)
 let tom_response_is_valid (resp : Llm_client.completion_response) : bool =
-  match parse_tom_response (Llm_client.text_of_response resp) with
+  match parse_tom_response (Llm_types.text_of_response resp) with
   | Ok _ -> true
   | Error _ -> false
 

--- a/lib/lodge_topic.ml
+++ b/lib/lodge_topic.ml
@@ -237,7 +237,7 @@ let parse_topics_response (text : string) : string list =
     Rejects empty, garbage, or non-array responses so the cascade retries
     with the next model. *)
 let topics_response_is_valid (result : Llm_client.completion_response) : bool =
-  let text = String.trim (Llm_client.text_of_response result) in
+  let text = String.trim (Llm_types.text_of_response result) in
   (* Must contain at least one bracket pair *)
   if not (String.contains text '[' && String.contains text ']') then false
   else

--- a/lib/perpetual_loop.ml
+++ b/lib/perpetual_loop.ml
@@ -95,14 +95,14 @@ let create_state config =
     ~system_prompt
     ~max_tokens:primary_model.max_context in
   (* Inject goal as first user message with sticky prefix for compaction safety *)
-  let goal_msg = Llm_client.user_msg
+  let goal_msg = Agent_sdk.Types.user_msg
     (sprintf "%s %s" Context_manager.goal_prefix config.initial_goal) in
   let context = Context_manager.append context goal_msg in
   let trace_id = generate_trace_id () in
   let session = Context_manager.create_session
     ~session_id:trace_id
     ~base_dir:config.session_base_dir in
-  let zero_usage : Llm_client.token_usage = {
+  let zero_usage : Llm_types.token_usage = {
     Agent_sdk.Types.input_tokens = 0; output_tokens = 0;
     cache_creation_input_tokens = 0; cache_read_input_tokens = 0;
   } in
@@ -326,7 +326,7 @@ let status ~config state : Yojson.Safe.t =
     ("last_usage", `Assoc [
       ("input_tokens", `Int state.last_usage.input_tokens);
       ("output_tokens", `Int state.last_usage.output_tokens);
-      ("total_tokens", `Int (Llm_client.total_tokens state.last_usage));
+      ("total_tokens", `Int (Llm_types.total_tokens state.last_usage));
     ]);
     ("last_latency_ms", `Int state.last_latency_ms);
     ("last_heartbeat_ts", `Float state.last_heartbeat);

--- a/lib/post_verifier_llm.ml
+++ b/lib/post_verifier_llm.ml
@@ -110,7 +110,7 @@ let score_to_verdict ~(dim_name : string) (score : int) : verdict =
 
 (** Validate that an LLM response contains parseable G-Eval scores. *)
 let geval_response_is_valid (resp : Llm_client.completion_response) : bool =
-  match parse_geval_response (Llm_client.text_of_response resp) with
+  match parse_geval_response (Llm_types.text_of_response resp) with
   | Ok _ -> true
   | Error _ -> false
 

--- a/lib/room_walph_eio.ml
+++ b/lib/room_walph_eio.ml
@@ -265,7 +265,7 @@ let get_chain_id_for_preset = function
   | _ -> None
 
 let walph_response_is_valid (resp : Llm_client.completion_response) =
-  let content = String.trim (Llm_client.text_of_response resp) in
+  let content = String.trim (Llm_types.text_of_response resp) in
   let lower = String.lowercase_ascii content in
   let len = String.length content in
   len > 0


### PR DESCRIPTION
## Summary

- `Llm_client.system_msg`, `user_msg`, `assistant_msg` → `Agent_sdk.Types.*` (keeper_turn, perpetual_loop)
- `Llm_client.text_of_response`, `total_tokens`, `token_usage` → `Llm_types.*` (keeper_turn, keeper_turn_response, lodge_heartbeat_agents, lodge_tom, lodge_topic, perpetual_loop, post_verifier_llm, room_walph_eio)
- `Llm_client.completion_response`, `model_spec`, `cascade`, `tool_call` 등 실제 Llm_client 기능은 변경 없음
- `llm_orchestration.ml`에서 `provider_config_of_request`/`completion_response_of_api_response`/`string_of_http_error`가 비정규화(unqualified) 호출되어 clean build 실패하던 기존 버그를 `Llm_provider_dispatch.*`로 정규화하여 수정. `.mli`에 노출 추가.

## 대상 파일 (10개)

1. `lib/keeper_turn_response.ml` — `token_usage`, `total_tokens`
2. `lib/keeper_turn.ml` — `system_msg`, `user_msg`, `assistant_msg`, `text_of_response`, `total_tokens`
3. `lib/local_agent_eio_runners.ml` — 변경 없음 (model_spec, default_local_model_spec만 사용)
4. `lib/lodge_cascade.ml` — 변경 없음 (model_spec, available_model_specs_of_strings만 사용)
5. `lib/lodge_heartbeat_agents.ml` — `text_of_response`
6. `lib/lodge_tom.ml` — `text_of_response`
7. `lib/lodge_topic.ml` — `text_of_response`
8. `lib/perpetual_loop.ml` — `user_msg`, `token_usage`, `total_tokens`
9. `lib/post_verifier_llm.ml` — `text_of_response`
10. `lib/room_walph_eio.ml` — `text_of_response`

## Test plan

- [x] `dune build --root .` 통과
- [ ] `make test` 통과 확인
- [ ] batch 1/2 PR과 충돌 없는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)