### PR TITLE
fix+refactor: spawn get_config bug, remove Mlx dead code, rename Llama→Local_runtime

### DIFF
--- a/lib/env_config_runtime.ml
+++ b/lib/env_config_runtime.ml
@@ -133,10 +133,9 @@ end
 
 (** {1 Local LLM Server Configuration} *)
 
-(** Local LLM runtime config.  Module kept as [Llama] for env-var
-    backward compatibility (LLAMA_SERVER_URL, LLAMA_DEFAULT_MODEL, etc.).
-    Rename to [Local_runtime] deferred to avoid breaking external consumers. *)
-module Llama = struct
+(** Local LLM runtime config (llama-server / any OpenAI-compatible backend).
+    Environment variables retain the LLAMA_ prefix for backward compatibility. *)
+module Local_runtime = struct
   (** OpenAI-compatible local LLM server URL *)
   let server_url =
     get_string ~default:"http://127.0.0.1:8085" "LLAMA_SERVER_URL"
@@ -150,6 +149,10 @@ module Llama = struct
   let max_tokens =
     get_int ~default:32768 "MASC_LLAMA_MAX_TOKENS"
 end
+
+(** Backward-compatible alias so existing [Env_config.Llama] references
+    continue to compile without changes. *)
+module Llama = Local_runtime
 
 (** {1 Federation Configuration} *)
 
@@ -203,12 +206,6 @@ module Voice = struct
 end
 
 (** {1 LLM Provider Defaults} *)
-
-module Mlx = struct
-  (** MLX local server URL *)
-  let server_url =
-    get_string ~default:"http://127.0.0.1:8091" "MLX_SERVER_URL"
-end
 
 module Custom_llm = struct
   (** Default URL for custom OpenAI-compatible server *)

--- a/lib/llm_types.ml
+++ b/lib/llm_types.ml
@@ -289,16 +289,6 @@ let rec model_spec_of_string s =
           Error (sprintf "Cannot parse model spec: %s (unsupported direct adapter '%s')" s provider)
         | None ->
           match provider with
-        | "mlx" ->
-          Ok {
-            provider = Custom "mlx";
-            model_id;
-            max_context = 128000;
-            api_url = Env_config_runtime.Mlx.server_url;
-            api_key_env = None;
-            cost_per_1k_input = 0.0;
-            cost_per_1k_output = 0.0;
-          }
         | "custom" ->
           (* Format: custom:model@http://host:port or custom:model *)
           let actual_model, url =
@@ -321,7 +311,7 @@ let rec model_spec_of_string s =
         | _ ->
           Error
             (sprintf
-               "Cannot parse model spec: %s (unsupported provider '%s'; supported: llama, claude, gemini, glm, openrouter, mlx, custom)"
+               "Cannot parse model spec: %s (unsupported provider '%s'; supported: llama, claude, gemini, glm, openrouter, custom)"
                s provider)
 
 let configured_default_model_label () =

--- a/lib/spawn.ml
+++ b/lib/spawn.ml
@@ -207,14 +207,32 @@ let default_configs = [
   });
 ]
 
-(** Get spawn config for agent *)
+(** Map CLI tool names and provider aliases to default_configs keys. *)
+let spawn_alias_map = [
+  ("claude-code", "claude");
+  ("claude-api", "claude");
+  ("anthropic", "claude");
+  ("gemini-cli", "gemini");
+  ("gemini-api", "gemini");
+  ("google", "gemini");
+  ("codex-cli", "codex");
+  ("codex-api", "codex");
+  ("openai", "codex");
+  ("llama.cpp", "llama");
+  ("llamacpp", "llama");
+]
+
+(** Get spawn config for agent.
+    Resolves CLI tool names (e.g. "claude-code") and provider canonical names
+    (e.g. "claude-api") to the short keys used in default_configs. *)
 let get_config agent_name =
-  let canonical =
-    match Provider_adapter.resolve_direct_canonical_name agent_name with
-    | Some value -> value
-    | None -> agent_name
-  in
-  List.assoc_opt canonical default_configs
+  let normalized = String.lowercase_ascii (String.trim agent_name) in
+  match List.assoc_opt normalized default_configs with
+  | Some _ as result -> result
+  | None ->
+    match List.assoc_opt normalized spawn_alias_map with
+    | Some key -> List.assoc_opt key default_configs
+    | None -> None
 
 (** Build MCP flags as argument list (no shell escaping needed) *)
 let build_mcp_args agent_name tools =


### PR DESCRIPTION
## Summary
- **Bug fix**: `spawn.ml get_config` canonical name mismatch — `resolve_direct_canonical_name("claude")` → `"claude-api"` but `default_configs` keyed by `"claude"`. 별도 alias map으로 수정.
- **Dead code**: `Env_config.Mlx` 모듈 제거 (MLX removed in PR #799). `llm_types.ml`의 `"mlx"` branch도 제거.
- **Rename**: `Env_config.Llama` → `Env_config.Local_runtime` + backward-compat alias

## Vendor Hardcoding Cleanup Series Phase 2 (MASC)

### spawn bug details
`get_config "claude"` → canonical `"claude-api"` → `List.assoc_opt "claude-api" default_configs` → `None`.
CI test `test_spawn:get_config known agents`가 지속 실패하던 원인.

## Test plan
- [x] `dune build --root .` 통과
- [x] `test_spawn` "get_config known agents" 8/8 통과 (이전 실패)
- [x] `Env_config.Llama` alias로 기존 30+ 참조 하위호환 유지

🤖 Generated with [Claude Code](https://claude.com/claude-code)