### PR TITLE
fix: resolve 4 user-reported bugs from end-user testing v2

### DIFF
--- a/lib/auth.ml
+++ b/lib/auth.ml
@@ -383,12 +383,21 @@ let verify_room_secret config secret : bool =
 (* High-level auth operations                   *)
 (* ============================================ *)
 
-(** Enable authentication for a room *)
-let enable_auth config ~require_token : string =
+(** Enable authentication for a room.
+    Creates a bootstrap admin token for the enabling agent to prevent
+    circular permission deadlock (BUG-025). *)
+let enable_auth config ~require_token ~agent_name : string * string option =
   let secret = init_room_secret config in
   let cfg = load_auth_config config in
   save_auth_config config { cfg with enabled = true; require_token };
-  secret
+  let bootstrap_token =
+    if agent_name <> "" then
+      match create_token config ~agent_name ~role:Admin with
+      | Ok (token, _cred) -> Some token
+      | Error _ -> None
+    else None
+  in
+  (secret, bootstrap_token)
 
 (** Disable authentication *)
 let disable_auth config =

--- a/lib/mcp_server_eio_protocol.ml
+++ b/lib/mcp_server_eio_protocol.ml
@@ -443,10 +443,10 @@ let handle_request
                        match TP.requested_tool_list_params req.params with
                        | Error msg -> make_error ~id (-32602) msg
                        | Ok { names; include_hidden; include_deprecated; include_usage; mode; tier; cursor } ->
-                           (* Default to room config mode instead of Full.
-                              Agents see only tools enabled for the current mode
-                              (e.g. ~80 in Coding). Use masc_discover_tools or
-                              mode=full param to access the full catalog. *)
+                           (* BUG-017 fix: Default to Full profile for tools/list.
+                              Previously wrapped in Role_filtered which filtered out
+                              core coordination tools (masc_join, masc_claim, etc.)
+                              from discovery while tools/call still allowed them. *)
                            let list_profile =
                              match profile with
                              | Managed_agent | Operator_remote ->
@@ -454,10 +454,7 @@ let handle_request
                              | Full | Role_filtered _ ->
                                (match mode with
                                 | Some _ -> profile  (* explicit mode param: respect it *)
-                                | None ->
-                                  let room_path = Room.masc_dir state.Mcp_server.room_config in
-                                  let config = Config.load room_path in
-                                  Role_filtered config.Config.mode)
+                                | None -> Full)
                            in
                            handle_list_tools_eio ~profile:list_profile ?names ~include_hidden
                              ~include_deprecated ~include_usage ?mode ?tier ?cursor

--- a/lib/metrics_store_eio.ml
+++ b/lib/metrics_store_eio.ml
@@ -192,11 +192,11 @@ let calculate_agent_metrics config ~agent_id ~days : agent_metrics option =
       period_start;
       period_end = now;
       total_tasks = total;
-      completed_tasks = List.length completed;
+      completed_tasks = List.length successful;
       failed_tasks = List.length failed;
       avg_completion_time_s = avg_time;
-      task_completion_rate = float_of_int (List.length successful) /. float_of_int total;
-      error_rate = float_of_int (List.length failed) /. float_of_int total;
+      task_completion_rate = if total > 0 then float_of_int (List.length successful) /. float_of_int total else 0.0;
+      error_rate = if total > 0 then float_of_int (List.length failed) /. float_of_int total else 0.0;
       handoff_success_rate = handoff_rate;
       unique_collaborators = unique_collabs;
     }

--- a/lib/room_query.ml
+++ b/lib/room_query.ml
@@ -147,6 +147,16 @@ let audit_orphan_tasks config : (Types.task * string) list =
       | _ -> None
     ) backlog.tasks
 
+let is_agent_active_at_path config path =
+  if not (path_exists config path) then false
+  else
+    try
+      let json = read_json config path in
+      match agent_of_yojson json with
+      | Ok agent -> agent.status <> Inactive
+      | Error _ -> false
+    with Sys_error _ | Yojson.Json_error _ -> false
+
 let is_agent_joined_in_room config ~room_id ~agent_name =
   if not (root_is_initialized config) then false
   else
@@ -155,12 +165,12 @@ let is_agent_joined_in_room config ~room_id ~agent_name =
     (* Check room-scoped path first *)
     let room_agents = agents_dir_in_room config room_id in
     let room_path = Filename.concat room_agents filename in
-    if path_exists config room_path then true
+    if is_agent_active_at_path config room_path then true
     else
       (* Fallback: check root agents_dir (where default join writes) *)
       let root_agents = agents_dir config in
       let root_path = Filename.concat root_agents filename in
-      path_exists config root_path
+      is_agent_active_at_path config root_path
 
 (** Check if an agent has joined the room *)
 let is_agent_joined config ~agent_name =

--- a/lib/tool_auth.ml
+++ b/lib/tool_auth.ml
@@ -11,17 +11,24 @@ type result = bool * string
 
 let handle_auth_enable ctx args =
   let require_token = get_bool args "require_token" false in
-  let secret = Auth.enable_auth ctx.config.base_path ~require_token in
+  let (secret, bootstrap_token) =
+    Auth.enable_auth ctx.config.base_path ~require_token ~agent_name:ctx.agent_name
+  in
+  let token_msg = match bootstrap_token with
+    | Some token ->
+        Printf.sprintf "\nBootstrap Admin Token for `%s` (SAVE THIS):\n`%s`\n" ctx.agent_name token
+    | None -> ""
+  in
   let msg = Printf.sprintf {|🔐 **Authentication Enabled**
 
 Room Secret (SAVE THIS - shown only once):
 `%s`
-
+%s
 Share this secret securely with authorized agents.
 Require token for actions: %b
 
 Use `masc_auth_create_token` to create agent tokens.
-|} secret require_token in
+|} secret token_msg require_token in
   (true, msg)
 
 let handle_auth_disable ctx _args =

--- a/lib/tool_misc.ml
+++ b/lib/tool_misc.ml
@@ -546,7 +546,10 @@ let handle_tool_admin_update ctx args =
           let room_secret =
             match enabled_opt with
             | Some true when not current.enabled ->
-                Some (Auth.enable_auth ctx.config.base_path ~require_token)
+                let (secret, _bootstrap) =
+                  Auth.enable_auth ctx.config.base_path ~require_token ~agent_name:ctx.agent_name
+                in
+                Some secret
             | Some false when current.enabled ->
                 Auth.disable_auth ctx.config.base_path;
                 None


### PR DESCRIPTION
## Summary

End-user 관점 black-box 테스트(v2.112.0)에서 발견된 33건 중 4건의 우선순위 버그를 수정합니다.

### Fixed Bugs

- **BUG-025 (Critical)**: Auth enable 후 unrecoverable stuck state — `enable_auth` 시 bootstrap admin 토큰 자동 생성
- **BUG-017 (High)**: Core tools hidden from MCP `tools/list` — `Role_filtered` 래핑 제거, `Full` 프로필 기본 사용
- **BUG-020 (High)**: Leave 후 broadcast 가능 — `is_agent_joined_in_room`이 `status != Inactive` 검증
- **BUG-019 (Medium)**: Fitness metrics double-count — `completed_tasks`를 successful 태스크만 집계

### Changed Files (6)

| File | Bug | Change |
|------|-----|--------|
| `lib/auth.ml` | BUG-025 | `enable_auth` 시그니처 변경, bootstrap admin 토큰 생성 |
| `lib/tool_auth.ml` | BUG-025 | `agent_name` 전달, bootstrap 토큰 메시지 표시 |
| `lib/tool_misc.ml` | BUG-025 | `enable_auth` 호출부 업데이트 |
| `lib/mcp_server_eio_protocol.ml` | BUG-017 | `tools/list`에서 `Full` 프로필 기본 사용 |
| `lib/room_query.ml` | BUG-020 | `is_agent_active_at_path` 추가, 파일 존재 대신 status 확인 |
| `lib/metrics_store_eio.ml` | BUG-019 | `completed_tasks` = successful only, 0-division 방어 |

### Related Issues

Closes #1583, Closes #1584, Closes #1585, Closes #1586

### Test Plan

- [ ] `dune build` 성공 확인
- [ ] `masc_auth_enable` → `masc_auth_create_token` → `masc_auth_disable` 전 사이클 테스트
- [ ] `tools/list`에서 `masc_join`, `masc_claim`, `masc_transition` 노출 확인
- [ ] `masc_leave` 후 `masc_broadcast` 거부 확인
- [ ] `masc_agent_fitness` completed/failed 상호 배타 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)