### PR TITLE
feat: OAS Collaboration.t bridge + agent_sdk 0.57.0 upgrade

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -35,7 +35,7 @@
   (cmdliner (>= 1.1))
   (cohttp (>= 5.0))
   (cohttp-eio (and (>= 6.0) (< 6.2)))
-  (agent_sdk (>= 0.53.0))
+  (agent_sdk (>= 0.57.0))
   (uri (>= 4.4))
   (tls (>= 0.16))
   (tls-eio (>= 0.16))

--- a/lib/team_context.ml
+++ b/lib/team_context.ml
@@ -118,6 +118,89 @@ let build ~base_path ~team_session_id =
         task_tree;
       }
 
+(* ── OAS Collaboration.t bridge ──────────────────────────────────
+   Lossy projection: MASC team_session (47 fields) → OAS Collaboration.t (12 fields).
+   MASC session_status has no Bootstrapping; planned_worker (16 fields) →
+   Collaboration.participant (6 fields).
+
+   New code should prefer Collaboration.t for cross-system interop.
+   Existing team_session consumers remain unaffected. *)
+
+let session_status_to_phase
+    (s : Team_session_types.session_status)
+    : Agent_sdk.Collaboration.phase =
+  match s with
+  | Running -> Active
+  | Paused -> Waiting_on_participants
+  | Completed -> Completed
+  | Interrupted -> Failed
+  | Failed -> Failed
+  | Cancelled -> Cancelled
+
+let execution_scope_to_participant_state
+    (scope : Team_session_types.execution_scope option)
+    : Agent_sdk.Collaboration.participant_state =
+  match scope with
+  | None -> Planned
+  | Some Observe_only -> Joined
+  | Some Limited_code_change -> Working
+  | Some Autonomous -> Working
+
+let planned_worker_to_participant
+    (pw : Team_session_types.planned_worker)
+    : Agent_sdk.Collaboration.participant =
+  {
+    name = pw.spawn_agent;
+    role = pw.spawn_role;
+    state = execution_scope_to_participant_state pw.execution_scope;
+    joined_at = None;
+    finished_at = None;
+    summary = None;
+  }
+
+(** Project a MASC team session into an OAS {!Agent_sdk.Collaboration.t}.
+
+    This is a lossy projection: planned_worker (16 fields) compresses to
+    participant (6 fields).  MASC has no explicit votes or artifacts list
+    in the session record, so those are empty.
+
+    [shared_context] is populated from [shared_findings] if available. *)
+let collaboration_of_session
+    ~base_path
+    (session : Team_session_types.session)
+    : Agent_sdk.Collaboration.t =
+  let ctx = Agent_sdk.Context.create () in
+  (* Inject shared findings into context *)
+  let findings =
+    load_findings ~base_path ~team_session_id:session.session_id
+  in
+  List.iteri (fun i f ->
+    Agent_sdk.Context.set ctx
+      (Printf.sprintf "finding_%d" i) (`String f)
+  ) findings;
+  {
+    id = session.session_id;
+    goal = session.goal;
+    phase = session_status_to_phase session.status;
+    participants =
+      List.map planned_worker_to_participant session.planned_workers;
+    artifacts = [];
+    votes = [];
+    shared_context = ctx;
+    created_at = session.started_at;
+    updated_at =
+      (match session.last_event_at with
+       | Some t -> t
+       | None -> session.started_at);
+    outcome = session.stop_reason;
+    max_participants = None;
+    metadata =
+      [("room_id", `String session.room_id);
+       ("orchestration_mode",
+        `String (Team_session_types.orchestration_mode_to_string
+                   session.orchestration_mode))];
+  }
+
 let truncate_list n lst =
   List.filteri (fun i _ -> i < n) lst
 

--- a/lib/team_context.mli
+++ b/lib/team_context.mli
@@ -53,3 +53,18 @@ val load_findings :
 
 (** Empty context for when no session is active. *)
 val empty : team_context
+
+(** {1 OAS Collaboration bridge}
+
+    Lossy projection from MASC team session (47 fields) to
+    OAS {!Agent_sdk.Collaboration.t} (12 fields).
+    MASC votes/artifacts are not in the session record, so those
+    fields are empty in the result.  [shared_context] is populated
+    from shared findings.
+
+    @since 2.114.0 *)
+
+val collaboration_of_session :
+  base_path:string ->
+  Team_session_types.session ->
+  Agent_sdk.Collaboration.t

--- a/masc_mcp.opam
+++ b/masc_mcp.opam
@@ -23,7 +23,7 @@ depends: [
   "cmdliner" {>= "1.1"}
   "cohttp" {>= "5.0"}
   "cohttp-eio" {>= "6.0" & < "6.2"}
-  "agent_sdk" {>= "0.53.0"}
+  "agent_sdk" {>= "0.57.0"}
   "uri" {>= "4.4"}
   "tls" {>= "0.16"}
   "tls-eio" {>= "0.16"}


### PR DESCRIPTION
## Summary

- **Phase 4**: `team_context.collaboration_of_session` — MASC session (47필드) → OAS Collaboration.t (12필드) 투영
- **agent_sdk pin 업그레이드**: 0.54.0 → 0.57.0 (Types.model variant → string 마이그레이션)
- 기존 team_session 47필드 God Object 미변경 — read-only projection

## Mapping

```
MASC session_status    → Collaboration.phase
  Running              → Active
  Paused               → Waiting_on_participants
  Completed            → Completed
  Interrupted          → Failed
  Failed               → Failed
  Cancelled            → Cancelled

MASC planned_worker    → Collaboration.participant
  spawn_agent          → name
  spawn_role           → role
  execution_scope      → state (Observe→Joined, Limited/Autonomous→Working)
```

## agent_sdk upgrade (breaking changes resolved)

- `Types.Custom "model_id"` → `"model_id"` (8 call sites)
- `Types.model` type changed from variant to `string`

## Test plan

- [x] `dune build --root .` — 빌드 성공
- [x] `dune runtest --root .` — 0 failures
- [x] Types.Custom 마이그레이션 8곳 완료

🤖 Generated with [Claude Code](https://claude.com/claude-code)